### PR TITLE
chore: reduce logging of flashblocks caching cases

### DIFF
--- a/crates/execution/flashblocks/src/processor.rs
+++ b/crates/execution/flashblocks/src/processor.rs
@@ -158,15 +158,20 @@ where
                         {
                             return;
                         }
-                        info!("waiting for first Flashblock");
                         // we should ignore this error since it doesn't necessarily indicate a problem
                         return;
                     }
                     _ => {}
                 }
 
-                error!(message = "could not process Flashblock", error = %e);
-                Metrics::block_processing_error().increment(1);
+                // skip logging expected caching case
+                if !matches!(
+                    e,
+                    StateProcessorError::Provider(ProviderError::MissingCanonicalHeader { .. })
+                ) {
+                    error!(message = "could not process Flashblock", error = %e);
+                    Metrics::block_processing_error().increment(1);
+                }
             }
         }
     }


### PR DESCRIPTION
Reduces logging while syncing. Skip logging in cases where flashblock processing fails during syncing. These flashblocks are cached and replayed when we receive the parent canonical block.