### PR TITLE
[backport] chore(chains): Add Sepolia Discv5 Bootnodes

### DIFF
--- a/crates/common/chains/src/config.rs
+++ b/crates/common/chains/src/config.rs
@@ -254,6 +254,8 @@ const SEPOLIA: ChainConfig = ChainConfig {
     bootnodes: &[
         "enode://548f715f3fc388a7c917ba644a2f16270f1ede48a5d88a4d14ea287cc916068363f3092e39936f1a3e7885198bef0e5af951f1d7b1041ce8ba4010917777e71f@18.210.176.114:30301",
         "enode://6f10052847a966a725c9f4adf6716f9141155b99a0fb487fea3f51498f4c2a2cb8d534e680ee678f9447db85b93ff7c74562762c3714783a7233ac448603b25f@107.21.251.55:30301",
+        "enr:-J64QFa3qMsONLGphfjEkeYyF6Jkil_jCuJmm7_a42ckZeUQGLVzrzstZNb1dgBp1GGx9bzImq5VxJLP-BaptZThGiWGAYrTytOvgmlkgnY0gmlwhGsV-zeHb3BzdGFja4S0lAUAiXNlY3AyNTZrMaEDahfSECTIS_cXyZ8IyNf4leANlZnrsMEWTkEYxf4GMCmDdGNwgiQGg3VkcIIkBg",
+        "enr:-J64QBwRIWAco7lv6jImSOjPU_W266lHXzpAS5YOh7WmgTyBZkgLgOwo_mxKJq3wz2XRbsoBItbv1dCyjIoNq67mFguGAYrTxM42gmlkgnY0gmlwhBLSsHKHb3BzdGFja4S0lAUAiXNlY3AyNTZrMaEDmoWSi8hcsRpQf2eJsNUx-sqv6fH4btmo2HsAzZFAKnKDdGNwgiQGg3VkcIIkBg",
     ],
 
     genesis_json: include_str!("../res/genesis/sepolia_base.json"),

--- a/crates/consensus/disc/src/driver.rs
+++ b/crates/consensus/disc/src/driver.rs
@@ -439,10 +439,8 @@ mod tests {
             &discovery.disc,
         )
         .await;
-        assert!(
-            discovery.disc.table_entries_enr().len() >= 2,
-            "Discovery table should have at least 2 ENRs"
-        );
+        let enrs = discovery.disc.table_entries_enr();
+        assert!(enrs.len() >= 2, "Discovery table should have at least 2 ENRs");
 
         // Filter out testnet ENRs that are not valid.
         let testnet = BootNodes::testnet();
@@ -463,12 +461,11 @@ mod tests {
             })
             .collect();
 
-        // There should be 2 valid boot nodes for the testnet (all enodes).
-        assert_eq!(testnet.len(), 2);
+        // There should be 4 valid boot nodes for the testnet (all enodes).
+        assert_eq!(testnet.len(), 4);
 
         // Those ENRs should be in the testnet bootnodes.
-        let disc_enrs = discovery.disc.table_entries_enr();
-        for enr in disc_enrs {
+        for enr in &enrs {
             assert!(
                 testnet.iter().any(|pub_key| pub_key == &enr.public_key()),
                 "Discovery table does not contain testnet ENR: {enr:?}"

--- a/crates/consensus/peers/src/nodes.rs
+++ b/crates/consensus/peers/src/nodes.rs
@@ -62,7 +62,7 @@ mod tests {
     #[test]
     fn test_validate_bootnode_lens() {
         assert_eq!(ChainConfig::mainnet().bootnodes.len(), 10);
-        assert_eq!(ChainConfig::sepolia().bootnodes.len(), 2);
+        assert_eq!(ChainConfig::sepolia().bootnodes.len(), 4);
     }
 
     #[test]

--- a/crates/consensus/peers/src/nodes.rs
+++ b/crates/consensus/peers/src/nodes.rs
@@ -82,7 +82,7 @@ mod tests {
         assert_eq!(mainnet.len(), 10);
 
         let testnet = BootNodes::from_chain_id(ChainConfig::sepolia().chain_id);
-        assert_eq!(testnet.len(), 2);
+        assert_eq!(testnet.len(), 4);
 
         let unknown = BootNodes::from_chain_id(0);
         assert!(unknown.is_empty());
@@ -94,7 +94,7 @@ mod tests {
         assert_eq!(bootnodes.len(), 10);
 
         let bootnodes = BootNodes::testnet();
-        assert_eq!(bootnodes.len(), 2);
+        assert_eq!(bootnodes.len(), 4);
     }
 
     #[test]

--- a/docs/guides/UPGRADES.md
+++ b/docs/guides/UPGRADES.md
@@ -359,7 +359,7 @@ pub fn spec_id(&self, timestamp: u64) -> base_revm::OpSpecId {
 
 ### 12. Update the reth `ChainHardforks` builder
 
-**File:** [`crates/execution/upgrades/src/chain.rs`](https://github.com/base/base/blob/main/crates/execution/upgrades/src/chain.rs)
+**File:** [`crates/common/chains/src/chain.rs`](https://github.com/base/base/blob/main/crates/common/chains/src/chain.rs)
 
 Append the new upgrade in `to_chain_hardforks()`. If it pairs with a new Ethereum upgrade (like Canyon→Shanghai), push both; if not, push only the Base upgrade entry:
 


### PR DESCRIPTION
> [!NOTE]
> This is a backport of #2325 into `releases/v0.8.0`.

## Summary

Adds ENR entries for the two existing Sepolia bootnodes on port 9222, which is the op-node discv5 discovery port. The original entries used port 30301 (the execution-layer p2p port), but op-node listens for discv5 traffic on 9222. Verified locally that 18.210.176.114:9222 responds with a valid ENR and the discovery table now populates correctly. Updates the bootnode count assertions in the disc driver test and peers unit test to reflect the four total entries.