### PR TITLE
fix(builder): bind metering cache entries for CHAIN-4318

### DIFF
--- a/crates/builder/core/src/flashblocks/context.rs
+++ b/crates/builder/core/src/flashblocks/context.rs
@@ -1044,6 +1044,9 @@ impl BasePayloadBuilderCtx {
                 BuilderMetrics::metering_known_transaction().increment(1);
             } else {
                 BuilderMetrics::metering_unknown_transaction().increment(1);
+                if self.builder_config.metering_provider.is_enabled() {
+                    self.builder_config.metering_provider.mark_included_without_metering(&tx_hash);
+                }
             }
 
             // append sender and transaction to the respective lists

--- a/crates/builder/core/src/metering.rs
+++ b/crates/builder/core/src/metering.rs
@@ -19,6 +19,12 @@ pub trait MeteringProvider: Debug + Send + Sync + 'static {
     /// Inserts metering information for a transaction.
     fn insert(&self, _tx_hash: TxHash, _metering: MeterBundleResponse) {}
 
+    /// Signals that a transaction was committed without metering data.
+    ///
+    /// Implementations can use this to track metering data that arrives after
+    /// payload inclusion.
+    fn mark_included_without_metering(&self, _tx_hash: &TxHash) {}
+
     /// Signals that a transaction was skipped (e.g. `MeteringDataPending`) and
     /// will be retried later, clearing any pending late-arrival tracking.
     fn skip(&self, _tx_hash: &TxHash) {}

--- a/crates/builder/core/src/metrics.rs
+++ b/crates/builder/core/src/metrics.rs
@@ -197,9 +197,9 @@ base_metrics::define_metrics! {
     rejected_tx_priority_fee: histogram,
     #[describe("Actual execution time for transactions without metering data (microseconds)")]
     unmetered_tx_actual_execution_time_us: histogram,
-    #[describe("Transactions committed to a payload without metering data")]
+    #[describe("Metering responses that arrived after unmetered payload inclusion")]
     metering_late_arrival_total: counter,
-    #[describe("Time between first metering lookup miss and metering data arrival (milliseconds)")]
+    #[describe("Time between unmetered payload inclusion and metering data arrival (milliseconds)")]
     metering_late_arrival_latency_ms: histogram,
     #[describe("Execution time from late-arriving metering data (microseconds)")]
     metering_late_arrival_execution_time_us: histogram,

--- a/crates/builder/metering/src/store.rs
+++ b/crates/builder/metering/src/store.rs
@@ -18,10 +18,11 @@ use moka::{notification::RemovalCause, policy::EvictionPolicy, sync::Cache};
 pub struct MeteringStore {
     /// LRU cache mapping transaction hash to metering data.
     cache: Cache<TxHash, MeterBundleResponse>,
-    /// Records when `get()` first returned `None` for a tx hash — the moment
-    /// the builder needed metering data but didn't have it. Cleared when the
-    /// tx is skipped (`MeteringDataPending`) so only txs that were actually
-    /// included without data retain their entry for late-arrival detection.
+    /// Records when a transaction was committed without metering data.
+    ///
+    /// Late-arriving data is only terminal for transactions that were already
+    /// included without it. A plain lookup miss is not enough because the
+    /// transaction may be skipped for a transient reason and retried later.
     needed_at: Cache<TxHash, Instant>,
     /// Whether resource metering is enabled.
     metering_enabled: AtomicBool,
@@ -85,14 +86,7 @@ impl MeteringProvider for MeteringStore {
             return None;
         }
 
-        let Some(entry) = self.cache.get(tx_hash) else {
-            // Atomically record the first miss — later flashblock iterations
-            // must not overwrite the original timestamp.
-            self.needed_at.entry_by_ref(tx_hash).or_insert(Instant::now());
-            return None;
-        };
-
-        Some(entry)
+        self.cache.get(tx_hash)
     }
 
     fn is_enabled(&self) -> bool {
@@ -115,6 +109,16 @@ impl MeteringProvider for MeteringStore {
 
         self.cache.insert(tx_hash, metering);
         BuilderMetrics::metering_store_size().set(self.cache.entry_count() as f64);
+    }
+
+    fn mark_included_without_metering(&self, tx_hash: &TxHash) {
+        if !self.metering_enabled.load(Ordering::Relaxed) || self.cache.get(tx_hash).is_some() {
+            return;
+        }
+
+        // Atomically record the first unmetered inclusion. Later flashblock
+        // iterations must not overwrite the original timestamp.
+        self.needed_at.entry_by_ref(tx_hash).or_insert(Instant::now());
     }
 
     fn skip(&self, tx_hash: &TxHash) {
@@ -234,12 +238,25 @@ mod tests {
     }
 
     #[test]
-    fn test_late_insert_after_inclusion() {
+    fn test_insert_after_lookup_miss_is_cached() {
         let store = MeteringStore::new(true, 100, Duration::from_secs(30));
         let tx_hash = TxHash::random();
 
-        // get() miss → tx included without data → data arrives late
+        // A lookup miss alone does not mean the transaction was included.
         assert!(store.get(&tx_hash).is_none());
+        assert!(!store.needed_at.contains_key(&tx_hash));
+
+        // Data that arrives after a miss is still needed if the tx remains pending.
+        store.insert(tx_hash, create_test_metering(42000));
+        assert!(store.get(&tx_hash).is_some(), "metering should cache after a plain miss");
+    }
+
+    #[test]
+    fn test_late_insert_after_unmetered_inclusion() {
+        let store = MeteringStore::new(true, 100, Duration::from_secs(30));
+        let tx_hash = TxHash::random();
+
+        store.mark_included_without_metering(&tx_hash);
         assert!(store.needed_at.contains_key(&tx_hash));
 
         // Late-arriving data is consumed by insert(), does not enter cache
@@ -254,8 +271,7 @@ mod tests {
         let store = MeteringStore::new(true, 100, Duration::from_secs(30));
         let tx_hash = TxHash::random();
 
-        // get() miss → tx skipped (MeteringDataPending)
-        assert!(store.get(&tx_hash).is_none());
+        store.mark_included_without_metering(&tx_hash);
         assert!(store.needed_at.contains_key(&tx_hash));
 
         store.skip(&tx_hash);
@@ -282,10 +298,21 @@ mod tests {
         let store = MeteringStore::new(true, 100, Duration::from_secs(30));
         let tx_hash = TxHash::random();
 
-        assert!(store.get(&tx_hash).is_none());
+        store.mark_included_without_metering(&tx_hash);
         assert!(store.needed_at.contains_key(&tx_hash));
 
         store.clear();
+        assert!(!store.needed_at.contains_key(&tx_hash));
+    }
+
+    #[test]
+    fn test_mark_included_without_metering_ignores_cached_data() {
+        let store = MeteringStore::new(true, 100, Duration::from_secs(30));
+        let tx_hash = TxHash::random();
+
+        store.insert(tx_hash, create_test_metering(21000));
+        store.mark_included_without_metering(&tx_hash);
+
         assert!(!store.needed_at.contains_key(&tx_hash));
     }
 


### PR DESCRIPTION
## Summary

- Fix late metering tracking so `MeteringStore` only records late-arrival state after a transaction is actually committed without metering data.
- Keep ordinary cache misses cacheable, so transactions skipped for transient builder limits can receive honest metering before retry.
- Update late-arrival metric descriptions to match inclusion-to-arrival semantics.

## Context

- References Immunefi 76464 / Linear CHAIN-4318.
- The report is valid as a subset of Immunefi 76311: both describe `needed_at` being set by speculative lookup misses and causing later metering to be discarded for transactions that were not included.
- Nearby reports 75597, 75991, 76305, 76337, 76490, and 76515 are related metering/freshness/fail-open cases but do not already cover this exact cache-poisoning fix on current `main`.

## Tests

- `cargo fmt --all`
- `RUSTFLAGS='' cargo test -p base-builder-metering`
- `forge soldeer update`
- `forge build`
- `RUSTFLAGS='' cargo test -p base-builder-core metering`
- `git diff --check`

## Risk

- Narrow behavior change: late-arrival accounting now starts at committed unmetered inclusion instead of cache lookup miss.
- Existing fail-open/fail-closed policy is unchanged.
