### PR TITLE
fix(proposer): bypass output cache for JIT validation

### DIFF
--- a/crates/proof/proposer/src/pipeline.rs
+++ b/crates/proof/proposer/src/pipeline.rs
@@ -938,6 +938,7 @@ where
         self.fetch_canonical_roots_with(blocks, false).await
     }
 
+    /// Concurrently fetches canonical output roots, bypassing the output cache.
     async fn fetch_fresh_canonical_roots(
         &self,
         blocks: Vec<u64>,
@@ -945,10 +946,13 @@ where
         self.fetch_canonical_roots_with(blocks, true).await
     }
 
+    /// Concurrently fetches canonical output roots with configurable cache usage.
+    ///
+    /// When `bypass_cache` is true, each root is fetched directly from the rollup node.
     async fn fetch_canonical_roots_with(
         &self,
         blocks: Vec<u64>,
-        fresh: bool,
+        bypass_cache: bool,
     ) -> Result<HashMap<u64, B256>, ProposerError> {
         if blocks.is_empty() {
             return Ok(HashMap::new());
@@ -957,7 +961,7 @@ where
             .map(|block_number| {
                 let rollup = &self.rollup_client;
                 async move {
-                    let output = if fresh {
+                    let output = if bypass_cache {
                         rollup.fresh_output_at_block(block_number).await
                     } else {
                         rollup.output_at_block(block_number).await

--- a/crates/proof/proposer/src/pipeline.rs
+++ b/crates/proof/proposer/src/pipeline.rs
@@ -935,6 +935,21 @@ where
         &self,
         blocks: Vec<u64>,
     ) -> Result<HashMap<u64, B256>, ProposerError> {
+        self.fetch_canonical_roots_with(blocks, false).await
+    }
+
+    async fn fetch_fresh_canonical_roots(
+        &self,
+        blocks: Vec<u64>,
+    ) -> Result<HashMap<u64, B256>, ProposerError> {
+        self.fetch_canonical_roots_with(blocks, true).await
+    }
+
+    async fn fetch_canonical_roots_with(
+        &self,
+        blocks: Vec<u64>,
+        fresh: bool,
+    ) -> Result<HashMap<u64, B256>, ProposerError> {
         if blocks.is_empty() {
             return Ok(HashMap::new());
         }
@@ -942,11 +957,12 @@ where
             .map(|block_number| {
                 let rollup = &self.rollup_client;
                 async move {
-                    rollup
-                        .output_at_block(block_number)
-                        .await
-                        .map(|out| (block_number, out.output_root))
-                        .map_err(ProposerError::Rpc)
+                    let output = if fresh {
+                        rollup.fresh_output_at_block(block_number).await
+                    } else {
+                        rollup.output_at_block(block_number).await
+                    };
+                    output.map(|out| (block_number, out.output_root)).map_err(ProposerError::Rpc)
                 }
             })
             .buffered(self.config.recovery_scan_concurrency)
@@ -1063,7 +1079,7 @@ where
         // JIT validation: check that the proved output root still matches canonical.
         let canonical_output = self
             .rollup_client
-            .output_at_block(target_block)
+            .fresh_output_at_block(target_block)
             .await
             .map_err(|e| SubmitAction::Failed(ProposerError::Rpc(e)))?;
 
@@ -1091,13 +1107,15 @@ where
             .extract_intermediate_roots(starting_block_number, proposals, &intermediate_blocks)
             .map_err(SubmitAction::Failed)?;
 
-        // Fetch canonical roots for non-target intermediate blocks only;
-        // the target block was already fetched for the JIT check above.
+        // Fetch fresh canonical roots for non-target intermediate blocks only;
+        // the target block was already fetched fresh for the JIT check above.
         let non_target_blocks: Vec<u64> =
             intermediate_blocks.iter().copied().filter(|&b| b != target_block).collect();
 
-        let mut canonical_map: HashMap<u64, B256> =
-            self.fetch_canonical_roots(non_target_blocks).await.map_err(SubmitAction::Failed)?;
+        let mut canonical_map: HashMap<u64, B256> = self
+            .fetch_fresh_canonical_roots(non_target_blocks)
+            .await
+            .map_err(SubmitAction::Failed)?;
         canonical_map.insert(target_block, canonical_output.output_root);
 
         for (root, block) in intermediate_roots.iter().zip(intermediate_blocks.iter()) {

--- a/crates/proof/proposer/src/test_utils.rs
+++ b/crates/proof/proposer/src/test_utils.rs
@@ -128,6 +128,9 @@ impl RollupProvider for MockRollupClient {
             .unwrap_or_else(|| B256::repeat_byte(block_number as u8));
         Ok(OutputAtBlock { output_root: root, block_ref: test_l2_block_ref(block_number, root) })
     }
+    async fn fresh_output_at_block(&self, block_number: u64) -> RpcResult<OutputAtBlock> {
+        self.output_at_block(block_number).await
+    }
 }
 
 /// Mock anchor state registry contract client for tests.

--- a/crates/proof/rpc/Cargo.toml
+++ b/crates/proof/rpc/Cargo.toml
@@ -51,4 +51,4 @@ backon.workspace = true
 moka = { workspace = true, features = ["future"] }
 
 [dev-dependencies]
-tokio = { workspace = true, features = ["test-util"] }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "test-util"] }

--- a/crates/proof/rpc/src/rollup_client.rs
+++ b/crates/proof/rpc/src/rollup_client.rs
@@ -121,6 +121,28 @@ impl RollupClient {
     pub const fn output_cache(&self) -> &MeteredCache<u64, OutputAtBlock> {
         &self.output_cache
     }
+
+    async fn request_output_at_block(&self, block_number: u64) -> RpcResult<OutputAtBlock> {
+        let backoff = self.retry_config.to_backoff_builder();
+
+        (|| async {
+            self.provider
+                .raw_request::<_, OutputAtBlock>(
+                    "optimism_outputAtBlock".into(),
+                    (format!("0x{block_number:x}"),),
+                )
+                .await
+                .map_err(|e| {
+                    RpcError::InvalidResponse(format!("Failed to get output at block: {e}"))
+                })
+        })
+        .retry(backoff)
+        .when(|e| e.is_retryable())
+        .notify(|err, dur| {
+            tracing::debug!(error = %err, delay = ?dur, "Retrying RollupClient::output_at_block");
+        })
+        .await
+    }
 }
 
 #[async_trait]
@@ -171,26 +193,14 @@ impl RollupProvider for RollupClient {
             return Ok(cached);
         }
 
-        let backoff = self.retry_config.to_backoff_builder();
+        let output = self.request_output_at_block(block_number).await?;
+        self.output_cache.insert(block_number, output).await;
 
-        let output = (|| async {
-            self.provider
-                .raw_request::<_, OutputAtBlock>(
-                    "optimism_outputAtBlock".into(),
-                    (format!("0x{block_number:x}"),),
-                )
-                .await
-                .map_err(|e| {
-                    RpcError::InvalidResponse(format!("Failed to get output at block: {e}"))
-                })
-        })
-        .retry(backoff)
-        .when(|e| e.is_retryable())
-        .notify(|err, dur| {
-            tracing::debug!(error = %err, delay = ?dur, "Retrying RollupClient::output_at_block");
-        })
-        .await?;
+        Ok(output)
+    }
 
+    async fn fresh_output_at_block(&self, block_number: u64) -> RpcResult<OutputAtBlock> {
+        let output = self.request_output_at_block(block_number).await?;
         self.output_cache.insert(block_number, output).await;
 
         Ok(output)

--- a/crates/proof/rpc/src/traits.rs
+++ b/crates/proof/rpc/src/traits.rs
@@ -79,4 +79,8 @@ pub trait RollupProvider: Send + Sync {
 
     /// Gets the output root at a specific L2 block via `optimism_outputAtBlock`.
     async fn output_at_block(&self, block_number: u64) -> RpcResult<OutputAtBlock>;
+
+    /// Gets the output root at a specific L2 block via `optimism_outputAtBlock`,
+    /// bypassing any local cache.
+    async fn fresh_output_at_block(&self, block_number: u64) -> RpcResult<OutputAtBlock>;
 }

--- a/crates/proof/rpc/tests/rollup_client_cache.rs
+++ b/crates/proof/rpc/tests/rollup_client_cache.rs
@@ -1,0 +1,124 @@
+//! Integration tests for rollup client output-at-block cache behavior.
+
+use std::{
+    io::{Read, Write},
+    net::{TcpListener, TcpStream},
+    sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    },
+    thread::{self, JoinHandle},
+    time::Duration,
+};
+
+use alloy_primitives::B256;
+use base_proof_rpc::{RollupClient, RollupClientConfig, RollupProvider};
+use url::Url;
+
+fn repeated_hash(byte: &str) -> String {
+    format!("0x{}", byte.repeat(32))
+}
+
+fn output_response(output_root: &str, block_number: u64) -> String {
+    format!(
+        r#"{{"jsonrpc":"2.0","id":1,"result":{{"outputRoot":"{output_root}","blockRef":{{"hash":"0x3333333333333333333333333333333333333333333333333333333333333333","number":{block_number},"parentHash":"0x2222222222222222222222222222222222222222222222222222222222222222","timestamp":1234567890,"l1origin":{{"hash":"0x1111111111111111111111111111111111111111111111111111111111111111","number":100}},"sequenceNumber":0}}}}}}"#
+    )
+}
+
+fn read_http_request(stream: &mut TcpStream) -> String {
+    let mut bytes = Vec::new();
+    let mut buf = [0; 1024];
+
+    loop {
+        let read = stream.read(&mut buf).expect("read request");
+        if read == 0 {
+            break;
+        }
+        bytes.extend_from_slice(&buf[..read]);
+
+        let Some(headers_end) = bytes.windows(4).position(|window| window == b"\r\n\r\n") else {
+            continue;
+        };
+        let headers = String::from_utf8_lossy(&bytes[..headers_end]);
+        let content_length = headers
+            .lines()
+            .find_map(|line| {
+                let (name, value) = line.split_once(": ")?;
+                name.eq_ignore_ascii_case("content-length")
+                    .then(|| value.parse::<usize>().expect("content length"))
+            })
+            .unwrap_or_default();
+
+        if bytes.len() >= headers_end + 4 + content_length {
+            break;
+        }
+    }
+
+    String::from_utf8(bytes).expect("request is UTF-8")
+}
+
+fn start_output_rpc(
+    roots: Vec<String>,
+    block_number: u64,
+) -> (Url, Arc<AtomicUsize>, JoinHandle<()>) {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind mock rollup RPC");
+    let addr = listener.local_addr().expect("local address");
+    let calls = Arc::new(AtomicUsize::new(0));
+    let calls_for_thread = Arc::clone(&calls);
+
+    let handle = thread::spawn(move || {
+        for root in roots {
+            let (mut stream, _) = listener.accept().expect("accept request");
+            let request = read_http_request(&mut stream);
+            assert!(request.contains("optimism_outputAtBlock"), "unexpected request: {request}");
+            assert!(
+                request.contains(&format!("0x{block_number:x}")),
+                "request did not ask for block {block_number}: {request}"
+            );
+
+            calls_for_thread.fetch_add(1, Ordering::SeqCst);
+            let body = output_response(&root, block_number);
+            let response = format!(
+                "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
+                body.len(),
+                body
+            );
+            stream.write_all(response.as_bytes()).expect("write response");
+        }
+    });
+
+    (Url::parse(&format!("http://{addr}")).expect("mock URL"), calls, handle)
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn fresh_output_at_block_bypasses_and_updates_cache() {
+    let block_number = 12_345;
+    let stale_root_hex = repeated_hash("11");
+    let fresh_root_hex = repeated_hash("22");
+    let stale_root: B256 = stale_root_hex.parse().expect("stale root");
+    let fresh_root: B256 = fresh_root_hex.parse().expect("fresh root");
+
+    let (url, calls, server) = start_output_rpc(vec![stale_root_hex, fresh_root_hex], block_number);
+    let client =
+        RollupClient::new(RollupClientConfig::new(url).with_timeout(Duration::from_secs(5)))
+            .expect("rollup client");
+
+    let first = client.output_at_block(block_number).await.expect("first cached read");
+    assert_eq!(first.output_root, stale_root);
+    assert_eq!(calls.load(Ordering::SeqCst), 1);
+
+    let cached = client.output_at_block(block_number).await.expect("second cached read");
+    assert_eq!(cached.output_root, stale_root);
+    assert_eq!(calls.load(Ordering::SeqCst), 1);
+
+    let fresh =
+        client.fresh_output_at_block(block_number).await.expect("fresh output-at-block read");
+    assert_eq!(fresh.output_root, fresh_root);
+    assert_eq!(calls.load(Ordering::SeqCst), 2);
+
+    let updated_cached = client.output_at_block(block_number).await.expect("updated cached read");
+    assert_eq!(updated_cached.output_root, fresh_root);
+    assert_eq!(calls.load(Ordering::SeqCst), 2);
+
+    server.join().expect("mock server");
+}

--- a/crates/proof/rpc/tests/rollup_client_cache.rs
+++ b/crates/proof/rpc/tests/rollup_client_cache.rs
@@ -13,15 +13,16 @@ use std::{
 
 use alloy_primitives::B256;
 use base_proof_rpc::{RollupClient, RollupClientConfig, RollupProvider};
+use serde_json::Value;
 use url::Url;
 
 fn repeated_hash(byte: &str) -> String {
     format!("0x{}", byte.repeat(32))
 }
 
-fn output_response(output_root: &str, block_number: u64) -> String {
+fn output_response(id: &Value, output_root: &str, block_number: u64) -> String {
     format!(
-        r#"{{"jsonrpc":"2.0","id":1,"result":{{"outputRoot":"{output_root}","blockRef":{{"hash":"0x3333333333333333333333333333333333333333333333333333333333333333","number":{block_number},"parentHash":"0x2222222222222222222222222222222222222222222222222222222222222222","timestamp":1234567890,"l1origin":{{"hash":"0x1111111111111111111111111111111111111111111111111111111111111111","number":100}},"sequenceNumber":0}}}}}}"#
+        r#"{{"jsonrpc":"2.0","id":{id},"result":{{"outputRoot":"{output_root}","blockRef":{{"hash":"0x3333333333333333333333333333333333333333333333333333333333333333","number":{block_number},"parentHash":"0x2222222222222222222222222222222222222222222222222222222222222222","timestamp":1234567890,"l1origin":{{"hash":"0x1111111111111111111111111111111111111111111111111111111111111111","number":100}},"sequenceNumber":0}}}}}}"#
     )
 }
 
@@ -57,6 +58,13 @@ fn read_http_request(stream: &mut TcpStream) -> String {
     String::from_utf8(bytes).expect("request is UTF-8")
 }
 
+fn request_id(request: &str) -> Value {
+    let body_start = request.find("\r\n\r\n").expect("request has body separator") + 4;
+    let body: Value = serde_json::from_str(&request[body_start..]).expect("request body is JSON");
+
+    body.get("id").cloned().expect("request has JSON-RPC id")
+}
+
 fn start_output_rpc(
     roots: Vec<String>,
     block_number: u64,
@@ -75,9 +83,10 @@ fn start_output_rpc(
                 request.contains(&format!("0x{block_number:x}")),
                 "request did not ask for block {block_number}: {request}"
             );
+            let id = request_id(&request);
 
             calls_for_thread.fetch_add(1, Ordering::SeqCst);
-            let body = output_response(&root, block_number);
+            let body = output_response(&id, &root, block_number);
             let response = format!(
                 "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
                 body.len(),


### PR DESCRIPTION
## Summary
- Add `RollupProvider::fresh_output_at_block` that issues an uncached RPC and refreshes the local output cache.
- Switch the proposer's just-in-time canonical root checks (target block + intermediate blocks) to use the fresh path so stale cached outputs cannot mask divergence at submission time.
- Add an integration test (`crates/proof/rpc/tests/rollup_client_cache.rs`) covering cached vs. fresh fetch behavior against a mock RPC.

## Why
The pre-submission JIT check existed to catch canonical divergence, but it was reading from the same cache populated during pipeline traversal. A stale cache hit would let the proposer submit against a no-longer-canonical root. Forcing a fresh fetch (and updating the cache afterwards) closes that window without giving up cache benefits elsewhere.