### PR TITLE
fix(consensus): restore O(N) origin scan in SpanBatch::get_singular_batches

### DIFF
--- a/crates/consensus/protocol/src/batch/span.rs
+++ b/crates/consensus/protocol/src/batch/span.rs
@@ -319,7 +319,7 @@ impl SpanBatch {
                 .enumerate()
                 .find(|(_, origin)| origin.number == batch.epoch_num)
                 .map(|(i, origin)| {
-                    origin_index = i;
+                    origin_index += i;
                     origin.hash
                 })
                 .ok_or(SpanBatchError::MissingL1Origin)?;


### PR DESCRIPTION
`origin_index` was being reset to the relative slice offset `(= i)` on each iteration instead of accumulated `(+=i)`, collapsing the amortized linear scan back to `O(N×M)`. Matches the correct pattern already used in check_batch at the same file.