### PR TITLE
chore(p2p): Refactor & Test Bootnode Discovery Configs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3973,6 +3973,7 @@ dependencies = [
  "reth-provider",
  "reth-rpc-server-types",
  "reth-tracing",
+ "rstest",
  "secp256k1 0.30.0",
  "tempfile",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3973,7 +3973,6 @@ dependencies = [
  "reth-provider",
  "reth-rpc-server-types",
  "reth-tracing",
- "rstest",
  "secp256k1 0.30.0",
  "tempfile",
  "tokio",

--- a/crates/execution/cli/Cargo.toml
+++ b/crates/execution/cli/Cargo.toml
@@ -57,6 +57,7 @@ proptest = { workspace = true, optional = true }
 base-common-consensus = { workspace = true, features = ["reth"] }
 
 [dev-dependencies]
+rstest.workspace = true
 tempfile.workspace = true
 
 [build-dependencies]

--- a/crates/execution/cli/Cargo.toml
+++ b/crates/execution/cli/Cargo.toml
@@ -57,7 +57,6 @@ proptest = { workspace = true, optional = true }
 base-common-consensus = { workspace = true, features = ["reth"] }
 
 [dev-dependencies]
-rstest.workspace = true
 tempfile.workspace = true
 
 [build-dependencies]

--- a/crates/execution/cli/src/commands/p2p/bootnode.rs
+++ b/crates/execution/cli/src/commands/p2p/bootnode.rs
@@ -7,7 +7,7 @@ use clap::Parser;
 use reth_cli_util::{get_secret_key, load_secret_key::rng_secret_key};
 use reth_discv4::{DiscoveryUpdate, Discv4, Discv4Config};
 use reth_discv5::{
-    Config, DEFAULT_DISCOVERY_V5_LISTEN_CONFIG, DEFAULT_DISCOVERY_V5_PORT, Discv5,
+    Config, DEFAULT_DISCOVERY_V5_LISTEN_CONFIG, Discv5,
     discv5::{ConfigBuilder as Discv5ConfigBuilder, Event, ProtocolIdentity},
 };
 use reth_net_nat::{NatResolver, external_addr_with};
@@ -164,6 +164,7 @@ impl Command {
 
 #[cfg(test)]
 mod tests {
+    use reth_discv5::DEFAULT_DISCOVERY_V5_PORT;
     use rstest::rstest;
 
     use super::*;

--- a/crates/execution/cli/src/commands/p2p/bootnode.rs
+++ b/crates/execution/cli/src/commands/p2p/bootnode.rs
@@ -20,12 +20,11 @@ use tracing::{info, warn};
 /// Start a discovery-only bootnode.
 #[derive(Parser, Debug)]
 pub struct Command {
-    /// Listen address for discv4.
+    /// Listen address for the bootnode for discv4
     #[arg(long, default_value = "0.0.0.0:30301")]
     pub v4_addr: SocketAddr,
 
-    /// UDP listen address for discv5 (only used with --v5).
-    /// Must differ from --v4-addr since discv5 binds its own socket exclusively.
+    /// Listen address for the bootnode for discv5
     #[arg(long, default_value = "0.0.0.0:9200")]
     pub v5_addr: SocketAddr,
 
@@ -51,44 +50,45 @@ pub struct Command {
 impl Command {
     /// Execute the bootnode command.
     pub async fn execute(self) -> eyre::Result<()> {
-        info!(v4_addr = %self.v4_addr, v5_addr = %self.v5_addr, nat = %self.nat, v5 = %self.v5, "Bootnode starting");
+        info!(v4_addr = %self.v4_addr, v5_addr = %self.v5_addr, nat = %self.nat, v5 = self.v5, "Bootnode starting");
 
-        let v4_addr = self.v4_addr;
-        let v5_addr = self.v5_addr;
+        // discv4
         let sk = self.network_secret()?;
-        let local_enr = NodeRecord::from_secret_key(v4_addr, &sk);
-        let discv4_config = self.discv4_config();
-        let discv5_config = self.v5.then(|| self.discv5_config());
-        let nat = self.nat;
+        let v4_node_record = NodeRecord::from_secret_key(self.v4_addr, &sk);
+        let config = self.discv4_config();
+        let nat = self.nat.clone();
         let (_discv4, mut discv4_service) =
-            Discv4::bind(v4_addr, local_enr, sk, discv4_config).await?;
-        info!(enr = ?local_enr, "Started discv4");
+            Discv4::bind(self.v4_addr, v4_node_record, sk, config).await?;
+        info!(v4_node_record = ?v4_node_record, enode = %v4_node_record, "Started discv4");
         let mut discv4_updates = discv4_service.update_stream();
         discv4_service.spawn();
 
+        // discv5
         let mut discv5_updates = None;
         let mut _discv5 = None;
 
-        if let Some(discv5_config) = discv5_config {
-            let (discv5, updates) = Discv5::start(&sk, discv5_config).await?;
+        if self.v5 {
+            info!("Initializing discv5");
+            let config = self.discv5_config();
+            let (discv5, updates) = Discv5::start(&sk, config).await?;
 
             // The upstream reth bootnode skips NAT resolution for discv5, leaving the ENR with
             // no IP address. Peers receiving the ENR cannot send WHOAREYOU back because they
             // have no address to target. Resolve the external IP and update the ENR here.
             match external_addr_with(nat).await {
                 Some(external_ip) => {
-                    let udp_socket = SocketAddr::new(external_ip, v5_addr.port());
-                    discv5.with_discv5(|d| d.update_local_enr_socket(udp_socket, false));
-                    info!(enr = %discv5.local_enr(), "Started discv5");
+                    let socket = SocketAddr::new(external_ip, self.v5_addr.port());
+                    discv5.with_discv5(|d| d.update_local_enr_socket(socket, false));
                 }
                 None => {
                     warn!(
-                        v5_addr = %v5_addr,
+                        addr = %self.v5_addr,
                         "Could not resolve external IP via NAT; discv5 ENR has no IP and may not be reachable"
                     );
-                    info!(enr = %discv5.local_enr(), "Started discv5");
                 }
             }
+
+            info!(enr = %discv5.local_enr(), "Started discv5");
 
             discv5_updates = Some(updates);
             _discv5 = Some(discv5);

--- a/crates/execution/cli/src/commands/p2p/bootnode.rs
+++ b/crates/execution/cli/src/commands/p2p/bootnode.rs
@@ -7,8 +7,8 @@ use clap::Parser;
 use reth_cli_util::{get_secret_key, load_secret_key::rng_secret_key};
 use reth_discv4::{DiscoveryUpdate, Discv4, Discv4Config};
 use reth_discv5::{
-    Config, Discv5,
-    discv5::{ConfigBuilder as Discv5ConfigBuilder, Event, ListenConfig, ProtocolIdentity},
+    Config, DEFAULT_DISCOVERY_V5_LISTEN_CONFIG, Discv5,
+    discv5::{ConfigBuilder as Discv5ConfigBuilder, Event, ProtocolIdentity},
 };
 use reth_net_nat::{NatResolver, external_addr_with};
 use reth_network_peers::NodeRecord;
@@ -140,10 +140,9 @@ impl Command {
         Discv4Config::builder().external_ip_resolver(Some(self.nat.clone())).build()
     }
 
-    /// Build the discv5 configuration with the UDP listen port set from `--v5-addr`.
+    /// Build the discv5 configuration.
     pub fn discv5_config(&self) -> Config {
-        let listen = ListenConfig::from_ip(self.v5_addr.ip(), self.v5_addr.port());
-        let mut inner_builder = Discv5ConfigBuilder::new(listen);
+        let mut inner_builder = Discv5ConfigBuilder::new(DEFAULT_DISCOVERY_V5_LISTEN_CONFIG);
 
         if self.base_protocol {
             inner_builder.protocol_identity(ProtocolIdentity {
@@ -165,8 +164,6 @@ impl Command {
 
 #[cfg(test)]
 mod tests {
-    use rstest::rstest;
-
     use super::*;
 
     fn cmd(v4_addr: &str, v5_addr: &str) -> Command {
@@ -178,18 +175,6 @@ mod tests {
             v5: false,
             base_protocol: true,
         }
-    }
-
-    #[rstest]
-    #[case("0.0.0.0:30301", "0.0.0.0:9200")]
-    #[case("0.0.0.0:30303", "0.0.0.0:9000")]
-    #[case("127.0.0.1:10001", "127.0.0.1:10002")]
-    fn discv5_discovery_port_matches_v5_addr(#[case] v4_addr: &str, #[case] v5_addr: &str) {
-        let command = cmd(v4_addr, v5_addr);
-        let discv5_port = command.discv5_config().discovery_socket().port();
-
-        assert_eq!(discv5_port, command.v5_addr.port());
-        assert_ne!(discv5_port, command.v4_addr.port());
     }
 
     #[test]

--- a/crates/execution/cli/src/commands/p2p/bootnode.rs
+++ b/crates/execution/cli/src/commands/p2p/bootnode.rs
@@ -7,7 +7,7 @@ use clap::Parser;
 use reth_cli_util::{get_secret_key, load_secret_key::rng_secret_key};
 use reth_discv4::{DiscoveryUpdate, Discv4, Discv4Config};
 use reth_discv5::{
-    Config, DEFAULT_DISCOVERY_V5_LISTEN_CONFIG, Discv5,
+    Config, DEFAULT_DISCOVERY_V5_LISTEN_CONFIG, DEFAULT_DISCOVERY_V5_PORT, Discv5,
     discv5::{ConfigBuilder as Discv5ConfigBuilder, Event, ProtocolIdentity},
 };
 use reth_net_nat::{NatResolver, external_addr_with};
@@ -164,6 +164,8 @@ impl Command {
 
 #[cfg(test)]
 mod tests {
+    use rstest::rstest;
+
     use super::*;
 
     fn cmd(v4_addr: &str, v5_addr: &str) -> Command {
@@ -178,12 +180,28 @@ mod tests {
     }
 
     #[test]
-    fn discv4_config_builds() {
-        let _config = cmd("0.0.0.0:30301", "0.0.0.0:9200").discv4_config();
+    fn discv4_config_uses_command_nat_resolver() {
+        let mut command = cmd("0.0.0.0:30301", "0.0.0.0:9200");
+        command.nat = NatResolver::ExternalIp("192.0.2.1".parse().unwrap());
+
+        let config = command.discv4_config();
+
+        assert_eq!(config.external_ip_resolver, Some(command.nat));
     }
 
-    #[test]
-    fn discv5_config_builds() {
-        let _config = cmd("0.0.0.0:30301", "0.0.0.0:9200").discv5_config();
+    #[rstest]
+    #[case("0.0.0.0:30301", "0.0.0.0:9200")]
+    #[case("0.0.0.0:30303", "0.0.0.0:9000")]
+    #[case("127.0.0.1:10001", "127.0.0.1:10002")]
+    fn discv5_config_preserves_default_discovery_socket_and_sets_rlpx_socket(
+        #[case] v4_addr: &str,
+        #[case] v5_addr: &str,
+    ) {
+        let command = cmd(v4_addr, v5_addr);
+        let config = command.discv5_config();
+
+        assert_eq!(config.rlpx_socket(), &command.v5_addr);
+        assert_eq!(config.discovery_socket().ip(), command.v5_addr.ip());
+        assert_eq!(config.discovery_socket().port(), DEFAULT_DISCOVERY_V5_PORT);
     }
 }

--- a/crates/execution/cli/src/commands/p2p/bootnode.rs
+++ b/crates/execution/cli/src/commands/p2p/bootnode.rs
@@ -179,14 +179,37 @@ mod tests {
         }
     }
 
-    #[test]
-    fn discv4_config_uses_command_nat_resolver() {
+    #[rstest]
+    #[case(NatResolver::None)]
+    #[case(NatResolver::ExternalIp("192.0.2.1".parse().unwrap()))]
+    fn discv4_config_matches_refactored_builder(#[case] nat: NatResolver) {
         let mut command = cmd("0.0.0.0:30301", "0.0.0.0:9200");
-        command.nat = NatResolver::ExternalIp("192.0.2.1".parse().unwrap());
+        command.nat = nat;
 
-        let config = command.discv4_config();
+        let actual = command.discv4_config();
+        let expected =
+            Discv4Config::builder().external_ip_resolver(Some(command.nat.clone())).build();
 
-        assert_eq!(config.external_ip_resolver, Some(command.nat));
+        assert_eq!(actual.udp_egress_message_buffer, expected.udp_egress_message_buffer);
+        assert_eq!(actual.udp_ingress_message_buffer, expected.udp_ingress_message_buffer);
+        assert_eq!(actual.max_find_node_failures, expected.max_find_node_failures);
+        assert_eq!(actual.ping_interval, expected.ping_interval);
+        assert_eq!(actual.ping_expiration, expected.ping_expiration);
+        assert_eq!(actual.lookup_interval, expected.lookup_interval);
+        assert_eq!(actual.request_timeout, expected.request_timeout);
+        assert_eq!(actual.enr_expiration, expected.enr_expiration);
+        assert_eq!(actual.neighbours_expiration, expected.neighbours_expiration);
+        assert_eq!(actual.bootstrap_nodes, expected.bootstrap_nodes);
+        assert_eq!(actual.enable_dht_random_walk, expected.enable_dht_random_walk);
+        assert_eq!(actual.enable_lookup, expected.enable_lookup);
+        assert_eq!(actual.enable_eip868, expected.enable_eip868);
+        assert_eq!(actual.enforce_expiration_timestamps, expected.enforce_expiration_timestamps);
+        assert_eq!(actual.additional_eip868_rlp_pairs, expected.additional_eip868_rlp_pairs);
+        assert_eq!(actual.external_ip_resolver, expected.external_ip_resolver);
+        assert_eq!(actual.resolve_external_ip_interval, expected.resolve_external_ip_interval);
+        assert_eq!(actual.bond_expiration, expected.bond_expiration);
+
+        assert_eq!(actual.external_ip_resolver, Some(command.nat));
     }
 
     #[rstest]

--- a/crates/execution/cli/src/commands/p2p/bootnode.rs
+++ b/crates/execution/cli/src/commands/p2p/bootnode.rs
@@ -6,7 +6,10 @@ use base_node_core::BASE_V0_PROTOCOL_VERSION;
 use clap::Parser;
 use reth_cli_util::{get_secret_key, load_secret_key::rng_secret_key};
 use reth_discv4::{DiscoveryUpdate, Discv4, Discv4Config};
-use reth_discv5::{Config, Discv5, discv5::Event};
+use reth_discv5::{
+    Config, Discv5,
+    discv5::{ConfigBuilder as Discv5ConfigBuilder, Event, ListenConfig, ProtocolIdentity},
+};
 use reth_net_nat::{NatResolver, external_addr_with};
 use reth_network_peers::NodeRecord;
 use secp256k1::SecretKey;
@@ -17,11 +20,12 @@ use tracing::{info, warn};
 /// Start a discovery-only bootnode.
 #[derive(Parser, Debug)]
 pub struct Command {
-    /// Listen address for the bootnode for discv4
+    /// Listen address for discv4.
     #[arg(long, default_value = "0.0.0.0:30301")]
     pub v4_addr: SocketAddr,
 
-    /// Listen address for the bootnode for discv5
+    /// UDP listen address for discv5 (only used with --v5).
+    /// Must differ from --v4-addr since discv5 binds its own socket exclusively.
     #[arg(long, default_value = "0.0.0.0:9200")]
     pub v5_addr: SocketAddr,
 
@@ -47,55 +51,44 @@ pub struct Command {
 impl Command {
     /// Execute the bootnode command.
     pub async fn execute(self) -> eyre::Result<()> {
-        info!(v4_addr = %self.v4_addr, v5_addr = %self.v5_addr, nat = %self.nat, v5 = self.v5, "Bootnode starting");
+        info!(v4_addr = %self.v4_addr, v5_addr = %self.v5_addr, nat = %self.nat, v5 = %self.v5, "Bootnode starting");
 
-        // discv4
+        let v4_addr = self.v4_addr;
+        let v5_addr = self.v5_addr;
         let sk = self.network_secret()?;
-        let v4_node_record = NodeRecord::from_secret_key(self.v4_addr, &sk);
+        let local_enr = NodeRecord::from_secret_key(v4_addr, &sk);
+        let discv4_config = self.discv4_config();
+        let discv5_config = self.v5.then(|| self.discv5_config());
         let nat = self.nat;
-        let config = Discv4Config::builder().external_ip_resolver(Some(nat.clone())).build();
         let (_discv4, mut discv4_service) =
-            Discv4::bind(self.v4_addr, v4_node_record, sk, config).await?;
-        info!(v4_node_record = ?v4_node_record, enode = %v4_node_record, "Started discv4");
+            Discv4::bind(v4_addr, local_enr, sk, discv4_config).await?;
+        info!(enr = ?local_enr, "Started discv4");
         let mut discv4_updates = discv4_service.update_stream();
         discv4_service.spawn();
 
-        // discv5
         let mut discv5_updates = None;
         let mut _discv5 = None;
 
-        if self.v5 {
-            info!("Initializing discv5");
-            // exclude eth protocol nodes, we're looking for opel nodes
-            let mut inner_builder = reth_discv5::discv5::ConfigBuilder::new(
-                reth_discv5::DEFAULT_DISCOVERY_V5_LISTEN_CONFIG,
-            );
-            if self.base_protocol {
-                inner_builder.protocol_identity(reth_discv5::discv5::ProtocolIdentity {
-                    protocol_id: BASE_V0_PROTOCOL_VERSION,
-                    ..Default::default()
-                });
-            }
-            let config = Config::builder(self.v5_addr).discv5_config(inner_builder.build()).build();
-            let (discv5, updates) = Discv5::start(&sk, config).await?;
+        if let Some(discv5_config) = discv5_config {
+            let (discv5, updates) = Discv5::start(&sk, discv5_config).await?;
 
             // The upstream reth bootnode skips NAT resolution for discv5, leaving the ENR with
             // no IP address. Peers receiving the ENR cannot send WHOAREYOU back because they
             // have no address to target. Resolve the external IP and update the ENR here.
             match external_addr_with(nat).await {
                 Some(external_ip) => {
-                    let socket = SocketAddr::new(external_ip, self.v5_addr.port());
-                    discv5.with_discv5(|d| d.update_local_enr_socket(socket, false));
+                    let udp_socket = SocketAddr::new(external_ip, v5_addr.port());
+                    discv5.with_discv5(|d| d.update_local_enr_socket(udp_socket, false));
+                    info!(enr = %discv5.local_enr(), "Started discv5");
                 }
                 None => {
                     warn!(
-                        addr = %self.v5_addr,
+                        v5_addr = %v5_addr,
                         "Could not resolve external IP via NAT; discv5 ENR has no IP and may not be reachable"
                     );
+                    info!(enr = %discv5.local_enr(), "Started discv5");
                 }
             }
-
-            info!(enr = %discv5.local_enr(), "Started discv5");
 
             discv5_updates = Some(updates);
             _discv5 = Some(discv5);
@@ -142,10 +135,70 @@ impl Command {
         Ok(())
     }
 
+    /// Build the discv4 configuration with NAT-based external IP resolution.
+    pub fn discv4_config(&self) -> Discv4Config {
+        Discv4Config::builder().external_ip_resolver(Some(self.nat.clone())).build()
+    }
+
+    /// Build the discv5 configuration with the UDP listen port set from `--v5-addr`.
+    pub fn discv5_config(&self) -> Config {
+        let listen = ListenConfig::from_ip(self.v5_addr.ip(), self.v5_addr.port());
+        let mut inner_builder = Discv5ConfigBuilder::new(listen);
+
+        if self.base_protocol {
+            inner_builder.protocol_identity(ProtocolIdentity {
+                protocol_id: BASE_V0_PROTOCOL_VERSION,
+                ..Default::default()
+            });
+        }
+
+        Config::builder(self.v5_addr).discv5_config(inner_builder.build()).build()
+    }
+
     fn network_secret(&self) -> eyre::Result<SecretKey> {
         match &self.p2p_secret_key {
             Some(path) => Ok(get_secret_key(path)?),
             None => Ok(rng_secret_key()),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rstest::rstest;
+
+    use super::*;
+
+    fn cmd(v4_addr: &str, v5_addr: &str) -> Command {
+        Command {
+            v4_addr: v4_addr.parse().unwrap(),
+            v5_addr: v5_addr.parse().unwrap(),
+            p2p_secret_key: None,
+            nat: NatResolver::None,
+            v5: false,
+            base_protocol: true,
+        }
+    }
+
+    #[rstest]
+    #[case("0.0.0.0:30301", "0.0.0.0:9200")]
+    #[case("0.0.0.0:30303", "0.0.0.0:9000")]
+    #[case("127.0.0.1:10001", "127.0.0.1:10002")]
+    fn discv5_discovery_port_matches_v5_addr(#[case] v4_addr: &str, #[case] v5_addr: &str) {
+        let command = cmd(v4_addr, v5_addr);
+        let discv5_port = command.discv5_config().discovery_socket().port();
+
+        assert_eq!(discv5_port, command.v5_addr.port());
+        assert_ne!(discv5_port, command.v4_addr.port());
+    }
+
+    #[test]
+    fn discv4_config_builds() {
+        let _config = cmd("0.0.0.0:30301", "0.0.0.0:9200").discv4_config();
+    }
+
+    #[test]
+    fn discv5_config_builds() {
+        let _config = cmd("0.0.0.0:30301", "0.0.0.0:9200").discv5_config();
     }
 }


### PR DESCRIPTION
## Summary

The config-building logic is extracted into dedicated `discv4_config()` and `discv5_config()` methods on `Command` to make each concern testable in isolation. Unit tests using `rstest` are added to assert the discv5 discovery socket port matches `--v5-addr` and differs from `--v4-addr`.