### PR TITLE
feat(consensus): Add Verifier L1 Confs

### DIFF
--- a/bin/consensus/src/cli.rs
+++ b/bin/consensus/src/cli.rs
@@ -207,6 +207,7 @@ impl Follow {
             beacon_client: l1_beacon,
             engine_provider: RootProvider::new_http(self.l1_rpc_args.l1_eth_rpc.clone()),
             finalized_poll_interval: L1Config::default_finalized_poll_interval(cfg.l1_chain_id),
+            verifier_l1_confs: self.l1_rpc_args.l1_verifier_confs,
         };
 
         FollowNode::new(
@@ -359,6 +360,7 @@ impl Node {
             beacon: self.l1_rpc_args.l1_beacon.clone(),
             rpc_url: self.l1_rpc_args.l1_eth_rpc.clone(),
             slot_duration_override: self.l1_rpc_args.l1_slot_duration_override,
+            verifier_l1_confs: self.l1_rpc_args.l1_verifier_confs,
         };
 
         // If metrics are enabled, initialize the global cli metrics.

--- a/crates/client/cli/src/l1.rs
+++ b/crates/client/cli/src/l1.rs
@@ -33,6 +33,11 @@ pub struct L1ClientArgs {
         env = "BASE_NODE_L1_SLOT_DURATION_OVERRIDE"
     )]
     pub l1_slot_duration_override: Option<u64>,
+    /// Number of L1 blocks to keep distance from the L1 head for the verifier (derivation
+    /// pipeline). Equivalent to op-node's `OP_NODE_VERIFIER_L1_CONFS`. Defaults to 0, meaning
+    /// the verifier derives from the latest L1 head with no confirmation delay.
+    #[arg(long = "l1.verifier-confs", default_value = "0", env = "BASE_NODE_VERIFIER_L1_CONFS")]
+    pub l1_verifier_confs: u64,
 }
 
 impl Default for L1ClientArgs {
@@ -42,6 +47,7 @@ impl Default for L1ClientArgs {
             l1_trust_rpc: DEFAULT_L1_TRUST_RPC,
             l1_beacon: Url::parse("http://localhost:5052").unwrap(),
             l1_slot_duration_override: None,
+            l1_verifier_confs: 0,
         }
     }
 }

--- a/crates/consensus/service/src/actors/l1_watcher/actor.rs
+++ b/crates/consensus/service/src/actors/l1_watcher/actor.rs
@@ -206,10 +206,7 @@ where
                         {
                             let target = head_block_info.number - self.verifier_l1_confs;
                             match self.l1_provider.get_block(BlockId::Number(target.into())).await {
-                                Ok(Some(block)) => {
-                                    let info: BlockInfo = block.into_consensus().into();
-                                    info
-                                }
+                                Ok(Some(block)) => block.into_consensus().into(),
                                 Ok(None) => {
                                     Metrics::l1_verifier_delayed_fetch_errors().increment(1);
                                     warn!(

--- a/crates/consensus/service/src/actors/l1_watcher/actor.rs
+++ b/crates/consensus/service/src/actors/l1_watcher/actor.rs
@@ -3,6 +3,7 @@
 
 use std::{sync::Arc, time::Duration};
 
+use alloy_eips::BlockId;
 use alloy_primitives::Address;
 use alloy_rpc_types_eth::{Filter, Log};
 use async_trait::async_trait;
@@ -22,7 +23,7 @@ use tokio_util::sync::{CancellationToken, WaitForCancellationFuture};
 
 use super::{L1BlockFetcher, L1WatcherDerivationClient};
 use crate::{
-    NodeActor,
+    Metrics, NodeActor,
     actors::{CancellableContext, l1_watcher::error::L1WatcherActorError},
 };
 
@@ -112,6 +113,10 @@ where
     head_stream: BlockStream,
     /// A stream over the finalized block accepted as canonical.
     finalized_stream: BlockStream,
+    /// Number of L1 blocks to keep distance from the L1 head for the derivation pipeline.
+    /// When non-zero, derivation receives the block at `head - verifier_l1_confs` rather than
+    /// the real head. The sequencer's watch channel always receives the real head.
+    verifier_l1_confs: u64,
 }
 impl<BlockStream, L1Provider, L1WatcherDerivationClient_>
     L1WatcherActor<BlockStream, L1Provider, L1WatcherDerivationClient_>
@@ -131,6 +136,7 @@ where
         cancellation: CancellationToken,
         head_stream: BlockStream,
         finalized_stream: BlockStream,
+        verifier_l1_confs: u64,
     ) -> Self {
         Self {
             rollup_config,
@@ -141,6 +147,7 @@ where
             cancellation,
             head_stream,
             finalized_stream,
+            verifier_l1_confs,
         }
     }
 }
@@ -161,6 +168,15 @@ where
         const INITIAL_BACKOFF: Duration = Duration::from_millis(50);
         const MAX_BACKOFF: Duration = Duration::from_millis(500);
 
+        Metrics::l1_verifier_confs_depth().set(self.verifier_l1_confs as f64);
+        if self.verifier_l1_confs > 0 {
+            info!(
+                target: "l1_watcher",
+                verifier_l1_confs = self.verifier_l1_confs,
+                "Verifier L1 confirmation delay enabled"
+            );
+        }
+
         let cancel = self.cancellation.clone();
 
         loop {
@@ -179,9 +195,50 @@ where
                         return Err(L1WatcherActorError::StreamEnded);
                     }
                     Some(head_block_info) => {
-                        // Send the head update event to all consumers.
+                        // Always broadcast the real head so the sequencer's
+                        // DelayedL1OriginSelectorProvider can compute its own offset.
                         self.latest_head.send_replace(Some(head_block_info));
-                        self.derivation_client.send_new_l1_head(head_block_info).await.map_err(|e| {
+
+                        // Apply verifier confirmation delay: derive from
+                        // `head - verifier_l1_confs` when the chain is deep enough.
+                        let derivation_block = if self.verifier_l1_confs > 0
+                            && head_block_info.number >= self.verifier_l1_confs
+                        {
+                            let target = head_block_info.number - self.verifier_l1_confs;
+                            match self.l1_provider.get_block(BlockId::Number(target.into())).await {
+                                Ok(Some(block)) => {
+                                    let info: BlockInfo = block.into_consensus().into();
+                                    info
+                                }
+                                Ok(None) => {
+                                    Metrics::l1_verifier_delayed_fetch_errors().increment(1);
+                                    warn!(
+                                        target: "l1_watcher",
+                                        head = head_block_info.number,
+                                        target,
+                                        "Delayed L1 block not found; skipping head update"
+                                    );
+                                    continue;
+                                }
+                                Err(e) => {
+                                    Metrics::l1_verifier_delayed_fetch_errors().increment(1);
+                                    warn!(
+                                        target: "l1_watcher",
+                                        error = %e,
+                                        head = head_block_info.number,
+                                        target,
+                                        "Failed to fetch delayed L1 block; skipping head update"
+                                    );
+                                    continue;
+                                }
+                            }
+                        } else {
+                            head_block_info
+                        };
+
+                        Metrics::l1_verifier_derivation_head()
+                            .absolute(derivation_block.number);
+                        self.derivation_client.send_new_l1_head(derivation_block).await.map_err(|e| {
                             warn!(target: "l1_watcher", error = %e, "Error sending l1 head update to derivation actor");
                             L1WatcherActorError::DerivationClientError(e)
                         })?;
@@ -193,13 +250,13 @@ where
                         let filter_address = self.rollup_config.l1_system_config_address;
                         let filter = Filter::new()
                             .address(filter_address)
-                            .select(head_block_info.hash);
+                            .select(derivation_block.hash);
 
                         let Some(logs) = LogRetrier::fetch_logs_with_retry(
                             &self.l1_provider,
                             filter,
                             &cancel,
-                            head_block_info,
+                            derivation_block,
                             INITIAL_BACKOFF,
                             MAX_BACKOFF,
                         )
@@ -207,7 +264,8 @@ where
                         else {
                             return Ok(());
                         };
-                        let ecotone_active = self.rollup_config.is_ecotone_active(head_block_info.timestamp);
+                        let ecotone_active =
+                            self.rollup_config.is_ecotone_active(derivation_block.timestamp);
                         for log in logs {
                             let sys_cfg_log = SystemConfigLog::new(log.into(), ecotone_active);
                             if let Ok(SystemConfigUpdate::UnsafeBlockSigner(UnsafeBlockSignerUpdate { unsafe_block_signer })) = sys_cfg_log.build() {
@@ -255,18 +313,29 @@ where
 
 #[cfg(test)]
 mod tests {
-    use std::sync::{
-        Arc,
-        atomic::{AtomicU32, Ordering},
+    use std::{
+        pin::Pin,
+        sync::{
+            Arc, Mutex,
+            atomic::{AtomicU32, Ordering},
+        },
     };
 
     use alloy_eips::BlockId;
     use alloy_primitives::B256;
     use alloy_rpc_types_eth::{Block, Filter, Log};
     use async_trait::async_trait;
+    use base_consensus_genesis::RollupConfig;
     use tokio_util::sync::CancellationToken;
 
     use super::*;
+    use crate::DerivationClientResult;
+
+    type BoxedBlockStream = Pin<Box<dyn Stream<Item = BlockInfo> + Unpin + Send>>;
+
+    // ---------------------------------------------------------------------------
+    // Mock L1BlockFetcher used by LogRetrier tests (unchanged)
+    // ---------------------------------------------------------------------------
 
     struct MockFetcher {
         call_count: Arc<AtomicU32>,
@@ -304,6 +373,146 @@ mod tests {
     fn dummy_block() -> BlockInfo {
         BlockInfo { hash: B256::ZERO, number: 0, parent_hash: B256::ZERO, timestamp: 0 }
     }
+
+    // ---------------------------------------------------------------------------
+    // Configurable fetcher for verifier L1 confs tests
+    // ---------------------------------------------------------------------------
+
+    /// Response behaviour for [`ConfigurableFetcher::get_block`].
+    enum GetBlockBehavior {
+        /// Always return a default [`Block`].
+        Default,
+        /// Always return `None`.
+        None,
+        /// Always return an error.
+        Err,
+    }
+
+    struct ConfigurableFetcher {
+        get_block_behavior: GetBlockBehavior,
+        get_block_requested_ids: Arc<Mutex<Vec<BlockId>>>,
+    }
+
+    impl ConfigurableFetcher {
+        fn returning_default_block() -> Self {
+            Self {
+                get_block_behavior: GetBlockBehavior::Default,
+                get_block_requested_ids: Arc::new(Mutex::new(Vec::new())),
+            }
+        }
+
+        fn returning_none() -> Self {
+            Self {
+                get_block_behavior: GetBlockBehavior::None,
+                get_block_requested_ids: Arc::new(Mutex::new(Vec::new())),
+            }
+        }
+
+        fn returning_error() -> Self {
+            Self {
+                get_block_behavior: GetBlockBehavior::Err,
+                get_block_requested_ids: Arc::new(Mutex::new(Vec::new())),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl L1BlockFetcher for ConfigurableFetcher {
+        type Error = String;
+
+        async fn get_logs(&self, _: Filter) -> Result<Vec<Log>, Self::Error> {
+            Ok(vec![])
+        }
+
+        async fn get_block(&self, id: BlockId) -> Result<Option<Block>, Self::Error> {
+            self.get_block_requested_ids.lock().unwrap().push(id);
+            match self.get_block_behavior {
+                GetBlockBehavior::Default => Ok(Some(Block::default())),
+                GetBlockBehavior::None => Ok(None),
+                GetBlockBehavior::Err => Err("provider error".to_string()),
+            }
+        }
+    }
+
+    // ---------------------------------------------------------------------------
+    // Mock derivation client that captures sent blocks
+    // ---------------------------------------------------------------------------
+
+    #[derive(Debug, Clone, Default)]
+    struct RecordingDerivationClient {
+        heads: Arc<Mutex<Vec<BlockInfo>>>,
+        finalized: Arc<Mutex<Vec<BlockInfo>>>,
+    }
+
+    #[async_trait]
+    impl L1WatcherDerivationClient for RecordingDerivationClient {
+        async fn send_finalized_l1_block(&self, block: BlockInfo) -> DerivationClientResult<()> {
+            self.finalized.lock().unwrap().push(block);
+            Ok(())
+        }
+
+        async fn send_new_l1_head(&self, block: BlockInfo) -> DerivationClientResult<()> {
+            self.heads.lock().unwrap().push(block);
+            Ok(())
+        }
+    }
+
+    impl RecordingDerivationClient {
+        fn sent_heads(&self) -> Vec<BlockInfo> {
+            self.heads.lock().unwrap().clone()
+        }
+    }
+
+    // ---------------------------------------------------------------------------
+    // Actor test helpers
+    // ---------------------------------------------------------------------------
+
+    fn block_at(number: u64) -> BlockInfo {
+        BlockInfo {
+            hash: B256::from([number as u8; 32]),
+            number,
+            parent_hash: B256::ZERO,
+            timestamp: number * 12,
+        }
+    }
+
+    /// Build and run an [`L1WatcherActor`] to completion (stream ends → `StreamEnded`).
+    ///
+    /// Returns the derivation client for assertion and the watch receiver for the raw head.
+    async fn run_actor<F: L1BlockFetcher>(
+        fetcher: F,
+        head_blocks: Vec<BlockInfo>,
+        verifier_l1_confs: u64,
+    ) -> (RecordingDerivationClient, watch::Receiver<Option<BlockInfo>>) {
+        let derivation_client = RecordingDerivationClient::default();
+        let (l1_head_tx, l1_head_rx) = watch::channel(None);
+        let cancel = CancellationToken::new();
+
+        let head_stream: BoxedBlockStream = Box::pin(futures::stream::iter(head_blocks));
+        // Finalized stream that never yields — actor will exit via head stream ending.
+        let finalized_stream: BoxedBlockStream = Box::pin(futures::stream::pending());
+
+        let actor = L1WatcherActor::new(
+            Arc::new(RollupConfig::default()),
+            fetcher,
+            l1_head_tx,
+            derivation_client.clone(),
+            None,
+            cancel,
+            head_stream,
+            finalized_stream,
+            verifier_l1_confs,
+        );
+
+        // The actor loop will process all head_stream items then return StreamEnded.
+        let _ = actor.start(()).await;
+
+        (derivation_client, l1_head_rx)
+    }
+
+    // ---------------------------------------------------------------------------
+    // LogRetrier tests (unchanged)
+    // ---------------------------------------------------------------------------
 
     #[tokio::test]
     async fn fetch_logs_succeeds_on_first_try() {
@@ -365,5 +574,121 @@ mod tests {
         )
         .await;
         assert!(matches!(result, Ok(None)));
+    }
+
+    // ---------------------------------------------------------------------------
+    // Verifier L1 confs tests
+    // ---------------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn zero_confs_forwards_real_head_to_derivation() {
+        let head = block_at(100);
+        let (client, rx) =
+            run_actor(ConfigurableFetcher::returning_default_block(), vec![head], 0).await;
+
+        // Derivation receives the real head block.
+        let heads = client.sent_heads();
+        assert_eq!(heads.len(), 1);
+        assert_eq!(heads[0].number, 100);
+
+        // Watch channel also has the real head.
+        assert_eq!(rx.borrow().unwrap().number, 100);
+    }
+
+    #[tokio::test]
+    async fn confs_delay_fetches_earlier_block_for_derivation() {
+        let fetcher = ConfigurableFetcher::returning_default_block();
+        let head = block_at(100);
+        let (client, rx) = run_actor(fetcher, vec![head], 4).await;
+
+        // Derivation receives the *delayed* block (default Block → BlockInfo with number 0).
+        let heads = client.sent_heads();
+        assert_eq!(heads.len(), 1);
+        // The fetcher returns Block::default() which converts to BlockInfo with number 0.
+        assert_eq!(heads[0].number, 0);
+
+        // Watch channel still has the real head.
+        assert_eq!(rx.borrow().unwrap().number, 100);
+    }
+
+    #[tokio::test]
+    async fn confs_delay_requests_correct_block_number() {
+        let fetcher = ConfigurableFetcher::returning_default_block();
+        let ids = Arc::clone(&fetcher.get_block_requested_ids);
+        let head = block_at(20);
+        let _ = run_actor(fetcher, vec![head], 4).await;
+
+        let requested = ids.lock().unwrap().clone();
+        assert_eq!(requested.len(), 1);
+        assert_eq!(requested[0], BlockId::Number(16u64.into()));
+    }
+
+    #[tokio::test]
+    async fn confs_delay_multiple_heads_each_fetched() {
+        let fetcher = ConfigurableFetcher::returning_default_block();
+        let ids = Arc::clone(&fetcher.get_block_requested_ids);
+        let _ = run_actor(fetcher, vec![block_at(10), block_at(14), block_at(20)], 4).await;
+
+        let requested: Vec<_> = ids.lock().unwrap().iter().map(|id| format!("{id:?}")).collect();
+        assert_eq!(requested.len(), 3);
+    }
+
+    #[tokio::test]
+    async fn confs_shallow_chain_forwards_real_head() {
+        // Head number (2) < verifier_l1_confs (4), so no delay is applied.
+        let fetcher = ConfigurableFetcher::returning_default_block();
+        let ids = Arc::clone(&fetcher.get_block_requested_ids);
+        let (client, _rx) = run_actor(fetcher, vec![block_at(2)], 4).await;
+
+        // No get_block call should have been made.
+        assert!(ids.lock().unwrap().is_empty());
+
+        // Derivation receives the real head.
+        let heads = client.sent_heads();
+        assert_eq!(heads.len(), 1);
+        assert_eq!(heads[0].number, 2);
+    }
+
+    #[tokio::test]
+    async fn confs_delayed_block_not_found_skips_derivation() {
+        let (client, rx) =
+            run_actor(ConfigurableFetcher::returning_none(), vec![block_at(100)], 4).await;
+
+        // Derivation should NOT receive any head — the block was not found.
+        assert!(client.sent_heads().is_empty());
+
+        // Watch channel still has the real head.
+        assert_eq!(rx.borrow().unwrap().number, 100);
+    }
+
+    #[tokio::test]
+    async fn confs_delayed_block_fetch_error_skips_derivation() {
+        let (client, rx) =
+            run_actor(ConfigurableFetcher::returning_error(), vec![block_at(100)], 4).await;
+
+        // Derivation should NOT receive any head — the fetch errored.
+        assert!(client.sent_heads().is_empty());
+
+        // Watch channel still has the real head.
+        assert_eq!(rx.borrow().unwrap().number, 100);
+    }
+
+    #[tokio::test]
+    async fn confs_mixed_shallow_and_deep_heads() {
+        // First head is too shallow (3 < 4), second is deep enough (10 >= 4).
+        let fetcher = ConfigurableFetcher::returning_default_block();
+        let ids = Arc::clone(&fetcher.get_block_requested_ids);
+        let (client, _rx) = run_actor(fetcher, vec![block_at(3), block_at(10)], 4).await;
+
+        let heads = client.sent_heads();
+        // Two derivation sends: block 3 forwarded directly, block 10 fetched as delayed.
+        assert_eq!(heads.len(), 2);
+        assert_eq!(heads[0].number, 3);
+        // Block::default() converts to number 0.
+        assert_eq!(heads[1].number, 0);
+
+        // Only the second head triggered a get_block call.
+        assert_eq!(ids.lock().unwrap().len(), 1);
+        assert_eq!(ids.lock().unwrap()[0], BlockId::Number(6u64.into()));
     }
 }

--- a/crates/consensus/service/src/metrics/mod.rs
+++ b/crates/consensus/service/src/metrics/mod.rs
@@ -44,4 +44,10 @@ base_metrics::define_metrics! {
     sequencer_drift_empty_blocks_total: counter,
     #[describe("Pre-built payloads discarded because the unsafe head advanced past their parent")]
     sequencer_stale_build_discarded_total: counter,
+    #[describe("Configured verifier L1 confirmation depth")]
+    l1_verifier_confs_depth: gauge,
+    #[describe("L1 block number forwarded to derivation after verifier confirmation delay")]
+    l1_verifier_derivation_head: counter,
+    #[describe("Failed attempts to fetch a delayed L1 block for verifier confirmation")]
+    l1_verifier_delayed_fetch_errors: counter,
 }

--- a/crates/consensus/service/src/service/builder.rs
+++ b/crates/consensus/service/src/service/builder.rs
@@ -51,6 +51,8 @@ pub struct L1ConfigBuilder {
     /// The duration in seconds of an L1 slot. This can be used to hardcode a fixed slot
     /// duration if the l1-beacon's slot configuration is not available.
     pub slot_duration_override: Option<u64>,
+    /// Number of L1 blocks to keep distance from the L1 head for the verifier.
+    pub verifier_l1_confs: u64,
 }
 
 /// The [`RollupNodeBuilder`] is used to construct a [`RollupNode`] service.
@@ -175,6 +177,7 @@ impl RollupNodeBuilder {
             beacon_client: l1_beacon,
             engine_provider: RootProvider::new_http(self.l1_config_builder.rpc_url.clone()),
             finalized_poll_interval,
+            verifier_l1_confs: self.l1_config_builder.verifier_l1_confs,
         };
 
         let jwt_secret = self.engine_config.l2_jwt_secret;

--- a/crates/consensus/service/src/service/follow.rs
+++ b/crates/consensus/service/src/service/follow.rs
@@ -191,6 +191,7 @@ impl FollowNode {
             cancellation.clone(),
             head_stream,
             finalized_stream,
+            self.l1_config.verifier_l1_confs,
         );
         let l1_query_processor = L1WatcherQueryProcessor::new(
             Arc::clone(&self.config),

--- a/crates/consensus/service/src/service/node.rs
+++ b/crates/consensus/service/src/service/node.rs
@@ -52,6 +52,10 @@ pub struct L1Config {
     /// - Ethereum mainnet/Sepolia: one epoch (~384 s = 32 slots × 12 s)
     /// - Devnet local L1: near-instant finality, poll aggressively (~2 s)
     pub finalized_poll_interval: Duration,
+    /// Number of L1 blocks to keep distance from the L1 head for the verifier (derivation
+    /// pipeline). When non-zero, the L1 watcher delays derivation heads by this many blocks,
+    /// providing reorg protection. Equivalent to op-node's `OP_NODE_VERIFIER_L1_CONFS`.
+    pub verifier_l1_confs: u64,
 }
 
 impl L1Config {
@@ -451,6 +455,7 @@ impl RollupNode {
             cancellation.clone(),
             head_stream,
             finalized_stream,
+            self.l1_config.verifier_l1_confs,
         );
         let l1_query_processor = L1WatcherQueryProcessor::new(
             Arc::clone(&self.config),

--- a/devnet/src/l2/in_process_consensus.rs
+++ b/devnet/src/l2/in_process_consensus.rs
@@ -142,6 +142,7 @@ impl InProcessConsensus {
             beacon: config.l1_beacon_url,
             rpc_url: config.l1_rpc_url.clone(),
             slot_duration_override: config.l1_slot_duration_override,
+            verifier_l1_confs: 0,
         };
 
         let engine_config = EngineConfig {

--- a/lychee.toml
+++ b/lychee.toml
@@ -19,6 +19,7 @@ exclude = [
     # Links to files moved or renamed (not yet on main)
     'https://github\.com/base/base/blob/main/crates/execution/upgrades',
     'https://github\.com/base/base/blob/main/crates/common/evm/src/spec_id\.rs',
+    'https://github\.com/base/base/blob/main/crates/common/evm/src/precompiles\.rs',
 
     # Shields.io badges that query live GitHub stats (flaky, not real links)
     'https://img.shields.io/github/commit-activity/w/base/base',


### PR DESCRIPTION
## Summary

Adds a configurable L1 confirmation depth for the verifier derivation pipeline via `--l1.verifier-confs` / `BASE_NODE_VERIFIER_L1_CONFS`, equivalent to op-node's `OP_NODE_VERIFIER_L1_CONFS`. When set, the L1 watcher delays the head forwarded to derivation by N blocks while the sequencer's watch channel always receives the real head. Defaults to 0 (no delay, preserving current behavior). Includes three new metrics for observability, startup logging when enabled, and eight unit tests covering all delay/skip/passthrough paths.