### PR TITLE
[backport] feat(bootnode): Active Bootnode Scanning

### DIFF
--- a/crates/execution/cli/src/commands/p2p/bootnode.rs
+++ b/crates/execution/cli/src/commands/p2p/bootnode.rs
@@ -1,20 +1,17 @@
 //! Bootnode command with discv5 NAT fix.
 
-use std::{net::SocketAddr, path::PathBuf, time::Duration};
+use std::{net::SocketAddr, path::PathBuf};
 
 use clap::Parser;
 use reth_cli_util::{get_secret_key, load_secret_key::rng_secret_key};
 use reth_discv4::{DiscoveryUpdate, Discv4, Discv4Config};
-use reth_discv5::{
-    Config, Discv5,
-    discv5::{Event, enr::NodeId},
-};
+use reth_discv5::{Config, Discv5, discv5::Event};
 use reth_net_nat::{NatResolver, external_addr_with};
 use reth_network_peers::NodeRecord;
 use secp256k1::SecretKey;
-use tokio::{select, time::interval as tokio_interval};
+use tokio::select;
 use tokio_stream::StreamExt;
-use tracing::{info, trace, warn};
+use tracing::{info, warn};
 
 /// Start a discovery-only bootnode.
 #[derive(Parser, Debug)]
@@ -41,8 +38,9 @@ pub struct Command {
     #[arg(long)]
     pub v5: bool,
 
-    /// Interval in seconds between discv5 FINDNODE crawl queries. Only active with --v5.
-    #[arg(long, default_value = "5")]
+    /// Steady-state interval in seconds between discv5 kbucket lookup queries. Only active with
+    /// --v5. During bootstrap a faster interval is used automatically.
+    #[arg(long, default_value = "20")]
     pub find_node_interval: u64,
 }
 
@@ -64,12 +62,13 @@ impl Command {
 
         // discv5
         let mut discv5_updates = None;
-        let mut discv5_handle = None;
-        let mut crawl_interval = None;
+        let mut _discv5 = None;
 
         if self.v5 {
             info!("Initializing discv5");
-            let config = Config::builder(self.v5_addr).build();
+            let config = Config::builder(self.v5_addr)
+                .lookup_interval(self.find_node_interval)
+                .build();
             let (discv5, updates) = Discv5::start(&sk, config).await?;
 
             // The upstream reth bootnode skips NAT resolution for discv5, leaving the ENR with
@@ -90,9 +89,8 @@ impl Command {
 
             info!(enr = %discv5.local_enr(), "Started discv5");
 
-            crawl_interval = Some(tokio_interval(Duration::from_secs(self.find_node_interval)));
             discv5_updates = Some(updates);
-            discv5_handle = Some(discv5);
+            _discv5 = Some(discv5);
         }
 
         loop {
@@ -128,25 +126,6 @@ impl Command {
                             info!("discv5 update stream ended");
                             break;
                         }
-                    }
-                }
-                _ = async {
-                    if let Some(interval) = &mut crawl_interval {
-                        interval.tick().await;
-                    } else {
-                        futures::future::pending::<()>().await
-                    }
-                } => {
-                    if let Some(ref disc) = discv5_handle {
-                        let id = NodeId::random();
-                        trace!(node_id = %id, "discv5 FINDNODE crawl");
-                        let fut = disc.with_discv5(|d| d.find_node(id));
-                        tokio::spawn(async move {
-                            match fut.await {
-                                Ok(nodes) => info!(count = nodes.len(), "discv5 FINDNODE returned nodes"),
-                                Err(err) => warn!(error = ?err, "discv5 FINDNODE failed"),
-                            }
-                        });
                     }
                 }
             }

--- a/crates/execution/cli/src/commands/p2p/bootnode.rs
+++ b/crates/execution/cli/src/commands/p2p/bootnode.rs
@@ -66,9 +66,8 @@ impl Command {
 
         if self.v5 {
             info!("Initializing discv5");
-            let config = Config::builder(self.v5_addr)
-                .lookup_interval(self.find_node_interval)
-                .build();
+            let config =
+                Config::builder(self.v5_addr).lookup_interval(self.find_node_interval).build();
             let (discv5, updates) = Discv5::start(&sk, config).await?;
 
             // The upstream reth bootnode skips NAT resolution for discv5, leaving the ENR with

--- a/crates/execution/cli/src/commands/p2p/bootnode.rs
+++ b/crates/execution/cli/src/commands/p2p/bootnode.rs
@@ -1,17 +1,20 @@
 //! Bootnode command with discv5 NAT fix.
 
-use std::{net::SocketAddr, path::PathBuf};
+use std::{net::SocketAddr, path::PathBuf, time::Duration};
 
 use clap::Parser;
 use reth_cli_util::{get_secret_key, load_secret_key::rng_secret_key};
 use reth_discv4::{DiscoveryUpdate, Discv4, Discv4Config};
-use reth_discv5::{Config, Discv5, discv5::Event};
+use reth_discv5::{
+    Config, Discv5,
+    discv5::{Event, enr::NodeId},
+};
 use reth_net_nat::{NatResolver, external_addr_with};
 use reth_network_peers::NodeRecord;
 use secp256k1::SecretKey;
-use tokio::select;
+use tokio::{select, time::interval as tokio_interval};
 use tokio_stream::StreamExt;
-use tracing::{info, warn};
+use tracing::{info, trace, warn};
 
 /// Start a discovery-only bootnode.
 #[derive(Parser, Debug)]
@@ -37,6 +40,10 @@ pub struct Command {
     /// Run a discv5 topic discovery bootnode in addition to discv4.
     #[arg(long)]
     pub v5: bool,
+
+    /// Interval in seconds between discv5 FINDNODE crawl queries. Only active with --v5.
+    #[arg(long, default_value = "5")]
+    pub find_node_interval: u64,
 }
 
 impl Command {
@@ -57,7 +64,8 @@ impl Command {
 
         // discv5
         let mut discv5_updates = None;
-        let mut _discv5 = None;
+        let mut discv5_handle = None;
+        let mut crawl_interval = None;
 
         if self.v5 {
             info!("Initializing discv5");
@@ -82,8 +90,9 @@ impl Command {
 
             info!(enr = %discv5.local_enr(), "Started discv5");
 
+            crawl_interval = Some(tokio_interval(Duration::from_secs(self.find_node_interval)));
             discv5_updates = Some(updates);
-            _discv5 = Some(discv5);
+            discv5_handle = Some(discv5);
         }
 
         loop {
@@ -119,6 +128,25 @@ impl Command {
                             info!("discv5 update stream ended");
                             break;
                         }
+                    }
+                }
+                _ = async {
+                    if let Some(interval) = &mut crawl_interval {
+                        interval.tick().await;
+                    } else {
+                        futures::future::pending::<()>().await
+                    }
+                } => {
+                    if let Some(ref disc) = discv5_handle {
+                        let id = NodeId::random();
+                        trace!(node_id = %id, "discv5 FINDNODE crawl");
+                        let fut = disc.with_discv5(|d| d.find_node(id));
+                        tokio::spawn(async move {
+                            match fut.await {
+                                Ok(nodes) => info!(count = nodes.len(), "discv5 FINDNODE returned nodes"),
+                                Err(err) => warn!(error = ?err, "discv5 FINDNODE failed"),
+                            }
+                        });
                     }
                 }
             }


### PR DESCRIPTION
> [!NOTE]
> This is a backport of #2376 into `releases/v0.8.0`.

Updates the `base-reth-node p2p bootnode --v5` command to actively crawl the discv5 universe and build its routing table. Previously the bootnode was purely reactive, only logging incoming `SessionEstablished` events and never issuing outbound discovery queries, leaving its routing table nearly empty. Now `reth_discv5::Discv5::start` calls `spawn_populate_kbuckets_bg` internally, which fires 200 rapid FINDNODE lookups at 5-second intervals on startup to seed the table, then walks Kademlia buckets 255 → 0 in steady state to ensure full keyspace coverage. A new `--find-node-interval` CLI arg (default: 20s) tunes the steady-state lookup rate.