### PR TITLE
perf(flashblocks): share BundleState via Arc to reduce clone overhead

### DIFF
--- a/crates/execution/flashblocks/src/pending_blocks.rs
+++ b/crates/execution/flashblocks/src/pending_blocks.rs
@@ -1,4 +1,4 @@
-use std::{sync::Arc, time::Instant};
+use std::sync::Arc;
 
 use alloy_consensus::{Header, Sealed, TxReceipt};
 use alloy_eips::BlockNumberOrTag;
@@ -26,9 +26,7 @@ use revm::{
     state::{AccountInfo, EvmState},
 };
 
-use crate::{
-    BuildError, PendingBlocksAPI, StateProcessorError, TransactionWithLogs, metrics::Metrics,
-};
+use crate::{BuildError, PendingBlocksAPI, StateProcessorError, TransactionWithLogs};
 
 /// Builder for [`PendingBlocks`].
 #[derive(Debug)]
@@ -50,7 +48,7 @@ pub struct PendingBlocksBuilder {
     execution_times: HashMap<B256, u128>,
     state_root_times: HashMap<B256, u128>,
 
-    bundle_state: BundleState,
+    bundle_state: Option<Arc<BundleState>>,
 
     // Deferred error from `with_transaction` (e.g. duplicate hash). Surfaced from `build()`.
     deferred_error: Option<BuildError>,
@@ -81,7 +79,7 @@ impl PendingBlocksBuilder {
             execution_times: HashMap::new(),
             state_root_times: HashMap::new(),
             state_overrides: None,
-            bundle_state: BundleState::default(),
+            bundle_state: None,
             deferred_error: None,
         }
     }
@@ -170,7 +168,7 @@ impl PendingBlocksBuilder {
     /// Sets the accumulated bundle state.
     #[inline]
     pub fn with_bundle_state(&mut self, bundle_state: BundleState) -> &Self {
-        self.bundle_state = bundle_state;
+        self.bundle_state = Some(Arc::new(bundle_state));
         self
     }
 
@@ -231,7 +229,7 @@ impl PendingBlocksBuilder {
             transaction_state: self.transaction_state,
             transaction_senders: self.transaction_senders,
             state_overrides: self.state_overrides,
-            bundle_state: self.bundle_state,
+            bundle_state: self.bundle_state.unwrap_or_default(),
             transaction_results: self.transaction_results,
             execution_times: self.execution_times,
             state_root_times: self.state_root_times,
@@ -260,7 +258,7 @@ pub struct PendingBlocks {
     execution_times: HashMap<B256, u128>,
     state_root_times: HashMap<B256, u128>,
 
-    bundle_state: BundleState,
+    bundle_state: Arc<BundleState>,
 }
 
 impl PendingBlocks {
@@ -342,19 +340,9 @@ impl PendingBlocks {
         self.transaction_senders.get(tx_hash).copied()
     }
 
-    /// Returns a clone of the bundle state.
-    ///
-    /// NOTE: This clones the entire `BundleState`, which contains a `HashMap` of all touched
-    /// accounts and their storage slots. The cost scales with the number of accounts and
-    /// storage slots modified in the flashblock. Monitor `bundle_state_clone_duration` and
-    /// `bundle_state_clone_size` metrics to track if this becomes a bottleneck.
-    pub fn get_bundle_state(&self) -> BundleState {
-        let size = self.bundle_state.state.len();
-        let start = Instant::now();
-        let cloned = self.bundle_state.clone();
-        Metrics::bundle_state_clone_duration().record(start.elapsed());
-        Metrics::bundle_state_clone_size().record(size as f64);
-        cloned
+    /// Returns a shared reference to the bundle state.
+    pub fn get_bundle_state(&self) -> Arc<BundleState> {
+        Arc::clone(&self.bundle_state)
     }
 
     /// Returns all transactions for a specific block number.

--- a/crates/execution/flashblocks/src/processor.rs
+++ b/crates/execution/flashblocks/src/processor.rs
@@ -36,7 +36,7 @@ use crate::{
 
 /// Messages consumed by the state processor.
 #[allow(clippy::large_enum_variant)]
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub enum StateUpdate {
     /// New canonical block to reconcile against pending state.
     Canonical(RecoveredBlock<BaseBlock>),
@@ -45,7 +45,7 @@ pub enum StateUpdate {
 }
 
 /// Processes flashblocks and canonical blocks to keep pending state updated.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct StateProcessor<Client> {
     rx: Arc<Mutex<UnboundedReceiver<StateUpdate>>>,
     pending_blocks: Arc<ArcSwapOption<PendingBlocks>>,
@@ -376,11 +376,18 @@ where
         // Track state changes across flashblocks, accumulating bundle state
         // from previous pending blocks if available.
         let mut db = match &prev_pending_blocks {
-            Some(pending_blocks) => State::builder()
-                .with_database(state_provider_db)
-                .with_bundle_update()
-                .with_bundle_prestate(pending_blocks.get_bundle_state())
-                .build(),
+            Some(pending_blocks) => {
+                let arc_state = pending_blocks.get_bundle_state();
+                let start = Instant::now();
+                let bundle_state = Arc::unwrap_or_clone(arc_state);
+                Metrics::bundle_state_clone_duration().record(start.elapsed());
+                Metrics::bundle_state_clone_size().record(bundle_state.state.len() as f64);
+                State::builder()
+                    .with_database(state_provider_db)
+                    .with_bundle_update()
+                    .with_bundle_prestate(bundle_state)
+                    .build()
+            }
             None => State::builder().with_database(state_provider_db).with_bundle_update().build(),
         };
 

--- a/crates/execution/metering/src/meter.rs
+++ b/crates/execution/metering/src/meter.rs
@@ -80,7 +80,7 @@ pub struct PendingTrieInput {
 #[derive(Debug, Clone)]
 pub struct PendingState {
     /// The accumulated bundle of state changes from pending flashblocks.
-    pub bundle_state: BundleState,
+    pub bundle_state: Arc<BundleState>,
     /// Optional pre-computed trie input for faster state root calculation.
     /// If provided, state root calculation skips recomputing the pending state's trie.
     pub trie_input: Option<PendingTrieInput>,
@@ -1338,7 +1338,7 @@ mod tests {
             Vec::<Vec<(Address, Option<Option<AccountInfo>>, Vec<(U256, U256)>)>>::new(),
             Vec::<(B256, Bytecode)>::new(),
         );
-        let pending_state = PendingState { bundle_state, trie_input: None };
+        let pending_state = PendingState { bundle_state: Arc::new(bundle_state), trie_input: None };
 
         // Transaction with nonce=0 — "too low" relative to pending nonce of 5
         let to = Address::random();
@@ -1646,7 +1646,8 @@ mod tests {
         let trie_input = compute_pending_trie_input(&state_provider, hashed)?;
         drop(state_provider);
 
-        let pending_state = PendingState { bundle_state, trie_input: Some(trie_input) };
+        let pending_state =
+            PendingState { bundle_state: Arc::new(bundle_state), trie_input: Some(trie_input) };
 
         // Create a bundle tx: Alice (nonce=1 from pending) sends to a random address
         let to = Address::random();


### PR DESCRIPTION
Share the pending `BundleState` through `Arc` so read-only consumers (RPC, metering) get a cheap pointer clone instead of deep-copying the entire accounts/storage map on every access.
