### PR TITLE
perf: snapshotter to only upload diffs for static files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5954,7 +5954,6 @@ dependencies = [
  "clap",
  "futures",
  "reth-cli-commands",
- "serde",
  "serde_json",
  "serial_test",
  "tempfile",

--- a/crates/infra/snapshotter/Cargo.toml
+++ b/crates/infra/snapshotter/Cargo.toml
@@ -15,16 +15,15 @@ anyhow = { workspace = true }
 bollard = { workspace = true }
 futures = { workspace = true }
 tracing = { workspace = true }
-serde_json = { workspace = true }
 async-trait = { workspace = true }
 reth-cli-commands = { workspace = true }
 tokio = { workspace = true, features = ["rt"] }
 clap = { workspace = true, features = ["derive", "env"] }
-serde = { workspace = true, features = ["std", "derive"] }
 aws-sdk-s3 = { workspace = true, features = ["rustls", "default-https-client", "rt-tokio"] }
 
 [dev-dependencies]
 futures = { workspace = true }
+serde_json = { workspace = true }
 tempfile = { workspace = true }
 bollard = { workspace = true }
 serial_test = { workspace = true }

--- a/crates/infra/snapshotter/src/lib.rs
+++ b/crates/infra/snapshotter/src/lib.rs
@@ -17,7 +17,7 @@ mod snapshot;
 pub use snapshot::SnapshotGenerator;
 
 mod upload;
-pub use upload::{LatestPointer, SnapshotUploader};
+pub use upload::{LatestPointer, SnapshotUploader, UploadStrategy, classify_upload_strategy};
 
 mod orchestrator;
 pub use orchestrator::Snapshotter;

--- a/crates/infra/snapshotter/src/lib.rs
+++ b/crates/infra/snapshotter/src/lib.rs
@@ -17,7 +17,7 @@ mod snapshot;
 pub use snapshot::SnapshotGenerator;
 
 mod upload;
-pub use upload::{LatestPointer, SnapshotUploader, UploadStrategy, classify_upload_strategy};
+pub use upload::{LatestPointer, SnapshotUploader, UploadStrategy};
 
 mod orchestrator;
 pub use orchestrator::Snapshotter;

--- a/crates/infra/snapshotter/src/lib.rs
+++ b/crates/infra/snapshotter/src/lib.rs
@@ -17,7 +17,7 @@ mod snapshot;
 pub use snapshot::SnapshotGenerator;
 
 mod upload;
-pub use upload::{LatestPointer, SnapshotUploader, UploadStrategy};
+pub use upload::{SnapshotUploader, UploadStrategy};
 
 mod orchestrator;
 pub use orchestrator::Snapshotter;

--- a/crates/infra/snapshotter/src/orchestrator.rs
+++ b/crates/infra/snapshotter/src/orchestrator.rs
@@ -117,10 +117,8 @@ impl<C: ContainerManager> Snapshotter<C> {
             bail!("snapshot generation produced no files");
         }
 
-        let block = extract_block_from_manifest(&run_output_dir)?;
-
         self.uploader
-            .upload(&run_output_dir, &files, block, run_timestamp)
+            .upload(&run_output_dir, &files, run_timestamp)
             .await
             .context("snapshot upload failed")?;
 
@@ -131,16 +129,6 @@ impl<C: ContainerManager> Snapshotter<C> {
 
         Ok(())
     }
-}
-
-/// Reads the block number from the generated `manifest.json`.
-fn extract_block_from_manifest(output_dir: &std::path::Path) -> Result<u64> {
-    let manifest_path = output_dir.join("manifest.json");
-    let content = std::fs::read_to_string(&manifest_path)
-        .with_context(|| format!("failed to read {}", manifest_path.display()))?;
-    let manifest: serde_json::Value =
-        serde_json::from_str(&content).context("failed to parse manifest.json")?;
-    manifest["block"].as_u64().ok_or_else(|| anyhow::anyhow!("manifest.json missing 'block' field"))
 }
 
 /// Creates a unique run output directory using the provided timestamp.

--- a/crates/infra/snapshotter/src/upload.rs
+++ b/crates/infra/snapshotter/src/upload.rs
@@ -13,6 +13,8 @@ use std::{
 use anyhow::{Context, Result, bail};
 use aws_sdk_s3::{
     Client as S3Client,
+    error::SdkError,
+    operation::get_object::GetObjectError,
     primitives::ByteStream,
     types::{CompletedMultipartUpload, CompletedPart},
 };
@@ -40,24 +42,22 @@ pub enum UploadStrategy {
     DiffBySize,
 }
 
-/// Classifies a snapshot filename into its upload strategy.
-///
-/// Static file chunks follow the pattern `{component}-{start}-{end}.tar.zst`
-/// (e.g. `headers-0-499999.tar.zst`). These are immutable for finalized block
-/// ranges and only the tip chunk changes between snapshots.
-///
-/// Everything else (state, rocksdb, manifest) is always uploaded.
-pub fn classify_upload_strategy(filename: &str) -> UploadStrategy {
-    if is_static_file_chunk(filename) {
-        UploadStrategy::DiffBySize
-    } else {
-        UploadStrategy::AlwaysUpload
+impl UploadStrategy {
+    /// Classifies a snapshot filename into its upload strategy.
+    ///
+    /// Static file chunks follow the pattern `{component}-{start}-{end}.tar.zst`
+    /// (e.g. `headers-0-499999.tar.zst`). These are immutable for finalized block
+    /// ranges and only the tip chunk changes between snapshots.
+    ///
+    /// Everything else (state, rocksdb, manifest) is always uploaded.
+    pub fn classify(filename: &str) -> Self {
+        if is_static_file_chunk(filename) { Self::DiffBySize } else { Self::AlwaysUpload }
     }
 }
 
 /// Returns `true` if the filename matches the static file chunk pattern:
-/// `{component}-{start}-{end}.tar.zst`. `rocksdb_incdices` is the prefix for
-/// `RocksDB`, `state` is the prefix for MDBX.
+/// `{component}-{start}-{end}.tar.zst`. `rocksdb_indices` and `state` do not match
+/// this pattern and are classified as `AlwaysUpload`.
 fn is_static_file_chunk(filename: &str) -> bool {
     let Some(stem) = filename.strip_suffix(".tar.zst") else {
         return false;
@@ -100,10 +100,11 @@ impl SnapshotUploader {
 
     /// Uploads snapshot artifacts with diff-based optimization.
     ///
-    /// The run prefix is `{prefix}/{block}-{timestamp}/`. Static file chunks that
-    /// already exist remotely with the same size are skipped. State, rocksdb, and
-    /// manifest are always re-uploaded. `manifest.json` is uploaded last, and
-    /// `latest.json` is written as an atomic pointer to this run.
+    /// Reads `latest.json` to find the previous run's prefix and lists objects
+    /// under it. Static file chunks that exist in the previous run with the same
+    /// size are skipped — they're immutable for finalized block ranges. State,
+    /// rocksdb, and manifest are always re-uploaded to the new run prefix.
+    /// `manifest.json` is uploaded last, then `latest.json` is updated.
     pub async fn upload(
         &self,
         output_dir: &Path,
@@ -124,7 +125,16 @@ impl SnapshotUploader {
             "uploading snapshot artifacts"
         );
 
-        let remote_objects = self.list_remote_objects(&run_prefix).await?;
+        let remote_objects = match self.read_latest_pointer().await? {
+            Some(prev) => {
+                info!(previous_prefix = %prev.prefix, previous_block = prev.block, "found previous snapshot");
+                self.list_remote_objects(&prev.prefix).await?
+            }
+            None => {
+                info!("no previous snapshot found, uploading all files");
+                HashMap::new()
+            }
+        };
 
         let manifest_path = output_dir.join("manifest.json");
         let mut to_upload = Vec::new();
@@ -139,22 +149,23 @@ impl SnapshotUploader {
                 file.file_name().map(|n| n.to_string_lossy().to_string()).unwrap_or_default();
 
             let local_size = std::fs::metadata(file)?.len();
-            let strategy = classify_upload_strategy(&file_name);
+            let strategy = UploadStrategy::classify(&file_name);
 
             if strategy == UploadStrategy::DiffBySize
-                && let Some(&remote_size) = remote_objects.get(&file_name) {
-                    if remote_size == local_size {
-                        debug!(file = %file_name, size = local_size, "skipping (remote size matches)");
-                        skipped += 1;
-                        continue;
-                    }
-                    debug!(
-                        file = %file_name,
-                        local_size,
-                        remote_size,
-                        "re-uploading (size mismatch)"
-                    );
+                && let Some(&remote_size) = remote_objects.get(&file_name)
+            {
+                if remote_size == local_size {
+                    debug!(file = %file_name, size = local_size, "skipping (remote size matches)");
+                    skipped += 1;
+                    continue;
                 }
+                debug!(
+                    file = %file_name,
+                    local_size,
+                    remote_size,
+                    "re-uploading (size mismatch)"
+                );
+            }
 
             to_upload.push(file.clone());
         }
@@ -181,6 +192,40 @@ impl SnapshotUploader {
         Ok(run_prefix)
     }
 
+    /// Reads the `latest.json` pointer from the bucket, returning `None` if it doesn't exist.
+    async fn read_latest_pointer(&self) -> Result<Option<LatestPointer>> {
+        let key = if self.prefix.is_empty() {
+            "latest.json".to_string()
+        } else {
+            format!("{}/latest.json", self.prefix)
+        };
+
+        match self.client.get_object().bucket(&self.bucket).key(&key).send().await {
+            Ok(resp) => {
+                let body = resp.body.collect().await?.into_bytes();
+                let pointer: LatestPointer = serde_json::from_slice(&body)
+                    .with_context(|| format!("failed to parse {key}"))?;
+                Ok(Some(pointer))
+            }
+            Err(err) => match &err {
+                SdkError::ServiceError(e) if matches!(e.err(), GetObjectError::NoSuchKey(_)) => {
+                    Ok(None)
+                }
+                _ => {
+                    let err_str = err.to_string();
+                    if err_str.contains("NoSuchKey")
+                        || err_str.contains("404")
+                        || err_str.contains("NotFound")
+                    {
+                        Ok(None)
+                    } else {
+                        Err(anyhow::anyhow!(err)).with_context(|| format!("failed to read {key}"))
+                    }
+                }
+            },
+        }
+    }
+
     /// Lists all objects under `run_prefix/` in the bucket, returning filename → size.
     async fn list_remote_objects(&self, run_prefix: &str) -> Result<HashMap<String, u64>> {
         let prefix_with_slash = format!("{run_prefix}/");
@@ -203,7 +248,7 @@ impl SnapshotUploader {
             for obj in resp.contents() {
                 if let Some(key) = obj.key() {
                     let filename = key.strip_prefix(&prefix_with_slash).unwrap_or(key).to_string();
-                    let size = obj.size.unwrap_or(0) as u64;
+                    let size = obj.size.unwrap_or(0).try_into().unwrap_or(0);
                     remote.insert(filename, size);
                 }
             }
@@ -409,41 +454,41 @@ mod tests {
     #[test]
     fn static_file_chunks_are_diff_eligible() {
         assert_eq!(
-            classify_upload_strategy("headers-0-499999.tar.zst"),
+            UploadStrategy::classify("headers-0-499999.tar.zst"),
             UploadStrategy::DiffBySize
         );
         assert_eq!(
-            classify_upload_strategy("transactions-500000-999999.tar.zst"),
+            UploadStrategy::classify("transactions-500000-999999.tar.zst"),
             UploadStrategy::DiffBySize
         );
         assert_eq!(
-            classify_upload_strategy("receipts-9500000-9999999.tar.zst"),
+            UploadStrategy::classify("receipts-9500000-9999999.tar.zst"),
             UploadStrategy::DiffBySize
         );
         assert_eq!(
-            classify_upload_strategy("account_changesets-0-499999.tar.zst"),
+            UploadStrategy::classify("account_changesets-0-499999.tar.zst"),
             UploadStrategy::DiffBySize
         );
         assert_eq!(
-            classify_upload_strategy("storage_changesets-1000000-1499999.tar.zst"),
+            UploadStrategy::classify("storage_changesets-1000000-1499999.tar.zst"),
             UploadStrategy::DiffBySize
         );
         assert_eq!(
-            classify_upload_strategy("transaction_senders-0-499999.tar.zst"),
+            UploadStrategy::classify("transaction_senders-0-499999.tar.zst"),
             UploadStrategy::DiffBySize
         );
     }
 
     #[test]
     fn non_chunk_files_always_upload() {
-        assert_eq!(classify_upload_strategy("state.tar.zst"), UploadStrategy::AlwaysUpload);
+        assert_eq!(UploadStrategy::classify("state.tar.zst"), UploadStrategy::AlwaysUpload);
         assert_eq!(
-            classify_upload_strategy("rocksdb_indices.tar.zst"),
+            UploadStrategy::classify("rocksdb_indices.tar.zst"),
             UploadStrategy::AlwaysUpload
         );
-        assert_eq!(classify_upload_strategy("manifest.json"), UploadStrategy::AlwaysUpload);
-        assert_eq!(classify_upload_strategy("latest.json"), UploadStrategy::AlwaysUpload);
-        assert_eq!(classify_upload_strategy("random-file.txt"), UploadStrategy::AlwaysUpload);
+        assert_eq!(UploadStrategy::classify("manifest.json"), UploadStrategy::AlwaysUpload);
+        assert_eq!(UploadStrategy::classify("latest.json"), UploadStrategy::AlwaysUpload);
+        assert_eq!(UploadStrategy::classify("random-file.txt"), UploadStrategy::AlwaysUpload);
     }
 
     #[test]

--- a/crates/infra/snapshotter/src/upload.rs
+++ b/crates/infra/snapshotter/src/upload.rs
@@ -1,6 +1,14 @@
-//! S3-compatible upload for snapshot artifacts.
+//! S3-compatible upload for snapshot artifacts with diff-based optimization.
+//!
+//! Static file chunks (e.g. `headers-0-499999.tar.zst`) are immutable for finalized
+//! block ranges — only the chunk covering the current tip changes between snapshots.
+//! The uploader compares local file sizes against existing remote objects and skips
+//! uploads for chunks that already exist with a matching size.
 
-use std::path::{Path, PathBuf};
+use std::{
+    collections::HashMap,
+    path::{Path, PathBuf},
+};
 
 use anyhow::{Context, Result, bail};
 use aws_sdk_s3::{
@@ -21,6 +29,49 @@ const MULTIPART_THRESHOLD: u64 = 100 * 1024 * 1024;
 
 /// Part size for multipart uploads (100 `MiB`).
 const MULTIPART_PART_SIZE: u64 = 100 * 1024 * 1024;
+
+/// Determines whether a snapshot component is re-uploaded every run
+/// or can be skipped when the remote copy already matches.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UploadStrategy {
+    /// Always upload regardless of remote state (mdbx, rocksdb, proofs).
+    AlwaysUpload,
+    /// Skip upload if the remote object exists with the same size (static file chunks).
+    DiffBySize,
+}
+
+/// Classifies a snapshot filename into its upload strategy.
+///
+/// Static file chunks follow the pattern `{component}-{start}-{end}.tar.zst`
+/// (e.g. `headers-0-499999.tar.zst`). These are immutable for finalized block
+/// ranges and only the tip chunk changes between snapshots.
+///
+/// Everything else (state, rocksdb, manifest) is always uploaded.
+pub fn classify_upload_strategy(filename: &str) -> UploadStrategy {
+    if is_static_file_chunk(filename) {
+        UploadStrategy::DiffBySize
+    } else {
+        UploadStrategy::AlwaysUpload
+    }
+}
+
+/// Returns `true` if the filename matches the static file chunk pattern:
+/// `{component}-{start}-{end}.tar.zst`. `rocksdb_incdices` is the prefix for
+/// `RocksDB`, `state` is the prefix for MDBX.
+fn is_static_file_chunk(filename: &str) -> bool {
+    let Some(stem) = filename.strip_suffix(".tar.zst") else {
+        return false;
+    };
+
+    let parts: Vec<&str> = stem.rsplitn(3, '-').collect();
+    if parts.len() < 3 {
+        return false;
+    }
+
+    let end_ok = parts[0].parse::<u64>().is_ok();
+    let start_ok = parts[1].parse::<u64>().is_ok();
+    end_ok && start_ok
+}
 
 /// Metadata written to `latest.json` after a successful upload.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -47,11 +98,12 @@ impl SnapshotUploader {
         Self { client, bucket, prefix }
     }
 
-    /// Uploads all files from the output directory to S3 under a unique run prefix.
+    /// Uploads snapshot artifacts with diff-based optimization.
     ///
-    /// The run prefix is `{prefix}/{block}-{timestamp}/`. After all archives are
-    /// uploaded, `manifest.json` is uploaded last, and finally `latest.json` is
-    /// written at `{prefix}/latest.json` as an atomic pointer to this run.
+    /// The run prefix is `{prefix}/{block}-{timestamp}/`. Static file chunks that
+    /// already exist remotely with the same size are skipped. State, rocksdb, and
+    /// manifest are always re-uploaded. `manifest.json` is uploaded last, and
+    /// `latest.json` is written as an atomic pointer to this run.
     pub async fn upload(
         &self,
         output_dir: &Path,
@@ -72,17 +124,44 @@ impl SnapshotUploader {
             "uploading snapshot artifacts"
         );
 
+        let remote_objects = self.list_remote_objects(&run_prefix).await?;
+
         let manifest_path = output_dir.join("manifest.json");
-        let mut non_manifest = Vec::new();
+        let mut to_upload = Vec::new();
+        let mut skipped = 0u64;
 
         for file in files {
             if file == &manifest_path {
                 continue;
             }
-            non_manifest.push(file.clone());
+
+            let file_name =
+                file.file_name().map(|n| n.to_string_lossy().to_string()).unwrap_or_default();
+
+            let local_size = std::fs::metadata(file)?.len();
+            let strategy = classify_upload_strategy(&file_name);
+
+            if strategy == UploadStrategy::DiffBySize
+                && let Some(&remote_size) = remote_objects.get(&file_name) {
+                    if remote_size == local_size {
+                        debug!(file = %file_name, size = local_size, "skipping (remote size matches)");
+                        skipped += 1;
+                        continue;
+                    }
+                    debug!(
+                        file = %file_name,
+                        local_size,
+                        remote_size,
+                        "re-uploading (size mismatch)"
+                    );
+                }
+
+            to_upload.push(file.clone());
         }
 
-        stream::iter(non_manifest)
+        info!(uploading = to_upload.len(), skipped, "diff analysis complete");
+
+        stream::iter(to_upload)
             .map(|file| {
                 let run_prefix = &run_prefix;
                 async move { self.upload_file(&file, run_prefix).await }
@@ -98,8 +177,46 @@ impl SnapshotUploader {
         let pointer = LatestPointer { prefix: run_prefix.clone(), block, timestamp };
         self.write_latest_pointer(&pointer).await?;
 
-        info!(run_prefix = %run_prefix, block, "upload complete");
+        info!(run_prefix = %run_prefix, block, skipped, "upload complete");
         Ok(run_prefix)
+    }
+
+    /// Lists all objects under `run_prefix/` in the bucket, returning filename → size.
+    async fn list_remote_objects(&self, run_prefix: &str) -> Result<HashMap<String, u64>> {
+        let prefix_with_slash = format!("{run_prefix}/");
+        let mut remote = HashMap::new();
+        let mut continuation_token = None;
+
+        loop {
+            let mut req =
+                self.client.list_objects_v2().bucket(&self.bucket).prefix(&prefix_with_slash);
+
+            if let Some(token) = continuation_token.take() {
+                req = req.continuation_token(token);
+            }
+
+            let resp = req
+                .send()
+                .await
+                .with_context(|| format!("failed to list objects under {prefix_with_slash}"))?;
+
+            for obj in resp.contents() {
+                if let Some(key) = obj.key() {
+                    let filename = key.strip_prefix(&prefix_with_slash).unwrap_or(key).to_string();
+                    let size = obj.size.unwrap_or(0) as u64;
+                    remote.insert(filename, size);
+                }
+            }
+
+            if resp.is_truncated() == Some(true) {
+                continuation_token = resp.next_continuation_token().map(String::from);
+            } else {
+                break;
+            }
+        }
+
+        debug!(count = remote.len(), "listed remote objects");
+        Ok(remote)
     }
 
     /// Uploads a single file, using multipart upload for files above the threshold.
@@ -282,5 +399,61 @@ impl SnapshotUploader {
             .with_context(|| format!("failed to write latest pointer at {key}"))?;
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn static_file_chunks_are_diff_eligible() {
+        assert_eq!(
+            classify_upload_strategy("headers-0-499999.tar.zst"),
+            UploadStrategy::DiffBySize
+        );
+        assert_eq!(
+            classify_upload_strategy("transactions-500000-999999.tar.zst"),
+            UploadStrategy::DiffBySize
+        );
+        assert_eq!(
+            classify_upload_strategy("receipts-9500000-9999999.tar.zst"),
+            UploadStrategy::DiffBySize
+        );
+        assert_eq!(
+            classify_upload_strategy("account_changesets-0-499999.tar.zst"),
+            UploadStrategy::DiffBySize
+        );
+        assert_eq!(
+            classify_upload_strategy("storage_changesets-1000000-1499999.tar.zst"),
+            UploadStrategy::DiffBySize
+        );
+        assert_eq!(
+            classify_upload_strategy("transaction_senders-0-499999.tar.zst"),
+            UploadStrategy::DiffBySize
+        );
+    }
+
+    #[test]
+    fn non_chunk_files_always_upload() {
+        assert_eq!(classify_upload_strategy("state.tar.zst"), UploadStrategy::AlwaysUpload);
+        assert_eq!(
+            classify_upload_strategy("rocksdb_indices.tar.zst"),
+            UploadStrategy::AlwaysUpload
+        );
+        assert_eq!(classify_upload_strategy("manifest.json"), UploadStrategy::AlwaysUpload);
+        assert_eq!(classify_upload_strategy("latest.json"), UploadStrategy::AlwaysUpload);
+        assert_eq!(classify_upload_strategy("random-file.txt"), UploadStrategy::AlwaysUpload);
+    }
+
+    #[test]
+    fn is_static_file_chunk_edge_cases() {
+        assert!(!is_static_file_chunk("state.tar.zst"));
+        assert!(!is_static_file_chunk("headers.tar.zst"));
+        assert!(!is_static_file_chunk("headers-abc-def.tar.zst"));
+        assert!(!is_static_file_chunk("headers-0-499999.tar.gz"));
+        assert!(!is_static_file_chunk("headers-0-499999"));
+        assert!(is_static_file_chunk("headers-0-499999.tar.zst"));
+        assert!(is_static_file_chunk("custom_component-100-200.tar.zst"));
     }
 }

--- a/crates/infra/snapshotter/src/upload.rs
+++ b/crates/infra/snapshotter/src/upload.rs
@@ -1,9 +1,13 @@
 //! S3-compatible upload for snapshot artifacts with diff-based optimization.
 //!
-//! Static file chunks (e.g. `headers-0-499999.tar.zst`) are immutable for finalized
-//! block ranges — only the chunk covering the current tip changes between snapshots.
-//! The uploader compares local file sizes against existing remote objects and skips
-//! uploads for chunks that already exist with a matching size.
+//! Artifacts are split into two areas within the bucket:
+//!
+//! - `{prefix}/static_files/` — static file chunks that are immutable for finalized
+//!   block ranges. Only the tip chunk changes between snapshots. The uploader
+//!   compares local sizes against existing remote objects and skips unchanged chunks.
+//!
+//! - `{prefix}/{date}/` — per-run directory for mdbx state, rocksdb, and the manifest.
+//!   These are always re-uploaded since they change every snapshot.
 
 use std::{
     collections::HashMap,
@@ -13,13 +17,10 @@ use std::{
 use anyhow::{Context, Result, bail};
 use aws_sdk_s3::{
     Client as S3Client,
-    error::SdkError,
-    operation::get_object::GetObjectError,
     primitives::ByteStream,
     types::{CompletedMultipartUpload, CompletedPart},
 };
 use futures::stream::{self, StreamExt, TryStreamExt};
-use serde::{Deserialize, Serialize};
 use tracing::{debug, info};
 
 /// Maximum number of concurrent file uploads.
@@ -36,9 +37,9 @@ const MULTIPART_PART_SIZE: u64 = 100 * 1024 * 1024;
 /// or can be skipped when the remote copy already matches.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum UploadStrategy {
-    /// Always upload regardless of remote state (mdbx, rocksdb, proofs).
+    /// Always upload to the per-run date directory (mdbx, rocksdb, manifest).
     AlwaysUpload,
-    /// Skip upload if the remote object exists with the same size (static file chunks).
+    /// Upload to `static_files/`, skipping if the remote object has the same size.
     DiffBySize,
 }
 
@@ -56,8 +57,7 @@ impl UploadStrategy {
 }
 
 /// Returns `true` if the filename matches the static file chunk pattern:
-/// `{component}-{start}-{end}.tar.zst`. `rocksdb_indices` and `state` do not match
-/// this pattern and are classified as `AlwaysUpload`.
+/// `{component}-{start}-{end}.tar.zst`.
 fn is_static_file_chunk(filename: &str) -> bool {
     let Some(stem) = filename.strip_suffix(".tar.zst") else {
         return false;
@@ -71,17 +71,6 @@ fn is_static_file_chunk(filename: &str) -> bool {
     let end_ok = parts[0].parse::<u64>().is_ok();
     let start_ok = parts[1].parse::<u64>().is_ok();
     end_ok && start_ok
-}
-
-/// Metadata written to `latest.json` after a successful upload.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct LatestPointer {
-    /// The run prefix where this snapshot's artifacts live.
-    pub prefix: String,
-    /// Block number of the snapshot.
-    pub block: u64,
-    /// Unix timestamp of the upload.
-    pub timestamp: u64,
 }
 
 /// Uploads snapshot artifacts to an S3-compatible store (R2, `MinIO`, etc.).
@@ -100,44 +89,32 @@ impl SnapshotUploader {
 
     /// Uploads snapshot artifacts with diff-based optimization.
     ///
-    /// Reads `latest.json` to find the previous run's prefix and lists objects
-    /// under it. Static file chunks that exist in the previous run with the same
-    /// size are skipped — they're immutable for finalized block ranges. State,
-    /// rocksdb, and manifest are always re-uploaded to the new run prefix.
-    /// `manifest.json` is uploaded last, then `latest.json` is updated.
+    /// Static file chunks go to `{prefix}/static_files/` and are skipped if the
+    /// remote object already exists with the same size. State, rocksdb, and
+    /// manifest go to `{prefix}/{date}/` and are always re-uploaded.
+    /// `manifest.json` is uploaded last as the "snapshot complete" signal.
     pub async fn upload(
         &self,
         output_dir: &Path,
         files: &[PathBuf],
-        block: u64,
         timestamp: u64,
     ) -> Result<String> {
-        let run_prefix = if self.prefix.is_empty() {
-            format!("{block}-{timestamp}")
-        } else {
-            format!("{}/{block}-{timestamp}", self.prefix)
-        };
+        let static_prefix = self.static_files_prefix();
+        let run_prefix = self.run_prefix(timestamp);
 
         info!(
             run_prefix = %run_prefix,
+            static_prefix = %static_prefix,
             file_count = files.len(),
             bucket = %self.bucket,
             "uploading snapshot artifacts"
         );
 
-        let remote_objects = match self.read_latest_pointer().await? {
-            Some(prev) => {
-                info!(previous_prefix = %prev.prefix, previous_block = prev.block, "found previous snapshot");
-                self.list_remote_objects(&prev.prefix).await?
-            }
-            None => {
-                info!("no previous snapshot found, uploading all files");
-                HashMap::new()
-            }
-        };
+        let remote_static_files = self.list_remote_objects(&static_prefix).await?;
 
         let manifest_path = output_dir.join("manifest.json");
-        let mut to_upload = Vec::new();
+        let mut static_uploads = Vec::new();
+        let mut run_uploads = Vec::new();
         let mut skipped = 0u64;
 
         for file in files {
@@ -145,38 +122,50 @@ impl SnapshotUploader {
                 continue;
             }
 
-            let file_name =
-                file.file_name().map(|n| n.to_string_lossy().to_string()).unwrap_or_default();
+            let file_name = file
+                .file_name()
+                .ok_or_else(|| anyhow::anyhow!("invalid file path: {}", file.display()))?
+                .to_string_lossy()
+                .to_string();
 
-            let local_size = std::fs::metadata(file)?.len();
+            let local_size = tokio::fs::metadata(file).await?.len();
             let strategy = UploadStrategy::classify(&file_name);
 
-            if strategy == UploadStrategy::DiffBySize
-                && let Some(&remote_size) = remote_objects.get(&file_name)
-            {
-                if remote_size == local_size {
-                    debug!(file = %file_name, size = local_size, "skipping (remote size matches)");
-                    skipped += 1;
-                    continue;
+            match strategy {
+                UploadStrategy::DiffBySize => {
+                    if let Some(&remote_size) = remote_static_files.get(&file_name) {
+                        if remote_size == local_size {
+                            debug!(file = %file_name, size = local_size, "skipping static file (size matches)");
+                            skipped += 1;
+                            continue;
+                        }
+                        debug!(file = %file_name, local_size, remote_size, "re-uploading static file (size mismatch)");
+                    }
+                    static_uploads.push(file.clone());
                 }
-                debug!(
-                    file = %file_name,
-                    local_size,
-                    remote_size,
-                    "re-uploading (size mismatch)"
-                );
+                UploadStrategy::AlwaysUpload => {
+                    run_uploads.push(file.clone());
+                }
             }
-
-            to_upload.push(file.clone());
         }
 
-        info!(uploading = to_upload.len(), skipped, "diff analysis complete");
+        info!(
+            static_uploads = static_uploads.len(),
+            run_uploads = run_uploads.len(),
+            skipped,
+            "diff analysis complete"
+        );
 
-        stream::iter(to_upload)
-            .map(|file| {
-                let run_prefix = &run_prefix;
-                async move { self.upload_file(&file, run_prefix).await }
-            })
+        let static_prefix_ref = &static_prefix;
+        stream::iter(static_uploads)
+            .map(|file| async move { self.upload_file(&file, static_prefix_ref).await })
+            .buffer_unordered(MAX_CONCURRENT_UPLOADS)
+            .try_collect::<Vec<()>>()
+            .await?;
+
+        let run_prefix_ref = &run_prefix;
+        stream::iter(run_uploads)
+            .map(|file| async move { self.upload_file(&file, run_prefix_ref).await })
             .buffer_unordered(MAX_CONCURRENT_UPLOADS)
             .try_collect::<Vec<()>>()
             .await?;
@@ -185,50 +174,31 @@ impl SnapshotUploader {
             self.upload_file(&manifest_path, &run_prefix).await?;
         }
 
-        let pointer = LatestPointer { prefix: run_prefix.clone(), block, timestamp };
-        self.write_latest_pointer(&pointer).await?;
-
-        info!(run_prefix = %run_prefix, block, skipped, "upload complete");
+        info!(run_prefix = %run_prefix, skipped, "upload complete");
         Ok(run_prefix)
     }
 
-    /// Reads the `latest.json` pointer from the bucket, returning `None` if it doesn't exist.
-    async fn read_latest_pointer(&self) -> Result<Option<LatestPointer>> {
-        let key = if self.prefix.is_empty() {
-            "latest.json".to_string()
+    /// Returns the `{prefix}/static_files` key prefix.
+    fn static_files_prefix(&self) -> String {
+        if self.prefix.is_empty() {
+            "static_files".to_string()
         } else {
-            format!("{}/latest.json", self.prefix)
-        };
-
-        match self.client.get_object().bucket(&self.bucket).key(&key).send().await {
-            Ok(resp) => {
-                let body = resp.body.collect().await?.into_bytes();
-                let pointer: LatestPointer = serde_json::from_slice(&body)
-                    .with_context(|| format!("failed to parse {key}"))?;
-                Ok(Some(pointer))
-            }
-            Err(err) => match &err {
-                SdkError::ServiceError(e) if matches!(e.err(), GetObjectError::NoSuchKey(_)) => {
-                    Ok(None)
-                }
-                _ => {
-                    let err_str = err.to_string();
-                    if err_str.contains("NoSuchKey")
-                        || err_str.contains("404")
-                        || err_str.contains("NotFound")
-                    {
-                        Ok(None)
-                    } else {
-                        Err(anyhow::anyhow!(err)).with_context(|| format!("failed to read {key}"))
-                    }
-                }
-            },
+            format!("{}/static_files", self.prefix)
         }
     }
 
-    /// Lists all objects under `run_prefix/` in the bucket, returning filename → size.
-    async fn list_remote_objects(&self, run_prefix: &str) -> Result<HashMap<String, u64>> {
-        let prefix_with_slash = format!("{run_prefix}/");
+    /// Returns the `{prefix}/{timestamp}` key prefix for a run.
+    fn run_prefix(&self, timestamp: u64) -> String {
+        if self.prefix.is_empty() {
+            timestamp.to_string()
+        } else {
+            format!("{}/{timestamp}", self.prefix)
+        }
+    }
+
+    /// Lists all objects under a prefix in the bucket, returning filename → size.
+    async fn list_remote_objects(&self, prefix: &str) -> Result<HashMap<String, u64>> {
+        let prefix_with_slash = format!("{prefix}/");
         let mut remote = HashMap::new();
         let mut continuation_token = None;
 
@@ -248,7 +218,7 @@ impl SnapshotUploader {
             for obj in resp.contents() {
                 if let Some(key) = obj.key() {
                     let filename = key.strip_prefix(&prefix_with_slash).unwrap_or(key).to_string();
-                    let size = obj.size.unwrap_or(0).try_into().unwrap_or(0);
+                    let size: u64 = obj.size.unwrap_or(0).try_into().unwrap_or(0);
                     remote.insert(filename, size);
                 }
             }
@@ -260,19 +230,19 @@ impl SnapshotUploader {
             }
         }
 
-        debug!(count = remote.len(), "listed remote objects");
+        debug!(prefix = %prefix, count = remote.len(), "listed remote objects");
         Ok(remote)
     }
 
     /// Uploads a single file, using multipart upload for files above the threshold.
-    async fn upload_file(&self, file_path: &Path, run_prefix: &str) -> Result<()> {
+    async fn upload_file(&self, file_path: &Path, dest_prefix: &str) -> Result<()> {
         let file_name = file_path
             .file_name()
             .ok_or_else(|| anyhow::anyhow!("invalid file path: {}", file_path.display()))?
             .to_string_lossy();
 
-        let key = format!("{run_prefix}/{file_name}");
-        let file_size = std::fs::metadata(file_path)?.len();
+        let key = format!("{dest_prefix}/{file_name}");
+        let file_size = tokio::fs::metadata(file_path).await?.len();
 
         if file_size > MULTIPART_THRESHOLD {
             debug!(key = %key, size = file_size, "uploading file (multipart)");
@@ -420,31 +390,6 @@ impl SnapshotUploader {
 
         Ok(CompletedPart::builder().part_number(part_number).e_tag(e_tag).build())
     }
-
-    /// Writes the `latest.json` pointer at `{prefix}/latest.json`.
-    async fn write_latest_pointer(&self, pointer: &LatestPointer) -> Result<()> {
-        let key = if self.prefix.is_empty() {
-            "latest.json".to_string()
-        } else {
-            format!("{}/latest.json", self.prefix)
-        };
-
-        let body = serde_json::to_vec_pretty(pointer)?;
-
-        debug!(key = %key, block = pointer.block, "writing latest pointer");
-
-        self.client
-            .put_object()
-            .bucket(&self.bucket)
-            .key(&key)
-            .body(ByteStream::from(body))
-            .content_type("application/json")
-            .send()
-            .await
-            .with_context(|| format!("failed to write latest pointer at {key}"))?;
-
-        Ok(())
-    }
 }
 
 #[cfg(test)]
@@ -487,7 +432,6 @@ mod tests {
             UploadStrategy::AlwaysUpload
         );
         assert_eq!(UploadStrategy::classify("manifest.json"), UploadStrategy::AlwaysUpload);
-        assert_eq!(UploadStrategy::classify("latest.json"), UploadStrategy::AlwaysUpload);
         assert_eq!(UploadStrategy::classify("random-file.txt"), UploadStrategy::AlwaysUpload);
     }
 

--- a/crates/infra/snapshotter/tests/e2e_test.rs
+++ b/crates/infra/snapshotter/tests/e2e_test.rs
@@ -7,7 +7,7 @@ use std::{
 
 use anyhow::Result;
 use async_trait::async_trait;
-use base_snapshotter::{ContainerManager, DockerContainerManager, LatestPointer, SnapshotUploader};
+use base_snapshotter::{ContainerManager, DockerContainerManager, SnapshotUploader};
 use bollard::{
     Docker,
     models::ContainerCreateBody,
@@ -68,7 +68,7 @@ impl ContainerManager for MockContainerManager {
 /// Builds a realistic fake snapshot matching reth's `SnapshotManifest` format.
 ///
 /// Modeled after the real manifests served at `snapshots-r2.reth.rs`.
-fn create_fake_snapshot(dir: &Path, block: u64) -> Result<Vec<std::path::PathBuf>> {
+fn create_fake_snapshot(dir: &Path, block: u64) -> Result<Vec<PathBuf>> {
     std::fs::create_dir_all(dir)?;
 
     let blocks_per_file = 500_000u64;
@@ -116,13 +116,7 @@ fn create_fake_snapshot(dir: &Path, block: u64) -> Result<Vec<std::path::PathBuf
                 "file": "state.tar.zst",
                 "size": 152_129_557_628u64,
                 "decompressed_size": 304_259_115_256u64,
-                "output_files": [
-                    {
-                        "path": "db/mdbx.dat",
-                        "size": 304_259_115_256u64,
-                        "blake3": "fake-blake3-mdbx"
-                    }
-                ]
+                "output_files": [{"path": "db/mdbx.dat", "size": 304_259_115_256u64, "blake3": "fake-blake3-mdbx"}]
             },
             "headers": chunked_component(block),
             "transactions": chunked_component(block),
@@ -134,13 +128,7 @@ fn create_fake_snapshot(dir: &Path, block: u64) -> Result<Vec<std::path::PathBuf
                 "file": "rocksdb_indices.tar.zst",
                 "size": 226_377_256_076u64,
                 "decompressed_size": 452_754_512_152u64,
-                "output_files": [
-                    {
-                        "path": "rocksdb/CURRENT",
-                        "size": 16,
-                        "blake3": "fake-blake3-rocksdb-current"
-                    }
-                ]
+                "output_files": [{"path": "rocksdb/CURRENT", "size": 16, "blake3": "fake-blake3-rocksdb-current"}]
             }
         }
     });
@@ -191,115 +179,43 @@ async fn upload_artifacts_to_minio() -> Result<()> {
     let output_dir = tmp.path().join("output");
     let files = create_fake_snapshot(&output_dir, 1_000_000)?;
 
-    let run_prefix = uploader.upload(&output_dir, &files, 1_000_000, 1700000000).await?;
+    let upload_prefix = uploader.upload(&output_dir, &files, 1_700_000_000).await?;
+    assert_eq!(upload_prefix, "mainnet/1700000000", "run prefix should be date-based");
 
-    assert!(
-        run_prefix.starts_with("mainnet/1000000-"),
-        "run_prefix should start with mainnet/1000000-, got: {run_prefix}"
-    );
+    let s3 = &harness.storage_client;
+    let bucket = &harness.bucket_name;
 
-    let state_key = format!("{run_prefix}/state.tar.zst");
-    let state_obj = harness
-        .storage_client
-        .get_object()
-        .bucket(&harness.bucket_name)
-        .key(&state_key)
-        .send()
-        .await?;
-    let state_body = state_obj.body.collect().await?.into_bytes();
-    assert_eq!(state_body.as_ref(), b"fake-state-archive", "state archive content mismatch");
+    // Verify always-upload files go to {prefix}/{date}/
+    let state_body = get_object_bytes(s3, bucket, "mainnet/1700000000/state.tar.zst").await?;
+    assert_eq!(state_body, b"fake-state-archive", "state should be in date dir");
 
-    let rocksdb_key = format!("{run_prefix}/rocksdb_indices.tar.zst");
-    let rocksdb_obj = harness
-        .storage_client
-        .get_object()
-        .bucket(&harness.bucket_name)
-        .key(&rocksdb_key)
-        .send()
-        .await?;
-    let rocksdb_body = rocksdb_obj.body.collect().await?.into_bytes();
-    assert_eq!(rocksdb_body.as_ref(), b"fake-rocksdb-archive", "rocksdb archive content mismatch");
+    let rocksdb_body =
+        get_object_bytes(s3, bucket, "mainnet/1700000000/rocksdb_indices.tar.zst").await?;
+    assert_eq!(rocksdb_body, b"fake-rocksdb-archive", "rocksdb should be in date dir");
 
+    let manifest_body = get_object_bytes(s3, bucket, "mainnet/1700000000/manifest.json").await?;
+    let manifest: serde_json::Value = serde_json::from_slice(&manifest_body)?;
+    assert_eq!(manifest["block"], 1_000_000, "manifest block mismatch");
+    assert_eq!(manifest["chain_id"], 8453, "manifest chain_id mismatch");
+
+    let components = manifest["components"].as_object().expect("components should be an object");
+    assert_eq!(components.len(), 8, "should have all 8 component types");
+
+    // Verify static file chunks go to {prefix}/static_files/
     for component in ["headers", "transactions", "receipts"] {
         for chunk_idx in 0..2u64 {
             let start = chunk_idx * 500_000;
             let end = (chunk_idx + 1) * 500_000 - 1;
-            let key = format!("{run_prefix}/{component}-{start}-{end}.tar.zst");
-            let obj = harness
-                .storage_client
-                .get_object()
-                .bucket(&harness.bucket_name)
-                .key(&key)
-                .send()
-                .await?;
-            let body = obj.body.collect().await?.into_bytes();
+            let key = format!("mainnet/static_files/{component}-{start}-{end}.tar.zst");
+            let body = get_object_bytes(s3, bucket, &key).await?;
             let expected = format!("fake-{component}-chunk-{chunk_idx}");
             assert_eq!(
-                body.as_ref(),
+                body,
                 expected.as_bytes(),
-                "{component} chunk {chunk_idx} content mismatch"
+                "{component} chunk {chunk_idx} should be in static_files/"
             );
         }
     }
-
-    let manifest_key = format!("{run_prefix}/manifest.json");
-    let manifest_obj = harness
-        .storage_client
-        .get_object()
-        .bucket(&harness.bucket_name)
-        .key(&manifest_key)
-        .send()
-        .await?;
-    let manifest_body = manifest_obj.body.collect().await?.into_bytes();
-    let manifest: serde_json::Value = serde_json::from_slice(&manifest_body)?;
-    assert_eq!(manifest["block"], 1_000_000, "manifest block number mismatch");
-    assert_eq!(manifest["chain_id"], 8453, "manifest chain_id mismatch");
-    assert_eq!(manifest["storage_version"], 2, "manifest storage_version mismatch");
-    assert!(manifest["reth_version"].is_string(), "manifest should have reth_version");
-
-    let components = manifest["components"].as_object().expect("components should be an object");
-    assert_eq!(components.len(), 8, "should have all 8 component types");
-    assert!(components.contains_key("state"), "missing state component");
-    assert!(components.contains_key("headers"), "missing headers component");
-    assert!(components.contains_key("transactions"), "missing transactions component");
-    assert!(components.contains_key("transaction_senders"), "missing transaction_senders");
-    assert!(components.contains_key("receipts"), "missing receipts component");
-    assert!(components.contains_key("account_changesets"), "missing account_changesets");
-    assert!(components.contains_key("storage_changesets"), "missing storage_changesets");
-    assert!(components.contains_key("rocksdb_indices"), "missing rocksdb_indices");
-
-    Ok(())
-}
-
-#[tokio::test]
-#[serial]
-async fn latest_pointer_updated_after_upload() -> Result<()> {
-    let harness = TestHarness::new().await?;
-    let uploader = SnapshotUploader::new(
-        harness.storage_client.clone(),
-        harness.bucket_name.clone(),
-        "sepolia".to_string(),
-    );
-
-    let tmp = tempfile::tempdir()?;
-    let output_dir = tmp.path().join("output");
-    let files = create_fake_snapshot(&output_dir, 500_000)?;
-
-    let run_prefix = uploader.upload(&output_dir, &files, 500_000, 1700000000).await?;
-
-    let latest_obj = harness
-        .storage_client
-        .get_object()
-        .bucket(&harness.bucket_name)
-        .key("sepolia/latest.json")
-        .send()
-        .await?;
-    let latest_body = latest_obj.body.collect().await?.into_bytes();
-    let pointer: LatestPointer = serde_json::from_slice(&latest_body)?;
-
-    assert_eq!(pointer.block, 500_000, "latest pointer block mismatch");
-    assert_eq!(pointer.prefix, run_prefix, "latest pointer prefix mismatch");
-    assert!(pointer.timestamp > 0, "latest pointer should have a non-zero timestamp");
 
     Ok(())
 }
@@ -318,23 +234,25 @@ async fn upload_with_empty_prefix() -> Result<()> {
     let output_dir = tmp.path().join("output");
     let files = create_fake_snapshot(&output_dir, 100)?;
 
-    let run_prefix = uploader.upload(&output_dir, &files, 100, 1700000000).await?;
+    let upload_prefix = uploader.upload(&output_dir, &files, 1_700_000_000).await?;
+    assert_eq!(upload_prefix, "1700000000", "empty prefix should produce bare date");
 
-    assert!(
-        run_prefix.starts_with("100-"),
-        "with empty prefix, run_prefix should start with block number, got: {run_prefix}"
-    );
+    let s3 = &harness.storage_client;
+    let bucket = &harness.bucket_name;
 
-    let latest_obj = harness
-        .storage_client
-        .get_object()
-        .bucket(&harness.bucket_name)
-        .key("latest.json")
-        .send()
-        .await?;
-    let latest_body = latest_obj.body.collect().await?.into_bytes();
-    let pointer: LatestPointer = serde_json::from_slice(&latest_body)?;
-    assert_eq!(pointer.block, 100, "latest pointer block should be 100");
+    let state_body = get_object_bytes(s3, bucket, "1700000000/state.tar.zst").await?;
+    assert_eq!(state_body, b"fake-state-archive", "state should be in date dir");
+
+    let rocksdb_body = get_object_bytes(s3, bucket, "1700000000/rocksdb_indices.tar.zst").await?;
+    assert_eq!(rocksdb_body, b"fake-rocksdb-archive", "rocksdb should be in date dir");
+
+    let manifest_body = get_object_bytes(s3, bucket, "1700000000/manifest.json").await?;
+    let manifest: serde_json::Value = serde_json::from_slice(&manifest_body)?;
+    assert_eq!(manifest["block"], 100, "manifest should be in date dir");
+
+    let headers_body =
+        get_object_bytes(s3, bucket, "static_files/headers-0-499999.tar.zst").await?;
+    assert_eq!(headers_body, b"fake-headers-chunk-0", "headers chunk 0 should be in static_files/");
 
     Ok(())
 }
@@ -352,10 +270,7 @@ async fn diff_upload_skips_unchanged_static_file_chunks() -> Result<()> {
         "diff-test".to_string(),
     );
 
-    // Simulate a previous snapshot run: upload files under a previous prefix
-    // and write latest.json pointing to it.
-    let prev_prefix = "diff-test/900000-1699000000";
-
+    // Pre-seed static_files/ with finalized chunks from a previous run
     let preexisting: &[(&str, &[u8])] = &[
         ("headers-0-499999.tar.zst", b"finalized-headers-0"),
         ("headers-500000-999999.tar.zst", b"finalized-headers-1"),
@@ -365,13 +280,10 @@ async fn diff_upload_skips_unchanged_static_file_chunks() -> Result<()> {
         ("receipts-500000-999999.tar.zst", b"finalized-receipts-1"),
         ("account_changesets-0-499999.tar.zst", b"finalized-acc-cs-0"),
         ("storage_changesets-0-499999.tar.zst", b"finalized-stor-cs-0"),
-        ("state.tar.zst", b"old-mdbx-state"),
-        ("rocksdb_indices.tar.zst", b"old-rocksdb"),
-        ("manifest.json", b"{\"block\":900000}"),
     ];
 
     for (name, data) in preexisting {
-        let key = format!("{prev_prefix}/{name}");
+        let key = format!("diff-test/static_files/{name}");
         s3.put_object()
             .bucket(bucket)
             .key(&key)
@@ -380,45 +292,19 @@ async fn diff_upload_skips_unchanged_static_file_chunks() -> Result<()> {
             .await?;
     }
 
-    let latest_pointer = serde_json::json!({
-        "prefix": prev_prefix,
-        "block": 900_000,
-        "timestamp": 1_699_000_000u64
-    });
-    s3.put_object()
-        .bucket(bucket)
-        .key("diff-test/latest.json")
-        .body(aws_sdk_s3::primitives::ByteStream::from(serde_json::to_vec(&latest_pointer)?))
-        .send()
-        .await?;
-
-    // Now run a new snapshot upload at block 1M.
-    // The uploader should read latest.json, find the previous prefix, compare sizes.
     let tmp = tempfile::tempdir()?;
     let output_dir = tmp.path().join("output");
     std::fs::create_dir_all(&output_dir)?;
 
-    let manifest = serde_json::json!({
-        "block": 1_000_000, "chain_id": 8453, "storage_version": 2,
-        "reth_version": "2.1.0 (d58c6e3)",
-        "components": {
-            "state": {"file": "state.tar.zst", "size": 100, "decompressed_size": 200, "output_files": []},
-            "rocksdb_indices": {"file": "rocksdb_indices.tar.zst", "size": 50, "decompressed_size": 100, "output_files": []},
-            "headers": {"blocks_per_file": 500000, "total_blocks": 1000000, "chunk_sizes": [20, 20], "chunk_decompressed_sizes": [], "chunk_output_files": []},
-            "transactions": {"blocks_per_file": 500000, "total_blocks": 1000000, "chunk_sizes": [30, 30], "chunk_decompressed_sizes": [], "chunk_output_files": []},
-            "receipts": {"blocks_per_file": 500000, "total_blocks": 1000000, "chunk_sizes": [15, 15], "chunk_decompressed_sizes": [], "chunk_output_files": []},
-            "account_changesets": {"blocks_per_file": 500000, "total_blocks": 1000000, "chunk_sizes": [18, 18], "chunk_decompressed_sizes": [], "chunk_output_files": []},
-            "storage_changesets": {"blocks_per_file": 500000, "total_blocks": 1000000, "chunk_sizes": [22, 22], "chunk_decompressed_sizes": [], "chunk_output_files": []}
-        }
-    });
-    std::fs::write(output_dir.join("manifest.json"), serde_json::to_string_pretty(&manifest)?)?;
+    let manifest = serde_json::json!({"block": 1_000_000, "chain_id": 8453, "storage_version": 2});
+    std::fs::write(output_dir.join("manifest.json"), serde_json::to_string(&manifest)?)?;
 
-    // AlwaysUpload: mdbx + rocksdb always re-uploaded
+    // AlwaysUpload: mdbx + rocksdb
     std::fs::write(output_dir.join("state.tar.zst"), b"new-mdbx-state-data")?;
     std::fs::write(output_dir.join("rocksdb_indices.tar.zst"), b"new-rocksdb-data")?;
 
-    // DiffBySize: finalized chunks with SAME size as previous run → should be SKIPPED
-    for &(name, data) in &preexisting[..8] {
+    // DiffBySize: finalized chunks with SAME size → should be SKIPPED
+    for &(name, data) in preexisting {
         std::fs::write(output_dir.join(name), data)?;
     }
 
@@ -438,40 +324,24 @@ async fn diff_upload_skips_unchanged_static_file_chunks() -> Result<()> {
         .collect();
     files.sort_unstable();
 
-    let new_run_prefix = uploader.upload(&output_dir, &files, 1_000_000, 1_700_000_000).await?;
-    assert!(
-        new_run_prefix.starts_with("diff-test/1000000-"),
-        "new run prefix should be under diff-test/, got: {new_run_prefix}"
-    );
+    let upload_prefix = uploader.upload(&output_dir, &files, 1_700_000_000).await?;
+    assert_eq!(upload_prefix, "diff-test/1700000000");
 
-    // Verify AlwaysUpload: mdbx + rocksdb re-uploaded to NEW prefix
-    let state_body =
-        get_object_bytes(s3, bucket, &format!("{new_run_prefix}/state.tar.zst")).await?;
-    assert_eq!(state_body, b"new-mdbx-state-data", "mdbx should always be re-uploaded");
+    // Verify AlwaysUpload: mdbx + rocksdb in date dir
+    let state_body = get_object_bytes(s3, bucket, "diff-test/1700000000/state.tar.zst").await?;
+    assert_eq!(state_body, b"new-mdbx-state-data", "mdbx should be in date dir");
 
     let rocksdb_body =
-        get_object_bytes(s3, bucket, &format!("{new_run_prefix}/rocksdb_indices.tar.zst")).await?;
-    assert_eq!(rocksdb_body, b"new-rocksdb-data", "rocksdb should always be re-uploaded");
+        get_object_bytes(s3, bucket, "diff-test/1700000000/rocksdb_indices.tar.zst").await?;
+    assert_eq!(rocksdb_body, b"new-rocksdb-data", "rocksdb should be in date dir");
 
-    // Verify DiffBySize SKIPPED: finalized chunks NOT uploaded to new prefix
-    // (they only exist under the previous prefix)
-    let skipped_chunks = [
-        "headers-0-499999.tar.zst",
-        "headers-500000-999999.tar.zst",
-        "transactions-0-499999.tar.zst",
-        "transactions-500000-999999.tar.zst",
-        "receipts-0-499999.tar.zst",
-        "receipts-500000-999999.tar.zst",
-        "account_changesets-0-499999.tar.zst",
-        "storage_changesets-0-499999.tar.zst",
-    ];
-    for name in skipped_chunks {
-        let key = format!("{new_run_prefix}/{name}");
-        let exists = s3.head_object().bucket(bucket).key(&key).send().await.is_ok();
-        assert!(!exists, "finalized chunk {name} should NOT be in new prefix (was skipped)");
+    // Verify DiffBySize SKIPPED: finalized chunks retain original content in static_files/
+    for (name, original_data) in preexisting {
+        let body = get_object_bytes(s3, bucket, &format!("diff-test/static_files/{name}")).await?;
+        assert_eq!(body.as_slice(), *original_data, "finalized chunk {name} should be unchanged");
     }
 
-    // Verify DiffBySize UPLOADED: new tip chunks exist in new prefix
+    // Verify DiffBySize UPLOADED: new tip chunks in static_files/
     let tip_checks: &[(&str, &[u8])] = &[
         ("headers-1000000-1499999.tar.zst", b"new-tip-headers"),
         ("transactions-1000000-1499999.tar.zst", b"new-tip-txs"),
@@ -480,15 +350,14 @@ async fn diff_upload_skips_unchanged_static_file_chunks() -> Result<()> {
         ("storage_changesets-500000-999999.tar.zst", b"new-tip-stor-cs"),
     ];
     for (name, expected) in tip_checks {
-        let body = get_object_bytes(s3, bucket, &format!("{new_run_prefix}/{name}")).await?;
-        assert_eq!(body.as_slice(), *expected, "tip chunk {name} should be uploaded");
+        let body = get_object_bytes(s3, bucket, &format!("diff-test/static_files/{name}")).await?;
+        assert_eq!(body.as_slice(), *expected, "tip chunk {name} should be in static_files/");
     }
 
-    // Verify latest.json updated to point to new run
-    let latest_body = get_object_bytes(s3, bucket, "diff-test/latest.json").await?;
-    let pointer: LatestPointer = serde_json::from_slice(&latest_body)?;
-    assert_eq!(pointer.block, 1_000_000, "latest should point to new block");
-    assert_eq!(pointer.prefix, new_run_prefix, "latest should point to new prefix");
+    // Verify manifest in date dir
+    let manifest_body = get_object_bytes(s3, bucket, "diff-test/1700000000/manifest.json").await?;
+    let parsed: serde_json::Value = serde_json::from_slice(&manifest_body)?;
+    assert_eq!(parsed["block"], 1_000_000, "manifest should be in date dir");
 
     Ok(())
 }
@@ -506,16 +375,14 @@ async fn always_upload_overwrites_existing_state_and_rocksdb() -> Result<()> {
         "overwrite-test".to_string(),
     );
 
-    // Simulate a previous run with old state + rocksdb
-    let prev_prefix = "overwrite-test/1500000-1699000000";
-
+    // Simulate a previous run's date dir with old state + rocksdb
     let prev_files: &[(&str, &[u8])] = &[
-        ("state.tar.zst", b"old-mdbx-snapshot-from-yesterday"),
+        ("state.tar.zst", b"old-mdbx-from-yesterday"),
         ("rocksdb_indices.tar.zst", b"old-rocksdb-from-yesterday"),
         ("manifest.json", b"{\"block\":1500000}"),
     ];
     for (name, data) in prev_files {
-        let key = format!("{prev_prefix}/{name}");
+        let key = format!("overwrite-test/1699000000/{name}");
         s3.put_object()
             .bucket(bucket)
             .key(&key)
@@ -524,31 +391,12 @@ async fn always_upload_overwrites_existing_state_and_rocksdb() -> Result<()> {
             .await?;
     }
 
-    // Write latest.json pointing to previous run
-    let latest_pointer = serde_json::json!({
-        "prefix": prev_prefix,
-        "block": 1_500_000,
-        "timestamp": 1_699_000_000u64
-    });
-    s3.put_object()
-        .bucket(bucket)
-        .key("overwrite-test/latest.json")
-        .body(aws_sdk_s3::primitives::ByteStream::from(serde_json::to_vec(&latest_pointer)?))
-        .send()
-        .await?;
-
-    // New snapshot with fresh state + rocksdb
+    // New snapshot
     let tmp = tempfile::tempdir()?;
     let output_dir = tmp.path().join("output");
     std::fs::create_dir_all(&output_dir)?;
 
-    let manifest = serde_json::json!({
-        "block": 2_000_000, "chain_id": 8453, "storage_version": 2,
-        "components": {
-            "state": {"file": "state.tar.zst", "size": 100, "decompressed_size": 200, "output_files": []},
-            "rocksdb_indices": {"file": "rocksdb_indices.tar.zst", "size": 50, "decompressed_size": 100, "output_files": []}
-        }
-    });
+    let manifest = serde_json::json!({"block": 2_000_000, "chain_id": 8453, "storage_version": 2});
     std::fs::write(output_dir.join("manifest.json"), serde_json::to_string(&manifest)?)?;
     std::fs::write(output_dir.join("state.tar.zst"), b"fresh-mdbx-state")?;
     std::fs::write(output_dir.join("rocksdb_indices.tar.zst"), b"fresh-rocksdb")?;
@@ -559,44 +407,28 @@ async fn always_upload_overwrites_existing_state_and_rocksdb() -> Result<()> {
         output_dir.join("state.tar.zst"),
     ];
 
-    let new_prefix = uploader.upload(&output_dir, &files, 2_000_000, 1_700_000_000).await?;
+    let upload_prefix = uploader.upload(&output_dir, &files, 1_700_000_000).await?;
+    assert_eq!(upload_prefix, "overwrite-test/1700000000");
 
-    // Verify state uploaded to NEW prefix (not the previous one)
-    let state_body = get_object_bytes(s3, bucket, &format!("{new_prefix}/state.tar.zst")).await?;
-    assert_eq!(
-        state_body, b"fresh-mdbx-state",
-        "state.tar.zst should be uploaded to new prefix despite existing in previous run"
-    );
+    // Verify new state in new date dir
+    let state_body =
+        get_object_bytes(s3, bucket, "overwrite-test/1700000000/state.tar.zst").await?;
+    assert_eq!(state_body, b"fresh-mdbx-state", "state should be in new date dir");
 
-    // Verify rocksdb uploaded to NEW prefix
+    // Verify new rocksdb in new date dir
     let rocksdb_body =
-        get_object_bytes(s3, bucket, &format!("{new_prefix}/rocksdb_indices.tar.zst")).await?;
-    assert_eq!(
-        rocksdb_body, b"fresh-rocksdb",
-        "rocksdb_indices.tar.zst should be uploaded to new prefix despite existing in previous run"
-    );
+        get_object_bytes(s3, bucket, "overwrite-test/1700000000/rocksdb_indices.tar.zst").await?;
+    assert_eq!(rocksdb_body, b"fresh-rocksdb", "rocksdb should be in new date dir");
 
     // Verify previous run's files are untouched
-    let old_state = get_object_bytes(s3, bucket, &format!("{prev_prefix}/state.tar.zst")).await?;
+    let old_state = get_object_bytes(s3, bucket, "overwrite-test/1699000000/state.tar.zst").await?;
     assert_eq!(
         old_state.as_slice(),
-        b"old-mdbx-snapshot-from-yesterday",
-        "previous run's state should be untouched"
+        b"old-mdbx-from-yesterday",
+        "previous run should be untouched"
     );
 
-    // Verify latest.json updated
-    let latest_body = get_object_bytes(s3, bucket, "overwrite-test/latest.json").await?;
-    let pointer: LatestPointer = serde_json::from_slice(&latest_body)?;
-    assert_eq!(pointer.block, 2_000_000, "latest should point to new block");
-    assert_eq!(pointer.prefix, new_prefix, "latest should point to new prefix");
-
     Ok(())
-}
-
-async fn get_object_bytes(client: &aws_sdk_s3::Client, bucket: &str, key: &str) -> Result<Vec<u8>> {
-    let resp = client.get_object().bucket(bucket).key(key).send().await?;
-    let bytes = resp.body.collect().await?.into_bytes();
-    Ok(bytes.to_vec())
 }
 
 #[tokio::test]
@@ -672,7 +504,7 @@ async fn e2e_stop_upload_restart_real_container() -> Result<()> {
     let pull_opts = CreateImageOptionsBuilder::new().from_image("alpine").tag("latest").build();
     docker.create_image(Some(pull_opts), None, None).collect::<Vec<_>>().await;
 
-    let container_name = format!("snappy-e2e-{}", std::process::id());
+    let container_name = format!("snapshotter-e2e-{}", std::process::id());
     let body = ContainerCreateBody {
         image: Some("alpine:latest".to_string()),
         cmd: Some(vec!["sleep".to_string(), "3600".to_string()]),
@@ -688,14 +520,11 @@ async fn e2e_stop_upload_restart_real_container() -> Result<()> {
 
     assert!(
         container_manager.is_running(&container_name).await?,
-        "container should be running before snappy"
+        "container should be running before snapshotter"
     );
 
     container_manager.stop(&container_name).await?;
-    assert!(
-        !container_manager.is_running(&container_name).await?,
-        "container should be stopped after stop()"
-    );
+    assert!(!container_manager.is_running(&container_name).await?, "should be stopped");
 
     let tmp = tempfile::tempdir()?;
     let output_dir = tmp.path().join("output");
@@ -706,17 +535,14 @@ async fn e2e_stop_upload_restart_real_container() -> Result<()> {
         harness.bucket_name.clone(),
         "e2e-test".to_string(),
     );
-    let run_prefix = uploader.upload(&output_dir, &files, 1_000_000, 1700000000).await?;
+    let upload_prefix = uploader.upload(&output_dir, &files, 1_700_000_000).await?;
 
-    let manifest_key = format!("{run_prefix}/manifest.json");
-    let manifest_obj = harness
-        .storage_client
-        .get_object()
-        .bucket(&harness.bucket_name)
-        .key(&manifest_key)
-        .send()
-        .await?;
-    let manifest_body = manifest_obj.body.collect().await?.into_bytes();
+    let manifest_body = get_object_bytes(
+        &harness.storage_client,
+        &harness.bucket_name,
+        &format!("{upload_prefix}/manifest.json"),
+    )
+    .await?;
     let manifest: serde_json::Value = serde_json::from_slice(&manifest_body)?;
     assert_eq!(manifest["block"], 1_000_000, "uploaded manifest should have correct block");
 
@@ -730,4 +556,10 @@ async fn e2e_stop_upload_restart_real_container() -> Result<()> {
     docker.remove_container(&container_name, None::<RemoveContainerOptions>).await.ok();
 
     Ok(())
+}
+
+async fn get_object_bytes(client: &aws_sdk_s3::Client, bucket: &str, key: &str) -> Result<Vec<u8>> {
+    let resp = client.get_object().bucket(bucket).key(key).send().await?;
+    let bytes = resp.body.collect().await?.into_bytes();
+    Ok(bytes.to_vec())
 }

--- a/crates/infra/snapshotter/tests/e2e_test.rs
+++ b/crates/infra/snapshotter/tests/e2e_test.rs
@@ -343,7 +343,8 @@ async fn upload_with_empty_prefix() -> Result<()> {
 #[serial]
 async fn diff_upload_skips_unchanged_static_file_chunks() -> Result<()> {
     let harness = TestHarness::new().await?;
-    let run_prefix = "diff-test/1000000-1700000000";
+    let s3 = &harness.storage_client;
+    let bucket = &harness.bucket_name;
 
     let uploader = SnapshotUploader::new(
         harness.storage_client.clone(),
@@ -351,11 +352,10 @@ async fn diff_upload_skips_unchanged_static_file_chunks() -> Result<()> {
         "diff-test".to_string(),
     );
 
-    let s3 = &harness.storage_client;
-    let bucket = &harness.bucket_name;
+    // Simulate a previous snapshot run: upload files under a previous prefix
+    // and write latest.json pointing to it.
+    let prev_prefix = "diff-test/900000-1699000000";
 
-    // Pre-seed R2 with finalized static file chunks from a previous snapshot run.
-    // These represent block ranges that are fully finalized and should NOT be re-uploaded.
     let preexisting: &[(&str, &[u8])] = &[
         ("headers-0-499999.tar.zst", b"finalized-headers-0"),
         ("headers-500000-999999.tar.zst", b"finalized-headers-1"),
@@ -365,10 +365,13 @@ async fn diff_upload_skips_unchanged_static_file_chunks() -> Result<()> {
         ("receipts-500000-999999.tar.zst", b"finalized-receipts-1"),
         ("account_changesets-0-499999.tar.zst", b"finalized-acc-cs-0"),
         ("storage_changesets-0-499999.tar.zst", b"finalized-stor-cs-0"),
+        ("state.tar.zst", b"old-mdbx-state"),
+        ("rocksdb_indices.tar.zst", b"old-rocksdb"),
+        ("manifest.json", b"{\"block\":900000}"),
     ];
 
     for (name, data) in preexisting {
-        let key = format!("{run_prefix}/{name}");
+        let key = format!("{prev_prefix}/{name}");
         s3.put_object()
             .bucket(bucket)
             .key(&key)
@@ -377,14 +380,26 @@ async fn diff_upload_skips_unchanged_static_file_chunks() -> Result<()> {
             .await?;
     }
 
+    let latest_pointer = serde_json::json!({
+        "prefix": prev_prefix,
+        "block": 900_000,
+        "timestamp": 1_699_000_000u64
+    });
+    s3.put_object()
+        .bucket(bucket)
+        .key("diff-test/latest.json")
+        .body(aws_sdk_s3::primitives::ByteStream::from(serde_json::to_vec(&latest_pointer)?))
+        .send()
+        .await?;
+
+    // Now run a new snapshot upload at block 1M.
+    // The uploader should read latest.json, find the previous prefix, compare sizes.
     let tmp = tempfile::tempdir()?;
     let output_dir = tmp.path().join("output");
     std::fs::create_dir_all(&output_dir)?;
 
     let manifest = serde_json::json!({
-        "block": 1_000_000,
-        "chain_id": 8453,
-        "storage_version": 2,
+        "block": 1_000_000, "chain_id": 8453, "storage_version": 2,
         "reth_version": "2.1.0 (d58c6e3)",
         "components": {
             "state": {"file": "state.tar.zst", "size": 100, "decompressed_size": 200, "output_files": []},
@@ -398,16 +413,16 @@ async fn diff_upload_skips_unchanged_static_file_chunks() -> Result<()> {
     });
     std::fs::write(output_dir.join("manifest.json"), serde_json::to_string_pretty(&manifest)?)?;
 
-    // AlwaysUpload: mdbx state + rocksdb (always re-uploaded, content changes every snapshot)
+    // AlwaysUpload: mdbx + rocksdb always re-uploaded
     std::fs::write(output_dir.join("state.tar.zst"), b"new-mdbx-state-data")?;
     std::fs::write(output_dir.join("rocksdb_indices.tar.zst"), b"new-rocksdb-data")?;
 
-    // DiffBySize: finalized chunks with SAME size as remote → should be SKIPPED
-    for (name, data) in preexisting {
-        std::fs::write(output_dir.join(name), *data)?;
+    // DiffBySize: finalized chunks with SAME size as previous run → should be SKIPPED
+    for &(name, data) in &preexisting[..8] {
+        std::fs::write(output_dir.join(name), data)?;
     }
 
-    // DiffBySize: tip chunks that are NEW (don't exist in remote) → should be UPLOADED
+    // DiffBySize: new tip chunks → should be UPLOADED
     std::fs::write(output_dir.join("headers-1000000-1499999.tar.zst"), b"new-tip-headers")?;
     std::fs::write(output_dir.join("transactions-1000000-1499999.tar.zst"), b"new-tip-txs")?;
     std::fs::write(output_dir.join("receipts-1000000-1499999.tar.zst"), b"new-tip-receipts")?;
@@ -423,28 +438,40 @@ async fn diff_upload_skips_unchanged_static_file_chunks() -> Result<()> {
         .collect();
     files.sort_unstable();
 
-    uploader.upload(&output_dir, &files, 1_000_000, 1_700_000_000).await?;
+    let new_run_prefix = uploader.upload(&output_dir, &files, 1_000_000, 1_700_000_000).await?;
+    assert!(
+        new_run_prefix.starts_with("diff-test/1000000-"),
+        "new run prefix should be under diff-test/, got: {new_run_prefix}"
+    );
 
-    // Verify AlwaysUpload: mdbx state re-uploaded
-    let state_body = get_object_bytes(s3, bucket, &format!("{run_prefix}/state.tar.zst")).await?;
-    assert_eq!(state_body, b"new-mdbx-state-data", "mdbx state should always be re-uploaded");
+    // Verify AlwaysUpload: mdbx + rocksdb re-uploaded to NEW prefix
+    let state_body =
+        get_object_bytes(s3, bucket, &format!("{new_run_prefix}/state.tar.zst")).await?;
+    assert_eq!(state_body, b"new-mdbx-state-data", "mdbx should always be re-uploaded");
 
-    // Verify AlwaysUpload: rocksdb re-uploaded
     let rocksdb_body =
-        get_object_bytes(s3, bucket, &format!("{run_prefix}/rocksdb_indices.tar.zst")).await?;
+        get_object_bytes(s3, bucket, &format!("{new_run_prefix}/rocksdb_indices.tar.zst")).await?;
     assert_eq!(rocksdb_body, b"new-rocksdb-data", "rocksdb should always be re-uploaded");
 
-    // Verify DiffBySize SKIPPED: finalized chunks retain original content
-    for (name, original_data) in preexisting {
-        let body = get_object_bytes(s3, bucket, &format!("{run_prefix}/{name}")).await?;
-        assert_eq!(
-            body.as_slice(),
-            *original_data,
-            "finalized chunk {name} should be skipped (content unchanged)"
-        );
+    // Verify DiffBySize SKIPPED: finalized chunks NOT uploaded to new prefix
+    // (they only exist under the previous prefix)
+    let skipped_chunks = [
+        "headers-0-499999.tar.zst",
+        "headers-500000-999999.tar.zst",
+        "transactions-0-499999.tar.zst",
+        "transactions-500000-999999.tar.zst",
+        "receipts-0-499999.tar.zst",
+        "receipts-500000-999999.tar.zst",
+        "account_changesets-0-499999.tar.zst",
+        "storage_changesets-0-499999.tar.zst",
+    ];
+    for name in skipped_chunks {
+        let key = format!("{new_run_prefix}/{name}");
+        let exists = s3.head_object().bucket(bucket).key(&key).send().await.is_ok();
+        assert!(!exists, "finalized chunk {name} should NOT be in new prefix (was skipped)");
     }
 
-    // Verify DiffBySize UPLOADED: new tip chunks exist
+    // Verify DiffBySize UPLOADED: new tip chunks exist in new prefix
     let tip_checks: &[(&str, &[u8])] = &[
         ("headers-1000000-1499999.tar.zst", b"new-tip-headers"),
         ("transactions-1000000-1499999.tar.zst", b"new-tip-txs"),
@@ -453,15 +480,15 @@ async fn diff_upload_skips_unchanged_static_file_chunks() -> Result<()> {
         ("storage_changesets-500000-999999.tar.zst", b"new-tip-stor-cs"),
     ];
     for (name, expected) in tip_checks {
-        let body = get_object_bytes(s3, bucket, &format!("{run_prefix}/{name}")).await?;
+        let body = get_object_bytes(s3, bucket, &format!("{new_run_prefix}/{name}")).await?;
         assert_eq!(body.as_slice(), *expected, "tip chunk {name} should be uploaded");
     }
 
-    // Verify manifest always uploaded
-    let manifest_body =
-        get_object_bytes(s3, bucket, &format!("{run_prefix}/manifest.json")).await?;
-    let parsed: serde_json::Value = serde_json::from_slice(&manifest_body)?;
-    assert_eq!(parsed["block"], 1_000_000, "manifest should be uploaded with correct block");
+    // Verify latest.json updated to point to new run
+    let latest_body = get_object_bytes(s3, bucket, "diff-test/latest.json").await?;
+    let pointer: LatestPointer = serde_json::from_slice(&latest_body)?;
+    assert_eq!(pointer.block, 1_000_000, "latest should point to new block");
+    assert_eq!(pointer.prefix, new_run_prefix, "latest should point to new prefix");
 
     Ok(())
 }
@@ -470,7 +497,8 @@ async fn diff_upload_skips_unchanged_static_file_chunks() -> Result<()> {
 #[serial]
 async fn always_upload_overwrites_existing_state_and_rocksdb() -> Result<()> {
     let harness = TestHarness::new().await?;
-    let run_prefix = "overwrite-test/2000000-1700000000";
+    let s3 = &harness.storage_client;
+    let bucket = &harness.bucket_name;
 
     let uploader = SnapshotUploader::new(
         harness.storage_client.clone(),
@@ -478,16 +506,16 @@ async fn always_upload_overwrites_existing_state_and_rocksdb() -> Result<()> {
         "overwrite-test".to_string(),
     );
 
-    let s3 = &harness.storage_client;
-    let bucket = &harness.bucket_name;
+    // Simulate a previous run with old state + rocksdb
+    let prev_prefix = "overwrite-test/1500000-1699000000";
 
-    // Pre-seed R2 with stale state and rocksdb from a previous snapshot
-    let stale: &[(&str, &[u8])] = &[
+    let prev_files: &[(&str, &[u8])] = &[
         ("state.tar.zst", b"old-mdbx-snapshot-from-yesterday"),
         ("rocksdb_indices.tar.zst", b"old-rocksdb-from-yesterday"),
+        ("manifest.json", b"{\"block\":1500000}"),
     ];
-    for (name, data) in stale {
-        let key = format!("{run_prefix}/{name}");
+    for (name, data) in prev_files {
+        let key = format!("{prev_prefix}/{name}");
         s3.put_object()
             .bucket(bucket)
             .key(&key)
@@ -496,6 +524,20 @@ async fn always_upload_overwrites_existing_state_and_rocksdb() -> Result<()> {
             .await?;
     }
 
+    // Write latest.json pointing to previous run
+    let latest_pointer = serde_json::json!({
+        "prefix": prev_prefix,
+        "block": 1_500_000,
+        "timestamp": 1_699_000_000u64
+    });
+    s3.put_object()
+        .bucket(bucket)
+        .key("overwrite-test/latest.json")
+        .body(aws_sdk_s3::primitives::ByteStream::from(serde_json::to_vec(&latest_pointer)?))
+        .send()
+        .await?;
+
+    // New snapshot with fresh state + rocksdb
     let tmp = tempfile::tempdir()?;
     let output_dir = tmp.path().join("output");
     std::fs::create_dir_all(&output_dir)?;
@@ -517,22 +559,36 @@ async fn always_upload_overwrites_existing_state_and_rocksdb() -> Result<()> {
         output_dir.join("state.tar.zst"),
     ];
 
-    uploader.upload(&output_dir, &files, 2_000_000, 1_700_000_000).await?;
+    let new_prefix = uploader.upload(&output_dir, &files, 2_000_000, 1_700_000_000).await?;
 
-    // Verify state was overwritten, not skipped
-    let state_body = get_object_bytes(s3, bucket, &format!("{run_prefix}/state.tar.zst")).await?;
+    // Verify state uploaded to NEW prefix (not the previous one)
+    let state_body = get_object_bytes(s3, bucket, &format!("{new_prefix}/state.tar.zst")).await?;
     assert_eq!(
         state_body, b"fresh-mdbx-state",
-        "state.tar.zst should be overwritten even though it existed in R2"
+        "state.tar.zst should be uploaded to new prefix despite existing in previous run"
     );
 
-    // Verify rocksdb was overwritten, not skipped
+    // Verify rocksdb uploaded to NEW prefix
     let rocksdb_body =
-        get_object_bytes(s3, bucket, &format!("{run_prefix}/rocksdb_indices.tar.zst")).await?;
+        get_object_bytes(s3, bucket, &format!("{new_prefix}/rocksdb_indices.tar.zst")).await?;
     assert_eq!(
         rocksdb_body, b"fresh-rocksdb",
-        "rocksdb_indices.tar.zst should be overwritten even though it existed in R2"
+        "rocksdb_indices.tar.zst should be uploaded to new prefix despite existing in previous run"
     );
+
+    // Verify previous run's files are untouched
+    let old_state = get_object_bytes(s3, bucket, &format!("{prev_prefix}/state.tar.zst")).await?;
+    assert_eq!(
+        old_state.as_slice(),
+        b"old-mdbx-snapshot-from-yesterday",
+        "previous run's state should be untouched"
+    );
+
+    // Verify latest.json updated
+    let latest_body = get_object_bytes(s3, bucket, "overwrite-test/latest.json").await?;
+    let pointer: LatestPointer = serde_json::from_slice(&latest_body)?;
+    assert_eq!(pointer.block, 2_000_000, "latest should point to new block");
+    assert_eq!(pointer.prefix, new_prefix, "latest should point to new prefix");
 
     Ok(())
 }

--- a/crates/infra/snapshotter/tests/e2e_test.rs
+++ b/crates/infra/snapshotter/tests/e2e_test.rs
@@ -1,7 +1,7 @@
 //! E2E tests for the snapshotter upload flow using `MinIO`.
 
 use std::{
-    path::Path,
+    path::{Path, PathBuf},
     sync::atomic::{AtomicBool, Ordering},
 };
 
@@ -337,6 +337,210 @@ async fn upload_with_empty_prefix() -> Result<()> {
     assert_eq!(pointer.block, 100, "latest pointer block should be 100");
 
     Ok(())
+}
+
+#[tokio::test]
+#[serial]
+async fn diff_upload_skips_unchanged_static_file_chunks() -> Result<()> {
+    let harness = TestHarness::new().await?;
+    let run_prefix = "diff-test/1000000-1700000000";
+
+    let uploader = SnapshotUploader::new(
+        harness.storage_client.clone(),
+        harness.bucket_name.clone(),
+        "diff-test".to_string(),
+    );
+
+    let s3 = &harness.storage_client;
+    let bucket = &harness.bucket_name;
+
+    // Pre-seed R2 with finalized static file chunks from a previous snapshot run.
+    // These represent block ranges that are fully finalized and should NOT be re-uploaded.
+    let preexisting: &[(&str, &[u8])] = &[
+        ("headers-0-499999.tar.zst", b"finalized-headers-0"),
+        ("headers-500000-999999.tar.zst", b"finalized-headers-1"),
+        ("transactions-0-499999.tar.zst", b"finalized-txs-0"),
+        ("transactions-500000-999999.tar.zst", b"finalized-txs-1"),
+        ("receipts-0-499999.tar.zst", b"finalized-receipts-0"),
+        ("receipts-500000-999999.tar.zst", b"finalized-receipts-1"),
+        ("account_changesets-0-499999.tar.zst", b"finalized-acc-cs-0"),
+        ("storage_changesets-0-499999.tar.zst", b"finalized-stor-cs-0"),
+    ];
+
+    for (name, data) in preexisting {
+        let key = format!("{run_prefix}/{name}");
+        s3.put_object()
+            .bucket(bucket)
+            .key(&key)
+            .body(aws_sdk_s3::primitives::ByteStream::from(data.to_vec()))
+            .send()
+            .await?;
+    }
+
+    let tmp = tempfile::tempdir()?;
+    let output_dir = tmp.path().join("output");
+    std::fs::create_dir_all(&output_dir)?;
+
+    let manifest = serde_json::json!({
+        "block": 1_000_000,
+        "chain_id": 8453,
+        "storage_version": 2,
+        "reth_version": "2.1.0 (d58c6e3)",
+        "components": {
+            "state": {"file": "state.tar.zst", "size": 100, "decompressed_size": 200, "output_files": []},
+            "rocksdb_indices": {"file": "rocksdb_indices.tar.zst", "size": 50, "decompressed_size": 100, "output_files": []},
+            "headers": {"blocks_per_file": 500000, "total_blocks": 1000000, "chunk_sizes": [20, 20], "chunk_decompressed_sizes": [], "chunk_output_files": []},
+            "transactions": {"blocks_per_file": 500000, "total_blocks": 1000000, "chunk_sizes": [30, 30], "chunk_decompressed_sizes": [], "chunk_output_files": []},
+            "receipts": {"blocks_per_file": 500000, "total_blocks": 1000000, "chunk_sizes": [15, 15], "chunk_decompressed_sizes": [], "chunk_output_files": []},
+            "account_changesets": {"blocks_per_file": 500000, "total_blocks": 1000000, "chunk_sizes": [18, 18], "chunk_decompressed_sizes": [], "chunk_output_files": []},
+            "storage_changesets": {"blocks_per_file": 500000, "total_blocks": 1000000, "chunk_sizes": [22, 22], "chunk_decompressed_sizes": [], "chunk_output_files": []}
+        }
+    });
+    std::fs::write(output_dir.join("manifest.json"), serde_json::to_string_pretty(&manifest)?)?;
+
+    // AlwaysUpload: mdbx state + rocksdb (always re-uploaded, content changes every snapshot)
+    std::fs::write(output_dir.join("state.tar.zst"), b"new-mdbx-state-data")?;
+    std::fs::write(output_dir.join("rocksdb_indices.tar.zst"), b"new-rocksdb-data")?;
+
+    // DiffBySize: finalized chunks with SAME size as remote → should be SKIPPED
+    for (name, data) in preexisting {
+        std::fs::write(output_dir.join(name), *data)?;
+    }
+
+    // DiffBySize: tip chunks that are NEW (don't exist in remote) → should be UPLOADED
+    std::fs::write(output_dir.join("headers-1000000-1499999.tar.zst"), b"new-tip-headers")?;
+    std::fs::write(output_dir.join("transactions-1000000-1499999.tar.zst"), b"new-tip-txs")?;
+    std::fs::write(output_dir.join("receipts-1000000-1499999.tar.zst"), b"new-tip-receipts")?;
+    std::fs::write(output_dir.join("account_changesets-500000-999999.tar.zst"), b"new-tip-acc-cs")?;
+    std::fs::write(
+        output_dir.join("storage_changesets-500000-999999.tar.zst"),
+        b"new-tip-stor-cs",
+    )?;
+
+    let mut files: Vec<PathBuf> = std::fs::read_dir(&output_dir)?
+        .filter_map(|e| e.ok().map(|e| e.path()))
+        .filter(|p| p.is_file())
+        .collect();
+    files.sort_unstable();
+
+    uploader.upload(&output_dir, &files, 1_000_000, 1_700_000_000).await?;
+
+    // Verify AlwaysUpload: mdbx state re-uploaded
+    let state_body = get_object_bytes(s3, bucket, &format!("{run_prefix}/state.tar.zst")).await?;
+    assert_eq!(state_body, b"new-mdbx-state-data", "mdbx state should always be re-uploaded");
+
+    // Verify AlwaysUpload: rocksdb re-uploaded
+    let rocksdb_body =
+        get_object_bytes(s3, bucket, &format!("{run_prefix}/rocksdb_indices.tar.zst")).await?;
+    assert_eq!(rocksdb_body, b"new-rocksdb-data", "rocksdb should always be re-uploaded");
+
+    // Verify DiffBySize SKIPPED: finalized chunks retain original content
+    for (name, original_data) in preexisting {
+        let body = get_object_bytes(s3, bucket, &format!("{run_prefix}/{name}")).await?;
+        assert_eq!(
+            body.as_slice(),
+            *original_data,
+            "finalized chunk {name} should be skipped (content unchanged)"
+        );
+    }
+
+    // Verify DiffBySize UPLOADED: new tip chunks exist
+    let tip_checks: &[(&str, &[u8])] = &[
+        ("headers-1000000-1499999.tar.zst", b"new-tip-headers"),
+        ("transactions-1000000-1499999.tar.zst", b"new-tip-txs"),
+        ("receipts-1000000-1499999.tar.zst", b"new-tip-receipts"),
+        ("account_changesets-500000-999999.tar.zst", b"new-tip-acc-cs"),
+        ("storage_changesets-500000-999999.tar.zst", b"new-tip-stor-cs"),
+    ];
+    for (name, expected) in tip_checks {
+        let body = get_object_bytes(s3, bucket, &format!("{run_prefix}/{name}")).await?;
+        assert_eq!(body.as_slice(), *expected, "tip chunk {name} should be uploaded");
+    }
+
+    // Verify manifest always uploaded
+    let manifest_body =
+        get_object_bytes(s3, bucket, &format!("{run_prefix}/manifest.json")).await?;
+    let parsed: serde_json::Value = serde_json::from_slice(&manifest_body)?;
+    assert_eq!(parsed["block"], 1_000_000, "manifest should be uploaded with correct block");
+
+    Ok(())
+}
+
+#[tokio::test]
+#[serial]
+async fn always_upload_overwrites_existing_state_and_rocksdb() -> Result<()> {
+    let harness = TestHarness::new().await?;
+    let run_prefix = "overwrite-test/2000000-1700000000";
+
+    let uploader = SnapshotUploader::new(
+        harness.storage_client.clone(),
+        harness.bucket_name.clone(),
+        "overwrite-test".to_string(),
+    );
+
+    let s3 = &harness.storage_client;
+    let bucket = &harness.bucket_name;
+
+    // Pre-seed R2 with stale state and rocksdb from a previous snapshot
+    let stale: &[(&str, &[u8])] = &[
+        ("state.tar.zst", b"old-mdbx-snapshot-from-yesterday"),
+        ("rocksdb_indices.tar.zst", b"old-rocksdb-from-yesterday"),
+    ];
+    for (name, data) in stale {
+        let key = format!("{run_prefix}/{name}");
+        s3.put_object()
+            .bucket(bucket)
+            .key(&key)
+            .body(aws_sdk_s3::primitives::ByteStream::from(data.to_vec()))
+            .send()
+            .await?;
+    }
+
+    let tmp = tempfile::tempdir()?;
+    let output_dir = tmp.path().join("output");
+    std::fs::create_dir_all(&output_dir)?;
+
+    let manifest = serde_json::json!({
+        "block": 2_000_000, "chain_id": 8453, "storage_version": 2,
+        "components": {
+            "state": {"file": "state.tar.zst", "size": 100, "decompressed_size": 200, "output_files": []},
+            "rocksdb_indices": {"file": "rocksdb_indices.tar.zst", "size": 50, "decompressed_size": 100, "output_files": []}
+        }
+    });
+    std::fs::write(output_dir.join("manifest.json"), serde_json::to_string(&manifest)?)?;
+    std::fs::write(output_dir.join("state.tar.zst"), b"fresh-mdbx-state")?;
+    std::fs::write(output_dir.join("rocksdb_indices.tar.zst"), b"fresh-rocksdb")?;
+
+    let files = vec![
+        output_dir.join("manifest.json"),
+        output_dir.join("rocksdb_indices.tar.zst"),
+        output_dir.join("state.tar.zst"),
+    ];
+
+    uploader.upload(&output_dir, &files, 2_000_000, 1_700_000_000).await?;
+
+    // Verify state was overwritten, not skipped
+    let state_body = get_object_bytes(s3, bucket, &format!("{run_prefix}/state.tar.zst")).await?;
+    assert_eq!(
+        state_body, b"fresh-mdbx-state",
+        "state.tar.zst should be overwritten even though it existed in R2"
+    );
+
+    // Verify rocksdb was overwritten, not skipped
+    let rocksdb_body =
+        get_object_bytes(s3, bucket, &format!("{run_prefix}/rocksdb_indices.tar.zst")).await?;
+    assert_eq!(
+        rocksdb_body, b"fresh-rocksdb",
+        "rocksdb_indices.tar.zst should be overwritten even though it existed in R2"
+    );
+
+    Ok(())
+}
+
+async fn get_object_bytes(client: &aws_sdk_s3::Client, bucket: &str, key: &str) -> Result<Vec<u8>> {
+    let resp = client.get_object().bucket(bucket).key(key).send().await?;
+    let bytes = resp.body.collect().await?.into_bytes();
+    Ok(bytes.to_vec())
 }
 
 #[tokio::test]


### PR DESCRIPTION
builds on #2550

- adds optimization to `upload(..)` fn by only uploading diffs on static files by introducing an enum for upload strategy 
   - skip logic is determined by comparing to local compressed sized to what's uploaded in the R2 bucket file size
   - if it's the same we skip the upload
- MDBX and RocksDB have an always upload strategy 
- added unit test for uploading diffs of static files
- added unit test for testing that MDBX and RocksDB always overwrites

bucket structure:
```
{prefix}/
├── static_files/
│   ├── headers-0-499999.tar.zst          ← uploaded once, immutable
│   ├── headers-500000-999999.tar.zst     ← uploaded once, immutable
│   ├── headers-1000000-1499999.tar.zst   ← tip chunk, overwritten each run
│   ├── transactions-0-499999.tar.zst
│   └── ...
├── 1778509076/
│   ├── manifest.json
│   ├── state.tar.zst                     ← mdbx from this run
│   └── rocksdb_indices.tar.zst           ← rocksdb from this run
├── 1778422676/
│   ├── manifest.json
│   ├── state.tar.zst
│   └── rocksdb_indices.tar.zst
```

next up:
- further optimization is skipping compression for files we already know would not be re-uploaded
- wire up `reth download`