### PR TITLE
fix(tee): log enclave exit state on crash

### DIFF
--- a/etc/docker/nitro-enclave/entrypoint-enclave.sh
+++ b/etc/docker/nitro-enclave/entrypoint-enclave.sh
@@ -29,10 +29,16 @@ done
 
 echo "Enclave is running"
 
+ENCLAVE_ID=$(./nitro-cli describe-enclaves | grep -o '"EnclaveID": "[^"]*"' | head -1 | cut -d'"' -f4)
+echo "Enclave ID: $ENCLAVE_ID"
+
 # Poll until enclave exits
-while ./nitro-cli describe-enclaves | grep -q '"State": "RUNNING"'; do
+while true; do
+    DESC=$(./nitro-cli describe-enclaves)
+    if ! echo "$DESC" | grep -q '"State": "RUNNING"'; then
+        echo "Enclave is no longer running"
+        echo "$DESC"
+        exit 1
+    fi
     sleep 30
 done
-
-echo "Enclave is no longer running"
-exit 1


### PR DESCRIPTION
## Summary

- Log `describe-enclaves` output when the enclave exits so we capture the exit code and final state
- Log enclave ID on startup for correlation

## Problem

When a Nitro enclave crashes, the management container detects it via the `describe-enclaves` polling loop but discards the output through `grep -q`. The exit code (137=OOM, 1=panic, 139=segfault) is lost, making it impossible to determine why the enclave died from logs alone.

## Change

The polling loop now captures `describe-enclaves` output into a variable and prints it when the enclave is no longer running. This gives us the full JSON including `State`, `ExitCode`, and `EnclaveID` in the container logs.