### PR TITLE
fix lychee coinbase blog check

### DIFF
--- a/lychee.toml
+++ b/lychee.toml
@@ -33,6 +33,7 @@ exclude = [
     'https://patreon\.com',
     'https://www\.patreon\.com',
     'https://tidelift\.com',
+    'https://www\.coinbase\.com',      # Fails in GitHub Actions with HTTP/2 protocol errors
 
     # Moved/deleted source files (links in docs that predate refactors)
     'https://github\.com/base/base/blob/main/crates/execution/upgrades/src/chain\.rs',


### PR DESCRIPTION
## Summary
Lychee is failing on some PR's due to the coinbase blog, see https://github.com/base/base/pull/2439