### PR TITLE
fix: gate txpool admin RPC on admin module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5607,6 +5607,7 @@ dependencies = [
  "eyre",
  "httpmock",
  "jsonrpsee",
+ "reth-rpc-server-types",
  "reth-transaction-pool",
  "serde",
  "serde_json",

--- a/crates/execution/txpool-rpc/Cargo.toml
+++ b/crates/execution/txpool-rpc/Cargo.toml
@@ -16,6 +16,7 @@ workspace = true
 base-node-runner.workspace = true
 
 # reth
+reth-rpc-server-types.workspace = true
 reth-transaction-pool.workspace = true
 
 # alloy

--- a/crates/execution/txpool-rpc/src/extension.rs
+++ b/crates/execution/txpool-rpc/src/extension.rs
@@ -1,6 +1,7 @@
 //! `TxPool` RPC extension for registering transaction pool management APIs.
 
 use base_node_runner::{BaseNodeExtension, BaseRpcContext, FromExtensionConfig, NodeHooks};
+use reth_rpc_server_types::RethRpcModule;
 
 use crate::{
     AdminTxPoolApiImpl, AdminTxPoolApiServer, TransactionStatusApiImpl, TransactionStatusApiServer,
@@ -32,7 +33,8 @@ impl BaseNodeExtension for TxPoolRpcExtension {
 
             // Register AdminTxPoolApi
             let admin_txpool_api = AdminTxPoolApiImpl::new(ctx.pool().clone());
-            ctx.modules.merge_configured(admin_txpool_api.into_rpc())?;
+            ctx.modules
+                .merge_if_module_configured(RethRpcModule::Admin, admin_txpool_api.into_rpc())?;
 
             Ok(())
         })


### PR DESCRIPTION
## Description
- gate txpool admin RPC registration on the configured Reth admin module
- keep base_transactionStatus registered on configured transports