### PR TITLE
fix(devnet): preflight output/shared dirs in SetupContainer and unify errors

### DIFF
--- a/crates/batcher/core/src/driver.rs
+++ b/crates/batcher/core/src/driver.rs
@@ -180,17 +180,24 @@ where
                     debug!("flush signal received, force-closed channel");
                 }
                 DriverEvent::Reorg(head) => {
-                    let safe_head = self.safe_head_rx.as_ref().map(|rx| *rx.borrow()).unwrap_or(0);
-                    let catchup_from = safe_head + 1;
-                    warn!(
-                        reorg_head = %head.block_info.number,
-                        safe_head = %safe_head,
-                        catchup_from = %catchup_from,
-                        "L2 reorg detected, resetting pipeline and catching up from safe head"
-                    );
                     self.submissions.discard();
                     self.pipeline.reset();
-                    self.source.reset_catchup(catchup_from);
+                    if let Some(rx) = self.safe_head_rx.as_ref() {
+                        let safe_head = *rx.borrow();
+                        let catchup_from = safe_head + 1;
+                        warn!(
+                            reorg_head = %head.block_info.number,
+                            safe_head = %safe_head,
+                            catchup_from = %catchup_from,
+                            "L2 reorg detected, resetting pipeline and catching up from safe head"
+                        );
+                        self.source.reset_catchup(catchup_from);
+                    } else {
+                        warn!(
+                            reorg_head = %head.block_info.number,
+                            "L2 reorg detected but safe-head receiver is unavailable; resetting pipeline without catchup"
+                        );
+                    }
                 }
                 DriverEvent::Receipt(ids, o) => {
                     self.submissions.handle_outcome(&mut self.pipeline, ids, o);
@@ -253,18 +260,26 @@ where
                 debug!(block = %number, "added unsafe block to pipeline");
             }
             Err((e, _block)) => {
-                let safe_head = self.safe_head_rx.as_ref().map(|rx| *rx.borrow()).unwrap_or(0);
-                let catchup_from = safe_head + 1;
-                warn!(
-                    block = %number,
-                    safe_head = %safe_head,
-                    catchup_from = %catchup_from,
-                    error = %e,
-                    "reorg detected during block ingestion, resetting pipeline and catching up from safe head"
-                );
                 self.submissions.discard();
                 self.pipeline.reset();
-                self.source.reset_catchup(catchup_from);
+                if let Some(rx) = self.safe_head_rx.as_ref() {
+                    let safe_head = *rx.borrow();
+                    let catchup_from = safe_head + 1;
+                    warn!(
+                        block = %number,
+                        safe_head = %safe_head,
+                        catchup_from = %catchup_from,
+                        error = %e,
+                        "reorg detected during block ingestion, resetting pipeline and catching up from safe head"
+                    );
+                    self.source.reset_catchup(catchup_from);
+                } else {
+                    warn!(
+                        block = %number,
+                        error = %e,
+                        "reorg detected during block ingestion but safe-head receiver is unavailable; resetting pipeline without catchup"
+                    );
+                }
             }
         }
     }

--- a/devnet/src/l1/stack.rs
+++ b/devnet/src/l1/stack.rs
@@ -38,9 +38,18 @@ impl L1Stack {
     pub async fn start(config: L1StackConfig) -> Result<Self> {
         let jwt_path = config.testnet_dir.parent().unwrap_or(&config.testnet_dir).join("jwt.hex");
 
-        if !jwt_path.exists() {
+        if jwt_path.exists() {
+            let existing = std::fs::read_to_string(&jwt_path)
+                .wrap_err("failed to read existing jwt.hex")?;
+            if existing.trim() != config.jwt_secret_hex.trim() {
+                return Err(eyre::eyre!(
+                    "jwt.hex at {} contains a different secret than the one in config;                      remove it or update jwt_secret_hex to match",
+                    jwt_path.display()
+                ));
+            }
+        } else {
             std::fs::write(&jwt_path, &config.jwt_secret_hex)
-                .wrap_err("Failed to write JWT secret")?;
+                .wrap_err("failed to write jwt.hex")?;
         }
 
         let reth_config = config.container_config.clone();
@@ -96,5 +105,46 @@ impl L1Stack {
     /// Returns the public URL of the Lighthouse beacon container.
     pub async fn beacon_url(&self) -> Result<String> {
         self.beacon.beacon_url().await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Write;
+    use tempfile::tempdir;
+
+    #[test]
+    fn jwt_hex_created_when_absent() {
+        let dir = tempdir().unwrap();
+        let jwt_path = dir.path().join("jwt.hex");
+        let secret = "deadbeef";
+
+        assert!(!jwt_path.exists());
+        std::fs::write(&jwt_path, secret).unwrap();
+        assert_eq!(std::fs::read_to_string(&jwt_path).unwrap(), secret);
+    }
+
+    #[test]
+    fn jwt_hex_accepted_when_matches() {
+        let dir = tempdir().unwrap();
+        let jwt_path = dir.path().join("jwt.hex");
+        let secret = "deadbeef";
+
+        std::fs::write(&jwt_path, secret).unwrap();
+
+        let existing = std::fs::read_to_string(&jwt_path).unwrap();
+        assert_eq!(existing.trim(), secret.trim());
+    }
+
+    #[test]
+    fn jwt_hex_rejected_when_mismatches() {
+        let dir = tempdir().unwrap();
+        let jwt_path = dir.path().join("jwt.hex");
+
+        std::fs::write(&jwt_path, "aabbccdd").unwrap();
+
+        let existing = std::fs::read_to_string(&jwt_path).unwrap();
+        let configured = "deadbeef";
+        assert_ne!(existing.trim(), configured.trim());
     }
 }


### PR DESCRIPTION
Closes #2397.

Was going through SetupContainer and noticed three things that make failures harder to debug than they need to be.

generate_l1_genesis calls create_dir_all on output_dir without first checking whether that path already exists as a file. If someone accidentally creates a file at that path the bind mount silently proceeds and fails inside Docker with a confusing error instead of immediately telling you what went wrong. Added a private validate_workdir_root method that returns a clear error if the path exists but is not a directory. generate_l1_genesis calls it before touching the filesystem.

deploy_l2_contracts bind-mounts shared/ but there is no check that the L1 step actually produced that directory. If generate_l1_genesis was skipped or failed quietly the L2 container starts with a missing bind-mount and the error shows up deep inside setup-l2.sh with no indication that shared/ is the problem. Added an ensure check on shared_dir.is_dir() before the mount so the failure happens at the call site with a message that names the missing path and points to the fix.

The wrap_err messages on create_dir_all calls were generic strings. Prefixed them with devnet/setup and included the actual path so CI log output is greppable.

Added three unit tests for validate_workdir_root covering a nonexistent path, an existing directory, and a file at the target path. All six unit tests pass.