### PR TITLE
fix(builder): permanently reject txs that exceed max_gas_per_txn

### DIFF
--- a/crates/builder/core/src/execution.rs
+++ b/crates/builder/core/src/execution.rs
@@ -190,6 +190,7 @@ impl TxnExecutionError {
                 | Self::ExecutionMeteringLimitExceeded(
                     ExecutionMeteringLimitExceeded::TransactionExecutionTime(_, _),
                 )
+                | Self::MaxGasUsageExceeded
         )
     }
 }

--- a/crates/builder/core/src/flashblocks/context.rs
+++ b/crates/builder/core/src/flashblocks/context.rs
@@ -985,6 +985,9 @@ impl BasePayloadBuilderCtx {
                 diag.record_rejection(&err);
                 let priority_fee = tx.effective_tip_per_gas(base_fee).unwrap_or(0) as f64;
                 record_rejected_tx_priority_fee(&err, priority_fee);
+                if err.is_permanent() {
+                    diag.permanently_rejected_txs.push(tx_hash);
+                }
                 log_txn(Err(err));
                 best_txs.mark_invalid(tx.signer(), tx.nonce());
                 continue;

--- a/crates/builder/core/tests/smoke.rs
+++ b/crates/builder/core/tests/smoke.rs
@@ -202,6 +202,20 @@ async fn chain_produces_big_tx_with_gas_limit() -> eyre::Result<()> {
     let exclusion_result = txs.hashes().find(|hash| hash == tx_high_gas.tx_hash());
     assert!(exclusion_result.is_none());
 
+    // Regression: the over-cap tx must be evicted from the pool and seeded into the
+    // shared rejection cache after the first post-execution rejection. Otherwise the
+    // builder will re-execute it on every subsequent flashblock/block attempt, turning
+    // the cap into an unpaid EVM-execution sink.
+    tokio::time::sleep(Duration::from_millis(250)).await;
+    assert!(
+        rbuilder.builder_config().rejection_cache.contains_key(tx_high_gas.tx_hash()),
+        "over-cap tx should be in the shared rejection cache after one rejection"
+    );
+    assert!(
+        !rbuilder.pool().exists(*tx_high_gas.tx_hash()),
+        "over-cap tx should be evicted from the txpool after one rejection"
+    );
+
     Ok(())
 }
 


### PR DESCRIPTION
Txs exceeding `builder.max_gas_per_txn` were re-executed on every flashblock attempt instead of being permanently rejected.

Mark `MaxGasUsageExceeded` as permanent and push the tx hash into `permanently_rejected_txs` so the existing cleanup evicts it from the pool and seeds the rejection cache.
