### PR TITLE
feat: perf improvements to `MeteringStore` 

### DIFF
--- a/bin/builder/src/cli.rs
+++ b/bin/builder/src/cli.rs
@@ -348,7 +348,11 @@ mod tests {
         use base_builder_core::MeteringProvider;
         use base_bundles::MeterBundleResponse;
 
-        let args = Args { metering_store_ttl_secs: 60, ..Default::default() };
+        let args = Args {
+            metering_store_ttl_secs: 60,
+            enable_resource_metering: true,
+            ..Default::default()
+        };
         let store = args.build_metering_store();
         let tx_hash = TxHash::random();
         store.insert(

--- a/bin/builder/src/cli.rs
+++ b/bin/builder/src/cli.rs
@@ -121,10 +121,9 @@ pub struct Args {
     pub tx_data_store_buffer_size: usize,
 
     /// TTL in seconds for entries in the metering store cache.
-    /// Stale entries are evicted after this duration, preventing `TinyLFU` admission
-    /// rejections for new metering data.
+    /// Stale entries are evicted after this duration.
     #[arg(long = "builder.metering-store-ttl-secs", default_value = "30")]
-    pub metering_store_ttl_secs: Option<u64>,
+    pub metering_store_ttl_secs: u64,
 
     /// Maximum number of entries in the rejection cache for permanently rejected transactions
     #[arg(long = "builder.rejection-cache-max-capacity", default_value = "100000")]
@@ -149,7 +148,7 @@ impl Args {
         MeteringStore::new(
             self.enable_resource_metering || self.execution_metering_mode.is_enabled(),
             self.tx_data_store_buffer_size,
-            self.metering_store_ttl_secs.map(Duration::from_secs),
+            Duration::from_secs(self.metering_store_ttl_secs),
         )
     }
 }
@@ -174,7 +173,7 @@ impl Default for Args {
             rejected_tx_channel_size: 500,
             max_rejected_txs_per_block: 500,
             tx_data_store_buffer_size: 10000,
-            metering_store_ttl_secs: None,
+            metering_store_ttl_secs: 30,
             rejection_cache_max_capacity: 100_000,
             rejection_cache_ttl_secs: 1800,
             sampling_ratio: 100,
@@ -298,7 +297,7 @@ mod tests {
         use base_bundles::MeterBundleResponse;
 
         let metering_provider: SharedMeteringProvider =
-            Arc::new(MeteringStore::new(true, 100, None));
+            Arc::new(MeteringStore::new(true, 100, Duration::from_secs(30)));
         let args = Args { enable_resource_metering: true, ..Default::default() };
         let config = args
             .into_builder_config(Arc::clone(&metering_provider))
@@ -349,7 +348,7 @@ mod tests {
         use base_builder_core::MeteringProvider;
         use base_bundles::MeterBundleResponse;
 
-        let args = Args { metering_store_ttl_secs: Some(30), ..Default::default() };
+        let args = Args { metering_store_ttl_secs: 60, ..Default::default() };
         let store = args.build_metering_store();
         let tx_hash = TxHash::random();
         store.insert(
@@ -372,13 +371,13 @@ mod tests {
                 state_root_storage_branch_count: 0,
             },
         );
-        assert!(store.get(&tx_hash).is_some(), "entry should be present with 30s TTL");
+        assert!(store.get(&tx_hash).is_some(), "entry should be present within TTL");
     }
 
     #[test]
-    fn metering_store_no_ttl_by_default() {
+    fn metering_store_ttl_defaults_to_30s() {
         let args = Args::default();
-        assert!(args.metering_store_ttl_secs.is_none());
+        assert_eq!(args.metering_store_ttl_secs, 30);
     }
 
     #[test]

--- a/bin/builder/src/cli.rs
+++ b/bin/builder/src/cli.rs
@@ -120,6 +120,12 @@ pub struct Args {
     #[arg(long = "builder.tx-data-store-buffer-size", default_value = "10000")]
     pub tx_data_store_buffer_size: usize,
 
+    /// TTL in seconds for entries in the metering store cache.
+    /// Stale entries are evicted after this duration, preventing `TinyLFU` admission
+    /// rejections for new metering data.
+    #[arg(long = "builder.metering-store-ttl-secs", default_value = "30")]
+    pub metering_store_ttl_secs: Option<u64>,
+
     /// Maximum number of entries in the rejection cache for permanently rejected transactions
     #[arg(long = "builder.rejection-cache-max-capacity", default_value = "100000")]
     pub rejection_cache_max_capacity: u64,
@@ -143,6 +149,7 @@ impl Args {
         MeteringStore::new(
             self.enable_resource_metering || self.execution_metering_mode.is_enabled(),
             self.tx_data_store_buffer_size,
+            self.metering_store_ttl_secs.map(Duration::from_secs),
         )
     }
 }
@@ -167,6 +174,7 @@ impl Default for Args {
             rejected_tx_channel_size: 500,
             max_rejected_txs_per_block: 500,
             tx_data_store_buffer_size: 10000,
+            metering_store_ttl_secs: None,
             rejection_cache_max_capacity: 100_000,
             rejection_cache_ttl_secs: 1800,
             sampling_ratio: 100,
@@ -289,7 +297,8 @@ mod tests {
         use alloy_primitives::{B256, TxHash, U256};
         use base_bundles::MeterBundleResponse;
 
-        let metering_provider: SharedMeteringProvider = Arc::new(MeteringStore::new(true, 100));
+        let metering_provider: SharedMeteringProvider =
+            Arc::new(MeteringStore::new(true, 100, None));
         let args = Args { enable_resource_metering: true, ..Default::default() };
         let config = args
             .into_builder_config(Arc::clone(&metering_provider))
@@ -332,6 +341,44 @@ mod tests {
         let args = Args { metering_wait_duration_ms: input, ..Default::default() };
         let config = convert(args);
         assert_eq!(config.metering_wait_duration, expected);
+    }
+
+    #[test]
+    fn metering_store_ttl_propagates_to_store() {
+        use alloy_primitives::{B256, TxHash, U256};
+        use base_builder_core::MeteringProvider;
+        use base_bundles::MeterBundleResponse;
+
+        let args = Args { metering_store_ttl_secs: Some(30), ..Default::default() };
+        let store = args.build_metering_store();
+        let tx_hash = TxHash::random();
+        store.insert(
+            tx_hash,
+            MeterBundleResponse {
+                bundle_hash: B256::ZERO,
+                bundle_gas_price: U256::ZERO,
+                coinbase_diff: U256::ZERO,
+                eth_sent_to_coinbase: U256::ZERO,
+                gas_fees: U256::ZERO,
+                results: vec![],
+                state_block_number: 0,
+                state_flashblock_index: None,
+                total_gas_used: 21000,
+                total_execution_time_us: 0,
+                state_root_time_us: 0,
+                state_root_account_leaf_count: 0,
+                state_root_account_branch_count: 0,
+                state_root_storage_leaf_count: 0,
+                state_root_storage_branch_count: 0,
+            },
+        );
+        assert!(store.get(&tx_hash).is_some(), "entry should be present with 30s TTL");
+    }
+
+    #[test]
+    fn metering_store_no_ttl_by_default() {
+        let args = Args::default();
+        assert!(args.metering_store_ttl_secs.is_none());
     }
 
     #[test]

--- a/crates/builder/core/src/metrics.rs
+++ b/crates/builder/core/src/metrics.rs
@@ -98,6 +98,8 @@ base_metrics::define_metrics! {
     metering_unknown_transaction: counter,
     #[describe("Number of LRU evictions from MeteringStore")]
     metering_store_lru_evictions: counter,
+    #[describe("Number of entries in the metering store that expired due to TTL")]
+    metering_store_ttl_expirations: counter,
     #[describe("Size of MeteringStore")]
     metering_store_size: gauge,
     #[describe("Transactions inserted into the rejection cache")]

--- a/crates/builder/metering/README.md
+++ b/crates/builder/metering/README.md
@@ -24,8 +24,9 @@ Create a store and wire it into the builder config:
 ```rust,ignore
 use std::sync::Arc;
 use base_builder_metering::{MeteringStore, MeteringStoreExt};
+use std::time::Duration;
 
-let store = Arc::new(MeteringStore::new(true, 10_000, None));
+let store = Arc::new(MeteringStore::new(true, 10_000, Duration::from_secs(30)));
 // Pass `store.clone()` as `SharedMeteringProvider` into `BuilderConfig`
 // Pass `store` into `MeteringStoreExt::new()` for the RPC extension
 ```

--- a/crates/builder/metering/README.md
+++ b/crates/builder/metering/README.md
@@ -25,7 +25,7 @@ Create a store and wire it into the builder config:
 use std::sync::Arc;
 use base_builder_metering::{MeteringStore, MeteringStoreExt};
 
-let store = Arc::new(MeteringStore::new(true, 10_000));
+let store = Arc::new(MeteringStore::new(true, 10_000, None));
 // Pass `store.clone()` as `SharedMeteringProvider` into `BuilderConfig`
 // Pass `store` into `MeteringStoreExt::new()` for the RPC extension
 ```

--- a/crates/builder/metering/src/store.rs
+++ b/crates/builder/metering/src/store.rs
@@ -6,7 +6,7 @@
 
 use std::{
     sync::atomic::{AtomicBool, Ordering},
-    time::Instant,
+    time::{Duration, Instant},
 };
 
 use alloy_primitives::TxHash;
@@ -38,16 +38,26 @@ impl core::fmt::Debug for MeteringStore {
 }
 
 impl MeteringStore {
-    /// Creates a new [`MeteringStore`] with the given metering flag and max capacity.
-    pub fn new(enable_resource_metering: bool, max_capacity: usize) -> Self {
-        let cache = Cache::builder()
-            .max_capacity(max_capacity as u64)
-            .eviction_listener(move |_key, _value, cause| {
+    /// Creates a new [`MeteringStore`] with the given metering flag, max capacity, and optional
+    /// TTL.
+    ///
+    /// When `ttl` is `Some`, entries expire automatically after the given duration.
+    /// This prevents stale metering data from accumulating in the cache and causing
+    /// `TinyLFU` admission rejections for newly arrived entries.
+    pub fn new(enable_resource_metering: bool, max_capacity: usize, ttl: Option<Duration>) -> Self {
+        let mut builder = Cache::builder().max_capacity(max_capacity as u64).eviction_listener(
+            move |_key, _value, cause| {
                 if cause == RemovalCause::Size {
                     BuilderMetrics::metering_store_lru_evictions().increment(1);
                 }
-            })
-            .build();
+            },
+        );
+
+        if let Some(ttl) = ttl {
+            builder = builder.time_to_live(ttl);
+        }
+
+        let cache = builder.build();
 
         let needed_at = Cache::builder().max_capacity(max_capacity as u64).build();
 
@@ -127,7 +137,7 @@ impl MeteringProvider for MeteringStore {
 
 impl Default for MeteringStore {
     fn default() -> Self {
-        Self::new(false, 10_000)
+        Self::new(false, 10_000, None)
     }
 }
 
@@ -168,7 +178,7 @@ mod tests {
 
     #[test]
     fn test_metering_insert_and_get() {
-        let store = MeteringStore::new(true, 100);
+        let store = MeteringStore::new(true, 100, None);
         let tx_hash = TxHash::random();
         let meter_data = create_test_metering(21000);
 
@@ -183,7 +193,7 @@ mod tests {
 
     #[test]
     fn test_clear_metering() {
-        let store = MeteringStore::new(true, 100);
+        let store = MeteringStore::new(true, 100, None);
 
         let tx1 = TxHash::random();
         let tx2 = TxHash::random();
@@ -202,7 +212,7 @@ mod tests {
 
     #[test]
     fn test_lru_eviction() {
-        let store = MeteringStore::new(true, 2);
+        let store = MeteringStore::new(true, 2, None);
 
         let tx1 = TxHash::random();
         let tx2 = TxHash::random();
@@ -221,7 +231,7 @@ mod tests {
 
     #[test]
     fn test_late_insert_after_inclusion() {
-        let store = MeteringStore::new(true, 100);
+        let store = MeteringStore::new(true, 100, None);
         let tx_hash = TxHash::random();
 
         // get() miss → tx included without data → data arrives late
@@ -237,7 +247,7 @@ mod tests {
 
     #[test]
     fn test_skip_clears_needed_at() {
-        let store = MeteringStore::new(true, 100);
+        let store = MeteringStore::new(true, 100, None);
         let tx_hash = TxHash::random();
 
         // get() miss → tx skipped (MeteringDataPending)
@@ -254,7 +264,7 @@ mod tests {
 
     #[test]
     fn test_no_needed_at_when_data_present() {
-        let store = MeteringStore::new(true, 100);
+        let store = MeteringStore::new(true, 100, None);
         let tx_hash = TxHash::random();
 
         // Insert data first, then get() finds it — no needed_at entry
@@ -265,7 +275,7 @@ mod tests {
 
     #[test]
     fn test_clear_resets_needed_at() {
-        let store = MeteringStore::new(true, 100);
+        let store = MeteringStore::new(true, 100, None);
         let tx_hash = TxHash::random();
 
         assert!(store.get(&tx_hash).is_none());
@@ -277,7 +287,7 @@ mod tests {
 
     #[test]
     fn test_metering_enabled_state_tracks_runtime_toggle() {
-        let store = MeteringStore::new(false, 100);
+        let store = MeteringStore::new(false, 100, None);
 
         assert!(!store.is_enabled());
 
@@ -292,7 +302,7 @@ mod tests {
     fn test_accessed_entries_survive_eviction() {
         // Small capacity to keep the TinyLFU frequency sketch deterministic.
         let capacity = 5;
-        let store = MeteringStore::new(true, capacity);
+        let store = MeteringStore::new(true, capacity, None);
 
         // Fill the cache to capacity.
         let mut hashes: Vec<TxHash> = Vec::new();
@@ -323,5 +333,32 @@ mod tests {
             store.get(&promoted).is_some(),
             "frequently accessed entry should survive eviction"
         );
+    }
+
+    #[test]
+    fn test_ttl_expires_entries() {
+        let store = MeteringStore::new(true, 100, Some(Duration::from_millis(50)));
+        let tx_hash = TxHash::random();
+
+        store.insert(tx_hash, create_test_metering(21000));
+        assert!(store.get(&tx_hash).is_some(), "entry should be present before TTL");
+
+        std::thread::sleep(Duration::from_millis(100));
+        store.run_pending_tasks();
+
+        assert!(store.get(&tx_hash).is_none(), "entry should expire after TTL");
+    }
+
+    #[test]
+    fn test_no_ttl_entries_persist() {
+        let store = MeteringStore::new(true, 100, None);
+        let tx_hash = TxHash::random();
+
+        store.insert(tx_hash, create_test_metering(21000));
+
+        std::thread::sleep(Duration::from_millis(50));
+        store.run_pending_tasks();
+
+        assert!(store.get(&tx_hash).is_some(), "entry should persist without TTL");
     }
 }

--- a/crates/builder/metering/src/store.rs
+++ b/crates/builder/metering/src/store.rs
@@ -12,7 +12,7 @@ use std::{
 use alloy_primitives::TxHash;
 use base_builder_core::{BuilderMetrics, MeteringProvider};
 use base_bundles::MeterBundleResponse;
-use moka::{notification::RemovalCause, sync::Cache};
+use moka::{notification::RemovalCause, policy::EvictionPolicy, sync::Cache};
 
 /// Concurrent metering store with LRU eviction.
 pub struct MeteringStore {
@@ -38,26 +38,23 @@ impl core::fmt::Debug for MeteringStore {
 }
 
 impl MeteringStore {
-    /// Creates a new [`MeteringStore`] with the given metering flag, max capacity, and optional
-    /// TTL.
+    /// Creates a new [`MeteringStore`] with the given metering flag, max capacity, and TTL.
     ///
-    /// When `ttl` is `Some`, entries expire automatically after the given duration.
-    /// This prevents stale metering data from accumulating in the cache and causing
-    /// `TinyLFU` admission rejections for newly arrived entries.
-    pub fn new(enable_resource_metering: bool, max_capacity: usize, ttl: Option<Duration>) -> Self {
-        let mut builder = Cache::builder().max_capacity(max_capacity as u64).eviction_listener(
-            move |_key, _value, cause| {
+    /// Uses LRU eviction (not `TinyLFU`) because this cache is write-once-read-once:
+    /// entries are inserted on metering arrival and read once at inclusion time.
+    /// `TinyLFU` would reject new entries with zero frequency since `insert()` does
+    /// not increment the frequency sketch — only `get()` does.
+    pub fn new(enable_resource_metering: bool, max_capacity: usize, ttl: Duration) -> Self {
+        let cache = Cache::builder()
+            .max_capacity(max_capacity as u64)
+            .eviction_policy(EvictionPolicy::lru())
+            .time_to_live(ttl)
+            .eviction_listener(move |_key, _value, cause| {
                 if cause == RemovalCause::Size {
                     BuilderMetrics::metering_store_lru_evictions().increment(1);
                 }
-            },
-        );
-
-        if let Some(ttl) = ttl {
-            builder = builder.time_to_live(ttl);
-        }
-
-        let cache = builder.build();
+            })
+            .build();
 
         let needed_at = Cache::builder().max_capacity(max_capacity as u64).build();
 
@@ -137,7 +134,7 @@ impl MeteringProvider for MeteringStore {
 
 impl Default for MeteringStore {
     fn default() -> Self {
-        Self::new(false, 10_000, None)
+        Self::new(false, 10_000, Duration::from_secs(30))
     }
 }
 
@@ -178,7 +175,7 @@ mod tests {
 
     #[test]
     fn test_metering_insert_and_get() {
-        let store = MeteringStore::new(true, 100, None);
+        let store = MeteringStore::new(true, 100, Duration::from_secs(30));
         let tx_hash = TxHash::random();
         let meter_data = create_test_metering(21000);
 
@@ -193,7 +190,7 @@ mod tests {
 
     #[test]
     fn test_clear_metering() {
-        let store = MeteringStore::new(true, 100, None);
+        let store = MeteringStore::new(true, 100, Duration::from_secs(30));
 
         let tx1 = TxHash::random();
         let tx2 = TxHash::random();
@@ -212,7 +209,7 @@ mod tests {
 
     #[test]
     fn test_lru_eviction() {
-        let store = MeteringStore::new(true, 2, None);
+        let store = MeteringStore::new(true, 2, Duration::from_secs(30));
 
         let tx1 = TxHash::random();
         let tx2 = TxHash::random();
@@ -231,7 +228,7 @@ mod tests {
 
     #[test]
     fn test_late_insert_after_inclusion() {
-        let store = MeteringStore::new(true, 100, None);
+        let store = MeteringStore::new(true, 100, Duration::from_secs(30));
         let tx_hash = TxHash::random();
 
         // get() miss → tx included without data → data arrives late
@@ -247,7 +244,7 @@ mod tests {
 
     #[test]
     fn test_skip_clears_needed_at() {
-        let store = MeteringStore::new(true, 100, None);
+        let store = MeteringStore::new(true, 100, Duration::from_secs(30));
         let tx_hash = TxHash::random();
 
         // get() miss → tx skipped (MeteringDataPending)
@@ -264,7 +261,7 @@ mod tests {
 
     #[test]
     fn test_no_needed_at_when_data_present() {
-        let store = MeteringStore::new(true, 100, None);
+        let store = MeteringStore::new(true, 100, Duration::from_secs(30));
         let tx_hash = TxHash::random();
 
         // Insert data first, then get() finds it — no needed_at entry
@@ -275,7 +272,7 @@ mod tests {
 
     #[test]
     fn test_clear_resets_needed_at() {
-        let store = MeteringStore::new(true, 100, None);
+        let store = MeteringStore::new(true, 100, Duration::from_secs(30));
         let tx_hash = TxHash::random();
 
         assert!(store.get(&tx_hash).is_none());
@@ -287,7 +284,7 @@ mod tests {
 
     #[test]
     fn test_metering_enabled_state_tracks_runtime_toggle() {
-        let store = MeteringStore::new(false, 100, None);
+        let store = MeteringStore::new(false, 100, Duration::from_secs(30));
 
         assert!(!store.is_enabled());
 
@@ -299,12 +296,10 @@ mod tests {
     }
 
     #[test]
-    fn test_accessed_entries_survive_eviction() {
-        // Small capacity to keep the TinyLFU frequency sketch deterministic.
+    fn test_recently_accessed_entries_survive_eviction() {
         let capacity = 5;
-        let store = MeteringStore::new(true, capacity, None);
+        let store = MeteringStore::new(true, capacity, Duration::from_secs(30));
 
-        // Fill the cache to capacity.
         let mut hashes: Vec<TxHash> = Vec::new();
         for i in 0..capacity as u64 {
             let h = TxHash::random();
@@ -314,30 +309,43 @@ mod tests {
         store.cache.run_pending_tasks();
         assert_eq!(store.len(), capacity);
 
-        // Access the first entry many times to build up its frequency estimate
-        // so TinyLFU's admission policy keeps it over newcomers.
-        let promoted = hashes[0];
-        for _ in 0..20 {
-            assert!(store.get(&promoted).is_some());
-        }
+        let recent = hashes[0];
+        assert!(store.get(&recent).is_some());
         store.cache.run_pending_tasks();
 
-        // Insert new entries one at a time, flushing between each so the
-        // eviction policy processes each displacement individually.
         for i in 0..capacity as u64 {
             store.insert(TxHash::random(), create_test_metering(i));
             store.cache.run_pending_tasks();
         }
 
         assert!(
-            store.get(&promoted).is_some(),
-            "frequently accessed entry should survive eviction"
+            store.get(&recent).is_none(),
+            "LRU eviction should eventually evict even recently accessed entries when enough new entries are inserted"
         );
     }
 
     #[test]
+    fn test_insert_always_admitted_with_lru() {
+        let capacity = 3;
+        let store = MeteringStore::new(true, capacity, Duration::from_secs(30));
+
+        for i in 0..capacity as u64 {
+            store.insert(TxHash::random(), create_test_metering(i * 1000));
+        }
+        store.cache.run_pending_tasks();
+        assert_eq!(store.len(), capacity);
+
+        let new_hash = TxHash::random();
+        store.insert(new_hash, create_test_metering(99000));
+        store.cache.run_pending_tasks();
+
+        assert!(store.get(&new_hash).is_some(), "new entry must be admitted under LRU policy");
+        assert_eq!(store.len(), capacity, "cache should remain at capacity");
+    }
+
+    #[test]
     fn test_ttl_expires_entries() {
-        let store = MeteringStore::new(true, 100, Some(Duration::from_millis(50)));
+        let store = MeteringStore::new(true, 100, Duration::from_millis(50));
         let tx_hash = TxHash::random();
 
         store.insert(tx_hash, create_test_metering(21000));
@@ -350,8 +358,8 @@ mod tests {
     }
 
     #[test]
-    fn test_no_ttl_entries_persist() {
-        let store = MeteringStore::new(true, 100, None);
+    fn test_entries_persist_within_ttl() {
+        let store = MeteringStore::new(true, 100, Duration::from_secs(30));
         let tx_hash = TxHash::random();
 
         store.insert(tx_hash, create_test_metering(21000));
@@ -359,6 +367,6 @@ mod tests {
         std::thread::sleep(Duration::from_millis(50));
         store.run_pending_tasks();
 
-        assert!(store.get(&tx_hash).is_some(), "entry should persist without TTL");
+        assert!(store.get(&tx_hash).is_some(), "entry should persist within TTL");
     }
 }

--- a/crates/builder/metering/src/store.rs
+++ b/crates/builder/metering/src/store.rs
@@ -53,10 +53,17 @@ impl MeteringStore {
                 if cause == RemovalCause::Size {
                     BuilderMetrics::metering_store_lru_evictions().increment(1);
                 }
+                if cause == RemovalCause::Expired {
+                    BuilderMetrics::metering_store_ttl_expirations().increment(1);
+                }
             })
             .build();
 
-        let needed_at = Cache::builder().max_capacity(max_capacity as u64).build();
+        let needed_at = Cache::builder()
+            .max_capacity(max_capacity as u64)
+            .eviction_policy(EvictionPolicy::lru())
+            .time_to_live(ttl)
+            .build();
 
         Self { cache, needed_at, metering_enabled: AtomicBool::new(enable_resource_metering) }
     }


### PR DESCRIPTION
- Add TTL
- Change from LFU to LRU, ensures that `insert()` always adds a new entry and evicts an old one. LFU is based on the probability a candidate may be used again which means that an insertion might not actually add the new tx hash when we want it to