### PR TITLE
chore(proof): make guest ELF builds reproducible across machines

### DIFF
--- a/crates/proof/tee/nitro-attestation-prover/guest/.cargo/config.toml
+++ b/crates/proof/tee/nitro-attestation-prover/guest/.cargo/config.toml
@@ -1,6 +1,14 @@
 # The risc0 toolchain ships an older rustc (1.91) than the workspace MSRV (1.93).
 # The --ignore-rust-version flag is required when invoking cargo build.
+#
+# IMPORTANT: Always use `just build` / `just bundle` for reproducible builds.
+# The Justfile sets RUSTFLAGS with --remap-path-prefix flags that ensure the
+# resulting ELF (and image ID) is identical regardless of checkout location.
+# Running cargo directly will produce a working but non-reproducible ELF.
 
 [build]
 # Tell getrandom 0.3 to use the "custom" backend provided by risc0-zkvm-platform.
+# Note: when RUSTFLAGS env var is set (as in the Justfile), it overrides this
+# config entirely — the Justfile includes this flag in its RUSTFLAGS.
 rustflags = ['--cfg', 'getrandom_backend="custom"']
+

--- a/crates/proof/tee/nitro-attestation-prover/guest/Justfile
+++ b/crates/proof/tee/nitro-attestation-prover/guest/Justfile
@@ -1,13 +1,24 @@
 # Guest binary name (hyphens become underscores in the compiled binary)
 guest := "base-proof-tee-nitro-verifier-guest"
 
+# Repo root: guest/ → nitro-attestation-prover/ → tee/ → proof/ → crates/ → <root>
+repo_root := canonicalize("../../../../..")
+
+# Cargo registry cache (defaults to ~/.cargo)
+cargo_home := env("CARGO_HOME", home_directory() / ".cargo")
+
+# Remap absolute paths so the ELF (and image ID) is identical regardless of
+# where the repo is checked out or where the Cargo registry lives.
+remap_flags := "--remap-path-prefix=" + repo_root + "=/build --remap-path-prefix=" + cargo_home + "=/registry"
+
 # Default recipe to display help information
 default:
     @just --list
 
 # Build the guest ELF with the risc0 toolchain
 build:
-    cargo +risc0 build --release --target riscv32im-risc0-zkvm-elf --ignore-rust-version
+    RUSTFLAGS='--cfg getrandom_backend="custom" {{ remap_flags }}' \
+        cargo +risc0 build --release --target riscv32im-risc0-zkvm-elf --ignore-rust-version
     @echo "ELF built at: target/riscv32im-risc0-zkvm-elf/release/{{ guest }}"
     @ls -lh target/riscv32im-risc0-zkvm-elf/release/{{ guest }}
 

--- a/crates/proof/tee/nitro-attestation-prover/guest/Justfile
+++ b/crates/proof/tee/nitro-attestation-prover/guest/Justfile
@@ -9,6 +9,8 @@ cargo_home := env("CARGO_HOME", home_directory() / ".cargo")
 
 # Remap absolute paths so the ELF (and image ID) is identical regardless of
 # where the repo is checked out or where the Cargo registry lives.
+# NOTE: repo_root and cargo_home must not contain spaces — rustc splits
+# RUSTFLAGS on whitespace, which would break the remap arguments.
 remap_flags := "--remap-path-prefix=" + repo_root + "=/build --remap-path-prefix=" + cargo_home + "=/registry"
 
 # Default recipe to display help information

--- a/crates/proof/tee/nitro-attestation-prover/guest/Justfile
+++ b/crates/proof/tee/nitro-attestation-prover/guest/Justfile
@@ -1,8 +1,8 @@
 # Guest binary name (hyphens become underscores in the compiled binary)
 guest := "base-proof-tee-nitro-verifier-guest"
 
-# Repo root: guest/ → nitro-attestation-prover/ → tee/ → proof/ → crates/ → <root>
-repo_root := canonicalize("../../../../..")
+# Repo root (resolved via git so the path doesn't break if the crate moves).
+repo_root := `git rev-parse --show-toplevel`
 
 # Cargo registry cache (defaults to ~/.cargo)
 cargo_home := env("CARGO_HOME", home_directory() / ".cargo")

--- a/crates/proof/tee/nitro-attestation-prover/guest/README.md
+++ b/crates/proof/tee/nitro-attestation-prover/guest/README.md
@@ -78,11 +78,36 @@ RISC0_SKIP_BUILD_KERNELS=1 cargo run \
     --output <output-path.r0bf>
 ```
 
-## Version pinning
+## Reproducibility
+
+The image ID is a hash of the ELF binary. For the same source code to always
+produce the same image ID, the ELF must be byte-identical across builds.
+Two things ensure this:
+
+### Dependency pinning
 
 The `risc0-zkvm` dependency is pinned to an exact version (`=x.y.z`) in
-`Cargo.toml` to ensure the image ID is reproducible. The `Cargo.lock` is
-committed for the same reason.
+`Cargo.toml` and the `Cargo.lock` is committed, so dependency resolution is
+deterministic.
+
+### Path remapping
+
+Rust embeds absolute file paths into the binary for panic messages (e.g.
+`panicked at /Users/you/project/src/foo.rs:42`). These paths change depending
+on where the repository is checked out, which produces a different ELF hash
+and therefore a different image ID — even from identical source code.
+
+The Justfile passes `--remap-path-prefix` flags via `RUSTFLAGS` to normalize
+these paths:
+
+- The repository checkout path is remapped to `/build`
+- The Cargo registry (`$CARGO_HOME`) is remapped to `/registry`
+
+**Always use `just build` / `just bundle`** to get reproducible builds. Running
+`cargo +risc0 build` directly will produce a working ELF but with
+machine-specific paths baked in.
+
+### Bumping versions
 
 When bumping risc0 versions, you **must** rebuild the ELF, re-upload to
 IPFS, and update the image ID in both the registrar config and the on-chain


### PR DESCRIPTION
## Summary

- Add `--remap-path-prefix` rustflags to the guest Justfile so that absolute filesystem paths (checkout directory, cargo registry) are normalized before being embedded in the ELF binary
- Without this, the same source code produces different image IDs when built from different directories or machines
- Update guest README with a "Reproducibility" section documenting both dependency pinning and path remapping

## Details

Rust embeds absolute file paths into the binary for panic messages (e.g. `panicked at /Users/you/project/src/foo.rs:42`). These paths change depending on where the repository is checked out, producing a different ELF hash and therefore a different risc0 image ID — even from identical source code and pinned dependencies.

The Justfile now passes two `--remap-path-prefix` flags via `RUSTFLAGS`:
- Repository checkout path → `/build`
- Cargo registry (`$CARGO_HOME`) → `/registry`

This ensures `just build` / `just bundle` produces a byte-identical ELF (and therefore identical image ID) regardless of the build environment.

## Changes

| File | Change |
|---|---|
| `guest/.cargo/config.toml` | Added comments directing users to use `just build` for reproducible builds |
| `guest/Justfile` | Added `--remap-path-prefix` flags via `RUSTFLAGS` |
| `guest/README.md` | Replaced "Version pinning" section with expanded "Reproducibility" section |