### PR TITLE
feat(basectl): add ZK prover TUI dashboard

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5841,6 +5841,7 @@ dependencies = [
  "base-consensus-rpc",
  "base-load-tests",
  "base-protocol",
+ "base-zk-client",
  "chrono",
  "crossterm",
  "dirs 6.0.0",
@@ -5852,6 +5853,7 @@ dependencies = [
  "serde_yaml",
  "tokio",
  "tokio-tungstenite 0.28.0",
+ "tonic 0.14.5",
  "tracing",
  "url",
 ]

--- a/bin/basectl/src/cli.rs
+++ b/bin/basectl/src/cli.rs
@@ -39,4 +39,7 @@ pub(crate) enum Commands {
     /// Network upgrade activation countdown and history
     #[command(visible_alias = "u")]
     Upgrades,
+    /// ZK prover service dashboard
+    #[command(visible_alias = "pv")]
+    Prover,
 }

--- a/bin/basectl/src/main.rs
+++ b/bin/basectl/src/main.rs
@@ -26,6 +26,7 @@ async fn main() -> anyhow::Result<()> {
         Some(cli::Commands::CommandCenter) => run_app(ViewId::CommandCenter, config).await,
         Some(cli::Commands::Conductor) => run_app(ViewId::Conductor, config).await,
         Some(cli::Commands::Upgrades) => run_app(ViewId::Upgrades, config).await,
+        Some(cli::Commands::Prover) => run_app(ViewId::Prover, config).await,
         None => run_app(ViewId::Home, config).await,
     }
 }

--- a/crates/infra/basectl/Cargo.toml
+++ b/crates/infra/basectl/Cargo.toml
@@ -22,7 +22,9 @@ base-common-chains = { workspace = true }
 base-common-network = { workspace = true }
 base-consensus-gossip = { workspace = true }
 base-common-flashblocks = { workspace = true }
+base-zk-client = { workspace = true }
 url = { workspace = true, features = ["serde"] }
+tonic = { workspace = true, features = ["transport"] }
 serde = { workspace = true, features = ["std"] }
 tracing = { workspace = true, features = ["std"] }
 tokio = { workspace = true, features = ["process"] }

--- a/crates/infra/basectl/src/app/mod.rs
+++ b/crates/infra/basectl/src/app/mod.rs
@@ -8,7 +8,8 @@ pub use core::App;
 
 mod resources;
 pub use resources::{
-    ConductorState, DaState, FlashState, LoadTestTask, ProofsState, Resources, ValidatorState,
+    ConductorState, DaState, FlashState, LoadTestTask, ProofsState, ProverState, Resources,
+    ValidatorState,
 };
 
 mod router;
@@ -24,5 +25,5 @@ pub use view::View;
 mod views;
 pub use views::{
     CommandCenterView, ConductorView, ConfigView, DaMonitorView, FlashblocksView, HomeView,
-    LoadTestView, ProofsView, TransactionPane, UpgradesView, create_view,
+    LoadTestView, ProofsView, ProverView, TransactionPane, UpgradesView, create_view,
 };

--- a/crates/infra/basectl/src/app/resources.rs
+++ b/crates/infra/basectl/src/app/resources.rs
@@ -15,7 +15,7 @@ use crate::{
     config::{ConductorNodeConfig, MonitoringConfig},
     rpc::{
         BacklogFetchResult, BlockDaInfo, ConductorNodeStatus, L1BlockInfo, L1ConnectionMode,
-        ProofsSnapshot, TimestampedFlashblock, ValidatorNodeStatus,
+        ProofsSnapshot, ProverSnapshot, TimestampedFlashblock, ValidatorNodeStatus,
     },
     tui::ToastState,
 };
@@ -141,6 +141,29 @@ impl ProofsState {
     }
 }
 
+/// State for ZK prover service monitoring (proof job list).
+#[derive(Debug, Default)]
+pub struct ProverState {
+    /// Most recent prover snapshot from the background poller.
+    pub snapshot: Option<ProverSnapshot>,
+    rx: Option<mpsc::Receiver<ProverSnapshot>>,
+}
+
+impl ProverState {
+    /// Sets the channel for receiving prover snapshots.
+    pub fn set_channel(&mut self, rx: mpsc::Receiver<ProverSnapshot>) {
+        self.rx = Some(rx);
+    }
+
+    /// Drains the latest snapshot from the background poller.
+    pub fn poll(&mut self) {
+        let Some(ref mut rx) = self.rx else { return };
+        while let Ok(snapshot) = rx.try_recv() {
+            self.snapshot = Some(snapshot);
+        }
+    }
+}
+
 /// Handle to a running load test task and its stop signal, used by [`super::App`]
 /// to await drain completion on shutdown so funds are returned to the funder.
 #[derive(Debug)]
@@ -168,6 +191,8 @@ pub struct Resources {
     pub validators: ValidatorState,
     /// Proof system monitoring state.
     pub proofs: ProofsState,
+    /// ZK prover service monitoring state.
+    pub prover: ProverState,
     /// L1 system config fetched from the contract.
     pub system_config: Option<SystemConfig>,
     sys_config_rx: Option<mpsc::Receiver<SystemConfig>>,
@@ -230,6 +255,7 @@ impl Resources {
             conductor: ConductorState::default(),
             validators: ValidatorState::default(),
             proofs: ProofsState::default(),
+            prover: ProverState::default(),
             system_config: None,
             sys_config_rx: None,
             load_test_task: None,

--- a/crates/infra/basectl/src/app/router.rs
+++ b/crates/infra/basectl/src/app/router.rs
@@ -15,6 +15,8 @@ pub enum ViewId {
     Conductor,
     /// Proof system monitor (dispute games, anchor state).
     Proofs,
+    /// ZK prover service dashboard (proof jobs list).
+    Prover,
     /// Load test runner and metrics viewer.
     LoadTest,
     /// Network upgrade activation countdown and history.

--- a/crates/infra/basectl/src/app/runner.rs
+++ b/crates/infra/basectl/src/app/runner.rs
@@ -11,10 +11,10 @@ use crate::{
     l1_client::fetch_full_system_config,
     rpc::{
         BacklogFetchResult, BlockDaInfo, ConductorNodeStatus, L1BlockInfo, L1ConnectionMode,
-        ProofsSnapshot, TimestampedFlashblock, ValidatorNodeStatus,
+        ProofsSnapshot, ProverSnapshot, TimestampedFlashblock, ValidatorNodeStatus,
         fetch_initial_backlog_with_progress, run_block_fetcher, run_conductor_poller,
         run_flashblock_ws, run_flashblock_ws_timestamped, run_l1_blob_watcher, run_proofs_poller,
-        run_safe_head_poller, run_validator_poller,
+        run_prover_poller, run_safe_head_poller, run_validator_poller,
     },
     tui::Toast,
 };
@@ -93,6 +93,7 @@ pub fn start_background_services(config: &MonitoringConfig, resources: &mut Reso
     tokio::spawn(fetch_initial_backlog_with_progress(config.rpc.to_string(), backlog_tx));
 
     let proofs_toast_tx = toast_tx.clone();
+    let prover_toast_tx = toast_tx.clone();
     tokio::spawn(run_safe_head_poller(config.rpc.to_string(), sync_tx, toast_tx));
 
     let (sys_config_tx, sys_config_rx) = mpsc::channel::<SystemConfig>(1);
@@ -134,6 +135,16 @@ pub fn start_background_services(config: &MonitoringConfig, resources: &mut Reso
             config.rpc.clone(),
             proofs_tx,
             proofs_toast_tx,
+        ));
+    }
+
+    if let Some(ref prover_rpc) = config.prover_rpc {
+        let (prover_tx, prover_rx) = mpsc::channel::<ProverSnapshot>(4);
+        resources.prover.set_channel(prover_rx);
+        tokio::spawn(run_prover_poller(
+            prover_rpc.to_string(),
+            prover_tx,
+            prover_toast_tx,
         ));
     }
 }

--- a/crates/infra/basectl/src/app/views/factory.rs
+++ b/crates/infra/basectl/src/app/views/factory.rs
@@ -1,6 +1,6 @@
 use super::{
     CommandCenterView, ConductorView, ConfigView, DaMonitorView, FlashblocksView, HomeView,
-    LoadTestView, ProofsView, UpgradesView,
+    LoadTestView, ProofsView, ProverView, UpgradesView,
 };
 use crate::app::{View, ViewId};
 
@@ -14,6 +14,7 @@ pub fn create_view(view_id: ViewId) -> Box<dyn View> {
         ViewId::Flashblocks => Box::new(FlashblocksView::new()),
         ViewId::Config => Box::new(ConfigView::new()),
         ViewId::Proofs => Box::new(ProofsView::new()),
+        ViewId::Prover => Box::new(ProverView::new()),
         ViewId::LoadTest => Box::new(LoadTestView::new()),
         ViewId::Upgrades => Box::new(UpgradesView::new()),
     }

--- a/crates/infra/basectl/src/app/views/home.rs
+++ b/crates/infra/basectl/src/app/views/home.rs
@@ -88,6 +88,13 @@ const MENU_ITEMS: &[MenuItem] = &[
         badge: None,
         view_id: Some(ViewId::Upgrades),
     },
+    MenuItem {
+        key: 'z',
+        label: "ZK Prover",
+        description: "Monitor ZK prover jobs and proof status",
+        badge: Some("config-required"),
+        view_id: Some(ViewId::Prover),
+    },
     MenuItem { key: 'q', label: "Quit", description: "Exit basectl", badge: None, view_id: None },
 ];
 
@@ -100,6 +107,7 @@ const KEYBINDINGS: &[Keybinding] = &[
     Keybinding { key: "l", description: "Load Test" },
     Keybinding { key: "p", description: "Proofs" },
     Keybinding { key: "u", description: "Upgrades" },
+    Keybinding { key: "z", description: "ZK Prover" },
     Keybinding { key: "j/k", description: "Navigate" },
     Keybinding { key: "←/→", description: "Switch column" },
     Keybinding { key: "Enter", description: "Select" },
@@ -141,6 +149,7 @@ impl View for HomeView {
             KeyCode::Char('l') => Action::SwitchView(ViewId::LoadTest),
             KeyCode::Char('p') => Action::SwitchView(ViewId::Proofs),
             KeyCode::Char('u') => Action::SwitchView(ViewId::Upgrades),
+            KeyCode::Char('z') => Action::SwitchView(ViewId::Prover),
             KeyCode::Up | KeyCode::Char('k') => {
                 self.selected_index = self.selected_index.saturating_sub(1);
                 Action::None

--- a/crates/infra/basectl/src/app/views/mod.rs
+++ b/crates/infra/basectl/src/app/views/mod.rs
@@ -27,6 +27,9 @@ pub use load_test::LoadTestView;
 mod proofs;
 pub use proofs::ProofsView;
 
+mod prover;
+pub use prover::ProverView;
+
 mod transaction_pane;
 pub use transaction_pane::TransactionPane;
 

--- a/crates/infra/basectl/src/app/views/prover.rs
+++ b/crates/infra/basectl/src/app/views/prover.rs
@@ -1,0 +1,275 @@
+use crossterm::event::{KeyCode, KeyEvent};
+use ratatui::{
+    layout::{Alignment, Constraint, Direction, Layout, Rect},
+    prelude::*,
+    widgets::{Block, Borders, Cell, Paragraph, Row, Table, TableState},
+};
+
+use crate::{
+    app::{Action, Resources, View},
+    commands::COLOR_BASE_BLUE,
+    rpc::ProverSnapshot,
+    tui::Keybinding,
+};
+
+const KEYBINDINGS: &[Keybinding] = &[
+    Keybinding { key: "j/k", description: "Navigate rows" },
+    Keybinding { key: "n/p", description: "Next/prev page" },
+    Keybinding { key: "f", description: "Cycle status filter" },
+    Keybinding { key: "Esc", description: "Back to home" },
+    Keybinding { key: "?", description: "Toggle help" },
+];
+
+const PAGE_SIZE: usize = 20;
+
+const STATUS_FILTERS: &[Option<i32>] = &[None, Some(1), Some(2), Some(3), Some(4)];
+
+const STATUS_LABELS: &[&str] = &["All", "Queued", "InProgress", "Succeeded", "Failed"];
+
+/// ZK prover service proof list view.
+#[derive(Debug, Default)]
+pub struct ProverView {
+    table_state: TableState,
+    selected: usize,
+    page: usize,
+    filter_idx: usize,
+    snapshot: Option<ProverSnapshot>,
+}
+
+impl ProverView {
+    /// Creates a new prover view.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    fn visible_proofs(&self) -> &[base_zk_client::ProofSummary] {
+        self.snapshot.as_ref().map_or(&[], |s| &s.proofs)
+    }
+
+    fn page_count(&self) -> usize {
+        let total = self.visible_proofs().len();
+        if total == 0 { 1 } else { total.div_ceil(PAGE_SIZE) }
+    }
+
+    fn page_slice(&self) -> &[base_zk_client::ProofSummary] {
+        let proofs = self.visible_proofs();
+        let start = self.page * PAGE_SIZE;
+        let end = (start + PAGE_SIZE).min(proofs.len());
+        if start >= proofs.len() { &[] } else { &proofs[start..end] }
+    }
+}
+
+impl View for ProverView {
+    fn keybindings(&self) -> &'static [Keybinding] {
+        KEYBINDINGS
+    }
+
+    fn tick(&mut self, resources: &mut Resources) -> Action {
+        resources.prover.poll();
+        if let Some(ref snapshot) = resources.prover.snapshot {
+            self.snapshot = Some(snapshot.clone());
+        }
+        Action::None
+    }
+
+    fn handle_key(&mut self, key: KeyEvent, _resources: &mut Resources) -> Action {
+        let page_items = self.page_slice().len();
+
+        match key.code {
+            KeyCode::Char('j') | KeyCode::Down => {
+                if page_items > 0 {
+                    self.selected = (self.selected + 1) % page_items;
+                    self.table_state.select(Some(self.selected));
+                }
+            }
+            KeyCode::Char('k') | KeyCode::Up => {
+                if page_items > 0 {
+                    self.selected = (self.selected + page_items - 1) % page_items;
+                    self.table_state.select(Some(self.selected));
+                }
+            }
+            KeyCode::Char('n') => {
+                if self.page + 1 < self.page_count() {
+                    self.page += 1;
+                    self.selected = 0;
+                    self.table_state.select(Some(0));
+                }
+            }
+            KeyCode::Char('p') => {
+                if self.page > 0 {
+                    self.page -= 1;
+                    self.selected = 0;
+                    self.table_state.select(Some(0));
+                }
+            }
+            KeyCode::Char('f') => {
+                self.filter_idx = (self.filter_idx + 1) % STATUS_FILTERS.len();
+                self.page = 0;
+                self.selected = 0;
+                self.table_state.select(Some(0));
+            }
+            _ => {}
+        }
+
+        Action::None
+    }
+
+    fn render(&mut self, frame: &mut Frame<'_>, area: Rect, _resources: &Resources) {
+        let chunks = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([Constraint::Length(3), Constraint::Min(0), Constraint::Length(1)])
+            .split(area);
+
+        render_header(frame, chunks[0], &self.snapshot, self.filter_idx);
+        render_table(frame, chunks[1], self, self.page);
+        render_footer(frame, chunks[2], self.page, self.page_count(), self.filter_idx);
+    }
+}
+
+fn render_header(
+    f: &mut Frame<'_>,
+    area: Rect,
+    snapshot: &Option<ProverSnapshot>,
+    filter_idx: usize,
+) {
+    let total = snapshot.as_ref().map_or(0, |s| s.total_count);
+    let filter_label = STATUS_LABELS[filter_idx];
+    let title = format!(" ZK Prover — {total} proofs (filter: {filter_label}) ");
+
+    let block = Block::default()
+        .title(title)
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(COLOR_BASE_BLUE));
+
+    let inner = block.inner(area);
+    f.render_widget(block, area);
+
+    if snapshot.is_none() {
+        let msg = Paragraph::new("Connecting to prover service…")
+            .alignment(Alignment::Center)
+            .style(Style::default().fg(Color::DarkGray));
+        f.render_widget(msg, inner);
+    }
+}
+
+fn render_table(f: &mut Frame<'_>, area: Rect, view: &mut ProverView, _page: usize) {
+    let proofs = view.page_slice();
+
+    let header_cells = ["ID", "Block", "Type", "Status", "Created", "Updated"]
+        .iter()
+        .map(|h| Cell::from(*h).style(Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD)));
+    let header = Row::new(header_cells).height(1);
+
+    let rows: Vec<Row<'_>> = proofs
+        .iter()
+        .map(|p| {
+            let id_short = if p.id.len() > 8 { &p.id[..8] } else { &p.id };
+            let block_range = format!("{}+{}", p.start_block_number, p.number_of_blocks_to_prove);
+            let proof_type = format_proof_type(p.proof_type);
+            let status = format_status(p.status);
+            let created = format_timestamp(&p.created_at);
+            let updated = format_timestamp(&p.updated_at);
+
+            let status_style = status_color(p.status);
+
+            Row::new(vec![
+                Cell::from(id_short.to_string()),
+                Cell::from(block_range),
+                Cell::from(proof_type),
+                Cell::from(status).style(status_style),
+                Cell::from(created),
+                Cell::from(updated),
+            ])
+        })
+        .collect();
+
+    let widths = [
+        Constraint::Length(10),
+        Constraint::Length(12),
+        Constraint::Length(10),
+        Constraint::Length(12),
+        Constraint::Length(20),
+        Constraint::Length(20),
+    ];
+
+    let table = Table::new(rows, widths)
+        .header(header)
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .border_style(Style::default().fg(COLOR_BASE_BLUE)),
+        )
+        .row_highlight_style(Style::default().bg(Color::DarkGray));
+
+    f.render_stateful_widget(table, area, &mut view.table_state);
+}
+
+fn render_footer(f: &mut Frame<'_>, area: Rect, page: usize, page_count: usize, filter_idx: usize) {
+    let key_style = Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD);
+    let desc_style = Style::default().fg(Color::DarkGray);
+    let sep = Span::styled("  │  ", Style::default().fg(Color::DarkGray));
+
+    let filter_label = STATUS_LABELS[filter_idx];
+
+    let spans = vec![
+        Span::styled("[j/k]", key_style),
+        Span::raw(" "),
+        Span::styled("navigate", desc_style),
+        sep.clone(),
+        Span::styled("[n/p]", key_style),
+        Span::raw(" "),
+        Span::styled(format!("page {}/{page_count}", page + 1), desc_style),
+        sep.clone(),
+        Span::styled("[f]", key_style),
+        Span::raw(" "),
+        Span::styled(format!("filter: {filter_label}"), desc_style),
+        sep.clone(),
+        Span::styled("[Esc]", key_style),
+        Span::raw(" "),
+        Span::styled("back", desc_style),
+        sep,
+        Span::styled("[?]", key_style),
+        Span::raw(" "),
+        Span::styled("help", desc_style),
+    ];
+
+    let footer = Paragraph::new(Line::from(spans));
+    f.render_widget(footer, area);
+}
+
+const fn format_proof_type(pt: i32) -> &'static str {
+    match pt {
+        1 => "Core",
+        2 | 3 => "Compressed",
+        4 => "Groth16",
+        _ => "Unknown",
+    }
+}
+
+const fn format_status(status: i32) -> &'static str {
+    match status {
+        1 => "Queued",
+        2 => "InProgress",
+        3 => "Succeeded",
+        4 => "Failed",
+        _ => "Unknown",
+    }
+}
+
+fn status_color(status: i32) -> Style {
+    match status {
+        1 => Style::default().fg(Color::Cyan),
+        2 => Style::default().fg(Color::Yellow),
+        3 => Style::default().fg(Color::Green),
+        4 => Style::default().fg(Color::Red),
+        _ => Style::default().fg(Color::DarkGray),
+    }
+}
+
+fn format_timestamp(ts: &str) -> String {
+    if ts.len() >= 16 {
+        ts[..16].replace('T', " ")
+    } else {
+        ts.to_string()
+    }
+}

--- a/crates/infra/basectl/src/config.rs
+++ b/crates/infra/basectl/src/config.rs
@@ -113,6 +113,9 @@ pub struct MonitoringConfig {
     /// Proof system monitoring configuration (dispute games, anchor state).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub proofs: Option<ProofsConfig>,
+    /// ZK prover service gRPC endpoint URL (e.g. `http://localhost:9000`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub prover_rpc: Option<Url>,
 }
 
 impl MonitoringConfig {
@@ -154,6 +157,7 @@ struct MonitoringConfigOverride {
     conductors: Option<Vec<ConductorNodeConfig>>,
     validators: Option<Vec<ValidatorNodeConfig>>,
     proofs: Option<ProofsConfig>,
+    prover_rpc: Option<Url>,
 }
 
 impl MonitoringConfig {
@@ -197,6 +201,7 @@ impl MonitoringConfig {
             conductors: None,
             validators: None,
             proofs: None,
+            prover_rpc: Some(Url::parse("https://base-zk-prover-service-mainnet.cbhq.net").unwrap()),
         }
     }
 
@@ -216,6 +221,7 @@ impl MonitoringConfig {
             conductors: None,
             validators: None,
             proofs: None,
+            prover_rpc: Some(Url::parse("https://base-zk-prover-service-sepolia.cbhq.net").unwrap()),
         }
     }
 
@@ -284,6 +290,7 @@ impl MonitoringConfig {
                 docker_cl: Some("base-client-cl".to_string()),
             }]),
             proofs: None,
+            prover_rpc: Some(Url::parse("https://base-zk-prover-service-dev.cbhq.net").unwrap()),
         }
     }
 
@@ -398,6 +405,7 @@ impl MonitoringConfig {
             conductors: overrides.conductors.or(base.conductors),
             validators: overrides.validators.or(base.validators),
             proofs: overrides.proofs.or(base.proofs),
+            prover_rpc: overrides.prover_rpc.or(base.prover_rpc),
         })
     }
 

--- a/crates/infra/basectl/src/lib.rs
+++ b/crates/infra/basectl/src/lib.rs
@@ -4,8 +4,9 @@ mod app;
 pub use app::{
     Action, App, CommandCenterView, ConductorState, ConductorView, ConfigView, DaMonitorView,
     DaState, FlashState, FlashblocksView, HomeView, LoadTestTask, LoadTestView, ProofsState,
-    ProofsView, Resources, Router, TransactionPane, UpgradesView, ValidatorState, View, ViewId,
-    create_view, run_app, run_flashblocks_json, start_background_services,
+    ProofsView, ProverState, ProverView, Resources, Router, TransactionPane, UpgradesView,
+    ValidatorState, View, ViewId, create_view, run_app, run_flashblocks_json,
+    start_background_services,
 };
 
 mod commands;
@@ -30,11 +31,13 @@ mod rpc;
 pub use rpc::{
     BacklogBlock, BacklogFetchResult, BacklogProgress, BlockDaInfo, ConductorNodeStatus,
     InitialBacklog, L1BlockInfo, L1ConnectionMode, LatestProposal, PausedPeers, ProofsSnapshot,
-    TimestampedFlashblock, TxSummary, ValidatorNodeStatus, decode_flashblock_transactions,
-    fetch_block_transactions, fetch_initial_backlog_with_progress, fetch_safe_and_latest,
-    pause_sequencer_node, restart_conductor_node, run_block_fetcher, run_conductor_poller,
-    run_flashblock_ws, run_flashblock_ws_timestamped, run_l1_blob_watcher, run_proofs_poller,
-    run_safe_head_poller, run_validator_poller, transfer_conductor_leader, unpause_sequencer_node,
+    ProverSnapshot, TimestampedFlashblock, TxSummary, ValidatorNodeStatus,
+    decode_flashblock_transactions, fetch_block_transactions,
+    fetch_initial_backlog_with_progress, fetch_safe_and_latest, pause_sequencer_node,
+    restart_conductor_node, run_block_fetcher, run_conductor_poller, run_flashblock_ws,
+    run_flashblock_ws_timestamped, run_l1_blob_watcher, run_proofs_poller, run_prover_poller,
+    run_safe_head_poller, run_validator_poller, transfer_conductor_leader,
+    unpause_sequencer_node,
 };
 
 mod tui;

--- a/crates/infra/basectl/src/rpc.rs
+++ b/crates/infra/basectl/src/rpc.rs
@@ -1446,6 +1446,69 @@ async fn find_latest_proposal<P: Provider + Clone>(
     None
 }
 
+/// Snapshot of the ZK prover service state fetched via gRPC `ListProofs`.
+#[derive(Debug, Clone)]
+pub struct ProverSnapshot {
+    /// Proof summaries returned by the prover service.
+    pub proofs: Vec<base_zk_client::ProofSummary>,
+    /// Total proofs matching the current filter.
+    pub total_count: u64,
+}
+
+/// Polls the ZK prover service via gRPC `ListProofs` at regular intervals.
+pub async fn run_prover_poller(
+    prover_rpc: String,
+    tx: mpsc::Sender<ProverSnapshot>,
+    toast_tx: mpsc::Sender<Toast>,
+) {
+    use base_zk_client::{ListProofsRequest, prover_service_client::ProverServiceClient};
+    use tonic::transport::Endpoint;
+
+    let channel = match Endpoint::from_shared(prover_rpc.clone()) {
+        Ok(ep) => ep.connect_timeout(Duration::from_secs(5)).connect_lazy(),
+        Err(e) => {
+            warn!(error = %e, "invalid prover gRPC endpoint");
+            let _ = toast_tx
+                .send(Toast::warning(format!("Prover: invalid endpoint: {e}")))
+                .await;
+            return;
+        }
+    };
+
+    let mut client = ProverServiceClient::new(channel);
+    let mut interval = tokio::time::interval(Duration::from_secs(3));
+    let mut notified_failure = false;
+
+    loop {
+        interval.tick().await;
+
+        let request = ListProofsRequest { offset: 0, limit: 50, status_filter: None };
+
+        match client.list_proofs(request).await {
+            Ok(response) => {
+                notified_failure = false;
+                let resp = response.into_inner();
+                let snapshot =
+                    ProverSnapshot { proofs: resp.proofs, total_count: resp.total_count };
+                if tx.send(snapshot).await.is_err() {
+                    return;
+                }
+            }
+            Err(e) => {
+                warn!(error = %e, endpoint = %prover_rpc, "prover ListProofs call failed");
+                if !notified_failure {
+                    notified_failure = true;
+                    let _ = toast_tx
+                        .send(Toast::warning(format!(
+                            "Prover: cannot reach {prover_rpc} — {e}"
+                        )))
+                        .await;
+                }
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::effective_priority_fee_per_gas;

--- a/crates/proof/zk/client/proto/zk_prover.proto
+++ b/crates/proof/zk/client/proto/zk_prover.proto
@@ -5,6 +5,7 @@ package prover;
 service ProverService {
   rpc ProveBlock(ProveBlockRequest) returns (ProveBlockResponse);
   rpc GetProof(GetProofRequest) returns (GetProofResponse);
+  rpc ListProofs(ListProofsRequest) returns (ListProofsResponse);
 }
 
 enum ProofType {
@@ -64,4 +65,32 @@ message GetProofResponse {
   Status status = 1;
   bytes receipt = 2; // the actual zk proof, only populated if status is SUCCEEDED
   optional string error_message = 3; // populated when status is STATUS_FAILED
+}
+
+message ListProofsRequest {
+  // Pagination offset (0-based).
+  uint64 offset = 1;
+  // Maximum number of results to return. Capped server-side.
+  uint64 limit = 2;
+  // Optional status filter. If unspecified or STATUS_UNSPECIFIED, returns all statuses.
+  optional GetProofResponse.Status status_filter = 3;
+}
+
+// Summary of a proof request (excludes receipt bytes for efficiency).
+message ProofSummary {
+  string id = 1;
+  uint64 start_block_number = 2;
+  uint64 number_of_blocks_to_prove = 3;
+  ProofType proof_type = 4;
+  GetProofResponse.Status status = 5;
+  string created_at = 6;
+  string updated_at = 7;
+  optional string completed_at = 8;
+  optional string error_message = 9;
+}
+
+message ListProofsResponse {
+  repeated ProofSummary proofs = 1;
+  // Total number of proofs matching the filter (for pagination).
+  uint64 total_count = 2;
 }

--- a/crates/proof/zk/client/src/lib.rs
+++ b/crates/proof/zk/client/src/lib.rs
@@ -12,6 +12,7 @@
 #[allow(
     unreachable_pub,
     clippy::clone_on_ref_ptr,
+    clippy::derive_partial_eq_without_eq,
     clippy::doc_markdown,
     clippy::missing_const_for_fn
 )]
@@ -27,9 +28,9 @@ pub const PROVER_FILE_DESCRIPTOR_SET: &[u8] =
     tonic::include_file_descriptor_set!("prover_descriptor");
 
 pub use proto::{
-    GetProofRequest, GetProofResponse, ProofType, ProveBlockRequest, ProveBlockResponse,
-    ReceiptType, get_proof_response, get_proof_response::Status as ProofJobStatus,
-    prover_service_client,
+    GetProofRequest, GetProofResponse, ListProofsRequest, ListProofsResponse, ProofSummary,
+    ProofType, ProveBlockRequest, ProveBlockResponse, ReceiptType, get_proof_response,
+    get_proof_response::Status as ProofJobStatus, prover_service_client,
 };
 
 mod client;

--- a/crates/proof/zk/db/src/repo.rs
+++ b/crates/proof/zk/db/src/repo.rs
@@ -844,6 +844,45 @@ impl ProofRequestRepo {
         rows.iter().map(row_to_proof_request).collect()
     }
 
+    /// List proof requests with offset-based pagination and return total count.
+    pub async fn list_with_offset(
+        &self,
+        status_filter: Option<ProofStatus>,
+        limit: i64,
+        offset: i64,
+    ) -> Result<(Vec<ProofRequest>, u64)> {
+        let status_str = status_filter.map(|s| s.as_str().to_string());
+
+        let rows = sqlx::query(
+            r#"
+            SELECT
+                id, start_block_number, number_of_blocks_to_prove, sequence_window,
+                proof_type, NULL::bytea AS stark_receipt, NULL::bytea AS snark_receipt,
+                status, error_message, prover_address, l1_head,
+                intermediate_root_interval, created_at, updated_at, completed_at, retry_count
+            FROM proof_requests
+            WHERE ($1::text IS NULL OR status = $1)
+            ORDER BY created_at DESC
+            LIMIT $2 OFFSET $3
+            "#,
+        )
+        .bind(status_str.as_deref())
+        .bind(limit)
+        .bind(offset)
+        .fetch_all(&self.pool)
+        .await?;
+
+        let count: (i64,) = sqlx::query_as(
+            "SELECT COUNT(*) FROM proof_requests WHERE ($1::text IS NULL OR status = $1)",
+        )
+        .bind(status_str.as_deref())
+        .fetch_one(&self.pool)
+        .await?;
+
+        let proofs = rows.iter().map(row_to_proof_request).collect::<Result<Vec<_>>>()?;
+        Ok((proofs, count.0.max(0) as u64))
+    }
+
     // ========== Outbox Methods ==========
 
     /// Create an outbox entry for background task processing.

--- a/crates/proof/zk/service/src/server/list_proofs.rs
+++ b/crates/proof/zk/service/src/server/list_proofs.rs
@@ -1,0 +1,153 @@
+//! Implementation of the `ListProofs` gRPC endpoint.
+
+use base_zk_client::{
+    ListProofsRequest, ListProofsResponse, ProofJobStatus, ProofSummary, get_proof_response,
+};
+use base_zk_db::ProofStatus;
+use tonic::{Request, Response, Status};
+use tracing::debug;
+
+use crate::{metrics, server::ProverServiceServer};
+
+const MAX_LIMIT: u64 = 100;
+const DEFAULT_LIMIT: u64 = 50;
+
+impl ProverServiceServer {
+    /// Returns a paginated list of proof summaries for the given filter.
+    pub async fn list_proofs_impl(
+        &self,
+        request: Request<ListProofsRequest>,
+    ) -> Result<Response<ListProofsResponse>, Status> {
+        let start = std::time::Instant::now();
+        let result = self.list_proofs_inner(request).await;
+
+        let (success, status_code) = match &result {
+            Ok(_) => (true, "OK"),
+            Err(s) => (false, metrics::grpc_status_code_str(s.code())),
+        };
+        let elapsed_ms = start.elapsed().as_secs_f64() * 1000.0;
+        metrics::inc_requests("ListProofs", success, status_code);
+        metrics::record_response_latency("ListProofs", success, elapsed_ms);
+
+        result
+    }
+
+    async fn list_proofs_inner(
+        &self,
+        request: Request<ListProofsRequest>,
+    ) -> Result<Response<ListProofsResponse>, Status> {
+        let req = request.into_inner();
+
+        let limit = match req.limit {
+            0 => DEFAULT_LIMIT,
+            n if n > MAX_LIMIT => MAX_LIMIT,
+            n => n,
+        };
+
+        let offset = req.offset;
+        if offset > i64::MAX as u64 {
+            return Err(Status::invalid_argument("offset exceeds maximum supported value"));
+        }
+
+        let status_filter = match req.status_filter {
+            None => None,
+            Some(v) => {
+                let proto_status = get_proof_response::Status::try_from(v).map_err(|_| {
+                    Status::invalid_argument(format!("invalid status_filter value: {v}"))
+                })?;
+                match proto_status {
+                    get_proof_response::Status::Unspecified => None,
+                    get_proof_response::Status::Created => Some(ProofStatus::Created),
+                    get_proof_response::Status::Pending => Some(ProofStatus::Pending),
+                    get_proof_response::Status::Running => Some(ProofStatus::Running),
+                    get_proof_response::Status::Succeeded => Some(ProofStatus::Succeeded),
+                    get_proof_response::Status::Failed => Some(ProofStatus::Failed),
+                }
+            }
+        };
+
+        debug!(
+            limit = limit,
+            offset = offset,
+            status_filter = ?status_filter,
+            "listing proofs"
+        );
+
+        let (proofs, total_count) = self
+            .repo
+            .list_with_offset(status_filter, limit as i64, offset as i64)
+            .await
+            .map_err(|e| Status::internal(format!("database error: {e}")))?;
+
+        let summaries: Vec<ProofSummary> = proofs
+            .into_iter()
+            .map(|p| ProofSummary {
+                id: p.id.to_string(),
+                start_block_number: p.start_block_number.max(0) as u64,
+                number_of_blocks_to_prove: p.number_of_blocks_to_prove.max(0) as u64,
+                proof_type: p.proof_type.proto_i32(),
+                status: proto_status(p.status).into(),
+                created_at: p.created_at.to_rfc3339(),
+                updated_at: p.updated_at.to_rfc3339(),
+                completed_at: p.completed_at.map(|t| t.to_rfc3339()),
+                error_message: p.error_message,
+            })
+            .collect();
+
+        Ok(Response::new(ListProofsResponse { proofs: summaries, total_count }))
+    }
+}
+
+const fn proto_status(status: ProofStatus) -> ProofJobStatus {
+    match status {
+        ProofStatus::Created => ProofJobStatus::Created,
+        ProofStatus::Pending => ProofJobStatus::Pending,
+        ProofStatus::Running => ProofJobStatus::Running,
+        ProofStatus::Succeeded => ProofJobStatus::Succeeded,
+        ProofStatus::Failed => ProofJobStatus::Failed,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn proto_status_maps_all_variants() {
+        assert_eq!(proto_status(ProofStatus::Created), ProofJobStatus::Created);
+        assert_eq!(proto_status(ProofStatus::Pending), ProofJobStatus::Pending);
+        assert_eq!(proto_status(ProofStatus::Running), ProofJobStatus::Running);
+        assert_eq!(proto_status(ProofStatus::Succeeded), ProofJobStatus::Succeeded);
+        assert_eq!(proto_status(ProofStatus::Failed), ProofJobStatus::Failed);
+    }
+
+    #[test]
+    fn limit_clamping_zero_uses_default() {
+        let limit = match 0u64 {
+            0 => DEFAULT_LIMIT,
+            n if n > MAX_LIMIT => MAX_LIMIT,
+            n => n,
+        };
+        assert_eq!(limit, 50);
+    }
+
+    #[test]
+    fn limit_clamping_exceeds_max_caps_at_100() {
+        let limit = match 500u64 {
+            0 => DEFAULT_LIMIT,
+            n if n > MAX_LIMIT => MAX_LIMIT,
+            n => n,
+        };
+        assert_eq!(limit, MAX_LIMIT);
+    }
+
+    #[test]
+    fn limit_clamping_valid_value_passthrough() {
+        let limit = match 25u64 {
+            0 => DEFAULT_LIMIT,
+            n if n > MAX_LIMIT => MAX_LIMIT,
+            n => n,
+        };
+        assert_eq!(limit, 25);
+    }
+}

--- a/crates/proof/zk/service/src/server/mod.rs
+++ b/crates/proof/zk/service/src/server/mod.rs
@@ -3,8 +3,8 @@
 use std::fmt;
 
 use base_zk_client::{
-    GetProofRequest, GetProofResponse, ProveBlockRequest, ProveBlockResponse,
-    prover_service_server::ProverService,
+    GetProofRequest, GetProofResponse, ListProofsRequest, ListProofsResponse, ProveBlockRequest,
+    ProveBlockResponse, prover_service_server::ProverService,
 };
 use base_zk_db::ProofRequestRepo;
 use tonic::{Request, Response, Status};
@@ -12,6 +12,7 @@ use tonic::{Request, Response, Status};
 use crate::proof_request_manager::ProofRequestManager;
 
 mod get_proof;
+mod list_proofs;
 mod prove_block;
 
 /// gRPC server implementing the `ProverService` trait.
@@ -48,5 +49,12 @@ impl ProverService for ProverServiceServer {
         request: Request<GetProofRequest>,
     ) -> std::result::Result<tonic::Response<GetProofResponse>, Status> {
         self.get_proof_impl(request).await
+    }
+
+    async fn list_proofs(
+        &self,
+        request: Request<ListProofsRequest>,
+    ) -> Result<Response<ListProofsResponse>, Status> {
+        self.list_proofs_impl(request).await
     }
 }


### PR DESCRIPTION
## Summary

Adds a with an interactive TUI dashboard for monitoring `zk-prover-service` proof jobs via the `ListProofs` gRPC RPC in `basectl`

## Changes

- **ProverView**: Paginated table with ID, Block, Type, Status, Created, Updated columns
- **Navigation**: `j/k` row nav, `n/p` page nav, `f` status filter cycling (All → Queued → InProgress → Succeeded → Failed)
- **Background poller**: Connects to prover gRPC every 3s, toast notification on connection failures
- **Home screen**: Added "ZK Prover" entry with `z` keybinding and "config-required" badge

## Dependencies

Requires CHAIN-4365 (`ListProofs` RPC) to be deployed to the prover service for the dashboard to show data.

Closes CHAIN-4364