### PR TITLE
fix(challenge): verify account proof address matches expected

### DIFF
--- a/crates/proof/challenge/src/test_utils.rs
+++ b/crates/proof/challenge/src/test_utils.rs
@@ -727,6 +727,21 @@ pub fn build_test_header_and_account(
     block_number: u64,
     storage_hash: B256,
 ) -> (ConsensusHeader, EIP1186AccountProofResponse) {
+    build_test_header_and_account_for_address(
+        block_number,
+        storage_hash,
+        Predeploys::L2_TO_L1_MESSAGE_PASSER,
+    )
+}
+
+/// Builds a consensus header and account proof response pair for `address`.
+/// The returned header's `state_root` is the trie root that the account proof
+/// verifies against.
+pub fn build_test_header_and_account_for_address(
+    block_number: u64,
+    storage_hash: B256,
+    address: Address,
+) -> (ConsensusHeader, EIP1186AccountProofResponse) {
     let account = TrieAccount {
         nonce: 0,
         balance: U256::ZERO,
@@ -736,7 +751,7 @@ pub fn build_test_header_and_account(
     let mut encoded = Vec::with_capacity(account.length());
     account.encode(&mut encoded);
 
-    let account_key = Nibbles::unpack(keccak256(Predeploys::L2_TO_L1_MESSAGE_PASSER));
+    let account_key = Nibbles::unpack(keccak256(address));
     let mut hb = HashBuilder::default().with_proof_retainer(ProofRetainer::new(vec![account_key]));
     hb.add_leaf(account_key, &encoded);
     let state_root = hb.root();
@@ -746,7 +761,7 @@ pub fn build_test_header_and_account(
 
     let header = ConsensusHeader { number: block_number, state_root, ..Default::default() };
     let account_result = EIP1186AccountProofResponse {
-        address: Predeploys::L2_TO_L1_MESSAGE_PASSER,
+        address,
         account_proof,
         balance: U256::ZERO,
         code_hash: B256::ZERO,

--- a/crates/proof/challenge/src/validator.rs
+++ b/crates/proof/challenge/src/validator.rs
@@ -202,9 +202,12 @@ impl<L2: L2Provider> OutputValidator<L2> {
         let account_result =
             self.l2_provider.get_proof(Predeploys::L2_TO_L1_MESSAGE_PASSER, rpc_hash).await?;
 
-        AccountProofVerifier::verify(&account_result, consensus_header.state_root).map_err(
-            |e| ValidatorError::AccountProofFailed { block_number, reason: e.to_string() },
-        )?;
+        AccountProofVerifier::verify(
+            &account_result,
+            consensus_header.state_root,
+            Predeploys::L2_TO_L1_MESSAGE_PASSER,
+        )
+        .map_err(|e| ValidatorError::AccountProofFailed { block_number, reason: e.to_string() })?;
 
         let storage_root = account_result.storage_hash;
         let output_root =
@@ -397,7 +400,9 @@ mod tests {
     use rstest::rstest;
 
     use super::*;
-    use crate::test_utils::{MockL2Provider, build_test_header_and_account};
+    use crate::test_utils::{
+        MockL2Provider, build_test_header_and_account, build_test_header_and_account_for_address,
+    };
 
     /// Creates a mock L2 provider with multiple blocks and returns a vec of
     /// expected output roots (one per block).
@@ -811,5 +816,37 @@ mod tests {
             matches!(err, ValidatorError::AccountProofFailed { block_number: 100, .. }),
             "expected AccountProofFailed, got: {err:?}"
         );
+    }
+
+    /// Regression: a valid proof for a different account must not be accepted
+    /// as the `L2ToL1MessagePasser` storage root.
+    #[tokio::test]
+    async fn test_account_proof_address_mismatch_rejected() {
+        let storage_hash = B256::repeat_byte(0xBB);
+        let substituted_address = Address::repeat_byte(0x99);
+        let (header, account) =
+            build_test_header_and_account_for_address(100, storage_hash, substituted_address);
+        let substituted_root =
+            OutputRoot::from_parts(header.state_root, storage_hash, header.hash_slow()).hash();
+
+        let mut provider = MockL2Provider::new();
+        provider.insert_block(100, header, account);
+
+        let validator = OutputValidator::new(Arc::new(provider));
+        let game_address = Address::repeat_byte(0x10);
+
+        let result = validator.validate_final_root(game_address, 100, substituted_root).await;
+
+        let err = result.expect_err("substituted account proof should be rejected");
+        match err {
+            ValidatorError::AccountProofFailed { block_number, reason } => {
+                assert_eq!(block_number, 100);
+                assert!(
+                    reason.contains("account proof address mismatch"),
+                    "expected address mismatch reason, got: {reason}"
+                );
+            }
+            other => panic!("expected AccountProofFailed, got: {other:?}"),
+        }
     }
 }

--- a/crates/proof/challenge/src/verify.rs
+++ b/crates/proof/challenge/src/verify.rs
@@ -3,7 +3,7 @@
 //! Provides [`AccountProofVerifier`] for verifying `eth_getProof` responses
 //! against a state root using Merkle Patricia Trie proofs.
 
-use alloy_primitives::{B256, keccak256};
+use alloy_primitives::{Address, B256, keccak256};
 use alloy_rlp::Encodable;
 use alloy_rpc_types_eth::EIP1186AccountProofResponse;
 use alloy_trie::{
@@ -15,6 +15,15 @@ use thiserror::Error;
 /// Errors from account proof verification.
 #[derive(Debug, Eq, PartialEq, Error)]
 pub enum AccountProofError {
+    /// The RPC response is for a different account than the caller requested.
+    #[error("account proof address mismatch: expected {expected}, got {actual}")]
+    AddressMismatch {
+        /// The address the caller expected to verify.
+        expected: Address,
+        /// The address returned in the proof response.
+        actual: Address,
+    },
+
     /// The Merkle proof does not match the expected account state.
     #[error("account proof verification failed: {0}")]
     VerificationFailed(#[from] ProofVerificationError),
@@ -29,13 +38,23 @@ impl AccountProofVerifier {
     ///
     /// # Errors
     ///
-    /// Returns [`AccountProofError::VerificationFailed`] if the proof is
-    /// invalid or the account data doesn't match.
+    /// Returns [`AccountProofError::AddressMismatch`] if the response is for a
+    /// different account than `expected_address`, or
+    /// [`AccountProofError::VerificationFailed`] if the proof is invalid or the
+    /// account data doesn't match.
     pub fn verify(
         response: &EIP1186AccountProofResponse,
         state_root: B256,
+        expected_address: Address,
     ) -> Result<(), AccountProofError> {
-        let key = Nibbles::unpack(keccak256(response.address));
+        if response.address != expected_address {
+            return Err(AccountProofError::AddressMismatch {
+                expected: expected_address,
+                actual: response.address,
+            });
+        }
+
+        let key = Nibbles::unpack(keccak256(expected_address));
 
         let account = TrieAccount {
             nonce: response.nonce,


### PR DESCRIPTION
## Summary
- `AccountProofVerifier::verify` now takes an `expected_address` and returns `AccountProofError::AddressMismatch` when the RPC response is for a different account. Without this check, a valid proof for any other account could be substituted as the `L2ToL1MessagePasser` storage root used to derive the output root.
- Updated `OutputValidator` to pass `Predeploys::L2_TO_L1_MESSAGE_PASSER` as the expected address.
- Added `build_test_header_and_account_for_address` test helper and a regression test (`test_account_proof_address_mismatch_rejected`) that constructs a valid proof for a substituted address and asserts it is rejected.

## Test plan
- `cargo test -p base-challenge`