### PR TITLE
refactor(consensus): Rename Hardfork Types to Upgrade

### DIFF
--- a/crates/consensus/derive/src/attributes/stateful.rs
+++ b/crates/consensus/derive/src/attributes/stateful.rs
@@ -12,7 +12,7 @@ use async_trait::async_trait;
 use base_common_consensus::Predeploys;
 use base_common_rpc_types_engine::BasePayloadAttributes;
 use base_consensus_genesis::RollupConfig;
-use base_consensus_upgrades::{Hardfork, Hardforks};
+use base_consensus_upgrades::{Upgrade, Upgrades};
 use base_protocol::{Deposits, L1BlockInfoTx, L2BlockInfo};
 use tracing::warn;
 
@@ -146,22 +146,22 @@ where
         if self.rollup_cfg.is_ecotone_active(next_l2_time)
             && !self.rollup_cfg.is_ecotone_active(l2_parent.block_info.timestamp)
         {
-            upgrade_transactions = Hardforks::ECOTONE.txs().collect();
+            upgrade_transactions = Upgrades::ECOTONE.txs().collect();
         }
         if self.rollup_cfg.is_fjord_active(next_l2_time)
             && !self.rollup_cfg.is_fjord_active(l2_parent.block_info.timestamp)
         {
-            upgrade_transactions.append(&mut Hardforks::FJORD.txs().collect());
+            upgrade_transactions.append(&mut Upgrades::FJORD.txs().collect());
         }
         if self.rollup_cfg.is_isthmus_active(next_l2_time)
             && !self.rollup_cfg.is_isthmus_active(l2_parent.block_info.timestamp)
         {
-            upgrade_transactions.append(&mut Hardforks::ISTHMUS.txs().collect());
+            upgrade_transactions.append(&mut Upgrades::ISTHMUS.txs().collect());
         }
         if self.rollup_cfg.is_jovian_active(next_l2_time)
             && !self.rollup_cfg.is_jovian_active(l2_parent.block_info.timestamp)
         {
-            upgrade_transactions.append(&mut Hardforks::JOVIAN.txs().collect());
+            upgrade_transactions.append(&mut Upgrades::JOVIAN.txs().collect());
         }
 
         // Build and encode the L1 info transaction for the current payload.

--- a/crates/consensus/upgrades/Cargo.toml
+++ b/crates/consensus/upgrades/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "base-consensus-upgrades"
 version.workspace = true
-description = "Consensus hardfork types for Base"
+description = "Consensus upgrade types for Base"
 
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/consensus/upgrades/README.md
+++ b/crates/consensus/upgrades/README.md
@@ -3,13 +3,13 @@
 <a href="https://crates.io/crates/base-consensus-upgrades"><img src="https://img.shields.io/crates/v/base-consensus-upgrades.svg" alt="base-consensus-upgrades crate"></a>
 <a href="https://specs.base.org"><img src="https://img.shields.io/badge/Docs-854a15?style=flat&labelColor=1C2C2E&color=BEC5C9&logo=mdBook&logoColor=BEC5C9" alt="Docs" /></a>
 
-Consensus layer hardfork types for Base including network upgrade transactions.
+Consensus layer upgrade types for Base including network upgrade transactions.
 
 ## Overview
 
-Provides typed hardfork abstractions for the Base consensus layer. Defines the `Hardfork`
-trait and a `Hardforks` registry, with concrete implementations for each upgrade (Ecotone, Fjord,
-Isthmus, Jovian) including the network upgrade transactions that must be injected at hardfork
+Provides typed upgrade abstractions for the Base consensus layer. Defines the `Upgrade`
+trait and an `Upgrades` registry, with concrete implementations for each upgrade (Ecotone, Fjord,
+Isthmus, Jovian) including the network upgrade transactions that must be injected at upgrade
 activation blocks.
 
 ## Usage
@@ -22,10 +22,10 @@ base-consensus-upgrades = { workspace = true }
 ```
 
 ```rust,ignore
-use base_consensus_upgrades::{Hardfork, Hardforks};
+use base_consensus_upgrades::{Upgrade, Upgrades};
 
-let hardforks = Hardforks::default();
-if hardforks.is_active::<Jovian>(timestamp) {
+let upgrades = Upgrades::default();
+if upgrades.is_active::<Jovian>(timestamp) {
     // apply Jovian upgrade transactions
 }
 ```

--- a/crates/consensus/upgrades/src/ecotone.rs
+++ b/crates/consensus/upgrades/src/ecotone.rs
@@ -6,7 +6,7 @@ use alloy_eips::eip2718::Encodable2718;
 use alloy_primitives::{Address, B256, Bytes, TxKind, U256, address, hex};
 use base_common_consensus::{Deployers, Predeploys, SystemAddresses, TxDeposit};
 
-use crate::{Hardfork, UpgradeCalldata};
+use crate::{Upgrade, UpgradeCalldata};
 
 /// The Ecotone network upgrade transactions.
 #[derive(Debug, Default, Clone, Copy)]
@@ -171,7 +171,7 @@ impl Ecotone {
     }
 }
 
-impl Hardfork for Ecotone {
+impl Upgrade for Ecotone {
     /// Constructs the Ecotone network upgrade transactions.
     fn txs(&self) -> impl Iterator<Item = Bytes> + '_ {
         Self::deposits().map(|tx| {

--- a/crates/consensus/upgrades/src/fjord.rs
+++ b/crates/consensus/upgrades/src/fjord.rs
@@ -6,7 +6,7 @@ use alloy_eips::eip2718::Encodable2718;
 use alloy_primitives::{Address, B256, Bytes, TxKind, U256, address, hex};
 use base_common_consensus::{Deployers, Predeploys, SystemAddresses, TxDeposit};
 
-use crate::{Hardfork, UpgradeCalldata};
+use crate::{Upgrade, UpgradeCalldata};
 
 /// The Fjord network upgrade transactions.
 #[derive(Debug, Default, Clone, Copy)]
@@ -98,7 +98,7 @@ impl Fjord {
     }
 }
 
-impl Hardfork for Fjord {
+impl Upgrade for Fjord {
     /// Constructs the Fjord network upgrade transactions.
     fn txs(&self) -> impl Iterator<Item = Bytes> + '_ {
         Self::deposits().map(|tx| {

--- a/crates/consensus/upgrades/src/forks.rs
+++ b/crates/consensus/upgrades/src/forks.rs
@@ -1,50 +1,50 @@
-//! Contains all hardforks represented in the [`crate::Hardfork`] type.
+//! Contains all upgrades represented in the [`crate::Upgrade`] type.
 
 use crate::{Ecotone, Fjord, Isthmus, Jovian};
 
-/// Base Hardforks
+/// Base Upgrades
 ///
-/// This type is used to encapsulate hardfork transactions.
-/// It exposes methods that return hardfork upgrade transactions
+/// This type is used to encapsulate upgrade transactions.
+/// It exposes methods that return upgrade transactions
 /// as [`alloy_primitives::Bytes`].
 ///
 /// # Example
 ///
-/// Build ecotone hardfork upgrade transaction:
+/// Build ecotone upgrade transaction:
 /// ```rust
-/// use base_consensus_upgrades::{Hardfork, Hardforks};
-/// let ecotone_upgrade_tx = Hardforks::ECOTONE.txs();
+/// use base_consensus_upgrades::{Upgrade, Upgrades};
+/// let ecotone_upgrade_tx = Upgrades::ECOTONE.txs();
 /// assert_eq!(ecotone_upgrade_tx.collect::<Vec<_>>().len(), 6);
 /// ```
 ///
-/// Build fjord hardfork upgrade transactions:
+/// Build fjord upgrade transactions:
 /// ```rust
-/// use base_consensus_upgrades::{Hardfork, Hardforks};
-/// let fjord_upgrade_txs = Hardforks::FJORD.txs();
+/// use base_consensus_upgrades::{Upgrade, Upgrades};
+/// let fjord_upgrade_txs = Upgrades::FJORD.txs();
 /// assert_eq!(fjord_upgrade_txs.collect::<Vec<_>>().len(), 3);
 /// ```
 ///
-/// Build isthmus hardfork upgrade transaction:
+/// Build isthmus upgrade transaction:
 /// ```rust
-/// use base_consensus_upgrades::{Hardfork, Hardforks};
-/// let isthmus_upgrade_tx = Hardforks::ISTHMUS.txs();
+/// use base_consensus_upgrades::{Upgrade, Upgrades};
+/// let isthmus_upgrade_tx = Upgrades::ISTHMUS.txs();
 /// assert_eq!(isthmus_upgrade_tx.collect::<Vec<_>>().len(), 8);
 /// ```
 #[derive(Debug, Default, Clone, Copy)]
 #[non_exhaustive]
-pub struct Hardforks;
+pub struct Upgrades;
 
-impl Hardforks {
-    /// The Ecotone hardfork upgrade transactions.
+impl Upgrades {
+    /// The Ecotone upgrade transactions.
     pub const ECOTONE: Ecotone = Ecotone;
 
-    /// The Fjord hardfork upgrade transactions.
+    /// The Fjord upgrade transactions.
     pub const FJORD: Fjord = Fjord;
 
-    /// The Isthmus hardfork upgrade transactions.
+    /// The Isthmus upgrade transactions.
     pub const ISTHMUS: Isthmus = Isthmus;
 
-    /// The Jovian hardfork upgrade transactions.
+    /// The Jovian upgrade transactions.
     pub const JOVIAN: Jovian = Jovian;
 }
 
@@ -53,20 +53,20 @@ mod tests {
     use alloc::vec::Vec;
 
     use super::*;
-    use crate::Hardfork;
+    use crate::Upgrade;
 
     #[test]
-    fn test_hardforks() {
-        let ecotone_upgrade_tx = Hardforks::ECOTONE.txs();
+    fn test_upgrades() {
+        let ecotone_upgrade_tx = Upgrades::ECOTONE.txs();
         assert_eq!(ecotone_upgrade_tx.collect::<Vec<_>>().len(), 6);
 
-        let fjord_upgrade_txs = Hardforks::FJORD.txs();
+        let fjord_upgrade_txs = Upgrades::FJORD.txs();
         assert_eq!(fjord_upgrade_txs.collect::<Vec<_>>().len(), 3);
 
-        let isthmus_upgrade_tx = Hardforks::ISTHMUS.txs();
+        let isthmus_upgrade_tx = Upgrades::ISTHMUS.txs();
         assert_eq!(isthmus_upgrade_tx.collect::<Vec<_>>().len(), 8);
 
-        let jovian_upgrade_tx = Hardforks::JOVIAN.txs();
+        let jovian_upgrade_tx = Upgrades::JOVIAN.txs();
         assert_eq!(jovian_upgrade_tx.collect::<Vec<_>>().len(), 5);
     }
 }

--- a/crates/consensus/upgrades/src/isthmus.rs
+++ b/crates/consensus/upgrades/src/isthmus.rs
@@ -10,7 +10,7 @@ use alloy_eips::eip2718::Encodable2718;
 use alloy_primitives::{Address, B256, Bytes, TxKind, U256, address, hex};
 use base_common_consensus::{Deployers, Predeploys, SystemAddresses, TxDeposit};
 
-use crate::{Hardfork, UpgradeCalldata};
+use crate::{Upgrade, UpgradeCalldata};
 
 /// The Isthmus network upgrade transactions.
 #[derive(Debug, Default, Clone, Copy)]
@@ -212,7 +212,7 @@ impl Isthmus {
     }
 }
 
-impl Hardfork for Isthmus {
+impl Upgrade for Isthmus {
     /// Constructs the network upgrade transactions.
     fn txs(&self) -> impl Iterator<Item = Bytes> + '_ {
         Self::deposits().map(|tx| {

--- a/crates/consensus/upgrades/src/jovian.rs
+++ b/crates/consensus/upgrades/src/jovian.rs
@@ -10,7 +10,7 @@ use alloy_eips::eip2718::Encodable2718;
 use alloy_primitives::{Address, Bytes, TxKind, U256, hex, keccak256};
 use base_common_consensus::{Deployers, Predeploys, SystemAddresses, TxDeposit};
 
-use crate::{Hardfork, UpgradeCalldata};
+use crate::{Upgrade, UpgradeCalldata};
 
 /// The Jovian network upgrade transactions.
 #[derive(Debug, Default, Clone, Copy)]
@@ -136,7 +136,7 @@ impl Jovian {
     }
 }
 
-impl Hardfork for Jovian {
+impl Upgrade for Jovian {
     /// Constructs the network upgrade transactions.
     fn txs(&self) -> impl Iterator<Item = Bytes> + '_ {
         Self::deposits().map(|tx| {

--- a/crates/consensus/upgrades/src/lib.rs
+++ b/crates/consensus/upgrades/src/lib.rs
@@ -36,10 +36,10 @@ macro_rules! bytecode_from_hex {
 }
 
 mod traits;
-pub use traits::Hardfork;
+pub use traits::Upgrade;
 
 mod forks;
-pub use forks::Hardforks;
+pub use forks::Upgrades;
 
 mod fjord;
 pub use fjord::Fjord;

--- a/crates/consensus/upgrades/src/traits.rs
+++ b/crates/consensus/upgrades/src/traits.rs
@@ -1,9 +1,9 @@
-//! The trait abstraction for a Hardfork.
+//! The trait abstraction for an Upgrade.
 
 use alloy_primitives::Bytes;
 
-/// The trait abstraction for a Hardfork.
-pub trait Hardfork {
-    /// Returns the hardfork upgrade transactions as [`Bytes`].
+/// The trait abstraction for an Upgrade.
+pub trait Upgrade {
+    /// Returns the upgrade transactions as [`Bytes`].
     fn txs(&self) -> impl Iterator<Item = Bytes> + '_;
 }

--- a/crates/consensus/upgrades/src/utils.rs
+++ b/crates/consensus/upgrades/src/utils.rs
@@ -1,4 +1,4 @@
-//! Utilities for creating hardforks.
+//! Utilities for creating upgrades.
 
 use alloy_primitives::{Address, Bytes, hex};
 

--- a/docs/guides/UPGRADES.md
+++ b/docs/guides/UPGRADES.md
@@ -359,7 +359,7 @@ pub fn spec_id(&self, timestamp: u64) -> base_revm::OpSpecId {
 
 ### 12. Update the reth `ChainHardforks` builder
 
-**File:** [`crates/execution/upgrades/src/chain.rs`](https://github.com/base/base/blob/main/crates/execution/upgrades/src/chain.rs)
+**File:** [`crates/common/chains/src/chain.rs`](https://github.com/base/base/blob/main/crates/common/chains/src/chain.rs)
 
 Append the new upgrade in `to_chain_hardforks()`. If it pairs with a new Ethereum upgrade (like Canyon→Shanghai), push both; if not, push only the Base upgrade entry:
 


### PR DESCRIPTION
## Summary

Renames the `Hardfork` trait and `Hardforks` registry in `base-consensus-upgrades` to `Upgrade` and `Upgrades` respectively, removing all "hardfork" terminology from doc comments and type names throughout the crate. All four concrete implementations (Ecotone, Fjord, Isthmus, Jovian) are updated to implement the renamed trait. The one external consumer in `base-consensus-derive` is updated to match.