### PR TITLE
chore(deps): Remove Unused Workspace Dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -278,7 +278,6 @@ base-test-utils = { path = "crates/utilities/test-utils" }
 base-tx-manager = { path = "crates/utilities/tx-manager" }
 base-ring-buffer = { path = "crates/utilities/ring-buffer" }
 base-balance-monitor = { path = "crates/utilities/balance-monitor" }
-base-macros = { path = "crates/utilities/macros", default-features = false }
 base-metrics = { path = "crates/utilities/metrics", default-features = false }
 base-runtime = { path = "crates/utilities/runtime", default-features = false }
 
@@ -321,7 +320,6 @@ alloy-consensus = { version = "1.8", default-features = false }
 alloy-sol-types = { version = "1.5.6", default-features = false }
 alloy-primitives = { version = "1.5.6", default-features = false }
 alloy-rpc-types-eth = { version = "1.8", default-features = false }
-alloy-rpc-types-trace = { version = "1.8", default-features = false }
 alloy-rpc-types-debug = { version = "1.8", default-features = false }
 alloy-rpc-types-engine = { version = "1.8", default-features = false }
 alloy-network-primitives = { version = "1.8", default-features = false }
@@ -341,7 +339,6 @@ reth-codecs = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3" }
 reth-db-api = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3" }
 reth-discv4 = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3" }
 reth-discv5 = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3" }
 reth-trie-db = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3" }
 reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3" }
 reth-network = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3" }
@@ -357,9 +354,7 @@ reth-consensus = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3" 
 reth-chainspec = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3" }
 reth-primitives = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3" }
 reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3" }
-reth-tokio-util = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3" }
 reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3" }
 reth-network-p2p = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3" }
 reth-storage-api = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3" }
 reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3" }
@@ -434,14 +429,12 @@ tracing = { version = "0.1.43", default-features = false }
 
 # Metrics
 ordered-float = "5"
-metrics-derive = "0.1.1"
 metrics = { version = "0.24.3", default-features = false }
 metrics-util = { version = "0.20.1", default-features = false }
 metrics-process = { version = "2.4.3", default-features = false }
 metrics-exporter-prometheus = { version = "0.18.1", default-features = false }
 
 # aws
-aws-nitro-enclaves-cose = "0.5"
 aws-nitro-enclaves-nsm-api = "0.4"
 aws-config = { version = "1.1.7", default-features = false }
 aws-sdk-s3 = { version = "1.106.0", default-features = false }
@@ -456,8 +449,6 @@ risc0-zkvm = { version = "^3.0", default-features = false }
 
 # SP1 v6.1.0 (Hypercube) — used by crates/proof/succinct
 sp1-sdk = { version = "=6.1.0" }
-sp1-lib = { version = "=6.1.0" }
-sp1-zkvm = { version = "=6.1.0" }
 sp1-build = "=6.1.0"
 sp1-prover-types = "=6.1.0"
 sp1-cluster-artifact = { git = "https://github.com/succinctlabs/sp1-cluster", tag = "v2.1.5" }
@@ -468,13 +459,10 @@ sp1-cluster-utils = { git = "https://github.com/succinctlabs/sp1-cluster", tag =
 sha3 = "0.10"
 k256 = "0.13"
 p384 = "0.13"
-zeroize = "1"
 ciborium = "0.2"
-x509-cert = "0.2"
 rustls = "0.23.35"
 secp256k1 = "0.30"
 x509-parser = "0.17"
-rustls-pki-types = "1.0"
 sha2 = { version = "0.10", default-features = false }
 c-kzg = { version = "2.1.5", default-features = false }
 
@@ -514,7 +502,6 @@ serial_test = "3"
 httpmock = "0.8.2"
 proptest = "1.10.0"
 similar-asserts = "1"
-proptest-arbitrary-interop = "0.1.0"
 arbitrary = { version = "1", default-features = false }
 wiremock = { version = "0.6.2", default-features = false }
 testcontainers = { version = "0.25", default-features = false }
@@ -532,7 +519,6 @@ lru = "0.16"
 rand = "0.9"
 rkyv = "0.8"
 moka = "0.12"
-vsock = "0.5"
 uuid = "1.21"
 dirs = "6.0.0"
 csv = "1.3.0"
@@ -574,7 +560,6 @@ opentelemetry = "0.31"
 cargo_metadata = "0.18.1"
 tracing-indicatif = "0.3"
 tikv-jemallocator = "0.6"
-concurrent-queue = "2.5.0"
 modular-bitfield = "0.13.1"
 crossbeam-channel = "0.5.13"
 tracing-opentelemetry = "0.32"
@@ -582,9 +567,7 @@ opentelemetry-appender-tracing = "0.31.1"
 opentelemetry-otlp = { version = "0.31", default-features = false }
 opentelemetry_sdk = { version = "0.31", default-features = false }
 rand_08 = { package = "rand", version = "0.8" }
-zip = { version = "8.1", default-features = false }
 strum = { version = "0.27", default-features = false }
-hashbrown = { version = "0.16", features = ["rayon"] }
 brotli = { version = "8.0.2", default-features = false }
 rocksdb = { version = "0.24", default-features = false }
 rdkafka = { version = "0.39", default-features = false }
@@ -592,7 +575,6 @@ thiserror = { version = "2.0", default-features = false }
 either = { version = "1.15.0", default-features = false }
 kzg-rs = { version = "0.2.8", default-features = false }
 dotenvy = { version = "0.15.7", default-features = false }
-opentelemetry-stdout = { version = "0.31", default-features = false }
 derive_more = { version = "2.1.0", default-features = false }
 figment = { version = "0.10.19", default-features = false }
 
@@ -604,8 +586,6 @@ governor = "0.7"
 nonzero_ext = "0.3"
 
 # transitive deps
-syn = "2.0"
-quote = "1.0"
 spin = "0.10"
 ipnet = "2.11"
 notify = "8.2"
@@ -615,12 +595,10 @@ backtrace = "0.3"
 getrandom = "0.4"
 multihash = "0.19"
 serde_repr = "0.1"
-proc-macro2 = "1.0"
 async-stream = "0.3"
 async-channel = "2.5"
 alloc-no-stdlib = "2.0"
 libp2p-stream = "0.4.0-alpha"
-buddy_system_allocator = "0.12"
 toml = { version = "1.0", default-features = false }
 ark-ff = { version = "0.5.0", default-features = false }
 unsigned-varint = { version = "0.8", default-features = false }


### PR DESCRIPTION
## Summary

Removes workspace-level dependency entries that are no longer referenced by any crate in the repository. These include unused alloy, reth, SP1, cryptography, metrics, and proc-macro crates that accumulated over time. Cleaning them from the root manifest prevents phantom feature resolution and keeps the workspace dependency list accurate.