### PR TITLE
feat(metrics): add bytes_compressed counter to websocket-proxy

### DIFF
--- a/bin/websocket-proxy/src/main.rs
+++ b/bin/websocket-proxy/src/main.rs
@@ -215,6 +215,7 @@ async fn main() {
                     brotli::CompressorWriter::new(&mut compressed_data_bytes, 4096, 5, 22);
                 compressor.write_all(data_bytes).unwrap();
             }
+            Metrics::bytes_compressed().increment(compressed_data_bytes.len() as u64);
             compressed_data_bytes
         } else {
             data.into_bytes()

--- a/crates/infra/websocket-proxy/src/metrics.rs
+++ b/crates/infra/websocket-proxy/src/metrics.rs
@@ -36,6 +36,8 @@ base_metrics::define_metrics! {
     upstream_connection_failures: counter,
     #[describe("Total bytes broadcasted to clients")]
     bytes_broadcasted: counter,
+    #[describe("Total brotli-compressed bytes sent upstream (pre-broadcast, counted once per message)")]
+    bytes_compressed: counter,
     #[describe("Count of clients disconnected due to pong timeout")]
     client_pong_disconnects: counter,
     #[describe("Number of ping attempts sent to upstream")]

--- a/crates/infra/websocket-proxy/src/metrics.rs
+++ b/crates/infra/websocket-proxy/src/metrics.rs
@@ -36,7 +36,7 @@ base_metrics::define_metrics! {
     upstream_connection_failures: counter,
     #[describe("Total bytes broadcasted to clients")]
     bytes_broadcasted: counter,
-    #[describe("Total brotli-compressed bytes sent upstream (pre-broadcast, counted once per message)")]
+    #[describe("Total brotli-compressed bytes placed on the broadcast channel (pre-fan-out, counted once per message)")]
     bytes_compressed: counter,
     #[describe("Count of clients disconnected due to pong timeout")]
     client_pong_disconnects: counter,


### PR DESCRIPTION
## Summary

- Adds `bytes_compressed` counter to the websocket-proxy metrics, tracking total brotli-compressed bytes placed on the broadcast channel once per upstream message (before fan-out to subscribers)
- Recorded only when `--enable-compression` is active; when disabled, wire bytes equal the uncompressed size already tracked by `base.reth_base_builder_ws_payload_byte_size`
