### PR TITLE
feat(upgrades): add BaseV1 upgrade scaffold

### DIFF
--- a/crates/consensus/upgrades/src/basev1.rs
+++ b/crates/consensus/upgrades/src/basev1.rs
@@ -1,0 +1,40 @@
+//! Module containing a [`TxDeposit`] builder for the Base V1 network upgrade transactions.
+//!
+//! Base V1 network upgrade transactions are defined in the [Base Specs][specs].
+//!
+//! [specs]: https://specs.base.org/upgrades/base-v1/derivation#network-upgrade-automation-transactions
+
+use alloy_primitives::{Address, Bytes};
+use base_common_consensus::Deployers;
+
+use crate::Upgrade;
+
+/// The Base V1 network upgrade transactions.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct BaseV1;
+
+impl BaseV1 {
+    upgrade_source_fn!(
+        /// Returns the source hash for the deployment of the l1 block contract.
+        deploy_l1_block_source,
+        "Base V1: L1 Block Deployment"
+    );
+
+    upgrade_source_fn!(
+        /// Returns the source hash for the l1 block proxy update.
+        l1_block_proxy_update,
+        "Base V1: L1 Block Proxy Update"
+    );
+
+    /// The Base V1 L1 Block Address
+    pub fn l1_block_address() -> Address {
+        Deployers::JOVIAN_L1_BLOCK.create(0)
+    }
+}
+
+impl Upgrade for BaseV1 {
+    /// Constructs the network upgrade transactions.
+    fn txs(&self) -> impl Iterator<Item = Bytes> + '_ {
+        core::iter::empty()
+    }
+}

--- a/crates/consensus/upgrades/src/forks.rs
+++ b/crates/consensus/upgrades/src/forks.rs
@@ -1,6 +1,6 @@
 //! Contains all upgrades represented in the [`crate::Upgrade`] type.
 
-use crate::{Ecotone, Fjord, Isthmus, Jovian};
+use crate::{BaseV1, Ecotone, Fjord, Isthmus, Jovian};
 
 /// Base Upgrades
 ///
@@ -46,6 +46,9 @@ impl Upgrades {
 
     /// The Jovian upgrade transactions.
     pub const JOVIAN: Jovian = Jovian;
+
+    /// The Base V1 upgrade transactions.
+    pub const BASE_V1: BaseV1 = BaseV1;
 }
 
 #[cfg(test)]

--- a/crates/consensus/upgrades/src/lib.rs
+++ b/crates/consensus/upgrades/src/lib.rs
@@ -58,3 +58,7 @@ pub use utils::UpgradeCalldata;
 
 #[cfg(test)]
 pub mod test_utils;
+
+
+mod basev1;
+pub use basev1::BaseV1;


### PR DESCRIPTION
## Summary

Adds the initial scaffold for the Base V1 network upgrade, following the same pattern established by the Jovian upgrade.

## Changes

- `basev1.rs`: New module with `BaseV1` struct, upgrade source hash functions, and `Upgrade` trait implementation
- `lib.rs`: Export `BaseV1` from the crate
- `forks.rs`: Add `Upgrades::BASE_V1` constant

## Notes

The `txs()` implementation returns an empty iterator as a placeholder until the full upgrade transaction details are confirmed per the upgrade coordination process.

Closes #1187