### PR TITLE
fix(zk): add proof session reservations

### DIFF
--- a/crates/proof/zk/db/migrations/009_add_unique_proof_sessions.sql
+++ b/crates/proof/zk/db/migrations/009_add_unique_proof_sessions.sql
@@ -1,0 +1,32 @@
+-- Migration 009: Enforce one session row per proof request and session type
+-- Prevents concurrent status pollers from creating duplicate SNARK aggregation jobs.
+-- Manual retries reclaim FAILED rows instead of inserting duplicate session rows.
+
+-- Keep the most useful row if duplicates already exist, then enforce the invariant.
+WITH ranked_sessions AS (
+    SELECT
+        id,
+        ROW_NUMBER() OVER (
+            PARTITION BY proof_request_id, session_type
+            ORDER BY
+                CASE status
+                    WHEN 'COMPLETED' THEN 0
+                    WHEN 'RUNNING' THEN 1
+                    WHEN 'SUBMITTING' THEN 2
+                    WHEN 'FAILED' THEN 3
+                    ELSE 4
+                END,
+                created_at ASC,
+                id ASC
+        ) AS row_num
+    FROM proof_sessions
+)
+DELETE FROM proof_sessions
+USING ranked_sessions
+WHERE proof_sessions.id = ranked_sessions.id
+  AND ranked_sessions.row_num > 1;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_proof_sessions_request_type_unique
+ON proof_sessions(proof_request_id, session_type);
+
+COMMENT ON COLUMN proof_sessions.status IS 'Session status: SUBMITTING, RUNNING, COMPLETED, FAILED';

--- a/crates/proof/zk/db/migrations/009_add_unique_proof_sessions.sql
+++ b/crates/proof/zk/db/migrations/009_add_unique_proof_sessions.sql
@@ -1,6 +1,5 @@
 -- Migration 009: Enforce one session row per proof request and session type
 -- Prevents concurrent status pollers from creating duplicate SNARK aggregation jobs.
--- Manual retries reclaim FAILED rows instead of inserting duplicate session rows.
 
 -- Keep the most useful row if duplicates already exist, then enforce the invariant.
 WITH ranked_sessions AS (

--- a/crates/proof/zk/db/src/models.rs
+++ b/crates/proof/zk/db/src/models.rs
@@ -59,6 +59,8 @@ impl TryFrom<&str> for ProofStatus {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, sqlx::Type)]
 #[sqlx(type_name = "VARCHAR", rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum SessionStatus {
+    /// Backend session is being submitted and does not have a backend ID yet.
+    Submitting,
     /// Backend session is actively running.
     Running,
     /// Backend session completed successfully.
@@ -71,6 +73,7 @@ impl SessionStatus {
     /// Convert enum to static string representation
     pub const fn as_str(&self) -> &'static str {
         match self {
+            Self::Submitting => "SUBMITTING",
             Self::Running => "RUNNING",
             Self::Completed => "COMPLETED",
             Self::Failed => "FAILED",
@@ -89,6 +92,7 @@ impl TryFrom<&str> for SessionStatus {
 
     fn try_from(s: &str) -> Result<Self, Self::Error> {
         match s {
+            "SUBMITTING" => Ok(Self::Submitting),
             "RUNNING" => Ok(Self::Running),
             "COMPLETED" => Ok(Self::Completed),
             "FAILED" => Ok(Self::Failed),

--- a/crates/proof/zk/db/src/repo.rs
+++ b/crates/proof/zk/db/src/repo.rs
@@ -588,10 +588,9 @@ impl ProofRequestRepo {
 
     /// Create a new proof session.
     ///
-    /// This is intended for direct, non-reserved session creation. If another caller already
-    /// created the same `(proof_request_id, session_type)` row, this returns that row ID instead of
-    /// failing on the uniqueness invariant. Callers that need to avoid duplicate backend submission
-    /// should use [`Self::reserve_proof_session`] before submitting work.
+    /// This is intended for direct, non-reserved session creation. It is not idempotent under the
+    /// `(proof_request_id, session_type)` uniqueness invariant; callers that need first-writer-wins
+    /// behavior should use [`Self::reserve_proof_session`] before backend submission.
     pub async fn create_proof_session(&self, session: CreateProofSession) -> Result<i64> {
         let row = sqlx::query(
             r#"
@@ -599,8 +598,6 @@ impl ProofRequestRepo {
                 proof_request_id, session_type, backend_session_id, status, metadata
             )
             VALUES ($1, $2, $3, $4, $5)
-            ON CONFLICT (proof_request_id, session_type) DO UPDATE
-            SET backend_session_id = proof_sessions.backend_session_id
             RETURNING id
             "#,
         )
@@ -746,6 +743,13 @@ impl ProofRequestRepo {
                   AND ps.session_type = $5
                   AND ps.created_at < NOW() - INTERVAL '1 minute' * $1
                   AND pr.status IN ('PENDING', 'RUNNING')
+                  AND NOT EXISTS (
+                      SELECT 1
+                      FROM proof_sessions active
+                      WHERE active.proof_request_id = ps.proof_request_id
+                        AND active.id <> ps.id
+                        AND active.status IN ('SUBMITTING', 'RUNNING')
+                  )
             ),
             failed_sessions AS (
                 UPDATE proof_sessions ps

--- a/crates/proof/zk/db/src/repo.rs
+++ b/crates/proof/zk/db/src/repo.rs
@@ -492,6 +492,107 @@ impl ProofRequestRepo {
 
     // ========== Proof Session Methods ==========
 
+    /// Reserve a proof session slot before submitting work to the backend.
+    ///
+    /// Returns `Some(reservation_id)` if this caller created the reservation and should submit the
+    /// backend job. Returns `None` if another caller already reserved or created this session type.
+    /// A failed session may be reclaimed so manual retries can submit the SNARK stage again.
+    pub async fn reserve_proof_session(
+        &self,
+        proof_request_id: Uuid,
+        session_type: SessionType,
+    ) -> Result<Option<String>> {
+        let reservation_id =
+            format!("submitting-{}-{}", session_type.as_str().to_ascii_lowercase(), Uuid::new_v4());
+
+        let row = sqlx::query(
+            r#"
+            INSERT INTO proof_sessions (
+                proof_request_id, session_type, backend_session_id, status, metadata
+            )
+            VALUES ($1, $2, $3, $4, NULL)
+            ON CONFLICT (proof_request_id, session_type) DO UPDATE
+            SET backend_session_id = EXCLUDED.backend_session_id,
+                status = EXCLUDED.status,
+                metadata = EXCLUDED.metadata,
+                error_message = NULL,
+                completed_at = NULL,
+                created_at = NOW()
+            WHERE proof_sessions.status = $5
+            RETURNING backend_session_id
+            "#,
+        )
+        .bind(proof_request_id)
+        .bind(session_type.as_str())
+        .bind(&reservation_id)
+        .bind(SessionStatus::Submitting.as_str())
+        .bind(SessionStatus::Failed.as_str())
+        .fetch_optional(&self.pool)
+        .await?;
+
+        Ok(row.map(|r| r.get("backend_session_id")))
+    }
+
+    /// Activate a reserved proof session after the backend returns its session ID.
+    ///
+    /// Returns `true` when the reservation was found and updated.
+    pub async fn activate_reserved_proof_session(
+        &self,
+        reservation_id: &str,
+        session: CreateProofSession,
+    ) -> Result<bool> {
+        let result = sqlx::query(
+            r#"
+            UPDATE proof_sessions
+            SET backend_session_id = $1,
+                status = $2,
+                metadata = $3,
+                error_message = NULL
+            WHERE backend_session_id = $4
+              AND proof_request_id = $5
+              AND session_type = $6
+              AND status = $7
+            "#,
+        )
+        .bind(&session.backend_session_id)
+        .bind(SessionStatus::Running.as_str())
+        .bind(&session.metadata)
+        .bind(reservation_id)
+        .bind(session.proof_request_id)
+        .bind(session.session_type.as_str())
+        .bind(SessionStatus::Submitting.as_str())
+        .execute(&self.pool)
+        .await?;
+
+        Ok(result.rows_affected() > 0)
+    }
+
+    /// Mark a reserved proof session as failed when backend submission fails.
+    pub async fn fail_reserved_proof_session(
+        &self,
+        reservation_id: &str,
+        error_message: &str,
+    ) -> Result<bool> {
+        let result = sqlx::query(
+            r#"
+            UPDATE proof_sessions
+            SET status = $1,
+                error_message = $2,
+                completed_at = NOW()
+            WHERE backend_session_id = $3
+              AND status = $4
+            "#,
+        )
+        .bind(SessionStatus::Failed.as_str())
+        .bind(error_message)
+        .bind(reservation_id)
+        .bind(SessionStatus::Submitting.as_str())
+        .execute(&self.pool)
+        .await?;
+
+        Ok(result.rows_affected() > 0)
+    }
+
     /// Create a new proof session
     pub async fn create_proof_session(&self, session: CreateProofSession) -> Result<i64> {
         let row = sqlx::query(

--- a/crates/proof/zk/db/src/repo.rs
+++ b/crates/proof/zk/db/src/repo.rs
@@ -588,9 +588,10 @@ impl ProofRequestRepo {
 
     /// Create a new proof session.
     ///
-    /// This is intended for direct, non-reserved session creation. It is not idempotent under the
-    /// `(proof_request_id, session_type)` uniqueness invariant; callers that need first-writer-wins
-    /// behavior should use [`Self::reserve_proof_session`] before backend submission.
+    /// This is intended for direct, non-reserved session creation. If another caller already
+    /// created the same `(proof_request_id, session_type)` row, this returns that row ID instead of
+    /// failing on the uniqueness invariant. Callers that need to avoid duplicate backend submission
+    /// should use [`Self::reserve_proof_session`] before submitting work.
     pub async fn create_proof_session(&self, session: CreateProofSession) -> Result<i64> {
         let row = sqlx::query(
             r#"
@@ -598,6 +599,8 @@ impl ProofRequestRepo {
                 proof_request_id, session_type, backend_session_id, status, metadata
             )
             VALUES ($1, $2, $3, $4, $5)
+            ON CONFLICT (proof_request_id, session_type) DO UPDATE
+            SET backend_session_id = proof_sessions.backend_session_id
             RETURNING id
             "#,
         )
@@ -722,6 +725,61 @@ impl ProofRequestRepo {
         .await?;
 
         rows.iter().map(row_to_proof_request).collect()
+    }
+
+    /// Mark proof requests with stale SUBMITTING sessions as failed.
+    ///
+    /// Only SNARK aggregation uses the reservation flow today; keep this scoped to SNARK so a
+    /// future reserved session type cannot fail an otherwise healthy multi-stage request.
+    pub async fn fail_stale_submitting_sessions(
+        &self,
+        stuck_timeout_mins: i32,
+        error_message: &str,
+    ) -> Result<Vec<ProofType>> {
+        let rows = sqlx::query(
+            r#"
+            WITH stale_sessions AS (
+                SELECT ps.id, ps.proof_request_id
+                FROM proof_sessions ps
+                INNER JOIN proof_requests pr ON pr.id = ps.proof_request_id
+                WHERE ps.status = 'SUBMITTING'
+                  AND ps.session_type = $5
+                  AND ps.created_at < NOW() - INTERVAL '1 minute' * $1
+                  AND pr.status IN ('PENDING', 'RUNNING')
+            ),
+            failed_sessions AS (
+                UPDATE proof_sessions ps
+                SET status = $2,
+                    error_message = $3,
+                    completed_at = NOW()
+                WHERE ps.id IN (SELECT id FROM stale_sessions)
+                RETURNING ps.proof_request_id
+            )
+            UPDATE proof_requests pr
+            SET status = $4,
+                error_message = $3,
+                completed_at = NOW()
+            WHERE pr.id IN (SELECT proof_request_id FROM failed_sessions)
+              AND pr.status IN ('PENDING', 'RUNNING')
+            RETURNING pr.proof_type
+            "#,
+        )
+        .bind(stuck_timeout_mins)
+        .bind(SessionStatus::Failed.as_str())
+        .bind(error_message)
+        .bind(ProofStatus::Failed.as_str())
+        .bind(SessionType::Snark.as_str())
+        .fetch_all(&self.pool)
+        .await?;
+
+        rows.iter()
+            .map(|row| {
+                let proof_type_str: &str = row.get("proof_type");
+                ProofType::try_from(proof_type_str).map_err(|e| {
+                    sqlx::Error::Protocol(format!("Unknown proof type '{proof_type_str}': {e}"))
+                })
+            })
+            .collect()
     }
 
     /// Update a proof session status

--- a/crates/proof/zk/db/src/repo.rs
+++ b/crates/proof/zk/db/src/repo.rs
@@ -693,9 +693,9 @@ impl ProofRequestRepo {
         rows.iter().map(row_to_proof_request).collect()
     }
 
-    /// Get proof requests that are stuck in PENDING without a running session.
+    /// Get proof requests that are stuck in PENDING without an active session.
     /// These are likely orphaned due to crashes before session creation.
-    /// Only checks for active (RUNNING) sessions so that retried requests
+    /// Only checks for active (SUBMITTING/RUNNING) sessions so that retried requests
     /// with old COMPLETED/FAILED sessions are still detected as stuck.
     pub async fn get_stuck_requests(&self, stuck_timeout_mins: i32) -> Result<Vec<ProofRequest>> {
         let rows = sqlx::query(
@@ -712,7 +712,7 @@ impl ProofRequestRepo {
               AND NOT EXISTS (
                   SELECT 1 FROM proof_sessions ps
                   WHERE ps.proof_request_id = pr.id
-                    AND ps.status = 'RUNNING'
+                    AND ps.status IN ('SUBMITTING', 'RUNNING')
               )
             ORDER BY pr.created_at ASC
             "#,

--- a/crates/proof/zk/db/src/repo.rs
+++ b/crates/proof/zk/db/src/repo.rs
@@ -496,7 +496,6 @@ impl ProofRequestRepo {
     ///
     /// Returns `Some(reservation_id)` if this caller created the reservation and should submit the
     /// backend job. Returns `None` if another caller already reserved or created this session type.
-    /// A failed session may be reclaimed so manual retries can submit the SNARK stage again.
     pub async fn reserve_proof_session(
         &self,
         proof_request_id: Uuid,
@@ -511,14 +510,7 @@ impl ProofRequestRepo {
                 proof_request_id, session_type, backend_session_id, status, metadata
             )
             VALUES ($1, $2, $3, $4, NULL)
-            ON CONFLICT (proof_request_id, session_type) DO UPDATE
-            SET backend_session_id = EXCLUDED.backend_session_id,
-                status = EXCLUDED.status,
-                metadata = EXCLUDED.metadata,
-                error_message = NULL,
-                completed_at = NULL,
-                created_at = NOW()
-            WHERE proof_sessions.status = $5
+            ON CONFLICT (proof_request_id, session_type) DO NOTHING
             RETURNING backend_session_id
             "#,
         )
@@ -526,7 +518,6 @@ impl ProofRequestRepo {
         .bind(session_type.as_str())
         .bind(&reservation_id)
         .bind(SessionStatus::Submitting.as_str())
-        .bind(SessionStatus::Failed.as_str())
         .fetch_optional(&self.pool)
         .await?;
 
@@ -535,6 +526,8 @@ impl ProofRequestRepo {
 
     /// Activate a reserved proof session after the backend returns its session ID.
     ///
+    /// Reuses [`CreateProofSession`] because activation fills in the same fields that direct
+    /// session creation would insert: request ID, session type, backend session ID, and metadata.
     /// Returns `true` when the reservation was found and updated.
     pub async fn activate_reserved_proof_session(
         &self,
@@ -593,7 +586,11 @@ impl ProofRequestRepo {
         Ok(result.rows_affected() > 0)
     }
 
-    /// Create a new proof session
+    /// Create a new proof session.
+    ///
+    /// This is intended for direct, non-reserved session creation. It is not idempotent under the
+    /// `(proof_request_id, session_type)` uniqueness invariant; callers that need first-writer-wins
+    /// behavior should use [`Self::reserve_proof_session`] before backend submission.
     pub async fn create_proof_session(&self, session: CreateProofSession) -> Result<i64> {
         let row = sqlx::query(
             r#"

--- a/crates/proof/zk/db/tests/postgres_integration.rs
+++ b/crates/proof/zk/db/tests/postgres_integration.rs
@@ -585,44 +585,6 @@ async fn test_update_proof_session() {
 
 #[tokio::test]
 #[ignore = "requires a running Postgres with the prover schema (set DATABASE_URL); run with `cargo nextest run --run-ignored all -p base-zk-db --test postgres_integration --test-threads=1`"]
-async fn test_create_proof_session_returns_existing_on_request_type_conflict() {
-    let pool = test_pool().await;
-    let repo = test_repo(pool);
-
-    let req_id = repo.create(snark_request()).await.unwrap();
-    let first_backend_id = format!("session-conflict-{}", Uuid::new_v4());
-    let second_backend_id = format!("session-conflict-{}", Uuid::new_v4());
-
-    let first_id = repo
-        .create_proof_session(CreateProofSession {
-            proof_request_id: req_id,
-            session_type: SessionType::Snark,
-            backend_session_id: first_backend_id.clone(),
-            metadata: Some(serde_json::json!({"proof_id": first_backend_id.clone()})),
-        })
-        .await
-        .unwrap();
-
-    let second_id = repo
-        .create_proof_session(CreateProofSession {
-            proof_request_id: req_id,
-            session_type: SessionType::Snark,
-            backend_session_id: second_backend_id,
-            metadata: None,
-        })
-        .await
-        .unwrap();
-
-    assert_eq!(first_id, second_id);
-
-    let sessions = repo.get_sessions_for_request(req_id).await.unwrap();
-    assert_eq!(sessions.len(), 1);
-    assert_eq!(sessions[0].backend_session_id, first_backend_id);
-    assert!(sessions[0].metadata.is_some());
-}
-
-#[tokio::test]
-#[ignore = "requires a running Postgres with the prover schema (set DATABASE_URL); run with `cargo nextest run --run-ignored all -p base-zk-db --test postgres_integration --test-threads=1`"]
 async fn test_update_proof_session_if_non_terminal() {
     let pool = test_pool().await;
     let repo = test_repo(pool);
@@ -888,6 +850,54 @@ async fn test_fail_stale_submitting_sessions_marks_request_failed() {
         repo.get_session_by_backend_id(&reservation_id).await.unwrap().expect("session exists");
     assert_eq!(session.status, SessionStatus::Failed);
     assert_eq!(session.error_message.as_deref(), Some("stale submitting reservation"));
+}
+
+#[tokio::test]
+#[ignore = "requires a running Postgres with the prover schema (set DATABASE_URL); run with `cargo nextest run --run-ignored all -p base-zk-db --test postgres_integration --test-threads=1`"]
+async fn test_fail_stale_submitting_sessions_keeps_request_with_active_session() {
+    let pool = test_pool().await;
+    let repo = test_repo(pool.clone());
+
+    let id = repo.create(snark_request()).await.unwrap();
+    repo.atomic_claim_task(id).await.unwrap();
+    repo.transition_pending_to_running(CreateProofSession {
+        proof_request_id: id,
+        session_type: SessionType::Stark,
+        backend_session_id: format!("stark-active-{}", Uuid::new_v4()),
+        metadata: None,
+    })
+    .await
+    .unwrap()
+    .expect("STARK session should start");
+
+    let reservation_id = repo
+        .reserve_proof_session(id, SessionType::Snark)
+        .await
+        .unwrap()
+        .expect("reservation wins");
+
+    sqlx::query(
+        r#"
+        UPDATE proof_sessions
+        SET created_at = NOW() - INTERVAL '10 minutes'
+        WHERE backend_session_id = $1
+        "#,
+    )
+    .bind(&reservation_id)
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    let failed_proof_types =
+        repo.fail_stale_submitting_sessions(1, "stale submitting reservation").await.unwrap();
+    assert!(failed_proof_types.is_empty());
+
+    let request = repo.get(id).await.unwrap().unwrap();
+    assert_eq!(request.status, ProofStatus::Running);
+
+    let session =
+        repo.get_session_by_backend_id(&reservation_id).await.unwrap().expect("session exists");
+    assert_eq!(session.status, SessionStatus::Submitting);
 }
 
 #[tokio::test]

--- a/crates/proof/zk/db/tests/postgres_integration.rs
+++ b/crates/proof/zk/db/tests/postgres_integration.rs
@@ -474,40 +474,6 @@ async fn test_reserve_proof_session_is_single_winner() {
 
 #[tokio::test]
 #[ignore = "requires a running Postgres with the prover schema (set DATABASE_URL); run with `cargo nextest run --run-ignored all -p base-zk-db --test postgres_integration --test-threads=1`"]
-async fn test_reserve_proof_session_reclaims_failed_session() {
-    let pool = test_pool().await;
-    let repo = test_repo(pool);
-
-    let req_id = repo.create(snark_request()).await.unwrap();
-    let first_reservation = repo
-        .reserve_proof_session(req_id, SessionType::Snark)
-        .await
-        .unwrap()
-        .expect("first reservation should win");
-
-    let failed =
-        repo.fail_reserved_proof_session(&first_reservation, "submission failed").await.unwrap();
-    assert!(failed);
-
-    let second_reservation = repo
-        .reserve_proof_session(req_id, SessionType::Snark)
-        .await
-        .unwrap()
-        .expect("failed reservation should be reclaimable");
-
-    assert_ne!(first_reservation, second_reservation);
-
-    let sessions = repo.get_sessions_for_request(req_id).await.unwrap();
-    assert_eq!(sessions.len(), 1);
-    assert_eq!(sessions[0].session_type, SessionType::Snark);
-    assert_eq!(sessions[0].backend_session_id, second_reservation);
-    assert_eq!(sessions[0].status, SessionStatus::Submitting);
-    assert!(sessions[0].error_message.is_none());
-    assert!(sessions[0].completed_at.is_none());
-}
-
-#[tokio::test]
-#[ignore = "requires a running Postgres with the prover schema (set DATABASE_URL); run with `cargo nextest run --run-ignored all -p base-zk-db --test postgres_integration --test-threads=1`"]
 async fn test_activate_reserved_proof_session() {
     let pool = test_pool().await;
     let repo = test_repo(pool);

--- a/crates/proof/zk/db/tests/postgres_integration.rs
+++ b/crates/proof/zk/db/tests/postgres_integration.rs
@@ -524,6 +524,34 @@ async fn test_activate_reserved_proof_session() {
 
 #[tokio::test]
 #[ignore = "requires a running Postgres with the prover schema (set DATABASE_URL); run with `cargo nextest run --run-ignored all -p base-zk-db --test postgres_integration --test-threads=1`"]
+async fn test_fail_reserved_proof_session() {
+    let pool = test_pool().await;
+    let repo = test_repo(pool);
+
+    let req_id = repo.create(snark_request()).await.unwrap();
+    let reservation_id = repo
+        .reserve_proof_session(req_id, SessionType::Snark)
+        .await
+        .unwrap()
+        .expect("reservation should win");
+
+    let failed =
+        repo.fail_reserved_proof_session(&reservation_id, "submission failed").await.unwrap();
+    assert!(failed);
+
+    let session =
+        repo.get_session_by_backend_id(&reservation_id).await.unwrap().expect("session exists");
+    assert_eq!(session.status, SessionStatus::Failed);
+    assert_eq!(session.error_message.as_deref(), Some("submission failed"));
+    assert!(session.completed_at.is_some());
+
+    let failed_again =
+        repo.fail_reserved_proof_session(&reservation_id, "submission failed again").await.unwrap();
+    assert!(!failed_again, "reservation should only fail while SUBMITTING");
+}
+
+#[tokio::test]
+#[ignore = "requires a running Postgres with the prover schema (set DATABASE_URL); run with `cargo nextest run --run-ignored all -p base-zk-db --test postgres_integration --test-threads=1`"]
 async fn test_update_proof_session() {
     let pool = test_pool().await;
     let repo = test_repo(pool);
@@ -756,6 +784,32 @@ async fn test_retry_or_fail_stuck_request_retries() {
     assert_eq!(req.status, ProofStatus::Created);
     assert_eq!(req.retry_count, 1);
     assert!(req.error_message.is_none());
+}
+
+#[tokio::test]
+#[ignore = "requires a running Postgres with the prover schema (set DATABASE_URL); run with `cargo nextest run --run-ignored all -p base-zk-db --test postgres_integration --test-threads=1`"]
+async fn test_get_stuck_requests_excludes_submitting_session() {
+    let pool = test_pool().await;
+    let repo = test_repo(pool.clone());
+
+    let id = repo.create(snark_request()).await.unwrap();
+    repo.atomic_claim_task(id).await.unwrap();
+    repo.reserve_proof_session(id, SessionType::Snark).await.unwrap().expect("reservation wins");
+
+    sqlx::query(
+        r#"
+        UPDATE proof_requests
+        SET updated_at = NOW() - INTERVAL '10 minutes'
+        WHERE id = $1
+        "#,
+    )
+    .bind(id)
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    let stuck = repo.get_stuck_requests(1).await.unwrap();
+    assert!(!stuck.iter().any(|request| request.id == id));
 }
 
 #[tokio::test]

--- a/crates/proof/zk/db/tests/postgres_integration.rs
+++ b/crates/proof/zk/db/tests/postgres_integration.rs
@@ -585,6 +585,44 @@ async fn test_update_proof_session() {
 
 #[tokio::test]
 #[ignore = "requires a running Postgres with the prover schema (set DATABASE_URL); run with `cargo nextest run --run-ignored all -p base-zk-db --test postgres_integration --test-threads=1`"]
+async fn test_create_proof_session_returns_existing_on_request_type_conflict() {
+    let pool = test_pool().await;
+    let repo = test_repo(pool);
+
+    let req_id = repo.create(snark_request()).await.unwrap();
+    let first_backend_id = format!("session-conflict-{}", Uuid::new_v4());
+    let second_backend_id = format!("session-conflict-{}", Uuid::new_v4());
+
+    let first_id = repo
+        .create_proof_session(CreateProofSession {
+            proof_request_id: req_id,
+            session_type: SessionType::Snark,
+            backend_session_id: first_backend_id.clone(),
+            metadata: Some(serde_json::json!({"proof_id": first_backend_id.clone()})),
+        })
+        .await
+        .unwrap();
+
+    let second_id = repo
+        .create_proof_session(CreateProofSession {
+            proof_request_id: req_id,
+            session_type: SessionType::Snark,
+            backend_session_id: second_backend_id,
+            metadata: None,
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(first_id, second_id);
+
+    let sessions = repo.get_sessions_for_request(req_id).await.unwrap();
+    assert_eq!(sessions.len(), 1);
+    assert_eq!(sessions[0].backend_session_id, first_backend_id);
+    assert!(sessions[0].metadata.is_some());
+}
+
+#[tokio::test]
+#[ignore = "requires a running Postgres with the prover schema (set DATABASE_URL); run with `cargo nextest run --run-ignored all -p base-zk-db --test postgres_integration --test-threads=1`"]
 async fn test_update_proof_session_if_non_terminal() {
     let pool = test_pool().await;
     let repo = test_repo(pool);
@@ -810,6 +848,46 @@ async fn test_get_stuck_requests_excludes_submitting_session() {
 
     let stuck = repo.get_stuck_requests(1).await.unwrap();
     assert!(!stuck.iter().any(|request| request.id == id));
+}
+
+#[tokio::test]
+#[ignore = "requires a running Postgres with the prover schema (set DATABASE_URL); run with `cargo nextest run --run-ignored all -p base-zk-db --test postgres_integration --test-threads=1`"]
+async fn test_fail_stale_submitting_sessions_marks_request_failed() {
+    let pool = test_pool().await;
+    let repo = test_repo(pool.clone());
+
+    let id = repo.create(snark_request()).await.unwrap();
+    repo.atomic_claim_task(id).await.unwrap();
+    let reservation_id = repo
+        .reserve_proof_session(id, SessionType::Snark)
+        .await
+        .unwrap()
+        .expect("reservation wins");
+
+    sqlx::query(
+        r#"
+        UPDATE proof_sessions
+        SET created_at = NOW() - INTERVAL '10 minutes'
+        WHERE backend_session_id = $1
+        "#,
+    )
+    .bind(&reservation_id)
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    let failed_proof_types =
+        repo.fail_stale_submitting_sessions(1, "stale submitting reservation").await.unwrap();
+    assert_eq!(failed_proof_types, vec![ProofType::OpSuccinctSp1ClusterSnarkGroth16]);
+
+    let request = repo.get(id).await.unwrap().unwrap();
+    assert_eq!(request.status, ProofStatus::Failed);
+    assert_eq!(request.error_message.as_deref(), Some("stale submitting reservation"));
+
+    let session =
+        repo.get_session_by_backend_id(&reservation_id).await.unwrap().expect("session exists");
+    assert_eq!(session.status, SessionStatus::Failed);
+    assert_eq!(session.error_message.as_deref(), Some("stale submitting reservation"));
 }
 
 #[tokio::test]

--- a/crates/proof/zk/db/tests/postgres_integration.rs
+++ b/crates/proof/zk/db/tests/postgres_integration.rs
@@ -454,6 +454,110 @@ async fn test_get_sessions_for_request() {
 
 #[tokio::test]
 #[ignore = "requires a running Postgres with the prover schema (set DATABASE_URL); run with `cargo nextest run --run-ignored all -p base-zk-db --test postgres_integration --test-threads=1`"]
+async fn test_reserve_proof_session_is_single_winner() {
+    let pool = test_pool().await;
+    let repo = test_repo(pool);
+
+    let req_id = repo.create(snark_request()).await.unwrap();
+
+    let first = repo.reserve_proof_session(req_id, SessionType::Snark).await.unwrap();
+    let second = repo.reserve_proof_session(req_id, SessionType::Snark).await.unwrap();
+
+    assert!(first.is_some(), "first reservation should win");
+    assert!(second.is_none(), "second reservation should observe existing session");
+
+    let sessions = repo.get_sessions_for_request(req_id).await.unwrap();
+    assert_eq!(sessions.len(), 1);
+    assert_eq!(sessions[0].session_type, SessionType::Snark);
+    assert_eq!(sessions[0].status, SessionStatus::Submitting);
+}
+
+#[tokio::test]
+#[ignore = "requires a running Postgres with the prover schema (set DATABASE_URL); run with `cargo nextest run --run-ignored all -p base-zk-db --test postgres_integration --test-threads=1`"]
+async fn test_reserve_proof_session_reclaims_failed_session() {
+    let pool = test_pool().await;
+    let repo = test_repo(pool);
+
+    let req_id = repo.create(snark_request()).await.unwrap();
+    let first_reservation = repo
+        .reserve_proof_session(req_id, SessionType::Snark)
+        .await
+        .unwrap()
+        .expect("first reservation should win");
+
+    let failed =
+        repo.fail_reserved_proof_session(&first_reservation, "submission failed").await.unwrap();
+    assert!(failed);
+
+    let second_reservation = repo
+        .reserve_proof_session(req_id, SessionType::Snark)
+        .await
+        .unwrap()
+        .expect("failed reservation should be reclaimable");
+
+    assert_ne!(first_reservation, second_reservation);
+
+    let sessions = repo.get_sessions_for_request(req_id).await.unwrap();
+    assert_eq!(sessions.len(), 1);
+    assert_eq!(sessions[0].session_type, SessionType::Snark);
+    assert_eq!(sessions[0].backend_session_id, second_reservation);
+    assert_eq!(sessions[0].status, SessionStatus::Submitting);
+    assert!(sessions[0].error_message.is_none());
+    assert!(sessions[0].completed_at.is_none());
+}
+
+#[tokio::test]
+#[ignore = "requires a running Postgres with the prover schema (set DATABASE_URL); run with `cargo nextest run --run-ignored all -p base-zk-db --test postgres_integration --test-threads=1`"]
+async fn test_activate_reserved_proof_session() {
+    let pool = test_pool().await;
+    let repo = test_repo(pool);
+
+    let req_id = repo.create(snark_request()).await.unwrap();
+    let reservation_id = repo
+        .reserve_proof_session(req_id, SessionType::Snark)
+        .await
+        .unwrap()
+        .expect("reservation should win");
+    let backend_id = format!("snark-{}", Uuid::new_v4());
+
+    let activated = repo
+        .activate_reserved_proof_session(
+            &reservation_id,
+            CreateProofSession {
+                proof_request_id: req_id,
+                session_type: SessionType::Snark,
+                backend_session_id: backend_id.clone(),
+                metadata: Some(serde_json::json!({"proof_id": backend_id.clone()})),
+            },
+        )
+        .await
+        .unwrap();
+
+    assert!(activated);
+
+    let sessions = repo.get_sessions_for_request(req_id).await.unwrap();
+    assert_eq!(sessions.len(), 1);
+    assert_eq!(sessions[0].backend_session_id, backend_id);
+    assert_eq!(sessions[0].status, SessionStatus::Running);
+    assert!(sessions[0].metadata.is_some());
+
+    let activated_again = repo
+        .activate_reserved_proof_session(
+            &reservation_id,
+            CreateProofSession {
+                proof_request_id: req_id,
+                session_type: SessionType::Snark,
+                backend_session_id: format!("snark-{}", Uuid::new_v4()),
+                metadata: None,
+            },
+        )
+        .await
+        .unwrap();
+    assert!(!activated_again, "reservation should only activate once");
+}
+
+#[tokio::test]
+#[ignore = "requires a running Postgres with the prover schema (set DATABASE_URL); run with `cargo nextest run --run-ignored all -p base-zk-db --test postgres_integration --test-threads=1`"]
 async fn test_update_proof_session() {
     let pool = test_pool().await;
     let repo = test_repo(pool);

--- a/crates/proof/zk/service/src/backends/op_succinct/cluster.rs
+++ b/crates/proof/zk/service/src/backends/op_succinct/cluster.rs
@@ -224,10 +224,34 @@ impl ProvingBackend for ClusterBackend {
                     proof_request_id = %proof_request.id,
                     "STARK completed, triggering stage-2 aggregation proof (SNARK Groth16)"
                 );
+                let Some(reservation_id) =
+                    repo.reserve_proof_session(proof_request.id, SessionType::Snark).await?
+                else {
+                    info!(
+                        proof_request_id = %proof_request.id,
+                        "SNARK proof session already reserved by another worker"
+                    );
+                    let updated_sessions = repo.get_sessions_for_request(proof_request.id).await?;
+                    return Ok(Self::determine_status(proof_request.proof_type, &updated_sessions));
+                };
+
                 let fresh_proof_request = repo.get(proof_request.id).await?.ok_or_else(|| {
                     anyhow::anyhow!("Proof request not found after STARK completion")
                 })?;
-                if let Err(e) = self.submit_aggregation_proof(&fresh_proof_request, repo).await {
+                if let Err(e) =
+                    self.submit_aggregation_proof(&fresh_proof_request, repo, &reservation_id).await
+                {
+                    let error_message = format!("Failed to submit aggregation proof: {e}");
+                    if let Err(fail_err) =
+                        repo.fail_reserved_proof_session(&reservation_id, &error_message).await
+                    {
+                        warn!(
+                            proof_request_id = %proof_request.id,
+                            reservation_id = %reservation_id,
+                            error = %fail_err,
+                            "failed to mark reserved SNARK proof session as failed"
+                        );
+                    }
                     error!(
                         proof_request_id = %proof_request.id,
                         error = %e,
@@ -235,7 +259,7 @@ impl ProvingBackend for ClusterBackend {
                     );
                     return Ok(ProofProcessingResult {
                         status: ProofStatus::Failed,
-                        error_message: Some(format!("Failed to submit aggregation proof: {e}")),
+                        error_message: Some(error_message),
                     });
                 }
                 let updated_sessions = repo.get_sessions_for_request(proof_request.id).await?;
@@ -615,6 +639,7 @@ impl ClusterBackend {
         &self,
         proof_request: &ProofRequest,
         repo: &ProofRequestRepo,
+        reservation_id: &str,
     ) -> anyhow::Result<()> {
         let BackendConfig::OpSuccinct {
             cluster_rpc,
@@ -731,7 +756,10 @@ impl ClusterBackend {
             metadata: Some(metadata),
         };
 
-        repo.create_proof_session(session).await?;
+        let activated = repo.activate_reserved_proof_session(reservation_id, session).await?;
+        if !activated {
+            anyhow::bail!("reserved SNARK proof session was not found for activation");
+        }
 
         info!(
             proof_request_id = %proof_request.id,

--- a/crates/proof/zk/service/src/backends/op_succinct/mock.rs
+++ b/crates/proof/zk/service/src/backends/op_succinct/mock.rs
@@ -18,7 +18,7 @@ use serde_json::json;
 use sp1_sdk::{
     SP1_CIRCUIT_VERSION, SP1ProofMode, SP1ProofWithPublicValues, SP1PublicValues, SP1VerifyingKey,
 };
-use tracing::info;
+use tracing::{info, warn};
 use uuid::Uuid;
 
 use crate::backends::traits::{
@@ -223,6 +223,16 @@ impl ProvingBackend for MockBackend {
                     proof_request_id = %proof_request.id,
                     "MockBackend: STARK done, creating SNARK session"
                 );
+                let Some(reservation_id) =
+                    repo.reserve_proof_session(proof_request.id, SessionType::Snark).await?
+                else {
+                    info!(
+                        proof_request_id = %proof_request.id,
+                        "MockBackend: SNARK proof session already reserved by another worker"
+                    );
+                    let final_sessions = repo.get_sessions_for_request(proof_request.id).await?;
+                    return Ok(determine_mock_status(proof_request.proof_type, &final_sessions));
+                };
 
                 let snark_session_id = format!("mock-snark-{}", Uuid::new_v4());
                 let metadata = json!({
@@ -239,7 +249,36 @@ impl ProvingBackend for MockBackend {
                     metadata: Some(metadata),
                 };
 
-                repo.create_proof_session(session).await?;
+                match repo.activate_reserved_proof_session(&reservation_id, session).await {
+                    Ok(true) => {}
+                    Ok(false) => {
+                        let error_message =
+                            "MockBackend: reserved SNARK proof session was not found for activation"
+                                .to_string();
+                        return Ok(ProofProcessingResult {
+                            status: ProofStatus::Failed,
+                            error_message: Some(error_message),
+                        });
+                    }
+                    Err(e) => {
+                        let error_message =
+                            format!("MockBackend: failed to activate SNARK session: {e}");
+                        if let Err(fail_err) =
+                            repo.fail_reserved_proof_session(&reservation_id, &error_message).await
+                        {
+                            warn!(
+                                proof_request_id = %proof_request.id,
+                                reservation_id = %reservation_id,
+                                error = %fail_err,
+                                "failed to mark reserved SNARK proof session as failed"
+                            );
+                        }
+                        return Ok(ProofProcessingResult {
+                            status: ProofStatus::Failed,
+                            error_message: Some(error_message),
+                        });
+                    }
+                }
 
                 let final_sessions = repo.get_sessions_for_request(proof_request.id).await?;
                 return Ok(determine_mock_status(proof_request.proof_type, &final_sessions));

--- a/crates/proof/zk/service/src/backends/op_succinct/network.rs
+++ b/crates/proof/zk/service/src/backends/op_succinct/network.rs
@@ -223,10 +223,34 @@ impl ProvingBackend for NetworkBackend {
                     proof_request_id = %proof_request.id,
                     "STARK completed, triggering stage-2 aggregation proof via SP1 Network"
                 );
+                let Some(reservation_id) =
+                    repo.reserve_proof_session(proof_request.id, SessionType::Snark).await?
+                else {
+                    info!(
+                        proof_request_id = %proof_request.id,
+                        "SNARK proof session already reserved by another worker"
+                    );
+                    let updated_sessions = repo.get_sessions_for_request(proof_request.id).await?;
+                    return Ok(Self::determine_status(proof_request.proof_type, &updated_sessions));
+                };
+
                 let fresh_proof_request = repo.get(proof_request.id).await?.ok_or_else(|| {
                     anyhow::anyhow!("proof request not found after STARK completion")
                 })?;
-                if let Err(e) = self.submit_aggregation_proof(&fresh_proof_request, repo).await {
+                if let Err(e) =
+                    self.submit_aggregation_proof(&fresh_proof_request, repo, &reservation_id).await
+                {
+                    let error_message = format!("failed to submit aggregation proof: {e}");
+                    if let Err(fail_err) =
+                        repo.fail_reserved_proof_session(&reservation_id, &error_message).await
+                    {
+                        warn!(
+                            proof_request_id = %proof_request.id,
+                            reservation_id = %reservation_id,
+                            error = %fail_err,
+                            "failed to mark reserved SNARK proof session as failed"
+                        );
+                    }
                     error!(
                         proof_request_id = %proof_request.id,
                         error = %e,
@@ -234,7 +258,7 @@ impl ProvingBackend for NetworkBackend {
                     );
                     return Ok(ProofProcessingResult {
                         status: ProofStatus::Failed,
-                        error_message: Some(format!("failed to submit aggregation proof: {e}")),
+                        error_message: Some(error_message),
                     });
                 }
                 let updated_sessions = repo.get_sessions_for_request(proof_request.id).await?;
@@ -417,6 +441,7 @@ impl NetworkBackend {
         &self,
         proof_request: &ProofRequest,
         repo: &ProofRequestRepo,
+        reservation_id: &str,
     ) -> anyhow::Result<()> {
         let BackendConfig::Network { network_prover, agg_pk, range_vk, .. } = &self.config else {
             unreachable!("validated in constructor");
@@ -511,7 +536,10 @@ impl NetworkBackend {
             metadata: Some(metadata),
         };
 
-        repo.create_proof_session(session).await?;
+        let activated = repo.activate_reserved_proof_session(reservation_id, session).await?;
+        if !activated {
+            anyhow::bail!("reserved SNARK proof session was not found for activation");
+        }
 
         info!(
             proof_request_id = %proof_request.id,

--- a/crates/proof/zk/service/src/worker/status_poller.rs
+++ b/crates/proof/zk/service/src/worker/status_poller.rs
@@ -52,6 +52,25 @@ impl StatusPoller {
 
     /// Poll once for all RUNNING proof requests and detect stuck requests
     async fn poll_once(&self) -> anyhow::Result<()> {
+        let stale_submitting_error =
+            format!("Session stuck in SUBMITTING state for {}+ minutes", self.stuck_timeout_mins);
+        let stale_submitting_proof_types = self
+            .repo
+            .fail_stale_submitting_sessions(self.stuck_timeout_mins, &stale_submitting_error)
+            .await?;
+        if !stale_submitting_proof_types.is_empty() {
+            warn!(
+                count = stale_submitting_proof_types.len(),
+                stuck_timeout_mins = self.stuck_timeout_mins,
+                "Failed proof requests with stale SUBMITTING sessions"
+            );
+            for proof_type in stale_submitting_proof_types {
+                let proof_type_label = metrics::proof_type_label(proof_type);
+                metrics::inc_stuck_requests(proof_type_label);
+                metrics::inc_proof_requests_completed("failed", proof_type_label);
+            }
+        }
+
         // Get all RUNNING proof_requests
         let running_requests = self.repo.get_running_proof_requests().await?;
 


### PR DESCRIPTION
## Summary
- Add a `SUBMITTING` proof-session status and DB helpers to reserve, activate, and fail reserved proof sessions.
- Enforce one proof session row per `(proof_request_id, session_type)` so concurrent workers cannot claim the same stage.
- Move SNARK aggregation submission paths onto the reserve-before-submit flow so a losing worker never submits an untracked backend job.
- Fail stale `SUBMITTING` SNARK reservations before stuck-request detection, while preserving requests that still have another active session.
- Cover reservation single-winner, activation, failure, stale cleanup, and active-session guard behavior in Postgres integration tests.

Retries for the same block range should create a new proof request ID; failed sessions remain scoped to their original proof request.

## Test plan
- `cargo fmt -p base-zk-db -p base-zk-service`
- `cargo check -p base-zk-db -p base-zk-service`
- `cargo clippy -p base-zk-db -p base-zk-service --all-targets`