### PR TITLE
[backport v0.8.0] fix(consensus): iterate all transactions in is_deposits_only

### DIFF
--- a/crates/consensus/protocol/src/attributes.rs
+++ b/crates/consensus/protocol/src/attributes.rs
@@ -66,7 +66,8 @@ impl AttributesWithParent {
         self.attributes
             .transactions
             .iter()
-            .all(|tx| tx.first().is_some_and(|tx| tx[0] == OpTxType::Deposit as u8))
+            .flatten()
+            .all(|tx| tx.first().copied() == Some(OpTxType::Deposit as u8))
     }
 
     /// Converts the [`AttributesWithParent`] into a deposits-only payload.
@@ -231,5 +232,85 @@ mod tests {
         let deposits_only_attributes = op_attributes_with_parent.as_deposits_only();
 
         assert_eq!(deposits_only_attributes.attributes().transactions, None);
+    }
+
+    fn awp_with_txs(txs: Option<Vec<alloy_primitives::Bytes>>) -> AttributesWithParent {
+        AttributesWithParent::new(
+            BasePayloadAttributes { transactions: txs, ..BasePayloadAttributes::default() },
+            L2BlockInfo::default(),
+            None,
+            true,
+        )
+    }
+
+    #[test]
+    fn is_deposits_only_true_for_none() {
+        assert!(awp_with_txs(None).is_deposits_only());
+    }
+
+    #[test]
+    fn is_deposits_only_true_for_empty_vec() {
+        assert!(awp_with_txs(Some(vec![])).is_deposits_only());
+    }
+
+    #[test]
+    fn is_deposits_only_true_for_single_deposit() {
+        let txs = Some(vec![vec![OpTxType::Deposit as u8, 0x00, 0x01].into()]);
+        assert!(awp_with_txs(txs).is_deposits_only());
+    }
+
+    #[test]
+    fn is_deposits_only_true_for_multiple_deposits() {
+        let txs = Some(vec![
+            vec![OpTxType::Deposit as u8, 0x00, 0x01].into(),
+            vec![OpTxType::Deposit as u8, 0x02, 0x03].into(),
+            vec![OpTxType::Deposit as u8, 0x04, 0x05].into(),
+        ]);
+        assert!(awp_with_txs(txs).is_deposits_only());
+    }
+
+    /// Regression test for the `Option<Vec<_>>::iter()` foot-gun: derived L2 blocks
+    /// always start with the L1-info deposit followed by user transactions. Before
+    /// the fix this returned `true` because the closure bound `&Vec<Bytes>` and
+    /// `.first()` only inspected the first transaction.
+    #[test]
+    fn is_deposits_only_false_for_l1_info_deposit_then_user_tx() {
+        let txs = Some(vec![
+            vec![OpTxType::Deposit as u8, 0x00, 0x01].into(),
+            vec![OpTxType::Eip1559 as u8, 0x00, 0x02].into(),
+        ]);
+        assert!(!awp_with_txs(txs).is_deposits_only());
+    }
+
+    #[test]
+    fn is_deposits_only_false_for_deposits_then_legacy_then_eip1559() {
+        let txs = Some(vec![
+            vec![OpTxType::Deposit as u8, 0x00, 0x01].into(),
+            vec![OpTxType::Deposit as u8, 0x02, 0x03].into(),
+            vec![OpTxType::Legacy as u8, 0x04, 0x05].into(),
+            vec![OpTxType::Eip1559 as u8, 0x06, 0x07].into(),
+        ]);
+        assert!(!awp_with_txs(txs).is_deposits_only());
+    }
+
+    #[test]
+    fn is_deposits_only_false_for_user_tx_only() {
+        let txs = Some(vec![vec![OpTxType::Eip1559 as u8, 0x00, 0x01].into()]);
+        assert!(!awp_with_txs(txs).is_deposits_only());
+    }
+
+    #[test]
+    fn is_deposits_only_false_when_first_tx_is_user_then_deposits() {
+        let txs = Some(vec![
+            vec![OpTxType::Eip1559 as u8, 0x00, 0x01].into(),
+            vec![OpTxType::Deposit as u8, 0x02, 0x03].into(),
+        ]);
+        assert!(!awp_with_txs(txs).is_deposits_only());
+    }
+
+    #[test]
+    fn is_deposits_only_false_for_empty_tx_bytes() {
+        let txs = Some(vec![alloy_primitives::Bytes::new()]);
+        assert!(!awp_with_txs(txs).is_deposits_only());
     }
 }


### PR DESCRIPTION
Backport of #2429 to `releases/v0.8.0`.

## Summary
- Fix `AttributesWithParent::is_deposits_only` so it actually inspects every transaction instead of only the first byte of the first transaction.
- Add unit tests covering `None`, empty list, single/multiple deposits, mixed deposit + user transactions in various orders, user-only payloads, and an empty-bytes transaction.

## Bug
`.iter()` on `Option<Vec<Bytes>>` yields the inner `Vec` (or nothing) — not its elements. The closure bound `tx: &Vec<Bytes>` and `tx.first()` returned the first transaction's bytes, of which only `tx[0]` (the first byte) was compared to the deposit type tag.

This means derived L2 blocks containing the L1-info deposit followed by user transactions were incorrectly classified as deposits-only, because only the leading L1-info deposit's type byte was checked.

## Fix
Flatten the option and check each transaction's first byte, so any non-deposit transaction correctly disqualifies the payload:

```rust
self.attributes
    .transactions
    .iter()
    .flatten()
    .all(|tx| tx.first().copied() == Some(OpTxType::Deposit as u8))
```

## Test plan
Cherry-picked cleanly. All 9 new unit tests pass on the backport branch:

- `is_deposits_only_true_for_none`
- `is_deposits_only_true_for_empty_vec`
- `is_deposits_only_true_for_single_deposit`
- `is_deposits_only_true_for_multiple_deposits`
- `is_deposits_only_false_for_l1_info_deposit_then_user_tx` (regression)
- `is_deposits_only_false_for_deposits_then_legacy_then_eip1559`
- `is_deposits_only_false_for_user_tx_only`
- `is_deposits_only_false_when_first_tx_is_user_then_deposits`
- `is_deposits_only_false_for_empty_tx_bytes`