### PR TITLE
chore(execution): Rename Base Types

### DIFF
--- a/actions/harness/src/engine.rs
+++ b/actions/harness/src/engine.rs
@@ -1,4 +1,4 @@
-//! In-process engine client for action tests backed by the production `OpPayloadBuilder`.
+//! In-process engine client for action tests backed by the production `BasePayloadBuilder`.
 
 use std::{
     collections::HashMap,
@@ -37,7 +37,7 @@ use base_consensus_node::{EngineClientError as NodeEngineClientError, SequencerE
 use base_execution_chainspec::BaseChainSpec;
 use base_execution_evm::BaseEvmConfig;
 use base_execution_payload_builder::{
-    OpBuiltPayload, OpPayloadBuilder, OpPayloadBuilderAttributes,
+    BaseBuiltPayload, BasePayloadBuilder, BasePayloadBuilderAttributes,
 };
 use base_execution_txpool::BasePooledTransaction;
 use base_node_core::BaseNode;
@@ -76,8 +76,8 @@ pub type TestPool = NoopTransactionPool<BasePooledTransaction>;
 /// A payload built in-process during sequencer mode, waiting to be fetched via `get_payload`.
 #[derive(Debug, Clone)]
 pub struct PendingPayload {
-    /// The built payload from the production `OpPayloadBuilder`.
-    pub built: OpBuiltPayload<BasePrimitives>,
+    /// The built payload from the production `BasePayloadBuilder`.
+    pub built: BaseBuiltPayload<BasePrimitives>,
 }
 
 /// Mutable state owned by [`ActionEngineClient`], protected by a `Mutex` so
@@ -98,10 +98,10 @@ pub struct ActionEngineClientInner {
     payload_counter: u64,
 }
 
-/// An in-process engine client for action tests backed by the production `OpPayloadBuilder`.
+/// An in-process engine client for action tests backed by the production `BasePayloadBuilder`.
 ///
 /// `ActionEngineClient` implements [`EngineClient`] using the real Reth payload building
-/// code path (`OpPayloadBuilder::try_build`). It supports two workflows:
+/// code path (`BasePayloadBuilder::try_build`). It supports two workflows:
 ///
 /// ## Derivation mode
 ///
@@ -203,7 +203,7 @@ impl ActionEngineClient {
     /// Create a new `ActionEngineClient` backed by a production payload builder.
     ///
     /// Initializes a temporary Reth database with the test genesis state and creates
-    /// a production `OpPayloadBuilder` for block building.
+    /// a production `BasePayloadBuilder` for block building.
     pub fn new(
         rollup_config: Arc<RollupConfig>,
         canonical_head: L2BlockInfo,
@@ -279,12 +279,12 @@ impl ActionEngineClient {
     }
 
     /// Build a block from the given `BasePayloadAttributes` and commit it to the database,
-    /// returning the `OpBuiltPayload`.
+    /// returning the `BaseBuiltPayload`.
     fn build_and_commit(
         inner: &mut ActionEngineClientInner,
         parent_hash: B256,
         attrs: BasePayloadAttributes,
-    ) -> TransportResult<OpBuiltPayload<BasePrimitives>> {
+    ) -> TransportResult<BaseBuiltPayload<BasePrimitives>> {
         // Look up the parent header from executed headers or fall back to the real genesis.
         // When building the first block the caller may pass B256::ZERO (the default rollup-config
         // genesis hash), but the Reth DB stores the genesis block under its actual computed hash.
@@ -307,7 +307,7 @@ impl ActionEngineClient {
                 (genesis_hash, genesis_header)
             });
 
-        let builder_attrs = OpPayloadBuilderAttributes::try_new(effective_parent_hash, attrs, 3)
+        let builder_attrs = BasePayloadBuilderAttributes::try_new(effective_parent_hash, attrs, 3)
             .map_err(|e| {
                 TransportError::from(TransportErrorKind::custom_str(&format!(
                     "failed to create builder attributes: {e}"
@@ -325,7 +325,7 @@ impl ActionEngineClient {
         };
 
         let pool = TestPool::new();
-        let payload_builder = OpPayloadBuilder::new(
+        let payload_builder = BasePayloadBuilder::new(
             pool,
             inner.blockchain_provider.clone(),
             inner.evm_config.clone(),
@@ -335,7 +335,7 @@ impl ActionEngineClient {
                 "payload builder failed: {e}"
             )))
         })?;
-        let built: OpBuiltPayload<BasePrimitives> = outcome.into_payload().ok_or_else(|| {
+        let built: BaseBuiltPayload<BasePrimitives> = outcome.into_payload().ok_or_else(|| {
             TransportError::from(TransportErrorKind::custom_str(
                 "payload builder returned no payload",
             ))

--- a/actions/harness/src/harness.rs
+++ b/actions/harness/src/harness.rs
@@ -255,7 +255,7 @@ impl ActionTestHarness {
     ///
     /// The returned sequencer generates real [`BaseBlock`]s using the production
     /// [`L1OriginSelector`], [`StatefulAttributesBuilder`], and
-    /// [`ActionEngineClient`] (backed by `OpPayloadBuilder`).
+    /// [`ActionEngineClient`] (backed by `BasePayloadBuilder`).
     ///
     /// Call `build_next_block_with_single_transaction().await` once per L2
     /// block to advance the sequencer.

--- a/crates/builder/core/src/flashblocks/context.rs
+++ b/crates/builder/core/src/flashblocks/context.rs
@@ -14,8 +14,8 @@ use base_common_chains::Upgrades;
 use base_common_consensus::{BaseReceipt, BaseTransactionSigned, DepositReceipt, OpTxType};
 use base_common_evm::{BaseReceiptBuilder, L1BlockInfo, OpSpecId};
 use base_execution_chainspec::BaseChainSpec;
-use base_execution_evm::{BaseEvmConfig, OpNextBlockEnvAttributes};
-use base_execution_payload_builder::{OpPayloadBuilderAttributes, error::BasePayloadBuilderError};
+use base_execution_evm::{BaseEvmConfig, BaseNextBlockEnvAttributes};
+use base_execution_payload_builder::{BasePayloadBuilderAttributes, error::BasePayloadBuilderError};
 use base_execution_txpool::{
     BundleTransaction, TimestampedTransaction, estimated_da_size::DataAvailabilitySized,
 };
@@ -273,17 +273,17 @@ impl FlashblocksExtraCtx {
 
 /// Container type that holds all the necessities to build a new payload.
 #[derive(Debug)]
-pub struct OpPayloadBuilderCtx {
+pub struct BasePayloadBuilderCtx {
     /// The type that knows how to perform system calls and configure the evm.
     pub evm_config: BaseEvmConfig,
     /// The chainspec
     pub chain_spec: Arc<BaseChainSpec>,
     /// How to build the payload.
-    pub config: PayloadConfig<OpPayloadBuilderAttributes<BaseTransactionSigned>>,
+    pub config: PayloadConfig<BasePayloadBuilderAttributes<BaseTransactionSigned>>,
     /// Evm Settings
     pub evm_env: EvmEnv<OpSpecId>,
     /// Block env attributes for the current block.
-    pub block_env_attributes: OpNextBlockEnvAttributes,
+    pub block_env_attributes: BaseNextBlockEnvAttributes,
     /// Marker to check whether the job has been cancelled.
     pub cancel: CancellationToken,
     /// Extra context for the payload builder
@@ -292,7 +292,7 @@ pub struct OpPayloadBuilderCtx {
     pub builder_config: BuilderConfig,
 }
 
-impl OpPayloadBuilderCtx {
+impl BasePayloadBuilderCtx {
     pub(super) fn with_cancel(self, cancel: CancellationToken) -> Self {
         Self { cancel, ..self }
     }
@@ -325,7 +325,7 @@ impl OpPayloadBuilderCtx {
     }
 
     /// Returns the builder attributes.
-    pub(super) const fn attributes(&self) -> &OpPayloadBuilderAttributes<BaseTransactionSigned> {
+    pub(super) const fn attributes(&self) -> &BasePayloadBuilderAttributes<BaseTransactionSigned> {
         &self.config.attributes
     }
 
@@ -447,7 +447,7 @@ impl OpPayloadBuilderCtx {
     }
 }
 
-impl OpPayloadBuilderCtx {
+impl BasePayloadBuilderCtx {
     /// Constructs a receipt for the given transaction.
     pub fn build_receipt<E: Evm>(
         &self,
@@ -1041,8 +1041,8 @@ impl OpPayloadBuilderCtx {
 }
 
 #[cfg(any(test, feature = "test-utils"))]
-impl OpPayloadBuilderCtx {
-    /// Creates a minimal [`OpPayloadBuilderCtx`] for unit tests.
+impl BasePayloadBuilderCtx {
+    /// Creates a minimal [`BasePayloadBuilderCtx`] for unit tests.
     ///
     /// Derives the EVM environment from the given chain spec and parent header,
     /// using default builder attributes and a no-op cancellation token.
@@ -1050,7 +1050,7 @@ impl OpPayloadBuilderCtx {
         let evm_config = BaseEvmConfig::base(Arc::clone(&chain_spec));
         let timestamp = parent.timestamp + 2;
 
-        let attributes = OpPayloadBuilderAttributes {
+        let attributes = BasePayloadBuilderAttributes {
             payload_attributes: reth_payload_builder::EthPayloadBuilderAttributes {
                 id: PayloadId::new([0; 8]),
                 parent: parent.hash(),
@@ -1062,7 +1062,7 @@ impl OpPayloadBuilderCtx {
             ..Default::default()
         };
 
-        let block_env_attributes = OpNextBlockEnvAttributes {
+        let block_env_attributes = BaseNextBlockEnvAttributes {
             timestamp,
             suggested_fee_recipient: Default::default(),
             prev_randao: Default::default(),

--- a/crates/builder/core/src/flashblocks/context.rs
+++ b/crates/builder/core/src/flashblocks/context.rs
@@ -15,7 +15,9 @@ use base_common_consensus::{BaseReceipt, BaseTransactionSigned, DepositReceipt, 
 use base_common_evm::{BaseReceiptBuilder, L1BlockInfo, OpSpecId};
 use base_execution_chainspec::BaseChainSpec;
 use base_execution_evm::{BaseEvmConfig, BaseNextBlockEnvAttributes};
-use base_execution_payload_builder::{BasePayloadBuilderAttributes, error::BasePayloadBuilderError};
+use base_execution_payload_builder::{
+    BasePayloadBuilderAttributes, error::BasePayloadBuilderError,
+};
 use base_execution_txpool::{
     BundleTransaction, TimestampedTransaction, estimated_da_size::DataAvailabilitySized,
 };

--- a/crates/builder/core/src/flashblocks/generator.rs
+++ b/crates/builder/core/src/flashblocks/generator.rs
@@ -526,7 +526,9 @@ mod tests {
     use alloy_eips::eip7685::Requests;
     use alloy_primitives::U256;
     use base_common_consensus::BasePrimitives;
-    use base_execution_payload_builder::{PayloadPrimitives, payload::BasePayloadBuilderAttributes};
+    use base_execution_payload_builder::{
+        PayloadPrimitives, payload::BasePayloadBuilderAttributes,
+    };
     use rand::rng;
     use reth_node_api::{BuiltPayloadExecutedBlock, NodePrimitives};
     use reth_primitives::SealedBlock;

--- a/crates/builder/core/src/flashblocks/generator.rs
+++ b/crates/builder/core/src/flashblocks/generator.rs
@@ -526,7 +526,7 @@ mod tests {
     use alloy_eips::eip7685::Requests;
     use alloy_primitives::U256;
     use base_common_consensus::BasePrimitives;
-    use base_execution_payload_builder::{PayloadPrimitives, payload::OpPayloadBuilderAttributes};
+    use base_execution_payload_builder::{PayloadPrimitives, payload::BasePayloadBuilderAttributes};
     use rand::rng;
     use reth_node_api::{BuiltPayloadExecutedBlock, NodePrimitives};
     use reth_primitives::SealedBlock;
@@ -670,7 +670,7 @@ mod tests {
     where
         N: PayloadPrimitives,
     {
-        type Attributes = OpPayloadBuilderAttributes<N::SignedTx>;
+        type Attributes = BasePayloadBuilderAttributes<N::SignedTx>;
         type BuiltPayload = MockPayload;
 
         async fn try_build(
@@ -740,7 +740,7 @@ mod tests {
         );
 
         // this is not nice but necessary
-        let mut attr = OpPayloadBuilderAttributes::default();
+        let mut attr = BasePayloadBuilderAttributes::default();
         attr.payload_attributes.parent = client.latest_header()?.unwrap().hash();
 
         {

--- a/crates/builder/core/src/flashblocks/handler.rs
+++ b/crates/builder/core/src/flashblocks/handler.rs
@@ -1,5 +1,5 @@
-use base_execution_payload_builder::OpBuiltPayload;
-use base_node_core::OpEngineTypes;
+use base_execution_payload_builder::BaseBuiltPayload;
+use base_node_core::BaseEngineTypes;
 use reth_node_builder::Events;
 use tokio::sync::mpsc;
 use tracing::{debug, warn};
@@ -11,16 +11,16 @@ use tracing::{debug, warn};
 #[derive(Debug)]
 pub struct PayloadHandler {
     // receives new payloads built by this builder.
-    built_rx: mpsc::Receiver<OpBuiltPayload>,
+    built_rx: mpsc::Receiver<BaseBuiltPayload>,
     // sends a `Events::BuiltPayload` to the reth payload builder when a new payload is received.
-    payload_events_handle: tokio::sync::broadcast::Sender<Events<OpEngineTypes>>,
+    payload_events_handle: tokio::sync::broadcast::Sender<Events<BaseEngineTypes>>,
 }
 
 impl PayloadHandler {
     /// Constructs a new `PayloadHandler`.
     pub const fn new(
-        built_rx: mpsc::Receiver<OpBuiltPayload>,
-        payload_events_handle: tokio::sync::broadcast::Sender<Events<OpEngineTypes>>,
+        built_rx: mpsc::Receiver<BaseBuiltPayload>,
+        payload_events_handle: tokio::sync::broadcast::Sender<Events<BaseEngineTypes>>,
     ) -> Self {
         Self { built_rx, payload_events_handle }
     }

--- a/crates/builder/core/src/flashblocks/mod.rs
+++ b/crates/builder/core/src/flashblocks/mod.rs
@@ -17,7 +17,7 @@ pub use handler::PayloadHandler;
 
 mod context;
 pub use context::{
-    FlashblockDiagnostics, FlashblockSelectionOutcome, FlashblocksExtraCtx, BasePayloadBuilderCtx,
+    BasePayloadBuilderCtx, FlashblockDiagnostics, FlashblockSelectionOutcome, FlashblocksExtraCtx,
 };
 
 mod payload;

--- a/crates/builder/core/src/flashblocks/mod.rs
+++ b/crates/builder/core/src/flashblocks/mod.rs
@@ -17,7 +17,7 @@ pub use handler::PayloadHandler;
 
 mod context;
 pub use context::{
-    FlashblockDiagnostics, FlashblockSelectionOutcome, FlashblocksExtraCtx, OpPayloadBuilderCtx,
+    FlashblockDiagnostics, FlashblockSelectionOutcome, FlashblocksExtraCtx, BasePayloadBuilderCtx,
 };
 
 mod payload;

--- a/crates/builder/core/src/flashblocks/payload.rs
+++ b/crates/builder/core/src/flashblocks/payload.rs
@@ -20,8 +20,8 @@ use base_common_flashblocks::{
     ExecutionPayloadBaseV1, ExecutionPayloadFlashblockDeltaV1, FlashblocksPayloadV1,
 };
 use base_execution_consensus::{calculate_receipt_root_no_memo, isthmus};
-use base_execution_evm::{BaseEvmConfig, OpNextBlockEnvAttributes};
-use base_execution_payload_builder::{OpBuiltPayload, OpPayloadBuilderAttributes};
+use base_execution_evm::{BaseEvmConfig, BaseNextBlockEnvAttributes};
+use base_execution_payload_builder::{BaseBuiltPayload, BasePayloadBuilderAttributes};
 use either::Either;
 use eyre::WrapErr as _;
 use reth_basic_payload_builder::BuildOutcome;
@@ -52,7 +52,7 @@ use crate::{
     flashblocks::{
         FlashblocksExtraCtx,
         best_txs::BestFlashblocksTxs,
-        context::OpPayloadBuilderCtx,
+        context::BasePayloadBuilderCtx,
         generator::{BlockCell, BuildArguments},
     },
     traits::{ClientBounds, PoolBounds},
@@ -86,7 +86,7 @@ pub struct FlashblocksExecutionInfo {
 
 /// Base payload builder
 #[derive(Debug, Clone)]
-pub(super) struct OpPayloadBuilder<Pool, Client> {
+pub(super) struct BasePayloadBuilder<Pool, Client> {
     /// The type responsible for creating the evm.
     pub evm_config: BaseEvmConfig,
     /// The transaction pool
@@ -95,7 +95,7 @@ pub(super) struct OpPayloadBuilder<Pool, Client> {
     pub client: Client,
     /// Sender for sending built payloads to [`PayloadHandler`],
     /// which broadcasts outgoing payloads via p2p.
-    pub payload_tx: mpsc::Sender<OpBuiltPayload>,
+    pub payload_tx: mpsc::Sender<BaseBuiltPayload>,
     /// WebSocket publisher for broadcasting flashblocks
     /// to all connected subscribers.
     pub ws_pub: Arc<WebSocketPublisher>,
@@ -103,27 +103,27 @@ pub(super) struct OpPayloadBuilder<Pool, Client> {
     pub config: BuilderConfig,
 }
 
-impl<Pool, Client> OpPayloadBuilder<Pool, Client> {
-    /// `OpPayloadBuilder` constructor.
+impl<Pool, Client> BasePayloadBuilder<Pool, Client> {
+    /// `BasePayloadBuilder` constructor.
     pub(super) const fn new(
         evm_config: BaseEvmConfig,
         pool: Pool,
         client: Client,
         config: BuilderConfig,
-        payload_tx: mpsc::Sender<OpBuiltPayload>,
+        payload_tx: mpsc::Sender<BaseBuiltPayload>,
         ws_pub: Arc<WebSocketPublisher>,
     ) -> Self {
         Self { evm_config, pool, client, payload_tx, ws_pub, config }
     }
 }
 
-impl<Pool, Client> reth_basic_payload_builder::PayloadBuilder for OpPayloadBuilder<Pool, Client>
+impl<Pool, Client> reth_basic_payload_builder::PayloadBuilder for BasePayloadBuilder<Pool, Client>
 where
     Pool: Clone + Send + Sync,
     Client: Clone + Send + Sync,
 {
-    type Attributes = OpPayloadBuilderAttributes<BaseTransactionSigned>;
-    type BuiltPayload = OpBuiltPayload;
+    type Attributes = BasePayloadBuilderAttributes<BaseTransactionSigned>;
+    type BuiltPayload = BaseBuiltPayload;
 
     fn try_build(
         &self,
@@ -147,7 +147,7 @@ where
     }
 }
 
-impl<Pool, Client> OpPayloadBuilder<Pool, Client>
+impl<Pool, Client> BasePayloadBuilder<Pool, Client>
 where
     Pool: PoolBounds,
     Client: ClientBounds,
@@ -155,11 +155,11 @@ where
     fn get_op_payload_builder_ctx(
         &self,
         config: reth_basic_payload_builder::PayloadConfig<
-            OpPayloadBuilderAttributes<base_common_consensus::BaseTxEnvelope>,
+            BasePayloadBuilderAttributes<base_common_consensus::BaseTxEnvelope>,
         >,
         cancel: CancellationToken,
         extra: FlashblocksExtraCtx,
-    ) -> eyre::Result<OpPayloadBuilderCtx> {
+    ) -> eyre::Result<BasePayloadBuilderCtx> {
         let chain_spec = self.client.chain_spec();
         let timestamp = config.attributes.timestamp();
 
@@ -177,7 +177,7 @@ where
             Default::default()
         };
 
-        let block_env_attributes = OpNextBlockEnvAttributes {
+        let block_env_attributes = BaseNextBlockEnvAttributes {
             timestamp,
             suggested_fee_recipient: config.attributes.suggested_fee_recipient(),
             prev_randao: config.attributes.prev_randao(),
@@ -192,7 +192,7 @@ where
             .next_evm_env(&config.parent_header, &block_env_attributes)
             .wrap_err("failed to create next evm env")?;
 
-        Ok(OpPayloadBuilderCtx {
+        Ok(BasePayloadBuilderCtx {
             evm_config,
             chain_spec,
             config,
@@ -214,8 +214,8 @@ where
     /// a result indicating success with the payload or an error in case of failure.
     async fn build_payload(
         &self,
-        args: BuildArguments<OpPayloadBuilderAttributes<BaseTransactionSigned>, OpBuiltPayload>,
-        best_payload: BlockCell<OpBuiltPayload>,
+        args: BuildArguments<BasePayloadBuilderAttributes<BaseTransactionSigned>, BaseBuiltPayload>,
+        best_payload: BlockCell<BaseBuiltPayload>,
     ) -> Result<(), PayloadBuilderError> {
         let block_build_start_time = Instant::now();
         let BuildArguments {
@@ -512,12 +512,12 @@ where
         P: StateRootProvider + HashedPostStateProvider + StorageRootProvider,
     >(
         &self,
-        ctx: &OpPayloadBuilderCtx,
+        ctx: &BasePayloadBuilderCtx,
         info: &mut ExecutionInfo,
         state: &mut State<DB>,
         best_txs: &mut NextBestFlashblocksTxs<Pool>,
         block_cancel: &CancellationToken,
-        best_payload: &BlockCell<OpBuiltPayload>,
+        best_payload: &BlockCell<BaseBuiltPayload>,
         publish_guard: &parking_lot::Mutex<()>,
         span: &tracing::Span,
         executed_sender_nonces: &mut HashMap<Address, u64>,
@@ -785,7 +785,7 @@ where
     /// Do some logging and metric recording when we stop build flashblocks
     fn record_flashblocks_metrics(
         &self,
-        ctx: &OpPayloadBuilderCtx,
+        ctx: &BasePayloadBuilderCtx,
         info: &ExecutionInfo,
         flashblocks_per_block: u64,
         span: &tracing::Span,
@@ -820,9 +820,9 @@ where
     fn finalize_payload<DB, P>(
         &self,
         state: &mut State<DB>,
-        ctx: &OpPayloadBuilderCtx,
+        ctx: &BasePayloadBuilderCtx,
         info: &mut ExecutionInfo,
-        finalized_cell: &BlockCell<OpBuiltPayload>,
+        finalized_cell: &BlockCell<BaseBuiltPayload>,
     ) -> Result<(), PayloadBuilderError>
     where
         DB: Database<Error = ProviderError> + AsRef<P>,
@@ -891,13 +891,13 @@ where
 }
 
 #[async_trait::async_trait]
-impl<Pool, Client> PayloadBuilder for OpPayloadBuilder<Pool, Client>
+impl<Pool, Client> PayloadBuilder for BasePayloadBuilder<Pool, Client>
 where
     Pool: PoolBounds,
     Client: ClientBounds,
 {
-    type Attributes = OpPayloadBuilderAttributes<BaseTransactionSigned>;
-    type BuiltPayload = OpBuiltPayload;
+    type Attributes = BasePayloadBuilderAttributes<BaseTransactionSigned>;
+    type BuiltPayload = BaseBuiltPayload;
 
     async fn try_build(
         &self,
@@ -923,7 +923,7 @@ struct FlashblocksMetadata {
 
 pub(crate) fn execute_pre_steps<DB>(
     state: &mut State<DB>,
-    ctx: &OpPayloadBuilderCtx,
+    ctx: &BasePayloadBuilderCtx,
 ) -> Result<ExecutionInfo, PayloadBuilderError>
 where
     DB: Database<Error = ProviderError> + std::fmt::Debug + revm::Database,
@@ -942,10 +942,10 @@ where
 
 pub(crate) fn build_block<DB, P>(
     state: &mut State<DB>,
-    ctx: &OpPayloadBuilderCtx,
+    ctx: &BasePayloadBuilderCtx,
     info: &mut ExecutionInfo,
     calculate_state_root: bool,
-) -> Result<(OpBuiltPayload, FlashblocksPayloadV1), PayloadBuilderError>
+) -> Result<(BaseBuiltPayload, FlashblocksPayloadV1), PayloadBuilderError>
 where
     DB: Database<Error = ProviderError> + AsRef<P> + revm::Database,
     P: StateRootProvider + HashedPostStateProvider + StorageRootProvider,
@@ -1173,7 +1173,7 @@ where
     state.transition_state = untouched_transition_state;
 
     Ok((
-        OpBuiltPayload::new(ctx.payload_id(), sealed_block, info.total_fees, Some(executed)),
+        BaseBuiltPayload::new(ctx.payload_id(), sealed_block, info.total_fees, Some(executed)),
         fb_payload,
     ))
 }
@@ -1193,7 +1193,7 @@ mod tests {
     use reth_revm::{State, database::StateProviderDatabase};
 
     use super::{FlashblocksMetadata, build_block};
-    use crate::{ExecutionInfo, flashblocks::context::OpPayloadBuilderCtx};
+    use crate::{ExecutionInfo, flashblocks::context::BasePayloadBuilderCtx};
 
     /// Creates a minimal [`BaseChainSpec`] with all L1 hardforks through Cancun
     /// active at genesis but **no** OP-specific hardforks (Bedrock, Canyon,
@@ -1231,7 +1231,7 @@ mod tests {
     fn build_block_empty_no_state_root() {
         let chain_spec = minimal_chain_spec();
         let parent = genesis_header();
-        let ctx = OpPayloadBuilderCtx::for_test(chain_spec, Arc::clone(&parent));
+        let ctx = BasePayloadBuilderCtx::for_test(chain_spec, Arc::clone(&parent));
 
         let db = StateProviderDatabase::new(NoopProvider::default());
         let mut state = State::builder().with_database(db).with_bundle_update().build();
@@ -1263,7 +1263,7 @@ mod tests {
     fn build_block_empty_with_state_root() {
         let chain_spec = minimal_chain_spec();
         let parent = genesis_header();
-        let ctx = OpPayloadBuilderCtx::for_test(chain_spec, Arc::clone(&parent));
+        let ctx = BasePayloadBuilderCtx::for_test(chain_spec, Arc::clone(&parent));
 
         let db = StateProviderDatabase::new(NoopProvider::default());
         let mut state = State::builder().with_database(db).with_bundle_update().build();
@@ -1294,7 +1294,7 @@ mod tests {
     fn build_block_rejects_block_number_mismatch() {
         let chain_spec = minimal_chain_spec();
         let parent = genesis_header();
-        let mut ctx = OpPayloadBuilderCtx::for_test(chain_spec, Arc::clone(&parent));
+        let mut ctx = BasePayloadBuilderCtx::for_test(chain_spec, Arc::clone(&parent));
 
         // Tamper with the EVM block number so it disagrees with parent + 1.
         // parent.number is 0, so the expected block number is 1.
@@ -1325,7 +1325,7 @@ mod tests {
     fn build_block_rejects_missing_beacon_block_root() {
         let chain_spec = minimal_chain_spec();
         let parent = genesis_header();
-        let mut ctx = OpPayloadBuilderCtx::for_test(chain_spec, Arc::clone(&parent));
+        let mut ctx = BasePayloadBuilderCtx::for_test(chain_spec, Arc::clone(&parent));
 
         // Clear the parent beacon block root that for_test() sets.
         ctx.config.attributes.payload_attributes.parent_beacon_block_root = None;

--- a/crates/builder/core/src/flashblocks/service.rs
+++ b/crates/builder/core/src/flashblocks/service.rs
@@ -18,7 +18,7 @@ use reth_payload_builder::{PayloadBuilderHandle, PayloadBuilderService};
 use reth_provider::CanonStateSubscriptions;
 use tracing::info;
 
-use super::{PayloadHandler, generator::BlockPayloadJobGenerator, payload::OpPayloadBuilder};
+use super::{PayloadHandler, generator::BlockPayloadJobGenerator, payload::BasePayloadBuilder};
 use crate::{
     BuilderConfig,
     traits::{NodeBounds, PoolBounds},
@@ -46,7 +46,7 @@ impl FlashblocksServiceBuilder {
 
         let ws_pub: Arc<WebSocketPublisher> =
             WebSocketPublisher::new(self.0.flashblocks_ws_addr)?.into();
-        let payload_builder = OpPayloadBuilder::new(
+        let payload_builder = BasePayloadBuilder::new(
             BaseEvmConfig::base(ctx.chain_spec()),
             pool,
             ctx.provider().clone(),

--- a/crates/builder/core/src/lib.rs
+++ b/crates/builder/core/src/lib.rs
@@ -30,9 +30,9 @@ pub use metering::{MeteringProvider, NoopMeteringProvider, SharedMeteringProvide
 
 mod flashblocks;
 pub use flashblocks::{
-    BestFlashblocksTxs, BlockCell, BlockPayloadJob, BlockPayloadJobGenerator, BuildArguments,
-    FlashblockDiagnostics, FlashblockSelectionOutcome, FlashblocksExecutionInfo,
-    FlashblocksExtraCtx, FlashblocksServiceBuilder, BasePayloadBuilderCtx, PayloadBuilder,
+    BasePayloadBuilderCtx, BestFlashblocksTxs, BlockCell, BlockPayloadJob,
+    BlockPayloadJobGenerator, BuildArguments, FlashblockDiagnostics, FlashblockSelectionOutcome,
+    FlashblocksExecutionInfo, FlashblocksExtraCtx, FlashblocksServiceBuilder, PayloadBuilder,
     PayloadHandler, RejectionCache, ResolvePayload, WaitForValue,
 };
 

--- a/crates/builder/core/src/lib.rs
+++ b/crates/builder/core/src/lib.rs
@@ -32,7 +32,7 @@ mod flashblocks;
 pub use flashblocks::{
     BestFlashblocksTxs, BlockCell, BlockPayloadJob, BlockPayloadJobGenerator, BuildArguments,
     FlashblockDiagnostics, FlashblockSelectionOutcome, FlashblocksExecutionInfo,
-    FlashblocksExtraCtx, FlashblocksServiceBuilder, OpPayloadBuilderCtx, PayloadBuilder,
+    FlashblocksExtraCtx, FlashblocksServiceBuilder, BasePayloadBuilderCtx, PayloadBuilder,
     PayloadHandler, RejectionCache, ResolvePayload, WaitForValue,
 };
 

--- a/crates/builder/core/src/test_utils/apis.rs
+++ b/crates/builder/core/src/test_utils/apis.rs
@@ -5,7 +5,7 @@ use alloy_primitives::B256;
 use alloy_rpc_types_engine::{ForkchoiceState, ForkchoiceUpdated, PayloadStatus};
 use base_common_rpc_types_engine::BaseExecutionPayloadV4;
 use base_execution_rpc::BaseEngineApiClient;
-use base_node_core::OpEngineTypes;
+use base_node_core::BaseEngineTypes;
 use jsonrpsee::{
     core::{RpcResult, client::SubscriptionClientT},
     proc_macros::rpc,
@@ -161,9 +161,9 @@ impl<P: Protocol> EngineApi<P> {
     pub async fn get_payload(
         &self,
         payload_id: PayloadId,
-    ) -> eyre::Result<<OpEngineTypes as EngineTypes>::ExecutionPayloadEnvelopeV4> {
+    ) -> eyre::Result<<BaseEngineTypes as EngineTypes>::ExecutionPayloadEnvelopeV4> {
         debug!(payload_id = %payload_id, timestamp = %chrono::Utc::now(), "Fetching payload");
-        Ok(BaseEngineApiClient::<OpEngineTypes>::get_payload_v4(&self.client().await, payload_id)
+        Ok(BaseEngineApiClient::<BaseEngineTypes>::get_payload_v4(&self.client().await, payload_id)
             .await?)
     }
 
@@ -176,7 +176,7 @@ impl<P: Protocol> EngineApi<P> {
         execution_requests: Requests,
     ) -> eyre::Result<PayloadStatus> {
         debug!(timestamp = %chrono::Utc::now(), "Submitting new payload");
-        Ok(BaseEngineApiClient::<OpEngineTypes>::new_payload_v4(
+        Ok(BaseEngineApiClient::<BaseEngineTypes>::new_payload_v4(
             &self.client().await,
             payload,
             versioned_hashes,
@@ -191,10 +191,10 @@ impl<P: Protocol> EngineApi<P> {
         &self,
         current_head: B256,
         new_head: B256,
-        payload_attributes: Option<<OpEngineTypes as PayloadTypes>::PayloadAttributes>,
+        payload_attributes: Option<<BaseEngineTypes as PayloadTypes>::PayloadAttributes>,
     ) -> eyre::Result<ForkchoiceUpdated> {
         debug!(timestamp = %chrono::Utc::now(), "Updating forkchoice");
-        Ok(BaseEngineApiClient::<OpEngineTypes>::fork_choice_updated_v3(
+        Ok(BaseEngineApiClient::<BaseEngineTypes>::fork_choice_updated_v3(
             &self.client().await,
             ForkchoiceState {
                 head_block_hash: new_head,

--- a/crates/builder/core/src/test_utils/instance.rs
+++ b/crates/builder/core/src/test_utils/instance.rs
@@ -135,12 +135,15 @@ impl LocalInstance {
         let gas_limit_config = builder_config.gas_limit_config.clone();
         let metering_provider = Arc::clone(&builder_config.metering_provider);
 
-        let addons: base_node_runner::BaseAddOns<_, BaseEthApiBuilder, BasePayloadValidatorBuilder> =
-            base_node
-                .add_ons_builder()
-                .with_da_config(da_config.clone())
-                .with_gas_limit_config(gas_limit_config.clone())
-                .build();
+        let addons: base_node_runner::BaseAddOns<
+            _,
+            BaseEthApiBuilder,
+            BasePayloadValidatorBuilder,
+        > = base_node
+            .add_ons_builder()
+            .with_da_config(da_config.clone())
+            .with_gas_limit_config(gas_limit_config.clone())
+            .build();
 
         let node_builder = NodeBuilder::<_, BaseChainSpec>::new(node_config.clone())
             .with_database(create_test_db(node_config.clone()))

--- a/crates/builder/core/src/test_utils/instance.rs
+++ b/crates/builder/core/src/test_utils/instance.rs
@@ -14,7 +14,7 @@ use async_trait::async_trait;
 use base_common_flashblocks::FlashblocksPayloadV1;
 use base_common_network::Base;
 use base_execution_chainspec::BaseChainSpec;
-use base_execution_rpc::OpEthApiBuilder;
+use base_execution_rpc::BaseEthApiBuilder;
 use base_execution_txpool::BasePooledTransaction;
 use base_node_core::{BasePayloadValidatorBuilder, args::RollupArgs, node::BasePoolBuilder};
 use base_node_runner::{BaseNode, test_utils::init_silenced_tracing};
@@ -135,7 +135,7 @@ impl LocalInstance {
         let gas_limit_config = builder_config.gas_limit_config.clone();
         let metering_provider = Arc::clone(&builder_config.metering_provider);
 
-        let addons: base_node_runner::BaseAddOns<_, OpEthApiBuilder, BasePayloadValidatorBuilder> =
+        let addons: base_node_runner::BaseAddOns<_, BaseEthApiBuilder, BasePayloadValidatorBuilder> =
             base_node
                 .add_ons_builder()
                 .with_da_config(da_config.clone())

--- a/crates/builder/core/src/traits.rs
+++ b/crates/builder/core/src/traits.rs
@@ -4,7 +4,7 @@ use alloy_consensus::Header;
 use base_common_consensus::{BasePrimitives, BaseTransactionSigned};
 use base_execution_chainspec::BaseChainSpec;
 use base_execution_txpool::{BundleTransaction, OpPooledTx, TimestampedTransaction};
-use base_node_core::OpEngineTypes;
+use base_node_core::BaseEngineTypes;
 use reth_node_api::{FullNodeTypes, NodeTypes};
 use reth_payload_util::PayloadTransactions;
 use reth_provider::{BlockReaderIdExt, ChainSpecProvider, StateProviderFactory};
@@ -14,7 +14,7 @@ use reth_transaction_pool::{TransactionPool, TransactionPoolExt};
 pub trait NodeBounds:
     FullNodeTypes<
     Types: NodeTypes<
-        Payload = OpEngineTypes,
+        Payload = BaseEngineTypes,
         ChainSpec = BaseChainSpec,
         Primitives = BasePrimitives,
     >,
@@ -25,7 +25,7 @@ pub trait NodeBounds:
 impl<T> NodeBounds for T where
     T: FullNodeTypes<
         Types: NodeTypes<
-            Payload = OpEngineTypes,
+            Payload = BaseEngineTypes,
             ChainSpec = BaseChainSpec,
             Primitives = BasePrimitives,
         >,

--- a/crates/client/metering/src/block.rs
+++ b/crates/client/metering/src/block.rs
@@ -6,7 +6,7 @@ use alloy_consensus::{BlockHeader, Header, transaction::SignerRecoverable};
 use alloy_primitives::B256;
 use base_common_consensus::BaseBlock;
 use base_execution_chainspec::BaseChainSpec;
-use base_execution_evm::{BaseEvmConfig, OpNextBlockEnvAttributes};
+use base_execution_evm::{BaseEvmConfig, BaseNextBlockEnvAttributes};
 use eyre::{Result as EyreResult, eyre};
 use reth_evm::{ConfigureEvm, execute::BlockBuilder};
 use reth_primitives_traits::Block as BlockT;
@@ -60,7 +60,7 @@ where
     let mut db = State::builder().with_database(state_db).with_bundle_update().build();
 
     // Set up block attributes from the actual block header
-    let attributes = OpNextBlockEnvAttributes {
+    let attributes = BaseNextBlockEnvAttributes {
         timestamp: block.header().timestamp(),
         suggested_fee_recipient: block.header().beneficiary(),
         prev_randao: block.header().mix_hash().unwrap_or_else(B256::random),

--- a/crates/client/metering/src/meter.rs
+++ b/crates/client/metering/src/meter.rs
@@ -11,7 +11,7 @@ use alloy_primitives::{Address, B256, U256};
 use base_bundles::{BundleExtensions, BundleTxs, ParsedBundle, TransactionResult};
 use base_common_evm::L1BlockInfo;
 use base_execution_chainspec::BaseChainSpec;
-use base_execution_evm::{BaseEvmConfig, OpNextBlockEnvAttributes};
+use base_execution_evm::{BaseEvmConfig, BaseNextBlockEnvAttributes};
 use eyre::{Result as EyreResult, eyre};
 use reth_evm::{ConfigureEvm, execute::BlockBuilder};
 use reth_primitives_traits::{Account, SealedHeader};
@@ -286,7 +286,7 @@ where
     let timestamp = bundle.min_timestamp.unwrap_or_else(|| header.timestamp() + BLOCK_TIME);
     // Pending flashblock headers may omit parent_beacon_block_root; prefer the explicit value
     // provided by the caller (e.g., flashblock base payload) to keep EIP-4788 happy.
-    let attributes = OpNextBlockEnvAttributes {
+    let attributes = BaseNextBlockEnvAttributes {
         timestamp,
         suggested_fee_recipient: header.beneficiary(),
         prev_randao: header.mix_hash().unwrap_or_else(B256::random),

--- a/crates/execution/cli/src/app.rs
+++ b/crates/execution/cli/src/app.rs
@@ -75,7 +75,10 @@ where
         install_prometheus_recorder();
 
         let components = |spec: Arc<BaseChainSpec>| {
-            (BaseExecutorProvider::base(Arc::clone(&spec)), Arc::new(BaseBeaconConsensus::new(spec)))
+            (
+                BaseExecutorProvider::base(Arc::clone(&spec)),
+                Arc::new(BaseBeaconConsensus::new(spec)),
+            )
         };
 
         match self.cli.command {

--- a/crates/execution/cli/src/app.rs
+++ b/crates/execution/cli/src/app.rs
@@ -1,7 +1,7 @@
 use std::{fmt, sync::Arc};
 
 use base_execution_chainspec::BaseChainSpec;
-use base_execution_consensus::OpBeaconConsensus;
+use base_execution_consensus::BaseBeaconConsensus;
 use base_execution_evm::BaseExecutorProvider;
 use base_node_core::BaseNode;
 use eyre::{Result, eyre};
@@ -75,7 +75,7 @@ where
         install_prometheus_recorder();
 
         let components = |spec: Arc<BaseChainSpec>| {
-            (BaseExecutorProvider::base(Arc::clone(&spec)), Arc::new(OpBeaconConsensus::new(spec)))
+            (BaseExecutorProvider::base(Arc::clone(&spec)), Arc::new(BaseBeaconConsensus::new(spec)))
         };
 
         match self.cli.command {

--- a/crates/execution/consensus/src/lib.rs
+++ b/crates/execution/consensus/src/lib.rs
@@ -43,15 +43,15 @@ pub use error::BaseConsensusError;
 ///
 /// Provides basic checks as outlined in the execution specs.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct OpBeaconConsensus {
+pub struct BaseBeaconConsensus {
     /// Configuration
     chain_spec: Arc<BaseChainSpec>,
     /// Maximum allowed extra data size in bytes
     max_extra_data_size: usize,
 }
 
-impl OpBeaconConsensus {
-    /// Create a new instance of [`OpBeaconConsensus`]
+impl BaseBeaconConsensus {
+    /// Create a new instance of [`BaseBeaconConsensus`]
     pub const fn new(chain_spec: Arc<BaseChainSpec>) -> Self {
         Self { chain_spec, max_extra_data_size: MAXIMUM_EXTRA_DATA_SIZE }
     }
@@ -68,7 +68,7 @@ impl OpBeaconConsensus {
     }
 }
 
-impl<N> FullConsensus<N> for OpBeaconConsensus
+impl<N> FullConsensus<N> for BaseBeaconConsensus
 where
     N: NodePrimitives<BlockHeader = Header, Receipt: DepositReceiptExt>,
 {
@@ -82,7 +82,7 @@ where
     }
 }
 
-impl<B> Consensus<B> for OpBeaconConsensus
+impl<B> Consensus<B> for BaseBeaconConsensus
 where
     B: Block<Header = Header>,
 {
@@ -146,7 +146,7 @@ where
     }
 }
 
-impl HeaderValidator<Header> for OpBeaconConsensus {
+impl HeaderValidator<Header> for BaseBeaconConsensus {
     fn validate_header(&self, header: &SealedHeader<Header>) -> Result<(), ConsensusError> {
         let header = header.header();
 
@@ -238,7 +238,7 @@ mod tests {
     use reth_primitives_traits::{RecoveredBlock, SealedBlock, SealedHeader, proofs};
     use reth_provider::BlockExecutionResult;
 
-    use crate::OpBeaconConsensus;
+    use crate::BaseBeaconConsensus;
 
     fn mock_tx(nonce: u64) -> BaseTransactionSigned {
         let tx = TxEip7702 {
@@ -270,7 +270,7 @@ mod tests {
         // create a tx
         let transaction = mock_tx(0);
 
-        let beacon_consensus = OpBeaconConsensus::new(Arc::new(chain_spec));
+        let beacon_consensus = BaseBeaconConsensus::new(Arc::new(chain_spec));
 
         let header = Header {
             base_fee_per_gas: Some(1337),
@@ -307,7 +307,7 @@ mod tests {
         // create a tx
         let transaction = mock_tx(0);
 
-        let beacon_consensus = OpBeaconConsensus::new(Arc::new(chain_spec));
+        let beacon_consensus = BaseBeaconConsensus::new(Arc::new(chain_spec));
 
         let header = Header {
             base_fee_per_gas: Some(1337),
@@ -350,7 +350,7 @@ mod tests {
         // create a tx
         let transaction = mock_tx(0);
 
-        let beacon_consensus = OpBeaconConsensus::new(Arc::new(chain_spec));
+        let beacon_consensus = BaseBeaconConsensus::new(Arc::new(chain_spec));
 
         let receipt = BaseReceipt::Eip7702(Receipt::<Log> {
             status: Eip658Value::success(),
@@ -396,7 +396,7 @@ mod tests {
         let block = RecoveredBlock::new_sealed(block, vec![Address::default()]);
 
         let post_execution =
-            <OpBeaconConsensus as FullConsensus<BasePrimitives>>::validate_block_post_execution(
+            <BaseBeaconConsensus as FullConsensus<BasePrimitives>>::validate_block_post_execution(
                 &beacon_consensus,
                 &block,
                 &result,
@@ -421,7 +421,7 @@ mod tests {
         // create a tx
         let transaction = mock_tx(0);
 
-        let beacon_consensus = OpBeaconConsensus::new(Arc::new(chain_spec));
+        let beacon_consensus = BaseBeaconConsensus::new(Arc::new(chain_spec));
 
         let receipt = BaseReceipt::Eip7702(Receipt::<Log> {
             status: Eip658Value::success(),
@@ -467,7 +467,7 @@ mod tests {
         let block = RecoveredBlock::new_sealed(block, vec![Address::default()]);
 
         let post_execution =
-            <OpBeaconConsensus as FullConsensus<BasePrimitives>>::validate_block_post_execution(
+            <BaseBeaconConsensus as FullConsensus<BasePrimitives>>::validate_block_post_execution(
                 &beacon_consensus,
                 &block,
                 &result,
@@ -495,7 +495,7 @@ mod tests {
         // create a tx
         let transaction = mock_tx(0);
 
-        let beacon_consensus = OpBeaconConsensus::new(Arc::new(chain_spec));
+        let beacon_consensus = BaseBeaconConsensus::new(Arc::new(chain_spec));
 
         let receipt = BaseReceipt::Eip7702(Receipt::<Log> {
             status: Eip658Value::success(),
@@ -566,7 +566,7 @@ mod tests {
         // create a tx
         let transaction = mock_tx(0);
 
-        let beacon_consensus = OpBeaconConsensus::new(Arc::new(chain_spec));
+        let beacon_consensus = BaseBeaconConsensus::new(Arc::new(chain_spec));
 
         let receipt = BaseReceipt::Eip7702(Receipt::<Log> {
             status: Eip658Value::success(),
@@ -643,7 +643,7 @@ mod tests {
         // create a tx
         let transaction = mock_tx(0);
 
-        let beacon_consensus = OpBeaconConsensus::new(Arc::new(chain_spec));
+        let beacon_consensus = BaseBeaconConsensus::new(Arc::new(chain_spec));
 
         let receipt = BaseReceipt::Eip7702(Receipt::<Log> {
             status: Eip658Value::success(),
@@ -717,7 +717,7 @@ mod tests {
         // create a tx
         let transaction = mock_tx(0);
 
-        let beacon_consensus = OpBeaconConsensus::new(Arc::new(chain_spec));
+        let beacon_consensus = BaseBeaconConsensus::new(Arc::new(chain_spec));
 
         let receipt = BaseReceipt::Eip7702(Receipt::<Log> {
             status: Eip658Value::success(),

--- a/crates/execution/engine-tree/src/cached_execution.rs
+++ b/crates/execution/engine-tree/src/cached_execution.rs
@@ -5,7 +5,7 @@ use std::{collections::HashMap, fmt::Debug, sync::Arc};
 use base_common_consensus::{BaseReceipt, BaseTxEnvelope, OpTxType};
 use base_common_evm::{BaseBlockExecutor, BaseTxResult, OpHaltReason, OpTransaction};
 use base_execution_chainspec::BaseChainSpec;
-use base_execution_evm::OpRethReceiptBuilder;
+use base_execution_evm::BaseRethReceiptBuilder;
 use base_flashblocks::{FlashblocksAPI, FlashblocksState};
 use reth_errors::BlockExecutionError;
 use reth_evm::{
@@ -112,7 +112,7 @@ impl<TxResult> CachedExecutionProvider<TxResult> for NoopCachedExecutionProvider
 /// Executor that fetches cached execution results for transactions.
 #[derive(Debug)]
 pub struct CachedExecutor<E, C> {
-    executor: BaseBlockExecutor<E, OpRethReceiptBuilder, Arc<BaseChainSpec>>,
+    executor: BaseBlockExecutor<E, BaseRethReceiptBuilder, Arc<BaseChainSpec>>,
     cached_execution_provider: C,
     txs: Vec<B256>,
     position_by_hash: HashMap<B256, usize>,
@@ -123,7 +123,7 @@ pub struct CachedExecutor<E, C> {
 impl<E, C> CachedExecutor<E, C> {
     /// Creates a new [`CachedExecutor`].
     pub fn new(
-        executor: BaseBlockExecutor<E, OpRethReceiptBuilder, Arc<BaseChainSpec>>,
+        executor: BaseBlockExecutor<E, BaseRethReceiptBuilder, Arc<BaseChainSpec>>,
         cached_execution_provider: C,
         txs: Vec<B256>,
         parent_block_hash: B256,

--- a/crates/execution/engine-tree/src/validator.rs
+++ b/crates/execution/engine-tree/src/validator.rs
@@ -26,9 +26,9 @@ use base_common_evm::{
 };
 use base_common_rpc_types_engine::ExecutionData;
 use base_execution_chainspec::BaseChainSpec;
-use base_execution_evm::OpRethReceiptBuilder;
+use base_execution_evm::BaseRethReceiptBuilder;
 use base_flashblocks::FlashblocksState;
-use base_node_core::OpEngineTypes;
+use base_node_core::BaseEngineTypes;
 use reth_chain_state::{DeferredTrieData, ExecutedBlock, LazyOverlay};
 use reth_consensus::{ConsensusError, FullConsensus, ReceiptRootBloom};
 use reth_engine_primitives::{
@@ -143,7 +143,7 @@ where
     Evm: ConfigureEvm<
             Primitives = BasePrimitives,
             BlockExecutorFactory = BaseBlockExecutorFactory<
-                OpRethReceiptBuilder,
+                BaseRethReceiptBuilder,
                 Arc<BaseChainSpec>,
                 BaseEvmFactory,
             >,
@@ -1485,7 +1485,7 @@ where
             ExecutionData,
             Primitives = BasePrimitives,
             BlockExecutorFactory = BaseBlockExecutorFactory<
-                OpRethReceiptBuilder,
+                BaseRethReceiptBuilder,
                 Arc<BaseChainSpec>,
             >,
         > + 'static,
@@ -1577,14 +1577,14 @@ impl<Node, EV> EngineValidatorBuilder<Node> for BaseEngineValidatorBuilder<EV>
 where
     Node: FullNodeComponents<
             Types: NodeTypes<
-                Payload = OpEngineTypes,
+                Payload = BaseEngineTypes,
                 ChainSpec = BaseChainSpec,
                 Primitives = BasePrimitives,
             >,
             Evm: ConfigureEngineEvm<ExecutionData>
                      + ConfigureEvm<
                 BlockExecutorFactory = BaseBlockExecutorFactory<
-                    OpRethReceiptBuilder,
+                    BaseRethReceiptBuilder,
                     Arc<BaseChainSpec>,
                 >,
             >,

--- a/crates/execution/evm/src/config.rs
+++ b/crates/execution/evm/src/config.rs
@@ -2,7 +2,7 @@ use revm::primitives::{Address, B256, Bytes};
 
 /// Context relevant for execution of a next block w.r.t OP.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct OpNextBlockEnvAttributes {
+pub struct BaseNextBlockEnvAttributes {
     /// The timestamp of the next block.
     pub timestamp: u64,
     /// The suggested fee recipient for the next block.
@@ -19,7 +19,7 @@ pub struct OpNextBlockEnvAttributes {
 
 #[cfg(feature = "rpc")]
 impl<H: alloy_consensus::BlockHeader> reth_rpc_eth_api::helpers::pending_block::BuildPendingEnv<H>
-    for OpNextBlockEnvAttributes
+    for BaseNextBlockEnvAttributes
 {
     fn build_pending_env(parent: &crate::SealedHeader<H>) -> Self {
         Self {

--- a/crates/execution/evm/src/execute.rs
+++ b/crates/execution/evm/src/execute.rs
@@ -17,7 +17,7 @@ mod tests {
     use reth_primitives_traits::{Account, RecoveredBlock};
     use reth_revm::{database::StateProviderDatabase, test_utils::StateProviderTest};
 
-    use crate::{BaseEvmConfig, OpRethReceiptBuilder};
+    use crate::{BaseEvmConfig, BaseRethReceiptBuilder};
 
     fn create_op_state_provider() -> StateProviderTest {
         let mut db = StateProviderTest::default();
@@ -52,7 +52,7 @@ mod tests {
     }
 
     fn evm_config(chain_spec: Arc<BaseChainSpec>) -> BaseEvmConfig {
-        BaseEvmConfig::new(chain_spec, OpRethReceiptBuilder::default())
+        BaseEvmConfig::new(chain_spec, BaseRethReceiptBuilder::default())
     }
 
     #[test]

--- a/crates/execution/evm/src/lib.rs
+++ b/crates/execution/evm/src/lib.rs
@@ -43,7 +43,7 @@ use {
 };
 
 mod config;
-pub use config::OpNextBlockEnvAttributes;
+pub use config::BaseNextBlockEnvAttributes;
 mod execute;
 pub use execute::*;
 pub mod l1;
@@ -86,7 +86,7 @@ fn build_evm_env(header: &Header, chain_spec: &(impl Upgrades + EthChainSpec)) -
 /// Builds an [`EvmEnv`] for the next block given a parent header.
 fn build_next_evm_env(
     parent: &Header,
-    attributes: &OpNextBlockEnvAttributes,
+    attributes: &BaseNextBlockEnvAttributes,
     base_fee_per_gas: u64,
     chain_spec: &(impl Upgrades + EthChainSpec),
 ) -> EvmEnv<OpSpecId> {
@@ -120,7 +120,7 @@ fn build_next_evm_env(
 pub struct BaseEvmConfig<
     ChainSpec = BaseChainSpec,
     N: NodePrimitives = BasePrimitives,
-    R = OpRethReceiptBuilder,
+    R = BaseRethReceiptBuilder,
     EvmFactory = BaseEvmFactory,
 > {
     /// Inner [`BaseBlockExecutorFactory`].
@@ -146,7 +146,7 @@ impl<ChainSpec, N: NodePrimitives, R: Clone, EvmFactory: Clone> Clone
 impl<ChainSpec: Upgrades> BaseEvmConfig<ChainSpec> {
     /// Creates a new [`BaseEvmConfig`] with the given chain spec for Base chains.
     pub fn base(chain_spec: Arc<ChainSpec>) -> Self {
-        Self::new(chain_spec, OpRethReceiptBuilder::default())
+        Self::new(chain_spec, BaseRethReceiptBuilder::default())
     }
 }
 
@@ -201,7 +201,7 @@ where
 {
     type Primitives = N;
     type Error = EIP1559ParamError;
-    type NextBlockEnvCtx = OpNextBlockEnvAttributes;
+    type NextBlockEnvCtx = BaseNextBlockEnvAttributes;
     type BlockExecutorFactory = BaseBlockExecutorFactory<R, Arc<ChainSpec>, EvmF>;
     type BlockAssembler = BaseBlockAssembler<ChainSpec>;
 

--- a/crates/execution/evm/src/receipts.rs
+++ b/crates/execution/evm/src/receipts.rs
@@ -8,9 +8,9 @@ use reth_evm::Evm;
 /// [`BaseReceipt`].
 #[derive(Debug, Default, Clone, Copy)]
 #[non_exhaustive]
-pub struct OpRethReceiptBuilder;
+pub struct BaseRethReceiptBuilder;
 
-impl BaseReceiptBuilder for OpRethReceiptBuilder {
+impl BaseReceiptBuilder for BaseRethReceiptBuilder {
     type Transaction = BaseTransactionSigned;
     type Receipt = BaseReceipt;
 

--- a/crates/execution/flashblocks/src/processor.rs
+++ b/crates/execution/flashblocks/src/processor.rs
@@ -14,7 +14,7 @@ use arc_swap::ArcSwapOption;
 use base_common_chains::Upgrades;
 use base_common_consensus::{BaseBlock, BaseTxEnvelope};
 use base_common_flashblocks::Flashblock;
-use base_execution_evm::{BaseEvmConfig, OpNextBlockEnvAttributes};
+use base_execution_evm::{BaseEvmConfig, BaseNextBlockEnvAttributes};
 use rayon::prelude::*;
 use reth_chainspec::{ChainSpecProvider, EthChainSpec};
 use reth_evm::ConfigureEvm;
@@ -393,7 +393,7 @@ where
             // Extract L1 block info using the AssembledBlock method
             let l1_block_info = assembled.l1_block_info()?;
 
-            let block_env_attributes = OpNextBlockEnvAttributes {
+            let block_env_attributes = BaseNextBlockEnvAttributes {
                 timestamp: assembled.base.timestamp,
                 suggested_fee_recipient: assembled.base.fee_recipient,
                 prev_randao: assembled.base.prev_randao,

--- a/crates/execution/node/src/engine.rs
+++ b/crates/execution/node/src/engine.rs
@@ -10,7 +10,7 @@ use base_common_rpc_types_engine::{
     BasePayloadAttributes, ExecutionData,
 };
 use base_execution_consensus::isthmus;
-use base_execution_payload_builder::{BasePayloadTypes, OpExecutionPayloadValidator};
+use base_execution_payload_builder::{BasePayloadTypes, BaseExecutionPayloadValidator};
 use reth_consensus::ConsensusError;
 use reth_node_api::{
     BuiltPayload, EngineApiValidator, EngineTypes, NodePrimitives, PayloadValidator,
@@ -28,11 +28,11 @@ use reth_trie_common::{HashedPostState, KeyHasher};
 /// The types used in the Base beacon consensus engine.
 #[derive(Debug, Default, Clone, serde::Deserialize, serde::Serialize)]
 #[non_exhaustive]
-pub struct OpEngineTypes<T: PayloadTypes = BasePayloadTypes> {
+pub struct BaseEngineTypes<T: PayloadTypes = BasePayloadTypes> {
     _marker: PhantomData<T>,
 }
 
-impl<T: PayloadTypes<ExecutionData = ExecutionData>> PayloadTypes for OpEngineTypes<T> {
+impl<T: PayloadTypes<ExecutionData = ExecutionData>> PayloadTypes for BaseEngineTypes<T> {
     type ExecutionData = T::ExecutionData;
     type BuiltPayload = T::BuiltPayload;
     type PayloadAttributes = T::PayloadAttributes;
@@ -47,7 +47,7 @@ impl<T: PayloadTypes<ExecutionData = ExecutionData>> PayloadTypes for OpEngineTy
     }
 }
 
-impl<T: PayloadTypes<ExecutionData = ExecutionData>> EngineTypes for OpEngineTypes<T>
+impl<T: PayloadTypes<ExecutionData = ExecutionData>> EngineTypes for BaseEngineTypes<T>
 where
     T::BuiltPayload: BuiltPayload<Primitives: NodePrimitives<Block = BaseBlock>>
         + TryInto<ExecutionPayloadV1>
@@ -66,19 +66,19 @@ where
 
 /// Validator for Base engine API.
 #[derive(Debug)]
-pub struct OpEngineValidator<P, Tx, ChainSpec> {
-    inner: OpExecutionPayloadValidator<ChainSpec>,
+pub struct BaseEngineValidator<P, Tx, ChainSpec> {
+    inner: BaseExecutionPayloadValidator<ChainSpec>,
     provider: P,
     hashed_addr_l2tol1_msg_passer: B256,
     phantom: PhantomData<Tx>,
 }
 
-impl<P, Tx, ChainSpec> OpEngineValidator<P, Tx, ChainSpec> {
+impl<P, Tx, ChainSpec> BaseEngineValidator<P, Tx, ChainSpec> {
     /// Instantiates a new validator.
     pub fn new<KH: KeyHasher>(chain_spec: Arc<ChainSpec>, provider: P) -> Self {
         let hashed_addr_l2tol1_msg_passer = KH::hash_key(Predeploys::L2_TO_L1_MESSAGE_PASSER);
         Self {
-            inner: OpExecutionPayloadValidator::new(chain_spec),
+            inner: BaseExecutionPayloadValidator::new(chain_spec),
             provider,
             hashed_addr_l2tol1_msg_passer,
             phantom: PhantomData,
@@ -86,14 +86,14 @@ impl<P, Tx, ChainSpec> OpEngineValidator<P, Tx, ChainSpec> {
     }
 }
 
-impl<P, Tx, ChainSpec> Clone for OpEngineValidator<P, Tx, ChainSpec>
+impl<P, Tx, ChainSpec> Clone for BaseEngineValidator<P, Tx, ChainSpec>
 where
     P: Clone,
     ChainSpec: Upgrades,
 {
     fn clone(&self) -> Self {
         Self {
-            inner: OpExecutionPayloadValidator::new(self.inner.clone()),
+            inner: BaseExecutionPayloadValidator::new(self.inner.clone()),
             provider: self.provider.clone(),
             hashed_addr_l2tol1_msg_passer: self.hashed_addr_l2tol1_msg_passer,
             phantom: Default::default(),
@@ -101,7 +101,7 @@ where
     }
 }
 
-impl<P, Tx, ChainSpec> OpEngineValidator<P, Tx, ChainSpec>
+impl<P, Tx, ChainSpec> BaseEngineValidator<P, Tx, ChainSpec>
 where
     ChainSpec: Upgrades,
 {
@@ -112,7 +112,7 @@ where
     }
 }
 
-impl<P, Tx, ChainSpec, Types> PayloadValidator<Types> for OpEngineValidator<P, Tx, ChainSpec>
+impl<P, Tx, ChainSpec, Types> PayloadValidator<Types> for BaseEngineValidator<P, Tx, ChainSpec>
 where
     P: StateProviderFactory + Unpin + 'static,
     Tx: SignedTransaction + Unpin + 'static,
@@ -159,7 +159,7 @@ where
     }
 }
 
-impl<Types, P, Tx, ChainSpec> EngineApiValidator<Types> for OpEngineValidator<P, Tx, ChainSpec>
+impl<Types, P, Tx, ChainSpec> EngineApiValidator<Types> for BaseEngineValidator<P, Tx, ChainSpec>
 where
     Types: PayloadTypes<
             PayloadAttributes = BasePayloadAttributes,
@@ -345,14 +345,14 @@ mod tests {
 
     #[test]
     fn test_well_formed_attributes_pre_holocene() {
-        let validator = OpEngineValidator::new::<KeccakKeyHasher>(
+        let validator = BaseEngineValidator::new::<KeccakKeyHasher>(
             BASE_SEPOLIA.clone(),
             NoopProvider::default(),
         );
         let attributes = get_attributes(None, None, 1732633199);
 
-        let result = <engine::OpEngineValidator<_, _, _> as EngineApiValidator<
-            OpEngineTypes,
+        let result = <engine::BaseEngineValidator<_, _, _> as EngineApiValidator<
+            BaseEngineTypes,
         >>::ensure_well_formed_attributes(
             &validator, EngineApiMessageVersion::V3, &attributes,
         );
@@ -361,14 +361,14 @@ mod tests {
 
     #[test]
     fn test_well_formed_attributes_holocene_no_eip1559_params() {
-        let validator = OpEngineValidator::new::<KeccakKeyHasher>(
+        let validator = BaseEngineValidator::new::<KeccakKeyHasher>(
             BASE_SEPOLIA.clone(),
             NoopProvider::default(),
         );
         let attributes = get_attributes(None, None, 1732633200);
 
-        let result = <engine::OpEngineValidator<_, _, _> as EngineApiValidator<
-            OpEngineTypes,
+        let result = <engine::BaseEngineValidator<_, _, _> as EngineApiValidator<
+            BaseEngineTypes,
         >>::ensure_well_formed_attributes(
             &validator, EngineApiMessageVersion::V3, &attributes,
         );
@@ -377,14 +377,14 @@ mod tests {
 
     #[test]
     fn test_well_formed_attributes_holocene_eip1559_params_zero_denominator() {
-        let validator = OpEngineValidator::new::<KeccakKeyHasher>(
+        let validator = BaseEngineValidator::new::<KeccakKeyHasher>(
             BASE_SEPOLIA.clone(),
             NoopProvider::default(),
         );
         let attributes = get_attributes(Some(b64!("0000000000000008")), None, 1732633200);
 
-        let result = <engine::OpEngineValidator<_, _, _> as EngineApiValidator<
-            OpEngineTypes,
+        let result = <engine::BaseEngineValidator<_, _, _> as EngineApiValidator<
+            BaseEngineTypes,
         >>::ensure_well_formed_attributes(
             &validator, EngineApiMessageVersion::V3, &attributes,
         );
@@ -393,14 +393,14 @@ mod tests {
 
     #[test]
     fn test_well_formed_attributes_holocene_eip1559_params_zero_elasticity() {
-        let validator = OpEngineValidator::new::<KeccakKeyHasher>(
+        let validator = BaseEngineValidator::new::<KeccakKeyHasher>(
             BASE_SEPOLIA.clone(),
             NoopProvider::default(),
         );
         let attributes = get_attributes(Some(b64!("0000000800000000")), None, 1732633200);
 
-        let result = <engine::OpEngineValidator<_, _, _> as EngineApiValidator<
-            OpEngineTypes,
+        let result = <engine::BaseEngineValidator<_, _, _> as EngineApiValidator<
+            BaseEngineTypes,
         >>::ensure_well_formed_attributes(
             &validator, EngineApiMessageVersion::V3, &attributes,
         );
@@ -409,14 +409,14 @@ mod tests {
 
     #[test]
     fn test_well_formed_attributes_holocene_valid() {
-        let validator = OpEngineValidator::new::<KeccakKeyHasher>(
+        let validator = BaseEngineValidator::new::<KeccakKeyHasher>(
             BASE_SEPOLIA.clone(),
             NoopProvider::default(),
         );
         let attributes = get_attributes(Some(b64!("0000000800000008")), None, 1732633200);
 
-        let result = <engine::OpEngineValidator<_, _, _> as EngineApiValidator<
-            OpEngineTypes,
+        let result = <engine::BaseEngineValidator<_, _, _> as EngineApiValidator<
+            BaseEngineTypes,
         >>::ensure_well_formed_attributes(
             &validator, EngineApiMessageVersion::V3, &attributes,
         );
@@ -425,14 +425,14 @@ mod tests {
 
     #[test]
     fn test_well_formed_attributes_holocene_valid_all_zero() {
-        let validator = OpEngineValidator::new::<KeccakKeyHasher>(
+        let validator = BaseEngineValidator::new::<KeccakKeyHasher>(
             BASE_SEPOLIA.clone(),
             NoopProvider::default(),
         );
         let attributes = get_attributes(Some(b64!("0000000000000000")), None, 1732633200);
 
-        let result = <engine::OpEngineValidator<_, _, _> as EngineApiValidator<
-            OpEngineTypes,
+        let result = <engine::BaseEngineValidator<_, _, _> as EngineApiValidator<
+            BaseEngineTypes,
         >>::ensure_well_formed_attributes(
             &validator, EngineApiMessageVersion::V3, &attributes,
         );
@@ -441,7 +441,7 @@ mod tests {
 
     #[test]
     fn test_well_formed_attributes_jovian_valid() {
-        let validator = OpEngineValidator::new::<KeccakKeyHasher>(
+        let validator = BaseEngineValidator::new::<KeccakKeyHasher>(
             BASE_SEPOLIA.clone(),
             NoopProvider::default(),
         );
@@ -451,8 +451,8 @@ mod tests {
             ChainConfig::sepolia().jovian_timestamp,
         );
 
-        let result = <engine::OpEngineValidator<_, _, _> as EngineApiValidator<
-            OpEngineTypes,
+        let result = <engine::BaseEngineValidator<_, _, _> as EngineApiValidator<
+            BaseEngineTypes,
         >>::ensure_well_formed_attributes(
             &validator, EngineApiMessageVersion::V3, &attributes,
         );
@@ -462,14 +462,14 @@ mod tests {
     /// After Jovian (and holocene), eip1559 params must be Some
     #[test]
     fn test_malformed_attributes_jovian_with_eip_1559_params_none() {
-        let validator = OpEngineValidator::new::<KeccakKeyHasher>(
+        let validator = BaseEngineValidator::new::<KeccakKeyHasher>(
             BASE_SEPOLIA.clone(),
             NoopProvider::default(),
         );
         let attributes = get_attributes(None, Some(1), ChainConfig::sepolia().jovian_timestamp);
 
-        let result = <engine::OpEngineValidator<_, _, _> as EngineApiValidator<
-            OpEngineTypes,
+        let result = <engine::BaseEngineValidator<_, _, _> as EngineApiValidator<
+            BaseEngineTypes,
         >>::ensure_well_formed_attributes(
             &validator, EngineApiMessageVersion::V3, &attributes,
         );
@@ -479,14 +479,14 @@ mod tests {
     /// Before Jovian, min base fee must be None
     #[test]
     fn test_malformed_attributes_pre_jovian_with_min_base_fee() {
-        let validator = OpEngineValidator::new::<KeccakKeyHasher>(
+        let validator = BaseEngineValidator::new::<KeccakKeyHasher>(
             BASE_SEPOLIA.clone(),
             NoopProvider::default(),
         );
         let attributes = get_attributes(Some(b64!("0000000000000000")), Some(1), 1732633200);
 
-        let result = <engine::OpEngineValidator<_, _, _> as EngineApiValidator<
-            OpEngineTypes,
+        let result = <engine::BaseEngineValidator<_, _, _> as EngineApiValidator<
+            BaseEngineTypes,
         >>::ensure_well_formed_attributes(
             &validator, EngineApiMessageVersion::V3, &attributes,
         );
@@ -496,7 +496,7 @@ mod tests {
     /// After Jovian, min base fee must be Some
     #[test]
     fn test_malformed_attributes_post_jovian_with_min_base_fee_none() {
-        let validator = OpEngineValidator::new::<KeccakKeyHasher>(
+        let validator = BaseEngineValidator::new::<KeccakKeyHasher>(
             BASE_SEPOLIA.clone(),
             NoopProvider::default(),
         );
@@ -506,8 +506,8 @@ mod tests {
             ChainConfig::sepolia().jovian_timestamp,
         );
 
-        let result = <engine::OpEngineValidator<_, _, _> as EngineApiValidator<
-            OpEngineTypes,
+        let result = <engine::BaseEngineValidator<_, _, _> as EngineApiValidator<
+            BaseEngineTypes,
         >>::ensure_well_formed_attributes(
             &validator, EngineApiMessageVersion::V3, &attributes,
         );

--- a/crates/execution/node/src/engine.rs
+++ b/crates/execution/node/src/engine.rs
@@ -10,7 +10,7 @@ use base_common_rpc_types_engine::{
     BasePayloadAttributes, ExecutionData,
 };
 use base_execution_consensus::isthmus;
-use base_execution_payload_builder::{BasePayloadTypes, BaseExecutionPayloadValidator};
+use base_execution_payload_builder::{BaseExecutionPayloadValidator, BasePayloadTypes};
 use reth_consensus::ConsensusError;
 use reth_node_api::{
     BuiltPayload, EngineApiValidator, EngineTypes, NodePrimitives, PayloadValidator,
@@ -354,7 +354,7 @@ mod tests {
         let result = <engine::BaseEngineValidator<_, _, _> as EngineApiValidator<
             BaseEngineTypes,
         >>::ensure_well_formed_attributes(
-            &validator, EngineApiMessageVersion::V3, &attributes,
+            &validator, EngineApiMessageVersion::V3, &attributes
         );
         assert!(result.is_ok());
     }
@@ -370,7 +370,7 @@ mod tests {
         let result = <engine::BaseEngineValidator<_, _, _> as EngineApiValidator<
             BaseEngineTypes,
         >>::ensure_well_formed_attributes(
-            &validator, EngineApiMessageVersion::V3, &attributes,
+            &validator, EngineApiMessageVersion::V3, &attributes
         );
         assert_invalid_params_error!(result, "MissingEip1559ParamsInPayloadAttributes");
     }
@@ -386,7 +386,7 @@ mod tests {
         let result = <engine::BaseEngineValidator<_, _, _> as EngineApiValidator<
             BaseEngineTypes,
         >>::ensure_well_formed_attributes(
-            &validator, EngineApiMessageVersion::V3, &attributes,
+            &validator, EngineApiMessageVersion::V3, &attributes
         );
         assert_invalid_params_error!(result, "Eip1559ParamsDenominatorZero");
     }
@@ -402,7 +402,7 @@ mod tests {
         let result = <engine::BaseEngineValidator<_, _, _> as EngineApiValidator<
             BaseEngineTypes,
         >>::ensure_well_formed_attributes(
-            &validator, EngineApiMessageVersion::V3, &attributes,
+            &validator, EngineApiMessageVersion::V3, &attributes
         );
         assert_invalid_params_error!(result, "Eip1559ParamsElasticityZero");
     }
@@ -418,7 +418,7 @@ mod tests {
         let result = <engine::BaseEngineValidator<_, _, _> as EngineApiValidator<
             BaseEngineTypes,
         >>::ensure_well_formed_attributes(
-            &validator, EngineApiMessageVersion::V3, &attributes,
+            &validator, EngineApiMessageVersion::V3, &attributes
         );
         assert!(result.is_ok());
     }
@@ -434,7 +434,7 @@ mod tests {
         let result = <engine::BaseEngineValidator<_, _, _> as EngineApiValidator<
             BaseEngineTypes,
         >>::ensure_well_formed_attributes(
-            &validator, EngineApiMessageVersion::V3, &attributes,
+            &validator, EngineApiMessageVersion::V3, &attributes
         );
         assert!(result.is_ok());
     }
@@ -454,7 +454,7 @@ mod tests {
         let result = <engine::BaseEngineValidator<_, _, _> as EngineApiValidator<
             BaseEngineTypes,
         >>::ensure_well_formed_attributes(
-            &validator, EngineApiMessageVersion::V3, &attributes,
+            &validator, EngineApiMessageVersion::V3, &attributes
         );
         assert!(result.is_ok());
     }
@@ -471,7 +471,7 @@ mod tests {
         let result = <engine::BaseEngineValidator<_, _, _> as EngineApiValidator<
             BaseEngineTypes,
         >>::ensure_well_formed_attributes(
-            &validator, EngineApiMessageVersion::V3, &attributes,
+            &validator, EngineApiMessageVersion::V3, &attributes
         );
         assert_invalid_params_error!(result, "MissingEip1559ParamsInPayloadAttributes");
     }
@@ -488,7 +488,7 @@ mod tests {
         let result = <engine::BaseEngineValidator<_, _, _> as EngineApiValidator<
             BaseEngineTypes,
         >>::ensure_well_formed_attributes(
-            &validator, EngineApiMessageVersion::V3, &attributes,
+            &validator, EngineApiMessageVersion::V3, &attributes
         );
         assert_invalid_params_error!(result, "MinBaseFeeNotAllowedBeforeJovian");
     }
@@ -509,7 +509,7 @@ mod tests {
         let result = <engine::BaseEngineValidator<_, _, _> as EngineApiValidator<
             BaseEngineTypes,
         >>::ensure_well_formed_attributes(
-            &validator, EngineApiMessageVersion::V3, &attributes,
+            &validator, EngineApiMessageVersion::V3, &attributes
         );
         assert_invalid_params_error!(result, "MissingMinBaseFeeInPayloadAttributes");
     }

--- a/crates/execution/node/src/lib.rs
+++ b/crates/execution/node/src/lib.rs
@@ -17,13 +17,13 @@ pub use args::TxpoolOrdering;
 /// Exports Base-specific implementations of the [`EngineTypes`](reth_node_api::EngineTypes)
 /// trait.
 pub mod engine;
-pub use engine::OpEngineTypes;
+pub use engine::BaseEngineTypes;
 
 pub mod node;
 pub use node::*;
 
 pub mod rpc;
-pub use rpc::OpEngineApiBuilder;
+pub use rpc::BaseEngineApiBuilder;
 
 pub mod version;
 pub use version::CLIENT_NAME;

--- a/crates/execution/node/src/node.rs
+++ b/crates/execution/node/src/node.rs
@@ -8,17 +8,17 @@ use base_common_chains::Upgrades;
 use base_common_consensus::BasePrimitives;
 use base_common_rpc_types_engine::{BasePayloadAttributes, ExecutionData};
 use base_execution_chainspec::BaseChainSpec;
-use base_execution_consensus::OpBeaconConsensus;
-use base_execution_evm::{BaseEvmConfig, OpRethReceiptBuilder};
+use base_execution_consensus::BaseBeaconConsensus;
+use base_execution_evm::{BaseEvmConfig, BaseRethReceiptBuilder};
 use base_execution_payload_builder::{
-    Attributes, OpBuiltPayload, PayloadPrimitives,
+    Attributes, BaseBuiltPayload, PayloadPrimitives,
     builder::BasePayloadTransactions,
     config::{BaseBuilderConfig, BaseDAConfig, GasLimitConfig},
 };
 use base_execution_rpc::{
     MinerApiExtServer,
     config::{BaseEthConfigApiServer, BaseEthConfigHandler},
-    eth::OpEthApiBuilder,
+    eth::BaseEthApiBuilder,
     miner::BaseMinerExtApi,
     witness::BaseDebugWitnessApi,
 };
@@ -64,19 +64,19 @@ use reth_trie_common::KeccakKeyHasher;
 use serde::de::DeserializeOwned;
 
 use crate::{
-    OpEngineApiBuilder, OpEngineTypes,
+    BaseEngineApiBuilder, BaseEngineTypes,
     args::{RollupArgs, TxpoolOrdering},
-    engine::OpEngineValidator,
+    engine::BaseEngineValidator,
 };
 
 /// Marker trait for Base node types with standard engine, chain spec, and primitives.
 pub trait BaseNodeTypes:
-    NodeTypes<Payload = OpEngineTypes, ChainSpec = BaseChainSpec, Primitives = BasePrimitives>
+    NodeTypes<Payload = BaseEngineTypes, ChainSpec = BaseChainSpec, Primitives = BasePrimitives>
 {
 }
 /// Blanket impl for all node types that conform to the Base spec.
 impl<N> BaseNodeTypes for N where
-    N: NodeTypes<Payload = OpEngineTypes, ChainSpec = BaseChainSpec, Primitives = BasePrimitives>
+    N: NodeTypes<Payload = BaseEngineTypes, ChainSpec = BaseChainSpec, Primitives = BasePrimitives>
 {
 }
 
@@ -191,7 +191,7 @@ pub struct BaseNode {
 }
 
 /// A [`ComponentsBuilder`] with its generic arguments set to a stack of Base-specific builders.
-pub type BaseNodeComponentBuilder<Node, Payload = OpPayloadBuilder> = ComponentsBuilder<
+pub type BaseNodeComponentBuilder<Node, Payload = BasePayloadBuilder> = ComponentsBuilder<
     Node,
     BasePoolBuilder,
     BasicPayloadServiceBuilder<Payload>,
@@ -243,7 +243,7 @@ impl BaseNode {
             .executor(BaseExecutorBuilder::default())
             .pool(BasePoolBuilder::default().with_ordering(ordering))
             .payload(BasicPayloadServiceBuilder::new(
-                OpPayloadBuilder::new(compute_pending_block)
+                BasePayloadBuilder::new(compute_pending_block)
                     .with_da_config(self.da_config.clone())
                     .with_gas_limit_config(self.gas_limit_config.clone()),
             ))
@@ -308,7 +308,7 @@ where
     type ComponentsBuilder = ComponentsBuilder<
         N,
         BasePoolBuilder,
-        BasicPayloadServiceBuilder<OpPayloadBuilder>,
+        BasicPayloadServiceBuilder<BasePayloadBuilder>,
         BaseNetworkBuilder,
         BaseExecutorBuilder,
         BaseConsensusBuilder,
@@ -316,9 +316,9 @@ where
 
     type AddOns = BaseAddOns<
         NodeAdapter<N, <Self::ComponentsBuilder as NodeComponentsBuilder<N>>::Components>,
-        OpEthApiBuilder,
+        BaseEthApiBuilder,
         BasePayloadValidatorBuilder,
-        OpEngineApiBuilder<BasePayloadValidatorBuilder>,
+        BaseEngineApiBuilder<BasePayloadValidatorBuilder>,
         BasicEngineValidatorBuilder<BasePayloadValidatorBuilder>,
     >;
 
@@ -352,7 +352,7 @@ impl NodeTypes for BaseNode {
     type Primitives = BasePrimitives;
     type ChainSpec = BaseChainSpec;
     type Storage = BaseStorage;
-    type Payload = OpEngineTypes;
+    type Payload = BaseEngineTypes;
 }
 
 /// Add-ons w.r.t. Base.
@@ -364,7 +364,7 @@ pub struct BaseAddOns<
     N: FullNodeComponents,
     EthB: EthApiBuilder<N>,
     PVB,
-    EB = OpEngineApiBuilder<PVB>,
+    EB = BaseEngineApiBuilder<PVB>,
     EVB = BasicEngineValidatorBuilder<PVB>,
     RpcMiddleware = Identity,
 > {
@@ -409,10 +409,10 @@ where
     }
 }
 
-impl<N> Default for BaseAddOns<N, OpEthApiBuilder, BasePayloadValidatorBuilder>
+impl<N> Default for BaseAddOns<N, BaseEthApiBuilder, BasePayloadValidatorBuilder>
 where
     N: FullNodeComponents<Types: BaseNodeTypes>,
-    OpEthApiBuilder: EthApiBuilder<N>,
+    BaseEthApiBuilder: EthApiBuilder<N>,
 {
     fn default() -> Self {
         Self::builder().build()
@@ -422,14 +422,14 @@ where
 impl<N, NetworkT, RpcMiddleware>
     BaseAddOns<
         N,
-        OpEthApiBuilder<NetworkT>,
+        BaseEthApiBuilder<NetworkT>,
         BasePayloadValidatorBuilder,
-        OpEngineApiBuilder<BasePayloadValidatorBuilder>,
+        BaseEngineApiBuilder<BasePayloadValidatorBuilder>,
         RpcMiddleware,
     >
 where
     N: FullNodeComponents<Types: BaseNodeTypes>,
-    OpEthApiBuilder<NetworkT>: EthApiBuilder<N>,
+    BaseEthApiBuilder<NetworkT>: EthApiBuilder<N>,
 {
     /// Build a [`BaseAddOns`] using [`BaseAddOnsBuilder`].
     pub fn builder() -> BaseAddOnsBuilder<NetworkT> {
@@ -567,7 +567,7 @@ where
         let eth_config =
             BaseEthConfigHandler::new(ctx.node.provider().clone(), ctx.node.evm_config().clone());
 
-        let builder = base_execution_payload_builder::OpPayloadBuilder::new(
+        let builder = base_execution_payload_builder::BasePayloadBuilder::new(
             ctx.node.pool().clone(),
             ctx.node.provider().clone(),
             ctx.node.evm_config().clone(),
@@ -763,10 +763,10 @@ impl<NetworkT, RpcMiddleware> BaseAddOnsBuilder<NetworkT, RpcMiddleware> {
     /// Builds an instance of [`BaseAddOns`].
     pub fn build<N, PVB, EB, EVB>(
         self,
-    ) -> BaseAddOns<N, OpEthApiBuilder<NetworkT>, PVB, EB, EVB, RpcMiddleware>
+    ) -> BaseAddOns<N, BaseEthApiBuilder<NetworkT>, PVB, EB, EVB, RpcMiddleware>
     where
         N: FullNodeComponents<Types: NodeTypes>,
-        OpEthApiBuilder<NetworkT>: EthApiBuilder<N>,
+        BaseEthApiBuilder<NetworkT>: EthApiBuilder<N>,
         PVB: PayloadValidatorBuilder<N> + Default,
         EB: Default,
         EVB: Default,
@@ -784,7 +784,7 @@ impl<NetworkT, RpcMiddleware> BaseAddOnsBuilder<NetworkT, RpcMiddleware> {
 
         BaseAddOns::new(
             RpcAddOns::new(
-                OpEthApiBuilder::default()
+                BaseEthApiBuilder::default()
                     .with_sequencer(sequencer_url.clone())
                     .with_sequencer_headers(sequencer_headers.clone())
                     .with_min_suggested_priority_fee(min_suggested_priority_fee),
@@ -818,7 +818,7 @@ where
     >;
 
     async fn build_evm(self, ctx: &BuilderContext<Node>) -> eyre::Result<Self::EVM> {
-        let evm_config = BaseEvmConfig::new(ctx.chain_spec(), OpRethReceiptBuilder::default());
+        let evm_config = BaseEvmConfig::new(ctx.chain_spec(), BaseRethReceiptBuilder::default());
 
         Ok(evm_config)
     }
@@ -931,7 +931,7 @@ where
 
 /// A basic Base payload service builder
 #[derive(Debug, Default, Clone)]
-pub struct OpPayloadBuilder<Txs = ()> {
+pub struct BasePayloadBuilder<Txs = ()> {
     /// By default the pending block equals the latest block
     /// to save resources and not leak txs from the tx-pool,
     /// this flag enables computing of the pending block
@@ -952,7 +952,7 @@ pub struct OpPayloadBuilder<Txs = ()> {
     pub gas_limit_config: GasLimitConfig,
 }
 
-impl OpPayloadBuilder {
+impl BasePayloadBuilder {
     /// Create a new instance with the given `compute_pending_block` flag and data availability
     /// config.
     pub fn new(compute_pending_block: bool) -> Self {
@@ -977,23 +977,23 @@ impl OpPayloadBuilder {
     }
 }
 
-impl<Txs> OpPayloadBuilder<Txs> {
+impl<Txs> BasePayloadBuilder<Txs> {
     /// Configures the type responsible for yielding the transactions that should be included in the
     /// payload.
-    pub fn with_transactions<T>(self, best_transactions: T) -> OpPayloadBuilder<T> {
+    pub fn with_transactions<T>(self, best_transactions: T) -> BasePayloadBuilder<T> {
         let Self { compute_pending_block, da_config, gas_limit_config, .. } = self;
-        OpPayloadBuilder { compute_pending_block, best_transactions, da_config, gas_limit_config }
+        BasePayloadBuilder { compute_pending_block, best_transactions, da_config, gas_limit_config }
     }
 }
 
-impl<Node, Pool, Txs, Evm, Attrs> PayloadBuilderBuilder<Node, Pool, Evm> for OpPayloadBuilder<Txs>
+impl<Node, Pool, Txs, Evm, Attrs> PayloadBuilderBuilder<Node, Pool, Evm> for BasePayloadBuilder<Txs>
 where
     Node: FullNodeTypes<
             Provider: ChainSpecProvider<ChainSpec: Upgrades>,
             Types: NodeTypes<
                 Primitives: PayloadPrimitives,
                 Payload: PayloadTypes<
-                    BuiltPayload = OpBuiltPayload<PrimitivesTy<Node::Types>>,
+                    BuiltPayload = BaseBuiltPayload<PrimitivesTy<Node::Types>>,
                     PayloadBuilderAttributes = Attrs,
                 >,
             >,
@@ -1011,7 +1011,7 @@ where
     Attrs: Attributes<Transaction = TxTy<Node::Types>>,
 {
     type PayloadBuilder =
-        base_execution_payload_builder::OpPayloadBuilder<Pool, Node::Provider, Evm, Txs, Attrs>;
+        base_execution_payload_builder::BasePayloadBuilder<Pool, Node::Provider, Evm, Txs, Attrs>;
 
     async fn build_payload_builder(
         self,
@@ -1020,7 +1020,7 @@ where
         evm_config: Evm,
     ) -> eyre::Result<Self::PayloadBuilder> {
         let payload_builder =
-            base_execution_payload_builder::OpPayloadBuilder::with_builder_config(
+            base_execution_payload_builder::BasePayloadBuilder::with_builder_config(
                 pool,
                 ctx.provider().clone(),
                 evm_config,
@@ -1140,14 +1140,14 @@ impl<Node> ConsensusBuilder<Node> for BaseConsensusBuilder
 where
     Node: FullNodeTypes<Types: BaseNodeTypes>,
 {
-    type Consensus = Arc<OpBeaconConsensus>;
+    type Consensus = Arc<BaseBeaconConsensus>;
 
     async fn build_consensus(self, ctx: &BuilderContext<Node>) -> eyre::Result<Self::Consensus> {
-        Ok(Arc::new(OpBeaconConsensus::new(ctx.chain_spec())))
+        Ok(Arc::new(BaseBeaconConsensus::new(ctx.chain_spec())))
     }
 }
 
-/// Builder for [`OpEngineValidator`].
+/// Builder for [`BaseEngineValidator`].
 #[derive(Debug, Default, Clone)]
 #[non_exhaustive]
 pub struct BasePayloadValidatorBuilder;
@@ -1158,14 +1158,14 @@ where
         Types: NodeTypes<ChainSpec: Upgrades, Payload: PayloadTypes<ExecutionData = ExecutionData>>,
     >,
 {
-    type Validator = OpEngineValidator<
+    type Validator = BaseEngineValidator<
         Node::Provider,
         <<Node::Types as NodeTypes>::Primitives as NodePrimitives>::SignedTx,
         <Node::Types as NodeTypes>::ChainSpec,
     >;
 
     async fn build(self, ctx: &AddOnsContext<'_, Node>) -> eyre::Result<Self::Validator> {
-        Ok(OpEngineValidator::new::<KeccakKeyHasher>(
+        Ok(BaseEngineValidator::new::<KeccakKeyHasher>(
             Arc::clone(&ctx.config.chain),
             ctx.node.provider().clone(),
         ))

--- a/crates/execution/node/src/rpc.rs
+++ b/crates/execution/node/src/rpc.rs
@@ -18,7 +18,7 @@
 //! use base_execution_chainspec::BASE_SEPOLIA;
 //! use base_execution_evm::BaseEvmConfig;
 //! use base_node_core::{BaseNetworkPrimitives, BaseExecutorBuilder, BaseNode};
-//! use base_execution_rpc::OpEthApiBuilder;
+//! use base_execution_rpc::BaseEthApiBuilder;
 //! use base_execution_txpool::BasePooledTransaction;
 //! use reth_provider::providers::BlockchainProvider;
 //! use reth_rpc::TraceApi;
@@ -76,7 +76,7 @@
 //!         cache,
 //!         engine_handle: ConsensusEngineHandle::new(tx),
 //!     };
-//!     let eth_api = OpEthApiBuilder::<Base>::default().build_eth_api(ctx).await.unwrap();
+//!     let eth_api = BaseEthApiBuilder::<Base>::default().build_eth_api(ctx).await.unwrap();
 //!
 //!     // build `trace` namespace API
 //!     let trace_api = TraceApi::new(eth_api, BlockingTaskGuard::new(10), EthConfig::default());
@@ -104,11 +104,11 @@ use crate::CLIENT_NAME;
 
 /// Builder for basic [`BaseEngineApi`] implementation.
 #[derive(Debug, Default, Clone)]
-pub struct OpEngineApiBuilder<EV> {
+pub struct BaseEngineApiBuilder<EV> {
     engine_validator_builder: EV,
 }
 
-impl<N, EV> EngineApiBuilder<N> for OpEngineApiBuilder<EV>
+impl<N, EV> EngineApiBuilder<N> for BaseEngineApiBuilder<EV>
 where
     N: FullNodeComponents<
         Types: NodeTypes<

--- a/crates/execution/node/src/utils.rs
+++ b/crates/execution/node/src/utils.rs
@@ -4,7 +4,7 @@ use alloy_genesis::Genesis;
 use alloy_primitives::{Address, B256};
 use alloy_rpc_types_engine::PayloadAttributes;
 use base_execution_chainspec::BaseChainSpecBuilder;
-use base_execution_payload_builder::{OpBuiltPayload, OpPayloadBuilderAttributes};
+use base_execution_payload_builder::{BaseBuiltPayload, BasePayloadBuilderAttributes};
 use reth_e2e_test_utils::{
     NodeHelperType, TmpDB, transaction::TransactionTestContext, wallet::Wallet,
 };
@@ -38,7 +38,7 @@ pub async fn advance_chain(
     length: usize,
     node: &mut BaseNode,
     wallet: Arc<Mutex<Wallet>>,
-) -> eyre::Result<Vec<OpBuiltPayload>> {
+) -> eyre::Result<Vec<BaseBuiltPayload>> {
     node.advance(length as u64, |_| {
         let wallet = Arc::clone(&wallet);
         Box::pin(async move {
@@ -56,7 +56,7 @@ pub async fn advance_chain(
 }
 
 /// Helper function to create a new eth payload attributes
-pub fn payload_attributes<T>(timestamp: u64) -> OpPayloadBuilderAttributes<T> {
+pub fn payload_attributes<T>(timestamp: u64) -> BasePayloadBuilderAttributes<T> {
     let attributes = PayloadAttributes {
         timestamp,
         prev_randao: B256::ZERO,
@@ -65,7 +65,7 @@ pub fn payload_attributes<T>(timestamp: u64) -> OpPayloadBuilderAttributes<T> {
         parent_beacon_block_root: Some(B256::ZERO),
     };
 
-    OpPayloadBuilderAttributes {
+    BasePayloadBuilderAttributes {
         payload_attributes: EthPayloadBuilderAttributes::new(B256::ZERO, attributes),
         transactions: vec![],
         no_tx_pool: false,

--- a/crates/execution/node/tests/e2e-testsuite/testsuite.rs
+++ b/crates/execution/node/tests/e2e-testsuite/testsuite.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use alloy_primitives::{Address, B64, B256};
 use base_common_rpc_types_engine::BasePayloadAttributes;
 use base_execution_chainspec::{BASE_MAINNET, BaseChainSpecBuilder};
-use base_node_core::{BaseNode, OpEngineTypes};
+use base_node_core::{BaseNode, BaseEngineTypes};
 use eyre::Result;
 use reth_e2e_test_utils::testsuite::{
     TestBuilder,
@@ -28,7 +28,7 @@ async fn test_testsuite_op_assert_mine_block() -> Result<()> {
         .with_network(NetworkSetup::single_node());
 
     let test =
-        TestBuilder::new().with_setup(setup).with_action(AssertMineBlock::<OpEngineTypes>::new(
+        TestBuilder::new().with_setup(setup).with_action(AssertMineBlock::<BaseEngineTypes>::new(
             0,
             vec![],
             Some(B256::ZERO),
@@ -73,7 +73,7 @@ async fn test_testsuite_op_assert_mine_block_isthmus_activated() -> Result<()> {
         .with_network(NetworkSetup::single_node());
 
     let test =
-        TestBuilder::new().with_setup(setup).with_action(AssertMineBlock::<OpEngineTypes>::new(
+        TestBuilder::new().with_setup(setup).with_action(AssertMineBlock::<BaseEngineTypes>::new(
             0,
             vec![],
             Some(B256::ZERO),

--- a/crates/execution/node/tests/e2e-testsuite/testsuite.rs
+++ b/crates/execution/node/tests/e2e-testsuite/testsuite.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use alloy_primitives::{Address, B64, B256};
 use base_common_rpc_types_engine::BasePayloadAttributes;
 use base_execution_chainspec::{BASE_MAINNET, BaseChainSpecBuilder};
-use base_node_core::{BaseNode, BaseEngineTypes};
+use base_node_core::{BaseEngineTypes, BaseNode};
 use eyre::Result;
 use reth_e2e_test_utils::testsuite::{
     TestBuilder,

--- a/crates/execution/node/tests/it/priority.rs
+++ b/crates/execution/node/tests/it/priority.rs
@@ -14,7 +14,7 @@ use base_node_core::{
     args::RollupArgs,
     node::{
         BaseConsensusBuilder, BaseExecutorBuilder, BaseNetworkBuilder, BaseNodeComponentBuilder,
-        BaseNodeTypes, BasePoolBuilder, OpPayloadBuilder,
+        BaseNodeTypes, BasePoolBuilder, BasePayloadBuilder,
     },
     utils::payload_attributes,
 };
@@ -89,7 +89,7 @@ impl BasePayloadTransactions<BasePooledTransaction> for CustomTxPriority {
 /// Builds the node with custom transaction priority service within default payload builder.
 fn build_components<Node>(
     chain_id: ChainId,
-) -> BaseNodeComponentBuilder<Node, OpPayloadBuilder<CustomTxPriority>>
+) -> BaseNodeComponentBuilder<Node, BasePayloadBuilder<CustomTxPriority>>
 where
     Node: FullNodeTypes<Types: BaseNodeTypes>,
 {
@@ -100,7 +100,7 @@ where
         .pool(BasePoolBuilder::default())
         .executor(BaseExecutorBuilder::default())
         .payload(BasicPayloadServiceBuilder::new(
-            OpPayloadBuilder::new(compute_pending_block)
+            BasePayloadBuilder::new(compute_pending_block)
                 .with_transactions(CustomTxPriority { chain_id }),
         ))
         .network(BaseNetworkBuilder::new(disable_txpool_gossip, !discovery_v4))

--- a/crates/execution/node/tests/it/priority.rs
+++ b/crates/execution/node/tests/it/priority.rs
@@ -14,7 +14,7 @@ use base_node_core::{
     args::RollupArgs,
     node::{
         BaseConsensusBuilder, BaseExecutorBuilder, BaseNetworkBuilder, BaseNodeComponentBuilder,
-        BaseNodeTypes, BasePoolBuilder, BasePayloadBuilder,
+        BaseNodeTypes, BasePayloadBuilder, BasePoolBuilder,
     },
     utils::payload_attributes,
 };

--- a/crates/execution/payload/src/builder.rs
+++ b/crates/execution/payload/src/builder.rs
@@ -39,18 +39,18 @@ use revm::context::{Block, BlockEnv};
 use tracing::{debug, trace, warn};
 
 use crate::{
-    Attributes, OpPayloadBuilderAttributes, PayloadPrimitives, config::BaseBuilderConfig,
-    error::BasePayloadBuilderError, payload::OpBuiltPayload,
+    Attributes, BasePayloadBuilderAttributes, PayloadPrimitives, config::BaseBuilderConfig,
+    error::BasePayloadBuilderError, payload::BaseBuiltPayload,
 };
 
 /// Base payload builder
 #[derive(Debug)]
-pub struct OpPayloadBuilder<
+pub struct BasePayloadBuilder<
     Pool,
     Client,
     Evm,
     Txs = (),
-    Attrs = OpPayloadBuilderAttributes<TxTy<<Evm as ConfigureEvm>::Primitives>>,
+    Attrs = BasePayloadBuilderAttributes<TxTy<<Evm as ConfigureEvm>::Primitives>>,
 > {
     /// The rollup's compute pending block configuration option.
     pub compute_pending_block: bool,
@@ -69,7 +69,7 @@ pub struct OpPayloadBuilder<
     _pd: PhantomData<Attrs>,
 }
 
-impl<Pool, Client, Evm, Txs, Attrs> Clone for OpPayloadBuilder<Pool, Client, Evm, Txs, Attrs>
+impl<Pool, Client, Evm, Txs, Attrs> Clone for BasePayloadBuilder<Pool, Client, Evm, Txs, Attrs>
 where
     Pool: Clone,
     Client: Clone,
@@ -89,8 +89,8 @@ where
     }
 }
 
-impl<Pool, Client, Evm, Attrs> OpPayloadBuilder<Pool, Client, Evm, (), Attrs> {
-    /// `OpPayloadBuilder` constructor.
+impl<Pool, Client, Evm, Attrs> BasePayloadBuilder<Pool, Client, Evm, (), Attrs> {
+    /// `BasePayloadBuilder` constructor.
     ///
     /// Configures the builder with the default settings.
     pub fn new(pool: Pool, client: Client, evm_config: Evm) -> Self {
@@ -116,7 +116,7 @@ impl<Pool, Client, Evm, Attrs> OpPayloadBuilder<Pool, Client, Evm, (), Attrs> {
     }
 }
 
-impl<Pool, Client, Evm, Txs, Attrs> OpPayloadBuilder<Pool, Client, Evm, Txs, Attrs> {
+impl<Pool, Client, Evm, Txs, Attrs> BasePayloadBuilder<Pool, Client, Evm, Txs, Attrs> {
     /// Sets the rollup's compute pending block configuration option.
     pub const fn set_compute_pending_block(mut self, compute_pending_block: bool) -> Self {
         self.compute_pending_block = compute_pending_block;
@@ -128,9 +128,9 @@ impl<Pool, Client, Evm, Txs, Attrs> OpPayloadBuilder<Pool, Client, Evm, Txs, Att
     pub fn with_transactions<T>(
         self,
         best_transactions: T,
-    ) -> OpPayloadBuilder<Pool, Client, Evm, T, Attrs> {
+    ) -> BasePayloadBuilder<Pool, Client, Evm, T, Attrs> {
         let Self { pool, client, compute_pending_block, evm_config, config, .. } = self;
-        OpPayloadBuilder {
+        BasePayloadBuilder {
             pool,
             client,
             compute_pending_block,
@@ -152,7 +152,7 @@ impl<Pool, Client, Evm, Txs, Attrs> OpPayloadBuilder<Pool, Client, Evm, Txs, Att
     }
 }
 
-impl<Pool, Client, Evm, N, T, Attrs> OpPayloadBuilder<Pool, Client, Evm, T, Attrs>
+impl<Pool, Client, Evm, N, T, Attrs> BasePayloadBuilder<Pool, Client, Evm, T, Attrs>
 where
     Pool: TransactionPool<Transaction: OpPooledTx<Consensus = N::SignedTx>>,
     Client: StateProviderFactory + ChainSpecProvider<ChainSpec: Upgrades>,
@@ -173,16 +173,16 @@ where
     /// a result indicating success with the payload or an error in case of failure.
     fn build_payload<'a, Txs>(
         &self,
-        args: BuildArguments<Attrs, OpBuiltPayload<N>>,
+        args: BuildArguments<Attrs, BaseBuiltPayload<N>>,
         best: impl FnOnce(BestTransactionsAttributes) -> Txs + Send + Sync + 'a,
-    ) -> Result<BuildOutcome<OpBuiltPayload<N>>, PayloadBuilderError>
+    ) -> Result<BuildOutcome<BaseBuiltPayload<N>>, PayloadBuilderError>
     where
         Txs:
             PayloadTransactions<Transaction: PoolTransaction<Consensus = N::SignedTx> + OpPooledTx>,
     {
         let BuildArguments { mut cached_reads, config, cancel, best_payload } = args;
 
-        let ctx = OpPayloadBuilderCtx {
+        let ctx = BasePayloadBuilderCtx {
             evm_config: self.evm_config.clone(),
             builder_config: self.config.clone(),
             chain_spec: self.client.chain_spec(),
@@ -218,7 +218,7 @@ where
             Attrs::try_new(parent.hash(), attributes, 3).map_err(PayloadBuilderError::other)?;
 
         let config = PayloadConfig { parent_header: Arc::new(parent), attributes };
-        let ctx = OpPayloadBuilderCtx {
+        let ctx = BasePayloadBuilderCtx {
             evm_config: self.evm_config.clone(),
             builder_config: self.config.clone(),
             chain_spec: self.client.chain_spec(),
@@ -234,9 +234,9 @@ where
     }
 }
 
-/// Implementation of the [`PayloadBuilder`] trait for [`OpPayloadBuilder`].
+/// Implementation of the [`PayloadBuilder`] trait for [`BasePayloadBuilder`].
 impl<Pool, Client, Evm, N, Txs, Attrs> PayloadBuilder
-    for OpPayloadBuilder<Pool, Client, Evm, Txs, Attrs>
+    for BasePayloadBuilder<Pool, Client, Evm, Txs, Attrs>
 where
     N: PayloadPrimitives,
     Client: StateProviderFactory + ChainSpecProvider<ChainSpec: Upgrades> + Clone,
@@ -249,7 +249,7 @@ where
     Attrs: Attributes<Transaction = N::SignedTx>,
 {
     type Attributes = Attrs;
-    type BuiltPayload = OpBuiltPayload<N>;
+    type BuiltPayload = BaseBuiltPayload<N>;
 
     fn try_build(
         &self,
@@ -321,8 +321,8 @@ impl<Txs> Builder<'_, Txs> {
         self,
         db: impl Database<Error = ProviderError>,
         state_provider: impl StateProvider,
-        ctx: OpPayloadBuilderCtx<Evm, ChainSpec, Attrs>,
-    ) -> Result<BuildOutcomeKind<OpBuiltPayload<N>>, PayloadBuilderError>
+        ctx: BasePayloadBuilderCtx<Evm, ChainSpec, Attrs>,
+    ) -> Result<BuildOutcomeKind<BaseBuiltPayload<N>>, PayloadBuilderError>
     where
         Evm: ConfigureEvm<
                 Primitives = N,
@@ -390,7 +390,7 @@ impl<Txs> Builder<'_, Txs> {
         let no_tx_pool = ctx.attributes().no_tx_pool();
 
         let payload =
-            OpBuiltPayload::new(ctx.payload_id(), sealed_block, info.total_fees, Some(executed));
+            BaseBuiltPayload::new(ctx.payload_id(), sealed_block, info.total_fees, Some(executed));
 
         if no_tx_pool {
             // if `no_tx_pool` is set only transactions from the payload attributes will be included
@@ -406,7 +406,7 @@ impl<Txs> Builder<'_, Txs> {
     pub fn witness<Evm, ChainSpec, N, Attrs>(
         self,
         state_provider: impl StateProvider,
-        ctx: &OpPayloadBuilderCtx<Evm, ChainSpec, Attrs>,
+        ctx: &BasePayloadBuilderCtx<Evm, ChainSpec, Attrs>,
     ) -> Result<ExecutionWitness, PayloadBuilderError>
     where
         Evm: ConfigureEvm<
@@ -537,10 +537,10 @@ impl ExecutionInfo {
 
 /// Container type that holds all necessities to build a new payload.
 #[derive(derive_more::Debug)]
-pub struct OpPayloadBuilderCtx<
+pub struct BasePayloadBuilderCtx<
     Evm: ConfigureEvm,
     ChainSpec,
-    Attrs = OpPayloadBuilderAttributes<TxTy<<Evm as ConfigureEvm>::Primitives>>,
+    Attrs = BasePayloadBuilderAttributes<TxTy<<Evm as ConfigureEvm>::Primitives>>,
 > {
     /// The type that knows how to perform system calls and configure the evm.
     pub evm_config: Evm,
@@ -553,10 +553,10 @@ pub struct OpPayloadBuilderCtx<
     /// Marker to check whether the job has been cancelled.
     pub cancel: CancelOnDrop,
     /// The currently best payload.
-    pub best_payload: Option<OpBuiltPayload<Evm::Primitives>>,
+    pub best_payload: Option<BaseBuiltPayload<Evm::Primitives>>,
 }
 
-impl<Evm, ChainSpec, Attrs> OpPayloadBuilderCtx<Evm, ChainSpec, Attrs>
+impl<Evm, ChainSpec, Attrs> BasePayloadBuilderCtx<Evm, ChainSpec, Attrs>
 where
     Evm: ConfigureEvm<
             Primitives: PayloadPrimitives,

--- a/crates/execution/payload/src/lib.rs
+++ b/crates/execution/payload/src/lib.rs
@@ -10,14 +10,14 @@
 extern crate alloc;
 
 pub mod builder;
-pub use builder::OpPayloadBuilder;
+pub use builder::BasePayloadBuilder;
 pub mod config;
 pub mod error;
 pub mod payload;
-pub use payload::{OpBuiltPayload, OpPayloadBuilderAttributes, payload_id};
+pub use payload::{BaseBuiltPayload, BasePayloadBuilderAttributes, payload_id};
 mod traits;
 pub use traits::*;
 mod types;
 pub use types::BasePayloadTypes;
 pub mod validator;
-pub use validator::OpExecutionPayloadValidator;
+pub use validator::BaseExecutionPayloadValidator;

--- a/crates/execution/payload/src/payload.rs
+++ b/crates/execution/payload/src/payload.rs
@@ -20,7 +20,7 @@ use base_common_rpc_types_engine::{
     BaseExecutionPayloadEnvelopeV3, BaseExecutionPayloadEnvelopeV4, BaseExecutionPayloadEnvelopeV5,
     BaseExecutionPayloadV4, BasePayloadAttributes,
 };
-use base_execution_evm::OpNextBlockEnvAttributes;
+use base_execution_evm::BaseNextBlockEnvAttributes;
 use reth_chainspec::EthChainSpec;
 use reth_payload_builder::{EthPayloadBuilderAttributes, PayloadBuilderError};
 use reth_payload_primitives::{
@@ -32,7 +32,7 @@ use reth_primitives_traits::{
 
 /// Base Payload Builder Attributes
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct OpPayloadBuilderAttributes<T> {
+pub struct BasePayloadBuilderAttributes<T> {
     /// Inner ethereum payload builder attributes
     pub payload_attributes: EthPayloadBuilderAttributes,
     /// `NoTxPool` option for the generated payload
@@ -48,7 +48,7 @@ pub struct OpPayloadBuilderAttributes<T> {
     pub min_base_fee: Option<u64>,
 }
 
-impl<T> Default for OpPayloadBuilderAttributes<T> {
+impl<T> Default for BasePayloadBuilderAttributes<T> {
     fn default() -> Self {
         Self {
             payload_attributes: Default::default(),
@@ -61,7 +61,7 @@ impl<T> Default for OpPayloadBuilderAttributes<T> {
     }
 }
 
-impl<T> OpPayloadBuilderAttributes<T> {
+impl<T> BasePayloadBuilderAttributes<T> {
     /// Extracts the extra data parameters post-Holocene hardfork.
     /// In Holocene, those parameters are the EIP-1559 base fee parameters.
     pub fn get_holocene_extra_data(
@@ -87,7 +87,7 @@ impl<T> OpPayloadBuilderAttributes<T> {
 }
 
 impl<T: Decodable2718 + Send + Sync + Debug + Unpin + 'static> PayloadBuilderAttributes
-    for OpPayloadBuilderAttributes<T>
+    for BasePayloadBuilderAttributes<T>
 {
     type RpcPayloadAttributes = BasePayloadAttributes;
     type Error = alloy_rlp::Error;
@@ -161,7 +161,7 @@ impl<T: Decodable2718 + Send + Sync + Debug + Unpin + 'static> PayloadBuilderAtt
 }
 
 impl<BaseTransactionSigned> From<EthPayloadBuilderAttributes>
-    for OpPayloadBuilderAttributes<BaseTransactionSigned>
+    for BasePayloadBuilderAttributes<BaseTransactionSigned>
 {
     fn from(value: EthPayloadBuilderAttributes) -> Self {
         Self { payload_attributes: value, ..Default::default() }
@@ -170,7 +170,7 @@ impl<BaseTransactionSigned> From<EthPayloadBuilderAttributes>
 
 /// Contains the built payload.
 #[derive(Debug, Clone)]
-pub struct OpBuiltPayload<N: NodePrimitives = BasePrimitives> {
+pub struct BaseBuiltPayload<N: NodePrimitives = BasePrimitives> {
     /// Identifier of the payload
     pub id: PayloadId,
     /// Sealed block
@@ -183,7 +183,7 @@ pub struct OpBuiltPayload<N: NodePrimitives = BasePrimitives> {
 
 // === impl BuiltPayload ===
 
-impl<N: NodePrimitives> OpBuiltPayload<N> {
+impl<N: NodePrimitives> BaseBuiltPayload<N> {
     /// Initializes the payload with the given initial block.
     pub const fn new(
         id: PayloadId,
@@ -215,7 +215,7 @@ impl<N: NodePrimitives> OpBuiltPayload<N> {
     }
 }
 
-impl<N: NodePrimitives> BuiltPayload for OpBuiltPayload<N> {
+impl<N: NodePrimitives> BuiltPayload for BaseBuiltPayload<N> {
     type Primitives = N;
 
     fn block(&self) -> &SealedBlock<N::Block> {
@@ -236,12 +236,12 @@ impl<N: NodePrimitives> BuiltPayload for OpBuiltPayload<N> {
 }
 
 // V1 engine_getPayloadV1 response
-impl<T, N> From<OpBuiltPayload<N>> for ExecutionPayloadV1
+impl<T, N> From<BaseBuiltPayload<N>> for ExecutionPayloadV1
 where
     T: SignedTransaction,
     N: NodePrimitives<Block = Block<T>>,
 {
-    fn from(value: OpBuiltPayload<N>) -> Self {
+    fn from(value: BaseBuiltPayload<N>) -> Self {
         Self::from_block_unchecked(
             value.block().hash(),
             &Arc::unwrap_or_clone(value.block).into_block(),
@@ -250,13 +250,13 @@ where
 }
 
 // V2 engine_getPayloadV2 response
-impl<T, N> From<OpBuiltPayload<N>> for ExecutionPayloadEnvelopeV2
+impl<T, N> From<BaseBuiltPayload<N>> for ExecutionPayloadEnvelopeV2
 where
     T: SignedTransaction,
     N: NodePrimitives<Block = Block<T>>,
 {
-    fn from(value: OpBuiltPayload<N>) -> Self {
-        let OpBuiltPayload { block, fees, .. } = value;
+    fn from(value: BaseBuiltPayload<N>) -> Self {
+        let BaseBuiltPayload { block, fees, .. } = value;
 
         Self {
             block_value: fees,
@@ -268,13 +268,13 @@ where
     }
 }
 
-impl<T, N> From<OpBuiltPayload<N>> for BaseExecutionPayloadEnvelopeV3
+impl<T, N> From<BaseBuiltPayload<N>> for BaseExecutionPayloadEnvelopeV3
 where
     T: SignedTransaction,
     N: NodePrimitives<Block = Block<T>>,
 {
-    fn from(value: OpBuiltPayload<N>) -> Self {
-        let OpBuiltPayload { block, fees, .. } = value;
+    fn from(value: BaseBuiltPayload<N>) -> Self {
+        let BaseBuiltPayload { block, fees, .. } = value;
 
         let parent_beacon_block_root = block.parent_beacon_block_root.unwrap_or_default();
 
@@ -300,13 +300,13 @@ where
     }
 }
 
-impl<T, N> From<OpBuiltPayload<N>> for BaseExecutionPayloadEnvelopeV4
+impl<T, N> From<BaseBuiltPayload<N>> for BaseExecutionPayloadEnvelopeV4
 where
     T: SignedTransaction,
     N: NodePrimitives<Block = Block<T>>,
 {
-    fn from(value: OpBuiltPayload<N>) -> Self {
-        let OpBuiltPayload { block, fees, .. } = value;
+    fn from(value: BaseBuiltPayload<N>) -> Self {
+        let BaseBuiltPayload { block, fees, .. } = value;
 
         let parent_beacon_block_root = block.parent_beacon_block_root.unwrap_or_default();
 
@@ -339,13 +339,13 @@ where
     }
 }
 
-impl<T, N> From<OpBuiltPayload<N>> for BaseExecutionPayloadEnvelopeV5
+impl<T, N> From<BaseBuiltPayload<N>> for BaseExecutionPayloadEnvelopeV5
 where
     T: SignedTransaction,
     N: NodePrimitives<Block = Block<T>>,
 {
-    fn from(value: OpBuiltPayload<N>) -> Self {
-        let OpBuiltPayload { block, fees, .. } = value;
+    fn from(value: BaseBuiltPayload<N>) -> Self {
+        let BaseBuiltPayload { block, fees, .. } = value;
 
         let l2_withdrawals_root = block.withdrawals_root.unwrap_or_default();
         let payload_v3 = ExecutionPayloadV3::from_block_unchecked(
@@ -437,15 +437,15 @@ pub fn payload_id(
     PayloadId::new(out.as_slice()[..8].try_into().expect("sufficient length"))
 }
 
-impl<H, T, ChainSpec> BuildNextEnv<OpPayloadBuilderAttributes<T>, H, ChainSpec>
-    for OpNextBlockEnvAttributes
+impl<H, T, ChainSpec> BuildNextEnv<BasePayloadBuilderAttributes<T>, H, ChainSpec>
+    for BaseNextBlockEnvAttributes
 where
     H: BlockHeader,
     T: SignedTransaction,
     ChainSpec: EthChainSpec + Upgrades,
 {
     fn build_next_env(
-        attributes: &OpPayloadBuilderAttributes<T>,
+        attributes: &BasePayloadBuilderAttributes<T>,
         parent: &SealedHeader<H>,
         chain_spec: &ChainSpec,
     ) -> Result<Self, PayloadBuilderError> {
@@ -553,8 +553,8 @@ mod tests {
 
     #[test]
     fn test_get_extra_data_post_holocene() {
-        let attributes: OpPayloadBuilderAttributes<BaseTransactionSigned> =
-            OpPayloadBuilderAttributes {
+        let attributes: BasePayloadBuilderAttributes<BaseTransactionSigned> =
+            BasePayloadBuilderAttributes {
                 eip_1559_params: Some(B64::from_str("0x0000000800000008").unwrap()),
                 ..Default::default()
             };
@@ -564,16 +564,16 @@ mod tests {
 
     #[test]
     fn test_get_extra_data_post_holocene_default() {
-        let attributes: OpPayloadBuilderAttributes<BaseTransactionSigned> =
-            OpPayloadBuilderAttributes { eip_1559_params: Some(B64::ZERO), ..Default::default() };
+        let attributes: BasePayloadBuilderAttributes<BaseTransactionSigned> =
+            BasePayloadBuilderAttributes { eip_1559_params: Some(B64::ZERO), ..Default::default() };
         let extra_data = attributes.get_holocene_extra_data(BaseFeeParams::new(80, 60));
         assert_eq!(extra_data.unwrap(), Bytes::copy_from_slice(&[0, 0, 0, 0, 80, 0, 0, 0, 60]));
     }
 
     #[test]
     fn test_get_extra_data_post_jovian() {
-        let attributes: OpPayloadBuilderAttributes<BaseTransactionSigned> =
-            OpPayloadBuilderAttributes {
+        let attributes: BasePayloadBuilderAttributes<BaseTransactionSigned> =
+            BasePayloadBuilderAttributes {
                 eip_1559_params: Some(B64::from_str("0x0000000800000008").unwrap()),
                 min_base_fee: Some(10),
                 ..Default::default()
@@ -589,8 +589,8 @@ mod tests {
 
     #[test]
     fn test_get_extra_data_post_jovian_default() {
-        let attributes: OpPayloadBuilderAttributes<BaseTransactionSigned> =
-            OpPayloadBuilderAttributes {
+        let attributes: BasePayloadBuilderAttributes<BaseTransactionSigned> =
+            BasePayloadBuilderAttributes {
                 eip_1559_params: Some(B64::ZERO),
                 min_base_fee: Some(10),
                 ..Default::default()
@@ -606,8 +606,8 @@ mod tests {
 
     #[test]
     fn test_get_extra_data_post_jovian_no_base_fee() {
-        let attributes: OpPayloadBuilderAttributes<BaseTransactionSigned> =
-            OpPayloadBuilderAttributes {
+        let attributes: BasePayloadBuilderAttributes<BaseTransactionSigned> =
+            BasePayloadBuilderAttributes {
                 eip_1559_params: Some(B64::ZERO),
                 min_base_fee: None,
                 ..Default::default()

--- a/crates/execution/payload/src/traits.rs
+++ b/crates/execution/payload/src/traits.rs
@@ -3,7 +3,7 @@ use base_common_consensus::{BaseTransaction, DepositReceiptExt};
 use reth_payload_primitives::PayloadBuilderAttributes;
 use reth_primitives_traits::{FullBlockHeader, NodePrimitives, SignedTransaction, WithEncoded};
 
-use crate::OpPayloadBuilderAttributes;
+use crate::BasePayloadBuilderAttributes;
 
 /// Helper trait to encapsulate common bounds on [`NodePrimitives`] for OP payload builder.
 pub trait PayloadPrimitives:
@@ -47,7 +47,7 @@ pub trait Attributes: PayloadBuilderAttributes {
     fn sequencer_transactions(&self) -> &[WithEncoded<Self::Transaction>];
 }
 
-impl<T: SignedTransaction> Attributes for OpPayloadBuilderAttributes<T> {
+impl<T: SignedTransaction> Attributes for BasePayloadBuilderAttributes<T> {
     type Transaction = T;
 
     fn no_tx_pool(&self) -> bool {

--- a/crates/execution/payload/src/types.rs
+++ b/crates/execution/payload/src/types.rs
@@ -3,7 +3,7 @@ use base_common_rpc_types_engine::{BasePayloadAttributes, ExecutionData};
 use reth_payload_primitives::{BuiltPayload, PayloadTypes};
 use reth_primitives_traits::{Block, NodePrimitives, SealedBlock};
 
-use crate::{OpBuiltPayload, OpPayloadBuilderAttributes};
+use crate::{BaseBuiltPayload, BasePayloadBuilderAttributes};
 
 /// ZST that aggregates Base [`PayloadTypes`].
 #[derive(Debug, Default, Clone, serde::Deserialize, serde::Serialize)]
@@ -12,12 +12,12 @@ pub struct BasePayloadTypes<N: NodePrimitives = BasePrimitives>(core::marker::Ph
 
 impl<N: NodePrimitives> PayloadTypes for BasePayloadTypes<N>
 where
-    OpBuiltPayload<N>: BuiltPayload,
+    BaseBuiltPayload<N>: BuiltPayload,
 {
     type ExecutionData = ExecutionData;
-    type BuiltPayload = OpBuiltPayload<N>;
+    type BuiltPayload = BaseBuiltPayload<N>;
     type PayloadAttributes = BasePayloadAttributes;
-    type PayloadBuilderAttributes = OpPayloadBuilderAttributes<N::SignedTx>;
+    type PayloadBuilderAttributes = BasePayloadBuilderAttributes<N::SignedTx>;
 
     fn block_to_payload(
         block: SealedBlock<

--- a/crates/execution/payload/src/validator.rs
+++ b/crates/execution/payload/src/validator.rs
@@ -12,13 +12,13 @@ use reth_primitives_traits::{Block as _, SealedBlock, SignedTransaction};
 
 /// Execution payload validator.
 #[derive(Clone, Debug, Deref, Constructor)]
-pub struct OpExecutionPayloadValidator<ChainSpec> {
+pub struct BaseExecutionPayloadValidator<ChainSpec> {
     /// Chain spec to validate against.
     #[deref]
     inner: Arc<ChainSpec>,
 }
 
-impl<ChainSpec> OpExecutionPayloadValidator<ChainSpec>
+impl<ChainSpec> BaseExecutionPayloadValidator<ChainSpec>
 where
     ChainSpec: Upgrades,
 {

--- a/crates/execution/rpc/src/debug.rs
+++ b/crates/execution/rpc/src/debug.rs
@@ -11,7 +11,7 @@ use async_trait::async_trait;
 use base_common_chains::Upgrades;
 use base_execution_payload_builder::{
     Attributes, PayloadPrimitives,
-    builder::{Builder, BasePayloadBuilderCtx},
+    builder::{BasePayloadBuilderCtx, Builder},
 };
 use base_execution_trie::{BaseProofsStorage, BaseProofsStore};
 use base_execution_txpool::BasePooledTransaction;

--- a/crates/execution/rpc/src/debug.rs
+++ b/crates/execution/rpc/src/debug.rs
@@ -11,7 +11,7 @@ use async_trait::async_trait;
 use base_common_chains::Upgrades;
 use base_execution_payload_builder::{
     Attributes, PayloadPrimitives,
-    builder::{Builder, OpPayloadBuilderCtx},
+    builder::{Builder, BasePayloadBuilderCtx},
 };
 use base_execution_trie::{BaseProofsStorage, BaseProofsStore};
 use base_execution_txpool::BasePooledTransaction;
@@ -207,7 +207,7 @@ where
 
                     let config =
                         PayloadConfig { parent_header: Arc::new(parent_header), attributes };
-                    let ctx = OpPayloadBuilderCtx {
+                    let ctx = BasePayloadBuilderCtx {
                         evm_config: this.evm_config.clone(),
                         chain_spec: this.provider.chain_spec(),
                         config,

--- a/crates/execution/rpc/src/error.rs
+++ b/crates/execution/rpc/src/error.rs
@@ -20,7 +20,7 @@ use revm::context_interface::result::{EVMError, InvalidTransaction};
 
 /// Base-specific errors, that extend [`EthApiError`].
 #[derive(Debug, thiserror::Error)]
-pub enum OpEthApiError {
+pub enum BaseEthApiError {
     /// L1 ethereum error.
     #[error(transparent)]
     Eth(#[from] EthApiError),
@@ -35,13 +35,13 @@ pub enum OpEthApiError {
     L1BlockGasError,
     /// Wrapper for [`revm_primitives::InvalidTransaction`](InvalidTransaction).
     #[error(transparent)]
-    InvalidTransaction(#[from] OpInvalidTransactionError),
+    InvalidTransaction(#[from] BaseInvalidTransactionError),
     /// Sequencer client error.
     #[error(transparent)]
     Sequencer(#[from] SequencerClientError),
 }
 
-impl AsEthApiError for OpEthApiError {
+impl AsEthApiError for BaseEthApiError {
     fn as_err(&self) -> Option<&EthApiError> {
         match self {
             Self::Eth(err) => Some(err),
@@ -50,22 +50,22 @@ impl AsEthApiError for OpEthApiError {
     }
 }
 
-impl From<OpEthApiError> for jsonrpsee_types::error::ErrorObject<'static> {
-    fn from(err: OpEthApiError) -> Self {
+impl From<BaseEthApiError> for jsonrpsee_types::error::ErrorObject<'static> {
+    fn from(err: BaseEthApiError) -> Self {
         match err {
-            OpEthApiError::Eth(err) => err.into(),
-            OpEthApiError::InvalidTransaction(err) => err.into(),
-            OpEthApiError::Evm(_)
-            | OpEthApiError::L1BlockFeeError
-            | OpEthApiError::L1BlockGasError => internal_rpc_err(err.to_string()),
-            OpEthApiError::Sequencer(err) => err.into(),
+            BaseEthApiError::Eth(err) => err.into(),
+            BaseEthApiError::InvalidTransaction(err) => err.into(),
+            BaseEthApiError::Evm(_)
+            | BaseEthApiError::L1BlockFeeError
+            | BaseEthApiError::L1BlockGasError => internal_rpc_err(err.to_string()),
+            BaseEthApiError::Sequencer(err) => err.into(),
         }
     }
 }
 
 /// Base-specific invalid transaction errors
 #[derive(thiserror::Error, Debug)]
-pub enum OpInvalidTransactionError {
+pub enum BaseInvalidTransactionError {
     /// A deposit transaction was submitted as a system transaction post-regolith.
     #[error("no system transactions allowed after regolith")]
     DepositSystemTxPostRegolith,
@@ -77,19 +77,19 @@ pub enum OpInvalidTransactionError {
     MissingEnvelopedTx,
 }
 
-impl From<OpInvalidTransactionError> for jsonrpsee_types::error::ErrorObject<'static> {
-    fn from(err: OpInvalidTransactionError) -> Self {
+impl From<BaseInvalidTransactionError> for jsonrpsee_types::error::ErrorObject<'static> {
+    fn from(err: BaseInvalidTransactionError) -> Self {
         match err {
-            OpInvalidTransactionError::DepositSystemTxPostRegolith
-            | OpInvalidTransactionError::HaltedDepositPostRegolith
-            | OpInvalidTransactionError::MissingEnvelopedTx => {
+            BaseInvalidTransactionError::DepositSystemTxPostRegolith
+            | BaseInvalidTransactionError::HaltedDepositPostRegolith
+            | BaseInvalidTransactionError::MissingEnvelopedTx => {
                 rpc_err(EthRpcErrorCode::TransactionRejected.code(), err.to_string(), None)
             }
         }
     }
 }
 
-impl TryFrom<OpTransactionError> for OpInvalidTransactionError {
+impl TryFrom<OpTransactionError> for BaseInvalidTransactionError {
     type Error = InvalidTransaction;
 
     fn try_from(err: OpTransactionError) -> Result<Self, Self::Error> {
@@ -129,7 +129,7 @@ impl From<SequencerClientError> for jsonrpsee_types::error::ErrorObject<'static>
     }
 }
 
-impl<T> From<EVMError<T, OpTransactionError>> for OpEthApiError
+impl<T> From<EVMError<T, OpTransactionError>> for BaseEthApiError
 where
     T: Into<EthApiError>,
 {
@@ -146,48 +146,48 @@ where
     }
 }
 
-impl FromEvmHalt<OpHaltReason> for OpEthApiError {
+impl FromEvmHalt<OpHaltReason> for BaseEthApiError {
     fn from_evm_halt(halt: OpHaltReason, gas_limit: u64) -> Self {
         match halt {
             OpHaltReason::FailedDeposit => {
-                OpInvalidTransactionError::HaltedDepositPostRegolith.into()
+                BaseInvalidTransactionError::HaltedDepositPostRegolith.into()
             }
             OpHaltReason::Base(halt) => EthApiError::from_evm_halt(halt, gas_limit).into(),
         }
     }
 }
 
-impl FromRevert for OpEthApiError {
+impl FromRevert for BaseEthApiError {
     fn from_revert(output: Bytes) -> Self {
         Self::Eth(EthApiError::from_revert(output))
     }
 }
 
-impl From<TransactionConversionError> for OpEthApiError {
+impl From<TransactionConversionError> for BaseEthApiError {
     fn from(value: TransactionConversionError) -> Self {
         Self::Eth(EthApiError::from(value))
     }
 }
 
-impl From<EthTxEnvError> for OpEthApiError {
+impl From<EthTxEnvError> for BaseEthApiError {
     fn from(value: EthTxEnvError) -> Self {
         Self::Eth(EthApiError::from(value))
     }
 }
 
-impl From<ProviderError> for OpEthApiError {
+impl From<ProviderError> for BaseEthApiError {
     fn from(value: ProviderError) -> Self {
         Self::Eth(EthApiError::from(value))
     }
 }
 
-impl From<BlockError> for OpEthApiError {
+impl From<BlockError> for BaseEthApiError {
     fn from(value: BlockError) -> Self {
         Self::Eth(EthApiError::from(value))
     }
 }
 
-impl From<Infallible> for OpEthApiError {
+impl From<Infallible> for BaseEthApiError {
     fn from(value: Infallible) -> Self {
         match value {}
     }

--- a/crates/execution/rpc/src/eth/block.rs
+++ b/crates/execution/rpc/src/eth/block.rs
@@ -5,20 +5,20 @@ use reth_rpc_eth_api::{
     helpers::{EthBlocks, LoadBlock},
 };
 
-use crate::{OpEthApi, OpEthApiError, eth::RpcNodeCore};
+use crate::{BaseEthApi, BaseEthApiError, eth::RpcNodeCore};
 
-impl<N, Rpc> EthBlocks for OpEthApi<N, Rpc>
+impl<N, Rpc> EthBlocks for BaseEthApi<N, Rpc>
 where
     N: RpcNodeCore,
-    OpEthApiError: FromEvmError<N::Evm>,
-    Rpc: RpcConvert<Primitives = N::Primitives, Error = OpEthApiError>,
+    BaseEthApiError: FromEvmError<N::Evm>,
+    Rpc: RpcConvert<Primitives = N::Primitives, Error = BaseEthApiError>,
 {
 }
 
-impl<N, Rpc> LoadBlock for OpEthApi<N, Rpc>
+impl<N, Rpc> LoadBlock for BaseEthApi<N, Rpc>
 where
     N: RpcNodeCore,
-    OpEthApiError: FromEvmError<N::Evm>,
-    Rpc: RpcConvert<Primitives = N::Primitives, Error = OpEthApiError>,
+    BaseEthApiError: FromEvmError<N::Evm>,
+    Rpc: RpcConvert<Primitives = N::Primitives, Error = BaseEthApiError>,
 {
 }

--- a/crates/execution/rpc/src/eth/call.rs
+++ b/crates/execution/rpc/src/eth/call.rs
@@ -3,29 +3,29 @@ use reth_rpc_eth_api::{
     helpers::{Call, EthCall, estimate::EstimateCall},
 };
 
-use crate::{OpEthApi, OpEthApiError, eth::RpcNodeCore};
+use crate::{BaseEthApi, BaseEthApiError, eth::RpcNodeCore};
 
-impl<N, Rpc> EthCall for OpEthApi<N, Rpc>
+impl<N, Rpc> EthCall for BaseEthApi<N, Rpc>
 where
     N: RpcNodeCore,
-    OpEthApiError: FromEvmError<N::Evm>,
-    Rpc: RpcConvert<Primitives = N::Primitives, Error = OpEthApiError, Evm = N::Evm>,
+    BaseEthApiError: FromEvmError<N::Evm>,
+    Rpc: RpcConvert<Primitives = N::Primitives, Error = BaseEthApiError, Evm = N::Evm>,
 {
 }
 
-impl<N, Rpc> EstimateCall for OpEthApi<N, Rpc>
+impl<N, Rpc> EstimateCall for BaseEthApi<N, Rpc>
 where
     N: RpcNodeCore,
-    OpEthApiError: FromEvmError<N::Evm>,
-    Rpc: RpcConvert<Primitives = N::Primitives, Error = OpEthApiError, Evm = N::Evm>,
+    BaseEthApiError: FromEvmError<N::Evm>,
+    Rpc: RpcConvert<Primitives = N::Primitives, Error = BaseEthApiError, Evm = N::Evm>,
 {
 }
 
-impl<N, Rpc> Call for OpEthApi<N, Rpc>
+impl<N, Rpc> Call for BaseEthApi<N, Rpc>
 where
     N: RpcNodeCore,
-    OpEthApiError: FromEvmError<N::Evm>,
-    Rpc: RpcConvert<Primitives = N::Primitives, Error = OpEthApiError, Evm = N::Evm>,
+    BaseEthApiError: FromEvmError<N::Evm>,
+    Rpc: RpcConvert<Primitives = N::Primitives, Error = BaseEthApiError, Evm = N::Evm>,
 {
     #[inline]
     fn call_gas_limit(&self) -> u64 {

--- a/crates/execution/rpc/src/eth/mod.rs
+++ b/crates/execution/rpc/src/eth/mod.rs
@@ -39,7 +39,7 @@ use reth_tasks::{
 };
 
 use crate::{
-    OpEthApiError, SequencerClient,
+    BaseEthApiError, SequencerClient,
     eth::{receipt::BaseReceiptConverter, transaction::BaseTxInfoMapper},
 };
 
@@ -56,32 +56,32 @@ pub type EthApiNodeBackend<N, Rpc> = EthApiInner<N, Rpc>;
 ///
 /// This type implements the [`FullEthApi`](reth_rpc_eth_api::helpers::FullEthApi) by implemented
 /// all the `Eth` helper traits and prerequisite traits.
-pub struct OpEthApi<N: RpcNodeCore, Rpc: RpcConvert> {
+pub struct BaseEthApi<N: RpcNodeCore, Rpc: RpcConvert> {
     /// Gateway to node's core components.
-    inner: Arc<OpEthApiInner<N, Rpc>>,
+    inner: Arc<BaseEthApiInner<N, Rpc>>,
 }
 
-impl<N: RpcNodeCore, Rpc: RpcConvert> Clone for OpEthApi<N, Rpc> {
+impl<N: RpcNodeCore, Rpc: RpcConvert> Clone for BaseEthApi<N, Rpc> {
     fn clone(&self) -> Self {
         Self { inner: Arc::clone(&self.inner) }
     }
 }
 
-impl<N: RpcNodeCore, Rpc: RpcConvert> OpEthApi<N, Rpc> {
-    /// Creates a new `OpEthApi`.
+impl<N: RpcNodeCore, Rpc: RpcConvert> BaseEthApi<N, Rpc> {
+    /// Creates a new `BaseEthApi`.
     pub fn new(
         eth_api: EthApiNodeBackend<N, Rpc>,
         sequencer_client: Option<SequencerClient>,
         min_suggested_priority_fee: U256,
     ) -> Self {
         let inner =
-            Arc::new(OpEthApiInner { eth_api, sequencer_client, min_suggested_priority_fee });
+            Arc::new(BaseEthApiInner { eth_api, sequencer_client, min_suggested_priority_fee });
         Self { inner }
     }
 
-    /// Build a [`OpEthApi`] using [`OpEthApiBuilder`].
-    pub const fn builder() -> OpEthApiBuilder<Rpc> {
-        OpEthApiBuilder::new()
+    /// Build a [`BaseEthApi`] using [`BaseEthApiBuilder`].
+    pub const fn builder() -> BaseEthApiBuilder<Rpc> {
+        BaseEthApiBuilder::new()
     }
 
     /// Returns a reference to the [`EthApiNodeBackend`].
@@ -94,12 +94,12 @@ impl<N: RpcNodeCore, Rpc: RpcConvert> OpEthApi<N, Rpc> {
     }
 }
 
-impl<N, Rpc> EthApiTypes for OpEthApi<N, Rpc>
+impl<N, Rpc> EthApiTypes for BaseEthApi<N, Rpc>
 where
     N: RpcNodeCore,
-    Rpc: RpcConvert<Primitives = N::Primitives, Error = OpEthApiError>,
+    Rpc: RpcConvert<Primitives = N::Primitives, Error = BaseEthApiError>,
 {
-    type Error = OpEthApiError;
+    type Error = BaseEthApiError;
     type NetworkTypes = Rpc::Network;
     type RpcConvert = Rpc;
 
@@ -108,7 +108,7 @@ where
     }
 }
 
-impl<N, Rpc> RpcNodeCore for OpEthApi<N, Rpc>
+impl<N, Rpc> RpcNodeCore for BaseEthApi<N, Rpc>
 where
     N: RpcNodeCore,
     Rpc: RpcConvert<Primitives = N::Primitives>,
@@ -140,7 +140,7 @@ where
     }
 }
 
-impl<N, Rpc> RpcNodeCoreExt for OpEthApi<N, Rpc>
+impl<N, Rpc> RpcNodeCoreExt for BaseEthApi<N, Rpc>
 where
     N: RpcNodeCore,
     Rpc: RpcConvert<Primitives = N::Primitives>,
@@ -151,10 +151,10 @@ where
     }
 }
 
-impl<N, Rpc> EthApiSpec for OpEthApi<N, Rpc>
+impl<N, Rpc> EthApiSpec for BaseEthApi<N, Rpc>
 where
     N: RpcNodeCore,
-    Rpc: RpcConvert<Primitives = N::Primitives, Error = OpEthApiError>,
+    Rpc: RpcConvert<Primitives = N::Primitives, Error = BaseEthApiError>,
 {
     #[inline]
     fn starting_block(&self) -> U256 {
@@ -162,10 +162,10 @@ where
     }
 }
 
-impl<N, Rpc> SpawnBlocking for OpEthApi<N, Rpc>
+impl<N, Rpc> SpawnBlocking for BaseEthApi<N, Rpc>
 where
     N: RpcNodeCore,
-    Rpc: RpcConvert<Primitives = N::Primitives, Error = OpEthApiError>,
+    Rpc: RpcConvert<Primitives = N::Primitives, Error = BaseEthApiError>,
 {
     #[inline]
     fn io_task_spawner(&self) -> impl TaskSpawner {
@@ -188,11 +188,11 @@ where
     }
 }
 
-impl<N, Rpc> LoadFee for OpEthApi<N, Rpc>
+impl<N, Rpc> LoadFee for BaseEthApi<N, Rpc>
 where
     N: RpcNodeCore,
-    OpEthApiError: FromEvmError<N::Evm>,
-    Rpc: RpcConvert<Primitives = N::Primitives, Error = OpEthApiError>,
+    BaseEthApiError: FromEvmError<N::Evm>,
+    Rpc: RpcConvert<Primitives = N::Primitives, Error = BaseEthApiError>,
 {
     #[inline]
     fn gas_oracle(&self) -> &GasPriceOracle<Self::Provider> {
@@ -214,7 +214,7 @@ where
     }
 }
 
-impl<N, Rpc> LoadState for OpEthApi<N, Rpc>
+impl<N, Rpc> LoadState for BaseEthApi<N, Rpc>
 where
     N: RpcNodeCore,
     Rpc: RpcConvert<Primitives = N::Primitives>,
@@ -222,10 +222,10 @@ where
 {
 }
 
-impl<N, Rpc> EthState for OpEthApi<N, Rpc>
+impl<N, Rpc> EthState for BaseEthApi<N, Rpc>
 where
     N: RpcNodeCore,
-    Rpc: RpcConvert<Primitives = N::Primitives, Error = OpEthApiError>,
+    Rpc: RpcConvert<Primitives = N::Primitives, Error = BaseEthApiError>,
     Self: LoadPendingBlock,
 {
     #[inline]
@@ -234,30 +234,30 @@ where
     }
 }
 
-impl<N, Rpc> EthFees for OpEthApi<N, Rpc>
+impl<N, Rpc> EthFees for BaseEthApi<N, Rpc>
 where
     N: RpcNodeCore,
-    OpEthApiError: FromEvmError<N::Evm>,
-    Rpc: RpcConvert<Primitives = N::Primitives, Error = OpEthApiError>,
+    BaseEthApiError: FromEvmError<N::Evm>,
+    Rpc: RpcConvert<Primitives = N::Primitives, Error = BaseEthApiError>,
 {
 }
 
-impl<N, Rpc> Trace for OpEthApi<N, Rpc>
+impl<N, Rpc> Trace for BaseEthApi<N, Rpc>
 where
     N: RpcNodeCore,
-    OpEthApiError: FromEvmError<N::Evm>,
-    Rpc: RpcConvert<Primitives = N::Primitives, Error = OpEthApiError, Evm = N::Evm>,
+    BaseEthApiError: FromEvmError<N::Evm>,
+    Rpc: RpcConvert<Primitives = N::Primitives, Error = BaseEthApiError, Evm = N::Evm>,
 {
 }
 
-impl<N: RpcNodeCore, Rpc: RpcConvert> fmt::Debug for OpEthApi<N, Rpc> {
+impl<N: RpcNodeCore, Rpc: RpcConvert> fmt::Debug for BaseEthApi<N, Rpc> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("OpEthApi").finish_non_exhaustive()
+        f.debug_struct("BaseEthApi").finish_non_exhaustive()
     }
 }
 
-/// Container type `OpEthApi`
-pub struct OpEthApiInner<N: RpcNodeCore, Rpc: RpcConvert> {
+/// Container type `BaseEthApi`
+pub struct BaseEthApiInner<N: RpcNodeCore, Rpc: RpcConvert> {
     /// Gateway to node's core components.
     eth_api: EthApiNodeBackend<N, Rpc>,
     /// Sequencer client, configured to forward submitted transactions to sequencer of given OP
@@ -269,13 +269,13 @@ pub struct OpEthApiInner<N: RpcNodeCore, Rpc: RpcConvert> {
     min_suggested_priority_fee: U256,
 }
 
-impl<N: RpcNodeCore, Rpc: RpcConvert> fmt::Debug for OpEthApiInner<N, Rpc> {
+impl<N: RpcNodeCore, Rpc: RpcConvert> fmt::Debug for BaseEthApiInner<N, Rpc> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        f.debug_struct("OpEthApiInner").finish()
+        f.debug_struct("BaseEthApiInner").finish()
     }
 }
 
-impl<N: RpcNodeCore, Rpc: RpcConvert> OpEthApiInner<N, Rpc> {
+impl<N: RpcNodeCore, Rpc: RpcConvert> BaseEthApiInner<N, Rpc> {
     /// Returns a reference to the [`EthApiNodeBackend`].
     const fn eth_api(&self) -> &EthApiNodeBackend<N, Rpc> {
         &self.eth_api
@@ -296,9 +296,9 @@ pub type BaseRpcConvert<N, NetworkT> = RpcConverter<
     BaseTxInfoMapper<<N as FullNodeTypes>::Provider>,
 >;
 
-/// Builds [`OpEthApi`] for Base.
+/// Builds [`BaseEthApi`] for Base.
 #[derive(Debug)]
-pub struct OpEthApiBuilder<NetworkT = Base> {
+pub struct BaseEthApiBuilder<NetworkT = Base> {
     /// Sequencer client, configured to forward submitted transactions to sequencer of given OP
     /// network.
     sequencer_url: Option<String>,
@@ -310,7 +310,7 @@ pub struct OpEthApiBuilder<NetworkT = Base> {
     _nt: PhantomData<NetworkT>,
 }
 
-impl<NetworkT> Default for OpEthApiBuilder<NetworkT> {
+impl<NetworkT> Default for BaseEthApiBuilder<NetworkT> {
     fn default() -> Self {
         Self {
             sequencer_url: None,
@@ -321,8 +321,8 @@ impl<NetworkT> Default for OpEthApiBuilder<NetworkT> {
     }
 }
 
-impl<NetworkT> OpEthApiBuilder<NetworkT> {
-    /// Creates a [`OpEthApiBuilder`] instance from core components.
+impl<NetworkT> BaseEthApiBuilder<NetworkT> {
+    /// Creates a [`BaseEthApiBuilder`] instance from core components.
     pub const fn new() -> Self {
         Self {
             sequencer_url: None,
@@ -351,7 +351,7 @@ impl<NetworkT> OpEthApiBuilder<NetworkT> {
     }
 }
 
-impl<N, NetworkT> EthApiBuilder<N> for OpEthApiBuilder<NetworkT>
+impl<N, NetworkT> EthApiBuilder<N> for BaseEthApiBuilder<NetworkT>
 where
     N: FullNodeComponents<
             Evm: ConfigureEvm<NextBlockEnvCtx: BuildPendingEnv<HeaderTy<N::Types>>>,
@@ -359,10 +359,10 @@ where
         >,
     NetworkT: RpcTypes,
     BaseRpcConvert<N, NetworkT>: RpcConvert<Network = NetworkT>,
-    OpEthApi<N, BaseRpcConvert<N, NetworkT>>:
+    BaseEthApi<N, BaseRpcConvert<N, NetworkT>>:
         FullEthApiServer<Provider = N::Provider, Pool = N::Pool>,
 {
-    type EthApi = OpEthApi<N, BaseRpcConvert<N, NetworkT>>;
+    type EthApi = BaseEthApi<N, BaseRpcConvert<N, NetworkT>>;
 
     async fn build_eth_api(self, ctx: EthApiCtx<'_, N>) -> eyre::Result<Self::EthApi> {
         let Self { sequencer_url, sequencer_headers, min_suggested_priority_fee, .. } = self;
@@ -382,6 +382,6 @@ where
 
         let eth_api = ctx.eth_api_builder().with_rpc_converter(rpc_converter).build_inner();
 
-        Ok(OpEthApi::new(eth_api, sequencer_client, U256::from(min_suggested_priority_fee)))
+        Ok(BaseEthApi::new(eth_api, sequencer_client, U256::from(min_suggested_priority_fee)))
     }
 }

--- a/crates/execution/rpc/src/eth/pending_block.rs
+++ b/crates/execution/rpc/src/eth/pending_block.rs
@@ -11,13 +11,13 @@ use reth_rpc_eth_types::{
 };
 use reth_storage_api::{BlockReaderIdExt, StateProviderBox};
 
-use crate::{OpEthApi, OpEthApiError};
+use crate::{BaseEthApi, BaseEthApiError};
 
-impl<N, Rpc> LoadPendingBlock for OpEthApi<N, Rpc>
+impl<N, Rpc> LoadPendingBlock for BaseEthApi<N, Rpc>
 where
     N: RpcNodeCore,
-    OpEthApiError: FromEvmError<N::Evm>,
-    Rpc: RpcConvert<Primitives = N::Primitives, Error = OpEthApiError>,
+    BaseEthApiError: FromEvmError<N::Evm>,
+    Rpc: RpcConvert<Primitives = N::Primitives, Error = BaseEthApiError>,
 {
     #[inline]
     fn pending_block(&self) -> &tokio::sync::Mutex<Option<PendingBlock<N::Primitives>>> {

--- a/crates/execution/rpc/src/eth/receipt.rs
+++ b/crates/execution/rpc/src/eth/receipt.rs
@@ -21,12 +21,12 @@ use reth_rpc_eth_api::{
 use reth_rpc_eth_types::{EthApiError, receipt::build_receipt};
 use reth_storage_api::BlockReader;
 
-use crate::{OpEthApi, OpEthApiError, eth::RpcNodeCore};
+use crate::{BaseEthApi, BaseEthApiError, eth::RpcNodeCore};
 
-impl<N, Rpc> LoadReceipt for OpEthApi<N, Rpc>
+impl<N, Rpc> LoadReceipt for BaseEthApi<N, Rpc>
 where
     N: RpcNodeCore,
-    Rpc: RpcConvert<Primitives = N::Primitives, Error = OpEthApiError>,
+    Rpc: RpcConvert<Primitives = N::Primitives, Error = BaseEthApiError>,
 {
 }
 
@@ -50,7 +50,7 @@ where
         BlockReader<Block = N::Block> + ChainSpecProvider<ChainSpec: Upgrades> + Debug + 'static,
 {
     type RpcReceipt = BaseTransactionReceipt;
-    type Error = OpEthApiError;
+    type Error = BaseEthApiError;
 
     fn convert_receipts(
         &self,
@@ -172,21 +172,21 @@ impl ReceiptFieldsBuilder {
         chain_spec: &impl Upgrades,
         tx: &T,
         l1_block_info: &mut base_common_evm::L1BlockInfo,
-    ) -> Result<Self, OpEthApiError> {
+    ) -> Result<Self, BaseEthApiError> {
         let raw_tx = tx.encoded_2718();
         let timestamp = self.block_timestamp;
 
         self.l1_fee = Some(
             l1_block_info
                 .l1_tx_data_fee(chain_spec, timestamp, &raw_tx, tx.is_deposit())
-                .map_err(|_| OpEthApiError::L1BlockFeeError)?
+                .map_err(|_| BaseEthApiError::L1BlockFeeError)?
                 .saturating_to(),
         );
 
         self.l1_data_gas = Some(
             l1_block_info
                 .l1_data_gas(chain_spec, timestamp, &raw_tx)
-                .map_err(|_| OpEthApiError::L1BlockGasError)?
+                .map_err(|_| BaseEthApiError::L1BlockGasError)?
                 .saturating_add(l1_block_info.l1_fee_overhead.unwrap_or_default())
                 .saturating_to(),
         );
@@ -284,7 +284,7 @@ impl BaseReceiptBuilder {
         chain_spec: &impl Upgrades,
         input: ConvertReceiptInput<'_, N>,
         l1_block_info: &mut base_common_evm::L1BlockInfo,
-    ) -> Result<Self, OpEthApiError>
+    ) -> Result<Self, BaseEthApiError>
     where
         N: NodePrimitives<SignedTx: BaseTransaction, Receipt = BaseReceipt>,
     {

--- a/crates/execution/rpc/src/eth/transaction.rs
+++ b/crates/execution/rpc/src/eth/transaction.rs
@@ -24,13 +24,13 @@ use reth_transaction_pool::{
 };
 use tracing::{debug, warn};
 
-use crate::{OpEthApi, OpEthApiError, SequencerClient};
+use crate::{BaseEthApi, BaseEthApiError, SequencerClient};
 
-impl<N, Rpc> EthTransactions for OpEthApi<N, Rpc>
+impl<N, Rpc> EthTransactions for BaseEthApi<N, Rpc>
 where
     N: RpcNodeCore,
-    OpEthApiError: FromEvmError<N::Evm>,
-    Rpc: RpcConvert<Primitives = N::Primitives, Error = OpEthApiError>,
+    BaseEthApiError: FromEvmError<N::Evm>,
+    Rpc: RpcConvert<Primitives = N::Primitives, Error = BaseEthApiError>,
 {
     fn signers(&self) -> &SignersForRpc<Self::Provider, Self::NetworkTypes> {
         self.inner.eth_api.signers()
@@ -139,11 +139,11 @@ where
     }
 }
 
-impl<N, Rpc> LoadTransaction for OpEthApi<N, Rpc>
+impl<N, Rpc> LoadTransaction for BaseEthApi<N, Rpc>
 where
     N: RpcNodeCore,
-    OpEthApiError: FromEvmError<N::Evm>,
-    Rpc: RpcConvert<Primitives = N::Primitives, Error = OpEthApiError>,
+    BaseEthApiError: FromEvmError<N::Evm>,
+    Rpc: RpcConvert<Primitives = N::Primitives, Error = BaseEthApiError>,
 {
     async fn transaction_by_hash(
         &self,
@@ -180,7 +180,7 @@ where
     }
 }
 
-impl<N, Rpc> OpEthApi<N, Rpc>
+impl<N, Rpc> BaseEthApi<N, Rpc>
 where
     N: RpcNodeCore,
     Rpc: RpcConvert<Primitives = N::Primitives>,

--- a/crates/execution/rpc/src/lib.rs
+++ b/crates/execution/rpc/src/lib.rs
@@ -22,8 +22,8 @@ pub use config::{BaseEthConfigApiServer, BaseEthConfigHandler};
 #[cfg(feature = "client")]
 pub use engine::BaseEngineApiClient;
 pub use engine::{BaseEngineApi, BaseEngineApiServer, ENGINE_CAPABILITIES};
-pub use error::{OpEthApiError, OpInvalidTransactionError, SequencerClientError};
-pub use eth::{BaseReceiptBuilder, OpEthApi, OpEthApiBuilder};
+pub use error::{BaseEthApiError, BaseInvalidTransactionError, SequencerClientError};
+pub use eth::{BaseReceiptBuilder, BaseEthApi, BaseEthApiBuilder};
 pub use metrics::{DebugApiExtMetrics, DebugApis, EthApiExtMetrics, SequencerMetrics};
 #[cfg(feature = "client")]
 pub use miner::MinerApiExtClient;

--- a/crates/execution/rpc/src/lib.rs
+++ b/crates/execution/rpc/src/lib.rs
@@ -23,7 +23,7 @@ pub use config::{BaseEthConfigApiServer, BaseEthConfigHandler};
 pub use engine::BaseEngineApiClient;
 pub use engine::{BaseEngineApi, BaseEngineApiServer, ENGINE_CAPABILITIES};
 pub use error::{BaseEthApiError, BaseInvalidTransactionError, SequencerClientError};
-pub use eth::{BaseReceiptBuilder, BaseEthApi, BaseEthApiBuilder};
+pub use eth::{BaseEthApi, BaseEthApiBuilder, BaseReceiptBuilder};
 pub use metrics::{DebugApiExtMetrics, DebugApis, EthApiExtMetrics, SequencerMetrics};
 #[cfg(feature = "client")]
 pub use miner::MinerApiExtClient;

--- a/crates/execution/rpc/src/witness.rs
+++ b/crates/execution/rpc/src/witness.rs
@@ -5,7 +5,7 @@ use std::{fmt::Debug, sync::Arc};
 use alloy_primitives::B256;
 use alloy_rpc_types_debug::ExecutionWitness;
 use base_common_chains::Upgrades;
-use base_execution_payload_builder::{Attributes, OpPayloadBuilder, PayloadPrimitives};
+use base_execution_payload_builder::{Attributes, BasePayloadBuilder, PayloadPrimitives};
 use base_execution_txpool::OpPooledTx;
 use jsonrpsee_core::{RpcResult, async_trait};
 use reth_chainspec::ChainSpecProvider;
@@ -32,7 +32,7 @@ impl<Pool, Provider, EvmConfig, Attrs> BaseDebugWitnessApi<Pool, Provider, EvmCo
     pub fn new(
         provider: Provider,
         task_spawner: Box<dyn TaskSpawner>,
-        builder: OpPayloadBuilder<Pool, Provider, EvmConfig, (), Attrs>,
+        builder: BasePayloadBuilder<Pool, Provider, EvmConfig, (), Attrs>,
     ) -> Self {
         let semaphore = Arc::new(Semaphore::new(3));
         let inner = BaseDebugWitnessApiInner { provider, builder, task_spawner, semaphore };
@@ -116,7 +116,7 @@ impl<Pool, Provider, EvmConfig, Attrs> Debug
 
 struct BaseDebugWitnessApiInner<Pool, Provider, EvmConfig, Attrs> {
     provider: Provider,
-    builder: OpPayloadBuilder<Pool, Provider, EvmConfig, (), Attrs>,
+    builder: BasePayloadBuilder<Pool, Provider, EvmConfig, (), Attrs>,
     task_spawner: Box<dyn TaskSpawner>,
     semaphore: Arc<Semaphore>,
 }

--- a/crates/execution/runner/src/add_ons.rs
+++ b/crates/execution/runner/src/add_ons.rs
@@ -12,7 +12,7 @@ use base_execution_rpc::{
     witness::BaseDebugWitnessApi,
 };
 use base_execution_txpool::OpPooledTx;
-use base_node_core::{BaseNodeTypes, BasePayloadValidatorBuilder, BaseEngineApiBuilder};
+use base_node_core::{BaseEngineApiBuilder, BaseNodeTypes, BasePayloadValidatorBuilder};
 use reth_evm::ConfigureEvm;
 use reth_node_api::{BuildNextEnv, FullNodeComponents, HeaderTy, NodeAddOns, PayloadTypes, TxTy};
 use reth_node_builder::{

--- a/crates/execution/runner/src/add_ons.rs
+++ b/crates/execution/runner/src/add_ons.rs
@@ -7,12 +7,12 @@ use base_execution_payload_builder::{
 use base_execution_rpc::{
     MinerApiExtServer,
     config::{BaseEthConfigApiServer, BaseEthConfigHandler},
-    eth::OpEthApiBuilder,
+    eth::BaseEthApiBuilder,
     miner::BaseMinerExtApi,
     witness::BaseDebugWitnessApi,
 };
 use base_execution_txpool::OpPooledTx;
-use base_node_core::{BaseNodeTypes, BasePayloadValidatorBuilder, OpEngineApiBuilder};
+use base_node_core::{BaseNodeTypes, BasePayloadValidatorBuilder, BaseEngineApiBuilder};
 use reth_evm::ConfigureEvm;
 use reth_node_api::{BuildNextEnv, FullNodeComponents, HeaderTy, NodeAddOns, PayloadTypes, TxTy};
 use reth_node_builder::{
@@ -39,7 +39,7 @@ pub struct BaseAddOns<
     N: FullNodeComponents,
     EthB: EthApiBuilder<N>,
     PVB,
-    EB = OpEngineApiBuilder<PVB>,
+    EB = BaseEngineApiBuilder<PVB>,
     EVB = BasicEngineValidatorBuilder<PVB>,
     RpcMiddleware = Identity,
 > {
@@ -68,10 +68,10 @@ where
     }
 }
 
-impl<N> Default for BaseAddOns<N, OpEthApiBuilder, BasePayloadValidatorBuilder>
+impl<N> Default for BaseAddOns<N, BaseEthApiBuilder, BasePayloadValidatorBuilder>
 where
     N: FullNodeComponents<Types: BaseNodeTypes>,
-    OpEthApiBuilder: EthApiBuilder<N>,
+    BaseEthApiBuilder: EthApiBuilder<N>,
 {
     fn default() -> Self {
         Self::builder().build()
@@ -81,14 +81,14 @@ where
 impl<N, NetworkT, RpcMiddleware>
     BaseAddOns<
         N,
-        OpEthApiBuilder<NetworkT>,
+        BaseEthApiBuilder<NetworkT>,
         BasePayloadValidatorBuilder,
-        OpEngineApiBuilder<BasePayloadValidatorBuilder>,
+        BaseEngineApiBuilder<BasePayloadValidatorBuilder>,
         RpcMiddleware,
     >
 where
     N: FullNodeComponents<Types: BaseNodeTypes>,
-    OpEthApiBuilder<NetworkT>: EthApiBuilder<N>,
+    BaseEthApiBuilder<NetworkT>: EthApiBuilder<N>,
 {
     /// Build a [`BaseAddOns`] using [`BaseAddOnsBuilder`].
     pub fn builder() -> BaseAddOnsBuilder<NetworkT> {
@@ -210,7 +210,7 @@ where
         let eth_config =
             BaseEthConfigHandler::new(ctx.node.provider().clone(), ctx.node.evm_config().clone());
 
-        let builder = base_execution_payload_builder::OpPayloadBuilder::new(
+        let builder = base_execution_payload_builder::BasePayloadBuilder::new(
             ctx.node.pool().clone(),
             ctx.node.provider().clone(),
             ctx.node.evm_config().clone(),
@@ -410,10 +410,10 @@ impl<NetworkT, RpcMiddleware> BaseAddOnsBuilder<NetworkT, RpcMiddleware> {
     /// Builds an instance of [`BaseAddOns`].
     pub fn build<N, PVB, EB, EVB>(
         self,
-    ) -> BaseAddOns<N, OpEthApiBuilder<NetworkT>, PVB, EB, EVB, RpcMiddleware>
+    ) -> BaseAddOns<N, BaseEthApiBuilder<NetworkT>, PVB, EB, EVB, RpcMiddleware>
     where
         N: FullNodeComponents<Types: NodeTypes>,
-        OpEthApiBuilder<NetworkT>: EthApiBuilder<N>,
+        BaseEthApiBuilder<NetworkT>: EthApiBuilder<N>,
         PVB: PayloadValidatorBuilder<N> + Default,
         EB: Default,
         EVB: Default,
@@ -431,7 +431,7 @@ impl<NetworkT, RpcMiddleware> BaseAddOnsBuilder<NetworkT, RpcMiddleware> {
 
         BaseAddOns::new(
             RpcAddOns::new(
-                OpEthApiBuilder::default()
+                BaseEthApiBuilder::default()
                     .with_sequencer(sequencer_url)
                     .with_sequencer_headers(sequencer_headers)
                     .with_min_suggested_priority_fee(min_suggested_priority_fee),

--- a/crates/execution/runner/src/builder.rs
+++ b/crates/execution/runner/src/builder.rs
@@ -26,13 +26,13 @@ type BaseComponents = <BaseComponentsBuilder as NodeComponentsBuilder<BaseNodeTy
 pub type BaseNodeAdapter = NodeAdapter<BaseNodeTypes, BaseComponents>;
 
 /// Convenience alias for the OP Eth API type exposed by the reth RPC add-ons.
-type OpEthApi = <ConcreteBaseAddOns as RethRpcAddOns<BaseNodeAdapter>>::EthApi;
+type BaseEthApi = <ConcreteBaseAddOns as RethRpcAddOns<BaseNodeAdapter>>::EthApi;
 
 /// Convenience alias for the full Base node handle produced after launch.
 type BaseFullNode = FullNode<BaseNodeAdapter, ConcreteBaseAddOns>;
 
 /// Alias for the RPC context used by Base extensions.
-pub type BaseRpcContext<'a> = RpcContext<'a, BaseNodeAdapter, OpEthApi>;
+pub type BaseRpcContext<'a> = RpcContext<'a, BaseNodeAdapter, BaseEthApi>;
 
 /// Hook type for extending RPC modules.
 type RpcModuleHook = Box<dyn FnOnce(&mut BaseRpcContext<'_>) -> Result<()> + Send + 'static>;

--- a/crates/execution/runner/src/node.rs
+++ b/crates/execution/runner/src/node.rs
@@ -4,13 +4,13 @@ use base_common_consensus::BasePrimitives;
 use base_engine_tree::BaseEngineValidatorBuilder;
 use base_execution_chainspec::BaseChainSpec;
 use base_execution_payload_builder::config::{BaseDAConfig, GasLimitConfig};
-use base_execution_rpc::eth::OpEthApiBuilder;
+use base_execution_rpc::eth::BaseEthApiBuilder;
 use base_execution_storage::BaseStorage;
 use base_node_core::{
     BaseConsensusBuilder, BaseExecutorBuilder, BaseNetworkBuilder, BaseNodeComponentBuilder,
-    BaseNodeTypes, BasePayloadValidatorBuilder, OpEngineApiBuilder, OpEngineTypes,
+    BaseNodeTypes, BasePayloadValidatorBuilder, BaseEngineApiBuilder, BaseEngineTypes,
     args::RollupArgs,
-    node::{BasePoolBuilder, OpPayloadBuilder},
+    node::{BasePoolBuilder, BasePayloadBuilder},
 };
 use reth_node_builder::{
     Node, NodeAdapter, NodeComponentsBuilder,
@@ -75,7 +75,7 @@ impl BaseNode {
             .pool(BasePoolBuilder::default())
             .executor(BaseExecutorBuilder::default())
             .payload(BasicPayloadServiceBuilder::new(
-                OpPayloadBuilder::new(compute_pending_block)
+                BasePayloadBuilder::new(compute_pending_block)
                     .with_da_config(self.da_config.clone())
                     .with_gas_limit_config(self.gas_limit_config.clone()),
             ))
@@ -150,7 +150,7 @@ where
     type ComponentsBuilder = ComponentsBuilder<
         N,
         BasePoolBuilder,
-        BasicPayloadServiceBuilder<OpPayloadBuilder>,
+        BasicPayloadServiceBuilder<BasePayloadBuilder>,
         BaseNetworkBuilder,
         BaseExecutorBuilder,
         BaseConsensusBuilder,
@@ -158,9 +158,9 @@ where
 
     type AddOns = BaseAddOns<
         NodeAdapter<N, <Self::ComponentsBuilder as NodeComponentsBuilder<N>>::Components>,
-        OpEthApiBuilder,
+        BaseEthApiBuilder,
         BasePayloadValidatorBuilder,
-        OpEngineApiBuilder<BasePayloadValidatorBuilder>,
+        BaseEngineApiBuilder<BasePayloadValidatorBuilder>,
         BaseEngineValidatorBuilder<BasePayloadValidatorBuilder>,
     >;
 
@@ -177,5 +177,5 @@ impl NodeTypes for BaseNode {
     type Primitives = BasePrimitives;
     type ChainSpec = BaseChainSpec;
     type Storage = BaseStorage;
-    type Payload = OpEngineTypes;
+    type Payload = BaseEngineTypes;
 }

--- a/crates/execution/runner/src/node.rs
+++ b/crates/execution/runner/src/node.rs
@@ -7,10 +7,10 @@ use base_execution_payload_builder::config::{BaseDAConfig, GasLimitConfig};
 use base_execution_rpc::eth::BaseEthApiBuilder;
 use base_execution_storage::BaseStorage;
 use base_node_core::{
-    BaseConsensusBuilder, BaseExecutorBuilder, BaseNetworkBuilder, BaseNodeComponentBuilder,
-    BaseNodeTypes, BasePayloadValidatorBuilder, BaseEngineApiBuilder, BaseEngineTypes,
+    BaseConsensusBuilder, BaseEngineApiBuilder, BaseEngineTypes, BaseExecutorBuilder,
+    BaseNetworkBuilder, BaseNodeComponentBuilder, BaseNodeTypes, BasePayloadValidatorBuilder,
     args::RollupArgs,
-    node::{BasePoolBuilder, BasePayloadBuilder},
+    node::{BasePayloadBuilder, BasePoolBuilder},
 };
 use reth_node_builder::{
     Node, NodeAdapter, NodeComponentsBuilder,

--- a/crates/execution/runner/src/service.rs
+++ b/crates/execution/runner/src/service.rs
@@ -2,7 +2,7 @@
 
 use base_node_core::{
     BaseConsensusBuilder, BaseExecutorBuilder, BaseNetworkBuilder,
-    node::{BasePoolBuilder, OpPayloadBuilder},
+    node::{BasePoolBuilder, BasePayloadBuilder},
 };
 use reth_node_builder::{
     NodeComponentsBuilder,
@@ -40,7 +40,7 @@ impl PayloadServiceBuilder for DefaultPayloadServiceBuilder {
     type ComponentsBuilder = ComponentsBuilder<
         BaseNodeTypes,
         BasePoolBuilder,
-        BasicPayloadServiceBuilder<OpPayloadBuilder>,
+        BasicPayloadServiceBuilder<BasePayloadBuilder>,
         BaseNetworkBuilder,
         BaseExecutorBuilder,
         BaseConsensusBuilder,

--- a/crates/execution/runner/src/service.rs
+++ b/crates/execution/runner/src/service.rs
@@ -2,7 +2,7 @@
 
 use base_node_core::{
     BaseConsensusBuilder, BaseExecutorBuilder, BaseNetworkBuilder,
-    node::{BasePoolBuilder, BasePayloadBuilder},
+    node::{BasePayloadBuilder, BasePoolBuilder},
 };
 use reth_node_builder::{
     NodeComponentsBuilder,

--- a/crates/execution/runner/src/test_utils/engine.rs
+++ b/crates/execution/runner/src/test_utils/engine.rs
@@ -10,7 +10,7 @@ use alloy_primitives::B256;
 use alloy_rpc_types_engine::{ForkchoiceState, ForkchoiceUpdated, PayloadId, PayloadStatus};
 use base_common_rpc_types_engine::BaseExecutionPayloadV4;
 use base_execution_rpc::BaseEngineApiClient;
-use base_node_core::OpEngineTypes;
+use base_node_core::BaseEngineTypes;
 use eyre::Result;
 use jsonrpsee::core::client::SubscriptionClientT;
 use reth_node_builder::{EngineTypes, PayloadTypes};
@@ -125,9 +125,9 @@ impl<P: EngineProtocol> EngineApi<P> {
     pub async fn get_payload(
         &self,
         payload_id: PayloadId,
-    ) -> eyre::Result<<OpEngineTypes as EngineTypes>::ExecutionPayloadEnvelopeV4> {
+    ) -> eyre::Result<<BaseEngineTypes as EngineTypes>::ExecutionPayloadEnvelopeV4> {
         debug!(payload_id = %payload_id, timestamp = %chrono::Utc::now(), "Fetching payload");
-        Ok(BaseEngineApiClient::<OpEngineTypes>::get_payload_v4(&self.client().await, payload_id)
+        Ok(BaseEngineApiClient::<BaseEngineTypes>::get_payload_v4(&self.client().await, payload_id)
             .await?)
     }
 
@@ -140,7 +140,7 @@ impl<P: EngineProtocol> EngineApi<P> {
         execution_requests: Requests,
     ) -> eyre::Result<PayloadStatus> {
         debug!(timestamp = %chrono::Utc::now(), "Submitting new payload");
-        Ok(BaseEngineApiClient::<OpEngineTypes>::new_payload_v4(
+        Ok(BaseEngineApiClient::<BaseEngineTypes>::new_payload_v4(
             &self.client().await,
             payload,
             versioned_hashes,
@@ -155,7 +155,7 @@ impl<P: EngineProtocol> EngineApi<P> {
         &self,
         current_head: B256,
         new_head: B256,
-        payload_attributes: Option<<OpEngineTypes as PayloadTypes>::PayloadAttributes>,
+        payload_attributes: Option<<BaseEngineTypes as PayloadTypes>::PayloadAttributes>,
     ) -> eyre::Result<ForkchoiceUpdated> {
         debug!(
             "Updating forkchoice at {} (current: {}, new: {})",
@@ -163,7 +163,7 @@ impl<P: EngineProtocol> EngineApi<P> {
             current_head,
             new_head
         );
-        let result = BaseEngineApiClient::<OpEngineTypes>::fork_choice_updated_v3(
+        let result = BaseEngineApiClient::<BaseEngineTypes>::fork_choice_updated_v3(
             &self.client().await,
             ForkchoiceState {
                 head_block_hash: new_head,

--- a/devnet/src/l2/in_process_builder.rs
+++ b/devnet/src/l2/in_process_builder.rs
@@ -124,7 +124,7 @@ impl InProcessBuilder {
 
         let addons: base_node_runner::BaseAddOns<
             _,
-            base_execution_rpc::OpEthApiBuilder,
+            base_execution_rpc::BaseEthApiBuilder,
             base_node_core::BasePayloadValidatorBuilder,
         > = base_node
             .add_ons_builder()


### PR DESCRIPTION
## Summary

Renames all 16 remaining `Op*`-prefixed execution layer types to `Base*` across 52 files. Every bare name (e.g. `PayloadBuilder`, `EngineTypes`, `EthApi`) conflicts with an identically-named type already imported from reth or alloy in the same files, so the `Base` prefix is used uniformly throughout. Types affected include payload building (`OpPayloadBuilder`, `OpBuiltPayload`, `OpPayloadBuilderAttributes`, `OpPayloadBuilderCtx`), engine integration (`OpEngineTypes`, `OpEngineValidator`, `OpEngineApiBuilder`), RPC layer (`OpEthApi`, `OpEthApiInner`, `OpEthApiBuilder`, `OpEthApiError`, `OpInvalidTransactionError`), consensus (`OpBeaconConsensus`), and EVM utilities (`OpNextBlockEnvAttributes`, `OpRethReceiptBuilder`, `OpExecutionPayloadValidator`).