### PR TITLE
Rename base package to base

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2463,6 +2463,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "base"
+version = "0.0.0"
+dependencies = [
+ "base-cli-utils",
+ "base-common-chains",
+ "clap",
+ "eyre",
+ "figment",
+ "serde",
+ "tracing",
+]
+
+[[package]]
 name = "base-access-lists"
 version = "0.0.0"
 dependencies = [
@@ -2679,19 +2692,6 @@ dependencies = [
  "futures",
  "thiserror 2.0.18",
  "tokio",
- "tracing",
-]
-
-[[package]]
-name = "base-bin"
-version = "0.0.0"
-dependencies = [
- "base-cli-utils",
- "base-common-chains",
- "clap",
- "eyre",
- "figment",
- "serde",
  "tracing",
 ]
 

--- a/bin/base/Cargo.toml
+++ b/bin/base/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "base-bin"
+name = "base"
 description = "Unified Base node binary"
 version.workspace = true
 edition.workspace = true


### PR DESCRIPTION
## Summary
- rename the bin/base Cargo package from base-bin to base
- update Cargo.lock to reflect the package rename
- make cargo run -p base -- --help work from the workspace root

## Verification
- cargo run -p base -- --help