### PR TITLE
chore(execution): Remove Stale Function Naming

### DIFF
--- a/actions/harness/src/engine.rs
+++ b/actions/harness/src/engine.rs
@@ -220,7 +220,7 @@ impl ActionEngineClient {
         init_genesis(&provider_factory).expect("failed to initialize genesis in action engine");
         let blockchain_provider = BlockchainProvider::new(provider_factory.clone())
             .expect("failed to create blockchain provider");
-        let evm_config = BaseEvmConfig::optimism(Arc::clone(&chain_spec));
+        let evm_config = BaseEvmConfig::base(Arc::clone(&chain_spec));
 
         let inner = Arc::new(Mutex::new(ActionEngineClientInner {
             provider_factory,

--- a/crates/builder/core/src/flashblocks/context.rs
+++ b/crates/builder/core/src/flashblocks/context.rs
@@ -1047,7 +1047,7 @@ impl OpPayloadBuilderCtx {
     /// Derives the EVM environment from the given chain spec and parent header,
     /// using default builder attributes and a no-op cancellation token.
     pub fn for_test(chain_spec: Arc<BaseChainSpec>, parent: Arc<SealedHeader>) -> Self {
-        let evm_config = BaseEvmConfig::optimism(Arc::clone(&chain_spec));
+        let evm_config = BaseEvmConfig::base(Arc::clone(&chain_spec));
         let timestamp = parent.timestamp + 2;
 
         let attributes = OpPayloadBuilderAttributes {

--- a/crates/builder/core/src/flashblocks/payload.rs
+++ b/crates/builder/core/src/flashblocks/payload.rs
@@ -19,7 +19,7 @@ use base_common_consensus::{BaseReceipt, BaseTransactionSigned};
 use base_common_flashblocks::{
     ExecutionPayloadBaseV1, ExecutionPayloadFlashblockDeltaV1, FlashblocksPayloadV1,
 };
-use base_execution_consensus::{calculate_receipt_root_no_memo_optimism, isthmus};
+use base_execution_consensus::{calculate_receipt_root_no_memo, isthmus};
 use base_execution_evm::{BaseEvmConfig, OpNextBlockEnvAttributes};
 use base_execution_payload_builder::{OpBuiltPayload, OpPayloadBuilderAttributes};
 use either::Either;
@@ -971,7 +971,7 @@ where
         ));
     }
 
-    let receipts_root = calculate_receipt_root_no_memo_optimism(
+    let receipts_root = calculate_receipt_root_no_memo(
         &info.receipts,
         &ctx.chain_spec,
         ctx.attributes().timestamp(),

--- a/crates/builder/core/src/flashblocks/service.rs
+++ b/crates/builder/core/src/flashblocks/service.rs
@@ -47,7 +47,7 @@ impl FlashblocksServiceBuilder {
         let ws_pub: Arc<WebSocketPublisher> =
             WebSocketPublisher::new(self.0.flashblocks_ws_addr)?.into();
         let payload_builder = OpPayloadBuilder::new(
-            BaseEvmConfig::optimism(ctx.chain_spec()),
+            BaseEvmConfig::base(ctx.chain_spec()),
             pool,
             ctx.provider().clone(),
             self.0.clone(),

--- a/crates/client/metering/src/block.rs
+++ b/crates/client/metering/src/block.rs
@@ -88,7 +88,7 @@ where
 
     let evm_start = Instant::now();
     {
-        let evm_config = BaseEvmConfig::optimism(chain_spec);
+        let evm_config = BaseEvmConfig::base(chain_spec);
         let mut builder = evm_config.builder_for_next_block(&mut db, &parent_header, attributes)?;
 
         builder.apply_pre_execution_changes()?;

--- a/crates/client/metering/src/meter.rs
+++ b/crates/client/metering/src/meter.rs
@@ -303,7 +303,7 @@ where
 
     let total_start = Instant::now();
     {
-        let evm_config = BaseEvmConfig::optimism(chain_spec);
+        let evm_config = BaseEvmConfig::base(chain_spec);
         let mut builder = evm_config.builder_for_next_block(&mut db, header, attributes)?;
 
         // Cap the base fee at MIN_BASEFEE so transactions aren't rejected for

--- a/crates/common/access-lists/tests/builder/main.rs
+++ b/crates/common/access-lists/tests/builder/main.rs
@@ -45,7 +45,7 @@ pub fn execute_txns_build_access_list(
     storage_overrides: Option<HashMap<Address, HashMap<U256, B256>>>,
 ) -> Result<FlashblockAccessList> {
     let chain_spec = load_chain_spec();
-    let evm_config = BaseEvmConfig::optimism(Arc::clone(&chain_spec));
+    let evm_config = BaseEvmConfig::base(Arc::clone(&chain_spec));
     let header = Header { base_fee_per_gas: Some(0), ..chain_spec.genesis_header().clone() };
 
     // Set up the underlying InMemoryDB with any overrides

--- a/crates/consensus/derive/src/stages/attributes_queue.rs
+++ b/crates/consensus/derive/src/stages/attributes_queue.rs
@@ -225,7 +225,7 @@ mod tests {
         test_utils::{TestAttributesBuilder, TestAttributesProvider, new_test_attributes_provider},
     };
 
-    fn default_optimism_payload_attributes() -> BasePayloadAttributes {
+    fn default_payload_attributes() -> BasePayloadAttributes {
         BasePayloadAttributes {
             payload_attributes: PayloadAttributes {
                 timestamp: 0,
@@ -366,7 +366,7 @@ mod tests {
     async fn test_create_next_attributes_success() {
         let cfg = RollupConfig::default();
         let mock = new_test_attributes_provider(None, vec![]);
-        let mut payload_attributes = default_optimism_payload_attributes();
+        let mut payload_attributes = default_payload_attributes();
         let mock_builder =
             TestAttributesBuilder { attributes: vec![Ok(payload_attributes.clone())] };
         let mut aq = AttributesQueue::new(Arc::new(cfg), mock, mock_builder);
@@ -396,7 +396,7 @@ mod tests {
         let cfg = RollupConfig::default();
         let mock =
             new_test_attributes_provider(Some(Default::default()), vec![Ok(Default::default())]);
-        let mut pa = default_optimism_payload_attributes();
+        let mut pa = default_payload_attributes();
         let mock_builder = TestAttributesBuilder { attributes: vec![Ok(pa.clone())] };
         let mut aq = AttributesQueue::new(Arc::new(cfg), mock, mock_builder);
         // If we load the batch, we should get the last in span.

--- a/crates/execution/cli/src/app.rs
+++ b/crates/execution/cli/src/app.rs
@@ -75,10 +75,7 @@ where
         install_prometheus_recorder();
 
         let components = |spec: Arc<BaseChainSpec>| {
-            (
-                BaseExecutorProvider::base(Arc::clone(&spec)),
-                Arc::new(OpBeaconConsensus::new(spec)),
-            )
+            (BaseExecutorProvider::base(Arc::clone(&spec)), Arc::new(OpBeaconConsensus::new(spec)))
         };
 
         match self.cli.command {

--- a/crates/execution/cli/src/app.rs
+++ b/crates/execution/cli/src/app.rs
@@ -76,7 +76,7 @@ where
 
         let components = |spec: Arc<BaseChainSpec>| {
             (
-                BaseExecutorProvider::optimism(Arc::clone(&spec)),
+                BaseExecutorProvider::base(Arc::clone(&spec)),
                 Arc::new(OpBeaconConsensus::new(spec)),
             )
         };

--- a/crates/execution/consensus/src/lib.rs
+++ b/crates/execution/consensus/src/lib.rs
@@ -31,7 +31,7 @@ use reth_primitives_traits::{
 };
 
 mod proof;
-pub use proof::{calculate_receipt_root_no_memo_optimism, calculate_receipt_root_optimism};
+pub use proof::{calculate_receipt_root, calculate_receipt_root_no_memo};
 
 pub mod validation;
 pub use validation::{canyon, isthmus, validate_block_post_execution};

--- a/crates/execution/consensus/src/proof.rs
+++ b/crates/execution/consensus/src/proof.rs
@@ -10,7 +10,7 @@ use base_common_chains::Upgrades;
 use base_common_consensus::DepositReceiptExt;
 
 /// Calculates the receipt root for a header.
-pub fn calculate_receipt_root_optimism<R: DepositReceiptExt>(
+pub fn calculate_receipt_root<R: DepositReceiptExt>(
     receipts: &[ReceiptWithBloom<&R>],
     chain_spec: impl Upgrades,
     timestamp: u64,
@@ -42,8 +42,8 @@ pub fn calculate_receipt_root_optimism<R: DepositReceiptExt>(
 
 /// Calculates the receipt root for a header for the reference type of a Base receipt.
 ///
-/// NOTE: Prefer calculate receipt root optimism if you have log blooms memoized.
-pub fn calculate_receipt_root_no_memo_optimism<R: DepositReceiptExt>(
+/// NOTE: Prefer [`calculate_receipt_root`] if you have log blooms memoized.
+pub fn calculate_receipt_root_no_memo<R: DepositReceiptExt>(
     receipts: &[R],
     chain_spec: impl Upgrades,
     timestamp: u64,
@@ -463,7 +463,7 @@ mod tests {
                     ],
                 }),
             ];
-            let root = calculate_receipt_root_optimism(
+            let root = calculate_receipt_root(
                 &receipts.iter().map(TxReceipt::with_bloom_ref).collect::<Vec<_>>(),
                 BASE_SEPOLIA.as_ref(),
                 case.1,
@@ -488,7 +488,7 @@ mod tests {
         });
         let receipt = ReceiptWithBloom { receipt: &inner, logs_bloom };
         let receipt = vec![receipt];
-        let root = calculate_receipt_root_optimism(&receipt, BASE_SEPOLIA.as_ref(), 0);
+        let root = calculate_receipt_root(&receipt, BASE_SEPOLIA.as_ref(), 0);
         assert_eq!(
             root,
             b256!("0xfe70ae4a136d98944951b2123859698d59ad251a381abc9960fa81cae3d0d4a0")

--- a/crates/execution/consensus/src/validation/mod.rs
+++ b/crates/execution/consensus/src/validation/mod.rs
@@ -16,7 +16,7 @@ use reth_execution_types::BlockExecutionResult;
 use reth_primitives_traits::{BlockBody, GotExpected, receipt::gas_spent_by_transactions};
 use tracing::debug;
 
-use crate::proof::calculate_receipt_root_optimism;
+use crate::proof::calculate_receipt_root;
 
 /// Ensures the block response data matches the header.
 ///
@@ -166,7 +166,7 @@ fn verify_receipts_optimism<R: DepositReceiptExt>(
     // Calculate receipts root.
     let receipts_with_bloom = receipts.iter().map(TxReceipt::with_bloom_ref).collect::<Vec<_>>();
     let receipts_root =
-        calculate_receipt_root_optimism(&receipts_with_bloom, chain_spec, timestamp);
+        calculate_receipt_root(&receipts_with_bloom, chain_spec, timestamp);
 
     // Calculate header logs bloom.
     let logs_bloom = receipts_with_bloom.iter().fold(Bloom::ZERO, |bloom, r| bloom | r.bloom_ref());

--- a/crates/execution/consensus/src/validation/mod.rs
+++ b/crates/execution/consensus/src/validation/mod.rs
@@ -165,8 +165,7 @@ fn verify_receipts_optimism<R: DepositReceiptExt>(
 ) -> Result<(), ConsensusError> {
     // Calculate receipts root.
     let receipts_with_bloom = receipts.iter().map(TxReceipt::with_bloom_ref).collect::<Vec<_>>();
-    let receipts_root =
-        calculate_receipt_root(&receipts_with_bloom, chain_spec, timestamp);
+    let receipts_root = calculate_receipt_root(&receipts_with_bloom, chain_spec, timestamp);
 
     // Calculate header logs bloom.
     let logs_bloom = receipts_with_bloom.iter().fold(Bloom::ZERO, |bloom, r| bloom | r.bloom_ref());

--- a/crates/execution/evm/src/build.rs
+++ b/crates/execution/evm/src/build.rs
@@ -10,7 +10,7 @@ use alloy_primitives::logs_bloom;
 use base_common_chains::Upgrades;
 use base_common_consensus::DepositReceiptExt;
 use base_common_evm::BaseBlockExecutionCtx;
-use base_execution_consensus::{calculate_receipt_root_no_memo_optimism, isthmus};
+use base_execution_consensus::{calculate_receipt_root_no_memo, isthmus};
 use reth_evm::execute::{BlockAssembler, BlockAssemblerInput};
 use reth_execution_errors::BlockExecutionError;
 use reth_execution_types::BlockExecutionResult;
@@ -59,7 +59,7 @@ impl<ChainSpec: Upgrades> BaseBlockAssembler<ChainSpec> {
 
         let transactions_root = proofs::calculate_transaction_root(&transactions);
         let receipts_root =
-            calculate_receipt_root_no_memo_optimism(receipts, &self.chain_spec, timestamp);
+            calculate_receipt_root_no_memo(receipts, &self.chain_spec, timestamp);
         let logs_bloom = logs_bloom(receipts.iter().flat_map(|r| r.logs()));
 
         let mut requests_hash = None;

--- a/crates/execution/evm/src/build.rs
+++ b/crates/execution/evm/src/build.rs
@@ -58,8 +58,7 @@ impl<ChainSpec: Upgrades> BaseBlockAssembler<ChainSpec> {
         let timestamp = evm_env.block_env.timestamp().saturating_to();
 
         let transactions_root = proofs::calculate_transaction_root(&transactions);
-        let receipts_root =
-            calculate_receipt_root_no_memo(receipts, &self.chain_spec, timestamp);
+        let receipts_root = calculate_receipt_root_no_memo(receipts, &self.chain_spec, timestamp);
         let logs_bloom = logs_bloom(receipts.iter().flat_map(|r| r.logs()));
 
         let mut requests_hash = None;

--- a/crates/execution/evm/src/lib.rs
+++ b/crates/execution/evm/src/lib.rs
@@ -145,7 +145,7 @@ impl<ChainSpec, N: NodePrimitives, R: Clone, EvmFactory: Clone> Clone
 
 impl<ChainSpec: Upgrades> BaseEvmConfig<ChainSpec> {
     /// Creates a new [`BaseEvmConfig`] with the given chain spec for Base chains.
-    pub fn optimism(chain_spec: Arc<ChainSpec>) -> Self {
+    pub fn base(chain_spec: Arc<ChainSpec>) -> Self {
         Self::new(chain_spec, OpRethReceiptBuilder::default())
     }
 }
@@ -361,7 +361,7 @@ mod tests {
     use super::*;
 
     fn test_evm_config() -> BaseEvmConfig {
-        BaseEvmConfig::optimism(BASE_MAINNET.clone())
+        BaseEvmConfig::base(BASE_MAINNET.clone())
     }
 
     #[test]
@@ -373,7 +373,7 @@ mod tests {
                 .azul_activated()
                 .build(),
         );
-        let evm_config = BaseEvmConfig::optimism(chain_spec);
+        let evm_config = BaseEvmConfig::base(chain_spec);
         let header = Header { timestamp: 0, ..Default::default() };
         let EvmEnv { cfg_env, .. } = evm_config.evm_env(&header).unwrap();
         assert_eq!(cfg_env.spec, OpSpecId::AZUL);
@@ -397,7 +397,7 @@ mod tests {
         // Use the `BaseEvmConfig` to create the `cfg_env` and `block_env` based on the ChainSpec,
         // Header, and total difficulty
         let EvmEnv { cfg_env, .. } =
-            BaseEvmConfig::optimism(Arc::new(BaseChainSpec { inner: chain_spec.clone() }))
+            BaseEvmConfig::base(Arc::new(BaseChainSpec { inner: chain_spec.clone() }))
                 .evm_env(&header)
                 .unwrap();
 

--- a/crates/execution/flashblocks/src/processor.rs
+++ b/crates/execution/flashblocks/src/processor.rs
@@ -359,7 +359,7 @@ where
             .map_err(|e| ProviderError::StateProvider(e.to_string()))?
             .ok_or(ProviderError::MissingCanonicalHeader { block_number: canonical_block })?;
 
-        let evm_config = BaseEvmConfig::optimism(self.client.chain_spec());
+        let evm_config = BaseEvmConfig::base(self.client.chain_spec());
         let state_provider = self
             .client
             .state_by_block_number_or_tag(BlockNumberOrTag::Number(canonical_block))

--- a/crates/execution/flashblocks/src/receipt_builder.rs
+++ b/crates/execution/flashblocks/src/receipt_builder.rs
@@ -248,7 +248,7 @@ mod tests {
         chain_spec: Arc<base_execution_chainspec::BaseChainSpec>,
         db: &mut InMemoryDB,
     ) -> impl Evm<HaltReason = OpHaltReason, DB = &mut InMemoryDB> + '_ {
-        let evm_config = BaseEvmConfig::optimism(chain_spec);
+        let evm_config = BaseEvmConfig::base(chain_spec);
         let header = Header::default();
         let evm_env = evm_config.evm_env(&header).expect("failed to create evm env");
         evm_config.evm_with_env(db, evm_env)

--- a/crates/execution/flashblocks/src/state_builder.rs
+++ b/crates/execution/flashblocks/src/state_builder.rs
@@ -433,7 +433,7 @@ mod tests {
         let db = make_db_with_beacon_roots_contract();
 
         let chain_spec = Arc::new(BaseChainSpecBuilder::base_mainnet().build());
-        let evm_config = BaseEvmConfig::optimism(Arc::clone(&chain_spec));
+        let evm_config = BaseEvmConfig::base(Arc::clone(&chain_spec));
         let header = Header { timestamp: POST_ECOTONE_TIMESTAMP, number: 1, ..Default::default() };
         let evm_env = evm_config.evm_env(&header).expect("failed to build evm env");
         let evm = evm_config.evm_with_env(db, evm_env);
@@ -489,7 +489,7 @@ mod tests {
         let pre_ecotone_timestamp = BASE_MAINNET_ECOTONE_TIMESTAMP - 1;
 
         let chain_spec = Arc::new(BaseChainSpecBuilder::base_mainnet().build());
-        let evm_config = BaseEvmConfig::optimism(Arc::clone(&chain_spec));
+        let evm_config = BaseEvmConfig::base(Arc::clone(&chain_spec));
         let header = Header { timestamp: pre_ecotone_timestamp, number: 1, ..Default::default() };
         let evm_env = evm_config.evm_env(&header).expect("failed to build evm env");
         let evm = evm_config.evm_with_env(db, evm_env);
@@ -550,7 +550,7 @@ mod tests {
     #[test]
     fn cached_execute_transaction_preserves_timing_from_prev_pending_blocks() {
         let chain_spec = Arc::new(BaseChainSpecBuilder::base_mainnet().build());
-        let evm_config = BaseEvmConfig::optimism(Arc::clone(&chain_spec));
+        let evm_config = BaseEvmConfig::base(Arc::clone(&chain_spec));
 
         let header = Header {
             number: 1,
@@ -672,7 +672,7 @@ mod tests {
             base_fee_per_gas: Some(1_000_000_000),
             ..Default::default()
         };
-        let evm_config = BaseEvmConfig::optimism(Arc::clone(&chain_spec));
+        let evm_config = BaseEvmConfig::base(Arc::clone(&chain_spec));
         let evm_env = evm_config.evm_env(&header).expect("failed to create evm env");
         let evm = evm_config.evm_with_env(db, evm_env);
 
@@ -715,7 +715,7 @@ mod tests {
             base_fee_per_gas: Some(1_000_000_000),
             ..Default::default()
         };
-        let evm_config = BaseEvmConfig::optimism(Arc::clone(&chain_spec));
+        let evm_config = BaseEvmConfig::base(Arc::clone(&chain_spec));
         let evm_env = evm_config.evm_env(&header).expect("failed to create evm env");
         let evm = evm_config.evm_with_env(db, evm_env);
 
@@ -771,7 +771,7 @@ mod tests {
             base_fee_per_gas: Some(1_000_000_000),
             ..Default::default()
         };
-        let evm_config = BaseEvmConfig::optimism(Arc::clone(&chain_spec));
+        let evm_config = BaseEvmConfig::base(Arc::clone(&chain_spec));
         let evm_env = evm_config.evm_env(&header).expect("failed to create evm env");
         let evm = evm_config.evm_with_env(db, evm_env);
 

--- a/crates/execution/node/src/utils.rs
+++ b/crates/execution/node/src/utils.rs
@@ -28,7 +28,7 @@ pub async fn setup(num_nodes: usize) -> eyre::Result<(Vec<BaseNode>, Wallet)> {
         Arc::new(BaseChainSpecBuilder::base_mainnet().genesis(genesis).ecotone_activated().build()),
         false,
         Default::default(),
-        optimism_payload_attributes,
+        payload_attributes,
     )
     .await
 }
@@ -56,7 +56,7 @@ pub async fn advance_chain(
 }
 
 /// Helper function to create a new eth payload attributes
-pub fn optimism_payload_attributes<T>(timestamp: u64) -> OpPayloadBuilderAttributes<T> {
+pub fn payload_attributes<T>(timestamp: u64) -> OpPayloadBuilderAttributes<T> {
     let attributes = PayloadAttributes {
         timestamp,
         prev_randao: B256::ZERO,

--- a/crates/execution/node/tests/it/custom_genesis.rs
+++ b/crates/execution/node/tests/it/custom_genesis.rs
@@ -65,8 +65,7 @@ async fn test_op_node_custom_genesis_number() {
         .await
         .expect("Failed to launch node");
 
-    let mut node =
-        NodeTestContext::new(node_handle.node, payload_attributes).await.unwrap();
+    let mut node = NodeTestContext::new(node_handle.node, payload_attributes).await.unwrap();
 
     // Verify stage checkpoints are initialized to genesis block number (1000)
     for stage in StageId::ALL {

--- a/crates/execution/node/tests/it/custom_genesis.rs
+++ b/crates/execution/node/tests/it/custom_genesis.rs
@@ -6,7 +6,7 @@ use alloy_consensus::BlockHeader;
 use alloy_genesis::Genesis;
 use alloy_primitives::B256;
 use base_execution_chainspec::BaseChainSpecBuilder;
-use base_node_core::{BaseNode, utils::optimism_payload_attributes};
+use base_node_core::{BaseNode, utils::payload_attributes};
 use reth_chainspec::EthChainSpec;
 use reth_db::test_utils::create_test_rw_db_with_path;
 use reth_e2e_test_utils::{
@@ -66,7 +66,7 @@ async fn test_op_node_custom_genesis_number() {
         .expect("Failed to launch node");
 
     let mut node =
-        NodeTestContext::new(node_handle.node, optimism_payload_attributes).await.unwrap();
+        NodeTestContext::new(node_handle.node, payload_attributes).await.unwrap();
 
     // Verify stage checkpoints are initialized to genesis block number (1000)
     for stage in StageId::ALL {

--- a/crates/execution/node/tests/it/priority.rs
+++ b/crates/execution/node/tests/it/priority.rs
@@ -16,7 +16,7 @@ use base_node_core::{
         BaseConsensusBuilder, BaseExecutorBuilder, BaseNetworkBuilder, BaseNodeComponentBuilder,
         BaseNodeTypes, BasePoolBuilder, OpPayloadBuilder,
     },
-    utils::optimism_payload_attributes,
+    utils::payload_attributes,
 };
 use reth_chainspec::EthChainSpec;
 use reth_db::test_utils::create_test_rw_db_with_path;
@@ -153,7 +153,7 @@ async fn test_custom_block_priority_config() {
         .expect("Failed to launch node");
 
     // Advance the chain with a single block.
-    let block_payloads = NodeTestContext::new(node_handle.node, optimism_payload_attributes)
+    let block_payloads = NodeTestContext::new(node_handle.node, payload_attributes)
         .await
         .unwrap()
         .advance(1, |_| {

--- a/crates/execution/payload/src/lib.rs
+++ b/crates/execution/payload/src/lib.rs
@@ -14,7 +14,7 @@ pub use builder::OpPayloadBuilder;
 pub mod config;
 pub mod error;
 pub mod payload;
-pub use payload::{OpBuiltPayload, OpPayloadBuilderAttributes, payload_id_optimism};
+pub use payload::{OpBuiltPayload, OpPayloadBuilderAttributes, payload_id};
 mod traits;
 pub use traits::*;
 mod types;

--- a/crates/execution/payload/src/payload.rs
+++ b/crates/execution/payload/src/payload.rs
@@ -100,7 +100,7 @@ impl<T: Decodable2718 + Send + Sync + Debug + Unpin + 'static> PayloadBuilderAtt
         attributes: BasePayloadAttributes,
         version: u8,
     ) -> Result<Self, Self::Error> {
-        let id = payload_id_optimism(&parent, &attributes, version);
+        let id = payload_id(&parent, &attributes, version);
 
         let transactions = attributes
             .transactions
@@ -381,7 +381,7 @@ where
 ///
 /// Note: This must be updated whenever the [`BasePayloadAttributes`] changes for a hardfork.
 /// See also <https://github.com/ethereum-optimism/op-geth/blob/d401af16f2dd94b010a72eaef10e07ac10b31931/miner/payload_building.go#L59-L59>
-pub fn payload_id_optimism(
+pub fn payload_id(
     parent: &B256,
     attributes: &BasePayloadAttributes,
     payload_version: u8,
@@ -512,7 +512,7 @@ mod tests {
         // Reth's `PayloadId` should match op-geth's `PayloadId`. This fails
         assert_eq!(
             expected,
-            payload_id_optimism(
+            payload_id(
                 &b256!("0x3533bf30edaf9505d0810bf475cbe4e5f4b9889904b9845e83efdeab4e92eb1e"),
                 &attrs,
                 EngineApiMessageVersion::V3 as u8
@@ -543,7 +543,7 @@ mod tests {
         // Reth's `PayloadId` should match op-geth's `PayloadId`. This fails
         assert_eq!(
             expected,
-            payload_id_optimism(
+            payload_id(
                 &b256!("0x3533bf30edaf9505d0810bf475cbe4e5f4b9889904b9845e83efdeab4e92eb1e"),
                 &attrs,
                 EngineApiMessageVersion::V4 as u8

--- a/crates/execution/txpool/src/transaction.rs
+++ b/crates/execution/txpool/src/transaction.rs
@@ -440,7 +440,7 @@ mod tests {
         let client = MockEthProvider::<BasePrimitives>::new()
             .with_chain_spec(BASE_MAINNET.clone())
             .with_genesis_block();
-        let evm_config = BaseEvmConfig::optimism(BASE_MAINNET.clone());
+        let evm_config = BaseEvmConfig::base(BASE_MAINNET.clone());
         let validator = EthTransactionValidatorBuilder::new(client, evm_config)
             .no_shanghai()
             .no_cancun()


### PR DESCRIPTION
## Summary

Renames several public and internal functions that carried legacy `_optimism` suffixes from the original OP Stack port to Base-appropriate names. `BaseEvmConfig::optimism()` becomes `BaseEvmConfig::base()`, `calculate_receipt_root_optimism` and its no-memo variant drop the suffix entirely, `payload_id_optimism` becomes `payload_id`, and `optimism_payload_attributes` becomes `payload_attributes`. The shorter names have no conflicts in their respective modules. All 22 affected call sites across execution, builder, metering, harness, and test utilities are updated.