### PR TITLE
test(proof/driver): add unit tests for PipelineCursor and TipCursor

### DIFF
--- a/crates/proof/driver/Cargo.toml
+++ b/crates/proof/driver/Cargo.toml
@@ -48,3 +48,6 @@ std = [
 	"thiserror/std",
 	"tracing/std",
 ]
+
+[dev-dependencies]
+alloy-eips = { workspace = true, features = ["std"] }

--- a/crates/proof/driver/src/cursor.rs
+++ b/crates/proof/driver/src/cursor.rs
@@ -119,3 +119,149 @@ impl PipelineCursor {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use alloy_consensus::{Header, Sealable};
+    use alloy_eips::BlockNumHash;
+    use alloy_primitives::B256;
+    use base_protocol::{BlockInfo, L2BlockInfo};
+
+    use super::*;
+
+    /// Constructs a [`BlockInfo`] with the given block number for test purposes.
+    fn block_info(number: u64) -> BlockInfo {
+        BlockInfo {
+            hash: B256::repeat_byte(number as u8),
+            number,
+            parent_hash: B256::repeat_byte(number.saturating_sub(1) as u8),
+            timestamp: number * 2,
+        }
+    }
+
+    /// Constructs a dummy [`TipCursor`] anchored to the given L1 block number.
+    fn tip_cursor(l2_number: u64) -> TipCursor {
+        let l2_block = BlockInfo {
+            hash: B256::repeat_byte(l2_number as u8),
+            number: l2_number,
+            parent_hash: B256::ZERO,
+            timestamp: l2_number * 2,
+        };
+        let l2_info = L2BlockInfo {
+            block_info: l2_block,
+            l1_origin: BlockNumHash { number: l2_number, hash: B256::ZERO },
+            seq_num: 0,
+        };
+        let header = Header { number: l2_number, ..Default::default() }.seal_slow();
+        TipCursor::new(l2_info, header, B256::repeat_byte(l2_number as u8))
+    }
+
+    #[test]
+    fn new_sets_capacity_from_channel_timeout() {
+        let channel_timeout = 10_u64;
+        let origin = block_info(1);
+        let cursor = PipelineCursor::new(channel_timeout, origin);
+
+        // capacity must exceed channel_timeout so reorg recovery can step back far enough
+        assert_eq!(cursor.capacity, channel_timeout as usize + 5);
+        assert_eq!(cursor.channel_timeout, channel_timeout);
+    }
+
+    #[test]
+    fn new_initialises_origin_correctly() {
+        let origin = block_info(42);
+        let cursor = PipelineCursor::new(5, origin);
+
+        assert_eq!(cursor.origin(), origin);
+        assert!(cursor.origins.contains(&42));
+        assert_eq!(cursor.origin_infos[&42], origin);
+    }
+
+    #[test]
+    fn advance_updates_origin_and_tip() {
+        let origin = block_info(1);
+        let mut cursor = PipelineCursor::new(5, origin);
+
+        let tip = tip_cursor(10);
+        let new_origin = block_info(2);
+        cursor.advance(new_origin, tip.clone());
+
+        assert_eq!(cursor.origin(), new_origin);
+        assert_eq!(cursor.tip().l2_safe_head.block_info.number, 10);
+        assert_eq!(cursor.l2_safe_head().block_info.number, 10);
+    }
+
+    #[test]
+    fn advance_evicts_oldest_entry_when_at_capacity() {
+        let channel_timeout = 2_u64;
+        let origin = block_info(1);
+        let mut cursor = PipelineCursor::new(channel_timeout, origin);
+        // capacity = 2 + 5 = 7; fill it completely
+        let capacity = cursor.capacity;
+
+        for i in 2..=(capacity as u64 + 1) {
+            cursor.advance(block_info(i), tip_cursor(i * 10));
+        }
+
+        // tips map should never exceed capacity
+        assert!(cursor.tips.len() <= capacity);
+        // oldest origin (block 1) should have been evicted
+        assert!(!cursor.origins.contains(&1));
+        assert!(!cursor.tips.contains_key(&1));
+    }
+
+    #[test]
+    fn reset_to_exact_channel_start_returns_correct_tip() {
+        let channel_timeout = 3_u64;
+        let origin = block_info(1);
+        let mut cursor = PipelineCursor::new(channel_timeout, origin);
+
+        // advance through blocks 2..=8
+        for i in 2..=8_u64 {
+            cursor.advance(block_info(i), tip_cursor(i * 10));
+        }
+
+        // fork at block 7 → channel_start = 7 - 3 = 4
+        let (returned_tip, returned_origin) = cursor.reset(7);
+        assert_eq!(returned_origin.number, 4);
+        assert_eq!(returned_tip.l2_safe_head.block_info.number, 40);
+    }
+
+    #[test]
+    fn reset_falls_back_to_closest_known_block_when_exact_missing() {
+        let channel_timeout = 10_u64;
+        let origin = block_info(100);
+        let mut cursor = PipelineCursor::new(channel_timeout, origin);
+
+        // advance only to block 105 — blocks 90..99 are not in cache
+        for i in 101..=105_u64 {
+            cursor.advance(block_info(i), tip_cursor(i));
+        }
+
+        // fork at 110 → channel_start = 110 - 10 = 100, which IS in the cache
+        let (returned_tip, returned_origin) = cursor.reset(110);
+        assert_eq!(returned_origin.number, 100);
+        assert_eq!(returned_tip.l2_safe_head.block_info.number, 100);
+    }
+
+    #[test]
+    fn l2_safe_head_header_returns_correct_header() {
+        let origin = block_info(1);
+        let mut cursor = PipelineCursor::new(5, origin);
+        let tip = tip_cursor(7);
+        cursor.advance(block_info(2), tip);
+
+        assert_eq!(cursor.l2_safe_head_header().number, 7);
+    }
+
+    #[test]
+    fn l2_safe_head_output_root_matches_tip() {
+        let origin = block_info(1);
+        let mut cursor = PipelineCursor::new(5, origin);
+        let tip = tip_cursor(9);
+        let expected_root = B256::repeat_byte(9);
+        cursor.advance(block_info(2), tip);
+
+        assert_eq!(*cursor.l2_safe_head_output_root(), expected_root);
+    }
+}

--- a/crates/proof/driver/src/tip.rs
+++ b/crates/proof/driver/src/tip.rs
@@ -47,3 +47,51 @@ impl TipCursor {
         &self.l2_safe_head_output_root
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use alloy_consensus::{Header, Sealable};
+    use alloy_eips::BlockNumHash;
+    use alloy_primitives::B256;
+    use base_protocol::{BlockInfo, L2BlockInfo};
+
+    use super::*;
+
+    fn make_tip(number: u64) -> TipCursor {
+        let block_info = BlockInfo {
+            hash: B256::repeat_byte(number as u8),
+            number,
+            parent_hash: B256::ZERO,
+            timestamp: number * 2,
+        };
+        let l2_info = L2BlockInfo {
+            block_info,
+            l1_origin: BlockNumHash { number, hash: B256::ZERO },
+            seq_num: 0,
+        };
+        let header = Header { number, ..Default::default() }.seal_slow();
+        let output_root = B256::repeat_byte(number as u8);
+        TipCursor::new(l2_info, header, output_root)
+    }
+
+    #[test]
+    fn accessors_return_correct_values() {
+        let tip = make_tip(42);
+
+        assert_eq!(tip.l2_safe_head().block_info.number, 42);
+        assert_eq!(tip.l2_safe_head_header().number, 42);
+        assert_eq!(*tip.l2_safe_head_output_root(), B256::repeat_byte(42));
+    }
+
+    #[test]
+    fn clone_produces_independent_copy() {
+        let tip = make_tip(5);
+        let cloned = tip.clone();
+
+        assert_eq!(
+            tip.l2_safe_head().block_info.number,
+            cloned.l2_safe_head().block_info.number
+        );
+        assert_eq!(tip.l2_safe_head_output_root(), cloned.l2_safe_head_output_root());
+    }
+}


### PR DESCRIPTION
PipelineCursor and TipCursor had no tests. Added coverage for:
* capacity and LRU eviction in advance()
* exact and fallback reset() behaviour for reorg recovery
* l2_safe_head, l2_safe_head_header, l2_safe_head_output_root accessors