### PR TITLE
[backport] fix(builder): rename stale flashblock state root time metrics to gas (#2182)

### DIFF
--- a/crates/builder/core/src/metrics.rs
+++ b/crates/builder/core/src/metrics.rs
@@ -184,12 +184,12 @@ base_metrics::define_metrics! {
     #[describe("Flashblock execution time headroom in microseconds")]
     #[label(flashblock_index)]
     flashblock_execution_time_headroom_us: histogram,
-    #[describe("Flashblock state root time used in microseconds")]
+    #[describe("Flashblock cumulative state root gas used")]
     #[label(flashblock_index)]
-    flashblock_state_root_time_used_us: histogram,
-    #[describe("Flashblock state root time headroom in microseconds")]
+    flashblock_state_root_gas_used: histogram,
+    #[describe("Flashblock state root gas headroom")]
     #[label(flashblock_index)]
-    flashblock_state_root_time_headroom_us: histogram,
+    flashblock_state_root_gas_headroom: histogram,
     #[describe("Priority fee of rejected transactions")]
     #[label(reason)]
     rejected_tx_priority_fee: histogram,
@@ -260,10 +260,10 @@ impl BuilderMetrics {
             );
         }
 
-        Self::flashblock_state_root_time_used_us(flashblock_index.clone())
+        Self::flashblock_state_root_gas_used(flashblock_index.clone())
             .record(info.cumulative_state_root_gas as f64);
         if let Some(block_state_root_gas_limit) = limits.block_state_root_gas_limit {
-            Self::flashblock_state_root_time_headroom_us(flashblock_index.clone())
+            Self::flashblock_state_root_gas_headroom(flashblock_index.clone())
                 .record(block_state_root_gas_limit.saturating_sub(info.cumulative_state_root_gas)
                     as f64);
         }


### PR DESCRIPTION
## Summary

Backport of #2182 to `releases/v0.8.0`.

Renames `flashblock_state_root_time_used_us` / `flashblock_state_root_time_headroom_us` to `flashblock_state_root_gas_used` / `flashblock_state_root_gas_headroom`. The metrics record cumulative state root gas (not microseconds) since fd5ca0187.

Cherry-picked from merge commit a26051d465. Applied cleanly with no conflicts.