### PR TITLE
fix(basectl): replace unwrap() with safe timestamp check in upgrades view

### DIFF
--- a/crates/infra/basectl/src/app/views/upgrades.rs
+++ b/crates/infra/basectl/src/app/views/upgrades.rs
@@ -417,9 +417,9 @@ impl View for UpgradesView {
                 // defined checks. This lets mainnet run Jovian checks instead of
                 // silently doing nothing when V1 has no timestamp.
                 if let Some(spec) = target_hardfork(chain)
-                    .and_then(|name| chain.specs.iter().find(|s| s.name == name))
+                    .and_then(|name| chain.specs.iter().find(|s| s.name == name && s.timestamp.is_some()))
                 {
-                    let ts = spec.timestamp.unwrap();
+                    let Some(ts) = spec.timestamp else { return Action::None; };
                     if let Some(rpc) = self.rpc_for_selected(resources) {
                         let mode = if ts > now { CheckMode::Before } else { CheckMode::After };
                         self.checks.start(self.selected_chain, rpc, spec.name, mode);


### PR DESCRIPTION
## Summary

`spec.timestamp.unwrap()` at line 422 can panic at runtime.

`target_hardfork` returns the `name` of a spec where `timestamp.is_some()`, but the subsequent `.find(|s| s.name == name)` lookup finds the **first** spec matching that name — which may be a different instance with `timestamp: None`.

## Fix

Filter by both name and timestamp in the lookup, and use a safe `let-else`:

```rust
// Before
if let Some(spec) = target_hardfork(chain)
    .and_then(|name| chain.specs.iter().find(|s| s.name == name))
{
    let ts = spec.timestamp.unwrap(); // can panic!

// After
if let Some(spec) = target_hardfork(chain)
    .and_then(|name| chain.specs.iter().find(|s| s.name == name && s.timestamp.is_some()))
{
    let Some(ts) = spec.timestamp else { return Action::None; };
```

Closes #2243