### PR TITLE
fix(challenger): validate only the challenged root when detecting fraudulent ZK challenges

### DIFF
--- a/crates/proof/challenge/src/driver.rs
+++ b/crates/proof/challenge/src/driver.rs
@@ -411,57 +411,10 @@ impl<L2: L2Provider, P: ZkProofProvider, T: TxManager, C: Clock> Driver<L2, P, T
     ) -> eyre::Result<()> {
         let game_address = candidate.factory.proxy;
 
-        let (result, intermediate_roots) = match self.validate_game(&candidate).await? {
-            Some(pair) => pair,
-            None => return Ok(()),
-        };
+        // Fetch the onchain intermediate roots.
+        let intermediate_roots =
+            self.verifier_client.intermediate_output_roots(game_address).await?;
 
-        // For Path 2: If the original proposal's root at the challenged index
-        // is valid, the ZK challenge was fraudulent. If it's invalid, the
-        // challenge was legitimate — skip.
-        //
-        // The validator scans intermediate roots sequentially and reports the
-        // first invalid index. If `first_invalid <= challenged_index`, the
-        // root at the challenged index (or an earlier one) was wrong, so the
-        // ZK challenge was legitimate.
-        if !result.is_valid {
-            match result.invalid_intermediate_index {
-                Some(first_invalid) => {
-                    let first_invalid_u64 = u64::try_from(first_invalid).map_err(|_| {
-                        eyre::eyre!(
-                            "first invalid intermediate index {first_invalid} overflows u64"
-                        )
-                    })?;
-                    if first_invalid_u64 <= challenged_index {
-                        debug!(
-                            game = %game_address,
-                            challenged_index = challenged_index,
-                            first_invalid_index = first_invalid,
-                            "ZK challenge is legitimate (original root was wrong), skipping"
-                        );
-                        return Ok(());
-                    }
-                    // first_invalid > challenged_index: all roots up to and
-                    // including the challenged index are valid, so the ZK
-                    // challenge was fraudulent. Fall through to nullify.
-                }
-                None => {
-                    // Validation says invalid but no specific index was identified.
-                    // Cannot confirm the challenged root is correct, so skip to
-                    // avoid submitting a potentially wrong nullification.
-                    warn!(
-                        game = %game_address,
-                        challenged_index = challenged_index,
-                        "validation returned invalid without specific index, skipping"
-                    );
-                    return Ok(());
-                }
-            }
-        }
-
-        // The on-chain root at the challenged index is correct.
-        // Use the on-chain root value as `intermediateRootToProve` — the
-        // contract requires it to match `intermediateOutputRoot(index)`.
         let idx = usize::try_from(challenged_index)
             .map_err(|_| eyre::eyre!("challenged_index {challenged_index} overflows usize"))?;
         let on_chain_root = intermediate_roots.get(idx).copied().ok_or_else(|| {
@@ -471,6 +424,45 @@ impl<L2: L2Provider, P: ZkProofProvider, T: TxManager, C: Clock> Driver<L2, P, T
                 intermediate_roots.len()
             )
         })?;
+
+        // Validate only the challenged root — not all intermediate roots.
+        // The checkpoint block for index `i` is:
+        //   starting_block + interval * (i + 1)
+        let checkpoint_block = candidate.checkpoint_start_block(challenged_index + 1)?;
+
+        let expected_root = match self.validator.compute_output_root(checkpoint_block).await {
+            Ok(root) => root,
+            Err(ValidatorError::BlockNotAvailable { .. }) => {
+                debug!(
+                    game = %game_address,
+                    block = checkpoint_block,
+                    "block not yet available, skipping game"
+                );
+                return Ok(());
+            }
+            Err(e) => {
+                warn!(
+                    game = %game_address,
+                    block = checkpoint_block,
+                    error = %e,
+                    "output root computation failed, skipping game"
+                );
+                return Ok(());
+            }
+        };
+
+        // If the onchain root at the challenged index does not match the
+        // locally computed root, the ZK challenge was legitimate — skip.
+        if on_chain_root != expected_root {
+            debug!(
+                game = %game_address,
+                challenged_index = challenged_index,
+                on_chain = %on_chain_root,
+                expected = %expected_root,
+                "ZK challenge is legitimate (challenged root was wrong), skipping"
+            );
+            return Ok(());
+        }
 
         info!(
             game = %game_address,

--- a/crates/proof/challenge/src/driver.rs
+++ b/crates/proof/challenge/src/driver.rs
@@ -411,19 +411,9 @@ impl<L2: L2Provider, P: ZkProofProvider, T: TxManager, C: Clock> Driver<L2, P, T
     ) -> eyre::Result<()> {
         let game_address = candidate.factory.proxy;
 
-        // Fetch the onchain intermediate roots.
-        let intermediate_roots =
-            self.verifier_client.intermediate_output_roots(game_address).await?;
-
-        let idx = usize::try_from(challenged_index)
-            .map_err(|_| eyre::eyre!("challenged_index {challenged_index} overflows usize"))?;
-        let on_chain_root = intermediate_roots.get(idx).copied().ok_or_else(|| {
-            eyre::eyre!(
-                "challenged_index {challenged_index} out of bounds \
-                     (game has {} intermediate roots)",
-                intermediate_roots.len()
-            )
-        })?;
+        // Fetch only the challenged onchain intermediate root (not all roots).
+        let on_chain_root =
+            self.verifier_client.intermediate_output_root(game_address, challenged_index).await?;
 
         // Validate only the challenged root — not all intermediate roots.
         // The checkpoint block for index `i` is:

--- a/crates/proof/challenge/src/test_utils.rs
+++ b/crates/proof/challenge/src/test_utils.rs
@@ -221,6 +221,17 @@ impl AggregateVerifierClient for MockAggregateVerifier {
         self.get(game_address, |s| s.intermediate_output_roots.clone())
     }
 
+    async fn intermediate_output_root(
+        &self,
+        game_address: Address,
+        index: u64,
+    ) -> Result<B256, ContractError> {
+        self.get(game_address, |s| {
+            let idx = index as usize;
+            s.intermediate_output_roots.get(idx).copied().unwrap_or(B256::ZERO)
+        })
+    }
+
     async fn countered_index(&self, game_address: Address) -> Result<u64, ContractError> {
         self.get(game_address, |s| s.countered_index)
     }

--- a/crates/proof/challenge/src/test_utils.rs
+++ b/crates/proof/challenge/src/test_utils.rs
@@ -228,7 +228,10 @@ impl AggregateVerifierClient for MockAggregateVerifier {
     ) -> Result<B256, ContractError> {
         self.get(game_address, |s| {
             let idx = index as usize;
-            s.intermediate_output_roots.get(idx).copied().unwrap_or(B256::ZERO)
+            s.intermediate_output_roots
+                .get(idx)
+                .copied()
+                .expect("intermediate_output_root: index out of bounds")
         })
     }
 

--- a/crates/proof/challenge/tests/driver.rs
+++ b/crates/proof/challenge/tests/driver.rs
@@ -769,6 +769,10 @@ async fn test_poll_or_submit_nullify_intent_not_dropped_when_zk_prover_set() {
     let l2 = default_l2();
     let mut game_state = mock_state_with_tee(0, ZK_PROVER_ADDR, DEFAULT_TEE_PROVER, 20);
     game_state.countered_index = 2; // challenged at 0-based index 1
+    // Provide intermediate roots so the scanner's FraudulentZkChallenge
+    // processing (which runs after the pending proof is submitted) does not
+    // panic when fetching the root at the challenged index.
+    game_state.intermediate_output_roots = vec![B256::repeat_byte(0x01), B256::repeat_byte(0x02)];
     let verifier = single_game_verifier(game_state);
 
     let mut driver = test_driver(factory, verifier, l2, default_zk_prover(), default_tx_manager());

--- a/crates/proof/challenge/tests/driver.rs
+++ b/crates/proof/challenge/tests/driver.rs
@@ -868,6 +868,38 @@ async fn test_step_fraudulent_zk_challenge_nullifies() {
     );
 }
 
+#[tokio::test]
+async fn test_step_fraudulent_zk_challenge_nullifies_despite_earlier_invalid_root() {
+    // Regression: an earlier intermediate root (index 0) is invalid, but the
+    // challenged root (index 1) is correct. The ZK challenge targets a valid
+    // root, so it is fraudulent and must be nullified. Previously the
+    // challenger incorrectly skipped because the first invalid index was
+    // <= the challenged index.
+    let (l2, factory, _root_15, root_20) = base_game_mocks();
+
+    let verifier = single_game_verifier(MockGameState {
+        zk_prover: ZK_PROVER_ADDR,
+        tee_prover: DEFAULT_TEE_PROVER,
+        // Index 0 is bogus, index 1 (challenged) is correct.
+        intermediate_output_roots: vec![BOGUS_ROOT, root_20],
+        countered_index: 2, // 1-based → challenged_index = 1
+        ..game_state(20)
+    });
+
+    let mut driver = test_driver(factory, verifier, l2, default_zk_prover(), default_tx_manager());
+    driver.step().await.unwrap();
+
+    let entry = driver
+        .pending_proofs
+        .get(&addr(0))
+        .expect("proof should be pending — challenged root is valid, ZK challenge is fraudulent");
+    assert_eq!(
+        entry.intent,
+        DisputeIntent::Nullify,
+        "intent should be Nullify when challenged root is valid despite earlier invalid root"
+    );
+}
+
 // ──────────────────────────────────────────────────────────────────────────
 // Path 3: Wrong ZK proposal → nullify with ZK
 // ──────────────────────────────────────────────────────────────────────────

--- a/crates/proof/contracts/src/aggregate_verifier.rs
+++ b/crates/proof/contracts/src/aggregate_verifier.rs
@@ -56,6 +56,9 @@ sol! {
         /// Returns the intermediate output roots submitted with this game.
         function intermediateOutputRoots() external view returns (bytes memory);
 
+        /// Returns the intermediate output root at the given index.
+        function intermediateOutputRoot(uint256 index) external view returns (bytes32);
+
         /// Returns the 1-based index of the challenged intermediate root.
         ///
         /// `0` means the game has not been challenged. When non-zero the
@@ -183,6 +186,13 @@ pub trait AggregateVerifierClient: Send + Sync {
         &self,
         game_address: Address,
     ) -> Result<Vec<B256>, ContractError>;
+
+    /// Returns a single intermediate output root at the given 0-based index.
+    async fn intermediate_output_root(
+        &self,
+        game_address: Address,
+        index: u64,
+    ) -> Result<B256, ContractError>;
 
     /// Returns the 1-based index of the challenged intermediate root.
     ///
@@ -393,6 +403,22 @@ impl AggregateVerifierClient for AggregateVerifierContractClient {
         let roots = raw.chunks_exact(32).map(|chunk| B256::from_slice(chunk)).collect();
 
         Ok(roots)
+    }
+
+    async fn intermediate_output_root(
+        &self,
+        game_address: Address,
+        index: u64,
+    ) -> Result<B256, ContractError> {
+        let contract =
+            IAggregateVerifier::IAggregateVerifierInstance::new(game_address, &self.provider);
+
+        let root =
+            contract.intermediateOutputRoot(U256::from(index)).call().await.map_err(|e| {
+                ContractError::Call { context: "intermediateOutputRoot failed".into(), source: e }
+            })?;
+
+        Ok(root)
     }
 
     async fn countered_index(&self, game_address: Address) -> Result<u64, ContractError> {

--- a/crates/proof/proposer/src/test_utils.rs
+++ b/crates/proof/proposer/src/test_utils.rs
@@ -269,6 +269,14 @@ impl AggregateVerifierClient for MockAggregateVerifier {
         }
         Ok(vec![B256::ZERO])
     }
+    async fn intermediate_output_root(
+        &self,
+        addr: Address,
+        index: u64,
+    ) -> Result<B256, ContractError> {
+        let roots = self.intermediate_output_roots(addr).await?;
+        Ok(roots.get(index as usize).copied().unwrap_or(B256::ZERO))
+    }
     async fn countered_index(&self, _: Address) -> Result<u64, ContractError> {
         Ok(0)
     }

--- a/crates/proof/proposer/src/test_utils.rs
+++ b/crates/proof/proposer/src/test_utils.rs
@@ -275,7 +275,10 @@ impl AggregateVerifierClient for MockAggregateVerifier {
         index: u64,
     ) -> Result<B256, ContractError> {
         let roots = self.intermediate_output_roots(addr).await?;
-        Ok(roots.get(index as usize).copied().unwrap_or(B256::ZERO))
+        Ok(roots
+            .get(index as usize)
+            .copied()
+            .expect("intermediate_output_root: index out of bounds"))
     }
     async fn countered_index(&self, _: Address) -> Result<u64, ContractError> {
         Ok(0)


### PR DESCRIPTION
## Summary

- **Fixes a bug** where the challenger skipped nullifying a fraudulent ZK challenge when an *earlier* intermediate root was invalid but the *challenged* root was correct.
- Replaces the full intermediate root scan + first-invalid-index heuristic with a single `compute_output_root` call targeting only the challenged index — correct, simpler, and faster.
- Adds a regression test for the exact scenario: `[invalid_root, valid_root]` with the ZK challenge targeting the valid root at index 1.

## Bug details

Previously, `process_fraudulent_zk_challenge` called `validate_game()` which validated **all** intermediate roots and returned the first invalid index. The decision logic was:

```
if first_invalid_index <= challenged_index → treat as legitimate (skip)
```

This failed when e.g. roots were `[i_0=wrong, i_1=correct]` and the ZK challenge targeted `i_1` (index 1). Since `first_invalid=0 <= challenged_index=1`, the challenger skipped — even though `i_1` was correct and the ZK challenge was fraudulent.

Additionally, `validate_output_roots` stops at the first failure, so it never even checked whether the challenged root was valid when an earlier root was wrong.