### PR TITLE
feat(consensus): Deterministic Sequencer Runtime Seam

### DIFF
--- a/crates/consensus/service/src/actors/mod.rs
+++ b/crates/consensus/service/src/actors/mod.rs
@@ -54,7 +54,8 @@ pub use sequencer::{
     L1OriginSelectorError, L1OriginSelectorProvider, OriginSelector, PayloadBuilder, PayloadSealer,
     PendingStopSender, PoolActivation, QueuedSequencerEngineClient, RecoveryModeGuard,
     ScheduledTicker, SealState, SealStepError, SequencerActor, SequencerActorError,
-    SequencerAdminQuery, SequencerConfig, SequencerEngineClient, UnsealedPayloadHandle,
+    SequencerAdminQuery, SequencerConfig, SequencerEngineClient, SequencerRuntime,
+    SequencerRuntimeFuture, SequencerTicker, TokioSequencerRuntime, UnsealedPayloadHandle,
 };
 #[cfg(test)]
 pub use sequencer::{MockConductor, MockOriginSelector, MockSequencerEngineClient};

--- a/crates/consensus/service/src/actors/sequencer/actor.rs
+++ b/crates/consensus/service/src/actors/sequencer/actor.rs
@@ -23,7 +23,6 @@ use crate::{
         SequencerEngineClient,
         engine::EngineClientError,
         sequencer::{
-            ScheduledTicker,
             build::{PayloadBuilder, UnsealedPayloadHandle},
             conductor::Conductor,
             error::SequencerActorError,
@@ -78,6 +77,8 @@ pub struct SequencerActor<
     pub recovery_mode: RecoveryModeGuard,
     /// The rollup configuration.
     pub rollup_config: Arc<RollupConfig>,
+    /// Runtime used for sequencer sleeps and block build ticks.
+    pub runtime: Arc<dyn super::SequencerRuntime>,
     /// A client to asynchronously sign and gossip built payloads to the network actor.
     pub unsafe_payload_gossip_client: UnsafePayloadGossipClient_,
     /// In-flight seal pipeline. [`Some`] while a sealed payload is being committed,
@@ -228,8 +229,7 @@ where
             }
             // Wait one block time before retrying the reset, but service admin queries
             // and honour cancellation throughout the backoff window.
-            let sleep = tokio::time::sleep(Duration::from_secs(self.rollup_config.block_time));
-            tokio::pin!(sleep);
+            let mut sleep = self.runtime.sleep(Duration::from_secs(self.rollup_config.block_time));
             loop {
                 select! {
                     biased;
@@ -271,7 +271,7 @@ where
 
     async fn start(mut self, _: Self::StartData) -> Result<(), Self::Error> {
         let mut build_ticker =
-            ScheduledTicker::new(Duration::from_secs(self.rollup_config.block_time));
+            self.runtime.ticker(Duration::from_secs(self.rollup_config.block_time));
 
         self.update_metrics();
 

--- a/crates/consensus/service/src/actors/sequencer/mod.rs
+++ b/crates/consensus/service/src/actors/sequencer/mod.rs
@@ -21,7 +21,10 @@ mod seal;
 pub use seal::{PayloadSealer, SealState, SealStepError};
 
 mod ticker;
-pub use ticker::ScheduledTicker;
+pub use ticker::{
+    ScheduledTicker, SequencerRuntime, SequencerRuntimeFuture, SequencerTicker,
+    TokioSequencerRuntime,
+};
 
 mod pool;
 pub use pool::PoolActivation;

--- a/crates/consensus/service/src/actors/sequencer/tests/actor_test.rs
+++ b/crates/consensus/service/src/actors/sequencer/tests/actor_test.rs
@@ -1,7 +1,12 @@
-use std::{sync::Arc, time::Duration};
+use std::{
+    collections::VecDeque,
+    sync::{Arc, Mutex},
+    time::{Duration, SystemTime},
+};
 
 use alloy_primitives::B256;
-use alloy_rpc_types_engine::ExecutionPayloadV1;
+use alloy_rpc_types_engine::{ExecutionPayloadV1, PayloadId};
+use async_trait::async_trait;
 use base_common_rpc_types_engine::{
     BaseExecutionPayload, BaseExecutionPayloadEnvelope, BasePayloadAttributes,
 };
@@ -10,15 +15,24 @@ use base_consensus_engine::SealTaskError;
 use base_protocol::{AttributesWithParent, BlockInfo, L2BlockInfo};
 use jsonrpsee::core::ClientError;
 use rstest::rstest;
+use tokio::{
+    sync::{Semaphore, mpsc, oneshot},
+    time::{Instant, timeout},
+};
+use tokio_util::sync::CancellationToken;
 
 use crate::{
-    ConductorError, SealState, SealStepError, SequencerActorError, UnsafePayloadGossipClientError,
-    UnsealedPayloadHandle,
+    Conductor, ConductorError, EngineClientResult, NodeActor, OriginSelector, SealState,
+    SealStepError, SequencerActor, SequencerActorError, SequencerAdminQuery, SequencerEngineClient,
+    SequencerRuntime, SequencerRuntimeFuture, SequencerTicker, UnsafePayloadGossipClient,
+    UnsafePayloadGossipClientError, UnsealedPayloadHandle,
     actors::{
         MockConductor, MockOriginSelector, MockSequencerEngineClient,
         MockUnsafePayloadGossipClient,
         engine::EngineClientError,
-        sequencer::{PayloadSealer, tests::test_util::test_actor},
+        sequencer::{
+            PayloadBuilder, PayloadSealer, RecoveryModeGuard, tests::test_util::test_actor,
+        },
     },
 };
 
@@ -81,6 +95,356 @@ fn head_at_with_hash(number: u64, hash: B256) -> L2BlockInfo {
         block_info: BlockInfo { number, hash, ..Default::default() },
         ..Default::default()
     }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SequencerLoopEvent {
+    Reset,
+    StartBuild,
+    GetSealedPayload,
+    CommitStarted,
+    CommitFinished,
+    GossipScheduled,
+    InsertUnsafePayload,
+}
+
+#[derive(Debug, Clone)]
+struct ManualSequencerRuntime {
+    sleeps: Arc<Semaphore>,
+    ticks: Arc<Semaphore>,
+}
+
+impl ManualSequencerRuntime {
+    fn new() -> Self {
+        Self { sleeps: Arc::new(Semaphore::new(0)), ticks: Arc::new(Semaphore::new(0)) }
+    }
+
+    fn tick(&self) {
+        self.ticks.add_permits(1);
+    }
+}
+
+impl SequencerRuntime for ManualSequencerRuntime {
+    fn ticker(&self, _period: Duration) -> Box<dyn SequencerTicker> {
+        Box::new(ManualSequencerTicker { ticks: Arc::clone(&self.ticks) })
+    }
+
+    fn sleep(&self, _duration: Duration) -> SequencerRuntimeFuture<'static, ()> {
+        let sleeps = Arc::clone(&self.sleeps);
+        Box::pin(async move {
+            let permit = sleeps.acquire_owned().await.expect("manual sleep semaphore is open");
+            drop(permit);
+        })
+    }
+}
+
+#[derive(Debug)]
+struct ManualSequencerTicker {
+    ticks: Arc<Semaphore>,
+}
+
+impl SequencerTicker for ManualSequencerTicker {
+    fn reset_at(&mut self, _target: SystemTime) {}
+
+    fn reset_immediately(&mut self) {}
+
+    fn tick(&mut self) -> SequencerRuntimeFuture<'_, Instant> {
+        let ticks = Arc::clone(&self.ticks);
+        Box::pin(async move {
+            let permit = ticks.acquire_owned().await.expect("manual tick semaphore is open");
+            drop(permit);
+            Instant::now()
+        })
+    }
+}
+
+#[derive(Debug)]
+struct SequencerLoopEngine {
+    events: mpsc::UnboundedSender<SequencerLoopEvent>,
+    head: L2BlockInfo,
+    reset_results: Mutex<VecDeque<EngineClientResult<()>>>,
+}
+
+impl SequencerLoopEngine {
+    fn new(
+        events: mpsc::UnboundedSender<SequencerLoopEvent>,
+        head: L2BlockInfo,
+        reset_results: Vec<EngineClientResult<()>>,
+    ) -> Self {
+        Self { events, head, reset_results: Mutex::new(reset_results.into()) }
+    }
+
+    fn send_event(&self, event: SequencerLoopEvent) {
+        self.events.send(event).expect("test event receiver is open");
+    }
+}
+
+#[async_trait]
+impl SequencerEngineClient for SequencerLoopEngine {
+    async fn reset_engine_forkchoice(&self) -> EngineClientResult<()> {
+        self.send_event(SequencerLoopEvent::Reset);
+        self.reset_results
+            .lock()
+            .expect("reset results lock is not poisoned")
+            .pop_front()
+            .unwrap_or(Ok(()))
+    }
+
+    async fn start_build_block(
+        &self,
+        _attributes: AttributesWithParent,
+    ) -> EngineClientResult<PayloadId> {
+        self.send_event(SequencerLoopEvent::StartBuild);
+        Ok(PayloadId::default())
+    }
+
+    async fn get_sealed_payload(
+        &self,
+        _payload_id: PayloadId,
+        _attributes: AttributesWithParent,
+    ) -> EngineClientResult<BaseExecutionPayloadEnvelope> {
+        self.send_event(SequencerLoopEvent::GetSealedPayload);
+        Ok(dummy_envelope())
+    }
+
+    async fn insert_unsafe_payload(
+        &self,
+        _payload: BaseExecutionPayloadEnvelope,
+    ) -> EngineClientResult<()> {
+        self.send_event(SequencerLoopEvent::InsertUnsafePayload);
+        Ok(())
+    }
+
+    async fn get_unsafe_head(&self) -> EngineClientResult<L2BlockInfo> {
+        Ok(self.head)
+    }
+}
+
+#[derive(Debug)]
+struct StaticOriginSelector;
+
+#[async_trait]
+impl OriginSelector for StaticOriginSelector {
+    async fn next_l1_origin(
+        &mut self,
+        _unsafe_head: L2BlockInfo,
+        _is_recovery_mode: bool,
+    ) -> Result<BlockInfo, crate::L1OriginSelectorError> {
+        Ok(BlockInfo::default())
+    }
+}
+
+#[derive(Debug, Clone)]
+struct BlockingConductor {
+    commits: Arc<Semaphore>,
+    events: mpsc::UnboundedSender<SequencerLoopEvent>,
+}
+
+impl BlockingConductor {
+    fn new(events: mpsc::UnboundedSender<SequencerLoopEvent>) -> Self {
+        Self { commits: Arc::new(Semaphore::new(0)), events }
+    }
+
+    fn complete_commit(&self) {
+        self.commits.add_permits(1);
+    }
+}
+
+#[async_trait]
+impl Conductor for BlockingConductor {
+    async fn leader(&self) -> Result<bool, ConductorError> {
+        Ok(true)
+    }
+
+    async fn active(&self) -> Result<bool, ConductorError> {
+        Ok(true)
+    }
+
+    async fn commit_unsafe_payload(
+        &self,
+        _payload: &BaseExecutionPayloadEnvelope,
+    ) -> Result<(), ConductorError> {
+        self.events.send(SequencerLoopEvent::CommitStarted).expect("test event receiver is open");
+        let permit =
+            Arc::clone(&self.commits).acquire_owned().await.expect("commit semaphore is open");
+        drop(permit);
+        self.events.send(SequencerLoopEvent::CommitFinished).expect("test event receiver is open");
+        Ok(())
+    }
+
+    async fn override_leader(&self) -> Result<(), ConductorError> {
+        Ok(())
+    }
+}
+
+#[derive(Debug)]
+struct RecordingGossip {
+    events: mpsc::UnboundedSender<SequencerLoopEvent>,
+}
+
+#[async_trait]
+impl UnsafePayloadGossipClient for RecordingGossip {
+    async fn schedule_execution_payload_gossip(
+        &self,
+        _payload: BaseExecutionPayloadEnvelope,
+    ) -> Result<(), UnsafePayloadGossipClientError> {
+        self.events.send(SequencerLoopEvent::GossipScheduled).expect("test event receiver is open");
+        Ok(())
+    }
+}
+
+fn loop_actor(
+    runtime: ManualSequencerRuntime,
+    engine_client: Arc<SequencerLoopEngine>,
+    admin_api_rx: mpsc::Receiver<SequencerAdminQuery>,
+    conductor: Option<BlockingConductor>,
+    gossip: RecordingGossip,
+) -> SequencerActor<
+    TestAttributesBuilder,
+    BlockingConductor,
+    StaticOriginSelector,
+    SequencerLoopEngine,
+    RecordingGossip,
+> {
+    let rollup_config = Arc::new(base_common_genesis::RollupConfig::default());
+    let recovery_mode = RecoveryModeGuard::new(false);
+    SequencerActor {
+        admin_api_rx,
+        builder: PayloadBuilder {
+            attributes_builder: TestAttributesBuilder {
+                attributes: vec![Ok(BasePayloadAttributes::default())],
+            },
+            engine_client: Arc::clone(&engine_client),
+            origin_selector: StaticOriginSelector,
+            recovery_mode: recovery_mode.clone(),
+            rollup_config: Arc::clone(&rollup_config),
+        },
+        cancellation_token: CancellationToken::new(),
+        conductor,
+        engine_client,
+        is_active: true,
+        recovery_mode,
+        rollup_config,
+        runtime: Arc::new(runtime),
+        unsafe_payload_gossip_client: gossip,
+        sealer: None,
+        pending_stop: None,
+        next_build_parent: None,
+    }
+}
+
+async fn expect_loop_event(
+    events: &mut mpsc::UnboundedReceiver<SequencerLoopEvent>,
+    expected: SequencerLoopEvent,
+) {
+    let event = timeout(Duration::from_secs(1), events.recv())
+        .await
+        .expect("timed out waiting for sequencer loop event")
+        .expect("sequencer loop event sender is open");
+    assert_eq!(event, expected);
+}
+
+#[tokio::test]
+async fn test_initial_reset_services_admin_query_during_backoff_sleep() {
+    let (event_tx, mut event_rx) = mpsc::unbounded_channel();
+    let runtime = ManualSequencerRuntime::new();
+    let head = head_at_with_hash(1, B256::from([0x11; 32]));
+    let engine_client = Arc::new(SequencerLoopEngine::new(
+        event_tx.clone(),
+        head,
+        vec![Err(EngineClientError::ELSyncing)],
+    ));
+    let (admin_tx, admin_rx) = mpsc::channel(4);
+    let actor =
+        loop_actor(runtime, engine_client, admin_rx, None, RecordingGossip { events: event_tx });
+    let cancellation = actor.cancellation_token.clone();
+    let actor_task = tokio::spawn(actor.start(()));
+
+    expect_loop_event(&mut event_rx, SequencerLoopEvent::Reset).await;
+
+    let (response_tx, response_rx) = oneshot::channel();
+    admin_tx
+        .send(SequencerAdminQuery::SequencerActive(response_tx))
+        .await
+        .expect("sequencer admin channel is open");
+    let response = timeout(Duration::from_secs(1), response_rx)
+        .await
+        .expect("sequencer active response timed out")
+        .expect("sequencer active response sender is open")
+        .expect("sequencer active query succeeds");
+    assert!(response);
+
+    cancellation.cancel();
+    let result = timeout(Duration::from_secs(1), actor_task)
+        .await
+        .expect("sequencer actor did not stop")
+        .expect("sequencer actor task did not panic");
+    assert!(result.is_ok());
+}
+
+#[tokio::test]
+async fn test_stop_sequencer_during_in_flight_seal_defers_until_insert_completes() {
+    let (event_tx, mut event_rx) = mpsc::unbounded_channel();
+    let runtime = ManualSequencerRuntime::new();
+    let head_hash = B256::from([0x22; 32]);
+    let head = head_at_with_hash(1, head_hash);
+    let engine_client = Arc::new(SequencerLoopEngine::new(event_tx.clone(), head, vec![Ok(())]));
+    let conductor = BlockingConductor::new(event_tx.clone());
+    let (admin_tx, admin_rx) = mpsc::channel(4);
+    let actor = loop_actor(
+        runtime.clone(),
+        engine_client,
+        admin_rx,
+        Some(conductor.clone()),
+        RecordingGossip { events: event_tx },
+    );
+    let cancellation = actor.cancellation_token.clone();
+    let actor_task = tokio::spawn(actor.start(()));
+
+    expect_loop_event(&mut event_rx, SequencerLoopEvent::Reset).await;
+    runtime.tick();
+    expect_loop_event(&mut event_rx, SequencerLoopEvent::StartBuild).await;
+    runtime.tick();
+    expect_loop_event(&mut event_rx, SequencerLoopEvent::GetSealedPayload).await;
+    expect_loop_event(&mut event_rx, SequencerLoopEvent::CommitStarted).await;
+
+    let (stop_tx, mut stop_rx) = oneshot::channel();
+    admin_tx
+        .send(SequencerAdminQuery::StopSequencer(stop_tx))
+        .await
+        .expect("sequencer admin channel is open");
+    let (active_tx, active_rx) = oneshot::channel();
+    admin_tx
+        .send(SequencerAdminQuery::SequencerActive(active_tx))
+        .await
+        .expect("sequencer admin channel is open");
+    let active = timeout(Duration::from_secs(1), active_rx)
+        .await
+        .expect("sequencer active response timed out")
+        .expect("sequencer active response sender is open")
+        .expect("sequencer active query succeeds");
+    assert!(!active);
+    assert!(matches!(stop_rx.try_recv(), Err(tokio::sync::oneshot::error::TryRecvError::Empty)));
+
+    conductor.complete_commit();
+
+    expect_loop_event(&mut event_rx, SequencerLoopEvent::CommitStarted).await;
+    expect_loop_event(&mut event_rx, SequencerLoopEvent::CommitFinished).await;
+    expect_loop_event(&mut event_rx, SequencerLoopEvent::GossipScheduled).await;
+    expect_loop_event(&mut event_rx, SequencerLoopEvent::InsertUnsafePayload).await;
+    let stop_head = timeout(Duration::from_secs(1), stop_rx)
+        .await
+        .expect("stop_sequencer response timed out")
+        .expect("stop_sequencer response sender is open")
+        .expect("stop_sequencer succeeds");
+    assert_eq!(stop_head, head_hash);
+
+    cancellation.cancel();
+    let result = timeout(Duration::from_secs(1), actor_task)
+        .await
+        .expect("sequencer actor did not stop")
+        .expect("sequencer actor task did not panic");
+    assert!(result.is_ok());
 }
 
 // --- try_seal_handle tests ---

--- a/crates/consensus/service/src/actors/sequencer/tests/test_util.rs
+++ b/crates/consensus/service/src/actors/sequencer/tests/test_util.rs
@@ -10,7 +10,7 @@ use crate::{
     actors::{
         MockConductor, MockOriginSelector, MockSequencerEngineClient,
         MockUnsafePayloadGossipClient,
-        sequencer::{PayloadBuilder, RecoveryModeGuard},
+        sequencer::{PayloadBuilder, RecoveryModeGuard, TokioSequencerRuntime},
     },
 };
 
@@ -43,6 +43,7 @@ pub(super) fn test_actor() -> SequencerActor<
         is_active: true,
         recovery_mode,
         rollup_config,
+        runtime: Arc::new(TokioSequencerRuntime),
         unsafe_payload_gossip_client: MockUnsafePayloadGossipClient::new(),
         sealer: None,
         pending_stop: None,

--- a/crates/consensus/service/src/actors/sequencer/ticker.rs
+++ b/crates/consensus/service/src/actors/sequencer/ticker.rs
@@ -5,11 +5,53 @@
 //! between target and actual fire is recorded to
 //! [`Metrics::sequencer_ticker_drift_seconds`]. Early fires record `0`.
 
-use std::time::{Duration, SystemTime};
+use std::{
+    future::Future,
+    pin::Pin,
+    time::{Duration, SystemTime},
+};
 
 use tokio::time::{Instant, Interval};
 
 use crate::Metrics;
+
+/// Boxed future returned by [`SequencerTicker`] and [`SequencerRuntime`].
+pub type SequencerRuntimeFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
+
+/// Runtime hook used by the sequencer actor for ordering-sensitive time operations.
+pub trait SequencerRuntime: std::fmt::Debug + Send + Sync {
+    /// Creates a ticker with the given period.
+    fn ticker(&self, period: Duration) -> Box<dyn SequencerTicker>;
+
+    /// Sleeps for the given duration.
+    fn sleep(&self, duration: Duration) -> SequencerRuntimeFuture<'static, ()>;
+}
+
+/// Ticker abstraction used by the sequencer actor.
+pub trait SequencerTicker: std::fmt::Debug + Send {
+    /// Reschedules the next tick for the given wall-clock target.
+    fn reset_at(&mut self, target: SystemTime);
+
+    /// Reschedules the next tick to fire immediately.
+    fn reset_immediately(&mut self);
+
+    /// Awaits the next tick.
+    fn tick(&mut self) -> SequencerRuntimeFuture<'_, Instant>;
+}
+
+/// Tokio-backed sequencer runtime used by production actors.
+#[derive(Debug, Default)]
+pub struct TokioSequencerRuntime;
+
+impl SequencerRuntime for TokioSequencerRuntime {
+    fn ticker(&self, period: Duration) -> Box<dyn SequencerTicker> {
+        Box::new(ScheduledTicker::new(period))
+    }
+
+    fn sleep(&self, duration: Duration) -> SequencerRuntimeFuture<'static, ()> {
+        Box::pin(tokio::time::sleep(duration))
+    }
+}
 
 /// A [`tokio::time::Interval`] that remembers its wall-clock target so the
 /// drift between intended and actual fire time can be observed transparently
@@ -63,5 +105,19 @@ impl ScheduledTicker {
             Metrics::sequencer_ticker_drift_seconds().record(drift);
         }
         instant
+    }
+}
+
+impl SequencerTicker for ScheduledTicker {
+    fn reset_at(&mut self, target: SystemTime) {
+        Self::reset_at(self, target);
+    }
+
+    fn reset_immediately(&mut self) {
+        Self::reset_immediately(self);
+    }
+
+    fn tick(&mut self) -> SequencerRuntimeFuture<'_, Instant> {
+        Box::pin(Self::tick(self))
     }
 }

--- a/crates/consensus/service/src/lib.rs
+++ b/crates/consensus/service/src/lib.rs
@@ -38,7 +38,8 @@ pub use actors::{
     QueuedSequencerAdminAPIClient, QueuedSequencerEngineClient, QueuedUnsafePayloadGossipClient,
     RecoveryModeGuard, ResetRequest, RpcActor, RpcActorError, RpcContext, ScheduledTicker,
     SealRequest, SealState, SealStepError, SequencerActor, SequencerActorError,
-    SequencerAdminQuery, SequencerConfig, SequencerEngineClient, UnsafePayloadGossipClient,
+    SequencerAdminQuery, SequencerConfig, SequencerEngineClient, SequencerRuntime,
+    SequencerRuntimeFuture, SequencerTicker, TokioSequencerRuntime, UnsafePayloadGossipClient,
     UnsafePayloadGossipClientError, UnsealedPayloadHandle,
 };
 

--- a/crates/consensus/service/src/service/node.rs
+++ b/crates/consensus/service/src/service/node.rs
@@ -33,7 +33,7 @@ use crate::{
     QueuedDerivationEngineClient, QueuedEngineDerivationClient, QueuedEngineRpcClient,
     QueuedL1WatcherDerivationClient, QueuedNetworkEngineClient, QueuedSequencerAdminAPIClient,
     QueuedSequencerEngineClient, RecoveryModeGuard, RpcActor, RpcContext, SequencerActor,
-    SequencerConfig,
+    SequencerConfig, TokioSequencerRuntime,
     actors::{BlockStream, NetworkInboundData, QueuedUnsafePayloadGossipClient},
 };
 
@@ -525,6 +525,7 @@ impl RollupNode {
                     is_active: self.sequencer_config.sequencer_stopped.not(),
                     recovery_mode,
                     rollup_config: Arc::clone(&self.config),
+                    runtime: Arc::new(TokioSequencerRuntime),
                     unsafe_payload_gossip_client: queued_gossip_client,
                     sealer: None,
                     pending_stop: None,


### PR DESCRIPTION
## Summary

This adds an injectable runtime seam for the sequencer actor's ticker and backoff sleep while preserving Tokio as the default production runtime. The new tests manually drive ticks, sleep, admin requests, and seal completion so the actor loop proves admin queries are serviced during reset backoff and stop_sequencer responses are deferred until an in-flight seal is inserted.