### PR TITLE
refactor(builder): move types to fix dependency direction

### DIFF
--- a/crates/builder/core/src/execution.rs
+++ b/crates/builder/core/src/execution.rs
@@ -8,13 +8,12 @@ use ExecutionMeteringLimitExceeded::{
     BlockStateRootGas, FlashblockExecutionTime, TransactionExecutionTime,
 };
 use alloy_primitives::{Address, U256};
+use base_access_lists::FlashblockAccessListBuilder;
 use base_bundles::RejectedTransaction;
 use base_common_consensus::{BaseReceipt, BaseTransactionSigned};
 use base_common_evm::BaseTransactionError;
 use derive_more::Display;
 use thiserror::Error;
-
-use crate::flashblocks::FlashblocksExecutionInfo;
 
 /// Resource limits configuration for transaction and block constraints.
 ///
@@ -210,6 +209,19 @@ pub enum TxnOutcome {
     Reverted,
     /// Transaction reverted and was excluded from the block.
     RevertedAndExcluded,
+}
+
+/// Execution information specific to flashblocks.
+///
+/// Tracks the last consumed flashblock index and manages the
+/// flashblock-level access list builder for progressive block construction.
+#[derive(Debug, Default, Clone)]
+pub struct FlashblocksExecutionInfo {
+    /// Index of the last consumed flashblock
+    pub(crate) last_flashblock_index: usize,
+
+    /// Flashblock-level access list builder
+    pub(crate) access_list_builder: FlashblockAccessListBuilder,
 }
 
 /// Accumulated execution state for the current block being built.

--- a/crates/builder/core/src/flashblocks/best_txs.rs
+++ b/crates/builder/core/src/flashblocks/best_txs.rs
@@ -1,48 +1,12 @@
 //! An adapter over `BestPayloadTransactions`
 
-use std::{collections::HashSet, sync::Arc, time::Duration};
+use std::{collections::HashSet, sync::Arc};
 
 use alloy_primitives::{Address, TxHash};
-use moka::sync::Cache;
 use reth_payload_util::PayloadTransactions;
 use reth_transaction_pool::{PoolTransaction, ValidPoolTransaction};
 
-use crate::BuilderMetrics;
-
-/// Shared, cross-block cache of permanently rejected transaction hashes.
-///
-/// Backed by [`moka::sync::Cache`] with a TTL so entries expire if metering
-/// predictions or operator limits change.
-#[derive(Clone, Debug)]
-pub struct RejectionCache(Cache<TxHash, ()>);
-
-impl RejectionCache {
-    /// Creates a new [`RejectionCache`] with the given capacity and TTL.
-    pub fn new(max_capacity: u64, ttl: Duration) -> Self {
-        Self(Cache::builder().max_capacity(max_capacity).time_to_live(ttl).build())
-    }
-
-    /// Checks if a transaction hash is in the cache.
-    pub fn contains_key(&self, hash: &TxHash) -> bool {
-        self.0.contains_key(hash)
-    }
-
-    /// Adds a transaction hash to the cache.
-    pub fn insert(&self, hash: TxHash) {
-        self.0.insert(hash, ());
-    }
-
-    /// Returns the number of cached entries.
-    pub fn entry_count(&self) -> u64 {
-        self.0.entry_count()
-    }
-
-    /// Flushes pending cache maintenance tasks (evictions, TTL expiry).
-    #[cfg(any(test, feature = "test-utils"))]
-    pub fn run_pending_tasks(&self) {
-        self.0.run_pending_tasks();
-    }
-}
+use crate::{BuilderMetrics, RejectionCache};
 
 /// An adapter over `BestPayloadTransactions` that allows to skip transactions that were already
 /// committed to the state. It also allows to refresh inner iterator on each flashblock building, to
@@ -153,7 +117,7 @@ mod tests {
         test_utils::{MockTransaction, MockTransactionFactory},
     };
 
-    use crate::flashblocks::best_txs::{BestFlashblocksTxs, RejectionCache};
+    use crate::{RejectionCache, flashblocks::best_txs::BestFlashblocksTxs};
 
     fn test_rejection_cache() -> RejectionCache {
         RejectionCache::new(1000, Duration::from_secs(60))

--- a/crates/builder/core/src/flashblocks/mod.rs
+++ b/crates/builder/core/src/flashblocks/mod.rs
@@ -1,7 +1,7 @@
 //! Flashblocks builder types.
 
 mod best_txs;
-pub use best_txs::{BestFlashblocksTxs, RejectionCache};
+pub use best_txs::BestFlashblocksTxs;
 
 mod generator;
 pub use generator::{
@@ -21,7 +21,6 @@ pub use context::{
 };
 
 mod payload;
-pub use payload::FlashblocksExecutionInfo;
 
 mod service;
 pub use service::FlashblocksServiceBuilder;

--- a/crates/builder/core/src/flashblocks/payload.rs
+++ b/crates/builder/core/src/flashblocks/payload.rs
@@ -12,7 +12,7 @@ use alloy_consensus::{
 use alloy_eips::{Encodable2718, eip7685::EMPTY_REQUESTS_HASH, merge::BEACON_NONCE};
 use alloy_evm::Database;
 use alloy_primitives::{Address, B256, Bloom, U256, logs_bloom, map::foldhash::HashMap};
-use base_access_lists::{FlashblockAccessList, FlashblockAccessListBuilder};
+use base_access_lists::FlashblockAccessList;
 use base_builder_publish::WebSocketPublisher;
 use base_bundles::RejectedTransaction;
 use base_common_chains::Upgrades;
@@ -71,19 +71,6 @@ type NextBestFlashblocksTxs<Pool> = BestFlashblocksTxs<
             >,
     >,
 >;
-
-/// Execution information specific to flashblocks.
-///
-/// Tracks the last consumed flashblock index and manages the
-/// flashblock-level access list builder for progressive block construction.
-#[derive(Debug, Default, Clone)]
-pub struct FlashblocksExecutionInfo {
-    /// Index of the last consumed flashblock
-    pub(crate) last_flashblock_index: usize,
-
-    /// Flashblock-level access list builder
-    pub(crate) access_list_builder: FlashblockAccessListBuilder,
-}
 
 /// Base payload builder
 #[derive(Debug, Clone)]

--- a/crates/builder/core/src/lib.rs
+++ b/crates/builder/core/src/lib.rs
@@ -15,8 +15,8 @@ pub use metrics::BuilderMetrics;
 
 mod execution;
 pub use execution::{
-    ExecutionInfo, ExecutionMeteringLimitExceeded, ResourceLimits, TxResources, TxnExecutionError,
-    TxnOutcome,
+    ExecutionInfo, ExecutionMeteringLimitExceeded, FlashblocksExecutionInfo, ResourceLimits,
+    TxResources, TxnExecutionError, TxnOutcome,
 };
 
 mod execution_metering_mode;
@@ -31,12 +31,15 @@ pub use metering::{MeteringProvider, NoopMeteringProvider, SharedMeteringProvide
 mod rejected_tx_forwarder;
 pub use rejected_tx_forwarder::RejectedTxForwarder;
 
+mod rejection_cache;
+pub use rejection_cache::RejectionCache;
+
 mod flashblocks;
 pub use flashblocks::{
     BasePayloadBuilderCtx, BestFlashblocksTxs, BlockCell, BlockPayloadJob,
     BlockPayloadJobGenerator, BuildArguments, FlashblockDiagnostics, FlashblockSelectionOutcome,
-    FlashblocksExecutionInfo, FlashblocksExtraCtx, FlashblocksServiceBuilder, PayloadBuilder,
-    PayloadHandler, RejectionCache, ResolvePayload, WaitForValue,
+    FlashblocksExtraCtx, FlashblocksServiceBuilder, PayloadBuilder, PayloadHandler, ResolvePayload,
+    WaitForValue,
 };
 
 mod extension;

--- a/crates/builder/core/src/rejection_cache.rs
+++ b/crates/builder/core/src/rejection_cache.rs
@@ -1,0 +1,41 @@
+//! Shared, cross-block cache of permanently rejected transaction hashes.
+
+use std::time::Duration;
+
+use alloy_primitives::TxHash;
+use moka::sync::Cache;
+
+/// Shared, cross-block cache of permanently rejected transaction hashes.
+///
+/// Backed by [`moka::sync::Cache`] with a TTL so entries expire if metering
+/// predictions or operator limits change.
+#[derive(Clone, Debug)]
+pub struct RejectionCache(Cache<TxHash, ()>);
+
+impl RejectionCache {
+    /// Creates a new [`RejectionCache`] with the given capacity and TTL.
+    pub fn new(max_capacity: u64, ttl: Duration) -> Self {
+        Self(Cache::builder().max_capacity(max_capacity).time_to_live(ttl).build())
+    }
+
+    /// Checks if a transaction hash is in the cache.
+    pub fn contains_key(&self, hash: &TxHash) -> bool {
+        self.0.contains_key(hash)
+    }
+
+    /// Adds a transaction hash to the cache.
+    pub fn insert(&self, hash: TxHash) {
+        self.0.insert(hash, ());
+    }
+
+    /// Returns the number of cached entries.
+    pub fn entry_count(&self) -> u64 {
+        self.0.entry_count()
+    }
+
+    /// Flushes pending cache maintenance tasks (evictions, TTL expiry).
+    #[cfg(any(test, feature = "test-utils"))]
+    pub fn run_pending_tasks(&self) {
+        self.0.run_pending_tasks();
+    }
+}


### PR DESCRIPTION
Move `FlashblocksExecutionInfo` from `flashblocks/payload.rs` to execution.rs and `RejectionCache` from `flashblocks/best_txs.rs` to root-level `rejection_cache.rs`. This eliminates upward dependencies where root modules were importing from the flashblocks submodule.