### PR TITLE
fix(proof): use getStartingAnchorRoot for recovery walk starting point

### DIFF
--- a/crates/proof/contracts/src/anchor_state_registry.rs
+++ b/crates/proof/contracts/src/anchor_state_registry.rs
@@ -17,6 +17,9 @@ sol! {
         /// Returns the current anchor root and its L2 sequence number.
         function getAnchorRoot() external view returns (bytes32 root, uint256 l2SequenceNumber);
 
+        /// Returns the static starting anchor root set at deployment.
+        function getStartingAnchorRoot() external view returns (bytes32 root, uint256 l2SequenceNumber);
+
         /// Returns the address of the `DisputeGameFactory`.
         function disputeGameFactory() external view returns (address);
 
@@ -94,6 +97,9 @@ impl AnchorPreflight {
 pub trait AnchorStateRegistryClient: Send + Sync {
     /// Returns the current anchor root.
     async fn get_anchor_root(&self) -> Result<AnchorRoot, ContractError>;
+
+    /// Returns the starting anchor root set at deployment.
+    async fn get_starting_anchor_root(&self) -> Result<AnchorRoot, ContractError>;
 }
 
 /// Concrete implementation backed by Alloy's sol-generated contract bindings.
@@ -126,6 +132,24 @@ impl AnchorStateRegistryClient for AnchorStateRegistryContractClient {
             root = ?result.root,
             l2_block_number,
             "Read anchor root from AnchorStateRegistry"
+        );
+
+        Ok(AnchorRoot { root: result.root, l2_block_number })
+    }
+
+    async fn get_starting_anchor_root(&self) -> Result<AnchorRoot, ContractError> {
+        let result = self.contract.getStartingAnchorRoot().call().await.map_err(|e| {
+            ContractError::Call { context: "getStartingAnchorRoot failed".into(), source: e }
+        })?;
+
+        let l2_block_number: u64 = result.l2SequenceNumber.try_into().map_err(|_| {
+            ContractError::Validation("starting anchor l2SequenceNumber overflows u64".into())
+        })?;
+
+        tracing::info!(
+            root = ?result.root,
+            l2_block_number,
+            "Read starting anchor root from AnchorStateRegistry"
         );
 
         Ok(AnchorRoot { root: result.root, l2_block_number })

--- a/crates/proof/proposer/src/driver.rs
+++ b/crates/proof/proposer/src/driver.rs
@@ -271,8 +271,10 @@ mod tests {
             output_roots: HashMap::new(),
             max_safe_block: None,
         });
-        let anchor_registry =
-            Arc::new(MockAnchorStateRegistry { anchor_root: test_anchor_root(0) });
+        let anchor_registry = Arc::new(MockAnchorStateRegistry {
+            anchor_root: test_anchor_root(0),
+            starting_anchor_root: test_anchor_root(0),
+        });
         let factory = Arc::new(MockDisputeGameFactory::with_games(vec![]));
 
         let pipeline = ProvingPipeline::new(

--- a/crates/proof/proposer/src/pipeline.rs
+++ b/crates/proof/proposer/src/pipeline.rs
@@ -720,7 +720,7 @@ where
             .await
             .map_err(|e| ProposerError::Contract(format!("recovery game_count failed: {e}")))?;
 
-        // Read the anchor root early so it can be included in the cache key.
+        // Read the live anchor root for cache validation.
         let anchor = self
             .anchor_registry
             .get_anchor_root()
@@ -743,17 +743,8 @@ where
             return Ok(cached.state);
         }
 
-        // ── Forward walk ────────────────────────────────────────────────
-        //
-        // When game_count increased and the anchor is still at or behind
-        // the cached tip, resume from the tip instead of re-walking from
-        // the anchor. This turns post-submission recovery from O(K) to
-        // O(1).
-        //
-        // A full walk from the anchor is required when:
-        // - No cache exists (cold start / pipeline reset).
-        // - The anchor advanced past the cached tip (governance / anomaly).
-        // - game_count decreased (L1 reorg removed games).
+        // Forward walk: resume from cached tip when possible, otherwise
+        // start from the starting anchor root (static, matches AggregateVerifier).
         let start = match cache.as_ref() {
             Some(cached) if tip_still_valid(cached) && count > cached.game_count => {
                 debug!(
@@ -764,11 +755,17 @@ where
                 );
                 cached.state
             }
-            _ => RecoveredState {
-                parent_address: self.config.driver.anchor_state_registry_address,
-                output_root: anchor.root,
-                l2_block_number: anchor.l2_block_number,
-            },
+            _ => {
+                let starting_anchor =
+                    self.anchor_registry.get_starting_anchor_root().await.map_err(|e| {
+                        ProposerError::Contract(format!("get_starting_anchor_root failed: {e}"))
+                    })?;
+                RecoveredState {
+                    parent_address: self.config.driver.anchor_state_registry_address,
+                    output_root: starting_anchor.root,
+                    l2_block_number: starting_anchor.l2_block_number,
+                }
+            }
         };
 
         let state = self.forward_walk(&start).await?;
@@ -1428,8 +1425,10 @@ mod tests {
             output_roots: HashMap::new(),
             max_safe_block: None,
         });
-        let anchor_registry =
-            Arc::new(MockAnchorStateRegistry { anchor_root: test_anchor_root(TEST_ANCHOR_BLOCK) });
+        let anchor_registry = Arc::new(MockAnchorStateRegistry {
+            anchor_root: test_anchor_root(TEST_ANCHOR_BLOCK),
+            starting_anchor_root: test_anchor_root(TEST_ANCHOR_BLOCK),
+        });
         let factory = Arc::new(MockDisputeGameFactory::with_games(vec![]));
 
         ProvingPipeline::new(
@@ -1478,8 +1477,10 @@ mod tests {
             output_roots,
             max_safe_block: None,
         });
-        let anchor_registry =
-            Arc::new(MockAnchorStateRegistry { anchor_root: test_anchor_root(anchor_block) });
+        let anchor_registry = Arc::new(MockAnchorStateRegistry {
+            anchor_root: test_anchor_root(anchor_block),
+            starting_anchor_root: test_anchor_root(anchor_block),
+        });
 
         ProvingPipeline::new(
             PipelineConfig {
@@ -1670,8 +1671,10 @@ mod tests {
             output_roots,
             max_safe_block: Some(TEST_BLOCK_INTERVAL * 2),
         });
-        let anchor_registry =
-            Arc::new(MockAnchorStateRegistry { anchor_root: test_anchor_root(TEST_ANCHOR_BLOCK) });
+        let anchor_registry = Arc::new(MockAnchorStateRegistry {
+            anchor_root: test_anchor_root(TEST_ANCHOR_BLOCK),
+            starting_anchor_root: test_anchor_root(TEST_ANCHOR_BLOCK),
+        });
 
         let pipeline = ProvingPipeline::new(
             PipelineConfig {
@@ -1928,8 +1931,10 @@ mod tests {
             output_roots: HashMap::new(),
             max_safe_block: None,
         });
-        let anchor_registry =
-            Arc::new(MockAnchorStateRegistry { anchor_root: test_anchor_root(TEST_ANCHOR_BLOCK) });
+        let anchor_registry = Arc::new(MockAnchorStateRegistry {
+            anchor_root: test_anchor_root(TEST_ANCHOR_BLOCK),
+            starting_anchor_root: test_anchor_root(TEST_ANCHOR_BLOCK),
+        });
         let factory = Arc::new(MockDisputeGameFactory::with_games(vec![]));
 
         let pipeline = ProvingPipeline::new(
@@ -2000,8 +2005,10 @@ mod tests {
             output_roots: HashMap::new(),
             max_safe_block: None,
         });
-        let anchor_registry =
-            Arc::new(MockAnchorStateRegistry { anchor_root: test_anchor_root(TEST_ANCHOR_BLOCK) });
+        let anchor_registry = Arc::new(MockAnchorStateRegistry {
+            anchor_root: test_anchor_root(TEST_ANCHOR_BLOCK),
+            starting_anchor_root: test_anchor_root(TEST_ANCHOR_BLOCK),
+        });
         let factory = Arc::new(MockDisputeGameFactory::with_games(vec![]));
 
         let pipeline = ProvingPipeline::new(

--- a/crates/proof/proposer/src/pipeline.rs
+++ b/crates/proof/proposer/src/pipeline.rs
@@ -678,17 +678,21 @@ where
         Some((state, safe_head))
     }
 
-    /// Recovers the latest on-chain state using a deterministic forward walk
-    /// from the anchor root.
+    /// Recovers the latest on-chain state using a deterministic forward walk.
+    ///
+    /// Two anchors are involved: the **live anchor** (`get_anchor_root()`)
+    /// advances when games resolve and is used only for cache validation; the
+    /// **starting anchor** (`get_starting_anchor_root()`) is static and serves
+    /// as the origin for full walks.
     ///
     /// # Strategy
     ///
-    /// 1. Read `game_count` from the factory and anchor root from the registry
-    ///    (2 RPC calls per tick — always needed for cache validation).
-    /// 2. **Cache check — fast path.** If both `game_count` and `anchor_root`
-    ///    match the cache, return the cached state immediately (zero RPCs).
-    /// 3. **Forward walk.** Walk from the anchor block, stepping by
-    ///    `block_interval`. At each step:
+    /// 1. Read `game_count` and the live anchor root (2 RPCs per tick).
+    /// 2. **Fast path.** If `game_count` is unchanged and the live anchor has
+    ///    not advanced past the cached tip, return cached state (zero RPCs).
+    /// 3. **Forward walk.** Start from the starting anchor (full walk) or the
+    ///    cached tip (incremental walk), stepping by `block_interval`. At each
+    ///    step:
     ///    - Compute expected block number deterministically.
     ///    - Fetch the canonical output root and intermediate roots from the
     ///      rollup node.
@@ -1873,6 +1877,64 @@ mod tests {
         // Anchor past cached tip → full walk from new anchor.
         assert_eq!(state.parent_address, proxy_addr(0));
         assert_eq!(state.l2_block_number, anchor_block + TEST_BLOCK_INTERVAL);
+    }
+
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn test_recovery_walks_from_starting_anchor_not_live_anchor() {
+        let starting_block = TEST_ANCHOR_BLOCK;
+        let live_anchor_block = TEST_BLOCK_INTERVAL;
+
+        let (factory, output_roots) =
+            game_chain_full(2, starting_block, TEST_BLOCK_INTERVAL, TEST_BLOCK_INTERVAL);
+
+        let cancel = CancellationToken::new();
+        let l1 = Arc::new(MockL1 { latest_block_number: TEST_L1_BLOCK_NUMBER });
+        let l2 = Arc::new(MockL2 { block_not_found: true, canonical_hash: None });
+        let prover: Arc<dyn ProverClient> =
+            Arc::new(MockProver { delay: MOCK_PROVER_DELAY, block_interval: TEST_BLOCK_INTERVAL });
+        let rollup = Arc::new(MockRollupClient {
+            sync_status: test_sync_status(0, B256::ZERO),
+            output_roots,
+            max_safe_block: None,
+        });
+        let anchor_registry = Arc::new(MockAnchorStateRegistry {
+            anchor_root: test_anchor_root(live_anchor_block),
+            starting_anchor_root: test_anchor_root(starting_block),
+        });
+
+        let pipeline = ProvingPipeline::new(
+            PipelineConfig {
+                max_parallel_proofs: 1,
+                max_retries: 1,
+                recovery_scan_concurrency: 8,
+                tee_prover_registry_address: None,
+                driver: DriverConfig {
+                    game_type: TEST_GAME_TYPE,
+                    block_interval: TEST_BLOCK_INTERVAL,
+                    intermediate_block_interval: TEST_BLOCK_INTERVAL,
+                    ..Default::default()
+                },
+            },
+            prover,
+            l1,
+            l2,
+            rollup,
+            anchor_registry,
+            Arc::new(factory),
+            Arc::new(MockAggregateVerifier::default()),
+            Arc::new(MockOutputProposer),
+            cancel,
+        );
+
+        let mut cache: Option<CachedRecovery> = None;
+        let state = pipeline.recover_latest_state(&mut cache).await.unwrap();
+
+        assert_eq!(
+            state.l2_block_number,
+            TEST_BLOCK_INTERVAL * 2,
+            "walk should traverse both games from starting anchor (block 0), not live anchor"
+        );
+        assert_eq!(state.parent_address, proxy_addr(1));
     }
 
     // ---- Recovery: intermediate roots with multiple checkpoints ----

--- a/crates/proof/proposer/src/test_utils.rs
+++ b/crates/proof/proposer/src/test_utils.rs
@@ -133,14 +133,20 @@ impl RollupProvider for MockRollupClient {
 /// Mock anchor state registry contract client for tests.
 #[derive(Debug)]
 pub struct MockAnchorStateRegistry {
-    /// The anchor root returned by `get_anchor_root()`.
+    /// The live anchor root returned by `get_anchor_root()`.
     pub anchor_root: AnchorRoot,
+    /// The static starting anchor root returned by `get_starting_anchor_root()`.
+    pub starting_anchor_root: AnchorRoot,
 }
 
 #[async_trait]
 impl AnchorStateRegistryClient for MockAnchorStateRegistry {
     async fn get_anchor_root(&self) -> Result<AnchorRoot, ContractError> {
         Ok(self.anchor_root)
+    }
+
+    async fn get_starting_anchor_root(&self) -> Result<AnchorRoot, ContractError> {
+        Ok(self.starting_anchor_root)
     }
 }
 


### PR DESCRIPTION
## Summary

- Fixes proposer-zeronet `UnexpectedBlockNumber` reverts that fire every 12s
- Root cause: proposer called `getAnchorRoot()` (live, advances as games resolve) but the `AggregateVerifier` contract uses `getStartingAnchorRoot()` (static, set at deployment) when `parentAddress == AnchorStateRegistry`
- The mismatch caused the forward walk to start from the wrong L2 block, producing proposals the contract always rejected

## Changes

- Added `getStartingAnchorRoot()` sol! binding to the `IAnchorStateRegistry` interface
- Added `get_starting_anchor_root()` method to `AnchorStateRegistryClient` trait + contract impl
- Updated `recover_latest_state()` in pipeline.rs to use `get_starting_anchor_root()` for the full-walk starting point
- Kept `get_anchor_root()` for cache validation (live anchor still useful for detecting stale cache)

## Testing

- All 72 proposer unit tests pass
- `cargo build -p base-proof-contracts -p base-proposer` clean