### PR TITLE
feat(zk): add ListProofs gRPC RPC with paginated query

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5696,6 +5696,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "chrono",
+ "futures",
  "serde",
  "serde_json",
  "sqlx",

--- a/crates/proof/zk/client/proto/zk_prover.proto
+++ b/crates/proof/zk/client/proto/zk_prover.proto
@@ -5,6 +5,7 @@ package prover;
 service ProverService {
   rpc ProveBlock(ProveBlockRequest) returns (ProveBlockResponse);
   rpc GetProof(GetProofRequest) returns (GetProofResponse);
+  rpc ListProofs(ListProofsRequest) returns (ListProofsResponse);
 }
 
 enum ProofType {
@@ -64,4 +65,32 @@ message GetProofResponse {
   Status status = 1;
   bytes receipt = 2; // the actual zk proof, only populated if status is SUCCEEDED
   optional string error_message = 3; // populated when status is STATUS_FAILED
+}
+
+message ListProofsRequest {
+  // Pagination offset (0-based).
+  uint64 offset = 1;
+  // Maximum number of results to return. Capped server-side.
+  uint64 limit = 2;
+  // Optional status filter. If unspecified or STATUS_UNSPECIFIED, returns all statuses.
+  optional GetProofResponse.Status status_filter = 3;
+}
+
+// Summary of a proof request (excludes receipt bytes for efficiency).
+message ProofSummary {
+  string id = 1;
+  uint64 start_block_number = 2;
+  uint64 number_of_blocks_to_prove = 3;
+  ProofType proof_type = 4;
+  GetProofResponse.Status status = 5;
+  string created_at = 6;
+  string updated_at = 7;
+  optional string completed_at = 8;
+  optional string error_message = 9;
+}
+
+message ListProofsResponse {
+  repeated ProofSummary proofs = 1;
+  // Total number of proofs matching the filter (for pagination).
+  uint64 total_count = 2;
 }

--- a/crates/proof/zk/client/src/lib.rs
+++ b/crates/proof/zk/client/src/lib.rs
@@ -12,6 +12,7 @@
 #[allow(
     unreachable_pub,
     clippy::clone_on_ref_ptr,
+    clippy::derive_partial_eq_without_eq,
     clippy::doc_markdown,
     clippy::missing_const_for_fn
 )]
@@ -27,9 +28,9 @@ pub const PROVER_FILE_DESCRIPTOR_SET: &[u8] =
     tonic::include_file_descriptor_set!("prover_descriptor");
 
 pub use proto::{
-    GetProofRequest, GetProofResponse, ProofType, ProveBlockRequest, ProveBlockResponse,
-    ReceiptType, get_proof_response, get_proof_response::Status as ProofJobStatus,
-    prover_service_client,
+    GetProofRequest, GetProofResponse, ListProofsRequest, ListProofsResponse, ProofSummary,
+    ProofType, ProveBlockRequest, ProveBlockResponse, ReceiptType, get_proof_response,
+    get_proof_response::Status as ProofJobStatus, prover_service_client,
 };
 
 mod client;

--- a/crates/proof/zk/db/Cargo.toml
+++ b/crates/proof/zk/db/Cargo.toml
@@ -10,6 +10,7 @@ repository.workspace = true
 [dependencies]
 # database
 sqlx = { workspace = true, features = ["runtime-tokio", "postgres", "uuid", "chrono", "derive", "tls-native-tls"] }
+futures.workspace = true
 
 # serialization
 serde_json.workspace = true

--- a/crates/proof/zk/db/src/lib.rs
+++ b/crates/proof/zk/db/src/lib.rs
@@ -6,8 +6,9 @@ pub use config::DatabaseConfig;
 mod models;
 pub use models::{
     CreateOutboxEntry, CreateProofRequest, CreateProofSession, MarkOutboxError,
-    MarkOutboxProcessed, OutboxEntry, ProofRequest, ProofSession, ProofStatus, ProofType,
-    RetryOutcome, SessionStatus, SessionType, UpdateProofSession, UpdateReceipt,
+    MarkOutboxProcessed, OutboxEntry, ProofRequest, ProofRequestListItem, ProofRequestPage,
+    ProofSession, ProofStatus, ProofType, RetryOutcome, SessionStatus, SessionType,
+    UpdateProofSession, UpdateReceipt,
 };
 
 mod repo;

--- a/crates/proof/zk/db/src/models.rs
+++ b/crates/proof/zk/db/src/models.rs
@@ -249,6 +249,58 @@ pub struct ProofRequest {
     pub retry_count: i32,
 }
 
+/// Receipt-free proof request row used by list endpoints.
+#[derive(Debug, Clone, FromRow, Serialize, Deserialize)]
+pub struct ProofRequestListItem {
+    /// Unique identifier.
+    pub id: Uuid,
+    /// Starting L2 block number.
+    pub start_block_number: i64,
+    /// Number of consecutive blocks to prove.
+    pub number_of_blocks_to_prove: i64,
+    /// Type of proof to generate.
+    pub proof_type: ProofType,
+    /// Current proof status.
+    pub status: ProofStatus,
+    /// Error message if the proof failed.
+    pub error_message: Option<String>,
+    /// Timestamp when the request was created.
+    pub created_at: DateTime<Utc>,
+    /// Timestamp of the last status update.
+    pub updated_at: DateTime<Utc>,
+    /// Timestamp when the proof completed (success or failure).
+    pub completed_at: Option<DateTime<Utc>>,
+}
+
+/// Offset pagination parameters 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ProofRequestPage {
+    limit: i64,
+    offset: i64,
+}
+
+impl ProofRequestPage {
+    /// Create pagination parameters from API-level unsigned values.
+    pub fn try_new(limit: u64, offset: u64) -> Result<Self, String> {
+        let limit =
+            i64::try_from(limit).map_err(|_| "limit exceeds maximum supported value".to_owned())?;
+        let offset = i64::try_from(offset)
+            .map_err(|_| "offset exceeds maximum supported value".to_owned())?;
+
+        Ok(Self { limit, offset })
+    }
+
+    /// Maximum number of rows to return.
+    pub const fn limit(&self) -> i64 {
+        self.limit
+    }
+
+    /// Number of rows to skip.
+    pub const fn offset(&self) -> i64 {
+        self.offset
+    }
+}
+
 /// A proof session record tracking a specific backend job (STARK or SNARK)
 #[derive(Debug, Clone, FromRow, Serialize, Deserialize)]
 pub struct ProofSession {

--- a/crates/proof/zk/db/src/models.rs
+++ b/crates/proof/zk/db/src/models.rs
@@ -272,7 +272,7 @@ pub struct ProofRequestListItem {
     pub completed_at: Option<DateTime<Utc>>,
 }
 
-/// Offset pagination parameters 
+/// Offset pagination parameters.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ProofRequestPage {
     limit: i64,
@@ -282,6 +282,10 @@ pub struct ProofRequestPage {
 impl ProofRequestPage {
     /// Create pagination parameters from API-level unsigned values.
     pub fn try_new(limit: u64, offset: u64) -> Result<Self, String> {
+        if limit == 0 {
+            return Err("limit must be greater than zero".to_owned());
+        }
+
         let limit =
             i64::try_from(limit).map_err(|_| "limit exceeds maximum supported value".to_owned())?;
         let offset = i64::try_from(offset)

--- a/crates/proof/zk/db/src/repo.rs
+++ b/crates/proof/zk/db/src/repo.rs
@@ -844,6 +844,45 @@ impl ProofRequestRepo {
         rows.iter().map(row_to_proof_request).collect()
     }
 
+    /// List proof requests with offset-based pagination and return total count.
+    pub async fn list_with_offset(
+        &self,
+        status_filter: Option<ProofStatus>,
+        limit: i64,
+        offset: i64,
+    ) -> Result<(Vec<ProofRequest>, u64)> {
+        let status_str = status_filter.map(|s| s.as_str().to_string());
+
+        let rows = sqlx::query(
+            r#"
+            SELECT
+                id, start_block_number, number_of_blocks_to_prove, sequence_window,
+                proof_type, NULL::bytea AS stark_receipt, NULL::bytea AS snark_receipt,
+                status, error_message, prover_address, l1_head,
+                intermediate_root_interval, created_at, updated_at, completed_at, retry_count
+            FROM proof_requests
+            WHERE ($1::text IS NULL OR status = $1)
+            ORDER BY created_at DESC
+            LIMIT $2 OFFSET $3
+            "#,
+        )
+        .bind(status_str.as_deref())
+        .bind(limit)
+        .bind(offset)
+        .fetch_all(&self.pool)
+        .await?;
+
+        let count: (i64,) = sqlx::query_as(
+            "SELECT COUNT(*) FROM proof_requests WHERE ($1::text IS NULL OR status = $1)",
+        )
+        .bind(status_str.as_deref())
+        .fetch_one(&self.pool)
+        .await?;
+
+        let proofs = rows.iter().map(row_to_proof_request).collect::<Result<Vec<_>>>()?;
+        Ok((proofs, count.0.max(0) as u64))
+    }
+
     // ========== Outbox Methods ==========
 
     /// Create an outbox entry for background task processing.

--- a/crates/proof/zk/db/src/repo.rs
+++ b/crates/proof/zk/db/src/repo.rs
@@ -3,8 +3,9 @@ use uuid::Uuid;
 
 use crate::{
     CreateOutboxEntry, CreateProofRequest, CreateProofSession, MarkOutboxError,
-    MarkOutboxProcessed, OutboxEntry, ProofRequest, ProofSession, ProofStatus, ProofType,
-    RetryOutcome, SessionStatus, SessionType, UpdateProofSession, UpdateReceipt,
+    MarkOutboxProcessed, OutboxEntry, ProofRequest, ProofRequestListItem, ProofRequestPage,
+    ProofSession, ProofStatus, ProofType, RetryOutcome, SessionStatus, SessionType,
+    UpdateProofSession, UpdateReceipt,
 };
 
 /// Repository for proof request database operations
@@ -848,23 +849,15 @@ impl ProofRequestRepo {
     pub async fn list_with_offset(
         &self,
         status_filter: Option<ProofStatus>,
-        limit: u64,
-        offset: u64,
-    ) -> Result<(Vec<ProofRequest>, u64)> {
-        let limit = i64::try_from(limit)
-            .map_err(|_| sqlx::Error::Protocol("limit exceeds i64 range".into()))?;
-        let offset = i64::try_from(offset)
-            .map_err(|_| sqlx::Error::Protocol("offset exceeds i64 range".into()))?;
-
+        page: ProofRequestPage,
+    ) -> Result<(Vec<ProofRequestListItem>, u64)> {
         let (rows, count) = if let Some(status) = status_filter {
-            let rows = sqlx::query(
+            let rows = sqlx::query_as::<_, ProofRequestListItem>(
                 r#"
                 SELECT
                     id, start_block_number, number_of_blocks_to_prove,
-                    sequence_window, proof_type,
-                    status, error_message,
-                    prover_address, l1_head, intermediate_root_interval,
-                    created_at, updated_at, completed_at, retry_count
+                    proof_type, status, error_message,
+                    created_at, updated_at, completed_at
                 FROM proof_requests
                 WHERE status = $1
                 ORDER BY created_at DESC
@@ -872,46 +865,40 @@ impl ProofRequestRepo {
                 "#,
             )
             .bind(status.as_str())
-            .bind(limit)
-            .bind(offset)
-            .fetch_all(&self.pool)
-            .await?;
+            .bind(page.limit())
+            .bind(page.offset())
+            .fetch_all(&self.pool);
 
-            let count: (i64,) =
-                sqlx::query_as("SELECT COUNT(*) FROM proof_requests WHERE status = $1")
-                    .bind(status.as_str())
-                    .fetch_one(&self.pool)
-                    .await?;
+            let count = sqlx::query_as::<_, (i64,)>(
+                "SELECT COUNT(*) FROM proof_requests WHERE status = $1",
+            )
+            .bind(status.as_str())
+            .fetch_one(&self.pool);
 
-            (rows, count)
+            futures::try_join!(rows, count)?
         } else {
-            let rows = sqlx::query(
+            let rows = sqlx::query_as::<_, ProofRequestListItem>(
                 r#"
                 SELECT
                     id, start_block_number, number_of_blocks_to_prove,
-                    sequence_window, proof_type,
-                    status, error_message,
-                    prover_address, l1_head, intermediate_root_interval,
-                    created_at, updated_at, completed_at, retry_count
+                    proof_type, status, error_message,
+                    created_at, updated_at, completed_at
                 FROM proof_requests
                 ORDER BY created_at DESC
                 LIMIT $1 OFFSET $2
                 "#,
             )
-            .bind(limit)
-            .bind(offset)
-            .fetch_all(&self.pool)
-            .await?;
+            .bind(page.limit())
+            .bind(page.offset())
+            .fetch_all(&self.pool);
 
-            let count: (i64,) =
-                sqlx::query_as("SELECT COUNT(*) FROM proof_requests").fetch_one(&self.pool).await?;
+            let count = sqlx::query_as::<_, (i64,)>("SELECT COUNT(*) FROM proof_requests")
+                .fetch_one(&self.pool);
 
-            (rows, count)
+            futures::try_join!(rows, count)?
         };
 
-        let proofs =
-            rows.iter().map(row_to_proof_request_without_receipts).collect::<Result<Vec<_>>>()?;
-        Ok((proofs, count.0.max(0) as u64))
+        Ok((rows, count.0.max(0) as u64))
     }
 
     // ========== Outbox Methods ==========
@@ -1020,19 +1007,6 @@ impl ProofRequestRepo {
 
 /// Helper function to convert a database row to `ProofRequest`
 fn row_to_proof_request(row: &sqlx::postgres::PgRow) -> Result<ProofRequest> {
-    row_to_proof_request_from_row(row, true)
-}
-
-/// Helper function to convert a database row to `ProofRequest` without loading receipt blobs.
-fn row_to_proof_request_without_receipts(row: &sqlx::postgres::PgRow) -> Result<ProofRequest> {
-    row_to_proof_request_from_row(row, false)
-}
-
-/// Convert a database row into `ProofRequest`, optionally reading receipt columns.
-fn row_to_proof_request_from_row(
-    row: &sqlx::postgres::PgRow,
-    read_receipt_columns: bool,
-) -> Result<ProofRequest> {
     let status_str: &str = row.get("status");
     let status = ProofStatus::try_from(status_str)
         .map_err(|e| sqlx::Error::Protocol(format!("Unknown proof status '{status_str}': {e}")))?;
@@ -1042,20 +1016,14 @@ fn row_to_proof_request_from_row(
         sqlx::Error::Protocol(format!("Unknown proof_type '{proof_type_str}': {e}"))
     })?;
 
-    let (stark_receipt, snark_receipt) = if read_receipt_columns {
-        (row.get("stark_receipt"), row.get("snark_receipt"))
-    } else {
-        (None, None)
-    };
-
     Ok(ProofRequest {
         id: row.get("id"),
         start_block_number: row.get("start_block_number"),
         number_of_blocks_to_prove: row.get("number_of_blocks_to_prove"),
         sequence_window: row.get("sequence_window"),
         proof_type,
-        stark_receipt,
-        snark_receipt,
+        stark_receipt: row.get("stark_receipt"),
+        snark_receipt: row.get("snark_receipt"),
         status,
         error_message: row.get("error_message"),
         prover_address: row.get("prover_address"),

--- a/crates/proof/zk/db/src/repo.rs
+++ b/crates/proof/zk/db/src/repo.rs
@@ -1028,6 +1028,7 @@ fn row_to_proof_request_without_receipts(row: &sqlx::postgres::PgRow) -> Result<
     row_to_proof_request_from_row(row, false)
 }
 
+/// Convert a database row into `ProofRequest`, optionally reading receipt columns.
 fn row_to_proof_request_from_row(
     row: &sqlx::postgres::PgRow,
     read_receipt_columns: bool,

--- a/crates/proof/zk/db/src/repo.rs
+++ b/crates/proof/zk/db/src/repo.rs
@@ -851,35 +851,61 @@ impl ProofRequestRepo {
         limit: i64,
         offset: i64,
     ) -> Result<(Vec<ProofRequest>, u64)> {
-        let status_str = status_filter.map(|s| s.as_str().to_string());
+        let (rows, count) = if let Some(status) = status_filter {
+            let rows = sqlx::query(
+                r#"
+                SELECT
+                    id, start_block_number, number_of_blocks_to_prove,
+                    sequence_window, proof_type,
+                    status, error_message,
+                    prover_address, l1_head, intermediate_root_interval,
+                    created_at, updated_at, completed_at, retry_count
+                FROM proof_requests
+                WHERE status = $1
+                ORDER BY created_at DESC
+                LIMIT $2 OFFSET $3
+                "#,
+            )
+            .bind(status.as_str())
+            .bind(limit)
+            .bind(offset)
+            .fetch_all(&self.pool)
+            .await?;
 
-        let rows = sqlx::query(
-            r#"
-            SELECT
-                id, start_block_number, number_of_blocks_to_prove, sequence_window,
-                proof_type, NULL::bytea AS stark_receipt, NULL::bytea AS snark_receipt,
-                status, error_message, prover_address, l1_head,
-                intermediate_root_interval, created_at, updated_at, completed_at, retry_count
-            FROM proof_requests
-            WHERE ($1::text IS NULL OR status = $1)
-            ORDER BY created_at DESC
-            LIMIT $2 OFFSET $3
-            "#,
-        )
-        .bind(status_str.as_deref())
-        .bind(limit)
-        .bind(offset)
-        .fetch_all(&self.pool)
-        .await?;
+            let count: (i64,) =
+                sqlx::query_as("SELECT COUNT(*) FROM proof_requests WHERE status = $1")
+                    .bind(status.as_str())
+                    .fetch_one(&self.pool)
+                    .await?;
 
-        let count: (i64,) = sqlx::query_as(
-            "SELECT COUNT(*) FROM proof_requests WHERE ($1::text IS NULL OR status = $1)",
-        )
-        .bind(status_str.as_deref())
-        .fetch_one(&self.pool)
-        .await?;
+            (rows, count)
+        } else {
+            let rows = sqlx::query(
+                r#"
+                SELECT
+                    id, start_block_number, number_of_blocks_to_prove,
+                    sequence_window, proof_type,
+                    status, error_message,
+                    prover_address, l1_head, intermediate_root_interval,
+                    created_at, updated_at, completed_at, retry_count
+                FROM proof_requests
+                ORDER BY created_at DESC
+                LIMIT $1 OFFSET $2
+                "#,
+            )
+            .bind(limit)
+            .bind(offset)
+            .fetch_all(&self.pool)
+            .await?;
 
-        let proofs = rows.iter().map(row_to_proof_request).collect::<Result<Vec<_>>>()?;
+            let count: (i64,) =
+                sqlx::query_as("SELECT COUNT(*) FROM proof_requests").fetch_one(&self.pool).await?;
+
+            (rows, count)
+        };
+
+        let proofs =
+            rows.iter().map(row_to_proof_request_without_receipts).collect::<Result<Vec<_>>>()?;
         Ok((proofs, count.0.max(0) as u64))
     }
 
@@ -1006,6 +1032,37 @@ fn row_to_proof_request(row: &sqlx::postgres::PgRow) -> Result<ProofRequest> {
         proof_type,
         stark_receipt: row.get("stark_receipt"),
         snark_receipt: row.get("snark_receipt"),
+        status,
+        error_message: row.get("error_message"),
+        prover_address: row.get("prover_address"),
+        l1_head: row.get("l1_head"),
+        intermediate_root_interval: row.get("intermediate_root_interval"),
+        created_at: row.get("created_at"),
+        updated_at: row.get("updated_at"),
+        completed_at: row.get("completed_at"),
+        retry_count: row.get("retry_count"),
+    })
+}
+
+/// Helper function to convert a database row to `ProofRequest` without loading receipt blobs.
+fn row_to_proof_request_without_receipts(row: &sqlx::postgres::PgRow) -> Result<ProofRequest> {
+    let status_str: &str = row.get("status");
+    let status = ProofStatus::try_from(status_str)
+        .map_err(|e| sqlx::Error::Protocol(format!("Unknown proof status '{status_str}': {e}")))?;
+
+    let proof_type_str: &str = row.get("proof_type");
+    let proof_type = ProofType::try_from(proof_type_str).map_err(|e| {
+        sqlx::Error::Protocol(format!("Unknown proof_type '{proof_type_str}': {e}"))
+    })?;
+
+    Ok(ProofRequest {
+        id: row.get("id"),
+        start_block_number: row.get("start_block_number"),
+        number_of_blocks_to_prove: row.get("number_of_blocks_to_prove"),
+        sequence_window: row.get("sequence_window"),
+        proof_type,
+        stark_receipt: None,
+        snark_receipt: None,
         status,
         error_message: row.get("error_message"),
         prover_address: row.get("prover_address"),

--- a/crates/proof/zk/db/src/repo.rs
+++ b/crates/proof/zk/db/src/repo.rs
@@ -848,9 +848,14 @@ impl ProofRequestRepo {
     pub async fn list_with_offset(
         &self,
         status_filter: Option<ProofStatus>,
-        limit: i64,
-        offset: i64,
+        limit: u64,
+        offset: u64,
     ) -> Result<(Vec<ProofRequest>, u64)> {
+        let limit = i64::try_from(limit)
+            .map_err(|_| sqlx::Error::Protocol("limit exceeds i64 range".into()))?;
+        let offset = i64::try_from(offset)
+            .map_err(|_| sqlx::Error::Protocol("offset exceeds i64 range".into()))?;
+
         let (rows, count) = if let Some(status) = status_filter {
             let rows = sqlx::query(
                 r#"
@@ -1015,37 +1020,18 @@ impl ProofRequestRepo {
 
 /// Helper function to convert a database row to `ProofRequest`
 fn row_to_proof_request(row: &sqlx::postgres::PgRow) -> Result<ProofRequest> {
-    let status_str: &str = row.get("status");
-    let status = ProofStatus::try_from(status_str)
-        .map_err(|e| sqlx::Error::Protocol(format!("Unknown proof status '{status_str}': {e}")))?;
-
-    let proof_type_str: &str = row.get("proof_type");
-    let proof_type = ProofType::try_from(proof_type_str).map_err(|e| {
-        sqlx::Error::Protocol(format!("Unknown proof_type '{proof_type_str}': {e}"))
-    })?;
-
-    Ok(ProofRequest {
-        id: row.get("id"),
-        start_block_number: row.get("start_block_number"),
-        number_of_blocks_to_prove: row.get("number_of_blocks_to_prove"),
-        sequence_window: row.get("sequence_window"),
-        proof_type,
-        stark_receipt: row.get("stark_receipt"),
-        snark_receipt: row.get("snark_receipt"),
-        status,
-        error_message: row.get("error_message"),
-        prover_address: row.get("prover_address"),
-        l1_head: row.get("l1_head"),
-        intermediate_root_interval: row.get("intermediate_root_interval"),
-        created_at: row.get("created_at"),
-        updated_at: row.get("updated_at"),
-        completed_at: row.get("completed_at"),
-        retry_count: row.get("retry_count"),
-    })
+    row_to_proof_request_from_row(row, true)
 }
 
 /// Helper function to convert a database row to `ProofRequest` without loading receipt blobs.
 fn row_to_proof_request_without_receipts(row: &sqlx::postgres::PgRow) -> Result<ProofRequest> {
+    row_to_proof_request_from_row(row, false)
+}
+
+fn row_to_proof_request_from_row(
+    row: &sqlx::postgres::PgRow,
+    read_receipt_columns: bool,
+) -> Result<ProofRequest> {
     let status_str: &str = row.get("status");
     let status = ProofStatus::try_from(status_str)
         .map_err(|e| sqlx::Error::Protocol(format!("Unknown proof status '{status_str}': {e}")))?;
@@ -1055,14 +1041,20 @@ fn row_to_proof_request_without_receipts(row: &sqlx::postgres::PgRow) -> Result<
         sqlx::Error::Protocol(format!("Unknown proof_type '{proof_type_str}': {e}"))
     })?;
 
+    let (stark_receipt, snark_receipt) = if read_receipt_columns {
+        (row.get("stark_receipt"), row.get("snark_receipt"))
+    } else {
+        (None, None)
+    };
+
     Ok(ProofRequest {
         id: row.get("id"),
         start_block_number: row.get("start_block_number"),
         number_of_blocks_to_prove: row.get("number_of_blocks_to_prove"),
         sequence_window: row.get("sequence_window"),
         proof_type,
-        stark_receipt: None,
-        snark_receipt: None,
+        stark_receipt,
+        snark_receipt,
         status,
         error_message: row.get("error_message"),
         prover_address: row.get("prover_address"),

--- a/crates/proof/zk/service/src/server/list_proofs.rs
+++ b/crates/proof/zk/service/src/server/list_proofs.rs
@@ -1,0 +1,153 @@
+//! Implementation of the `ListProofs` gRPC endpoint.
+
+use base_zk_client::{
+    ListProofsRequest, ListProofsResponse, ProofJobStatus, ProofSummary, get_proof_response,
+};
+use base_zk_db::ProofStatus;
+use tonic::{Request, Response, Status};
+use tracing::debug;
+
+use crate::{metrics, server::ProverServiceServer};
+
+const MAX_LIMIT: u64 = 100;
+const DEFAULT_LIMIT: u64 = 50;
+
+impl ProverServiceServer {
+    /// Returns a paginated list of proof summaries for the given filter.
+    pub async fn list_proofs_impl(
+        &self,
+        request: Request<ListProofsRequest>,
+    ) -> Result<Response<ListProofsResponse>, Status> {
+        let start = std::time::Instant::now();
+        let result = self.list_proofs_inner(request).await;
+
+        let (success, status_code) = match &result {
+            Ok(_) => (true, "OK"),
+            Err(s) => (false, metrics::grpc_status_code_str(s.code())),
+        };
+        let elapsed_ms = start.elapsed().as_secs_f64() * 1000.0;
+        metrics::inc_requests("ListProofs", success, status_code);
+        metrics::record_response_latency("ListProofs", success, elapsed_ms);
+
+        result
+    }
+
+    async fn list_proofs_inner(
+        &self,
+        request: Request<ListProofsRequest>,
+    ) -> Result<Response<ListProofsResponse>, Status> {
+        let req = request.into_inner();
+
+        let limit = match req.limit {
+            0 => DEFAULT_LIMIT,
+            n if n > MAX_LIMIT => MAX_LIMIT,
+            n => n,
+        };
+
+        let offset = req.offset;
+        if offset > i64::MAX as u64 {
+            return Err(Status::invalid_argument("offset exceeds maximum supported value"));
+        }
+
+        let status_filter = match req.status_filter {
+            None => None,
+            Some(v) => {
+                let proto_status = get_proof_response::Status::try_from(v).map_err(|_| {
+                    Status::invalid_argument(format!("invalid status_filter value: {v}"))
+                })?;
+                match proto_status {
+                    get_proof_response::Status::Unspecified => None,
+                    get_proof_response::Status::Created => Some(ProofStatus::Created),
+                    get_proof_response::Status::Pending => Some(ProofStatus::Pending),
+                    get_proof_response::Status::Running => Some(ProofStatus::Running),
+                    get_proof_response::Status::Succeeded => Some(ProofStatus::Succeeded),
+                    get_proof_response::Status::Failed => Some(ProofStatus::Failed),
+                }
+            }
+        };
+
+        debug!(
+            limit = limit,
+            offset = offset,
+            status_filter = ?status_filter,
+            "listing proofs"
+        );
+
+        let (proofs, total_count) = self
+            .repo
+            .list_with_offset(status_filter, limit as i64, offset as i64)
+            .await
+            .map_err(|e| Status::internal(format!("database error: {e}")))?;
+
+        let summaries: Vec<ProofSummary> = proofs
+            .into_iter()
+            .map(|p| ProofSummary {
+                id: p.id.to_string(),
+                start_block_number: p.start_block_number.max(0) as u64,
+                number_of_blocks_to_prove: p.number_of_blocks_to_prove.max(0) as u64,
+                proof_type: p.proof_type.proto_i32(),
+                status: proto_status(p.status).into(),
+                created_at: p.created_at.to_rfc3339(),
+                updated_at: p.updated_at.to_rfc3339(),
+                completed_at: p.completed_at.map(|t| t.to_rfc3339()),
+                error_message: p.error_message,
+            })
+            .collect();
+
+        Ok(Response::new(ListProofsResponse { proofs: summaries, total_count }))
+    }
+}
+
+const fn proto_status(status: ProofStatus) -> ProofJobStatus {
+    match status {
+        ProofStatus::Created => ProofJobStatus::Created,
+        ProofStatus::Pending => ProofJobStatus::Pending,
+        ProofStatus::Running => ProofJobStatus::Running,
+        ProofStatus::Succeeded => ProofJobStatus::Succeeded,
+        ProofStatus::Failed => ProofJobStatus::Failed,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn proto_status_maps_all_variants() {
+        assert_eq!(proto_status(ProofStatus::Created), ProofJobStatus::Created);
+        assert_eq!(proto_status(ProofStatus::Pending), ProofJobStatus::Pending);
+        assert_eq!(proto_status(ProofStatus::Running), ProofJobStatus::Running);
+        assert_eq!(proto_status(ProofStatus::Succeeded), ProofJobStatus::Succeeded);
+        assert_eq!(proto_status(ProofStatus::Failed), ProofJobStatus::Failed);
+    }
+
+    #[test]
+    fn limit_clamping_zero_uses_default() {
+        let limit = match 0u64 {
+            0 => DEFAULT_LIMIT,
+            n if n > MAX_LIMIT => MAX_LIMIT,
+            n => n,
+        };
+        assert_eq!(limit, 50);
+    }
+
+    #[test]
+    fn limit_clamping_exceeds_max_caps_at_100() {
+        let limit = match 500u64 {
+            0 => DEFAULT_LIMIT,
+            n if n > MAX_LIMIT => MAX_LIMIT,
+            n => n,
+        };
+        assert_eq!(limit, MAX_LIMIT);
+    }
+
+    #[test]
+    fn limit_clamping_valid_value_passthrough() {
+        let limit = match 25u64 {
+            0 => DEFAULT_LIMIT,
+            n if n > MAX_LIMIT => MAX_LIMIT,
+            n => n,
+        };
+        assert_eq!(limit, 25);
+    }
+}

--- a/crates/proof/zk/service/src/server/list_proofs.rs
+++ b/crates/proof/zk/service/src/server/list_proofs.rs
@@ -52,7 +52,7 @@ impl ProverServiceServer {
 
         let (proofs, total_count) = self
             .repo
-            .list_with_offset(status_filter, limit as i64, offset)
+            .list_with_offset(status_filter, limit, offset)
             .await
             .map_err(|e| Status::internal(format!("database error: {e}")))?;
 
@@ -83,12 +83,12 @@ const fn clamp_limit(limit: u64) -> u64 {
     }
 }
 
-fn validate_offset(offset: u64) -> Result<i64, Status> {
+fn validate_offset(offset: u64) -> Result<u64, Status> {
     if offset > i64::MAX as u64 {
         return Err(Status::invalid_argument("offset exceeds maximum supported value"));
     }
 
-    Ok(offset as i64)
+    Ok(offset)
 }
 
 fn parse_status_filter(status_filter: Option<i32>) -> Result<Option<ProofStatus>, Status> {

--- a/crates/proof/zk/service/src/server/list_proofs.rs
+++ b/crates/proof/zk/service/src/server/list_proofs.rs
@@ -1,9 +1,10 @@
 //! Implementation of the `ListProofs` gRPC endpoint.
 
 use base_zk_client::{
-    ListProofsRequest, ListProofsResponse, ProofJobStatus, ProofSummary, get_proof_response,
+    ListProofsRequest, ListProofsResponse, ProofJobStatus, ProofSummary,
+    ProofType as ProtoProofType, get_proof_response,
 };
-use base_zk_db::ProofStatus;
+use base_zk_db::{ProofStatus, ProofType as DbProofType};
 use tonic::{Request, Response, Status};
 use tracing::debug;
 
@@ -38,33 +39,9 @@ impl ProverServiceServer {
     ) -> Result<Response<ListProofsResponse>, Status> {
         let req = request.into_inner();
 
-        let limit = match req.limit {
-            0 => DEFAULT_LIMIT,
-            n if n > MAX_LIMIT => MAX_LIMIT,
-            n => n,
-        };
-
-        let offset = req.offset;
-        if offset > i64::MAX as u64 {
-            return Err(Status::invalid_argument("offset exceeds maximum supported value"));
-        }
-
-        let status_filter = match req.status_filter {
-            None => None,
-            Some(v) => {
-                let proto_status = get_proof_response::Status::try_from(v).map_err(|_| {
-                    Status::invalid_argument(format!("invalid status_filter value: {v}"))
-                })?;
-                match proto_status {
-                    get_proof_response::Status::Unspecified => None,
-                    get_proof_response::Status::Created => Some(ProofStatus::Created),
-                    get_proof_response::Status::Pending => Some(ProofStatus::Pending),
-                    get_proof_response::Status::Running => Some(ProofStatus::Running),
-                    get_proof_response::Status::Succeeded => Some(ProofStatus::Succeeded),
-                    get_proof_response::Status::Failed => Some(ProofStatus::Failed),
-                }
-            }
-        };
+        let limit = clamp_limit(req.limit);
+        let offset = validate_offset(req.offset)?;
+        let status_filter = parse_status_filter(req.status_filter)?;
 
         debug!(
             limit = limit,
@@ -75,7 +52,7 @@ impl ProverServiceServer {
 
         let (proofs, total_count) = self
             .repo
-            .list_with_offset(status_filter, limit as i64, offset as i64)
+            .list_with_offset(status_filter, limit as i64, offset)
             .await
             .map_err(|e| Status::internal(format!("database error: {e}")))?;
 
@@ -85,7 +62,7 @@ impl ProverServiceServer {
                 id: p.id.to_string(),
                 start_block_number: p.start_block_number.max(0) as u64,
                 number_of_blocks_to_prove: p.number_of_blocks_to_prove.max(0) as u64,
-                proof_type: p.proof_type.proto_i32(),
+                proof_type: proto_proof_type(p.proof_type).into(),
                 status: proto_status(p.status).into(),
                 created_at: p.created_at.to_rfc3339(),
                 updated_at: p.updated_at.to_rfc3339(),
@@ -95,6 +72,48 @@ impl ProverServiceServer {
             .collect();
 
         Ok(Response::new(ListProofsResponse { proofs: summaries, total_count }))
+    }
+}
+
+const fn clamp_limit(limit: u64) -> u64 {
+    match limit {
+        0 => DEFAULT_LIMIT,
+        n if n > MAX_LIMIT => MAX_LIMIT,
+        n => n,
+    }
+}
+
+fn validate_offset(offset: u64) -> Result<i64, Status> {
+    if offset > i64::MAX as u64 {
+        return Err(Status::invalid_argument("offset exceeds maximum supported value"));
+    }
+
+    Ok(offset as i64)
+}
+
+fn parse_status_filter(status_filter: Option<i32>) -> Result<Option<ProofStatus>, Status> {
+    match status_filter {
+        None => Ok(None),
+        Some(v) => {
+            let proto_status = get_proof_response::Status::try_from(v).map_err(|_| {
+                Status::invalid_argument(format!("invalid status_filter value: {v}"))
+            })?;
+            Ok(match proto_status {
+                get_proof_response::Status::Unspecified => None,
+                get_proof_response::Status::Created => Some(ProofStatus::Created),
+                get_proof_response::Status::Pending => Some(ProofStatus::Pending),
+                get_proof_response::Status::Running => Some(ProofStatus::Running),
+                get_proof_response::Status::Succeeded => Some(ProofStatus::Succeeded),
+                get_proof_response::Status::Failed => Some(ProofStatus::Failed),
+            })
+        }
+    }
+}
+
+const fn proto_proof_type(proof_type: DbProofType) -> ProtoProofType {
+    match proof_type {
+        DbProofType::OpSuccinctSp1ClusterCompressed => ProtoProofType::Compressed,
+        DbProofType::OpSuccinctSp1ClusterSnarkGroth16 => ProtoProofType::SnarkGroth16,
     }
 }
 
@@ -122,32 +141,52 @@ mod tests {
     }
 
     #[test]
-    fn limit_clamping_zero_uses_default() {
-        let limit = match 0u64 {
-            0 => DEFAULT_LIMIT,
-            n if n > MAX_LIMIT => MAX_LIMIT,
-            n => n,
-        };
-        assert_eq!(limit, 50);
+    fn proto_proof_type_maps_all_variants() {
+        assert_eq!(
+            proto_proof_type(DbProofType::OpSuccinctSp1ClusterCompressed),
+            ProtoProofType::Compressed
+        );
+        assert_eq!(
+            proto_proof_type(DbProofType::OpSuccinctSp1ClusterSnarkGroth16),
+            ProtoProofType::SnarkGroth16
+        );
     }
 
     #[test]
-    fn limit_clamping_exceeds_max_caps_at_100() {
-        let limit = match 500u64 {
-            0 => DEFAULT_LIMIT,
-            n if n > MAX_LIMIT => MAX_LIMIT,
-            n => n,
-        };
-        assert_eq!(limit, MAX_LIMIT);
+    fn clamp_limit_handles_default_max_and_passthrough() {
+        assert_eq!(clamp_limit(0), DEFAULT_LIMIT);
+        assert_eq!(clamp_limit(500), MAX_LIMIT);
+        assert_eq!(clamp_limit(25), 25);
     }
 
     #[test]
-    fn limit_clamping_valid_value_passthrough() {
-        let limit = match 25u64 {
-            0 => DEFAULT_LIMIT,
-            n if n > MAX_LIMIT => MAX_LIMIT,
-            n => n,
-        };
-        assert_eq!(limit, 25);
+    fn validate_offset_rejects_overflow() {
+        let err = validate_offset(i64::MAX as u64 + 1).unwrap_err();
+        assert_eq!(err.code(), tonic::Code::InvalidArgument);
+    }
+
+    #[test]
+    fn status_filter_maps_unset_unspecified_and_valid_values() {
+        assert_eq!(parse_status_filter(None).unwrap(), None);
+        assert_eq!(
+            parse_status_filter(Some(get_proof_response::Status::Unspecified as i32)).unwrap(),
+            None
+        );
+
+        for (proto, expected) in [
+            (get_proof_response::Status::Created, ProofStatus::Created),
+            (get_proof_response::Status::Pending, ProofStatus::Pending),
+            (get_proof_response::Status::Running, ProofStatus::Running),
+            (get_proof_response::Status::Succeeded, ProofStatus::Succeeded),
+            (get_proof_response::Status::Failed, ProofStatus::Failed),
+        ] {
+            assert_eq!(parse_status_filter(Some(proto as i32)).unwrap(), Some(expected));
+        }
+    }
+
+    #[test]
+    fn status_filter_rejects_invalid_value() {
+        let err = parse_status_filter(Some(999)).unwrap_err();
+        assert_eq!(err.code(), tonic::Code::InvalidArgument);
     }
 }

--- a/crates/proof/zk/service/src/server/list_proofs.rs
+++ b/crates/proof/zk/service/src/server/list_proofs.rs
@@ -159,6 +159,12 @@ mod tests {
     }
 
     #[test]
+    fn proof_request_page_rejects_zero_limit() {
+        let err = ProofRequestPage::try_new(0, 0).unwrap_err();
+        assert_eq!(err, "limit must be greater than zero");
+    }
+
+    #[test]
     fn status_filter_maps_unset_unspecified_and_valid_values() {
         assert_eq!(parse_status_filter(None).unwrap(), None);
         assert_eq!(

--- a/crates/proof/zk/service/src/server/list_proofs.rs
+++ b/crates/proof/zk/service/src/server/list_proofs.rs
@@ -4,7 +4,7 @@ use base_zk_client::{
     ListProofsRequest, ListProofsResponse, ProofJobStatus, ProofSummary,
     ProofType as ProtoProofType, get_proof_response,
 };
-use base_zk_db::{ProofStatus, ProofType as DbProofType};
+use base_zk_db::{ProofRequestPage, ProofStatus, ProofType as DbProofType};
 use tonic::{Request, Response, Status};
 use tracing::debug;
 
@@ -40,19 +40,20 @@ impl ProverServiceServer {
         let req = request.into_inner();
 
         let limit = clamp_limit(req.limit);
-        let offset = validate_offset(req.offset)?;
+        let page =
+            ProofRequestPage::try_new(limit, req.offset).map_err(Status::invalid_argument)?;
         let status_filter = parse_status_filter(req.status_filter)?;
 
         debug!(
             limit = limit,
-            offset = offset,
+            offset = req.offset,
             status_filter = ?status_filter,
             "listing proofs"
         );
 
         let (proofs, total_count) = self
             .repo
-            .list_with_offset(status_filter, limit, offset)
+            .list_with_offset(status_filter, page)
             .await
             .map_err(|e| Status::internal(format!("database error: {e}")))?;
 
@@ -81,14 +82,6 @@ const fn clamp_limit(limit: u64) -> u64 {
         n if n > MAX_LIMIT => MAX_LIMIT,
         n => n,
     }
-}
-
-fn validate_offset(offset: u64) -> Result<u64, Status> {
-    if offset > i64::MAX as u64 {
-        return Err(Status::invalid_argument("offset exceeds maximum supported value"));
-    }
-
-    Ok(offset)
 }
 
 fn parse_status_filter(status_filter: Option<i32>) -> Result<Option<ProofStatus>, Status> {
@@ -160,9 +153,9 @@ mod tests {
     }
 
     #[test]
-    fn validate_offset_rejects_overflow() {
-        let err = validate_offset(i64::MAX as u64 + 1).unwrap_err();
-        assert_eq!(err.code(), tonic::Code::InvalidArgument);
+    fn proof_request_page_rejects_offset_overflow() {
+        let err = ProofRequestPage::try_new(MAX_LIMIT, i64::MAX as u64 + 1).unwrap_err();
+        assert_eq!(err, "offset exceeds maximum supported value");
     }
 
     #[test]

--- a/crates/proof/zk/service/src/server/mod.rs
+++ b/crates/proof/zk/service/src/server/mod.rs
@@ -3,8 +3,8 @@
 use std::fmt;
 
 use base_zk_client::{
-    GetProofRequest, GetProofResponse, ProveBlockRequest, ProveBlockResponse,
-    prover_service_server::ProverService,
+    GetProofRequest, GetProofResponse, ListProofsRequest, ListProofsResponse, ProveBlockRequest,
+    ProveBlockResponse, prover_service_server::ProverService,
 };
 use base_zk_db::ProofRequestRepo;
 use tonic::{Request, Response, Status};
@@ -12,6 +12,7 @@ use tonic::{Request, Response, Status};
 use crate::proof_request_manager::ProofRequestManager;
 
 mod get_proof;
+mod list_proofs;
 mod prove_block;
 
 /// gRPC server implementing the `ProverService` trait.
@@ -48,5 +49,12 @@ impl ProverService for ProverServiceServer {
         request: Request<GetProofRequest>,
     ) -> std::result::Result<tonic::Response<GetProofResponse>, Status> {
         self.get_proof_impl(request).await
+    }
+
+    async fn list_proofs(
+        &self,
+        request: Request<ListProofsRequest>,
+    ) -> Result<Response<ListProofsResponse>, Status> {
+        self.list_proofs_impl(request).await
     }
 }


### PR DESCRIPTION
Introduces a ListProofs RPC to the zk-prover-service so consumers can retrieve paginated proof summaries.

Closes CHAIN-4365