### PR TITLE
chore(docs): Rename Base References

### DIFF
--- a/actions/README.md
+++ b/actions/README.md
@@ -146,7 +146,7 @@ sequential blocks with incrementing numbers and timestamps) or by constructing
 
 `MockL2Block` carries only the fields the batcher inspects: block number,
 parent hash, timestamp, the L1 origin (epoch number and hash), and raw encoded
-transactions. It does not wrap a full `SealedBlock` or `OpPayloadAttributes`
+transactions. It does not wrap a full `SealedBlock` or `BasePayloadAttributes`
 because the batcher does not need the rest of the block structure.
 
 

--- a/actions/harness/src/miner.rs
+++ b/actions/harness/src/miner.rs
@@ -70,7 +70,7 @@ impl Default for L1MinerConfig {
 
 /// A batcher transaction to be included in an L1 block.
 ///
-/// Op-stack batchers submit calldata transactions where:
+/// OP Stack batchers submit calldata transactions where:
 /// - `to` is the batch inbox address from the rollup config
 /// - `from` is the batcher's address
 /// - `input` is the frame-encoded batch data (version byte + encoded frames)

--- a/actions/harness/src/providers/l2.rs
+++ b/actions/harness/src/providers/l2.rs
@@ -90,7 +90,7 @@ impl ActionL2ChainProvider {
         self.blocks.insert(block.block_info.number, block);
     }
 
-    /// Insert a known L2 op-block (with transactions) into the provider.
+    /// Insert a known L2 block with transactions into the provider.
     pub fn insert_op_block(&mut self, number: u64, block: BaseBlock) {
         self.op_blocks.insert(number, block);
     }

--- a/crates/client/metering/src/transaction.rs
+++ b/crates/client/metering/src/transaction.rs
@@ -16,10 +16,12 @@ pub enum TxValidationError {
     InsufficientFundsForL1Gas(U256, U256),
 }
 
-/// Helper function to validate a transaction. A valid transaction must satisfy the following criteria:
+/// Helper function to validate a transaction.
+///
+/// A valid transaction must satisfy the following criteria:
 /// - The transaction's execution cost is less than the account's balance
 /// - The transaction's L1 gas cost is less than the account's balance
-///   
+///
 /// Note: We don't need to check for EIP-4844 because bundle transactions are Recovered<BaseTxEnvelope>
 /// which only includes Legacy, Eip2930, Eip1559, Eip7702, and Deposit.
 pub fn validate_tx<T: Transaction + Encodable2718>(
@@ -38,8 +40,8 @@ pub fn validate_tx<T: Transaction + Encodable2718>(
         return Err(TxValidationError::InsufficientFundsForTransfer(txn_cost, account.balance));
     }
 
-    // op-checks to see if sender can cover L1 gas cost
-    // from: https://github.com/paradigmxyz/reth/blob/6aa73f14808491aae77fc7c6eb4f0aa63bef7e6e/crates/optimism/txpool/src/validator.rs#L219
+    // Base-specific checks to see whether the sender can cover the L1 gas cost.
+    // Reference: https://github.com/paradigmxyz/reth/blob/6aa73f14808491aae77fc7c6eb4f0aa63bef7e6e/crates/optimism/txpool/src/validator.rs#L219
     let l1_cost_addition = l1_block_info.calculate_tx_l1_cost(&data, OpSpecId::ISTHMUS);
     let l1_cost = txn_cost.saturating_add(l1_cost_addition);
     if l1_cost > account.balance {

--- a/crates/common/consensus/README.md
+++ b/crates/common/consensus/README.md
@@ -5,7 +5,7 @@ Base chain consensus interface.
 ## Overview
 
 Contains constants, types, and functions for implementing Base EL consensus and communication.
-Includes an extended `OpTxEnvelope` type with deposit transactions, and receipts containing
+Includes an extended `BaseTxEnvelope` type with deposit transactions, and receipts containing
 chain-specific fields (`deposit_nonce` + `deposit_receipt_version`). Types in this crate
 correspond to `alloy-consensus` types that were modified from the base Ethereum protocol for
 the Base protocol.
@@ -23,7 +23,7 @@ base-common-consensus = { workspace = true }
 ```
 
 ```rust,ignore
-use base_common_consensus::{OpTxEnvelope, OpReceiptEnvelope};
+use base_common_consensus::{BaseReceiptEnvelope, BaseTxEnvelope};
 ```
 
 ## Provenance

--- a/crates/common/evm/README.md
+++ b/crates/common/evm/README.md
@@ -5,9 +5,10 @@ EVM implementation.
 ## Overview
 
 Provides Base-specific EVM execution support. Maps hardfork activation timestamps to revm
-`SpecId` values, and exposes `OpEvm`, `OpEvmFactory`, `BaseBlockExecutor`, and
+`SpecId` values, and exposes `BaseEvm`, `BaseEvmFactory`, `BaseBlockExecutor`, and
 `BaseBlockExecutorFactory` for executing blocks with the correct gas rules and precompile sets for
-each hardfork. Also provides `OpAlloyReceiptBuilder` for constructing OP receipts and
+each hardfork. Also provides `AlloyReceiptBuilder` and `BaseReceiptBuilder` for constructing Base
+receipts and
 `ensure_create2_deployer` for Canyon hardfork compatibility.
 
 ## Usage
@@ -20,10 +21,10 @@ base-common-evm = { workspace = true }
 ```
 
 ```rust,ignore
-use base_common_evm::{OpEvmFactory, spec_by_timestamp_after_bedrock};
+use base_common_evm::{BaseEvmFactory, BasePrecompiles, OpSpecId};
 
-let spec = spec_by_timestamp_after_bedrock(timestamp);
-let factory = OpEvmFactory::default();
+let factory = BaseEvmFactory::default();
+let precompiles = BasePrecompiles::new_with_spec(OpSpecId::ISTHMUS);
 ```
 
 ## License

--- a/crates/common/evm/src/precompiles/provider.rs
+++ b/crates/common/evm/src/precompiles/provider.rs
@@ -22,7 +22,7 @@ pub struct BasePrecompiles {
 }
 
 impl BasePrecompiles {
-    /// Create a new precompile provider with the given `OpSpec`.
+    /// Create a new precompile provider with the given [`OpSpecId`].
     #[inline]
     pub fn new_with_spec(spec: OpSpecId) -> Self {
         let precompiles = match spec {

--- a/crates/common/network/README.md
+++ b/crates/common/network/README.md
@@ -6,10 +6,8 @@ Base chain network types and RPC behavior abstraction.
 
 Defines the `Base` network type that implements the `alloy_network::Network` trait with Base
 transaction and receipt types. This provides a consistent interface to alloy providers and signers
-regardless of Base-specific RPC changes. Also re-exports alloy response types (`BlockResponse`,
-`ReceiptResponse`, `TransactionResponse`) and OP transaction types (`OpTxType`, `OpTxEnvelope`,
-`OpTypedTransaction`). It also provides the `BaseEngineApi` extension trait for Base-specific
-Engine API RPC methods.
+regardless of Base-specific RPC changes.
+It also provides the `BaseEngineApi` extension trait for Base-specific Engine API RPC methods.
 
 ## Usage
 

--- a/crates/common/rpc-types-engine/README.md
+++ b/crates/common/rpc-types-engine/README.md
@@ -5,9 +5,9 @@ Base chain RPC types for the `engine` namespace.
 ## Overview
 
 Defines execution engine payload types for the consensus-to-execution Engine API. Includes
-`OpPayloadAttributes` for block building requests, versioned payload envelopes
-(`OpExecutionPayloadEnvelope`, `OpNetworkPayloadEnvelope`), `OpExecutionPayloadV4`, and
-versioned sidecars (`OpExecutionPayloadSidecar`). These types are exchanged between the
+`BasePayloadAttributes` for block building requests, versioned payload envelopes
+(`BaseExecutionPayloadEnvelope`, `NetworkPayloadEnvelope`), `BaseExecutionPayloadV4`, and
+versioned sidecars (`BaseExecutionPayloadSidecar`). These types are exchanged between the
 consensus client and the execution node via the Engine API.
 
 ## Usage
@@ -20,9 +20,10 @@ base-common-rpc-types-engine = { workspace = true }
 ```
 
 ```rust,ignore
-use base_common_rpc_types_engine::{OpPayloadAttributes, OpExecutionPayloadEnvelope};
+use base_common_rpc_types_engine::{BaseExecutionPayloadEnvelope, BasePayloadAttributes};
 
-let attrs = OpPayloadAttributes { timestamp, transactions, .. };
+let attrs: BasePayloadAttributes = todo!();
+let envelope: BaseExecutionPayloadEnvelope = todo!();
 ```
 
 ## License

--- a/crates/common/rpc-types-engine/src/payload/v3.rs
+++ b/crates/common/rpc-types-engine/src/payload/v3.rs
@@ -3,7 +3,7 @@
 use alloy_primitives::{B256, U256};
 use alloy_rpc_types_engine::{BlobsBundleV1, ExecutionPayloadV3};
 
-/// This structure maps for the return value of `engine_getPayload` of the beacon chain spec, for
+/// This structure maps to the return value of `engine_getPayload` in the beacon chain spec, for
 /// V3.
 ///
 /// See also:

--- a/crates/common/rpc-types-engine/src/payload/v4.rs
+++ b/crates/common/rpc-types-engine/src/payload/v4.rs
@@ -181,7 +181,7 @@ impl ssz::Encode for BaseExecutionPayloadV4 {
     }
 }
 
-/// This structure maps for the return value of `engine_getPayload` of the beacon chain spec, for
+/// This structure maps to the return value of `engine_getPayload` in the beacon chain spec, for
 /// V4.
 ///
 /// See also:

--- a/crates/common/rpc-types-engine/src/payload/v5.rs
+++ b/crates/common/rpc-types-engine/src/payload/v5.rs
@@ -7,10 +7,10 @@ use alloy_rpc_types_engine::BlobsBundleV2;
 
 use super::v4::BaseExecutionPayloadV4;
 
-/// This structure maps for the return value of `engine_getPayload` of the beacon chain spec, for
+/// This structure maps to the return value of `engine_getPayload` in the beacon chain spec, for
 /// V5.
 ///
-/// The OP variant follows the same pattern as V4: replaces `ExecutionPayloadV3` with
+/// The Base variant follows the same pattern as V4: it replaces `ExecutionPayloadV3` with
 /// [`BaseExecutionPayloadV4`] (which adds `withdrawalsRoot`), and keeps all other fields identical
 /// to the mainnet [`ExecutionPayloadEnvelopeV5`](alloy_rpc_types_engine::ExecutionPayloadEnvelopeV5).
 ///

--- a/crates/common/rpc-types/README.md
+++ b/crates/common/rpc-types/README.md
@@ -5,9 +5,9 @@ Base chain RPC types.
 ## Overview
 
 Defines the JSON-RPC request and response types specific to Base chains, including genesis and
-chain info types (`BaseGenesisInfo`, `BaseChainInfo`, `BaseFeeInfo`), transaction types
-(`BaseTransactionFields`, `OpTransactionRequest`, `Transaction`), receipt types
-(`OpTransactionReceipt`, `OpTransactionReceiptFields`), and `L1BlockInfo` for fee data. These
+chain info types (`GenesisInfo`, `ChainInfo`, `FeeInfo`), transaction types
+(`BaseTransactionFields`, `BaseTransactionRequest`, `Transaction`), receipt types
+(`BaseTransactionReceipt`, `TransactionReceiptFields`), and `L1BlockInfo` for fee data. These
 types are used to serialize and deserialize Base-specific RPC payloads.
 
 ## Usage
@@ -20,9 +20,9 @@ base-common-rpc-types = { workspace = true }
 ```
 
 ```rust,ignore
-use base_common_rpc_types::{OpTransactionReceipt, L1BlockInfo};
+use base_common_rpc_types::{BaseTransactionReceipt, L1BlockInfo};
 
-let receipt: OpTransactionReceipt = provider.get_transaction_receipt(hash).await?;
+let receipt: BaseTransactionReceipt = provider.get_transaction_receipt(hash).await?;
 let l1_fee = receipt.l1_block_info.l1_fee;
 ```
 

--- a/crates/consensus/derive/README.md
+++ b/crates/consensus/derive/README.md
@@ -9,7 +9,7 @@ A `no_std` compatible implementation of Base's [derivation pipeline][derive].
 ## Overview
 
 Implements the full L2 chain derivation pipeline as specified by the Base protocol. The
-`DerivationPipeline` steps through L1 data to produce `OpPayloadAttributes` for each L2 block.
+`DerivationPipeline` steps through L1 data to produce `BasePayloadAttributes` for each L2 block.
 `EthereumDataSource` fetches batch data from calldata or blobs, `StatefulAttributesBuilder`
 constructs payload attributes with deposits and sequencer configuration, and `PipelineBuilder`
 wires all stages together. The crate is `no_std` compatible for use in fault proof VMs.

--- a/crates/consensus/protocol/src/frame.rs
+++ b/crates/consensus/protocol/src/frame.rs
@@ -220,9 +220,9 @@ impl Frame {
         Ok((frame_len, frame))
     }
 
-    /// Parse the on chain serialization of frame(s) in an L1 transaction. Currently
+    /// Parse the on-chain serialization of frame(s) in an L1 transaction. Currently
     /// only version 0 of the serialization format is supported. All frames must be parsed
-    /// without error and there must not be any left over data and there must be at least one
+    /// without error, there must not be any leftover data, and there must be at least one
     /// frame.
     ///
     /// Frames are stored in L1 transactions with the following format:

--- a/crates/execution/cli/README.md
+++ b/crates/execution/cli/README.md
@@ -4,8 +4,8 @@ CLI extensions for the Base execution node.
 
 ## Overview
 
-Provides the command-line interface for the op-reth execution node. Wraps argument parsing with
-Base-specific chain spec resolution via `OpChainSpecParser`, and exposes a `Cli` type that
+Provides the command-line interface for the Base execution node. Wraps argument parsing with
+Base-specific chain spec resolution via `BaseChainSpecParser`, and exposes a `Cli` type that
 drives node startup from parsed arguments.
 
 ## Usage

--- a/crates/execution/cli/src/commands/init_state.rs
+++ b/crates/execution/cli/src/commands/init_state.rs
@@ -10,12 +10,12 @@ use reth_cli_commands::common::CliNodeTypes;
 
 /// Initializes the database with the genesis block.
 #[derive(Debug, Parser)]
-pub struct InitStateCommandOp<C: ChainSpecParser> {
+pub struct BaseInitStateCommand<C: ChainSpecParser> {
     #[command(flatten)]
     init_state: reth_cli_commands::init_state::InitStateCommand<C>,
 }
 
-impl<C: ChainSpecParser<ChainSpec = BaseChainSpec>> InitStateCommandOp<C> {
+impl<C: ChainSpecParser<ChainSpec = BaseChainSpec>> BaseInitStateCommand<C> {
     /// Execute the `init` command
     pub async fn execute<N: CliNodeTypes<ChainSpec = C::ChainSpec, Primitives = BasePrimitives>>(
         self,
@@ -24,8 +24,8 @@ impl<C: ChainSpecParser<ChainSpec = BaseChainSpec>> InitStateCommandOp<C> {
     }
 }
 
-impl<C: ChainSpecParser> InitStateCommandOp<C> {
-    /// Returns the underlying chain being used to run this command
+impl<C: ChainSpecParser> BaseInitStateCommand<C> {
+    /// Returns the underlying chain being used to run this command.
     pub fn chain_spec(&self) -> Option<&Arc<C::ChainSpec>> {
         self.init_state.chain_spec()
     }

--- a/crates/execution/cli/src/commands/mod.rs
+++ b/crates/execution/cli/src/commands/mod.rs
@@ -30,7 +30,7 @@ pub enum Commands<Ext: clap::Args + fmt::Debug = NoArgs> {
     Init(init_cmd::InitCommand<BaseChainSpecParser>),
     /// Initialize the database from a state dump file.
     #[command(name = "init-state")]
-    InitState(init_state::InitStateCommandOp<BaseChainSpecParser>),
+    InitState(init_state::BaseInitStateCommand<BaseChainSpecParser>),
     /// Dumps genesis block JSON configuration to stdout.
     DumpGenesis(dump_genesis::DumpGenesisCommand<BaseChainSpecParser>),
     /// Database debugging utilities

--- a/crates/execution/cli/src/lib.rs
+++ b/crates/execution/cli/src/lib.rs
@@ -7,7 +7,7 @@
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
-/// A configurable App on top of the cli parser.
+/// A configurable app on top of the CLI parser.
 pub mod app;
 /// Base chain specification parser.
 pub mod chainspec;
@@ -38,7 +38,7 @@ use reth_rpc_server_types::{DefaultRpcModuleValidator, RpcModuleValidator};
 
 /// The main base-reth cli interface.
 ///
-/// This is the entrypoint to the executable.
+/// This is the entry point to the executable.
 #[derive(Debug, Parser)]
 #[command(author, name = version_metadata().name_client.as_ref(), version = version_metadata().short_version.as_ref(), long_version = version_metadata().long_version.as_ref(), about = "Reth", long_about = None)]
 pub struct Cli<
@@ -63,12 +63,12 @@ pub struct Cli<
 }
 
 impl Cli {
-    /// Parsers only the default CLI arguments
+    /// Parses only the default CLI arguments.
     pub fn parse_args() -> Self {
         Self::parse()
     }
 
-    /// Parsers only the default CLI arguments from the given iterator
+    /// Parses only the default CLI arguments from the given iterator.
     pub fn try_parse_args_from<I, T>(itr: I) -> Result<Self, clap::error::Error>
     where
         I: IntoIterator<Item = T>,

--- a/crates/execution/consensus/README.md
+++ b/crates/execution/consensus/README.md
@@ -5,7 +5,7 @@ Consensus implementation for Base.
 ## Overview
 
 Implements block validation following Base consensus rules for the execution layer. The
-`OpBeaconConsensus` type validates block headers and bodies against hardfork-specific rules,
+`BaseBeaconConsensus` type validates block headers and bodies against hardfork-specific rules,
 including blob gas accounting, deposit ordering, Canyon EIP-1559, and Isthmus system contract
 upgrades. Also provides receipt root calculation and post-execution validation helpers.
 
@@ -19,9 +19,9 @@ base-execution-consensus = { workspace = true }
 ```
 
 ```rust,ignore
-use base_execution_consensus::OpBeaconConsensus;
+use base_execution_consensus::BaseBeaconConsensus;
 
-let consensus = OpBeaconConsensus::new(chain_spec);
+let consensus = BaseBeaconConsensus::new(chain_spec);
 consensus.validate_block_pre_execution(&block)?;
 ```
 

--- a/crates/execution/consensus/src/lib.rs
+++ b/crates/execution/consensus/src/lib.rs
@@ -91,7 +91,7 @@ where
         body: &B::Body,
         header: &SealedHeader<B::Header>,
     ) -> Result<(), ConsensusError> {
-        validation::validate_body_against_header_op(&self.chain_spec, body, header.header())
+        validation::validate_body_against_header_base(&self.chain_spec, body, header.header())
     }
 
     fn validate_block_pre_execution(&self, block: &SealedBlock<B>) -> Result<(), ConsensusError> {

--- a/crates/execution/consensus/src/proof.rs
+++ b/crates/execution/consensus/src/proof.rs
@@ -90,7 +90,7 @@ mod tests {
     /// This was implemented due to a minor bug in op-geth and op-erigon where in
     /// the Regolith hardfork, the receipt root calculation does not include the
     /// deposit nonce in the receipt encoding.
-    /// To fix this an op-reth patch was applied to the receipt root calculation
+    /// To fix this, a downstream patch was applied to the receipt root calculation
     /// to strip the deposit nonce from each receipt before calculating the root.
     #[test]
     fn check_optimism_receipt_root() {

--- a/crates/execution/consensus/src/validation/mod.rs
+++ b/crates/execution/consensus/src/validation/mod.rs
@@ -28,7 +28,7 @@ fn should_trust_precomputed_receipt_root(chain_spec: &impl Upgrades, timestamp: 
 ///   - ommer hash
 ///   - transaction root
 ///   - withdrawals root: the body's withdrawals root must only match the header's before isthmus
-pub fn validate_body_against_header_op<B, H>(
+pub fn validate_body_against_header_base<B, H>(
     chain_spec: impl Upgrades,
     body: &B,
     header: &H,
@@ -583,10 +583,10 @@ mod tests {
             ommers: vec![],
             withdrawals: Some(Default::default()),
         };
-        validate_body_against_header_op(&chainspec, &body, &header).unwrap();
+        validate_body_against_header_base(&chainspec, &body, &header).unwrap();
 
         body.withdrawals.take();
-        validate_body_against_header_op(&chainspec, &body, &header).unwrap_err();
+        validate_body_against_header_base(&chainspec, &body, &header).unwrap_err();
     }
 
     #[test]

--- a/crates/execution/engine-tree/README.md
+++ b/crates/execution/engine-tree/README.md
@@ -76,18 +76,20 @@ let validator = BaseEngineValidator::new(
 Implement `CachedExecutionProvider` to supply pre-computed execution results:
 
 ```rust,ignore
+use base_common_consensus::OpTxType;
+use base_common_evm::{BaseHaltReason, BaseTxResult};
 use base_engine_tree::CachedExecutionProvider;
 
 #[derive(Debug, Clone)]
 struct MyFlashblockCache { /* ... */ }
 
-impl CachedExecutionProvider<OpTxResult<OpHaltReason, OpTxType>> for MyFlashblockCache {
+impl CachedExecutionProvider<BaseTxResult<BaseHaltReason, OpTxType>> for MyFlashblockCache {
     fn get_cached_execution_for_tx(
         &self,
         parent_block_hash: &B256,
         prev_cached_hash: Option<&B256>,
         tx_hash: &B256,
-    ) -> Option<OpTxResult<OpHaltReason, OpTxType>> {
+    ) -> Option<BaseTxResult<BaseHaltReason, OpTxType>> {
         // Look up cached result from flashblock execution
         self.cache.get(start_state_root, tx_hash)
     }

--- a/crates/execution/evm/src/receipts.rs
+++ b/crates/execution/evm/src/receipts.rs
@@ -4,7 +4,7 @@ use base_common_consensus::{BaseReceipt, BaseTransactionSigned, OpTxType};
 use base_common_evm::BaseReceiptBuilder;
 use reth_evm::Evm;
 
-/// A builder that operates on op-reth primitive types, specifically [`BaseTransactionSigned`] and
+/// A builder that operates on Base primitive types, specifically [`BaseTransactionSigned`] and
 /// [`BaseReceipt`].
 #[derive(Debug, Default, Clone, Copy)]
 #[non_exhaustive]

--- a/crates/execution/flashblocks/src/state_builder.rs
+++ b/crates/execution/flashblocks/src/state_builder.rs
@@ -17,7 +17,7 @@ use base_common_consensus::{BasePrimitives, BaseReceipt, BaseTxEnvelope, Predepl
 use base_common_evm::{BaseHaltReason, L1BlockInfo, ensure_create2_deployer};
 use base_common_flz::tx_estimated_size_fjord as estimate_tx_compressed_size;
 use base_common_rpc_types::{BaseTransactionReceipt, Transaction};
-use base_execution_rpc::BaseReceiptBuilder as OpRpcReceiptBuilder;
+use base_execution_rpc::BaseReceiptBuilder as BaseRpcReceiptBuilder;
 use reth_evm::{Evm, FromRecoveredTx};
 use reth_rpc_convert::transaction::ConvertReceiptInput;
 use revm::{
@@ -333,7 +333,7 @@ where
                     meta,
                 };
 
-                let mut op_receipt = OpRpcReceiptBuilder::new(
+                let mut base_receipt = BaseRpcReceiptBuilder::new(
                     self.receipt_builder.chain_spec(),
                     input,
                     &mut self.l1_block_info,
@@ -341,11 +341,11 @@ where
                 .map_err(|e| ExecutionError::RpcReceiptBuild(e.to_string()))?
                 .build();
 
-                op_receipt.inner.blob_gas_used = Some(da_footprint_used);
+                base_receipt.inner.blob_gas_used = Some(da_footprint_used);
                 self.next_log_index += receipt.logs().len();
 
                 let (deposit_receipt_version, deposit_nonce) = if transaction.is_deposit() {
-                    let BaseReceipt::Deposit(deposit_receipt) = &op_receipt.inner.inner.receipt
+                    let BaseReceipt::Deposit(deposit_receipt) = &base_receipt.inner.inner.receipt
                     else {
                         return Err(ExecutionError::DepositReceiptMismatch.into());
                     };
@@ -370,7 +370,7 @@ where
 
                 Ok(ExecutedPendingTransaction {
                     rpc_transaction,
-                    receipt: op_receipt,
+                    receipt: base_receipt,
                     state,
                     result,
                     execution_time_us: Some(elapsed_us),

--- a/crates/execution/node/README.md
+++ b/crates/execution/node/README.md
@@ -5,9 +5,9 @@ Base execution node implementation.
 ## Overview
 
 Provides the core node type definitions and builder components for the Base execution node. Includes
-`OpEngineTypes` for consensus/execution engine integration, `OpEngineApiBuilder` for constructing
-the Engine API handler, `OpStorage` for chain state persistence, and payload builder and attestor
-types. This crate wires together the execution layer's engine, RPC, and payload subsystems.
+`BaseEngineTypes` for consensus/execution engine integration, `BaseEngineApiBuilder` for
+constructing the Engine API handler, and payload and proof-history types. This crate wires
+together the execution layer's engine, RPC, and payload subsystems.
 
 ## Usage
 
@@ -19,10 +19,10 @@ base-execution-node = { workspace = true }
 ```
 
 ```rust,ignore
-use base_execution_node::{OpEngineTypes, OpEngineApiBuilder};
+use base_execution_node::{BaseEngineApiBuilder, BaseEngineTypes};
 
 let node = NodeBuilder::new(config)
-    .with_types::<OpEngineTypes>()
+    .with_types::<BaseEngineTypes>()
     .with_components(components)
     .launch()
     .await?;

--- a/crates/execution/payload/README.md
+++ b/crates/execution/payload/README.md
@@ -5,10 +5,11 @@ Payload builder for Base.
 ## Overview
 
 Implements Base payload building and validation for the Base execution node. The
-`OpPayloadBuilder` assembles new execution payloads from transaction pool contents and
-`OpPayloadAttributes` received from the consensus layer. `OpExecutionPayloadValidator` verifies
+`BasePayloadBuilder` assembles new execution payloads from transaction pool contents and
+`BasePayloadBuilderAttributes` received from the consensus layer. `BaseExecutionPayloadValidator`
+verifies
 built payloads against consensus rules. Also provides data availability configuration via
-`OpDAConfig` for fee calculation.
+`BaseDAConfig` for fee calculation.
 
 ## Usage
 
@@ -20,9 +21,9 @@ base-execution-payload-builder = { workspace = true }
 ```
 
 ```rust,ignore
-use base_execution_payload_builder::OpPayloadBuilder;
+use base_execution_payload_builder::BasePayloadBuilder;
 
-let builder = OpPayloadBuilder::new(evm_config, payload_validator);
+let builder = BasePayloadBuilder::new(evm_config, payload_validator);
 let payload = builder.build_payload(attrs, best_payload)?;
 ```
 

--- a/crates/execution/payload/src/config.rs
+++ b/crates/execution/payload/src/config.rs
@@ -1,4 +1,4 @@
-//! Additional configuration for the Base payload builder
+//! Additional configuration for the Base payload builder.
 
 use std::sync::{Arc, atomic::AtomicU64};
 
@@ -17,16 +17,17 @@ impl BaseBuilderConfig {
         Self { da_config, gas_limit_config }
     }
 
-    /// Returns the Data Availability configuration for the OP builder, if it has configured
+    /// Returns the data availability configuration for the Base payload builder, if it has
+    /// configured
     /// constraints.
     pub fn constrained_da_config(&self) -> Option<&BaseDAConfig> {
         if self.da_config.is_empty() { None } else { Some(&self.da_config) }
     }
 }
 
-/// Contains the Data Availability configuration for the OP builder.
+/// Contains the data availability configuration for the Base payload builder.
 ///
-/// This type is shareable and can be used to update the DA configuration for the OP payload
+/// This type is shareable and can be used to update the DA configuration for the Base payload
 /// builder.
 #[derive(Debug, Clone, Default)]
 pub struct BaseDAConfig {
@@ -46,7 +47,7 @@ impl BaseDAConfig {
         self.max_da_tx_size().is_none() && self.max_da_block_size().is_none()
     }
 
-    /// Returns the max allowed data availability size per transactions, if any.
+    /// Returns the maximum allowed data availability size per transaction, if any.
     pub fn max_da_tx_size(&self) -> Option<u64> {
         let val = self.inner.max_da_tx_size.load(std::sync::atomic::Ordering::Relaxed);
         if val == 0 { None } else { Some(val) }
@@ -90,9 +91,10 @@ struct BaseDAConfigInner {
     max_da_block_size: AtomicU64,
 }
 
-/// Contains the Gas Limit configuration for the OP builder.
+/// Contains the gas-limit configuration for the Base payload builder.
 ///
-/// This type is shareable and can be used to update the Gas Limit configuration for the OP payload
+/// This type is shareable and can be used to update the gas-limit configuration for the Base
+/// payload
 /// builder.
 #[derive(Debug, Clone, Default)]
 pub struct GasLimitConfig {

--- a/crates/execution/rpc/README.md
+++ b/crates/execution/rpc/README.md
@@ -5,7 +5,7 @@ RPC extensions for the Base execution node.
 ## Overview
 
 Provides JSON-RPC API implementations for Base chains, including the full Ethereum API
-(`OpEthApi`), the Engine API (`OpEngineApi`), debug, miner, sequencer, and witness endpoints.
+(`BaseEthApi`), the Engine API (`BaseEngineApi`), debug, miner, sequencer, and witness endpoints.
 Also includes `SequencerClient` for forwarding transactions to the sequencer and error types for
 Base-specific RPC failures.
 
@@ -19,9 +19,9 @@ base-execution-rpc = { workspace = true }
 ```
 
 ```rust,ignore
-use base_execution_rpc::{OpEthApiBuilder, SequencerClient};
+use base_execution_rpc::{BaseEthApiBuilder, SequencerClient};
 
-let eth_api = OpEthApiBuilder::new()
+let eth_api = BaseEthApiBuilder::new()
     .with_sequencer(SequencerClient::new(sequencer_url))
     .build(ctx)?;
 ```

--- a/crates/execution/rpc/src/eth/mod.rs
+++ b/crates/execution/rpc/src/eth/mod.rs
@@ -1,4 +1,4 @@
-//! OP-Reth `eth_` endpoint implementation.
+//! Base `eth_` endpoint implementation.
 
 pub mod proofs;
 pub mod receipt;
@@ -46,7 +46,7 @@ use crate::{
 /// Adapter for [`EthApiInner`], which holds all the data required to serve core `eth_` API.
 pub type EthApiNodeBackend<N, Rpc> = EthApiInner<N, Rpc>;
 
-/// OP-Reth `Eth` API implementation.
+/// Base `Eth` API implementation.
 ///
 /// This type provides the functionality for handling `eth_` related requests.
 ///

--- a/crates/execution/rpc/src/miner.rs
+++ b/crates/execution/rpc/src/miner.rs
@@ -1,4 +1,4 @@
-//! Miner API extension for OP.
+//! Miner API extension for Base.
 
 use alloy_primitives::U64;
 use base_execution_payload_builder::config::{BaseDAConfig, GasLimitConfig};
@@ -6,11 +6,12 @@ use jsonrpsee::proc_macros::rpc;
 use jsonrpsee_core::{RpcResult, async_trait};
 use tracing::debug;
 
-/// Op API extension for controlling the miner.
+/// Base API extension for controlling the miner.
 #[cfg_attr(not(feature = "client"), rpc(server, namespace = "miner"))]
 #[cfg_attr(feature = "client", rpc(server, client, namespace = "miner"))]
 pub trait MinerApiExt {
-    /// Sets the maximum data availability size of any tx allowed in a block, and the total max l1
+    /// Sets the maximum data availability size of any transaction allowed in a block, and the
+    /// total maximum L1
     /// data size of the block. 0 means no maximum.
     #[method(name = "setMaxDASize")]
     async fn set_max_da_size(&self, max_tx_size: U64, max_block_size: U64) -> RpcResult<bool>;
@@ -27,7 +28,7 @@ pub trait MinerApiExt {
 
 base_metrics::define_metrics! {
     base_rpc.miner,
-    struct = OpMinerMetrics,
+    struct = BaseMinerMetrics,
     #[describe("Max DA tx size set on the miner")]
     max_da_tx_size: gauge,
     #[describe("Max DA block size set on the miner")]
@@ -36,7 +37,7 @@ base_metrics::define_metrics! {
     gas_limit: gauge,
 }
 
-/// Miner API extension for OP, exposes settings for the data availability configuration via the
+/// Miner API extension for Base, exposing settings for the data availability configuration via the
 /// `miner_` API.
 #[derive(Debug, Clone)]
 pub struct BaseMinerExtApi {
@@ -45,7 +46,7 @@ pub struct BaseMinerExtApi {
 }
 
 impl BaseMinerExtApi {
-    /// Instantiate the miner API extension with the given, sharable data availability
+    /// Instantiate the miner API extension with the given, shareable data availability
     /// configuration.
     pub const fn new(da_config: BaseDAConfig, gas_limit_config: GasLimitConfig) -> Self {
         Self { da_config, gas_limit_config }
@@ -59,8 +60,8 @@ impl MinerApiExtServer for BaseMinerExtApi {
         debug!(target: "rpc", max_tx_size = %max_tx_size, max_block_size = %max_block_size, "Setting max DA size");
         self.da_config.set_max_da_size(max_tx_size.to(), max_block_size.to());
 
-        OpMinerMetrics::max_da_tx_size().set(max_tx_size.to::<u64>() as f64);
-        OpMinerMetrics::max_da_block_size().set(max_block_size.to::<u64>() as f64);
+        BaseMinerMetrics::max_da_tx_size().set(max_tx_size.to::<u64>() as f64);
+        BaseMinerMetrics::max_da_block_size().set(max_block_size.to::<u64>() as f64);
 
         Ok(true)
     }
@@ -76,7 +77,7 @@ impl MinerApiExtServer for BaseMinerExtApi {
     async fn set_gas_limit(&self, gas_limit: U64) -> RpcResult<bool> {
         debug!(target: "rpc", gas_limit = %gas_limit, "Setting gas limit");
         self.gas_limit_config.set_gas_limit(gas_limit.to());
-        OpMinerMetrics::gas_limit().set(gas_limit.to::<u64>() as f64);
+        BaseMinerMetrics::gas_limit().set(gas_limit.to::<u64>() as f64);
         Ok(true)
     }
 }

--- a/crates/execution/runner/README.md
+++ b/crates/execution/runner/README.md
@@ -13,7 +13,7 @@ aliases for building modular node extensions.
 - **`BaseNodeRunner`**: Orchestrates Base node wiring and launch.
 - **`NodeHooks`**: Hook accumulator used by extensions to register RPC and node-start hooks.
 - **`BaseNodeBuilder`**: Type alias for the node builder with launch context.
-- **`OpProvider`**: Type alias for the blockchain provider instance.
+- **`BaseProvider`**: Type alias for the blockchain provider instance.
 
 Configuration types are located in their respective feature crates:
 - **`FlashblocksConfig`**: in `base-flashblocks` crate

--- a/crates/execution/storage/README.md
+++ b/crates/execution/storage/README.md
@@ -4,7 +4,7 @@ Storage implementation for Base.
 
 ## Overview
 
-Defines the `OpStorage` abstraction for chain state persistence in the Base execution node.
+Defines the `BaseStorage` abstraction for chain state persistence in the Base execution node.
 Wraps Reth's storage layer with Base-specific configuration including pruning mode
 compatibility checks and the storage types needed by the execution engine and provider stack.
 
@@ -18,9 +18,9 @@ base-execution-storage = { workspace = true }
 ```
 
 ```rust,ignore
-use base_execution_storage::OpStorage;
+use base_execution_storage::BaseStorage;
 
-let storage = OpStorage::new(db_path, prune_config)?;
+let storage = BaseStorage::new(db_path, prune_config)?;
 ```
 
 ## License

--- a/crates/execution/trie/README.md
+++ b/crates/execution/trie/README.md
@@ -4,11 +4,11 @@ Trie implementation for Base.
 
 ## Overview
 
-Manages Merkle Patricia Trie proof storage for the fault-proof window. The `OpProofsStorage`
-type (backed by either in-memory or MDBX) accumulates per-block state diffs and trie node
-preimages, making them available for proof generation without re-executing blocks. Provides
-cursor interfaces for navigating account and storage tries, a pruner for removing data outside
-the retention window, and an initialization job for syncing historical proofs at startup.
+Manages Merkle Patricia Trie proof storage for the fault-proof window. The `BaseProofsStore`
+traits and storage backends accumulate per-block state diffs and trie node preimages, making them
+available for proof generation without re-executing blocks. Provides cursor interfaces for
+navigating account and storage tries, a pruner for removing data outside the retention window, and
+an initialization job for syncing historical proofs at startup.
 
 ## Usage
 
@@ -20,10 +20,10 @@ base-execution-trie = { workspace = true }
 ```
 
 ```rust,ignore
-use base_execution_trie::{MdbxProofsStorage, OpProofStoragePruner};
+use base_execution_trie::{BaseProofStoragePruner, MdbxProofsStorage};
 
 let storage = MdbxProofsStorage::open(db_path)?;
-let pruner = OpProofStoragePruner::new(storage.clone(), retention_blocks);
+let pruner = BaseProofStoragePruner::new(storage.clone(), retention_blocks);
 ```
 
 ## License

--- a/crates/execution/txpool/README.md
+++ b/crates/execution/txpool/README.md
@@ -5,7 +5,7 @@ Transaction pool for Base.
 ## Overview
 
 Extends Reth's transaction pool with Base-specific validation and ordering for the Base node.
-`OpTransactionValidator` enforces L1 data fee checks and Base-specific validity rules.
+`BaseTransactionValidator` enforces L1 data fee checks and Base-specific validity rules.
 `BaseOrdering` and `TimestampOrdering` provide customizable transaction prioritization strategies.
 Also includes a `Consumer` for processing mempool events, a `Forwarder` for relaying transactions,
 and a `BuilderApiImpl` for builder-specific pool management.
@@ -20,10 +20,10 @@ base-txpool = { workspace = true }
 ```
 
 ```rust,ignore
-use base_txpool::{BaseTransactionPool, OpTransactionValidator, BaseOrdering};
+use base_txpool::{BaseOrdering, BaseTransactionPool, BaseTransactionValidator};
 
 let pool = Pool::new(
-    OpTransactionValidator::new(client, evm),
+    BaseTransactionValidator::new(client, evm),
     BaseOrdering::default(),
     config,
 );

--- a/crates/execution/txpool/src/validator.rs
+++ b/crates/execution/txpool/src/validator.rs
@@ -155,7 +155,7 @@ where
     /// See also [`TransactionValidator::validate_transaction`]
     ///
     /// This behaves the same as [`EthTransactionValidator::validate_one_with_state`], but in
-    /// addition applies OP validity checks:
+    /// addition applies Base-specific validity checks:
     /// - ensures tx is not eip4844
     /// - ensures that the account has enough balance to cover the L1 gas cost
     pub async fn validate_one_with_state(
@@ -173,11 +173,11 @@ where
 
         let outcome = self.inner.validate_one_with_state(origin, transaction, state);
 
-        self.apply_op_checks(outcome)
+        self.apply_base_checks(outcome)
     }
 
     /// Performs the necessary Base-specific checks based on top of the regular eth outcome.
-    fn apply_op_checks(
+    fn apply_base_checks(
         &self,
         outcome: TransactionValidationOutcome<Tx>,
     ) -> TransactionValidationOutcome<Tx> {

--- a/crates/proof/succinct/programs/range/README.md
+++ b/crates/proof/succinct/programs/range/README.md
@@ -1,4 +1,4 @@
 # `range`
 
-This binary contains the client program for executing the Optimism rollup state transition across a range of blocks, which can be used to generate an on chain validity proof. Depending on the compilation pipeline, it will compile to be run either in native mode or in zkVM mode. In native mode, the data for verifying
+This binary contains the client program for executing the Optimism rollup state transition across a range of blocks, which can be used to generate an on-chain validity proof. Depending on the compilation pipeline, it will compile to be run either in native mode or in zkVM mode. In native mode, the data for verifying
 the batch validity is fetched from RPC, while in zkVM mode, the data is supplied by the host binary to the verifiable program.

--- a/crates/proof/succinct/programs/range/ethereum/src/main.rs
+++ b/crates/proof/succinct/programs/range/ethereum/src/main.rs
@@ -1,7 +1,7 @@
-//! A program to verify a Optimism L2 block STF with Ethereum DA in the zkVM.
+//! A program to verify an Optimism L2 block STF with Ethereum DA in the zkVM.
 //!
 //! This binary contains the client program for executing the Optimism rollup state transition
-//! across a range of blocks, which can be used to generate an on chain validity proof. Depending on
+//! across a range of blocks, which can be used to generate an on-chain validity proof. Depending on
 //! the compilation pipeline, it will compile to be run either in native mode or in zkVM mode. In
 //! native mode, the data for verifying the batch validity is fetched from RPC, while in zkVM mode,
 //! the data is supplied by the host binary to the verifiable program.

--- a/crates/proof/succinct/utils/client/src/boot.rs
+++ b/crates/proof/succinct/utils/client/src/boot.rs
@@ -1,5 +1,5 @@
 //! This module contains the prologue phase of the client program, pulling in the boot
-//! information, which is passed to the zkVM a public inputs to be verified on chain.
+//! information, which is passed to the zkVM as public inputs to be verified on-chain.
 
 use alloy_primitives::{B256, Bytes};
 use alloy_sol_types::sol;

--- a/crates/proof/zk/service/src/backends/utils.rs
+++ b/crates/proof/zk/service/src/backends/utils.rs
@@ -9,7 +9,7 @@ use tracing::debug;
 
 /// L2 output root at a specific block.
 #[derive(serde::Deserialize, Debug)]
-pub(super) struct OpOutputAtBlock {
+pub(super) struct OutputAtBlock {
     #[serde(rename = "blockRef")]
     pub block_ref: BlockRef,
 }
@@ -92,7 +92,7 @@ impl L1HeadCalculator {
     where
         OP: Provider<Base>,
     {
-        let response: OpOutputAtBlock = op_provider
+        let response: OutputAtBlock = op_provider
             .raw_request(
                 "optimism_outputAtBlock".into(),
                 (BlockNumberOrTag::Number(l2_block_number),),

--- a/docs/guides/P2P.md
+++ b/docs/guides/P2P.md
@@ -665,7 +665,7 @@ The Base transaction pool is defined in
 extends reth's standard transaction pool with rollup-specific validation and ordering.
 
 The
-[`OpTransactionValidator`](https://github.com/base/base/blob/main/crates/execution/txpool/src/validator.rs)
+[`BaseTransactionValidator`](https://github.com/base/base/blob/main/crates/execution/txpool/src/validator.rs)
 wraps reth's `EthTransactionValidator` and adds L1 data gas fee checks. Every transaction on Base
 incurs both an L2 execution gas cost and an L1 data fee (the cost of posting the transaction data to
 Ethereum L1). The validator ensures that the sender's balance covers both fees. It also rejects
@@ -814,7 +814,7 @@ networks are completely separate and serve different purposes.
 
 -
   [`crates/execution/txpool/src/validator.rs`](https://github.com/base/base/blob/main/crates/execution/txpool/src/validator.rs)
-  — OpTransactionValidator with L1 data gas checks
+  — BaseTransactionValidator with L1 data gas checks
 -
   [`crates/execution/txpool/src/ordering.rs`](https://github.com/base/base/blob/main/crates/execution/txpool/src/ordering.rs)
   — BaseOrdering (fee-based vs FIFO)

--- a/docs/specs/pages/index.md
+++ b/docs/specs/pages/index.md
@@ -21,4 +21,5 @@ Our aim is to design a protocol specification that is:
 ## Lineage
 
 Base Chain inherits Ethereum's EVM semantics, transaction rules, and L1-anchored security. It was
-originally built on the [OP Stack](https://specs.optimism.io). After the Jovian Hardfork, Base Chain follows this specification.
+originally built on the [OP Stack](https://specs.optimism.io). After the Jovian Hardfork, Base
+Chain follows this specification.

--- a/docs/specs/pages/protocol/bridging/withdrawals.md
+++ b/docs/specs/pages/protocol/bridging/withdrawals.md
@@ -112,7 +112,7 @@ recognize that having the same address does not imply that a contract on L2 will
 
 ## The Optimism Portal Contract
 
-The Optimism Portal serves as both the entry and exit point to the Optimism L2. It is a contract which inherits from
+The Optimism Portal serves as both the entry and exit point to the Optimism L2. It is a contract that inherits from
 the [OptimismPortal](deposits.md#deposit-contract) contract, and in addition provides the following interface for
 withdrawals:
 

--- a/docs/specs/pages/protocol/consensus/p2p.md
+++ b/docs/specs/pages/protocol/consensus/p2p.md
@@ -51,7 +51,7 @@ The Ethereum Node Record (ENR) for a Base rollup node must contain the following
 - An IPv4 address (`ip` field) and/or IPv6 address (`ip6` field).
 - A TCP port (`tcp` field) representing the local libp2p listening port.
 - A UDP port (`udp` field) representing the local discv5 listening port.
-- An OpStack (`opstack` field) L2 network identifier
+- An OP Stack (`opstack` field) L2 network identifier.
 
 The `opstack` value is encoded as a single RLP `bytes` value, the concatenation of:
 
@@ -59,7 +59,8 @@ The `opstack` value is encoded as a single RLP `bytes` value, the concatenation 
 - fork ID (`unsigned varint`)
 
 Note that DiscV5 is a shared DHT (Distributed Hash Table): the L1 consensus and execution nodes,
-as well as testnet nodes, and even external IOT nodes, all communicate records in this large common DHT.
+as well as testnet nodes and even external IoT nodes, all communicate records in this large common
+DHT.
 This makes it more difficult to censor the discovery of node records.
 
 The discovery process in Base is a pipeline of node records:

--- a/docs/specs/pages/upgrades/azul/overview.md
+++ b/docs/specs/pages/upgrades/azul/overview.md
@@ -4,7 +4,8 @@
 
 :::warning
 Only `base-consensus` and `base-reth-node` will support the Base Azul hardfork. If you are running
-`op-node`, `op-geth` or any other clients you will need to update prior to the activation date.
+`op-node`, `op-geth`, or any other clients, you will need to update them prior to the activation
+date.
 :::
 
 - Add Osaka Support

--- a/docs/specs/pages/upgrades/pectra-blob-schedule/derivation.md
+++ b/docs/specs/pages/upgrades/pectra-blob-schedule/derivation.md
@@ -18,11 +18,11 @@ at any given L1 block will apply to the L1 Attributes Deposited Transaction.
 
 ## Motivation and Rationale
 
-Due to a consensus layer bug, OPStack chains on Holesky and Sepolia running officially released op-node software
+Due to a consensus layer bug, OP Stack chains on Holesky and Sepolia running officially released op-node software
 did not update their blob base fee update fraction (for L1 Attributes Deposited Transaction)
 in tandem with the Prague upgrade on L1.
 
-These chains, or any OPStack chain with a sequencer running
+These chains, or any OP Stack chain with a sequencer running
 the buggy consensus code[^1] when Holesky/Sepolia activated Pectra,
 will have an inaccurate blob base fee in the [L1Block](../../protocol/execution/evm/predeploys.md#l1block) contract.
 This optional fork is a mechanism to bring those chains back in line.


### PR DESCRIPTION
## Summary

This PR replaces residual "OP", "Op-stack", and "op_" naming with Base-specific equivalents across documentation, code comments, and internal identifiers throughout the workspace. Changes include renaming `OpMinerMetrics` to `BaseMinerMetrics`, `apply_op_checks` to `apply_base_checks`, local variable `op_receipt` to `base_receipt`, and updating dozens of doc-comment phrases that still referred to the OP stack or OP payload builder. Grammar fixes in doc comments (e.g., "maps for" → "maps to", "sharable" → "shareable") are included where they were encountered during the sweep.