### PR TITLE
fix(tee): log enclave exit state on crash [backport v0.8.0]

### DIFF
--- a/etc/docker/nitro-enclave/entrypoint-enclave.sh
+++ b/etc/docker/nitro-enclave/entrypoint-enclave.sh
@@ -29,10 +29,16 @@ done
 
 echo "Enclave is running"
 
+ENCLAVE_ID=$(./nitro-cli describe-enclaves | grep -o '"EnclaveID": "[^"]*"' | head -1 | cut -d'"' -f4)
+echo "Enclave ID: $ENCLAVE_ID"
+
 # Poll until enclave exits
-while ./nitro-cli describe-enclaves | grep -q '"State": "RUNNING"'; do
+while true; do
+    DESC=$(./nitro-cli describe-enclaves)
+    if ! echo "$DESC" | grep -q '"State": "RUNNING"'; then
+        echo "Enclave is no longer running"
+        echo "$DESC"
+        exit 1
+    fi
     sleep 30
 done
-
-echo "Enclave is no longer running"
-exit 1


### PR DESCRIPTION
## Summary

Backport of #2239 to `releases/v0.8.0`.

- Log `describe-enclaves` output when the enclave exits so we capture the exit code and final state
- Log enclave ID on startup for correlation

When a Nitro enclave crashes, the exit code (137=OOM, 1=panic, 139=segfault) was previously lost because `grep -q` discarded the output. The polling loop now captures and prints the full JSON on exit.