### PR TITLE
refactor(basectl): rename ChainConfig to MonitoringConfig

### DIFF
--- a/bin/basectl/src/main.rs
+++ b/bin/basectl/src/main.rs
@@ -2,7 +2,7 @@
 
 mod cli;
 
-use basectl_cli::{ChainConfig, ViewId, run_app, run_flashblocks_json};
+use basectl_cli::{MonitoringConfig, ViewId, run_app, run_flashblocks_json};
 use clap::Parser;
 
 #[tokio::main]
@@ -17,7 +17,7 @@ async fn main() -> anyhow::Result<()> {
     match cli.command {
         Some(cli::Commands::Config) => run_app(ViewId::Config, config).await,
         Some(cli::Commands::Flashblocks { json: true }) => {
-            run_flashblocks_json(ChainConfig::load(config).await?).await
+            run_flashblocks_json(MonitoringConfig::load(config).await?).await
         }
         Some(cli::Commands::Flashblocks { json: false }) => {
             run_app(ViewId::Flashblocks, config).await

--- a/crates/infra/basectl/README.md
+++ b/crates/infra/basectl/README.md
@@ -19,9 +19,9 @@ basectl-cli = { workspace = true }
 ```
 
 ```rust,ignore
-use basectl_cli::{run_app, ChainConfig};
+use basectl_cli::{run_app, MonitoringConfig};
 
-let config = ChainConfig::from_cli(args);
+let config = MonitoringConfig::from_cli(args);
 run_app(config).await?;
 ```
 

--- a/crates/infra/basectl/src/app/core.rs
+++ b/crates/infra/basectl/src/app/core.rs
@@ -12,7 +12,7 @@ use tokio::sync::oneshot;
 use super::{Action, Resources, Router, View, ViewId, runner::start_background_services};
 use crate::{
     commands::{COLOR_BASE_BLUE, EVENT_POLL_TIMEOUT},
-    config::ChainConfig,
+    config::MonitoringConfig,
     tui::{AppFrame, Toast, restore_terminal, setup_terminal},
 };
 
@@ -29,7 +29,7 @@ struct NetworkPicker {
 
 impl NetworkPicker {
     fn new() -> Self {
-        Self { options: ChainConfig::available_names(), cursor: 0 }
+        Self { options: MonitoringConfig::available_names(), cursor: 0 }
     }
 }
 
@@ -46,7 +46,7 @@ pub struct App {
     /// Network picker overlay; `None` when closed.
     network_picker: Option<NetworkPicker>,
     /// Pending async network-load result. `Some` while a switch is in flight.
-    pending_network: Option<oneshot::Receiver<anyhow::Result<ChainConfig>>>,
+    pending_network: Option<oneshot::Receiver<anyhow::Result<MonitoringConfig>>>,
 }
 
 impl fmt::Debug for App {
@@ -255,7 +255,7 @@ impl App {
         let (tx, rx) = oneshot::channel();
         self.pending_network = Some(rx);
         tokio::spawn(async move {
-            let result = ChainConfig::load(&name).await;
+            let result = MonitoringConfig::load(&name).await;
             let _ = tx.send(result);
         });
     }
@@ -295,7 +295,7 @@ impl App {
 
     fn apply_network_switch<F>(
         &mut self,
-        new_config: ChainConfig,
+        new_config: MonitoringConfig,
         current_view: &mut Box<dyn View>,
         view_factory: &mut F,
     ) where

--- a/crates/infra/basectl/src/app/resources.rs
+++ b/crates/infra/basectl/src/app/resources.rs
@@ -12,7 +12,7 @@ use tokio::{
 
 use crate::{
     commands::{DaTracker, FlashblockEntry, LoadingState},
-    config::{ChainConfig, ConductorNodeConfig},
+    config::{ConductorNodeConfig, MonitoringConfig},
     rpc::{
         BacklogFetchResult, BlockDaInfo, ConductorNodeStatus, L1BlockInfo, L1ConnectionMode,
         ProofsSnapshot, TimestampedFlashblock, ValidatorNodeStatus,
@@ -155,7 +155,7 @@ pub struct LoadTestTask {
 #[derive(Debug)]
 pub struct Resources {
     /// Active chain configuration.
-    pub config: ChainConfig,
+    pub config: MonitoringConfig,
     /// Data availability monitoring state.
     pub da: DaState,
     /// Flashblock stream state.
@@ -221,7 +221,7 @@ pub struct FlashState {
 
 impl Resources {
     /// Creates new resources with the given chain configuration.
-    pub fn new(config: ChainConfig) -> Self {
+    pub fn new(config: MonitoringConfig) -> Self {
         Self {
             config,
             da: DaState::new(),

--- a/crates/infra/basectl/src/app/runner.rs
+++ b/crates/infra/basectl/src/app/runner.rs
@@ -7,7 +7,7 @@ use tokio::sync::{mpsc, watch};
 
 use super::{App, Resources, ViewId, views::create_view};
 use crate::{
-    config::ChainConfig,
+    config::MonitoringConfig,
     l1_client::fetch_full_system_config,
     rpc::{
         BacklogFetchResult, BlockDaInfo, ConductorNodeStatus, L1BlockInfo, L1ConnectionMode,
@@ -21,7 +21,7 @@ use crate::{
 
 /// Launches the TUI application starting from the specified view and network.
 pub async fn run_app(initial_view: ViewId, network: &str) -> Result<()> {
-    let config = ChainConfig::load(network).await?;
+    let config = MonitoringConfig::load(network).await?;
     let mut resources = Resources::new(config.clone());
     start_background_services(&config, &mut resources);
     let app = App::new(resources, initial_view);
@@ -34,7 +34,7 @@ pub async fn run_app(initial_view: ViewId, network: &str) -> Result<()> {
 /// safe-head polling, system config fetching, conductor polling, validator polling,
 /// and proof monitoring. All tasks communicate back through channels stored in
 /// `resources`.
-pub fn start_background_services(config: &ChainConfig, resources: &mut Resources) {
+pub fn start_background_services(config: &MonitoringConfig, resources: &mut Resources) {
     let (fb_tx, fb_rx) = mpsc::channel::<TimestampedFlashblock>(100);
     let (da_fb_tx, da_fb_rx) = mpsc::channel::<Flashblock>(100);
     let (sync_tx, sync_rx) = mpsc::channel::<u64>(10);
@@ -139,7 +139,7 @@ pub fn start_background_services(config: &ChainConfig, resources: &mut Resources
 }
 
 /// Streams flashblocks as JSON lines to stdout.
-pub async fn run_flashblocks_json(config: ChainConfig) -> Result<()> {
+pub async fn run_flashblocks_json(config: MonitoringConfig) -> Result<()> {
     let (tx, mut rx) = mpsc::channel::<Flashblock>(100);
     let (toast_tx, mut toast_rx) = mpsc::channel::<Toast>(50);
 

--- a/crates/infra/basectl/src/config.rs
+++ b/crates/infra/basectl/src/config.rs
@@ -80,7 +80,7 @@ pub struct ConductorNodeConfig {
 
 /// Monitoring configuration for a chain watched by basectl.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ChainConfig {
+pub struct MonitoringConfig {
     /// Human-readable chain name (e.g. "mainnet", "sepolia").
     pub name: String,
     /// L2 JSON-RPC endpoint URL.
@@ -115,7 +115,7 @@ pub struct ChainConfig {
     pub proofs: Option<ProofsConfig>,
 }
 
-impl ChainConfig {
+impl MonitoringConfig {
     /// Returns the block explorer base URL for this chain, if known.
     pub fn explorer_base_url(&self) -> Option<&'static str> {
         match self.name.as_str() {
@@ -140,7 +140,7 @@ const fn default_blob_target() -> u64 {
 }
 
 #[derive(Debug, Clone, Deserialize, Default)]
-struct ChainConfigOverride {
+struct MonitoringConfigOverride {
     name: Option<String>,
     rpc: Option<Url>,
     flashblocks_ws: Option<Url>,
@@ -156,7 +156,7 @@ struct ChainConfigOverride {
     proofs: Option<ProofsConfig>,
 }
 
-impl ChainConfig {
+impl MonitoringConfig {
     /// Returns a sorted list of all available network names: the three built-ins
     /// followed by any `*.yaml`/`*.yml` files found in `~/.config/base/networks/`
     /// that are not already covered by the built-ins.
@@ -383,7 +383,7 @@ impl ChainConfig {
         let contents = std::fs::read_to_string(path)
             .with_context(|| format!("Failed to read config file: {}", path.display()))?;
 
-        let overrides: ChainConfigOverride = serde_yaml::from_str(&contents)
+        let overrides: MonitoringConfigOverride = serde_yaml::from_str(&contents)
             .with_context(|| format!("Failed to parse config file: {}", path.display()))?;
 
         Ok(Self {
@@ -412,11 +412,11 @@ mod tests {
 
     #[tokio::test]
     async fn test_builtin_configs() {
-        let mainnet = ChainConfig::load("mainnet").await.unwrap();
+        let mainnet = MonitoringConfig::load("mainnet").await.unwrap();
         assert_eq!(mainnet.name, "mainnet");
         assert!(mainnet.rpc.as_str().contains("mainnet"));
 
-        let sepolia = ChainConfig::load("sepolia").await.unwrap();
+        let sepolia = MonitoringConfig::load("sepolia").await.unwrap();
         assert_eq!(sepolia.name, "sepolia");
         assert!(sepolia.rpc.as_str().contains("sepolia"));
     }
@@ -424,7 +424,7 @@ mod tests {
     #[test]
     fn test_devnet_base_config() {
         // Test the base devnet config structure (without RPC call)
-        let devnet = ChainConfig::devnet_base();
+        let devnet = MonitoringConfig::devnet_base();
         assert_eq!(devnet.name, "devnet");
         assert!(devnet.rpc.as_str().contains("localhost"));
         assert_eq!(devnet.rpc.as_str(), "http://localhost:7545/");
@@ -436,7 +436,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_unknown_config() {
-        let result = ChainConfig::load("nonexistent").await;
+        let result = MonitoringConfig::load("nonexistent").await;
         assert!(result.is_err());
     }
 }

--- a/crates/infra/basectl/src/lib.rs
+++ b/crates/infra/basectl/src/lib.rs
@@ -21,7 +21,7 @@ pub use commands::{
 };
 
 mod config;
-pub use config::{ChainConfig, ConductorNodeConfig, ProofsConfig, ValidatorNodeConfig};
+pub use config::{ConductorNodeConfig, MonitoringConfig, ProofsConfig, ValidatorNodeConfig};
 
 mod l1_client;
 pub use l1_client::fetch_full_system_config;


### PR DESCRIPTION
## Summary

Pure rename of the basectl-local `ChainConfig` to `MonitoringConfig` (and `ChainConfigOverride` → `MonitoringConfigOverride`).

This makes progress on an effort to consolidate chain definitions. 