### PR TITLE
fix(succinct): check KZG proof verification result in CustomCrypto

### DIFF
--- a/crates/proof/succinct/utils/client/src/precompiles/custom.rs
+++ b/crates/proof/succinct/utils/client/src/precompiles/custom.rs
@@ -30,8 +30,12 @@ impl Crypto for CustomCrypto {
         let proof =
             Bytes48::from_slice(proof).map_err(|_| PrecompileError::BlobVerifyKzgProofFailed)?;
 
-        KzgProof::verify_kzg_proof(&commitment, &z, &y, &proof, &self.kzg_settings)
+        let valid = KzgProof::verify_kzg_proof(&commitment, &z, &y, &proof, &self.kzg_settings)
             .map_err(|_| PrecompileError::BlobVerifyKzgProofFailed)?;
+
+        if !valid {
+            return Err(PrecompileError::BlobVerifyKzgProofFailed);
+        }
 
         Ok(())
     }


### PR DESCRIPTION
## Summary

`KzgProof::verify_kzg_proof` returns `Result<bool, KzgError>` where `Ok(false)` means the pairing check failed. The previous code discarded the boolean via `?`, silently accepting invalid proofs. This caused a divergence between the zkVM (`CustomCrypto`) and Base EL (`DefaultCrypto`) for the KZG point-evaluation precompile (`0x0a`).

## Fix

Capture the boolean and return `Err(BlobVerifyKzgProofFailed)` when `false`.