### PR TITLE
[backport] fix: pass down bootnodes to chain config properly

### DIFF
--- a/crates/execution/chainspec/src/spec.rs
+++ b/crates/execution/chainspec/src/spec.rs
@@ -6,7 +6,7 @@ use alloy_eips::eip7840::BlobParams;
 use alloy_genesis::Genesis;
 use alloy_hardforks::Hardfork;
 use alloy_primitives::{B256, U256};
-use base_common_chains::{BaseUpgrade, Upgrades};
+use base_common_chains::{BaseUpgrade, ChainConfig, Upgrades};
 use base_common_consensus::Predeploys;
 use base_execution_upgrades::BASE_MAINNET_UPGRADES;
 use derive_more::{Constructor, Deref, Into};
@@ -15,7 +15,7 @@ use reth_chainspec::{
     EthereumHardforks, ForkFilter, ForkId, Hardforks, Head,
 };
 use reth_ethereum_forks::{ChainHardforks, EthereumHardfork, ForkCondition};
-use reth_network_peers::NodeRecord;
+use reth_network_peers::{NodeRecord, parse_nodes};
 use reth_primitives_traits::SealedHeader;
 
 use crate::{
@@ -174,7 +174,13 @@ impl EthChainSpec for BaseChainSpec {
     }
 
     fn bootnodes(&self) -> Option<Vec<NodeRecord>> {
-        self.inner.bootnodes()
+        match self.chain().id() {
+            8453 => Some(parse_nodes(ChainConfig::mainnet().bootnodes)),
+            84532 => Some(parse_nodes(ChainConfig::sepolia().bootnodes)),
+            11763072 => Some(parse_nodes(ChainConfig::alpha().bootnodes)),
+            763360 => Some(parse_nodes(ChainConfig::zeronet().bootnodes)),
+            _ => None,
+        }
     }
 
     fn is_optimism(&self) -> bool {

--- a/crates/execution/chainspec/src/spec.rs
+++ b/crates/execution/chainspec/src/spec.rs
@@ -174,16 +174,11 @@ impl EthChainSpec for BaseChainSpec {
     }
 
     fn bootnodes(&self) -> Option<Vec<NodeRecord>> {
-        let config = match self.chain().id() {
-            8453 => ChainConfig::mainnet(),
-            84532 => ChainConfig::sepolia(),
-            11763072 => ChainConfig::alpha(),
-            763360 => ChainConfig::zeronet(),
-            _ => return None,
-        };
-        let enodes: Vec<&str> =
-            config.bootnodes.iter().filter(|s| !s.starts_with("enr:")).copied().collect();
-        Some(parse_nodes(&enodes))
+        ChainConfig::by_chain_id(self.chain().id()).map(|cfg| {
+            let enodes: Vec<&str> =
+                cfg.bootnodes.iter().filter(|s| !s.starts_with("enr:")).copied().collect();
+            parse_nodes(&enodes)
+        })
     }
 
     fn is_optimism(&self) -> bool {

--- a/crates/execution/chainspec/src/spec.rs
+++ b/crates/execution/chainspec/src/spec.rs
@@ -174,13 +174,16 @@ impl EthChainSpec for BaseChainSpec {
     }
 
     fn bootnodes(&self) -> Option<Vec<NodeRecord>> {
-        match self.chain().id() {
-            8453 => Some(parse_nodes(ChainConfig::mainnet().bootnodes)),
-            84532 => Some(parse_nodes(ChainConfig::sepolia().bootnodes)),
-            11763072 => Some(parse_nodes(ChainConfig::alpha().bootnodes)),
-            763360 => Some(parse_nodes(ChainConfig::zeronet().bootnodes)),
-            _ => None,
-        }
+        let config = match self.chain().id() {
+            8453 => ChainConfig::mainnet(),
+            84532 => ChainConfig::sepolia(),
+            11763072 => ChainConfig::alpha(),
+            763360 => ChainConfig::zeronet(),
+            _ => return None,
+        };
+        let enodes: Vec<&str> =
+            config.bootnodes.iter().filter(|s| !s.starts_with("enr:")).copied().collect();
+        Some(parse_nodes(&enodes))
     }
 
     fn is_optimism(&self) -> bool {

--- a/docs/guides/UPGRADES.md
+++ b/docs/guides/UPGRADES.md
@@ -212,7 +212,7 @@ fn is_base_v1_active_at_timestamp(&self, timestamp: u64) -> bool {
 **Files:**
 - [`crates/common/chains/src/upgrade.rs`](../../crates/common/chains/src/upgrade.rs) (mainnet, sepolia, devnet constants)
 - [`crates/common/chains/src/lib.rs`](../../crates/common/chains/src/lib.rs)
-- [`crates/consensus/registry/src/test_utils/mod.rs`](https://github.com/base/base/blob/main/crates/consensus/registry/src/test_utils/mod.rs)
+- [`crates/common/chains/src/test_utils.rs`](https://github.com/base/base/blob/main/crates/common/chains/src/test_utils.rs)
 
 Add named constants once an activation timestamp is confirmed:
 
@@ -244,7 +244,7 @@ Until an activation timestamp is confirmed, leave `base: None` and the chain arr
 
 ### 7. Update the default rollup config
 
-**File:** [`crates/consensus/registry/src/test_utils/mod.rs`](https://github.com/base/base/blob/main/crates/consensus/registry/src/test_utils/mod.rs)
+**File:** [`crates/common/chains/src/test_utils.rs`](https://github.com/base/base/blob/main/crates/common/chains/src/test_utils.rs)
 
 The `default_rollup_config()` function sets all upgrades active at genesis for dev use. Add the new upgrade:
 
@@ -260,7 +260,7 @@ hardforks: HardForkConfig {
 
 ### 8. Verify the upgrade consistency tests
 
-**File:** [`crates/consensus/registry/tests/hardfork_consistency.rs`](https://github.com/base/base/blob/main/crates/consensus/registry/tests/hardfork_consistency.rs)
+**File:** [`crates/common/chains/tests/hardfork_consistency.rs`](https://github.com/base/base/blob/main/crates/common/chains/tests/hardfork_consistency.rs)
 
 These tests assert that `BaseChainConfig::mainnet().upgrade_activation(fork)` matches `BaseChainUpgrades::mainnet().upgrade_activation(fork)` for every `BaseUpgrade` variant. They should pass without changes as long as both sides consistently return `ForkCondition::Never` for an unscheduled upgrade or the same timestamp once scheduled.
 


### PR DESCRIPTION
## Summary

Backport of `hh/pass-down-bootnodes-to-chainconfig` to `releases/v0.8.0`.

- **fix**: Use `ChainConfig::by_chain_id()` to look up bootnodes instead of delegating to `self.inner.bootnodes()`, which was returning an empty list
- **fix**: Filter out ENR strings (`enr:` prefix) before parsing bootnodes, since the parser only handles enode URLs
- **refactor**: Use `by_chain_id()` helper for bootnode lookup

### Cherry-picked commits
- `295ab667e` fix: pass down bootnodes to chain config properly
- `1de0e2d02` fix: filter out ENR strings before parsing bootnodes
- `63d8b35e9` refactor: use by_chain_id() for bootnode lookup

### Conflict resolution
One import conflict resolved: kept `ChainConfig` in `base_common_chains` import and preserved `BASE_MAINNET_UPGRADES` from `base_execution_upgrades` (matching the release branch's module structure).