### PR TITLE
fix(batcher): skip catchup from genesis when safe_head_rx is None on reorg

### DIFF
--- a/crates/batcher/core/src/driver.rs
+++ b/crates/batcher/core/src/driver.rs
@@ -180,17 +180,24 @@ where
                     debug!("flush signal received, force-closed channel");
                 }
                 DriverEvent::Reorg(head) => {
-                    let safe_head = self.safe_head_rx.as_ref().map(|rx| *rx.borrow()).unwrap_or(0);
-                    let catchup_from = safe_head + 1;
-                    warn!(
-                        reorg_head = %head.block_info.number,
-                        safe_head = %safe_head,
-                        catchup_from = %catchup_from,
-                        "L2 reorg detected, resetting pipeline and catching up from safe head"
-                    );
                     self.submissions.discard();
                     self.pipeline.reset();
-                    self.source.reset_catchup(catchup_from);
+                    if let Some(rx) = self.safe_head_rx.as_ref() {
+                        let safe_head = *rx.borrow();
+                        let catchup_from = safe_head + 1;
+                        warn!(
+                            reorg_head = %head.block_info.number,
+                            safe_head = %safe_head,
+                            catchup_from = %catchup_from,
+                            "L2 reorg detected, resetting pipeline and catching up from safe head"
+                        );
+                        self.source.reset_catchup(catchup_from);
+                    } else {
+                        warn!(
+                            reorg_head = %head.block_info.number,
+                            "L2 reorg detected but safe-head receiver is unavailable; resetting pipeline without catchup"
+                        );
+                    }
                 }
                 DriverEvent::Receipt(ids, o) => {
                     self.submissions.handle_outcome(&mut self.pipeline, ids, o);
@@ -253,18 +260,26 @@ where
                 debug!(block = %number, "added unsafe block to pipeline");
             }
             Err((e, _block)) => {
-                let safe_head = self.safe_head_rx.as_ref().map(|rx| *rx.borrow()).unwrap_or(0);
-                let catchup_from = safe_head + 1;
-                warn!(
-                    block = %number,
-                    safe_head = %safe_head,
-                    catchup_from = %catchup_from,
-                    error = %e,
-                    "reorg detected during block ingestion, resetting pipeline and catching up from safe head"
-                );
                 self.submissions.discard();
                 self.pipeline.reset();
-                self.source.reset_catchup(catchup_from);
+                if let Some(rx) = self.safe_head_rx.as_ref() {
+                    let safe_head = *rx.borrow();
+                    let catchup_from = safe_head + 1;
+                    warn!(
+                        block = %number,
+                        safe_head = %safe_head,
+                        catchup_from = %catchup_from,
+                        error = %e,
+                        "reorg detected during block ingestion, resetting pipeline and catching up from safe head"
+                    );
+                    self.source.reset_catchup(catchup_from);
+                } else {
+                    warn!(
+                        block = %number,
+                        error = %e,
+                        "reorg detected during block ingestion but safe-head receiver is unavailable; resetting pipeline without catchup"
+                    );
+                }
             }
         }
     }


### PR DESCRIPTION
Was going through driver.rs and noticed the two reorg handlers both do unwrap_or(0) on safe_head_rx while the admin Resume handler right below them at line 304 already handles this correctly with an if let Some guard. The difference matters because driver.rs line 387 sets safe_head_rx to None when the SafeHeadPoller sender drops. After that any reorg event falls into unwrap_or(0) and calls reset_catchup(1) which walks every block from genesis  around 30M blocks on mainnet and also clears the dedup cache in hybrid.rs:137 so already-batched blocks get re-delivered.

Matched the Resume pattern in both places. Build passes.