### PR TITLE
feat(consensus): Opt In Queued RPC Timeouts

### DIFF
--- a/crates/consensus/rpc/src/client.rs
+++ b/crates/consensus/rpc/src/client.rs
@@ -77,6 +77,10 @@ pub enum SequencerAdminAPIError {
     #[error("Error receiving response: response channel closed.")]
     ResponseError,
 
+    /// Timed out waiting for an actor response.
+    #[error("Timed out waiting for response.")]
+    ResponseTimeout,
+
     /// Sequencer stopped successfully, followed by some error.
     #[error("Sequencer stopped successfully, followed by error: {0}.")]
     ErrorAfterSequencerWasStopped(String),

--- a/crates/consensus/service/src/actors/mod.rs
+++ b/crates/consensus/service/src/actors/mod.rs
@@ -17,7 +17,8 @@ pub use engine::{
 
 mod rpc;
 pub use rpc::{
-    QueuedEngineRpcClient, QueuedSequencerAdminAPIClient, RpcActor, RpcActorError, RpcContext,
+    QueuedEngineRpcClient, QueuedRpcClientOptions, QueuedSequencerAdminAPIClient, RpcActor,
+    RpcActorError, RpcContext,
 };
 
 mod derivation;

--- a/crates/consensus/service/src/actors/rpc/client_options.rs
+++ b/crates/consensus/service/src/actors/rpc/client_options.rs
@@ -1,0 +1,13 @@
+//! Options shared by queued RPC clients.
+
+use std::time::Duration;
+
+/// Runtime options for queued in-process RPC clients.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct QueuedRpcClientOptions {
+    /// Optional deadline for waiting on actor response channels.
+    ///
+    /// `None` preserves the historical behavior: once a request is accepted, the caller waits
+    /// until the actor responds or drops the response channel.
+    pub request_timeout: Option<Duration>,
+}

--- a/crates/consensus/service/src/actors/rpc/engine_rpc_client.rs
+++ b/crates/consensus/service/src/actors/rpc/engine_rpc_client.rs
@@ -82,7 +82,7 @@ impl QueuedEngineRpcClient {
                 error!(
                     target: "block_engine",
                     response_name,
-                    timeout_ms = timeout.as_millis(),
+                    timeout_ms = timeout.as_millis() as u64,
                     "Timed out waiting for engine rpc response"
                 );
                 ErrorObject::owned(

--- a/crates/consensus/service/src/actors/rpc/engine_rpc_client.rs
+++ b/crates/consensus/service/src/actors/rpc/engine_rpc_client.rs
@@ -6,7 +6,6 @@ use base_common_genesis::RollupConfig;
 use base_consensus_engine::{EngineQueries, EngineState};
 use base_consensus_rpc::EngineRpcClient;
 use base_protocol::{L2BlockInfo, OutputRoot};
-use derive_more::Constructor;
 use jsonrpsee::{
     core::RpcResult,
     types::{ErrorCode, ErrorObject},
@@ -16,17 +15,33 @@ use tokio::sync::{
     oneshot, watch,
 };
 
+use super::QueuedRpcClientOptions;
 use crate::EngineRpcRequest;
 
 /// Queue-based implementation of the [`EngineRpcClient`] trait. This handles all channel-based
 /// operations, providing a nice facade for callers.
-#[derive(Clone, Constructor, Debug)]
+#[derive(Clone, Debug)]
 pub struct QueuedEngineRpcClient {
     /// A channel to use to send engine RPC requests.
     pub engine_rpc_request_tx: mpsc::Sender<EngineRpcRequest>,
+    /// Runtime options for request/response handling.
+    pub options: QueuedRpcClientOptions,
 }
 
 impl QueuedEngineRpcClient {
+    /// Creates a new queued engine RPC client with historical no-timeout behavior.
+    pub fn new(engine_rpc_request_tx: mpsc::Sender<EngineRpcRequest>) -> Self {
+        Self::new_with_options(engine_rpc_request_tx, QueuedRpcClientOptions::default())
+    }
+
+    /// Creates a new queued engine RPC client with explicit runtime options.
+    pub const fn new_with_options(
+        engine_rpc_request_tx: mpsc::Sender<EngineRpcRequest>,
+        options: QueuedRpcClientOptions,
+    ) -> Self {
+        Self { engine_rpc_request_tx, options }
+    }
+
     /// Attempts to enqueue an engine query without waiting for channel capacity.
     ///
     /// Public RPC requests fail fast under load so they cannot block consensus-critical work.
@@ -44,6 +59,42 @@ impl QueuedEngineRpcClient {
             },
         )
     }
+
+    /// Awaits an engine actor response using the configured timeout policy.
+    pub async fn receive_engine_response<T>(
+        &self,
+        response_rx: oneshot::Receiver<T>,
+        response_name: &'static str,
+    ) -> RpcResult<T> {
+        let receive = async {
+            response_rx.await.map_err(|_| {
+                error!(
+                    target: "block_engine",
+                    response_name,
+                    "Failed to receive response from engine rpc"
+                );
+                ErrorObject::from(ErrorCode::InternalError)
+            })
+        };
+
+        if let Some(timeout) = self.options.request_timeout {
+            tokio::time::timeout(timeout, receive).await.map_err(|_| {
+                error!(
+                    target: "block_engine",
+                    response_name,
+                    timeout_ms = timeout.as_millis(),
+                    "Timed out waiting for engine rpc response"
+                );
+                ErrorObject::owned(
+                    ErrorCode::InternalError.code(),
+                    "engine rpc response timed out",
+                    None::<()>,
+                )
+            })?
+        } else {
+            receive.await
+        }
+    }
 }
 
 #[async_trait]
@@ -53,10 +104,7 @@ impl EngineRpcClient for QueuedEngineRpcClient {
 
         self.try_enqueue_engine_query(EngineQueries::Config(config_tx))?;
 
-        config_rx.await.map_err(|_| {
-            error!(target: "block_engine", "Failed to receive config from engine rpc");
-            ErrorObject::from(ErrorCode::InternalError)
-        })
+        self.receive_engine_response(config_rx, "config").await
     }
 
     async fn get_state(&self) -> RpcResult<EngineState> {
@@ -64,10 +112,7 @@ impl EngineRpcClient for QueuedEngineRpcClient {
 
         self.try_enqueue_engine_query(EngineQueries::State(state_tx))?;
 
-        state_rx.await.map_err(|_| {
-            error!(target: "block_engine", "Failed to receive state from engine rpc");
-            ErrorObject::from(ErrorCode::InternalError)
-        })
+        self.receive_engine_response(state_rx, "state").await
     }
 
     async fn output_at_block(
@@ -78,10 +123,7 @@ impl EngineRpcClient for QueuedEngineRpcClient {
 
         self.try_enqueue_engine_query(EngineQueries::OutputAtBlock { block, sender: output_tx })?;
 
-        output_rx.await.map_err(|_| {
-            error!(target: "block_engine", "Failed to receive output at block from engine rpc");
-            ErrorObject::from(ErrorCode::InternalError)
-        })
+        self.receive_engine_response(output_rx, "output_at_block").await
     }
 
     async fn dev_get_task_queue_length(&self) -> RpcResult<usize> {
@@ -89,10 +131,7 @@ impl EngineRpcClient for QueuedEngineRpcClient {
 
         self.try_enqueue_engine_query(EngineQueries::TaskQueueLength(length_tx))?;
 
-        length_rx.await.map_err(|_| {
-            error!(target: "block_engine", "Failed to receive task queue length from engine rpc");
-            ErrorObject::from(ErrorCode::InternalError)
-        })
+        self.receive_engine_response(length_rx, "task_queue_length").await
     }
 
     async fn dev_subscribe_to_engine_queue_length(&self) -> RpcResult<watch::Receiver<usize>> {
@@ -100,10 +139,7 @@ impl EngineRpcClient for QueuedEngineRpcClient {
 
         self.try_enqueue_engine_query(EngineQueries::QueueLengthReceiver(sub_tx))?;
 
-        sub_rx.await.map_err(|_| {
-            error!(target: "block_engine", "Failed to receive queue length receiver from engine rpc");
-            ErrorObject::from(ErrorCode::InternalError)
-        })
+        self.receive_engine_response(sub_rx, "queue_length_receiver").await
     }
 
     async fn dev_subscribe_to_engine_state(&self) -> RpcResult<watch::Receiver<EngineState>> {
@@ -111,9 +147,33 @@ impl EngineRpcClient for QueuedEngineRpcClient {
 
         self.try_enqueue_engine_query(EngineQueries::StateReceiver(sub_tx))?;
 
-        sub_rx.await.map_err(|_| {
-            error!(target: "block_engine", "Failed to receive state receiver from engine rpc");
-            ErrorObject::from(ErrorCode::InternalError)
-        })
+        self.receive_engine_response(sub_rx, "state_receiver").await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use base_consensus_rpc::EngineRpcClient as _;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn get_state_times_out_when_response_is_not_sent() {
+        let (engine_rpc_request_tx, mut engine_rpc_request_rx) = mpsc::channel(1);
+        let client = QueuedEngineRpcClient::new_with_options(
+            engine_rpc_request_tx,
+            QueuedRpcClientOptions { request_timeout: Some(Duration::ZERO) },
+        );
+
+        let result = client.get_state().await;
+
+        assert!(result.is_err(), "client should return timeout error");
+        let request = engine_rpc_request_rx.recv().await.expect("request should be queued");
+        assert!(
+            matches!(request, EngineRpcRequest::EngineQuery(_)),
+            "expected queued engine query"
+        );
     }
 }

--- a/crates/consensus/service/src/actors/rpc/mod.rs
+++ b/crates/consensus/service/src/actors/rpc/mod.rs
@@ -3,6 +3,9 @@
 mod actor;
 pub use actor::{RpcActor, RpcContext};
 
+mod client_options;
+pub use client_options::QueuedRpcClientOptions;
+
 mod engine_rpc_client;
 pub use engine_rpc_client::QueuedEngineRpcClient;
 

--- a/crates/consensus/service/src/actors/rpc/sequencer_rpc_client.rs
+++ b/crates/consensus/service/src/actors/rpc/sequencer_rpc_client.rs
@@ -38,13 +38,25 @@ impl QueuedSequencerAdminAPIClient {
         &self,
         response_rx: oneshot::Receiver<Result<T, SequencerAdminAPIError>>,
     ) -> Result<T, SequencerAdminAPIError> {
-        let receive =
-            async { response_rx.await.map_err(|_| SequencerAdminAPIError::ResponseError)? };
+        let receive = async {
+            response_rx.await.map_err(|_| {
+                error!(
+                    target: "sequencer_admin",
+                    "Failed to receive response from sequencer admin rpc"
+                );
+                SequencerAdminAPIError::ResponseError
+            })?
+        };
 
         if let Some(timeout) = self.options.request_timeout {
-            tokio::time::timeout(timeout, receive)
-                .await
-                .map_err(|_| SequencerAdminAPIError::ResponseTimeout)?
+            tokio::time::timeout(timeout, receive).await.map_err(|_| {
+                error!(
+                    target: "sequencer_admin",
+                    timeout_ms = timeout.as_millis() as u64,
+                    "Timed out waiting for sequencer admin rpc response"
+                );
+                SequencerAdminAPIError::ResponseTimeout
+            })?
         } else {
             receive.await
         }

--- a/crates/consensus/service/src/actors/rpc/sequencer_rpc_client.rs
+++ b/crates/consensus/service/src/actors/rpc/sequencer_rpc_client.rs
@@ -4,17 +4,51 @@
 use alloy_primitives::B256;
 use async_trait::async_trait;
 use base_consensus_rpc::{SequencerAdminAPIClient, SequencerAdminAPIError};
-use derive_more::Constructor;
 use tokio::sync::{mpsc, oneshot};
 
+use super::QueuedRpcClientOptions;
 use crate::SequencerAdminQuery;
 
 /// Queued implementation of [`SequencerAdminAPIClient`] that handles requests by sending them to
 /// a handler via the contained sender.
-#[derive(Debug, Clone, Constructor)]
+#[derive(Debug, Clone)]
 pub struct QueuedSequencerAdminAPIClient {
     /// Queue used to relay admin queries
     request_tx: mpsc::Sender<SequencerAdminQuery>,
+    /// Runtime options for request/response handling.
+    options: QueuedRpcClientOptions,
+}
+
+impl QueuedSequencerAdminAPIClient {
+    /// Creates a new queued sequencer admin client with historical no-timeout behavior.
+    pub fn new(request_tx: mpsc::Sender<SequencerAdminQuery>) -> Self {
+        Self::new_with_options(request_tx, QueuedRpcClientOptions::default())
+    }
+
+    /// Creates a new queued sequencer admin client with explicit runtime options.
+    pub const fn new_with_options(
+        request_tx: mpsc::Sender<SequencerAdminQuery>,
+        options: QueuedRpcClientOptions,
+    ) -> Self {
+        Self { request_tx, options }
+    }
+
+    /// Awaits a sequencer admin actor response using the configured timeout policy.
+    pub async fn receive_admin_response<T>(
+        &self,
+        response_rx: oneshot::Receiver<Result<T, SequencerAdminAPIError>>,
+    ) -> Result<T, SequencerAdminAPIError> {
+        let receive =
+            async { response_rx.await.map_err(|_| SequencerAdminAPIError::ResponseError)? };
+
+        if let Some(timeout) = self.options.request_timeout {
+            tokio::time::timeout(timeout, receive)
+                .await
+                .map_err(|_| SequencerAdminAPIError::ResponseTimeout)?
+        } else {
+            receive.await
+        }
+    }
 }
 
 #[async_trait]
@@ -25,7 +59,7 @@ impl SequencerAdminAPIClient for QueuedSequencerAdminAPIClient {
         self.request_tx.send(SequencerAdminQuery::SequencerActive(tx)).await.map_err(|_| {
             SequencerAdminAPIError::RequestError("request channel closed".to_string())
         })?;
-        rx.await.map_err(|_| SequencerAdminAPIError::ResponseError)?
+        self.receive_admin_response(rx).await
     }
 
     async fn is_conductor_enabled(&self) -> Result<bool, SequencerAdminAPIError> {
@@ -34,7 +68,7 @@ impl SequencerAdminAPIClient for QueuedSequencerAdminAPIClient {
         self.request_tx.send(SequencerAdminQuery::ConductorEnabled(tx)).await.map_err(|_| {
             SequencerAdminAPIError::RequestError("request channel closed".to_string())
         })?;
-        rx.await.map_err(|_| SequencerAdminAPIError::ResponseError)?
+        self.receive_admin_response(rx).await
     }
 
     async fn is_recovery_mode(&self) -> Result<bool, SequencerAdminAPIError> {
@@ -43,7 +77,7 @@ impl SequencerAdminAPIClient for QueuedSequencerAdminAPIClient {
         self.request_tx.send(SequencerAdminQuery::RecoveryMode(tx)).await.map_err(|_| {
             SequencerAdminAPIError::RequestError("request channel closed".to_string())
         })?;
-        rx.await.map_err(|_| SequencerAdminAPIError::ResponseError)?
+        self.receive_admin_response(rx).await
     }
 
     async fn start_sequencer(&self, unsafe_head: B256) -> Result<(), SequencerAdminAPIError> {
@@ -52,7 +86,7 @@ impl SequencerAdminAPIClient for QueuedSequencerAdminAPIClient {
         self.request_tx.send(SequencerAdminQuery::StartSequencer(unsafe_head, tx)).await.map_err(
             |_| SequencerAdminAPIError::RequestError("request channel closed".to_string()),
         )?;
-        rx.await.map_err(|_| SequencerAdminAPIError::ResponseError)?
+        self.receive_admin_response(rx).await
     }
 
     async fn stop_sequencer(&self) -> Result<B256, SequencerAdminAPIError> {
@@ -61,7 +95,7 @@ impl SequencerAdminAPIClient for QueuedSequencerAdminAPIClient {
         self.request_tx.send(SequencerAdminQuery::StopSequencer(tx)).await.map_err(|_| {
             SequencerAdminAPIError::RequestError("request channel closed".to_string())
         })?;
-        rx.await.map_err(|_| SequencerAdminAPIError::ResponseError)?
+        self.receive_admin_response(rx).await
     }
 
     async fn set_recovery_mode(&self, mode: bool) -> Result<(), SequencerAdminAPIError> {
@@ -70,7 +104,7 @@ impl SequencerAdminAPIClient for QueuedSequencerAdminAPIClient {
         self.request_tx.send(SequencerAdminQuery::SetRecoveryMode(mode, tx)).await.map_err(
             |_| SequencerAdminAPIError::RequestError("request channel closed".to_string()),
         )?;
-        rx.await.map_err(|_| SequencerAdminAPIError::ResponseError)?
+        self.receive_admin_response(rx).await
     }
 
     async fn override_leader(&self) -> Result<(), SequencerAdminAPIError> {
@@ -79,7 +113,7 @@ impl SequencerAdminAPIClient for QueuedSequencerAdminAPIClient {
         self.request_tx.send(SequencerAdminQuery::OverrideLeader(tx)).await.map_err(|_| {
             SequencerAdminAPIError::RequestError("request channel closed".to_string())
         })?;
-        rx.await.map_err(|_| SequencerAdminAPIError::ResponseError)?
+        self.receive_admin_response(rx).await
     }
 
     async fn reset_derivation_pipeline(&self) -> Result<(), SequencerAdminAPIError> {
@@ -88,6 +122,31 @@ impl SequencerAdminAPIClient for QueuedSequencerAdminAPIClient {
         self.request_tx.send(SequencerAdminQuery::ResetDerivationPipeline(tx)).await.map_err(
             |_| SequencerAdminAPIError::RequestError("request channel closed".to_string()),
         )?;
-        rx.await.map_err(|_| SequencerAdminAPIError::ResponseError)?
+        self.receive_admin_response(rx).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn is_sequencer_active_times_out_when_response_is_not_sent() {
+        let (request_tx, mut request_rx) = mpsc::channel(1);
+        let client = QueuedSequencerAdminAPIClient::new_with_options(
+            request_tx,
+            QueuedRpcClientOptions { request_timeout: Some(Duration::ZERO) },
+        );
+
+        let result = client.is_sequencer_active().await;
+
+        assert!(matches!(result, Err(SequencerAdminAPIError::ResponseTimeout)));
+        let request = request_rx.recv().await.expect("request should be queued");
+        assert!(
+            matches!(request, SequencerAdminQuery::SequencerActive(_)),
+            "expected queued sequencer-active query"
+        );
     }
 }

--- a/crates/consensus/service/src/lib.rs
+++ b/crates/consensus/service/src/lib.rs
@@ -33,12 +33,12 @@ pub use actors::{
     NetworkDriver, NetworkDriverError, NetworkEngineClient, NetworkHandler, NetworkInboundData,
     NodeActor, OriginSelector, PayloadBuilder, PayloadSealer, PendingStopSender, PoolActivation,
     QueuedDerivationEngineClient, QueuedEngineDerivationClient, QueuedEngineRpcClient,
-    QueuedL1WatcherDerivationClient, QueuedNetworkEngineClient, QueuedSequencerAdminAPIClient,
-    QueuedSequencerEngineClient, QueuedUnsafePayloadGossipClient, RecoveryModeGuard, ResetRequest,
-    RpcActor, RpcActorError, RpcContext, ScheduledTicker, SealRequest, SealState, SealStepError,
-    SequencerActor, SequencerActorError, SequencerAdminQuery, SequencerConfig,
-    SequencerEngineClient, UnsafePayloadGossipClient, UnsafePayloadGossipClientError,
-    UnsealedPayloadHandle,
+    QueuedL1WatcherDerivationClient, QueuedNetworkEngineClient, QueuedRpcClientOptions,
+    QueuedSequencerAdminAPIClient, QueuedSequencerEngineClient, QueuedUnsafePayloadGossipClient,
+    RecoveryModeGuard, ResetRequest, RpcActor, RpcActorError, RpcContext, ScheduledTicker,
+    SealRequest, SealState, SealStepError, SequencerActor, SequencerActorError,
+    SequencerAdminQuery, SequencerConfig, SequencerEngineClient, UnsafePayloadGossipClient,
+    UnsafePayloadGossipClientError, UnsealedPayloadHandle,
 };
 
 mod metrics;


### PR DESCRIPTION
## Summary

This adds shared queued RPC client options for consensus service clients. Existing constructors keep the historical no-timeout behavior, while new opt-in constructors can bound waits on accepted but unanswered engine RPC and sequencer admin requests. Tests cover the deterministic timeout path for both client types.