### PR TITLE
test(devnet): Add End-To-End FCU Latency Test

### DIFF
--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -313,7 +313,17 @@ jobs:
       - name: Pre-pull docker images
         run: just devnet pull-images
       - name: Run devnet tests
+        env:
+          FCU_LATENCY_OUTPUT: ${{ runner.temp }}/fcu_latency.json
         run: just devnet tests-ci
+      - name: Upload FCU latency summary
+        if: always()
+        uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b # v4.5.0
+        with:
+          name: fcu-latency
+          path: ${{ runner.temp }}/fcu_latency.json
+          if-no-files-found: ignore
+          retention-days: 30
       - name: Check for JUnit testcases
         if: always()
         id: junit-results

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8050,6 +8050,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+ "tracing-subscriber 0.3.23",
  "url",
 ]
 

--- a/crates/consensus/engine/src/task_queue/tasks/synchronize/task.rs
+++ b/crates/consensus/engine/src/task_queue/tasks/synchronize/task.rs
@@ -165,6 +165,7 @@ impl<EngineClient_: EngineClient> EngineTaskExt for SynchronizeTask<EngineClient
         debug!(
             target: "engine",
             fcu_duration = ?fcu_duration,
+            fcu_duration_us = fcu_duration.as_micros() as u64,
             forkchoice = ?forkchoice,
             ?confirmed,
             response = ?valid_response,

--- a/crates/proof/succinct/elf/manifest.toml
+++ b/crates/proof/succinct/elf/manifest.toml
@@ -14,7 +14,7 @@
 
 [[elfs]]
 name = "range-elf-embedded"
-sha256 = "4effbbc475936182d1541085142742bbda0675dc659280965ca2ac7fa1769e4d"
+sha256 = "02b82e3eefd5dd4d6c21f55aea13ac3367f05ec009b0904e7719c5011703bc69"
 
 [[elfs]]
 name = "aggregation-elf"

--- a/devnet/Cargo.toml
+++ b/devnet/Cargo.toml
@@ -89,3 +89,6 @@ alloy-consensus = { workspace = true, features = ["std"] }
 
 # base-alloy
 base-common-rpc-types.workspace = true
+
+# tracing capture
+tracing-subscriber = { workspace = true, features = ["env-filter", "registry", "fmt"] }

--- a/devnet/tests/fcu_latency.rs
+++ b/devnet/tests/fcu_latency.rs
@@ -27,9 +27,7 @@ use eyre::{Result, WrapErr};
 use serde::Serialize;
 use tokio::time::{sleep, timeout};
 use tracing::{Event, Subscriber, field::Visit};
-use tracing_subscriber::{
-    EnvFilter, Layer, layer::Context, prelude::*, registry::LookupSpan,
-};
+use tracing_subscriber::{EnvFilter, Layer, layer::Context, prelude::*, registry::LookupSpan};
 
 const L1_CHAIN_ID: u64 = 1337;
 const L2_CHAIN_ID: u64 = 84538453;

--- a/devnet/tests/fcu_latency.rs
+++ b/devnet/tests/fcu_latency.rs
@@ -1,0 +1,208 @@
+//! End-to-end FCU latency measurement against the full devnet stack.
+//!
+//! Captures the `fcu_duration_us` field emitted by the consensus engine's
+//! [`SynchronizeTask`] every time it issues an `engine_forkchoiceUpdatedV3`
+//! call to reth. Both the L2 builder and L2 client consensus nodes run
+//! in-process, so a single global tracing subscriber sees every FCU from both
+//! and we get an aggregated end-to-end view that includes the gossip → mpsc →
+//! engine task queue → newPayload → FCU path that the in-process microbench
+//! cannot exercise.
+//!
+//! On completion the test asserts a generous mean bound (regression guard)
+//! and writes a JSON summary to `${FCU_LATENCY_OUTPUT}` (default
+//! `target/fcu_latency.json`) for CI artifact upload and trend visibility.
+
+use std::{
+    env,
+    fs::File,
+    io::Write,
+    path::PathBuf,
+    sync::{Arc, Mutex},
+    time::Duration,
+};
+
+use alloy_provider::Provider;
+use devnet::DevnetBuilder;
+use eyre::{Result, WrapErr};
+use serde::Serialize;
+use tokio::time::{sleep, timeout};
+use tracing::{Event, Subscriber, field::Visit};
+use tracing_subscriber::{
+    EnvFilter, Layer, layer::Context, prelude::*, registry::LookupSpan,
+};
+
+const L1_CHAIN_ID: u64 = 1337;
+const L2_CHAIN_ID: u64 = 84538453;
+
+/// Number of L2 blocks to observe before snapshotting samples.
+///
+/// With both consensus nodes running in-process we capture roughly two FCU
+/// samples per produced block (sequencer + validator), so 25 blocks yields ~50
+/// samples — enough for a stable mean and p50, marginal for p95.
+const TARGET_BLOCKS: u64 = 25;
+
+const BLOCK_PRODUCTION_TIMEOUT: Duration = Duration::from_secs(180);
+const BLOCK_POLL_INTERVAL: Duration = Duration::from_millis(500);
+
+/// Loose mean bound. Devnet runs both nodes locally with IPC engine transport,
+/// so real FCU latency is sub-millisecond. 50 ms is generous enough to absorb
+/// CI noise while still catching gross regressions (e.g. accidental synchronous
+/// I/O on the FCU path).
+const MAX_MEAN_US: u64 = 50_000;
+
+/// Minimum FCU samples required for the assertions to be meaningful.
+const MIN_SAMPLES: usize = 20;
+
+#[tokio::test]
+async fn fcu_latency_under_devnet_block_production() -> Result<()> {
+    let samples = install_fcu_capture_subscriber();
+
+    let devnet = DevnetBuilder::new()
+        .with_l1_chain_id(L1_CHAIN_ID)
+        .with_l2_chain_id(L2_CHAIN_ID)
+        .build()
+        .await?;
+
+    let l2_builder = devnet.l2_builder_provider()?;
+
+    timeout(BLOCK_PRODUCTION_TIMEOUT, async {
+        loop {
+            let block = l2_builder.get_block_number().await?;
+            if block >= TARGET_BLOCKS {
+                return Ok::<_, eyre::Error>(block);
+            }
+            sleep(BLOCK_POLL_INTERVAL).await;
+        }
+    })
+    .await
+    .wrap_err("L2 builder did not reach target block count in time")??;
+
+    let collected = samples.lock().expect("samples lock not poisoned").clone();
+    assert!(
+        collected.len() >= MIN_SAMPLES,
+        "expected at least {MIN_SAMPLES} FCU samples after {TARGET_BLOCKS} blocks, got {}",
+        collected.len(),
+    );
+
+    let stats = LatencyStats::from_samples(&collected);
+    eprintln!(
+        "fcu_latency: samples={} mean={}µs p50={}µs p95={}µs max={}µs",
+        stats.samples, stats.mean_us, stats.p50_us, stats.p95_us, stats.max_us
+    );
+
+    write_summary(&stats).wrap_err("failed to write fcu_latency summary")?;
+
+    assert!(
+        stats.mean_us <= MAX_MEAN_US,
+        "FCU mean latency {}µs exceeds budget of {}µs (samples={}, p95={}µs, max={}µs)",
+        stats.mean_us,
+        MAX_MEAN_US,
+        stats.samples,
+        stats.p95_us,
+        stats.max_us,
+    );
+
+    Ok(())
+}
+
+/// Installs a global tracing subscriber that records `fcu_duration_us` u64
+/// fields from `target = "engine"` events into the returned shared buffer.
+///
+/// Must be called before any in-process node spawns its tasks so the
+/// subscriber is the global default they inherit. Safe to call exactly once
+/// per test process — repeated installs no-op.
+fn install_fcu_capture_subscriber() -> Arc<Mutex<Vec<u64>>> {
+    let samples = Arc::new(Mutex::new(Vec::<u64>::new()));
+    let layer = FcuCaptureLayer { samples: Arc::clone(&samples) };
+
+    let env_filter = EnvFilter::builder()
+        .with_default_directive(tracing::level_filters::LevelFilter::WARN.into())
+        .parse_lossy("warn,engine=debug,reth_tasks=off,reth_node_builder::launch::common=off");
+
+    let _ = tracing_subscriber::registry().with(env_filter).with(layer).try_init();
+
+    samples
+}
+
+struct FcuCaptureLayer {
+    samples: Arc<Mutex<Vec<u64>>>,
+}
+
+impl<S> Layer<S> for FcuCaptureLayer
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+{
+    fn on_event(&self, event: &Event<'_>, _ctx: Context<'_, S>) {
+        if event.metadata().target() != "engine" {
+            return;
+        }
+        let mut visitor = FcuVisitor { duration_us: None };
+        event.record(&mut visitor);
+        if let Some(d) = visitor.duration_us
+            && let Ok(mut guard) = self.samples.lock()
+        {
+            guard.push(d);
+        }
+    }
+}
+
+struct FcuVisitor {
+    duration_us: Option<u64>,
+}
+
+impl Visit for FcuVisitor {
+    fn record_u64(&mut self, field: &tracing::field::Field, value: u64) {
+        if field.name() == "fcu_duration_us" {
+            self.duration_us = Some(value);
+        }
+    }
+
+    fn record_debug(&mut self, _: &tracing::field::Field, _: &dyn std::fmt::Debug) {}
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct LatencyStats {
+    samples: usize,
+    mean_us: u64,
+    p50_us: u64,
+    p95_us: u64,
+    max_us: u64,
+}
+
+impl LatencyStats {
+    fn from_samples(samples: &[u64]) -> Self {
+        let mut sorted = samples.to_vec();
+        sorted.sort_unstable();
+        let mean_us = sorted.iter().sum::<u64>() / sorted.len() as u64;
+        Self {
+            samples: sorted.len(),
+            mean_us,
+            p50_us: percentile(&sorted, 50),
+            p95_us: percentile(&sorted, 95),
+            max_us: *sorted.last().expect("non-empty after MIN_SAMPLES check"),
+        }
+    }
+}
+
+/// Nearest-rank percentile on a pre-sorted slice. `rank` is 1..=99.
+fn percentile(sorted: &[u64], rank: u8) -> u64 {
+    debug_assert!(!sorted.is_empty());
+    let idx = ((rank as usize * sorted.len()) / 100).min(sorted.len() - 1);
+    sorted[idx]
+}
+
+fn write_summary(stats: &LatencyStats) -> Result<()> {
+    let path = env::var_os("FCU_LATENCY_OUTPUT")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from("target/fcu_latency.json"));
+
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).wrap_err("failed to create summary dir")?;
+    }
+
+    let mut file = File::create(&path).wrap_err_with(|| format!("create {}", path.display()))?;
+    file.write_all(&serde_json::to_vec_pretty(stats)?)?;
+    file.write_all(b"\n")?;
+    eprintln!("fcu_latency: wrote summary to {}", path.display());
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Adds a devnet integration test that captures `fcu_duration_us` events emitted by the consensus engine's `SynchronizeTask` and asserts a generous bound on mean FCU latency across both in-process consensus nodes. The test installs a global tracing subscriber with a custom layer before devnet boots, advances 25 L2 blocks, then computes mean, p50, and p95 from the raw samples and writes a JSON summary to `${FCU_LATENCY_OUTPUT}` for CI artifact upload. A one-line addition in `SynchronizeTask` exposes `fcu_duration_us` as a structured `u64` field alongside the existing `fcu_duration` so the visitor can capture it via `record_u64` without parsing `Duration`'s Debug repr. The devnet job in CI now uploads the summary as the `fcu-latency` artifact with 30-day retention so latency trends are visible across runs.