### PR TITLE
feat: IPC engine transport support to base-consensus

### DIFF
--- a/bin/consensus/src/cli.rs
+++ b/bin/consensus/src/cli.rs
@@ -16,6 +16,7 @@ use base_consensus_node::{
 use base_consensus_providers::OnlineBeaconClient;
 use base_consensus_registry::Registry;
 use clap::{Args, Parser, Subcommand};
+use eyre::Context;
 use strum::IntoEnumIterator;
 use tracing::{error, info, warn};
 use url::Url;
@@ -405,10 +406,12 @@ impl Node {
         if let Some(path) = self.safedb_path.clone() {
             builder = builder.with_safedb_path(path);
         }
-        builder.build().start().await.map_err(|e| {
-            error!(target: "rollup_node", error = %e, "Failed to start rollup node service");
-            eyre::eyre!("{e}")
-        })?;
+        builder.build().await.wrap_err("Failed to build rollup node")?.start().await.map_err(
+            |e| {
+                error!(target: "rollup_node", error = %e, "Failed to start rollup node service");
+                eyre::eyre!("{e}")
+            },
+        )?;
 
         Ok(())
     }

--- a/crates/consensus/engine/src/client.rs
+++ b/crates/consensus/engine/src/client.rs
@@ -1,11 +1,11 @@
 //! An Engine API Client.
 
-use std::{future::Future, sync::Arc};
+use std::{future::Future, io, sync::Arc};
 
 use alloy_eips::{BlockId, eip1898::BlockNumberOrTag};
 use alloy_network::{Ethereum, Network};
 use alloy_primitives::{Address, B256, BlockHash, Bytes, StorageKey};
-use alloy_provider::{EthGetBlock, Provider, RootProvider, RpcWithBlock};
+use alloy_provider::{EthGetBlock, IpcConnect, Provider, RootProvider, RpcWithBlock};
 use alloy_rpc_client::{ClientBuilder, RpcClient};
 use alloy_rpc_types_engine::{
     ClientVersionV1, ExecutionPayloadBodiesV1, ExecutionPayloadEnvelopeV2, ExecutionPayloadInputV2,
@@ -106,23 +106,37 @@ where
 {
     /// Creates a new RPC client for the given address and JWT secret.
     ///
-    /// Supports both `http://`/`https://` and `ws://`/`wss://` schemes. For WebSocket URLs a
-    /// [`JwtWsConnect`] is used, which mints a fresh JWT on every connect and reconnect attempt.
+    /// Supports `http://`/`https://`, `ws://`/`wss://`, and `file://` schemes. For WebSocket URLs
+    /// a [`JwtWsConnect`] is used, which mints a fresh JWT on every connect and reconnect attempt.
     /// This ensures the `iat` claim is always within the ±60-second window enforced by Reth and
     /// Geth, unlike a static token that would become stale after 60 seconds.
     ///
-    /// Returns an error if the WebSocket handshake fails (e.g. the engine is not yet reachable).
-    /// HTTP/HTTPS URLs are constructed lazily and never fail here.
+    /// For `file://` URLs, the client connects over IPC and the JWT secret is intentionally
+    /// unused because access control is provided by filesystem permissions on the socket path.
+    ///
+    /// Returns an error if the WebSocket handshake fails (e.g. the engine is not yet reachable),
+    /// or if the URL scheme is unsupported. HTTP/HTTPS URLs are constructed lazily and never fail
+    /// here.
     pub async fn rpc_client<N: Network>(
         addr: Url,
         jwt: JwtSecret,
     ) -> TransportResult<RootProvider<N>> {
         match addr.scheme() {
+            "file" => {
+                let path = addr.to_file_path().map_err(|_| {
+                    TransportErrorKind::custom(io::Error::new(
+                        io::ErrorKind::InvalidInput,
+                        "file:// engine URLs must contain an absolute filesystem path",
+                    ))
+                })?;
+                let client = ClientBuilder::default().ipc(IpcConnect::new(path)).await?;
+                Ok(RootProvider::<N>::new(client))
+            }
             "ws" | "wss" => {
                 let client = ClientBuilder::default().pubsub(JwtWsConnect::new(addr, jwt)).await?;
                 Ok(RootProvider::<N>::new(client))
             }
-            _ => {
+            "http" | "https" => {
                 let hyper_client =
                     Client::builder(TokioExecutor::new()).build_http::<Full<Bytes>>();
                 let auth_layer = AuthLayer::new(jwt);
@@ -132,6 +146,12 @@ where
                 let rpc_client = RpcClient::new(http_hyper, false);
                 Ok(RootProvider::<N>::new(rpc_client))
             }
+            scheme => Err(TransportErrorKind::custom(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!(
+                    "unsupported engine URL scheme '{scheme}'; expected http, https, ws, wss, or file"
+                ),
+            ))),
         }
     }
 }
@@ -409,6 +429,21 @@ mod tests {
             BaseEngineClient::<RootProvider, RootProvider<Base>>::rpc_client::<Base>(addr, jwt)
                 .await
                 .unwrap();
+    }
+
+    /// `rpc_client` with an unsupported URL scheme must fail with a clear validation error.
+    #[tokio::test]
+    async fn rpc_client_invalid_scheme_rejected() {
+        let addr: Url = "htpp://127.0.0.1:8551".parse().unwrap();
+        let jwt = JwtSecret::random();
+        let error =
+            BaseEngineClient::<RootProvider, RootProvider<Base>>::rpc_client::<Base>(addr, jwt)
+                .await
+                .unwrap_err();
+
+        assert!(error.to_string().contains(
+            "unsupported engine URL scheme 'htpp'; expected http, https, ws, wss, or file"
+        ));
     }
 
     /// `rpc_client` with a `ws://` URL must complete the WebSocket handshake at build time.

--- a/crates/consensus/service/src/service/builder.rs
+++ b/crates/consensus/service/src/service/builder.rs
@@ -3,19 +3,13 @@
 use std::{path::PathBuf, sync::Arc, time::Duration};
 
 use alloy_genesis::ChainConfig;
-use alloy_primitives::Bytes;
 use alloy_provider::RootProvider;
-use alloy_rpc_client::RpcClient;
-use alloy_transport_http::{
-    AuthLayer, Http, HyperClient,
-    hyper_util::{client::legacy::Client, rt::TokioExecutor},
-};
+use alloy_transport::TransportResult;
 use base_common_network::Base;
+use base_consensus_engine::BaseEngineClient;
 use base_consensus_genesis::RollupConfig;
 use base_consensus_providers::OnlineBeaconClient;
 use base_consensus_rpc::RpcBuilder;
-use http_body_util::Full;
-use tower::ServiceBuilder;
 use url::Url;
 
 use crate::{
@@ -88,6 +82,20 @@ pub struct RollupNodeBuilder {
 }
 
 impl RollupNodeBuilder {
+    fn derivation_l2_provider_url(mut url: Url) -> Url {
+        match url.scheme() {
+            "ws" => {
+                let _ = url.set_scheme("http");
+            }
+            "wss" => {
+                let _ = url.set_scheme("https");
+            }
+            _ => {}
+        }
+
+        url
+    }
+
     /// Creates a new [`RollupNodeBuilder`] with the given [`RollupConfig`].
     pub const fn new(
         config: RollupConfig,
@@ -151,17 +159,11 @@ impl RollupNodeBuilder {
 
     /// Assembles the [`RollupNode`] service.
     ///
-    /// ## Panics
-    ///
-    /// Panics if:
-    /// - The L1 provider RPC URL is not set.
-    /// - The L1 beacon API URL is not set.
-    /// - The L2 provider RPC URL is not set.
-    /// - The L2 engine URL is not set.
-    /// - The jwt secret is not set.
-    /// - The P2P config is not set.
-    /// - The rollup boost args are not set.
-    pub fn build(self) -> RollupNode {
+    /// Returns an error if the internal L2 provider transport cannot be constructed. WebSocket
+    /// URLs are normalized to HTTP(S) so the derivation pipeline's request/response L2 provider
+    /// remains lazy during startup. `file://` URLs still connect eagerly because IPC is an
+    /// explicit opt-in transport.
+    pub async fn build(self) -> TransportResult<RollupNode> {
         let mut l1_beacon = OnlineBeaconClient::new_http(self.l1_config_builder.beacon.to_string());
         if let Some(l1_slot_duration) = self.l1_config_builder.slot_duration_override {
             l1_beacon = l1_beacon.with_l1_slot_duration_override(l1_slot_duration);
@@ -180,35 +182,12 @@ impl RollupNodeBuilder {
             verifier_l1_confs: self.l1_config_builder.verifier_l1_confs,
         };
 
-        let jwt_secret = self.engine_config.l2_jwt_secret;
-        let hyper_client = Client::builder(TokioExecutor::new()).build_http::<Full<Bytes>>();
-
-        let auth_layer = AuthLayer::new(jwt_secret);
-        let service = ServiceBuilder::new().layer(auth_layer).service(hyper_client);
-
-        // Normalize ws:// -> http:// and wss:// -> https:// so the Hyper HTTP client
-        // can connect regardless of whether the engine URL uses a WebSocket scheme.
-        //
-        // This provider is used exclusively for request/response eth_* calls by the
-        // derivation pipeline (block fetching, receipt fetching, system config). It does
-        // not use subscriptions, so HTTP is sufficient and avoids an async WS handshake
-        // here. `build()` is sync; the engine client (built async in `node.rs`) is the
-        // one that uses the WS transport end-to-end.
-        let mut l2_http_url = self.engine_config.l2_url.clone();
-        match l2_http_url.scheme() {
-            "ws" => {
-                let _ = l2_http_url.set_scheme("http");
-            }
-            "wss" => {
-                let _ = l2_http_url.set_scheme("https");
-            }
-            _ => {}
-        }
-
-        let layer_transport = HyperClient::with_service(service);
-        let http_hyper = Http::with_client(layer_transport, l2_http_url);
-        let rpc_client = RpcClient::new(http_hyper, false);
-        let l2_provider = RootProvider::<Base>::new(rpc_client);
+        let l2_provider_url = Self::derivation_l2_provider_url(self.engine_config.l2_url.clone());
+        let l2_provider = BaseEngineClient::<RootProvider, RootProvider<Base>>::rpc_client::<Base>(
+            l2_provider_url,
+            self.engine_config.l2_jwt_secret,
+        )
+        .await?;
 
         let rollup_config = Arc::new(self.config);
 
@@ -221,7 +200,7 @@ impl RollupNodeBuilder {
             )
         });
 
-        RollupNode {
+        Ok(RollupNode {
             config: rollup_config,
             l1_config,
             l2_provider,
@@ -232,6 +211,88 @@ impl RollupNodeBuilder {
             sequencer_config,
             derivation_delegate_provider,
             safedb_path: self.safedb_path,
-        }
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        net::{IpAddr, Ipv4Addr},
+        sync::Arc,
+    };
+
+    use alloy_primitives::Address;
+    use alloy_rpc_types_engine::JwtSecret;
+    use base_consensus_disc::LocalNode;
+    use discv5::enr::k256::ecdsa::SigningKey;
+    use libp2p::Multiaddr;
+
+    use super::*;
+    use crate::NodeMode;
+
+    fn test_builder(l2_url: Url) -> RollupNodeBuilder {
+        let rollup_config = RollupConfig::default();
+        let l1_config_builder = L1ConfigBuilder {
+            chain_config: ChainConfig::default(),
+            trust_rpc: true,
+            beacon: Url::parse("http://127.0.0.1:5052").unwrap(),
+            rpc_url: Url::parse("http://127.0.0.1:8545").unwrap(),
+            slot_duration_override: None,
+            verifier_l1_confs: 0,
+        };
+        let engine_config = EngineConfig {
+            config: Arc::new(rollup_config.clone()),
+            l2_url,
+            l2_jwt_secret: JwtSecret::random(),
+            l1_url: Url::parse("http://127.0.0.1:8545").unwrap(),
+            mode: NodeMode::Validator,
+        };
+        let discovery_listen = LocalNode::new(
+            SigningKey::from_bytes((&[7_u8; 32]).into()).unwrap(),
+            IpAddr::V4(Ipv4Addr::LOCALHOST),
+            0,
+            0,
+        );
+        let p2p_config = NetworkConfig::new(
+            rollup_config.clone(),
+            discovery_listen,
+            "/ip4/127.0.0.1/tcp/0".parse::<Multiaddr>().unwrap(),
+            Address::ZERO,
+        );
+
+        RollupNodeBuilder::new(
+            rollup_config,
+            l1_config_builder,
+            true,
+            engine_config,
+            p2p_config,
+            None,
+        )
+    }
+
+    #[test]
+    fn derivation_l2_provider_url_normalizes_websocket_schemes() {
+        let ws_url = RollupNodeBuilder::derivation_l2_provider_url(
+            Url::parse("ws://127.0.0.1:8551/path?query=value").unwrap(),
+        );
+        assert_eq!(ws_url.as_str(), "http://127.0.0.1:8551/path?query=value");
+
+        let wss_url = RollupNodeBuilder::derivation_l2_provider_url(
+            Url::parse("wss://127.0.0.1:8551/path?query=value").unwrap(),
+        );
+        assert_eq!(wss_url.as_str(), "https://127.0.0.1:8551/path?query=value");
+
+        let file_url = Url::parse("file:///tmp/base-engine.ipc").unwrap();
+        let normalized_file_url = RollupNodeBuilder::derivation_l2_provider_url(file_url.clone());
+        assert_eq!(normalized_file_url, file_url);
+    }
+
+    #[tokio::test]
+    async fn build_keeps_ws_startup_lazy_for_derivation_provider() {
+        let rollup_node =
+            test_builder(Url::parse("ws://127.0.0.1:8551").unwrap()).build().await.unwrap();
+
+        assert_eq!(rollup_node.engine_config.l2_url.scheme(), "ws");
     }
 }

--- a/crates/utilities/jwt/src/validator.rs
+++ b/crates/utilities/jwt/src/validator.rs
@@ -1,8 +1,18 @@
 //! JWT validation utilities.
 
+#[cfg(feature = "engine-validation")]
+use alloy_provider::RootProvider;
 use alloy_rpc_types_engine::JwtSecret;
 #[cfg(feature = "engine-validation")]
-use tracing::debug;
+use backon::{ExponentialBuilder, Retryable};
+#[cfg(feature = "engine-validation")]
+use base_common_network::Base;
+#[cfg(feature = "engine-validation")]
+use base_common_provider::BaseEngineApi;
+#[cfg(feature = "engine-validation")]
+use base_consensus_engine::BaseEngineClient;
+#[cfg(feature = "engine-validation")]
+use tracing::{debug, error};
 
 #[cfg(feature = "engine-validation")]
 use crate::JwtValidationError;
@@ -64,8 +74,11 @@ impl JwtValidator {
     /// on authentication errors (invalid JWT signature).
     ///
     /// # Arguments
-    /// * `engine_url` - The URL of the engine API endpoint. Supports both HTTP(S) and WS(S)
-    ///   URLs. WebSocket URLs are automatically converted to HTTP for validation.
+    /// * `engine_url` - The URL of the engine API endpoint. Supports HTTP(S), WS(S), and
+    ///   `file://` URLs. WebSocket URLs are normalized to HTTP(S) for validation because the
+    ///   engine capability exchange is not served over WS. In the IPC case this checks engine
+    ///   reachability and capability exchange over the socket path; JWT authentication is not
+    ///   exercised because IPC access is gated by filesystem permissions instead.
     ///
     /// # Returns
     /// * `Ok(JwtSecret)` - The validated JWT secret
@@ -75,26 +88,20 @@ impl JwtValidator {
         self,
         engine_url: url::Url,
     ) -> Result<JwtSecret, JwtValidationError> {
-        use alloy_provider::RootProvider;
-        use backon::{ExponentialBuilder, Retryable};
-        use base_common_network::Base;
-        use base_common_provider::BaseEngineApi;
-        use base_consensus_engine::BaseEngineClient;
-        use tracing::{debug, error};
-
-        // Convert WebSocket URLs to HTTP for validation.
-        // The underlying engine client only supports HTTP transport, so we convert
-        // ws:// -> http:// and wss:// -> https:// for the capability exchange.
-        let http_url = Self::normalize_engine_url(engine_url)?;
-
-        let engine = BaseEngineClient::<RootProvider, RootProvider<Base>>::rpc_client::<Base>(
-            http_url,
-            self.secret,
-        )
-        .await
-        .map_err(|e| JwtValidationError::CapabilityExchange(e.to_string()))?;
+        let engine_url = Self::normalize_engine_url(engine_url)?;
 
         let exchange = || async {
+            // Recreate the client on every retry because the IPC transport connects eagerly.
+            // This allows startup retries to cover the initial socket connect when the engine
+            // listener is not ready yet. HTTP URLs are lazy and would not need this, but
+            // recreating them is harmless.
+            let engine = BaseEngineClient::<RootProvider, RootProvider<Base>>::rpc_client::<Base>(
+                engine_url.clone(),
+                self.secret,
+            )
+            .await
+            .map_err(|e| eyre::eyre!(JwtValidationError::CapabilityExchange(e.to_string())))?;
+
             match <RootProvider<Base> as BaseEngineApi>::exchange_capabilities(&engine, vec![])
                 .await
             {
@@ -138,13 +145,13 @@ impl JwtValidator {
     ///
     /// - `ws://` becomes `http://`
     /// - `wss://` becomes `https://`
-    /// - `http://` and `https://` are returned unchanged
+    /// - `http://`, `https://`, and `file://` are returned unchanged
     ///
     /// # Errors
     /// Returns an error if the URL scheme is unsupported.
     fn normalize_engine_url(mut url: url::Url) -> Result<url::Url, JwtValidationError> {
         match url.scheme() {
-            "http" | "https" => Ok(url),
+            "http" | "https" | "file" => Ok(url),
             "ws" => {
                 debug!("Converting WebSocket URL to HTTP for engine validation");
                 url.set_scheme("http").map_err(|()| {
@@ -164,7 +171,7 @@ impl JwtValidator {
                 Ok(url)
             }
             scheme => Err(JwtValidationError::CapabilityExchange(format!(
-                "Unsupported URL scheme '{scheme}'. Expected http, https, ws, or wss"
+                "Unsupported URL scheme '{scheme}'. Expected http, https, ws, wss, or file"
             ))),
         }
     }
@@ -172,6 +179,8 @@ impl JwtValidator {
 
 #[cfg(all(test, feature = "engine-validation"))]
 mod tests {
+    use std::env;
+
     use url::Url;
 
     use super::*;
@@ -190,6 +199,14 @@ mod tests {
         let url = Url::parse("https://localhost:8551").unwrap();
         let result = JwtValidator::normalize_engine_url(url).unwrap();
         assert_eq!(result.scheme(), "https");
+    }
+
+    #[test]
+    fn normalize_file_url_unchanged() {
+        let path = env::temp_dir().join("jwt-validator-engine.ipc");
+        let url = Url::from_file_path(&path).unwrap();
+        let result = JwtValidator::normalize_engine_url(url.clone()).unwrap();
+        assert_eq!(result, url);
     }
 
     #[test]

--- a/devnet/src/l2/in_process_consensus.rs
+++ b/devnet/src/l2/in_process_consensus.rs
@@ -185,7 +185,7 @@ impl InProcessConsensus {
             });
         }
 
-        let node = builder.build();
+        let node = builder.build().await.wrap_err("Failed to build consensus node")?;
 
         let mode = config.mode;
         let (startup_tx, startup_rx) = tokio::sync::oneshot::channel();


### PR DESCRIPTION
## Summary
- add `file://` engine transport support to `base-consensus` via alloy IPC
- retry JWT capability validation across the initial IPC connect so startup races do not fail fast
- keep Docker devnet on ws/http by default while leaving the IPC settings commented nearby for local validation