### PR TITLE
perf: optimize batcher hot paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2922,6 +2922,7 @@ dependencies = [
  "base-protocol",
  "base-runtime",
  "base-tx-manager",
+ "criterion",
  "derive_more 2.1.1",
  "eyre",
  "futures",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2892,6 +2892,7 @@ dependencies = [
  "base-metrics",
  "base-protocol",
  "clap",
+ "criterion",
  "metrics",
  "rand 0.9.4",
  "rstest",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3713,6 +3713,7 @@ dependencies = [
  "base-metrics",
  "base-protocol",
  "bytes",
+ "criterion",
  "derive_more 2.1.1",
  "discv5",
  "futures",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5415,6 +5415,7 @@ dependencies = [
  "base-common-rpc-types",
  "base-common-rpc-types-engine",
  "brotli",
+ "criterion",
  "derive_more 2.1.1",
  "miniz_oxide 0.9.1",
  "proptest",

--- a/crates/batcher/encoder/Cargo.toml
+++ b/crates/batcher/encoder/Cargo.toml
@@ -26,8 +26,13 @@ base-common-genesis = { workspace = true, features = ["std"] }
 clap = { workspace = true, features = ["derive"], optional = true }
 
 [dev-dependencies]
+criterion.workspace = true
 rstest.workspace = true
 alloy-consensus = { workspace = true, features = ["std"] }
+
+[[bench]]
+name = "da_backlog"
+harness = false
 
 [features]
 clap = [ "dep:clap" ]

--- a/crates/batcher/encoder/benches/da_backlog.rs
+++ b/crates/batcher/encoder/benches/da_backlog.rs
@@ -1,0 +1,85 @@
+//! Benchmarks for [`BatchEncoder::da_backlog_bytes`].
+
+use std::{hint::black_box, sync::Arc};
+
+use alloy_consensus::{BlockBody, Header, SignableTransaction, TxLegacy};
+use alloy_primitives::{B256, Bytes, Sealed, Signature};
+use base_batcher_encoder::{BatchEncoder, BatchPipeline, EncoderConfig};
+use base_common_consensus::{BaseBlock, BaseTxEnvelope, TxDeposit};
+use base_common_genesis::RollupConfig;
+use base_protocol::{L1BlockInfoBedrock, L1BlockInfoTx};
+use criterion::{Criterion, criterion_group, criterion_main};
+
+const BLOCK_COUNT: usize = 4_096;
+const USER_TXS_PER_BLOCK: usize = 8;
+const USER_TX_INPUT_BYTES: usize = 512;
+
+fn make_deposit_tx() -> BaseTxEnvelope {
+    let calldata = L1BlockInfoTx::Bedrock(L1BlockInfoBedrock::default()).encode_calldata();
+    BaseTxEnvelope::Deposit(Sealed::new(TxDeposit { input: calldata, ..Default::default() }))
+}
+
+fn make_user_tx(seed: u64) -> BaseTxEnvelope {
+    let tx = TxLegacy {
+        nonce: seed,
+        input: Bytes::from(vec![seed as u8; USER_TX_INPUT_BYTES]),
+        ..Default::default()
+    };
+    BaseTxEnvelope::Legacy(tx.into_signed(Signature::test_signature()))
+}
+
+fn make_block(parent_hash: B256, number: u64) -> BaseBlock {
+    let mut transactions = Vec::with_capacity(1 + USER_TXS_PER_BLOCK);
+    transactions.push(make_deposit_tx());
+    transactions
+        .extend((0..USER_TXS_PER_BLOCK).map(|offset| make_user_tx(number * 100 + offset as u64)));
+
+    BaseBlock {
+        header: Header { parent_hash, number, ..Default::default() },
+        body: BlockBody { transactions, ..Default::default() },
+    }
+}
+
+fn encoder_with_backlog(encoded_blocks: usize) -> BatchEncoder {
+    let config = EncoderConfig { target_frame_size: usize::MAX / 4, ..EncoderConfig::default() };
+    let mut encoder = BatchEncoder::new(Arc::new(RollupConfig::default()), config);
+
+    let mut parent_hash = B256::ZERO;
+    for number in 0..BLOCK_COUNT as u64 {
+        let block = make_block(parent_hash, number);
+        parent_hash = block.header.hash_slow();
+        encoder.add_block(block).unwrap();
+    }
+
+    for _ in 0..encoded_blocks {
+        encoder.step().unwrap();
+    }
+
+    encoder
+}
+
+fn bench_da_backlog_bytes(c: &mut Criterion) {
+    let mut group = c.benchmark_group("batcher_encoder/da_backlog_bytes");
+    group.sample_size(20);
+
+    let full_backlog = encoder_with_backlog(0);
+    group.bench_function("4096_blocks_pending", |b| {
+        b.iter(|| {
+            let encoder = black_box(&full_backlog);
+            black_box(encoder.da_backlog_bytes());
+        });
+    });
+
+    let partially_encoded = encoder_with_backlog(BLOCK_COUNT / 2);
+    group.bench_function("4096_blocks_half_encoded", |b| {
+        b.iter(|| {
+            let encoder = black_box(&partially_encoded);
+            black_box(encoder.da_backlog_bytes());
+        });
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_da_backlog_bytes);
+criterion_main!(benches);

--- a/crates/batcher/encoder/src/encoder.rs
+++ b/crates/batcher/encoder/src/encoder.rs
@@ -36,6 +36,11 @@ pub struct BatchEncoder {
     l1_head: u64,
     /// L2 blocks waiting to be encoded. Pruned when all their frames are confirmed.
     blocks: VecDeque<BaseBlock>,
+    /// Cached byte size of the DA backlog represented by unencoded queued blocks.
+    ///
+    /// Updated eagerly when blocks are added, encoded, or discarded so
+    /// [`BatchPipeline::da_backlog_bytes`] stays O(1) even for large backlogs.
+    da_backlog_bytes: u64,
     /// Index into `blocks`: next block not yet fed into the current channel.
     block_cursor: usize,
     /// Hash of the last block's header (or `B256::ZERO` if empty). Used for reorg detection.
@@ -76,6 +81,7 @@ impl fmt::Debug for BatchEncoder {
         f.debug_struct("BatchEncoder")
             .field("l1_head", &self.l1_head)
             .field("blocks_len", &self.blocks.len())
+            .field("da_backlog_bytes", &self.da_backlog_bytes)
             .field("block_cursor", &self.block_cursor)
             .field("tip", &self.tip)
             .field("current_channel", &self.current_channel)
@@ -102,6 +108,7 @@ impl BatchEncoder {
             config,
             l1_head: 0,
             blocks: VecDeque::new(),
+            da_backlog_bytes: 0,
             block_cursor: 0,
             tip: B256::ZERO,
             current_channel: None,
@@ -316,6 +323,17 @@ impl BatchEncoder {
             Some(OpenChannel { out: channel_out, opened_at_l1: self.l1_head, blocks_added: 0 });
     }
 
+    /// Returns the estimated DA backlog contribution of a queued block.
+    fn block_da_backlog_bytes(block: &BaseBlock) -> u64 {
+        block
+            .body
+            .transactions
+            .iter()
+            .filter(|tx| !matches!(tx, BaseTxEnvelope::Deposit(_)))
+            .map(|tx| tx.encode_2718_len() as u64)
+            .sum()
+    }
+
     /// Check if the current channel (or span accumulator) has timed out and close it if so.
     fn check_channel_timeout(&mut self) -> bool {
         // Apply the safety margin so channels are closed `sub_safety_margin` L1 blocks
@@ -360,7 +378,9 @@ impl BatchPipeline for BatchEncoder {
 
         let number = block.header.number;
         let hash = block.header.hash_slow();
+        let backlog_bytes = Self::block_da_backlog_bytes(&block);
         self.tip = hash;
+        self.da_backlog_bytes += backlog_bytes;
         self.blocks.push_back(block);
         BatcherMetrics::pending_blocks().increment(1.0);
 
@@ -382,6 +402,7 @@ impl BatchPipeline for BatchEncoder {
 
         // Get the block at the cursor.
         let block = &self.blocks[self.block_cursor];
+        let block_da_backlog_bytes = Self::block_da_backlog_bytes(block);
 
         // Convert block to a SingleBatch. Failure here is fatal: skipping the block
         // would produce a gap in the L2 block sequence submitted to L1.
@@ -400,6 +421,8 @@ impl BatchPipeline for BatchEncoder {
                 self.span_raw_bytes += block_raw_bytes;
                 self.span_accumulator.push((single_batch, seq_num));
                 self.block_cursor += 1;
+                self.da_backlog_bytes =
+                    self.da_backlog_bytes.saturating_sub(block_da_backlog_bytes);
 
                 // Track the L1 head at which the first block of this span was accumulated.
                 // `check_channel_timeout()` uses this to detect when the span has been open
@@ -455,6 +478,8 @@ impl BatchPipeline for BatchEncoder {
                     Ok(()) => {
                         open.blocks_added += 1;
                         self.block_cursor += 1;
+                        self.da_backlog_bytes =
+                            self.da_backlog_bytes.saturating_sub(block_da_backlog_bytes);
 
                         debug!(
                             block_cursor = self.block_cursor,
@@ -674,6 +699,7 @@ impl BatchPipeline for BatchEncoder {
             "resetting encoder pipeline (reorg or explicit reset)"
         );
         self.blocks.clear();
+        self.da_backlog_bytes = 0;
         self.block_cursor = 0;
         self.tip = B256::ZERO;
         self.current_channel = None;
@@ -722,13 +748,7 @@ impl BatchPipeline for BatchEncoder {
     }
 
     fn da_backlog_bytes(&self) -> u64 {
-        self.blocks
-            .iter()
-            .skip(self.block_cursor)
-            .flat_map(|b| &b.body.transactions)
-            .filter(|tx| !matches!(tx, BaseTxEnvelope::Deposit(_)))
-            .map(|tx| tx.encode_2718_len() as u64)
-            .sum()
+        self.da_backlog_bytes
     }
 
     fn set_blob_override(&mut self, active: bool) {
@@ -884,6 +904,33 @@ mod tests {
         let backlog = encoder.da_backlog_bytes();
         // The backlog should only count the user tx, not the deposit.
         assert!(backlog > 0);
+    }
+
+    #[test]
+    fn test_da_backlog_cache_tracks_encoding_lifecycle() {
+        let mut encoder = default_encoder();
+
+        let block1 = make_block_with_user_tx(B256::ZERO);
+        let block1_hash = block1.header.hash_slow();
+        let block2 = make_block_with_user_tx(block1_hash);
+
+        encoder.add_block(block1).unwrap();
+        let backlog_after_first_add = encoder.da_backlog_bytes();
+        assert_eq!(encoder.da_backlog_bytes, backlog_after_first_add);
+
+        encoder.add_block(block2).unwrap();
+        let backlog_after_second_add = encoder.da_backlog_bytes();
+        assert!(backlog_after_second_add > backlog_after_first_add);
+        assert_eq!(encoder.da_backlog_bytes, backlog_after_second_add);
+
+        encoder.step().unwrap();
+        let backlog_after_encode = encoder.da_backlog_bytes();
+        assert!(backlog_after_encode < backlog_after_second_add);
+        assert_eq!(encoder.da_backlog_bytes, backlog_after_encode);
+
+        encoder.reset();
+        assert_eq!(encoder.da_backlog_bytes(), 0);
+        assert_eq!(encoder.da_backlog_bytes, 0);
     }
 
     #[test]

--- a/crates/batcher/service/Cargo.toml
+++ b/crates/batcher/service/Cargo.toml
@@ -47,7 +47,12 @@ metrics = [
 
 [dev-dependencies]
 httpmock.workspace = true
+criterion.workspace = true
 alloy-rlp.workspace = true
 alloy-eips.workspace = true
 miniz_oxide.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+
+[[bench]]
+name = "recent_txs"
+harness = false

--- a/crates/batcher/service/benches/recent_txs.rs
+++ b/crates/batcher/service/benches/recent_txs.rs
@@ -36,6 +36,13 @@ const MIXED_BACK_LOADED_READY_COHORTS: [ReadyTransitionCohort; 5] = [
     ReadyTransitionCohort { start_block: 0, ready_block: 3, channel_count: 256 },
     ReadyTransitionCohort { start_block: 2, ready_block: 3, channel_count: 256 },
 ];
+const MATCHED_VOLUME_BACK_LOADED_READY_COHORTS: [ReadyTransitionCohort; 5] = [
+    ReadyTransitionCohort { start_block: 0, ready_block: 0, channel_count: 128 },
+    ReadyTransitionCohort { start_block: 0, ready_block: 1, channel_count: 128 },
+    ReadyTransitionCohort { start_block: 0, ready_block: 2, channel_count: 256 },
+    ReadyTransitionCohort { start_block: 0, ready_block: 3, channel_count: 384 },
+    ReadyTransitionCohort { start_block: 1, ready_block: 3, channel_count: 128 },
+];
 
 #[derive(Clone, Copy, Debug)]
 struct ReadyTransitionCohort {
@@ -1334,6 +1341,126 @@ fn bench_recent_tx_process_blocks_touch_start_sparsity(c: &mut Criterion) {
     group.finish();
 }
 
+fn bench_recent_tx_process_blocks_touch_start_matched_volume(c: &mut Criterion) {
+    let mut group =
+        c.benchmark_group("batcher_service/recent_txs/process_blocks_touch_start_matched_volume");
+    group.sample_size(15);
+
+    let rollup_config = test_rollup_config();
+    let dense_start_block_tx_payloads =
+        multi_block_weighted_ready_tx_payloads(&BACK_LOADED_READY_CHANNEL_COUNTS);
+    let matched_volume_sparse_start_block_tx_payloads = multi_block_cohort_ready_tx_payloads(
+        MIXED_READY_BLOCK_COUNT,
+        &MATCHED_VOLUME_BACK_LOADED_READY_COHORTS,
+    );
+
+    group.bench_function(
+        "baseline_vec_scan_all_dense_start_back_loaded_4_blocks_1024_channels_matched_volume",
+        |b| {
+            b.iter_batched(
+                HashMap::new,
+                |mut channels| {
+                    black_box(process_blocks_with_vec_tracking_and_full_scan(
+                        black_box(&mut channels),
+                        black_box(&dense_start_block_tx_payloads),
+                        black_box(&rollup_config),
+                    ));
+                    black_box(channels)
+                },
+                BatchSize::SmallInput,
+            );
+        },
+    );
+    group.bench_function(
+        "fresh_tracker_dense_start_back_loaded_4_blocks_1024_channels_matched_volume",
+        |b| {
+            b.iter_batched(
+                HashMap::new,
+                |mut channels| {
+                    black_box(process_blocks_with_fresh_tracker_and_touched_only_drain(
+                        black_box(&mut channels),
+                        black_box(&dense_start_block_tx_payloads),
+                        black_box(&rollup_config),
+                    ));
+                    black_box(channels)
+                },
+                BatchSize::SmallInput,
+            );
+        },
+    );
+    group.bench_function(
+        "reused_tracker_dense_start_back_loaded_4_blocks_1024_channels_matched_volume",
+        |b| {
+            b.iter_batched(
+                HashMap::new,
+                |mut channels| {
+                    black_box(process_blocks_with_tracker_and_touched_only_drain(
+                        black_box(&mut channels),
+                        black_box(&dense_start_block_tx_payloads),
+                        black_box(&rollup_config),
+                    ));
+                    black_box(channels)
+                },
+                BatchSize::SmallInput,
+            );
+        },
+    );
+
+    group.bench_function(
+        "baseline_vec_scan_all_matched_volume_sparse_start_back_loaded_4_blocks_1024_channels",
+        |b| {
+            b.iter_batched(
+                HashMap::new,
+                |mut channels| {
+                    black_box(process_blocks_with_vec_tracking_and_full_scan(
+                        black_box(&mut channels),
+                        black_box(&matched_volume_sparse_start_block_tx_payloads),
+                        black_box(&rollup_config),
+                    ));
+                    black_box(channels)
+                },
+                BatchSize::SmallInput,
+            );
+        },
+    );
+    group.bench_function(
+        "fresh_tracker_matched_volume_sparse_start_back_loaded_4_blocks_1024_channels",
+        |b| {
+            b.iter_batched(
+                HashMap::new,
+                |mut channels| {
+                    black_box(process_blocks_with_fresh_tracker_and_touched_only_drain(
+                        black_box(&mut channels),
+                        black_box(&matched_volume_sparse_start_block_tx_payloads),
+                        black_box(&rollup_config),
+                    ));
+                    black_box(channels)
+                },
+                BatchSize::SmallInput,
+            );
+        },
+    );
+    group.bench_function(
+        "reused_tracker_matched_volume_sparse_start_back_loaded_4_blocks_1024_channels",
+        |b| {
+            b.iter_batched(
+                HashMap::new,
+                |mut channels| {
+                    black_box(process_blocks_with_tracker_and_touched_only_drain(
+                        black_box(&mut channels),
+                        black_box(&matched_volume_sparse_start_block_tx_payloads),
+                        black_box(&rollup_config),
+                    ));
+                    black_box(channels)
+                },
+                BatchSize::SmallInput,
+            );
+        },
+    );
+
+    group.finish();
+}
+
 criterion_group!(
     benches,
     bench_recent_tx_ready_channel_lookup,
@@ -1346,5 +1473,6 @@ criterion_group!(
     bench_recent_tx_process_blocks_weighted_ready,
     bench_recent_tx_process_blocks_mixed_ready,
     bench_recent_tx_process_blocks_touch_start_sparsity,
+    bench_recent_tx_process_blocks_touch_start_matched_volume,
 );
 criterion_main!(benches);

--- a/crates/batcher/service/benches/recent_txs.rs
+++ b/crates/batcher/service/benches/recent_txs.rs
@@ -142,6 +142,17 @@ fn track_touched_channel_ids_with_tracker(frame_channel_ids: &[ChannelId]) -> Ve
     tracker.touched_channel_ids().to_vec()
 }
 
+fn track_touched_channel_ids_with_reused_tracker(
+    tracker: &mut TouchedChannelTracker,
+    frame_channel_ids: &[ChannelId],
+) -> Vec<ChannelId> {
+    tracker.reset_with_capacity(frame_channel_ids.len());
+    for channel_id in frame_channel_ids {
+        tracker.record(*channel_id);
+    }
+    tracker.touched_channel_ids().to_vec()
+}
+
 fn bench_recent_tx_drain_ready_channels(c: &mut Criterion) {
     let mut group = c.benchmark_group("batcher_service/recent_txs/drain_ready_channels");
     group.sample_size(20);
@@ -304,6 +315,15 @@ fn bench_recent_tx_track_touched_channel_ids(c: &mut Criterion) {
     group.bench_function("hashset_tracker_4096_unique_frame_channel_ids", |b| {
         b.iter(|| black_box(track_touched_channel_ids_with_tracker(black_box(&unique_frame_ids))));
     });
+    let mut reused_unique_tracker = TouchedChannelTracker::with_capacity(unique_frame_ids.len());
+    group.bench_function("reused_hashset_tracker_4096_unique_frame_channel_ids", |b| {
+        b.iter(|| {
+            black_box(track_touched_channel_ids_with_reused_tracker(
+                black_box(&mut reused_unique_tracker),
+                black_box(&unique_frame_ids),
+            ))
+        });
+    });
 
     let duplicate_fanout_frame_ids = duplicate_fanout_frame_channel_ids();
     group.bench_function("baseline_vec_scan_4096_frames_across_512_unique_channel_ids", |b| {
@@ -316,6 +336,16 @@ fn bench_recent_tx_track_touched_channel_ids(c: &mut Criterion) {
             black_box(track_touched_channel_ids_with_tracker(black_box(
                 &duplicate_fanout_frame_ids,
             )))
+        });
+    });
+    let mut reused_duplicate_tracker =
+        TouchedChannelTracker::with_capacity(duplicate_fanout_frame_ids.len());
+    group.bench_function("reused_hashset_tracker_4096_frames_across_512_unique_channel_ids", |b| {
+        b.iter(|| {
+            black_box(track_touched_channel_ids_with_reused_tracker(
+                black_box(&mut reused_duplicate_tracker),
+                black_box(&duplicate_fanout_frame_ids),
+            ))
         });
     });
 

--- a/crates/batcher/service/benches/recent_txs.rs
+++ b/crates/batcher/service/benches/recent_txs.rs
@@ -1,0 +1,268 @@
+//! Benchmarks for recent-transaction startup scan channel draining.
+
+use std::hint::black_box;
+
+use alloy_eips::eip1898::BlockNumHash;
+use alloy_primitives::B256;
+use alloy_rlp::Encodable;
+use base_batcher_service::RecentTxScanner;
+use base_common_genesis::{ChainGenesis, RollupConfig};
+use base_protocol::{Batch, BlockInfo, Channel, ChannelId, Frame, SingleBatch};
+use criterion::{BatchSize, Criterion, criterion_group, criterion_main};
+
+const READY_CHANNEL_COUNT: usize = 4_096;
+const SPARSE_TOUCHED_CHANNEL_COUNT: usize = 64;
+
+fn test_rollup_config() -> RollupConfig {
+    RollupConfig {
+        genesis: ChainGenesis {
+            l2: BlockNumHash { number: 1_000, hash: B256::ZERO },
+            l2_time: 1_000,
+            ..Default::default()
+        },
+        block_time: 2,
+        ..Default::default()
+    }
+}
+
+fn encode_single_batch(batch: &SingleBatch) -> Vec<u8> {
+    let typed_batch = Batch::Single(batch.clone());
+    let mut batch_bytes = Vec::new();
+    typed_batch.encode(&mut batch_bytes).expect("batch must encode");
+
+    let mut rlp_buf = Vec::new();
+    batch_bytes.as_slice().encode(&mut rlp_buf);
+    miniz_oxide::deflate::compress_to_vec_zlib(&rlp_buf, 6)
+}
+
+fn ready_channel(id: ChannelId, timestamp: u64) -> Channel {
+    let block_info = BlockInfo::default();
+    let mut channel = Channel::new(id, block_info);
+    channel
+        .add_frame(
+            Frame {
+                id,
+                number: 0,
+                data: encode_single_batch(&SingleBatch { timestamp, ..Default::default() }),
+                is_last: true,
+            },
+            block_info,
+        )
+        .expect("frame must be accepted");
+    channel
+}
+
+fn incomplete_channel(id: ChannelId) -> Channel {
+    let block_info = BlockInfo::default();
+    let mut channel = Channel::new(id, block_info);
+    channel
+        .add_frame(Frame { id, number: 0, data: b"partial".to_vec(), is_last: false }, block_info)
+        .expect("frame must be accepted");
+    channel
+}
+
+fn channel_id(seed: usize) -> ChannelId {
+    let mut id = [0u8; 16];
+    id[..8].copy_from_slice(&(seed as u64).to_be_bytes());
+    id
+}
+
+fn mixed_channel_map() -> std::collections::HashMap<ChannelId, Channel> {
+    let mut channels = std::collections::HashMap::with_capacity(READY_CHANNEL_COUNT * 2);
+    for index in 0..READY_CHANNEL_COUNT {
+        channels.insert(channel_id(index), ready_channel(channel_id(index), 1_010 + index as u64 * 2));
+        channels.insert(
+            channel_id(index + READY_CHANNEL_COUNT),
+            incomplete_channel(channel_id(index + READY_CHANNEL_COUNT)),
+        );
+    }
+    channels
+}
+
+fn incomplete_channel_map() -> std::collections::HashMap<ChannelId, Channel> {
+    let mut channels = std::collections::HashMap::with_capacity(READY_CHANNEL_COUNT * 2);
+    for index in 0..READY_CHANNEL_COUNT * 2 {
+        channels.insert(channel_id(index), incomplete_channel(channel_id(index)));
+    }
+    channels
+}
+
+fn sparse_ready_channel_map() -> std::collections::HashMap<ChannelId, Channel> {
+    let mut channels = std::collections::HashMap::with_capacity(READY_CHANNEL_COUNT * 2);
+    for index in 0..SPARSE_TOUCHED_CHANNEL_COUNT {
+        channels.insert(channel_id(index), ready_channel(channel_id(index), 1_010 + index as u64 * 2));
+    }
+    for index in SPARSE_TOUCHED_CHANNEL_COUNT..READY_CHANNEL_COUNT * 2 {
+        channels.insert(channel_id(index), incomplete_channel(channel_id(index)));
+    }
+    channels
+}
+
+fn touched_ready_ids() -> Vec<ChannelId> {
+    (0..READY_CHANNEL_COUNT).map(channel_id).collect()
+}
+
+fn touched_incomplete_ids() -> Vec<ChannelId> {
+    (0..READY_CHANNEL_COUNT).map(channel_id).collect()
+}
+
+fn touched_sparse_ids() -> Vec<ChannelId> {
+    (0..SPARSE_TOUCHED_CHANNEL_COUNT).map(channel_id).collect()
+}
+
+fn bench_recent_tx_drain_ready_channels(c: &mut Criterion) {
+    let mut group = c.benchmark_group("batcher_service/recent_txs/drain_ready_channels");
+    group.sample_size(20);
+
+    let rollup_config = test_rollup_config();
+    let ready_ids = touched_ready_ids();
+    group.bench_function("baseline_scan_all_with_4096_ready_and_4096_incomplete", |b| {
+        b.iter_batched(
+            mixed_channel_map,
+            |mut channels| {
+                let mut highest = None;
+                RecentTxScanner::drain_all_ready_channels(
+                    black_box(&mut channels),
+                    black_box(0),
+                    black_box(&rollup_config),
+                    black_box(&mut highest),
+                );
+                black_box((channels, highest));
+            },
+            BatchSize::SmallInput,
+        );
+    });
+
+    group.bench_function("4096_touched_ready_among_8192_channels", |b| {
+        b.iter_batched(
+            mixed_channel_map,
+            |mut channels| {
+                let mut highest = None;
+                RecentTxScanner::drain_ready_channels(
+                    black_box(&mut channels),
+                    black_box(&ready_ids),
+                    black_box(0),
+                    black_box(&rollup_config),
+                    black_box(&mut highest),
+                );
+                black_box((channels, highest));
+            },
+            BatchSize::SmallInput,
+        );
+    });
+
+    let incomplete_ids = touched_incomplete_ids();
+    group.bench_function("baseline_scan_all_with_8192_incomplete", |b| {
+        b.iter_batched(
+            incomplete_channel_map,
+            |mut channels| {
+                let mut highest = None;
+                RecentTxScanner::drain_all_ready_channels(
+                    black_box(&mut channels),
+                    black_box(0),
+                    black_box(&rollup_config),
+                    black_box(&mut highest),
+                );
+                black_box((channels, highest));
+            },
+            BatchSize::SmallInput,
+        );
+    });
+
+    group.bench_function("4096_touched_incomplete_among_8192_channels", |b| {
+        b.iter_batched(
+            incomplete_channel_map,
+            |mut channels| {
+                let mut highest = None;
+                RecentTxScanner::drain_ready_channels(
+                    black_box(&mut channels),
+                    black_box(&incomplete_ids),
+                    black_box(0),
+                    black_box(&rollup_config),
+                    black_box(&mut highest),
+                );
+                black_box((channels, highest));
+            },
+            BatchSize::SmallInput,
+        );
+    });
+
+    let sparse_ids = touched_sparse_ids();
+    group.bench_function("baseline_scan_all_with_64_touched_ready_among_8192_channels", |b| {
+        b.iter_batched(
+            sparse_ready_channel_map,
+            |mut channels| {
+                let mut highest = None;
+                RecentTxScanner::drain_all_ready_channels(
+                    black_box(&mut channels),
+                    black_box(0),
+                    black_box(&rollup_config),
+                    black_box(&mut highest),
+                );
+                black_box((channels, highest));
+            },
+            BatchSize::SmallInput,
+        );
+    });
+
+    group.bench_function("64_touched_ready_among_8192_channels", |b| {
+        b.iter_batched(
+            sparse_ready_channel_map,
+            |mut channels| {
+                let mut highest = None;
+                RecentTxScanner::drain_ready_channels(
+                    black_box(&mut channels),
+                    black_box(&sparse_ids),
+                    black_box(0),
+                    black_box(&rollup_config),
+                    black_box(&mut highest),
+                );
+                black_box((channels, highest));
+            },
+            BatchSize::SmallInput,
+        );
+    });
+
+    group.bench_function(
+        "baseline_scan_all_with_64_touched_incomplete_among_8192_channels",
+        |b| {
+            b.iter_batched(
+                incomplete_channel_map,
+                |mut channels| {
+                    let mut highest = None;
+                    RecentTxScanner::drain_all_ready_channels(
+                        black_box(&mut channels),
+                        black_box(0),
+                        black_box(&rollup_config),
+                        black_box(&mut highest),
+                    );
+                    black_box((channels, highest));
+                },
+                BatchSize::SmallInput,
+            );
+        },
+    );
+
+    group.bench_function("64_touched_incomplete_among_8192_channels", |b| {
+        b.iter_batched(
+            incomplete_channel_map,
+            |mut channels| {
+                let mut highest = None;
+                RecentTxScanner::drain_ready_channels(
+                    black_box(&mut channels),
+                    black_box(&sparse_ids),
+                    black_box(0),
+                    black_box(&rollup_config),
+                    black_box(&mut highest),
+                );
+                black_box((channels, highest));
+            },
+            BatchSize::SmallInput,
+        );
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_recent_tx_drain_ready_channels);
+criterion_main!(benches);

--- a/crates/batcher/service/benches/recent_txs.rs
+++ b/crates/batcher/service/benches/recent_txs.rs
@@ -25,9 +25,24 @@ const READY_TRANSITION_BLOCK_COUNT: usize = 4;
 const READY_TRANSITION_CHANNEL_COUNT: usize = 1_024;
 const STAGGERED_READY_BLOCK_COUNT: usize = 4;
 const STAGGERED_READY_CHANNEL_COUNT: usize = 1_024;
+const MIXED_READY_BLOCK_COUNT: usize = 4;
 const FRONT_LOADED_READY_CHANNEL_COUNTS: [usize; STAGGERED_READY_BLOCK_COUNT] =
     [512, 256, 128, 128];
 const BACK_LOADED_READY_CHANNEL_COUNTS: [usize; STAGGERED_READY_BLOCK_COUNT] = [128, 128, 256, 512];
+const MIXED_BACK_LOADED_READY_COHORTS: [ReadyTransitionCohort; 5] = [
+    ReadyTransitionCohort { start_block: 0, ready_block: 0, channel_count: 128 },
+    ReadyTransitionCohort { start_block: 0, ready_block: 1, channel_count: 128 },
+    ReadyTransitionCohort { start_block: 1, ready_block: 2, channel_count: 256 },
+    ReadyTransitionCohort { start_block: 0, ready_block: 3, channel_count: 256 },
+    ReadyTransitionCohort { start_block: 2, ready_block: 3, channel_count: 256 },
+];
+
+#[derive(Clone, Copy, Debug)]
+struct ReadyTransitionCohort {
+    start_block: usize,
+    ready_block: usize,
+    channel_count: usize,
+}
 
 fn test_rollup_config() -> RollupConfig {
     RollupConfig {
@@ -300,6 +315,57 @@ fn multi_block_weighted_ready_tx_payloads(ready_channel_counts: &[usize]) -> Vec
 
     debug_assert_eq!(channel_index, ready_channel_counts.iter().sum::<usize>());
     debug_assert_eq!(block_tx_payloads.len(), block_count);
+
+    block_tx_payloads
+}
+
+fn multi_block_cohort_ready_tx_payloads(
+    block_count: usize,
+    ready_cohorts: &[ReadyTransitionCohort],
+) -> Vec<Vec<Vec<u8>>> {
+    let mut block_tx_payloads: Vec<Vec<Vec<u8>>> = (0..block_count).map(|_| Vec::new()).collect();
+    let mut channel_index = 0usize;
+
+    for ready_cohort in ready_cohorts {
+        assert!(
+            ready_cohort.start_block <= ready_cohort.ready_block,
+            "ready cohort start block must not exceed its ready block"
+        );
+        assert!(
+            ready_cohort.ready_block < block_count,
+            "ready cohort ready block must stay within the requested block count"
+        );
+
+        for _ in 0..ready_cohort.channel_count {
+            let channel_id = channel_id(channel_index);
+            let encoded_batch = encode_single_batch(&SingleBatch {
+                timestamp: 1_010 + channel_index as u64 * 2,
+                ..Default::default()
+            });
+            let active_block_count = ready_cohort.ready_block - ready_cohort.start_block + 1;
+
+            for (frame_offset, frame_data) in
+                split_frame_data_across_blocks(&encoded_batch, active_block_count)
+                    .into_iter()
+                    .enumerate()
+            {
+                let block_index = ready_cohort.start_block + frame_offset;
+                block_tx_payloads[block_index].push(encode_tx_frames_payload(&[Frame {
+                    id: channel_id,
+                    number: frame_offset as u16,
+                    data: frame_data,
+                    is_last: block_index == ready_cohort.ready_block,
+                }]));
+            }
+
+            channel_index += 1;
+        }
+    }
+
+    debug_assert_eq!(
+        channel_index,
+        ready_cohorts.iter().map(|ready_cohort| ready_cohort.channel_count).sum::<usize>()
+    );
 
     block_tx_payloads
 }
@@ -1104,6 +1170,62 @@ fn bench_recent_tx_process_blocks_weighted_ready(c: &mut Criterion) {
     group.finish();
 }
 
+fn bench_recent_tx_process_blocks_mixed_ready(c: &mut Criterion) {
+    let mut group = c.benchmark_group("batcher_service/recent_txs/process_blocks_mixed_ready");
+    group.sample_size(15);
+
+    let rollup_config = test_rollup_config();
+    let block_tx_payloads = multi_block_cohort_ready_tx_payloads(
+        MIXED_READY_BLOCK_COUNT,
+        &MIXED_BACK_LOADED_READY_COHORTS,
+    );
+
+    group.bench_function("baseline_vec_scan_all_mixed_back_loaded_4_blocks_1024_channels", |b| {
+        b.iter_batched(
+            HashMap::new,
+            |mut channels| {
+                black_box(process_blocks_with_vec_tracking_and_full_scan(
+                    black_box(&mut channels),
+                    black_box(&block_tx_payloads),
+                    black_box(&rollup_config),
+                ));
+                black_box(channels)
+            },
+            BatchSize::SmallInput,
+        );
+    });
+    group.bench_function("fresh_tracker_mixed_back_loaded_4_blocks_1024_channels", |b| {
+        b.iter_batched(
+            HashMap::new,
+            |mut channels| {
+                black_box(process_blocks_with_fresh_tracker_and_touched_only_drain(
+                    black_box(&mut channels),
+                    black_box(&block_tx_payloads),
+                    black_box(&rollup_config),
+                ));
+                black_box(channels)
+            },
+            BatchSize::SmallInput,
+        );
+    });
+    group.bench_function("reused_tracker_mixed_back_loaded_4_blocks_1024_channels", |b| {
+        b.iter_batched(
+            HashMap::new,
+            |mut channels| {
+                black_box(process_blocks_with_tracker_and_touched_only_drain(
+                    black_box(&mut channels),
+                    black_box(&block_tx_payloads),
+                    black_box(&rollup_config),
+                ));
+                black_box(channels)
+            },
+            BatchSize::SmallInput,
+        );
+    });
+
+    group.finish();
+}
+
 criterion_group!(
     benches,
     bench_recent_tx_ready_channel_lookup,
@@ -1114,5 +1236,6 @@ criterion_group!(
     bench_recent_tx_process_blocks_ready_transition,
     bench_recent_tx_process_blocks_staggered_ready,
     bench_recent_tx_process_blocks_weighted_ready,
+    bench_recent_tx_process_blocks_mixed_ready,
 );
 criterion_main!(benches);

--- a/crates/batcher/service/benches/recent_txs.rs
+++ b/crates/batcher/service/benches/recent_txs.rs
@@ -10,7 +10,9 @@ use alloy_primitives::B256;
 use alloy_rlp::Encodable;
 use base_batcher_service::{RecentTxScanner, TouchedChannelTracker};
 use base_common_genesis::{ChainGenesis, RollupConfig};
-use base_protocol::{Batch, BlockInfo, Channel, ChannelId, Frame, SingleBatch};
+use base_protocol::{
+    Batch, BlockInfo, Channel, ChannelId, DERIVATION_VERSION_0, Frame, SingleBatch,
+};
 use criterion::{BatchSize, Criterion, criterion_group, criterion_main};
 
 const READY_CHANNEL_COUNT: usize = 4_096;
@@ -127,6 +129,41 @@ fn duplicate_fanout_frame_channel_ids() -> Vec<ChannelId> {
         .collect()
 }
 
+fn encode_tx_frames_payload(frames: &[Frame]) -> Vec<u8> {
+    let mut encoded =
+        Vec::with_capacity(1 + frames.iter().map(|frame| frame.encode().len()).sum::<usize>());
+    encoded.push(DERIVATION_VERSION_0);
+    for frame in frames {
+        encoded.extend_from_slice(&frame.encode());
+    }
+    encoded
+}
+
+fn ready_tx_payload(id: ChannelId, timestamp: u64) -> Vec<u8> {
+    encode_tx_frames_payload(&[Frame {
+        id,
+        number: 0,
+        data: encode_single_batch(&SingleBatch { timestamp, ..Default::default() }),
+        is_last: true,
+    }])
+}
+
+fn incomplete_tx_payload(id: ChannelId, number: u16) -> Vec<u8> {
+    encode_tx_frames_payload(&[Frame { id, number, data: b"partial".to_vec(), is_last: false }])
+}
+
+fn ready_block_tx_payloads() -> Vec<Vec<u8>> {
+    (0..READY_CHANNEL_COUNT)
+        .map(|index| ready_tx_payload(channel_id(index), 1_010 + index as u64 * 2))
+        .collect()
+}
+
+fn sparse_incomplete_followup_tx_payloads() -> Vec<Vec<u8>> {
+    (0..SPARSE_TOUCHED_CHANNEL_COUNT)
+        .map(|index| incomplete_tx_payload(channel_id(index), 1))
+        .collect()
+}
+
 fn track_touched_channel_ids_with_vec(frame_channel_ids: &[ChannelId]) -> Vec<ChannelId> {
     let mut touched_channel_ids = Vec::with_capacity(frame_channel_ids.len());
     for channel_id in frame_channel_ids {
@@ -183,6 +220,60 @@ fn count_ready_touched_channels_with_get(
         }
     }
     ready_channels
+}
+
+fn process_block_with_vec_tracking_and_full_scan(
+    channels: &mut HashMap<ChannelId, Channel>,
+    tx_payloads: &[Vec<u8>],
+    rollup_config: &RollupConfig,
+) -> Option<u64> {
+    let block_info = BlockInfo::default();
+    let mut touched_channel_ids = Vec::with_capacity(tx_payloads.len());
+    for tx_payload in tx_payloads {
+        let frames =
+            Frame::parse_frames(tx_payload).expect("fixture tx payload must parse into frames");
+        for frame in frames {
+            if !touched_channel_ids.contains(&frame.id) {
+                touched_channel_ids.push(frame.id);
+            }
+            let channel =
+                channels.entry(frame.id).or_insert_with(|| Channel::new(frame.id, block_info));
+            channel.add_frame(frame, block_info).expect("fixture frame must be accepted");
+        }
+    }
+
+    let mut highest = None;
+    RecentTxScanner::drain_all_ready_channels(channels, 0, rollup_config, &mut highest);
+    highest
+}
+
+fn process_block_with_tracker_and_touched_only_drain(
+    channels: &mut HashMap<ChannelId, Channel>,
+    tx_payloads: &[Vec<u8>],
+    rollup_config: &RollupConfig,
+) -> Option<u64> {
+    let block_info = BlockInfo::default();
+    let mut touched_channel_ids = TouchedChannelTracker::with_capacity(tx_payloads.len());
+    for tx_payload in tx_payloads {
+        let frames =
+            Frame::parse_frames(tx_payload).expect("fixture tx payload must parse into frames");
+        for frame in frames {
+            touched_channel_ids.record(frame.id);
+            let channel =
+                channels.entry(frame.id).or_insert_with(|| Channel::new(frame.id, block_info));
+            channel.add_frame(frame, block_info).expect("fixture frame must be accepted");
+        }
+    }
+
+    let mut highest = None;
+    RecentTxScanner::drain_ready_channels(
+        channels,
+        touched_channel_ids.touched_channel_ids(),
+        0,
+        rollup_config,
+        &mut highest,
+    );
+    highest
 }
 
 fn bench_recent_tx_ready_channel_lookup(c: &mut Criterion) {
@@ -443,10 +534,85 @@ fn bench_recent_tx_track_touched_channel_ids(c: &mut Criterion) {
     group.finish();
 }
 
+fn bench_recent_tx_process_block(c: &mut Criterion) {
+    let mut group = c.benchmark_group("batcher_service/recent_txs/process_block");
+    group.sample_size(20);
+
+    let rollup_config = test_rollup_config();
+    let ready_tx_payloads = ready_block_tx_payloads();
+    group.bench_function("baseline_vec_scan_all_4096_ready_unique_channels_from_empty", |b| {
+        b.iter_batched(
+            HashMap::new,
+            |mut channels| {
+                black_box(process_block_with_vec_tracking_and_full_scan(
+                    black_box(&mut channels),
+                    black_box(&ready_tx_payloads),
+                    black_box(&rollup_config),
+                ));
+                black_box(channels)
+            },
+            BatchSize::SmallInput,
+        );
+    });
+    group.bench_function("tracker_touched_only_4096_ready_unique_channels_from_empty", |b| {
+        b.iter_batched(
+            HashMap::new,
+            |mut channels| {
+                black_box(process_block_with_tracker_and_touched_only_drain(
+                    black_box(&mut channels),
+                    black_box(&ready_tx_payloads),
+                    black_box(&rollup_config),
+                ));
+                black_box(channels)
+            },
+            BatchSize::SmallInput,
+        );
+    });
+
+    let sparse_incomplete_tx_payloads = sparse_incomplete_followup_tx_payloads();
+    group.bench_function(
+        "baseline_vec_scan_all_64_incomplete_touches_among_8192_buffered_channels",
+        |b| {
+            b.iter_batched(
+                incomplete_channel_map,
+                |mut channels| {
+                    black_box(process_block_with_vec_tracking_and_full_scan(
+                        black_box(&mut channels),
+                        black_box(&sparse_incomplete_tx_payloads),
+                        black_box(&rollup_config),
+                    ));
+                    black_box(channels)
+                },
+                BatchSize::SmallInput,
+            );
+        },
+    );
+    group.bench_function(
+        "tracker_touched_only_64_incomplete_touches_among_8192_buffered_channels",
+        |b| {
+            b.iter_batched(
+                incomplete_channel_map,
+                |mut channels| {
+                    black_box(process_block_with_tracker_and_touched_only_drain(
+                        black_box(&mut channels),
+                        black_box(&sparse_incomplete_tx_payloads),
+                        black_box(&rollup_config),
+                    ));
+                    black_box(channels)
+                },
+                BatchSize::SmallInput,
+            );
+        },
+    );
+
+    group.finish();
+}
+
 criterion_group!(
     benches,
     bench_recent_tx_ready_channel_lookup,
     bench_recent_tx_drain_ready_channels,
     bench_recent_tx_track_touched_channel_ids,
+    bench_recent_tx_process_block,
 );
 criterion_main!(benches);

--- a/crates/batcher/service/benches/recent_txs.rs
+++ b/crates/batcher/service/benches/recent_txs.rs
@@ -1,6 +1,9 @@
 //! Benchmarks for recent-transaction startup scan channel draining.
 
-use std::hint::black_box;
+use std::{
+    collections::{HashMap, hash_map::Entry},
+    hint::black_box,
+};
 
 use alloy_eips::eip1898::BlockNumHash;
 use alloy_primitives::B256;
@@ -151,6 +154,94 @@ fn track_touched_channel_ids_with_reused_tracker(
         tracker.record(*channel_id);
     }
     tracker.touched_channel_ids().to_vec()
+}
+
+fn count_ready_touched_channels_with_entry_api(
+    channels: &mut HashMap<ChannelId, Channel>,
+    touched_channel_ids: &[ChannelId],
+) -> usize {
+    let mut ready_channels = 0;
+    for channel_id in touched_channel_ids {
+        let Entry::Occupied(channel_entry) = channels.entry(*channel_id) else {
+            continue;
+        };
+        if channel_entry.get().is_ready() {
+            ready_channels += 1;
+        }
+    }
+    ready_channels
+}
+
+fn count_ready_touched_channels_with_get(
+    channels: &HashMap<ChannelId, Channel>,
+    touched_channel_ids: &[ChannelId],
+) -> usize {
+    let mut ready_channels = 0;
+    for channel_id in touched_channel_ids {
+        if channels.get(channel_id).is_some_and(Channel::is_ready) {
+            ready_channels += 1;
+        }
+    }
+    ready_channels
+}
+
+fn bench_recent_tx_ready_channel_lookup(c: &mut Criterion) {
+    let mut group = c.benchmark_group("batcher_service/recent_txs/ready_channel_lookup");
+    group.sample_size(20);
+
+    let incomplete_ids = touched_incomplete_ids();
+    group.bench_function("baseline_get_4096_touched_incomplete_among_8192_channels", |b| {
+        b.iter_batched(
+            incomplete_channel_map,
+            |channels| {
+                black_box(count_ready_touched_channels_with_get(
+                    black_box(&channels),
+                    black_box(&incomplete_ids),
+                ))
+            },
+            BatchSize::SmallInput,
+        );
+    });
+    group.bench_function("entry_api_4096_touched_incomplete_among_8192_channels", |b| {
+        b.iter_batched(
+            incomplete_channel_map,
+            |mut channels| {
+                black_box(count_ready_touched_channels_with_entry_api(
+                    black_box(&mut channels),
+                    black_box(&incomplete_ids),
+                ))
+            },
+            BatchSize::SmallInput,
+        );
+    });
+
+    let sparse_ids = touched_sparse_ids();
+    group.bench_function("baseline_get_64_touched_ready_among_8192_channels", |b| {
+        b.iter_batched(
+            sparse_ready_channel_map,
+            |channels| {
+                black_box(count_ready_touched_channels_with_get(
+                    black_box(&channels),
+                    black_box(&sparse_ids),
+                ))
+            },
+            BatchSize::SmallInput,
+        );
+    });
+    group.bench_function("entry_api_64_touched_ready_among_8192_channels", |b| {
+        b.iter_batched(
+            sparse_ready_channel_map,
+            |mut channels| {
+                black_box(count_ready_touched_channels_with_entry_api(
+                    black_box(&mut channels),
+                    black_box(&sparse_ids),
+                ))
+            },
+            BatchSize::SmallInput,
+        );
+    });
+
+    group.finish();
 }
 
 fn bench_recent_tx_drain_ready_channels(c: &mut Criterion) {
@@ -354,6 +445,7 @@ fn bench_recent_tx_track_touched_channel_ids(c: &mut Criterion) {
 
 criterion_group!(
     benches,
+    bench_recent_tx_ready_channel_lookup,
     bench_recent_tx_drain_ready_channels,
     bench_recent_tx_track_touched_channel_ids,
 );

--- a/crates/batcher/service/benches/recent_txs.rs
+++ b/crates/batcher/service/benches/recent_txs.rs
@@ -13,7 +13,7 @@ use base_common_genesis::{ChainGenesis, RollupConfig};
 use base_protocol::{
     Batch, BlockInfo, Channel, ChannelId, DERIVATION_VERSION_0, Frame, SingleBatch,
 };
-use criterion::{BatchSize, Criterion, criterion_group, criterion_main};
+use criterion::{BatchSize, BenchmarkId, Criterion, criterion_group, criterion_main};
 
 const READY_CHANNEL_COUNT: usize = 4_096;
 const SPARSE_TOUCHED_CHANNEL_COUNT: usize = 64;
@@ -26,6 +26,8 @@ const READY_TRANSITION_CHANNEL_COUNT: usize = 1_024;
 const STAGGERED_READY_BLOCK_COUNT: usize = 4;
 const STAGGERED_READY_CHANNEL_COUNT: usize = 1_024;
 const MIXED_READY_BLOCK_COUNT: usize = 4;
+const DECODE_DENSITY_CHANNEL_COUNT: usize = 1_024;
+const DECODE_DENSITY_READY_CHANNEL_COUNTS: [usize; 4] = [0, 256, 512, DECODE_DENSITY_CHANNEL_COUNT];
 const FRONT_LOADED_READY_CHANNEL_COUNTS: [usize; STAGGERED_READY_BLOCK_COUNT] =
     [512, 256, 128, 128];
 const BACK_LOADED_READY_CHANNEL_COUNTS: [usize; STAGGERED_READY_BLOCK_COUNT] = [128, 128, 256, 512];
@@ -375,6 +377,50 @@ fn multi_block_cohort_ready_tx_payloads(
     );
 
     block_tx_payloads
+}
+
+fn prebuffered_decode_density_fixture(
+    channel_count: usize,
+    ready_channel_count: usize,
+) -> (HashMap<ChannelId, Channel>, Vec<Vec<u8>>) {
+    let block_info = BlockInfo::default();
+    let mut channels = HashMap::with_capacity(channel_count);
+    let mut tx_payloads = Vec::with_capacity(channel_count);
+
+    for index in 0..channel_count {
+        let channel_id = channel_id(index);
+        let encoded_batch = encode_single_batch(&SingleBatch {
+            timestamp: 1_010 + index as u64 * 2,
+            ..Default::default()
+        });
+        let total_frame_count = if index < ready_channel_count { 3 } else { 4 };
+        let frame_data_chunks = split_frame_data_across_blocks(&encoded_batch, total_frame_count);
+        let mut channel = Channel::new(channel_id, block_info);
+
+        for (frame_number, frame_data) in frame_data_chunks.iter().take(2).enumerate() {
+            channel
+                .add_frame(
+                    Frame {
+                        id: channel_id,
+                        number: frame_number as u16,
+                        data: frame_data.clone(),
+                        is_last: false,
+                    },
+                    block_info,
+                )
+                .expect("fixture frame must be accepted");
+        }
+
+        tx_payloads.push(encode_tx_frames_payload(&[Frame {
+            id: channel_id,
+            number: 2,
+            data: frame_data_chunks[2].clone(),
+            is_last: index < ready_channel_count,
+        }]));
+        channels.insert(channel_id, channel);
+    }
+
+    (channels, tx_payloads)
 }
 
 fn track_touched_channel_ids_with_vec(frame_channel_ids: &[ChannelId]) -> Vec<ChannelId> {
@@ -1461,6 +1507,70 @@ fn bench_recent_tx_process_blocks_touch_start_matched_volume(c: &mut Criterion) 
     group.finish();
 }
 
+fn bench_recent_tx_process_block_decode_density(c: &mut Criterion) {
+    let mut group = c.benchmark_group("batcher_service/recent_txs/process_block_decode_density");
+    group.sample_size(15);
+
+    let rollup_config = test_rollup_config();
+
+    for ready_channel_count in DECODE_DENSITY_READY_CHANNEL_COUNTS {
+        group.bench_with_input(
+            BenchmarkId::new(
+                "baseline_vec_scan_all_prebuffered_touched_channels_ready_on_current_block",
+                ready_channel_count,
+            ),
+            &ready_channel_count,
+            |b, &ready_channel_count| {
+                b.iter_batched(
+                    || {
+                        prebuffered_decode_density_fixture(
+                            DECODE_DENSITY_CHANNEL_COUNT,
+                            ready_channel_count,
+                        )
+                    },
+                    |(mut channels, tx_payloads)| {
+                        black_box(process_block_with_vec_tracking_and_full_scan(
+                            black_box(&mut channels),
+                            black_box(&tx_payloads),
+                            black_box(&rollup_config),
+                        ));
+                        black_box(channels)
+                    },
+                    BatchSize::SmallInput,
+                );
+            },
+        );
+        group.bench_with_input(
+            BenchmarkId::new(
+                "tracker_touched_only_prebuffered_touched_channels_ready_on_current_block",
+                ready_channel_count,
+            ),
+            &ready_channel_count,
+            |b, &ready_channel_count| {
+                b.iter_batched(
+                    || {
+                        prebuffered_decode_density_fixture(
+                            DECODE_DENSITY_CHANNEL_COUNT,
+                            ready_channel_count,
+                        )
+                    },
+                    |(mut channels, tx_payloads)| {
+                        black_box(process_block_with_tracker_and_touched_only_drain(
+                            black_box(&mut channels),
+                            black_box(&tx_payloads),
+                            black_box(&rollup_config),
+                        ));
+                        black_box(channels)
+                    },
+                    BatchSize::SmallInput,
+                );
+            },
+        );
+    }
+
+    group.finish();
+}
+
 criterion_group!(
     benches,
     bench_recent_tx_ready_channel_lookup,
@@ -1474,5 +1584,6 @@ criterion_group!(
     bench_recent_tx_process_blocks_mixed_ready,
     bench_recent_tx_process_blocks_touch_start_sparsity,
     bench_recent_tx_process_blocks_touch_start_matched_volume,
+    bench_recent_tx_process_block_decode_density,
 );
 criterion_main!(benches);

--- a/crates/batcher/service/benches/recent_txs.rs
+++ b/crates/batcher/service/benches/recent_txs.rs
@@ -21,6 +21,8 @@ const DUPLICATE_FANOUT_FRAME_COUNT: usize = 4_096;
 const DUPLICATE_FANOUT_UNIQUE_CHANNEL_COUNT: usize = 512;
 const MULTI_BLOCK_COUNT: usize = 8;
 const MULTI_BLOCK_TOUCHED_CHANNEL_COUNT: usize = 4_096;
+const READY_TRANSITION_BLOCK_COUNT: usize = 4;
+const READY_TRANSITION_CHANNEL_COUNT: usize = 1_024;
 
 fn test_rollup_config() -> RollupConfig {
     RollupConfig {
@@ -179,6 +181,57 @@ fn multi_block_incomplete_tx_payloads(
         .collect()
 }
 
+fn split_frame_data_across_blocks(data: &[u8], block_count: usize) -> Vec<Vec<u8>> {
+    assert!(block_count > 0, "ready-transition fixtures require at least one block");
+    assert!(
+        data.len() >= block_count,
+        "ready-transition fixtures require at least one payload byte per block"
+    );
+
+    let base_chunk_len = data.len() / block_count;
+    let remainder = data.len() % block_count;
+    let mut chunks = Vec::with_capacity(block_count);
+    let mut offset = 0;
+
+    for block_index in 0..block_count {
+        let chunk_len = base_chunk_len + usize::from(block_index < remainder);
+        let next_offset = offset + chunk_len;
+        chunks.push(data[offset..next_offset].to_vec());
+        offset = next_offset;
+    }
+
+    chunks
+}
+
+fn multi_block_ready_transition_tx_payloads(
+    block_count: usize,
+    channel_count: usize,
+) -> Vec<Vec<Vec<u8>>> {
+    let mut block_tx_payloads: Vec<Vec<Vec<u8>>> =
+        (0..block_count).map(|_| Vec::with_capacity(channel_count)).collect();
+
+    for index in 0..channel_count {
+        let channel_id = channel_id(index);
+        let encoded_batch = encode_single_batch(&SingleBatch {
+            timestamp: 1_010 + index as u64 * 2,
+            ..Default::default()
+        });
+
+        for (block_index, frame_data) in
+            split_frame_data_across_blocks(&encoded_batch, block_count).into_iter().enumerate()
+        {
+            block_tx_payloads[block_index].push(encode_tx_frames_payload(&[Frame {
+                id: channel_id,
+                number: block_index as u16,
+                data: frame_data,
+                is_last: block_index + 1 == block_count,
+            }]));
+        }
+    }
+
+    block_tx_payloads
+}
+
 fn track_touched_channel_ids_with_vec(frame_channel_ids: &[ChannelId]) -> Vec<ChannelId> {
     let mut touched_channel_ids = Vec::with_capacity(frame_channel_ids.len());
     for channel_id in frame_channel_ids {
@@ -288,6 +341,35 @@ fn process_block_with_tracker_and_touched_only_drain(
         rollup_config,
         &mut highest,
     );
+    highest
+}
+
+fn process_blocks_with_vec_tracking_and_full_scan(
+    channels: &mut HashMap<ChannelId, Channel>,
+    block_tx_payloads: &[Vec<Vec<u8>>],
+    rollup_config: &RollupConfig,
+) -> Option<u64> {
+    let block_info = BlockInfo::default();
+    let mut highest = None;
+
+    for tx_payloads in block_tx_payloads {
+        let mut touched_channel_ids = Vec::with_capacity(tx_payloads.len());
+        for tx_payload in tx_payloads {
+            let frames =
+                Frame::parse_frames(tx_payload).expect("fixture tx payload must parse into frames");
+            for frame in frames {
+                if !touched_channel_ids.contains(&frame.id) {
+                    touched_channel_ids.push(frame.id);
+                }
+                let channel =
+                    channels.entry(frame.id).or_insert_with(|| Channel::new(frame.id, block_info));
+                channel.add_frame(frame, block_info).expect("fixture frame must be accepted");
+            }
+        }
+
+        RecentTxScanner::drain_all_ready_channels(channels, 0, rollup_config, &mut highest);
+    }
+
     highest
 }
 
@@ -736,6 +818,65 @@ fn bench_recent_tx_process_blocks(c: &mut Criterion) {
     group.finish();
 }
 
+fn bench_recent_tx_process_blocks_ready_transition(c: &mut Criterion) {
+    let mut group = c.benchmark_group("batcher_service/recent_txs/process_blocks_ready_transition");
+    group.sample_size(15);
+
+    let rollup_config = test_rollup_config();
+    let block_tx_payloads = multi_block_ready_transition_tx_payloads(
+        READY_TRANSITION_BLOCK_COUNT,
+        READY_TRANSITION_CHANNEL_COUNT,
+    );
+
+    group.bench_function(
+        "baseline_vec_scan_all_4_blocks_1024_channels_ready_on_final_block",
+        |b| {
+            b.iter_batched(
+                HashMap::new,
+                |mut channels| {
+                    black_box(process_blocks_with_vec_tracking_and_full_scan(
+                        black_box(&mut channels),
+                        black_box(&block_tx_payloads),
+                        black_box(&rollup_config),
+                    ));
+                    black_box(channels)
+                },
+                BatchSize::SmallInput,
+            );
+        },
+    );
+    group.bench_function("fresh_tracker_4_blocks_1024_channels_ready_on_final_block", |b| {
+        b.iter_batched(
+            HashMap::new,
+            |mut channels| {
+                black_box(process_blocks_with_fresh_tracker_and_touched_only_drain(
+                    black_box(&mut channels),
+                    black_box(&block_tx_payloads),
+                    black_box(&rollup_config),
+                ));
+                black_box(channels)
+            },
+            BatchSize::SmallInput,
+        );
+    });
+    group.bench_function("reused_tracker_4_blocks_1024_channels_ready_on_final_block", |b| {
+        b.iter_batched(
+            HashMap::new,
+            |mut channels| {
+                black_box(process_blocks_with_tracker_and_touched_only_drain(
+                    black_box(&mut channels),
+                    black_box(&block_tx_payloads),
+                    black_box(&rollup_config),
+                ));
+                black_box(channels)
+            },
+            BatchSize::SmallInput,
+        );
+    });
+
+    group.finish();
+}
+
 criterion_group!(
     benches,
     bench_recent_tx_ready_channel_lookup,
@@ -743,5 +884,6 @@ criterion_group!(
     bench_recent_tx_track_touched_channel_ids,
     bench_recent_tx_process_block,
     bench_recent_tx_process_blocks,
+    bench_recent_tx_process_blocks_ready_transition,
 );
 criterion_main!(benches);

--- a/crates/batcher/service/benches/recent_txs.rs
+++ b/crates/batcher/service/benches/recent_txs.rs
@@ -6,12 +6,12 @@ use std::{
 };
 
 use alloy_eips::eip1898::BlockNumHash;
-use alloy_primitives::B256;
+use alloy_primitives::{B256, Bytes};
 use alloy_rlp::Encodable;
 use base_batcher_service::{RecentTxScanner, TouchedChannelTracker};
 use base_common_genesis::{ChainGenesis, RollupConfig};
 use base_protocol::{
-    Batch, BlockInfo, Channel, ChannelId, DERIVATION_VERSION_0, Frame, SingleBatch,
+    Batch, BatchReader, BlockInfo, Channel, ChannelId, DERIVATION_VERSION_0, Frame, SingleBatch,
 };
 use criterion::{BatchSize, BenchmarkId, Criterion, criterion_group, criterion_main};
 
@@ -27,6 +27,8 @@ const STAGGERED_READY_BLOCK_COUNT: usize = 4;
 const STAGGERED_READY_CHANNEL_COUNT: usize = 1_024;
 const MIXED_READY_BLOCK_COUNT: usize = 4;
 const DECODE_DENSITY_CHANNEL_COUNT: usize = 1_024;
+const DECODE_COMPONENT_BATCH_COUNT: usize = 16;
+const DECODE_COMPONENT_FRAME_COUNTS: [usize; 3] = [1, 4, 16];
 const DECODE_DENSITY_READY_CHANNEL_COUNTS: [usize; 4] = [0, 256, 512, DECODE_DENSITY_CHANNEL_COUNT];
 const FRONT_LOADED_READY_CHANNEL_COUNTS: [usize; STAGGERED_READY_BLOCK_COUNT] =
     [512, 256, 128, 128];
@@ -75,6 +77,20 @@ fn encode_single_batch(batch: &SingleBatch) -> Vec<u8> {
     miniz_oxide::deflate::compress_to_vec_zlib(&rlp_buf, 6)
 }
 
+fn encode_single_batch_stream(batch_count: usize) -> Vec<u8> {
+    let mut rlp_buf = Vec::new();
+    for batch_index in 0..batch_count {
+        let typed_batch = Batch::Single(SingleBatch {
+            timestamp: 1_010 + batch_index as u64 * 2,
+            ..Default::default()
+        });
+        let mut batch_bytes = Vec::new();
+        typed_batch.encode(&mut batch_bytes).expect("batch must encode");
+        batch_bytes.as_slice().encode(&mut rlp_buf);
+    }
+    miniz_oxide::deflate::compress_to_vec_zlib(&rlp_buf, 6)
+}
+
 fn ready_channel(id: ChannelId, timestamp: u64) -> Channel {
     let block_info = BlockInfo::default();
     let mut channel = Channel::new(id, block_info);
@@ -89,6 +105,30 @@ fn ready_channel(id: ChannelId, timestamp: u64) -> Channel {
             block_info,
         )
         .expect("frame must be accepted");
+    channel
+}
+
+fn ready_multi_batch_channel(id: ChannelId, frame_count: usize, batch_count: usize) -> Channel {
+    let block_info = BlockInfo::default();
+    let mut channel = Channel::new(id, block_info);
+    let compressed_batches = encode_single_batch_stream(batch_count);
+
+    for (frame_number, frame_data) in
+        split_frame_data_across_blocks(&compressed_batches, frame_count).into_iter().enumerate()
+    {
+        channel
+            .add_frame(
+                Frame {
+                    id,
+                    number: frame_number as u16,
+                    data: frame_data,
+                    is_last: frame_number + 1 == frame_count,
+                },
+                block_info,
+            )
+            .expect("frame must be accepted");
+    }
+
     channel
 }
 
@@ -421,6 +461,37 @@ fn prebuffered_decode_density_fixture(
     }
 
     (channels, tx_payloads)
+}
+
+fn decode_channel_data(
+    data: Bytes,
+    inclusion_timestamp: u64,
+    rollup_config: &RollupConfig,
+) -> Option<u64> {
+    let max_rlp = rollup_config.max_rlp_bytes_per_channel(inclusion_timestamp) as usize;
+    let mut reader = BatchReader::new(data, max_rlp);
+    let mut highest_l2 = None;
+
+    while let Some(batch) = reader.next_batch(rollup_config) {
+        let last_timestamp = match &batch {
+            Batch::Single(single_batch) => single_batch.timestamp,
+            Batch::Span(span_batch) => span_batch.final_timestamp(),
+        };
+        let relative = rollup_config.block_number_from_timestamp(last_timestamp);
+        let l2_block = rollup_config.genesis.l2.number + relative;
+        highest_l2 = Some(highest_l2.map_or(l2_block, |highest: u64| highest.max(l2_block)));
+    }
+
+    highest_l2
+}
+
+fn decode_ready_channel(
+    channel: &Channel,
+    inclusion_timestamp: u64,
+    rollup_config: &RollupConfig,
+) -> Option<u64> {
+    let data = channel.frame_data().expect("fixture channel must be ready");
+    decode_channel_data(data, inclusion_timestamp, rollup_config)
 }
 
 fn track_touched_channel_ids_with_vec(frame_channel_ids: &[ChannelId]) -> Vec<ChannelId> {
@@ -1571,6 +1642,68 @@ fn bench_recent_tx_process_block_decode_density(c: &mut Criterion) {
     group.finish();
 }
 
+fn bench_recent_tx_decode_channel_components(c: &mut Criterion) {
+    let mut group = c.benchmark_group("batcher_service/recent_txs/decode_channel_components");
+    group.sample_size(15);
+
+    let rollup_config = test_rollup_config();
+
+    for frame_count in DECODE_COMPONENT_FRAME_COUNTS {
+        let channel = ready_multi_batch_channel(
+            channel_id(frame_count),
+            frame_count,
+            DECODE_COMPONENT_BATCH_COUNT,
+        );
+        let frame_data = channel.frame_data().expect("fixture channel must be ready");
+
+        group.bench_with_input(
+            BenchmarkId::new("frame_data_only_16_batches_split_across_frames", frame_count),
+            &frame_count,
+            |b, _| {
+                b.iter(|| {
+                    black_box(
+                        black_box(&channel).frame_data().expect("fixture channel must be ready"),
+                    )
+                });
+            },
+        );
+        group.bench_with_input(
+            BenchmarkId::new(
+                "batch_reader_only_preaggregated_16_batches_split_across_frames",
+                frame_count,
+            ),
+            &frame_count,
+            |b, _| {
+                b.iter(|| {
+                    black_box(decode_channel_data(
+                        black_box(frame_data.clone()),
+                        black_box(0),
+                        black_box(&rollup_config),
+                    ))
+                });
+            },
+        );
+        group.bench_with_input(
+            BenchmarkId::new(
+                "frame_data_plus_batch_reader_16_batches_split_across_frames",
+                frame_count,
+            ),
+            &frame_count,
+            |b, _| {
+                b.iter(|| {
+                    black_box(decode_ready_channel(
+                        black_box(&channel),
+                        black_box(0),
+                        black_box(&rollup_config),
+                    ))
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
 criterion_group!(
     benches,
     bench_recent_tx_ready_channel_lookup,
@@ -1585,5 +1718,6 @@ criterion_group!(
     bench_recent_tx_process_blocks_touch_start_sparsity,
     bench_recent_tx_process_blocks_touch_start_matched_volume,
     bench_recent_tx_process_block_decode_density,
+    bench_recent_tx_decode_channel_components,
 );
 criterion_main!(benches);

--- a/crates/batcher/service/benches/recent_txs.rs
+++ b/crates/batcher/service/benches/recent_txs.rs
@@ -23,6 +23,8 @@ const MULTI_BLOCK_COUNT: usize = 8;
 const MULTI_BLOCK_TOUCHED_CHANNEL_COUNT: usize = 4_096;
 const READY_TRANSITION_BLOCK_COUNT: usize = 4;
 const READY_TRANSITION_CHANNEL_COUNT: usize = 1_024;
+const STAGGERED_READY_BLOCK_COUNT: usize = 4;
+const STAGGERED_READY_CHANNEL_COUNT: usize = 1_024;
 
 fn test_rollup_config() -> RollupConfig {
     RollupConfig {
@@ -225,6 +227,36 @@ fn multi_block_ready_transition_tx_payloads(
                 number: block_index as u16,
                 data: frame_data,
                 is_last: block_index + 1 == block_count,
+            }]));
+        }
+    }
+
+    block_tx_payloads
+}
+
+fn multi_block_staggered_ready_tx_payloads(
+    block_count: usize,
+    channel_count: usize,
+) -> Vec<Vec<Vec<u8>>> {
+    let mut block_tx_payloads: Vec<Vec<Vec<u8>>> =
+        (0..block_count).map(|_| Vec::with_capacity(channel_count)).collect();
+
+    for index in 0..channel_count {
+        let channel_id = channel_id(index);
+        let encoded_batch = encode_single_batch(&SingleBatch {
+            timestamp: 1_010 + index as u64 * 2,
+            ..Default::default()
+        });
+        let ready_block = index % block_count;
+
+        for (block_index, frame_data) in
+            split_frame_data_across_blocks(&encoded_batch, ready_block + 1).into_iter().enumerate()
+        {
+            block_tx_payloads[block_index].push(encode_tx_frames_payload(&[Frame {
+                id: channel_id,
+                number: block_index as u16,
+                data: frame_data,
+                is_last: block_index == ready_block,
             }]));
         }
     }
@@ -877,6 +909,62 @@ fn bench_recent_tx_process_blocks_ready_transition(c: &mut Criterion) {
     group.finish();
 }
 
+fn bench_recent_tx_process_blocks_staggered_ready(c: &mut Criterion) {
+    let mut group = c.benchmark_group("batcher_service/recent_txs/process_blocks_staggered_ready");
+    group.sample_size(15);
+
+    let rollup_config = test_rollup_config();
+    let block_tx_payloads = multi_block_staggered_ready_tx_payloads(
+        STAGGERED_READY_BLOCK_COUNT,
+        STAGGERED_READY_CHANNEL_COUNT,
+    );
+
+    group.bench_function("baseline_vec_scan_all_4_blocks_1024_channels_ready_in_quarters", |b| {
+        b.iter_batched(
+            HashMap::new,
+            |mut channels| {
+                black_box(process_blocks_with_vec_tracking_and_full_scan(
+                    black_box(&mut channels),
+                    black_box(&block_tx_payloads),
+                    black_box(&rollup_config),
+                ));
+                black_box(channels)
+            },
+            BatchSize::SmallInput,
+        );
+    });
+    group.bench_function("fresh_tracker_4_blocks_1024_channels_ready_in_quarters", |b| {
+        b.iter_batched(
+            HashMap::new,
+            |mut channels| {
+                black_box(process_blocks_with_fresh_tracker_and_touched_only_drain(
+                    black_box(&mut channels),
+                    black_box(&block_tx_payloads),
+                    black_box(&rollup_config),
+                ));
+                black_box(channels)
+            },
+            BatchSize::SmallInput,
+        );
+    });
+    group.bench_function("reused_tracker_4_blocks_1024_channels_ready_in_quarters", |b| {
+        b.iter_batched(
+            HashMap::new,
+            |mut channels| {
+                black_box(process_blocks_with_tracker_and_touched_only_drain(
+                    black_box(&mut channels),
+                    black_box(&block_tx_payloads),
+                    black_box(&rollup_config),
+                ));
+                black_box(channels)
+            },
+            BatchSize::SmallInput,
+        );
+    });
+
+    group.finish();
+}
+
 criterion_group!(
     benches,
     bench_recent_tx_ready_channel_lookup,
@@ -885,5 +973,6 @@ criterion_group!(
     bench_recent_tx_process_block,
     bench_recent_tx_process_blocks,
     bench_recent_tx_process_blocks_ready_transition,
+    bench_recent_tx_process_blocks_staggered_ready,
 );
 criterion_main!(benches);

--- a/crates/batcher/service/benches/recent_txs.rs
+++ b/crates/batcher/service/benches/recent_txs.rs
@@ -25,6 +25,9 @@ const READY_TRANSITION_BLOCK_COUNT: usize = 4;
 const READY_TRANSITION_CHANNEL_COUNT: usize = 1_024;
 const STAGGERED_READY_BLOCK_COUNT: usize = 4;
 const STAGGERED_READY_CHANNEL_COUNT: usize = 1_024;
+const FRONT_LOADED_READY_CHANNEL_COUNTS: [usize; STAGGERED_READY_BLOCK_COUNT] =
+    [512, 256, 128, 128];
+const BACK_LOADED_READY_CHANNEL_COUNTS: [usize; STAGGERED_READY_BLOCK_COUNT] = [128, 128, 256, 512];
 
 fn test_rollup_config() -> RollupConfig {
     RollupConfig {
@@ -260,6 +263,43 @@ fn multi_block_staggered_ready_tx_payloads(
             }]));
         }
     }
+
+    block_tx_payloads
+}
+
+fn multi_block_weighted_ready_tx_payloads(ready_channel_counts: &[usize]) -> Vec<Vec<Vec<u8>>> {
+    let block_count = ready_channel_counts.len();
+    let mut block_tx_payloads: Vec<Vec<Vec<u8>>> = ready_channel_counts
+        .iter()
+        .map(|channel_count| Vec::with_capacity(*channel_count))
+        .collect();
+
+    let mut channel_index = 0usize;
+    for (ready_block, ready_channel_count) in ready_channel_counts.iter().copied().enumerate() {
+        for _ in 0..ready_channel_count {
+            let channel_id = channel_id(channel_index);
+            let encoded_batch = encode_single_batch(&SingleBatch {
+                timestamp: 1_010 + channel_index as u64 * 2,
+                ..Default::default()
+            });
+            for (block_index, frame_data) in
+                split_frame_data_across_blocks(&encoded_batch, ready_block + 1)
+                    .into_iter()
+                    .enumerate()
+            {
+                block_tx_payloads[block_index].push(encode_tx_frames_payload(&[Frame {
+                    id: channel_id,
+                    number: block_index as u16,
+                    data: frame_data,
+                    is_last: block_index == ready_block,
+                }]));
+            }
+            channel_index += 1;
+        }
+    }
+
+    debug_assert_eq!(channel_index, ready_channel_counts.iter().sum::<usize>());
+    debug_assert_eq!(block_tx_payloads.len(), block_count);
 
     block_tx_payloads
 }
@@ -965,6 +1005,105 @@ fn bench_recent_tx_process_blocks_staggered_ready(c: &mut Criterion) {
     group.finish();
 }
 
+fn bench_recent_tx_process_blocks_weighted_ready(c: &mut Criterion) {
+    let mut group = c.benchmark_group("batcher_service/recent_txs/process_blocks_weighted_ready");
+    group.sample_size(15);
+
+    let rollup_config = test_rollup_config();
+    let front_loaded_block_tx_payloads =
+        multi_block_weighted_ready_tx_payloads(&FRONT_LOADED_READY_CHANNEL_COUNTS);
+    let back_loaded_block_tx_payloads =
+        multi_block_weighted_ready_tx_payloads(&BACK_LOADED_READY_CHANNEL_COUNTS);
+
+    group.bench_function("baseline_vec_scan_all_front_loaded_4_blocks_1024_channels", |b| {
+        b.iter_batched(
+            HashMap::new,
+            |mut channels| {
+                black_box(process_blocks_with_vec_tracking_and_full_scan(
+                    black_box(&mut channels),
+                    black_box(&front_loaded_block_tx_payloads),
+                    black_box(&rollup_config),
+                ));
+                black_box(channels)
+            },
+            BatchSize::SmallInput,
+        );
+    });
+    group.bench_function("fresh_tracker_front_loaded_4_blocks_1024_channels", |b| {
+        b.iter_batched(
+            HashMap::new,
+            |mut channels| {
+                black_box(process_blocks_with_fresh_tracker_and_touched_only_drain(
+                    black_box(&mut channels),
+                    black_box(&front_loaded_block_tx_payloads),
+                    black_box(&rollup_config),
+                ));
+                black_box(channels)
+            },
+            BatchSize::SmallInput,
+        );
+    });
+    group.bench_function("reused_tracker_front_loaded_4_blocks_1024_channels", |b| {
+        b.iter_batched(
+            HashMap::new,
+            |mut channels| {
+                black_box(process_blocks_with_tracker_and_touched_only_drain(
+                    black_box(&mut channels),
+                    black_box(&front_loaded_block_tx_payloads),
+                    black_box(&rollup_config),
+                ));
+                black_box(channels)
+            },
+            BatchSize::SmallInput,
+        );
+    });
+
+    group.bench_function("baseline_vec_scan_all_back_loaded_4_blocks_1024_channels", |b| {
+        b.iter_batched(
+            HashMap::new,
+            |mut channels| {
+                black_box(process_blocks_with_vec_tracking_and_full_scan(
+                    black_box(&mut channels),
+                    black_box(&back_loaded_block_tx_payloads),
+                    black_box(&rollup_config),
+                ));
+                black_box(channels)
+            },
+            BatchSize::SmallInput,
+        );
+    });
+    group.bench_function("fresh_tracker_back_loaded_4_blocks_1024_channels", |b| {
+        b.iter_batched(
+            HashMap::new,
+            |mut channels| {
+                black_box(process_blocks_with_fresh_tracker_and_touched_only_drain(
+                    black_box(&mut channels),
+                    black_box(&back_loaded_block_tx_payloads),
+                    black_box(&rollup_config),
+                ));
+                black_box(channels)
+            },
+            BatchSize::SmallInput,
+        );
+    });
+    group.bench_function("reused_tracker_back_loaded_4_blocks_1024_channels", |b| {
+        b.iter_batched(
+            HashMap::new,
+            |mut channels| {
+                black_box(process_blocks_with_tracker_and_touched_only_drain(
+                    black_box(&mut channels),
+                    black_box(&back_loaded_block_tx_payloads),
+                    black_box(&rollup_config),
+                ));
+                black_box(channels)
+            },
+            BatchSize::SmallInput,
+        );
+    });
+
+    group.finish();
+}
+
 criterion_group!(
     benches,
     bench_recent_tx_ready_channel_lookup,
@@ -974,5 +1113,6 @@ criterion_group!(
     bench_recent_tx_process_blocks,
     bench_recent_tx_process_blocks_ready_transition,
     bench_recent_tx_process_blocks_staggered_ready,
+    bench_recent_tx_process_blocks_weighted_ready,
 );
 criterion_main!(benches);

--- a/crates/batcher/service/benches/recent_txs.rs
+++ b/crates/batcher/service/benches/recent_txs.rs
@@ -19,6 +19,8 @@ const READY_CHANNEL_COUNT: usize = 4_096;
 const SPARSE_TOUCHED_CHANNEL_COUNT: usize = 64;
 const DUPLICATE_FANOUT_FRAME_COUNT: usize = 4_096;
 const DUPLICATE_FANOUT_UNIQUE_CHANNEL_COUNT: usize = 512;
+const MULTI_BLOCK_COUNT: usize = 8;
+const MULTI_BLOCK_TOUCHED_CHANNEL_COUNT: usize = 4_096;
 
 fn test_rollup_config() -> RollupConfig {
     RollupConfig {
@@ -158,9 +160,22 @@ fn ready_block_tx_payloads() -> Vec<Vec<u8>> {
         .collect()
 }
 
+fn incomplete_followup_tx_payloads(frame_number: u16, channel_count: usize) -> Vec<Vec<u8>> {
+    (0..channel_count).map(|index| incomplete_tx_payload(channel_id(index), frame_number)).collect()
+}
+
 fn sparse_incomplete_followup_tx_payloads() -> Vec<Vec<u8>> {
-    (0..SPARSE_TOUCHED_CHANNEL_COUNT)
-        .map(|index| incomplete_tx_payload(channel_id(index), 1))
+    incomplete_followup_tx_payloads(1, SPARSE_TOUCHED_CHANNEL_COUNT)
+}
+
+fn multi_block_incomplete_tx_payloads(
+    block_count: usize,
+    touched_channel_count: usize,
+) -> Vec<Vec<Vec<u8>>> {
+    (0..block_count)
+        .map(|block_index| {
+            incomplete_followup_tx_payloads((block_index + 1) as u16, touched_channel_count)
+        })
         .collect()
 }
 
@@ -608,11 +623,125 @@ fn bench_recent_tx_process_block(c: &mut Criterion) {
     group.finish();
 }
 
+fn process_blocks_with_tracker_and_touched_only_drain(
+    channels: &mut HashMap<ChannelId, Channel>,
+    block_tx_payloads: &[Vec<Vec<u8>>],
+    rollup_config: &RollupConfig,
+) -> Option<u64> {
+    let block_info = BlockInfo::default();
+    let mut touched_channel_ids = TouchedChannelTracker::default();
+    let mut highest = None;
+
+    for tx_payloads in block_tx_payloads {
+        touched_channel_ids.reset_with_capacity(tx_payloads.len());
+        for tx_payload in tx_payloads {
+            let frames =
+                Frame::parse_frames(tx_payload).expect("fixture tx payload must parse into frames");
+            for frame in frames {
+                touched_channel_ids.record(frame.id);
+                let channel =
+                    channels.entry(frame.id).or_insert_with(|| Channel::new(frame.id, block_info));
+                channel.add_frame(frame, block_info).expect("fixture frame must be accepted");
+            }
+        }
+
+        RecentTxScanner::drain_ready_channels(
+            channels,
+            touched_channel_ids.touched_channel_ids(),
+            0,
+            rollup_config,
+            &mut highest,
+        );
+    }
+
+    highest
+}
+
+fn process_blocks_with_fresh_tracker_and_touched_only_drain(
+    channels: &mut HashMap<ChannelId, Channel>,
+    block_tx_payloads: &[Vec<Vec<u8>>],
+    rollup_config: &RollupConfig,
+) -> Option<u64> {
+    let block_info = BlockInfo::default();
+    let mut highest = None;
+
+    for tx_payloads in block_tx_payloads {
+        let mut touched_channel_ids = TouchedChannelTracker::with_capacity(tx_payloads.len());
+        for tx_payload in tx_payloads {
+            let frames =
+                Frame::parse_frames(tx_payload).expect("fixture tx payload must parse into frames");
+            for frame in frames {
+                touched_channel_ids.record(frame.id);
+                let channel =
+                    channels.entry(frame.id).or_insert_with(|| Channel::new(frame.id, block_info));
+                channel.add_frame(frame, block_info).expect("fixture frame must be accepted");
+            }
+        }
+
+        RecentTxScanner::drain_ready_channels(
+            channels,
+            touched_channel_ids.touched_channel_ids(),
+            0,
+            rollup_config,
+            &mut highest,
+        );
+    }
+
+    highest
+}
+
+fn bench_recent_tx_process_blocks(c: &mut Criterion) {
+    let mut group = c.benchmark_group("batcher_service/recent_txs/process_blocks");
+    group.sample_size(20);
+
+    let rollup_config = test_rollup_config();
+    let block_tx_payloads =
+        multi_block_incomplete_tx_payloads(MULTI_BLOCK_COUNT, MULTI_BLOCK_TOUCHED_CHANNEL_COUNT);
+
+    group.bench_function(
+        "fresh_tracker_8_blocks_4096_incomplete_touches_each_among_persistent_channels",
+        |b| {
+            b.iter_batched(
+                HashMap::new,
+                |mut channels| {
+                    black_box(process_blocks_with_fresh_tracker_and_touched_only_drain(
+                        black_box(&mut channels),
+                        black_box(&block_tx_payloads),
+                        black_box(&rollup_config),
+                    ));
+                    black_box(channels)
+                },
+                BatchSize::SmallInput,
+            );
+        },
+    );
+    group.bench_function(
+        "reused_tracker_8_blocks_4096_incomplete_touches_each_among_persistent_channels",
+        |b| {
+            b.iter_batched(
+                HashMap::new,
+                |mut channels| {
+                    black_box(process_blocks_with_tracker_and_touched_only_drain(
+                        black_box(&mut channels),
+                        black_box(&block_tx_payloads),
+                        black_box(&rollup_config),
+                    ));
+                    black_box(channels)
+                },
+                BatchSize::SmallInput,
+            );
+        },
+    );
+
+    group.finish();
+}
+
 criterion_group!(
     benches,
     bench_recent_tx_ready_channel_lookup,
     bench_recent_tx_drain_ready_channels,
     bench_recent_tx_track_touched_channel_ids,
     bench_recent_tx_process_block,
+    bench_recent_tx_process_blocks,
 );
 criterion_main!(benches);

--- a/crates/batcher/service/benches/recent_txs.rs
+++ b/crates/batcher/service/benches/recent_txs.rs
@@ -1226,6 +1226,114 @@ fn bench_recent_tx_process_blocks_mixed_ready(c: &mut Criterion) {
     group.finish();
 }
 
+fn bench_recent_tx_process_blocks_touch_start_sparsity(c: &mut Criterion) {
+    let mut group =
+        c.benchmark_group("batcher_service/recent_txs/process_blocks_touch_start_sparsity");
+    group.sample_size(15);
+
+    let rollup_config = test_rollup_config();
+    let dense_start_block_tx_payloads =
+        multi_block_weighted_ready_tx_payloads(&BACK_LOADED_READY_CHANNEL_COUNTS);
+    let sparse_start_block_tx_payloads = multi_block_cohort_ready_tx_payloads(
+        MIXED_READY_BLOCK_COUNT,
+        &MIXED_BACK_LOADED_READY_COHORTS,
+    );
+
+    group.bench_function(
+        "baseline_vec_scan_all_dense_start_back_loaded_4_blocks_1024_channels",
+        |b| {
+            b.iter_batched(
+                HashMap::new,
+                |mut channels| {
+                    black_box(process_blocks_with_vec_tracking_and_full_scan(
+                        black_box(&mut channels),
+                        black_box(&dense_start_block_tx_payloads),
+                        black_box(&rollup_config),
+                    ));
+                    black_box(channels)
+                },
+                BatchSize::SmallInput,
+            );
+        },
+    );
+    group.bench_function("fresh_tracker_dense_start_back_loaded_4_blocks_1024_channels", |b| {
+        b.iter_batched(
+            HashMap::new,
+            |mut channels| {
+                black_box(process_blocks_with_fresh_tracker_and_touched_only_drain(
+                    black_box(&mut channels),
+                    black_box(&dense_start_block_tx_payloads),
+                    black_box(&rollup_config),
+                ));
+                black_box(channels)
+            },
+            BatchSize::SmallInput,
+        );
+    });
+    group.bench_function("reused_tracker_dense_start_back_loaded_4_blocks_1024_channels", |b| {
+        b.iter_batched(
+            HashMap::new,
+            |mut channels| {
+                black_box(process_blocks_with_tracker_and_touched_only_drain(
+                    black_box(&mut channels),
+                    black_box(&dense_start_block_tx_payloads),
+                    black_box(&rollup_config),
+                ));
+                black_box(channels)
+            },
+            BatchSize::SmallInput,
+        );
+    });
+
+    group.bench_function(
+        "baseline_vec_scan_all_sparse_start_back_loaded_4_blocks_1024_channels",
+        |b| {
+            b.iter_batched(
+                HashMap::new,
+                |mut channels| {
+                    black_box(process_blocks_with_vec_tracking_and_full_scan(
+                        black_box(&mut channels),
+                        black_box(&sparse_start_block_tx_payloads),
+                        black_box(&rollup_config),
+                    ));
+                    black_box(channels)
+                },
+                BatchSize::SmallInput,
+            );
+        },
+    );
+    group.bench_function("fresh_tracker_sparse_start_back_loaded_4_blocks_1024_channels", |b| {
+        b.iter_batched(
+            HashMap::new,
+            |mut channels| {
+                black_box(process_blocks_with_fresh_tracker_and_touched_only_drain(
+                    black_box(&mut channels),
+                    black_box(&sparse_start_block_tx_payloads),
+                    black_box(&rollup_config),
+                ));
+                black_box(channels)
+            },
+            BatchSize::SmallInput,
+        );
+    });
+    group.bench_function("reused_tracker_sparse_start_back_loaded_4_blocks_1024_channels", |b| {
+        b.iter_batched(
+            HashMap::new,
+            |mut channels| {
+                black_box(process_blocks_with_tracker_and_touched_only_drain(
+                    black_box(&mut channels),
+                    black_box(&sparse_start_block_tx_payloads),
+                    black_box(&rollup_config),
+                ));
+                black_box(channels)
+            },
+            BatchSize::SmallInput,
+        );
+    });
+
+    group.finish();
+}
+
 criterion_group!(
     benches,
     bench_recent_tx_ready_channel_lookup,
@@ -1237,5 +1345,6 @@ criterion_group!(
     bench_recent_tx_process_blocks_staggered_ready,
     bench_recent_tx_process_blocks_weighted_ready,
     bench_recent_tx_process_blocks_mixed_ready,
+    bench_recent_tx_process_blocks_touch_start_sparsity,
 );
 criterion_main!(benches);

--- a/crates/batcher/service/benches/recent_txs.rs
+++ b/crates/batcher/service/benches/recent_txs.rs
@@ -5,13 +5,15 @@ use std::hint::black_box;
 use alloy_eips::eip1898::BlockNumHash;
 use alloy_primitives::B256;
 use alloy_rlp::Encodable;
-use base_batcher_service::RecentTxScanner;
+use base_batcher_service::{RecentTxScanner, TouchedChannelTracker};
 use base_common_genesis::{ChainGenesis, RollupConfig};
 use base_protocol::{Batch, BlockInfo, Channel, ChannelId, Frame, SingleBatch};
 use criterion::{BatchSize, Criterion, criterion_group, criterion_main};
 
 const READY_CHANNEL_COUNT: usize = 4_096;
 const SPARSE_TOUCHED_CHANNEL_COUNT: usize = 64;
+const DUPLICATE_FANOUT_FRAME_COUNT: usize = 4_096;
+const DUPLICATE_FANOUT_UNIQUE_CHANNEL_COUNT: usize = 512;
 
 fn test_rollup_config() -> RollupConfig {
     RollupConfig {
@@ -70,7 +72,8 @@ fn channel_id(seed: usize) -> ChannelId {
 fn mixed_channel_map() -> std::collections::HashMap<ChannelId, Channel> {
     let mut channels = std::collections::HashMap::with_capacity(READY_CHANNEL_COUNT * 2);
     for index in 0..READY_CHANNEL_COUNT {
-        channels.insert(channel_id(index), ready_channel(channel_id(index), 1_010 + index as u64 * 2));
+        channels
+            .insert(channel_id(index), ready_channel(channel_id(index), 1_010 + index as u64 * 2));
         channels.insert(
             channel_id(index + READY_CHANNEL_COUNT),
             incomplete_channel(channel_id(index + READY_CHANNEL_COUNT)),
@@ -90,7 +93,8 @@ fn incomplete_channel_map() -> std::collections::HashMap<ChannelId, Channel> {
 fn sparse_ready_channel_map() -> std::collections::HashMap<ChannelId, Channel> {
     let mut channels = std::collections::HashMap::with_capacity(READY_CHANNEL_COUNT * 2);
     for index in 0..SPARSE_TOUCHED_CHANNEL_COUNT {
-        channels.insert(channel_id(index), ready_channel(channel_id(index), 1_010 + index as u64 * 2));
+        channels
+            .insert(channel_id(index), ready_channel(channel_id(index), 1_010 + index as u64 * 2));
     }
     for index in SPARSE_TOUCHED_CHANNEL_COUNT..READY_CHANNEL_COUNT * 2 {
         channels.insert(channel_id(index), incomplete_channel(channel_id(index)));
@@ -108,6 +112,34 @@ fn touched_incomplete_ids() -> Vec<ChannelId> {
 
 fn touched_sparse_ids() -> Vec<ChannelId> {
     (0..SPARSE_TOUCHED_CHANNEL_COUNT).map(channel_id).collect()
+}
+
+fn unique_frame_channel_ids() -> Vec<ChannelId> {
+    (0..READY_CHANNEL_COUNT).map(channel_id).collect()
+}
+
+fn duplicate_fanout_frame_channel_ids() -> Vec<ChannelId> {
+    (0..DUPLICATE_FANOUT_FRAME_COUNT)
+        .map(|index| channel_id(index % DUPLICATE_FANOUT_UNIQUE_CHANNEL_COUNT))
+        .collect()
+}
+
+fn track_touched_channel_ids_with_vec(frame_channel_ids: &[ChannelId]) -> Vec<ChannelId> {
+    let mut touched_channel_ids = Vec::with_capacity(frame_channel_ids.len());
+    for channel_id in frame_channel_ids {
+        if !touched_channel_ids.contains(channel_id) {
+            touched_channel_ids.push(*channel_id);
+        }
+    }
+    touched_channel_ids
+}
+
+fn track_touched_channel_ids_with_tracker(frame_channel_ids: &[ChannelId]) -> Vec<ChannelId> {
+    let mut tracker = TouchedChannelTracker::with_capacity(frame_channel_ids.len());
+    for channel_id in frame_channel_ids {
+        tracker.record(*channel_id);
+    }
+    tracker.touched_channel_ids().to_vec()
 }
 
 fn bench_recent_tx_drain_ready_channels(c: &mut Criterion) {
@@ -223,25 +255,22 @@ fn bench_recent_tx_drain_ready_channels(c: &mut Criterion) {
         );
     });
 
-    group.bench_function(
-        "baseline_scan_all_with_64_touched_incomplete_among_8192_channels",
-        |b| {
-            b.iter_batched(
-                incomplete_channel_map,
-                |mut channels| {
-                    let mut highest = None;
-                    RecentTxScanner::drain_all_ready_channels(
-                        black_box(&mut channels),
-                        black_box(0),
-                        black_box(&rollup_config),
-                        black_box(&mut highest),
-                    );
-                    black_box((channels, highest));
-                },
-                BatchSize::SmallInput,
-            );
-        },
-    );
+    group.bench_function("baseline_scan_all_with_64_touched_incomplete_among_8192_channels", |b| {
+        b.iter_batched(
+            incomplete_channel_map,
+            |mut channels| {
+                let mut highest = None;
+                RecentTxScanner::drain_all_ready_channels(
+                    black_box(&mut channels),
+                    black_box(0),
+                    black_box(&rollup_config),
+                    black_box(&mut highest),
+                );
+                black_box((channels, highest));
+            },
+            BatchSize::SmallInput,
+        );
+    });
 
     group.bench_function("64_touched_incomplete_among_8192_channels", |b| {
         b.iter_batched(
@@ -264,5 +293,38 @@ fn bench_recent_tx_drain_ready_channels(c: &mut Criterion) {
     group.finish();
 }
 
-criterion_group!(benches, bench_recent_tx_drain_ready_channels);
+fn bench_recent_tx_track_touched_channel_ids(c: &mut Criterion) {
+    let mut group = c.benchmark_group("batcher_service/recent_txs/track_touched_channel_ids");
+    group.sample_size(20);
+
+    let unique_frame_ids = unique_frame_channel_ids();
+    group.bench_function("baseline_vec_scan_4096_unique_frame_channel_ids", |b| {
+        b.iter(|| black_box(track_touched_channel_ids_with_vec(black_box(&unique_frame_ids))));
+    });
+    group.bench_function("hashset_tracker_4096_unique_frame_channel_ids", |b| {
+        b.iter(|| black_box(track_touched_channel_ids_with_tracker(black_box(&unique_frame_ids))));
+    });
+
+    let duplicate_fanout_frame_ids = duplicate_fanout_frame_channel_ids();
+    group.bench_function("baseline_vec_scan_4096_frames_across_512_unique_channel_ids", |b| {
+        b.iter(|| {
+            black_box(track_touched_channel_ids_with_vec(black_box(&duplicate_fanout_frame_ids)))
+        });
+    });
+    group.bench_function("hashset_tracker_4096_frames_across_512_unique_channel_ids", |b| {
+        b.iter(|| {
+            black_box(track_touched_channel_ids_with_tracker(black_box(
+                &duplicate_fanout_frame_ids,
+            )))
+        });
+    });
+
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_recent_tx_drain_ready_channels,
+    bench_recent_tx_track_touched_channel_ids,
+);
 criterion_main!(benches);

--- a/crates/batcher/service/src/lib.rs
+++ b/crates/batcher/service/src/lib.rs
@@ -11,7 +11,9 @@ mod config;
 pub use config::BatcherConfig;
 
 mod recent_txs;
-pub use recent_txs::{MAX_CHECK_RECENT_TXS_DEPTH, RecentTxScanner, SCAN_FETCH_CONCURRENCY};
+pub use recent_txs::{
+    MAX_CHECK_RECENT_TXS_DEPTH, RecentTxScanner, SCAN_FETCH_CONCURRENCY, TouchedChannelTracker,
+};
 
 mod source;
 pub use source::RpcPollingSource;

--- a/crates/batcher/service/src/recent_txs.rs
+++ b/crates/batcher/service/src/recent_txs.rs
@@ -37,6 +37,25 @@ impl TouchedChannelTracker {
         }
     }
 
+    /// Clears the tracker so it can be reused for another block scan.
+    pub fn clear(&mut self) {
+        self.touched_channel_ids.clear();
+        self.seen_channel_ids.clear();
+    }
+
+    /// Clears the tracker and grows its backing storage if `capacity` requires it.
+    pub fn reset_with_capacity(&mut self, capacity: usize) {
+        self.clear();
+
+        if self.touched_channel_ids.capacity() < capacity {
+            self.touched_channel_ids.reserve(capacity - self.touched_channel_ids.capacity());
+        }
+
+        if self.seen_channel_ids.capacity() < capacity {
+            self.seen_channel_ids.reserve(capacity - self.seen_channel_ids.capacity());
+        }
+    }
+
     /// Records a touched channel ID the first time it appears in the current block.
     pub fn record(&mut self, channel_id: ChannelId) {
         if self.seen_channel_ids.insert(channel_id) {
@@ -98,6 +117,7 @@ impl RecentTxScanner {
 
         let mut channels: HashMap<ChannelId, Channel> = HashMap::new();
         let mut highest_l2: Option<u64> = None;
+        let mut touched_channel_ids = TouchedChannelTracker::default();
 
         // Fetch blocks in parallel with bounded concurrency, preserving L1 order.
         // Blocks are processed as the stream yields them so peak memory is
@@ -135,8 +155,7 @@ impl RecentTxScanner {
                 timestamp: block.header.inner.timestamp,
             };
 
-            let mut touched_channel_ids =
-                TouchedChannelTracker::with_capacity(block.transactions.len());
+            touched_channel_ids.reset_with_capacity(block.transactions.len());
             for tx in block.transactions.txns() {
                 if tx.inner.signer() != batcher_address {
                     continue;
@@ -476,5 +495,24 @@ mod tests {
         tracker.record(channel_id_a);
 
         assert_eq!(tracker.touched_channel_ids(), &[channel_id_b, channel_id_a, channel_id_c]);
+    }
+
+    #[test]
+    fn touched_channel_tracker_reset_allows_reuse_after_clear() {
+        let channel_id_a: ChannelId = [1u8; 16];
+        let channel_id_b: ChannelId = [2u8; 16];
+        let channel_id_c: ChannelId = [3u8; 16];
+        let mut tracker = TouchedChannelTracker::with_capacity(2);
+
+        tracker.record(channel_id_a);
+        tracker.record(channel_id_b);
+        assert_eq!(tracker.touched_channel_ids(), &[channel_id_a, channel_id_b]);
+
+        tracker.reset_with_capacity(4);
+        tracker.record(channel_id_b);
+        tracker.record(channel_id_c);
+        tracker.record(channel_id_b);
+
+        assert_eq!(tracker.touched_channel_ids(), &[channel_id_b, channel_id_c]);
     }
 }

--- a/crates/batcher/service/src/recent_txs.rs
+++ b/crates/batcher/service/src/recent_txs.rs
@@ -106,6 +106,7 @@ impl RecentTxScanner {
                 timestamp: block.header.inner.timestamp,
             };
 
+            let mut touched_channel_ids = Vec::new();
             for tx in block.transactions.txns() {
                 if tx.inner.signer() != batcher_address {
                     continue;
@@ -122,6 +123,9 @@ impl RecentTxScanner {
                 };
 
                 for frame in frames {
+                    if !touched_channel_ids.contains(&frame.id) {
+                        touched_channel_ids.push(frame.id);
+                    }
                     let channel = channels
                         .entry(frame.id)
                         .or_insert_with(|| Channel::new(frame.id, block_info));
@@ -131,14 +135,13 @@ impl RecentTxScanner {
                 }
             }
 
-            // Drain channels that became complete within this block.
-            let complete_ids: Vec<ChannelId> =
-                channels.iter().filter(|(_, ch)| ch.is_ready()).map(|(id, _)| *id).collect();
-            for id in complete_ids {
-                if let Some(ch) = channels.remove(&id) {
-                    Self::decode_channel(&ch, block_info.timestamp, rollup_config, &mut highest_l2);
-                }
-            }
+            Self::drain_ready_channels(
+                &mut channels,
+                &touched_channel_ids,
+                block_info.timestamp,
+                rollup_config,
+                &mut highest_l2,
+            );
         }
 
         if let Some(block) = highest_l2 {
@@ -148,6 +151,48 @@ impl RecentTxScanner {
         }
 
         Ok(highest_l2)
+    }
+
+    /// Decodes all ready channels by scanning the full buffered map.
+    ///
+    /// This preserves the original O(n) scan behavior and is kept public so the
+    /// focused Criterion bench can compare the touched-only drain against the
+    /// full-map scan it replaced.
+    pub fn drain_all_ready_channels(
+        channels: &mut HashMap<ChannelId, Channel>,
+        inclusion_timestamp: u64,
+        rollup_config: &RollupConfig,
+        highest_l2: &mut Option<u64>,
+    ) {
+        let ready_channel_ids: Vec<ChannelId> =
+            channels.iter().filter(|(_, channel)| channel.is_ready()).map(|(id, _)| *id).collect();
+        for channel_id in ready_channel_ids {
+            if let Some(channel) = channels.remove(&channel_id) {
+                Self::decode_channel(&channel, inclusion_timestamp, rollup_config, highest_l2);
+            }
+        }
+    }
+
+    /// Decodes all channels that became ready within the current block.
+    ///
+    /// This helper is public so the startup-scan drain path can be benchmarked
+    /// directly without requiring a full RPC-backed recent-transaction scan.
+    pub fn drain_ready_channels(
+        channels: &mut HashMap<ChannelId, Channel>,
+        touched_channel_ids: &[ChannelId],
+        inclusion_timestamp: u64,
+        rollup_config: &RollupConfig,
+        highest_l2: &mut Option<u64>,
+    ) {
+        for channel_id in touched_channel_ids {
+            let is_ready = channels.get(channel_id).is_some_and(Channel::is_ready);
+            if !is_ready {
+                continue;
+            }
+            if let Some(channel) = channels.remove(channel_id) {
+                Self::decode_channel(&channel, inclusion_timestamp, rollup_config, highest_l2);
+            }
+        }
     }
 
     /// Decodes all batches from a complete channel and updates `highest_l2` with
@@ -175,6 +220,8 @@ impl RecentTxScanner {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
+
     use alloy_eips::eip1898::BlockNumHash;
     use alloy_primitives::B256;
     use alloy_rlp::Encodable;
@@ -324,5 +371,64 @@ mod tests {
         let mut highest = Some(2000u64);
         RecentTxScanner::decode_channel(&channel, 0, &cfg, &mut highest);
         assert_eq!(highest, Some(2000));
+    }
+
+    #[test]
+    fn drain_ready_channels_only_checks_touched_ids() {
+        let cfg = test_rollup_config(1000, 1000, 2);
+        let ready_channel = single_frame_channel(
+            [9u8; 16],
+            encode_single_batch(&SingleBatch { timestamp: 1010, ..Default::default() }),
+        );
+        let untouched_ready_id = ready_channel.id();
+        let touched_incomplete_id: ChannelId = [8u8; 16];
+        let mut touched_incomplete = Channel::new(touched_incomplete_id, BlockInfo::default());
+        touched_incomplete
+            .add_frame(
+                Frame {
+                    id: touched_incomplete_id,
+                    number: 0,
+                    data: b"partial".to_vec(),
+                    is_last: false,
+                },
+                BlockInfo::default(),
+            )
+            .expect("frame must be accepted");
+
+        let mut channels =
+            HashMap::from([(untouched_ready_id, ready_channel), (touched_incomplete_id, touched_incomplete)]);
+        let mut highest = None;
+
+        RecentTxScanner::drain_ready_channels(
+            &mut channels,
+            &[touched_incomplete_id],
+            0,
+            &cfg,
+            &mut highest,
+        );
+
+        assert_eq!(highest, None, "untouched ready channels should not be decoded this block");
+        assert!(
+            channels.contains_key(&untouched_ready_id),
+            "untouched ready channels must remain buffered"
+        );
+        assert!(
+            channels.contains_key(&touched_incomplete_id),
+            "touched but incomplete channels must remain buffered"
+        );
+
+        RecentTxScanner::drain_ready_channels(
+            &mut channels,
+            &[untouched_ready_id],
+            0,
+            &cfg,
+            &mut highest,
+        );
+
+        assert_eq!(highest, Some(1005));
+        assert!(
+            !channels.contains_key(&untouched_ready_id),
+            "touched ready channels must be drained once decoded"
+        );
     }
 }

--- a/crates/batcher/service/src/recent_txs.rs
+++ b/crates/batcher/service/src/recent_txs.rs
@@ -252,7 +252,7 @@ impl RecentTxScanner {
     ) {
         let Some(data) = channel.frame_data() else { return };
         let max_rlp = rollup_config.max_rlp_bytes_per_channel(inclusion_timestamp) as usize;
-        let mut reader = BatchReader::new(data.to_vec(), max_rlp);
+        let mut reader = BatchReader::new(data, max_rlp);
         while let Some(batch) = reader.next_batch(rollup_config) {
             let last_timestamp = match &batch {
                 Batch::Single(sb) => sb.timestamp,

--- a/crates/batcher/service/src/recent_txs.rs
+++ b/crates/batcher/service/src/recent_txs.rs
@@ -1,6 +1,6 @@
 //! Startup scan of recent L1 blocks for submitted batcher frames.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use alloy_primitives::Address;
 use alloy_provider::{Provider, RootProvider};
@@ -20,6 +20,35 @@ pub const MAX_CHECK_RECENT_TXS_DEPTH: u64 = 128;
 /// Bounds peak memory to roughly this many full L1 blocks while still
 /// achieving significant speedup over sequential fetching.
 pub const SCAN_FETCH_CONCURRENCY: usize = 16;
+
+/// Tracks the unique channel IDs touched while scanning a single L1 block.
+#[derive(Debug, Default)]
+pub struct TouchedChannelTracker {
+    touched_channel_ids: Vec<ChannelId>,
+    seen_channel_ids: HashSet<ChannelId>,
+}
+
+impl TouchedChannelTracker {
+    /// Creates a tracker sized for roughly `capacity` recorded frame touches.
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self {
+            touched_channel_ids: Vec::with_capacity(capacity),
+            seen_channel_ids: HashSet::with_capacity(capacity),
+        }
+    }
+
+    /// Records a touched channel ID the first time it appears in the current block.
+    pub fn record(&mut self, channel_id: ChannelId) {
+        if self.seen_channel_ids.insert(channel_id) {
+            self.touched_channel_ids.push(channel_id);
+        }
+    }
+
+    /// Returns the touched channel IDs in first-seen order.
+    pub fn touched_channel_ids(&self) -> &[ChannelId] {
+        &self.touched_channel_ids
+    }
+}
 
 /// Scans recent L1 blocks on startup to find the highest submitted L2 block.
 ///
@@ -106,7 +135,8 @@ impl RecentTxScanner {
                 timestamp: block.header.inner.timestamp,
             };
 
-            let mut touched_channel_ids = Vec::new();
+            let mut touched_channel_ids =
+                TouchedChannelTracker::with_capacity(block.transactions.len());
             for tx in block.transactions.txns() {
                 if tx.inner.signer() != batcher_address {
                     continue;
@@ -123,9 +153,7 @@ impl RecentTxScanner {
                 };
 
                 for frame in frames {
-                    if !touched_channel_ids.contains(&frame.id) {
-                        touched_channel_ids.push(frame.id);
-                    }
+                    touched_channel_ids.record(frame.id);
                     let channel = channels
                         .entry(frame.id)
                         .or_insert_with(|| Channel::new(frame.id, block_info));
@@ -137,7 +165,7 @@ impl RecentTxScanner {
 
             Self::drain_ready_channels(
                 &mut channels,
-                &touched_channel_ids,
+                touched_channel_ids.touched_channel_ids(),
                 block_info.timestamp,
                 rollup_config,
                 &mut highest_l2,
@@ -228,7 +256,7 @@ mod tests {
     use base_common_genesis::{ChainGenesis, RollupConfig};
     use base_protocol::{Batch, BlockInfo, Channel, ChannelId, Frame, SingleBatch};
 
-    use super::RecentTxScanner;
+    use super::{RecentTxScanner, TouchedChannelTracker};
 
     /// Build a [`RollupConfig`] with controllable genesis parameters for tests.
     fn test_rollup_config(
@@ -395,8 +423,10 @@ mod tests {
             )
             .expect("frame must be accepted");
 
-        let mut channels =
-            HashMap::from([(untouched_ready_id, ready_channel), (touched_incomplete_id, touched_incomplete)]);
+        let mut channels = HashMap::from([
+            (untouched_ready_id, ready_channel),
+            (touched_incomplete_id, touched_incomplete),
+        ]);
         let mut highest = None;
 
         RecentTxScanner::drain_ready_channels(
@@ -430,5 +460,21 @@ mod tests {
             !channels.contains_key(&untouched_ready_id),
             "touched ready channels must be drained once decoded"
         );
+    }
+
+    #[test]
+    fn touched_channel_tracker_deduplicates_and_preserves_first_seen_order() {
+        let channel_id_a: ChannelId = [1u8; 16];
+        let channel_id_b: ChannelId = [2u8; 16];
+        let channel_id_c: ChannelId = [3u8; 16];
+        let mut tracker = TouchedChannelTracker::with_capacity(6);
+
+        tracker.record(channel_id_b);
+        tracker.record(channel_id_a);
+        tracker.record(channel_id_b);
+        tracker.record(channel_id_c);
+        tracker.record(channel_id_a);
+
+        assert_eq!(tracker.touched_channel_ids(), &[channel_id_b, channel_id_a, channel_id_c]);
     }
 }

--- a/crates/consensus/derive/src/stages/channel/channel_reader.rs
+++ b/crates/consensus/derive/src/stages/channel/channel_reader.rs
@@ -69,8 +69,7 @@ where
                 RollupConfig::MAX_RLP_BYTES_PER_CHANNEL_BEDROCK
             };
 
-            self.next_batch =
-                Some(BatchReader::new(&channel[..], max_rlp_bytes_per_channel as usize));
+            self.next_batch = Some(BatchReader::new(channel, max_rlp_bytes_per_channel as usize));
             Metrics::pipeline_batch_reader_set().set(1);
         }
         Ok(())

--- a/crates/consensus/protocol/Cargo.toml
+++ b/crates/consensus/protocol/Cargo.toml
@@ -52,6 +52,7 @@ spin.workspace = true
 rstest.workspace = true
 proptest.workspace = true
 serde_json.workspace = true
+criterion.workspace = true
 base-common-chains.workspace = true
 base-common-rpc-types.workspace = true
 brotli = { workspace = true, features = ["std"] }
@@ -60,6 +61,10 @@ arbitrary = { workspace = true, features = ["derive"] }
 rand = { workspace = true, features = ["std", "std_rng"] }
 tracing-subscriber = { workspace = true, features = ["fmt"] }
 alloy-primitives = { workspace = true, features = ["arbitrary"] }
+
+[[bench]]
+name = "batch_reader"
+harness = false
 
 [features]
 default = [ "std" ]

--- a/crates/consensus/protocol/benches/batch_reader.rs
+++ b/crates/consensus/protocol/benches/batch_reader.rs
@@ -1,19 +1,19 @@
-//! Benchmarks for [`BatchReader`] constructor and decode paths.
+//! Benchmarks for [`BatchReader`] constructor, decompression, and decode paths.
 
 use std::hint::black_box;
 
 use alloy_primitives::{Bytes, hex};
 use base_common_genesis::RollupConfig;
-use base_protocol::BatchReader;
+use base_protocol::{BatchReader, Brotli};
 use criterion::{BatchSize, BenchmarkId, Criterion, criterion_group, criterion_main};
 use miniz_oxide::{
     deflate::{CompressionLevel, compress_to_vec_zlib},
-    inflate::decompress_to_vec_zlib,
+    inflate::{decompress_to_vec_zlib, decompress_to_vec_zlib_with_limit},
 };
 
 const BATCH_COUNTS: [usize; 2] = [1, 64];
 
-fn compressed_batch_fixture(batch_count: usize) -> (Bytes, usize) {
+fn decompressed_batch_fixture(batch_count: usize) -> Vec<u8> {
     let file_contents = String::from_utf8_lossy(include_bytes!("../testdata/batch.hex"));
     let file_contents = &file_contents[..file_contents.len() - 1];
     let raw = hex::decode(file_contents).expect("batch fixture must decode");
@@ -23,10 +23,28 @@ fn compressed_batch_fixture(batch_count: usize) -> (Bytes, usize) {
     for _ in 0..batch_count {
         multi_batch.extend_from_slice(&single_batch);
     }
+    multi_batch
+}
+
+fn compressed_batch_fixture(batch_count: usize) -> (Bytes, usize) {
+    let multi_batch = decompressed_batch_fixture(batch_count);
     let max_rlp_bytes_per_channel = multi_batch.len();
     let compressed = compress_to_vec_zlib(&multi_batch, CompressionLevel::BestSpeed.into()).into();
 
     (compressed, max_rlp_bytes_per_channel)
+}
+
+fn brotli_compressed_batch_fixture(batch_count: usize) -> (Bytes, usize) {
+    let multi_batch = decompressed_batch_fixture(batch_count);
+    let max_rlp_bytes_per_channel = multi_batch.len();
+
+    let mut compressed = Vec::new();
+    let mut input = multi_batch.as_slice();
+    let params = brotli::enc::BrotliEncoderParams::default();
+    brotli::BrotliCompress(&mut input, &mut compressed, &params)
+        .expect("batch fixture must brotli compress");
+
+    (compressed.into(), max_rlp_bytes_per_channel)
 }
 
 fn decode_all_batches(mut reader: BatchReader, cfg: &RollupConfig) -> usize {
@@ -72,6 +90,59 @@ fn bench_batch_reader_constructor(c: &mut Criterion) {
                             black_box(data),
                             black_box(max_rlp_bytes_per_channel),
                         ));
+                    },
+                    BatchSize::SmallInput,
+                );
+            },
+        );
+    }
+
+    group.finish();
+}
+
+fn bench_batch_reader_decompression_only(c: &mut Criterion) {
+    let mut group = c.benchmark_group("protocol/batch_reader/decompression_only");
+    group.sample_size(20);
+
+    for batch_count in BATCH_COUNTS {
+        let (zlib_compressed, max_rlp_bytes_per_channel) = compressed_batch_fixture(batch_count);
+        let (brotli_compressed, _) = brotli_compressed_batch_fixture(batch_count);
+
+        group.bench_with_input(
+            BenchmarkId::new("zlib", batch_count),
+            &zlib_compressed,
+            |b, compressed| {
+                b.iter_batched(
+                    || compressed.clone(),
+                    |data| {
+                        black_box(
+                            decompress_to_vec_zlib_with_limit(
+                                black_box(data).as_ref(),
+                                black_box(max_rlp_bytes_per_channel),
+                            )
+                            .expect("zlib fixture must decompress"),
+                        );
+                    },
+                    BatchSize::SmallInput,
+                );
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("brotli", batch_count),
+            &brotli_compressed,
+            |b, compressed| {
+                b.iter_batched(
+                    || compressed.clone(),
+                    |data| {
+                        black_box(
+                            Brotli
+                                .decompress(
+                                    black_box(data).as_ref(),
+                                    black_box(max_rlp_bytes_per_channel),
+                                )
+                                .expect("brotli fixture must decompress"),
+                        );
                     },
                     BatchSize::SmallInput,
                 );
@@ -131,5 +202,10 @@ fn bench_batch_reader_decode_all_batches(c: &mut Criterion) {
     group.finish();
 }
 
-criterion_group!(benches, bench_batch_reader_constructor, bench_batch_reader_decode_all_batches,);
+criterion_group!(
+    benches,
+    bench_batch_reader_constructor,
+    bench_batch_reader_decompression_only,
+    bench_batch_reader_decode_all_batches,
+);
 criterion_main!(benches);

--- a/crates/consensus/protocol/benches/batch_reader.rs
+++ b/crates/consensus/protocol/benches/batch_reader.rs
@@ -53,6 +53,14 @@ enum TypedTransactionFixture {
     Eip7702(TxEip7702),
 }
 
+#[derive(Clone, Copy)]
+enum TypedTransactionKind {
+    Legacy,
+    Eip2930,
+    Eip1559,
+    Eip7702,
+}
+
 fn decompressed_batch_fixture(batch_count: usize) -> Vec<u8> {
     let file_contents = String::from_utf8_lossy(include_bytes!("../testdata/batch.hex"));
     let file_contents = &file_contents[..file_contents.len() - 1];
@@ -403,12 +411,32 @@ fn typed_transaction_fixtures_from_decoded_span_transactions(
 }
 
 impl TypedTransactionFixture {
+    const fn kind(&self) -> TypedTransactionKind {
+        match self {
+            Self::Legacy(_) => TypedTransactionKind::Legacy,
+            Self::Eip2930(_) => TypedTransactionKind::Eip2930,
+            Self::Eip1559(_) => TypedTransactionKind::Eip1559,
+            Self::Eip7702(_) => TypedTransactionKind::Eip7702,
+        }
+    }
+
     fn signature_hash(&self) -> B256 {
         match self {
             Self::Legacy(tx) => tx.signature_hash(),
             Self::Eip2930(tx) => tx.signature_hash(),
             Self::Eip1559(tx) => tx.signature_hash(),
             Self::Eip7702(tx) => tx.signature_hash(),
+        }
+    }
+}
+
+impl TypedTransactionKind {
+    const fn label(self) -> &'static str {
+        match self {
+            Self::Legacy => "legacy",
+            Self::Eip2930 => "eip2930",
+            Self::Eip1559 => "eip1559",
+            Self::Eip7702 => "eip7702",
         }
     }
 }
@@ -423,6 +451,31 @@ fn signature_hash_all_typed_transactions(typed_transactions: &[TypedTransactionF
     }
 
     tx_count
+}
+
+fn typed_transaction_fixtures_grouped_by_kind(
+    typed_transactions: &[TypedTransactionFixture],
+) -> Vec<(TypedTransactionKind, Vec<TypedTransactionFixture>)> {
+    let mut legacy = Vec::new();
+    let mut eip2930 = Vec::new();
+    let mut eip1559 = Vec::new();
+    let mut eip7702 = Vec::new();
+
+    for typed_transaction in typed_transactions {
+        match typed_transaction.kind() {
+            TypedTransactionKind::Legacy => legacy.push(typed_transaction.clone()),
+            TypedTransactionKind::Eip2930 => eip2930.push(typed_transaction.clone()),
+            TypedTransactionKind::Eip1559 => eip1559.push(typed_transaction.clone()),
+            TypedTransactionKind::Eip7702 => eip7702.push(typed_transaction.clone()),
+        }
+    }
+
+    vec![
+        (TypedTransactionKind::Legacy, legacy),
+        (TypedTransactionKind::Eip2930, eip2930),
+        (TypedTransactionKind::Eip1559, eip1559),
+        (TypedTransactionKind::Eip7702, eip7702),
+    ]
 }
 
 fn build_all_signed_tx_envelopes(
@@ -920,6 +973,50 @@ fn bench_batch_reader_span_signed_tx_components(c: &mut Criterion) {
     group.finish();
 }
 
+fn bench_batch_reader_span_signature_hash_by_tx_type(c: &mut Criterion) {
+    let mut group = c.benchmark_group("protocol/batch_reader/span_signature_hash_by_tx_type");
+    group.sample_size(20);
+
+    let cfg = RollupConfig::default();
+    let chain_id = cfg.l2_chain_id.id();
+
+    for batch_count in BATCH_COUNTS {
+        let decompressed = decompressed_batch_fixture(batch_count);
+        let raw_span_batches = raw_span_batch_templates_from_decompressed(decompressed.as_slice());
+        let span_transactions = span_transaction_fixtures_from_raw_span_batches(&raw_span_batches);
+        let decoded_span_transactions = decoded_span_transaction_fixtures(&span_transactions);
+        let typed_transactions = typed_transaction_fixtures_from_decoded_span_transactions(
+            &decoded_span_transactions,
+            chain_id,
+        );
+
+        for (kind, typed_transactions) in
+            typed_transaction_fixtures_grouped_by_kind(&typed_transactions)
+        {
+            if typed_transactions.is_empty() {
+                continue;
+            }
+
+            group.bench_with_input(
+                BenchmarkId::new(
+                    format!("{}_{}_txs", kind.label(), typed_transactions.len()),
+                    batch_count,
+                ),
+                &typed_transactions,
+                |b, typed_transactions| {
+                    b.iter(|| {
+                        black_box(signature_hash_all_typed_transactions(black_box(
+                            typed_transactions.as_slice(),
+                        )));
+                    });
+                },
+            );
+        }
+    }
+
+    group.finish();
+}
+
 criterion_group!(
     benches,
     bench_batch_reader_constructor,
@@ -930,5 +1027,6 @@ criterion_group!(
     bench_batch_reader_batch_decode_components,
     bench_batch_reader_span_full_txs_components,
     bench_batch_reader_span_signed_tx_components,
+    bench_batch_reader_span_signature_hash_by_tx_type,
 );
 criterion_main!(benches);

--- a/crates/consensus/protocol/benches/batch_reader.rs
+++ b/crates/consensus/protocol/benches/batch_reader.rs
@@ -5,7 +5,7 @@ use std::hint::black_box;
 use alloy_primitives::{Bytes, hex};
 use alloy_rlp::Decodable;
 use base_common_genesis::{HardForkConfig, RollupConfig};
-use base_protocol::{Batch, BatchReader, Brotli};
+use base_protocol::{Batch, BatchReader, BatchType, Brotli, RawSpanBatch};
 use criterion::{BatchSize, BenchmarkId, Criterion, criterion_group, criterion_main};
 use miniz_oxide::{
     deflate::{CompressionLevel, compress_to_vec_zlib},
@@ -109,6 +109,27 @@ fn batch_payloads_from_decompressed(mut data: &[u8]) -> Vec<Bytes> {
     batch_payloads
 }
 
+fn span_batch_payloads_from_decompressed(data: &[u8]) -> Vec<Bytes> {
+    batch_payloads_from_decompressed(data)
+        .into_iter()
+        .map(|batch_payload| match batch_payload.as_ref().first().copied() {
+            Some(batch_type) if batch_type == BatchType::SPAN => batch_payload.slice(1..),
+            Some(batch_type) => panic!("expected span batch fixture, got batch type {batch_type}"),
+            None => panic!("batch payload fixture must not be empty"),
+        })
+        .collect()
+}
+
+fn raw_span_batch_templates_from_decompressed(data: &[u8]) -> Vec<RawSpanBatch> {
+    span_batch_payloads_from_decompressed(data)
+        .into_iter()
+        .map(|raw_span_payload| {
+            let mut raw_span_payload = raw_span_payload.as_ref();
+            RawSpanBatch::decode(&mut raw_span_payload).expect("span batch fixture must decode")
+        })
+        .collect()
+}
+
 fn count_rlp_wrapped_batches(mut data: &[u8]) -> usize {
     let mut batch_count = 0;
 
@@ -133,6 +154,50 @@ fn decode_all_batch_payloads(batch_payloads: &[Bytes], cfg: &RollupConfig) -> us
     }
 
     batch_count
+}
+
+fn decode_all_raw_span_batches(raw_span_payloads: &[Bytes]) -> usize {
+    let mut batch_count = 0;
+
+    for raw_span_payload in raw_span_payloads {
+        let mut raw_span_payload = raw_span_payload.as_ref();
+        let raw_span_batch =
+            RawSpanBatch::decode(&mut raw_span_payload).expect("span batch fixture must decode");
+        black_box(raw_span_batch);
+        batch_count += 1;
+    }
+
+    batch_count
+}
+
+fn decode_all_raw_span_full_txs(raw_span_batches: &[RawSpanBatch], chain_id: u64) -> usize {
+    let mut tx_count = 0;
+
+    for raw_span_batch in raw_span_batches {
+        let txs = raw_span_batch
+            .payload
+            .txs
+            .full_txs(chain_id)
+            .expect("span batch fixture transactions must decode");
+        tx_count += txs.len();
+        black_box(txs);
+    }
+
+    tx_count
+}
+
+fn derive_all_raw_span_batches(raw_span_batches: &mut [RawSpanBatch], cfg: &RollupConfig) -> usize {
+    let mut block_count = 0;
+
+    for raw_span_batch in raw_span_batches {
+        let span_batch = raw_span_batch
+            .derive(cfg.block_time, cfg.genesis.l2_time, cfg.l2_chain_id.id())
+            .expect("span batch fixture must derive");
+        block_count += span_batch.batches.len();
+        black_box(span_batch);
+    }
+
+    block_count
 }
 
 fn bench_rollup_config(label: &'static str) -> RollupConfig {
@@ -368,6 +433,66 @@ fn bench_batch_reader_post_decompression_components(c: &mut Criterion) {
     group.finish();
 }
 
+fn bench_batch_reader_batch_decode_components(c: &mut Criterion) {
+    let mut group = c.benchmark_group("protocol/batch_reader/batch_decode_components");
+    group.sample_size(20);
+
+    let cfg = RollupConfig::default();
+    let chain_id = cfg.l2_chain_id.id();
+
+    for batch_count in BATCH_COUNTS {
+        let decompressed = decompressed_batch_fixture(batch_count);
+        let raw_span_payloads = span_batch_payloads_from_decompressed(decompressed.as_slice());
+        let raw_span_batches = raw_span_batch_templates_from_decompressed(decompressed.as_slice());
+
+        group.bench_with_input(
+            BenchmarkId::new("raw_span_decode_only", batch_count),
+            &raw_span_payloads,
+            |b, raw_span_payloads| {
+                b.iter(|| {
+                    black_box(decode_all_raw_span_batches(black_box(raw_span_payloads.as_slice())));
+                });
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("span_full_txs_only", batch_count),
+            &raw_span_batches,
+            |b, raw_span_batches| {
+                b.iter_batched(
+                    || raw_span_batches.clone(),
+                    |raw_span_batches| {
+                        black_box(decode_all_raw_span_full_txs(
+                            black_box(raw_span_batches.as_slice()),
+                            black_box(chain_id),
+                        ));
+                    },
+                    BatchSize::LargeInput,
+                );
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("span_derive_only", batch_count),
+            &raw_span_batches,
+            |b, raw_span_batches| {
+                b.iter_batched(
+                    || raw_span_batches.clone(),
+                    |mut raw_span_batches| {
+                        black_box(derive_all_raw_span_batches(
+                            black_box(raw_span_batches.as_mut_slice()),
+                            black_box(&cfg),
+                        ));
+                    },
+                    BatchSize::LargeInput,
+                );
+            },
+        );
+    }
+
+    group.finish();
+}
+
 criterion_group!(
     benches,
     bench_batch_reader_constructor,
@@ -375,5 +500,6 @@ criterion_group!(
     bench_batch_reader_decode_all_batches,
     bench_batch_reader_post_decompression_decode_only,
     bench_batch_reader_post_decompression_components,
+    bench_batch_reader_batch_decode_components,
 );
 criterion_main!(benches);

--- a/crates/consensus/protocol/benches/batch_reader.rs
+++ b/crates/consensus/protocol/benches/batch_reader.rs
@@ -27,6 +27,19 @@ const SYNTHETIC_SIGNATURE_HASH_RICH_INPUT_LEN: usize = 1_024;
 const SYNTHETIC_SIGNATURE_HASH_RICH_ACCESS_LIST_ENTRY_COUNT: usize = 4;
 const SYNTHETIC_SIGNATURE_HASH_RICH_STORAGE_KEYS_PER_ENTRY: usize = 4;
 const SYNTHETIC_SIGNATURE_HASH_RICH_AUTHORIZATION_COUNT: usize = 4;
+const LEGACY_DIMENSION_SENSITIVITY_SHAPES: [SyntheticSignatureHashShape; 2] =
+    [SyntheticSignatureHashShape::Simple, SyntheticSignatureHashShape::InputHeavy];
+const ACCESS_LIST_DIMENSION_SENSITIVITY_SHAPES: [SyntheticSignatureHashShape; 3] = [
+    SyntheticSignatureHashShape::Simple,
+    SyntheticSignatureHashShape::InputHeavy,
+    SyntheticSignatureHashShape::AccessListHeavy,
+];
+const EIP7702_DIMENSION_SENSITIVITY_SHAPES: [SyntheticSignatureHashShape; 4] = [
+    SyntheticSignatureHashShape::Simple,
+    SyntheticSignatureHashShape::InputHeavy,
+    SyntheticSignatureHashShape::AccessListHeavy,
+    SyntheticSignatureHashShape::AuthorizationHeavy,
+];
 
 #[derive(Clone)]
 struct CompressionFixture {
@@ -63,7 +76,7 @@ enum TypedTransactionFixture {
     Eip7702(TxEip7702),
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, PartialEq, Eq)]
 enum TypedTransactionKind {
     Legacy,
     Eip2930,
@@ -74,6 +87,9 @@ enum TypedTransactionKind {
 #[derive(Clone, Copy)]
 enum SyntheticSignatureHashShape {
     Simple,
+    InputHeavy,
+    AccessListHeavy,
+    AuthorizationHeavy,
     Rich,
 }
 
@@ -461,16 +477,41 @@ impl SyntheticSignatureHashShape {
     const fn label(self) -> &'static str {
         match self {
             Self::Simple => "simple",
+            Self::InputHeavy => "input_heavy",
+            Self::AccessListHeavy => "access_list_heavy",
+            Self::AuthorizationHeavy => "authorization_heavy",
             Self::Rich => "rich",
+        }
+    }
+
+    const fn input_len(self) -> usize {
+        match self {
+            Self::Simple | Self::AccessListHeavy | Self::AuthorizationHeavy => 32,
+            Self::InputHeavy | Self::Rich => SYNTHETIC_SIGNATURE_HASH_RICH_INPUT_LEN,
+        }
+    }
+
+    const fn access_list_entry_count(self) -> usize {
+        match self {
+            Self::AccessListHeavy | Self::Rich => {
+                SYNTHETIC_SIGNATURE_HASH_RICH_ACCESS_LIST_ENTRY_COUNT
+            }
+            Self::Simple | Self::InputHeavy | Self::AuthorizationHeavy => 0,
+        }
+    }
+
+    const fn authorization_count(self) -> usize {
+        match self {
+            Self::AuthorizationHeavy | Self::Rich => {
+                SYNTHETIC_SIGNATURE_HASH_RICH_AUTHORIZATION_COUNT
+            }
+            Self::Simple | Self::InputHeavy | Self::AccessListHeavy => 1,
         }
     }
 }
 
 fn synthetic_signature_hash_input(seed: u8, shape: SyntheticSignatureHashShape) -> Bytes {
-    let input_len = match shape {
-        SyntheticSignatureHashShape::Simple => 32,
-        SyntheticSignatureHashShape::Rich => SYNTHETIC_SIGNATURE_HASH_RICH_INPUT_LEN,
-    };
+    let input_len = shape.input_len();
     let mut input = Vec::with_capacity(input_len);
     for idx in 0..input_len {
         input.push(seed.wrapping_add(idx as u8));
@@ -482,10 +523,9 @@ fn synthetic_signature_hash_access_list(
     seed: u8,
     shape: SyntheticSignatureHashShape,
 ) -> AccessList {
-    match shape {
-        SyntheticSignatureHashShape::Simple => AccessList::default(),
-        SyntheticSignatureHashShape::Rich => (0
-            ..SYNTHETIC_SIGNATURE_HASH_RICH_ACCESS_LIST_ENTRY_COUNT)
+    match shape.access_list_entry_count() {
+        0 => AccessList::default(),
+        access_list_entry_count => (0..access_list_entry_count)
             .map(|entry_idx| AccessListItem {
                 address: Address::from([seed.wrapping_add(entry_idx as u8 + 1); 20]),
                 storage_keys: (0..SYNTHETIC_SIGNATURE_HASH_RICH_STORAGE_KEYS_PER_ENTRY)
@@ -505,10 +545,7 @@ fn synthetic_signature_hash_authorization_list(
     nonce: u64,
     shape: SyntheticSignatureHashShape,
 ) -> Vec<SignedAuthorization> {
-    let authorization_count = match shape {
-        SyntheticSignatureHashShape::Simple => 1,
-        SyntheticSignatureHashShape::Rich => SYNTHETIC_SIGNATURE_HASH_RICH_AUTHORIZATION_COUNT,
-    };
+    let authorization_count = shape.authorization_count();
 
     (0..authorization_count)
         .map(|offset| {
@@ -596,6 +633,18 @@ fn synthetic_signature_hash_fixtures(
         (TypedTransactionKind::Eip1559, eip1559),
         (TypedTransactionKind::Eip7702, eip7702),
     ]
+}
+
+const fn synthetic_signature_hash_dimension_sensitivity_shapes(
+    kind: TypedTransactionKind,
+) -> &'static [SyntheticSignatureHashShape] {
+    match kind {
+        TypedTransactionKind::Legacy => &LEGACY_DIMENSION_SENSITIVITY_SHAPES,
+        TypedTransactionKind::Eip2930 | TypedTransactionKind::Eip1559 => {
+            &ACCESS_LIST_DIMENSION_SENSITIVITY_SHAPES
+        }
+        TypedTransactionKind::Eip7702 => &EIP7702_DIMENSION_SENSITIVITY_SHAPES,
+    }
 }
 
 fn signature_hash_all_typed_transactions(typed_transactions: &[TypedTransactionFixture]) -> usize {
@@ -1235,6 +1284,51 @@ fn bench_batch_reader_synthetic_signature_hash_shape_sensitivity(c: &mut Criteri
     group.finish();
 }
 
+fn bench_batch_reader_synthetic_signature_hash_dimension_sensitivity(c: &mut Criterion) {
+    let mut group =
+        c.benchmark_group("protocol/batch_reader/synthetic_signature_hash_dimension_sensitivity");
+    group.sample_size(10);
+
+    let chain_id = RollupConfig::default().l2_chain_id.id();
+
+    for kind in [
+        TypedTransactionKind::Legacy,
+        TypedTransactionKind::Eip2930,
+        TypedTransactionKind::Eip1559,
+        TypedTransactionKind::Eip7702,
+    ] {
+        for shape in synthetic_signature_hash_dimension_sensitivity_shapes(kind) {
+            let typed_transactions = synthetic_signature_hash_fixtures(
+                SYNTHETIC_SIGNATURE_HASH_TX_COUNT,
+                chain_id,
+                *shape,
+            )
+            .into_iter()
+            .find_map(|(fixture_kind, typed_transactions)| {
+                (fixture_kind == kind).then_some(typed_transactions)
+            })
+            .expect("synthetic signature hash fixtures must include every tx kind");
+
+            group.bench_with_input(
+                BenchmarkId::new(
+                    format!("{}_{}_txs_{}", kind.label(), typed_transactions.len(), shape.label()),
+                    "synthetic",
+                ),
+                &typed_transactions,
+                |b, typed_transactions| {
+                    b.iter(|| {
+                        black_box(signature_hash_all_typed_transactions(black_box(
+                            typed_transactions.as_slice(),
+                        )));
+                    });
+                },
+            );
+        }
+    }
+
+    group.finish();
+}
+
 criterion_group!(
     benches,
     bench_batch_reader_constructor,
@@ -1248,5 +1342,6 @@ criterion_group!(
     bench_batch_reader_span_signature_hash_by_tx_type,
     bench_batch_reader_synthetic_signature_hash_by_tx_type,
     bench_batch_reader_synthetic_signature_hash_shape_sensitivity,
+    bench_batch_reader_synthetic_signature_hash_dimension_sensitivity,
 );
 criterion_main!(benches);

--- a/crates/consensus/protocol/benches/batch_reader.rs
+++ b/crates/consensus/protocol/benches/batch_reader.rs
@@ -2,10 +2,14 @@
 
 use std::hint::black_box;
 
-use alloy_primitives::{Bytes, hex};
+use alloy_consensus::TxEnvelope;
+use alloy_eips::eip2718::Encodable2718;
+use alloy_primitives::{Address, Bytes, Signature, hex};
 use alloy_rlp::Decodable;
 use base_common_genesis::{HardForkConfig, RollupConfig};
-use base_protocol::{Batch, BatchReader, BatchType, Brotli, RawSpanBatch};
+use base_protocol::{
+    Batch, BatchReader, BatchType, Brotli, RawSpanBatch, SpanBatchTransactionData,
+};
 use criterion::{BatchSize, BenchmarkId, Criterion, criterion_group, criterion_main};
 use miniz_oxide::{
     deflate::{CompressionLevel, compress_to_vec_zlib},
@@ -19,6 +23,26 @@ struct CompressionFixture {
     label: &'static str,
     compressed: Bytes,
     max_rlp_bytes_per_channel: usize,
+}
+
+#[derive(Clone)]
+struct SpanTransactionFixture {
+    tx_data: Vec<u8>,
+    nonce: u64,
+    gas: u64,
+    to: Option<Address>,
+    signature: Signature,
+    is_protected: bool,
+}
+
+#[derive(Clone)]
+struct DecodedSpanTransactionFixture {
+    tx: SpanBatchTransactionData,
+    nonce: u64,
+    gas: u64,
+    to: Option<Address>,
+    signature: Signature,
+    is_protected: bool,
 }
 
 fn decompressed_batch_fixture(batch_count: usize) -> Vec<u8> {
@@ -198,6 +222,164 @@ fn derive_all_raw_span_batches(raw_span_batches: &mut [RawSpanBatch], cfg: &Roll
     }
 
     block_count
+}
+
+fn span_transaction_fixtures_from_raw_span_batches(
+    raw_span_batches: &[RawSpanBatch],
+) -> Vec<SpanTransactionFixture> {
+    let total_tx_count = raw_span_batches
+        .iter()
+        .map(|raw_span_batch| raw_span_batch.payload.txs.total_block_tx_count as usize)
+        .sum();
+    let mut fixtures = Vec::with_capacity(total_tx_count);
+
+    for raw_span_batch in raw_span_batches {
+        let txs = &raw_span_batch.payload.txs;
+        let mut to_idx = 0;
+        let mut protected_bit_idx = 0;
+
+        for idx in 0..txs.total_block_tx_count as usize {
+            let contract_creation_bit = txs
+                .contract_creation_bits
+                .get_bit(idx)
+                .expect("span batch fixture contract creation bit must exist");
+            let to = if contract_creation_bit == 0 {
+                let to = *txs.tx_tos.get(to_idx).expect("span batch fixture to address must exist");
+                to_idx += 1;
+                Some(to)
+            } else {
+                None
+            };
+            let tx_type = *txs.tx_types.get(idx).expect("span batch fixture tx type must exist");
+            let is_protected = if tx_type.is_legacy() {
+                let is_protected =
+                    txs.protected_bits.get_bit(protected_bit_idx).unwrap_or_default() == 1;
+                protected_bit_idx += 1;
+                is_protected
+            } else {
+                true
+            };
+
+            fixtures.push(SpanTransactionFixture {
+                tx_data: txs.tx_data[idx].clone(),
+                nonce: *txs.tx_nonces.get(idx).expect("span batch fixture nonce must exist"),
+                gas: *txs.tx_gases.get(idx).expect("span batch fixture gas must exist"),
+                to,
+                signature: *txs.tx_sigs.get(idx).expect("span batch fixture signature must exist"),
+                is_protected,
+            });
+        }
+    }
+
+    fixtures
+}
+
+fn decode_all_span_transaction_data(span_transactions: &[SpanTransactionFixture]) -> usize {
+    let mut tx_count = 0;
+
+    for span_transaction in span_transactions {
+        let mut tx_data = span_transaction.tx_data.as_slice();
+        let tx = SpanBatchTransactionData::decode(&mut tx_data)
+            .expect("span batch fixture transaction data must decode");
+        black_box(tx);
+        tx_count += 1;
+    }
+
+    tx_count
+}
+
+fn decoded_span_transaction_fixtures(
+    span_transactions: &[SpanTransactionFixture],
+) -> Vec<DecodedSpanTransactionFixture> {
+    span_transactions
+        .iter()
+        .map(|span_transaction| {
+            let mut tx_data = span_transaction.tx_data.as_slice();
+            let tx = SpanBatchTransactionData::decode(&mut tx_data)
+                .expect("span batch fixture transaction data must decode");
+            DecodedSpanTransactionFixture {
+                tx,
+                nonce: span_transaction.nonce,
+                gas: span_transaction.gas,
+                to: span_transaction.to,
+                signature: span_transaction.signature,
+                is_protected: span_transaction.is_protected,
+            }
+        })
+        .collect()
+}
+
+fn build_all_signed_tx_envelopes(
+    span_transactions: &[DecodedSpanTransactionFixture],
+    chain_id: u64,
+) -> usize {
+    let mut tx_count = 0;
+
+    for span_transaction in span_transactions {
+        let tx_envelope = span_transaction
+            .tx
+            .to_signed_tx(
+                span_transaction.nonce,
+                span_transaction.gas,
+                span_transaction.to,
+                chain_id,
+                span_transaction.signature,
+                span_transaction.is_protected,
+            )
+            .expect("span batch fixture signed transaction must build");
+        black_box(tx_envelope);
+        tx_count += 1;
+    }
+
+    tx_count
+}
+
+fn signed_tx_envelopes_from_decoded_span_transactions(
+    span_transactions: &[DecodedSpanTransactionFixture],
+    chain_id: u64,
+) -> Vec<TxEnvelope> {
+    span_transactions
+        .iter()
+        .map(|span_transaction| {
+            span_transaction
+                .tx
+                .to_signed_tx(
+                    span_transaction.nonce,
+                    span_transaction.gas,
+                    span_transaction.to,
+                    chain_id,
+                    span_transaction.signature,
+                    span_transaction.is_protected,
+                )
+                .expect("span batch fixture signed transaction must build")
+        })
+        .collect()
+}
+
+fn encode_all_signed_tx_envelopes(tx_envelopes: &[TxEnvelope]) -> usize {
+    let mut total_bytes = 0;
+
+    for tx_envelope in tx_envelopes {
+        let mut buf = Vec::new();
+        tx_envelope.encode_2718(&mut buf);
+        total_bytes += buf.len();
+        black_box(buf);
+    }
+
+    total_bytes
+}
+
+fn encode_all_signed_tx_envelopes_exact_capacity(tx_envelopes: &[TxEnvelope]) -> usize {
+    let mut total_bytes = 0;
+
+    for tx_envelope in tx_envelopes {
+        let mut buf = Vec::with_capacity(tx_envelope.encode_2718_len());
+        tx_envelope.encode_2718(&mut buf);
+        total_bytes += buf.len();
+        black_box(buf);
+    }
+
+    total_bytes
 }
 
 fn bench_rollup_config(label: &'static str) -> RollupConfig {
@@ -493,6 +675,76 @@ fn bench_batch_reader_batch_decode_components(c: &mut Criterion) {
     group.finish();
 }
 
+fn bench_batch_reader_span_full_txs_components(c: &mut Criterion) {
+    let mut group = c.benchmark_group("protocol/batch_reader/span_full_txs_components");
+    group.sample_size(20);
+
+    let cfg = RollupConfig::default();
+    let chain_id = cfg.l2_chain_id.id();
+
+    for batch_count in BATCH_COUNTS {
+        let decompressed = decompressed_batch_fixture(batch_count);
+        let raw_span_batches = raw_span_batch_templates_from_decompressed(decompressed.as_slice());
+        let span_transactions = span_transaction_fixtures_from_raw_span_batches(&raw_span_batches);
+        let decoded_span_transactions = decoded_span_transaction_fixtures(&span_transactions);
+        let signed_tx_envelopes = signed_tx_envelopes_from_decoded_span_transactions(
+            &decoded_span_transactions,
+            chain_id,
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("span_tx_data_decode_only", batch_count),
+            &span_transactions,
+            |b, span_transactions| {
+                b.iter(|| {
+                    black_box(decode_all_span_transaction_data(black_box(
+                        span_transactions.as_slice(),
+                    )));
+                });
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("span_to_signed_tx_only", batch_count),
+            &decoded_span_transactions,
+            |b, decoded_span_transactions| {
+                b.iter(|| {
+                    black_box(build_all_signed_tx_envelopes(
+                        black_box(decoded_span_transactions.as_slice()),
+                        black_box(chain_id),
+                    ));
+                });
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("span_encode_2718_only", batch_count),
+            &signed_tx_envelopes,
+            |b, signed_tx_envelopes| {
+                b.iter(|| {
+                    black_box(encode_all_signed_tx_envelopes(black_box(
+                        signed_tx_envelopes.as_slice(),
+                    )));
+                });
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("span_encode_2718_exact_capacity_only", batch_count),
+            &signed_tx_envelopes,
+            |b, signed_tx_envelopes| {
+                b.iter(|| {
+                    black_box(encode_all_signed_tx_envelopes_exact_capacity(black_box(
+                        signed_tx_envelopes.as_slice(),
+                    )));
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
 criterion_group!(
     benches,
     bench_batch_reader_constructor,
@@ -501,5 +753,6 @@ criterion_group!(
     bench_batch_reader_post_decompression_decode_only,
     bench_batch_reader_post_decompression_components,
     bench_batch_reader_batch_decode_components,
+    bench_batch_reader_span_full_txs_components,
 );
 criterion_main!(benches);

--- a/crates/consensus/protocol/benches/batch_reader.rs
+++ b/crates/consensus/protocol/benches/batch_reader.rs
@@ -2,9 +2,9 @@
 
 use std::hint::black_box;
 
-use alloy_consensus::TxEnvelope;
+use alloy_consensus::{SignableTransaction, TxEip1559, TxEip2930, TxEip7702, TxEnvelope, TxLegacy};
 use alloy_eips::eip2718::Encodable2718;
-use alloy_primitives::{Address, Bytes, Signature, hex};
+use alloy_primitives::{Address, B256, Bytes, Signature, TxKind, U256, hex};
 use alloy_rlp::Decodable;
 use base_common_genesis::{HardForkConfig, RollupConfig};
 use base_protocol::{
@@ -43,6 +43,14 @@ struct DecodedSpanTransactionFixture {
     to: Option<Address>,
     signature: Signature,
     is_protected: bool,
+}
+
+#[derive(Clone)]
+enum TypedTransactionFixture {
+    Legacy(TxLegacy),
+    Eip2930(TxEip2930),
+    Eip1559(TxEip1559),
+    Eip7702(TxEip7702),
 }
 
 fn decompressed_batch_fixture(batch_count: usize) -> Vec<u8> {
@@ -307,6 +315,114 @@ fn decoded_span_transaction_fixtures(
             }
         })
         .collect()
+}
+
+fn u128_from_u256(value: &U256) -> u128 {
+    u128::from_be_bytes(
+        value.to_be_bytes::<32>()[16..]
+            .try_into()
+            .expect("low 16 bytes of U256 must decode as u128"),
+    )
+}
+
+fn build_typed_transaction(
+    span_transaction: &DecodedSpanTransactionFixture,
+    chain_id: u64,
+) -> TypedTransactionFixture {
+    match &span_transaction.tx {
+        SpanBatchTransactionData::Legacy(data) => TypedTransactionFixture::Legacy(TxLegacy {
+            chain_id: span_transaction.is_protected.then_some(chain_id),
+            nonce: span_transaction.nonce,
+            gas_price: u128_from_u256(&data.gas_price),
+            gas_limit: span_transaction.gas,
+            to: span_transaction.to.map_or(TxKind::Create, TxKind::Call),
+            value: data.value,
+            input: data.data.clone().into(),
+        }),
+        SpanBatchTransactionData::Eip2930(data) => TypedTransactionFixture::Eip2930(TxEip2930 {
+            chain_id,
+            nonce: span_transaction.nonce,
+            gas_price: u128_from_u256(&data.gas_price),
+            gas_limit: span_transaction.gas,
+            to: span_transaction.to.map_or(TxKind::Create, TxKind::Call),
+            value: data.value,
+            input: data.data.clone().into(),
+            access_list: data.access_list.clone(),
+        }),
+        SpanBatchTransactionData::Eip1559(data) => TypedTransactionFixture::Eip1559(TxEip1559 {
+            chain_id,
+            nonce: span_transaction.nonce,
+            max_fee_per_gas: u128_from_u256(&data.max_fee_per_gas),
+            max_priority_fee_per_gas: u128_from_u256(&data.max_priority_fee_per_gas),
+            gas_limit: span_transaction.gas,
+            to: span_transaction.to.map_or(TxKind::Create, TxKind::Call),
+            value: data.value,
+            input: data.data.clone().into(),
+            access_list: data.access_list.clone(),
+        }),
+        SpanBatchTransactionData::Eip7702(data) => TypedTransactionFixture::Eip7702(TxEip7702 {
+            chain_id,
+            nonce: span_transaction.nonce,
+            max_fee_per_gas: u128_from_u256(&data.max_fee_per_gas),
+            max_priority_fee_per_gas: u128_from_u256(&data.max_priority_fee_per_gas),
+            gas_limit: span_transaction.gas,
+            to: span_transaction
+                .to
+                .expect("span batch fixture eip7702 transaction must have a to address"),
+            value: data.value,
+            input: data.data.clone().into(),
+            access_list: data.access_list.clone(),
+            authorization_list: data.authorization_list.clone(),
+        }),
+    }
+}
+
+fn build_all_typed_transactions(
+    span_transactions: &[DecodedSpanTransactionFixture],
+    chain_id: u64,
+) -> usize {
+    let mut tx_count = 0;
+
+    for span_transaction in span_transactions {
+        let tx = build_typed_transaction(span_transaction, chain_id);
+        black_box(tx);
+        tx_count += 1;
+    }
+
+    tx_count
+}
+
+fn typed_transaction_fixtures_from_decoded_span_transactions(
+    span_transactions: &[DecodedSpanTransactionFixture],
+    chain_id: u64,
+) -> Vec<TypedTransactionFixture> {
+    span_transactions
+        .iter()
+        .map(|span_transaction| build_typed_transaction(span_transaction, chain_id))
+        .collect()
+}
+
+impl TypedTransactionFixture {
+    fn signature_hash(&self) -> B256 {
+        match self {
+            Self::Legacy(tx) => tx.signature_hash(),
+            Self::Eip2930(tx) => tx.signature_hash(),
+            Self::Eip1559(tx) => tx.signature_hash(),
+            Self::Eip7702(tx) => tx.signature_hash(),
+        }
+    }
+}
+
+fn signature_hash_all_typed_transactions(typed_transactions: &[TypedTransactionFixture]) -> usize {
+    let mut tx_count = 0;
+
+    for typed_transaction in typed_transactions {
+        let signature_hash = typed_transaction.signature_hash();
+        black_box(signature_hash);
+        tx_count += 1;
+    }
+
+    tx_count
 }
 
 fn build_all_signed_tx_envelopes(
@@ -745,6 +861,65 @@ fn bench_batch_reader_span_full_txs_components(c: &mut Criterion) {
     group.finish();
 }
 
+fn bench_batch_reader_span_signed_tx_components(c: &mut Criterion) {
+    let mut group = c.benchmark_group("protocol/batch_reader/span_signed_tx_components");
+    group.sample_size(20);
+
+    let cfg = RollupConfig::default();
+    let chain_id = cfg.l2_chain_id.id();
+
+    for batch_count in BATCH_COUNTS {
+        let decompressed = decompressed_batch_fixture(batch_count);
+        let raw_span_batches = raw_span_batch_templates_from_decompressed(decompressed.as_slice());
+        let span_transactions = span_transaction_fixtures_from_raw_span_batches(&raw_span_batches);
+        let decoded_span_transactions = decoded_span_transaction_fixtures(&span_transactions);
+        let typed_transactions = typed_transaction_fixtures_from_decoded_span_transactions(
+            &decoded_span_transactions,
+            chain_id,
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("span_to_signed_tx_only", batch_count),
+            &decoded_span_transactions,
+            |b, decoded_span_transactions| {
+                b.iter(|| {
+                    black_box(build_all_signed_tx_envelopes(
+                        black_box(decoded_span_transactions.as_slice()),
+                        black_box(chain_id),
+                    ));
+                });
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("span_build_typed_tx_only", batch_count),
+            &decoded_span_transactions,
+            |b, decoded_span_transactions| {
+                b.iter(|| {
+                    black_box(build_all_typed_transactions(
+                        black_box(decoded_span_transactions.as_slice()),
+                        black_box(chain_id),
+                    ));
+                });
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("span_signature_hash_only", batch_count),
+            &typed_transactions,
+            |b, typed_transactions| {
+                b.iter(|| {
+                    black_box(signature_hash_all_typed_transactions(black_box(
+                        typed_transactions.as_slice(),
+                    )));
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
 criterion_group!(
     benches,
     bench_batch_reader_constructor,
@@ -754,5 +929,6 @@ criterion_group!(
     bench_batch_reader_post_decompression_components,
     bench_batch_reader_batch_decode_components,
     bench_batch_reader_span_full_txs_components,
+    bench_batch_reader_span_signed_tx_components,
 );
 criterion_main!(benches);

--- a/crates/consensus/protocol/benches/batch_reader.rs
+++ b/crates/consensus/protocol/benches/batch_reader.rs
@@ -3,7 +3,11 @@
 use std::hint::black_box;
 
 use alloy_consensus::{SignableTransaction, TxEip1559, TxEip2930, TxEip7702, TxEnvelope, TxLegacy};
-use alloy_eips::eip2718::Encodable2718;
+use alloy_eips::{
+    eip2718::Encodable2718,
+    eip2930::{AccessList, AccessListItem},
+    eip7702::SignedAuthorization,
+};
 use alloy_primitives::{Address, B256, Bytes, Signature, TxKind, U256, hex};
 use alloy_rlp::Decodable;
 use alloy_rpc_types_eth::Authorization;
@@ -19,6 +23,10 @@ use miniz_oxide::{
 
 const BATCH_COUNTS: [usize; 2] = [1, 64];
 const SYNTHETIC_SIGNATURE_HASH_TX_COUNT: usize = 1_024;
+const SYNTHETIC_SIGNATURE_HASH_RICH_INPUT_LEN: usize = 1_024;
+const SYNTHETIC_SIGNATURE_HASH_RICH_ACCESS_LIST_ENTRY_COUNT: usize = 4;
+const SYNTHETIC_SIGNATURE_HASH_RICH_STORAGE_KEYS_PER_ENTRY: usize = 4;
+const SYNTHETIC_SIGNATURE_HASH_RICH_AUTHORIZATION_COUNT: usize = 4;
 
 #[derive(Clone)]
 struct CompressionFixture {
@@ -61,6 +69,12 @@ enum TypedTransactionKind {
     Eip2930,
     Eip1559,
     Eip7702,
+}
+
+#[derive(Clone, Copy)]
+enum SyntheticSignatureHashShape {
+    Simple,
+    Rich,
 }
 
 fn decompressed_batch_fixture(batch_count: usize) -> Vec<u8> {
@@ -443,9 +457,75 @@ impl TypedTransactionKind {
     }
 }
 
+impl SyntheticSignatureHashShape {
+    const fn label(self) -> &'static str {
+        match self {
+            Self::Simple => "simple",
+            Self::Rich => "rich",
+        }
+    }
+}
+
+fn synthetic_signature_hash_input(seed: u8, shape: SyntheticSignatureHashShape) -> Bytes {
+    let input_len = match shape {
+        SyntheticSignatureHashShape::Simple => 32,
+        SyntheticSignatureHashShape::Rich => SYNTHETIC_SIGNATURE_HASH_RICH_INPUT_LEN,
+    };
+    let mut input = Vec::with_capacity(input_len);
+    for idx in 0..input_len {
+        input.push(seed.wrapping_add(idx as u8));
+    }
+    input.into()
+}
+
+fn synthetic_signature_hash_access_list(
+    seed: u8,
+    shape: SyntheticSignatureHashShape,
+) -> AccessList {
+    match shape {
+        SyntheticSignatureHashShape::Simple => AccessList::default(),
+        SyntheticSignatureHashShape::Rich => (0
+            ..SYNTHETIC_SIGNATURE_HASH_RICH_ACCESS_LIST_ENTRY_COUNT)
+            .map(|entry_idx| AccessListItem {
+                address: Address::from([seed.wrapping_add(entry_idx as u8 + 1); 20]),
+                storage_keys: (0..SYNTHETIC_SIGNATURE_HASH_RICH_STORAGE_KEYS_PER_ENTRY)
+                    .map(|key_idx| {
+                        B256::from([seed.wrapping_add((entry_idx * 16 + key_idx) as u8); 32])
+                    })
+                    .collect(),
+            })
+            .collect::<Vec<_>>()
+            .into(),
+    }
+}
+
+fn synthetic_signature_hash_authorization_list(
+    chain_id: u64,
+    to: Address,
+    nonce: u64,
+    shape: SyntheticSignatureHashShape,
+) -> Vec<SignedAuthorization> {
+    let authorization_count = match shape {
+        SyntheticSignatureHashShape::Simple => 1,
+        SyntheticSignatureHashShape::Rich => SYNTHETIC_SIGNATURE_HASH_RICH_AUTHORIZATION_COUNT,
+    };
+
+    (0..authorization_count)
+        .map(|offset| {
+            Authorization {
+                chain_id: U256::from(chain_id),
+                address: Address::from([to.as_slice()[0].wrapping_add(offset as u8); 20]),
+                nonce: nonce + offset as u64,
+            }
+            .into_signed(Signature::test_signature())
+        })
+        .collect()
+}
+
 fn synthetic_signature_hash_fixtures(
     tx_count: usize,
     chain_id: u64,
+    shape: SyntheticSignatureHashShape,
 ) -> Vec<(TypedTransactionKind, Vec<TypedTransactionFixture>)> {
     let mut legacy = Vec::with_capacity(tx_count);
     let mut eip2930 = Vec::with_capacity(tx_count);
@@ -458,7 +538,8 @@ fn synthetic_signature_hash_fixtures(
         let to = Address::from([seed; 20]);
         let value = U256::from(nonce + 1);
         let gas_limit = 21_000 + (nonce % 1_024);
-        let input = Bytes::from(vec![seed; 32]);
+        let input = synthetic_signature_hash_input(seed, shape);
+        let access_list = synthetic_signature_hash_access_list(seed, shape);
 
         legacy.push(TypedTransactionFixture::Legacy(TxLegacy {
             chain_id: Some(chain_id),
@@ -478,7 +559,7 @@ fn synthetic_signature_hash_fixtures(
             to: TxKind::Call(to),
             value,
             input: input.clone(),
-            access_list: Default::default(),
+            access_list: access_list.clone(),
         }));
 
         eip1559.push(TypedTransactionFixture::Eip1559(TxEip1559 {
@@ -490,11 +571,9 @@ fn synthetic_signature_hash_fixtures(
             to: TxKind::Call(to),
             value,
             input: input.clone(),
-            access_list: Default::default(),
+            access_list: access_list.clone(),
         }));
 
-        let authorization = Authorization { chain_id: U256::from(chain_id), address: to, nonce };
-        let signed_authorization = authorization.into_signed(Signature::test_signature());
         eip7702.push(TypedTransactionFixture::Eip7702(TxEip7702 {
             chain_id,
             nonce,
@@ -504,8 +583,10 @@ fn synthetic_signature_hash_fixtures(
             to,
             value,
             input,
-            access_list: Default::default(),
-            authorization_list: vec![signed_authorization],
+            access_list,
+            authorization_list: synthetic_signature_hash_authorization_list(
+                chain_id, to, nonce, shape,
+            ),
         }));
     }
 
@@ -1099,9 +1180,11 @@ fn bench_batch_reader_synthetic_signature_hash_by_tx_type(c: &mut Criterion) {
 
     let chain_id = RollupConfig::default().l2_chain_id.id();
 
-    for (kind, typed_transactions) in
-        synthetic_signature_hash_fixtures(SYNTHETIC_SIGNATURE_HASH_TX_COUNT, chain_id)
-    {
+    for (kind, typed_transactions) in synthetic_signature_hash_fixtures(
+        SYNTHETIC_SIGNATURE_HASH_TX_COUNT,
+        chain_id,
+        SyntheticSignatureHashShape::Simple,
+    ) {
         group.bench_with_input(
             BenchmarkId::new(
                 format!("{}_{}_txs", kind.label(), typed_transactions.len()),
@@ -1121,6 +1204,37 @@ fn bench_batch_reader_synthetic_signature_hash_by_tx_type(c: &mut Criterion) {
     group.finish();
 }
 
+fn bench_batch_reader_synthetic_signature_hash_shape_sensitivity(c: &mut Criterion) {
+    let mut group =
+        c.benchmark_group("protocol/batch_reader/synthetic_signature_hash_shape_sensitivity");
+    group.sample_size(10);
+
+    let chain_id = RollupConfig::default().l2_chain_id.id();
+
+    for shape in [SyntheticSignatureHashShape::Simple, SyntheticSignatureHashShape::Rich] {
+        for (kind, typed_transactions) in
+            synthetic_signature_hash_fixtures(SYNTHETIC_SIGNATURE_HASH_TX_COUNT, chain_id, shape)
+        {
+            group.bench_with_input(
+                BenchmarkId::new(
+                    format!("{}_{}_txs_{}", kind.label(), typed_transactions.len(), shape.label()),
+                    "synthetic",
+                ),
+                &typed_transactions,
+                |b, typed_transactions| {
+                    b.iter(|| {
+                        black_box(signature_hash_all_typed_transactions(black_box(
+                            typed_transactions.as_slice(),
+                        )));
+                    });
+                },
+            );
+        }
+    }
+
+    group.finish();
+}
+
 criterion_group!(
     benches,
     bench_batch_reader_constructor,
@@ -1133,5 +1247,6 @@ criterion_group!(
     bench_batch_reader_span_signed_tx_components,
     bench_batch_reader_span_signature_hash_by_tx_type,
     bench_batch_reader_synthetic_signature_hash_by_tx_type,
+    bench_batch_reader_synthetic_signature_hash_shape_sensitivity,
 );
 criterion_main!(benches);

--- a/crates/consensus/protocol/benches/batch_reader.rs
+++ b/crates/consensus/protocol/benches/batch_reader.rs
@@ -1,0 +1,135 @@
+//! Benchmarks for [`BatchReader`] constructor and decode paths.
+
+use std::hint::black_box;
+
+use alloy_primitives::{Bytes, hex};
+use base_common_genesis::RollupConfig;
+use base_protocol::BatchReader;
+use criterion::{BatchSize, BenchmarkId, Criterion, criterion_group, criterion_main};
+use miniz_oxide::{
+    deflate::{CompressionLevel, compress_to_vec_zlib},
+    inflate::decompress_to_vec_zlib,
+};
+
+const BATCH_COUNTS: [usize; 2] = [1, 64];
+
+fn compressed_batch_fixture(batch_count: usize) -> (Bytes, usize) {
+    let file_contents = String::from_utf8_lossy(include_bytes!("../testdata/batch.hex"));
+    let file_contents = &file_contents[..file_contents.len() - 1];
+    let raw = hex::decode(file_contents).expect("batch fixture must decode");
+    let single_batch = decompress_to_vec_zlib(&raw).expect("batch fixture must decompress");
+
+    let mut multi_batch = Vec::with_capacity(single_batch.len() * batch_count);
+    for _ in 0..batch_count {
+        multi_batch.extend_from_slice(&single_batch);
+    }
+    let max_rlp_bytes_per_channel = multi_batch.len();
+    let compressed = compress_to_vec_zlib(&multi_batch, CompressionLevel::BestSpeed.into()).into();
+
+    (compressed, max_rlp_bytes_per_channel)
+}
+
+fn decode_all_batches(mut reader: BatchReader, cfg: &RollupConfig) -> usize {
+    let mut batch_count = 0;
+    while reader.next_batch(cfg).is_some() {
+        batch_count += 1;
+    }
+    batch_count
+}
+
+fn bench_batch_reader_constructor(c: &mut Criterion) {
+    let mut group = c.benchmark_group("protocol/batch_reader/constructor");
+    group.sample_size(20);
+
+    for batch_count in BATCH_COUNTS {
+        let (compressed, max_rlp_bytes_per_channel) = compressed_batch_fixture(batch_count);
+
+        group.bench_with_input(
+            BenchmarkId::new("baseline_vec_clone", batch_count),
+            &compressed,
+            |b, compressed| {
+                b.iter_batched(
+                    || compressed.clone(),
+                    |data| {
+                        black_box(BatchReader::new(
+                            black_box(data).to_vec(),
+                            black_box(max_rlp_bytes_per_channel),
+                        ));
+                    },
+                    BatchSize::SmallInput,
+                );
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("owned_bytes", batch_count),
+            &compressed,
+            |b, compressed| {
+                b.iter_batched(
+                    || compressed.clone(),
+                    |data| {
+                        black_box(BatchReader::new(
+                            black_box(data),
+                            black_box(max_rlp_bytes_per_channel),
+                        ));
+                    },
+                    BatchSize::SmallInput,
+                );
+            },
+        );
+    }
+
+    group.finish();
+}
+
+fn bench_batch_reader_decode_all_batches(c: &mut Criterion) {
+    let mut group = c.benchmark_group("protocol/batch_reader/decode_all_batches");
+    group.sample_size(20);
+
+    let cfg = RollupConfig::default();
+    for batch_count in BATCH_COUNTS {
+        let (compressed, max_rlp_bytes_per_channel) = compressed_batch_fixture(batch_count);
+
+        group.bench_with_input(
+            BenchmarkId::new("baseline_vec_clone", batch_count),
+            &compressed,
+            |b, compressed| {
+                b.iter_batched(
+                    || compressed.clone(),
+                    |data| {
+                        black_box(decode_all_batches(
+                            BatchReader::new(
+                                black_box(data).to_vec(),
+                                black_box(max_rlp_bytes_per_channel),
+                            ),
+                            black_box(&cfg),
+                        ));
+                    },
+                    BatchSize::SmallInput,
+                );
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("owned_bytes", batch_count),
+            &compressed,
+            |b, compressed| {
+                b.iter_batched(
+                    || compressed.clone(),
+                    |data| {
+                        black_box(decode_all_batches(
+                            BatchReader::new(black_box(data), black_box(max_rlp_bytes_per_channel)),
+                            black_box(&cfg),
+                        ));
+                    },
+                    BatchSize::SmallInput,
+                );
+            },
+        );
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_batch_reader_constructor, bench_batch_reader_decode_all_batches,);
+criterion_main!(benches);

--- a/crates/consensus/protocol/benches/batch_reader.rs
+++ b/crates/consensus/protocol/benches/batch_reader.rs
@@ -6,6 +6,7 @@ use alloy_consensus::{SignableTransaction, TxEip1559, TxEip2930, TxEip7702, TxEn
 use alloy_eips::eip2718::Encodable2718;
 use alloy_primitives::{Address, B256, Bytes, Signature, TxKind, U256, hex};
 use alloy_rlp::Decodable;
+use alloy_rpc_types_eth::Authorization;
 use base_common_genesis::{HardForkConfig, RollupConfig};
 use base_protocol::{
     Batch, BatchReader, BatchType, Brotli, RawSpanBatch, SpanBatchTransactionData,
@@ -17,6 +18,7 @@ use miniz_oxide::{
 };
 
 const BATCH_COUNTS: [usize; 2] = [1, 64];
+const SYNTHETIC_SIGNATURE_HASH_TX_COUNT: usize = 1_024;
 
 #[derive(Clone)]
 struct CompressionFixture {
@@ -439,6 +441,80 @@ impl TypedTransactionKind {
             Self::Eip7702 => "eip7702",
         }
     }
+}
+
+fn synthetic_signature_hash_fixtures(
+    tx_count: usize,
+    chain_id: u64,
+) -> Vec<(TypedTransactionKind, Vec<TypedTransactionFixture>)> {
+    let mut legacy = Vec::with_capacity(tx_count);
+    let mut eip2930 = Vec::with_capacity(tx_count);
+    let mut eip1559 = Vec::with_capacity(tx_count);
+    let mut eip7702 = Vec::with_capacity(tx_count);
+
+    for idx in 0..tx_count {
+        let nonce = idx as u64;
+        let seed = ((idx % u8::MAX as usize) + 1) as u8;
+        let to = Address::from([seed; 20]);
+        let value = U256::from(nonce + 1);
+        let gas_limit = 21_000 + (nonce % 1_024);
+        let input = Bytes::from(vec![seed; 32]);
+
+        legacy.push(TypedTransactionFixture::Legacy(TxLegacy {
+            chain_id: Some(chain_id),
+            nonce,
+            gas_price: 1_000_000_000u128 + idx as u128,
+            gas_limit,
+            to: TxKind::Call(to),
+            value,
+            input: input.clone(),
+        }));
+
+        eip2930.push(TypedTransactionFixture::Eip2930(TxEip2930 {
+            chain_id,
+            nonce,
+            gas_price: 1_000_000_000u128 + idx as u128,
+            gas_limit,
+            to: TxKind::Call(to),
+            value,
+            input: input.clone(),
+            access_list: Default::default(),
+        }));
+
+        eip1559.push(TypedTransactionFixture::Eip1559(TxEip1559 {
+            chain_id,
+            nonce,
+            max_fee_per_gas: 3_000_000_000u128 + idx as u128,
+            max_priority_fee_per_gas: 1_000_000_000u128 + idx as u128,
+            gas_limit,
+            to: TxKind::Call(to),
+            value,
+            input: input.clone(),
+            access_list: Default::default(),
+        }));
+
+        let authorization = Authorization { chain_id: U256::from(chain_id), address: to, nonce };
+        let signed_authorization = authorization.into_signed(Signature::test_signature());
+        eip7702.push(TypedTransactionFixture::Eip7702(TxEip7702 {
+            chain_id,
+            nonce,
+            max_fee_per_gas: 3_000_000_000u128 + idx as u128,
+            max_priority_fee_per_gas: 1_000_000_000u128 + idx as u128,
+            gas_limit,
+            to,
+            value,
+            input,
+            access_list: Default::default(),
+            authorization_list: vec![signed_authorization],
+        }));
+    }
+
+    vec![
+        (TypedTransactionKind::Legacy, legacy),
+        (TypedTransactionKind::Eip2930, eip2930),
+        (TypedTransactionKind::Eip1559, eip1559),
+        (TypedTransactionKind::Eip7702, eip7702),
+    ]
 }
 
 fn signature_hash_all_typed_transactions(typed_transactions: &[TypedTransactionFixture]) -> usize {
@@ -1017,6 +1093,34 @@ fn bench_batch_reader_span_signature_hash_by_tx_type(c: &mut Criterion) {
     group.finish();
 }
 
+fn bench_batch_reader_synthetic_signature_hash_by_tx_type(c: &mut Criterion) {
+    let mut group = c.benchmark_group("protocol/batch_reader/synthetic_signature_hash_by_tx_type");
+    group.sample_size(20);
+
+    let chain_id = RollupConfig::default().l2_chain_id.id();
+
+    for (kind, typed_transactions) in
+        synthetic_signature_hash_fixtures(SYNTHETIC_SIGNATURE_HASH_TX_COUNT, chain_id)
+    {
+        group.bench_with_input(
+            BenchmarkId::new(
+                format!("{}_{}_txs", kind.label(), typed_transactions.len()),
+                "synthetic",
+            ),
+            &typed_transactions,
+            |b, typed_transactions| {
+                b.iter(|| {
+                    black_box(signature_hash_all_typed_transactions(black_box(
+                        typed_transactions.as_slice(),
+                    )));
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
 criterion_group!(
     benches,
     bench_batch_reader_constructor,
@@ -1028,5 +1132,6 @@ criterion_group!(
     bench_batch_reader_span_full_txs_components,
     bench_batch_reader_span_signed_tx_components,
     bench_batch_reader_span_signature_hash_by_tx_type,
+    bench_batch_reader_synthetic_signature_hash_by_tx_type,
 );
 criterion_main!(benches);

--- a/crates/consensus/protocol/benches/batch_reader.rs
+++ b/crates/consensus/protocol/benches/batch_reader.rs
@@ -3,8 +3,9 @@
 use std::hint::black_box;
 
 use alloy_primitives::{Bytes, hex};
+use alloy_rlp::Decodable;
 use base_common_genesis::{HardForkConfig, RollupConfig};
-use base_protocol::{BatchReader, Brotli};
+use base_protocol::{Batch, BatchReader, Brotli};
 use criterion::{BatchSize, BenchmarkId, Criterion, criterion_group, criterion_main};
 use miniz_oxide::{
     deflate::{CompressionLevel, compress_to_vec_zlib},
@@ -78,6 +79,22 @@ fn decode_all_batches(mut reader: BatchReader, cfg: &RollupConfig) -> usize {
     while reader.next_batch(cfg).is_some() {
         batch_count += 1;
     }
+    batch_count
+}
+
+fn decode_all_batches_from_decompressed(mut data: &[u8], cfg: &RollupConfig) -> usize {
+    let mut batch_count = 0;
+
+    while !data.is_empty() {
+        let Ok(bytes) = Bytes::decode(&mut data) else {
+            break;
+        };
+        let Ok(_) = Batch::decode(&mut bytes.as_ref(), cfg) else {
+            break;
+        };
+        batch_count += 1;
+    }
+
     batch_count
 }
 
@@ -174,7 +191,7 @@ fn bench_batch_reader_decompression_only(c: &mut Criterion) {
                         black_box(
                             Brotli
                                 .decompress(
-                                    black_box(data).as_ref(),
+                                    black_box(&data[1..]),
                                     black_box(fixture.max_rlp_bytes_per_channel),
                                 )
                                 .expect("brotli fixture must decompress"),
@@ -241,10 +258,42 @@ fn bench_batch_reader_decode_all_batches(c: &mut Criterion) {
     group.finish();
 }
 
+fn bench_batch_reader_post_decompression_decode_only(c: &mut Criterion) {
+    let mut group = c.benchmark_group("protocol/batch_reader/post_decompression_decode_only");
+    group.sample_size(20);
+
+    for batch_count in BATCH_COUNTS {
+        for fixture in compression_fixtures(batch_count) {
+            let cfg = bench_rollup_config(fixture.label);
+            let decompressed = decompressed_batch_fixture(batch_count);
+
+            group.bench_with_input(
+                BenchmarkId::new(fixture.label, batch_count),
+                &decompressed,
+                |b, decompressed| {
+                    b.iter_batched(
+                        || decompressed.clone(),
+                        |data| {
+                            black_box(decode_all_batches_from_decompressed(
+                                black_box(data).as_slice(),
+                                black_box(&cfg),
+                            ));
+                        },
+                        BatchSize::SmallInput,
+                    );
+                },
+            );
+        }
+    }
+
+    group.finish();
+}
+
 criterion_group!(
     benches,
     bench_batch_reader_constructor,
     bench_batch_reader_decompression_only,
     bench_batch_reader_decode_all_batches,
+    bench_batch_reader_post_decompression_decode_only,
 );
 criterion_main!(benches);

--- a/crates/consensus/protocol/benches/batch_reader.rs
+++ b/crates/consensus/protocol/benches/batch_reader.rs
@@ -3,7 +3,7 @@
 use std::hint::black_box;
 
 use alloy_primitives::{Bytes, hex};
-use base_common_genesis::RollupConfig;
+use base_common_genesis::{HardForkConfig, RollupConfig};
 use base_protocol::{BatchReader, Brotli};
 use criterion::{BatchSize, BenchmarkId, Criterion, criterion_group, criterion_main};
 use miniz_oxide::{
@@ -12,6 +12,13 @@ use miniz_oxide::{
 };
 
 const BATCH_COUNTS: [usize; 2] = [1, 64];
+
+#[derive(Clone)]
+struct CompressionFixture {
+    label: &'static str,
+    compressed: Bytes,
+    max_rlp_bytes_per_channel: usize,
+}
 
 fn decompressed_batch_fixture(batch_count: usize) -> Vec<u8> {
     let file_contents = String::from_utf8_lossy(include_bytes!("../testdata/batch.hex"));
@@ -38,7 +45,7 @@ fn brotli_compressed_batch_fixture(batch_count: usize) -> (Bytes, usize) {
     let multi_batch = decompressed_batch_fixture(batch_count);
     let max_rlp_bytes_per_channel = multi_batch.len();
 
-    let mut compressed = Vec::new();
+    let mut compressed = vec![BatchReader::CHANNEL_VERSION_BROTLI];
     let mut input = multi_batch.as_slice();
     let params = brotli::enc::BrotliEncoderParams::default();
     brotli::BrotliCompress(&mut input, &mut compressed, &params)
@@ -47,12 +54,42 @@ fn brotli_compressed_batch_fixture(batch_count: usize) -> (Bytes, usize) {
     (compressed.into(), max_rlp_bytes_per_channel)
 }
 
+fn compression_fixtures(batch_count: usize) -> [CompressionFixture; 2] {
+    let (zlib_compressed, zlib_max_rlp_bytes_per_channel) = compressed_batch_fixture(batch_count);
+    let (brotli_compressed, brotli_max_rlp_bytes_per_channel) =
+        brotli_compressed_batch_fixture(batch_count);
+
+    [
+        CompressionFixture {
+            label: "zlib",
+            compressed: zlib_compressed,
+            max_rlp_bytes_per_channel: zlib_max_rlp_bytes_per_channel,
+        },
+        CompressionFixture {
+            label: "brotli",
+            compressed: brotli_compressed,
+            max_rlp_bytes_per_channel: brotli_max_rlp_bytes_per_channel,
+        },
+    ]
+}
+
 fn decode_all_batches(mut reader: BatchReader, cfg: &RollupConfig) -> usize {
     let mut batch_count = 0;
     while reader.next_batch(cfg).is_some() {
         batch_count += 1;
     }
     batch_count
+}
+
+fn bench_rollup_config(label: &'static str) -> RollupConfig {
+    match label {
+        "brotli" => RollupConfig {
+            hardforks: HardForkConfig { fjord_time: Some(0), ..Default::default() },
+            ..Default::default()
+        },
+        "zlib" => RollupConfig::default(),
+        unsupported => panic!("unsupported compression label: {unsupported}"),
+    }
 }
 
 fn bench_batch_reader_constructor(c: &mut Criterion) {
@@ -105,20 +142,19 @@ fn bench_batch_reader_decompression_only(c: &mut Criterion) {
     group.sample_size(20);
 
     for batch_count in BATCH_COUNTS {
-        let (zlib_compressed, max_rlp_bytes_per_channel) = compressed_batch_fixture(batch_count);
-        let (brotli_compressed, _) = brotli_compressed_batch_fixture(batch_count);
+        let [zlib_fixture, brotli_fixture] = compression_fixtures(batch_count);
 
         group.bench_with_input(
             BenchmarkId::new("zlib", batch_count),
-            &zlib_compressed,
-            |b, compressed| {
+            &zlib_fixture,
+            |b, fixture| {
                 b.iter_batched(
-                    || compressed.clone(),
+                    || fixture.compressed.clone(),
                     |data| {
                         black_box(
                             decompress_to_vec_zlib_with_limit(
                                 black_box(data).as_ref(),
-                                black_box(max_rlp_bytes_per_channel),
+                                black_box(fixture.max_rlp_bytes_per_channel),
                             )
                             .expect("zlib fixture must decompress"),
                         );
@@ -130,16 +166,16 @@ fn bench_batch_reader_decompression_only(c: &mut Criterion) {
 
         group.bench_with_input(
             BenchmarkId::new("brotli", batch_count),
-            &brotli_compressed,
-            |b, compressed| {
+            &brotli_fixture,
+            |b, fixture| {
                 b.iter_batched(
-                    || compressed.clone(),
+                    || fixture.compressed.clone(),
                     |data| {
                         black_box(
                             Brotli
                                 .decompress(
                                     black_box(data).as_ref(),
-                                    black_box(max_rlp_bytes_per_channel),
+                                    black_box(fixture.max_rlp_bytes_per_channel),
                                 )
                                 .expect("brotli fixture must decompress"),
                         );
@@ -157,46 +193,49 @@ fn bench_batch_reader_decode_all_batches(c: &mut Criterion) {
     let mut group = c.benchmark_group("protocol/batch_reader/decode_all_batches");
     group.sample_size(20);
 
-    let cfg = RollupConfig::default();
     for batch_count in BATCH_COUNTS {
-        let (compressed, max_rlp_bytes_per_channel) = compressed_batch_fixture(batch_count);
+        for fixture in compression_fixtures(batch_count) {
+            let cfg = bench_rollup_config(fixture.label);
+            group.bench_with_input(
+                BenchmarkId::new(format!("baseline_vec_clone_{}", fixture.label), batch_count),
+                &fixture,
+                |b, fixture| {
+                    b.iter_batched(
+                        || fixture.compressed.clone(),
+                        |data| {
+                            black_box(decode_all_batches(
+                                BatchReader::new(
+                                    black_box(data).to_vec(),
+                                    black_box(fixture.max_rlp_bytes_per_channel),
+                                ),
+                                black_box(&cfg),
+                            ));
+                        },
+                        BatchSize::SmallInput,
+                    );
+                },
+            );
 
-        group.bench_with_input(
-            BenchmarkId::new("baseline_vec_clone", batch_count),
-            &compressed,
-            |b, compressed| {
-                b.iter_batched(
-                    || compressed.clone(),
-                    |data| {
-                        black_box(decode_all_batches(
-                            BatchReader::new(
-                                black_box(data).to_vec(),
-                                black_box(max_rlp_bytes_per_channel),
-                            ),
-                            black_box(&cfg),
-                        ));
-                    },
-                    BatchSize::SmallInput,
-                );
-            },
-        );
-
-        group.bench_with_input(
-            BenchmarkId::new("owned_bytes", batch_count),
-            &compressed,
-            |b, compressed| {
-                b.iter_batched(
-                    || compressed.clone(),
-                    |data| {
-                        black_box(decode_all_batches(
-                            BatchReader::new(black_box(data), black_box(max_rlp_bytes_per_channel)),
-                            black_box(&cfg),
-                        ));
-                    },
-                    BatchSize::SmallInput,
-                );
-            },
-        );
+            group.bench_with_input(
+                BenchmarkId::new(format!("owned_bytes_{}", fixture.label), batch_count),
+                &fixture,
+                |b, fixture| {
+                    b.iter_batched(
+                        || fixture.compressed.clone(),
+                        |data| {
+                            black_box(decode_all_batches(
+                                BatchReader::new(
+                                    black_box(data),
+                                    black_box(fixture.max_rlp_bytes_per_channel),
+                                ),
+                                black_box(&cfg),
+                            ));
+                        },
+                        BatchSize::SmallInput,
+                    );
+                },
+            );
+        }
     }
 
     group.finish();

--- a/crates/consensus/protocol/benches/batch_reader.rs
+++ b/crates/consensus/protocol/benches/batch_reader.rs
@@ -98,6 +98,43 @@ fn decode_all_batches_from_decompressed(mut data: &[u8], cfg: &RollupConfig) -> 
     batch_count
 }
 
+fn batch_payloads_from_decompressed(mut data: &[u8]) -> Vec<Bytes> {
+    let mut batch_payloads = Vec::new();
+
+    while !data.is_empty() {
+        let bytes = Bytes::decode(&mut data).expect("decompressed fixture must decode bytes");
+        batch_payloads.push(bytes);
+    }
+
+    batch_payloads
+}
+
+fn count_rlp_wrapped_batches(mut data: &[u8]) -> usize {
+    let mut batch_count = 0;
+
+    while !data.is_empty() {
+        let Ok(_) = Bytes::decode(&mut data) else {
+            break;
+        };
+        batch_count += 1;
+    }
+
+    batch_count
+}
+
+fn decode_all_batch_payloads(batch_payloads: &[Bytes], cfg: &RollupConfig) -> usize {
+    let mut batch_count = 0;
+
+    for payload in batch_payloads {
+        let Ok(_) = Batch::decode(&mut payload.as_ref(), cfg) else {
+            break;
+        };
+        batch_count += 1;
+    }
+
+    batch_count
+}
+
 fn bench_rollup_config(label: &'static str) -> RollupConfig {
     match label {
         "brotli" => RollupConfig {
@@ -289,11 +326,54 @@ fn bench_batch_reader_post_decompression_decode_only(c: &mut Criterion) {
     group.finish();
 }
 
+fn bench_batch_reader_post_decompression_components(c: &mut Criterion) {
+    let mut group = c.benchmark_group("protocol/batch_reader/post_decompression_components");
+    group.sample_size(20);
+
+    for batch_count in BATCH_COUNTS {
+        for fixture in compression_fixtures(batch_count) {
+            let cfg = bench_rollup_config(fixture.label);
+            let decompressed = decompressed_batch_fixture(batch_count);
+            let batch_payloads = batch_payloads_from_decompressed(decompressed.as_slice());
+
+            group.bench_with_input(
+                BenchmarkId::new(format!("rlp_only_{}", fixture.label), batch_count),
+                &decompressed,
+                |b, decompressed| {
+                    b.iter_batched(
+                        || decompressed.clone(),
+                        |data| {
+                            black_box(count_rlp_wrapped_batches(black_box(data).as_slice()));
+                        },
+                        BatchSize::SmallInput,
+                    );
+                },
+            );
+
+            group.bench_with_input(
+                BenchmarkId::new(format!("batch_decode_only_{}", fixture.label), batch_count),
+                &batch_payloads,
+                |b, batch_payloads| {
+                    b.iter(|| {
+                        black_box(decode_all_batch_payloads(
+                            black_box(batch_payloads.as_slice()),
+                            black_box(&cfg),
+                        ));
+                    });
+                },
+            );
+        }
+    }
+
+    group.finish();
+}
+
 criterion_group!(
     benches,
     bench_batch_reader_constructor,
     bench_batch_reader_decompression_only,
     bench_batch_reader_decode_all_batches,
     bench_batch_reader_post_decompression_decode_only,
+    bench_batch_reader_post_decompression_components,
 );
 criterion_main!(benches);

--- a/crates/consensus/protocol/src/batch/reader.rs
+++ b/crates/consensus/protocol/src/batch/reader.rs
@@ -33,7 +33,7 @@ pub enum DecompressionError {
 #[derive(Debug)]
 pub struct BatchReader {
     /// The raw data to decode.
-    pub data: Option<Vec<u8>>,
+    pub data: Option<Bytes>,
     /// Decompressed data.
     pub decompressed: Vec<u8>,
     /// The current cursor in the `decompressed` data.
@@ -58,7 +58,7 @@ impl BatchReader {
     /// channel.
     pub fn new<T>(data: T, max_rlp_bytes_per_channel: usize) -> Self
     where
-        T: Into<Vec<u8>>,
+        T: Into<Bytes>,
     {
         Self {
             data: Some(data.into()),
@@ -94,11 +94,11 @@ impl BatchReader {
         }
     }
 
-    fn decompress_zlib(&mut self, data: Vec<u8>) -> Result<(), DecompressionError> {
+    fn decompress_zlib(&mut self, data: Bytes) -> Result<(), DecompressionError> {
         // Decompress with a limit to prevent zip-bomb attacks.
         // Per spec, if decompressed data exceeds the limit, the output is
         // truncated to max_rlp_bytes_per_channel bytes (not rejected).
-        match decompress_to_vec_zlib_with_limit(&data, self.max_rlp_bytes_per_channel) {
+        match decompress_to_vec_zlib_with_limit(data.as_ref(), self.max_rlp_bytes_per_channel) {
             Ok(decompressed) => {
                 self.decompressed = decompressed;
             }
@@ -115,7 +115,7 @@ impl BatchReader {
         Ok(())
     }
 
-    fn decompress_brotli(&mut self, data: Vec<u8>) -> Result<(), DecompressionError> {
+    fn decompress_brotli(&mut self, data: Bytes) -> Result<(), DecompressionError> {
         self.brotli_used = true;
         // Note: the first byte of the channel data is the Brotli channel version but not part of
         // the compressed data, so it's skipped here but not for zlib.

--- a/crates/consensus/protocol/src/batch/transactions.rs
+++ b/crates/consensus/protocol/src/batch/transactions.rs
@@ -279,7 +279,7 @@ impl SpanBatchTransactions {
                 true
             };
             let tx_envelope = tx.to_signed_tx(*nonce, *gas, to, chain_id, sig, is_protected)?;
-            let mut buf = Vec::new();
+            let mut buf = Vec::with_capacity(tx_envelope.encode_2718_len());
             tx_envelope.encode_2718(&mut buf);
             txs.push(buf);
         }

--- a/crates/consensus/protocol/src/batch/transactions.rs
+++ b/crates/consensus/protocol/src/batch/transactions.rs
@@ -238,7 +238,7 @@ impl SpanBatchTransactions {
 
     /// Retrieve all of the raw transactions from the [`SpanBatchTransactions`].
     pub fn full_txs(&self, chain_id: u64) -> Result<Vec<Vec<u8>>, SpanBatchError> {
-        let mut txs = Vec::new();
+        let mut txs = Vec::with_capacity(self.total_block_tx_count as usize);
         let mut to_idx = 0;
         let mut protected_bit_idx = 0;
         for idx in 0..self.total_block_tx_count {

--- a/crates/consensus/service/Cargo.toml
+++ b/crates/consensus/service/Cargo.toml
@@ -81,13 +81,18 @@ rstest.workspace = true
 anyhow.workspace = true
 mockall.workspace = true
 arbitrary.workspace = true
+criterion.workspace = true
 base-common-rpc-types.workspace = true
 alloy-primitives = { workspace = true, features = ["k256"] }
-base-consensus-derive = {workspace = true, features = ["test-utils"]}
+base-consensus-derive = { workspace = true, features = ["test-utils"] }
 base-consensus-engine = { workspace = true, features = ["test-utils"] }
 alloy-consensus = { workspace = true, features = ["arbitrary", "std"] }
 base-common-consensus = { workspace = true, features = ["arbitrary", "k256"] }
 alloy-rpc-types-engine = { workspace = true, features = ["arbitrary", "std"] }
+
+[[bench]]
+name = "finalizer"
+harness = false
 
 [features]
 default = []

--- a/crates/consensus/service/benches/finalizer.rs
+++ b/crates/consensus/service/benches/finalizer.rs
@@ -51,11 +51,20 @@ fn bench_enqueue_for_finalization(c: &mut Criterion) {
 fn bench_try_finalize_next(c: &mut Criterion) {
     let mut group = c.benchmark_group("consensus_finalizer/try_finalize_next");
 
-    let finalized_tip = finalized_l1(ENTRY_COUNT / 2);
+    let finalized_first = finalized_l1(1);
+    group.bench_function("4096_entries_finalize_first", |b| {
+        b.iter_batched(
+            finalizer_with_entries,
+            |mut finalizer| black_box(finalizer.try_finalize_next(black_box(finalized_first))),
+            criterion::BatchSize::SmallInput,
+        );
+    });
+
+    let finalized_half = finalized_l1(ENTRY_COUNT / 2);
     group.bench_function("4096_entries_finalize_half", |b| {
         b.iter_batched(
             finalizer_with_entries,
-            |mut finalizer| black_box(finalizer.try_finalize_next(black_box(finalized_tip))),
+            |mut finalizer| black_box(finalizer.try_finalize_next(black_box(finalized_half))),
             criterion::BatchSize::SmallInput,
         );
     });

--- a/crates/consensus/service/benches/finalizer.rs
+++ b/crates/consensus/service/benches/finalizer.rs
@@ -1,0 +1,76 @@
+//! Benchmarks for [`L2Finalizer`] queue operations.
+
+use std::hint::black_box;
+
+use alloy_eips::BlockNumHash;
+use base_common_rpc_types_engine::BasePayloadAttributes;
+use base_consensus_node::L2Finalizer;
+use base_protocol::{AttributesWithParent, BlockInfo, L2BlockInfo};
+use criterion::{Criterion, criterion_group, criterion_main};
+
+const ENTRY_COUNT: u64 = 4_096;
+
+fn attrs(l2_parent_number: u64, l1_origin_number: u64) -> AttributesWithParent {
+    let parent = L2BlockInfo {
+        block_info: BlockInfo { number: l2_parent_number, ..Default::default() },
+        l1_origin: BlockNumHash::default(),
+        seq_num: 0,
+    };
+    let derived_from = BlockInfo { number: l1_origin_number, ..Default::default() };
+    AttributesWithParent::new(BasePayloadAttributes::default(), parent, Some(derived_from), false)
+}
+
+fn finalized_l1(number: u64) -> BlockInfo {
+    BlockInfo { number, ..Default::default() }
+}
+
+fn finalizer_with_entries() -> L2Finalizer {
+    let mut finalizer = L2Finalizer::default();
+    for number in 1..=ENTRY_COUNT {
+        finalizer.enqueue_for_finalization(&attrs(number, number));
+    }
+    finalizer
+}
+
+fn bench_enqueue_for_finalization(c: &mut Criterion) {
+    let mut group = c.benchmark_group("consensus_finalizer/enqueue_for_finalization");
+
+    group.bench_function("4096_unique_l1_epochs", |b| {
+        b.iter(|| {
+            let mut finalizer = L2Finalizer::default();
+            for number in 1..=ENTRY_COUNT {
+                finalizer.enqueue_for_finalization(black_box(&attrs(number, number)));
+            }
+            black_box(finalizer);
+        });
+    });
+
+    group.finish();
+}
+
+fn bench_try_finalize_next(c: &mut Criterion) {
+    let mut group = c.benchmark_group("consensus_finalizer/try_finalize_next");
+
+    let finalized_tip = finalized_l1(ENTRY_COUNT / 2);
+    group.bench_function("4096_entries_finalize_half", |b| {
+        b.iter_batched(
+            finalizer_with_entries,
+            |mut finalizer| black_box(finalizer.try_finalize_next(black_box(finalized_tip))),
+            criterion::BatchSize::SmallInput,
+        );
+    });
+
+    let old_tip = finalized_l1(0);
+    group.bench_function("empty_queue_miss", |b| {
+        b.iter_batched(
+            L2Finalizer::default,
+            |mut finalizer| black_box(finalizer.try_finalize_next(black_box(old_tip))),
+            criterion::BatchSize::SmallInput,
+        );
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_enqueue_for_finalization, bench_try_finalize_next);
+criterion_main!(benches);

--- a/crates/consensus/service/src/actors/derivation/finalizer.rs
+++ b/crates/consensus/service/src/actors/derivation/finalizer.rs
@@ -61,11 +61,26 @@ impl L2Finalizer {
         // queue of all L1 blocks not contained in the finalized L1 chain.
         if let Some((_, highest_safe_number)) = highest_safe {
             let result = *highest_safe_number;
-            self.awaiting_finalization.retain(|&number, _| number > new_finalized_l1_block.number);
+            self.awaiting_finalization = Self::future_entries(
+                &mut self.awaiting_finalization,
+                new_finalized_l1_block.number,
+            );
             Some(result)
         } else {
             None
         }
+    }
+
+    fn future_entries(
+        awaiting_finalization: &mut BTreeMap<L1BlockNumber, L2BlockNumber>,
+        finalized_l1_number: L1BlockNumber,
+    ) -> BTreeMap<L1BlockNumber, L2BlockNumber> {
+        if finalized_l1_number == L1BlockNumber::MAX {
+            awaiting_finalization.clear();
+            return BTreeMap::new();
+        }
+
+        awaiting_finalization.split_off(&(finalized_l1_number + 1))
     }
 }
 
@@ -178,5 +193,14 @@ mod tests {
         assert_eq!(f.try_finalize_next(l1_at(5)), Some(20));
         // Queue is now empty; an older signal cannot regress to a stale entry.
         assert!(f.try_finalize_next(l1_at(2)).is_none());
+    }
+
+    #[test]
+    fn max_l1_finalization_drains_without_overflow() {
+        let mut f = L2Finalizer::default();
+        f.enqueue_for_finalization(&attrs(0, u64::MAX));
+
+        assert_eq!(f.try_finalize_next(l1_at(u64::MAX)), Some(1));
+        assert!(f.try_finalize_next(l1_at(u64::MAX)).is_none());
     }
 }

--- a/docs/autonomy/perf-autopilot.md
+++ b/docs/autonomy/perf-autopilot.md
@@ -1,0 +1,93 @@
+# Autonomous Performance Autopilot
+
+Goal: continuously improve performance of the Base services in this repository through recurring research, targeted benchmarking, small safe code changes, and PR-driven delivery.
+
+The autopilot runs in the dedicated worktree at `/home/refcell/dev/base-perf-autopilot` on branch `automation/perf-autopilot`.
+
+Scope
+
+The current highest-value service areas are:
+
+1. `crates/consensus/service` and adjacent consensus crates
+   - likely hot paths: sequencer build/seal loop, engine request queue, derivation stepping, provider RPC/cache behavior, gossip validation/publish
+   - existing observability: service, engine, derive, gossip, and provider metrics behind the `metrics` feature
+
+2. `crates/batcher/service`, `crates/batcher/core`, `crates/batcher/encoder`, and `crates/batcher/source`
+   - likely hot paths: driver loop backlog handling, encoding/compression, blob/calldata submission packing, recent-tx startup scan, source polling/catchup
+   - existing observability: encoder/core metrics, queue depth, submission outcomes, compression ratios, in-flight counts
+
+3. `crates/proof/zk/service`
+   - likely hot paths: witness generation, L1-head calculation, status polling, repeated `GetProof` sync calls, session/state round-trips, SNARK stage-2 aggregation, proxy rate limiting
+   - existing observability: request counters, latency histograms, witness generation duration, proof request duration, stuck request counters
+
+4. Shared benchmarking and load testing
+   - `crates/infra/load-tests`
+   - existing benches in `crates/builder/core`, `crates/builder/publish`, `crates/proof/mpt`, and `crates/client/flashblocks-node`
+
+Operating rules
+
+- Work in small increments.
+- Prefer measurement before modification.
+- Reuse existing benchmarks first. If coverage is missing, add focused benchmark or timing instrumentation before changing logic.
+- Favor changes that improve durable capability: benchmark harnesses, metrics, profiling hooks, caching, batching, concurrency limits, backpressure, and algorithmic simplification.
+- Keep commits reviewable and conventional, usually `perf: ...`, `bench: ...`, `docs: ...`, or `refactor: ...`.
+- Never push directly to `main`.
+- Use PRs for meaningful code changes.
+- When uncertain, prefer report-only progress rather than speculative edits.
+
+Per-run workflow
+
+1. Pull latest changes for the branch and inspect the working tree.
+2. Read `docs/autonomy/perf-journal.md` to avoid repeating work.
+3. Choose one concrete focus area based on the strongest combination of expected impact and measurability.
+4. Do external research as needed on Rust async performance, tokio scheduling, libp2p/discv5 tuning, RPC batching/caching, compression, proof-service polling, or relevant protocol/client techniques.
+5. Run or extend the narrowest benchmark that can validate the hypothesis.
+6. If a code change is justified, implement the smallest testable improvement.
+7. Re-run the relevant benchmark or load test and capture before/after numbers.
+8. Append a concise timestamped entry to `docs/autonomy/perf-journal.md` with hypothesis, commands, results, and next step.
+9. Commit substantive progress. If a meaningful code delta exists and no PR is open for this branch, open or update a PR.
+
+Useful commands
+
+Repo root: `/home/refcell/dev/base-perf-autopilot`
+
+Consensus
+- `cargo test -p base-consensus-node -- --list`
+- `cargo test -p base-consensus-node actors::sequencer:: -- --nocapture --test-threads=1`
+- `cargo test -p base-consensus-node engine_request_processor -- --nocapture --test-threads=1`
+- `cargo build -p base-consensus-node --features metrics`
+
+Batcher
+- `cargo test -p base-batcher-encoder -- --nocapture`
+- `cargo test -p base-batcher-core --features test-utils -- --nocapture`
+- `cargo test -p base-batcher-service -- --nocapture`
+- `cargo test -p base-batcher-source -- --nocapture`
+- `cargo run -p base-batcher-bin -- --help`
+
+ZK service
+- `cargo test -p base-zk-service`
+- `cargo nextest run --run-ignored all -p base-zk-service --test mock_backend_e2e`
+- `cargo nextest run --run-ignored all -p base-zk-service --test snark_groth16_e2e`
+
+Existing benches
+- `cargo bench -p base-builder-core --bench state_root`
+- `cargo bench -p base-builder-publish --bench publisher`
+- `cargo bench -p base-proof-mpt --bench trie_node`
+- `cargo bench -p base-flashblocks-node --bench pending_state`
+- `cargo bench -p base-flashblocks-node --bench sender_recovery`
+
+Load tests
+- `just --justfile crates/infra/load-tests/Justfile devnet`
+- `cargo run -p base-load-tests --bin base-load-test -- crates/infra/load-tests/examples/devnet.yaml`
+
+Definition of done for a single run
+
+A run is successful if it produces at least one of the following:
+
+- a benchmark result with clear numbers
+- a new or improved benchmark harness
+- a metrics or profiling improvement
+- a small code change with measured benefit
+- a research note that materially changes the next experiment
+
+Avoid repeating the same experiment unless the setup changed or the prior result was inconclusive.

--- a/docs/autonomy/perf-journal.md
+++ b/docs/autonomy/perf-journal.md
@@ -160,3 +160,28 @@ Results:
 - `cargo clippy -p base-batcher-service --tests --benches --no-deps -- -D warnings` passed
 Next:
 - if the startup scan is revisited again, add a block-level benchmark that includes frame parsing plus touched-ID tracking so allocator reuse can be measured in a shape closer to real RPC-fetched blocks, not just the isolated tracker microbench
+
+## 2026-04-27 07:36 UTC
+Focus: `base-batcher-service` ready-channel lookup cost inside `RecentTxScanner::drain_ready_channels()`.
+Hypothesis: after touched-only draining and touched-ID tracker improvements, the remaining per-channel bookkeeping might still benefit from avoiding the separate `HashMap::get` + `HashMap::remove` sequence; a focused lookup microbench should show whether an `entry`-based path is worth pursuing before touching production code.
+Commands:
+- `cargo bench -p base-batcher-service --bench recent_txs -- --warm-up-time 0.5 --measurement-time 1.0 --sample-size 15`
+- temporarily changed `RecentTxScanner::drain_ready_channels()` to use `HashMap::entry` and re-ran focused validation/benchmarks
+- reverted the production change after measurement showed no win
+- extended `crates/batcher/service/benches/recent_txs.rs` with a new `ready_channel_lookup` Criterion group that compares `get`-based readiness checks against `entry`-based lookups on the touched-only path
+- `cargo fmt --all`
+- `cargo test -p base-batcher-service recent_txs -- --nocapture`
+- `cargo clippy -p base-batcher-service --tests --benches --no-deps -- -D warnings`
+- `cargo bench -p base-batcher-service --bench recent_txs -- --warm-up-time 0.5 --measurement-time 1.0 --sample-size 15`
+Results:
+- added benchmark-only coverage for the ready-check bookkeeping gap without changing production logic; the bench file is now the only code delta for this run
+- the focused lookup microbench showed `entry` is not a clear win here and is often worse on the important no-ready and sparse-ready shapes, so the production `get` + `remove` implementation was intentionally left unchanged
+- confirming lookup results with the new benchmark group:
+  - `baseline_get_4096_touched_incomplete_among_8192_channels`: `411.61 µs .. 447.80 µs`
+  - `entry_api_4096_touched_incomplete_among_8192_channels`: `441.73 µs .. 593.54 µs` (slower / noisier)
+  - `baseline_get_64_touched_ready_among_8192_channels`: `395.70 µs .. 751.97 µs`
+  - `entry_api_64_touched_ready_among_8192_channels`: `378.14 µs .. 418.30 µs` (not enough evidence of a durable win given the baseline noise)
+- existing drain-path benches remained in the same rough bands, with decode-heavy cases still dominating end-to-end startup scan cost
+- focused tests still passed (`8 passed`) and `cargo clippy -p base-batcher-service --tests --benches --no-deps -- -D warnings` passed
+Next:
+- if this startup scan path is revisited again, benchmark frame parsing plus touched-only draining together so the next candidate optimization is chosen from a more end-to-end block-level profile instead of another tiny lookup tweak

--- a/docs/autonomy/perf-journal.md
+++ b/docs/autonomy/perf-journal.md
@@ -1,0 +1,26 @@
+# Performance Autopilot Journal
+
+This file records each autonomous performance run.
+
+Entry format
+
+## YYYY-MM-DD HH:MM UTC
+Focus:
+Hypothesis:
+Commands:
+Results:
+Next:
+
+## 2026-04-26 14:01 UTC
+Focus: bootstrap performance autopilot
+Hypothesis: the repo already contains enough service hotspots, metrics, load tests, and benchmark hooks to start an autonomous optimization loop without guessing blindly.
+Commands:
+- inspected consensus, batcher, zk service, and shared benchmarking infrastructure
+- created dedicated worktree `/home/refcell/dev/base-perf-autopilot`
+Results:
+- consensus hotspots identified around sequencer build/seal, engine request processing, derivation, provider RPC/cache behavior, and gossip paths
+- batcher hotspots identified around driver scheduling, encoder/compression, blob packing, recent-tx startup scan, and source polling/catchup
+- zk hotspots identified around witness generation, status polling, repeated GetProof syncs, session round-trips, and proxy rate limiting
+- reusable benchmarking infrastructure exists in `crates/infra/load-tests` plus several criterion benches elsewhere in the repo
+Next:
+- start with the narrowest measurable improvement in one hotspot area, likely batcher encoder/submission or zk service polling behavior

--- a/docs/autonomy/perf-journal.md
+++ b/docs/autonomy/perf-journal.md
@@ -80,3 +80,32 @@ Results:
 - `cargo clippy -p base-consensus-node --tests --benches --no-deps -- -D warnings` passed again; full clippy without `--no-deps` remains blocked by pre-existing dependency lints outside the touched crate
 Next:
 - if the finalizer is revisited, add a larger matrix of retained-tail sizes (for example finalize-at-1, finalize-at-1/4, finalize-at-1/2, finalize-at-3/4) to characterize how `split_off` scales with survivor count and to catch future regressions in queue-shape sensitivity
+
+## 2026-04-27 01:10 UTC
+Focus: `base-batcher-service` recent transaction startup scan in `RecentTxScanner::highest_submitted_l2_block()`.
+Hypothesis: the startup scan should not rescan every buffered channel after each L1 block when only channels touched by frames in the current block can transition to ready; restricting the drain to touched channel IDs should reduce unnecessary map scans, especially when the buffered channel set is large and the current block only advances a small subset.
+Commands:
+- `cargo test -p base-batcher-service recent_txs -- --nocapture`
+- `cargo bench -p base-batcher-service --bench recent_txs -- --warm-up-time 0.5 --measurement-time 1.5 --sample-size 20`
+- added a focused Criterion bench at `crates/batcher/service/benches/recent_txs.rs`
+- changed `RecentTxScanner` to track per-block `touched_channel_ids` and drain only those ready channels
+- added `drain_ready_channels_only_checks_touched_ids`
+- `cargo bench -p base-batcher-service --bench recent_txs -- --warm-up-time 0.5 --measurement-time 1.0 --sample-size 15`
+- `cargo clippy -p base-batcher-service --tests --benches --no-deps -- -D warnings`
+Results:
+- extracted two public benchmark hooks: `drain_ready_channels` for the touched-only path and `drain_all_ready_channels` for the old full-scan baseline, without changing `decode_channel` behavior
+- replaced the per-block `channels.iter().filter(|(_, ch)| ch.is_ready())` full scan with touched-ID draining in `highest_submitted_l2_block()`
+- added a regression test proving untouched ready channels remain buffered, touched incomplete channels stay buffered, and touched ready channels are decoded and removed when their ID is supplied
+- added `criterion` bench coverage for three shapes: fully touched mixed channels, fully touched incomplete channels, and sparse touched channels against a larger buffered set
+- validation passed: focused tests `6 passed`; `cargo clippy -p base-batcher-service --tests --benches --no-deps -- -D warnings` passed
+- benchmark results after the change:
+  - `baseline_scan_all_with_4096_ready_and_4096_incomplete`: `7.8886 ms .. 8.4072 ms`
+  - `4096_touched_ready_among_8192_channels`: `7.8312 ms .. 8.2868 ms` (effectively flat because ready-channel decode dominates)
+  - `baseline_scan_all_with_8192_incomplete`: `391.27 µs .. 672.34 µs`
+  - `4096_touched_incomplete_among_8192_channels`: `427.93 µs .. 511.84 µs` (same rough band)
+  - `baseline_scan_all_with_64_touched_ready_among_8192_channels`: `513.58 µs .. 720.29 µs`
+  - `64_touched_ready_among_8192_channels`: `507.07 µs .. 833.40 µs` (noisy, effectively flat)
+  - `baseline_scan_all_with_64_touched_incomplete_among_8192_channels`: `396.74 µs .. 424.37 µs`
+  - `64_touched_incomplete_among_8192_channels`: `366.17 µs .. 382.39 µs` (~8-10% lower in the sparse no-decode case, matching the intended avoided-scan scenario)
+Next:
+- if this path is revisited, grow the benchmark matrix around frame fan-out and touched-ID cardinality so the crossover point between touched-only draining and full-map scanning is explicit, especially for startup scans with many buffered but mostly untouched channels

--- a/docs/autonomy/perf-journal.md
+++ b/docs/autonomy/perf-journal.md
@@ -450,3 +450,28 @@ Results:
 Next:
 - if this shared decode path is revisited again, extend the new `base-protocol` bench with a decompression-only split (zlib vs brotli) so the next iteration can tell whether any remaining decode floor is in `decompress_*` itself or in per-batch RLP decoding after decompression.
 
+## 2026-04-28 11:24 UTC
+Focus: `base-protocol` shared decode-path decompression-only benchmark coverage.
+Hypothesis: the new shared `BatchReader` bench still mixes codec work with per-batch decoding, so adding a decompression-only split for zlib and brotli on the same synthetic fixtures should show whether the remaining `64`-batch decode floor is mostly in decompression or in post-decompression batch decoding.
+Commands:
+- `cargo bench -p base-protocol --bench batch_reader decode_all_batches -- --warm-up-time 0.5 --measurement-time 1.0 --sample-size 20`
+- edited `crates/consensus/protocol/benches/batch_reader.rs` to add a reusable decompressed fixture builder plus a new `protocol/batch_reader/decompression_only` Criterion group covering zlib and brotli at `1` and `64` batches
+- `cargo fmt --all`
+- `cargo test -p base-protocol batch_reader -- --nocapture`
+- `cargo clippy -p base-protocol --tests --benches --no-deps -- -D warnings`
+- `cargo bench -p base-protocol --bench batch_reader decompression_only -- --warm-up-time 0.5 --measurement-time 1.0 --sample-size 20`
+- `cargo bench -p base-protocol --bench batch_reader decode_all_batches -- --warm-up-time 0.5 --measurement-time 1.0 --sample-size 20`
+- extracted median `point_estimate` values from `target/criterion/protocol_batch_reader_*/*/*/base/estimates.json`
+Results:
+- kept production logic unchanged and extended the shared protocol bench to measure decompression in isolation, which closes the remaining observability gap from the prior run without changing consensus or batcher behavior
+- validation passed: `cargo test -p base-protocol batch_reader -- --nocapture` (`2 passed`) and `cargo clippy -p base-protocol --tests --benches --no-deps -- -D warnings`
+- constructor medians remain the same order of magnitude as the prior run, confirming the owned-`Bytes` copy removal still dominates constructor-only cost: `1` batch baseline `8.045 µs` vs owned `5.96 ns`; `64` batches baseline `9.113 ms` vs owned `5.93 ns`
+- new decompression-only medians show codec cost already dominates the decode floor, and brotli is materially faster than zlib on the shared synthetic fixture sizes:
+  - `1` batch: zlib `1.960 ms`, brotli `4.208 ms`
+  - `64` batches: zlib `143.22 ms`, brotli `70.74 ms`
+- refreshed full decode medians after the bench expansion:
+  - `1` batch: baseline `5.356 ms` vs owned `5.368 ms` (effectively noise)
+  - `64` batches: baseline `375.47 ms` vs owned `363.63 ms` (~`3.2%` lower median)
+- interpretation: for large channels, decompression accounts for a substantial share of total decode time (`~38%` for zlib and `~19%` for brotli relative to the current `64`-batch full-decode medians), so the next meaningful optimization likely sits in zlib decompression or in the remaining per-batch RLP decode work rather than in additional constructor plumbing
+Next:
+- if this shared decode path is revisited again, split the `decode_all_batches` harness one step further by compression type so the next iteration can quantify how much of the remaining `~220 ms` to `~293 ms` non-constructor cost is specific to zlib channels versus shared post-decompression batch decoding.

--- a/docs/autonomy/perf-journal.md
+++ b/docs/autonomy/perf-journal.md
@@ -647,3 +647,31 @@ Results:
 - PR status check: existing open PR remains `#2409` (`perf: optimize batcher hot paths`), so no new PR was opened
 Next:
 - revisit `SpanBatchTransactionData::to_signed_tx()` with a more structural candidate, likely reducing repeated cloning/setup inside typed transaction construction (`input`, access lists, or authorization lists) and validating it first against the existing `span_full_txs_components` harness before touching production code again.
+
+## 2026-04-29 04:48 UTC
+Focus: `base-protocol` span transaction reconstruction clone pressure inside `SpanBatchTransactions::full_txs()`.
+Hypothesis: `full_txs()` decodes each `SpanBatchTransactionData` and then rebuilds a signed envelope from borrowed transaction data, so adding owned `into_signed_tx` variants and moving `Bytes`/access lists/authorization lists into typed transactions might cut clone overhead inside the dominant `span_to_signed_tx_only` stage.
+Commands:
+- `cargo bench -p base-protocol --bench batch_reader batch_decode_components -- --warm-up-time 0.2 --measurement-time 0.5 --sample-size 10`
+- `cargo bench -p base-protocol --bench batch_reader span_full_txs_components -- --warm-up-time 0.2 --measurement-time 0.5 --sample-size 10`
+- edited `crates/consensus/protocol/src/batch/tx_data/{legacy,eip2930,eip1559,eip7702,wrapper}.rs` plus `crates/consensus/protocol/src/batch/transactions.rs` to add owned `into_signed_tx` helpers and route `full_txs()` through them
+- `cargo fmt --all`
+- `cargo test -p base-protocol batch_reader -- --nocapture`
+- `cargo clippy -p base-protocol --tests --benches --no-deps -- -D warnings`
+- `cargo bench -p base-protocol --bench batch_reader batch_decode_components -- --warm-up-time 0.2 --measurement-time 0.5 --sample-size 10`
+- `cargo bench -p base-protocol --bench batch_reader span_full_txs_components -- --warm-up-time 0.2 --measurement-time 0.5 --sample-size 10`
+- reverted the production edits after the confirming benchmarks regressed or stayed within noise on the targeted hot path
+Results:
+- refreshed pre-change medians on the current tree: `span_full_txs_only/1` = `2.8310 ms`, `span_full_txs_only/64` = `196.16 ms`, `span_to_signed_tx_only/1` = `2.4103 ms`, `span_to_signed_tx_only/64` = `160.40 ms`, `span_tx_data_decode_only/64` = `11.226 ms`, and `span_encode_2718_exact_capacity_only/64` = `15.981 ms`
+- the owned-conversion experiment validated cleanly but did not produce an end-to-end win and appears to hurt the isolated reconstruction component on this machine, so it was reverted and the branch is clean
+- confirming after-change medians before revert:
+  - `span_full_txs_only/1`: `2.8310 ms` -> `2.8514 ms` (~`0.7%` slower)
+  - `span_full_txs_only/64`: `196.16 ms` -> `196.61 ms` (~`0.2%` slower / effectively flat)
+  - `span_to_signed_tx_only/1`: `2.4103 ms` -> `2.4409 ms` (~`1.3%` slower)
+  - `span_to_signed_tx_only/64`: `160.40 ms` -> `162.24 ms` (~`1.1%` slower)
+  - `span_tx_data_decode_only/64`: `11.226 ms` -> `11.806 ms` (~`5.2%` slower)
+  - `span_encode_2718_exact_capacity_only/64`: `15.981 ms` -> `16.029 ms` (flat)
+- validation on the temporary experiment still passed: `cargo test -p base-protocol batch_reader -- --nocapture` (`2 passed`) and `cargo clippy -p base-protocol --tests --benches --no-deps -- -D warnings`
+- branch/PR hygiene check: `git status` is clean after revert and the existing open PR is still `#2409`, so there was nothing to commit or push this run
+Next:
+- avoid more ownership-plumbing experiments in `full_txs()` until a deeper component harness proves where the remaining `span_to_signed_tx_only` time is really spent; the next best target is a finer split inside signed transaction construction (for example signature-hash generation versus typed-transaction assembly per tx kind) so future edits can attack the dominant substage directly.

--- a/docs/autonomy/perf-journal.md
+++ b/docs/autonomy/perf-journal.md
@@ -570,3 +570,24 @@ Results:
 - interpretation: raw span parsing is only about `5.7%` of the single-batch zlib post-decompression floor and `7.9%` of the `64`-batch floor, while `SpanBatchTransactions::full_txs` accounts for about `89%` of the single-batch cost and about `95%` of the `64`-batch cost; the remaining derive step above `full_txs` is comparatively small, so future optimization work should focus on transaction reconstruction/encoding inside `full_txs` rather than on raw span parsing or prefix/origin derivation
 Next:
 - if this decode path is revisited again, drill into `SpanBatchTransactions::full_txs` itself (for example `SpanBatchTransactionData::decode`, signature/to-field assembly, and `TxEnvelope::encode_2718`) so the next experiment can identify whether the remaining shared decode floor is dominated by span transaction-data parsing or transaction re-encoding.
+
+## 2026-04-28 22:23 UTC
+Focus: `base-protocol` span transaction reconstruction allocation in `SpanBatchTransactions::full_txs()`.
+Hypothesis: the span decode component bench now shows `SpanBatchTransactions::full_txs()` dominates `Batch::decode`, and the method already knows the exact number of output transactions up front; preallocating the output `Vec<Vec<u8>>` to `total_block_tx_count` should remove repeated outer-vector growth during reconstruction and yield a small measurable win without changing semantics.
+Commands:
+- `cargo bench -p base-protocol --bench batch_reader batch_decode_components -- --warm-up-time 0.2 --measurement-time 0.5 --sample-size 10`
+- edited `crates/consensus/protocol/src/batch/transactions.rs` to change `full_txs()` from `Vec::new()` to `Vec::with_capacity(self.total_block_tx_count as usize)`
+- `cargo test -p base-protocol batch_reader -- --nocapture`
+- `cargo clippy -p base-protocol --tests --benches --no-deps -- -D warnings`
+- `cargo bench -p base-protocol --bench batch_reader batch_decode_components -- --warm-up-time 0.2 --measurement-time 0.5 --sample-size 10`
+Results:
+- made a one-line production change that preallocates the outer `txs` vector in `SpanBatchTransactions::full_txs()`, matching the already-known transaction count and avoiding incremental growth while reconstructing encoded transactions
+- validation passed: `cargo test -p base-protocol batch_reader -- --nocapture` (`2 passed`) and `cargo clippy -p base-protocol --tests --benches --no-deps -- -D warnings`
+- focused benchmark results from the before/after `batch_decode_components` runs showed a small but measurable improvement in the hot `full_txs` stage while adjacent stages stayed effectively flat:
+  - `span_full_txs_only/1`: `3.0463 ms` -> `3.0158 ms` (~`1.0%` lower median)
+  - `span_full_txs_only/64`: `214.02 ms` -> `213.03 ms` (~`0.5%` lower median)
+  - `raw_span_decode_only/64`: `18.330 ms` -> `17.719 ms` (same order of magnitude; not the target of the change)
+  - `span_derive_only/64`: `223.09 ms` -> `222.24 ms` (effectively flat / within noise)
+- interpretation: most of the remaining `full_txs` floor is still inside transaction-data decode and transaction re-encoding, but preallocating the outer result buffer is a safe low-risk cleanup that trims a little allocator churn from the hottest measured substage
+Next:
+- if this decode path is revisited again, microbenchmark `SpanBatchTransactionData::decode` against `TxEnvelope::encode_2718` inside `full_txs()` so the next iteration can tell whether the remaining shared decode floor is dominated by span transaction-data parsing or by re-encoding reconstructed signed transactions.

--- a/docs/autonomy/perf-journal.md
+++ b/docs/autonomy/perf-journal.md
@@ -780,3 +780,27 @@ Results:
 - branch/PR hygiene check: existing open PR remains `#2409` (`perf: optimize batcher hot paths`), so no new PR was opened
 Next:
 - if this decode path is revisited again, add one more synthetic sweep that varies only one shape dimension at a time (calldata size vs access-list size vs authorization-list size) so the next experiment can attribute the rich-shape slowdown to a specific hashed field rather than the combined larger fixture.
+
+## 2026-04-29 15:41 UTC
+Focus: `base-protocol` synthetic signature-hash dimension sensitivity across isolated calldata, access-list, and authorization-list expansions.
+Hypothesis: the prior `simple` versus `rich` synthetic benchmark proved larger payloads and typed lists matter, but it still changed multiple fields at once; a one-factor-at-a-time benchmark should isolate which hashed field drives most of the slowdown for each typed transaction kind before attempting any production optimization around `signature_hash()`.
+Commands:
+- `cargo bench -p base-protocol --bench batch_reader synthetic_signature_hash_shape_sensitivity -- --warm-up-time 0.2 --measurement-time 0.5 --sample-size 10`
+- edited `crates/consensus/protocol/benches/batch_reader.rs` to add new synthetic shapes (`input_heavy`, `access_list_heavy`, `authorization_heavy`) plus a `protocol/batch_reader/synthetic_signature_hash_dimension_sensitivity` Criterion group
+- `cargo fmt --all`
+- `cargo bench -p base-protocol --bench batch_reader synthetic_signature_hash_dimension_sensitivity -- --warm-up-time 0.2 --measurement-time 0.5 --sample-size 10`
+- `cargo test -p base-protocol batch_reader -- --nocapture`
+- `cargo clippy -p base-protocol --tests --benches --no-deps -- -D warnings`
+- extracted medians from `target/criterion/protocol_batch_reader_synthetic_signature_hash_{shape_sensitivity,dimension_sensitivity}/*/*/estimates.json`
+Results:
+- kept production logic unchanged and extended the shared protocol bench with isolated synthetic shape knobs so each tx kind now has the smallest relevant comparison set: legacy measures `simple` vs `input_heavy`, EIP-2930/EIP-1559 add `access_list_heavy`, and EIP-7702 adds `authorization_heavy`
+- validation passed: `cargo test -p base-protocol batch_reader -- --nocapture` (`2 passed`) and `cargo clippy -p base-protocol --tests --benches --no-deps -- -D warnings`
+- refreshed pre-edit shape-sensitivity medians confirmed the combined `rich` shape still widened the gap substantially on this machine: legacy `272.24 µs` -> `1.8249 ms`, EIP-2930 `274.73 µs` -> `3.0109 ms`, EIP-1559 `279.87 µs` -> `3.0098 ms`, EIP-7702 `530.81 µs` -> `3.8130 ms`
+- new isolated-dimension medians show calldata expansion is the largest single driver for every kind, while typed-list overhead is material but smaller than the full combined `rich` shape:
+  - legacy: `simple` `280.94 µs` (~`274 ns/tx`) vs `input_heavy` `1.8088 ms` (~`1.77 µs/tx`), so nearly all of the legacy rich-shape slowdown comes from calldata size alone
+  - EIP-2930: `simple` `283.16 µs` (~`277 ns/tx`), `input_heavy` `1.8169 ms` (~`1.77 µs/tx`), `access_list_heavy` `1.4907 ms` (~`1.46 µs/tx`); the combined rich shape at `3.0109 ms` is roughly additive across large calldata plus populated access lists
+  - EIP-1559: `simple` `286.09 µs` (~`279 ns/tx`), `input_heavy` `1.8213 ms` (~`1.78 µs/tx`), `access_list_heavy` `1.4885 ms` (~`1.45 µs/tx`); this tracks EIP-2930 closely, suggesting access-list hashing rather than fee-field differences drives most typed-list overhead
+  - EIP-7702: `simple` `531.93 µs` (~`519 ns/tx`), `input_heavy` `2.0648 ms` (~`2.02 µs/tx`), `access_list_heavy` `1.5182 ms` (~`1.48 µs/tx`), `authorization_heavy` `1.0616 ms` (~`1.04 µs/tx`); large calldata is still the biggest single contributor, but authorization hashing is a distinct secondary cost unique to 7702
+- interpretation: future hash-focused work should prioritize payload-size-sensitive hashing paths first, then separately evaluate access-list and EIP-7702 authorization handling; optimizing around typed-list serialization alone is unlikely to explain the full `rich` synthetic slowdown
+Next:
+- if this decode path is revisited again, add a mixed two-factor synthetic sweep (for example input+access-list for EIP-2930/EIP-1559 and input+authorization for EIP-7702) or profile upstream `signature_hash()` internals so the next experiment can test whether the near-additive slowdown comes from repeated RLP length calculation, list encoding, or keccak input materialization.

--- a/docs/autonomy/perf-journal.md
+++ b/docs/autonomy/perf-journal.md
@@ -185,3 +185,26 @@ Results:
 - focused tests still passed (`8 passed`) and `cargo clippy -p base-batcher-service --tests --benches --no-deps -- -D warnings` passed
 Next:
 - if this startup scan path is revisited again, benchmark frame parsing plus touched-only draining together so the next candidate optimization is chosen from a more end-to-end block-level profile instead of another tiny lookup tweak
+
+## 2026-04-27 09:48 UTC
+Focus: `base-batcher-service` recent-tx startup scan block-level benchmarking coverage.
+Hypothesis: the existing microbenches proved touched-ID bookkeeping wins in isolation, but the next useful measurement layer is a block-level harness that includes version-0 frame parsing, channel mutation, and draining together; this should show whether the touched-only startup-scan changes still matter once more realistic per-block work is included.
+Commands:
+- `cargo bench -p base-batcher-service --bench recent_txs -- --warm-up-time 0.5 --measurement-time 1.0 --sample-size 15`
+- extended `crates/batcher/service/benches/recent_txs.rs` with a new `process_block` Criterion group that replays encoded version-0 frame payloads into the same `Frame::parse_frames` + channel update + drain flow used by `RecentTxScanner`
+- `cargo fmt --all`
+- `cargo bench -p base-batcher-service --bench recent_txs -- --warm-up-time 0.5 --measurement-time 1.0 --sample-size 15`
+- `cargo test -p base-batcher-service recent_txs -- --nocapture`
+- `cargo clippy -p base-batcher-service --tests --benches --no-deps -- -D warnings`
+Results:
+- added benchmark-only helpers that synthesize encoded transaction payloads and compare the old per-block `Vec::contains` + full-map drain strategy against the current tracker-backed touched-only drain path without requiring RPC I/O
+- the new `process_block` group closes the gap between tiny bookkeeping microbenches and the noisier end-to-end drain benchmarks by measuring parsing, channel insertion, touched-ID tracking, and draining together on a single fixture block
+- new block-level benchmark results:
+  - `baseline_vec_scan_all_4096_ready_unique_channels_from_empty`: `9.5927 ms .. 9.6277 ms`
+  - `tracker_touched_only_4096_ready_unique_channels_from_empty`: `7.6659 ms .. 7.8739 ms` (~19% lower median)
+  - `baseline_vec_scan_all_64_incomplete_touches_among_8192_buffered_channels`: `24.384 µs .. 25.826 µs`
+  - `tracker_touched_only_64_incomplete_touches_among_8192_buffered_channels`: `7.2882 µs .. 10.650 µs` (roughly 2.5-3x lower despite some noise)
+- this confirms the prior touched-only + tracker work still produces a measurable win once frame parsing and channel mutation are included, even though the decode-heavy drain benchmarks remain noisy on some shapes
+- focused validation passed again: `cargo test -p base-batcher-service recent_txs -- --nocapture` (`8 passed`) and `cargo clippy -p base-batcher-service --tests --benches --no-deps -- -D warnings`
+Next:
+- if this path is revisited again, add a multi-block benchmark that reuses the same tracker across successive synthetic L1 blocks so allocator reuse and survivor-heavy buffered-channel sets can be measured in a shape even closer to the real startup scan loop

--- a/docs/autonomy/perf-journal.md
+++ b/docs/autonomy/perf-journal.md
@@ -135,3 +135,28 @@ Results:
 - existing drain-path benches stayed in the same rough bands as the prior run, so this iteration primarily improved per-block touched-ID bookkeeping rather than decode-heavy channel draining
 Next:
 - if startup scan latency is revisited again, add an end-to-end block-parsing bench that combines frame parsing, touched-ID tracking, and touched-only draining so the next iteration can quantify where bookkeeping stops mattering relative to channel decode cost
+
+## 2026-04-27 05:28 UTC
+Focus: `base-batcher-service` per-block tracker reuse inside `RecentTxScanner::highest_submitted_l2_block()`.
+Hypothesis: after replacing touched-channel deduplication with `TouchedChannelTracker`, the startup scan still allocates a fresh tracker per L1 block; reusing one tracker across blocks should shave a little more bookkeeping overhead off the scan without changing touched-ID order or drain semantics.
+Commands:
+- `cargo bench -p base-batcher-service --bench recent_txs -- --warm-up-time 0.5 --measurement-time 1.0 --sample-size 15`
+- edited `crates/batcher/service/src/recent_txs.rs` to let `TouchedChannelTracker` clear/reset its storage and reused a single tracker across the scan loop
+- extended `crates/batcher/service/benches/recent_txs.rs` with comparative microbenches for fresh-allocating vs. reused tracker bookkeeping
+- `cargo fmt --all`
+- `cargo test -p base-batcher-service recent_txs -- --nocapture`
+- `cargo bench -p base-batcher-service --bench recent_txs -- --warm-up-time 0.5 --measurement-time 1.0 --sample-size 15`
+- `cargo clippy -p base-batcher-service --tests --benches --no-deps -- -D warnings`
+Results:
+- added `TouchedChannelTracker::clear` and `reset_with_capacity`, then moved `highest_submitted_l2_block()` to reuse one tracker across the whole block scan instead of allocating a fresh `HashSet` + `Vec` pair for every fetched L1 block
+- added `touched_channel_tracker_reset_allows_reuse_after_clear` to lock in reuse semantics and prove dedup/order behavior survives resets; focused tests now pass (`8 passed`)
+- added two new Criterion cases to compare the old fresh-allocation tracker path against the reused tracker path directly
+- end-to-end drain-path benches stayed noisy and effectively flat, which matches prior runs that showed decode work dominates there
+- comparative bookkeeping microbench results on the confirming run:
+  - `hashset_tracker_4096_unique_frame_channel_ids`: `48.533 µs .. 48.898 µs`
+  - `reused_hashset_tracker_4096_unique_frame_channel_ids`: `48.225 µs .. 48.270 µs` (~0.9% lower median)
+  - `hashset_tracker_4096_frames_across_512_unique_channel_ids`: `44.627 µs .. 44.936 µs`
+  - `reused_hashset_tracker_4096_frames_across_512_unique_channel_ids`: `44.311 µs .. 44.498 µs` (~0.8% lower median)
+- `cargo clippy -p base-batcher-service --tests --benches --no-deps -- -D warnings` passed
+Next:
+- if the startup scan is revisited again, add a block-level benchmark that includes frame parsing plus touched-ID tracking so allocator reuse can be measured in a shape closer to real RPC-fetched blocks, not just the isolated tracker microbench

--- a/docs/autonomy/perf-journal.md
+++ b/docs/autonomy/perf-journal.md
@@ -327,6 +327,26 @@ Results:
 - added benchmark-only paired coverage that keeps the same approximate back-loaded completion shape (`128/128/256/512`) but compares a dense-start fixture where every channel begins on block 0 against the existing sparse-start cohort fixture where later channels only appear on later blocks
 - the new pairwise comparison makes the survivor-heavy contribution explicit: dense-start baseline `2.4536 ms` vs sparse-start baseline `2.2503 ms` (~`8.3%` lower just from later touch-start sparsity), while the touched-only path still improves both shapes but wins more on dense-start survivor-heavy blocks: dense-start fresh tracker `2.2463 ms` (~`8.4%` lower) and reused tracker `2.2340 ms` (~`9.0%` lower) versus sparse-start fresh tracker `2.1074 ms` (~`6.4%` lower) and reused tracker `2.1106 ms` (~`6.2%` lower)
 - this narrows the interpretation: a meaningful part of the startup-scan gain comes from avoiding scans over channels that have existed since early blocks, while later touch-start sparsity alone already removes a large slice of the old full-scan cost
-- focused validation passed again: `cargo test -p base-batcher-service recent_txs -- --nocapture` (`8 passed`) and `cargo clippy -p base-batcher-service --tests --benches --no-deps -- -D warnings`
 Next:
 - if this startup-scan path is revisited again, add a third pair where dense-start and sparse-start fixtures keep both completion counts and per-block transaction counts even closer so the remaining gap can be attributed almost entirely to survivor-heavy channel-map size rather than total parse volume
+
+## 2026-04-28 00:36 UTC
+Focus: `base-batcher-service` recent-tx startup scan matched-volume touch-start benchmark coverage.
+Hypothesis: the prior dense-start vs sparse-start pair still changed per-block transaction volume, so some of the baseline gap could still come from less frame parsing; adding a matched-volume sparse-start fixture should isolate survivor-heavy buffered-map cost more cleanly by keeping block-by-block payload counts aligned with the dense-start back-loaded shape.
+Commands:
+- `cargo bench -p base-batcher-service --bench recent_txs process_blocks_touch_start_sparsity -- --warm-up-time 0.5 --measurement-time 1.0 --sample-size 15`
+- extended `crates/batcher/service/benches/recent_txs.rs` with `MATCHED_VOLUME_BACK_LOADED_READY_COHORTS` and a new `process_blocks_touch_start_matched_volume` Criterion group
+- `cargo fmt --all`
+- `cargo bench -p base-batcher-service --bench recent_txs process_blocks_touch_start_matched_volume -- --warm-up-time 0.5 --measurement-time 1.0 --sample-size 15`
+- `cargo test -p base-batcher-service recent_txs -- --nocapture`
+- `cargo clippy -p base-batcher-service --tests --benches --no-deps -- -D warnings`
+Results:
+- refreshed the existing touch-start sparsity baseline before editing the bench file: dense-start baseline `2.4297 ms`, fresh tracker `2.1906 ms`, reused tracker `2.2198 ms`; sparse-start baseline `2.2413 ms`, fresh tracker `2.1163 ms`, reused tracker `2.1221 ms`
+- added benchmark-only matched-volume coverage where the sparse-start shape keeps the same total `1024` channels and the same per-block completion distribution as the dense-start back-loaded fixture, but delays only a `128`-channel cohort from block `0` to block `1`
+- the matched-volume harness reduced the old dense-vs-sparse baseline gap to about `0.8%` (`2.4297 ms` dense vs `2.4097 ms` matched-volume sparse), showing most of the earlier `8%+` gap came from reduced parse volume rather than survivor-heavy map size alone
+- even with matched block-by-block payload volume, the touched-only drain still beat the full scan in both shapes: dense-start fresh tracker `2.1906 ms` (~`9.8%` lower) and reused tracker `2.2198 ms` (~`8.6%` lower); matched-volume sparse-start fresh tracker `2.2298 ms` (~`7.5%` lower) and reused tracker `2.1861 ms` (~`9.3%` lower)
+- this narrows the interpretation further: touched-only draining still has a durable win even after controlling for parse volume, but the extra dense-vs-sparse gap is much smaller once per-block transaction counts are matched, so future production changes should target the drain/decode path rather than assuming large additional gains from touch-start sparsity alone
+- focused validation passed again: `cargo test -p base-batcher-service recent_txs -- --nocapture` (`8 passed`) and `cargo clippy -p base-batcher-service --tests --benches --no-deps -- -D warnings`
+Next:
+- if this startup-scan path is revisited again, add a benchmark that holds both block payload counts and touched-ID cardinality constant while varying ready-channel decode density, so the next experiment can decide whether any remaining optimization opportunity sits in touched-only draining, channel decode, or `Frame::parse_frames`
+

--- a/docs/autonomy/perf-journal.md
+++ b/docs/autonomy/perf-journal.md
@@ -702,3 +702,31 @@ Results:
 - branch/PR hygiene check: existing open PR remains `#2409` (`perf: optimize batcher hot paths`), so no new PR was opened
 Next:
 - if this path is revisited again, target `signature_hash()` specifically (or prove it cannot be amortized/cached safely in the span decode path) before attempting any more `to_signed_tx()` field-assembly changes.
+
+## 2026-04-29 09:06 UTC
+Focus: `base-protocol` span signature-hash cost distribution by transaction type.
+Hypothesis: after confirming `signature_hash()` dominates `SpanBatchTransactionData::to_signed_tx()`, the next useful narrowing step is to measure hash cost by typed transaction kind; if one kind is materially more expensive per transaction, future hash-focused work should target that path first instead of treating all span transactions the same.
+Commands:
+- `cargo bench -p base-protocol --bench batch_reader span_signed_tx_components -- --warm-up-time 0.2 --measurement-time 0.5 --sample-size 10`
+- edited `crates/consensus/protocol/benches/batch_reader.rs` to add `TypedTransactionKind`, grouping helpers, and a new `protocol/batch_reader/span_signature_hash_by_tx_type` Criterion group
+- `cargo fmt --all`
+- `cargo test -p base-protocol batch_reader -- --nocapture`
+- `cargo clippy -p base-protocol --tests --benches --no-deps -- -D warnings`
+- `cargo bench -p base-protocol --bench batch_reader span_signature_hash_by_tx_type -- --warm-up-time 0.2 --measurement-time 0.5 --sample-size 10`
+- extracted medians from `target/criterion/protocol_batch_reader_span_signature_hash_by_tx_type/*/*/new/estimates.json`
+- `gh pr list --head automation/perf-autopilot --state open`
+Results:
+- kept production logic unchanged and added benchmark-only coverage that groups the same decoded span fixtures by typed transaction kind before measuring `signature_hash()`
+- validation passed: `cargo test -p base-protocol batch_reader -- --nocapture` (`2 passed`) and `cargo clippy -p base-protocol --tests --benches --no-deps -- -D warnings`
+- the current fixture mix is almost entirely legacy and EIP-1559 transactions, with no EIP-7702 transactions present in `batch.hex`; the new bench therefore measured three active kinds on this machine
+- median signature-hash timings from the new group:
+  - `legacy_454_txs/1`: `983.158 µs` total, about `2.17 µs/tx`
+  - `eip2930_11_txs/1`: `21.489 µs` total, about `1.95 µs/tx`
+  - `eip1559_1301_txs/1`: `1.314 ms` total, about `1.01 µs/tx`
+  - `legacy_29056_txs/64`: `66.855 ms` total, about `2.30 µs/tx`
+  - `eip2930_704_txs/64`: `1.394 ms` total, about `1.98 µs/tx`
+  - `eip1559_83264_txs/64`: `88.996 ms` total, about `1.07 µs/tx`
+- interpretation: signature hashing is still the dominant stage overall, but its per-transaction cost is not uniform; legacy and EIP-2930 hashing are roughly 2x the per-tx cost of EIP-1559 on the current fixture mix, so any future optimization or upstream investigation should start with those hash paths or with fixture coverage that includes EIP-7702 before touching production decode logic
+- branch/PR hygiene check: existing open PR remains `#2409` (`perf: optimize batcher hot paths`), so no new PR was opened
+Next:
+- if this decode path is revisited again, either add a fixture with meaningful EIP-7702 coverage or inspect whether legacy/EIP-2930 `signature_hash()` paths can be optimized or replaced by a cheaper safe construction in the span decode flow before attempting any production changes.

--- a/docs/autonomy/perf-journal.md
+++ b/docs/autonomy/perf-journal.md
@@ -291,3 +291,22 @@ Results:
 - focused validation passed again: `cargo test -p base-batcher-service recent_txs -- --nocapture` (`8 passed`) and `cargo clippy -p base-batcher-service --tests --benches --no-deps -- -D warnings`
 Next:
 - if this startup-scan path is revisited again, add a mixed readiness matrix with uneven per-block touch counts (not just completion counts) so the next experiment can separate savings from survivor-heavy draining versus savings from fewer per-block frame parses
+
+## 2026-04-27 20:25 UTC
+Focus: `base-batcher-service` recent-tx startup scan mixed readiness benchmark coverage with uneven touch-start timing.
+Hypothesis: the weighted readiness matrix still starts every channel on block 0, so it conflates survivor-heavy drain savings with the cost of touching every channel on every earlier block; a cohort-based mixed fixture where some channels first appear on later blocks should separate those effects before any more production changes.
+Commands:
+- `cargo bench -p base-batcher-service --bench recent_txs process_blocks_weighted_ready -- --warm-up-time 0.5 --measurement-time 1.0 --sample-size 15`
+- extended `crates/batcher/service/benches/recent_txs.rs` with `ReadyTransitionCohort`, `multi_block_cohort_ready_tx_payloads`, and a new `process_blocks_mixed_ready` Criterion group
+- `cargo fmt --all`
+- `cargo bench -p base-batcher-service --bench recent_txs process_blocks_mixed_ready -- --warm-up-time 0.5 --measurement-time 1.0 --sample-size 15`
+- `cargo test -p base-batcher-service recent_txs -- --nocapture`
+- `cargo clippy -p base-batcher-service --tests --benches --no-deps -- -D warnings`
+Results:
+- refreshed the weighted-ready baseline before editing the bench file: front-loaded median `2.2425 ms` baseline vs `2.0634 ms` fresh tracker (~`8.0%` lower) vs `2.0278 ms` reused tracker (~`9.6%` lower); back-loaded median `2.5104 ms` baseline vs `2.2357 ms` fresh tracker (~`10.9%` lower) vs `2.1885 ms` reused tracker (~`12.8%` lower)
+- added benchmark-only mixed readiness coverage where `1024` channels are split into five cohorts with staggered start blocks and back-loaded completion (`128` ready on block 0, `128` on block 1, `256` starting at block 1 and ready on block 2, `256` spanning all four blocks, and `256` starting at block 2 and ready on block 3)
+- the new mixed fixture showed the touched-only path still wins when later cohorts do not exist in early blocks, but the gain is smaller than the fully back-loaded weighted case: `baseline_vec_scan_all_mixed_back_loaded_4_blocks_1024_channels` = `2.2023 ms`, `fresh_tracker_mixed_back_loaded_4_blocks_1024_channels` = `2.0648 ms` (~`6.2%` lower), `reused_tracker_mixed_back_loaded_4_blocks_1024_channels` = `2.0934 ms` (~`4.9%` lower)
+- compared with the weighted back-loaded result, the reduced win in the mixed fixture suggests a meaningful part of the touched-only benefit comes from avoiding scans over long-lived survivor-heavy channels, not just from distributing completion later in time
+- focused validation passed again: `cargo test -p base-batcher-service recent_txs -- --nocapture` (`8 passed`) and `cargo clippy -p base-batcher-service --tests --benches --no-deps -- -D warnings`
+Next:
+- if this startup-scan path is revisited again, add another mixed fixture that holds completion timing constant while varying only touch-start sparsity, so the next experiment can quantify how much of the win comes from survivor-heavy buffered maps versus per-block frame parsing volume

--- a/docs/autonomy/perf-journal.md
+++ b/docs/autonomy/perf-journal.md
@@ -591,3 +591,33 @@ Results:
 - interpretation: most of the remaining `full_txs` floor is still inside transaction-data decode and transaction re-encoding, but preallocating the outer result buffer is a safe low-risk cleanup that trims a little allocator churn from the hottest measured substage
 Next:
 - if this decode path is revisited again, microbenchmark `SpanBatchTransactionData::decode` against `TxEnvelope::encode_2718` inside `full_txs()` so the next iteration can tell whether the remaining shared decode floor is dominated by span transaction-data parsing or by re-encoding reconstructed signed transactions.
+
+## 2026-04-29 00:33 UTC
+Focus: `base-protocol` span transaction re-encoding allocation in `SpanBatchTransactions::full_txs()`.
+Hypothesis: the remaining `full_txs()` floor is likely split across transaction-data decode, signed-envelope construction, and `encode_2718`; if the encoding stage is still allocating from `Vec::new()` despite knowing `encode_2718_len()`, preallocating each transaction buffer should produce a measurable win and a new component harness should show how much of `full_txs()` it removes.
+Commands:
+- `cargo bench -p base-protocol --bench batch_reader batch_decode_components -- --warm-up-time 0.2 --measurement-time 0.5 --sample-size 10`
+- extended `crates/consensus/protocol/benches/batch_reader.rs` with a new `protocol/batch_reader/span_full_txs_components` Criterion group that splits `SpanBatchTransactions::full_txs()` into `SpanBatchTransactionData::decode`, `SpanBatchTransactionData::to_signed_tx`, and `TxEnvelope::encode_2718`, including both `Vec::new()` and `Vec::with_capacity(tx_envelope.encode_2718_len())` encoding cases
+- edited `crates/consensus/protocol/src/batch/transactions.rs` to change the per-transaction encode buffer from `Vec::new()` to `Vec::with_capacity(tx_envelope.encode_2718_len())`
+- `cargo test -p base-protocol batch_reader -- --nocapture`
+- `cargo clippy -p base-protocol --tests --benches --no-deps -- -D warnings`
+- `cargo bench -p base-protocol --bench batch_reader batch_decode_components -- --warm-up-time 0.2 --measurement-time 0.5 --sample-size 10`
+- `cargo bench -p base-protocol --bench batch_reader span_full_txs_components -- --warm-up-time 0.2 --measurement-time 0.5 --sample-size 10`
+Results:
+- added durable benchmark coverage that makes the hottest remaining `full_txs()` stages explicit instead of guessing from aggregate decode time alone
+- the new component harness shows per-transaction signed-envelope construction dominates, but encoding allocation was still a meaningful secondary cost and exact-capacity buffers help a lot in isolation:
+  - `span_tx_data_decode_only/1`: `101.33 µs`
+  - `span_to_signed_tx_only/1`: `2.411 ms`
+  - `span_encode_2718_only/1`: `302.79 µs`
+  - `span_encode_2718_exact_capacity_only/1`: `145.36 µs` (~`52.0%` lower than `Vec::new()`)
+  - `span_tx_data_decode_only/64`: `11.166 ms`
+  - `span_to_signed_tx_only/64`: `160.47 ms`
+  - `span_encode_2718_only/64`: `25.780 ms`
+  - `span_encode_2718_exact_capacity_only/64`: `15.957 ms` (~`38.1%` lower than `Vec::new()`)
+- the production change moved the full `full_txs()` stage by a meaningful amount once measured end-to-end in the existing harness:
+  - `span_full_txs_only/1`: `3.0887 ms` -> `2.8193 ms` (~`8.7%` lower median from Criterion output)
+  - `span_full_txs_only/64`: `214.58 ms` -> `196.27 ms` (~`8.5%` lower median)
+  - `span_derive_only/64`: `223.39 ms` -> `205.48 ms` (~`8.0%` lower median), consistent with `derive` spending most of its time inside `full_txs()`
+- validation passed: `cargo test -p base-protocol batch_reader -- --nocapture` (`2 passed`) and `cargo clippy -p base-protocol --tests --benches --no-deps -- -D warnings`
+Next:
+- if this decode path is revisited again, use the new `span_full_txs_components` harness to test whether `SpanBatchTransactionData::to_signed_tx` can avoid more temporary allocation or repeated setup, since it now accounts for the largest remaining share of the `full_txs()` floor.

--- a/docs/autonomy/perf-journal.md
+++ b/docs/autonomy/perf-journal.md
@@ -547,3 +547,26 @@ Results:
 - interpretation: outer RLP framing is only about `0.8%` of the single-batch post-decompression path and about `2.4%` to `2.6%` of the `64`-batch path; nearly all remaining shared decode cost sits inside `Batch::decode`/span derivation rather than payload extraction
 Next:
 - if this decode path is revisited again, add a deeper component split inside `Batch::decode` itself (for example `SingleBatch::decode` versus `RawSpanBatch::decode` plus span derivation) so the next experiment can identify whether large-channel cost is dominated by raw span parsing, transaction-data decoding, or span derivation.
+
+## 2026-04-28 20:10 UTC
+Focus: `base-protocol` shared post-decompression span decode split inside `Batch::decode`.
+Hypothesis: after isolating outer RLP framing, the remaining floor likely sits inside span-batch decoding; a deeper span-specific benchmark should reveal whether large-channel cost is dominated by raw span parsing, transaction reconstruction in `SpanBatchTransactions::full_txs`, or final `RawSpanBatch::derive` work.
+Commands:
+- `cargo bench -p base-protocol --bench batch_reader post_decompression_components -- --warm-up-time 0.2 --measurement-time 0.5 --sample-size 10`
+- edited `crates/consensus/protocol/benches/batch_reader.rs` to add `span_batch_payloads_from_decompressed`, `raw_span_batch_templates_from_decompressed`, `decode_all_raw_span_batches`, `decode_all_raw_span_full_txs`, `derive_all_raw_span_batches`, and a new `protocol/batch_reader/batch_decode_components` Criterion group
+- `cargo fmt --all`
+- `cargo test -p base-protocol batch_reader -- --nocapture`
+- `cargo clippy -p base-protocol --tests --benches --no-deps -- -D warnings`
+- `cargo bench -p base-protocol --bench batch_reader batch_decode_components -- --warm-up-time 0.2 --measurement-time 0.5 --sample-size 10`
+- extracted median `point_estimate` values from `target/criterion/protocol_batch_reader_{post_decompression_components,batch_decode_components}/*/*/new/estimates.json`
+Results:
+- kept production logic unchanged and extended the shared protocol benchmark to strip the leading span batch-type byte from each decompressed RLP payload, then measure three deeper `Batch::decode` stages independently: `RawSpanBatch::decode`, `SpanBatchTransactions::full_txs` on predecoded templates, and full `RawSpanBatch::derive`
+- validation passed: `cargo test -p base-protocol batch_reader -- --nocapture` (`2 passed`) and `cargo clippy -p base-protocol --tests --benches --no-deps -- -D warnings`
+- refreshed zlib post-decompression `Batch::decode` medians from the existing harness: `1` batch `3.3849866 ms`, `64` batches `222.0288915 ms`
+- new span-component medians:
+  - `RawSpanBatch::decode` only: `1` batch `192.06 µs`, `64` batches `17.576 ms`
+  - `SpanBatchTransactions::full_txs` only: `1` batch `3.0213 ms`, `64` batches `211.24 ms`
+  - full `RawSpanBatch::derive`: `1` batch `3.1785 ms`, `64` batches `221.62 ms`
+- interpretation: raw span parsing is only about `5.7%` of the single-batch zlib post-decompression floor and `7.9%` of the `64`-batch floor, while `SpanBatchTransactions::full_txs` accounts for about `89%` of the single-batch cost and about `95%` of the `64`-batch cost; the remaining derive step above `full_txs` is comparatively small, so future optimization work should focus on transaction reconstruction/encoding inside `full_txs` rather than on raw span parsing or prefix/origin derivation
+Next:
+- if this decode path is revisited again, drill into `SpanBatchTransactions::full_txs` itself (for example `SpanBatchTransactionData::decode`, signature/to-field assembly, and `TxEnvelope::encode_2718`) so the next experiment can identify whether the remaining shared decode floor is dominated by span transaction-data parsing or transaction re-encoding.

--- a/docs/autonomy/perf-journal.md
+++ b/docs/autonomy/perf-journal.md
@@ -730,3 +730,29 @@ Results:
 - branch/PR hygiene check: existing open PR remains `#2409` (`perf: optimize batcher hot paths`), so no new PR was opened
 Next:
 - if this decode path is revisited again, either add a fixture with meaningful EIP-7702 coverage or inspect whether legacy/EIP-2930 `signature_hash()` paths can be optimized or replaced by a cheaper safe construction in the span decode flow before attempting any production changes.
+
+## 2026-04-29 11:20 UTC
+Focus: `base-protocol` signature-hash benchmark coverage for EIP-7702 and tx-type apples-to-apples comparisons.
+Hypothesis: the existing `span_signature_hash_by_tx_type` fixture is useful for real mix analysis but cannot measure EIP-7702 because `batch.hex` contains none; adding a synthetic same-cardinality tx-type benchmark should close that coverage gap and reveal whether the earlier per-tx ordering was mostly fixture-shape dependent.
+Commands:
+- `cargo bench -p base-protocol --bench batch_reader span_signature_hash_by_tx_type -- --warm-up-time 0.2 --measurement-time 0.5 --sample-size 10`
+- edited `crates/consensus/protocol/benches/batch_reader.rs` to add synthetic typed-transaction fixtures plus a new `protocol/batch_reader/synthetic_signature_hash_by_tx_type` Criterion group
+- `cargo fmt --all`
+- `cargo test -p base-protocol batch_reader -- --nocapture`
+- `cargo clippy -p base-protocol --tests --benches --no-deps -- -D warnings`
+- `cargo bench -p base-protocol --bench batch_reader synthetic_signature_hash_by_tx_type -- --warm-up-time 0.2 --measurement-time 0.5 --sample-size 10`
+- extracted medians from `target/criterion/protocol_batch_reader_synthetic_signature_hash_by_tx_type/*/*/new/estimates.json`
+- `gh pr list --head automation/perf-autopilot --state open`
+Results:
+- refreshed the existing fixture-backed hash benchmark before editing the bench file; it still measured only legacy, EIP-2930, and EIP-1559 because `batch.hex` contains no EIP-7702 transactions, confirming the coverage gap from the prior run
+- added benchmark-only synthetic coverage that builds `1024` typed transactions per kind (`legacy`, `eip2930`, `eip1559`, `eip7702`) with the same cardinality and simple uniform payload shape, leaving production logic unchanged
+- validation passed: `cargo test -p base-protocol batch_reader -- --nocapture` (`2 passed`) and `cargo clippy -p base-protocol --tests --benches --no-deps -- -D warnings`
+- median synthetic signature-hash timings from Criterion `estimates.json`:
+  - `legacy_1024_txs/synthetic`: `273.52 µs` total, about `267 ns/tx`
+  - `eip2930_1024_txs/synthetic`: `272.97 µs` total, about `267 ns/tx`
+  - `eip1559_1024_txs/synthetic`: `307.85 µs` total, about `301 ns/tx`
+  - `eip7702_1024_txs/synthetic`: `525.64 µs` total, about `513 ns/tx`
+- interpretation: the earlier fixture-backed ranking was heavily influenced by the real span fixture mix and transaction shapes; under matched synthetic cardinality, EIP-7702 hashing is the most expensive of the four measured kinds while legacy and EIP-2930 are effectively tied and EIP-1559 sits modestly above them
+- branch/PR hygiene check: existing open PR remains `#2409` (`perf: optimize batcher hot paths`), so no new PR was opened
+Next:
+- if this decode path is revisited again, compare synthetic per-kind hash cost against richer payload/access-list/authorization-list shapes or a real EIP-7702 fixture so the next experiment can tell how much of the new gap is intrinsic to transaction type versus specific field population.

--- a/docs/autonomy/perf-journal.md
+++ b/docs/autonomy/perf-journal.md
@@ -20,7 +20,24 @@ Commands:
 Results:
 - consensus hotspots identified around sequencer build/seal, engine request processing, derivation, provider RPC/cache behavior, and gossip paths
 - batcher hotspots identified around driver scheduling, encoder/compression, blob packing, recent-tx startup scan, and source polling/catchup
-- zk hotspots identified around witness generation, status polling, repeated GetProof syncs, session round-trips, and proxy rate limiting
+- zk hotspots identified around witness generation, status polling, repeated GetProof sync calls, session round-trips, and proxy rate limiting
 - reusable benchmarking infrastructure exists in `crates/infra/load-tests` plus several criterion benches elsewhere in the repo
 Next:
 - start with the narrowest measurable improvement in one hotspot area, likely batcher encoder/submission or zk service polling behavior
+
+## 2026-04-26 18:32 UTC
+Focus: `base-batcher-encoder` DA backlog accounting in `BatchEncoder::da_backlog_bytes()`.
+Hypothesis: the backlog getter is on the batcher throttle path and should not rescan every unencoded block/transaction; caching the pending DA bytes should turn reads from O(n) into O(1) while preserving exact behavior.
+Commands:
+- `cargo test -p base-batcher-encoder`
+- `cargo bench -p base-batcher-encoder --bench da_backlog -- --warm-up-time 0.5 --measurement-time 1.5 --sample-size 20`
+- `cargo clippy -p base-batcher-encoder --tests --benches -- -D warnings`
+- `cargo fmt --all`
+Results:
+- added a cached `da_backlog_bytes: u64` field to `BatchEncoder`, updating it on `add_block`, successful single/span encoding, and `reset()` so `da_backlog_bytes()` is now O(1)
+- added `test_da_backlog_cache_tracks_encoding_lifecycle` to verify cache correctness through add/encode/reset transitions; full crate tests pass (`60 passed`)
+- added a new Criterion bench at `crates/batcher/encoder/benches/da_backlog.rs` covering `4096_blocks_pending` and `4096_blocks_half_encoded`
+- fixed the bench harness so clippy passes and benchmark calls are not trivially constant-folded via `black_box`
+- post-change benchmark results: `4096_blocks_pending` = `202.18 ps .. 203.75 ps`, `4096_blocks_half_encoded` = `201.22 ps .. 201.49 ps`, confirming constant-time reads regardless of backlog depth/encoded cursor position
+Next:
+- watch for any follow-up review feedback on whether additional encoder counters or a comparative regression benchmark against the old linear scan would be useful

--- a/docs/autonomy/perf-journal.md
+++ b/docs/autonomy/perf-journal.md
@@ -208,3 +208,23 @@ Results:
 - focused validation passed again: `cargo test -p base-batcher-service recent_txs -- --nocapture` (`8 passed`) and `cargo clippy -p base-batcher-service --tests --benches --no-deps -- -D warnings`
 Next:
 - if this path is revisited again, add a multi-block benchmark that reuses the same tracker across successive synthetic L1 blocks so allocator reuse and survivor-heavy buffered-channel sets can be measured in a shape even closer to the real startup scan loop
+
+## 2026-04-27 11:57 UTC
+Focus: `base-batcher-service` recent-tx startup scan multi-block benchmarking coverage for tracker reuse.
+Hypothesis: the prior single-block harness still hid most of the small tracker-reuse benefit; a multi-block benchmark that keeps the buffered channel map alive across several synthetic L1 blocks should make the fresh-vs-reused tracker choice measurable in a shape closer to the real startup scan loop.
+Commands:
+- `cargo bench -p base-batcher-service --bench recent_txs -- --warm-up-time 0.5 --measurement-time 1.0 --sample-size 15`
+- extended `crates/batcher/service/benches/recent_txs.rs` with new multi-block payload builders plus a `process_blocks` Criterion group that compares fresh tracker allocation per block against `TouchedChannelTracker::reset_with_capacity` reuse across eight successive synthetic blocks
+- `cargo test -p base-batcher-service recent_txs -- --nocapture`
+- `cargo clippy -p base-batcher-service --tests --benches --no-deps -- -D warnings`
+- `cargo bench -p base-batcher-service --bench recent_txs -- --warm-up-time 0.5 --measurement-time 1.0 --sample-size 15`
+Results:
+- kept production logic unchanged and added benchmark-only coverage for the exact next gap identified in the previous run: persistent buffered channels across multiple synthetic blocks with touched-only draining after each block
+- the new `process_blocks` group isolates tracker lifecycle cost better than the single-block harness by letting channels persist while replaying `8 × 4096` incomplete touches, which is closer to a survivor-heavy startup scan
+- new multi-block benchmark results:
+  - `fresh_tracker_8_blocks_4096_incomplete_touches_each_among_persistent_channels`: `3.8344 ms .. 4.2619 ms`
+  - `reused_tracker_8_blocks_4096_incomplete_touches_each_among_persistent_channels`: `3.7320 ms .. 3.8966 ms` (~6.4% lower median)
+- confirming run also kept the earlier block-level signal intact: `baseline_vec_scan_all_4096_ready_unique_channels_from_empty` = `9.5838 ms .. 9.7675 ms`, `tracker_touched_only_4096_ready_unique_channels_from_empty` = `7.6493 ms .. 7.8187 ms`
+- focused validation passed again: `cargo test -p base-batcher-service recent_txs -- --nocapture` (`8 passed`) and `cargo clippy -p base-batcher-service --tests --benches --no-deps -- -D warnings`
+Next:
+- if this startup-scan path is revisited again, extend the multi-block harness with channels that become ready only on later blocks so the benchmark covers both tracker reuse and the eventual decode/drain transition inside a persistent survivor-heavy channel set

--- a/docs/autonomy/perf-journal.md
+++ b/docs/autonomy/perf-journal.md
@@ -675,3 +675,30 @@ Results:
 - branch/PR hygiene check: `git status` is clean after revert and the existing open PR is still `#2409`, so there was nothing to commit or push this run
 Next:
 - avoid more ownership-plumbing experiments in `full_txs()` until a deeper component harness proves where the remaining `span_to_signed_tx_only` time is really spent; the next best target is a finer split inside signed transaction construction (for example signature-hash generation versus typed-transaction assembly per tx kind) so future edits can attack the dominant substage directly.
+
+## 2026-04-29 06:57 UTC
+Focus: `base-protocol` span signed-transaction construction decomposition inside `SpanBatchTransactionData::to_signed_tx()`.
+Hypothesis: the remaining `span_to_signed_tx_only` floor may not be in transaction field assembly at all; a deeper benchmark that separates typed-transaction construction from `signature_hash()` generation should show whether another production edit is justified or whether hashing already dominates the stage.
+Commands:
+- `cargo bench -p base-protocol --bench batch_reader span_full_txs_components -- --warm-up-time 0.2 --measurement-time 0.5 --sample-size 10`
+- edited `crates/consensus/protocol/benches/batch_reader.rs` to add a new `protocol/batch_reader/span_signed_tx_components` Criterion group with `span_build_typed_tx_only` and `span_signature_hash_only` fixtures alongside the existing `span_to_signed_tx_only` case
+- `cargo fmt --all`
+- `cargo test -p base-protocol batch_reader -- --nocapture`
+- `cargo clippy -p base-protocol --tests --benches --no-deps -- -D warnings`
+- `cargo bench -p base-protocol --bench batch_reader span_signed_tx_components -- --warm-up-time 0.2 --measurement-time 0.5 --sample-size 10`
+- extracted medians from `target/criterion/protocol_batch_reader_span_signed_tx_components/*/*/new/estimates.json`
+- `gh pr list --head automation/perf-autopilot --state open`
+Results:
+- kept production logic unchanged and added benchmark-only coverage that rebuilds typed transactions from decoded span fixtures, then measures `signature_hash()` separately from typed-transaction field assembly
+- validation passed: `cargo test -p base-protocol batch_reader -- --nocapture` (`2 passed`) and `cargo clippy -p base-protocol --tests --benches --no-deps -- -D warnings`
+- new median benchmark results show `signature_hash()` is overwhelmingly dominant inside `to_signed_tx()`:
+  - `span_to_signed_tx_only/1`: `2.3998 ms`
+  - `span_build_typed_tx_only/1`: `39.285 µs` (~`1.64%` of total)
+  - `span_signature_hash_only/1`: `2.3287 ms` (~`97.0%` of total)
+  - `span_to_signed_tx_only/64`: `160.14 ms`
+  - `span_build_typed_tx_only/64`: `2.6204 ms` (~`1.64%` of total)
+  - `span_signature_hash_only/64`: `154.78 ms` (~`96.6%` of total)
+- interpretation: another ownership/plumbing change in typed transaction assembly is unlikely to move the end-to-end `full_txs()` floor much; nearly all of the remaining cost in `to_signed_tx()` is signature-hash generation
+- branch/PR hygiene check: existing open PR remains `#2409` (`perf: optimize batcher hot paths`), so no new PR was opened
+Next:
+- if this path is revisited again, target `signature_hash()` specifically (or prove it cannot be amortized/cached safely in the span decode path) before attempting any more `to_signed_tx()` field-assembly changes.

--- a/docs/autonomy/perf-journal.md
+++ b/docs/autonomy/perf-journal.md
@@ -394,3 +394,30 @@ Results:
 Next:
 - if this startup-scan path is revisited again, add a decode-only microbenchmark around `channel.frame_data()` + `BatchReader::next_batch()` so future work can isolate frame concatenation and decompression costs from touched-ID tracking and channel-map drain behavior.
 
+## 2026-04-28 06:57 UTC
+Focus: `base-batcher-service` recent-tx startup scan decode-component benchmark coverage.
+Hypothesis: the decode-density harness still mixed touched-ID draining, frame parsing, `channel.frame_data()`, and `BatchReader` work; a decode-only component bench should isolate whether the next likely hotspot is frame concatenation or decompression/decoding before touching production code again.
+Commands:
+- `cargo bench -p base-batcher-service --bench recent_txs process_block_decode_density -- --warm-up-time 0.5 --measurement-time 1.0 --sample-size 15`
+- edited `crates/batcher/service/benches/recent_txs.rs` to add `decode_channel_components` coverage with ready multi-batch channels split across `1`, `4`, and `16` frames
+- `cargo fmt --all`
+- `cargo test -p base-batcher-service recent_txs -- --nocapture`
+- `cargo clippy -p base-batcher-service --tests --benches --no-deps -- -D warnings`
+- `cargo bench -p base-batcher-service --bench recent_txs decode_channel_components -- --warm-up-time 0.5 --measurement-time 1.0 --sample-size 15`
+- extracted median `point_estimate` values from `target/criterion/.../estimates.json`
+Results:
+- kept production logic unchanged and added benchmark-only helpers that separately measure `channel.frame_data()` alone, `BatchReader` on preaggregated channel bytes alone, and the combined decode path for a `16`-batch ready channel
+- validation passed: `cargo test -p base-batcher-service recent_txs -- --nocapture` (`8 passed`) and `cargo clippy -p base-batcher-service --tests --benches --no-deps -- -D warnings`
+- refreshed decode-density medians on the current tree to preserve continuity before the harness edit:
+  - `0` ready channels: baseline full scan `205.30 µs`; tracker+touched-only `104.18 µs` (~`49.3%` lower)
+  - `256` ready channels: baseline `681.31 µs`; tracker+touched-only `589.41 µs` (~`13.5%` lower)
+  - `512` ready channels: baseline `1.1581 ms`; tracker+touched-only `1.0310 ms` (~`11.0%` lower)
+  - `1024` ready channels: baseline `2.1614 ms`; tracker+touched-only `1.9537 ms` (~`9.6%` lower)
+- new decode-component medians show `BatchReader` dominates while `channel.frame_data()` stays a small but growing additive cost as frame count rises:
+  - `1` frame: `frame_data_only` `19.52 ns`; `batch_reader_only` `3.4034 µs`; combined `3.4197 µs`
+  - `4` frames: `frame_data_only` `25.62 ns`; `batch_reader_only` `3.4136 µs`; combined `3.3986 µs`
+  - `16` frames: `frame_data_only` `82.71 ns`; `batch_reader_only` `3.4251 µs`; combined `3.4930 µs`
+- interpretation: even when a ready channel is split across many frames, frame concatenation remains tiny relative to decompression and batch decoding, so the next production opportunity is more likely inside `BatchReader`/decode work than in additional `channel.frame_data()` tweaks
+Next:
+- if this path is revisited again, inspect `BatchReader::decompress` and per-batch decode overhead for reusable scratch buffers or avoidable allocations, using the new component harness to verify whether any candidate actually moves the `~3.4 µs` decode floor.
+

--- a/docs/autonomy/perf-journal.md
+++ b/docs/autonomy/perf-journal.md
@@ -525,3 +525,25 @@ Results:
 - interpretation: on large zlib channels the remaining floor is split between codec work (`134.25 ms`, ~`37.9%` of total) and post-decompression batch decode (`224.88 ms`, ~`63.5%` of total), while on large brotli channels most of the cost is now clearly in shared post-decompression decode (`223.63 ms`, ~`80.2%` of total) rather than brotli itself (`59.66 ms`, ~`21.4%`)
 Next:
 - if this decode path is revisited again, profile or microbenchmark the shared post-decompression path itself (for example `Bytes::decode` framing versus `Batch::decode`/span derivation) because that now looks like the dominant remaining hotspot, especially for brotli channels.
+
+## 2026-04-28 18:08 UTC
+Focus: `base-protocol` shared post-decompression decode split between outer RLP framing and `Batch::decode` work.
+Hypothesis: the prior post-decompression harness still mixed `Bytes::decode` framing with actual batch decoding, so splitting those stages should reveal whether the remaining floor is in outer RLP payload extraction or inside batch-specific decode/derive logic.
+Commands:
+- `cargo bench -p base-protocol --bench batch_reader post_decompression_decode_only -- --warm-up-time 0.2 --measurement-time 0.5 --sample-size 10`
+- edited `crates/consensus/protocol/benches/batch_reader.rs` to add `batch_payloads_from_decompressed`, `count_rlp_wrapped_batches`, `decode_all_batch_payloads`, and a new `protocol/batch_reader/post_decompression_components` Criterion group
+- `cargo fmt --all`
+- `cargo test -p base-protocol batch_reader -- --nocapture`
+- `cargo clippy -p base-protocol --tests --benches --no-deps -- -D warnings`
+- `cargo bench -p base-protocol --bench batch_reader post_decompression_components -- --warm-up-time 0.2 --measurement-time 0.5 --sample-size 10`
+- extracted median `point_estimate` values from `target/criterion/protocol_batch_reader_{post_decompression_decode_only,post_decompression_components}/*/*/new/estimates.json`
+Results:
+- kept production logic unchanged and added benchmark-only coverage that splits the shared post-decompression path into outer `Bytes::decode` framing (`rlp_only_*`) versus `Batch::decode` on pre-extracted payloads (`batch_decode_only_*`)
+- validation passed again: `cargo test -p base-protocol batch_reader -- --nocapture` (`2 passed`) and `cargo clippy -p base-protocol --tests --benches --no-deps -- -D warnings`
+- refreshed post-decompression decode-only medians: zlib `1` batch `3.360 ms`, brotli `1` batch `3.416 ms`, zlib `64` batches `225.80 ms`, brotli `64` batches `224.80 ms`
+- new component medians:
+  - outer RLP framing only: zlib `1` batch `27.57 µs`, brotli `1` batch `25.93 µs`, zlib `64` batches `5.844 ms`, brotli `64` batches `5.441 ms`
+  - `Batch::decode` on pre-extracted payloads: zlib `1` batch `3.384 ms`, brotli `1` batch `3.398 ms`, zlib `64` batches `221.89 ms`, brotli `64` batches `221.59 ms`
+- interpretation: outer RLP framing is only about `0.8%` of the single-batch post-decompression path and about `2.4%` to `2.6%` of the `64`-batch path; nearly all remaining shared decode cost sits inside `Batch::decode`/span derivation rather than payload extraction
+Next:
+- if this decode path is revisited again, add a deeper component split inside `Batch::decode` itself (for example `SingleBatch::decode` versus `RawSpanBatch::decode` plus span derivation) so the next experiment can identify whether large-channel cost is dominated by raw span parsing, transaction-data decoding, or span derivation.

--- a/docs/autonomy/perf-journal.md
+++ b/docs/autonomy/perf-journal.md
@@ -109,3 +109,29 @@ Results:
   - `64_touched_incomplete_among_8192_channels`: `366.17 µs .. 382.39 µs` (~8-10% lower in the sparse no-decode case, matching the intended avoided-scan scenario)
 Next:
 - if this path is revisited, grow the benchmark matrix around frame fan-out and touched-ID cardinality so the crossover point between touched-only draining and full-map scanning is explicit, especially for startup scans with many buffered but mostly untouched channels
+
+## 2026-04-27 03:21 UTC
+Focus: `base-batcher-service` touched-channel deduplication inside `RecentTxScanner::highest_submitted_l2_block()`.
+Hypothesis: after moving the startup scan to touched-only draining, per-block deduplication via `Vec::contains` is still O(k²) in the number of parsed frames; replacing it with a small reusable tracker backed by `HashSet` + ordered `Vec` should materially reduce the bookkeeping cost for high fan-out blocks without changing drain semantics.
+Commands:
+- `cargo bench -p base-batcher-service --bench recent_txs -- --warm-up-time 0.5 --measurement-time 1.0 --sample-size 15`
+- edited `crates/batcher/service/src/recent_txs.rs` to add `TouchedChannelTracker` and use it from `highest_submitted_l2_block()`
+- extended `crates/batcher/service/benches/recent_txs.rs` with comparative touched-ID tracking microbenches for the old `Vec::contains` path vs. the new tracker
+- `cargo fmt --all`
+- `cargo test -p base-batcher-service recent_txs -- --nocapture`
+- `cargo bench -p base-batcher-service --bench recent_txs -- --warm-up-time 0.5 --measurement-time 1.0 --sample-size 15`
+- `cargo clippy -p base-batcher-service --tests --benches --no-deps -- -D warnings`
+Results:
+- added a public `TouchedChannelTracker` type, re-exported from `lib.rs`, that preserves first-seen channel order while deduplicating in O(1)-average membership checks via `HashSet`
+- switched `highest_submitted_l2_block()` from ad hoc `Vec::contains` deduplication to `TouchedChannelTracker::record`, keeping the touched-only drain API unchanged
+- added `touched_channel_tracker_deduplicates_and_preserves_first_seen_order` to lock in ordering and dedup behavior alongside the existing drain regression test
+- added focused Criterion coverage that compares the old vector scan against the new tracker for `4096` unique touched IDs and `4096` frames spread across `512` unique channel IDs
+- validation passed: focused tests `7 passed`; `cargo clippy -p base-batcher-service --tests --benches --no-deps -- -D warnings` passed
+- touched-ID tracking benchmark results after the change:
+  - `baseline_vec_scan_4096_unique_frame_channel_ids`: `1.9804 ms .. 2.0371 ms`
+  - `hashset_tracker_4096_unique_frame_channel_ids`: `46.993 µs .. 47.127 µs` (~42x lower)
+  - `baseline_vec_scan_4096_frames_across_512_unique_channel_ids`: `272.70 µs .. 278.45 µs`
+  - `hashset_tracker_4096_frames_across_512_unique_channel_ids`: `43.241 µs .. 43.367 µs` (~6.3x lower)
+- existing drain-path benches stayed in the same rough bands as the prior run, so this iteration primarily improved per-block touched-ID bookkeeping rather than decode-heavy channel draining
+Next:
+- if startup scan latency is revisited again, add an end-to-end block-parsing bench that combines frame parsing, touched-ID tracking, and touched-only draining so the next iteration can quantify where bookkeeping stops mattering relative to channel decode cost

--- a/docs/autonomy/perf-journal.md
+++ b/docs/autonomy/perf-journal.md
@@ -371,3 +371,26 @@ Results:
 Next:
 - if this startup-scan path is revisited again, use the new decode-density harness to test any drain/decode candidate directly; the next likely production opportunity is in channel decode or `Frame::parse_frames`, not in another touched-ID bookkeeping tweak
 
+## 2026-04-28 04:48 UTC
+Focus: `base-batcher-service` recent-tx startup scan decode path in `RecentTxScanner::decode_channel()`.
+Hypothesis: the decode path still clones concatenated channel frame data with `data.to_vec()` before constructing `BatchReader`; passing the owned `Bytes` directly should avoid one full payload copy per ready channel while preserving decoding semantics.
+Commands:
+- `cargo bench -p base-batcher-service --bench recent_txs process_block_decode_density -- --warm-up-time 0.5 --measurement-time 1.0 --sample-size 15`
+- edited `crates/batcher/service/src/recent_txs.rs` to pass `channel.frame_data()` directly into `BatchReader::new`
+- `cargo fmt --all`
+- `cargo test -p base-batcher-service recent_txs -- --nocapture`
+- `cargo clippy -p base-batcher-service --tests --benches --no-deps -- -D warnings`
+- `cargo bench -p base-batcher-service --bench recent_txs process_block_decode_density -- --warm-up-time 0.5 --measurement-time 1.0 --sample-size 15`
+- extracted median `point_estimate` values from `target/criterion/.../estimates.json` for before/after comparison
+Results:
+- changed `RecentTxScanner::decode_channel()` from `BatchReader::new(data.to_vec(), max_rlp)` to `BatchReader::new(data, max_rlp)`, removing an unnecessary `Bytes`→`Vec<u8>` clone before decompression while leaving all tests green
+- validation passed: `cargo test -p base-batcher-service recent_txs -- --nocapture` (`8 passed`) and `cargo clippy -p base-batcher-service --tests --benches --no-deps -- -D warnings`
+- decode-density median results after the change (before → after):
+  - `0` ready channels: baseline full scan `284.11 µs` → `197.00 µs`; tracker+touched-only `107.05 µs` → `105.80 µs`
+  - `256` ready channels: baseline `711.99 µs` → `686.94 µs`; tracker+touched-only `588.78 µs` → `572.95 µs`
+  - `512` ready channels: baseline `1.2746 ms` → `1.1505 ms`; tracker+touched-only `1.0348 ms` → `1.0337 ms`
+  - `1024` ready channels: baseline `2.2045 ms` → `2.1306 ms`; tracker+touched-only `1.9483 ms` → `1.9690 ms`
+- the signal is modest and somewhat noisy, but the touched-only path stayed essentially flat or slightly better on three of four decode-density cases while the code simplification safely removes one per-channel buffer materialization from the hot decode path
+Next:
+- if this startup-scan path is revisited again, add a decode-only microbenchmark around `channel.frame_data()` + `BatchReader::next_batch()` so future work can isolate frame concatenation and decompression costs from touched-ID tracking and channel-map drain behavior.
+

--- a/docs/autonomy/perf-journal.md
+++ b/docs/autonomy/perf-journal.md
@@ -249,3 +249,24 @@ Results:
 - focused validation passed again: `cargo test -p base-batcher-service recent_txs -- --nocapture` (`8 passed`) and `cargo clippy -p base-batcher-service --tests --benches --no-deps -- -D warnings`
 Next:
 - if this path is revisited again, vary the delayed-ready matrix (for example channel count, block count, and percentage of channels completing on each block) so the crossover between decode cost, touched-only draining, and tracker reuse is explicit before attempting another production optimization
+
+## 2026-04-27 16:13 UTC
+Focus: `base-batcher-service` recent-tx startup scan staggered-ready multi-block benchmark coverage.
+Hypothesis: the prior delayed-ready harness forced every channel to complete on the same final block, which still compressed all decode/drain work into one step; a staggered-ready fixture where channels complete across successive blocks should better expose whether touched-only draining keeps its advantage once readiness is distributed over time and whether tracker reuse matters more in that incremental-completion shape.
+Commands:
+- `cargo bench -p base-batcher-service --bench recent_txs process_blocks_ready_transition -- --warm-up-time 0.5 --measurement-time 1.0 --sample-size 15`
+- extended `crates/batcher/service/benches/recent_txs.rs` with `multi_block_staggered_ready_tx_payloads` and a new `process_blocks_staggered_ready` Criterion group
+- `cargo fmt --all`
+- `cargo bench -p base-batcher-service --bench recent_txs process_blocks_staggered_ready -- --warm-up-time 0.5 --measurement-time 1.0 --sample-size 15`
+- `cargo test -p base-batcher-service recent_txs -- --nocapture`
+- `cargo clippy -p base-batcher-service --tests --benches --no-deps -- -D warnings`
+Results:
+- re-ran the existing delayed-ready harness before editing the bench file to refresh the baseline shape on this machine: `baseline_vec_scan_all_4_blocks_1024_channels_ready_on_final_block` = `2.6685 ms .. 2.6910 ms`, `fresh_tracker_4_blocks_1024_channels_ready_on_final_block` = `2.3085 ms .. 2.3116 ms`, and `reused_tracker_4_blocks_1024_channels_ready_on_final_block` = `2.3507 ms .. 2.3932 ms`
+- added benchmark-only staggered-ready coverage where `1024` channels are evenly distributed across four completion blocks (`25%` become ready on each block), keeping production logic unchanged
+- the new staggered-ready harness showed the touched-only path still beats the old full-map scan when readiness is spread over time:
+  - `baseline_vec_scan_all_4_blocks_1024_channels_ready_in_quarters`: `2.2951 ms .. 2.3111 ms`
+  - `fresh_tracker_4_blocks_1024_channels_ready_in_quarters`: `2.1147 ms .. 2.1479 ms` (~7.4% lower median)
+  - `reused_tracker_4_blocks_1024_channels_ready_in_quarters`: `2.1165 ms .. 2.1321 ms` (~7.7% lower median, effectively tied with fresh allocation and only ~0.3% lower median)
+- focused validation passed again: `cargo test -p base-batcher-service recent_txs -- --nocapture` (`8 passed`) and `cargo clippy -p base-batcher-service --tests --benches --no-deps -- -D warnings`
+Next:
+- if this startup-scan path is revisited again, extend the readiness matrix again (for example front-loaded, back-loaded, and mixed completion ratios) to map the crossover between incremental decode cost and touched-only drain savings before attempting any further production optimization

--- a/docs/autonomy/perf-journal.md
+++ b/docs/autonomy/perf-journal.md
@@ -270,3 +270,24 @@ Results:
 - focused validation passed again: `cargo test -p base-batcher-service recent_txs -- --nocapture` (`8 passed`) and `cargo clippy -p base-batcher-service --tests --benches --no-deps -- -D warnings`
 Next:
 - if this startup-scan path is revisited again, extend the readiness matrix again (for example front-loaded, back-loaded, and mixed completion ratios) to map the crossover between incremental decode cost and touched-only drain savings before attempting any further production optimization
+
+## 2026-04-27 18:19 UTC
+Focus: `base-batcher-service` recent-tx startup scan weighted readiness benchmark coverage.
+Hypothesis: the prior delayed/staggered multi-block fixtures showed touched-only draining still wins when readiness is distributed across blocks, but they did not distinguish whether the win is stronger when channels complete early versus late; adding front-loaded and back-loaded readiness matrices should make that crossover explicit before any further production optimization.
+Commands:
+- `cargo bench -p base-batcher-service --bench recent_txs process_blocks_staggered_ready -- --warm-up-time 0.5 --measurement-time 1.0 --sample-size 15`
+- extended `crates/batcher/service/benches/recent_txs.rs` with `multi_block_weighted_ready_tx_payloads`, front-loaded/back-loaded readiness distributions, and a new `process_blocks_weighted_ready` Criterion group
+- `cargo fmt --all`
+- `cargo bench -p base-batcher-service --bench recent_txs process_blocks_weighted_ready -- --warm-up-time 0.5 --measurement-time 1.0 --sample-size 15`
+- `cargo test -p base-batcher-service recent_txs -- --nocapture`
+- `cargo clippy -p base-batcher-service --tests --benches --no-deps -- -D warnings`
+Results:
+- refreshed the even staggered-ready baseline before editing the bench file: `baseline_vec_scan_all_4_blocks_1024_channels_ready_in_quarters` = `2.2775 ms .. 2.3121 ms`, `fresh_tracker_4_blocks_1024_channels_ready_in_quarters` = `2.1231 ms .. 2.1526 ms`, and `reused_tracker_4_blocks_1024_channels_ready_in_quarters` = `2.1196 ms .. 2.1639 ms`, confirming the touched-only path still holds an about `6.8%` win when completions are evenly distributed
+- added benchmark-only weighted readiness coverage where `1024` channels complete across four blocks in front-loaded (`512/256/128/128`) and back-loaded (`128/128/256/512`) distributions, keeping production logic unchanged
+- the new weighted harness shows touched-only draining helps in both shapes, with a larger gain when completion is back-loaded:
+  - front-loaded: `baseline_vec_scan_all_front_loaded_4_blocks_1024_channels` = `2.1548 ms .. 2.1787 ms`, `fresh_tracker_front_loaded_4_blocks_1024_channels` = `2.0488 ms .. 2.0856 ms` (~`4.7%` lower median), `reused_tracker_front_loaded_4_blocks_1024_channels` = `2.0433 ms .. 2.0741 ms` (~`4.8%` lower median)
+  - back-loaded: `baseline_vec_scan_all_back_loaded_4_blocks_1024_channels` = `2.4837 ms .. 2.5261 ms`, `fresh_tracker_back_loaded_4_blocks_1024_channels` = `2.2126 ms .. 2.2628 ms` (~`10.6%` lower median), `reused_tracker_back_loaded_4_blocks_1024_channels` = `2.2077 ms .. 2.2229 ms` (~`11.5%` lower median)
+- this makes the crossover clearer: touched-only draining buys more once a larger survivor-heavy channel set persists into later blocks, while tracker reuse remains effectively tied with fresh allocation and at most a small secondary factor
+- focused validation passed again: `cargo test -p base-batcher-service recent_txs -- --nocapture` (`8 passed`) and `cargo clippy -p base-batcher-service --tests --benches --no-deps -- -D warnings`
+Next:
+- if this startup-scan path is revisited again, add a mixed readiness matrix with uneven per-block touch counts (not just completion counts) so the next experiment can separate savings from survivor-heavy draining versus savings from fewer per-block frame parses

--- a/docs/autonomy/perf-journal.md
+++ b/docs/autonomy/perf-journal.md
@@ -756,3 +756,27 @@ Results:
 - branch/PR hygiene check: existing open PR remains `#2409` (`perf: optimize batcher hot paths`), so no new PR was opened
 Next:
 - if this decode path is revisited again, compare synthetic per-kind hash cost against richer payload/access-list/authorization-list shapes or a real EIP-7702 fixture so the next experiment can tell how much of the new gap is intrinsic to transaction type versus specific field population.
+
+## 2026-04-29 13:31 UTC
+Focus: `base-protocol` synthetic signature-hash shape sensitivity across richer transaction payloads and lists.
+Hypothesis: the previous same-cardinality synthetic benchmark used very small uniform transactions, so it likely understated the cost of typed payload fields; adding a second synthetic shape with large calldata plus populated access lists and authorization lists should show how much of the tx-type spread is intrinsic to the hash path versus fixture sparsity.
+Commands:
+- `cargo bench -p base-protocol --bench batch_reader synthetic_signature_hash_by_tx_type -- --warm-up-time 0.2 --measurement-time 0.5 --sample-size 10`
+- edited `crates/consensus/protocol/benches/batch_reader.rs` to add `SyntheticSignatureHashShape`, richer synthetic fixture builders, and a new `protocol/batch_reader/synthetic_signature_hash_shape_sensitivity` Criterion group
+- `cargo fmt --all`
+- `cargo test -p base-protocol batch_reader -- --nocapture`
+- `cargo clippy -p base-protocol --tests --benches --no-deps -- -D warnings`
+- `cargo bench -p base-protocol --bench batch_reader synthetic_signature_hash_shape_sensitivity -- --warm-up-time 0.2 --measurement-time 0.5 --sample-size 10`
+- extracted medians from `target/criterion/protocol_batch_reader_synthetic_signature_hash_shape_sensitivity/*/*/new/estimates.json`
+- `gh pr list --head automation/perf-autopilot --state open`
+Results:
+- kept production logic unchanged and extended the synthetic hash harness with paired `simple` and `rich` shapes for all four typed transaction kinds; the `rich` shape uses `1024` bytes of calldata plus populated access lists for EIP-2930/EIP-1559 and four signed authorizations for EIP-7702
+- validation passed: `cargo test -p base-protocol batch_reader -- --nocapture` (`2 passed`) and `cargo clippy -p base-protocol --tests --benches --no-deps -- -D warnings`
+- median signature-hash timings from the new shape-sensitivity group:
+  - simple shape: `legacy` `274.22 µs` (~`268 ns/tx`), `eip2930` `274.87 µs` (~`268 ns/tx`), `eip1559` `280.25 µs` (~`274 ns/tx`), `eip7702` `536.49 µs` (~`524 ns/tx`)
+  - rich shape: `legacy` `1.8150 ms` (~`1.77 µs/tx`), `eip2930` `3.0080 ms` (~`2.94 µs/tx`), `eip1559` `3.0030 ms` (~`2.93 µs/tx`), `eip7702` `3.8093 ms` (~`3.72 µs/tx`)
+- interpretation: the earlier synthetic ranking was directionally right about EIP-7702 being the slowest kind, but richer payloads magnify the typed-list overhead substantially; compared with the simple shape, rich synthetic transactions raise legacy hash cost by about `6.6x`, EIP-2930 by about `10.9x`, EIP-1559 by about `10.7x`, and EIP-7702 by about `7.1x`
+- this narrows the next optimization target: any future hash-focused work should treat access-list-bearing transactions and EIP-7702 separately instead of extrapolating from tiny uniform payloads alone
+- branch/PR hygiene check: existing open PR remains `#2409` (`perf: optimize batcher hot paths`), so no new PR was opened
+Next:
+- if this decode path is revisited again, add one more synthetic sweep that varies only one shape dimension at a time (calldata size vs access-list size vs authorization-list size) so the next experiment can attribute the rich-shape slowdown to a specific hashed field rather than the combined larger fixture.

--- a/docs/autonomy/perf-journal.md
+++ b/docs/autonomy/perf-journal.md
@@ -498,3 +498,30 @@ Results:
 - interpretation: the earlier sub-microsecond brotli results were benchmark-fixture artifacts, not real decode throughput; with valid brotli inputs the shared decode floor is on the same order as zlib and still shows the strongest owned-`Bytes` win on large zlib channels
 Next:
 - if this shared decode path is revisited again, extend the protocol bench with separate post-decompression decode coverage (for example feed pre-decompressed zlib and brotli payloads into the same batch-decoding loop) so the next iteration can quantify how much of the remaining large-channel gap is codec-specific versus shared RLP/batch decoding.
+
+## 2026-04-28 16:01 UTC
+Focus: `base-protocol` shared decode-path split between decompression and post-decompression batch decoding.
+Hypothesis: after correcting protocol-valid brotli fixtures, a post-decompression decode-only harness should show whether the remaining large-channel floor is still mostly codec work or mostly shared RLP/batch decoding.
+Commands:
+- `cargo bench -p base-protocol --bench batch_reader decode_all_batches -- --warm-up-time 0.2 --measurement-time 0.5 --sample-size 10`
+- edited `crates/consensus/protocol/benches/batch_reader.rs` to add `decode_all_batches_from_decompressed` and a new `protocol/batch_reader/post_decompression_decode_only` Criterion group
+- fixed the existing brotli decompression-only bench to strip the leading `CHANNEL_VERSION_BROTLI` byte before calling the raw `Brotli.decompress` helper
+- `cargo fmt --all`
+- `cargo test -p base-protocol batch_reader -- --nocapture`
+- `cargo clippy -p base-protocol --tests --benches --no-deps -- -D warnings`
+- `cargo bench -p base-protocol --bench batch_reader post_decompression_decode_only -- --warm-up-time 0.2 --measurement-time 0.5 --sample-size 10`
+- `cargo bench -p base-protocol --bench batch_reader decompression_only -- --warm-up-time 0.2 --measurement-time 0.5 --sample-size 10`
+- `cargo bench -p base-protocol --bench batch_reader decode_all_batches -- --warm-up-time 0.2 --measurement-time 0.5 --sample-size 10`
+- extracted median `point_estimate` values from `target/criterion/protocol_batch_reader_{post_decompression_decode_only,decompression_only,decode_all_batches}/*/*/new/estimates.json`
+Results:
+- added benchmark-only coverage that decodes batches from already-decompressed channel payloads, isolating shared `Bytes::decode` + `Batch::decode` work from the codec step without changing production logic
+- corrected the raw brotli decompression microbench so it now measures the actual compressed payload rather than the protocol wrapper byte; the old helper expects the payload after the version byte even though `BatchReader` itself consumes the tagged channel bytes
+- validation passed again: `cargo test -p base-protocol batch_reader -- --nocapture` (`2 passed`) and `cargo clippy -p base-protocol --tests --benches --no-deps -- -D warnings`
+- median benchmark results on the current tree:
+  - post-decompression decode-only: zlib `1` batch `3.338 ms`, brotli `1` batch `3.378 ms`, zlib `64` batches `224.88 ms`, brotli `64` batches `223.63 ms`
+  - decompression-only: zlib `1` batch `1.928 ms`, brotli `1` batch `4.078 ms`, zlib `64` batches `134.25 ms`, brotli `64` batches `59.66 ms`
+  - full decode with owned `Bytes`: zlib `1` batch `5.328 ms`, brotli `1` batch `7.693 ms`, zlib `64` batches `353.93 ms`, brotli `64` batches `278.80 ms`
+  - refreshed full-decode baseline vs owned comparison on the same run: zlib `64` batches `365.03 ms` baseline vs `353.93 ms` owned (~`3.0%` lower); brotli `64` batches `278.34 ms` baseline vs `278.80 ms` owned (effectively flat / noise)
+- interpretation: on large zlib channels the remaining floor is split between codec work (`134.25 ms`, ~`37.9%` of total) and post-decompression batch decode (`224.88 ms`, ~`63.5%` of total), while on large brotli channels most of the cost is now clearly in shared post-decompression decode (`223.63 ms`, ~`80.2%` of total) rather than brotli itself (`59.66 ms`, ~`21.4%`)
+Next:
+- if this decode path is revisited again, profile or microbenchmark the shared post-decompression path itself (for example `Bytes::decode` framing versus `Batch::decode`/span derivation) because that now looks like the dominant remaining hotspot, especially for brotli channels.

--- a/docs/autonomy/perf-journal.md
+++ b/docs/autonomy/perf-journal.md
@@ -350,3 +350,24 @@ Results:
 Next:
 - if this startup-scan path is revisited again, add a benchmark that holds both block payload counts and touched-ID cardinality constant while varying ready-channel decode density, so the next experiment can decide whether any remaining optimization opportunity sits in touched-only draining, channel decode, or `Frame::parse_frames`
 
+## 2026-04-28 02:42 UTC
+Focus: `base-batcher-service` recent-tx startup scan decode-density benchmark coverage with constant touched-ID cardinality.
+Hypothesis: the matched-volume touch-start harness narrowed the survivor-heavy map effect, but it still left ambiguity about how much remaining variance comes from ready-channel decode versus drain bookkeeping; a prebuffered single-block fixture with fixed touched cardinality and payload count should isolate that crossover.
+Commands:
+- `cargo fmt --all`
+- `cargo bench -p base-batcher-service --bench recent_txs process_block_decode_density -- --warm-up-time 0.5 --measurement-time 1.0 --sample-size 15`
+- `cargo test -p base-batcher-service recent_txs -- --nocapture`
+- `cargo clippy -p base-batcher-service --tests --benches --no-deps -- -D warnings`
+Results:
+- added benchmark-only coverage in `crates/batcher/service/benches/recent_txs.rs` for `process_block_decode_density`, using a new `prebuffered_decode_density_fixture` that starts `1024` touched channels with two frames already buffered and then replays one current-block frame per channel while varying how many touched channels become ready on that block (`0`, `256`, `512`, `1024`)
+- this fixture keeps touched-ID cardinality and current-block payload count constant, separating ready-channel decode cost from touched-only drain bookkeeping without changing production logic
+- validation passed: focused tests still pass (`8 passed`) and `cargo clippy -p base-batcher-service --tests --benches --no-deps -- -D warnings` passed
+- median benchmark results from Criterion `estimates.json`:
+  - `0` ready channels: baseline full scan `284.11 µs` vs tracker+touched-only `107.05 µs` (~`62.3%` lower)
+  - `256` ready channels: baseline `711.99 µs` vs tracker+touched-only `588.78 µs` (~`17.3%` lower)
+  - `512` ready channels: baseline `1.2746 ms` vs tracker+touched-only `1.0348 ms` (~`18.8%` lower)
+  - `1024` ready channels: baseline `2.2045 ms` vs tracker+touched-only `1.9483 ms` (~`11.6%` lower)
+- the new harness makes the crossover clearer: touched-only draining remains beneficial across the whole range, but the relative win shrinks as more touched channels finish and decode cost dominates more of the block budget
+Next:
+- if this startup-scan path is revisited again, use the new decode-density harness to test any drain/decode candidate directly; the next likely production opportunity is in channel decode or `Frame::parse_frames`, not in another touched-ID bookkeeping tweak
+

--- a/docs/autonomy/perf-journal.md
+++ b/docs/autonomy/perf-journal.md
@@ -421,3 +421,32 @@ Results:
 Next:
 - if this path is revisited again, inspect `BatchReader::decompress` and per-batch decode overhead for reusable scratch buffers or avoidable allocations, using the new component harness to verify whether any candidate actually moves the `~3.4 µs` decode floor.
 
+## 2026-04-28 09:15 UTC
+Focus: `base-protocol::BatchReader` raw-input ownership on the shared decode path used by batcher and consensus derivation.
+Hypothesis: `BatchReader::new` still stores raw channel bytes as `Vec<u8>`, so callers that already own `Bytes` pay an avoidable clone before decompression; switching `BatchReader` to hold `Bytes` directly and adding a side-by-side benchmark should eliminate that constructor copy and show whether decode throughput improves on larger multi-batch channels.
+Commands:
+- `cargo bench -p base-batcher-service --bench recent_txs decode_channel_components -- --warm-up-time 0.5 --measurement-time 1.0 --sample-size 15`
+- edited `crates/consensus/protocol/src/batch/reader.rs` to store raw input as `Option<Bytes>` and accept `Into<Bytes>` in `BatchReader::new`
+- edited `crates/consensus/derive/src/stages/channel/channel_reader.rs` to pass owned channel bytes into `BatchReader::new`
+- added `crates/consensus/protocol/benches/batch_reader.rs` plus Criterion wiring in `crates/consensus/protocol/Cargo.toml`
+- `cargo bench -p base-protocol --bench batch_reader -- --warm-up-time 0.5 --measurement-time 1.0 --sample-size 20`
+- `cargo fmt --all`
+- `cargo test -p base-protocol batch_reader -- --nocapture`
+- `cargo test -p base-consensus-derive channel_reader -- --nocapture`
+- `cargo clippy -p base-protocol --tests --benches --no-deps -- -D warnings`
+- `cargo clippy -p base-consensus-derive --tests --no-deps -- -D warnings`
+- extracted median `point_estimate` values from `target/criterion/protocol_batch_reader_*/*/*/base/estimates.json`
+Results:
+- changed `BatchReader` to retain owned raw input as `Bytes` instead of `Vec<u8>`, letting callers such as `ChannelReader` move channel payloads into the reader without an intermediate heap clone
+- added a new shared protocol benchmark that measures both the old `Bytes::to_vec()` constructor path and the new owned-`Bytes` path for constructor-only cost and full decode cost, using `1`-batch and `64`-batch synthetic channels derived from the existing `batch.hex` fixture
+- validation passed: focused protocol tests (`2 passed`), focused derive tests (`7 passed`), `cargo clippy -p base-protocol --tests --benches --no-deps -- -D warnings`, and `cargo clippy -p base-consensus-derive --tests --no-deps -- -D warnings`
+- constructor benchmark medians show the copy elimination clearly:
+  - `1` batch: baseline `Bytes::to_vec()` `8.045 µs` vs owned `Bytes` `5.96 ns`
+  - `64` batches: baseline `Bytes::to_vec()` `9.113 ms` vs owned `Bytes` `5.93 ns`
+- full decode benchmark medians show the copy matters most once the channel is larger:
+  - `1` batch: baseline `5.452 ms` vs owned `Bytes` `5.554 ms` (effectively noise / no durable win at this size)
+  - `64` batches: baseline `382.56 ms` vs owned `Bytes` `369.54 ms` (~`3.4%` lower median)
+- interpretation: the removed input clone is a large constructor-only win and a modest but measurable end-to-end win on larger multi-batch channels, which is consistent with decompression and batch decoding still dominating small ready-channel work
+Next:
+- if this shared decode path is revisited again, extend the new `base-protocol` bench with a decompression-only split (zlib vs brotli) so the next iteration can tell whether any remaining decode floor is in `decompress_*` itself or in per-batch RLP decoding after decompression.
+

--- a/docs/autonomy/perf-journal.md
+++ b/docs/autonomy/perf-journal.md
@@ -621,3 +621,29 @@ Results:
 - validation passed: `cargo test -p base-protocol batch_reader -- --nocapture` (`2 passed`) and `cargo clippy -p base-protocol --tests --benches --no-deps -- -D warnings`
 Next:
 - if this decode path is revisited again, use the new `span_full_txs_components` harness to test whether `SpanBatchTransactionData::to_signed_tx` can avoid more temporary allocation or repeated setup, since it now accounts for the largest remaining share of the `full_txs()` floor.
+
+## 2026-04-29 02:40 UTC
+Focus: `base-protocol` span transaction reconstruction inside `SpanBatchTransactionData::to_signed_tx()`.
+Hypothesis: the `to_signed_tx()` hot path still converts fee fields from `U256` to `u128` by materializing 32-byte big-endian arrays and slicing the low 16 bytes; replacing those conversions with direct `u128::try_from(&U256)` calls might remove a little per-transaction copying in the dominant reconstruction stage.
+Commands:
+- `cargo bench -p base-protocol --bench batch_reader batch_decode_components -- --warm-up-time 0.2 --measurement-time 0.5 --sample-size 10`
+- `cargo bench -p base-protocol --bench batch_reader span_full_txs_components -- --warm-up-time 0.2 --measurement-time 0.5 --sample-size 10`
+- edited `crates/consensus/protocol/src/batch/tx_data/{legacy,eip2930,eip1559,eip7702}.rs` to replace manual `to_be_bytes::<32>()[16..]` conversions with `u128::try_from(&U256)`
+- `cargo bench -p base-protocol --bench batch_reader batch_decode_components -- --warm-up-time 0.2 --measurement-time 0.5 --sample-size 10`
+- `cargo bench -p base-protocol --bench batch_reader span_full_txs_components -- --warm-up-time 0.2 --measurement-time 0.5 --sample-size 10`
+- `cargo test -p base-protocol batch_reader -- --nocapture`
+- `cargo clippy -p base-protocol --tests --benches --no-deps -- -D warnings`
+- reverted the production edits after the confirming run showed no improvement on the targeted end-to-end stage
+Results:
+- the before-change refresh on the current tree kept the prior hot-stage picture intact: `span_full_txs_only/64` stayed at `196.57 ms` median and `span_to_signed_tx_only/64` at `160.15 ms`, with `span_encode_2718_only/64` at `25.072 ms`
+- the attempted direct-conversion change did not improve the targeted reconstruction stage and slightly regressed the isolated component benches on this machine, so it was intentionally reverted and the branch is left clean
+- confirming after-change medians before revert:
+  - `span_full_txs_only/1`: `2.8439 ms` -> `2.8437 ms` (flat)
+  - `span_full_txs_only/64`: `196.57 ms` -> `196.61 ms` (flat)
+  - `span_to_signed_tx_only/1`: `2.3974 ms` -> `2.4117 ms` (~`0.6%` slower)
+  - `span_to_signed_tx_only/64`: `160.15 ms` -> `161.22 ms` (~`0.7%` slower)
+  - `span_encode_2718_exact_capacity_only/64`: `16.099 ms` -> `16.151 ms` (flat)
+- validation on the temporary experiment still passed: `cargo test -p base-protocol batch_reader -- --nocapture` (`2 passed`) and `cargo clippy -p base-protocol --tests --benches --no-deps -- -D warnings`
+- PR status check: existing open PR remains `#2409` (`perf: optimize batcher hot paths`), so no new PR was opened
+Next:
+- revisit `SpanBatchTransactionData::to_signed_tx()` with a more structural candidate, likely reducing repeated cloning/setup inside typed transaction construction (`input`, access lists, or authorization lists) and validating it first against the existing `span_full_txs_components` harness before touching production code again.

--- a/docs/autonomy/perf-journal.md
+++ b/docs/autonomy/perf-journal.md
@@ -41,3 +41,22 @@ Results:
 - post-change benchmark results: `4096_blocks_pending` = `202.18 ps .. 203.75 ps`, `4096_blocks_half_encoded` = `201.22 ps .. 201.49 ps`, confirming constant-time reads regardless of backlog depth/encoded cursor position
 Next:
 - watch for any follow-up review feedback on whether additional encoder counters or a comparative regression benchmark against the old linear scan would be useful
+
+## 2026-04-26 20:42 UTC
+Focus: `base-consensus-node` derivation finalizer drain path in `L2Finalizer::try_finalize_next()`.
+Hypothesis: when finalizing after a deep derivation backlog, draining finalized epochs with `BTreeMap::retain` does unnecessary full-map scanning; replacing it with `BTreeMap::split_off` should keep only future epochs in O(log n) tree work plus moved survivors, reducing the hot-path cost while preserving semantics.
+Commands:
+- `cargo bench -p base-consensus-node --bench finalizer -- --warm-up-time 0.5 --measurement-time 1.5 --sample-size 20`
+- `cargo test -p base-consensus-node actors::derivation::finalizer:: -- --nocapture --test-threads=1`
+- `cargo clippy -p base-consensus-node --tests --benches --no-deps -- -D warnings`
+- `cargo fmt --all`
+Results:
+- added a new Criterion bench at `crates/consensus/service/benches/finalizer.rs` covering `enqueue_for_finalization`, `try_finalize_next` on a `4096`-entry queue, and an empty-queue miss case
+- replaced the finalization drain in `L2Finalizer::try_finalize_next()` with a helper backed by `BTreeMap::split_off`, and handled `u64::MAX` explicitly to avoid overflow when computing the first surviving epoch
+- added `max_l1_finalization_drains_without_overflow` to lock in the overflow edge case
+- initial baseline bench before the code change measured `4096_entries_finalize_half` at `40.104 µs .. 42.834 µs`, `4096_unique_l1_epochs` at `107.75 µs .. 109.15 µs`, and `empty_queue_miss` at `4.5253 ns .. 4.7974 ns`
+- post-change re-run measured `4096_entries_finalize_half` at `10.928 µs .. 14.483 µs`, roughly a 3-4x improvement on the drain path; `4096_unique_l1_epochs` stayed effectively flat at `103.65 µs .. 105.15 µs`, and `empty_queue_miss` stayed flat at `6.5262 ns .. 6.6165 ns` on the confirming run
+- focused finalizer tests passed (`9 passed`)
+- full `cargo clippy -p base-consensus-node --tests --benches -- -D warnings` is currently blocked by pre-existing lint failures in dependency crate `base-consensus-disc`, so validation used `--no-deps` and passed for the touched crate
+Next:
+- watch PR feedback on whether the finalizer bench should grow a larger survivor-heavy case (for example, finalizing 1 block out of a much larger queue) to characterize `split_off` behavior under different retained-tail sizes

--- a/docs/autonomy/perf-journal.md
+++ b/docs/autonomy/perf-journal.md
@@ -310,3 +310,23 @@ Results:
 - focused validation passed again: `cargo test -p base-batcher-service recent_txs -- --nocapture` (`8 passed`) and `cargo clippy -p base-batcher-service --tests --benches --no-deps -- -D warnings`
 Next:
 - if this startup-scan path is revisited again, add another mixed fixture that holds completion timing constant while varying only touch-start sparsity, so the next experiment can quantify how much of the win comes from survivor-heavy buffered maps versus per-block frame parsing volume
+
+## 2026-04-27 22:31 UTC
+Focus: `base-batcher-service` recent-tx startup scan touch-start sparsity benchmark coverage.
+Hypothesis: the new mixed readiness fixture suggested part of the touched-only drain win comes from survivor-heavy buffered channels, but it still did not compare that against a dense-start shape with similar back-loaded completion; adding a paired dense-start vs sparse-start benchmark should isolate how much of the win comes from later touch-start sparsity versus long-lived survivor-heavy channels.
+Commands:
+- `cargo bench -p base-batcher-service --bench recent_txs process_blocks_weighted_ready -- --warm-up-time 0.5 --measurement-time 1.0 --sample-size 15`
+- `cargo bench -p base-batcher-service --bench recent_txs process_blocks_mixed_ready -- --warm-up-time 0.5 --measurement-time 1.0 --sample-size 15`
+- extended `crates/batcher/service/benches/recent_txs.rs` with a new `process_blocks_touch_start_sparsity` Criterion group that runs paired dense-start and sparse-start back-loaded fixtures
+- `cargo fmt --all`
+- `cargo bench -p base-batcher-service --bench recent_txs process_blocks_touch_start_sparsity -- --warm-up-time 0.5 --measurement-time 1.0 --sample-size 15`
+- `cargo test -p base-batcher-service recent_txs -- --nocapture`
+- `cargo clippy -p base-batcher-service --tests --benches --no-deps -- -D warnings`
+Results:
+- refreshed the existing baselines before editing the bench file: weighted back-loaded median `2.4868 ms` baseline vs `2.2218 ms` fresh tracker (~`10.7%` lower) vs `2.1999 ms` reused tracker (~`11.5%` lower); mixed sparse-start median `2.2125 ms` baseline vs `2.0913 ms` fresh tracker (~`5.5%` lower) vs `2.0833 ms` reused tracker (~`5.8%` lower)
+- added benchmark-only paired coverage that keeps the same approximate back-loaded completion shape (`128/128/256/512`) but compares a dense-start fixture where every channel begins on block 0 against the existing sparse-start cohort fixture where later channels only appear on later blocks
+- the new pairwise comparison makes the survivor-heavy contribution explicit: dense-start baseline `2.4536 ms` vs sparse-start baseline `2.2503 ms` (~`8.3%` lower just from later touch-start sparsity), while the touched-only path still improves both shapes but wins more on dense-start survivor-heavy blocks: dense-start fresh tracker `2.2463 ms` (~`8.4%` lower) and reused tracker `2.2340 ms` (~`9.0%` lower) versus sparse-start fresh tracker `2.1074 ms` (~`6.4%` lower) and reused tracker `2.1106 ms` (~`6.2%` lower)
+- this narrows the interpretation: a meaningful part of the startup-scan gain comes from avoiding scans over channels that have existed since early blocks, while later touch-start sparsity alone already removes a large slice of the old full-scan cost
+- focused validation passed again: `cargo test -p base-batcher-service recent_txs -- --nocapture` (`8 passed`) and `cargo clippy -p base-batcher-service --tests --benches --no-deps -- -D warnings`
+Next:
+- if this startup-scan path is revisited again, add a third pair where dense-start and sparse-start fixtures keep both completion counts and per-block transaction counts even closer so the remaining gap can be attributed almost entirely to survivor-heavy channel-map size rather than total parse volume

--- a/docs/autonomy/perf-journal.md
+++ b/docs/autonomy/perf-journal.md
@@ -475,3 +475,26 @@ Results:
 - interpretation: for large channels, decompression accounts for a substantial share of total decode time (`~38%` for zlib and `~19%` for brotli relative to the current `64`-batch full-decode medians), so the next meaningful optimization likely sits in zlib decompression or in the remaining per-batch RLP decode work rather than in additional constructor plumbing
 Next:
 - if this shared decode path is revisited again, split the `decode_all_batches` harness one step further by compression type so the next iteration can quantify how much of the remaining `~220 ms` to `~293 ms` non-constructor cost is specific to zlib channels versus shared post-decompression batch decoding.
+
+## 2026-04-28 13:39 UTC
+Focus: `base-protocol` shared decode-path benchmark correctness for compression-specific `BatchReader` decoding.
+Hypothesis: the current `decode_all_batches` bench only exercises zlib-valid fixtures/config, so adding protocol-valid brotli fixtures and a Fjord-active config should expose whether the earlier shared decode numbers were accidentally measuring early returns instead of real brotli decode work.
+Commands:
+- `cargo bench -p base-protocol --bench batch_reader decode_all_batches -- --warm-up-time 0.5 --measurement-time 1.0 --sample-size 20`
+- edited `crates/consensus/protocol/benches/batch_reader.rs` to add compression-tagged fixtures, prepend the brotli channel-version byte, and select a Fjord-active `RollupConfig` for brotli decode cases
+- `cargo fmt --all`
+- `cargo bench -p base-protocol --bench batch_reader decode_all_batches -- --warm-up-time 0.5 --measurement-time 1.0 --sample-size 20`
+- `cargo test -p base-protocol batch_reader -- --nocapture`
+- `cargo clippy -p base-protocol --tests --benches --no-deps -- -D warnings`
+- extracted median `point_estimate` values from `target/criterion/protocol_batch_reader_decode_all_batches/*/*/base/estimates.json`
+Results:
+- corrected the shared decode benchmark so brotli cases now use protocol-valid channel bytes (`CHANNEL_VERSION_BROTLI` prefix) and a Fjord-active rollup config instead of accidentally short-circuiting on unsupported-type or pre-Fjord checks
+- validation passed: `cargo test -p base-protocol batch_reader -- --nocapture` (`2 passed`) and `cargo clippy -p base-protocol --tests --benches --no-deps -- -D warnings`
+- refreshed decode medians now split cleanly by compression type:
+  - zlib `1` batch: baseline `5.3706 ms` vs owned `5.4123 ms` (~`0.8%` slower, noise)
+  - brotli `1` batch: baseline `7.9290 ms` vs owned `8.0884 ms` (~`2.0%` slower, noise)
+  - zlib `64` batches: baseline `376.38 ms` vs owned `361.43 ms` (~`4.0%` lower median)
+  - brotli `64` batches: baseline `290.80 ms` vs owned `288.24 ms` (~`0.9%` lower median)
+- interpretation: the earlier sub-microsecond brotli results were benchmark-fixture artifacts, not real decode throughput; with valid brotli inputs the shared decode floor is on the same order as zlib and still shows the strongest owned-`Bytes` win on large zlib channels
+Next:
+- if this shared decode path is revisited again, extend the protocol bench with separate post-decompression decode coverage (for example feed pre-decompressed zlib and brotli payloads into the same batch-decoding loop) so the next iteration can quantify how much of the remaining large-channel gap is codec-specific versus shared RLP/batch decoding.

--- a/docs/autonomy/perf-journal.md
+++ b/docs/autonomy/perf-journal.md
@@ -60,3 +60,23 @@ Results:
 - full `cargo clippy -p base-consensus-node --tests --benches -- -D warnings` is currently blocked by pre-existing lint failures in dependency crate `base-consensus-disc`, so validation used `--no-deps` and passed for the touched crate
 Next:
 - watch PR feedback on whether the finalizer bench should grow a larger survivor-heavy case (for example, finalizing 1 block out of a much larger queue) to characterize `split_off` behavior under different retained-tail sizes
+
+## 2026-04-26 22:49 UTC
+Focus: `base-consensus-node` finalizer benchmarking coverage for survivor-heavy drain cases in `L2Finalizer::try_finalize_next()`.
+Hypothesis: the prior finalizer bench only measured the half-drain case, leaving a gap for the likely worst retained-tail shape after the `split_off` optimization; adding a `finalize_first` benchmark should quantify the cost when almost the entire queue survives.
+Commands:
+- `cargo bench -p base-consensus-node --bench finalizer -- --warm-up-time 0.5 --measurement-time 1.5 --sample-size 20`
+- edited `crates/consensus/service/benches/finalizer.rs` to add `4096_entries_finalize_first`
+- `cargo bench -p base-consensus-node --bench finalizer -- --warm-up-time 0.5 --measurement-time 1.5 --sample-size 20`
+- `cargo test -p base-consensus-node actors::derivation::finalizer:: -- --nocapture --test-threads=1`
+- `cargo clippy -p base-consensus-node --tests --benches --no-deps -- -D warnings`
+- `cargo fmt --all`
+Results:
+- baseline before the bench edit confirmed the existing post-optimization behavior: `4096_entries_finalize_half` = `11.155 µs .. 14.292 µs`, `4096_unique_l1_epochs` = `105.13 µs .. 107.81 µs`, `empty_queue_miss` = `6.5632 ns .. 6.8584 ns`
+- added a new survivor-heavy Criterion case, `4096_entries_finalize_first`, without changing production logic
+- the new benchmark measured `4096_entries_finalize_first` at `10.206 µs .. 11.149 µs`, showing the `split_off` drain remains in the same low-`10 µs` band even when `4095/4096` entries survive
+- confirming run kept `4096_entries_finalize_half` in the same range at `11.880 µs .. 16.408 µs`; `empty_queue_miss` stayed flat at `6.5506 ns .. 6.8324 ns`
+- focused finalizer tests still passed (`9 passed`)
+- `cargo clippy -p base-consensus-node --tests --benches --no-deps -- -D warnings` passed again; full clippy without `--no-deps` remains blocked by pre-existing dependency lints outside the touched crate
+Next:
+- if the finalizer is revisited, add a larger matrix of retained-tail sizes (for example finalize-at-1, finalize-at-1/4, finalize-at-1/2, finalize-at-3/4) to characterize how `split_off` scales with survivor count and to catch future regressions in queue-shape sensitivity

--- a/docs/autonomy/perf-journal.md
+++ b/docs/autonomy/perf-journal.md
@@ -228,3 +228,24 @@ Results:
 - focused validation passed again: `cargo test -p base-batcher-service recent_txs -- --nocapture` (`8 passed`) and `cargo clippy -p base-batcher-service --tests --benches --no-deps -- -D warnings`
 Next:
 - if this startup-scan path is revisited again, extend the multi-block harness with channels that become ready only on later blocks so the benchmark covers both tracker reuse and the eventual decode/drain transition inside a persistent survivor-heavy channel set
+
+## 2026-04-27 14:07 UTC
+Focus: `base-batcher-service` recent-tx startup scan delayed-ready multi-block benchmark coverage.
+Hypothesis: the prior multi-block harness only measured incomplete survivor-heavy channels, so it still underrepresented the moment when touched channels finally become ready and trigger decode/drain work; a delayed-ready multi-block fixture should better capture the durable benefit of touched-only draining once channels finish on a later block.
+Commands:
+- `cargo bench -p base-batcher-service --bench recent_txs process_blocks -- --warm-up-time 0.5 --measurement-time 1.0 --sample-size 15`
+- extended `crates/batcher/service/benches/recent_txs.rs` with `split_frame_data_across_blocks`, `multi_block_ready_transition_tx_payloads`, `process_blocks_with_vec_tracking_and_full_scan`, and a new `process_blocks_ready_transition` Criterion group
+- `cargo fmt --all`
+- `cargo bench -p base-batcher-service --bench recent_txs process_blocks_ready_transition -- --warm-up-time 0.5 --measurement-time 1.0 --sample-size 15`
+- `cargo test -p base-batcher-service recent_txs -- --nocapture`
+- `cargo clippy -p base-batcher-service --tests --benches --no-deps -- -D warnings`
+Results:
+- the pre-change check confirmed the earlier incomplete-only `process_blocks` harness still does not show a durable tracker-reuse win on this machine (`fresh_tracker_8_blocks_4096_incomplete_touches_each_among_persistent_channels`: `3.4449 ms .. 3.7434 ms`; `reused_tracker_8_blocks_4096_incomplete_touches_each_among_persistent_channels`: `3.8477 ms .. 4.3095 ms`)
+- added benchmark-only delayed-ready coverage where `1024` channels receive four split frames across four synthetic blocks and only become ready on the final block, keeping production logic unchanged
+- the new delayed-ready harness showed the touched-only path still materially beats the old full-map drain once readiness and decode happen later in a persistent channel set:
+  - `baseline_vec_scan_all_4_blocks_1024_channels_ready_on_final_block`: `2.6940 ms .. 2.7362 ms`
+  - `fresh_tracker_4_blocks_1024_channels_ready_on_final_block`: `2.3213 ms .. 2.3388 ms` (~14.1% lower median)
+  - `reused_tracker_4_blocks_1024_channels_ready_on_final_block`: `2.3446 ms .. 2.3634 ms` (~12.8% lower median, slightly slower than fresh allocation in this shape)
+- focused validation passed again: `cargo test -p base-batcher-service recent_txs -- --nocapture` (`8 passed`) and `cargo clippy -p base-batcher-service --tests --benches --no-deps -- -D warnings`
+Next:
+- if this path is revisited again, vary the delayed-ready matrix (for example channel count, block count, and percentage of channels completing on each block) so the crossover between decode cost, touched-only draining, and tracker reuse is explicit before attempting another production optimization

--- a/docs/autonomy/perf-pr-template.md
+++ b/docs/autonomy/perf-pr-template.md
@@ -1,0 +1,11 @@
+## Summary
+- describe the performance hypothesis
+- summarize the code or benchmark change
+- report before/after numbers
+
+## Validation
+- list the exact commands used
+- include benchmark or load-test results
+
+## Notes
+- mention risks, tradeoffs, and follow-up work

--- a/docs/autonomy/perf_context.py
+++ b/docs/autonomy/perf_context.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+from datetime import datetime, timezone
+from pathlib import Path
+import re
+
+ROOT = Path("/home/refcell/dev/base-perf-autopilot")
+JOURNAL = ROOT / "docs/autonomy/perf-journal.md"
+
+
+def last_entry_heading(text: str) -> str:
+    matches = re.findall(r"^##\s+(.+)$", text, flags=re.MULTILINE)
+    return matches[-1] if matches else "none"
+
+
+text = JOURNAL.read_text() if JOURNAL.exists() else ""
+now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S UTC")
+print(f"timestamp: {now}")
+print(f"repo_root: {ROOT}")
+print(f"journal: {JOURNAL}")
+print(f"last_journal_entry: {last_entry_heading(text)}")


### PR DESCRIPTION
## Summary
- narrow the batcher recent-tx startup drain to channels touched in the current L1 block instead of rescanning the whole buffered map every block
- add a focused Criterion harness for `RecentTxScanner` with full-scan baselines and sparse touched-channel cases
- record the measurements and follow-up guidance in the perf autopilot journal

## Why
- the startup scan previously walked every buffered channel after each L1 block, even when the block only appended frames to a small subset of channels
- channel readiness can only change for channels touched by frames in the current block, so the extra whole-map scan is avoidable
- the new benchmark matrix keeps this path measurable and shows where the optimization matters most

## Test Plan
- cargo test -p base-batcher-service recent_txs -- --nocapture
- cargo clippy -p base-batcher-service --tests --benches --no-deps -- -D warnings
- cargo bench -p base-batcher-service --bench recent_txs -- --warm-up-time 0.5 --measurement-time 1.0 --sample-size 15
