### PR TITLE
fix(proposer): configure prover request timeout

### DIFF
--- a/crates/proof/proposer/src/cli.rs
+++ b/crates/proof/proposer/src/cli.rs
@@ -63,6 +63,15 @@ pub struct ProposerArgs {
     #[arg(long = "prover-rpc", env = cli_env!("PROVER_RPC"))]
     pub prover_rpc: Url,
 
+    /// Prover RPC request timeout (e.g., "70m", "4200s").
+    #[arg(
+        long = "prover-timeout",
+        env = cli_env!("PROVER_TIMEOUT"),
+        default_value = "70m",
+        value_parser = humantime::parse_duration
+    )]
+    pub prover_timeout: Duration,
+
     /// URL of the L1 Ethereum RPC endpoint.
     #[arg(long = "l1-eth-rpc", env = cli_env!("L1_ETH_RPC"))]
     pub l1_eth_rpc: Url,
@@ -258,6 +267,7 @@ mod tests {
         // Check defaults
         assert!(!cli.proposer.dry_run);
         assert!(!cli.proposer.allow_non_finalized);
+        assert_eq!(cli.proposer.prover_timeout, Duration::from_secs(70 * 60));
         assert_eq!(cli.proposer.poll_interval, Duration::from_secs(12));
         assert_eq!(cli.proposer.rpc_timeout, Duration::from_secs(30));
         assert_eq!(cli.proposer.rollup_rpc.as_str(), "http://localhost:7545/");

--- a/crates/proof/proposer/src/config.rs
+++ b/crates/proof/proposer/src/config.rs
@@ -46,6 +46,8 @@ pub struct ProposerConfig {
     pub allow_non_finalized: bool,
     /// URL of the prover RPC endpoint.
     pub prover_rpc: Url,
+    /// Prover RPC request timeout.
+    pub prover_timeout: Duration,
     /// URL of the L1 Ethereum RPC endpoint.
     pub l1_eth_rpc: Url,
     /// URL of the L2 Ethereum RPC endpoint.
@@ -128,6 +130,14 @@ impl ProposerConfig {
             });
         }
 
+        if proposer.prover_timeout.is_zero() {
+            return Err(ConfigError::OutOfRange {
+                field: "prover-timeout",
+                constraint: "greater than 0",
+                value: "0",
+            });
+        }
+
         if proposer.poll_interval.is_zero() {
             return Err(ConfigError::OutOfRange {
                 field: "poll-interval",
@@ -176,6 +186,7 @@ impl ProposerConfig {
             dry_run: proposer.dry_run,
             allow_non_finalized: proposer.allow_non_finalized,
             prover_rpc: proposer.prover_rpc,
+            prover_timeout: proposer.prover_timeout,
             l1_eth_rpc: proposer.l1_eth_rpc,
             l2_eth_rpc: proposer.l2_eth_rpc,
             anchor_state_registry_addr: proposer.anchor_state_registry_addr,
@@ -250,6 +261,7 @@ mod tests {
                     .unwrap(),
                 game_type: 1,
                 tee_image_hash: B256::repeat_byte(0x01),
+                prover_timeout: Duration::from_secs(70 * 60),
                 poll_interval: Duration::from_secs(12),
                 rpc_timeout: Duration::from_secs(30),
                 rollup_rpc: Url::parse("http://localhost:7545").unwrap(),
@@ -294,6 +306,7 @@ mod tests {
         assert!(!config.dry_run);
         assert!(!config.allow_non_finalized);
         assert_eq!(config.game_type, 1);
+        assert_eq!(config.prover_timeout, Duration::from_secs(70 * 60));
         assert_eq!(config.poll_interval, Duration::from_secs(12));
         assert_eq!(config.rpc_timeout, Duration::from_secs(30));
         assert_eq!(config.max_parallel_proofs, 1);
@@ -307,6 +320,14 @@ mod tests {
         let config = ProposerConfig::from_cli(cli).unwrap();
 
         assert_eq!(config.tx_manager.as_ref().unwrap().tx_send_timeout, Duration::ZERO);
+    }
+
+    #[test]
+    fn test_zero_prover_timeout() {
+        let mut cli = minimal_cli();
+        cli.proposer.prover_timeout = Duration::ZERO;
+        let result = ProposerConfig::from_cli(cli);
+        assert!(matches!(result, Err(ConfigError::OutOfRange { field: "prover-timeout", .. })));
     }
 
     #[test]

--- a/crates/proof/proposer/src/constants.rs
+++ b/crates/proof/proposer/src/constants.rs
@@ -6,9 +6,6 @@ use std::time::Duration;
 /// transaction to be included on-chain.
 pub const PROPOSAL_TIMEOUT: Duration = Duration::from_mins(10);
 
-/// Timeout for prover server RPC calls.
-pub const PROVER_TIMEOUT: Duration = Duration::from_mins(30);
-
 /// Default maximum number of concurrent RPC calls during the recovery scan.
 pub const RECOVERY_SCAN_CONCURRENCY: usize = 8;
 

--- a/crates/proof/proposer/src/lib.rs
+++ b/crates/proof/proposer/src/lib.rs
@@ -15,9 +15,7 @@ mod config;
 pub use config::{ConfigError, ProposerConfig};
 
 mod constants;
-pub use constants::{
-    MAX_PROOF_RETRIES, PROPOSAL_TIMEOUT, PROVER_TIMEOUT, RECOVERY_SCAN_CONCURRENCY,
-};
+pub use constants::{MAX_PROOF_RETRIES, PROPOSAL_TIMEOUT, RECOVERY_SCAN_CONCURRENCY};
 
 mod output_proposer;
 pub use output_proposer::{DryRunProposer, OutputProposer, ProposalSubmitter};

--- a/crates/proof/proposer/src/service.rs
+++ b/crates/proof/proposer/src/service.rs
@@ -53,6 +53,7 @@ impl ProposerService {
             dispute_game_factory = %config.dispute_game_factory_addr,
             game_type = config.game_type,
             tee_image_hash = %config.tee_image_hash,
+            prover_timeout = ?config.prover_timeout,
             poll_interval = ?config.poll_interval,
             rpc_timeout = ?config.rpc_timeout,
             max_parallel_proofs = config.max_parallel_proofs,
@@ -89,7 +90,7 @@ impl ProposerService {
         info!(endpoint = %config.rollup_rpc, "Rollup client initialized");
 
         let prover_client = HttpClientBuilder::default()
-            .request_timeout(crate::constants::PROVER_TIMEOUT)
+            .request_timeout(config.prover_timeout)
             .build(config.prover_rpc.as_str())
             .wrap_err("failed to create prover RPC client")?;
         info!(endpoint = %config.prover_rpc, "Prover RPC client initialized");


### PR DESCRIPTION
## Summary
- add --prover-timeout / BASE_PROPOSER_PROVER_TIMEOUT for the Nitro prover RPC client
- default the proposer-side prover request timeout to 70m
- validate non-zero prover timeout and log the resolved value

## Test plan
- cargo fmt --check
- cargo test -p base-proposer