### PR TITLE
fix(load-tests): retry funding on nonce-too-low errors

### DIFF
--- a/crates/infra/load-tests/src/runner/load_runner.rs
+++ b/crates/infra/load-tests/src/runner/load_runner.rs
@@ -488,6 +488,8 @@ impl LoadRunner {
 
             let mut send_stream = stream::iter(send_futs).buffer_unordered(FUNDING_BATCH_SIZE);
 
+            let mut nonce_refresh_needed: Vec<(Address, U256)> = Vec::new();
+
             while let Some((result, address, deficit, nonce)) = send_stream.next().await {
                 match result {
                     Ok(pending) => {
@@ -499,6 +501,9 @@ impl LoadRunner {
                         let error_str = e.to_string();
                         if error_str.contains("already known") {
                             retries.push((address, deficit, nonce));
+                        } else if error_str.contains("nonce too low") {
+                            info!(to = %address, nonce, "nonce too low, will refresh and retry");
+                            nonce_refresh_needed.push((address, deficit));
                         } else {
                             error!(to = %address, error = %e, "failed to fund account");
                             fatal_errors.push(format!("failed to fund {address}: {e}"));
@@ -554,6 +559,61 @@ impl LoadRunner {
                 Self::await_confirmations(&self.batch_rpc, &mut batch_pending, &pb_fund).await?;
             if reverted > 0 {
                 warn!(reverted, "some funding txs reverted");
+            }
+
+            if !nonce_refresh_needed.is_empty() {
+                let fresh_nonce = funder_provider
+                    .get_transaction_count(funder_address)
+                    .pending()
+                    .await
+                    .map_err(|e| BaselineError::Rpc(e.to_string()))?;
+
+                info!(
+                    count = nonce_refresh_needed.len(),
+                    fresh_nonce, "retrying funding txs with refreshed nonce"
+                );
+
+                let nonce_retry_futs =
+                    nonce_refresh_needed.into_iter().enumerate().map(|(i, (address, deficit))| {
+                        let provider = Arc::clone(&funder_provider);
+                        let retry_nonce = fresh_nonce + i as u64;
+                        async move {
+                            let tx = TransactionRequest::default()
+                                .with_to(address)
+                                .with_value(deficit)
+                                .with_nonce(retry_nonce)
+                                .with_chain_id(chain_id)
+                                .with_gas_limit(21_000)
+                                .with_max_fee_per_gas(max_fee)
+                                .with_max_priority_fee_per_gas(max_priority_fee);
+                            let result = provider.send_transaction(tx).await;
+                            (result, address, retry_nonce)
+                        }
+                    });
+
+                let mut nonce_retry_stream =
+                    stream::iter(nonce_retry_futs).buffered(FUNDING_BATCH_SIZE);
+
+                let mut nonce_retry_pending: Vec<(TxHash, Address)> = Vec::new();
+                while let Some((result, address, retry_nonce)) = nonce_retry_stream.next().await {
+                    match result {
+                        Ok(pending) => {
+                            let tx_hash = *pending.tx_hash();
+                            info!(to = %address, nonce = retry_nonce, tx_hash = %tx_hash, "nonce-refreshed funding tx sent");
+                            nonce_retry_pending.push((tx_hash, address));
+                        }
+                        Err(retry_err) => {
+                            warn!(to = %address, nonce = retry_nonce, error = %retry_err, "nonce-refreshed retry also failed, proceeding");
+                        }
+                    }
+                }
+
+                let (_, nonce_reverted) =
+                    Self::await_confirmations(&self.batch_rpc, &mut nonce_retry_pending, &pb_fund)
+                        .await?;
+                if nonce_reverted > 0 {
+                    warn!(reverted = nonce_reverted, "some nonce-refreshed funding txs reverted");
+                }
             }
         }
         pb_fund.finish_and_clear();


### PR DESCRIPTION
## Summary

- Detects "nonce too low" errors during account funding in load tests
- Fetches fresh pending nonce from chain and retries failed funding transactions
- Enables rerunning load tests with the same seed without waiting or changing seeds

## Problem

When rerunning a load test with the same wallet seed, previously-mined funding transactions cause the funder's local nonce to be stale. The RPC rejects new funding attempts with "nonce too low", causing the load test to fail.

## Solution

Added retry logic in `fund_accounts` that:
1. Catches "nonce too low" errors alongside existing "already known" handling
2. Queries the current pending nonce from the chain
3. Retries failed funding txs with sequential nonces starting from the fresh value