### PR TITLE
fix(challenger): signal readiness after init 

### DIFF
--- a/crates/proof/challenge/src/driver.rs
+++ b/crates/proof/challenge/src/driver.rs
@@ -15,13 +15,7 @@
 //!    TEE proof first (`nullify()`), falling back to ZK `nullify()`.
 //!    After the TEE proof is nullified, the game is re-scanned as Path 3.
 
-use std::{
-    sync::{
-        Arc,
-        atomic::{AtomicBool, Ordering},
-    },
-    time::Duration,
-};
+use std::{sync::Arc, time::Duration};
 
 use alloy_primitives::{Address, B256, Bytes};
 use base_proof_contracts::AggregateVerifierClient;
@@ -49,8 +43,6 @@ pub struct DriverConfig {
     pub poll_interval: Duration,
     /// Cancellation token for graceful shutdown.
     pub cancel: CancellationToken,
-    /// Shared flag flipped to `true` after the first successful driver step.
-    pub ready: Arc<AtomicBool>,
 }
 
 /// TEE proof configuration, bundling the provider and L1 head provider.
@@ -126,8 +118,6 @@ where
     pub poll_interval: Duration,
     /// Token used to signal graceful shutdown.
     pub cancel: CancellationToken,
-    /// Indicates whether the driver has completed its first scan.
-    pub ready: Arc<AtomicBool>,
 }
 
 impl<L2: L2Provider, P: ZkProofProvider, T: TxManager, C: Clock> std::fmt::Debug
@@ -158,31 +148,20 @@ impl<L2: L2Provider, P: ZkProofProvider, T: TxManager, C: Clock> Driver<L2, P, T
             bond_manager: components.bond_manager,
             poll_interval: config.poll_interval,
             cancel: config.cancel,
-            ready: config.ready,
         }
     }
 
     /// Runs the main driver loop until the cancellation token is fired.
     pub async fn run(mut self) {
         info!("challenger driver starting");
-        let mut signalled_ready = false;
         loop {
             if self.cancel.is_cancelled() {
                 info!("challenger driver shutting down");
                 break;
             }
 
-            match self.step().await {
-                Ok(()) => {
-                    if !signalled_ready {
-                        signalled_ready = true;
-                        self.ready.store(true, Ordering::SeqCst);
-                        info!("service is ready");
-                    }
-                }
-                Err(e) => {
-                    warn!(error = %e, "driver step failed");
-                }
+            if let Err(e) = self.step().await {
+                warn!(error = %e, "driver step failed");
             }
 
             ChallengerMetrics::pending_proofs().set(self.pending_proofs.len() as f64);

--- a/crates/proof/challenge/src/service.rs
+++ b/crates/proof/challenge/src/service.rs
@@ -195,11 +195,8 @@ impl ChallengerService {
         };
 
         // ── 9. Run driver ────────────────────────────────────────────────────
-        let driver_config = DriverConfig {
-            poll_interval: config.poll_interval,
-            cancel: cancel.child_token(),
-            ready: Arc::clone(&ready),
-        };
+        let driver_config =
+            DriverConfig { poll_interval: config.poll_interval, cancel: cancel.child_token() };
         let driver = Driver::new(
             driver_config,
             DriverComponents {
@@ -212,6 +209,11 @@ impl ChallengerService {
                 bond_manager,
             },
         );
+
+        // Signal readiness immediately after initialization — the driver loop
+        // itself is purely operational work that should not gate readiness probes.
+        ready.store(true, Ordering::SeqCst);
+        info!("service is ready");
 
         // Drop guard ensures child tasks are cancelled even if the driver panics.
         let cancel_guard = cancel.clone().drop_guard();

--- a/crates/proof/challenge/tests/driver.rs
+++ b/crates/proof/challenge/tests/driver.rs
@@ -2,7 +2,7 @@
 
 use std::{
     collections::HashMap,
-    sync::{Arc, Mutex, atomic::AtomicBool},
+    sync::{Arc, Mutex},
     time::Duration,
 };
 
@@ -81,11 +81,8 @@ fn test_driver_with_tee(
     let validator = OutputValidator::new(l2_provider);
     let submitter = ChallengeSubmitter::new(tx_manager);
 
-    let config = DriverConfig {
-        poll_interval: Duration::from_millis(10),
-        cancel: CancellationToken::new(),
-        ready: Arc::new(AtomicBool::new(false)),
-    };
+    let config =
+        DriverConfig { poll_interval: Duration::from_millis(10), cancel: CancellationToken::new() };
 
     Driver::new(
         config,
@@ -376,11 +373,8 @@ async fn test_step_scan_error_propagated() {
     let validator = OutputValidator::new(l2);
     let submitter = ChallengeSubmitter::new(default_tx_manager());
 
-    let config = DriverConfig {
-        poll_interval: Duration::from_millis(10),
-        cancel: CancellationToken::new(),
-        ready: Arc::new(AtomicBool::new(false)),
-    };
+    let config =
+        DriverConfig { poll_interval: Duration::from_millis(10), cancel: CancellationToken::new() };
 
     let mut driver = Driver::new(
         config,


### PR DESCRIPTION
`Scanner.scan()` takes 175-260s in production, exceeding the k8s startup probe window. To address this, we move `ready=true` before the driver loop.