### PR TITLE
fix(flashblocks): handle empty flashblock slice and block-number underflow in build_pending_state

### DIFF
--- a/crates/execution/flashblocks/src/processor.rs
+++ b/crates/execution/flashblocks/src/processor.rs
@@ -356,8 +356,10 @@ where
                 .push(flashblock.clone());
         }
 
-        let earliest_block_number = flashblocks_per_block.keys().min().unwrap();
-        let canonical_block = earliest_block_number - 1;
+        let Some(earliest_block_number) = flashblocks_per_block.keys().min().copied() else {
+            return Ok(None);
+        };
+        let canonical_block = earliest_block_number.saturating_sub(1);
         let mut last_block_header = self
             .client
             .header_by_number(canonical_block)


### PR DESCRIPTION
Fixes #2617

## Problem

`build_pending_state` had two bugs on consecutive lines:

1. **Panic on empty slice** — `keys().min().unwrap()` panics when called with an empty `flashblocks` slice (malformed upstream message, sequencer restart race). This is called from the core `StateProcessor::start()` event loop, so a panic takes down the entire pending-state subsystem.

2. **u64 underflow** — bare `earliest_block_number - 1` on a `BlockNumber` (`u64`) wraps to `u64::MAX` if a flashblock arrives with `block_number == 0`, producing a corrupted provider lookup instead of a clean error.

## Fix

- Return `Ok(None)` early when the input slice is empty instead of panicking.
- Use `.saturating_sub(1)` for the canonical block derivation, consistent with the same pattern already used in `db/store.rs`.