### PR TITLE
fix(trie): persist new slots written together with storage wipe

### DIFF
--- a/crates/execution/trie/src/db/store.rs
+++ b/crates/execution/trie/src/db/store.rs
@@ -1,4 +1,4 @@
-use std::{ops::RangeBounds, path::Path};
+use std::{collections::BTreeMap, ops::RangeBounds, path::Path};
 
 use alloy_eips::{BlockNumHash, NumHash, eip1898::BlockWithParent};
 use alloy_primitives::{B256, U256, map::HashMap};
@@ -385,32 +385,44 @@ impl MdbxProofsStorage {
         Ok(deleted_count)
     }
 
-    /// Append deletion tombstones for all existing storage items of `hashed_address` at
-    /// `block_number`. Iterates via `next()` from a RO cursor and writes MaybeDeleted(None)
-    /// rows.
-    fn wipe_storage<T, Next, K, VV, V>(
+    /// Tombstone every key returned by `next`, then overlay `new_entries` so collisions
+    /// resolve in favor of `new_entries`, and `append_dup` the merged set in sorted-key order at
+    /// `block_number`. Used by the wipe branches of `store_trie_updates_for_block` to keep new
+    /// slots / nodes that arrive in the same block as a `wiped`/`is_deleted` entry —
+    /// `HashedStorage::from_plain_storage` sets `wiped = was_destroyed()` (true for
+    /// `DestroyedChanged`), so a SELFDESTRUCT + same-block recreate produces both at once.
+    fn wipe_and_overlay<T, Next, I, K, VV, V>(
         &self,
         tx: &(impl DbTxMut + DbTx),
         block_number: u64,
         hashed_address: B256,
         mut next: Next,
+        new_entries: I,
     ) -> BaseProofsStorageResult<Vec<T::Key>>
     where
         T: Table<Value = VersionedValue<V>> + DupSort,
         Next: FnMut() -> BaseProofsStorageResult<Option<(K, VV)>>,
+        I: IntoIterator<Item = (K, Option<V>)>,
         (B256, K, Option<V>): IntoKV<T>,
         T::Key: Clone,
+        K: Ord,
     {
-        let mut cur = tx.cursor_dup_write::<T>()?;
-        let mut keys: Vec<T::Key> = Vec::new();
-
+        let mut merged: BTreeMap<K, Option<V>> = BTreeMap::new();
         while let Some((k, _vv)) = next()? {
-            let key: T::Key = (hashed_address, k, Option::<V>::None).into_key();
-            let del: T::Value = VersionedValue { block_number, value: MaybeDeleted(None) };
-            cur.append_dup(key.clone(), del)?;
-            keys.push(key);
+            merged.insert(k, None);
+        }
+        for (k, v) in new_entries {
+            merged.insert(k, v);
         }
 
+        let mut cur = tx.cursor_dup_write::<T>()?;
+        let mut keys: Vec<T::Key> = Vec::with_capacity(merged.len());
+        for (k, value) in merged {
+            let key: T::Key = (hashed_address, k, Option::<V>::None).into_key();
+            let vv: T::Value = VersionedValue { block_number, value: MaybeDeleted(value) };
+            cur.append_dup(key.clone(), vv)?;
+            keys.push(key);
+        }
         Ok(keys)
     }
 
@@ -505,17 +517,16 @@ impl MdbxProofsStorage {
 
         let mut storage_trie_keys = Vec::<StorageTrieKey>::with_capacity(storage_trie_len);
         for (hashed_address, nodes) in sorted_trie_updates.storage_tries_ref() {
-            // Handle wiped - mark all storage trie as deleted at the current block number
             if nodes.is_deleted && append_mode {
-                // Yet to have any update for the current block number - So just using up to
-                // previous block number
                 let mut ro = self.storage_trie_cursor(*hashed_address, block_number - 1)?;
-                let keys =
-                    self.wipe_storage(tx, block_number, *hashed_address, || Ok(ro.next()?))?;
-
+                let keys = self.wipe_and_overlay(
+                    tx,
+                    block_number,
+                    *hashed_address,
+                    || Ok(ro.next()?),
+                    nodes.storage_nodes_ref().iter().cloned(),
+                )?;
                 storage_trie_keys.extend(keys);
-
-                // Skip any further processing for this hashed_address
                 continue;
             }
 
@@ -534,15 +545,19 @@ impl MdbxProofsStorage {
 
         let mut hashed_storage_keys = Vec::<HashedStorageKey>::with_capacity(hashed_storage_len);
         for (hashed_address, storage) in sorted_post_state.storages {
-            // Handle wiped - mark all storage slots as deleted at the current block number
             if append_mode && storage.is_wiped() {
-                // Yet to have any update for the current block number - So just using up to
-                // previous block number
                 let mut ro = self.storage_hashed_cursor(hashed_address, block_number - 1)?;
-                let keys =
-                    self.wipe_storage(tx, block_number, hashed_address, || Ok(ro.next()?))?;
+                let keys = self.wipe_and_overlay(
+                    tx,
+                    block_number,
+                    hashed_address,
+                    || Ok(ro.next()?),
+                    storage
+                        .storage_slots_ref()
+                        .iter()
+                        .map(|(slot, val)| (*slot, Some(StorageValue(*val)))),
+                )?;
                 hashed_storage_keys.extend(keys);
-                // Skip any further processing for this hashed_address
                 continue;
             }
             let keys = self.persist_history_batch(
@@ -2998,6 +3013,78 @@ mod tests {
             assert_eq!(vv.block_number, BLOCK.block.number);
             assert!(vv.value.0.is_some(), "expected normal node for non-wiped address at BLOCK");
         }
+    }
+
+    /// Mirror of `tests/lib.rs::test_store_trie_updates_with_wiped_storage_and_new_slots` for
+    /// the storage *trie* path. When `StorageTrieUpdates::is_deleted` is true AND
+    /// `storage_nodes` is non-empty (the shape revm/reth produce when a contract is destroyed
+    /// and recreated with a fresh trie in the same block), the wipe branch must tombstone every
+    /// pre-existing path for the address AND persist the new post-recreation nodes — with new
+    /// nodes winning on path collision.
+    #[test]
+    fn store_trie_updates_wiped_storage_trie_with_new_nodes() {
+        let dir = TempDir::new().unwrap();
+        let store = MdbxProofsStorage::new(dir.path()).expect("env");
+
+        let addr = B256::from([0x77; 32]);
+        let pre_path_dropped = Nibbles::from_nibbles_unchecked([0x01, 0x02]);
+        let pre_path_overwritten = Nibbles::from_nibbles_unchecked([0x0A, 0x0B]);
+        let new_path_kept = Nibbles::from_nibbles_unchecked([0xCC, 0xDD]);
+
+        store
+            .store_storage_branches(
+                addr,
+                vec![
+                    (pre_path_dropped, Some(BranchNodeCompact::default())),
+                    (pre_path_overwritten, Some(BranchNodeCompact::default())),
+                ],
+            )
+            .expect("seed");
+
+        const BLOCK: BlockWithParent =
+            BlockWithParent::new(B256::ZERO, NumHash::new(123, B256::ZERO));
+        let mut diff_trie_updates = TrieUpdates::default();
+        let mut wiped_with_new = StorageTrieUpdates::default();
+        wiped_with_new.set_deleted(true);
+        wiped_with_new.storage_nodes.insert(new_path_kept, BranchNodeCompact::default());
+        wiped_with_new.storage_nodes.insert(pre_path_overwritten, BranchNodeCompact::default());
+        diff_trie_updates.storage_tries.insert(addr, wiped_with_new);
+
+        let diff = BlockStateDiff {
+            sorted_trie_updates: diff_trie_updates.into_sorted(),
+            sorted_post_state: HashedPostStateSorted::default(),
+        };
+        store.store_trie_updates(BLOCK, diff).expect("store");
+
+        let tx = store.env.tx().expect("tx");
+        let mut cur = tx.new_cursor::<StorageTrieHistory>().expect("cursor");
+
+        let dropped_key = StorageTrieKey::new(addr, StoredNibbles::from(pre_path_dropped));
+        let dropped_vv = cur
+            .seek_by_key_subkey(dropped_key, BLOCK.block.number)
+            .expect("seek")
+            .expect("tombstone exists");
+        assert_eq!(dropped_vv.block_number, BLOCK.block.number);
+        assert!(dropped_vv.value.0.is_none(), "pre-existing path with no new node must tombstone");
+
+        let overwritten_key = StorageTrieKey::new(addr, StoredNibbles::from(pre_path_overwritten));
+        let overwritten_vv = cur
+            .seek_by_key_subkey(overwritten_key, BLOCK.block.number)
+            .expect("seek")
+            .expect("overlay exists");
+        assert_eq!(overwritten_vv.block_number, BLOCK.block.number);
+        assert!(
+            overwritten_vv.value.0.is_some(),
+            "collision path must reflect the new node, not the wipe tombstone",
+        );
+
+        let new_key = StorageTrieKey::new(addr, StoredNibbles::from(new_path_kept));
+        let new_vv = cur
+            .seek_by_key_subkey(new_key, BLOCK.block.number)
+            .expect("seek")
+            .expect("new node exists");
+        assert_eq!(new_vv.block_number, BLOCK.block.number);
+        assert!(new_vv.value.0.is_some(), "new path must be persisted, not dropped by the wipe");
     }
 
     #[test]

--- a/crates/execution/trie/src/in_memory.rs
+++ b/crates/execution/trie/src/in_memory.rs
@@ -113,11 +113,13 @@ impl InMemoryStorageInner {
                         result.hashed_storages_written_total += 1;
                     }
                 }
-            } else {
-                for (slot, value) in storage.storage_slots_ref() {
-                    self.hashed_storages.insert((block_number, *hashed_address, *slot), *value);
-                    result.hashed_storages_written_total += 1;
-                }
+            }
+            // Persist any new slots that arrive in the same block as the wipe (e.g. SELFDESTRUCT
+            // + same-block re-CREATE2 produces `wiped = true` together with fresh
+            // `storage_slots_ref()` for the recreated contract). Mirrors the MDBX backend.
+            for (slot, value) in storage.storage_slots_ref() {
+                self.hashed_storages.insert((block_number, *hashed_address, *slot), *value);
+                result.hashed_storages_written_total += 1;
             }
         }
 

--- a/crates/execution/trie/tests/lib.rs
+++ b/crates/execution/trie/tests/lib.rs
@@ -1270,6 +1270,92 @@ fn test_store_trie_updates_with_wiped_storage<S: BaseProofsStore + BaseProofsIni
     Ok(())
 }
 
+/// When a [`HashedPostState`] entry has `wiped = true` AND non-empty `storage` (the shape revm
+/// produces for `AccountStatus::DestroyedChanged` accounts that are destroyed and recreated in
+/// the same block), `store_trie_updates` must tombstone every prior storage slot for the address
+/// at `block_number` AND persist the new post-recreation slot values from `storage`. Dropping
+/// the new slots corrupts `HashedStorageHistory` and makes `BaseProofsStateProviderRef::storage`
+/// return `None` for the new slots, producing divergent storage / state / output roots
+/// downstream of `LiveTrieCollector`.
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[serial]
+fn test_store_trie_updates_with_wiped_storage_and_new_slots<
+    S: BaseProofsStore + BaseProofsInitialStateStore,
+>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let hashed_address = B256::repeat_byte(0x01);
+    let block_ref = BlockWithParent::new(B256::ZERO, NumHash::new(100, B256::repeat_byte(0x96)));
+
+    let pre_existing_slots = vec![
+        (B256::repeat_byte(0x10), U256::from(100)),
+        (B256::repeat_byte(0x20), U256::from(200)),
+    ];
+    storage.store_hashed_storages(hashed_address, pre_existing_slots.clone())?;
+
+    let new_slot_kept = (B256::repeat_byte(0x30), U256::from(0xCAFE));
+    let new_slot_overwriting_old = (B256::repeat_byte(0x10), U256::from(0xBEEF));
+
+    let mut post_state = HashedPostState::default();
+    let wiped_with_new =
+        HashedStorage::from_iter(true, vec![new_slot_kept, new_slot_overwriting_old]);
+    post_state.storages.insert(hashed_address, wiped_with_new);
+
+    let block_state_diff = BlockStateDiff {
+        sorted_trie_updates: TrieUpdatesSorted::default(),
+        sorted_post_state: post_state.into_sorted(),
+    };
+
+    storage.store_trie_updates(block_ref, block_state_diff)?;
+
+    let mut cursor150 = storage.storage_hashed_cursor(hashed_address, 150)?;
+    let mut found = Vec::new();
+    while let Some((key, value)) = cursor150.next()? {
+        found.push((key, value));
+    }
+
+    assert_eq!(
+        found,
+        vec![new_slot_overwriting_old, new_slot_kept],
+        "After wipe+recreate, only the new post-recreation slots must be visible",
+    );
+
+    let mut seek_kept = storage.storage_hashed_cursor(hashed_address, 150)?;
+    assert_eq!(
+        seek_kept.seek(new_slot_kept.0)?,
+        Some(new_slot_kept),
+        "New slot 0x30 = 0xCAFE must round-trip through the cursor",
+    );
+
+    let mut seek_overwritten = storage.storage_hashed_cursor(hashed_address, 150)?;
+    assert_eq!(
+        seek_overwritten.seek(new_slot_overwriting_old.0)?,
+        Some(new_slot_overwriting_old),
+        "Reused slot 0x10 must reflect the new post-recreation value 0xBEEF, not the wiped 100",
+    );
+
+    let mut seek_dropped = storage.storage_hashed_cursor(hashed_address, 150)?;
+    assert_eq!(
+        seek_dropped.seek(B256::repeat_byte(0x20))?,
+        Some(new_slot_kept),
+        "seek(0x20) must skip the tombstoned old slot and advance to the next visible entry \
+         (0x30 = 0xCAFE), proving 0x20 is not visible at block 150",
+    );
+
+    let mut cursor75 = storage.storage_hashed_cursor(hashed_address, 75)?;
+    let mut pre_wipe_found = Vec::new();
+    while let Some((key, value)) = cursor75.next()? {
+        pre_wipe_found.push((key, value));
+    }
+    assert_eq!(
+        pre_wipe_found, pre_existing_slots,
+        "Cursor positioned before the wipe block must still see the original slot values",
+    );
+
+    Ok(())
+}
+
 /// Test that `store_trie_updates` properly stores branch nodes, leaf nodes, and removals
 ///
 /// This test verifies that all data stored via `store_trie_updates` can be read back


### PR DESCRIPTION
## Summary

`store_trie_updates_for_block` (MDBX backend) and `InMemoryProofsStorage::store_block_data` took the wipe branch + `continue` for any `HashedStorage` with `is_wiped() == true`, dropping every storage slot and storage-trie node arriving in the same block as the wipe.

`HashedStorage::from_plain_storage` sets `wiped = status.was_destroyed()`, which is true not only for `Destroyed` / `DestroyedAgain` but also for `DestroyedChanged`. An account destroyed and recreated in the same block (post-EIP-6780: same-tx CREATE + SELFDESTRUCT-in-constructor at a deterministic CREATE2 address followed by a same-block write to that address) ends up as `DestroyedChanged` with the post-recreation slot values present in `storage_slots_ref()` and the post-recreation trie nodes present in `storage_nodes_ref()`. The buggy branches threw all of those away, so `HashedStorageHistory` and `StorageTrieHistory` for the affected block carried only tombstones. `BaseProofsStateProviderRef::storage` then returned `None` for the new slots, and any storage / state / output root recomputed from `BaseProofsStorage` diverged from canonical L2, leaving the affected blocks unprovable until the database was manually rebuilt.

## Fix

Mirror the upstream OP-reth fix at [`ethereum-optimism/optimism@5177bc9 rust/op-reth/crates/trie/src/db/store.rs`](https://github.com/ethereum-optimism/optimism/blob/5177bc90d227748316da2e39004460fbc77c5b51/rust/op-reth/crates/trie/src/db/store.rs#L475-L504): in both wipe branches build a sorted `BTreeMap` of (old slot/path -> tombstone) and then overlay (new slot/path -> live value) so new writes override tombstones at the same key. `append_dup` the merged entries in sorted order and push every key into the per-block `ChangeSet` so unwind/replace/fetch stay consistent. Apply the same merge to `InMemoryProofsStorage` so the test backend matches the MDBX backend.

The two wipe sites collapse to a shared `wipe_and_overlay<T, K, V, OldVV>` helper (essentially the previous `wipe_storage` helper extended to also overlay new entries), so each call site is now opening the read cursor + one helper call.

## Test plan

Adds a regression test `test_store_trie_updates_with_wiped_storage_and_new_slots` covering the InMemory and MDBX backends and exercising the three failure modes:
- new slot kept (must be visible after the wipe block),
- slot reused (new value must override the tombstone written for the same slot),
- slot wiped without a new write (must remain tombstoned).

```
$ cargo test -p base-execution-trie
test result: ok. 88 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out  # live integration tests
```

## Severity

Working severity for the cluster is Medium per the output-state-divergence rule: the failure mode is proof-side state divergence -> proposer `RootMismatch` -> block unprovable until patched. The corrupted root cannot be accepted on L1 (AggregateVerifier rejects it), no funds are at risk, and recovery exists (rebuild ProofsStorage / patch and resync).