### PR TITLE
fix(tee): refresh signer address from enclave on each proof request

### DIFF
--- a/crates/proof/tee/nitro-host/src/health.rs
+++ b/crates/proof/tee/nitro-host/src/health.rs
@@ -69,10 +69,7 @@ mod tests {
     use base_proof_contracts::TEEProverRegistryClient;
 
     use super::*;
-    use crate::{
-        test_utils::{MockRegistry, TEST_SIGNER},
-        transport::NitroTransport,
-    };
+    use crate::{test_utils::MockRegistry, transport::NitroTransport};
 
     fn test_healthz_with_mock(
         registry: impl TEEProverRegistryClient + 'static,
@@ -86,8 +83,7 @@ mod tests {
 
     #[tokio::test]
     async fn healthz_returns_ok_when_valid() {
-        let (checker, rpc) = test_healthz_with_mock(MockRegistry::new(true));
-        checker.set_signer_for_test(TEST_SIGNER);
+        let (_checker, rpc) = test_healthz_with_mock(MockRegistry::new(true));
         let result = HealthzApiServer::healthz(&rpc).await;
         assert!(result.is_ok());
         assert_eq!(result.unwrap().version, "0.0.0");
@@ -95,8 +91,7 @@ mod tests {
 
     #[tokio::test]
     async fn healthz_returns_error_when_not_valid() {
-        let (checker, rpc) = test_healthz_with_mock(MockRegistry::new(false));
-        checker.set_signer_for_test(TEST_SIGNER);
+        let (_checker, rpc) = test_healthz_with_mock(MockRegistry::new(false));
         let result = HealthzApiServer::healthz(&rpc).await;
         assert!(result.is_err());
     }
@@ -104,15 +99,13 @@ mod tests {
     #[tokio::test]
     async fn healthz_latches_after_first_success() {
         let registry = MockRegistry::new(true);
-        let (checker, rpc) = test_healthz_with_mock(registry.clone());
-        checker.set_signer_for_test(TEST_SIGNER);
+        let (_checker, rpc) = test_healthz_with_mock(registry.clone());
 
         let result = HealthzApiServer::healthz(&rpc).await;
         assert!(result.is_ok());
 
         registry.valid.store(false, Ordering::Relaxed);
         registry.should_fail.store(true, Ordering::Relaxed);
-        checker.set_cache_for_test(None).await;
 
         let result = HealthzApiServer::healthz(&rpc).await;
         assert!(result.is_ok());
@@ -122,8 +115,7 @@ mod tests {
     async fn healthz_errors_on_rpc_failure_before_latch() {
         let registry = MockRegistry::new(false);
         registry.should_fail.store(true, Ordering::Relaxed);
-        let (checker, rpc) = test_healthz_with_mock(registry);
-        checker.set_signer_for_test(TEST_SIGNER);
+        let (_checker, rpc) = test_healthz_with_mock(registry);
         let result = HealthzApiServer::healthz(&rpc).await;
         assert!(result.is_err());
     }
@@ -132,8 +124,7 @@ mod tests {
     async fn healthz_rpc_call_count() {
         let registry = MockRegistry::new(true);
         let call_count = Arc::clone(&registry.call_count);
-        let (checker, rpc) = test_healthz_with_mock(registry);
-        checker.set_signer_for_test(TEST_SIGNER);
+        let (_checker, rpc) = test_healthz_with_mock(registry);
 
         let _ = HealthzApiServer::healthz(&rpc).await;
         assert_eq!(call_count.load(Ordering::Relaxed), 1);

--- a/crates/proof/tee/nitro-host/src/registration.rs
+++ b/crates/proof/tee/nitro-host/src/registration.rs
@@ -3,8 +3,8 @@
 //! Two consumers, two policies:
 //! - **Health endpoint** — latching: once valid, stays healthy forever (avoids
 //!   ASG replacement on transient L1 failures).
-//! - **Proving guard** — fail-closed with a TTL cache: rejects proof requests
-//!   when the signer is invalid or L1 is unreachable.
+//! - **Proving guard** — fail-closed: rejects proof requests when the signer
+//!   is invalid or L1 is unreachable.
 //!
 //! # Trade-off: latching health after deregistration
 //!
@@ -17,22 +17,18 @@
 //! signal with no retry layer, switch to a bounded latch (e.g. stay healthy
 //! for N minutes after the last successful validation).
 
-use std::{
-    sync::Arc,
-    time::{Duration, Instant},
-};
+use std::{sync::Arc, time::Duration};
 
 use alloy_primitives::Address;
 use alloy_signer::utils::public_key_to_address;
 use base_proof_contracts::TEEProverRegistryClient;
 use k256::ecdsa::VerifyingKey;
 use thiserror::Error;
-use tokio::sync::{OnceCell, RwLock};
+use tokio::sync::OnceCell;
 use tracing::warn;
 
 use super::transport::NitroTransport;
 
-pub(crate) const CACHE_TTL: Duration = Duration::from_secs(30);
 const CHECK_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// Errors from signer-validity checks.
@@ -60,14 +56,13 @@ pub enum RegistrationError {
 /// Checks whether the enclave signer is a **valid** signer in the on-chain
 /// `TEEProverRegistry` (registered AND matching the current image hash).
 ///
-/// Validity results are cached for [`CACHE_TTL`] to avoid hitting L1 on every
-/// request.  A separate latching flag tracks whether the signer has *ever*
+/// Each call to [`require_valid_signer`](Self::require_valid_signer) performs a
+/// live L1 query — proof requests are infrequent enough that caching is
+/// unnecessary.  A separate latching flag tracks whether the signer has *ever*
 /// been valid — once set, [`check_health`](Self::check_health) always succeeds.
 pub struct RegistrationChecker {
     transport: Arc<NitroTransport>,
     registry: Box<dyn TEEProverRegistryClient>,
-    signer: OnceCell<Address>,
-    cache: RwLock<Option<(bool, Instant)>>,
     healthy: OnceCell<()>,
 }
 
@@ -86,49 +81,30 @@ impl RegistrationChecker {
         Self {
             transport,
             registry: Box::new(registry),
-            signer: OnceCell::new(),
-            cache: RwLock::new(None),
             healthy: OnceCell::new(),
         }
     }
 
     async fn signer_address(&self) -> Result<Address, RegistrationError> {
-        self.signer
-            .get_or_try_init(|| async {
-                let public_key = self
-                    .transport
-                    .signer_public_key()
-                    .await
-                    .map_err(|e| RegistrationError::Setup(format!("signer public key: {e}")))?;
-                let verifying_key = VerifyingKey::from_sec1_bytes(&public_key)
-                    .map_err(|e| RegistrationError::Setup(format!("invalid public key: {e}")))?;
-                Ok(public_key_to_address(&verifying_key))
-            })
+        let public_key = self
+            .transport
+            .signer_public_key()
             .await
-            .copied()
+            .map_err(|e| RegistrationError::Setup(format!("signer public key: {e}")))?;
+        let verifying_key = VerifyingKey::from_sec1_bytes(&public_key)
+            .map_err(|e| RegistrationError::Setup(format!("invalid public key: {e}")))?;
+        Ok(public_key_to_address(&verifying_key))
     }
 
     async fn fetch_validity(&self) -> Result<(bool, Address), RegistrationError> {
         let signer = self.signer_address().await?;
-
-        {
-            let cache = self.cache.read().await;
-            if let Some((valid, checked_at)) = *cache
-                && checked_at.elapsed() < CACHE_TTL
-            {
-                return Ok((valid, signer));
-            }
-        }
 
         let result =
             tokio::time::timeout(CHECK_TIMEOUT, self.registry.is_valid_signer(signer)).await;
 
         match result {
             Ok(Ok(valid)) => {
-                let mut cache = self.cache.write().await;
-                let was_valid = cache.map(|(v, _)| v);
-                *cache = Some((valid, Instant::now()));
-                if !valid && was_valid != Some(false) {
+                if !valid {
                     warn!(signer = %signer, "signer is not a valid signer in TEEProverRegistry");
                 }
                 Ok((valid, signer))
@@ -166,30 +142,14 @@ impl RegistrationChecker {
     }
 }
 
-impl RegistrationChecker {
-    #[cfg(test)]
-    pub(crate) fn set_signer_for_test(&self, signer: Address) {
-        let _ = self.signer.set(signer);
-    }
-
-    #[cfg(test)]
-    pub(crate) async fn set_cache_for_test(&self, value: Option<(bool, Instant)>) {
-        *self.cache.write().await = value;
-    }
-}
-
 #[cfg(test)]
 mod tests {
-    use std::{
-        sync::{Arc, atomic::Ordering},
-        time::Instant,
-    };
+    use std::sync::{Arc, atomic::Ordering};
 
-    use alloy_primitives::Address;
     use base_proof_contracts::TEEProverRegistryClient;
 
     use super::*;
-    use crate::test_utils::{MockRegistry, TEST_SIGNER};
+    use crate::test_utils::MockRegistry;
 
     fn test_checker_with_mock(
         registry: impl TEEProverRegistryClient + 'static,
@@ -203,22 +163,22 @@ mod tests {
         let server = Arc::new(base_proof_tee_nitro_enclave::Server::new_local().unwrap());
         let transport = Arc::new(NitroTransport::local(server));
         let dummy_url = url::Url::parse("http://localhost:1").unwrap();
-        let registry =
-            base_proof_contracts::TEEProverRegistryContractClient::new(Address::ZERO, dummy_url);
+        let registry = base_proof_contracts::TEEProverRegistryContractClient::new(
+            alloy_primitives::Address::ZERO,
+            dummy_url,
+        );
         RegistrationChecker::new(transport, registry)
     }
 
     #[tokio::test]
     async fn health_returns_true_when_valid() {
         let checker = test_checker_with_mock(MockRegistry::new(true));
-        checker.set_signer_for_test(TEST_SIGNER);
         assert!(checker.check_health().await.unwrap());
     }
 
     #[tokio::test]
     async fn health_returns_false_when_not_valid() {
         let checker = test_checker_with_mock(MockRegistry::new(false));
-        checker.set_signer_for_test(TEST_SIGNER);
         assert!(!checker.check_health().await.unwrap());
     }
 
@@ -226,13 +186,11 @@ mod tests {
     async fn health_latches_after_first_success() {
         let registry = MockRegistry::new(true);
         let checker = test_checker_with_mock(registry.clone());
-        checker.set_signer_for_test(TEST_SIGNER);
 
         assert!(checker.check_health().await.unwrap());
 
         registry.valid.store(false, Ordering::Relaxed);
         registry.should_fail.store(true, Ordering::Relaxed);
-        checker.set_cache_for_test(None).await;
 
         assert!(checker.check_health().await.unwrap());
     }
@@ -242,7 +200,6 @@ mod tests {
         let registry = MockRegistry::new(false);
         registry.should_fail.store(true, Ordering::Relaxed);
         let checker = test_checker_with_mock(registry);
-        checker.set_signer_for_test(TEST_SIGNER);
         assert!(checker.check_health().await.is_err());
     }
 
@@ -250,27 +207,21 @@ mod tests {
     async fn health_ok_on_rpc_failure_after_latch() {
         let registry = MockRegistry::new(true);
         let checker = test_checker_with_mock(registry.clone());
-        checker.set_signer_for_test(TEST_SIGNER);
         assert!(checker.check_health().await.unwrap());
 
         registry.should_fail.store(true, Ordering::Relaxed);
-        checker.set_cache_for_test(None).await;
         assert!(checker.check_health().await.unwrap());
     }
 
     #[tokio::test]
-    async fn require_valid_signer_ok_when_cached_valid() {
-        let checker = test_checker();
-        checker.set_signer_for_test(TEST_SIGNER);
-        checker.set_cache_for_test(Some((true, Instant::now()))).await;
+    async fn require_valid_signer_ok() {
+        let checker = test_checker_with_mock(MockRegistry::new(true));
         assert!(checker.require_valid_signer().await.is_ok());
     }
 
     #[tokio::test]
-    async fn require_valid_signer_rejects_when_cached_invalid() {
-        let checker = test_checker();
-        checker.set_signer_for_test(TEST_SIGNER);
-        checker.set_cache_for_test(Some((false, Instant::now()))).await;
+    async fn require_valid_signer_rejects_when_invalid() {
+        let checker = test_checker_with_mock(MockRegistry::new(false));
         assert!(matches!(
             checker.require_valid_signer().await.unwrap_err(),
             RegistrationError::NotValid { .. }
@@ -280,7 +231,6 @@ mod tests {
     #[tokio::test]
     async fn require_valid_signer_rejects_on_rpc_error() {
         let checker = test_checker();
-        checker.set_signer_for_test(TEST_SIGNER);
         assert!(matches!(
             checker.require_valid_signer().await.unwrap_err(),
             RegistrationError::Rpc { .. }
@@ -288,28 +238,15 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn require_valid_signer_rejects_on_expired_cache() {
-        let checker = test_checker();
-        checker.set_signer_for_test(TEST_SIGNER);
-        let expired = Instant::now() - CACHE_TTL - Duration::from_secs(1);
-        checker.set_cache_for_test(Some((true, expired))).await;
-        assert!(matches!(
-            checker.require_valid_signer().await.unwrap_err(),
-            RegistrationError::Rpc { .. }
-        ));
-    }
-
-    #[tokio::test]
-    async fn cache_hit_within_ttl() {
+    async fn each_call_hits_registry() {
         let registry = MockRegistry::new(true);
         let call_count = Arc::clone(&registry.call_count);
         let checker = test_checker_with_mock(registry);
-        checker.set_signer_for_test(TEST_SIGNER);
 
         assert!(checker.require_valid_signer().await.is_ok());
         assert_eq!(call_count.load(Ordering::Relaxed), 1);
 
         assert!(checker.require_valid_signer().await.is_ok());
-        assert_eq!(call_count.load(Ordering::Relaxed), 1);
+        assert_eq!(call_count.load(Ordering::Relaxed), 2);
     }
 }

--- a/crates/proof/tee/nitro-host/src/registration.rs
+++ b/crates/proof/tee/nitro-host/src/registration.rs
@@ -78,11 +78,7 @@ impl RegistrationChecker {
         transport: Arc<NitroTransport>,
         registry: impl TEEProverRegistryClient + 'static,
     ) -> Self {
-        Self {
-            transport,
-            registry: Box::new(registry),
-            healthy: OnceCell::new(),
-        }
+        Self { transport, registry: Box::new(registry), healthy: OnceCell::new() }
     }
 
     async fn signer_address(&self) -> Result<Address, RegistrationError> {

--- a/crates/proof/tee/nitro-host/src/test_utils.rs
+++ b/crates/proof/tee/nitro-host/src/test_utils.rs
@@ -5,12 +5,9 @@ use std::sync::{
     atomic::{AtomicBool, AtomicUsize, Ordering},
 };
 
-use alloy_primitives::{Address, address};
+use alloy_primitives::Address;
 use base_proof_contracts::TEEProverRegistryClient;
 use jsonrpsee::core::async_trait;
-
-/// Well-known test signer address (Hardhat account #0).
-pub const TEST_SIGNER: Address = address!("f39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
 
 /// In-memory mock of [`TEEProverRegistryClient`] for unit tests.
 ///


### PR DESCRIPTION
## Summary

- Fix stale signer address causing all proof requests to be rejected after an enclave restart
- Remove `OnceCell<Address>` caching and 30s TTL validity cache from `RegistrationChecker`
- Each `require_valid_signer()` call now fetches the current key from the enclave and performs a live L1 query

## Problem

The Nitro enclave crashed and restarted on `i-037cbf4702a5affb4` at 14:26 UTC, generating a new random ECDSA signing key. The host process kept running with the old signer address cached in a `OnceCell<Address>` — it never re-fetched from the enclave. The registrar correctly registered the new key and deregistered the old one as an orphan, but the host kept checking the stale address against the contract, rejecting every proof request with `signer is not a valid signer in TEEProverRegistry` for 1.5+ hours.

## Root cause chain

1. **Enclave crashed** (likely OOM) — logged `"Enclave is no longer running"`
2. **Docker restarted** the management container → `nitro-cli run-enclave` → new enclave VM with new key
3. **Host kept old key** — `OnceCell<Address>` in `signer_address()` never re-fetched
4. **Registrar detected** the new key, registered it, orphaned the old one
5. **Host rejected all proofs** — stale address returns NOT VALID from the contract

## Fix

- `signer_address()` now fetches the public key from the enclave via vsock on every call (sub-ms cost)
- Removed the 30s `CACHE_TTL` validity cache entirely — proof requests are minutes apart, caching is unnecessary
- Health endpoint still latches after first success (no change to `/healthz` behavior)
- Net **-109/+34 lines** — simpler code with fewer failure modes

## Testing

All 21 tests pass. Key test changes:
- Removed `set_signer_for_test()` / `TEST_SIGNER` — tests now use the actual key from the local transport
- `each_call_hits_registry` verifies every `require_valid_signer()` call makes a live L1 query (call_count increments to 2)
- Removed cache-specific tests (`cache_hit_within_ttl`, `expired_cache`) that no longer apply