### PR TITLE
chore: remove unused rpc transaction generics

### DIFF
--- a/crates/common/rpc-types/src/reth.rs
+++ b/crates/common/rpc-types/src/reth.rs
@@ -11,7 +11,7 @@ use alloy_evm::{
 use alloy_network::TxSigner;
 use alloy_primitives::{Address, Bytes};
 use alloy_signer::Signature;
-use base_common_consensus::{BaseTransaction, BaseTransactionInfo, BaseTxEnvelope};
+use base_common_consensus::{BaseTransactionInfo, BaseTxEnvelope};
 use base_common_evm::OpTransaction as OpRevm;
 use reth_rpc_convert::{
     SignTxRequestError, SignableTxRequest, TryIntoSimTx, transaction::FromConsensusTx,
@@ -20,12 +20,12 @@ use revm::context::TxEnv;
 
 use crate::{BaseTransactionRequest, Transaction};
 
-impl<T: BaseTransaction + alloy_consensus::Transaction> FromConsensusTx<T> for Transaction<T> {
+impl FromConsensusTx<BaseTxEnvelope> for Transaction {
     type TxInfo = BaseTransactionInfo;
     type Err = Infallible;
 
     fn from_consensus_tx(
-        tx: T,
+        tx: BaseTxEnvelope,
         signer: Address,
         tx_info: BaseTransactionInfo,
     ) -> Result<Self, Infallible> {

--- a/crates/common/rpc-types/src/transaction.rs
+++ b/crates/common/rpc-types/src/transaction.rs
@@ -1,10 +1,10 @@
 //! Types related to transactions for Base chains.
 
 use alloy_consensus::{Transaction as TransactionTrait, Typed2718, transaction::Recovered};
-use alloy_eips::{Encodable2718, eip2930::AccessList, eip7702::SignedAuthorization};
+use alloy_eips::{eip2930::AccessList, eip7702::SignedAuthorization};
 use alloy_primitives::{Address, B256, BlockHash, Bytes, ChainId, TxKind, U256};
 use alloy_serde::OtherFields;
-use base_common_consensus::{BaseTransaction, BaseTransactionInfo, BaseTxEnvelope};
+use base_common_consensus::{BaseTransactionInfo, BaseTxEnvelope};
 use serde::{Deserialize, Serialize};
 
 mod request;
@@ -15,16 +15,12 @@ pub use request::BaseTransactionRequest;
     Clone, Debug, PartialEq, Eq, Serialize, Deserialize, derive_more::Deref, derive_more::DerefMut,
 )]
 #[cfg_attr(all(any(test, feature = "arbitrary"), feature = "k256"), derive(arbitrary::Arbitrary))]
-#[serde(
-    try_from = "tx_serde::TransactionSerdeHelper<T>",
-    into = "tx_serde::TransactionSerdeHelper<T>",
-    bound = "T: TransactionTrait + BaseTransaction + Clone + serde::Serialize + serde::de::DeserializeOwned"
-)]
-pub struct Transaction<T = BaseTxEnvelope> {
+#[serde(try_from = "tx_serde::TransactionSerdeHelper", into = "tx_serde::TransactionSerdeHelper")]
+pub struct Transaction {
     /// Ethereum Transaction Types
     #[deref]
     #[deref_mut]
-    pub inner: alloy_rpc_types_eth::Transaction<T>,
+    pub inner: alloy_rpc_types_eth::Transaction<BaseTxEnvelope>,
 
     /// Nonce for deposit transactions. Only present in RPC responses.
     pub deposit_nonce: Option<u64>,
@@ -33,9 +29,9 @@ pub struct Transaction<T = BaseTxEnvelope> {
     pub deposit_receipt_version: Option<u64>,
 }
 
-impl<T: BaseTransaction + TransactionTrait> Transaction<T> {
+impl Transaction {
     /// Converts a consensus `tx` with an additional context `tx_info` into an RPC [`Transaction`].
-    pub fn from_transaction(tx: Recovered<T>, tx_info: BaseTransactionInfo) -> Self {
+    pub fn from_transaction(tx: Recovered<BaseTxEnvelope>, tx_info: BaseTransactionInfo) -> Self {
         let base_fee = tx_info.inner.base_fee;
         let effective_gas_price = if tx.is_deposit() {
             // For deposits, we must always set the `gasPrice` field to 0 in rpc
@@ -64,13 +60,13 @@ impl<T: BaseTransaction + TransactionTrait> Transaction<T> {
     }
 }
 
-impl<T: Typed2718> Typed2718 for Transaction<T> {
+impl Typed2718 for Transaction {
     fn ty(&self) -> u8 {
         self.inner.ty()
     }
 }
 
-impl<T: TransactionTrait> TransactionTrait for Transaction<T> {
+impl TransactionTrait for Transaction {
     fn chain_id(&self) -> Option<ChainId> {
         self.inner.chain_id()
     }
@@ -144,9 +140,7 @@ impl<T: TransactionTrait> TransactionTrait for Transaction<T> {
     }
 }
 
-impl<T: TransactionTrait + Encodable2718> alloy_network_primitives::TransactionResponse
-    for Transaction<T>
-{
+impl alloy_network_primitives::TransactionResponse for Transaction {
     fn tx_hash(&self) -> alloy_primitives::TxHash {
         self.inner.tx_hash()
     }
@@ -195,8 +189,8 @@ impl TryFrom<BaseTransactionFields> for OtherFields {
     }
 }
 
-impl<T> AsRef<T> for Transaction<T> {
-    fn as_ref(&self) -> &T {
+impl AsRef<BaseTxEnvelope> for Transaction {
+    fn as_ref(&self) -> &BaseTxEnvelope {
         self.inner.as_ref()
     }
 }
@@ -210,7 +204,7 @@ mod tx_serde {
     //!
     //! Additionally, we need similar logic for the `gasPrice` field
     use alloy_consensus::{Transaction as TransactionTrait, transaction::Recovered};
-    use base_common_consensus::BaseTransaction;
+    use base_common_consensus::BaseTxEnvelope;
     use serde::{Deserialize, Serialize, de::Error};
 
     use super::{Address, BlockHash, Transaction};
@@ -239,9 +233,9 @@ mod tx_serde {
 
     #[derive(Serialize, Deserialize)]
     #[serde(rename_all = "camelCase")]
-    pub(crate) struct TransactionSerdeHelper<T> {
+    pub(crate) struct TransactionSerdeHelper {
         #[serde(flatten)]
-        inner: T,
+        inner: BaseTxEnvelope,
         #[serde(default)]
         block_hash: Option<BlockHash>,
         #[serde(default, with = "alloy_serde::quantity::opt")]
@@ -259,8 +253,8 @@ mod tx_serde {
         other: OptionalFields,
     }
 
-    impl<T: TransactionTrait + BaseTransaction> From<Transaction<T>> for TransactionSerdeHelper<T> {
-        fn from(value: Transaction<T>) -> Self {
+    impl From<Transaction> for TransactionSerdeHelper {
+        fn from(value: Transaction) -> Self {
             let Transaction {
                 inner:
                     alloy_rpc_types_eth::Transaction {
@@ -291,10 +285,10 @@ mod tx_serde {
         }
     }
 
-    impl<T: TransactionTrait + BaseTransaction> TryFrom<TransactionSerdeHelper<T>> for Transaction<T> {
+    impl TryFrom<TransactionSerdeHelper> for Transaction {
         type Error = serde_json::Error;
 
-        fn try_from(value: TransactionSerdeHelper<T>) -> Result<Self, Self::Error> {
+        fn try_from(value: TransactionSerdeHelper) -> Result<Self, Self::Error> {
             let TransactionSerdeHelper {
                 inner,
                 block_hash,


### PR DESCRIPTION
## Summary
For Base, these will always be the Base Transaction types