### PR TITLE
refactor(consensus): Move Consolidate Off Queue

### DIFF
--- a/crates/consensus/engine/README.md
+++ b/crates/consensus/engine/README.md
@@ -14,13 +14,13 @@ The `base-consensus-engine` crate provides an engine client for interacting with
 - **[`EngineClient`](crate::EngineClient)** - HTTP client for Engine API communication with JWT authentication
 - **[`EngineState`](crate::EngineState)** - Tracks the current state of the execution layer
 - **Task Types** - Specialized tasks for remaining queued engine operations:
-  - [`ConsolidateTask`](crate::ConsolidateTask) - Consolidate unsafe payloads to advance the safe chain
+  - [`DelegatedForkchoiceTask`](crate::DelegatedForkchoiceTask) - Apply delegated safe and finalized labels
   - [`FinalizeTask`](crate::FinalizeTask) - Finalize safe payloads on L1 confirmation
   - [`SynchronizeTask`](crate::SynchronizeTask) - Internal task for execution layer forkchoice synchronization
 
 ## Architecture
 
-The engine owns state directly. Sequencer build, get-payload, and insert operations call `Engine` methods directly, while remaining derived-state operations are still queued and executed atomically:
+The engine owns state directly. Sequencer build, get-payload, insert, and safe-head consolidation operations call `Engine` methods directly, while the remaining delegated forkchoice and finalize operations are still queued and executed atomically:
 
 ```text
 ┌─────────────┐    ┌──────────────┐    ┌─────────────┐

--- a/crates/consensus/engine/src/lib.rs
+++ b/crates/consensus/engine/src/lib.rs
@@ -11,12 +11,11 @@ extern crate tracing;
 
 mod task_queue;
 pub use task_queue::{
-    BuildTaskError, ConsolidateInput, ConsolidateTask, ConsolidateTaskError,
-    DelegatedForkchoiceTask, DelegatedForkchoiceTaskError, DelegatedForkchoiceUpdate, Engine,
-    EngineBuildError, EngineResetError, EngineTask, EngineTaskError, EngineTaskErrorSeverity,
-    EngineTaskErrors, EngineTaskExt, FinalizeTask, FinalizeTaskError, InsertPayloadSafety,
-    InsertTaskError, InsertTaskResult, SealTask, SealTaskError, SynchronizeTask,
-    SynchronizeTaskError,
+    BuildTaskError, ConsolidateInput, ConsolidateTaskError, DelegatedForkchoiceTask,
+    DelegatedForkchoiceTaskError, DelegatedForkchoiceUpdate, Engine, EngineBuildError,
+    EngineResetError, EngineTask, EngineTaskError, EngineTaskErrorSeverity, EngineTaskErrors,
+    EngineTaskExt, FinalizeTask, FinalizeTaskError, InsertPayloadSafety, InsertTaskError,
+    InsertTaskResult, SealTask, SealTaskError, SynchronizeTask, SynchronizeTaskError,
 };
 
 mod attributes;

--- a/crates/consensus/engine/src/task_queue/core.rs
+++ b/crates/consensus/engine/src/task_queue/core.rs
@@ -16,13 +16,13 @@ use base_protocol::{AttributesWithParent, BaseBlockConversionError, L2BlockInfo}
 use thiserror::Error;
 use tokio::{sync::watch::Sender, task::yield_now};
 
-use super::EngineTaskExt;
+use super::{EngineTaskExt, build_and_seal};
 use crate::{
-    BuildTaskError, EngineBuildError, EngineClient, EngineForkchoiceVersion,
-    EngineGetPayloadVersion, EngineState, EngineSyncStateUpdate, EngineTask, EngineTaskError,
-    EngineTaskErrorSeverity, InsertPayloadSafety, InsertTaskError, InsertTaskResult, Metrics,
-    SealTaskError, SyncStartError, SynchronizeTask, SynchronizeTaskError, find_starting_forkchoice,
-    task_queue::EngineTaskErrors,
+    BuildTaskError, ConsolidateInput, ConsolidateTaskError, EngineBuildError, EngineClient,
+    EngineForkchoiceVersion, EngineGetPayloadVersion, EngineState, EngineSyncStateUpdate,
+    EngineTask, EngineTaskError, EngineTaskErrorSeverity, InsertPayloadSafety, InsertTaskError,
+    InsertTaskResult, Metrics, SealTaskError, SyncStartError, SynchronizeTask,
+    SynchronizeTaskError, find_starting_forkchoice, task_queue::EngineTaskErrors,
 };
 
 /// The [`Engine`] task queue.
@@ -418,6 +418,276 @@ impl<EngineClient_: EngineClient> Engine<EngineClient_> {
     /// Checks the response of the `engine_newPayload` call.
     pub const fn check_new_payload_status(status: &PayloadStatusEnum) -> bool {
         matches!(status, PayloadStatusEnum::Valid | PayloadStatusEnum::Syncing)
+    }
+
+    /// Consolidates the safe head directly against the execution layer.
+    pub async fn consolidate(
+        &mut self,
+        client: Arc<EngineClient_>,
+        config: Arc<RollupConfig>,
+        input: ConsolidateInput,
+    ) -> Result<(), ConsolidateTaskError> {
+        let _task_timer =
+            base_metrics::timed!(Metrics::engine_task_duration(Metrics::CONSOLIDATE_TASK_LABEL));
+
+        loop {
+            match Self::consolidate_with_state(
+                &mut self.state,
+                Arc::clone(&client),
+                Arc::clone(&config),
+                input.clone(),
+            )
+            .await
+            {
+                Ok(()) => {
+                    self.state_sender.send_replace(self.state);
+                    Metrics::engine_task_count(Metrics::CONSOLIDATE_TASK_LABEL).increment(1);
+                    return Ok(());
+                }
+                Err(err) => {
+                    let severity = err.severity();
+                    Metrics::engine_task_failure(
+                        Metrics::CONSOLIDATE_TASK_LABEL,
+                        severity.as_label(),
+                    )
+                    .increment(1);
+
+                    match severity {
+                        EngineTaskErrorSeverity::Temporary => {
+                            trace!(target: "engine", error = %err, "Temporary engine error");
+                            yield_now().await;
+                        }
+                        EngineTaskErrorSeverity::Critical => {
+                            error!(target: "engine", error = %err, "Critical engine error");
+                            return Err(err);
+                        }
+                        EngineTaskErrorSeverity::Reset => {
+                            warn!(target: "engine", "Engine requested derivation reset");
+                            return Err(err);
+                        }
+                        EngineTaskErrorSeverity::Flush => {
+                            warn!(target: "engine", "Engine requested derivation flush");
+                            return Err(err);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /// Consolidates the safe head using the provided engine state.
+    pub async fn consolidate_with_state(
+        state: &mut EngineState,
+        client: Arc<EngineClient_>,
+        config: Arc<RollupConfig>,
+        input: ConsolidateInput,
+    ) -> Result<(), ConsolidateTaskError> {
+        // Behavior depends on how the safe head is provided:
+        //
+        // - `Attributes`: The safe head is advanced through the normal derivation flow, where the
+        //   DerivationActor and EngineActor coordinate both safe and unsafe heads. In this case, we
+        //   consolidate as long as the unsafe head has not fallen behind.
+        //
+        // - `BlockInfo`: The safe head is injected externally by the DerivationActor while
+        //   delegating derivation, and is not coordinated with the EngineActor's safe/unsafe heads.
+        //   If the injected safe head is ahead of the EngineActor's unsafe head, we reconcile the
+        //   unsafe chain up to the safe head instead of consolidating.
+        let safe_head_number = match &input {
+            ConsolidateInput::Attributes { .. } => state.sync_state.safe_head().block_info.number,
+            ConsolidateInput::BlockInfo(safe_block_info) => safe_block_info.block_info.number,
+        };
+        if safe_head_number < state.sync_state.unsafe_head().block_info.number {
+            Self::consolidate_safe_head(state, client, config, input).await
+        } else {
+            Self::reconcile_unsafe_to_safe(state, client, config, &input).await
+        }
+    }
+
+    /// Rebuilds and seals attributes when consolidation cannot use the current unsafe block.
+    pub async fn build_and_seal_safe_payload(
+        state: &mut EngineState,
+        client: Arc<EngineClient_>,
+        config: Arc<RollupConfig>,
+        attributes: &AttributesWithParent,
+    ) -> Result<(), ConsolidateTaskError> {
+        build_and_seal(state, client, config, attributes.clone(), InsertPayloadSafety::Safe)
+            .await?;
+
+        Ok(())
+    }
+
+    /// Reconciles the engine unsafe, local safe, and safe heads to an externally supplied safe head.
+    pub async fn reconcile_to_safe_head(
+        state: &mut EngineState,
+        client: Arc<EngineClient_>,
+        config: Arc<RollupConfig>,
+        safe_l2: &L2BlockInfo,
+    ) -> Result<(), ConsolidateTaskError> {
+        warn!(
+            target: "engine",
+            safe_l2 = %safe_l2,
+            "Apply safe head"
+        );
+
+        let fcu_start = Instant::now();
+
+        // We intentionally set unsafe_head to safe_l2 to ensure the engine observes a
+        // self-consistent head state. This is required to correctly handle reorgs (where unsafe
+        // may be ahead on a non-canonical fork) and to trigger EL sync when the local unsafe head
+        // lags behind the safe head.
+        SynchronizeTask::new(
+            client,
+            config,
+            EngineSyncStateUpdate {
+                unsafe_head: Some(*safe_l2),
+                local_safe_head: Some(*safe_l2),
+                safe_head: Some(*safe_l2),
+                ..Default::default()
+            },
+        )
+        .execute(state)
+        .await
+        .map_err(|e| {
+            warn!(target: "engine", error = ?e, "Apply safe head failed");
+            e
+        })?;
+
+        let fcu_duration = fcu_start.elapsed();
+
+        info!(
+            target: "engine",
+            hash = %safe_l2.block_info.hash,
+            number = safe_l2.block_info.number,
+            fcu_duration = ?fcu_duration,
+            "Updated safe head via follow safe"
+        );
+
+        Ok(())
+    }
+
+    /// Reconciles the unsafe chain to the safe input when direct consolidation cannot be used.
+    pub async fn reconcile_unsafe_to_safe(
+        state: &mut EngineState,
+        client: Arc<EngineClient_>,
+        config: Arc<RollupConfig>,
+        input: &ConsolidateInput,
+    ) -> Result<(), ConsolidateTaskError> {
+        match input {
+            ConsolidateInput::Attributes(attributes) => {
+                Self::build_and_seal_safe_payload(state, client, config, attributes).await
+            }
+            ConsolidateInput::BlockInfo(safe_l2) => {
+                Self::reconcile_to_safe_head(state, client, config, safe_l2).await
+            }
+        }
+    }
+
+    /// Consolidates the safe head by checking the current unsafe block against the input.
+    pub async fn consolidate_safe_head(
+        state: &mut EngineState,
+        client: Arc<EngineClient_>,
+        config: Arc<RollupConfig>,
+        input: ConsolidateInput,
+    ) -> Result<(), ConsolidateTaskError> {
+        let global_start = Instant::now();
+
+        let block_num = input.l2_block_number();
+        let fetch_start = Instant::now();
+        let block = match client.l2_block_by_label(block_num.into()).await {
+            Ok(Some(block)) => block,
+            Ok(None) => {
+                warn!(target: "engine", block_num, "Received `None` block");
+                return Err(ConsolidateTaskError::MissingUnsafeL2Block(block_num));
+            }
+            Err(_) => {
+                warn!(target: "engine", "Failed to fetch unsafe l2 block for consolidation");
+                return Err(ConsolidateTaskError::FailedToFetchUnsafeL2Block);
+            }
+        };
+        let block_fetch_duration = fetch_start.elapsed();
+        let block_hash = block.header.hash;
+
+        if input.is_consistent_with_block(&config, &block) {
+            trace!(
+                target: "engine",
+                input = ?input,
+                block_hash = %block_hash,
+                "Consolidating engine state",
+            );
+            match L2BlockInfo::from_block_and_genesis(
+                &block.into_consensus().map_transactions(|tx| tx.inner.inner.into_inner()),
+                &config.genesis,
+            ) {
+                // Only issue a forkchoice update if the attributes are the last in the span
+                // batch. This is an optimization to avoid sending a FCU call for every block in
+                // the span batch.
+                Ok(block_info) if !input.is_attributes_last_in_span() => {
+                    let total_duration = global_start.elapsed();
+
+                    state.sync_state = state.sync_state.apply_update(EngineSyncStateUpdate {
+                        local_safe_head: Some(block_info),
+                        safe_head: Some(block_info),
+                        ..Default::default()
+                    });
+
+                    info!(
+                        target: "engine",
+                        hash = %block_info.block_info.hash,
+                        number = block_info.block_info.number,
+                        ?total_duration,
+                        ?block_fetch_duration,
+                        "Updated safe head via L1 consolidation"
+                    );
+
+                    return Ok(());
+                }
+                Ok(block_info) => {
+                    let fcu_start = Instant::now();
+
+                    SynchronizeTask::new(
+                        Arc::clone(&client),
+                        Arc::clone(&config),
+                        EngineSyncStateUpdate {
+                            local_safe_head: Some(block_info),
+                            safe_head: Some(block_info),
+                            ..Default::default()
+                        },
+                    )
+                    .execute(state)
+                    .await
+                    .map_err(|e| {
+                        warn!(target: "engine", error = ?e, "Consolidation failed");
+                        e
+                    })?;
+
+                    let fcu_duration = fcu_start.elapsed();
+                    let total_duration = global_start.elapsed();
+
+                    info!(
+                        target: "engine",
+                        hash = %block_info.block_info.hash,
+                        number = block_info.block_info.number,
+                        ?total_duration,
+                        ?block_fetch_duration,
+                        fcu_duration = ?fcu_duration,
+                        "Updated safe head via L1 consolidation"
+                    );
+
+                    return Ok(());
+                }
+                Err(e) => {
+                    warn!(target: "engine", error = ?e, "Failed to construct L2BlockInfo, proceeding to build task");
+                }
+            }
+        }
+
+        debug!(
+            target: "engine",
+            input = ?input,
+            block_hash = %block_hash,
+            "ConsolidateInput mismatch! Initiating reorg",
+        );
+        Self::reconcile_unsafe_to_safe(state, client, config, &input).await
     }
 
     /// Validates a forkchoice update status returned while starting a build.

--- a/crates/consensus/engine/src/task_queue/tasks/consolidate/error.rs
+++ b/crates/consensus/engine/src/task_queue/tasks/consolidate/error.rs
@@ -1,4 +1,4 @@
-//! Contains error types for the [`crate::ConsolidateTask`].
+//! Contains error types for direct engine consolidation.
 
 use thiserror::Error;
 
@@ -7,7 +7,7 @@ use crate::{
     task_queue::tasks::{BuildAndSealError, task::EngineTaskErrorSeverity},
 };
 
-/// An error that occurs when running the [`crate::ConsolidateTask`].
+/// An error that occurs when consolidating the engine state.
 #[derive(Debug, Error)]
 pub enum ConsolidateTaskError {
     /// The unsafe L2 block is missing.

--- a/crates/consensus/engine/src/task_queue/tasks/consolidate/mod.rs
+++ b/crates/consensus/engine/src/task_queue/tasks/consolidate/mod.rs
@@ -4,7 +4,7 @@ mod error;
 pub use error::ConsolidateTaskError;
 
 mod task;
-pub use task::{ConsolidateInput, ConsolidateTask};
+pub use task::ConsolidateInput;
 
 #[cfg(test)]
 mod task_test;

--- a/crates/consensus/engine/src/task_queue/tasks/consolidate/task.rs
+++ b/crates/consensus/engine/src/task_queue/tasks/consolidate/task.rs
@@ -1,17 +1,9 @@
-//! A task to consolidate the engine state.
-
-use std::{sync::Arc, time::Instant};
+//! Input types for safe-head consolidation.
 
 use alloy_rpc_types_eth::Block;
-use async_trait::async_trait;
 use base_common_genesis::RollupConfig;
 use base_common_rpc_types::Transaction;
 use base_protocol::{AttributesWithParent, L2BlockInfo};
-
-use crate::{
-    ConsolidateTaskError, EngineClient, EngineState, EngineTaskExt, InsertPayloadSafety,
-    SynchronizeTask, state::EngineSyncStateUpdate, task_queue::build_and_seal,
-};
 
 /// Input for consolidation - either derived attributes or safe L2 block
 #[derive(Debug, Clone)]
@@ -36,7 +28,7 @@ impl From<AttributesWithParent> for ConsolidateInput {
 
 impl ConsolidateInput {
     /// Returns the block number for this consolidation input.
-    const fn l2_block_number(&self) -> u64 {
+    pub const fn l2_block_number(&self) -> u64 {
         match self {
             Self::Attributes(attributes) => attributes.block_number(),
             Self::BlockInfo(info) => info.block_info.number,
@@ -44,7 +36,7 @@ impl ConsolidateInput {
     }
 
     /// Checks if the block is consistent with this consolidation input.
-    fn is_consistent_with_block(&self, cfg: &RollupConfig, block: &Block<Transaction>) -> bool {
+    pub fn is_consistent_with_block(&self, cfg: &RollupConfig, block: &Block<Transaction>) -> bool {
         match self {
             Self::Attributes(attributes) => {
                 crate::AttributesMatch::check(cfg, attributes, block).is_match()
@@ -54,252 +46,11 @@ impl ConsolidateInput {
     }
 
     /// Returns true if this is `Attributes` and `attributes.is_last_in_span` is true.
-    const fn is_attributes_last_in_span(&self) -> bool {
+    pub const fn is_attributes_last_in_span(&self) -> bool {
         matches!(
             self,
             Self::Attributes(attributes)
                 if attributes.is_last_in_span
         )
-    }
-}
-
-/// The [`ConsolidateTask`] attempts to consolidate the engine state
-/// using the specified payload attributes or block info.
-#[derive(Debug, Clone)]
-pub struct ConsolidateTask<EngineClient_: EngineClient> {
-    /// The engine client.
-    pub client: Arc<EngineClient_>,
-    /// The [`RollupConfig`].
-    pub cfg: Arc<RollupConfig>,
-    /// The input for consolidation (either attributes or block info).
-    pub input: ConsolidateInput,
-}
-
-impl<EngineClient_: EngineClient> ConsolidateTask<EngineClient_> {
-    /// Creates a new [`ConsolidateTask`] with the specified input
-    pub const fn new(
-        client: Arc<EngineClient_>,
-        cfg: Arc<RollupConfig>,
-        input: ConsolidateInput,
-    ) -> Self {
-        Self { client, cfg, input }
-    }
-
-    /// This is used when the [`ConsolidateTask`] fails to consolidate the engine state
-    async fn execute_build_and_seal_tasks(
-        &self,
-        state: &mut EngineState,
-        attributes: &AttributesWithParent,
-    ) -> Result<(), ConsolidateTaskError> {
-        build_and_seal(
-            state,
-            Arc::clone(&self.client),
-            Arc::clone(&self.cfg),
-            attributes.clone(),
-            InsertPayloadSafety::Safe,
-        )
-        .await?;
-
-        Ok(())
-    }
-
-    /// This provides symmetric fallback behavior to with `build_and_seal`.
-    async fn reconcile_to_safe_head(
-        &self,
-        state: &mut EngineState,
-        safe_l2: &L2BlockInfo,
-    ) -> Result<(), ConsolidateTaskError> {
-        warn!(
-            target: "engine",
-            safe_l2 = %safe_l2,
-            "Apply safe head"
-        );
-
-        let fcu_start = Instant::now();
-
-        // We intentionally set unsafe_head to safe_l2 to ensure the engine observes a
-        // self-consistent head state. This is required to correctly handle reorgs (where unsafe
-        // may be ahead on a non-canonical fork) and to trigger EL sync when the local unsafe head
-        // lags behind the safe head.
-        SynchronizeTask::new(
-            Arc::clone(&self.client),
-            Arc::clone(&self.cfg),
-            EngineSyncStateUpdate {
-                unsafe_head: Some(*safe_l2),
-                local_safe_head: Some(*safe_l2),
-                safe_head: Some(*safe_l2),
-                ..Default::default()
-            },
-        )
-        .execute(state)
-        .await
-        .map_err(|e| {
-            warn!(target: "engine", error = ?e, "Apply safe head failed");
-            e
-        })?;
-
-        let fcu_duration = fcu_start.elapsed();
-
-        info!(
-            target: "engine",
-            hash = %safe_l2.block_info.hash,
-            number = safe_l2.block_info.number,
-            fcu_duration = ?fcu_duration,
-            "Updated safe head via follow safe"
-        );
-
-        Ok(())
-    }
-
-    /// Handles the fallback case when the block doesn't match the input or does not exist.
-    async fn reconcile_unsafe_to_safe(
-        &self,
-        state: &mut EngineState,
-    ) -> Result<(), ConsolidateTaskError> {
-        match &self.input {
-            ConsolidateInput::Attributes(attributes) => {
-                self.execute_build_and_seal_tasks(state, attributes).await
-            }
-            ConsolidateInput::BlockInfo(safe_l2) => {
-                self.reconcile_to_safe_head(state, safe_l2).await
-            }
-        }
-    }
-
-    /// Attempts consolidation on the engine state.
-    pub async fn consolidate(&self, state: &mut EngineState) -> Result<(), ConsolidateTaskError> {
-        let global_start = Instant::now();
-
-        // Fetch the unsafe L2 block
-        let block_num = self.input.l2_block_number();
-        let fetch_start = Instant::now();
-        let block = match self.client.l2_block_by_label(block_num.into()).await {
-            Ok(Some(block)) => block,
-            Ok(None) => {
-                warn!(target: "engine", block_num, "Received `None` block");
-                return Err(ConsolidateTaskError::MissingUnsafeL2Block(block_num));
-            }
-            Err(_) => {
-                warn!(target: "engine", "Failed to fetch unsafe l2 block for consolidation");
-                return Err(ConsolidateTaskError::FailedToFetchUnsafeL2Block);
-            }
-        };
-        let block_fetch_duration = fetch_start.elapsed();
-        let block_hash = block.header.hash;
-
-        if self.input.is_consistent_with_block(&self.cfg, &block) {
-            trace!(
-                target: "engine",
-                input = ?self.input,
-                block_hash = %block_hash,
-                "Consolidating engine state",
-            );
-            match L2BlockInfo::from_block_and_genesis(
-                &block.into_consensus().map_transactions(|tx| tx.inner.inner.into_inner()),
-                &self.cfg.genesis,
-            ) {
-                // Only issue a forkchoice update if the attributes are the last in the span
-                // batch. This is an optimization to avoid sending a FCU
-                // call for every block in the span batch.
-                Ok(block_info) if !self.input.is_attributes_last_in_span() => {
-                    let total_duration = global_start.elapsed();
-
-                    // Apply a transient update to the safe head.
-                    state.sync_state = state.sync_state.apply_update(EngineSyncStateUpdate {
-                        local_safe_head: Some(block_info),
-                        safe_head: Some(block_info),
-                        ..Default::default()
-                    });
-
-                    info!(
-                        target: "engine",
-                        hash = %block_info.block_info.hash,
-                        number = block_info.block_info.number,
-                        ?total_duration,
-                        ?block_fetch_duration,
-                        "Updated safe head via L1 consolidation"
-                    );
-
-                    return Ok(());
-                }
-                Ok(block_info) => {
-                    let fcu_start = Instant::now();
-
-                    SynchronizeTask::new(
-                        Arc::clone(&self.client),
-                        Arc::clone(&self.cfg),
-                        EngineSyncStateUpdate {
-                            local_safe_head: Some(block_info),
-                            safe_head: Some(block_info),
-                            ..Default::default()
-                        },
-                    )
-                    .execute(state)
-                    .await
-                    .map_err(|e| {
-                        warn!(target: "engine", error = ?e, "Consolidation failed");
-                        e
-                    })?;
-
-                    let fcu_duration = fcu_start.elapsed();
-                    let total_duration = global_start.elapsed();
-
-                    info!(
-                        target: "engine",
-                        hash = %block_info.block_info.hash,
-                        number = block_info.block_info.number,
-                        ?total_duration,
-                        ?block_fetch_duration,
-                        fcu_duration = ?fcu_duration,
-                        "Updated safe head via L1 consolidation"
-                    );
-
-                    return Ok(());
-                }
-                Err(e) => {
-                    // Continue on to build the block since we failed to construct the block info.
-                    warn!(target: "engine", error = ?e, "Failed to construct L2BlockInfo, proceeding to build task");
-                }
-            }
-        }
-
-        debug!(
-            target: "engine",
-            input = ?self.input,
-            block_hash = %block_hash,
-            "ConsolidateInput mismatch! Initiating reorg",
-        );
-        // Handle mismatch case - called when consistency check fails
-        // or when L2BlockInfo construction fails in Attributes branch
-        self.reconcile_unsafe_to_safe(state).await
-    }
-}
-
-#[async_trait]
-impl<EngineClient_: EngineClient> EngineTaskExt for ConsolidateTask<EngineClient_> {
-    type Output = ();
-
-    type Error = ConsolidateTaskError;
-
-    // Behavior depends on how the safe head is provided:
-    //
-    // - `Attributes`: The safe head is advanced through the normal derivation flow, where the
-    //   DerivationActor and EngineActor coordinate both safe and unsafe heads. In this case, we
-    //   consolidate as long as the unsafe head has not fallen behind.
-    //
-    // - `BlockInfo`: The safe head is injected externally by the DerivationActor while delegating
-    //   derivation, and is not coordinated with the EngineActor's safe/unsafe heads. If the
-    //   injected safe head is ahead of the EngineActor's unsafe head, we reconcile the unsafe chain
-    //   up to the safe head instead of consolidating.
-    async fn execute(&self, state: &mut EngineState) -> Result<(), ConsolidateTaskError> {
-        let safe_head_number = match &self.input {
-            ConsolidateInput::Attributes { .. } => state.sync_state.safe_head().block_info.number,
-            ConsolidateInput::BlockInfo(safe_block_info) => safe_block_info.block_info.number,
-        };
-        if safe_head_number < state.sync_state.unsafe_head().block_info.number {
-            self.consolidate(state).await
-        } else {
-            self.reconcile_unsafe_to_safe(state).await
-        }
     }
 }

--- a/crates/consensus/engine/src/task_queue/tasks/consolidate/task_test.rs
+++ b/crates/consensus/engine/src/task_queue/tasks/consolidate/task_test.rs
@@ -1,4 +1,4 @@
-//! Tests for `ConsolidateTask::execute`
+//! Tests for direct engine consolidation.
 
 use std::sync::Arc;
 
@@ -13,7 +13,7 @@ use base_common_rpc_types::Transaction as BaseTransaction;
 use base_protocol::L1BlockInfoBedrock;
 
 use crate::{
-    AttributesMatch, AttributesMismatch, ConsolidateTask, EngineTaskExt,
+    AttributesMatch, AttributesMismatch, Engine,
     task_queue::tasks::consolidate::task::ConsolidateInput,
     test_utils::{TestAttributesBuilder, TestEngineStateBuilder, test_engine_client_builder},
 };
@@ -94,18 +94,18 @@ async fn consolidate_does_not_crash_when_safe_behind_unsafe_and_attributes_misma
             .build(),
     );
 
-    let task = ConsolidateTask::new(
+    let result = Engine::consolidate_with_state(
+        &mut state,
         client,
         Arc::new(RollupConfig::default()),
         ConsolidateInput::from(attributes),
-    );
+    )
+    .await;
 
-    // Execute — previously this returned Critical UnsafeHeadChangedSinceBuild.
+    // Execute consolidation — previously this returned Critical UnsafeHeadChangedSinceBuild.
     // Now it proceeds to seal_and_canonicalize_block (which will fail for other
     // reasons in a mock environment, but crucially NOT with the stale-unsafe-head
     // check that caused the crash loop).
-    let result = task.execute(&mut state).await;
-
     // The task may still error (e.g. GetPayload fails in the mock) but it must
     // NOT be the stale-unsafe-head error that caused the crash loop.
     // The Display string for SealTaskError::UnsafeHeadChangedSinceBuild is
@@ -160,9 +160,13 @@ async fn consolidate_rejects_attribute_transaction_with_trailing_bytes() {
             .with_l2_block_by_label(BlockNumberOrTag::Number(block_number), unsafe_block)
             .build(),
     );
-    let task = ConsolidateTask::new(client, Arc::new(cfg), ConsolidateInput::from(attributes));
-
-    let result = task.execute(&mut state).await;
+    let result = Engine::consolidate_with_state(
+        &mut state,
+        client,
+        Arc::new(cfg),
+        ConsolidateInput::from(attributes),
+    )
+    .await;
 
     assert!(result.is_err());
     assert_eq!(state.sync_state.safe_head(), original_safe_head);

--- a/crates/consensus/engine/src/task_queue/tasks/delegated_forkchoice/task.rs
+++ b/crates/consensus/engine/src/task_queue/tasks/delegated_forkchoice/task.rs
@@ -8,7 +8,7 @@ use base_protocol::L2BlockInfo;
 use derive_more::Constructor;
 
 use crate::{
-    ConsolidateInput, ConsolidateTask, DelegatedForkchoiceTaskError, EngineClient, EngineState,
+    ConsolidateInput, DelegatedForkchoiceTaskError, Engine, EngineClient, EngineState,
     EngineTaskExt, FinalizeTask,
 };
 
@@ -38,12 +38,12 @@ impl<EngineClient_: EngineClient> EngineTaskExt for DelegatedForkchoiceTask<Engi
     type Error = DelegatedForkchoiceTaskError;
 
     async fn execute(&self, state: &mut EngineState) -> Result<(), Self::Error> {
-        ConsolidateTask::new(
+        Engine::<EngineClient_>::consolidate_with_state(
+            state,
             Arc::clone(&self.client),
             Arc::clone(&self.cfg),
             ConsolidateInput::BlockInfo(self.update.safe_l2),
         )
-        .execute(state)
         .await?;
 
         let actual_safe = state.sync_state.safe_head().block_info.number;

--- a/crates/consensus/engine/src/task_queue/tasks/mod.rs
+++ b/crates/consensus/engine/src/task_queue/tasks/mod.rs
@@ -18,7 +18,7 @@ mod seal;
 pub use seal::{SealTask, SealTaskError};
 
 mod consolidate;
-pub use consolidate::{ConsolidateInput, ConsolidateTask, ConsolidateTaskError};
+pub use consolidate::{ConsolidateInput, ConsolidateTaskError};
 
 mod delegated_forkchoice;
 pub use delegated_forkchoice::{

--- a/crates/consensus/engine/src/task_queue/tasks/synchronize/task.rs
+++ b/crates/consensus/engine/src/task_queue/tasks/synchronize/task.rs
@@ -21,7 +21,7 @@ use crate::{
 ///
 /// ## Usage Patterns
 ///
-/// - **Internal Synchronization**: Called by direct insert processing, [`ConsolidateTask`], and
+/// - **Internal Synchronization**: Called by direct insert/consolidate processing and
 ///   [`FinalizeTask`]
 /// - **Engine Reset**: Used during engine resets to establish initial forkchoice state
 /// - **Safe Head Updates**: Synchronizes safe and finalized head changes
@@ -32,7 +32,6 @@ use crate::{
 /// explicitly handled within direct build processing, eliminating the need for explicit
 /// forkchoice management in most user scenarios.
 ///
-/// [`ConsolidateTask`]: crate::ConsolidateTask  
 /// [`FinalizeTask`]: crate::FinalizeTask
 #[derive(Debug, Clone, Constructor)]
 pub struct SynchronizeTask<EngineClient_: EngineClient> {
@@ -105,7 +104,7 @@ impl<EngineClient_: EngineClient> EngineTaskExt for SynchronizeTask<EngineClient
         //
         // NOTE:
         // We shouldn't retry the synchronize task there. Since the `sync_state` is only updated
-        // inside the `SynchronizeTask` (except inside the ConsolidateTask, when the block is not
+        // inside the `SynchronizeTask` (except during consolidation, when the block is not
         // the last in the batch) - the engine will get stuck retrying the `SynchronizeTask`
         if state.sync_state != Default::default() && state.sync_state == new_sync_state {
             debug!(target: "engine", ?new_sync_state, "No forkchoice update needed");

--- a/crates/consensus/engine/src/task_queue/tasks/task.rs
+++ b/crates/consensus/engine/src/task_queue/tasks/task.rs
@@ -9,11 +9,10 @@ use derive_more::Display;
 use thiserror::Error;
 use tokio::task::yield_now;
 
-use super::{ConsolidateTask, DelegatedForkchoiceTask, FinalizeTask};
+use super::{DelegatedForkchoiceTask, FinalizeTask, SealTaskError};
 use crate::{
     BuildTaskError, ConsolidateTaskError, DelegatedForkchoiceTaskError, EngineClient, EngineState,
     FinalizeTaskError, InsertTaskError, Metrics,
-    task_queue::{SealTask, SealTaskError},
 };
 
 /// The severity of an engine task error.
@@ -110,12 +109,6 @@ impl EngineTaskError for EngineTaskErrors {
 /// [`Engine`]: crate::Engine
 #[derive(Debug, Clone)]
 pub enum EngineTask<EngineClient_: EngineClient> {
-    /// Seals the block with the given payload ID and attributes, inserting it into the execution
-    /// engine.
-    Seal(Box<SealTask<EngineClient_>>),
-    /// Performs consolidation on the engine state, reverting to payload attribute processing
-    /// via the direct build-and-seal fallback if consolidation fails.
-    Consolidate(Box<ConsolidateTask<EngineClient_>>),
     /// Applies delegated safe and finalized labels for follow mode.
     DelegatedForkchoice(Box<DelegatedForkchoiceTask<EngineClient_>>),
     /// Finalizes an L2 block
@@ -126,8 +119,6 @@ impl<EngineClient_: EngineClient> EngineTask<EngineClient_> {
     /// Executes the task without consuming it.
     async fn execute_inner(&self, state: &mut EngineState) -> Result<(), EngineTaskErrors> {
         match self {
-            Self::Seal(task) => task.execute(state).await?,
-            Self::Consolidate(task) => task.execute(state).await?,
             Self::DelegatedForkchoice(task) => task.execute(state).await?,
             Self::Finalize(task) => task.execute(state).await?,
         };
@@ -137,9 +128,7 @@ impl<EngineClient_: EngineClient> EngineTask<EngineClient_> {
 
     const fn task_metrics_label(&self) -> &'static str {
         match self {
-            Self::Consolidate(_) => Metrics::CONSOLIDATE_TASK_LABEL,
             Self::DelegatedForkchoice(_) => Metrics::DELEGATED_FORKCHOICE_TASK_LABEL,
-            Self::Seal(_) => Metrics::SEAL_TASK_LABEL,
             Self::Finalize(_) => Metrics::FINALIZE_TASK_LABEL,
         }
     }
@@ -149,9 +138,7 @@ impl<EngineClient_: EngineClient> PartialEq for EngineTask<EngineClient_> {
     fn eq(&self, other: &Self) -> bool {
         matches!(
             (self, other),
-            (Self::Seal(_), Self::Seal(_))
-                | (Self::Consolidate(_), Self::Consolidate(_))
-                | (Self::DelegatedForkchoice(_), Self::DelegatedForkchoice(_))
+            (Self::DelegatedForkchoice(_), Self::DelegatedForkchoice(_))
                 | (Self::Finalize(_), Self::Finalize(_))
         )
     }
@@ -167,35 +154,19 @@ impl<EngineClient_: EngineClient> PartialOrd for EngineTask<EngineClient_> {
 
 impl<EngineClient_: EngineClient> Ord for EngineTask<EngineClient_> {
     fn cmp(&self, other: &Self) -> Ordering {
-        // Order (descending): Seal -> Consolidate -> Finalize
+        // Order (descending): Delegated forkchoice -> Finalize
         //
         // https://specs.base.org/protocol/consensus/derivation#forkchoice-synchronization
         //
-        // - Seal tasks are prioritized above all queued tasks to give priority to the sequencer.
-        // - Consolidate tasks are prioritized over Finalize tasks, as they advance the safe chain
-        //   via derivation.
+        // - Delegated forkchoice tasks are prioritized over Finalize tasks, as they advance the
+        //   safe chain via derivation.
         // - Finalize tasks have the lowest priority, as they only update finalized status.
         match (self, other) {
             // Same variant cases
-            (Self::Consolidate(_), Self::Consolidate(_))
-            | (Self::DelegatedForkchoice(_), Self::DelegatedForkchoice(_))
-            | (Self::Seal(_), Self::Seal(_))
+            (Self::DelegatedForkchoice(_), Self::DelegatedForkchoice(_))
             | (Self::Finalize(_), Self::Finalize(_)) => Ordering::Equal,
-
-            // Seal tasks are prioritized over all other queued tasks.
-            (Self::Seal(_), _) => Ordering::Greater,
-            (_, Self::Seal(_)) => Ordering::Less,
-
-            // Consolidate-style tasks are prioritized over Finalize tasks.
-            (Self::Consolidate(_) | Self::DelegatedForkchoice(_), Self::Finalize(_)) => {
-                Ordering::Greater
-            }
-            (Self::Finalize(_), Self::Consolidate(_) | Self::DelegatedForkchoice(_)) => {
-                Ordering::Less
-            }
-
-            // Consolidate and delegated forkchoice share equal priority.
-            (Self::Consolidate(_) | Self::DelegatedForkchoice(_), _) => Ordering::Equal,
+            (Self::DelegatedForkchoice(_), Self::Finalize(_)) => Ordering::Greater,
+            (Self::Finalize(_), Self::DelegatedForkchoice(_)) => Ordering::Less,
         }
     }
 }

--- a/crates/consensus/service/src/actors/engine/engine_request_processor.rs
+++ b/crates/consensus/service/src/actors/engine/engine_request_processor.rs
@@ -5,8 +5,8 @@ use base_common_genesis::RollupConfig;
 use base_common_rpc_types_engine::BaseExecutionPayloadEnvelope;
 use base_consensus_derive::{ResetSignal, Signal};
 use base_consensus_engine::{
-    ConsolidateTask, DelegatedForkchoiceTask, Engine, EngineClient, EngineSyncStateUpdate,
-    EngineTask, EngineTaskError, EngineTaskErrorSeverity, EngineTaskErrors, FinalizeTask,
+    DelegatedForkchoiceTask, Engine, EngineClient, EngineSyncStateUpdate, EngineTask,
+    EngineTaskError, EngineTaskErrorSeverity, EngineTaskErrors, FinalizeTask,
     Metrics as EngineMetrics, SealTaskError,
 };
 use base_protocol::L2BlockInfo;
@@ -690,12 +690,18 @@ where
                         })?;
                     }
                     EngineActorRequest::ProcessSafeL2SignalRequest(safe_signal) => {
-                        let task = EngineTask::Consolidate(Box::new(ConsolidateTask::new(
-                            Arc::clone(&self.client),
-                            Arc::clone(&self.rollup),
-                            safe_signal,
-                        )));
-                        self.engine.enqueue(task);
+                        if let Err(err) = self
+                            .engine
+                            .consolidate(
+                                Arc::clone(&self.client),
+                                Arc::clone(&self.rollup),
+                                safe_signal,
+                            )
+                            .await
+                        {
+                            self.handle_engine_task_error(EngineTaskErrors::Consolidate(err))
+                                .await?;
+                        }
                     }
                     EngineActorRequest::ProcessDelegatedForkchoiceUpdateRequest(update) => {
                         let task = EngineTask::DelegatedForkchoice(Box::new(


### PR DESCRIPTION
## Summary

This moves safe-head consolidation out of the engine task queue and onto direct Engine methods. ProcessSafeL2SignalRequest now executes consolidation directly, while delegated forkchoice reuses the same direct consolidation helper before finalizing. The old ConsolidateTask wrapper and unused queued seal/consolidate variants are deleted so the remaining queue only covers delegated forkchoice and finalize.