### PR TITLE
fix(gossip): enforce gossip blocklists on inbound connections

### DIFF
--- a/crates/consensus/gossip/src/driver.rs
+++ b/crates/consensus/gossip/src/driver.rs
@@ -239,8 +239,8 @@ where
     /// Dials the given [`Multiaddr`].
     pub fn dial_multiaddr(&mut self, addr: Multiaddr) {
         // Check if we're allowed to dial the address.
-        if let Err(dial_error) = self.connection_gate.can_dial(&addr) {
-            debug!(target: "gossip", ?dial_error, "unable to dial peer");
+        if let Err(connect_error) = self.connection_gate.can_connect_outbound(&addr) {
+            debug!(target: "gossip", ?connect_error, "unable to dial peer");
             return;
         }
 
@@ -377,7 +377,17 @@ where
             SwarmEvent::Behaviour(behavior_event) => {
                 return self.handle_gossip_event(behavior_event);
             }
-            SwarmEvent::ConnectionEstablished { peer_id, .. } => {
+            SwarmEvent::ConnectionEstablished { peer_id, connection_id, endpoint, .. } => {
+                if endpoint.is_listener() {
+                    let addr = endpoint.get_remote_address();
+                    if let Err(error) = self.connection_gate.can_connect_inbound(&peer_id, addr) {
+                        debug!(target: "gossip", peer_id = %peer_id, addr = %addr, error = ?error, "Closing blocked inbound connection");
+                        self.swarm.close_connection(connection_id);
+                        Metrics::gossipsub_connection("blocked_inbound").increment(1.0);
+                        return None;
+                    }
+                }
+
                 let peer_count = self.swarm.connected_peers().count();
                 debug!(target: "gossip", peer_id = %peer_id, peer_count, "Connection established");
                 Metrics::gossipsub_connection("connected").increment(1.0);

--- a/crates/consensus/gossip/src/error.rs
+++ b/crates/consensus/gossip/src/error.rs
@@ -70,9 +70,9 @@ pub enum GossipDriverBuilderError {
     SyncReqRespAlreadyAccepted,
 }
 
-/// An error type representing reasons why a peer cannot be dialed.
+/// An error type representing reasons why a peer connection cannot be established.
 #[derive(Debug, Clone, Error)]
-pub enum DialError {
+pub enum ConnectionError {
     /// Failed to extract `PeerId` from Multiaddr.
     #[error("Failed to extract PeerId from Multiaddr: {addr}")]
     InvalidMultiaddr {

--- a/crates/consensus/gossip/src/gate.rs
+++ b/crates/consensus/gossip/src/gate.rs
@@ -13,9 +13,13 @@ use crate::{Connectedness, DialError};
 /// logic for which peers are allowed to connect to the
 /// gossip swarm.
 pub trait ConnectionGate {
-    /// Checks if a peer is allowed to connect to the gossip swarm.
+    /// Checks if an outbound peer is allowed to connect to the gossip swarm.
     /// Returns Ok(()) if the peer can be dialed, or Err(DialError) with the reason why not.
-    fn can_dial(&mut self, peer_id: &Multiaddr) -> Result<(), DialError>;
+    fn can_connect_outbound(&mut self, addr: &Multiaddr) -> Result<(), DialError>;
+
+    /// Checks if an inbound peer is allowed to connect to the gossip swarm.
+    /// Returns Ok(()) if the peer can be accepted, or Err(DialError) with the reason why not.
+    fn can_connect_inbound(&mut self, peer_id: &PeerId, addr: &Multiaddr) -> Result<(), DialError>;
 
     /// Returns the [`Connectedness`] for a given peer id.
     fn connectedness(&self, peer_id: &PeerId) -> Connectedness;

--- a/crates/consensus/gossip/src/gate.rs
+++ b/crates/consensus/gossip/src/gate.rs
@@ -5,7 +5,7 @@ use std::net::IpAddr;
 use ipnet::IpNet;
 use libp2p::{Multiaddr, PeerId};
 
-use crate::{Connectedness, DialError};
+use crate::{Connectedness, ConnectionError};
 
 /// Connection Gate
 ///
@@ -14,12 +14,16 @@ use crate::{Connectedness, DialError};
 /// gossip swarm.
 pub trait ConnectionGate {
     /// Checks if an outbound peer is allowed to connect to the gossip swarm.
-    /// Returns Ok(()) if the peer can be dialed, or Err(DialError) with the reason why not.
-    fn can_connect_outbound(&mut self, addr: &Multiaddr) -> Result<(), DialError>;
+    /// Returns Ok(()) if the peer can be dialed, or Err(ConnectionError) with the reason why not.
+    fn can_connect_outbound(&mut self, addr: &Multiaddr) -> Result<(), ConnectionError>;
 
     /// Checks if an inbound peer is allowed to connect to the gossip swarm.
-    /// Returns Ok(()) if the peer can be accepted, or Err(DialError) with the reason why not.
-    fn can_connect_inbound(&mut self, peer_id: &PeerId, addr: &Multiaddr) -> Result<(), DialError>;
+    /// Returns Ok(()) if the peer can be accepted, or Err(ConnectionError) with the reason why not.
+    fn can_connect_inbound(
+        &mut self,
+        peer_id: &PeerId,
+        addr: &Multiaddr,
+    ) -> Result<(), ConnectionError>;
 
     /// Returns the [`Connectedness`] for a given peer id.
     fn connectedness(&self, peer_id: &PeerId) -> Connectedness;

--- a/crates/consensus/gossip/src/gater.rs
+++ b/crates/consensus/gossip/src/gater.rs
@@ -207,10 +207,46 @@ impl ConnectionGater {
         }
         false
     }
+
+    /// Gets the [`IpAddr`] used for blocklist checks from a given [`Multiaddr`].
+    ///
+    /// Returns `Ok(None)` when DNS resolution fails. This preserves the existing outbound behavior:
+    /// allow the connection attempt and let libp2p handle the resolution failure.
+    pub fn blocklist_ip_from_addr(addr: &Multiaddr) -> Result<Option<IpAddr>, DialError> {
+        match Self::try_resolve_dns(addr) {
+            Some(Ok(ip)) => Ok(Some(ip)),
+            Some(Err(())) => Ok(None),
+            None => Self::ip_from_addr(addr)
+                .map(Some)
+                .ok_or_else(|| DialError::InvalidIpAddress { addr: addr.clone() }),
+        }
+    }
+
+    /// Checks shared peer, address, and subnet blocklists for the given peer and address.
+    pub fn can_connect(&self, peer_id: &PeerId, addr: &Multiaddr) -> Result<(), DialError> {
+        if self.blocked_peers.contains(peer_id) {
+            return Err(DialError::PeerBlocked { peer_id: *peer_id });
+        }
+
+        let Some(ip_addr) = Self::blocklist_ip_from_addr(addr)? else {
+            debug!(target: "gossip", addr = ?addr, "DNS resolution failed, allowing connection");
+            return Ok(());
+        };
+
+        if self.blocked_addrs.contains(&ip_addr) {
+            return Err(DialError::AddressBlocked { ip: ip_addr });
+        }
+
+        if self.check_ip_in_blocked_subnets(&ip_addr) {
+            return Err(DialError::SubnetBlocked { ip: ip_addr });
+        }
+
+        Ok(())
+    }
 }
 
 impl ConnectionGate for ConnectionGater {
-    fn can_dial(&mut self, addr: &Multiaddr) -> Result<(), DialError> {
+    fn can_connect_outbound(&mut self, addr: &Multiaddr) -> Result<(), DialError> {
         // Get the peer id from the given multiaddr.
         let peer_id = Self::peer_id_from_addr(addr).ok_or_else(|| {
             warn!(target: "p2p", peer=?addr, "Failed to extract PeerId from Multiaddr");
@@ -237,43 +273,56 @@ impl ConnectionGate for ConnectionGater {
             return Err(DialError::ThresholdReached { addr: addr.clone() });
         }
 
-        // If the peer is blocked, do not dial.
-        if self.blocked_peers.contains(&peer_id) {
-            debug!(target: "gossip", peer=?addr, "Peer is blocked, not dialing");
-            Metrics::dial_peer_error("blocked_peer").increment(1.0);
-            return Err(DialError::PeerBlocked { peer_id });
+        if let Err(error) = self.can_connect(&peer_id, addr) {
+            match &error {
+                DialError::PeerBlocked { .. } => {
+                    debug!(target: "gossip", peer=?addr, "Peer is blocked, not dialing");
+                    Metrics::dial_peer_error("blocked_peer").increment(1.0);
+                }
+                DialError::InvalidIpAddress { .. } => {
+                    warn!(target: "p2p", peer=?addr, "Failed to extract IpAddr from Multiaddr");
+                }
+                DialError::AddressBlocked { ip } => {
+                    debug!(target: "gossip", peer=?addr, ip = %ip, "Address is blocked, not dialing");
+                    self.connectedness.insert(peer_id, Connectedness::CannotConnect);
+                    Metrics::dial_peer_error("blocked_address").increment(1.0);
+                }
+                DialError::SubnetBlocked { ip } => {
+                    debug!(target: "gossip", ip = %ip, "IP address is in a blocked subnet, not dialing");
+                    Metrics::dial_peer_error("blocked_subnet").increment(1.0);
+                }
+                _ => {}
+            }
+            return Err(error);
         }
 
-        // Get IP address - either directly from multiaddr or by resolving DNS.
-        let ip_addr = match Self::try_resolve_dns(addr) {
-            Some(Ok(ip)) => {
-                debug!(target: "gossip", peer=?addr, resolved_ip=?ip, "Resolved DNS multiaddr");
-                ip
-            }
-            Some(Err(())) => {
-                // DNS resolution failed - allow the dial, libp2p will handle it.
-                debug!(target: "gossip", peer=?addr, "DNS resolution failed, allowing dial");
-                return Ok(());
-            }
-            None => Self::ip_from_addr(addr).ok_or_else(|| {
-                warn!(target: "p2p", peer=?addr, "Failed to extract IpAddr from Multiaddr");
-                DialError::InvalidIpAddress { addr: addr.clone() }
-            })?,
-        };
+        Ok(())
+    }
 
-        // If the address is blocked, do not dial.
-        if self.blocked_addrs.contains(&ip_addr) {
-            debug!(target: "gossip", peer=?addr, "Address is blocked, not dialing");
-            self.connectedness.insert(peer_id, Connectedness::CannotConnect);
-            Metrics::dial_peer_error("blocked_address").increment(1.0);
-            return Err(DialError::AddressBlocked { ip: ip_addr });
-        }
-
-        // If address lies in any blocked subnets, do not dial.
-        if self.check_ip_in_blocked_subnets(&ip_addr) {
-            debug!(target: "gossip", ip=?ip_addr, "IP address is in a blocked subnet, not dialing");
-            Metrics::dial_peer_error("blocked_subnet").increment(1.0);
-            return Err(DialError::SubnetBlocked { ip: ip_addr });
+    fn can_connect_inbound(&mut self, peer_id: &PeerId, addr: &Multiaddr) -> Result<(), DialError> {
+        if let Err(error) = self.can_connect(peer_id, addr) {
+            match &error {
+                DialError::PeerBlocked { .. } => {
+                    debug!(target: "gossip", peer = %peer_id, addr = ?addr, "Inbound peer is blocked");
+                    Metrics::dial_peer_error("blocked_inbound_peer").increment(1.0);
+                    self.connectedness.insert(*peer_id, Connectedness::CannotConnect);
+                }
+                DialError::InvalidIpAddress { .. } => {
+                    warn!(target: "p2p", addr = ?addr, peer = %peer_id, "Failed to extract IpAddr from inbound Multiaddr");
+                }
+                DialError::AddressBlocked { ip } => {
+                    debug!(target: "gossip", peer = %peer_id, ip = %ip, "Inbound address is blocked");
+                    Metrics::dial_peer_error("blocked_inbound_address").increment(1.0);
+                    self.connectedness.insert(*peer_id, Connectedness::CannotConnect);
+                }
+                DialError::SubnetBlocked { ip } => {
+                    debug!(target: "gossip", peer = %peer_id, ip = %ip, "Inbound address is in a blocked subnet");
+                    Metrics::dial_peer_error("blocked_inbound_subnet").increment(1.0);
+                    self.connectedness.insert(*peer_id, Connectedness::CannotConnect);
+                }
+                _ => {}
+            }
+            return Err(error);
         }
 
         Ok(())
@@ -418,7 +467,7 @@ mod tests {
 
         // Test invalid multiaddr (missing peer ID)
         let invalid_addr = Multiaddr::from_str("/ip4/127.0.0.1/tcp/8080").unwrap();
-        let result = gater.can_dial(&invalid_addr);
+        let result = gater.can_connect_outbound(&invalid_addr);
         assert!(matches!(result, Err(DialError::InvalidMultiaddr { .. })));
 
         // Test with valid address
@@ -428,13 +477,13 @@ mod tests {
         .unwrap();
 
         // First dial should succeed
-        assert!(gater.can_dial(&valid_addr).is_ok());
+        assert!(gater.can_connect_outbound(&valid_addr).is_ok());
 
         // Mark as dialing
         gater.dialing(&valid_addr);
 
         // Second dial should fail with AlreadyDialing
-        let result = gater.can_dial(&valid_addr);
+        let result = gater.can_connect_outbound(&valid_addr);
         assert!(matches!(result, Err(DialError::AlreadyDialing { .. })));
     }
 
@@ -484,7 +533,7 @@ mod tests {
     }
 
     #[test]
-    fn test_dns_multiaddr_can_dial() {
+    fn test_dns_multiaddr_can_connect_outbound() {
         let mut gater = ConnectionGater::new(GaterConfig::default());
 
         // DNS4 multiaddr should be allowed to dial (IP checks skipped)
@@ -492,19 +541,19 @@ mod tests {
             "/dns4/example.com/tcp/9003/p2p/12D3KooWEyoppNCUx8Yx66oV9fJnriXwCcXwDDUA2kj6vnc6iDEp",
         )
         .unwrap();
-        assert!(gater.can_dial(&dns4_addr).is_ok());
+        assert!(gater.can_connect_outbound(&dns4_addr).is_ok());
 
         // Real-world DNS multiaddr format (like the one from the issue)
         let real_world_dns = Multiaddr::from_str(
             "/dns4/alfonso-0-opn-reth-a-rpc-1-p2p.primary.infra.dev.oplabs.cloud/tcp/9003/p2p/16Uiu2HAmUSo81N6iNQNKZCiqDAg5Mcmh9gwvPgKmKj1HH6qCR4Kq",
         )
         .unwrap();
-        assert!(gater.can_dial(&real_world_dns).is_ok());
+        assert!(gater.can_connect_outbound(&real_world_dns).is_ok());
 
         // DNS multiaddr with blocked peer should still be blocked
         let peer_id = ConnectionGater::peer_id_from_addr(&dns4_addr).unwrap();
         gater.block_peer(&peer_id);
-        assert!(gater.can_dial(&dns4_addr).is_err());
+        assert!(gater.can_connect_outbound(&dns4_addr).is_err());
     }
 
     #[test]
@@ -518,13 +567,13 @@ mod tests {
         .unwrap();
 
         // Should succeed before blocking
-        assert!(gater.can_dial(&dns_localhost).is_ok());
+        assert!(gater.can_connect_outbound(&dns_localhost).is_ok());
 
         // Block 127.0.0.1
         gater.block_addr(IpAddr::from_str("127.0.0.1").unwrap());
 
         // Should now fail because localhost resolves to blocked IP
-        let result = gater.can_dial(&dns_localhost);
+        let result = gater.can_connect_outbound(&dns_localhost);
         assert!(matches!(result, Err(DialError::AddressBlocked { .. })));
     }
 
@@ -539,13 +588,52 @@ mod tests {
         .unwrap();
 
         // Should succeed before blocking
-        assert!(gater.can_dial(&dns_localhost).is_ok());
+        assert!(gater.can_connect_outbound(&dns_localhost).is_ok());
 
         // Block the 127.0.0.0/8 subnet
         gater.block_subnet("127.0.0.0/8".parse().unwrap());
 
         // Should now fail because localhost resolves to IP in blocked subnet
-        let result = gater.can_dial(&dns_localhost);
+        let result = gater.can_connect_outbound(&dns_localhost);
+        assert!(matches!(result, Err(DialError::SubnetBlocked { .. })));
+    }
+
+    #[test]
+    fn test_inbound_blocked_peer() {
+        let mut gater = ConnectionGater::new(GaterConfig::default());
+        let addr = Multiaddr::from_str("/ip4/127.0.0.1/tcp/9003").unwrap();
+        let peer_id: PeerId =
+            "12D3KooWEyoppNCUx8Yx66oV9fJnriXwCcXwDDUA2kj6vnc6iDEp".parse().unwrap();
+
+        gater.block_peer(&peer_id);
+
+        let result = gater.can_connect_inbound(&peer_id, &addr);
+        assert!(matches!(result, Err(DialError::PeerBlocked { .. })));
+    }
+
+    #[test]
+    fn test_inbound_blocked_address() {
+        let mut gater = ConnectionGater::new(GaterConfig::default());
+        let addr = Multiaddr::from_str("/ip4/127.0.0.1/tcp/9003").unwrap();
+        let peer_id: PeerId =
+            "12D3KooWEyoppNCUx8Yx66oV9fJnriXwCcXwDDUA2kj6vnc6iDEp".parse().unwrap();
+
+        gater.block_addr(IpAddr::from_str("127.0.0.1").unwrap());
+
+        let result = gater.can_connect_inbound(&peer_id, &addr);
+        assert!(matches!(result, Err(DialError::AddressBlocked { .. })));
+    }
+
+    #[test]
+    fn test_inbound_blocked_subnet() {
+        let mut gater = ConnectionGater::new(GaterConfig::default());
+        let addr = Multiaddr::from_str("/ip4/127.0.0.1/tcp/9003").unwrap();
+        let peer_id: PeerId =
+            "12D3KooWEyoppNCUx8Yx66oV9fJnriXwCcXwDDUA2kj6vnc6iDEp".parse().unwrap();
+
+        gater.block_subnet("127.0.0.0/8".parse().unwrap());
+
+        let result = gater.can_connect_inbound(&peer_id, &addr);
         assert!(matches!(result, Err(DialError::SubnetBlocked { .. })));
     }
 

--- a/crates/consensus/gossip/src/gater.rs
+++ b/crates/consensus/gossip/src/gater.rs
@@ -315,6 +315,7 @@ impl ConnectionGate for ConnectionGater {
                 }
                 ConnectionError::SubnetBlocked { ip } => {
                     debug!(target: "gossip", ip = %ip, "IP address is in a blocked subnet, not dialing");
+                    self.connectedness.insert(peer_id, Connectedness::CannotConnect);
                     Metrics::dial_peer_error("blocked_subnet").increment(1.0);
                 }
                 _ => {}
@@ -334,20 +335,22 @@ impl ConnectionGate for ConnectionGater {
             match &error {
                 ConnectionError::PeerBlocked { .. } => {
                     debug!(target: "gossip", peer = %peer_id, addr = ?addr, "Inbound peer is blocked");
-                    Metrics::dial_peer_error("blocked_inbound_peer").increment(1.0);
+                    Metrics::inbound_connection_error("blocked_peer").increment(1.0);
                     self.connectedness.insert(*peer_id, Connectedness::CannotConnect);
                 }
                 ConnectionError::InvalidIpAddress { .. } => {
                     warn!(target: "p2p", addr = ?addr, peer = %peer_id, "Failed to extract IpAddr from inbound Multiaddr");
+                    Metrics::inbound_connection_error("invalid_ip_address").increment(1.0);
+                    self.connectedness.insert(*peer_id, Connectedness::CannotConnect);
                 }
                 ConnectionError::AddressBlocked { ip } => {
                     debug!(target: "gossip", peer = %peer_id, ip = %ip, "Inbound address is blocked");
-                    Metrics::dial_peer_error("blocked_inbound_address").increment(1.0);
+                    Metrics::inbound_connection_error("blocked_address").increment(1.0);
                     self.connectedness.insert(*peer_id, Connectedness::CannotConnect);
                 }
                 ConnectionError::SubnetBlocked { ip } => {
                     debug!(target: "gossip", peer = %peer_id, ip = %ip, "Inbound address is in a blocked subnet");
-                    Metrics::dial_peer_error("blocked_inbound_subnet").increment(1.0);
+                    Metrics::inbound_connection_error("blocked_subnet").increment(1.0);
                     self.connectedness.insert(*peer_id, Connectedness::CannotConnect);
                 }
                 _ => {}
@@ -605,6 +608,8 @@ mod tests {
         // Should now fail because localhost resolves to blocked IP
         let result = gater.can_connect_outbound(&dns_localhost);
         assert!(matches!(result, Err(ConnectionError::AddressBlocked { .. })));
+        let peer_id = ConnectionGater::peer_id_from_addr(&dns_localhost).unwrap();
+        assert_eq!(gater.connectedness(&peer_id), Connectedness::CannotConnect);
     }
 
     #[test]
@@ -626,6 +631,8 @@ mod tests {
         // Should now fail because localhost resolves to IP in blocked subnet
         let result = gater.can_connect_outbound(&dns_localhost);
         assert!(matches!(result, Err(ConnectionError::SubnetBlocked { .. })));
+        let peer_id = ConnectionGater::peer_id_from_addr(&dns_localhost).unwrap();
+        assert_eq!(gater.connectedness(&peer_id), Connectedness::CannotConnect);
     }
 
     #[test]

--- a/crates/consensus/gossip/src/gater.rs
+++ b/crates/consensus/gossip/src/gater.rs
@@ -10,7 +10,16 @@ use ipnet::IpNet;
 use libp2p::{Multiaddr, PeerId};
 use tokio::time::Instant;
 
-use crate::{Connectedness, ConnectionGate, DialError, Metrics};
+use crate::{Connectedness, ConnectionError, ConnectionGate, Metrics};
+
+/// Policy for connection checks when DNS resolution fails.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DnsResolutionFailure {
+    /// Allow the connection attempt to proceed.
+    Allow,
+    /// Reject the connection attempt.
+    Reject,
+}
 
 /// Dial information tracking for peer connection management.
 ///
@@ -210,35 +219,52 @@ impl ConnectionGater {
 
     /// Gets the [`IpAddr`] used for blocklist checks from a given [`Multiaddr`].
     ///
-    /// Returns `Ok(None)` when DNS resolution fails. This preserves the existing outbound behavior:
-    /// allow the connection attempt and let libp2p handle the resolution failure.
-    pub fn blocklist_ip_from_addr(addr: &Multiaddr) -> Result<Option<IpAddr>, DialError> {
+    /// Returns `Ok(None)` when DNS resolution fails. Callers choose whether to allow or reject
+    /// unresolved DNS addresses based on the connection direction.
+    pub fn blocklist_ip_from_addr(addr: &Multiaddr) -> Result<Option<IpAddr>, ConnectionError> {
         match Self::try_resolve_dns(addr) {
             Some(Ok(ip)) => Ok(Some(ip)),
             Some(Err(())) => Ok(None),
             None => Self::ip_from_addr(addr)
                 .map(Some)
-                .ok_or_else(|| DialError::InvalidIpAddress { addr: addr.clone() }),
+                .ok_or_else(|| ConnectionError::InvalidIpAddress { addr: addr.clone() }),
         }
     }
 
     /// Checks shared peer, address, and subnet blocklists for the given peer and address.
-    pub fn can_connect(&self, peer_id: &PeerId, addr: &Multiaddr) -> Result<(), DialError> {
+    ///
+    /// Outbound checks allow unresolved DNS addresses so libp2p can handle resolution at the
+    /// transport layer. Inbound checks reject unresolved DNS addresses because listener endpoints
+    /// should have IP-based remote addresses.
+    pub fn can_connect(
+        &self,
+        peer_id: &PeerId,
+        addr: &Multiaddr,
+        dns_resolution_failure: DnsResolutionFailure,
+    ) -> Result<(), ConnectionError> {
         if self.blocked_peers.contains(peer_id) {
-            return Err(DialError::PeerBlocked { peer_id: *peer_id });
+            return Err(ConnectionError::PeerBlocked { peer_id: *peer_id });
         }
 
         let Some(ip_addr) = Self::blocklist_ip_from_addr(addr)? else {
-            debug!(target: "gossip", addr = ?addr, "DNS resolution failed, allowing connection");
-            return Ok(());
+            return match dns_resolution_failure {
+                DnsResolutionFailure::Allow => {
+                    debug!(target: "gossip", addr = ?addr, "DNS resolution failed, allowing connection");
+                    Ok(())
+                }
+                DnsResolutionFailure::Reject => {
+                    warn!(target: "gossip", addr = ?addr, "DNS resolution failed, rejecting connection");
+                    Err(ConnectionError::InvalidIpAddress { addr: addr.clone() })
+                }
+            };
         };
 
         if self.blocked_addrs.contains(&ip_addr) {
-            return Err(DialError::AddressBlocked { ip: ip_addr });
+            return Err(ConnectionError::AddressBlocked { ip: ip_addr });
         }
 
         if self.check_ip_in_blocked_subnets(&ip_addr) {
-            return Err(DialError::SubnetBlocked { ip: ip_addr });
+            return Err(ConnectionError::SubnetBlocked { ip: ip_addr });
         }
 
         Ok(())
@@ -246,19 +272,19 @@ impl ConnectionGater {
 }
 
 impl ConnectionGate for ConnectionGater {
-    fn can_connect_outbound(&mut self, addr: &Multiaddr) -> Result<(), DialError> {
+    fn can_connect_outbound(&mut self, addr: &Multiaddr) -> Result<(), ConnectionError> {
         // Get the peer id from the given multiaddr.
         let peer_id = Self::peer_id_from_addr(addr).ok_or_else(|| {
             warn!(target: "p2p", peer=?addr, "Failed to extract PeerId from Multiaddr");
             Metrics::dial_peer_error("invalid_multiaddr").increment(1.0);
-            DialError::InvalidMultiaddr { addr: addr.clone() }
+            ConnectionError::InvalidMultiaddr { addr: addr.clone() }
         })?;
 
         // Cannot dial a peer that is already being dialed.
         if self.current_dials.contains(&peer_id) {
             debug!(target: "gossip", peer=?addr, "Already dialing peer, not dialing");
             Metrics::dial_peer_error("already_dialing").increment(1.0);
-            return Err(DialError::AlreadyDialing { peer_id });
+            return Err(ConnectionError::AlreadyDialing { peer_id });
         }
 
         // If the peer is protected, do not apply thresholds.
@@ -270,24 +296,24 @@ impl ConnectionGate for ConnectionGater {
             debug!(target: "gossip", peer=?addr, "Dial threshold reached, not dialing");
             self.connectedness.insert(peer_id, Connectedness::CannotConnect);
             Metrics::dial_peer_error("threshold_reached").increment(1.0);
-            return Err(DialError::ThresholdReached { addr: addr.clone() });
+            return Err(ConnectionError::ThresholdReached { addr: addr.clone() });
         }
 
-        if let Err(error) = self.can_connect(&peer_id, addr) {
+        if let Err(error) = self.can_connect(&peer_id, addr, DnsResolutionFailure::Allow) {
             match &error {
-                DialError::PeerBlocked { .. } => {
+                ConnectionError::PeerBlocked { .. } => {
                     debug!(target: "gossip", peer=?addr, "Peer is blocked, not dialing");
                     Metrics::dial_peer_error("blocked_peer").increment(1.0);
                 }
-                DialError::InvalidIpAddress { .. } => {
+                ConnectionError::InvalidIpAddress { .. } => {
                     warn!(target: "p2p", peer=?addr, "Failed to extract IpAddr from Multiaddr");
                 }
-                DialError::AddressBlocked { ip } => {
+                ConnectionError::AddressBlocked { ip } => {
                     debug!(target: "gossip", peer=?addr, ip = %ip, "Address is blocked, not dialing");
                     self.connectedness.insert(peer_id, Connectedness::CannotConnect);
                     Metrics::dial_peer_error("blocked_address").increment(1.0);
                 }
-                DialError::SubnetBlocked { ip } => {
+                ConnectionError::SubnetBlocked { ip } => {
                     debug!(target: "gossip", ip = %ip, "IP address is in a blocked subnet, not dialing");
                     Metrics::dial_peer_error("blocked_subnet").increment(1.0);
                 }
@@ -299,23 +325,27 @@ impl ConnectionGate for ConnectionGater {
         Ok(())
     }
 
-    fn can_connect_inbound(&mut self, peer_id: &PeerId, addr: &Multiaddr) -> Result<(), DialError> {
-        if let Err(error) = self.can_connect(peer_id, addr) {
+    fn can_connect_inbound(
+        &mut self,
+        peer_id: &PeerId,
+        addr: &Multiaddr,
+    ) -> Result<(), ConnectionError> {
+        if let Err(error) = self.can_connect(peer_id, addr, DnsResolutionFailure::Reject) {
             match &error {
-                DialError::PeerBlocked { .. } => {
+                ConnectionError::PeerBlocked { .. } => {
                     debug!(target: "gossip", peer = %peer_id, addr = ?addr, "Inbound peer is blocked");
                     Metrics::dial_peer_error("blocked_inbound_peer").increment(1.0);
                     self.connectedness.insert(*peer_id, Connectedness::CannotConnect);
                 }
-                DialError::InvalidIpAddress { .. } => {
+                ConnectionError::InvalidIpAddress { .. } => {
                     warn!(target: "p2p", addr = ?addr, peer = %peer_id, "Failed to extract IpAddr from inbound Multiaddr");
                 }
-                DialError::AddressBlocked { ip } => {
+                ConnectionError::AddressBlocked { ip } => {
                     debug!(target: "gossip", peer = %peer_id, ip = %ip, "Inbound address is blocked");
                     Metrics::dial_peer_error("blocked_inbound_address").increment(1.0);
                     self.connectedness.insert(*peer_id, Connectedness::CannotConnect);
                 }
-                DialError::SubnetBlocked { ip } => {
+                ConnectionError::SubnetBlocked { ip } => {
                     debug!(target: "gossip", peer = %peer_id, ip = %ip, "Inbound address is in a blocked subnet");
                     Metrics::dial_peer_error("blocked_inbound_subnet").increment(1.0);
                     self.connectedness.insert(*peer_id, Connectedness::CannotConnect);
@@ -462,13 +492,13 @@ mod tests {
     }
 
     #[test]
-    fn test_dial_error_handling() {
+    fn test_connection_error_handling() {
         let mut gater = ConnectionGater::new(GaterConfig::default());
 
         // Test invalid multiaddr (missing peer ID)
         let invalid_addr = Multiaddr::from_str("/ip4/127.0.0.1/tcp/8080").unwrap();
         let result = gater.can_connect_outbound(&invalid_addr);
-        assert!(matches!(result, Err(DialError::InvalidMultiaddr { .. })));
+        assert!(matches!(result, Err(ConnectionError::InvalidMultiaddr { .. })));
 
         // Test with valid address
         let valid_addr = Multiaddr::from_str(
@@ -484,7 +514,7 @@ mod tests {
 
         // Second dial should fail with AlreadyDialing
         let result = gater.can_connect_outbound(&valid_addr);
-        assert!(matches!(result, Err(DialError::AlreadyDialing { .. })));
+        assert!(matches!(result, Err(ConnectionError::AlreadyDialing { .. })));
     }
 
     #[test]
@@ -574,7 +604,7 @@ mod tests {
 
         // Should now fail because localhost resolves to blocked IP
         let result = gater.can_connect_outbound(&dns_localhost);
-        assert!(matches!(result, Err(DialError::AddressBlocked { .. })));
+        assert!(matches!(result, Err(ConnectionError::AddressBlocked { .. })));
     }
 
     #[test]
@@ -595,7 +625,7 @@ mod tests {
 
         // Should now fail because localhost resolves to IP in blocked subnet
         let result = gater.can_connect_outbound(&dns_localhost);
-        assert!(matches!(result, Err(DialError::SubnetBlocked { .. })));
+        assert!(matches!(result, Err(ConnectionError::SubnetBlocked { .. })));
     }
 
     #[test]
@@ -608,7 +638,7 @@ mod tests {
         gater.block_peer(&peer_id);
 
         let result = gater.can_connect_inbound(&peer_id, &addr);
-        assert!(matches!(result, Err(DialError::PeerBlocked { .. })));
+        assert!(matches!(result, Err(ConnectionError::PeerBlocked { .. })));
     }
 
     #[test]
@@ -621,7 +651,7 @@ mod tests {
         gater.block_addr(IpAddr::from_str("127.0.0.1").unwrap());
 
         let result = gater.can_connect_inbound(&peer_id, &addr);
-        assert!(matches!(result, Err(DialError::AddressBlocked { .. })));
+        assert!(matches!(result, Err(ConnectionError::AddressBlocked { .. })));
     }
 
     #[test]
@@ -634,7 +664,7 @@ mod tests {
         gater.block_subnet("127.0.0.0/8".parse().unwrap());
 
         let result = gater.can_connect_inbound(&peer_id, &addr);
-        assert!(matches!(result, Err(DialError::SubnetBlocked { .. })));
+        assert!(matches!(result, Err(ConnectionError::SubnetBlocked { .. })));
     }
 
     #[test]

--- a/crates/consensus/gossip/src/lib.rs
+++ b/crates/consensus/gossip/src/lib.rs
@@ -36,13 +36,13 @@ mod gate;
 pub use gate::ConnectionGate;
 
 mod gater;
-pub use gater::{ConnectionGater, DialInfo, GaterConfig};
+pub use gater::{ConnectionGater, DialInfo, DnsResolutionFailure, GaterConfig};
 
 mod builder;
 pub use builder::GossipDriverBuilder;
 
 mod error;
-pub use error::{DialError, GossipDriverBuilderError, HandlerEncodeError, PublishError};
+pub use error::{ConnectionError, GossipDriverBuilderError, HandlerEncodeError, PublishError};
 
 mod event;
 pub use event::Event;

--- a/crates/consensus/gossip/src/metrics/mod.rs
+++ b/crates/consensus/gossip/src/metrics/mod.rs
@@ -21,7 +21,10 @@ base_metrics::define_metrics! {
     gossipsub_event: gauge,
 
     #[describe("Connections made to the libp2p Swarm")]
-    #[label(name = "type", default = ["connected", "outgoing_error", "incoming_error", "closed"])]
+    #[label(
+        name = "type",
+        default = ["connected", "outgoing_error", "incoming_error", "closed", "blocked_inbound"]
+    )]
     gossipsub_connection: gauge,
 
     #[describe("Number of NetworkPayloadEnvelope gossipped out through the libp2p Swarm")]
@@ -49,6 +52,13 @@ base_metrics::define_metrics! {
         ]
     )]
     dial_peer_error: gauge,
+
+    #[describe("Number of inbound connection rejections by the connection gate")]
+    #[label(
+        name = "type",
+        default = ["blocked_peer", "blocked_address", "blocked_subnet", "invalid_ip_address"]
+    )]
+    inbound_connection_error: gauge,
 
     #[describe("Calls made to the Gossip RPC module")]
     #[label(

--- a/crates/consensus/gossip/src/mod.rs
+++ b/crates/consensus/gossip/src/mod.rs
@@ -54,6 +54,7 @@ mod gater;
 pub use gater::{
     ConnectionGater, // implementation
     DialInfo,
+    DnsResolutionFailure,
     GaterConfig,
 };
 
@@ -61,7 +62,7 @@ mod builder;
 pub use builder::GossipDriverBuilder;
 
 mod error;
-pub use error::{DialError, GossipDriverBuilderError, HandlerEncodeError, PublishError};
+pub use error::{ConnectionError, GossipDriverBuilderError, HandlerEncodeError, PublishError};
 
 mod event;
 pub use event::Event;


### PR DESCRIPTION
### Description
Apply checks to inbound gossip connections as well as outbound connections. e.g. respect subnet restrictions and banning.