### PR TITLE
fix(batcher): Replay Timed Out Channels

### DIFF
--- a/crates/batcher/encoder/src/channel.rs
+++ b/crates/batcher/encoder/src/channel.rs
@@ -9,6 +9,8 @@ use base_protocol::{ChannelId, Frame};
 pub struct OpenChannel {
     /// The underlying channel writer.
     pub out: ChannelOut<ShadowCompressor>,
+    /// Index of the first block encoded into this channel.
+    pub block_start: usize,
     /// L1 block number when this channel was opened (for `MaxChannelDuration`).
     pub opened_at_l1: u64,
     /// Number of L2 blocks fed into this channel so far.
@@ -21,6 +23,7 @@ impl fmt::Debug for OpenChannel {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("OpenChannel")
             .field("channel_id", &self.out.id)
+            .field("block_start", &self.block_start)
             .field("opened_at_l1", &self.opened_at_l1)
             .field("blocks_added", &self.blocks_added)
             .field("da_backlog_bytes", &self.da_backlog_bytes)
@@ -41,12 +44,18 @@ pub struct ReadyChannel {
     pub cursor: usize,
     /// Which input blocks this channel covers (indices into the encoder's block queue).
     pub block_range: Range<usize>,
+    /// Exact input block range encoded into this channel.
+    pub encoded_block_range: Range<usize>,
     /// DA bytes still represented by this closed channel's frames.
     pub da_backlog_bytes: u64,
     /// Number of in-flight submissions for this channel.
     pub pending_confirmations: usize,
     /// Number of frames that have been confirmed.
     pub confirmed_count: usize,
+    /// Earliest L1 block that confirmed any frame from this channel.
+    pub first_confirmed_l1_block: Option<u64>,
+    /// Latest L1 block that confirmed any frame from this channel.
+    pub last_confirmed_l1_block: Option<u64>,
 }
 
 /// Tracks a pending submission back to its channel and frame range.

--- a/crates/batcher/encoder/src/encoder.rs
+++ b/crates/batcher/encoder/src/encoder.rs
@@ -200,7 +200,7 @@ impl BatchEncoder {
                 // blocks are never silently lost if the channel rejects the batch (e.g.
                 // if the span batch exceeds MAX_RLP_BYTES_PER_CHANNEL).
                 if self.current_channel.is_none() {
-                    self.open_new_channel();
+                    self.open_new_channel(self.block_cursor.saturating_sub(total));
                 }
 
                 let add_ok = self
@@ -274,6 +274,7 @@ impl BatchEncoder {
         // subsequent confirmations find their .end adjusted to 0 and are no-ops.
         // This correctly handles out-of-order confirmations without double-pruning.
         let block_range = 0..self.block_cursor;
+        let encoded_block_range = open.block_start..self.block_cursor;
         let frame_count = frames.len();
         let duration_blocks = self.l1_head.saturating_sub(opened_at_l1);
         let compressed_bytes: usize = frames.iter().map(|f| f.data.len()).sum();
@@ -284,6 +285,8 @@ impl BatchEncoder {
             frame_count = %frame_count,
             block_range_start = %block_range.start,
             block_range_end = %block_range.end,
+            encoded_block_range_start = %encoded_block_range.start,
+            encoded_block_range_end = %encoded_block_range.end,
             close_reason = %close_reason,
             duration_blocks = %duration_blocks,
             input_bytes = %input_bytes,
@@ -307,14 +310,17 @@ impl BatchEncoder {
             frames,
             cursor: 0,
             block_range,
+            encoded_block_range,
             da_backlog_bytes: closed_da_backlog_bytes,
             pending_confirmations: 0,
             confirmed_count: 0,
+            first_confirmed_l1_block: None,
+            last_confirmed_l1_block: None,
         });
     }
 
     /// Create a new open channel with a random `ChannelId`.
-    fn open_new_channel(&mut self) {
+    fn open_new_channel(&mut self, block_start: usize) {
         let mut id = ChannelId::default();
         self.rng.fill_bytes(&mut id);
 
@@ -328,11 +334,17 @@ impl BatchEncoder {
 
         let channel_out = ChannelOut::new(id, Arc::clone(&self.rollup_config), compressor);
 
-        debug!(channel_id = ?id, l1_head = %self.l1_head, "opened new channel");
+        debug!(
+            channel_id = ?id,
+            block_start = %block_start,
+            l1_head = %self.l1_head,
+            "opened new channel"
+        );
         BatcherMetrics::channel_opened_total().increment(1);
 
         self.current_channel = Some(OpenChannel {
             out: channel_out,
+            block_start,
             opened_at_l1: self.l1_head,
             blocks_added: 0,
             da_backlog_bytes: 0,
@@ -369,6 +381,77 @@ impl BatchEncoder {
         }
 
         should_close
+    }
+
+    /// Returns the conservative protocol channel timeout used for confirmation windows.
+    fn confirmation_channel_timeout(&self) -> u64 {
+        let pre_granite = self.rollup_config.channel_timeout(0);
+        let post_granite = self.rollup_config.channel_timeout(u64::MAX);
+        match (pre_granite, post_granite) {
+            (0, timeout) | (timeout, 0) => timeout,
+            (pre, post) => pre.min(post),
+        }
+    }
+
+    /// Drops confirmed-too-late channels and rewinds encoding to republish their blocks.
+    fn invalidate_ready_channel(
+        &mut self,
+        chan_idx: usize,
+        observed_l1_block: u64,
+        channel_timeout: u64,
+    ) {
+        if chan_idx >= self.ready_channels.len() {
+            return;
+        }
+
+        let channel = &self.ready_channels[chan_idx];
+        let channel_id = channel.id;
+        let first_confirmed_l1_block = channel.first_confirmed_l1_block;
+        let last_confirmed_l1_block = channel.last_confirmed_l1_block;
+        let replay_from = channel.encoded_block_range.start;
+        let removed_pending_frames: usize = self
+            .ready_channels
+            .iter()
+            .skip(chan_idx)
+            .map(|channel| channel.frames.len().saturating_sub(channel.cursor))
+            .sum();
+
+        warn!(
+            channel_id = ?channel_id,
+            first_confirmed_l1_block = ?first_confirmed_l1_block,
+            last_confirmed_l1_block = ?last_confirmed_l1_block,
+            observed_l1_block = %observed_l1_block,
+            channel_timeout = %channel_timeout,
+            replay_from_block_index = %replay_from,
+            "confirmed channel exceeded derivation timeout, replaying blocks"
+        );
+
+        self.ready_channels.truncate(chan_idx);
+        self.pending.retain(|_, pending| pending.channel_idx < chan_idx);
+        self.current_channel = None;
+        self.span_accumulator.clear();
+        self.span_raw_bytes = 0;
+        self.span_da_backlog_bytes = 0;
+        self.span_opened_at_l1 = None;
+        self.block_cursor = self.block_cursor.min(replay_from);
+
+        if removed_pending_frames > 0 {
+            BatcherMetrics::pending_frames().decrement(removed_pending_frames as f64);
+        }
+    }
+
+    /// Invalidates the first ready channel whose confirmation window has expired.
+    fn invalidate_expired_ready_channels(&mut self) {
+        let channel_timeout = self.confirmation_channel_timeout();
+        let Some(chan_idx) = self.ready_channels.iter().position(|channel| {
+            channel
+                .first_confirmed_l1_block
+                .is_some_and(|first| first.saturating_add(channel_timeout) < self.l1_head)
+        }) else {
+            return;
+        };
+
+        self.invalidate_ready_channel(chan_idx, self.l1_head, channel_timeout);
     }
 }
 
@@ -470,7 +553,7 @@ impl BatchPipeline for BatchEncoder {
             BatchType::Single => {
                 // Ensure a channel is open.
                 if self.current_channel.is_none() {
-                    self.open_new_channel();
+                    self.open_new_channel(self.block_cursor);
                 }
 
                 // Try to add the batch to the current channel.
@@ -585,7 +668,7 @@ impl BatchPipeline for BatchEncoder {
         None
     }
 
-    fn confirm(&mut self, id: SubmissionId, _l1_block: u64) {
+    fn confirm(&mut self, id: SubmissionId, l1_block: u64) {
         let Some(pending_ref) = self.pending.remove(&id) else {
             warn!(id = ?id, "confirm called for unknown submission id");
             return;
@@ -597,9 +680,27 @@ impl BatchPipeline for BatchEncoder {
             return;
         }
 
+        let channel_timeout = self.confirmation_channel_timeout();
         let channel = &mut self.ready_channels[chan_idx];
         channel.pending_confirmations = channel.pending_confirmations.saturating_sub(1);
         channel.confirmed_count += pending_ref.frame_count;
+        channel.first_confirmed_l1_block =
+            Some(channel.first_confirmed_l1_block.map_or(l1_block, |first| first.min(l1_block)));
+        channel.last_confirmed_l1_block =
+            Some(channel.last_confirmed_l1_block.map_or(l1_block, |last| last.max(l1_block)));
+
+        let first_confirmed_l1_block =
+            channel.first_confirmed_l1_block.expect("first confirmed block was just set");
+        let timeout_block = first_confirmed_l1_block.saturating_add(channel_timeout);
+        let timed_out_by_late_confirmation = timeout_block < l1_block;
+        let channel_incomplete = channel.confirmed_count < channel.frames.len();
+        let timed_out_by_l1_head = channel_incomplete && timeout_block < self.l1_head;
+        if timed_out_by_late_confirmation || timed_out_by_l1_head {
+            let observed_l1_block =
+                if timed_out_by_late_confirmation { l1_block } else { self.l1_head };
+            self.invalidate_ready_channel(chan_idx, observed_l1_block, channel_timeout);
+            return;
+        }
 
         // Check if all frames are confirmed and none are in-flight.
         if channel.confirmed_count >= channel.frames.len() && channel.pending_confirmations == 0 {
@@ -637,6 +738,10 @@ impl BatchPipeline for BatchEncoder {
                 // block_range.start is always 0 and unused in prune logic.
                 for ch in &mut self.ready_channels {
                     ch.block_range.end = ch.block_range.end.saturating_sub(prune_count);
+                    ch.encoded_block_range.start =
+                        ch.encoded_block_range.start.saturating_sub(prune_count);
+                    ch.encoded_block_range.end =
+                        ch.encoded_block_range.end.saturating_sub(prune_count);
                 }
             }
         }
@@ -690,6 +795,7 @@ impl BatchPipeline for BatchEncoder {
         }
         self.l1_head = l1_block;
         self.check_channel_timeout();
+        self.invalidate_expired_ready_channels();
     }
 
     fn reset(&mut self) {
@@ -745,6 +851,8 @@ impl BatchPipeline for BatchEncoder {
         // does not over-prune later. This mirrors the adjustment in confirm().
         for ch in &mut self.ready_channels {
             ch.block_range.end = ch.block_range.end.saturating_sub(prune_count);
+            ch.encoded_block_range.start = ch.encoded_block_range.start.saturating_sub(prune_count);
+            ch.encoded_block_range.end = ch.encoded_block_range.end.saturating_sub(prune_count);
         }
     }
 
@@ -832,6 +940,30 @@ mod tests {
     fn default_encoder() -> BatchEncoder {
         let rollup_config = Arc::new(RollupConfig::default());
         BatchEncoder::new(rollup_config, EncoderConfig::default())
+    }
+
+    fn encoder_with_confirmation_timeout(channel_timeout: u64) -> BatchEncoder {
+        let rollup_config = Arc::new(RollupConfig {
+            channel_timeout,
+            granite_channel_timeout: channel_timeout,
+            ..RollupConfig::default()
+        });
+        let config = EncoderConfig {
+            max_frame_size: 32,
+            target_frame_size: 32,
+            target_num_frames: 1,
+            max_channel_duration: 1000,
+            ..EncoderConfig::default()
+        };
+        BatchEncoder::new(rollup_config, config)
+    }
+
+    fn drain_submissions(encoder: &mut BatchEncoder) -> Vec<BatchSubmission> {
+        let mut submissions = Vec::new();
+        while let Some(submission) = encoder.next_submission() {
+            submissions.push(submission);
+        }
+        submissions
     }
 
     #[test]
@@ -1282,6 +1414,81 @@ mod tests {
             submitted_frame_count,
             "requeued submission must contain the same number of frames"
         );
+    }
+
+    #[test]
+    fn test_late_confirmation_replays_timed_out_channel() {
+        let mut encoder = encoder_with_confirmation_timeout(2);
+
+        encoder.add_block(make_block_with_user_tx(B256::ZERO)).unwrap();
+        assert_eq!(encoder.step().unwrap(), StepResult::BlockEncoded);
+        encoder.force_close_channel();
+
+        let original_channel_id = encoder.ready_channels[0].id;
+        let submissions = drain_submissions(&mut encoder);
+        assert!(
+            submissions.len() >= 2,
+            "test requires a multi-frame channel, got {} submission(s)",
+            submissions.len()
+        );
+
+        encoder.confirm(submissions[0].id, 1);
+        assert_eq!(encoder.blocks.len(), 1, "partial confirmation must not prune blocks");
+
+        encoder.confirm(submissions[1].id, 4);
+        assert_eq!(encoder.blocks.len(), 1, "timed-out confirmation must preserve blocks");
+        assert_eq!(encoder.block_cursor, 0, "encoder must rewind to replay the block");
+        assert!(encoder.ready_channels.is_empty(), "old channel must be discarded");
+        assert!(encoder.pending.is_empty(), "stale in-flight tail submissions must be forgotten");
+
+        for submission in submissions.iter().skip(2) {
+            encoder.confirm(submission.id, 4);
+        }
+        assert_eq!(encoder.blocks.len(), 1, "stale late confirmations must be no-ops");
+
+        assert_eq!(encoder.step().unwrap(), StepResult::BlockEncoded);
+        encoder.force_close_channel();
+
+        let replay_submissions = drain_submissions(&mut encoder);
+        assert!(!replay_submissions.is_empty(), "replay must emit a fresh channel");
+        assert_ne!(
+            replay_submissions[0].channel_id, original_channel_id,
+            "replay must use a fresh channel id"
+        );
+
+        for submission in replay_submissions {
+            encoder.confirm(submission.id, 5);
+        }
+        assert!(encoder.blocks.is_empty(), "fresh replay should prune after timely confirmation");
+    }
+
+    #[test]
+    fn test_l1_head_expiry_replays_before_tail_confirms() {
+        let mut encoder = encoder_with_confirmation_timeout(2);
+
+        encoder.add_block(make_block_with_user_tx(B256::ZERO)).unwrap();
+        assert_eq!(encoder.step().unwrap(), StepResult::BlockEncoded);
+        encoder.force_close_channel();
+
+        let submissions = drain_submissions(&mut encoder);
+        assert!(
+            submissions.len() >= 2,
+            "test requires a multi-frame channel, got {} submission(s)",
+            submissions.len()
+        );
+
+        encoder.confirm(submissions[0].id, 1);
+        encoder.advance_l1_head(4);
+
+        assert_eq!(encoder.blocks.len(), 1, "expired channel must preserve blocks");
+        assert_eq!(encoder.block_cursor, 0, "expired channel must rewind for replay");
+        assert!(encoder.ready_channels.is_empty(), "expired channel must be discarded");
+        assert!(encoder.pending.is_empty(), "stale tail submissions must be forgotten");
+
+        for submission in submissions.iter().skip(1) {
+            encoder.confirm(submission.id, 4);
+        }
+        assert_eq!(encoder.blocks.len(), 1, "late tail confirmations must stay stale");
     }
 
     // --- step() fatal error tests ---


### PR DESCRIPTION
## Summary

This fixes batcher confirmation handling for channels whose frames land outside the derivation channel timeout window. The encoder now tracks the L1 confirmation span for each ready channel and replays the affected L2 blocks in a fresh channel instead of pruning them after late confirmations. It also invalidates incomplete ready channels as soon as the observed L1 head proves their confirmation window has expired.

CHAIN-4294