### PR TITLE
fix(websocket-proxy): limit inbound frame size and reject unexpected client data

### DIFF
--- a/crates/infra/websocket-proxy/src/registry.rs
+++ b/crates/infra/websocket-proxy/src/registry.rs
@@ -161,6 +161,20 @@ impl Registry {
                                 let _ = pong_error_tx.send(());
                                 return;
                             }
+                            Some(Ok(Message::Ping(_))) => {
+                                // This is a no-op, but needs to be handled separately from the
+                                // catch-all [`Some(Ok(_))`] arm below as otherwise client pings would be unexpected
+                                // behavior and cause the connection to be shut down
+                                trace!(message = "received ping from client", client = client_id);
+                            }
+                            Some(Ok(_)) => {
+                                debug!(
+                                    message = "unexpected inbound frame from client, disconnecting",
+                                    client = client_id,
+                                );
+                                let _ = pong_error_tx.send(());
+                                return;
+                            }
                             Some(Err(e)) => {
                                 trace!(
                                     message = "error receiving from client",
@@ -175,7 +189,6 @@ impl Registry {
                                 let _ = pong_error_tx.send(());
                                 return;
                             }
-                            _ => {}
                         }
                     }
 

--- a/crates/infra/websocket-proxy/src/server.rs
+++ b/crates/infra/websocket-proxy/src/server.rs
@@ -260,17 +260,26 @@ fn websocket_handler(
         }
     };
 
-    ws.on_failed_upgrade(move |e: Error| {
-        info!(
-            message = "failed to upgrade connection",
-            error = e.to_string(),
-            client = addr.to_string()
-        )
-    })
-    .on_upgrade(async move |socket| {
-        let client = ClientConnection::new(client_addr, ticket, socket, filter);
-        state.registry.subscribe(client).await;
-    })
+    // Downstream clients are primarily receive-only (flashblock broadcast). Limit inbound
+    // frame and message sizes to prevent clients from forcing large allocations
+    // that the proxy never uses. Only small control frames (ping, pong, close) are
+    // expected from clients.
+    const MAX_CLIENT_MESSAGE_SIZE: usize = 4 * 1024;
+    const MAX_CLIENT_FRAME_SIZE: usize = 4 * 1024;
+
+    ws.max_message_size(MAX_CLIENT_MESSAGE_SIZE)
+        .max_frame_size(MAX_CLIENT_FRAME_SIZE)
+        .on_failed_upgrade(move |e: Error| {
+            info!(
+                message = "failed to upgrade connection",
+                error = e.to_string(),
+                client = addr.to_string()
+            )
+        })
+        .on_upgrade(async move |socket| {
+            let client = ClientConnection::new(client_addr, ticket, socket, filter);
+            state.registry.subscribe(client).await;
+        })
 }
 
 fn extract_addr(header: &HeaderValue, fallback: IpAddr) -> IpAddr {


### PR DESCRIPTION
## Summary

- Configures `WebSocketUpgrade` with 4 KiB `max_message_size` and `max_frame_size` so tungstenite rejects oversized inbound frames before heap allocation
- Replaces the silent `_ => {}` catch-all in `start_reader` with an explicit disconnect on unexpected `Text`/`Binary` frames
- Preserves `Ping` handling so client keepalive continues to work (axum auto-replies with `Pong`)

## Context

The websocket proxy is one-directional: it subscribes to upstream flashblocks and broadcasts them to downstream clients. However, each client connection spawns a reader task that accepts and silently discards all inbound data frames. With tungstenite's defaults (64 MiB max message, 16 MiB max frame), a client can force large per-connection heap allocations that the proxy never uses. Under sustained load with multiple connections, this leads to OOM.

These limits only affect the inbound (client→server) read path. Outbound flashblock broadcasts to clients are unaffected.