### PR TITLE
chore(docker): avoid installing recommended packages

### DIFF
--- a/crates/proof/succinct/validity/Dockerfile
+++ b/crates/proof/succinct/validity/Dockerfile
@@ -2,7 +2,7 @@
 FROM rust:1.85 AS builder
 
 # Install build dependencies
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential \
     libclang-dev \
     pkg-config \
@@ -51,7 +51,7 @@ FROM rust:1.85-slim
 WORKDIR /app
 
 # Install required runtime dependencies
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \
     clang \
     pkg-config \


### PR DESCRIPTION
## Summary

Adds `--no-install-recommends` to apt package installation commands in the validity Dockerfile.

## Motivation

Avoids installing unnecessary recommended packages and helps keep Docker images smaller and cleaner.

## Changes

* Updated builder image apt install command
* Updated runtime image apt install command

## Testing

* Verified Dockerfile changes manually
* No application logic changed