### PR TITLE
chore(devnet): improve devnet performance by removing tests that dont require full network

### DIFF
--- a/crates/execution/txpool/src/bundle/rpc.rs
+++ b/crates/execution/txpool/src/bundle/rpc.rs
@@ -213,7 +213,19 @@ where
 
 #[cfg(test)]
 mod tests {
+    use reth_transaction_pool::noop::NoopTransactionPool;
+
     use super::*;
+
+    fn handler(
+        current_block: u64,
+    ) -> SendBundleApiImpl<NoopTransactionPool<BasePooledTransaction>> {
+        SendBundleApiImpl::new(
+            NoopTransactionPool::<BasePooledTransaction>::new(),
+            true,
+            std::sync::Arc::new(std::sync::atomic::AtomicU64::new(current_block)),
+        )
+    }
 
     #[test]
     fn rejects_empty_txs() {
@@ -377,5 +389,41 @@ mod tests {
             builders: None,
         };
         assert!(validate_bundle_request(&req, 100).is_ok());
+    }
+
+    #[tokio::test]
+    async fn send_bundle_rejects_empty_bundle() {
+        let handler = handler(100);
+        let req = SendBundleRequest {
+            txs: vec![],
+            block_number: None,
+            min_timestamp: None,
+            max_timestamp: None,
+            reverting_tx_hashes: None,
+            replacement_uuid: None,
+            builders: None,
+        };
+
+        let err = handler.send_bundle(req).await.unwrap_err();
+        assert_eq!(err.code(), ErrorCode::InvalidParams.code());
+        assert!(err.message().contains("exactly 1 transaction"));
+    }
+
+    #[tokio::test]
+    async fn send_bundle_rejects_block_number_too_far_ahead() {
+        let handler = handler(100);
+        let req = SendBundleRequest {
+            txs: vec![Bytes::from_static(b"tx")],
+            block_number: Some(200),
+            min_timestamp: None,
+            max_timestamp: None,
+            reverting_tx_hashes: None,
+            replacement_uuid: None,
+            builders: None,
+        };
+
+        let err = handler.send_bundle(req).await.unwrap_err();
+        assert_eq!(err.code(), ErrorCode::InvalidParams.code());
+        assert!(err.message().contains("too far ahead"));
     }
 }

--- a/devnet/tests/bundles.rs
+++ b/devnet/tests/bundles.rs
@@ -12,7 +12,7 @@ use alloy_signer::SignerSync;
 use alloy_signer_local::PrivateKeySigner;
 use base_common_network::Base;
 use base_common_rpc_types::BaseTransactionRequest;
-use base_execution_txpool::{MAX_BUNDLE_ADVANCE_BLOCKS, unix_time_millis};
+use base_execution_txpool::unix_time_millis;
 use base_tx_forwarding::TxForwardingConfig;
 use devnet::{DevnetBuilder, config::ANVIL_ACCOUNT_1};
 use eyre::{Result, WrapErr};
@@ -161,62 +161,6 @@ async fn test_send_bundle_accepts_valid_bundle() -> Result<()> {
     assert_eq!(receipt.inner.block_number, Some(target_block));
     assert_eq!(receipt.inner.from, sender);
     assert_eq!(receipt.inner.to, Some(recipient));
-
-    Ok(())
-}
-
-#[tokio::test]
-async fn test_send_bundle_rejects_invalid_bundle() -> Result<()> {
-    let devnet = DevnetBuilder::new()
-        .with_l1_chain_id(L1_CHAIN_ID)
-        .with_l2_chain_id(L2_CHAIN_ID)
-        .with_tx_forwarding(TxForwardingConfig::new(vec![]))
-        .build()
-        .await?;
-
-    let client_provider = devnet.l2_client_provider()?;
-    wait_for_block(&client_provider, 2).await?;
-
-    let rpc_client = RpcClient::builder().http(devnet.l2_client_rpc_url()?);
-
-    let empty_request = BundleRequest {
-        txs: vec![],
-        block_number: None,
-        min_timestamp: None,
-        max_timestamp: None,
-        reverting_tx_hashes: None,
-        replacement_uuid: None,
-        builders: None,
-    };
-
-    let empty_result: Result<B256, _> =
-        rpc_client.request("eth_sendBundle", (empty_request,)).await;
-    let empty_err = empty_result.expect_err("Expected empty bundle to fail");
-    let empty_err_str = empty_err.to_string();
-    assert!(
-        empty_err_str.contains("exactly 1 transaction") || empty_err_str.contains("-32602"),
-        "Unexpected error for empty bundle: {empty_err_str}"
-    );
-
-    let current_block = client_provider.get_block_number().await?;
-    let far_block = current_block + MAX_BUNDLE_ADVANCE_BLOCKS + 1;
-    let far_request = BundleRequest {
-        txs: vec![Bytes::from_static(b"tx")],
-        block_number: Some(far_block),
-        min_timestamp: None,
-        max_timestamp: None,
-        reverting_tx_hashes: None,
-        replacement_uuid: None,
-        builders: None,
-    };
-
-    let far_result: Result<B256, _> = rpc_client.request("eth_sendBundle", (far_request,)).await;
-    let far_err = far_result.expect_err("Expected far-future block bundle to fail");
-    let far_err_str = far_err.to_string();
-    assert!(
-        far_err_str.contains("too far ahead") || far_err_str.contains("-32602"),
-        "Unexpected error for far-future bundle: {far_err_str}"
-    );
 
     Ok(())
 }

--- a/devnet/tests/tx_forwarding.rs
+++ b/devnet/tests/tx_forwarding.rs
@@ -147,58 +147,6 @@ async fn test_insert_validated_transaction_single() -> Result<()> {
     Ok(())
 }
 
-/// Tests that invalid transaction bytes are rejected with appropriate error.
-#[tokio::test]
-async fn test_insert_validated_transaction_invalid_bytes() -> Result<()> {
-    let devnet = DevnetBuilder::new()
-        .with_l1_chain_id(L1_CHAIN_ID)
-        .with_l2_chain_id(L2_CHAIN_ID)
-        .build()
-        .await?;
-
-    // Wait for builder to be ready
-    let builder_provider = devnet.l2_builder_provider()?;
-    timeout(Duration::from_secs(15), async {
-        loop {
-            let block = builder_provider.get_block_number().await?;
-            if block >= 2 {
-                return Ok::<_, eyre::Error>(block);
-            }
-            sleep(Duration::from_millis(500)).await;
-        }
-    })
-    .await
-    .wrap_err("Builder block production timed out")??;
-
-    // Create RPC client for the builder
-    let builder_rpc_url = devnet.l2_rpc_url()?;
-    let rpc_client = RpcClient::builder().http(builder_rpc_url);
-
-    // Create an invalid ValidatedTransaction with garbage bytes
-    let validated_tx = ValidatedTransaction {
-        sender: Address::repeat_byte(0x42),
-        raw: Bytes::from(vec![0xDE, 0xAD, 0xBE, 0xEF]),
-        target_block_number: None,
-        min_timestamp: None,
-        max_timestamp: None,
-    };
-
-    // Call base_insertValidatedTransaction - should fail
-    let result: Result<(), _> =
-        rpc_client.request("base_insertValidatedTransaction", (validated_tx,)).await;
-
-    let err = result.expect_err("expected decode error for invalid bytes");
-    let err_str = err.to_string();
-
-    // Should get InvalidParams error (-32602) for decode failure
-    assert!(
-        err_str.contains("-32602") || err_str.contains("failed to decode"),
-        "expected InvalidParams for decode failure, got: {err_str}"
-    );
-
-    Ok(())
-}
-
 /// Full end-to-end test for the transaction forwarding pipeline.
 ///
 /// This test verifies the complete flow:


### PR DESCRIPTION
## Summary
- remove two full-stack devnet negative-path tests that only exercise cheap request rejection
- add explicit lower-level `eth_sendBundle` rejection tests for empty bundles and far-future target blocks
- rely on the existing builder RPC invalid-bytes test as equivalent coverage for validated transaction rejection

## Why
These failures do not need full devnet boot and end up paying the slowest part of the test stack for cheap rejection paths.