### PR TITLE
fix: respect rpc admin flags

### DIFF
--- a/crates/consensus/rpc/src/config.rs
+++ b/crates/consensus/rpc/src/config.rs
@@ -35,6 +35,11 @@ impl RpcBuilder {
         self.dev_enabled
     }
 
+    /// Returns whether privileged admin RPC endpoints are enabled.
+    pub const fn admin_enabled(&self) -> bool {
+        self.enable_admin
+    }
+
     /// Returns the socket address of the [`RpcBuilder`].
     pub const fn socket(&self) -> SocketAddr {
         self.socket

--- a/crates/consensus/service/src/actors/rpc/actor.rs
+++ b/crates/consensus/service/src/actors/rpc/actor.rs
@@ -116,10 +116,13 @@ where
             modules.merge(P2pRpc::new(p2p_network).into_rpc())?;
         }
 
-        // Build the admin rpc module.
-        if let Some(network_admin) = network_admin {
-            modules
-                .merge(AdminRpc::new(self.sequencer_admin_rpc_client, network_admin).into_rpc())?;
+        if self.config.admin_enabled() {
+            // Build the admin rpc module.
+            if let Some(network_admin) = network_admin {
+                modules.merge(
+                    AdminRpc::new(self.sequencer_admin_rpc_client, network_admin).into_rpc(),
+                )?;
+            }
         }
 
         // Create context for communication between actors.
@@ -173,9 +176,119 @@ where
 
 #[cfg(test)]
 mod tests {
-    use std::{net::SocketAddr, num::NonZeroUsize, time::Duration};
+    use std::{
+        net::{SocketAddr, TcpListener},
+        num::NonZeroUsize,
+        sync::Arc,
+        time::Duration,
+    };
 
     use super::*;
+    use alloy_eips::BlockNumberOrTag;
+    use alloy_primitives::B256;
+    use base_common_genesis::RollupConfig;
+    use base_consensus_engine::EngineState;
+    use base_consensus_rpc::{SequencerAdminAPIClient, SequencerAdminAPIError};
+    use base_consensus_safedb::{SafeDBError, SafeHeadResponse};
+    use base_protocol::{L2BlockInfo, OutputRoot};
+    use jsonrpsee::{
+        core::{ClientError, client::ClientT},
+        http_client::HttpClientBuilder,
+        rpc_params,
+        types::ErrorCode,
+    };
+    use tokio::{sync::watch, time::sleep};
+
+    #[derive(Clone, Debug)]
+    struct TestEngineRpcClient;
+
+    #[async_trait]
+    impl EngineRpcClient for TestEngineRpcClient {
+        async fn get_config(&self) -> jsonrpsee::core::RpcResult<RollupConfig> {
+            Ok(RollupConfig::default())
+        }
+
+        async fn get_state(&self) -> jsonrpsee::core::RpcResult<EngineState> {
+            Ok(EngineState::default())
+        }
+
+        async fn output_at_block(
+            &self,
+            _: BlockNumberOrTag,
+        ) -> jsonrpsee::core::RpcResult<(L2BlockInfo, OutputRoot, EngineState)> {
+            Ok((
+                L2BlockInfo::default(),
+                OutputRoot::from_parts(B256::ZERO, B256::ZERO, B256::ZERO),
+                EngineState::default(),
+            ))
+        }
+
+        async fn dev_get_task_queue_length(&self) -> jsonrpsee::core::RpcResult<usize> {
+            Ok(0)
+        }
+
+        async fn dev_subscribe_to_engine_queue_length(
+            &self,
+        ) -> jsonrpsee::core::RpcResult<watch::Receiver<usize>> {
+            let (_, rx) = watch::channel(0);
+            Ok(rx)
+        }
+
+        async fn dev_subscribe_to_engine_state(
+            &self,
+        ) -> jsonrpsee::core::RpcResult<watch::Receiver<EngineState>> {
+            let (_, rx) = watch::channel(EngineState::default());
+            Ok(rx)
+        }
+    }
+
+    #[derive(Debug)]
+    struct TestSequencerAdminClient;
+
+    #[async_trait]
+    impl SequencerAdminAPIClient for TestSequencerAdminClient {
+        async fn is_sequencer_active(&self) -> Result<bool, SequencerAdminAPIError> {
+            Ok(false)
+        }
+
+        async fn is_conductor_enabled(&self) -> Result<bool, SequencerAdminAPIError> {
+            Ok(false)
+        }
+
+        async fn is_recovery_mode(&self) -> Result<bool, SequencerAdminAPIError> {
+            Ok(false)
+        }
+
+        async fn start_sequencer(&self, _: B256) -> Result<(), SequencerAdminAPIError> {
+            Ok(())
+        }
+
+        async fn stop_sequencer(&self) -> Result<B256, SequencerAdminAPIError> {
+            Ok(B256::ZERO)
+        }
+
+        async fn set_recovery_mode(&self, _: bool) -> Result<(), SequencerAdminAPIError> {
+            Ok(())
+        }
+
+        async fn override_leader(&self) -> Result<(), SequencerAdminAPIError> {
+            Ok(())
+        }
+
+        async fn reset_derivation_pipeline(&self) -> Result<(), SequencerAdminAPIError> {
+            Ok(())
+        }
+    }
+
+    #[derive(Debug)]
+    struct TestSafeDBReader;
+
+    #[async_trait]
+    impl SafeDBReader for TestSafeDBReader {
+        async fn safe_head_at_l1(&self, _: u64) -> Result<SafeHeadResponse, SafeDBError> {
+            Err(SafeDBError::Disabled)
+        }
+    }
 
     #[tokio::test]
     async fn test_launch_no_modules() {
@@ -213,5 +326,83 @@ mod tests {
 
         let result = launch(&launcher, modules).await;
         assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_admin_rpc_disabled_even_with_admin_channels() {
+        let result = admin_sequencer_active(false).await;
+
+        let Err(ClientError::Call(error)) = result else {
+            panic!("expected method not found, got {result:?}");
+        };
+
+        assert_eq!(error.code(), ErrorCode::MethodNotFound.code());
+    }
+
+    #[tokio::test]
+    async fn test_admin_rpc_enabled_with_admin_channels() {
+        let result = admin_sequencer_active(true).await.expect("admin rpc request succeeds");
+
+        assert!(!result);
+    }
+
+    async fn admin_sequencer_active(enable_admin: bool) -> Result<bool, ClientError> {
+        let socket = unused_loopback_addr();
+        let config = RpcBuilder {
+            socket,
+            no_restart: true,
+            enable_admin,
+            admin_persistence: None,
+            ws_enabled: false,
+            dev_enabled: false,
+            http_timeout: Duration::from_secs(60),
+            max_concurrent_requests: NonZeroUsize::new(1024).expect("nonzero"),
+        };
+        let actor = RpcActor::new(
+            config,
+            TestEngineRpcClient,
+            Some(TestSequencerAdminClient),
+            Arc::new(TestSafeDBReader),
+        );
+        let cancellation = CancellationToken::new();
+        let (network_admin, _network_admin_rx) = mpsc::channel(1);
+        let (l1_watcher_queries, _l1_watcher_queries_rx) = mpsc::channel(1);
+        let context = RpcContext {
+            p2p_network: None,
+            network_admin: Some(network_admin),
+            l1_watcher_queries,
+            cancellation: cancellation.clone(),
+        };
+
+        let task = tokio::spawn(actor.start(context));
+        let client =
+            HttpClientBuilder::default().build(format!("http://{socket}")).expect("rpc client");
+        let result = request_admin_sequencer_active(&client).await;
+
+        cancellation.cancel();
+        task.await.expect("rpc actor task join").expect("rpc actor stops");
+
+        result
+    }
+
+    async fn request_admin_sequencer_active(
+        client: &jsonrpsee::http_client::HttpClient,
+    ) -> Result<bool, ClientError> {
+        for attempt in 0..50 {
+            let result = ClientT::request(client, "admin_sequencerActive", rpc_params![]).await;
+
+            if !matches!(result, Err(ClientError::Transport(_))) || attempt == 49 {
+                return result;
+            }
+
+            sleep(Duration::from_millis(10)).await;
+        }
+
+        unreachable!("request loop returns on the final attempt");
+    }
+
+    fn unused_loopback_addr() -> SocketAddr {
+        let listener = TcpListener::bind(SocketAddr::from(([127, 0, 0, 1], 0))).expect("bind port");
+        listener.local_addr().expect("local address")
     }
 }


### PR DESCRIPTION
## Summary
- gate consensus admin RPC registration on RpcBuilder::admin_enabled()
- add RPC actor regression coverage proving admin methods are not registered when the flag is disabled, even when admin channels are present

## Tests
- cargo fmt --check
- cargo test -p base-consensus-node actors::rpc::actor