### PR TITLE
docs(readme): Update Stale README Docs

### DIFF
--- a/actions/README.md
+++ b/actions/README.md
@@ -42,22 +42,23 @@ actions/
     src/
     ├── lib.rs                  public API (re-exports)
     ├── action.rs               Action trait, L2BlockProvider trait
-    ├── miner.rs                L1Miner, L1 blocks, PendingTx, reorgs
-    ├── l2.rs                   L2Sequencer, ActionL2Source, TestAccount
     ├── harness.rs              ActionTestHarness
     ├── matrix.rs               ForkMatrix (upgrade combinations)
     ├── test_rollup_config.rs   TestRollupConfigBuilder
-    ├── p2p.rs                  SupervisedP2P, TestGossipTransport
     ├── engine.rs               ActionEngineClient
+    ├── l1/
+    │   ├── miner.rs            L1Miner, L1 blocks, signed txs, receipts, reorgs
+    │   ├── provider.rs         SharedL1Chain, ActionL1ChainProvider
+    │   ├── block_fetcher.rs    ActionL1BlockFetcher
+    │   └── blob.rs             ActionBlobProvider
+    ├── l2.rs                   L2Sequencer, ActionL2Source, TestAccount
+    ├── p2p.rs                  SupervisedP2P, TestGossipTransport
     ├── node.rs                 TestRollupNode, derivation / verifier pipelines
     ├── batcher/
     │   ├── actor.rs            Batcher actor
     │   └── tx_manager.rs       L1MinerTxManager (inbox submission)
-    └── providers/              L1 / L2 / blob sources for pipelines
-        ├── l1.rs               SharedL1Chain, ActionL1ChainProvider, ActionDataSource
-        ├── l1_block_fetcher.rs ActionL1BlockFetcher
-        ├── l2.rs               ActionL2ChainProvider
-        └── blob.rs             ActionBlobDataSource, blob DA
+    └── providers/
+        └── l2.rs               ActionL2ChainProvider
     tests/                      integration tests - one scenario per module (subdirs when grouped)
 ```
 
@@ -69,7 +70,7 @@ actor's source file.
 
 ## How actors work
 
-Every actor implements the `Action` trait:
+The simplest actors implement the `Action` trait:
 
 ```rust
 pub trait Action {
@@ -80,42 +81,45 @@ pub trait Action {
 ```
 
 `act()` performs one discrete step and returns a typed result. Tests can call
-`act()` directly, or call the actor's more descriptive methods (e.g.
-`L1Miner::mine_block()`). The trait exists so a test harness can drive a
-heterogeneous list of actors uniformly when that is useful.
+`act()` directly for actors that implement the trait, or call more descriptive
+methods such as `L1Miner::mine_block()` and `Batcher::advance()`. The trait
+exists so a test harness can drive a heterogeneous list of simple actors
+uniformly when that is useful.
 
-Actors are plain Rust structs. They own their state and do not communicate
-through shared memory, channels, or async runtimes. If one actor needs to
-write to another — for example the batcher needs to submit a transaction to
-the L1 miner — it takes a mutable reference to the target actor. The borrow
-checker enforces that only one actor mutates state at a time, which eliminates
-a whole class of test flakiness that plagues Go's goroutine-based approach.
+Actors are plain Rust structs. They own their state, and tests drive their
+public methods directly. Simple actors mutate each other through explicit
+references. Production-shaped actors use channels or background tasks when
+that is part of the behavior under test; for example, `Batcher` owns a
+background `BatchDriver` task and exposes methods that let tests stage,
+mine, confirm, fail, or reorg L1 submissions at precise points.
 
 
 ## L1Miner
 
 `L1Miner` maintains an in-memory chain of `L1Block`s. Each block holds a
-consensus `Header` (number, timestamp, parent hash, base fee) and a list of
-`PendingTx` entries representing the batcher transactions included in that
-block.
+consensus `Header`, ordered signed `TxEnvelope` bodies, matching consensus and
+RPC-shaped receipts, and optional EIP-4844 blob sidecars. This is the shape
+the production derivation pipeline reads from L1.
 
-When the batcher wants to submit a batch to L1, it calls
-`L1Miner::submit_tx(PendingTx { from, to, input })`. The miner accumulates
-pending transactions and drains them into the next block when `mine_block()`
-is called. This mirrors what happens on a real L1: the batcher broadcasts a
-signed transaction, it enters the mempool, and the next block proposer
-includes it.
+When the batcher wants to submit data to L1, `L1MinerTxManager` signs the
+candidate as an EIP-1559 or EIP-4844 transaction and stages it for the miner.
+The miner drains staged transactions into the next block when `mine_block()`
+is called. Tests can also enqueue synthetic L1 events such as deposits,
+system-config updates, gas updates, and operator-fee updates; those helpers
+wrap each log in a signed transaction and attach the log to that
+transaction's receipt.
 
 The block header uses `alloy_consensus::Header` and calls `hash_slow()` to
 compute parent hashes, so the in-memory chain has a realistic hash structure
 that the derivation pipeline can traverse.
 
-Safe and finalized head pointers lag behind the latest head by 32 and 64
-blocks respectively, approximating Ethereum's post-merge consensus behaviour.
+Safe and finalized head pointers are explicit test state. Tests advance or set
+them with `act_l1_safe_next`, `act_l1_finalize_next`, `act_l1_safe`, and
+`act_l1_finalize`, which keeps finality and reorg scenarios deterministic.
 Tests that need more control can read `block_by_number()` directly.
 
 
-## PendingTx and the derivation pipeline
+## Signed L1 data and the derivation pipeline
 
 On a real network, batcher transactions are EIP-1559 transactions where:
 
@@ -128,69 +132,74 @@ The derivation pipeline's L1 retrieval stage filters L1 transactions by
 comparing `to` against the batch inbox address and `from` against the expected
 batcher address. It then extracts `input` as raw frame data.
 
-`PendingTx` in the harness captures exactly those three fields. No
-cryptographic signing is required for action tests because the derivation
-pipeline does not verify signatures — it only reads the sender address and
-calldata. When we later wire up a derivation actor in action tests, the
-`L1Block::batcher_txs` field provides the same interface that a real provider
-would give the pipeline.
+The harness now models that boundary with signed L1 transactions instead of a
+loose transaction shortcut. `BatcherConfig` carries a deterministic L1 signer,
+and `L1MinerTxManager` uses it to build signed calldata or blob submissions.
+`ActionL1ChainProvider` returns those signed transaction bodies to
+`EthereumDataSource`, while `ActionBlobProvider` serves blob sidecars by
+versioned hash. The derivation pipeline therefore exercises the production
+calldata and blob DA sources even though the underlying L1 chain is still
+in-memory.
 
 
-## MockL2Source and MockL2Block
+## ActionL2Source and BaseBlock
 
 The batcher actor needs to read L2 blocks in order to know what to batch.
-`MockL2Source` is a `VecDeque<MockL2Block>` that the batcher drains. Tests
-pre-populate the source either by calling `generate()` (which creates
-sequential blocks with incrementing numbers and timestamps) or by constructing
-`MockL2Block` values manually when they need specific field values.
+`ActionL2Source` is a `VecDeque<BaseBlock>` that implements
+`L2BlockProvider`. Tests usually fill it with blocks produced by
+`L2Sequencer`, which uses the production L1 origin selector, attributes
+builder, and in-process engine client. Each block therefore contains a real
+L1-info deposit transaction and signed user transactions, rather than a
+batcher-only mock shape.
 
-`MockL2Block` carries only the fields the batcher inspects: block number,
-parent hash, timestamp, the L1 origin (epoch number and hash), and raw encoded
-transactions. It does not wrap a full `SealedBlock` or `BasePayloadAttributes`
-because the batcher does not need the rest of the block structure.
+`ActionTestHarness::create_l2_source(n)` is the shortcut for building a source
+with `n` sequenced blocks. Tests that need precise block contents can create
+an empty `ActionL2Source`, build blocks through `L2Sequencer`, and push them
+manually.
 
 
-## Batcher actor (coming next)
+## Batcher actor
 
-The batcher will drain `MockL2Block`s from the `L2BlockProvider`, construct a
-`SingleBatch` per block using `base_protocol::SingleBatch`, feed those batches
-into a `base_comp::ChannelOut<BrotliCompressor>` at `BrotliLevel::Brotli10`
-(the compression level Base uses in production), and call
-`L1Miner::submit_tx()` for each output frame.
+`Batcher` drains `BaseBlock`s from an `L2BlockProvider` and forwards them to a
+production `BatchDriver` running in a background tokio task. The driver owns a
+`BatchEncoder`, channel manager behavior, calldata/blob frame construction,
+and submission flow. The harness-owned boundary is `L1MinerTxManager`, which
+turns the driver's transaction candidates into signed L1 transactions and
+lets tests control when those transactions are staged, mined, confirmed,
+failed, or reorged.
 
-The frame encoding follows the rollup derivation spec:
-
-```
-[DERIVATION_VERSION_0] ++ channel_id (16 B) ++ frame_number (2 B)
-    ++ frame_data_length (4 B) ++ frame_data ++ is_last (1 B)
-```
-
-Using `base_comp::ChannelOut` directly (rather than a wrapper) means the
-action tests exercise the same code path as the real batcher — if there is a
-bug in frame encoding or compression, an action test will catch it.
+For the common happy path, call `batcher.advance(&mut h.l1).await`: it drains
+the L2 source, flushes the encoder, mines one L1 block, and confirms the
+resulting receipts. For more exact scenarios, use `encode_only`,
+`stage_n_frames`, `confirm_staged`, `fail_next_n_submissions`, `reorg`, and
+`wait_until_requeued`.
 
 
 ## Writing a test
 
 ```rust
-use base_action_harness::{Action, ActionTestHarness, MockL2Block, PendingTx};
-use alloy_primitives::{Address, Bytes};
+use base_action_harness::{ActionTestHarness, Batcher, BatcherConfig};
 
-#[test]
-fn example_action_test() {
+#[tokio::test]
+async fn example_action_test() {
     let mut h = ActionTestHarness::default();
+    let batcher_cfg = BatcherConfig::default();
 
-    // Step 1: mine some L1 blocks.
+    // Step 1: mine some L1 context.
     h.mine_l1_blocks(3);
     assert_eq!(h.l1.latest_number(), 3);
 
-    // Step 2: generate mock L2 blocks and submit a batch.
-    h.generate_l2_blocks(5);
-    // (batcher.advance() will go here once the batcher actor is implemented)
+    // Step 2: build real L2 blocks and batch them into one L1 block.
+    let source = h.create_l2_source(5).await;
+    let mut batcher = Batcher::new(source, &h.rollup_config, batcher_cfg);
+    batcher.advance(&mut h.l1).await;
 
-    // Step 3: mine another L1 block to include the batcher tx.
-    h.l1.mine_block();
-    assert_eq!(h.l1.latest().batcher_txs.len(), 1);
+    // Step 3: inspect the signed L1 submissions.
+    assert!(h.l1.latest_number() >= 4);
+    assert!(
+        !h.l1.tip().transactions.is_empty() || !h.l1.tip().blob_sidecars.is_empty(),
+        "mined block should contain signed batcher submissions"
+    );
 }
 ```
 

--- a/crates/consensus/service/README.md
+++ b/crates/consensus/service/README.md
@@ -111,7 +111,7 @@ The network actor manages the libp2p gossipsub swarm and the discv5 discovery da
 
 The `GossipTransport` trait abstracts the transport backend. The production implementation is `NetworkHandler`, which wraps a `GossipDriver<ConnectionGater>` (the libp2p swarm), a `Discv5Handler`, an `mpsc::Receiver<Enr>` from discovery, a `watch::Sender<Address>` for the signer broadcast, and optionally a `BlockSignerHandler`. The `NetworkHandler::publish()` method signs the payload, constructs a `NetworkPayloadEnvelope`, and publishes it to the correct gossipsub topic based on the payload timestamp relative to hardfork activation. `NetworkHandler::next_unsafe_block()` runs a `select!` that drains gossipsub events through `GossipDriver::handle_event()`, dials newly discovered peers from the ENR receiver, and periodically inspects peer scores to disconnect and ban peers below the configured ban threshold.
 
-The `NetworkDriver::build()` produces the `NetworkHandler` by starting the libp2p swarm, resolving the local external address from the TCP listen multiaddr, updating the discv5 ENR socket, starting the discv5 daemon, and wiring together the peer score interval.
+`NetworkBuilder::build()` produces a `NetworkDriver`. `NetworkDriver::start()` then starts the libp2p swarm, resolves the local external address from the TCP listen multiaddr, updates the discv5 ENR socket, starts the discv5 daemon, and wires together the peer score interval before returning the `NetworkHandler`.
 
 ## L1 Watcher Actor
 

--- a/crates/consensus/service/src/actors/network/README.md
+++ b/crates/consensus/service/src/actors/network/README.md
@@ -1,54 +1,64 @@
 # Network actor
 
-The network actor is responsible for handling interactions with the p2p layer of the base-node, specifically the libp2p gossip driver and the discv5 handler.
+The network actor owns the consensus node's P2P boundary: libp2p gossipsub
+for unsafe-block propagation and discv5 for peer discovery. Production code
+constructs it from a `NetworkBuilder`; tests can bypass sockets by calling
+`NetworkActor::with_transport` with an in-process `GossipTransport`.
 
 ### Example
 
 > **Warning**
 >
-> Notice, the socket address uses `0.0.0.0`.
-> If you are experiencing issues connecting to peers for discovery,
-> check to make sure you are not using the loopback address,
-> `127.0.0.1` aka "localhost", which can prevent outward facing connections.
+> Bind and advertise an outward-facing address when joining a real network.
+> Using `127.0.0.1` or `localhost` prevents other peers from connecting back
+> to your node.
 
-```rust,no_run
+```rust,ignore
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+
 use alloy_primitives::address;
-use tokio_util::sync::CancellationToken;
 use base_common_genesis::RollupConfig;
 use base_consensus_disc::LocalNode;
-use base_consensus_service::{NetworkActor};
-use libp2p::Multiaddr;
+use base_consensus_service::{
+    NetworkActor, NetworkBuilder, NetworkConfig, NetworkEngineClient, NodeActor,
+};
 use discv5::enr::CombinedKey;
+use libp2p::{Multiaddr, multiaddr::Protocol};
+use tokio_util::sync::CancellationToken;
 
-#[tokio::main]
-async fn main() {
-    // Construct the Network
-    let signer = address!("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
+async fn run_network<E>(engine_client: E) -> eyre::Result<()>
+where
+    E: NetworkEngineClient + 'static,
+{
+    let unsafe_block_signer = address!("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
     let gossip = SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 9099);
-    let mut gossip_addr = Multiaddr::from(gossip.ip());
-    gossip_addr.push(libp2p::multiaddr::Protocol::Tcp(gossip.port()));
-    let advertise_ip = IpAddr::V4(Ipv4Addr::UNSPECIFIED);
+    let mut gossip_addr = Multiaddr::empty();
+    gossip_addr.push(Protocol::Ip4(Ipv4Addr::UNSPECIFIED));
+    gossip_addr.push(Protocol::Tcp(gossip.port()));
 
     let CombinedKey::Secp256k1(k256_key) = CombinedKey::generate_secp256k1() else {
-        unreachable!()
+        unreachable!();
     };
-    let disc = LocalNode::new(k256_key, advertise_ip, 9097, 9098);
+    let discovery = LocalNode::new(k256_key, IpAddr::V4(Ipv4Addr::UNSPECIFIED), 9097, 9098);
 
-    // The unsafe blocks are sent by the network actor to `blocks_rx`. This channel receiver can be
-    // used by external actors/modules to handle incoming unsafe blocks.
-    let (blocks, blocks_rx) = tokio::sync::mpsc::channel(1024);
-
-    let (inbound_data, network) = NetworkActor::new(NetworkActor::builder(Config::new(
+    let config = NetworkConfig::new(
         RollupConfig::default(),
-        disc,
+        discovery,
         gossip_addr,
-        signer
-    )));
+        unsafe_block_signer,
+    );
+    let builder = NetworkBuilder::from(config);
+    let cancellation = CancellationToken::new();
 
-    // This will start the p2p stack of the base-node (ie the libp2p gossip and discovery layers)
-    network.start(NetworkContext { blocks, cancellation: CancellationToken::new() }).await?;
+    let (inbound, network) =
+        NetworkActor::new(engine_client, cancellation.clone(), builder).await?;
+
+    tokio::spawn(network.start(()));
+
+    // Other actors use these senders to update signer state, publish unsafe
+    // payloads, and route P2P/admin RPC requests into the network actor.
+    inbound.signer.send(unsafe_block_signer).await?;
+
+    Ok(())
 }
 ```
-
-[!WARNING]: ###example


### PR DESCRIPTION
## Summary

Small PR to update the action test README to reflect the current signed L1 transaction, BaseBlock, and Batcher flows. It also refreshes the consensus service network actor documentation so the example matches the current NetworkBuilder and NetworkActor APIs.