### PR TITLE
test(actions): Conductor, Signing, Fault Injection Tests

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -14,6 +14,12 @@ max-threads = 6
 junit = { path = "test-results.xml" }
 retries = 1
 
+# Action tests use a full EVM stack; the slowest tests can take 30-45 s.
+# Flag anything that runs longer than 90 s as slow and kill it after 2 periods.
+[[profile.ci.overrides]]
+filter = 'package(base-action-harness)'
+slow-timeout = { period = "90s", terminate-after = 2 }
+
 [[profile.default.overrides]]
 filter = 'test(system_test_)'
 test-group = 'system-test-serial'

--- a/.github/workflows/action-tests.yml
+++ b/.github/workflows/action-tests.yml
@@ -19,7 +19,8 @@ permissions:
 jobs:
   action-tests:
     name: Action Tests
-    runs-on: ubuntu-latest
+    runs-on:
+      group: BasePerfRunnerGroup
     timeout-minutes: 30
     steps:
       - name: Harden the runner (Audit all outbound calls)
@@ -35,9 +36,12 @@ jobs:
           native-deps: "true"
           mold: "true"
           foundry: "true"
+          components: clippy
           tools: cargo-nextest
           rust-cache-shared-key: "stable"
       - name: Build test contracts
         run: just build::contracts
+      - name: Lint action tests
+        run: just actions::lint-ci
       - name: Run action tests
-        run: just actions::test
+        run: just actions::test-ci

--- a/actions/Justfile
+++ b/actions/Justfile
@@ -10,6 +10,10 @@ default:
 test:
     cargo nextest run -p base-action-harness
 
+# Run all action tests with the CI profile
+test-ci:
+    cargo nextest run -P ci --locked -p base-action-harness --cargo-profile ci
+
 # Run action tests with output shown (useful when debugging a failing test)
 test-verbose:
     cargo nextest run -p base-action-harness --no-capture
@@ -21,3 +25,7 @@ check:
 # Clippy the action harness crate
 lint:
     cargo clippy -p base-action-harness --all-targets -- -D warnings
+
+# Clippy the action harness crate with the CI profile
+lint-ci:
+    cargo clippy --locked -p base-action-harness --all-targets --profile ci -- -D warnings

--- a/actions/harness/Cargo.toml
+++ b/actions/harness/Cargo.toml
@@ -40,7 +40,7 @@ alloy-rpc-types-engine = { workspace = true, features = ["std"] }
 # base-common
 base-common-network.workspace = true
 base-common-rpc-types.workspace = true
-base-common-rpc-types-engine.workspace = true
+base-common-rpc-types-engine = { workspace = true, features = ["std"] }
 base-common-consensus = { workspace = true, features = ["std", "evm"] }
 
 # base

--- a/actions/harness/src/batcher/actor.rs
+++ b/actions/harness/src/batcher/actor.rs
@@ -224,6 +224,41 @@ impl<S: L2BlockProvider> Batcher<S> {
         self.tx_manager.stage_n_to_l1(l1, n)
     }
 
+    /// Schedule the next `n` frame submissions to fail immediately.
+    ///
+    /// Each of the next `n` calls the background [`BatchDriver`] makes to
+    /// [`TxManager::send_async`] will resolve with
+    /// [`TxManagerError::Rpc`] instead of queuing to the L1 miner. The driver
+    /// requeues the frame and retries, so calling this before [`encode_only`]
+    /// simulates transient L1 submission failures without losing data.
+    ///
+    /// Use [`wait_until_requeued`] after [`encode_only`] to wait for the driver
+    /// to process the failures and return frames to the pending queue.
+    ///
+    /// [`TxManager::send_async`]: base_tx_manager::TxManager::send_async
+    /// [`TxManagerError::Rpc`]: base_tx_manager::TxManagerError::Rpc
+    /// [`encode_only`]: Batcher::encode_only
+    /// [`wait_until_requeued`]: Batcher::wait_until_requeued
+    pub fn fail_next_n_submissions(&self, n: usize) {
+        self.tx_manager.fail_next_n(n);
+    }
+
+    /// Mine all pending frame submissions in one L1 block.
+    ///
+    /// Stages every pending frame, mines one L1 block, fires all receipt
+    /// oneshots, and yields once so the driver processes confirmations.
+    /// Returns the mined block number.
+    ///
+    /// Use this after [`wait_until_requeued`] to confirm a requeued batch
+    /// without needing to encode new L2 blocks.
+    ///
+    /// [`wait_until_requeued`]: Batcher::wait_until_requeued
+    pub async fn mine_pending(&self, l1: &mut L1Miner) -> u64 {
+        let block_number = self.tx_manager.mine_block(l1);
+        tokio::task::yield_now().await;
+        block_number
+    }
+
     /// Drop the first `n` pending frame submissions without staging them to L1.
     ///
     /// Returns the actual number dropped. Use this to skip specific frame

--- a/actions/harness/src/batcher/tx_manager.rs
+++ b/actions/harness/src/batcher/tx_manager.rs
@@ -280,7 +280,8 @@ impl TxManager for L1MinerTxManager {
             if inner.fail_remaining > 0 {
                 inner.fail_remaining -= 1;
                 let (tx, rx) = oneshot::channel::<SendResponse>();
-                let _ = tx.send(Err(TxManagerError::Rpc("simulated submission failure".to_string())));
+                let _ =
+                    tx.send(Err(TxManagerError::Rpc("simulated submission failure".to_string())));
                 return SendHandle::new(rx);
             }
         }

--- a/actions/harness/src/batcher/tx_manager.rs
+++ b/actions/harness/src/batcher/tx_manager.rs
@@ -37,6 +37,9 @@ impl std::fmt::Debug for Pending {
 pub struct Inner {
     pending: Vec<Pending>,
     staged: Vec<Pending>,
+    /// Number of upcoming `send_async` calls to immediately fail with
+    /// [`TxManagerError::Rpc`] before falling through to normal queuing.
+    fail_remaining: usize,
 }
 
 /// Adapts [`L1Miner`] to the [`TxManager`] trait for action tests.
@@ -102,6 +105,20 @@ impl L1MinerTxManager {
     /// Returns the number of pending (not yet staged) submissions.
     pub fn pending_count(&self) -> usize {
         self.inner.lock().unwrap().pending.len()
+    }
+
+    /// Schedule the next `n` [`send_async`] calls to immediately resolve with
+    /// [`TxManagerError::Rpc`], causing the [`BatchDriver`] to requeue the
+    /// associated frames in the encoder pipeline.
+    ///
+    /// Failures are consumed one-per-call: setting `n = 3` means the next
+    /// three separate `send_async` calls each fail, regardless of whether they
+    /// carry the same or different frames.
+    ///
+    /// [`send_async`]: L1MinerTxManager::send_async
+    /// [`BatchDriver`]: base_batcher_core::BatchDriver
+    pub fn fail_next_n(&self, n: usize) {
+        self.inner.lock().unwrap().fail_remaining += n;
     }
 
     /// Drop the first `n` pending submissions without staging them to L1.
@@ -258,6 +275,16 @@ impl TxManager for L1MinerTxManager {
     }
 
     async fn send_async(&self, candidate: TxCandidate) -> SendHandle {
+        {
+            let mut inner = self.inner.lock().unwrap();
+            if inner.fail_remaining > 0 {
+                inner.fail_remaining -= 1;
+                let (tx, rx) = oneshot::channel::<SendResponse>();
+                let _ = tx.send(Err(TxManagerError::Rpc("simulated submission failure".to_string())));
+                return SendHandle::new(rx);
+            }
+        }
+
         let (responder, rx) = oneshot::channel::<SendResponse>();
         let pending = if candidate.blobs.is_empty() {
             Pending {

--- a/actions/harness/src/conductor.rs
+++ b/actions/harness/src/conductor.rs
@@ -1,0 +1,147 @@
+//! Controllable conductor for action tests.
+//!
+//! Provides [`TestConductor`] and [`TestConductorHandle`] for testing sequencer
+//! behavior under conductor-gated leadership. Multiple sequencers can share a
+//! single [`TestConductorHandle`] to coordinate leadership transitions.
+
+use std::sync::{Arc, Mutex};
+
+use alloy_primitives::B256;
+use async_trait::async_trait;
+use base_common_rpc_types_engine::BaseExecutionPayloadEnvelope;
+use base_consensus_node::{Conductor, ConductorError};
+
+/// Shared mutable state backing a [`TestConductorHandle`].
+#[derive(Debug)]
+pub struct ConductorState {
+    leader_id: Option<u8>,
+    committed_payloads: Vec<(u8, B256)>,
+}
+
+impl ConductorState {
+    fn new(leader_id: Option<u8>) -> Self {
+        Self { leader_id, committed_payloads: Vec::new() }
+    }
+}
+
+/// Shared handle to a simulated conductor for use in action tests.
+///
+/// Clone the handle to share leadership state between multiple [`TestConductor`]
+/// instances. Use [`conductor`] to mint a per-sequencer [`TestConductor`] that
+/// is identified by a sequencer ID.
+///
+/// [`conductor`]: TestConductorHandle::conductor
+#[derive(Debug, Clone)]
+pub struct TestConductorHandle(Arc<Mutex<ConductorState>>);
+
+impl TestConductorHandle {
+    /// Create a handle with the given initial leader.
+    ///
+    /// Pass `Some(id)` to make sequencer `id` the initial leader.
+    /// Pass `None` to start with no leader.
+    pub fn new(leader_id: Option<u8>) -> Self {
+        Self(Arc::new(Mutex::new(ConductorState::new(leader_id))))
+    }
+
+    /// Convenience constructor: sequencer `0` is the initial leader.
+    pub fn with_leader_zero() -> Self {
+        Self::new(Some(0))
+    }
+
+    /// Transfer leadership to the given sequencer id.
+    pub fn set_leader(&self, id: u8) {
+        self.0.lock().expect("conductor state lock poisoned").leader_id = Some(id);
+    }
+
+    /// Clear leadership (no sequencer is the leader).
+    pub fn clear_leader(&self) {
+        self.0.lock().expect("conductor state lock poisoned").leader_id = None;
+    }
+
+    /// Return the total number of payloads committed across all sequencers.
+    pub fn committed_count(&self) -> usize {
+        self.0.lock().expect("conductor state lock poisoned").committed_payloads.len()
+    }
+
+    /// Return a snapshot of all committed payloads as `(sequencer_id, block_hash)` pairs.
+    pub fn committed_payloads(&self) -> Vec<(u8, B256)> {
+        self.0.lock().expect("conductor state lock poisoned").committed_payloads.clone()
+    }
+
+    /// Return the committed payloads for a specific sequencer id.
+    pub fn committed_by(&self, id: u8) -> Vec<B256> {
+        self.0
+            .lock()
+            .expect("conductor state lock poisoned")
+            .committed_payloads
+            .iter()
+            .filter(|(s, _)| *s == id)
+            .map(|(_, h)| *h)
+            .collect()
+    }
+
+    /// Mint a [`TestConductor`] identified by `id`.
+    ///
+    /// The conductor shares this handle's state. Pass it to
+    /// [`L2Sequencer::set_conductor`] to gate block building on leadership.
+    ///
+    /// [`L2Sequencer::set_conductor`]: crate::L2Sequencer::set_conductor
+    pub fn conductor(&self, id: u8) -> TestConductor {
+        TestConductor { handle: self.clone(), id }
+    }
+}
+
+impl Default for TestConductorHandle {
+    fn default() -> Self {
+        Self::new(Some(0))
+    }
+}
+
+/// Per-sequencer [`Conductor`] implementation backed by a shared [`TestConductorHandle`].
+///
+/// Mint one per sequencer via [`TestConductorHandle::conductor`]. Each
+/// `TestConductor` has an `id` that identifies which sequencer it represents.
+/// Leadership is determined by comparing `id` against the handle's current
+/// `leader_id`.
+#[derive(Debug, Clone)]
+pub struct TestConductor {
+    handle: TestConductorHandle,
+    id: u8,
+}
+
+impl TestConductor {
+    /// Return the sequencer id this conductor represents.
+    pub const fn id(&self) -> u8 {
+        self.id
+    }
+}
+
+#[async_trait]
+impl Conductor for TestConductor {
+    async fn leader(&self) -> Result<bool, ConductorError> {
+        let state = self.handle.0.lock().expect("conductor state lock poisoned");
+        Ok(state.leader_id == Some(self.id))
+    }
+
+    async fn active(&self) -> Result<bool, ConductorError> {
+        Ok(true)
+    }
+
+    async fn commit_unsafe_payload(
+        &self,
+        payload: &BaseExecutionPayloadEnvelope,
+    ) -> Result<(), ConductorError> {
+        let mut state = self.handle.0.lock().expect("conductor state lock poisoned");
+        if state.leader_id != Some(self.id) {
+            return Err(ConductorError::NotLeader);
+        }
+        let block_hash = payload.execution_payload.as_v1().block_hash;
+        state.committed_payloads.push((self.id, block_hash));
+        Ok(())
+    }
+
+    async fn override_leader(&self) -> Result<(), ConductorError> {
+        self.handle.set_leader(self.id);
+        Ok(())
+    }
+}

--- a/actions/harness/src/conductor.rs
+++ b/actions/harness/src/conductor.rs
@@ -19,7 +19,7 @@ pub struct ConductorState {
 }
 
 impl ConductorState {
-    fn new(leader_id: Option<u8>) -> Self {
+    const fn new(leader_id: Option<u8>) -> Self {
         Self { leader_id, committed_payloads: Vec::new() }
     }
 }

--- a/actions/harness/src/harness.rs
+++ b/actions/harness/src/harness.rs
@@ -269,11 +269,12 @@ impl ActionTestHarness {
         key: PrivateKeySigner,
     ) -> TestGossipTransport {
         let address = key.address();
-        sequencer.set_unsafe_block_signer(key);
+        sequencer.set_unsafe_block_signer(key.clone());
         let (p2p, mut transport) = TestGossipTransport::channel();
         sequencer.set_supervised_p2p(p2p);
         transport.set_block_signer(address);
         transport.set_chain_id(self.rollup_config.l2_chain_id.id());
+        transport.set_signing_key(key);
         transport
     }
 

--- a/actions/harness/src/harness.rs
+++ b/actions/harness/src/harness.rs
@@ -2,10 +2,11 @@ use std::{fmt::Debug, sync::Arc};
 
 use alloy_eips::BlockNumHash;
 use alloy_genesis::ChainConfig;
+use alloy_signer_local::PrivateKeySigner;
 use base_common_consensus::{BaseBlock, BaseTxEnvelope};
 use base_common_genesis::RollupConfig;
 use base_consensus_derive::{DataAvailabilityProvider, PipelineBuilder, StatefulAttributesBuilder};
-use base_consensus_node::L1OriginSelector;
+use base_consensus_node::{GossipTransport, L1OriginSelector};
 use base_protocol::{BlockInfo, L1BlockInfoTx, L2BlockInfo};
 
 use crate::{
@@ -248,6 +249,32 @@ impl ActionTestHarness {
         let transport = self.create_supervised_p2p(sequencer);
         let node = self.create_blob_test_rollup_node(sequencer, l1_chain.clone(), transport);
         (node, l1_chain)
+    }
+
+    /// Create a [`SupervisedP2P`] / [`TestGossipTransport`] pair with real
+    /// signature signing and validation enabled.
+    ///
+    /// - Attaches `key` to `sequencer` so that [`L2Sequencer::broadcast_unsafe_block`]
+    ///   signs each gossipped block with the production formula.
+    /// - Configures the returned [`TestGossipTransport`] to validate incoming
+    ///   blocks against the same address, using the rollup config's chain ID.
+    ///
+    /// Use this in place of [`create_supervised_p2p`] when a test needs to
+    /// exercise signature verification.
+    ///
+    /// [`create_supervised_p2p`]: ActionTestHarness::create_supervised_p2p
+    pub fn create_signing_p2p(
+        &self,
+        sequencer: &mut L2Sequencer,
+        key: PrivateKeySigner,
+    ) -> TestGossipTransport {
+        let address = key.address();
+        sequencer.set_unsafe_block_signer(key);
+        let (p2p, mut transport) = TestGossipTransport::channel();
+        sequencer.set_supervised_p2p(p2p);
+        transport.set_block_signer(address);
+        transport.set_chain_id(self.rollup_config.l2_chain_id.id());
+        transport
     }
 
     /// Create an [`L2Sequencer`] starting from L2 genesis, wired to a

--- a/actions/harness/src/l2.rs
+++ b/actions/harness/src/l2.rs
@@ -16,10 +16,10 @@ use base_common_rpc_types_engine::{
     NetworkPayloadEnvelope, PayloadHash,
 };
 use base_consensus_derive::{AttributesBuilder, StatefulAttributesBuilder};
-use base_consensus_node::{L1OriginSelector, OriginSelector, SequencerEngineClient};
+use base_consensus_node::{
+    Conductor, ConductorError, L1OriginSelector, OriginSelector, SequencerEngineClient,
+};
 use base_protocol::{AttributesWithParent, BlockInfo, L2BlockInfo};
-
-use base_consensus_node::{Conductor, ConductorError};
 
 use crate::{
     ActionEngineClient, ActionL1ChainProvider, ActionL2ChainProvider, L2BlockProvider,
@@ -470,15 +470,18 @@ impl L2Sequencer {
             };
             let ph = envelope.payload_hash();
             let msg = ph.signature_message(self.rollup_config.l2_chain_id.id());
-            let sig = signer
-                .sign_hash_sync(&msg)
-                .expect("unsafe block signing must not fail");
+            let sig = signer.sign_hash_sync(&msg).expect("unsafe block signing must not fail");
             (sig, ph)
         } else {
             (Signature::new(U256::ZERO, U256::ZERO, false), PayloadHash(B256::ZERO))
         };
 
-        p2p.send(NetworkPayloadEnvelope { payload: execution_payload, signature, payload_hash, parent_beacon_block_root });
+        p2p.send(NetworkPayloadEnvelope {
+            payload: execution_payload,
+            signature,
+            payload_hash,
+            parent_beacon_block_root,
+        });
     }
 
     /// Build the next L2 block containing no user transactions.

--- a/actions/harness/src/l2.rs
+++ b/actions/harness/src/l2.rs
@@ -463,18 +463,19 @@ impl L2Sequencer {
         let (execution_payload, _) = BaseExecutionPayload::from_block_unchecked(block_hash, block);
         let parent_beacon_block_root = block.header.parent_beacon_block_root;
 
-        let (signature, payload_hash) = if let Some(signer) = &self.unsafe_block_signer {
-            let envelope = BaseExecutionPayloadEnvelope {
-                execution_payload: execution_payload.clone(),
-                parent_beacon_block_root,
-            };
-            let ph = envelope.payload_hash();
-            let msg = ph.signature_message(self.rollup_config.l2_chain_id.id());
-            let sig = signer.sign_hash_sync(&msg).expect("unsafe block signing must not fail");
-            (sig, ph)
-        } else {
-            (Signature::new(U256::ZERO, U256::ZERO, false), PayloadHash(B256::ZERO))
-        };
+        let (signature, payload_hash) = self.unsafe_block_signer.as_ref().map_or_else(
+            || (Signature::new(U256::ZERO, U256::ZERO, false), PayloadHash(B256::ZERO)),
+            |signer| {
+                let envelope = BaseExecutionPayloadEnvelope {
+                    execution_payload: execution_payload.clone(),
+                    parent_beacon_block_root,
+                };
+                let ph = envelope.payload_hash();
+                let msg = ph.signature_message(self.rollup_config.l2_chain_id.id());
+                let sig = signer.sign_hash_sync(&msg).expect("unsafe block signing must not fail");
+                (sig, ph)
+            },
+        );
 
         p2p.send(NetworkPayloadEnvelope {
             payload: execution_payload,

--- a/actions/harness/src/l2.rs
+++ b/actions/harness/src/l2.rs
@@ -590,8 +590,15 @@ impl L2Sequencer {
             .map_err(|e| L2SequencerError::Engine(format!("get_sealed: {e}")))?;
 
         // 5. Conductor commit: register the sealed payload before inserting.
+        // Map ConductorError::NotLeader to L2SequencerError::NotLeader so that
+        // callers get the same variant regardless of whether leadership was lost
+        // before the build started (pre-check) or between the check and commit
+        // (TOCTOU).
         if let Some(conductor) = &self.conductor {
-            conductor.commit_unsafe_payload(&envelope).await?;
+            conductor.commit_unsafe_payload(&envelope).await.map_err(|e| match e {
+                ConductorError::NotLeader => L2SequencerError::NotLeader,
+                other => L2SequencerError::Conductor(other),
+            })?;
         }
 
         // 6. Insert the block into the engine (updates canonical head).

--- a/actions/harness/src/l2.rs
+++ b/actions/harness/src/l2.rs
@@ -12,11 +12,14 @@ use alloy_signer_local::PrivateKeySigner;
 use base_common_consensus::{BaseBlock, BaseTxEnvelope};
 use base_common_genesis::RollupConfig;
 use base_common_rpc_types_engine::{
-    BaseExecutionPayload, BaseExecutionPayloadSidecar, NetworkPayloadEnvelope, PayloadHash,
+    BaseExecutionPayload, BaseExecutionPayloadEnvelope, BaseExecutionPayloadSidecar,
+    NetworkPayloadEnvelope, PayloadHash,
 };
 use base_consensus_derive::{AttributesBuilder, StatefulAttributesBuilder};
 use base_consensus_node::{L1OriginSelector, OriginSelector, SequencerEngineClient};
 use base_protocol::{AttributesWithParent, BlockInfo, L2BlockInfo};
+
+use base_consensus_node::{Conductor, ConductorError};
 
 use crate::{
     ActionEngineClient, ActionL1ChainProvider, ActionL2ChainProvider, L2BlockProvider,
@@ -142,6 +145,12 @@ pub enum L2SequencerError {
     /// Payload conversion error.
     #[error("payload conversion error: {0}")]
     PayloadConversion(String),
+    /// Conductor rejected the block (e.g. not leader, RPC error).
+    #[error("conductor error: {0}")]
+    Conductor(#[from] ConductorError),
+    /// This sequencer is not the conductor leader and cannot build blocks.
+    #[error("sequencer is not the conductor leader")]
+    NotLeader,
 }
 
 /// A pre-built queue of [`BaseBlock`]s for the batcher to drain.
@@ -282,6 +291,15 @@ pub struct L2Sequencer {
     l1_origin_pin: Option<BlockInfo>,
     /// Mutable L2 chain provider (for inserting new blocks/configs after each build).
     l2_provider: ActionL2ChainProvider,
+    /// Optional conductor. When set, each build checks leadership via `leader()` and
+    /// commits the sealed payload via `commit_unsafe_payload()` before inserting.
+    conductor: Option<Arc<dyn Conductor>>,
+    /// Optional signing key for gossip. When set, [`broadcast_unsafe_block`] computes the
+    /// real [`PayloadHash`] and signs with the production formula instead of using a zero
+    /// signature.
+    ///
+    /// [`broadcast_unsafe_block`]: L2Sequencer::broadcast_unsafe_block
+    unsafe_block_signer: Option<PrivateKeySigner>,
 }
 
 impl L2Sequencer {
@@ -308,6 +326,8 @@ impl L2Sequencer {
             supervised_p2p: None,
             l1_origin_pin: None,
             l2_provider,
+            conductor: None,
+            unsafe_block_signer: None,
         }
     }
 
@@ -384,25 +404,81 @@ impl L2Sequencer {
         self.supervised_p2p = Some(p2p);
     }
 
-    /// Broadcast `block` as an [`NetworkPayloadEnvelope`] to the wired
+    /// Attach an unsafe block signing key to this sequencer.
+    ///
+    /// Once set, [`broadcast_unsafe_block`] computes the real [`PayloadHash`]
+    /// and signs it with the production formula:
+    /// `keccak256(domain || chain_id_padded || keccak256(SSZ(payload)))`.
+    ///
+    /// Wire the corresponding address to the receiving [`TestGossipTransport`]
+    /// via [`GossipTransport::set_block_signer`] and [`TestGossipTransport::set_chain_id`]
+    /// to activate end-to-end signature validation.
+    ///
+    /// [`broadcast_unsafe_block`]: L2Sequencer::broadcast_unsafe_block
+    /// [`GossipTransport::set_block_signer`]: base_consensus_node::GossipTransport::set_block_signer
+    /// [`TestGossipTransport::set_chain_id`]: crate::TestGossipTransport::set_chain_id
+    pub fn set_unsafe_block_signer(&mut self, key: PrivateKeySigner) {
+        self.unsafe_block_signer = Some(key);
+    }
+
+    /// Return the address corresponding to the configured unsafe block signing key, if any.
+    pub fn unsafe_block_signer_address(&self) -> Option<Address> {
+        self.unsafe_block_signer.as_ref().map(|s| s.address())
+    }
+
+    /// Attach a conductor to this sequencer.
+    ///
+    /// Once set, every call to [`build_next_block_with_transactions`] first
+    /// checks leadership via [`Conductor::leader`] and, after sealing,
+    /// commits the payload via [`Conductor::commit_unsafe_payload`]. Build
+    /// attempts return [`L2SequencerError::NotLeader`] when leadership is
+    /// absent.
+    ///
+    /// Use [`TestConductorHandle::conductor`] to create a [`TestConductor`]
+    /// and pass it here.
+    ///
+    /// [`build_next_block_with_transactions`]: L2Sequencer::build_next_block_with_transactions
+    /// [`TestConductorHandle::conductor`]: crate::TestConductorHandle::conductor
+    /// [`TestConductor`]: crate::TestConductor
+    pub fn set_conductor(&mut self, conductor: Arc<dyn Conductor>) {
+        self.conductor = Some(conductor);
+    }
+
+    /// Broadcast `block` as a [`NetworkPayloadEnvelope`] to the wired
     /// [`SupervisedP2P`] handle.
     ///
-    /// A no-op when no handle has been set via [`set_supervised_p2p`]. The
-    /// envelope carries a zero signature; test transports skip signature
-    /// validation.
+    /// A no-op when no handle has been set via [`set_supervised_p2p`].
+    ///
+    /// When an unsafe block signing key is configured via
+    /// [`set_unsafe_block_signer`], the envelope is signed with the production
+    /// formula (`keccak256(domain || chain_id_padded || keccak256(SSZ(payload)))`).
+    /// Otherwise the envelope carries a zero signature, which passes through
+    /// transports that have no expected signer configured.
     ///
     /// [`set_supervised_p2p`]: L2Sequencer::set_supervised_p2p
+    /// [`set_unsafe_block_signer`]: L2Sequencer::set_unsafe_block_signer
     pub fn broadcast_unsafe_block(&self, block: &BaseBlock) {
         let Some(p2p) = &self.supervised_p2p else { return };
         let block_hash = block.header.hash_slow();
         let (execution_payload, _) = BaseExecutionPayload::from_block_unchecked(block_hash, block);
-        let network = NetworkPayloadEnvelope {
-            payload: execution_payload,
-            signature: Signature::new(U256::ZERO, U256::ZERO, false),
-            payload_hash: PayloadHash(B256::ZERO),
-            parent_beacon_block_root: None,
+        let parent_beacon_block_root = block.header.parent_beacon_block_root;
+
+        let (signature, payload_hash) = if let Some(signer) = &self.unsafe_block_signer {
+            let envelope = BaseExecutionPayloadEnvelope {
+                execution_payload: execution_payload.clone(),
+                parent_beacon_block_root,
+            };
+            let ph = envelope.payload_hash();
+            let msg = ph.signature_message(self.rollup_config.l2_chain_id.id());
+            let sig = signer
+                .sign_hash_sync(&msg)
+                .expect("unsafe block signing must not fail");
+            (sig, ph)
+        } else {
+            (Signature::new(U256::ZERO, U256::ZERO, false), PayloadHash(B256::ZERO))
         };
-        p2p.send(network);
+
+        p2p.send(NetworkPayloadEnvelope { payload: execution_payload, signature, payload_hash, parent_beacon_block_root });
     }
 
     /// Build the next L2 block containing no user transactions.
@@ -456,6 +532,14 @@ impl L2Sequencer {
         &mut self,
         user_txs: Vec<BaseTxEnvelope>,
     ) -> Result<BaseBlock, L2SequencerError> {
+        // 0. Conductor leadership check: refuse to build if this node is not the leader.
+        if let Some(conductor) = &self.conductor {
+            let is_leader = conductor.leader().await?;
+            if !is_leader {
+                return Err(L2SequencerError::NotLeader);
+            }
+        }
+
         // 1. Origin selection: use pinned origin if set, otherwise production L1OriginSelector.
         let l1_origin = if let Some(pin) = self.l1_origin_pin {
             pin
@@ -502,13 +586,18 @@ impl L2Sequencer {
             .await
             .map_err(|e| L2SequencerError::Engine(format!("get_sealed: {e}")))?;
 
-        // 5. Insert the block into the engine (updates canonical head).
+        // 5. Conductor commit: register the sealed payload before inserting.
+        if let Some(conductor) = &self.conductor {
+            conductor.commit_unsafe_payload(&envelope).await?;
+        }
+
+        // 6. Insert the block into the engine (updates canonical head).
         self.engine_client
             .insert_unsafe_payload(envelope.clone())
             .await
             .map_err(|e| L2SequencerError::Engine(format!("insert: {e}")))?;
 
-        // 6. Convert BaseExecutionPayload to BaseBlock.
+        // 7. Convert BaseExecutionPayload to BaseBlock.
         // Use try_into_block_with_sidecar so PBBR and requests_hash are restored on the
         // returned header. try_into_block() omits these fields, making hash_slow() return a
         // different value than the sealed block hash. BatchEncoder::add_block tracks self.tip
@@ -541,7 +630,7 @@ impl L2Sequencer {
             .try_into_block_with_sidecar(&sidecar)
             .map_err(|e| L2SequencerError::PayloadConversion(format!("{e}")))?;
 
-        // 7. Compute seq_num and update head.
+        // 8. Compute seq_num and update head.
         let seq_num =
             if l1_origin.number == self.head.l1_origin.number { self.head.seq_num + 1 } else { 0 };
         let block_number = block.header.number;
@@ -558,7 +647,7 @@ impl L2Sequencer {
             seq_num,
         };
 
-        // 8. Update L2 provider state for next iteration.
+        // 9. Update L2 provider state for next iteration.
         self.l2_provider.insert_block(self.head);
         // The system config is updated via the attributes builder's internal
         // L2 chain provider when the epoch changes. For the sequencer's

--- a/actions/harness/src/lib.rs
+++ b/actions/harness/src/lib.rs
@@ -6,6 +6,9 @@
 mod action;
 pub use action::{Action, L2BlockProvider};
 
+mod conductor;
+pub use conductor::{ConductorState, TestConductor, TestConductorHandle};
+
 mod miner;
 pub use miner::{
     L1Block, L1Miner, L1MinerConfig, PendingTx, ReorgError, UserDeposit, block_info_from,

--- a/actions/harness/src/p2p.rs
+++ b/actions/harness/src/p2p.rs
@@ -58,7 +58,7 @@ impl SupervisedP2P {
 /// as in production where [`BlockHandler`] rejects invalid gossip before
 /// forwarding to the derivation pipeline.
 ///
-/// ### publish() and signing
+/// ### `publish()` and signing
 ///
 /// [`GossipTransport::publish`] is used in self-loop scenarios where the same
 /// transport both publishes and receives. If a `signing_key` is set via
@@ -112,7 +112,7 @@ impl TestGossipTransport {
     ///
     /// Must be set alongside [`GossipTransport::set_block_signer`] for
     /// signature validation to activate.
-    pub fn set_chain_id(&mut self, chain_id: u64) {
+    pub const fn set_chain_id(&mut self, chain_id: u64) {
         self.chain_id = Some(chain_id);
     }
 

--- a/actions/harness/src/p2p.rs
+++ b/actions/harness/src/p2p.rs
@@ -1,7 +1,9 @@
 //! In-process gossip transport for action tests.
 //!
 //! Provides a channel-backed [`GossipTransport`] implementation that routes
-//! blocks between test actors without opening real network ports.
+//! blocks between test actors without opening real network ports. When a
+//! signing key and expected signer address are configured, the transport
+//! enforces the same signature validation as production [`BlockHandler`] code.
 
 use alloy_primitives::{Address, B256, Signature, U256};
 use async_trait::async_trait;
@@ -14,7 +16,7 @@ use tokio::sync::mpsc;
 
 /// Handle for injecting blocks into a [`TestGossipTransport`].
 ///
-/// Held by test code or the sequencer. Call [`send`] to deliver an
+/// Held by test code or the sequencer. Call [`send`] to deliver a
 /// [`NetworkPayloadEnvelope`] to the matching [`TestGossipTransport`].
 ///
 /// [`send`]: SupervisedP2P::send
@@ -24,7 +26,7 @@ pub struct SupervisedP2P {
 }
 
 impl SupervisedP2P {
-    /// Send an [`NetworkPayloadEnvelope`] into the transport channel.
+    /// Send a [`NetworkPayloadEnvelope`] into the transport channel.
     pub fn send(&self, payload: NetworkPayloadEnvelope) {
         let _ = self.tx.send(payload);
     }
@@ -36,41 +38,86 @@ impl SupervisedP2P {
 /// Use [`channel`] to construct the [`SupervisedP2P`] / [`TestGossipTransport`]
 /// pair.
 ///
-/// In a single-node test, [`publish`] routes directly to [`next_unsafe_block`]
-/// via the internal channel. In a two-node test, the sequencer holds a
-/// [`SupervisedP2P`] handle and this transport is held by the node under test.
+/// ### Signature validation
+///
+/// By default, all received blocks are forwarded regardless of signature. Call
+/// [`set_block_signer`] to configure the expected signer address and
+/// [`set_chain_id`] to supply the chain ID. Once both are set, every block
+/// delivered via [`try_next_unsafe_block`] or [`next_unsafe_block`] is checked
+/// against the production signing formula:
+///
+/// ```text
+/// msg  = keccak256(domain || chain_id_padded || keccak256(SSZ(payload)))
+/// signer = ecrecover(envelope.signature, msg)
+/// valid  = signer == expected_signer
+/// ```
+///
+/// Invalid blocks are silently discarded so the node never sees them, exactly
+/// as in production where [`BlockHandler`] rejects invalid gossip before
+/// forwarding to the derivation pipeline.
 ///
 /// [`channel`]: TestGossipTransport::channel
-/// [`publish`]: GossipTransport::publish
+/// [`set_block_signer`]: GossipTransport::set_block_signer
+/// [`set_chain_id`]: TestGossipTransport::set_chain_id
+/// [`try_next_unsafe_block`]: TestGossipTransport::try_next_unsafe_block
 /// [`next_unsafe_block`]: GossipTransport::next_unsafe_block
+/// [`BlockHandler`]: base_consensus_gossip::BlockHandler
 #[derive(Debug)]
 pub struct TestGossipTransport {
     tx: mpsc::UnboundedSender<NetworkPayloadEnvelope>,
     rx: mpsc::UnboundedReceiver<NetworkPayloadEnvelope>,
+    /// Expected signer address, set via [`GossipTransport::set_block_signer`].
+    expected_signer: Option<Address>,
+    /// Chain ID used in the signature message, set via [`set_chain_id`].
+    ///
+    /// [`set_chain_id`]: TestGossipTransport::set_chain_id
+    chain_id: Option<u64>,
 }
 
 impl TestGossipTransport {
     /// Create a [`SupervisedP2P`] / [`TestGossipTransport`] pair sharing a
-    /// single channel.
-    ///
-    /// The [`SupervisedP2P`] handle allows test code or the sequencer to inject
-    /// blocks. The [`TestGossipTransport`] delivers them via
-    /// [`next_unsafe_block`].
-    ///
-    /// [`next_unsafe_block`]: GossipTransport::next_unsafe_block
+    /// single channel, with no signature validation enabled.
     pub fn channel() -> (SupervisedP2P, Self) {
         let (tx, rx) = mpsc::unbounded_channel();
-        (SupervisedP2P { tx: tx.clone() }, Self { tx, rx })
+        (SupervisedP2P { tx: tx.clone() }, Self { tx, rx, expected_signer: None, chain_id: None })
+    }
+
+    /// Set the chain ID used to construct the signature verification message.
+    ///
+    /// Must be set alongside [`GossipTransport::set_block_signer`] for
+    /// signature validation to activate.
+    pub fn set_chain_id(&mut self, chain_id: u64) {
+        self.chain_id = Some(chain_id);
+    }
+
+    /// Returns `true` if the envelope carries a valid signature from
+    /// [`expected_signer`], or if signature validation is not configured.
+    ///
+    /// Signature validation is only active when both `expected_signer` and
+    /// `chain_id` are set.
+    ///
+    /// [`expected_signer`]: TestGossipTransport::expected_signer
+    fn signature_valid(&self, envelope: &NetworkPayloadEnvelope) -> bool {
+        let (Some(signer), Some(chain_id)) = (self.expected_signer, self.chain_id) else {
+            return true;
+        };
+        let msg = envelope.payload_hash.signature_message(chain_id);
+        envelope.signature.recover_address_from_prehash(&msg).is_ok_and(|s| s == signer)
     }
 
     /// Try to receive the next unsafe block without blocking.
     ///
-    /// Returns `None` immediately if no block is currently available. Use this
-    /// to drain the channel in a non-blocking loop inside [`TestRollupNode::step`].
-    ///
-    /// [`TestRollupNode::step`]: crate::TestRollupNode::step
+    /// Returns `None` immediately if no block is currently available.
+    /// Blocks that fail signature validation (when configured) are silently
+    /// discarded and the next available block is returned.
     pub fn try_next_unsafe_block(&mut self) -> Option<NetworkPayloadEnvelope> {
-        self.rx.try_recv().ok()
+        loop {
+            match self.rx.try_recv() {
+                Ok(envelope) if self.signature_valid(&envelope) => return Some(envelope),
+                Ok(_) => continue,
+                Err(_) => return None,
+            }
+        }
     }
 }
 
@@ -95,10 +142,17 @@ impl GossipTransport for TestGossipTransport {
     }
 
     async fn next_unsafe_block(&mut self) -> Option<NetworkPayloadEnvelope> {
-        self.rx.recv().await
+        loop {
+            let envelope = self.rx.recv().await?;
+            if self.signature_valid(&envelope) {
+                return Some(envelope);
+            }
+        }
     }
 
-    fn set_block_signer(&mut self, _address: Address) {}
+    fn set_block_signer(&mut self, address: Address) {
+        self.expected_signer = Some(address);
+    }
 
     fn handle_p2p_rpc(&mut self, _request: P2pRpcRequest) {}
 }

--- a/actions/harness/src/p2p.rs
+++ b/actions/harness/src/p2p.rs
@@ -6,6 +6,8 @@
 //! enforces the same signature validation as production [`BlockHandler`] code.
 
 use alloy_primitives::{Address, B256, Signature, U256};
+use alloy_signer::SignerSync;
+use alloy_signer_local::PrivateKeySigner;
 use async_trait::async_trait;
 use base_common_rpc_types_engine::{
     BaseExecutionPayloadEnvelope, NetworkPayloadEnvelope, PayloadHash,
@@ -56,12 +58,27 @@ impl SupervisedP2P {
 /// as in production where [`BlockHandler`] rejects invalid gossip before
 /// forwarding to the derivation pipeline.
 ///
+/// ### publish() and signing
+///
+/// [`GossipTransport::publish`] is used in self-loop scenarios where the same
+/// transport both publishes and receives. If a `signing_key` is set via
+/// [`set_signing_key`], `publish` signs the outbound envelope with the
+/// production formula so that the validation check in [`next_unsafe_block`]
+/// passes. Without a signing key, `publish` emits a zero-signature envelope;
+/// calling `publish` on a transport where signature validation is active but no
+/// signing key is set will panic rather than silently hang the receiver.
+///
+/// Use [`ActionTestHarness::create_signing_p2p`] to configure both the signing
+/// key and the expected signer address together.
+///
 /// [`channel`]: TestGossipTransport::channel
 /// [`set_block_signer`]: GossipTransport::set_block_signer
 /// [`set_chain_id`]: TestGossipTransport::set_chain_id
+/// [`set_signing_key`]: TestGossipTransport::set_signing_key
 /// [`try_next_unsafe_block`]: TestGossipTransport::try_next_unsafe_block
 /// [`next_unsafe_block`]: GossipTransport::next_unsafe_block
 /// [`BlockHandler`]: base_consensus_gossip::BlockHandler
+/// [`ActionTestHarness::create_signing_p2p`]: crate::ActionTestHarness::create_signing_p2p
 #[derive(Debug)]
 pub struct TestGossipTransport {
     tx: mpsc::UnboundedSender<NetworkPayloadEnvelope>,
@@ -72,6 +89,12 @@ pub struct TestGossipTransport {
     ///
     /// [`set_chain_id`]: TestGossipTransport::set_chain_id
     chain_id: Option<u64>,
+    /// Signing key used by [`GossipTransport::publish`] to sign outbound
+    /// envelopes. Required when signature validation is active; set via
+    /// [`set_signing_key`].
+    ///
+    /// [`set_signing_key`]: TestGossipTransport::set_signing_key
+    signing_key: Option<PrivateKeySigner>,
 }
 
 impl TestGossipTransport {
@@ -79,7 +102,10 @@ impl TestGossipTransport {
     /// single channel, with no signature validation enabled.
     pub fn channel() -> (SupervisedP2P, Self) {
         let (tx, rx) = mpsc::unbounded_channel();
-        (SupervisedP2P { tx: tx.clone() }, Self { tx, rx, expected_signer: None, chain_id: None })
+        (
+            SupervisedP2P { tx: tx.clone() },
+            Self { tx, rx, expected_signer: None, chain_id: None, signing_key: None },
+        )
     }
 
     /// Set the chain ID used to construct the signature verification message.
@@ -88,6 +114,15 @@ impl TestGossipTransport {
     /// signature validation to activate.
     pub fn set_chain_id(&mut self, chain_id: u64) {
         self.chain_id = Some(chain_id);
+    }
+
+    /// Set the signing key used by [`GossipTransport::publish`].
+    ///
+    /// Required when signature validation is active and `publish` will be
+    /// called (i.e. self-loop test scenarios). Without this, `publish` panics
+    /// if `expected_signer` and `chain_id` are configured.
+    pub fn set_signing_key(&mut self, key: PrivateKeySigner) {
+        self.signing_key = Some(key);
     }
 
     /// Returns `true` if the envelope carries a valid signature from
@@ -131,13 +166,27 @@ impl GossipTransport for TestGossipTransport {
 
     async fn publish(&mut self, payload: BaseExecutionPayloadEnvelope) -> Result<(), Self::Error> {
         let parent_beacon_block_root = payload.parent_beacon_block_root;
-        let network = NetworkPayloadEnvelope {
-            payload: payload.execution_payload,
-            signature: Signature::new(U256::ZERO, U256::ZERO, false),
-            payload_hash: PayloadHash(B256::ZERO),
-            parent_beacon_block_root,
+        let (signature, payload_hash) = if self.expected_signer.is_some() {
+            let key = self.signing_key.as_ref().expect(
+                "TestGossipTransport: publish() called with signature validation active but \
+                 no signing key set — call set_signing_key() or use create_signing_p2p()",
+            );
+            let chain_id = self.chain_id.expect(
+                "TestGossipTransport: expected_signer set but chain_id is not — call set_chain_id()",
+            );
+            let ph = payload.payload_hash();
+            let sig =
+                key.sign_hash_sync(&ph.signature_message(chain_id)).expect("signing must not fail");
+            (sig, ph)
+        } else {
+            (Signature::new(U256::ZERO, U256::ZERO, false), PayloadHash(B256::ZERO))
         };
-        let _ = self.tx.send(network);
+        let _ = self.tx.send(NetworkPayloadEnvelope {
+            payload: payload.execution_payload,
+            signature,
+            payload_hash,
+            parent_beacon_block_root,
+        });
         Ok(())
     }
 

--- a/actions/harness/tests/batcher_submission_failure.rs
+++ b/actions/harness/tests/batcher_submission_failure.rs
@@ -1,0 +1,106 @@
+//! Action tests for batcher recovery when L1 frame submission fails.
+//!
+//! These tests verify the end-to-end path:
+//!   sequencer → batcher (submission fails) → batcher requeues → derivation
+//!
+//! The [`BatchDriver`] reacts to a failed [`SendHandle`] by calling
+//! `pipeline.requeue_frame()` and retrying on the next loop iteration.
+//! The L1MinerTxManager's `fail_next_n` mechanism fires an immediate
+//! [`TxManagerError::Rpc`] receipt so this path is exercised without any
+//! real L1 interaction.
+
+use base_action_harness::{
+    ActionL2Source, ActionTestHarness, Batcher, BatcherConfig, L1MinerConfig, SharedL1Chain,
+    TestRollupConfigBuilder,
+};
+use base_batcher_encoder::{DaType, EncoderConfig};
+
+fn calldata_batcher_config() -> BatcherConfig {
+    BatcherConfig {
+        encoder: EncoderConfig { da_type: DaType::Calldata, ..EncoderConfig::default() },
+        ..BatcherConfig::default()
+    }
+}
+
+/// When the first frame submission fails, the [`BatchDriver`] requeues the
+/// frame, retries, and the derivation node successfully derives the L2 block.
+#[tokio::test]
+async fn submission_failure_requeues_and_derivation_recovers() {
+    let batcher_cfg = calldata_batcher_config();
+    let rollup_cfg = TestRollupConfigBuilder::base_mainnet(&batcher_cfg).build();
+    let mut h = ActionTestHarness::new(L1MinerConfig::default(), rollup_cfg);
+
+    let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
+    let mut sequencer = h.create_l2_sequencer(l1_chain);
+    let block = sequencer.build_next_block_with_single_transaction().await;
+
+    let (mut node, chain) = h.create_test_rollup_node_from_sequencer(
+        &mut sequencer,
+        SharedL1Chain::from_blocks(h.l1.chain().to_vec()),
+    );
+
+    let mut source = ActionL2Source::new();
+    source.push(block);
+    let mut batcher = Batcher::new(source, &h.rollup_config, batcher_cfg);
+
+    // Fail the first submission so the driver must requeue and retry.
+    batcher.fail_next_n_submissions(1);
+    batcher.encode_only().await;
+
+    // Wait for the driver to process the failure receipt and return the frame
+    // to the pending queue via requeue + re-submit.
+    batcher.wait_until_requeued(1).await;
+
+    // Mine the successfully requeued frame into an L1 block.
+    let block_num = batcher.mine_pending(&mut h.l1).await;
+    chain.push(h.l1.tip().clone());
+
+    node.initialize().await;
+    let derived = node.run_until_idle().await;
+
+    assert_eq!(derived, 1, "requeued frame must produce one derived L2 block");
+    assert_eq!(node.l2_safe_number(), 1, "safe head must reach 1 after recovery");
+    assert!(block_num >= 1, "requeued frame was mined into an L1 block");
+}
+
+/// With three consecutive submission failures the [`BatchDriver`] requeues and
+/// retries three times before the fourth attempt succeeds. No data is lost: the
+/// derivation node sees the correct L2 block.
+#[tokio::test]
+async fn consecutive_failures_then_success_derives_correctly() {
+    let batcher_cfg = calldata_batcher_config();
+    let rollup_cfg = TestRollupConfigBuilder::base_mainnet(&batcher_cfg).build();
+    let mut h = ActionTestHarness::new(L1MinerConfig::default(), rollup_cfg);
+
+    let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
+    let mut sequencer = h.create_l2_sequencer(l1_chain);
+    let block = sequencer.build_next_block_with_single_transaction().await;
+
+    let (mut node, chain) = h.create_test_rollup_node_from_sequencer(
+        &mut sequencer,
+        SharedL1Chain::from_blocks(h.l1.chain().to_vec()),
+    );
+
+    let mut source = ActionL2Source::new();
+    source.push(block);
+    let mut batcher = Batcher::new(source, &h.rollup_config, batcher_cfg);
+
+    // Fail the next three attempts. The driver retries on each failure until
+    // the fourth send_async call succeeds and the frame lands in pending.
+    batcher.fail_next_n_submissions(3);
+    batcher.encode_only().await;
+
+    // Poll until the frame has made it through all three failures and back to
+    // pending via the successful fourth submission.
+    batcher.wait_until_requeued(1).await;
+
+    let block_num = batcher.mine_pending(&mut h.l1).await;
+    chain.push(h.l1.tip().clone());
+
+    node.initialize().await;
+    let derived = node.run_until_idle().await;
+
+    assert_eq!(derived, 1, "frame must survive three consecutive failures and derive one L2 block");
+    assert_eq!(node.l2_safe_number(), 1, "safe head must reach 1 after three retries");
+    assert!(block_num >= 1, "frame was eventually mined into an L1 block");
+}

--- a/actions/harness/tests/batcher_submission_failure.rs
+++ b/actions/harness/tests/batcher_submission_failure.rs
@@ -5,7 +5,7 @@
 //!
 //! The [`BatchDriver`] reacts to a failed [`SendHandle`] by calling
 //! `pipeline.requeue_frame()` and retrying on the next loop iteration.
-//! The L1MinerTxManager's `fail_next_n` mechanism fires an immediate
+//! The [`L1MinerTxManager`]'s `fail_next_n` mechanism fires an immediate
 //! [`TxManagerError::Rpc`] receipt so this path is exercised without any
 //! real L1 interaction.
 

--- a/actions/harness/tests/conductor.rs
+++ b/actions/harness/tests/conductor.rs
@@ -1,0 +1,136 @@
+use std::sync::Arc;
+
+use base_action_harness::{
+    ActionTestHarness, L2SequencerError, SharedL1Chain, TestConductorHandle,
+};
+
+/// Verify that a sequencer wired to a conductor emits exactly one
+/// `commit_unsafe_payload` call per block it builds.
+#[tokio::test]
+async fn conductor_leader_commits_each_block() {
+    let h = ActionTestHarness::default();
+    let chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
+
+    let handle = TestConductorHandle::with_leader_zero();
+    let mut seq = h.create_l2_sequencer(chain);
+    seq.set_conductor(Arc::new(handle.conductor(0)));
+
+    for i in 1u64..=3 {
+        seq.build_next_block_with_single_transaction().await;
+        assert_eq!(
+            handle.committed_count(),
+            i as usize,
+            "expected {i} commits after building block {i}"
+        );
+    }
+
+    let payloads = handle.committed_payloads();
+    assert_eq!(payloads.len(), 3);
+    assert!(
+        payloads.iter().all(|(id, _)| *id == 0),
+        "all commits should be attributed to sequencer 0"
+    );
+    // Each committed block hash must be distinct.
+    let hashes: std::collections::HashSet<_> = payloads.iter().map(|(_, h)| h).collect();
+    assert_eq!(hashes.len(), 3, "committed hashes must all be distinct");
+}
+
+/// Verify that a sequencer with no conductor leadership cannot build blocks.
+#[tokio::test]
+async fn conductor_non_leader_cannot_build() {
+    let h = ActionTestHarness::default();
+    let chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
+
+    // Sequencer id=1 but only id=0 is leader.
+    let handle = TestConductorHandle::with_leader_zero();
+    let mut seq = h.create_l2_sequencer(chain);
+    seq.set_conductor(Arc::new(handle.conductor(1)));
+
+    let err = seq.try_build_next_block_with_transactions(vec![]).await.unwrap_err();
+    assert!(
+        matches!(err, L2SequencerError::NotLeader),
+        "non-leader sequencer must return NotLeader, got: {err}"
+    );
+    assert_eq!(handle.committed_count(), 0, "no payloads should be committed");
+}
+
+/// Verify that leadership transfer correctly gates block production: the old
+/// leader is blocked after transfer and the new leader can build.
+#[tokio::test]
+async fn conductor_leadership_transfer_gates_building() {
+    let h = ActionTestHarness::default();
+    let chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
+
+    let handle = TestConductorHandle::with_leader_zero();
+    let mut seq = h.create_l2_sequencer(chain);
+    seq.set_conductor(Arc::new(handle.conductor(0)));
+
+    // Build 2 blocks as leader.
+    seq.build_next_block_with_single_transaction().await;
+    seq.build_next_block_with_single_transaction().await;
+    assert_eq!(handle.committed_count(), 2);
+
+    // Revoke leadership.
+    handle.clear_leader();
+
+    let err = seq.try_build_next_block_with_transactions(vec![]).await.unwrap_err();
+    assert!(
+        matches!(err, L2SequencerError::NotLeader),
+        "sequencer must be blocked after leadership revoked, got: {err}"
+    );
+    assert_eq!(handle.committed_count(), 2, "no new commits after revocation");
+
+    // Restore leadership.
+    handle.set_leader(0);
+    seq.build_next_block_with_single_transaction().await;
+    assert_eq!(handle.committed_count(), 3, "commit should succeed after leadership restored");
+}
+
+/// Verify that two independent sequencers sharing a [`TestConductorHandle`]
+/// obey its leadership assignment: only the designated leader commits payloads,
+/// and payloads from each sequencer are attributed to the correct id.
+#[tokio::test]
+async fn conductor_two_sequencers_only_leader_produces() {
+    let h = ActionTestHarness::default();
+
+    // Sequencer A starts as leader (id=0); sequencer B (id=1) is a follower.
+    let handle = TestConductorHandle::with_leader_zero();
+
+    let chain_a = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
+    let mut seq_a = h.create_l2_sequencer(chain_a);
+    seq_a.set_conductor(Arc::new(handle.conductor(0)));
+
+    let chain_b = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
+    let mut seq_b = h.create_l2_sequencer(chain_b);
+    seq_b.set_conductor(Arc::new(handle.conductor(1)));
+
+    // Sequencer B is blocked.
+    assert!(matches!(
+        seq_b.try_build_next_block_with_transactions(vec![]).await.unwrap_err(),
+        L2SequencerError::NotLeader
+    ));
+
+    // Sequencer A builds 3 blocks.
+    for _ in 0..3 {
+        seq_a.build_next_block_with_single_transaction().await;
+    }
+    assert_eq!(handle.committed_by(0).len(), 3, "sequencer A must have 3 commits");
+    assert_eq!(handle.committed_by(1).len(), 0, "sequencer B must have 0 commits");
+
+    // Transfer leadership to B.
+    handle.set_leader(1);
+
+    // Sequencer A is now blocked.
+    assert!(matches!(
+        seq_a.try_build_next_block_with_transactions(vec![]).await.unwrap_err(),
+        L2SequencerError::NotLeader
+    ));
+
+    // Sequencer B builds 2 blocks.
+    for _ in 0..2 {
+        seq_b.build_next_block_with_single_transaction().await;
+    }
+    assert_eq!(handle.committed_by(0).len(), 3, "sequencer A commits must not grow");
+    assert_eq!(handle.committed_by(1).len(), 2, "sequencer B must have 2 commits");
+    assert_eq!(handle.committed_count(), 5, "total commits across both sequencers");
+}

--- a/actions/harness/tests/conductor.rs
+++ b/actions/harness/tests/conductor.rs
@@ -1,3 +1,5 @@
+//! Action tests for conductor-gated sequencer leadership.
+
 use std::sync::Arc;
 
 use base_action_harness::{

--- a/actions/harness/tests/unsafe_signing.rs
+++ b/actions/harness/tests/unsafe_signing.rs
@@ -1,0 +1,153 @@
+use alloy_primitives::{B256, Signature, U256};
+use alloy_signer_local::PrivateKeySigner;
+use base_action_harness::{ActionTestHarness, SharedL1Chain, TestGossipTransport};
+use base_common_rpc_types_engine::{BaseExecutionPayload, NetworkPayloadEnvelope, PayloadHash};
+use base_consensus_node::GossipTransport as _;
+
+/// End-to-end: a sequencer with a real signing key produces blocks whose
+/// signatures the verifier node accepts, advancing its unsafe head.
+#[tokio::test]
+async fn signed_blocks_accepted_as_unsafe_head() {
+    let h = ActionTestHarness::default();
+    let chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
+    let key = PrivateKeySigner::random();
+
+    let mut seq = h.create_l2_sequencer(chain.clone());
+    let transport = h.create_signing_p2p(&mut seq, key);
+    let mut node = h.create_test_rollup_node(&seq, chain, transport);
+    node.initialize().await;
+
+    for _ in 0..3 {
+        let block = seq.build_next_block_with_single_transaction().await;
+        seq.broadcast_unsafe_block(&block);
+    }
+
+    node.run_until_idle().await;
+    assert_eq!(node.l2_unsafe().block_info.number, 3, "signed blocks must advance unsafe head");
+    assert_eq!(node.l2_safe().block_info.number, 0, "safe head stays at genesis without batches");
+}
+
+/// A block carrying a zero signature is silently dropped when the transport
+/// has an expected signer configured.
+#[tokio::test]
+async fn zero_signature_dropped_when_signer_configured() {
+    let h = ActionTestHarness::default();
+    let chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
+    let key = PrivateKeySigner::random();
+
+    let mut seq = h.create_l2_sequencer(chain);
+
+    let (injector, mut transport) = TestGossipTransport::channel();
+    seq.set_supervised_p2p(injector);
+    transport.set_block_signer(key.address());
+    transport.set_chain_id(h.rollup_config.l2_chain_id.id());
+
+    // Build via sequencer (no signing key set — default zero-sig path).
+    let block = seq.build_next_block_with_single_transaction().await;
+    seq.broadcast_unsafe_block(&block);
+
+    assert!(
+        transport.try_next_unsafe_block().is_none(),
+        "zero-signature block must be silently dropped when expected signer is configured"
+    );
+}
+
+/// A block signed with the wrong key is silently dropped by the transport.
+#[tokio::test]
+async fn wrong_signing_key_rejected() {
+    let h = ActionTestHarness::default();
+    let chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
+
+    let correct_key = PrivateKeySigner::random();
+    let wrong_key = PrivateKeySigner::random();
+
+    let mut seq = h.create_l2_sequencer(chain);
+    seq.set_unsafe_block_signer(wrong_key);
+
+    let (p2p, mut transport) = TestGossipTransport::channel();
+    seq.set_supervised_p2p(p2p);
+    transport.set_block_signer(correct_key.address());
+    transport.set_chain_id(h.rollup_config.l2_chain_id.id());
+
+    let block = seq.build_next_block_with_single_transaction().await;
+    seq.broadcast_unsafe_block(&block);
+
+    assert!(
+        transport.try_next_unsafe_block().is_none(),
+        "block signed with wrong key must be dropped"
+    );
+}
+
+/// Directly injecting a zero-sig block into a transport with an expected
+/// signer configured is rejected. A block signed by the expected key is
+/// accepted when injected through the same channel.
+#[tokio::test]
+async fn injected_forged_block_dropped_real_block_accepted() {
+    let h = ActionTestHarness::default();
+    let chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
+    let key = PrivateKeySigner::random();
+
+    let mut seq = h.create_l2_sequencer(chain);
+    seq.set_unsafe_block_signer(key.clone());
+
+    let (p2p, mut transport) = TestGossipTransport::channel();
+    seq.set_supervised_p2p(p2p.clone());
+    transport.set_block_signer(key.address());
+    transport.set_chain_id(h.rollup_config.l2_chain_id.id());
+
+    // Build a block and get its execution payload.
+    let block = seq.build_next_block_with_single_transaction().await;
+    let block_hash = block.header.hash_slow();
+    let (execution_payload, _) = BaseExecutionPayload::from_block_unchecked(block_hash, &block);
+
+    // Inject a forged (zero-sig) envelope directly via the supervisor channel.
+    p2p.send(NetworkPayloadEnvelope {
+        payload: execution_payload.clone(),
+        signature: Signature::new(U256::ZERO, U256::ZERO, false),
+        payload_hash: PayloadHash(B256::ZERO),
+        parent_beacon_block_root: block.header.parent_beacon_block_root,
+    });
+    assert!(transport.try_next_unsafe_block().is_none(), "forged block must be dropped");
+
+    // Now broadcast through the sequencer's signed path — should be accepted.
+    seq.broadcast_unsafe_block(&block);
+    assert!(transport.try_next_unsafe_block().is_some(), "correctly signed block must be accepted");
+}
+
+/// After a key rotation, blocks from the old key are rejected and blocks
+/// from the new key are accepted.
+#[tokio::test]
+async fn signer_rotation_gates_acceptance() {
+    let h = ActionTestHarness::default();
+    let chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
+
+    let key_a = PrivateKeySigner::random();
+    let key_b = PrivateKeySigner::random();
+
+    let mut seq = h.create_l2_sequencer(chain);
+    seq.set_unsafe_block_signer(key_a.clone());
+
+    let (p2p, mut transport) = TestGossipTransport::channel();
+    seq.set_supervised_p2p(p2p);
+    transport.set_block_signer(key_a.address());
+    transport.set_chain_id(h.rollup_config.l2_chain_id.id());
+
+    // key_a block, expected key_a → accepted.
+    let block1 = seq.build_next_block_with_single_transaction().await;
+    seq.broadcast_unsafe_block(&block1);
+    assert!(transport.try_next_unsafe_block().is_some(), "key_a block must pass before rotation");
+
+    // Rotate expected signer to key_b; sequencer still signs with key_a.
+    transport.set_block_signer(key_b.address());
+
+    let block2 = seq.build_next_block_with_single_transaction().await;
+    seq.broadcast_unsafe_block(&block2);
+    assert!(transport.try_next_unsafe_block().is_none(), "key_a block must be rejected after rotation to key_b");
+
+    // Rotate sequencer to key_b.
+    seq.set_unsafe_block_signer(key_b);
+
+    let block3 = seq.build_next_block_with_single_transaction().await;
+    seq.broadcast_unsafe_block(&block3);
+    assert!(transport.try_next_unsafe_block().is_some(), "key_b block must pass after rotation");
+}

--- a/actions/harness/tests/unsafe_signing.rs
+++ b/actions/harness/tests/unsafe_signing.rs
@@ -142,7 +142,10 @@ async fn signer_rotation_gates_acceptance() {
 
     let block2 = seq.build_next_block_with_single_transaction().await;
     seq.broadcast_unsafe_block(&block2);
-    assert!(transport.try_next_unsafe_block().is_none(), "key_a block must be rejected after rotation to key_b");
+    assert!(
+        transport.try_next_unsafe_block().is_none(),
+        "key_a block must be rejected after rotation to key_b"
+    );
 
     // Rotate sequencer to key_b.
     seq.set_unsafe_block_signer(key_b);

--- a/actions/harness/tests/unsafe_signing.rs
+++ b/actions/harness/tests/unsafe_signing.rs
@@ -1,3 +1,5 @@
+//! Action tests for unsafe block signing and P2P signature validation.
+
 use alloy_primitives::{B256, Signature, U256};
 use alloy_signer_local::PrivateKeySigner;
 use base_action_harness::{ActionTestHarness, SharedL1Chain, TestGossipTransport};
@@ -102,7 +104,7 @@ async fn injected_forged_block_dropped_real_block_accepted() {
 
     // Inject a forged (zero-sig) envelope directly via the supervisor channel.
     p2p.send(NetworkPayloadEnvelope {
-        payload: execution_payload.clone(),
+        payload: execution_payload,
         signature: Signature::new(U256::ZERO, U256::ZERO, false),
         payload_hash: PayloadHash(B256::ZERO),
         parent_beacon_block_root: block.header.parent_beacon_block_root,

--- a/crates/consensus/service/README.md
+++ b/crates/consensus/service/README.md
@@ -9,19 +9,135 @@ An implementation of the Base [RollupNode][rn-spec] service.
 
 ## Overview
 
-Orchestrates all Base rollup node subsystems — engine, gossip, discovery, derivation, and RPC
-— into a single `RollupNode` service. Wires together the consensus engine client, P2P
-networking stack, L1/L2 derivation pipeline, and admin RPC server, providing a unified
-start/stop lifecycle.
+This crate wires together every subsystem of the Base consensus node into a single runnable service. It owns no domain logic itself — derivation lives in `base-consensus-derive`, engine state management lives in `base-consensus-engine`, peer-to-peer gossip lives in `base-consensus-gossip`, and so on. What this crate provides is the composition layer: it constructs each subsystem as an independent async actor, opens the typed channels between them, and manages the shared lifetime of all actors through a single `CancellationToken`.
 
-## Usage
+The entry point for most callers is `RollupNodeBuilder`, which accepts the required configuration for each subsystem and produces a `RollupNode` whose `start()` method blocks until the process receives SIGINT or SIGTERM or until any actor exits with an error.
 
-Add the dependency to your `Cargo.toml`:
+## Actor Model
 
-```toml
-[dependencies]
-base-consensus-node = { workspace = true }
-```
+The service is built around a strict actor model. Each actor is a struct that implements the `NodeActor` trait, which has a single async method `start(self, context: Self::StartData) -> Result<(), Self::Error>`. Actors do not share mutable state. Instead, all cross-actor communication happens through typed channels: `tokio::sync::mpsc` channels for requests and `tokio::sync::watch` channels for broadcast state. Every actor holds a `CancellationToken` cloned from the root token created at startup; when any actor exits with an error the token is cancelled, which causes all remaining actors to observe their cancellation futures and exit cleanly.
+
+The `spawn_and_wait!` macro in `service/util.rs` is the mechanism that brings all actors up together. It spawns each actor onto a `tokio::task::JoinSet`, then drives a `select!` loop that listens simultaneously for OS shutdown signals and for the first task to complete. On either event it cancels the token and then waits for remaining tasks to drain. Errors from individual tasks are formatted and returned as `Err(String)` from the top-level `start()` method.
+
+## Service Variants
+
+The crate exposes two top-level service types: `RollupNode` and `FollowNode`.
+
+`RollupNode` is the full consensus node. It runs the complete L1 derivation pipeline, participates in the P2P network, and optionally runs the sequencer. It is constructed through `RollupNodeBuilder`, which requires a `RollupConfig`, an `L1ConfigBuilder`, a boolean for whether to trust the L2 RPC, an `EngineConfig` carrying the L2 engine RPC URL and JWT secret, and a `NetworkConfig`. Optional extensions include an RPC server (`RpcBuilder`), sequencer behavior (`SequencerConfig`), a derivation delegation endpoint (`DerivationDelegateConfig`), a persistent safe-head database path, and a finalized block poll interval override.
+
+`FollowNode` is a stripped-down variant that does not run derivation at all. Instead it polls a remote L2 execution layer node via RPC and drives the local engine to mirror that node's chain. It spawns only the engine actor, the delegate-L2 derivation actor, the L1 watcher actor, and optionally the RPC actor. It is used in contexts where a node needs to track the canonical chain without performing the full derivation computation.
+
+## RollupNode Mode
+
+`RollupNode` is mode-aware. The mode is stored in `EngineConfig::mode` as the `NodeMode` enum with two variants: `Validator` and `Sequencer`. In `Validator` mode the engine bootstraps by seeding state from the execution layer's existing head, signals the derivation pipeline, and waits for derivation to drive safe-head updates. In `Sequencer` mode the engine bootstraps differently — either with a conductor-follower probe using zeroed safe/finalized heads, or as an active sequencer that probes with real heads or resets at genesis — and additionally publishes an `unsafe_head_tx` watch channel that the sequencer actor reads to know the current building parent.
+
+## Construction and Startup Sequence
+
+When `RollupNodeBuilder::build()` is called, it constructs the `L1Config` (containing a `OnlineBeaconClient`, an Alloy `RootProvider` for L1, and consensus parameters), connects to the L2 execution layer via `BaseEngineClient`, and optionally builds a `DerivationDelegateClient` if delegation is configured. The result is a `RollupNode` with all configuration resolved but no actors running yet.
+
+Calling `RollupNode::start()` begins the actor wiring phase. The sequence is deterministic:
+
+First, a root `CancellationToken` is created. If a safe-head database path was provided, a `SafeDB` backed by redb is opened; otherwise a `DisabledSafeDB` is used. In delegation mode the database is always disabled.
+
+Second, the core channels are created. There is one `mpsc` channel of capacity 1024 for `DerivationActorRequest`, one of capacity 1024 for `EngineActorRequest`, and one `watch` channel for the unsafe L2 head (`L2BlockInfo`).
+
+Third, the engine actor is constructed. It wraps a `BaseEngineClient` together with an `Engine` task queue, an `EngineProcessor` that holds the bootstrap logic and main processing loop, and an `EngineRpcProcessor` that handles concurrent RPC queries behind a semaphore of size 16. The engine actor receives on its `mpsc::Receiver<EngineActorRequest>` and routes each request either to the processing task or to the RPC task based on the request variant.
+
+Fourth, the derivation actor is created. In normal mode this is a `DerivationActor` wrapping an `OnlinePipeline` from `base-consensus-derive`. In delegation mode this is a `DelegateDerivationActor` that polls an external `optimism_syncStatus` RPC endpoint instead of running the pipeline. Both communicate to the engine through a `QueuedDerivationEngineClient` that wraps `mpsc::Sender<EngineActorRequest>`.
+
+Fifth, the network actor is created via `NetworkActor::new()`. This async constructor builds the libp2p gossipsub swarm and the discv5 discovery daemon, starts both, optionally updates the local ENR with the discovered external address, and returns a `NetworkInboundData` struct containing the sender halves of four channels: the `signer` channel (capacity 16) for updating the unsafe block signer address, the `p2p_rpc` channel (capacity 1024) for P2P RPC requests, the `admin_rpc` channel (capacity 1024) for network admin queries, and the `gossip_payload_tx` channel (capacity 256) for payloads the sequencer wants to gossip.
+
+Sixth, the L1 watcher actor is created. It receives two `BlockStream` instances — one polling `eth_getBlockByNumber("latest")` at a 4-second interval and one polling `eth_getBlockByNumber("finalized")` at a configurable interval — and an `Arc<AtomicU64>` shared with the `ConfDepthProvider` so that the derivation pipeline knows the L1 head without polling again. When a new L1 head arrives, the watcher applies the `verifier_l1_confs` offset, fetches the delayed block by number, and forwards it to the derivation actor. It also fetches `SystemConfigLog` events from the L1 system config address on each head update, extracting any `UnsafeBlockSigner` update and forwarding the new signer address to the network actor's `signer` channel. A separate `L1WatcherQueryProcessor` runs concurrently (up to 32 concurrent queries) and handles point-in-time `L1WatcherQueries` from the RPC layer.
+
+Seventh, if the node is in sequencer mode, the sequencer actor is created. It receives the `watch::Receiver<L2BlockInfo>` for the unsafe head, a `QueuedUnsafePayloadGossipClient` wrapping `gossip_payload_tx`, a `PayloadBuilder` carrying the `L1OriginSelector` and `StatefulAttributesBuilder`, an optional `ConductorClient`, and a `RecoveryModeGuard` (an `Arc<AtomicBool>` shared between the actor and the builder). An `mpsc` channel of capacity 1024 is created for `SequencerAdminQuery` messages; the sender half is returned as a `QueuedSequencerAdminAPIClient` for use by the RPC actor.
+
+Eighth, if an `RpcBuilder` was provided, the RPC actor is created. It wraps a `QueuedEngineRpcClient`, an optional `QueuedSequencerAdminAPIClient`, and the `Arc<dyn SafeDBReader>`. The `RpcContext` passed at startup carries the sender halves of the p2p RPC, network admin, and L1 watcher query channels.
+
+Finally, `spawn_and_wait!` spawns all constructed actors onto the `JoinSet` and enters the shutdown monitoring loop.
+
+## Engine Actor
+
+The engine actor is the hub of the service. All other actors that need to affect the L2 execution layer send requests to it. It owns the `Engine` struct from `base-consensus-engine`, which maintains the task queue and the `EngineState` watch channel. The actor's main loop receives `EngineActorRequest` variants and routes them:
+
+`BuildRequest` carries a `PayloadId` response channel and is forwarded to the processing task, which calls `engine_api::forkchoice_updated` with the payload attributes to begin block building and returns the resulting `PayloadId`.
+
+`GetPayloadRequest` carries attributes and a result channel; the processing task calls `engine_api::get_payload` and returns the sealed `BaseExecutionPayloadEnvelope`.
+
+`SealRequest` is similar to `GetPayloadRequest` but used in the sequencer path where the result will be gossiped and then inserted.
+
+`ProcessUnsafeL2BlockRequest` is fire-and-forget. It takes a `BaseExecutionPayloadEnvelope` received from the P2P network or from the sequencer's insert step, calls `engine_api::new_payload`, then calls `engine_api::forkchoice_updated` to make the block the new unsafe head.
+
+`ProcessSafeL2SignalRequest` takes a `ConsolidateInput` from the derivation actor — either a derived set of `AttributesWithParent` or a delegated `L2BlockInfo` — and runs the safe-head consolidation path: attributes are forwarded to `engine_api::forkchoice_updated`, and the resulting safe head is sent back to the derivation actor via the `QueuedEngineDerivationClient`.
+
+`ResetRequest` triggers a full engine reset: the processing task calls the reset procedure on the `Engine`, clears in-flight state, and sends a `ResetSignal` to the derivation actor so the pipeline rewinds to the last safe head.
+
+`RpcRequest` is routed to the RPC processor task. It handles `EngineQueries` variants — `Config`, `State`, `OutputAtBlock`, `TaskQueueLength`, `QueueLengthReceiver`, `StateReceiver` — all of which read from the engine's watch channels or perform point-in-time queries without affecting processing state.
+
+At startup, the engine processor determines its bootstrap role. If the node is a validator it calls `bootstrap_validator()`, which seeds `unsafe_head`, `safe_head`, and `finalized_head` from the execution layer's current state without sending any forkchoice update, leaving `el_sync_complete` as false until the derivation actor signals completion. If the node is an active sequencer it calls `bootstrap_active_sequencer()`, which resets the engine at genesis or probes it with real safe/finalized heads to establish the initial forkchoice state. If the conductor-follower role is resolved it calls `bootstrap_conductor_follower()`, which probes with zeroed safe/finalized heads.
+
+After bootstrap, the processing loop drains the engine task queue on every iteration before waiting for the next request. Drain errors are classified by severity: `Critical` errors halt the actor, `Reset` errors trigger a pipeline reset, `Flush` errors flush invalid payloads from the queue, and `Temporary` errors are logged and retried.
+
+## Derivation Actor
+
+The derivation actor drives the `OnlinePipeline` from `base-consensus-derive` and translates its output into engine requests. It maintains a `DerivationStateMachine` with six states.
+
+The initial state is `AwaitingELSyncCompletion`. The actor waits in this state until the engine sends a `ProcessEngineSyncCompletionRequest` via `QueuedEngineDerivationClient::notify_sync_completed()`, at which point the state transitions to `Deriving`.
+
+In `Deriving` the actor calls `pipeline.step()` in a loop. Each call either returns `PreparedAttributes` — a set of `AttributesWithParent` ready to send to the engine — or returns an error. On `PreparedAttributes` the actor transitions to `AwaitingSafeHeadConfirmation`, enqueues the attributes in the `L2Finalizer`, records the L1 inclusion block as `pending_derived_from`, and sends a `ProcessSafeL2SignalRequest` to the engine. On `NotEnoughData` it yields and transitions to `AwaitingL1Data`. On a reset error (reorg detected or Holocene activation) it sends a `ProcessEngineSignalRequest` and transitions to `AwaitingSignal`.
+
+The `AwaitingSafeHeadConfirmation` state persists until the engine actor confirms the attributes by calling back through `QueuedEngineDerivationClient::send_new_engine_safe_head()`. That call generates a `ProcessEngineSafeHeadUpdateRequest`, which records the new safe head in the `SafeDB` (paired with the L1 block from `pending_derived_from`) and transitions back to `Deriving` to produce the next batch of attributes.
+
+The `L2Finalizer` struct tracks finalization by maintaining a `BTreeMap<u64, u64>` from L1 block number to the highest L2 block number derived in that epoch. When the L1 watcher reports a new finalized L1 block, the actor calls `L2Finalizer::try_finalize_next()`, which scans the map for all entries at or below the finalized L1 number, drains them, and returns the highest L2 block number. That number is forwarded to the engine as a `ProcessFinalizedL2BlockNumberRequest`.
+
+The delegation variants differ significantly. `DelegateDerivationActor` polls an external `optimism_syncStatus` endpoint every 4 seconds, validates the reported safe and finalized L2 blocks' L1 origins against its local L1 provider for hash consistency, and then forwards the safe and finalized L2 heads to the engine. It does not run a pipeline at all. `DelegateL2DerivationActor` is used by `FollowNode`; it polls the source L2 node's head by block number every 2 seconds, fetches each missing payload, sends them to the engine as `ProcessUnsafeL2BlockRequest` one at a time, and then issues a delegated forkchoice update after the batch is complete.
+
+## Sequencer Actor
+
+The sequencer actor owns the block production loop. It runs a `tokio::select!` with five arms in priority order: cancellation, admin queries, the seal pipeline step, the build ticker (gated on `sealer.is_none()`), and initial reset retries before the main loop starts.
+
+The ticker fires every `rollup_config.block_time` seconds (default two seconds) and is wall-clock synchronized. After each successful seal the next tick is scheduled for `UNIX_EPOCH + (sealed_block_timestamp + block_time) * 1s - last_seal_duration`, so that the ticker fires slightly early to account for the time taken by the seal pipeline.
+
+The build-seal cycle works as follows. On each tick, if there is a payload handle from a previous `start_build_block` call, the sequencer calls `get_sealed_payload` to retrieve the finalized `BaseExecutionPayloadEnvelope` from the engine. If the build is stale — the sealed envelope's parent does not match `next_build_parent` — it is discarded and a fresh build is started. If the seal succeeds, `next_build_parent` is computed from the sealed envelope's header so the next build will be anchored to the correct parent, and the `PayloadSealer` is constructed to drive the three-stage pipeline.
+
+The `PayloadSealer` runs one async operation per call to `step()`. In the first stage (`Sealed`) it calls `conductor.commit_unsafe_payload()` if a conductor is configured, or skips to the next stage if not. In the second stage (`Committed`) it calls `gossip_client.schedule_execution_payload_gossip()`, which is a fire-and-forget send to the network actor's `gossip_payload_tx` channel. In the third stage (`Gossiped`) it calls `engine_client.insert_unsafe_payload()`, another fire-and-forget that sends `ProcessUnsafeL2BlockRequest` to the engine actor. On `Ok(true)` from `step()` the sealer is dropped and the build ticker resumes. If any step returns an error the sequencer logs a warning and retries on the next select iteration.
+
+Parallel to the seal pipeline, the `PayloadBuilder` drives the next block's preparation. `build()` reads the current unsafe head from the watch channel via `engine_client.get_unsafe_head()` and delegates to `build_on(parent)`. Inside `build_on`, the `L1OriginSelector` determines the next L1 epoch: it consults its cached current and next L1 origins, advances to the next epoch if the L2 timestamp has caught up, and respects `max_sequencer_drift` to decide when empty blocks must be produced because the next L1 block is unavailable. The origin selector is wrapped in `DelayedL1OriginSelectorProvider`, which gates block-number lookups to only return blocks at or below `l1_head - l1_conf_delay`. After origin selection, `StatefulAttributesBuilder::prepare_payload_attributes()` from `base-consensus-derive` produces the `OpPayloadAttributes`, the `PoolActivation` check determines whether to include transactions from the mempool or produce an empty block (recovery mode, sequencer drift, or hardfork activation blocks all force empty blocks), and `start_build_block()` sends a `BuildRequest` to the engine actor and returns the `PayloadId`.
+
+The `RecoveryModeGuard` is an `Arc<AtomicBool>` shared between the sequencer actor and the payload builder. Setting recovery mode via the admin API writes to the atomic, and the builder reads it on every build attempt. When recovery mode is true, `PoolActivation::is_enabled()` returns false and empty blocks are produced.
+
+## Network Actor
+
+The network actor manages the libp2p gossipsub swarm and the discv5 discovery daemon. It exposes four inbound channels to the rest of the service. Other actors send payloads to `gossip_payload_tx` (capacity 256) when they want blocks propagated, send address updates to `signer` (capacity 16) when the unsafe block signer changes, send P2P RPC queries to `p2p_rpc` (capacity 1024), and send admin queries to `admin_rpc` (capacity 1024).
+
+The `GossipTransport` trait abstracts the transport backend. The production implementation is `NetworkHandler`, which wraps a `GossipDriver<ConnectionGater>` (the libp2p swarm), a `Discv5Handler`, an `mpsc::Receiver<Enr>` from discovery, a `watch::Sender<Address>` for the signer broadcast, and optionally a `BlockSignerHandler`. The `NetworkHandler::publish()` method signs the payload, constructs a `NetworkPayloadEnvelope`, and publishes it to the correct gossipsub topic based on the payload timestamp relative to hardfork activation. `NetworkHandler::next_unsafe_block()` runs a `select!` that drains gossipsub events through `GossipDriver::handle_event()`, dials newly discovered peers from the ENR receiver, and periodically inspects peer scores to disconnect and ban peers below the configured ban threshold.
+
+The `NetworkDriver::build()` produces the `NetworkHandler` by starting the libp2p swarm, resolving the local external address from the TCP listen multiaddr, updating the discv5 ENR socket, starting the discv5 daemon, and wiring together the peer score interval.
+
+## L1 Watcher Actor
+
+The L1 watcher actor is the service's source of truth for L1 chain state. It runs two concurrent streams: `head_stream` polls `eth_getBlockByNumber("latest")` every four seconds and `finalized_stream` polls `eth_getBlockByNumber("finalized")` at the interval configured in `L1Config`. Both streams are deduplicated — they only emit when the block changes.
+
+On each new head, the watcher computes the confirmation-delayed block number as `head.number - verifier_l1_confs`. If the delayed number is reachable it fetches that block by number via `AlloyL1BlockFetcher::get_block()` and sends it to the derivation actor as a `ProcessL1HeadUpdateRequest`. It also broadcasts the real head through the `watch::Sender<Option<BlockInfo>>` and stores the real head number in the shared `Arc<AtomicU64>` so the `ConfDepthProvider` used by the derivation pipeline can gate its own L1 lookups.
+
+Log fetching runs on the same head-update path. The watcher calls `AlloyL1BlockFetcher::get_logs()` with a filter for `SystemConfigLog` events from the rollup config's L1 system config address. If the logs contain a `SystemConfigUpdate::UnsafeBlockSigner` event it extracts the new signer address and sends it to the network actor via the `block_signer_sender` channel. The log fetch retries up to ten times with exponential backoff from 50 ms to 500 ms before the actor returns an error.
+
+On each finalized block, the watcher sends the block directly to the derivation actor as a `ProcessFinalizedL1Block` without any confirmation delay.
+
+The `L1WatcherQueryProcessor` runs as a separate actor that receives `L1WatcherQueries` from the RPC layer over an `mpsc::Receiver<L1WatcherQueries>` (capacity 1024) and processes them with concurrency up to 32 via `for_each_concurrent`. The two supported query types are `Config`, which returns the `RollupConfig`, and `L1State`, which assembles a point-in-time `L1State` struct by reading the watch channel and issuing `eth_blockNumber` calls for latest, safe, and finalized tags.
+
+## RPC Actor
+
+The RPC actor wraps a `jsonrpsee` HTTP server and optionally a WebSocket server. It builds the server module set based on what was configured: `HealthzRpc` is always present, `P2pRpc` is included when a p2p channel sender is available, `AdminRpc` is included when a network admin channel sender is available, `RollupRpc` carries the engine RPC client and L1 watcher query client together with the `SafeDBReader`, `DevEngineRpc` is included in dev mode, and `WsRPC` is included when WebSocket is enabled.
+
+`QueuedEngineRpcClient` implements the `EngineRpcClient` trait by sending `EngineActorRequest::RpcRequest` messages and awaiting oneshot responses. All queries go through the engine actor's main channel and are dispatched to the `EngineRpcProcessor`, which handles them concurrently behind the semaphore.
+
+`QueuedSequencerAdminAPIClient` implements the `SequencerAdminAPIClient` trait by sending `SequencerAdminQuery` messages with oneshot response channels. The sequencer actor services these in the high-priority admin arm of its `select!` loop.
+
+The RPC actor monitors the server handle for unexpected stops. If the server stops before the cancellation token fires it can restart up to a configured number of times. After exhausting restarts it cancels the root token, which brings down the entire service.
+
+## Channel Wiring Summary
+
+The complete channel graph between actors is as follows. The L1 watcher actor writes new L1 heads and finalized L1 blocks to the derivation actor via `mpsc::Sender<DerivationActorRequest>` (capacity 1024). The L1 watcher actor also broadcasts the raw L1 head through `watch::Sender<Option<BlockInfo>>` to any subscribers (currently consumed by the sequencer's `ConfDepthProvider` indirectly via the shared atomic). The derivation actor writes `ConsolidateInput` signals, finalized L2 block numbers, and delegated forkchoice updates to the engine actor via `mpsc::Sender<EngineActorRequest>` (capacity 1024). The engine actor notifies the derivation actor of safe-head updates and sync completion via `mpsc::Sender<DerivationActorRequest>` on the same channel (but from the opposite direction). The sequencer actor sends build requests, seal requests, get-payload requests, insert-unsafe requests, and reset requests to the engine actor via the same `mpsc::Sender<EngineActorRequest>`. The engine actor publishes the current unsafe head to the sequencer via `watch::Sender<L2BlockInfo>`. The network actor forwards inbound gossip payloads to the engine actor via `mpsc::Sender<EngineActorRequest>` through `QueuedNetworkEngineClient`. The sequencer actor sends payloads to gossip via `mpsc::Sender<BaseExecutionPayloadEnvelope>` (capacity 256) to the network actor's `publish_rx`. The L1 watcher actor sends signer address updates via `mpsc::Sender<Address>` (capacity 16) to the network actor's `signer` receiver. The RPC actor sends engine queries via `mpsc::Sender<EngineActorRequest>` and sequencer admin queries via `mpsc::Sender<SequencerAdminQuery>` (capacity 1024). The RPC actor sends P2P RPC requests via `mpsc::Sender<P2pRpcRequest>` (capacity 1024) and network admin queries via `mpsc::Sender<NetworkAdminQuery>` (capacity 1024) to the network actor. The RPC actor sends `L1WatcherQueries` via `mpsc::Sender<L1WatcherQueries>` (capacity 1024) to the `L1WatcherQueryProcessor`.
 
 ## License
 

--- a/crates/consensus/service/README.md
+++ b/crates/consensus/service/README.md
@@ -27,7 +27,7 @@ The crate exposes two top-level service types: `RollupNode` and `FollowNode`.
 
 `FollowNode` is a stripped-down variant that does not run derivation at all. Instead it polls a remote L2 execution layer node via RPC and drives the local engine to mirror that node's chain. It spawns only the engine actor, the delegate-L2 derivation actor, the L1 watcher actor, and optionally the RPC actor. It is used in contexts where a node needs to track the canonical chain without performing the full derivation computation.
 
-## RollupNode Mode
+## `RollupNode` Mode
 
 `RollupNode` is mode-aware. The mode is stored in `EngineConfig::mode` as the `NodeMode` enum with two variants: `Validator` and `Sequencer`. In `Validator` mode the engine bootstraps by seeding state from the execution layer's existing head, signals the derivation pipeline, and waits for derivation to drive safe-head updates. In `Sequencer` mode the engine bootstraps differently — either with a conductor-follower probe using zeroed safe/finalized heads, or as an active sequencer that probes with real heads or resets at genesis — and additionally publishes an `unsafe_head_tx` watch channel that the sequencer actor reads to know the current building parent.
 

--- a/crates/consensus/service/src/actors/sequencer/conductor.rs
+++ b/crates/consensus/service/src/actors/sequencer/conductor.rs
@@ -75,4 +75,7 @@ pub enum ConductorError {
     /// An error occurred while making an RPC call to the conductor.
     #[error("RPC error: {0}")]
     Rpc(#[from] ClientError),
+    /// The conductor rejected the payload because this node is not the leader.
+    #[error("not the conductor leader")]
+    NotLeader,
 }


### PR DESCRIPTION
## Summary

Adds three new categories of action tests that exercise previously uncovered production code paths in the Base consensus stack. The conductor tests wire a real `TestConductor` into `L2Sequencer` and verify that only the designated leader can build blocks, with `commit_unsafe_payload` called per block and leadership transfer correctly gating production. The unsafe signing tests add real `PrivateKeySigner` support to `L2Sequencer::broadcast_unsafe_block` and signature validation to `TestGossipTransport`, verifying that forged or wrong-key blocks are silently dropped by verifier nodes. The submission failure tests add `fail_next_n` fault injection to `L1MinerTxManager` so the batcher's requeue-on-failure path is exercised end-to-end through derivation for the first time.