### PR TITLE
fix: add zeronet bootnodes

### DIFF
--- a/crates/common/chains/src/config.rs
+++ b/crates/common/chains/src/config.rs
@@ -406,7 +406,12 @@ const ZERONET: ChainConfig = ChainConfig {
 
     max_gas_limit: 25_000_000,
 
-    bootnodes: &[],
+    bootnodes: &[
+        "enr:-J-4QDS5Z5P4BoDbOlLGOcdXjcv2Nc5_PgP28lIxP4lKU6qYR-m10c8rHdcHk0DdmTvZpndoSpuK__688dmX-tlOsNKGAZ22NI20gmlkgnY0gmlwhCzGBHaHb3BzdGFja4WA-80FAIlzZWNwMjU2azGhA4Qs8_ZWeMdUNldNdjnAxd018gjWofqKoW4_pr0qzvTtg3RjcIIkBoN1ZHCCJAY",
+        "enode://cd4528698249ad8b36fa7b1cad75aa5683ad355e6f0776629eaff1d83cfbb575062330d711efefbfa0d531c86969c2daf9a88fb28cddbbad216f46ac367981eb@44.198.4.118:30301",
+        "enr:-J-4QKgMF6zAv7u_75LTXLJKgLtEn4HcI8gaqsDAl78nfw7VQE-EN6dUZCZW4_CI42MAOWUCinrV8rP5hbBu3aje-u-GAZ22LUBogmlkgnY0gmlwhDQCC1-Hb3BzdGFja4WA-80FAIlzZWNwMjU2azGhArwjzoKlEKQiEXtuZ0qT23Wy_3IeEXbAJo7VKDO2Yovig3RjcIIkBoN1ZHCCJAY",
+        "enode://ea188fb5482ff8eb372956d674ecb6d09cbd42e6874121957a47b2ad252f54953c49866d2dcabcfc272fcc63e163a67b097fe4354283e56ddf077fc017b2a127@52.2.11.95:30301",
+    ],
 
     genesis_json: include_str!("../res/genesis/zeronet_base.json"),
 };

--- a/crates/consensus/peers/src/nodes.rs
+++ b/crates/consensus/peers/src/nodes.rs
@@ -63,6 +63,7 @@ mod tests {
     fn test_validate_bootnode_lens() {
         assert_eq!(ChainConfig::mainnet().bootnodes.len(), 10);
         assert_eq!(ChainConfig::sepolia().bootnodes.len(), 4);
+        assert_eq!(ChainConfig::zeronet().bootnodes.len(), 4);
     }
 
     #[test]
@@ -74,6 +75,10 @@ mod tests {
         for raw in ChainConfig::sepolia().bootnodes {
             BootNode::parse_bootnode(raw).expect("hardcoded bootnode should parse");
         }
+
+        for raw in ChainConfig::zeronet().bootnodes {
+            BootNode::parse_bootnode(raw).expect("hardcoded bootnode should parse");
+        }
     }
 
     #[test]
@@ -83,6 +88,9 @@ mod tests {
 
         let testnet = BootNodes::from_chain_id(ChainConfig::sepolia().chain_id);
         assert_eq!(testnet.len(), 4);
+
+        let zeronet = BootNodes::from_chain_id(ChainConfig::zeronet().chain_id);
+        assert_eq!(zeronet.len(), 4);
 
         let unknown = BootNodes::from_chain_id(0);
         assert!(unknown.is_empty());


### PR DESCRIPTION
## Summary
- add the provided ENR/enode bootnodes to the zeronet chain config
- extend consensus peer bootnode tests to cover zeronet count and parsing

## Testing
- cargo test -p base-consensus-peers test_bootnodes -- --nocapture
- cargo test -p base-consensus-peers test_parse_raw_bootnodes -- --nocapture
- cargo test -p base-common-chains --lib