### PR TITLE
feat(txpool): add error reason labels to mempool v2 metrics

### DIFF
--- a/crates/execution/txpool/src/builder/metrics.rs
+++ b/crates/execution/txpool/src/builder/metrics.rs
@@ -1,7 +1,5 @@
 //! Metrics for the builder RPC handler.
 
-use reth_transaction_pool::error::{PoolError, PoolErrorKind};
-
 base_metrics::define_metrics! {
     txpool.builder_rpc
     #[describe("Transactions successfully inserted into the pool")]
@@ -22,20 +20,4 @@ base_metrics::define_metrics! {
     txs_rejected: counter,
     #[describe("Time to insert a transaction in the local txpool")]
     insert_duration: histogram,
-}
-
-impl Metrics {
-    /// Maps a [`PoolError`] to a static label for the `txs_rejected` metric.
-    pub const fn rejection_label(err: &PoolError) -> &'static str {
-        match &err.kind {
-            PoolErrorKind::AlreadyImported => "already_imported",
-            PoolErrorKind::ReplacementUnderpriced => "replacement_underpriced",
-            PoolErrorKind::FeeCapBelowMinimumProtocolFeeCap(_) => "fee_cap_below_minimum",
-            PoolErrorKind::SpammerExceededCapacity(_) => "spammer_exceeded_capacity",
-            PoolErrorKind::DiscardedOnInsert => "discarded_on_insert",
-            PoolErrorKind::InvalidTransaction(_) => "invalid_transaction",
-            PoolErrorKind::ExistingConflictingTransactionType(_, _) => "conflicting_tx_type",
-            PoolErrorKind::Other(_) => "other",
-        }
-    }
 }

--- a/crates/execution/txpool/src/builder/metrics.rs
+++ b/crates/execution/txpool/src/builder/metrics.rs
@@ -1,5 +1,7 @@
 //! Metrics for the builder RPC handler.
 
+use reth_transaction_pool::error::{PoolError, PoolErrorKind};
+
 base_metrics::define_metrics! {
     txpool.builder_rpc
     #[describe("Transactions successfully inserted into the pool")]
@@ -7,7 +9,33 @@ base_metrics::define_metrics! {
     #[describe("Transactions that failed to decode")]
     decode_errors: counter,
     #[describe("Transactions rejected by the pool")]
+    #[label(name = "reason", default = [
+        "already_imported",
+        "replacement_underpriced",
+        "fee_cap_below_minimum",
+        "spammer_exceeded_capacity",
+        "discarded_on_insert",
+        "invalid_transaction",
+        "conflicting_tx_type",
+        "other",
+    ])]
     txs_rejected: counter,
     #[describe("Time to insert a transaction in the local txpool")]
     insert_duration: histogram,
+}
+
+impl Metrics {
+    /// Maps a [`PoolError`] to a static label for the `txs_rejected` metric.
+    pub const fn rejection_label(err: &PoolError) -> &'static str {
+        match &err.kind {
+            PoolErrorKind::AlreadyImported => "already_imported",
+            PoolErrorKind::ReplacementUnderpriced => "replacement_underpriced",
+            PoolErrorKind::FeeCapBelowMinimumProtocolFeeCap(_) => "fee_cap_below_minimum",
+            PoolErrorKind::SpammerExceededCapacity(_) => "spammer_exceeded_capacity",
+            PoolErrorKind::DiscardedOnInsert => "discarded_on_insert",
+            PoolErrorKind::InvalidTransaction(_) => "invalid_transaction",
+            PoolErrorKind::ExistingConflictingTransactionType(_, _) => "conflicting_tx_type",
+            PoolErrorKind::Other(_) => "other",
+        }
+    }
 }

--- a/crates/execution/txpool/src/builder/metrics.rs
+++ b/crates/execution/txpool/src/builder/metrics.rs
@@ -7,16 +7,7 @@ base_metrics::define_metrics! {
     #[describe("Transactions that failed to decode")]
     decode_errors: counter,
     #[describe("Transactions rejected by the pool")]
-    #[label(name = "reason", default = [
-        "already_imported",
-        "replacement_underpriced",
-        "fee_cap_below_minimum",
-        "spammer_exceeded_capacity",
-        "discarded_on_insert",
-        "invalid_transaction",
-        "conflicting_tx_type",
-        "other",
-    ])]
+    #[label(reason)]
     txs_rejected: counter,
     #[describe("Time to insert a transaction in the local txpool")]
     insert_duration: histogram,

--- a/crates/execution/txpool/src/builder/rpc.rs
+++ b/crates/execution/txpool/src/builder/rpc.rs
@@ -89,8 +89,7 @@ where
             }
             Err(e) => {
                 debug!(sender = %sender, error = %e, "pool rejected transaction");
-                BuilderApiMetrics::txs_rejected(PoolRejectionLabel::from_error(&e))
-                    .increment(1);
+                BuilderApiMetrics::txs_rejected(PoolRejectionLabel::from_error(&e)).increment(1);
                 Err(ErrorObjectOwned::owned(
                     ErrorCode::InternalError.code(),
                     format!("pool rejected transaction: {e}"),

--- a/crates/execution/txpool/src/builder/rpc.rs
+++ b/crates/execution/txpool/src/builder/rpc.rs
@@ -89,7 +89,8 @@ where
             }
             Err(e) => {
                 debug!(sender = %sender, error = %e, "pool rejected transaction");
-                BuilderApiMetrics::txs_rejected().increment(1);
+                BuilderApiMetrics::txs_rejected(BuilderApiMetrics::rejection_label(&e))
+                    .increment(1);
                 Err(ErrorObjectOwned::owned(
                     ErrorCode::InternalError.code(),
                     format!("pool rejected transaction: {e}"),

--- a/crates/execution/txpool/src/builder/rpc.rs
+++ b/crates/execution/txpool/src/builder/rpc.rs
@@ -12,7 +12,7 @@ use reth_transaction_pool::TransactionPool;
 use tracing::debug;
 
 use super::metrics::Metrics as BuilderApiMetrics;
-use crate::{BasePooledTransaction, ValidatedTransaction};
+use crate::{BasePooledTransaction, PoolRejectionLabel, ValidatedTransaction};
 
 /// RPC interface for submitting pre-validated transactions to a block builder.
 #[rpc(server, namespace = "base")]
@@ -89,7 +89,7 @@ where
             }
             Err(e) => {
                 debug!(sender = %sender, error = %e, "pool rejected transaction");
-                BuilderApiMetrics::txs_rejected(BuilderApiMetrics::rejection_label(&e))
+                BuilderApiMetrics::txs_rejected(PoolRejectionLabel::from_error(&e))
                     .increment(1);
                 Err(ErrorObjectOwned::owned(
                     ErrorCode::InternalError.code(),

--- a/crates/execution/txpool/src/bundle/metrics.rs
+++ b/crates/execution/txpool/src/bundle/metrics.rs
@@ -1,0 +1,55 @@
+//! Metrics for the `eth_sendBundle` RPC handler.
+
+use reth_transaction_pool::error::{PoolError, PoolErrorKind};
+
+base_metrics::define_metrics! {
+    txpool.bundle_rpc
+    #[describe("Bundles successfully inserted into the pool")]
+    txs_inserted: counter,
+    #[describe("Bundles that failed to decode")]
+    decode_errors: counter,
+    #[describe("Bundles that failed signer recovery")]
+    recovery_errors: counter,
+    #[describe("Bundles rejected by request validation")]
+    #[label(name = "reason", default = [
+        "invalid_tx_count",
+        "block_number_past",
+        "block_number_too_far",
+        "min_timestamp_too_far",
+        "max_timestamp_past",
+        "max_timestamp_too_far",
+        "min_after_max_timestamp",
+        "unsupported_field",
+    ])]
+    validation_errors: counter,
+    #[describe("Bundles rejected by the pool")]
+    #[label(name = "reason", default = [
+        "already_imported",
+        "replacement_underpriced",
+        "fee_cap_below_minimum",
+        "spammer_exceeded_capacity",
+        "discarded_on_insert",
+        "invalid_transaction",
+        "conflicting_tx_type",
+        "other",
+    ])]
+    txs_rejected: counter,
+    #[describe("Requests rejected because eth_sendBundle is disabled")]
+    not_enabled: counter,
+}
+
+impl Metrics {
+    /// Maps a [`PoolError`] to a static label for the `txs_rejected` metric.
+    pub const fn rejection_label(err: &PoolError) -> &'static str {
+        match &err.kind {
+            PoolErrorKind::AlreadyImported => "already_imported",
+            PoolErrorKind::ReplacementUnderpriced => "replacement_underpriced",
+            PoolErrorKind::FeeCapBelowMinimumProtocolFeeCap(_) => "fee_cap_below_minimum",
+            PoolErrorKind::SpammerExceededCapacity(_) => "spammer_exceeded_capacity",
+            PoolErrorKind::DiscardedOnInsert => "discarded_on_insert",
+            PoolErrorKind::InvalidTransaction(_) => "invalid_transaction",
+            PoolErrorKind::ExistingConflictingTransactionType(_, _) => "conflicting_tx_type",
+            PoolErrorKind::Other(_) => "other",
+        }
+    }
+}

--- a/crates/execution/txpool/src/bundle/metrics.rs
+++ b/crates/execution/txpool/src/bundle/metrics.rs
@@ -1,7 +1,5 @@
 //! Metrics for the `eth_sendBundle` RPC handler.
 
-use reth_transaction_pool::error::{PoolError, PoolErrorKind};
-
 base_metrics::define_metrics! {
     txpool.bundle_rpc
     #[describe("Bundles successfully inserted into the pool")]
@@ -36,20 +34,4 @@ base_metrics::define_metrics! {
     txs_rejected: counter,
     #[describe("Requests rejected because eth_sendBundle is disabled")]
     not_enabled: counter,
-}
-
-impl Metrics {
-    /// Maps a [`PoolError`] to a static label for the `txs_rejected` metric.
-    pub const fn rejection_label(err: &PoolError) -> &'static str {
-        match &err.kind {
-            PoolErrorKind::AlreadyImported => "already_imported",
-            PoolErrorKind::ReplacementUnderpriced => "replacement_underpriced",
-            PoolErrorKind::FeeCapBelowMinimumProtocolFeeCap(_) => "fee_cap_below_minimum",
-            PoolErrorKind::SpammerExceededCapacity(_) => "spammer_exceeded_capacity",
-            PoolErrorKind::DiscardedOnInsert => "discarded_on_insert",
-            PoolErrorKind::InvalidTransaction(_) => "invalid_transaction",
-            PoolErrorKind::ExistingConflictingTransactionType(_, _) => "conflicting_tx_type",
-            PoolErrorKind::Other(_) => "other",
-        }
-    }
 }

--- a/crates/execution/txpool/src/bundle/metrics.rs
+++ b/crates/execution/txpool/src/bundle/metrics.rs
@@ -9,28 +9,10 @@ base_metrics::define_metrics! {
     #[describe("Bundles that failed signer recovery")]
     recovery_errors: counter,
     #[describe("Bundles rejected by request validation")]
-    #[label(name = "reason", default = [
-        "invalid_tx_count",
-        "block_number_past",
-        "block_number_too_far",
-        "min_timestamp_too_far",
-        "max_timestamp_past",
-        "max_timestamp_too_far",
-        "min_after_max_timestamp",
-        "unsupported_field",
-    ])]
+    #[label(reason)]
     validation_errors: counter,
     #[describe("Bundles rejected by the pool")]
-    #[label(name = "reason", default = [
-        "already_imported",
-        "replacement_underpriced",
-        "fee_cap_below_minimum",
-        "spammer_exceeded_capacity",
-        "discarded_on_insert",
-        "invalid_transaction",
-        "conflicting_tx_type",
-        "other",
-    ])]
+    #[label(reason)]
     txs_rejected: counter,
     #[describe("Requests rejected because eth_sendBundle is disabled")]
     not_enabled: counter,

--- a/crates/execution/txpool/src/bundle/mod.rs
+++ b/crates/execution/txpool/src/bundle/mod.rs
@@ -1,5 +1,8 @@
 //! Bundle transaction types and lifecycle management for `eth_sendBundle` RPC support.
 
+mod metrics;
+pub use metrics::Metrics as BundleApiMetrics;
+
 mod rpc;
 pub use rpc::{SendBundleApiImpl, SendBundleApiServer, SendBundleRequest};
 

--- a/crates/execution/txpool/src/bundle/rpc.rs
+++ b/crates/execution/txpool/src/bundle/rpc.rs
@@ -12,7 +12,7 @@ use tracing::debug;
 
 use super::metrics::Metrics as BundleApiMetrics;
 use crate::{
-    BasePooledTransaction,
+    BasePooledTransaction, PoolRejectionLabel,
     transaction::{MAX_BUNDLE_ADVANCE_BLOCKS, MAX_BUNDLE_ADVANCE_MILLIS},
 };
 
@@ -80,15 +80,15 @@ fn rpc_err(code: ErrorCode, msg: impl Into<String>) -> ErrorObjectOwned {
     ErrorObjectOwned::owned(code.code(), msg.into(), None::<()>)
 }
 
-/// Validates the structural constraints on a [`SendBundleRequest`].
-///
-/// Returns `Ok(())` if all restrictions pass, or an RPC error describing the
-/// first violated constraint.
 fn validation_err(reason: &'static str, msg: impl Into<String>) -> ErrorObjectOwned {
     BundleApiMetrics::validation_errors(reason).increment(1);
     rpc_err(ErrorCode::InvalidParams, msg)
 }
 
+/// Validates the structural constraints on a [`SendBundleRequest`].
+///
+/// Returns `Ok(())` if all restrictions pass, or an RPC error describing the
+/// first violated constraint.
 fn validate_bundle_request(
     req: &SendBundleRequest,
     current_block: u64,
@@ -213,7 +213,7 @@ where
         );
 
         self.pool.add_external_transaction(pool_tx).await.map_err(|e| {
-            BundleApiMetrics::txs_rejected(BundleApiMetrics::rejection_label(&e)).increment(1);
+            BundleApiMetrics::txs_rejected(PoolRejectionLabel::from_error(&e)).increment(1);
             rpc_err(ErrorCode::InternalError, format!("pool rejected transaction: {e}"))
         })?;
 

--- a/crates/execution/txpool/src/bundle/rpc.rs
+++ b/crates/execution/txpool/src/bundle/rpc.rs
@@ -10,6 +10,7 @@ use reth_primitives_traits::SignedTransaction;
 use reth_transaction_pool::TransactionPool;
 use tracing::debug;
 
+use super::metrics::Metrics as BundleApiMetrics;
 use crate::{
     BasePooledTransaction,
     transaction::{MAX_BUNDLE_ADVANCE_BLOCKS, MAX_BUNDLE_ADVANCE_MILLIS},
@@ -83,13 +84,18 @@ fn rpc_err(code: ErrorCode, msg: impl Into<String>) -> ErrorObjectOwned {
 ///
 /// Returns `Ok(())` if all restrictions pass, or an RPC error describing the
 /// first violated constraint.
+fn validation_err(reason: &'static str, msg: impl Into<String>) -> ErrorObjectOwned {
+    BundleApiMetrics::validation_errors(reason).increment(1);
+    rpc_err(ErrorCode::InvalidParams, msg)
+}
+
 fn validate_bundle_request(
     req: &SendBundleRequest,
     current_block: u64,
 ) -> Result<(), ErrorObjectOwned> {
     if req.txs.len() != 1 {
-        return Err(rpc_err(
-            ErrorCode::InvalidParams,
+        return Err(validation_err(
+            "invalid_tx_count",
             format!("txs must contain exactly 1 transaction, got {}", req.txs.len()),
         ));
     }
@@ -98,15 +104,15 @@ fn validate_bundle_request(
 
     if let Some(block_number) = req.block_number {
         if block_number < current_block {
-            return Err(rpc_err(
-                ErrorCode::InvalidParams,
+            return Err(validation_err(
+                "block_number_past",
                 format!("blockNumber {block_number} is in the past (current {current_block})",),
             ));
         }
         let max_block = current_block + MAX_BUNDLE_ADVANCE_BLOCKS;
         if block_number > max_block {
-            return Err(rpc_err(
-                ErrorCode::InvalidParams,
+            return Err(validation_err(
+                "block_number_too_far",
                 format!(
                     "blockNumber {block_number} is too far ahead (max {max_block}, current {current_block})",
                 ),
@@ -117,8 +123,8 @@ fn validate_bundle_request(
     if let Some(min_ts) = req.min_timestamp {
         let max_allowed = now_ms + MAX_BUNDLE_ADVANCE_MILLIS;
         if min_ts > max_allowed {
-            return Err(rpc_err(
-                ErrorCode::InvalidParams,
+            return Err(validation_err(
+                "min_timestamp_too_far",
                 format!("minTimestamp {min_ts}ms is too far ahead (max {max_allowed}ms)"),
             ));
         }
@@ -126,15 +132,15 @@ fn validate_bundle_request(
 
     if let Some(max_ts) = req.max_timestamp {
         if max_ts < now_ms {
-            return Err(rpc_err(
-                ErrorCode::InvalidParams,
+            return Err(validation_err(
+                "max_timestamp_past",
                 format!("maxTimestamp {max_ts}ms is in the past (now {now_ms}ms)"),
             ));
         }
         let max_allowed = now_ms + MAX_BUNDLE_ADVANCE_MILLIS;
         if max_ts > max_allowed {
-            return Err(rpc_err(
-                ErrorCode::InvalidParams,
+            return Err(validation_err(
+                "max_timestamp_too_far",
                 format!("maxTimestamp {max_ts}ms is too far ahead (max {max_allowed}ms)"),
             ));
         }
@@ -143,22 +149,22 @@ fn validate_bundle_request(
     if let (Some(min_ts), Some(max_ts)) = (req.min_timestamp, req.max_timestamp)
         && min_ts > max_ts
     {
-        return Err(rpc_err(
-            ErrorCode::InvalidParams,
+        return Err(validation_err(
+            "min_after_max_timestamp",
             format!("minTimestamp {min_ts}ms is after maxTimestamp {max_ts}ms"),
         ));
     }
 
     if req.reverting_tx_hashes.as_ref().is_some_and(|v| !v.is_empty()) {
-        return Err(rpc_err(ErrorCode::InvalidParams, "revertingTxHashes is not supported"));
+        return Err(validation_err("unsupported_field", "revertingTxHashes is not supported"));
     }
 
     if req.replacement_uuid.is_some() {
-        return Err(rpc_err(ErrorCode::InvalidParams, "replacementUuid is not supported"));
+        return Err(validation_err("unsupported_field", "replacementUuid is not supported"));
     }
 
     if req.builders.as_ref().is_some_and(|v| !v.is_empty()) {
-        return Err(rpc_err(ErrorCode::InvalidParams, "builders is not supported"));
+        return Err(validation_err("unsupported_field", "builders is not supported"));
     }
 
     Ok(())
@@ -171,6 +177,7 @@ where
 {
     async fn send_bundle(&self, bundle: SendBundleRequest) -> RpcResult<TxHash> {
         if !self.enabled {
+            BundleApiMetrics::not_enabled().increment(1);
             return Err(rpc_err(ErrorCode::MethodNotFound, "eth_sendBundle is not enabled"));
         }
 
@@ -179,10 +186,12 @@ where
 
         let raw = &bundle.txs[0];
         let consensus_tx = BaseTransactionSigned::decode_2718(&mut raw.as_ref()).map_err(|e| {
+            BundleApiMetrics::decode_errors().increment(1);
             rpc_err(ErrorCode::InvalidParams, format!("failed to decode transaction: {e:?}"))
         })?;
 
         let recovered = consensus_tx.try_into_recovered().map_err(|e| {
+            BundleApiMetrics::recovery_errors().increment(1);
             rpc_err(ErrorCode::InvalidParams, format!("failed to recover signer: {e:?}"))
         })?;
 
@@ -204,9 +213,11 @@ where
         );
 
         self.pool.add_external_transaction(pool_tx).await.map_err(|e| {
+            BundleApiMetrics::txs_rejected(BundleApiMetrics::rejection_label(&e)).increment(1);
             rpc_err(ErrorCode::InternalError, format!("pool rejected transaction: {e}"))
         })?;
 
+        BundleApiMetrics::txs_inserted().increment(1);
         Ok(tx_hash)
     }
 }

--- a/crates/execution/txpool/src/forwarder/metrics.rs
+++ b/crates/execution/txpool/src/forwarder/metrics.rs
@@ -13,7 +13,7 @@ base_metrics::define_metrics! {
     txs_forwarded: counter,
     #[describe("Total RPC send errors (after all retries exhausted)")]
     #[label(builder_url)]
-    #[label(name = "reason")]
+    #[label(reason)]
     rpc_errors: counter,
     #[describe("Total number of transactions rejected by the builder's pool within successful batch calls")]
     #[label(builder_url)]

--- a/crates/execution/txpool/src/forwarder/metrics.rs
+++ b/crates/execution/txpool/src/forwarder/metrics.rs
@@ -1,5 +1,7 @@
 //! Metrics for the transaction forwarder.
 
+use jsonrpsee::core::ClientError;
+
 base_metrics::define_metrics! {
     txpool.forwarder,
     struct = ForwarderMetrics,
@@ -11,6 +13,14 @@ base_metrics::define_metrics! {
     txs_forwarded: counter,
     #[describe("Total RPC send errors (after all retries exhausted)")]
     #[label(builder_url)]
+    #[label(name = "reason", default = [
+        "transport",
+        "request_timeout",
+        "restart_needed",
+        "call_error",
+        "parse_error",
+        "other",
+    ])]
     rpc_errors: counter,
     #[describe("Total number of transactions rejected by the builder's pool within successful batch calls")]
     #[label(builder_url)]
@@ -27,4 +37,18 @@ base_metrics::define_metrics! {
     #[describe("Current number of transactions buffered and awaiting send")]
     #[label(builder_url)]
     buffer_size: gauge,
+}
+
+impl ForwarderMetrics {
+    /// Maps a [`ClientError`] to a static label for the `rpc_errors` metric.
+    pub const fn rpc_error_label(err: &ClientError) -> &'static str {
+        match err {
+            ClientError::Transport(_) => "transport",
+            ClientError::RequestTimeout => "request_timeout",
+            ClientError::RestartNeeded(_) => "restart_needed",
+            ClientError::Call(_) => "call_error",
+            ClientError::ParseError(_) => "parse_error",
+            _ => "other",
+        }
+    }
 }

--- a/crates/execution/txpool/src/forwarder/metrics.rs
+++ b/crates/execution/txpool/src/forwarder/metrics.rs
@@ -13,14 +13,7 @@ base_metrics::define_metrics! {
     txs_forwarded: counter,
     #[describe("Total RPC send errors (after all retries exhausted)")]
     #[label(builder_url)]
-    #[label(name = "reason", default = [
-        "transport",
-        "request_timeout",
-        "restart_needed",
-        "call_error",
-        "parse_error",
-        "other",
-    ])]
+    #[label(name = "reason")]
     rpc_errors: counter,
     #[describe("Total number of transactions rejected by the builder's pool within successful batch calls")]
     #[label(builder_url)]

--- a/crates/execution/txpool/src/forwarder/task.rs
+++ b/crates/execution/txpool/src/forwarder/task.rs
@@ -300,7 +300,11 @@ where
                         retryable = Self::is_retryable(&err),
                         "RPC send failed, dropping batch",
                     );
-                    ForwarderMetrics::rpc_errors(Arc::clone(&self.url_label)).increment(1);
+                    ForwarderMetrics::rpc_errors(
+                        Arc::clone(&self.url_label),
+                        ForwarderMetrics::rpc_error_label(&err),
+                    )
+                    .increment(1);
                     return;
                 }
             }

--- a/crates/execution/txpool/src/lib.rs
+++ b/crates/execution/txpool/src/lib.rs
@@ -26,6 +26,9 @@ pub use consumer::{Consumer, ConsumerConfig, ConsumerMetrics, RecentlySent, Spaw
 mod forwarder;
 pub use forwarder::{Forwarder, ForwarderConfig, ForwarderMetrics, SpawnedForwarder};
 
+mod pool_error_label;
+pub use pool_error_label::PoolRejectionLabel;
+
 mod builder;
 pub use builder::{BuilderApiImpl, BuilderApiMetrics, BuilderApiServer};
 

--- a/crates/execution/txpool/src/lib.rs
+++ b/crates/execution/txpool/src/lib.rs
@@ -31,7 +31,8 @@ pub use builder::{BuilderApiImpl, BuilderApiMetrics, BuilderApiServer};
 
 mod bundle;
 pub use bundle::{
-    SendBundleApiImpl, SendBundleApiServer, SendBundleRequest, maintain_bundle_transactions,
+    BundleApiMetrics, SendBundleApiImpl, SendBundleApiServer, SendBundleRequest,
+    maintain_bundle_transactions,
 };
 
 mod wire;

--- a/crates/execution/txpool/src/pool_error_label.rs
+++ b/crates/execution/txpool/src/pool_error_label.rs
@@ -1,0 +1,23 @@
+//! Shared pool-error label classification for metrics.
+
+use reth_transaction_pool::error::{PoolError, PoolErrorKind};
+
+/// Maps [`PoolErrorKind`] variants to static metric label strings.
+#[derive(Debug)]
+pub struct PoolRejectionLabel;
+
+impl PoolRejectionLabel {
+    /// Returns a `&'static str` label for the given [`PoolError`].
+    pub fn from_error(err: &PoolError) -> &'static str {
+        match &err.kind {
+            PoolErrorKind::AlreadyImported => "already_imported",
+            PoolErrorKind::ReplacementUnderpriced => "replacement_underpriced",
+            PoolErrorKind::FeeCapBelowMinimumProtocolFeeCap(_) => "fee_cap_below_minimum",
+            PoolErrorKind::SpammerExceededCapacity(_) => "spammer_exceeded_capacity",
+            PoolErrorKind::DiscardedOnInsert => "discarded_on_insert",
+            PoolErrorKind::InvalidTransaction(_) => "invalid_transaction",
+            PoolErrorKind::ExistingConflictingTransactionType(_, _) => "conflicting_tx_type",
+            PoolErrorKind::Other(_) => "other",
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Add a `reason` label to the builder RPC `txs_rejected` counter, classifying rejections by `PoolErrorKind` variant (e.g. `already_imported`, `invalid_transaction`, `discarded_on_insert`)
- Add a `reason` label to the forwarder `rpc_errors` counter, classifying failures by `ClientError` variant (e.g. `transport`, `request_timeout`, `call_error`)
- Instrument `bundle/rpc.rs` (`eth_sendBundle`) with metrics from scratch — previously had zero observability. Adds labeled counters for validation errors, decode errors, recovery errors, pool rejections, disabled-method hits, and successful insertions