### PR TITLE
[backport v0.8.0] feat(metrics): add #[no_zero] attribute to opt out of zero initialization

### DIFF
--- a/crates/proof/proposer/src/metrics.rs
+++ b/crates/proof/proposer/src/metrics.rs
@@ -6,9 +6,11 @@ base_metrics::define_metrics! {
     up: gauge,
 
     #[describe("Proposer account balance in wei")]
+    #[no_zero]
     account_balance_wei: gauge,
 
     #[describe("Most recently proposed L2 block number")]
+    #[no_zero]
     last_proposed_block: gauge,
 
     #[describe("Proof tasks currently in flight")]
@@ -21,6 +23,7 @@ base_metrics::define_metrics! {
     pipeline_retries: gauge,
 
     #[describe("Latest safe (or finalized) L2 block number")]
+    #[no_zero]
     safe_head: gauge,
 
     #[describe("Total number of L2 output proposals submitted")]

--- a/crates/utilities/metrics/src/define_metrics.rs
+++ b/crates/utilities/metrics/src/define_metrics.rs
@@ -16,6 +16,13 @@
 /// - `#[label(name)]` — optional per-field (may be repeated up to 2x).
 /// - `#[label(name = "...")]` — optional per-field string label name.
 /// - `#[label(name = "...", default = ["..."])]` — optional per-field labeled zero values.
+/// - `#[no_zero]` — optional per-field; opts the metric out of the auto-generated
+///   `Metrics::zero()` initialization. Use this for gauges that track external
+///   state (e.g. account balances, chain heads) where `0` is a meaningful
+///   alerting value and would generate false alerts during the warmup window
+///   between process start and the first real read. The metric series will be
+///   absent from scrapes until the first observation is recorded. The metric
+///   is still registered with `describe()`.
 ///
 /// # Example
 ///
@@ -207,6 +214,9 @@ macro_rules! __metric_label_keys {
     (@collect ($scope:tt, $field:ident, $kind:ident) [$($labels:expr,)*] #[describe($desc:expr)] $($rest:tt)*) => {
         $crate::__metric_label_keys!(@collect ($scope, $field, $kind) [$($labels,)*] $($rest)*);
     };
+    (@collect ($scope:tt, $field:ident, $kind:ident) [$($labels:expr,)*] #[no_zero] $($rest:tt)*) => {
+        $crate::__metric_label_keys!(@collect ($scope, $field, $kind) [$($labels,)*] $($rest)*);
+    };
     (@collect ($scope:tt, $field:ident, $kind:ident) [$($labels:expr,)*] #[label($label:ident)] $($rest:tt)*) => {
         $crate::__metric_label_keys!(@collect ($scope, $field, $kind) [$($labels,)* stringify!($label),] $($rest)*);
     };
@@ -291,6 +301,9 @@ macro_rules! __define_metric_zero {
 #[doc(hidden)]
 #[macro_export]
 macro_rules! __metric_zero_defaults {
+    // `#[no_zero]` short-circuits the entire chain: consume any remaining
+    // attributes and emit no zeroing code for this field.
+    (@collect ($field:ident, $kind:ident) [$($labels:tt)*] #[no_zero] $($rest:tt)*) => {};
     (@collect ($field:ident, $kind:ident) [$($labels:tt)*] #[describe($desc:expr)] $($rest:tt)*) => {
         $crate::__metric_zero_defaults!(@collect ($field, $kind) [$($labels)*] $($rest)*);
     };

--- a/crates/utilities/metrics/tests/metrics.rs
+++ b/crates/utilities/metrics/tests/metrics.rs
@@ -583,6 +583,111 @@ fn zero_initializes_unlabeled_and_labeled_metrics() {
     });
 }
 
+base_metrics::define_metrics! {
+    no_zero_test,
+    struct = NoZeroMetrics,
+
+    #[describe("Unlabeled gauge that should not be zeroed")]
+    #[no_zero]
+    state_gauge: gauge,
+
+    #[describe("Unlabeled counter that should not be zeroed")]
+    #[no_zero]
+    skipped_counter: counter,
+
+    #[describe("Labeled gauge with defaults that should not be zeroed")]
+    #[no_zero]
+    #[label(name = "kind", default = ["one", "two"])]
+    labeled_state_gauge: gauge,
+
+    #[describe("Sibling gauge that should still be zeroed")]
+    sibling_gauge: gauge,
+}
+
+#[test]
+fn no_zero_skips_zero_initialization() {
+    with_recorder(|snap| {
+        NoZeroMetrics::zero();
+
+        let snapshot = snap.snapshot().into_vec();
+
+        // The opted-out metrics should not appear in the snapshot at all.
+        assert_eq!(find_metric(&snapshot, MetricKind::Gauge, "no_zero_test.state_gauge"), None,);
+        assert_eq!(
+            find_metric(&snapshot, MetricKind::Counter, "no_zero_test.skipped_counter"),
+            None,
+        );
+        assert_eq!(
+            find_metric_labeled(
+                &snapshot,
+                MetricKind::Gauge,
+                "no_zero_test.labeled_state_gauge",
+                &[("kind", "one")]
+            ),
+            None,
+        );
+        assert_eq!(
+            find_metric_labeled(
+                &snapshot,
+                MetricKind::Gauge,
+                "no_zero_test.labeled_state_gauge",
+                &[("kind", "two")]
+            ),
+            None,
+        );
+
+        // The sibling without `#[no_zero]` should still be zeroed.
+        assert_eq!(
+            find_metric(&snapshot, MetricKind::Gauge, "no_zero_test.sibling_gauge"),
+            Some(&DebugValue::Gauge(OrderedFloat(0.0))),
+        );
+    });
+}
+
+#[test]
+fn no_zero_metrics_can_still_be_set_explicitly() {
+    with_recorder(|snap| {
+        NoZeroMetrics::zero();
+        NoZeroMetrics::state_gauge().set(42.0);
+        NoZeroMetrics::skipped_counter().increment(5);
+        NoZeroMetrics::labeled_state_gauge("one").set(7.0);
+
+        let snapshot = snap.snapshot().into_vec();
+        assert_eq!(
+            find_metric(&snapshot, MetricKind::Gauge, "no_zero_test.state_gauge"),
+            Some(&DebugValue::Gauge(OrderedFloat(42.0))),
+        );
+        assert_eq!(
+            find_metric(&snapshot, MetricKind::Counter, "no_zero_test.skipped_counter"),
+            Some(&DebugValue::Counter(5)),
+        );
+        assert_eq!(
+            find_metric_labeled(
+                &snapshot,
+                MetricKind::Gauge,
+                "no_zero_test.labeled_state_gauge",
+                &[("kind", "one")]
+            ),
+            Some(&DebugValue::Gauge(OrderedFloat(7.0))),
+        );
+    });
+}
+
+#[test]
+fn no_zero_metrics_are_still_described_by_init() {
+    with_recorder(|snap| {
+        NoZeroMetrics::init();
+        // Touch the metric so it appears in the snapshot alongside its description.
+        NoZeroMetrics::state_gauge().set(1.0);
+
+        let snapshot = snap.snapshot().into_vec();
+        assert_eq!(
+            find_description(&snapshot, MetricKind::Gauge, "no_zero_test.state_gauge").as_deref(),
+            Some("Unlabeled gauge that should not be zeroed"),
+        );
+    });
+}
+
 #[test]
 fn init_describes_and_zeroes_metrics() {
     with_recorder(|snap| {


### PR DESCRIPTION
## Summary

Backport of #2309 to `releases/v0.8.0`.

- Adds `#[no_zero]` attribute to the metrics macro to opt out of zero-value initialization for specific metrics