### PR TITLE
fix(challenger): bound ZK proof sessions with explicit status handling and wall-clock timeout

### DIFF
--- a/crates/proof/challenge/src/cli.rs
+++ b/crates/proof/challenge/src/cli.rs
@@ -89,6 +89,16 @@ pub struct ChallengerArgs {
     )]
     pub zk_request_timeout: Duration,
 
+    /// Maximum wall-clock time to wait for a ZK proof session before treating it as failed and
+    /// retrying (e.g., "30m", "2h"). Should be set above the typical proof generation time.
+    #[arg(
+        long = "max-proof-duration",
+        env = cli_env!("MAX_PROOF_DURATION"),
+        default_value = "4h",
+        value_parser = humantime::parse_duration
+    )]
+    pub max_proof_duration: Duration,
+
     /// URL of the TEE enclave RPC endpoint (optional; enables TEE-first proof sourcing).
     #[arg(long = "tee-rpc-url", env = cli_env!("TEE_RPC_URL"))]
     pub tee_rpc_url: Option<Url>,

--- a/crates/proof/challenge/src/config.rs
+++ b/crates/proof/challenge/src/config.rs
@@ -307,6 +307,7 @@ mod tests {
     #[case::lookback_games("--lookback-games", "0", "lookback-games")]
     #[case::bond_discovery_interval("--bond-discovery-interval", "0s", "bond-discovery-interval")]
     #[case::anchor_update_retention("--anchor-update-retention", "0s", "anchor-update-retention")]
+    #[case::max_proof_duration("--max-proof-duration", "0s", "max-proof-duration")]
     fn test_zero_value_rejected(#[case] flag: &str, #[case] value: &str, #[case] field: &str) {
         let all_args = [&LOCAL_SIGNER_ARGS[..], &[flag, value]].concat();
         let cli = cli_from_args(&all_args);

--- a/crates/proof/challenge/src/config.rs
+++ b/crates/proof/challenge/src/config.rs
@@ -97,6 +97,8 @@ pub struct ChallengerConfig {
     pub zk_connect_timeout: Duration,
     /// Timeout for individual gRPC requests to the ZK proof service.
     pub zk_request_timeout: Duration,
+    /// Maximum wall-clock time to wait for a ZK proof session before treating it as failed.
+    pub max_proof_duration: Duration,
     /// URL of the TEE enclave RPC endpoint (optional).
     pub tee_rpc_url: Option<Validated<Url>>,
     /// Timeout for individual TEE proof requests (only `Some` when TEE is enabled).
@@ -174,6 +176,7 @@ impl ChallengerConfig {
         require_nonzero_duration(cli.challenger.poll_interval, "poll-interval")?;
         require_nonzero_duration(cli.challenger.zk_connect_timeout, "zk-connect-timeout")?;
         require_nonzero_duration(cli.challenger.zk_request_timeout, "zk-request-timeout")?;
+        require_nonzero_duration(cli.challenger.max_proof_duration, "max-proof-duration")?;
 
         let tee_request_timeout = if tee_rpc_url.is_some() {
             require_nonzero_duration(cli.challenger.tee_request_timeout, "tee-request-timeout")?;
@@ -216,6 +219,7 @@ impl ChallengerConfig {
             zk_rpc_url,
             zk_connect_timeout: cli.challenger.zk_connect_timeout,
             zk_request_timeout: cli.challenger.zk_request_timeout,
+            max_proof_duration: cli.challenger.max_proof_duration,
             tee_rpc_url,
             tee_request_timeout,
             signing,

--- a/crates/proof/challenge/src/driver.rs
+++ b/crates/proof/challenge/src/driver.rs
@@ -44,6 +44,8 @@ use crate::{
 pub struct DriverConfig {
     /// How often the driver polls for new games.
     pub poll_interval: Duration,
+    /// Maximum wall-clock time to wait for a ZK proof session before treating it as failed.
+    pub max_proof_duration: Duration,
     /// Cancellation token for graceful shutdown.
     pub cancel: CancellationToken,
 }
@@ -119,6 +121,8 @@ where
     pub bond_manager: Option<BondManager<C>>,
     /// Interval between polling cycles.
     pub poll_interval: Duration,
+    /// Maximum wall-clock time to wait for a ZK proof session before treating it as failed.
+    pub max_proof_duration: Duration,
     /// Token used to signal graceful shutdown.
     pub cancel: CancellationToken,
 }
@@ -137,8 +141,6 @@ impl<L2: L2Provider, P: ZkProofProvider, T: TxManager, C: Clock> std::fmt::Debug
 impl<L2: L2Provider, P: ZkProofProvider, T: TxManager, C: Clock> Driver<L2, P, T, C> {
     /// Maximum number of times a failed proof job will be retried before being dropped.
     pub const MAX_PROOF_RETRIES: u32 = 3;
-    /// Maximum wall-clock time to wait for a proof session before treating it as failed.
-    pub const MAX_PROOF_DURATION: Duration = Duration::from_secs(30 * 60);
 
     /// Creates a new driver with the given components.
     pub fn new(config: DriverConfig, components: DriverComponents<L2, P, T, C>) -> Self {
@@ -152,6 +154,7 @@ impl<L2: L2Provider, P: ZkProofProvider, T: TxManager, C: Clock> Driver<L2, P, T
             pending_proofs: PendingProofs::new(),
             bond_manager: components.bond_manager,
             poll_interval: config.poll_interval,
+            max_proof_duration: config.max_proof_duration,
             cancel: config.cancel,
         }
     }
@@ -699,8 +702,10 @@ impl<L2: L2Provider, P: ZkProofProvider, T: TxManager, C: Clock> Driver<L2, P, T
         // Poll proof status first — if still pending, skip the contract
         // calls that check game liveness. This avoids 3 RPC round-trips
         // per tick for proofs that are not yet ready.
-        let proof_update =
-            self.pending_proofs.poll(game_address, &*self.zk_prover, Self::MAX_PROOF_DURATION).await?;
+        let proof_update = self
+            .pending_proofs
+            .poll(game_address, &*self.zk_prover, self.max_proof_duration)
+            .await?;
         match &proof_update {
             Some(ProofUpdate::Pending) => {
                 debug!(game = %game_address, "proof not ready, will retry next tick");

--- a/crates/proof/challenge/src/driver.rs
+++ b/crates/proof/challenge/src/driver.rs
@@ -15,7 +15,10 @@
 //!    TEE proof first (`nullify()`), falling back to ZK `nullify()`.
 //!    After the TEE proof is nullified, the game is re-scanned as Path 3.
 
-use std::{sync::Arc, time::Duration};
+use std::{
+    sync::Arc,
+    time::{Duration, Instant},
+};
 
 use alloy_primitives::{Address, B256, Bytes};
 use base_proof_contracts::{AggregateVerifierClient, GameStatus};
@@ -134,6 +137,8 @@ impl<L2: L2Provider, P: ZkProofProvider, T: TxManager, C: Clock> std::fmt::Debug
 impl<L2: L2Provider, P: ZkProofProvider, T: TxManager, C: Clock> Driver<L2, P, T, C> {
     /// Maximum number of times a failed proof job will be retried before being dropped.
     pub const MAX_PROOF_RETRIES: u32 = 3;
+    /// Maximum wall-clock time to wait for a proof session before treating it as failed.
+    pub const MAX_PROOF_DURATION: Duration = Duration::from_secs(30 * 60);
 
     /// Creates a new driver with the given components.
     pub fn new(config: DriverConfig, components: DriverComponents<L2, P, T, C>) -> Self {
@@ -694,7 +699,8 @@ impl<L2: L2Provider, P: ZkProofProvider, T: TxManager, C: Clock> Driver<L2, P, T
         // Poll proof status first — if still pending, skip the contract
         // calls that check game liveness. This avoids 3 RPC round-trips
         // per tick for proofs that are not yet ready.
-        let proof_update = self.pending_proofs.poll(game_address, &*self.zk_prover).await?;
+        let proof_update =
+            self.pending_proofs.poll(game_address, &*self.zk_prover, Self::MAX_PROOF_DURATION).await?;
         match &proof_update {
             Some(ProofUpdate::Pending) => {
                 debug!(game = %game_address, "proof not ready, will retry next tick");
@@ -876,7 +882,10 @@ impl<L2: L2Provider, P: ZkProofProvider, T: TxManager, C: Clock> Driver<L2, P, T
                     "proof job re-initiated"
                 );
                 if let Some(p) = self.pending_proofs.get_mut(&game_address) {
-                    p.phase = ProofPhase::AwaitingProof { session_id: response.session_id };
+                    p.phase = ProofPhase::AwaitingProof {
+                        session_id: response.session_id,
+                        started_at: Instant::now(),
+                    };
                 }
             }
             Err(e) => {

--- a/crates/proof/challenge/src/pending.rs
+++ b/crates/proof/challenge/src/pending.rs
@@ -266,6 +266,22 @@ impl PendingProofs {
             }
         };
 
+        // Check the timeout before the RPC so persistent transport errors
+        // don't keep the entry pinned in `AwaitingProof`.
+        let elapsed = started_at.elapsed();
+        if elapsed > max_proof_duration {
+            let pending = self.0.get_mut(&game).expect("entry just inspected");
+            warn!(
+                game = %game,
+                elapsed = ?elapsed,
+                limit = ?max_proof_duration,
+                "proof session timed out, will retry"
+            );
+            pending.retry_count += 1;
+            pending.phase = ProofPhase::NeedsRetry;
+            return Ok(Some(ProofUpdate::NeedsRetry));
+        }
+
         let request =
             GetProofRequest { session_id, receipt_type: Some(ReceiptType::OnChainSnark as i32) };
 
@@ -296,20 +312,7 @@ impl PendingProofs {
                 ProofUpdate::NeedsRetry
             }
             Ok(ProofJobStatus::Created | ProofJobStatus::Pending | ProofJobStatus::Running) => {
-                let elapsed = started_at.elapsed();
-                if elapsed > max_proof_duration {
-                    warn!(
-                        game = %game,
-                        elapsed = ?elapsed,
-                        limit = ?max_proof_duration,
-                        "proof session timed out, will retry"
-                    );
-                    pending.retry_count += 1;
-                    pending.phase = ProofPhase::NeedsRetry;
-                    ProofUpdate::NeedsRetry
-                } else {
-                    ProofUpdate::Pending
-                }
+                ProofUpdate::Pending
             }
             Ok(ProofJobStatus::Unspecified) | Err(_) => {
                 warn!(raw_status = response.status, game = %game, "unexpected proof job status, treating as retryable failure");

--- a/crates/proof/challenge/src/pending.rs
+++ b/crates/proof/challenge/src/pending.rs
@@ -7,7 +7,10 @@
 //! Each entry also carries a [`DisputeIntent`] that determines whether the
 //! completed proof will be submitted via `challenge()` or `nullify()` on-chain.
 
-use std::{collections::HashMap, time::{Duration, Instant}};
+use std::{
+    collections::HashMap,
+    time::{Duration, Instant},
+};
 
 use alloy_primitives::{Address, B256, Bytes};
 use base_proof_primitives::PROOF_TYPE_ZK;
@@ -251,8 +254,10 @@ impl PendingProofs {
             None => return Ok(None),
         };
 
-        let session_id = match &pending.phase {
-            ProofPhase::AwaitingProof { session_id, .. } => session_id.clone(),
+        let (session_id, started_at) = match &pending.phase {
+            ProofPhase::AwaitingProof { session_id, started_at } => {
+                (session_id.clone(), *started_at)
+            }
             ProofPhase::ReadyToSubmit { proof_bytes } => {
                 return Ok(Some(ProofUpdate::Ready(proof_bytes.clone())));
             }
@@ -291,14 +296,14 @@ impl PendingProofs {
                 ProofUpdate::NeedsRetry
             }
             Ok(ProofJobStatus::Created | ProofJobStatus::Pending | ProofJobStatus::Running) => {
-                let timed_out =
-                    if let ProofPhase::AwaitingProof { started_at, .. } = &pending.phase {
-                        started_at.elapsed() > max_proof_duration
-                    } else {
-                        false
-                    };
-                if timed_out {
-                    warn!(game = %game, "proof session timed out, will retry");
+                let elapsed = started_at.elapsed();
+                if elapsed > max_proof_duration {
+                    warn!(
+                        game = %game,
+                        elapsed = ?elapsed,
+                        limit = ?max_proof_duration,
+                        "proof session timed out, will retry"
+                    );
                     pending.retry_count += 1;
                     pending.phase = ProofPhase::NeedsRetry;
                     ProofUpdate::NeedsRetry

--- a/crates/proof/challenge/src/pending.rs
+++ b/crates/proof/challenge/src/pending.rs
@@ -7,7 +7,7 @@
 //! Each entry also carries a [`DisputeIntent`] that determines whether the
 //! completed proof will be submitted via `challenge()` or `nullify()` on-chain.
 
-use std::collections::HashMap;
+use std::{collections::HashMap, time::{Duration, Instant}};
 
 use alloy_primitives::{Address, B256, Bytes};
 use base_proof_primitives::PROOF_TYPE_ZK;
@@ -74,6 +74,8 @@ pub enum ProofPhase {
     AwaitingProof {
         /// Session ID returned by the ZK proof service.
         session_id: String,
+        /// Wall-clock time at which the proof request was initiated.
+        started_at: Instant,
     },
     /// Proof obtained — receipt bytes are ready for nullification submission.
     ReadyToSubmit {
@@ -115,7 +117,7 @@ impl PendingProof {
     }
 
     /// Creates a new `PendingProof` in the `AwaitingProof` phase.
-    pub const fn awaiting(
+    pub fn awaiting(
         session_id: String,
         invalid_index: u64,
         expected_root: B256,
@@ -123,7 +125,7 @@ impl PendingProof {
         intent: DisputeIntent,
     ) -> Self {
         Self {
-            phase: ProofPhase::AwaitingProof { session_id },
+            phase: ProofPhase::AwaitingProof { session_id, started_at: Instant::now() },
             kind: ProofKind::Zk { prove_request },
             invalid_index,
             expected_root,
@@ -242,6 +244,7 @@ impl PendingProofs {
         &mut self,
         game: Address,
         zk_prover: &P,
+        max_proof_duration: Duration,
     ) -> eyre::Result<Option<ProofUpdate>> {
         let pending = match self.0.get(&game) {
             Some(p) => p,
@@ -249,7 +252,7 @@ impl PendingProofs {
         };
 
         let session_id = match &pending.phase {
-            ProofPhase::AwaitingProof { session_id } => session_id.clone(),
+            ProofPhase::AwaitingProof { session_id, .. } => session_id.clone(),
             ProofPhase::ReadyToSubmit { proof_bytes } => {
                 return Ok(Some(ProofUpdate::Ready(proof_bytes.clone())));
             }
@@ -288,7 +291,20 @@ impl PendingProofs {
                 ProofUpdate::NeedsRetry
             }
             Ok(ProofJobStatus::Created | ProofJobStatus::Pending | ProofJobStatus::Running) => {
-                ProofUpdate::Pending
+                let timed_out =
+                    if let ProofPhase::AwaitingProof { started_at, .. } = &pending.phase {
+                        started_at.elapsed() > max_proof_duration
+                    } else {
+                        false
+                    };
+                if timed_out {
+                    warn!(game = %game, "proof session timed out, will retry");
+                    pending.retry_count += 1;
+                    pending.phase = ProofPhase::NeedsRetry;
+                    ProofUpdate::NeedsRetry
+                } else {
+                    ProofUpdate::Pending
+                }
             }
             Ok(ProofJobStatus::Unspecified) | Err(_) => {
                 warn!(raw_status = response.status, game = %game, "unexpected proof job status, treating as retryable failure");

--- a/crates/proof/challenge/src/pending.rs
+++ b/crates/proof/challenge/src/pending.rs
@@ -262,10 +262,6 @@ impl PendingProofs {
             GetProofRequest { session_id, receipt_type: Some(ReceiptType::OnChainSnark as i32) };
 
         let response = zk_prover.get_proof(request).await?;
-        let status = ProofJobStatus::try_from(response.status).unwrap_or_else(|_| {
-            warn!(raw_status = response.status, game = %game, "unrecognized proof job status");
-            ProofJobStatus::Unspecified
-        });
 
         // Re-borrow after the await point.
         let pending = match self.0.get_mut(&game) {
@@ -273,8 +269,8 @@ impl PendingProofs {
             None => return Ok(None),
         };
 
-        let update = match status {
-            ProofJobStatus::Succeeded => {
+        let update = match ProofJobStatus::try_from(response.status) {
+            Ok(ProofJobStatus::Succeeded) => {
                 let mut raw = Vec::with_capacity(1 + response.receipt.len());
                 raw.push(PROOF_TYPE_ZK);
                 raw.extend_from_slice(&response.receipt);
@@ -285,13 +281,21 @@ impl PendingProofs {
 
                 update
             }
-            ProofJobStatus::Failed => {
+            Ok(ProofJobStatus::Failed) => {
                 warn!(game = %game, error_message = ?response.error_message, "proof job failed");
                 pending.retry_count += 1;
                 pending.phase = ProofPhase::NeedsRetry;
                 ProofUpdate::NeedsRetry
             }
-            _ => ProofUpdate::Pending,
+            Ok(ProofJobStatus::Created | ProofJobStatus::Pending | ProofJobStatus::Running) => {
+                ProofUpdate::Pending
+            }
+            Ok(ProofJobStatus::Unspecified) | Err(_) => {
+                warn!(raw_status = response.status, game = %game, "unexpected proof job status, treating as retryable failure");
+                pending.retry_count += 1;
+                pending.phase = ProofPhase::NeedsRetry;
+                ProofUpdate::NeedsRetry
+            }
         };
 
         Ok(Some(update))

--- a/crates/proof/challenge/src/service.rs
+++ b/crates/proof/challenge/src/service.rs
@@ -195,8 +195,11 @@ impl ChallengerService {
         };
 
         // ── 9. Run driver ────────────────────────────────────────────────────
-        let driver_config =
-            DriverConfig { poll_interval: config.poll_interval, cancel: cancel.child_token() };
+        let driver_config = DriverConfig {
+            poll_interval: config.poll_interval,
+            max_proof_duration: config.max_proof_duration,
+            cancel: cancel.child_token(),
+        };
         let driver = Driver::new(
             driver_config,
             DriverComponents {

--- a/crates/proof/challenge/tests/driver.rs
+++ b/crates/proof/challenge/tests/driver.rs
@@ -415,7 +415,8 @@ async fn test_step_pending_proof_skips_prove_block() {
 
     let mut driver = test_driver(factory, Arc::clone(&verifier), l2, Arc::clone(&zk), tx_manager);
 
-    // Step 1: proof is initiated but not ready (Unspecified) → session stored.
+    // Step 1: proof is initiated → session stored in AwaitingProof. The mock's
+    // proof_status is not polled this tick (pending_proofs is empty at poll time).
     driver.step().await.unwrap();
     assert!(
         driver.pending_proofs.contains_key(&addr(0)),

--- a/crates/proof/challenge/tests/driver.rs
+++ b/crates/proof/challenge/tests/driver.rs
@@ -81,8 +81,11 @@ fn test_driver_with_tee(
     let validator = OutputValidator::new(l2_provider);
     let submitter = ChallengeSubmitter::new(tx_manager);
 
-    let config =
-        DriverConfig { poll_interval: Duration::from_millis(10), cancel: CancellationToken::new() };
+    let config = DriverConfig {
+        poll_interval: Duration::from_millis(10),
+        max_proof_duration: Duration::from_secs(4 * 60 * 60),
+        cancel: CancellationToken::new(),
+    };
 
     Driver::new(
         config,
@@ -376,8 +379,11 @@ async fn test_step_scan_error_propagated() {
     let validator = OutputValidator::new(l2);
     let submitter = ChallengeSubmitter::new(default_tx_manager());
 
-    let config =
-        DriverConfig { poll_interval: Duration::from_millis(10), cancel: CancellationToken::new() };
+    let config = DriverConfig {
+        poll_interval: Duration::from_millis(10),
+        max_proof_duration: Duration::from_secs(4 * 60 * 60),
+        cancel: CancellationToken::new(),
+    };
 
     let mut driver = Driver::new(
         config,
@@ -1512,7 +1518,6 @@ async fn test_step_checkpoint_count_mismatch_surfaces_error() {
     );
 }
 
-// ── Fix A: unexpected status codes treated as retryable failures ──────────
 
 fn minimal_prove_request(session_id: &str) -> base_zk_client::ProveBlockRequest {
     base_zk_client::ProveBlockRequest {
@@ -1550,13 +1555,14 @@ async fn test_poll_unspecified_status_triggers_retry() {
     );
 
     let update = proofs.poll(addr(0), &*zk, Duration::from_secs(3600)).await.unwrap();
-    assert!(matches!(update, Some(ProofUpdate::NeedsRetry)), "Unspecified should trigger NeedsRetry");
+    assert!(
+        matches!(update, Some(ProofUpdate::NeedsRetry)),
+        "Unspecified should trigger NeedsRetry"
+    );
     let entry = proofs.get(&addr(0)).unwrap();
     assert_eq!(entry.retry_count, 1);
     assert!(matches!(entry.phase, ProofPhase::NeedsRetry));
 }
-
-// ── Fix B: wall-clock timeout on AwaitingProof ────────────────────────────
 
 #[tokio::test]
 async fn test_poll_running_within_timeout_stays_pending() {
@@ -1581,7 +1587,10 @@ async fn test_poll_running_within_timeout_stays_pending() {
     );
 
     let update = proofs.poll(addr(0), &*zk, Duration::from_secs(3600)).await.unwrap();
-    assert!(matches!(update, Some(ProofUpdate::Pending)), "Running within timeout should stay Pending");
+    assert!(
+        matches!(update, Some(ProofUpdate::Pending)),
+        "Running within timeout should stay Pending"
+    );
     let entry = proofs.get(&addr(0)).unwrap();
     assert_eq!(entry.retry_count, 0);
     assert!(matches!(entry.phase, ProofPhase::AwaitingProof { .. }));
@@ -1611,7 +1620,10 @@ async fn test_poll_running_timeout_triggers_retry() {
 
     // Zero timeout: already expired on the first poll.
     let update = proofs.poll(addr(0), &*zk, Duration::ZERO).await.unwrap();
-    assert!(matches!(update, Some(ProofUpdate::NeedsRetry)), "Timed-out Running should trigger NeedsRetry");
+    assert!(
+        matches!(update, Some(ProofUpdate::NeedsRetry)),
+        "Timed-out Running should trigger NeedsRetry"
+    );
     let entry = proofs.get(&addr(0)).unwrap();
     assert_eq!(entry.retry_count, 1);
     assert!(matches!(entry.phase, ProofPhase::NeedsRetry));

--- a/crates/proof/challenge/tests/driver.rs
+++ b/crates/proof/challenge/tests/driver.rs
@@ -9,8 +9,8 @@ use std::{
 use alloy_primitives::{Address, B256, Bytes};
 use base_challenger::{
     BondManager, ChallengeSubmitter, DisputeIntent, Driver, DriverComponents, DriverConfig,
-    GameScanner, L1HeadProvider, OutputValidator, PendingProof, ProofPhase, ScannerConfig,
-    TeeConfig,
+    GameScanner, L1HeadProvider, OutputValidator, PendingProof, PendingProofs, ProofPhase,
+    ProofUpdate, ScannerConfig, TeeConfig,
     test_utils::{
         DEFAULT_L1_HEAD, DEFAULT_TEE_PROVER, MockAggregateVerifier, MockBondTransactionSubmitter,
         MockDisputeGameFactory, MockGameState, MockL1HeadProvider, MockL2Provider,
@@ -1510,4 +1510,109 @@ async fn test_step_checkpoint_count_mismatch_surfaces_error() {
         "no proof should be initiated when checkpoint count mismatches — \
          the error should be surfaced, not silently swallowed"
     );
+}
+
+// ── Fix A: unexpected status codes treated as retryable failures ──────────
+
+fn minimal_prove_request(session_id: &str) -> base_zk_client::ProveBlockRequest {
+    base_zk_client::ProveBlockRequest {
+        start_block_number: 0,
+        number_of_blocks_to_prove: 1,
+        sequence_window: None,
+        proof_type: ProofType::SnarkGroth16.into(),
+        session_id: Some(session_id.to_string()),
+        prover_address: None,
+        l1_head: None,
+        intermediate_root_interval: None,
+    }
+}
+
+#[tokio::test]
+async fn test_poll_unspecified_status_triggers_retry() {
+    let zk = Arc::new(MockZkProofProvider {
+        session_id: "unspecified-session".to_string(),
+        state: Mutex::new(MockZkProofState {
+            proof_status: ProofJobStatus::Unspecified as i32,
+            ..Default::default()
+        }),
+    });
+
+    let mut proofs = PendingProofs::new();
+    proofs.insert(
+        addr(0),
+        PendingProof::awaiting(
+            "unspecified-session".to_string(),
+            0,
+            B256::ZERO,
+            minimal_prove_request("unspecified-session"),
+            DisputeIntent::Challenge,
+        ),
+    );
+
+    let update = proofs.poll(addr(0), &*zk, Duration::from_secs(3600)).await.unwrap();
+    assert!(matches!(update, Some(ProofUpdate::NeedsRetry)), "Unspecified should trigger NeedsRetry");
+    let entry = proofs.get(&addr(0)).unwrap();
+    assert_eq!(entry.retry_count, 1);
+    assert!(matches!(entry.phase, ProofPhase::NeedsRetry));
+}
+
+// ── Fix B: wall-clock timeout on AwaitingProof ────────────────────────────
+
+#[tokio::test]
+async fn test_poll_running_within_timeout_stays_pending() {
+    let zk = Arc::new(MockZkProofProvider {
+        session_id: "running-session".to_string(),
+        state: Mutex::new(MockZkProofState {
+            proof_status: ProofJobStatus::Running as i32,
+            ..Default::default()
+        }),
+    });
+
+    let mut proofs = PendingProofs::new();
+    proofs.insert(
+        addr(0),
+        PendingProof::awaiting(
+            "running-session".to_string(),
+            0,
+            B256::ZERO,
+            minimal_prove_request("running-session"),
+            DisputeIntent::Challenge,
+        ),
+    );
+
+    let update = proofs.poll(addr(0), &*zk, Duration::from_secs(3600)).await.unwrap();
+    assert!(matches!(update, Some(ProofUpdate::Pending)), "Running within timeout should stay Pending");
+    let entry = proofs.get(&addr(0)).unwrap();
+    assert_eq!(entry.retry_count, 0);
+    assert!(matches!(entry.phase, ProofPhase::AwaitingProof { .. }));
+}
+
+#[tokio::test]
+async fn test_poll_running_timeout_triggers_retry() {
+    let zk = Arc::new(MockZkProofProvider {
+        session_id: "stuck-session".to_string(),
+        state: Mutex::new(MockZkProofState {
+            proof_status: ProofJobStatus::Running as i32,
+            ..Default::default()
+        }),
+    });
+
+    let mut proofs = PendingProofs::new();
+    proofs.insert(
+        addr(0),
+        PendingProof::awaiting(
+            "stuck-session".to_string(),
+            0,
+            B256::ZERO,
+            minimal_prove_request("stuck-session"),
+            DisputeIntent::Challenge,
+        ),
+    );
+
+    // Zero timeout: already expired on the first poll.
+    let update = proofs.poll(addr(0), &*zk, Duration::ZERO).await.unwrap();
+    assert!(matches!(update, Some(ProofUpdate::NeedsRetry)), "Timed-out Running should trigger NeedsRetry");
+    let entry = proofs.get(&addr(0)).unwrap();
+    assert_eq!(entry.retry_count, 1);
+    assert!(matches!(entry.phase, ProofPhase::NeedsRetry));
 }

--- a/crates/proof/challenge/tests/driver.rs
+++ b/crates/proof/challenge/tests/driver.rs
@@ -1519,7 +1519,6 @@ async fn test_step_checkpoint_count_mismatch_surfaces_error() {
     );
 }
 
-
 fn minimal_prove_request(session_id: &str) -> base_zk_client::ProveBlockRequest {
     base_zk_client::ProveBlockRequest {
         start_block_number: 0,


### PR DESCRIPTION
## Problem

`PendingProofs::poll` dispatched any non-Succeeded/non-Failed ZK prover status to a `_ => ProofUpdate::Pending` catch-all. The driver short-circuits on `Pending` without incrementing `retry_count`, changing the phase, or applying any timeout. Combined with the `process_candidate` skip-if-pending guard, any game whose proof session got stuck returned `Pending` indefinitely, making that game non-challengeable for the lifetime of the process.

Two concrete triggers:
- The ZK prover loses its session (crash, restart) and responds `STATUS_UNSPECIFIED` or a gRPC error.
- A future proto status code (e.g. `STATUS_CANCELLED = 6`) added before the Rust client is rebuilt: `try_from` returns `Err`, silently remapped to `Unspecified`, then caught by `_`.

## Fix

**Exhaustive status dispatch**

Replace `_ => ProofUpdate::Pending` with an explicit match on `ProofJobStatus::try_from(response.status)`:
- `Created | Pending | Running` -> `ProofUpdate::Pending` (legitimate intermediate states)
- `Unspecified | Err(_)` -> `NeedsRetry` (server-side error, treated as retryable failure)

Any future unknown status code now surfaces as `Err(_)` and flows into the bounded retry path instead of stalling forever.

**Wall-clock timeout on `AwaitingProof`**

`ProofPhase::AwaitingProof` now carries a `started_at: Instant`. On each poll, if `elapsed() > max_proof_duration` the entry transitions to `NeedsRetry`. The timeout check runs **before** the `get_proof` RPC so persistent transport errors (prover crashed/unreachable) can no longer keep the entry pinned in `AwaitingProof` indefinitely; the same bound applies whether the RPC fails or returns a stuck intermediate status.

The timeout is configurable via `--max-proof-duration` (env `CHALLENGER_MAX_PROOF_DURATION`, default `4h`). Zero values are rejected at startup.

## Files changed

- `src/pending.rs`: exhaustive match, `started_at` field, timeout check before RPC, `max_proof_duration` parameter on `poll`
- `src/driver.rs`: `max_proof_duration` field on `Driver` and `DriverConfig`, updated `poll` call site
- `src/cli.rs`: `--max-proof-duration` flag (default `4h`)
- `src/config.rs`: `max_proof_duration` in `ChallengerConfig`, zero-value rejection
- `src/service.rs`: wires `max_proof_duration` into `DriverConfig`

## Tests

New tests in `tests/driver.rs`:
- `test_poll_unspecified_status_triggers_retry`: `Unspecified` response increments `retry_count` and transitions to `NeedsRetry`
- `test_poll_running_within_timeout_stays_pending`: `Running` within timeout stays `Pending`
- `test_poll_running_timeout_triggers_retry`: timeout fires before the RPC, transitioning to `NeedsRetry`
- `test_max_proof_duration_zero_rejected`: zero `--max-proof-duration` is rejected at config validation
