### PR TITLE
chore(docs): Remove Stale Comments

### DIFF
--- a/actions/harness/src/engine.rs
+++ b/actions/harness/src/engine.rs
@@ -670,7 +670,7 @@ impl EngineClient for ActionEngineClient {
     async fn new_payload_v1(&self, _payload: ExecutionPayloadV1) -> TransportResult<PayloadStatus> {
         Err(TransportError::from(TransportErrorKind::custom_str(
             "ActionEngineClient does not support new_payload_v1 \
-             (OP Stack derivation uses new_payload_v2 or later)",
+             (Base derivation uses new_payload_v2 or later)",
         )))
     }
 

--- a/actions/harness/tests/derivation.rs
+++ b/actions/harness/tests/derivation.rs
@@ -392,7 +392,7 @@ async fn reorg_flip_flop_empty_middle_fork() {
 
     node.act_reset(l2_genesis).await;
     // act_reset sets safe_head and finalized_head to the reset target (l2_genesis).
-    // Per the OP Stack spec, unsafe_head is NOT clamped to safe_head on reset —
+    // Per the Base spec, unsafe_head is NOT clamped to safe_head on reset —
     // it is re-discovered by walking back from the current tip to the first block
     // with a plausible (canonical or ahead-of-L1) L1 origin.  In this node-only
     // context no gossip blocks were received, so unsafe_head was never advanced

--- a/crates/client/cli/src/p2p.rs
+++ b/crates/client/cli/src/p2p.rs
@@ -162,14 +162,14 @@ pub struct P2PArgs {
     /// The threshold used to ban peers.
     ///
     /// For peers to be banned, the `p2p.ban.peers` flag must be set to `true`.
-    /// By default, peers are banned if their score is below -100. This follows the `op-node` default `<https://github.com/ethereum-optimism/optimism/blob/09a8351a72e43647c8a96f98c16bb60e7b25dc6e/op-node/flags/p2p_flags.go#L123-L130>`.
+    /// By default, peers are banned if their score is below -100. This follows the reference node default `<https://github.com/ethereum-optimism/optimism/blob/09a8351a72e43647c8a96f98c16bb60e7b25dc6e/op-node/flags/p2p_flags.go#L123-L130>`.
     #[arg(long = "p2p.ban.threshold", default_value = "-100", env = "BASE_NODE_P2P_BAN_THRESHOLD")]
     pub ban_threshold: i64,
 
     /// The duration in minutes to ban a peer for.
     ///
     /// For peers to be banned, the `p2p.ban.peers` flag must be set to `true`.
-    /// By default peers are banned for 1 hour. This follows the `op-node` default `<https://github.com/ethereum-optimism/optimism/blob/09a8351a72e43647c8a96f98c16bb60e7b25dc6e/op-node/flags/p2p_flags.go#L131-L138>`.
+    /// By default peers are banned for 1 hour. This follows the reference node default `<https://github.com/ethereum-optimism/optimism/blob/09a8351a72e43647c8a96f98c16bb60e7b25dc6e/op-node/flags/p2p_flags.go#L131-L138>`.
     #[arg(long = "p2p.ban.duration", default_value = "60", env = "BASE_NODE_P2P_BAN_DURATION")]
     pub ban_duration: u64,
 
@@ -207,8 +207,8 @@ pub struct P2PArgs {
     ///
     /// Topic scoring is a mechanism to score peers based on their behavior in the gossip network.
     /// Historically, topic scoring was only enabled for the v1 topic on the Base p2p network
-    /// in the `op-node`. This was a silent bug, and topic scoring is actively being
-    /// [phased out of the `op-node`][out].
+    /// in the reference node. This was a silent bug, and topic scoring is actively being
+    /// [phased out of the reference node][out].
     ///
     /// This flag is only presented for backwards compatibility and debugging purposes.
     ///

--- a/crates/common/access-lists/tests/builder/transfers.rs
+++ b/crates/common/access-lists/tests/builder/transfers.rs
@@ -92,7 +92,7 @@ fn test_gas_included_in_balance_change() {
     assert!(!sender_changes.balance_changes.is_empty(), "Sender should have balance change");
 
     // Verify there's a fee vault/beneficiary that received the gas payment
-    // In OP stack this is typically the sequencer fee vault
+    // In Base this is typically the sequencer fee vault
     let fee_recipients: Vec<_> = access_list
         .account_changes
         .iter()

--- a/crates/consensus/derive/src/pipeline/core.rs
+++ b/crates/consensus/derive/src/pipeline/core.rs
@@ -51,7 +51,7 @@ where
     /// is at most `channel_timeout` L1 blocks behind the safe head's L1 origin, then returns
     /// that block's L1 origin and system config.
     ///
-    /// This matches op-node's `initialReset` behavior: using the system config from a
+    /// This matches the reference node's `initialReset` behavior: using the system config from a
     /// potentially older L2 block ensures we see any batcher-address changes that could
     /// affect channels still open within the channel timeout window.
     async fn initial_reset(

--- a/crates/consensus/engine/src/task_queue/tasks/consolidate/task_test.rs
+++ b/crates/consensus/engine/src/task_queue/tasks/consolidate/task_test.rs
@@ -25,7 +25,7 @@ use crate::{
 /// correct parent, so the comparison is invalid.
 ///
 /// After the fix the reconcile path proceeds to `seal_and_canonicalize_block`
-/// directly, matching op-node's behaviour.
+/// directly, matching the reference node's behaviour.
 ///
 /// This test FAILS on unfixed main and PASSES after the fix lands.
 #[tokio::test]

--- a/crates/consensus/engine/src/task_queue/tasks/seal/task.rs
+++ b/crates/consensus/engine/src/task_queue/tasks/seal/task.rs
@@ -279,7 +279,7 @@ impl<EngineClient_: EngineClient> EngineTaskExt for SealTask<EngineClient_> {
             "Starting new seal job"
         );
 
-        // NOTE: op-node does not compare the current unsafe head against the
+        // NOTE: the reference node does not compare the current unsafe head against the
         // attributes parent before sealing.  The BuildTask already sent an FCU
         // with `attributes.parent` as the head, so the EL is building on the
         // correct parent regardless of where the engine's in-memory unsafe head

--- a/crates/consensus/engine/src/versions.rs
+++ b/crates/consensus/engine/src/versions.rs
@@ -11,7 +11,7 @@
 //! - **Isthmus, Jovian** → V4 methods
 //! - **Base Azul (Osaka)** → `getPayloadV5`, `newPayloadV4`
 //!
-//! Adapted from the [OP Node version providers](https://github.com/ethereum-optimism/optimism/blob/develop/op-node/rollup/types.go#L546).
+//! Adapted from the [reference node version providers](https://github.com/ethereum-optimism/optimism/blob/develop/op-node/rollup/types.go#L546).
 
 use base_consensus_genesis::RollupConfig;
 

--- a/crates/consensus/genesis/src/chain/hardfork.rs
+++ b/crates/consensus/genesis/src/chain/hardfork.rs
@@ -71,7 +71,7 @@ pub struct HardForkConfig {
     pub holocene_time: Option<u64>,
     /// `pectra_blob_schedule_time` sets the activation time for the activation of the Pectra blob
     /// fee schedule for the L1 block info transaction. This is an optional fork, only present
-    /// on Base sepolia chains that observed the L1 Pectra network upgrade with `op-node`
+    /// on Base sepolia chains that observed the L1 Pectra network upgrade with the reference node
     /// <=v1.11.1 sequencing the network.
     ///
     /// Active if `pectra_blob_schedule_time` != None && L2 block timestamp >=

--- a/crates/consensus/genesis/src/system/config.rs
+++ b/crates/consensus/genesis/src/system/config.rs
@@ -124,7 +124,7 @@ impl SystemConfig {
     ///
     /// Each config update log is applied independently. Malformed or invalid updates are
     /// skipped so that subsequent valid updates in the same block are still processed.
-    /// This matches the op-node reference behavior in `UpdateSystemConfigWithL1Receipts`.
+    /// This matches the reference node behavior in `UpdateSystemConfigWithL1Receipts`.
     ///
     /// Returns the successfully applied update kinds and any errors encountered.
     pub fn update_with_receipts(

--- a/crates/consensus/gossip/src/block_validity.rs
+++ b/crates/consensus/gossip/src/block_validity.rs
@@ -93,7 +93,7 @@ impl BlockHandler {
     /// Ie, the entries pruned must be old enough blocks to be considered invalid
     /// if new blocks for that height are received.
     ///
-    /// This value is chosen to match `op-node` validator's lru cache size.
+    /// This value is chosen to match the reference node validator's lru cache size.
     /// See: <https://github.com/ethereum-optimism/optimism/blob/836d50be5d5f4ae14ffb2ea6106720a2b080cdae/op-node/p2p/gossip.go#L266>
     pub const SEEN_HASH_CACHE_SIZE: usize = 1_000;
 

--- a/crates/consensus/gossip/src/rpc/request.rs
+++ b/crates/consensus/gossip/src/rpc/request.rs
@@ -318,7 +318,7 @@ impl P2pRpcRequest {
 
         // We consider that base-nodes are gossiping blocks if their peers are subscribed to any of
         // the blocks topics.
-        // This is the same heuristic as the one used in the op-node (`<https://github.com/ethereum-optimism/optimism/blob/6a8b2349c29c2a14f948fcb8aefb90526130acec/op-node/p2p/rpc_server.go#L179-L183>`).
+        // This is the same heuristic as the one used in the reference node (`<https://github.com/ethereum-optimism/optimism/blob/6a8b2349c29c2a14f948fcb8aefb90526130acec/op-node/p2p/rpc_server.go#L179-L183>`).
         let peer_gossip_info = gossip
             .swarm
             .behaviour()
@@ -417,7 +417,7 @@ impl P2pRpcRequest {
                             connectedness: peer_connectedness,
                             direction,
                             // Note: we use the chain id from the ENR if it exists, otherwise we
-                            // use 0 to be consistent with op-node's behavior (`<https://github.com/ethereum-optimism/optimism/blob/6a8b2349c29c2a14f948fcb8aefb90526130acec/op-service/apis/p2p.go#L55>`).
+                            // use 0 to be consistent with the reference node's behavior (`<https://github.com/ethereum-optimism/optimism/blob/6a8b2349c29c2a14f948fcb8aefb90526130acec/op-service/apis/p2p.go#L55>`).
                             chain_id: base_enr.map(|enr| enr.chain_id).unwrap_or(0),
                             gossip_blocks: peer_gossip_info.contains(peer_id),
                             protected: protected_peers.contains(peer_id),

--- a/crates/consensus/gossip/src/rpc/types.rs
+++ b/crates/consensus/gossip/src/rpc/types.rs
@@ -227,7 +227,7 @@ pub struct PeerStats {
     Eq,
     Copy,
     Default,
-    // We need to use `serde_repr` to serialize the enum as an integer to match the `op-node` API.
+    // We need to use `serde_repr` to serialize the enum as an integer to match the reference node API.
     serde_repr::Serialize_repr,
     serde_repr::Deserialize_repr,
 )]

--- a/crates/consensus/protocol/src/batch/raw.rs
+++ b/crates/consensus/protocol/src/batch/raw.rs
@@ -134,7 +134,7 @@ mod tests {
 
     #[test]
     fn test_decode_encode_raw_span_batch() {
-        // Load in the raw span batch from the `op-node` derivation pipeline implementation.
+        // Load in the raw span batch from the reference derivation pipeline implementation.
         let raw_span_batch_hex = include_bytes!("./testdata/raw_batch.hex");
         let raw_span_batch = RawSpanBatch::decode(&mut raw_span_batch_hex.as_slice()).unwrap();
 

--- a/crates/consensus/providers/src/conf_depth.rs
+++ b/crates/consensus/providers/src/conf_depth.rs
@@ -2,7 +2,7 @@
 //!
 //! Wraps an [`AlloyChainProvider`] to enforce an L1 confirmation depth cutoff on
 //! `block_info_by_number` lookups. This prevents the derivation pipeline from reading
-//! L1 blocks that are too close to the chain tip, matching the behaviour of op-node's
+//! L1 blocks that are too close to the chain tip, matching the behaviour of the reference node's
 //! `ConfDepth` wrapper.
 
 use std::sync::{
@@ -28,7 +28,7 @@ pub type L1HeadNumber = Arc<AtomicU64>;
 ///
 /// When `conf_depth > 0`, `block_info_by_number(n)` returns a temporary `BlockNotFound`
 /// error for any block `n` where `n + conf_depth > l1_head`. This causes the derivation
-/// pipeline to yield and retry later, matching the behavior of op-node's `ConfDepth` wrapper.
+/// pipeline to yield and retry later, matching the behavior of the reference node's `ConfDepth` wrapper.
 ///
 /// All other methods delegate to the inner [`AlloyChainProvider`] unchanged.
 #[derive(Debug, Clone)]

--- a/crates/consensus/rpc/src/rollup.rs
+++ b/crates/consensus/rpc/src/rollup.rs
@@ -54,7 +54,7 @@ impl<EngineRpcClient_: EngineRpcClient> RollupRpc<EngineRpcClient_> {
         Self { engine_client, l1_watcher_sender, safe_db_reader }
     }
 
-    // Important note: we zero-out the fields that can't be derived yet to follow op-node's
+    // Important note: we zero-out the fields that can't be derived yet to follow the reference node's
     // behaviour.
     fn sync_status_from_actor_queries(
         l1_sync_status: L1State,

--- a/crates/consensus/service/src/actors/sequencer/admin_api_impl.rs
+++ b/crates/consensus/service/src/actors/sequencer/admin_api_impl.rs
@@ -123,7 +123,7 @@ where
     /// - `unsafe_head` does not match the engine's current unsafe head hash.
     ///
     /// When a conductor is configured, this checks `conductor_leader` before activating,
-    /// matching op-node's `Start()` behavior. If the node is not the leader the call returns
+    /// matching the reference node's `Start()` behavior. If the node is not the leader the call returns
     /// [`SequencerAdminAPIError::NotLeader`] and the sequencer remains inactive.
     pub(super) async fn start_sequencer(
         &mut self,

--- a/crates/execution/flashblocks/src/rpc/eth.rs
+++ b/crates/execution/flashblocks/src/rpc/eth.rs
@@ -38,7 +38,7 @@ impl<'de> serde::Deserialize<'de> for BlockNumberOrTagExt {
             }
 
             fn visit_str<E: serde::de::Error>(self, v: &str) -> Result<Self::Value, E> {
-                // Remap the OP Stack "unsafe" tag to "latest". Our EL surfaces the unsafe
+                // Remap the Base "unsafe" tag to "latest". Our EL surfaces the unsafe
                 // head as "latest" (the most recently sealed block via engine_forkchoiceUpdated).
                 if v == "unsafe" {
                     return Ok(BlockNumberOrTagExt(BlockNumberOrTag::Latest));

--- a/crates/execution/node/tests/e2e-testsuite/p2p.rs
+++ b/crates/execution/node/tests/e2e-testsuite/p2p.rs
@@ -64,7 +64,7 @@ async fn can_sync() -> eyre::Result<()> {
     let side_chain = side_payload_chain.iter().map(|p| p.block().hash()).collect::<Vec<_>>();
 
     // Creates fork chain by submitting 89b payload.
-    // By returning Valid here, op-node will finally return a finalized hash
+    // By returning Valid here, the consensus node will finally return a finalized hash
     let _ = third_node.submit_payload(side_payload_chain[0].clone()).await;
 
     // It will issue a pipeline reorg to 88a, and then make 89b canonical AND finalized.

--- a/crates/execution/rpc/src/engine.rs
+++ b/crates/execution/rpc/src/engine.rs
@@ -90,7 +90,7 @@ pub trait BaseEngineApi<Engine: EngineTypes> {
 
     /// See also <https://github.com/ethereum/execution-apis/blob/6709c2a795b707202e93c4f2867fa0bf2640a84f/src/engine/paris.md#engine_forkchoiceupdatedv1>
     ///
-    /// This exists because it is used by op-node: <https://github.com/ethereum-optimism/optimism/blob/0bc5fe8d16155dc68bcdf1fa5733abc58689a618/op-node/rollup/types.go#L615-L617>
+    /// This exists for compatibility with consensus nodes: <https://github.com/ethereum-optimism/optimism/blob/0bc5fe8d16155dc68bcdf1fa5733abc58689a618/op-node/rollup/types.go#L615-L617>
     ///
     /// Caution: This should not accept the `withdrawals` field in the payload attributes.
     #[method(name = "forkchoiceUpdatedV1")]

--- a/crates/infra/basectl/src/config.rs
+++ b/crates/infra/basectl/src/config.rs
@@ -292,12 +292,12 @@ impl ChainConfig {
         let provider = ProviderBuilder::new()
             .connect(op_node_url.as_str())
             .await
-            .with_context(|| format!("Failed to connect to op-node at {op_node_url}"))?;
+            .with_context(|| format!("Failed to connect to consensus node at {op_node_url}"))?;
 
         let config: RollupConfig = provider
             .raw_request("optimism_rollupConfig".into(), ())
             .await
-            .with_context(|| "Failed to fetch rollup config from op-node")?;
+            .with_context(|| "Failed to fetch rollup config from consensus node")?;
 
         Ok(config)
     }
@@ -359,7 +359,7 @@ impl ChainConfig {
         let op_node_url = config.op_node_rpc.as_ref().expect("devnet should have op_node_rpc");
 
         let rollup_config = Self::fetch_rollup_config(op_node_url).await.with_context(
-            || "Failed to fetch rollup config from op-node. Is the devnet running?",
+            || "Failed to fetch rollup config from consensus node. Is the devnet running?",
         )?;
 
         config.system_config = rollup_config.l1_system_config_address;

--- a/crates/infra/basectl/src/config.rs
+++ b/crates/infra/basectl/src/config.rs
@@ -294,10 +294,11 @@ impl ChainConfig {
             .await
             .with_context(|| format!("Failed to connect to consensus node at {op_node_url}"))?;
 
-        let config: RollupConfig = provider
-            .raw_request("optimism_rollupConfig".into(), ())
-            .await
-            .with_context(|| "Failed to fetch rollup config from consensus node")?;
+        let config: RollupConfig =
+            provider
+                .raw_request("optimism_rollupConfig".into(), ())
+                .await
+                .with_context(|| "Failed to fetch rollup config from consensus node")?;
 
         Ok(config)
     }

--- a/crates/infra/load-tests/src/runner/load_runner.rs
+++ b/crates/infra/load-tests/src/runner/load_runner.rs
@@ -985,7 +985,7 @@ impl LoadRunner {
         let max_fee =
             gas_price.saturating_mul(2).max(max_priority_fee).min(self.config.max_gas_price);
         let drain_gas_limit = 21_000u128;
-        // L1 data fee on OP Stack can be significant (0.0001-0.001 ETH depending on L1 gas prices).
+        // L1 data fee on Base can be significant (0.0001-0.001 ETH depending on L1 gas prices).
         // Use 0.001 ETH (1e15 wei) buffer to be safe. We may leave dust in accounts.
         let l1_fee_buffer = 1_000_000_000_000_000u128;
         let drain_gas_cost = U256::from(drain_gas_limit * max_fee + l1_fee_buffer);

--- a/crates/utilities/tx-manager/src/error.rs
+++ b/crates/utilities/tx-manager/src/error.rs
@@ -239,7 +239,7 @@ pub type TxManagerResult<T> = Result<T, TxManagerError>;
 /// Classifies alloy [`TransportError`]s into structured [`TxManagerError`]
 /// variants.
 ///
-/// This mirrors the Go `op-service/txmgr` `errStringMatch` approach, enabling
+/// This mirrors the Go `txmgr` `errStringMatch` approach, enabling
 /// the send loop to make retry/abort decisions based on error type.
 ///
 /// For server-returned errors ([`RpcError::ErrorResp`]), classification uses

--- a/devnet/src/deployer/mod.rs
+++ b/devnet/src/deployer/mod.rs
@@ -4,4 +4,4 @@ pub mod artifacts;
 pub mod op_deployer;
 
 pub use artifacts::DeploymentArtifacts;
-pub use op_deployer::{OpDeployerContainer, RoleAddresses};
+pub use op_deployer::{DeployerContainer, RoleAddresses};

--- a/devnet/src/deployer/op_deployer.rs
+++ b/devnet/src/deployer/op_deployer.rs
@@ -58,9 +58,9 @@ impl Default for RoleAddresses {
     }
 }
 
-/// op-deployer container wrapper for L2 contract deployment.
+/// Container wrapper for L2 contract deployment via op-deployer.
 #[derive(Debug)]
-pub struct OpDeployerContainer {
+pub struct DeployerContainer {
     l1_rpc_url: Url,
     l1_chain_id: u64,
     l2_chain_id: u64,
@@ -70,8 +70,8 @@ pub struct OpDeployerContainer {
     network: Option<String>,
 }
 
-impl OpDeployerContainer {
-    /// Creates a new op-deployer container wrapper.
+impl DeployerContainer {
+    /// Creates a new deployer container wrapper.
     pub fn new(
         l1_rpc_url: Url,
         l1_chain_id: u64,

--- a/devnet/src/l2/in_process_builder.rs
+++ b/devnet/src/l2/in_process_builder.rs
@@ -54,7 +54,7 @@ pub struct InProcessBuilderConfig {
 /// An in-process builder node that replaces Docker-based `BuilderContainer`.
 ///
 /// This spawns a real builder node within the current process, binding to dynamic ports.
-/// Docker containers (like op-node) can connect via `host.docker.internal`.
+/// Docker containers (like consensus nodes) can connect via `host.docker.internal`.
 pub struct InProcessBuilder {
     http_api_addr: SocketAddr,
     ws_api_addr: SocketAddr,

--- a/devnet/src/rpc.rs
+++ b/devnet/src/rpc.rs
@@ -85,7 +85,7 @@ impl DevnetRpcClient {
         Ok((l1, l2_builder, l2_client))
     }
 
-    /// Get sync status from L2 builder op-node.
+    /// Get sync status from the L2 builder consensus node.
     pub async fn l2_builder_sync_status(&self) -> Result<SyncStatus> {
         self.l2_builder_op_client
             .sync_status()
@@ -93,7 +93,7 @@ impl DevnetRpcClient {
             .wrap_err("Failed to get L2 builder sync status")
     }
 
-    /// Get sync status from L2 client op-node.
+    /// Get sync status from the L2 client consensus node.
     pub async fn l2_client_sync_status(&self) -> Result<SyncStatus> {
         self.l2_client_op_client.sync_status().await.wrap_err("Failed to get L2 client sync status")
     }


### PR DESCRIPTION
## Summary

Removes all remaining "op-node" and "OP Stack" branding from doc comments, inline comments, and user-facing error strings across 27 files. References to behavior copied from the reference Go implementation now say "the reference node" instead of "op-node", "OP Stack" descriptions of Base behavior now say "Base", and user-facing error messages in basectl now say "consensus node". Also renames `OpDeployerContainer` to `DeployerContainer` in the devnet deployer crate. GitHub source attribution URLs into the ethereum-optimism monorepo are preserved unchanged since they identify specific reference implementations.