### PR TITLE
fix: pass down bootnodes to chain config properly

### DIFF
--- a/crates/execution/chainspec/src/spec.rs
+++ b/crates/execution/chainspec/src/spec.rs
@@ -172,15 +172,11 @@ impl EthChainSpec for BaseChainSpec {
     }
 
     fn bootnodes(&self) -> Option<Vec<NodeRecord>> {
-        let config = match self.chain().id() {
-            8453 => ChainConfig::mainnet(),
-            84532 => ChainConfig::sepolia(),
-            763360 => ChainConfig::zeronet(),
-            _ => return None
-        };
-        let enodes: Vec<&str> =
-            config.bootnodes.iter().filter(|s| !s.starts_with("enr:")).copied().collect();
-        Some(parse_nodes(&enodes))
+        ChainConfig::by_chain_id(self.chain().id()).map(|cfg| {
+            let enodes: Vec<&str> =
+                cfg.bootnodes.iter().filter(|s| !s.starts_with("enr:")).copied().collect();
+            parse_nodes(&enodes)
+        })
     }
 
     fn is_optimism(&self) -> bool {

--- a/crates/execution/chainspec/src/spec.rs
+++ b/crates/execution/chainspec/src/spec.rs
@@ -172,12 +172,15 @@ impl EthChainSpec for BaseChainSpec {
     }
 
     fn bootnodes(&self) -> Option<Vec<NodeRecord>> {
-        match self.chain().id() {
-            8453 => Some(parse_nodes(ChainConfig::mainnet().bootnodes)),
-            84532 => Some(parse_nodes(ChainConfig::sepolia().bootnodes)),
-            763360 => Some(parse_nodes(ChainConfig::zeronet().bootnodes)),
-            _ => None,
-        }
+        let config = match self.chain().id() {
+            8453 => ChainConfig::mainnet(),
+            84532 => ChainConfig::sepolia(),
+            763360 => ChainConfig::zeronet(),
+            _ => return None
+        };
+        let enodes: Vec<&str> =
+            config.bootnodes.iter().filter(|s| !s.starts_with("enr:")).copied().collect();
+        Some(parse_nodes(&enodes))
     }
 
     fn is_optimism(&self) -> bool {

--- a/crates/execution/chainspec/src/spec.rs
+++ b/crates/execution/chainspec/src/spec.rs
@@ -6,7 +6,7 @@ use alloy_eips::eip7840::BlobParams;
 use alloy_genesis::Genesis;
 use alloy_hardforks::Hardfork;
 use alloy_primitives::{B256, U256};
-use base_common_chains::{BaseUpgrade, Upgrades};
+use base_common_chains::{BaseUpgrade, ChainConfig, Upgrades};
 use base_common_consensus::Predeploys;
 use derive_more::{Constructor, Deref, Into};
 use reth_chainspec::{
@@ -14,7 +14,7 @@ use reth_chainspec::{
     EthereumHardforks, ForkFilter, ForkId, Hardforks, Head,
 };
 use reth_ethereum_forks::{ChainHardforks, EthereumHardfork, ForkCondition};
-use reth_network_peers::NodeRecord;
+use reth_network_peers::{NodeRecord, parse_nodes};
 use reth_primitives_traits::SealedHeader;
 
 use crate::{
@@ -172,7 +172,12 @@ impl EthChainSpec for BaseChainSpec {
     }
 
     fn bootnodes(&self) -> Option<Vec<NodeRecord>> {
-        self.inner.bootnodes()
+        match self.chain().id() {
+            8453 => Some(parse_nodes(ChainConfig::mainnet().bootnodes)),
+            84532 => Some(parse_nodes(ChainConfig::sepolia().bootnodes)),
+            763360 => Some(parse_nodes(ChainConfig::zeronet().bootnodes)),
+            _ => None,
+        }
     }
 
     fn is_optimism(&self) -> bool {


### PR DESCRIPTION
The bootnodes defined in ChainConfig::sepolia().bootnodes (the 2 enodes in config.rs:254-257) are never wired into reth's ChainSpec. 

`BaseNetworkBuilder::build_network_config` resolves bootnodes via:
```rs
      args.network.resolved_bootnodes()
       .or_else(|| ctx.chain_spec().bootnodes())
       .unwrap_or_default()
   ```
`ctx.chain_spec().bootnodes()` calls `self.inner.bootnodes()` — reth's `ChainSpec::bootnodes()`.
But BASE_SEPOLIA (base_sepolia.rs:37) constructs the reth ChainSpec with `..Default::default()`, which sets bootnodes to an empty vec.

Unless the user passes `--bootnodes` on the CLI (which populates `resolved_bootnodes()`), the node starts with zero bootnodes and can only discover peers through discv4/v5 broadcast — connecting to random peers that likely aren't on the Base Sepolia network, hence every ECIES handshake getting rejected.

