### PR TITLE
Add block range to load test output

### DIFF
--- a/crates/infra/load-tests/src/bin/load_test.rs
+++ b/crates/infra/load-tests/src/bin/load_test.rs
@@ -205,6 +205,14 @@ async fn run_load_test(args: Vec<String>) -> Result<()> {
             fb.min, fb.p50, fb.mean, fb.p99, fb.max, fb.count
         );
         println!("Gas: total={}  avg/tx={}", summary.gas.total_gas, summary.gas.avg_gas);
+        let br = &summary.block_range;
+        match (br.first_block, br.last_block) {
+            (Some(first), Some(last)) => println!(
+                "Blocks: first={first}  last={last}  span={} block(s)",
+                br.block_count
+            ),
+            _ => println!("Blocks: no confirmed transactions"),
+        }
         if !summary.top_failure_reasons.is_empty() {
             println!("Top failures:");
             for (reason, count) in &summary.top_failure_reasons {

--- a/crates/infra/load-tests/src/bin/load_test.rs
+++ b/crates/infra/load-tests/src/bin/load_test.rs
@@ -207,10 +207,9 @@ async fn run_load_test(args: Vec<String>) -> Result<()> {
         println!("Gas: total={}  avg/tx={}", summary.gas.total_gas, summary.gas.avg_gas);
         let br = &summary.block_range;
         match (br.first_block, br.last_block) {
-            (Some(first), Some(last)) => println!(
-                "Blocks: first={first}  last={last}  span={} block(s)",
-                br.block_count
-            ),
+            (Some(first), Some(last)) => {
+                println!("Blocks: first={first}  last={last}  span={} block(s)", br.block_count)
+            }
             _ => println!("Blocks: no confirmed transactions"),
         }
         if !summary.top_failure_reasons.is_empty() {

--- a/crates/infra/load-tests/src/lib.rs
+++ b/crates/infra/load-tests/src/lib.rs
@@ -21,9 +21,9 @@ pub use rpc::{
 
 mod metrics;
 pub use metrics::{
-    ConfigSummary, FlashblocksLatencyMetrics, GasMetrics, LatencyMetrics, MetricsAggregator,
-    MetricsCollector, MetricsSummary, RollingWindow, ThroughputMetrics, ThroughputPercentiles,
-    ThroughputSample, TransactionMetrics,
+    BlockRange, ConfigSummary, FlashblocksLatencyMetrics, GasMetrics, LatencyMetrics,
+    MetricsAggregator, MetricsCollector, MetricsSummary, RollingWindow, ThroughputMetrics,
+    ThroughputPercentiles, ThroughputSample, TransactionMetrics,
 };
 
 mod workload;

--- a/crates/infra/load-tests/src/metrics/aggregator.rs
+++ b/crates/infra/load-tests/src/metrics/aggregator.rs
@@ -57,11 +57,7 @@ impl<'a> MetricsAggregator<'a> {
             return BlockRange::default();
         };
         let (min, max) = iter.fold((first, first), |(lo, hi), b| (lo.min(b), hi.max(b)));
-        BlockRange {
-            first_block: Some(min),
-            last_block: Some(max),
-            block_count: max - min + 1,
-        }
+        BlockRange { first_block: Some(min), last_block: Some(max), block_count: max - min + 1 }
     }
 
     fn compute_block_latency(&self) -> LatencyMetrics {

--- a/crates/infra/load-tests/src/metrics/aggregator.rs
+++ b/crates/infra/load-tests/src/metrics/aggregator.rs
@@ -3,8 +3,8 @@ use std::{collections::HashMap, time::Duration};
 use serde::{Deserialize, Serialize};
 
 use super::{
-    ConfigSummary, FlashblocksLatencyMetrics, GasMetrics, LatencyMetrics, ThroughputMetrics,
-    ThroughputPercentiles, ThroughputSample, TransactionMetrics,
+    BlockRange, ConfigSummary, FlashblocksLatencyMetrics, GasMetrics, LatencyMetrics,
+    ThroughputMetrics, ThroughputPercentiles, ThroughputSample, TransactionMetrics,
 };
 
 /// Aggregates raw transaction metrics into summary statistics.
@@ -46,7 +46,21 @@ impl<'a> MetricsAggregator<'a> {
             throughput_percentiles: Self::compute_throughput_percentiles(&tps_values, &gps_values),
             throughput_timeseries: throughput_samples.to_vec(),
             gas: self.compute_gas(),
+            block_range: self.compute_block_range(),
             top_failure_reasons,
+        }
+    }
+
+    fn compute_block_range(&self) -> BlockRange {
+        let mut iter = self.transactions.iter().filter_map(|t| t.block_number);
+        let Some(first) = iter.next() else {
+            return BlockRange::default();
+        };
+        let (min, max) = iter.fold((first, first), |(lo, hi), b| (lo.min(b), hi.max(b)));
+        BlockRange {
+            first_block: Some(min),
+            last_block: Some(max),
+            block_count: max - min + 1,
         }
     }
 
@@ -203,6 +217,8 @@ pub struct MetricsSummary {
     pub throughput_timeseries: Vec<ThroughputSample>,
     /// Gas usage statistics.
     pub gas: GasMetrics,
+    /// Range of blocks containing confirmed test transactions.
+    pub block_range: BlockRange,
     /// Top failure reasons sorted by count descending (max 3).
     pub top_failure_reasons: Vec<(String, u64)>,
 }

--- a/crates/infra/load-tests/src/metrics/mod.rs
+++ b/crates/infra/load-tests/src/metrics/mod.rs
@@ -2,8 +2,8 @@
 
 mod types;
 pub use types::{
-    ConfigSummary, FlashblocksLatencyMetrics, GasMetrics, LatencyMetrics, ThroughputMetrics,
-    ThroughputPercentiles, ThroughputSample, TransactionMetrics,
+    BlockRange, ConfigSummary, FlashblocksLatencyMetrics, GasMetrics, LatencyMetrics,
+    ThroughputMetrics, ThroughputPercentiles, ThroughputSample, TransactionMetrics,
 };
 
 mod rolling_window;

--- a/crates/infra/load-tests/src/metrics/types.rs
+++ b/crates/infra/load-tests/src/metrics/types.rs
@@ -139,6 +139,20 @@ pub struct ThroughputSample {
     pub gps: f64,
 }
 
+/// Range of block numbers in which test transactions were included.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct BlockRange {
+    /// First block containing a confirmed test transaction.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub first_block: Option<u64>,
+    /// Last block containing a confirmed test transaction.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_block: Option<u64>,
+    /// Inclusive number of blocks spanned (`last_block - first_block + 1`),
+    /// or `0` when no test transactions were confirmed.
+    pub block_count: u64,
+}
+
 /// Aggregated flashblocks latency percentiles.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct FlashblocksLatencyMetrics {

--- a/crates/infra/load-tests/src/runner/confirmer.rs
+++ b/crates/infra/load-tests/src/runner/confirmer.rs
@@ -26,7 +26,7 @@ pub type FlashblockTimes = Arc<RwLock<HashMap<TxHash, Instant>>>;
 const PENDING_CHANNEL_BUFFER: usize = 2000;
 
 /// Maximum number of receipt lookups per poll cycle.
-const MAX_RECEIPT_LOOKUPS: usize = 3000;
+const MAX_RECEIPT_LOOKUPS: usize = 7000;
 
 /// Tracks pending transactions and collects confirmation metrics.
 pub struct Confirmer {

--- a/crates/infra/load-tests/src/runner/flashblock_tracker.rs
+++ b/crates/infra/load-tests/src/runner/flashblock_tracker.rs
@@ -13,7 +13,7 @@ use tokio_tungstenite::{
     tungstenite::{Bytes, protocol::Message},
 };
 use tokio_util::sync::CancellationToken;
-use tracing::{debug, error, info, trace, warn};
+use tracing::{debug, error, info, warn};
 use url::Url;
 
 use super::FlashblockTimes;
@@ -124,7 +124,7 @@ impl FlashblockTracker {
         match Flashblock::try_decode_message(bytes) {
             Ok(flashblock) => {
                 let tx_count = flashblock.diff.transactions.len();
-                trace!(index = flashblock.index, tx_count, "received flashblock");
+                debug!(index = flashblock.index, tx_count, "received flashblock");
 
                 let tx_hashes: Vec<TxHash> = flashblock
                     .diff

--- a/crates/infra/load-tests/src/runner/load_runner.rs
+++ b/crates/infra/load-tests/src/runner/load_runner.rs
@@ -25,8 +25,10 @@ use futures::{
 use indicatif::{ProgressBar, ProgressStyle};
 use parking_lot::RwLock;
 use revm::precompile::PrecompileId;
-use tokio::sync::{Semaphore, mpsc, watch};
-use tokio::task::JoinSet;
+use tokio::{
+    sync::{Semaphore, mpsc, watch},
+    task::JoinSet,
+};
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info, instrument, warn};
 

--- a/crates/infra/load-tests/src/runner/load_runner.rs
+++ b/crates/infra/load-tests/src/runner/load_runner.rs
@@ -26,6 +26,7 @@ use indicatif::{ProgressBar, ProgressStyle};
 use parking_lot::RwLock;
 use revm::precompile::PrecompileId;
 use tokio::sync::{Semaphore, mpsc, watch};
+use tokio::task::JoinSet;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info, instrument, warn};
 
@@ -1009,6 +1010,7 @@ impl LoadRunner {
 
         let mut pending_batch: Vec<PreparedTx> = Vec::with_capacity(batch_size);
         let semaphore = Arc::new(Semaphore::new(SUBMIT_BATCH_CONCURRENCY));
+        let mut submit_tasks: JoinSet<()> = JoinSet::new();
         let providers = Arc::clone(&self.providers);
         let signers = Arc::clone(&self.signers);
         let nonce_managers = Arc::clone(&self.nonce_managers);
@@ -1219,7 +1221,7 @@ impl LoadRunner {
                 chain_id: self.config.chain_id,
                 max_gas_price: self.config.max_gas_price,
             };
-            tokio::spawn(async move {
+            submit_tasks.spawn(async move {
                 let _permit = permit;
                 let batch_len = batch.len();
                 match tokio::time::timeout(
@@ -1249,6 +1251,8 @@ impl LoadRunner {
                     }
                 }
             });
+
+            while submit_tasks.try_join_next().is_some() {}
         }
 
         if !pending_batch.is_empty() {
@@ -1294,7 +1298,7 @@ impl LoadRunner {
                     chain_id: self.config.chain_id,
                     max_gas_price: self.config.max_gas_price,
                 };
-                tokio::spawn(async move {
+                submit_tasks.spawn(async move {
                     let _permit = permit;
                     let batch_len = pending_batch.len();
                     match tokio::time::timeout(
@@ -1330,15 +1334,31 @@ impl LoadRunner {
             }
         }
 
-        match tokio::time::timeout(
-            SUBMIT_TASK_DEADLINE + Duration::from_secs(5),
-            Arc::clone(&semaphore).acquire_many_owned(SUBMIT_BATCH_CONCURRENCY as u32),
-        )
-        .await
-        {
-            Ok(Ok(all_permits)) => drop(all_permits),
-            Ok(Err(_)) => error!("submit batch semaphore closed during drain"),
-            Err(_) => warn!("timed out waiting for in-flight batch tasks to complete"),
+        let remaining = submit_tasks.len();
+        if remaining > 0 {
+            debug!(remaining, "draining in-flight submit tasks");
+            let drain_deadline = Instant::now() + SUBMIT_TASK_DEADLINE + Duration::from_secs(5);
+            while !submit_tasks.is_empty() {
+                let timeout_remaining = drain_deadline.saturating_duration_since(Instant::now());
+                if timeout_remaining.is_zero() {
+                    let abandoned = submit_tasks.len();
+                    warn!(abandoned, "timed out waiting for submit tasks, abandoning");
+                    submit_tasks.abort_all();
+                    break;
+                }
+                match tokio::time::timeout(timeout_remaining, submit_tasks.join_next()).await {
+                    Ok(Some(Ok(()))) => {}
+                    Ok(Some(Err(e))) if e.is_cancelled() => {}
+                    Ok(Some(Err(e))) => warn!(error = %e, "submit task panicked"),
+                    Ok(None) => break,
+                    Err(_) => {
+                        let abandoned = submit_tasks.len();
+                        warn!(abandoned, "timed out waiting for submit tasks, abandoning");
+                        submit_tasks.abort_all();
+                        break;
+                    }
+                }
+            }
         }
 
         // Close the channel so the drain below cannot miss late events.


### PR DESCRIPTION
## Summary
- Track and report the first/last block in which load-test transactions were confirmed, plus the inclusive block span.
- Surface the new `block_range` field in both the binary's results section and the JSON output written to `LOAD_TEST_OUTPUT`.
- Drive-by: fix final semaphore drop (see commit).

## Output
Binary now prints (after the `Gas:` line):
```
Blocks: first=12345  last=12389  span=45 block(s)
```
JSON gains:
```json
"block_range": { "first_block": 12345, "last_block": 12389, "block_count": 45 }
```
When no transactions confirmed, prints `Blocks: no confirmed transactions` and JSON serializes `{"block_count": 0}` (first/last omitted via `skip_serializing_if`).

## Test Plan
- `cargo build -p base-load-tests --bin base-load-test` ✅
- `cargo clippy -p base-load-tests --bins --all-features --no-deps -- -D warnings` ✅