### PR TITLE
fix(ci): exclude cantina.xyz/code from lychee link checks

### DIFF
--- a/lychee.toml
+++ b/lychee.toml
@@ -20,6 +20,9 @@ exclude = [
     'https://img.shields.io/github/commit-activity/w/base/base',
     'https://img.shields.io/github/issues-pr-raw/base/base',
 
+    # Cantina code/overview pages redirect (302) through an auth gate
+    'https://cantina\.xyz/code/',
+
     # Sites that block automated HTTP clients / scrapers
     'https://.*etherscan\.io',         # Block explorer; returns 403/429 for bots
     'https://medium\.com',             # Medium blocks crawlers


### PR DESCRIPTION
## Summary

Cantina code/overview pages return 302 redirects through an auth gate, causing lychee to reject the links in `SECURITY.md` (added in #2424).

Adds `cantina.xyz/code/` to the lychee exclude list. The `cantina.xyz/bounties/` URL is not affected (returns 200).