### PR TITLE
[Backport v0.8.0] chore(consensus): expand sequencer and engine observability

### DIFF
--- a/crates/consensus/engine/src/metrics/mod.rs
+++ b/crates/consensus/engine/src/metrics/mod.rs
@@ -51,6 +51,26 @@ base_metrics::define_metrics! {
     engine_finalize_duration_seconds: histogram,
     #[describe("Number of tasks currently pending in the engine task queue")]
     engine_task_queue_depth: gauge,
+    #[describe(
+        "Per-task wall-clock duration including CL-side retry/yield overhead (broader than engine_method_request_duration which only covers the reth round-trip)"
+    )]
+    #[label(
+        name = "task",
+        default = [
+            "insert",
+            "consolidate",
+            "delegated-forkchoice",
+            "build",
+            "finalize",
+            "seal",
+            "get-payload"
+        ]
+    )]
+    engine_task_duration: histogram,
+    #[describe(
+        "Wall-clock duration of one EngineProcessor loop iteration: drain + recv wait + request handling. Upper bound on per-request wait time in the EngineActor->EngineProcessor mpsc channel — a request arriving anywhere in the previous iteration waits at most this long before recv picks it up."
+    )]
+    engine_processor_iteration_duration: histogram,
 }
 
 impl Metrics {

--- a/crates/consensus/engine/src/task_queue/tasks/task.rs
+++ b/crates/consensus/engine/src/task_queue/tasks/task.rs
@@ -246,6 +246,13 @@ impl<EngineClient_: EngineClient> EngineTaskExt for EngineTask<EngineClient_> {
     type Error = EngineTaskErrors;
 
     async fn execute(&self, state: &mut EngineState) -> Result<(), Self::Error> {
+        // Wall-clock duration of the entire retry loop (not per attempt), so the
+        // difference against `engine_method_request_duration{method}` isolates pure
+        // CL retry/yield overhead. Records on drop regardless of outcome
+        // (success / critical / reset / flush).
+        let label = self.task_metrics_label();
+        let _task_timer = base_metrics::timed!(Metrics::engine_task_duration(label));
+
         // Retry the task until it succeeds or a critical error occurs.
         while let Err(e) = self.execute_inner(state).await {
             let severity = e.severity();

--- a/crates/consensus/service/src/actors/engine/engine_request_processor.rs
+++ b/crates/consensus/service/src/actors/engine/engine_request_processor.rs
@@ -6,7 +6,8 @@ use base_consensus_derive::{ResetSignal, Signal};
 use base_consensus_engine::{
     BuildTask, ConsolidateInput, ConsolidateTask, DelegatedForkchoiceTask,
     DelegatedForkchoiceUpdate, Engine, EngineClient, EngineSyncStateUpdate, EngineTask,
-    EngineTaskError, EngineTaskErrorSeverity, FinalizeTask, GetPayloadTask, InsertTask, SealTask,
+    EngineTaskError, EngineTaskErrorSeverity, FinalizeTask, GetPayloadTask, InsertTask,
+    Metrics as EngineMetrics, SealTask,
 };
 use base_consensus_genesis::RollupConfig;
 use base_protocol::L2BlockInfo;
@@ -603,6 +604,13 @@ where
             }
 
             loop {
+                // Full processor iteration window: drain + recv wait + request handling.
+                // Bounds the worst-case channel wait — any request arriving during this
+                // iteration waits at most this long before the next recv picks it up.
+                let _iter_timer = base_metrics::timed!(
+                    EngineMetrics::engine_processor_iteration_duration()
+                );
+
                 // Attempt to drain all outstanding tasks from the engine queue before adding new
                 // ones.
                 self.drain().await.inspect_err(

--- a/crates/consensus/service/src/actors/engine/engine_request_processor.rs
+++ b/crates/consensus/service/src/actors/engine/engine_request_processor.rs
@@ -607,9 +607,8 @@ where
                 // Full processor iteration window: drain + recv wait + request handling.
                 // Bounds the worst-case channel wait — any request arriving during this
                 // iteration waits at most this long before the next recv picks it up.
-                let _iter_timer = base_metrics::timed!(
-                    EngineMetrics::engine_processor_iteration_duration()
-                );
+                let _iter_timer =
+                    base_metrics::timed!(EngineMetrics::engine_processor_iteration_duration());
 
                 // Attempt to drain all outstanding tasks from the engine queue before adding new
                 // ones.

--- a/crates/consensus/service/src/actors/mod.rs
+++ b/crates/consensus/service/src/actors/mod.rs
@@ -51,9 +51,9 @@ mod sequencer;
 pub use sequencer::{
     Conductor, ConductorClient, ConductorError, DelayedL1OriginSelectorProvider, L1OriginSelector,
     L1OriginSelectorError, L1OriginSelectorProvider, OriginSelector, PayloadBuilder, PayloadSealer,
-    PendingStopSender, PoolActivation, QueuedSequencerEngineClient, RecoveryModeGuard, SealState,
-    SealStepError, SequencerActor, SequencerActorError, SequencerAdminQuery, SequencerConfig,
-    SequencerEngineClient, UnsealedPayloadHandle,
+    PendingStopSender, PoolActivation, QueuedSequencerEngineClient, RecoveryModeGuard,
+    ScheduledTicker, SealState, SealStepError, SequencerActor, SequencerActorError,
+    SequencerAdminQuery, SequencerConfig, SequencerEngineClient, UnsealedPayloadHandle,
 };
 #[cfg(test)]
 pub use sequencer::{MockConductor, MockOriginSelector, MockSequencerEngineClient};

--- a/crates/consensus/service/src/actors/sequencer/actor.rs
+++ b/crates/consensus/service/src/actors/sequencer/actor.rs
@@ -297,6 +297,10 @@ where
                     self.handle_admin_query(&mut next_payload_to_seal, query).await;
 
                     if !active_before && self.is_active {
+                        // Clear the previous completion timestamp so the first block
+                        // after a stop->start cycle does not record the entire idle
+                        // period as sequencer_block_to_block_duration.
+                        last_block_complete_at = None;
                         build_ticker.reset_immediately();
                     }
                 }

--- a/crates/consensus/service/src/actors/sequencer/actor.rs
+++ b/crates/consensus/service/src/actors/sequencer/actor.rs
@@ -2,7 +2,7 @@
 
 use std::{
     sync::Arc,
-    time::{Duration, Instant, SystemTime, UNIX_EPOCH},
+    time::{Duration, Instant, UNIX_EPOCH},
 };
 
 use alloy_primitives::B256;
@@ -29,6 +29,7 @@ use crate::{
             origin_selector::OriginSelector,
             recovery::RecoveryModeGuard,
             seal::PayloadSealer,
+            ScheduledTicker,
         },
     },
 };
@@ -120,7 +121,8 @@ where
             .get_sealed_payload(handle.payload_id, handle.attributes_with_parent.clone())
             .await?;
 
-        Metrics::sequencer_block_building_seal_task_duration().set(seal_request_start.elapsed());
+        Metrics::sequencer_block_building_seal_task_duration()
+            .record(seal_request_start.elapsed());
         Metrics::sequencer_total_transactions_sequenced()
             .increment(handle.attributes_with_parent.count_transactions());
 
@@ -270,7 +272,7 @@ where
 
     async fn start(mut self, _: Self::StartData) -> Result<(), Self::Error> {
         let mut build_ticker =
-            tokio::time::interval(Duration::from_secs(self.rollup_config.block_time));
+            ScheduledTicker::new(Duration::from_secs(self.rollup_config.block_time));
 
         self.update_metrics();
 
@@ -280,6 +282,9 @@ where
         // Admin API queries are serviced during this phase (see schedule_initial_reset).
         self.schedule_initial_reset(&mut next_payload_to_seal).await?;
         let mut last_seal_duration = Duration::from_secs(0);
+
+        let mut last_block_complete_at: Option<Instant> = None;
+
         loop {
             select! {
                 biased;
@@ -311,7 +316,18 @@ where
                 } => {
                     match result {
                         Ok(true) => {
-                            self.sealer = None;
+                            if let Some(sealer) = self.sealer.take() {
+                                Metrics::sequencer_seal_pipeline_duration()
+                                    .record(sealer.started_at.elapsed());
+                            }
+
+                            let now = Instant::now();
+                            if let Some(prev) = last_block_complete_at {
+                                Metrics::sequencer_block_to_block_duration()
+                                    .record(now.duration_since(prev));
+                            }
+                            last_block_complete_at = Some(now);
+
                             // Respond to a pending stop_sequencer request now that the
                             // in-flight seal is complete.
                             if let Some(tx) = self.pending_stop.take() {
@@ -402,10 +418,7 @@ where
                                 let next_block_time = UNIX_EPOCH
                                     + Duration::from_secs(next_block_seconds)
                                     - last_seal_duration;
-                                match next_block_time.duration_since(SystemTime::now()) {
-                                    Ok(duration) => build_ticker.reset_after(duration),
-                                    Err(_) => build_ticker.reset_immediately(),
-                                }
+                                build_ticker.reset_at(next_block_time);
                                 // Do not call build() here. The next payload is built in the
                                 // Ok(true) arm after insert_unsafe_payload has been queued,
                                 // so InsertTask always precedes BuildTask in the engine queue.
@@ -424,10 +437,7 @@ where
                                     let next_block_time = UNIX_EPOCH
                                         + Duration::from_secs(next_block_seconds)
                                         - last_seal_duration;
-                                    match next_block_time.duration_since(SystemTime::now()) {
-                                        Ok(duration) => build_ticker.reset_after(duration),
-                                        Err(_) => build_ticker.reset_immediately(),
-                                    }
+                                    build_ticker.reset_at(next_block_time);
                                 } else {
                                     build_ticker.reset_immediately();
                                 }
@@ -460,10 +470,7 @@ where
                             let next_block_time = UNIX_EPOCH
                                 + Duration::from_secs(next_block_seconds)
                                 - last_seal_duration;
-                            match next_block_time.duration_since(SystemTime::now()) {
-                                Ok(duration) => build_ticker.reset_after(duration),
-                                Err(_) => build_ticker.reset_immediately(),
-                            }
+                            build_ticker.reset_at(next_block_time);
                         } else {
                             build_ticker.reset_immediately();
                         }

--- a/crates/consensus/service/src/actors/sequencer/actor.rs
+++ b/crates/consensus/service/src/actors/sequencer/actor.rs
@@ -23,13 +23,13 @@ use crate::{
         SequencerEngineClient,
         engine::EngineClientError,
         sequencer::{
+            ScheduledTicker,
             build::{PayloadBuilder, UnsealedPayloadHandle},
             conductor::Conductor,
             error::SequencerActorError,
             origin_selector::OriginSelector,
             recovery::RecoveryModeGuard,
             seal::PayloadSealer,
-            ScheduledTicker,
         },
     },
 };
@@ -121,8 +121,7 @@ where
             .get_sealed_payload(handle.payload_id, handle.attributes_with_parent.clone())
             .await?;
 
-        Metrics::sequencer_block_building_seal_task_duration()
-            .record(seal_request_start.elapsed());
+        Metrics::sequencer_block_building_seal_task_duration().record(seal_request_start.elapsed());
         Metrics::sequencer_total_transactions_sequenced()
             .increment(handle.attributes_with_parent.count_transactions());
 

--- a/crates/consensus/service/src/actors/sequencer/build.rs
+++ b/crates/consensus/service/src/actors/sequencer/build.rs
@@ -93,14 +93,15 @@ impl<A: AttributesBuilder, O: OriginSelector, E: SequencerEngineClient> PayloadB
             return Ok(None);
         };
 
-        Metrics::sequencer_attributes_build_duration().set(attributes_build_start.elapsed());
+        Metrics::sequencer_attributes_build_duration().record(attributes_build_start.elapsed());
 
         let build_request_start = Instant::now();
 
         let payload_id =
             self.engine_client.start_build_block(attributes_with_parent.clone()).await?;
 
-        Metrics::sequencer_block_building_start_task_duration().set(build_request_start.elapsed());
+        Metrics::sequencer_block_building_start_task_duration()
+            .record(build_request_start.elapsed());
 
         Ok(Some(UnsealedPayloadHandle { payload_id, attributes_with_parent }))
     }

--- a/crates/consensus/service/src/actors/sequencer/mod.rs
+++ b/crates/consensus/service/src/actors/sequencer/mod.rs
@@ -20,6 +20,9 @@ pub use recovery::RecoveryModeGuard;
 mod seal;
 pub use seal::{PayloadSealer, SealState, SealStepError};
 
+mod ticker;
+pub use ticker::ScheduledTicker;
+
 mod pool;
 pub use pool::PoolActivation;
 

--- a/crates/consensus/service/src/actors/sequencer/seal.rs
+++ b/crates/consensus/service/src/actors/sequencer/seal.rs
@@ -48,12 +48,16 @@ pub struct PayloadSealer {
     pub envelope: BaseExecutionPayloadEnvelope,
     /// Current pipeline stage.
     pub state: SealState,
+    /// Wall-clock instant the sealer was constructed (start of the seal pipeline).
+    /// Read by the actor on `Ok(true)` to record
+    /// [`crate::Metrics::sequencer_seal_pipeline_duration`].
+    pub started_at: Instant,
 }
 
 impl PayloadSealer {
     /// Creates a new sealer starting at the [`SealState::Sealed`] stage.
-    pub const fn new(envelope: BaseExecutionPayloadEnvelope) -> Self {
-        Self { envelope, state: SealState::Sealed }
+    pub fn new(envelope: BaseExecutionPayloadEnvelope) -> Self {
+        Self { envelope, state: SealState::Sealed, started_at: Instant::now() }
     }
 
     /// Performs one step of the seal pipeline.
@@ -104,7 +108,9 @@ impl PayloadSealer {
         };
 
         match &result {
-            Ok(_) => Metrics::sequencer_seal_step_duration(step_label).set(step_start.elapsed()),
+            Ok(_) => {
+                Metrics::sequencer_seal_step_duration(step_label).record(step_start.elapsed())
+            }
             Err(_) => Metrics::sequencer_seal_step_retries_total(step_label).increment(1),
         }
 

--- a/crates/consensus/service/src/actors/sequencer/seal.rs
+++ b/crates/consensus/service/src/actors/sequencer/seal.rs
@@ -108,9 +108,7 @@ impl PayloadSealer {
         };
 
         match &result {
-            Ok(_) => {
-                Metrics::sequencer_seal_step_duration(step_label).record(step_start.elapsed())
-            }
+            Ok(_) => Metrics::sequencer_seal_step_duration(step_label).record(step_start.elapsed()),
             Err(_) => Metrics::sequencer_seal_step_retries_total(step_label).increment(1),
         }
 

--- a/crates/consensus/service/src/actors/sequencer/ticker.rs
+++ b/crates/consensus/service/src/actors/sequencer/ticker.rs
@@ -59,8 +59,7 @@ impl ScheduledTicker {
     pub async fn tick(&mut self) -> Instant {
         let instant = self.interval.tick().await;
         if let Some(target) = self.target.take() {
-            let drift =
-                SystemTime::now().duration_since(target).unwrap_or(Duration::ZERO);
+            let drift = SystemTime::now().duration_since(target).unwrap_or(Duration::ZERO);
             Metrics::sequencer_ticker_drift_seconds().record(drift);
         }
         instant

--- a/crates/consensus/service/src/actors/sequencer/ticker.rs
+++ b/crates/consensus/service/src/actors/sequencer/ticker.rs
@@ -1,0 +1,68 @@
+//! Wall-clock scheduled ticker that records its own drift on every fire.
+//!
+//! Wraps [`tokio::time::Interval`] together with the wall-clock target time
+//! requested at the last reset. When the interval fires, the elapsed time
+//! between target and actual fire is recorded to
+//! [`Metrics::sequencer_ticker_drift_seconds`]. Early fires record `0`.
+
+use std::time::{Duration, SystemTime};
+
+use tokio::time::{Instant, Interval};
+
+use crate::Metrics;
+
+/// A [`tokio::time::Interval`] that remembers its wall-clock target so the
+/// drift between intended and actual fire time can be observed transparently
+/// every tick.
+#[derive(Debug)]
+pub struct ScheduledTicker {
+    interval: Interval,
+    target: Option<SystemTime>,
+}
+
+impl ScheduledTicker {
+    /// Creates a new ticker with the given period.
+    ///
+    /// The first fire occurs immediately, mirroring [`tokio::time::interval`]
+    /// semantics. No target is set, so the first tick records no drift.
+    pub fn new(period: Duration) -> Self {
+        Self { interval: tokio::time::interval(period), target: None }
+    }
+
+    /// Reschedules the next tick for the given wall-clock target.
+    ///
+    /// If `target` is in the past the ticker fires immediately. The next
+    /// [`Self::tick`] will record the drift between `target` and the actual
+    /// fire time.
+    pub fn reset_at(&mut self, target: SystemTime) {
+        self.target = Some(target);
+        match target.duration_since(SystemTime::now()) {
+            Ok(duration) => self.interval.reset_after(duration),
+            Err(_) => self.interval.reset_immediately(),
+        }
+    }
+
+    /// Reschedules the next tick to fire immediately, with `now` as the
+    /// drift target (so the recorded drift is approximately zero plus any
+    /// scheduler latency).
+    pub fn reset_immediately(&mut self) {
+        self.reset_at(SystemTime::now());
+    }
+
+    /// Awaits the next tick.
+    ///
+    /// On fire, records [`Metrics::sequencer_ticker_drift_seconds`] using the
+    /// target from the last [`Self::reset_at`] / [`Self::reset_immediately`]
+    /// call. Early fires (target in the future) are clamped to
+    /// [`Duration::ZERO`]. Ticks with no prior target (e.g. the very first
+    /// tick after construction) record nothing.
+    pub async fn tick(&mut self) -> Instant {
+        let instant = self.interval.tick().await;
+        if let Some(target) = self.target.take() {
+            let drift =
+                SystemTime::now().duration_since(target).unwrap_or(Duration::ZERO);
+            Metrics::sequencer_ticker_drift_seconds().record(drift);
+        }
+        instant
+    }
+}

--- a/crates/consensus/service/src/lib.rs
+++ b/crates/consensus/service/src/lib.rs
@@ -41,10 +41,10 @@ pub use actors::{
     PendingStopSender, PoolActivation, QueuedDerivationEngineClient, QueuedEngineDerivationClient,
     QueuedEngineRpcClient, QueuedL1WatcherDerivationClient, QueuedNetworkEngineClient,
     QueuedSequencerAdminAPIClient, QueuedSequencerEngineClient, QueuedUnsafePayloadGossipClient,
-    RecoveryModeGuard, ResetRequest, RpcActor, RpcActorError, RpcContext, SealRequest, SealState,
-    SealStepError, SequencerActor, SequencerActorError, SequencerAdminQuery, SequencerConfig,
-    SequencerEngineClient, UnsafePayloadGossipClient, UnsafePayloadGossipClientError,
-    UnsealedPayloadHandle,
+    RecoveryModeGuard, ResetRequest, RpcActor, RpcActorError, RpcContext, ScheduledTicker,
+    SealRequest, SealState, SealStepError, SequencerActor, SequencerActorError,
+    SequencerAdminQuery, SequencerConfig, SequencerEngineClient, UnsafePayloadGossipClient,
+    UnsafePayloadGossipClientError, UnsealedPayloadHandle,
 };
 
 mod metrics;

--- a/crates/consensus/service/src/metrics/mod.rs
+++ b/crates/consensus/service/src/metrics/mod.rs
@@ -32,7 +32,7 @@ base_metrics::define_metrics! {
     sequencer_block_to_block_duration: histogram,
     #[describe("Wall-clock drift between the build-ticker target time and the actual fire time (>= 0; clamped to 0 when the ticker fires early)")]
     sequencer_ticker_drift_seconds: histogram,
-    #[describe("Wall-clock duration of the full seal pipeline (conductor commit → gossip → engine insert), measured from when the ticker picks up the pre-built handle until step() returns Ok(true). Excludes the EL build idle wait.")]
+    #[describe("Wall-clock duration of the full seal pipeline (conductor commit → gossip → engine insert), measured from PayloadSealer construction (after the EL seal response) until step() returns Ok(true). Excludes the EL build idle wait and the EL seal request.")]
     sequencer_seal_pipeline_duration: histogram,
     #[describe("Seal errors by fatality")]
     #[label(name = "fatal", default = ["true", "false"])]

--- a/crates/consensus/service/src/metrics/mod.rs
+++ b/crates/consensus/service/src/metrics/mod.rs
@@ -15,21 +15,25 @@ base_metrics::define_metrics! {
     #[label(recovery)]
     sequencer_state: gauge,
     #[describe("Duration of the sequencer attributes builder")]
-    sequencer_attributes_build_duration: gauge,
+    sequencer_attributes_build_duration: histogram,
     #[describe("Duration of the sequencer block building start task")]
-    sequencer_block_building_start_task_duration: gauge,
+    sequencer_block_building_start_task_duration: histogram,
     #[describe("Duration of the sequencer block building seal task")]
-    sequencer_block_building_seal_task_duration: gauge,
-    #[describe("Duration of the sequencer conductor commitment")]
-    sequencer_conductor_commitment_duration: gauge,
+    sequencer_block_building_seal_task_duration: histogram,
     #[describe("Total count of sequenced transactions")]
     sequencer_total_transactions_sequenced: counter,
     #[describe("Sequencer seal step retries by step")]
     #[label(name = "step", default = ["conductor", "gossip", "insert"])]
     sequencer_seal_step_retries_total: counter,
     #[describe("Sequencer seal step duration by step")]
-    #[label(step)]
-    sequencer_seal_step_duration: gauge,
+    #[label(name = "step", default = ["conductor", "gossip", "insert"])]
+    sequencer_seal_step_duration: histogram,
+    #[describe("Wall-clock duration between successive successful seal completions (Ok(true) returns)")]
+    sequencer_block_to_block_duration: histogram,
+    #[describe("Wall-clock drift between the build-ticker target time and the actual fire time (>= 0; clamped to 0 when the ticker fires early)")]
+    sequencer_ticker_drift_seconds: histogram,
+    #[describe("Wall-clock duration of the full seal pipeline (conductor commit → gossip → engine insert), measured from when the ticker picks up the pre-built handle until step() returns Ok(true). Excludes the EL build idle wait.")]
+    sequencer_seal_pipeline_duration: histogram,
     #[describe("Seal errors by fatality")]
     #[label(name = "fatal", default = ["true", "false"])]
     sequencer_seal_errors_total: counter,


### PR DESCRIPTION
Backport of #2523 to `releases/v0.8.0`.

Consensus-side observability for the **200ms-blocks** rollout. After this PR the dashboard can answer *"did we ship 200ms?"* and trace a regression to a single component without code changes.

## Track on the dashboard

**Headline (did we ship?)**
- `sequencer_block_to_block_duration` p99 — block cadence
- `sequencer_ticker_drift_seconds` p99 — slot alignment

**Diagnosis funnel (when headlines regress)**
- Build half: `sequencer_attributes_build_duration`, `sequencer_block_building_start_task_duration`
- Seal half (envelope): `sequencer_seal_pipeline_duration`
- Seal half (components): `sequencer_block_building_seal_task_duration`, `sequencer_seal_step_duration{step=conductor|gossip|insert}`
- Engine: `engine_task_duration{task}` minus `engine_method_request_duration{method}` = pure CL overhead
- Engine queueing: `engine_processor_iteration_duration` bounds the worst-case wait between `EngineActor` and `EngineProcessor`

## Cherry-picked commits
- `7c7c8c494` chore(consensus): expand sequencer and engine observability
- `f352519a4` chore(consensus): clarify seal pipeline duration metric description
- `a374d2907` fix(consensus): reset last_block_complete_at on sequencer restart

## Conflicts resolved
One textual conflict in `crates/consensus/service/src/actors/engine/engine_request_processor.rs` import block — `releases/v0.8.0` does not yet have `InsertPayloadSafety` (added in #2492 on main), so kept the v0.8.0 import set and added only the new `Metrics as EngineMetrics` import. No semantic divergence.

`cargo check -p base-consensus-node -p base-consensus-engine` clean on the resolved tree.