### PR TITLE
feat(proposer): delegate proposal timeout to tx-manager

### DIFF
--- a/crates/proof/proposer/src/cli.rs
+++ b/crates/proof/proposer/src/cli.rs
@@ -14,7 +14,7 @@ base_cli_utils::define_log_args!("BASE_PROPOSER");
 base_cli_utils::define_metrics_args!("BASE_PROPOSER", 7300);
 base_cli_utils::define_health_args!("BASE_PROPOSER", 8080);
 base_tx_manager::define_signer_cli!("BASE_PROPOSER");
-base_tx_manager::define_tx_manager_cli!("BASE_PROPOSER");
+base_tx_manager::define_tx_manager_cli!("BASE_PROPOSER", tx_send_timeout_default = "10m");
 
 /// Proposer - TEE-based output proposal generation for Base.
 #[derive(Debug, Clone, Parser)]
@@ -229,6 +229,7 @@ mod tests {
     use base_cli_utils::LogFormat;
 
     use super::*;
+    use crate::constants::PROPOSAL_TIMEOUT;
 
     #[test]
     fn test_cli_defaults() {
@@ -282,6 +283,7 @@ mod tests {
         assert_eq!(cli.proposer.rpc_max_retries, 5);
         assert_eq!(cli.proposer.rpc_retry_initial_delay, Duration::from_millis(100));
         assert_eq!(cli.proposer.rpc_retry_max_delay, Duration::from_secs(10));
+        assert_eq!(cli.proposer.tx_manager.tx_send_timeout, PROPOSAL_TIMEOUT);
 
         // Check signing defaults (all None)
         assert!(cli.proposer.signer.private_key.is_none());
@@ -294,6 +296,34 @@ mod tests {
         // Test that missing required fields cause an error
         let args = vec!["proposer"];
         assert!(Cli::try_parse_from(args).is_err());
+    }
+
+    #[test]
+    fn test_cli_preserves_explicit_zero_tx_send_timeout() {
+        let args = vec![
+            "proposer",
+            "--prover-rpc",
+            "http://localhost:8080",
+            "--l1-eth-rpc",
+            "http://localhost:8545",
+            "--l2-eth-rpc",
+            "http://localhost:9545",
+            "--anchor-state-registry-addr",
+            "0x1234567890123456789012345678901234567890",
+            "--dispute-game-factory-addr",
+            "0x2234567890123456789012345678901234567890",
+            "--game-type",
+            "1",
+            "--tee-image-hash",
+            "0x0000000000000000000000000000000000000000000000000000000000000001",
+            "--rollup-rpc",
+            "http://localhost:7545",
+            "--tx-manager.tx-send-timeout",
+            "0s",
+        ];
+        let cli = Cli::try_parse_from(args).unwrap();
+
+        assert!(cli.proposer.tx_manager.tx_send_timeout.is_zero());
     }
 
     #[test]

--- a/crates/proof/proposer/src/config.rs
+++ b/crates/proof/proposer/src/config.rs
@@ -227,10 +227,12 @@ mod tests {
     use base_cli_utils::LogFormat;
 
     use super::*;
-    use crate::cli::{
-        AdminArgs, Cli, HealthArgs, LogArgs, MetricsArgs, ProposerArgs, SignerCli, TxManagerCli,
+    use crate::{
+        cli::{
+            AdminArgs, Cli, HealthArgs, LogArgs, MetricsArgs, ProposerArgs, SignerCli, TxManagerCli,
+        },
+        constants::PROPOSAL_TIMEOUT,
     };
-    use crate::constants::PROPOSAL_TIMEOUT;
 
     fn minimal_cli() -> Cli {
         Cli {

--- a/crates/proof/proposer/src/config.rs
+++ b/crates/proof/proposer/src/config.rs
@@ -230,6 +230,7 @@ mod tests {
     use crate::cli::{
         AdminArgs, Cli, HealthArgs, LogArgs, MetricsArgs, ProposerArgs, SignerCli, TxManagerCli,
     };
+    use crate::constants::PROPOSAL_TIMEOUT;
 
     fn minimal_cli() -> Cli {
         Cli {
@@ -294,6 +295,16 @@ mod tests {
         assert_eq!(config.poll_interval, Duration::from_secs(12));
         assert_eq!(config.rpc_timeout, Duration::from_secs(30));
         assert_eq!(config.max_parallel_proofs, 1);
+        assert_eq!(config.tx_manager.as_ref().unwrap().tx_send_timeout, PROPOSAL_TIMEOUT);
+    }
+
+    #[test]
+    fn test_explicit_zero_tx_send_timeout_disables_tx_manager_timeout() {
+        let mut cli = minimal_cli();
+        cli.proposer.tx_manager.tx_send_timeout = Duration::ZERO;
+        let config = ProposerConfig::from_cli(cli).unwrap();
+
+        assert_eq!(config.tx_manager.as_ref().unwrap().tx_send_timeout, Duration::ZERO);
     }
 
     #[test]

--- a/crates/proof/proposer/src/constants.rs
+++ b/crates/proof/proposer/src/constants.rs
@@ -2,7 +2,8 @@
 
 use std::time::Duration;
 
-/// Maximum time to wait for a proposal to be included on-chain.
+/// Default maximum time for the transaction manager to wait for a proposal
+/// transaction to be included on-chain.
 pub const PROPOSAL_TIMEOUT: Duration = Duration::from_mins(10);
 
 /// Timeout for prover server RPC calls.

--- a/crates/proof/proposer/src/pipeline.rs
+++ b/crates/proof/proposer/src/pipeline.rs
@@ -49,7 +49,6 @@ use tracing::{debug, error, info, instrument, warn};
 
 use crate::{
     Metrics,
-    constants::PROPOSAL_TIMEOUT,
     driver::{DriverConfig, RecoveredState},
     error::ProposerError,
     output_proposer::OutputProposer,
@@ -1164,26 +1163,20 @@ where
             "Proposing output (creating dispute game)"
         );
 
-        // Submit with timeout.
         let mut propose_timer = base_metrics::timed!(Metrics::proposal_l1_tx_duration_seconds());
-        let propose_result = tokio::time::timeout(
-            PROPOSAL_TIMEOUT,
-            self.output_proposer.propose_output(
-                aggregate_proposal,
-                parent_address,
-                &intermediate_roots,
-            ),
-        )
-        .await;
+        let propose_result = self
+            .output_proposer
+            .propose_output(aggregate_proposal, parent_address, &intermediate_roots)
+            .await;
 
         match propose_result {
-            Ok(Ok(())) => {
+            Ok(()) => {
                 drop(propose_timer);
                 info!(target_block, "Dispute game created successfully");
                 Metrics::l2_output_proposals_total().increment(1);
                 Ok(())
             }
-            Ok(Err(e)) => {
+            Err(e) => {
                 if e.is_game_already_exists() {
                     drop(propose_timer);
                     info!(
@@ -1195,13 +1188,6 @@ where
                     propose_timer.disarm();
                     Err(SubmitAction::Failed(e))
                 }
-            }
-            Err(_) => {
-                propose_timer.disarm();
-                Err(SubmitAction::Failed(ProposerError::Internal(format!(
-                    "dispute game creation timed out after {}s",
-                    PROPOSAL_TIMEOUT.as_secs()
-                ))))
             }
         }
     }
@@ -1305,6 +1291,7 @@ mod tests {
     use std::{collections::HashMap, sync::Arc, time::Duration};
 
     use alloy_primitives::{Address, B256};
+    use async_trait::async_trait;
     use base_proof_primitives::{ProofResult, Proposal, ProverClient};
     use rstest::rstest;
     use tokio_util::sync::CancellationToken;
@@ -1468,6 +1455,24 @@ mod tests {
         block_interval: u64,
         intermediate_block_interval: u64,
     ) -> TestPipeline {
+        recovery_pipeline_full_with_output_proposer(
+            factory,
+            output_roots,
+            anchor_block,
+            block_interval,
+            intermediate_block_interval,
+            Arc::new(MockOutputProposer),
+        )
+    }
+
+    fn recovery_pipeline_full_with_output_proposer(
+        factory: MockDisputeGameFactory,
+        output_roots: HashMap<u64, B256>,
+        anchor_block: u64,
+        block_interval: u64,
+        intermediate_block_interval: u64,
+        output_proposer: Arc<dyn OutputProposer>,
+    ) -> TestPipeline {
         let cancel = CancellationToken::new();
         let l1 = Arc::new(MockL1 { latest_block_number: TEST_L1_BLOCK_NUMBER });
         let l2 = Arc::new(MockL2 { block_not_found: true, canonical_hash: None });
@@ -1501,7 +1506,7 @@ mod tests {
             anchor_registry,
             Arc::new(factory),
             Arc::new(MockAggregateVerifier::default()),
-            Arc::new(MockOutputProposer),
+            output_proposer,
             cancel,
         )
     }
@@ -2116,6 +2121,24 @@ mod tests {
         ProofResult::Tee { aggregate_proposal: aggregate, proposals }
     }
 
+    #[derive(Debug)]
+    struct DelayedOutputProposer {
+        delay: Duration,
+    }
+
+    #[async_trait]
+    impl OutputProposer for DelayedOutputProposer {
+        async fn propose_output(
+            &self,
+            _proposal: &Proposal,
+            _parent_address: Address,
+            _intermediate_roots: &[B256],
+        ) -> Result<(), ProposerError> {
+            tokio::time::sleep(self.delay).await;
+            Ok(())
+        }
+    }
+
     #[tokio::test(flavor = "current_thread", start_paused = true)]
     async fn test_validate_and_submit_intermediate_roots_match() {
         // MockRollupClient returns B256::repeat_byte(n) for blocks without
@@ -2126,6 +2149,29 @@ mod tests {
         let result =
             pipeline.validate_and_submit(&proof_result, SUBMIT_BLOCK_INTERVAL, Address::ZERO).await;
         assert!(result.is_ok(), "all roots match, submission should succeed");
+    }
+
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn test_validate_and_submit_does_not_apply_outer_timeout() {
+        let pipeline = recovery_pipeline_full_with_output_proposer(
+            MockDisputeGameFactory::with_games(vec![]),
+            HashMap::new(),
+            TEST_ANCHOR_BLOCK,
+            SUBMIT_BLOCK_INTERVAL,
+            SUBMIT_INTERMEDIATE_INTERVAL,
+            Arc::new(DelayedOutputProposer {
+                delay: crate::constants::PROPOSAL_TIMEOUT + Duration::from_secs(1),
+            }),
+        );
+        let proof_result = submit_proof_result(SUBMIT_BLOCK_INTERVAL);
+
+        let result =
+            pipeline.validate_and_submit(&proof_result, SUBMIT_BLOCK_INTERVAL, Address::ZERO).await;
+
+        assert!(
+            result.is_ok(),
+            "submission should rely on tx-manager timeout, not an outer timeout"
+        );
     }
 
     #[rstest]

--- a/crates/utilities/tx-manager/src/macros.rs
+++ b/crates/utilities/tx-manager/src/macros.rs
@@ -6,6 +6,10 @@
 /// ```rust,ignore
 /// base_tx_manager::define_tx_manager_cli!("BASE_TX_MANAGER");
 /// base_tx_manager::define_tx_manager_cli!("BASE_CHALLENGER_TX_MANAGER");
+/// base_tx_manager::define_tx_manager_cli!(
+///     "BASE_PROPOSER",
+///     tx_send_timeout_default = "10m",
+/// );
 /// ```
 ///
 /// The generated struct exposes confirmations, fee limits, timeouts, polling
@@ -35,6 +39,9 @@
 #[macro_export]
 macro_rules! define_tx_manager_cli {
     ($prefix:literal) => {
+        $crate::define_tx_manager_cli!($prefix, tx_send_timeout_default = "0s");
+    };
+    ($prefix:literal, tx_send_timeout_default = $tx_send_timeout_default:literal $(,)?) => {
         /// CLI arguments for the transaction manager.
         ///
         /// Designed to be `#[command(flatten)]`-ed into parent CLI structs
@@ -134,7 +141,7 @@ macro_rules! define_tx_manager_cli {
             #[arg(
                 long = "tx-manager.tx-send-timeout",
                 env = concat!($prefix, "_", "TX_SEND_TIMEOUT"),
-                default_value = "0s",
+                default_value = $tx_send_timeout_default,
                 value_parser = ::humantime::parse_duration
             )]
             pub tx_send_timeout: ::std::time::Duration,


### PR DESCRIPTION
## Summary
- Drop the outer `PROPOSAL_TIMEOUT` wrapper around `output_proposer.propose_output` in the proposer pipeline and rely on the tx-manager's `tx_send_timeout` instead, avoiding a redundant/competing timeout.
- Extend `define_tx_manager_cli!` to accept an optional `tx_send_timeout_default = "..."` override so individual binaries can pick a sensible default without changing the macro's general default of `0s` (disabled).
- Set the proposer's default `--tx-manager.tx-send-timeout` to `10m`, preserving the previous effective timeout.

## Test plan
- `cargo test -p base-proposer` (covers new tests: default tx_send_timeout, explicit `0s` override, and that `validate_and_submit` no longer enforces an outer timeout)