### PR TITLE
fix(gossip): bind message ids to topics

### DIFF
--- a/crates/consensus/gossip/src/config.rs
+++ b/crates/consensus/gossip/src/config.rs
@@ -6,7 +6,7 @@ use libp2p::{
     connection_limits::ConnectionLimits,
     gossipsub::{Config, ConfigBuilder, Message, MessageId},
 };
-use openssl::sha::sha256;
+use openssl::sha::Sha256;
 use snap::raw::Decoder;
 
 ////////////////////////////////////////////////////////////////////////////////////////////////
@@ -53,6 +53,12 @@ pub const DEFAULT_MAX_ESTABLISHED_CONNECTIONS: u32 = 30;
 
 /// The default maximum number of established libp2p connections per peer.
 pub const DEFAULT_MAX_ESTABLISHED_CONNECTIONS_PER_PEER: u32 = 1;
+
+/// Domain tag for malformed snappy messages in gossip message IDs.
+const DOMAIN_INVALID_SNAPPY: [u8; 4] = [0x0, 0x0, 0x0, 0x0];
+
+/// Domain tag for valid snappy messages in gossip message IDs.
+const DOMAIN_VALID_SNAPPY: [u8; 4] = [0x1, 0x0, 0x0, 0x0];
 
 ////////////////////////////////////////////////////////////////////////////////////////////////
 // Duration Constants
@@ -170,6 +176,11 @@ pub fn default_config() -> Config {
 
 /// Computes the [`MessageId`] of a `gossipsub` message.
 ///
+/// The message ID is bound to the gossip topic, matching the OP Stack
+/// implementation. This prevents the global gossipsub duplicate cache from
+/// treating byte-identical payloads on different block-version topics as the
+/// same message.
+///
 /// Reject oversized snappy frames before allocating: `snap::raw::decompress_len`
 /// parses only the varu32 preamble and never allocates. Frames whose declared
 /// decoded size exceeds [`MAX_GOSSIP_SIZE`] are hashed under the invalid-snappy
@@ -179,26 +190,21 @@ fn compute_message_id(msg: &Message) -> MessageId {
     let id = match snap::raw::decompress_len(&msg.data) {
         Ok(declared) if declared > MAX_GOSSIP_SIZE => {
             warn!(target: "cfg", declared, max = MAX_GOSSIP_SIZE, "Rejecting oversized snappy message");
-            invalid_snappy_id(&msg.data)
+            invalid_snappy_id(msg)
         }
         Ok(_) => {
             let mut decoder = Decoder::new();
             decoder.decompress_vec(&msg.data).map_or_else(
                 |_| {
                     warn!(target: "cfg", "Failed to decompress message, using invalid snappy");
-                    invalid_snappy_id(&msg.data)
+                    invalid_snappy_id(msg)
                 },
-                |data| {
-                    let domain_valid_snappy: Vec<u8> = vec![0x1, 0x0, 0x0, 0x0];
-                    sha256([domain_valid_snappy.as_slice(), data.as_slice()].concat().as_slice())
-                        [..20]
-                        .to_vec()
-                },
+                |data| message_id_hash(msg, &DOMAIN_VALID_SNAPPY, &data),
             )
         }
         Err(_) => {
             warn!(target: "cfg", "Failed to read snappy preamble, using invalid snappy");
-            invalid_snappy_id(&msg.data)
+            invalid_snappy_id(msg)
         }
     };
 
@@ -206,9 +212,21 @@ fn compute_message_id(msg: &Message) -> MessageId {
 }
 
 /// Hash `data` under the invalid-snappy domain tag.
-fn invalid_snappy_id(data: &[u8]) -> Vec<u8> {
-    let domain_invalid_snappy: Vec<u8> = vec![0x0, 0x0, 0x0, 0x0];
-    sha256([domain_invalid_snappy.as_slice(), data].concat().as_slice())[..20].to_vec()
+fn invalid_snappy_id(msg: &Message) -> Vec<u8> {
+    message_id_hash(msg, &DOMAIN_INVALID_SNAPPY, &msg.data)
+}
+
+/// Hashes a gossip message ID preimage.
+fn message_id_hash(msg: &Message, domain: &[u8; 4], data: &[u8]) -> Vec<u8> {
+    let topic = msg.topic.as_str().as_bytes();
+    let topic_len = (topic.len() as u64).to_le_bytes();
+    let mut hasher = Sha256::new();
+    hasher.update(domain);
+    hasher.update(&topic_len);
+    hasher.update(topic);
+    hasher.update(data);
+
+    hasher.finish()[..20].to_vec()
 }
 
 #[cfg(test)]
@@ -244,8 +262,8 @@ mod tests {
         };
 
         let id = compute_message_id(&msg);
-        let hashed = sha256(&[&[0x0, 0x0, 0x0, 0x0], [1, 2, 3, 4, 5].as_slice()].concat());
-        assert_eq!(id.0, hashed[..20].to_vec());
+        let hashed = message_id_hash(&msg, &DOMAIN_INVALID_SNAPPY, &[1, 2, 3, 4, 5]);
+        assert_eq!(id.0, hashed);
     }
 
     #[test]
@@ -259,8 +277,46 @@ mod tests {
         };
 
         let id = compute_message_id(&msg);
-        let hashed = sha256(&[&[0x1, 0x0, 0x0, 0x0], [1, 2, 3, 4, 5].as_slice()].concat());
-        assert_eq!(id.0, hashed[..20].to_vec());
+        let hashed = message_id_hash(&msg, &DOMAIN_VALID_SNAPPY, &[1, 2, 3, 4, 5]);
+        assert_eq!(id.0, hashed);
+    }
+
+    #[test]
+    fn test_compute_message_id_matches_op_reference_golden() {
+        let compressed = snap::raw::Encoder::new().compress_vec(&[1, 2, 3, 4, 5]).unwrap();
+        let msg = Message {
+            source: None,
+            data: compressed,
+            sequence_number: None,
+            topic: libp2p::gossipsub::TopicHash::from_raw("test"),
+        };
+
+        // SHA256(valid-snappy-domain || topic-len-le || "test" || [1, 2, 3, 4, 5])[:20].
+        let expected = [
+            0xad, 0xbe, 0x54, 0x7b, 0x27, 0xf4, 0x12, 0x94, 0xa0, 0x8a, 0x09, 0x21, 0x0a, 0x5e,
+            0x85, 0x31, 0xe8, 0x3c, 0xdc, 0x16,
+        ];
+
+        assert_eq!(compute_message_id(&msg).0, expected);
+    }
+
+    #[test]
+    fn test_compute_message_id_includes_topic() {
+        let compressed = snap::raw::Encoder::new().compress_vec(&[1, 2, 3, 4, 5]).unwrap();
+        let msg_v3 = Message {
+            source: None,
+            data: compressed.clone(),
+            sequence_number: None,
+            topic: libp2p::gossipsub::TopicHash::from_raw("/optimism/8453/2/blocks"),
+        };
+        let msg_v4 = Message {
+            source: None,
+            data: compressed,
+            sequence_number: None,
+            topic: libp2p::gossipsub::TopicHash::from_raw("/optimism/8453/3/blocks"),
+        };
+
+        assert_ne!(compute_message_id(&msg_v3), compute_message_id(&msg_v4));
     }
 
     #[test]
@@ -278,7 +334,7 @@ mod tests {
         };
 
         let id = compute_message_id(&msg);
-        let expected = sha256(&[&[0x0, 0x0, 0x0, 0x0], bomb.as_slice()].concat())[..20].to_vec();
+        let expected = message_id_hash(&msg, &DOMAIN_INVALID_SNAPPY, &bomb);
         assert_eq!(id.0, expected, "oversized bomb must hash under the invalid-snappy domain");
     }
 }

--- a/docs/specs/pages/protocol/consensus/p2p.md
+++ b/docs/specs/pages/protocol/consensus/p2p.md
@@ -158,14 +158,15 @@ The application contents are compressed with [snappy][snappy] single-block-compr
 
 ##### Message ID computation
 
-[Same as L1][l1-message-id], with recognition of compression:
+[Same as L1][l1-message-id], with recognition of compression and topic binding.
+Let `topic_len` be the 8-byte little-endian length of `message.topic`.
 
 - If `message.data` has a valid snappy decompression, set `message-id` to the first 20 bytes of the `SHA256` hash of
-  the concatenation of `MESSAGE_DOMAIN_VALID_SNAPPY` with the snappy decompressed message data,
-  i.e. `SHA256(MESSAGE_DOMAIN_VALID_SNAPPY + snappy_decompress(message.data))[:20]`.
+  the concatenation of `MESSAGE_DOMAIN_VALID_SNAPPY`, `topic_len`, `message.topic`, and the snappy decompressed message data,
+  i.e. `SHA256(MESSAGE_DOMAIN_VALID_SNAPPY + topic_len + message.topic + snappy_decompress(message.data))[:20]`.
 - Otherwise, set `message-id` to the first 20 bytes of the `SHA256` hash of
-  the concatenation of `MESSAGE_DOMAIN_INVALID_SNAPPY` with the raw message data,
-  i.e. `SHA256(MESSAGE_DOMAIN_INVALID_SNAPPY + message.data)[:20]`.
+  the concatenation of `MESSAGE_DOMAIN_INVALID_SNAPPY`, `topic_len`, `message.topic`, and the raw message data,
+  i.e. `SHA256(MESSAGE_DOMAIN_INVALID_SNAPPY + topic_len + message.topic + message.data)[:20]`.
 
 #### Heartbeat and parameters
 


### PR DESCRIPTION
## Summary
- bind gossipsub message IDs to the topic using the OP Stack preimage shape: domain || topic_len_le || topic || payload
- preserve the existing Snappy decoded-size guard and valid/invalid Snappy domains
- add a regression test that byte-identical payloads on V3 and V4 block topics produce different message IDs

## Context
The relevant op-node implementation is `op-node/p2p/gossip.go::BuildMsgIdFn`, which includes the topic length and topic before hashing the payload. Without topic binding, libp2p-gossipsub duplicate-cache entries can collide across Base block-version topics.

## Test Plan
- `cargo test --package base-consensus-gossip --lib`
- `cargo clippy --package base-consensus-gossip --all-targets -- -D warnings`