### PR TITLE
chore(docs): Update Spec Links to Base Org

### DIFF
--- a/crates/builder/core/src/test_utils/driver.rs
+++ b/crates/builder/core/src/test_utils/driver.rs
@@ -331,7 +331,7 @@ impl<RpcProtocol: Protocol> ChainDriver<RpcProtocol> {
 // 2. Zero operator fee scalar
 // 3. Zero operator fee constant
 // 4. DA footprint of 400 applied
-// See: // https://specs.optimism.io/protocol/jovian/l1-attributes.html for Jovian specs.
+// See: // https://specs.base.org/upgrades/jovian/l1-attributes for Jovian specs.
 const JOVIAN_DATA: &[u8] = &hex!(
     "3db6be2b0000146b000f79c500000000000000040000000066d052e700000000013ad8a
     3000000000000000000000000000000000000000000000000000000003ef12787000000

--- a/crates/common/consensus/src/extra/jovian.rs
+++ b/crates/common/consensus/src/extra/jovian.rs
@@ -13,7 +13,7 @@ const VERSION_BYTE: u8 = 1;
 /// - 4 bytes `elasticity_multiplier` (big-endian u32)
 /// - 8 bytes `min_base_fee` (big-endian u64)
 ///
-/// See: <https://specs.optimism.io/protocol/jovian/exec-engine.html>
+/// See: <https://specs.base.org/upgrades/jovian/exec-engine>
 #[derive(Debug)]
 pub struct JovianExtraData;
 

--- a/crates/common/consensus/src/predeploys.rs
+++ b/crates/common/consensus/src/predeploys.rs
@@ -1,7 +1,7 @@
 //! Addresses of Base pre-deploys.
 //!
 //! This module contains predeploy contract addresses and system addresses for Base.
-//! See the complete set of predeploys at <https://specs.optimism.io/protocol/predeploys.html#predeploys>
+//! See the complete set of predeploys at <https://specs.base.org/protocol/execution/evm/predeploys#predeploys>
 
 use alloy_primitives::{Address, address};
 
@@ -41,93 +41,93 @@ impl Predeploys {
 
     /// The `LegacyMessagePasser` contract stores commitments to withdrawal transactions before the
     /// Bedrock upgrade.
-    /// <https://specs.optimism.io/protocol/predeploys.html#legacymessagepasser>
+    /// <https://specs.base.org/protocol/execution/evm/predeploys#legacymessagepasser>
     pub const LEGACY_MESSAGE_PASSER: Address =
         address!("0x4200000000000000000000000000000000000000");
 
     /// The `DeployerWhitelist` was used to provide additional safety during initial phases of
     /// Base.
-    /// <https://specs.optimism.io/protocol/predeploys.html#deployerwhitelist>
+    /// <https://specs.base.org/protocol/execution/evm/predeploys#deployerwhitelist>
     pub const DEPLOYER_WHITELIST: Address = address!("0x4200000000000000000000000000000000000002");
 
     /// The `LegacyERC20ETH` predeploy represented all ether in the system before the Bedrock upgrade.
-    /// <https://specs.optimism.io/protocol/predeploys.html#legacyerc20eth>
+    /// <https://specs.base.org/protocol/execution/evm/predeploys#legacyerc20eth>
     pub const LEGACY_ERC20_ETH: Address = address!("0xDeadDeAddeAddEAddeadDEaDDEAdDeaDDeAD0000");
 
     /// The WETH9 predeploy address.
-    /// <https://specs.optimism.io/protocol/predeploys.html#weth9>
+    /// <https://specs.base.org/protocol/execution/evm/predeploys#weth9>
     pub const WETH9: Address = address!("0x4200000000000000000000000000000000000006");
 
     /// Higher level API for sending cross domain messages.
-    /// <https://specs.optimism.io/protocol/predeploys.html#l2crossdomainmessenger>
+    /// <https://specs.base.org/protocol/execution/evm/predeploys#l2crossdomainmessenger>
     pub const L2_CROSS_DOMAIN_MESSENGER: Address =
         address!("0x4200000000000000000000000000000000000007");
 
     /// The L2 cross-domain messenger proxy address.
-    /// <https://specs.optimism.io/protocol/predeploys.html#l2standardbridge>
+    /// <https://specs.base.org/protocol/execution/evm/predeploys#l2standardbridge>
     pub const L2_STANDARD_BRIDGE: Address = address!("0x4200000000000000000000000000000000000010");
 
     /// The sequencer fee vault proxy address.
-    /// <https://specs.optimism.io/protocol/predeploys.html#sequencerfeevault>
+    /// <https://specs.base.org/protocol/execution/evm/predeploys#sequencerfeevault>
     pub const SEQUENCER_FEE_VAULT: Address = address!("0x4200000000000000000000000000000000000011");
 
     /// The mintable ERC20 factory proxy address.
-    /// <https://specs.optimism.io/protocol/predeploys.html#optimismmintableerc20factory>
+    /// <https://specs.base.org/protocol/execution/evm/predeploys#optimismmintableerc20factory>
     pub const BASE_MINTABLE_ERC20_FACTORY: Address =
         address!("0x4200000000000000000000000000000000000012");
 
     /// Returns the last known L1 block number (legacy system).
-    /// <https://specs.optimism.io/protocol/predeploys.html#l1blocknumber>
+    /// <https://specs.base.org/protocol/execution/evm/predeploys#l1blocknumber>
     pub const L1_BLOCK_NUMBER: Address = address!("0x4200000000000000000000000000000000000013");
 
     /// The gas price oracle proxy address.
-    /// <https://specs.optimism.io/protocol/predeploys.html#gaspriceoracle>
+    /// <https://specs.base.org/protocol/execution/evm/predeploys#gaspriceoracle>
     pub const GAS_PRICE_ORACLE: Address = address!("0x420000000000000000000000000000000000000F");
 
     /// The governance token proxy address.
-    /// <https://specs.optimism.io/governance/gov-token.html>
+    /// <https://specs.base.org/protocol/execution/evm/predeploys#governancetoken>
     pub const GOVERNANCE_TOKEN: Address = address!("0x4200000000000000000000000000000000000042");
 
     /// The L1 block information proxy address.
-    /// <https://specs.optimism.io/protocol/predeploys.html#l1block>
+    /// <https://specs.base.org/protocol/execution/evm/predeploys#l1block>
     pub const L1_BLOCK_INFO: Address = address!("0x4200000000000000000000000000000000000015");
 
     /// The L2 contract `L2ToL1MessagePasser`, stores commitments to withdrawal transactions.
-    /// <https://specs.optimism.io/protocol/predeploys.html#l2tol1messagepasser>
+    /// <https://specs.base.org/protocol/execution/evm/predeploys#l2tol1messagepasser>
     pub const L2_TO_L1_MESSAGE_PASSER: Address =
         address!("0x4200000000000000000000000000000000000016");
 
     /// The L2 ERC721 bridge proxy address.
-    /// <https://specs.optimism.io/protocol/predeploys.html>
+    /// <https://specs.base.org/protocol/execution/evm/predeploys>
     pub const L2_ERC721_BRIDGE: Address = address!("0x4200000000000000000000000000000000000014");
 
     /// The mintable ERC721 proxy address.
-    /// <https://specs.optimism.io/protocol/predeploys.html#optimismmintableerc721factory>
+    /// <https://specs.base.org/protocol/execution/evm/predeploys#optimismmintableerc721factory>
     pub const BASE_MINTABLE_ERC721_FACTORY: Address =
         address!("0x4200000000000000000000000000000000000017");
 
     /// The L2 proxy admin address.
-    /// <https://specs.optimism.io/protocol/predeploys.html#proxyadmin>
+    /// <https://specs.base.org/protocol/execution/evm/predeploys#proxyadmin>
     pub const PROXY_ADMIN: Address = address!("0x4200000000000000000000000000000000000018");
 
     /// The base fee vault address.
-    /// <https://specs.optimism.io/protocol/predeploys.html#basefeevault>
+    /// <https://specs.base.org/protocol/execution/evm/predeploys#basefeevault>
     pub const BASE_FEE_VAULT: Address = address!("0x4200000000000000000000000000000000000019");
 
     /// The L1 fee vault address.
-    /// <https://specs.optimism.io/protocol/predeploys.html#l1feevault>
+    /// <https://specs.base.org/protocol/execution/evm/predeploys#l1feevault>
     pub const L1_FEE_VAULT: Address = address!("0x420000000000000000000000000000000000001a");
 
     /// The schema registry proxy address.
-    /// <https://specs.optimism.io/protocol/predeploys.html#schemaregistry>
+    /// <https://specs.base.org/protocol/execution/evm/predeploys#schemaregistry>
     pub const SCHEMA_REGISTRY: Address = address!("0x4200000000000000000000000000000000000020");
 
     /// The EAS proxy address.
-    /// <https://specs.optimism.io/protocol/predeploys.html#eas>
+    /// <https://specs.base.org/protocol/execution/evm/predeploys#eas>
     pub const EAS: Address = address!("0x4200000000000000000000000000000000000021");
 
     /// Provides access to L1 beacon block roots (EIP-4788).
-    /// <https://specs.optimism.io/protocol/predeploys.html#beacon-block-root>
+    /// <https://specs.base.org/protocol/execution/evm/predeploys#beacon-block-root>
     pub const BEACON_BLOCK_ROOT: Address = address!("0x000F3df6D732807Ef1319fB7B8bB8522d0Beac02");
 
     /// The Operator Fee Vault proxy address.
@@ -147,7 +147,7 @@ pub struct SystemAddresses;
 
 impl SystemAddresses {
     /// The depositor address of the L1 attributes transaction (`L1Block` contract depositor).
-    /// <https://specs.optimism.io/protocol/deposits.html#l1-attributes-deposited-transaction>
+    /// <https://specs.base.org/protocol/bridging/deposits#l1-attributes-deposited-transaction>
     pub const DEPOSITOR_ACCOUNT: Address = address!("0xDeaDDEaDDeAdDeAdDEAdDEaddeAddEAdDEAd0001");
 }
 

--- a/crates/common/consensus/src/receipts/envelope.rs
+++ b/crates/common/consensus/src/receipts/envelope.rs
@@ -46,7 +46,7 @@ pub enum BaseReceiptEnvelope<T = Log> {
     Eip7702(ReceiptWithBloom<Receipt<T>>),
     /// Receipt envelope with type flag 126, containing a [deposit] receipt.
     ///
-    /// [deposit]: https://specs.optimism.io/protocol/deposits.html
+    /// [deposit]: https://specs.base.org/protocol/bridging/deposits
     #[cfg_attr(feature = "serde", serde(rename = "0x7e", alias = "0x7E"))]
     Deposit(ReceiptWithBloom<DepositReceipt<T>>),
 }

--- a/crates/common/evm/src/api/builder.rs
+++ b/crates/common/evm/src/api/builder.rs
@@ -25,7 +25,7 @@ pub trait Builder: Sized {
     /// Builds a [`BaseEvm`] with the given inspector. The inspect flag is `true`,
     /// so [`Inspector`][revm::Inspector] callbacks are invoked on every
     /// [`alloy_evm::Evm::transact`] call.
-    fn build_op_with_inspector<INSP>(self, inspector: INSP) -> BaseEvm<Self::Db, INSP>;
+    fn build_with_inspector<INSP>(self, inspector: INSP) -> BaseEvm<Self::Db, INSP>;
 }
 
 impl<DB: Database> Builder for OpContext<DB> {
@@ -45,7 +45,7 @@ impl<DB: Database> Builder for OpContext<DB> {
         )
     }
 
-    fn build_op_with_inspector<INSP>(self, inspector: INSP) -> BaseEvm<DB, INSP> {
+    fn build_with_inspector<INSP>(self, inspector: INSP) -> BaseEvm<DB, INSP> {
         let spec: OpSpecId = self.cfg.spec;
         BaseEvm::new(
             revm::context::Evm {

--- a/crates/common/evm/src/api/default_ctx.rs
+++ b/crates/common/evm/src/api/default_ctx.rs
@@ -36,7 +36,7 @@ mod tests {
     #[test]
     fn default_run_op() {
         let ctx = Context::op();
-        let mut evm = ctx.build_op_with_inspector(NoOpInspector {});
+        let mut evm = ctx.build_with_inspector(NoOpInspector {});
         // execute without inspector
         let _ = evm.transact(OpTransaction::builder().build_fill());
         // execute with inspector callbacks

--- a/crates/common/evm/src/evm.rs
+++ b/crates/common/evm/src/evm.rs
@@ -58,7 +58,7 @@ pub struct BaseEvm<DB: Database, I, P = BasePrecompiles> {
 impl<DB: Database, I, P> BaseEvm<DB, I, P> {
     /// Constructs a [`BaseEvm`] from a pre-built [`RevmEvm`] and an inspect flag.
     ///
-    /// Prefer [`crate::Builder::build_op`] or [`crate::Builder::build_op_with_inspector`]
+    /// Prefer [`crate::Builder::build_op`] or [`crate::Builder::build_with_inspector`]
     /// to construct from an [`OpContext`] directly.
     pub const fn new(inner: InnerEvm<DB, I, P>, inspect: bool) -> Self {
         Self { inner, inspect }

--- a/crates/common/evm/src/executor/block_executor.rs
+++ b/crates/common/evm/src/executor/block_executor.rs
@@ -451,7 +451,7 @@ mod tests {
             })
             .modify_cfg_chained(|cfg| cfg.spec = OpSpecId::JOVIAN);
 
-        let evm = ctx.build_op_with_inspector(NoOpInspector {});
+        let evm = ctx.build_with_inspector(NoOpInspector {});
 
         BaseBlockExecutor::new(
             evm,

--- a/crates/common/evm/src/factory.rs
+++ b/crates/common/evm/src/factory.rs
@@ -59,7 +59,7 @@ impl EvmFactory for BaseEvmFactory {
             .with_db(db)
             .with_block(input.block_env)
             .with_cfg(input.cfg_env)
-            .build_op_with_inspector(inspector)
+            .build_with_inspector(inspector)
             .with_precompiles(PrecompilesMap::from_static(
                 BasePrecompiles::new_with_spec(spec_id).precompiles(),
             ))

--- a/crates/common/provider/src/ext/engine.rs
+++ b/crates/common/provider/src/ext/engine.rs
@@ -17,7 +17,7 @@ use base_common_rpc_types_engine::{
 /// > The provider should use a JWT authentication layer.
 ///
 /// This follows the Base specs:
-/// <https://specs.optimism.io/protocol/exec-engine.html#engine-api>
+/// <https://specs.base.org/protocol/execution#engine-api>
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 pub trait BaseEngineApi<N, T> {
@@ -70,7 +70,7 @@ pub trait BaseEngineApi<N, T> {
     ///
     /// OP modifications:
     /// - The `payload_attributes` parameter is extended with the [`BasePayloadAttributes`] type
-    ///   as described in <https://specs.optimism.io/protocol/exec-engine.html#extended-payloadattributesv2>
+    ///   as described in <https://specs.base.org/protocol/execution#extended-payloadattributesv2>
     async fn fork_choice_updated_v2(
         &self,
         fork_choice_state: ForkchoiceState,
@@ -86,7 +86,7 @@ pub trait BaseEngineApi<N, T> {
     /// - Must be called with an Ecotone payload
     /// - Attributes must contain the parent beacon block root field
     /// - The `payload_attributes` parameter is extended with the [`BasePayloadAttributes`] type
-    ///   as described in <https://specs.optimism.io/protocol/exec-engine.html#extended-payloadattributesv2>
+    ///   as described in <https://specs.base.org/protocol/execution#extended-payloadattributesv2>
     async fn fork_choice_updated_v3(
         &self,
         fork_choice_state: ForkchoiceState,

--- a/crates/common/rpc-types-engine/src/envelope.rs
+++ b/crates/common/rpc-types-engine/src/envelope.rs
@@ -28,7 +28,7 @@ pub struct BaseExecutionPayloadEnvelope {
 impl BaseExecutionPayloadEnvelope {
     /// Returns the payload hash over the ssz encoded payload envelope data.
     ///
-    /// <https://specs.optimism.io/protocol/rollup-node-p2p.html#block-signatures>
+    /// <https://specs.base.org/protocol/consensus/p2p#block-signatures>
     #[cfg(feature = "std")]
     pub fn payload_hash(&self) -> crate::PayloadHash {
         use ssz::Encode;
@@ -45,7 +45,7 @@ impl ssz::Encode for BaseExecutionPayloadEnvelope {
 
     fn ssz_append(&self, buf: &mut Vec<u8>) {
         // Write parent beacon block root only if the payload is not a v1 or v2 payload.
-        // <https://specs.optimism.io/protocol/rollup-node-p2p.html#block-encoding>
+        // <https://specs.base.org/protocol/consensus/p2p#block-encoding>
         if !matches!(
             self.execution_payload,
             BaseExecutionPayload::V1(_) | BaseExecutionPayload::V2(_)
@@ -155,14 +155,14 @@ impl ExecutionData {
 
     /// Creates a new instance from args to engine API method `newPayloadV2`.
     ///
-    /// Spec: <https://specs.optimism.io/protocol/exec-engine.html#engine_newpayloadv2>
+    /// Spec: <https://specs.base.org/protocol/execution#engine_newpayloadv2>
     pub fn v2(payload: ExecutionPayloadInputV2) -> Self {
         Self::new(BaseExecutionPayload::v2(payload), BaseExecutionPayloadSidecar::default())
     }
 
     /// Creates a new instance from args to engine API method `newPayloadV3`.
     ///
-    /// Spec: <https://specs.optimism.io/protocol/exec-engine.html#engine_newpayloadv3>
+    /// Spec: <https://specs.base.org/protocol/execution#engine_newpayloadv3>
     pub fn v3(
         payload: ExecutionPayloadV3,
         versioned_hashes: Vec<B256>,
@@ -179,7 +179,7 @@ impl ExecutionData {
 
     /// Creates a new instance from args to engine API method `newPayloadV4`.
     ///
-    /// Spec: <https://specs.optimism.io/protocol/exec-engine.html#engine_newpayloadv4>
+    /// Spec: <https://specs.base.org/protocol/execution#engine_newpayloadv4>
     pub fn v4(
         payload: BaseExecutionPayloadV4,
         versioned_hashes: Vec<B256>,

--- a/crates/common/rpc-types-engine/src/payload/mod.rs
+++ b/crates/common/rpc-types-engine/src/payload/mod.rs
@@ -352,7 +352,7 @@ impl BaseExecutionPayload {
     /// Creates a new instance from `newPayloadV2` payload, i.e. [`V1`](Self::V1) or
     /// [`V2`](Self::V2) variant.
     ///
-    /// Spec: <https://specs.optimism.io/protocol/exec-engine.html#engine_newpayloadv2>
+    /// Spec: <https://specs.base.org/protocol/execution#engine_newpayloadv2>
     pub fn v2(payload: ExecutionPayloadInputV2) -> Self {
         match payload.into_payload() {
             ExecutionPayload::V1(payload) => Self::V1(payload),
@@ -363,14 +363,14 @@ impl BaseExecutionPayload {
 
     /// Creates a new instance from `newPayloadV3` payload, i.e. [`V3`](Self::V3) variant.
     ///
-    /// Spec: <https://specs.optimism.io/protocol/exec-engine.html#engine_newpayloadv3>
+    /// Spec: <https://specs.base.org/protocol/execution#engine_newpayloadv3>
     pub const fn v3(payload: ExecutionPayloadV3) -> Self {
         Self::V3(payload)
     }
 
     /// Creates a new instance from `newPayloadV4` payload, i.e. [`V4`](Self::V4) variant.
     ///
-    /// Spec: <https://specs.optimism.io/protocol/exec-engine.html#engine_newpayloadv4>
+    /// Spec: <https://specs.base.org/protocol/execution#engine_newpayloadv4>
     pub const fn v4(payload: BaseExecutionPayloadV4) -> Self {
         Self::V4(payload)
     }

--- a/crates/common/rpc-types-engine/src/payload/v4.rs
+++ b/crates/common/rpc-types-engine/src/payload/v4.rs
@@ -8,7 +8,7 @@ use alloy_primitives::{B256, Bytes, U256};
 use alloy_rpc_types_engine::{BlobsBundleV1, ExecutionPayloadV3, PayloadError};
 
 /// The Base execution payload for `newPayloadV4` of the engine API introduced with isthmus.
-/// See also <https://specs.optimism.io/protocol/isthmus/exec-engine.html#engine_newpayloadv4-api>
+/// See also <https://specs.base.org/upgrades/isthmus/exec-engine#engine_newpayloadv4-api>
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]

--- a/crates/common/rpc-types-engine/src/sidecar.rs
+++ b/crates/common/rpc-types-engine/src/sidecar.rs
@@ -16,12 +16,12 @@ pub struct BaseExecutionPayloadSidecar {
     /// Ecotone request params, inherited from Cancun, introduced in `engine_newPayloadV3` that are
     /// not present in the [`ExecutionPayloadV3`](alloy_rpc_types_engine::ExecutionPayloadV3).
     ///
-    /// NOTE: Blob versioned hashes should always be empty. See <https://specs.optimism.io/protocol/exec-engine.html#engine_newpayloadv3>.
+    /// NOTE: Blob versioned hashes should always be empty. See <https://specs.base.org/protocol/execution#engine_newpayloadv3>.
     ecotone: MaybeCancunPayloadFields,
     /// Isthmus request params, inherited from Prague, introduced in `engine_newPayloadV4` that are
     /// not present in the [`BaseExecutionPayloadV4`].
     ///
-    /// NOTE: These fields, i.e. the EL request hashes, should always be empty. See <https://specs.optimism.io/protocol/exec-engine.html#engine_newpayloadv4>.
+    /// NOTE: These fields, i.e. the EL request hashes, should always be empty. See <https://specs.base.org/protocol/execution#engine_newpayloadv4>.
     isthmus: MaybePraguePayloadFields,
 }
 

--- a/crates/consensus/derive/README.md
+++ b/crates/consensus/derive/README.md
@@ -4,7 +4,7 @@
 
 A `no_std` compatible implementation of Base's [derivation pipeline][derive].
 
-[derive]: https://specs.optimism.io/protocol/derivation.html#l2-chain-derivation-specification
+[derive]: https://specs.base.org/protocol/consensus/derivation#l2-chain-derivation-specification
 
 ## Overview
 

--- a/crates/consensus/derive/src/stages/batch/batch_queue.rs
+++ b/crates/consensus/derive/src/stages/batch/batch_queue.rs
@@ -138,7 +138,7 @@ where
                 BatchValidity::Future => {
                     // Drop Future batches post-holocene.
                     //
-                    // See: <https://specs.optimism.io/protocol/holocene/derivation.html#batch_queue>
+                    // See: <https://specs.base.org/upgrades/holocene/derivation#batch_queue>
                     if !self.cfg.is_holocene_active(origin.timestamp) {
                         remaining.push(batch.clone());
                     } else {

--- a/crates/consensus/derive/src/stages/batch/batch_stream.rs
+++ b/crates/consensus/derive/src/stages/batch/batch_stream.rs
@@ -32,7 +32,7 @@ pub trait BatchStreamProvider {
 /// It slots in between the [`ChannelReader`] and [`BatchQueue`]
 /// stages, buffering span batches until they are validated.
 ///
-/// [`Holocene`]: https://specs.optimism.io/protocol/holocene/overview.html
+/// [`Holocene`]: https://specs.base.org/upgrades/holocene/overview
 /// [`ChannelReader`]: crate::stages::ChannelReader
 /// [`BatchQueue`]: crate::stages::BatchQueue
 #[derive(Debug)]

--- a/crates/consensus/derive/src/stages/channel/channel_reader.rs
+++ b/crates/consensus/derive/src/stages/channel/channel_reader.rs
@@ -102,7 +102,7 @@ where
     /// This method is called by the `BatchStream` if an invalid span batch is found.
     /// In the case of an invalid span batch, the associated channel must be flushed.
     ///
-    /// See: <https://specs.optimism.io/protocol/holocene/derivation.html#span-batches>
+    /// See: <https://specs.base.org/upgrades/holocene/derivation#span-batches>
     ///
     /// SAFETY: Only called post-holocene activation.
     fn flush(&mut self) {

--- a/crates/consensus/engine/src/state/core.rs
+++ b/crates/consensus/engine/src/state/core.rs
@@ -22,7 +22,7 @@ use crate::Metrics;
 /// 2. **Safe** - Derived from L1 data
 /// 3. **Finalized** - Derived from finalized L1 data only
 ///
-/// See the [Base specifications](https://specs.optimism.io) for detailed safety definitions.
+/// See the [Base specifications](https://specs.base.org) for detailed safety definitions.
 #[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
 pub struct EngineSyncState {
     /// Most recent block found on the P2P network (lowest safety level).
@@ -131,7 +131,7 @@ impl EngineState {
     /// is ahead of the safe head. When the two are equal, consolidation isn't
     /// required and the [`crate::BuildTask`] can be used to build the block.
     ///
-    /// [Consolidation]: https://specs.optimism.io/protocol/derivation.html#l1-consolidation-payload-attributes-matching
+    /// [Consolidation]: https://specs.base.org/protocol/consensus/derivation#l1-consolidation-payload-attributes-matching
     pub fn needs_consolidation(&self) -> bool {
         self.sync_state.safe_head() != self.sync_state.unsafe_head()
     }

--- a/crates/consensus/engine/src/task_queue/tasks/task.rs
+++ b/crates/consensus/engine/src/task_queue/tasks/task.rs
@@ -188,7 +188,7 @@ impl<EngineClient_: EngineClient> Ord for EngineTask<EngineClient_> {
     fn cmp(&self, other: &Self) -> Ordering {
         // Order (descending): BuildBlock -> InsertUnsafe -> Consolidate -> Finalize
         //
-        // https://specs.optimism.io/protocol/derivation.html#forkchoice-synchronization
+        // https://specs.base.org/protocol/consensus/derivation#forkchoice-synchronization
         //
         // - Block building jobs are prioritized above all other tasks, to give priority to the
         //   sequencer. BuildTask handles forkchoice updates automatically.

--- a/crates/consensus/gossip/src/behaviour.rs
+++ b/crates/consensus/gossip/src/behaviour.rs
@@ -36,7 +36,7 @@ pub struct Behaviour {
     #[debug(skip)]
     pub identify: libp2p::identify::Behaviour,
     /// Enables the sync request/response protocol.
-    /// See `<https://specs.optimism.io/protocol/rollup-node-p2p.html#payload_by_number>`
+    /// See `<https://specs.base.org/protocol/consensus/p2p#payload_by_number>`
     #[debug(skip)]
     pub sync_req_resp: libp2p_stream::Behaviour,
 }

--- a/crates/consensus/gossip/src/block_validity.rs
+++ b/crates/consensus/gossip/src/block_validity.rs
@@ -99,13 +99,13 @@ impl BlockHandler {
 
     /// The maximum number of blocks to keep per height.
     /// This value is chosen according to the Base specs:
-    /// <https://specs.optimism.io/protocol/rollup-node-p2p.html#block-validation>
+    /// <https://specs.base.org/protocol/consensus/p2p#block-validation>
     const MAX_BLOCKS_TO_KEEP: usize = 5;
 
     /// Determines if a block is valid.
     ///
     /// We validate the block according to the rules defined here:
-    /// <https://specs.optimism.io/protocol/rollup-node-p2p.html#block-validation>
+    /// <https://specs.base.org/protocol/consensus/p2p#block-validation>
     ///
     /// The block encoding/compression are assumed to be valid at this point (they are first checked
     /// in the handle).

--- a/crates/consensus/gossip/src/driver.rs
+++ b/crates/consensus/gossip/src/driver.rs
@@ -132,7 +132,7 @@ where
     /// Handles the sync request/response protocol.
     ///
     /// This is a mock handler that supports the `payload_by_number` protocol.
-    /// It always returns: not found (1), version (0). `<https://specs.optimism.io/protocol/rollup-node-p2p.html#payload_by_number>`
+    /// It always returns: not found (1), version (0). `<https://specs.base.org/protocol/consensus/p2p#payload_by_number>`
     ///
     /// ## Note
     ///
@@ -162,7 +162,7 @@ where
 
                     debug!(target: "gossip", bytes_received, peer_id = %peer_id, payload = ?buffer, "Received inbound sync request");
 
-                    // We return: not found (1), version (0). `<https://specs.optimism.io/protocol/rollup-node-p2p.html#payload_by_number>`
+                    // We return: not found (1), version (0). `<https://specs.base.org/protocol/consensus/p2p#payload_by_number>`
                     // Response format: <response> = <res><version><payload>
                     // No payload is returned.
                     const OUTPUT: [u8; 2] = hex!("0100");

--- a/crates/consensus/protocol/src/batch/single.rs
+++ b/crates/consensus/protocol/src/batch/single.rs
@@ -60,7 +60,7 @@ impl SingleBatch {
     ///
     /// The batch format type is defined in the [Base Specs][specs].
     ///
-    /// [specs]: https://specs.optimism.io/protocol/derivation.html#batch-format
+    /// [specs]: https://specs.base.org/protocol/consensus/derivation#batch-format
     pub fn check_batch(
         &self,
         cfg: &RollupConfig,

--- a/crates/consensus/protocol/src/output_root.rs
+++ b/crates/consensus/protocol/src/output_root.rs
@@ -7,7 +7,7 @@ use derive_more::Display;
 /// block header as well as the storage root of the [`Predeploys::L2_TO_L1_MESSAGE_PASSER`] account
 /// into the top-level commitment construction.
 ///
-/// <https://specs.optimism.io/protocol/proposals.html#l2-output-commitment-construction>
+/// <https://specs.base.org/protocol/fault-proof/proposer#l2-output-commitment-construction>
 ///
 /// [Predeploys::L2_TO_L1_MESSAGE_PASSER]: base_common_consensus::Predeploys::L2_TO_L1_MESSAGE_PASSER
 #[derive(Debug, Display, Clone, Copy, PartialEq, Eq, Hash)]

--- a/crates/consensus/service/README.md
+++ b/crates/consensus/service/README.md
@@ -5,7 +5,7 @@
 
 An implementation of the Base [RollupNode][rn-spec] service.
 
-[rn-spec]: https://specs.optimism.io/protocol/rollup-node.html
+[rn-spec]: https://specs.base.org/protocol/consensus
 
 ## Overview
 

--- a/crates/consensus/upgrades/src/ecotone.rs
+++ b/crates/consensus/upgrades/src/ecotone.rs
@@ -30,12 +30,12 @@ impl Ecotone {
     pub const EIP4788_FROM: Address = address!("0B799C86a49DEeb90402691F1041aa3AF2d3C875");
 
     /// The L1 Block Deployer Code Hash
-    /// See: <https://specs.optimism.io/protocol/ecotone/derivation.html#l1block-deployment>
+    /// See: <https://specs.base.org/upgrades/ecotone/derivation#l1block-deployment>
     pub const L1_BLOCK_DEPLOYER_CODE_HASH: B256 = alloy_primitives::b256!(
         "0xc88a313aa75dc4fbf0b6850d9f9ae41e04243b7008cf3eadb29256d4a71c1dfd"
     );
     /// The Gas Price Oracle Code Hash
-    /// See: <https://specs.optimism.io/protocol/ecotone/derivation.html#gaspriceoracle-deployment>
+    /// See: <https://specs.base.org/upgrades/ecotone/derivation#gaspriceoracle-deployment>
     pub const GAS_PRICE_ORACLE_CODE_HASH: B256 = alloy_primitives::b256!(
         "0x8b71360ea773b4cfaf1ae6d2bd15464a4e1e2e360f786e475f63aeaed8da0ae5"
     );
@@ -95,7 +95,7 @@ impl Ecotone {
     pub fn deposits() -> impl Iterator<Item = TxDeposit> {
         ([
             // Deploy the L1 Block contract for Ecotone.
-            // See: <https://specs.optimism.io/protocol/ecotone/derivation.html#l1block-deployment>
+            // See: <https://specs.base.org/upgrades/ecotone/derivation#l1block-deployment>
             TxDeposit {
                 source_hash: Self::deploy_l1_block_source(),
                 from: Deployers::ECOTONE_L1_BLOCK,
@@ -107,7 +107,7 @@ impl Ecotone {
                 input: Self::l1_block_deployment_bytecode(),
             },
             // Deploy the Gas Price Oracle contract for Ecotone.
-            // See: <https://specs.optimism.io/protocol/ecotone/derivation.html#gaspriceoracle-deployment>
+            // See: <https://specs.base.org/upgrades/ecotone/derivation#gaspriceoracle-deployment>
             TxDeposit {
                 source_hash: Self::deploy_gas_price_oracle_source(),
                 from: Deployers::ECOTONE_GAS_PRICE_ORACLE,
@@ -119,7 +119,7 @@ impl Ecotone {
                 input: Self::ecotone_gas_price_oracle_deployment_bytecode(),
             },
             // Updates the l1 block proxy to point to the new L1 Block contract.
-            // See: <https://specs.optimism.io/protocol/ecotone/derivation.html#l1block-proxy-update>
+            // See: <https://specs.base.org/upgrades/ecotone/derivation#l1block-proxy-update>
             TxDeposit {
                 source_hash: Self::update_l1_block_source(),
                 from: Address::ZERO,
@@ -131,7 +131,7 @@ impl Ecotone {
                 input: UpgradeCalldata::build(Self::NEW_L1_BLOCK),
             },
             // Updates the gas price oracle proxy to point to the new Gas Price Oracle contract.
-            // See: <https://specs.optimism.io/protocol/ecotone/derivation.html#gaspriceoracle-proxy-update>
+            // See: <https://specs.base.org/upgrades/ecotone/derivation#gaspriceoracle-proxy-update>
             TxDeposit {
                 source_hash: Self::update_gas_price_oracle_source(),
                 from: Address::ZERO,
@@ -143,7 +143,7 @@ impl Ecotone {
                 input: UpgradeCalldata::build(Self::GAS_PRICE_ORACLE),
             },
             // Enables the Ecotone Gas Price Oracle.
-            // See: <https://specs.optimism.io/protocol/ecotone/derivation.html#gaspriceoracle-enable-ecotone>
+            // See: <https://specs.base.org/upgrades/ecotone/derivation#gaspriceoracle-enable-ecotone>
             TxDeposit {
                 source_hash: Self::enable_ecotone_source(),
                 from: SystemAddresses::DEPOSITOR_ACCOUNT,
@@ -155,7 +155,7 @@ impl Ecotone {
                 input: Self::ENABLE_ECOTONE_INPUT.into(),
             },
             // Deploys the beacon block roots contract.
-            // See: <https://specs.optimism.io/protocol/ecotone/derivation.html#beacon-block-roots-contract-deployment-eip-4788>
+            // See: <https://specs.base.org/upgrades/ecotone/derivation#beacon-block-roots-contract-deployment-eip-4788>
             TxDeposit {
                 source_hash: Self::beacon_roots_source(),
                 from: Self::EIP4788_FROM,

--- a/crates/consensus/upgrades/src/fjord.rs
+++ b/crates/consensus/upgrades/src/fjord.rs
@@ -26,7 +26,7 @@ impl Fjord {
     pub const SET_FJORD_METHOD_SIGNATURE: [u8; 4] = hex!("8e98b106");
 
     /// The Fjord Gas Price Oracle code hash.
-    /// See: <https://specs.optimism.io/protocol/fjord/derivation.html#gaspriceoracle-deployment>
+    /// See: <https://specs.base.org/upgrades/fjord/derivation#gaspriceoracle-deployment>
     pub const GAS_PRICE_ORACLE_CODE_HASH: B256 = alloy_primitives::b256!(
         "0xa88fa50a2745b15e6794247614b5298483070661adacb8d32d716434ed24c6b2"
     );
@@ -58,7 +58,7 @@ impl Fjord {
     pub fn deposits() -> impl Iterator<Item = TxDeposit> {
         ([
             // Deploys the Fjord Gas Price Oracle contract.
-            // See: <https://specs.optimism.io/protocol/fjord/derivation.html#gaspriceoracle-deployment>
+            // See: <https://specs.base.org/upgrades/fjord/derivation#gaspriceoracle-deployment>
             TxDeposit {
                 source_hash: Self::deploy_fjord_gas_price_oracle_source(),
                 from: Deployers::FJORD_GAS_PRICE_ORACLE,
@@ -70,7 +70,7 @@ impl Fjord {
                 input: Self::gas_price_oracle_deployment_bytecode(),
             },
             // Updates the gas price Oracle proxy to point to the Fjord Gas Price Oracle.
-            // See: <https://specs.optimism.io/protocol/fjord/derivation.html#gaspriceoracle-proxy-update>
+            // See: <https://specs.base.org/upgrades/fjord/derivation#gaspriceoracle-proxy-update>
             TxDeposit {
                 source_hash: Self::update_fjord_gas_price_oracle_source(),
                 from: Address::ZERO,
@@ -82,7 +82,7 @@ impl Fjord {
                 input: UpgradeCalldata::build(Self::FJORD_GAS_PRICE_ORACLE),
             },
             // Enables the Fjord Gas Price Oracle.
-            // See: <https://specs.optimism.io/protocol/fjord/derivation.html#gaspriceoracle-enable-fjord>
+            // See: <https://specs.base.org/upgrades/fjord/derivation#gaspriceoracle-enable-fjord>
             TxDeposit {
                 source_hash: Self::enable_fjord_source(),
                 from: SystemAddresses::DEPOSITOR_ACCOUNT,

--- a/crates/consensus/upgrades/src/isthmus.rs
+++ b/crates/consensus/upgrades/src/isthmus.rs
@@ -2,7 +2,7 @@
 //!
 //! Isthmus network upgrade transactions are defined in the [Base Specs][specs].
 //!
-//! [specs]: https://specs.optimism.io/protocol/isthmus/derivation.html#network-upgrade-automation-transactions
+//! [specs]: https://specs.base.org/upgrades/isthmus/derivation#network-upgrade-automation-transactions
 
 use alloc::vec::Vec;
 
@@ -41,18 +41,18 @@ impl Isthmus {
     pub const OPERATOR_FEE_VAULT: Address = address!("4fa2be8cd41504037f1838bce3bcc93bc68ff537");
 
     /// The Isthmus L1 Block Deployer Code Hash
-    /// See: <https://specs.optimism.io/protocol/isthmus/derivation.html#l1block-deployment>
+    /// See: <https://specs.base.org/upgrades/isthmus/derivation#l1block-deployment>
     pub const L1_BLOCK_DEPLOYER_CODE_HASH: B256 = alloy_primitives::b256!(
         "0x8e3fe7a416d3e5f3b7be74ddd4e7e58e516fa3f80b67c6d930e3cd7297da4a4b"
     );
 
     /// The Isthmus Gas Price Oracle Code Hash
-    /// See: <https://specs.optimism.io/protocol/isthmus/derivation.html#gaspriceoracle-deployment>
+    /// See: <https://specs.base.org/upgrades/isthmus/derivation#gaspriceoracle-deployment>
     pub const GAS_PRICE_ORACLE_CODE_HASH: B256 = alloy_primitives::b256!(
         "0x4d195a9d7caf9fb6d4beaf80de252c626c853afd5868c4f4f8d19c9d301c2679"
     );
     /// The Isthmus Operator Fee Vault Code Hash
-    /// See: <https://specs.optimism.io/protocol/isthmus/derivation.html#operator-fee-vault-deployment>
+    /// See: <https://specs.base.org/upgrades/isthmus/derivation#operator-fee-vault-deployment>
     pub const OPERATOR_FEE_VAULT_CODE_HASH: B256 = alloy_primitives::b256!(
         "0x57dc55c9c09ca456fa728f253fe7b895d3e6aae0706104935fe87c7721001971"
     );

--- a/crates/consensus/upgrades/src/jovian.rs
+++ b/crates/consensus/upgrades/src/jovian.rs
@@ -2,7 +2,7 @@
 //!
 //! Jovian network upgrade transactions are defined in the [Base Specs][specs].
 //!
-//! [specs]: https://specs.optimism.io/protocol/jovian/derivation.html#network-upgrade-automation-transactions
+//! [specs]: https://specs.base.org/upgrades/jovian/derivation#network-upgrade-automation-transactions
 
 use alloc::vec::Vec;
 

--- a/crates/execution/consensus/src/validation/canyon.rs
+++ b/crates/execution/consensus/src/validation/canyon.rs
@@ -26,7 +26,7 @@ pub fn ensure_empty_withdrawals_root<H: BlockHeader>(header: &H) -> Result<(), C
 }
 
 /// Verifies that withdrawals in block body (Shanghai) is always empty in Canyon.
-/// <https://specs.optimism.io/protocol/rollup-node-p2p.html#block-validation>
+/// <https://specs.base.org/protocol/consensus/p2p#block-validation>
 #[inline]
 pub fn ensure_empty_shanghai_withdrawals<T: BlockBody>(body: &T) -> Result<(), BaseConsensusError> {
     // Shanghai rule

--- a/crates/execution/consensus/src/validation/isthmus.rs
+++ b/crates/execution/consensus/src/validation/isthmus.rs
@@ -61,7 +61,7 @@ pub fn withdrawals_root_prehashed<DB: StorageRootProvider>(
 ///
 /// Takes state updates resulting from execution of block.
 ///
-/// See <https://specs.optimism.io/protocol/isthmus/exec-engine.html#l2tol1messagepasser-storage-root-in-header>.
+/// See <https://specs.base.org/upgrades/isthmus/exec-engine#l2tol1messagepasser-storage-root-in-header>.
 pub fn verify_withdrawals_root<DB, H>(
     state_updates: &BundleState,
     state: DB,
@@ -99,7 +99,7 @@ where
 /// Takes pre-hashed storage updates of `L2ToL1MessagePasser.sol` predeploy, resulting from
 /// execution of block, if any. Otherwise takes empty [`HashedStorage::default`].
 ///
-/// See <https://specs.optimism.io/protocol/isthmus/exec-engine.html#l2tol1messagepasser-storage-root-in-header>.
+/// See <https://specs.base.org/upgrades/isthmus/exec-engine#l2tol1messagepasser-storage-root-in-header>.
 pub fn verify_withdrawals_root_prehashed<DB, H>(
     hashed_storage_updates: HashedStorage,
     state: DB,

--- a/crates/execution/engine-tree/src/cached_execution.rs
+++ b/crates/execution/engine-tree/src/cached_execution.rs
@@ -78,7 +78,7 @@ where
         }
 
         trace!(tx_hash = ?tx_hash, "cache hit for transaction");
-        pending_blocks.get_op_tx_result(tx_hash)
+        pending_blocks.get_tx_result(tx_hash)
     }
 }
 

--- a/crates/execution/flashblocks/src/pending_blocks.rs
+++ b/crates/execution/flashblocks/src/pending_blocks.rs
@@ -351,7 +351,7 @@ impl PendingBlocks {
     }
 
     /// Returns the receipt and state for a transaction.
-    pub fn get_op_tx_result(&self, tx_hash: &B256) -> Option<BaseTxResult<OpHaltReason, OpTxType>> {
+    pub fn get_tx_result(&self, tx_hash: &B256) -> Option<BaseTxResult<OpHaltReason, OpTxType>> {
         let (((result, state), tx), sender) = self
             .get_transaction_result(tx_hash)
             .zip(self.get_transaction_state(tx_hash))
@@ -824,12 +824,12 @@ mod tests {
     }
 
     #[test]
-    fn get_op_tx_result_reconstructs_all_fields_for_legacy_tx() {
+    fn get_tx_result_reconstructs_all_fields_for_legacy_tx() {
         let da_footprint = 42_000u64;
         let (tx_hash, pending_blocks) =
             build_pending_blocks(test_legacy_transaction(), Some(da_footprint));
 
-        let result = pending_blocks.get_op_tx_result(&tx_hash).expect("should return tx result");
+        let result = pending_blocks.get_tx_result(&tx_hash).expect("should return tx result");
 
         assert_eq!(result.inner.blob_gas_used, da_footprint);
         assert_eq!(result.inner.tx_type, OpTxType::Legacy);
@@ -839,10 +839,10 @@ mod tests {
     }
 
     #[test]
-    fn get_op_tx_result_reconstructs_all_fields_for_deposit_tx() {
+    fn get_tx_result_reconstructs_all_fields_for_deposit_tx() {
         let (tx_hash, pending_blocks) = build_pending_blocks(test_deposit_transaction(), Some(0));
 
-        let result = pending_blocks.get_op_tx_result(&tx_hash).expect("should return tx result");
+        let result = pending_blocks.get_tx_result(&tx_hash).expect("should return tx result");
 
         assert_eq!(result.inner.blob_gas_used, 0);
         assert_eq!(result.inner.tx_type, OpTxType::Deposit);
@@ -852,16 +852,16 @@ mod tests {
     }
 
     #[test]
-    fn get_op_tx_result_defaults_blob_gas_to_zero_when_receipt_field_is_none() {
+    fn get_tx_result_defaults_blob_gas_to_zero_when_receipt_field_is_none() {
         let (tx_hash, pending_blocks) = build_pending_blocks(test_legacy_transaction(), None);
 
-        let result = pending_blocks.get_op_tx_result(&tx_hash).expect("should return tx result");
+        let result = pending_blocks.get_tx_result(&tx_hash).expect("should return tx result");
 
         assert_eq!(result.inner.blob_gas_used, 0);
     }
 
     #[test]
-    fn get_op_tx_result_defaults_blob_gas_to_zero_without_receipt() {
+    fn get_tx_result_defaults_blob_gas_to_zero_without_receipt() {
         let tx = test_legacy_transaction();
         let tx_hash = tx.tx_hash();
         let mut builder = PendingBlocksBuilder::default();
@@ -874,7 +874,7 @@ mod tests {
         // Intentionally skip with_receipt to test the no-receipt fallback path
         let pending_blocks = builder.build().expect("should build pending blocks");
 
-        let result = pending_blocks.get_op_tx_result(&tx_hash).expect("should return tx result");
+        let result = pending_blocks.get_tx_result(&tx_hash).expect("should return tx result");
 
         assert_eq!(result.inner.blob_gas_used, 0);
     }

--- a/crates/execution/payload/src/validator.rs
+++ b/crates/execution/payload/src/validator.rs
@@ -51,12 +51,12 @@ where
 /// The checks are done in the order that conforms with the engine-API specification.
 ///
 /// This is intended to be invoked after receiving the payload from the CLI.
-/// The additional fields, starting with [`MaybeCancunPayloadFields`](alloy_rpc_types_engine::MaybeCancunPayloadFields), are not part of the payload, but are additional fields starting in the `engine_newPayloadV3` RPC call, See also <https://specs.optimism.io/protocol/exec-engine.html#engine_newpayloadv3>
+/// The additional fields, starting with [`MaybeCancunPayloadFields`](alloy_rpc_types_engine::MaybeCancunPayloadFields), are not part of the payload, but are additional fields starting in the `engine_newPayloadV3` RPC call, See also <https://specs.base.org/protocol/execution#engine_newpayloadv3>
 ///
 /// If the cancun fields are provided this also validates that the versioned hashes in the block
 /// are empty as well as those passed in the sidecar. If the payload fields are not provided.
 ///
-/// Validation according to specs <https://specs.optimism.io/protocol/exec-engine.html#engine-api>.
+/// Validation according to specs <https://specs.base.org/protocol/execution#engine-api>.
 pub fn ensure_well_formed_payload<ChainSpec, T>(
     chain_spec: ChainSpec,
     payload: ExecutionData,

--- a/crates/execution/rpc/src/engine.rs
+++ b/crates/execution/rpc/src/engine.rs
@@ -20,7 +20,7 @@ use tracing::{debug, instrument, trace};
 
 /// The list of all supported Engine capabilities available over the engine endpoint.
 ///
-/// Spec: <https://specs.optimism.io/protocol/exec-engine.html>
+/// Spec: <https://specs.base.org/protocol/execution>
 pub const ENGINE_CAPABILITIES: &[&str] = &[
     "engine_forkchoiceUpdatedV1",
     "engine_forkchoiceUpdatedV2",
@@ -43,7 +43,7 @@ pub const ENGINE_CAPABILITIES: &[&str] = &[
 /// > The provider should use a JWT authentication layer.
 ///
 /// This follows the Base specs that can be found at:
-/// <https://specs.optimism.io/protocol/exec-engine.html#engine-api>
+/// <https://specs.base.org/protocol/execution#engine-api>
 #[cfg_attr(not(feature = "client"), rpc(server, namespace = "engine"), server_bounds(Engine::PayloadAttributes: jsonrpsee::core::DeserializeOwned))]
 #[cfg_attr(feature = "client", rpc(server, client, namespace = "engine", client_bounds(Engine::PayloadAttributes: jsonrpsee::core::Serialize + Clone), server_bounds(Engine::PayloadAttributes: jsonrpsee::core::DeserializeOwned)))]
 pub trait BaseEngineApi<Engine: EngineTypes> {
@@ -108,7 +108,7 @@ pub trait BaseEngineApi<Engine: EngineTypes> {
     /// See also <https://github.com/ethereum/execution-apis/blob/6709c2a795b707202e93c4f2867fa0bf2640a84f/src/engine/shanghai.md#engine_forkchoiceupdatedv2>
     ///
     /// OP modifications:
-    /// - The `payload_attributes` parameter is extended with the [`EngineTypes::PayloadAttributes`](EngineTypes) type as described in <https://specs.optimism.io/protocol/exec-engine.html#extended-payloadattributesv2>
+    /// - The `payload_attributes` parameter is extended with the [`EngineTypes::PayloadAttributes`](EngineTypes) type as described in <https://specs.base.org/protocol/execution#extended-payloadattributesv2>
     #[method(name = "forkchoiceUpdatedV2")]
     async fn fork_choice_updated_v2(
         &self,
@@ -124,7 +124,7 @@ pub trait BaseEngineApi<Engine: EngineTypes> {
     /// OP modifications:
     /// - Must be called with an Ecotone payload
     /// - Attributes must contain the parent beacon block root field
-    /// - The `payload_attributes` parameter is extended with the [`EngineTypes::PayloadAttributes`](EngineTypes) type as described in <https://specs.optimism.io/protocol/exec-engine.html#extended-payloadattributesv2>
+    /// - The `payload_attributes` parameter is extended with the [`EngineTypes::PayloadAttributes`](EngineTypes) type as described in <https://specs.base.org/protocol/execution#extended-payloadattributesv2>
     #[method(name = "forkchoiceUpdatedV3")]
     async fn fork_choice_updated_v3(
         &self,

--- a/crates/proof/driver/src/cursor.rs
+++ b/crates/proof/driver/src/cursor.rs
@@ -37,7 +37,7 @@ impl PipelineCursor {
     pub fn new(channel_timeout: u64, origin: BlockInfo) -> Self {
         // NOTE: capacity must be greater than the `channel_timeout` to allow
         // for derivation to proceed through a deep reorg.
-        // Ref: <https://specs.optimism.io/protocol/derivation.html#timeouts>
+        // Ref: <https://specs.base.org/protocol/consensus/derivation#timeouts>
         let capacity = channel_timeout as usize + 5;
 
         let mut origins = VecDeque::with_capacity(capacity);

--- a/crates/proof/fpvm-precompiles/src/factory.rs
+++ b/crates/proof/fpvm-precompiles/src/factory.rs
@@ -95,7 +95,7 @@ where
             .with_db(db)
             .with_block(input.block_env)
             .with_cfg(input.cfg_env)
-            .build_op_with_inspector(inspector)
+            .build_with_inspector(inspector)
             .with_precompiles(FpvmPrecompiles::new_with_spec(
                 spec_id,
                 self.hint_writer.clone(),

--- a/crates/proof/fpvm-precompiles/src/precompiles/bls12_g1_add.rs
+++ b/crates/proof/fpvm-precompiles/src/precompiles/bls12_g1_add.rs
@@ -19,7 +19,7 @@ use super::utils::precompile_run;
 /// Performs an FPVM-accelerated BLS12-381 G1 addition check.
 ///
 /// Notice, there is no input size limit for this precompile.
-/// See: <https://specs.optimism.io/protocol/isthmus/exec-engine.html#evm-changes>
+/// See: <https://specs.base.org/upgrades/isthmus/exec-engine#evm-changes>
 pub(crate) fn fpvm_bls12_g1_add<H, O>(
     input: &[u8],
     gas_limit: u64,

--- a/crates/proof/fpvm-precompiles/src/precompiles/bls12_g1_msm.rs
+++ b/crates/proof/fpvm-precompiles/src/precompiles/bls12_g1_msm.rs
@@ -19,7 +19,7 @@ use super::utils::precompile_run;
 
 /// The maximum input size for the BLS12-381 g1 msm operation after the Isthmus Hardfork.
 ///
-/// See: <https://specs.optimism.io/protocol/isthmus/exec-engine.html#evm-changes>
+/// See: <https://specs.base.org/upgrades/isthmus/exec-engine#evm-changes>
 const BLS12_MAX_G1_MSM_SIZE_ISTHMUS: usize = 513760;
 
 /// The maximum input size for the BLS12-381 g1 msm operation after the Jovian Hardfork.

--- a/crates/proof/fpvm-precompiles/src/precompiles/bls12_g2_add.rs
+++ b/crates/proof/fpvm-precompiles/src/precompiles/bls12_g2_add.rs
@@ -19,7 +19,7 @@ use super::utils::precompile_run;
 /// Performs an FPVM-accelerated BLS12-381 G2 addition check.
 ///
 /// Notice, there is no input size limit for this precompile.
-/// See: <https://specs.optimism.io/protocol/isthmus/exec-engine.html#evm-changes>
+/// See: <https://specs.base.org/upgrades/isthmus/exec-engine#evm-changes>
 pub(crate) fn fpvm_bls12_g2_add<H, O>(
     input: &[u8],
     gas_limit: u64,

--- a/crates/proof/fpvm-precompiles/src/precompiles/bls12_g2_msm.rs
+++ b/crates/proof/fpvm-precompiles/src/precompiles/bls12_g2_msm.rs
@@ -19,7 +19,7 @@ use super::utils::precompile_run;
 
 /// The maximum input size for the BLS12-381 g2 msm operation after the Isthmus Hardfork.
 ///
-/// See: <https://specs.optimism.io/protocol/isthmus/exec-engine.html#evm-changes>
+/// See: <https://specs.base.org/upgrades/isthmus/exec-engine#evm-changes>
 const BLS12_MAX_G2_MSM_SIZE_ISTHMUS: usize = 488448;
 
 /// The maximum input size for the BLS12-381 g2 msm operation after the Jovian Hardfork.

--- a/crates/proof/fpvm-precompiles/src/precompiles/bls12_map_fp.rs
+++ b/crates/proof/fpvm-precompiles/src/precompiles/bls12_map_fp.rs
@@ -19,7 +19,7 @@ use super::utils::precompile_run;
 /// Performs an FPVM-accelerated BLS12-381 map fp check.
 ///
 /// Notice, there is no input size limit for this precompile.
-/// See: <https://specs.optimism.io/protocol/isthmus/exec-engine.html#evm-changes>
+/// See: <https://specs.base.org/upgrades/isthmus/exec-engine#evm-changes>
 pub(crate) fn fpvm_bls12_map_fp<H, O>(
     input: &[u8],
     gas_limit: u64,

--- a/crates/proof/fpvm-precompiles/src/precompiles/bls12_map_fp2.rs
+++ b/crates/proof/fpvm-precompiles/src/precompiles/bls12_map_fp2.rs
@@ -19,7 +19,7 @@ use super::utils::precompile_run;
 /// Performs an FPVM-accelerated BLS12-381 map fp2 check.
 ///
 /// Notice, there is no input size limit for this precompile.
-/// See: <https://specs.optimism.io/protocol/isthmus/exec-engine.html#evm-changes>
+/// See: <https://specs.base.org/upgrades/isthmus/exec-engine#evm-changes>
 pub(crate) fn fpvm_bls12_map_fp2<H, O>(
     input: &[u8],
     gas_limit: u64,

--- a/crates/proof/preimage/README.md
+++ b/crates/proof/preimage/README.md
@@ -27,7 +27,7 @@ let data = oracle.get(preimage_key)?;
 hint_writer.write(&hint)?;
 ```
 
-[preimage-abi-spec]: https://specs.optimism.io/experimental/fault-proof/index.html#pre-image-oracle
+[preimage-abi-spec]: https://specs.base.org/protocol/fault-proof#pre-image-oracle
 
 ## License
 

--- a/crates/proof/preimage/src/key.rs
+++ b/crates/proof/preimage/src/key.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize as SerdeDeserialize, Serialize as SerdeSerialize};
 
 use crate::errors::PreimageOracleError;
 
-/// <https://specs.optimism.io/experimental/fault-proof/index.html#pre-image-key-types>
+/// <https://specs.base.org/protocol/fault-proof#pre-image-key-types>
 #[derive(Debug, Default, Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash)]
 #[repr(u8)]
 #[cfg_attr(feature = "serde", derive(SerdeSerialize, SerdeDeserialize))]

--- a/crates/proof/std-fpvm/README.md
+++ b/crates/proof/std-fpvm/README.md
@@ -26,7 +26,7 @@ let mut buf = [0u8; 32];
 BasicKernelInterface::read(fd, &mut buf)?;
 ```
 
-[g-fault-proof-vm]: https://specs.optimism.io/experimental/fault-proof/index.html#fault-proof-vm
+[g-fault-proof-vm]: https://specs.base.org/protocol/fault-proof#fault-proof-vm
 
 ## License
 

--- a/crates/proof/std-fpvm/src/mips64/io.rs
+++ b/crates/proof/std-fpvm/src/mips64/io.rs
@@ -7,7 +7,7 @@ pub(crate) struct Mips64IO;
 
 /// Relevant system call numbers for the `MIPS64r2` target architecture.
 ///
-/// See [Cannon System Call Specification](https://specs.optimism.io/experimental/fault-proof/cannon-fault-proof-vm.html#syscalls)
+/// See [Cannon System Call Specification](https://specs.base.org/protocol/fault-proof/cannon-fault-proof-vm#syscalls)
 ///
 /// **Note**: This is not an exhaustive list of system calls available to the `client` program,
 /// only the ones necessary for the [`BasicKernelInterface`] trait implementation. If an extension

--- a/docs/specs/pages/protocol/execution/evm/predeploys.md
+++ b/docs/specs/pages/protocol/execution/evm/predeploys.md
@@ -333,4 +333,4 @@ Ecotone network upgrade and is specified in [EIP-4788](https://eips.ethereum.org
 
 Address: `0x420000000000000000000000000000000000001B`
 
-See [Operator Fee Vault](https://specs.optimism.io/protocol/isthmus/predeploys.html#operatorfeevault) spec.
+See [Operator Fee Vault](https://specs.base.org/upgrades/isthmus/predeploys#operatorfeevault) spec.


### PR DESCRIPTION
## Summary

Replaces all `specs.optimism.io` doc comment and README links with their verified `specs.base.org` equivalents, mapping the old flat `protocol/*.html` and `experimental/` paths to the new hierarchical structure under `protocol/consensus/`, `upgrades/`, and `protocol/fault-proof/`. The `docs/specs/pages/index.md` OP Stack historical reference is intentionally left pointing at `specs.optimism.io` since it describes lineage, not a Base spec page. Also drops the `op` prefix from two internal method names: `build_op_with_inspector` → `build_with_inspector` and `get_op_tx_result` → `get_tx_result`.