### PR TITLE
fix(batcher): reset from fresh local safe head

### DIFF
--- a/crates/batcher/core/src/driver.rs
+++ b/crates/batcher/core/src/driver.rs
@@ -14,11 +14,18 @@ use tracing::{debug, error, info, warn};
 
 use crate::{
     AdminCommand, BatchDriverConfig, BatchDriverError, BatcherStatus, DaThrottle,
-    LocalSafeHeadProvider, SubmissionQueue, ThrottleClient, ThrottleController, event::DriverEvent,
+    LocalSafeHeadProvider, SubmissionQueue, ThrottleClient, ThrottleController,
+    event::{DriverEvent, ResetSafeHeadResult},
 };
 
 /// Delay between reset-boundary local-safe-head retries.
 const RESET_SAFE_HEAD_RETRY_DELAY: Duration = Duration::from_secs(5);
+
+#[derive(Debug)]
+struct PendingResetSafeHead {
+    rx: mpsc::Receiver<Option<u64>>,
+    fallback: Option<u64>,
+}
 
 /// Async orchestration loop for the batcher.
 ///
@@ -57,8 +64,8 @@ where
     safe_head_rx: Option<tokio::sync::watch::Receiver<u64>>,
     /// Optional provider used to fetch a fresh local safe head for reset boundaries.
     local_safe_head_provider: Option<Arc<dyn LocalSafeHeadProvider>>,
-    /// Result channel for an in-flight reset-boundary local-safe lookup.
-    reset_safe_head_rx: Option<mpsc::Receiver<Option<u64>>>,
+    /// In-flight reset-boundary lookup.
+    pending_reset_safe_head: Option<PendingResetSafeHead>,
     /// Maximum wall-clock time to wait for in-flight submissions to settle
     /// when draining on cancellation or source exhaustion.
     drain_timeout: Duration,
@@ -109,7 +116,7 @@ where
             l1_head_source: Some(l1_head_source),
             safe_head_rx: None,
             local_safe_head_provider: None,
-            reset_safe_head_rx: None,
+            pending_reset_safe_head: None,
             drain_timeout: config.drain_timeout,
             stopped: false,
             admin_rx: None,
@@ -228,9 +235,20 @@ where
                     self.pipeline.prune_safe(n);
                     debug!(local_safe_l2 = %n, "pruned safe blocks via watch");
                 }
-                DriverEvent::ResetSafeHead(n) => {
-                    self.reset_safe_head_rx = None;
-                    self.catch_up_from_safe_head(n);
+                DriverEvent::ResetSafeHead(result) => {
+                    self.pending_reset_safe_head = None;
+                    match result {
+                        ResetSafeHeadResult::Resolved { safe_head } => {
+                            self.catch_up_from_safe_head(safe_head);
+                        }
+                        ResetSafeHeadResult::Closed { fallback } => {
+                            warn!(
+                                fallback_safe_head = ?fallback,
+                                "local safe head reset boundary task closed without result, using fallback"
+                            );
+                            self.catch_up_from_safe_head(fallback);
+                        }
+                    }
                 }
                 DriverEvent::L1SourceClosed => {
                     debug!("L1 head source closed, disabling arm");
@@ -310,13 +328,12 @@ where
             return;
         };
 
-        if self.reset_safe_head_rx.is_some() {
-            warn!("local safe head reset boundary lookup already pending");
-            return;
+        if self.pending_reset_safe_head.is_some() {
+            warn!("replacing pending local safe head reset boundary lookup");
         }
 
         let (tx, rx) = mpsc::channel(1);
-        self.reset_safe_head_rx = Some(rx);
+        self.pending_reset_safe_head = Some(PendingResetSafeHead { rx, fallback: watch_value });
 
         let runtime = self.runtime.clone();
         let provider = Arc::clone(provider);
@@ -386,14 +403,14 @@ where
     /// return type with a no-op variant.
     async fn next_event(&mut self) -> Result<DriverEvent, BatchDriverError> {
         loop {
-            let reset_pending = self.reset_safe_head_rx.is_some();
+            let reset_pending = self.pending_reset_safe_head.is_some();
             let event = tokio::select! {
                 biased;
 
                 _ = self.runtime.cancelled() => DriverEvent::Shutdown,
 
-                safe_head = Self::next_reset_safe_head(&mut self.reset_safe_head_rx) => {
-                    DriverEvent::ResetSafeHead(safe_head)
+                result = Self::next_reset_safe_head(&mut self.pending_reset_safe_head) => {
+                    DriverEvent::ResetSafeHead(result)
                 },
 
                 cmd = Self::next_admin_cmd(&mut self.admin_rx) => {
@@ -516,9 +533,14 @@ where
     }
 
     /// Returns a completed reset-boundary lookup, or parks forever if none is pending.
-    async fn next_reset_safe_head(rx: &mut Option<mpsc::Receiver<Option<u64>>>) -> Option<u64> {
-        match rx {
-            Some(rx) => rx.recv().await.flatten(),
+    async fn next_reset_safe_head(
+        pending: &mut Option<PendingResetSafeHead>,
+    ) -> ResetSafeHeadResult {
+        match pending {
+            Some(pending) => match pending.rx.recv().await {
+                Some(safe_head) => ResetSafeHeadResult::Resolved { safe_head },
+                None => ResetSafeHeadResult::Closed { fallback: pending.fallback },
+            },
             None => std::future::pending().await,
         }
     }

--- a/crates/batcher/core/src/driver.rs
+++ b/crates/batcher/core/src/driver.rs
@@ -57,6 +57,8 @@ where
     safe_head_rx: Option<tokio::sync::watch::Receiver<u64>>,
     /// Optional provider used to fetch a fresh local safe head for reset boundaries.
     local_safe_head_provider: Option<Arc<dyn LocalSafeHeadProvider>>,
+    /// Result channel for an in-flight reset-boundary local-safe lookup.
+    reset_safe_head_rx: Option<mpsc::Receiver<Option<u64>>>,
     /// Maximum wall-clock time to wait for in-flight submissions to settle
     /// when draining on cancellation or source exhaustion.
     drain_timeout: Duration,
@@ -107,6 +109,7 @@ where
             l1_head_source: Some(l1_head_source),
             safe_head_rx: None,
             local_safe_head_provider: None,
+            reset_safe_head_rx: None,
             drain_timeout: config.drain_timeout,
             stopped: false,
             admin_rx: None,
@@ -199,30 +202,20 @@ where
                     draining = true;
                 }
                 DriverEvent::Block(b) => {
-                    self.on_block(b).await?;
+                    self.on_block(b);
                 }
                 DriverEvent::Flush => {
                     self.pipeline.force_close_channel();
                     debug!("flush signal received, force-closed channel");
                 }
                 DriverEvent::Reorg(head) => {
-                    let safe_head = Self::reset_safe_head(
-                        self.runtime.clone(),
-                        self.local_safe_head_provider.clone(),
-                        self.safe_head_rx.as_ref().map(|rx| *rx.borrow()),
-                    )
-                    .await
-                    .unwrap_or(0);
-                    let catchup_from = safe_head + 1;
                     warn!(
                         reorg_head = %head.block_info.number,
-                        local_safe_l2 = %safe_head,
-                        catchup_from = %catchup_from,
-                        "L2 reorg detected, resetting pipeline and catching up from local safe head"
+                        "L2 reorg detected, resetting pipeline before local safe head catchup"
                     );
-                    self.submissions.discard();
-                    self.pipeline.reset();
-                    self.source.reset_catchup(catchup_from);
+                    self.reset_for_local_safe_catchup(
+                        self.safe_head_rx.as_ref().map(|rx| *rx.borrow()),
+                    );
                 }
                 DriverEvent::Receipt(ids, o) => {
                     self.submissions.handle_outcome(&mut self.pipeline, ids, o);
@@ -234,6 +227,10 @@ where
                 DriverEvent::SafeHead(n) => {
                     self.pipeline.prune_safe(n);
                     debug!(local_safe_l2 = %n, "pruned safe blocks via watch");
+                }
+                DriverEvent::ResetSafeHead(n) => {
+                    self.reset_safe_head_rx = None;
+                    self.catch_up_from_safe_head(n);
                 }
                 DriverEvent::L1SourceClosed => {
                     debug!("L1 head source closed, disabling arm");
@@ -275,72 +272,101 @@ where
     /// Ingest a new L2 block into the pipeline.
     ///
     /// If the pipeline signals a reorg via `add_block` (parent-hash mismatch),
-    /// discards in-flight submissions, resets the pipeline, and restarts
-    /// sequential catchup from `local_safe_l2 + 1`. The triggering block will be
-    /// re-delivered by the sequential poller.
-    async fn on_block(&mut self, block: Box<BaseBlock>) -> Result<(), BatchDriverError> {
+    /// discards in-flight submissions, resets the pipeline, and fetches a
+    /// fresh `local_safe_l2` before restarting sequential catchup from
+    /// `local_safe_l2 + 1`. The triggering block will be re-delivered by the
+    /// sequential poller.
+    fn on_block(&mut self, block: Box<BaseBlock>) {
         let number = block.header.number;
         match self.pipeline.add_block(*block) {
             Ok(()) => {
                 debug!(block = %number, "added unsafe block to pipeline");
             }
             Err((e, _block)) => {
-                let safe_head = Self::reset_safe_head(
-                    self.runtime.clone(),
-                    self.local_safe_head_provider.clone(),
-                    self.safe_head_rx.as_ref().map(|rx| *rx.borrow()),
-                )
-                .await
-                .unwrap_or(0);
-                let catchup_from = safe_head + 1;
                 warn!(
                     block = %number,
-                    local_safe_l2 = %safe_head,
-                    catchup_from = %catchup_from,
                     error = %e,
-                    "reorg detected during block ingestion, resetting pipeline and catching up from local safe head"
+                    "reorg detected during block ingestion, resetting pipeline before local safe head catchup"
                 );
-                self.submissions.discard();
-                self.pipeline.reset();
-                self.source.reset_catchup(catchup_from);
+                self.reset_for_local_safe_catchup(
+                    self.safe_head_rx.as_ref().map(|rx| *rx.borrow()),
+                );
             }
         }
-        Ok(())
     }
 
-    /// Return the reset boundary local safe head.
+    /// Reset local state and catch up from the current local safe head.
     ///
-    /// Prefer a fresh local-safe-head provider when one is configured. The watch
-    /// channel is retained as a fallback for tests and custom embedders that do
-    /// not wire a provider. Provider errors are retried until the fetch succeeds
-    /// or the runtime is cancelled; falling back to a stale watch value while a
+    /// When a provider is configured, the fresh lookup runs in a background
+    /// task and the source arm is parked until the result arrives. This keeps
+    /// the driver responsive to admin commands, receipts, L1 heads, and
+    /// shutdown while still avoiding fallback to a stale watch value.
+    fn reset_for_local_safe_catchup(&mut self, watch_value: Option<u64>) {
+        self.submissions.discard();
+        self.pipeline.reset();
+
+        let Some(provider) = self.local_safe_head_provider.as_ref() else {
+            self.catch_up_from_safe_head(watch_value);
+            return;
+        };
+
+        if self.reset_safe_head_rx.is_some() {
+            warn!("local safe head reset boundary lookup already pending");
+            return;
+        }
+
+        let (tx, rx) = mpsc::channel(1);
+        self.reset_safe_head_rx = Some(rx);
+
+        let runtime = self.runtime.clone();
+        let provider = Arc::clone(provider);
+        self.runtime.spawn(async move {
+            let safe_head = Self::reset_safe_head_with_retry(runtime, provider, watch_value).await;
+            let _ = tx.send(safe_head).await;
+        });
+    }
+
+    /// Apply a resolved reset boundary to the source.
+    fn catch_up_from_safe_head(&mut self, safe_head: Option<u64>) {
+        if let Some(safe_head) = safe_head {
+            let catchup_from = safe_head + 1;
+            self.source.reset_catchup(catchup_from);
+            info!(
+                local_safe_l2 = %safe_head,
+                catchup_from = %catchup_from,
+                "batcher catching up from local safe head"
+            );
+        }
+    }
+
+    /// Return the reset boundary local safe head, retrying provider errors.
+    ///
+    /// The watch channel is retained as a shutdown fallback for tests and
+    /// custom embedders. During normal operation, provider errors are retried
+    /// until the fetch succeeds; falling back to a stale watch value while a
     /// provider exists would reintroduce the reorg skip hazard.
-    async fn reset_safe_head(
+    async fn reset_safe_head_with_retry(
         runtime: R,
-        provider: Option<Arc<dyn LocalSafeHeadProvider>>,
+        provider: Arc<dyn LocalSafeHeadProvider>,
         watch_value: Option<u64>,
     ) -> Option<u64> {
-        if let Some(provider) = provider {
-            loop {
-                match provider.local_safe_l2_number().await {
-                    Ok(n) => return Some(n),
-                    Err(e) => {
-                        warn!(
-                            error = %e,
-                            retry_delay = ?RESET_SAFE_HEAD_RETRY_DELAY,
-                            "failed to fetch local safe head for reset boundary, retrying"
-                        );
-                        tokio::select! {
-                            biased;
-                            _ = runtime.cancelled() => return watch_value,
-                            _ = runtime.sleep(RESET_SAFE_HEAD_RETRY_DELAY) => {}
-                        }
+        loop {
+            match provider.local_safe_l2_number().await {
+                Ok(n) => return Some(n),
+                Err(e) => {
+                    warn!(
+                        error = %e,
+                        retry_delay = ?RESET_SAFE_HEAD_RETRY_DELAY,
+                        "failed to fetch local safe head for reset boundary, retrying"
+                    );
+                    tokio::select! {
+                        biased;
+                        _ = runtime.cancelled() => return watch_value,
+                        _ = runtime.sleep(RESET_SAFE_HEAD_RETRY_DELAY) => {}
                     }
                 }
             }
         }
-
-        watch_value
     }
 
     /// Block on the next external event using a biased `tokio::select!`.
@@ -360,10 +386,15 @@ where
     /// return type with a no-op variant.
     async fn next_event(&mut self) -> Result<DriverEvent, BatchDriverError> {
         loop {
+            let reset_pending = self.reset_safe_head_rx.is_some();
             let event = tokio::select! {
                 biased;
 
                 _ = self.runtime.cancelled() => DriverEvent::Shutdown,
+
+                safe_head = Self::next_reset_safe_head(&mut self.reset_safe_head_rx) => {
+                    DriverEvent::ResetSafeHead(safe_head)
+                },
 
                 cmd = Self::next_admin_cmd(&mut self.admin_rx) => {
                     match cmd {
@@ -375,23 +406,11 @@ where
                             info!(stopped = true, "batcher paused via admin");
                         }
                         AdminCommand::Resume => {
-                            let safe_head = Self::reset_safe_head(
-                                self.runtime.clone(),
-                                self.local_safe_head_provider.clone(),
-                                self.safe_head_rx.as_ref().map(|rx| *rx.borrow()),
-                            )
-                            .await;
-                            if let Some(n) = safe_head {
-                                self.source.reset_catchup(n + 1);
-                                info!(
-                                    stopped = false,
-                                    catchup_from = %(n + 1),
-                                    "batcher resumed via admin, catching up from local safe head"
-                                );
-                            } else {
-                                info!(stopped = false, "batcher resumed via admin");
-                            }
                             self.stopped = false;
+                            self.reset_for_local_safe_catchup(
+                                self.safe_head_rx.as_ref().map(|rx| *rx.borrow()),
+                            );
+                            info!(stopped = false, "batcher resumed via admin");
                         }
                         AdminCommand::SetThrottle { strategy, config } => {
                             self.throttle.set_controller(
@@ -420,7 +439,13 @@ where
                     continue;
                 }
 
-                event = self.source.next() => match event {
+                event = async {
+                    if reset_pending {
+                        std::future::pending::<Result<L2BlockEvent, SourceError>>().await
+                    } else {
+                        self.source.next().await
+                    }
+                } => match event {
                     Ok(L2BlockEvent::Block(_) | L2BlockEvent::Flush) if self.stopped => {
                         continue;
                     }
@@ -486,6 +511,14 @@ where
                 Some(cmd) => cmd,
                 None => std::future::pending().await,
             },
+            None => std::future::pending().await,
+        }
+    }
+
+    /// Returns a completed reset-boundary lookup, or parks forever if none is pending.
+    async fn next_reset_safe_head(rx: &mut Option<mpsc::Receiver<Option<u64>>>) -> Option<u64> {
+        match rx {
+            Some(rx) => rx.recv().await.flatten(),
             None => std::future::pending().await,
         }
     }

--- a/crates/batcher/core/src/driver.rs
+++ b/crates/batcher/core/src/driver.rs
@@ -1,6 +1,6 @@
 //! The async batch driver that orchestrates encoding, block sourcing, and L1 submission.
 
-use std::time::Duration;
+use std::{sync::Arc, time::Duration};
 
 use base_batcher_encoder::{BatchPipeline, StepResult};
 use base_batcher_source::{
@@ -13,8 +13,8 @@ use tokio::sync::mpsc;
 use tracing::{debug, error, info, warn};
 
 use crate::{
-    AdminCommand, BatchDriverConfig, BatchDriverError, BatcherStatus, DaThrottle, SubmissionQueue,
-    ThrottleClient, ThrottleController, event::DriverEvent,
+    AdminCommand, BatchDriverConfig, BatchDriverError, BatcherStatus, DaThrottle,
+    LocalSafeHeadProvider, SubmissionQueue, ThrottleClient, ThrottleController, event::DriverEvent,
 };
 
 /// Async orchestration loop for the batcher.
@@ -52,6 +52,8 @@ where
     l1_head_source: Option<L>,
     /// Optional external L2 safe head feed for pruning confirmed blocks.
     safe_head_rx: Option<tokio::sync::watch::Receiver<u64>>,
+    /// Optional provider used to fetch a fresh local safe head for reset boundaries.
+    local_safe_head_provider: Option<Arc<dyn LocalSafeHeadProvider>>,
     /// Maximum wall-clock time to wait for in-flight submissions to settle
     /// when draining on cancellation or source exhaustion.
     drain_timeout: Duration,
@@ -101,6 +103,7 @@ where
             throttle,
             l1_head_source: Some(l1_head_source),
             safe_head_rx: None,
+            local_safe_head_provider: None,
             drain_timeout: config.drain_timeout,
             stopped: false,
             admin_rx: None,
@@ -115,6 +118,18 @@ where
     /// free blocks that are confirmed safe on L2.
     pub fn with_safe_head_rx(mut self, rx: tokio::sync::watch::Receiver<u64>) -> Self {
         self.safe_head_rx = Some(rx);
+        self
+    }
+
+    /// Attach a provider for fetching the current local safe L2 head.
+    ///
+    /// Reorg and resume resets use this provider instead of the pruning watch so
+    /// the catchup boundary can move backward after an L1 reorg.
+    pub fn with_local_safe_head_provider(
+        mut self,
+        provider: Arc<dyn LocalSafeHeadProvider>,
+    ) -> Self {
+        self.local_safe_head_provider = Some(provider);
         self
     }
 
@@ -181,20 +196,25 @@ where
                     draining = true;
                 }
                 DriverEvent::Block(b) => {
-                    self.on_block(b);
+                    self.on_block(b).await?;
                 }
                 DriverEvent::Flush => {
                     self.pipeline.force_close_channel();
                     debug!("flush signal received, force-closed channel");
                 }
                 DriverEvent::Reorg(head) => {
-                    let safe_head = self.safe_head_rx.as_ref().map(|rx| *rx.borrow()).unwrap_or(0);
+                    let safe_head = Self::reset_safe_head(
+                        self.local_safe_head_provider.clone(),
+                        self.safe_head_rx.as_ref().map(|rx| *rx.borrow()),
+                    )
+                    .await?
+                    .unwrap_or(0);
                     let catchup_from = safe_head + 1;
                     warn!(
                         reorg_head = %head.block_info.number,
-                        safe_head = %safe_head,
+                        local_safe_l2 = %safe_head,
                         catchup_from = %catchup_from,
-                        "L2 reorg detected, resetting pipeline and catching up from safe head"
+                        "L2 reorg detected, resetting pipeline and catching up from local safe head"
                     );
                     self.submissions.discard();
                     self.pipeline.reset();
@@ -209,7 +229,7 @@ where
                 }
                 DriverEvent::SafeHead(n) => {
                     self.pipeline.prune_safe(n);
-                    debug!(safe_l2_number = %n, "pruned safe blocks via watch");
+                    debug!(local_safe_l2 = %n, "pruned safe blocks via watch");
                 }
                 DriverEvent::L1SourceClosed => {
                     debug!("L1 head source closed, disabling arm");
@@ -252,29 +272,55 @@ where
     ///
     /// If the pipeline signals a reorg via `add_block` (parent-hash mismatch),
     /// discards in-flight submissions, resets the pipeline, and restarts
-    /// sequential catchup from `safe_head + 1`. The triggering block will be
+    /// sequential catchup from `local_safe_l2 + 1`. The triggering block will be
     /// re-delivered by the sequential poller.
-    fn on_block(&mut self, block: Box<BaseBlock>) {
+    async fn on_block(&mut self, block: Box<BaseBlock>) -> Result<(), BatchDriverError> {
         let number = block.header.number;
         match self.pipeline.add_block(*block) {
             Ok(()) => {
                 debug!(block = %number, "added unsafe block to pipeline");
             }
             Err((e, _block)) => {
-                let safe_head = self.safe_head_rx.as_ref().map(|rx| *rx.borrow()).unwrap_or(0);
+                let safe_head = Self::reset_safe_head(
+                    self.local_safe_head_provider.clone(),
+                    self.safe_head_rx.as_ref().map(|rx| *rx.borrow()),
+                )
+                .await?
+                .unwrap_or(0);
                 let catchup_from = safe_head + 1;
                 warn!(
                     block = %number,
-                    safe_head = %safe_head,
+                    local_safe_l2 = %safe_head,
                     catchup_from = %catchup_from,
                     error = %e,
-                    "reorg detected during block ingestion, resetting pipeline and catching up from safe head"
+                    "reorg detected during block ingestion, resetting pipeline and catching up from local safe head"
                 );
                 self.submissions.discard();
                 self.pipeline.reset();
                 self.source.reset_catchup(catchup_from);
             }
         }
+        Ok(())
+    }
+
+    /// Return the reset boundary local safe head.
+    ///
+    /// Prefer a fresh local-safe-head provider when one is configured. The watch
+    /// channel is retained as a fallback for tests and custom embedders that do
+    /// not wire a provider.
+    async fn reset_safe_head(
+        provider: Option<Arc<dyn LocalSafeHeadProvider>>,
+        watch_value: Option<u64>,
+    ) -> Result<Option<u64>, BatchDriverError> {
+        if let Some(provider) = provider {
+            let n = provider
+                .local_safe_l2_number()
+                .await
+                .map_err(|e| BatchDriverError::LocalSafeHead(e.to_string()))?;
+            return Ok(Some(n));
+        }
+
+        Ok(watch_value)
     }
 
     /// Block on the next external event using a biased `tokio::select!`.
@@ -288,7 +334,7 @@ where
     /// resets the pipeline, then drops `Block` and `Flush` source events until
     /// [`AdminCommand::Resume`] is received. Reorg events propagate regardless
     /// of pause state. On resume the source is reset to catch up sequentially
-    /// from the last known safe L2 head.
+    /// from the last known local safe L2 head.
     ///
     /// Non-fatal L1 head source errors loop internally to avoid polluting the
     /// return type with a no-op variant.
@@ -309,14 +355,17 @@ where
                             info!(stopped = true, "batcher paused via admin");
                         }
                         AdminCommand::Resume => {
-                            let safe_head =
-                                self.safe_head_rx.as_ref().map(|rx| *rx.borrow());
+                            let safe_head = Self::reset_safe_head(
+                                self.local_safe_head_provider.clone(),
+                                self.safe_head_rx.as_ref().map(|rx| *rx.borrow()),
+                            )
+                            .await?;
                             if let Some(n) = safe_head {
                                 self.source.reset_catchup(n + 1);
                                 info!(
                                     stopped = false,
                                     catchup_from = %(n + 1),
-                                    "batcher resumed via admin, catching up from safe head"
+                                    "batcher resumed via admin, catching up from local safe head"
                                 );
                             } else {
                                 info!(stopped = false, "batcher resumed via admin");

--- a/crates/batcher/core/src/driver.rs
+++ b/crates/batcher/core/src/driver.rs
@@ -17,6 +17,9 @@ use crate::{
     LocalSafeHeadProvider, SubmissionQueue, ThrottleClient, ThrottleController, event::DriverEvent,
 };
 
+/// Delay between reset-boundary local-safe-head retries.
+const RESET_SAFE_HEAD_RETRY_DELAY: Duration = Duration::from_secs(5);
+
 /// Async orchestration loop for the batcher.
 ///
 /// Combines a [`BatchPipeline`] (encoding), an [`UnsafeBlockSource`] (L2 block delivery),
@@ -204,10 +207,11 @@ where
                 }
                 DriverEvent::Reorg(head) => {
                     let safe_head = Self::reset_safe_head(
+                        self.runtime.clone(),
                         self.local_safe_head_provider.clone(),
                         self.safe_head_rx.as_ref().map(|rx| *rx.borrow()),
                     )
-                    .await?
+                    .await
                     .unwrap_or(0);
                     let catchup_from = safe_head + 1;
                     warn!(
@@ -282,10 +286,11 @@ where
             }
             Err((e, _block)) => {
                 let safe_head = Self::reset_safe_head(
+                    self.runtime.clone(),
                     self.local_safe_head_provider.clone(),
                     self.safe_head_rx.as_ref().map(|rx| *rx.borrow()),
                 )
-                .await?
+                .await
                 .unwrap_or(0);
                 let catchup_from = safe_head + 1;
                 warn!(
@@ -307,20 +312,35 @@ where
     ///
     /// Prefer a fresh local-safe-head provider when one is configured. The watch
     /// channel is retained as a fallback for tests and custom embedders that do
-    /// not wire a provider.
+    /// not wire a provider. Provider errors are retried until the fetch succeeds
+    /// or the runtime is cancelled; falling back to a stale watch value while a
+    /// provider exists would reintroduce the reorg skip hazard.
     async fn reset_safe_head(
+        runtime: R,
         provider: Option<Arc<dyn LocalSafeHeadProvider>>,
         watch_value: Option<u64>,
-    ) -> Result<Option<u64>, BatchDriverError> {
+    ) -> Option<u64> {
         if let Some(provider) = provider {
-            let n = provider
-                .local_safe_l2_number()
-                .await
-                .map_err(|e| BatchDriverError::LocalSafeHead(e.to_string()))?;
-            return Ok(Some(n));
+            loop {
+                match provider.local_safe_l2_number().await {
+                    Ok(n) => return Some(n),
+                    Err(e) => {
+                        warn!(
+                            error = %e,
+                            retry_delay = ?RESET_SAFE_HEAD_RETRY_DELAY,
+                            "failed to fetch local safe head for reset boundary, retrying"
+                        );
+                        tokio::select! {
+                            biased;
+                            _ = runtime.cancelled() => return watch_value,
+                            _ = runtime.sleep(RESET_SAFE_HEAD_RETRY_DELAY) => {}
+                        }
+                    }
+                }
+            }
         }
 
-        Ok(watch_value)
+        watch_value
     }
 
     /// Block on the next external event using a biased `tokio::select!`.
@@ -356,10 +376,11 @@ where
                         }
                         AdminCommand::Resume => {
                             let safe_head = Self::reset_safe_head(
+                                self.runtime.clone(),
                                 self.local_safe_head_provider.clone(),
                                 self.safe_head_rx.as_ref().map(|rx| *rx.borrow()),
                             )
-                            .await?;
+                            .await;
                             if let Some(n) = safe_head {
                                 self.source.reset_catchup(n + 1);
                                 info!(

--- a/crates/batcher/core/src/error.rs
+++ b/crates/batcher/core/src/error.rs
@@ -17,4 +17,7 @@ pub enum BatchDriverError {
     /// in the submitted L2 block sequence.
     #[error("fatal pipeline step error: {0}")]
     Step(#[from] StepError),
+    /// The current local safe L2 head could not be fetched for a reset boundary.
+    #[error("local safe head provider error: {0}")]
+    LocalSafeHead(String),
 }

--- a/crates/batcher/core/src/error.rs
+++ b/crates/batcher/core/src/error.rs
@@ -17,7 +17,4 @@ pub enum BatchDriverError {
     /// in the submitted L2 block sequence.
     #[error("fatal pipeline step error: {0}")]
     Step(#[from] StepError),
-    /// The current local safe L2 head could not be fetched for a reset boundary.
-    #[error("local safe head provider error: {0}")]
-    LocalSafeHead(String),
 }

--- a/crates/batcher/core/src/event.rs
+++ b/crates/batcher/core/src/event.rs
@@ -23,6 +23,8 @@ pub enum DriverEvent {
     L1Head(u64),
     /// Safe L2 head advanced (from watch channel).
     SafeHead(u64),
+    /// Fresh local safe head lookup completed for a reset boundary.
+    ResetSafeHead(Option<u64>),
     /// L1 head source permanently closed (Exhausted or Closed error).
     L1SourceClosed,
 }

--- a/crates/batcher/core/src/event.rs
+++ b/crates/batcher/core/src/event.rs
@@ -6,6 +6,21 @@ use base_protocol::L2BlockInfo;
 
 use crate::TxOutcome;
 
+/// Result of an asynchronous local safe head lookup for a reset boundary.
+#[derive(Debug)]
+pub enum ResetSafeHeadResult {
+    /// The lookup task returned a reset boundary.
+    Resolved {
+        /// Safe head to catch up from, when one is available.
+        safe_head: Option<u64>,
+    },
+    /// The lookup task closed before sending a result, leaving only the watch fallback.
+    Closed {
+        /// Last local safe head observed on the watch channel before the lookup started.
+        fallback: Option<u64>,
+    },
+}
+
 /// Events the driver can receive from external sources during the I/O phase.
 #[derive(Debug)]
 pub enum DriverEvent {
@@ -24,7 +39,7 @@ pub enum DriverEvent {
     /// Safe L2 head advanced (from watch channel).
     SafeHead(u64),
     /// Fresh local safe head lookup completed for a reset boundary.
-    ResetSafeHead(Option<u64>),
+    ResetSafeHead(ResetSafeHeadResult),
     /// L1 head source permanently closed (Exhausted or Closed error).
     L1SourceClosed,
 }

--- a/crates/batcher/core/src/lib.rs
+++ b/crates/batcher/core/src/lib.rs
@@ -30,6 +30,9 @@ pub use config::BatchDriverConfig;
 mod event;
 pub use event::DriverEvent;
 
+mod local_safe_head;
+pub use local_safe_head::{LocalSafeHeadProvider, LocalSafeHeadResult};
+
 mod admin;
 pub use admin::{
     ADMIN_CHANNEL_CAPACITY, AdminCommand, AdminError, AdminHandle, AdminResult, BatcherStatus,

--- a/crates/batcher/core/src/lib.rs
+++ b/crates/batcher/core/src/lib.rs
@@ -28,7 +28,7 @@ mod config;
 pub use config::BatchDriverConfig;
 
 mod event;
-pub use event::DriverEvent;
+pub use event::{DriverEvent, ResetSafeHeadResult};
 
 mod local_safe_head;
 pub use local_safe_head::{LocalSafeHeadProvider, LocalSafeHeadResult};

--- a/crates/batcher/core/src/local_safe_head.rs
+++ b/crates/batcher/core/src/local_safe_head.rs
@@ -1,0 +1,18 @@
+//! Provider trait for fetching the current local safe L2 head.
+
+use std::error::Error;
+
+use futures::future::BoxFuture;
+
+/// Result type returned by local-safe-head providers.
+pub type LocalSafeHeadResult = Result<u64, Box<dyn Error + Send + Sync>>;
+
+/// Fetches the current local safe L2 block number from the rollup node.
+///
+/// Reset and catchup decisions must use a fresh local safe head rather than a
+/// cached monotonic safe-head watch value, because L1 reorgs can move the local
+/// safe head backward.
+pub trait LocalSafeHeadProvider: std::fmt::Debug + Send + Sync + 'static {
+    /// Return the current local safe L2 block number.
+    fn local_safe_l2_number(&self) -> BoxFuture<'_, LocalSafeHeadResult>;
+}

--- a/crates/batcher/core/tests/pause_resume.rs
+++ b/crates/batcher/core/tests/pause_resume.rs
@@ -8,8 +8,8 @@ use std::{
 use alloy_primitives::Address;
 use async_trait::async_trait;
 use base_batcher_core::{
-    AdminHandle, BatchDriver, BatchDriverConfig, DaThrottle, NoopThrottleClient,
-    ThrottleController,
+    AdminHandle, BatchDriver, BatchDriverConfig, DaThrottle, LocalSafeHeadProvider,
+    LocalSafeHeadResult, NoopThrottleClient, ThrottleController,
     test_utils::{
         DriverFixture, ImmediateConfirmTxManager, PendingL1HeadSource, Recorded, TrackingPipeline,
     },
@@ -23,7 +23,19 @@ use base_runtime::{
     Cancellation, Clock, Spawner,
     deterministic::{Config, Runner},
 };
+use futures::future::BoxFuture;
 use tokio::sync::watch;
+
+#[derive(Debug)]
+struct StaticLocalSafeHeadProvider {
+    number: u64,
+}
+
+impl LocalSafeHeadProvider for StaticLocalSafeHeadProvider {
+    fn local_safe_l2_number(&self) -> BoxFuture<'_, LocalSafeHeadResult> {
+        Box::pin(async move { Ok(self.number) })
+    }
+}
 
 /// Source that tracks `reset_catchup` calls and parks forever on `next()`.
 #[derive(Debug)]
@@ -120,6 +132,51 @@ fn test_resume_triggers_catchup_from_safe_head() {
             *catchup_args.lock().unwrap(),
             vec![43],
             "source must be reset to safe_head + 1 on resume"
+        );
+    });
+}
+
+/// Resume uses a fresh local safe head provider when available, so a stale
+/// pre-reorg pruning watch cannot skip canonical blocks during catchup.
+#[test]
+fn test_resume_uses_fresh_local_safe_head_over_stale_watch() {
+    Runner::start(Config::seeded(0), |ctx| async move {
+        let (source, catchup_args) = TrackingSource::new();
+        let (admin_handle, admin_rx) = AdminHandle::channel();
+        let (safe_head_tx, safe_head_rx) = watch::channel::<u64>(150);
+
+        let driver = BatchDriver::new(
+            ctx.clone(),
+            TrackingPipeline::new(Arc::new(Mutex::new(Recorded::default()))),
+            source,
+            ImmediateConfirmTxManager { l1_block: 1 },
+            BatchDriverConfig {
+                inbox: Address::ZERO,
+                max_pending_transactions: 1,
+                drain_timeout: Duration::from_millis(10),
+                force_blobs_when_throttling: true,
+            },
+            DaThrottle::new(ThrottleController::noop(), Arc::new(NoopThrottleClient)),
+            PendingL1HeadSource,
+        )
+        .with_admin_rx(admin_rx)
+        .with_safe_head_rx(safe_head_rx)
+        .with_local_safe_head_provider(Arc::new(StaticLocalSafeHeadProvider { number: 100 }));
+
+        let handle = ctx.spawn(driver.run());
+
+        admin_handle.pause().await.unwrap();
+        ctx.sleep(Duration::from_millis(10)).await;
+        admin_handle.resume().await.unwrap();
+        ctx.sleep(Duration::from_millis(10)).await;
+        ctx.cancel();
+
+        drop(safe_head_tx);
+        assert!(handle.await.unwrap().is_ok());
+        assert_eq!(
+            *catchup_args.lock().unwrap(),
+            vec![101],
+            "resume catchup must start from fresh local_safe_l2 + 1"
         );
     });
 }

--- a/crates/batcher/core/tests/reorg.rs
+++ b/crates/batcher/core/tests/reorg.rs
@@ -9,8 +9,8 @@ use std::{
 use alloy_primitives::{Address, B256};
 use async_trait::async_trait;
 use base_batcher_core::{
-    BatchDriver, BatchDriverConfig, DaThrottle, LocalSafeHeadProvider, LocalSafeHeadResult,
-    NoopThrottleClient, ThrottleController,
+    AdminHandle, BatchDriver, BatchDriverConfig, DaThrottle, LocalSafeHeadProvider,
+    LocalSafeHeadResult, NoopThrottleClient, ThrottleController,
     test_utils::{
         ImmediateConfirmTxManager, OneBlockSource, OneReorgPipeline, PendingL1HeadSource, Recorded,
         ReorgPipeline, TrackingPipeline,
@@ -56,6 +56,15 @@ impl LocalSafeHeadProvider for QueuedLocalSafeHeadProvider {
                 Err(e) => Err(e.into()),
             }
         })
+    }
+}
+
+#[derive(Debug)]
+struct FailingLocalSafeHeadProvider;
+
+impl LocalSafeHeadProvider for FailingLocalSafeHeadProvider {
+    fn local_safe_l2_number(&self) -> BoxFuture<'_, LocalSafeHeadResult> {
+        Box::pin(async { Err("sync status unavailable".into()) })
     }
 }
 
@@ -305,6 +314,61 @@ fn test_l2_reorg_event_retries_local_safe_head_fetch_failure() {
             "pipeline must still be reset after retry succeeds"
         );
     });
+}
+
+/// Local-safe retry must not block the driver's control plane. The source arm
+/// stays parked until the reset boundary is resolved, but admin commands should
+/// still be serviced while the provider retry task waits for the next attempt.
+#[test]
+fn test_l2_reorg_event_local_safe_head_retry_does_not_block_admin() {
+    Runner::start(
+        Config { seed: 0, cycle_limit: None, timeout: Some(Duration::from_secs(1)) },
+        |ctx| async move {
+            let recorded = Arc::new(Mutex::new(Recorded::default()));
+            let pipeline = TrackingPipeline::new(Arc::clone(&recorded));
+            let reorg_head = L2BlockInfo::new(
+                BlockInfo::new(B256::ZERO, 150, B256::ZERO, 0),
+                Default::default(),
+                0,
+            );
+            let (source, catchup_args) =
+                ReorgThenPendingSource::new(L2BlockEvent::Reorg { new_safe_head: reorg_head });
+            let (admin_handle, admin_rx) = AdminHandle::channel();
+            let (safe_head_tx, safe_head_rx) = watch::channel::<u64>(150);
+
+            let driver = BatchDriver::new(
+                ctx.clone(),
+                pipeline,
+                source,
+                ImmediateConfirmTxManager { l1_block: 1 },
+                BatchDriverConfig {
+                    inbox: Address::ZERO,
+                    max_pending_transactions: 1,
+                    drain_timeout: Duration::from_millis(10),
+                    force_blobs_when_throttling: true,
+                },
+                DaThrottle::new(ThrottleController::noop(), Arc::new(NoopThrottleClient)),
+                PendingL1HeadSource,
+            )
+            .with_admin_rx(admin_rx)
+            .with_safe_head_rx(safe_head_rx)
+            .with_local_safe_head_provider(Arc::new(FailingLocalSafeHeadProvider));
+            let handle = ctx.spawn(driver.run());
+
+            ctx.sleep(Duration::from_millis(10)).await;
+
+            let status = admin_handle.get_status().await.unwrap();
+            assert!(!status.stopped, "admin status must respond while local-safe lookup retries");
+            assert!(
+                catchup_args.lock().unwrap().is_empty(),
+                "source catchup must wait for a fresh local safe head"
+            );
+
+            ctx.cancel();
+            drop(safe_head_tx);
+            assert!(handle.await.unwrap().is_ok());
+        },
+    );
 }
 
 /// Parent-hash mismatch reorgs use the same reset boundary as explicit source

--- a/crates/batcher/core/tests/reorg.rs
+++ b/crates/batcher/core/tests/reorg.rs
@@ -1,6 +1,7 @@
 //! Integration tests for reorg handling in [`BatchDriver`].
 
 use std::{
+    collections::VecDeque,
     sync::{Arc, Mutex},
     time::Duration,
 };
@@ -33,6 +34,28 @@ struct StaticLocalSafeHeadProvider {
 impl LocalSafeHeadProvider for StaticLocalSafeHeadProvider {
     fn local_safe_l2_number(&self) -> BoxFuture<'_, LocalSafeHeadResult> {
         Box::pin(async move { Ok(self.number) })
+    }
+}
+
+#[derive(Debug)]
+struct QueuedLocalSafeHeadProvider {
+    values: Mutex<VecDeque<Result<u64, &'static str>>>,
+}
+
+impl QueuedLocalSafeHeadProvider {
+    fn new(values: impl IntoIterator<Item = Result<u64, &'static str>>) -> Self {
+        Self { values: Mutex::new(values.into_iter().collect()) }
+    }
+}
+
+impl LocalSafeHeadProvider for QueuedLocalSafeHeadProvider {
+    fn local_safe_l2_number(&self) -> BoxFuture<'_, LocalSafeHeadResult> {
+        Box::pin(async move {
+            match self.values.lock().unwrap().pop_front().expect("missing queued value") {
+                Ok(n) => Ok(n),
+                Err(e) => Err(e.into()),
+            }
+        })
     }
 }
 
@@ -229,6 +252,58 @@ fn test_l2_reorg_event_uses_fresh_local_safe_head_over_stale_watch() {
             "reorg catchup must start from fresh local_safe_l2 + 1"
         );
         assert_eq!(recorded.lock().unwrap().resets, 1, "pipeline must still be reset on reorg");
+    });
+}
+
+/// If fetching the fresh local safe head fails during reorg handling, the
+/// driver should retry instead of crashing or falling back to the stale watch.
+#[test]
+fn test_l2_reorg_event_retries_local_safe_head_fetch_failure() {
+    Runner::start(Config::seeded(0), |ctx| async move {
+        let recorded = Arc::new(Mutex::new(Recorded::default()));
+        let pipeline = TrackingPipeline::new(Arc::clone(&recorded));
+        let reorg_head =
+            L2BlockInfo::new(BlockInfo::new(B256::ZERO, 150, B256::ZERO, 0), Default::default(), 0);
+        let (source, catchup_args) =
+            ReorgThenPendingSource::new(L2BlockEvent::Reorg { new_safe_head: reorg_head });
+        let (safe_head_tx, safe_head_rx) = watch::channel::<u64>(150);
+
+        let driver = BatchDriver::new(
+            ctx.clone(),
+            pipeline,
+            source,
+            ImmediateConfirmTxManager { l1_block: 1 },
+            BatchDriverConfig {
+                inbox: Address::ZERO,
+                max_pending_transactions: 1,
+                drain_timeout: Duration::from_millis(10),
+                force_blobs_when_throttling: true,
+            },
+            DaThrottle::new(ThrottleController::noop(), Arc::new(NoopThrottleClient)),
+            PendingL1HeadSource,
+        )
+        .with_safe_head_rx(safe_head_rx)
+        .with_local_safe_head_provider(Arc::new(QueuedLocalSafeHeadProvider::new([
+            Err("sync status unavailable"),
+            Ok(100),
+        ])));
+        let handle = ctx.spawn(driver.run());
+
+        ctx.sleep(Duration::from_secs(6)).await;
+        ctx.cancel();
+
+        drop(safe_head_tx);
+        assert!(handle.await.unwrap().is_ok());
+        assert_eq!(
+            *catchup_args.lock().unwrap(),
+            vec![101],
+            "reorg catchup must retry fresh local_safe_l2 and not use stale watch"
+        );
+        assert_eq!(
+            recorded.lock().unwrap().resets,
+            1,
+            "pipeline must still be reset after retry succeeds"
+        );
     });
 }
 

--- a/crates/batcher/core/tests/reorg.rs
+++ b/crates/batcher/core/tests/reorg.rs
@@ -2,7 +2,10 @@
 
 use std::{
     collections::VecDeque,
-    sync::{Arc, Mutex},
+    sync::{
+        Arc, Mutex,
+        atomic::{AtomicUsize, Ordering},
+    },
     time::Duration,
 };
 
@@ -65,6 +68,18 @@ struct FailingLocalSafeHeadProvider;
 impl LocalSafeHeadProvider for FailingLocalSafeHeadProvider {
     fn local_safe_l2_number(&self) -> BoxFuture<'_, LocalSafeHeadResult> {
         Box::pin(async { Err("sync status unavailable".into()) })
+    }
+}
+
+#[derive(Debug, Default)]
+struct FirstCallPendingLocalSafeHeadProvider {
+    calls: AtomicUsize,
+}
+
+impl LocalSafeHeadProvider for FirstCallPendingLocalSafeHeadProvider {
+    fn local_safe_l2_number(&self) -> BoxFuture<'_, LocalSafeHeadResult> {
+        let call = self.calls.fetch_add(1, Ordering::SeqCst);
+        Box::pin(async move { if call == 0 { std::future::pending().await } else { Ok(100) } })
     }
 }
 
@@ -369,6 +384,61 @@ fn test_l2_reorg_event_local_safe_head_retry_does_not_block_admin() {
             assert!(handle.await.unwrap().is_ok());
         },
     );
+}
+
+/// A second reset while a local-safe lookup is already pending should replace
+/// the pending lookup. Otherwise an old unresolved task can keep the source
+/// parked forever.
+#[test]
+fn test_l2_reorg_event_replaces_pending_local_safe_head_lookup() {
+    Runner::start(Config::seeded(0), |ctx| async move {
+        let recorded = Arc::new(Mutex::new(Recorded::default()));
+        let pipeline = TrackingPipeline::new(Arc::clone(&recorded));
+        let reorg_head =
+            L2BlockInfo::new(BlockInfo::new(B256::ZERO, 150, B256::ZERO, 0), Default::default(), 0);
+        let (source, catchup_args) =
+            ReorgThenPendingSource::new(L2BlockEvent::Reorg { new_safe_head: reorg_head });
+        let (admin_handle, admin_rx) = AdminHandle::channel();
+        let (safe_head_tx, safe_head_rx) = watch::channel::<u64>(150);
+
+        let provider = Arc::new(FirstCallPendingLocalSafeHeadProvider::default());
+        let driver = BatchDriver::new(
+            ctx.clone(),
+            pipeline,
+            source,
+            ImmediateConfirmTxManager { l1_block: 1 },
+            BatchDriverConfig {
+                inbox: Address::ZERO,
+                max_pending_transactions: 1,
+                drain_timeout: Duration::from_millis(10),
+                force_blobs_when_throttling: true,
+            },
+            DaThrottle::new(ThrottleController::noop(), Arc::new(NoopThrottleClient)),
+            PendingL1HeadSource,
+        )
+        .with_admin_rx(admin_rx)
+        .with_safe_head_rx(safe_head_rx)
+        .with_local_safe_head_provider(provider);
+        let handle = ctx.spawn(driver.run());
+
+        ctx.sleep(Duration::from_millis(10)).await;
+        admin_handle.resume().await.unwrap();
+        ctx.sleep(Duration::from_millis(10)).await;
+        ctx.cancel();
+
+        drop(safe_head_tx);
+        assert!(handle.await.unwrap().is_ok());
+        assert_eq!(
+            *catchup_args.lock().unwrap(),
+            vec![101],
+            "second reset must replace the unresolved local-safe lookup and catch up"
+        );
+        assert_eq!(
+            recorded.lock().unwrap().resets,
+            2,
+            "pipeline should be reset for the original reorg and the replacement reset"
+        );
+    });
 }
 
 /// Parent-hash mismatch reorgs use the same reset boundary as explicit source

--- a/crates/batcher/core/tests/reorg.rs
+++ b/crates/batcher/core/tests/reorg.rs
@@ -6,19 +6,63 @@ use std::{
 };
 
 use alloy_primitives::{Address, B256};
+use async_trait::async_trait;
 use base_batcher_core::{
-    BatchDriver, BatchDriverConfig, DaThrottle, NoopThrottleClient, ThrottleController,
+    BatchDriver, BatchDriverConfig, DaThrottle, LocalSafeHeadProvider, LocalSafeHeadResult,
+    NoopThrottleClient, ThrottleController,
     test_utils::{
         ImmediateConfirmTxManager, OneBlockSource, OneReorgPipeline, PendingL1HeadSource, Recorded,
         ReorgPipeline, TrackingPipeline,
     },
 };
-use base_batcher_source::{ChannelBlockSource, L2BlockEvent};
+use base_batcher_source::{ChannelBlockSource, L2BlockEvent, SourceError, UnsafeBlockSource};
+use base_common_consensus::BaseBlock;
 use base_protocol::{BlockInfo, L2BlockInfo};
 use base_runtime::{
     Cancellation, Clock, Spawner,
     deterministic::{Config, Runner},
 };
+use futures::future::BoxFuture;
+use tokio::sync::watch;
+
+#[derive(Debug)]
+struct StaticLocalSafeHeadProvider {
+    number: u64,
+}
+
+impl LocalSafeHeadProvider for StaticLocalSafeHeadProvider {
+    fn local_safe_l2_number(&self) -> BoxFuture<'_, LocalSafeHeadResult> {
+        Box::pin(async move { Ok(self.number) })
+    }
+}
+
+#[derive(Debug)]
+struct ReorgThenPendingSource {
+    event: Option<L2BlockEvent>,
+    catchup_args: Arc<Mutex<Vec<u64>>>,
+}
+
+impl ReorgThenPendingSource {
+    fn new(event: L2BlockEvent) -> (Self, Arc<Mutex<Vec<u64>>>) {
+        let catchup_args = Arc::new(Mutex::new(Vec::new()));
+        (Self { event: Some(event), catchup_args: Arc::clone(&catchup_args) }, catchup_args)
+    }
+}
+
+#[async_trait]
+impl UnsafeBlockSource for ReorgThenPendingSource {
+    async fn next(&mut self) -> Result<L2BlockEvent, SourceError> {
+        if let Some(event) = self.event.take() {
+            return Ok(event);
+        }
+
+        std::future::pending().await
+    }
+
+    fn reset_catchup(&mut self, start_from: u64) {
+        self.catchup_args.lock().unwrap().push(start_from);
+    }
+}
 
 /// When `add_block` returns `ReorgError`, the driver must reset the pipeline and
 /// call `reset_catchup` on the source so it re-delivers all post-reorg blocks
@@ -138,6 +182,99 @@ fn test_l2_reorg_event_resets_pipeline() {
             recorded.lock().unwrap().resets,
             1,
             "pipeline must be reset when source delivers a Reorg event"
+        );
+    });
+}
+
+/// When the safe-head watch still contains a stale pre-reorg value, the driver
+/// must fetch the current local safe head for the reset boundary instead of
+/// skipping ahead to the stale watch value.
+#[test]
+fn test_l2_reorg_event_uses_fresh_local_safe_head_over_stale_watch() {
+    Runner::start(Config::seeded(0), |ctx| async move {
+        let recorded = Arc::new(Mutex::new(Recorded::default()));
+        let pipeline = TrackingPipeline::new(Arc::clone(&recorded));
+        let reorg_head =
+            L2BlockInfo::new(BlockInfo::new(B256::ZERO, 150, B256::ZERO, 0), Default::default(), 0);
+        let (source, catchup_args) =
+            ReorgThenPendingSource::new(L2BlockEvent::Reorg { new_safe_head: reorg_head });
+        let (safe_head_tx, safe_head_rx) = watch::channel::<u64>(150);
+
+        let driver = BatchDriver::new(
+            ctx.clone(),
+            pipeline,
+            source,
+            ImmediateConfirmTxManager { l1_block: 1 },
+            BatchDriverConfig {
+                inbox: Address::ZERO,
+                max_pending_transactions: 1,
+                drain_timeout: Duration::from_millis(10),
+                force_blobs_when_throttling: true,
+            },
+            DaThrottle::new(ThrottleController::noop(), Arc::new(NoopThrottleClient)),
+            PendingL1HeadSource,
+        )
+        .with_safe_head_rx(safe_head_rx)
+        .with_local_safe_head_provider(Arc::new(StaticLocalSafeHeadProvider { number: 100 }));
+        let handle = ctx.spawn(driver.run());
+
+        ctx.sleep(Duration::from_millis(50)).await;
+        ctx.cancel();
+
+        drop(safe_head_tx);
+        assert!(handle.await.unwrap().is_ok());
+        assert_eq!(
+            *catchup_args.lock().unwrap(),
+            vec![101],
+            "reorg catchup must start from fresh local_safe_l2 + 1"
+        );
+        assert_eq!(recorded.lock().unwrap().resets, 1, "pipeline must still be reset on reorg");
+    });
+}
+
+/// Parent-hash mismatch reorgs use the same reset boundary as explicit source
+/// reorg events: fresh local safe head, not the potentially stale pruning watch.
+#[test]
+fn test_add_block_reorg_uses_fresh_local_safe_head_over_stale_watch() {
+    Runner::start(Config::seeded(0), |ctx| async move {
+        let recorded = Arc::new(Mutex::new(Recorded::default()));
+        let pipeline = ReorgPipeline::new(Arc::clone(&recorded));
+        let (source, catchup_args) =
+            ReorgThenPendingSource::new(L2BlockEvent::Block(Box::<BaseBlock>::default()));
+        let (safe_head_tx, safe_head_rx) = watch::channel::<u64>(150);
+
+        let driver = BatchDriver::new(
+            ctx.clone(),
+            pipeline,
+            source,
+            ImmediateConfirmTxManager { l1_block: 1 },
+            BatchDriverConfig {
+                inbox: Address::ZERO,
+                max_pending_transactions: 1,
+                drain_timeout: Duration::from_millis(10),
+                force_blobs_when_throttling: true,
+            },
+            DaThrottle::new(ThrottleController::noop(), Arc::new(NoopThrottleClient)),
+            PendingL1HeadSource,
+        )
+        .with_safe_head_rx(safe_head_rx)
+        .with_local_safe_head_provider(Arc::new(StaticLocalSafeHeadProvider { number: 100 }));
+        let handle = ctx.spawn(driver.run());
+
+        ctx.sleep(Duration::from_millis(50)).await;
+        ctx.cancel();
+
+        drop(safe_head_tx);
+        assert!(handle.await.unwrap().is_ok());
+        assert_eq!(
+            *catchup_args.lock().unwrap(),
+            vec![101],
+            "add_block reorg catchup must start from fresh local_safe_l2 + 1"
+        );
+        assert_eq!(
+            recorded.lock().unwrap().resets,
+            1,
+            "pipeline must still be reset on add_block reorg"
         );
     });
 }

--- a/crates/batcher/service/src/lib.rs
+++ b/crates/batcher/service/src/lib.rs
@@ -26,7 +26,7 @@ mod throttle;
 pub use throttle::RpcThrottleClient;
 
 mod safe_head_poller;
-pub use safe_head_poller::{RpcLocalSafeHeadProvider, SafeHeadPoller, SafeHeadProvider};
+pub use safe_head_poller::{RpcLocalSafeHeadProvider, SafeHeadPoller};
 
 mod service;
 pub use service::{BatcherService, ReadyBatcher};

--- a/crates/batcher/service/src/lib.rs
+++ b/crates/batcher/service/src/lib.rs
@@ -26,7 +26,7 @@ mod throttle;
 pub use throttle::RpcThrottleClient;
 
 mod safe_head_poller;
-pub use safe_head_poller::{SafeHeadPoller, SafeHeadProvider};
+pub use safe_head_poller::{RpcLocalSafeHeadProvider, SafeHeadPoller, SafeHeadProvider};
 
 mod service;
 pub use service::{BatcherService, ReadyBatcher};

--- a/crates/batcher/service/src/safe_head_poller.rs
+++ b/crates/batcher/service/src/safe_head_poller.rs
@@ -1,47 +1,65 @@
-//! Background poller that keeps the safe L2 head watch channel up to date.
+//! Background poller that keeps the local safe L2 head watch channel up to date.
 
-use std::{future::Future, time::Duration};
+use std::{error::Error, time::Duration};
 
+use base_batcher_core::{LocalSafeHeadProvider, LocalSafeHeadResult};
+use base_consensus_rpc::RollupNodeApiClient;
+use futures::future::BoxFuture;
 use tokio::sync::watch;
 use tokio_util::sync::CancellationToken;
 use tracing::warn;
 
-/// Fetches the current safe L2 head block number from the rollup node.
-///
-/// The canonical implementation delegates to
-/// [`RollupNodeApiClient::sync_status`](base_consensus_rpc::RollupNodeApiClient).
-pub trait SafeHeadProvider: Send + Sync + 'static {
-    /// Return the current safe L2 head block number.
-    fn safe_l2_number(
-        &self,
-    ) -> impl Future<Output = Result<u64, Box<dyn std::error::Error + Send + Sync>>> + Send + '_;
+/// Compatibility export for callers that import the provider trait from this crate.
+pub use base_batcher_core::LocalSafeHeadProvider as SafeHeadProvider;
+
+/// RPC-backed provider for the current local safe L2 head.
+#[derive(Clone)]
+pub struct RpcLocalSafeHeadProvider {
+    client: jsonrpsee::http_client::HttpClient,
 }
 
-impl SafeHeadProvider for jsonrpsee::http_client::HttpClient {
-    async fn safe_l2_number(&self) -> Result<u64, Box<dyn std::error::Error + Send + Sync>> {
-        use base_consensus_rpc::RollupNodeApiClient;
-        let status = self.sync_status().await?;
-        Ok(status.safe_l2.block_info.number)
+impl std::fmt::Debug for RpcLocalSafeHeadProvider {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RpcLocalSafeHeadProvider").finish_non_exhaustive()
     }
 }
 
-/// Polls a [`SafeHeadProvider`] at a fixed interval and advances a watch
-/// channel when the safe L2 head moves forward.
+impl RpcLocalSafeHeadProvider {
+    /// Create a new RPC-backed local safe head provider.
+    pub const fn new(client: jsonrpsee::http_client::HttpClient) -> Self {
+        Self { client }
+    }
+
+    /// Fetch the current local safe L2 block number.
+    pub async fn fetch_local_safe_l2_number(&self) -> Result<u64, Box<dyn Error + Send + Sync>> {
+        let status = self.client.sync_status().await?;
+        Ok(status.local_safe_l2.block_info.number)
+    }
+}
+
+impl LocalSafeHeadProvider for RpcLocalSafeHeadProvider {
+    fn local_safe_l2_number(&self) -> BoxFuture<'_, LocalSafeHeadResult> {
+        Box::pin(self.fetch_local_safe_l2_number())
+    }
+}
+
+/// Polls a [`LocalSafeHeadProvider`] at a fixed interval and updates a watch
+/// channel when the local safe L2 head changes.
 ///
 /// The poller waits `poll_interval` before the first call, then loops.
-/// When the safe head advances, it calls [`watch::Sender::send_if_modified`]
+/// When the local safe head changes, it calls [`watch::Sender::send_if_modified`]
 /// so receivers are only woken when the value actually changes.
 ///
 /// Stops cleanly when the [`CancellationToken`] passed to [`run`](Self::run)
 /// is cancelled — at most one in-flight RPC call is waited for before exit.
 #[derive(Debug)]
-pub struct SafeHeadPoller<C: SafeHeadProvider> {
+pub struct SafeHeadPoller<C: LocalSafeHeadProvider> {
     provider: C,
     poll_interval: Duration,
     safe_head_tx: watch::Sender<u64>,
 }
 
-impl<C: SafeHeadProvider> SafeHeadPoller<C> {
+impl<C: LocalSafeHeadProvider> SafeHeadPoller<C> {
     /// Create a new [`SafeHeadPoller`].
     pub const fn new(
         provider: C,
@@ -62,10 +80,10 @@ impl<C: SafeHeadProvider> SafeHeadPoller<C> {
                 _ = cancellation.cancelled() => break,
                 _ = tokio::time::sleep(self.poll_interval) => {}
             }
-            match self.provider.safe_l2_number().await {
+            match self.provider.local_safe_l2_number().await {
                 Ok(n) => {
                     self.safe_head_tx.send_if_modified(|old| {
-                        if n > *old {
+                        if n != *old {
                             *old = n;
                             true
                         } else {
@@ -74,7 +92,7 @@ impl<C: SafeHeadProvider> SafeHeadPoller<C> {
                     });
                 }
                 Err(e) => {
-                    warn!(error = %e, "failed to poll optimism_syncStatus for safe head");
+                    warn!(error = %e, "failed to poll optimism_syncStatus for local safe head");
                 }
             }
         }
@@ -93,31 +111,42 @@ mod tests {
         time::Duration,
     };
 
+    use base_batcher_core::{LocalSafeHeadProvider, LocalSafeHeadResult};
+    use futures::future::BoxFuture;
     use tokio::sync::watch;
     use tokio_util::sync::CancellationToken;
 
-    use super::{SafeHeadPoller, SafeHeadProvider};
+    use super::SafeHeadPoller;
 
     // ---- Mock providers ----
 
     /// Returns values from a pre-loaded queue; returns `0` when exhausted.
+    #[derive(Debug)]
     struct MockProvider {
         values: Arc<Mutex<Vec<u64>>>,
     }
 
-    impl SafeHeadProvider for MockProvider {
-        async fn safe_l2_number(&self) -> Result<u64, Box<dyn std::error::Error + Send + Sync>> {
-            let mut v = self.values.lock().unwrap();
-            Ok(if v.is_empty() { 0 } else { v.remove(0) })
+    impl LocalSafeHeadProvider for MockProvider {
+        fn local_safe_l2_number(&self) -> BoxFuture<'_, LocalSafeHeadResult> {
+            Box::pin(async move {
+                let mut v = self.values.lock().unwrap();
+                Ok(if v.is_empty() { 0 } else { v.remove(0) })
+            })
         }
     }
 
     /// Always returns an error.
     struct ErrorProvider;
 
-    impl SafeHeadProvider for ErrorProvider {
-        async fn safe_l2_number(&self) -> Result<u64, Box<dyn std::error::Error + Send + Sync>> {
-            Err("rpc error".into())
+    impl std::fmt::Debug for ErrorProvider {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            f.debug_struct("ErrorProvider").finish()
+        }
+    }
+
+    impl LocalSafeHeadProvider for ErrorProvider {
+        fn local_safe_l2_number(&self) -> BoxFuture<'_, LocalSafeHeadResult> {
+            Box::pin(async move { Err("rpc error".into()) })
         }
     }
 
@@ -143,7 +172,29 @@ mod tests {
         cancellation.cancel();
         handle.await.unwrap();
 
-        assert!(*rx.borrow() >= 5, "safe head must have advanced to at least 5");
+        assert!(*rx.borrow() >= 5, "local safe head must have advanced to at least 5");
+    }
+
+    /// When the local safe head regresses after an L1 reorg, the watch channel
+    /// must be updated and receivers notified.
+    #[tokio::test]
+    async fn poll_regresses_watch_channel() {
+        let (tx, mut rx) = watch::channel(10u64);
+        let provider = MockProvider { values: Arc::new(Mutex::new(vec![5])) };
+        let cancellation = CancellationToken::new();
+
+        let poller = SafeHeadPoller::new(provider, Duration::from_millis(1), tx);
+        let handle = poller.spawn(cancellation.clone());
+
+        tokio::time::timeout(Duration::from_millis(200), rx.changed())
+            .await
+            .expect("watch should fire within 200 ms")
+            .expect("sender should still be alive");
+
+        cancellation.cancel();
+        handle.await.unwrap();
+
+        assert_eq!(*rx.borrow(), 5, "local safe head must regress to the provider value");
     }
 
     /// When the cancellation token fires, the poller must exit within one poll
@@ -182,28 +233,26 @@ mod tests {
         assert_eq!(*rx.borrow(), 0, "watch must not advance when provider errors");
     }
 
-    /// When the provider returns the same or lower value, `send_if_modified`
-    /// must not notify receivers. Check while the poller is still running
-    /// (sender alive) so a dropped-sender signal cannot mask a missing change.
+    /// When the provider returns the same value, `send_if_modified` must not
+    /// notify receivers. Check while the poller is still running (sender alive)
+    /// so a dropped-sender signal cannot mask a missing change.
     #[tokio::test]
     async fn watch_not_notified_when_value_unchanged() {
         let (tx, mut rx) = watch::channel(10u64);
         // Mark the initial value as seen so `changed()` only fires on a new send.
         let _ = rx.borrow_and_update();
 
-        // MockProvider with no queued values returns 0, which is < 10 (initial),
-        // so send_if_modified will always return false.
-        let provider = MockProvider { values: Arc::new(Mutex::new(vec![])) };
+        let provider = MockProvider { values: Arc::new(Mutex::new(vec![10])) };
         let cancellation = CancellationToken::new();
 
-        let poller = SafeHeadPoller::new(provider, Duration::from_millis(1), tx);
+        let poller = SafeHeadPoller::new(provider, Duration::from_millis(50), tx);
         let handle = poller.spawn(cancellation.clone());
 
         // Let the poller run multiple cycles, then check *before* cancelling so
         // the sender is still alive and a Err(RecvError) cannot mask an absent change.
-        tokio::time::sleep(Duration::from_millis(30)).await;
+        tokio::time::sleep(Duration::from_millis(60)).await;
         let changed = tokio::time::timeout(Duration::from_millis(5), rx.changed()).await;
-        assert!(changed.is_err(), "watch must not fire when safe head does not advance");
+        assert!(changed.is_err(), "watch must not fire when local safe head does not change");
 
         cancellation.cancel();
         handle.await.unwrap();

--- a/crates/batcher/service/src/safe_head_poller.rs
+++ b/crates/batcher/service/src/safe_head_poller.rs
@@ -9,9 +9,6 @@ use tokio::sync::watch;
 use tokio_util::sync::CancellationToken;
 use tracing::warn;
 
-/// Compatibility export for callers that import the provider trait from this crate.
-pub use base_batcher_core::LocalSafeHeadProvider as SafeHeadProvider;
-
 /// RPC-backed provider for the current local safe L2 head.
 #[derive(Clone)]
 pub struct RpcLocalSafeHeadProvider {

--- a/crates/batcher/service/src/service.rs
+++ b/crates/batcher/service/src/service.rs
@@ -24,8 +24,8 @@ use url::Url;
 
 use crate::{
     BatcherConfig, MAX_CHECK_RECENT_TXS_DEPTH, NullL1HeadSubscription, NullSubscription,
-    RecentTxScanner, RpcL1HeadPollingSource, RpcPollingSource, RpcThrottleClient, SafeHeadPoller,
-    WsBlockSubscription, WsL1HeadSubscription,
+    RecentTxScanner, RpcL1HeadPollingSource, RpcLocalSafeHeadProvider, RpcPollingSource,
+    RpcThrottleClient, SafeHeadPoller, WsBlockSubscription, WsL1HeadSubscription,
 };
 
 /// Service-internal throttle client variant: either a no-op or an RPC client.
@@ -312,6 +312,7 @@ impl BatcherService {
                     info!(
                         current_l1 = %status.current_l1.number,
                         unsafe_l2 = %status.unsafe_l2.block_info.number,
+                        local_safe_l2 = %status.local_safe_l2.block_info.number,
                         safe_l2 = %status.safe_l2.block_info.number,
                         "rollup node reports sync, proceeding with batcher startup"
                     );
@@ -472,16 +473,16 @@ impl BatcherService {
             .await?;
         }
 
-        // Fetch sync status to determine the safe L2 head for startup backfill.
+        // Fetch sync status to determine the local safe L2 head for startup backfill.
         let sync_status = rollup_client
             .sync_status()
             .await
             .map_err(|e| eyre::eyre!("optimism_syncStatus RPC failed: {e}"))?;
-        let safe_l2_number = sync_status.safe_l2.block_info.number;
+        let local_safe_l2_number = sync_status.local_safe_l2.block_info.number;
         let next_l2_timestamp =
-            sync_status.safe_l2.block_info.timestamp.saturating_add(rollup_config.block_time);
+            sync_status.local_safe_l2.block_info.timestamp.saturating_add(rollup_config.block_time);
         self.config.encoder_config.validate_for_rollup_config(&rollup_config, next_l2_timestamp)?;
-        info!(safe_l2 = %safe_l2_number, "fetched safe L2 head");
+        info!(local_safe_l2 = %local_safe_l2_number, "fetched local safe L2 head");
 
         // Validate the recent-tx scan depth against the maximum. Do this early so
         // the error surfaces before any network I/O for the scan.
@@ -533,14 +534,14 @@ impl BatcherService {
             .map_err(|e| eyre::eyre!("failed to fetch L2 latest block number: {e}"))?;
 
         // Advance the cursor past any L2 blocks that are already on L1 but not yet safe.
-        // Use the higher of the safe head and the scan result as the backfill start.
-        let cursor_start = safe_l2_number.max(scanned_highest.unwrap_or(0));
+        // Use the higher of the local safe head and the scan result as the backfill start.
+        let cursor_start = local_safe_l2_number.max(scanned_highest.unwrap_or(0));
 
         // Build the L2 polling source. If blocks between cursor_start+1 and latest
         // were not yet submitted, use sequential catchup mode to avoid skipping them.
         let poller = if cursor_start < latest_l2 {
             info!(
-                safe_l2 = %safe_l2_number,
+                local_safe_l2 = %local_safe_l2_number,
                 cursor_start = %cursor_start,
                 latest_l2 = %latest_l2,
                 "starting sequential backfill from cursor"
@@ -623,15 +624,20 @@ impl BatcherService {
         .map_err(|e| eyre::eyre!("failed to create tx manager: {e}"))?;
 
         // Create a safe-head watch channel for runtime pruning of confirmed blocks.
-        let (safe_head_tx, safe_head_rx) = watch::channel::<u64>(safe_l2_number);
+        let (safe_head_tx, safe_head_rx) = watch::channel::<u64>(local_safe_l2_number);
+        let local_safe_head_provider = RpcLocalSafeHeadProvider::new(rollup_client.clone());
 
         // Spawn the safe-head poller. It polls `optimism_syncStatus` at the
-        // configured interval and advances the watch when the safe L2 head
-        // moves forward, allowing the encoder to prune confirmed blocks.
+        // configured interval and updates the watch when the local safe L2 head
+        // changes, allowing the encoder to prune confirmed blocks.
         // Extract the raw token so the poller can use it before the runtime
         // moves into the driver below.
-        SafeHeadPoller::new(rollup_client, self.config.poll_interval, safe_head_tx)
-            .spawn(runtime.token().clone());
+        SafeHeadPoller::new(
+            local_safe_head_provider.clone(),
+            self.config.poll_interval,
+            safe_head_tx,
+        )
+        .spawn(runtime.token().clone());
 
         // Build the driver — all fallible setup is complete at this point.
         let mut driver = BatchDriver::new(
@@ -649,6 +655,7 @@ impl BatcherService {
             l1_head_source,
         )
         .with_safe_head_rx(safe_head_rx)
+        .with_local_safe_head_provider(Arc::new(local_safe_head_provider))
         .with_stopped(self.config.stopped);
 
         let admin_server = match self.config.admin_addr {


### PR DESCRIPTION
## Summary
- fetch fresh `local_safe_l2` for batcher reorg and resume reset boundaries
- switch batcher startup/poller tracking from `safe_l2` to `local_safe_l2`
- allow local safe head regressions after L1 reorgs
- retry transient local-safe-head lookup failures during reset without halting the driver
- keep the L2 source parked until the reset boundary is resolved, while admin, receipts, L1 heads, pruning, and shutdown continue to run
- replace any pending reset-boundary lookup when a later reset arrives, and log/fallback if the lookup task closes without a result
- add stale-watch regression coverage for explicit reorg, parent-mismatch reorg, resume, one-shot RPC failure during reorg reset, nonblocking retry behavior, and replacement of pending reset lookups

## Design Invariant
A reset/catchup boundary must be derived from the current `local_safe_l2`, not from a monotonic safe-head watch value. After an L1 reorg, the local safe head can move backward; if the batcher resets from a stale higher watch value, it can advance the source past canonical L2 blocks that still need to be reloaded and submitted.

The safe-head watch is still useful for pruning already-safe data, but it is not authoritative for reset boundaries when a fresh local-safe provider is available.

## op-batcher Reference
This follows the Go `op-batcher` reset model rather than the previous monotonic watch model:
- `op-batcher/batcher/sync_actions.go` uses fresh `SyncStatus.LocalSafeL2` instead of `SafeL2` for batcher sync decisions.
- `computeSyncActions` computes the load range as `[LocalSafeL2 + 1, UnsafeL2]`.
- On safe-chain gaps, safe-chain reorg hash mismatch, or unexpected safe progress, the batcher clears queued state and reloads all unsafe blocks from `LocalSafeL2 + 1`.
- `op-batcher/batcher/driver.go` polls fresh sync status before deciding what to prune or reload.
- During reorg-triggered state clear, `clearState` retries `safeL1Origin` every 5 seconds until it can read `SyncStatus.LocalSafeL2.L1Origin`, or shutdown cancels the driver.

```mermaid
flowchart TD
    A[blockLoadingLoop tick] --> B[Fetch fresh SyncStatus]
    B -->|success| C[Read LocalSafeL2 and UnsafeL2]
    B -->|error| B1[Log and retry on next tick]
    C --> D[computeSyncActions]
    D --> E{Queued state matches local-safe chain?}
    E -->|yes| F[Load missing range: LocalSafeL2 + 1 through UnsafeL2]
    E -->|gap or hash mismatch| G[clearState]
    G --> H[safeL1Origin retries every 5s]
    H -->|success| I[Reset channel state to fresh local-safe origin]
    H -->|shutdown| J[Exit]
    I --> F
```

`op-batcher` can block the block-loading goroutine while `clearState` retries because receipts, publishing, and throttling are handled by separate goroutines.

## base-batcher Design
The Rust batcher has a single driver event loop, so this PR keeps the same reset-boundary invariant without blocking unrelated work. Reorg and resume reset paths spawn a fresh local-safe lookup task. Until the task resolves, the driver parks only the L2 source arm so it cannot load blocks from an unresolved boundary. Other event-loop arms remain live.

```mermaid
flowchart TD
    A[Reorg, parent mismatch, or admin resume] --> B[Discard in-flight submissions]
    B --> C[Reset encoding pipeline]
    C --> D{LocalSafeHeadProvider configured?}
    D -->|no| E[Fallback to watch value]
    E --> F[Reset source catchup to safe_head + 1]
    D -->|yes| G[Spawn reset-boundary lookup task]
    G --> H[Store PendingResetSafeHead: receiver + fallback]
    H --> I[Park only L2 source arm]
    I --> J{Lookup result}
    J -->|Resolved safe_head| F
    J -->|Task closed| K[Warn and use fallback]
    K --> F
```

While the reset-boundary lookup is pending, the driver still processes the non-source arms:

```mermaid
flowchart LR
    P[Pending reset lookup] --> S[L2 source arm parked]
    P --> A[admin commands]
    P --> R[L1 receipt settlement]
    P --> H[L1 head updates]
    P --> W[safe-head watch pruning]
    P --> C[shutdown cancellation]
```

The latest patch also handles the two edge cases from review:
- A later reset replaces the pending lookup, so the active receiver/fallback belong to the latest reset attempt.
- If a lookup task closes without sending, the driver logs the failure and uses the captured fallback instead of silently clearing the pending reset and resuming from the old source cursor.

## Tests
- `cargo fmt`
- `cargo test -p base-batcher-core --features test-utils`
- `cargo test -p base-batcher-service`
- `git diff --check`