### PR TITLE
bootnode: split v4_addr and v5_addr

### DIFF
--- a/crates/execution/cli/src/commands/p2p/bootnode.rs
+++ b/crates/execution/cli/src/commands/p2p/bootnode.rs
@@ -16,9 +16,13 @@ use tracing::{info, warn};
 /// Start a discovery-only bootnode.
 #[derive(Parser, Debug)]
 pub struct Command {
-    /// Listen address for the bootnode.
+    /// Listen address for the bootnode for discv4
     #[arg(long, default_value = "0.0.0.0:30301")]
-    pub addr: SocketAddr,
+    pub v4_addr: SocketAddr,
+
+    /// Listen address for the bootnode for discv5
+    #[arg(long, default_value = "0.0.0.0:9200")]
+    pub v5_addr: SocketAddr,
 
     /// Secret key for the bootnode. Deterministically sets the peer ID.
     /// If the path exists, the key is loaded; otherwise a new key is generated and saved there.
@@ -38,25 +42,26 @@ pub struct Command {
 impl Command {
     /// Execute the bootnode command.
     pub async fn execute(self) -> eyre::Result<()> {
-        info!(addr = %self.addr, nat = %self.nat, v5 = self.v5, "Bootnode starting");
+        info!(v4_addr = %self.v4_addr, v5_addr = %self.v5_addr, nat = %self.nat, v5 = self.v5, "Bootnode starting");
 
+        // discv4
         let sk = self.network_secret()?;
-        let local_enr = NodeRecord::from_secret_key(self.addr, &sk);
-
+        let v4_node_record = NodeRecord::from_secret_key(self.v4_addr, &sk);
         let nat = self.nat;
         let config = Discv4Config::builder().external_ip_resolver(Some(nat.clone())).build();
-        let (_discv4, mut discv4_service) = Discv4::bind(self.addr, local_enr, sk, config).await?;
-
-        info!(enr = ?local_enr, "Started discv4");
-
+        let (_discv4, mut discv4_service) =
+            Discv4::bind(self.v4_addr, v4_node_record, sk, config).await?;
+        info!(v4_node_record = ?v4_node_record, enode = %v4_node_record, "Started discv4");
         let mut discv4_updates = discv4_service.update_stream();
         discv4_service.spawn();
 
+        // discv5
         let mut discv5_updates = None;
         let mut _discv5 = None;
 
         if self.v5 {
-            let config = Config::builder(self.addr).build();
+            info!("Initializing discv5");
+            let config = Config::builder(self.v5_addr).build();
             let (discv5, updates) = Discv5::start(&sk, config).await?;
 
             // The upstream reth bootnode skips NAT resolution for discv5, leaving the ENR with
@@ -64,18 +69,18 @@ impl Command {
             // have no address to target. Resolve the external IP and update the ENR here.
             match external_addr_with(nat).await {
                 Some(external_ip) => {
-                    let udp_socket = SocketAddr::new(external_ip, self.addr.port());
-                    discv5.with_discv5(|d| d.update_local_enr_socket(udp_socket, false));
-                    info!(enr = %discv5.local_enr(), "Started discv5");
+                    let socket = SocketAddr::new(external_ip, self.v5_addr.port());
+                    discv5.with_discv5(|d| d.update_local_enr_socket(socket, false));
                 }
                 None => {
                     warn!(
-                        addr = %self.addr,
+                        addr = %self.v5_addr,
                         "Could not resolve external IP via NAT; discv5 ENR has no IP and may not be reachable"
                     );
-                    info!(enr = %discv5.local_enr(), "Started discv5");
                 }
             }
+
+            info!(enr = %discv5.local_enr(), "Started discv5");
 
             discv5_updates = Some(updates);
             _discv5 = Some(discv5);


### PR DESCRIPTION
Instead of a single `addr`, take `v4_addr` and `v5_addr` so that the Discv5 ENR isn't set to `:30301` which is the port discv4 is listening on