### PR TITLE
fix(websocket-proxy): report duplicate API key value in DuplicateAPIKeyArgument error

### DIFF
--- a/crates/infra/websocket-proxy/src/auth.rs
+++ b/crates/infra/websocket-proxy/src/auth.rs
@@ -38,7 +38,7 @@ impl std::fmt::Display for AuthenticationParseError {
             DuplicateApplicationArgument(app) => {
                 write!(f, "Duplicate application argument: [{app}]")
             }
-            DuplicateAPIKeyArgument(app) => write!(f, "Duplicate API key: [{app}]"),
+            DuplicateAPIKeyArgument(key) => write!(f, "Duplicate API key: [{key}]"),
         }
     }
 }
@@ -77,7 +77,7 @@ impl TryFrom<Vec<String>> for Authentication {
             }
 
             if key_to_application.contains_key(key) {
-                return Err(DuplicateAPIKeyArgument(app.to_string()));
+                return Err(DuplicateAPIKeyArgument(key.to_string()));
             }
 
             applications.insert(app.to_string());
@@ -173,6 +173,6 @@ mod tests {
 
         let auth = Authentication::try_from(vec!["app1:key1".to_string(), "app2:key1".to_string()]);
         assert!(auth.is_err());
-        assert_eq!(auth.unwrap_err(), DuplicateAPIKeyArgument("app2".into()));
+        assert_eq!(auth.unwrap_err(), DuplicateAPIKeyArgument("key1".into()));
     }
 }


### PR DESCRIPTION
## Summary

`Authentication::try_from` was reporting the application name in the
`DuplicateAPIKeyArgument` error when a duplicate **key** was detected,
producing misleading messages such as `Duplicate API key: [app2]` even
though the conflict was on the key, not the app. The variant doc
(`/// The same API key appears more than once.`) and the `Display`
template (`"Duplicate API key: [{...}]"`) both promise the key value;
this PR fixes the call site to actually pass it.

## Changes

- `auth.rs`: pass `key` (not `app`) into `DuplicateAPIKeyArgument` at the duplicate-key check site.
- `auth.rs`: rename the bound variable in the `Display` arm from `app` to `key` for clarity (no behavior change).
- `auth.rs` test: update the assertion to expect the duplicated key (`"key1"`) rather than the second application (`"app2"`); the old assertion was matching the buggy behavior.

## Test plan

- [x] `cargo test -p websocket-proxy auth`
- [x] `cargo clippy -p websocket-proxy --all-targets -- -D warnings`