### PR TITLE
fix(engine): drop poisoned build attrs on InvalidPayload

### DIFF
--- a/crates/consensus/engine/src/task_queue/core.rs
+++ b/crates/consensus/engine/src/task_queue/core.rs
@@ -189,11 +189,15 @@ impl<EngineClient_: EngineClient> Engine<EngineClient_> {
     /// Exception: tasks that fail with [`EngineTaskErrorSeverity::Flush`] are popped from the
     /// queue before the error is returned. The poisoned task must not be retried in-place — the
     /// engine processor will signal the derivation pipeline to flush its buffered batch/channel
-    /// state and the next call to [`Engine::drain`] will proceed with the remaining tasks.
+    /// state and the next call to [`Engine::drain`] will proceed with the remaining tasks. Any
+    /// [`EngineState`] mutations the task made before failing are published to subscribers prior
+    /// to popping, mirroring the success path so watch consumers (e.g. the RPC state view) stay
+    /// in sync.
     pub async fn drain(&mut self) -> Result<(), EngineTaskErrors> {
         while let Some((task, _)) = self.tasks.peek() {
             if let Err(err) = task.execute(&mut self.state).await {
                 if matches!(err.severity(), EngineTaskErrorSeverity::Flush) {
+                    self.state_sender.send_replace(self.state);
                     self.pop_head();
                 }
                 return Err(err);

--- a/crates/consensus/engine/src/task_queue/core.rs
+++ b/crates/consensus/engine/src/task_queue/core.rs
@@ -197,10 +197,9 @@ impl<EngineClient_: EngineClient> Engine<EngineClient_> {
         // Drain tasks in order of priority, halting on errors for a retry to be attempted.
         while let Some((task, _)) = self.tasks.peek() {
             // Execute the task.
-            let flush_err = match task.execute(&mut self.state).await {
-                Ok(()) => None,
-                Err(err) if matches!(err.severity(), EngineTaskErrorSeverity::Flush) => Some(err),
-                Err(err) => return Err(err),
+            let outcome = match task.execute(&mut self.state).await {
+                Err(err) if err.severity() != EngineTaskErrorSeverity::Flush => return Err(err),
+                other => other,
             };
 
             // Update the state and notify the engine actor.
@@ -212,9 +211,7 @@ impl<EngineClient_: EngineClient> Engine<EngineClient_> {
             self.task_queue_length.send_replace(self.tasks.len());
             Metrics::engine_task_queue_depth().set(self.tasks.len() as f64);
 
-            if let Some(err) = flush_err {
-                return Err(err);
-            }
+            outcome?;
         }
 
         Ok(())

--- a/crates/consensus/engine/src/task_queue/core.rs
+++ b/crates/consensus/engine/src/task_queue/core.rs
@@ -26,7 +26,9 @@ use crate::{
 ///
 /// Tasks within the queue are also considered fallible. If they fail with a temporary error,
 /// they are not popped from the queue, the error is returned, and they are retried on the
-/// next call to [`Engine::drain`].
+/// next call to [`Engine::drain`]. Tasks that fail with a [`EngineTaskErrorSeverity::Flush`]
+/// error are popped from the queue before the error is returned, so that the derivation
+/// pipeline can be flushed without the offending task being retried in-place.
 #[derive(Debug)]
 pub struct Engine<EngineClient_: EngineClient> {
     /// The state of the engine.
@@ -183,23 +185,32 @@ impl<EngineClient_: EngineClient> Engine<EngineClient_> {
     /// Attempts to drain the queue by executing all [`EngineTask`]s in-order. If any task returns
     /// an error along the way, it is not popped from the queue (in case it must be retried) and
     /// the error is returned.
+    ///
+    /// Exception: tasks that fail with [`EngineTaskErrorSeverity::Flush`] are popped from the
+    /// queue before the error is returned. The poisoned task must not be retried in-place — the
+    /// engine processor will signal the derivation pipeline to flush its buffered batch/channel
+    /// state and the next call to [`Engine::drain`] will proceed with the remaining tasks.
     pub async fn drain(&mut self) -> Result<(), EngineTaskErrors> {
-        // Drain tasks in order of priority, halting on errors for a retry to be attempted.
         while let Some((task, _)) = self.tasks.peek() {
-            // Execute the task
-            task.execute(&mut self.state).await?;
+            if let Err(err) = task.execute(&mut self.state).await {
+                if matches!(err.severity(), EngineTaskErrorSeverity::Flush) {
+                    self.pop_head();
+                }
+                return Err(err);
+            }
 
-            // Update the state and notify the engine actor.
             self.state_sender.send_replace(self.state);
-
-            // Pop the task from the queue now that it's been executed.
-            self.tasks.pop();
-
-            self.task_queue_length.send_replace(self.tasks.len());
-            Metrics::engine_task_queue_depth().set(self.tasks.len() as f64);
+            self.pop_head();
         }
 
         Ok(())
+    }
+
+    /// Pops the head task from the queue and republishes the queue length metrics.
+    fn pop_head(&mut self) {
+        self.tasks.pop();
+        self.task_queue_length.send_replace(self.tasks.len());
+        Metrics::engine_task_queue_depth().set(self.tasks.len() as f64);
     }
 }
 
@@ -221,15 +232,31 @@ pub enum EngineResetError {
 mod tests {
     use std::sync::Arc;
 
+    use alloy_primitives::FixedBytes;
     use alloy_rpc_types_engine::{ForkchoiceUpdated, PayloadId, PayloadStatus, PayloadStatusEnum};
     use base_common_genesis::RollupConfig;
     use tokio::sync::watch;
 
     use crate::{
-        BuildTask, Engine, EngineState, EngineSyncStateUpdate, EngineTask, GetPayloadTask,
-        InsertPayloadSafety, SealTask,
-        test_utils::{TestAttributesBuilder, test_block_info, test_engine_client_builder},
+        BuildTask, Engine, EngineState, EngineSyncStateUpdate, EngineTask, EngineTaskError,
+        EngineTaskErrorSeverity, EngineTaskErrors, GetPayloadTask, InsertPayloadSafety, SealTask,
+        test_utils::{
+            TestAttributesBuilder, TestEngineStateBuilder, test_block_info,
+            test_engine_client_builder,
+        },
     };
+
+    fn invalid_fcu() -> ForkchoiceUpdated {
+        ForkchoiceUpdated {
+            payload_status: PayloadStatus {
+                status: PayloadStatusEnum::Invalid {
+                    validation_error: "malformed transaction".into(),
+                },
+                latest_valid_hash: Some(FixedBytes([2u8; 32])),
+            },
+            payload_id: None,
+        }
+    }
 
     fn syncing_fcu() -> ForkchoiceUpdated {
         ForkchoiceUpdated {
@@ -455,5 +482,75 @@ mod tests {
         // el_sync_finished stays false despite Valid being configured.
         assert!(!confirmed, "probe after seed short-circuits — documents the invariant");
         assert!(!engine.state().el_sync_finished);
+    }
+
+    /// Regression test: a [`BuildTask`] whose attr-bearing FCU returns
+    /// `PayloadStatusEnum::Invalid` must surface as [`EngineTaskErrorSeverity::Flush`] and the
+    /// poisoned task must be popped from the head of the queue, otherwise the engine processor
+    /// would re-execute the same task on every drain and starve every later request behind it.
+    #[tokio::test]
+    async fn drain_pops_head_on_flush_severity() {
+        let parent_block = test_block_info(0);
+        let unsafe_block = test_block_info(1);
+        let attributes_timestamp = unsafe_block.block_info.timestamp;
+
+        let mut cfg = RollupConfig::default();
+        // Force the FCU-with-attrs codepath through V3 (Ecotone active at attr timestamp).
+        cfg.hardforks.ecotone_time = Some(attributes_timestamp);
+
+        let client = Arc::new(
+            test_engine_client_builder()
+                .with_fork_choice_updated_v3_response(invalid_fcu())
+                .build(),
+        );
+        let cfg = Arc::new(cfg);
+
+        let attributes = TestAttributesBuilder::new()
+            .with_parent(parent_block)
+            .with_timestamp(attributes_timestamp)
+            .build();
+
+        let initial_state = TestEngineStateBuilder::new()
+            .with_unsafe_head(unsafe_block)
+            .with_safe_head(parent_block)
+            .with_finalized_head(parent_block)
+            .build();
+
+        let (state_tx, _state_rx) = watch::channel(initial_state);
+        let (queue_tx, queue_rx) = watch::channel(0usize);
+        let mut engine = Engine::new(initial_state, state_tx, queue_tx);
+
+        // Head: poisoned build task. Tail: a follow-up build task that should remain queued so
+        // we can also assert that drain only removes the failing head, not the rest of the
+        // queue (queued tasks may still be valid since they were enqueued from independent
+        // requests).
+        engine.enqueue(EngineTask::Build(Box::new(BuildTask::new(
+            Arc::clone(&client),
+            Arc::clone(&cfg),
+            attributes.clone(),
+            None,
+        ))));
+        engine.enqueue(EngineTask::Build(Box::new(BuildTask::new(
+            Arc::clone(&client),
+            Arc::clone(&cfg),
+            attributes,
+            None,
+        ))));
+        assert_eq!(*queue_rx.borrow(), 2);
+
+        let err = engine.drain().await.expect_err("invalid FCU must fail drain");
+        match &err {
+            EngineTaskErrors::Build(build_err) => assert_eq!(
+                build_err.severity(),
+                EngineTaskErrorSeverity::Flush,
+                "InvalidPayload must surface as Flush"
+            ),
+            other => panic!("expected Build error, got {other:?}"),
+        }
+        assert_eq!(err.severity(), EngineTaskErrorSeverity::Flush);
+
+        // Poisoned head popped, follow-up still in queue, metrics watch updated.
+        assert_eq!(engine.tasks.len(), 1, "only the poisoned head should be popped on Flush");
+        assert_eq!(*queue_rx.borrow(), 1, "queue length watch must be republished after pop");
     }
 }

--- a/crates/consensus/engine/src/task_queue/core.rs
+++ b/crates/consensus/engine/src/task_queue/core.rs
@@ -552,5 +552,23 @@ mod tests {
         // Poisoned head popped, follow-up still in queue, metrics watch updated.
         assert_eq!(engine.tasks.len(), 1, "only the poisoned head should be popped on Flush");
         assert_eq!(*queue_rx.borrow(), 1, "queue length watch must be republished after pop");
+
+        // Now flip the EL's response to a valid FCU and re-drain. This proves that drain
+        // *resumes* after a flush — the surviving follow-up task must execute and be popped,
+        // emptying the queue. Without the head-pop fix, this second drain would re-execute the
+        // poisoned task forever and never reach the follow-up.
+        client
+            .set_fork_choice_updated_v3_response(ForkchoiceUpdated {
+                payload_status: PayloadStatus {
+                    status: PayloadStatusEnum::Valid,
+                    latest_valid_hash: Some(FixedBytes([3u8; 32])),
+                },
+                payload_id: Some(PayloadId::new([7u8; 8])),
+            })
+            .await;
+
+        engine.drain().await.expect("drain must succeed once the EL accepts the follow-up");
+        assert_eq!(engine.tasks.len(), 0, "follow-up task should drain to completion");
+        assert_eq!(*queue_rx.borrow(), 0, "queue length watch must reflect empty queue");
     }
 }

--- a/crates/consensus/engine/src/task_queue/core.rs
+++ b/crates/consensus/engine/src/task_queue/core.rs
@@ -194,27 +194,30 @@ impl<EngineClient_: EngineClient> Engine<EngineClient_> {
     /// to popping, mirroring the success path so watch consumers (e.g. the RPC state view) stay
     /// in sync.
     pub async fn drain(&mut self) -> Result<(), EngineTaskErrors> {
+        // Drain tasks in order of priority, halting on errors for a retry to be attempted.
         while let Some((task, _)) = self.tasks.peek() {
-            if let Err(err) = task.execute(&mut self.state).await {
-                if matches!(err.severity(), EngineTaskErrorSeverity::Flush) {
-                    self.state_sender.send_replace(self.state);
-                    self.pop_head();
-                }
+            // Execute the task.
+            let flush_err = match task.execute(&mut self.state).await {
+                Ok(()) => None,
+                Err(err) if matches!(err.severity(), EngineTaskErrorSeverity::Flush) => Some(err),
+                Err(err) => return Err(err),
+            };
+
+            // Update the state and notify the engine actor.
+            self.state_sender.send_replace(self.state);
+
+            // Pop the task from the queue now that it's been executed.
+            self.tasks.pop();
+
+            self.task_queue_length.send_replace(self.tasks.len());
+            Metrics::engine_task_queue_depth().set(self.tasks.len() as f64);
+
+            if let Some(err) = flush_err {
                 return Err(err);
             }
-
-            self.state_sender.send_replace(self.state);
-            self.pop_head();
         }
 
         Ok(())
-    }
-
-    /// Pops the head task from the queue and republishes the queue length metrics.
-    fn pop_head(&mut self) {
-        self.tasks.pop();
-        self.task_queue_length.send_replace(self.tasks.len());
-        Metrics::engine_task_queue_depth().set(self.tasks.len() as f64);
     }
 }
 

--- a/crates/consensus/engine/src/task_queue/core.rs
+++ b/crates/consensus/engine/src/task_queue/core.rs
@@ -198,8 +198,9 @@ impl<EngineClient_: EngineClient> Engine<EngineClient_> {
         while let Some((task, _)) = self.tasks.peek() {
             // Execute the task.
             let outcome = match task.execute(&mut self.state).await {
-                Err(err) if err.severity() != EngineTaskErrorSeverity::Flush => return Err(err),
-                other => other,
+                Ok(()) => Ok(()),
+                Err(err) if err.severity() == EngineTaskErrorSeverity::Flush => Err(err),
+                Err(err) => return Err(err),
             };
 
             // Update the state and notify the engine actor.

--- a/crates/consensus/engine/src/task_queue/tasks/build/error.rs
+++ b/crates/consensus/engine/src/task_queue/tasks/build/error.rs
@@ -130,6 +130,10 @@ mod tests {
         BuildTaskError::EngineBuildError(EngineBuildError::EngineSyncing),
         EngineTaskErrorSeverity::Temporary
     )]
+    #[case::mpsc_send(
+        BuildTaskError::MpscSend(Box::new(mpsc::error::SendError(PayloadId::new([0u8; 8])))),
+        EngineTaskErrorSeverity::Critical
+    )]
     fn test_build_task_error_severity(
         #[case] err: BuildTaskError,
         #[case] expected: EngineTaskErrorSeverity,

--- a/crates/consensus/engine/src/task_queue/tasks/build/error.rs
+++ b/crates/consensus/engine/src/task_queue/tasks/build/error.rs
@@ -96,8 +96,8 @@ mod tests {
     /// Regression anchor for PR #2637. `InvalidPayload` must surface `Flush`
     /// (so the engine processor flushes the derivation channel and the
     /// poisoned task is popped from the head of the queue) AND carry the
-    /// EL's `validation_error` through `Display` so operators can identify
-    /// which batch poisoned the pipeline.
+    /// EL's `validation_error` so operators can identify which batch
+    /// poisoned the pipeline.
     #[test]
     fn invalid_payload_is_flush_and_preserves_validation_error() {
         let err = BuildTaskError::EngineBuildError(EngineBuildError::InvalidPayload(
@@ -109,61 +109,5 @@ mod tests {
             format!("{err:?}").contains("malformed transaction at index 3"),
             "Debug must surface the EL validation error, got: {err:?}",
         );
-    }
-
-    #[test]
-    fn attributes_insertion_failed_is_temporary_and_wraps_rpc_error() {
-        let rpc_err: RpcError<TransportErrorKind> = RpcError::local_usage_str("connection refused");
-        let build_err: EngineBuildError = rpc_err.into();
-        let err = BuildTaskError::EngineBuildError(build_err);
-
-        assert_eq!(err.severity(), EngineTaskErrorSeverity::Temporary);
-        assert!(
-            format!("{err:?}").contains("AttributesInsertionFailed"),
-            "expected AttributesInsertionFailed in Debug, got: {err:?}",
-        );
-    }
-
-    #[test]
-    fn unexpected_payload_status_is_temporary() {
-        let err = BuildTaskError::EngineBuildError(EngineBuildError::UnexpectedPayloadStatus(
-            PayloadStatusEnum::Syncing,
-        ));
-        assert_eq!(err.severity(), EngineTaskErrorSeverity::Temporary);
-    }
-
-    #[test]
-    fn missing_payload_id_is_temporary() {
-        let err = BuildTaskError::EngineBuildError(EngineBuildError::MissingPayloadId);
-        assert_eq!(err.severity(), EngineTaskErrorSeverity::Temporary);
-    }
-
-    #[test]
-    fn engine_syncing_is_temporary() {
-        let err = BuildTaskError::EngineBuildError(EngineBuildError::EngineSyncing);
-        assert_eq!(err.severity(), EngineTaskErrorSeverity::Temporary);
-    }
-
-    #[test]
-    fn forkchoice_state_invalid_is_reset() {
-        let err = BuildTaskError::EngineBuildError(EngineBuildError::ForkchoiceStateInvalid);
-        assert_eq!(err.severity(), EngineTaskErrorSeverity::Reset);
-    }
-
-    #[test]
-    fn finalized_ahead_of_unsafe_is_critical_and_carries_block_numbers() {
-        let inner = EngineBuildError::FinalizedAheadOfUnsafe(42, 17);
-        let err = BuildTaskError::EngineBuildError(inner);
-
-        assert_eq!(err.severity(), EngineTaskErrorSeverity::Critical);
-        let inner_msg = format!("{err:?}");
-        assert!(inner_msg.contains("42") && inner_msg.contains("17"), "got: {inner_msg}");
-    }
-
-    #[test]
-    fn mpsc_send_failure_is_critical() {
-        let err =
-            BuildTaskError::MpscSend(Box::new(mpsc::error::SendError(PayloadId::new([0u8; 8]))));
-        assert_eq!(err.severity(), EngineTaskErrorSeverity::Critical);
     }
 }

--- a/crates/consensus/engine/src/task_queue/tasks/build/error.rs
+++ b/crates/consensus/engine/src/task_queue/tasks/build/error.rs
@@ -91,53 +91,79 @@ impl EngineTaskError for BuildTaskError {
 
 #[cfg(test)]
 mod tests {
-    use rstest::rstest;
-
     use super::*;
 
-    fn rpc_error() -> RpcError<TransportErrorKind> {
-        RpcError::local_usage_str("test")
+    /// Regression anchor for PR #2637. `InvalidPayload` must surface `Flush`
+    /// (so the engine processor flushes the derivation channel and the
+    /// poisoned task is popped from the head of the queue) AND carry the
+    /// EL's `validation_error` through `Display` so operators can identify
+    /// which batch poisoned the pipeline.
+    #[test]
+    fn invalid_payload_is_flush_and_preserves_validation_error() {
+        let err = BuildTaskError::EngineBuildError(EngineBuildError::InvalidPayload(
+            "malformed transaction at index 3".to_string(),
+        ));
+
+        assert_eq!(err.severity(), EngineTaskErrorSeverity::Flush);
+        assert!(
+            format!("{err:?}").contains("malformed transaction at index 3"),
+            "Debug must surface the EL validation error, got: {err:?}",
+        );
     }
 
-    #[rstest]
-    #[case::finalized_ahead_of_unsafe(
-        BuildTaskError::EngineBuildError(EngineBuildError::FinalizedAheadOfUnsafe(10, 5)),
-        EngineTaskErrorSeverity::Critical
-    )]
-    #[case::attributes_insertion_failed(
-        BuildTaskError::EngineBuildError(EngineBuildError::AttributesInsertionFailed(rpc_error())),
-        EngineTaskErrorSeverity::Temporary
-    )]
-    #[case::forkchoice_state_invalid(
-        BuildTaskError::EngineBuildError(EngineBuildError::ForkchoiceStateInvalid),
-        EngineTaskErrorSeverity::Reset
-    )]
-    #[case::invalid_payload(
-        BuildTaskError::EngineBuildError(EngineBuildError::InvalidPayload("bad tx".into())),
-        EngineTaskErrorSeverity::Flush
-    )]
-    #[case::unexpected_payload_status(
-        BuildTaskError::EngineBuildError(EngineBuildError::UnexpectedPayloadStatus(
+    #[test]
+    fn attributes_insertion_failed_is_temporary_and_wraps_rpc_error() {
+        let rpc_err: RpcError<TransportErrorKind> = RpcError::local_usage_str("connection refused");
+        let build_err: EngineBuildError = rpc_err.into();
+        let err = BuildTaskError::EngineBuildError(build_err);
+
+        assert_eq!(err.severity(), EngineTaskErrorSeverity::Temporary);
+        assert!(
+            format!("{err:?}").contains("AttributesInsertionFailed"),
+            "expected AttributesInsertionFailed in Debug, got: {err:?}",
+        );
+    }
+
+    #[test]
+    fn unexpected_payload_status_is_temporary() {
+        let err = BuildTaskError::EngineBuildError(EngineBuildError::UnexpectedPayloadStatus(
             PayloadStatusEnum::Syncing,
-        )),
-        EngineTaskErrorSeverity::Temporary
-    )]
-    #[case::missing_payload_id(
-        BuildTaskError::EngineBuildError(EngineBuildError::MissingPayloadId),
-        EngineTaskErrorSeverity::Temporary
-    )]
-    #[case::engine_syncing(
-        BuildTaskError::EngineBuildError(EngineBuildError::EngineSyncing),
-        EngineTaskErrorSeverity::Temporary
-    )]
-    #[case::mpsc_send(
-        BuildTaskError::MpscSend(Box::new(mpsc::error::SendError(PayloadId::new([0u8; 8])))),
-        EngineTaskErrorSeverity::Critical
-    )]
-    fn test_build_task_error_severity(
-        #[case] err: BuildTaskError,
-        #[case] expected: EngineTaskErrorSeverity,
-    ) {
-        assert_eq!(err.severity(), expected);
+        ));
+        assert_eq!(err.severity(), EngineTaskErrorSeverity::Temporary);
+    }
+
+    #[test]
+    fn missing_payload_id_is_temporary() {
+        let err = BuildTaskError::EngineBuildError(EngineBuildError::MissingPayloadId);
+        assert_eq!(err.severity(), EngineTaskErrorSeverity::Temporary);
+    }
+
+    #[test]
+    fn engine_syncing_is_temporary() {
+        let err = BuildTaskError::EngineBuildError(EngineBuildError::EngineSyncing);
+        assert_eq!(err.severity(), EngineTaskErrorSeverity::Temporary);
+    }
+
+    #[test]
+    fn forkchoice_state_invalid_is_reset() {
+        let err = BuildTaskError::EngineBuildError(EngineBuildError::ForkchoiceStateInvalid);
+        assert_eq!(err.severity(), EngineTaskErrorSeverity::Reset);
+    }
+
+    #[test]
+    fn finalized_ahead_of_unsafe_is_critical_and_carries_block_numbers() {
+        let inner = EngineBuildError::FinalizedAheadOfUnsafe(42, 17);
+        let err = BuildTaskError::EngineBuildError(inner);
+
+        assert_eq!(err.severity(), EngineTaskErrorSeverity::Critical);
+        let inner_msg = format!("{err:?}");
+        assert!(inner_msg.contains("42") && inner_msg.contains("17"), "got: {inner_msg}");
+    }
+
+    #[test]
+    fn mpsc_send_failure_is_critical() {
+        let err =
+            BuildTaskError::MpscSend(Box::new(mpsc::error::SendError(PayloadId::new([0u8; 8]))));
+        assert_eq!(err.severity(), EngineTaskErrorSeverity::Critical);
     }
 }

--- a/crates/consensus/engine/src/task_queue/tasks/build/error.rs
+++ b/crates/consensus/engine/src/task_queue/tasks/build/error.rs
@@ -63,8 +63,19 @@ impl EngineTaskError for BuildTaskError {
             Self::EngineBuildError(EngineBuildError::FinalizedAheadOfUnsafe(_, _)) => {
                 EngineTaskErrorSeverity::Critical
             }
+            // The execution layer rejected the payload attributes derived from the current
+            // batch (e.g. malformed transaction bytes, invalid state transition).
+            //
+            // Per the derivation spec, the attributes must be dropped and the forkchoice
+            // state must be left unchanged. Surfacing this as `Flush` causes the engine
+            // processor to signal `FlushChannel` to the derivation pipeline (clearing the
+            // poisoned batch + upstream channel state) while `Engine::drain` removes this
+            // task from the head of the queue. Without this, the build task is retried
+            // in-place forever, starving every later engine request behind it.
+            Self::EngineBuildError(EngineBuildError::InvalidPayload(_)) => {
+                EngineTaskErrorSeverity::Flush
+            }
             Self::EngineBuildError(EngineBuildError::AttributesInsertionFailed(_))
-            | Self::EngineBuildError(EngineBuildError::InvalidPayload(_))
             | Self::EngineBuildError(EngineBuildError::UnexpectedPayloadStatus(_))
             | Self::EngineBuildError(EngineBuildError::MissingPayloadId)
             | Self::EngineBuildError(EngineBuildError::EngineSyncing) => {
@@ -75,5 +86,54 @@ impl EngineTaskError for BuildTaskError {
             }
             Self::MpscSend(_) => EngineTaskErrorSeverity::Critical,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rstest::rstest;
+
+    use super::*;
+
+    fn rpc_error() -> RpcError<TransportErrorKind> {
+        RpcError::local_usage_str("test")
+    }
+
+    #[rstest]
+    #[case::finalized_ahead_of_unsafe(
+        BuildTaskError::EngineBuildError(EngineBuildError::FinalizedAheadOfUnsafe(10, 5)),
+        EngineTaskErrorSeverity::Critical
+    )]
+    #[case::attributes_insertion_failed(
+        BuildTaskError::EngineBuildError(EngineBuildError::AttributesInsertionFailed(rpc_error())),
+        EngineTaskErrorSeverity::Temporary
+    )]
+    #[case::forkchoice_state_invalid(
+        BuildTaskError::EngineBuildError(EngineBuildError::ForkchoiceStateInvalid),
+        EngineTaskErrorSeverity::Reset
+    )]
+    #[case::invalid_payload(
+        BuildTaskError::EngineBuildError(EngineBuildError::InvalidPayload("bad tx".into())),
+        EngineTaskErrorSeverity::Flush
+    )]
+    #[case::unexpected_payload_status(
+        BuildTaskError::EngineBuildError(EngineBuildError::UnexpectedPayloadStatus(
+            PayloadStatusEnum::Syncing,
+        )),
+        EngineTaskErrorSeverity::Temporary
+    )]
+    #[case::missing_payload_id(
+        BuildTaskError::EngineBuildError(EngineBuildError::MissingPayloadId),
+        EngineTaskErrorSeverity::Temporary
+    )]
+    #[case::engine_syncing(
+        BuildTaskError::EngineBuildError(EngineBuildError::EngineSyncing),
+        EngineTaskErrorSeverity::Temporary
+    )]
+    fn test_build_task_error_severity(
+        #[case] err: BuildTaskError,
+        #[case] expected: EngineTaskErrorSeverity,
+    ) {
+        assert_eq!(err.severity(), expected);
     }
 }

--- a/crates/consensus/engine/src/task_queue/tasks/build/error.rs
+++ b/crates/consensus/engine/src/task_queue/tasks/build/error.rs
@@ -93,11 +93,10 @@ impl EngineTaskError for BuildTaskError {
 mod tests {
     use super::*;
 
-    /// Regression anchor for PR #2637. `InvalidPayload` must surface `Flush`
-    /// (so the engine processor flushes the derivation channel and the
-    /// poisoned task is popped from the head of the queue) AND carry the
-    /// EL's `validation_error` so operators can identify which batch
-    /// poisoned the pipeline.
+    /// `InvalidPayload` must surface `Flush` (so the engine processor flushes
+    /// the derivation channel and the poisoned task is popped from the head
+    /// of the queue) AND carry the EL's `validation_error` so operators can
+    /// identify which batch poisoned the pipeline.
     #[test]
     fn invalid_payload_is_flush_and_preserves_validation_error() {
         let err = BuildTaskError::EngineBuildError(EngineBuildError::InvalidPayload(

--- a/crates/consensus/service/src/actors/engine/engine_request_processor.rs
+++ b/crates/consensus/service/src/actors/engine/engine_request_processor.rs
@@ -768,17 +768,21 @@ mod tests {
     use base_common_genesis::{ChainGenesis, RollupConfig, SystemConfig};
     use base_common_rpc_types::Transaction as BaseTransaction;
     use base_common_rpc_types_engine::{BaseExecutionPayload, BaseExecutionPayloadEnvelope};
+    use base_consensus_derive::Signal;
     use base_consensus_engine::{
         Engine, EngineState,
-        test_utils::{TestEngineStateBuilder, test_block_info, test_engine_client_builder},
+        test_utils::{
+            TestAttributesBuilder, TestEngineStateBuilder, test_block_info,
+            test_engine_client_builder,
+        },
     };
     use base_protocol::{BlockInfo, L2BlockInfo};
     use rstest::rstest;
     use tokio::sync::{mpsc, watch};
 
     use crate::{
-        EngineClientError, EngineProcessingRequest, EngineProcessor, EngineProcessorOptions,
-        EngineRequestReceiver, MockConductor, NodeMode, ResetRequest,
+        BuildRequest, EngineClientError, EngineProcessingRequest, EngineProcessor,
+        EngineProcessorOptions, EngineRequestReceiver, MockConductor, NodeMode, ResetRequest,
         actors::engine::client::MockEngineDerivationClient,
     };
 
@@ -1609,6 +1613,116 @@ mod tests {
             L2BlockInfo::default(),
             "validator at genesis must not set finalized_head via engine.reset() (expected zeroed, got hash {})",
             state.sync_state.finalized_head().block_info.hash,
+        );
+    }
+
+    /// Regression test: when a `Build` request fails with an `InvalidPayload` (the EL rejects
+    /// the derived attributes), the processor must dispatch exactly one
+    /// [`Signal::FlushChannel`] to the derivation actor and resume servicing requests rather
+    /// than retrying the poisoned task in place. Without the
+    /// [`EngineTaskErrorSeverity::Flush`] mapping plus the head-pop in
+    /// [`base_consensus_engine::Engine::drain`], the processor would either spin on the same
+    /// FCU forever or starve every later request behind the poisoned head.
+    #[tokio::test]
+    async fn build_invalid_payload_dispatches_flush_signal_exactly_once() {
+        let parent_block = test_block_info(0);
+        let unsafe_block = test_block_info(1);
+        let attributes_timestamp = unsafe_block.block_info.timestamp;
+
+        let mut cfg = RollupConfig::default();
+        cfg.hardforks.ecotone_time = Some(attributes_timestamp);
+        let cfg = Arc::new(cfg);
+
+        let invalid_fcu = ForkchoiceUpdated {
+            payload_status: PayloadStatus {
+                status: PayloadStatusEnum::Invalid {
+                    validation_error: "malformed transaction".into(),
+                },
+                latest_valid_hash: Some(B256::with_last_byte(2)),
+            },
+            payload_id: None,
+        };
+        let client = Arc::new(
+            test_engine_client_builder().with_fork_choice_updated_v3_response(invalid_fcu).build(),
+        );
+
+        let (signal_tx, mut signal_rx) = mpsc::channel(4);
+        let mut mock_derivation = MockEngineDerivationClient::new();
+        // Bootstrap and per-block plumbing calls — accept any number of calls so the
+        // test focuses on the Flush dispatch alone.
+        mock_derivation.expect_send_new_engine_safe_head().returning(|_| Ok(()));
+        mock_derivation.expect_notify_sync_completed().returning(|_| Ok(()));
+        mock_derivation
+            .expect_send_signal()
+            .withf(|s| matches!(s, Signal::FlushChannel))
+            .times(1)
+            .returning(move |signal| {
+                let signal_tx = signal_tx.clone();
+                tokio::spawn(async move {
+                    let _ = signal_tx.send(signal).await;
+                });
+                Ok(())
+            });
+
+        let initial_state = TestEngineStateBuilder::new()
+            .with_unsafe_head(unsafe_block)
+            .with_safe_head(parent_block)
+            .with_el_sync_finished(true)
+            .build();
+        let (state_tx, _state_rx) = watch::channel(initial_state);
+        let (queue_tx, queue_rx) = watch::channel(0usize);
+        let engine = Engine::new(initial_state, state_tx, queue_tx);
+
+        let processor = EngineProcessor::new(
+            Arc::clone(&client),
+            Arc::clone(&cfg),
+            mock_derivation,
+            engine,
+            EngineProcessorOptions {
+                node_mode: NodeMode::Validator,
+                unsafe_head_tx: None,
+                conductor: None,
+                sequencer_stopped: false,
+            },
+        );
+
+        let (req_tx, req_rx) = mpsc::channel(8);
+        let handle = processor.start(req_rx);
+
+        let attributes = TestAttributesBuilder::new()
+            .with_parent(parent_block)
+            .with_timestamp(attributes_timestamp)
+            .build();
+        let (build_result_tx, _build_result_rx) = mpsc::channel(1);
+        req_tx
+            .send(EngineProcessingRequest::Build(Box::new(BuildRequest {
+                attributes,
+                result_tx: build_result_tx,
+            })))
+            .await
+            .expect("failed to send build request");
+
+        let received = tokio::time::timeout(std::time::Duration::from_secs(5), signal_rx.recv())
+            .await
+            .expect("timed out waiting for FlushChannel signal")
+            .expect("signal channel closed before FlushChannel was sent");
+        assert!(matches!(received, Signal::FlushChannel));
+
+        // Queue must drain back to zero — proves the poisoned task was popped, not re-queued.
+        let mut queue_rx = queue_rx;
+        tokio::time::timeout(std::time::Duration::from_secs(5), queue_rx.wait_for(|n| *n == 0))
+            .await
+            .expect("queue length never returned to zero")
+            .expect("queue length watch closed before draining");
+
+        // Clean shutdown: dropping the request channel makes start() exit with ChannelClosed.
+        // The mockall `times(1)` expectation is verified on drop of `mock_derivation` inside
+        // the spawned task — any second call to send_signal would panic the task.
+        drop(req_tx);
+        let result = handle.await.expect("processor task panicked");
+        assert!(
+            matches!(result, Err(crate::EngineError::ChannelClosed)),
+            "expected ChannelClosed on clean shutdown, got {result:?}"
         );
     }
 }


### PR DESCRIPTION
## Summary

When the EL rejects payload attributes from a Build task (`engine_forkchoiceUpdated` returns `Invalid`), the engine used to retry the same task forever. That blocks every later task in the queue.

This PR drops the bad attributes instead: classify `InvalidPayload` as `Flush`, and have `Engine::drain` pop the head task on `Flush` before returning the error. The engine processor already turns `Flush` into `Signal::FlushChannel`, which tells derivation to discard the bad batch and produce new attributes (eventually deposits-only, which always passes).

Matches the spec: *"On payload processing errors the attributes must be dropped, and the forkchoice state must be left unchanged."* (`docs/specs/pages/protocol/consensus/derivation.md:843-844`)

## Changes

- `build/error.rs` — `InvalidPayload` is now `Flush` instead of `Temporary`.
- `task_queue/core.rs` — `Engine::drain` pops the head task on `Flush` (with metrics/watch kept in sync).
- Tests for the severity mapping, the drain-and-resume behaviour, and an end-to-end check that one bad Build dispatches exactly one `FlushChannel` signal and the queue drains back to zero.
