### PR TITLE
fix(disc): Bound Discv5 ENR Forwarding

### DIFF
--- a/crates/consensus/disc/src/driver.rs
+++ b/crates/consensus/disc/src/driver.rs
@@ -7,11 +7,28 @@ use base_consensus_peers::{
 use derive_more::Debug;
 use discv5::{Config, Discv5, Enr, enr::NodeId};
 use tokio::{
-    sync::mpsc::channel,
+    sync::mpsc::{Sender, channel, error::TrySendError},
     time::{Duration, sleep},
 };
 
 use crate::{Discv5Builder, Discv5Handler, HandlerRequest, LocalNode, Metrics};
+
+/// Attempts to forward an ENR to the gossip service without spawning or parking on backpressure.
+fn try_forward_enr(enr_sender: &Sender<Enr>, enr: Enr) -> bool {
+    match enr_sender.try_send(enr) {
+        Ok(()) => true,
+        Err(TrySendError::Full(_)) => {
+            Metrics::discovery_dropped("backpressure").increment(1.0);
+            debug!(target: "discovery", "dropping enr because receiver is full");
+            false
+        }
+        Err(TrySendError::Closed(_)) => {
+            Metrics::discovery_dropped("closed").increment(1.0);
+            debug!(target: "discovery", "dropping enr because receiver is closed");
+            false
+        }
+    }
+}
 
 /// The [`Discv5Driver`] drives the discovery service.
 ///
@@ -179,9 +196,7 @@ impl Discv5Driver {
             // Step 3: Forward ENRs in the bootstore to the enr receiver.
             if self.forward {
                 for enr in store.valid_peers_with_chain_id(self.chain_id) {
-                    if let Err(e) = enr_sender.send(enr.clone()).await {
-                        debug!(target: "discovery", error = ?e, "Failed to forward enr");
-                    }
+                    try_forward_enr(&enr_sender, enr.clone());
                 }
             }
 
@@ -281,39 +296,27 @@ impl Discv5Driver {
                                 if EnrValidation::validate(&enr, chain_id).is_valid() {
                                     debug!(target: "discovery", enr = ?enr, "Valid ENR discovered, forwarding to swarm");
                                     Metrics::discovery_event("discovered").increment(1.0);
-                                    store.add_enr(enr.clone());
-                                    let sender = enr_sender.clone();
-                                    tokio::spawn(async move {
-                                        if let Err(e) = sender.send(enr).await {
-                                            debug!(target: "discovery", error = ?e, "Failed to send enr");
-                                        }
-                                    });
+                                    if try_forward_enr(&enr_sender, enr.clone()) {
+                                        store.add_enr(enr);
+                                    }
                                 }
                             }
                             discv5::Event::SessionEstablished(enr, addr) => {
                                 if EnrValidation::validate(&enr, chain_id).is_valid() {
                                     debug!(target: "discovery", addr = ?addr, enr = ?enr, "Session established with valid ENR, forwarding to swarm");
                                     Metrics::discovery_event("session_established").increment(1.0);
-                                    store.add_enr(enr.clone());
-                                    let sender = enr_sender.clone();
-                                    tokio::spawn(async move {
-                                        if let Err(e) = sender.send(enr).await {
-                                            debug!(target: "discovery", error = ?e, "Failed to send enr");
-                                        }
-                                    });
+                                    if try_forward_enr(&enr_sender, enr.clone()) {
+                                        store.add_enr(enr);
+                                    }
                                 }
                             }
                             discv5::Event::UnverifiableEnr { enr, .. } => {
                                 if EnrValidation::validate(&enr, chain_id).is_valid() {
                                     debug!(target: "discovery", enr = ?enr, "Valid ENR discovered, forwarding to swarm");
                                     Metrics::discovery_event("unverifiable_enr").increment(1.0);
-                                    store.add_enr(enr.clone());
-                                    let sender = enr_sender.clone();
-                                    tokio::spawn(async move {
-                                        if let Err(e) = sender.send(enr).await {
-                                            debug!(target: "discovery", error = ?e, "Failed to send enr");
-                                        }
-                                    });
+                                    if try_forward_enr(&enr_sender, enr.clone()) {
+                                        store.add_enr(enr);
+                                    }
                                 }
 
                             }
@@ -331,7 +334,7 @@ impl Discv5Driver {
                                 Ok(nodes) => {
                                     let enrs = nodes.into_iter().filter(|node| EnrValidation::validate(node, chain_id).is_valid());
                                     for enr in enrs {
-                                        _ = enr_sender.send(enr).await;
+                                        try_forward_enr(&enr_sender, enr);
                                     }
                                 }
                                 Err(err) => {
@@ -385,9 +388,41 @@ mod tests {
         handler::NodeContact,
     };
     use tempfile::tempdir;
+    use tokio::sync::mpsc;
 
     use super::*;
     use crate::LocalNode;
+
+    fn test_enr() -> Enr {
+        let key = CombinedKey::generate_secp256k1();
+        Enr::builder().build(&key).expect("test enr should build")
+    }
+
+    #[test]
+    fn try_forward_enr_succeeds_when_channel_has_capacity() {
+        let (tx, mut rx) = mpsc::channel(1);
+        let enr = test_enr();
+
+        assert!(try_forward_enr(&tx, enr.clone()));
+
+        assert_eq!(rx.try_recv().expect("enr should be forwarded"), enr);
+    }
+
+    #[test]
+    fn try_forward_enr_drops_when_channel_is_full() {
+        let (tx, _rx) = mpsc::channel(1);
+
+        assert!(try_forward_enr(&tx, test_enr()));
+        assert!(!try_forward_enr(&tx, test_enr()));
+    }
+
+    #[test]
+    fn try_forward_enr_drops_when_channel_is_closed() {
+        let (tx, rx) = mpsc::channel(1);
+        drop(rx);
+
+        assert!(!try_forward_enr(&tx, test_enr()));
+    }
 
     #[tokio::test]
     async fn test_online_discv5_driver() {

--- a/crates/consensus/disc/src/metrics.rs
+++ b/crates/consensus/disc/src/metrics.rs
@@ -7,6 +7,10 @@ base_metrics::define_metrics! {
     #[label(name = "type", default = ["discovered", "session_established", "unverifiable_enr"])]
     discovery_event: gauge,
 
+    #[describe("ENRs dropped before forwarding to the gossip service")]
+    #[label(name = "reason", default = ["backpressure", "closed"])]
+    discovery_dropped: gauge,
+
     #[describe("Requests made to find a node through the discv5 peer discovery service")]
     find_node_request: gauge,
 


### PR DESCRIPTION
## Summary

This bounds discovery ENR forwarding by replacing detached send tasks with immediate try_send backpressure. When the gossip receiver is full or closed, discovery now drops the ENR and records a drop metric instead of parking an unbounded task. The change also adds regression coverage for successful forwarding, full-channel shedding, and closed-channel shedding.