### PR TITLE
fix(mempool-rebroadcaster): handle non-JSON-RPC errors without panic

### DIFF
--- a/crates/infra/mempool-rebroadcaster/src/rebroadcaster.rs
+++ b/crates/infra/mempool-rebroadcaster/src/rebroadcaster.rs
@@ -112,12 +112,15 @@ impl Rebroadcaster {
                 .await;
 
             if let Err(e) = result {
-                let err_msg = e.as_error_resp().unwrap().message.to_string();
+                let err_msg = e
+                    .as_error_resp()
+                    .map(|r| r.message.to_string())
+                    .unwrap_or_else(|| e.to_string());
                 if !IGNORED_ERRORS.contains(&err_msg.as_str()) {
                     output.unexpected_failed_geth_to_reth += 1;
                     error!(
                         tx = ?hash,
-                        error = ?err_msg,
+                        error = %err_msg,
                         from = sender,
                         "error sending txn from geth to reth"
                     );
@@ -138,12 +141,15 @@ impl Rebroadcaster {
                 .await;
 
             if let Err(e) = result {
-                let err_msg = e.as_error_resp().unwrap().message.to_string();
+                let err_msg = e
+                    .as_error_resp()
+                    .map(|r| r.message.to_string())
+                    .unwrap_or_else(|| e.to_string());
                 if !IGNORED_ERRORS.contains(&err_msg.as_str()) {
                     output.unexpected_failed_reth_to_geth += 1;
                     error!(
                         tx = ?hash,
-                        error = ?err_msg,
+                        error = %err_msg,
                         from = sender,
                         "error sending txn from reth to geth"
                     );


### PR DESCRIPTION
Fixes #2616

## Problem

`as_error_resp()` returns `None` for transport-level errors (timeouts, connection resets, HTTP 5xx). The previous `.unwrap()` on both send paths panicked and crashed the rebroadcaster process on any such error.

## Fix

Replace the unconditional `.unwrap()` with `.map(...).unwrap_or_else(|| e.to_string())` so the service survives transient network failures. The existing `IGNORED_ERRORS` filtering is preserved unchanged.

Also updated the `error!` tracing call to use `%` (Display) instead of `?` (Debug) for the error message, consistent with the workspace tracing style guide.