### PR TITLE
feat(nitro-host): dual-enclave support with on-chain routing

### DIFF
--- a/bin/prover/nitro-host/src/cli.rs
+++ b/bin/prover/nitro-host/src/cli.rs
@@ -24,7 +24,7 @@ use clap::{Parser, Subcommand};
 #[cfg(any(target_os = "linux", feature = "local"))]
 use eyre::eyre;
 #[cfg(any(target_os = "linux", feature = "local"))]
-use tracing::info;
+use tracing::{info, warn};
 
 base_cli_utils::define_log_args!("BASE_PROVER_NITRO_HOST");
 base_cli_utils::define_metrics_args!("BASE_PROVER_NITRO_HOST", 7300);
@@ -115,8 +115,8 @@ struct ServerArgs {
     server: ProverServerArgs,
 
     /// Vsock CID of the enclave.
-    #[arg(long, env = "VSOCK_CID")]
-    vsock_cid: u32,
+    #[arg(long, env = "VSOCK_CID", value_delimiter = ',')]
+    vsock_cid: Vec<u32>,
 }
 
 impl Cli {
@@ -161,13 +161,23 @@ impl ServerArgs {
             enable_experimental_witness_endpoint: self.server.enable_experimental_witness_endpoint,
         };
 
-        let transport = Arc::new(NitroTransport::vsock(self.vsock_cid, VSOCK_PORT));
+        let transports: Vec<Arc<NitroTransport>> = self
+            .vsock_cid
+            .iter()
+            .map(|&cid| Arc::new(NitroTransport::vsock(cid, VSOCK_PORT)))
+            .collect();
+        if transports.len() > 1 && self.server.tee_prover_registry_address.is_none() {
+            return Err(eyre!(
+                "multi-CID requires --tee-prover-registry-address for on-chain routing"
+            ));
+        }
         let timeout = Duration::from_secs(self.server.proof_request_timeout_secs);
-        let mut server = NitroProverServer::new(config, transport, timeout);
+        let mut server = NitroProverServer::new_multi(config, transports, timeout);
         if let Some(reg) = registration_health {
             server = server.with_registration_health(reg);
         }
 
+        info!(cids = ?self.vsock_cid, "configured vsock CIDs");
         info!(addr = %self.server.listen_addr, "starting nitro prover host server");
         let handle = server.run(self.server.listen_addr).await?;
         handle.stopped().await;
@@ -181,6 +191,9 @@ impl ServerArgs {
 struct LocalArgs {
     #[command(flatten)]
     server: ProverServerArgs,
+
+    #[arg(long, env = "LOCAL_ENCLAVE_COUNT", default_value = "1")]
+    local_enclave_count: usize,
 }
 
 #[cfg(feature = "local")]
@@ -206,10 +219,20 @@ impl LocalArgs {
             enable_experimental_witness_endpoint: self.server.enable_experimental_witness_endpoint,
         };
 
-        let enclave_server = Arc::new(EnclaveServer::new_local()?);
-        let transport = Arc::new(NitroTransport::local(enclave_server));
+        let transports: Vec<Arc<NitroTransport>> = (0..self.local_enclave_count)
+            .map(|_| {
+                let server = Arc::new(EnclaveServer::new_local()?);
+                Ok(Arc::new(NitroTransport::local(server)))
+            })
+            .collect::<eyre::Result<Vec<_>>>()?;
+        if self.local_enclave_count > 1 && self.server.tee_prover_registry_address.is_none() {
+            warn!(
+                count = self.local_enclave_count,
+                "multiple local enclaves without registry; defaulting to index 0 for routing"
+            );
+        }
         let timeout = Duration::from_secs(self.server.proof_request_timeout_secs);
-        let mut server = NitroProverServer::new(prover_config, transport, timeout);
+        let mut server = NitroProverServer::new_multi(prover_config, transports, timeout);
         if let Some(reg) = registration_health {
             server = server.with_registration_health(reg);
         }

--- a/crates/proof/tee/nitro-host/src/health.rs
+++ b/crates/proof/tee/nitro-host/src/health.rs
@@ -76,7 +76,7 @@ mod tests {
     ) -> (Arc<RegistrationChecker>, RegistrationHealthzRpc) {
         let server = Arc::new(base_proof_tee_nitro_enclave::Server::new_local().unwrap());
         let transport = Arc::new(NitroTransport::local(server));
-        let checker = Arc::new(RegistrationChecker::new(transport, registry));
+        let checker = Arc::new(RegistrationChecker::new(vec![transport], registry));
         let rpc = RegistrationHealthzRpc::new("0.0.0", Arc::clone(&checker));
         (checker, rpc)
     }

--- a/crates/proof/tee/nitro-host/src/lib.rs
+++ b/crates/proof/tee/nitro-host/src/lib.rs
@@ -7,7 +7,7 @@ mod backend;
 pub use backend::NitroBackend;
 
 mod registration;
-pub use registration::{RegistrationChecker, RegistrationError};
+pub use registration::{RegistrationChecker, RegistrationError, ValidSigner};
 
 mod health;
 pub use health::{RegistrationHealthConfig, RegistrationHealthzRpc};

--- a/crates/proof/tee/nitro-host/src/registration.rs
+++ b/crates/proof/tee/nitro-host/src/registration.rs
@@ -227,12 +227,15 @@ impl RegistrationChecker {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::{Arc, atomic::Ordering};
+    use std::{
+        collections::HashMap,
+        sync::{Arc, atomic::Ordering},
+    };
 
     use base_proof_contracts::TEEProverRegistryClient;
 
     use super::*;
-    use crate::test_utils::MockRegistry;
+    use crate::test_utils::{AddressBasedMockRegistry, MockRegistry};
 
     fn test_checker_with_mock(
         registry: impl TEEProverRegistryClient + 'static,
@@ -251,6 +254,32 @@ mod tests {
             dummy_url,
         );
         RegistrationChecker::new(vec![transport], registry)
+    }
+
+    fn two_transport_checker(
+        registry: impl TEEProverRegistryClient + 'static,
+    ) -> RegistrationChecker {
+        let s1 = Arc::new(base_proof_tee_nitro_enclave::Server::new_local().unwrap());
+        let s2 = Arc::new(base_proof_tee_nitro_enclave::Server::new_local().unwrap());
+        let t1 = Arc::new(NitroTransport::local(s1));
+        let t2 = Arc::new(NitroTransport::local(s2));
+        RegistrationChecker::new(vec![t1, t2], registry)
+    }
+
+    async fn transport_signer_address(transport: &NitroTransport) -> Address {
+        let public_key = transport
+            .signer_public_key()
+            .await
+            .expect("signer public key should be available in tests");
+        let verifying_key = VerifyingKey::from_sec1_bytes(&public_key)
+            .expect("signer public key should parse in tests");
+        public_key_to_address(&verifying_key)
+    }
+
+    async fn two_transport_signers(checker: &RegistrationChecker) -> (Address, Address) {
+        let signer_one = transport_signer_address(&checker.transports[0]).await;
+        let signer_two = transport_signer_address(&checker.transports[1]).await;
+        (signer_one, signer_two)
     }
 
     #[tokio::test]
@@ -331,5 +360,119 @@ mod tests {
 
         assert!(checker.require_valid_signer().await.is_ok());
         assert_eq!(call_count.load(Ordering::Relaxed), 2);
+    }
+
+    #[tokio::test]
+    async fn select_single_valid_returns_it() {
+        let registry = AddressBasedMockRegistry::new(HashMap::new());
+        let checker = two_transport_checker(registry.clone());
+        let (signer_one, signer_two) = two_transport_signers(&checker).await;
+
+        {
+            let mut validity_map = registry
+                .validity_map
+                .lock()
+                .expect("validity map lock should succeed");
+            validity_map.insert(signer_one, true);
+            validity_map.insert(signer_two, false);
+        }
+
+        let valid = checker.select_valid_enclave().await.expect("valid signer expected");
+        assert_eq!(valid.index, 0);
+        assert_eq!(valid.signer, signer_one);
+    }
+
+    #[tokio::test]
+    async fn select_second_valid_returns_index_1() {
+        let registry = AddressBasedMockRegistry::new(HashMap::new());
+        let checker = two_transport_checker(registry.clone());
+        let (signer_one, signer_two) = two_transport_signers(&checker).await;
+
+        {
+            let mut validity_map = registry
+                .validity_map
+                .lock()
+                .expect("validity map lock should succeed");
+            validity_map.insert(signer_one, false);
+            validity_map.insert(signer_two, true);
+        }
+
+        let valid = checker.select_valid_enclave().await.expect("valid signer expected");
+        assert_eq!(valid.index, 1);
+        assert_eq!(valid.signer, signer_two);
+    }
+
+    #[tokio::test]
+    async fn select_both_valid_returns_first() {
+        let registry = AddressBasedMockRegistry::new(HashMap::new());
+        let checker = two_transport_checker(registry.clone());
+        let (signer_one, signer_two) = two_transport_signers(&checker).await;
+
+        {
+            let mut validity_map = registry
+                .validity_map
+                .lock()
+                .expect("validity map lock should succeed");
+            validity_map.insert(signer_one, true);
+            validity_map.insert(signer_two, true);
+        }
+
+        let valid = checker.select_valid_enclave().await.expect("valid signer expected");
+        assert_eq!(valid.index, 0);
+        assert_eq!(valid.signer, signer_one);
+    }
+
+    #[tokio::test]
+    async fn select_none_valid_returns_no_valid_signer() {
+        let registry = AddressBasedMockRegistry::new(HashMap::new());
+        let checker = two_transport_checker(registry);
+        let (signer_one, signer_two) = two_transport_signers(&checker).await;
+
+        let err = checker
+            .select_valid_enclave()
+            .await
+            .expect_err("expected no valid signer error");
+
+        match err {
+            RegistrationError::NoValidSigner { signers } => {
+                assert_eq!(signers.len(), 2);
+                assert!(signers.contains(&signer_one));
+                assert!(signers.contains(&signer_two));
+            }
+            other => panic!("unexpected error: {other:?}"),
+        }
+    }
+
+    // select_skips_failed_key_fetch is not directly testable because NitroTransport::local
+    // always returns a signer public key and RegistrationChecker is hard-wired to NitroTransport.
+
+    #[tokio::test]
+    async fn health_latches_with_multi_transport() {
+        let registry = AddressBasedMockRegistry::new(HashMap::new());
+        let checker = two_transport_checker(registry.clone());
+        let (signer_one, signer_two) = two_transport_signers(&checker).await;
+
+        {
+            let mut validity_map = registry
+                .validity_map
+                .lock()
+                .expect("validity map lock should succeed");
+            validity_map.insert(signer_one, true);
+            validity_map.insert(signer_two, false);
+        }
+
+        assert!(checker.check_health().await.expect("health should be ok"));
+
+        {
+            let mut validity_map = registry
+                .validity_map
+                .lock()
+                .expect("validity map lock should succeed");
+            validity_map.insert(signer_one, false);
+            validity_map.insert(signer_two, false);
+        }
+
+        registry.should_fail.store(true, Ordering::Relaxed);
+        assert!(checker.check_health().await.expect("latched health should stay ok"));
     }
 }

--- a/crates/proof/tee/nitro-host/src/registration.rs
+++ b/crates/proof/tee/nitro-host/src/registration.rs
@@ -51,6 +51,16 @@ pub enum RegistrationError {
         /// The signer address that failed validation.
         signer: Address,
     },
+    #[error("no valid signer found among: {signers:?}")]
+    NoValidSigner {
+        signers: Vec<Address>,
+    },
+}
+
+#[derive(Debug)]
+pub struct ValidSigner {
+    pub index: usize,
+    pub signer: Address,
 }
 
 /// Checks whether the enclave signer is a **valid** signer in the on-chain
@@ -61,7 +71,7 @@ pub enum RegistrationError {
 /// unnecessary.  A separate latching flag tracks whether the signer has *ever*
 /// been valid — once set, [`check_health`](Self::check_health) always succeeds.
 pub struct RegistrationChecker {
-    transport: Arc<NitroTransport>,
+    transports: Vec<Arc<NitroTransport>>,
     registry: Box<dyn TEEProverRegistryClient>,
     healthy: OnceCell<()>,
 }
@@ -75,15 +85,16 @@ impl std::fmt::Debug for RegistrationChecker {
 impl RegistrationChecker {
     /// Creates a new checker for the given transport and registry client.
     pub fn new(
-        transport: Arc<NitroTransport>,
+        transports: Vec<Arc<NitroTransport>>,
         registry: impl TEEProverRegistryClient + 'static,
     ) -> Self {
-        Self { transport, registry: Box::new(registry), healthy: OnceCell::new() }
+        Self { transports, registry: Box::new(registry), healthy: OnceCell::new() }
     }
 
-    async fn signer_address(&self) -> Result<Address, RegistrationError> {
-        let public_key = self
-            .transport
+    async fn signer_address(
+        transport: &NitroTransport,
+    ) -> Result<Address, RegistrationError> {
+        let public_key = transport
             .signer_public_key()
             .await
             .map_err(|e| RegistrationError::Setup(format!("signer public key: {e}")))?;
@@ -92,22 +103,55 @@ impl RegistrationChecker {
         Ok(public_key_to_address(&verifying_key))
     }
 
-    async fn fetch_validity(&self) -> Result<(bool, Address), RegistrationError> {
-        let signer = self.signer_address().await?;
-
+    async fn is_valid_signer(&self, signer: Address) -> Result<bool, RegistrationError> {
         let result =
             tokio::time::timeout(CHECK_TIMEOUT, self.registry.is_valid_signer(signer)).await;
 
         match result {
-            Ok(Ok(valid)) => {
-                if !valid {
-                    warn!(signer = %signer, "signer is not a valid signer in TEEProverRegistry");
-                }
-                Ok((valid, signer))
-            }
+            Ok(Ok(valid)) => Ok(valid),
             Ok(Err(e)) => Err(RegistrationError::Rpc { signer, reason: e.to_string() }),
             Err(_) => Err(RegistrationError::Rpc { signer, reason: "request timed out".into() }),
         }
+    }
+
+    async fn fetch_validity(&self) -> Result<bool, RegistrationError> {
+        let mut any_valid = false;
+        let mut rpc_error = None;
+
+        for (index, transport) in self.transports.iter().enumerate() {
+            let signer = match Self::signer_address(transport).await {
+                Ok(signer) => signer,
+                Err(e) => {
+                    warn!(error = %e, index, "skipping transport: key fetch failed");
+                    continue;
+                }
+            };
+
+            match self.is_valid_signer(signer).await {
+                Ok(valid) => {
+                    if valid {
+                        any_valid = true;
+                    } else {
+                        warn!(signer = %signer, index, "signer is not a valid signer in TEEProverRegistry");
+                    }
+                }
+                Err(e) => {
+                    if rpc_error.is_none() {
+                        rpc_error = Some(e);
+                    }
+                }
+            }
+        }
+
+        if any_valid {
+            return Ok(true);
+        }
+
+        if let Some(error) = rpc_error {
+            return Err(error);
+        }
+
+        Ok(false)
     }
 
     /// Latching health check: returns `true` once the signer has ever been
@@ -118,7 +162,7 @@ impl RegistrationChecker {
         if self.healthy.get().is_some() {
             return Ok(true);
         }
-        let (valid, _) = self.fetch_validity().await?;
+        let valid = self.fetch_validity().await?;
         if valid {
             let _ = self.healthy.set(());
         }
@@ -130,11 +174,54 @@ impl RegistrationChecker {
     /// Fail-closed: if L1 is unreachable or the signer is not valid, the
     /// proof request is rejected.
     pub async fn require_valid_signer(&self) -> Result<(), RegistrationError> {
-        match self.fetch_validity().await {
-            Ok((true, _)) => Ok(()),
-            Ok((false, signer)) => Err(RegistrationError::NotValid { signer }),
+        let transport = self
+            .transports
+            .first()
+            .ok_or_else(|| RegistrationError::NoValidSigner { signers: Vec::new() })?;
+        let signer = Self::signer_address(transport).await?;
+
+        match self.is_valid_signer(signer).await {
+            Ok(true) => Ok(()),
+            Ok(false) => Err(RegistrationError::NotValid { signer }),
             Err(e) => Err(e),
         }
+    }
+
+    pub async fn select_valid_enclave(&self) -> Result<ValidSigner, RegistrationError> {
+        let mut discovered = Vec::new();
+        let mut valid_signers = Vec::new();
+
+        for (index, transport) in self.transports.iter().enumerate() {
+            let signer = match Self::signer_address(transport).await {
+                Ok(signer) => signer,
+                Err(e) => {
+                    warn!(error = %e, index, "skipping transport: key fetch failed");
+                    continue;
+                }
+            };
+
+            discovered.push(signer);
+
+            match self.is_valid_signer(signer).await {
+                Ok(true) => valid_signers.push(ValidSigner { index, signer }),
+                Ok(false) => {
+                    warn!(signer = %signer, index, "signer is not a valid signer in TEEProverRegistry");
+                }
+                Err(e) => return Err(e),
+            }
+        }
+
+        if valid_signers.is_empty() {
+            return Err(RegistrationError::NoValidSigner { signers: discovered });
+        }
+
+        if valid_signers.len() > 1 {
+            let signers: Vec<Address> =
+                valid_signers.iter().map(|valid| valid.signer).collect();
+            warn!(signers = ?signers, "multiple valid signers found; using first");
+        }
+
+        Ok(valid_signers.remove(0))
     }
 }
 
@@ -152,7 +239,7 @@ mod tests {
     ) -> RegistrationChecker {
         let server = Arc::new(base_proof_tee_nitro_enclave::Server::new_local().unwrap());
         let transport = Arc::new(NitroTransport::local(server));
-        RegistrationChecker::new(transport, registry)
+        RegistrationChecker::new(vec![transport], registry)
     }
 
     fn test_checker() -> RegistrationChecker {
@@ -163,7 +250,7 @@ mod tests {
             alloy_primitives::Address::ZERO,
             dummy_url,
         );
-        RegistrationChecker::new(transport, registry)
+        RegistrationChecker::new(vec![transport], registry)
     }
 
     #[tokio::test]

--- a/crates/proof/tee/nitro-host/src/registration.rs
+++ b/crates/proof/tee/nitro-host/src/registration.rs
@@ -51,15 +51,20 @@ pub enum RegistrationError {
         /// The signer address that failed validation.
         signer: Address,
     },
+    /// No enclave signer is currently valid in `TEEProverRegistry`.
     #[error("no valid signer found among: {signers:?}")]
     NoValidSigner {
+        /// The signer addresses that were checked.
         signers: Vec<Address>,
     },
 }
 
+/// A signer that has been confirmed valid on-chain via `TEEProverRegistry`.
 #[derive(Debug)]
 pub struct ValidSigner {
+    /// Index of the enclave in the configured transport list.
     pub index: usize,
+    /// Ethereum address of the valid signer.
     pub signer: Address,
 }
 
@@ -187,6 +192,10 @@ impl RegistrationChecker {
         }
     }
 
+    /// Selects the first enclave whose signer is currently valid on-chain.
+    ///
+    /// Iterates transports in config order, querying `isValidSigner` for each.
+    /// Returns the first valid signer; logs a warning if multiple are valid.
     pub async fn select_valid_enclave(&self) -> Result<ValidSigner, RegistrationError> {
         let mut discovered = Vec::new();
         let mut valid_signers = Vec::new();

--- a/crates/proof/tee/nitro-host/src/server.rs
+++ b/crates/proof/tee/nitro-host/src/server.rs
@@ -24,14 +24,18 @@ const MAX_USER_DATA_BYTES: usize = 512;
 /// Maximum allowed size for the `nonce` attestation field (NSM limit).
 const MAX_NONCE_BYTES: usize = 512;
 
+struct EnclaveService {
+    transport: Arc<NitroTransport>,
+    service: ProverService<NitroBackend>,
+}
+
 /// Host-side TEE prover server exposing a JSON-RPC interface.
 ///
 /// Implements two JSON-RPC namespaces:
 /// - `prover_*`: proving operations (forwarded to the enclave via transport)
 /// - `enclave_*`: signer info queries (also forwarded via transport)
 pub struct NitroProverServer {
-    service: ProverService<NitroBackend>,
-    transport: Arc<NitroTransport>,
+    enclaves: Vec<EnclaveService>,
     proof_request_timeout: Duration,
     registration_health: Option<RegistrationHealthConfig>,
 }
@@ -49,10 +53,26 @@ impl NitroProverServer {
         transport: Arc<NitroTransport>,
         proof_request_timeout: Duration,
     ) -> Self {
-        let backend = NitroBackend::new(Arc::clone(&transport));
+        Self::new_multi(config, vec![transport], proof_request_timeout)
+    }
+
+    pub fn new_multi(
+        config: ProverConfig,
+        transports: Vec<Arc<NitroTransport>>,
+        proof_request_timeout: Duration,
+    ) -> Self {
+        let enclaves = transports
+            .into_iter()
+            .map(|transport| {
+                let backend = NitroBackend::new(Arc::clone(&transport));
+                EnclaveService {
+                    transport,
+                    service: ProverService::new(config.clone(), backend),
+                }
+            })
+            .collect();
         Self {
-            service: ProverService::new(config, backend),
-            transport,
+            enclaves,
             proof_request_timeout,
             registration_health: None,
         }
@@ -74,6 +94,11 @@ impl NitroProverServer {
         info!(addr = %addr, "nitro rpc server started");
 
         let mut module = RpcModule::new(());
+        let transports: Vec<Arc<NitroTransport>> = self
+            .enclaves
+            .iter()
+            .map(|enclave| Arc::clone(&enclave.transport))
+            .collect();
 
         let checker = match self.registration_health {
             Some(config) => {
@@ -85,8 +110,7 @@ impl NitroProverServer {
                     .map_err(|e| eyre::eyre!("invalid L1 RPC URL: {e}"))?;
                 let registry =
                     TEEProverRegistryContractClient::new(config.registry_address, l1_url);
-                let checker =
-                    Arc::new(RegistrationChecker::new(Arc::clone(&self.transport), registry));
+                let checker = Arc::new(RegistrationChecker::new(transports.clone(), registry));
                 module.merge(
                     RegistrationHealthzRpc::new(env!("CARGO_PKG_VERSION"), Arc::clone(&checker))
                         .into_rpc(),
@@ -101,7 +125,7 @@ impl NitroProverServer {
 
         module.merge(
             NitroProverRpc {
-                service: self.service,
+                enclaves: self.enclaves,
                 proof_request_timeout: self.proof_request_timeout,
                 checker,
             }
@@ -110,7 +134,7 @@ impl NitroProverServer {
 
         module.merge(
             NitroSignerRpc {
-                transports: vec![Arc::clone(&self.transport)],
+                transports,
             }
             .into_rpc(),
         )?;
@@ -121,7 +145,7 @@ impl NitroProverServer {
 
 /// Inner RPC handler for `prover_*` methods.
 struct NitroProverRpc {
-    service: ProverService<NitroBackend>,
+    enclaves: Vec<EnclaveService>,
     proof_request_timeout: Duration,
     checker: Option<Arc<RegistrationChecker>>,
 }
@@ -129,17 +153,20 @@ struct NitroProverRpc {
 #[async_trait]
 impl ProverApiServer for NitroProverRpc {
     async fn prove(&self, request: ProofRequest) -> RpcResult<ProofResult> {
-        if let Some(checker) = &self.checker {
-            checker.require_valid_signer().await.map_err(|e| {
+        let service = if let Some(checker) = &self.checker {
+            let signer = checker.select_valid_enclave().await.map_err(|e| {
                 warn!(error = %e, "rejecting proof request: signer validation failed");
                 jsonrpsee::types::ErrorObjectOwned::owned(-32001, e.to_string(), None::<()>)
             })?;
-        }
+            &self.enclaves[signer.index].service
+        } else {
+            &self.enclaves[0].service
+        };
 
         let l2_block = request.claimed_l2_block_number;
         let timeout = self.proof_request_timeout;
 
-        match tokio::time::timeout(timeout, self.service.prove_block(request)).await {
+        match tokio::time::timeout(timeout, service.prove_block(request)).await {
             Ok(result) => result.map_err(|e| {
                 jsonrpsee::types::ErrorObjectOwned::owned(-32000, e.to_string(), None::<()>)
             }),

--- a/crates/proof/tee/nitro-host/src/server.rs
+++ b/crates/proof/tee/nitro-host/src/server.rs
@@ -56,6 +56,7 @@ impl NitroProverServer {
         Self::new_multi(config, vec![transport], proof_request_timeout)
     }
 
+    /// Create a server with multiple enclave transports for dual-enclave deployments.
     pub fn new_multi(
         config: ProverConfig,
         transports: Vec<Arc<NitroTransport>>,

--- a/crates/proof/tee/nitro-host/src/server.rs
+++ b/crates/proof/tee/nitro-host/src/server.rs
@@ -108,7 +108,12 @@ impl NitroProverServer {
             .into_rpc(),
         )?;
 
-        module.merge(NitroSignerRpc { transport: Arc::clone(&self.transport) }.into_rpc())?;
+        module.merge(
+            NitroSignerRpc {
+                transports: vec![Arc::clone(&self.transport)],
+            }
+            .into_rpc(),
+        )?;
 
         Ok(server.start(module))
     }
@@ -155,16 +160,20 @@ impl ProverApiServer for NitroProverRpc {
 
 /// Inner RPC handler for `enclave_*` methods.
 struct NitroSignerRpc {
-    transport: Arc<NitroTransport>,
+    transports: Vec<Arc<NitroTransport>>,
 }
 
 #[async_trait]
 impl EnclaveApiServer for NitroSignerRpc {
     async fn signer_public_key(&self) -> RpcResult<Vec<Vec<u8>>> {
-        let key = self.transport.signer_public_key().await.map_err(|e| {
-            jsonrpsee::types::ErrorObjectOwned::owned(-32001, e.to_string(), None::<()>)
-        })?;
-        Ok(vec![key])
+        let mut keys = Vec::with_capacity(self.transports.len());
+        for transport in &self.transports {
+            let key = transport.signer_public_key().await.map_err(|e| {
+                jsonrpsee::types::ErrorObjectOwned::owned(-32001, e.to_string(), None::<()>)
+            })?;
+            keys.push(key);
+        }
+        Ok(keys)
     }
 
     async fn signer_attestation(
@@ -190,11 +199,17 @@ impl EnclaveApiServer for NitroSignerRpc {
             ));
         }
 
-        let attestation =
-            self.transport.signer_attestation(user_data, nonce).await.map_err(|e| {
-                jsonrpsee::types::ErrorObjectOwned::owned(-32001, e.to_string(), None::<()>)
-            })?;
-        Ok(vec![attestation])
+        let mut attestations = Vec::with_capacity(self.transports.len());
+        for transport in &self.transports {
+            let attestation = transport
+                .signer_attestation(user_data.clone(), nonce.clone())
+                .await
+                .map_err(|e| {
+                    jsonrpsee::types::ErrorObjectOwned::owned(-32001, e.to_string(), None::<()>)
+                })?;
+            attestations.push(attestation);
+        }
+        Ok(attestations)
     }
 }
 
@@ -211,7 +226,9 @@ mod tests {
         let transport = Arc::new(NitroTransport::local(Arc::clone(&server)));
         let expected = server.signer_public_key();
 
-        let rpc = NitroSignerRpc { transport };
+        let rpc = NitroSignerRpc {
+            transports: vec![transport],
+        };
         let result = EnclaveApiServer::signer_public_key(&rpc).await.unwrap();
         assert_eq!(result.len(), 1);
         assert_eq!(result[0], expected);
@@ -231,7 +248,9 @@ mod tests {
         let server = Arc::new(EnclaveServer::new_local().unwrap());
         let transport = Arc::new(NitroTransport::local(Arc::clone(&server)));
 
-        let rpc = NitroSignerRpc { transport };
+        let rpc = NitroSignerRpc {
+            transports: vec![transport],
+        };
         // NSM is unavailable outside a real Nitro enclave, so attestation fails.
         // Assert the error is propagated (not swallowed) through the RPC layer.
         let result = EnclaveApiServer::signer_attestation(&rpc, None, None).await;
@@ -242,7 +261,9 @@ mod tests {
     async fn signer_attestation_rejects_oversized_user_data() {
         let server = Arc::new(EnclaveServer::new_local().unwrap());
         let transport = Arc::new(NitroTransport::local(Arc::clone(&server)));
-        let rpc = NitroSignerRpc { transport };
+        let rpc = NitroSignerRpc {
+            transports: vec![transport],
+        };
 
         let oversized = vec![0u8; MAX_USER_DATA_BYTES + 1];
         let result = EnclaveApiServer::signer_attestation(&rpc, Some(oversized), None).await;
@@ -255,7 +276,9 @@ mod tests {
     async fn signer_attestation_rejects_oversized_nonce() {
         let server = Arc::new(EnclaveServer::new_local().unwrap());
         let transport = Arc::new(NitroTransport::local(Arc::clone(&server)));
-        let rpc = NitroSignerRpc { transport };
+        let rpc = NitroSignerRpc {
+            transports: vec![transport],
+        };
 
         let oversized = vec![0u8; MAX_NONCE_BYTES + 1];
         let result = EnclaveApiServer::signer_attestation(&rpc, None, Some(oversized)).await;

--- a/crates/proof/tee/nitro-host/src/test_utils.rs
+++ b/crates/proof/tee/nitro-host/src/test_utils.rs
@@ -1,8 +1,12 @@
 //! Shared test utilities for the `base-proof-tee-nitro-host` crate.
 
-use std::sync::{
-    Arc,
-    atomic::{AtomicBool, AtomicUsize, Ordering},
+use std::{
+    collections::HashMap,
+    sync::{
+        Arc,
+        Mutex,
+        atomic::{AtomicBool, AtomicUsize, Ordering},
+    },
 };
 
 use alloy_primitives::Address;
@@ -20,6 +24,23 @@ pub struct MockRegistry {
     pub call_count: Arc<AtomicUsize>,
     /// When `true`, `is_valid_signer` returns a [`ContractError::Validation`] error.
     pub should_fail: Arc<AtomicBool>,
+}
+
+#[derive(Debug, Clone)]
+pub struct AddressBasedMockRegistry {
+    pub validity_map: Arc<Mutex<HashMap<Address, bool>>>,
+    pub call_count: Arc<AtomicUsize>,
+    pub should_fail: Arc<AtomicBool>,
+}
+
+impl AddressBasedMockRegistry {
+    pub fn new(validity_map: HashMap<Address, bool>) -> Self {
+        Self {
+            validity_map: Arc::new(Mutex::new(validity_map)),
+            call_count: Arc::new(AtomicUsize::new(0)),
+            should_fail: Arc::new(AtomicBool::new(false)),
+        }
+    }
 }
 
 impl MockRegistry {
@@ -44,6 +65,39 @@ impl TEEProverRegistryClient for MockRegistry {
             return Err(base_proof_contracts::ContractError::Validation("mock RPC failure".into()));
         }
         Ok(self.valid.load(Ordering::Relaxed))
+    }
+
+    async fn is_registered_signer(
+        &self,
+        _signer: Address,
+    ) -> Result<bool, base_proof_contracts::ContractError> {
+        unimplemented!()
+    }
+
+    async fn get_registered_signers(
+        &self,
+    ) -> Result<Vec<Address>, base_proof_contracts::ContractError> {
+        unimplemented!()
+    }
+}
+
+#[async_trait]
+impl TEEProverRegistryClient for AddressBasedMockRegistry {
+    async fn is_valid_signer(
+        &self,
+        signer: Address,
+    ) -> Result<bool, base_proof_contracts::ContractError> {
+        self.call_count.fetch_add(1, Ordering::Relaxed);
+        if self.should_fail.load(Ordering::Relaxed) {
+            return Err(base_proof_contracts::ContractError::Validation(
+                "mock RPC failure".into(),
+            ));
+        }
+        let validity_map = self
+            .validity_map
+            .lock()
+            .expect("AddressBasedMockRegistry validity map mutex poisoned");
+        Ok(validity_map.get(&signer).copied().unwrap_or(false))
     }
 
     async fn is_registered_signer(


### PR DESCRIPTION
## Summary

- Host connects to **multiple enclaves** via `--vsock-cid 16,17` (comma-separated)
- `prover_prove` routes to the enclave whose signer is **valid on-chain** via `isValidSigner`
- `enclave_signerPublicKey` / `enclave_signerAttestation` return keys from **all** enclaves
- Backward compatible: single-CID config continues to work unchanged
- Local dev mode supports `--local-enclave-count N` for multi-enclave testing

## Motivation

During Base upgrades, two enclaves (old + new) run simultaneously on the same EC2 instance. The host needs to route proof requests to whichever enclave's signer is currently valid on-chain (`TEEProverRegistry.isValidSigner`). At the hardfork boundary, the on-chain image hash rotates — the host auto-routes to the new enclave.

## Changes

### `crates/proof/tee/nitro-host/`

| File | Change |
|---|---|
| `registration.rs` | `RegistrationChecker` accepts `Vec<Arc<NitroTransport>>`, adds `ValidSigner` struct, `select_valid_enclave()` method, `NoValidSigner` error variant |
| `server.rs` | `EnclaveService` struct, `NitroProverServer::new_multi()`, `NitroProverRpc::prove` routes via `select_valid_enclave()`, `NitroSignerRpc` aggregates from all transports |
| `lib.rs` | Re-exports `ValidSigner` |
| `health.rs` | Test helper updated for multi-transport constructor |

### `bin/prover/nitro-host/`

| File | Change |
|---|---|
| `cli.rs` | `--vsock-cid` accepts `Vec<u32>` with delimiter, multi-CID guard requires registry address, `--local-enclave-count` for local dev |

## Testing

- 26 unit tests (5 new multi-transport tests):
  - `select_single_valid_returns_it`
  - `select_second_valid_returns_index_1`
  - `select_both_valid_returns_first` (first in config order wins)
  - `select_none_valid_returns_no_valid_signer`
  - `health_latches_with_multi_transport`
- `cargo check -p base-prover-nitro-host --features local` ✓
- `cargo test -p base-proof-tee-nitro-host` ✓ (26/26 pass)

## Companion PR

- Deployment (protocols repo): https://coinbase.ghe.com/protocols/base-proofs/pull/158