### PR TITLE
fix(devnet): remove dead_code allows on L1 lighthouse stack

### DIFF
--- a/devnet/src/l1/lighthouse.rs
+++ b/devnet/src/l1/lighthouse.rs
@@ -8,6 +8,7 @@ use testcontainers::{
     core::{IntoContainerPort, Mount, WaitFor},
     runners::AsyncRunner,
 };
+use url::Host;
 
 use super::config::L1ContainerConfig;
 use crate::{
@@ -95,9 +96,7 @@ impl LighthouseBeaconContainer {
 /// Lighthouse validator client container wrapper.
 #[derive(Debug)]
 pub struct LighthouseValidatorContainer {
-    #[allow(dead_code)]
     container: ContainerAsync<GenericImage>,
-    #[allow(dead_code)]
     name: String,
 }
 
@@ -143,6 +142,16 @@ impl LighthouseValidatorContainer {
             .await?;
 
         Ok(Self { container, name })
+    }
+
+    /// Returns the Docker/container name assigned to this validator client.
+    pub fn container_name(&self) -> &str {
+        &self.name
+    }
+
+    /// Returns the host identifier used to reach this container from the test harness.
+    pub async fn host(&self) -> Result<Host> {
+        self.container.get_host().await.map_err(Into::into)
     }
 }
 

--- a/devnet/src/l1/stack.rs
+++ b/devnet/src/l1/stack.rs
@@ -1,6 +1,6 @@
 //! L1 stack orchestration (Reth + Lighthouse).
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use eyre::{Result, WrapErr};
 use url::Url;
@@ -27,9 +27,7 @@ pub struct L1StackConfig {
 pub struct L1Stack {
     reth: RethContainer,
     beacon: LighthouseBeaconContainer,
-    #[allow(dead_code)]
     validator: LighthouseValidatorContainer,
-    #[allow(dead_code)]
     jwt_path: PathBuf,
 }
 
@@ -81,6 +79,16 @@ impl L1Stack {
     /// Returns a reference to the Lighthouse beacon container.
     pub const fn beacon(&self) -> &LighthouseBeaconContainer {
         &self.beacon
+    }
+
+    /// Returns a reference to the Lighthouse validator container.
+    pub const fn validator(&self) -> &LighthouseValidatorContainer {
+        &self.validator
+    }
+
+    /// Path to the JWT secret file shared between Reth and Lighthouse.
+    pub fn jwt_path(&self) -> &Path {
+        &self.jwt_path
     }
 
     /// Returns the public RPC URL of the Reth container.


### PR DESCRIPTION
- Remove `#[allow(dead_code)]` on `LighthouseValidatorContainer` and `L1Stack` by exposing the data through small, intentional APIs.
- `LighthouseValidatorContainer`: add `container_name()` and `host()` (mirrors the beacon container pattern; `host()` uses the underlying testcontainers handle).
- `L1Stack`: add `validator()` and `jwt_path()` accessors so the validator client and JWT file path are part of the public surface.
