### PR TITLE
feat(load-tests): add config, timeseries, and error to JSON output

### DIFF
--- a/crates/builder/core/src/flashblocks/context.rs
+++ b/crates/builder/core/src/flashblocks/context.rs
@@ -7,7 +7,7 @@ use std::{
 use alloy_consensus::{Eip658Value, Transaction};
 use alloy_eips::{Encodable2718, Typed2718};
 use alloy_evm::Database;
-use alloy_primitives::{B256, BlockHash, Bytes, TxHash, U256};
+use alloy_primitives::{BlockHash, Bytes, TxHash, U256};
 use alloy_rpc_types_eth::Withdrawals;
 use base_access_lists::FBALBuilderDb;
 use base_bundles::{MeterBundleResponse, RejectedTransaction, RejectionReason};
@@ -1111,6 +1111,9 @@ impl BasePayloadBuilderCtx {
         }
     }
 }
+
+#[cfg(any(test, feature = "test-utils"))]
+use alloy_primitives::B256;
 
 #[cfg(any(test, feature = "test-utils"))]
 impl BasePayloadBuilderCtx {

--- a/crates/infra/basectl/src/app/views/load_test.rs
+++ b/crates/infra/basectl/src/app/views/load_test.rs
@@ -106,11 +106,11 @@ enum RunState {
         snap_rx: watch::Receiver<DisplaySnapshot>,
         run_count_rx: watch::Receiver<u32>,
         done_rx: mpsc::Receiver<Result<MetricsSummary, String>>,
-        current_snap: DisplaySnapshot,
+        current_snap: Box<DisplaySnapshot>,
         current_phase: RunPhase,
     },
     Complete {
-        summary: MetricsSummary,
+        summary: Box<MetricsSummary>,
         elapsed: Duration,
         run_count: u32,
     },
@@ -753,7 +753,7 @@ impl LoadTestView {
             snap_rx,
             run_count_rx,
             done_rx,
-            current_snap: DisplaySnapshot::default(),
+            current_snap: Box::<DisplaySnapshot>::default(),
             current_phase: RunPhase::Bootstrap,
         };
 
@@ -1067,7 +1067,7 @@ impl View for LoadTestView {
             }
             // Update snapshot (non-blocking — take latest value).
             if snap_rx.has_changed().unwrap_or(false) {
-                *current_snap = snap_rx.borrow_and_update().clone();
+                **current_snap = snap_rx.borrow_and_update().clone();
             }
             // Update run count from the background task loop.
             if run_count_rx.has_changed().unwrap_or(false) {
@@ -1097,7 +1097,8 @@ impl View for LoadTestView {
                         summary.throughput.tps,
                         summary.throughput.gps,
                     )));
-                    self.state = RunState::Complete { summary, elapsed, run_count };
+                    self.state =
+                        RunState::Complete { summary: Box::new(summary), elapsed, run_count };
                 }
                 Err(e) => {
                     resources.load_test_task = None;

--- a/crates/infra/load-tests/examples/devnet.yaml
+++ b/crates/infra/load-tests/examples/devnet.yaml
@@ -13,6 +13,9 @@ block_watcher_url: "ws://localhost:8546"
 # Flashblocks websocket url (flashblock latency tracking)
 flashblocks_ws_url: "ws://localhost:7111"
 
+# Separate endpoint for confirmation polling (defaults to rpc when not set)
+# confirmer_url: "http://localhost:8547"
+
 # Number of sender accounts
 sender_count: 100
 

--- a/crates/infra/load-tests/examples/sepolia.yaml
+++ b/crates/infra/load-tests/examples/sepolia.yaml
@@ -2,11 +2,11 @@
 #
 # Requires FUNDER_KEY environment variable with a funded private key
 
-rpc: "https://sepolia-dedicated.base.org/AQpTGzZOSBOdzLusH3tBiTXIkCqcNM5M"
+rpc: "https://sepolia.base.org/"
 
-block_watcher_url: "https://c3-chainproxy-base-sepolia-archive-dev.cbhq.net"
+block_watcher_url: "https://sepolia.base.org/"
 flashblocks_ws_url: "wss://sepolia.flashblocks.base.org/ws"
-confirmer_url: "https://c3-chainproxy-base-sepolia-archive-dev.cbhq.net"
+confirmer_url: "https://sepolia.base.org/"
 
 sender_count: 200
 target_gps: 60000000

--- a/crates/infra/load-tests/examples/sepolia.yaml
+++ b/crates/infra/load-tests/examples/sepolia.yaml
@@ -2,33 +2,36 @@
 #
 # Requires FUNDER_KEY environment variable with a funded private key
 
-rpc: https://sepolia.base.org/
+rpc: "https://sepolia-dedicated.base.org/AQpTGzZOSBOdzLusH3tBiTXIkCqcNM5M"
 
-block_watcher_url: "https://sepolia.base.org/"
+block_watcher_url: "https://c3-chainproxy-base-sepolia-archive-dev.cbhq.net"
 flashblocks_ws_url: "wss://sepolia.flashblocks.base.org/ws"
+confirmer_url: "https://c3-chainproxy-base-sepolia-archive-dev.cbhq.net"
 
 sender_count: 200
-target_gps: 70000000
+target_gps: 60000000
 in_flight_per_sender: 128
 batch_size: 50
-batch_timeout: "100ms"
+batch_timeout: "10ms"
 duration: "60s"
-seed: 12345
+seed: 123456
 
 # 0.01 ETH per account (covers gas for 30s at 2.1M GPS; drained after test)
 funding_amount: "10000000000000000"
 
 transactions:
-  - weight: 50
-    type: uniswap_v3
-    router: "0x94cC0AaC535CCDB3C01d6787D6413C739ae12bc4"
-    token_in: "0x15948C3043A980A8d980d4D615A5E4c9514B0D64"
-    token_out: "0x4dc9ccF2C5A346c4032B648006B4774Ad2a021c4"
-    fee: 3000
-  - weight: 50
-    type: aerodrome_cl
-    router: "0x6a786a4f9bc46fF861260545C490a7356c5ecbFe"
-    token_in: "0x15948C3043A980A8d980d4D615A5E4c9514B0D64"
-    token_out: "0x4dc9ccF2C5A346c4032B648006B4774Ad2a021c4"
-    tick_spacing: 100
+  - weight: 100
+    type: transfer
+  # - weight: 50
+  #   type: uniswap_v3
+  #   router: "0x94cC0AaC535CCDB3C01d6787D6413C739ae12bc4"
+  #   token_in: "0x15948C3043A980A8d980d4D615A5E4c9514B0D64"
+  #   token_out: "0x4dc9ccF2C5A346c4032B648006B4774Ad2a021c4"
+  #   fee: 3000
+  # - weight: 50
+  #   type: aerodrome_cl
+  #   router: "0x6a786a4f9bc46fF861260545C490a7356c5ecbFe"
+  #   token_in: "0x15948C3043A980A8d980d4D615A5E4c9514B0D64"
+  #   token_out: "0x4dc9ccF2C5A346c4032B648006B4774Ad2a021c4"
+  #   tick_spacing: 100
 

--- a/crates/infra/load-tests/src/bin/load_test.rs
+++ b/crates/infra/load-tests/src/bin/load_test.rs
@@ -204,6 +204,17 @@ async fn run_load_test(args: Vec<String>) -> Result<()> {
                 println!("  {count:>6}x  {reason}");
             }
         }
+
+        // Write JSON results to file when LOAD_TEST_OUTPUT is set.
+        if let Ok(output_path) = std::env::var("LOAD_TEST_OUTPUT") {
+            match summary.to_json() {
+                Ok(json) => match std::fs::write(&output_path, &json) {
+                    Ok(()) => println!("Results written to {output_path}"),
+                    Err(e) => eprintln!("Warning: failed to write results to {output_path}: {e}"),
+                },
+                Err(e) => eprintln!("Warning: failed to serialize results: {e}"),
+            }
+        }
     }
 
     // Brief cooldown so in-flight load-test transactions can land and

--- a/crates/infra/load-tests/src/bin/load_test.rs
+++ b/crates/infra/load-tests/src/bin/load_test.rs
@@ -155,13 +155,16 @@ async fn run_load_test(args: Vec<String>) -> Result<()> {
     )
     .await;
 
-    let summary = match &run_result {
-        Ok(s) => s.clone(),
-        Err(e) => MetricsSummary {
-            config: Some(config_summary),
-            error: Some(e.to_string()),
-            ..Default::default()
-        },
+    let (summary, run_err) = match run_result {
+        Ok(summary) => (summary, None),
+        Err(e) => {
+            let summary = MetricsSummary {
+                config: Some(config_summary),
+                error: Some(e.to_string()),
+                ..Default::default()
+            };
+            (summary, Some(e))
+        }
     };
 
     if summary.error.is_none() || summary.throughput.total_submitted > 0 {
@@ -235,7 +238,9 @@ async fn run_load_test(args: Vec<String>) -> Result<()> {
         Err(e) => eprintln!("Warning: drain failed: {e}"),
     }
 
-    run_result?;
+    if let Some(e) = run_err {
+        return Err(e.into());
+    }
 
     Ok(())
 }

--- a/crates/infra/load-tests/src/bin/load_test.rs
+++ b/crates/infra/load-tests/src/bin/load_test.rs
@@ -19,7 +19,7 @@ use alloy_rpc_types::TransactionRequest;
 use alloy_signer_local::PrivateKeySigner;
 use base_load_tests::{
     AccountPool, BaselineError, BatchRpcClient, FundedAccount, LoadRunner, LoadTestDisplay,
-    Result as LoadResult, RpcClient, TestConfig, create_wallet_provider,
+    MetricsSummary, Result as LoadResult, RpcClient, TestConfig, create_wallet_provider,
 };
 use eyre::{Result, bail};
 use futures::stream::{self, StreamExt};
@@ -135,7 +135,9 @@ async fn run_load_test(args: Vec<String>) -> Result<()> {
     let funding_amount = test_config.parse_funding_amount()?;
     let swap_token_amount = test_config.parse_swap_token_amount()?;
 
+    let config_summary = test_config.to_summary();
     let mut runner = LoadRunner::new(load_config.clone())?;
+    runner.set_config_summary(config_summary.clone());
 
     // Install signal handler before any long-running work. First signal sets
     // the stop flag so `run()` exits its loop gracefully and the drain sequence
@@ -143,29 +145,32 @@ async fn run_load_test(args: Vec<String>) -> Result<()> {
     let stop_flag = runner.stop_flag();
     install_signal_handler(stop_flag);
 
-    println!("Funding test accounts...");
-    runner.fund_accounts(funding_key.clone(), funding_amount).await?;
-    println!("Accounts funded.");
+    let run_result = run_test_phases(
+        &mut runner,
+        &funding_key,
+        funding_amount,
+        swap_token_amount,
+        &mp,
+        load_config.duration,
+    )
+    .await;
 
-    if !runner.collect_swap_tokens().is_empty() {
-        println!("Distributing swap tokens...");
-        runner.setup_swap_tokens(funding_key.clone(), swap_token_amount).await?;
-        println!("Swap tokens distributed.");
-    }
-    println!();
+    let summary = match &run_result {
+        Ok(s) => s.clone(),
+        Err(e) => {
+            let mut error_summary = MetricsSummary::default();
+            error_summary.config = Some(config_summary);
+            error_summary.error = Some(e.to_string());
+            error_summary
+        }
+    };
 
-    println!("Running load test...");
-
-    // Create bars after all pre-run println output so setup text doesn't
-    // interleave with the live display.
-    let display = LoadTestDisplay::new(&mp, load_config.duration);
-    runner.set_display(display);
-
-    let run_result = runner.run().await;
-
-    if let Ok(ref summary) = run_result {
+    if summary.error.is_none() || summary.throughput.total_submitted > 0 {
         println!();
         println!("=== Results ===");
+        if let Some(ref err) = summary.error {
+            println!("Error: {err}");
+        }
         println!(
             "Submitted: {} | Confirmed: {} | Failed: {}",
             summary.throughput.total_submitted,
@@ -204,16 +209,19 @@ async fn run_load_test(args: Vec<String>) -> Result<()> {
                 println!("  {count:>6}x  {reason}");
             }
         }
+    } else if let Some(ref err) = summary.error {
+        println!();
+        println!("=== Error ===");
+        println!("{err}");
+    }
 
-        // Write JSON results to file when LOAD_TEST_OUTPUT is set.
-        if let Ok(output_path) = std::env::var("LOAD_TEST_OUTPUT") {
-            match summary.to_json() {
-                Ok(json) => match std::fs::write(&output_path, &json) {
-                    Ok(()) => println!("Results written to {output_path}"),
-                    Err(e) => eprintln!("Warning: failed to write results to {output_path}: {e}"),
-                },
-                Err(e) => eprintln!("Warning: failed to serialize results: {e}"),
-            }
+    if let Ok(output_path) = std::env::var("LOAD_TEST_OUTPUT") {
+        match summary.to_json() {
+            Ok(json) => match std::fs::write(&output_path, &json) {
+                Ok(()) => println!("Results written to {output_path}"),
+                Err(e) => eprintln!("Warning: failed to write results to {output_path}: {e}"),
+            },
+            Err(e) => eprintln!("Warning: failed to serialize results: {e}"),
         }
     }
 
@@ -233,8 +241,33 @@ async fn run_load_test(args: Vec<String>) -> Result<()> {
     Ok(())
 }
 
-/// Spawns a background task that converts OS signals into a cooperative stop
-/// via the shared [`AtomicBool`]. A second signal force-exits the process.
+async fn run_test_phases(
+    runner: &mut LoadRunner,
+    funding_key: &PrivateKeySigner,
+    funding_amount: U256,
+    swap_token_amount: U256,
+    mp: &indicatif::MultiProgress,
+    duration: Option<Duration>,
+) -> LoadResult<MetricsSummary> {
+    println!("Funding test accounts...");
+    runner.fund_accounts(funding_key.clone(), funding_amount).await?;
+    println!("Accounts funded.");
+
+    if !runner.collect_swap_tokens().is_empty() {
+        println!("Distributing swap tokens...");
+        runner.setup_swap_tokens(funding_key.clone(), swap_token_amount).await?;
+        println!("Swap tokens distributed.");
+    }
+    println!();
+
+    println!("Running load test...");
+
+    let display = LoadTestDisplay::new(mp, duration);
+    runner.set_display(display);
+
+    runner.run().await
+}
+
 fn install_signal_handler(stop_flag: Arc<AtomicBool>) {
     tokio::spawn(async move {
         wait_for_shutdown_signal().await;

--- a/crates/infra/load-tests/src/bin/load_test.rs
+++ b/crates/infra/load-tests/src/bin/load_test.rs
@@ -157,12 +157,11 @@ async fn run_load_test(args: Vec<String>) -> Result<()> {
 
     let summary = match &run_result {
         Ok(s) => s.clone(),
-        Err(e) => {
-            let mut error_summary = MetricsSummary::default();
-            error_summary.config = Some(config_summary);
-            error_summary.error = Some(e.to_string());
-            error_summary
-        }
+        Err(e) => MetricsSummary {
+            config: Some(config_summary),
+            error: Some(e.to_string()),
+            ..Default::default()
+        },
     };
 
     if summary.error.is_none() || summary.throughput.total_submitted > 0 {
@@ -241,6 +240,7 @@ async fn run_load_test(args: Vec<String>) -> Result<()> {
     Ok(())
 }
 
+/// Runs funding, token setup, and the load test loop, returning the metrics summary.
 async fn run_test_phases(
     runner: &mut LoadRunner,
     funding_key: &PrivateKeySigner,

--- a/crates/infra/load-tests/src/config/test_config.rs
+++ b/crates/infra/load-tests/src/config/test_config.rs
@@ -135,6 +135,10 @@ pub struct TestConfig {
     /// WebSocket URL for flashblocks subscription.
     #[serde(default, alias = "flashblocks_url")]
     pub flashblocks_ws_url: Option<Url>,
+    /// Separate HTTP JSON-RPC endpoint for confirmation polling.
+    /// Defaults to `rpc` when not set.
+    #[serde(default)]
+    pub confirmer_url: Option<Url>,
 }
 
 impl Default for TestConfig {
@@ -157,6 +161,7 @@ impl Default for TestConfig {
             swap_token_amount: default_swap_token_amount(),
             block_watcher_url: None,
             flashblocks_ws_url: None,
+            confirmer_url: None,
         }
     }
 }
@@ -179,6 +184,7 @@ impl fmt::Debug for TestConfig {
             .field("swap_token_amount", &self.swap_token_amount)
             .field("block_watcher_url", &self.block_watcher_url)
             .field("flashblocks_ws_url", &self.flashblocks_ws_url)
+            .field("confirmer_url", &self.confirmer_url)
             .finish()
     }
 }
@@ -461,6 +467,7 @@ impl TestConfig {
             max_gas_price: crate::runner::DEFAULT_MAX_GAS_PRICE,
             block_watcher_url: self.block_watcher_url.clone(),
             flashblocks_ws_url: self.flashblocks_ws_url.clone(),
+            confirmer_url: self.confirmer_url.clone(),
         })
     }
 

--- a/crates/infra/load-tests/src/config/test_config.rs
+++ b/crates/infra/load-tests/src/config/test_config.rs
@@ -436,7 +436,14 @@ impl TestConfig {
             target_gps: self.target_gps,
             seed: self.seed,
             chain_id: self.chain_id,
-            transactions: serde_json::to_value(&self.transactions).unwrap_or_default(),
+            transactions: serde_json::to_value(&self.transactions)
+                .inspect_err(|e| {
+                    tracing::warn!(
+                        error = %e,
+                        "failed to serialize transactions for config summary"
+                    );
+                })
+                .unwrap_or_default(),
             looper_contract: self.looper_contract.clone(),
             swap_token_amount: self.swap_token_amount.clone(),
         }

--- a/crates/infra/load-tests/src/config/test_config.rs
+++ b/crates/infra/load-tests/src/config/test_config.rs
@@ -7,6 +7,7 @@ use serde::{Deserialize, Serialize};
 use url::Url;
 
 use crate::{
+    metrics::ConfigSummary,
     runner::{TxConfig, TxType},
     utils::{BaselineError, Result},
 };
@@ -420,6 +421,25 @@ impl TestConfig {
                 self.swap_token_amount
             ))
         })
+    }
+
+    /// Returns a summary of the config for JSON output (excludes URLs and secrets).
+    pub fn to_summary(&self) -> ConfigSummary {
+        ConfigSummary {
+            funding_amount: self.funding_amount.clone(),
+            sender_count: self.sender_count,
+            sender_offset: self.sender_offset,
+            in_flight_per_sender: self.in_flight_per_sender,
+            batch_size: self.batch_size,
+            batch_timeout: self.batch_timeout.clone(),
+            duration: self.duration.clone(),
+            target_gps: self.target_gps,
+            seed: self.seed,
+            chain_id: self.chain_id,
+            transactions: serde_json::to_value(&self.transactions).unwrap_or_default(),
+            looper_contract: self.looper_contract.clone(),
+            swap_token_amount: self.swap_token_amount.clone(),
+        }
     }
 
     /// Converts this test config into a `LoadConfig` for runtime use.

--- a/crates/infra/load-tests/src/lib.rs
+++ b/crates/infra/load-tests/src/lib.rs
@@ -21,8 +21,9 @@ pub use rpc::{
 
 mod metrics;
 pub use metrics::{
-    FlashblocksLatencyMetrics, GasMetrics, LatencyMetrics, MetricsAggregator, MetricsCollector,
-    MetricsSummary, RollingWindow, ThroughputMetrics, ThroughputPercentiles, TransactionMetrics,
+    ConfigSummary, FlashblocksLatencyMetrics, GasMetrics, LatencyMetrics, MetricsAggregator,
+    MetricsCollector, MetricsSummary, RollingWindow, ThroughputMetrics, ThroughputPercentiles,
+    ThroughputSample, TransactionMetrics,
 };
 
 mod workload;

--- a/crates/infra/load-tests/src/metrics/aggregator.rs
+++ b/crates/infra/load-tests/src/metrics/aggregator.rs
@@ -3,8 +3,8 @@ use std::{collections::HashMap, time::Duration};
 use serde::{Deserialize, Serialize};
 
 use super::{
-    FlashblocksLatencyMetrics, GasMetrics, LatencyMetrics, ThroughputMetrics,
-    ThroughputPercentiles, TransactionMetrics,
+    ConfigSummary, FlashblocksLatencyMetrics, GasMetrics, LatencyMetrics, ThroughputMetrics,
+    ThroughputPercentiles, ThroughputSample, TransactionMetrics,
 };
 
 /// Aggregates raw transaction metrics into summary statistics.
@@ -26,19 +26,25 @@ impl<'a> MetricsAggregator<'a> {
         submitted: u64,
         failed: u64,
         failure_reasons: &HashMap<String, u64>,
-        tps_samples: &[f64],
-        gps_samples: &[f64],
+        throughput_samples: &[ThroughputSample],
+        config: Option<ConfigSummary>,
     ) -> MetricsSummary {
         let mut top_failure_reasons: Vec<(String, u64)> =
             failure_reasons.iter().map(|(k, v)| (k.clone(), *v)).collect();
         top_failure_reasons.sort_by(|a, b| b.1.cmp(&a.1));
         top_failure_reasons.truncate(3);
 
+        let tps_values: Vec<f64> = throughput_samples.iter().map(|s| s.tps).collect();
+        let gps_values: Vec<f64> = throughput_samples.iter().map(|s| s.gps).collect();
+
         MetricsSummary {
+            config,
+            error: None,
             block_latency: self.compute_block_latency(),
             flashblocks_latency: self.compute_flashblocks_latency(),
             throughput: self.compute_throughput(duration, submitted, failed),
-            throughput_percentiles: Self::compute_throughput_percentiles(tps_samples, gps_samples),
+            throughput_percentiles: Self::compute_throughput_percentiles(&tps_values, &gps_values),
+            throughput_timeseries: throughput_samples.to_vec(),
             gas: self.compute_gas(),
             top_failure_reasons,
         }
@@ -179,6 +185,12 @@ impl<'a> MetricsAggregator<'a> {
 /// Summary of all collected metrics.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct MetricsSummary {
+    /// Test configuration (excludes URLs and secrets).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub config: Option<ConfigSummary>,
+    /// Fatal error that stopped the test (e.g., funding failure).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
     /// Block production latency.
     pub block_latency: LatencyMetrics,
     /// Flashblocks sequencer latency.
@@ -187,6 +199,8 @@ pub struct MetricsSummary {
     pub throughput: ThroughputMetrics,
     /// Rolling-window throughput percentiles (TPS and GPS).
     pub throughput_percentiles: ThroughputPercentiles,
+    /// Throughput samples over time for graphing.
+    pub throughput_timeseries: Vec<ThroughputSample>,
     /// Gas usage statistics.
     pub gas: GasMetrics,
     /// Top failure reasons sorted by count descending (max 3).

--- a/crates/infra/load-tests/src/metrics/collector.rs
+++ b/crates/infra/load-tests/src/metrics/collector.rs
@@ -6,7 +6,10 @@ use std::{
 use alloy_primitives::TxHash;
 use tracing::debug;
 
-use super::{MetricsAggregator, MetricsSummary, RollingWindow, TransactionMetrics};
+use super::{
+    ConfigSummary, MetricsAggregator, MetricsSummary, RollingWindow, ThroughputSample,
+    TransactionMetrics,
+};
 
 /// Collects transaction metrics during test execution.
 #[derive(Debug)]
@@ -17,8 +20,7 @@ pub struct MetricsCollector {
     failure_reasons: HashMap<String, u64>,
     rolling: RollingWindow,
     flashblocks_rolling: RollingWindow,
-    tps_samples: Vec<f64>,
-    gps_samples: Vec<f64>,
+    throughput_samples: Vec<ThroughputSample>,
 }
 
 impl MetricsCollector {
@@ -31,8 +33,7 @@ impl MetricsCollector {
             failure_reasons: HashMap::new(),
             rolling: RollingWindow::new(),
             flashblocks_rolling: RollingWindow::new(),
-            tps_samples: Vec::new(),
-            gps_samples: Vec::new(),
+            throughput_samples: Vec::new(),
         }
     }
 
@@ -88,15 +89,15 @@ impl MetricsCollector {
     ///
     /// `duration` should span from first submission to last confirmation
     /// so that the reported TPS reflects end-to-end throughput.
-    pub fn summarize(&self, duration: Duration) -> MetricsSummary {
+    pub fn summarize(&self, duration: Duration, config: Option<ConfigSummary>) -> MetricsSummary {
         let aggregator = MetricsAggregator::new(&self.transactions);
         aggregator.summarize(
             duration,
             self.submitted_count,
             self.failed_count,
             &self.failure_reasons,
-            &self.tps_samples,
-            &self.gps_samples,
+            &self.throughput_samples,
+            config,
         )
     }
 
@@ -108,17 +109,19 @@ impl MetricsCollector {
         self.failure_reasons.clear();
         self.rolling = RollingWindow::new();
         self.flashblocks_rolling = RollingWindow::new();
-        self.tps_samples.clear();
-        self.gps_samples.clear();
+        self.throughput_samples.clear();
     }
 
-    /// Snapshots the current rolling TPS and GPS for percentile computation.
-    pub fn sample_throughput(&mut self) {
+    /// Snapshots the current rolling TPS and GPS with elapsed time for timeseries output.
+    pub fn sample_throughput(&mut self, elapsed: Duration) {
         let tps = self.rolling.tps();
         let gps = self.rolling.gps();
         if tps > 0.0 {
-            self.tps_samples.push(tps);
-            self.gps_samples.push(gps);
+            self.throughput_samples.push(ThroughputSample {
+                elapsed_secs: elapsed.as_secs_f64(),
+                tps,
+                gps,
+            });
         }
     }
 

--- a/crates/infra/load-tests/src/metrics/mod.rs
+++ b/crates/infra/load-tests/src/metrics/mod.rs
@@ -2,8 +2,8 @@
 
 mod types;
 pub use types::{
-    FlashblocksLatencyMetrics, GasMetrics, LatencyMetrics, ThroughputMetrics,
-    ThroughputPercentiles, TransactionMetrics,
+    ConfigSummary, FlashblocksLatencyMetrics, GasMetrics, LatencyMetrics, ThroughputMetrics,
+    ThroughputPercentiles, ThroughputSample, TransactionMetrics,
 };
 
 mod rolling_window;

--- a/crates/infra/load-tests/src/metrics/types.rs
+++ b/crates/infra/load-tests/src/metrics/types.rs
@@ -162,7 +162,34 @@ pub struct FlashblocksLatencyMetrics {
 
 /// Test configuration included in the JSON output (excludes URLs and secrets).
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[allow(missing_docs)]
+pub struct ConfigSummary {
+    /// Amount funded to each sender account (in wei, as string).
+    pub funding_amount: String,
+    /// Number of sender accounts.
+    pub sender_count: u32,
+    /// Offset into the derivation path.
+    pub sender_offset: u32,
+    /// Maximum in-flight transactions per sender.
+    pub in_flight_per_sender: u32,
+    /// Number of transactions per RPC batch.
+    pub batch_size: u32,
+    /// Maximum wait before flushing a partial batch.
+    pub batch_timeout: Option<String>,
+    /// Test duration.
+    pub duration: Option<String>,
+    /// Target gas per second.
+    pub target_gps: Option<u64>,
+    /// Deterministic account seed.
+    pub seed: u64,
+    /// Chain ID.
+    pub chain_id: Option<u64>,
+    /// Transaction type configuration.
+    pub transactions: serde_json::Value,
+    /// Address of the precompile looper contract.
+    pub looper_contract: Option<String>,
+    /// Amount of each swap token per sender (in wei, as string).
+    pub swap_token_amount: String,
+}
 pub struct ConfigSummary {
     pub funding_amount: String,
     pub sender_count: u32,

--- a/crates/infra/load-tests/src/metrics/types.rs
+++ b/crates/infra/load-tests/src/metrics/types.rs
@@ -128,6 +128,17 @@ pub struct GasMetrics {
     pub avg_gas_price: u128,
 }
 
+/// A single throughput sample captured during the test run.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ThroughputSample {
+    /// Elapsed time since the test started, in seconds.
+    pub elapsed_secs: f64,
+    /// Rolling 30s transactions-per-second at this point.
+    pub tps: f64,
+    /// Rolling 30s gas-per-second at this point.
+    pub gps: f64,
+}
+
 /// Aggregated flashblocks latency percentiles.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct FlashblocksLatencyMetrics {
@@ -147,4 +158,23 @@ pub struct FlashblocksLatencyMetrics {
     pub p95: Duration,
     /// 99th percentile latency.
     pub p99: Duration,
+}
+
+/// Test configuration included in the JSON output (excludes URLs and secrets).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[allow(missing_docs)]
+pub struct ConfigSummary {
+    pub funding_amount: String,
+    pub sender_count: u32,
+    pub sender_offset: u32,
+    pub in_flight_per_sender: u32,
+    pub batch_size: u32,
+    pub batch_timeout: Option<String>,
+    pub duration: Option<String>,
+    pub target_gps: Option<u64>,
+    pub seed: u64,
+    pub chain_id: Option<u64>,
+    pub transactions: serde_json::Value,
+    pub looper_contract: Option<String>,
+    pub swap_token_amount: String,
 }

--- a/crates/infra/load-tests/src/metrics/types.rs
+++ b/crates/infra/load-tests/src/metrics/types.rs
@@ -190,18 +190,3 @@ pub struct ConfigSummary {
     /// Amount of each swap token per sender (in wei, as string).
     pub swap_token_amount: String,
 }
-pub struct ConfigSummary {
-    pub funding_amount: String,
-    pub sender_count: u32,
-    pub sender_offset: u32,
-    pub in_flight_per_sender: u32,
-    pub batch_size: u32,
-    pub batch_timeout: Option<String>,
-    pub duration: Option<String>,
-    pub target_gps: Option<u64>,
-    pub seed: u64,
-    pub chain_id: Option<u64>,
-    pub transactions: serde_json::Value,
-    pub looper_contract: Option<String>,
-    pub swap_token_amount: String,
-}

--- a/crates/infra/load-tests/src/runner/config.rs
+++ b/crates/infra/load-tests/src/runner/config.rs
@@ -121,6 +121,11 @@ pub struct LoadConfig {
     pub block_watcher_url: Option<Url>,
     /// WebSocket URL for flashblocks subscription.
     pub flashblocks_ws_url: Option<Url>,
+    /// Separate HTTP JSON-RPC endpoint for transaction confirmation polling.
+    /// When set, all receipt fetching and block queries from the confirmer use
+    /// this endpoint instead of `rpc_http_url`, reducing load on the submission
+    /// endpoint.
+    pub confirmer_url: Option<Url>,
 }
 
 impl LoadConfig {
@@ -146,6 +151,7 @@ impl LoadConfig {
             flashblocks_ws_url: Some(
                 "ws://localhost:7111".parse().expect("valid default flashblocks_ws_url"),
             ),
+            confirmer_url: None,
         }
     }
 

--- a/crates/infra/load-tests/src/runner/load_runner.rs
+++ b/crates/infra/load-tests/src/runner/load_runner.rs
@@ -1122,6 +1122,7 @@ impl LoadRunner {
             rate_limiter.tick_batch(pending_batch.len()).await;
 
             let batch = std::mem::replace(&mut pending_batch, Vec::with_capacity(batch_size));
+            let batch_len = batch.len();
             let permit = match tokio::time::timeout(
                 SEMAPHORE_ACQUIRE_TIMEOUT,
                 Arc::clone(&semaphore).acquire_owned(),
@@ -1135,9 +1136,14 @@ impl LoadRunner {
                 }
                 Err(_) => {
                     warn!(
-                        batch_len = batch.len(),
+                        batch_len,
                         "semaphore acquire timed out, dropping batch to stay responsive"
                     );
+                    for _ in 0..batch_len {
+                        let _ = submit_event_tx
+                            .send(SubmitEvent::Failed("submit semaphore acquire timed out".into()))
+                            .await;
+                    }
                     rate_limiter.reset_tick();
                     continue;
                 }
@@ -1186,51 +1192,82 @@ impl LoadRunner {
         }
 
         if !pending_batch.is_empty() {
-            let permit = Arc::clone(&semaphore)
-                .acquire_owned()
-                .await
-                .expect("submit batch semaphore closed");
-            let ctx = BatchSubmitCtx {
-                providers: Arc::clone(&providers),
-                signers: Arc::clone(&signers),
-                batch_rpc: batch_rpc.clone(),
-                nonce_managers: Arc::clone(&nonce_managers),
-                confirmer_handle: confirmer_handle.clone(),
-                submit_event_tx: submit_event_tx.clone(),
-                gas_price: self.gas_price,
-                chain_id: self.config.chain_id,
-                max_gas_price: self.config.max_gas_price,
-            };
-            tokio::spawn(async move {
-                let _permit = permit;
-                let batch_len = pending_batch.len();
-                match tokio::time::timeout(
-                    SUBMIT_TASK_DEADLINE,
-                    AssertUnwindSafe(Self::submit_batch(ctx.clone(), pending_batch)).catch_unwind(),
-                )
-                .await
-                {
-                    Ok(Ok(submitted)) => debug!(submitted, "final batch submitted"),
-                    Ok(Err(_)) => {
-                        error!(batch_len, "final batch submission task panicked");
-                        for _ in 0..batch_len {
-                            let _ = ctx
-                                .submit_event_tx
-                                .send(SubmitEvent::Failed("task panicked".into()))
-                                .await;
-                        }
+            let final_batch_len = pending_batch.len();
+            let permit = match tokio::time::timeout(
+                SEMAPHORE_ACQUIRE_TIMEOUT,
+                Arc::clone(&semaphore).acquire_owned(),
+            )
+            .await
+            {
+                Ok(Ok(permit)) => Some(permit),
+                Ok(Err(_)) => {
+                    error!(batch_len = final_batch_len, "submit batch semaphore closed");
+                    for _ in 0..final_batch_len {
+                        let _ = submit_event_tx
+                            .send(SubmitEvent::Failed("submit batch semaphore closed".into()))
+                            .await;
                     }
-                    Err(_) => {
-                        warn!(batch_len, "final batch submission task timed out");
-                        for _ in 0..batch_len {
-                            let _ = ctx
-                                .submit_event_tx
-                                .send(SubmitEvent::Failed("submit task deadline exceeded".into()))
-                                .await;
-                        }
-                    }
+                    None
                 }
-            });
+                Err(_) => {
+                    warn!(
+                        batch_len = final_batch_len,
+                        "semaphore acquire timed out, dropping final batch to stay responsive"
+                    );
+                    for _ in 0..final_batch_len {
+                        let _ = submit_event_tx
+                            .send(SubmitEvent::Failed("submit semaphore acquire timed out".into()))
+                            .await;
+                    }
+                    None
+                }
+            };
+            if let Some(permit) = permit {
+                let ctx = BatchSubmitCtx {
+                    providers: Arc::clone(&providers),
+                    signers: Arc::clone(&signers),
+                    batch_rpc: batch_rpc.clone(),
+                    nonce_managers: Arc::clone(&nonce_managers),
+                    confirmer_handle: confirmer_handle.clone(),
+                    submit_event_tx: submit_event_tx.clone(),
+                    gas_price: self.gas_price,
+                    chain_id: self.config.chain_id,
+                    max_gas_price: self.config.max_gas_price,
+                };
+                tokio::spawn(async move {
+                    let _permit = permit;
+                    let batch_len = pending_batch.len();
+                    match tokio::time::timeout(
+                        SUBMIT_TASK_DEADLINE,
+                        AssertUnwindSafe(Self::submit_batch(ctx.clone(), pending_batch))
+                            .catch_unwind(),
+                    )
+                    .await
+                    {
+                        Ok(Ok(submitted)) => debug!(submitted, "final batch submitted"),
+                        Ok(Err(_)) => {
+                            error!(batch_len, "final batch submission task panicked");
+                            for _ in 0..batch_len {
+                                let _ = ctx
+                                    .submit_event_tx
+                                    .send(SubmitEvent::Failed("task panicked".into()))
+                                    .await;
+                            }
+                        }
+                        Err(_) => {
+                            warn!(batch_len, "final batch submission task timed out");
+                            for _ in 0..batch_len {
+                                let _ = ctx
+                                    .submit_event_tx
+                                    .send(SubmitEvent::Failed(
+                                        "submit task deadline exceeded".into(),
+                                    ))
+                                    .await;
+                            }
+                        }
+                    }
+                });
+            }
         }
 
         match tokio::time::timeout(

--- a/crates/infra/load-tests/src/runner/load_runner.rs
+++ b/crates/infra/load-tests/src/runner/load_runner.rs
@@ -894,11 +894,8 @@ impl LoadRunner {
             None
         };
 
-        let confirmer_rpc_url = self
-            .config
-            .confirmer_url
-            .clone()
-            .unwrap_or_else(|| self.config.rpc_http_url.clone());
+        let confirmer_rpc_url =
+            self.config.confirmer_url.clone().unwrap_or_else(|| self.config.rpc_http_url.clone());
 
         if self.config.confirmer_url.is_some() {
             info!(url = %confirmer_rpc_url, "using separate endpoint for confirmation polling");
@@ -1202,8 +1199,7 @@ impl LoadRunner {
                 let batch_len = pending_batch.len();
                 match tokio::time::timeout(
                     SUBMIT_TASK_DEADLINE,
-                    AssertUnwindSafe(Self::submit_batch(ctx.clone(), pending_batch))
-                        .catch_unwind(),
+                    AssertUnwindSafe(Self::submit_batch(ctx.clone(), pending_batch)).catch_unwind(),
                 )
                 .await
                 {
@@ -1231,7 +1227,7 @@ impl LoadRunner {
         }
 
         match tokio::time::timeout(
-            SUBMIT_TASK_DEADLINE,
+            SUBMIT_TASK_DEADLINE + Duration::from_secs(5),
             Arc::clone(&semaphore).acquire_many_owned(SUBMIT_BATCH_CONCURRENCY as u32),
         )
         .await

--- a/crates/infra/load-tests/src/runner/load_runner.rs
+++ b/crates/infra/load-tests/src/runner/load_runner.rs
@@ -854,7 +854,7 @@ impl LoadRunner {
 
         const METRICS_CHANNEL_BUFFER: usize = 2000;
         const SUBMIT_CHANNEL_BUFFER: usize = 2000;
-        const SUBMIT_BATCH_CONCURRENCY: usize = 32;
+        const SUBMIT_BATCH_CONCURRENCY: usize = 64;
         let (metrics_tx, mut metrics_rx) =
             mpsc::channel::<TransactionMetrics>(METRICS_CHANNEL_BUFFER);
         let (submit_event_tx, mut submit_event_rx) =
@@ -894,6 +894,16 @@ impl LoadRunner {
             None
         };
 
+        let confirmer_rpc_url = self
+            .config
+            .confirmer_url
+            .clone()
+            .unwrap_or_else(|| self.config.rpc_http_url.clone());
+
+        if self.config.confirmer_url.is_some() {
+            info!(url = %confirmer_rpc_url, "using separate endpoint for confirmation polling");
+        }
+
         let sender_addresses: Vec<_> = self.accounts.accounts().iter().map(|a| a.address).collect();
         let mut confirmer = Confirmer::new(
             &sender_addresses,
@@ -902,12 +912,12 @@ impl LoadRunner {
             Arc::clone(&flashblock_times),
             Arc::clone(&block_first_seen),
             block_watcher_enabled,
-            self.batch_rpc.clone(),
+            BatchRpcClient::new(confirmer_rpc_url.clone()),
         );
         let confirmer_handle = confirmer.handle();
         let confirmer_handle_for_run = confirmer_handle.clone();
 
-        let confirmer_client = RpcClient::new(self.config.rpc_http_url.clone());
+        let confirmer_client = RpcClient::new(confirmer_rpc_url.clone());
         let confirmer_task = tokio::spawn(async move {
             confirmer.run(confirmer_client, &confirmer_handle_for_run).await
         });
@@ -946,6 +956,8 @@ impl LoadRunner {
         const RATE_LIMITER_UPDATE_INTERVAL: Duration = Duration::from_secs(2);
         const PROGRESS_REPORT_INTERVAL: Duration = Duration::from_secs(5);
         const DISPLAY_RENDER_INTERVAL: Duration = Duration::from_millis(500);
+        const SEMAPHORE_ACQUIRE_TIMEOUT: Duration = Duration::from_secs(5);
+        const SUBMIT_TASK_DEADLINE: Duration = Duration::from_secs(15);
 
         let use_live_display = self.display.as_ref().is_some_and(|d| d.is_active());
         let use_snapshot_tx = self.snapshot_tx.is_some();
@@ -1106,10 +1118,26 @@ impl LoadRunner {
             rate_limiter.tick_batch(pending_batch.len()).await;
 
             let batch = std::mem::replace(&mut pending_batch, Vec::with_capacity(batch_size));
-            let permit = Arc::clone(&semaphore)
-                .acquire_owned()
-                .await
-                .expect("submit batch semaphore closed");
+            let permit = match tokio::time::timeout(
+                SEMAPHORE_ACQUIRE_TIMEOUT,
+                Arc::clone(&semaphore).acquire_owned(),
+            )
+            .await
+            {
+                Ok(Ok(permit)) => permit,
+                Ok(Err(_)) => {
+                    error!("submit batch semaphore closed");
+                    break;
+                }
+                Err(_) => {
+                    warn!(
+                        batch_len = batch.len(),
+                        "semaphore acquire timed out, dropping batch to stay responsive"
+                    );
+                    rate_limiter.reset_tick();
+                    continue;
+                }
+            };
             let ctx = BatchSubmitCtx {
                 providers: Arc::clone(&providers),
                 signers: Arc::clone(&signers),
@@ -1124,15 +1152,28 @@ impl LoadRunner {
             tokio::spawn(async move {
                 let _permit = permit;
                 let batch_len = batch.len();
-                match AssertUnwindSafe(Self::submit_batch(ctx.clone(), batch)).catch_unwind().await
+                match tokio::time::timeout(
+                    SUBMIT_TASK_DEADLINE,
+                    AssertUnwindSafe(Self::submit_batch(ctx.clone(), batch)).catch_unwind(),
+                )
+                .await
                 {
-                    Ok(submitted) => debug!(submitted, "batch submitted"),
-                    Err(_) => {
+                    Ok(Ok(submitted)) => debug!(submitted, "batch submitted"),
+                    Ok(Err(_)) => {
                         error!(batch_len, "batch submission task panicked");
                         for _ in 0..batch_len {
                             let _ = ctx
                                 .submit_event_tx
                                 .send(SubmitEvent::Failed("task panicked".into()))
+                                .await;
+                        }
+                    }
+                    Err(_) => {
+                        warn!(batch_len, "batch submission task timed out, releasing permit");
+                        for _ in 0..batch_len {
+                            let _ = ctx
+                                .submit_event_tx
+                                .send(SubmitEvent::Failed("submit task deadline exceeded".into()))
                                 .await;
                         }
                     }
@@ -1159,12 +1200,15 @@ impl LoadRunner {
             tokio::spawn(async move {
                 let _permit = permit;
                 let batch_len = pending_batch.len();
-                match AssertUnwindSafe(Self::submit_batch(ctx.clone(), pending_batch))
-                    .catch_unwind()
-                    .await
+                match tokio::time::timeout(
+                    SUBMIT_TASK_DEADLINE,
+                    AssertUnwindSafe(Self::submit_batch(ctx.clone(), pending_batch))
+                        .catch_unwind(),
+                )
+                .await
                 {
-                    Ok(submitted) => debug!(submitted, "final batch submitted"),
-                    Err(_) => {
+                    Ok(Ok(submitted)) => debug!(submitted, "final batch submitted"),
+                    Ok(Err(_)) => {
                         error!(batch_len, "final batch submission task panicked");
                         for _ in 0..batch_len {
                             let _ = ctx
@@ -1173,15 +1217,29 @@ impl LoadRunner {
                                 .await;
                         }
                     }
+                    Err(_) => {
+                        warn!(batch_len, "final batch submission task timed out");
+                        for _ in 0..batch_len {
+                            let _ = ctx
+                                .submit_event_tx
+                                .send(SubmitEvent::Failed("submit task deadline exceeded".into()))
+                                .await;
+                        }
+                    }
                 }
             });
         }
 
-        let all_permits = Arc::clone(&semaphore)
-            .acquire_many_owned(SUBMIT_BATCH_CONCURRENCY as u32)
-            .await
-            .expect("submit batch semaphore closed");
-        drop(all_permits);
+        match tokio::time::timeout(
+            SUBMIT_TASK_DEADLINE,
+            Arc::clone(&semaphore).acquire_many_owned(SUBMIT_BATCH_CONCURRENCY as u32),
+        )
+        .await
+        {
+            Ok(Ok(all_permits)) => drop(all_permits),
+            Ok(Err(_)) => error!("submit batch semaphore closed during drain"),
+            Err(_) => warn!("timed out waiting for in-flight batch tasks to complete"),
+        }
 
         // Close the channel so the drain below cannot miss late events.
         drop(submit_event_tx);

--- a/crates/infra/load-tests/src/runner/load_runner.rs
+++ b/crates/infra/load-tests/src/runner/load_runner.rs
@@ -44,7 +44,7 @@ use super::{
 use crate::{
     BaselineError, Result,
     config::{OsakaTarget, WorkloadConfig},
-    metrics::{MetricsCollector, MetricsSummary, TransactionMetrics},
+    metrics::{ConfigSummary, MetricsCollector, MetricsSummary, TransactionMetrics},
     rpc::{BatchRpcClient, BatchSendResult, RpcClient, WalletProvider, create_wallet_provider},
     workload::{
         AccountPool, AerodromeClPayload, CalldataPayload, Erc20Payload, OsakaPayload,
@@ -96,6 +96,7 @@ const NONCE_RPC_TIMEOUT: Duration = Duration::from_secs(10);
 /// Executes load tests by generating and submitting transactions at a target rate.
 pub struct LoadRunner {
     config: LoadConfig,
+    config_summary: Option<ConfigSummary>,
     client: RpcClient,
     accounts: AccountPool,
     generator: WorkloadGenerator,
@@ -157,6 +158,7 @@ impl LoadRunner {
 
         Ok(Self {
             config,
+            config_summary: None,
             client,
             accounts,
             generator,
@@ -181,6 +183,11 @@ impl LoadRunner {
     /// Sets the funder wallet address for inclusion in live snapshots.
     pub fn set_funder_address(&mut self, addr: String) {
         self.funder_address = Some(addr);
+    }
+
+    /// Sets the config summary for inclusion in JSON output.
+    pub fn set_config_summary(&mut self, summary: ConfigSummary) {
+        self.config_summary = Some(summary);
     }
 
     fn build_providers(
@@ -1016,7 +1023,7 @@ impl LoadRunner {
 
             if use_live_display || use_snapshot_tx {
                 if last_progress_report.elapsed() >= DISPLAY_RENDER_INTERVAL {
-                    self.collector.sample_throughput();
+                    self.collector.sample_throughput(start.elapsed());
                     let snap = self.build_snapshot(
                         start,
                         &confirmer_handle,
@@ -1032,7 +1039,7 @@ impl LoadRunner {
                     last_progress_report = Instant::now();
                 }
             } else if last_progress_report.elapsed() >= PROGRESS_REPORT_INTERVAL {
-                self.collector.sample_throughput();
+                self.collector.sample_throughput(start.elapsed());
                 let elapsed_secs = start.elapsed().as_secs();
                 let submitted = self.collector.submitted_count();
                 let confirmed = self.collector.confirmed_count();
@@ -1331,7 +1338,7 @@ impl LoadRunner {
         let confirmed = self.collector.confirmed_count();
         info!(confirmed, submitted, "confirmation collection complete");
 
-        Ok(self.collector.summarize(last_confirmed_at))
+        Ok(self.collector.summarize(last_confirmed_at, self.config_summary.clone()))
     }
 
     fn build_snapshot(

--- a/crates/infra/load-tests/tests/smoke.rs
+++ b/crates/infra/load-tests/tests/smoke.rs
@@ -122,7 +122,7 @@ fn metrics_summary_latency() {
         ));
     }
 
-    let summary = collector.summarize(Duration::from_secs(10));
+    let summary = collector.summarize(Duration::from_secs(10), None);
 
     assert_eq!(summary.throughput.total_confirmed, 5);
 
@@ -157,7 +157,7 @@ fn metrics_summary_gas() {
         Some(2),
     ));
 
-    let summary = collector.summarize(Duration::from_secs(10));
+    let summary = collector.summarize(Duration::from_secs(10), None);
 
     assert_eq!(summary.gas.total_gas, 63000);
     assert_eq!(summary.gas.avg_gas, 31500);
@@ -176,7 +176,7 @@ fn metrics_summary_json_serialization() {
         Some(1),
     ));
 
-    let summary = collector.summarize(Duration::from_secs(10));
+    let summary = collector.summarize(Duration::from_secs(10), None);
     let json = summary.to_json().unwrap();
 
     assert!(json.contains("block_latency"));


### PR DESCRIPTION
## Summary
- Add throughput timeseries (`elapsed_secs`, `tps`, `gps`) for graphing TPS over time
- Add config summary to JSON output (excludes URLs and secrets)
- Write JSON even on early failures (funding, setup) with error field
- Fix clippy error in ctx.rs (move b256 import)