### PR TITLE
chore(docs): Update Base Types

### DIFF
--- a/actions/harness/src/matrix.rs
+++ b/actions/harness/src/matrix.rs
@@ -63,7 +63,7 @@ impl ForkMatrix {
     ///
     /// The `pectra-blob-schedule` compatibility patch (a Base Sepolia-only quirk)
     /// and Base-specific forks are excluded; this matrix covers only the upstream
-    /// OP mainnet upgrade sequence.
+    /// Base mainnet upgrade sequence.
     pub fn from_granite() -> Self {
         static PROGRESSION: &[(&str, ForkSetter)] = &[
             ("granite", |h| h.granite_time = Some(0)),

--- a/actions/harness/tests/derivation.rs
+++ b/actions/harness/tests/derivation.rs
@@ -58,7 +58,7 @@ async fn single_l2_block_derived_from_batcher_frame() {
 /// advances by one L2 block per L1 block.
 ///
 /// All three L2 blocks belong to the same L1 epoch (genesis). This is the
-/// realistic Optimism scenario: with 12 s L1 blocks and 2 s L2 blocks there
+/// realistic Base scenario: with 12 s L1 blocks and 2 s L2 blocks there
 /// are ~6 L2 slots per L1 epoch; each batch may land in a different L1 block
 /// within the sequencer window while still referencing the same L1 epoch.
 #[tokio::test]

--- a/crates/client/cli/src/p2p.rs
+++ b/crates/client/cli/src/p2p.rs
@@ -1,8 +1,4 @@
 //! P2P CLI Flags
-//!
-//! These are based on p2p flags from the [`op-node`][op-node] CLI.
-//!
-//! [op-node]: https://github.com/ethereum-optimism/optimism/blob/develop/op-node/flags/p2p_flags.go
 
 use std::{
     net::{IpAddr, SocketAddr, ToSocketAddrs},

--- a/crates/client/cli/src/sequencer.rs
+++ b/crates/client/cli/src/sequencer.rs
@@ -1,8 +1,4 @@
 //! Sequencer CLI Flags
-//!
-//! These are based on sequencer flags from the [`op-node`][op-node] CLI.
-//!
-//! [op-node]: https://github.com/ethereum-optimism/optimism/blob/develop/op-node/flags/flags.go#L233-L265
 
 use std::{num::ParseIntError, time::Duration};
 

--- a/crates/common/consensus/src/predeploys.rs
+++ b/crates/common/consensus/src/predeploys.rs
@@ -1,4 +1,4 @@
-//! Addresses of OP pre-deploys.
+//! Addresses of Base pre-deploys.
 //!
 //! This module contains predeploy contract addresses and system addresses for Base.
 //! See the complete set of predeploys at <https://specs.optimism.io/protocol/predeploys.html#predeploys>
@@ -20,14 +20,14 @@ impl Predeploys {
         Self::L2_CROSS_DOMAIN_MESSENGER,
         Self::L2_STANDARD_BRIDGE,
         Self::SEQUENCER_FEE_VAULT,
-        Self::OP_MINTABLE_ERC20_FACTORY,
+        Self::BASE_MINTABLE_ERC20_FACTORY,
         Self::L1_BLOCK_NUMBER,
         Self::GAS_PRICE_ORACLE,
         Self::GOVERNANCE_TOKEN,
         Self::L1_BLOCK_INFO,
         Self::L2_TO_L1_MESSAGE_PASSER,
         Self::L2_ERC721_BRIDGE,
-        Self::OP_MINTABLE_ERC721_FACTORY,
+        Self::BASE_MINTABLE_ERC721_FACTORY,
         Self::PROXY_ADMIN,
         Self::BASE_FEE_VAULT,
         Self::L1_FEE_VAULT,
@@ -73,7 +73,7 @@ impl Predeploys {
 
     /// The mintable ERC20 factory proxy address.
     /// <https://specs.optimism.io/protocol/predeploys.html#optimismmintableerc20factory>
-    pub const OP_MINTABLE_ERC20_FACTORY: Address =
+    pub const BASE_MINTABLE_ERC20_FACTORY: Address =
         address!("0x4200000000000000000000000000000000000012");
 
     /// Returns the last known L1 block number (legacy system).
@@ -103,7 +103,7 @@ impl Predeploys {
 
     /// The mintable ERC721 proxy address.
     /// <https://specs.optimism.io/protocol/predeploys.html#optimismmintableerc721factory>
-    pub const OP_MINTABLE_ERC721_FACTORY: Address =
+    pub const BASE_MINTABLE_ERC721_FACTORY: Address =
         address!("0x4200000000000000000000000000000000000017");
 
     /// The L2 proxy admin address.

--- a/crates/common/rpc-types/src/genesis.rs
+++ b/crates/common/rpc-types/src/genesis.rs
@@ -1,4 +1,4 @@
-//! OP types for genesis data.
+//! Base types for genesis data.
 
 use alloy_serde::OtherFields;
 use serde::de::Error;

--- a/crates/common/rpc-types/src/transaction.rs
+++ b/crates/common/rpc-types/src/transaction.rs
@@ -202,7 +202,7 @@ impl<T> AsRef<T> for Transaction<T> {
 }
 
 mod tx_serde {
-    //! Helper module for serializing and deserializing OP [`Transaction`].
+    //! Helper module for serializing and deserializing Base [`Transaction`].
     //!
     //! This is needed because we might need to deserialize the `from` field into both
     //! [`alloy_consensus::transaction::Recovered::signer`] which resides in

--- a/crates/consensus/gossip/src/rpc/mod.rs
+++ b/crates/consensus/gossip/src/rpc/mod.rs
@@ -34,7 +34,7 @@
 //! ## Usage
 //!
 //! The RPC interface is designed to be compatible with existing Base tooling
-//! and monitoring systems, providing the same API surface as the reference `op-node`
+//! and monitoring systems, providing the same API surface as the reference `base-node`
 //! implementation where applicable.
 //!
 //! ## Security Considerations

--- a/crates/consensus/protocol/src/block.rs
+++ b/crates/consensus/protocol/src/block.rs
@@ -128,7 +128,7 @@ impl arbitrary::Arbitrary<'_> for L2BlockInfo {
     }
 }
 
-/// An error that can occur when converting an OP [`Block`] to [`L2BlockInfo`].
+/// An error that can occur when converting a [`Block`] to [`L2BlockInfo`].
 #[derive(Debug, thiserror::Error)]
 pub enum FromBlockError {
     /// The genesis block hash does not match the expected value.

--- a/crates/consensus/rpc/src/p2p.rs
+++ b/crates/consensus/rpc/src/p2p.rs
@@ -1,9 +1,4 @@
 //! RPC Module to serve the P2P API.
-//!
-//! The P2P RPC API is a JSON-RPC API compatible with the [op-node] API.
-//!
-//!
-//! [op-node]: https://github.com/ethereum-optimism/optimism/blob/7a6788836984996747193b91901a824c39032bd8/op-node/p2p/rpc_api.go#L45
 
 use std::{net::IpAddr, str::FromStr, time::Duration};
 

--- a/crates/execution/chainspec/src/builder.rs
+++ b/crates/execution/chainspec/src/builder.rs
@@ -9,7 +9,7 @@ use reth_primitives_traits::SealedHeader;
 
 use crate::BaseChainSpec;
 
-/// Chain spec builder for an OP stack chain.
+/// Chain spec builder for a Base chain.
 #[derive(Debug, Default, From)]
 pub struct BaseChainSpecBuilder {
     /// [`ChainSpecBuilder`]

--- a/crates/execution/consensus/src/proof.rs
+++ b/crates/execution/consensus/src/proof.rs
@@ -40,7 +40,7 @@ pub fn calculate_receipt_root_optimism<R: DepositReceiptExt>(
     ordered_trie_root_with_encoder(receipts, |r, buf| r.encode_2718(buf))
 }
 
-/// Calculates the receipt root for a header for the reference type of an OP receipt.
+/// Calculates the receipt root for a header for the reference type of a Base receipt.
 ///
 /// NOTE: Prefer calculate receipt root optimism if you have log blooms memoized.
 pub fn calculate_receipt_root_no_memo_optimism<R: DepositReceiptExt>(

--- a/crates/execution/payload/src/config.rs
+++ b/crates/execution/payload/src/config.rs
@@ -1,18 +1,18 @@
-//! Additional configuration for the OP builder
+//! Additional configuration for the Base payload builder
 
 use std::sync::{Arc, atomic::AtomicU64};
 
-/// Settings for the OP builder.
+/// Settings for the Base payload builder.
 #[derive(Debug, Clone, Default)]
 pub struct BaseBuilderConfig {
-    /// Data availability configuration for the OP builder.
+    /// Data availability configuration for the Base payload builder.
     pub da_config: BaseDAConfig,
-    /// Gas limit configuration for the OP builder.
+    /// Gas limit configuration for the Base payload builder.
     pub gas_limit_config: GasLimitConfig,
 }
 
 impl BaseBuilderConfig {
-    /// Creates a new OP builder configuration with the given data availability configuration.
+    /// Creates a new Base payload builder configuration with the given data availability configuration.
     pub const fn new(da_config: BaseDAConfig, gas_limit_config: GasLimitConfig) -> Self {
         Self { da_config, gas_limit_config }
     }

--- a/crates/execution/runner/src/service.rs
+++ b/crates/execution/runner/src/service.rs
@@ -17,7 +17,7 @@ use crate::{
 /// Trait for customizing the payload service used by the node.
 ///
 /// Implementors provide a custom [`NodeComponentsBuilder`] that wires in their
-/// payload service. The default implementation uses reth's standard OP payload builder.
+/// payload service. The default implementation uses reth's standard Base payload builder.
 ///
 /// The produced components must have the same concrete `Components` type as the default
 /// so that hooks (RPC, `ExEx`, node-started) remain type-compatible.
@@ -32,7 +32,7 @@ pub trait PayloadServiceBuilder: Send + 'static {
     fn build_components(self, base_node: &BaseNode) -> Self::ComponentsBuilder;
 }
 
-/// Default payload service using the standard OP payload builder.
+/// Default payload service using the standard Base payload builder.
 #[derive(Debug, Default)]
 pub struct DefaultPayloadServiceBuilder;
 

--- a/crates/infra/load-tests/src/workload/payloads/calldata.rs
+++ b/crates/infra/load-tests/src/workload/payloads/calldata.rs
@@ -9,7 +9,7 @@ const GAS_PER_ZERO_BYTE: u64 = 4;
 const GAS_PER_NONZERO_BYTE: u64 = 16;
 const TOKENS_PER_NONZERO_BYTE: u64 = GAS_PER_NONZERO_BYTE / GAS_PER_ZERO_BYTE;
 
-/// EIP-7623 floor cost per calldata token (active on Prague / OP Stack Isthmus+).
+/// EIP-7623 floor cost per calldata token (active on Prague / Base Isthmus+).
 const EIP7623_FLOOR_COST_PER_TOKEN: u64 = 10;
 
 /// Generates ETH transfer transactions with random calldata.


### PR DESCRIPTION
## Summary

Replaces residual OP Stack and Optimism branding in doc comments across the workspace with Base equivalents. This includes renaming the `OP_MINTABLE_ERC20_FACTORY` and `OP_MINTABLE_ERC721_FACTORY` predeploy constants to `BASE_MINTABLE_ERC20_FACTORY` and `BASE_MINTABLE_ERC721_FACTORY`, updating module-level doc comments that said "OP pre-deploys", "OP builder", "OP types", etc., and removing stale references to the op-node CLI as the origin of our flag definitions. External `specs.optimism.io` spec links are left intact as they remain the authoritative protocol references.