### PR TITLE
fix(proposer): log block context when forward walk fails to fetch canonical roots [backport v0.8.0]

### DIFF
--- a/crates/proof/proposer/src/pipeline.rs
+++ b/crates/proof/proposer/src/pipeline.rs
@@ -836,6 +836,12 @@ where
                         // All other RPC errors (retryable or not) propagate so
                         // recovery retries on the next tick rather than caching
                         // a partial result.
+                        warn!(
+                            expected_block,
+                            parent_block,
+                            error = %e,
+                            "Forward walk failed to fetch canonical roots"
+                        );
                         return Err(e);
                     }
                 };


### PR DESCRIPTION
## Summary

Backport of #2253 to `releases/v0.8.0`.

- Adds a structured `warn!` with `expected_block` and `parent_block` fields when `fetch_canonical_roots` fails during the forward walk in `recover_latest_state`.

Cherry-picked cleanly from `fix/proposer-log` (`60c4794c2`).