### PR TITLE
feat(load-tests): add Simulator-based payload for general resource stress

### DIFF
--- a/crates/infra/basectl/src/app/views/load_test.rs
+++ b/crates/infra/basectl/src/app/views/load_test.rs
@@ -1892,6 +1892,11 @@ fn format_tx_type(tx_type: &TxTypeConfig) -> String {
             };
             format!("osaka {t}")
         }
+        TxTypeConfig::Simulator { create_accounts, create_storage, .. } => {
+            format!(
+                "simulator (create_accounts={create_accounts}, create_storage={create_storage})"
+            )
+        }
     }
 }
 

--- a/crates/infra/load-tests/README.md
+++ b/crates/infra/load-tests/README.md
@@ -108,3 +108,46 @@ looper_contract: "0x..."  # Deployed PrecompileLooper contract
 ```
 
 The `PrecompileLooper` contract enables batch testing by calling a precompile multiple times in a single transaction, useful for scenarios like multi-signature verification or repeated hash operations.
+
+#### Simulator (general resource stress)
+
+The `simulator` payload calls `Simulator.run(SimulatorConfig)` on the deployed `Simulator` contract from `base/benchmark`. Each YAML field maps 1:1 to the corresponding field on the on-chain `SimulatorConfig` struct, letting you describe many resource-stress workloads without embedding new contracts in this crate.
+
+Already-deployed instances:
+
+| Network | Address |
+|---------|---------|
+| Sepolia Alpha | `0x596E578e5Db8B287208518Db6366194720958e35` |
+| Base Sepolia  | `0xee1dc3309A40a5645769bFCEF90f4131af626f19` |
+| Mainnet       | `0xF86d7753dc7778A5e30901c91F611611c93C07Ad` |
+
+Per-chunk initialization (`initialize_storage_chunk`, `initialize_address_chunk`) is only required when the workload uses `load_*` or `update_*` ops; pure `create_*` workloads call `run` directly.
+
+Example — XEN-shape (one new account-trie entry + one new storage-trie entry per slot, 470 of each per tx, ~16.7M gas):
+
+```yaml
+sender_count: 100
+target_gps: 30000000
+transactions:
+  - weight: 100
+    type: simulator
+    target: "0xee1dc3309A40a5645769bFCEF90f4131af626f19"
+    gas_limit: 16700000
+    create_accounts: 470
+    create_storage: 470
+```
+
+Example — mixed storage + blake2f:
+
+```yaml
+- weight: 100
+  type: simulator
+  target: "0x..."
+  gas_limit: 16700000
+  create_storage: 200
+  precompiles:
+    - address: "0x0000000000000000000000000000000000000009"
+      num_calls: 50
+```
+
+All op fields default to 0 if omitted. See `Simulator.sol` in the `base/benchmark` repo for full op semantics.

--- a/crates/infra/load-tests/src/config/mod.rs
+++ b/crates/infra/load-tests/src/config/mod.rs
@@ -4,4 +4,7 @@ mod workload;
 pub use workload::WorkloadConfig;
 
 mod test_config;
-pub use test_config::{OsakaTarget, PrecompileTarget, TestConfig, TxTypeConfig, WeightedTxType};
+pub use test_config::{
+    OsakaTarget, PrecompileTarget, SimulatorPrecompileConfig, TestConfig, TxTypeConfig,
+    WeightedTxType,
+};

--- a/crates/infra/load-tests/src/config/test_config.rs
+++ b/crates/infra/load-tests/src/config/test_config.rs
@@ -227,6 +227,49 @@ pub enum TxTypeConfig {
         /// Target Osaka feature.
         target: OsakaTarget,
     },
+
+    /// Generic resource-stress payload that calls `Simulator.run(SimulatorConfig)`
+    /// on the deployed `Simulator` contract from `base/benchmark`. Each field
+    /// below maps 1:1 to the corresponding field on the on-chain config struct.
+    Simulator {
+        /// Address of the deployed `Simulator` contract.
+        target: String,
+        /// Gas limit per generated transaction.
+        gas_limit: u64,
+        /// Number of `BALANCE`-load ops on existing accounts.
+        #[serde(default)]
+        load_accounts: u64,
+        /// Number of `send(1)` updates to existing accounts.
+        #[serde(default)]
+        update_accounts: u64,
+        /// Number of newly-created accounts (one new account-trie entry each).
+        #[serde(default)]
+        create_accounts: u64,
+        /// Number of `SLOAD` ops on existing slots.
+        #[serde(default)]
+        load_storage: u64,
+        /// Number of `SSTORE` ops on existing slots.
+        #[serde(default)]
+        update_storage: u64,
+        /// Number of `SSTORE`-to-zero ops on existing slots.
+        #[serde(default)]
+        delete_storage: u64,
+        /// Number of newly-written storage slots (one new storage-trie entry each).
+        #[serde(default)]
+        create_storage: u64,
+        /// Optional precompile mix.
+        #[serde(default)]
+        precompiles: Vec<SimulatorPrecompileConfig>,
+    },
+}
+
+/// Per-precompile entry in the simulator config.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SimulatorPrecompileConfig {
+    /// Precompile address (e.g. `"0x0000000000000000000000000000000000000009"` for blake2f).
+    pub address: String,
+    /// Number of calls to that precompile per `run`.
+    pub num_calls: u64,
 }
 
 const fn default_calldata_size() -> usize {
@@ -411,6 +454,48 @@ impl TestConfig {
                 }
             }
             TxTypeConfig::Osaka { target } => TxType::Osaka { target: target.clone() },
+            TxTypeConfig::Simulator {
+                target,
+                gas_limit,
+                load_accounts,
+                update_accounts,
+                create_accounts,
+                load_storage,
+                update_storage,
+                delete_storage,
+                create_storage,
+                precompiles,
+            } => {
+                let target_addr = target.parse::<Address>().map_err(|e| {
+                    BaselineError::Config(format!("invalid simulator target '{target}': {e}"))
+                })?;
+                let precompiles = precompiles
+                    .iter()
+                    .map(|p| {
+                        let addr = p.address.parse::<Address>().map_err(|e| {
+                            BaselineError::Config(format!(
+                                "invalid simulator precompile address '{}': {e}",
+                                p.address
+                            ))
+                        })?;
+                        Ok(crate::workload::SimulatorPrecompile {
+                            address: addr,
+                            num_calls: p.num_calls,
+                        })
+                    })
+                    .collect::<Result<Vec<_>>>()?;
+                let ops = crate::workload::SimulatorOps {
+                    load_accounts: *load_accounts,
+                    update_accounts: *update_accounts,
+                    create_accounts: *create_accounts,
+                    load_storage: *load_storage,
+                    update_storage: *update_storage,
+                    delete_storage: *delete_storage,
+                    create_storage: *create_storage,
+                    precompiles,
+                };
+                TxType::Simulator { target: target_addr, ops, gas_limit: *gas_limit }
+            }
         };
         Ok(TxConfig { weight: weighted.weight, tx_type })
     }
@@ -559,6 +644,55 @@ transactions:
         }
 
         assert!(config.looper_contract.is_some());
+    }
+
+    #[test]
+    fn parse_simulator_config() {
+        let yaml = r#"
+rpc: http://localhost:8545
+transactions:
+  - weight: 100
+    type: simulator
+    target: "0xee1dc3309A40a5645769bFCEF90f4131af626f19"
+    gas_limit: 16700000
+    create_accounts: 470
+    precompiles:
+      - address: "0x0000000000000000000000000000000000000009"
+        num_calls: 100
+"#;
+        let config = TestConfig::from_yaml(yaml).unwrap();
+        assert_eq!(config.transactions.len(), 1);
+
+        let load_config = config.to_load_config(Some(1337)).unwrap();
+        match &load_config.transactions[0].tx_type {
+            TxType::Simulator { target, ops, gas_limit } => {
+                let expected: Address =
+                    "0xee1dc3309A40a5645769bFCEF90f4131af626f19".parse().unwrap();
+                assert_eq!(*target, expected);
+                assert_eq!(*gas_limit, 16_700_000);
+                assert_eq!(ops.create_accounts, 470);
+                assert_eq!(ops.create_storage, 0);
+                assert_eq!(ops.precompiles.len(), 1);
+                assert_eq!(ops.precompiles[0].num_calls, 100);
+            }
+            _ => panic!("expected runner TxType::Simulator"),
+        }
+    }
+
+    #[test]
+    fn parse_simulator_config_rejects_bad_address() {
+        let yaml = r#"
+rpc: http://localhost:8545
+transactions:
+  - weight: 100
+    type: simulator
+    target: "not-an-address"
+    gas_limit: 16700000
+    create_accounts: 470
+"#;
+        let config = TestConfig::from_yaml(yaml).unwrap();
+        let err = config.to_load_config(Some(1337)).unwrap_err();
+        assert!(err.to_string().contains("simulator"));
     }
 
     #[test]

--- a/crates/infra/load-tests/src/lib.rs
+++ b/crates/infra/load-tests/src/lib.rs
@@ -4,7 +4,8 @@
 
 mod config;
 pub use config::{
-    OsakaTarget, PrecompileTarget, TestConfig, TxTypeConfig, WeightedTxType, WorkloadConfig,
+    OsakaTarget, PrecompileTarget, SimulatorPrecompileConfig, TestConfig, TxTypeConfig,
+    WeightedTxType, WorkloadConfig,
 };
 
 mod devnet;
@@ -25,8 +26,9 @@ pub use metrics::{
 mod workload;
 pub use workload::{
     AccountPool, CalldataPayload, Erc20Payload, FundedAccount, OsakaPayload, Payload,
-    PrecompileLooper, PrecompilePayload, SeededRng, StoragePayload, TransferPayload,
-    UniswapV2Payload, UniswapV3Payload, WorkloadGenerator, parse_precompile_id,
+    PrecompileLooper, PrecompilePayload, SeededRng, SimulatorOps, SimulatorPayload,
+    SimulatorPrecompile, StoragePayload, TransferPayload, UniswapV2Payload, UniswapV3Payload,
+    WorkloadGenerator, parse_precompile_id,
 };
 
 mod runner;

--- a/crates/infra/load-tests/src/runner/config.rs
+++ b/crates/infra/load-tests/src/runner/config.rs
@@ -7,6 +7,7 @@ use url::Url;
 use crate::{
     config::OsakaTarget,
     utils::{BaselineError, Result},
+    workload::SimulatorOps,
 };
 
 /// Configuration for a single transaction type with its weight.
@@ -52,6 +53,16 @@ pub enum TxType {
     Osaka {
         /// Target Osaka feature.
         target: OsakaTarget,
+    },
+    /// Generic resource-stress payload that calls `Simulator.run(SimulatorConfig)`
+    /// on the deployed `Simulator` contract from `base/benchmark`.
+    Simulator {
+        /// Address of the deployed `Simulator` contract.
+        target: Address,
+        /// Per-call op counts forwarded to `Simulator.run`.
+        ops: SimulatorOps,
+        /// Gas limit per generated transaction.
+        gas_limit: u64,
     },
 }
 

--- a/crates/infra/load-tests/src/runner/load_runner.rs
+++ b/crates/infra/load-tests/src/runner/load_runner.rs
@@ -39,7 +39,7 @@ use crate::{
     rpc::{RpcClient, WalletProvider, create_wallet_provider},
     workload::{
         AccountPool, CalldataPayload, Erc20Payload, OsakaPayload, PrecompilePayload,
-        TransferPayload, WorkloadGenerator,
+        SimulatorPayload, TransferPayload, WorkloadGenerator,
     },
 };
 
@@ -204,6 +204,12 @@ impl LoadRunner {
                     generator =
                         generator.with_payload(OsakaPayload::new(target.clone()), weight_pct);
                 }
+                TxType::Simulator { target, ops, gas_limit } => {
+                    generator = generator.with_payload(
+                        SimulatorPayload::new(*target, ops.clone(), *gas_limit),
+                        weight_pct,
+                    );
+                }
             }
         }
 
@@ -227,6 +233,7 @@ impl LoadRunner {
                     OsakaTarget::Clz => 80_000,
                     OsakaTarget::P256verifyOsaka | OsakaTarget::ModexpOsaka => 30_000,
                 },
+                TxType::Simulator { gas_limit, .. } => *gas_limit,
             };
             weighted_gas += gas_estimate * tx_config.weight as u64;
         }

--- a/crates/infra/load-tests/src/workload/mod.rs
+++ b/crates/infra/load-tests/src/workload/mod.rs
@@ -9,7 +9,8 @@ pub use seeded::SeededRng;
 mod payloads;
 pub use payloads::{
     CalldataPayload, Erc20Payload, OsakaPayload, Payload, PrecompileLooper, PrecompilePayload,
-    StoragePayload, TransferPayload, UniswapV2Payload, UniswapV3Payload, parse_precompile_id,
+    SimulatorOps, SimulatorPayload, SimulatorPrecompile, StoragePayload, TransferPayload,
+    UniswapV2Payload, UniswapV3Payload, parse_precompile_id,
 };
 
 mod generator;

--- a/crates/infra/load-tests/src/workload/payloads/mod.rs
+++ b/crates/infra/load-tests/src/workload/payloads/mod.rs
@@ -29,6 +29,9 @@ pub use uniswap::{UniswapV2Payload, UniswapV3Payload};
 mod osaka;
 pub use osaka::OsakaPayload;
 
+mod simulator;
+pub use simulator::{SimulatorOps, SimulatorPayload, SimulatorPrecompile};
+
 /// A transaction payload generator.
 pub trait Payload: Send + Sync + std::fmt::Debug {
     /// Returns the name of this payload type.

--- a/crates/infra/load-tests/src/workload/payloads/simulator.rs
+++ b/crates/infra/load-tests/src/workload/payloads/simulator.rs
@@ -1,0 +1,188 @@
+//! Generic resource-stress payload that calls `Simulator.run(SimulatorConfig)`
+//! on the `Simulator` contract from `base/benchmark`.
+//!
+//! `Simulator` exposes per-call knobs for state-trie and account-trie work
+//! (`create_storage`, `create_accounts`, `update_*`, `load_*`, `delete_*`)
+//! plus a precompile mix. Pointing this payload at one of the already-deployed
+//! Simulator instances avoids embedding any new contract bytecode in the load
+//! tool — the whole workload is described by the `SimulatorConfig` struct.
+//!
+//! Deployed addresses (see `base/benchmark`):
+//! - Sepolia Alpha: `0x596E578e5Db8B287208518Db6366194720958e35`
+//! - Base Sepolia:  `0xee1dc3309A40a5645769bFCEF90f4131af626f19`
+//! - Mainnet:       `0xF86d7753dc7778A5e30901c91F611611c93C07Ad`
+//!
+//! Per-chunk initialization (`initialize_storage_chunk`, `initialize_address_chunk`)
+//! is only required if the workload uses `load_*` or `update_*` ops; pure
+//! `create_*` workloads call `run` directly.
+
+use alloy_network::TransactionBuilder;
+use alloy_primitives::{Address, Bytes, U160, U256};
+use alloy_rpc_types::TransactionRequest;
+use alloy_sol_types::{SolCall, sol};
+
+use super::Payload;
+use crate::workload::SeededRng;
+
+sol! {
+    interface ISimulator {
+        struct PrecompileConfig {
+            address precompile_address;
+            uint256 num_calls;
+        }
+
+        struct SimulatorConfig {
+            uint160 load_accounts;
+            uint160 update_accounts;
+            uint160 create_accounts;
+            uint256 load_storage;
+            uint256 update_storage;
+            uint256 delete_storage;
+            uint256 create_storage;
+            PrecompileConfig[] precompiles;
+        }
+
+        function run(SimulatorConfig calldata config) external;
+    }
+}
+
+/// Per-precompile entry in the simulator config.
+#[derive(Debug, Clone, Copy)]
+pub struct SimulatorPrecompile {
+    /// Precompile address (e.g. `0x09` for blake2f).
+    pub address: Address,
+    /// Number of calls to that precompile per `run`.
+    pub num_calls: u64,
+}
+
+/// Op counts forwarded to `Simulator.run`. Each field maps 1:1 to the
+/// corresponding field on the on-chain `SimulatorConfig` struct.
+#[derive(Debug, Clone, Default)]
+pub struct SimulatorOps {
+    /// Number of `BALANCE`-load ops on existing accounts.
+    pub load_accounts: u64,
+    /// Number of `send(1)` updates to existing accounts.
+    pub update_accounts: u64,
+    /// Number of newly-created accounts (one new account-trie entry each).
+    pub create_accounts: u64,
+    /// Number of `SLOAD` ops on existing slots.
+    pub load_storage: u64,
+    /// Number of `SSTORE` ops on existing slots.
+    pub update_storage: u64,
+    /// Number of `SSTORE`-to-zero ops on existing slots.
+    pub delete_storage: u64,
+    /// Number of newly-written storage slots (one new storage-trie entry each).
+    pub create_storage: u64,
+    /// Optional precompile mix.
+    pub precompiles: Vec<SimulatorPrecompile>,
+}
+
+/// Generates `Simulator.run(SimulatorConfig)` transactions.
+///
+/// The on-chain Simulator is offset-aware (each instance was constructed with
+/// a starting offset) and bumps internal counters as it runs, so concurrent
+/// senders pointing at the same Simulator are safe — they just race on the
+/// shared counters and write to disjoint regions.
+#[derive(Debug, Clone)]
+pub struct SimulatorPayload {
+    target: Address,
+    ops: SimulatorOps,
+    gas_limit: u64,
+}
+
+impl SimulatorPayload {
+    /// Creates a new simulator payload targeting `target` with the given ops
+    /// and gas limit.
+    pub const fn new(target: Address, ops: SimulatorOps, gas_limit: u64) -> Self {
+        Self { target, ops, gas_limit }
+    }
+
+    /// Returns the gas limit used per generated transaction.
+    pub const fn gas_limit(&self) -> u64 {
+        self.gas_limit
+    }
+}
+
+impl Payload for SimulatorPayload {
+    fn name(&self) -> &'static str {
+        "simulator"
+    }
+
+    fn generate(&self, _rng: &mut SeededRng, _from: Address, _to: Address) -> TransactionRequest {
+        let precompiles: Vec<ISimulator::PrecompileConfig> = self
+            .ops
+            .precompiles
+            .iter()
+            .map(|p| ISimulator::PrecompileConfig {
+                precompile_address: p.address,
+                num_calls: U256::from(p.num_calls),
+            })
+            .collect();
+
+        let call = ISimulator::runCall {
+            config: ISimulator::SimulatorConfig {
+                load_accounts: U160::from(self.ops.load_accounts),
+                update_accounts: U160::from(self.ops.update_accounts),
+                create_accounts: U160::from(self.ops.create_accounts),
+                load_storage: U256::from(self.ops.load_storage),
+                update_storage: U256::from(self.ops.update_storage),
+                delete_storage: U256::from(self.ops.delete_storage),
+                create_storage: U256::from(self.ops.create_storage),
+                precompiles,
+            },
+        };
+
+        TransactionRequest::default()
+            .with_to(self.target)
+            .with_input(Bytes::from(call.abi_encode()))
+            .with_gas_limit(self.gas_limit)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn generate_produces_well_formed_calldata() {
+        let target = Address::repeat_byte(0xab);
+        let ops = SimulatorOps { create_accounts: 470, ..SimulatorOps::default() };
+        let payload = SimulatorPayload::new(target, ops, 16_700_000);
+
+        let mut rng = SeededRng::new(1);
+        let tx = payload.generate(&mut rng, Address::ZERO, Address::ZERO);
+
+        assert_eq!(tx.to.and_then(|k| k.to().copied()), Some(target));
+        assert_eq!(tx.gas, Some(16_700_000));
+
+        let input = tx.input.input().expect("calldata present").clone();
+        let decoded = ISimulator::runCall::abi_decode(&input).expect("decodable");
+        assert_eq!(decoded.config.create_accounts, U160::from(470u64));
+        assert_eq!(decoded.config.create_storage, U256::ZERO);
+        assert!(decoded.config.precompiles.is_empty());
+    }
+
+    #[test]
+    fn generate_includes_precompiles() {
+        let target = Address::repeat_byte(0xcd);
+        let ops = SimulatorOps {
+            create_storage: 10,
+            precompiles: vec![SimulatorPrecompile {
+                address: Address::with_last_byte(0x09),
+                num_calls: 5,
+            }],
+            ..SimulatorOps::default()
+        };
+        let payload = SimulatorPayload::new(target, ops, 5_000_000);
+
+        let mut rng = SeededRng::new(1);
+        let tx = payload.generate(&mut rng, Address::ZERO, Address::ZERO);
+        let input = tx.input.input().expect("calldata present").clone();
+        let decoded = ISimulator::runCall::abi_decode(&input).expect("decodable");
+
+        assert_eq!(decoded.config.create_storage, U256::from(10u64));
+        assert_eq!(decoded.config.precompiles.len(), 1);
+        assert_eq!(decoded.config.precompiles[0].precompile_address, Address::with_last_byte(0x09));
+        assert_eq!(decoded.config.precompiles[0].num_calls, U256::from(5u64));
+    }
+}


### PR DESCRIPTION
> **Draft — alternative to #2363. Only one of these will land.** This PR reuses the already-deployed `Simulator` contract from `base/benchmark` and exposes its full config in YAML, so XEN-shape becomes `create_accounts: N, create_storage: N` with no new contracts embedded in this crate. #2363 instead ships XEN-specific `State`/`Worker`/`Multicall` Solidity.

## Summary

- Adds a `simulator` YAML transaction type that calls `Simulator.run(SimulatorConfig)` on the deployed `Simulator` contract from `base/benchmark` (already deployed on Sepolia Alpha, Base Sepolia, and Mainnet).
- Each YAML field maps 1:1 to the on-chain `SimulatorConfig` struct, so workloads — account-trie growth, storage-trie growth, updates, deletes, precompile mixes — can be described entirely in YAML with no new contracts embedded in this crate.

## Test plan

- [x] `cargo +nightly fmt --all`
- [x] `cargo +nightly clippy -p base-load-tests -p basectl --all-features`
- [x] `cargo nextest run -p base-load-tests` — 31/31 pass, including new YAML round-trip + payload tests
- [ ] End-to-end run against sepolia / sepolia alpha pointing at the deployed Simulator addresses

type=routine
risk=low
impact=sev5