### PR TITLE
fix(gossip): wire PeerMonitoring config through GossipDriver

### DIFF
--- a/crates/consensus/gossip/src/builder.rs
+++ b/crates/consensus/gossip/src/builder.rs
@@ -284,10 +284,8 @@ mod tests {
 
     #[tokio::test]
     async fn build_preserves_peer_monitoring_when_set() {
-        let peer_monitoring = PeerMonitoring {
-            ban_threshold: -100.0,
-            ban_duration: Duration::from_secs(60 * 60),
-        };
+        let peer_monitoring =
+            PeerMonitoring { ban_threshold: -100.0, ban_duration: Duration::from_secs(60 * 60) };
 
         let (driver, _signer_tx) =
             test_builder().with_peer_monitoring(Some(peer_monitoring)).build().unwrap();

--- a/crates/consensus/gossip/src/builder.rs
+++ b/crates/consensus/gossip/src/builder.rs
@@ -246,6 +246,60 @@ impl GossipDriverBuilder {
         let gater_config = self.gater_config.take().unwrap_or_default();
         let gate = crate::ConnectionGater::new(gater_config);
 
-        Ok((GossipDriver::new(swarm, addr, handler, sync_handler, sync_protocol, gate), signer_tx))
+        Ok((
+            GossipDriver::new(
+                swarm,
+                addr,
+                handler,
+                sync_handler,
+                sync_protocol,
+                gate,
+                self.peer_monitoring,
+            ),
+            signer_tx,
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_chains::Chain;
+
+    use super::*;
+
+    fn test_builder() -> GossipDriverBuilder {
+        let rollup_config = RollupConfig {
+            l2_chain_id: Chain::base_mainnet(),
+            block_time: 2,
+            ..Default::default()
+        };
+        GossipDriverBuilder::new(
+            rollup_config,
+            Address::repeat_byte(0x11),
+            "/ip4/127.0.0.1/tcp/0".parse().unwrap(),
+            Keypair::generate_secp256k1(),
+        )
+        .with_peer_scoring(PeerScoreLevel::Light)
+    }
+
+    #[tokio::test]
+    async fn build_preserves_peer_monitoring_when_set() {
+        let peer_monitoring = PeerMonitoring {
+            ban_threshold: -100.0,
+            ban_duration: Duration::from_secs(60 * 60),
+        };
+
+        let (driver, _signer_tx) =
+            test_builder().with_peer_monitoring(Some(peer_monitoring)).build().unwrap();
+
+        let configured = driver.peer_monitoring.expect("peer_monitoring should be wired through");
+        assert_eq!(configured.ban_threshold, -100.0);
+        assert_eq!(configured.ban_duration, Duration::from_secs(60 * 60));
+    }
+
+    #[tokio::test]
+    async fn build_leaves_peer_monitoring_unset_by_default() {
+        let (driver, _signer_tx) = test_builder().build().unwrap();
+        assert!(driver.peer_monitoring.is_none());
     }
 }

--- a/crates/consensus/gossip/src/driver.rs
+++ b/crates/consensus/gossip/src/driver.rs
@@ -86,13 +86,14 @@ where
         sync_handler: libp2p_stream::Control,
         sync_protocol: IncomingStreams,
         gate: G,
+        peer_monitoring: Option<PeerMonitoring>,
     ) -> Self {
         Self {
             swarm,
             addr,
             handler,
             peerstore: Default::default(),
-            peer_monitoring: None,
+            peer_monitoring,
             peer_connection_start: Default::default(),
             sync_handler,
             sync_protocol: Some(sync_protocol),


### PR DESCRIPTION
`GossipDriverBuilder::build()` never passed `peer_monitoring` into `GossipDriver::new()`, and `GossipDriver::new()` hard-coded the field to `None`. The `--p2p.ban.peers` / `--p2p.ban.threshold` / `--p2p.ban.duration` flags were silently ignored: `NetworkHandler` gates the ban path on `peer_monitoring.is_some()`, so low-score peers were never disconnected or banned.

Fix: thread `peer_monitoring` through `GossipDriver::new()`.

Reported via Immunefi (#76262, Insight).