### PR TITLE
fix(proposer): refresh recovery after invalid parent failures

### DIFF
--- a/crates/proof/contracts/src/aggregate_verifier.rs
+++ b/crates/proof/contracts/src/aggregate_verifier.rs
@@ -26,6 +26,10 @@ sol! {
         /// Error returned when the proof's L1 origin is older than the EIP-2935 history window.
         error L1OriginTooOld(uint256 l1OriginNumber, uint256 currentBlock);
 
+        /// Error returned by `initialize` when the parent game is unregistered,
+        /// unrespected, blacklisted, retired, or resolved as `CHALLENGER_WINS`.
+        error InvalidParentGame();
+
         /// Returns the root claim (output root) of this game.
         function rootClaim() external pure returns (bytes32);
 
@@ -295,6 +299,11 @@ pub trait AggregateVerifierClient: Send + Sync {
 /// The 4-byte selector for `L1OriginTooOld()`.
 pub const fn l1_origin_too_old_selector() -> [u8; 4] {
     IAggregateVerifier::L1OriginTooOld::SELECTOR
+}
+
+/// The 4-byte selector for `InvalidParentGame()`.
+pub const fn invalid_parent_game_selector() -> [u8; 4] {
+    IAggregateVerifier::InvalidParentGame::SELECTOR
 }
 
 /// Concrete implementation backed by Alloy's sol-generated contract bindings.
@@ -836,6 +845,14 @@ mod tests {
         let selector = l1_origin_too_old_selector();
         assert_eq!(selector.len(), 4);
         assert_ne!(selector, [0u8; 4]);
+    }
+
+    #[test]
+    fn test_invalid_parent_game_selector() {
+        let selector = invalid_parent_game_selector();
+        assert_eq!(selector.len(), 4);
+        assert_ne!(selector, [0u8; 4]);
+        assert_ne!(selector, l1_origin_too_old_selector());
     }
 
     #[test]

--- a/crates/proof/contracts/src/lib.rs
+++ b/crates/proof/contracts/src/lib.rs
@@ -10,7 +10,7 @@ mod aggregate_verifier;
 pub use aggregate_verifier::{
     AggregateVerifierClient, AggregateVerifierContractClient, GameInfo, GameStatus,
     encode_challenge_calldata, encode_claim_credit_calldata, encode_nullify_calldata,
-    encode_resolve_calldata, l1_origin_too_old_selector,
+    encode_resolve_calldata, invalid_parent_game_selector, l1_origin_too_old_selector,
 };
 
 mod delayed_weth;

--- a/crates/proof/proposer/src/driver.rs
+++ b/crates/proof/proposer/src/driver.rs
@@ -73,7 +73,7 @@ impl Default for DriverConfig {
 ///
 /// This is either a game found in the `DisputeGameFactory` or the
 /// anchor root from the `AnchorStateRegistry` when no games exist.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct RecoveredState {
     /// Proxy address of the parent game, or the `AnchorStateRegistry` address
     /// when creating the first game from anchor state (no parent game exists).

--- a/crates/proof/proposer/src/error.rs
+++ b/crates/proof/proposer/src/error.rs
@@ -30,6 +30,10 @@ pub enum ProposerError {
     #[error("l1 origin too old")]
     L1OriginTooOld,
 
+    /// The parent game is no longer valid on-chain (`AggregateVerifier.InvalidParentGame()`).
+    #[error("invalid parent game")]
+    InvalidParentGame,
+
     /// Configuration error.
     #[error("config error: {0}")]
     Config(String),
@@ -62,6 +66,8 @@ impl ProposerError {
     pub const ERROR_TYPE_GAME_ALREADY_EXISTS: &str = "game_already_exists";
     /// Metric label for stale L1 origin errors.
     pub const ERROR_TYPE_L1_ORIGIN_TOO_OLD: &str = "l1_origin_too_old";
+    /// Metric label for invalid parent game rejections.
+    pub const ERROR_TYPE_INVALID_PARENT_GAME: &str = "invalid_parent_game";
 
     /// Returns true if this error indicates the game already exists.
     pub const fn is_game_already_exists(&self) -> bool {
@@ -73,6 +79,11 @@ impl ProposerError {
         matches!(self, Self::L1OriginTooOld)
     }
 
+    /// Returns true if this error indicates the parent game is no longer valid on-chain.
+    pub const fn is_invalid_parent_game(&self) -> bool {
+        matches!(self, Self::InvalidParentGame)
+    }
+
     /// Returns the metrics label for this error variant.
     pub const fn metric_label(&self) -> &'static str {
         match self {
@@ -82,6 +93,7 @@ impl ProposerError {
             Self::TxReverted(_) => Self::ERROR_TYPE_TX_REVERTED,
             Self::GameAlreadyExists => Self::ERROR_TYPE_GAME_ALREADY_EXISTS,
             Self::L1OriginTooOld => Self::ERROR_TYPE_L1_ORIGIN_TOO_OLD,
+            Self::InvalidParentGame => Self::ERROR_TYPE_INVALID_PARENT_GAME,
             Self::Config(_) => Self::ERROR_TYPE_CONFIG,
             Self::Internal(_) => Self::ERROR_TYPE_INTERNAL,
             Self::TxManager(_) => Self::ERROR_TYPE_TX_MANAGER,

--- a/crates/proof/proposer/src/output_proposer.rs
+++ b/crates/proof/proposer/src/output_proposer.rs
@@ -8,7 +8,7 @@ use alloy_primitives::{Address, B256, U256};
 use async_trait::async_trait;
 use base_proof_contracts::{
     encode_create_calldata, encode_extra_data, game_already_exists_selector,
-    l1_origin_too_old_selector,
+    invalid_parent_game_selector, l1_origin_too_old_selector,
 };
 use base_proof_primitives::Proposal;
 use base_tx_manager::{TxCandidate, TxManager, TxManagerError};
@@ -18,6 +18,7 @@ use crate::error::ProposerError;
 
 const GAME_ALREADY_EXISTS: &str = "GameAlreadyExists";
 const L1_ORIGIN_TOO_OLD: &str = "L1OriginTooOld";
+const INVALID_PARENT_GAME: &str = "InvalidParentGame";
 
 /// Classifies a [`TxManagerError`] into a [`ProposerError`].
 ///
@@ -27,6 +28,7 @@ const L1_ORIGIN_TOO_OLD: &str = "L1OriginTooOld";
 fn classify_tx_manager_error(err: TxManagerError) -> ProposerError {
     let game_exists_selector = game_already_exists_selector();
     let l1_origin_selector = l1_origin_too_old_selector();
+    let invalid_parent_selector = invalid_parent_game_selector();
 
     if let TxManagerError::ExecutionReverted { ref reason, ref data } = err {
         if reason.as_deref().is_some_and(|r| r.contains(GAME_ALREADY_EXISTS)) {
@@ -41,6 +43,12 @@ fn classify_tx_manager_error(err: TxManagerError) -> ProposerError {
         if data.as_ref().is_some_and(|d| d.starts_with(&l1_origin_selector)) {
             return ProposerError::L1OriginTooOld;
         }
+        if reason.as_deref().is_some_and(|r| r.contains(INVALID_PARENT_GAME)) {
+            return ProposerError::InvalidParentGame;
+        }
+        if data.as_ref().is_some_and(|d| d.starts_with(&invalid_parent_selector)) {
+            return ProposerError::InvalidParentGame;
+        }
         return ProposerError::TxManager(err);
     }
 
@@ -54,6 +62,11 @@ fn classify_tx_manager_error(err: TxManagerError) -> ProposerError {
         || msg.contains(L1_ORIGIN_TOO_OLD)
     {
         return ProposerError::L1OriginTooOld;
+    }
+    if msg.contains(&alloy_primitives::hex::encode(invalid_parent_selector))
+        || msg.contains(INVALID_PARENT_GAME)
+    {
+        return ProposerError::InvalidParentGame;
     }
     ProposerError::TxManager(err)
 }
@@ -354,6 +367,7 @@ mod tests {
     enum ExpectedClassification {
         GameAlreadyExists,
         L1OriginTooOld,
+        InvalidParentGame,
         TxManager,
     }
 
@@ -414,6 +428,32 @@ mod tests {
         ExpectedClassification::L1OriginTooOld,
         "L1OriginTooOld raw data contains selector"
     )]
+    #[case::rpc_with_invalid_parent_selector_hex(
+        TxManagerError::Rpc(format!("execution reverted: 0x{}", alloy_primitives::hex::encode(base_proof_contracts::invalid_parent_game_selector()))),
+        ExpectedClassification::InvalidParentGame,
+        "InvalidParentGame selector hex in Rpc message"
+    )]
+    #[case::rpc_with_invalid_parent_name(
+        TxManagerError::Rpc(format!("{INVALID_PARENT_GAME}()")),
+        ExpectedClassification::InvalidParentGame,
+        "InvalidParentGame name in Rpc message"
+    )]
+    #[case::reverted_with_invalid_parent_reason(
+        TxManagerError::ExecutionReverted {
+            reason: Some(format!("{INVALID_PARENT_GAME}()")),
+            data: None,
+        },
+        ExpectedClassification::InvalidParentGame,
+        "InvalidParentGame reason string contains name"
+    )]
+    #[case::reverted_with_invalid_parent_selector_data(
+        TxManagerError::ExecutionReverted {
+            reason: None,
+            data: Some(Bytes::from(base_proof_contracts::invalid_parent_game_selector().to_vec())),
+        },
+        ExpectedClassification::InvalidParentGame,
+        "InvalidParentGame raw data contains selector"
+    )]
     #[case::reverted_other_error(
         TxManagerError::ExecutionReverted {
             reason: Some("SomeOtherError()".to_string()),
@@ -442,6 +482,10 @@ mod tests {
                 matches!(result, ProposerError::L1OriginTooOld),
                 "{scenario}: expected L1OriginTooOld, got {result:?}"
             ),
+            ExpectedClassification::InvalidParentGame => assert!(
+                matches!(result, ProposerError::InvalidParentGame),
+                "{scenario}: expected InvalidParentGame, got {result:?}"
+            ),
             ExpectedClassification::TxManager => assert!(
                 matches!(result, ProposerError::TxManager(_)),
                 "{scenario}: expected TxManager, got {result:?}"
@@ -461,5 +505,14 @@ mod tests {
     #[case::other_error(ProposerError::Contract("other".into()), false)]
     fn test_is_l1_origin_too_old(#[case] err: ProposerError, #[case] expected: bool) {
         assert_eq!(err.is_l1_origin_too_old(), expected);
+    }
+
+    #[rstest]
+    #[case::invalid_parent_game(ProposerError::InvalidParentGame, true)]
+    #[case::game_already_exists(ProposerError::GameAlreadyExists, false)]
+    #[case::l1_origin_too_old(ProposerError::L1OriginTooOld, false)]
+    #[case::other_error(ProposerError::Contract("other".into()), false)]
+    fn test_is_invalid_parent_game(#[case] err: ProposerError, #[case] expected: bool) {
+        assert_eq!(err.is_invalid_parent_game(), expected);
     }
 }

--- a/crates/proof/proposer/src/pipeline.rs
+++ b/crates/proof/proposer/src/pipeline.rs
@@ -584,6 +584,10 @@ where
                 );
                 state.proved.insert(target_block, proof);
                 state.submitting = None;
+                // Drop cached recovery so the next tick re-walks from
+                // anchor. A submit failure may indicate the cached parent
+                // is no longer valid on-chain
+                state.cached_recovery = None;
                 state.record_gauges();
                 false
             }
@@ -2284,6 +2288,46 @@ mod tests {
 
         state.reset();
         assert!(state.cached_recovery.is_none(), "reset() should clear cached_recovery");
+    }
+
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn test_failed_submission_clears_cached_recovery() {
+        let pipeline =
+            recovery_pipeline(MockDisputeGameFactory::with_games(vec![]), HashMap::new());
+        let target_block = TEST_BLOCK_INTERVAL;
+        let proposal = test_proposal(target_block);
+        let proof =
+            ProofResult::Tee { aggregate_proposal: proposal.clone(), proposals: vec![proposal] };
+
+        let mut state = PipelineState::new();
+        state.submitting = Some(target_block);
+        state.cached_recovery = Some(CachedRecovery {
+            game_count: 1,
+            state: RecoveredState {
+                parent_address: proxy_addr(0),
+                output_root: B256::repeat_byte(0x01),
+                l2_block_number: target_block,
+            },
+        });
+
+        let chain_next = pipeline
+            .handle_submit_result(
+                Ok(SubmitOutcome::Failed {
+                    target_block,
+                    proof,
+                    error: ProposerError::Contract("mock submission failure".into()),
+                }),
+                &mut state,
+            )
+            .await;
+
+        assert!(!chain_next, "failed submission should not chain another submit");
+        assert!(
+            state.cached_recovery.is_none(),
+            "failed submission must drop cached recovery so next tick re-walks fresh"
+        );
+        assert!(state.proved.contains_key(&target_block), "proof should be re-queued for retry");
+        assert!(state.submitting.is_none(), "submitting slot should be released");
     }
 
     // ---- Intermediate output root validation (submission) tests ----

--- a/crates/proof/proposer/src/pipeline.rs
+++ b/crates/proof/proposer/src/pipeline.rs
@@ -84,7 +84,7 @@ pub struct PipelineConfig {
 /// - No cache exists (cold start / pipeline reset).
 /// - The anchor advanced past the cached tip (governance intervention).
 /// - `game_count` decreased (L1 reorg removed games).
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct CachedRecovery {
     /// Factory `game_count` at the time of the last walk.
     game_count: u64,
@@ -577,17 +577,22 @@ where
             }
             SubmitOutcome::Failed { target_block, proof, error } => {
                 Metrics::errors_total(error.metric_label()).increment(1);
-                warn!(
-                    error = %error,
-                    target_block,
-                    "Submission failed, will retry"
-                );
+                // Drop the cache only when the contract explicitly reports
+                // the parent is no longer valid; transient failures (RPC,
+                // gas/nonce, signing) leave it intact to avoid an
+                // unnecessary forward walk on the next tick.
+                if error.is_invalid_parent_game() {
+                    warn!(
+                        error = %error,
+                        target_block,
+                        "Submission rejected: parent game invalid, dropping recovery cache"
+                    );
+                    state.cached_recovery = None;
+                } else {
+                    warn!(error = %error, target_block, "Submission failed, will retry");
+                }
                 state.proved.insert(target_block, proof);
                 state.submitting = None;
-                // Drop cached recovery so the next tick re-walks from
-                // anchor. A submit failure may indicate the cached parent
-                // is no longer valid on-chain
-                state.cached_recovery = None;
                 state.record_gauges();
                 false
             }
@@ -2290,8 +2295,9 @@ mod tests {
         assert!(state.cached_recovery.is_none(), "reset() should clear cached_recovery");
     }
 
-    #[tokio::test(flavor = "current_thread", start_paused = true)]
-    async fn test_failed_submission_clears_cached_recovery() {
+    /// Pipeline, primed state with a cached recovery tip, and a proof ready
+    /// for `handle_submit_result(SubmitOutcome::Failed { .. })` tests.
+    fn submission_failure_fixture() -> (TestPipeline, PipelineState, ProofResult) {
         let pipeline =
             recovery_pipeline(MockDisputeGameFactory::with_games(vec![]), HashMap::new());
         let target_block = TEST_BLOCK_INTERVAL;
@@ -2310,21 +2316,59 @@ mod tests {
             },
         });
 
+        (pipeline, state, proof)
+    }
+
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn test_invalid_parent_game_submission_clears_cached_recovery() {
+        let (pipeline, mut state, proof) = submission_failure_fixture();
+        let target_block = TEST_BLOCK_INTERVAL;
+        let cached_before = state.cached_recovery;
+
         let chain_next = pipeline
             .handle_submit_result(
                 Ok(SubmitOutcome::Failed {
                     target_block,
                     proof,
-                    error: ProposerError::Contract("mock submission failure".into()),
+                    error: ProposerError::InvalidParentGame,
                 }),
                 &mut state,
             )
             .await;
 
+        assert!(cached_before.is_some());
         assert!(!chain_next, "failed submission should not chain another submit");
-        assert!(
-            state.cached_recovery.is_none(),
-            "failed submission must drop cached recovery so next tick re-walks fresh"
+        assert!(state.cached_recovery.is_none(), "InvalidParentGame must drop the cache");
+        assert!(state.proved.contains_key(&target_block), "proof should be re-queued for retry");
+        assert!(state.submitting.is_none(), "submitting slot should be released");
+    }
+
+    #[rstest]
+    #[case::contract_revert(ProposerError::Contract("mock submission failure".into()))]
+    #[case::rpc_transport(ProposerError::Rpc(base_proof_rpc::RpcError::Transport("rpc down".into())))]
+    #[case::rpc_timeout(ProposerError::Rpc(base_proof_rpc::RpcError::Timeout("slow rpc".into())))]
+    #[case::tx_manager_nonce(ProposerError::TxManager(base_tx_manager::TxManagerError::NonceTooLow))]
+    #[case::tx_reverted(ProposerError::TxReverted("0xdeadbeef".into()))]
+    #[case::internal(ProposerError::Internal("bug".into()))]
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn test_transient_failed_submission_preserves_cached_recovery(
+        #[case] error: ProposerError,
+    ) {
+        let (pipeline, mut state, proof) = submission_failure_fixture();
+        let target_block = TEST_BLOCK_INTERVAL;
+        let cached_before = state.cached_recovery;
+
+        let chain_next = pipeline
+            .handle_submit_result(
+                Ok(SubmitOutcome::Failed { target_block, proof, error }),
+                &mut state,
+            )
+            .await;
+
+        assert!(!chain_next, "transient failure should not chain another submit");
+        assert_eq!(
+            state.cached_recovery, cached_before,
+            "transient failure must preserve the cached recovery tip"
         );
         assert!(state.proved.contains_key(&target_block), "proof should be re-queued for retry");
         assert!(state.submitting.is_none(), "submitting slot should be released");

--- a/crates/proof/proposer/src/pipeline.rs
+++ b/crates/proof/proposer/src/pipeline.rs
@@ -2347,7 +2347,9 @@ mod tests {
     #[case::contract_revert(ProposerError::Contract("mock submission failure".into()))]
     #[case::rpc_transport(ProposerError::Rpc(base_proof_rpc::RpcError::Transport("rpc down".into())))]
     #[case::rpc_timeout(ProposerError::Rpc(base_proof_rpc::RpcError::Timeout("slow rpc".into())))]
-    #[case::tx_manager_nonce(ProposerError::TxManager(base_tx_manager::TxManagerError::NonceTooLow))]
+    #[case::tx_manager_nonce(ProposerError::TxManager(
+        base_tx_manager::TxManagerError::NonceTooLow
+    ))]
     #[case::tx_reverted(ProposerError::TxReverted("0xdeadbeef".into()))]
     #[case::internal(ProposerError::Internal("bug".into()))]
     #[tokio::test(flavor = "current_thread", start_paused = true)]


### PR DESCRIPTION
## Summary

In `handle_submit_result`, drop `state.cached_recovery` whenever the submission completes with `SubmitOutcome::Failed`. The next poll-tick re-walks from the anchor and rebuilds the parent chain from current on-chain state instead of replaying the stale cached parent.

## Fix

`handle_submit_result` now sets `state.cached_recovery = None` on `SubmitOutcome::Failed`. The next tick's `recover_latest_state` re-walks from the anchor. The on-chain contract (`_isValidGame`) remains the source of truth for parent validity; this change only ensures the proposer does not compound its own stale internal state across retry boundaries.

## Why this scope

- Mirroring `_isValidGame` in Rust would duplicate contract logic, add per-walk-step RPCs on the happy path, and still could not make progress past a permanently invalid occupied UUID slot — that is a contract-level constraint requiring operator intervention regardless.
