### PR TITLE
feat(nitro-host): multi-transport RegistrationChecker + NitroSignerRpc [1/3]

### DIFF
--- a/crates/proof/tee/nitro-host/src/health.rs
+++ b/crates/proof/tee/nitro-host/src/health.rs
@@ -76,7 +76,7 @@ mod tests {
     ) -> (Arc<RegistrationChecker>, RegistrationHealthzRpc) {
         let server = Arc::new(base_proof_tee_nitro_enclave::Server::new_local().unwrap());
         let transport = Arc::new(NitroTransport::local(server));
-        let checker = Arc::new(RegistrationChecker::new(transport, registry));
+        let checker = Arc::new(RegistrationChecker::new(vec![transport], registry));
         let rpc = RegistrationHealthzRpc::new("0.0.0", Arc::clone(&checker));
         (checker, rpc)
     }

--- a/crates/proof/tee/nitro-host/src/health.rs
+++ b/crates/proof/tee/nitro-host/src/health.rs
@@ -76,7 +76,7 @@ mod tests {
     ) -> (Arc<RegistrationChecker>, RegistrationHealthzRpc) {
         let server = Arc::new(base_proof_tee_nitro_enclave::Server::new_local().unwrap());
         let transport = Arc::new(NitroTransport::local(server));
-        let checker = Arc::new(RegistrationChecker::new(vec![transport], registry));
+        let checker = Arc::new(RegistrationChecker::new(vec![transport], registry).unwrap());
         let rpc = RegistrationHealthzRpc::new("0.0.0", Arc::clone(&checker));
         (checker, rpc)
     }

--- a/crates/proof/tee/nitro-host/src/lib.rs
+++ b/crates/proof/tee/nitro-host/src/lib.rs
@@ -7,7 +7,7 @@ mod backend;
 pub use backend::NitroBackend;
 
 mod registration;
-pub use registration::{RegistrationChecker, RegistrationError};
+pub use registration::{RegistrationChecker, RegistrationError, ValidSigner};
 
 mod health;
 pub use health::{RegistrationHealthConfig, RegistrationHealthzRpc};

--- a/crates/proof/tee/nitro-host/src/registration.rs
+++ b/crates/proof/tee/nitro-host/src/registration.rs
@@ -51,13 +51,20 @@ pub enum RegistrationError {
         /// The signer address that failed validation.
         signer: Address,
     },
+    /// No enclave signer is currently valid in `TEEProverRegistry`.
     #[error("no valid signer found among: {signers:?}")]
-    NoValidSigner { signers: Vec<Address> },
+    NoValidSigner {
+        /// The signer addresses that were checked.
+        signers: Vec<Address>,
+    },
 }
 
+/// A signer that has been confirmed valid on-chain via `TEEProverRegistry`.
 #[derive(Debug)]
 pub struct ValidSigner {
+    /// Index of the enclave in the configured transport list.
     pub index: usize,
+    /// Ethereum address of the valid signer.
     pub signer: Address,
 }
 
@@ -183,6 +190,7 @@ impl RegistrationChecker {
         }
     }
 
+    /// Selects the first enclave whose signer is currently valid on-chain.
     pub async fn select_valid_enclave(&self) -> Result<ValidSigner, RegistrationError> {
         let mut discovered = Vec::new();
         let mut valid_signers = Vec::new();

--- a/crates/proof/tee/nitro-host/src/registration.rs
+++ b/crates/proof/tee/nitro-host/src/registration.rs
@@ -123,12 +123,11 @@ impl RegistrationChecker {
     }
 
     async fn fetch_validity(&self) -> Result<bool, RegistrationError> {
-        let mut any_valid = false;
-        let mut rpc_error = None;
+        let mut first_rpc_error = None;
 
         for (index, transport) in self.transports.iter().enumerate() {
             let signer = match Self::signer_address(transport).await {
-                Ok(signer) => signer,
+                Ok(s) => s,
                 Err(e) => {
                     warn!(error = %e, index, "skipping transport: key fetch failed");
                     continue;
@@ -136,30 +135,18 @@ impl RegistrationChecker {
             };
 
             match self.is_valid_signer(signer).await {
-                Ok(valid) => {
-                    if valid {
-                        any_valid = true;
-                    } else {
-                        warn!(signer = %signer, index, "signer is not a valid signer in TEEProverRegistry");
-                    }
+                Ok(true) => return Ok(true),
+                Ok(false) => {
+                    warn!(signer = %signer, index, "signer not valid in TEEProverRegistry");
                 }
-                Err(e) => {
-                    if rpc_error.is_none() {
-                        rpc_error = Some(e);
-                    }
-                }
-            }
+                Err(e) => drop(first_rpc_error.get_or_insert(e)),
+            };
         }
 
-        if any_valid {
-            return Ok(true);
+        match first_rpc_error {
+            Some(e) => Err(e),
+            None => Ok(false),
         }
-
-        if let Some(error) = rpc_error {
-            return Err(error);
-        }
-
-        Ok(false)
     }
 
     /// Latching health check: returns `true` once the signer has ever been

--- a/crates/proof/tee/nitro-host/src/registration.rs
+++ b/crates/proof/tee/nitro-host/src/registration.rs
@@ -90,15 +90,15 @@ impl std::fmt::Debug for RegistrationChecker {
 impl RegistrationChecker {
     /// Creates a new checker for the given transports and registry client.
     ///
-    /// # Panics
-    ///
-    /// Panics if `transports` is empty.
+    /// Returns an error if `transports` is empty.
     pub fn new(
         transports: Vec<Arc<NitroTransport>>,
         registry: impl TEEProverRegistryClient + 'static,
-    ) -> Self {
-        assert!(!transports.is_empty(), "at least one transport is required");
-        Self { transports, registry: Box::new(registry), healthy: OnceCell::new() }
+    ) -> Result<Self, RegistrationError> {
+        if transports.is_empty() {
+            return Err(RegistrationError::Setup("at least one transport is required".into()));
+        }
+        Ok(Self { transports, registry: Box::new(registry), healthy: OnceCell::new() })
     }
 
     async fn signer_address(transport: &NitroTransport) -> Result<Address, RegistrationError> {
@@ -247,7 +247,7 @@ mod tests {
     ) -> RegistrationChecker {
         let server = Arc::new(base_proof_tee_nitro_enclave::Server::new_local().unwrap());
         let transport = Arc::new(NitroTransport::local(server));
-        RegistrationChecker::new(vec![transport], registry)
+        RegistrationChecker::new(vec![transport], registry).unwrap()
     }
 
     fn test_checker() -> RegistrationChecker {
@@ -258,7 +258,7 @@ mod tests {
             alloy_primitives::Address::ZERO,
             dummy_url,
         );
-        RegistrationChecker::new(vec![transport], registry)
+        RegistrationChecker::new(vec![transport], registry).unwrap()
     }
 
     #[tokio::test]

--- a/crates/proof/tee/nitro-host/src/registration.rs
+++ b/crates/proof/tee/nitro-host/src/registration.rs
@@ -51,6 +51,16 @@ pub enum RegistrationError {
         /// The signer address that failed validation.
         signer: Address,
     },
+    #[error("no valid signer found among: {signers:?}")]
+    NoValidSigner {
+        signers: Vec<Address>,
+    },
+}
+
+#[derive(Debug)]
+pub struct ValidSigner {
+    pub index: usize,
+    pub signer: Address,
 }
 
 /// Checks whether the enclave signer is a **valid** signer in the on-chain
@@ -61,7 +71,7 @@ pub enum RegistrationError {
 /// unnecessary.  A separate latching flag tracks whether the signer has *ever*
 /// been valid — once set, [`check_health`](Self::check_health) always succeeds.
 pub struct RegistrationChecker {
-    transport: Arc<NitroTransport>,
+    transports: Vec<Arc<NitroTransport>>,
     registry: Box<dyn TEEProverRegistryClient>,
     healthy: OnceCell<()>,
 }
@@ -75,15 +85,16 @@ impl std::fmt::Debug for RegistrationChecker {
 impl RegistrationChecker {
     /// Creates a new checker for the given transport and registry client.
     pub fn new(
-        transport: Arc<NitroTransport>,
+        transports: Vec<Arc<NitroTransport>>,
         registry: impl TEEProverRegistryClient + 'static,
     ) -> Self {
-        Self { transport, registry: Box::new(registry), healthy: OnceCell::new() }
+        Self { transports, registry: Box::new(registry), healthy: OnceCell::new() }
     }
 
-    async fn signer_address(&self) -> Result<Address, RegistrationError> {
-        let public_key = self
-            .transport
+    async fn signer_address(
+        transport: &NitroTransport,
+    ) -> Result<Address, RegistrationError> {
+        let public_key = transport
             .signer_public_key()
             .await
             .map_err(|e| RegistrationError::Setup(format!("signer public key: {e}")))?;
@@ -92,22 +103,55 @@ impl RegistrationChecker {
         Ok(public_key_to_address(&verifying_key))
     }
 
-    async fn fetch_validity(&self) -> Result<(bool, Address), RegistrationError> {
-        let signer = self.signer_address().await?;
-
+    async fn is_valid_signer(&self, signer: Address) -> Result<bool, RegistrationError> {
         let result =
             tokio::time::timeout(CHECK_TIMEOUT, self.registry.is_valid_signer(signer)).await;
 
         match result {
-            Ok(Ok(valid)) => {
-                if !valid {
-                    warn!(signer = %signer, "signer is not a valid signer in TEEProverRegistry");
-                }
-                Ok((valid, signer))
-            }
+            Ok(Ok(valid)) => Ok(valid),
             Ok(Err(e)) => Err(RegistrationError::Rpc { signer, reason: e.to_string() }),
             Err(_) => Err(RegistrationError::Rpc { signer, reason: "request timed out".into() }),
         }
+    }
+
+    async fn fetch_validity(&self) -> Result<bool, RegistrationError> {
+        let mut any_valid = false;
+        let mut rpc_error = None;
+
+        for (index, transport) in self.transports.iter().enumerate() {
+            let signer = match Self::signer_address(transport).await {
+                Ok(signer) => signer,
+                Err(e) => {
+                    warn!(error = %e, index, "skipping transport: key fetch failed");
+                    continue;
+                }
+            };
+
+            match self.is_valid_signer(signer).await {
+                Ok(valid) => {
+                    if valid {
+                        any_valid = true;
+                    } else {
+                        warn!(signer = %signer, index, "signer is not a valid signer in TEEProverRegistry");
+                    }
+                }
+                Err(e) => {
+                    if rpc_error.is_none() {
+                        rpc_error = Some(e);
+                    }
+                }
+            }
+        }
+
+        if any_valid {
+            return Ok(true);
+        }
+
+        if let Some(error) = rpc_error {
+            return Err(error);
+        }
+
+        Ok(false)
     }
 
     /// Latching health check: returns `true` once the signer has ever been
@@ -118,7 +162,7 @@ impl RegistrationChecker {
         if self.healthy.get().is_some() {
             return Ok(true);
         }
-        let (valid, _) = self.fetch_validity().await?;
+        let valid = self.fetch_validity().await?;
         if valid {
             let _ = self.healthy.set(());
         }
@@ -130,11 +174,54 @@ impl RegistrationChecker {
     /// Fail-closed: if L1 is unreachable or the signer is not valid, the
     /// proof request is rejected.
     pub async fn require_valid_signer(&self) -> Result<(), RegistrationError> {
-        match self.fetch_validity().await {
-            Ok((true, _)) => Ok(()),
-            Ok((false, signer)) => Err(RegistrationError::NotValid { signer }),
+        let transport = self
+            .transports
+            .first()
+            .ok_or_else(|| RegistrationError::NoValidSigner { signers: Vec::new() })?;
+        let signer = Self::signer_address(transport).await?;
+
+        match self.is_valid_signer(signer).await {
+            Ok(true) => Ok(()),
+            Ok(false) => Err(RegistrationError::NotValid { signer }),
             Err(e) => Err(e),
         }
+    }
+
+    pub async fn select_valid_enclave(&self) -> Result<ValidSigner, RegistrationError> {
+        let mut discovered = Vec::new();
+        let mut valid_signers = Vec::new();
+
+        for (index, transport) in self.transports.iter().enumerate() {
+            let signer = match Self::signer_address(transport).await {
+                Ok(signer) => signer,
+                Err(e) => {
+                    warn!(error = %e, index, "skipping transport: key fetch failed");
+                    continue;
+                }
+            };
+
+            discovered.push(signer);
+
+            match self.is_valid_signer(signer).await {
+                Ok(true) => valid_signers.push(ValidSigner { index, signer }),
+                Ok(false) => {
+                    warn!(signer = %signer, index, "signer is not a valid signer in TEEProverRegistry");
+                }
+                Err(e) => return Err(e),
+            }
+        }
+
+        if valid_signers.is_empty() {
+            return Err(RegistrationError::NoValidSigner { signers: discovered });
+        }
+
+        if valid_signers.len() > 1 {
+            let signers: Vec<Address> =
+                valid_signers.iter().map(|valid| valid.signer).collect();
+            warn!(signers = ?signers, "multiple valid signers found; using first");
+        }
+
+        Ok(valid_signers.remove(0))
     }
 }
 
@@ -152,7 +239,7 @@ mod tests {
     ) -> RegistrationChecker {
         let server = Arc::new(base_proof_tee_nitro_enclave::Server::new_local().unwrap());
         let transport = Arc::new(NitroTransport::local(server));
-        RegistrationChecker::new(transport, registry)
+        RegistrationChecker::new(vec![transport], registry)
     }
 
     fn test_checker() -> RegistrationChecker {
@@ -163,7 +250,7 @@ mod tests {
             alloy_primitives::Address::ZERO,
             dummy_url,
         );
-        RegistrationChecker::new(transport, registry)
+        RegistrationChecker::new(vec![transport], registry)
     }
 
     #[tokio::test]

--- a/crates/proof/tee/nitro-host/src/registration.rs
+++ b/crates/proof/tee/nitro-host/src/registration.rs
@@ -52,9 +52,7 @@ pub enum RegistrationError {
         signer: Address,
     },
     #[error("no valid signer found among: {signers:?}")]
-    NoValidSigner {
-        signers: Vec<Address>,
-    },
+    NoValidSigner { signers: Vec<Address> },
 }
 
 #[derive(Debug)]
@@ -91,9 +89,7 @@ impl RegistrationChecker {
         Self { transports, registry: Box::new(registry), healthy: OnceCell::new() }
     }
 
-    async fn signer_address(
-        transport: &NitroTransport,
-    ) -> Result<Address, RegistrationError> {
+    async fn signer_address(transport: &NitroTransport) -> Result<Address, RegistrationError> {
         let public_key = transport
             .signer_public_key()
             .await
@@ -216,8 +212,7 @@ impl RegistrationChecker {
         }
 
         if valid_signers.len() > 1 {
-            let signers: Vec<Address> =
-                valid_signers.iter().map(|valid| valid.signer).collect();
+            let signers: Vec<Address> = valid_signers.iter().map(|valid| valid.signer).collect();
             warn!(signers = ?signers, "multiple valid signers found; using first");
         }
 

--- a/crates/proof/tee/nitro-host/src/registration.rs
+++ b/crates/proof/tee/nitro-host/src/registration.rs
@@ -139,7 +139,9 @@ impl RegistrationChecker {
                 Ok(false) => {
                     warn!(signer = %signer, index, "signer not valid in TEEProverRegistry");
                 }
-                Err(e) => drop(first_rpc_error.get_or_insert(e)),
+                Err(e) => {
+                    first_rpc_error.get_or_insert(e);
+                }
             };
         }
 
@@ -164,16 +166,14 @@ impl RegistrationChecker {
         Ok(valid)
     }
 
-    /// Fails the request unless the signer is currently valid.
+    /// Fails the request unless the **first** transport's signer is currently
+    /// valid.
     ///
     /// Fail-closed: if L1 is unreachable or the signer is not valid, the
     /// proof request is rejected.
     pub async fn require_valid_signer(&self) -> Result<(), RegistrationError> {
-        let transport = self
-            .transports
-            .first()
-            .ok_or_else(|| RegistrationError::NoValidSigner { signers: Vec::new() })?;
-        let signer = Self::signer_address(transport).await?;
+        // Constructor guarantees at least one transport.
+        let signer = Self::signer_address(&self.transports[0]).await?;
 
         match self.is_valid_signer(signer).await {
             Ok(true) => Ok(()),
@@ -183,13 +183,14 @@ impl RegistrationChecker {
     }
 
     /// Selects the first enclave whose signer is currently valid on-chain.
+    ///
+    /// Returns as soon as a valid signer is found (config order).
     pub async fn select_valid_enclave(&self) -> Result<ValidSigner, RegistrationError> {
         let mut discovered = Vec::new();
-        let mut valid_signers = Vec::new();
 
         for (index, transport) in self.transports.iter().enumerate() {
             let signer = match Self::signer_address(transport).await {
-                Ok(signer) => signer,
+                Ok(s) => s,
                 Err(e) => {
                     warn!(error = %e, index, "skipping transport: key fetch failed");
                     continue;
@@ -199,35 +200,29 @@ impl RegistrationChecker {
             discovered.push(signer);
 
             match self.is_valid_signer(signer).await {
-                Ok(true) => valid_signers.push(ValidSigner { index, signer }),
+                Ok(true) => return Ok(ValidSigner { index, signer }),
                 Ok(false) => {
-                    warn!(signer = %signer, index, "signer is not a valid signer in TEEProverRegistry");
+                    warn!(signer = %signer, index, "signer not valid in TEEProverRegistry");
                 }
                 Err(e) => return Err(e),
             }
         }
 
-        if valid_signers.is_empty() {
-            return Err(RegistrationError::NoValidSigner { signers: discovered });
-        }
-
-        if valid_signers.len() > 1 {
-            let signers: Vec<Address> = valid_signers.iter().map(|valid| valid.signer).collect();
-            warn!(signers = ?signers, "multiple valid signers found; using first");
-        }
-
-        Ok(valid_signers.remove(0))
+        Err(RegistrationError::NoValidSigner { signers: discovered })
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use std::sync::{Arc, atomic::Ordering};
+    use std::{
+        collections::HashMap,
+        sync::{Arc, atomic::Ordering},
+    };
 
     use base_proof_contracts::TEEProverRegistryClient;
 
     use super::*;
-    use crate::test_utils::MockRegistry;
+    use crate::test_utils::{AddressBasedMockRegistry, MockRegistry};
 
     fn test_checker_with_mock(
         registry: impl TEEProverRegistryClient + 'static,
@@ -246,6 +241,28 @@ mod tests {
             dummy_url,
         );
         RegistrationChecker::new(vec![transport], registry).unwrap()
+    }
+
+    fn two_transport_checker(
+        registry: impl TEEProverRegistryClient + 'static,
+    ) -> RegistrationChecker {
+        let s1 = Arc::new(base_proof_tee_nitro_enclave::Server::new_local().unwrap());
+        let s2 = Arc::new(base_proof_tee_nitro_enclave::Server::new_local().unwrap());
+        let t1 = Arc::new(NitroTransport::local(s1));
+        let t2 = Arc::new(NitroTransport::local(s2));
+        RegistrationChecker::new(vec![t1, t2], registry).unwrap()
+    }
+
+    async fn transport_signer_address(transport: &NitroTransport) -> Address {
+        let pk = transport.signer_public_key().await.unwrap();
+        let vk = VerifyingKey::from_sec1_bytes(&pk).unwrap();
+        public_key_to_address(&vk)
+    }
+
+    async fn two_transport_signers(checker: &RegistrationChecker) -> (Address, Address) {
+        let a = transport_signer_address(&checker.transports[0]).await;
+        let b = transport_signer_address(&checker.transports[1]).await;
+        (a, b)
     }
 
     #[tokio::test]
@@ -326,5 +343,91 @@ mod tests {
 
         assert!(checker.require_valid_signer().await.is_ok());
         assert_eq!(call_count.load(Ordering::Relaxed), 2);
+    }
+
+    #[tokio::test]
+    async fn select_first_invalid_second_valid_returns_index_1() {
+        let registry = AddressBasedMockRegistry::new(HashMap::new());
+        let checker = two_transport_checker(registry.clone());
+        let (addr0, addr1) = two_transport_signers(&checker).await;
+
+        registry.validity_map.lock().unwrap().insert(addr0, false);
+        registry.validity_map.lock().unwrap().insert(addr1, true);
+
+        let valid = checker.select_valid_enclave().await.unwrap();
+        assert_eq!(valid.index, 1);
+        assert_eq!(valid.signer, addr1);
+    }
+
+    #[tokio::test]
+    async fn select_both_valid_returns_first() {
+        let registry = AddressBasedMockRegistry::new(HashMap::new());
+        let checker = two_transport_checker(registry.clone());
+        let (addr0, addr1) = two_transport_signers(&checker).await;
+
+        registry.validity_map.lock().unwrap().insert(addr0, true);
+        registry.validity_map.lock().unwrap().insert(addr1, true);
+
+        let valid = checker.select_valid_enclave().await.unwrap();
+        assert_eq!(valid.index, 0);
+        assert_eq!(valid.signer, addr0);
+    }
+
+    #[tokio::test]
+    async fn select_none_valid_returns_no_valid_signer() {
+        let registry = AddressBasedMockRegistry::new(HashMap::new());
+        let checker = two_transport_checker(registry);
+
+        let err = checker.select_valid_enclave().await.unwrap_err();
+        match err {
+            RegistrationError::NoValidSigner { signers } => {
+                assert_eq!(signers.len(), 2);
+            }
+            other => panic!("expected NoValidSigner, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn health_any_valid_returns_true() {
+        let registry = AddressBasedMockRegistry::new(HashMap::new());
+        let checker = two_transport_checker(registry.clone());
+        let (addr0, addr1) = two_transport_signers(&checker).await;
+
+        registry.validity_map.lock().unwrap().insert(addr0, false);
+        registry.validity_map.lock().unwrap().insert(addr1, true);
+
+        assert!(checker.check_health().await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn health_latches_with_multi_transport() {
+        let registry = AddressBasedMockRegistry::new(HashMap::new());
+        let checker = two_transport_checker(registry.clone());
+        let (addr0, addr1) = two_transport_signers(&checker).await;
+
+        registry.validity_map.lock().unwrap().insert(addr0, true);
+        registry.validity_map.lock().unwrap().insert(addr1, false);
+
+        assert!(checker.check_health().await.unwrap());
+
+        registry.validity_map.lock().unwrap().insert(addr0, false);
+        registry.should_fail.store(true, Ordering::Relaxed);
+
+        assert!(checker.check_health().await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn require_valid_signer_checks_first_transport_only() {
+        let registry = AddressBasedMockRegistry::new(HashMap::new());
+        let checker = two_transport_checker(registry.clone());
+        let (addr0, addr1) = two_transport_signers(&checker).await;
+
+        registry.validity_map.lock().unwrap().insert(addr0, false);
+        registry.validity_map.lock().unwrap().insert(addr1, true);
+
+        assert!(matches!(
+            checker.require_valid_signer().await.unwrap_err(),
+            RegistrationError::NotValid { .. }
+        ));
     }
 }

--- a/crates/proof/tee/nitro-host/src/registration.rs
+++ b/crates/proof/tee/nitro-host/src/registration.rs
@@ -88,11 +88,16 @@ impl std::fmt::Debug for RegistrationChecker {
 }
 
 impl RegistrationChecker {
-    /// Creates a new checker for the given transport and registry client.
+    /// Creates a new checker for the given transports and registry client.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `transports` is empty.
     pub fn new(
         transports: Vec<Arc<NitroTransport>>,
         registry: impl TEEProverRegistryClient + 'static,
     ) -> Self {
+        assert!(!transports.is_empty(), "at least one transport is required");
         Self { transports, registry: Box::new(registry), healthy: OnceCell::new() }
     }
 

--- a/crates/proof/tee/nitro-host/src/server.rs
+++ b/crates/proof/tee/nitro-host/src/server.rs
@@ -86,7 +86,7 @@ impl NitroProverServer {
                 let registry =
                     TEEProverRegistryContractClient::new(config.registry_address, l1_url);
                 let checker =
-                    Arc::new(RegistrationChecker::new(Arc::clone(&self.transport), registry));
+                    Arc::new(RegistrationChecker::new(vec![Arc::clone(&self.transport)], registry));
                 module.merge(
                     RegistrationHealthzRpc::new(env!("CARGO_PKG_VERSION"), Arc::clone(&checker))
                         .into_rpc(),

--- a/crates/proof/tee/nitro-host/src/server.rs
+++ b/crates/proof/tee/nitro-host/src/server.rs
@@ -157,6 +157,11 @@ impl ProverApiServer for NitroProverRpc {
 }
 
 /// Inner RPC handler for `enclave_*` methods.
+///
+/// All-or-nothing: both `signer_public_key` and `signer_attestation` fail if
+/// **any** transport is unreachable.  Callers need the complete set of keys /
+/// attestations (one per enclave) to register all signers on-chain, so a
+/// partial response would be unusable.
 struct NitroSignerRpc {
     transports: Vec<Arc<NitroTransport>>,
 }

--- a/crates/proof/tee/nitro-host/src/server.rs
+++ b/crates/proof/tee/nitro-host/src/server.rs
@@ -85,8 +85,10 @@ impl NitroProverServer {
                     .map_err(|e| eyre::eyre!("invalid L1 RPC URL: {e}"))?;
                 let registry =
                     TEEProverRegistryContractClient::new(config.registry_address, l1_url);
-                let checker =
-                    Arc::new(RegistrationChecker::new(vec![Arc::clone(&self.transport)], registry));
+                let checker = Arc::new(
+                    RegistrationChecker::new(vec![Arc::clone(&self.transport)], registry)
+                        .map_err(|e| eyre::eyre!("registration checker init failed: {e}"))?,
+                );
                 module.merge(
                     RegistrationHealthzRpc::new(env!("CARGO_PKG_VERSION"), Arc::clone(&checker))
                         .into_rpc(),

--- a/crates/proof/tee/nitro-host/src/server.rs
+++ b/crates/proof/tee/nitro-host/src/server.rs
@@ -108,7 +108,12 @@ impl NitroProverServer {
             .into_rpc(),
         )?;
 
-        module.merge(NitroSignerRpc { transport: Arc::clone(&self.transport) }.into_rpc())?;
+        module.merge(
+            NitroSignerRpc {
+                transports: vec![Arc::clone(&self.transport)],
+            }
+            .into_rpc(),
+        )?;
 
         Ok(server.start(module))
     }
@@ -155,16 +160,20 @@ impl ProverApiServer for NitroProverRpc {
 
 /// Inner RPC handler for `enclave_*` methods.
 struct NitroSignerRpc {
-    transport: Arc<NitroTransport>,
+    transports: Vec<Arc<NitroTransport>>,
 }
 
 #[async_trait]
 impl EnclaveApiServer for NitroSignerRpc {
     async fn signer_public_key(&self) -> RpcResult<Vec<Vec<u8>>> {
-        let key = self.transport.signer_public_key().await.map_err(|e| {
-            jsonrpsee::types::ErrorObjectOwned::owned(-32001, e.to_string(), None::<()>)
-        })?;
-        Ok(vec![key])
+        let mut keys = Vec::with_capacity(self.transports.len());
+        for transport in &self.transports {
+            let key = transport.signer_public_key().await.map_err(|e| {
+                jsonrpsee::types::ErrorObjectOwned::owned(-32001, e.to_string(), None::<()>)
+            })?;
+            keys.push(key);
+        }
+        Ok(keys)
     }
 
     async fn signer_attestation(
@@ -190,11 +199,17 @@ impl EnclaveApiServer for NitroSignerRpc {
             ));
         }
 
-        let attestation =
-            self.transport.signer_attestation(user_data, nonce).await.map_err(|e| {
-                jsonrpsee::types::ErrorObjectOwned::owned(-32001, e.to_string(), None::<()>)
-            })?;
-        Ok(vec![attestation])
+        let mut attestations = Vec::with_capacity(self.transports.len());
+        for transport in &self.transports {
+            let attestation = transport
+                .signer_attestation(user_data.clone(), nonce.clone())
+                .await
+                .map_err(|e| {
+                    jsonrpsee::types::ErrorObjectOwned::owned(-32001, e.to_string(), None::<()>)
+                })?;
+            attestations.push(attestation);
+        }
+        Ok(attestations)
     }
 }
 
@@ -211,7 +226,9 @@ mod tests {
         let transport = Arc::new(NitroTransport::local(Arc::clone(&server)));
         let expected = server.signer_public_key();
 
-        let rpc = NitroSignerRpc { transport };
+        let rpc = NitroSignerRpc {
+            transports: vec![transport],
+        };
         let result = EnclaveApiServer::signer_public_key(&rpc).await.unwrap();
         assert_eq!(result.len(), 1);
         assert_eq!(result[0], expected);
@@ -231,7 +248,9 @@ mod tests {
         let server = Arc::new(EnclaveServer::new_local().unwrap());
         let transport = Arc::new(NitroTransport::local(Arc::clone(&server)));
 
-        let rpc = NitroSignerRpc { transport };
+        let rpc = NitroSignerRpc {
+            transports: vec![transport],
+        };
         // NSM is unavailable outside a real Nitro enclave, so attestation fails.
         // Assert the error is propagated (not swallowed) through the RPC layer.
         let result = EnclaveApiServer::signer_attestation(&rpc, None, None).await;
@@ -242,7 +261,9 @@ mod tests {
     async fn signer_attestation_rejects_oversized_user_data() {
         let server = Arc::new(EnclaveServer::new_local().unwrap());
         let transport = Arc::new(NitroTransport::local(Arc::clone(&server)));
-        let rpc = NitroSignerRpc { transport };
+        let rpc = NitroSignerRpc {
+            transports: vec![transport],
+        };
 
         let oversized = vec![0u8; MAX_USER_DATA_BYTES + 1];
         let result = EnclaveApiServer::signer_attestation(&rpc, Some(oversized), None).await;
@@ -255,7 +276,9 @@ mod tests {
     async fn signer_attestation_rejects_oversized_nonce() {
         let server = Arc::new(EnclaveServer::new_local().unwrap());
         let transport = Arc::new(NitroTransport::local(Arc::clone(&server)));
-        let rpc = NitroSignerRpc { transport };
+        let rpc = NitroSignerRpc {
+            transports: vec![transport],
+        };
 
         let oversized = vec![0u8; MAX_NONCE_BYTES + 1];
         let result = EnclaveApiServer::signer_attestation(&rpc, None, Some(oversized)).await;

--- a/crates/proof/tee/nitro-host/src/server.rs
+++ b/crates/proof/tee/nitro-host/src/server.rs
@@ -108,12 +108,8 @@ impl NitroProverServer {
             .into_rpc(),
         )?;
 
-        module.merge(
-            NitroSignerRpc {
-                transports: vec![Arc::clone(&self.transport)],
-            }
-            .into_rpc(),
-        )?;
+        module
+            .merge(NitroSignerRpc { transports: vec![Arc::clone(&self.transport)] }.into_rpc())?;
 
         Ok(server.start(module))
     }
@@ -226,9 +222,7 @@ mod tests {
         let transport = Arc::new(NitroTransport::local(Arc::clone(&server)));
         let expected = server.signer_public_key();
 
-        let rpc = NitroSignerRpc {
-            transports: vec![transport],
-        };
+        let rpc = NitroSignerRpc { transports: vec![transport] };
         let result = EnclaveApiServer::signer_public_key(&rpc).await.unwrap();
         assert_eq!(result.len(), 1);
         assert_eq!(result[0], expected);
@@ -248,9 +242,7 @@ mod tests {
         let server = Arc::new(EnclaveServer::new_local().unwrap());
         let transport = Arc::new(NitroTransport::local(Arc::clone(&server)));
 
-        let rpc = NitroSignerRpc {
-            transports: vec![transport],
-        };
+        let rpc = NitroSignerRpc { transports: vec![transport] };
         // NSM is unavailable outside a real Nitro enclave, so attestation fails.
         // Assert the error is propagated (not swallowed) through the RPC layer.
         let result = EnclaveApiServer::signer_attestation(&rpc, None, None).await;
@@ -261,9 +253,7 @@ mod tests {
     async fn signer_attestation_rejects_oversized_user_data() {
         let server = Arc::new(EnclaveServer::new_local().unwrap());
         let transport = Arc::new(NitroTransport::local(Arc::clone(&server)));
-        let rpc = NitroSignerRpc {
-            transports: vec![transport],
-        };
+        let rpc = NitroSignerRpc { transports: vec![transport] };
 
         let oversized = vec![0u8; MAX_USER_DATA_BYTES + 1];
         let result = EnclaveApiServer::signer_attestation(&rpc, Some(oversized), None).await;
@@ -276,9 +266,7 @@ mod tests {
     async fn signer_attestation_rejects_oversized_nonce() {
         let server = Arc::new(EnclaveServer::new_local().unwrap());
         let transport = Arc::new(NitroTransport::local(Arc::clone(&server)));
-        let rpc = NitroSignerRpc {
-            transports: vec![transport],
-        };
+        let rpc = NitroSignerRpc { transports: vec![transport] };
 
         let oversized = vec![0u8; MAX_NONCE_BYTES + 1];
         let result = EnclaveApiServer::signer_attestation(&rpc, None, Some(oversized)).await;

--- a/crates/proof/tee/nitro-host/src/test_utils.rs
+++ b/crates/proof/tee/nitro-host/src/test_utils.rs
@@ -1,8 +1,11 @@
 //! Shared test utilities for the `base-proof-tee-nitro-host` crate.
 
-use std::sync::{
-    Arc,
-    atomic::{AtomicBool, AtomicUsize, Ordering},
+use std::{
+    collections::HashMap,
+    sync::{
+        Arc, Mutex,
+        atomic::{AtomicBool, AtomicUsize, Ordering},
+    },
 };
 
 use alloy_primitives::Address;
@@ -44,6 +47,56 @@ impl TEEProverRegistryClient for MockRegistry {
             return Err(base_proof_contracts::ContractError::Validation("mock RPC failure".into()));
         }
         Ok(self.valid.load(Ordering::Relaxed))
+    }
+
+    async fn is_registered_signer(
+        &self,
+        _signer: Address,
+    ) -> Result<bool, base_proof_contracts::ContractError> {
+        unimplemented!()
+    }
+
+    async fn get_registered_signers(
+        &self,
+    ) -> Result<Vec<Address>, base_proof_contracts::ContractError> {
+        unimplemented!()
+    }
+}
+
+/// Mock registry that returns different validity per signer address.
+#[derive(Debug, Clone)]
+pub struct AddressBasedMockRegistry {
+    /// Per-address validity map; addresses not in the map default to `false`.
+    pub validity_map: Arc<Mutex<HashMap<Address, bool>>>,
+    /// Number of times `is_valid_signer` has been called.
+    pub call_count: Arc<AtomicUsize>,
+    /// When `true`, all calls return an error.
+    pub should_fail: Arc<AtomicBool>,
+}
+
+impl AddressBasedMockRegistry {
+    /// Creates a new mock with the given per-address validity map.
+    pub fn new(validity_map: HashMap<Address, bool>) -> Self {
+        Self {
+            validity_map: Arc::new(Mutex::new(validity_map)),
+            call_count: Arc::new(AtomicUsize::new(0)),
+            should_fail: Arc::new(AtomicBool::new(false)),
+        }
+    }
+}
+
+#[async_trait]
+impl TEEProverRegistryClient for AddressBasedMockRegistry {
+    async fn is_valid_signer(
+        &self,
+        signer: Address,
+    ) -> Result<bool, base_proof_contracts::ContractError> {
+        self.call_count.fetch_add(1, Ordering::Relaxed);
+        if self.should_fail.load(Ordering::Relaxed) {
+            return Err(base_proof_contracts::ContractError::Validation("mock RPC failure".into()));
+        }
+        let map = self.validity_map.lock().expect("validity map poisoned");
+        Ok(map.get(&signer).copied().unwrap_or(false))
     }
 
     async fn is_registered_signer(


### PR DESCRIPTION
## Summary (Stack 1/3)

Foundation for dual-enclave support. Changes `RegistrationChecker` and `NitroSignerRpc` to accept multiple enclave transports.

### `registration.rs`
- `RegistrationChecker::new()` accepts `Vec<Arc<NitroTransport>>`
- New `ValidSigner { index, signer }` struct
- New `select_valid_enclave()` — iterates transports, queries `isValidSigner`, returns first valid
- New `NoValidSigner` error variant
- `check_health()` returns true if ANY transport's signer is valid (then latches)
- `require_valid_signer()` preserved for backward compat (uses first transport)

### `server.rs`
- `NitroSignerRpc` holds `Vec<Arc<NitroTransport>>`
- `signer_public_key()` / `signer_attestation()` aggregate from all transports

### Stack
- **→ [1/3] Multi-transport foundation** (this PR)
- [2/3] Prove routing + tests
- [3/3] CLI wiring