### PR TITLE
refactor(contracts): introduce GameStatus enum replacing raw u8 

### DIFF
--- a/crates/proof/challenge/src/bond.rs
+++ b/crates/proof/challenge/src/bond.rs
@@ -34,7 +34,7 @@ use std::{
 use alloy_primitives::Address;
 use base_proof_contracts::{
     AggregateVerifierClient, DelayedWETHClient, DelayedWETHContractClient,
-    DisputeGameFactoryClient, encode_claim_credit_calldata, encode_resolve_calldata,
+    DisputeGameFactoryClient, GameStatus, encode_claim_credit_calldata, encode_resolve_calldata,
     encode_set_anchor_state_calldata,
 };
 use base_runtime::Clock;
@@ -87,11 +87,10 @@ pub struct TrackedGame {
     /// `setAnchorState()` call or when the game is not eligible
     /// (e.g. `CHALLENGER_WINS`).
     pub anchor_update_complete: bool,
-    /// Cached on-chain game status (`0` = in progress, `1` = challenger
-    /// wins, `2` = defender wins). Populated on the first successful
+    /// Cached on-chain game status. Populated on the first successful
     /// `status()` RPC read; subsequent ticks reuse the cached value
     /// because the status is immutable after resolution.
-    pub cached_status: Option<u8>,
+    pub cached_status: Option<GameStatus>,
     /// Cached `AnchorStateRegistry` address for this game. Read from the
     /// game contract on first use and reused thereafter (immutable per game).
     pub cached_asr_address: Option<Address>,
@@ -179,9 +178,6 @@ impl<C: Clock> BondManager<C> {
 
     /// How long to wait before retrying a reverted withdraw attempt.
     const WITHDRAW_REVERT_RETRY_DELAY: Duration = Duration::from_secs(60);
-
-    /// `DEFENDER_WINS` game status constant.
-    const STATUS_DEFENDER_WINS: u8 = 2;
 
     /// Creates a new bond manager for the given set of claim addresses.
     pub fn new(
@@ -779,7 +775,7 @@ impl<C: Clock> BondManager<C> {
     ) -> eyre::Result<Option<RemovalReason>> {
         let status = verifier_client.status(game_address).await?;
 
-        if status == GameScanner::STATUS_IN_PROGRESS {
+        if status == GameStatus::InProgress {
             let game_over = verifier_client.game_over(game_address).await?;
             if !game_over {
                 debug!(game = %game_address, "game dispute period not yet elapsed");
@@ -829,7 +825,7 @@ impl<C: Clock> BondManager<C> {
         } else {
             ChallengerMetrics::resolve_tx_outcome_total(ChallengerMetrics::STATUS_ALREADY_RESOLVED)
                 .increment(1);
-            info!(game = %game_address, status, "game already resolved");
+            info!(game = %game_address, status = ?status, "game already resolved");
             // Status is immutable after resolution — cache it so that
             // try_anchor_update (called later this tick) can skip the
             // redundant RPC round-trip.
@@ -1233,7 +1229,7 @@ impl<C: Clock> BondManager<C> {
             }
         };
 
-        if status != Self::STATUS_DEFENDER_WINS {
+        if status != GameStatus::DefenderWins {
             self.skip_anchor_update_permanently(game_address);
             return;
         }
@@ -1629,7 +1625,7 @@ mod tests {
             },
         );
 
-        let mut state = mock_state(2, Address::ZERO, 100);
+        let mut state = mock_state(GameStatus::DefenderWins, Address::ZERO, 100);
         state.bond_recipient = claim_addr;
         state.resolved_at = resolved_at;
         state.bond_unlocked = true;
@@ -1708,7 +1704,7 @@ mod tests {
             },
         );
 
-        let mut state = mock_state(2, Address::ZERO, 100);
+        let mut state = mock_state(GameStatus::DefenderWins, Address::ZERO, 100);
         state.bond_recipient = claim_addr;
         state.resolved_at = resolved_at;
         state.bond_unlocked = true;
@@ -1831,7 +1827,7 @@ mod tests {
         let games: Vec<_> = (0..game_count).map(|i| factory_game(i, 0)).collect();
         let mut verifier_games = HashMap::new();
         for i in 0..game_count {
-            let mut state = mock_state(0, zk_prover, 100 + i);
+            let mut state = mock_state(GameStatus::InProgress, zk_prover, 100 + i);
             state.bond_recipient = bond_recipient;
             verifier_games.insert(addr(i), state);
         }
@@ -1867,7 +1863,7 @@ mod tests {
         let claim_addr = Address::repeat_byte(0xCC);
         let other_recipient = Address::repeat_byte(0xDD);
         // bond_recipient is someone else, but zkProver matches our address.
-        // Status 0 = IN_PROGRESS, so the game should match via zkProver.
+        // Status is InProgress, so the game should match via zkProver.
         let (factory, verifier) = discovery_mocks(2, other_recipient, claim_addr);
 
         let clock = fixed_clock(0);
@@ -1916,7 +1912,7 @@ mod tests {
 
         let games = vec![factory_game(0, 0)];
         let mut verifier_games = HashMap::new();
-        let mut state = mock_state(1, Address::ZERO, 100);
+        let mut state = mock_state(GameStatus::ChallengerWins, Address::ZERO, 100);
         state.bond_recipient = claim_addr;
         state.bond_claimed = true; // already claimed
         state.resolved_at = 500;
@@ -2064,7 +2060,7 @@ mod tests {
         // resolved_at = 1_999_999_900 → age = 2_000_000_000 - 1_999_999_900 = 100s
         // monotonic 500 - 100 = 400 → unlocked_at should be 400s.
         let game = addr(0);
-        let mut state = mock_state(1, Address::ZERO, 100);
+        let mut state = mock_state(GameStatus::ChallengerWins, Address::ZERO, 100);
         state.resolved_at = 1_999_999_900;
         state.bond_unlocked = true;
 
@@ -2084,7 +2080,7 @@ mod tests {
     #[tokio::test]
     async fn determine_phase_returns_needs_withdraw_when_delay_elapsed() {
         let game = addr(0);
-        let mut state = mock_state(1, Address::ZERO, 100);
+        let mut state = mock_state(GameStatus::ChallengerWins, Address::ZERO, 100);
         state.resolved_at = 1_999_999_900;
         state.bond_unlocked = true;
 
@@ -2108,7 +2104,7 @@ mod tests {
 
         // resolved_at = 1_999_999_800 -> age = 2_000_000_000 - 1_999_999_800 = 200s.
         // With a 60s WETH delay, this should advance straight to withdrawal.
-        let mut state = mock_state(1, Address::ZERO, 100);
+        let mut state = mock_state(GameStatus::ChallengerWins, Address::ZERO, 100);
         state.bond_recipient = claim_addr;
         state.resolved_at = 1_999_999_800;
         state.bond_unlocked = true;
@@ -2150,7 +2146,7 @@ mod tests {
         let game = addr(0);
         let tx_hash = B256::repeat_byte(0xDD);
 
-        let mut state = mock_state(1, Address::ZERO, 100);
+        let mut state = mock_state(GameStatus::ChallengerWins, Address::ZERO, 100);
         state.bond_recipient = claim_addr;
         state.resolved_at = 1_999_999_900;
         state.bond_unlocked = false;
@@ -2306,7 +2302,7 @@ mod tests {
         mgr.track_game(game, claim_addr);
         // Game is still in NeedsResolve — should not attempt anchor update.
 
-        let mut state = mock_state(2, Address::ZERO, 100);
+        let mut state = mock_state(GameStatus::DefenderWins, Address::ZERO, 100);
         state.bond_recipient = claim_addr;
         state.anchor_state_registry = asr;
         let verifier = Arc::new(MockAggregateVerifier::new([(game, state)].into_iter().collect()));
@@ -2328,8 +2324,8 @@ mod tests {
         mgr.track_game(game, claim_addr);
         mgr.set_phase(game, BondPhase::NeedsUnlock);
 
-        // Status 1 = CHALLENGER_WINS — not eligible for anchor update.
-        let mut state = mock_state(1, Address::ZERO, 100);
+        // ChallengerWins — not eligible for anchor update.
+        let mut state = mock_state(GameStatus::ChallengerWins, Address::ZERO, 100);
         state.bond_recipient = claim_addr;
         state.anchor_state_registry = asr;
         let verifier = Arc::new(MockAggregateVerifier::new([(game, state)].into_iter().collect()));
@@ -2352,8 +2348,8 @@ mod tests {
         mgr.track_game(game, claim_addr);
         mgr.set_phase(game, BondPhase::NeedsUnlock);
 
-        // Status 2 = DEFENDER_WINS — eligible.
-        let mut state = mock_state(2, Address::ZERO, 100);
+        // DefenderWins — eligible for anchor update.
+        let mut state = mock_state(GameStatus::DefenderWins, Address::ZERO, 100);
         state.bond_recipient = claim_addr;
         state.anchor_state_registry = asr;
         let verifier = Arc::new(MockAggregateVerifier::new([(game, state)].into_iter().collect()));
@@ -2385,7 +2381,7 @@ mod tests {
             },
         );
 
-        let mut state = mock_state(2, Address::ZERO, 100);
+        let mut state = mock_state(GameStatus::DefenderWins, Address::ZERO, 100);
         state.bond_recipient = claim_addr;
         state.anchor_state_registry = asr;
         let verifier = Arc::new(MockAggregateVerifier::new([(game, state)].into_iter().collect()));
@@ -2410,7 +2406,7 @@ mod tests {
         mgr.track_game(game, claim_addr);
         mgr.set_phase(game, BondPhase::NeedsUnlock);
 
-        let mut state = mock_state(2, Address::ZERO, 100);
+        let mut state = mock_state(GameStatus::DefenderWins, Address::ZERO, 100);
         state.bond_recipient = claim_addr;
         state.anchor_state_registry = asr;
         let verifier = Arc::new(MockAggregateVerifier::new([(game, state)].into_iter().collect()));
@@ -2439,7 +2435,7 @@ mod tests {
         mgr.track_game(game, claim_addr);
         mgr.set_phase(game, BondPhase::NeedsUnlock);
 
-        let mut state = mock_state(2, Address::ZERO, 100);
+        let mut state = mock_state(GameStatus::DefenderWins, Address::ZERO, 100);
         state.bond_recipient = claim_addr;
         state.anchor_state_registry = asr;
         mutate(&mut state);
@@ -2491,7 +2487,7 @@ mod tests {
         mgr.track_game(game, claim_addr);
         mgr.set_phase(game, BondPhase::Completed);
 
-        let mut state = mock_state(2, Address::ZERO, 100);
+        let mut state = mock_state(GameStatus::DefenderWins, Address::ZERO, 100);
         state.bond_recipient = claim_addr;
         state.anchor_state_registry = asr;
         state.is_finalized = false;
@@ -2515,7 +2511,7 @@ mod tests {
         mgr.track_game(game, claim_addr);
         mgr.set_phase(game, BondPhase::Completed);
 
-        let mut state = mock_state(2, Address::ZERO, 100);
+        let mut state = mock_state(GameStatus::DefenderWins, Address::ZERO, 100);
         state.bond_recipient = claim_addr;
         state.anchor_state_registry = asr;
         state.is_finalized = false;
@@ -2540,7 +2536,7 @@ mod tests {
         let mut mgr = make_manager(vec![claim_addr]);
         mgr.track_game(game, claim_addr);
 
-        let mut state = mock_state(2, Address::ZERO, 100);
+        let mut state = mock_state(GameStatus::DefenderWins, Address::ZERO, 100);
         state.bond_recipient = other_recipient;
         state.anchor_state_registry = asr;
         state.is_finalized = false;

--- a/crates/proof/challenge/src/driver.rs
+++ b/crates/proof/challenge/src/driver.rs
@@ -18,7 +18,7 @@
 use std::{sync::Arc, time::Duration};
 
 use alloy_primitives::{Address, B256, Bytes};
-use base_proof_contracts::AggregateVerifierClient;
+use base_proof_contracts::{AggregateVerifierClient, GameStatus};
 use base_proof_primitives::{
     ProofEncoder, ProofRequest as TeeProofRequest, ProofResult, ProverClient,
 };
@@ -694,8 +694,8 @@ impl<L2: L2Provider, P: ZkProofProvider, T: TxManager, C: Clock> Driver<L2, P, T
             self.verifier_client.zk_prover(game_address),
         )?;
 
-        if status != GameScanner::STATUS_IN_PROGRESS {
-            debug!(game = %game_address, status = status, "game no longer in progress, dropping pending proof");
+        if status != GameStatus::InProgress {
+            debug!(game = %game_address, status = ?status, "game no longer in progress, dropping pending proof");
             self.pending_proofs.remove(&game_address);
             return Ok(());
         }

--- a/crates/proof/challenge/src/scanner.rs
+++ b/crates/proof/challenge/src/scanner.rs
@@ -39,7 +39,7 @@ use std::{
 
 use alloy_primitives::{Address, B256};
 use base_proof_contracts::{
-    AggregateVerifierClient, DisputeGameFactoryClient, GameAtIndex, GameInfo,
+    AggregateVerifierClient, DisputeGameFactoryClient, GameAtIndex, GameInfo, GameStatus,
 };
 use eyre::Result;
 use futures::stream::{self, StreamExt};
@@ -147,9 +147,6 @@ impl std::fmt::Debug for GameScanner {
 }
 
 impl GameScanner {
-    /// Game status indicating the dispute is still in progress.
-    pub const STATUS_IN_PROGRESS: u8 = 0;
-
     /// Maximum number of games to evaluate concurrently during a scan.
     pub const SCAN_CONCURRENCY: usize = 32;
 
@@ -230,8 +227,8 @@ impl GameScanner {
         let factory = self.factory_client.game_at_index(index).await?;
 
         let status = self.verifier_client.status(factory.proxy).await?;
-        if status != Self::STATUS_IN_PROGRESS {
-            debug!(index = index, status = status, "skipping game not in progress");
+        if status != GameStatus::InProgress {
+            debug!(index = index, status = ?status, "skipping game not in progress");
             return Ok(None);
         }
 

--- a/crates/proof/challenge/src/test_utils.rs
+++ b/crates/proof/challenge/src/test_utils.rs
@@ -18,7 +18,7 @@ use async_trait::async_trait;
 use base_common_consensus::Predeploys;
 use base_proof_contracts::{
     AggregateVerifierClient, AnchorPreflight, AnchorRoot, ContractError, DisputeGameFactoryClient,
-    GameAtIndex, GameInfo,
+    GameAtIndex, GameInfo, GameStatus,
 };
 use base_proof_primitives::{ProofRequest, ProofResult, ProverClient};
 use base_proof_rpc::{L2Provider, RpcError, RpcResult};
@@ -36,8 +36,8 @@ pub const TEST_DISCOVERY_INTERVAL: Duration = Duration::from_secs(300);
 /// Per-game state for the mock verifier.
 #[derive(Debug, Clone)]
 pub struct MockGameState {
-    /// Game status (`0=IN_PROGRESS`, `1=CHALLENGER_WINS`, `2=DEFENDER_WINS`).
-    pub status: u8,
+    /// Game status.
+    pub status: GameStatus,
     /// Address of the ZK prover (`Address::ZERO` if unchallenged).
     pub zk_prover: Address,
     /// Address of the TEE prover (`Address::ZERO` if no TEE proof submitted).
@@ -87,7 +87,7 @@ pub struct MockGameState {
 impl Default for MockGameState {
     fn default() -> Self {
         Self {
-            status: 0,
+            status: GameStatus::InProgress,
             zk_prover: Address::ZERO,
             tee_prover: Address::ZERO,
             game_info: GameInfo {
@@ -215,7 +215,7 @@ impl AggregateVerifierClient for MockAggregateVerifier {
         self.get(game_address, |s| s.game_info)
     }
 
-    async fn status(&self, game_address: Address) -> Result<u8, ContractError> {
+    async fn status(&self, game_address: Address) -> Result<GameStatus, ContractError> {
         self.get(game_address, |s| s.status)
     }
 
@@ -385,13 +385,17 @@ pub const DEFAULT_L1_HEAD: B256 = B256::repeat_byte(0xAA);
 ///
 /// Uses [`DEFAULT_TEE_PROVER`] as the TEE prover address. Use
 /// [`mock_state_with_tee`] to override.
-pub const fn mock_state(status: u8, zk_prover: Address, block_number: u64) -> MockGameState {
+pub const fn mock_state(
+    status: GameStatus,
+    zk_prover: Address,
+    block_number: u64,
+) -> MockGameState {
     mock_state_with_tee(status, zk_prover, DEFAULT_TEE_PROVER, block_number)
 }
 
 /// Helper to build mock game state with an explicit TEE prover address.
 pub const fn mock_state_with_tee(
-    status: u8,
+    status: GameStatus,
     zk_prover: Address,
     tee_prover: Address,
     block_number: u64,
@@ -843,11 +847,11 @@ mod tests {
 
         let challenger_addr = Address::repeat_byte(0xCC);
         let mut verifier_games = HashMap::new();
-        verifier_games.insert(addr(0), mock_state(0, Address::ZERO, 100));
-        verifier_games.insert(addr(1), mock_state(0, Address::ZERO, 150));
-        verifier_games.insert(addr(2), mock_state(1, Address::ZERO, 200));
-        verifier_games.insert(addr(3), mock_state(0, challenger_addr, 300));
-        verifier_games.insert(addr(4), mock_state(0, Address::ZERO, 400));
+        verifier_games.insert(addr(0), mock_state(GameStatus::InProgress, Address::ZERO, 100));
+        verifier_games.insert(addr(1), mock_state(GameStatus::InProgress, Address::ZERO, 150));
+        verifier_games.insert(addr(2), mock_state(GameStatus::ChallengerWins, Address::ZERO, 200));
+        verifier_games.insert(addr(3), mock_state(GameStatus::InProgress, challenger_addr, 300));
+        verifier_games.insert(addr(4), mock_state(GameStatus::InProgress, Address::ZERO, 400));
 
         let verifier = Arc::new(MockAggregateVerifier::new(verifier_games));
 
@@ -885,11 +889,11 @@ mod tests {
 
         let mut verifier_games = HashMap::new();
         // Game 0: TEE + ZK (dual proof, no challenge) -> candidate (InvalidDualProposal)
-        verifier_games.insert(addr(0), mock_state(0, zk_addr, 100));
+        verifier_games.insert(addr(0), mock_state(GameStatus::InProgress, zk_addr, 100));
         // Game 1: TEE only -> candidate (InvalidTeeProposal)
-        verifier_games.insert(addr(1), mock_state(0, Address::ZERO, 200));
+        verifier_games.insert(addr(1), mock_state(GameStatus::InProgress, Address::ZERO, 200));
         // Game 2: TEE + ZK (dual proof, no challenge) -> candidate (InvalidDualProposal)
-        verifier_games.insert(addr(2), mock_state(0, zk_addr, 300));
+        verifier_games.insert(addr(2), mock_state(GameStatus::InProgress, zk_addr, 300));
 
         let verifier = Arc::new(MockAggregateVerifier::new(verifier_games));
 
@@ -928,7 +932,8 @@ mod tests {
 
         for i in 0..100u64 {
             games.push(factory_game(i, 1));
-            verifier_games.insert(addr(i), mock_state(0, Address::ZERO, i * 10));
+            verifier_games
+                .insert(addr(i), mock_state(GameStatus::InProgress, Address::ZERO, i * 10));
         }
 
         let factory = Arc::new(MockDisputeGameFactory { games });
@@ -959,9 +964,9 @@ mod tests {
         });
 
         let mut verifier_games = HashMap::new();
-        verifier_games.insert(addr(0), mock_state(0, Address::ZERO, 100));
+        verifier_games.insert(addr(0), mock_state(GameStatus::InProgress, Address::ZERO, 100));
         // index 1 won't be queried on the verifier because the factory errors first
-        verifier_games.insert(addr(2), mock_state(0, Address::ZERO, 300));
+        verifier_games.insert(addr(2), mock_state(GameStatus::InProgress, Address::ZERO, 300));
 
         let verifier = Arc::new(MockAggregateVerifier::new(verifier_games));
 
@@ -990,9 +995,12 @@ mod tests {
 
         let mut verifier_games = HashMap::new();
         // Game 0: IN_PROGRESS, no ZK prover, has a TEE prover -> candidate
-        verifier_games.insert(addr(0), mock_state_with_tee(0, Address::ZERO, tee_addr, 100));
+        verifier_games.insert(
+            addr(0),
+            mock_state_with_tee(GameStatus::InProgress, Address::ZERO, tee_addr, 100),
+        );
         // Game 1: IN_PROGRESS, no ZK prover, has default TEE prover -> candidate
-        verifier_games.insert(addr(1), mock_state(0, Address::ZERO, 200));
+        verifier_games.insert(addr(1), mock_state(GameStatus::InProgress, Address::ZERO, 200));
 
         let verifier = Arc::new(MockAggregateVerifier::new(verifier_games));
 
@@ -1014,7 +1022,7 @@ mod tests {
         });
 
         let mut verifier_games = HashMap::new();
-        verifier_games.insert(addr(1), mock_state(0, Address::ZERO, 200));
+        verifier_games.insert(addr(1), mock_state(GameStatus::InProgress, Address::ZERO, 200));
 
         let verifier = Arc::new(MockAggregateVerifier::new(verifier_games));
 
@@ -1036,7 +1044,7 @@ mod tests {
         let factory = Arc::new(MockDisputeGameFactory { games: vec![factory_game(0, 1)] });
 
         let mut verifier_games = HashMap::new();
-        let mut state = mock_state_with_tee(0, zk_addr, tee_addr, 100);
+        let mut state = mock_state_with_tee(GameStatus::InProgress, zk_addr, tee_addr, 100);
         state.countered_index = 3; // 1-based: challenged at 0-based index 2
         verifier_games.insert(addr(0), state);
 
@@ -1062,7 +1070,10 @@ mod tests {
 
         let mut verifier_games = HashMap::new();
         // tee_prover == ZERO, zk_prover != ZERO, countered_index == 0
-        verifier_games.insert(addr(0), mock_state_with_tee(0, zk_addr, Address::ZERO, 100));
+        verifier_games.insert(
+            addr(0),
+            mock_state_with_tee(GameStatus::InProgress, zk_addr, Address::ZERO, 100),
+        );
 
         let verifier = Arc::new(MockAggregateVerifier::new(verifier_games));
         let scanner = GameScanner::new(factory, verifier, ScannerConfig { lookback_games: 1000 });
@@ -1080,7 +1091,7 @@ mod tests {
         let factory = Arc::new(MockDisputeGameFactory { games: vec![factory_game(0, 1)] });
 
         let mut verifier_games = HashMap::new();
-        verifier_games.insert(addr(0), mock_state(0, Address::ZERO, 100));
+        verifier_games.insert(addr(0), mock_state(GameStatus::InProgress, Address::ZERO, 100));
 
         let verifier = Arc::new(MockAggregateVerifier::new(verifier_games));
         let scanner = GameScanner::new(factory, verifier, ScannerConfig { lookback_games: 1000 });
@@ -1102,7 +1113,8 @@ mod tests {
 
         let mut verifier_games = HashMap::new();
         // Both provers non-zero, countered_index == 0 (added via verifyProposalProof)
-        verifier_games.insert(addr(0), mock_state_with_tee(0, zk_addr, tee_addr, 100));
+        verifier_games
+            .insert(addr(0), mock_state_with_tee(GameStatus::InProgress, zk_addr, tee_addr, 100));
 
         let verifier = Arc::new(MockAggregateVerifier::new(verifier_games));
         let scanner = GameScanner::new(factory, verifier, ScannerConfig { lookback_games: 1000 });
@@ -1126,11 +1138,20 @@ mod tests {
 
         let mut verifier_games = HashMap::new();
         // Game 0: both provers zeroed (nullified) → filtered out
-        verifier_games.insert(addr(0), mock_state_with_tee(0, Address::ZERO, Address::ZERO, 100));
+        verifier_games.insert(
+            addr(0),
+            mock_state_with_tee(GameStatus::InProgress, Address::ZERO, Address::ZERO, 100),
+        );
         // Game 1: TEE prover active, ZK prover zero → candidate
-        verifier_games.insert(addr(1), mock_state_with_tee(0, Address::ZERO, tee_addr, 200));
+        verifier_games.insert(
+            addr(1),
+            mock_state_with_tee(GameStatus::InProgress, Address::ZERO, tee_addr, 200),
+        );
         // Game 2: both provers zeroed (nullified) → filtered out
-        verifier_games.insert(addr(2), mock_state_with_tee(0, Address::ZERO, Address::ZERO, 300));
+        verifier_games.insert(
+            addr(2),
+            mock_state_with_tee(GameStatus::InProgress, Address::ZERO, Address::ZERO, 300),
+        );
 
         let verifier = Arc::new(MockAggregateVerifier::new(verifier_games));
 

--- a/crates/proof/challenge/tests/driver.rs
+++ b/crates/proof/challenge/tests/driver.rs
@@ -19,7 +19,7 @@ use base_challenger::{
         mock_state, mock_state_with_tee, receipt_with_status,
     },
 };
-use base_proof_contracts::{AggregateVerifierClient, ContractError, GameAtIndex};
+use base_proof_contracts::{AggregateVerifierClient, ContractError, GameAtIndex, GameStatus};
 use base_proof_primitives::{ProofResult, Proposal, ProverClient};
 use base_protocol::OutputRoot;
 use base_runtime::TokioRuntime;
@@ -283,7 +283,10 @@ async fn test_step_invalid_game_proof_succeeded() {
     );
 
     // Simulate the on-chain effect of a successful challenge: game is resolved.
-    verifier.update_game(addr(0), MockGameState { status: 1, ..game_state(20) });
+    verifier.update_game(
+        addr(0),
+        MockGameState { status: GameStatus::ChallengerWins, ..game_state(20) },
+    );
 
     // Step 2: proof polled → Succeeded → nullification submitted → entry removed.
     driver.step().await.unwrap();
@@ -417,7 +420,10 @@ async fn test_step_pending_proof_skips_prove_block() {
     zk.state.lock().unwrap().proof_status = ProofJobStatus::Succeeded as i32;
 
     // Simulate the on-chain effect: game is resolved after challenge tx.
-    verifier.update_game(addr(0), MockGameState { status: 1, ..game_state(20) });
+    verifier.update_game(
+        addr(0),
+        MockGameState { status: GameStatus::ChallengerWins, ..game_state(20) },
+    );
 
     // Step 2: same game re-discovered → polls existing session, proof succeeds,
     // challenge tx submitted, session removed from pending_proofs.
@@ -457,7 +463,10 @@ async fn test_step_nullification_failure_preserves_proof() {
     assert!(entry.is_ready(), "phase should be ReadyToSubmit after tx failure");
 
     // Simulate the on-chain effect of a successful challenge: game is resolved.
-    verifier.update_game(addr(0), MockGameState { status: 1, ..game_state(20) });
+    verifier.update_game(
+        addr(0),
+        MockGameState { status: GameStatus::ChallengerWins, ..game_state(20) },
+    );
 
     // Step 3: poll_pending_proofs re-submits the challenge tx, now it succeeds.
     driver.step().await.unwrap();
@@ -469,9 +478,10 @@ async fn test_step_nullification_failure_preserves_proof() {
 
 #[tokio::test]
 async fn test_poll_or_submit_drops_resolved_game() {
-    // Game has resolved (status=1 CHALLENGER_WINS) — driver should drop the
+    // Game has resolved (ChallengerWins) — driver should drop the
     // pending proof without attempting submission.
-    let mut driver = driver_with_ready_proof(mock_state(1, Address::ZERO, 20));
+    let mut driver =
+        driver_with_ready_proof(mock_state(GameStatus::ChallengerWins, Address::ZERO, 20));
     driver.step().await.unwrap();
     assert!(
         !driver.pending_proofs.contains_key(&addr(0)),
@@ -483,7 +493,8 @@ async fn test_poll_or_submit_drops_resolved_game() {
 async fn test_poll_or_submit_drops_already_challenged_game() {
     // Game is still IN_PROGRESS but already challenged (zk_prover != ZERO)
     // — driver should drop the pending proof.
-    let mut driver = driver_with_ready_proof(mock_state(0, ZK_PROVER_ADDR, 20));
+    let mut driver =
+        driver_with_ready_proof(mock_state(GameStatus::InProgress, ZK_PROVER_ADDR, 20));
     driver.step().await.unwrap();
     assert!(
         !driver.pending_proofs.contains_key(&addr(0)),
@@ -495,8 +506,12 @@ async fn test_poll_or_submit_drops_already_challenged_game() {
 async fn test_poll_or_submit_drops_nullified_game() {
     // Game is still IN_PROGRESS but both provers are ZERO (nullified)
     // — driver should drop the pending proof without attempting submission.
-    let mut driver =
-        driver_with_ready_proof(mock_state_with_tee(0, Address::ZERO, Address::ZERO, 20));
+    let mut driver = driver_with_ready_proof(mock_state_with_tee(
+        GameStatus::InProgress,
+        Address::ZERO,
+        Address::ZERO,
+        20,
+    ));
     driver.step().await.unwrap();
     assert!(
         !driver.pending_proofs.contains_key(&addr(0)),
@@ -556,7 +571,10 @@ async fn test_step_proof_retry_succeeds() {
     zk.state.lock().unwrap().proof_status = ProofJobStatus::Succeeded as i32;
 
     // Simulate the on-chain effect of a successful challenge: game is resolved.
-    verifier.update_game(addr(0), MockGameState { status: 1, ..game_state(20) });
+    verifier.update_game(
+        addr(0),
+        MockGameState { status: GameStatus::ChallengerWins, ..game_state(20) },
+    );
 
     // Step 3: proof succeeds, challenge tx submitted, entry removed.
     driver.step().await.unwrap();
@@ -592,7 +610,10 @@ async fn test_step_proof_exceeds_max_retries() {
 
     // Simulate the on-chain effect: mark the game as resolved so the
     // stateless scanner does not re-discover it after the entry is dropped.
-    verifier.update_game(addr(0), MockGameState { status: 1, ..game_state(20) });
+    verifier.update_game(
+        addr(0),
+        MockGameState { status: GameStatus::ChallengerWins, ..game_state(20) },
+    );
 
     // One more step: poll returns Failed → retry_count becomes max_retries + 1,
     // handle_proof_retry sees retry_count > MAX_PROOF_RETRIES and drops the entry.
@@ -676,7 +697,10 @@ async fn test_step_invalid_game_tee_fails_zk_succeeds() {
     );
 
     // Simulate the on-chain effect of a successful challenge: game is resolved.
-    verifier.update_game(addr(0), MockGameState { status: 1, ..game_state(20) });
+    verifier.update_game(
+        addr(0),
+        MockGameState { status: GameStatus::ChallengerWins, ..game_state(20) },
+    );
 
     // Step 2: proof polled → Succeeded → challenge tx submitted → entry removed.
     driver.step().await.unwrap();
@@ -805,7 +829,10 @@ async fn test_step_tee_submission_failure_falls_back_to_zk() {
     // Simulate the on-chain effect of a successful challenge: game is
     // resolved. This prevents the scanner from re-discovering the game
     // after the pending proof is submitted in step 2.
-    verifier.update_game(addr(0), MockGameState { status: 1, ..game_state(20) });
+    verifier.update_game(
+        addr(0),
+        MockGameState { status: GameStatus::ChallengerWins, ..game_state(20) },
+    );
 
     // Step 2: ZK proof polled → Succeeded → entry cleaned up.
     driver.step().await.unwrap();
@@ -844,7 +871,8 @@ async fn test_poll_or_submit_nullify_intent_not_dropped_when_zk_prover_set() {
     // requires zkProver == ZERO).
     let factory = single_game_factory();
     let l2 = default_l2();
-    let mut game_state = mock_state_with_tee(0, ZK_PROVER_ADDR, DEFAULT_TEE_PROVER, 20);
+    let mut game_state =
+        mock_state_with_tee(GameStatus::InProgress, ZK_PROVER_ADDR, DEFAULT_TEE_PROVER, 20);
     game_state.countered_index = 2; // challenged at 0-based index 1
     // Provide intermediate roots so the scanner's FraudulentZkChallenge
     // processing (which runs after the pending proof is submitted) does not
@@ -869,8 +897,12 @@ async fn test_poll_or_submit_challenge_intent_dropped_when_zk_prover_set() {
     // when zkProver is non-zero (game already challenged).
     let factory = single_game_factory();
     let l2 = default_l2();
-    let verifier =
-        single_game_verifier(mock_state_with_tee(0, ZK_PROVER_ADDR, DEFAULT_TEE_PROVER, 20));
+    let verifier = single_game_verifier(mock_state_with_tee(
+        GameStatus::InProgress,
+        ZK_PROVER_ADDR,
+        DEFAULT_TEE_PROVER,
+        20,
+    ));
 
     let tx = MockTxManager::new(Err(TxManagerError::NonceTooLow)); // Should never be called
     let mut driver = test_driver(factory, verifier, l2, default_zk_prover(), tx);
@@ -1164,7 +1196,7 @@ async fn test_step_dual_proof_tee_fails_falls_back_to_zk_nullify() {
 // ──────────────────────────────────────────────────────────────────────────
 
 const fn bond_test_state(claim_addr: Address) -> MockGameState {
-    let mut state = mock_state(1, Address::ZERO, 100);
+    let mut state = mock_state(GameStatus::ChallengerWins, Address::ZERO, 100);
     state.bond_recipient = claim_addr;
     state
 }
@@ -1192,7 +1224,7 @@ async fn test_bond_manager_full_lifecycle() {
     // AwaitingDelay → NeedsWithdraw → Completed.
     //
     // The mock verifier uses a static game state, so we set
-    // status=1 (CHALLENGER_WINS) to represent a game that has already been
+    // ChallengerWins to represent a game that has already been
     // resolved on-chain. The manager detects this and advances directly
     // to NeedsUnlock without submitting a resolve transaction.
     let claim_addr = ZK_PROVER_ADDR;
@@ -1210,7 +1242,7 @@ async fn test_bond_manager_full_lifecycle() {
     assert!(mgr.track_game(game_addr, claim_addr));
     assert_eq!(mgr.tracked_count(), 1);
 
-    // Poll 1: NeedsResolve → status=1 (already resolved, CHALLENGER_WINS) → NeedsUnlock.
+    // Poll 1: NeedsResolve → already resolved (ChallengerWins) → NeedsUnlock.
     mgr.poll(&*verifier, &submitter).await;
     assert_eq!(mgr.tracked_count(), 1, "game should still be tracked after detecting resolution");
 
@@ -1316,7 +1348,7 @@ async fn test_bond_manager_tx_failure_retries() {
     let mut mgr = default_bond_manager(claim_addr);
     mgr.track_game(game_addr, claim_addr);
 
-    // Poll 1: NeedsResolve → status=1 (already resolved, CHALLENGER_WINS) → NeedsUnlock.
+    // Poll 1: NeedsResolve → already resolved (ChallengerWins) → NeedsUnlock.
     mgr.poll(&*verifier, &submitter).await;
     assert_eq!(mgr.tracked_count(), 1, "game should still be tracked after detecting resolution");
 
@@ -1349,7 +1381,7 @@ async fn test_bond_manager_keeps_defender_wins_when_recipient_is_claimable() {
     let game_addr = addr(0);
 
     let mut state = bond_test_state(claim_addr);
-    state.status = 2; // DEFENDER_WINS
+    state.status = GameStatus::DefenderWins;
     let verifier = single_game_verifier(state);
 
     // One response for the anchor state update that is attempted after
@@ -1377,7 +1409,7 @@ async fn test_bond_manager_removes_game_when_recipient_not_claimable() {
     let game_addr = addr(0);
 
     let mut state = bond_test_state(claim_addr);
-    state.status = 2; // DEFENDER_WINS
+    state.status = GameStatus::DefenderWins;
     state.bond_recipient = other_addr; // bond goes to someone else
     let verifier = single_game_verifier(state);
 

--- a/crates/proof/contracts/src/aggregate_verifier.rs
+++ b/crates/proof/contracts/src/aggregate_verifier.rs
@@ -32,7 +32,7 @@ sol! {
         /// Returns the L2 block number this game proposes.
         function l2SequenceNumber() external pure returns (uint256);
 
-        /// Returns the current game status (`0=IN_PROGRESS`, `1=CHALLENGER_WINS`, `2=DEFENDER_WINS`).
+        /// Returns the current game status. See [`GameStatus`] for values.
         function status() external view returns (uint8);
 
         /// Returns the address that provided a TEE proof.
@@ -158,14 +158,49 @@ pub struct GameInfo {
     pub parent_address: Address,
 }
 
+/// Status values returned by `AggregateVerifier.status()`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum GameStatus {
+    /// The game is still in progress.
+    InProgress = 0,
+    /// The challenger won the dispute.
+    ChallengerWins = 1,
+    /// The defender won the dispute.
+    DefenderWins = 2,
+}
+
+impl std::fmt::Display for GameStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::InProgress => write!(f, "InProgress (0)"),
+            Self::ChallengerWins => write!(f, "ChallengerWins (1)"),
+            Self::DefenderWins => write!(f, "DefenderWins (2)"),
+        }
+    }
+}
+
+impl TryFrom<u8> for GameStatus {
+    type Error = u8;
+
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        match value {
+            0 => Ok(Self::InProgress),
+            1 => Ok(Self::ChallengerWins),
+            2 => Ok(Self::DefenderWins),
+            other => Err(other),
+        }
+    }
+}
+
 /// Async trait for querying `AggregateVerifier` game instances.
 #[async_trait]
 pub trait AggregateVerifierClient: Send + Sync {
     /// Queries game details from a game proxy address.
     async fn game_info(&self, game_address: Address) -> Result<GameInfo, ContractError>;
 
-    /// Returns the current game status (`0=IN_PROGRESS`, `1=CHALLENGER_WINS`, `2=DEFENDER_WINS`).
-    async fn status(&self, game_address: Address) -> Result<u8, ContractError>;
+    /// Returns the current game status.
+    async fn status(&self, game_address: Address) -> Result<GameStatus, ContractError>;
 
     /// Returns the address that provided a ZK proof for the given game.
     async fn zk_prover(&self, game_address: Address) -> Result<Address, ContractError>;
@@ -310,15 +345,21 @@ impl AggregateVerifierClient for AggregateVerifierContractClient {
         Ok(GameInfo { root_claim, l2_block_number, parent_address })
     }
 
-    async fn status(&self, game_address: Address) -> Result<u8, ContractError> {
+    async fn status(&self, game_address: Address) -> Result<GameStatus, ContractError> {
         let contract =
             IAggregateVerifier::IAggregateVerifierInstance::new(game_address, &self.provider);
 
-        contract
+        let raw: u8 = contract
             .status()
             .call()
             .await
-            .map_err(|e| ContractError::Call { context: "status failed".into(), source: e })
+            .map_err(|e| ContractError::Call { context: "status failed".into(), source: e })?;
+
+        GameStatus::try_from(raw).map_err(|unknown| {
+            ContractError::Validation(format!(
+                "game {game_address} returned unrecognized status {unknown}"
+            ))
+        })
     }
 
     async fn zk_prover(&self, game_address: Address) -> Result<Address, ContractError> {

--- a/crates/proof/contracts/src/lib.rs
+++ b/crates/proof/contracts/src/lib.rs
@@ -8,9 +8,9 @@
 
 mod aggregate_verifier;
 pub use aggregate_verifier::{
-    AggregateVerifierClient, AggregateVerifierContractClient, GameInfo, encode_challenge_calldata,
-    encode_claim_credit_calldata, encode_nullify_calldata, encode_resolve_calldata,
-    l1_origin_too_old_selector,
+    AggregateVerifierClient, AggregateVerifierContractClient, GameInfo, GameStatus,
+    encode_challenge_calldata, encode_claim_credit_calldata, encode_nullify_calldata,
+    encode_resolve_calldata, l1_origin_too_old_selector,
 };
 
 mod delayed_weth;

--- a/crates/proof/proposer/src/test_utils.rs
+++ b/crates/proof/proposer/src/test_utils.rs
@@ -12,6 +12,7 @@ use base_common_genesis::RollupConfig;
 use base_proof_contracts::{
     AggregateVerifierClient, AnchorPreflight, AnchorRoot, AnchorSnapshot,
     AnchorStateRegistryClient, ContractError, DisputeGameFactoryClient, GameAtIndex, GameInfo,
+    GameStatus,
 };
 use base_proof_primitives::{ProofResult, Proposal, ProverClient};
 use base_proof_rpc::{
@@ -217,6 +218,8 @@ impl DisputeGameFactoryClient for MockDisputeGameFactory {
 pub struct MockAggregateVerifier {
     /// Map of game address to game info returned by `game_info()`.
     pub game_info_map: HashMap<Address, GameInfo>,
+    /// Map of game address to status returned by `status()`.
+    pub status_map: HashMap<Address, GameStatus>,
     /// Addresses for which `game_info()` returns an error.
     pub failing_addresses: HashSet<Address>,
     /// Map of game address to intermediate output roots.
@@ -244,8 +247,8 @@ impl AggregateVerifierClient for MockAggregateVerifier {
             parent_address: Address::ZERO,
         }))
     }
-    async fn status(&self, _: Address) -> Result<u8, ContractError> {
-        Ok(0)
+    async fn status(&self, addr: Address) -> Result<GameStatus, ContractError> {
+        Ok(self.status_map.get(&addr).copied().unwrap_or(GameStatus::InProgress))
     }
     async fn zk_prover(&self, _: Address) -> Result<Address, ContractError> {
         Ok(Address::ZERO)
@@ -321,6 +324,7 @@ impl AggregateVerifierClient for MockAggregateVerifier {
     async fn is_game_finalized(&self, _: Address, _: Address) -> Result<bool, ContractError> {
         Ok(true)
     }
+
     async fn anchor_preflight(
         &self,
         _: Address,


### PR DESCRIPTION
Add a shared GameStatus enum (InProgress, ChallengerWins, DefenderWins) in base-proof-contracts with TryFrom<u8>, Display, and #[repr(u8)]. Change the AggregateVerifierClient::status() trait to return GameStatus directly, pushing the u8 → enum conversion to the wire boundary.

Migrate all callers in the challenger (bond manager, driver, scanner) and proposer mocks from raw u8 constants and comparisons to typed enum variants, removing scattered STATUS_IN_PROGRESS / STATUS_DEFENDER_WINS constants.