### PR TITLE
[Backport v0.8.0] feat: include receipt fields in flashblock subscriptions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4042,6 +4042,7 @@ dependencies = [
  "alloy-rpc-types",
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
+ "alloy-serde",
  "arc-swap",
  "base-common-chains",
  "base-common-consensus",

--- a/crates/client/flashblocks-node/tests/flashblocks_rpc.rs
+++ b/crates/client/flashblocks-node/tests/flashblocks_rpc.rs
@@ -1172,6 +1172,16 @@ async fn test_eth_subscribe_new_flashblock_transactions_full() -> eyre::Result<(
     assert!(tx["hash"].is_string(), "Expected full tx with hash field");
     assert!(tx["blockNumber"].is_string(), "Expected full tx with blockNumber field");
     assert!(tx["logs"].is_array(), "Expected logs array in full transaction");
+    assert_eq!(tx["status"], "0x1", "Expected receipt-style status field");
+    assert!(
+        tx["cumulativeGasUsed"].is_string(),
+        "Expected cumulativeGasUsed field in full transaction"
+    );
+    assert!(
+        tx["contractAddress"].is_null() || tx["contractAddress"].is_string(),
+        "Expected contractAddress field in full transaction"
+    );
+    assert!(tx["logsBloom"].is_string(), "Expected logsBloom field in full transaction");
 
     // Send second flashblock with 9 more transactions (delta only, not cumulative)
     setup.send_flashblock(setup.create_second_payload()).await?;
@@ -1185,6 +1195,16 @@ async fn test_eth_subscribe_new_flashblock_transactions_full() -> eyre::Result<(
         let tx = &notif["params"]["result"];
         assert!(tx["hash"].is_string() && tx["blockNumber"].is_string());
         assert!(tx["logs"].is_array(), "Expected logs array in full transaction");
+        assert_eq!(tx["status"], "0x1", "Expected receipt-style status field");
+        assert!(
+            tx["cumulativeGasUsed"].is_string(),
+            "Expected cumulativeGasUsed field in full transaction"
+        );
+        assert!(
+            tx["contractAddress"].is_null() || tx["contractAddress"].is_string(),
+            "Expected contractAddress field in full transaction"
+        );
+        assert!(tx["logsBloom"].is_string(), "Expected logsBloom field in full transaction");
         received_count += 1;
     }
     assert_eq!(received_count, 9);

--- a/crates/client/flashblocks-node/tests/flashblocks_rpc.rs
+++ b/crates/client/flashblocks-node/tests/flashblocks_rpc.rs
@@ -1172,7 +1172,11 @@ async fn test_eth_subscribe_new_flashblock_transactions_full() -> eyre::Result<(
     assert!(tx["hash"].is_string(), "Expected full tx with hash field");
     assert!(tx["blockNumber"].is_string(), "Expected full tx with blockNumber field");
     assert!(tx["logs"].is_array(), "Expected logs array in full transaction");
-    assert!(tx["gasUsed"].is_number(), "Expected numeric gasUsed field");
+    let gas_used = tx["gasUsed"].as_str().expect("expected gasUsed hex string");
+    assert!(
+        gas_used.starts_with("0x"),
+        "Expected receipt-style gasUsed field, got: {gas_used}"
+    );
     assert_eq!(tx["status"], "0x1", "Expected receipt-style status field");
     assert!(
         tx["cumulativeGasUsed"].is_string(),
@@ -1196,7 +1200,11 @@ async fn test_eth_subscribe_new_flashblock_transactions_full() -> eyre::Result<(
         let tx = &notif["params"]["result"];
         assert!(tx["hash"].is_string() && tx["blockNumber"].is_string());
         assert!(tx["logs"].is_array(), "Expected logs array in full transaction");
-        assert!(tx["gasUsed"].is_number(), "Expected numeric gasUsed field");
+        let gas_used = tx["gasUsed"].as_str().expect("expected gasUsed hex string");
+        assert!(
+            gas_used.starts_with("0x"),
+            "Expected receipt-style gasUsed field, got: {gas_used}"
+        );
         assert_eq!(tx["status"], "0x1", "Expected receipt-style status field");
         assert!(
             tx["cumulativeGasUsed"].is_string(),

--- a/crates/client/flashblocks-node/tests/flashblocks_rpc.rs
+++ b/crates/client/flashblocks-node/tests/flashblocks_rpc.rs
@@ -1172,6 +1172,7 @@ async fn test_eth_subscribe_new_flashblock_transactions_full() -> eyre::Result<(
     assert!(tx["hash"].is_string(), "Expected full tx with hash field");
     assert!(tx["blockNumber"].is_string(), "Expected full tx with blockNumber field");
     assert!(tx["logs"].is_array(), "Expected logs array in full transaction");
+    assert!(tx["gasUsed"].is_number(), "Expected numeric gasUsed field");
     assert_eq!(tx["status"], "0x1", "Expected receipt-style status field");
     assert!(
         tx["cumulativeGasUsed"].is_string(),
@@ -1195,6 +1196,7 @@ async fn test_eth_subscribe_new_flashblock_transactions_full() -> eyre::Result<(
         let tx = &notif["params"]["result"];
         assert!(tx["hash"].is_string() && tx["blockNumber"].is_string());
         assert!(tx["logs"].is_array(), "Expected logs array in full transaction");
+        assert!(tx["gasUsed"].is_number(), "Expected numeric gasUsed field");
         assert_eq!(tx["status"], "0x1", "Expected receipt-style status field");
         assert!(
             tx["cumulativeGasUsed"].is_string(),

--- a/crates/client/flashblocks-node/tests/flashblocks_rpc.rs
+++ b/crates/client/flashblocks-node/tests/flashblocks_rpc.rs
@@ -1173,10 +1173,7 @@ async fn test_eth_subscribe_new_flashblock_transactions_full() -> eyre::Result<(
     assert!(tx["blockNumber"].is_string(), "Expected full tx with blockNumber field");
     assert!(tx["logs"].is_array(), "Expected logs array in full transaction");
     let gas_used = tx["gasUsed"].as_str().expect("expected gasUsed hex string");
-    assert!(
-        gas_used.starts_with("0x"),
-        "Expected receipt-style gasUsed field, got: {gas_used}"
-    );
+    assert!(gas_used.starts_with("0x"), "Expected receipt-style gasUsed field, got: {gas_used}");
     assert_eq!(tx["status"], "0x1", "Expected receipt-style status field");
     assert!(
         tx["cumulativeGasUsed"].is_string(),

--- a/crates/execution/flashblocks/Cargo.toml
+++ b/crates/execution/flashblocks/Cargo.toml
@@ -38,6 +38,7 @@ revm-database.workspace = true
 alloy-network.workspace = true
 alloy-provider.workspace = true
 alloy-rpc-types.workspace = true
+alloy-serde.workspace = true
 alloy-primitives.workspace = true
 alloy-eips = { workspace = true, features = ["std"] }
 alloy-consensus = { workspace = true, features = ["std"] }

--- a/crates/execution/flashblocks/Cargo.toml
+++ b/crates/execution/flashblocks/Cargo.toml
@@ -35,10 +35,10 @@ revm.workspace = true
 revm-database.workspace = true
 
 # alloy
+alloy-serde.workspace = true
 alloy-network.workspace = true
 alloy-provider.workspace = true
 alloy-rpc-types.workspace = true
-alloy-serde.workspace = true
 alloy-primitives.workspace = true
 alloy-eips = { workspace = true, features = ["std"] }
 alloy-consensus = { workspace = true, features = ["std"] }

--- a/crates/execution/flashblocks/src/error.rs
+++ b/crates/execution/flashblocks/src/error.rs
@@ -110,6 +110,15 @@ pub enum BuildError {
     /// Cannot build pending blocks with no flashblocks.
     #[error("no flashblocks: cannot build pending blocks from empty flashblock collection")]
     NoFlashblocks,
+
+    /// Cannot build pending blocks when a transaction is missing its receipt.
+    #[error(
+        "missing receipt: cannot build pending blocks when transaction {tx_hash} has no receipt"
+    )]
+    MissingReceipt {
+        /// The hash of the transaction missing a receipt.
+        tx_hash: B256,
+    },
 }
 
 /// Errors that can occur during flashblock state processing.
@@ -237,19 +246,6 @@ mod tests {
         for substring in substrings {
             assert!(display.contains(substring), "expected '{display}' to contain '{substring}'");
         }
-    }
-
-    #[rstest]
-    #[case::missing_headers(
-        BuildError::MissingHeaders,
-        "missing headers: cannot build pending blocks without header information"
-    )]
-    #[case::no_flashblocks(
-        BuildError::NoFlashblocks,
-        "no flashblocks: cannot build pending blocks from empty flashblock collection"
-    )]
-    fn test_build_error_display(#[case] error: BuildError, #[case] expected: &str) {
-        assert_eq!(error.to_string(), expected);
     }
 
     #[rstest]

--- a/crates/execution/flashblocks/src/pending_blocks.rs
+++ b/crates/execution/flashblocks/src/pending_blocks.rs
@@ -12,7 +12,7 @@ use alloy_rpc_types_engine::PayloadId;
 use alloy_rpc_types_eth::{Filter, Header as RPCHeader, Log};
 use arc_swap::Guard;
 use base_common_consensus::OpTxType;
-use base_common_evm::{BaseHaltReason, BaseTxResult};
+use base_common_evm::{BaseTxResult, OpHaltReason};
 use base_common_flashblocks::Flashblock;
 use base_common_network::Base;
 use base_common_rpc_types::{BaseTransactionReceipt, Transaction};
@@ -43,7 +43,7 @@ pub struct PendingBlocksBuilder {
     transaction_state: HashMap<B256, EvmState>,
     transaction_senders: HashMap<B256, Address>,
     state_overrides: Option<StateOverride>,
-    transaction_results: HashMap<B256, ExecutionResult<BaseHaltReason>>,
+    transaction_results: HashMap<B256, ExecutionResult<OpHaltReason>>,
     execution_times: HashMap<B256, u128>,
     state_root_times: HashMap<B256, u128>,
 
@@ -156,7 +156,7 @@ impl PendingBlocksBuilder {
     pub fn with_transaction_result(
         &mut self,
         hash: B256,
-        result: ExecutionResult<BaseHaltReason>,
+        result: ExecutionResult<OpHaltReason>,
     ) -> &Self {
         self.transaction_results.insert(hash, result);
         self
@@ -228,7 +228,7 @@ pub struct PendingBlocks {
     transaction_state: HashMap<B256, EvmState>,
     transaction_senders: HashMap<B256, Address>,
     state_overrides: Option<StateOverride>,
-    transaction_results: HashMap<B256, ExecutionResult<BaseHaltReason>>,
+    transaction_results: HashMap<B256, ExecutionResult<OpHaltReason>>,
     execution_times: HashMap<B256, u128>,
     state_root_times: HashMap<B256, u128>,
 
@@ -358,10 +358,7 @@ impl PendingBlocks {
     }
 
     /// Returns the execution result for a transaction.
-    pub fn get_transaction_result(
-        &self,
-        tx_hash: &B256,
-    ) -> Option<&ExecutionResult<BaseHaltReason>> {
+    pub fn get_transaction_result(&self, tx_hash: &B256) -> Option<&ExecutionResult<OpHaltReason>> {
         self.transaction_results.get(tx_hash)
     }
 
@@ -376,7 +373,7 @@ impl PendingBlocks {
     }
 
     /// Returns the receipt and state for a transaction.
-    pub fn get_tx_result(&self, tx_hash: &B256) -> Option<BaseTxResult<BaseHaltReason, OpTxType>> {
+    pub fn get_op_tx_result(&self, tx_hash: &B256) -> Option<BaseTxResult<OpHaltReason, OpTxType>> {
         let (((result, state), tx), sender) = self
             .get_transaction_result(tx_hash)
             .zip(self.get_transaction_state(tx_hash))
@@ -811,7 +808,7 @@ mod tests {
         receipt
     }
 
-    fn test_execution_result() -> ExecutionResult<BaseHaltReason> {
+    fn test_execution_result() -> ExecutionResult<OpHaltReason> {
         ExecutionResult::Success {
             reason: revm::context::result::SuccessReason::Stop,
             gas_used: 21000,
@@ -856,7 +853,7 @@ mod tests {
         let (tx_hash, pending_blocks) =
             build_pending_blocks(test_legacy_transaction(), Some(da_footprint));
 
-        let result = pending_blocks.get_tx_result(&tx_hash).expect("should return tx result");
+        let result = pending_blocks.get_op_tx_result(&tx_hash).expect("should return tx result");
 
         assert_eq!(result.inner.blob_gas_used, da_footprint);
         assert_eq!(result.inner.tx_type, OpTxType::Legacy);
@@ -869,7 +866,7 @@ mod tests {
     fn get_tx_result_reconstructs_all_fields_for_deposit_tx() {
         let (tx_hash, pending_blocks) = build_pending_blocks(test_deposit_transaction(), Some(0));
 
-        let result = pending_blocks.get_tx_result(&tx_hash).expect("should return tx result");
+        let result = pending_blocks.get_op_tx_result(&tx_hash).expect("should return tx result");
 
         assert_eq!(result.inner.blob_gas_used, 0);
         assert_eq!(result.inner.tx_type, OpTxType::Deposit);
@@ -882,7 +879,7 @@ mod tests {
     fn get_tx_result_defaults_blob_gas_to_zero_when_receipt_field_is_none() {
         let (tx_hash, pending_blocks) = build_pending_blocks(test_legacy_transaction(), None);
 
-        let result = pending_blocks.get_tx_result(&tx_hash).expect("should return tx result");
+        let result = pending_blocks.get_op_tx_result(&tx_hash).expect("should return tx result");
 
         assert_eq!(result.inner.blob_gas_used, 0);
     }

--- a/crates/execution/flashblocks/src/pending_blocks.rs
+++ b/crates/execution/flashblocks/src/pending_blocks.rs
@@ -12,7 +12,7 @@ use alloy_rpc_types_engine::PayloadId;
 use alloy_rpc_types_eth::{Filter, Header as RPCHeader, Log};
 use arc_swap::Guard;
 use base_common_consensus::OpTxType;
-use base_common_evm::{BaseTxResult, OpHaltReason};
+use base_common_evm::{BaseHaltReason, BaseTxResult};
 use base_common_flashblocks::Flashblock;
 use base_common_network::Base;
 use base_common_rpc_types::{BaseTransactionReceipt, Transaction};
@@ -43,7 +43,7 @@ pub struct PendingBlocksBuilder {
     transaction_state: HashMap<B256, EvmState>,
     transaction_senders: HashMap<B256, Address>,
     state_overrides: Option<StateOverride>,
-    transaction_results: HashMap<B256, ExecutionResult<OpHaltReason>>,
+    transaction_results: HashMap<B256, ExecutionResult<BaseHaltReason>>,
     execution_times: HashMap<B256, u128>,
     state_root_times: HashMap<B256, u128>,
 
@@ -156,7 +156,7 @@ impl PendingBlocksBuilder {
     pub fn with_transaction_result(
         &mut self,
         hash: B256,
-        result: ExecutionResult<OpHaltReason>,
+        result: ExecutionResult<BaseHaltReason>,
     ) -> &Self {
         self.transaction_results.insert(hash, result);
         self
@@ -183,6 +183,13 @@ impl PendingBlocksBuilder {
 
         let latest_flashblock_index =
             self.flashblocks.last().map(|fb| fb.index).ok_or(BuildError::NoFlashblocks)?;
+
+        for transaction in &self.transactions {
+            let tx_hash = transaction.tx_hash();
+            if !self.transaction_receipts.contains_key(&tx_hash) {
+                return Err(BuildError::MissingReceipt { tx_hash }.into());
+            }
+        }
 
         Ok(PendingBlocks {
             earliest_header,
@@ -221,7 +228,7 @@ pub struct PendingBlocks {
     transaction_state: HashMap<B256, EvmState>,
     transaction_senders: HashMap<B256, Address>,
     state_overrides: Option<StateOverride>,
-    transaction_results: HashMap<B256, ExecutionResult<OpHaltReason>>,
+    transaction_results: HashMap<B256, ExecutionResult<BaseHaltReason>>,
     execution_times: HashMap<B256, u128>,
     state_root_times: HashMap<B256, u128>,
 
@@ -231,29 +238,16 @@ pub struct PendingBlocks {
 impl PendingBlocks {
     fn transaction_with_logs(
         transaction: &Transaction,
-        receipt: Option<&BaseTransactionReceipt>,
+        receipt: &BaseTransactionReceipt,
     ) -> TransactionWithLogs {
-        let (logs, gas_used, status, cumulative_gas_used, contract_address, logs_bloom) = receipt
-            .map(|receipt| {
-                (
-                    receipt.inner.logs().to_vec(),
-                    Some(receipt.inner.gas_used),
-                    Some(receipt.inner.inner.status_or_post_state()),
-                    Some(receipt.inner.inner.cumulative_gas_used()),
-                    receipt.inner.contract_address,
-                    Some(receipt.inner.inner.logs_bloom),
-                )
-            })
-            .unwrap_or_default();
-
         TransactionWithLogs {
             transaction: transaction.clone(),
-            logs,
-            gas_used,
-            status,
-            cumulative_gas_used,
-            contract_address,
-            logs_bloom,
+            logs: receipt.inner.logs().to_vec(),
+            gas_used: receipt.inner.gas_used,
+            status: receipt.inner.inner.status(),
+            cumulative_gas_used: receipt.inner.inner.cumulative_gas_used(),
+            contract_address: receipt.inner.contract_address,
+            logs_bloom: receipt.inner.inner.logs_bloom,
         }
     }
 
@@ -364,7 +358,10 @@ impl PendingBlocks {
     }
 
     /// Returns the execution result for a transaction.
-    pub fn get_transaction_result(&self, tx_hash: &B256) -> Option<&ExecutionResult<OpHaltReason>> {
+    pub fn get_transaction_result(
+        &self,
+        tx_hash: &B256,
+    ) -> Option<&ExecutionResult<BaseHaltReason>> {
         self.transaction_results.get(tx_hash)
     }
 
@@ -379,7 +376,7 @@ impl PendingBlocks {
     }
 
     /// Returns the receipt and state for a transaction.
-    pub fn get_op_tx_result(&self, tx_hash: &B256) -> Option<BaseTxResult<OpHaltReason, OpTxType>> {
+    pub fn get_tx_result(&self, tx_hash: &B256) -> Option<BaseTxResult<BaseHaltReason, OpTxType>> {
         let (((result, state), tx), sender) = self
             .get_transaction_result(tx_hash)
             .zip(self.get_transaction_state(tx_hash))
@@ -454,7 +451,11 @@ impl PendingBlocks {
     pub fn get_pending_transactions_with_logs(&self) -> Vec<TransactionWithLogs> {
         self.transactions
             .iter()
-            .map(|tx| Self::transaction_with_logs(tx, self.transaction_receipts.get(&tx.tx_hash())))
+            .filter_map(|tx| {
+                self.transaction_receipts
+                    .get(&tx.tx_hash())
+                    .map(|receipt| Self::transaction_with_logs(tx, receipt))
+            })
             .collect()
     }
 
@@ -508,7 +509,11 @@ impl PendingBlocks {
         self.transactions
             .iter()
             .skip(prev_count)
-            .map(|tx| Self::transaction_with_logs(tx, self.transaction_receipts.get(&tx.tx_hash())))
+            .filter_map(|tx| {
+                self.transaction_receipts
+                    .get(&tx.tx_hash())
+                    .map(|receipt| Self::transaction_with_logs(tx, receipt))
+            })
             .collect()
     }
 
@@ -527,8 +532,7 @@ impl PendingBlocks {
             .iter()
             .skip(prev_count)
             .filter_map(|tx| {
-                let tx_hash = tx.tx_hash();
-                let receipt = self.transaction_receipts.get(&tx_hash)?;
+                let receipt = self.transaction_receipts.get(&tx.tx_hash())?;
                 let logs = receipt.inner.logs();
 
                 let has_match = logs.iter().any(|log| filter.matches(&log.inner));
@@ -536,7 +540,7 @@ impl PendingBlocks {
                     return None;
                 }
 
-                Some(Self::transaction_with_logs(tx, Some(receipt)))
+                Some(Self::transaction_with_logs(tx, receipt))
             })
             .collect()
     }
@@ -807,7 +811,7 @@ mod tests {
         receipt
     }
 
-    fn test_execution_result() -> ExecutionResult<OpHaltReason> {
+    fn test_execution_result() -> ExecutionResult<BaseHaltReason> {
         ExecutionResult::Success {
             reason: revm::context::result::SuccessReason::Stop,
             gas_used: 21000,
@@ -847,12 +851,12 @@ mod tests {
     }
 
     #[test]
-    fn get_op_tx_result_reconstructs_all_fields_for_legacy_tx() {
+    fn get_tx_result_reconstructs_all_fields_for_legacy_tx() {
         let da_footprint = 42_000u64;
         let (tx_hash, pending_blocks) =
             build_pending_blocks(test_legacy_transaction(), Some(da_footprint));
 
-        let result = pending_blocks.get_op_tx_result(&tx_hash).expect("should return tx result");
+        let result = pending_blocks.get_tx_result(&tx_hash).expect("should return tx result");
 
         assert_eq!(result.inner.blob_gas_used, da_footprint);
         assert_eq!(result.inner.tx_type, OpTxType::Legacy);
@@ -862,10 +866,10 @@ mod tests {
     }
 
     #[test]
-    fn get_op_tx_result_reconstructs_all_fields_for_deposit_tx() {
+    fn get_tx_result_reconstructs_all_fields_for_deposit_tx() {
         let (tx_hash, pending_blocks) = build_pending_blocks(test_deposit_transaction(), Some(0));
 
-        let result = pending_blocks.get_op_tx_result(&tx_hash).expect("should return tx result");
+        let result = pending_blocks.get_tx_result(&tx_hash).expect("should return tx result");
 
         assert_eq!(result.inner.blob_gas_used, 0);
         assert_eq!(result.inner.tx_type, OpTxType::Deposit);
@@ -875,16 +879,16 @@ mod tests {
     }
 
     #[test]
-    fn get_op_tx_result_defaults_blob_gas_to_zero_when_receipt_field_is_none() {
+    fn get_tx_result_defaults_blob_gas_to_zero_when_receipt_field_is_none() {
         let (tx_hash, pending_blocks) = build_pending_blocks(test_legacy_transaction(), None);
 
-        let result = pending_blocks.get_op_tx_result(&tx_hash).expect("should return tx result");
+        let result = pending_blocks.get_tx_result(&tx_hash).expect("should return tx result");
 
         assert_eq!(result.inner.blob_gas_used, 0);
     }
 
     #[test]
-    fn get_op_tx_result_defaults_blob_gas_to_zero_without_receipt() {
+    fn get_tx_result_defaults_blob_gas_to_zero_without_receipt() {
         let tx = test_legacy_transaction();
         let tx_hash = tx.tx_hash();
         let mut builder = PendingBlocksBuilder::default();
@@ -894,12 +898,10 @@ mod tests {
         builder.with_transaction_sender(tx_hash, test_sender());
         builder.with_transaction_state(tx_hash, Default::default());
         builder.with_transaction_result(tx_hash, test_execution_result());
-        // Intentionally skip with_receipt to test the no-receipt fallback path
-        let pending_blocks = builder.build().expect("should build pending blocks");
+        // Intentionally skip with_receipt to verify pending blocks reject incomplete transactions.
+        let err = builder.build().expect_err("build should fail without a receipt");
 
-        let result = pending_blocks.get_op_tx_result(&tx_hash).expect("should return tx result");
-
-        assert_eq!(result.inner.blob_gas_used, 0);
+        assert_eq!(err, StateProcessorError::Build(BuildError::MissingReceipt { tx_hash }));
     }
 
     fn test_receipt_with_log_and_topic(
@@ -1126,7 +1128,7 @@ mod tests {
         let txs = pending.get_latest_flashblock_transactions_with_logs_filtered(&filter);
 
         assert_eq!(txs.len(), 1);
-        assert_eq!(txs[0].gas_used, Some(21_000));
+        assert_eq!(txs[0].gas_used, 21_000);
     }
 
     #[test]
@@ -1139,7 +1141,7 @@ mod tests {
         let txs = pending.get_latest_flashblock_transactions_with_logs();
 
         assert_eq!(txs.len(), 1);
-        assert_eq!(txs[0].gas_used, Some(21_000));
+        assert_eq!(txs[0].gas_used, 21_000);
     }
 
     #[test]
@@ -1168,10 +1170,10 @@ mod tests {
         let txs = pending.get_latest_flashblock_transactions_with_logs();
 
         assert_eq!(txs.len(), 1);
-        assert_eq!(txs[0].status, Some(alloy_consensus::Eip658Value::Eip658(true)));
-        assert_eq!(txs[0].cumulative_gas_used, Some(42_000));
+        assert!(txs[0].status);
+        assert_eq!(txs[0].cumulative_gas_used, 42_000);
         assert_eq!(txs[0].contract_address, Some(contract_address));
-        assert_eq!(txs[0].logs_bloom, Some(logs_bloom));
+        assert_eq!(txs[0].logs_bloom, logs_bloom);
     }
 
     #[test]

--- a/crates/execution/flashblocks/src/pending_blocks.rs
+++ b/crates/execution/flashblocks/src/pending_blocks.rs
@@ -244,7 +244,7 @@ impl PendingBlocks {
             transaction: transaction.clone(),
             logs: receipt.inner.logs().to_vec(),
             gas_used: receipt.inner.gas_used,
-            status: receipt.inner.inner.status(),
+            status: receipt.inner.inner.status_or_post_state(),
             cumulative_gas_used: receipt.inner.inner.cumulative_gas_used(),
             contract_address: receipt.inner.contract_address,
             logs_bloom: receipt.inner.inner.logs_bloom,
@@ -1170,7 +1170,7 @@ mod tests {
         let txs = pending.get_latest_flashblock_transactions_with_logs();
 
         assert_eq!(txs.len(), 1);
-        assert!(txs[0].status);
+        assert_eq!(txs[0].status, alloy_consensus::Eip658Value::Eip658(true));
         assert_eq!(txs[0].cumulative_gas_used, 42_000);
         assert_eq!(txs[0].contract_address, Some(contract_address));
         assert_eq!(txs[0].logs_bloom, logs_bloom);

--- a/crates/execution/flashblocks/src/pending_blocks.rs
+++ b/crates/execution/flashblocks/src/pending_blocks.rs
@@ -1,6 +1,6 @@
 use std::{sync::Arc, time::Instant};
 
-use alloy_consensus::{Header, Sealed};
+use alloy_consensus::{Header, Sealed, TxReceipt};
 use alloy_eips::BlockNumberOrTag;
 use alloy_primitives::{
     Address, B256, BlockNumber, TxHash, U256,
@@ -229,6 +229,34 @@ pub struct PendingBlocks {
 }
 
 impl PendingBlocks {
+    fn transaction_with_logs(
+        transaction: &Transaction,
+        receipt: Option<&BaseTransactionReceipt>,
+    ) -> TransactionWithLogs {
+        let (logs, gas_used, status, cumulative_gas_used, contract_address, logs_bloom) = receipt
+            .map(|receipt| {
+                (
+                    receipt.inner.logs().to_vec(),
+                    Some(receipt.inner.gas_used),
+                    Some(receipt.inner.inner.status_or_post_state()),
+                    Some(receipt.inner.inner.cumulative_gas_used()),
+                    receipt.inner.contract_address,
+                    Some(receipt.inner.inner.logs_bloom),
+                )
+            })
+            .unwrap_or_default();
+
+        TransactionWithLogs {
+            transaction: transaction.clone(),
+            logs,
+            gas_used,
+            status,
+            cumulative_gas_used,
+            contract_address,
+            logs_bloom,
+        }
+    }
+
     /// Returns the latest block number in the pending state.
     #[inline]
     pub fn latest_block_number(&self) -> BlockNumber {
@@ -426,15 +454,7 @@ impl PendingBlocks {
     pub fn get_pending_transactions_with_logs(&self) -> Vec<TransactionWithLogs> {
         self.transactions
             .iter()
-            .map(|tx| {
-                let tx_hash = tx.tx_hash();
-                let (logs, gas_used) = self
-                    .transaction_receipts
-                    .get(&tx_hash)
-                    .map(|receipt| (receipt.inner.logs().to_vec(), Some(receipt.inner.gas_used)))
-                    .unwrap_or_default();
-                TransactionWithLogs { transaction: tx.clone(), logs, gas_used }
-            })
+            .map(|tx| Self::transaction_with_logs(tx, self.transaction_receipts.get(&tx.tx_hash())))
             .collect()
     }
 
@@ -488,15 +508,7 @@ impl PendingBlocks {
         self.transactions
             .iter()
             .skip(prev_count)
-            .map(|tx| {
-                let tx_hash = tx.tx_hash();
-                let (logs, gas_used) = self
-                    .transaction_receipts
-                    .get(&tx_hash)
-                    .map(|receipt| (receipt.inner.logs().to_vec(), Some(receipt.inner.gas_used)))
-                    .unwrap_or_default();
-                TransactionWithLogs { transaction: tx.clone(), logs, gas_used }
-            })
+            .map(|tx| Self::transaction_with_logs(tx, self.transaction_receipts.get(&tx.tx_hash())))
             .collect()
     }
 
@@ -524,11 +536,7 @@ impl PendingBlocks {
                     return None;
                 }
 
-                Some(TransactionWithLogs {
-                    transaction: tx.clone(),
-                    logs: logs.to_vec(),
-                    gas_used: Some(receipt.inner.gas_used),
-                })
+                Some(Self::transaction_with_logs(tx, Some(receipt)))
             })
             .collect()
     }
@@ -782,6 +790,21 @@ mod tests {
             },
             l1_block_info: Default::default(),
         }
+    }
+
+    fn test_receipt_with_subscription_fields(
+        tx_hash: B256,
+        log_address: Address,
+        contract_address: Address,
+        logs_bloom: Bloom,
+    ) -> BaseTransactionReceipt {
+        let mut receipt = test_receipt_with_log(tx_hash, log_address);
+        receipt.inner.inner.receipt.as_receipt_mut().status =
+            alloy_consensus::Eip658Value::Eip658(true);
+        receipt.inner.inner.receipt.as_receipt_mut().cumulative_gas_used = 42_000;
+        receipt.inner.inner.logs_bloom = logs_bloom;
+        receipt.inner.contract_address = Some(contract_address);
+        receipt
     }
 
     fn test_execution_result() -> ExecutionResult<OpHaltReason> {
@@ -1117,6 +1140,38 @@ mod tests {
 
         assert_eq!(txs.len(), 1);
         assert_eq!(txs[0].gas_used, Some(21_000));
+    }
+
+    #[test]
+    fn unfiltered_transactions_populate_receipt_fields() {
+        let tx_hash = B256::with_last_byte(0xAA);
+        let log_address = Address::with_last_byte(0x0A);
+        let contract_address = Address::with_last_byte(0x0B);
+        let logs_bloom: Bloom = [0x22; 256].into();
+
+        let header = Sealed::new_unchecked(Header::default(), B256::ZERO);
+        let mut builder = PendingBlocksBuilder::new();
+        builder.with_flashblocks([test_flashblock()]);
+        builder.with_header(header);
+        builder.with_transaction(test_transaction_with_hash(tx_hash));
+        builder.with_receipt(
+            tx_hash,
+            test_receipt_with_subscription_fields(
+                tx_hash,
+                log_address,
+                contract_address,
+                logs_bloom,
+            ),
+        );
+        let pending = builder.build().expect("build should succeed");
+
+        let txs = pending.get_latest_flashblock_transactions_with_logs();
+
+        assert_eq!(txs.len(), 1);
+        assert_eq!(txs[0].status, Some(alloy_consensus::Eip658Value::Eip658(true)));
+        assert_eq!(txs[0].cumulative_gas_used, Some(42_000));
+        assert_eq!(txs[0].contract_address, Some(contract_address));
+        assert_eq!(txs[0].logs_bloom, Some(logs_bloom));
     }
 
     #[test]

--- a/crates/execution/flashblocks/src/rpc/types.rs
+++ b/crates/execution/flashblocks/src/rpc/types.rs
@@ -194,7 +194,7 @@ mod tests {
         assert!(obj.contains_key("value"), "missing flattened tx 'value' field");
         assert!(obj.contains_key("blockNumber"), "missing flattened tx 'blockNumber' field");
 
-        assert_eq!(obj["gasUsed"], 21_000u64, "gasUsed should be 21000");
+        assert_eq!(obj["gasUsed"], 21_000, "gasUsed should serialize as a JSON number");
         assert_eq!(obj["status"], "0x1", "status should use receipt quantity encoding");
         assert_eq!(
             obj["cumulativeGasUsed"], "0xa410",
@@ -235,7 +235,10 @@ mod tests {
         let twl = test_transaction_with_logs();
         let json_str = serde_json::to_string(&twl).expect("serialization should succeed");
 
-        assert!(json_str.contains("\"gasUsed\""), "JSON must contain gasUsed key");
+        assert!(
+            json_str.contains("\"gasUsed\":21000"),
+            "JSON must contain gasUsed key with numeric encoding"
+        );
         assert!(json_str.contains("\"status\":\"0x1\""), "JSON must contain status key");
         assert!(
             json_str.contains("\"cumulativeGasUsed\":\"0xa410\""),

--- a/crates/execution/flashblocks/src/rpc/types.rs
+++ b/crates/execution/flashblocks/src/rpc/types.rs
@@ -1,5 +1,6 @@
 //! Subscription types for the `eth_` `PubSub` RPC extension
 
+use alloy_consensus::Eip658Value;
 use alloy_primitives::{Address, Bloom};
 use alloy_rpc_types_eth::{Log, pubsub::SubscriptionKind};
 use base_common_rpc_types::Transaction;
@@ -22,9 +23,9 @@ pub struct TransactionWithLogs {
     /// Gas consumed by this transaction's execution.
     #[serde(with = "alloy_serde::quantity")]
     pub gas_used: u64,
-    /// Status of the transaction, encoded as a receipt-style quantity.
-    #[serde(with = "alloy_serde::quantity")]
-    pub status: bool,
+    /// Status of the transaction, serialized the same way as `eth_getTransactionReceipt`.
+    #[serde(flatten)]
+    pub status: Eip658Value,
     /// Cumulative gas used in the block up to and including this transaction.
     #[serde(with = "alloy_serde::quantity")]
     pub cumulative_gas_used: u64,
@@ -167,7 +168,7 @@ mod tests {
             transaction: tx,
             logs: vec![log],
             gas_used: 21_000,
-            status: true,
+            status: Eip658Value::Eip658(true),
             cumulative_gas_used: 42_000,
             contract_address: Some(Address::with_last_byte(0xEF)),
             logs_bloom: [0x11; 256].into(),

--- a/crates/execution/flashblocks/src/rpc/types.rs
+++ b/crates/execution/flashblocks/src/rpc/types.rs
@@ -1,15 +1,17 @@
 //! Subscription types for the `eth_` `PubSub` RPC extension
 
+use alloy_consensus::Eip658Value;
+use alloy_primitives::{Address, Bloom};
 use alloy_rpc_types_eth::{Log, pubsub::SubscriptionKind};
 use base_common_rpc_types::Transaction;
 use derive_more::From;
 use serde::{Deserialize, Serialize};
 
-/// A full transaction object with its associated logs and gas usage.
+/// A full transaction object with its associated logs and receipt-equivalent fields.
 ///
 /// This is returned by `newFlashblockTransactions` subscription when `full = true`
 /// or when a log filter is provided, giving both the transaction details, logs emitted
-/// by its execution, and gas accounting fields.
+/// by its execution, and receipt-derived fields already available from flashblock execution.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct TransactionWithLogs {
@@ -20,6 +22,16 @@ pub struct TransactionWithLogs {
     pub logs: Vec<Log>,
     /// Gas consumed by this transaction's execution.
     pub gas_used: Option<u64>,
+    /// Status of the transaction, serialized the same way as transaction receipts.
+    #[serde(flatten, default)]
+    pub status: Option<Eip658Value>,
+    /// Cumulative gas used in the block up to and including this transaction.
+    #[serde(default, with = "alloy_serde::quantity::opt")]
+    pub cumulative_gas_used: Option<u64>,
+    /// Contract address created, if this was a contract creation transaction.
+    pub contract_address: Option<Address>,
+    /// Bloom filter for all logs emitted by this transaction.
+    pub logs_bloom: Option<Bloom>,
 }
 
 /// Extended subscription kind that includes both standard Ethereum subscription types
@@ -151,7 +163,15 @@ mod tests {
             removed: false,
         };
 
-        TransactionWithLogs { transaction: tx, logs: vec![log], gas_used: Some(21_000) }
+        TransactionWithLogs {
+            transaction: tx,
+            logs: vec![log],
+            gas_used: Some(21_000),
+            status: Some(Eip658Value::Eip658(true)),
+            cumulative_gas_used: Some(42_000),
+            contract_address: Some(Address::with_last_byte(0xEF)),
+            logs_bloom: Some([0x11; 256].into()),
+        }
     }
 
     #[test]
@@ -162,6 +182,10 @@ mod tests {
 
         assert!(obj.contains_key("logs"), "missing 'logs' field");
         assert!(obj.contains_key("gasUsed"), "missing 'gasUsed' field");
+        assert!(obj.contains_key("status"), "missing 'status' field");
+        assert!(obj.contains_key("cumulativeGasUsed"), "missing 'cumulativeGasUsed' field");
+        assert!(obj.contains_key("contractAddress"), "missing 'contractAddress' field");
+        assert!(obj.contains_key("logsBloom"), "missing 'logsBloom' field");
         assert!(obj.contains_key("nonce"), "missing flattened tx 'nonce' field");
         assert!(obj.contains_key("gasPrice"), "missing flattened tx 'gasPrice' field");
         assert!(obj.contains_key("hash"), "missing flattened tx 'hash' field");
@@ -171,6 +195,21 @@ mod tests {
         assert!(obj.contains_key("blockNumber"), "missing flattened tx 'blockNumber' field");
 
         assert_eq!(obj["gasUsed"], 21_000u64, "gasUsed should be 21000");
+        assert_eq!(obj["status"], "0x1", "status should use receipt quantity encoding");
+        assert_eq!(
+            obj["cumulativeGasUsed"], "0xa410",
+            "cumulativeGasUsed should use receipt quantity encoding"
+        );
+        assert_eq!(
+            obj["contractAddress"],
+            format!("{:#x}", Address::with_last_byte(0xEF)),
+            "contractAddress should serialize as an address"
+        );
+        assert_eq!(
+            obj["logsBloom"],
+            format!("0x{}", "11".repeat(256)),
+            "logsBloom should serialize as a bloom hex string"
+        );
 
         let logs = obj["logs"].as_array().expect("logs should be an array");
         assert_eq!(logs.len(), 1);
@@ -197,6 +236,13 @@ mod tests {
         let json_str = serde_json::to_string(&twl).expect("serialization should succeed");
 
         assert!(json_str.contains("\"gasUsed\""), "JSON must contain gasUsed key");
+        assert!(json_str.contains("\"status\":\"0x1\""), "JSON must contain status key");
+        assert!(
+            json_str.contains("\"cumulativeGasUsed\":\"0xa410\""),
+            "JSON must contain cumulativeGasUsed key"
+        );
+        assert!(json_str.contains("\"contractAddress\""), "JSON must contain contractAddress key");
+        assert!(json_str.contains("\"logsBloom\""), "JSON must contain logsBloom key");
         assert!(json_str.contains("\"logs\""), "JSON must contain logs key");
         assert!(json_str.contains("\"gasPrice\""), "JSON must contain gasPrice key");
         assert!(json_str.contains("\"nonce\""), "JSON must contain nonce key");
@@ -216,10 +262,30 @@ mod tests {
     fn transaction_with_logs_gas_used_none_serialization() {
         let mut twl = test_transaction_with_logs();
         twl.gas_used = None;
+        twl.status = None;
+        twl.cumulative_gas_used = None;
+        twl.contract_address = None;
+        twl.logs_bloom = None;
         let json = serde_json::to_value(&twl).expect("serialization should succeed");
         let obj = json.as_object().expect("should be a JSON object");
 
         assert!(obj.contains_key("gasUsed"), "gasUsed key should be present even when None");
         assert!(obj["gasUsed"].is_null(), "gasUsed should be null when None");
+        assert!(
+            !obj.contains_key("status"),
+            "status should be omitted when the receipt status is unavailable"
+        );
+        assert!(
+            obj.contains_key("cumulativeGasUsed"),
+            "cumulativeGasUsed key should be present even when None"
+        );
+        assert!(obj["cumulativeGasUsed"].is_null(), "cumulativeGasUsed should be null when None");
+        assert!(
+            obj.contains_key("contractAddress"),
+            "contractAddress key should be present even when None"
+        );
+        assert!(obj["contractAddress"].is_null(), "contractAddress should be null when None");
+        assert!(obj.contains_key("logsBloom"), "logsBloom key should be present even when None");
+        assert!(obj["logsBloom"].is_null(), "logsBloom should be null when None");
     }
 }

--- a/crates/execution/flashblocks/src/rpc/types.rs
+++ b/crates/execution/flashblocks/src/rpc/types.rs
@@ -1,7 +1,6 @@
 //! Subscription types for the `eth_` `PubSub` RPC extension
 
-use alloy_consensus::Eip658Value;
-use alloy_primitives::{Address, B256, Bloom};
+use alloy_primitives::{Address, Bloom};
 use alloy_rpc_types_eth::{Log, pubsub::SubscriptionKind};
 use base_common_rpc_types::Transaction;
 use derive_more::From;
@@ -21,18 +20,18 @@ pub struct TransactionWithLogs {
     /// Logs emitted by this transaction.
     pub logs: Vec<Log>,
     /// Gas consumed by this transaction's execution.
-    #[serde(default, with = "alloy_serde::quantity::opt")]
-    pub gas_used: Option<u64>,
-    /// Status of the transaction, serialized the same way as transaction receipts.
-    #[serde(flatten, default, with = "transaction_status_serde")]
-    pub status: Option<Eip658Value>,
+    #[serde(with = "alloy_serde::quantity")]
+    pub gas_used: u64,
+    /// Status of the transaction, encoded as a receipt-style quantity.
+    #[serde(with = "alloy_serde::quantity")]
+    pub status: bool,
     /// Cumulative gas used in the block up to and including this transaction.
-    #[serde(default, with = "alloy_serde::quantity::opt")]
-    pub cumulative_gas_used: Option<u64>,
+    #[serde(with = "alloy_serde::quantity")]
+    pub cumulative_gas_used: u64,
     /// Contract address created, if this was a contract creation transaction.
     pub contract_address: Option<Address>,
     /// Bloom filter for all logs emitted by this transaction.
-    pub logs_bloom: Option<Bloom>,
+    pub logs_bloom: Bloom,
 }
 
 /// Extended subscription kind that includes both standard Ethereum subscription types
@@ -89,52 +88,6 @@ pub enum BaseSubscriptionKind {
     ///   where at least one log matches the filter. All logs are included in the response, not
     ///   just the matching ones.
     NewFlashblockTransactions,
-}
-
-mod transaction_status_serde {
-    use super::*;
-
-    #[derive(Deserialize, Serialize)]
-    #[serde(untagged)]
-    enum TransactionStatusSerde {
-        Eip658 {
-            #[serde(default, with = "alloy_serde::quantity::opt")]
-            status: Option<bool>,
-        },
-        PostState {
-            root: B256,
-        },
-    }
-
-    pub(super) fn serialize<S>(
-        status: &Option<Eip658Value>,
-        serializer: S,
-    ) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        match status {
-            Some(Eip658Value::Eip658(status)) => {
-                TransactionStatusSerde::Eip658 { status: Some(*status) }.serialize(serializer)
-            }
-            Some(Eip658Value::PostState(root)) => {
-                TransactionStatusSerde::PostState { root: *root }.serialize(serializer)
-            }
-            None => TransactionStatusSerde::Eip658 { status: None }.serialize(serializer),
-        }
-    }
-
-    pub(super) fn deserialize<'de, D>(deserializer: D) -> Result<Option<Eip658Value>, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        let status = TransactionStatusSerde::deserialize(deserializer)?;
-
-        Ok(match status {
-            TransactionStatusSerde::Eip658 { status } => status.map(Eip658Value::Eip658),
-            TransactionStatusSerde::PostState { root } => Some(Eip658Value::PostState(root)),
-        })
-    }
 }
 
 impl ExtendedSubscriptionKind {
@@ -213,11 +166,11 @@ mod tests {
         TransactionWithLogs {
             transaction: tx,
             logs: vec![log],
-            gas_used: Some(21_000),
-            status: Some(Eip658Value::Eip658(true)),
-            cumulative_gas_used: Some(42_000),
+            gas_used: 21_000,
+            status: true,
+            cumulative_gas_used: 42_000,
             contract_address: Some(Address::with_last_byte(0xEF)),
-            logs_bloom: Some([0x11; 256].into()),
+            logs_bloom: [0x11; 256].into(),
         }
     }
 
@@ -241,10 +194,7 @@ mod tests {
         assert!(obj.contains_key("value"), "missing flattened tx 'value' field");
         assert!(obj.contains_key("blockNumber"), "missing flattened tx 'blockNumber' field");
 
-        assert_eq!(
-            obj["gasUsed"], "0x5208",
-            "gasUsed should use receipt quantity encoding"
-        );
+        assert_eq!(obj["gasUsed"], "0x5208", "gasUsed should use receipt quantity encoding");
         assert_eq!(obj["status"], "0x1", "status should use receipt quantity encoding");
         assert_eq!(
             obj["cumulativeGasUsed"], "0xa410",
@@ -312,34 +262,27 @@ mod tests {
     }
 
     #[test]
-    fn transaction_with_logs_gas_used_none_serialization() {
+    fn transaction_with_logs_contract_address_none_serialization() {
         let mut twl = test_transaction_with_logs();
-        twl.gas_used = None;
-        twl.status = None;
-        twl.cumulative_gas_used = None;
         twl.contract_address = None;
-        twl.logs_bloom = None;
         let json = serde_json::to_value(&twl).expect("serialization should succeed");
         let obj = json.as_object().expect("should be a JSON object");
 
-        assert!(obj.contains_key("gasUsed"), "gasUsed key should be present even when None");
-        assert!(obj["gasUsed"].is_null(), "gasUsed should be null when None");
-        assert!(
-            obj.contains_key("status"),
-            "status key should be present even when the receipt status is unavailable"
-        );
-        assert!(obj["status"].is_null(), "status should be null when None");
-        assert!(
-            obj.contains_key("cumulativeGasUsed"),
-            "cumulativeGasUsed key should be present even when None"
-        );
-        assert!(obj["cumulativeGasUsed"].is_null(), "cumulativeGasUsed should be null when None");
         assert!(
             obj.contains_key("contractAddress"),
             "contractAddress key should be present even when None"
         );
         assert!(obj["contractAddress"].is_null(), "contractAddress should be null when None");
-        assert!(obj.contains_key("logsBloom"), "logsBloom key should be present even when None");
-        assert!(obj["logsBloom"].is_null(), "logsBloom should be null when None");
+        assert_eq!(obj["gasUsed"], "0x5208", "gasUsed should remain a required quantity field");
+        assert_eq!(obj["status"], "0x1", "status should remain a required receipt field");
+        assert_eq!(
+            obj["cumulativeGasUsed"], "0xa410",
+            "cumulativeGasUsed should remain a required quantity field"
+        );
+        assert_eq!(
+            obj["logsBloom"],
+            format!("0x{}", "11".repeat(256)),
+            "logsBloom should remain a required bloom field"
+        );
     }
 }

--- a/crates/execution/flashblocks/src/rpc/types.rs
+++ b/crates/execution/flashblocks/src/rpc/types.rs
@@ -1,7 +1,7 @@
 //! Subscription types for the `eth_` `PubSub` RPC extension
 
 use alloy_consensus::Eip658Value;
-use alloy_primitives::{Address, Bloom};
+use alloy_primitives::{Address, B256, Bloom};
 use alloy_rpc_types_eth::{Log, pubsub::SubscriptionKind};
 use base_common_rpc_types::Transaction;
 use derive_more::From;
@@ -21,9 +21,10 @@ pub struct TransactionWithLogs {
     /// Logs emitted by this transaction.
     pub logs: Vec<Log>,
     /// Gas consumed by this transaction's execution.
+    #[serde(default, with = "alloy_serde::quantity::opt")]
     pub gas_used: Option<u64>,
     /// Status of the transaction, serialized the same way as transaction receipts.
-    #[serde(flatten, default)]
+    #[serde(flatten, default, with = "transaction_status_serde")]
     pub status: Option<Eip658Value>,
     /// Cumulative gas used in the block up to and including this transaction.
     #[serde(default, with = "alloy_serde::quantity::opt")]
@@ -88,6 +89,52 @@ pub enum BaseSubscriptionKind {
     ///   where at least one log matches the filter. All logs are included in the response, not
     ///   just the matching ones.
     NewFlashblockTransactions,
+}
+
+mod transaction_status_serde {
+    use super::*;
+
+    #[derive(Deserialize, Serialize)]
+    #[serde(untagged)]
+    enum TransactionStatusSerde {
+        Eip658 {
+            #[serde(default, with = "alloy_serde::quantity::opt")]
+            status: Option<bool>,
+        },
+        PostState {
+            root: B256,
+        },
+    }
+
+    pub(super) fn serialize<S>(
+        status: &Option<Eip658Value>,
+        serializer: S,
+    ) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match status {
+            Some(Eip658Value::Eip658(status)) => {
+                TransactionStatusSerde::Eip658 { status: Some(*status) }.serialize(serializer)
+            }
+            Some(Eip658Value::PostState(root)) => {
+                TransactionStatusSerde::PostState { root: *root }.serialize(serializer)
+            }
+            None => TransactionStatusSerde::Eip658 { status: None }.serialize(serializer),
+        }
+    }
+
+    pub(super) fn deserialize<'de, D>(deserializer: D) -> Result<Option<Eip658Value>, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let status = TransactionStatusSerde::deserialize(deserializer)?;
+
+        Ok(match status {
+            TransactionStatusSerde::Eip658 { status } => status.map(Eip658Value::Eip658),
+            TransactionStatusSerde::PostState { root } => Some(Eip658Value::PostState(root)),
+        })
+    }
 }
 
 impl ExtendedSubscriptionKind {
@@ -194,7 +241,10 @@ mod tests {
         assert!(obj.contains_key("value"), "missing flattened tx 'value' field");
         assert!(obj.contains_key("blockNumber"), "missing flattened tx 'blockNumber' field");
 
-        assert_eq!(obj["gasUsed"], 21_000, "gasUsed should serialize as a JSON number");
+        assert_eq!(
+            obj["gasUsed"], "0x5208",
+            "gasUsed should use receipt quantity encoding"
+        );
         assert_eq!(obj["status"], "0x1", "status should use receipt quantity encoding");
         assert_eq!(
             obj["cumulativeGasUsed"], "0xa410",
@@ -236,8 +286,8 @@ mod tests {
         let json_str = serde_json::to_string(&twl).expect("serialization should succeed");
 
         assert!(
-            json_str.contains("\"gasUsed\":21000"),
-            "JSON must contain gasUsed key with numeric encoding"
+            json_str.contains("\"gasUsed\":\"0x5208\""),
+            "JSON must contain gasUsed key with quantity encoding"
         );
         assert!(json_str.contains("\"status\":\"0x1\""), "JSON must contain status key");
         assert!(
@@ -275,9 +325,10 @@ mod tests {
         assert!(obj.contains_key("gasUsed"), "gasUsed key should be present even when None");
         assert!(obj["gasUsed"].is_null(), "gasUsed should be null when None");
         assert!(
-            !obj.contains_key("status"),
-            "status should be omitted when the receipt status is unavailable"
+            obj.contains_key("status"),
+            "status key should be present even when the receipt status is unavailable"
         );
+        assert!(obj["status"].is_null(), "status should be null when None");
         assert!(
             obj.contains_key("cumulativeGasUsed"),
             "cumulativeGasUsed key should be present even when None"


### PR DESCRIPTION
## Summary
- backport flashblock receipt-field subscription support to releases/v0.8.0
- include the follow-up review fixes and receipt-field serialization alignment
- keep gas and status fields aligned with receipt-style JSON-RPC encoding

## Backport of
- #2287