### PR TITLE
fix(builder): remove duplicate tx execution time metric

### DIFF
--- a/crates/builder/core/src/flashblocks/context.rs
+++ b/crates/builder/core/src/flashblocks/context.rs
@@ -903,7 +903,7 @@ impl BasePayloadBuilderCtx {
                 return Ok(diag);
             }
 
-            let tx_simulation_start_time = Instant::now();
+            let execution_start_time = Instant::now();
             let ResultAndState { result, state } = match evm.transact(&tx) {
                 Ok(res) => res,
                 Err(err) => {
@@ -938,11 +938,13 @@ impl BasePayloadBuilderCtx {
                 }
             };
 
-            let actual_execution_time_us = tx_simulation_start_time.elapsed().as_micros();
+            let execution_time = execution_start_time.elapsed();
 
-            BuilderMetrics::tx_simulation_duration().record(tx_simulation_start_time.elapsed());
+            // The "simulation" terminology comes from upstream op-rbuilder's name for
+            // locally executing a candidate transaction before committing it to the payload;
+            // this is not metering service simulation data from MeterBundleResponse.
+            BuilderMetrics::tx_simulation_duration().record(execution_time);
             BuilderMetrics::tx_byte_size().record(tx.inner().size() as f64);
-            BuilderMetrics::tx_actual_execution_time_us().record(actual_execution_time_us as f64);
             num_txs_simulated += 1;
 
             // Record state modification counts (trie work proxy)
@@ -954,12 +956,12 @@ impl BasePayloadBuilderCtx {
             // Record execution time for unmetered transactions (race condition indicator)
             if resource_usage.is_none() {
                 BuilderMetrics::unmetered_tx_actual_execution_time_us()
-                    .record(actual_execution_time_us as f64);
+                    .record(execution_time.as_micros() as f64);
             }
 
             // Record prediction accuracy
             if let Some(predicted_us) = predicted_execution_time_us {
-                let error = predicted_us as f64 - actual_execution_time_us as f64;
+                let error = predicted_us as f64 - execution_time.as_micros() as f64;
                 BuilderMetrics::execution_time_prediction_error_us().record(error);
             }
 

--- a/crates/builder/core/src/metrics.rs
+++ b/crates/builder/core/src/metrics.rs
@@ -80,7 +80,9 @@ base_metrics::define_metrics! {
     reverted_tx_gas_used: histogram,
     #[describe("Gas used by reverted transactions in the latest block")]
     payload_reverted_tx_gas_used: gauge,
-    #[describe("Histogram of tx simulation duration")]
+    #[describe(
+        "Histogram of local builder EVM transaction execution/simulation duration in seconds"
+    )]
     tx_simulation_duration: histogram,
     #[describe("Byte size of transactions")]
     tx_byte_size: histogram,
@@ -134,8 +136,6 @@ base_metrics::define_metrics! {
     execution_time_prediction_error_us: histogram,
     #[describe("Distribution of predicted execution times from metering service (microseconds)")]
     tx_predicted_execution_time_us: histogram,
-    #[describe("Distribution of actual execution times (microseconds)")]
-    tx_actual_execution_time_us: histogram,
     #[describe("Per-transaction state root gas (computed from metering data)")]
     tx_state_root_gas: histogram,
     #[describe("Cumulative state root gas per block")]


### PR DESCRIPTION
## Summary

Remove the duplicate `base_builder.tx_actual_execution_time_us` histogram and keep `base_builder.tx_simulation_duration` as the canonical local EVM transaction execution timer.

This also clarifies why the remaining metric says "simulation": that term comes from upstream `op-rbuilder`'s naming for locally executing a candidate transaction before committing it to the payload. It does **not** refer to metering-service `MeterBundleResponse` simulation data.

## Context

We ended up with two metrics from the same source timer:

- `tx_simulation_duration` was introduced upstream in flashbots/op-rbuilder#378 (c5f2c1d) as broad builder observability around the local `evm.transact(...)` attempt.
- `base/base` imported that op-rbuilder code in base/base#354 (ce34d669).
- `base/base` then renamed/moved op-rbuilder into `base-builder` in base/base#658 (73b03363), preserving the metric.
- `tx_actual_execution_time_us` was added later in base/base#534 (c5bdb96c) for execution-metering prediction accuracy, but it records the same elapsed timer as `tx_simulation_duration`.

Datadog confirms `tx_simulation_duration` is seconds-scale because `metrics::Histogram::record(Duration)` converts through `Duration::as_secs_f64()`. The `base.reth_base_builder_tx_simulation_duration.*` values line up with `base.reth_base_builder_tx_actual_execution_time_us.*` after multiplying by `1_000_000`, so the `_us` metric does not add information and is less precise because it uses integer `as_micros()`.

## Changes

- Remove `tx_actual_execution_time_us` metric definition and recording.
- Keep `tx_simulation_duration` as the canonical metric.
- Record `execution_start_time.elapsed()` once and reuse it for:
  - the canonical seconds-based `tx_simulation_duration` metric
  - local microsecond math for prediction error and unmetered transaction metrics
- Update the `tx_simulation_duration` description to say it is local builder EVM transaction execution/simulation duration in seconds.
- Add an inline comment explaining the upstream `op-rbuilder` origin of the "simulation" terminology.

## Validation

- `cargo check -p base-builder-core --features metrics`
- `cargo fmt -p base-builder-core --check`

Note: both validation commands pass. `cargo check` still reports the pre-existing unused `B256` warning, and `cargo fmt --check` still prints existing stable-rustfmt warnings for unstable config keys.



