### PR TITLE
fix: error severity for invalid FC state -> reset

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3571,6 +3571,7 @@ version = "0.8.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
+ "alloy-json-rpc",
  "alloy-network",
  "alloy-primitives",
  "alloy-provider",

--- a/crates/consensus/disc/src/driver.rs
+++ b/crates/consensus/disc/src/driver.rs
@@ -475,6 +475,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore = "flaky: depends on live mainnet bootstrap nodes responding"]
     async fn test_online_discv5_driver_bootstrap_mainnet() {
         base_cli_utils::init_test_tracing();
 

--- a/crates/consensus/engine/Cargo.toml
+++ b/crates/consensus/engine/Cargo.toml
@@ -17,6 +17,7 @@ base-consensus-genesis.workspace = true
 base-protocol = {workspace = true, features = ["serde", "std"]}
 
 # alloy
+alloy-json-rpc.workspace = true
 alloy-network.workspace = true
 alloy-pubsub.workspace = true
 alloy-transport.workspace = true

--- a/crates/consensus/engine/src/task_queue/tasks/build/error.rs
+++ b/crates/consensus/engine/src/task_queue/tasks/build/error.rs
@@ -29,6 +29,9 @@ pub enum EngineBuildError {
     /// The forkchoice update call to the engine api failed.
     #[error("Failed to build payload attributes in the engine. Forkchoice RPC error: {0}")]
     AttributesInsertionFailed(#[from] RpcError<TransportErrorKind>),
+    /// The engine returned an invalid forkchoice state error.
+    #[error("Invalid forkchoice state")]
+    ForkchoiceStateInvalid,
     /// The inserted payload is invalid.
     #[error("The inserted payload is invalid: {0}")]
     InvalidPayload(String),
@@ -66,6 +69,9 @@ impl EngineTaskError for BuildTaskError {
             | Self::EngineBuildError(EngineBuildError::MissingPayloadId)
             | Self::EngineBuildError(EngineBuildError::EngineSyncing) => {
                 EngineTaskErrorSeverity::Temporary
+            }
+            Self::EngineBuildError(EngineBuildError::ForkchoiceStateInvalid) => {
+                EngineTaskErrorSeverity::Reset
             }
             Self::MpscSend(_) => EngineTaskErrorSeverity::Critical,
         }

--- a/crates/consensus/engine/src/task_queue/tasks/build/task.rs
+++ b/crates/consensus/engine/src/task_queue/tasks/build/task.rs
@@ -1,7 +1,7 @@
 //! A task for building a new block and importing it.
 use std::{sync::Arc, time::Instant};
 
-use alloy_rpc_types_engine::{PayloadId, PayloadStatusEnum};
+use alloy_rpc_types_engine::{INVALID_FORK_CHOICE_STATE_ERROR, PayloadId, PayloadStatusEnum};
 use async_trait::async_trait;
 use base_consensus_genesis::RollupConfig;
 use base_protocol::AttributesWithParent;
@@ -128,7 +128,15 @@ impl<EngineClient_: EngineClient> BuildTask<EngineClient_> {
         }
         .map_err(|e| {
             error!(target: "engine_builder", error = %e, "Forkchoice update failed");
-            BuildTaskError::EngineBuildError(EngineBuildError::AttributesInsertionFailed(e))
+            let error = e
+                .as_error_resp()
+                .and_then(|e| {
+                    (e.code == INVALID_FORK_CHOICE_STATE_ERROR as i64)
+                        .then_some(EngineBuildError::ForkchoiceStateInvalid)
+                })
+                .unwrap_or_else(|| EngineBuildError::AttributesInsertionFailed(e));
+
+            BuildTaskError::EngineBuildError(error)
         })?;
 
         Self::validate_forkchoice_status(update.payload_status.status)?;

--- a/crates/consensus/engine/src/task_queue/tasks/build/task_test.rs
+++ b/crates/consensus/engine/src/task_queue/tasks/build/task_test.rs
@@ -2,8 +2,11 @@
 
 use std::sync::Arc;
 
+use alloy_json_rpc::ErrorPayload;
 use alloy_primitives::FixedBytes;
-use alloy_rpc_types_engine::{ForkchoiceUpdated, PayloadId, PayloadStatus, PayloadStatusEnum};
+use alloy_rpc_types_engine::{
+    ForkchoiceUpdated, INVALID_FORK_CHOICE_STATE_ERROR, PayloadId, PayloadStatus, PayloadStatusEnum,
+};
 use base_consensus_genesis::RollupConfig;
 use rstest::rstest;
 use thiserror::Error;
@@ -11,7 +14,7 @@ use tokio::sync::mpsc;
 
 use crate::{
     BuildTask, BuildTaskError, EngineBuildError, EngineClient, EngineForkchoiceVersion,
-    EngineState, EngineTaskExt,
+    EngineState, EngineTaskError, EngineTaskErrorSeverity, EngineTaskExt,
     test_utils::{
         MockEngineClientBuilder, TestAttributesBuilder, TestEngineStateBuilder, test_block_info,
         test_engine_client_builder,
@@ -54,6 +57,8 @@ enum TestErr {
     EngineSyncing,
     #[error("FinalizedAheadOfUnsafe.")]
     FinalizedAheadOfUnsafe,
+    #[error("ForkchoiceStateInvalid.")]
+    ForkchoiceStateInvalid,
     #[error("InvalidPayload.")]
     InvalidPayload,
     #[error("MissingPayloadId.")]
@@ -77,6 +82,7 @@ async fn wrapped_execute<EngineClient_: EngineClient>(
             }
             EngineBuildError::EngineSyncing => Err(TestErr::EngineSyncing),
             EngineBuildError::FinalizedAheadOfUnsafe(_, _) => Err(TestErr::FinalizedAheadOfUnsafe),
+            EngineBuildError::ForkchoiceStateInvalid => Err(TestErr::ForkchoiceStateInvalid),
             EngineBuildError::InvalidPayload(_) => Err(TestErr::InvalidPayload),
             EngineBuildError::MissingPayloadId => Err(TestErr::MissingPayloadId),
             EngineBuildError::UnexpectedPayloadStatus(_) => Err(TestErr::Unexpected),
@@ -166,4 +172,71 @@ async fn test_execute_variants(
             );
         }
     }
+}
+
+fn configure_fcu_error(
+    b: MockEngineClientBuilder,
+    fcu_version: EngineForkchoiceVersion,
+    error: ErrorPayload,
+    cfg: &mut RollupConfig,
+    attributes_timestamp: u64,
+) -> MockEngineClientBuilder {
+    match fcu_version {
+        EngineForkchoiceVersion::V2 => {
+            cfg.hardforks.ecotone_time = Some(attributes_timestamp + 1);
+            b.with_fork_choice_updated_v2_error(error)
+        }
+        EngineForkchoiceVersion::V3 => {
+            cfg.hardforks.ecotone_time = Some(attributes_timestamp);
+            b.with_fork_choice_updated_v3_error(error)
+        }
+    }
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_invalid_forkchoice_state_triggers_reset(
+    #[values(EngineForkchoiceVersion::V2, EngineForkchoiceVersion::V3)]
+    fcu_version: EngineForkchoiceVersion,
+) {
+    let parent_block = test_block_info(0);
+    let unsafe_block = test_block_info(1);
+    let attributes_timestamp = unsafe_block.block_info.timestamp;
+
+    let mut cfg = RollupConfig::default();
+
+    let error = ErrorPayload {
+        code: INVALID_FORK_CHOICE_STATE_ERROR as i64,
+        message: "Invalid fork choice state".into(),
+        data: None,
+    };
+
+    let engine_client = configure_fcu_error(
+        test_engine_client_builder(),
+        fcu_version,
+        error,
+        &mut cfg,
+        attributes_timestamp,
+    )
+    .build();
+
+    let attributes = TestAttributesBuilder::new()
+        .with_parent(parent_block)
+        .with_timestamp(attributes_timestamp)
+        .build();
+
+    let task = BuildTask::new(Arc::new(engine_client), Arc::new(cfg), attributes, None);
+
+    let mut state = TestEngineStateBuilder::new()
+        .with_unsafe_head(unsafe_block)
+        .with_safe_head(parent_block)
+        .with_finalized_head(parent_block)
+        .build();
+
+    let result = wrapped_execute(&task, &mut state).await;
+
+    assert_eq!(result, Err(TestErr::ForkchoiceStateInvalid));
+
+    let err = BuildTaskError::EngineBuildError(EngineBuildError::ForkchoiceStateInvalid);
+    assert_eq!(err.severity(), EngineTaskErrorSeverity::Reset);
 }

--- a/crates/consensus/engine/src/test_utils/engine_client.rs
+++ b/crates/consensus/engine/src/test_utils/engine_client.rs
@@ -3,6 +3,7 @@
 use std::{collections::HashMap, sync::Arc};
 
 use alloy_eips::{BlockId, eip1898::BlockNumberOrTag};
+use alloy_json_rpc::ErrorPayload;
 use alloy_network::{Ethereum, Network};
 use alloy_primitives::{Address, B256, BlockHash, StorageKey};
 use alloy_provider::{EthGetBlock, ProviderCall, RpcWithBlock};
@@ -59,6 +60,12 @@ pub struct MockEngineStorage {
     pub fork_choice_updated_v2_response: Option<ForkchoiceUpdated>,
     /// Storage for `fork_choice_updated_v3` responses.
     pub fork_choice_updated_v3_response: Option<ForkchoiceUpdated>,
+
+    // Version-specific fork_choice_updated error overrides
+    /// Error to return for `fork_choice_updated_v2` instead of a response.
+    pub fork_choice_updated_v2_error: Option<ErrorPayload>,
+    /// Error to return for `fork_choice_updated_v3` instead of a response.
+    pub fork_choice_updated_v3_error: Option<ErrorPayload>,
 
     // Version-specific get_payload responses
     /// Storage for execution payload envelope v2 responses.
@@ -182,6 +189,18 @@ impl MockEngineClientBuilder {
     /// Sets the `fork_choice_updated_v3` response.
     pub fn with_fork_choice_updated_v3_response(mut self, response: ForkchoiceUpdated) -> Self {
         self.storage.fork_choice_updated_v3_response = Some(response);
+        self
+    }
+
+    /// Sets an error to return for `fork_choice_updated_v2`.
+    pub fn with_fork_choice_updated_v2_error(mut self, error: ErrorPayload) -> Self {
+        self.storage.fork_choice_updated_v2_error = Some(error);
+        self
+    }
+
+    /// Sets an error to return for `fork_choice_updated_v3`.
+    pub fn with_fork_choice_updated_v3_error(mut self, error: ErrorPayload) -> Self {
+        self.storage.fork_choice_updated_v3_error = Some(error);
         self
     }
 
@@ -560,6 +579,9 @@ impl BaseEngineApi<Base, Http<HyperAuthClient>> for MockEngineClient {
         _payload_attributes: Option<BasePayloadAttributes>,
     ) -> TransportResult<ForkchoiceUpdated> {
         let storage = self.storage.read().await;
+        if let Some(error) = storage.fork_choice_updated_v2_error.clone() {
+            return Err(TransportError::ErrorResp(error));
+        }
         storage.fork_choice_updated_v2_response.clone().ok_or_else(|| {
             TransportError::from(TransportErrorKind::custom_str(
                 "fork_choice_updated_v2 was called but no v2 response configured. \
@@ -574,6 +596,9 @@ impl BaseEngineApi<Base, Http<HyperAuthClient>> for MockEngineClient {
         _payload_attributes: Option<BasePayloadAttributes>,
     ) -> TransportResult<ForkchoiceUpdated> {
         let storage = self.storage.read().await;
+        if let Some(error) = storage.fork_choice_updated_v3_error.clone() {
+            return Err(TransportError::ErrorResp(error));
+        }
         storage.fork_choice_updated_v3_response.clone().ok_or_else(|| {
             TransportError::from(TransportErrorKind::custom_str(
                 "fork_choice_updated_v3 was called but no v3 response configured. \


### PR DESCRIPTION
Change the error severity for an invalid forkchoice state error to Reset so the engine resets if we get this error. This matches `SynchronizationTask` and `op-node` behavior.

Disables flaky test `test_online_discv5_driver_bootstrap_mainnet`.