### PR TITLE
fix(proof): bind rollup config chain id

### DIFF
--- a/crates/proof/proof/src/boot.rs
+++ b/crates/proof/proof/src/boot.rs
@@ -245,8 +245,8 @@ impl BootInfo {
         } else {
             warn!(
                 target: "boot_loader",
-                "No rollup config found for chain ID {}, falling back to preimage oracle. This is insecure in production without additional validation!",
-                chain_id
+                chain_id,
+                "no rollup config found in built-in registry, falling back to preimage oracle"
             );
             let ser_cfg = oracle
                 .get(PreimageKey::new_local(L2_ROLLUP_CONFIG_KEY.to()))
@@ -254,6 +254,14 @@ impl BootInfo {
                 .map_err(OracleProviderError::Preimage)?;
             serde_json::from_slice(&ser_cfg).map_err(OracleProviderError::Serde)?
         };
+
+        let rollup_config_chain_id = rollup_config.l2_chain_id.id();
+        if chain_id != rollup_config_chain_id {
+            return Err(OracleProviderError::RollupConfigChainIdMismatch {
+                boot_chain_id: chain_id,
+                rollup_config_chain_id,
+            });
+        }
 
         // Attempt to load the rollup config from the chain ID. If there is no config for the chain,
         // fall back to loading the config from the preimage oracle.
@@ -344,5 +352,80 @@ impl BootInfo {
             intermediate_block_interval,
             l1_head_number,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::{boxed::Box, vec::Vec};
+
+    use alloy_primitives::B256;
+    use async_trait::async_trait;
+    use base_common_chains::Registry;
+    use base_proof_preimage::{
+        PreimageKey, PreimageOracleClient,
+        errors::{PreimageOracleError, PreimageOracleResult},
+    };
+
+    use super::*;
+
+    struct MockOracle {
+        data: Vec<(PreimageKey, Vec<u8>)>,
+    }
+
+    impl MockOracle {
+        fn new() -> Self {
+            Self { data: Vec::new() }
+        }
+
+        fn insert(&mut self, key: U256, value: Vec<u8>) {
+            self.data.push((PreimageKey::new_local(key.to()), value));
+        }
+    }
+
+    #[async_trait]
+    impl PreimageOracleClient for MockOracle {
+        async fn get(&self, key: PreimageKey) -> PreimageOracleResult<Vec<u8>> {
+            self.data
+                .iter()
+                .find_map(|(entry_key, value)| (*entry_key == key).then(|| value.clone()))
+                .ok_or(PreimageOracleError::KeyNotFound)
+        }
+
+        async fn get_exact(&self, key: PreimageKey, buf: &mut [u8]) -> PreimageOracleResult<()> {
+            let value = self.get(key).await?;
+            if value.len() != buf.len() {
+                return Err(PreimageOracleError::BufferLengthMismatch(buf.len(), value.len()));
+            }
+
+            buf.copy_from_slice(&value);
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn rejects_oracle_rollup_config_with_mismatched_chain_id() {
+        let rollup_config =
+            Registry::rollup_config(84532).expect("Base Sepolia config should exist").clone();
+
+        let mut oracle = MockOracle::new();
+        oracle.insert(L1_HEAD_KEY, B256::repeat_byte(0x11).to_vec());
+        oracle.insert(L2_OUTPUT_ROOT_KEY, B256::repeat_byte(0x22).to_vec());
+        oracle.insert(L2_CLAIM_KEY, B256::repeat_byte(0x33).to_vec());
+        oracle.insert(L2_CLAIM_BLOCK_NUMBER_KEY, 40_308_263u64.to_be_bytes().to_vec());
+        oracle.insert(L2_CHAIN_ID_KEY, 999_999_999u64.to_be_bytes().to_vec());
+        oracle.insert(
+            L2_ROLLUP_CONFIG_KEY,
+            serde_json::to_vec(&rollup_config).expect("rollup config should serialize"),
+        );
+
+        let err = BootInfo::load(&oracle).await.expect_err("boot info should reject mismatch");
+        assert!(matches!(
+            err,
+            OracleProviderError::RollupConfigChainIdMismatch {
+                boot_chain_id: 999_999_999,
+                rollup_config_chain_id: 84532,
+            }
+        ));
     }
 }

--- a/crates/proof/proof/src/boot.rs
+++ b/crates/proof/proof/src/boot.rs
@@ -245,8 +245,8 @@ impl BootInfo {
         } else {
             warn!(
                 target: "boot_loader",
+                "No rollup config found for chain ID {}, falling back to preimage oracle. This is insecure in production without additional validation!",
                 chain_id,
-                "no rollup config found in built-in registry, falling back to preimage oracle"
             );
             let ser_cfg = oracle
                 .get(PreimageKey::new_local(L2_ROLLUP_CONFIG_KEY.to()))
@@ -255,6 +255,8 @@ impl BootInfo {
             serde_json::from_slice(&ser_cfg).map_err(OracleProviderError::Serde)?
         };
 
+        // Registry configs should already match, but oracle-provided configs must be bound to the
+        // committed boot chain ID before any config-derived chain parameters are trusted.
         let rollup_config_chain_id = rollup_config.l2_chain_id.id();
         if chain_id != rollup_config_chain_id {
             return Err(OracleProviderError::RollupConfigChainIdMismatch {
@@ -427,5 +429,32 @@ mod tests {
                 rollup_config_chain_id: 84532,
             }
         ));
+    }
+
+    #[tokio::test]
+    async fn accepts_oracle_rollup_config_with_matching_chain_id() {
+        const ORACLE_CHAIN_ID: u64 = 999_999_999;
+
+        let rollup_config =
+            Registry::rollup_config(84532).expect("Base Sepolia config should exist").clone();
+        let mut rollup_config_value =
+            serde_json::to_value(&rollup_config).expect("rollup config should convert to value");
+        rollup_config_value["l2_chain_id"] = serde_json::json!(ORACLE_CHAIN_ID);
+
+        let mut oracle = MockOracle::new();
+        oracle.insert(L1_HEAD_KEY, B256::repeat_byte(0x11).to_vec());
+        oracle.insert(L2_OUTPUT_ROOT_KEY, B256::repeat_byte(0x22).to_vec());
+        oracle.insert(L2_CLAIM_KEY, B256::repeat_byte(0x33).to_vec());
+        oracle.insert(L2_CLAIM_BLOCK_NUMBER_KEY, 40_308_263u64.to_be_bytes().to_vec());
+        oracle.insert(L2_CHAIN_ID_KEY, ORACLE_CHAIN_ID.to_be_bytes().to_vec());
+        oracle.insert(
+            L2_ROLLUP_CONFIG_KEY,
+            serde_json::to_vec(&rollup_config_value).expect("rollup config should serialize"),
+        );
+
+        let boot_info = BootInfo::load(&oracle).await.expect("boot info should load");
+
+        assert_eq!(boot_info.chain_id, ORACLE_CHAIN_ID);
+        assert_eq!(boot_info.rollup_config.l2_chain_id.id(), ORACLE_CHAIN_ID);
     }
 }

--- a/crates/proof/proof/src/boot.rs
+++ b/crates/proof/proof/src/boot.rs
@@ -246,7 +246,7 @@ impl BootInfo {
             warn!(
                 target: "boot_loader",
                 "No rollup config found for chain ID {}, falling back to preimage oracle. This is insecure in production without additional validation!",
-                chain_id,
+                chain_id
             );
             let ser_cfg = oracle
                 .get(PreimageKey::new_local(L2_ROLLUP_CONFIG_KEY.to()))

--- a/crates/proof/proof/src/errors.rs
+++ b/crates/proof/proof/src/errors.rs
@@ -110,6 +110,19 @@ pub enum OracleProviderError {
     /// * `0` - The unknown chain ID that was encountered
     #[error("Unknown chain ID: {0}")]
     UnknownChainId(u64),
+    /// Rollup config L2 chain ID does not match the boot chain ID.
+    ///
+    /// This error occurs when an oracle-provided rollup config claims to be for
+    /// a different L2 chain than the local chain ID used to select it.
+    #[error(
+        "Rollup config chain ID mismatch: boot chain ID {boot_chain_id}, rollup config L2 chain ID {rollup_config_chain_id}"
+    )]
+    RollupConfigChainIdMismatch {
+        /// The chain ID loaded from local boot input.
+        boot_chain_id: u64,
+        /// The L2 chain ID claimed by the loaded rollup config.
+        rollup_config_chain_id: u64,
+    },
     /// Blob KZG commitment verification failed.
     ///
     /// This error occurs when the KZG commitment computed from a reconstructed


### PR DESCRIPTION
## Summary
- Reject boot inputs where the local L2 chain ID differs from the loaded rollup config's L2 chain ID.
- Add a regression test for the oracle fallback mismatch used in the audit report.
- Keep the public config hash and Solidity verifier constants unchanged because registry chains now cannot substitute oracle configs for another chain.

## Testing
- cargo test -p base-proof rejects_oracle_rollup_config_with_mismatched_chain_id
- cargo test -p base-proof
- cargo fmt --check (passes with existing stable-rustfmt warnings about ignored unstable options)