### PR TITLE
chore: remove unused receipt envelope generic

### DIFF
--- a/crates/common/consensus/src/receipts/envelope.rs
+++ b/crates/common/consensus/src/receipts/envelope.rs
@@ -25,33 +25,33 @@ use crate::{DepositReceipt, DepositReceiptWithBloom, OpTxType};
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(tag = "type"))]
-pub enum BaseReceiptEnvelope<T = Log> {
+pub enum BaseReceiptEnvelope {
     /// Receipt envelope with no type flag.
     #[cfg_attr(feature = "serde", serde(rename = "0x0", alias = "0x00"))]
-    Legacy(ReceiptWithBloom<Receipt<T>>),
+    Legacy(ReceiptWithBloom<Receipt<Log>>),
     /// Receipt envelope with type flag 1, containing a [EIP-2930] receipt.
     ///
     /// [EIP-2930]: https://eips.ethereum.org/EIPS/eip-2930
     #[cfg_attr(feature = "serde", serde(rename = "0x1", alias = "0x01"))]
-    Eip2930(ReceiptWithBloom<Receipt<T>>),
+    Eip2930(ReceiptWithBloom<Receipt<Log>>),
     /// Receipt envelope with type flag 2, containing a [EIP-1559] receipt.
     ///
     /// [EIP-1559]: https://eips.ethereum.org/EIPS/eip-1559
     #[cfg_attr(feature = "serde", serde(rename = "0x2", alias = "0x02"))]
-    Eip1559(ReceiptWithBloom<Receipt<T>>),
+    Eip1559(ReceiptWithBloom<Receipt<Log>>),
     /// Receipt envelope with type flag 4, containing a [EIP-7702] receipt.
     ///
     /// [EIP-7702]: https://eips.ethereum.org/EIPS/eip-7702
     #[cfg_attr(feature = "serde", serde(rename = "0x4", alias = "0x04"))]
-    Eip7702(ReceiptWithBloom<Receipt<T>>),
+    Eip7702(ReceiptWithBloom<Receipt<Log>>),
     /// Receipt envelope with type flag 126, containing a [deposit] receipt.
     ///
     /// [deposit]: https://specs.base.org/protocol/bridging/deposits
     #[cfg_attr(feature = "serde", serde(rename = "0x7e", alias = "0x7E"))]
-    Deposit(ReceiptWithBloom<DepositReceipt<T>>),
+    Deposit(ReceiptWithBloom<DepositReceipt>),
 }
 
-impl BaseReceiptEnvelope<Log> {
+impl BaseReceiptEnvelope {
     /// Creates a new [`BaseReceiptEnvelope`] from the given parts.
     pub fn from_parts<'a>(
         status: bool,
@@ -93,7 +93,7 @@ impl BaseReceiptEnvelope<Log> {
     }
 }
 
-impl<T> BaseReceiptEnvelope<T> {
+impl BaseReceiptEnvelope {
     /// Return the [`OpTxType`] of the inner receipt.
     pub const fn tx_type(&self) -> OpTxType {
         match self {
@@ -120,26 +120,13 @@ impl<T> BaseReceiptEnvelope<T> {
         self.as_receipt().unwrap().cumulative_gas_used
     }
 
-    /// Converts the receipt's log type by applying a function to each log.
-    ///
-    /// Returns the receipt with the new log type.
-    pub fn map_logs<U>(self, f: impl FnMut(T) -> U) -> BaseReceiptEnvelope<U> {
-        match self {
-            Self::Legacy(r) => BaseReceiptEnvelope::Legacy(r.map_logs(f)),
-            Self::Eip2930(r) => BaseReceiptEnvelope::Eip2930(r.map_logs(f)),
-            Self::Eip1559(r) => BaseReceiptEnvelope::Eip1559(r.map_logs(f)),
-            Self::Eip7702(r) => BaseReceiptEnvelope::Eip7702(r.map_logs(f)),
-            Self::Deposit(r) => BaseReceiptEnvelope::Deposit(r.map_receipt(|r| r.map_logs(f))),
-        }
-    }
-
     /// Return the receipt logs.
-    pub fn logs(&self) -> &[T] {
+    pub fn logs(&self) -> &[Log] {
         &self.as_receipt().unwrap().logs
     }
 
     /// Consumes the type and returns the logs.
-    pub fn into_logs(self) -> Vec<T> {
+    pub fn into_logs(self) -> Vec<Log> {
         self.into_receipt().logs
     }
 
@@ -164,7 +151,7 @@ impl<T> BaseReceiptEnvelope<T> {
     }
 
     /// Returns the deposit receipt if it is a deposit receipt.
-    pub const fn as_deposit_receipt_with_bloom(&self) -> Option<&DepositReceiptWithBloom<T>> {
+    pub const fn as_deposit_receipt_with_bloom(&self) -> Option<&DepositReceiptWithBloom> {
         match self {
             Self::Deposit(t) => Some(t),
             _ => None,
@@ -172,7 +159,7 @@ impl<T> BaseReceiptEnvelope<T> {
     }
 
     /// Returns the deposit receipt if it is a deposit receipt.
-    pub const fn as_deposit_receipt(&self) -> Option<&DepositReceipt<T>> {
+    pub const fn as_deposit_receipt(&self) -> Option<&DepositReceipt> {
         match self {
             Self::Deposit(t) => Some(&t.receipt),
             _ => None,
@@ -180,7 +167,7 @@ impl<T> BaseReceiptEnvelope<T> {
     }
 
     /// Consumes the type and returns the underlying [`Receipt`].
-    pub fn into_receipt(self) -> Receipt<T> {
+    pub fn into_receipt(self) -> Receipt<Log> {
         match self {
             Self::Legacy(t) | Self::Eip2930(t) | Self::Eip1559(t) | Self::Eip7702(t) => t.receipt,
             Self::Deposit(t) => t.receipt.into_inner(),
@@ -189,7 +176,7 @@ impl<T> BaseReceiptEnvelope<T> {
 
     /// Return the inner receipt. Currently this is infallible, however, future
     /// receipt types may be added.
-    pub const fn as_receipt(&self) -> Option<&Receipt<T>> {
+    pub const fn as_receipt(&self) -> Option<&Receipt<Log>> {
         match self {
             Self::Legacy(t) | Self::Eip2930(t) | Self::Eip1559(t) | Self::Eip7702(t) => {
                 Some(&t.receipt)
@@ -218,11 +205,8 @@ impl BaseReceiptEnvelope {
     }
 }
 
-impl<T> TxReceipt for BaseReceiptEnvelope<T>
-where
-    T: Clone + core::fmt::Debug + PartialEq + Eq + Send + Sync,
-{
-    type Log = T;
+impl TxReceipt for BaseReceiptEnvelope {
+    type Log = Log;
 
     fn status_or_post_state(&self) -> Eip658Value {
         self.as_receipt().unwrap().status
@@ -247,7 +231,7 @@ where
     }
 
     /// Return the receipt logs.
-    fn logs(&self) -> &[T] {
+    fn logs(&self) -> &[Log] {
         &self.as_receipt().unwrap().logs
     }
 }
@@ -330,26 +314,20 @@ impl Decodable2718 for BaseReceiptEnvelope {
     }
 }
 
-impl<T> From<T> for BaseReceiptEnvelope<T>
-where
-    T: Into<ReceiptWithBloom<DepositReceipt<T>>>,
-{
-    fn from(value: T) -> Self {
-        Self::Deposit(value.into())
+impl From<DepositReceiptWithBloom> for BaseReceiptEnvelope {
+    fn from(value: DepositReceiptWithBloom) -> Self {
+        Self::Deposit(value)
     }
 }
 
-impl<T> From<BaseReceiptEnvelope<T>> for Receipt<T> {
-    fn from(receipt: BaseReceiptEnvelope<T>) -> Self {
+impl From<BaseReceiptEnvelope> for Receipt<Log> {
+    fn from(receipt: BaseReceiptEnvelope) -> Self {
         receipt.into_receipt()
     }
 }
 
 #[cfg(all(test, feature = "arbitrary"))]
-impl<'a, T> arbitrary::Arbitrary<'a> for BaseReceiptEnvelope<T>
-where
-    T: arbitrary::Arbitrary<'a>,
-{
+impl<'a> arbitrary::Arbitrary<'a> for BaseReceiptEnvelope {
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
         match u.int_in_range(0..=4)? {
             0 => Ok(Self::Legacy(ReceiptWithBloom::arbitrary(u)?)),

--- a/crates/common/consensus/src/receipts/receipt.rs
+++ b/crates/common/consensus/src/receipts/receipt.rs
@@ -453,8 +453,8 @@ impl From<super::BaseReceiptEnvelope> for BaseReceipt {
     }
 }
 
-impl<T> From<ReceiptWithBloom<BaseReceipt<T>>> for BaseReceiptEnvelope<T> {
-    fn from(value: ReceiptWithBloom<BaseReceipt<T>>) -> Self {
+impl From<ReceiptWithBloom<BaseReceipt>> for BaseReceiptEnvelope {
+    fn from(value: ReceiptWithBloom<BaseReceipt>) -> Self {
         let (receipt, logs_bloom) = value.into_components();
         match receipt {
             BaseReceipt::Legacy(receipt) => Self::Legacy(ReceiptWithBloom { receipt, logs_bloom }),

--- a/crates/common/rpc-types/src/receipt.rs
+++ b/crates/common/rpc-types/src/receipt.rs
@@ -202,18 +202,17 @@ pub struct L1BlockInfo {
 
 impl Eq for L1BlockInfo {}
 
-impl From<BaseTransactionReceipt> for BaseReceiptEnvelope<alloy_primitives::Log> {
+impl From<BaseTransactionReceipt> for BaseReceiptEnvelope {
     fn from(value: BaseTransactionReceipt) -> Self {
-        let inner_envelope = value.inner.inner.into();
+        let ReceiptWithBloom { logs_bloom, receipt } = value.inner.inner;
 
         /// Helper function to convert the inner logs within a [`ReceiptWithBloom`] from RPC to
         /// consensus types.
         #[inline(always)]
         fn convert_standard_receipt(
-            receipt: ReceiptWithBloom<Receipt<alloy_rpc_types_eth::Log>>,
+            receipt: Receipt<alloy_rpc_types_eth::Log>,
+            logs_bloom: alloy_primitives::Bloom,
         ) -> ReceiptWithBloom<Receipt<alloy_primitives::Log>> {
-            let ReceiptWithBloom { logs_bloom, receipt } = receipt;
-
             let consensus_logs = receipt.logs.into_iter().map(|log| log.inner).collect();
             ReceiptWithBloom {
                 receipt: Receipt {
@@ -225,18 +224,20 @@ impl From<BaseTransactionReceipt> for BaseReceiptEnvelope<alloy_primitives::Log>
             }
         }
 
-        match inner_envelope {
-            BaseReceiptEnvelope::Legacy(receipt) => Self::Legacy(convert_standard_receipt(receipt)),
-            BaseReceiptEnvelope::Eip2930(receipt) => {
-                Self::Eip2930(convert_standard_receipt(receipt))
+        match receipt {
+            BaseReceipt::Legacy(receipt) => {
+                Self::Legacy(convert_standard_receipt(receipt, logs_bloom))
             }
-            BaseReceiptEnvelope::Eip1559(receipt) => {
-                Self::Eip1559(convert_standard_receipt(receipt))
+            BaseReceipt::Eip2930(receipt) => {
+                Self::Eip2930(convert_standard_receipt(receipt, logs_bloom))
             }
-            BaseReceiptEnvelope::Eip7702(receipt) => {
-                Self::Eip7702(convert_standard_receipt(receipt))
+            BaseReceipt::Eip1559(receipt) => {
+                Self::Eip1559(convert_standard_receipt(receipt, logs_bloom))
             }
-            BaseReceiptEnvelope::Deposit(DepositReceiptWithBloom { logs_bloom, receipt }) => {
+            BaseReceipt::Eip7702(receipt) => {
+                Self::Eip7702(convert_standard_receipt(receipt, logs_bloom))
+            }
+            BaseReceipt::Deposit(receipt) => {
                 let consensus_logs = receipt.inner.logs.into_iter().map(|log| log.inner).collect();
                 let consensus_receipt = DepositReceiptWithBloom {
                     receipt: DepositReceipt {


### PR DESCRIPTION
## Summary
- remove the unused log generic from BaseReceiptEnvelope
- simplify receipt envelope conversions around the concrete Base log type