### PR TITLE
fix(proposer): log block context when forward walk fails to fetch canonical roots

### DIFF
--- a/crates/proof/proposer/src/pipeline.rs
+++ b/crates/proof/proposer/src/pipeline.rs
@@ -836,6 +836,12 @@ where
                         // All other RPC errors (retryable or not) propagate so
                         // recovery retries on the next tick rather than caching
                         // a partial result.
+                        warn!(
+                            expected_block,
+                            parent_block,
+                            error = %e,
+                            "Forward walk failed to fetch canonical roots"
+                        );
                         return Err(e);
                     }
                 };


### PR DESCRIPTION
## Summary

- Adds a structured `warn!` with `expected_block` and `parent_block` fields when `fetch_canonical_roots` fails during the forward walk in `recover_latest_state`.

## Problem

When the proposer's forward walk fails to fetch canonical roots (e.g. RPC error), the only log emitted is `"Failed to recover on-chain state, retrying next tick"` with the error — but **no indication of which block was being queried**. This makes it hard to debug production issues

## Fix

Added a `warn!` log at the RPC error path in `forward_walk()` (`pipeline.rs`) that logs:
- `expected_block` — the block the walk was trying to fetch roots for
- `parent_block` — the block the walk was advancing from
- `error` — the RPC error

Now Datadog will show:
1. `"Read anchor root from AnchorStateRegistry"` — `l2_block_number`, `root`
2. **`"Forward walk failed to fetch canonical roots"`** — `expected_block`, `parent_block`, `error` ← NEW
3. `"Failed to recover on-chain state, retrying next tick"` — `error`