### PR TITLE
[v0.8.0] fix(consensus): cap snappy-decoded gossip payload size

### DIFF
--- a/crates/common/rpc-types-engine/src/envelope.rs
+++ b/crates/common/rpc-types-engine/src/envelope.rs
@@ -14,6 +14,15 @@ use alloy_rpc_types_engine::{
 
 use crate::{BaseExecutionPayload, BaseExecutionPayloadSidecar, BaseExecutionPayloadV4};
 
+/// Maximum allowed decoded size for a snappy-compressed [`NetworkPayloadEnvelope`].
+///
+/// Mirrors `MAX_GOSSIP_SIZE` in `base-consensus-gossip` and bounds the heap
+/// allocation performed by [`NetworkPayloadEnvelope::decode_v1`] and friends.
+/// Without this cap, a wire-valid 9 `MiB` snappy frame can declare a 200 `MiB`
+/// decoded length and force the decoder to allocate that buffer before any
+/// downstream length, SSZ, or signature check runs.
+pub const MAX_DECOMPRESSED_ENVELOPE_BYTES: usize = 10 * (1 << 20);
+
 /// A thin wrapper around [`BaseExecutionPayload`] that includes the parent beacon block root.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -249,13 +258,31 @@ pub struct NetworkPayloadEnvelope {
 }
 
 impl NetworkPayloadEnvelope {
+    /// Snappy-decompresses `data` after checking that the declared decoded size
+    /// does not exceed [`MAX_DECOMPRESSED_ENVELOPE_BYTES`].
+    ///
+    /// `snap::raw::decompress_len` parses only the varu32 preamble and never
+    /// allocates, so this guard runs in O(1) and prevents an unauthenticated
+    /// peer from forcing arbitrarily large heap allocations on the consensus
+    /// node before any signature or SSZ check has run.
+    #[cfg(feature = "std")]
+    fn decompress_bounded(data: &[u8]) -> Result<Vec<u8>, PayloadEnvelopeError> {
+        let declared = snap::raw::decompress_len(data)?;
+        if declared > MAX_DECOMPRESSED_ENVELOPE_BYTES {
+            return Err(PayloadEnvelopeError::DecodedTooLarge {
+                given: declared,
+                max: MAX_DECOMPRESSED_ENVELOPE_BYTES,
+            });
+        }
+        Ok(snap::raw::Decoder::new().decompress_vec(data)?)
+    }
+
     /// Decode a payload envelope from a snappy-compressed byte array.
     /// The payload version decoded is `ExecutionPayloadV1` from SSZ bytes.
     #[cfg(feature = "std")]
     pub fn decode_v1(data: &[u8]) -> Result<Self, PayloadEnvelopeError> {
         use ssz::Decode;
-        let mut decoder = snap::raw::Decoder::new();
-        let decompressed = decoder.decompress_vec(data)?;
+        let decompressed = Self::decompress_bounded(data)?;
 
         if decompressed.len() < 66 {
             return Err(PayloadEnvelopeError::InvalidLength);
@@ -298,8 +325,7 @@ impl NetworkPayloadEnvelope {
     #[cfg(feature = "std")]
     pub fn decode_v2(data: &[u8]) -> Result<Self, PayloadEnvelopeError> {
         use ssz::Decode;
-        let mut decoder = snap::raw::Decoder::new();
-        let decompressed = decoder.decompress_vec(data)?;
+        let decompressed = Self::decompress_bounded(data)?;
 
         if decompressed.len() < 66 {
             return Err(PayloadEnvelopeError::InvalidLength);
@@ -342,8 +368,7 @@ impl NetworkPayloadEnvelope {
     #[cfg(feature = "std")]
     pub fn decode_v3(data: &[u8]) -> Result<Self, PayloadEnvelopeError> {
         use ssz::Decode;
-        let mut decoder = snap::raw::Decoder::new();
-        let decompressed = decoder.decompress_vec(data)?;
+        let decompressed = Self::decompress_bounded(data)?;
 
         if decompressed.len() < 98 {
             return Err(PayloadEnvelopeError::InvalidLength);
@@ -398,8 +423,7 @@ impl NetworkPayloadEnvelope {
     #[cfg(feature = "std")]
     pub fn decode_v4(data: &[u8]) -> Result<Self, PayloadEnvelopeError> {
         use ssz::Decode;
-        let mut decoder = snap::raw::Decoder::new();
-        let decompressed = decoder.decompress_vec(data)?;
+        let decompressed = Self::decompress_bounded(data)?;
 
         if decompressed.len() < 98 {
             return Err(PayloadEnvelopeError::InvalidLength);
@@ -478,6 +502,14 @@ pub enum PayloadEnvelopeError {
     /// The payload envelope is of invalid length.
     #[error("Invalid length")]
     InvalidLength,
+    /// The declared decompressed size exceeds [`MAX_DECOMPRESSED_ENVELOPE_BYTES`].
+    #[error("Decoded payload too large: {given} > {max}")]
+    DecodedTooLarge {
+        /// Declared decoded size in bytes.
+        given: usize,
+        /// Maximum allowed decoded size in bytes.
+        max: usize,
+    },
 }
 
 impl From<alloy_primitives::SignatureError> for PayloadEnvelopeError {
@@ -633,5 +665,29 @@ mod tests {
         assert_eq!(1741842007, payload_envelop.payload.timestamp());
         let encoded = payload_envelop.encode_v4().unwrap();
         assert_eq!(data, encoded);
+    }
+
+    #[test]
+    #[cfg(feature = "std")]
+    fn test_decode_rejects_oversized_decompressed_payload() {
+        let huge = vec![0u8; MAX_DECOMPRESSED_ENVELOPE_BYTES + 1];
+        let bomb = snap::raw::Encoder::new().compress_vec(&huge).unwrap();
+
+        let declared = snap::raw::decompress_len(&bomb).unwrap();
+        assert!(declared > MAX_DECOMPRESSED_ENVELOPE_BYTES);
+        assert!(bomb.len() < MAX_DECOMPRESSED_ENVELOPE_BYTES);
+
+        for result in [
+            NetworkPayloadEnvelope::decode_v1(&bomb),
+            NetworkPayloadEnvelope::decode_v2(&bomb),
+            NetworkPayloadEnvelope::decode_v3(&bomb),
+            NetworkPayloadEnvelope::decode_v4(&bomb),
+        ] {
+            assert!(matches!(
+                result,
+                Err(PayloadEnvelopeError::DecodedTooLarge { given, max })
+                    if given == declared && max == MAX_DECOMPRESSED_ENVELOPE_BYTES
+            ));
+        }
     }
 }

--- a/crates/common/rpc-types-engine/src/lib.rs
+++ b/crates/common/rpc-types-engine/src/lib.rs
@@ -15,8 +15,8 @@ pub use attributes::BasePayloadAttributes;
 
 mod envelope;
 pub use envelope::{
-    BaseExecutionPayloadEnvelope, ExecutionData, NetworkPayloadEnvelope,
-    PayloadEnvelopeEncodeError, PayloadEnvelopeError, PayloadHash,
+    BaseExecutionPayloadEnvelope, ExecutionData, MAX_DECOMPRESSED_ENVELOPE_BYTES,
+    NetworkPayloadEnvelope, PayloadEnvelopeEncodeError, PayloadEnvelopeError, PayloadHash,
 };
 
 mod sidecar;

--- a/crates/consensus/gossip/src/config.rs
+++ b/crates/consensus/gossip/src/config.rs
@@ -101,24 +101,46 @@ pub fn default_config() -> Config {
 }
 
 /// Computes the [`MessageId`] of a `gossipsub` message.
+///
+/// Reject oversized snappy frames before allocating: `snap::raw::decompress_len`
+/// parses only the varu32 preamble and never allocates. Frames whose declared
+/// decoded size exceeds [`MAX_GOSSIP_SIZE`] are hashed under the invalid-snappy
+/// domain, identical to malformed snappy input. This prevents an anonymous peer
+/// from forcing the gossipsub task to allocate hundreds of `MiB` per packet.
 fn compute_message_id(msg: &Message) -> MessageId {
-    let mut decoder = Decoder::new();
-    let id = decoder.decompress_vec(&msg.data).map_or_else(
-        |_| {
-            warn!(target: "cfg", "Failed to decompress message, using invalid snappy");
-            let domain_invalid_snappy: Vec<u8> = vec![0x0, 0x0, 0x0, 0x0];
-            sha256([domain_invalid_snappy.as_slice(), msg.data.as_slice()].concat().as_slice())
-                [..20]
-                .to_vec()
-        },
-        |data| {
-            let domain_valid_snappy: Vec<u8> = vec![0x1, 0x0, 0x0, 0x0];
-            sha256([domain_valid_snappy.as_slice(), data.as_slice()].concat().as_slice())[..20]
-                .to_vec()
-        },
-    );
+    let id = match snap::raw::decompress_len(&msg.data) {
+        Ok(declared) if declared > MAX_GOSSIP_SIZE => {
+            warn!(target: "cfg", declared, max = MAX_GOSSIP_SIZE, "Rejecting oversized snappy message");
+            invalid_snappy_id(&msg.data)
+        }
+        Ok(_) => {
+            let mut decoder = Decoder::new();
+            decoder.decompress_vec(&msg.data).map_or_else(
+                |_| {
+                    warn!(target: "cfg", "Failed to decompress message, using invalid snappy");
+                    invalid_snappy_id(&msg.data)
+                },
+                |data| {
+                    let domain_valid_snappy: Vec<u8> = vec![0x1, 0x0, 0x0, 0x0];
+                    sha256([domain_valid_snappy.as_slice(), data.as_slice()].concat().as_slice())
+                        [..20]
+                        .to_vec()
+                },
+            )
+        }
+        Err(_) => {
+            warn!(target: "cfg", "Failed to read snappy preamble, using invalid snappy");
+            invalid_snappy_id(&msg.data)
+        }
+    };
 
     MessageId(id)
+}
+
+/// Hash `data` under the invalid-snappy domain tag.
+fn invalid_snappy_id(data: &[u8]) -> Vec<u8> {
+    let domain_invalid_snappy: Vec<u8> = vec![0x0, 0x0, 0x0, 0x0];
+    sha256([domain_invalid_snappy.as_slice(), data].concat().as_slice())[..20].to_vec()
 }
 
 #[cfg(test)]
@@ -160,5 +182,24 @@ mod tests {
         let id = compute_message_id(&msg);
         let hashed = sha256(&[&[0x1, 0x0, 0x0, 0x0], [1, 2, 3, 4, 5].as_slice()].concat());
         assert_eq!(id.0, hashed[..20].to_vec());
+    }
+
+    #[test]
+    fn test_compute_message_id_rejects_oversized_snappy_bomb() {
+        let huge = vec![0u8; MAX_GOSSIP_SIZE + 1];
+        let bomb = snap::raw::Encoder::new().compress_vec(&huge).unwrap();
+        assert!(bomb.len() < MAX_GOSSIP_SIZE, "wire size must pass max_transmit_size");
+        assert!(snap::raw::decompress_len(&bomb).unwrap() > MAX_GOSSIP_SIZE);
+
+        let msg = Message {
+            source: None,
+            data: bomb.clone(),
+            sequence_number: None,
+            topic: libp2p::gossipsub::TopicHash::from_raw("test"),
+        };
+
+        let id = compute_message_id(&msg);
+        let expected = sha256(&[&[0x0, 0x0, 0x0, 0x0], bomb.as_slice()].concat())[..20].to_vec();
+        assert_eq!(id.0, expected, "oversized bomb must hash under the invalid-snappy domain");
     }
 }


### PR DESCRIPTION
Backport of #2444 to `releases/v0.8.0`.

## Summary

`compute_message_id` (`crates/consensus/gossip/src/config.rs`) and `NetworkPayloadEnvelope::decode_v{1..4}` (`crates/common/rpc-types-engine/src/envelope.rs`) snappy-decompress untrusted gossip data without bounding the *decoded* size. The existing `max_transmit_size(MAX_GOSSIP_SIZE)` only caps **compressed** wire bytes, so a wire-valid ~9 MiB snappy frame can declare ~200 MiB decoded and force the gossipsub task to allocate that much heap before any signature, length, or SSZ check runs.

Pre-checks the declared decoded length via `snap::raw::decompress_len` (parses only the varu32 preamble; O(1), no allocation) and rejects when the declared size exceeds the cap. Mirrors the canonical guard used by `paradigmxyz/reth` and required by the Ethereum consensus-specs p2p-interface.

## Cherry-pick

Cherry-picked cleanly from commit `1c6bc9fdd` on `fix/snappy-compression` (PR #2444). Auto-merge resolved hunks in `config.rs` and `envelope.rs` — no manual conflict resolution required. The connection-limits work (#2432) and `specs.optimism.io` → `specs.base.org` doc-URL rewrites on `main` are not present on `releases/v0.8.0`, but the affected hunks were disjoint.

## Verification

\`\`\`
cargo test  -p base-common-rpc-types-engine -p base-consensus-gossip --lib
# 32 passed (envelope) / 45 passed (gossip), 0 failed — incl. the two new regression tests

cargo clippy -p base-common-rpc-types-engine -p base-consensus-gossip --all-targets -- -D warnings
# clean
\`\`\`