### PR TITLE
fix(zk): reserve SNARK session before Groth16 submit

### DIFF
--- a/crates/proof/zk/db/migrations/009_add_unique_active_session.sql
+++ b/crates/proof/zk/db/migrations/009_add_unique_active_session.sql
@@ -3,8 +3,12 @@
 -- SP1 cluster. See CHAIN-4254 (Immunefi 75630).
 --
 -- The index is partial on (SUBMITTING, RUNNING); terminal sessions remain as audit
--- history. Pre-existing duplicates (only RUNNING is possible since SUBMITTING is new)
--- are de-duplicated below before the index is added.
+-- history. Pre-existing duplicates are failed (not deleted) to preserve the audit
+-- trail, keeping the newest row active.
+
+BEGIN;
+
+-- Fail duplicate active sessions, keeping the newest per (proof_request_id, session_type).
 WITH ranked AS (
     SELECT
         id,
@@ -15,11 +19,16 @@ WITH ranked AS (
     FROM proof_sessions
     WHERE status IN ('SUBMITTING', 'RUNNING')
 )
-DELETE FROM proof_sessions
-USING ranked
+UPDATE proof_sessions
+SET status = 'FAILED',
+    error_message = 'duplicate session cleared by migration 009',
+    completed_at = NOW()
+FROM ranked
 WHERE proof_sessions.id = ranked.id
   AND ranked.row_num > 1;
 
 CREATE UNIQUE INDEX IF NOT EXISTS idx_proof_sessions_request_type_active_unique
 ON proof_sessions(proof_request_id, session_type)
 WHERE status IN ('SUBMITTING', 'RUNNING');
+
+COMMIT;

--- a/crates/proof/zk/db/migrations/009_add_unique_active_session.sql
+++ b/crates/proof/zk/db/migrations/009_add_unique_active_session.sql
@@ -1,0 +1,28 @@
+-- Migration 009: Enforce at most one ACTIVE session per (proof_request, session_type)
+-- Prevents concurrent status pollers from creating duplicate SNARK Groth16 jobs on
+-- the SP1 cluster. See CHAIN-4254 (Immunefi 75630).
+--
+-- The index is partial on RUNNING so terminal (FAILED/COMPLETED) sessions remain as
+-- audit history without blocking a retried request from creating a fresh session for
+-- the same (proof_request_id, session_type) pair.
+
+-- Resolve any pre-existing RUNNING duplicates before adding the constraint. Terminal
+-- duplicates are left alone since the partial index does not see them.
+WITH ranked AS (
+    SELECT
+        id,
+        ROW_NUMBER() OVER (
+            PARTITION BY proof_request_id, session_type
+            ORDER BY created_at ASC, id ASC
+        ) AS row_num
+    FROM proof_sessions
+    WHERE status = 'RUNNING'
+)
+DELETE FROM proof_sessions
+USING ranked
+WHERE proof_sessions.id = ranked.id
+  AND ranked.row_num > 1;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_proof_sessions_request_type_running_unique
+ON proof_sessions(proof_request_id, session_type)
+WHERE status = 'RUNNING';

--- a/crates/proof/zk/db/migrations/009_add_unique_active_session.sql
+++ b/crates/proof/zk/db/migrations/009_add_unique_active_session.sql
@@ -2,12 +2,16 @@
 -- Prevents concurrent status pollers from creating duplicate SNARK Groth16 jobs on
 -- the SP1 cluster. See CHAIN-4254 (Immunefi 75630).
 --
--- The index is partial on RUNNING so terminal (FAILED/COMPLETED) sessions remain as
--- audit history without blocking a retried request from creating a fresh session for
--- the same (proof_request_id, session_type) pair.
+-- The index is partial on the active states (SUBMITTING and RUNNING) so terminal
+-- (FAILED/COMPLETED) sessions remain as audit history without blocking a retried
+-- request from creating a fresh session for the same (proof_request_id, session_type)
+-- pair. SUBMITTING covers the reservation window between slot reservation and the
+-- moment the row is updated with the real backend session id; RUNNING covers the
+-- live backend job thereafter.
 
--- Resolve any pre-existing RUNNING duplicates before adding the constraint. Terminal
--- duplicates are left alone since the partial index does not see them.
+-- Resolve any pre-existing active duplicates before adding the constraint. Terminal
+-- duplicates are left alone since the partial index does not see them. SUBMITTING
+-- did not exist before this migration, so only RUNNING rows can be duplicated here.
 WITH ranked AS (
     SELECT
         id,
@@ -16,13 +20,13 @@ WITH ranked AS (
             ORDER BY created_at ASC, id ASC
         ) AS row_num
     FROM proof_sessions
-    WHERE status = 'RUNNING'
+    WHERE status IN ('SUBMITTING', 'RUNNING')
 )
 DELETE FROM proof_sessions
 USING ranked
 WHERE proof_sessions.id = ranked.id
   AND ranked.row_num > 1;
 
-CREATE UNIQUE INDEX IF NOT EXISTS idx_proof_sessions_request_type_running_unique
+CREATE UNIQUE INDEX IF NOT EXISTS idx_proof_sessions_request_type_active_unique
 ON proof_sessions(proof_request_id, session_type)
-WHERE status = 'RUNNING';
+WHERE status IN ('SUBMITTING', 'RUNNING');

--- a/crates/proof/zk/db/migrations/009_add_unique_active_session.sql
+++ b/crates/proof/zk/db/migrations/009_add_unique_active_session.sql
@@ -1,17 +1,10 @@
--- Migration 009: Enforce at most one ACTIVE session per (proof_request, session_type)
--- Prevents concurrent status pollers from creating duplicate SNARK Groth16 jobs on
--- the SP1 cluster. See CHAIN-4254 (Immunefi 75630).
+-- Migration 009: Enforce at most one active session per (proof_request, session_type)
+-- to prevent concurrent pollers from creating duplicate SNARK Groth16 jobs on the
+-- SP1 cluster. See CHAIN-4254 (Immunefi 75630).
 --
--- The index is partial on the active states (SUBMITTING and RUNNING) so terminal
--- (FAILED/COMPLETED) sessions remain as audit history without blocking a retried
--- request from creating a fresh session for the same (proof_request_id, session_type)
--- pair. SUBMITTING covers the reservation window between slot reservation and the
--- moment the row is updated with the real backend session id; RUNNING covers the
--- live backend job thereafter.
-
--- Resolve any pre-existing active duplicates before adding the constraint. Terminal
--- duplicates are left alone since the partial index does not see them. SUBMITTING
--- did not exist before this migration, so only RUNNING rows can be duplicated here.
+-- The index is partial on (SUBMITTING, RUNNING); terminal sessions remain as audit
+-- history. Pre-existing duplicates (only RUNNING is possible since SUBMITTING is new)
+-- are de-duplicated below before the index is added.
 WITH ranked AS (
     SELECT
         id,

--- a/crates/proof/zk/db/migrations/009_add_unique_active_session.sql
+++ b/crates/proof/zk/db/migrations/009_add_unique_active_session.sql
@@ -10,7 +10,7 @@ WITH ranked AS (
         id,
         ROW_NUMBER() OVER (
             PARTITION BY proof_request_id, session_type
-            ORDER BY created_at ASC, id ASC
+            ORDER BY created_at DESC, id DESC
         ) AS row_num
     FROM proof_sessions
     WHERE status IN ('SUBMITTING', 'RUNNING')

--- a/crates/proof/zk/db/src/models.rs
+++ b/crates/proof/zk/db/src/models.rs
@@ -59,6 +59,10 @@ impl TryFrom<&str> for ProofStatus {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, sqlx::Type)]
 #[sqlx(type_name = "VARCHAR", rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum SessionStatus {
+    /// Reservation placeholder before the backend job has been submitted. The row holds a
+    /// synthetic `backend_session_id` so the partial unique index serializes concurrent
+    /// reservations; sync loops skip it because they only poll RUNNING rows.
+    Submitting,
     /// Backend session is actively running.
     Running,
     /// Backend session completed successfully.
@@ -71,6 +75,7 @@ impl SessionStatus {
     /// Convert enum to static string representation
     pub const fn as_str(&self) -> &'static str {
         match self {
+            Self::Submitting => "SUBMITTING",
             Self::Running => "RUNNING",
             Self::Completed => "COMPLETED",
             Self::Failed => "FAILED",
@@ -89,6 +94,7 @@ impl TryFrom<&str> for SessionStatus {
 
     fn try_from(s: &str) -> Result<Self, Self::Error> {
         match s {
+            "SUBMITTING" => Ok(Self::Submitting),
             "RUNNING" => Ok(Self::Running),
             "COMPLETED" => Ok(Self::Completed),
             "FAILED" => Ok(Self::Failed),

--- a/crates/proof/zk/db/src/repo.rs
+++ b/crates/proof/zk/db/src/repo.rs
@@ -502,6 +502,25 @@ impl ProofRequestRepo {
 
         let retry_count: i32 = row.get("retry_count");
 
+        // Fail any RUNNING sessions before resetting so the retried run cannot collide with
+        // `idx_proof_sessions_request_type_running_unique`. No-op on the normal reaper path,
+        // since `get_stuck_requests` already excludes requests that have a RUNNING session.
+        sqlx::query(
+            r#"
+            UPDATE proof_sessions
+            SET status = $1,
+                error_message = COALESCE(error_message, $2),
+                completed_at = NOW()
+            WHERE proof_request_id = $3 AND status = $4
+            "#,
+        )
+        .bind(SessionStatus::Failed.as_str())
+        .bind("cleared during stuck-request retry")
+        .bind(id)
+        .bind(SessionStatus::Running.as_str())
+        .execute(&mut *tx)
+        .await?;
+
         if retry_count >= max_retries {
             sqlx::query(
                 r#"

--- a/crates/proof/zk/db/src/repo.rs
+++ b/crates/proof/zk/db/src/repo.rs
@@ -212,6 +212,26 @@ impl ProofRequestRepo {
                     return Ok(CreateProofRequestOutcome::RetryExhausted(id));
                 }
 
+                // Fail any active sessions before resetting so the requeued run cannot
+                // collide with `idx_proof_sessions_request_type_active_unique`. Mirrors
+                // the cleanup in `retry_or_fail_stuck_request`.
+                sqlx::query(
+                    r#"
+                    UPDATE proof_sessions
+                    SET status = $1,
+                        error_message = COALESCE(error_message, $2),
+                        completed_at = NOW()
+                    WHERE proof_request_id = $3 AND status IN ($4, $5)
+                    "#,
+                )
+                .bind(SessionStatus::Failed.as_str())
+                .bind("cleared during create_with_outbox requeue")
+                .bind(id)
+                .bind(SessionStatus::Submitting.as_str())
+                .bind(SessionStatus::Running.as_str())
+                .execute(&mut *tx)
+                .await?;
+
                 sqlx::query(
                     r#"
                     UPDATE proof_requests
@@ -625,21 +645,14 @@ impl ProofRequestRepo {
         Ok(id)
     }
 
-    /// Reserve a `(proof_request_id, session_type)` slot before submitting expensive work
-    /// to a backend. Returns `Some(reservation_id)` if this caller won the race and should
-    /// proceed; `None` if another caller already holds the active row.
+    /// Reserve a `(proof_request_id, session_type)` slot for a future backend submission.
+    /// Returns `Some(reservation_id)` for the single race winner; `None` if another
+    /// caller already holds an active (`SUBMITTING` or `RUNNING`) row.
     ///
-    /// The row is inserted with `status = 'SUBMITTING'` and a synthetic
-    /// `backend_session_id`. The partial unique index
-    /// `idx_proof_sessions_request_type_active_unique` covers both `SUBMITTING` and
-    /// `RUNNING`, so concurrent reservations and a later activation of the same slot
-    /// remain serialized end-to-end. Sync loops only poll `RUNNING` rows, so the
-    /// reservation row is invisible to them until activation.
-    ///
-    /// Callers must follow up with [`Self::activate_reserved_proof_session`] on success
-    /// (which transitions the row to `RUNNING` with the real backend session id) or
-    /// [`Self::fail_reserved_proof_session`] on failure (which transitions the row to
-    /// `FAILED` and releases the slot).
+    /// The row is inserted as `SUBMITTING` so sync loops (which only poll `RUNNING`
+    /// rows) skip it until activation. Callers must follow up with
+    /// [`Self::activate_reserved_proof_session`] on success or
+    /// [`Self::fail_reserved_proof_session`] on failure.
     pub async fn reserve_proof_session(
         &self,
         proof_request_id: Uuid,
@@ -651,8 +664,7 @@ impl ProofRequestRepo {
             Uuid::new_v4()
         );
 
-        // The ON CONFLICT predicate must mirror the partial unique index predicate so
-        // Postgres infers that index for conflict resolution.
+        // ON CONFLICT predicate mirrors the partial unique index predicate.
         let row = sqlx::query(
             r#"
             INSERT INTO proof_sessions (

--- a/crates/proof/zk/db/src/repo.rs
+++ b/crates/proof/zk/db/src/repo.rs
@@ -605,6 +605,117 @@ impl ProofRequestRepo {
         Ok(id)
     }
 
+    /// Reserve a `(proof_request_id, session_type)` slot before submitting expensive work
+    /// to a backend. Returns `Some(reservation_id)` if this caller won the race and should
+    /// proceed; `None` if another caller already holds the active row.
+    ///
+    /// The synthetic `reservation_id` is written to `backend_session_id` so the partial
+    /// unique index `idx_proof_sessions_request_type_running_unique` enforces single-winner
+    /// semantics. Callers must follow up with [`Self::activate_reserved_proof_session`] on
+    /// success or [`Self::fail_reserved_proof_session`] on failure so the slot is either
+    /// updated to the real backend session id or released by transitioning to FAILED.
+    pub async fn reserve_proof_session(
+        &self,
+        proof_request_id: Uuid,
+        session_type: SessionType,
+    ) -> Result<Option<String>> {
+        let reservation_id = format!(
+            "reservation-{}-{}",
+            session_type.as_str().to_ascii_lowercase(),
+            Uuid::new_v4()
+        );
+
+        // The partial unique index is restricted to rows with status = 'RUNNING'; the
+        // matching predicate must be repeated here so Postgres infers that index for
+        // ON CONFLICT.
+        let row = sqlx::query(
+            r#"
+            INSERT INTO proof_sessions (
+                proof_request_id, session_type, backend_session_id, status, metadata
+            )
+            VALUES ($1, $2, $3, $4, NULL)
+            ON CONFLICT (proof_request_id, session_type)
+                WHERE status = 'RUNNING'
+                DO NOTHING
+            RETURNING backend_session_id
+            "#,
+        )
+        .bind(proof_request_id)
+        .bind(session_type.as_str())
+        .bind(&reservation_id)
+        .bind(SessionStatus::Running.as_str())
+        .fetch_optional(&self.pool)
+        .await?;
+
+        Ok(row.map(|r| r.get("backend_session_id")))
+    }
+
+    /// Swap a reservation row's synthetic `backend_session_id` for the real one returned
+    /// by the proving backend. Returns `true` when the reserved row was found and
+    /// updated. A `false` return means the reservation was no longer eligible (e.g.
+    /// already failed or activated by an out-of-band path) and the caller should treat
+    /// the backend job as orphaned.
+    pub async fn activate_reserved_proof_session(
+        &self,
+        reservation_id: &str,
+        session: CreateProofSession,
+    ) -> Result<bool> {
+        let result = sqlx::query(
+            r#"
+            UPDATE proof_sessions
+            SET backend_session_id = $1,
+                metadata = $2,
+                error_message = NULL
+            WHERE backend_session_id = $3
+              AND proof_request_id = $4
+              AND session_type = $5
+              AND status = 'RUNNING'
+            "#,
+        )
+        .bind(&session.backend_session_id)
+        .bind(&session.metadata)
+        .bind(reservation_id)
+        .bind(session.proof_request_id)
+        .bind(session.session_type.as_str())
+        .execute(&self.pool)
+        .await?;
+
+        Ok(result.rows_affected() > 0)
+    }
+
+    /// Mark a reservation row as FAILED so the partial unique index releases the slot
+    /// and a future poll can retry. Used when the backend submit step itself fails
+    /// after a successful reservation.
+    pub async fn fail_reserved_proof_session(
+        &self,
+        proof_request_id: Uuid,
+        session_type: SessionType,
+        reservation_id: &str,
+        error_message: &str,
+    ) -> Result<bool> {
+        let result = sqlx::query(
+            r#"
+            UPDATE proof_sessions
+            SET status = $1,
+                error_message = $2,
+                completed_at = NOW()
+            WHERE backend_session_id = $3
+              AND proof_request_id = $4
+              AND session_type = $5
+              AND status = 'RUNNING'
+            "#,
+        )
+        .bind(SessionStatus::Failed.as_str())
+        .bind(error_message)
+        .bind(reservation_id)
+        .bind(proof_request_id)
+        .bind(session_type.as_str())
+        .execute(&self.pool)
+        .await?;
+
+        Ok(result.rows_affected() > 0)
+    }
+
     /// Get a proof session by backend session ID
     pub async fn get_session_by_backend_id(
         &self,

--- a/crates/proof/zk/db/src/repo.rs
+++ b/crates/proof/zk/db/src/repo.rs
@@ -687,11 +687,9 @@ impl ProofRequestRepo {
         Ok(row.map(|r| r.get("backend_session_id")))
     }
 
-    /// Promote a reservation row from `SUBMITTING` to `RUNNING`, swapping the synthetic
-    /// `backend_session_id` for the real one returned by the proving backend. Returns
-    /// `true` when the reserved row was found and updated. A `false` return means the
-    /// reservation was no longer eligible (e.g. already failed or activated by an
-    /// out-of-band path) and the caller should treat the backend job as orphaned.
+    /// Promote a `SUBMITTING` reservation row to `RUNNING` with the real backend session
+    /// id. Returns `false` if the row was no longer eligible (failed or activated
+    /// out-of-band); the caller should then treat the backend job as orphaned.
     pub async fn activate_reserved_proof_session(
         &self,
         reservation_id: &str,
@@ -856,7 +854,7 @@ impl ProofRequestRepo {
               AND NOT EXISTS (
                   SELECT 1 FROM proof_sessions ps
                   WHERE ps.proof_request_id = pr.id
-                    AND ps.status = 'RUNNING'
+                    AND ps.status IN ('SUBMITTING', 'RUNNING')
               )
             ORDER BY pr.created_at ASC
             "#,

--- a/crates/proof/zk/db/src/repo.rs
+++ b/crates/proof/zk/db/src/repo.rs
@@ -502,21 +502,22 @@ impl ProofRequestRepo {
 
         let retry_count: i32 = row.get("retry_count");
 
-        // Fail any RUNNING sessions before resetting so the retried run cannot collide with
-        // `idx_proof_sessions_request_type_running_unique`. No-op on the normal reaper path,
-        // since `get_stuck_requests` already excludes requests that have a RUNNING session.
+        // Fail any active sessions before resetting so the retried run cannot collide with
+        // `idx_proof_sessions_request_type_active_unique`. No-op on the normal reaper path,
+        // since `get_stuck_requests` already excludes requests that have an active session.
         sqlx::query(
             r#"
             UPDATE proof_sessions
             SET status = $1,
                 error_message = COALESCE(error_message, $2),
                 completed_at = NOW()
-            WHERE proof_request_id = $3 AND status = $4
+            WHERE proof_request_id = $3 AND status IN ($4, $5)
             "#,
         )
         .bind(SessionStatus::Failed.as_str())
         .bind("cleared during stuck-request retry")
         .bind(id)
+        .bind(SessionStatus::Submitting.as_str())
         .bind(SessionStatus::Running.as_str())
         .execute(&mut *tx)
         .await?;
@@ -628,11 +629,17 @@ impl ProofRequestRepo {
     /// to a backend. Returns `Some(reservation_id)` if this caller won the race and should
     /// proceed; `None` if another caller already holds the active row.
     ///
-    /// The synthetic `reservation_id` is written to `backend_session_id` so the partial
-    /// unique index `idx_proof_sessions_request_type_running_unique` enforces single-winner
-    /// semantics. Callers must follow up with [`Self::activate_reserved_proof_session`] on
-    /// success or [`Self::fail_reserved_proof_session`] on failure so the slot is either
-    /// updated to the real backend session id or released by transitioning to FAILED.
+    /// The row is inserted with `status = 'SUBMITTING'` and a synthetic
+    /// `backend_session_id`. The partial unique index
+    /// `idx_proof_sessions_request_type_active_unique` covers both `SUBMITTING` and
+    /// `RUNNING`, so concurrent reservations and a later activation of the same slot
+    /// remain serialized end-to-end. Sync loops only poll `RUNNING` rows, so the
+    /// reservation row is invisible to them until activation.
+    ///
+    /// Callers must follow up with [`Self::activate_reserved_proof_session`] on success
+    /// (which transitions the row to `RUNNING` with the real backend session id) or
+    /// [`Self::fail_reserved_proof_session`] on failure (which transitions the row to
+    /// `FAILED` and releases the slot).
     pub async fn reserve_proof_session(
         &self,
         proof_request_id: Uuid,
@@ -644,9 +651,8 @@ impl ProofRequestRepo {
             Uuid::new_v4()
         );
 
-        // The partial unique index is restricted to rows with status = 'RUNNING'; the
-        // matching predicate must be repeated here so Postgres infers that index for
-        // ON CONFLICT.
+        // The ON CONFLICT predicate must mirror the partial unique index predicate so
+        // Postgres infers that index for conflict resolution.
         let row = sqlx::query(
             r#"
             INSERT INTO proof_sessions (
@@ -654,7 +660,7 @@ impl ProofRequestRepo {
             )
             VALUES ($1, $2, $3, $4, NULL)
             ON CONFLICT (proof_request_id, session_type)
-                WHERE status = 'RUNNING'
+                WHERE status IN ('SUBMITTING', 'RUNNING')
                 DO NOTHING
             RETURNING backend_session_id
             "#,
@@ -662,18 +668,18 @@ impl ProofRequestRepo {
         .bind(proof_request_id)
         .bind(session_type.as_str())
         .bind(&reservation_id)
-        .bind(SessionStatus::Running.as_str())
+        .bind(SessionStatus::Submitting.as_str())
         .fetch_optional(&self.pool)
         .await?;
 
         Ok(row.map(|r| r.get("backend_session_id")))
     }
 
-    /// Swap a reservation row's synthetic `backend_session_id` for the real one returned
-    /// by the proving backend. Returns `true` when the reserved row was found and
-    /// updated. A `false` return means the reservation was no longer eligible (e.g.
-    /// already failed or activated by an out-of-band path) and the caller should treat
-    /// the backend job as orphaned.
+    /// Promote a reservation row from `SUBMITTING` to `RUNNING`, swapping the synthetic
+    /// `backend_session_id` for the real one returned by the proving backend. Returns
+    /// `true` when the reserved row was found and updated. A `false` return means the
+    /// reservation was no longer eligible (e.g. already failed or activated by an
+    /// out-of-band path) and the caller should treat the backend job as orphaned.
     pub async fn activate_reserved_proof_session(
         &self,
         reservation_id: &str,
@@ -684,27 +690,30 @@ impl ProofRequestRepo {
             UPDATE proof_sessions
             SET backend_session_id = $1,
                 metadata = $2,
+                status = $3,
                 error_message = NULL
-            WHERE backend_session_id = $3
-              AND proof_request_id = $4
-              AND session_type = $5
-              AND status = 'RUNNING'
+            WHERE backend_session_id = $4
+              AND proof_request_id = $5
+              AND session_type = $6
+              AND status = $7
             "#,
         )
         .bind(&session.backend_session_id)
         .bind(&session.metadata)
+        .bind(SessionStatus::Running.as_str())
         .bind(reservation_id)
         .bind(session.proof_request_id)
         .bind(session.session_type.as_str())
+        .bind(SessionStatus::Submitting.as_str())
         .execute(&self.pool)
         .await?;
 
         Ok(result.rows_affected() > 0)
     }
 
-    /// Mark a reservation row as FAILED so the partial unique index releases the slot
-    /// and a future poll can retry. Used when the backend submit step itself fails
-    /// after a successful reservation.
+    /// Mark a `SUBMITTING` reservation row as `FAILED` so the partial unique index
+    /// releases the slot and a future poll can retry. Used when the backend submit step
+    /// itself fails after a successful reservation.
     pub async fn fail_reserved_proof_session(
         &self,
         proof_request_id: Uuid,
@@ -721,7 +730,7 @@ impl ProofRequestRepo {
             WHERE backend_session_id = $3
               AND proof_request_id = $4
               AND session_type = $5
-              AND status = 'RUNNING'
+              AND status = $6
             "#,
         )
         .bind(SessionStatus::Failed.as_str())
@@ -729,6 +738,7 @@ impl ProofRequestRepo {
         .bind(reservation_id)
         .bind(proof_request_id)
         .bind(session_type.as_str())
+        .bind(SessionStatus::Submitting.as_str())
         .execute(&self.pool)
         .await?;
 

--- a/crates/proof/zk/service/src/backends/op_succinct/cluster.rs
+++ b/crates/proof/zk/service/src/backends/op_succinct/cluster.rs
@@ -650,8 +650,44 @@ impl ClusterBackend {
         match self.build_aggregation_session(proof_request).await {
             Ok(session) => {
                 let backend_session_id = session.backend_session_id.clone();
-                let activated =
-                    repo.activate_reserved_proof_session(&reservation_id, session).await?;
+                let activated = match repo
+                    .activate_reserved_proof_session(&reservation_id, session)
+                    .await
+                {
+                    Ok(v) => v,
+                    Err(e) => {
+                        // Cluster job has already been submitted but the DB activation
+                        // failed. Release the reservation so the partial unique index
+                        // does not permanently block future SNARK attempts; the in-flight
+                        // cluster job is orphaned and will fall on the floor.
+                        let error_message =
+                            format!("failed to activate reserved SNARK session: {e}");
+                        if let Err(fail_err) = repo
+                            .fail_reserved_proof_session(
+                                proof_request.id,
+                                SessionType::Snark,
+                                &reservation_id,
+                                &error_message,
+                            )
+                            .await
+                        {
+                            warn!(
+                                proof_request_id = %proof_request.id,
+                                reservation_id = %reservation_id,
+                                error = %fail_err,
+                                "failed to release SNARK reservation after activation error"
+                            );
+                        }
+                        error!(
+                            proof_request_id = %proof_request.id,
+                            reservation_id = %reservation_id,
+                            backend_session_id = %backend_session_id,
+                            error = %e,
+                            "failed to activate reserved SNARK session; backend job may be orphaned"
+                        );
+                        return Err(e.into());
+                    }
+                };
                 if !activated {
                     warn!(
                         proof_request_id = %proof_request.id,

--- a/crates/proof/zk/service/src/backends/op_succinct/cluster.rs
+++ b/crates/proof/zk/service/src/backends/op_succinct/cluster.rs
@@ -616,7 +616,7 @@ impl ClusterBackend {
     /// `proof_request_manager.rs`). To prevent duplicate Groth16 jobs from being
     /// enqueued on the SP1 cluster, the SNARK session row is reserved in Postgres
     /// **before** any expensive work. The partial unique index
-    /// `idx_proof_sessions_request_type_running_unique` ensures only one caller wins;
+    /// `idx_proof_sessions_request_type_active_unique` ensures only one caller wins;
     /// the others observe `Ok(None)` and never reach `create_request`.
     async fn submit_aggregation_proof(
         &self,

--- a/crates/proof/zk/service/src/backends/op_succinct/cluster.rs
+++ b/crates/proof/zk/service/src/backends/op_succinct/cluster.rs
@@ -569,7 +569,9 @@ impl ClusterBackend {
         Ok(())
     }
 
-    /// Determine final status based on sessions and proof type.
+    /// Determine final status based on sessions and proof type. `Submitting` sessions
+    /// are treated as in-flight (neither failed nor completed), keeping the request in
+    /// `Running` until activation transitions the row to `RUNNING`.
     fn determine_status(proof_type: ProofType, sessions: &[ProofSession]) -> ProofProcessingResult {
         if sessions.is_empty() {
             return ProofProcessingResult { status: ProofStatus::Pending, error_message: None };

--- a/crates/proof/zk/service/src/backends/op_succinct/cluster.rs
+++ b/crates/proof/zk/service/src/backends/op_succinct/cluster.rs
@@ -982,4 +982,18 @@ mod tests {
             ClusterBackend::determine_status(ProofType::OpSuccinctSp1ClusterCompressed, &sessions);
         assert_eq!(result.status, ProofStatus::Failed);
     }
+
+    #[test]
+    fn test_determine_status_snark_stark_completed_snark_submitting_returns_running() {
+        let sessions = vec![
+            make_session(SessionType::Stark, DbSessionStatus::Completed),
+            make_session(SessionType::Snark, DbSessionStatus::Submitting),
+        ];
+        let result = ClusterBackend::determine_status(
+            ProofType::OpSuccinctSp1ClusterSnarkGroth16,
+            &sessions,
+        );
+        assert_eq!(result.status, ProofStatus::Running);
+        assert!(result.error_message.is_none());
+    }
 }

--- a/crates/proof/zk/service/src/backends/op_succinct/cluster.rs
+++ b/crates/proof/zk/service/src/backends/op_succinct/cluster.rs
@@ -611,11 +611,94 @@ impl ClusterBackend {
     }
 
     /// Submit an aggregation proof (stage 2) after the STARK proof completes.
+    ///
+    /// Concurrent pollers race here (`StatusPoller` + `GetProof` RPC, see
+    /// `proof_request_manager.rs`). To prevent duplicate Groth16 jobs from being
+    /// enqueued on the SP1 cluster, the SNARK session row is reserved in Postgres
+    /// **before** any expensive work. The partial unique index
+    /// `idx_proof_sessions_request_type_running_unique` ensures only one caller wins;
+    /// the others observe `Ok(None)` and never reach `create_request`.
     async fn submit_aggregation_proof(
         &self,
         proof_request: &ProofRequest,
         repo: &ProofRequestRepo,
     ) -> anyhow::Result<()> {
+        let reservation_id = match repo
+            .reserve_proof_session(proof_request.id, SessionType::Snark)
+            .await
+        {
+            Ok(Some(id)) => id,
+            Ok(None) => {
+                info!(
+                    proof_request_id = %proof_request.id,
+                    "SNARK session already reserved by another worker; skipping aggregation submit"
+                );
+                return Ok(());
+            }
+            Err(e) => {
+                // Defer to the next poll rather than terminalizing the request on a
+                // transient store error.
+                warn!(
+                    proof_request_id = %proof_request.id,
+                    error = %e,
+                    "failed to reserve SNARK proof session; deferring aggregation to next poll"
+                );
+                return Ok(());
+            }
+        };
+
+        match self.build_aggregation_session(proof_request).await {
+            Ok(session) => {
+                let backend_session_id = session.backend_session_id.clone();
+                let activated =
+                    repo.activate_reserved_proof_session(&reservation_id, session).await?;
+                if !activated {
+                    warn!(
+                        proof_request_id = %proof_request.id,
+                        reservation_id = %reservation_id,
+                        backend_session_id = %backend_session_id,
+                        "SNARK reservation row missing at activation time; backend job may be orphaned"
+                    );
+                } else {
+                    info!(
+                        proof_request_id = %proof_request.id,
+                        backend_session_id = %backend_session_id,
+                        "activated SNARK proof session for aggregation"
+                    );
+                }
+                Ok(())
+            }
+            Err(e) => {
+                let error_message = format!("aggregation submit failed: {e}");
+                if let Err(fail_err) = repo
+                    .fail_reserved_proof_session(
+                        proof_request.id,
+                        SessionType::Snark,
+                        &reservation_id,
+                        &error_message,
+                    )
+                    .await
+                {
+                    warn!(
+                        proof_request_id = %proof_request.id,
+                        reservation_id = %reservation_id,
+                        error = %fail_err,
+                        "failed to release SNARK reservation after submit failure"
+                    );
+                }
+                Err(e)
+            }
+        }
+    }
+
+    /// Build the aggregation stdin, submit it to the SP1 cluster, and return the
+    /// resulting [`CreateProofSession`] descriptor. The DB write happens in the caller
+    /// via [`ProofRequestRepo::activate_reserved_proof_session`] so that the reservation
+    /// flow stays atomic with respect to the cluster submit.
+    async fn build_aggregation_session(
+        &self,
+        proof_request: &ProofRequest,
+    ) -> anyhow::Result<CreateProofSession> {
         let BackendConfig::OpSuccinct {
             cluster_rpc,
             artifact_client,
@@ -635,7 +718,6 @@ impl ClusterBackend {
             .parse()
             .map_err(|e| anyhow::anyhow!("invalid prover_address in DB: {e}"))?;
 
-        // 1. Deserialize STARK proof.
         let stark_receipt_bytes = proof_request
             .stark_receipt
             .as_ref()
@@ -645,14 +727,12 @@ impl ClusterBackend {
             bincode::serde::decode_from_slice(stark_receipt_bytes, bincode::config::standard())
                 .map_err(|e| anyhow::anyhow!("Failed to deserialize STARK proof: {e}"))?;
 
-        // 2. Extract boot_info from public values.
         let mut public_values = stark_proof_with_pv.public_values.clone();
         let boot_info: base_proof_succinct_client_utils::boot::BootInfoStruct =
             public_values.read();
         let boot_infos = vec![boot_info];
         let proofs = vec![stark_proof_with_pv.proof];
 
-        // 3. Fetch L1 headers for aggregation.
         let fetcher = self.provider.fetcher();
         let header = fetcher
             .get_latest_l1_head_in_batch(&boot_infos)
@@ -672,7 +752,6 @@ impl ClusterBackend {
             "fetched L1 headers for aggregation proof"
         );
 
-        // 4. Build aggregation stdin.
         let stdin = get_agg_proof_stdin(
             proofs,
             boot_infos,
@@ -683,7 +762,6 @@ impl ClusterBackend {
         )
         .map_err(|e| anyhow::anyhow!("Failed to build aggregation stdin: {e}"))?;
 
-        // 5. Submit aggregation ELF with Groth16 mode.
         let proof_config = ProofRequestConfig {
             cluster_rpc: cluster_rpc.clone(),
             mode: ProofMode::Groth16,
@@ -709,7 +787,6 @@ impl ClusterBackend {
             "aggregation proof (Groth16) submitted to SP1 cluster"
         );
 
-        // 6. Create SNARK session in DB.
         let start_time_secs = SystemTime::now()
             .duration_since(SystemTime::UNIX_EPOCH)
             .expect("system time before UNIX epoch")
@@ -724,21 +801,12 @@ impl ClusterBackend {
             "start_time_secs": start_time_secs,
         });
 
-        let session = CreateProofSession {
+        Ok(CreateProofSession {
             proof_request_id: proof_request.id,
             session_type: SessionType::Snark,
             backend_session_id: cluster_proof_request.proof_id,
             metadata: Some(metadata),
-        };
-
-        repo.create_proof_session(session).await?;
-
-        info!(
-            proof_request_id = %proof_request.id,
-            "created SNARK proof session for aggregation"
-        );
-
-        Ok(())
+        })
     }
 }
 

--- a/crates/proof/zk/service/src/backends/op_succinct/cluster.rs
+++ b/crates/proof/zk/service/src/backends/op_succinct/cluster.rs
@@ -614,12 +614,9 @@ impl ClusterBackend {
 
     /// Submit an aggregation proof (stage 2) after the STARK proof completes.
     ///
-    /// Concurrent pollers race here (`StatusPoller` + `GetProof` RPC, see
-    /// `proof_request_manager.rs`). To prevent duplicate Groth16 jobs from being
-    /// enqueued on the SP1 cluster, the SNARK session row is reserved in Postgres
-    /// **before** any expensive work. The partial unique index
-    /// `idx_proof_sessions_request_type_active_unique` ensures only one caller wins;
-    /// the others observe `Ok(None)` and never reach `create_request`.
+    /// Concurrent pollers race here; the SNARK session is reserved via
+    /// `idx_proof_sessions_request_type_active_unique` so only one caller reaches
+    /// `create_request`. The others observe `Ok(None)` and skip.
     async fn submit_aggregation_proof(
         &self,
         proof_request: &ProofRequest,
@@ -658,10 +655,9 @@ impl ClusterBackend {
                 {
                     Ok(v) => v,
                     Err(e) => {
-                        // Cluster job has already been submitted but the DB activation
-                        // failed. Release the reservation so the partial unique index
-                        // does not permanently block future SNARK attempts; the in-flight
-                        // cluster job is orphaned and will fall on the floor.
+                        // DB activation failed after the cluster job was submitted. Release
+                        // the reservation so the unique index doesn't permanently block
+                        // retries; the in-flight cluster job is orphaned.
                         let error_message =
                             format!("failed to activate reserved SNARK session: {e}");
                         if let Err(fail_err) = repo
@@ -729,10 +725,9 @@ impl ClusterBackend {
         }
     }
 
-    /// Build the aggregation stdin, submit it to the SP1 cluster, and return the
-    /// resulting [`CreateProofSession`] descriptor. The DB write happens in the caller
-    /// via [`ProofRequestRepo::activate_reserved_proof_session`] so that the reservation
-    /// flow stays atomic with respect to the cluster submit.
+    /// Build aggregation stdin and submit to the SP1 cluster, returning the resulting
+    /// [`CreateProofSession`]. The DB write happens in the caller via
+    /// [`ProofRequestRepo::activate_reserved_proof_session`].
     async fn build_aggregation_session(
         &self,
         proof_request: &ProofRequest,

--- a/crates/proof/zk/service/src/backends/op_succinct/network.rs
+++ b/crates/proof/zk/service/src/backends/op_succinct/network.rs
@@ -374,6 +374,9 @@ impl NetworkBackend {
         Ok(())
     }
 
+    /// Determine final status based on sessions and proof type. `Submitting` sessions
+    /// are treated as in-flight (neither failed nor completed), keeping the request in
+    /// `Running` until activation transitions the row to `RUNNING`.
     fn determine_status(proof_type: ProofType, sessions: &[ProofSession]) -> ProofProcessingResult {
         if sessions.is_empty() {
             return ProofProcessingResult { status: ProofStatus::Pending, error_message: None };

--- a/crates/proof/zk/service/src/backends/op_succinct/network.rs
+++ b/crates/proof/zk/service/src/backends/op_succinct/network.rs
@@ -458,10 +458,9 @@ impl NetworkBackend {
                 {
                     Ok(v) => v,
                     Err(e) => {
-                        // Network job has already been submitted but the DB activation
-                        // failed. Release the reservation so the partial unique index
-                        // does not permanently block future SNARK attempts; the in-flight
-                        // network job is orphaned and will fall on the floor.
+                        // DB activation failed after the network job was submitted. Release
+                        // the reservation so the unique index doesn't permanently block
+                        // retries; the in-flight network job is orphaned.
                         let error_message =
                             format!("failed to activate reserved SNARK session: {e}");
                         if let Err(fail_err) = repo

--- a/crates/proof/zk/service/src/backends/op_succinct/network.rs
+++ b/crates/proof/zk/service/src/backends/op_succinct/network.rs
@@ -413,11 +413,90 @@ impl NetworkBackend {
         }
     }
 
+    /// Submit an aggregation proof (stage 2) after the STARK proof completes.
+    ///
+    /// Concurrent pollers race here; the SNARK session row is reserved in Postgres
+    /// **before** any expensive work so that the partial unique index
+    /// `idx_proof_sessions_request_type_running_unique` ensures only one caller
+    /// reaches the network prover. See cluster.rs for details.
     async fn submit_aggregation_proof(
         &self,
         proof_request: &ProofRequest,
         repo: &ProofRequestRepo,
     ) -> anyhow::Result<()> {
+        let reservation_id = match repo
+            .reserve_proof_session(proof_request.id, SessionType::Snark)
+            .await
+        {
+            Ok(Some(id)) => id,
+            Ok(None) => {
+                info!(
+                    proof_request_id = %proof_request.id,
+                    "SNARK session already reserved by another worker; skipping aggregation submit"
+                );
+                return Ok(());
+            }
+            Err(e) => {
+                warn!(
+                    proof_request_id = %proof_request.id,
+                    error = %e,
+                    "failed to reserve SNARK proof session; deferring aggregation to next poll"
+                );
+                return Ok(());
+            }
+        };
+
+        match self.build_aggregation_session(proof_request).await {
+            Ok(session) => {
+                let backend_session_id = session.backend_session_id.clone();
+                let activated =
+                    repo.activate_reserved_proof_session(&reservation_id, session).await?;
+                if !activated {
+                    warn!(
+                        proof_request_id = %proof_request.id,
+                        reservation_id = %reservation_id,
+                        backend_session_id = %backend_session_id,
+                        "SNARK reservation row missing at activation time; backend job may be orphaned"
+                    );
+                } else {
+                    info!(
+                        proof_request_id = %proof_request.id,
+                        backend_session_id = %backend_session_id,
+                        "activated SNARK proof session for aggregation"
+                    );
+                }
+                Ok(())
+            }
+            Err(e) => {
+                let error_message = format!("aggregation submit failed: {e}");
+                if let Err(fail_err) = repo
+                    .fail_reserved_proof_session(
+                        proof_request.id,
+                        SessionType::Snark,
+                        &reservation_id,
+                        &error_message,
+                    )
+                    .await
+                {
+                    warn!(
+                        proof_request_id = %proof_request.id,
+                        reservation_id = %reservation_id,
+                        error = %fail_err,
+                        "failed to release SNARK reservation after submit failure"
+                    );
+                }
+                Err(e)
+            }
+        }
+    }
+
+    /// Build the aggregation stdin, submit it to the SP1 Network, and return the
+    /// resulting [`CreateProofSession`] descriptor. The DB write happens in the caller
+    /// via [`ProofRequestRepo::activate_reserved_proof_session`].
+    async fn build_aggregation_session(
+        &self,
+        proof_request: &ProofRequest,
+    ) -> anyhow::Result<CreateProofSession> {
         let BackendConfig::Network { network_prover, agg_pk, range_vk, .. } = &self.config else {
             unreachable!("validated in constructor");
         };
@@ -429,7 +508,6 @@ impl NetworkBackend {
             .parse()
             .map_err(|e| anyhow::anyhow!("invalid prover_address in DB: {e}"))?;
 
-        // Deserialize STARK proof.
         let stark_receipt_bytes = proof_request
             .stark_receipt
             .as_ref()
@@ -439,14 +517,12 @@ impl NetworkBackend {
             bincode::serde::decode_from_slice(stark_receipt_bytes, bincode::config::standard())
                 .map_err(|e| anyhow::anyhow!("failed to deserialize STARK proof: {e}"))?;
 
-        // Extract boot_info from public values.
         let mut public_values = stark_proof_with_pv.public_values.clone();
         let boot_info: base_proof_succinct_client_utils::boot::BootInfoStruct =
             public_values.read();
         let boot_infos = vec![boot_info];
         let proofs = vec![stark_proof_with_pv.proof];
 
-        // Fetch L1 headers for aggregation.
         let fetcher = self.provider.fetcher();
         let header = fetcher
             .get_latest_l1_head_in_batch(&boot_infos)
@@ -466,7 +542,6 @@ impl NetworkBackend {
             "fetched L1 headers for aggregation proof"
         );
 
-        // Build aggregation stdin.
         let stdin = get_agg_proof_stdin(
             proofs,
             boot_infos,
@@ -477,7 +552,6 @@ impl NetworkBackend {
         )
         .map_err(|e| anyhow::anyhow!("failed to build aggregation stdin: {e}"))?;
 
-        // Submit aggregation ELF with Groth16 mode to SP1 Network.
         let timeout = self.timeout();
         let strategy = self.fulfillment_strategy();
 
@@ -504,21 +578,12 @@ impl NetworkBackend {
             "proof_id": proof_id.to_string(),
         });
 
-        let session = CreateProofSession {
+        Ok(CreateProofSession {
             proof_request_id: proof_request.id,
             session_type: SessionType::Snark,
             backend_session_id: proof_id.to_string(),
             metadata: Some(metadata),
-        };
-
-        repo.create_proof_session(session).await?;
-
-        info!(
-            proof_request_id = %proof_request.id,
-            "created SNARK proof session for aggregation"
-        );
-
-        Ok(())
+        })
     }
 }
 

--- a/crates/proof/zk/service/src/backends/op_succinct/network.rs
+++ b/crates/proof/zk/service/src/backends/op_succinct/network.rs
@@ -720,6 +720,20 @@ mod tests {
     }
 
     #[test]
+    fn test_determine_status_snark_stark_completed_snark_submitting_returns_running() {
+        let sessions = vec![
+            make_session(SessionType::Stark, DbSessionStatus::Completed),
+            make_session(SessionType::Snark, DbSessionStatus::Submitting),
+        ];
+        let result = NetworkBackend::determine_status(
+            ProofType::OpSuccinctSp1ClusterSnarkGroth16,
+            &sessions,
+        );
+        assert_eq!(result.status, ProofStatus::Running);
+        assert!(result.error_message.is_none());
+    }
+
+    #[test]
     fn test_parse_proof_id_valid() {
         let hex = "0x0000000000000000000000000000000000000000000000000000000000000001";
         let result = NetworkBackend::parse_proof_id(hex);

--- a/crates/proof/zk/service/src/backends/op_succinct/network.rs
+++ b/crates/proof/zk/service/src/backends/op_succinct/network.rs
@@ -449,8 +449,44 @@ impl NetworkBackend {
         match self.build_aggregation_session(proof_request).await {
             Ok(session) => {
                 let backend_session_id = session.backend_session_id.clone();
-                let activated =
-                    repo.activate_reserved_proof_session(&reservation_id, session).await?;
+                let activated = match repo
+                    .activate_reserved_proof_session(&reservation_id, session)
+                    .await
+                {
+                    Ok(v) => v,
+                    Err(e) => {
+                        // Network job has already been submitted but the DB activation
+                        // failed. Release the reservation so the partial unique index
+                        // does not permanently block future SNARK attempts; the in-flight
+                        // network job is orphaned and will fall on the floor.
+                        let error_message =
+                            format!("failed to activate reserved SNARK session: {e}");
+                        if let Err(fail_err) = repo
+                            .fail_reserved_proof_session(
+                                proof_request.id,
+                                SessionType::Snark,
+                                &reservation_id,
+                                &error_message,
+                            )
+                            .await
+                        {
+                            warn!(
+                                proof_request_id = %proof_request.id,
+                                reservation_id = %reservation_id,
+                                error = %fail_err,
+                                "failed to release SNARK reservation after activation error"
+                            );
+                        }
+                        error!(
+                            proof_request_id = %proof_request.id,
+                            reservation_id = %reservation_id,
+                            backend_session_id = %backend_session_id,
+                            error = %e,
+                            "failed to activate reserved SNARK session; backend job may be orphaned"
+                        );
+                        return Err(e.into());
+                    }
+                };
                 if !activated {
                     warn!(
                         proof_request_id = %proof_request.id,

--- a/crates/proof/zk/service/src/backends/op_succinct/network.rs
+++ b/crates/proof/zk/service/src/backends/op_succinct/network.rs
@@ -417,7 +417,7 @@ impl NetworkBackend {
     ///
     /// Concurrent pollers race here; the SNARK session row is reserved in Postgres
     /// **before** any expensive work so that the partial unique index
-    /// `idx_proof_sessions_request_type_running_unique` ensures only one caller
+    /// `idx_proof_sessions_request_type_active_unique` ensures only one caller
     /// reaches the network prover. See cluster.rs for details.
     async fn submit_aggregation_proof(
         &self,


### PR DESCRIPTION
## Summary

Concurrent callers of `sync_and_update_proof_status` (`StatusPoller` and `GetProof` RPC) all observed the same "STARK done, no SNARK yet" state and each submitted an independent Groth16 prove job to the SP1 cluster, then each inserted a duplicate `proof_sessions` row. PoC: 8 concurrent workers triggered 8 cluster `create_request` calls for a single proof request.

This PR gates the SNARK stage with a partial unique index plus a reserve-then-submit flow, so only one caller ever reaches `create_request`.

## Tracking

CHAIN-4254 (Immunefi 75630)