### PR TITLE
refactor(chains): Split Bootnodes By Stack Layer

### DIFF
--- a/crates/common/chains/src/config.rs
+++ b/crates/common/chains/src/config.rs
@@ -99,12 +99,37 @@ pub struct ChainConfig {
     pub max_gas_limit: u64,
 
     // Networking
-    /// Raw bootnode strings (ENR or enode format) for consensus discovery.
-    pub bootnodes: &'static [&'static str],
+    /// Bootnodes for peer discovery, split by stack layer.
+    pub bootnodes: Bootnodes,
 
     // Execution genesis
     /// Embedded genesis JSON for reth alloc tables.
     pub genesis_json: &'static str,
+}
+
+/// Raw bootnode strings split by the stack layer that should consume them.
+///
+/// Execution and consensus run independent discv5 networks (different protocol
+/// IDs and ports). Mixing them at bootstrap time is wasted work — and broken,
+/// since each side will fail to authenticate the other's packets.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Bootnodes {
+    /// Bootnodes for the execution-layer discv5 network (enode URLs on the
+    /// EL discovery ports, e.g. 30301 / 9200).
+    pub execution: &'static [&'static str],
+    /// Bootnodes for the consensus-layer discv5 network (ENRs on the CL
+    /// discovery port, e.g. 9222).
+    pub consensus: &'static [&'static str],
+}
+
+impl Bootnodes {
+    /// Empty bootnodes for both layers.
+    pub const EMPTY: Self = Self { execution: &[], consensus: &[] };
+
+    /// Total number of raw bootnode entries across both layers.
+    pub const fn total(&self) -> usize {
+        self.execution.len() + self.consensus.len()
+    }
 }
 
 impl ChainConfig {
@@ -283,23 +308,27 @@ const MAINNET: ChainConfig = ChainConfig {
 
     max_gas_limit: 105_000_000,
 
-    bootnodes: &[
-        "enr:-J24QNz9lbrKbN4iSmmjtnr7SjUMk4zB7f1krHZcTZx-JRKZd0kA2gjufUROD6T3sOWDVDnFJRvqBBo62zuF-hYCohOGAYiOoEyEgmlkgnY0gmlwhAPniryHb3BzdGFja4OFQgCJc2VjcDI1NmsxoQKNVFlCxh_B-716tTs-h1vMzZkSs1FTu_OYTNjgufplG4N0Y3CCJAaDdWRwgiQG",
-        "enr:-J24QH-f1wt99sfpHy4c0QJM-NfmsIfmlLAMMcgZCUEgKG_BBYFc6FwYgaMJMQN5dsRBJApIok0jFn-9CS842lGpLmqGAYiOoDRAgmlkgnY0gmlwhLhIgb2Hb3BzdGFja4OFQgCJc2VjcDI1NmsxoQJ9FTIv8B9myn1MWaC_2lJ-sMoeCDkusCsk4BYHjjCq04N0Y3CCJAaDdWRwgiQG",
-        "enr:-J24QDXyyxvQYsd0yfsN0cRr1lZ1N11zGTplMNlW4xNEc7LkPXh0NAJ9iSOVdRO95GPYAIc6xmyoCCG6_0JxdL3a0zaGAYiOoAjFgmlkgnY0gmlwhAPckbGHb3BzdGFja4OFQgCJc2VjcDI1NmsxoQJwoS7tzwxqXSyFL7g0JM-KWVbgvjfB8JA__T7yY_cYboN0Y3CCJAaDdWRwgiQG",
-        "enr:-J24QHmGyBwUZXIcsGYMaUqGGSl4CFdx9Tozu-vQCn5bHIQbR7On7dZbU61vYvfrJr30t0iahSqhc64J46MnUO2JvQaGAYiOoCKKgmlkgnY0gmlwhAPnCzSHb3BzdGFja4OFQgCJc2VjcDI1NmsxoQINc4fSijfbNIiGhcgvwjsjxVFJHUstK9L1T8OTKUjgloN0Y3CCJAaDdWRwgiQG",
-        "enr:-J24QG3ypT4xSu0gjb5PABCmVxZqBjVw9ca7pvsI8jl4KATYAnxBmfkaIuEqy9sKvDHKuNCsy57WwK9wTt2aQgcaDDyGAYiOoGAXgmlkgnY0gmlwhDbGmZaHb3BzdGFja4OFQgCJc2VjcDI1NmsxoQIeAK_--tcLEiu7HvoUlbV52MspE0uCocsx1f_rYvRenIN0Y3CCJAaDdWRwgiQG",
-        "enode://87a32fd13bd596b2ffca97020e31aef4ddcc1bbd4b95bb633d16c1329f654f34049ed240a36b449fda5e5225d70fe40bc667f53c304b71f8e68fc9d448690b51@3.231.138.188:30301",
-        "enode://87a32fd13bd596b2ffca97020e31aef4ddcc1bbd4b95bb633d16c1329f654f34049ed240a36b449fda5e5225d70fe40bc667f53c304b71f8e68fc9d448690b51@3.231.138.188:9200",
-        "enode://ca21ea8f176adb2e229ce2d700830c844af0ea941a1d8152a9513b966fe525e809c3a6c73a2c18a12b74ed6ec4380edf91662778fe0b79f6a591236e49e176f9@184.72.129.189:30301",
-        "enode://ca21ea8f176adb2e229ce2d700830c844af0ea941a1d8152a9513b966fe525e809c3a6c73a2c18a12b74ed6ec4380edf91662778fe0b79f6a591236e49e176f9@184.72.129.189:9200",
-        "enode://acf4507a211ba7c1e52cdf4eef62cdc3c32e7c9c47998954f7ba024026f9a6b2150cd3f0b734d9c78e507ab70d59ba61dfe5c45e1078c7ad0775fb251d7735a2@3.220.145.177:30301",
-        "enode://acf4507a211ba7c1e52cdf4eef62cdc3c32e7c9c47998954f7ba024026f9a6b2150cd3f0b734d9c78e507ab70d59ba61dfe5c45e1078c7ad0775fb251d7735a2@3.220.145.177:9200",
-        "enode://8a5a5006159bf079d06a04e5eceab2a1ce6e0f721875b2a9c96905336219dbe14203d38f70f3754686a6324f786c2f9852d8c0dd3adac2d080f4db35efc678c5@3.231.11.52:30301",
-        "enode://8a5a5006159bf079d06a04e5eceab2a1ce6e0f721875b2a9c96905336219dbe14203d38f70f3754686a6324f786c2f9852d8c0dd3adac2d080f4db35efc678c5@3.231.11.52:9200",
-        "enode://cdadbe835308ad3557f9a1de8db411da1a260a98f8421d62da90e71da66e55e98aaa8e90aa7ce01b408a54e4bd2253d701218081ded3dbe5efbbc7b41d7cef79@54.198.153.150:30301",
-        "enode://cdadbe835308ad3557f9a1de8db411da1a260a98f8421d62da90e71da66e55e98aaa8e90aa7ce01b408a54e4bd2253d701218081ded3dbe5efbbc7b41d7cef79@54.198.153.150:9200",
-    ],
+    bootnodes: Bootnodes {
+        execution: &[
+            "enode://87a32fd13bd596b2ffca97020e31aef4ddcc1bbd4b95bb633d16c1329f654f34049ed240a36b449fda5e5225d70fe40bc667f53c304b71f8e68fc9d448690b51@3.231.138.188:30301",
+            "enode://87a32fd13bd596b2ffca97020e31aef4ddcc1bbd4b95bb633d16c1329f654f34049ed240a36b449fda5e5225d70fe40bc667f53c304b71f8e68fc9d448690b51@3.231.138.188:9200",
+            "enode://ca21ea8f176adb2e229ce2d700830c844af0ea941a1d8152a9513b966fe525e809c3a6c73a2c18a12b74ed6ec4380edf91662778fe0b79f6a591236e49e176f9@184.72.129.189:30301",
+            "enode://ca21ea8f176adb2e229ce2d700830c844af0ea941a1d8152a9513b966fe525e809c3a6c73a2c18a12b74ed6ec4380edf91662778fe0b79f6a591236e49e176f9@184.72.129.189:9200",
+            "enode://acf4507a211ba7c1e52cdf4eef62cdc3c32e7c9c47998954f7ba024026f9a6b2150cd3f0b734d9c78e507ab70d59ba61dfe5c45e1078c7ad0775fb251d7735a2@3.220.145.177:30301",
+            "enode://acf4507a211ba7c1e52cdf4eef62cdc3c32e7c9c47998954f7ba024026f9a6b2150cd3f0b734d9c78e507ab70d59ba61dfe5c45e1078c7ad0775fb251d7735a2@3.220.145.177:9200",
+            "enode://8a5a5006159bf079d06a04e5eceab2a1ce6e0f721875b2a9c96905336219dbe14203d38f70f3754686a6324f786c2f9852d8c0dd3adac2d080f4db35efc678c5@3.231.11.52:30301",
+            "enode://8a5a5006159bf079d06a04e5eceab2a1ce6e0f721875b2a9c96905336219dbe14203d38f70f3754686a6324f786c2f9852d8c0dd3adac2d080f4db35efc678c5@3.231.11.52:9200",
+            "enode://cdadbe835308ad3557f9a1de8db411da1a260a98f8421d62da90e71da66e55e98aaa8e90aa7ce01b408a54e4bd2253d701218081ded3dbe5efbbc7b41d7cef79@54.198.153.150:30301",
+            "enode://cdadbe835308ad3557f9a1de8db411da1a260a98f8421d62da90e71da66e55e98aaa8e90aa7ce01b408a54e4bd2253d701218081ded3dbe5efbbc7b41d7cef79@54.198.153.150:9200",
+        ],
+        consensus: &[
+            "enr:-J24QNz9lbrKbN4iSmmjtnr7SjUMk4zB7f1krHZcTZx-JRKZd0kA2gjufUROD6T3sOWDVDnFJRvqBBo62zuF-hYCohOGAYiOoEyEgmlkgnY0gmlwhAPniryHb3BzdGFja4OFQgCJc2VjcDI1NmsxoQKNVFlCxh_B-716tTs-h1vMzZkSs1FTu_OYTNjgufplG4N0Y3CCJAaDdWRwgiQG",
+            "enr:-J24QH-f1wt99sfpHy4c0QJM-NfmsIfmlLAMMcgZCUEgKG_BBYFc6FwYgaMJMQN5dsRBJApIok0jFn-9CS842lGpLmqGAYiOoDRAgmlkgnY0gmlwhLhIgb2Hb3BzdGFja4OFQgCJc2VjcDI1NmsxoQJ9FTIv8B9myn1MWaC_2lJ-sMoeCDkusCsk4BYHjjCq04N0Y3CCJAaDdWRwgiQG",
+            "enr:-J24QDXyyxvQYsd0yfsN0cRr1lZ1N11zGTplMNlW4xNEc7LkPXh0NAJ9iSOVdRO95GPYAIc6xmyoCCG6_0JxdL3a0zaGAYiOoAjFgmlkgnY0gmlwhAPckbGHb3BzdGFja4OFQgCJc2VjcDI1NmsxoQJwoS7tzwxqXSyFL7g0JM-KWVbgvjfB8JA__T7yY_cYboN0Y3CCJAaDdWRwgiQG",
+            "enr:-J24QHmGyBwUZXIcsGYMaUqGGSl4CFdx9Tozu-vQCn5bHIQbR7On7dZbU61vYvfrJr30t0iahSqhc64J46MnUO2JvQaGAYiOoCKKgmlkgnY0gmlwhAPnCzSHb3BzdGFja4OFQgCJc2VjcDI1NmsxoQINc4fSijfbNIiGhcgvwjsjxVFJHUstK9L1T8OTKUjgloN0Y3CCJAaDdWRwgiQG",
+            "enr:-J24QG3ypT4xSu0gjb5PABCmVxZqBjVw9ca7pvsI8jl4KATYAnxBmfkaIuEqy9sKvDHKuNCsy57WwK9wTt2aQgcaDDyGAYiOoGAXgmlkgnY0gmlwhDbGmZaHb3BzdGFja4OFQgCJc2VjcDI1NmsxoQIeAK_--tcLEiu7HvoUlbV52MspE0uCocsx1f_rYvRenIN0Y3CCJAaDdWRwgiQG",
+        ],
+    },
 
     genesis_json: include_str!("../res/genesis/base.json"),
 };
@@ -349,14 +378,18 @@ const SEPOLIA: ChainConfig = ChainConfig {
 
     max_gas_limit: 45_000_000,
 
-    bootnodes: &[
-        "enode://548f715f3fc388a7c917ba644a2f16270f1ede48a5d88a4d14ea287cc916068363f3092e39936f1a3e7885198bef0e5af951f1d7b1041ce8ba4010917777e71f@18.210.176.114:30301",
-        "enode://548f715f3fc388a7c917ba644a2f16270f1ede48a5d88a4d14ea287cc916068363f3092e39936f1a3e7885198bef0e5af951f1d7b1041ce8ba4010917777e71f@18.210.176.114:9200",
-        "enode://6f10052847a966a725c9f4adf6716f9141155b99a0fb487fea3f51498f4c2a2cb8d534e680ee678f9447db85b93ff7c74562762c3714783a7233ac448603b25f@107.21.251.55:30301",
-        "enode://6f10052847a966a725c9f4adf6716f9141155b99a0fb487fea3f51498f4c2a2cb8d534e680ee678f9447db85b93ff7c74562762c3714783a7233ac448603b25f@107.21.251.55:9200",
-        "enr:-J64QFa3qMsONLGphfjEkeYyF6Jkil_jCuJmm7_a42ckZeUQGLVzrzstZNb1dgBp1GGx9bzImq5VxJLP-BaptZThGiWGAYrTytOvgmlkgnY0gmlwhGsV-zeHb3BzdGFja4S0lAUAiXNlY3AyNTZrMaEDahfSECTIS_cXyZ8IyNf4leANlZnrsMEWTkEYxf4GMCmDdGNwgiQGg3VkcIIkBg",
-        "enr:-J64QBwRIWAco7lv6jImSOjPU_W266lHXzpAS5YOh7WmgTyBZkgLgOwo_mxKJq3wz2XRbsoBItbv1dCyjIoNq67mFguGAYrTxM42gmlkgnY0gmlwhBLSsHKHb3BzdGFja4S0lAUAiXNlY3AyNTZrMaEDmoWSi8hcsRpQf2eJsNUx-sqv6fH4btmo2HsAzZFAKnKDdGNwgiQGg3VkcIIkBg",
-    ],
+    bootnodes: Bootnodes {
+        execution: &[
+            "enode://548f715f3fc388a7c917ba644a2f16270f1ede48a5d88a4d14ea287cc916068363f3092e39936f1a3e7885198bef0e5af951f1d7b1041ce8ba4010917777e71f@18.210.176.114:30301",
+            "enode://548f715f3fc388a7c917ba644a2f16270f1ede48a5d88a4d14ea287cc916068363f3092e39936f1a3e7885198bef0e5af951f1d7b1041ce8ba4010917777e71f@18.210.176.114:9200",
+            "enode://6f10052847a966a725c9f4adf6716f9141155b99a0fb487fea3f51498f4c2a2cb8d534e680ee678f9447db85b93ff7c74562762c3714783a7233ac448603b25f@107.21.251.55:30301",
+            "enode://6f10052847a966a725c9f4adf6716f9141155b99a0fb487fea3f51498f4c2a2cb8d534e680ee678f9447db85b93ff7c74562762c3714783a7233ac448603b25f@107.21.251.55:9200",
+        ],
+        consensus: &[
+            "enr:-J64QFa3qMsONLGphfjEkeYyF6Jkil_jCuJmm7_a42ckZeUQGLVzrzstZNb1dgBp1GGx9bzImq5VxJLP-BaptZThGiWGAYrTytOvgmlkgnY0gmlwhGsV-zeHb3BzdGFja4S0lAUAiXNlY3AyNTZrMaEDahfSECTIS_cXyZ8IyNf4leANlZnrsMEWTkEYxf4GMCmDdGNwgiQGg3VkcIIkBg",
+            "enr:-J64QBwRIWAco7lv6jImSOjPU_W266lHXzpAS5YOh7WmgTyBZkgLgOwo_mxKJq3wz2XRbsoBItbv1dCyjIoNq67mFguGAYrTxM42gmlkgnY0gmlwhBLSsHKHb3BzdGFja4S0lAUAiXNlY3AyNTZrMaEDmoWSi8hcsRpQf2eJsNUx-sqv6fH4btmo2HsAzZFAKnKDdGNwgiQGg3VkcIIkBg",
+        ],
+    },
 
     genesis_json: include_str!("../res/genesis/sepolia_base.json"),
 };
@@ -406,7 +439,7 @@ const DEVNET: ChainConfig = ChainConfig {
 
     max_gas_limit: 30_000_000,
 
-    bootnodes: &[],
+    bootnodes: Bootnodes::EMPTY,
 
     genesis_json: include_str!("../res/genesis/dev.json"),
 };
@@ -456,14 +489,18 @@ const ZERONET: ChainConfig = ChainConfig {
 
     max_gas_limit: 25_000_000,
 
-    bootnodes: &[
-        "enr:-J-4QDS5Z5P4BoDbOlLGOcdXjcv2Nc5_PgP28lIxP4lKU6qYR-m10c8rHdcHk0DdmTvZpndoSpuK__688dmX-tlOsNKGAZ22NI20gmlkgnY0gmlwhCzGBHaHb3BzdGFja4WA-80FAIlzZWNwMjU2azGhA4Qs8_ZWeMdUNldNdjnAxd018gjWofqKoW4_pr0qzvTtg3RjcIIkBoN1ZHCCJAY",
-        "enode://cd4528698249ad8b36fa7b1cad75aa5683ad355e6f0776629eaff1d83cfbb575062330d711efefbfa0d531c86969c2daf9a88fb28cddbbad216f46ac367981eb@44.198.4.118:30301",
-        "enode://cd4528698249ad8b36fa7b1cad75aa5683ad355e6f0776629eaff1d83cfbb575062330d711efefbfa0d531c86969c2daf9a88fb28cddbbad216f46ac367981eb@44.198.4.118:9200",
-        "enr:-J-4QKgMF6zAv7u_75LTXLJKgLtEn4HcI8gaqsDAl78nfw7VQE-EN6dUZCZW4_CI42MAOWUCinrV8rP5hbBu3aje-u-GAZ22LUBogmlkgnY0gmlwhDQCC1-Hb3BzdGFja4WA-80FAIlzZWNwMjU2azGhArwjzoKlEKQiEXtuZ0qT23Wy_3IeEXbAJo7VKDO2Yovig3RjcIIkBoN1ZHCCJAY",
-        "enode://ea188fb5482ff8eb372956d674ecb6d09cbd42e6874121957a47b2ad252f54953c49866d2dcabcfc272fcc63e163a67b097fe4354283e56ddf077fc017b2a127@52.2.11.95:30301",
-        "enode://ea188fb5482ff8eb372956d674ecb6d09cbd42e6874121957a47b2ad252f54953c49866d2dcabcfc272fcc63e163a67b097fe4354283e56ddf077fc017b2a127@52.2.11.95:9200",
-    ],
+    bootnodes: Bootnodes {
+        execution: &[
+            "enode://cd4528698249ad8b36fa7b1cad75aa5683ad355e6f0776629eaff1d83cfbb575062330d711efefbfa0d531c86969c2daf9a88fb28cddbbad216f46ac367981eb@44.198.4.118:30301",
+            "enode://cd4528698249ad8b36fa7b1cad75aa5683ad355e6f0776629eaff1d83cfbb575062330d711efefbfa0d531c86969c2daf9a88fb28cddbbad216f46ac367981eb@44.198.4.118:9200",
+            "enode://ea188fb5482ff8eb372956d674ecb6d09cbd42e6874121957a47b2ad252f54953c49866d2dcabcfc272fcc63e163a67b097fe4354283e56ddf077fc017b2a127@52.2.11.95:30301",
+            "enode://ea188fb5482ff8eb372956d674ecb6d09cbd42e6874121957a47b2ad252f54953c49866d2dcabcfc272fcc63e163a67b097fe4354283e56ddf077fc017b2a127@52.2.11.95:9200",
+        ],
+        consensus: &[
+            "enr:-J-4QDS5Z5P4BoDbOlLGOcdXjcv2Nc5_PgP28lIxP4lKU6qYR-m10c8rHdcHk0DdmTvZpndoSpuK__688dmX-tlOsNKGAZ22NI20gmlkgnY0gmlwhCzGBHaHb3BzdGFja4WA-80FAIlzZWNwMjU2azGhA4Qs8_ZWeMdUNldNdjnAxd018gjWofqKoW4_pr0qzvTtg3RjcIIkBoN1ZHCCJAY",
+            "enr:-J-4QKgMF6zAv7u_75LTXLJKgLtEn4HcI8gaqsDAl78nfw7VQE-EN6dUZCZW4_CI42MAOWUCinrV8rP5hbBu3aje-u-GAZ22LUBogmlkgnY0gmlwhDQCC1-Hb3BzdGFja4WA-80FAIlzZWNwMjU2azGhArwjzoKlEKQiEXtuZ0qT23Wy_3IeEXbAJo7VKDO2Yovig3RjcIIkBoN1ZHCCJAY",
+        ],
+    },
 
     genesis_json: include_str!("../res/genesis/zeronet_base.json"),
 };

--- a/crates/common/chains/src/lib.rs
+++ b/crates/common/chains/src/lib.rs
@@ -6,7 +6,7 @@
 extern crate alloc;
 
 mod config;
-pub use config::ChainConfig;
+pub use config::{Bootnodes, ChainConfig};
 
 mod upgrade;
 pub use upgrade::BaseUpgrade;

--- a/crates/consensus/disc/src/driver.rs
+++ b/crates/consensus/disc/src/driver.rs
@@ -461,9 +461,8 @@ mod tests {
             })
             .collect();
 
-        // There should be 6 valid boot nodes for the testnet:
-        // 2 ENRs + 4 enodes (each enode listed on ports 30301 and 9200).
-        assert_eq!(testnet.len(), 6);
+        // `BootNodes::testnet()` returns CL bootnodes only — 2 raw ENRs.
+        assert_eq!(testnet.len(), 2);
 
         // Those ENRs should be in the testnet bootnodes.
         for enr in &enrs {
@@ -502,9 +501,8 @@ mod tests {
             })
             .collect();
 
-        // There should be 15 valid boot nodes for the mainnet:
-        // 5 Base Mainnet ENRs + 10 Base enodes (each enode listed on ports 30301 and 9200).
-        assert_eq!(mainnet.len(), 15);
+        // `BootNodes::mainnet()` returns CL bootnodes only — 5 raw ENRs.
+        assert_eq!(mainnet.len(), 5);
 
         let socket = SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 0);
 
@@ -533,9 +531,10 @@ mod tests {
             &discovery.disc,
         )
         .await;
+        // All 5 CL ENRs are added directly without I/O — no liveness check needed.
         assert!(
-            discovery.disc.table_entries_enr().len() >= 10,
-            "Discovery table should have at least 10 ENRs"
+            discovery.disc.table_entries_enr().len() >= 5,
+            "Discovery table should have at least 5 ENRs"
         );
 
         // Those ENRs should be in the mainnet bootnodes.

--- a/crates/consensus/peers/src/nodes.rs
+++ b/crates/consensus/peers/src/nodes.rs
@@ -15,6 +15,7 @@ impl TryFrom<&ChainConfig> for BootNodes {
     fn try_from(config: &ChainConfig) -> Result<Self, Self::Error> {
         config
             .bootnodes
+            .consensus
             .iter()
             .map(|raw| BootNode::parse_bootnode(raw))
             .collect::<Result<Vec<_>, _>>()
@@ -61,36 +62,34 @@ mod tests {
 
     #[test]
     fn test_validate_bootnode_lens() {
-        assert_eq!(ChainConfig::mainnet().bootnodes.len(), 15);
-        assert_eq!(ChainConfig::sepolia().bootnodes.len(), 6);
-        assert_eq!(ChainConfig::zeronet().bootnodes.len(), 6);
+        assert_eq!(ChainConfig::mainnet().bootnodes.execution.len(), 10);
+        assert_eq!(ChainConfig::mainnet().bootnodes.consensus.len(), 5);
+        assert_eq!(ChainConfig::sepolia().bootnodes.execution.len(), 4);
+        assert_eq!(ChainConfig::sepolia().bootnodes.consensus.len(), 2);
+        assert_eq!(ChainConfig::zeronet().bootnodes.execution.len(), 4);
+        assert_eq!(ChainConfig::zeronet().bootnodes.consensus.len(), 2);
     }
 
     #[test]
     fn test_parse_raw_bootnodes() {
-        for raw in ChainConfig::mainnet().bootnodes {
-            BootNode::parse_bootnode(raw).expect("hardcoded bootnode should parse");
-        }
-
-        for raw in ChainConfig::sepolia().bootnodes {
-            BootNode::parse_bootnode(raw).expect("hardcoded bootnode should parse");
-        }
-
-        for raw in ChainConfig::zeronet().bootnodes {
-            BootNode::parse_bootnode(raw).expect("hardcoded bootnode should parse");
+        for cfg in [ChainConfig::mainnet(), ChainConfig::sepolia(), ChainConfig::zeronet()] {
+            for raw in cfg.bootnodes.execution.iter().chain(cfg.bootnodes.consensus.iter()) {
+                BootNode::parse_bootnode(raw).expect("hardcoded bootnode should parse");
+            }
         }
     }
 
     #[test]
     fn test_bootnodes_from_chain_id() {
+        // `BootNodes::from_chain_id` returns CL bootnodes only.
         let mainnet = BootNodes::from_chain_id(ChainConfig::mainnet().chain_id);
-        assert_eq!(mainnet.len(), 15);
+        assert_eq!(mainnet.len(), 5);
 
         let testnet = BootNodes::from_chain_id(ChainConfig::sepolia().chain_id);
-        assert_eq!(testnet.len(), 6);
+        assert_eq!(testnet.len(), 2);
 
         let zeronet = BootNodes::from_chain_id(ChainConfig::zeronet().chain_id);
-        assert_eq!(zeronet.len(), 6);
+        assert_eq!(zeronet.len(), 2);
 
         let unknown = BootNodes::from_chain_id(0);
         assert!(unknown.is_empty());
@@ -98,11 +97,12 @@ mod tests {
 
     #[test]
     fn test_bootnodes_len() {
+        // `BootNodes::mainnet`/`testnet` return CL bootnodes only.
         let bootnodes = BootNodes::mainnet();
-        assert_eq!(bootnodes.len(), 15);
+        assert_eq!(bootnodes.len(), 5);
 
         let bootnodes = BootNodes::testnet();
-        assert_eq!(bootnodes.len(), 6);
+        assert_eq!(bootnodes.len(), 2);
     }
 
     #[test]

--- a/crates/execution/chainspec/src/spec.rs
+++ b/crates/execution/chainspec/src/spec.rs
@@ -172,11 +172,7 @@ impl EthChainSpec for BaseChainSpec {
     }
 
     fn bootnodes(&self) -> Option<Vec<NodeRecord>> {
-        ChainConfig::by_chain_id(self.chain().id()).map(|cfg| {
-            let enodes: Vec<&str> =
-                cfg.bootnodes.iter().filter(|s| !s.starts_with("enr:")).copied().collect();
-            parse_nodes(&enodes)
-        })
+        ChainConfig::by_chain_id(self.chain().id()).map(|cfg| parse_nodes(cfg.bootnodes.execution))
     }
 
     fn is_optimism(&self) -> bool {
@@ -555,6 +551,54 @@ mod tests {
             genesis.hash_slow(),
             b256!("0x1842d6ef4c40e2a4794458e167f6d327269df919b626979111c37ad3a96047bf")
         );
+    }
+
+    #[test]
+    fn el_bootnodes_count_matches_config() {
+        // `bootnodes()` must surface every EL entry from `ChainConfig.bootnodes.execution`.
+        // A mismatch means `parse_nodes` silently dropped a malformed entry.
+        for (spec, cfg) in [
+            (&*BASE_MAINNET, ChainConfig::mainnet()),
+            (&*BASE_SEPOLIA, ChainConfig::sepolia()),
+            (&*BASE_ZERONET, ChainConfig::zeronet()),
+        ] {
+            let parsed = spec.bootnodes().expect("known chain returns Some");
+            assert_eq!(
+                parsed.len(),
+                cfg.bootnodes.execution.len(),
+                "EL bootnode parse drop on chain {}",
+                cfg.chain_id,
+            );
+        }
+    }
+
+    #[test]
+    fn el_bootnodes_have_no_consensus_entries() {
+        // The EL chainspec must never expose CL ENRs — they belong to a different
+        // discv5 network (different protocol ID / port) and bricked discovery in the past.
+        for (spec, cfg) in [
+            (&*BASE_MAINNET, ChainConfig::mainnet()),
+            (&*BASE_SEPOLIA, ChainConfig::sepolia()),
+            (&*BASE_ZERONET, ChainConfig::zeronet()),
+        ] {
+            assert!(
+                cfg.bootnodes.execution.iter().all(|s| s.starts_with("enode://")),
+                "non-enode entry in EL list for chain {}",
+                cfg.chain_id,
+            );
+            let parsed = spec.bootnodes().unwrap();
+            for record in &parsed {
+                assert_ne!(record.tcp_port, 0, "EL bootnode missing TCP port: {record:?}");
+                assert_ne!(record.udp_port, 0, "EL bootnode missing UDP port: {record:?}");
+            }
+        }
+    }
+
+    #[test]
+    fn el_bootnodes_unknown_chain_returns_none() {
+        let unknown =
+            BaseChainSpecBuilder::base_mainnet().chain(alloy_chains::Chain::from_id(99_999)).build();
+        assert!(unknown.bootnodes().is_none());
     }
 
     #[test]

--- a/crates/execution/chainspec/src/spec.rs
+++ b/crates/execution/chainspec/src/spec.rs
@@ -596,8 +596,9 @@ mod tests {
 
     #[test]
     fn el_bootnodes_unknown_chain_returns_none() {
-        let unknown =
-            BaseChainSpecBuilder::base_mainnet().chain(alloy_chains::Chain::from_id(99_999)).build();
+        let unknown = BaseChainSpecBuilder::base_mainnet()
+            .chain(alloy_chains::Chain::from_id(99_999))
+            .build();
         assert!(unknown.bootnodes().is_none());
     }
 


### PR DESCRIPTION
## Summary

Restructures `ChainConfig.bootnodes` from a single flat `&[&str]` list into a `Bootnodes { execution, consensus }` struct so each layer only sees the bootnodes that belong to its discv5 network. Previously the CL's bootstrap loop tried to `request_enr` every EL endpoint in the list, which silently times out now that EL bootnodes use the `basev0` protocol identity, leaving the CL discovery table under-populated and breaking `test_online_discv5_driver_bootstrap_mainnet`. With the split the CL bootstrap is pure-local for the raw ENR entries (test runs in 0.03s instead of 14s) and the EL chainspec drops the `enr:` filter that was working around the old shape. Also adds the EL-side bootnode tests that didn't exist before — count parity with the static config, structural checks, and a guard that no CL ENRs leak back into the EL list.