### PR TITLE
feat(nitro-host): CLI multi-CID support + docs [3/3]

### DIFF
--- a/bin/prover/nitro-host/src/cli.rs
+++ b/bin/prover/nitro-host/src/cli.rs
@@ -24,7 +24,7 @@ use clap::{Parser, Subcommand};
 #[cfg(any(target_os = "linux", feature = "local"))]
 use eyre::eyre;
 #[cfg(any(target_os = "linux", feature = "local"))]
-use tracing::info;
+use tracing::{info, warn};
 
 base_cli_utils::define_log_args!("BASE_PROVER_NITRO_HOST");
 base_cli_utils::define_metrics_args!("BASE_PROVER_NITRO_HOST", 7300);
@@ -115,8 +115,8 @@ struct ServerArgs {
     server: ProverServerArgs,
 
     /// Vsock CID of the enclave.
-    #[arg(long, env = "VSOCK_CID")]
-    vsock_cid: u32,
+    #[arg(long, env = "VSOCK_CID", value_delimiter = ',')]
+    vsock_cid: Vec<u32>,
 }
 
 impl Cli {
@@ -161,13 +161,23 @@ impl ServerArgs {
             enable_experimental_witness_endpoint: self.server.enable_experimental_witness_endpoint,
         };
 
-        let transport = Arc::new(NitroTransport::vsock(self.vsock_cid, VSOCK_PORT));
+        let transports: Vec<Arc<NitroTransport>> = self
+            .vsock_cid
+            .iter()
+            .map(|&cid| Arc::new(NitroTransport::vsock(cid, VSOCK_PORT)))
+            .collect();
+        if transports.len() > 1 && self.server.tee_prover_registry_address.is_none() {
+            return Err(eyre!(
+                "multi-CID requires --tee-prover-registry-address for on-chain routing"
+            ));
+        }
         let timeout = Duration::from_secs(self.server.proof_request_timeout_secs);
-        let mut server = NitroProverServer::new(config, transport, timeout);
+        let mut server = NitroProverServer::new_multi(config, transports, timeout);
         if let Some(reg) = registration_health {
             server = server.with_registration_health(reg);
         }
 
+        info!(cids = ?self.vsock_cid, "configured vsock CIDs");
         info!(addr = %self.server.listen_addr, "starting nitro prover host server");
         let handle = server.run(self.server.listen_addr).await?;
         handle.stopped().await;
@@ -181,6 +191,9 @@ impl ServerArgs {
 struct LocalArgs {
     #[command(flatten)]
     server: ProverServerArgs,
+
+    #[arg(long, env = "LOCAL_ENCLAVE_COUNT", default_value = "1")]
+    local_enclave_count: usize,
 }
 
 #[cfg(feature = "local")]
@@ -206,10 +219,20 @@ impl LocalArgs {
             enable_experimental_witness_endpoint: self.server.enable_experimental_witness_endpoint,
         };
 
-        let enclave_server = Arc::new(EnclaveServer::new_local()?);
-        let transport = Arc::new(NitroTransport::local(enclave_server));
+        let transports: Vec<Arc<NitroTransport>> = (0..self.local_enclave_count)
+            .map(|_| {
+                let server = Arc::new(EnclaveServer::new_local()?);
+                Ok(Arc::new(NitroTransport::local(server)))
+            })
+            .collect::<eyre::Result<Vec<_>>>()?;
+        if self.local_enclave_count > 1 && self.server.tee_prover_registry_address.is_none() {
+            warn!(
+                count = self.local_enclave_count,
+                "multiple local enclaves without registry; defaulting to index 0 for routing"
+            );
+        }
         let timeout = Duration::from_secs(self.server.proof_request_timeout_secs);
-        let mut server = NitroProverServer::new(prover_config, transport, timeout);
+        let mut server = NitroProverServer::new_multi(prover_config, transports, timeout);
         if let Some(reg) = registration_health {
             server = server.with_registration_health(reg);
         }

--- a/bin/prover/nitro-host/src/cli.rs
+++ b/bin/prover/nitro-host/src/cli.rs
@@ -24,7 +24,9 @@ use clap::{Parser, Subcommand};
 #[cfg(any(target_os = "linux", feature = "local"))]
 use eyre::eyre;
 #[cfg(any(target_os = "linux", feature = "local"))]
-use tracing::{info, warn};
+use tracing::info;
+#[cfg(feature = "local")]
+use tracing::warn;
 
 base_cli_utils::define_log_args!("BASE_PROVER_NITRO_HOST");
 base_cli_utils::define_metrics_args!("BASE_PROVER_NITRO_HOST", 7300);
@@ -114,7 +116,7 @@ struct ServerArgs {
     #[command(flatten)]
     server: ProverServerArgs,
 
-    /// Vsock CID of the enclave.
+    /// Vsock CID(s) of the enclave(s), comma-separated for multi-enclave mode.
     #[arg(long, env = "VSOCK_CID", value_delimiter = ',')]
     vsock_cid: Vec<u32>,
 }
@@ -161,16 +163,19 @@ impl ServerArgs {
             enable_experimental_witness_endpoint: self.server.enable_experimental_witness_endpoint,
         };
 
+        if self.vsock_cid.is_empty() {
+            return Err(eyre!("at least one --vsock-cid is required"));
+        }
+        if self.vsock_cid.len() > 1 && self.server.tee_prover_registry_address.is_none() {
+            return Err(eyre!(
+                "multi-CID requires --tee-prover-registry-address for on-chain routing"
+            ));
+        }
         let transports: Vec<Arc<NitroTransport>> = self
             .vsock_cid
             .iter()
             .map(|&cid| Arc::new(NitroTransport::vsock(cid, VSOCK_PORT)))
             .collect();
-        if transports.len() > 1 && self.server.tee_prover_registry_address.is_none() {
-            return Err(eyre!(
-                "multi-CID requires --tee-prover-registry-address for on-chain routing"
-            ));
-        }
         let timeout = Duration::from_secs(self.server.proof_request_timeout_secs);
         let mut server = NitroProverServer::new_multi(config, transports, timeout);
         if let Some(reg) = registration_health {
@@ -192,6 +197,7 @@ struct LocalArgs {
     #[command(flatten)]
     server: ProverServerArgs,
 
+    /// Number of local enclave instances to run (minimum 1).
     #[arg(long, env = "LOCAL_ENCLAVE_COUNT", default_value = "1")]
     local_enclave_count: usize,
 }
@@ -219,6 +225,9 @@ impl LocalArgs {
             enable_experimental_witness_endpoint: self.server.enable_experimental_witness_endpoint,
         };
 
+        if self.local_enclave_count == 0 {
+            return Err(eyre!("--local-enclave-count must be at least 1"));
+        }
         let transports: Vec<Arc<NitroTransport>> = (0..self.local_enclave_count)
             .map(|_| {
                 let server = Arc::new(EnclaveServer::new_local()?);

--- a/bin/prover/nitro-host/src/cli.rs
+++ b/bin/prover/nitro-host/src/cli.rs
@@ -228,18 +228,18 @@ impl LocalArgs {
         if self.local_enclave_count == 0 {
             return Err(eyre!("--local-enclave-count must be at least 1"));
         }
-        let transports: Vec<Arc<NitroTransport>> = (0..self.local_enclave_count)
-            .map(|_| {
-                let server = Arc::new(EnclaveServer::new_local()?);
-                Ok(Arc::new(NitroTransport::local(server)))
-            })
-            .collect::<eyre::Result<Vec<_>>>()?;
         if self.local_enclave_count > 1 && self.server.tee_prover_registry_address.is_none() {
             warn!(
                 count = self.local_enclave_count,
                 "multiple local enclaves without registry; defaulting to index 0 for routing"
             );
         }
+        let transports: Vec<Arc<NitroTransport>> = (0..self.local_enclave_count)
+            .map(|_| {
+                let server = Arc::new(EnclaveServer::new_local()?);
+                Ok(Arc::new(NitroTransport::local(server)))
+            })
+            .collect::<eyre::Result<Vec<_>>>()?;
         let timeout = Duration::from_secs(self.server.proof_request_timeout_secs);
         let mut server = NitroProverServer::new_multi(prover_config, transports, timeout);
         if let Some(reg) = registration_health {


### PR DESCRIPTION
## Summary (Stack 3/3)

CLI wiring and documentation. Stacked on #2257.

### \`cli.rs\`
- \`--vsock-cid\` accepts \`Vec<u32>\` with \`value_delimiter = ','\` (e.g. \`--vsock-cid 16,17\`)
- Multi-CID without \`--tee-prover-registry-address\` fails fast with clear error
- Uses \`NitroProverServer::new_multi()\` for both server and local modes
- Local mode: \`--local-enclave-count N\` (default 1)

### Doc comments
- \`ValidSigner\`, \`NoValidSigner\`, \`select_valid_enclave()\`, \`new_multi()\`

### Companion PR
- Deployment: https://coinbase.ghe.com/protocols/base-proofs/pull/158

### Verification
- \`cargo check -p base-prover-nitro-host --features local\` ✓
- \`cargo test -p base-proof-tee-nitro-host\` ✓ (26/26 pass)

### Stack
- [1/3] Multi-transport foundation (#2256)
- [2/3] Prove routing + tests (#2257)
- **→ [3/3] CLI wiring + docs** (this PR)