### PR TITLE
fix(batcher): always reset source on resume when safe_head_rx is None

### DIFF
--- a/crates/batcher/core/src/driver.rs
+++ b/crates/batcher/core/src/driver.rs
@@ -309,18 +309,15 @@ where
                             info!(stopped = true, "batcher paused via admin");
                         }
                         AdminCommand::Resume => {
-                            let safe_head =
-                                self.safe_head_rx.as_ref().map(|rx| *rx.borrow());
-                            if let Some(n) = safe_head {
-                                self.source.reset_catchup(n + 1);
-                                info!(
-                                    stopped = false,
-                                    catchup_from = %(n + 1),
-                                    "batcher resumed via admin, catching up from safe head"
-                                );
-                            } else {
-                                info!(stopped = false, "batcher resumed via admin");
-                            }
+                            let safe_head = self.safe_head_rx.as_ref()
+                                .map(|rx| *rx.borrow())
+                                .unwrap_or(0);
+                            self.source.reset_catchup(safe_head + 1);
+                            info!(
+                                stopped = false,
+                                catchup_from = %(safe_head + 1),
+                                "batcher resumed via admin, catching up from safe head"
+                            );
                             self.stopped = false;
                         }
                         AdminCommand::SetThrottle { strategy, config } => {


### PR DESCRIPTION
Pause resets the pipeline but Resume only called source.reset_catchup() when safe_head_rx was Some, leaving blocks lost when it was None. Always call reset_catchup with unwrap_or(0) fallback, consistent with the existing reorg handlers.