### PR TITLE
fix: implicit gas handling in azul

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4343,6 +4343,7 @@ dependencies = [
  "alloy-signer",
  "base-common-consensus",
  "base-common-network",
+ "base-common-rpc-types",
  "base-common-rpc-types-engine",
  "base-engine-tree",
  "base-execution-chainspec",

--- a/crates/client/flashblocks-node/src/test_harness.rs
+++ b/crates/client/flashblocks-node/src/test_harness.rs
@@ -34,7 +34,7 @@ use base_node_runner::{
         NODE_STARTUP_DELAY_MS, TestHarness, init_silenced_tracing,
     },
 };
-use base_test_utils::{Account, build_test_genesis};
+use base_test_utils::{Account, build_test_genesis_azul};
 use derive_more::Deref;
 use eyre::Result;
 use reth_chain_state::CanonStateSubscriptions;
@@ -239,7 +239,7 @@ impl FlashblocksLocalNode {
 
     async fn with_options(process_canonical: bool) -> Result<Self> {
         // Build default chain spec programmatically
-        let genesis = build_test_genesis();
+        let genesis = build_test_genesis_azul();
         let chain_spec = Arc::new(BaseChainSpec::from_genesis(genesis));
 
         let extension = FlashblocksTestExtension::new(process_canonical);
@@ -298,7 +298,7 @@ impl FlashblocksHarness {
         init_silenced_tracing();
 
         // Build default chain spec programmatically
-        let genesis = build_test_genesis();
+        let genesis = build_test_genesis_azul();
         let chain_spec = Arc::new(BaseChainSpec::from_genesis(genesis));
 
         // Create the extension and keep a reference to get parts after launch

--- a/crates/client/flashblocks-node/tests/azul.rs
+++ b/crates/client/flashblocks-node/tests/azul.rs
@@ -123,7 +123,7 @@ async fn azul_eth_call_without_data_accepts_implicit_gas_limit() -> Result<()> {
     let result = harness
         .provider()
         .call(transfer_request_without_gas())
-        .block(BlockNumberOrTag::Pending.into())
+        .block(BlockNumberOrTag::Latest.into())
         .await?;
     assert!(result.is_empty(), "plain eth_call to EOA should return empty bytes");
 
@@ -140,7 +140,7 @@ async fn azul_eth_call_with_data_to_contract_accepts_implicit_gas_limit() -> Res
         .to(address!("0000000000000000000000000000000000000004"))
         .input(TransactionInput::new(calldata.clone()));
 
-    let result = harness.provider().call(request).block(BlockNumberOrTag::Pending.into()).await?;
+    let result = harness.provider().call(request).block(BlockNumberOrTag::Latest.into()).await?;
     assert_eq!(result, calldata);
 
     Ok(())

--- a/crates/client/flashblocks-node/tests/flashblocks_rpc.rs
+++ b/crates/client/flashblocks-node/tests/flashblocks_rpc.rs
@@ -619,7 +619,7 @@ async fn test_eth_simulate_v1() -> Result<()> {
         block_state_calls: vec![SimBlock {
             calls: vec![
                 // read count1() from counter contract
-                setup.count1().into(),
+                setup.count1().gas_limit(100_000).into(),
                 // increment() value in contract
                 BaseTransactionRequest::default()
                     .from(address!("0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266"))
@@ -629,7 +629,7 @@ async fn test_eth_simulate_v1() -> Result<()> {
                     .input(TransactionInput::new(bytes!("0xd09de08a")))
                     .into(),
                 // read count1() from counter contract
-                setup.count1().into(),
+                setup.count1().gas_limit(100_000).into(),
             ],
             block_overrides: None,
             state_overrides: None,

--- a/crates/client/flashblocks-node/tests/gas_limit_cap.rs
+++ b/crates/client/flashblocks-node/tests/gas_limit_cap.rs
@@ -13,7 +13,7 @@ use std::sync::Arc;
 use alloy_consensus::{SignableTransaction, Transaction};
 use alloy_eips::{BlockNumberOrTag, eip2718::Encodable2718};
 use alloy_network::TransactionBuilder;
-use alloy_primitives::{Bytes, address};
+use alloy_primitives::{Bytes, address, bytes};
 use alloy_provider::Provider;
 use alloy_rpc_types_eth::TransactionInput;
 use alloy_signer::SignerSync;
@@ -48,6 +48,10 @@ fn transfer_request_without_gas() -> BaseTransactionRequest {
 
 fn transfer_request_with_data_without_gas() -> BaseTransactionRequest {
     transfer_request_without_gas().input(TransactionInput::new(Bytes::from_static(&[0x00])))
+}
+
+fn transfer_request_with_gas_and_data() -> BaseTransactionRequest {
+    transfer_request_with_data_without_gas().gas_limit(100_000)
 }
 
 #[tokio::test]
@@ -102,6 +106,17 @@ async fn azul_estimate_gas_with_data_accepts_implicit_gas_limit() -> Result<()> 
 }
 
 #[tokio::test]
+async fn azul_estimate_gas_with_explicit_gas_and_data_passes() -> Result<()> {
+    let chain_spec = Arc::new(BaseChainSpec::from_genesis(build_test_genesis_azul()));
+    let harness = TestHarnessBuilder::new().with_chain_spec(chain_spec).build().await?;
+    let gas = harness.provider().estimate_gas(transfer_request_with_gas_and_data()).await?;
+    assert!(gas > 21_000, "tx with calldata should exceed plain transfer gas");
+    assert!(gas <= 100_000, "estimate should respect the provided gas cap");
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn azul_eth_call_without_data_accepts_implicit_gas_limit() -> Result<()> {
     let chain_spec = Arc::new(BaseChainSpec::from_genesis(build_test_genesis_azul()));
     let harness = TestHarnessBuilder::new().with_chain_spec(chain_spec).build().await?;
@@ -148,6 +163,25 @@ async fn azul_fill_transaction_with_data_accepts_implicit_gas_limit() -> Result<
     let harness = TestHarnessBuilder::new().with_chain_spec(chain_spec).build().await?;
     let filled =
         harness.provider().fill_transaction(transfer_request_with_data_without_gas()).await?;
+    assert!(!filled.raw.is_empty(), "filled raw transaction should not be empty");
+    assert!(filled.tx.gas_limit() > 21_000, "tx with calldata should exceed plain transfer gas");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn azul_fill_transaction_long_calldata_accepts_implicit_gas_limit() -> Result<()> {
+    let chain_spec = Arc::new(BaseChainSpec::from_genesis(build_test_genesis_azul()));
+    let harness = TestHarnessBuilder::new().with_chain_spec(chain_spec).build().await?;
+    let request = BaseTransactionRequest::default()
+        .from(address!("1234567890abcdef1234567890abcdef12345678"))
+        .to(address!("abcdef1234567890abcdef1234567890abcdef12"))
+        .transaction_type(2u8)
+        .input(TransactionInput::new(bytes!(
+            "095ea7b3000000000000000000000000fedcba9876543210fedcba9876543210fedcba98000000000000000000000000000000000000000000000000000000000001e240"
+        )));
+
+    let filled = harness.provider().fill_transaction(request).await?;
     assert!(!filled.raw.is_empty(), "filled raw transaction should not be empty");
     assert!(filled.tx.gas_limit() > 21_000, "tx with calldata should exceed plain transfer gas");
 

--- a/crates/client/flashblocks-node/tests/gas_limit_cap.rs
+++ b/crates/client/flashblocks-node/tests/gas_limit_cap.rs
@@ -1,16 +1,21 @@
-//! Integration tests for EIP-7825 transaction gas limit cap enforcement.
+//! Integration tests for EIP-7825 transaction gas limit cap enforcement and
+//! omitted-gas RPC behavior on Azul.
 //!
 //! Base Azul introduces a per-transaction gas limit cap of 2^24 (16,777,216).
-//! These tests verify that `eth_sendRawTransaction` correctly rejects
-//! transactions exceeding this cap when Azul is active.
+//! These tests verify that:
+//! - `eth_sendRawTransaction` correctly rejects transactions exceeding this cap
+//!   when Azul is active.
+//! - RPC methods that estimate or fill gas continue to work when `gas` is
+//!   omitted, both with and without calldata.
 
 use std::sync::Arc;
 
-use alloy_consensus::SignableTransaction;
-use alloy_eips::eip2718::Encodable2718;
+use alloy_consensus::{SignableTransaction, Transaction};
+use alloy_eips::{BlockNumberOrTag, eip2718::Encodable2718};
 use alloy_network::TransactionBuilder;
-use alloy_primitives::Bytes;
+use alloy_primitives::{Bytes, address};
 use alloy_provider::Provider;
+use alloy_rpc_types_eth::TransactionInput;
 use alloy_signer::SignerSync;
 use base_common_rpc_types::BaseTransactionRequest;
 use base_execution_chainspec::BaseChainSpec;
@@ -35,6 +40,14 @@ fn sign_tx_with_gas_limit(from: Account, to: alloy_primitives::Address, gas_limi
     let signature = from.signer().sign_hash_sync(&tx.signature_hash()).expect("sign tx");
     let signed_tx = tx.into_signed(signature);
     signed_tx.encoded_2718().into()
+}
+
+fn transfer_request_without_gas() -> BaseTransactionRequest {
+    BaseTransactionRequest::default().from(Account::Alice.address()).to(Account::Bob.address())
+}
+
+fn transfer_request_with_data_without_gas() -> BaseTransactionRequest {
+    transfer_request_without_gas().input(TransactionInput::new(Bytes::from_static(&[0x00])))
 }
 
 #[tokio::test]
@@ -64,6 +77,79 @@ async fn pre_azul_accepts_tx_above_gas_limit_cap() -> Result<()> {
 
     let result = harness.provider().send_raw_transaction(&raw_tx).await;
     assert!(result.is_ok(), "tx with gas_limit > cap should be accepted when Azul is not active");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn azul_estimate_gas_without_data_returns_transfer_gas() -> Result<()> {
+    let chain_spec = Arc::new(BaseChainSpec::from_genesis(build_test_genesis_azul()));
+    let harness = TestHarnessBuilder::new().with_chain_spec(chain_spec).build().await?;
+    let gas = harness.provider().estimate_gas(transfer_request_without_gas()).await?;
+    assert_eq!(gas, 21_000);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn azul_estimate_gas_with_data_accepts_implicit_gas_limit() -> Result<()> {
+    let chain_spec = Arc::new(BaseChainSpec::from_genesis(build_test_genesis_azul()));
+    let harness = TestHarnessBuilder::new().with_chain_spec(chain_spec).build().await?;
+    let gas = harness.provider().estimate_gas(transfer_request_with_data_without_gas()).await?;
+    assert!(gas > 21_000, "tx with calldata should exceed plain transfer gas");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn azul_eth_call_without_data_accepts_implicit_gas_limit() -> Result<()> {
+    let chain_spec = Arc::new(BaseChainSpec::from_genesis(build_test_genesis_azul()));
+    let harness = TestHarnessBuilder::new().with_chain_spec(chain_spec).build().await?;
+    let result = harness
+        .provider()
+        .call(transfer_request_without_gas())
+        .block(BlockNumberOrTag::Pending.into())
+        .await?;
+    assert!(result.is_empty(), "plain eth_call to EOA should return empty bytes");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn azul_eth_call_with_data_to_contract_accepts_implicit_gas_limit() -> Result<()> {
+    let chain_spec = Arc::new(BaseChainSpec::from_genesis(build_test_genesis_azul()));
+    let harness = TestHarnessBuilder::new().with_chain_spec(chain_spec).build().await?;
+    let calldata = Bytes::from_static(&[0xde, 0xad, 0xbe, 0xef]);
+    let request = BaseTransactionRequest::default()
+        .from(Account::Alice.address())
+        .to(address!("0000000000000000000000000000000000000004"))
+        .input(TransactionInput::new(calldata.clone()));
+
+    let result = harness.provider().call(request).block(BlockNumberOrTag::Pending.into()).await?;
+    assert_eq!(result, calldata);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn azul_fill_transaction_without_data_uses_transfer_gas() -> Result<()> {
+    let chain_spec = Arc::new(BaseChainSpec::from_genesis(build_test_genesis_azul()));
+    let harness = TestHarnessBuilder::new().with_chain_spec(chain_spec).build().await?;
+    let filled = harness.provider().fill_transaction(transfer_request_without_gas()).await?;
+    assert!(!filled.raw.is_empty(), "filled raw transaction should not be empty");
+    assert_eq!(filled.tx.gas_limit(), 21_000);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn azul_fill_transaction_with_data_accepts_implicit_gas_limit() -> Result<()> {
+    let chain_spec = Arc::new(BaseChainSpec::from_genesis(build_test_genesis_azul()));
+    let harness = TestHarnessBuilder::new().with_chain_spec(chain_spec).build().await?;
+    let filled =
+        harness.provider().fill_transaction(transfer_request_with_data_without_gas()).await?;
+    assert!(!filled.raw.is_empty(), "filled raw transaction should not be empty");
+    assert!(filled.tx.gas_limit() > 21_000, "tx with calldata should exceed plain transfer gas");
 
     Ok(())
 }

--- a/crates/execution/evm/src/lib.rs
+++ b/crates/execution/evm/src/lib.rs
@@ -26,7 +26,9 @@ use reth_chainspec::EthChainSpec;
 #[cfg(feature = "std")]
 use reth_evm::{ConfigureEngineEvm, ExecutableTxIterator};
 use reth_evm::{ConfigureEvm, EvmEnv, TransactionEnv, precompiles::PrecompilesMap};
-use reth_primitives_traits::{NodePrimitives, SealedBlock, SealedHeader, SignedTransaction};
+use reth_primitives_traits::{
+    NodePrimitives, SealedBlock, SealedHeader, SignedTransaction, constants::MAX_TX_GAS_LIMIT_OSAKA,
+};
 use revm::context::{BlockEnv, TxEnv};
 #[allow(unused_imports)]
 use {
@@ -56,11 +58,25 @@ pub use build::BaseBlockAssembler;
 mod error;
 pub use error::{BaseBlockExecutionError, L1BlockInfoError};
 
+fn build_cfg_env(
+    spec: OpSpecId,
+    timestamp: u64,
+    chain_spec: &(impl Upgrades + EthChainSpec),
+) -> CfgEnv<OpSpecId> {
+    let mut cfg_env =
+        CfgEnv::new().with_chain_id(chain_spec.chain().id()).with_spec_and_mainnet_gas_params(spec);
+
+    if chain_spec.is_base_azul_active_at_timestamp(timestamp) {
+        cfg_env.tx_gas_limit_cap = Some(MAX_TX_GAS_LIMIT_OSAKA);
+    }
+
+    cfg_env
+}
+
 /// Builds an [`EvmEnv`] for a given block header using [`base_common_evm`]'s spec resolution.
 fn build_evm_env(header: &Header, chain_spec: &(impl Upgrades + EthChainSpec)) -> EvmEnv<OpSpecId> {
     let spec = OpSpecId::from_header(chain_spec, header);
-    let cfg_env =
-        CfgEnv::new().with_chain_id(chain_spec.chain().id()).with_spec_and_mainnet_gas_params(spec);
+    let cfg_env = build_cfg_env(spec, header.timestamp, chain_spec);
 
     let blob_excess_gas_and_price = spec
         .into_eth_spec()
@@ -91,8 +107,7 @@ fn build_next_evm_env(
     chain_spec: &(impl Upgrades + EthChainSpec),
 ) -> EvmEnv<OpSpecId> {
     let spec = OpSpecId::from_timestamp(chain_spec, attributes.timestamp);
-    let cfg_env =
-        CfgEnv::new().with_chain_id(chain_spec.chain().id()).with_spec_and_mainnet_gas_params(spec);
+    let cfg_env = build_cfg_env(spec, attributes.timestamp, chain_spec);
 
     let blob_excess_gas_and_price = spec
         .into_eth_spec()
@@ -272,10 +287,7 @@ where
         let block_number = payload.payload.block_number();
 
         let spec = OpSpecId::from_timestamp(self.chain_spec(), timestamp);
-
-        let cfg_env = CfgEnv::new()
-            .with_chain_id(self.chain_spec().chain().id())
-            .with_spec_and_mainnet_gas_params(spec);
+        let cfg_env = build_cfg_env(spec, timestamp, self.chain_spec());
 
         let blob_excess_gas_and_price = spec
             .into_eth_spec()
@@ -377,6 +389,7 @@ mod tests {
         let header = Header { timestamp: 0, ..Default::default() };
         let EvmEnv { cfg_env, .. } = evm_config.evm_env(&header).unwrap();
         assert_eq!(cfg_env.spec, OpSpecId::AZUL);
+        assert_eq!(cfg_env.tx_gas_limit_cap, Some(MAX_TX_GAS_LIMIT_OSAKA));
     }
 
     #[test]

--- a/crates/execution/runner/Cargo.toml
+++ b/crates/execution/runner/Cargo.toml
@@ -55,6 +55,7 @@ alloy-rpc-types-engine = { workspace = true, optional = true, features = [
 ] }
 
 # base-alloy
+base-common-rpc-types = { workspace = true, optional = true }
 base-common-network = { workspace = true, optional = true }
 base-common-consensus = { workspace = true, features = ["reth"] }
 base-common-rpc-types-engine = { workspace = true, optional = true }
@@ -86,6 +87,7 @@ test-utils = [
 	"dep:alloy-rpc-types",
 	"dep:alloy-rpc-types-engine",
 	"dep:base-common-network",
+	"dep:base-common-rpc-types",
 	"dep:base-common-rpc-types-engine",
 	"dep:base-test-utils",
 	"dep:chrono",

--- a/crates/execution/runner/src/test_utils/engine.rs
+++ b/crates/execution/runner/src/test_utils/engine.rs
@@ -121,14 +121,32 @@ impl<P: EngineProtocol> EngineApi<P> {
         P::client(self.jwt_secret, self.address.clone()).await
     }
 
-    /// Get a payload by ID from the Engine API
-    pub async fn get_payload(
+    /// Get a Prague/Isthmus payload by ID from the Engine API.
+    pub async fn get_payload_v4(
         &self,
         payload_id: PayloadId,
     ) -> eyre::Result<<BaseEngineTypes as EngineTypes>::ExecutionPayloadEnvelopeV4> {
         debug!(payload_id = %payload_id, timestamp = %chrono::Utc::now(), "Fetching payload");
         Ok(BaseEngineApiClient::<BaseEngineTypes>::get_payload_v4(&self.client().await, payload_id)
             .await?)
+    }
+
+    /// Get an Osaka/Azul payload by ID from the Engine API.
+    pub async fn get_payload_v5(
+        &self,
+        payload_id: PayloadId,
+    ) -> eyre::Result<<BaseEngineTypes as EngineTypes>::ExecutionPayloadEnvelopeV5> {
+        debug!(payload_id = %payload_id, timestamp = %chrono::Utc::now(), "Fetching payload");
+        Ok(BaseEngineApiClient::<BaseEngineTypes>::get_payload_v5(&self.client().await, payload_id)
+            .await?)
+    }
+
+    /// Get a payload by ID from the Engine API.
+    pub async fn get_payload(
+        &self,
+        payload_id: PayloadId,
+    ) -> eyre::Result<<BaseEngineTypes as EngineTypes>::ExecutionPayloadEnvelopeV4> {
+        self.get_payload_v4(payload_id).await
     }
 
     /// Submit a new payload to the Engine API

--- a/crates/execution/runner/src/test_utils/harness.rs
+++ b/crates/execution/runner/src/test_utils/harness.rs
@@ -10,6 +10,7 @@ use alloy_rpc_types::BlockNumberOrTag;
 use alloy_rpc_types_engine::PayloadAttributes;
 use base_common_consensus::BaseBlock;
 use base_common_network::Base;
+use base_common_rpc_types::GenesisInfo;
 use base_common_rpc_types_engine::BasePayloadAttributes;
 use base_execution_chainspec::BaseChainSpec;
 use base_test_utils::build_test_genesis;
@@ -182,22 +183,27 @@ impl TestHarness {
 
         sleep(Duration::from_millis(BLOCK_BUILD_DELAY_MS)).await;
 
-        let payload_envelope = self.engine.get_payload(payload_id).await?;
+        let azul_active = GenesisInfo::extract_from(&chain_spec.genesis.config.extra_fields)
+            .and_then(|genesis_info| genesis_info.base.azul)
+            .is_some_and(|activation_time| next_timestamp >= activation_time);
 
-        let execution_requests = if payload_envelope.execution_requests.is_empty() {
+        let (execution_payload, execution_requests): (_, Vec<Bytes>) = if azul_active {
+            let payload_envelope = self.engine.get_payload_v5(payload_id).await?;
+            (payload_envelope.execution_payload, payload_envelope.execution_requests)
+        } else {
+            let payload_envelope = self.engine.get_payload_v4(payload_id).await?;
+            (payload_envelope.execution_payload, payload_envelope.execution_requests)
+        };
+
+        let execution_requests = if execution_requests.is_empty() {
             Requests::default()
         } else {
-            Requests::new(payload_envelope.execution_requests)
+            Requests::new(execution_requests)
         };
 
         let payload_status = self
             .engine
-            .new_payload(
-                payload_envelope.execution_payload,
-                vec![],
-                payload_envelope.parent_beacon_block_root,
-                execution_requests,
-            )
+            .new_payload(execution_payload, vec![], parent_beacon_block_root, execution_requests)
             .await?;
 
         if payload_status.status.is_invalid() {


### PR DESCRIPTION
## Summary
- set the Osaka tx gas limit cap in Base EVM env construction whenever Azul is active
- switch the default flashblocks test harness genesis to Azul/Osaka
- add regression coverage for implicit-gas (with/without calldata)
