### PR TITLE
refactor(common): Rename Azul Activation Helper

### DIFF
--- a/crates/builder/core/src/flashblocks/payload.rs
+++ b/crates/builder/core/src/flashblocks/payload.rs
@@ -1109,7 +1109,7 @@ where
     let _access_list = fal_builder.build(min_tx_index, max_tx_index);
 
     let metadata: FlashblocksMetadata =
-        if ctx.chain_spec.is_base_azul_active_at_timestamp(ctx.attributes().timestamp()) {
+        if ctx.chain_spec.is_azul_active_at_timestamp(ctx.attributes().timestamp()) {
             FlashblocksMetadata {
                 block_number: ctx.parent().number + 1,
                 access_list: None,

--- a/crates/common/chains/src/chain.rs
+++ b/crates/common/chains/src/chain.rs
@@ -268,31 +268,31 @@ mod tests {
     }
 
     #[test]
-    fn is_base_azul_active_at_timestamp() {
+    fn is_azul_active_at_timestamp() {
         // Azul is scheduled on mainnet at 1779386400
         let base_mainnet_forks = ChainUpgrades::mainnet();
-        assert!(!base_mainnet_forks.is_base_azul_active_at_timestamp(0));
-        assert!(!base_mainnet_forks.is_base_azul_active_at_timestamp(1_779_386_399));
-        assert!(base_mainnet_forks.is_base_azul_active_at_timestamp(1_779_386_400));
-        assert!(base_mainnet_forks.is_base_azul_active_at_timestamp(u64::MAX));
+        assert!(!base_mainnet_forks.is_azul_active_at_timestamp(0));
+        assert!(!base_mainnet_forks.is_azul_active_at_timestamp(1_779_386_399));
+        assert!(base_mainnet_forks.is_azul_active_at_timestamp(1_779_386_400));
+        assert!(base_mainnet_forks.is_azul_active_at_timestamp(u64::MAX));
 
         // Azul is scheduled on sepolia at 1776708000
         let base_sepolia_forks = ChainUpgrades::sepolia();
-        assert!(!base_sepolia_forks.is_base_azul_active_at_timestamp(0));
-        assert!(!base_sepolia_forks.is_base_azul_active_at_timestamp(1_776_707_999));
-        assert!(base_sepolia_forks.is_base_azul_active_at_timestamp(1_776_708_000));
-        assert!(base_sepolia_forks.is_base_azul_active_at_timestamp(u64::MAX));
+        assert!(!base_sepolia_forks.is_azul_active_at_timestamp(0));
+        assert!(!base_sepolia_forks.is_azul_active_at_timestamp(1_776_707_999));
+        assert!(base_sepolia_forks.is_azul_active_at_timestamp(1_776_708_000));
+        assert!(base_sepolia_forks.is_azul_active_at_timestamp(u64::MAX));
 
         // Azul is active at genesis on devnet (ForkCondition::ZERO_TIMESTAMP)
         let devnet_forks = ChainUpgrades::devnet();
-        assert!(devnet_forks.is_base_azul_active_at_timestamp(0));
+        assert!(devnet_forks.is_azul_active_at_timestamp(0));
 
         // Azul is scheduled on zeronet at 1775152800
         let zeronet_forks = ChainUpgrades::zeronet();
-        assert!(!zeronet_forks.is_base_azul_active_at_timestamp(0));
-        assert!(!zeronet_forks.is_base_azul_active_at_timestamp(1_775_152_799));
-        assert!(zeronet_forks.is_base_azul_active_at_timestamp(1_775_152_800));
-        assert!(zeronet_forks.is_base_azul_active_at_timestamp(u64::MAX));
+        assert!(!zeronet_forks.is_azul_active_at_timestamp(0));
+        assert!(!zeronet_forks.is_azul_active_at_timestamp(1_775_152_799));
+        assert!(zeronet_forks.is_azul_active_at_timestamp(1_775_152_800));
+        assert!(zeronet_forks.is_azul_active_at_timestamp(u64::MAX));
     }
 
     #[test]

--- a/crates/common/chains/src/upgrade.rs
+++ b/crates/common/chains/src/upgrade.rs
@@ -60,7 +60,7 @@ impl BaseUpgrade {
     pub fn from_timestamp(chain_spec: impl Upgrades, timestamp: u64) -> Self {
         if chain_spec.is_beryl_active_at_timestamp(timestamp) {
             Self::Beryl
-        } else if chain_spec.is_base_azul_active_at_timestamp(timestamp) {
+        } else if chain_spec.is_azul_active_at_timestamp(timestamp) {
             Self::Azul
         } else if chain_spec.is_jovian_active_at_timestamp(timestamp) {
             Self::Jovian

--- a/crates/common/chains/src/upgrades.rs
+++ b/crates/common/chains/src/upgrades.rs
@@ -61,7 +61,7 @@ pub trait Upgrades: EthereumHardforks {
     }
 
     /// Returns `true` if [`Azul`](BaseUpgrade::Azul) is active at given block timestamp.
-    fn is_base_azul_active_at_timestamp(&self, timestamp: u64) -> bool {
+    fn is_azul_active_at_timestamp(&self, timestamp: u64) -> bool {
         self.upgrade_activation(BaseUpgrade::Azul).active_at_timestamp(timestamp)
     }
 

--- a/crates/execution/evm/src/lib.rs
+++ b/crates/execution/evm/src/lib.rs
@@ -66,7 +66,7 @@ fn build_cfg_env(
     let mut cfg_env =
         CfgEnv::new().with_chain_id(chain_spec.chain().id()).with_spec_and_mainnet_gas_params(spec);
 
-    if chain_spec.is_base_azul_active_at_timestamp(timestamp) {
+    if chain_spec.is_azul_active_at_timestamp(timestamp) {
         cfg_env.tx_gas_limit_cap = Some(MAX_TX_GAS_LIMIT_OSAKA);
     }
 

--- a/docs/guides/UPGRADES.md
+++ b/docs/guides/UPGRADES.md
@@ -188,7 +188,7 @@ For **cascading** upgrades, replace the previous arm's `unwrap_or(ForkCondition:
 
 ```rust
 /// Returns `true` if [`Azul`](BaseUpgrade::Azul) is active at given block timestamp.
-fn is_base_azul_active_at_timestamp(&self, timestamp: u64) -> bool {
+fn is_azul_active_at_timestamp(&self, timestamp: u64) -> bool {
     self.upgrade_activation(BaseUpgrade::Azul).active_at_timestamp(timestamp)
 }
 ```
@@ -325,7 +325,7 @@ Add the new upgrade as the first check (newest upgrade wins):
 pub fn from_timestamp(chain_spec: impl Upgrades, timestamp: u64) -> Self {
     if chain_spec.is_beryl_active_at_timestamp(timestamp) {
         Self::Beryl
-    } else if chain_spec.is_base_azul_active_at_timestamp(timestamp) {
+    } else if chain_spec.is_azul_active_at_timestamp(timestamp) {
         Self::Azul
     } else if chain_spec.is_jovian_active_at_timestamp(timestamp) {
         Self::Jovian


### PR DESCRIPTION
## Summary

This renames the Azul upgrade helper from `is_base_azul_active_at_timestamp` to `is_azul_active_at_timestamp` so it matches the surrounding upgrade helper names. The call sites in common EVM, execution EVM, builder flashblocks, and the upgrade guide now use the shorter API name. Validation covered the focused common-chains test and a compile check of the affected downstream crates.