### PR TITLE
feat(load-tests): add XEN-shape payload for storage-trie + account-creation stress

### DIFF
--- a/crates/infra/basectl/src/app/views/load_test.rs
+++ b/crates/infra/basectl/src/app/views/load_test.rs
@@ -1892,6 +1892,9 @@ fn format_tx_type(tx_type: &TxTypeConfig) -> String {
             };
             format!("osaka {t}")
         }
+        TxTypeConfig::Xen { proxies_per_tx, .. } => {
+            format!("xen ×{proxies_per_tx}")
+        }
     }
 }
 

--- a/crates/infra/load-tests/README.md
+++ b/crates/infra/load-tests/README.md
@@ -108,3 +108,23 @@ looper_contract: "0x..."  # Deployed PrecompileLooper contract
 ```
 
 The `PrecompileLooper` contract enables batch testing by calling a precompile multiple times in a single transaction, useful for scenarios like multi-signature verification or repeated hash operations.
+
+#### XEN-shape (storage trie + account creation)
+
+The `xen` payload mirrors XEN's `bulkClaimRank`: each transaction loops `proxies_per_tx` CREATE2 deployments of a `Worker` contract, and each worker writes a per-msg.sender slot in an underlying `State` contract — N new account-trie entries plus N unique storage-trie writes per tx, with no merging in `HashedPostState`. Useful for stressing the storage trie and driving elevated account creation in a single scenario.
+
+Sources, the bundled Foundry project, and deploy notes live in [`contracts/xen/`](contracts/xen/README.md). After deploying `Multicall` and `State` to the target network, configure the payload:
+
+```yaml
+sender_count: 100
+target_gps: 30000000
+transactions:
+  - weight: 100
+    type: xen
+    multicall: "0x..."  # Multicall address
+    state: "0x..."      # State address
+    term: 1000
+    proxies_per_tx: 10
+```
+
+Per-tx gas estimate: `50_000 + proxies_per_tx * 35_000`.

--- a/crates/infra/load-tests/contracts/xen/.gitignore
+++ b/crates/infra/load-tests/contracts/xen/.gitignore
@@ -1,0 +1,2 @@
+out/
+cache/

--- a/crates/infra/load-tests/contracts/xen/Multicall.sol
+++ b/crates/infra/load-tests/contracts/xen/Multicall.sol
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {Worker} from "./Worker.sol";
+
+/// @title Multicall
+/// @notice Loops `count` CREATE2 deployments of `Worker`, where each per-iteration
+/// salt is `keccak256(abi.encodePacked(baseSalt, i))`. Mirrors the trie-load
+/// shape of XEN's `bulkClaimRank`: one tx produces N new account-trie entries
+/// (the workers) and N unique storage-trie writes (per-worker slots in `state`).
+contract Multicall {
+    function bulkClaimRank(
+        address state,
+        uint256 term,
+        uint256 baseSalt,
+        uint256 count
+    ) external {
+        bytes memory initCode = abi.encodePacked(
+            type(Worker).creationCode,
+            abi.encode(state, term)
+        );
+        for (uint256 i = 0; i < count; i++) {
+            bytes32 salt = keccak256(abi.encodePacked(baseSalt, i));
+            assembly {
+                let addr := create2(0, add(initCode, 0x20), mload(initCode), salt)
+                if iszero(addr) {
+                    revert(0, 0)
+                }
+            }
+        }
+    }
+}

--- a/crates/infra/load-tests/contracts/xen/README.md
+++ b/crates/infra/load-tests/contracts/xen/README.md
@@ -1,0 +1,62 @@
+# XEN-shape contracts
+
+Three minimal contracts used by the `xen` load-test payload. They mirror the
+trie-load shape of XEN's `bulkClaimRank` (one tx → N CREATE2 deploys + N
+unique storage writes) without any of XEN's economics, ranks, or hardfork-tied
+initialization.
+
+## Files
+
+- `State.sol` — single mapping `ranks[address] => uint256`; one `claimRank` method.
+- `Worker.sol` — calls `State.claimRank` once in its constructor. Deployed via CREATE2 by `Multicall`.
+- `Multicall.sol` — loops `count` CREATE2 deployments of `Worker`. Per-iteration salt is `keccak256(abi.encodePacked(baseSalt, i))`.
+
+## Compiling
+
+This directory is a self-contained Foundry project. Forge resolves solc 0.8.28
+via the bundled `foundry.toml`:
+
+```bash
+cd crates/infra/load-tests/contracts/xen
+forge build
+```
+
+After compilation, the deployment bytecode for each contract is at
+`out/<Contract>.sol/<Contract>.json` under `.bytecode.object`. To re-embed
+into the Rust payload, copy each into the `&'static [u8]` constants in
+`crates/infra/load-tests/src/workload/payloads/xen.rs`:
+
+```bash
+jq -r '.bytecode.object' out/State.sol/State.json
+jq -r '.bytecode.object' out/Worker.sol/Worker.json
+jq -r '.bytecode.object' out/Multicall.sol/Multicall.json
+```
+
+Strip the leading `0x` before pasting into `hex!(...)`.
+
+## Deploying
+
+Follow the `LooperPayload` pattern: deploy the contracts manually (e.g. via
+`forge create`, `cast send --create`, or a small one-shot script), then pass
+the resulting addresses to the load test via the YAML `transactions` block:
+
+```yaml
+sender_count: 100
+target_gps: 30000000
+transactions:
+  - weight: 100
+    type: xen
+    multicall: "0x..."  # Multicall address
+    state: "0x..."      # State address
+    term: 1000
+    proxies_per_tx: 10
+```
+
+## Notes
+
+- `Worker` is a plain contract, not an EIP-1167 minimal proxy. Real XEN uses
+  proxies for cheaper deploys, but the trie work — one new account-trie entry
+  per worker — is the same either way.
+- `Multicall.bulkClaimRank` reverts if any inner CREATE2 fails (e.g. salt
+  collision). With a fresh `baseSalt` per tx and a `proxies_per_tx` count
+  well below `2^32`, collisions are vanishingly rare in practice.

--- a/crates/infra/load-tests/contracts/xen/State.sol
+++ b/crates/infra/load-tests/contracts/xen/State.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+/// @title State
+/// @notice Minimal XEN-like state contract used by the load test.
+/// Stores a per-msg.sender uint256 keyed in a single mapping. Each
+/// `claimRank` call by a fresh msg.sender (e.g. a freshly-CREATE2'd
+/// `Worker`) writes a unique storage slot, producing one storage-trie
+/// entry per call.
+contract State {
+    mapping(address => uint256) public ranks;
+
+    function claimRank(uint256 term) external {
+        ranks[msg.sender] = term;
+    }
+}

--- a/crates/infra/load-tests/contracts/xen/Worker.sol
+++ b/crates/infra/load-tests/contracts/xen/Worker.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+interface IState {
+    function claimRank(uint256 term) external;
+}
+
+/// @title Worker
+/// @notice Per-claim contract deployed via CREATE2 by `Multicall`. Calls
+/// `State.claimRank` once in its constructor; the deployed contract code
+/// persists, producing one new account-trie entry per deployment.
+contract Worker {
+    constructor(address state, uint256 term) {
+        IState(state).claimRank(term);
+    }
+}

--- a/crates/infra/load-tests/contracts/xen/foundry.toml
+++ b/crates/infra/load-tests/contracts/xen/foundry.toml
@@ -1,0 +1,7 @@
+[profile.default]
+src = "."
+out = "out"
+solc = "0.8.28"
+optimizer = true
+optimizer_runs = 200
+evm_version = "paris"

--- a/crates/infra/load-tests/src/config/test_config.rs
+++ b/crates/infra/load-tests/src/config/test_config.rs
@@ -227,6 +227,18 @@ pub enum TxTypeConfig {
         /// Target Osaka feature.
         target: OsakaTarget,
     },
+
+    /// XEN-shape `bulkClaimRank` payload (requires deployed `Multicall` + `State`).
+    Xen {
+        /// Address of the deployed `Multicall` contract.
+        multicall: String,
+        /// Address of the deployed `State` contract.
+        state: String,
+        /// `term` argument forwarded to `State.claimRank`.
+        term: u64,
+        /// Number of workers (CREATE2 deployments) per transaction.
+        proxies_per_tx: u32,
+    },
 }
 
 const fn default_calldata_size() -> usize {
@@ -411,6 +423,22 @@ impl TestConfig {
                 }
             }
             TxTypeConfig::Osaka { target } => TxType::Osaka { target: target.clone() },
+            TxTypeConfig::Xen { multicall, state, term, proxies_per_tx } => {
+                let multicall_addr = multicall.parse::<Address>().map_err(|e| {
+                    BaselineError::Config(format!(
+                        "invalid xen multicall address '{multicall}': {e}"
+                    ))
+                })?;
+                let state_addr = state.parse::<Address>().map_err(|e| {
+                    BaselineError::Config(format!("invalid xen state address '{state}': {e}"))
+                })?;
+                TxType::Xen {
+                    multicall: multicall_addr,
+                    state: state_addr,
+                    term: *term,
+                    proxies_per_tx: *proxies_per_tx,
+                }
+            }
         };
         Ok(TxConfig { weight: weighted.weight, tx_type })
     }
@@ -593,6 +621,65 @@ flashblocks_ws_url: wss://localhost:7111
         let config = TestConfig::from_yaml(yaml).unwrap();
         assert_eq!(config.rpc_ws_url.as_ref().unwrap().scheme(), "wss");
         assert_eq!(config.flashblocks_ws_url.as_ref().unwrap().scheme(), "wss");
+    }
+
+    #[test]
+    fn parse_xen_config() {
+        let yaml = r#"
+rpc: http://localhost:8545
+transactions:
+  - weight: 100
+    type: xen
+    multicall: "0x1111111111111111111111111111111111111111"
+    state: "0x2222222222222222222222222222222222222222"
+    term: 1000
+    proxies_per_tx: 10
+"#;
+        let config = TestConfig::from_yaml(yaml).unwrap();
+        assert_eq!(config.transactions.len(), 1);
+
+        match &config.transactions[0].tx_type {
+            TxTypeConfig::Xen { multicall, state, term, proxies_per_tx } => {
+                assert_eq!(multicall, "0x1111111111111111111111111111111111111111");
+                assert_eq!(state, "0x2222222222222222222222222222222222222222");
+                assert_eq!(*term, 1000);
+                assert_eq!(*proxies_per_tx, 10);
+            }
+            _ => panic!("expected Xen"),
+        }
+
+        let load_config = config.to_load_config(Some(1337)).unwrap();
+        assert_eq!(load_config.transactions.len(), 1);
+        match &load_config.transactions[0].tx_type {
+            TxType::Xen { multicall, state, term, proxies_per_tx } => {
+                let expected_multicall: Address =
+                    "0x1111111111111111111111111111111111111111".parse().unwrap();
+                let expected_state: Address =
+                    "0x2222222222222222222222222222222222222222".parse().unwrap();
+                assert_eq!(*multicall, expected_multicall);
+                assert_eq!(*state, expected_state);
+                assert_eq!(*term, 1000);
+                assert_eq!(*proxies_per_tx, 10);
+            }
+            _ => panic!("expected runner TxType::Xen"),
+        }
+    }
+
+    #[test]
+    fn parse_xen_config_rejects_bad_address() {
+        let yaml = r#"
+rpc: http://localhost:8545
+transactions:
+  - weight: 100
+    type: xen
+    multicall: "not-an-address"
+    state: "0x2222222222222222222222222222222222222222"
+    term: 1000
+    proxies_per_tx: 10
+"#;
+        let config = TestConfig::from_yaml(yaml).unwrap();
+        let err = config.to_load_config(Some(1337)).unwrap_err();
+        assert!(err.to_string().contains("multicall"));
     }
 
     #[test]

--- a/crates/infra/load-tests/src/lib.rs
+++ b/crates/infra/load-tests/src/lib.rs
@@ -26,7 +26,8 @@ mod workload;
 pub use workload::{
     AccountPool, CalldataPayload, Erc20Payload, FundedAccount, OsakaPayload, Payload,
     PrecompileLooper, PrecompilePayload, SeededRng, StoragePayload, TransferPayload,
-    UniswapV2Payload, UniswapV3Payload, WorkloadGenerator, parse_precompile_id,
+    UniswapV2Payload, UniswapV3Payload, WorkloadGenerator, XEN_GAS_BASE, XEN_GAS_PER_PROXY,
+    XenContracts, XenPayload, parse_precompile_id,
 };
 
 mod runner;

--- a/crates/infra/load-tests/src/runner/config.rs
+++ b/crates/infra/load-tests/src/runner/config.rs
@@ -53,6 +53,19 @@ pub enum TxType {
         /// Target Osaka feature.
         target: OsakaTarget,
     },
+    /// XEN-shape `bulkClaimRank` payload: stresses the storage trie and drives
+    /// elevated account creation by deploying N CREATE2 worker contracts per
+    /// transaction, each writing a unique storage slot in `state`.
+    Xen {
+        /// Address of the deployed `Multicall` contract.
+        multicall: Address,
+        /// Address of the deployed `State` contract.
+        state: Address,
+        /// `term` argument forwarded to `State.claimRank`.
+        term: u64,
+        /// Number of workers (and storage writes) per transaction.
+        proxies_per_tx: u32,
+    },
 }
 
 /// Default maximum gas price cap (1000 gwei).

--- a/crates/infra/load-tests/src/runner/load_runner.rs
+++ b/crates/infra/load-tests/src/runner/load_runner.rs
@@ -39,7 +39,7 @@ use crate::{
     rpc::{RpcClient, WalletProvider, create_wallet_provider},
     workload::{
         AccountPool, CalldataPayload, Erc20Payload, OsakaPayload, PrecompilePayload,
-        TransferPayload, WorkloadGenerator,
+        TransferPayload, WorkloadGenerator, XEN_GAS_BASE, XEN_GAS_PER_PROXY, XenPayload,
     },
 };
 
@@ -204,6 +204,12 @@ impl LoadRunner {
                     generator =
                         generator.with_payload(OsakaPayload::new(target.clone()), weight_pct);
                 }
+                TxType::Xen { multicall, state, term, proxies_per_tx } => {
+                    generator = generator.with_payload(
+                        XenPayload::new(*multicall, *state, *term, *proxies_per_tx),
+                        weight_pct,
+                    );
+                }
             }
         }
 
@@ -227,6 +233,9 @@ impl LoadRunner {
                     OsakaTarget::Clz => 80_000,
                     OsakaTarget::P256verifyOsaka | OsakaTarget::ModexpOsaka => 30_000,
                 },
+                TxType::Xen { proxies_per_tx, .. } => {
+                    XEN_GAS_BASE + XEN_GAS_PER_PROXY * (*proxies_per_tx as u64)
+                }
             };
             weighted_gas += gas_estimate * tx_config.weight as u64;
         }

--- a/crates/infra/load-tests/src/workload/mod.rs
+++ b/crates/infra/load-tests/src/workload/mod.rs
@@ -9,7 +9,8 @@ pub use seeded::SeededRng;
 mod payloads;
 pub use payloads::{
     CalldataPayload, Erc20Payload, OsakaPayload, Payload, PrecompileLooper, PrecompilePayload,
-    StoragePayload, TransferPayload, UniswapV2Payload, UniswapV3Payload, parse_precompile_id,
+    StoragePayload, TransferPayload, UniswapV2Payload, UniswapV3Payload, XEN_GAS_BASE,
+    XEN_GAS_PER_PROXY, XenContracts, XenPayload, parse_precompile_id,
 };
 
 mod generator;

--- a/crates/infra/load-tests/src/workload/payloads/mod.rs
+++ b/crates/infra/load-tests/src/workload/payloads/mod.rs
@@ -29,6 +29,9 @@ pub use uniswap::{UniswapV2Payload, UniswapV3Payload};
 mod osaka;
 pub use osaka::OsakaPayload;
 
+mod xen;
+pub use xen::{XEN_GAS_BASE, XEN_GAS_PER_PROXY, XenContracts, XenPayload};
+
 /// A transaction payload generator.
 pub trait Payload: Send + Sync + std::fmt::Debug {
     /// Returns the name of this payload type.

--- a/crates/infra/load-tests/src/workload/payloads/xen.rs
+++ b/crates/infra/load-tests/src/workload/payloads/xen.rs
@@ -1,0 +1,164 @@
+//! XEN-shape payload: stresses the storage trie and drives elevated account
+//! creation by mirroring XEN's `bulkClaimRank` shape. One transaction loops
+//! `proxies_per_tx` CREATE2 deployments of a `Worker` contract, and each
+//! worker writes a per-msg.sender storage slot in an underlying `State`
+//! contract — N new account-trie entries plus N unique storage-trie writes
+//! per transaction, with no merging in `HashedPostState`.
+//!
+//! Sources live in `crates/infra/load-tests/contracts/xen/`. See the README
+//! there for the exact compile + re-embed steps.
+//!
+//! Compiled with solc 0.8.28, optimizer enabled (200 runs), `evm_version` paris.
+
+use alloy_network::TransactionBuilder;
+use alloy_primitives::{Address, Bytes, U256, hex};
+use alloy_rpc_types::TransactionRequest;
+use alloy_sol_types::{SolCall, sol};
+
+use super::Payload;
+use crate::workload::SeededRng;
+
+sol! {
+    interface IXenMulticall {
+        function bulkClaimRank(address state, uint256 term, uint256 baseSalt, uint256 count) external;
+    }
+}
+
+/// Embedded bytecodes for the XEN-shape contracts.
+///
+/// Compiled with:
+/// ```text
+/// cd crates/infra/load-tests/contracts/xen && forge build
+/// ```
+/// (forge resolves solc 0.8.28 itself via the bundled `foundry.toml`.)
+#[derive(Debug, Clone, Copy)]
+pub struct XenContracts;
+
+impl XenContracts {
+    /// Deployment bytecode for `State.sol`.
+    pub const STATE_BYTECODE: &'static [u8] = &hex!(
+        "6080604052348015600f57600080fd5b506101018061001f6000396000f3fe6080604052348015600f57600080fd5b506004361060325760003560e01c806325691de41460375780639ff054df146066575b600080fd5b605460423660046085565b60006020819052908152604090205481565b60405190815260200160405180910390f35b6083607136600460b3565b33600090815260208190526040902055565b005b600060208284031215609657600080fd5b81356001600160a01b038116811460ac57600080fd5b9392505050565b60006020828403121560c457600080fd5b503591905056fea26469706673582212209da2b8a502c840944301ded5a8b3325c92869ed09b0846260cf14e1595bf4b6c64736f6c634300081c0033"
+    );
+
+    /// Deployment bytecode for `Worker.sol`.
+    ///
+    /// Informational only: `MULTICALL_BYTECODE` already embeds the worker's
+    /// creation code via `type(Worker).creationCode`. Kept here so users can
+    /// independently verify or deploy a standalone worker.
+    pub const WORKER_BYTECODE: &'static [u8] = &hex!(
+        "6080604052348015600f57600080fd5b5060405161010f38038061010f833981016040819052602c91608a565b604051639ff054df60e01b8152600481018290526001600160a01b03831690639ff054df90602401600060405180830381600087803b158015606d57600080fd5b505af11580156080573d6000803e3d6000fd5b50505050505060c2565b60008060408385031215609c57600080fd5b82516001600160a01b038116811460b257600080fd5b6020939093015192949293505050565b603f806100d06000396000f3fe6080604052600080fdfea2646970667358221220fc04d189326c845d2f4f1389fdb2d824259e477b8cbee153fc31a76994f28ece64736f6c634300081c0033"
+    );
+
+    /// Deployment bytecode for `Multicall.sol`.
+    pub const MULTICALL_BYTECODE: &'static [u8] = &hex!(
+        "6080604052348015600f57600080fd5b506102f88061001f6000396000f3fe608060405234801561001057600080fd5b506004361061002b5760003560e01c8063d9eac7f714610030575b600080fd5b61004361003e36600461011f565b610045565b005b60006040518060200161005790610112565b601f1982820381018352601f9091011660408181526001600160a01b0388166020830152810186905260600160408051601f19818403018152908290526100a19291602001610196565b604051602081830303815290604052905060005b8281101561010a576040805160208101869052908101829052600090606001604051602081830303815290604052805190602001209050808351602085016000f58061010057600080fd5b50506001016100b5565b505050505050565b61010f806101b483390190565b6000806000806080858703121561013557600080fd5b84356001600160a01b038116811461014c57600080fd5b966020860135965060408601359560600135945092505050565b6000815160005b81811015610187576020818501810151868301520161016d565b50600093019283525090919050565b60006101ab6101a58386610166565b84610166565b94935050505056fe6080604052348015600f57600080fd5b5060405161010f38038061010f833981016040819052602c91608a565b604051639ff054df60e01b8152600481018290526001600160a01b03831690639ff054df90602401600060405180830381600087803b158015606d57600080fd5b505af11580156080573d6000803e3d6000fd5b50505050505060c2565b60008060408385031215609c57600080fd5b82516001600160a01b038116811460b257600080fd5b6020939093015192949293505050565b603f806100d06000396000f3fe6080604052600080fdfea2646970667358221220fc04d189326c845d2f4f1389fdb2d824259e477b8cbee153fc31a76994f28ece64736f6c634300081c0033a26469706673582212205ae8c736d7bf26d069401dc6fa9b39b4c7c8cb0a49547fdc9f0f27af8cb3295064736f6c634300081c0033"
+    );
+
+    /// Returns `State`'s deployment bytecode as a `Bytes`.
+    pub const fn state_deployment_bytecode() -> Bytes {
+        Bytes::from_static(Self::STATE_BYTECODE)
+    }
+
+    /// Returns `Worker`'s deployment bytecode as a `Bytes`.
+    pub const fn worker_deployment_bytecode() -> Bytes {
+        Bytes::from_static(Self::WORKER_BYTECODE)
+    }
+
+    /// Returns `Multicall`'s deployment bytecode as a `Bytes`.
+    pub const fn multicall_deployment_bytecode() -> Bytes {
+        Bytes::from_static(Self::MULTICALL_BYTECODE)
+    }
+}
+
+/// Per-worker gas estimate used both for the runtime gas-limit and the
+/// scenario-level average-gas estimator. ~25k for the worker deploy + ~5k
+/// for the per-worker storage write + ~5k overhead.
+pub const XEN_GAS_PER_PROXY: u64 = 35_000;
+
+/// Per-tx fixed overhead added on top of `proxies_per_tx * XEN_GAS_PER_PROXY`.
+pub const XEN_GAS_BASE: u64 = 50_000;
+
+/// Generates `Multicall.bulkClaimRank` transactions.
+#[derive(Debug, Clone)]
+pub struct XenPayload {
+    multicall: Address,
+    state: Address,
+    term: u64,
+    proxies_per_tx: u32,
+}
+
+impl XenPayload {
+    /// Creates a new XEN payload.
+    pub const fn new(multicall: Address, state: Address, term: u64, proxies_per_tx: u32) -> Self {
+        Self { multicall, state, term, proxies_per_tx }
+    }
+
+    /// Returns the gas limit used per generated transaction.
+    pub const fn gas_limit(&self) -> u64 {
+        XEN_GAS_BASE + (self.proxies_per_tx as u64 * XEN_GAS_PER_PROXY)
+    }
+}
+
+impl Payload for XenPayload {
+    fn name(&self) -> &'static str {
+        "xen"
+    }
+
+    fn generate(&self, rng: &mut SeededRng, _from: Address, _to: Address) -> TransactionRequest {
+        let base_salt: u64 = rng.random();
+        let call = IXenMulticall::bulkClaimRankCall {
+            state: self.state,
+            term: U256::from(self.term),
+            baseSalt: U256::from(base_salt),
+            count: U256::from(self.proxies_per_tx),
+        };
+
+        TransactionRequest::default()
+            .with_to(self.multicall)
+            .with_input(Bytes::from(call.abi_encode()))
+            .with_gas_limit(self.gas_limit())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bytecodes_are_non_empty() {
+        assert!(!XenContracts::STATE_BYTECODE.is_empty());
+        assert!(!XenContracts::WORKER_BYTECODE.is_empty());
+        assert!(!XenContracts::MULTICALL_BYTECODE.is_empty());
+    }
+
+    #[test]
+    fn gas_limit_scales_linearly() {
+        let p = XenPayload::new(Address::repeat_byte(1), Address::repeat_byte(2), 1000, 10);
+        assert_eq!(p.gas_limit(), 50_000 + 10 * 35_000);
+
+        let p2 = XenPayload::new(Address::repeat_byte(1), Address::repeat_byte(2), 1000, 0);
+        assert_eq!(p2.gas_limit(), 50_000);
+    }
+
+    #[test]
+    fn generate_produces_well_formed_calldata() {
+        let multicall = Address::repeat_byte(0xaa);
+        let state = Address::repeat_byte(0xbb);
+        let payload = XenPayload::new(multicall, state, 1000, 7);
+
+        let mut rng = SeededRng::new(42);
+        let tx = payload.generate(&mut rng, Address::ZERO, Address::ZERO);
+
+        assert_eq!(tx.to.and_then(|k| k.to().copied()), Some(multicall));
+        assert_eq!(tx.gas, Some(50_000 + 7 * 35_000));
+
+        let input = tx.input.input().expect("calldata present").clone();
+        // selector (4) + 4 * 32-byte args = 132 bytes.
+        assert_eq!(input.len(), 4 + 4 * 32);
+
+        let decoded = IXenMulticall::bulkClaimRankCall::abi_decode(&input).expect("decodable");
+        assert_eq!(decoded.state, state);
+        assert_eq!(decoded.term, U256::from(1000u64));
+        assert_eq!(decoded.count, U256::from(7u64));
+    }
+}


### PR DESCRIPTION
> **Draft — alternative to #2366. Only one of these will land.** This PR ships an XEN-specific payload with bundled `State`/`Worker`/`Multicall` contracts. #2366 instead reuses the already-deployed `Simulator` from `base/benchmark` and exposes its full config in YAML.

## Summary

- Adds a `xen` YAML transaction type that mirrors XEN's `bulkClaimRank` shape: each tx loops N CREATE2 `Worker` deployments, and each worker writes a unique slot in an underlying `State` contract — N new account-trie entries plus N unique storage writes per tx, with no merging in `HashedPostState`.
- Bundles minimal `State.sol`, `Worker.sol`, `Multicall.sol` sources (with a self-contained Foundry project) and embeds their compiled bytecode as `&'static [u8]` constants on `XenContracts`. Follows the `LooperPayload` pattern: deploy manually, pass the addresses via YAML.
- Unblocks the `xen` performance-baseline scenario.

## Test plan

- [x] `cargo +nightly fmt --all`
- [x] `cargo +nightly clippy -p base-load-tests -p basectl --all-features` (workspace-wide clippy blocked locally by an unrelated risc0 metal-kernel toolchain issue)
- [x] `cargo nextest run -p base-load-tests` — 32/32 pass, including new YAML round-trip + payload tests
- [ ] End-to-end run against sepolia after `forge create`-ing `State` and `Multicall`

type=routine
risk=low
impact=sev5