### PR TITLE
fix(zk): remove unsafe env mutation, harden db config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5478,6 +5478,7 @@ dependencies = [
  "tonic-web",
  "tower-http",
  "tracing",
+ "url",
 ]
 
 [[package]]

--- a/bin/prover/zk/Cargo.toml
+++ b/bin/prover/zk/Cargo.toml
@@ -48,5 +48,8 @@ tonic-reflection.workspace = true
 http.workspace = true
 tower-http = { workspace = true, features = ["cors"] }
 
+# URL parsing
+url.workspace = true
+
 # Tracing
 tracing.workspace = true

--- a/bin/prover/zk/src/cli.rs
+++ b/bin/prover/zk/src/cli.rs
@@ -3,6 +3,7 @@
 use std::sync::Arc;
 
 use base_cli_utils::{LogConfig, RuntimeManager};
+use base_proof_succinct_host_utils::fetcher::RPCConfig;
 use base_zk_client::prover_service_server::ProverServiceServer as ProtoProverServiceServer;
 use base_zk_db::{DatabaseConfig, ProofRequestRepo};
 use base_zk_outbox::{DatabaseOutboxReader, OutboxProcessor};
@@ -18,6 +19,7 @@ use http::header;
 use tonic::transport::Server;
 use tower_http::cors::{AllowHeaders, AllowMethods, AllowOrigin, CorsLayer};
 use tracing::info;
+use url::Url;
 
 base_cli_utils::define_log_args!("BASE_PROVER_ZK");
 base_cli_utils::define_metrics_args!("BASE_PROVER_ZK", 7301);
@@ -186,23 +188,15 @@ impl ZkArgs {
 
         info!(l1_url = %l1_url, l2_url = %l2_url, beacon_url = %beacon_url, "using RPC URLs");
 
-        // Set OP-Succinct environment variables required by the data fetcher.
-        // SAFETY: called before spawning any threads; the tokio runtime is
-        // single-threaded at this point so no concurrent reads can race.
-        unsafe {
-            std::env::set_var("L1_RPC", &l1_url);
-            std::env::set_var("L1_BEACON_RPC", &beacon_url);
-            std::env::set_var("L2_RPC", &l2_url);
-            std::env::set_var("L2_NODE_RPC", &self.base_consensus_address);
-        }
-
-        info!(
-            l1_rpc = %l1_url,
-            l1_beacon_rpc = %beacon_url,
-            l2_rpc = %l2_url,
-            l2_node_rpc = %self.base_consensus_address,
-            "set OP-Succinct RPC environment variables"
-        );
+        let rpc_config = RPCConfig {
+            l1_rpc: Url::parse(&l1_url).map_err(|e| eyre!("invalid L1 RPC URL: {e}"))?,
+            l1_beacon_rpc: Some(
+                Url::parse(&beacon_url).map_err(|e| eyre!("invalid beacon RPC URL: {e}"))?,
+            ),
+            l2_rpc: Url::parse(&l2_url).map_err(|e| eyre!("invalid L2 RPC URL: {e}"))?,
+            l2_node_rpc: Url::parse(&self.base_consensus_address)
+                .map_err(|e| eyre!("invalid L2 node RPC URL: {e}"))?,
+        };
 
         info!("computing range and aggregation verifying keys");
         let (range_pk, range_vk, agg_pk, agg_vk) =
@@ -221,7 +215,7 @@ impl ZkArgs {
             info!("SP1_PROVER=network: using OP-Succinct SP1 Network backend");
 
             let fetcher = Arc::new(
-                base_proof_succinct_host_utils::fetcher::OPSuccinctDataFetcher::new_with_rollup_config()
+                base_proof_succinct_host_utils::fetcher::OPSuccinctDataFetcher::from_rpc_config_with_rollup_config(rpc_config)
                     .await
                     .map_err(|e| eyre!("failed to create OPSuccinctDataFetcher: {e}"))?,
             );
@@ -279,10 +273,9 @@ impl ZkArgs {
         } else {
             info!("SP1_PROVER=cluster: using OP-Succinct cluster backend");
 
-            // Create OP-Succinct data fetcher and provider.
             info!("creating OP-Succinct data fetcher");
             let fetcher = Arc::new(
-                base_proof_succinct_host_utils::fetcher::OPSuccinctDataFetcher::new_with_rollup_config()
+                base_proof_succinct_host_utils::fetcher::OPSuccinctDataFetcher::from_rpc_config_with_rollup_config(rpc_config)
                     .await
                     .map_err(|e| eyre!("failed to create OPSuccinctDataFetcher: {e}"))?,
             );

--- a/crates/proof/succinct/utils/host/src/fetcher.rs
+++ b/crates/proof/succinct/utils/host/src/fetcher.rs
@@ -169,10 +169,17 @@ impl OPSuccinctDataFetcher {
         }
     }
 
-    /// Initialize the fetcher with a rollup config.
+    /// Initialize the fetcher with a rollup config, reading RPC URLs from environment variables.
     pub async fn new_with_rollup_config() -> Result<Self> {
         let rpc_config = get_rpcs_from_env();
+        Self::from_rpc_config_with_rollup_config(rpc_config).await
+    }
 
+    /// Initialize the fetcher with an explicit [`RPCConfig`] and a rollup config.
+    ///
+    /// Prefer this over [`new_with_rollup_config`](Self::new_with_rollup_config) when the RPC
+    /// URLs are already known, avoiding reliance on environment variables.
+    pub async fn from_rpc_config_with_rollup_config(rpc_config: RPCConfig) -> Result<Self> {
         let l1_provider =
             Arc::new(ProviderBuilder::default().connect_http(rpc_config.l1_rpc.clone()));
         let l2_provider =

--- a/crates/proof/zk/db/src/config.rs
+++ b/crates/proof/zk/db/src/config.rs
@@ -1,11 +1,11 @@
-use std::time::Duration;
+use std::{fmt, time::Duration};
 
 use anyhow::{Context, Result};
 use sqlx::{PgPool, postgres::PgPoolOptions};
 use tracing::info;
 
 /// Database configuration.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct DatabaseConfig {
     /// Connection URL.
     pub url: String,
@@ -13,6 +13,16 @@ pub struct DatabaseConfig {
     pub max_connections: u32,
     /// Timeout for acquiring a connection.
     pub connection_timeout: Duration,
+}
+
+impl fmt::Debug for DatabaseConfig {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("DatabaseConfig")
+            .field("url", &mask_password(&self.url))
+            .field("max_connections", &self.max_connections)
+            .field("connection_timeout", &self.connection_timeout)
+            .finish()
+    }
 }
 
 impl DatabaseConfig {


### PR DESCRIPTION
## Summary
- Pass `RPCConfig` directly to `OPSuccinctDataFetcher` instead of using unsafe `env::set_var` in an async context
- Replace derived `Debug` on `DatabaseConfig` with manual impl that masks the password field