### PR TITLE
[backport] fix(p2p): Fix Discv5 Bootnode ENR IP

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3700,6 +3700,8 @@ dependencies = [
 name = "base-execution-cli"
 version = "0.8.0"
 dependencies = [
+ "alloy-eips",
+ "backon",
  "base-common-consensus",
  "base-execution-chainspec",
  "base-execution-consensus",
@@ -3714,14 +3716,24 @@ dependencies = [
  "reth-cli",
  "reth-cli-commands",
  "reth-cli-runner",
+ "reth-cli-util",
  "reth-db",
+ "reth-discv4",
+ "reth-discv5",
+ "reth-net-nat",
+ "reth-network",
+ "reth-network-p2p",
+ "reth-network-peers",
  "reth-node-builder",
  "reth-node-core",
  "reth-node-metrics",
  "reth-provider",
  "reth-rpc-server-types",
  "reth-tracing",
+ "secp256k1 0.30.0",
  "tempfile",
+ "tokio",
+ "tokio-stream",
  "tracing",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -329,10 +329,13 @@ reth-tasks = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3" }
 reth-errors = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3" }
 reth-codecs = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3" }
 reth-db-api = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3" }
+reth-discv4 = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3" }
 reth-metrics = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3" }
 reth-trie-db = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3" }
 reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3" }
 reth-network = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3" }
+reth-net-nat = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3" }
 reth-tracing = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3" }
 reth-provider = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3" }
 reth-cli-util = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3" }
@@ -347,6 +350,7 @@ reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3"
 reth-tokio-util = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3" }
 reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3" }
 reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3" }
+reth-network-p2p = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3" }
 reth-storage-api = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3" }
 reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3" }
 reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3" }

--- a/crates/execution/cli/Cargo.toml
+++ b/crates/execution/cli/Cargo.toml
@@ -12,10 +12,17 @@ workspace = true
 
 [dependencies]
 reth-cli.workspace = true
+reth-discv4.workspace = true
+reth-discv5.workspace = true
+reth-net-nat.workspace = true
 reth-provider.workspace = true
 reth-node-core.workspace = true
 base-node-core.workspace = true
+reth-network.workspace = true
+reth-cli-util.workspace = true
+reth-network-p2p.workspace = true
 reth-cli-commands.workspace = true
+reth-network-peers.workspace = true
 reth-rpc-server-types.workspace = true
 reth-db = { workspace = true, features = ["mdbx"] }
 
@@ -38,7 +45,12 @@ futures.workspace = true
 clap = { workspace = true, features = ["derive", "env"] }
 
 eyre.workspace = true
+tokio.workspace = true
+backon.workspace = true
 tracing.workspace = true
+alloy-eips.workspace = true
+secp256k1.workspace = true
+tokio-stream.workspace = true
 
 # reth test-vectors
 proptest = { workspace = true, optional = true }

--- a/crates/execution/cli/src/commands/mod.rs
+++ b/crates/execution/cli/src/commands/mod.rs
@@ -7,13 +7,14 @@ use clap::Subcommand;
 use reth_cli_commands::{
     config_cmd, db, dump_genesis, init_cmd,
     node::{self, NoArgs},
-    p2p, prune, re_execute, stage,
+    prune, re_execute, stage,
 };
 
 use crate::chainspec::BaseChainSpecParser;
 
 pub mod init_state;
 pub mod op_proofs;
+pub mod p2p;
 
 #[cfg(feature = "dev")]
 pub mod test_vectors;
@@ -40,7 +41,7 @@ pub enum Commands<Ext: clap::Args + fmt::Debug = NoArgs> {
     Stage(Box<stage::Command<BaseChainSpecParser>>),
     /// P2P Debugging utilities
     #[command(name = "p2p")]
-    P2P(Box<p2p::Command<BaseChainSpecParser>>),
+    P2P(Box<p2p::Command>),
     /// Write config to stdout
     #[command(name = "config")]
     Config(config_cmd::Command),

--- a/crates/execution/cli/src/commands/p2p/bootnode.rs
+++ b/crates/execution/cli/src/commands/p2p/bootnode.rs
@@ -1,0 +1,131 @@
+//! Bootnode command with discv5 NAT fix.
+
+use std::{net::SocketAddr, path::PathBuf};
+
+use clap::Parser;
+use reth_cli_util::{get_secret_key, load_secret_key::rng_secret_key};
+use reth_discv4::{DiscoveryUpdate, Discv4, Discv4Config};
+use reth_discv5::{Config, Discv5, discv5::Event};
+use reth_net_nat::{NatResolver, external_addr_with};
+use reth_network_peers::NodeRecord;
+use secp256k1::SecretKey;
+use tokio::select;
+use tokio_stream::StreamExt;
+use tracing::{info, warn};
+
+/// Start a discovery-only bootnode.
+#[derive(Parser, Debug)]
+pub struct Command {
+    /// Listen address for the bootnode.
+    #[arg(long, default_value = "0.0.0.0:30301")]
+    pub addr: SocketAddr,
+
+    /// Secret key for the bootnode. Deterministically sets the peer ID.
+    /// If the path exists, the key is loaded; otherwise a new key is generated and saved there.
+    /// If omitted, an ephemeral key is used.
+    #[arg(long, value_name = "PATH")]
+    pub p2p_secret_key: Option<PathBuf>,
+
+    /// NAT resolution method (any|none|upnp|publicip|extip:\<IP\>)
+    #[arg(long, default_value = "any")]
+    pub nat: NatResolver,
+
+    /// Run a discv5 topic discovery bootnode in addition to discv4.
+    #[arg(long)]
+    pub v5: bool,
+}
+
+impl Command {
+    /// Execute the bootnode command.
+    pub async fn execute(self) -> eyre::Result<()> {
+        info!(addr = %self.addr, nat = %self.nat, v5 = self.v5, "Bootnode starting");
+
+        let sk = self.network_secret()?;
+        let local_enr = NodeRecord::from_secret_key(self.addr, &sk);
+
+        let nat = self.nat;
+        let config = Discv4Config::builder().external_ip_resolver(Some(nat.clone())).build();
+        let (_discv4, mut discv4_service) = Discv4::bind(self.addr, local_enr, sk, config).await?;
+
+        info!(enr = ?local_enr, "Started discv4");
+
+        let mut discv4_updates = discv4_service.update_stream();
+        discv4_service.spawn();
+
+        let mut discv5_updates = None;
+        let mut _discv5 = None;
+
+        if self.v5 {
+            let config = Config::builder(self.addr).build();
+            let (discv5, updates) = Discv5::start(&sk, config).await?;
+
+            // The upstream reth bootnode skips NAT resolution for discv5, leaving the ENR with
+            // no IP address. Peers receiving the ENR cannot send WHOAREYOU back because they
+            // have no address to target. Resolve the external IP and update the ENR here.
+            match external_addr_with(nat).await {
+                Some(external_ip) => {
+                    let udp_socket = SocketAddr::new(external_ip, self.addr.port());
+                    discv5.with_discv5(|d| d.update_local_enr_socket(udp_socket, false));
+                    info!(enr = %discv5.local_enr(), "Started discv5");
+                }
+                None => {
+                    warn!(
+                        addr = %self.addr,
+                        "Could not resolve external IP via NAT; discv5 ENR has no IP and may not be reachable"
+                    );
+                    info!(enr = %discv5.local_enr(), "Started discv5");
+                }
+            }
+
+            discv5_updates = Some(updates);
+            _discv5 = Some(discv5);
+        }
+
+        loop {
+            select! {
+                update = discv4_updates.next() => {
+                    match update {
+                        Some(DiscoveryUpdate::Added(record)) => {
+                            info!(peer_id = ?record.id, "discv4 peer added");
+                        }
+                        Some(DiscoveryUpdate::Removed(peer_id)) => {
+                            info!(peer_id = ?peer_id, "discv4 peer removed");
+                        }
+                        Some(_) => {}
+                        None => {
+                            info!("discv4 update stream ended");
+                            break;
+                        }
+                    }
+                }
+                update = async {
+                    if let Some(updates) = &mut discv5_updates {
+                        updates.recv().await
+                    } else {
+                        futures::future::pending().await
+                    }
+                } => {
+                    match update {
+                        Some(Event::SessionEstablished(enr, _)) => {
+                            info!(peer_id = ?enr.id(), "discv5 session established");
+                        }
+                        Some(_) => {}
+                        None => {
+                            info!("discv5 update stream ended");
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    fn network_secret(&self) -> eyre::Result<SecretKey> {
+        match &self.p2p_secret_key {
+            Some(path) => Ok(get_secret_key(path)?),
+            None => Ok(rng_secret_key()),
+        }
+    }
+}

--- a/crates/execution/cli/src/commands/p2p/mod.rs
+++ b/crates/execution/cli/src/commands/p2p/mod.rs
@@ -1,0 +1,141 @@
+//! P2P subcommands, overriding the upstream bootnode with a discv5 NAT fix.
+
+use std::sync::Arc;
+
+use alloy_eips::BlockHashOrNumber;
+use backon::Retryable;
+use base_execution_chainspec::BaseChainSpec;
+use clap::{Parser, Subcommand};
+use reth_cli_commands::{
+    common::CliNodeTypes,
+    p2p::{DownloadArgs, enode, rlpx},
+};
+use reth_cli_util::hash_or_num_value_parser;
+use reth_network::{BlockDownloaderProvider, NetworkHandle};
+use reth_network_p2p::bodies::client::BodiesClient;
+use reth_node_core::utils::get_single_header;
+
+pub mod bootnode;
+
+/// P2P debugging utilities.
+#[derive(Debug, Parser)]
+pub struct Command {
+    #[command(subcommand)]
+    command: Subcommands,
+}
+
+impl Command {
+    /// Execute the p2p command.
+    pub async fn execute<N>(self) -> eyre::Result<()>
+    where
+        N: CliNodeTypes<ChainSpec = BaseChainSpec>,
+        NetworkHandle<N::NetworkPrimitives>: BlockDownloaderProvider,
+    {
+        match self.command {
+            Subcommands::Header { args, id } => {
+                let handle = args.launch_network::<N>().await?;
+                let fetch_client = handle.fetch_client().await?;
+                let backoff = args.backoff();
+
+                let header = (move || get_single_header(fetch_client.clone(), id))
+                    .retry(backoff)
+                    .notify(|err, _| {
+                        tracing::warn!(target: "reth::cli", error = %err, "Error requesting header. Retrying...")
+                    })
+                    .await?;
+                tracing::info!(target: "reth::cli", ?header, "Successfully downloaded header");
+            }
+            Subcommands::Body { args, id } => {
+                let handle = args.launch_network::<N>().await?;
+                let fetch_client = handle.fetch_client().await?;
+                let backoff = args.backoff();
+
+                let hash = match id {
+                    BlockHashOrNumber::Hash(hash) => hash,
+                    BlockHashOrNumber::Number(number) => {
+                        tracing::info!(target: "reth::cli", "Block number provided. Downloading header first...");
+                        let client = fetch_client.clone();
+                        let header = (move || {
+                            get_single_header(
+                                client.clone(),
+                                BlockHashOrNumber::Number(number),
+                            )
+                        })
+                        .retry(backoff)
+                        .notify(|err, _| {
+                            tracing::warn!(target: "reth::cli", error = %err, "Error requesting header. Retrying...")
+                        })
+                        .await?;
+                        header.hash()
+                    }
+                };
+
+                let (_, result) = (move || {
+                    let client = fetch_client.clone();
+                    client.get_block_bodies(vec![hash])
+                })
+                .retry(backoff)
+                .notify(|err, _| {
+                    tracing::warn!(target: "reth::cli", error = %err, "Error requesting block. Retrying...")
+                })
+                .await?
+                .split();
+
+                if result.len() != 1 {
+                    eyre::bail!(
+                        "Invalid number of bodies received. Expected: 1. Received: {}",
+                        result.len()
+                    )
+                }
+                let body = result.into_iter().next().unwrap();
+                tracing::info!(target: "reth::cli", ?body, "Successfully downloaded body");
+            }
+            Subcommands::Rlpx(command) => {
+                command.execute().await?;
+            }
+            Subcommands::Bootnode(command) => {
+                command.execute().await?;
+            }
+            Subcommands::Enode(command) => {
+                command.execute()?;
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Returns the chain spec if one is embedded in the active subcommand.
+    ///
+    /// Header and Body delegate chain parsing internally to [`DownloadArgs`] whose `chain`
+    /// field is private, so we return `None` for those. Only the log-directory path suffix
+    /// uses this value, so the impact is cosmetic.
+    pub const fn chain_spec(&self) -> Option<&Arc<BaseChainSpec>> {
+        None
+    }
+}
+
+#[derive(Subcommand, Debug)]
+enum Subcommands {
+    /// Download a block header by number or hash.
+    Header {
+        #[command(flatten)]
+        args: DownloadArgs<crate::chainspec::BaseChainSpecParser>,
+        /// Block number or hash to fetch.
+        #[arg(value_parser = hash_or_num_value_parser)]
+        id: BlockHashOrNumber,
+    },
+    /// Download a block body by number or hash.
+    Body {
+        #[command(flatten)]
+        args: DownloadArgs<crate::chainspec::BaseChainSpecParser>,
+        /// Block number or hash to fetch.
+        #[arg(value_parser = hash_or_num_value_parser)]
+        id: BlockHashOrNumber,
+    },
+    /// `RLPx` utilities.
+    Rlpx(rlpx::Command),
+    /// Start a discovery-only bootnode.
+    Bootnode(bootnode::Command),
+    /// Print the enode identifier of this node.
+    Enode(enode::Command),
+}

--- a/docs/guides/UPGRADES.md
+++ b/docs/guides/UPGRADES.md
@@ -212,7 +212,7 @@ fn is_base_v1_active_at_timestamp(&self, timestamp: u64) -> bool {
 **Files:**
 - [`crates/common/chains/src/upgrade.rs`](../../crates/common/chains/src/upgrade.rs) (mainnet, sepolia, devnet constants)
 - [`crates/common/chains/src/lib.rs`](../../crates/common/chains/src/lib.rs)
-- [`crates/consensus/registry/src/test_utils/mod.rs`](https://github.com/base/base/blob/main/crates/consensus/registry/src/test_utils/mod.rs)
+- [`crates/common/chains/src/test_utils.rs`](https://github.com/base/base/blob/main/crates/common/chains/src/test_utils.rs)
 
 Add named constants once an activation timestamp is confirmed:
 
@@ -244,7 +244,7 @@ Until an activation timestamp is confirmed, leave `base: None` and the chain arr
 
 ### 7. Update the default rollup config
 
-**File:** [`crates/consensus/registry/src/test_utils/mod.rs`](https://github.com/base/base/blob/main/crates/consensus/registry/src/test_utils/mod.rs)
+**File:** [`crates/common/chains/src/test_utils.rs`](https://github.com/base/base/blob/main/crates/common/chains/src/test_utils.rs)
 
 The `default_rollup_config()` function sets all upgrades active at genesis for dev use. Add the new upgrade:
 
@@ -260,7 +260,7 @@ hardforks: HardForkConfig {
 
 ### 8. Verify the upgrade consistency tests
 
-**File:** [`crates/consensus/registry/tests/hardfork_consistency.rs`](https://github.com/base/base/blob/main/crates/consensus/registry/tests/hardfork_consistency.rs)
+**File:** [`crates/common/chains/tests/hardfork_consistency.rs`](https://github.com/base/base/blob/main/crates/common/chains/tests/hardfork_consistency.rs)
 
 These tests assert that `BaseChainConfig::mainnet().upgrade_activation(fork)` matches `BaseChainUpgrades::mainnet().upgrade_activation(fork)` for every `BaseUpgrade` variant. They should pass without changes as long as both sides consistently return `ForkCondition::Never` for an unscheduled upgrade or the same timestamp once scheduled.
 


### PR DESCRIPTION
> [!NOTE]
> This is a backport of #2330 into `releases/v0.8.0`.

## Summary

The upstream reth `p2p bootnode` command applies NAT resolution for discv4 via `external_ip_resolver` but skips it entirely for discv5. This leaves the local ENR with no IP field because `build_local_enr` omits the `ip4` entry when the listen address is `0.0.0.0` (UNSPECIFIED). Peers that receive an ENR with no IP have no address to send WHOAREYOU to, so the discv5 handshake never completes and no sessions are established.

This fix overrides the `p2p bootnode` subcommand to resolve the external IP via the configured NAT resolver after starting discv5, then patches the ENR UDP socket using `update_local_enr_socket`. The discv5 service still binds to `0.0.0.0` for listening; only the advertised ENR address is updated, mirroring exactly how discv4 handles NAT.