### PR TITLE
fix(CHAIN-4336): stop retrying requeued blob encode failures

### DIFF
--- a/crates/batcher/core/src/submissions.rs
+++ b/crates/batcher/core/src/submissions.rs
@@ -121,7 +121,7 @@ impl<TM: TxManager> SubmissionQueue<TM> {
                             pipeline.requeue(id);
                         }
                         drop(permit);
-                        continue;
+                        break;
                     }
                 },
                 DaType::Calldata => TxCandidate {


### PR DESCRIPTION
## Summary
- stop the submit_pending loop after blob encoding fails and requeues the dequeued submission IDs
- avoid immediately retrying the same requeued deterministic encode failure in the same driver tick
- keep the existing submit_pending API and requeue behavior unchanged

## Testing
- cargo fmt --check
- cargo test -p base-batcher-core

Linear: CHAIN-4336