### PR TITLE
ci: deduplicate workflows between merge queue and main

### DIFF
--- a/.github/workflows/action-tests.yml
+++ b/.github/workflows/action-tests.yml
@@ -1,8 +1,6 @@
 name: Action Tests
 
 on:
-  push:
-    branches: [main]
   pull_request:
   merge_group:
 

--- a/.github/workflows/lychee.yml
+++ b/.github/workflows/lychee.yml
@@ -1,9 +1,6 @@
 name: Lychee Checks
 
 on:
-  push:
-    branches-ignore:
-      - 'gh-readonly-queue/**'
   pull_request:
   merge_group:
   workflow_dispatch:

--- a/.github/workflows/no-std.yml
+++ b/.github/workflows/no-std.yml
@@ -1,8 +1,6 @@
 name: no_std
 
 on:
-  push:
-    branches: [main]
   pull_request:
   merge_group:
 

--- a/.github/workflows/zepter.yml
+++ b/.github/workflows/zepter.yml
@@ -1,8 +1,6 @@
 name: Zepter
 
 on:
-  push:
-    branches: [main]
   pull_request:
     branches: [main]
   merge_group:


### PR DESCRIPTION
## Summary
These workflows already run on the merge queue, no need to continue running them on main. If we can save some minutes, I'll feel less bad about juicing the runners.