### PR TITLE
chore(workspace): Sort Cargo Deps Waterfall Style

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,16 +52,7 @@ members = [
   "actions/*",
 ]
 default-members = [
-  "bin/based",
-  "bin/node",
-  "bin/basectl",
-  "bin/builder",
-  "bin/challenger",
-  "bin/consensus",
-  "bin/ingress-rpc",
-  "bin/audit-archiver",
-  "bin/mempool-rebroadcaster",
-  "bin/proposer",
+  "bin/*",
   "bin/prover/nitro-host",
   "bin/prover/nitro-enclave",
   "bin/prover/zk",
@@ -157,11 +148,11 @@ incremental = false
 # Base Primitives
 base-bundles = { path = "crates/common/bundles" }
 base-common-signer = { path = "crates/common/signer" }
+base-common-chains = { path = "crates/common/chains" }
 base-common-network = { path = "crates/common/network" }
 base-common-provider = { path = "crates/common/provider" }
-base-common-chains = { path = "crates/common/chains" }
-base-common-rpc-types = { path = "crates/common/rpc-types" }
 base-access-lists = { path = "crates/common/access-lists" }
+base-common-rpc-types = { path = "crates/common/rpc-types" }
 base-common-flashblocks = { path = "crates/common/flashblocks" }
 base-common-evm = { path = "crates/common/evm", default-features = false }
 base-common-flz = { path = "crates/common/flz", default-features = false }
@@ -174,11 +165,11 @@ base-builder-publish = { path = "crates/builder/publish" }
 base-builder-metering = { path = "crates/builder/metering" }
 
 # Client
-base-bundle-extension = { path = "crates/client/bundle" }
 base-client-cli = { path = "crates/client/cli" }
 base-metering = { path = "crates/client/metering" }
-base-tx-forwarding = { path = "crates/client/tx-forwarding" }
+base-bundle-extension = { path = "crates/client/bundle" }
 base-proofs-extension = { path = "crates/client/proofs" }
+base-tx-forwarding = { path = "crates/client/tx-forwarding" }
 base-txpool-tracing = { path = "crates/client/txpool-tracing" }
 base-flashblocks-node = { path = "crates/client/flashblocks-node" }
 
@@ -209,9 +200,9 @@ base-execution-trie = { path = "crates/execution/trie" }
 base-txpool-rpc = { path = "crates/execution/txpool-rpc" }
 base-engine-tree = { path = "crates/execution/engine-tree" }
 base-flashblocks = { path = "crates/execution/flashblocks" }
-base-execution-upgrades = { path = "crates/execution/upgrades" }
-base-execution-storage = { path = "crates/execution/storage" }
 base-execution-txpool = { path = "crates/execution/txpool" }
+base-execution-storage = { path = "crates/execution/storage" }
+base-execution-upgrades = { path = "crates/execution/upgrades" }
 base-execution-chainspec = { path = "crates/execution/chainspec" }
 base-execution-consensus = { path = "crates/execution/consensus" }
 base-execution-payload-builder = { path = "crates/execution/payload" }
@@ -219,8 +210,8 @@ base-execution-payload-builder = { path = "crates/execution/payload" }
 # Infra
 based = { path = "crates/infra/based" }
 basectl-cli = { path = "crates/infra/basectl" }
-base-load-tests = { path = "crates/infra/load-tests" }
 audit-archiver-lib = { path = "crates/infra/audit" }
+base-load-tests = { path = "crates/infra/load-tests" }
 ingress-rpc-lib = { path = "crates/infra/ingress-rpc" }
 websocket-proxy = { path = "crates/infra/websocket-proxy" }
 mempool-rebroadcaster = { path = "crates/infra/mempool-rebroadcaster" }
@@ -234,14 +225,13 @@ base-zk-outbox = { path = "crates/proof/zk/outbox" }
 base-challenger = { path = "crates/proof/challenge" }
 base-zk-service = { path = "crates/proof/zk/service" }
 base-proof-contracts = { path = "crates/proof/contracts" }
-base-proof-tee-nitro-host = { path = "crates/proof/tee/nitro-host" }
-base-proof-tee-nitro-enclave = { path = "crates/proof/tee/nitro-enclave" }
 base-proof-tee-registrar = { path = "crates/proof/tee/registrar" }
+base-proof-tee-nitro-host = { path = "crates/proof/tee/nitro-host" }
 base-proof = { path = "crates/proof/proof", default-features = false }
 base-proof-mpt = { path = "crates/proof/mpt", default-features = false }
+base-proof-tee-nitro-enclave = { path = "crates/proof/tee/nitro-enclave" }
 base-proof-host = { path = "crates/proof/host", default-features = false }
 base-proof-tee-nitro-verifier = { path = "crates/proof/tee/nitro-verifier" }
-base-proof-tee-nitro-attestation-prover = { path = "crates/proof/tee/nitro-attestation-prover" }
 base-proof-client = { path = "crates/proof/client", default-features = false }
 base-proof-driver = { path = "crates/proof/driver", default-features = false }
 base-proof-executor = { path = "crates/proof/executor", default-features = false }
@@ -249,6 +239,7 @@ base-proof-preimage = { path = "crates/proof/preimage", default-features = false
 base-proof-std-fpvm = { path = "crates/proof/std-fpvm", default-features = false }
 base-proof-primitives = { path = "crates/proof/primitives", default-features = false }
 base-proof-std-fpvm-proc = { path = "crates/proof/std-fpvm-proc", default-features = false }
+base-proof-tee-nitro-attestation-prover = { path = "crates/proof/tee/nitro-attestation-prover" }
 base-proof-fpvm-precompiles = { path = "crates/proof/fpvm-precompiles", default-features = false }
 
 # Actions
@@ -287,27 +278,27 @@ revm-context-interface = { version = "14.0.0", default-features = false }
 alloy-signer = "1.8"
 alloy-pubsub = "1.8"
 alloy-network = "1.8"
-alloy-eip7928 = "0.3.0"
 alloy-provider = "1.8"
 alloy-contract = "1.8"
 alloy-json-rpc = "1.8"
+alloy-eip7928 = "0.3.0"
 alloy-transport = "1.8"
 alloy-rpc-types = "1.8"
+alloy-rpc-client = "1.8"
 alloy-hardforks = "0.4.5"
 alloy-sol-macro = "1.5.6"
-alloy-rpc-client = "1.8"
 alloy-signer-local = "1.8"
+alloy-transport-ws = "1.8"
 alloy-node-bindings = "1.8"
 alloy-transport-http = "1.8"
-alloy-transport-ws = "1.8"
 alloy-rpc-types-beacon = "1.8"
+alloy-eips = { version = "1.8", default-features = false }
+alloy-serde = { version = "1.8", default-features = false }
 alloy-rlp = { version = "0.3.13", default-features = false }
 alloy-trie = { version = "0.9.4", default-features = false }
-alloy-eips = { version = "1.8", default-features = false }
 alloy-evm = { version = "0.27.2", default-features = false }
-alloy-serde = { version = "1.8", default-features = false }
-alloy-chains = { version = "0.2.5", default-features = false }
 alloy-genesis = { version = "1.8", default-features = false }
+alloy-chains = { version = "0.2.5", default-features = false }
 alloy-consensus = { version = "1.8", default-features = false }
 alloy-sol-types = { version = "1.5.6", default-features = false }
 alloy-primitives = { version = "1.5.6", default-features = false }
@@ -417,12 +408,12 @@ tracing-subscriber = "0.3.22"
 tracing = { version = "0.1.43", default-features = false }
 
 # Metrics
+ordered-float = "5"
 metrics-derive = "0.1.1"
 metrics = { version = "0.24.3", default-features = false }
+metrics-util = { version = "0.20.1", default-features = false }
 metrics-process = { version = "2.4.3", default-features = false }
 metrics-exporter-prometheus = { version = "0.18.1", default-features = false }
-metrics-util = { version = "0.20.1", default-features = false }
-ordered-float = "5"
 
 # aws
 aws-nitro-enclaves-cose = "0.5"
@@ -459,8 +450,8 @@ tower = "0.5"
 http-body = "1.0"
 hyper-util = "0.1.11"
 http-body-util = "0.1.3"
-tower-http = { version = "0.6", features = ["limit", "timeout"] }
 axum = { version = "0.8.3", default-features = false }
+tower-http = { version = "0.6", features = ["limit", "timeout"] }
 
 # p2p
 discv5 = "0.10"
@@ -496,6 +487,7 @@ testcontainers-modules = { version = "0.15", default-features = false }
 
 # misc
 snap = "1"
+redb = "2"
 hex = "0.4"
 url = "2.5"
 libc = "0.2"
@@ -503,6 +495,7 @@ ctor = "0.6"
 eyre = "0.6"
 lru = "0.16"
 rand = "0.9"
+rkyv = "0.8"
 moka = "0.12"
 vsock = "0.5"
 uuid = "1.21"
@@ -510,9 +503,7 @@ dirs = "6.0.0"
 anyhow = "1.0"
 rayon = "1.11"
 nanoid = "0.4"
-strum = { version = "0.27", default-features = false }
 tar = "0.4.44"
-rkyv = "0.8"
 backon = "1.6"
 time = "0.3.44"
 base64 = "0.22"
@@ -529,7 +520,6 @@ ratatui = "0.30.0"
 crossterm = "0.29"
 indicatif = "0.18"
 arc-swap = "1.7.1"
-tracing-indicatif = "0.3"
 tokio-vsock = "0.7"
 hex-literal = "1.1"
 auto_impl = "1.2.0"
@@ -539,15 +529,16 @@ ambassador = "0.4.2"
 miniz_oxide = "0.9.0"
 parking_lot = "0.12.3"
 opentelemetry = "0.31"
+tracing-indicatif = "0.3"
 tikv-jemallocator = "0.6"
 concurrent-queue = "2.5.0"
 modular-bitfield = "0.13.1"
 crossbeam-channel = "0.5.13"
 rand_08 = { package = "rand", version = "0.8" }
 zip = { version = "8.1", default-features = false }
+strum = { version = "0.27", default-features = false }
 hashbrown = { version = "0.16", features = ["rayon"] }
 brotli = { version = "8.0.2", default-features = false }
-redb = "2"
 rocksdb = { version = "0.24", default-features = false }
 rdkafka = { version = "0.39", default-features = false }
 thiserror = { version = "2.0", default-features = false }


### PR DESCRIPTION
## Summary

Sorts workspace dependency declarations in the root `Cargo.toml` by line length (waterfall style) to match the project's established convention. Also simplifies the `default-members` list by replacing the explicit per-binary entries with a `bin/*` glob. No functional changes are made; this is purely organizational cleanup.