### PR TITLE
docs(proof): clarify guest ELF verification steps

### DIFF
--- a/crates/proof/tee/nitro-attestation-prover/guest/Justfile
+++ b/crates/proof/tee/nitro-attestation-prover/guest/Justfile
@@ -71,6 +71,54 @@ bundle: build
         target/riscv32im-risc0-zkvm-elf/release/{{ guest }} \
         --output target/{{ guest }}.r0bf
 
+# Verify build artifacts and optionally compare against a remote IPFS upload.
+# Prints the ELF hash, R0BF hash, and image ID. If an IPFS URL is provided,
+# downloads the remote R0BF and checks it matches the local bundle.
+#
+# Usage:
+#   just verify                     # local hashes only
+#   just verify "https://..."       # also compare against IPFS
+verify ipfs_url="":
+    #!/usr/bin/env bash
+    set -euo pipefail
+    elf="target/riscv32im-risc0-zkvm-elf/release/{{ guest }}"
+    r0bf="target/{{ guest }}.r0bf"
+    if [ ! -f "$elf" ]; then
+        echo "error: ELF not found at $elf — run 'just bundle' first." >&2
+        exit 1
+    fi
+    if [ ! -f "$r0bf" ]; then
+        echo "error: R0BF not found at $r0bf — run 'just bundle' first." >&2
+        exit 1
+    fi
+    echo "=== Raw ELF hash ==="
+    sha256sum "$elf"
+    echo ""
+    echo "=== R0BF bundle hash ==="
+    sha256sum "$r0bf"
+    echo ""
+    echo "=== Image ID ==="
+    RISC0_SKIP_BUILD_KERNELS=1 cargo run -q \
+        --manifest-path tools/compute-image-id/Cargo.toml -- "$elf" 2>&1 \
+        | grep "Image ID"
+    if [ -n "{{ ipfs_url }}" ]; then
+        echo ""
+        echo "=== Remote IPFS comparison ==="
+        tmp=$(mktemp)
+        curl -fsSL -o "$tmp" "{{ ipfs_url }}"
+        remote_hash=$(sha256sum "$tmp" | cut -d' ' -f1)
+        local_hash=$(sha256sum "$r0bf" | cut -d' ' -f1)
+        rm "$tmp"
+        echo "Local R0BF:  $local_hash"
+        echo "Remote R0BF: $remote_hash"
+        if [ "$local_hash" = "$remote_hash" ]; then
+            echo "MATCH — remote IPFS file is identical to local build."
+        else
+            echo "MISMATCH — remote IPFS file differs from local build!" >&2
+            exit 1
+        fi
+    fi
+
 # Install the pinned risc0 toolchain via rzup
 install-toolchain:
     rzup install rust {{ expected_risc0_rust }}

--- a/crates/proof/tee/nitro-attestation-prover/guest/Justfile
+++ b/crates/proof/tee/nitro-attestation-prover/guest/Justfile
@@ -71,25 +71,25 @@ bundle: build
         target/riscv32im-risc0-zkvm-elf/release/{{ guest }} \
         --output target/{{ guest }}.r0bf
 
-# Verify build artifacts and optionally compare against a remote IPFS upload.
-# Prints the ELF hash, R0BF hash, and image ID. If an IPFS URL is provided,
-# downloads the remote R0BF and checks it matches the local bundle.
+# Build, verify, and optionally compare against a remote IPFS upload.
+# If build artifacts don't exist yet, automatically runs the full build
+# first. Prints the ELF hash, R0BF hash, and image ID. If an IPFS URL
+# is provided, downloads the remote R0BF and checks it matches the
+# local bundle.
 #
 # Usage:
-#   just verify                     # local hashes only
+#   just verify                     # build (if needed) + local hashes
 #   just verify "https://..."       # also compare against IPFS
 verify ipfs_url="":
     #!/usr/bin/env bash
     set -euo pipefail
     elf="target/riscv32im-risc0-zkvm-elf/release/{{ guest }}"
     r0bf="target/{{ guest }}.r0bf"
-    if [ ! -f "$elf" ]; then
-        echo "error: ELF not found at $elf — run 'just bundle' first." >&2
-        exit 1
-    fi
-    if [ ! -f "$r0bf" ]; then
-        echo "error: R0BF not found at $r0bf — run 'just bundle' first." >&2
-        exit 1
+    if [ ! -f "$elf" ] || [ ! -f "$r0bf" ]; then
+        echo "Build artifacts not found — running full build..."
+        echo ""
+        just bundle
+        echo ""
     fi
     echo "=== Raw ELF hash ==="
     sha256sum "$elf"

--- a/crates/proof/tee/nitro-attestation-prover/guest/README.md
+++ b/crates/proof/tee/nitro-attestation-prover/guest/README.md
@@ -25,13 +25,39 @@ docker build --platform=linux/amd64 \
 docker run --rm --platform=linux/amd64 \
     -v "$(pwd)":/build/base \
     nitro-guest-builder
-
-# 3. Verify the ELF hash
-shasum -a 256 crates/proof/tee/nitro-attestation-prover/guest/target/riscv32im-risc0-zkvm-elf/release/base-proof-tee-nitro-verifier-guest
 ```
 
-The output shows the **image ID** and writes the bundled R0BF file to
-`target/base-proof-tee-nitro-verifier-guest.r0bf`.
+Step 2 prints the **image ID** and writes two artifacts:
+
+| Artifact | Path | Description |
+|---|---|---|
+| Raw ELF | `target/riscv32im-risc0-zkvm-elf/release/base-proof-tee-nitro-verifier-guest` | The compiled guest binary |
+| R0BF bundle | `target/base-proof-tee-nitro-verifier-guest.r0bf` | ELF + risc0 v1compat kernel (uploaded to IPFS) |
+
+### Verifying your build
+
+Compare your local build against another builder and against the production
+IPFS upload. There are three distinct hashes — make sure you compare like
+with like:
+
+```sh
+# 3a. Hash the raw ELF (compare with other builders' ELF hash)
+shasum -a 256 crates/proof/tee/nitro-attestation-prover/guest/target/riscv32im-risc0-zkvm-elf/release/base-proof-tee-nitro-verifier-guest
+
+# 3b. Hash the R0BF bundle (compare with the production IPFS upload)
+shasum -a 256 crates/proof/tee/nitro-attestation-prover/guest/target/base-proof-tee-nitro-verifier-guest.r0bf
+
+# 3c. Download the R0BF from IPFS and verify it matches your local bundle.
+#     Obtain the IPFS gateway URL from the config service
+#     (the --boundless-verifier-program-url value).
+curl -fsSL -o /tmp/guest-remote.r0bf "<IPFS_GATEWAY_URL>"
+shasum -a 256 /tmp/guest-remote.r0bf
+# This should match the hash from step 3b.
+```
+
+The **image ID** printed by step 2 is a third value — it is risc0's own hash
+of the ELF (not a SHA-256). This is the value used on-chain and in the
+registrar `--image-id` config.
 
 ### Apple Silicon note
 

--- a/crates/proof/tee/nitro-attestation-prover/guest/README.md
+++ b/crates/proof/tee/nitro-attestation-prover/guest/README.md
@@ -36,28 +36,33 @@ Step 2 prints the **image ID** and writes two artifacts:
 
 ### Verifying your build
 
-Compare your local build against another builder and against the production
-IPFS upload. There are three distinct hashes — make sure you compare like
-with like:
+Use `just verify` to print all hashes and optionally compare against the
+production IPFS upload in a single command:
 
 ```sh
-# 3a. Hash the raw ELF (compare with other builders' ELF hash)
-shasum -a 256 crates/proof/tee/nitro-attestation-prover/guest/target/riscv32im-risc0-zkvm-elf/release/base-proof-tee-nitro-verifier-guest
+# 3. Verify local build hashes only
+docker run --rm --platform=linux/amd64 \
+    -v "$(pwd)":/build/base \
+    nitro-guest-builder verify
 
-# 3b. Hash the R0BF bundle (compare with the production IPFS upload)
-shasum -a 256 crates/proof/tee/nitro-attestation-prover/guest/target/base-proof-tee-nitro-verifier-guest.r0bf
-
-# 3c. Download the R0BF from IPFS and verify it matches your local bundle.
-#     Obtain the IPFS gateway URL from the config service
-#     (the --boundless-verifier-program-url value).
-curl -fsSL -o /tmp/guest-remote.r0bf "<IPFS_GATEWAY_URL>"
-shasum -a 256 /tmp/guest-remote.r0bf
-# This should match the hash from step 3b.
+# Or: also verify the production IPFS upload matches your local build.
+# Obtain the IPFS gateway URL from the config service
+# (the --boundless-verifier-program-url value).
+docker run --rm --platform=linux/amd64 \
+    -v "$(pwd)":/build/base \
+    nitro-guest-builder verify "<IPFS_GATEWAY_URL>"
 ```
 
-The **image ID** printed by step 2 is a third value — it is risc0's own hash
-of the ELF (not a SHA-256). This is the value used on-chain and in the
-registrar `--image-id` config.
+This prints three distinct values:
+
+| Value | What it is | Used for |
+|---|---|---|
+| **Raw ELF hash** | SHA-256 of the compiled guest binary | Comparing builds across machines |
+| **R0BF bundle hash** | SHA-256 of the bundled file (ELF + risc0 kernel) | Verifying the IPFS upload |
+| **Image ID** | risc0's own hash of the ELF (not a SHA-256) | On-chain config and registrar `--image-id` |
+
+When an IPFS URL is provided, the command also downloads the remote R0BF
+and checks it matches your local bundle, printing `MATCH` or `MISMATCH`.
 
 ### Apple Silicon note
 

--- a/crates/proof/tee/nitro-attestation-prover/guest/README.md
+++ b/crates/proof/tee/nitro-attestation-prover/guest/README.md
@@ -11,7 +11,7 @@ check` invocations for everyone who doesn't have that toolchain installed.
 
 ## Quick start
 
-Build the Docker image (once), then build the ELF and bundle it:
+Build the Docker image (once), then build and verify:
 
 ```sh
 # From the repository root:
@@ -21,26 +21,7 @@ docker build --platform=linux/amd64 \
     -t nitro-guest-builder \
     crates/proof/tee/nitro-attestation-prover/guest
 
-# 2. Build ELF, bundle into R0BF, and compute image ID
-docker run --rm --platform=linux/amd64 \
-    -v "$(pwd)":/build/base \
-    nitro-guest-builder
-```
-
-Step 2 prints the **image ID** and writes two artifacts:
-
-| Artifact | Path | Description |
-|---|---|---|
-| Raw ELF | `target/riscv32im-risc0-zkvm-elf/release/base-proof-tee-nitro-verifier-guest` | The compiled guest binary |
-| R0BF bundle | `target/base-proof-tee-nitro-verifier-guest.r0bf` | ELF + risc0 v1compat kernel (uploaded to IPFS) |
-
-### Verifying your build
-
-Use `just verify` to print all hashes and optionally compare against the
-production IPFS upload in a single command:
-
-```sh
-# 3. Verify local build hashes only
+# 2. Build and verify (automatically builds if artifacts don't exist)
 docker run --rm --platform=linux/amd64 \
     -v "$(pwd)":/build/base \
     nitro-guest-builder verify
@@ -53,7 +34,8 @@ docker run --rm --platform=linux/amd64 \
     nitro-guest-builder verify "<IPFS_GATEWAY_URL>"
 ```
 
-This prints three distinct values:
+Step 2 automatically runs the full build if artifacts don't exist yet
+(subsequent runs skip the build and just print hashes). It outputs:
 
 | Value | What it is | Used for |
 |---|---|---|
@@ -63,6 +45,13 @@ This prints three distinct values:
 
 When an IPFS URL is provided, the command also downloads the remote R0BF
 and checks it matches your local bundle, printing `MATCH` or `MISMATCH`.
+
+The build produces two artifacts:
+
+| Artifact | Path |
+|---|---|
+| Raw ELF | `target/riscv32im-risc0-zkvm-elf/release/base-proof-tee-nitro-verifier-guest` |
+| R0BF bundle | `target/base-proof-tee-nitro-verifier-guest.r0bf` |
 
 ### Apple Silicon note
 

--- a/crates/proof/tee/nitro-attestation-prover/guest/README.md
+++ b/crates/proof/tee/nitro-attestation-prover/guest/README.md
@@ -80,35 +80,20 @@ gh release download r0.1.91.1 --repo risc0/rust \
 The Dockerfile detects and uses the pre-downloaded file automatically.
 The tarball is git-ignored and can be deleted after the image is built.
 
-## Full workflow
+## Deploying to production
 
-### 1. Build and bundle
+After building and verifying (see Quick Start above):
 
-```sh
-docker run --rm --platform=linux/amd64 \
-    -v /path/to/base-repo:/build/base \
-    nitro-guest-builder
-```
+1. **Upload to IPFS**: Upload `target/base-proof-tee-nitro-verifier-guest.r0bf`
+   to IPFS (e.g. via Pinata). Note the resulting gateway URL.
 
-This runs two steps inside the container:
-- **Build**: compiles the guest ELF with `cargo +risc0` for `riscv32im-risc0-zkvm-elf`
-- **Bundle**: combines the raw ELF with the risc0 v1compat kernel into R0BF
-  (RISC Zero Binary Format) and computes the image ID
+2. **Update configuration**: Three values must all match the same build:
 
-### 2. Upload to IPFS
-
-Upload the bundled R0BF file (`target/base-proof-tee-nitro-verifier-guest.r0bf`)
-to IPFS (e.g. via Pinata). Note the resulting gateway URL.
-
-### 3. Update configuration
-
-Three values must all match the same build:
-
-| Where | Value |
-|---|---|
-| Registrar CLI `--image-id` | Image ID printed by the build |
-| Registrar CLI `--boundless-verifier-program-url` | IPFS gateway URL from step 2 |
-| On-chain `TEEProverRegistry` contract | Same image ID, set via admin transaction |
+   | Where | Value |
+   |---|---|
+   | Registrar CLI `--image-id` | Image ID printed by the build |
+   | Registrar CLI `--boundless-verifier-program-url` | IPFS gateway URL from step 1 |
+   | On-chain `TEEProverRegistry` contract | Same image ID, set via admin transaction |
 
 ## Other Docker commands
 


### PR DESCRIPTION
## Summary
- Clarifies the Quick Start section to distinguish the three different hashes: raw ELF SHA-256, R0BF bundle SHA-256, and risc0 image ID
- Adds step-by-step instructions for verifying the production IPFS upload against the local build
- Adds table listing the two build artifacts and their paths

Follow-up to #2542.