### PR TITLE
feat: scaffold unified base binary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2684,6 +2684,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "base-bin"
+version = "0.0.0"
+dependencies = [
+ "base-cli-utils",
+ "base-common-chains",
+ "clap",
+ "eyre",
+ "figment",
+ "serde",
+ "tracing",
+]
+
+[[package]]
 name = "base-blobs"
 version = "0.0.0"
 dependencies = [
@@ -7010,7 +7023,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ab67060fc6b8ef687992d439ca0fa36e7ed17e9a0b16b25b601e8757df720de"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -8043,6 +8056,22 @@ name = "fiat-crypto"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+
+[[package]]
+name = "figment"
+version = "0.10.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cb01cd46b0cf372153850f4c6c272d9cbea2da513e07538405148f95bd789f3"
+dependencies = [
+ "atomic",
+ "parking_lot",
+ "pear",
+ "serde",
+ "tempfile",
+ "toml 0.8.23",
+ "uncased",
+ "version_check",
+]
 
 [[package]]
 name = "filedescriptor"
@@ -9719,6 +9748,12 @@ dependencies = [
  "uuid",
  "wiremock",
 ]
+
+[[package]]
+name = "inlinable_string"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8fae54786f62fb2918dcfae3d568594e50eb9b5c25bf04371af6fe7516452fb"
 
 [[package]]
 name = "inotify"
@@ -12582,6 +12617,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "pear"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdeeaa00ce488657faba8ebf44ab9361f9365a97bd39ffb8a60663f57ff4b467"
+dependencies = [
+ "inlinable_string",
+ "pear_codegen",
+ "yansi",
+]
+
+[[package]]
+name = "pear_codegen"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bab5b985dc082b345f812b7df84e1bef27e7207b39e448439ba8bd69c93f147"
+dependencies = [
+ "proc-macro2",
+ "proc-macro2-diagnostics",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "pem"
 version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13133,6 +13191,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "proc-macro2-diagnostics"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "version_check",
+ "yansi",
 ]
 
 [[package]]
@@ -20227,6 +20298,15 @@ name = "unarray"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
+name = "uncased"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1b88fcfe09e89d3866a5c11019378088af2d24c3fbd4f0543f96b479ec90697"
+dependencies = [
+ "version_check",
+]
 
 [[package]]
 name = "unicase"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -545,6 +545,7 @@ thiserror = { version = "2.0", default-features = false }
 either = { version = "1.15.0", default-features = false }
 dotenvy = { version = "0.15.7", default-features = false }
 derive_more = { version = "2.1.0", default-features = false }
+figment = { version = "0.10.19", default-features = false }
 
 # database
 sqlx = { version = "0.8", default-features = false }

--- a/bin/base/Cargo.toml
+++ b/bin/base/Cargo.toml
@@ -1,0 +1,35 @@
+[package]
+name = "base-bin"
+description = "Unified Base node binary"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+
+[[bin]]
+name = "base"
+path = "src/main.rs"
+
+[lints]
+workspace = true
+
+[dependencies]
+# workspace
+base-cli-utils.workspace = true
+base-common-chains.workspace = true
+
+# cli
+clap = { workspace = true, features = ["env"] }
+
+# tracing
+tracing = { workspace = true, features = ["std"] }
+
+# misc
+eyre.workspace = true
+serde = { workspace = true, features = ["derive"] }
+figment = { workspace = true, features = ["env", "toml"] }
+
+[dev-dependencies]
+figment = { workspace = true, features = ["test"] }

--- a/bin/base/README.md
+++ b/bin/base/README.md
@@ -1,0 +1,33 @@
+# `base`
+
+Minimal scaffolding for the unified Base node binary.
+
+The current implementation only does four things:
+
+- parses the public `base` CLI surface for `--chain` and `node rpc`
+- initializes workspace-standard logging
+- initializes the Prometheus recorder when metrics are enabled
+- logs `Hello, I'm running this chain` with the resolved chain config
+
+Supported CLI forms:
+
+```text
+base node rpc
+base --chain sepolia node rpc
+base -c sepolia node rpc
+base --chain zeronet node rpc
+base --chain ./chain.toml node rpc
+base -c ./chain.toml node rpc
+```
+
+Chain selection currently supports:
+
+- built-in names: `mainnet`, `sepolia`, `zeronet`
+- TOML files with optional fields:
+- TOML files for custom chains:
+
+```toml
+name = "custom-chain"
+l2_chain_id = 84532
+l1_chain_id = 11155111
+```

--- a/bin/base/src/app.rs
+++ b/bin/base/src/app.rs
@@ -1,0 +1,36 @@
+use base_cli_utils::{LogConfig, MetricsConfig};
+use eyre::WrapErr;
+
+use crate::{cli::BaseCli, config::ChainResolver};
+
+/// Runs the `base` binary.
+#[derive(Debug, Clone)]
+pub(crate) struct BaseApp {
+    /// Parsed CLI input.
+    pub cli: BaseCli,
+}
+
+impl BaseApp {
+    /// Creates a new app from parsed CLI input.
+    pub(crate) const fn new(cli: BaseCli) -> Self {
+        Self { cli }
+    }
+
+    /// Runs the requested command.
+    pub(crate) fn run(self) -> eyre::Result<()> {
+        let BaseCli { chain, logging, metrics, command } = self.cli;
+
+        LogConfig::from(logging)
+            .init_tracing_subscriber()
+            .wrap_err("failed to initialize tracing")?;
+
+        MetricsConfig::from(metrics)
+            .init_with(|| {
+                base_cli_utils::register_version_metrics!();
+            })
+            .wrap_err("failed to install Prometheus recorder")?;
+
+        let resolved_chain = ChainResolver::new(chain).resolve()?;
+        command.run(resolved_chain)
+    }
+}

--- a/bin/base/src/cli.rs
+++ b/bin/base/src/cli.rs
@@ -1,0 +1,140 @@
+use clap::{Args, Parser, Subcommand};
+use tracing::info;
+
+use crate::config::{ChainArg, ResolvedChainConfig};
+
+base_cli_utils::define_log_args!("BASE_NODE");
+base_cli_utils::define_metrics_args!("BASE_NODE", 9090);
+
+/// The `base` CLI.
+#[derive(Parser, Clone, Debug)]
+#[command(
+    author,
+    version = env!("CARGO_PKG_VERSION"),
+    styles = base_cli_utils::CliStyles::init(),
+    about,
+    long_about = None
+)]
+pub(crate) struct BaseCli {
+    /// Chain selection.
+    #[arg(long, short = 'c', global = true, default_value = "mainnet", env = "BASE_CHAIN")]
+    pub(crate) chain: ChainArg,
+
+    /// Logging configuration.
+    #[command(flatten)]
+    pub(crate) logging: LogArgs,
+
+    /// Metrics configuration.
+    #[command(flatten)]
+    pub(crate) metrics: MetricsArgs,
+
+    /// The command to run.
+    #[command(subcommand)]
+    pub(crate) command: BaseCommand,
+}
+
+/// Top-level commands for `base`.
+#[derive(Subcommand, Clone, Debug)]
+#[non_exhaustive]
+pub(crate) enum BaseCommand {
+    /// Start the integrated Base node.
+    #[command(name = "node")]
+    Node(NodeArgs),
+}
+
+impl BaseCommand {
+    /// Runs the selected top-level command.
+    pub(crate) fn run(self, resolved_chain: ResolvedChainConfig) -> eyre::Result<()> {
+        match self {
+            Self::Node(node) => node.run(resolved_chain),
+        }
+    }
+}
+
+/// Arguments for `base node`.
+#[derive(Args, Clone, Debug)]
+pub(crate) struct NodeArgs {
+    /// The node flavor to run.
+    #[command(subcommand)]
+    pub(crate) command: NodeSubcommand,
+}
+
+impl NodeArgs {
+    /// Runs the selected `node` subcommand.
+    pub(crate) fn run(self, resolved_chain: ResolvedChainConfig) -> eyre::Result<()> {
+        match self.command {
+            NodeSubcommand::Rpc(rpc) => rpc.run(resolved_chain),
+        }
+    }
+}
+
+/// Subcommands for `base node`.
+#[derive(Subcommand, Clone, Debug)]
+pub(crate) enum NodeSubcommand {
+    /// Run the integrated node in RPC mode.
+    #[command(name = "rpc")]
+    Rpc(RpcCommand),
+}
+
+/// Arguments for `base node rpc`.
+#[derive(Args, Clone, Debug, Default)]
+pub(crate) struct RpcCommand;
+
+impl RpcCommand {
+    /// Runs the `rpc` flavor.
+    pub(crate) fn run(self, resolved_chain: ResolvedChainConfig) -> eyre::Result<()> {
+        info!(chain = ?resolved_chain, "Hello, I'm running this chain");
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::ffi::OsStr;
+
+    use clap::{CommandFactory, Parser};
+
+    use super::*;
+    use crate::config::BuiltInChain;
+
+    #[test]
+    fn parses_default_chain_for_node_rpc() {
+        let cli = BaseCli::parse_from(["base", "node", "rpc"]);
+
+        assert!(matches!(cli.chain, ChainArg::BuiltIn(BuiltInChain::Mainnet)));
+        assert!(matches!(cli.command, BaseCommand::Node(_)));
+    }
+
+    #[test]
+    fn parses_named_chain_selector() {
+        let cli = BaseCli::parse_from(["base", "-c", "sepolia", "node", "rpc"]);
+
+        assert!(matches!(cli.chain, ChainArg::BuiltIn(BuiltInChain::Sepolia)));
+    }
+
+    #[test]
+    fn parses_path_chain_selector() {
+        let cli = BaseCli::parse_from(["base", "--chain", "./chain.toml", "node", "rpc"]);
+
+        assert!(matches!(cli.chain, ChainArg::File(_)));
+    }
+
+    #[test]
+    fn chain_arg_uses_base_chain_env_var() {
+        let command = BaseCli::command();
+        let chain_arg =
+            command.get_arguments().find(|arg| arg.get_long() == Some("chain")).unwrap();
+
+        assert_eq!(chain_arg.get_env(), Some(OsStr::new("BASE_CHAIN")));
+    }
+
+    #[test]
+    fn rejects_multiple_chain_selectors() {
+        let err =
+            BaseCli::try_parse_from(["base", "-c", "mainnet", "--chain", "sepolia", "node", "rpc"])
+                .unwrap_err();
+
+        let rendered = err.to_string();
+        assert!(rendered.contains("cannot be used multiple times"));
+    }
+}

--- a/bin/base/src/config.rs
+++ b/bin/base/src/config.rs
@@ -1,0 +1,278 @@
+use std::{
+    fmt,
+    path::{Path, PathBuf},
+    str::FromStr,
+};
+
+use base_common_chains::ChainConfig as BuiltInChainConfig;
+use eyre::WrapErr;
+use figment::{
+    Figment,
+    providers::{Env, Format, Serialized, Toml},
+};
+use serde::{Deserialize, Serialize};
+
+/// Prefix for chain configuration environment variables.
+pub(crate) const BASE_CHAIN_ENV_PREFIX: &str = "BASE_CHAIN_";
+
+/// A built-in chain supported by the `base` binary.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub(crate) enum BuiltInChain {
+    /// Base mainnet.
+    Mainnet,
+    /// Base sepolia.
+    Sepolia,
+    /// Base zeronet.
+    Zeronet,
+}
+
+impl BuiltInChain {
+    /// Returns the canonical CLI name for this chain.
+    pub(crate) const fn as_str(self) -> &'static str {
+        match self {
+            Self::Mainnet => "mainnet",
+            Self::Sepolia => "sepolia",
+            Self::Zeronet => "zeronet",
+        }
+    }
+
+    /// Returns the built-in chain config backing this selection.
+    pub(crate) const fn chain_config(self) -> &'static BuiltInChainConfig {
+        match self {
+            Self::Mainnet => BuiltInChainConfig::mainnet(),
+            Self::Sepolia => BuiltInChainConfig::sepolia(),
+            Self::Zeronet => BuiltInChainConfig::zeronet(),
+        }
+    }
+}
+
+impl fmt::Display for BuiltInChain {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl FromStr for BuiltInChain {
+    type Err = String;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value.to_ascii_lowercase().as_str() {
+            "mainnet" => Ok(Self::Mainnet),
+            "sepolia" => Ok(Self::Sepolia),
+            "zeronet" => Ok(Self::Zeronet),
+            _ => Err(format!(
+                "unsupported built-in chain `{value}`; expected one of mainnet, sepolia, zeronet"
+            )),
+        }
+    }
+}
+
+/// CLI input for the root `--chain` flag.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum ChainArg {
+    /// Use one of the built-in static chains.
+    BuiltIn(BuiltInChain),
+    /// Load chain settings from a TOML file.
+    File(PathBuf),
+}
+
+impl Default for ChainArg {
+    fn default() -> Self {
+        Self::BuiltIn(BuiltInChain::Mainnet)
+    }
+}
+
+impl FromStr for ChainArg {
+    type Err = std::convert::Infallible;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        Ok(BuiltInChain::from_str(value)
+            .map_or_else(|_| Self::File(PathBuf::from(value)), Self::BuiltIn))
+    }
+}
+
+/// The concrete source of a resolved chain config.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) enum ResolvedChainSource {
+    /// The config came from a built-in static chain.
+    BuiltIn(BuiltInChain),
+    /// The config came from a TOML file.
+    File(PathBuf),
+}
+
+/// The resolved chain config used by the `base` binary.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct ResolvedChainConfig {
+    /// Human-readable chain name.
+    pub(crate) name: String,
+    /// L2 chain ID.
+    pub(crate) l2_chain_id: u64,
+    /// L1 chain ID.
+    pub(crate) l1_chain_id: u64,
+    /// Where this config came from.
+    pub(crate) source: ResolvedChainSource,
+}
+
+/// The subset of chain settings merged from built-ins, TOML, and env.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct ResolvedChainValues {
+    /// Human-readable chain name.
+    pub(crate) name: String,
+    /// L2 chain ID.
+    pub(crate) l2_chain_id: u64,
+    /// L1 chain ID.
+    pub(crate) l1_chain_id: u64,
+}
+
+impl ResolvedChainValues {
+    /// Creates resolved values from a built-in chain.
+    pub(crate) fn from_builtin(chain: BuiltInChain) -> Self {
+        let config = chain.chain_config();
+        Self {
+            name: chain.as_str().to_owned(),
+            l2_chain_id: config.chain_id,
+            l1_chain_id: config.l1_chain_id,
+        }
+    }
+}
+
+impl ResolvedChainConfig {
+    /// Creates a resolved config from merged values and an explicit source.
+    pub(crate) fn new(values: ResolvedChainValues, source: ResolvedChainSource) -> Self {
+        Self {
+            name: values.name,
+            l2_chain_id: values.l2_chain_id,
+            l1_chain_id: values.l1_chain_id,
+            source,
+        }
+    }
+}
+
+/// Resolves a chain selection into a concrete config.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ChainResolver {
+    /// The requested chain input.
+    pub(crate) chain: ChainArg,
+}
+
+impl ChainResolver {
+    /// Creates a new chain resolver.
+    pub(crate) const fn new(chain: ChainArg) -> Self {
+        Self { chain }
+    }
+
+    /// Resolves the configured chain input.
+    pub(crate) fn resolve(&self) -> eyre::Result<ResolvedChainConfig> {
+        match &self.chain {
+            ChainArg::BuiltIn(chain) => {
+                let figment =
+                    Figment::from(Serialized::defaults(ResolvedChainValues::from_builtin(*chain)))
+                        .merge(Env::prefixed(BASE_CHAIN_ENV_PREFIX));
+                Self::extract(figment, ResolvedChainSource::BuiltIn(*chain))
+            }
+            ChainArg::File(path) => Self::resolve_file(path),
+        }
+    }
+
+    /// Resolves a chain config from a TOML file.
+    pub(crate) fn resolve_file(path: &Path) -> eyre::Result<ResolvedChainConfig> {
+        let figment =
+            Figment::new().merge(Toml::file(path)).merge(Env::prefixed(BASE_CHAIN_ENV_PREFIX));
+        Self::extract(figment, ResolvedChainSource::File(path.to_path_buf()))
+    }
+
+    /// Extracts the merged chain values into the public resolved config.
+    pub(crate) fn extract(
+        figment: Figment,
+        source: ResolvedChainSource,
+    ) -> eyre::Result<ResolvedChainConfig> {
+        let values = figment.extract::<ResolvedChainValues>().wrap_err_with(|| match &source {
+            ResolvedChainSource::BuiltIn(chain) => {
+                format!("failed to resolve chain config for built-in chain `{chain}`")
+            }
+            ResolvedChainSource::File(path) => {
+                format!("failed to resolve chain config from {}", path.display())
+            }
+        })?;
+
+        Ok(ResolvedChainConfig::new(values, source))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use figment::Jail;
+
+    use super::*;
+
+    fn with_cleared_env(test: impl FnOnce(&mut Jail) -> figment::Result<()>) {
+        Jail::expect_with(|jail| {
+            jail.clear_env();
+            test(jail)
+        });
+    }
+
+    #[test]
+    fn resolves_mainnet_builtin() {
+        with_cleared_env(|_| {
+            let resolved =
+                ChainResolver::new(ChainArg::BuiltIn(BuiltInChain::Mainnet)).resolve().unwrap();
+
+            assert_eq!(resolved.name, "mainnet");
+            assert_eq!(resolved.l2_chain_id, 8453);
+            assert_eq!(resolved.l1_chain_id, 1);
+            assert_eq!(resolved.source, ResolvedChainSource::BuiltIn(BuiltInChain::Mainnet));
+
+            Ok(())
+        });
+    }
+
+    #[test]
+    fn resolves_sepolia_builtin() {
+        with_cleared_env(|_| {
+            let resolved =
+                ChainResolver::new(ChainArg::BuiltIn(BuiltInChain::Sepolia)).resolve().unwrap();
+
+            assert_eq!(resolved.name, "sepolia");
+            assert_eq!(resolved.l2_chain_id, 84532);
+            assert_eq!(resolved.l1_chain_id, 11155111);
+
+            Ok(())
+        });
+    }
+
+    #[test]
+    fn resolves_zeronet_builtin() {
+        with_cleared_env(|_| {
+            let resolved =
+                ChainResolver::new(ChainArg::BuiltIn(BuiltInChain::Zeronet)).resolve().unwrap();
+
+            assert_eq!(resolved.name, "zeronet");
+            assert_eq!(resolved.l2_chain_id, 763360);
+            assert_eq!(resolved.source, ResolvedChainSource::BuiltIn(BuiltInChain::Zeronet));
+
+            Ok(())
+        });
+    }
+
+    #[test]
+    fn resolves_custom_toml_file() {
+        with_cleared_env(|jail| {
+            let path = jail.directory().join("chain.toml");
+            jail.create_file(
+                &path,
+                "name = \"custom-chain\"\nl2_chain_id = 999\nl1_chain_id = 11155111\n",
+            )?;
+
+            let resolved = ChainResolver::resolve_file(&path).unwrap();
+
+            assert_eq!(resolved.name, "custom-chain");
+            assert_eq!(resolved.l2_chain_id, 999);
+            assert_eq!(resolved.l1_chain_id, 11155111);
+            assert_eq!(resolved.source, ResolvedChainSource::File(path));
+
+            Ok(())
+        });
+    }
+}

--- a/bin/base/src/main.rs
+++ b/bin/base/src/main.rs
@@ -1,0 +1,22 @@
+#![doc = include_str!("../README.md")]
+#![doc(issue_tracker_base_url = "https://github.com/base/base/issues/")]
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
+
+use clap::Parser;
+
+mod app;
+mod cli;
+mod config;
+
+use app::BaseApp;
+use cli::BaseCli;
+
+fn main() {
+    base_cli_utils::init_common!();
+
+    if let Err(err) = BaseApp::new(BaseCli::parse()).run() {
+        eprintln!("Error: {err:?}");
+        std::process::exit(1);
+    }
+}


### PR DESCRIPTION
## Summary
- add a new `bin/base` workspace package that builds a single `base` binary with a local library target
- wire minimal logging, Prometheus bootstrap, root chain selection, and `base node rpc` CLI parsing
- add a small custom-chain TOML model and log the resolved chain config for the initial hello-path

## Testing
- cargo test -p base-bin
