### PR TITLE
fix(consensus): reject invalid eip1559 params

### DIFF
--- a/crates/common/consensus/src/extra/mod.rs
+++ b/crates/common/consensus/src/extra/mod.rs
@@ -26,6 +26,9 @@ pub enum EIP1559ParamError {
     /// Extra data is not the correct length.
     #[error("Extra data is not the correct length")]
     InvalidExtraDataLength,
+    /// Invalid EIP-1559 parameter combination.
+    #[error("EIP-1559 denominator and elasticity must both be zero or both be non-zero")]
+    InvalidParams,
     /// Minimum base fee must be None before Jovian.
     #[error("Minimum base fee must be None before Jovian")]
     MinBaseFeeMustBeNone,

--- a/crates/execution/chainspec/src/basefee.rs
+++ b/crates/execution/chainspec/src/basefee.rs
@@ -8,6 +8,21 @@ use base_common_chains::Upgrades;
 use base_common_consensus::{EIP1559ParamError, HoloceneExtraData, JovianExtraData};
 use reth_chainspec::{BaseFeeParams, EthChainSpec};
 
+fn base_fee_params_from_extra_data(
+    chain_spec: impl EthChainSpec,
+    timestamp: u64,
+    elasticity: u32,
+    denominator: u32,
+) -> Result<BaseFeeParams, EIP1559ParamError> {
+    if elasticity == 0 && denominator == 0 {
+        Ok(chain_spec.base_fee_params_at_timestamp(timestamp))
+    } else if elasticity == 0 || denominator == 0 {
+        Err(EIP1559ParamError::InvalidParams)
+    } else {
+        Ok(BaseFeeParams::new(denominator as u128, elasticity as u128))
+    }
+}
+
 /// Extracts the Holocene EIP-1559 parameters from the encoded extra data from the parent header.
 ///
 /// Caution: Caller must ensure that holocene is active in the parent header.
@@ -23,11 +38,8 @@ where
 {
     let (elasticity, denominator) = HoloceneExtraData::decode(parent.extra_data())?;
 
-    let base_fee_params = if elasticity == 0 && denominator == 0 {
-        chain_spec.base_fee_params_at_timestamp(timestamp)
-    } else {
-        BaseFeeParams::new(denominator as u128, elasticity as u128)
-    };
+    let base_fee_params =
+        base_fee_params_from_extra_data(chain_spec, timestamp, elasticity, denominator)?;
 
     Ok(parent.next_block_base_fee(base_fee_params).unwrap_or_default())
 }
@@ -50,11 +62,8 @@ where
 {
     let (elasticity, denominator, min_base_fee) = JovianExtraData::decode(parent.extra_data())?;
 
-    let base_fee_params = if elasticity == 0 && denominator == 0 {
-        chain_spec.base_fee_params_at_timestamp(timestamp)
-    } else {
-        BaseFeeParams::new(denominator as u128, elasticity as u128)
-    };
+    let base_fee_params =
+        base_fee_params_from_extra_data(chain_spec, timestamp, elasticity, denominator)?;
 
     // Starting from Jovian, we use the maximum of the gas used and the blob gas used to calculate
     // the next base fee.
@@ -78,6 +87,7 @@ where
 mod tests {
     use alloc::sync::Arc;
 
+    use alloy_primitives::Bytes;
     use base_common_chains::BaseUpgrade;
     use base_common_consensus::JovianExtraData;
     use reth_chainspec::{ChainSpec, ForkCondition, Hardfork};
@@ -193,6 +203,34 @@ mod tests {
         assert_eq!(
             expected_base_fee,
             compute_jovian_base_fee(chain_spec, &parent, timestamp).unwrap()
+        );
+    }
+
+    #[test]
+    fn test_next_base_fee_jovian_rejects_zero_elasticity_with_nonzero_denominator() {
+        let chain_spec = get_chainspec();
+        let mut parent = chain_spec.genesis_header().clone();
+
+        parent.extra_data =
+            Bytes::copy_from_slice(&[1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]);
+
+        assert_eq!(
+            EIP1559ParamError::InvalidParams,
+            compute_jovian_base_fee(chain_spec, &parent, JOVIAN_TIMESTAMP).unwrap_err()
+        );
+    }
+
+    #[test]
+    fn test_next_base_fee_jovian_rejects_zero_denominator_with_nonzero_elasticity() {
+        let chain_spec = get_chainspec();
+        let mut parent = chain_spec.genesis_header().clone();
+
+        parent.extra_data =
+            Bytes::copy_from_slice(&[1, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0]);
+
+        assert_eq!(
+            EIP1559ParamError::InvalidParams,
+            compute_jovian_base_fee(chain_spec, &parent, JOVIAN_TIMESTAMP).unwrap_err()
         );
     }
 }


### PR DESCRIPTION
## Summary
- reject mixed-zero Holocene/Jovian EIP-1559 header params at the base-fee computation boundary before constructing `BaseFeeParams`
- preserve the existing `(0,0)` fallback to chain-spec base-fee params
- leave `HoloceneExtraData`/`JovianExtraData` decoding, payload validation, header validation, and consolidation behavior unchanged
- add Jovian regression coverage for the two mixed-zero cases that could otherwise reach `calc_next_block_base_fee` with a zero elasticity multiplier

## Testing
- `git diff --check`
- `cargo fmt --check`
- `cargo test -p base-execution-chainspec basefee`
- `cargo test -p base-execution-consensus get_base_fee`
- `cargo clippy -p base-execution-chainspec --all-targets -- -D warnings`