### PR TITLE
[backport] fix: filter out ETH protocol nodes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4564,6 +4564,7 @@ dependencies = [
  "reth-consensus",
  "reth-db",
  "reth-db-api",
+ "reth-discv5",
  "reth-e2e-test-utils",
  "reth-evm",
  "reth-network",

--- a/crates/execution/cli/src/commands/p2p/bootnode.rs
+++ b/crates/execution/cli/src/commands/p2p/bootnode.rs
@@ -5,7 +5,7 @@ use std::{net::SocketAddr, path::PathBuf};
 use clap::Parser;
 use reth_cli_util::{get_secret_key, load_secret_key::rng_secret_key};
 use reth_discv4::{DiscoveryUpdate, Discv4, Discv4Config};
-use reth_discv5::{Config, Discv5, discv5::Event};
+use reth_discv5::{Config, Discv5, NetworkStackId, discv5::Event};
 use reth_net_nat::{NatResolver, external_addr_with};
 use reth_network_peers::NodeRecord;
 use secp256k1::SecretKey;
@@ -61,7 +61,10 @@ impl Command {
 
         if self.v5 {
             info!("Initializing discv5");
-            let config = Config::builder(self.v5_addr).build();
+            // exclude eth protocol nodes, we're looking for opel nodes
+            let config = Config::builder(self.v5_addr)
+                .must_not_include_keys(&[NetworkStackId::ETH, NetworkStackId::ETH2])
+                .build();
             let (discv5, updates) = Discv5::start(&sk, config).await?;
 
             // The upstream reth bootnode skips NAT resolution for discv5, leaving the ENR with

--- a/crates/execution/node/Cargo.toml
+++ b/crates/execution/node/Cargo.toml
@@ -13,6 +13,7 @@ workspace = true
 [dependencies]
 # reth
 reth-db.workspace = true
+reth-discv5.workspace = true
 reth-evm.workspace = true
 reth-tasks.workspace = true
 reth-db-api.workspace = true

--- a/crates/execution/node/src/node.rs
+++ b/crates/execution/node/src/node.rs
@@ -28,6 +28,7 @@ use base_execution_txpool::{
     BaseTransactionValidator, TimestampedTransaction,
 };
 use reth_chainspec::{BaseFeeParams, ChainSpecProvider, EthChainSpec, Hardforks};
+use reth_discv5::NetworkStackId;
 use reth_evm::ConfigureEvm;
 use reth_network::{
     NetworkConfig, NetworkHandle, NetworkManager, NetworkPrimitives, PeersInfo,
@@ -1083,14 +1084,16 @@ impl BaseNetworkBuilder {
                 }
                 if !args.discovery.disable_discovery {
                     builder = builder.discovery_v5(
-                        args.discovery.discovery_v5_builder(
-                            rlpx_socket,
-                            ctx.config()
-                                .network
-                                .resolved_bootnodes()
-                                .or_else(|| ctx.chain_spec().bootnodes())
-                                .unwrap_or_default(),
-                        ),
+                        args.discovery
+                            .discovery_v5_builder(
+                                rlpx_socket,
+                                ctx.config()
+                                    .network
+                                    .resolved_bootnodes()
+                                    .or_else(|| ctx.chain_spec().bootnodes())
+                                    .unwrap_or_default(),
+                            )
+                            .must_not_include_keys(&[NetworkStackId::ETH, NetworkStackId::ETH2]),
                     );
                 }
 


### PR DESCRIPTION
> [!NOTE]
> This is a backport of #2375 into `main`.

We only want to connect with nodes that are using `opel`, not `eth`, so filter these out of the bootnode, and builder/validator.