### PR TITLE
docs(derive): Document Holocene Stage Order

### DIFF
--- a/crates/consensus/derive/src/stages/mod.rs
+++ b/crates/consensus/derive/src/stages/mod.rs
@@ -3,17 +3,32 @@
 //! It offers a high-level API to functionally apply each stage's output as an input to the next
 //! stage, until finally arriving at the produced execution payloads.
 //!
-//! **Stages:**
+//! The [`ChannelProvider`] and [`BatchProvider`] stages are multiplexers whose active inner
+//! stages depend on Holocene activation. [`BatchStream`] is always present in the composed stack,
+//! but it only performs span-batch streaming after Holocene; before Holocene it passes batches
+//! through unchanged.
+//!
+//! **Pre-Holocene effective stage order:**
 //!
 //! 1. L1 Traversal
 //! 2. L1 Retrieval
 //! 3. Frame Queue
-//! 4. Channel Provider
+//! 4. Channel Bank
 //! 5. Channel Reader (Batch Decoding)
-//! 6. Batch Stream (Introduced in the Holocene Hardfork)
+//! 6. Batch Stream (Pass-Through)
 //! 7. Batch Queue
 //! 8. Payload Attributes Derivation
-//! 9. (Omitted) Engine Queue
+//!
+//! **Post-Holocene effective stage order:**
+//!
+//! 1. L1 Traversal
+//! 2. L1 Retrieval
+//! 3. Frame Queue
+//! 4. Channel Assembler
+//! 5. Channel Reader (Batch Decoding)
+//! 6. Batch Stream (Span Batches)
+//! 7. Batch Validator
+//! 8. Payload Attributes Derivation
 
 mod traversal;
 pub use traversal::PollingTraversal;


### PR DESCRIPTION
## Summary

This updates the derive stage module docs to show the effective pre-Holocene and post-Holocene pipeline order. It clarifies which inner stages are selected by the channel and batch provider multiplexers, and notes that batch streaming only performs span-batch work after Holocene activation.