### PR TITLE
feat: improve discovery and p2p stability

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4523,6 +4523,7 @@ dependencies = [
  "alloy-genesis",
  "alloy-network",
  "alloy-primitives",
+ "alloy-rlp",
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
  "base-common-chains",

--- a/crates/execution/cli/src/commands/p2p/bootnode.rs
+++ b/crates/execution/cli/src/commands/p2p/bootnode.rs
@@ -40,7 +40,7 @@ pub struct Command {
     pub v5: bool,
 
     /// Enable the Base discv5 protocol identity.
-    #[arg(long = "v5.base-protocol", default_value_t = false, action = clap::ArgAction::Set)]
+    #[arg(long = "v5.base-protocol", default_value_t = true, action = clap::ArgAction::Set)]
     pub base_protocol: bool,
 }
 

--- a/crates/execution/cli/src/commands/p2p/bootnode.rs
+++ b/crates/execution/cli/src/commands/p2p/bootnode.rs
@@ -2,10 +2,11 @@
 
 use std::{net::SocketAddr, path::PathBuf};
 
+use base_node_core::BASE_V0_PROTOCOL_VERSION;
 use clap::Parser;
 use reth_cli_util::{get_secret_key, load_secret_key::rng_secret_key};
 use reth_discv4::{DiscoveryUpdate, Discv4, Discv4Config};
-use reth_discv5::{Config, Discv5, NetworkStackId, discv5::Event};
+use reth_discv5::{Config, Discv5, discv5::Event};
 use reth_net_nat::{NatResolver, external_addr_with};
 use reth_network_peers::NodeRecord;
 use secp256k1::SecretKey;
@@ -37,6 +38,10 @@ pub struct Command {
     /// Run a discv5 topic discovery bootnode in addition to discv4.
     #[arg(long)]
     pub v5: bool,
+
+    /// Enable the Base discv5 protocol identity.
+    #[arg(long = "v5.base-protocol", default_value_t = false, action = clap::ArgAction::Set)]
+    pub base_protocol: bool,
 }
 
 impl Command {
@@ -62,9 +67,16 @@ impl Command {
         if self.v5 {
             info!("Initializing discv5");
             // exclude eth protocol nodes, we're looking for opel nodes
-            let config = Config::builder(self.v5_addr)
-                .must_not_include_keys(&[NetworkStackId::ETH, NetworkStackId::ETH2])
-                .build();
+            let mut inner_builder = reth_discv5::discv5::ConfigBuilder::new(
+                reth_discv5::DEFAULT_DISCOVERY_V5_LISTEN_CONFIG,
+            );
+            if self.base_protocol {
+                inner_builder.protocol_identity(reth_discv5::discv5::ProtocolIdentity {
+                    protocol_id: BASE_V0_PROTOCOL_VERSION,
+                    ..Default::default()
+                });
+            }
+            let config = Config::builder(self.v5_addr).discv5_config(inner_builder.build()).build();
             let (discv5, updates) = Discv5::start(&sk, config).await?;
 
             // The upstream reth bootnode skips NAT resolution for discv5, leaving the ENR with

--- a/crates/execution/node/Cargo.toml
+++ b/crates/execution/node/Cargo.toml
@@ -12,6 +12,7 @@ workspace = true
 
 [dependencies]
 # reth
+alloy-rlp.workspace = true
 reth-db.workspace = true
 reth-discv5.workspace = true
 reth-evm.workspace = true

--- a/crates/execution/node/src/args.rs
+++ b/crates/execution/node/src/args.rs
@@ -127,6 +127,13 @@ pub struct RollupArgs {
         default_value_t = 0
     )]
     pub proofs_history_verification_interval: u64,
+
+    /// Enable the Base discv5 protocol identity.
+    ///
+    /// When enabled, the node advertises itself with the `basev0` protocol ID in discv5,
+    /// allowing it to find and connect to other Base nodes more efficiently.
+    #[arg(long = "rollup.discovery.v5.base", default_value_t = false, action = clap::ArgAction::Set)]
+    pub base_protocol: bool,
 }
 
 impl Default for RollupArgs {
@@ -144,6 +151,7 @@ impl Default for RollupArgs {
             proofs_history_window: 1_296_000,
             proofs_history_prune_interval: Duration::from_secs(15),
             proofs_history_verification_interval: 0,
+            base_protocol: false,
         }
     }
 }
@@ -251,5 +259,22 @@ mod tests {
         ])
         .args;
         assert_eq!(args.txpool_ordering, TxpoolOrdering::Timestamp);
+    }
+
+    #[test]
+    fn test_parse_base_protocol_default_false() {
+        let args = CommandParser::<RollupArgs>::parse_from(["reth"]).args;
+        assert!(!args.base_protocol);
+    }
+
+    #[test]
+    fn test_parse_base_protocol_disabled() {
+        let args = CommandParser::<RollupArgs>::parse_from([
+            "reth",
+            "--rollup.discovery.v5.base",
+            "false",
+        ])
+        .args;
+        assert!(!args.base_protocol);
     }
 }

--- a/crates/execution/node/src/args.rs
+++ b/crates/execution/node/src/args.rs
@@ -132,7 +132,7 @@ pub struct RollupArgs {
     ///
     /// When enabled, the node advertises itself with the `basev0` protocol ID in discv5,
     /// allowing it to find and connect to other Base nodes more efficiently.
-    #[arg(long = "rollup.discovery.v5.base", default_value_t = false, action = clap::ArgAction::Set)]
+    #[arg(long = "rollup.discovery.v5.base", default_value_t = true, action = clap::ArgAction::Set)]
     pub base_protocol: bool,
 }
 
@@ -151,7 +151,7 @@ impl Default for RollupArgs {
             proofs_history_window: 1_296_000,
             proofs_history_prune_interval: Duration::from_secs(15),
             proofs_history_verification_interval: 0,
-            base_protocol: false,
+            base_protocol: true,
         }
     }
 }
@@ -262,9 +262,9 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_base_protocol_default_false() {
+    fn test_parse_base_protocol_default_true() {
         let args = CommandParser::<RollupArgs>::parse_from(["reth"]).args;
-        assert!(!args.base_protocol);
+        assert!(args.base_protocol);
     }
 
     #[test]

--- a/crates/execution/node/src/node.rs
+++ b/crates/execution/node/src/node.rs
@@ -33,10 +33,7 @@ use base_execution_txpool::{
     BaseTransactionValidator, TimestampedTransaction,
 };
 use reth_chainspec::{BaseFeeParams, ChainSpecProvider, EthChainSpec, Hardforks};
-use reth_discv5::{
-    NetworkStackId,
-    discv5::enr::{IP_ENR_KEY, IP6_ENR_KEY},
-};
+use reth_discv5::discv5::enr::{IP_ENR_KEY, IP6_ENR_KEY};
 use reth_evm::ConfigureEvm;
 use reth_network::{
     NetworkConfig, NetworkHandle, NetworkManager, NetworkPrimitives, PeersInfo,
@@ -77,6 +74,9 @@ use crate::{
     args::{RollupArgs, TxpoolOrdering},
     engine::BaseEngineValidator,
 };
+
+/// Discovery v5 protocol version for Base.
+pub const BASE_V0_PROTOCOL_VERSION: [u8; 6] = *b"basev0";
 
 /// Marker trait for Base node types with standard engine, chain spec, and primitives.
 pub trait BaseNodeTypes:
@@ -241,6 +241,7 @@ impl BaseNode {
             compute_pending_block,
             discovery_v4,
             txpool_ordering,
+            base_protocol,
             ..
         } = self.args;
         let ordering = match txpool_ordering {
@@ -256,7 +257,7 @@ impl BaseNode {
                     .with_da_config(self.da_config.clone())
                     .with_gas_limit_config(self.gas_limit_config.clone()),
             ))
-            .network(BaseNetworkBuilder::new(disable_txpool_gossip, !discovery_v4))
+            .network(BaseNetworkBuilder::new(disable_txpool_gossip, !discovery_v4, base_protocol))
             .consensus(BaseConsensusBuilder::default())
     }
 
@@ -1046,24 +1047,24 @@ where
 }
 
 /// A basic Base network builder.
-#[derive(Debug, Default)]
+#[derive(Debug, Clone, Default)]
 pub struct BaseNetworkBuilder {
     /// Disable transaction pool gossip
     pub disable_txpool_gossip: bool,
     /// Disable discovery v4
     pub disable_discovery_v4: bool,
-}
-
-impl Clone for BaseNetworkBuilder {
-    fn clone(&self) -> Self {
-        Self::new(self.disable_txpool_gossip, self.disable_discovery_v4)
-    }
+    /// Enable the Base discv5 protocol identity
+    pub base_protocol: bool,
 }
 
 impl BaseNetworkBuilder {
     /// Creates a new `BaseNetworkBuilder`.
-    pub const fn new(disable_txpool_gossip: bool, disable_discovery_v4: bool) -> Self {
-        Self { disable_txpool_gossip, disable_discovery_v4 }
+    pub const fn new(
+        disable_txpool_gossip: bool,
+        disable_discovery_v4: bool,
+        base_protocol: bool,
+    ) -> Self {
+        Self { disable_txpool_gossip, disable_discovery_v4, base_protocol }
     }
 }
 
@@ -1089,6 +1090,7 @@ impl BaseNetworkBuilder {
     {
         let disable_txpool_gossip = self.disable_txpool_gossip;
         let disable_discovery_v4 = self.disable_discovery_v4;
+        let base_protocol = self.base_protocol;
         let args = &ctx.config().network;
         let network_builder = ctx
             .network_config_builder()?
@@ -1120,6 +1122,17 @@ impl BaseNetworkBuilder {
 
                     let external_addr = block_on(args.nat.clone().external_addr());
 
+                    let mut discv5_config_builder =
+                        reth_discv5::discv5::ConfigBuilder::new(listen_config);
+                    if base_protocol {
+                        discv5_config_builder.protocol_identity(
+                            reth_discv5::discv5::ProtocolIdentity {
+                                protocol_id: BASE_V0_PROTOCOL_VERSION,
+                                ..Default::default()
+                            },
+                        );
+                    }
+
                     let mut reth_config_builder = args
                         .discovery
                         .discovery_v5_builder(
@@ -1130,10 +1143,7 @@ impl BaseNetworkBuilder {
                                 .or_else(|| ctx.chain_spec().bootnodes())
                                 .unwrap_or_default(),
                         )
-                        .must_not_include_keys(&[NetworkStackId::ETH, NetworkStackId::ETH2])
-                        .discv5_config(
-                            reth_discv5::discv5::ConfigBuilder::new(listen_config).build(),
-                        );
+                        .discv5_config(discv5_config_builder.build());
 
                     reth_config_builder = match external_addr {
                         Some(std::net::IpAddr::V4(addr)) => {

--- a/crates/execution/node/src/node.rs
+++ b/crates/execution/node/src/node.rs
@@ -1047,7 +1047,7 @@ where
 }
 
 /// A basic Base network builder.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 pub struct BaseNetworkBuilder {
     /// Disable transaction pool gossip
     pub disable_txpool_gossip: bool,
@@ -1055,6 +1055,12 @@ pub struct BaseNetworkBuilder {
     pub disable_discovery_v4: bool,
     /// Enable the Base discv5 protocol identity
     pub base_protocol: bool,
+}
+
+impl Default for BaseNetworkBuilder {
+    fn default() -> Self {
+        Self { disable_discovery_v4: false, disable_txpool_gossip: false, base_protocol: true }
+    }
 }
 
 impl BaseNetworkBuilder {

--- a/crates/execution/node/src/node.rs
+++ b/crates/execution/node/src/node.rs
@@ -1,9 +1,14 @@
 //! Base Node types config.
 
-use std::{marker::PhantomData, sync::Arc};
+use std::{
+    marker::PhantomData,
+    net::{SocketAddrV4, SocketAddrV6},
+    sync::Arc,
+};
 
 use alloy_consensus::BlockHeader;
-use alloy_primitives::{Address, B64, B256};
+use alloy_primitives::{Address, B64, B256, Bytes, bytes::BytesMut};
+use alloy_rlp::Encodable;
 use base_common_chains::Upgrades;
 use base_common_consensus::BasePrimitives;
 use base_common_rpc_types_engine::{BasePayloadAttributes, ExecutionData};
@@ -28,7 +33,10 @@ use base_execution_txpool::{
     BaseTransactionValidator, TimestampedTransaction,
 };
 use reth_chainspec::{BaseFeeParams, ChainSpecProvider, EthChainSpec, Hardforks};
-use reth_discv5::NetworkStackId;
+use reth_discv5::{
+    NetworkStackId,
+    discv5::enr::{IP_ENR_KEY, IP6_ENR_KEY},
+};
 use reth_evm::ConfigureEvm;
 use reth_network::{
     NetworkConfig, NetworkHandle, NetworkManager, NetworkPrimitives, PeersInfo,
@@ -1059,6 +1067,14 @@ impl BaseNetworkBuilder {
     }
 }
 
+fn block_on<T>(f: impl Future<Output = T>) -> T {
+    if let Ok(runtime) = tokio::runtime::Handle::try_current() {
+        tokio::task::block_in_place(|| runtime.block_on(f))
+    } else {
+        tokio::runtime::Runtime::new().unwrap().block_on(f)
+    }
+}
+
 impl BaseNetworkBuilder {
     /// Returns the [`NetworkConfig`] that contains the settings to launch the p2p network.
     ///
@@ -1083,18 +1099,61 @@ impl BaseNetworkBuilder {
                     builder = builder.disable_discv4_discovery();
                 }
                 if !args.discovery.disable_discovery {
-                    builder = builder.discovery_v5(
-                        args.discovery
-                            .discovery_v5_builder(
-                                rlpx_socket,
-                                ctx.config()
-                                    .network
-                                    .resolved_bootnodes()
-                                    .or_else(|| ctx.chain_spec().bootnodes())
-                                    .unwrap_or_default(),
-                            )
-                            .must_not_include_keys(&[NetworkStackId::ETH, NetworkStackId::ETH2]),
+                    // copied from discovery_v5_builder to override discv5_config
+                    let discv5_addr_ipv4 =
+                        args.discovery.discv5_addr.or_else(|| match rlpx_socket {
+                            std::net::SocketAddr::V4(addr) => Some(*addr.ip()),
+                            std::net::SocketAddr::V6(_) => None,
+                        });
+                    let discv5_addr_ipv6 =
+                        args.discovery.discv5_addr_ipv6.or_else(|| match rlpx_socket {
+                            std::net::SocketAddr::V4(_) => None,
+                            std::net::SocketAddr::V6(addr) => Some(*addr.ip()),
+                        });
+                    let listen_config = reth_discv5::discv5::ListenConfig::from_two_sockets(
+                        discv5_addr_ipv4
+                            .map(|addr| SocketAddrV4::new(addr, args.discovery.discv5_port)),
+                        discv5_addr_ipv6.map(|addr| {
+                            SocketAddrV6::new(addr, args.discovery.discv5_port_ipv6, 0, 0)
+                        }),
                     );
+
+                    let external_addr = block_on(args.nat.clone().external_addr());
+
+                    let mut reth_config_builder = args
+                        .discovery
+                        .discovery_v5_builder(
+                            rlpx_socket,
+                            ctx.config()
+                                .network
+                                .resolved_bootnodes()
+                                .or_else(|| ctx.chain_spec().bootnodes())
+                                .unwrap_or_default(),
+                        )
+                        .must_not_include_keys(&[NetworkStackId::ETH, NetworkStackId::ETH2])
+                        .discv5_config(
+                            reth_discv5::discv5::ConfigBuilder::new(listen_config).build(),
+                        );
+
+                    reth_config_builder = match external_addr {
+                        Some(std::net::IpAddr::V4(addr)) => {
+                            let addr = addr.octets();
+                            let mut out = BytesMut::with_capacity(addr.length());
+                            addr.encode(&mut out);
+                            reth_config_builder
+                                .add_enr_kv_pair(IP_ENR_KEY, Bytes::from(out.freeze()))
+                        }
+                        Some(std::net::IpAddr::V6(addr)) => {
+                            let addr = addr.octets();
+                            let mut out = BytesMut::with_capacity(addr.length());
+                            addr.encode(&mut out);
+                            reth_config_builder
+                                .add_enr_kv_pair(IP6_ENR_KEY, Bytes::from(out.freeze()))
+                        }
+                        _ => reth_config_builder,
+                    };
+
+                    builder = builder.discovery_v5(reth_config_builder);
                 }
 
                 builder

--- a/crates/execution/node/tests/it/custom_genesis.rs
+++ b/crates/execution/node/tests/it/custom_genesis.rs
@@ -19,7 +19,7 @@ use reth_stages_types::StageId;
 use tokio::sync::Mutex;
 
 /// Tests that a Base node can initialize with a custom genesis block number.
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_op_node_custom_genesis_number() {
     reth_tracing::init_test_tracing();
 

--- a/crates/execution/node/tests/it/priority.rs
+++ b/crates/execution/node/tests/it/priority.rs
@@ -107,7 +107,7 @@ where
         .consensus(BaseConsensusBuilder::default())
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_custom_block_priority_config() {
     reth_tracing::init_test_tracing();
 

--- a/crates/execution/node/tests/it/priority.rs
+++ b/crates/execution/node/tests/it/priority.rs
@@ -93,8 +93,13 @@ fn build_components<Node>(
 where
     Node: FullNodeTypes<Types: BaseNodeTypes>,
 {
-    let RollupArgs { disable_txpool_gossip, compute_pending_block, discovery_v4, .. } =
-        RollupArgs::default();
+    let RollupArgs {
+        disable_txpool_gossip,
+        compute_pending_block,
+        discovery_v4,
+        base_protocol,
+        ..
+    } = RollupArgs::default();
     ComponentsBuilder::default()
         .node_types::<Node>()
         .pool(BasePoolBuilder::default())
@@ -103,7 +108,7 @@ where
             BasePayloadBuilder::new(compute_pending_block)
                 .with_transactions(CustomTxPriority { chain_id }),
         ))
-        .network(BaseNetworkBuilder::new(disable_txpool_gossip, !discovery_v4))
+        .network(BaseNetworkBuilder::new(disable_txpool_gossip, !discovery_v4, base_protocol))
         .consensus(BaseConsensusBuilder::default())
 }
 

--- a/crates/execution/node/tests/it/rpc.rs
+++ b/crates/execution/node/tests/it/rpc.rs
@@ -12,7 +12,7 @@ use reth_rpc_api::servers::AdminApiServer;
 use reth_tasks::Runtime;
 
 // <https://github.com/paradigmxyz/reth/issues/19765>
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_admin_external_ip() -> eyre::Result<()> {
     reth_tracing::init_test_tracing();
 

--- a/crates/execution/runner/src/node.rs
+++ b/crates/execution/runner/src/node.rs
@@ -68,8 +68,13 @@ impl BaseNode {
     where
         Node: FullNodeTypes<Types: BaseNodeTypes>,
     {
-        let RollupArgs { disable_txpool_gossip, compute_pending_block, discovery_v4, .. } =
-            self.args;
+        let RollupArgs {
+            disable_txpool_gossip,
+            compute_pending_block,
+            discovery_v4,
+            base_protocol,
+            ..
+        } = self.args;
         ComponentsBuilder::default()
             .node_types::<Node>()
             .pool(BasePoolBuilder::default())
@@ -79,7 +84,7 @@ impl BaseNode {
                     .with_da_config(self.da_config.clone())
                     .with_gas_limit_config(self.gas_limit_config.clone()),
             ))
-            .network(BaseNetworkBuilder::new(disable_txpool_gossip, !discovery_v4))
+            .network(BaseNetworkBuilder::new(disable_txpool_gossip, !discovery_v4, base_protocol))
             .consensus(BaseConsensusBuilder::default())
     }
 


### PR DESCRIPTION
- ensure the Base EL node ENR contains the node's IP address when extip is used
- add flag for using `basev0` discovery protocol separated from existing `discv5` discovery network
- default flag to true