### PR TITLE
feat(infra): Add Base Canary Monitoring Service

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2910,6 +2910,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "base-canary"
+version = "0.0.0"
+dependencies = [
+ "alloy-eips",
+ "alloy-network",
+ "alloy-primitives",
+ "alloy-provider",
+ "alloy-rpc-types",
+ "alloy-signer-local",
+ "async-trait",
+ "base-cli-utils",
+ "base-consensus-gossip",
+ "base-consensus-rpc",
+ "base-health",
+ "base-load-tests",
+ "base-metrics",
+ "base-protocol",
+ "clap",
+ "eyre",
+ "humantime",
+ "jsonrpsee",
+ "libp2p",
+ "libp2p-identity",
+ "metrics",
+ "rand 0.9.4",
+ "rstest",
+ "serde",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "base-canary-bin"
+version = "0.0.0"
+dependencies = [
+ "base-canary",
+ "base-cli-utils",
+ "clap",
+ "eyre",
+ "tokio",
+]
+
+[[package]]
 name = "base-challenger"
 version = "0.0.0"
 dependencies = [
@@ -5293,9 +5339,11 @@ dependencies = [
  "alloy-primitives",
  "alloy-provider",
  "alloy-rpc-types-eth",
+ "alloy-signer-local",
  "alloy-sol-types",
  "anyhow",
  "arboard",
+ "base-canary",
  "base-common-chains",
  "base-common-consensus",
  "base-common-flashblocks",
@@ -5317,6 +5365,7 @@ dependencies = [
  "serde_yaml",
  "tokio",
  "tokio-tungstenite 0.28.0",
+ "tokio-util",
  "tracing",
  "url",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ default-members = [
   "bin/node",
   "bin/basectl",
   "bin/builder",
+  "bin/canary",
   "bin/challenger",
   "bin/consensus",
   "bin/ingress-rpc",
@@ -218,6 +219,7 @@ base-execution-payload-builder = { path = "crates/execution/payload" }
 
 # Infra
 based = { path = "crates/infra/based" }
+base-canary = { path = "crates/infra/canary" }
 basectl-cli = { path = "crates/infra/basectl" }
 base-load-tests = { path = "crates/infra/load-tests" }
 audit-archiver-lib = { path = "crates/infra/audit" }

--- a/bin/canary/Cargo.toml
+++ b/bin/canary/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "base-canary-bin"
+description = "Base Canary Binary"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+
+[[bin]]
+name = "base-canary"
+path = "src/main.rs"
+
+[lints]
+workspace = true
+
+[dependencies]
+eyre.workspace = true
+base-cli-utils.workspace = true
+tokio = { workspace = true, features = ["full"] }
+clap = { workspace = true, features = ["derive", "env"] }
+base-canary = { workspace = true, features = ["metrics"] }

--- a/bin/canary/README.md
+++ b/bin/canary/README.md
@@ -1,0 +1,24 @@
+# base-canary
+
+Long-lived canary service that periodically performs health checks, balance
+monitoring, and load tests against a target L2 network.
+
+Scheduling supports two modes, selectable via `--schedule-mode`:
+
+* **deterministic** — fixed interval between canary runs.
+* **random** — interval with a random jitter component
+  (`interval + rand(0..jitter)`).
+
+## Usage
+
+```sh
+base-canary \
+  --l2-rpc-url http://localhost:8545 \
+  --private-key 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80 \
+  --schedule-mode deterministic \
+  --schedule-interval 60s \
+  --load-test-duration 30s
+```
+
+All flags can be set via environment variables prefixed with `BASE_CANARY_`
+(e.g. `BASE_CANARY_L2_RPC_URL`).

--- a/bin/canary/src/cli.rs
+++ b/bin/canary/src/cli.rs
@@ -1,0 +1,28 @@
+//! CLI definition for the canary binary.
+
+use clap::Parser;
+use eyre::WrapErr;
+
+/// Base Canary.
+#[derive(Parser)]
+#[command(author, version)]
+#[group(skip)]
+pub(crate) struct Cli {
+    #[command(flatten)]
+    args: base_canary::Cli,
+}
+
+impl Cli {
+    /// Run the canary service.
+    pub(crate) async fn run(self) -> eyre::Result<()> {
+        let config = base_canary::CanaryConfig::from_cli(self.args)?;
+        config.log.init_tracing_subscriber()?;
+        config
+            .metrics
+            .init_with(|| {
+                base_cli_utils::register_version_metrics!();
+            })
+            .wrap_err("failed to install Prometheus recorder")?;
+        base_canary::CanaryService::run(config).await
+    }
+}

--- a/bin/canary/src/main.rs
+++ b/bin/canary/src/main.rs
@@ -1,0 +1,18 @@
+#![doc = include_str!("../README.md")]
+#![doc(issue_tracker_base_url = "https://github.com/base/base/issues/")]
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
+
+use clap::Parser as _;
+
+mod cli;
+
+#[tokio::main]
+async fn main() {
+    base_cli_utils::init_common!();
+
+    if let Err(err) = cli::Cli::parse().run().await {
+        eprintln!("Error: {err:?}");
+        std::process::exit(1);
+    }
+}

--- a/crates/infra/basectl/Cargo.toml
+++ b/crates/infra/basectl/Cargo.toml
@@ -16,8 +16,11 @@ arboard = { workspace = true }
 futures = { workspace = true }
 crossterm = { workspace = true }
 serde_yaml = { workspace = true }
+tokio-util = { workspace = true }
+base-canary = { workspace = true }
 alloy-contract = { workspace = true }
 base-load-tests = { workspace = true }
+alloy-signer-local = { workspace = true }
 base-common-chains = { workspace = true }
 base-common-network = { workspace = true }
 base-consensus-gossip = { workspace = true }

--- a/crates/infra/basectl/src/app/mod.rs
+++ b/crates/infra/basectl/src/app/mod.rs
@@ -8,7 +8,8 @@ pub use core::App;
 
 mod resources;
 pub use resources::{
-    ConductorState, DaState, FlashState, LoadTestTask, ProofsState, Resources, ValidatorState,
+    CanaryEvent, CanaryOutcome, CanaryState, ConductorState, DaState, FlashState, LoadTestTask,
+    ProofsState, Resources, ValidatorState,
 };
 
 mod router;
@@ -23,6 +24,6 @@ pub use view::View;
 /// TUI view implementations.
 mod views;
 pub use views::{
-    CommandCenterView, ConductorView, ConfigView, DaMonitorView, FlashblocksView, HomeView,
-    LoadTestView, ProofsView, TransactionPane, UpgradesView, create_view,
+    CanaryView, CommandCenterView, ConductorView, ConfigView, DaMonitorView, FlashblocksView,
+    HomeView, LoadTestView, ProofsView, TransactionPane, UpgradesView, create_view,
 };

--- a/crates/infra/basectl/src/app/resources.rs
+++ b/crates/infra/basectl/src/app/resources.rs
@@ -3,12 +3,14 @@ use std::{
     sync::{Arc, atomic::AtomicBool},
 };
 
+use base_canary::ActionOutcome;
 use base_common_flashblocks::Flashblock;
 use base_consensus_genesis::SystemConfig;
 use tokio::{
     sync::{mpsc, watch},
     task::JoinHandle,
 };
+use tokio_util::sync::CancellationToken;
 
 use crate::{
     commands::{DaTracker, FlashblockEntry, LoadingState},
@@ -151,6 +153,121 @@ pub struct LoadTestTask {
     pub handle: JoinHandle<()>,
 }
 
+/// An event emitted by the background canary task.
+#[derive(Debug)]
+pub enum CanaryEvent {
+    /// An action has started executing.
+    ActionStarted {
+        /// Name of the action.
+        name: &'static str,
+    },
+    /// An action has finished.
+    ActionCompleted {
+        /// Name of the action.
+        name: &'static str,
+        /// Outcome of the action execution.
+        outcome: ActionOutcome,
+    },
+    /// Waiting for the next scheduled run; `delay_secs` counts down each second.
+    WaitingForNextRun {
+        /// Seconds remaining until the next run.
+        delay_secs: u64,
+    },
+}
+
+/// A completed canary action outcome shown in the results list.
+#[derive(Debug)]
+pub struct CanaryOutcome {
+    /// Action that produced this outcome.
+    pub name: &'static str,
+    /// Result of the action execution.
+    pub outcome: ActionOutcome,
+}
+
+/// Persistent canary runner state — lives in [`Resources`] so the task
+/// keeps executing across view switches.
+#[derive(Debug, Default)]
+pub struct CanaryState {
+    /// Completed action outcomes, newest at the back.
+    pub outcomes: VecDeque<CanaryOutcome>,
+    /// Name of the action currently executing, if any.
+    pub current_action: Option<&'static str>,
+    /// Seconds until the next scheduled run, while waiting between cycles.
+    pub next_run_secs: Option<u64>,
+    cancel: Option<CancellationToken>,
+    event_rx: Option<mpsc::Receiver<CanaryEvent>>,
+    handle: Option<JoinHandle<()>>,
+}
+
+impl CanaryState {
+    /// Returns `true` if the canary task is currently running.
+    pub fn is_running(&self) -> bool {
+        self.handle.as_ref().is_some_and(|h| !h.is_finished())
+    }
+
+    /// Registers a newly spawned canary task, replacing any previous one.
+    pub fn set_task(
+        &mut self,
+        cancel: CancellationToken,
+        event_rx: mpsc::Receiver<CanaryEvent>,
+        handle: JoinHandle<()>,
+    ) {
+        self.stop();
+        self.outcomes.clear();
+        self.current_action = None;
+        self.next_run_secs = None;
+        self.cancel = Some(cancel);
+        self.event_rx = Some(event_rx);
+        self.handle = Some(handle);
+    }
+
+    /// Cancels and drops the running task.
+    pub fn stop(&mut self) {
+        if let Some(c) = self.cancel.take() {
+            c.cancel();
+        }
+        if let Some(h) = self.handle.take() {
+            h.abort();
+        }
+        self.event_rx = None;
+        self.current_action = None;
+        self.next_run_secs = None;
+    }
+
+    /// Drains pending events from the channel and updates state.
+    ///
+    /// Call once per tick from [`super::views::CanaryView`].
+    pub fn drain_events(&mut self) {
+        let Some(ref mut rx) = self.event_rx else { return };
+        while let Ok(event) = rx.try_recv() {
+            match event {
+                CanaryEvent::ActionStarted { name } => {
+                    self.current_action = Some(name);
+                    self.next_run_secs = None;
+                }
+                CanaryEvent::ActionCompleted { name, outcome } => {
+                    self.current_action = None;
+                    self.outcomes.push_back(CanaryOutcome { name, outcome });
+                    if self.outcomes.len() > 200 {
+                        self.outcomes.pop_front();
+                    }
+                }
+                CanaryEvent::WaitingForNextRun { delay_secs } => {
+                    self.next_run_secs = Some(delay_secs);
+                }
+            }
+        }
+        // Detect natural task exit.
+        if self.handle.as_ref().is_some_and(|h| h.is_finished()) {
+            self.handle = None;
+            self.cancel = None;
+            self.event_rx = None;
+            self.current_action = None;
+            self.next_run_secs = None;
+        }
+    }
+}
+
 /// Shared resources available to all TUI views.
 #[derive(Debug)]
 pub struct Resources {
@@ -168,6 +285,8 @@ pub struct Resources {
     pub validators: ValidatorState,
     /// Proof system monitoring state.
     pub proofs: ProofsState,
+    /// Canary runner state, persists across view switches.
+    pub canary: CanaryState,
     /// L1 system config fetched from the contract.
     pub system_config: Option<SystemConfig>,
     sys_config_rx: Option<mpsc::Receiver<SystemConfig>>,
@@ -230,6 +349,7 @@ impl Resources {
             conductor: ConductorState::default(),
             validators: ValidatorState::default(),
             proofs: ProofsState::default(),
+            canary: CanaryState::default(),
             system_config: None,
             sys_config_rx: None,
             load_test_task: None,

--- a/crates/infra/basectl/src/app/router.rs
+++ b/crates/infra/basectl/src/app/router.rs
@@ -19,6 +19,8 @@ pub enum ViewId {
     LoadTest,
     /// Network upgrade activation countdown and history.
     Upgrades,
+    /// Canary service runner and log stream (devnet only).
+    Canary,
 }
 
 /// Manages view navigation history and the current active view.

--- a/crates/infra/basectl/src/app/views/canary.rs
+++ b/crates/infra/basectl/src/app/views/canary.rs
@@ -1,0 +1,354 @@
+//! Canary view — renders in-process canary runner state from [`Resources`].
+//!
+//! All mutable state lives in [`crate::app::Resources::canary`] so the task
+//! keeps executing across view switches. The view itself is stateless except
+//! for the scroll offset.
+
+use std::{
+    collections::VecDeque,
+    time::{Duration, Instant},
+};
+
+use alloy_primitives::{U256, utils::parse_ether};
+use alloy_provider::{Provider, ProviderBuilder};
+use alloy_signer_local::PrivateKeySigner;
+use base_canary::{
+    BalanceCheckAction, CanaryAction, GossipSpamAction, HealthCheckAction, InvalidBatchAction,
+    LoadTestAction, LoadTestConfig, ScheduleMode, Scheduler,
+};
+use base_load_tests::HARDHAT_TEST_KEYS;
+use crossterm::event::{KeyCode, KeyEvent};
+use ratatui::{
+    Frame,
+    layout::{Alignment, Constraint, Direction, Layout, Rect},
+    prelude::*,
+    widgets::{Block, Borders, List, ListItem, Paragraph},
+};
+use tokio::sync::mpsc;
+use tokio_util::sync::CancellationToken;
+use url::Url;
+
+use crate::{
+    app::{Action, CanaryEvent, CanaryOutcome, Resources, View},
+    commands::COLOR_BASE_BLUE,
+    tui::Keybinding,
+};
+
+/// L2 execution-client RPC endpoint for a local devnet.
+const DEVNET_L2_RPC: &str = "http://localhost:8545";
+/// L2 execution-client WebSocket endpoint for a local devnet.
+const DEVNET_L2_WS: &str = "ws://localhost:8546";
+/// L1 RPC endpoint for a local devnet (Reth/Anvil).
+const DEVNET_L1_RPC: &str = "http://localhost:4545";
+/// Consensus-layer RPC endpoint for the devnet client node.
+const DEVNET_CL_RPC: &str = "http://localhost:8549";
+
+// Action defaults — match the base-canary binary defaults.
+const DEFAULT_MIN_BALANCE_ETH: &str = "0.01";
+const DEFAULT_FUNDING_ETH: &str = "0.1";
+const DEFAULT_MAX_BLOCK_AGE: Duration = Duration::from_secs(30);
+const DEFAULT_SCHEDULE_INTERVAL: Duration = Duration::from_secs(60);
+const DEFAULT_LOAD_TEST_GPS: u64 = 12_600_000;
+const DEFAULT_LOAD_TEST_DURATION: Duration = Duration::from_secs(30);
+const DEFAULT_LOAD_TEST_ACCOUNTS: usize = 60;
+const DEFAULT_LOAD_TEST_SEED: u64 = 1;
+
+const KEYBINDINGS: &[Keybinding] = &[
+    Keybinding { key: "s", description: "Start / Stop" },
+    Keybinding { key: "↑/↓", description: "Scroll" },
+    Keybinding { key: "Esc", description: "Back" },
+];
+
+/// Renders the canary runner. All persistent state lives in [`Resources::canary`].
+#[derive(Debug, Default)]
+pub struct CanaryView {
+    /// Lines scrolled back from the bottom (0 = auto-scroll to latest).
+    scroll_offset: usize,
+}
+
+impl CanaryView {
+    /// Creates a new canary view.
+    pub const fn new() -> Self {
+        Self { scroll_offset: 0 }
+    }
+
+    fn spawn_task(resources: &mut Resources) {
+        let cancel = CancellationToken::new();
+        let (event_tx, event_rx) = mpsc::channel(64);
+        let cancel_for_task = cancel.clone();
+
+        let handle = tokio::spawn(async move {
+            let Ok(l2_rpc_url) = Url::parse(DEVNET_L2_RPC) else { return };
+            let Ok(l2_ws_url) = Url::parse(DEVNET_L2_WS) else { return };
+
+            let provider = ProviderBuilder::new().connect_http(l2_rpc_url.clone());
+            let chain_id = tokio::time::timeout(Duration::from_secs(5), provider.get_chain_id())
+                .await
+                .ok()
+                .and_then(|r| r.ok())
+                .unwrap_or(84538453);
+
+            // Pick the first Hardhat test account that holds a non-zero balance.
+            // Devnets don't always fund account 0; this mirrors devnet_funder() from
+            // base-load-tests so the canary always gets a usable key automatically.
+            let mut signer: Option<PrivateKeySigner> = None;
+            for key_str in HARDHAT_TEST_KEYS {
+                let Ok(s) = key_str.parse::<PrivateKeySigner>() else { continue };
+                if provider.get_balance(s.address()).await.is_ok_and(|b| !b.is_zero()) {
+                    signer = Some(s);
+                    break;
+                }
+            }
+            let Some(signer) = signer else { return };
+
+            let min_balance = parse_ether(DEFAULT_MIN_BALANCE_ETH).unwrap_or(U256::ZERO);
+            let funding_amount = parse_ether(DEFAULT_FUNDING_ETH).unwrap_or(U256::ZERO);
+
+            // HARDHAT_TEST_KEYS[1] is the "wrong" signer for the invalid batch action —
+            // it is provably different from the real devnet batcher key.
+            let wrong_signer =
+                HARDHAT_TEST_KEYS[1].parse::<PrivateKeySigner>().expect("valid hardhat key");
+
+            let Ok(cl_rpc_url) = Url::parse(DEVNET_CL_RPC) else { return };
+            let Ok(l1_rpc_url) = Url::parse(DEVNET_L1_RPC) else { return };
+
+            let actions: Vec<Box<dyn CanaryAction>> = vec![
+                Box::new(BalanceCheckAction::new(
+                    l2_rpc_url.clone(),
+                    signer.address(),
+                    min_balance,
+                )),
+                Box::new(HealthCheckAction::new(l2_rpc_url.clone(), DEFAULT_MAX_BLOCK_AGE)),
+                Box::new(LoadTestAction::new(LoadTestConfig {
+                    l2_rpc_url: l2_rpc_url.clone(),
+                    l2_ws_url: Some(l2_ws_url),
+                    chain_id,
+                    funding_key: signer,
+                    funding_amount_wei: funding_amount,
+                    target_gps: DEFAULT_LOAD_TEST_GPS,
+                    duration: DEFAULT_LOAD_TEST_DURATION,
+                    account_count: DEFAULT_LOAD_TEST_ACCOUNTS,
+                    seed: DEFAULT_LOAD_TEST_SEED,
+                })),
+                Box::new(GossipSpamAction::new(cl_rpc_url.clone(), 1000, Duration::ZERO)),
+                Box::new(InvalidBatchAction::new(l1_rpc_url, cl_rpc_url, wrong_signer)),
+            ];
+
+            let scheduler = Scheduler::new(
+                ScheduleMode::Deterministic,
+                DEFAULT_SCHEDULE_INTERVAL,
+                Duration::ZERO,
+            );
+
+            loop {
+                for action in &actions {
+                    if cancel_for_task.is_cancelled() {
+                        return;
+                    }
+                    let name = action.name();
+                    let _ = event_tx.send(CanaryEvent::ActionStarted { name }).await;
+                    let outcome = action.execute(cancel_for_task.child_token()).await;
+                    if event_tx.send(CanaryEvent::ActionCompleted { name, outcome }).await.is_err()
+                    {
+                        return;
+                    }
+                }
+
+                if cancel_for_task.is_cancelled() {
+                    return;
+                }
+
+                let delay = scheduler.next_delay();
+                let deadline = Instant::now() + delay;
+                loop {
+                    if cancel_for_task.is_cancelled() {
+                        return;
+                    }
+                    let remaining = deadline.saturating_duration_since(Instant::now());
+                    if remaining.is_zero() {
+                        break;
+                    }
+                    let secs_left = remaining.as_secs();
+                    let _ = event_tx
+                        .send(CanaryEvent::WaitingForNextRun { delay_secs: secs_left })
+                        .await;
+                    let tick = remaining.min(Duration::from_secs(1));
+                    tokio::select! {
+                        () = cancel_for_task.cancelled() => return,
+                        () = tokio::time::sleep(tick) => {}
+                    }
+                }
+            }
+        });
+
+        resources.canary.set_task(cancel, event_rx, handle);
+    }
+}
+
+impl View for CanaryView {
+    fn keybindings(&self) -> &'static [Keybinding] {
+        KEYBINDINGS
+    }
+
+    fn handle_key(&mut self, key: KeyEvent, resources: &mut Resources) -> Action {
+        if resources.config.name != "devnet" {
+            return Action::None;
+        }
+
+        match key.code {
+            KeyCode::Char('s') => {
+                if resources.canary.is_running() {
+                    resources.canary.stop();
+                } else {
+                    Self::spawn_task(resources);
+                }
+                Action::None
+            }
+            KeyCode::Up | KeyCode::Char('k') => {
+                self.scroll_offset += 1;
+                Action::None
+            }
+            KeyCode::Down | KeyCode::Char('j') => {
+                self.scroll_offset = self.scroll_offset.saturating_sub(1);
+                Action::None
+            }
+            _ => Action::None,
+        }
+    }
+
+    fn tick(&mut self, resources: &mut Resources) -> Action {
+        resources.canary.drain_events();
+        Action::None
+    }
+
+    fn render(&mut self, frame: &mut Frame<'_>, area: Rect, resources: &Resources) {
+        if resources.config.name != "devnet" {
+            let msg = Paragraph::new(
+                "Canary is only available on devnet.\n\nStart basectl with -c devnet.",
+            )
+            .style(Style::default().fg(Color::DarkGray))
+            .alignment(Alignment::Center);
+            frame.render_widget(msg, area);
+            return;
+        }
+
+        let chunks = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([Constraint::Length(3), Constraint::Min(0)])
+            .split(area);
+
+        render_header(
+            frame,
+            chunks[0],
+            resources.canary.is_running(),
+            resources.canary.current_action,
+            resources.canary.next_run_secs,
+        );
+        render_outcomes(
+            frame,
+            chunks[1],
+            &resources.canary.outcomes,
+            self.scroll_offset,
+            resources.canary.is_running(),
+        );
+    }
+}
+
+fn render_header(
+    frame: &mut Frame<'_>,
+    area: Rect,
+    running: bool,
+    current_action: Option<&str>,
+    next_run_secs: Option<u64>,
+) {
+    let state_span = if running {
+        Span::styled("Running", Style::default().fg(Color::Green))
+    } else {
+        Span::styled("Idle", Style::default().fg(Color::DarkGray))
+    };
+
+    let mut spans = vec![Span::raw("Status: "), state_span];
+
+    if let Some(action) = current_action {
+        spans.push(Span::raw("   Executing: "));
+        spans.push(Span::styled(action, Style::default().fg(Color::Cyan)));
+    } else if let Some(secs) = next_run_secs {
+        spans.push(Span::raw("   Next run in: "));
+        spans.push(Span::styled(format!("{secs}s"), Style::default().fg(Color::DarkGray)));
+    }
+
+    let header = Paragraph::new(Line::from(spans)).block(
+        Block::default()
+            .title(" Canary ")
+            .borders(Borders::ALL)
+            .border_style(Style::default().fg(COLOR_BASE_BLUE)),
+    );
+
+    frame.render_widget(header, area);
+}
+
+fn render_outcomes(
+    frame: &mut Frame<'_>,
+    area: Rect,
+    outcomes: &VecDeque<CanaryOutcome>,
+    scroll_offset: usize,
+    running: bool,
+) {
+    let block = Block::default()
+        .title(" Results ")
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(Color::DarkGray));
+
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+
+    if outcomes.is_empty() {
+        let hint = if running {
+            "Waiting for first action to complete..."
+        } else {
+            "Press [s] to start the canary."
+        };
+        let para = Paragraph::new(hint)
+            .style(Style::default().fg(Color::DarkGray))
+            .alignment(Alignment::Center);
+        frame.render_widget(para, inner);
+        return;
+    }
+
+    let visible = inner.height as usize;
+    let total = outcomes.len();
+    let scroll = scroll_offset.min(total.saturating_sub(visible));
+    let start = total.saturating_sub(visible + scroll);
+
+    let items: Vec<ListItem<'_>> = outcomes
+        .iter()
+        .skip(start)
+        .take(visible)
+        .map(|row| {
+            let (icon, icon_style) = if row.outcome.succeeded {
+                ("✓", Style::default().fg(Color::Green))
+            } else {
+                ("✗", Style::default().fg(Color::Red))
+            };
+            let msg_style = if row.outcome.succeeded {
+                Style::default().fg(Color::Gray)
+            } else {
+                Style::default().fg(Color::Red)
+            };
+            let duration_ms = row.outcome.duration.as_millis();
+            let line = Line::from(vec![
+                Span::styled(icon, icon_style),
+                Span::raw(" "),
+                Span::styled(
+                    format!("{:<16}", row.name),
+                    Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD),
+                ),
+                Span::styled(row.outcome.message.as_str(), msg_style),
+                Span::styled(format!("  {duration_ms}ms"), Style::default().fg(Color::DarkGray)),
+            ]);
+            ListItem::new(line)
+        })
+        .collect();
+
+    frame.render_widget(List::new(items), inner);
+}

--- a/crates/infra/basectl/src/app/views/factory.rs
+++ b/crates/infra/basectl/src/app/views/factory.rs
@@ -1,6 +1,6 @@
 use super::{
-    CommandCenterView, ConductorView, ConfigView, DaMonitorView, FlashblocksView, HomeView,
-    LoadTestView, ProofsView, UpgradesView,
+    CanaryView, CommandCenterView, ConductorView, ConfigView, DaMonitorView, FlashblocksView,
+    HomeView, LoadTestView, ProofsView, UpgradesView,
 };
 use crate::app::{View, ViewId};
 
@@ -9,6 +9,7 @@ pub fn create_view(view_id: ViewId) -> Box<dyn View> {
     match view_id {
         ViewId::Home => Box::new(HomeView::new()),
         ViewId::CommandCenter => Box::new(CommandCenterView::new()),
+        ViewId::Canary => Box::new(CanaryView::new()),
         ViewId::Conductor => Box::new(ConductorView::new()),
         ViewId::DaMonitor => Box::new(DaMonitorView::new()),
         ViewId::Flashblocks => Box::new(FlashblocksView::new()),

--- a/crates/infra/basectl/src/app/views/home.rs
+++ b/crates/infra/basectl/src/app/views/home.rs
@@ -70,6 +70,12 @@ const MENU_ITEMS: &[MenuItem] = &[
         view_id: Some(ViewId::LoadTest),
     },
     MenuItem {
+        key: 'y',
+        label: "Canary",
+        description: "Run the canary health monitor (devnet only)",
+        view_id: Some(ViewId::Canary),
+    },
+    MenuItem {
         key: 'u',
         label: "Upgrades",
         description: "Network upgrade activation countdown and history",
@@ -85,6 +91,7 @@ const KEYBINDINGS: &[Keybinding] = &[
     Keybinding { key: "f", description: "Flashblocks" },
     Keybinding { key: "h", description: "HA Conductor" },
     Keybinding { key: "l", description: "Load Test" },
+    Keybinding { key: "y", description: "Canary" },
     Keybinding { key: "p", description: "Proofs" },
     Keybinding { key: "u", description: "Upgrades" },
     Keybinding { key: "j/k", description: "Navigate" },
@@ -118,6 +125,7 @@ impl View for HomeView {
             KeyCode::Char('f') => Action::SwitchView(ViewId::Flashblocks),
             KeyCode::Char('h') => Action::SwitchView(ViewId::Conductor),
             KeyCode::Char('l') => Action::SwitchView(ViewId::LoadTest),
+            KeyCode::Char('y') => Action::SwitchView(ViewId::Canary),
             KeyCode::Char('p') => Action::SwitchView(ViewId::Proofs),
             KeyCode::Char('u') => Action::SwitchView(ViewId::Upgrades),
             KeyCode::Up | KeyCode::Char('k') => {

--- a/crates/infra/basectl/src/app/views/mod.rs
+++ b/crates/infra/basectl/src/app/views/mod.rs
@@ -1,5 +1,8 @@
 //! TUI view components for basectl panels and dashboards.
 
+mod canary;
+pub use canary::CanaryView;
+
 mod command_center;
 pub use command_center::CommandCenterView;
 

--- a/crates/infra/basectl/src/lib.rs
+++ b/crates/infra/basectl/src/lib.rs
@@ -2,10 +2,11 @@
 
 mod app;
 pub use app::{
-    Action, App, CommandCenterView, ConductorState, ConductorView, ConfigView, DaMonitorView,
-    DaState, FlashState, FlashblocksView, HomeView, LoadTestTask, LoadTestView, ProofsState,
-    ProofsView, Resources, Router, TransactionPane, UpgradesView, ValidatorState, View, ViewId,
-    create_view, run_app, run_flashblocks_json, start_background_services,
+    Action, App, CanaryEvent, CanaryOutcome, CanaryState, CanaryView, CommandCenterView,
+    ConductorState, ConductorView, ConfigView, DaMonitorView, DaState, FlashState, FlashblocksView,
+    HomeView, LoadTestTask, LoadTestView, ProofsState, ProofsView, Resources, Router,
+    TransactionPane, UpgradesView, ValidatorState, View, ViewId, create_view, run_app,
+    run_flashblocks_json, start_background_services,
 };
 
 mod commands;

--- a/crates/infra/canary/Cargo.toml
+++ b/crates/infra/canary/Cargo.toml
@@ -1,0 +1,64 @@
+[package]
+name = "base-canary"
+description = "Base Canary — scheduled canary actions for network health monitoring"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+# alloy
+alloy-eips.workspace = true
+alloy-network.workspace = true
+alloy-provider.workspace = true
+alloy-rpc-types.workspace = true
+alloy-primitives.workspace = true
+alloy-signer-local.workspace = true
+
+# base
+base-metrics.workspace = true
+base-protocol.workspace = true
+base-cli-utils.workspace = true
+base-load-tests.workspace = true
+base-consensus-gossip.workspace = true
+base-health = { workspace = true, features = ["axum-server"] }
+base-consensus-rpc = { workspace = true, features = ["client"] }
+
+# networking
+libp2p = { workspace = true, features = ["gossipsub"] }
+jsonrpsee = { workspace = true, features = ["http-client"] }
+libp2p-identity = { workspace = true, features = ["ed25519"] }
+
+# async
+tokio.workspace = true
+tokio-util.workspace = true
+async-trait.workspace = true
+
+# tracing
+tracing.workspace = true
+
+# error handling
+eyre.workspace = true
+thiserror.workspace = true
+
+# cli
+url.workspace = true
+rand.workspace = true
+serde.workspace = true
+humantime.workspace = true
+clap = { workspace = true, features = ["derive", "env"] }
+
+# metrics
+metrics = { workspace = true, optional = true }
+
+[dev-dependencies]
+rstest.workspace = true
+tokio = { workspace = true, features = ["test-util"] }
+
+[features]
+metrics = [ "base-metrics/metrics", "dep:metrics" ]

--- a/crates/infra/canary/README.md
+++ b/crates/infra/canary/README.md
@@ -1,0 +1,21 @@
+# base-canary
+
+Core library for the Base canary service. Provides scheduled execution of
+pluggable canary actions — load tests, block-production health checks, and
+wallet balance monitoring — with Prometheus metrics and structured tracing.
+
+## Actions
+
+| Action | Description |
+|--------|-------------|
+| `LoadTestAction` | Wraps `base-load-tests` `LoadRunner` to submit transactions at a target gas rate and report latency / throughput metrics. |
+| `HealthCheckAction` | Fetches the latest L2 block and checks whether its age exceeds a configurable threshold. |
+| `BalanceCheckAction` | Monitors the canary wallet balance and warns when it drops below a minimum. |
+
+## Scheduling
+
+The `Scheduler` supports two modes:
+
+* **Deterministic** — sleeps for a fixed interval between cycles.
+* **Random** — sleeps for `interval + rand(0..jitter)`, producing a
+  semi-randomized cadence.

--- a/crates/infra/canary/README.md
+++ b/crates/infra/canary/README.md
@@ -12,6 +12,98 @@ wallet balance monitoring — with Prometheus metrics and structured tracing.
 | `HealthCheckAction` | Fetches the latest L2 block and checks whether its age exceeds a configurable threshold. |
 | `BalanceCheckAction` | Monitors the canary wallet balance and warns when it drops below a minimum. |
 
+## Adding a new action
+
+Each action is a struct that implements the `CanaryAction` trait. The trait has
+two methods: `name`, which returns a static string used as a metrics label and
+log field, and `execute`, which receives a `CancellationToken` and returns an
+`ActionOutcome`.
+
+Start by creating a file in `src/actions/`. A minimal action looks like this:
+
+```rust
+// src/actions/peer_count.rs
+
+use std::time::Instant;
+
+use async_trait::async_trait;
+use tokio_util::sync::CancellationToken;
+use url::Url;
+
+use crate::{ActionOutcome, CanaryAction};
+
+#[derive(Debug)]
+pub struct PeerCountAction {
+    cl_rpc_url: Url,
+}
+
+impl PeerCountAction {
+    pub const fn new(cl_rpc_url: Url) -> Self {
+        Self { cl_rpc_url }
+    }
+}
+
+#[async_trait]
+impl CanaryAction for PeerCountAction {
+    fn name(&self) -> &'static str {
+        "peer_count"
+    }
+
+    async fn execute(&self, cancel: CancellationToken) -> ActionOutcome {
+        let start = Instant::now();
+
+        if cancel.is_cancelled() {
+            return ActionOutcome::failed("cancelled", start);
+        }
+
+        // ... perform the check ...
+
+        ActionOutcome::success("peer count within expected range", start)
+    }
+}
+```
+
+`ActionOutcome::success` and `ActionOutcome::failed` both accept any
+`impl Into<String>` as the message and record elapsed time automatically from
+the `start` instant you pass in. If the operation can be cancelled mid-flight,
+check `cancel.is_cancelled()` at natural yield points or use `tokio::select!`
+to race against `cancel.cancelled()`.
+
+Once the file exists, export it from `src/actions/mod.rs`:
+
+```rust
+mod peer_count;
+pub use peer_count::PeerCountAction;
+```
+
+Then add it to the `pub use actions::{...}` list in `src/lib.rs` so consumers
+can import it directly from the crate root.
+
+If the action records its own metrics, add the metric definitions to
+`src/metrics.rs` using the `define_metrics!` macro and call them from within
+`execute`. The `action_runs_total` and `action_duration_seconds` histograms are
+recorded automatically by `CanaryService` for every action, so you only need
+additional entries for action-specific observations. If you add a new action
+name, add it to the `default` label list on those two metrics so Prometheus
+pre-populates the time series.
+
+To enable the action in the running service, add it inside `build_actions` in
+`src/service.rs`:
+
+```rust
+if config.enable_peer_count {
+    if let Some(cl_rpc_url) = &config.cl_rpc_url {
+        actions.push(Box::new(PeerCountAction::new(cl_rpc_url.clone())));
+    }
+}
+```
+
+If the action needs configuration, add the corresponding fields to
+`CanaryArgs` in `src/cli.rs` and to `CanaryConfig` in `src/config.rs`,
+following the same pattern as the existing `enable_*` and URL fields. The
+`from_cli` method on `CanaryConfig` is where validation lives; add any
+required checks there before constructing the config struct.
+
 ## Scheduling
 
 The `Scheduler` supports two modes:

--- a/crates/infra/canary/src/action.rs
+++ b/crates/infra/canary/src/action.rs
@@ -1,0 +1,43 @@
+//! Canary action trait and outcome types.
+
+use std::time::{Duration, Instant};
+
+use async_trait::async_trait;
+use tokio_util::sync::CancellationToken;
+
+/// Outcome of a canary action execution.
+#[derive(Debug, Clone)]
+pub struct ActionOutcome {
+    /// Whether the action succeeded.
+    pub succeeded: bool,
+    /// How long the action took.
+    pub duration: Duration,
+    /// Human-readable summary.
+    pub message: String,
+}
+
+impl ActionOutcome {
+    /// Constructs a failed [`ActionOutcome`] with elapsed time since `start`.
+    pub fn failed(message: impl Into<String>, start: Instant) -> Self {
+        Self { succeeded: false, duration: start.elapsed(), message: message.into() }
+    }
+
+    /// Constructs a successful [`ActionOutcome`] with elapsed time since `start`.
+    pub fn success(message: impl Into<String>, start: Instant) -> Self {
+        Self { succeeded: true, duration: start.elapsed(), message: message.into() }
+    }
+}
+
+/// Trait for pluggable canary actions.
+///
+/// Each action represents a discrete check or test that the canary performs on
+/// each scheduled cycle.
+#[async_trait]
+pub trait CanaryAction: Send + Sync + std::fmt::Debug {
+    /// Returns the action name (used for metrics labels and log fields).
+    fn name(&self) -> &'static str;
+
+    /// Executes the action, respecting the cancellation token for graceful
+    /// shutdown.
+    async fn execute(&self, cancel: CancellationToken) -> ActionOutcome;
+}

--- a/crates/infra/canary/src/actions/balance_check.rs
+++ b/crates/infra/canary/src/actions/balance_check.rs
@@ -1,0 +1,78 @@
+//! Balance check canary action.
+
+use std::time::{Duration, Instant};
+
+use alloy_primitives::{Address, U256, utils::format_ether};
+use alloy_provider::{Provider, ProviderBuilder};
+use async_trait::async_trait;
+use tokio::time::timeout;
+use tokio_util::sync::CancellationToken;
+use tracing::{debug, warn};
+use url::Url;
+
+use crate::{ActionOutcome, CanaryAction, Metrics};
+
+/// Timeout for individual RPC calls.
+const RPC_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Checks the canary wallet balance and warns when it drops below a threshold.
+#[derive(Debug, Clone)]
+pub struct BalanceCheckAction {
+    l2_rpc_url: Url,
+    address: Address,
+    min_balance_wei: U256,
+}
+
+impl BalanceCheckAction {
+    /// Creates a new [`BalanceCheckAction`].
+    pub const fn new(l2_rpc_url: Url, address: Address, min_balance_wei: U256) -> Self {
+        Self { l2_rpc_url, address, min_balance_wei }
+    }
+}
+
+#[async_trait]
+impl CanaryAction for BalanceCheckAction {
+    fn name(&self) -> &'static str {
+        "balance_check"
+    }
+
+    async fn execute(&self, cancel: CancellationToken) -> ActionOutcome {
+        let start = Instant::now();
+
+        let provider = ProviderBuilder::new().connect_http(self.l2_rpc_url.clone());
+
+        let balance = tokio::select! {
+            () = cancel.cancelled() => return ActionOutcome::failed("cancelled", start),
+            result = timeout(RPC_TIMEOUT, provider.get_balance(self.address)) => match result {
+                Ok(Ok(b)) => b,
+                Ok(Err(e)) => return ActionOutcome::failed(format!("failed to fetch balance: {e}"), start),
+                Err(_) => return ActionOutcome::failed(
+                    format!("balance fetch timed out after {}s", RPC_TIMEOUT.as_secs()),
+                    start,
+                ),
+            }
+        };
+
+        let balance_eth = format_ether(balance);
+        debug!(balance_wei = %balance, balance_eth = %balance_eth, "fetched canary wallet balance");
+
+        // NOTE: f64 loses precision above 2^53 wei (~9 ETH). A canary wallet
+        // is expected to hold well under that, so the approximation is acceptable.
+        Metrics::wallet_balance_wei().set(balance.to::<u128>() as f64);
+
+        if balance >= self.min_balance_wei {
+            ActionOutcome::success(format!("balance {balance_eth} ETH is above minimum"), start)
+        } else {
+            let min_eth = format_ether(self.min_balance_wei);
+            warn!(
+                balance_eth = %balance_eth,
+                min_eth = %min_eth,
+                "canary wallet balance below minimum"
+            );
+            ActionOutcome::failed(
+                format!("balance {balance_eth} ETH is below minimum {min_eth} ETH"),
+                start,
+            )
+        }
+    }
+}

--- a/crates/infra/canary/src/actions/gossip_spam.rs
+++ b/crates/infra/canary/src/actions/gossip_spam.rs
@@ -1,0 +1,210 @@
+//! Gossip network spam canary action.
+
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+use async_trait::async_trait;
+use base_consensus_gossip::{ConnectionGater, GossipDriver, GossipDriverBuilder};
+use base_consensus_rpc::{BaseP2PApiClient, RollupNodeApiClient};
+use jsonrpsee::http_client::HttpClientBuilder;
+use libp2p::Multiaddr;
+use libp2p_identity::Keypair;
+use tokio::time::timeout;
+use tokio_util::sync::CancellationToken;
+use tracing::{debug, info, warn};
+use url::Url;
+
+use crate::{ActionOutcome, CanaryAction};
+
+/// Timeout for the rollup config and peer info RPC calls.
+const RPC_TIMEOUT: Duration = Duration::from_secs(10);
+/// How long to wait for the first peer connection before giving up.
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(8);
+/// How long to poll the driver for a single event before moving on.
+const EVENT_POLL_MS: u64 = 50;
+
+/// Connects as an ephemeral gossip peer and floods the network with garbage
+/// messages.
+///
+/// Each message has valid wire framing (snappy-compressed) but an invalid
+/// signature, so peers accept the connection but immediately reject the
+/// payload. This exercises the network's spam-rejection path without
+/// interfering with real block propagation.
+#[derive(Debug)]
+pub struct GossipSpamAction {
+    cl_rpc_url: Url,
+    spam_count: u32,
+    spam_interval: Duration,
+}
+
+impl GossipSpamAction {
+    /// Creates a new [`GossipSpamAction`].
+    pub const fn new(cl_rpc_url: Url, spam_count: u32, spam_interval: Duration) -> Self {
+        Self { cl_rpc_url, spam_count, spam_interval }
+    }
+
+    async fn build_driver(
+        cl_rpc_url: &Url,
+    ) -> Result<(GossipDriver<ConnectionGater>, Multiaddr), String> {
+        let cl_client = HttpClientBuilder::default()
+            .build(cl_rpc_url.as_str())
+            .map_err(|e| format!("failed to build CL RPC client: {e}"))?;
+
+        let rollup_config = timeout(RPC_TIMEOUT, cl_client.rollup_config())
+            .await
+            .map_err(|_| "rollup_config RPC timed out".to_string())?
+            .map_err(|e| format!("rollup_config RPC failed: {e}"))?;
+
+        let peer_info = timeout(RPC_TIMEOUT, cl_client.opp2p_self())
+            .await
+            .map_err(|_| "opp2p_self RPC timed out".to_string())?
+            .map_err(|e| format!("opp2p_self RPC failed: {e}"))?;
+
+        // Find the first TCP address from peer_info and append the /p2p/{PeerId} component
+        // if it is not already present.
+        let peer_id_str = peer_info.peer_id.clone();
+        let target_addr = peer_info
+            .addresses
+            .iter()
+            .filter_map(|a| a.parse::<Multiaddr>().ok())
+            .find(|ma| ma.iter().any(|p| matches!(p, libp2p::multiaddr::Protocol::P2p(_))))
+            .or_else(|| {
+                // No /p2p component found; try to parse and append manually.
+                let pid: libp2p::PeerId = peer_id_str.parse().ok()?;
+                peer_info
+                    .addresses
+                    .iter()
+                    .filter_map(|a| a.parse::<Multiaddr>().ok())
+                    .map(|mut ma| {
+                        ma.push(libp2p::multiaddr::Protocol::P2p(pid));
+                        ma
+                    })
+                    .next()
+            })
+            .ok_or_else(|| "no usable peer address in opp2p_self response".to_string())?;
+
+        // Random ed25519 identity — distinct from the real block signer.
+        let keypair = Keypair::generate_ed25519();
+
+        // Listen on an OS-assigned TCP port.
+        let listen_addr: Multiaddr =
+            "/ip4/0.0.0.0/tcp/0".parse().map_err(|e| format!("invalid listen addr: {e}"))?;
+
+        let (mut driver, _signer_tx) = GossipDriverBuilder::new(
+            rollup_config,
+            alloy_primitives::Address::ZERO,
+            listen_addr,
+            keypair,
+        )
+        .build()
+        .map_err(|e| format!("failed to build gossip driver: {e}"))?;
+
+        driver.start().await.map_err(|e| format!("failed to start gossip driver: {e}"))?;
+
+        Ok((driver, target_addr))
+    }
+}
+
+#[async_trait]
+impl CanaryAction for GossipSpamAction {
+    fn name(&self) -> &'static str {
+        "gossip_spam"
+    }
+
+    async fn execute(&self, cancel: CancellationToken) -> ActionOutcome {
+        let start = Instant::now();
+
+        if cancel.is_cancelled() {
+            return ActionOutcome::failed("cancelled", start);
+        }
+
+        let (mut driver, target_addr) = match Self::build_driver(&self.cl_rpc_url).await {
+            Ok(v) => v,
+            Err(e) => return ActionOutcome::failed(e, start),
+        };
+
+        debug!(target = %target_addr, "dialing devnet gossip peer");
+        driver.dial_multiaddr(target_addr);
+
+        // Phase 1: drive events until the peer connects or we time out.
+        let connect_deadline = Instant::now() + CONNECT_TIMEOUT;
+        loop {
+            if cancel.is_cancelled() {
+                return ActionOutcome::failed("cancelled during peer connect", start);
+            }
+            if Instant::now() >= connect_deadline {
+                break;
+            }
+            let remaining = connect_deadline.saturating_duration_since(Instant::now());
+            let poll_dur = remaining.min(Duration::from_millis(EVENT_POLL_MS));
+            match timeout(poll_dur, driver.next()).await {
+                Ok(Some(ev)) => {
+                    driver.handle_event(ev);
+                    if driver.connected_peers() > 0 {
+                        info!(peers = driver.connected_peers(), "connected to gossip network");
+                        break;
+                    }
+                }
+                Ok(None) => break,
+                Err(_) => {} // poll timeout — try again
+            }
+        }
+
+        if driver.connected_peers() == 0 {
+            return ActionOutcome::failed("failed to connect to any gossip peer", start);
+        }
+
+        // Phase 2: publish spam messages as fast as possible, draining the swarm
+        // event loop periodically to flush outbound queues.
+        let now_secs = SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default().as_secs();
+        let topic_hash = driver.handler.topic(now_secs).hash();
+
+        // Raw garbage bytes: snappy-compressing a known pattern means peers decode
+        // the outer frame but fail on SSZ parsing — exercising the rejection path.
+        let spam_bytes: Vec<u8> = b"base-canary-gossip-spam".to_vec();
+
+        // Drain the swarm every this many publishes so outbound queues don't stall.
+        const DRAIN_EVERY: u32 = 50;
+
+        let mut published = 0u32;
+        for i in 0..self.spam_count {
+            if cancel.is_cancelled() {
+                break;
+            }
+
+            let _ = driver
+                .swarm
+                .behaviour_mut()
+                .gossipsub
+                .publish(topic_hash.clone(), spam_bytes.clone());
+            published += 1;
+
+            // Periodically drain swarm events to flush outbound queues.
+            if (i + 1) % DRAIN_EVERY == 0 || i + 1 == self.spam_count {
+                while let Ok(Some(ev)) =
+                    timeout(Duration::from_millis(EVENT_POLL_MS), driver.next()).await
+                {
+                    driver.handle_event(ev);
+                }
+            }
+
+            if !self.spam_interval.is_zero() && published < self.spam_count {
+                tokio::time::sleep(self.spam_interval).await;
+            }
+        }
+
+        if published == 0 {
+            return ActionOutcome::failed("failed to publish any spam messages", start);
+        }
+
+        let peers = driver.connected_peers();
+        info!(published, peers, "gossip spam action complete");
+        if published < self.spam_count {
+            warn!(published, target = self.spam_count, "fewer spam messages published than target");
+        }
+
+        ActionOutcome::success(
+            format!("published {published}/{} spam msgs to {peers} peer(s)", self.spam_count),
+            start,
+        )
+    }
+}

--- a/crates/infra/canary/src/actions/health_check.rs
+++ b/crates/infra/canary/src/actions/health_check.rs
@@ -1,0 +1,99 @@
+//! Health check canary action.
+
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+use alloy_eips::BlockNumberOrTag;
+use alloy_provider::{Provider, ProviderBuilder};
+use async_trait::async_trait;
+use tokio::time::timeout;
+use tokio_util::sync::CancellationToken;
+use tracing::debug;
+use url::Url;
+
+use crate::{ActionOutcome, CanaryAction, Metrics};
+
+/// Timeout for individual RPC calls.
+const RPC_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Fetches the latest L2 block and checks whether its age exceeds a threshold.
+#[derive(Debug, Clone)]
+pub struct HealthCheckAction {
+    l2_rpc_url: Url,
+    max_block_age: Duration,
+}
+
+impl HealthCheckAction {
+    /// Creates a new [`HealthCheckAction`].
+    pub const fn new(l2_rpc_url: Url, max_block_age: Duration) -> Self {
+        Self { l2_rpc_url, max_block_age }
+    }
+}
+
+#[async_trait]
+impl CanaryAction for HealthCheckAction {
+    fn name(&self) -> &'static str {
+        "health_check"
+    }
+
+    async fn execute(&self, cancel: CancellationToken) -> ActionOutcome {
+        let start = Instant::now();
+
+        let provider = ProviderBuilder::new().connect_http(self.l2_rpc_url.clone());
+
+        let block = tokio::select! {
+            () = cancel.cancelled() => return ActionOutcome::failed("cancelled", start),
+            result = timeout(RPC_TIMEOUT, provider.get_block_by_number(BlockNumberOrTag::Latest)) => {
+                match result {
+                    Ok(Ok(Some(b))) => b,
+                    Ok(Ok(None)) => return ActionOutcome::failed("latest block not found", start),
+                    Ok(Err(e)) => return ActionOutcome::failed(
+                        format!("failed to fetch latest block: {e}"),
+                        start,
+                    ),
+                    Err(_) => return ActionOutcome::failed(
+                        format!("block fetch timed out after {}s", RPC_TIMEOUT.as_secs()),
+                        start,
+                    ),
+                }
+            }
+        };
+
+        let now_secs = match SystemTime::now().duration_since(UNIX_EPOCH) {
+            Ok(d) => d.as_secs(),
+            Err(e) => return ActionOutcome::failed(format!("system clock error: {e}"), start),
+        };
+
+        let block_timestamp = block.header.timestamp;
+        let block_age_secs = now_secs.saturating_sub(block_timestamp);
+        let block_age = Duration::from_secs(block_age_secs);
+
+        debug!(
+            block_number = block.header.number,
+            block_timestamp = block_timestamp,
+            block_age_secs = block_age_secs,
+            "fetched latest block"
+        );
+
+        Metrics::health_check_block_age_ms().set(block_age.as_millis() as f64);
+
+        if block_age <= self.max_block_age {
+            ActionOutcome::success(
+                format!(
+                    "block {} is {block_age_secs}s old (threshold: {}s)",
+                    block.header.number,
+                    self.max_block_age.as_secs()
+                ),
+                start,
+            )
+        } else {
+            ActionOutcome::failed(
+                format!(
+                    "block {} is {block_age_secs}s old, exceeds threshold of {}s",
+                    block.header.number,
+                    self.max_block_age.as_secs()
+                ),
+                start,
+            )
+        }
+    }
+}

--- a/crates/infra/canary/src/actions/invalid_batch.rs
+++ b/crates/infra/canary/src/actions/invalid_batch.rs
@@ -1,0 +1,131 @@
+//! Invalid batch submission canary action.
+
+use std::time::{Duration, Instant};
+
+use alloy_network::{EthereumWallet, TransactionBuilder};
+use alloy_primitives::Bytes;
+use alloy_provider::{Provider, ProviderBuilder};
+use alloy_rpc_types::TransactionRequest;
+use alloy_signer_local::PrivateKeySigner;
+use async_trait::async_trait;
+use base_consensus_rpc::RollupNodeApiClient;
+use base_protocol::{DERIVATION_VERSION_0, Frame};
+use jsonrpsee::http_client::HttpClientBuilder;
+use tokio::time::timeout;
+use tokio_util::sync::CancellationToken;
+use tracing::{debug, info};
+use url::Url;
+
+use crate::{ActionOutcome, CanaryAction};
+
+/// Timeout for the rollup config RPC call.
+const CONFIG_TIMEOUT: Duration = Duration::from_secs(10);
+/// Timeout waiting for the L1 receipt.
+const RECEIPT_TIMEOUT: Duration = Duration::from_secs(60);
+
+/// Submits a batch transaction to the L1 batch inbox signed with the wrong key.
+///
+/// The L1 accepts the transaction (it is a valid signed tx), but the derivation
+/// pipeline rejects it because the signer does not match the registered batcher
+/// address in the rollup config.
+#[derive(Debug)]
+pub struct InvalidBatchAction {
+    l1_rpc_url: Url,
+    cl_rpc_url: Url,
+    signer: PrivateKeySigner,
+}
+
+impl InvalidBatchAction {
+    /// Creates a new [`InvalidBatchAction`].
+    pub const fn new(l1_rpc_url: Url, cl_rpc_url: Url, signer: PrivateKeySigner) -> Self {
+        Self { l1_rpc_url, cl_rpc_url, signer }
+    }
+}
+
+#[async_trait]
+impl CanaryAction for InvalidBatchAction {
+    fn name(&self) -> &'static str {
+        "invalid_batch"
+    }
+
+    async fn execute(&self, cancel: CancellationToken) -> ActionOutcome {
+        let start = Instant::now();
+
+        // Fetch rollup config to get the batch inbox address and L1 chain ID.
+        let cl_client = match HttpClientBuilder::default().build(self.cl_rpc_url.as_str()) {
+            Ok(c) => c,
+            Err(e) => {
+                return ActionOutcome::failed(format!("failed to build CL RPC client: {e}"), start);
+            }
+        };
+
+        let rollup_config = tokio::select! {
+            () = cancel.cancelled() => return ActionOutcome::failed("cancelled", start),
+            result = timeout(CONFIG_TIMEOUT, cl_client.rollup_config()) => match result {
+                Ok(Ok(cfg)) => cfg,
+                Ok(Err(e)) => return ActionOutcome::failed(
+                    format!("rollup_config RPC failed: {e}"),
+                    start,
+                ),
+                Err(_) => return ActionOutcome::failed("rollup_config RPC timed out", start),
+            }
+        };
+
+        let batch_inbox = rollup_config.batch_inbox_address;
+        let l1_chain_id = rollup_config.l1_chain_id;
+        debug!(inbox = %batch_inbox, l1_chain_id, "fetched rollup config for invalid batch action");
+
+        // Build a minimal frame: all-zero channel ID, frame 0, tiny payload, last frame.
+        let frame = Frame::new([0u8; 16], 0, b"base-canary-invalid".to_vec(), true);
+        let mut calldata = vec![DERIVATION_VERSION_0];
+        calldata.extend_from_slice(&frame.encode());
+
+        let wallet = EthereumWallet::from(self.signer.clone());
+        let provider = ProviderBuilder::new().wallet(wallet).connect_http(self.l1_rpc_url.clone());
+
+        let tx = TransactionRequest::default()
+            .with_to(batch_inbox)
+            .with_input(Bytes::from(calldata))
+            .with_chain_id(l1_chain_id);
+
+        let pending = tokio::select! {
+            () = cancel.cancelled() => return ActionOutcome::failed("cancelled", start),
+            result = provider.send_transaction(tx) => match result {
+                Ok(p) => p,
+                Err(e) => return ActionOutcome::failed(
+                    format!("failed to send L1 batch tx: {e}"),
+                    start,
+                ),
+            }
+        };
+
+        let tx_hash = *pending.tx_hash();
+        info!(tx_hash = %tx_hash, inbox = %batch_inbox, "invalid batch tx submitted to L1");
+
+        let receipt = tokio::select! {
+            () = cancel.cancelled() => {
+                return ActionOutcome::failed(
+                    format!("cancelled after submission (tx: {tx_hash})"),
+                    start,
+                );
+            }
+            result = timeout(RECEIPT_TIMEOUT, pending.get_receipt()) => match result {
+                Ok(Ok(r)) => r,
+                Ok(Err(e)) => return ActionOutcome::failed(
+                    format!("receipt fetch failed: {e}"),
+                    start,
+                ),
+                Err(_) => return ActionOutcome::failed(
+                    format!("receipt timed out after {}s (tx: {tx_hash})", RECEIPT_TIMEOUT.as_secs()),
+                    start,
+                ),
+            }
+        };
+
+        let block_number = receipt.block_number.unwrap_or(0);
+        ActionOutcome::success(
+            format!("invalid batch tx {tx_hash} mined in L1 block {block_number}"),
+            start,
+        )
+    }
+}

--- a/crates/infra/canary/src/actions/load_test.rs
+++ b/crates/infra/canary/src/actions/load_test.rs
@@ -1,0 +1,182 @@
+//! Load test canary action.
+
+use std::time::{Duration, Instant};
+
+use alloy_primitives::U256;
+use alloy_signer_local::PrivateKeySigner;
+use async_trait::async_trait;
+use base_load_tests::{
+    DEFAULT_MAX_GAS_PRICE, DisplaySnapshot, LoadConfig, LoadRunner, TxConfig, TxType,
+};
+use tokio_util::sync::CancellationToken;
+use tracing::{debug, info, warn};
+use url::Url;
+
+use crate::{ActionOutcome, CanaryAction, Metrics};
+
+/// Configuration for [`LoadTestAction`].
+#[derive(Debug, Clone)]
+pub struct LoadTestConfig {
+    /// L2 HTTP RPC endpoint.
+    pub l2_rpc_url: Url,
+    /// L2 WebSocket RPC endpoint (optional, for block latency tracking).
+    pub l2_ws_url: Option<Url>,
+    /// Chain ID.
+    pub chain_id: u64,
+    /// Private key used to fund and drain test accounts.
+    pub funding_key: PrivateKeySigner,
+    /// Amount to fund each test account, in wei.
+    pub funding_amount_wei: U256,
+    /// Target gas per second for transaction generation.
+    pub target_gps: u64,
+    /// How long to run the load test per cycle.
+    pub duration: Duration,
+    /// Number of sender accounts to create.
+    pub account_count: usize,
+    /// Seed for deterministic account derivation.
+    ///
+    /// Each canary instance should use a unique seed to avoid nonce collisions
+    /// when multiple instances run against the same network.
+    pub seed: u64,
+}
+
+/// Wraps [`LoadRunner`] from `base-load-tests` as a canary action.
+///
+/// Each execution creates a fresh `LoadRunner`, funds test accounts, runs
+/// the load test for the configured duration, drains accounts, and reports
+/// metrics.
+#[derive(Debug)]
+pub struct LoadTestAction {
+    funding_key: PrivateKeySigner,
+    funding_amount_wei: U256,
+    load_config: LoadConfig,
+}
+
+impl LoadTestAction {
+    /// Creates a new [`LoadTestAction`] from the given configuration.
+    pub fn new(config: LoadTestConfig) -> Self {
+        let load_config = LoadConfig {
+            rpc_http_url: config.l2_rpc_url,
+            chain_id: config.chain_id,
+            account_count: config.account_count,
+            seed: config.seed,
+            mnemonic: None,
+            sender_offset: 0,
+            transactions: vec![TxConfig { weight: 100, tx_type: TxType::Transfer }],
+            target_gps: config.target_gps,
+            duration: Some(config.duration),
+            max_in_flight_per_sender: 50,
+            batch_size: 5,
+            batch_timeout: Duration::from_millis(50),
+            max_gas_price: DEFAULT_MAX_GAS_PRICE,
+            rpc_ws_url: config.l2_ws_url,
+            flashblocks_ws_url: None,
+        };
+
+        Self {
+            funding_key: config.funding_key,
+            funding_amount_wei: config.funding_amount_wei,
+            load_config,
+        }
+    }
+}
+
+#[async_trait]
+impl CanaryAction for LoadTestAction {
+    fn name(&self) -> &'static str {
+        "load_test"
+    }
+
+    async fn execute(&self, cancel: CancellationToken) -> ActionOutcome {
+        let start = Instant::now();
+
+        // Reset metrics at the start of each cycle so stale values don't persist on failure.
+        Metrics::load_test_tps().set(0.0);
+        Metrics::load_test_p50_latency_ms().set(0.0);
+        Metrics::load_test_p99_latency_ms().set(0.0);
+        Metrics::load_test_success_rate().set(0.0);
+
+        // Create a fresh LoadRunner for each cycle.
+        let mut runner = match LoadRunner::new(self.load_config.clone()) {
+            Ok(r) => r,
+            Err(e) => {
+                return ActionOutcome::failed(format!("failed to create load runner: {e}"), start);
+            }
+        };
+
+        // Suppress indicatif progress bars so they don't bleed into the TUI.
+        // set_snapshot_tx causes progress_bar() to return ProgressBar::hidden().
+        let (snapshot_tx, _snapshot_rx) = tokio::sync::watch::channel(DisplaySnapshot::default());
+        runner.set_snapshot_tx(snapshot_tx);
+
+        // Set the stop flag so we can abort on cancellation.
+        let stop_flag = runner.stop_flag();
+        let cancel_guard = cancel.clone();
+        let stop_handle = tokio::spawn(async move {
+            cancel_guard.cancelled().await;
+            stop_flag.store(true, std::sync::atomic::Ordering::SeqCst);
+        });
+
+        // Fund test accounts, aborting early if cancelled.
+        info!(
+            accounts = self.load_config.account_count,
+            funding_wei = %self.funding_amount_wei,
+            "funding load test accounts"
+        );
+        let fund_result = tokio::select! {
+            () = cancel.cancelled() => {
+                stop_handle.abort();
+                return ActionOutcome::failed("cancelled during account funding", start);
+            }
+            result = runner.fund_accounts(self.funding_key.clone(), self.funding_amount_wei) => result
+        };
+        if let Err(e) = fund_result {
+            stop_handle.abort();
+            return ActionOutcome::failed(format!("failed to fund accounts: {e}"), start);
+        }
+
+        // Run the load test.
+        debug!(
+            target_gps = self.load_config.target_gps,
+            duration = ?self.load_config.duration,
+            "starting load test"
+        );
+        let summary = match runner.run().await {
+            Ok(s) => s,
+            Err(e) => {
+                stop_handle.abort();
+                // Best-effort drain even on failure.
+                if let Err(drain_err) = runner.drain_accounts(self.funding_key.clone()).await {
+                    warn!(error = %drain_err, "failed to drain accounts after load test failure");
+                }
+                return ActionOutcome::failed(format!("load test failed: {e}"), start);
+            }
+        };
+
+        stop_handle.abort();
+
+        // Best-effort drain.
+        if let Err(e) = runner.drain_accounts(self.funding_key.clone()).await {
+            warn!(error = %e, "failed to drain load test accounts");
+        }
+
+        // Record metrics.
+        let tps = summary.throughput.tps;
+        let p50_ms = summary.block_latency.p50.as_millis() as f64;
+        let p99_ms = summary.block_latency.p99.as_millis() as f64;
+        let success_rate = summary.throughput.success_rate();
+
+        Metrics::load_test_tps().set(tps);
+        Metrics::load_test_p50_latency_ms().set(p50_ms);
+        Metrics::load_test_p99_latency_ms().set(p99_ms);
+        Metrics::load_test_success_rate().set(success_rate);
+
+        let succeeded = summary.throughput.total_confirmed > 0;
+        let message = format!(
+            "tps={tps:.1} p50={p50_ms:.0}ms p99={p99_ms:.0}ms confirmed={}/{} rate={success_rate:.1}%",
+            summary.throughput.total_confirmed, summary.throughput.total_submitted,
+        );
+
+        ActionOutcome { succeeded, duration: start.elapsed(), message }
+    }
+}

--- a/crates/infra/canary/src/actions/mod.rs
+++ b/crates/infra/canary/src/actions/mod.rs
@@ -1,0 +1,16 @@
+//! Concrete canary action implementations.
+
+mod balance_check;
+pub use balance_check::BalanceCheckAction;
+
+mod gossip_spam;
+pub use gossip_spam::GossipSpamAction;
+
+mod health_check;
+pub use health_check::HealthCheckAction;
+
+mod invalid_batch;
+pub use invalid_batch::InvalidBatchAction;
+
+mod load_test;
+pub use load_test::{LoadTestAction, LoadTestConfig};

--- a/crates/infra/canary/src/cli.rs
+++ b/crates/infra/canary/src/cli.rs
@@ -1,0 +1,292 @@
+//! CLI argument definitions for the canary.
+//!
+//! All flags use the `BASE_CANARY_` environment-variable prefix
+//! (e.g. `BASE_CANARY_L2_RPC_URL`). The default metrics port is **7400**.
+
+use std::time::Duration;
+
+use alloy_primitives::U256;
+use alloy_signer_local::PrivateKeySigner;
+use base_cli_utils::CliStyles;
+use clap::{Parser, ValueEnum};
+use url::Url;
+
+base_cli_utils::define_cli_env!("BASE_CANARY");
+base_cli_utils::define_log_args!("BASE_CANARY");
+base_cli_utils::define_metrics_args!("BASE_CANARY", 7400);
+base_cli_utils::define_health_args!("BASE_CANARY", 8080);
+
+/// Parses an ETH amount string (e.g. `"0.1"`) into wei.
+fn parse_eth_amount(s: &str) -> Result<U256, String> {
+    alloy_primitives::utils::parse_ether(s).map_err(|e| e.to_string())
+}
+
+/// Schedule mode for canary action dispatch.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum ScheduleModeArg {
+    /// Fixed interval between runs.
+    Deterministic,
+    /// Random interval within `[interval, interval + jitter]`.
+    Random,
+}
+
+/// Canary — scheduled network health monitoring for Base.
+#[derive(Debug, Parser)]
+#[command(name = "canary")]
+#[command(version, about, long_about = None)]
+#[command(styles = CliStyles::init())]
+pub struct Cli {
+    /// Canary configuration arguments.
+    #[command(flatten)]
+    pub canary: CanaryArgs,
+
+    /// Logging configuration arguments.
+    #[command(flatten)]
+    pub logging: LogArgs,
+
+    /// Metrics configuration arguments.
+    #[command(flatten)]
+    pub metrics: MetricsArgs,
+
+    /// Health server configuration arguments.
+    #[command(flatten)]
+    pub health: HealthArgs,
+}
+
+/// Core canary configuration arguments.
+#[derive(Debug, Parser)]
+#[command(next_help_heading = "Canary")]
+pub struct CanaryArgs {
+    /// URL of the L2 HTTP RPC endpoint.
+    #[arg(long = "l2-rpc-url", env = cli_env!("L2_RPC_URL"))]
+    pub l2_rpc_url: Url,
+
+    /// URL of the L2 WebSocket RPC endpoint (optional; used for block subscriptions during load tests).
+    #[arg(long = "l2-ws-url", env = cli_env!("L2_WS_URL"))]
+    pub l2_ws_url: Option<Url>,
+
+    /// Private key for the canary wallet (hex-encoded, `0x`-prefixed).
+    #[arg(long = "private-key", env = cli_env!("PRIVATE_KEY"))]
+    pub private_key: PrivateKeySigner,
+
+    /// Schedule mode: deterministic (fixed interval) or random (interval + jitter).
+    #[arg(
+        long = "schedule-mode",
+        default_value = "deterministic",
+        env = cli_env!("SCHEDULE_MODE")
+    )]
+    pub schedule_mode: ScheduleModeArg,
+
+    /// Base interval between canary runs (e.g. `"60s"`, `"5m"`).
+    #[arg(
+        long = "schedule-interval",
+        default_value = "60s",
+        env = cli_env!("SCHEDULE_INTERVAL"),
+        value_parser = humantime::parse_duration
+    )]
+    pub schedule_interval: Duration,
+
+    /// Maximum random jitter added to the interval in random mode (e.g. `"30s"`).
+    #[arg(
+        long = "schedule-jitter",
+        default_value = "30s",
+        env = cli_env!("SCHEDULE_JITTER"),
+        value_parser = humantime::parse_duration
+    )]
+    pub schedule_jitter: Duration,
+
+    /// Chain ID. Auto-detected from the L2 RPC if omitted.
+    #[arg(long = "chain-id", env = cli_env!("CHAIN_ID"))]
+    pub chain_id: Option<u64>,
+
+    /// Target gas per second for load test transactions.
+    #[arg(long = "load-test-gps", default_value = "210000", env = cli_env!("LOAD_TEST_GPS"))]
+    pub load_test_gps: u64,
+
+    /// Duration of each load test run (e.g. `"30s"`, `"2m"`).
+    #[arg(
+        long = "load-test-duration",
+        default_value = "30s",
+        env = cli_env!("LOAD_TEST_DURATION"),
+        value_parser = humantime::parse_duration
+    )]
+    pub load_test_duration: Duration,
+
+    /// Number of sender accounts for the load test.
+    #[arg(
+        long = "load-test-accounts",
+        default_value = "5",
+        env = cli_env!("LOAD_TEST_ACCOUNTS")
+    )]
+    pub load_test_accounts: usize,
+
+    /// Seed for deterministic load test account generation.
+    ///
+    /// Each canary instance should use a unique seed to avoid nonce collisions
+    /// when multiple instances run against the same network.
+    #[arg(long = "load-test-seed", default_value = "1", env = cli_env!("LOAD_TEST_SEED"))]
+    pub load_test_seed: u64,
+
+    /// Funding amount per load test account (e.g. `"0.1"` ETH).
+    #[arg(
+        long = "funding-amount-eth",
+        default_value = "0.1",
+        env = cli_env!("FUNDING_AMOUNT_ETH"),
+        value_parser = parse_eth_amount
+    )]
+    pub funding_amount_wei: U256,
+
+    /// Enable the load test action.
+    #[arg(
+        long = "enable-load-test",
+        default_value = "true",
+        action = clap::ArgAction::Set,
+        env = cli_env!("ENABLE_LOAD_TEST")
+    )]
+    pub enable_load_test: bool,
+
+    /// Enable the health check action.
+    #[arg(
+        long = "enable-health-check",
+        default_value = "true",
+        action = clap::ArgAction::Set,
+        env = cli_env!("ENABLE_HEALTH_CHECK")
+    )]
+    pub enable_health_check: bool,
+
+    /// Enable the balance check action.
+    #[arg(
+        long = "enable-balance-check",
+        default_value = "true",
+        action = clap::ArgAction::Set,
+        env = cli_env!("ENABLE_BALANCE_CHECK")
+    )]
+    pub enable_balance_check: bool,
+
+    /// Minimum wallet balance before the balance check warns (e.g. `"0.01"` ETH).
+    #[arg(
+        long = "min-balance-eth",
+        default_value = "0.01",
+        env = cli_env!("MIN_BALANCE_ETH"),
+        value_parser = parse_eth_amount
+    )]
+    pub min_balance_wei: U256,
+
+    /// Maximum acceptable block age in seconds before the health check fails.
+    #[arg(
+        long = "max-block-age-secs",
+        default_value = "30",
+        env = cli_env!("MAX_BLOCK_AGE_SECS")
+    )]
+    pub max_block_age_secs: u64,
+
+    /// Enable the gossip spam action.
+    #[arg(
+        long = "enable-gossip-spam",
+        default_value = "false",
+        action = clap::ArgAction::Set,
+        env = cli_env!("ENABLE_GOSSIP_SPAM")
+    )]
+    pub enable_gossip_spam: bool,
+
+    /// Enable the invalid batch action.
+    #[arg(
+        long = "enable-invalid-batch",
+        default_value = "false",
+        action = clap::ArgAction::Set,
+        env = cli_env!("ENABLE_INVALID_BATCH")
+    )]
+    pub enable_invalid_batch: bool,
+
+    /// URL of the consensus-layer RPC endpoint (required for gossip-spam and invalid-batch).
+    #[arg(long = "cl-rpc-url", env = cli_env!("CL_RPC_URL"))]
+    pub cl_rpc_url: Option<Url>,
+
+    /// URL of the L1 HTTP RPC endpoint (required for invalid-batch).
+    #[arg(long = "l1-rpc-url", env = cli_env!("L1_RPC_URL"))]
+    pub l1_rpc_url: Option<Url>,
+
+    /// Number of spam messages to publish per gossip-spam cycle.
+    #[arg(
+        long = "gossip-spam-count",
+        default_value = "1000",
+        env = cli_env!("GOSSIP_SPAM_COUNT")
+    )]
+    pub gossip_spam_count: u32,
+
+    /// Interval between gossip spam messages in milliseconds (0 = flood as fast as possible).
+    #[arg(
+        long = "gossip-spam-interval-ms",
+        default_value = "0",
+        env = cli_env!("GOSSIP_SPAM_INTERVAL_MS")
+    )]
+    pub gossip_spam_interval_ms: u64,
+}
+
+#[cfg(test)]
+mod tests {
+    use rstest::rstest;
+
+    use super::*;
+
+    const TEST_KEY: &str = "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
+
+    fn base_args() -> Vec<&'static str> {
+        vec!["canary", "--l2-rpc-url", "http://localhost:8545", "--private-key", TEST_KEY]
+    }
+
+    #[test]
+    fn test_cli_defaults() {
+        let cli = Cli::try_parse_from(base_args()).unwrap();
+        assert_eq!(cli.canary.schedule_mode, ScheduleModeArg::Deterministic);
+        assert_eq!(cli.canary.schedule_interval, Duration::from_secs(60));
+        assert_eq!(cli.canary.schedule_jitter, Duration::from_secs(30));
+        assert_eq!(cli.canary.load_test_gps, 210_000);
+        assert_eq!(cli.canary.load_test_duration, Duration::from_secs(30));
+        assert_eq!(cli.canary.load_test_accounts, 5);
+        assert_eq!(cli.canary.load_test_seed, 1);
+        assert!(cli.canary.enable_load_test);
+        assert!(cli.canary.enable_health_check);
+        assert!(cli.canary.enable_balance_check);
+        assert!(cli.canary.chain_id.is_none());
+    }
+
+    #[test]
+    fn test_cli_eth_amounts_parsed_to_wei() {
+        let cli = Cli::try_parse_from(base_args()).unwrap();
+        assert_eq!(cli.canary.funding_amount_wei, U256::from(100_000_000_000_000_000u128));
+        assert_eq!(cli.canary.min_balance_wei, U256::from(10_000_000_000_000_000u128));
+    }
+
+    #[test]
+    fn test_cli_missing_required() {
+        assert!(Cli::try_parse_from(["canary"]).is_err());
+    }
+
+    #[rstest]
+    #[case::invalid_private_key(vec!["--private-key", "not-a-key"])]
+    #[case::invalid_eth_amount(vec!["--funding-amount-eth", "not-a-number"])]
+    fn test_cli_invalid_arg_rejected(#[case] overrides: Vec<&'static str>) {
+        let mut args = base_args();
+        args.extend_from_slice(&overrides);
+        assert!(Cli::try_parse_from(args).is_err());
+    }
+
+    #[test]
+    fn test_cli_random_mode() {
+        let mut args = base_args();
+        args.extend_from_slice(&["--schedule-mode", "random", "--schedule-jitter", "45s"]);
+        let cli = Cli::try_parse_from(args).unwrap();
+        assert_eq!(cli.canary.schedule_mode, ScheduleModeArg::Random);
+        assert_eq!(cli.canary.schedule_jitter, Duration::from_secs(45));
+    }
+
+    #[test]
+    fn test_cli_disable_action() {
+        let mut args = base_args();
+        args.extend_from_slice(&["--enable-load-test", "false"]);
+        let cli = Cli::try_parse_from(args).unwrap();
+        assert!(!cli.canary.enable_load_test);
+        assert!(cli.canary.enable_health_check);
+    }
+}

--- a/crates/infra/canary/src/config.rs
+++ b/crates/infra/canary/src/config.rs
@@ -1,0 +1,305 @@
+//! Configuration types and validation for the canary.
+
+use std::{net::SocketAddr, time::Duration};
+
+use alloy_primitives::U256;
+use alloy_signer_local::PrivateKeySigner;
+use base_cli_utils::{LogConfig, MetricsConfig};
+use thiserror::Error;
+use url::Url;
+
+use crate::{
+    ScheduleMode,
+    cli::{Cli, ScheduleModeArg},
+};
+
+/// Errors that can occur during configuration validation.
+#[derive(Debug, Error)]
+pub enum ConfigError {
+    /// Invalid URL format.
+    #[error("invalid {field} URL: missing host")]
+    InvalidUrl {
+        /// The field name containing the invalid URL.
+        field: &'static str,
+    },
+    /// A field value is out of the allowed range.
+    #[error("{field} must be {constraint}, got {value}")]
+    OutOfRange {
+        /// The field name that is out of range.
+        field: &'static str,
+        /// Description of the allowed range.
+        constraint: &'static str,
+        /// The actual value supplied.
+        value: String,
+    },
+}
+
+/// Validated canary configuration.
+#[derive(Debug)]
+pub struct CanaryConfig {
+    /// L2 HTTP RPC endpoint.
+    pub l2_rpc_url: Url,
+    /// L2 WebSocket RPC endpoint (optional).
+    pub l2_ws_url: Option<Url>,
+    /// Signer for the canary wallet.
+    pub private_key: PrivateKeySigner,
+    /// Schedule mode.
+    pub schedule_mode: ScheduleMode,
+    /// Base interval between canary runs.
+    pub schedule_interval: Duration,
+    /// Maximum random jitter added in random mode.
+    pub schedule_jitter: Duration,
+    /// Chain ID (`None` → auto-detect from RPC).
+    pub chain_id: Option<u64>,
+    /// Target gas per second for load tests.
+    pub load_test_gps: u64,
+    /// Duration of each load test run.
+    pub load_test_duration: Duration,
+    /// Number of sender accounts for load tests.
+    pub load_test_accounts: usize,
+    /// Seed for deterministic load test account derivation.
+    pub load_test_seed: u64,
+    /// Funding amount per account in wei.
+    pub funding_amount_wei: U256,
+    /// Whether the load test action is enabled.
+    pub enable_load_test: bool,
+    /// Whether the health check action is enabled.
+    pub enable_health_check: bool,
+    /// Whether the balance check action is enabled.
+    pub enable_balance_check: bool,
+    /// Minimum acceptable wallet balance in wei.
+    pub min_balance_wei: U256,
+    /// Maximum acceptable block age.
+    pub max_block_age: Duration,
+    /// Whether the gossip spam action is enabled.
+    pub enable_gossip_spam: bool,
+    /// Whether the invalid batch action is enabled.
+    pub enable_invalid_batch: bool,
+    /// Consensus-layer RPC URL (required for gossip-spam and invalid-batch).
+    pub cl_rpc_url: Option<Url>,
+    /// L1 RPC URL (required for invalid-batch).
+    pub l1_rpc_url: Option<Url>,
+    /// Number of spam messages per gossip-spam cycle.
+    pub gossip_spam_count: u32,
+    /// Interval between gossip spam messages.
+    pub gossip_spam_interval: Duration,
+    /// Logging configuration.
+    pub log: LogConfig,
+    /// Metrics server configuration.
+    pub metrics: MetricsConfig,
+    /// Health server socket address.
+    pub health_addr: SocketAddr,
+}
+
+impl CanaryConfig {
+    /// Creates a validated [`CanaryConfig`] from parsed CLI arguments.
+    pub fn from_cli(cli: Cli) -> Result<Self, ConfigError> {
+        let Cli { canary, logging, metrics, health } = cli;
+
+        validate_url(&canary.l2_rpc_url, "l2-rpc-url")?;
+        if let Some(ws) = &canary.l2_ws_url {
+            validate_url(ws, "l2-ws-url")?;
+        }
+
+        if canary.schedule_interval.is_zero() {
+            return Err(ConfigError::OutOfRange {
+                field: "schedule-interval",
+                constraint: "greater than 0",
+                value: "0".to_string(),
+            });
+        }
+
+        if canary.enable_load_test {
+            if canary.load_test_accounts == 0 {
+                return Err(ConfigError::OutOfRange {
+                    field: "load-test-accounts",
+                    constraint: "at least 1",
+                    value: "0".to_string(),
+                });
+            }
+            if canary.load_test_gps == 0 {
+                return Err(ConfigError::OutOfRange {
+                    field: "load-test-gps",
+                    constraint: "greater than 0",
+                    value: "0".to_string(),
+                });
+            }
+            if canary.load_test_duration.is_zero() {
+                return Err(ConfigError::OutOfRange {
+                    field: "load-test-duration",
+                    constraint: "greater than 0",
+                    value: "0".to_string(),
+                });
+            }
+            if canary.funding_amount_wei == U256::ZERO {
+                return Err(ConfigError::OutOfRange {
+                    field: "funding-amount-eth",
+                    constraint: "greater than 0",
+                    value: "0".to_string(),
+                });
+            }
+        }
+
+        if canary.enable_health_check && canary.max_block_age_secs == 0 {
+            return Err(ConfigError::OutOfRange {
+                field: "max-block-age-secs",
+                constraint: "greater than 0",
+                value: "0".to_string(),
+            });
+        }
+
+        if (canary.enable_gossip_spam || canary.enable_invalid_batch) && canary.cl_rpc_url.is_none()
+        {
+            return Err(ConfigError::InvalidUrl { field: "cl-rpc-url" });
+        }
+
+        if let Some(cl) = &canary.cl_rpc_url {
+            validate_url(cl, "cl-rpc-url")?;
+        }
+
+        if canary.enable_invalid_batch && canary.l1_rpc_url.is_none() {
+            return Err(ConfigError::InvalidUrl { field: "l1-rpc-url" });
+        }
+
+        if let Some(l1) = &canary.l1_rpc_url {
+            validate_url(l1, "l1-rpc-url")?;
+        }
+
+        if canary.enable_gossip_spam && canary.gossip_spam_count == 0 {
+            return Err(ConfigError::OutOfRange {
+                field: "gossip-spam-count",
+                constraint: "greater than 0",
+                value: "0".to_string(),
+            });
+        }
+
+        if metrics.enabled && metrics.port == 0 {
+            return Err(ConfigError::OutOfRange {
+                field: "metrics-port",
+                constraint: "non-zero when metrics are enabled",
+                value: "0".to_string(),
+            });
+        }
+
+        Ok(Self {
+            l2_rpc_url: canary.l2_rpc_url,
+            l2_ws_url: canary.l2_ws_url,
+            private_key: canary.private_key,
+            schedule_mode: ScheduleMode::from(canary.schedule_mode),
+            schedule_interval: canary.schedule_interval,
+            schedule_jitter: canary.schedule_jitter,
+            chain_id: canary.chain_id,
+            load_test_gps: canary.load_test_gps,
+            load_test_duration: canary.load_test_duration,
+            load_test_accounts: canary.load_test_accounts,
+            load_test_seed: canary.load_test_seed,
+            funding_amount_wei: canary.funding_amount_wei,
+            enable_load_test: canary.enable_load_test,
+            enable_health_check: canary.enable_health_check,
+            enable_balance_check: canary.enable_balance_check,
+            min_balance_wei: canary.min_balance_wei,
+            max_block_age: Duration::from_secs(canary.max_block_age_secs),
+            enable_gossip_spam: canary.enable_gossip_spam,
+            enable_invalid_batch: canary.enable_invalid_batch,
+            cl_rpc_url: canary.cl_rpc_url,
+            l1_rpc_url: canary.l1_rpc_url,
+            gossip_spam_count: canary.gossip_spam_count,
+            gossip_spam_interval: Duration::from_millis(canary.gossip_spam_interval_ms),
+            log: LogConfig::from(logging),
+            metrics: metrics.into(),
+            health_addr: health.socket_addr(),
+        })
+    }
+}
+
+impl From<ScheduleModeArg> for ScheduleMode {
+    fn from(arg: ScheduleModeArg) -> Self {
+        match arg {
+            ScheduleModeArg::Deterministic => Self::Deterministic,
+            ScheduleModeArg::Random => Self::Random,
+        }
+    }
+}
+
+/// Validates that a URL has a host component.
+fn validate_url(url: &Url, field: &'static str) -> Result<(), ConfigError> {
+    if url.host().is_none() {
+        return Err(ConfigError::InvalidUrl { field });
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use alloy_primitives::U256;
+    use alloy_signer_local::PrivateKeySigner;
+    use rstest::rstest;
+
+    use super::*;
+    use crate::cli::{CanaryArgs, HealthArgs, LogArgs, MetricsArgs, ScheduleModeArg};
+
+    fn minimal_cli() -> Cli {
+        Cli {
+            canary: CanaryArgs {
+                l2_rpc_url: Url::parse("http://localhost:8545").unwrap(),
+                l2_ws_url: None,
+                private_key: "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
+                    .parse::<PrivateKeySigner>()
+                    .unwrap(),
+                schedule_mode: ScheduleModeArg::Deterministic,
+                schedule_interval: Duration::from_secs(60),
+                schedule_jitter: Duration::from_secs(30),
+                chain_id: None,
+                load_test_gps: 210_000,
+                load_test_duration: Duration::from_secs(30),
+                load_test_accounts: 5,
+                load_test_seed: 1,
+                funding_amount_wei: U256::from(100_000_000_000_000_000u128),
+                enable_load_test: true,
+                enable_health_check: true,
+                enable_balance_check: true,
+                min_balance_wei: U256::from(10_000_000_000_000_000u128),
+                max_block_age_secs: 30,
+                enable_gossip_spam: false,
+                enable_invalid_batch: false,
+                cl_rpc_url: None,
+                l1_rpc_url: None,
+                gossip_spam_count: 1000,
+                gossip_spam_interval_ms: 0,
+            },
+            logging: LogArgs { level: 3, stdout_quiet: false, ..Default::default() },
+            metrics: MetricsArgs { enabled: false, ..Default::default() },
+            health: HealthArgs::default(),
+        }
+    }
+
+    #[test]
+    fn test_valid_config() {
+        let config = CanaryConfig::from_cli(minimal_cli()).unwrap();
+        assert_eq!(config.schedule_mode, ScheduleMode::Deterministic);
+        assert_eq!(config.schedule_interval, Duration::from_secs(60));
+        assert_eq!(config.load_test_accounts, 5);
+        assert_eq!(config.load_test_seed, 1);
+        assert!(config.enable_load_test);
+        assert_eq!(config.funding_amount_wei, U256::from(100_000_000_000_000_000u128));
+        assert_eq!(config.min_balance_wei, U256::from(10_000_000_000_000_000u128));
+    }
+
+    #[rstest]
+    #[case::schedule_interval(|c: &mut CanaryArgs| c.schedule_interval = Duration::ZERO, "schedule-interval")]
+    #[case::load_test_accounts(|c: &mut CanaryArgs| c.load_test_accounts = 0, "load-test-accounts")]
+    #[case::load_test_gps(|c: &mut CanaryArgs| c.load_test_gps = 0, "load-test-gps")]
+    #[case::funding_amount(|c: &mut CanaryArgs| c.funding_amount_wei = U256::ZERO, "funding-amount-eth")]
+    #[case::max_block_age(|c: &mut CanaryArgs| c.max_block_age_secs = 0, "max-block-age-secs")]
+    fn test_out_of_range_rejected(
+        #[case] mutate: fn(&mut CanaryArgs),
+        #[case] field: &'static str,
+    ) {
+        let mut cli = minimal_cli();
+        mutate(&mut cli.canary);
+        let result = CanaryConfig::from_cli(cli);
+        assert!(matches!(result, Err(ConfigError::OutOfRange { field: f, .. }) if f == field));
+    }
+}

--- a/crates/infra/canary/src/lib.rs
+++ b/crates/infra/canary/src/lib.rs
@@ -1,0 +1,28 @@
+#![doc = include_str!("../README.md")]
+#![doc(issue_tracker_base_url = "https://github.com/base/base/issues/")]
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
+
+mod cli;
+pub use cli::{CanaryArgs, Cli, HealthArgs, LogArgs, MetricsArgs, ScheduleModeArg};
+
+mod config;
+pub use config::{CanaryConfig, ConfigError};
+
+mod scheduler;
+pub use scheduler::{ScheduleMode, Scheduler};
+
+mod action;
+pub use action::{ActionOutcome, CanaryAction};
+
+mod actions;
+pub use actions::{
+    BalanceCheckAction, GossipSpamAction, HealthCheckAction, InvalidBatchAction, LoadTestAction,
+    LoadTestConfig,
+};
+
+mod metrics;
+pub use metrics::Metrics;
+
+mod service;
+pub use service::CanaryService;

--- a/crates/infra/canary/src/metrics.rs
+++ b/crates/infra/canary/src/metrics.rs
@@ -1,0 +1,55 @@
+//! Canary Prometheus metrics.
+
+base_metrics::define_metrics! {
+    base_canary,
+    struct = Metrics,
+
+    #[describe("Canary service is running")]
+    up: gauge,
+
+    #[describe("Total canary action executions")]
+    #[label(
+        name = "action",
+        default = ["load_test", "health_check", "balance_check", "gossip_spam", "invalid_batch"]
+    )]
+    #[label(name = "outcome", default = ["success", "failure"])]
+    action_runs_total: counter,
+
+    #[describe("Action execution duration in seconds")]
+    #[label(
+        name = "action",
+        default = ["load_test", "health_check", "balance_check", "gossip_spam", "invalid_batch"]
+    )]
+    action_duration_seconds: histogram,
+
+    #[describe("Canary wallet balance in wei")]
+    wallet_balance_wei: gauge,
+
+    #[describe("Last observed load test transactions per second")]
+    load_test_tps: gauge,
+
+    #[describe("Last observed load test p50 block latency in milliseconds")]
+    load_test_p50_latency_ms: gauge,
+
+    #[describe("Last observed load test p99 block latency in milliseconds")]
+    load_test_p99_latency_ms: gauge,
+
+    #[describe("Last observed load test success rate percentage")]
+    load_test_success_rate: gauge,
+
+    #[describe("Last observed block age in milliseconds")]
+    health_check_block_age_ms: gauge,
+
+    #[describe("Seconds until next scheduled canary run")]
+    schedule_next_run_seconds: gauge,
+
+    #[describe("Total gossip spam messages published")]
+    gossip_spam_msgs_total: counter,
+
+    #[describe("Number of gossip peers connected during last spam cycle")]
+    gossip_spam_connected_peers: gauge,
+
+    #[describe("Total invalid batch transactions submitted to L1")]
+    #[label(name = "outcome", default = ["success", "failure"])]
+    invalid_batch_l1_txs_total: counter,
+}

--- a/crates/infra/canary/src/scheduler.rs
+++ b/crates/infra/canary/src/scheduler.rs
@@ -1,0 +1,86 @@
+//! Scheduling logic for canary action dispatch.
+
+use std::time::Duration;
+
+use rand::Rng;
+
+/// Schedule mode for canary runs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ScheduleMode {
+    /// Fixed interval between runs.
+    Deterministic,
+    /// Random interval within `[interval, interval + jitter]`.
+    Random,
+}
+
+/// Computes the next sleep duration between canary runs.
+#[derive(Debug, Clone)]
+pub struct Scheduler {
+    mode: ScheduleMode,
+    interval: Duration,
+    jitter: Duration,
+}
+
+impl Scheduler {
+    /// Creates a new [`Scheduler`].
+    pub const fn new(mode: ScheduleMode, interval: Duration, jitter: Duration) -> Self {
+        Self { mode, interval, jitter }
+    }
+
+    /// Returns the next delay before the next canary cycle.
+    pub fn next_delay(&self) -> Duration {
+        match self.mode {
+            ScheduleMode::Deterministic => self.interval,
+            ScheduleMode::Random => {
+                let jitter_millis = if self.jitter.is_zero() {
+                    0
+                } else {
+                    rand::rng().random_range(0..=self.jitter.as_millis() as u64)
+                };
+                self.interval + Duration::from_millis(jitter_millis)
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_deterministic_returns_exact_interval() {
+        let scheduler =
+            Scheduler::new(ScheduleMode::Deterministic, Duration::from_secs(60), Duration::ZERO);
+
+        for _ in 0..10 {
+            assert_eq!(scheduler.next_delay(), Duration::from_secs(60));
+        }
+    }
+
+    #[test]
+    fn test_random_within_bounds() {
+        let interval = Duration::from_secs(60);
+        let jitter = Duration::from_secs(30);
+        let scheduler = Scheduler::new(ScheduleMode::Random, interval, jitter);
+
+        for _ in 0..100 {
+            let delay = scheduler.next_delay();
+            assert!(delay >= interval, "delay {delay:?} should be >= interval {interval:?}");
+            assert!(
+                delay <= interval + jitter,
+                "delay {delay:?} should be <= interval + jitter {:?}",
+                interval + jitter
+            );
+        }
+    }
+
+    #[test]
+    fn test_random_zero_jitter() {
+        let scheduler =
+            Scheduler::new(ScheduleMode::Random, Duration::from_secs(10), Duration::ZERO);
+
+        for _ in 0..10 {
+            assert_eq!(scheduler.next_delay(), Duration::from_secs(10));
+        }
+    }
+}

--- a/crates/infra/canary/src/service.rs
+++ b/crates/infra/canary/src/service.rs
@@ -1,0 +1,204 @@
+//! Canary service lifecycle.
+
+use std::{
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
+    time::Duration,
+};
+
+use alloy_provider::{Provider, ProviderBuilder};
+use base_cli_utils::RuntimeManager;
+use base_health::HealthServer;
+use eyre::Result;
+use tokio::time::timeout;
+use tokio_util::sync::CancellationToken;
+use tracing::{error, info, warn};
+
+use crate::{
+    BalanceCheckAction, CanaryAction, CanaryConfig, GossipSpamAction, HealthCheckAction,
+    InvalidBatchAction, LoadTestAction, LoadTestConfig, Metrics, Scheduler,
+};
+
+/// Timeout for the chain ID RPC call during startup.
+const CHAIN_ID_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Top-level canary service.
+#[derive(Debug)]
+pub struct CanaryService;
+
+impl CanaryService {
+    /// Runs the full canary service lifecycle.
+    pub async fn run(config: CanaryConfig) -> Result<()> {
+        info!(version = env!("CARGO_PKG_VERSION"), "Canary starting");
+
+        let cancel = CancellationToken::new();
+        let _signal_handle = RuntimeManager::install_signal_handler(cancel.clone());
+
+        // Auto-detect chain ID if not provided.
+        let chain_id = match config.chain_id {
+            Some(id) => id,
+            None => {
+                let provider = ProviderBuilder::new().connect_http(config.l2_rpc_url.clone());
+                let id =
+                    timeout(CHAIN_ID_TIMEOUT, provider.get_chain_id()).await.map_err(|_| {
+                        eyre::eyre!(
+                            "chain ID auto-detection timed out after {}s",
+                            CHAIN_ID_TIMEOUT.as_secs()
+                        )
+                    })??;
+                info!(chain_id = id, "auto-detected chain ID");
+                id
+            }
+        };
+
+        // Build enabled actions.
+        let actions = Self::build_actions(&config, chain_id);
+        if actions.is_empty() {
+            return Err(eyre::eyre!("no canary actions enabled"));
+        }
+
+        // Start health server.
+        let ready = Arc::new(AtomicBool::new(false));
+        let health_cancel = cancel.clone();
+        let health_ready = Arc::clone(&ready);
+        let health_addr = config.health_addr;
+        let health_handle = tokio::spawn(async move {
+            if let Err(e) = HealthServer::serve(health_addr, health_ready, health_cancel).await {
+                error!(error = %e, "health server failed");
+            }
+        });
+
+        let scheduler =
+            Scheduler::new(config.schedule_mode, config.schedule_interval, config.schedule_jitter);
+
+        ready.store(true, Ordering::SeqCst);
+        Metrics::up().set(1.0);
+
+        info!(
+            schedule_mode = ?config.schedule_mode,
+            schedule_interval = ?config.schedule_interval,
+            schedule_jitter = ?config.schedule_jitter,
+            enabled_actions = actions.len(),
+            health_addr = %config.health_addr,
+            chain_id = chain_id,
+            "canary service ready"
+        );
+
+        // Main loop.
+        loop {
+            for action in &actions {
+                if cancel.is_cancelled() {
+                    break;
+                }
+
+                let action_cancel = cancel.child_token();
+                info!(action = action.name(), "executing canary action");
+
+                let outcome = action.execute(action_cancel).await;
+
+                let outcome_label = if outcome.succeeded { "success" } else { "failure" };
+                Metrics::action_runs_total(action.name(), outcome_label).increment(1);
+                Metrics::action_duration_seconds(action.name())
+                    .record(outcome.duration.as_secs_f64());
+
+                if outcome.succeeded {
+                    info!(
+                        action = action.name(),
+                        duration_ms = outcome.duration.as_millis() as u64,
+                        message = %outcome.message,
+                        "canary action succeeded"
+                    );
+                } else {
+                    error!(
+                        action = action.name(),
+                        duration_ms = outcome.duration.as_millis() as u64,
+                        message = %outcome.message,
+                        "canary action failed"
+                    );
+                }
+            }
+
+            // Compute and sleep until next cycle.
+            let delay = scheduler.next_delay();
+            Metrics::schedule_next_run_seconds().set(delay.as_secs_f64());
+            info!(next_run_secs = delay.as_secs(), "waiting for next scheduled run");
+
+            tokio::select! {
+                () = cancel.cancelled() => break,
+                () = tokio::time::sleep(delay) => {}
+            }
+        }
+
+        // Shutdown.
+        Metrics::up().set(0.0);
+        ready.store(false, Ordering::SeqCst);
+        info!("canary stopped");
+
+        health_handle.abort();
+        match health_handle.await {
+            Ok(()) => {}
+            Err(e) if e.is_cancelled() => {}
+            Err(e) => warn!(error = %e, "health server task error during shutdown"),
+        }
+
+        Ok(())
+    }
+
+    fn build_actions(config: &CanaryConfig, chain_id: u64) -> Vec<Box<dyn CanaryAction>> {
+        let mut actions: Vec<Box<dyn CanaryAction>> = Vec::new();
+
+        if config.enable_balance_check {
+            let address = config.private_key.address();
+            actions.push(Box::new(BalanceCheckAction::new(
+                config.l2_rpc_url.clone(),
+                address,
+                config.min_balance_wei,
+            )));
+        }
+
+        if config.enable_health_check {
+            actions.push(Box::new(HealthCheckAction::new(
+                config.l2_rpc_url.clone(),
+                config.max_block_age,
+            )));
+        }
+
+        if config.enable_load_test {
+            actions.push(Box::new(LoadTestAction::new(LoadTestConfig {
+                l2_rpc_url: config.l2_rpc_url.clone(),
+                l2_ws_url: config.l2_ws_url.clone(),
+                chain_id,
+                funding_key: config.private_key.clone(),
+                funding_amount_wei: config.funding_amount_wei,
+                target_gps: config.load_test_gps,
+                duration: config.load_test_duration,
+                account_count: config.load_test_accounts,
+                seed: config.load_test_seed,
+            })));
+        }
+
+        if config.enable_gossip_spam
+            && let Some(cl_rpc_url) = &config.cl_rpc_url
+        {
+            actions.push(Box::new(GossipSpamAction::new(
+                cl_rpc_url.clone(),
+                config.gossip_spam_count,
+                config.gossip_spam_interval,
+            )));
+        }
+
+        if config.enable_invalid_batch
+            && let (Some(l1), Some(cl)) = (&config.l1_rpc_url, &config.cl_rpc_url)
+        {
+            actions.push(Box::new(InvalidBatchAction::new(
+                l1.clone(),
+                cl.clone(),
+                config.private_key.clone(),
+            )));
+        }
+
+        actions
+    }
+}


### PR DESCRIPTION
## Summary

Introduces `base-canary`, a scheduled canary service for Base network health monitoring. The service runs three configurable actions on a deterministic or jittered schedule: a load test wrapping the existing `base-load-tests` `LoadRunner`, a health check that validates latest block age, and a balance check that monitors the canary wallet. All meaningful logic lives in the `base-canary` library crate; the binary is minimal glue. Configuration is fully driven by CLI flags and `BASE_CANARY_` env vars, with ETH amounts parsed via `parse_ether()` for precision, per-instance load test seeds to prevent nonce collisions, and 30s RPC timeouts throughout. Prometheus metrics cover TPS, latency percentiles, success rates, block age, and schedule timing.