### PR TITLE
[backport] refactor(metering): split trie node counts into leaf and branch (#2108)

### DIFF
--- a/bin/builder/src/cli.rs
+++ b/bin/builder/src/cli.rs
@@ -292,8 +292,10 @@ mod tests {
                 total_gas_used: 21000,
                 total_execution_time_us: 500,
                 state_root_time_us: 100,
-                state_root_account_node_count: 0,
-                state_root_storage_node_count: 0,
+                state_root_account_leaf_count: 0,
+                state_root_account_branch_count: 0,
+                state_root_storage_leaf_count: 0,
+                state_root_storage_branch_count: 0,
             },
         );
 

--- a/crates/builder/metering/src/store.rs
+++ b/crates/builder/metering/src/store.rs
@@ -114,8 +114,10 @@ mod tests {
             total_gas_used: gas_used,
             total_execution_time_us: 533,
             state_root_time_us: 0,
-            state_root_account_node_count: 0,
-            state_root_storage_node_count: 0,
+            state_root_account_leaf_count: 0,
+            state_root_account_branch_count: 0,
+            state_root_storage_leaf_count: 0,
+            state_root_storage_branch_count: 0,
         }
     }
 

--- a/crates/client/metering/src/meter.rs
+++ b/crates/client/metering/src/meter.rs
@@ -109,77 +109,66 @@ pub struct MeterBundleOutput {
     pub total_time_us: u128,
     /// State root calculation time in microseconds
     pub state_root_time_us: u128,
-    /// Best-effort count of account trie nodes attributed to bundle state changes during state
-    /// root calculation.
-    ///
-    /// `reth` does not expose "all account trie nodes hashed for just this bundle" directly, so
-    /// we derive this by combining bundle-owned account leaves from `HashedPostState` with account
-    /// branch/removal updates from `TrieUpdates`.
-    pub state_root_account_node_count: u64,
-    /// Best-effort count of storage trie nodes attributed to bundle state changes during state
-    /// root calculation.
-    ///
-    /// Like the account count, this is derived from two `reth` views of the work: bundle-owned
-    /// storage leaves from `HashedPostState` plus storage branch/removal updates from
-    /// `TrieUpdates`, with non-bundle artifacts filtered out below.
-    pub state_root_storage_node_count: u64,
+    /// Count of account leaves in the bundle's `HashedPostState`: one per modified account that
+    /// survives in the post-state trie. Proportional to gas (each account touch costs gas) and
+    /// does not reflect trie depth.
+    pub state_root_account_leaf_count: u64,
+    /// Count of account branch/removal nodes emitted by `TrieUpdates` during state root
+    /// calculation. These are intermediate trie nodes that were rebuilt or removed, and their
+    /// count scales with trie depth — the structural cost that gas does not price.
+    pub state_root_account_branch_count: u64,
+    /// Count of storage slot leaves in the bundle's `HashedPostState`: one per modified non-zero
+    /// storage slot. Like account leaves, proportional to gas and does not reflect trie depth.
+    pub state_root_storage_leaf_count: u64,
+    /// Count of storage branch/removal nodes emitted by `TrieUpdates` during state root
+    /// calculation, restricted to tries the bundle actually modified. Like account branches,
+    /// these scale with trie depth.
+    pub state_root_storage_branch_count: u64,
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 struct StateRootTrieNodeCounts {
-    account_trie_nodes: u64,
-    storage_trie_nodes: u64,
+    account_leaves: u64,
+    account_branches: u64,
+    storage_leaves: u64,
+    storage_branches: u64,
 }
 
-/// Counts trie nodes represented on the hashed post-state leaf side.
+/// Counts surviving leaves in the bundle's `HashedPostState`.
 ///
-/// `reth` splits "work done for a state root" into two different surfaces:
-/// - `HashedPostState`: surviving leaves in the bundle delta.
-/// - `TrieUpdates`: branch/removal updates emitted while rebuilding affected trie paths.
-///
-/// This helper handles the leaf side of that split. The account count includes changed account
-/// leaves that remain in the post-state trie.
-///
-/// The storage count includes changed storage slot leaves that remain in the post-state trie.
-/// Deleted accounts, zero-valued storage removals, and pure storage wipes are not counted here,
-/// because reth represents them as overlay deletions rather than emitted leaves.
-///
+/// These are the values that changed, not intermediate trie structure. Account leaves are one per
+/// modified surviving account; storage leaves are one per modified non-zero storage slot. Deleted
+/// accounts and zero-valued storage removals are represented through trie updates, not here.
 fn count_state_root_leaf_nodes(hashed_state: &HashedPostState) -> StateRootTrieNodeCounts {
-    let account_trie_nodes =
+    let account_leaves =
         hashed_state.accounts.values().filter(|account| account.is_some()).count() as u64;
-    let storage_trie_nodes = hashed_state
+    let storage_leaves = hashed_state
         .storages
         .values()
         .map(|storage| storage.storage.values().filter(|value| !value.is_zero()).count())
         .sum::<usize>() as u64;
 
-    StateRootTrieNodeCounts { account_trie_nodes, storage_trie_nodes }
+    StateRootTrieNodeCounts { account_leaves, storage_leaves, ..Default::default() }
 }
 
-/// Adds trie-structure counts emitted by state root calculation.
+/// Adds branch/removal counts from `TrieUpdates` emitted during state root calculation.
 ///
-/// These counts cover account/storage branch updates and removals plus storage trie deletion
-/// markers. Empty-path roots are excluded because reth filters those out of `TrieUpdates`, and a
-/// root can be either a branch or a leaf depending on trie shape.
-///
-/// The `changed_storage_tries` filter is intentional. `reth` records `StorageTrieUpdates` for any
-/// account whose storage root was considered, including `deleted()` markers for empty-storage
-/// accounts and cached pending-state tries we prepended via `prepend_cached`. Those entries are
-/// useful for trie persistence, but they are not a defensible attribution of bundle-local storage
-/// hashing work. Restricting storage-side structural attribution to tries present in the bundle's
-/// own `HashedPostState` keeps these counts aligned with bundle-owned storage changes.
+/// These are intermediate trie nodes that were rebuilt or removed — the structural work whose cost
+/// scales with trie depth. The `changed_storage_tries` filter restricts storage-side attribution
+/// to tries the bundle actually modified, excluding cached pending-state tries and empty-storage
+/// deletion markers.
 fn add_state_root_trie_update_counts(
     counts: &mut StateRootTrieNodeCounts,
     changed_storage_tries: &HashSet<B256>,
     trie_updates: &reth_trie_common::updates::TrieUpdates,
 ) {
-    counts.account_trie_nodes = counts.account_trie_nodes.saturating_add(
+    counts.account_branches = counts.account_branches.saturating_add(
         trie_updates
             .account_nodes_ref()
             .len()
             .saturating_add(trie_updates.removed_nodes_ref().len()) as u64,
     );
-    counts.storage_trie_nodes = counts.storage_trie_nodes.saturating_add(
+    counts.storage_branches = counts.storage_branches.saturating_add(
         trie_updates
             .storage_tries_ref()
             .iter()
@@ -441,8 +430,10 @@ where
         bundle_hash,
         total_time_us,
         state_root_time_us,
-        state_root_account_node_count: trie_node_counts.account_trie_nodes,
-        state_root_storage_node_count: trie_node_counts.storage_trie_nodes,
+        state_root_account_leaf_count: trie_node_counts.account_leaves,
+        state_root_account_branch_count: trie_node_counts.account_branches,
+        state_root_storage_leaf_count: trie_node_counts.storage_leaves,
+        state_root_storage_branch_count: trie_node_counts.storage_branches,
     })
 }
 
@@ -509,8 +500,10 @@ mod tests {
         // Even empty bundles have some EVM setup overhead
         assert!(output.total_time_us > 0);
         assert!(output.state_root_time_us > 0);
-        assert_eq!(output.state_root_account_node_count, 0);
-        assert_eq!(output.state_root_storage_node_count, 0);
+        assert_eq!(output.state_root_account_leaf_count, 0);
+        assert_eq!(output.state_root_account_branch_count, 0);
+        assert_eq!(output.state_root_storage_leaf_count, 0);
+        assert_eq!(output.state_root_storage_branch_count, 0);
         assert_eq!(output.bundle_hash, keccak256([]));
 
         Ok(())
@@ -560,8 +553,11 @@ mod tests {
         let result = &output.results[0];
         assert!(output.total_time_us > 0);
         assert!(output.state_root_time_us > 0);
-        assert!(output.state_root_account_node_count > 0);
-        assert_eq!(output.state_root_storage_node_count, 0);
+        assert!(
+            output.state_root_account_leaf_count > 0 || output.state_root_account_branch_count > 0
+        );
+        assert_eq!(output.state_root_storage_leaf_count, 0);
+        assert_eq!(output.state_root_storage_branch_count, 0);
 
         assert_eq!(result.from_address, Account::Alice.address());
         assert_eq!(result.to_address, Some(to));
@@ -626,9 +622,11 @@ mod tests {
         )?;
 
         assert_eq!(output.results.len(), 1);
-        assert!(output.state_root_account_node_count > 0);
         assert!(
-            output.state_root_storage_node_count > 0,
+            output.state_root_account_leaf_count > 0 || output.state_root_account_branch_count > 0
+        );
+        assert!(
+            output.state_root_storage_leaf_count > 0 || output.state_root_storage_branch_count > 0,
             "storage-writing transactions should attribute storage trie work"
         );
 

--- a/crates/client/metering/src/rpc.rs
+++ b/crates/client/metering/src/rpc.rs
@@ -279,8 +279,10 @@ where
             total_gas_used: output.total_gas_used,
             total_execution_time_us,
             state_root_time_us: output.state_root_time_us,
-            state_root_account_node_count: output.state_root_account_node_count,
-            state_root_storage_node_count: output.state_root_storage_node_count,
+            state_root_account_leaf_count: output.state_root_account_leaf_count,
+            state_root_account_branch_count: output.state_root_account_branch_count,
+            state_root_storage_leaf_count: output.state_root_storage_leaf_count,
+            state_root_storage_branch_count: output.state_root_storage_branch_count,
         })
     }
 
@@ -1093,8 +1095,10 @@ mod tests {
             total_gas_used: 21_000,
             total_execution_time_us: 123,
             state_root_time_us: 45,
-            state_root_account_node_count: 7,
-            state_root_storage_node_count: 11,
+            state_root_account_leaf_count: 3,
+            state_root_account_branch_count: 4,
+            state_root_storage_leaf_count: 6,
+            state_root_storage_branch_count: 5,
             ..Default::default()
         };
 

--- a/crates/common/bundles/src/meter.rs
+++ b/crates/common/bundles/src/meter.rs
@@ -61,24 +61,22 @@ pub struct MeterBundleResponse {
     /// Time spent calculating state root in microseconds.
     #[serde(default)]
     pub state_root_time_us: u128,
-    /// Best-effort count of account trie nodes attributed to bundle state changes during state
-    /// root calculation.
-    ///
-    /// This combines surviving/inserted account leaves from the bundle delta with account trie
-    /// branch updates/removals emitted by `reth`. Deleted account leaves are represented through
-    /// the branch-side trie updates, not counted again as leaves. Empty-path roots are excluded.
+    /// Count of account leaves from the bundle's hashed post-state: one per modified surviving
+    /// account. Proportional to gas and does not reflect trie depth.
     #[serde(default)]
-    pub state_root_account_node_count: u64,
-    /// Best-effort count of storage trie nodes attributed to bundle state changes during state
-    /// root calculation.
-    ///
-    /// This combines surviving/inserted storage slot leaves from the bundle delta with
-    /// storage-trie branch updates/removals/deletes emitted by `reth`, excluding known non-bundle
-    /// artifacts such as empty-storage deletion markers from untouched tries. Zero-valued slot
-    /// removals and pure storage wipes are represented through the trie updates, not counted again
-    /// as leaves. Empty-path roots are excluded.
+    pub state_root_account_leaf_count: u64,
+    /// Count of account branch/removal nodes emitted during state root calculation. These
+    /// intermediate trie nodes scale with trie depth — the structural cost gas does not price.
     #[serde(default)]
-    pub state_root_storage_node_count: u64,
+    pub state_root_account_branch_count: u64,
+    /// Count of storage slot leaves from the bundle's hashed post-state: one per modified
+    /// non-zero slot. Proportional to gas and does not reflect trie depth.
+    #[serde(default)]
+    pub state_root_storage_leaf_count: u64,
+    /// Count of storage branch/removal nodes emitted during state root calculation, restricted
+    /// to tries the bundle actually modified. Like account branches, these scale with trie depth.
+    #[serde(default)]
+    pub state_root_storage_branch_count: u64,
 }
 
 #[cfg(test)]
@@ -158,22 +156,28 @@ mod tests {
             total_gas_used: 21000,
             total_execution_time_us: 1000,
             state_root_time_us: 500,
-            state_root_account_node_count: 12,
-            state_root_storage_node_count: 34,
+            state_root_account_leaf_count: 5,
+            state_root_account_branch_count: 7,
+            state_root_storage_leaf_count: 20,
+            state_root_storage_branch_count: 14,
         };
 
         let json = serde_json::to_string(&response).unwrap();
         assert!(json.contains("\"stateFlashblockIndex\":42"));
         assert!(json.contains("\"stateBlockNumber\":12345"));
         assert!(json.contains("\"stateRootTimeUs\":500"));
-        assert!(json.contains("\"stateRootAccountNodeCount\":12"));
-        assert!(json.contains("\"stateRootStorageNodeCount\":34"));
+        assert!(json.contains("\"stateRootAccountLeafCount\":5"));
+        assert!(json.contains("\"stateRootAccountBranchCount\":7"));
+        assert!(json.contains("\"stateRootStorageLeafCount\":20"));
+        assert!(json.contains("\"stateRootStorageBranchCount\":14"));
 
         let deserialized: MeterBundleResponse = serde_json::from_str(&json).unwrap();
         assert_eq!(deserialized.state_flashblock_index, Some(42));
         assert_eq!(deserialized.state_block_number, 12345);
-        assert_eq!(deserialized.state_root_account_node_count, 12);
-        assert_eq!(deserialized.state_root_storage_node_count, 34);
+        assert_eq!(deserialized.state_root_account_leaf_count, 5);
+        assert_eq!(deserialized.state_root_account_branch_count, 7);
+        assert_eq!(deserialized.state_root_storage_leaf_count, 20);
+        assert_eq!(deserialized.state_root_storage_branch_count, 14);
     }
 
     #[test]
@@ -190,8 +194,10 @@ mod tests {
             total_gas_used: 21000,
             total_execution_time_us: 1000,
             state_root_time_us: 0,
-            state_root_account_node_count: 0,
-            state_root_storage_node_count: 0,
+            state_root_account_leaf_count: 0,
+            state_root_account_branch_count: 0,
+            state_root_storage_leaf_count: 0,
+            state_root_storage_branch_count: 0,
         };
 
         let json = serde_json::to_string(&response).unwrap();
@@ -225,7 +231,9 @@ mod tests {
         assert_eq!(deserialized.state_flashblock_index, None);
         assert_eq!(deserialized.state_block_number, 12345);
         assert_eq!(deserialized.total_gas_used, 21000);
-        assert_eq!(deserialized.state_root_account_node_count, 0);
-        assert_eq!(deserialized.state_root_storage_node_count, 0);
+        assert_eq!(deserialized.state_root_account_leaf_count, 0);
+        assert_eq!(deserialized.state_root_account_branch_count, 0);
+        assert_eq!(deserialized.state_root_storage_leaf_count, 0);
+        assert_eq!(deserialized.state_root_storage_branch_count, 0);
     }
 }

--- a/crates/common/bundles/src/test_utils.rs
+++ b/crates/common/bundles/src/test_utils.rs
@@ -85,8 +85,10 @@ pub fn create_test_meter_bundle_response() -> MeterBundleResponse {
         total_gas_used: 0,
         total_execution_time_us: 0,
         state_root_time_us: 0,
-        state_root_account_node_count: 0,
-        state_root_storage_node_count: 0,
+        state_root_account_leaf_count: 0,
+        state_root_account_branch_count: 0,
+        state_root_storage_leaf_count: 0,
+        state_root_storage_branch_count: 0,
     }
 }
 


### PR DESCRIPTION
## Summary

Backport of #2108 to `releases/v0.8.0`.

Splits trie node counts into separate leaf and branch metrics for clearer attribution.

Cherry-picked from merge commit dbb557615e. Applied cleanly with no conflicts.