### PR TITLE
test(devnet): raise nextest concurrency

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -8,7 +8,7 @@ max-threads = 1
 max-threads = 1
 
 [test-groups.devnet]
-max-threads = 1
+max-threads = 4
 
 [[profile.default.overrides]]
 filter = 'test(system_test_)'
@@ -29,4 +29,3 @@ filter = 'package(devnet)'
 test-group = 'devnet'
 retries = 1
 slow-timeout = { period = "120s", terminate-after = 3 }
-

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -8,7 +8,7 @@ max-threads = 1
 max-threads = 1
 
 [test-groups.devnet]
-max-threads = 4
+max-threads = 6
 
 [[profile.default.overrides]]
 filter = 'test(system_test_)'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -263,7 +263,8 @@ jobs:
 
   devnet-tests:
     name: Devnet Tests
-    runs-on: ubuntu-latest
+    runs-on:
+      group: BasePerfRunnerGroup
     timeout-minutes: 60
     steps:
       - name: Harden the runner (Audit all outbound calls)


### PR DESCRIPTION
## Summary
- raise the `devnet` nextest group concurrency from `1` to `6`

## Why
The devnet suite is currently fully serialized by nextest. This change increases parallelism at the runner level to speed up CI