### PR TITLE
refactor(zk): Make ZK dispatch outbox authoritative

### DIFF
--- a/bin/prover/zk/src/cli.rs
+++ b/bin/prover/zk/src/cli.rs
@@ -350,7 +350,7 @@ impl ZkArgs {
             status_poller.run().await;
         });
 
-        let prover_server = ProverServiceServer::new(repo.clone(), manager.clone());
+        let prover_server = ProverServiceServer::new(repo.clone());
 
         let addr = self.grpc_listen_addr.parse()?;
 

--- a/crates/proof/zk/db/migrations/009_add_submitting_sessions.sql
+++ b/crates/proof/zk/db/migrations/009_add_submitting_sessions.sql
@@ -1,0 +1,10 @@
+-- Migration 009: Add durable submission stages for outbox-dispatched work.
+
+ALTER TABLE proof_sessions
+ALTER COLUMN backend_session_id DROP NOT NULL;
+
+DROP INDEX IF EXISTS idx_proof_sessions_active_stage;
+
+CREATE UNIQUE INDEX idx_proof_sessions_active_stage
+ON proof_sessions (proof_request_id, session_type)
+WHERE status IN ('SUBMITTING', 'RUNNING');

--- a/crates/proof/zk/db/migrations/009_add_submitting_sessions.sql
+++ b/crates/proof/zk/db/migrations/009_add_submitting_sessions.sql
@@ -3,6 +3,15 @@
 ALTER TABLE proof_sessions
 ALTER COLUMN backend_session_id DROP NOT NULL;
 
+ALTER TABLE proof_sessions
+ADD COLUMN IF NOT EXISTS updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW();
+
+DROP TRIGGER IF EXISTS update_proof_sessions_updated_at ON proof_sessions;
+CREATE TRIGGER update_proof_sessions_updated_at
+    BEFORE UPDATE ON proof_sessions
+    FOR EACH ROW
+    EXECUTE FUNCTION update_updated_at_column();
+
 DROP INDEX IF EXISTS idx_proof_sessions_active_stage;
 
 CREATE UNIQUE INDEX idx_proof_sessions_active_stage

--- a/crates/proof/zk/db/src/lib.rs
+++ b/crates/proof/zk/db/src/lib.rs
@@ -7,8 +7,8 @@ mod models;
 pub use models::{
     ClaimedProofRequest, CreateOutboxEntry, CreateProofRequest, MarkOutboxError,
     MarkOutboxProcessed, OutboxEntry, ProofRequest, ProofSession, ProofStatus, ProofType,
-    RetryOutcome, SessionStatus, SessionType, StuckProofSubmission, UpdateProofSession,
-    UpdateReceipt,
+    RetryOutcome, SUBMIT_SNARK_TASK, SUBMIT_STARK_TASK, SessionStatus, SessionType,
+    StuckProofSubmission, UpdateProofSession, UpdateReceipt,
 };
 
 mod repo;

--- a/crates/proof/zk/db/src/lib.rs
+++ b/crates/proof/zk/db/src/lib.rs
@@ -5,9 +5,10 @@ pub use config::DatabaseConfig;
 
 mod models;
 pub use models::{
-    CreateOutboxEntry, CreateProofRequest, CreateProofSession, MarkOutboxError,
+    ClaimedProofRequest, CreateOutboxEntry, CreateProofRequest, MarkOutboxError,
     MarkOutboxProcessed, OutboxEntry, ProofRequest, ProofSession, ProofStatus, ProofType,
-    RetryOutcome, SessionStatus, SessionType, UpdateProofSession, UpdateReceipt,
+    RetryOutcome, SessionStatus, SessionType, StuckProofSubmission, UpdateProofSession,
+    UpdateReceipt,
 };
 
 mod repo;

--- a/crates/proof/zk/db/src/models.rs
+++ b/crates/proof/zk/db/src/models.rs
@@ -59,6 +59,8 @@ impl TryFrom<&str> for ProofStatus {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, sqlx::Type)]
 #[sqlx(type_name = "VARCHAR", rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum SessionStatus {
+    /// Backend session is being submitted and does not yet have a backend ID.
+    Submitting,
     /// Backend session is actively running.
     Running,
     /// Backend session completed successfully.
@@ -71,6 +73,7 @@ impl SessionStatus {
     /// Convert enum to static string representation
     pub const fn as_str(&self) -> &'static str {
         match self {
+            Self::Submitting => "SUBMITTING",
             Self::Running => "RUNNING",
             Self::Completed => "COMPLETED",
             Self::Failed => "FAILED",
@@ -89,6 +92,7 @@ impl TryFrom<&str> for SessionStatus {
 
     fn try_from(s: &str) -> Result<Self, Self::Error> {
         match s {
+            "SUBMITTING" => Ok(Self::Submitting),
             "RUNNING" => Ok(Self::Running),
             "COMPLETED" => Ok(Self::Completed),
             "FAILED" => Ok(Self::Failed),
@@ -259,7 +263,7 @@ pub struct ProofSession {
     /// Whether this session produces a STARK or SNARK proof.
     pub session_type: SessionType,
     /// Backend-assigned session identifier.
-    pub backend_session_id: String,
+    pub backend_session_id: Option<String>,
     /// Current session status.
     pub status: SessionStatus,
     /// Error message if the session failed.
@@ -293,17 +297,24 @@ pub struct CreateProofRequest {
     pub intermediate_root_interval: Option<u64>,
 }
 
-/// Parameters for creating a new proof session
+/// A proof request paired with a durable SUBMITTING stage.
 #[derive(Debug, Clone)]
-pub struct CreateProofSession {
-    /// Parent proof request identifier.
-    pub proof_request_id: Uuid,
-    /// Whether this is a STARK or SNARK session.
+pub struct ClaimedProofRequest {
+    /// Proof request to submit.
+    pub proof_request: ProofRequest,
+    /// SUBMITTING session ID.
+    pub proof_session_id: i64,
+    /// Stage type.
     pub session_type: SessionType,
-    /// Backend-assigned session identifier.
-    pub backend_session_id: String,
-    /// Backend-specific metadata (JSON).
-    pub metadata: Option<serde_json::Value>,
+}
+
+/// A stale SUBMITTING session paired with its parent request.
+#[derive(Debug, Clone)]
+pub struct StuckProofSubmission {
+    /// Parent proof request.
+    pub proof_request: ProofRequest,
+    /// Stale proof session.
+    pub proof_session: ProofSession,
 }
 
 /// Parameters for updating a proof session status

--- a/crates/proof/zk/db/src/models.rs
+++ b/crates/proof/zk/db/src/models.rs
@@ -5,6 +5,11 @@ use serde::{Deserialize, Serialize};
 use sqlx::FromRow;
 use uuid::Uuid;
 
+/// Outbox task type for initial STARK submission.
+pub const SUBMIT_STARK_TASK: &str = "submit_stark";
+/// Outbox task type for follow-up SNARK submission.
+pub const SUBMIT_SNARK_TASK: &str = "submit_snark";
+
 /// Status of a proof request
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, sqlx::Type)]
 #[sqlx(type_name = "VARCHAR", rename_all = "SCREAMING_SNAKE_CASE")]

--- a/crates/proof/zk/db/src/models.rs
+++ b/crates/proof/zk/db/src/models.rs
@@ -272,6 +272,8 @@ pub struct ProofSession {
     pub metadata: Option<serde_json::Value>,
     /// Timestamp when the session was created.
     pub created_at: DateTime<Utc>,
+    /// Timestamp when the session was last updated.
+    pub updated_at: DateTime<Utc>,
     /// Timestamp when the session completed.
     pub completed_at: Option<DateTime<Utc>>,
 }

--- a/crates/proof/zk/db/src/repo.rs
+++ b/crates/proof/zk/db/src/repo.rs
@@ -2,10 +2,14 @@ use sqlx::{PgPool, Result, Row};
 use uuid::Uuid;
 
 use crate::{
-    CreateOutboxEntry, CreateProofRequest, CreateProofSession, MarkOutboxError,
+    ClaimedProofRequest, CreateOutboxEntry, CreateProofRequest, MarkOutboxError,
     MarkOutboxProcessed, OutboxEntry, ProofRequest, ProofSession, ProofStatus, ProofType,
-    RetryOutcome, SessionStatus, SessionType, UpdateProofSession, UpdateReceipt,
+    RetryOutcome, SessionStatus, SessionType, StuckProofSubmission, UpdateProofSession,
+    UpdateReceipt,
 };
+
+const SUBMIT_STARK_TASK: &str = "submit_stark";
+const SUBMIT_SNARK_TASK: &str = "submit_snark";
 
 /// Repository for proof request database operations
 #[derive(Clone, Debug)]
@@ -155,6 +159,239 @@ impl ProofRequestRepo {
         Ok(id)
     }
 
+    /// Create a durable SUBMITTING stage from an outbox task.
+    ///
+    /// Returns `Ok(None)` when an equivalent active or completed stage already
+    /// exists, allowing the outbox row to be marked processed idempotently.
+    pub async fn create_submitting_stage_for_outbox(
+        &self,
+        proof_request_id: Uuid,
+        session_type: SessionType,
+    ) -> Result<Option<ClaimedProofRequest>> {
+        let mut tx = self.pool.begin().await?;
+
+        let existing_stage: Option<i64> = sqlx::query_scalar(
+            r#"
+            SELECT id
+            FROM proof_sessions
+            WHERE proof_request_id = $1
+              AND session_type = $2
+              AND status IN ('SUBMITTING', 'RUNNING', 'COMPLETED')
+            LIMIT 1
+            "#,
+        )
+        .bind(proof_request_id)
+        .bind(session_type.as_str())
+        .fetch_optional(&mut *tx)
+        .await?;
+
+        if existing_stage.is_some() {
+            tx.commit().await?;
+            return Ok(None);
+        }
+
+        let request_row = sqlx::query(
+            r#"
+            UPDATE proof_requests
+            SET status = CASE WHEN $2 = 'STARK' THEN 'PENDING' ELSE status END,
+                error_message = NULL
+            WHERE id = $1
+              AND status NOT IN ('SUCCEEDED', 'FAILED')
+            RETURNING id, start_block_number, number_of_blocks_to_prove,
+                      sequence_window, proof_type, stark_receipt, snark_receipt,
+                      status, error_message, prover_address, l1_head,
+                      intermediate_root_interval,
+                      created_at, updated_at, completed_at, retry_count
+            "#,
+        )
+        .bind(proof_request_id)
+        .bind(session_type.as_str())
+        .fetch_optional(&mut *tx)
+        .await?;
+
+        let Some(request_row) = request_row else {
+            tx.commit().await?;
+            return Ok(None);
+        };
+
+        let session_id: i64 = sqlx::query_scalar(
+            r#"
+            INSERT INTO proof_sessions (
+                proof_request_id, session_type, backend_session_id, status, metadata
+            )
+            VALUES ($1, $2, NULL, $3, NULL)
+            RETURNING id
+            "#,
+        )
+        .bind(proof_request_id)
+        .bind(session_type.as_str())
+        .bind(SessionStatus::Submitting.as_str())
+        .fetch_one(&mut *tx)
+        .await?;
+
+        tx.commit().await?;
+
+        Ok(Some(ClaimedProofRequest {
+            proof_request: row_to_proof_request(&request_row)?,
+            proof_session_id: session_id,
+            session_type,
+        }))
+    }
+
+    /// Mark a SUBMITTING stage as RUNNING after the backend accepts it.
+    pub async fn mark_submitting_session_running(
+        &self,
+        proof_session_id: i64,
+        backend_session_id: &str,
+        metadata: Option<serde_json::Value>,
+    ) -> Result<bool> {
+        let mut tx = self.pool.begin().await?;
+
+        let request_id: Option<Uuid> = sqlx::query_scalar(
+            r#"
+            UPDATE proof_sessions
+            SET backend_session_id = $1,
+                status = $2,
+                metadata = COALESCE($3, metadata)
+            WHERE id = $4
+              AND status = 'SUBMITTING'
+            RETURNING proof_request_id
+            "#,
+        )
+        .bind(backend_session_id)
+        .bind(SessionStatus::Running.as_str())
+        .bind(&metadata)
+        .bind(proof_session_id)
+        .fetch_optional(&mut *tx)
+        .await?;
+
+        let Some(request_id) = request_id else {
+            tx.rollback().await?;
+            return Ok(false);
+        };
+
+        sqlx::query(
+            r#"
+            UPDATE proof_requests
+            SET status = $1
+            WHERE id = $2
+              AND status NOT IN ('SUCCEEDED', 'FAILED')
+            "#,
+        )
+        .bind(ProofStatus::Running.as_str())
+        .bind(request_id)
+        .execute(&mut *tx)
+        .await?;
+
+        tx.commit().await?;
+        Ok(true)
+    }
+
+    /// Fail a SUBMITTING stage before it reaches the backend.
+    pub async fn fail_submitting_session_and_request(
+        &self,
+        proof_session_id: i64,
+        proof_request_id: Uuid,
+        error_message: String,
+    ) -> Result<bool> {
+        let mut tx = self.pool.begin().await?;
+
+        let result = sqlx::query(
+            r#"
+            UPDATE proof_sessions
+            SET status = $1,
+                error_message = $2,
+                completed_at = NOW()
+            WHERE id = $3
+              AND status = 'SUBMITTING'
+            "#,
+        )
+        .bind(SessionStatus::Failed.as_str())
+        .bind(&error_message)
+        .bind(proof_session_id)
+        .execute(&mut *tx)
+        .await?;
+
+        if result.rows_affected() == 0 {
+            tx.rollback().await?;
+            return Ok(false);
+        }
+
+        sqlx::query(
+            r#"
+            UPDATE proof_requests
+            SET status = $1,
+                error_message = $2,
+                completed_at = NOW()
+            WHERE id = $3
+              AND status NOT IN ('SUCCEEDED', 'FAILED')
+            "#,
+        )
+        .bind(ProofStatus::Failed.as_str())
+        .bind(&error_message)
+        .bind(proof_request_id)
+        .execute(&mut *tx)
+        .await?;
+
+        tx.commit().await?;
+        Ok(true)
+    }
+
+    /// Enqueue the SNARK stage once the STARK receipt has been persisted.
+    pub async fn enqueue_snark_outbox_if_needed(&self, id: Uuid) -> Result<bool> {
+        let mut tx = self.pool.begin().await?;
+
+        let should_enqueue = sqlx::query_scalar::<_, bool>(
+            r#"
+            SELECT EXISTS (
+                SELECT 1
+                FROM proof_requests
+                WHERE id = $1
+                  AND proof_type = 'op_succinct_sp1_cluster_snark_groth16'
+                  AND stark_receipt IS NOT NULL
+                  AND snark_receipt IS NULL
+                  AND status = 'RUNNING'
+            )
+            AND NOT EXISTS (
+                SELECT 1
+                FROM proof_sessions
+                WHERE proof_request_id = $1
+                  AND session_type = 'SNARK'
+                  AND status IN ('SUBMITTING', 'RUNNING', 'COMPLETED')
+            )
+            AND NOT EXISTS (
+                SELECT 1
+                FROM proof_request_outbox
+                WHERE proof_request_id = $1
+                  AND processed = FALSE
+                  AND request_params->>'task_type' = 'submit_snark'
+            )
+            "#,
+        )
+        .bind(id)
+        .fetch_one(&mut *tx)
+        .await?;
+
+        if !should_enqueue {
+            tx.commit().await?;
+            return Ok(false);
+        }
+
+        sqlx::query(
+            r#"
+            INSERT INTO proof_request_outbox (proof_request_id, request_params)
+            VALUES ($1, jsonb_build_object('task_type', $2))
+            "#,
+        )
+        .bind(id)
+        .bind(SUBMIT_SNARK_TASK)
+        .execute(&mut *tx)
+        .await?;
+
+        tx.commit().await?;
+        Ok(true)
+    }
+
     /// Get a proof request by ID
     pub async fn get(&self, id: Uuid) -> Result<Option<ProofRequest>> {
         let row = sqlx::query(
@@ -211,104 +448,6 @@ impl ProofRequestRepo {
         let updated = result.rows_affected() > 0;
 
         Ok(updated)
-    }
-
-    /// Atomically claim a task by transitioning it from CREATED to PENDING.
-    /// Returns true if the task was successfully claimed (was in CREATED state).
-    /// Returns false if the task was already claimed or doesn't exist.
-    pub async fn atomic_claim_task(&self, id: Uuid) -> Result<bool> {
-        let result = sqlx::query(
-            r#"
-            UPDATE proof_requests
-            SET status = $1
-            WHERE id = $2 AND status = $3
-            "#,
-        )
-        .bind(ProofStatus::Pending.as_str())
-        .bind(id)
-        .bind(ProofStatus::Created.as_str())
-        .execute(&self.pool)
-        .await?;
-
-        let claimed = result.rows_affected() > 0;
-
-        Ok(claimed)
-    }
-
-    /// Atomically create a proof session and transition proof request PENDING → RUNNING.
-    /// Returns `Ok(Some(session_id))` if the request was in PENDING state.
-    /// Returns `Ok(None)` if the request was NOT in PENDING state (race lost).
-    pub async fn transition_pending_to_running(
-        &self,
-        session: CreateProofSession,
-    ) -> Result<Option<i64>> {
-        let mut tx = self.pool.begin().await?;
-
-        let result = sqlx::query(
-            r#"
-            UPDATE proof_requests
-            SET status = $1
-            WHERE id = $2 AND status = $3
-            "#,
-        )
-        .bind(ProofStatus::Running.as_str())
-        .bind(session.proof_request_id)
-        .bind(ProofStatus::Pending.as_str())
-        .execute(&mut *tx)
-        .await?;
-
-        if result.rows_affected() == 0 {
-            tx.rollback().await?;
-            return Ok(None);
-        }
-
-        let row = sqlx::query(
-            r#"
-            INSERT INTO proof_sessions (
-                proof_request_id, session_type, backend_session_id, status, metadata
-            )
-            VALUES ($1, $2, $3, $4, $5)
-            RETURNING id
-            "#,
-        )
-        .bind(session.proof_request_id)
-        .bind(session.session_type.as_str())
-        .bind(&session.backend_session_id)
-        .bind(SessionStatus::Running.as_str())
-        .bind(&session.metadata)
-        .fetch_one(&mut *tx)
-        .await?;
-
-        let session_id: i64 = row.get("id");
-        tx.commit().await?;
-
-        Ok(Some(session_id))
-    }
-
-    /// Transition proof request PENDING → FAILED with error message.
-    /// Returns true if the transition succeeded (was PENDING).
-    pub async fn transition_pending_to_failed(
-        &self,
-        id: Uuid,
-        error_message: String,
-    ) -> Result<bool> {
-        let result = sqlx::query(
-            r#"
-            UPDATE proof_requests
-            SET status = $1,
-                error_message = $2,
-                completed_at = NOW()
-            WHERE id = $3 AND status = $4
-            "#,
-        )
-        .bind(ProofStatus::Failed.as_str())
-        .bind(&error_message)
-        .bind(id)
-        .bind(ProofStatus::Pending.as_str())
-        .execute(&self.pool)
-        .await?;
-
-        Ok(result.rows_affected() > 0)
     }
 
     /// Transition proof request RUNNING → FAILED with optional error message.
@@ -491,29 +630,6 @@ impl ProofRequestRepo {
 
     // ========== Proof Session Methods ==========
 
-    /// Create a new proof session
-    pub async fn create_proof_session(&self, session: CreateProofSession) -> Result<i64> {
-        let row = sqlx::query(
-            r#"
-            INSERT INTO proof_sessions (
-                proof_request_id, session_type, backend_session_id, status, metadata
-            )
-            VALUES ($1, $2, $3, $4, $5)
-            RETURNING id
-            "#,
-        )
-        .bind(session.proof_request_id)
-        .bind(session.session_type.as_str())
-        .bind(&session.backend_session_id)
-        .bind(SessionStatus::Running.as_str())
-        .bind(&session.metadata)
-        .fetch_one(&self.pool)
-        .await?;
-
-        let id: i64 = row.get("id");
-        Ok(id)
-    }
-
     /// Get a proof session by backend session ID
     pub async fn get_session_by_backend_id(
         &self,
@@ -613,7 +729,7 @@ impl ProofRequestRepo {
               AND NOT EXISTS (
                   SELECT 1 FROM proof_sessions ps
                   WHERE ps.proof_request_id = pr.id
-                    AND ps.status = 'RUNNING'
+                    AND ps.status IN ('SUBMITTING', 'RUNNING')
               )
             ORDER BY pr.created_at ASC
             "#,
@@ -623,6 +739,180 @@ impl ProofRequestRepo {
         .await?;
 
         rows.iter().map(row_to_proof_request).collect()
+    }
+
+    /// Get SUBMITTING sessions that never reached the backend.
+    pub async fn get_stuck_submissions(
+        &self,
+        stuck_timeout_mins: i32,
+    ) -> Result<Vec<StuckProofSubmission>> {
+        let rows = sqlx::query(
+            r#"
+            SELECT
+                pr.id, pr.start_block_number, pr.number_of_blocks_to_prove,
+                pr.sequence_window, pr.proof_type, pr.stark_receipt, pr.snark_receipt,
+                pr.status, pr.error_message, pr.prover_address, pr.l1_head,
+                pr.intermediate_root_interval,
+                pr.created_at, pr.updated_at, pr.completed_at, pr.retry_count,
+                ps.id AS session_id, ps.session_type, ps.backend_session_id,
+                ps.status AS session_status, ps.error_message AS session_error_message,
+                ps.metadata, ps.created_at AS session_created_at,
+                ps.completed_at AS session_completed_at
+            FROM proof_sessions ps
+            JOIN proof_requests pr ON pr.id = ps.proof_request_id
+            WHERE ps.status = 'SUBMITTING'
+              AND ps.created_at < NOW() - INTERVAL '1 minute' * $1
+              AND pr.status NOT IN ('SUCCEEDED', 'FAILED')
+            ORDER BY ps.created_at ASC
+            "#,
+        )
+        .bind(stuck_timeout_mins)
+        .fetch_all(&self.pool)
+        .await?;
+
+        rows.iter().map(row_to_stuck_submission).collect()
+    }
+
+    /// Retry or fail a stale SUBMITTING session.
+    pub async fn retry_or_fail_stuck_submission(
+        &self,
+        proof_session_id: i64,
+        max_retries: i32,
+        error_message: &str,
+    ) -> Result<RetryOutcome> {
+        let mut tx = self.pool.begin().await?;
+
+        let maybe_row = sqlx::query(
+            r#"
+            SELECT pr.id, pr.retry_count, pr.start_block_number,
+                   pr.number_of_blocks_to_prove, pr.sequence_window, pr.proof_type,
+                   pr.prover_address, pr.l1_head, pr.intermediate_root_interval,
+                   ps.session_type, ps.status AS session_status
+            FROM proof_sessions ps
+            JOIN proof_requests pr ON pr.id = ps.proof_request_id
+            WHERE ps.id = $1
+            FOR UPDATE
+            "#,
+        )
+        .bind(proof_session_id)
+        .fetch_optional(&mut *tx)
+        .await?;
+
+        let Some(row) = maybe_row else {
+            tx.rollback().await?;
+            return Ok(RetryOutcome::Skipped);
+        };
+
+        if row.get::<&str, _>("session_status") != SessionStatus::Submitting.as_str() {
+            tx.rollback().await?;
+            return Ok(RetryOutcome::Skipped);
+        }
+
+        let proof_request_id: Uuid = row.get("id");
+        let retry_count: i32 = row.get("retry_count");
+
+        if retry_count >= max_retries {
+            let message =
+                format!("{error_message} (max retries exceeded after {retry_count} attempts)");
+            sqlx::query(
+                r#"
+                UPDATE proof_sessions
+                SET status = 'FAILED', error_message = $1, completed_at = NOW()
+                WHERE id = $2
+                "#,
+            )
+            .bind(&message)
+            .bind(proof_session_id)
+            .execute(&mut *tx)
+            .await?;
+
+            sqlx::query(
+                r#"
+                UPDATE proof_requests
+                SET status = 'FAILED', error_message = $1, completed_at = NOW()
+                WHERE id = $2
+                "#,
+            )
+            .bind(&message)
+            .bind(proof_request_id)
+            .execute(&mut *tx)
+            .await?;
+
+            tx.commit().await?;
+            return Ok(RetryOutcome::PermanentlyFailed);
+        }
+
+        sqlx::query(
+            r#"
+            UPDATE proof_sessions
+            SET status = 'FAILED', error_message = $1, completed_at = NOW()
+            WHERE id = $2
+            "#,
+        )
+        .bind(error_message)
+        .bind(proof_session_id)
+        .execute(&mut *tx)
+        .await?;
+
+        let session_type = row.get::<&str, _>("session_type");
+        if session_type == SessionType::Stark.as_str() {
+            let request_params = build_outbox_params(
+                row.get::<i64, _>("start_block_number"),
+                row.get::<i64, _>("number_of_blocks_to_prove"),
+                row.get::<Option<i64>, _>("sequence_window"),
+                row.get::<&str, _>("proof_type"),
+                row.get::<Option<&str>, _>("prover_address"),
+                row.get::<Option<&str>, _>("l1_head"),
+                row.get::<Option<i64>, _>("intermediate_root_interval"),
+            );
+
+            sqlx::query(
+                r#"
+                UPDATE proof_requests
+                SET status = 'CREATED', retry_count = retry_count + 1, error_message = NULL
+                WHERE id = $1
+                "#,
+            )
+            .bind(proof_request_id)
+            .execute(&mut *tx)
+            .await?;
+
+            sqlx::query(
+                r#"
+                INSERT INTO proof_request_outbox (proof_request_id, request_params)
+                VALUES ($1, $2)
+                "#,
+            )
+            .bind(proof_request_id)
+            .bind(&request_params)
+            .execute(&mut *tx)
+            .await?;
+        } else {
+            sqlx::query(
+                r#"
+                UPDATE proof_requests
+                SET retry_count = retry_count + 1, error_message = NULL
+                WHERE id = $1
+                "#,
+            )
+            .bind(proof_request_id)
+            .execute(&mut *tx)
+            .await?;
+
+            sqlx::query(
+                r#"
+                INSERT INTO proof_request_outbox (proof_request_id, request_params)
+                VALUES ($1, jsonb_build_object('task_type', $2))
+                "#,
+            )
+            .bind(proof_request_id)
+            .bind(SUBMIT_SNARK_TASK)
+            .execute(&mut *tx)
+            .await?;
+        }
+
+        tx.commit().await?;
+        Ok(RetryOutcome::Retried)
     }
 
     /// Update a proof session status
@@ -1004,6 +1294,33 @@ fn row_to_proof_session(row: &sqlx::postgres::PgRow) -> Result<ProofSession> {
     })
 }
 
+fn row_to_stuck_submission(row: &sqlx::postgres::PgRow) -> Result<StuckProofSubmission> {
+    let session_status_str: &str = row.get("session_status");
+    let session_status = SessionStatus::try_from(session_status_str).map_err(|e| {
+        sqlx::Error::Protocol(format!("Unknown session status '{session_status_str}': {e}"))
+    })?;
+
+    let session_type_str: &str = row.get("session_type");
+    let session_type = SessionType::try_from(session_type_str).map_err(|e| {
+        sqlx::Error::Protocol(format!("Unknown session type '{session_type_str}': {e}"))
+    })?;
+
+    Ok(StuckProofSubmission {
+        proof_request: row_to_proof_request(row)?,
+        proof_session: ProofSession {
+            id: row.get("session_id"),
+            proof_request_id: row.get("id"),
+            session_type,
+            backend_session_id: row.get("backend_session_id"),
+            status: session_status,
+            error_message: row.get("session_error_message"),
+            metadata: row.get("metadata"),
+            created_at: row.get("session_created_at"),
+            completed_at: row.get("session_completed_at"),
+        },
+    })
+}
+
 /// Build the canonical JSON payload for outbox entries.
 ///
 /// Both [`ProofRequestRepo::create_with_outbox`] and
@@ -1019,6 +1336,7 @@ fn build_outbox_params(
     intermediate_root_interval: Option<i64>,
 ) -> serde_json::Value {
     serde_json::json!({
+        "task_type": SUBMIT_STARK_TASK,
         "start_block_number": start_block_number,
         "number_of_blocks_to_prove": number_of_blocks_to_prove,
         "sequence_window": sequence_window,

--- a/crates/proof/zk/db/src/repo.rs
+++ b/crates/proof/zk/db/src/repo.rs
@@ -4,12 +4,9 @@ use uuid::Uuid;
 use crate::{
     ClaimedProofRequest, CreateOutboxEntry, CreateProofRequest, MarkOutboxError,
     MarkOutboxProcessed, OutboxEntry, ProofRequest, ProofSession, ProofStatus, ProofType,
-    RetryOutcome, SessionStatus, SessionType, StuckProofSubmission, UpdateProofSession,
-    UpdateReceipt,
+    RetryOutcome, SUBMIT_SNARK_TASK, SUBMIT_STARK_TASK, SessionStatus, SessionType,
+    StuckProofSubmission, UpdateProofSession, UpdateReceipt,
 };
-
-const SUBMIT_STARK_TASK: &str = "submit_stark";
-const SUBMIT_SNARK_TASK: &str = "submit_snark";
 
 /// Repository for proof request database operations
 #[derive(Clone, Debug)]
@@ -291,7 +288,22 @@ impl ProofRequestRepo {
         .await?;
 
         if request_result.rows_affected() == 0 {
-            tx.rollback().await?;
+            sqlx::query(
+                r#"
+                UPDATE proof_sessions
+                SET status = $1,
+                    error_message = $2,
+                    completed_at = NOW()
+                WHERE id = $3
+                "#,
+            )
+            .bind(SessionStatus::Failed.as_str())
+            .bind("Backend accepted session after proof request became terminal")
+            .bind(proof_session_id)
+            .execute(&mut *tx)
+            .await?;
+
+            tx.commit().await?;
             return Ok(false);
         }
 
@@ -367,12 +379,19 @@ impl ProofRequestRepo {
     }
 
     /// Enqueue the SNARK stage once the STARK receipt has been persisted.
-    pub async fn enqueue_snark_outbox_if_needed(&self, id: Uuid) -> Result<bool> {
+    ///
+    /// Failed SNARK sessions are retryable, but bounded by the proof request's
+    /// existing `retry_count` and the caller-provided retry limit.
+    pub async fn enqueue_snark_outbox_if_needed(
+        &self,
+        id: Uuid,
+        max_retries: i32,
+    ) -> Result<RetryOutcome> {
         let mut tx = self.pool.begin().await?;
 
-        let locked_request: Option<Uuid> = sqlx::query_scalar(
+        let locked_request = sqlx::query(
             r#"
-            SELECT id
+            SELECT retry_count
             FROM proof_requests
             WHERE id = $1
             FOR UPDATE
@@ -382,45 +401,78 @@ impl ProofRequestRepo {
         .fetch_optional(&mut *tx)
         .await?;
 
-        if locked_request.is_none() {
+        let Some(locked_request) = locked_request else {
             tx.commit().await?;
-            return Ok(false);
-        }
+            return Ok(RetryOutcome::Skipped);
+        };
 
-        let should_enqueue = sqlx::query_scalar::<_, bool>(
+        let retry_count: i32 = locked_request.get("retry_count");
+
+        let enqueue_state = sqlx::query(
             r#"
-            SELECT EXISTS (
-                SELECT 1
-                FROM proof_requests
-                WHERE id = $1
-                  AND proof_type = 'op_succinct_sp1_cluster_snark_groth16'
-                  AND stark_receipt IS NOT NULL
-                  AND snark_receipt IS NULL
-                  AND status = 'RUNNING'
-            )
-            AND NOT EXISTS (
-                SELECT 1
-                FROM proof_sessions
-                WHERE proof_request_id = $1
-                  AND session_type = 'SNARK'
-                  AND status IN ('SUBMITTING', 'RUNNING', 'COMPLETED')
-            )
-            AND NOT EXISTS (
-                SELECT 1
-                FROM proof_request_outbox
-                WHERE proof_request_id = $1
-                  AND processed = FALSE
-                  AND request_params->>'task_type' = 'submit_snark'
-            )
+            SELECT
+                EXISTS (
+                    SELECT 1
+                    FROM proof_sessions
+                    WHERE proof_request_id = $1
+                      AND session_type = 'SNARK'
+                      AND status = 'FAILED'
+                ) AS has_failed_snark,
+                EXISTS (
+                    SELECT 1
+                    FROM proof_requests
+                    WHERE id = $1
+                      AND proof_type = 'op_succinct_sp1_cluster_snark_groth16'
+                      AND stark_receipt IS NOT NULL
+                      AND snark_receipt IS NULL
+                      AND status = 'RUNNING'
+                )
+                AND NOT EXISTS (
+                    SELECT 1
+                    FROM proof_sessions
+                    WHERE proof_request_id = $1
+                      AND session_type = 'SNARK'
+                      AND status IN ('SUBMITTING', 'RUNNING', 'COMPLETED')
+                )
+                AND NOT EXISTS (
+                    SELECT 1
+                    FROM proof_request_outbox
+                    WHERE proof_request_id = $1
+                      AND processed = FALSE
+                      AND request_params->>'task_type' = 'submit_snark'
+                ) AS should_enqueue
             "#,
         )
         .bind(id)
         .fetch_one(&mut *tx)
         .await?;
 
+        let has_failed_snark: bool = enqueue_state.get("has_failed_snark");
+        let should_enqueue: bool = enqueue_state.get("should_enqueue");
+
         if !should_enqueue {
             tx.commit().await?;
-            return Ok(false);
+            return Ok(RetryOutcome::Skipped);
+        }
+
+        if has_failed_snark && retry_count >= max_retries {
+            tx.commit().await?;
+            return Ok(RetryOutcome::PermanentlyFailed);
+        }
+
+        if has_failed_snark {
+            sqlx::query(
+                r#"
+                UPDATE proof_requests
+                SET retry_count = retry_count + 1,
+                    error_message = NULL
+                WHERE id = $1
+                  AND status = 'RUNNING'
+                "#,
+            )
+            .bind(id)
+            .execute(&mut *tx)
+            .await?;
         }
 
         sqlx::query(
@@ -435,7 +487,7 @@ impl ProofRequestRepo {
         .await?;
 
         tx.commit().await?;
-        Ok(true)
+        Ok(RetryOutcome::Retried)
     }
 
     /// Get a proof request by ID

--- a/crates/proof/zk/db/src/repo.rs
+++ b/crates/proof/zk/db/src/repo.rs
@@ -78,7 +78,8 @@ impl ProofRequestRepo {
     ///
     /// When a `session_id` is provided in the request, it is used as the proof
     /// request UUID and the insert uses `ON CONFLICT (id) DO NOTHING` so that
-    /// duplicate submissions return the existing request ID without error.
+    /// duplicate submissions return the existing request ID without inserting
+    /// another outbox row.
     pub async fn create_with_outbox(&self, req: CreateProofRequest) -> Result<Uuid> {
         let id = req.session_id.unwrap_or_else(Uuid::new_v4);
 
@@ -214,20 +215,26 @@ impl ProofRequestRepo {
             return Ok(None);
         };
 
-        let session_id: i64 = sqlx::query_scalar(
+        let session_id: Option<i64> = sqlx::query_scalar(
             r#"
             INSERT INTO proof_sessions (
                 proof_request_id, session_type, backend_session_id, status, metadata
             )
             VALUES ($1, $2, NULL, $3, NULL)
+            ON CONFLICT DO NOTHING
             RETURNING id
             "#,
         )
         .bind(proof_request_id)
         .bind(session_type.as_str())
         .bind(SessionStatus::Submitting.as_str())
-        .fetch_one(&mut *tx)
+        .fetch_optional(&mut *tx)
         .await?;
+
+        let Some(session_id) = session_id else {
+            tx.commit().await?;
+            return Ok(None);
+        };
 
         tx.commit().await?;
 
@@ -270,7 +277,7 @@ impl ProofRequestRepo {
             return Ok(false);
         };
 
-        sqlx::query(
+        let request_result = sqlx::query(
             r#"
             UPDATE proof_requests
             SET status = $1
@@ -283,8 +290,30 @@ impl ProofRequestRepo {
         .execute(&mut *tx)
         .await?;
 
+        if request_result.rows_affected() == 0 {
+            tx.rollback().await?;
+            return Ok(false);
+        }
+
         tx.commit().await?;
         Ok(true)
+    }
+
+    /// Refresh a SUBMITTING session while backend submission is still in progress.
+    pub async fn touch_submitting_session(&self, proof_session_id: i64) -> Result<bool> {
+        let result = sqlx::query(
+            r#"
+            UPDATE proof_sessions
+            SET updated_at = NOW()
+            WHERE id = $1
+              AND status = 'SUBMITTING'
+            "#,
+        )
+        .bind(proof_session_id)
+        .execute(&self.pool)
+        .await?;
+
+        Ok(result.rows_affected() > 0)
     }
 
     /// Fail a SUBMITTING stage before it reaches the backend.
@@ -340,6 +369,23 @@ impl ProofRequestRepo {
     /// Enqueue the SNARK stage once the STARK receipt has been persisted.
     pub async fn enqueue_snark_outbox_if_needed(&self, id: Uuid) -> Result<bool> {
         let mut tx = self.pool.begin().await?;
+
+        let locked_request: Option<Uuid> = sqlx::query_scalar(
+            r#"
+            SELECT id
+            FROM proof_requests
+            WHERE id = $1
+            FOR UPDATE
+            "#,
+        )
+        .bind(id)
+        .fetch_optional(&mut *tx)
+        .await?;
+
+        if locked_request.is_none() {
+            tx.commit().await?;
+            return Ok(false);
+        }
 
         let should_enqueue = sqlx::query_scalar::<_, bool>(
             r#"
@@ -496,6 +542,14 @@ impl ProofRequestRepo {
                 error_message = $4,
                 completed_at = NOW()
             WHERE id = $5 AND status = $6
+              AND (
+                  (proof_type = 'op_succinct_sp1_cluster_compressed'
+                   AND COALESCE($1, stark_receipt) IS NOT NULL)
+                  OR
+                  (proof_type = 'op_succinct_sp1_cluster_snark_groth16'
+                   AND COALESCE($1, stark_receipt) IS NOT NULL
+                   AND COALESCE($2, snark_receipt) IS NOT NULL)
+              )
             "#,
         )
         .bind(&update.stark_receipt)
@@ -638,7 +692,7 @@ impl ProofRequestRepo {
         let row = sqlx::query(
             r#"
             SELECT id, proof_request_id, session_type, backend_session_id,
-                   status, error_message, metadata, created_at, completed_at
+                   status, error_message, metadata, created_at, updated_at, completed_at
             FROM proof_sessions
             WHERE backend_session_id = $1
             "#,
@@ -658,7 +712,7 @@ impl ProofRequestRepo {
         let rows = sqlx::query(
             r#"
             SELECT id, proof_request_id, session_type, backend_session_id,
-                   status, error_message, metadata, created_at, completed_at
+                   status, error_message, metadata, created_at, updated_at, completed_at
             FROM proof_sessions
             WHERE proof_request_id = $1
             ORDER BY created_at ASC
@@ -676,7 +730,7 @@ impl ProofRequestRepo {
         let rows = sqlx::query(
             r#"
             SELECT id, proof_request_id, session_type, backend_session_id,
-                   status, error_message, metadata, created_at, completed_at
+                   status, error_message, metadata, created_at, updated_at, completed_at
             FROM proof_sessions
             WHERE status = $1
             ORDER BY created_at ASC
@@ -757,11 +811,12 @@ impl ProofRequestRepo {
                 ps.id AS session_id, ps.session_type, ps.backend_session_id,
                 ps.status AS session_status, ps.error_message AS session_error_message,
                 ps.metadata, ps.created_at AS session_created_at,
+                ps.updated_at AS session_updated_at,
                 ps.completed_at AS session_completed_at
             FROM proof_sessions ps
             JOIN proof_requests pr ON pr.id = ps.proof_request_id
             WHERE ps.status = 'SUBMITTING'
-              AND ps.created_at < NOW() - INTERVAL '1 minute' * $1
+              AND ps.updated_at < NOW() - INTERVAL '1 minute' * $1
               AND pr.status NOT IN ('SUCCEEDED', 'FAILED')
             ORDER BY ps.created_at ASC
             "#,
@@ -791,7 +846,7 @@ impl ProofRequestRepo {
             FROM proof_sessions ps
             JOIN proof_requests pr ON pr.id = ps.proof_request_id
             WHERE ps.id = $1
-            FOR UPDATE
+            FOR UPDATE OF ps, pr
             "#,
         )
         .bind(proof_session_id)
@@ -1038,6 +1093,7 @@ impl ProofRequestRepo {
         &self,
         backend_session_id: &str,
         update_receipt: UpdateReceipt,
+        metadata: Option<serde_json::Value>,
     ) -> Result<bool> {
         let mut tx = self.pool.begin().await?;
 
@@ -1052,6 +1108,16 @@ impl ProofRequestRepo {
                 completed_at = CASE WHEN $3 IN ('SUCCEEDED', 'FAILED') THEN NOW() ELSE completed_at END
             WHERE id = $5
               AND status = 'RUNNING'
+              AND (
+                  $3 <> 'SUCCEEDED'
+                  OR
+                  (proof_type = 'op_succinct_sp1_cluster_compressed'
+                   AND COALESCE($1, stark_receipt) IS NOT NULL)
+                  OR
+                  (proof_type = 'op_succinct_sp1_cluster_snark_groth16'
+                   AND COALESCE($1, stark_receipt) IS NOT NULL
+                   AND COALESCE($2, snark_receipt) IS NOT NULL)
+              )
             "#,
         )
         .bind(&update_receipt.stark_receipt)
@@ -1067,18 +1133,26 @@ impl ProofRequestRepo {
             return Ok(false);
         }
 
-        sqlx::query(
+        let session_result = sqlx::query(
             r#"
             UPDATE proof_sessions
             SET status = $1,
+                metadata = COALESCE($2, metadata),
                 completed_at = NOW()
-            WHERE backend_session_id = $2
+            WHERE backend_session_id = $3
+              AND status = 'RUNNING'
             "#,
         )
         .bind(SessionStatus::Completed.as_str())
+        .bind(&metadata)
         .bind(backend_session_id)
         .execute(&mut *tx)
         .await?;
+
+        if session_result.rows_affected() == 0 {
+            tx.rollback().await?;
+            return Ok(false);
+        }
 
         tx.commit().await?;
 
@@ -1160,6 +1234,9 @@ impl ProofRequestRepo {
     ///
     /// Returns entries in order by `sequence_id` (FIFO), excluding entries that
     /// have exceeded `max_retries` attempts.
+    ///
+    /// This is intentionally an at-least-once read. Multiple readers may observe
+    /// the same row, and downstream durable-stage creation must be idempotent.
     pub async fn get_unprocessed_outbox_entries(
         &self,
         limit: i64,
@@ -1290,6 +1367,7 @@ fn row_to_proof_session(row: &sqlx::postgres::PgRow) -> Result<ProofSession> {
         error_message: row.get("error_message"),
         metadata: row.get("metadata"),
         created_at: row.get("created_at"),
+        updated_at: row.get("updated_at"),
         completed_at: row.get("completed_at"),
     })
 }
@@ -1316,6 +1394,7 @@ fn row_to_stuck_submission(row: &sqlx::postgres::PgRow) -> Result<StuckProofSubm
             error_message: row.get("session_error_message"),
             metadata: row.get("metadata"),
             created_at: row.get("session_created_at"),
+            updated_at: row.get("session_updated_at"),
             completed_at: row.get("session_completed_at"),
         },
     })

--- a/crates/proof/zk/db/tests/postgres_integration.rs
+++ b/crates/proof/zk/db/tests/postgres_integration.rs
@@ -16,9 +16,8 @@
 use std::time::Duration;
 
 use base_zk_db::{
-    CreateProofRequest, CreateProofSession, MarkOutboxError, MarkOutboxProcessed, ProofRequestRepo,
-    ProofStatus, ProofType, RetryOutcome, SessionStatus, SessionType, UpdateProofSession,
-    UpdateReceipt,
+    CreateProofRequest, MarkOutboxError, MarkOutboxProcessed, ProofRequestRepo, ProofStatus,
+    ProofType, SessionStatus, SessionType, UpdateProofSession, UpdateReceipt,
 };
 use sqlx::{PgPool, postgres::PgPoolOptions};
 use uuid::Uuid;
@@ -72,18 +71,28 @@ fn snark_request() -> CreateProofRequest {
 /// Returns `(request_id, backend_session_id)`.
 async fn setup_running_request(repo: &ProofRequestRepo) -> (Uuid, String) {
     let id = repo.create(compressed_request()).await.unwrap();
-    repo.atomic_claim_task(id).await.unwrap();
     let backend_id = format!("session-{}", Uuid::new_v4());
-    repo.transition_pending_to_running(CreateProofSession {
-        proof_request_id: id,
-        session_type: SessionType::Stark,
-        backend_session_id: backend_id.clone(),
-        metadata: None,
-    })
-    .await
-    .unwrap()
-    .expect("transition should succeed");
+    setup_running_session(repo, id, SessionType::Stark, &backend_id).await;
     (id, backend_id)
+}
+
+async fn setup_running_session(
+    repo: &ProofRequestRepo,
+    request_id: Uuid,
+    session_type: SessionType,
+    backend_id: &str,
+) -> i64 {
+    let claimed = repo
+        .create_submitting_stage_for_outbox(request_id, session_type)
+        .await
+        .unwrap()
+        .expect("stage should be created");
+    assert!(
+        repo.mark_submitting_session_running(claimed.proof_session_id, backend_id, None)
+            .await
+            .unwrap()
+    );
+    claimed.proof_session_id
 }
 
 // ============================================================
@@ -160,104 +169,6 @@ async fn test_get_nonexistent_returns_none() {
     assert!(result.is_none());
 }
 
-// ============================================================
-// Guarded state transition tests
-// ============================================================
-
-#[tokio::test]
-#[ignore = "requires a running Postgres with the prover schema (set DATABASE_URL); run with `cargo nextest run --run-ignored all -p base-zk-db --test postgres_integration --test-threads=1`"]
-async fn test_transition_pending_to_running() {
-    let pool = test_pool().await;
-    let repo = test_repo(pool);
-
-    let id = repo.create(compressed_request()).await.unwrap();
-    repo.atomic_claim_task(id).await.unwrap();
-
-    let backend_id = format!("ptr-{}", Uuid::new_v4());
-    let session_id = repo
-        .transition_pending_to_running(CreateProofSession {
-            proof_request_id: id,
-            session_type: SessionType::Stark,
-            backend_session_id: backend_id.clone(),
-            metadata: None,
-        })
-        .await
-        .unwrap();
-    assert!(session_id.is_some());
-
-    let req = repo.get(id).await.unwrap().unwrap();
-    assert_eq!(req.status, ProofStatus::Running);
-
-    let session =
-        repo.get_session_by_backend_id(&backend_id).await.unwrap().expect("should find session");
-    assert_eq!(session.status, SessionStatus::Running);
-}
-
-#[tokio::test]
-#[ignore = "requires a running Postgres with the prover schema (set DATABASE_URL); run with `cargo nextest run --run-ignored all -p base-zk-db --test postgres_integration --test-threads=1`"]
-async fn test_transition_pending_to_running_race() {
-    let pool = test_pool().await;
-    let repo = test_repo(pool);
-
-    let id = repo.create(compressed_request()).await.unwrap();
-    repo.atomic_claim_task(id).await.unwrap();
-
-    let first = repo
-        .transition_pending_to_running(CreateProofSession {
-            proof_request_id: id,
-            session_type: SessionType::Stark,
-            backend_session_id: format!("first-{}", Uuid::new_v4()),
-            metadata: None,
-        })
-        .await
-        .unwrap();
-    assert!(first.is_some());
-
-    let second = repo
-        .transition_pending_to_running(CreateProofSession {
-            proof_request_id: id,
-            session_type: SessionType::Stark,
-            backend_session_id: format!("second-{}", Uuid::new_v4()),
-            metadata: None,
-        })
-        .await
-        .unwrap();
-    assert!(second.is_none(), "second transition should lose the race");
-}
-
-#[tokio::test]
-#[ignore = "requires a running Postgres with the prover schema (set DATABASE_URL); run with `cargo nextest run --run-ignored all -p base-zk-db --test postgres_integration --test-threads=1`"]
-async fn test_transition_pending_to_failed() {
-    let pool = test_pool().await;
-    let repo = test_repo(pool);
-
-    let id = repo.create(compressed_request()).await.unwrap();
-    repo.atomic_claim_task(id).await.unwrap();
-
-    let updated = repo.transition_pending_to_failed(id, "submission timeout".into()).await.unwrap();
-    assert!(updated);
-
-    let req = repo.get(id).await.unwrap().unwrap();
-    assert_eq!(req.status, ProofStatus::Failed);
-    assert_eq!(req.error_message.as_deref(), Some("submission timeout"));
-    assert!(req.completed_at.is_some());
-}
-
-#[tokio::test]
-#[ignore = "requires a running Postgres with the prover schema (set DATABASE_URL); run with `cargo nextest run --run-ignored all -p base-zk-db --test postgres_integration --test-threads=1`"]
-async fn test_transition_pending_to_failed_wrong_state() {
-    let pool = test_pool().await;
-    let repo = test_repo(pool);
-
-    let id = repo.create(compressed_request()).await.unwrap();
-    // Still CREATED, not PENDING
-    let updated = repo.transition_pending_to_failed(id, "should not work".into()).await.unwrap();
-    assert!(!updated);
-
-    let req = repo.get(id).await.unwrap().unwrap();
-    assert_eq!(req.status, ProofStatus::Created);
-}
-
 #[tokio::test]
 #[ignore = "requires a running Postgres with the prover schema (set DATABASE_URL); run with `cargo nextest run --run-ignored all -p base-zk-db --test postgres_integration --test-threads=1`"]
 async fn test_transition_running_to_failed() {
@@ -283,7 +194,7 @@ async fn test_transition_running_to_failed_wrong_state() {
     let repo = test_repo(pool);
 
     let id = repo.create(compressed_request()).await.unwrap();
-    repo.atomic_claim_task(id).await.unwrap();
+    repo.create_submitting_stage_for_outbox(id, SessionType::Stark).await.unwrap();
     // PENDING, not RUNNING
     let updated =
         repo.transition_running_to_failed(id, Some("should not work".into())).await.unwrap();
@@ -335,62 +246,8 @@ async fn test_update_receipt_if_running() {
 }
 
 // ============================================================
-// Atomic claim tests
-// ============================================================
-
-#[tokio::test]
-#[ignore = "requires a running Postgres with the prover schema (set DATABASE_URL); run with `cargo nextest run --run-ignored all -p base-zk-db --test postgres_integration --test-threads=1`"]
-async fn test_atomic_claim_task() {
-    let pool = test_pool().await;
-    let repo = test_repo(pool);
-
-    let id = repo.create(compressed_request()).await.unwrap();
-
-    // First claim should succeed (CREATED -> PENDING)
-    let claimed = repo.atomic_claim_task(id).await.unwrap();
-    assert!(claimed);
-
-    let req = repo.get(id).await.unwrap().unwrap();
-    assert_eq!(req.status, ProofStatus::Pending);
-
-    // Second claim should fail (already PENDING)
-    let claimed = repo.atomic_claim_task(id).await.unwrap();
-    assert!(!claimed);
-}
-
-#[tokio::test]
-#[ignore = "requires a running Postgres with the prover schema (set DATABASE_URL); run with `cargo nextest run --run-ignored all -p base-zk-db --test postgres_integration --test-threads=1`"]
-async fn test_atomic_claim_nonexistent() {
-    let pool = test_pool().await;
-    let repo = test_repo(pool);
-
-    let claimed = repo.atomic_claim_task(Uuid::new_v4()).await.unwrap();
-    assert!(!claimed);
-}
-
-// ============================================================
 // Proof session tests
 // ============================================================
-
-#[tokio::test]
-#[ignore = "requires a running Postgres with the prover schema (set DATABASE_URL); run with `cargo nextest run --run-ignored all -p base-zk-db --test postgres_integration --test-threads=1`"]
-async fn test_create_proof_session() {
-    let pool = test_pool().await;
-    let repo = test_repo(pool);
-
-    let req_id = repo.create(compressed_request()).await.unwrap();
-    let session_id = repo
-        .create_proof_session(CreateProofSession {
-            proof_request_id: req_id,
-            session_type: SessionType::Stark,
-            backend_session_id: format!("test-session-{}", Uuid::new_v4()),
-            metadata: Some(serde_json::json!({"key": "value"})),
-        })
-        .await
-        .unwrap();
-
-    assert!(session_id > 0);
-}
 
 #[tokio::test]
 #[ignore = "requires a running Postgres with the prover schema (set DATABASE_URL); run with `cargo nextest run --run-ignored all -p base-zk-db --test postgres_integration --test-threads=1`"]
@@ -401,21 +258,14 @@ async fn test_get_session_by_backend_id() {
     let req_id = repo.create(compressed_request()).await.unwrap();
     let backend_id = format!("backend-{}", Uuid::new_v4());
 
-    repo.create_proof_session(CreateProofSession {
-        proof_request_id: req_id,
-        session_type: SessionType::Stark,
-        backend_session_id: backend_id.clone(),
-        metadata: None,
-    })
-    .await
-    .unwrap();
+    setup_running_session(&repo, req_id, SessionType::Stark, &backend_id).await;
 
     let session =
         repo.get_session_by_backend_id(&backend_id).await.unwrap().expect("should find session");
     assert_eq!(session.proof_request_id, req_id);
     assert_eq!(session.session_type, SessionType::Stark);
     assert_eq!(session.status, SessionStatus::Running);
-    assert_eq!(session.backend_session_id, backend_id);
+    assert_eq!(session.backend_session_id.as_deref(), Some(backend_id.as_str()));
 }
 
 #[tokio::test]
@@ -426,25 +276,10 @@ async fn test_get_sessions_for_request() {
 
     let req_id = repo.create(snark_request()).await.unwrap();
 
-    // Create STARK session
-    repo.create_proof_session(CreateProofSession {
-        proof_request_id: req_id,
-        session_type: SessionType::Stark,
-        backend_session_id: format!("stark-{}", Uuid::new_v4()),
-        metadata: None,
-    })
-    .await
-    .unwrap();
-
-    // Create SNARK session
-    repo.create_proof_session(CreateProofSession {
-        proof_request_id: req_id,
-        session_type: SessionType::Snark,
-        backend_session_id: format!("snark-{}", Uuid::new_v4()),
-        metadata: None,
-    })
-    .await
-    .unwrap();
+    setup_running_session(&repo, req_id, SessionType::Stark, &format!("stark-{}", Uuid::new_v4()))
+        .await;
+    setup_running_session(&repo, req_id, SessionType::Snark, &format!("snark-{}", Uuid::new_v4()))
+        .await;
 
     let sessions = repo.get_sessions_for_request(req_id).await.unwrap();
     assert_eq!(sessions.len(), 2);
@@ -461,14 +296,7 @@ async fn test_update_proof_session() {
     let req_id = repo.create(compressed_request()).await.unwrap();
     let backend_id = format!("session-update-{}", Uuid::new_v4());
 
-    repo.create_proof_session(CreateProofSession {
-        proof_request_id: req_id,
-        session_type: SessionType::Stark,
-        backend_session_id: backend_id.clone(),
-        metadata: None,
-    })
-    .await
-    .unwrap();
+    setup_running_session(&repo, req_id, SessionType::Stark, &backend_id).await;
 
     repo.update_proof_session(UpdateProofSession {
         backend_session_id: backend_id.clone(),
@@ -494,14 +322,7 @@ async fn test_update_proof_session_if_non_terminal() {
     let req_id = repo.create(compressed_request()).await.unwrap();
     let backend_id = format!("session-nonterminal-{}", Uuid::new_v4());
 
-    repo.create_proof_session(CreateProofSession {
-        proof_request_id: req_id,
-        session_type: SessionType::Stark,
-        backend_session_id: backend_id.clone(),
-        metadata: None,
-    })
-    .await
-    .unwrap();
+    setup_running_session(&repo, req_id, SessionType::Stark, &backend_id).await;
 
     // First update: RUNNING -> COMPLETED (should succeed)
     let updated = repo
@@ -635,17 +456,7 @@ async fn test_complete_session_and_update_receipt_skips_non_running() {
     let repo = test_repo(pool);
 
     let id = repo.create(compressed_request()).await.unwrap();
-    repo.atomic_claim_task(id).await.unwrap();
-    // Request is PENDING, not RUNNING
     let backend_id = format!("complete-pending-{}", Uuid::new_v4());
-    repo.create_proof_session(CreateProofSession {
-        proof_request_id: id,
-        session_type: SessionType::Stark,
-        backend_session_id: backend_id.clone(),
-        metadata: None,
-    })
-    .await
-    .unwrap();
 
     let updated = repo
         .complete_session_and_update_receipt(
@@ -663,73 +474,7 @@ async fn test_complete_session_and_update_receipt_skips_non_running() {
     assert!(!updated, "should not update a PENDING request");
 
     let req = repo.get(id).await.unwrap().unwrap();
-    assert_eq!(req.status, ProofStatus::Pending); // unchanged
-}
-
-// ============================================================
-// Retry logic tests
-// ============================================================
-
-#[tokio::test]
-#[ignore = "requires a running Postgres with the prover schema (set DATABASE_URL); run with `cargo nextest run --run-ignored all -p base-zk-db --test postgres_integration --test-threads=1`"]
-async fn test_retry_or_fail_stuck_request_retries() {
-    let pool = test_pool().await;
-    let repo = test_repo(pool);
-
-    let id = repo.create(compressed_request()).await.unwrap();
-    repo.atomic_claim_task(id).await.unwrap();
-
-    let outcome = repo.retry_or_fail_stuck_request(id, 3, "stuck in PENDING").await.unwrap();
-    assert_eq!(outcome, RetryOutcome::Retried);
-
-    let req = repo.get(id).await.unwrap().unwrap();
-    assert_eq!(req.status, ProofStatus::Created);
-    assert_eq!(req.retry_count, 1);
-    assert!(req.error_message.is_none());
-}
-
-#[tokio::test]
-#[ignore = "requires a running Postgres with the prover schema (set DATABASE_URL); run with `cargo nextest run --run-ignored all -p base-zk-db --test postgres_integration --test-threads=1`"]
-async fn test_retry_or_fail_stuck_request_exhausted() {
-    let pool = test_pool().await;
-    let repo = test_repo(pool);
-
-    let id = repo.create(compressed_request()).await.unwrap();
-
-    // Retry 3 times: each cycle is claim → retry (resets to CREATED) → claim again
-    for i in 0..3 {
-        repo.atomic_claim_task(id).await.unwrap();
-        let outcome = repo.retry_or_fail_stuck_request(id, 3, "stuck").await.unwrap();
-        assert_eq!(outcome, RetryOutcome::Retried, "retry {i} should succeed");
-    }
-
-    // retry_count is now 3, claim once more
-    repo.atomic_claim_task(id).await.unwrap();
-
-    // This time should permanently fail (retry_count >= max_retries)
-    let outcome = repo.retry_or_fail_stuck_request(id, 3, "stuck").await.unwrap();
-    assert_eq!(outcome, RetryOutcome::PermanentlyFailed);
-
-    let req = repo.get(id).await.unwrap().unwrap();
-    assert_eq!(req.status, ProofStatus::Failed);
-    assert!(req.error_message.as_deref().unwrap().contains("max retries exceeded"));
-    assert!(req.completed_at.is_some());
-}
-
-#[tokio::test]
-#[ignore = "requires a running Postgres with the prover schema (set DATABASE_URL); run with `cargo nextest run --run-ignored all -p base-zk-db --test postgres_integration --test-threads=1`"]
-async fn test_retry_or_fail_stuck_request_wrong_state() {
-    let pool = test_pool().await;
-    let repo = test_repo(pool);
-
-    let (id, _backend_id) = setup_running_request(&repo).await;
-
-    // Request is RUNNING, not PENDING — should be skipped
-    let outcome = repo.retry_or_fail_stuck_request(id, 3, "stuck").await.unwrap();
-    assert_eq!(outcome, RetryOutcome::Skipped);
-
-    let req = repo.get(id).await.unwrap().unwrap();
-    assert_eq!(req.status, ProofStatus::Running); // unchanged
+    assert_eq!(req.status, ProofStatus::Created); // unchanged
 }
 
 // ============================================================
@@ -843,25 +588,10 @@ async fn test_get_running_sessions() {
     let running_id = format!("running-session-{}", Uuid::new_v4());
     let completed_id = format!("completed-session-{}", Uuid::new_v4());
 
-    // Create a running session
-    repo.create_proof_session(CreateProofSession {
-        proof_request_id: req_id,
-        session_type: SessionType::Stark,
-        backend_session_id: running_id.clone(),
-        metadata: None,
-    })
-    .await
-    .unwrap();
+    setup_running_session(&repo, req_id, SessionType::Stark, &running_id).await;
 
     // Create and complete another session
-    repo.create_proof_session(CreateProofSession {
-        proof_request_id: req_id,
-        session_type: SessionType::Snark,
-        backend_session_id: completed_id.clone(),
-        metadata: None,
-    })
-    .await
-    .unwrap();
+    setup_running_session(&repo, req_id, SessionType::Snark, &completed_id).await;
     repo.update_proof_session(UpdateProofSession {
         backend_session_id: completed_id.clone(),
         status: SessionStatus::Completed,
@@ -872,8 +602,9 @@ async fn test_get_running_sessions() {
     .unwrap();
 
     let running = repo.get_running_sessions().await.unwrap();
-    let has_running = running.iter().any(|s| s.backend_session_id == running_id);
-    let has_completed = running.iter().any(|s| s.backend_session_id == completed_id);
+    let has_running = running.iter().any(|s| s.backend_session_id.as_deref() == Some(&running_id));
+    let has_completed =
+        running.iter().any(|s| s.backend_session_id.as_deref() == Some(&completed_id));
     assert!(has_running, "should include running session");
     assert!(!has_completed, "should not include completed session");
 }
@@ -926,21 +657,9 @@ async fn test_full_snark_pipeline() {
     // 1. Create SNARK request
     let req_id = repo.create(snark_request()).await.unwrap();
 
-    // 2. Claim task (CREATED -> PENDING)
-    assert!(repo.atomic_claim_task(req_id).await.unwrap());
-
-    // 3. Submit STARK session (PENDING -> RUNNING)
+    // 2. Submit STARK session
     let stark_backend_id = format!("stark-pipeline-{}", Uuid::new_v4());
-    let session_id = repo
-        .transition_pending_to_running(CreateProofSession {
-            proof_request_id: req_id,
-            session_type: SessionType::Stark,
-            backend_session_id: stark_backend_id.clone(),
-            metadata: None,
-        })
-        .await
-        .unwrap();
-    assert!(session_id.is_some());
+    setup_running_session(&repo, req_id, SessionType::Stark, &stark_backend_id).await;
 
     // 4. STARK completes — store receipt but keep RUNNING (awaiting SNARK)
     let stark_receipt = vec![0x01, 0x02, 0x03];
@@ -964,14 +683,7 @@ async fn test_full_snark_pipeline() {
 
     // 5. Submit SNARK session
     let snark_backend_id = format!("snark-pipeline-{}", Uuid::new_v4());
-    repo.create_proof_session(CreateProofSession {
-        proof_request_id: req_id,
-        session_type: SessionType::Snark,
-        backend_session_id: snark_backend_id.clone(),
-        metadata: None,
-    })
-    .await
-    .unwrap();
+    setup_running_session(&repo, req_id, SessionType::Snark, &snark_backend_id).await;
 
     // 6. SNARK completes — store receipt, mark SUCCEEDED
     let snark_receipt = vec![0xAA, 0xBB, 0xCC];

--- a/crates/proof/zk/db/tests/postgres_integration.rs
+++ b/crates/proof/zk/db/tests/postgres_integration.rs
@@ -17,7 +17,7 @@ use std::time::Duration;
 
 use base_zk_db::{
     CreateProofRequest, MarkOutboxError, MarkOutboxProcessed, ProofRequestRepo, ProofStatus,
-    ProofType, SessionStatus, SessionType, UpdateProofSession, UpdateReceipt,
+    ProofType, RetryOutcome, SessionStatus, SessionType, UpdateProofSession, UpdateReceipt,
 };
 use sqlx::{PgPool, postgres::PgPoolOptions};
 use uuid::Uuid;
@@ -567,12 +567,15 @@ async fn test_concurrent_snark_enqueue_is_serialized() {
     .await
     .unwrap();
 
-    let first = repo.enqueue_snark_outbox_if_needed(req_id);
-    let second = repo.enqueue_snark_outbox_if_needed(req_id);
+    let first = repo.enqueue_snark_outbox_if_needed(req_id, 3);
+    let second = repo.enqueue_snark_outbox_if_needed(req_id, 3);
     let (first, second) = tokio::join!(first, second);
 
     assert_eq!(
-        [first.unwrap(), second.unwrap()].into_iter().filter(|inserted| *inserted).count(),
+        [first.unwrap(), second.unwrap()]
+            .into_iter()
+            .filter(|outcome| *outcome == RetryOutcome::Retried)
+            .count(),
         1,
         "exactly one caller should enqueue the SNARK stage"
     );
@@ -613,6 +616,42 @@ async fn test_submitting_session_heartbeat_only_touches_submitting() {
         .unwrap()
     );
     assert!(!repo.touch_submitting_session(claimed.proof_session_id).await.unwrap());
+}
+
+#[tokio::test]
+#[ignore = "requires a running Postgres with the prover schema (set DATABASE_URL); run with `cargo nextest run --run-ignored all -p base-zk-db --test postgres_integration --test-threads=1`"]
+async fn test_running_transition_persists_backend_id_when_request_is_terminal() {
+    let pool = test_pool().await;
+    let repo = test_repo(pool.clone());
+
+    let id = repo.create(compressed_request()).await.unwrap();
+    let claimed = repo
+        .create_submitting_stage_for_outbox(id, SessionType::Stark)
+        .await
+        .unwrap()
+        .expect("stage should be claimed");
+
+    sqlx::query("UPDATE proof_requests SET status = 'FAILED' WHERE id = $1")
+        .bind(id)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    let backend_id = format!("accepted-terminal-{}", Uuid::new_v4());
+    let updated = repo
+        .mark_submitting_session_running(claimed.proof_session_id, &backend_id, None)
+        .await
+        .unwrap();
+
+    assert!(!updated);
+
+    let session = repo.get_session_by_backend_id(&backend_id).await.unwrap().unwrap();
+    assert_eq!(session.status, SessionStatus::Failed);
+    assert!(session.completed_at.is_some());
+    assert_eq!(
+        session.error_message.as_deref(),
+        Some("Backend accepted session after proof request became terminal")
+    );
 }
 
 #[tokio::test]
@@ -683,7 +722,60 @@ async fn test_snark_enqueue_allows_failed_snark_attempts() {
     .await
     .unwrap();
 
-    assert!(repo.enqueue_snark_outbox_if_needed(req_id).await.unwrap());
+    assert_eq!(
+        repo.enqueue_snark_outbox_if_needed(req_id, 3).await.unwrap(),
+        RetryOutcome::Retried
+    );
+}
+
+#[tokio::test]
+#[ignore = "requires a running Postgres with the prover schema (set DATABASE_URL); run with `cargo nextest run --run-ignored all -p base-zk-db --test postgres_integration --test-threads=1`"]
+async fn test_snark_enqueue_fails_request_after_retry_budget() {
+    let pool = test_pool().await;
+    let repo = test_repo(pool.clone());
+
+    let req_id = repo.create(snark_request()).await.unwrap();
+    let stark_backend_id = format!("stark-budget-{}", Uuid::new_v4());
+    setup_running_session(&repo, req_id, SessionType::Stark, &stark_backend_id).await;
+    repo.complete_session_and_update_receipt(
+        &stark_backend_id,
+        UpdateReceipt {
+            id: req_id,
+            stark_receipt: Some(vec![0x01]),
+            snark_receipt: None,
+            status: ProofStatus::Running,
+            error_message: None,
+        },
+        None,
+    )
+    .await
+    .unwrap();
+
+    let failed_snark_backend_id = format!("snark-budget-{}", Uuid::new_v4());
+    setup_running_session(&repo, req_id, SessionType::Snark, &failed_snark_backend_id).await;
+    repo.update_proof_session(UpdateProofSession {
+        backend_session_id: failed_snark_backend_id,
+        status: SessionStatus::Failed,
+        error_message: Some("retryable failure".to_string()),
+        metadata: None,
+    })
+    .await
+    .unwrap();
+
+    sqlx::query("UPDATE proof_requests SET retry_count = 3 WHERE id = $1")
+        .bind(req_id)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    assert_eq!(
+        repo.enqueue_snark_outbox_if_needed(req_id, 3).await.unwrap(),
+        RetryOutcome::PermanentlyFailed
+    );
+
+    let request = repo.get(req_id).await.unwrap().unwrap();
+    assert_eq!(request.status, ProofStatus::Running);
+    assert!(request.error_message.is_none());
 }
 
 #[tokio::test]

--- a/crates/proof/zk/db/tests/postgres_integration.rs
+++ b/crates/proof/zk/db/tests/postgres_integration.rs
@@ -397,6 +397,7 @@ async fn test_fail_session_and_request_skips_terminal() {
             status: ProofStatus::Succeeded,
             error_message: None,
         },
+        None,
     )
     .await
     .unwrap();
@@ -434,6 +435,7 @@ async fn test_complete_session_and_update_receipt() {
                 status: ProofStatus::Succeeded,
                 error_message: None,
             },
+            Some(serde_json::json!({"completed": true})),
         )
         .await
         .unwrap();
@@ -447,6 +449,7 @@ async fn test_complete_session_and_update_receipt() {
     let session = repo.get_session_by_backend_id(&backend_id).await.unwrap().unwrap();
     assert_eq!(session.status, SessionStatus::Completed);
     assert!(session.completed_at.is_some());
+    assert_eq!(session.metadata.unwrap()["completed"].as_bool(), Some(true));
 }
 
 #[tokio::test]
@@ -468,6 +471,7 @@ async fn test_complete_session_and_update_receipt_skips_non_running() {
                 status: ProofStatus::Succeeded,
                 error_message: None,
             },
+            None,
         )
         .await
         .unwrap();
@@ -514,6 +518,172 @@ async fn test_create_with_outbox_idempotent() {
 
     assert_eq!(id1, explicit_id);
     assert_eq!(id2, explicit_id); // idempotent — same ID returned
+}
+
+#[tokio::test]
+#[ignore = "requires a running Postgres with the prover schema (set DATABASE_URL); run with `cargo nextest run --run-ignored all -p base-zk-db --test postgres_integration --test-threads=1`"]
+async fn test_concurrent_submitting_stage_creation_is_idempotent() {
+    let pool = test_pool().await;
+    let repo = test_repo(pool);
+
+    let id = repo.create(compressed_request()).await.unwrap();
+
+    let first = repo.create_submitting_stage_for_outbox(id, SessionType::Stark);
+    let second = repo.create_submitting_stage_for_outbox(id, SessionType::Stark);
+    let (first, second) = tokio::join!(first, second);
+
+    let created = [first.unwrap(), second.unwrap()].into_iter().filter(Option::is_some).count();
+    assert_eq!(created, 1, "exactly one caller should claim the durable stage");
+
+    let sessions = repo.get_sessions_for_request(id).await.unwrap();
+    assert_eq!(sessions.len(), 1);
+    assert_eq!(sessions[0].status, SessionStatus::Submitting);
+
+    let request = repo.get(id).await.unwrap().unwrap();
+    assert_eq!(request.status, ProofStatus::Pending);
+}
+
+#[tokio::test]
+#[ignore = "requires a running Postgres with the prover schema (set DATABASE_URL); run with `cargo nextest run --run-ignored all -p base-zk-db --test postgres_integration --test-threads=1`"]
+async fn test_concurrent_snark_enqueue_is_serialized() {
+    let pool = test_pool().await;
+    let repo = test_repo(pool);
+
+    let req_id = repo.create(snark_request()).await.unwrap();
+    let stark_backend_id = format!("stark-enqueue-{}", Uuid::new_v4());
+    setup_running_session(&repo, req_id, SessionType::Stark, &stark_backend_id).await;
+
+    repo.complete_session_and_update_receipt(
+        &stark_backend_id,
+        UpdateReceipt {
+            id: req_id,
+            stark_receipt: Some(vec![0x01]),
+            snark_receipt: None,
+            status: ProofStatus::Running,
+            error_message: None,
+        },
+        None,
+    )
+    .await
+    .unwrap();
+
+    let first = repo.enqueue_snark_outbox_if_needed(req_id);
+    let second = repo.enqueue_snark_outbox_if_needed(req_id);
+    let (first, second) = tokio::join!(first, second);
+
+    assert_eq!(
+        [first.unwrap(), second.unwrap()].into_iter().filter(|inserted| *inserted).count(),
+        1,
+        "exactly one caller should enqueue the SNARK stage"
+    );
+
+    let entries = repo.get_unprocessed_outbox_entries(100, 3).await.unwrap();
+    let snark_entries = entries
+        .iter()
+        .filter(|entry| {
+            entry.proof_request_id == req_id
+                && entry.request_params.get("task_type").and_then(serde_json::Value::as_str)
+                    == Some("submit_snark")
+        })
+        .count();
+    assert_eq!(snark_entries, 1);
+}
+
+#[tokio::test]
+#[ignore = "requires a running Postgres with the prover schema (set DATABASE_URL); run with `cargo nextest run --run-ignored all -p base-zk-db --test postgres_integration --test-threads=1`"]
+async fn test_submitting_session_heartbeat_only_touches_submitting() {
+    let pool = test_pool().await;
+    let repo = test_repo(pool);
+
+    let id = repo.create(compressed_request()).await.unwrap();
+    let claimed = repo
+        .create_submitting_stage_for_outbox(id, SessionType::Stark)
+        .await
+        .unwrap()
+        .expect("stage should be claimed");
+
+    assert!(repo.touch_submitting_session(claimed.proof_session_id).await.unwrap());
+    assert!(
+        repo.mark_submitting_session_running(
+            claimed.proof_session_id,
+            &format!("heartbeat-{}", Uuid::new_v4()),
+            None,
+        )
+        .await
+        .unwrap()
+    );
+    assert!(!repo.touch_submitting_session(claimed.proof_session_id).await.unwrap());
+}
+
+#[tokio::test]
+#[ignore = "requires a running Postgres with the prover schema (set DATABASE_URL); run with `cargo nextest run --run-ignored all -p base-zk-db --test postgres_integration --test-threads=1`"]
+async fn test_succeeded_transition_requires_snark_receipt_for_snark_requests() {
+    let pool = test_pool().await;
+    let repo = test_repo(pool);
+
+    let req_id = repo.create(snark_request()).await.unwrap();
+    let stark_backend_id = format!("stark-receipt-{}", Uuid::new_v4());
+    setup_running_session(&repo, req_id, SessionType::Stark, &stark_backend_id).await;
+
+    let updated = repo
+        .complete_session_and_update_receipt(
+            &stark_backend_id,
+            UpdateReceipt {
+                id: req_id,
+                stark_receipt: Some(vec![0x01]),
+                snark_receipt: None,
+                status: ProofStatus::Succeeded,
+                error_message: None,
+            },
+            None,
+        )
+        .await
+        .unwrap();
+
+    assert!(!updated, "SNARK request should not succeed without a SNARK receipt");
+
+    let request = repo.get(req_id).await.unwrap().unwrap();
+    assert_eq!(request.status, ProofStatus::Running);
+
+    let session = repo.get_session_by_backend_id(&stark_backend_id).await.unwrap().unwrap();
+    assert_eq!(session.status, SessionStatus::Running);
+}
+
+#[tokio::test]
+#[ignore = "requires a running Postgres with the prover schema (set DATABASE_URL); run with `cargo nextest run --run-ignored all -p base-zk-db --test postgres_integration --test-threads=1`"]
+async fn test_snark_enqueue_allows_failed_snark_attempts() {
+    let pool = test_pool().await;
+    let repo = test_repo(pool);
+
+    let req_id = repo.create(snark_request()).await.unwrap();
+    let stark_backend_id = format!("stark-retry-{}", Uuid::new_v4());
+    setup_running_session(&repo, req_id, SessionType::Stark, &stark_backend_id).await;
+    repo.complete_session_and_update_receipt(
+        &stark_backend_id,
+        UpdateReceipt {
+            id: req_id,
+            stark_receipt: Some(vec![0x01]),
+            snark_receipt: None,
+            status: ProofStatus::Running,
+            error_message: None,
+        },
+        None,
+    )
+    .await
+    .unwrap();
+
+    let failed_snark_backend_id = format!("snark-failed-{}", Uuid::new_v4());
+    setup_running_session(&repo, req_id, SessionType::Snark, &failed_snark_backend_id).await;
+    repo.update_proof_session(UpdateProofSession {
+        backend_session_id: failed_snark_backend_id,
+        status: SessionStatus::Failed,
+        error_message: Some("retryable failure".to_string()),
+        metadata: None,
+    })
+    .await
+    .unwrap();
+
+    assert!(repo.enqueue_snark_outbox_if_needed(req_id).await.unwrap());
 }
 
 #[tokio::test]
@@ -672,6 +842,7 @@ async fn test_full_snark_pipeline() {
             status: ProofStatus::Running, // still running — SNARK stage not done
             error_message: None,
         },
+        None,
     )
     .await
     .unwrap();
@@ -696,6 +867,7 @@ async fn test_full_snark_pipeline() {
             status: ProofStatus::Succeeded,
             error_message: None,
         },
+        None,
     )
     .await
     .unwrap();

--- a/crates/proof/zk/service/src/backends/mock.rs
+++ b/crates/proof/zk/service/src/backends/mock.rs
@@ -11,7 +11,7 @@ use async_trait::async_trait;
 use base_proof_succinct_client_utils::boot::BootInfoStruct;
 use base_zk_client::ProveBlockRequest;
 use base_zk_db::{
-    CreateProofSession, ProofRequest, ProofRequestRepo, ProofSession, ProofStatus, ProofType,
+    ProofRequest, ProofRequestRepo, ProofSession, ProofStatus, ProofType,
     SessionStatus as DbSessionStatus, SessionType, UpdateReceipt,
 };
 use serde_json::json;
@@ -128,6 +128,22 @@ impl ProvingBackend for MockBackend {
         })
     }
 
+    async fn submit_snark(&self, _proof_request: &ProofRequest) -> anyhow::Result<ProveResult> {
+        let session_id = format!("mock-snark-{}", Uuid::new_v4());
+        self.sessions.lock().unwrap().insert(session_id.clone(), ());
+
+        Ok(ProveResult {
+            session_id: Some(session_id),
+            metadata: Some(json!({
+                "mock": true,
+                "proof_output_id": format!("mock-snark-output-{}", Uuid::new_v4()),
+                "deadline_secs": 0u64,
+                "start_time_secs": 0u64,
+            })),
+            witness_gen_duration_ms: None,
+        })
+    }
+
     async fn process_proof_request(
         &self,
         proof_request: &ProofRequest,
@@ -192,15 +208,16 @@ impl ProvingBackend for MockBackend {
                     },
                 };
 
-                repo.complete_session_and_update_receipt(
-                    &session.backend_session_id,
-                    update_receipt,
-                )
-                .await?;
+                let Some(backend_session_id) = session.backend_session_id.as_deref() else {
+                    continue;
+                };
+
+                repo.complete_session_and_update_receipt(backend_session_id, update_receipt)
+                    .await?;
 
                 info!(
                     proof_request_id = %proof_request.id,
-                    session_id = %session.backend_session_id,
+                    session_id = %backend_session_id,
                     session_type = %session.session_type,
                     "MockBackend: instantly completed session"
                 );
@@ -219,30 +236,7 @@ impl ProvingBackend for MockBackend {
                 updated_sessions.iter().any(|s| s.session_type == SessionType::Snark);
 
             if has_stark_completed && !has_snark_session {
-                info!(
-                    proof_request_id = %proof_request.id,
-                    "MockBackend: STARK done, creating SNARK session"
-                );
-
-                let snark_session_id = format!("mock-snark-{}", Uuid::new_v4());
-                let metadata = json!({
-                    "mock": true,
-                    "proof_output_id": format!("mock-snark-output-{}", Uuid::new_v4()),
-                    "deadline_secs": 0u64,
-                    "start_time_secs": 0u64,
-                });
-
-                let session = CreateProofSession {
-                    proof_request_id: proof_request.id,
-                    session_type: SessionType::Snark,
-                    backend_session_id: snark_session_id,
-                    metadata: Some(metadata),
-                };
-
-                repo.create_proof_session(session).await?;
-
-                let final_sessions = repo.get_sessions_for_request(proof_request.id).await?;
-                return Ok(determine_mock_status(proof_request.proof_type, &final_sessions));
+                repo.enqueue_snark_outbox_if_needed(proof_request.id).await?;
             }
         }
 

--- a/crates/proof/zk/service/src/backends/mock.rs
+++ b/crates/proof/zk/service/src/backends/mock.rs
@@ -11,7 +11,7 @@ use async_trait::async_trait;
 use base_proof_succinct_client_utils::boot::BootInfoStruct;
 use base_zk_client::ProveBlockRequest;
 use base_zk_db::{
-    ProofRequest, ProofRequestRepo, ProofSession, ProofStatus, ProofType,
+    ProofRequest, ProofRequestRepo, ProofSession, ProofStatus, ProofType, RetryOutcome,
     SessionStatus as DbSessionStatus, SessionType, UpdateReceipt,
 };
 use serde_json::json;
@@ -148,6 +148,7 @@ impl ProvingBackend for MockBackend {
         &self,
         proof_request: &ProofRequest,
         repo: &ProofRequestRepo,
+        max_retries: i32,
     ) -> anyhow::Result<ProofProcessingResult> {
         let sessions = repo.get_sessions_for_request(proof_request.id).await?;
 
@@ -251,7 +252,15 @@ impl ProvingBackend for MockBackend {
             });
 
             if has_stark_completed && !has_snark_session {
-                repo.enqueue_snark_outbox_if_needed(proof_request.id).await?;
+                match repo.enqueue_snark_outbox_if_needed(proof_request.id, max_retries).await? {
+                    RetryOutcome::PermanentlyFailed => {
+                        return Ok(ProofProcessingResult {
+                            status: ProofStatus::Failed,
+                            error_message: Some("SNARK stage exceeded retry budget".to_string()),
+                        });
+                    }
+                    RetryOutcome::Retried | RetryOutcome::Skipped => {}
+                }
             }
         }
 

--- a/crates/proof/zk/service/src/backends/mock.rs
+++ b/crates/proof/zk/service/src/backends/mock.rs
@@ -212,8 +212,16 @@ impl ProvingBackend for MockBackend {
                     continue;
                 };
 
-                repo.complete_session_and_update_receipt(backend_session_id, update_receipt)
+                let updated = repo
+                    .complete_session_and_update_receipt(backend_session_id, update_receipt, None)
                     .await?;
+
+                if !updated {
+                    anyhow::bail!(
+                        "MockBackend could not complete session {backend_session_id} for request {}",
+                        proof_request.id
+                    );
+                }
 
                 info!(
                     proof_request_id = %proof_request.id,
@@ -232,8 +240,15 @@ impl ProvingBackend for MockBackend {
             let has_stark_completed = updated_sessions.iter().any(|s| {
                 s.session_type == SessionType::Stark && s.status == DbSessionStatus::Completed
             });
-            let has_snark_session =
-                updated_sessions.iter().any(|s| s.session_type == SessionType::Snark);
+            let has_snark_session = updated_sessions.iter().any(|s| {
+                s.session_type == SessionType::Snark
+                    && matches!(
+                        s.status,
+                        DbSessionStatus::Submitting
+                            | DbSessionStatus::Running
+                            | DbSessionStatus::Completed
+                    )
+            });
 
             if has_stark_completed && !has_snark_session {
                 repo.enqueue_snark_outbox_if_needed(proof_request.id).await?;
@@ -261,17 +276,17 @@ fn determine_mock_status(
         return ProofProcessingResult { status: ProofStatus::Pending, error_message: None };
     }
 
-    for session in sessions {
-        if session.status == DbSessionStatus::Failed {
-            return ProofProcessingResult {
-                status: ProofStatus::Failed,
-                error_message: session.error_message.clone(),
-            };
-        }
-    }
-
     match proof_type {
         ProofType::OpSuccinctSp1ClusterCompressed => {
+            for session in sessions {
+                if session.status == DbSessionStatus::Failed {
+                    return ProofProcessingResult {
+                        status: ProofStatus::Failed,
+                        error_message: session.error_message.clone(),
+                    };
+                }
+            }
+
             let all_completed = sessions.iter().all(|s| s.status == DbSessionStatus::Completed);
             ProofProcessingResult {
                 status: if all_completed { ProofStatus::Succeeded } else { ProofStatus::Running },
@@ -279,6 +294,15 @@ fn determine_mock_status(
             }
         }
         ProofType::OpSuccinctSp1ClusterSnarkGroth16 => {
+            if let Some(failed_stark) = sessions.iter().find(|s| {
+                s.session_type == SessionType::Stark && s.status == DbSessionStatus::Failed
+            }) {
+                return ProofProcessingResult {
+                    status: ProofStatus::Failed,
+                    error_message: failed_stark.error_message.clone(),
+                };
+            }
+
             let stark_done = sessions.iter().any(|s| {
                 s.session_type == SessionType::Stark && s.status == DbSessionStatus::Completed
             });

--- a/crates/proof/zk/service/src/backends/network.rs
+++ b/crates/proof/zk/service/src/backends/network.rs
@@ -13,7 +13,7 @@ use base_proof_succinct_elfs::RANGE_ELF_EMBEDDED;
 use base_proof_succinct_host_utils::get_agg_proof_stdin;
 use base_zk_client::ProveBlockRequest;
 use base_zk_db::{
-    CreateProofSession, ProofRequest, ProofRequestRepo, ProofSession, ProofStatus, ProofType,
+    ProofRequest, ProofRequestRepo, ProofSession, ProofStatus, ProofType,
     SessionStatus as DbSessionStatus, SessionType, UpdateProofSession, UpdateReceipt,
 };
 use serde_json::json;
@@ -189,6 +189,10 @@ impl ProvingBackend for NetworkBackend {
         })
     }
 
+    async fn submit_snark(&self, proof_request: &ProofRequest) -> anyhow::Result<ProveResult> {
+        self.submit_aggregation_proof(proof_request).await
+    }
+
     async fn process_proof_request(
         &self,
         proof_request: &ProofRequest,
@@ -204,7 +208,7 @@ impl ProvingBackend for NetworkBackend {
             {
                 warn!(
                     proof_request_id = %proof_request.id,
-                    session_id = %session.backend_session_id,
+                    session_id = ?session.backend_session_id,
                     error = %e,
                     "failed to sync session with SP1 Network"
                 );
@@ -226,22 +230,7 @@ impl ProvingBackend for NetworkBackend {
                     proof_request_id = %proof_request.id,
                     "STARK completed, triggering stage-2 aggregation proof via SP1 Network"
                 );
-                let fresh_proof_request = repo.get(proof_request.id).await?.ok_or_else(|| {
-                    anyhow::anyhow!("proof request not found after STARK completion")
-                })?;
-                if let Err(e) = self.submit_aggregation_proof(&fresh_proof_request, repo).await {
-                    error!(
-                        proof_request_id = %proof_request.id,
-                        error = %e,
-                        "failed to submit aggregation proof"
-                    );
-                    return Ok(ProofProcessingResult {
-                        status: ProofStatus::Failed,
-                        error_message: Some(format!("failed to submit aggregation proof: {e}")),
-                    });
-                }
-                let updated_sessions = repo.get_sessions_for_request(proof_request.id).await?;
-                return Ok(Self::determine_status(proof_request.proof_type, &updated_sessions));
+                repo.enqueue_snark_outbox_if_needed(proof_request.id).await?;
             }
         }
 
@@ -249,7 +238,11 @@ impl ProvingBackend for NetworkBackend {
     }
 
     async fn get_session_status(&self, session: &ProofSession) -> anyhow::Result<SessionStatus> {
-        let proof_id = Self::parse_proof_id(&session.backend_session_id)?;
+        let backend_session_id = session
+            .backend_session_id
+            .as_deref()
+            .ok_or_else(|| anyhow::anyhow!("session is missing backend session ID"))?;
+        let proof_id = Self::parse_proof_id(backend_session_id)?;
         let prover = self.network_prover();
 
         let (status, _proof) = prover
@@ -284,7 +277,11 @@ impl NetworkBackend {
         session: &ProofSession,
         repo: &ProofRequestRepo,
     ) -> anyhow::Result<()> {
-        let proof_id = Self::parse_proof_id(&session.backend_session_id)?;
+        let backend_session_id = session
+            .backend_session_id
+            .as_deref()
+            .ok_or_else(|| anyhow::anyhow!("session is missing backend session ID"))?;
+        let proof_id = Self::parse_proof_id(backend_session_id)?;
         let prover = self.network_prover();
 
         let (status, proof) = match prover.get_proof_status(proof_id).await {
@@ -292,7 +289,7 @@ impl NetworkBackend {
             Err(e) => {
                 warn!(
                     proof_request_id = %proof_request_id,
-                    session_id = %session.backend_session_id,
+                    session_id = %backend_session_id,
                     error = %e,
                     "transient error checking network proof status, will retry"
                 );
@@ -308,7 +305,7 @@ impl NetworkBackend {
 
                 info!(
                     proof_request_id = %proof_request_id,
-                    session_id = %session.backend_session_id,
+                    session_id = %backend_session_id,
                     "proof fulfilled by SP1 Network"
                 );
 
@@ -316,7 +313,7 @@ impl NetworkBackend {
                     bincode::serde::encode_to_vec(&proof_with_pv, bincode::config::standard())?;
 
                 let update = UpdateProofSession {
-                    backend_session_id: session.backend_session_id.clone(),
+                    backend_session_id: backend_session_id.to_string(),
                     status: DbSessionStatus::Completed,
                     error_message: None,
                     metadata: session.metadata.clone(),
@@ -343,7 +340,7 @@ impl NetworkBackend {
 
                 info!(
                     proof_request_id = %proof_request_id,
-                    session_id = %session.backend_session_id,
+                    session_id = %backend_session_id,
                     "proof downloaded and stored"
                 );
             }
@@ -352,13 +349,13 @@ impl NetworkBackend {
                     format!("proof unfulfillable, execution_status={}", status.execution_status());
                 error!(
                     proof_request_id = %proof_request_id,
-                    session_id = %session.backend_session_id,
+                    session_id = %backend_session_id,
                     failure_detail = %reason,
                     "SP1 Network proof generation failed"
                 );
 
                 let update = UpdateProofSession {
-                    backend_session_id: session.backend_session_id.clone(),
+                    backend_session_id: backend_session_id.to_string(),
                     status: DbSessionStatus::Failed,
                     error_message: Some(reason),
                     metadata: session.metadata.clone(),
@@ -368,7 +365,7 @@ impl NetworkBackend {
             _ => {
                 info!(
                     proof_request_id = %proof_request_id,
-                    session_id = %session.backend_session_id,
+                    session_id = %backend_session_id,
                     "SP1 Network proof still running"
                 );
             }
@@ -419,8 +416,7 @@ impl NetworkBackend {
     async fn submit_aggregation_proof(
         &self,
         proof_request: &ProofRequest,
-        repo: &ProofRequestRepo,
-    ) -> anyhow::Result<()> {
+    ) -> anyhow::Result<ProveResult> {
         let BackendConfig::Network { network_prover, agg_pk, range_vk, .. } = &self.config else {
             unreachable!("validated in constructor");
         };
@@ -507,21 +503,11 @@ impl NetworkBackend {
             "proof_id": proof_id.to_string(),
         });
 
-        let session = CreateProofSession {
-            proof_request_id: proof_request.id,
-            session_type: SessionType::Snark,
-            backend_session_id: proof_id.to_string(),
+        Ok(ProveResult {
+            session_id: Some(proof_id.to_string()),
             metadata: Some(metadata),
-        };
-
-        repo.create_proof_session(session).await?;
-
-        info!(
-            proof_request_id = %proof_request.id,
-            "created SNARK proof session for aggregation"
-        );
-
-        Ok(())
+            witness_gen_duration_ms: None,
+        })
     }
 }
 
@@ -537,7 +523,7 @@ mod tests {
             id: 1,
             proof_request_id: uuid::Uuid::new_v4(),
             session_type,
-            backend_session_id: "test-session".to_string(),
+            backend_session_id: Some("test-session".to_string()),
             status,
             error_message: None,
             metadata: None,

--- a/crates/proof/zk/service/src/backends/network.rs
+++ b/crates/proof/zk/service/src/backends/network.rs
@@ -13,7 +13,7 @@ use base_proof_succinct_elfs::RANGE_ELF_EMBEDDED;
 use base_proof_succinct_host_utils::get_agg_proof_stdin;
 use base_zk_client::ProveBlockRequest;
 use base_zk_db::{
-    ProofRequest, ProofRequestRepo, ProofSession, ProofStatus, ProofType,
+    ProofRequest, ProofRequestRepo, ProofSession, ProofStatus, ProofType, RetryOutcome,
     SessionStatus as DbSessionStatus, SessionType, UpdateProofSession, UpdateReceipt,
 };
 use serde_json::json;
@@ -197,6 +197,7 @@ impl ProvingBackend for NetworkBackend {
         &self,
         proof_request: &ProofRequest,
         repo: &ProofRequestRepo,
+        max_retries: i32,
     ) -> anyhow::Result<ProofProcessingResult> {
         let sessions = repo.get_sessions_for_request(proof_request.id).await?;
 
@@ -237,7 +238,15 @@ impl ProvingBackend for NetworkBackend {
                     proof_request_id = %proof_request.id,
                     "STARK completed, triggering stage-2 aggregation proof via SP1 Network"
                 );
-                repo.enqueue_snark_outbox_if_needed(proof_request.id).await?;
+                match repo.enqueue_snark_outbox_if_needed(proof_request.id, max_retries).await? {
+                    RetryOutcome::PermanentlyFailed => {
+                        return Ok(ProofProcessingResult {
+                            status: ProofStatus::Failed,
+                            error_message: Some("SNARK stage exceeded retry budget".to_string()),
+                        });
+                    }
+                    RetryOutcome::Retried | RetryOutcome::Skipped => {}
+                }
             }
         }
 

--- a/crates/proof/zk/service/src/backends/network.rs
+++ b/crates/proof/zk/service/src/backends/network.rs
@@ -222,8 +222,15 @@ impl ProvingBackend for NetworkBackend {
             let has_stark_completed = updated_sessions.iter().any(|s| {
                 s.session_type == SessionType::Stark && s.status == DbSessionStatus::Completed
             });
-            let has_snark_session =
-                updated_sessions.iter().any(|s| s.session_type == SessionType::Snark);
+            let has_snark_session = updated_sessions.iter().any(|s| {
+                s.session_type == SessionType::Snark
+                    && matches!(
+                        s.status,
+                        DbSessionStatus::Submitting
+                            | DbSessionStatus::Running
+                            | DbSessionStatus::Completed
+                    )
+            });
 
             if has_stark_completed && !has_snark_session {
                 info!(
@@ -312,14 +319,6 @@ impl NetworkBackend {
                 let proof_bytes =
                     bincode::serde::encode_to_vec(&proof_with_pv, bincode::config::standard())?;
 
-                let update = UpdateProofSession {
-                    backend_session_id: backend_session_id.to_string(),
-                    status: DbSessionStatus::Completed,
-                    error_message: None,
-                    metadata: session.metadata.clone(),
-                };
-                repo.update_proof_session(update).await?;
-
                 let update_receipt = match session.session_type {
                     SessionType::Stark => UpdateReceipt {
                         id: proof_request_id,
@@ -336,7 +335,22 @@ impl NetworkBackend {
                         error_message: None,
                     },
                 };
-                repo.update_receipt_if_running(update_receipt).await?;
+                let updated = repo
+                    .complete_session_and_update_receipt(
+                        backend_session_id,
+                        update_receipt,
+                        session.metadata.clone(),
+                    )
+                    .await?;
+
+                if !updated {
+                    warn!(
+                        proof_request_id = %proof_request_id,
+                        session_id = %backend_session_id,
+                        "Network proof completed but database state was not updated"
+                    );
+                    return Ok(());
+                }
 
                 info!(
                     proof_request_id = %proof_request_id,
@@ -379,17 +393,17 @@ impl NetworkBackend {
             return ProofProcessingResult { status: ProofStatus::Pending, error_message: None };
         }
 
-        for session in sessions {
-            if session.status == DbSessionStatus::Failed {
-                return ProofProcessingResult {
-                    status: ProofStatus::Failed,
-                    error_message: session.error_message.clone(),
-                };
-            }
-        }
-
         match proof_type {
             ProofType::OpSuccinctSp1ClusterCompressed => {
+                for session in sessions {
+                    if session.status == DbSessionStatus::Failed {
+                        return ProofProcessingResult {
+                            status: ProofStatus::Failed,
+                            error_message: session.error_message.clone(),
+                        };
+                    }
+                }
+
                 let all_completed = sessions.iter().all(|s| s.status == DbSessionStatus::Completed);
                 if all_completed {
                     ProofProcessingResult { status: ProofStatus::Succeeded, error_message: None }
@@ -398,6 +412,15 @@ impl NetworkBackend {
                 }
             }
             ProofType::OpSuccinctSp1ClusterSnarkGroth16 => {
+                if let Some(failed_stark) = sessions.iter().find(|s| {
+                    s.session_type == SessionType::Stark && s.status == DbSessionStatus::Failed
+                }) {
+                    return ProofProcessingResult {
+                        status: ProofStatus::Failed,
+                        error_message: failed_stark.error_message.clone(),
+                    };
+                }
+
                 let stark_done = sessions.iter().any(|s| {
                     s.session_type == SessionType::Stark && s.status == DbSessionStatus::Completed
                 });
@@ -528,6 +551,7 @@ mod tests {
             error_message: None,
             metadata: None,
             created_at: now,
+            updated_at: now,
             completed_at: None,
         }
     }

--- a/crates/proof/zk/service/src/backends/op_succinct/backend.rs
+++ b/crates/proof/zk/service/src/backends/op_succinct/backend.rs
@@ -8,7 +8,7 @@ use base_proof_succinct_elfs::{AGGREGATION_ELF, RANGE_ELF_EMBEDDED};
 use base_proof_succinct_host_utils::get_agg_proof_stdin;
 use base_zk_client::ProveBlockRequest;
 use base_zk_db::{
-    CreateProofSession, ProofRequest, ProofRequestRepo, ProofSession, ProofStatus, ProofType,
+    ProofRequest, ProofRequestRepo, ProofSession, ProofStatus, ProofType,
     SessionStatus as DbSessionStatus, SessionType, UpdateProofSession, UpdateReceipt,
 };
 use serde_json::json;
@@ -184,6 +184,10 @@ impl ProvingBackend for OpSuccinctBackend {
         })
     }
 
+    async fn submit_snark(&self, proof_request: &ProofRequest) -> anyhow::Result<ProveResult> {
+        self.submit_aggregation_proof(proof_request).await
+    }
+
     async fn process_proof_request(
         &self,
         proof_request: &ProofRequest,
@@ -200,7 +204,7 @@ impl ProvingBackend for OpSuccinctBackend {
             {
                 warn!(
                     proof_request_id = %proof_request.id,
-                    session_id = %session.backend_session_id,
+                    session_id = ?session.backend_session_id,
                     error = %e,
                     "failed to sync session with SP1 cluster"
                 );
@@ -224,22 +228,7 @@ impl ProvingBackend for OpSuccinctBackend {
                     proof_request_id = %proof_request.id,
                     "STARK completed, triggering stage-2 aggregation proof (SNARK Groth16)"
                 );
-                let fresh_proof_request = repo.get(proof_request.id).await?.ok_or_else(|| {
-                    anyhow::anyhow!("Proof request not found after STARK completion")
-                })?;
-                if let Err(e) = self.submit_aggregation_proof(&fresh_proof_request, repo).await {
-                    error!(
-                        proof_request_id = %proof_request.id,
-                        error = %e,
-                        "failed to submit aggregation proof"
-                    );
-                    return Ok(ProofProcessingResult {
-                        status: ProofStatus::Failed,
-                        error_message: Some(format!("Failed to submit aggregation proof: {e}")),
-                    });
-                }
-                let updated_sessions = repo.get_sessions_for_request(proof_request.id).await?;
-                return Ok(Self::determine_status(proof_request.proof_type, &updated_sessions));
+                repo.enqueue_snark_outbox_if_needed(proof_request.id).await?;
             }
         }
 
@@ -251,10 +240,14 @@ impl ProvingBackend for OpSuccinctBackend {
         let BackendConfig::OpSuccinct { cluster_client, .. } = &self.config else {
             unreachable!("validated in constructor");
         };
+        let backend_session_id = session
+            .backend_session_id
+            .as_deref()
+            .ok_or_else(|| anyhow::anyhow!("session is missing backend session ID"))?;
 
         let resp = cluster_client
             .get_proof_request(sp1_cluster_common::proto::ProofRequestGetRequest {
-                proof_id: session.backend_session_id.clone(),
+                proof_id: backend_session_id.to_string(),
             })
             .await
             .map_err(|e| anyhow::anyhow!("Failed to get proof request: {e}"))?;
@@ -409,6 +402,10 @@ impl OpSuccinctBackend {
         let BackendConfig::OpSuccinct { artifact_client, .. } = &self.config else {
             unreachable!("validated in constructor");
         };
+        let backend_session_id = session
+            .backend_session_id
+            .as_deref()
+            .ok_or_else(|| anyhow::anyhow!("session is missing backend session ID"))?;
 
         let metadata = session
             .metadata
@@ -426,7 +423,7 @@ impl OpSuccinctBackend {
             Err(e) => {
                 warn!(
                     proof_request_id = %proof_request_id,
-                    session_id = %session.backend_session_id,
+                    session_id = %backend_session_id,
                     error = %e,
                     "transient error checking session status, will retry"
                 );
@@ -438,13 +435,13 @@ impl OpSuccinctBackend {
             SessionStatus::Failed(reason) => {
                 error!(
                     proof_request_id = %proof_request_id,
-                    session_id = %session.backend_session_id,
+                    session_id = %backend_session_id,
                     failure_detail = %reason,
                     "proof generation failed or was cancelled"
                 );
 
                 let update = UpdateProofSession {
-                    backend_session_id: session.backend_session_id.clone(),
+                    backend_session_id: backend_session_id.to_string(),
                     status: DbSessionStatus::Failed,
                     error_message: Some(reason),
                     metadata: session.metadata.clone(),
@@ -453,7 +450,7 @@ impl OpSuccinctBackend {
 
                 info!(
                     proof_request_id = %proof_request_id,
-                    session_id = %session.backend_session_id,
+                    session_id = %backend_session_id,
                     "session marked as failed in database"
                 );
             }
@@ -474,7 +471,7 @@ impl OpSuccinctBackend {
                     Ok(Err(e)) => {
                         error!(
                             proof_request_id = %proof_request_id,
-                            session_id = %session.backend_session_id,
+                            session_id = %backend_session_id,
                             error = %e,
                             "failed to download proof artifact for completed session"
                         );
@@ -483,7 +480,7 @@ impl OpSuccinctBackend {
                     Err(join_err) => {
                         warn!(
                             proof_request_id = %proof_request_id,
-                            session_id = %session.backend_session_id,
+                            session_id = %backend_session_id,
                             error = %join_err,
                             "proof artifact download panicked, will retry next poll"
                         );
@@ -502,7 +499,7 @@ impl OpSuccinctBackend {
 
                 info!(
                     proof_request_id = %proof_request_id,
-                    session_id = %session.backend_session_id,
+                    session_id = %backend_session_id,
                     total_elapsed_secs = ?total_elapsed_secs,
                     "proof completed, downloaded from artifact store"
                 );
@@ -519,7 +516,7 @@ impl OpSuccinctBackend {
                 }
 
                 let update = UpdateProofSession {
-                    backend_session_id: session.backend_session_id.clone(),
+                    backend_session_id: backend_session_id.to_string(),
                     status: DbSessionStatus::Completed,
                     error_message: None,
                     metadata: Some(updated_metadata),
@@ -546,21 +543,21 @@ impl OpSuccinctBackend {
 
                 info!(
                     proof_request_id = %proof_request_id,
-                    session_id = %session.backend_session_id,
+                    session_id = %backend_session_id,
                     "proof downloaded and stored"
                 );
             }
             SessionStatus::Running => {
                 info!(
                     proof_request_id = %proof_request_id,
-                    session_id = %session.backend_session_id,
+                    session_id = %backend_session_id,
                     "proof still running"
                 );
             }
             SessionStatus::NotFound => {
                 warn!(
                     proof_request_id = %proof_request_id,
-                    session_id = %session.backend_session_id,
+                    session_id = %backend_session_id,
                     "session not found in cluster, will retry"
                 );
             }
@@ -614,8 +611,7 @@ impl OpSuccinctBackend {
     async fn submit_aggregation_proof(
         &self,
         proof_request: &ProofRequest,
-        repo: &ProofRequestRepo,
-    ) -> anyhow::Result<()> {
+    ) -> anyhow::Result<ProveResult> {
         let BackendConfig::OpSuccinct {
             cluster_rpc,
             artifact_client,
@@ -709,7 +705,6 @@ impl OpSuccinctBackend {
             "aggregation proof (Groth16) submitted to SP1 cluster"
         );
 
-        // 6. Create SNARK session in DB.
         let start_time_secs = SystemTime::now()
             .duration_since(SystemTime::UNIX_EPOCH)
             .expect("system time before UNIX epoch")
@@ -724,21 +719,11 @@ impl OpSuccinctBackend {
             "start_time_secs": start_time_secs,
         });
 
-        let session = CreateProofSession {
-            proof_request_id: proof_request.id,
-            session_type: SessionType::Snark,
-            backend_session_id: cluster_proof_request.proof_id,
+        Ok(ProveResult {
+            session_id: Some(cluster_proof_request.proof_id),
             metadata: Some(metadata),
-        };
-
-        repo.create_proof_session(session).await?;
-
-        info!(
-            proof_request_id = %proof_request.id,
-            "created SNARK proof session for aggregation"
-        );
-
-        Ok(())
+            witness_gen_duration_ms: None,
+        })
     }
 }
 
@@ -754,7 +739,7 @@ mod tests {
             id: 1,
             proof_request_id: Uuid::new_v4(),
             session_type,
-            backend_session_id: "test-session".to_string(),
+            backend_session_id: Some("test-session".to_string()),
             status,
             error_message: None,
             metadata: None,

--- a/crates/proof/zk/service/src/backends/op_succinct/backend.rs
+++ b/crates/proof/zk/service/src/backends/op_succinct/backend.rs
@@ -8,7 +8,7 @@ use base_proof_succinct_elfs::{AGGREGATION_ELF, RANGE_ELF_EMBEDDED};
 use base_proof_succinct_host_utils::get_agg_proof_stdin;
 use base_zk_client::ProveBlockRequest;
 use base_zk_db::{
-    ProofRequest, ProofRequestRepo, ProofSession, ProofStatus, ProofType,
+    ProofRequest, ProofRequestRepo, ProofSession, ProofStatus, ProofType, RetryOutcome,
     SessionStatus as DbSessionStatus, SessionType, UpdateProofSession, UpdateReceipt,
 };
 use serde_json::json;
@@ -192,6 +192,7 @@ impl ProvingBackend for OpSuccinctBackend {
         &self,
         proof_request: &ProofRequest,
         repo: &ProofRequestRepo,
+        max_retries: i32,
     ) -> anyhow::Result<ProofProcessingResult> {
         // 1. Get all sessions for this proof request.
         let sessions = repo.get_sessions_for_request(proof_request.id).await?;
@@ -235,7 +236,15 @@ impl ProvingBackend for OpSuccinctBackend {
                     proof_request_id = %proof_request.id,
                     "STARK completed, triggering stage-2 aggregation proof (SNARK Groth16)"
                 );
-                repo.enqueue_snark_outbox_if_needed(proof_request.id).await?;
+                match repo.enqueue_snark_outbox_if_needed(proof_request.id, max_retries).await? {
+                    RetryOutcome::PermanentlyFailed => {
+                        return Ok(ProofProcessingResult {
+                            status: ProofStatus::Failed,
+                            error_message: Some("SNARK stage exceeded retry budget".to_string()),
+                        });
+                    }
+                    RetryOutcome::Retried | RetryOutcome::Skipped => {}
+                }
             }
         }
 

--- a/crates/proof/zk/service/src/backends/op_succinct/backend.rs
+++ b/crates/proof/zk/service/src/backends/op_succinct/backend.rs
@@ -220,8 +220,15 @@ impl ProvingBackend for OpSuccinctBackend {
             let has_stark_completed = updated_sessions.iter().any(|s| {
                 s.session_type == SessionType::Stark && s.status == DbSessionStatus::Completed
             });
-            let has_snark_session =
-                updated_sessions.iter().any(|s| s.session_type == SessionType::Snark);
+            let has_snark_session = updated_sessions.iter().any(|s| {
+                s.session_type == SessionType::Snark
+                    && matches!(
+                        s.status,
+                        DbSessionStatus::Submitting
+                            | DbSessionStatus::Running
+                            | DbSessionStatus::Completed
+                    )
+            });
 
             if has_stark_completed && !has_snark_session {
                 info!(
@@ -515,14 +522,6 @@ impl OpSuccinctBackend {
                     obj.insert("total_elapsed_secs".to_string(), json!(total));
                 }
 
-                let update = UpdateProofSession {
-                    backend_session_id: backend_session_id.to_string(),
-                    status: DbSessionStatus::Completed,
-                    error_message: None,
-                    metadata: Some(updated_metadata),
-                };
-                repo.update_proof_session(update).await?;
-
                 let update_receipt = match session.session_type {
                     SessionType::Stark => UpdateReceipt {
                         id: proof_request_id,
@@ -539,7 +538,22 @@ impl OpSuccinctBackend {
                         error_message: None,
                     },
                 };
-                repo.update_receipt_if_running(update_receipt).await?;
+                let updated = repo
+                    .complete_session_and_update_receipt(
+                        backend_session_id,
+                        update_receipt,
+                        Some(updated_metadata),
+                    )
+                    .await?;
+
+                if !updated {
+                    warn!(
+                        proof_request_id = %proof_request_id,
+                        session_id = %backend_session_id,
+                        "SP1 cluster proof completed but database state was not updated"
+                    );
+                    return Ok(());
+                }
 
                 info!(
                     proof_request_id = %proof_request_id,
@@ -572,18 +586,17 @@ impl OpSuccinctBackend {
             return ProofProcessingResult { status: ProofStatus::Pending, error_message: None };
         }
 
-        // Any failure → FAILED.
-        for session in sessions {
-            if session.status == DbSessionStatus::Failed {
-                return ProofProcessingResult {
-                    status: ProofStatus::Failed,
-                    error_message: session.error_message.clone(),
-                };
-            }
-        }
-
         match proof_type {
             ProofType::OpSuccinctSp1ClusterCompressed => {
+                for session in sessions {
+                    if session.status == DbSessionStatus::Failed {
+                        return ProofProcessingResult {
+                            status: ProofStatus::Failed,
+                            error_message: session.error_message.clone(),
+                        };
+                    }
+                }
+
                 let all_succeeded = sessions.iter().all(|s| s.status == DbSessionStatus::Completed);
                 if all_succeeded {
                     ProofProcessingResult { status: ProofStatus::Succeeded, error_message: None }
@@ -592,6 +605,15 @@ impl OpSuccinctBackend {
                 }
             }
             ProofType::OpSuccinctSp1ClusterSnarkGroth16 => {
+                if let Some(failed_stark) = sessions.iter().find(|s| {
+                    s.session_type == SessionType::Stark && s.status == DbSessionStatus::Failed
+                }) {
+                    return ProofProcessingResult {
+                        status: ProofStatus::Failed,
+                        error_message: failed_stark.error_message.clone(),
+                    };
+                }
+
                 let stark_done = sessions.iter().any(|s| {
                     s.session_type == SessionType::Stark && s.status == DbSessionStatus::Completed
                 });
@@ -744,6 +766,7 @@ mod tests {
             error_message: None,
             metadata: None,
             created_at: now,
+            updated_at: now,
             completed_at: None,
         }
     }
@@ -849,7 +872,7 @@ mod tests {
     }
 
     #[test]
-    fn test_determine_status_snark_snark_failed_returns_failed() {
+    fn test_determine_status_snark_snark_failed_returns_running_for_retry() {
         let sessions = vec![
             make_session(SessionType::Stark, DbSessionStatus::Completed),
             make_failed_session(SessionType::Snark, "aggregation error"),
@@ -858,8 +881,8 @@ mod tests {
             ProofType::OpSuccinctSp1ClusterSnarkGroth16,
             &sessions,
         );
-        assert_eq!(result.status, ProofStatus::Failed);
-        assert_eq!(result.error_message.as_deref(), Some("aggregation error"));
+        assert_eq!(result.status, ProofStatus::Running);
+        assert!(result.error_message.is_none());
     }
 
     #[test]

--- a/crates/proof/zk/service/src/backends/traits.rs
+++ b/crates/proof/zk/service/src/backends/traits.rs
@@ -278,6 +278,7 @@ pub trait ProvingBackend: Send + Sync {
         &self,
         proof_request: &ProofRequest,
         repo: &ProofRequestRepo,
+        max_retries: i32,
     ) -> anyhow::Result<ProofProcessingResult>;
 
     /// Fetches latest backend session status for a stored session reference.
@@ -368,6 +369,7 @@ mod tests {
             &self,
             _proof_request: &ProofRequest,
             _repo: &ProofRequestRepo,
+            _max_retries: i32,
         ) -> anyhow::Result<ProofProcessingResult> {
             unimplemented!()
         }

--- a/crates/proof/zk/service/src/backends/traits.rs
+++ b/crates/proof/zk/service/src/backends/traits.rs
@@ -270,6 +270,9 @@ pub trait ProvingBackend: Send + Sync {
     /// Starts proving for a block request.
     async fn prove(&self, request: &ProveBlockRequest) -> anyhow::Result<ProveResult>;
 
+    /// Starts SNARK submission for a request with a completed STARK receipt.
+    async fn submit_snark(&self, proof_request: &ProofRequest) -> anyhow::Result<ProveResult>;
+
     /// Processes a queued proof request and returns the next status transition.
     async fn process_proof_request(
         &self,
@@ -356,6 +359,9 @@ mod tests {
             BackendType::OpSuccinct
         }
         async fn prove(&self, _request: &ProveBlockRequest) -> anyhow::Result<ProveResult> {
+            unimplemented!()
+        }
+        async fn submit_snark(&self, _proof_request: &ProofRequest) -> anyhow::Result<ProveResult> {
             unimplemented!()
         }
         async fn process_proof_request(

--- a/crates/proof/zk/service/src/proof_request_manager.rs
+++ b/crates/proof/zk/service/src/proof_request_manager.rs
@@ -148,6 +148,9 @@ mod tests {
         ) -> anyhow::Result<ProveResult> {
             unimplemented!()
         }
+        async fn submit_snark(&self, _proof_request: &ProofRequest) -> anyhow::Result<ProveResult> {
+            unimplemented!()
+        }
         async fn process_proof_request(
             &self,
             _proof_request: &ProofRequest,

--- a/crates/proof/zk/service/src/proof_request_manager.rs
+++ b/crates/proof/zk/service/src/proof_request_manager.rs
@@ -30,9 +30,13 @@ impl ProofRequestManager {
     ///
     /// Uses guarded DB transitions for terminal states so that only the first
     /// caller to transition the request actually succeeds. This prevents
-    /// double-counting metrics when `StatusPoller` and `GetProof` RPC race on
-    /// the same proof request.
-    pub async fn sync_and_update_proof_status(&self, proof_request: &ProofRequest) -> Result<()> {
+    /// double-counting metrics when multiple poller ticks race on the same
+    /// proof request.
+    pub async fn sync_and_update_proof_status(
+        &self,
+        proof_request: &ProofRequest,
+        max_retries: i32,
+    ) -> Result<()> {
         let prev_status = proof_request.status;
         let proof_type_label = metrics::proof_type_label(proof_request.proof_type);
 
@@ -41,7 +45,7 @@ impl ProofRequestManager {
 
         // 2. Let backend drive the proof request (sync sessions, create new sessions, determine
         //    status)
-        let result = backend.process_proof_request(proof_request, &self.repo).await?;
+        let result = backend.process_proof_request(proof_request, &self.repo, max_retries).await?;
 
         // 3. Update proof request status based on backend's result.
         //    Both terminal paths use guarded transitions so that only the first
@@ -135,7 +139,7 @@ impl ProofRequestManager {
     }
 }
 
-fn has_required_receipts(proof_request: &ProofRequest) -> bool {
+const fn has_required_receipts(proof_request: &ProofRequest) -> bool {
     match proof_request.proof_type {
         ProofType::OpSuccinctSp1ClusterCompressed => proof_request.stark_receipt.is_some(),
         ProofType::OpSuccinctSp1ClusterSnarkGroth16 => {
@@ -173,6 +177,7 @@ mod tests {
             &self,
             _proof_request: &ProofRequest,
             _repo: &ProofRequestRepo,
+            _max_retries: i32,
         ) -> anyhow::Result<ProofProcessingResult> {
             Ok(self.result.clone())
         }

--- a/crates/proof/zk/service/src/proof_request_manager.rs
+++ b/crates/proof/zk/service/src/proof_request_manager.rs
@@ -54,6 +54,15 @@ impl ProofRequestManager {
                         anyhow::anyhow!("Proof request not found after processing")
                     })?;
 
+                if !has_required_receipts(&updated_proof_request) {
+                    warn!(
+                        proof_request_id = %proof_request.id,
+                        proof_type = %updated_proof_request.proof_type,
+                        "Backend reported success before required receipts were persisted"
+                    );
+                    return Ok(());
+                }
+
                 // Mark as succeeded with fresh receipts
                 let update = UpdateReceipt {
                     id: proof_request.id,
@@ -123,6 +132,15 @@ impl ProofRequestManager {
         self.backend_registry
             .get(backend_type)
             .ok_or_else(|| anyhow::anyhow!("Backend not found for proof type: {proof_type:?}"))
+    }
+}
+
+fn has_required_receipts(proof_request: &ProofRequest) -> bool {
+    match proof_request.proof_type {
+        ProofType::OpSuccinctSp1ClusterCompressed => proof_request.stark_receipt.is_some(),
+        ProofType::OpSuccinctSp1ClusterSnarkGroth16 => {
+            proof_request.stark_receipt.is_some() && proof_request.snark_receipt.is_some()
+        }
     }
 }
 

--- a/crates/proof/zk/service/src/server/get_proof.rs
+++ b/crates/proof/zk/service/src/server/get_proof.rs
@@ -2,7 +2,7 @@ use base_zk_client::{GetProofRequest, GetProofResponse, ProofJobStatus, ReceiptT
 use base_zk_db::ProofStatus;
 use sp1_sdk::SP1ProofWithPublicValues;
 use tonic::{Request, Response, Status};
-use tracing::{Instrument, info};
+use tracing::info;
 use uuid::Uuid;
 
 use crate::{metrics, server::ProverServiceServer};
@@ -93,43 +93,7 @@ impl ProverServiceServer {
         let (proto_status, receipt_bytes, error_message) = match proof_req.status {
             ProofStatus::Created => (ProofJobStatus::Created, vec![], None),
             ProofStatus::Pending => (ProofJobStatus::Pending, vec![], None),
-            ProofStatus::Running => {
-                // Sync sessions and update proof status, with a tracing span so all
-                // nested log lines carry proof_request_id.
-                let sync_span = tracing::info_span!(
-                    "sync_proof_status",
-                    proof_request_id = %proof_request_id,
-                );
-                self.manager
-                    .sync_and_update_proof_status(&proof_req)
-                    .instrument(sync_span)
-                    .await
-                    .map_err(|e| Status::internal(format!("Failed to sync proof status: {e}")))?;
-
-                // Re-query proof request to get updated status
-                let updated_proof_req = self
-                    .repo
-                    .get(proof_request_id)
-                    .await
-                    .map_err(|e| Status::internal(format!("Database error: {e}")))?
-                    .ok_or_else(|| Status::not_found("Proof request not found"))?;
-
-                // Map updated status to response
-                match updated_proof_req.status {
-                    ProofStatus::Succeeded => {
-                        let receipt =
-                            get_receipt_by_type(&updated_proof_req, requested_receipt_type)?;
-                        (ProofJobStatus::Succeeded, receipt, None)
-                    }
-                    ProofStatus::Failed => {
-                        (ProofJobStatus::Failed, vec![], updated_proof_req.error_message)
-                    }
-                    _ => {
-                        // Still RUNNING or PENDING
-                        (ProofJobStatus::Running, vec![], None)
-                    }
-                }
-            }
+            ProofStatus::Running => (ProofJobStatus::Running, vec![], None),
             ProofStatus::Succeeded => {
                 let receipt_buf = get_receipt_by_type(&proof_req, requested_receipt_type)?;
                 (ProofJobStatus::Succeeded, receipt_buf, None)

--- a/crates/proof/zk/service/src/server/mod.rs
+++ b/crates/proof/zk/service/src/server/mod.rs
@@ -9,8 +9,6 @@ use base_zk_client::{
 use base_zk_db::ProofRequestRepo;
 use tonic::{Request, Response, Status};
 
-use crate::proof_request_manager::ProofRequestManager;
-
 mod get_proof;
 mod prove_block;
 
@@ -18,7 +16,6 @@ mod prove_block;
 #[derive(Clone)]
 pub struct ProverServiceServer {
     repo: ProofRequestRepo,
-    manager: ProofRequestManager,
 }
 
 impl fmt::Debug for ProverServiceServer {
@@ -29,8 +26,8 @@ impl fmt::Debug for ProverServiceServer {
 
 impl ProverServiceServer {
     /// Create a new prover service server.
-    pub const fn new(repo: ProofRequestRepo, manager: ProofRequestManager) -> Self {
-        Self { repo, manager }
+    pub const fn new(repo: ProofRequestRepo) -> Self {
+        Self { repo }
     }
 }
 

--- a/crates/proof/zk/service/src/worker/prover_worker.rs
+++ b/crates/proof/zk/service/src/worker/prover_worker.rs
@@ -1,9 +1,8 @@
 use std::{fmt, sync::Arc};
 
 use base_zk_client::ProveBlockRequest;
-use base_zk_db::{CreateProofSession, ProofRequestRepo, ProofType, SessionType};
+use base_zk_db::{ClaimedProofRequest, ProofRequest, ProofRequestRepo, SessionType};
 use tracing::{debug, error, info, warn};
-use uuid::Uuid;
 
 use crate::{backends::ProvingBackend, metrics};
 
@@ -11,14 +10,13 @@ use crate::{backends::ProvingBackend, metrics};
 pub struct ProverWorker {
     repo: ProofRequestRepo,
     backend: Arc<dyn ProvingBackend>,
-    proof_request_id: Uuid,
-    params: ProveBlockRequest,
+    claimed: ClaimedProofRequest,
 }
 
 impl fmt::Debug for ProverWorker {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("ProverWorker")
-            .field("proof_request_id", &self.proof_request_id)
+            .field("proof_request_id", &self.claimed.proof_request.id)
             .field("backend", &self.backend.name())
             .finish_non_exhaustive()
     }
@@ -29,52 +27,38 @@ impl ProverWorker {
     pub fn new(
         repo: ProofRequestRepo,
         backend: Arc<dyn ProvingBackend>,
-        proof_request_id: Uuid,
-        params: ProveBlockRequest,
+        claimed: ClaimedProofRequest,
     ) -> Self {
-        Self { repo, backend, proof_request_id, params }
+        Self { repo, backend, claimed }
     }
 
     /// Run the proving task
     pub async fn run(self) -> anyhow::Result<()> {
+        let proof_request = &self.claimed.proof_request;
         info!(
-            proof_request_id = %self.proof_request_id,
-            "Attempting to claim proving task"
+            proof_request_id = %proof_request.id,
+            session_type = %self.claimed.session_type,
+            "Submitting durable proving stage"
         );
 
-        // Atomically claim the task (CREATED -> PENDING)
-        // This ensures idempotency - only one worker will successfully claim the task
-        let claimed = self
-            .repo
-            .atomic_claim_task(self.proof_request_id)
-            .await
-            .map_err(|e| anyhow::anyhow!("Failed to claim task: {e}"))?;
-
-        if !claimed {
-            info!(
-                proof_request_id = %self.proof_request_id,
-                "Task already claimed or processed, skipping"
-            );
-            return Ok(());
-        }
-
         info!(
-            proof_request_id = %self.proof_request_id,
+            proof_request_id = %proof_request.id,
             backend = %self.backend.name(),
-            "Successfully claimed task, starting proving"
+            "Starting backend submission"
         );
 
         debug!(
-            proof_request_id = %self.proof_request_id,
+            proof_request_id = %proof_request.id,
             backend = %self.backend.name(),
-            "Calling backend to prove block"
+            "Calling backend"
         );
 
-        let pt_label = ProofType::try_from(self.params.proof_type)
-            .map_or("unknown", metrics::proof_type_label);
+        let pt_label = metrics::proof_type_label(proof_request.proof_type);
 
-        // Call backend prove (backend handles temp dir creation and config)
-        let result = self.backend.prove(&self.params).await;
+        let result = match self.claimed.session_type {
+            SessionType::Stark => self.backend.prove(&proof_request_to_proto(proof_request)?).await,
+            SessionType::Snark => self.backend.submit_snark(proof_request).await,
+        };
 
         match result {
             Ok(prove_result) => {
@@ -86,40 +70,40 @@ impl ProverWorker {
                 // Success path
                 if let Some(session_id) = prove_result.session_id {
                     info!(
-                        proof_request_id = %self.proof_request_id,
+                        proof_request_id = %proof_request.id,
                         session_id = %session_id,
                         backend = %self.backend.name(),
-                        "Got backend session ID for STARK proof"
+                        "Got backend session ID"
                     );
 
-                    // Atomically create proof session and update proof request to RUNNING
-                    let session = CreateProofSession {
-                        proof_request_id: self.proof_request_id,
-                        session_type: SessionType::Stark,
-                        backend_session_id: session_id.clone(),
-                        metadata: prove_result.metadata,
-                    };
-
-                    match self.repo.transition_pending_to_running(session).await {
-                        Ok(Some(db_session_id)) => {
+                    match self
+                        .repo
+                        .mark_submitting_session_running(
+                            self.claimed.proof_session_id,
+                            &session_id,
+                            prove_result.metadata,
+                        )
+                        .await
+                    {
+                        Ok(true) => {
                             info!(
-                                proof_request_id = %self.proof_request_id,
+                                proof_request_id = %proof_request.id,
                                 backend_session_id = %session_id,
-                                db_session_id,
-                                "Created STARK proof session and transitioned request to RUNNING"
+                                db_session_id = self.claimed.proof_session_id,
+                                "Marked proof session RUNNING"
                             );
                         }
-                        Ok(None) => {
+                        Ok(false) => {
                             warn!(
-                                proof_request_id = %self.proof_request_id,
+                                proof_request_id = %proof_request.id,
                                 backend_session_id = %session_id,
-                                "Could not transition to RUNNING — request no longer PENDING (race with stuck detector?)"
+                                "Could not mark session RUNNING"
                             );
                             return Ok(());
                         }
                         Err(e) => {
                             error!(
-                                proof_request_id = %self.proof_request_id,
+                                proof_request_id = %proof_request.id,
                                 backend_session_id = %session_id,
                                 backend = %self.backend.name(),
                                 error = %e,
@@ -127,13 +111,13 @@ impl ProverWorker {
                             );
                             return Err(anyhow::anyhow!(
                                 "Failed to persist session {session_id} for request {}: {e}",
-                                self.proof_request_id
+                                proof_request.id
                             ));
                         }
                     }
                 } else {
                     info!(
-                        proof_request_id = %self.proof_request_id,
+                        proof_request_id = %proof_request.id,
                         "Proof completed without session ID (local proving)"
                     );
                 }
@@ -144,7 +128,7 @@ impl ProverWorker {
                 // Failure path
                 let error_msg = format!("Backend error: {e}");
                 warn!(
-                    proof_request_id = %self.proof_request_id,
+                    proof_request_id = %proof_request.id,
                     backend = %self.backend.name(),
                     error = %error_msg,
                     "Backend proving failed"
@@ -152,7 +136,11 @@ impl ProverWorker {
 
                 let was_failed = self
                     .repo
-                    .transition_pending_to_failed(self.proof_request_id, error_msg.clone())
+                    .fail_submitting_session_and_request(
+                        self.claimed.proof_session_id,
+                        proof_request.id,
+                        error_msg.clone(),
+                    )
                     .await?;
 
                 if was_failed {
@@ -162,13 +150,13 @@ impl ProverWorker {
                     metrics::inc_proof_requests_completed("failed", pt_label);
 
                     info!(
-                        proof_request_id = %self.proof_request_id,
+                        proof_request_id = %proof_request.id,
                         "Updated proof request as FAILED"
                     );
                 } else {
                     warn!(
-                        proof_request_id = %self.proof_request_id,
-                        "Could not transition to FAILED — request no longer PENDING"
+                        proof_request_id = %proof_request.id,
+                        "Could not transition submitting stage to FAILED"
                     );
                 }
 
@@ -176,4 +164,20 @@ impl ProverWorker {
             }
         }
     }
+}
+
+fn proof_request_to_proto(proof_request: &ProofRequest) -> anyhow::Result<ProveBlockRequest> {
+    Ok(ProveBlockRequest {
+        start_block_number: u64::try_from(proof_request.start_block_number)?,
+        number_of_blocks_to_prove: u64::try_from(proof_request.number_of_blocks_to_prove)?,
+        sequence_window: proof_request.sequence_window.map(u64::try_from).transpose()?,
+        proof_type: proof_request.proof_type.proto_i32(),
+        session_id: None,
+        prover_address: proof_request.prover_address.clone(),
+        l1_head: proof_request.l1_head.clone(),
+        intermediate_root_interval: proof_request
+            .intermediate_root_interval
+            .map(u64::try_from)
+            .transpose()?,
+    })
 }

--- a/crates/proof/zk/service/src/worker/prover_worker.rs
+++ b/crates/proof/zk/service/src/worker/prover_worker.rs
@@ -1,10 +1,12 @@
-use std::{fmt, sync::Arc};
+use std::{fmt, future::Future, sync::Arc, time::Duration};
 
 use base_zk_client::ProveBlockRequest;
 use base_zk_db::{ClaimedProofRequest, ProofRequest, ProofRequestRepo, SessionType};
 use tracing::{debug, error, info, warn};
 
 use crate::{backends::ProvingBackend, metrics};
+
+const SUBMISSION_HEARTBEAT_SECS: u64 = 30;
 
 /// Individual worker that processes a single proving task
 pub struct ProverWorker {
@@ -56,8 +58,30 @@ impl ProverWorker {
         let pt_label = metrics::proof_type_label(proof_request.proof_type);
 
         let result = match self.claimed.session_type {
-            SessionType::Stark => self.backend.prove(&proof_request_to_proto(proof_request)?).await,
-            SessionType::Snark => self.backend.submit_snark(proof_request).await,
+            SessionType::Stark => {
+                let request = match proof_request_to_proto(proof_request) {
+                    Ok(request) => request,
+                    Err(e) => {
+                        let error_msg = format!("Invalid proof request: {e}");
+                        self.fail_submitting_request(proof_request, error_msg.clone()).await?;
+                        return Err(anyhow::anyhow!(error_msg));
+                    }
+                };
+                await_with_heartbeat(
+                    self.repo.clone(),
+                    self.claimed.proof_session_id,
+                    self.backend.prove(&request),
+                )
+                .await
+            }
+            SessionType::Snark => {
+                await_with_heartbeat(
+                    self.repo.clone(),
+                    self.claimed.proof_session_id,
+                    self.backend.submit_snark(proof_request),
+                )
+                .await
+            }
         };
 
         match result {
@@ -94,12 +118,15 @@ impl ProverWorker {
                             );
                         }
                         Ok(false) => {
-                            warn!(
+                            error!(
                                 proof_request_id = %proof_request.id,
                                 backend_session_id = %session_id,
-                                "Could not mark session RUNNING"
+                                "Backend accepted job but session could not be marked RUNNING"
                             );
-                            return Ok(());
+                            return Err(anyhow::anyhow!(
+                                "Backend accepted session {session_id} for request {}, but DB state could not be marked RUNNING",
+                                proof_request.id
+                            ));
                         }
                         Err(e) => {
                             error!(
@@ -116,10 +143,13 @@ impl ProverWorker {
                         }
                     }
                 } else {
-                    info!(
+                    let error_msg = "Backend returned no session ID".to_string();
+                    error!(
                         proof_request_id = %proof_request.id,
-                        "Proof completed without session ID (local proving)"
+                        "Backend submission returned without session ID"
                     );
+                    self.fail_submitting_request(proof_request, error_msg.clone()).await?;
+                    return Err(anyhow::anyhow!(error_msg));
                 }
 
                 Ok(())
@@ -161,6 +191,59 @@ impl ProverWorker {
                 }
 
                 Err(anyhow::anyhow!(error_msg))
+            }
+        }
+    }
+
+    async fn fail_submitting_request(
+        &self,
+        proof_request: &ProofRequest,
+        error_msg: String,
+    ) -> anyhow::Result<()> {
+        let was_failed = self
+            .repo
+            .fail_submitting_session_and_request(
+                self.claimed.proof_session_id,
+                proof_request.id,
+                error_msg,
+            )
+            .await?;
+
+        if !was_failed {
+            warn!(
+                proof_request_id = %proof_request.id,
+                proof_session_id = self.claimed.proof_session_id,
+                "Could not transition submitting stage to FAILED"
+            );
+        }
+
+        Ok(())
+    }
+}
+
+async fn await_with_heartbeat<F, T>(
+    repo: ProofRequestRepo,
+    proof_session_id: i64,
+    future: F,
+) -> anyhow::Result<T>
+where
+    F: Future<Output = anyhow::Result<T>>,
+{
+    tokio::pin!(future);
+    let mut interval = tokio::time::interval(Duration::from_secs(SUBMISSION_HEARTBEAT_SECS));
+    interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+
+    loop {
+        tokio::select! {
+            result = &mut future => return result,
+            _ = interval.tick() => {
+                if let Err(e) = repo.touch_submitting_session(proof_session_id).await {
+                    warn!(
+                        proof_session_id,
+                        error = %e,
+                        "Failed to heartbeat submitting session"
+                    );
+                }
             }
         }
     }

--- a/crates/proof/zk/service/src/worker/prover_worker_pool.rs
+++ b/crates/proof/zk/service/src/worker/prover_worker_pool.rs
@@ -1,10 +1,8 @@
 use std::{fmt, sync::Arc};
 
 use async_trait::async_trait;
-use base_zk_client::ProveBlockRequest;
-use base_zk_db::{ProofRequestRepo, ProofType};
+use base_zk_db::{ProofRequestRepo, SessionType};
 use base_zk_outbox::{OutboxTask, TaskQueue};
-use serde::Deserialize;
 use tokio::{sync::Mutex, task::JoinHandle};
 use tracing::{Instrument, error, info};
 
@@ -14,39 +12,7 @@ use crate::{
     worker::prover_worker::ProverWorker,
 };
 
-/// Intermediate struct for deserializing from database JSON.
-/// The database stores `proof_type` as a string, but proto expects an integer.
-#[derive(Deserialize)]
-struct ProveBlockRequestParams {
-    start_block_number: u64,
-    number_of_blocks_to_prove: u64,
-    sequence_window: Option<u64>,
-    proof_type: String,
-    prover_address: Option<String>,
-    l1_head: Option<String>,
-    intermediate_root_interval: Option<u64>,
-}
-
-impl ProveBlockRequestParams {
-    /// Convert into proto `ProveBlockRequest` and the parsed [`ProofType`], consuming `self`.
-    fn into_proto(self) -> anyhow::Result<(ProveBlockRequest, ProofType)> {
-        let proof_type =
-            ProofType::try_from(self.proof_type.as_str()).map_err(|e| anyhow::anyhow!(e))?;
-
-        let request = ProveBlockRequest {
-            start_block_number: self.start_block_number,
-            number_of_blocks_to_prove: self.number_of_blocks_to_prove,
-            sequence_window: self.sequence_window,
-            proof_type: proof_type.proto_i32(),
-            session_id: None,
-            prover_address: self.prover_address,
-            l1_head: self.l1_head,
-            intermediate_root_interval: self.intermediate_root_interval,
-        };
-
-        Ok((request, proof_type))
-    }
-}
+const SUBMIT_SNARK_TASK: &str = "submit_snark";
 
 /// Pool that creates `ProverWorker` instances and implements `TaskQueue`.
 ///
@@ -90,29 +56,26 @@ impl ProverWorkerPool {
 impl TaskQueue for ProverWorkerPool {
     async fn submit(&self, task: OutboxTask) -> anyhow::Result<()> {
         let proof_request_id = task.proof_request_id;
+        let task_type = task
+            .params
+            .get("task_type")
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or("submit_stark");
+        let session_type =
+            if task_type == SUBMIT_SNARK_TASK { SessionType::Snark } else { SessionType::Stark };
 
-        // Deserialize params from JSON (string proof_type) to intermediate struct
-        let params_intermediate: ProveBlockRequestParams = serde_json::from_value(task.params)
-            .map_err(|e| {
-                error!(
-                    proof_request_id = %proof_request_id,
-                    error = %e,
-                    "Failed to deserialize ProveBlockRequestParams"
-                );
-                metrics::inc_outbox_tasks_processed("failed", "unknown");
-                anyhow::anyhow!("Failed to deserialize ProveBlockRequestParams: {e}")
-            })?;
-
-        // Convert to proto (integer proof_type) and extract the parsed ProofType
-        let (params, proof_type) = params_intermediate.into_proto().map_err(|e| {
-            error!(
+        let Some(claimed) =
+            self.repo.create_submitting_stage_for_outbox(proof_request_id, session_type).await?
+        else {
+            info!(
                 proof_request_id = %proof_request_id,
-                error = %e,
-                "Failed to convert to ProveBlockRequest"
+                session_type = %session_type,
+                "Outbox task already has an active stage"
             );
-            metrics::inc_outbox_tasks_processed("failed", "unknown");
-            e
-        })?;
+            return Ok(());
+        };
+
+        let proof_type = claimed.proof_request.proof_type;
         let pt_label = metrics::proof_type_label(proof_type);
         let backend_type: BackendType = proof_type.into();
 
@@ -141,7 +104,7 @@ impl TaskQueue for ProverWorkerPool {
         let backend_name = backend.name();
 
         // Create a new ProverWorker
-        let worker = ProverWorker::new(repo, backend, proof_request_id, params);
+        let worker = ProverWorker::new(repo, backend, claimed);
 
         // Create a tracing span that propagates proof_request_id to ALL nested log
         // calls — including witness generation, L1-head calculation, cluster submission,

--- a/crates/proof/zk/service/src/worker/prover_worker_pool.rs
+++ b/crates/proof/zk/service/src/worker/prover_worker_pool.rs
@@ -1,7 +1,7 @@
 use std::{fmt, sync::Arc};
 
 use async_trait::async_trait;
-use base_zk_db::{ProofRequestRepo, SessionType};
+use base_zk_db::{ProofRequestRepo, SUBMIT_SNARK_TASK, SUBMIT_STARK_TASK, SessionType};
 use base_zk_outbox::{OutboxTask, TaskQueue};
 use tokio::{sync::Mutex, task::JoinHandle};
 use tracing::{Instrument, error, info};
@@ -11,9 +11,6 @@ use crate::{
     metrics,
     worker::prover_worker::ProverWorker,
 };
-
-const SUBMIT_SNARK_TASK: &str = "submit_snark";
-const SUBMIT_STARK_TASK: &str = "submit_stark";
 
 /// Pool that creates `ProverWorker` instances and implements `TaskQueue`.
 ///

--- a/crates/proof/zk/service/src/worker/prover_worker_pool.rs
+++ b/crates/proof/zk/service/src/worker/prover_worker_pool.rs
@@ -13,6 +13,7 @@ use crate::{
 };
 
 const SUBMIT_SNARK_TASK: &str = "submit_snark";
+const SUBMIT_STARK_TASK: &str = "submit_stark";
 
 /// Pool that creates `ProverWorker` instances and implements `TaskQueue`.
 ///
@@ -56,13 +57,19 @@ impl ProverWorkerPool {
 impl TaskQueue for ProverWorkerPool {
     async fn submit(&self, task: OutboxTask) -> anyhow::Result<()> {
         let proof_request_id = task.proof_request_id;
-        let task_type = task
-            .params
-            .get("task_type")
-            .and_then(serde_json::Value::as_str)
-            .unwrap_or("submit_stark");
-        let session_type =
-            if task_type == SUBMIT_SNARK_TASK { SessionType::Snark } else { SessionType::Stark };
+        let task_type = task.params.get("task_type").and_then(serde_json::Value::as_str);
+        let session_type = match session_type_for_task_type(task_type) {
+            Ok(session_type) => session_type,
+            Err(other) => {
+                error!(
+                    proof_request_id = %proof_request_id,
+                    task_type = %other,
+                    "Unknown outbox task type"
+                );
+                metrics::inc_outbox_tasks_processed("failed", "unknown");
+                anyhow::bail!("Unknown outbox task_type: {other}");
+            }
+        };
 
         let Some(claimed) =
             self.repo.create_submitting_stage_for_outbox(proof_request_id, session_type).await?
@@ -142,5 +149,37 @@ impl TaskQueue for ProverWorkerPool {
 
         // Return immediately - task has been successfully submitted to the worker
         Ok(())
+    }
+}
+
+fn session_type_for_task_type(task_type: Option<&str>) -> Result<SessionType, String> {
+    match task_type {
+        Some(task) if task == SUBMIT_SNARK_TASK => Ok(SessionType::Snark),
+        Some(task) if task == SUBMIT_STARK_TASK => Ok(SessionType::Stark),
+        None => Ok(SessionType::Stark),
+        Some(other) => Err(other.to_string()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn missing_task_type_defaults_to_stark() {
+        assert_eq!(session_type_for_task_type(None), Ok(SessionType::Stark));
+    }
+
+    #[test]
+    fn explicit_snark_task_maps_to_snark() {
+        assert_eq!(session_type_for_task_type(Some(SUBMIT_SNARK_TASK)), Ok(SessionType::Snark));
+    }
+
+    #[test]
+    fn unknown_task_type_is_rejected() {
+        assert_eq!(
+            session_type_for_task_type(Some("submit_stork")),
+            Err("submit_stork".to_string())
+        );
     }
 }

--- a/crates/proof/zk/service/src/worker/status_poller.rs
+++ b/crates/proof/zk/service/src/worker/status_poller.rs
@@ -140,6 +140,53 @@ impl StatusPoller {
             }
         }
 
+        let stuck_submissions = self.repo.get_stuck_submissions(self.stuck_timeout_mins).await?;
+
+        for submission in stuck_submissions {
+            let proof_type_label = metrics::proof_type_label(submission.proof_request.proof_type);
+            let error_msg = format!(
+                "{} submission stuck before backend acceptance for {}+ minutes",
+                submission.proof_session.session_type, self.stuck_timeout_mins
+            );
+
+            match self
+                .repo
+                .retry_or_fail_stuck_submission(
+                    submission.proof_session.id,
+                    self.max_proof_retries,
+                    &error_msg,
+                )
+                .await
+            {
+                Ok(RetryOutcome::Retried) => {
+                    info!(
+                        proof_request_id = %submission.proof_request.id,
+                        proof_session_id = submission.proof_session.id,
+                        "Retrying stuck submission with new outbox entry"
+                    );
+                    metrics::inc_retried_requests(proof_type_label);
+                }
+                Ok(RetryOutcome::PermanentlyFailed) => {
+                    error!(
+                        proof_request_id = %submission.proof_request.id,
+                        proof_session_id = submission.proof_session.id,
+                        "Permanently failing stuck submission"
+                    );
+                    metrics::inc_stuck_requests(proof_type_label);
+                    metrics::inc_proof_requests_completed("failed", proof_type_label);
+                }
+                Ok(RetryOutcome::Skipped) => {}
+                Err(e) => {
+                    error!(
+                        proof_request_id = %submission.proof_request.id,
+                        proof_session_id = submission.proof_session.id,
+                        error = %e,
+                        "Failed to retry/fail stuck submission"
+                    );
+                }
+            }
+        }
+
         Ok(())
     }
 }

--- a/crates/proof/zk/service/src/worker/status_poller.rs
+++ b/crates/proof/zk/service/src/worker/status_poller.rs
@@ -69,7 +69,7 @@ impl StatusPoller {
                 );
                 if let Err(e) = self
                     .manager
-                    .sync_and_update_proof_status(proof_request)
+                    .sync_and_update_proof_status(proof_request, self.max_proof_retries)
                     .instrument(poll_span)
                     .await
                 {


### PR DESCRIPTION
## Summary
- Make the proof request outbox the authoritative dispatch path by creating durable SUBMITTING sessions before backend submission.
- Move SNARK submission onto outbox tasks and remove the old request-status queue APIs from production code.
- Make GetProof read-only so backend progress is handled by workers and the status poller.

## Test plan
- cargo check -p base-zk-db -p base-zk-service -p base-prover-zk
- cargo test -p base-zk-db -p base-zk-service --no-run --color never


Made with [Cursor](https://cursor.com)