### PR TITLE
chore: remove unused engine api generics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2499,7 +2499,6 @@ dependencies = [
  "alloy-signer",
  "alloy-signer-local",
  "alloy-transport",
- "alloy-transport-http",
  "async-trait",
  "base-batcher-core",
  "base-batcher-encoder",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4156,7 +4156,6 @@ dependencies = [
  "alloy-primitives",
  "alloy-provider",
  "alloy-rpc-types-engine",
- "alloy-transport-http",
  "backon",
  "base-common-network",
  "base-common-provider",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3130,12 +3130,12 @@ dependencies = [
 name = "base-common-provider"
 version = "0.0.0"
 dependencies = [
- "alloy-network",
  "alloy-primitives",
  "alloy-provider",
  "alloy-rpc-types-engine",
  "alloy-transport",
  "async-trait",
+ "base-common-network",
  "base-common-rpc-types-engine",
 ]
 

--- a/actions/harness/Cargo.toml
+++ b/actions/harness/Cargo.toml
@@ -33,7 +33,6 @@ alloy-transport.workspace = true
 alloy-primitives.workspace = true
 alloy-signer-local.workspace = true
 alloy-rpc-types-eth.workspace = true
-alloy-transport-http.workspace = true
 alloy-genesis = { workspace = true, features = ["std"] }
 alloy-consensus = { workspace = true, features = ["std"] }
 alloy-rpc-types-engine = { workspace = true, features = ["std"] }

--- a/actions/harness/src/engine.rs
+++ b/actions/harness/src/engine.rs
@@ -20,7 +20,6 @@ use alloy_rpc_types_eth::{
     Block, BlockTransactions, EIP1186AccountProofResponse, Transaction as EthTransaction,
 };
 use alloy_transport::{TransportError, TransportErrorKind, TransportResult};
-use alloy_transport_http::Http;
 use async_trait::async_trait;
 use base_common_consensus::BasePrimitives;
 use base_common_network::Base;
@@ -31,7 +30,7 @@ use base_common_rpc_types_engine::{
     BaseExecutionPayloadEnvelopeV4, BaseExecutionPayloadEnvelopeV5, BaseExecutionPayloadV4,
     BasePayloadAttributes,
 };
-use base_consensus_engine::{EngineClient, EngineClientError, HyperAuthClient};
+use base_consensus_engine::{EngineClient, EngineClientError};
 use base_consensus_genesis::RollupConfig;
 use base_consensus_node::{EngineClientError as NodeEngineClientError, SequencerEngineClient};
 use base_execution_chainspec::BaseChainSpec;
@@ -739,7 +738,7 @@ impl EngineClient for ActionEngineClient {
 }
 
 #[async_trait]
-impl BaseEngineApi<Base, Http<HyperAuthClient>> for ActionEngineClient {
+impl BaseEngineApi for ActionEngineClient {
     async fn new_payload_v2(
         &self,
         payload: ExecutionPayloadInputV2,

--- a/crates/common/provider/Cargo.toml
+++ b/crates/common/provider/Cargo.toml
@@ -15,10 +15,10 @@ workspace = true
 
 [dependencies]
 # Workspace
+base-common-network.workspace = true
 base-common-rpc-types-engine = { workspace = true, features = ["serde"] }
 
 # Alloy
-alloy-network.workspace = true
 alloy-provider.workspace = true
 alloy-transport.workspace = true
 alloy-primitives = { workspace = true, features = ["rlp", "serde"] }

--- a/crates/common/provider/src/ext/engine.rs
+++ b/crates/common/provider/src/ext/engine.rs
@@ -1,17 +1,17 @@
-use alloy_network::Network;
 use alloy_primitives::{B256, BlockHash, Bytes};
 use alloy_provider::Provider;
 use alloy_rpc_types_engine::{
     ClientVersionV1, ExecutionPayloadBodiesV1, ExecutionPayloadEnvelopeV2, ExecutionPayloadInputV2,
     ExecutionPayloadV3, ForkchoiceState, ForkchoiceUpdated, PayloadId, PayloadStatus,
 };
-use alloy_transport::{Transport, TransportResult};
+use alloy_transport::TransportResult;
+use base_common_network::Base;
 use base_common_rpc_types_engine::{
     BaseExecutionPayloadEnvelopeV3, BaseExecutionPayloadEnvelopeV4, BaseExecutionPayloadEnvelopeV5,
     BaseExecutionPayloadV4, BasePayloadAttributes,
 };
 
-/// Extension trait for engine API RPC methods.
+/// Extension trait for Base Engine API RPC methods.
 ///
 /// Note:
 /// > The provider should use a JWT authentication layer.
@@ -20,7 +20,7 @@ use base_common_rpc_types_engine::{
 /// <https://specs.base.org/protocol/execution#engine-api>
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
-pub trait BaseEngineApi<N, T> {
+pub trait BaseEngineApi {
     /// Sends the given payload to the execution layer client, as specified for the Shanghai fork.
     ///
     /// See also <https://github.com/ethereum/execution-apis/blob/584905270d8ad665718058060267061ecfd79ca5/src/engine/shanghai.md#engine_newpayloadv2>
@@ -199,11 +199,9 @@ pub trait BaseEngineApi<N, T> {
 
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
-impl<N, T, P> BaseEngineApi<N, T> for P
+impl<P> BaseEngineApi for P
 where
-    N: Network,
-    T: Transport + Clone,
-    P: Provider<N>,
+    P: Provider<Base>,
 {
     async fn new_payload_v2(
         &self,

--- a/crates/consensus/engine/src/client.rs
+++ b/crates/consensus/engine/src/client.rs
@@ -15,11 +15,8 @@ use alloy_rpc_types_engine::{
 use alloy_rpc_types_eth::{Block, EIP1186AccountProofResponse};
 use alloy_transport::{RpcError, TransportErrorKind, TransportResult};
 use alloy_transport_http::{
-    AuthLayer, AuthService, Http, HyperClient,
-    hyper_util::{
-        client::legacy::{Client, connect::HttpConnector},
-        rt::TokioExecutor,
-    },
+    AuthLayer, Http, HyperClient,
+    hyper_util::{client::legacy::Client, rt::TokioExecutor},
 };
 use async_trait::async_trait;
 use base_common_network::Base;
@@ -49,9 +46,6 @@ pub enum EngineClientError {
     #[error("An error occurred while decoding the payload: {0}")]
     BlockInfoDecodeError(#[from] FromBlockError),
 }
-/// A Hyper HTTP client with a JWT authentication layer.
-pub type HyperAuthClient<B = Full<Bytes>> = HyperClient<B, AuthService<Client<HttpConnector, B>>>;
-
 /// Engine API client used to communicate with L1/L2 ELs.
 /// `EngineClient` trait that is very coupled to its only implementation.
 /// The main reason this exists is for mocking/unit testing.

--- a/crates/consensus/engine/src/client.rs
+++ b/crates/consensus/engine/src/client.rs
@@ -56,7 +56,7 @@ pub type HyperAuthClient<B = Full<Bytes>> = HyperClient<B, AuthService<Client<Ht
 /// `EngineClient` trait that is very coupled to its only implementation.
 /// The main reason this exists is for mocking/unit testing.
 #[async_trait]
-pub trait EngineClient: BaseEngineApi<Base, Http<HyperAuthClient>> + Send + Sync {
+pub trait EngineClient: BaseEngineApi + Send + Sync {
     /// Returns a reference to the inner [`RollupConfig`].
     fn cfg(&self) -> &RollupConfig;
 
@@ -230,8 +230,7 @@ where
 }
 
 #[async_trait::async_trait]
-impl<L1Provider, L2Provider> BaseEngineApi<Base, Http<HyperAuthClient>>
-    for BaseEngineClient<L1Provider, L2Provider>
+impl<L1Provider, L2Provider> BaseEngineApi for BaseEngineClient<L1Provider, L2Provider>
 where
     L1Provider: Provider,
     L2Provider: Provider<Base>,
@@ -240,10 +239,7 @@ where
         &self,
         payload: ExecutionPayloadInputV2,
     ) -> TransportResult<PayloadStatus> {
-        let call = <L2Provider as BaseEngineApi<Base, Http<HyperAuthClient>>>::new_payload_v2(
-            &self.engine,
-            payload,
-        );
+        let call = <L2Provider as BaseEngineApi>::new_payload_v2(&self.engine, payload);
 
         record_call_time(call, Metrics::NEW_PAYLOAD_METHOD).await
     }
@@ -253,7 +249,7 @@ where
         payload: ExecutionPayloadV3,
         parent_beacon_block_root: B256,
     ) -> TransportResult<PayloadStatus> {
-        let call = <L2Provider as BaseEngineApi<Base, Http<HyperAuthClient>>>::new_payload_v3(
+        let call = <L2Provider as BaseEngineApi>::new_payload_v3(
             &self.engine,
             payload,
             parent_beacon_block_root,
@@ -267,7 +263,7 @@ where
         payload: BaseExecutionPayloadV4,
         parent_beacon_block_root: B256,
     ) -> TransportResult<PayloadStatus> {
-        let call = <L2Provider as BaseEngineApi<Base, Http<HyperAuthClient>>>::new_payload_v4(
+        let call = <L2Provider as BaseEngineApi>::new_payload_v4(
             &self.engine,
             payload,
             parent_beacon_block_root,
@@ -281,12 +277,11 @@ where
         fork_choice_state: ForkchoiceState,
         payload_attributes: Option<BasePayloadAttributes>,
     ) -> TransportResult<ForkchoiceUpdated> {
-        let call =
-            <L2Provider as BaseEngineApi<Base, Http<HyperAuthClient>>>::fork_choice_updated_v2(
-                &self.engine,
-                fork_choice_state,
-                payload_attributes,
-            );
+        let call = <L2Provider as BaseEngineApi>::fork_choice_updated_v2(
+            &self.engine,
+            fork_choice_state,
+            payload_attributes,
+        );
 
         record_call_time(call, Metrics::FORKCHOICE_UPDATE_METHOD).await
     }
@@ -296,12 +291,11 @@ where
         fork_choice_state: ForkchoiceState,
         payload_attributes: Option<BasePayloadAttributes>,
     ) -> TransportResult<ForkchoiceUpdated> {
-        let call =
-            <L2Provider as BaseEngineApi<Base, Http<HyperAuthClient>>>::fork_choice_updated_v3(
-                &self.engine,
-                fork_choice_state,
-                payload_attributes,
-            );
+        let call = <L2Provider as BaseEngineApi>::fork_choice_updated_v3(
+            &self.engine,
+            fork_choice_state,
+            payload_attributes,
+        );
 
         record_call_time(call, Metrics::FORKCHOICE_UPDATE_METHOD).await
     }
@@ -310,10 +304,7 @@ where
         &self,
         payload_id: PayloadId,
     ) -> TransportResult<ExecutionPayloadEnvelopeV2> {
-        let call = <L2Provider as BaseEngineApi<Base, Http<HyperAuthClient>>>::get_payload_v2(
-            &self.engine,
-            payload_id,
-        );
+        let call = <L2Provider as BaseEngineApi>::get_payload_v2(&self.engine, payload_id);
 
         record_call_time(call, Metrics::GET_PAYLOAD_METHOD).await
     }
@@ -322,10 +313,7 @@ where
         &self,
         payload_id: PayloadId,
     ) -> TransportResult<BaseExecutionPayloadEnvelopeV3> {
-        let call = <L2Provider as BaseEngineApi<Base, Http<HyperAuthClient>>>::get_payload_v3(
-            &self.engine,
-            payload_id,
-        );
+        let call = <L2Provider as BaseEngineApi>::get_payload_v3(&self.engine, payload_id);
 
         record_call_time(call, Metrics::GET_PAYLOAD_METHOD).await
     }
@@ -334,10 +322,7 @@ where
         &self,
         payload_id: PayloadId,
     ) -> TransportResult<BaseExecutionPayloadEnvelopeV4> {
-        let call = <L2Provider as BaseEngineApi<Base, Http<HyperAuthClient>>>::get_payload_v4(
-            &self.engine,
-            payload_id,
-        );
+        let call = <L2Provider as BaseEngineApi>::get_payload_v4(&self.engine, payload_id);
 
         record_call_time(call, Metrics::GET_PAYLOAD_METHOD).await
     }
@@ -346,10 +331,7 @@ where
         &self,
         payload_id: PayloadId,
     ) -> TransportResult<BaseExecutionPayloadEnvelopeV5> {
-        let call = <L2Provider as BaseEngineApi<Base, Http<HyperAuthClient>>>::get_payload_v5(
-            &self.engine,
-            payload_id,
-        );
+        let call = <L2Provider as BaseEngineApi>::get_payload_v5(&self.engine, payload_id);
 
         record_call_time(call, Metrics::GET_PAYLOAD_METHOD).await
     }
@@ -358,11 +340,8 @@ where
         &self,
         block_hashes: Vec<BlockHash>,
     ) -> TransportResult<ExecutionPayloadBodiesV1> {
-        <L2Provider as BaseEngineApi<Base, Http<HyperAuthClient>>>::get_payload_bodies_by_hash_v1(
-            &self.engine,
-            block_hashes,
-        )
-        .await
+        <L2Provider as BaseEngineApi>::get_payload_bodies_by_hash_v1(&self.engine, block_hashes)
+            .await
     }
 
     async fn get_payload_bodies_by_range_v1(
@@ -370,34 +349,22 @@ where
         start: u64,
         count: u64,
     ) -> TransportResult<ExecutionPayloadBodiesV1> {
-        <L2Provider as BaseEngineApi<Base, Http<HyperAuthClient>>>::get_payload_bodies_by_range_v1(
-            &self.engine,
-            start,
-            count,
-        )
-        .await
+        <L2Provider as BaseEngineApi>::get_payload_bodies_by_range_v1(&self.engine, start, count)
+            .await
     }
 
     async fn get_client_version_v1(
         &self,
         client_version: ClientVersionV1,
     ) -> TransportResult<Vec<ClientVersionV1>> {
-        <L2Provider as BaseEngineApi<Base, Http<HyperAuthClient>>>::get_client_version_v1(
-            &self.engine,
-            client_version,
-        )
-        .await
+        <L2Provider as BaseEngineApi>::get_client_version_v1(&self.engine, client_version).await
     }
 
     async fn exchange_capabilities(
         &self,
         capabilities: Vec<String>,
     ) -> TransportResult<Vec<String>> {
-        <L2Provider as BaseEngineApi<Base, Http<HyperAuthClient>>>::exchange_capabilities(
-            &self.engine,
-            capabilities,
-        )
-        .await
+        <L2Provider as BaseEngineApi>::exchange_capabilities(&self.engine, capabilities).await
     }
 }
 

--- a/crates/consensus/engine/src/lib.rs
+++ b/crates/consensus/engine/src/lib.rs
@@ -22,9 +22,7 @@ mod attributes;
 pub use attributes::{AttributesMatch, AttributesMismatch};
 
 mod client;
-pub use client::{
-    BaseEngineClient, EngineClient, EngineClientBuilder, EngineClientError, HyperAuthClient,
-};
+pub use client::{BaseEngineClient, EngineClient, EngineClientBuilder, EngineClientError};
 
 mod ws_connect;
 pub use ws_connect::JwtWsConnect;

--- a/crates/consensus/engine/src/test_utils/engine_client.rs
+++ b/crates/consensus/engine/src/test_utils/engine_client.rs
@@ -13,7 +13,6 @@ use alloy_rpc_types_engine::{
 };
 use alloy_rpc_types_eth::{Block, EIP1186AccountProofResponse, Transaction as EthTransaction};
 use alloy_transport::{TransportError, TransportErrorKind, TransportResult};
-use alloy_transport_http::Http;
 use async_trait::async_trait;
 use base_common_network::Base;
 use base_common_provider::BaseEngineApi;
@@ -26,7 +25,7 @@ use base_consensus_genesis::RollupConfig;
 use base_protocol::L2BlockInfo;
 use tokio::sync::RwLock;
 
-use crate::{EngineClient, EngineClientError, HyperAuthClient};
+use crate::{EngineClient, EngineClientError};
 
 /// Builder for creating test `MockEngineClient` instances with sensible defaults
 pub fn test_engine_client_builder() -> MockEngineClientBuilder {
@@ -512,7 +511,7 @@ impl EngineClient for MockEngineClient {
 }
 
 #[async_trait]
-impl BaseEngineApi<Base, Http<HyperAuthClient>> for MockEngineClient {
+impl BaseEngineApi for MockEngineClient {
     async fn new_payload_v2(
         &self,
         _payload: ExecutionPayloadInputV2,

--- a/crates/utilities/jwt/Cargo.toml
+++ b/crates/utilities/jwt/Cargo.toml
@@ -26,7 +26,6 @@ backon = { workspace = true, optional = true }
 alloy-provider = { workspace = true, optional = true }
 base-common-network = { workspace = true, optional = true }
 base-common-provider = { workspace = true, optional = true }
-alloy-transport-http = { workspace = true, optional = true }
 base-consensus-engine = { workspace = true, optional = true }
 tracing = { workspace = true, optional = true, features = ["std"] }
 
@@ -34,7 +33,6 @@ tracing = { workspace = true, optional = true, features = ["std"] }
 test-utils = [ "base-consensus-engine?/test-utils" ]
 engine-validation = [
 	"dep:alloy-provider",
-	"dep:alloy-transport-http",
 	"dep:backon",
 	"dep:base-common-network",
 	"dep:base-common-provider",

--- a/crates/utilities/jwt/src/validator.rs
+++ b/crates/utilities/jwt/src/validator.rs
@@ -1,6 +1,7 @@
 //! JWT validation utilities.
 
 use alloy_rpc_types_engine::JwtSecret;
+#[cfg(feature = "engine-validation")]
 use tracing::debug;
 
 #[cfg(feature = "engine-validation")]
@@ -75,11 +76,10 @@ impl JwtValidator {
         engine_url: url::Url,
     ) -> Result<JwtSecret, JwtValidationError> {
         use alloy_provider::RootProvider;
-        use alloy_transport_http::Http;
         use backon::{ExponentialBuilder, Retryable};
         use base_common_network::Base;
         use base_common_provider::BaseEngineApi;
-        use base_consensus_engine::{BaseEngineClient, HyperAuthClient};
+        use base_consensus_engine::BaseEngineClient;
         use tracing::{debug, error};
 
         // Convert WebSocket URLs to HTTP for validation.
@@ -95,11 +95,8 @@ impl JwtValidator {
         .map_err(|e| JwtValidationError::CapabilityExchange(e.to_string()))?;
 
         let exchange = || async {
-            match <RootProvider<Base> as BaseEngineApi<
-                Base,
-                Http<HyperAuthClient>,
-            >>::exchange_capabilities(&engine, vec![])
-            .await
+            match <RootProvider<Base> as BaseEngineApi>::exchange_capabilities(&engine, vec![])
+                .await
             {
                 Ok(_) => {
                     debug!("Successfully exchanged capabilities with engine");


### PR DESCRIPTION
## Summary
Remove network generic, this is never overridden.