### PR TITLE
fix(ci): Upgrade setup-just to v4

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -106,7 +106,7 @@ runs:
         cache-targets: "false"
 
     - name: Install just
-      uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3
+      uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4
 
     - name: Install cargo tools
       if: inputs.tools != ''

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -107,6 +107,8 @@ runs:
 
     - name: Install just
       uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4
+      with:
+        just-version: "1.43.1"
 
     - name: Install cargo tools
       if: inputs.tools != ''

--- a/.github/workflows/zepter.yml
+++ b/.github/workflows/zepter.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 1
-      - uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3
+      - uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4
       - uses: taiki-e/install-action@3575e532701a5fc614b0c842e4119af4cc5fd16d # v2.62.60
         with:
           tool: zepter

--- a/.github/workflows/zepter.yml
+++ b/.github/workflows/zepter.yml
@@ -24,6 +24,8 @@ jobs:
         with:
           fetch-depth: 1
       - uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4
+        with:
+          just-version: "1.43.1"
       - uses: taiki-e/install-action@3575e532701a5fc614b0c842e4119af4cc5fd16d # v2.62.60
         with:
           tool: zepter


### PR DESCRIPTION
## Summary

The `extractions/setup-just` action was pinned to v3, which has a bug in its `setup-crate` dependency that causes it to fail finding `just` releases with the error \"no release for just matching version specifier\". This was causing `zepter`, `no_std`, `no_std (proof)`, `Action Tests`, and several `ci` jobs to fail. v4, released April 5, upgrades `setup-crate` to Node 24 and fixes the release lookup. Both places using the action — `zepter.yml` and the shared `setup` composite action — are updated.