### PR TITLE
fix(basectl): Recover From Load Test Errors

### DIFF
--- a/crates/infra/basectl/src/app/views/load_test.rs
+++ b/crates/infra/basectl/src/app/views/load_test.rs
@@ -939,23 +939,29 @@ impl View for LoadTestView {
         match key.code {
             // Network selection — only while idle.
             KeyCode::Left | KeyCode::Char('h')
-                if matches!(self.state, RunState::Idle | RunState::Complete { .. } | RunState::Error(_))
-                    && !self.configs.is_empty() =>
+                if matches!(
+                    self.state,
+                    RunState::Idle | RunState::Complete { .. } | RunState::Error(_)
+                ) && !self.configs.is_empty() =>
             {
                 let n = self.configs.len();
                 self.selected = (self.selected + n - 1) % n;
             }
             KeyCode::Right | KeyCode::Char('l')
-                if matches!(self.state, RunState::Idle | RunState::Complete { .. } | RunState::Error(_))
-                    && !self.configs.is_empty() =>
+                if matches!(
+                    self.state,
+                    RunState::Idle | RunState::Complete { .. } | RunState::Error(_)
+                ) && !self.configs.is_empty() =>
             {
                 self.selected = (self.selected + 1) % self.configs.len();
             }
 
             // Begin single run.
             KeyCode::Char('b')
-                if matches!(self.state, RunState::Idle | RunState::Complete { .. } | RunState::Error(_))
-                    && !self.configs.is_empty() =>
+                if matches!(
+                    self.state,
+                    RunState::Idle | RunState::Complete { .. } | RunState::Error(_)
+                ) && !self.configs.is_empty() =>
             {
                 self.continuous = false;
                 self.state = RunState::Idle;
@@ -964,8 +970,10 @@ impl View for LoadTestView {
 
             // Begin continuous run.
             KeyCode::Char('c')
-                if matches!(self.state, RunState::Idle | RunState::Complete { .. } | RunState::Error(_))
-                    && !self.configs.is_empty() =>
+                if matches!(
+                    self.state,
+                    RunState::Idle | RunState::Complete { .. } | RunState::Error(_)
+                ) && !self.configs.is_empty() =>
             {
                 self.continuous = true;
                 self.state = RunState::Idle;

--- a/crates/infra/basectl/src/app/views/load_test.rs
+++ b/crates/infra/basectl/src/app/views/load_test.rs
@@ -939,14 +939,14 @@ impl View for LoadTestView {
         match key.code {
             // Network selection — only while idle.
             KeyCode::Left | KeyCode::Char('h')
-                if matches!(self.state, RunState::Idle | RunState::Complete { .. })
+                if matches!(self.state, RunState::Idle | RunState::Complete { .. } | RunState::Error(_))
                     && !self.configs.is_empty() =>
             {
                 let n = self.configs.len();
                 self.selected = (self.selected + n - 1) % n;
             }
             KeyCode::Right | KeyCode::Char('l')
-                if matches!(self.state, RunState::Idle | RunState::Complete { .. })
+                if matches!(self.state, RunState::Idle | RunState::Complete { .. } | RunState::Error(_))
                     && !self.configs.is_empty() =>
             {
                 self.selected = (self.selected + 1) % self.configs.len();
@@ -954,7 +954,7 @@ impl View for LoadTestView {
 
             // Begin single run.
             KeyCode::Char('b')
-                if matches!(self.state, RunState::Idle | RunState::Complete { .. })
+                if matches!(self.state, RunState::Idle | RunState::Complete { .. } | RunState::Error(_))
                     && !self.configs.is_empty() =>
             {
                 self.continuous = false;
@@ -964,7 +964,7 @@ impl View for LoadTestView {
 
             // Begin continuous run.
             KeyCode::Char('c')
-                if matches!(self.state, RunState::Idle | RunState::Complete { .. })
+                if matches!(self.state, RunState::Idle | RunState::Complete { .. } | RunState::Error(_))
                     && !self.configs.is_empty() =>
             {
                 self.continuous = true;


### PR DESCRIPTION
## Summary

When the load test TUI entered `RunState::Error`, the key handlers for `[b]` (begin), `[c]` (continuous), and `[←/→]` (network select) all guarded against `RunState::Idle | RunState::Complete` only, so keypresses were silently dropped despite the UI prompting "Press [b] to try again". This adds `RunState::Error(_)` to those guards so the retry and network-select keys work correctly after a configuration or runtime error.