### PR TITLE
fix(proposer): discard proofs with stale L1 origin

### DIFF
--- a/crates/proof/contracts/src/aggregate_verifier.rs
+++ b/crates/proof/contracts/src/aggregate_verifier.rs
@@ -9,7 +9,7 @@
 
 use alloy_primitives::{Address, B256, Bytes, U256};
 use alloy_provider::RootProvider;
-use alloy_sol_types::{SolCall, sol};
+use alloy_sol_types::{SolCall, SolError, sol};
 use async_trait::async_trait;
 
 use crate::{
@@ -23,6 +23,9 @@ sol! {
     /// Each game instance is a clone created by `DisputeGameFactory.create()`.
     #[sol(rpc)]
     interface IAggregateVerifier {
+        /// Error returned when the proof's L1 origin is older than the EIP-2935 history window.
+        error L1OriginTooOld(uint256 l1OriginNumber, uint256 currentBlock);
+
         /// Returns the root claim (output root) of this game.
         function rootClaim() external pure returns (bytes32);
 
@@ -252,6 +255,11 @@ pub trait AggregateVerifierClient: Send + Sync {
         asr_address: Address,
         game_address: Address,
     ) -> Result<AnchorPreflight, ContractError>;
+}
+
+/// The 4-byte selector for `L1OriginTooOld()`.
+pub const fn l1_origin_too_old_selector() -> [u8; 4] {
+    IAggregateVerifier::L1OriginTooOld::SELECTOR
 }
 
 /// Concrete implementation backed by Alloy's sol-generated contract bindings.
@@ -780,6 +788,13 @@ mod tests {
     fn test_encode_claim_credit_calldata_has_selector() {
         let calldata = encode_claim_credit_calldata();
         assert_eq!(&calldata[..4], &IAggregateVerifier::claimCreditCall::SELECTOR);
+    }
+
+    #[test]
+    fn test_l1_origin_too_old_selector() {
+        let selector = l1_origin_too_old_selector();
+        assert_eq!(selector.len(), 4);
+        assert_ne!(selector, [0u8; 4]);
     }
 
     #[test]

--- a/crates/proof/contracts/src/lib.rs
+++ b/crates/proof/contracts/src/lib.rs
@@ -10,6 +10,7 @@ mod aggregate_verifier;
 pub use aggregate_verifier::{
     AggregateVerifierClient, AggregateVerifierContractClient, GameInfo, encode_challenge_calldata,
     encode_claim_credit_calldata, encode_nullify_calldata, encode_resolve_calldata,
+    l1_origin_too_old_selector,
 };
 
 mod delayed_weth;

--- a/crates/proof/proposer/src/error.rs
+++ b/crates/proof/proposer/src/error.rs
@@ -26,6 +26,10 @@ pub enum ProposerError {
     #[error("game already exists")]
     GameAlreadyExists,
 
+    /// The proof's L1 origin is older than the EIP-2935 history window.
+    #[error("l1 origin too old")]
+    L1OriginTooOld,
+
     /// Configuration error.
     #[error("config error: {0}")]
     Config(String),
@@ -56,10 +60,17 @@ impl ProposerError {
     pub const ERROR_TYPE_TX_MANAGER: &str = "tx_manager";
     /// Metric label for duplicate game errors.
     pub const ERROR_TYPE_GAME_ALREADY_EXISTS: &str = "game_already_exists";
+    /// Metric label for stale L1 origin errors.
+    pub const ERROR_TYPE_L1_ORIGIN_TOO_OLD: &str = "l1_origin_too_old";
 
     /// Returns true if this error indicates the game already exists.
     pub const fn is_game_already_exists(&self) -> bool {
         matches!(self, Self::GameAlreadyExists)
+    }
+
+    /// Returns true if this error indicates the proof's L1 origin is too old.
+    pub const fn is_l1_origin_too_old(&self) -> bool {
+        matches!(self, Self::L1OriginTooOld)
     }
 
     /// Returns the metrics label for this error variant.
@@ -70,6 +81,7 @@ impl ProposerError {
             Self::Contract(_) => Self::ERROR_TYPE_CONTRACT,
             Self::TxReverted(_) => Self::ERROR_TYPE_TX_REVERTED,
             Self::GameAlreadyExists => Self::ERROR_TYPE_GAME_ALREADY_EXISTS,
+            Self::L1OriginTooOld => Self::ERROR_TYPE_L1_ORIGIN_TOO_OLD,
             Self::Config(_) => Self::ERROR_TYPE_CONFIG,
             Self::Internal(_) => Self::ERROR_TYPE_INTERNAL,
             Self::TxManager(_) => Self::ERROR_TYPE_TX_MANAGER,

--- a/crates/proof/proposer/src/output_proposer.rs
+++ b/crates/proof/proposer/src/output_proposer.rs
@@ -8,6 +8,7 @@ use alloy_primitives::{Address, B256, U256};
 use async_trait::async_trait;
 use base_proof_contracts::{
     encode_create_calldata, encode_extra_data, game_already_exists_selector,
+    l1_origin_too_old_selector,
 };
 use base_proof_primitives::Proposal;
 use base_tx_manager::{TxCandidate, TxManager, TxManagerError};
@@ -16,28 +17,43 @@ use tracing::info;
 use crate::error::ProposerError;
 
 const GAME_ALREADY_EXISTS: &str = "GameAlreadyExists";
+const L1_ORIGIN_TOO_OLD: &str = "L1OriginTooOld";
 
 /// Classifies a [`TxManagerError`] into a [`ProposerError`].
 ///
 /// Checks the structured revert reason and raw data for the
-/// `GameAlreadyExists` selector first, then falls back to searching the
+/// known non-retryable selectors first, then falls back to searching the
 /// Display string for non-`ExecutionReverted` variants (e.g. `Rpc`).
 fn classify_tx_manager_error(err: TxManagerError) -> ProposerError {
-    let selector = game_already_exists_selector();
+    let game_exists_selector = game_already_exists_selector();
+    let l1_origin_selector = l1_origin_too_old_selector();
 
     if let TxManagerError::ExecutionReverted { ref reason, ref data } = err {
         if reason.as_deref().is_some_and(|r| r.contains(GAME_ALREADY_EXISTS)) {
             return ProposerError::GameAlreadyExists;
         }
-        if data.as_ref().is_some_and(|d| d.starts_with(&selector)) {
+        if data.as_ref().is_some_and(|d| d.starts_with(&game_exists_selector)) {
             return ProposerError::GameAlreadyExists;
+        }
+        if reason.as_deref().is_some_and(|r| r.contains(L1_ORIGIN_TOO_OLD)) {
+            return ProposerError::L1OriginTooOld;
+        }
+        if data.as_ref().is_some_and(|d| d.starts_with(&l1_origin_selector)) {
+            return ProposerError::L1OriginTooOld;
         }
         return ProposerError::TxManager(err);
     }
 
     let msg = err.to_string();
-    if msg.contains(&alloy_primitives::hex::encode(selector)) || msg.contains(GAME_ALREADY_EXISTS) {
+    if msg.contains(&alloy_primitives::hex::encode(game_exists_selector))
+        || msg.contains(GAME_ALREADY_EXISTS)
+    {
         return ProposerError::GameAlreadyExists;
+    }
+    if msg.contains(&alloy_primitives::hex::encode(l1_origin_selector))
+        || msg.contains(L1_ORIGIN_TOO_OLD)
+    {
+        return ProposerError::L1OriginTooOld;
     }
     ProposerError::TxManager(err)
 }
@@ -334,15 +350,22 @@ mod tests {
     // classify_tx_manager_error tests
     // ========================================================================
 
+    #[derive(Debug)]
+    enum ExpectedClassification {
+        GameAlreadyExists,
+        L1OriginTooOld,
+        TxManager,
+    }
+
     #[rstest]
     #[case::rpc_with_selector_hex(
         TxManagerError::Rpc(format!("execution reverted: 0x{}", alloy_primitives::hex::encode(base_proof_contracts::game_already_exists_selector()))),
-        true,
+        ExpectedClassification::GameAlreadyExists,
         "selector hex in Rpc message"
     )]
     #[case::rpc_with_name(
         TxManagerError::Rpc(format!("{GAME_ALREADY_EXISTS}()")),
-        true,
+        ExpectedClassification::GameAlreadyExists,
         "error name in Rpc message"
     )]
     #[case::reverted_with_reason(
@@ -350,7 +373,7 @@ mod tests {
             reason: Some(format!("{GAME_ALREADY_EXISTS}()")),
             data: None,
         },
-        true,
+        ExpectedClassification::GameAlreadyExists,
         "reason string contains name"
     )]
     #[case::reverted_with_selector_data(
@@ -362,34 +385,67 @@ mod tests {
                 data: Some(Bytes::from(data)),
             }
         },
-        true,
+        ExpectedClassification::GameAlreadyExists,
         "raw data contains selector"
+    )]
+    #[case::rpc_with_l1_origin_selector_hex(
+        TxManagerError::Rpc(format!("execution reverted: 0x{}", alloy_primitives::hex::encode(base_proof_contracts::l1_origin_too_old_selector()))),
+        ExpectedClassification::L1OriginTooOld,
+        "L1OriginTooOld selector hex in Rpc message"
+    )]
+    #[case::rpc_with_l1_origin_name(
+        TxManagerError::Rpc(format!("{L1_ORIGIN_TOO_OLD}()")),
+        ExpectedClassification::L1OriginTooOld,
+        "L1OriginTooOld name in Rpc message"
+    )]
+    #[case::reverted_with_l1_origin_reason(
+        TxManagerError::ExecutionReverted {
+            reason: Some(format!("{L1_ORIGIN_TOO_OLD}()")),
+            data: None,
+        },
+        ExpectedClassification::L1OriginTooOld,
+        "L1OriginTooOld reason string contains name"
+    )]
+    #[case::reverted_with_l1_origin_selector_data(
+        TxManagerError::ExecutionReverted {
+            reason: None,
+            data: Some(Bytes::from(base_proof_contracts::l1_origin_too_old_selector().to_vec())),
+        },
+        ExpectedClassification::L1OriginTooOld,
+        "L1OriginTooOld raw data contains selector"
     )]
     #[case::reverted_other_error(
         TxManagerError::ExecutionReverted {
             reason: Some("SomeOtherError()".to_string()),
             data: Some(Bytes::from(vec![0xde, 0xad, 0xbe, 0xef])),
         },
-        false,
+        ExpectedClassification::TxManager,
         "unrelated revert"
     )]
-    #[case::nonce_too_low(TxManagerError::NonceTooLow, false, "non-revert error")]
+    #[case::nonce_too_low(
+        TxManagerError::NonceTooLow,
+        ExpectedClassification::TxManager,
+        "non-revert error"
+    )]
     fn test_classify_tx_manager_error(
         #[case] err: TxManagerError,
-        #[case] expect_game_exists: bool,
+        #[case] expected: ExpectedClassification,
         #[case] scenario: &str,
     ) {
         let result = classify_tx_manager_error(err);
-        if expect_game_exists {
-            assert!(
+        match expected {
+            ExpectedClassification::GameAlreadyExists => assert!(
                 matches!(result, ProposerError::GameAlreadyExists),
                 "{scenario}: expected GameAlreadyExists, got {result:?}"
-            );
-        } else {
-            assert!(
+            ),
+            ExpectedClassification::L1OriginTooOld => assert!(
+                matches!(result, ProposerError::L1OriginTooOld),
+                "{scenario}: expected L1OriginTooOld, got {result:?}"
+            ),
+            ExpectedClassification::TxManager => assert!(
                 matches!(result, ProposerError::TxManager(_)),
                 "{scenario}: expected TxManager, got {result:?}"
-            );
+            ),
         }
     }
 
@@ -398,5 +454,12 @@ mod tests {
     #[case::other_error(ProposerError::Contract("other".into()), false)]
     fn test_is_game_already_exists(#[case] err: ProposerError, #[case] expected: bool) {
         assert_eq!(err.is_game_already_exists(), expected);
+    }
+
+    #[rstest]
+    #[case::l1_origin_too_old(ProposerError::L1OriginTooOld, true)]
+    #[case::other_error(ProposerError::Contract("other".into()), false)]
+    fn test_is_l1_origin_too_old(#[case] err: ProposerError, #[case] expected: bool) {
+        assert_eq!(err.is_l1_origin_too_old(), expected);
     }
 }

--- a/crates/proof/proposer/src/pipeline.rs
+++ b/crates/proof/proposer/src/pipeline.rs
@@ -1216,6 +1216,14 @@ where
                         "Game already exists, next tick will load fresh state from chain"
                     );
                     Err(SubmitAction::GameAlreadyExists)
+                } else if e.is_l1_origin_too_old() {
+                    propose_timer.disarm();
+                    warn!(
+                        error = %e,
+                        target_block,
+                        "Proof L1 origin is too old, discarding proof to re-prove"
+                    );
+                    Err(SubmitAction::Discard(e))
                 } else {
                     propose_timer.disarm();
                     Err(SubmitAction::Failed(e))
@@ -2318,6 +2326,21 @@ mod tests {
         }
     }
 
+    #[derive(Debug)]
+    struct L1OriginTooOldOutputProposer;
+
+    #[async_trait]
+    impl OutputProposer for L1OriginTooOldOutputProposer {
+        async fn propose_output(
+            &self,
+            _proposal: &Proposal,
+            _parent_address: Address,
+            _intermediate_roots: &[B256],
+        ) -> Result<(), ProposerError> {
+            Err(ProposerError::L1OriginTooOld)
+        }
+    }
+
     #[tokio::test(flavor = "current_thread", start_paused = true)]
     async fn test_validate_and_submit_intermediate_roots_match() {
         // MockRollupClient returns B256::repeat_byte(n) for blocks without
@@ -2350,6 +2373,27 @@ mod tests {
         assert!(
             result.is_ok(),
             "submission should rely on tx-manager timeout, not an outer timeout"
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn test_validate_and_submit_discards_l1_origin_too_old() {
+        let pipeline = recovery_pipeline_full_with_output_proposer(
+            MockDisputeGameFactory::with_games(vec![]),
+            HashMap::new(),
+            TEST_ANCHOR_BLOCK,
+            SUBMIT_BLOCK_INTERVAL,
+            SUBMIT_INTERMEDIATE_INTERVAL,
+            Arc::new(L1OriginTooOldOutputProposer),
+        );
+        let proof_result = submit_proof_result(SUBMIT_BLOCK_INTERVAL);
+
+        let result =
+            pipeline.validate_and_submit(&proof_result, SUBMIT_BLOCK_INTERVAL, Address::ZERO).await;
+
+        assert!(
+            matches!(result, Err(SubmitAction::Discard(ProposerError::L1OriginTooOld))),
+            "stale L1 origin should discard the proof, got {result:?}"
         );
     }
 


### PR DESCRIPTION
## Summary
- Classify `L1OriginTooOld` reverts from the aggregate verifier using the matching Solidity error selector.
- Discard stale submitted proofs instead of requeueing them so the proposer can re-prove with a fresh L1 origin.
- Add unit coverage for selector classification and the discard submission path.

## Test plan
- `cargo test -p base-proof-contracts`
- `cargo test -p base-proposer`


Made with [Cursor](https://cursor.com)