### PR TITLE
chore(execution): Rename Legacy Names

### DIFF
--- a/crates/execution/consensus/src/validation/mod.rs
+++ b/crates/execution/consensus/src/validation/mod.rs
@@ -123,7 +123,7 @@ pub fn validate_block_post_execution<R: DepositReceiptExt>(
                 header.logs_bloom(),
             )
         } else {
-            verify_receipts_optimism(
+            verify_receipts(
                 header.receipts_root(),
                 header.logs_bloom(),
                 receipts,
@@ -156,7 +156,7 @@ pub fn validate_block_post_execution<R: DepositReceiptExt>(
 }
 
 /// Verify the calculated receipts root against the expected receipts root.
-fn verify_receipts_optimism<R: DepositReceiptExt>(
+fn verify_receipts<R: DepositReceiptExt>(
     expected_receipts_root: B256,
     expected_logs_bloom: Bloom,
     receipts: &[R],

--- a/crates/execution/evm/src/lib.rs
+++ b/crates/execution/evm/src/lib.rs
@@ -57,7 +57,7 @@ mod error;
 pub use error::{BaseBlockExecutionError, L1BlockInfoError};
 
 /// Builds an [`EvmEnv`] for a given block header using [`base_common_evm`]'s spec resolution.
-fn op_evm_env(header: &Header, chain_spec: &(impl Upgrades + EthChainSpec)) -> EvmEnv<OpSpecId> {
+fn build_evm_env(header: &Header, chain_spec: &(impl Upgrades + EthChainSpec)) -> EvmEnv<OpSpecId> {
     let spec = OpSpecId::from_header(chain_spec, header);
     let cfg_env =
         CfgEnv::new().with_chain_id(chain_spec.chain().id()).with_spec_and_mainnet_gas_params(spec);
@@ -84,7 +84,7 @@ fn op_evm_env(header: &Header, chain_spec: &(impl Upgrades + EthChainSpec)) -> E
 }
 
 /// Builds an [`EvmEnv`] for the next block given a parent header.
-fn op_next_evm_env(
+fn build_next_evm_env(
     parent: &Header,
     attributes: &OpNextBlockEnvAttributes,
     base_fee_per_gas: u64,
@@ -214,7 +214,7 @@ where
     }
 
     fn evm_env(&self, header: &Header) -> Result<EvmEnv<OpSpecId>, Self::Error> {
-        Ok(op_evm_env(header, self.chain_spec()))
+        Ok(build_evm_env(header, self.chain_spec()))
     }
 
     fn next_evm_env(
@@ -225,7 +225,7 @@ where
         let base_fee =
             self.chain_spec().next_block_base_fee(parent, attributes.timestamp).unwrap_or_default();
 
-        Ok(op_next_evm_env(parent, attributes, base_fee, self.chain_spec()))
+        Ok(build_next_evm_env(parent, attributes, base_fee, self.chain_spec()))
     }
 
     fn context_for_block(

--- a/crates/execution/node/src/lib.rs
+++ b/crates/execution/node/src/lib.rs
@@ -26,7 +26,7 @@ pub mod rpc;
 pub use rpc::OpEngineApiBuilder;
 
 pub mod version;
-pub use version::OP_NAME_CLIENT;
+pub use version::CLIENT_NAME;
 
 pub mod proof_history;
 

--- a/crates/execution/node/src/node.rs
+++ b/crates/execution/node/src/node.rs
@@ -132,15 +132,16 @@ impl PayloadAttributesBuilder<BasePayloadAttributes> for BaseLocalPayloadAttribu
         );
 
         let default_eip_1559_params = BaseFeeParams::optimism();
-        let denominator = std::env::var("OP_DEV_EIP1559_DENOMINATOR")
+        let denominator = std::env::var("BASE_DEV_EIP1559_DENOMINATOR")
             .ok()
             .and_then(|v| v.parse::<u32>().ok())
             .unwrap_or(default_eip_1559_params.max_change_denominator as u32);
-        let elasticity = std::env::var("OP_DEV_EIP1559_ELASTICITY")
+        let elasticity = std::env::var("BASE_DEV_EIP1559_ELASTICITY")
             .ok()
             .and_then(|v| v.parse::<u32>().ok())
             .unwrap_or(default_eip_1559_params.elasticity_multiplier as u32);
-        let gas_limit = std::env::var("OP_DEV_GAS_LIMIT").ok().and_then(|v| v.parse::<u64>().ok());
+        let gas_limit =
+            std::env::var("BASE_DEV_GAS_LIMIT").ok().and_then(|v| v.parse::<u64>().ok());
 
         let mut eip1559_bytes = [0u8; 8];
         eip1559_bytes[0..4].copy_from_slice(&denominator.to_be_bytes());

--- a/crates/execution/node/src/rpc.rs
+++ b/crates/execution/node/src/rpc.rs
@@ -90,7 +90,7 @@ use std::sync::Arc;
 
 use alloy_rpc_types_engine::ClientVersionV1;
 use base_common_rpc_types_engine::ExecutionData;
-use base_execution_rpc::{BaseEngineApi, engine::OP_ENGINE_CAPABILITIES};
+use base_execution_rpc::{BaseEngineApi, engine::ENGINE_CAPABILITIES};
 use reth_chainspec::EthereumHardforks;
 use reth_node_api::{
     AddOnsContext, EngineApiValidator, EngineTypes, FullNodeComponents, NodeTypes,
@@ -100,7 +100,7 @@ use reth_node_core::version::{CLIENT_CODE, version_metadata};
 use reth_payload_builder::PayloadStore;
 use reth_rpc_engine_api::{EngineApi, EngineCapabilities};
 
-use crate::OP_NAME_CLIENT;
+use crate::CLIENT_NAME;
 
 /// Builder for basic [`BaseEngineApi`] implementation.
 #[derive(Debug, Default, Clone)]
@@ -133,7 +133,7 @@ where
         let engine_validator = engine_validator_builder.build(ctx).await?;
         let client = ClientVersionV1 {
             code: CLIENT_CODE,
-            name: OP_NAME_CLIENT.to_string(),
+            name: CLIENT_NAME.to_string(),
             version: version_metadata().cargo_pkg_version.to_string(),
             commit: version_metadata().vergen_git_sha.to_string(),
         };
@@ -145,7 +145,7 @@ where
             ctx.node.pool().clone(),
             Box::new(ctx.node.task_executor().clone()),
             client,
-            EngineCapabilities::new(OP_ENGINE_CAPABILITIES.iter().copied()),
+            EngineCapabilities::new(ENGINE_CAPABILITIES.iter().copied()),
             engine_validator,
             ctx.config.engine.accept_execution_requests_hash,
             ctx.node.network().clone(),

--- a/crates/execution/node/src/version.rs
+++ b/crates/execution/node/src/version.rs
@@ -1,4 +1,4 @@
 //! Version information for base-reth.
 
 /// The human readable name of the client
-pub const OP_NAME_CLIENT: &str = "Base-Reth";
+pub const CLIENT_NAME: &str = "Base-Reth";

--- a/crates/execution/rpc/src/engine.rs
+++ b/crates/execution/rpc/src/engine.rs
@@ -21,7 +21,7 @@ use tracing::{debug, instrument, trace};
 /// The list of all supported Engine capabilities available over the engine endpoint.
 ///
 /// Spec: <https://specs.optimism.io/protocol/exec-engine.html>
-pub const OP_ENGINE_CAPABILITIES: &[&str] = &[
+pub const ENGINE_CAPABILITIES: &[&str] = &[
     "engine_forkchoiceUpdatedV1",
     "engine_forkchoiceUpdatedV2",
     "engine_forkchoiceUpdatedV3",

--- a/crates/execution/rpc/src/lib.rs
+++ b/crates/execution/rpc/src/lib.rs
@@ -21,7 +21,7 @@ pub mod witness;
 pub use config::{BaseEthConfigApiServer, BaseEthConfigHandler};
 #[cfg(feature = "client")]
 pub use engine::BaseEngineApiClient;
-pub use engine::{BaseEngineApi, BaseEngineApiServer, OP_ENGINE_CAPABILITIES};
+pub use engine::{BaseEngineApi, BaseEngineApiServer, ENGINE_CAPABILITIES};
 pub use error::{OpEthApiError, OpInvalidTransactionError, SequencerClientError};
 pub use eth::{BaseReceiptBuilder, OpEthApi, OpEthApiBuilder};
 pub use metrics::{DebugApiExtMetrics, DebugApis, EthApiExtMetrics, SequencerMetrics};

--- a/crates/proof/tee/nitro-enclave/src/server.rs
+++ b/crates/proof/tee/nitro-enclave/src/server.rs
@@ -18,7 +18,7 @@ use crate::{
 };
 
 /// Environment variable for setting the signer key in local mode.
-const SIGNER_KEY_ENV_VAR: &str = "OP_ENCLAVE_SIGNER_KEY";
+const SIGNER_KEY_ENV_VAR: &str = "BASE_ENCLAVE_SIGNER_KEY";
 
 /// PCR0 is a SHA-384 hash (48 bytes) per the AWS Nitro Enclaves specification.
 const PCR0_LENGTH: usize = 48;
@@ -93,7 +93,7 @@ impl Server {
     /// Create a new server instance in local mode for development.
     ///
     /// Uses the OS RNG and sets `tee_image_hash` to zero. Optionally reads a
-    /// signer key from the `OP_ENCLAVE_SIGNER_KEY` environment variable.
+    /// signer key from the `BASE_ENCLAVE_SIGNER_KEY` environment variable.
     pub fn new_local() -> Result<Self> {
         let signer_key = match std::env::var(SIGNER_KEY_ENV_VAR) {
             Ok(hex_key) => {


### PR DESCRIPTION
## Summary

Renames remaining legacy `OP_`/`op_`/`_optimism` identifiers in our own code to drop the OP Stack prefix or use Base equivalents. Covers four dev-only environment variables (`OP_DEV_*` and `OP_ENCLAVE_SIGNER_KEY`), two exported constants (`OP_NAME_CLIENT` becomes `CLIENT_NAME`, `OP_ENGINE_CAPABILITIES` becomes `ENGINE_CAPABILITIES`), the internal `op_evm_env`/`op_next_evm_env` helpers (renamed to `build_evm_env`/`build_next_evm_env` since `evm_env`/`next_evm_env` collide with the trait methods on the same impl), and `verify_receipts_optimism` which loses the suffix. Wire-protocol names (`optimism_*` RPC methods, the `opstack` ENR key) are intentionally left alone, and re-exported upstream types from `op-alloy`/`kona` are out of our control. Overlaps file-wise with #2273 in `evm/src/lib.rs` and `validation/mod.rs`, so whichever lands second will need a trivial rebase.