### PR TITLE
fix(engine): validate Isthmus withdrawals with overlay state

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3897,6 +3897,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
+ "base-common-chains",
  "base-common-consensus",
  "base-common-evm",
  "base-common-flashblocks",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3898,7 +3898,6 @@ dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
- "base-common-chains",
  "base-common-consensus",
  "base-common-evm",
  "base-common-flashblocks",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3890,6 +3890,7 @@ dependencies = [
 name = "base-engine-tree"
 version = "0.0.0"
 dependencies = [
+ "alloy-chains",
  "alloy-consensus",
  "alloy-eip7928",
  "alloy-eips",
@@ -3913,6 +3914,7 @@ dependencies = [
  "reth-chain-state",
  "reth-chainspec",
  "reth-consensus",
+ "reth-db-common",
  "reth-engine-primitives",
  "reth-engine-tree",
  "reth-errors",

--- a/crates/execution/engine-tree/Cargo.toml
+++ b/crates/execution/engine-tree/Cargo.toml
@@ -31,6 +31,7 @@ reth-primitives-traits.workspace = true
 reth-engine-primitives.workspace = true
 reth-payload-primitives.workspace = true
 base-execution-chainspec.workspace = true
+base-common-chains.workspace = true
 base-common-consensus = { workspace = true, features = ["reth"] }
 
 revm.workspace = true

--- a/crates/execution/engine-tree/Cargo.toml
+++ b/crates/execution/engine-tree/Cargo.toml
@@ -31,7 +31,6 @@ reth-primitives-traits.workspace = true
 reth-engine-primitives.workspace = true
 reth-payload-primitives.workspace = true
 base-execution-chainspec.workspace = true
-base-common-chains.workspace = true
 base-common-consensus = { workspace = true, features = ["reth"] }
 
 revm.workspace = true

--- a/crates/execution/engine-tree/Cargo.toml
+++ b/crates/execution/engine-tree/Cargo.toml
@@ -53,9 +53,12 @@ derive_more.workspace = true
 crossbeam-channel.workspace = true
 
 [dev-dependencies]
+alloy-chains.workspace = true
 reth-chainspec.workspace = true
+reth-db-common.workspace = true
 reth-storage-errors.workspace = true
 alloy-rpc-types-eth.workspace = true
+base-common-rpc-types.workspace = true
 alloy-rpc-types-engine.workspace = true
 base-common-flashblocks.workspace = true
-base-common-rpc-types.workspace = true
+reth-provider = { workspace = true, features = ["test-utils"] }

--- a/crates/execution/engine-tree/src/lib.rs
+++ b/crates/execution/engine-tree/src/lib.rs
@@ -9,4 +9,4 @@ pub use cached_execution::{
 };
 
 mod validator;
-pub use validator::{BaseEngineValidator, BaseEngineValidatorBuilder};
+pub use validator::{BaseEngineValidator, BaseEngineValidatorBuilder, PayloadValidatorWithState};

--- a/crates/execution/engine-tree/src/lib.rs
+++ b/crates/execution/engine-tree/src/lib.rs
@@ -9,4 +9,4 @@ pub use cached_execution::{
 };
 
 mod validator;
-pub use validator::{BaseEngineValidator, BaseEngineValidatorBuilder, PayloadValidatorWithState};
+pub use validator::{BaseEngineValidator, BaseEngineValidatorBuilder};

--- a/crates/execution/engine-tree/src/validator.rs
+++ b/crates/execution/engine-tree/src/validator.rs
@@ -17,6 +17,7 @@ use alloy_eip7928::BlockAccessList;
 use alloy_eips::eip2718::Decodable2718;
 use alloy_evm::Evm;
 use alloy_primitives::B256;
+use base_common_chains::Upgrades;
 use base_common_consensus::{
     BaseBlock, BasePrimitives, BaseReceipt, BaseTransactionSigned, OpTxType,
 };
@@ -28,7 +29,7 @@ use base_common_rpc_types_engine::ExecutionData;
 use base_execution_chainspec::BaseChainSpec;
 use base_execution_evm::BaseRethReceiptBuilder;
 use base_flashblocks::FlashblocksState;
-use base_node_core::BaseEngineTypes;
+use base_node_core::{BaseEngineTypes, engine::BaseEngineValidator as BasePayloadValidator};
 use reth_chain_state::{DeferredTrieData, ExecutedBlock, LazyOverlay};
 use reth_consensus::{ConsensusError, FullConsensus, ReceiptRootBloom};
 use reth_engine_primitives::{
@@ -49,7 +50,7 @@ use reth_evm::{
     ConfigureEvm, EvmEnvFor, ExecutionCtxFor, SpecFor, block::BlockExecutor,
     execute::ExecutableTxFor,
 };
-use reth_node_api::{AddOnsContext, BlockTy, FullNodeComponents, FullNodeTypes, NodeTypes};
+use reth_node_api::{AddOnsContext, FullNodeComponents, FullNodeTypes, NodeTypes};
 use reth_node_builder::{
     invalid_block_hook::InvalidBlockHookExt,
     rpc::{ChangesetCache, EngineValidatorBuilder, PayloadValidatorBuilder},
@@ -79,6 +80,39 @@ use tracing::{debug, debug_span, error, info, instrument, trace, warn};
 use crate::cached_execution::{
     CachedExecutionProvider, CachedExecutor, FlashblocksCachedExecutionProvider,
 };
+
+/// Base payload validators that can verify post-execution rules against an explicit parent state.
+pub trait PayloadValidatorWithState<Types: PayloadTypes>:
+    PayloadValidator<Types, Block = BaseBlock>
+{
+    /// Verifies payload post-execution rules against the parent state provider used for execution.
+    fn validate_block_post_execution_with_state<DB>(
+        &self,
+        state_updates: &HashedPostState,
+        state: DB,
+        block: &RecoveredBlock<BaseBlock>,
+    ) -> Result<(), ConsensusError>
+    where
+        DB: StateProvider;
+}
+
+impl<Types, P, Tx> PayloadValidatorWithState<Types> for BasePayloadValidator<P, Tx, BaseChainSpec>
+where
+    Types: PayloadTypes,
+    Self: PayloadValidator<Types, Block = BaseBlock>,
+{
+    fn validate_block_post_execution_with_state<DB>(
+        &self,
+        state_updates: &HashedPostState,
+        state: DB,
+        block: &RecoveredBlock<BaseBlock>,
+    ) -> Result<(), ConsensusError>
+    where
+        DB: StateProvider,
+    {
+        Self::validate_block_post_execution_with_state(self, state_updates, state, block.header())
+    }
+}
 
 /// A helper type that provides reusable payload validation logic for network-specific validators.
 ///
@@ -342,7 +376,7 @@ where
             type_name = ?input.type_name(),
         )
     )]
-    pub fn validate_block_with_state<
+    fn validate_block_with_state<
         T: PayloadTypes<
                 BuiltPayload: BuiltPayload<Primitives = BasePrimitives>,
                 ExecutionData = ExecutionData,
@@ -353,7 +387,7 @@ where
         mut ctx: TreeCtx<'_, BasePrimitives>,
     ) -> ValidationOutcome<BasePrimitives, InsertPayloadError<BaseBlock>>
     where
-        V: PayloadValidator<T, Block = BaseBlock>,
+        V: PayloadValidatorWithState<T>,
         Evm: ConfigureEngineEvm<ExecutionData, Primitives = BasePrimitives>,
     {
         /// A helper macro that returns the block in case there was an error
@@ -463,7 +497,7 @@ where
         let mut handle = ensure_ok!(self.spawn_payload_processor(
             env.clone(),
             txs,
-            provider_builder,
+            provider_builder.clone(),
             overlay_factory.clone(),
             strategy,
             block_access_list,
@@ -519,6 +553,7 @@ where
                 &block,
                 &parent_block,
                 &output,
+                &provider_builder,
                 &mut ctx,
                 receipt_root_bloom
             ),
@@ -1063,11 +1098,12 @@ where
         block: &RecoveredBlock<BaseBlock>,
         parent_block: &SealedHeader<Header>,
         output: &BlockExecutionOutput<BaseReceipt>,
+        parent_state_provider_builder: &StateProviderBuilder<BasePrimitives, P>,
         ctx: &mut TreeCtx<'_, BasePrimitives>,
         receipt_root_bloom: Option<ReceiptRootBloom>,
     ) -> Result<HashedPostState, InsertBlockErrorKind>
     where
-        V: PayloadValidator<T, Block = BaseBlock>,
+        V: PayloadValidatorWithState<T>,
     {
         let start = Instant::now();
 
@@ -1105,13 +1141,21 @@ where
         let hashed_state = self.provider.hashed_post_state(&output.state);
         drop(_enter);
 
-        let _enter = debug_span!(target: "engine::tree::payload_validator", "validate_block_post_execution_with_hashed_state").entered();
-        if let Err(err) =
-            self.validator.validate_block_post_execution_with_hashed_state(&hashed_state, block)
-        {
-            // call post-block hook
-            self.on_invalid_block(parent_block, block, output, None, ctx.state_mut());
-            return Err(err.into());
+        let _enter = debug_span!(target: "engine::tree::payload_validator", "validate_block_post_execution_with_state").entered();
+        // State-aware post-execution validation only applies from Isthmus onward.
+        if self.provider.chain_spec().is_isthmus_active_at_timestamp(block.header().timestamp()) {
+            // Build a fresh parent-state provider for validation instead of reusing the execution
+            // provider, which may be wrapped with execution caches.
+            let parent_state_provider = parent_state_provider_builder.build()?;
+            if let Err(err) = self.validator.validate_block_post_execution_with_state(
+                &hashed_state,
+                parent_state_provider,
+                block,
+            ) {
+                // call post-block hook
+                self.on_invalid_block(parent_block, block, output, None, ctx.state_mut());
+                return Err(err.into());
+            }
         }
 
         // record post-execution validation duration
@@ -1480,7 +1524,7 @@ where
         + ChainSpecProvider<ChainSpec = BaseChainSpec>
         + Clone
         + 'static,
-    V: PayloadValidator<Types, Block = BaseBlock>,
+    V: PayloadValidatorWithState<Types>,
     Evm: ConfigureEngineEvm<
             ExecutionData,
             Primitives = BasePrimitives,
@@ -1592,10 +1636,7 @@ where
     <<Node as FullNodeTypes>::Types as NodeTypes>::Payload:
         PayloadTypes<ExecutionData = ExecutionData>,
     EV: PayloadValidatorBuilder<Node>,
-    EV::Validator: reth_engine_primitives::PayloadValidator<
-            <Node::Types as NodeTypes>::Payload,
-            Block = BlockTy<Node::Types>,
-        >,
+    EV::Validator: PayloadValidatorWithState<<Node::Types as NodeTypes>::Payload>,
 {
     type EngineValidator = BaseEngineValidator<
         Node::Provider,

--- a/crates/execution/engine-tree/src/validator.rs
+++ b/crates/execution/engine-tree/src/validator.rs
@@ -110,7 +110,7 @@ where
     where
         DB: StateProvider,
     {
-        Self::validate_block_post_execution_with_state(self, state_updates, state, block.header())
+        Self::verify_isthmus_withdrawals_root(self, state_updates, state, block.header())
     }
 }
 

--- a/crates/execution/engine-tree/src/validator.rs
+++ b/crates/execution/engine-tree/src/validator.rs
@@ -1107,7 +1107,7 @@ where
         let hashed_state = self.provider.hashed_post_state(&output.state);
         drop(_enter);
 
-        let _enter = debug_span!(target: "engine::tree::payload_validator", "validate_block_post_execution_with_state").entered();
+        let _enter = debug_span!(target: "engine::tree::payload_validator", "validate_block_post_execution_with_parent_state").entered();
         // Build a fresh parent-state provider for validation instead of reusing the execution
         // provider, which may be wrapped with execution caches.
         let parent_state_provider = parent_state_provider_builder.build()?;

--- a/crates/execution/engine-tree/src/validator.rs
+++ b/crates/execution/engine-tree/src/validator.rs
@@ -17,9 +17,8 @@ use alloy_eip7928::BlockAccessList;
 use alloy_eips::eip2718::Decodable2718;
 use alloy_evm::Evm;
 use alloy_primitives::B256;
-use base_common_chains::Upgrades;
 use base_common_consensus::{
-    BaseBlock, BasePrimitives, BaseReceipt, BaseTransactionSigned, OpTxType, Predeploys,
+    BaseBlock, BasePrimitives, BaseReceipt, BaseTransactionSigned, OpTxType,
 };
 use base_common_evm::{
     BaseBlockExecutor, BaseBlockExecutorFactory, BaseEvm, BaseEvmFactory, BaseHaltReason,
@@ -29,7 +28,7 @@ use base_common_rpc_types_engine::ExecutionData;
 use base_execution_chainspec::BaseChainSpec;
 use base_execution_evm::BaseRethReceiptBuilder;
 use base_flashblocks::FlashblocksState;
-use base_node_core::{BaseEngineTypes, engine::verify_isthmus_withdrawals_root};
+use base_node_core::{BaseEngineTypes, engine::BasePostExecutionValidator};
 use reth_chain_state::{DeferredTrieData, ExecutedBlock, LazyOverlay};
 use reth_consensus::{ConsensusError, FullConsensus, ReceiptRootBloom};
 use reth_engine_primitives::{
@@ -72,7 +71,7 @@ use reth_revm::{
     database::StateProviderDatabase,
     db::{State, states::bundle_state::BundleRetention},
 };
-use reth_trie::{HashedPostState, KeccakKeyHasher, KeyHasher, StateRoot, updates::TrieUpdates};
+use reth_trie::{HashedPostState, StateRoot, updates::TrieUpdates};
 use reth_trie_parallel::root::{ParallelStateRoot, ParallelStateRootError};
 use revm_primitives::Address;
 use tracing::{debug, debug_span, error, info, instrument, trace, warn};
@@ -114,8 +113,6 @@ where
     metrics: EngineApiMetrics,
     /// Validator for the payload.
     validator: V,
-    /// Hashed L2-to-L1 message passer predeploy address used by Isthmus withdrawals validation.
-    hashed_addr_l2tol1_msg_passer: B256,
     /// Cached execution provider.
     cached_execution_provider: C,
     /// Changeset cache for in-memory trie changesets
@@ -155,7 +152,7 @@ where
 {
     /// Creates a new `TreePayloadValidator`.
     #[allow(clippy::too_many_arguments)]
-    pub fn new<KH: KeyHasher>(
+    pub fn new(
         provider: P,
         consensus: Arc<dyn FullConsensus<BasePrimitives>>,
         evm_config: Evm,
@@ -184,7 +181,6 @@ where
             invalid_block_hook,
             metrics: EngineApiMetrics::default(),
             validator,
-            hashed_addr_l2tol1_msg_passer: KH::hash_key(Predeploys::L2_TO_L1_MESSAGE_PASSER),
             changeset_cache,
             cached_execution_provider,
             runtime,
@@ -357,7 +353,7 @@ where
         mut ctx: TreeCtx<'_, BasePrimitives>,
     ) -> ValidationOutcome<BasePrimitives, InsertPayloadError<BaseBlock>>
     where
-        V: PayloadValidator<T, Block = BaseBlock>,
+        V: BasePostExecutionValidator<T>,
         Evm: ConfigureEngineEvm<ExecutionData, Primitives = BasePrimitives>,
     {
         /// A helper macro that returns the block in case there was an error
@@ -1073,7 +1069,7 @@ where
         receipt_root_bloom: Option<ReceiptRootBloom>,
     ) -> Result<HashedPostState, InsertBlockErrorKind>
     where
-        V: PayloadValidator<T, Block = BaseBlock>,
+        V: BasePostExecutionValidator<T>,
     {
         let start = Instant::now();
 
@@ -1112,23 +1108,17 @@ where
         drop(_enter);
 
         let _enter = debug_span!(target: "engine::tree::payload_validator", "validate_block_post_execution_with_state").entered();
-        // Avoid building parent state before Isthmus; the verifier repeats this gate for direct
-        // callers that already have a parent state provider.
-        if self.provider.chain_spec().is_isthmus_active_at_timestamp(block.header().timestamp()) {
-            // Build a fresh parent-state provider for validation instead of reusing the execution
-            // provider, which may be wrapped with execution caches.
-            let parent_state_provider = parent_state_provider_builder.build()?;
-            if let Err(err) = verify_isthmus_withdrawals_root(
-                self.provider.chain_spec().as_ref(),
-                self.hashed_addr_l2tol1_msg_passer,
-                &hashed_state,
-                parent_state_provider,
-                block.header(),
-            ) {
-                // call post-block hook
-                self.on_invalid_block(parent_block, block, output, None, ctx.state_mut());
-                return Err(err.into());
-            }
+        // Build a fresh parent-state provider for validation instead of reusing the execution
+        // provider, which may be wrapped with execution caches.
+        let parent_state_provider = parent_state_provider_builder.build()?;
+        if let Err(err) = self.validator.validate_block_post_execution_with_state(
+            &hashed_state,
+            parent_state_provider,
+            block,
+        ) {
+            // call post-block hook
+            self.on_invalid_block(parent_block, block, output, None, ctx.state_mut());
+            return Err(err.into());
         }
 
         // record post-execution validation duration
@@ -1497,7 +1487,7 @@ where
         + ChainSpecProvider<ChainSpec = BaseChainSpec>
         + Clone
         + 'static,
-    V: PayloadValidator<Types, Block = BaseBlock>,
+    V: BasePostExecutionValidator<Types>,
     Evm: ConfigureEngineEvm<
             ExecutionData,
             Primitives = BasePrimitives,
@@ -1609,7 +1599,7 @@ where
     <<Node as FullNodeTypes>::Types as NodeTypes>::Payload:
         PayloadTypes<ExecutionData = ExecutionData>,
     EV: PayloadValidatorBuilder<Node>,
-    EV::Validator: PayloadValidator<<Node::Types as NodeTypes>::Payload, Block = BaseBlock>,
+    EV::Validator: BasePostExecutionValidator<<Node::Types as NodeTypes>::Payload>,
 {
     type EngineValidator = BaseEngineValidator<
         Node::Provider,
@@ -1627,7 +1617,7 @@ where
         let validator = self.payload_validator_builder.build(ctx).await?;
         let data_dir = ctx.config.datadir.clone().resolve_datadir(ctx.config.chain.chain());
         let invalid_block_hook = ctx.create_invalid_block_hook(&data_dir).await?;
-        Ok(BaseEngineValidator::new::<KeccakKeyHasher>(
+        Ok(BaseEngineValidator::new(
             ctx.node.provider().clone(),
             std::sync::Arc::new(ctx.node.consensus().clone()),
             ctx.node.evm_config().clone(),

--- a/crates/execution/engine-tree/src/validator.rs
+++ b/crates/execution/engine-tree/src/validator.rs
@@ -1111,7 +1111,7 @@ where
         // Build a fresh parent-state provider for validation instead of reusing the execution
         // provider, which may be wrapped with execution caches.
         let parent_state_provider = parent_state_provider_builder.build()?;
-        if let Err(err) = self.validator.validate_block_post_execution_with_state(
+        if let Err(err) = self.validator.validate_block_post_execution_with_parent_state(
             &hashed_state,
             parent_state_provider,
             block,

--- a/crates/execution/engine-tree/src/validator.rs
+++ b/crates/execution/engine-tree/src/validator.rs
@@ -19,7 +19,7 @@ use alloy_evm::Evm;
 use alloy_primitives::B256;
 use base_common_chains::Upgrades;
 use base_common_consensus::{
-    BaseBlock, BasePrimitives, BaseReceipt, BaseTransactionSigned, OpTxType,
+    BaseBlock, BasePrimitives, BaseReceipt, BaseTransactionSigned, OpTxType, Predeploys,
 };
 use base_common_evm::{
     BaseBlockExecutor, BaseBlockExecutorFactory, BaseEvm, BaseEvmFactory, BaseHaltReason,
@@ -29,7 +29,7 @@ use base_common_rpc_types_engine::ExecutionData;
 use base_execution_chainspec::BaseChainSpec;
 use base_execution_evm::BaseRethReceiptBuilder;
 use base_flashblocks::FlashblocksState;
-use base_node_core::{BaseEngineTypes, engine::BaseEngineValidator as BasePayloadValidator};
+use base_node_core::{BaseEngineTypes, engine::verify_isthmus_withdrawals_root};
 use reth_chain_state::{DeferredTrieData, ExecutedBlock, LazyOverlay};
 use reth_consensus::{ConsensusError, FullConsensus, ReceiptRootBloom};
 use reth_engine_primitives::{
@@ -72,7 +72,7 @@ use reth_revm::{
     database::StateProviderDatabase,
     db::{State, states::bundle_state::BundleRetention},
 };
-use reth_trie::{HashedPostState, StateRoot, updates::TrieUpdates};
+use reth_trie::{HashedPostState, KeccakKeyHasher, KeyHasher, StateRoot, updates::TrieUpdates};
 use reth_trie_parallel::root::{ParallelStateRoot, ParallelStateRootError};
 use revm_primitives::Address;
 use tracing::{debug, debug_span, error, info, instrument, trace, warn};
@@ -80,39 +80,6 @@ use tracing::{debug, debug_span, error, info, instrument, trace, warn};
 use crate::cached_execution::{
     CachedExecutionProvider, CachedExecutor, FlashblocksCachedExecutionProvider,
 };
-
-/// Base payload validators that can verify post-execution rules against an explicit parent state.
-pub trait PayloadValidatorWithState<Types: PayloadTypes>:
-    PayloadValidator<Types, Block = BaseBlock>
-{
-    /// Verifies payload post-execution rules against the parent state provider used for execution.
-    fn validate_block_post_execution_with_state<DB>(
-        &self,
-        state_updates: &HashedPostState,
-        state: DB,
-        block: &RecoveredBlock<BaseBlock>,
-    ) -> Result<(), ConsensusError>
-    where
-        DB: StateProvider;
-}
-
-impl<Types, P, Tx> PayloadValidatorWithState<Types> for BasePayloadValidator<P, Tx, BaseChainSpec>
-where
-    Types: PayloadTypes,
-    Self: PayloadValidator<Types, Block = BaseBlock>,
-{
-    fn validate_block_post_execution_with_state<DB>(
-        &self,
-        state_updates: &HashedPostState,
-        state: DB,
-        block: &RecoveredBlock<BaseBlock>,
-    ) -> Result<(), ConsensusError>
-    where
-        DB: StateProvider,
-    {
-        Self::verify_isthmus_withdrawals_root(self, state_updates, state, block.header())
-    }
-}
 
 /// A helper type that provides reusable payload validation logic for network-specific validators.
 ///
@@ -147,6 +114,8 @@ where
     metrics: EngineApiMetrics,
     /// Validator for the payload.
     validator: V,
+    /// Hashed L2-to-L1 message passer predeploy address used by Isthmus withdrawals validation.
+    hashed_addr_l2tol1_msg_passer: B256,
     /// Cached execution provider.
     cached_execution_provider: C,
     /// Changeset cache for in-memory trie changesets
@@ -186,7 +155,7 @@ where
 {
     /// Creates a new `TreePayloadValidator`.
     #[allow(clippy::too_many_arguments)]
-    pub fn new(
+    pub fn new<KH: KeyHasher>(
         provider: P,
         consensus: Arc<dyn FullConsensus<BasePrimitives>>,
         evm_config: Evm,
@@ -215,6 +184,7 @@ where
             invalid_block_hook,
             metrics: EngineApiMetrics::default(),
             validator,
+            hashed_addr_l2tol1_msg_passer: KH::hash_key(Predeploys::L2_TO_L1_MESSAGE_PASSER),
             changeset_cache,
             cached_execution_provider,
             runtime,
@@ -387,7 +357,7 @@ where
         mut ctx: TreeCtx<'_, BasePrimitives>,
     ) -> ValidationOutcome<BasePrimitives, InsertPayloadError<BaseBlock>>
     where
-        V: PayloadValidatorWithState<T>,
+        V: PayloadValidator<T, Block = BaseBlock>,
         Evm: ConfigureEngineEvm<ExecutionData, Primitives = BasePrimitives>,
     {
         /// A helper macro that returns the block in case there was an error
@@ -1103,7 +1073,7 @@ where
         receipt_root_bloom: Option<ReceiptRootBloom>,
     ) -> Result<HashedPostState, InsertBlockErrorKind>
     where
-        V: PayloadValidatorWithState<T>,
+        V: PayloadValidator<T, Block = BaseBlock>,
     {
         let start = Instant::now();
 
@@ -1142,15 +1112,18 @@ where
         drop(_enter);
 
         let _enter = debug_span!(target: "engine::tree::payload_validator", "validate_block_post_execution_with_state").entered();
-        // State-aware post-execution validation only applies from Isthmus onward.
+        // Avoid building parent state before Isthmus; the verifier repeats this gate for direct
+        // callers that already have a parent state provider.
         if self.provider.chain_spec().is_isthmus_active_at_timestamp(block.header().timestamp()) {
             // Build a fresh parent-state provider for validation instead of reusing the execution
             // provider, which may be wrapped with execution caches.
             let parent_state_provider = parent_state_provider_builder.build()?;
-            if let Err(err) = self.validator.validate_block_post_execution_with_state(
+            if let Err(err) = verify_isthmus_withdrawals_root(
+                self.provider.chain_spec().as_ref(),
+                self.hashed_addr_l2tol1_msg_passer,
                 &hashed_state,
                 parent_state_provider,
-                block,
+                block.header(),
             ) {
                 // call post-block hook
                 self.on_invalid_block(parent_block, block, output, None, ctx.state_mut());
@@ -1524,7 +1497,7 @@ where
         + ChainSpecProvider<ChainSpec = BaseChainSpec>
         + Clone
         + 'static,
-    V: PayloadValidatorWithState<Types>,
+    V: PayloadValidator<Types, Block = BaseBlock>,
     Evm: ConfigureEngineEvm<
             ExecutionData,
             Primitives = BasePrimitives,
@@ -1636,7 +1609,7 @@ where
     <<Node as FullNodeTypes>::Types as NodeTypes>::Payload:
         PayloadTypes<ExecutionData = ExecutionData>,
     EV: PayloadValidatorBuilder<Node>,
-    EV::Validator: PayloadValidatorWithState<<Node::Types as NodeTypes>::Payload>,
+    EV::Validator: PayloadValidator<<Node::Types as NodeTypes>::Payload, Block = BaseBlock>,
 {
     type EngineValidator = BaseEngineValidator<
         Node::Provider,
@@ -1654,7 +1627,7 @@ where
         let validator = self.payload_validator_builder.build(ctx).await?;
         let data_dir = ctx.config.datadir.clone().resolve_datadir(ctx.config.chain.chain());
         let invalid_block_hook = ctx.create_invalid_block_hook(&data_dir).await?;
-        Ok(BaseEngineValidator::new(
+        Ok(BaseEngineValidator::new::<KeccakKeyHasher>(
             ctx.node.provider().clone(),
             std::sync::Arc::new(ctx.node.consensus().clone()),
             ctx.node.evm_config().clone(),

--- a/crates/execution/engine-tree/tests/isthmus.rs
+++ b/crates/execution/engine-tree/tests/isthmus.rs
@@ -1,0 +1,135 @@
+//! Regression tests for Isthmus-specific engine-tree validation.
+
+use std::sync::Arc;
+
+use alloy_chains::Chain;
+use alloy_consensus::Header;
+use alloy_primitives::{Address, B256, U256, keccak256};
+use base_common_consensus::{
+    BaseBlock, BasePrimitives, BaseReceipt, BaseTransactionSigned, Predeploys,
+};
+use base_engine_tree::PayloadValidatorWithState;
+use base_execution_chainspec::{BaseChainSpec, BaseChainSpecBuilder};
+use base_node_core::{BaseEngineTypes, BaseNode, engine::BaseEngineValidator};
+use reth_chain_state::{ComputedTrieData, ExecutedBlock};
+use reth_db_common::init::init_genesis;
+use reth_engine_primitives::PayloadValidator;
+use reth_engine_tree::tree::StateProviderBuilder;
+use reth_primitives_traits::{RecoveredBlock, SealedBlock};
+use reth_provider::{
+    BlockExecutionOutput, StateProviderFactory, providers::BlockchainProvider,
+    test_utils::create_test_provider_factory_with_node_types,
+};
+use reth_revm::{bytecode::Bytecode, state::AccountInfo};
+use reth_trie::{
+    HashedPostState, HashedStorage, KeccakKeyHasher, test_utils::storage_root_prehashed,
+};
+use revm::database::BundleState;
+
+#[test]
+fn isthmus_withdrawals_root_validation_uses_in_memory_parent_overlay() {
+    let chain_spec = Arc::new(
+        BaseChainSpecBuilder::default()
+            .chain(Chain::dev())
+            .genesis(Default::default())
+            .isthmus_activated()
+            .build(),
+    );
+    let provider_factory =
+        create_test_provider_factory_with_node_types::<BaseNode>(Arc::clone(&chain_spec));
+    let genesis_hash = init_genesis(&provider_factory).expect("initialize genesis");
+    let provider = BlockchainProvider::new(provider_factory).expect("create blockchain provider");
+
+    let parent_block = recovered_empty_block(1, genesis_hash, None);
+    let parent_hash = parent_block.hash();
+    let (parent_execution_output, parent_hashed_state, parent_withdrawals_root) =
+        parent_message_passer_update();
+    let parent_executed_block = ExecutedBlock::<BasePrimitives>::new(
+        Arc::new(parent_block),
+        Arc::new(parent_execution_output),
+        ComputedTrieData {
+            hashed_state: Arc::new(parent_hashed_state.into_sorted()),
+            ..Default::default()
+        },
+    );
+
+    let child_block = recovered_empty_block(2, parent_hash, Some(parent_withdrawals_root));
+    let child_state_updates = HashedPostState::default();
+    let validator = BaseEngineValidator::<_, BaseTransactionSigned, BaseChainSpec>::new::<
+        KeccakKeyHasher,
+    >(Arc::clone(&chain_spec), provider.clone());
+
+    let legacy_result =
+        PayloadValidator::<BaseEngineTypes>::validate_block_post_execution_with_hashed_state(
+            &validator,
+            &child_state_updates,
+            &child_block,
+        );
+    assert!(
+        legacy_result.is_err(),
+        "legacy validation should not find the unpersisted parent by hash"
+    );
+    assert!(
+        provider.state_by_block_hash(parent_hash).is_err(),
+        "test setup requires the parent to exist only in memory"
+    );
+
+    let parent_state_provider_builder =
+        StateProviderBuilder::new(provider, genesis_hash, Some(vec![parent_executed_block]));
+    let parent_state_provider =
+        parent_state_provider_builder.build().expect("build overlay parent state provider");
+
+    PayloadValidatorWithState::<BaseEngineTypes>::validate_block_post_execution_with_state(
+        &validator,
+        &child_state_updates,
+        parent_state_provider,
+        &child_block,
+    )
+    .expect("state-aware validation should use the in-memory parent overlay");
+}
+
+fn parent_message_passer_update() -> (BlockExecutionOutput<BaseReceipt>, HashedPostState, B256) {
+    let storage_slots = [(U256::from(1), U256::from(11)), (U256::from(2), U256::from(22))];
+    let parent_storage = HashedStorage::from_iter(
+        false,
+        storage_slots.iter().copied().map(|(slot, value)| (keccak256(B256::from(slot)), value)),
+    );
+
+    let mut parent_hashed_state = HashedPostState::default();
+    parent_hashed_state
+        .storages
+        .insert(keccak256(Predeploys::L2_TO_L1_MESSAGE_PASSER), parent_storage.clone());
+
+    let parent_bundle_state = BundleState::new(
+        [(
+            Predeploys::L2_TO_L1_MESSAGE_PASSER,
+            None::<AccountInfo>,
+            None::<AccountInfo>,
+            storage_slots
+                .iter()
+                .copied()
+                .map(|(slot, value)| (slot, (U256::ZERO, value)))
+                .collect(),
+        )],
+        Vec::<Vec<(Address, Option<Option<AccountInfo>>, Vec<(U256, U256)>)>>::new(),
+        Vec::<(B256, Bytecode)>::new(),
+    );
+
+    (
+        BlockExecutionOutput { state: parent_bundle_state, ..Default::default() },
+        parent_hashed_state,
+        storage_root_prehashed(parent_storage.storage),
+    )
+}
+
+fn recovered_empty_block(
+    number: u64,
+    parent_hash: B256,
+    withdrawals_root: Option<B256>,
+) -> RecoveredBlock<BaseBlock> {
+    let header =
+        Header { parent_hash, number, timestamp: number, withdrawals_root, ..Default::default() };
+    let block = BaseBlock { header, body: Default::default() };
+
+    RecoveredBlock::new_sealed(SealedBlock::seal_slow(block), Vec::new())
+}

--- a/crates/execution/engine-tree/tests/isthmus.rs
+++ b/crates/execution/engine-tree/tests/isthmus.rs
@@ -8,52 +8,32 @@ use alloy_primitives::{Address, B256, U256, keccak256};
 use base_common_consensus::{
     BaseBlock, BasePrimitives, BaseReceipt, BaseTransactionSigned, Predeploys,
 };
-use base_engine_tree::PayloadValidatorWithState;
 use base_execution_chainspec::{BaseChainSpec, BaseChainSpecBuilder};
-use base_node_core::{BaseEngineTypes, BaseNode, engine::BaseEngineValidator};
+use base_node_core::{
+    BaseEngineTypes, BaseNode,
+    engine::{BaseEngineValidator, verify_isthmus_withdrawals_root},
+};
 use reth_chain_state::{ComputedTrieData, ExecutedBlock};
 use reth_db_common::init::init_genesis;
 use reth_engine_primitives::PayloadValidator;
 use reth_engine_tree::tree::StateProviderBuilder;
 use reth_primitives_traits::{RecoveredBlock, SealedBlock};
 use reth_provider::{
-    BlockExecutionOutput, StateProviderFactory, providers::BlockchainProvider,
-    test_utils::create_test_provider_factory_with_node_types,
+    BlockExecutionOutput, BlockReader, StateProviderFactory, StateReader,
+    providers::BlockchainProvider, test_utils::create_test_provider_factory_with_node_types,
 };
 use reth_revm::{bytecode::Bytecode, state::AccountInfo};
 use reth_trie::{
-    HashedPostState, HashedStorage, KeccakKeyHasher, test_utils::storage_root_prehashed,
+    HashedPostState, HashedStorage, KeccakKeyHasher, KeyHasher, test_utils::storage_root_prehashed,
 };
 use revm::database::BundleState;
 
 #[test]
-fn isthmus_withdrawals_root_validation_uses_in_memory_parent_overlay() {
-    let chain_spec = Arc::new(
-        BaseChainSpecBuilder::default()
-            .chain(Chain::dev())
-            .genesis(Default::default())
-            .isthmus_activated()
-            .build(),
-    );
-    let provider_factory =
-        create_test_provider_factory_with_node_types::<BaseNode>(Arc::clone(&chain_spec));
-    let genesis_hash = init_genesis(&provider_factory).expect("initialize genesis");
-    let provider = BlockchainProvider::new(provider_factory).expect("create blockchain provider");
-
-    let parent_block = recovered_empty_block(1, genesis_hash, None);
-    let parent_hash = parent_block.hash();
-    let (parent_execution_output, parent_hashed_state, parent_withdrawals_root) =
-        parent_message_passer_update();
-    let parent_executed_block = ExecutedBlock::<BasePrimitives>::new(
-        Arc::new(parent_block),
-        Arc::new(parent_execution_output),
-        ComputedTrieData {
-            hashed_state: Arc::new(parent_hashed_state.into_sorted()),
-            ..Default::default()
-        },
-    );
-
-    let child_block = recovered_empty_block(2, parent_hash, Some(parent_withdrawals_root));
+fn legacy_isthmus_validation_errors_when_parent_is_only_in_memory() {
+    let (chain_spec, provider, _genesis_hash, parent_executed_block, _parent_withdrawals_root) =
+        isthmus_parent_overlay_fixture();
+    let parent_hash = parent_executed_block.recovered_block().hash();
+    let child_block = recovered_empty_block(2, parent_hash, Some(B256::ZERO));
     let child_state_updates = HashedPostState::default();
     let validator = BaseEngineValidator::<_, BaseTransactionSigned, BaseChainSpec>::new::<
         KeccakKeyHasher,
@@ -67,25 +47,96 @@ fn isthmus_withdrawals_root_validation_uses_in_memory_parent_overlay() {
         );
     assert!(
         legacy_result.is_err(),
-        "legacy validation should not find the unpersisted parent by hash"
+        "legacy validation should fail closed when the parent state is not canonical"
     );
     assert!(
         provider.state_by_block_hash(parent_hash).is_err(),
         "test setup requires the parent to exist only in memory"
     );
+}
 
+#[test]
+fn isthmus_validation_rejects_bad_withdrawals_root_with_in_memory_parent_overlay() {
+    let (chain_spec, provider, genesis_hash, parent_executed_block, parent_withdrawals_root) =
+        isthmus_parent_overlay_fixture();
+    let parent_hash = parent_executed_block.recovered_block().hash();
+    let bad_withdrawals_root = B256::repeat_byte(0x42);
+    assert_ne!(bad_withdrawals_root, parent_withdrawals_root);
+    let child_block = recovered_empty_block(2, parent_hash, Some(bad_withdrawals_root));
+    let child_state_updates = HashedPostState::default();
     let parent_state_provider_builder =
         StateProviderBuilder::new(provider, genesis_hash, Some(vec![parent_executed_block]));
     let parent_state_provider =
         parent_state_provider_builder.build().expect("build overlay parent state provider");
 
-    PayloadValidatorWithState::<BaseEngineTypes>::validate_block_post_execution_with_state(
-        &validator,
+    let result = verify_isthmus_withdrawals_root(
+        chain_spec.as_ref(),
+        KeccakKeyHasher::hash_key(Predeploys::L2_TO_L1_MESSAGE_PASSER),
         &child_state_updates,
         parent_state_provider,
-        &child_block,
+        child_block.header(),
+    );
+
+    assert!(
+        result.is_err(),
+        "state-aware validation should reject an invalid withdrawals root for in-memory parents"
+    );
+}
+
+#[test]
+fn isthmus_validation_accepts_valid_withdrawals_root_with_in_memory_parent_overlay() {
+    let (chain_spec, provider, genesis_hash, parent_executed_block, parent_withdrawals_root) =
+        isthmus_parent_overlay_fixture();
+    let parent_hash = parent_executed_block.recovered_block().hash();
+    let child_block = recovered_empty_block(2, parent_hash, Some(parent_withdrawals_root));
+    let child_state_updates = HashedPostState::default();
+    let parent_state_provider_builder =
+        StateProviderBuilder::new(provider, genesis_hash, Some(vec![parent_executed_block]));
+    let parent_state_provider =
+        parent_state_provider_builder.build().expect("build overlay parent state provider");
+
+    verify_isthmus_withdrawals_root(
+        chain_spec.as_ref(),
+        KeccakKeyHasher::hash_key(Predeploys::L2_TO_L1_MESSAGE_PASSER),
+        &child_state_updates,
+        parent_state_provider,
+        child_block.header(),
     )
     .expect("state-aware validation should use the in-memory parent overlay");
+}
+
+fn isthmus_parent_overlay_fixture() -> (
+    Arc<BaseChainSpec>,
+    impl BlockReader + StateProviderFactory + StateReader + Clone,
+    B256,
+    ExecutedBlock<BasePrimitives>,
+    B256,
+) {
+    let chain_spec = Arc::new(
+        BaseChainSpecBuilder::default()
+            .chain(Chain::dev())
+            .genesis(Default::default())
+            .isthmus_activated()
+            .build(),
+    );
+    let provider_factory =
+        create_test_provider_factory_with_node_types::<BaseNode>(Arc::clone(&chain_spec));
+    let genesis_hash = init_genesis(&provider_factory).expect("initialize genesis");
+    let provider = BlockchainProvider::new(provider_factory).expect("create blockchain provider");
+
+    let parent_block = recovered_empty_block(1, genesis_hash, None);
+    let (parent_execution_output, parent_hashed_state, parent_withdrawals_root) =
+        parent_message_passer_update();
+    let parent_executed_block = ExecutedBlock::<BasePrimitives>::new(
+        Arc::new(parent_block),
+        Arc::new(parent_execution_output),
+        ComputedTrieData {
+            hashed_state: Arc::new(parent_hashed_state.into_sorted()),
+            ..Default::default()
+        },
+    );
+
+    (chain_spec, provider, genesis_hash, parent_executed_block, parent_withdrawals_root)
 }
 
 fn parent_message_passer_update() -> (BlockExecutionOutput<BaseReceipt>, HashedPostState, B256) {

--- a/crates/execution/engine-tree/tests/isthmus.rs
+++ b/crates/execution/engine-tree/tests/isthmus.rs
@@ -9,10 +9,7 @@ use base_common_consensus::{
     BaseBlock, BasePrimitives, BaseReceipt, BaseTransactionSigned, Predeploys,
 };
 use base_execution_chainspec::{BaseChainSpec, BaseChainSpecBuilder};
-use base_node_core::{
-    BaseEngineTypes, BaseNode,
-    engine::{BaseEngineValidator, verify_isthmus_withdrawals_root},
-};
+use base_node_core::{BaseEngineTypes, BaseNode, engine::BaseEngineValidator};
 use reth_chain_state::{ComputedTrieData, ExecutedBlock};
 use reth_db_common::init::init_genesis;
 use reth_engine_primitives::PayloadValidator;
@@ -24,7 +21,7 @@ use reth_provider::{
 };
 use reth_revm::{bytecode::Bytecode, state::AccountInfo};
 use reth_trie::{
-    HashedPostState, HashedStorage, KeccakKeyHasher, KeyHasher, test_utils::storage_root_prehashed,
+    HashedPostState, HashedStorage, KeccakKeyHasher, test_utils::storage_root_prehashed,
 };
 use revm::database::BundleState;
 
@@ -64,14 +61,18 @@ fn isthmus_validation_rejects_bad_withdrawals_root_with_in_memory_parent_overlay
     assert_ne!(bad_withdrawals_root, parent_withdrawals_root);
     let child_block = recovered_empty_block(2, parent_hash, Some(bad_withdrawals_root));
     let child_state_updates = HashedPostState::default();
-    let parent_state_provider_builder =
-        StateProviderBuilder::new(provider, genesis_hash, Some(vec![parent_executed_block]));
+    let parent_state_provider_builder = StateProviderBuilder::new(
+        provider.clone(),
+        genesis_hash,
+        Some(vec![parent_executed_block]),
+    );
     let parent_state_provider =
         parent_state_provider_builder.build().expect("build overlay parent state provider");
+    let validator = BaseEngineValidator::<_, BaseTransactionSigned, BaseChainSpec>::new::<
+        KeccakKeyHasher,
+    >(chain_spec, provider);
 
-    let result = verify_isthmus_withdrawals_root(
-        chain_spec.as_ref(),
-        KeccakKeyHasher::hash_key(Predeploys::L2_TO_L1_MESSAGE_PASSER),
+    let result = validator.validate_block_post_execution_with_state(
         &child_state_updates,
         parent_state_provider,
         child_block.header(),
@@ -90,19 +91,24 @@ fn isthmus_validation_accepts_valid_withdrawals_root_with_in_memory_parent_overl
     let parent_hash = parent_executed_block.recovered_block().hash();
     let child_block = recovered_empty_block(2, parent_hash, Some(parent_withdrawals_root));
     let child_state_updates = HashedPostState::default();
-    let parent_state_provider_builder =
-        StateProviderBuilder::new(provider, genesis_hash, Some(vec![parent_executed_block]));
+    let parent_state_provider_builder = StateProviderBuilder::new(
+        provider.clone(),
+        genesis_hash,
+        Some(vec![parent_executed_block]),
+    );
     let parent_state_provider =
         parent_state_provider_builder.build().expect("build overlay parent state provider");
+    let validator = BaseEngineValidator::<_, BaseTransactionSigned, BaseChainSpec>::new::<
+        KeccakKeyHasher,
+    >(chain_spec, provider);
 
-    verify_isthmus_withdrawals_root(
-        chain_spec.as_ref(),
-        KeccakKeyHasher::hash_key(Predeploys::L2_TO_L1_MESSAGE_PASSER),
-        &child_state_updates,
-        parent_state_provider,
-        child_block.header(),
-    )
-    .expect("state-aware validation should use the in-memory parent overlay");
+    validator
+        .validate_block_post_execution_with_state(
+            &child_state_updates,
+            parent_state_provider,
+            child_block.header(),
+        )
+        .expect("state-aware validation should use the in-memory parent overlay");
 }
 
 fn isthmus_parent_overlay_fixture() -> (

--- a/crates/execution/node/src/engine.rs
+++ b/crates/execution/node/src/engine.rs
@@ -112,7 +112,7 @@ where
     }
 
     /// Verifies Isthmus withdrawals root against the given parent state provider.
-    pub fn validate_block_post_execution_with_state<DB, H>(
+    pub fn verify_isthmus_withdrawals_root<DB, H>(
         &self,
         state_updates: &HashedPostState,
         state: DB,
@@ -161,7 +161,7 @@ where
                 "failed to load parent state for Isthmus withdrawals root validation: {err}"
             ))
         })?;
-        self.validate_block_post_execution_with_state(state_updates, state, block.header())
+        self.verify_isthmus_withdrawals_root(state_updates, state, block.header())
     }
 
     fn convert_payload_to_block(

--- a/crates/execution/node/src/engine.rs
+++ b/crates/execution/node/src/engine.rs
@@ -22,7 +22,7 @@ use reth_node_api::{
     validate_version_specific_fields,
 };
 use reth_primitives_traits::{Block, RecoveredBlock, SealedBlock, SignedTransaction};
-use reth_provider::StateProviderFactory;
+use reth_provider::{StateProvider, StateProviderFactory};
 use reth_trie_common::{HashedPostState, KeyHasher};
 
 /// The types used in the Base beacon consensus engine.
@@ -110,6 +110,32 @@ where
     pub fn chain_spec(&self) -> &ChainSpec {
         self.inner.chain_spec()
     }
+
+    /// Verifies Isthmus withdrawals root against the given parent state provider.
+    pub fn validate_block_post_execution_with_state<DB, H>(
+        &self,
+        state_updates: &HashedPostState,
+        state: DB,
+        header: H,
+    ) -> Result<(), ConsensusError>
+    where
+        DB: StateProvider,
+        H: BlockHeader,
+    {
+        if !self.chain_spec().is_isthmus_active_at_timestamp(header.timestamp()) {
+            return Ok(());
+        }
+
+        let predeploy_storage_updates = state_updates
+            .storages
+            .get(&self.hashed_addr_l2tol1_msg_passer)
+            .cloned()
+            .unwrap_or_default();
+        isthmus::verify_withdrawals_root_prehashed(predeploy_storage_updates, state, header)
+            .map_err(|err| {
+                ConsensusError::Other(format!("failed to verify block post-execution: {err}"))
+            })
+    }
 }
 
 impl<P, Tx, ChainSpec, Types> PayloadValidator<Types> for BaseEngineValidator<P, Tx, ChainSpec>
@@ -126,29 +152,16 @@ where
         state_updates: &HashedPostState,
         block: &RecoveredBlock<Self::Block>,
     ) -> Result<(), ConsensusError> {
-        if self.chain_spec().is_isthmus_active_at_timestamp(block.timestamp()) {
-            let Ok(state) = self.provider.state_by_block_hash(block.parent_hash()) else {
-                // FIXME: we don't necessarily have access to the parent block here because the
-                // parent block isn't necessarily part of the canonical chain yet. Instead this
-                // function should receive the list of in memory blocks as input
-                return Ok(());
-            };
-            let predeploy_storage_updates = state_updates
-                .storages
-                .get(&self.hashed_addr_l2tol1_msg_passer)
-                .cloned()
-                .unwrap_or_default();
-            isthmus::verify_withdrawals_root_prehashed(
-                predeploy_storage_updates,
-                state,
-                block.header(),
-            )
-            .map_err(|err| {
-                ConsensusError::Other(format!("failed to verify block post-execution: {err}"))
-            })?
+        if !self.chain_spec().is_isthmus_active_at_timestamp(block.timestamp()) {
+            return Ok(());
         }
 
-        Ok(())
+        let state = self.provider.state_by_block_hash(block.parent_hash()).map_err(|err| {
+            ConsensusError::Other(format!(
+                "failed to load parent state for Isthmus withdrawals root validation: {err}"
+            ))
+        })?;
+        self.validate_block_post_execution_with_state(state_updates, state, block.header())
     }
 
     fn convert_payload_to_block(

--- a/crates/execution/node/src/engine.rs
+++ b/crates/execution/node/src/engine.rs
@@ -155,7 +155,7 @@ pub trait BasePostExecutionValidator<Types: PayloadTypes>:
     PayloadValidator<Types, Block = BaseBlock>
 {
     /// See [`BaseEngineValidator::validate_block_post_execution_with_state`].
-    fn validate_block_post_execution_with_state<DB: StateProvider>(
+    fn validate_block_post_execution_with_parent_state<DB: StateProvider>(
         &self,
         state_updates: &HashedPostState,
         parent_state: DB,
@@ -170,7 +170,7 @@ where
     Self: PayloadValidator<Types, Block = BaseBlock>,
     ChainSpec: Upgrades,
 {
-    fn validate_block_post_execution_with_state<DB: StateProvider>(
+    fn validate_block_post_execution_with_parent_state<DB: StateProvider>(
         &self,
         state_updates: &HashedPostState,
         parent_state: DB,

--- a/crates/execution/node/src/engine.rs
+++ b/crates/execution/node/src/engine.rs
@@ -110,32 +110,30 @@ where
     pub fn chain_spec(&self) -> &ChainSpec {
         self.inner.chain_spec()
     }
+}
 
-    /// Verifies Isthmus withdrawals root against the given parent state provider.
-    pub fn verify_isthmus_withdrawals_root<DB, H>(
-        &self,
-        state_updates: &HashedPostState,
-        state: DB,
-        header: H,
-    ) -> Result<(), ConsensusError>
-    where
-        DB: StateProvider,
-        H: BlockHeader,
-    {
-        if !self.chain_spec().is_isthmus_active_at_timestamp(header.timestamp()) {
-            return Ok(());
-        }
-
-        let predeploy_storage_updates = state_updates
-            .storages
-            .get(&self.hashed_addr_l2tol1_msg_passer)
-            .cloned()
-            .unwrap_or_default();
-        isthmus::verify_withdrawals_root_prehashed(predeploy_storage_updates, state, header)
-            .map_err(|err| {
-                ConsensusError::Other(format!("failed to verify block post-execution: {err}"))
-            })
+/// Verifies the Isthmus withdrawals root against the supplied parent state provider.
+pub fn verify_isthmus_withdrawals_root<DB, H, ChainSpec>(
+    chain_spec: &ChainSpec,
+    hashed_msg_passer_addr: B256,
+    state_updates: &HashedPostState,
+    state: DB,
+    header: H,
+) -> Result<(), ConsensusError>
+where
+    DB: StateProvider,
+    H: BlockHeader,
+    ChainSpec: Upgrades,
+{
+    if !chain_spec.is_isthmus_active_at_timestamp(header.timestamp()) {
+        return Ok(());
     }
+
+    let predeploy_storage_updates =
+        state_updates.storages.get(&hashed_msg_passer_addr).cloned().unwrap_or_default();
+    isthmus::verify_withdrawals_root_prehashed(predeploy_storage_updates, state, header).map_err(
+        |err| ConsensusError::Other(format!("failed to verify block post-execution: {err}")),
+    )
 }
 
 impl<P, Tx, ChainSpec, Types> PayloadValidator<Types> for BaseEngineValidator<P, Tx, ChainSpec>
@@ -152,6 +150,8 @@ where
         state_updates: &HashedPostState,
         block: &RecoveredBlock<Self::Block>,
     ) -> Result<(), ConsensusError> {
+        // Avoid loading parent state before Isthmus; the verifier repeats this gate for direct
+        // callers that already have a parent state provider.
         if !self.chain_spec().is_isthmus_active_at_timestamp(block.timestamp()) {
             return Ok(());
         }
@@ -161,7 +161,13 @@ where
                 "failed to load parent state for Isthmus withdrawals root validation: {err}"
             ))
         })?;
-        self.verify_isthmus_withdrawals_root(state_updates, state, block.header())
+        verify_isthmus_withdrawals_root(
+            self.chain_spec(),
+            self.hashed_addr_l2tol1_msg_passer,
+            state_updates,
+            state,
+            block.header(),
+        )
     }
 
     fn convert_payload_to_block(

--- a/crates/execution/node/src/engine.rs
+++ b/crates/execution/node/src/engine.rs
@@ -110,30 +110,79 @@ where
     pub fn chain_spec(&self) -> &ChainSpec {
         self.inner.chain_spec()
     }
+
+    /// Verifies hardfork-gated post-execution rules against the supplied parent state.
+    ///
+    /// Authoritative implementation of all Base-specific post-execution checks that require
+    /// access to parent state (currently: Isthmus' L2-to-L1 message-passer storage root).
+    /// Callers supply `parent_state` explicitly so engine pipelines can pass in-memory-aware
+    /// overlay providers when the parent block isn't canonical yet.
+    ///
+    /// To add a check for a future hardfork, extend the body with another
+    /// `if chain_spec.is_<X>_active_at_timestamp(...)` arm.
+    pub fn validate_block_post_execution_with_state<DB, H>(
+        &self,
+        state_updates: &HashedPostState,
+        parent_state: DB,
+        header: H,
+    ) -> Result<(), ConsensusError>
+    where
+        DB: StateProvider,
+        H: BlockHeader,
+    {
+        if !self.chain_spec().is_isthmus_active_at_timestamp(header.timestamp()) {
+            return Ok(());
+        }
+
+        let predeploy_storage_updates = state_updates
+            .storages
+            .get(&self.hashed_addr_l2tol1_msg_passer)
+            .cloned()
+            .unwrap_or_default();
+        isthmus::verify_withdrawals_root_prehashed(predeploy_storage_updates, parent_state, header)
+            .map_err(|err| {
+                ConsensusError::Other(format!("failed to verify block post-execution: {err}"))
+            })
+    }
 }
 
-/// Verifies the Isthmus withdrawals root against the supplied parent state provider.
-pub fn verify_isthmus_withdrawals_root<DB, H, ChainSpec>(
-    chain_spec: &ChainSpec,
-    hashed_msg_passer_addr: B256,
-    state_updates: &HashedPostState,
-    state: DB,
-    header: H,
-) -> Result<(), ConsensusError>
+/// Extension trait that exposes [`BaseEngineValidator::validate_block_post_execution_with_state`]
+/// through generic engine pipelines (e.g. `base-engine-tree`'s `V` validator parameter).
+///
+/// The inherent method on [`BaseEngineValidator`] is the source of truth; this trait is just a
+/// dispatch surface so callers that don't know the concrete validator type can still invoke it.
+pub trait BasePostExecutionValidator<Types: PayloadTypes>:
+    PayloadValidator<Types, Block = BaseBlock>
+{
+    /// See [`BaseEngineValidator::validate_block_post_execution_with_state`].
+    fn validate_block_post_execution_with_state<DB: StateProvider>(
+        &self,
+        state_updates: &HashedPostState,
+        parent_state: DB,
+        block: &RecoveredBlock<BaseBlock>,
+    ) -> Result<(), ConsensusError>;
+}
+
+impl<Types, P, Tx, ChainSpec> BasePostExecutionValidator<Types>
+    for BaseEngineValidator<P, Tx, ChainSpec>
 where
-    DB: StateProvider,
-    H: BlockHeader,
+    Types: PayloadTypes,
+    Self: PayloadValidator<Types, Block = BaseBlock>,
     ChainSpec: Upgrades,
 {
-    if !chain_spec.is_isthmus_active_at_timestamp(header.timestamp()) {
-        return Ok(());
+    fn validate_block_post_execution_with_state<DB: StateProvider>(
+        &self,
+        state_updates: &HashedPostState,
+        parent_state: DB,
+        block: &RecoveredBlock<BaseBlock>,
+    ) -> Result<(), ConsensusError> {
+        Self::validate_block_post_execution_with_state(
+            self,
+            state_updates,
+            parent_state,
+            block.header(),
+        )
     }
-
-    let predeploy_storage_updates =
-        state_updates.storages.get(&hashed_msg_passer_addr).cloned().unwrap_or_default();
-    isthmus::verify_withdrawals_root_prehashed(predeploy_storage_updates, state, header).map_err(
-        |err| ConsensusError::Other(format!("failed to verify block post-execution: {err}")),
-    )
 }
 
 impl<P, Tx, ChainSpec, Types> PayloadValidator<Types> for BaseEngineValidator<P, Tx, ChainSpec>
@@ -150,24 +199,18 @@ where
         state_updates: &HashedPostState,
         block: &RecoveredBlock<Self::Block>,
     ) -> Result<(), ConsensusError> {
-        // Avoid loading parent state before Isthmus; the verifier repeats this gate for direct
-        // callers that already have a parent state provider.
         if !self.chain_spec().is_isthmus_active_at_timestamp(block.timestamp()) {
             return Ok(());
         }
 
-        let state = self.provider.state_by_block_hash(block.parent_hash()).map_err(|err| {
-            ConsensusError::Other(format!(
-                "failed to load parent state for Isthmus withdrawals root validation: {err}"
-            ))
-        })?;
-        verify_isthmus_withdrawals_root(
-            self.chain_spec(),
-            self.hashed_addr_l2tol1_msg_passer,
-            state_updates,
-            state,
-            block.header(),
-        )
+        let parent_state =
+            self.provider.state_by_block_hash(block.parent_hash()).map_err(|err| {
+                ConsensusError::Other(format!(
+                    "failed to load parent state for Isthmus withdrawals root validation: {err}"
+                ))
+            })?;
+
+        self.validate_block_post_execution_with_state(state_updates, parent_state, block.header())
     }
 
     fn convert_payload_to_block(

--- a/crates/execution/node/src/lib.rs
+++ b/crates/execution/node/src/lib.rs
@@ -17,7 +17,7 @@ pub use args::TxpoolOrdering;
 /// Exports Base-specific implementations of the [`EngineTypes`](reth_node_api::EngineTypes)
 /// trait.
 pub mod engine;
-pub use engine::BaseEngineTypes;
+pub use engine::{BaseEngineTypes, BasePostExecutionValidator};
 
 pub mod node;
 pub use node::*;


### PR DESCRIPTION
## Summary
- Validate Isthmus withdrawals roots against the in-memory-aware parent state provider used by engine-tree execution.
- Remove the silent success path when the legacy payload validator cannot load parent state for Isthmus validation.

## Test plan
- `RISC0_SKIP_BUILD_KERNELS=1 BASE_SUCCINCT_ELF_STUB=1 cargo check -p base-node-core -p base-engine-tree`


Made with [Cursor](https://cursor.com)