### PR TITLE
fix: reject trailing bytes in EIP-2718 decoding

### DIFF
--- a/crates/execution/engine-tree/src/validator.rs
+++ b/crates/execution/engine-tree/src/validator.rs
@@ -769,7 +769,9 @@ where
                 .payload
                 .transactions()
                 .iter()
-                .map(|tx| BaseTransactionSigned::decode_2718(&mut &tx[..]).map(|tx| tx.tx_hash()))
+                .map(|tx| {
+                    BaseTransactionSigned::decode_2718_exact(tx.as_ref()).map(|tx| tx.tx_hash())
+                })
                 .collect::<Result<Vec<_>, _>>()
                 .map_err(|err| InsertBlockErrorKind::Other(Box::new(err)))?,
             BlockOrPayload::Block(block) => {

--- a/crates/execution/txpool/src/builder/rpc.rs
+++ b/crates/execution/txpool/src/builder/rpc.rs
@@ -59,7 +59,7 @@ where
 
         // Decode the EIP-2718 transaction bytes
         let consensus_tx =
-            BaseTransactionSigned::decode_2718(&mut tx.raw.as_ref()).map_err(|e| {
+            BaseTransactionSigned::decode_2718_exact(tx.raw.as_ref()).map_err(|e| {
                 BuilderApiMetrics::decode_errors().increment(1);
                 ErrorObjectOwned::owned(
                     ErrorCode::InvalidParams.code(),
@@ -314,5 +314,27 @@ mod tests {
         // Decode should succeed, but the txpool is a noop so it will reject the tx
         // This error code should be InternalError
         assert_eq!(err.code(), ErrorCode::InternalError.code());
+    }
+
+    #[tokio::test]
+    async fn decode_tx_with_trailing_bytes_returns_invalid_params() {
+        let handler = handler();
+
+        let (sender, raw) = create_eip1559_tx();
+        let mut trailing_raw = raw.to_vec();
+        trailing_raw.extend_from_slice(&[0xde, 0xad, 0xbe, 0xef]);
+        let tx = ValidatedTransaction {
+            sender,
+            raw: Bytes::from(trailing_raw),
+            target_block_number: None,
+            min_timestamp: None,
+            max_timestamp: None,
+        };
+
+        let result = handler.insert_validated_transaction(tx).await;
+        assert!(result.is_err(), "expected decode error for trailing bytes");
+
+        let err = result.unwrap_err();
+        assert_eq!(err.code(), ErrorCode::InvalidParams.code());
     }
 }

--- a/crates/execution/txpool/src/bundle/rpc.rs
+++ b/crates/execution/txpool/src/bundle/rpc.rs
@@ -178,7 +178,7 @@ where
         validate_bundle_request(&bundle, current_block)?;
 
         let raw = &bundle.txs[0];
-        let consensus_tx = BaseTransactionSigned::decode_2718(&mut raw.as_ref()).map_err(|e| {
+        let consensus_tx = BaseTransactionSigned::decode_2718_exact(raw.as_ref()).map_err(|e| {
             rpc_err(ErrorCode::InvalidParams, format!("failed to decode transaction: {e:?}"))
         })?;
 
@@ -213,9 +213,30 @@ where
 
 #[cfg(test)]
 mod tests {
+    use alloy_consensus::TxEip1559;
+    use alloy_eips::eip2718::Encodable2718;
+    use alloy_primitives::{Address, Signature, TxKind, U256};
+    use base_common_consensus::{BaseTransactionSigned, BaseTypedTransaction};
     use reth_transaction_pool::noop::NoopTransactionPool;
 
     use super::*;
+
+    fn create_eip1559_tx() -> Bytes {
+        let tx = TxEip1559 {
+            chain_id: 1,
+            nonce: 0,
+            gas_limit: 21000,
+            max_fee_per_gas: 100,
+            max_priority_fee_per_gas: 10,
+            to: TxKind::Call(Address::repeat_byte(0x01)),
+            value: U256::from(1000),
+            access_list: Default::default(),
+            input: Default::default(),
+        };
+        let sig = Signature::new(U256::from(1), U256::from(2), false);
+        let signed = BaseTransactionSigned::new_unhashed(BaseTypedTransaction::Eip1559(tx), sig);
+        Bytes::from(signed.encoded_2718())
+    }
 
     fn handler(
         current_block: u64,
@@ -425,5 +446,25 @@ mod tests {
         let err = handler.send_bundle(req).await.unwrap_err();
         assert_eq!(err.code(), ErrorCode::InvalidParams.code());
         assert!(err.message().contains("too far ahead"));
+    }
+
+    #[tokio::test]
+    async fn send_bundle_rejects_tx_with_trailing_bytes() {
+        let handler = handler(100);
+        let mut raw = create_eip1559_tx().to_vec();
+        raw.extend_from_slice(&[0xde, 0xad, 0xbe, 0xef]);
+        let req = SendBundleRequest {
+            txs: vec![Bytes::from(raw)],
+            block_number: None,
+            min_timestamp: None,
+            max_timestamp: None,
+            reverting_tx_hashes: None,
+            replacement_uuid: None,
+            builders: None,
+        };
+
+        let err = handler.send_bundle(req).await.unwrap_err();
+        assert_eq!(err.code(), ErrorCode::InvalidParams.code());
+        assert!(err.message().contains("failed to decode transaction"));
     }
 }


### PR DESCRIPTION
## Summary
- switch the remaining production EIP-2718 decoding call sites from `decode_2718` to `decode_2718_exact`
- add regression coverage for RPC inputs with trailing bytes in the txpool builder and bundle handlers

## Problem
Issue #2622 called out three production paths that still accepted trailing bytes when decoding EIP-2718 transactions:
- `eth_sendBundle`
- `insertValidatedTransaction`
- payload validation in the engine tree validator

Using the non-strict decoder can accept malformed inputs that contain a valid transaction prefix followed by extra bytes.

## Solution
- replace `decode_2718` with `decode_2718_exact` in the remaining txpool and payload validation call sites
- add tests covering trailing-byte rejections for the builder and bundle RPC handlers

## Verification
- `RUSTFLAGS='-C link-arg=-fuse-ld=lld' cargo check -p base-execution-txpool --lib`
