### PR TITLE
fix: implicit gas handling in azul

### DIFF
--- a/crates/client/flashblocks-node/src/test_harness.rs
+++ b/crates/client/flashblocks-node/src/test_harness.rs
@@ -33,7 +33,7 @@ use base_node_runner::{
     test_utils::{
         Account, L1_BLOCK_INFO_DEPOSIT_TX, L1_BLOCK_INFO_DEPOSIT_TX_HASH, LocalNode,
         LocalNodeProvider, NODE_STARTUP_DELAY_MS, TestHarness, build_test_genesis,
-        init_silenced_tracing,
+        build_test_genesis_v1, init_silenced_tracing,
     },
 };
 use derive_more::Deref;
@@ -240,7 +240,7 @@ impl FlashblocksLocalNode {
 
     async fn with_options(process_canonical: bool) -> Result<Self> {
         // Build default chain spec programmatically
-        let genesis = build_test_genesis();
+        let genesis = build_test_genesis_v1();
         let chain_spec = Arc::new(OpChainSpec::from_genesis(genesis));
 
         let extension = FlashblocksTestExtension::new(process_canonical);
@@ -299,7 +299,7 @@ impl FlashblocksHarness {
         init_silenced_tracing();
 
         // Build default chain spec programmatically
-        let genesis = build_test_genesis();
+        let genesis = build_test_genesis_v1();
         let chain_spec = Arc::new(OpChainSpec::from_genesis(genesis));
 
         // Create the extension and keep a reference to get parts after launch

--- a/crates/client/flashblocks-node/tests/flashblocks_rpc.rs
+++ b/crates/client/flashblocks-node/tests/flashblocks_rpc.rs
@@ -618,7 +618,7 @@ async fn test_eth_simulate_v1() -> Result<()> {
         block_state_calls: vec![SimBlock {
             calls: vec![
                 // read count1() from counter contract
-                setup.count1().into(),
+                setup.count1().gas_limit(100_000).into(),
                 // increment() value in contract
                 OpTransactionRequest::default()
                     .from(address!("0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266"))
@@ -628,7 +628,7 @@ async fn test_eth_simulate_v1() -> Result<()> {
                     .input(TransactionInput::new(bytes!("0xd09de08a")))
                     .into(),
                 // read count1() from counter contract
-                setup.count1().into(),
+                setup.count1().gas_limit(100_000).into(),
             ],
             block_overrides: None,
             state_overrides: None,

--- a/crates/client/flashblocks-node/tests/gas_limit_cap.rs
+++ b/crates/client/flashblocks-node/tests/gas_limit_cap.rs
@@ -1,16 +1,21 @@
-//! Integration tests for EIP-7825 transaction gas limit cap enforcement.
+//! Integration tests for EIP-7825 transaction gas limit cap enforcement and
+//! omitted-gas RPC behavior on Azul.
 //!
 //! Base V1 introduces a per-transaction gas limit cap of 2^24 (16,777,216).
-//! These tests verify that `eth_sendRawTransaction` correctly rejects
-//! transactions exceeding this cap when V1 is active.
+//! These tests verify that:
+//! - `eth_sendRawTransaction` correctly rejects transactions exceeding this cap
+//!   when V1 is active.
+//! - RPC methods that estimate or fill gas continue to work when `gas` is
+//!   omitted, both with and without calldata.
 
 use std::sync::Arc;
 
-use alloy_consensus::SignableTransaction;
-use alloy_eips::eip2718::Encodable2718;
+use alloy_consensus::{SignableTransaction, Transaction};
+use alloy_eips::{BlockNumberOrTag, eip2718::Encodable2718};
 use alloy_network::TransactionBuilder;
-use alloy_primitives::Bytes;
+use alloy_primitives::{Bytes, address, bytes};
 use alloy_provider::Provider;
+use alloy_rpc_types_eth::TransactionInput;
 use base_alloy_rpc_types::OpTransactionRequest;
 use base_execution_chainspec::OpChainSpec;
 use base_node_runner::test_utils::{
@@ -36,6 +41,14 @@ fn sign_tx_with_gas_limit(from: Account, to: alloy_primitives::Address, gas_limi
     let signature = from.signer().sign_hash_sync(&tx.signature_hash()).expect("sign tx");
     let signed_tx = tx.into_signed(signature);
     signed_tx.encoded_2718().into()
+}
+
+fn transfer_request_without_gas() -> OpTransactionRequest {
+    OpTransactionRequest::default().from(Account::Alice.address()).to(Account::Bob.address())
+}
+
+fn transfer_request_with_data_without_gas() -> OpTransactionRequest {
+    transfer_request_without_gas().input(TransactionInput::new(Bytes::from_static(&[0x00])))
 }
 
 #[tokio::test]
@@ -65,6 +78,79 @@ async fn pre_v1_accepts_tx_above_gas_limit_cap() -> Result<()> {
 
     let result = harness.provider().send_raw_transaction(&raw_tx).await;
     assert!(result.is_ok(), "tx with gas_limit > cap should be accepted when V1 is not active");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn v1_estimate_gas_without_data_returns_transfer_gas() -> Result<()> {
+    let chain_spec = Arc::new(OpChainSpec::from_genesis(build_test_genesis_v1()));
+    let harness = TestHarnessBuilder::new().with_chain_spec(chain_spec).build().await?;
+    let gas = harness.provider().estimate_gas(transfer_request_without_gas()).await?;
+    assert_eq!(gas, 21_000);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn v1_estimate_gas_with_data_accepts_implicit_gas_limit() -> Result<()> {
+    let chain_spec = Arc::new(OpChainSpec::from_genesis(build_test_genesis_v1()));
+    let harness = TestHarnessBuilder::new().with_chain_spec(chain_spec).build().await?;
+    let gas = harness.provider().estimate_gas(transfer_request_with_data_without_gas()).await?;
+    assert!(gas > 21_000, "tx with calldata should exceed plain transfer gas");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn v1_eth_call_without_data_accepts_implicit_gas_limit() -> Result<()> {
+    let chain_spec = Arc::new(OpChainSpec::from_genesis(build_test_genesis_v1()));
+    let harness = TestHarnessBuilder::new().with_chain_spec(chain_spec).build().await?;
+    let result = harness
+        .provider()
+        .call(transfer_request_without_gas())
+        .block(BlockNumberOrTag::Pending.into())
+        .await?;
+    assert!(result.is_empty(), "plain eth_call to EOA should return empty bytes");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn v1_eth_call_with_data_to_contract_accepts_implicit_gas_limit() -> Result<()> {
+    let chain_spec = Arc::new(OpChainSpec::from_genesis(build_test_genesis_v1()));
+    let harness = TestHarnessBuilder::new().with_chain_spec(chain_spec).build().await?;
+    let calldata = Bytes::from_static(&[0xde, 0xad, 0xbe, 0xef]);
+    let request = OpTransactionRequest::default()
+        .from(Account::Alice.address())
+        .to(address!("0000000000000000000000000000000000000004"))
+        .input(TransactionInput::new(calldata.clone()));
+
+    let result = harness.provider().call(request).block(BlockNumberOrTag::Pending.into()).await?;
+    assert_eq!(result, calldata);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn v1_fill_transaction_without_data_uses_transfer_gas() -> Result<()> {
+    let chain_spec = Arc::new(OpChainSpec::from_genesis(build_test_genesis_v1()));
+    let harness = TestHarnessBuilder::new().with_chain_spec(chain_spec).build().await?;
+    let filled = harness.provider().fill_transaction(transfer_request_without_gas()).await?;
+    assert!(!filled.raw.is_empty(), "filled raw transaction should not be empty");
+    assert_eq!(filled.tx.gas_limit(), 21_000);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn v1_fill_transaction_with_data_accepts_implicit_gas_limit() -> Result<()> {
+    let chain_spec = Arc::new(OpChainSpec::from_genesis(build_test_genesis_v1()));
+    let harness = TestHarnessBuilder::new().with_chain_spec(chain_spec).build().await?;
+    let filled =
+        harness.provider().fill_transaction(transfer_request_with_data_without_gas()).await?;
+    assert!(!filled.raw.is_empty(), "filled raw transaction should not be empty");
+    assert!(filled.tx.gas_limit() > 21_000, "tx with calldata should exceed plain transfer gas");
 
     Ok(())
 }

--- a/crates/client/flashblocks-node/tests/gas_limit_cap.rs
+++ b/crates/client/flashblocks-node/tests/gas_limit_cap.rs
@@ -51,6 +51,10 @@ fn transfer_request_with_data_without_gas() -> OpTransactionRequest {
     transfer_request_without_gas().input(TransactionInput::new(Bytes::from_static(&[0x00])))
 }
 
+fn transfer_request_with_gas_and_data() -> OpTransactionRequest {
+    transfer_request_with_data_without_gas().gas_limit(100_000)
+}
+
 #[tokio::test]
 async fn v1_gas_limit_cap() -> Result<()> {
     let chain_spec = Arc::new(OpChainSpec::from_genesis(build_test_genesis_v1()));
@@ -103,6 +107,17 @@ async fn v1_estimate_gas_with_data_accepts_implicit_gas_limit() -> Result<()> {
 }
 
 #[tokio::test]
+async fn v1_estimate_gas_with_explicit_gas_and_data_passes() -> Result<()> {
+    let chain_spec = Arc::new(OpChainSpec::from_genesis(build_test_genesis_v1()));
+    let harness = TestHarnessBuilder::new().with_chain_spec(chain_spec).build().await?;
+    let gas = harness.provider().estimate_gas(transfer_request_with_gas_and_data()).await?;
+    assert!(gas > 21_000, "tx with calldata should exceed plain transfer gas");
+    assert!(gas <= 100_000, "estimate should respect the provided gas cap");
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn v1_eth_call_without_data_accepts_implicit_gas_limit() -> Result<()> {
     let chain_spec = Arc::new(OpChainSpec::from_genesis(build_test_genesis_v1()));
     let harness = TestHarnessBuilder::new().with_chain_spec(chain_spec).build().await?;
@@ -149,6 +164,25 @@ async fn v1_fill_transaction_with_data_accepts_implicit_gas_limit() -> Result<()
     let harness = TestHarnessBuilder::new().with_chain_spec(chain_spec).build().await?;
     let filled =
         harness.provider().fill_transaction(transfer_request_with_data_without_gas()).await?;
+    assert!(!filled.raw.is_empty(), "filled raw transaction should not be empty");
+    assert!(filled.tx.gas_limit() > 21_000, "tx with calldata should exceed plain transfer gas");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn v1_fill_transaction_long_calldata_accepts_implicit_gas_limit() -> Result<()> {
+    let chain_spec = Arc::new(OpChainSpec::from_genesis(build_test_genesis_v1()));
+    let harness = TestHarnessBuilder::new().with_chain_spec(chain_spec).build().await?;
+    let request = OpTransactionRequest::default()
+        .from(address!("1234567890abcdef1234567890abcdef12345678"))
+        .to(address!("abcdef1234567890abcdef1234567890abcdef12"))
+        .transaction_type(2u8)
+        .input(TransactionInput::new(bytes!(
+            "095ea7b3000000000000000000000000fedcba9876543210fedcba9876543210fedcba98000000000000000000000000000000000000000000000000000000000001e240"
+        )));
+
+    let filled = harness.provider().fill_transaction(request).await?;
     assert!(!filled.raw.is_empty(), "filled raw transaction should not be empty");
     assert!(filled.tx.gas_limit() > 21_000, "tx with calldata should exceed plain transfer gas");
 

--- a/crates/client/flashblocks-node/tests/v1.rs
+++ b/crates/client/flashblocks-node/tests/v1.rs
@@ -1,5 +1,5 @@
 //! Integration tests for EIP-7825 transaction gas limit cap enforcement and
-//! omitted-gas RPC behavior on Azul.
+//! omitted-gas RPC behavior on Base V1.
 //!
 //! Base V1 introduces a per-transaction gas limit cap of 2^24 (16,777,216).
 //! These tests verify that:
@@ -124,7 +124,7 @@ async fn v1_eth_call_without_data_accepts_implicit_gas_limit() -> Result<()> {
     let result = harness
         .provider()
         .call(transfer_request_without_gas())
-        .block(BlockNumberOrTag::Pending.into())
+        .block(BlockNumberOrTag::Latest.into())
         .await?;
     assert!(result.is_empty(), "plain eth_call to EOA should return empty bytes");
 
@@ -141,7 +141,7 @@ async fn v1_eth_call_with_data_to_contract_accepts_implicit_gas_limit() -> Resul
         .to(address!("0000000000000000000000000000000000000004"))
         .input(TransactionInput::new(calldata.clone()));
 
-    let result = harness.provider().call(request).block(BlockNumberOrTag::Pending.into()).await?;
+    let result = harness.provider().call(request).block(BlockNumberOrTag::Latest.into()).await?;
     assert_eq!(result, calldata);
 
     Ok(())

--- a/crates/execution/evm/src/lib.rs
+++ b/crates/execution/evm/src/lib.rs
@@ -27,7 +27,9 @@ use reth_chainspec::EthChainSpec;
 #[cfg(feature = "std")]
 use reth_evm::{ConfigureEngineEvm, ExecutableTxIterator};
 use reth_evm::{ConfigureEvm, EvmEnv, TransactionEnv, precompiles::PrecompilesMap};
-use reth_primitives_traits::{NodePrimitives, SealedBlock, SealedHeader, SignedTransaction};
+use reth_primitives_traits::{
+    NodePrimitives, SealedBlock, SealedHeader, SignedTransaction, constants::MAX_TX_GAS_LIMIT_OSAKA,
+};
 use revm::context::{BlockEnv, TxEnv};
 #[allow(unused_imports)]
 use {
@@ -57,14 +59,28 @@ pub use build::OpBlockAssembler;
 mod error;
 pub use error::{L1BlockInfoError, OpBlockExecutionError};
 
+fn build_cfg_env(
+    spec: OpSpecId,
+    timestamp: u64,
+    chain_spec: &(impl BaseUpgrades + EthChainSpec),
+) -> CfgEnv<OpSpecId> {
+    let mut cfg_env =
+        CfgEnv::new().with_chain_id(chain_spec.chain().id()).with_spec_and_mainnet_gas_params(spec);
+
+    if chain_spec.is_base_v1_active_at_timestamp(timestamp) {
+        cfg_env.tx_gas_limit_cap = Some(MAX_TX_GAS_LIMIT_OSAKA);
+    }
+
+    cfg_env
+}
+
 /// Builds an [`EvmEnv`] for a given block header using [`base_alloy_evm`]'s spec resolution.
 fn op_evm_env(
     header: &Header,
     chain_spec: &(impl BaseUpgrades + EthChainSpec),
 ) -> EvmEnv<OpSpecId> {
     let spec = revm_spec_by_timestamp_after_bedrock(chain_spec, header.timestamp);
-    let cfg_env =
-        CfgEnv::new().with_chain_id(chain_spec.chain().id()).with_spec_and_mainnet_gas_params(spec);
+    let cfg_env = build_cfg_env(spec, header.timestamp, chain_spec);
 
     let blob_excess_gas_and_price = spec
         .into_eth_spec()
@@ -95,8 +111,7 @@ fn op_next_evm_env(
     chain_spec: &(impl BaseUpgrades + EthChainSpec),
 ) -> EvmEnv<OpSpecId> {
     let spec = revm_spec_by_timestamp_after_bedrock(chain_spec, attributes.timestamp);
-    let cfg_env =
-        CfgEnv::new().with_chain_id(chain_spec.chain().id()).with_spec_and_mainnet_gas_params(spec);
+    let cfg_env = build_cfg_env(spec, attributes.timestamp, chain_spec);
 
     let blob_excess_gas_and_price = spec
         .into_eth_spec()
@@ -279,10 +294,7 @@ where
         let block_number = payload.payload.block_number();
 
         let spec = revm_spec_by_timestamp_after_bedrock(self.chain_spec(), timestamp);
-
-        let cfg_env = CfgEnv::new()
-            .with_chain_id(self.chain_spec().chain().id())
-            .with_spec_and_mainnet_gas_params(spec);
+        let cfg_env = build_cfg_env(spec, timestamp, self.chain_spec());
 
         let blob_excess_gas_and_price = spec
             .into_eth_spec()
@@ -357,7 +369,7 @@ mod tests {
     use reth_execution_types::{
         AccountRevertInit, BundleStateInit, Chain, ExecutionOutcome, RevertsInit,
     };
-    use reth_primitives_traits::{Account, RecoveredBlock};
+    use reth_primitives_traits::{Account, RecoveredBlock, constants::MAX_TX_GAS_LIMIT_OSAKA};
     use revm::{
         database::{BundleState, CacheDB},
         database_interface::EmptyDBTyped,
@@ -385,6 +397,7 @@ mod tests {
         let header = Header { timestamp: 0, ..Default::default() };
         let EvmEnv { cfg_env, .. } = evm_config.evm_env(&header).unwrap();
         assert_eq!(cfg_env.spec, OpSpecId::BASE_V1);
+        assert_eq!(cfg_env.tx_gas_limit_cap, Some(MAX_TX_GAS_LIMIT_OSAKA));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- set the Osaka tx gas limit cap in Base EVM env construction whenever Azul is active
- switch the default flashblocks test harness genesis to Azul/Osaka
- add regression coverage for implicit-gas (with/without calldata)

Backport of #2297 onto `releases/v0.7.6`.