### PR TITLE
chore: Refactor OP Succinct prover backend

### DIFF
--- a/bin/prover/zk/src/cli.rs
+++ b/bin/prover/zk/src/cli.rs
@@ -8,9 +8,10 @@ use base_zk_client::prover_service_server::ProverServiceServer as ProtoProverSer
 use base_zk_db::{DatabaseConfig, ProofRequestRepo};
 use base_zk_outbox::{DatabaseOutboxReader, OutboxProcessor};
 use base_zk_service::{
-    ArtifactClientWrapper, ArtifactStorageConfig, BackendConfig, BackendRegistry, ClusterBackend,
-    MockBackend, NetworkBackend, OpSuccinctProvider, ProofRequestManager, ProverServiceServer,
-    ProverWorkerPool, ProxyConfigs, RateLimitConfig, StatusPoller, start_all_proxies,
+    ArtifactClientWrapper, ArtifactStorageConfig, BackendConfig, BackendRegistry,
+    OpSuccinctClusterBackend, OpSuccinctMockBackend, OpSuccinctNetworkBackend, OpSuccinctProvider,
+    ProofRequestManager, ProverServiceServer, ProverWorkerPool, ProxyConfigs, RateLimitConfig,
+    StatusPoller, start_all_proxies,
 };
 use clap::Parser;
 use eyre::eyre;
@@ -211,7 +212,7 @@ impl ZkArgs {
 
         if self.prover_mode == "mock" {
             info!("SP1_PROVER=mock: using MockBackend (instant fake proofs, no cluster)");
-            let mock_backend = MockBackend::new(range_vk, agg_vk);
+            let mock_backend = OpSuccinctMockBackend::new(range_vk, agg_vk);
             backend_registry.register(Arc::new(mock_backend));
         } else if self.prover_mode == "network" {
             info!("SP1_PROVER=network: using Succinct SP1 Network backend");
@@ -270,7 +271,7 @@ impl ZkArgs {
                 timeout_hours: self.sp1_cluster_timeout_hours,
             };
 
-            let backend = Arc::new(NetworkBackend::new(provider, config));
+            let backend = Arc::new(OpSuccinctNetworkBackend::new(provider, config));
             backend_registry.register(backend);
         } else {
             info!("SP1_PROVER=cluster: using Succinct cluster backend");
@@ -313,7 +314,7 @@ impl ZkArgs {
                 range_vk,
             };
 
-            let backend = Arc::new(ClusterBackend::new(provider, config));
+            let backend = Arc::new(OpSuccinctClusterBackend::new(provider, config));
             backend_registry.register(backend);
         }
 

--- a/bin/prover/zk/src/cli.rs
+++ b/bin/prover/zk/src/cli.rs
@@ -8,10 +8,9 @@ use base_zk_client::prover_service_server::ProverServiceServer as ProtoProverSer
 use base_zk_db::{DatabaseConfig, ProofRequestRepo};
 use base_zk_outbox::{DatabaseOutboxReader, OutboxProcessor};
 use base_zk_service::{
-    ArtifactClientWrapper, ArtifactStorageConfig, BackendConfig, BackendRegistry, MockBackend,
-    NetworkBackend, OpSuccinctBackend, OpSuccinctProvider, ProofRequestManager,
-    ProverServiceServer, ProverWorkerPool, ProxyConfigs, RateLimitConfig, StatusPoller,
-    start_all_proxies,
+    ArtifactClientWrapper, ArtifactStorageConfig, BackendConfig, BackendRegistry,
+    ProofRequestManager, ProverServiceServer, ProverWorkerPool, ProxyConfigs, RateLimitConfig,
+    StatusPoller, op_succinct, start_all_proxies,
 };
 use clap::Parser;
 use eyre::eyre;
@@ -212,7 +211,7 @@ impl ZkArgs {
 
         if self.prover_mode == "mock" {
             info!("SP1_PROVER=mock: using MockBackend (instant fake proofs, no cluster)");
-            let mock_backend = MockBackend::new(range_vk, agg_vk);
+            let mock_backend = op_succinct::MockBackend::new(range_vk, agg_vk);
             backend_registry.register(Arc::new(mock_backend));
         } else if self.prover_mode == "network" {
             info!("SP1_PROVER=network: using Succinct SP1 Network backend");
@@ -222,7 +221,7 @@ impl ZkArgs {
                     .await
                     .map_err(|e| eyre!("failed to create OPSuccinctDataFetcher: {e}"))?,
             );
-            let provider = OpSuccinctProvider::new(fetcher);
+            let provider = op_succinct::OpSuccinctProvider::new(fetcher);
 
             let fulfillment_strategy =
                 base_proof_succinct_host_utils::network::parse_fulfillment_strategy(
@@ -271,7 +270,7 @@ impl ZkArgs {
                 timeout_hours: self.sp1_cluster_timeout_hours,
             };
 
-            let backend = Arc::new(NetworkBackend::new(provider, config));
+            let backend = Arc::new(op_succinct::NetworkBackend::new(provider, config));
             backend_registry.register(backend);
         } else {
             info!("SP1_PROVER=cluster: using Succinct cluster backend");
@@ -282,7 +281,7 @@ impl ZkArgs {
                     .await
                     .map_err(|e| eyre!("failed to create OPSuccinctDataFetcher: {e}"))?,
             );
-            let provider = OpSuccinctProvider::new(fetcher);
+            let provider = op_succinct::OpSuccinctProvider::new(fetcher);
 
             // Create SP1 cluster gRPC client.
             let cluster_rpc = self
@@ -314,7 +313,7 @@ impl ZkArgs {
                 range_vk,
             };
 
-            let backend = Arc::new(OpSuccinctBackend::new(provider, config));
+            let backend = Arc::new(op_succinct::ClusterBackend::new(provider, config));
             backend_registry.register(backend);
         }
 

--- a/bin/prover/zk/src/cli.rs
+++ b/bin/prover/zk/src/cli.rs
@@ -8,9 +8,9 @@ use base_zk_client::prover_service_server::ProverServiceServer as ProtoProverSer
 use base_zk_db::{DatabaseConfig, ProofRequestRepo};
 use base_zk_outbox::{DatabaseOutboxReader, OutboxProcessor};
 use base_zk_service::{
-    ArtifactClientWrapper, ArtifactStorageConfig, BackendConfig, BackendRegistry,
-    ProofRequestManager, ProverServiceServer, ProverWorkerPool, ProxyConfigs, RateLimitConfig,
-    StatusPoller, op_succinct, start_all_proxies,
+    ArtifactClientWrapper, ArtifactStorageConfig, BackendConfig, BackendRegistry, ClusterBackend,
+    MockBackend, NetworkBackend, OpSuccinctProvider, ProofRequestManager, ProverServiceServer,
+    ProverWorkerPool, ProxyConfigs, RateLimitConfig, StatusPoller, start_all_proxies,
 };
 use clap::Parser;
 use eyre::eyre;
@@ -211,7 +211,7 @@ impl ZkArgs {
 
         if self.prover_mode == "mock" {
             info!("SP1_PROVER=mock: using MockBackend (instant fake proofs, no cluster)");
-            let mock_backend = op_succinct::MockBackend::new(range_vk, agg_vk);
+            let mock_backend = MockBackend::new(range_vk, agg_vk);
             backend_registry.register(Arc::new(mock_backend));
         } else if self.prover_mode == "network" {
             info!("SP1_PROVER=network: using Succinct SP1 Network backend");
@@ -221,7 +221,7 @@ impl ZkArgs {
                     .await
                     .map_err(|e| eyre!("failed to create OPSuccinctDataFetcher: {e}"))?,
             );
-            let provider = op_succinct::OpSuccinctProvider::new(fetcher);
+            let provider = OpSuccinctProvider::new(fetcher);
 
             let fulfillment_strategy =
                 base_proof_succinct_host_utils::network::parse_fulfillment_strategy(
@@ -270,7 +270,7 @@ impl ZkArgs {
                 timeout_hours: self.sp1_cluster_timeout_hours,
             };
 
-            let backend = Arc::new(op_succinct::NetworkBackend::new(provider, config));
+            let backend = Arc::new(NetworkBackend::new(provider, config));
             backend_registry.register(backend);
         } else {
             info!("SP1_PROVER=cluster: using Succinct cluster backend");
@@ -281,7 +281,7 @@ impl ZkArgs {
                     .await
                     .map_err(|e| eyre!("failed to create OPSuccinctDataFetcher: {e}"))?,
             );
-            let provider = op_succinct::OpSuccinctProvider::new(fetcher);
+            let provider = OpSuccinctProvider::new(fetcher);
 
             // Create SP1 cluster gRPC client.
             let cluster_rpc = self
@@ -313,7 +313,7 @@ impl ZkArgs {
                 range_vk,
             };
 
-            let backend = Arc::new(op_succinct::ClusterBackend::new(provider, config));
+            let backend = Arc::new(ClusterBackend::new(provider, config));
             backend_registry.register(backend);
         }
 

--- a/crates/proof/zk/service/src/backends/mod.rs
+++ b/crates/proof/zk/service/src/backends/mod.rs
@@ -1,6 +1,9 @@
 //! Proving backends for ZK proof generation.
 
-pub mod op_succinct;
+mod op_succinct;
+pub use op_succinct::{
+    ClusterBackend, MockBackend, NetworkBackend, OpSuccinctProvider, WitnessParams,
+};
 
 mod traits;
 pub use traits::{

--- a/crates/proof/zk/service/src/backends/mod.rs
+++ b/crates/proof/zk/service/src/backends/mod.rs
@@ -1,13 +1,6 @@
 //! Proving backends for ZK proof generation.
 
-mod mock;
-pub use mock::MockBackend;
-
-mod network;
-pub use network::NetworkBackend;
-
-mod op_succinct;
-pub use op_succinct::{OpSuccinctBackend, OpSuccinctProvider, WitnessParams};
+pub mod op_succinct;
 
 mod traits;
 pub use traits::{

--- a/crates/proof/zk/service/src/backends/mod.rs
+++ b/crates/proof/zk/service/src/backends/mod.rs
@@ -2,7 +2,9 @@
 
 mod op_succinct;
 pub use op_succinct::{
-    ClusterBackend, MockBackend, NetworkBackend, OpSuccinctProvider, WitnessParams,
+    ClusterBackend as OpSuccinctClusterBackend, MockBackend as OpSuccinctMockBackend,
+    NetworkBackend as OpSuccinctNetworkBackend, OpSuccinctProvider,
+    WitnessParams as OpSuccinctWitnessParams,
 };
 
 mod traits;

--- a/crates/proof/zk/service/src/backends/op_succinct/cluster.rs
+++ b/crates/proof/zk/service/src/backends/op_succinct/cluster.rs
@@ -28,32 +28,32 @@ use crate::backends::traits::{
     ProvingBackend, SessionStatus,
 };
 
-/// Succinct proving backend.
+/// SP1 Cluster proving backend.
 #[derive(Clone)]
-pub struct OpSuccinctBackend {
+pub struct ClusterBackend {
     provider: OpSuccinctProvider,
     config: BackendConfig,
 }
 
-impl fmt::Debug for OpSuccinctBackend {
+impl fmt::Debug for ClusterBackend {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("OpSuccinctBackend").finish_non_exhaustive()
+        f.debug_struct("ClusterBackend").finish_non_exhaustive()
     }
 }
 
-impl OpSuccinctBackend {
+impl ClusterBackend {
     /// Create a new backend with a pre-initialized provider and config.
     pub fn new(provider: OpSuccinctProvider, config: BackendConfig) -> Self {
         assert!(
             matches!(config, BackendConfig::OpSuccinct { .. }),
-            "OpSuccinctBackend requires BackendConfig::OpSuccinct"
+            "ClusterBackend requires BackendConfig::OpSuccinct"
         );
         Self { provider, config }
     }
 }
 
 #[async_trait]
-impl ProvingBackend for OpSuccinctBackend {
+impl ProvingBackend for ClusterBackend {
     fn backend_type(&self) -> BackendType {
         BackendType::OpSuccinct
     }
@@ -326,7 +326,7 @@ fn format_cluster_failure(req: &ClusterProtoProofRequest) -> String {
     parts.join("; ")
 }
 
-impl OpSuccinctBackend {
+impl ClusterBackend {
     async fn verify_artifacts(
         &self,
         cluster_client: &sp1_cluster_common::client::ClusterServiceClient,
@@ -772,7 +772,7 @@ mod tests {
     #[test]
     fn test_determine_status_no_sessions_returns_pending() {
         let result =
-            OpSuccinctBackend::determine_status(ProofType::OpSuccinctSp1ClusterCompressed, &[]);
+            ClusterBackend::determine_status(ProofType::OpSuccinctSp1ClusterCompressed, &[]);
         assert_eq!(result.status, ProofStatus::Pending);
         assert!(result.error_message.is_none());
     }
@@ -780,17 +780,15 @@ mod tests {
     #[test]
     fn test_determine_status_no_sessions_snark_returns_pending() {
         let result =
-            OpSuccinctBackend::determine_status(ProofType::OpSuccinctSp1ClusterSnarkGroth16, &[]);
+            ClusterBackend::determine_status(ProofType::OpSuccinctSp1ClusterSnarkGroth16, &[]);
         assert_eq!(result.status, ProofStatus::Pending);
     }
 
     #[test]
     fn test_determine_status_compressed_all_completed_returns_succeeded() {
         let sessions = vec![make_session(SessionType::Stark, DbSessionStatus::Completed)];
-        let result = OpSuccinctBackend::determine_status(
-            ProofType::OpSuccinctSp1ClusterCompressed,
-            &sessions,
-        );
+        let result =
+            ClusterBackend::determine_status(ProofType::OpSuccinctSp1ClusterCompressed, &sessions);
         assert_eq!(result.status, ProofStatus::Succeeded);
         assert!(result.error_message.is_none());
     }
@@ -798,20 +796,16 @@ mod tests {
     #[test]
     fn test_determine_status_compressed_running_returns_running() {
         let sessions = vec![make_session(SessionType::Stark, DbSessionStatus::Running)];
-        let result = OpSuccinctBackend::determine_status(
-            ProofType::OpSuccinctSp1ClusterCompressed,
-            &sessions,
-        );
+        let result =
+            ClusterBackend::determine_status(ProofType::OpSuccinctSp1ClusterCompressed, &sessions);
         assert_eq!(result.status, ProofStatus::Running);
     }
 
     #[test]
     fn test_determine_status_compressed_failed_returns_failed() {
         let sessions = vec![make_failed_session(SessionType::Stark, "OOM")];
-        let result = OpSuccinctBackend::determine_status(
-            ProofType::OpSuccinctSp1ClusterCompressed,
-            &sessions,
-        );
+        let result =
+            ClusterBackend::determine_status(ProofType::OpSuccinctSp1ClusterCompressed, &sessions);
         assert_eq!(result.status, ProofStatus::Failed);
         assert_eq!(result.error_message.as_deref(), Some("OOM"));
     }
@@ -822,7 +816,7 @@ mod tests {
             make_session(SessionType::Stark, DbSessionStatus::Completed),
             make_session(SessionType::Snark, DbSessionStatus::Completed),
         ];
-        let result = OpSuccinctBackend::determine_status(
+        let result = ClusterBackend::determine_status(
             ProofType::OpSuccinctSp1ClusterSnarkGroth16,
             &sessions,
         );
@@ -832,7 +826,7 @@ mod tests {
     #[test]
     fn test_determine_status_snark_only_stark_completed_returns_running() {
         let sessions = vec![make_session(SessionType::Stark, DbSessionStatus::Completed)];
-        let result = OpSuccinctBackend::determine_status(
+        let result = ClusterBackend::determine_status(
             ProofType::OpSuccinctSp1ClusterSnarkGroth16,
             &sessions,
         );
@@ -845,7 +839,7 @@ mod tests {
             make_session(SessionType::Stark, DbSessionStatus::Completed),
             make_session(SessionType::Snark, DbSessionStatus::Running),
         ];
-        let result = OpSuccinctBackend::determine_status(
+        let result = ClusterBackend::determine_status(
             ProofType::OpSuccinctSp1ClusterSnarkGroth16,
             &sessions,
         );
@@ -855,7 +849,7 @@ mod tests {
     #[test]
     fn test_determine_status_snark_stark_failed_returns_failed() {
         let sessions = vec![make_failed_session(SessionType::Stark, "cluster timeout")];
-        let result = OpSuccinctBackend::determine_status(
+        let result = ClusterBackend::determine_status(
             ProofType::OpSuccinctSp1ClusterSnarkGroth16,
             &sessions,
         );
@@ -869,7 +863,7 @@ mod tests {
             make_session(SessionType::Stark, DbSessionStatus::Completed),
             make_failed_session(SessionType::Snark, "aggregation error"),
         ];
-        let result = OpSuccinctBackend::determine_status(
+        let result = ClusterBackend::determine_status(
             ProofType::OpSuccinctSp1ClusterSnarkGroth16,
             &sessions,
         );
@@ -883,10 +877,8 @@ mod tests {
             make_session(SessionType::Stark, DbSessionStatus::Completed),
             make_failed_session(SessionType::Snark, "failure wins"),
         ];
-        let result = OpSuccinctBackend::determine_status(
-            ProofType::OpSuccinctSp1ClusterCompressed,
-            &sessions,
-        );
+        let result =
+            ClusterBackend::determine_status(ProofType::OpSuccinctSp1ClusterCompressed, &sessions);
         assert_eq!(result.status, ProofStatus::Failed);
     }
 }

--- a/crates/proof/zk/service/src/backends/op_succinct/mock.rs
+++ b/crates/proof/zk/service/src/backends/op_succinct/mock.rs
@@ -21,7 +21,7 @@ use sp1_sdk::{
 use tracing::info;
 use uuid::Uuid;
 
-use super::traits::{
+use crate::backends::traits::{
     BackendType, ProofProcessingResult, ProveResult, ProvingBackend, SessionStatus,
 };
 

--- a/crates/proof/zk/service/src/backends/op_succinct/mod.rs
+++ b/crates/proof/zk/service/src/backends/op_succinct/mod.rs
@@ -1,7 +1,13 @@
-//! Succinct proving backend using the SP1 cluster.
+//! OP Succinct proving backends.
 
-mod backend;
-pub use backend::OpSuccinctBackend;
+mod cluster;
+pub use cluster::ClusterBackend;
+
+mod mock;
+pub use mock::MockBackend;
+
+mod network;
+pub use network::NetworkBackend;
 
 mod provider;
 pub use provider::{OpSuccinctProvider, WitnessParams};

--- a/crates/proof/zk/service/src/backends/op_succinct/network.rs
+++ b/crates/proof/zk/service/src/backends/op_succinct/network.rs
@@ -23,8 +23,8 @@ use sp1_sdk::{
 };
 use tracing::{error, info, warn};
 
-use super::{
-    OpSuccinctProvider, WitnessParams,
+use crate::backends::{
+    op_succinct::provider::{OpSuccinctProvider, WitnessParams},
     traits::{
         BackendConfig, BackendType, ProofProcessingResult, ProveResult, ProvingBackend,
         SessionStatus,

--- a/crates/proof/zk/service/src/backends/op_succinct/network.rs
+++ b/crates/proof/zk/service/src/backends/op_succinct/network.rs
@@ -23,12 +23,9 @@ use sp1_sdk::{
 };
 use tracing::{error, info, warn};
 
-use crate::backends::{
-    op_succinct::provider::{OpSuccinctProvider, WitnessParams},
-    traits::{
-        BackendConfig, BackendType, ProofProcessingResult, ProveResult, ProvingBackend,
-        SessionStatus,
-    },
+use super::provider::{OpSuccinctProvider, WitnessParams};
+use crate::backends::traits::{
+    BackendConfig, BackendType, ProofProcessingResult, ProveResult, ProvingBackend, SessionStatus,
 };
 
 /// SP1 Network proving backend.

--- a/crates/proof/zk/service/src/lib.rs
+++ b/crates/proof/zk/service/src/lib.rs
@@ -2,10 +2,10 @@
 #![recursion_limit = "256"]
 
 mod backends;
+pub use backends::op_succinct;
 pub use backends::{
     ArtifactClientWrapper, ArtifactStorageConfig, BackendConfig, BackendRegistry, BackendType,
-    L1HeadCalculator, MockBackend, NetworkBackend, OpSuccinctBackend, OpSuccinctProvider,
-    ProofProcessingResult, ProveResult, ProvingBackend, SessionStatus, WitnessParams,
+    L1HeadCalculator, ProofProcessingResult, ProveResult, ProvingBackend, SessionStatus,
 };
 
 pub mod metrics;

--- a/crates/proof/zk/service/src/lib.rs
+++ b/crates/proof/zk/service/src/lib.rs
@@ -2,10 +2,10 @@
 #![recursion_limit = "256"]
 
 mod backends;
-pub use backends::op_succinct;
 pub use backends::{
     ArtifactClientWrapper, ArtifactStorageConfig, BackendConfig, BackendRegistry, BackendType,
-    L1HeadCalculator, ProofProcessingResult, ProveResult, ProvingBackend, SessionStatus,
+    ClusterBackend, L1HeadCalculator, MockBackend, NetworkBackend, OpSuccinctProvider,
+    ProofProcessingResult, ProveResult, ProvingBackend, SessionStatus, WitnessParams,
 };
 
 pub mod metrics;

--- a/crates/proof/zk/service/src/lib.rs
+++ b/crates/proof/zk/service/src/lib.rs
@@ -4,8 +4,9 @@
 mod backends;
 pub use backends::{
     ArtifactClientWrapper, ArtifactStorageConfig, BackendConfig, BackendRegistry, BackendType,
-    ClusterBackend, L1HeadCalculator, MockBackend, NetworkBackend, OpSuccinctProvider,
-    ProofProcessingResult, ProveResult, ProvingBackend, SessionStatus, WitnessParams,
+    L1HeadCalculator, OpSuccinctClusterBackend, OpSuccinctMockBackend, OpSuccinctNetworkBackend,
+    OpSuccinctProvider, OpSuccinctWitnessParams, ProofProcessingResult, ProveResult,
+    ProvingBackend, SessionStatus,
 };
 
 pub mod metrics;


### PR DESCRIPTION
## Summary
- Group OP Succinct cluster, network, and mock prover backend implementations under `base_zk_service::op_succinct`.
- Rename the cluster implementation from `OpSuccinctBackend` to `ClusterBackend` so each proving mode has a concrete backend type.
- Update the ZK prover binary to construct backends through the `op_succinct` namespace.

Made with [Cursor](https://cursor.com)