### PR TITLE
fix(challenger): make claimCredit retry warn message reflect backoff path

### DIFF
--- a/crates/proof/challenge/src/bond.rs
+++ b/crates/proof/challenge/src/bond.rs
@@ -1023,12 +1023,6 @@ impl<C: Clock> BondManager<C> {
                 Ok(completed.then_some(RemovalReason::Completed))
             }
             Err(e) => {
-                warn!(
-                    game = %game_address,
-                    error = %e,
-                    step,
-                    "claimCredit transaction failed, will retry"
-                );
                 ChallengerMetrics::claim_credit_tx_outcome_total(ChallengerMetrics::STATUS_ERROR)
                     .increment(1);
                 if let Some(retry_delay) = revert_retry_delay
@@ -1038,15 +1032,25 @@ impl<C: Clock> BondManager<C> {
                     let retry_delay = retry_delay.min(delay);
                     let elapsed_before_retry = delay.saturating_sub(retry_delay);
                     let unlocked_at = self.clock.now().saturating_sub(elapsed_before_retry);
-                    info!(
+                    warn!(
                         game = %game_address,
-                        retry_delay_secs = retry_delay.as_secs(),
+                        error = %e,
                         step,
-                        "claimCredit reverted, backing off before retry"
+                        retry = "after_backoff",
+                        retry_delay_secs = retry_delay.as_secs(),
+                        "claimCredit transaction failed, will retry after backoff"
                     );
                     self.set_phase(
                         game_address,
                         BondPhase::AwaitingDelay { unlocked_at, unlocked_at_unix_secs: None },
+                    );
+                } else {
+                    warn!(
+                        game = %game_address,
+                        error = %e,
+                        step,
+                        retry = "immediate",
+                        "claimCredit transaction failed, will retry"
                     );
                 }
                 Ok(None)


### PR DESCRIPTION
## Summary

- Splits the `submit_claim_credit` failure `warn!` into two branches so the message and a new `retry` field accurately distinguish immediate retry vs. back-off retry on the withdraw path.
- Folds the previously separate `info!` ("claimCredit reverted, backing off before retry") into the `warn!`, keeping the `retry_delay_secs` structured field so operators get all backoff info in one log line.

## Why

Per leopoldjoy's review nit on #2580: the previous `warn!` always said "will retry" even when the very next block transitioned the phase back to `AwaitingDelay` with up to a 60s back-off, which could mislead operators triaging logs.

## Behavior

- Reverted withdraw + `revert_retry_delay` set → `warn!(retry = "after_backoff", retry_delay_secs = ..., "claimCredit transaction failed, will retry after backoff")`
- All other failures → `warn!(retry = "immediate", "claimCredit transaction failed, will retry")`
- Existing structured fields (`game`, `error`, `step`) are preserved.

## Testing

- `cargo test -p base-challenger --lib bond::` (42 tests pass)
- `cargo clippy -p base-challenger --all-targets -- -D warnings`

## Linear

CHAIN-4453