### PR TITLE
fix(batcher): reserve blob derivation prefix in frame budget

### DIFF
--- a/bin/batcher/src/cli.rs
+++ b/bin/batcher/src/cli.rs
@@ -267,9 +267,15 @@ pub(crate) struct BatcherArgs {
 impl BatcherArgs {
     /// Convert CLI arguments into a [`BatcherConfig`].
     fn into_config(self) -> eyre::Result<BatcherConfig> {
+        let frame_size = match self.da_type {
+            base_batcher_encoder::DaType::Blob => self
+                .target_frame_size
+                .saturating_sub(base_batcher_encoder::EncoderConfig::BLOB_DERIVATION_PREFIX_SIZE),
+            base_batcher_encoder::DaType::Calldata => self.target_frame_size,
+        };
         let encoder_config = base_batcher_encoder::EncoderConfig {
-            target_frame_size: self.target_frame_size,
-            max_frame_size: self.target_frame_size,
+            target_frame_size: frame_size,
+            max_frame_size: frame_size,
             max_channel_duration: self.max_channel_duration,
             sub_safety_margin: self.sub_safety_margin,
             target_num_frames: self.target_num_frames,
@@ -394,11 +400,42 @@ mod tests {
     }
 
     #[test]
+    fn into_config_reserves_blob_derivation_prefix_from_target_frame_size() {
+        let cli = parse_cli(&[]);
+        let config = cli.args.into_config().expect("config should build");
+
+        assert_eq!(
+            config.encoder_config.target_frame_size,
+            base_batcher_encoder::EncoderConfig::MAX_BLOB_FRAME_SIZE
+        );
+        assert_eq!(config.encoder_config.max_frame_size, config.encoder_config.target_frame_size);
+    }
+
+    #[test]
+    fn into_config_reserves_blob_prefix_for_explicit_target_frame_size() {
+        let cli = parse_cli(&["--target-frame-size", "130000"]);
+        let config = cli.args.into_config().expect("config should build");
+
+        assert_eq!(config.encoder_config.target_frame_size, 129_999);
+        assert_eq!(config.encoder_config.max_frame_size, 129_999);
+    }
+
+    #[test]
     fn into_config_accepts_calldata_da_mode() {
         let cli = parse_cli(&["--data-availability-type", "calldata"]);
         let config = cli.args.into_config().expect("config should build");
 
         assert_eq!(config.encoder_config.da_type, base_batcher_encoder::DaType::Calldata);
+    }
+
+    #[test]
+    fn into_config_does_not_reserve_blob_prefix_for_calldata_da_mode() {
+        let cli =
+            parse_cli(&["--data-availability-type", "calldata", "--target-frame-size", "130000"]);
+        let config = cli.args.into_config().expect("config should build");
+
+        assert_eq!(config.encoder_config.target_frame_size, 130_000);
+        assert_eq!(config.encoder_config.max_frame_size, 130_000);
     }
 
     #[test]

--- a/crates/batcher/blobs/src/encoder.rs
+++ b/crates/batcher/blobs/src/encoder.rs
@@ -3,7 +3,9 @@
 use std::sync::Arc;
 
 use alloy_eips::eip4844::{BYTES_PER_BLOB, Blob, VERSIONED_HASH_VERSION_KZG};
-use base_protocol::{DERIVATION_VERSION_0, Frame};
+use base_protocol::{
+    BLOB_MAX_DATA_SIZE as PROTOCOL_BLOB_MAX_DATA_SIZE, DERIVATION_VERSION_0, Frame,
+};
 
 /// Errors returned by [`BlobEncoder::encode`].
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
@@ -33,7 +35,7 @@ impl BlobEncoder {
     /// bytes (4 x 31 payload bytes + 3 reassembled bytes). With 1024 rounds that
     /// gives `127 * 1024 = 130_048` bytes, minus 4 bytes for the version +
     /// 3-byte length header in field element 0.
-    pub const BLOB_MAX_DATA_SIZE: usize = (4 * 31 + 3) * 1024 - 4; // 130_044
+    pub const BLOB_MAX_DATA_SIZE: usize = PROTOCOL_BLOB_MAX_DATA_SIZE;
 
     /// Number of encoding rounds (one per group of 4 field elements).
     pub const BLOB_ENCODING_ROUNDS: usize = 1024;

--- a/crates/batcher/encoder/src/config.rs
+++ b/crates/batcher/encoder/src/config.rs
@@ -1,7 +1,11 @@
 //! Encoder configuration and its validation error type.
 
 use base_common_genesis::RollupConfig;
-use base_protocol::BatchType;
+use base_protocol::{
+    BLOB_DERIVATION_PREFIX_SIZE as PROTOCOL_BLOB_DERIVATION_PREFIX_SIZE,
+    BLOB_MAX_DATA_SIZE as PROTOCOL_BLOB_MAX_DATA_SIZE, BatchType,
+    MAX_BLOB_FRAME_SIZE as PROTOCOL_MAX_BLOB_FRAME_SIZE,
+};
 
 use crate::DaType;
 
@@ -9,13 +13,13 @@ use crate::DaType;
 #[derive(Debug, Clone)]
 pub struct EncoderConfig {
     /// Target compressed output size per channel. Drives `ShadowCompressor` closure.
-    /// Default: 130,044 bytes (`BLOB_MAX_DATA_SIZE`).
+    /// Default: 130,043 bytes (`MAX_BLOB_FRAME_SIZE`).
     pub target_frame_size: usize,
 
     /// Maximum byte size of each output frame when draining a closed channel.
     ///
-    /// Defaults to `target_frame_size`. Set smaller to force multi-frame output
-    /// (e.g. in tests that exercise partial-channel submission and channel timeouts).
+    /// Set smaller to force multi-frame output (e.g. in tests that exercise
+    /// partial-channel submission and channel timeouts).
     pub max_frame_size: usize,
 
     /// Maximum L1 blocks a channel may stay open.
@@ -94,8 +98,8 @@ pub struct EncoderConfig {
 impl Default for EncoderConfig {
     fn default() -> Self {
         Self {
-            target_frame_size: 130_044,
-            max_frame_size: 130_044,
+            target_frame_size: Self::MAX_BLOB_FRAME_SIZE,
+            max_frame_size: Self::MAX_BLOB_FRAME_SIZE,
             max_channel_duration: 2,
             sub_safety_margin: 0,
             target_num_frames: 1,
@@ -108,6 +112,16 @@ impl Default for EncoderConfig {
 }
 
 impl EncoderConfig {
+    /// Maximum number of bytes that can be encoded into one blob payload.
+    pub const BLOB_MAX_DATA_SIZE: usize = PROTOCOL_BLOB_MAX_DATA_SIZE;
+
+    /// Size of the derivation-version prefix prepended to each blob payload.
+    pub const BLOB_DERIVATION_PREFIX_SIZE: usize = PROTOCOL_BLOB_DERIVATION_PREFIX_SIZE;
+
+    /// Largest serialized frame that can fit in one blob after reserving the
+    /// derivation-version prefix.
+    pub const MAX_BLOB_FRAME_SIZE: usize = PROTOCOL_MAX_BLOB_FRAME_SIZE;
+
     /// Validate the configuration, returning an error if any constraint is violated.
     ///
     /// This should be called at service startup before constructing a
@@ -124,6 +138,20 @@ impl EncoderConfig {
         if matches!(self.da_type, DaType::Calldata) && self.target_num_frames != 1 {
             return Err(EncoderConfigError::CalldataRequiresSingleFrame {
                 target_num_frames: self.target_num_frames,
+            });
+        }
+        if matches!(self.da_type, DaType::Blob) && self.max_frame_size > Self::MAX_BLOB_FRAME_SIZE {
+            return Err(EncoderConfigError::BlobFrameSizeTooLarge {
+                max_frame_size: self.max_frame_size,
+                max_blob_frame_size: Self::MAX_BLOB_FRAME_SIZE,
+            });
+        }
+        if matches!(self.da_type, DaType::Blob)
+            && self.target_frame_size > Self::MAX_BLOB_FRAME_SIZE
+        {
+            return Err(EncoderConfigError::BlobTargetFrameSizeTooLarge {
+                target_frame_size: self.target_frame_size,
+                max_blob_frame_size: Self::MAX_BLOB_FRAME_SIZE,
             });
         }
         if self.approx_compr_ratio <= 0.0 || self.approx_compr_ratio > 1.0 {
@@ -188,6 +216,30 @@ pub enum EncoderConfigError {
         /// The configured target number of frames.
         target_num_frames: usize,
     },
+    /// `da_type == DaType::Blob` but `max_frame_size` leaves no room for the
+    /// derivation-version prefix.
+    #[error(
+        "blob DA max_frame_size ({max_frame_size}) must be at most \
+         {max_blob_frame_size} to leave room for the derivation-version prefix"
+    )]
+    BlobFrameSizeTooLarge {
+        /// The configured maximum frame size.
+        max_frame_size: usize,
+        /// The maximum frame size that leaves room for the derivation-version prefix.
+        max_blob_frame_size: usize,
+    },
+    /// `da_type == DaType::Blob` but `target_frame_size` leaves no room for the
+    /// derivation-version prefix.
+    #[error(
+        "blob DA target_frame_size ({target_frame_size}) must be at most \
+         {max_blob_frame_size} to leave room for the derivation-version prefix"
+    )]
+    BlobTargetFrameSizeTooLarge {
+        /// The configured target frame size.
+        target_frame_size: usize,
+        /// The maximum frame size that leaves room for the derivation-version prefix.
+        max_blob_frame_size: usize,
+    },
     /// `approx_compr_ratio <= 0.0 || approx_compr_ratio > 1.0`.
     ///
     /// A ratio ≤ 0.0 causes `compressed_estimate` to always be 0, so the span
@@ -234,6 +286,18 @@ mod tests {
         EncoderConfig { sub_safety_margin, max_channel_duration, ..EncoderConfig::default() }
     }
 
+    #[test]
+    fn default_blob_max_frame_size_reserves_derivation_prefix() {
+        let cfg = EncoderConfig::default();
+
+        assert_eq!(cfg.target_frame_size, EncoderConfig::MAX_BLOB_FRAME_SIZE);
+        assert_eq!(cfg.max_frame_size, EncoderConfig::MAX_BLOB_FRAME_SIZE);
+        assert_eq!(
+            cfg.max_frame_size + EncoderConfig::BLOB_DERIVATION_PREFIX_SIZE,
+            EncoderConfig::BLOB_MAX_DATA_SIZE
+        );
+    }
+
     #[rstest]
     #[case(0, 2)] // zero margin: always valid
     #[case(1, 2)] // one below duration
@@ -259,6 +323,56 @@ mod tests {
         let msg = err.to_string();
         assert!(msg.contains(&sub_safety_margin.to_string()));
         assert!(msg.contains(&max_channel_duration.to_string()));
+    }
+
+    #[test]
+    fn validate_rejects_blob_frame_size_that_leaves_no_prefix_room() {
+        let cfg = EncoderConfig {
+            max_frame_size: EncoderConfig::BLOB_MAX_DATA_SIZE,
+            ..EncoderConfig::default()
+        };
+
+        let err = cfg.validate().unwrap_err();
+        assert!(matches!(
+            err,
+            EncoderConfigError::BlobFrameSizeTooLarge {
+                max_frame_size,
+                max_blob_frame_size,
+            } if max_frame_size == EncoderConfig::BLOB_MAX_DATA_SIZE
+                && max_blob_frame_size == EncoderConfig::MAX_BLOB_FRAME_SIZE
+        ));
+        assert!(err.to_string().contains("derivation-version prefix"));
+    }
+
+    #[test]
+    fn validate_rejects_blob_target_frame_size_that_leaves_no_prefix_room() {
+        let cfg = EncoderConfig {
+            target_frame_size: EncoderConfig::BLOB_MAX_DATA_SIZE,
+            ..EncoderConfig::default()
+        };
+
+        let err = cfg.validate().unwrap_err();
+        assert!(matches!(
+            err,
+            EncoderConfigError::BlobTargetFrameSizeTooLarge {
+                target_frame_size,
+                max_blob_frame_size,
+            } if target_frame_size == EncoderConfig::BLOB_MAX_DATA_SIZE
+                && max_blob_frame_size == EncoderConfig::MAX_BLOB_FRAME_SIZE
+        ));
+        assert!(err.to_string().contains("target_frame_size"));
+    }
+
+    #[test]
+    fn validate_allows_calldata_frame_size_without_blob_prefix_room() {
+        let cfg = EncoderConfig {
+            da_type: DaType::Calldata,
+            target_frame_size: EncoderConfig::BLOB_MAX_DATA_SIZE,
+            max_frame_size: EncoderConfig::BLOB_MAX_DATA_SIZE,
+            ..EncoderConfig::default()
+        };
+
+        assert!(cfg.validate().is_ok());
     }
 
     #[rstest]

--- a/crates/batcher/encoder/src/encoder.rs
+++ b/crates/batcher/encoder/src/encoder.rs
@@ -987,7 +987,7 @@ mod tests {
     fn test_da_backlog_counts_span_blocks_before_flush() {
         let config = EncoderConfig {
             batch_type: BatchType::Span,
-            target_frame_size: 130_044,
+            target_frame_size: EncoderConfig::MAX_BLOB_FRAME_SIZE,
             max_channel_duration: 1000,
             ..EncoderConfig::default()
         };
@@ -1372,7 +1372,7 @@ mod tests {
         let config = EncoderConfig {
             batch_type: BatchType::Span,
             target_frame_size: 1,
-            max_frame_size: 130_044,
+            max_frame_size: EncoderConfig::MAX_BLOB_FRAME_SIZE,
             ..EncoderConfig::default()
         };
         BatchEncoder::new(Arc::new(RollupConfig::default()), config)
@@ -1385,7 +1385,7 @@ mod tests {
     fn test_span_batch_accumulates_blocks_without_channel() {
         let config = EncoderConfig {
             batch_type: BatchType::Span,
-            target_frame_size: 130_044, // large: size won't trigger
+            target_frame_size: EncoderConfig::MAX_BLOB_FRAME_SIZE, // large: size won't trigger
             max_channel_duration: 1000,
             ..EncoderConfig::default()
         };
@@ -1452,8 +1452,8 @@ mod tests {
         });
         let config = EncoderConfig {
             batch_type: BatchType::Span,
-            target_frame_size: 130_044,
-            max_frame_size: 130_044,
+            target_frame_size: EncoderConfig::MAX_BLOB_FRAME_SIZE,
+            max_frame_size: EncoderConfig::MAX_BLOB_FRAME_SIZE,
             max_channel_duration: 1000,
             ..EncoderConfig::default()
         };
@@ -1500,8 +1500,8 @@ mod tests {
     ) {
         let config = EncoderConfig {
             batch_type: BatchType::Span,
-            target_frame_size: 130_044, // large: size won't trigger
-            max_frame_size: 130_044,
+            target_frame_size: EncoderConfig::MAX_BLOB_FRAME_SIZE, // large: size won't trigger
+            max_frame_size: EncoderConfig::MAX_BLOB_FRAME_SIZE,
             max_channel_duration,
             sub_safety_margin,
             ..EncoderConfig::default()
@@ -1556,7 +1556,7 @@ mod tests {
     fn test_span_batch_reset_clears_span_state() {
         let config = EncoderConfig {
             batch_type: BatchType::Span,
-            target_frame_size: 130_044, // large: size won't trigger
+            target_frame_size: EncoderConfig::MAX_BLOB_FRAME_SIZE, // large: size won't trigger
             max_channel_duration: 1000,
             ..EncoderConfig::default()
         };

--- a/crates/consensus/derive/src/sources/blob_data.rs
+++ b/crates/consensus/derive/src/sources/blob_data.rs
@@ -4,14 +4,12 @@ use alloc::{boxed::Box, vec};
 
 use alloy_eips::eip4844::{BYTES_PER_BLOB, Blob, VERSIONED_HASH_VERSION_KZG};
 use alloy_primitives::Bytes;
+pub use base_protocol::BLOB_MAX_DATA_SIZE;
 
 use crate::{BlobDecodingError, BlobProviderError};
 
 /// The blob encoding version
 pub const BLOB_ENCODING_VERSION: u8 = 0;
-
-/// Maximum blob data size
-pub const BLOB_MAX_DATA_SIZE: usize = (4 * 31 + 3) * 1024 - 4; // 130044
 
 /// Blob Encoding/Decoding Rounds
 pub const BLOB_ENCODING_ROUNDS: usize = 1024;

--- a/crates/consensus/protocol/src/frame.rs
+++ b/crates/consensus/protocol/src/frame.rs
@@ -37,6 +37,20 @@ use crate::ChannelId;
 /// ensure compatibility and enable future protocol upgrades.
 pub const DERIVATION_VERSION_0: u8 = 0;
 
+/// Maximum number of derivation payload bytes that fit in a single EIP-4844 blob.
+///
+/// The blob codec packs 127 data bytes into every 128 blob bytes across 1024
+/// rounds, then reserves 4 bytes for the blob encoding version and length
+/// header.
+pub const BLOB_MAX_DATA_SIZE: usize = (4 * 31 + 3) * 1024 - 4;
+
+/// Size of the derivation-version byte prepended to each blob payload.
+pub const BLOB_DERIVATION_PREFIX_SIZE: usize = 1;
+
+/// Largest serialized frame that can fit in one blob after reserving the
+/// derivation-version prefix.
+pub const MAX_BLOB_FRAME_SIZE: usize = BLOB_MAX_DATA_SIZE - BLOB_DERIVATION_PREFIX_SIZE;
+
 /// A frame decoding error.
 #[derive(Debug, thiserror::Error, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum FrameDecodingError {

--- a/crates/consensus/protocol/src/lib.rs
+++ b/crates/consensus/protocol/src/lib.rs
@@ -33,7 +33,10 @@ mod block;
 pub use block::{BlockInfo, FromBlockError, L2BlockInfo};
 
 mod frame;
-pub use frame::{DERIVATION_VERSION_0, Frame, FrameDecodingError, FrameParseError};
+pub use frame::{
+    BLOB_DERIVATION_PREFIX_SIZE, BLOB_MAX_DATA_SIZE, DERIVATION_VERSION_0, Frame,
+    FrameDecodingError, FrameParseError, MAX_BLOB_FRAME_SIZE,
+};
 
 mod utils;
 pub use utils::{read_tx_data, to_system_config};


### PR DESCRIPTION
## Summary
- reserve one byte of blob frame budget for the derivation-version prefix before frames are emitted
- reject blob encoder configs whose max frame size cannot fit in a blob after the prefix
- keep calldata frame sizing unchanged

## Context
`BlobEncoder::encode_packed` prepends `DERIVATION_VERSION_0` before encoded frames. With a `130_044` max frame size, a full serialized frame can produce `1 + 130_044 = 130_045` bytes, exceeding `BlobEncoder::BLOB_MAX_DATA_SIZE`.

This mirrors the equivalent op-batcher sizing behavior. In `ethereum-optimism/optimism@abe047afc995e0e22abf5ea9b157e267e907d494`, blob mode sets `MaxFrameSize = eth.MaxBlobDataSize - 1`, then `txData.Blobs()` prepends `DerivationVersion0` before calling `eth.Blob.FromData`, whose max input is `MaxBlobDataSize`.

Relevant op-batcher references:
- https://github.com/ethereum-optimism/optimism/blob/abe047afc995e0e22abf5ea9b157e267e907d494/op-batcher/batcher/service.go#L275-L280
- https://github.com/ethereum-optimism/optimism/blob/abe047afc995e0e22abf5ea9b157e267e907d494/op-batcher/batcher/tx_data.go#L46-L55
- https://github.com/ethereum-optimism/optimism/blob/abe047afc995e0e22abf5ea9b157e267e907d494/op-service/eth/blob.go#L18-L24
- https://github.com/ethereum-optimism/optimism/blob/abe047afc995e0e22abf5ea9b157e267e907d494/op-service/eth/blob.go#L92-L95

## Tests
- `cargo fmt --check`
- `cargo test -p base-batcher-encoder config::tests`
- `cargo test -p base-batcher-bin cli::tests`
- `cargo test -p base-batcher-encoder`
- `cargo test -p base-batcher-core test_blob_encoding_failure_requeues_submission`