### PR TITLE
fix(nitro): cap vsock frame size at 512 MiB

### DIFF
--- a/crates/proof/tee/nitro-enclave/src/transport.rs
+++ b/crates/proof/tee/nitro-enclave/src/transport.rs
@@ -17,6 +17,18 @@ pub enum TransportError {
     /// Serialization or deserialization of a message failed.
     #[error("codec error: {0}")]
     Codec(String),
+
+    /// A frame exceeded [`Frame::MAX_FRAME_BYTES`].
+    ///
+    /// Raised before any backing buffer is allocated to prevent a malicious or
+    /// buggy peer from forcing a multi-gigabyte allocation inside the enclave.
+    #[error("frame too large: {len} bytes exceeds limit of {limit} bytes")]
+    FrameTooLarge {
+        /// Length declared by the peer (or computed locally for writes).
+        len: usize,
+        /// Hard cap enforced by the codec.
+        limit: usize,
+    },
 }
 
 /// Maximum bytes per individual `write()` syscall on vsock.
@@ -40,10 +52,28 @@ const MAX_WRITE_SIZE: usize = 28 * 1024;
 ///
 /// Writes are throttled to [`MAX_WRITE_SIZE`]-byte segments to avoid
 /// triggering a Linux kernel vsock corruption bug.
+///
+/// Both reads and writes are bounded by [`Frame::MAX_FRAME_BYTES`] so that a
+/// malicious or buggy peer cannot force the enclave (which has a fixed shared
+/// memory budget) to allocate a multi-gigabyte buffer up front.
 #[derive(Debug, Clone, Copy)]
 pub struct Frame;
 
 impl Frame {
+    /// Maximum length, in bytes, of a single bincode frame payload.
+    ///
+    /// The Nitro Enclave is configured with an 8 `GiB` shared memory pool
+    /// (`etc/docker/nitro-enclave/allocator.yaml`). Each in-flight `Prove`
+    /// request consumes roughly `2 * payload_bytes` (one copy in the read
+    /// buffer, one in the bincode-decoded owned values), so an unchecked peer
+    /// could fill the pool with a single ~4 `GiB` frame and OOM-kill the
+    /// enclave — taking every concurrent proving job down with it.
+    ///
+    /// 512 `MiB` comfortably covers honest `Prove` payloads (preimage bundles
+    /// are typically tens of `MiB`) while leaving ample headroom for several
+    /// concurrent jobs to coexist after the 2x decode amplification.
+    pub const MAX_FRAME_BYTES: usize = 512 * 1024 * 1024;
+
     /// Write a value as a length-prefixed bincode frame.
     pub async fn write<T: serde::Serialize>(
         writer: &mut (impl AsyncWriteExt + Unpin),
@@ -51,6 +81,13 @@ impl Frame {
     ) -> TransportResult<()> {
         let payload = bincode::serde::encode_to_vec(value, bincode::config::standard())
             .map_err(|e| TransportError::Codec(e.to_string()))?;
+
+        if payload.len() > Self::MAX_FRAME_BYTES {
+            return Err(TransportError::FrameTooLarge {
+                len: payload.len(),
+                limit: Self::MAX_FRAME_BYTES,
+            });
+        }
 
         let len = u32::try_from(payload.len())
             .map_err(|_| TransportError::Codec("payload exceeds u32::MAX".into()))?;
@@ -67,13 +104,17 @@ impl Frame {
 
     /// Read a value from a length-prefixed bincode frame.
     ///
-    /// The peer-supplied length can be up to `u32::MAX` (~4 `GiB`). This is safe
-    /// because all transport peers are local (enclave ↔ host over vsock) and
-    /// witness bundles can legitimately be very large.
+    /// Frames larger than [`Self::MAX_FRAME_BYTES`] are rejected before any
+    /// payload buffer is allocated, so a hostile peer cannot trigger an OOM
+    /// inside the enclave by advertising a giant length prefix.
     pub async fn read<T: serde::de::DeserializeOwned>(
         reader: &mut (impl AsyncReadExt + Unpin),
     ) -> TransportResult<T> {
         let len = reader.read_u32().await? as usize;
+
+        if len > Self::MAX_FRAME_BYTES {
+            return Err(TransportError::FrameTooLarge { len, limit: Self::MAX_FRAME_BYTES });
+        }
 
         debug!(payload_bytes = len, "frame read start");
 
@@ -95,5 +136,57 @@ impl Frame {
             writer.write_all(chunk).await?;
         }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Cursor;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn round_trip_small_frame() {
+        let mut buf = Vec::new();
+        Frame::write(&mut buf, &"hello".to_string()).await.expect("write");
+
+        let mut reader = Cursor::new(buf);
+        let value: String = Frame::read(&mut reader).await.expect("read");
+        assert_eq!(value, "hello");
+    }
+
+    #[tokio::test]
+    async fn read_rejects_oversized_frame_without_allocating() {
+        // Encode a length prefix one byte over the cap and no body. The reader
+        // must reject before attempting `vec![0u8; len]`, otherwise this test
+        // would request a multi-hundred-MiB allocation purely to confirm the
+        // cap exists.
+        let oversized = u32::try_from(Frame::MAX_FRAME_BYTES + 1).expect("fits in u32");
+        let bytes = oversized.to_be_bytes().to_vec();
+        let mut reader = Cursor::new(bytes);
+
+        let err = Frame::read::<Vec<u8>>(&mut reader).await.expect_err("must reject");
+        match err {
+            TransportError::FrameTooLarge { len, limit } => {
+                assert_eq!(len, Frame::MAX_FRAME_BYTES + 1);
+                assert_eq!(limit, Frame::MAX_FRAME_BYTES);
+            }
+            other => panic!("expected FrameTooLarge, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn read_accepts_max_sized_length_prefix_with_real_payload() {
+        // Boundary check: a length exactly at the cap is allowed by the size
+        // gate. We exercise that gate by writing a small payload using a
+        // length prefix that is at the limit, then truncating the read so we
+        // do not actually allocate 512 MiB. We assert the failure mode is the
+        // expected short-read I/O error rather than `FrameTooLarge`.
+        let at_limit = u32::try_from(Frame::MAX_FRAME_BYTES).expect("fits in u32");
+        let bytes = at_limit.to_be_bytes().to_vec();
+        let mut reader = Cursor::new(bytes);
+
+        let err = Frame::read::<Vec<u8>>(&mut reader).await.expect_err("short read");
+        assert!(matches!(err, TransportError::Io(_)), "expected short-read I/O error, got {err:?}");
     }
 }

--- a/crates/proof/tee/nitro-host/src/vsock.rs
+++ b/crates/proof/tee/nitro-host/src/vsock.rs
@@ -2,7 +2,7 @@ use std::time::Duration;
 
 use base_proof_preimage::PreimageKey;
 use base_proof_primitives::ProofResult;
-use base_proof_tee_nitro_enclave::{EnclaveRequest, EnclaveResponse, Frame};
+use base_proof_tee_nitro_enclave::{EnclaveRequest, EnclaveResponse, Frame, TransportError};
 use tokio_vsock::{VsockAddr, VsockStream};
 use tracing::info;
 
@@ -51,6 +51,18 @@ impl VsockTransport {
             port = self.port,
             "sending prove request to enclave"
         );
+
+        // Cheap pre-flight check: the encoded frame is necessarily larger than
+        // the sum of preimage values (which dominate the wire size). Refusing
+        // to dial the enclave at all when we already know the frame will be
+        // rejected avoids a wasted vsock round trip and a multi-hundred-MiB
+        // bincode allocation on the host.
+        if total_value_bytes > Frame::MAX_FRAME_BYTES {
+            return Err(NitroHostError::FrameWrite(TransportError::FrameTooLarge {
+                len: total_value_bytes,
+                limit: Frame::MAX_FRAME_BYTES,
+            }));
+        }
 
         let mut stream = self.connect().await?;
 


### PR DESCRIPTION
## Summary
- `Frame::read` in the Nitro enclave's vsock transport trusted the peer-supplied length prefix (up to `u32::MAX` ≈ 4 GiB) and pre-allocated the buffer before any validation. Combined with the enclave's 8 GiB shared memory pool and ~2× decode amplification, a single oversized frame — or a few concurrent honest-but-large `Prove` payloads — could OOM the entire enclave process and drop every in-flight proving job.
- Reject frames over `MAX_FRAME_BYTES` (512 MiB) on both read and write paths, before any backing buffer is allocated. 512 MiB comfortably covers honest preimage bundles (typically tens of MiB) while leaving headroom for several concurrent jobs.
- Note: broader admission-control / per-phase memory budget across concurrent proof jobs is left as a follow-up — this PR closes the entry-point vector at the codec.