### PR TITLE
[backport] feat(consensus): Restore Local Safe Head Field

### DIFF
--- a/crates/consensus/engine/src/metrics/mod.rs
+++ b/crates/consensus/engine/src/metrics/mod.rs
@@ -56,6 +56,8 @@ base_metrics::define_metrics! {
 impl Metrics {
     /// Unsafe block label.
     pub const UNSAFE_BLOCK_LABEL: &str = "unsafe";
+    /// Local-safe block label.
+    pub const LOCAL_SAFE_BLOCK_LABEL: &str = "local-safe";
     /// Safe block label.
     pub const SAFE_BLOCK_LABEL: &str = "safe";
     /// Finalized block label.

--- a/crates/consensus/engine/src/state/core.rs
+++ b/crates/consensus/engine/src/state/core.rs
@@ -19,15 +19,18 @@ use crate::Metrics;
 /// The state tracks blocks at different safety levels, listed from least to most safe:
 ///
 /// 1. **Unsafe** - Most recent blocks from P2P network (unverified)
-/// 2. **Safe** - Derived from L1 data
-/// 3. **Finalized** - Derived from finalized L1 data only
+/// 2. **Local-safe** - Derived from L1 data, completed span-batch
+/// 3. **Safe** - Derived from L1 data and cross-verified to have safe L1 dependencies
+/// 4. **Finalized** - Derived from finalized L1 data only
 ///
 /// See the [Base specifications](https://specs.optimism.io) for detailed safety definitions.
 #[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
 pub struct EngineSyncState {
     /// Most recent block found on the P2P network (lowest safety level).
     unsafe_head: L2BlockInfo,
-    /// Derived from L1 data.
+    /// Derived from L1 data as a completed span-batch, but not yet cross-verified.
+    local_safe_head: L2BlockInfo,
+    /// Derived from L1 data and cross-verified to have safe L1 dependencies.
     safe_head: L2BlockInfo,
     /// Derived from finalized L1 data with only finalized dependencies (highest safety level).
     finalized_head: L2BlockInfo,
@@ -37,6 +40,11 @@ impl EngineSyncState {
     /// Returns the current unsafe head.
     pub const fn unsafe_head(&self) -> L2BlockInfo {
         self.unsafe_head
+    }
+
+    /// Returns the current local safe head.
+    pub const fn local_safe_head(&self) -> L2BlockInfo {
+        self.local_safe_head
     }
 
     /// Returns the current safe head.
@@ -75,6 +83,10 @@ impl EngineSyncState {
             Metrics::block_refs_latency(Metrics::UNSAFE_BLOCK_LABEL)
                 .set(now_secs - unsafe_head.block_info.timestamp as f64);
         }
+        if let Some(local_safe_head) = sync_state_update.local_safe_head {
+            Metrics::block_labels(Metrics::LOCAL_SAFE_BLOCK_LABEL)
+                .set(local_safe_head.block_info.number as f64);
+        }
         if let Some(safe_head) = sync_state_update.safe_head {
             Metrics::block_labels(Metrics::SAFE_BLOCK_LABEL)
                 .set(safe_head.block_info.number as f64);
@@ -90,6 +102,7 @@ impl EngineSyncState {
 
         Self {
             unsafe_head: sync_state_update.unsafe_head.unwrap_or(self.unsafe_head),
+            local_safe_head: sync_state_update.local_safe_head.unwrap_or(self.local_safe_head),
             safe_head: sync_state_update.safe_head.unwrap_or(self.safe_head),
             finalized_head: sync_state_update.finalized_head.unwrap_or(self.finalized_head),
         }
@@ -101,9 +114,13 @@ impl EngineSyncState {
 pub struct EngineSyncStateUpdate {
     /// Most recent block found on the p2p network
     pub unsafe_head: Option<L2BlockInfo>,
-    /// Derived from L1 data.
+    /// Derived from L1, and known to be a completed span-batch,
+    /// but not cross-verified yet.
+    pub local_safe_head: Option<L2BlockInfo>,
+    /// Derived from L1 and cross-verified to have cross-safe dependencies.
     pub safe_head: Option<L2BlockInfo>,
-    /// Derived from finalized L1 data.
+    /// Derived from finalized L1 data,
+    /// and cross-verified to only have finalized dependencies.
     pub finalized_head: Option<L2BlockInfo>,
 }
 
@@ -160,6 +177,14 @@ mod tests {
             });
         }
 
+        /// Set the local safe head.
+        pub fn set_local_safe_head(&mut self, local_safe_head: L2BlockInfo) {
+            self.sync_state = self.sync_state.apply_update(EngineSyncStateUpdate {
+                local_safe_head: Some(local_safe_head),
+                ..Default::default()
+            });
+        }
+
         /// Set the safe head.
         pub fn set_safe_head(&mut self, safe_head: L2BlockInfo) {
             self.sync_state = self.sync_state.apply_update(EngineSyncStateUpdate {
@@ -179,8 +204,9 @@ mod tests {
 
     #[rstest]
     #[case::set_unsafe(EngineState::set_unsafe_head, Metrics::UNSAFE_BLOCK_LABEL, 1)]
-    #[case::set_safe_head(EngineState::set_safe_head, Metrics::SAFE_BLOCK_LABEL, 2)]
-    #[case::set_finalized_head(EngineState::set_finalized_head, Metrics::FINALIZED_BLOCK_LABEL, 3)]
+    #[case::set_local_safe(EngineState::set_local_safe_head, Metrics::LOCAL_SAFE_BLOCK_LABEL, 2)]
+    #[case::set_safe_head(EngineState::set_safe_head, Metrics::SAFE_BLOCK_LABEL, 3)]
+    #[case::set_finalized_head(EngineState::set_finalized_head, Metrics::FINALIZED_BLOCK_LABEL, 4)]
     #[cfg(feature = "metrics")]
     fn test_chain_label_metrics(
         #[case] set_fn: impl Fn(&mut EngineState, L2BlockInfo),

--- a/crates/consensus/engine/src/task_queue/core.rs
+++ b/crates/consensus/engine/src/task_queue/core.rs
@@ -251,6 +251,7 @@ mod tests {
         let mut engine = Engine::new(EngineState::default(), state_tx, queue_tx);
         let update = EngineSyncStateUpdate {
             unsafe_head: Some(head),
+            local_safe_head: Some(safe),
             safe_head: Some(safe),
             finalized_head: Some(finalized),
         };

--- a/crates/consensus/engine/src/task_queue/core.rs
+++ b/crates/consensus/engine/src/task_queue/core.rs
@@ -91,6 +91,7 @@ impl<EngineClient_: EngineClient> Engine<EngineClient_> {
             Arc::clone(&config),
             EngineSyncStateUpdate {
                 unsafe_head: Some(start.un_safe),
+                local_safe_head: Some(start.safe),
                 safe_head: Some(start.safe),
                 finalized_head: Some(start.finalized),
             },

--- a/crates/consensus/engine/src/task_queue/tasks/consolidate/task.rs
+++ b/crates/consensus/engine/src/task_queue/tasks/consolidate/task.rs
@@ -126,6 +126,7 @@ impl<EngineClient_: EngineClient> ConsolidateTask<EngineClient_> {
             Arc::clone(&self.cfg),
             EngineSyncStateUpdate {
                 unsafe_head: Some(*safe_l2),
+                local_safe_head: Some(*safe_l2),
                 safe_head: Some(*safe_l2),
                 ..Default::default()
             },
@@ -205,6 +206,7 @@ impl<EngineClient_: EngineClient> ConsolidateTask<EngineClient_> {
 
                     // Apply a transient update to the safe head.
                     state.sync_state = state.sync_state.apply_update(EngineSyncStateUpdate {
+                        local_safe_head: Some(block_info),
                         safe_head: Some(block_info),
                         ..Default::default()
                     });
@@ -226,7 +228,11 @@ impl<EngineClient_: EngineClient> ConsolidateTask<EngineClient_> {
                     SynchronizeTask::new(
                         Arc::clone(&self.client),
                         Arc::clone(&self.cfg),
-                        EngineSyncStateUpdate { safe_head: Some(block_info), ..Default::default() },
+                        EngineSyncStateUpdate {
+                            local_safe_head: Some(block_info),
+                            safe_head: Some(block_info),
+                            ..Default::default()
+                        },
                     )
                     .execute(state)
                     .await

--- a/crates/consensus/engine/src/task_queue/tasks/insert/task.rs
+++ b/crates/consensus/engine/src/task_queue/tasks/insert/task.rs
@@ -132,6 +132,7 @@ impl<EngineClient_: EngineClient> EngineTaskExt for InsertTask<EngineClient_> {
             Arc::clone(&self.rollup_config),
             EngineSyncStateUpdate {
                 unsafe_head: Some(new_unsafe_ref),
+                local_safe_head: self.is_payload_safe.then_some(new_unsafe_ref),
                 safe_head: self.is_payload_safe.then_some(new_unsafe_ref),
                 ..Default::default()
             },

--- a/crates/consensus/engine/src/test_utils/engine_state.rs
+++ b/crates/consensus/engine/src/test_utils/engine_state.rs
@@ -8,6 +8,7 @@ use crate::{EngineState, EngineSyncStateUpdate};
 #[derive(Debug)]
 pub struct TestEngineStateBuilder {
     unsafe_head: L2BlockInfo,
+    local_safe_head: Option<L2BlockInfo>,
     safe_head: Option<L2BlockInfo>,
     finalized_head: Option<L2BlockInfo>,
     el_sync_finished: bool,
@@ -28,7 +29,13 @@ impl TestEngineStateBuilder {
             seq_num: 0,
         };
 
-        Self { unsafe_head: genesis, safe_head: None, finalized_head: None, el_sync_finished: true }
+        Self {
+            unsafe_head: genesis,
+            local_safe_head: None,
+            safe_head: None,
+            finalized_head: None,
+            el_sync_finished: true,
+        }
     }
 
     /// Sets the unsafe head
@@ -62,6 +69,7 @@ impl TestEngineStateBuilder {
 
         state.sync_state = state.sync_state.apply_update(EngineSyncStateUpdate {
             unsafe_head: Some(self.unsafe_head),
+            local_safe_head: Some(self.local_safe_head.unwrap_or(self.unsafe_head)),
             safe_head: Some(self.safe_head.unwrap_or(self.unsafe_head)),
             finalized_head: Some(self.finalized_head.unwrap_or(self.unsafe_head)),
         });

--- a/crates/consensus/protocol/src/sync.rs
+++ b/crates/consensus/protocol/src/sync.rs
@@ -51,6 +51,10 @@ pub struct SyncStatus {
     /// This points to the L2 block that was derived fully from finalized L1 information, thus
     /// irreversible.
     pub finalized_l2: L2BlockInfo,
+    /// Local safe L2 block ref.
+    ///
+    /// This is an L2 block derived from L1, not yet cross-verified.
+    pub local_safe_l2: L2BlockInfo,
 }
 
 #[cfg(test)]
@@ -111,6 +115,7 @@ mod tests {
             ),
             safe_l2: L2BlockInfo::default(),
             finalized_l2: L2BlockInfo::default(),
+            local_safe_l2: L2BlockInfo::default(),
         };
 
         let json = serde_json::to_string(&status).unwrap();

--- a/crates/consensus/rpc/src/rollup.rs
+++ b/crates/consensus/rpc/src/rollup.rs
@@ -67,6 +67,7 @@ impl<EngineRpcClient_: EngineRpcClient> RollupRpc<EngineRpcClient_> {
             safe_l1: l1_sync_status.safe_l1.unwrap_or_default(),
             finalized_l1: l1_sync_status.finalized_l1.unwrap_or_default(),
             unsafe_l2: l2_sync_status.sync_state.unsafe_head(),
+            local_safe_l2: l2_sync_status.sync_state.local_safe_head(),
             safe_l2: l2_sync_status.sync_state.safe_head(),
             finalized_l2: l2_sync_status.sync_state.finalized_head(),
         }

--- a/crates/consensus/service/src/actors/engine/engine_request_processor.rs
+++ b/crates/consensus/service/src/actors/engine/engine_request_processor.rs
@@ -413,6 +413,7 @@ where
 
             let probe_update = EngineSyncStateUpdate {
                 unsafe_head: Some(head),
+                local_safe_head: Some(safe),
                 safe_head: Some(safe),
                 finalized_head: Some(finalized),
             };


### PR DESCRIPTION
> [!NOTE]
> This is a backport of #2361 into `releases/v0.8.0`.

## Summary

Restores `local_safe_head` to the engine state machine, sync status types, RPC surface, and associated metrics. This reverts the removal made in #1819, which had treated the field as dead scaffolding for OP interop. The field is re-added to `EngineSyncState`, `EngineSyncStateUpdate`, `SyncStatus`, and all sites that construct or consume forkchoice updates, including consolidate, insert, and bootstrap paths.