### PR TITLE
fix(proof): Reject Malformed Trie Preimages

### DIFF
--- a/crates/proof/host/src/error.rs
+++ b/crates/proof/host/src/error.rs
@@ -1,5 +1,6 @@
 use std::array::TryFromSliceError;
 
+use alloy_primitives::B256;
 use alloy_rlp::Error as RlpError;
 use alloy_transport::TransportError;
 use base_proof_client::FaultProofProgramError;
@@ -67,6 +68,14 @@ pub enum HostError {
     /// Error fetching code hash preimage.
     #[error("Error fetching code hash preimage: {0}")]
     CodeHashPreimageFetchFailed(String),
+    /// State node preimage hash mismatch.
+    #[error("State node preimage hash mismatch: expected {expected}, actual {actual}")]
+    StateNodePreimageHashMismatch {
+        /// Expected hash.
+        expected: B256,
+        /// Actual hash.
+        actual: B256,
+    },
     /// Failed to serve a preimage request.
     #[error("Failed to serve preimage request: {0}")]
     PreimageRequestFailed(PreimageOracleError),

--- a/crates/proof/host/src/handler.rs
+++ b/crates/proof/host/src/handler.rs
@@ -305,6 +305,13 @@ async fn handle_hint_inner(
             warn!("debug_executePayload failed to return a complete witness");
 
             let preimage: Bytes = providers.l2.client().request("debug_dbGet", &[hash]).await?;
+            let actual_hash = keccak256(preimage.as_ref());
+            if actual_hash != hash {
+                return Err(HostError::StateNodePreimageHashMismatch {
+                    expected: hash,
+                    actual: actual_hash,
+                });
+            }
 
             let mut kv_write_lock = kv.write().await;
             kv_write_lock.set(PreimageKey::new_keccak256(*hash).into(), preimage.into())?;
@@ -416,7 +423,18 @@ async fn handle_hint_inner(
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
+    use alloy_genesis::ChainConfig;
+    use alloy_provider::{RootProvider, builder as provider_builder, mock::Asserter};
+    use base_common_genesis::RollupConfig;
+    use base_common_network::Base;
+    use base_consensus_providers::{OnlineBeaconClient, OnlineBlobProvider};
+    use base_proof_primitives::ProofRequest;
+    use tokio::sync::RwLock;
+
     use super::*;
+    use crate::{MemoryKeyValueStore, ProverConfig};
 
     const TEST_HASH: B256 = B256::new([0x42u8; 32]);
     const TEST_TIMESTAMP: u64 = 1234567890;
@@ -433,6 +451,30 @@ mod tests {
         0x42, 0x42, 0x42, 0x42, 0x42, 0x42, 0x42, 0x42, 0x42, 0x42, 0x42, 0x42, 0x42, 0x42, 0x42,
         0x42, 0x42, 0x00, 0x00, 0x00, 0x00, 0x49, 0x96, 0x02, 0xD2,
     ];
+
+    fn test_cfg() -> HostConfig {
+        HostConfig {
+            request: ProofRequest::default(),
+            prover: ProverConfig {
+                l1_eth_url: "http://127.0.0.1:1".to_string(),
+                l2_eth_url: "http://127.0.0.1:1".to_string(),
+                l1_beacon_url: "http://127.0.0.1:1".to_string(),
+                l2_chain_id: 0,
+                rollup_config: RollupConfig::default(),
+                l1_config: ChainConfig::default(),
+                enable_experimental_witness_endpoint: false,
+            },
+            data_dir: None,
+        }
+    }
+
+    fn test_providers(l2: RootProvider<Base>) -> HostProviders {
+        let l1 = RootProvider::new_http("http://127.0.0.1:1".parse().unwrap());
+        let beacon = OnlineBeaconClient::new_http("http://127.0.0.1:1".to_string());
+        let blobs =
+            OnlineBlobProvider { beacon_client: beacon, genesis_time: 0, slot_interval: 12 };
+        HostProviders { l1, blobs, l2 }
+    }
 
     #[test]
     fn test_parse_blob_hint_formats() {
@@ -455,5 +497,31 @@ mod tests {
         assert!(err_msg.contains("Invalid blob hint length"));
         assert!(err_msg.contains("expected 40 or 48 bytes"));
         assert!(err_msg.contains("got 35"));
+    }
+
+    #[tokio::test]
+    async fn test_l2_state_node_rejects_hash_mismatch() {
+        const MALFORMED_PREIMAGE: [u8; 3] = [0xC2, 0x80, 0x80];
+
+        let requested_hash = TEST_HASH;
+        let preimage = Bytes::from(MALFORMED_PREIMAGE.to_vec());
+        let actual_hash = keccak256(preimage.as_ref());
+        let asserter = Asserter::new();
+        asserter.push_success(&preimage);
+        let l2 = provider_builder::<Base>().connect_mocked_client(asserter);
+        let providers = test_providers(l2);
+        let kv: SharedKeyValueStore = Arc::new(RwLock::new(MemoryKeyValueStore::new()));
+        let hint = HintType::L2StateNode.with_data(&[requested_hash.as_slice()]);
+
+        let err = handle_hint(hint, &test_cfg(), &providers, Arc::clone(&kv)).await.unwrap_err();
+
+        match err {
+            HostError::StateNodePreimageHashMismatch { expected, actual } => {
+                assert_eq!(expected, requested_hash);
+                assert_eq!(actual, actual_hash);
+            }
+            other => panic!("unexpected error: {other}"),
+        }
+        assert!(kv.read().await.get(PreimageKey::new_keccak256(*requested_hash).into()).is_none());
     }
 }

--- a/crates/proof/mpt/src/node.rs
+++ b/crates/proof/mpt/src/node.rs
@@ -439,9 +439,12 @@ impl TrieNode {
     fn try_decode_leaf_or_extension_payload(buf: &mut &[u8]) -> TrieNodeResult<Self> {
         // Decode the path and value of the leaf or extension node.
         let path = Bytes::decode(buf).map_err(TrieNodeError::RLPError)?;
-        let first_nibble = path[0] >> NIBBLE_WIDTH;
+        let Some(first_byte) = path.first() else {
+            return Err(TrieNodeError::InvalidNodeType);
+        };
+        let first_nibble = first_byte >> NIBBLE_WIDTH;
         let first = match first_nibble {
-            PREFIX_EXTENSION_ODD | PREFIX_LEAF_ODD => Some(path[0] & 0x0F),
+            PREFIX_EXTENSION_ODD | PREFIX_LEAF_ODD => Some(first_byte & 0x0F),
             PREFIX_EXTENSION_EVEN | PREFIX_LEAF_EVEN => None,
             _ => return Err(TrieNodeError::InvalidNodeType),
         };
@@ -707,6 +710,13 @@ mod tests {
         let expected =
             TrieNode::Leaf { prefix: Nibbles::unpack(bytes!("646f")), value: bytes!("76657262FF") };
         assert_eq!(expected, TrieNode::decode(&mut LEAF_RLP.as_slice()).unwrap());
+    }
+
+    #[test]
+    fn test_decode_leaf_or_extension_empty_path_errors() {
+        const EMPTY_PATH_LEAF_OR_EXTENSION_RLP: [u8; 3] = hex!("c28080");
+
+        assert!(TrieNode::decode(&mut EMPTY_PATH_LEAF_OR_EXTENSION_RLP.as_slice()).is_err());
     }
 
     #[test]

--- a/crates/proof/succinct/elf/manifest.toml
+++ b/crates/proof/succinct/elf/manifest.toml
@@ -14,7 +14,7 @@
 
 [[elfs]]
 name = "range-elf-embedded"
-sha256 = "ae35e1a350a30407d62ff1dbc0eb467d4aebaeaff333b4cf00555e75b6b56bc8"
+sha256 = "40e1483c672d080608e79d59dc48a049c6f3c7c6fab7fc0b1384598cbc2b4bd2"
 
 [[elfs]]
 name = "aggregation-elf"


### PR DESCRIPTION
## Summary

This hardens proof trie decoding so malformed leaf or extension nodes with empty compact paths return a structured decode error instead of panicking. It also hash-binds L2 state node preimages returned by debug_dbGet before storing them in the host KV store. Focused regressions cover the malformed MPT input and mismatched L2StateNode preimage path.

CHAIN-4249