### PR TITLE
feat(zk): guarded state machine transitions and auto-retry for stuck proof requests

### DIFF
--- a/bin/prover/zk/src/cli.rs
+++ b/bin/prover/zk/src/cli.rs
@@ -94,6 +94,9 @@ struct ZkArgs {
     #[arg(long, env = "STUCK_REQUEST_TIMEOUT_MINS", default_value_t = 10)]
     stuck_request_timeout_mins: i32,
 
+    #[arg(long, env = "MAX_PROOF_RETRIES", default_value_t = 3)]
+    max_proof_retries: u32,
+
     #[arg(long, env = "SP1_PROVER", default_value = "cluster")]
     prover_mode: String,
 
@@ -341,6 +344,7 @@ impl ZkArgs {
             manager.clone(),
             self.status_poller_interval_secs,
             self.stuck_request_timeout_mins,
+            self.max_proof_retries as i32,
         );
         let status_handle = tokio::spawn(async move {
             status_poller.run().await;

--- a/crates/proof/zk/db/migrations/007_add_retry_count.sql
+++ b/crates/proof/zk/db/migrations/007_add_retry_count.sql
@@ -1,0 +1,4 @@
+-- Add retry_count to proof_requests for auto-retry of stuck PENDING requests.
+-- The stuck detector resets requests to CREATED up to MAX_PROOF_RETRIES times
+-- before permanently failing them.
+ALTER TABLE proof_requests ADD COLUMN retry_count INTEGER NOT NULL DEFAULT 0;

--- a/crates/proof/zk/db/src/lib.rs
+++ b/crates/proof/zk/db/src/lib.rs
@@ -7,7 +7,7 @@ mod models;
 pub use models::{
     CreateOutboxEntry, CreateProofRequest, CreateProofSession, MarkOutboxError,
     MarkOutboxProcessed, OutboxEntry, ProofRequest, ProofSession, ProofStatus, ProofType,
-    SessionStatus, SessionType, UpdateProofSession, UpdateReceipt,
+    RetryOutcome, SessionStatus, SessionType, UpdateProofSession, UpdateReceipt,
 };
 
 mod repo;

--- a/crates/proof/zk/db/src/models.rs
+++ b/crates/proof/zk/db/src/models.rs
@@ -135,6 +135,17 @@ impl TryFrom<&str> for SessionType {
     }
 }
 
+/// Outcome of attempting to retry or fail a stuck proof request.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RetryOutcome {
+    /// Request was reset to CREATED with incremented `retry_count`.
+    Retried,
+    /// Request was permanently marked FAILED (max retries exceeded).
+    PermanentlyFailed,
+    /// Request was no longer in PENDING state (already claimed or transitioned).
+    Skipped,
+}
+
 /// Type of proof that determines success criteria
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, sqlx::Type)]
 #[sqlx(type_name = "VARCHAR")]
@@ -232,6 +243,8 @@ pub struct ProofRequest {
     pub updated_at: DateTime<Utc>,
     /// Timestamp when the proof completed (success or failure).
     pub completed_at: Option<DateTime<Utc>>,
+    /// Number of times this request has been retried after getting stuck.
+    pub retry_count: i32,
 }
 
 /// A proof session record tracking a specific backend job (STARK or SNARK)

--- a/crates/proof/zk/db/src/repo.rs
+++ b/crates/proof/zk/db/src/repo.rs
@@ -4,7 +4,7 @@ use uuid::Uuid;
 use crate::{
     CreateOutboxEntry, CreateProofRequest, CreateProofSession, MarkOutboxError,
     MarkOutboxProcessed, OutboxEntry, ProofRequest, ProofSession, ProofStatus, ProofType,
-    SessionStatus, SessionType, UpdateProofSession, UpdateReceipt,
+    RetryOutcome, SessionStatus, SessionType, UpdateProofSession, UpdateReceipt,
 };
 
 /// Repository for proof request database operations
@@ -68,17 +68,27 @@ impl ProofRequestRepo {
     pub async fn create_with_outbox(&self, req: CreateProofRequest) -> Result<Uuid> {
         let id = req.session_id.unwrap_or_else(Uuid::new_v4);
 
-        // Serialize request params as JSON for outbox
-        let request_params = serde_json::json!({
-            "start_block_number": req.start_block_number,
-            "number_of_blocks_to_prove": req.number_of_blocks_to_prove,
-            "sequence_window": req.sequence_window,
-            "proof_type": req.proof_type.as_str(),
-            "prover_address": req.prover_address,
-            "l1_head": req.l1_head,
-        });
+        let start_block_number = i64::try_from(req.start_block_number)
+            .map_err(|_| sqlx::Error::Protocol("block number exceeds i64 range".into()))?;
+        let number_of_blocks_to_prove = i64::try_from(req.number_of_blocks_to_prove)
+            .map_err(|_| sqlx::Error::Protocol("blocks to prove exceeds i64 range".into()))?;
+        let sequence_window = req
+            .sequence_window
+            .map(|w| {
+                i64::try_from(w)
+                    .map_err(|_| sqlx::Error::Protocol("sequence window exceeds i64 range".into()))
+            })
+            .transpose()?;
 
-        // Start transaction
+        let request_params = build_outbox_params(
+            start_block_number,
+            number_of_blocks_to_prove,
+            sequence_window,
+            req.proof_type.as_str(),
+            req.prover_address.as_deref(),
+            req.l1_head.as_deref(),
+        );
+
         let mut tx = self.pool.begin().await?;
 
         let result = sqlx::query(
@@ -92,23 +102,9 @@ impl ProofRequestRepo {
             "#,
         )
         .bind(id)
-        .bind(
-            i64::try_from(req.start_block_number)
-                .map_err(|_| sqlx::Error::Protocol("block number exceeds i64 range".into()))?,
-        )
-        .bind(
-            i64::try_from(req.number_of_blocks_to_prove)
-                .map_err(|_| sqlx::Error::Protocol("blocks to prove exceeds i64 range".into()))?,
-        )
-        .bind(
-            req.sequence_window
-                .map(|w| {
-                    i64::try_from(w).map_err(|_| {
-                        sqlx::Error::Protocol("sequence window exceeds i64 range".into())
-                    })
-                })
-                .transpose()?,
-        )
+        .bind(start_block_number)
+        .bind(number_of_blocks_to_prove)
+        .bind(sequence_window)
         .bind(req.proof_type.as_str())
         .bind(ProofStatus::Created.as_str())
         .bind(&req.prover_address)
@@ -148,7 +144,7 @@ impl ProofRequestRepo {
                 stark_receipt, snark_receipt,
                 status, error_message,
                 prover_address, l1_head,
-                created_at, updated_at, completed_at
+                created_at, updated_at, completed_at, retry_count
             FROM proof_requests
             WHERE id = $1
             "#,
@@ -160,108 +156,34 @@ impl ProofRequestRepo {
         row.map(|r| row_to_proof_request(&r)).transpose()
     }
 
-    /// Update a proof request with receipt
-    pub async fn update_receipt(&self, update: UpdateReceipt) -> Result<()> {
-        sqlx::query(
-            r#"
-            UPDATE proof_requests
-            SET
-                stark_receipt = COALESCE($1, stark_receipt),
-                snark_receipt = COALESCE($2, snark_receipt),
-                status = $3,
-                error_message = $4,
-                completed_at = CASE WHEN $3 IN ('SUCCEEDED', 'FAILED') THEN NOW() ELSE completed_at END
-            WHERE id = $5
-            "#,
-        )
-        .bind(&update.stark_receipt)
-        .bind(&update.snark_receipt)
-        .bind(update.status.as_str())
-        .bind(&update.error_message)
-        .bind(update.id)
-        .execute(&self.pool)
-        .await?;
+    /// Update receipt fields while the request is still RUNNING.
+    /// Status is kept as RUNNING — this method cannot be used for state transitions.
+    /// Returns true if update succeeded, false otherwise.
+    pub async fn update_receipt_if_running(&self, update: UpdateReceipt) -> Result<bool> {
+        debug_assert_eq!(
+            update.status,
+            ProofStatus::Running,
+            "update_receipt_if_running is for intermediate receipt updates only; \
+             use transition_running_to_succeeded or fail_session_and_request for state transitions",
+        );
 
-        Ok(())
-    }
-
-    /// Update status and error message
-    pub async fn update_status(
-        &self,
-        id: Uuid,
-        status: ProofStatus,
-        error_message: Option<String>,
-    ) -> Result<()> {
-        sqlx::query(
-            r#"
-            UPDATE proof_requests
-            SET
-                status = $1,
-                error_message = $2,
-                completed_at = CASE WHEN $1 IN ('SUCCEEDED', 'FAILED') THEN NOW() ELSE completed_at END
-            WHERE id = $3
-            "#,
-        )
-        .bind(status.as_str())
-        .bind(&error_message)
-        .bind(id)
-        .execute(&self.pool)
-        .await?;
-
-        Ok(())
-    }
-
-    /// Update receipt only if current status is non-terminal (PENDING/RUNNING).
-    /// Returns true if update succeeded, false if already terminal.
-    pub async fn update_receipt_if_non_terminal(&self, update: UpdateReceipt) -> Result<bool> {
         let result = sqlx::query(
             r#"
             UPDATE proof_requests
             SET
                 stark_receipt = COALESCE($1, stark_receipt),
                 snark_receipt = COALESCE($2, snark_receipt),
-                status = $3,
-                error_message = $4,
-                completed_at = CASE WHEN $3 IN ('SUCCEEDED', 'FAILED') THEN NOW() ELSE completed_at END
-            WHERE id = $5
-              AND status NOT IN ('SUCCEEDED', 'FAILED')
+                status = 'RUNNING',
+                error_message = $3,
+                completed_at = NULL
+            WHERE id = $4
+              AND status = 'RUNNING'
             "#,
         )
         .bind(&update.stark_receipt)
         .bind(&update.snark_receipt)
-        .bind(update.status.as_str())
         .bind(&update.error_message)
         .bind(update.id)
-        .execute(&self.pool)
-        .await?;
-
-        let updated = result.rows_affected() > 0;
-
-        Ok(updated)
-    }
-
-    /// Update status only if current status is non-terminal.
-    /// Returns true if update succeeded, false if already terminal.
-    pub async fn update_status_if_non_terminal(
-        &self,
-        id: Uuid,
-        status: ProofStatus,
-        error_message: Option<String>,
-    ) -> Result<bool> {
-        let result = sqlx::query(
-            r#"
-            UPDATE proof_requests
-            SET
-                status = $1,
-                error_message = $2,
-                completed_at = CASE WHEN $1 IN ('SUCCEEDED', 'FAILED') THEN NOW() ELSE completed_at END
-            WHERE id = $3
-              AND status NOT IN ('SUCCEEDED', 'FAILED')
-            "#,
-        )
-        .bind(status.as_str())
-        .bind(&error_message)
-        .bind(id)
         .execute(&self.pool)
         .await?;
 
@@ -290,6 +212,258 @@ impl ProofRequestRepo {
         let claimed = result.rows_affected() > 0;
 
         Ok(claimed)
+    }
+
+    /// Atomically create a proof session and transition proof request PENDING → RUNNING.
+    /// Returns `Ok(Some(session_id))` if the request was in PENDING state.
+    /// Returns `Ok(None)` if the request was NOT in PENDING state (race lost).
+    pub async fn transition_pending_to_running(
+        &self,
+        session: CreateProofSession,
+    ) -> Result<Option<i64>> {
+        let mut tx = self.pool.begin().await?;
+
+        let result = sqlx::query(
+            r#"
+            UPDATE proof_requests
+            SET status = $1
+            WHERE id = $2 AND status = $3
+            "#,
+        )
+        .bind(ProofStatus::Running.as_str())
+        .bind(session.proof_request_id)
+        .bind(ProofStatus::Pending.as_str())
+        .execute(&mut *tx)
+        .await?;
+
+        if result.rows_affected() == 0 {
+            tx.rollback().await?;
+            return Ok(None);
+        }
+
+        let row = sqlx::query(
+            r#"
+            INSERT INTO proof_sessions (
+                proof_request_id, session_type, backend_session_id, status, metadata
+            )
+            VALUES ($1, $2, $3, $4, $5)
+            RETURNING id
+            "#,
+        )
+        .bind(session.proof_request_id)
+        .bind(session.session_type.as_str())
+        .bind(&session.backend_session_id)
+        .bind(SessionStatus::Running.as_str())
+        .bind(&session.metadata)
+        .fetch_one(&mut *tx)
+        .await?;
+
+        let session_id: i64 = row.get("id");
+        tx.commit().await?;
+
+        Ok(Some(session_id))
+    }
+
+    /// Transition proof request PENDING → FAILED with error message.
+    /// Returns true if the transition succeeded (was PENDING).
+    pub async fn transition_pending_to_failed(
+        &self,
+        id: Uuid,
+        error_message: String,
+    ) -> Result<bool> {
+        let result = sqlx::query(
+            r#"
+            UPDATE proof_requests
+            SET status = $1,
+                error_message = $2,
+                completed_at = NOW()
+            WHERE id = $3 AND status = $4
+            "#,
+        )
+        .bind(ProofStatus::Failed.as_str())
+        .bind(&error_message)
+        .bind(id)
+        .bind(ProofStatus::Pending.as_str())
+        .execute(&self.pool)
+        .await?;
+
+        Ok(result.rows_affected() > 0)
+    }
+
+    /// Transition proof request RUNNING → FAILED with optional error message.
+    /// Returns true if the transition succeeded (was RUNNING).
+    pub async fn transition_running_to_failed(
+        &self,
+        id: Uuid,
+        error_message: Option<String>,
+    ) -> Result<bool> {
+        let result = sqlx::query(
+            r#"
+            UPDATE proof_requests
+            SET status = $1,
+                error_message = $2,
+                completed_at = NOW()
+            WHERE id = $3 AND status = $4
+            "#,
+        )
+        .bind(ProofStatus::Failed.as_str())
+        .bind(&error_message)
+        .bind(id)
+        .bind(ProofStatus::Running.as_str())
+        .execute(&self.pool)
+        .await?;
+
+        Ok(result.rows_affected() > 0)
+    }
+
+    /// Transition proof request RUNNING → SUCCEEDED with receipt data.
+    /// Returns true if the transition succeeded (was RUNNING).
+    pub async fn transition_running_to_succeeded(&self, update: UpdateReceipt) -> Result<bool> {
+        debug_assert_eq!(
+            update.status,
+            ProofStatus::Succeeded,
+            "transition_running_to_succeeded called with status {:?}; the status field is ignored \
+             — this method always writes SUCCEEDED",
+            update.status,
+        );
+
+        let result = sqlx::query(
+            r#"
+            UPDATE proof_requests
+            SET stark_receipt = COALESCE($1, stark_receipt),
+                snark_receipt = COALESCE($2, snark_receipt),
+                status = $3,
+                error_message = $4,
+                completed_at = NOW()
+            WHERE id = $5 AND status = $6
+            "#,
+        )
+        .bind(&update.stark_receipt)
+        .bind(&update.snark_receipt)
+        .bind(ProofStatus::Succeeded.as_str())
+        .bind(&update.error_message)
+        .bind(update.id)
+        .bind(ProofStatus::Running.as_str())
+        .execute(&self.pool)
+        .await?;
+
+        Ok(result.rows_affected() > 0)
+    }
+
+    /// Retry a stuck PENDING request if under the retry limit, otherwise fail it permanently.
+    ///
+    /// If `retry_count < max_retries`: atomically resets to CREATED, increments `retry_count`,
+    /// and creates a new outbox entry so a worker picks it up again.
+    /// If `retry_count >= max_retries`: transitions to FAILED.
+    pub async fn retry_or_fail_stuck_request(
+        &self,
+        id: Uuid,
+        max_retries: i32,
+        error_message: &str,
+    ) -> Result<RetryOutcome> {
+        let mut tx = self.pool.begin().await?;
+
+        let maybe_row = sqlx::query(
+            r#"
+            SELECT retry_count, status, start_block_number, number_of_blocks_to_prove,
+                   sequence_window, proof_type, prover_address, l1_head
+            FROM proof_requests
+            WHERE id = $1
+            FOR UPDATE
+            "#,
+        )
+        .bind(id)
+        .fetch_optional(&mut *tx)
+        .await?;
+
+        let Some(row) = maybe_row else {
+            tx.rollback().await?;
+            return Ok(RetryOutcome::Skipped);
+        };
+
+        let status_str: &str = row.get("status");
+        if status_str != ProofStatus::Pending.as_str() {
+            tx.rollback().await?;
+            return Ok(RetryOutcome::Skipped);
+        }
+
+        let retry_count: i32 = row.get("retry_count");
+
+        if retry_count >= max_retries {
+            sqlx::query(
+                r#"
+                UPDATE proof_requests
+                SET status = $1,
+                    error_message = $2,
+                    completed_at = NOW()
+                WHERE id = $3
+                "#,
+            )
+            .bind(ProofStatus::Failed.as_str())
+            .bind(format!("{error_message} (max retries exceeded after {retry_count} attempts)"))
+            .bind(id)
+            .execute(&mut *tx)
+            .await?;
+
+            tx.commit().await?;
+            return Ok(RetryOutcome::PermanentlyFailed);
+        }
+
+        sqlx::query(
+            r#"
+            UPDATE proof_requests
+            SET status = $1,
+                retry_count = retry_count + 1,
+                error_message = NULL
+            WHERE id = $2
+            "#,
+        )
+        .bind(ProofStatus::Created.as_str())
+        .bind(id)
+        .execute(&mut *tx)
+        .await?;
+
+        // Copy the most recent outbox entry for this request. If the outbox was
+        // already cleaned up (0 rows), reconstruct request_params from the
+        // proof_request row we hold under FOR UPDATE.
+        let outbox_copy = sqlx::query(
+            r#"
+            INSERT INTO proof_request_outbox (proof_request_id, request_params)
+            SELECT proof_request_id, request_params
+            FROM proof_request_outbox
+            WHERE proof_request_id = $1
+            ORDER BY sequence_id DESC
+            LIMIT 1
+            "#,
+        )
+        .bind(id)
+        .execute(&mut *tx)
+        .await?;
+
+        if outbox_copy.rows_affected() == 0 {
+            let request_params = build_outbox_params(
+                row.get::<i64, _>("start_block_number"),
+                row.get::<i64, _>("number_of_blocks_to_prove"),
+                row.get::<Option<i64>, _>("sequence_window"),
+                row.get::<&str, _>("proof_type"),
+                row.get::<Option<&str>, _>("prover_address"),
+                row.get::<Option<&str>, _>("l1_head"),
+            );
+
+            sqlx::query(
+                r#"
+                INSERT INTO proof_request_outbox (proof_request_id, request_params)
+                VALUES ($1, $2)
+                "#,
+            )
+            .bind(id)
+            .bind(&request_params)
+            .execute(&mut *tx)
+            .await?;
+        }
+
+        tx.commit().await?;
+        Ok(RetryOutcome::Retried)
     }
 
     // ========== Proof Session Methods ==========
@@ -383,7 +557,7 @@ impl ProofRequestRepo {
             SELECT id, start_block_number, number_of_blocks_to_prove,
                    sequence_window, proof_type, stark_receipt, snark_receipt,
                    status, error_message, prover_address, l1_head,
-                   created_at, updated_at, completed_at
+                   created_at, updated_at, completed_at, retry_count
             FROM proof_requests
             WHERE status = $1
             ORDER BY created_at ASC
@@ -396,8 +570,10 @@ impl ProofRequestRepo {
         rows.iter().map(row_to_proof_request).collect()
     }
 
-    /// Get proof requests that are stuck in PENDING without any sessions.
+    /// Get proof requests that are stuck in PENDING without a running session.
     /// These are likely orphaned due to crashes before session creation.
+    /// Only checks for active (RUNNING) sessions so that retried requests
+    /// with old COMPLETED/FAILED sessions are still detected as stuck.
     pub async fn get_stuck_requests(&self, stuck_timeout_mins: i32) -> Result<Vec<ProofRequest>> {
         let rows = sqlx::query(
             r#"
@@ -405,13 +581,14 @@ impl ProofRequestRepo {
                 pr.id, pr.start_block_number, pr.number_of_blocks_to_prove,
                 pr.sequence_window, pr.proof_type, pr.stark_receipt, pr.snark_receipt,
                 pr.status, pr.error_message, pr.prover_address, pr.l1_head,
-                pr.created_at, pr.updated_at, pr.completed_at
+                pr.created_at, pr.updated_at, pr.completed_at, pr.retry_count
             FROM proof_requests pr
             WHERE pr.status = 'PENDING'
               AND pr.updated_at < NOW() - INTERVAL '1 minute' * $1
               AND NOT EXISTS (
                   SELECT 1 FROM proof_sessions ps
                   WHERE ps.proof_request_id = pr.id
+                    AND ps.status = 'RUNNING'
               )
             ORDER BY pr.created_at ASC
             "#,
@@ -473,53 +650,16 @@ impl ProofRequestRepo {
         Ok(updated)
     }
 
-    /// Atomically create a proof session and update proof request to RUNNING
-    pub async fn create_session_and_update_status(
-        &self,
-        session: CreateProofSession,
-        status: ProofStatus,
-    ) -> Result<i64> {
-        let mut tx = self.pool.begin().await?;
-
-        // Insert proof session
-        let row = sqlx::query(
-            r#"
-            INSERT INTO proof_sessions (
-                proof_request_id, session_type, backend_session_id, status, metadata
-            )
-            VALUES ($1, $2, $3, $4, $5)
-            RETURNING id
-            "#,
-        )
-        .bind(session.proof_request_id)
-        .bind(session.session_type.as_str())
-        .bind(&session.backend_session_id)
-        .bind(SessionStatus::Running.as_str())
-        .bind(&session.metadata)
-        .fetch_one(&mut *tx)
-        .await?;
-
-        let session_id: i64 = row.get("id");
-
-        // Update proof request status
-        sqlx::query(
-            r#"
-            UPDATE proof_requests
-            SET status = $1
-            WHERE id = $2
-            "#,
-        )
-        .bind(status.as_str())
-        .bind(session.proof_request_id)
-        .execute(&mut *tx)
-        .await?;
-
-        tx.commit().await?;
-
-        Ok(session_id)
-    }
-
-    /// Atomically update proof session to FAILED and proof request to FAILED
+    /// Atomically update proof session to FAILED and proof request RUNNING → FAILED.
+    ///
+    /// The request update is guarded on `status = 'RUNNING'` so that a
+    /// concurrent stuck-detector marking PENDING → FAILED cannot be
+    /// overwritten. If the guard fails the entire transaction is rolled back
+    /// so the session is not left in an inconsistent `FAILED` state while the
+    /// request remains unchanged.
+    ///
+    /// Returns `true` if both updates were applied, `false` if the request was
+    /// not in RUNNING state (transaction rolled back, no changes persisted).
     pub async fn fail_session_and_request(
         &self,
         backend_session_id: &str,
@@ -528,7 +668,27 @@ impl ProofRequestRepo {
     ) -> Result<bool> {
         let mut tx = self.pool.begin().await?;
 
-        // Update proof session to FAILED
+        let result = sqlx::query(
+            r#"
+            UPDATE proof_requests
+            SET status = $1,
+                error_message = $2,
+                completed_at = NOW()
+            WHERE id = $3
+              AND status = 'RUNNING'
+            "#,
+        )
+        .bind(ProofStatus::Failed.as_str())
+        .bind(&error_message)
+        .bind(proof_request_id)
+        .execute(&mut *tx)
+        .await?;
+
+        if result.rows_affected() == 0 {
+            tx.rollback().await?;
+            return Ok(false);
+        }
+
         sqlx::query(
             r#"
             UPDATE proof_sessions
@@ -544,31 +704,21 @@ impl ProofRequestRepo {
         .execute(&mut *tx)
         .await?;
 
-        // Update proof request to FAILED (only if not already terminal)
-        let result = sqlx::query(
-            r#"
-            UPDATE proof_requests
-            SET status = $1,
-                error_message = $2,
-                completed_at = NOW()
-            WHERE id = $3
-              AND status NOT IN ('SUCCEEDED', 'FAILED')
-            "#,
-        )
-        .bind(ProofStatus::Failed.as_str())
-        .bind(&error_message)
-        .bind(proof_request_id)
-        .execute(&mut *tx)
-        .await?;
-
-        let updated = result.rows_affected() > 0;
-
         tx.commit().await?;
 
-        Ok(updated)
+        Ok(true)
     }
 
-    /// Atomically update proof session to COMPLETED and update proof request with receipt
+    /// Atomically update proof session to COMPLETED and update proof request
+    /// with the receipt.
+    ///
+    /// The request update is guarded on `status = 'RUNNING'`. If the guard
+    /// fails the entire transaction is rolled back so the session is not left
+    /// in an inconsistent `COMPLETED` state while the request remains
+    /// unchanged.
+    ///
+    /// Returns `true` if both updates were applied, `false` if the request was
+    /// not in RUNNING state (transaction rolled back, no changes persisted).
     pub async fn complete_session_and_update_receipt(
         &self,
         backend_session_id: &str,
@@ -576,7 +726,32 @@ impl ProofRequestRepo {
     ) -> Result<bool> {
         let mut tx = self.pool.begin().await?;
 
-        // Update proof session to COMPLETED
+        let result = sqlx::query(
+            r#"
+            UPDATE proof_requests
+            SET
+                stark_receipt = COALESCE($1, stark_receipt),
+                snark_receipt = COALESCE($2, snark_receipt),
+                status = $3,
+                error_message = $4,
+                completed_at = CASE WHEN $3 IN ('SUCCEEDED', 'FAILED') THEN NOW() ELSE completed_at END
+            WHERE id = $5
+              AND status = 'RUNNING'
+            "#,
+        )
+        .bind(&update_receipt.stark_receipt)
+        .bind(&update_receipt.snark_receipt)
+        .bind(update_receipt.status.as_str())
+        .bind(&update_receipt.error_message)
+        .bind(update_receipt.id)
+        .execute(&mut *tx)
+        .await?;
+
+        if result.rows_affected() == 0 {
+            tx.rollback().await?;
+            return Ok(false);
+        }
+
         sqlx::query(
             r#"
             UPDATE proof_sessions
@@ -590,33 +765,9 @@ impl ProofRequestRepo {
         .execute(&mut *tx)
         .await?;
 
-        // Update proof request with receipt (only if not already terminal)
-        let result = sqlx::query(
-            r#"
-            UPDATE proof_requests
-            SET
-                stark_receipt = COALESCE($1, stark_receipt),
-                snark_receipt = COALESCE($2, snark_receipt),
-                status = $3,
-                error_message = $4,
-                completed_at = CASE WHEN $3 IN ('SUCCEEDED', 'FAILED') THEN NOW() ELSE completed_at END
-            WHERE id = $5
-              AND status NOT IN ('SUCCEEDED', 'FAILED')
-            "#,
-        )
-        .bind(&update_receipt.stark_receipt)
-        .bind(&update_receipt.snark_receipt)
-        .bind(update_receipt.status.as_str())
-        .bind(&update_receipt.error_message)
-        .bind(update_receipt.id)
-        .execute(&mut *tx)
-        .await?;
-
-        let updated = result.rows_affected() > 0;
-
         tx.commit().await?;
 
-        Ok(updated)
+        Ok(true)
     }
 
     /// List all proof requests with optional status filter
@@ -634,7 +785,7 @@ impl ProofRequestRepo {
                     stark_receipt, snark_receipt,
                     status, error_message,
                     prover_address, l1_head,
-                    created_at, updated_at, completed_at
+                    created_at, updated_at, completed_at, retry_count
                 FROM proof_requests
                 WHERE status = $1
                 ORDER BY created_at DESC
@@ -654,7 +805,7 @@ impl ProofRequestRepo {
                     stark_receipt, snark_receipt,
                     status, error_message,
                     prover_address, l1_head,
-                    created_at, updated_at, completed_at
+                    created_at, updated_at, completed_at, retry_count
                 FROM proof_requests
                 ORDER BY created_at DESC
                 LIMIT $1
@@ -798,6 +949,7 @@ fn row_to_proof_request(row: &sqlx::postgres::PgRow) -> Result<ProofRequest> {
         created_at: row.get("created_at"),
         updated_at: row.get("updated_at"),
         completed_at: row.get("completed_at"),
+        retry_count: row.get("retry_count"),
     })
 }
 
@@ -823,6 +975,29 @@ fn row_to_proof_session(row: &sqlx::postgres::PgRow) -> Result<ProofSession> {
         metadata: row.get("metadata"),
         created_at: row.get("created_at"),
         completed_at: row.get("completed_at"),
+    })
+}
+
+/// Build the canonical JSON payload for outbox entries.
+///
+/// Both [`ProofRequestRepo::create_with_outbox`] and
+/// [`ProofRequestRepo::retry_or_fail_stuck_request`] must produce the same
+/// shape so the downstream worker can parse either identically.
+fn build_outbox_params(
+    start_block_number: i64,
+    number_of_blocks_to_prove: i64,
+    sequence_window: Option<i64>,
+    proof_type: &str,
+    prover_address: Option<&str>,
+    l1_head: Option<&str>,
+) -> serde_json::Value {
+    serde_json::json!({
+        "start_block_number": start_block_number,
+        "number_of_blocks_to_prove": number_of_blocks_to_prove,
+        "sequence_window": sequence_window,
+        "proof_type": proof_type,
+        "prover_address": prover_address,
+        "l1_head": l1_head,
     })
 }
 

--- a/crates/proof/zk/db/tests/postgres_integration.rs
+++ b/crates/proof/zk/db/tests/postgres_integration.rs
@@ -17,7 +17,8 @@ use std::time::Duration;
 
 use base_zk_db::{
     CreateProofRequest, CreateProofSession, MarkOutboxError, MarkOutboxProcessed, ProofRequestRepo,
-    ProofStatus, ProofType, SessionStatus, SessionType, UpdateProofSession, UpdateReceipt,
+    ProofStatus, ProofType, RetryOutcome, SessionStatus, SessionType, UpdateProofSession,
+    UpdateReceipt,
 };
 use sqlx::{PgPool, postgres::PgPoolOptions};
 use uuid::Uuid;
@@ -65,6 +66,24 @@ fn snark_request() -> CreateProofRequest {
     }
 }
 
+/// Create a request in RUNNING state with an associated proof session.
+/// Returns `(request_id, backend_session_id)`.
+async fn setup_running_request(repo: &ProofRequestRepo) -> (Uuid, String) {
+    let id = repo.create(compressed_request()).await.unwrap();
+    repo.atomic_claim_task(id).await.unwrap();
+    let backend_id = format!("session-{}", Uuid::new_v4());
+    repo.transition_pending_to_running(CreateProofSession {
+        proof_request_id: id,
+        session_type: SessionType::Stark,
+        backend_session_id: backend_id.clone(),
+        metadata: None,
+    })
+    .await
+    .unwrap()
+    .expect("transition should succeed");
+    (id, backend_id)
+}
+
 // ============================================================
 // Basic CRUD tests
 // ============================================================
@@ -90,6 +109,7 @@ async fn test_create_and_get_compressed() {
     assert!(req.prover_address.is_none());
     assert!(req.l1_head.is_none());
     assert!(req.completed_at.is_none());
+    assert_eq!(req.retry_count, 0);
 }
 
 #[tokio::test]
@@ -139,67 +159,136 @@ async fn test_get_nonexistent_returns_none() {
 }
 
 // ============================================================
-// Status update tests
+// Guarded state transition tests
 // ============================================================
 
 #[tokio::test]
 #[ignore = "requires a running Postgres with the prover schema (set DATABASE_URL); run with `cargo nextest run --run-ignored all -p base-zk-db --test postgres_integration --test-threads=1`"]
-async fn test_update_status() {
+async fn test_transition_pending_to_running() {
     let pool = test_pool().await;
     let repo = test_repo(pool);
 
     let id = repo.create(compressed_request()).await.unwrap();
+    repo.atomic_claim_task(id).await.unwrap();
 
-    repo.update_status(id, ProofStatus::Running, None).await.unwrap();
+    let backend_id = format!("ptr-{}", Uuid::new_v4());
+    let session_id = repo
+        .transition_pending_to_running(CreateProofSession {
+            proof_request_id: id,
+            session_type: SessionType::Stark,
+            backend_session_id: backend_id.clone(),
+            metadata: None,
+        })
+        .await
+        .unwrap();
+    assert!(session_id.is_some());
+
     let req = repo.get(id).await.unwrap().unwrap();
     assert_eq!(req.status, ProofStatus::Running);
-    assert!(req.completed_at.is_none()); // RUNNING doesn't set completed_at
 
-    repo.update_status(id, ProofStatus::Failed, Some("timeout".into())).await.unwrap();
-    let req = repo.get(id).await.unwrap().unwrap();
-    assert_eq!(req.status, ProofStatus::Failed);
-    assert_eq!(req.error_message.as_deref(), Some("timeout"));
-    assert!(req.completed_at.is_some()); // FAILED sets completed_at
+    let session =
+        repo.get_session_by_backend_id(&backend_id).await.unwrap().expect("should find session");
+    assert_eq!(session.status, SessionStatus::Running);
 }
 
 #[tokio::test]
 #[ignore = "requires a running Postgres with the prover schema (set DATABASE_URL); run with `cargo nextest run --run-ignored all -p base-zk-db --test postgres_integration --test-threads=1`"]
-async fn test_update_status_if_non_terminal_succeeds_for_running() {
+async fn test_transition_pending_to_running_race() {
     let pool = test_pool().await;
     let repo = test_repo(pool);
 
     let id = repo.create(compressed_request()).await.unwrap();
-    repo.update_status(id, ProofStatus::Running, None).await.unwrap();
+    repo.atomic_claim_task(id).await.unwrap();
 
-    let updated =
-        repo.update_status_if_non_terminal(id, ProofStatus::Succeeded, None).await.unwrap();
+    let first = repo
+        .transition_pending_to_running(CreateProofSession {
+            proof_request_id: id,
+            session_type: SessionType::Stark,
+            backend_session_id: format!("first-{}", Uuid::new_v4()),
+            metadata: None,
+        })
+        .await
+        .unwrap();
+    assert!(first.is_some());
+
+    let second = repo
+        .transition_pending_to_running(CreateProofSession {
+            proof_request_id: id,
+            session_type: SessionType::Stark,
+            backend_session_id: format!("second-{}", Uuid::new_v4()),
+            metadata: None,
+        })
+        .await
+        .unwrap();
+    assert!(second.is_none(), "second transition should lose the race");
+}
+
+#[tokio::test]
+#[ignore = "requires a running Postgres with the prover schema (set DATABASE_URL); run with `cargo nextest run --run-ignored all -p base-zk-db --test postgres_integration --test-threads=1`"]
+async fn test_transition_pending_to_failed() {
+    let pool = test_pool().await;
+    let repo = test_repo(pool);
+
+    let id = repo.create(compressed_request()).await.unwrap();
+    repo.atomic_claim_task(id).await.unwrap();
+
+    let updated = repo.transition_pending_to_failed(id, "submission timeout".into()).await.unwrap();
     assert!(updated);
 
     let req = repo.get(id).await.unwrap().unwrap();
-    assert_eq!(req.status, ProofStatus::Succeeded);
+    assert_eq!(req.status, ProofStatus::Failed);
+    assert_eq!(req.error_message.as_deref(), Some("submission timeout"));
     assert!(req.completed_at.is_some());
 }
 
 #[tokio::test]
 #[ignore = "requires a running Postgres with the prover schema (set DATABASE_URL); run with `cargo nextest run --run-ignored all -p base-zk-db --test postgres_integration --test-threads=1`"]
-async fn test_update_status_if_non_terminal_skips_terminal() {
+async fn test_transition_pending_to_failed_wrong_state() {
     let pool = test_pool().await;
     let repo = test_repo(pool);
 
     let id = repo.create(compressed_request()).await.unwrap();
-    // Move to SUCCEEDED (terminal)
-    repo.update_status(id, ProofStatus::Succeeded, None).await.unwrap();
-
-    // Try to update again — should be skipped
-    let updated = repo
-        .update_status_if_non_terminal(id, ProofStatus::Failed, Some("late error".into()))
-        .await
-        .unwrap();
+    // Still CREATED, not PENDING
+    let updated = repo.transition_pending_to_failed(id, "should not work".into()).await.unwrap();
     assert!(!updated);
 
     let req = repo.get(id).await.unwrap().unwrap();
-    assert_eq!(req.status, ProofStatus::Succeeded); // unchanged
-    assert!(req.error_message.is_none()); // unchanged
+    assert_eq!(req.status, ProofStatus::Created);
+}
+
+#[tokio::test]
+#[ignore = "requires a running Postgres with the prover schema (set DATABASE_URL); run with `cargo nextest run --run-ignored all -p base-zk-db --test postgres_integration --test-threads=1`"]
+async fn test_transition_running_to_failed() {
+    let pool = test_pool().await;
+    let repo = test_repo(pool);
+
+    let (id, _backend_id) = setup_running_request(&repo).await;
+
+    let updated =
+        repo.transition_running_to_failed(id, Some("cluster timeout".into())).await.unwrap();
+    assert!(updated);
+
+    let req = repo.get(id).await.unwrap().unwrap();
+    assert_eq!(req.status, ProofStatus::Failed);
+    assert_eq!(req.error_message.as_deref(), Some("cluster timeout"));
+    assert!(req.completed_at.is_some());
+}
+
+#[tokio::test]
+#[ignore = "requires a running Postgres with the prover schema (set DATABASE_URL); run with `cargo nextest run --run-ignored all -p base-zk-db --test postgres_integration --test-threads=1`"]
+async fn test_transition_running_to_failed_wrong_state() {
+    let pool = test_pool().await;
+    let repo = test_repo(pool);
+
+    let id = repo.create(compressed_request()).await.unwrap();
+    repo.atomic_claim_task(id).await.unwrap();
+    // PENDING, not RUNNING
+    let updated =
+        repo.transition_running_to_failed(id, Some("should not work".into())).await.unwrap();
+    assert!(!updated);
+
+    let req = repo.get(id).await.unwrap().unwrap();
+    assert_eq!(req.status, ProofStatus::Pending);
 }
 
 // ============================================================
@@ -208,41 +297,14 @@ async fn test_update_status_if_non_terminal_skips_terminal() {
 
 #[tokio::test]
 #[ignore = "requires a running Postgres with the prover schema (set DATABASE_URL); run with `cargo nextest run --run-ignored all -p base-zk-db --test postgres_integration --test-threads=1`"]
-async fn test_update_receipt_stark() {
+async fn test_update_receipt_if_running() {
     let pool = test_pool().await;
     let repo = test_repo(pool);
 
-    let id = repo.create(compressed_request()).await.unwrap();
-    let stark_data = vec![0xDE, 0xAD, 0xBE, 0xEF];
-
-    repo.update_receipt(UpdateReceipt {
-        id,
-        stark_receipt: Some(stark_data.clone()),
-        snark_receipt: None,
-        status: ProofStatus::Succeeded,
-        error_message: None,
-    })
-    .await
-    .unwrap();
-
-    let req = repo.get(id).await.unwrap().unwrap();
-    assert_eq!(req.stark_receipt.as_deref(), Some(stark_data.as_slice()));
-    assert!(req.snark_receipt.is_none());
-    assert_eq!(req.status, ProofStatus::Succeeded);
-    assert!(req.completed_at.is_some());
-}
-
-#[tokio::test]
-#[ignore = "requires a running Postgres with the prover schema (set DATABASE_URL); run with `cargo nextest run --run-ignored all -p base-zk-db --test postgres_integration --test-threads=1`"]
-async fn test_update_receipt_if_non_terminal() {
-    let pool = test_pool().await;
-    let repo = test_repo(pool);
-
-    let id = repo.create(compressed_request()).await.unwrap();
-    repo.update_status(id, ProofStatus::Running, None).await.unwrap();
+    let (id, _backend_id) = setup_running_request(&repo).await;
 
     let updated = repo
-        .update_receipt_if_non_terminal(UpdateReceipt {
+        .update_receipt_if_running(UpdateReceipt {
             id,
             stark_receipt: Some(vec![1, 2, 3]),
             snark_receipt: None,
@@ -255,7 +317,7 @@ async fn test_update_receipt_if_non_terminal() {
 
     // Now that it's SUCCEEDED, a second update should be skipped
     let updated = repo
-        .update_receipt_if_non_terminal(UpdateReceipt {
+        .update_receipt_if_running(UpdateReceipt {
             id,
             stark_receipt: Some(vec![4, 5, 6]),
             snark_receipt: None,
@@ -473,57 +535,11 @@ async fn test_update_proof_session_if_non_terminal() {
 
 #[tokio::test]
 #[ignore = "requires a running Postgres with the prover schema (set DATABASE_URL); run with `cargo nextest run --run-ignored all -p base-zk-db --test postgres_integration --test-threads=1`"]
-async fn test_create_session_and_update_status() {
-    let pool = test_pool().await;
-    let repo = test_repo(pool);
-
-    let req_id = repo.create(compressed_request()).await.unwrap();
-    repo.atomic_claim_task(req_id).await.unwrap(); // CREATED -> PENDING
-
-    let backend_id = format!("atomic-create-{}", Uuid::new_v4());
-    let session_id = repo
-        .create_session_and_update_status(
-            CreateProofSession {
-                proof_request_id: req_id,
-                session_type: SessionType::Stark,
-                backend_session_id: backend_id.clone(),
-                metadata: None,
-            },
-            ProofStatus::Running,
-        )
-        .await
-        .unwrap();
-    assert!(session_id > 0);
-
-    // Verify both updated atomically
-    let req = repo.get(req_id).await.unwrap().unwrap();
-    assert_eq!(req.status, ProofStatus::Running);
-
-    let session =
-        repo.get_session_by_backend_id(&backend_id).await.unwrap().expect("should find session");
-    assert_eq!(session.status, SessionStatus::Running);
-}
-
-#[tokio::test]
-#[ignore = "requires a running Postgres with the prover schema (set DATABASE_URL); run with `cargo nextest run --run-ignored all -p base-zk-db --test postgres_integration --test-threads=1`"]
 async fn test_fail_session_and_request() {
     let pool = test_pool().await;
     let repo = test_repo(pool);
 
-    let req_id = repo.create(compressed_request()).await.unwrap();
-    let backend_id = format!("fail-atomic-{}", Uuid::new_v4());
-
-    repo.create_session_and_update_status(
-        CreateProofSession {
-            proof_request_id: req_id,
-            session_type: SessionType::Stark,
-            backend_session_id: backend_id.clone(),
-            metadata: None,
-        },
-        ProofStatus::Running,
-    )
-    .await
-    .unwrap();
+    let (req_id, backend_id) = setup_running_request(&repo).await;
 
     let updated = repo
         .fail_session_and_request(&backend_id, req_id, Some("cluster timeout".into()))
@@ -547,33 +563,33 @@ async fn test_fail_session_and_request_skips_terminal() {
     let pool = test_pool().await;
     let repo = test_repo(pool);
 
-    let req_id = repo.create(compressed_request()).await.unwrap();
-    let backend_id = format!("fail-terminal-{}", Uuid::new_v4());
+    let (req_id, backend_id) = setup_running_request(&repo).await;
 
-    repo.create_session_and_update_status(
-        CreateProofSession {
-            proof_request_id: req_id,
-            session_type: SessionType::Stark,
-            backend_session_id: backend_id.clone(),
-            metadata: None,
+    repo.complete_session_and_update_receipt(
+        &backend_id,
+        UpdateReceipt {
+            id: req_id,
+            stark_receipt: Some(vec![0xDE, 0xAD]),
+            snark_receipt: None,
+            status: ProofStatus::Succeeded,
+            error_message: None,
         },
-        ProofStatus::Running,
     )
     .await
     .unwrap();
 
-    // Move request to SUCCEEDED first
-    repo.update_status(req_id, ProofStatus::Succeeded, None).await.unwrap();
-
-    // Now try to fail — request should NOT be updated
+    // Now try to fail — request should NOT be updated (already SUCCEEDED, not RUNNING)
     let updated = repo
         .fail_session_and_request(&backend_id, req_id, Some("late error".into()))
         .await
         .unwrap();
-    assert!(!updated); // request was already terminal
+    assert!(!updated);
 
     let req = repo.get(req_id).await.unwrap().unwrap();
-    assert_eq!(req.status, ProofStatus::Succeeded); // unchanged
+    assert_eq!(req.status, ProofStatus::Succeeded);
+
+    let session = repo.get_session_by_backend_id(&backend_id).await.unwrap().unwrap();
+    assert_eq!(session.status, SessionStatus::Completed);
 }
 
 #[tokio::test]
@@ -582,20 +598,7 @@ async fn test_complete_session_and_update_receipt() {
     let pool = test_pool().await;
     let repo = test_repo(pool);
 
-    let req_id = repo.create(compressed_request()).await.unwrap();
-    let backend_id = format!("complete-atomic-{}", Uuid::new_v4());
-
-    repo.create_session_and_update_status(
-        CreateProofSession {
-            proof_request_id: req_id,
-            session_type: SessionType::Stark,
-            backend_session_id: backend_id.clone(),
-            metadata: None,
-        },
-        ProofStatus::Running,
-    )
-    .await
-    .unwrap();
+    let (req_id, backend_id) = setup_running_request(&repo).await;
 
     let stark_data = vec![0xCA, 0xFE, 0xBA, 0xBE];
     let updated = repo
@@ -621,6 +624,110 @@ async fn test_complete_session_and_update_receipt() {
     let session = repo.get_session_by_backend_id(&backend_id).await.unwrap().unwrap();
     assert_eq!(session.status, SessionStatus::Completed);
     assert!(session.completed_at.is_some());
+}
+
+#[tokio::test]
+#[ignore = "requires a running Postgres with the prover schema (set DATABASE_URL); run with `cargo nextest run --run-ignored all -p base-zk-db --test postgres_integration --test-threads=1`"]
+async fn test_complete_session_and_update_receipt_skips_non_running() {
+    let pool = test_pool().await;
+    let repo = test_repo(pool);
+
+    let id = repo.create(compressed_request()).await.unwrap();
+    repo.atomic_claim_task(id).await.unwrap();
+    // Request is PENDING, not RUNNING
+    let backend_id = format!("complete-pending-{}", Uuid::new_v4());
+    repo.create_proof_session(CreateProofSession {
+        proof_request_id: id,
+        session_type: SessionType::Stark,
+        backend_session_id: backend_id.clone(),
+        metadata: None,
+    })
+    .await
+    .unwrap();
+
+    let updated = repo
+        .complete_session_and_update_receipt(
+            &backend_id,
+            UpdateReceipt {
+                id,
+                stark_receipt: Some(vec![1, 2, 3]),
+                snark_receipt: None,
+                status: ProofStatus::Succeeded,
+                error_message: None,
+            },
+        )
+        .await
+        .unwrap();
+    assert!(!updated, "should not update a PENDING request");
+
+    let req = repo.get(id).await.unwrap().unwrap();
+    assert_eq!(req.status, ProofStatus::Pending); // unchanged
+}
+
+// ============================================================
+// Retry logic tests
+// ============================================================
+
+#[tokio::test]
+#[ignore = "requires a running Postgres with the prover schema (set DATABASE_URL); run with `cargo nextest run --run-ignored all -p base-zk-db --test postgres_integration --test-threads=1`"]
+async fn test_retry_or_fail_stuck_request_retries() {
+    let pool = test_pool().await;
+    let repo = test_repo(pool);
+
+    let id = repo.create(compressed_request()).await.unwrap();
+    repo.atomic_claim_task(id).await.unwrap();
+
+    let outcome = repo.retry_or_fail_stuck_request(id, 3, "stuck in PENDING").await.unwrap();
+    assert_eq!(outcome, RetryOutcome::Retried);
+
+    let req = repo.get(id).await.unwrap().unwrap();
+    assert_eq!(req.status, ProofStatus::Created);
+    assert_eq!(req.retry_count, 1);
+    assert!(req.error_message.is_none());
+}
+
+#[tokio::test]
+#[ignore = "requires a running Postgres with the prover schema (set DATABASE_URL); run with `cargo nextest run --run-ignored all -p base-zk-db --test postgres_integration --test-threads=1`"]
+async fn test_retry_or_fail_stuck_request_exhausted() {
+    let pool = test_pool().await;
+    let repo = test_repo(pool);
+
+    let id = repo.create(compressed_request()).await.unwrap();
+
+    // Retry 3 times: each cycle is claim → retry (resets to CREATED) → claim again
+    for i in 0..3 {
+        repo.atomic_claim_task(id).await.unwrap();
+        let outcome = repo.retry_or_fail_stuck_request(id, 3, "stuck").await.unwrap();
+        assert_eq!(outcome, RetryOutcome::Retried, "retry {i} should succeed");
+    }
+
+    // retry_count is now 3, claim once more
+    repo.atomic_claim_task(id).await.unwrap();
+
+    // This time should permanently fail (retry_count >= max_retries)
+    let outcome = repo.retry_or_fail_stuck_request(id, 3, "stuck").await.unwrap();
+    assert_eq!(outcome, RetryOutcome::PermanentlyFailed);
+
+    let req = repo.get(id).await.unwrap().unwrap();
+    assert_eq!(req.status, ProofStatus::Failed);
+    assert!(req.error_message.as_deref().unwrap().contains("max retries exceeded"));
+    assert!(req.completed_at.is_some());
+}
+
+#[tokio::test]
+#[ignore = "requires a running Postgres with the prover schema (set DATABASE_URL); run with `cargo nextest run --run-ignored all -p base-zk-db --test postgres_integration --test-threads=1`"]
+async fn test_retry_or_fail_stuck_request_wrong_state() {
+    let pool = test_pool().await;
+    let repo = test_repo(pool);
+
+    let (id, _backend_id) = setup_running_request(&repo).await;
+
+    // Request is RUNNING, not PENDING — should be skipped
+    let outcome = repo.retry_or_fail_stuck_request(id, 3, "stuck").await.unwrap();
+    assert_eq!(outcome, RetryOutcome::Skipped);
+
+    let req = repo.get(id).await.unwrap().unwrap();
+    assert_eq!(req.status, ProofStatus::Running); // unchanged
 }
 
 // ============================================================
@@ -775,8 +882,7 @@ async fn test_get_running_proof_requests() {
     let pool = test_pool().await;
     let repo = test_repo(pool);
 
-    let id = repo.create(compressed_request()).await.unwrap();
-    repo.update_status(id, ProofStatus::Running, None).await.unwrap();
+    let (id, _backend_id) = setup_running_request(&repo).await;
 
     let running = repo.get_running_proof_requests().await.unwrap();
     let found = running.iter().any(|r| r.id == id);
@@ -790,8 +896,7 @@ async fn test_list_with_filter() {
     let repo = test_repo(pool);
 
     let id1 = repo.create(compressed_request()).await.unwrap();
-    let id2 = repo.create(compressed_request()).await.unwrap();
-    repo.update_status(id2, ProofStatus::Running, None).await.unwrap();
+    let (id2, _backend_id) = setup_running_request(&repo).await;
 
     // List only CREATED
     let created_list = repo.list(Some(ProofStatus::Created), 100).await.unwrap();
@@ -824,17 +929,16 @@ async fn test_full_snark_pipeline() {
 
     // 3. Submit STARK session (PENDING -> RUNNING)
     let stark_backend_id = format!("stark-pipeline-{}", Uuid::new_v4());
-    repo.create_session_and_update_status(
-        CreateProofSession {
+    let session_id = repo
+        .transition_pending_to_running(CreateProofSession {
             proof_request_id: req_id,
             session_type: SessionType::Stark,
             backend_session_id: stark_backend_id.clone(),
             metadata: None,
-        },
-        ProofStatus::Running,
-    )
-    .await
-    .unwrap();
+        })
+        .await
+        .unwrap();
+    assert!(session_id.is_some());
 
     // 4. STARK completes — store receipt but keep RUNNING (awaiting SNARK)
     let stark_receipt = vec![0x01, 0x02, 0x03];

--- a/crates/proof/zk/service/src/backends/network.rs
+++ b/crates/proof/zk/service/src/backends/network.rs
@@ -333,7 +333,7 @@ impl NetworkBackend {
                         error_message: None,
                     },
                 };
-                repo.update_receipt_if_non_terminal(update_receipt).await?;
+                repo.update_receipt_if_running(update_receipt).await?;
 
                 info!(
                     proof_request_id = %proof_request_id,

--- a/crates/proof/zk/service/src/backends/op_succinct/backend.rs
+++ b/crates/proof/zk/service/src/backends/op_succinct/backend.rs
@@ -536,7 +536,7 @@ impl OpSuccinctBackend {
                         error_message: None,
                     },
                 };
-                repo.update_receipt_if_non_terminal(update_receipt).await?;
+                repo.update_receipt_if_running(update_receipt).await?;
 
                 info!(
                     proof_request_id = %proof_request_id,

--- a/crates/proof/zk/service/src/metrics.rs
+++ b/crates/proof/zk/service/src/metrics.rs
@@ -23,6 +23,8 @@ pub const PROOF_REQUEST_DURATION_MS: &str = "zk_prover_service.proof_request_dur
 pub const PROOF_REQUESTS_COMPLETED: &str = "zk_prover_service.proof_requests_completed";
 /// Stuck requests detected and failed. Tags: `proof_type`
 pub const STUCK_REQUESTS: &str = "zk_prover_service.stuck_requests";
+/// Stuck requests retried (reset to CREATED). Tags: `proof_type`
+pub const RETRIED_REQUESTS: &str = "zk_prover_service.retried_requests";
 /// Outbox task submission outcomes. Tags: status (submitted/failed), `proof_type`
 pub const OUTBOX_TASKS_PROCESSED: &str = "zk_prover_service.outbox_tasks_processed";
 
@@ -50,6 +52,7 @@ impl ProverMetrics {
         );
         describe_counter!(PROOF_REQUESTS_COMPLETED, "Terminal proof request outcomes");
         describe_counter!(STUCK_REQUESTS, "Stuck requests detected and failed");
+        describe_counter!(RETRIED_REQUESTS, "Stuck requests retried (reset to CREATED)");
         describe_counter!(OUTBOX_TASKS_PROCESSED, "Outbox task submission outcomes");
     }
 }
@@ -107,6 +110,11 @@ pub fn inc_proof_requests_completed(status: &str, proof_type: &str) {
 /// Increment stuck requests counter.
 pub fn inc_stuck_requests(proof_type: &str) {
     counter!(STUCK_REQUESTS, "proof_type" => proof_type.to_string()).increment(1);
+}
+
+/// Increment retried requests counter.
+pub fn inc_retried_requests(proof_type: &str) {
+    counter!(RETRIED_REQUESTS, "proof_type" => proof_type.to_string()).increment(1);
 }
 
 /// Increment outbox task processed counter.

--- a/crates/proof/zk/service/src/proof_request_manager.rs
+++ b/crates/proof/zk/service/src/proof_request_manager.rs
@@ -28,10 +28,10 @@ impl ProofRequestManager {
 
     /// Sync proof request status by delegating to backend.
     ///
-    /// Uses `_if_non_terminal` DB methods for terminal transitions so that only
-    /// the first caller to transition the request actually succeeds. This
-    /// prevents double-counting metrics when `StatusPoller` and `GetProof` RPC
-    /// race on the same proof request.
+    /// Uses guarded DB transitions for terminal states so that only the first
+    /// caller to transition the request actually succeeds. This prevents
+    /// double-counting metrics when `StatusPoller` and `GetProof` RPC race on
+    /// the same proof request.
     pub async fn sync_and_update_proof_status(&self, proof_request: &ProofRequest) -> Result<()> {
         let prev_status = proof_request.status;
         let proof_type_label = metrics::proof_type_label(proof_request.proof_type);
@@ -44,8 +44,8 @@ impl ProofRequestManager {
         let result = backend.process_proof_request(proof_request, &self.repo).await?;
 
         // 3. Update proof request status based on backend's result.
-        //    Both terminal paths use _if_non_terminal variants so that only the
-        //    first caller to transition the request actually succeeds.
+        //    Both terminal paths use guarded transitions so that only the first
+        //    caller to transition the request actually succeeds.
         match result.status {
             ProofStatus::Succeeded => {
                 // Re-query to get updated receipts (backend updated them during processing)
@@ -62,21 +62,16 @@ impl ProofRequestManager {
                     status: ProofStatus::Succeeded,
                     error_message: None,
                 };
-                let was_updated = self.repo.update_receipt_if_non_terminal(update).await?;
+                let was_updated = self.repo.transition_running_to_succeeded(update).await?;
                 if !was_updated {
                     // Another caller already transitioned this request; skip metrics.
                     return Ok(());
                 }
             }
             ProofStatus::Failed => {
-                // Mark as failed (only if not already terminal)
                 let was_updated = self
                     .repo
-                    .update_status_if_non_terminal(
-                        proof_request.id,
-                        ProofStatus::Failed,
-                        result.error_message,
-                    )
+                    .transition_running_to_failed(proof_request.id, result.error_message)
                     .await?;
                 if !was_updated {
                     // Another caller already transitioned this request; skip metrics.

--- a/crates/proof/zk/service/src/server/get_proof.rs
+++ b/crates/proof/zk/service/src/server/get_proof.rs
@@ -177,6 +177,7 @@ mod tests {
             created_at: now,
             updated_at: now,
             completed_at: Some(now),
+            retry_count: 0,
         }
     }
 

--- a/crates/proof/zk/service/src/worker/prover_worker.rs
+++ b/crates/proof/zk/service/src/worker/prover_worker.rs
@@ -1,7 +1,7 @@
 use std::{fmt, sync::Arc};
 
 use base_zk_client::ProveBlockRequest;
-use base_zk_db::{CreateProofSession, ProofRequestRepo, ProofStatus, ProofType, SessionType};
+use base_zk_db::{CreateProofSession, ProofRequestRepo, ProofType, SessionType};
 use tracing::{debug, error, info, warn};
 use uuid::Uuid;
 
@@ -100,28 +100,37 @@ impl ProverWorker {
                         metadata: prove_result.metadata,
                     };
 
-                    if let Err(e) = self
-                        .repo
-                        .create_session_and_update_status(session, ProofStatus::Running)
-                        .await
-                    {
-                        error!(
-                            proof_request_id = %self.proof_request_id,
-                            backend_session_id = %session_id,
-                            backend = %self.backend.name(),
-                            error = %e,
-                            "Failed to persist session after successful prove — backend session may be orphaned"
-                        );
-                        return Err(anyhow::anyhow!(
-                            "Failed to persist session {session_id} for request {}: {e}",
-                            self.proof_request_id
-                        ));
+                    match self.repo.transition_pending_to_running(session).await {
+                        Ok(Some(db_session_id)) => {
+                            info!(
+                                proof_request_id = %self.proof_request_id,
+                                backend_session_id = %session_id,
+                                db_session_id,
+                                "Created STARK proof session and transitioned request to RUNNING"
+                            );
+                        }
+                        Ok(None) => {
+                            warn!(
+                                proof_request_id = %self.proof_request_id,
+                                backend_session_id = %session_id,
+                                "Could not transition to RUNNING — request no longer PENDING (race with stuck detector?)"
+                            );
+                            return Ok(());
+                        }
+                        Err(e) => {
+                            error!(
+                                proof_request_id = %self.proof_request_id,
+                                backend_session_id = %session_id,
+                                backend = %self.backend.name(),
+                                error = %e,
+                                "Failed to persist session after successful prove — backend session may be orphaned"
+                            );
+                            return Err(anyhow::anyhow!(
+                                "Failed to persist session {session_id} for request {}: {e}",
+                                self.proof_request_id
+                            ));
+                        }
                     }
-
-                    info!(
-                        proof_request_id = %self.proof_request_id,
-                        "Atomically created STARK proof session and updated status to RUNNING"
-                    );
                 } else {
                     info!(
                         proof_request_id = %self.proof_request_id,
@@ -141,24 +150,27 @@ impl ProverWorker {
                     "Backend proving failed"
                 );
 
-                // Update database status to failed
-                self.repo
-                    .update_status(
-                        self.proof_request_id,
-                        ProofStatus::Failed,
-                        Some(error_msg.clone()),
-                    )
+                let was_failed = self
+                    .repo
+                    .transition_pending_to_failed(self.proof_request_id, error_msg.clone())
                     .await?;
 
-                // Emit proof_requests_completed for early failures (PENDING → FAILED).
-                // These are never seen by the StatusPoller (which only queries RUNNING),
-                // so we emit directly here.
-                metrics::inc_proof_requests_completed("failed", pt_label);
+                if was_failed {
+                    // Emit proof_requests_completed for early failures (PENDING → FAILED).
+                    // These are never seen by the StatusPoller (which only queries RUNNING),
+                    // so we emit directly here.
+                    metrics::inc_proof_requests_completed("failed", pt_label);
 
-                info!(
-                    proof_request_id = %self.proof_request_id,
-                    "Updated proof request as FAILED"
-                );
+                    info!(
+                        proof_request_id = %self.proof_request_id,
+                        "Updated proof request as FAILED"
+                    );
+                } else {
+                    warn!(
+                        proof_request_id = %self.proof_request_id,
+                        "Could not transition to FAILED — request no longer PENDING"
+                    );
+                }
 
                 Err(anyhow::anyhow!(error_msg))
             }

--- a/crates/proof/zk/service/src/worker/status_poller.rs
+++ b/crates/proof/zk/service/src/worker/status_poller.rs
@@ -1,8 +1,8 @@
 use std::time::Duration;
 
-use base_zk_db::ProofRequestRepo;
+use base_zk_db::{ProofRequestRepo, RetryOutcome};
 use tokio::time::sleep;
-use tracing::{Instrument, error, info};
+use tracing::{Instrument, error, info, warn};
 
 use crate::{metrics, proof_request_manager::ProofRequestManager};
 
@@ -14,24 +14,27 @@ use crate::{metrics, proof_request_manager::ProofRequestManager};
 /// jobs complete (SUCCEEDED) or fail (FAILED).
 ///
 /// Additionally, it detects stuck requests (PENDING/RUNNING without active sessions)
-/// and fails them after a timeout to prevent orphaned jobs.
+/// and retries or fails them after a timeout to prevent orphaned jobs.
 #[derive(Debug, Clone)]
 pub struct StatusPoller {
     repo: ProofRequestRepo,
     manager: ProofRequestManager,
     poll_interval_secs: u64,
     stuck_timeout_mins: i32,
+    max_proof_retries: i32,
 }
 
 impl StatusPoller {
-    /// Creates a status poller (`poll_interval_secs=<secs>`, `stuck_timeout_mins=<mins>`).
+    /// Creates a status poller (`poll_interval_secs=<secs>`, `stuck_timeout_mins=<mins>`,
+    /// `max_proof_retries=<n>`).
     pub const fn new(
         repo: ProofRequestRepo,
         manager: ProofRequestManager,
         poll_interval_secs: u64,
         stuck_timeout_mins: i32,
+        max_proof_retries: i32,
     ) -> Self {
-        Self { repo, manager, poll_interval_secs, stuck_timeout_mins }
+        Self { repo, manager, poll_interval_secs, stuck_timeout_mins, max_proof_retries }
     }
 
     /// Run the status poller in a loop
@@ -92,31 +95,47 @@ impl StatusPoller {
             for request in stuck_requests {
                 let proof_type_label = metrics::proof_type_label(request.proof_type);
 
-                error!(
-                    proof_request_id = %request.id,
-                    status = %request.status,
-                    updated_at = %request.updated_at,
-                    "Failing stuck proof request"
-                );
-
                 let error_msg = format!(
                     "Request stuck in {} state without active session for {}+ minutes",
                     request.status, self.stuck_timeout_mins
                 );
 
-                if let Err(e) = self
+                match self
                     .repo
-                    .update_status(request.id, base_zk_db::ProofStatus::Failed, Some(error_msg))
+                    .retry_or_fail_stuck_request(request.id, self.max_proof_retries, &error_msg)
                     .await
                 {
-                    error!(
-                        proof_request_id = %request.id,
-                        error = %e,
-                        "Failed to mark stuck request as failed"
-                    );
-                } else {
-                    metrics::inc_stuck_requests(proof_type_label);
-                    metrics::inc_proof_requests_completed("failed", proof_type_label);
+                    Ok(RetryOutcome::Retried) => {
+                        info!(
+                            proof_request_id = %request.id,
+                            retry_count = request.retry_count + 1,
+                            max_retries = self.max_proof_retries,
+                            "Retrying stuck request — reset to CREATED with new outbox entry"
+                        );
+                        metrics::inc_retried_requests(proof_type_label);
+                    }
+                    Ok(RetryOutcome::PermanentlyFailed) => {
+                        error!(
+                            proof_request_id = %request.id,
+                            retry_count = request.retry_count,
+                            "Permanently failing stuck request — max retries exceeded"
+                        );
+                        metrics::inc_stuck_requests(proof_type_label);
+                        metrics::inc_proof_requests_completed("failed", proof_type_label);
+                    }
+                    Ok(RetryOutcome::Skipped) => {
+                        warn!(
+                            proof_request_id = %request.id,
+                            "Stuck request no longer PENDING — already claimed or transitioned"
+                        );
+                    }
+                    Err(e) => {
+                        error!(
+                            proof_request_id = %request.id,
+                            error = %e,
+                            "Failed to retry/fail stuck request"
+                        );
+                    }
                 }
             }
         }


### PR DESCRIPTION
Replace unguarded `update_status`/`update_receipt` calls with explicit state-guarded transitions to eliminate race conditions between the `StatusPoller`, prover workers, and `GetProof` RPC.

Add auto-retry for stuck `PENDING` requests up to `MAX_PROOF_RETRIES` (configurable via env, default 3) before permanently failing.

CHAIN-3774, CHAIN-3776