### PR TITLE
perf(execution): Speed Up L1 Parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3315,6 +3315,7 @@ dependencies = [
  "base-common-consensus",
  "base-common-flz",
  "base-common-precompiles",
+ "criterion",
  "reth-evm",
  "revm",
  "rstest",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4053,6 +4053,7 @@ dependencies = [
  "base-common-rpc-types-engine",
  "base-execution-chainspec",
  "base-execution-consensus",
+ "criterion",
  "reth-chainspec",
  "reth-evm",
  "reth-execution-errors",

--- a/crates/common/evm/Cargo.toml
+++ b/crates/common/evm/Cargo.toml
@@ -38,11 +38,16 @@ reth-evm = { workspace = true, optional = true }
 
 [dev-dependencies]
 rstest.workspace = true
+criterion.workspace = true
 sha2 = { workspace = true, default-features = false }
 alloy-hardforks.workspace = true
 alloy-sol-types = { workspace = true, default-features = false }
 alloy-primitives = { workspace = true, default-features = false }
 serde_json = { workspace = true, default-features = false, features = ["alloc", "preserve_order"] }
+
+[[bench]]
+name = "l1block"
+harness = false
 
 [features]
 default = [ "blst", "c-kzg", "portable", "secp256k1", "std" ]

--- a/crates/common/evm/benches/l1block.rs
+++ b/crates/common/evm/benches/l1block.rs
@@ -1,0 +1,71 @@
+//! Benchmarks for loading L1 block-info values from EVM state.
+
+use base_common_consensus::Predeploys;
+use base_common_evm::{BaseSpecId, BaseUpgrade, L1BlockInfo};
+use criterion::{BatchSize, Criterion, criterion_group, criterion_main};
+use revm::{database::InMemoryDB, primitives::U256, state::AccountInfo};
+
+fn packed_ecotone_scalars(base_fee_scalar: u32, blob_base_fee_scalar: u32) -> U256 {
+    let mut slot = [0u8; 32];
+    slot[L1BlockInfo::BASE_FEE_SCALAR_OFFSET..L1BlockInfo::BASE_FEE_SCALAR_OFFSET + 4]
+        .copy_from_slice(&base_fee_scalar.to_be_bytes());
+    slot[L1BlockInfo::BLOB_BASE_FEE_SCALAR_OFFSET..L1BlockInfo::BLOB_BASE_FEE_SCALAR_OFFSET + 4]
+        .copy_from_slice(&blob_base_fee_scalar.to_be_bytes());
+    U256::from_be_bytes(slot)
+}
+
+fn packed_operator_fee_and_da_footprint(
+    da_footprint_gas_scalar: u16,
+    operator_fee_scalar: u32,
+    operator_fee_constant: u64,
+) -> U256 {
+    let mut slot = [0u8; 32];
+    slot[L1BlockInfo::DA_FOOTPRINT_GAS_SCALAR_OFFSET
+        ..L1BlockInfo::DA_FOOTPRINT_GAS_SCALAR_OFFSET + 2]
+        .copy_from_slice(&da_footprint_gas_scalar.to_be_bytes());
+    slot[L1BlockInfo::OPERATOR_FEE_SCALAR_OFFSET..L1BlockInfo::OPERATOR_FEE_SCALAR_OFFSET + 4]
+        .copy_from_slice(&operator_fee_scalar.to_be_bytes());
+    slot[L1BlockInfo::OPERATOR_FEE_CONSTANT_OFFSET..L1BlockInfo::OPERATOR_FEE_CONSTANT_OFFSET + 8]
+        .copy_from_slice(&operator_fee_constant.to_be_bytes());
+    U256::from_be_bytes(slot)
+}
+
+fn l1_block_info_db() -> InMemoryDB {
+    let mut db = InMemoryDB::default();
+    db.insert_account_info(Predeploys::L1_BLOCK_INFO, AccountInfo::default());
+
+    let l1_block_contract = db.load_account(Predeploys::L1_BLOCK_INFO).unwrap();
+    l1_block_contract.storage.insert(L1BlockInfo::L1_BASE_FEE_SLOT, U256::from(1));
+    l1_block_contract.storage.insert(L1BlockInfo::ECOTONE_L1_BLOB_BASE_FEE_SLOT, U256::from(2));
+    l1_block_contract
+        .storage
+        .insert(L1BlockInfo::ECOTONE_L1_FEE_SCALARS_SLOT, packed_ecotone_scalars(3, 4));
+    l1_block_contract.storage.insert(
+        L1BlockInfo::OPERATOR_FEE_SCALARS_SLOT,
+        packed_operator_fee_and_da_footprint(5, 6, 7),
+    );
+
+    db
+}
+
+fn bench_try_fetch(c: &mut Criterion) {
+    let mut group = c.benchmark_group("l1_block_info_try_fetch");
+
+    for upgrade in [BaseUpgrade::Isthmus, BaseUpgrade::Jovian] {
+        group.bench_function(format!("{upgrade:?}"), |b| {
+            b.iter_batched(
+                l1_block_info_db,
+                |mut db| {
+                    L1BlockInfo::try_fetch(&mut db, U256::from(100), BaseSpecId::new(upgrade))
+                        .unwrap()
+                },
+                BatchSize::SmallInput,
+            );
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_try_fetch);
+criterion_main!(benches);

--- a/crates/common/evm/src/l1block.rs
+++ b/crates/common/evm/src/l1block.rs
@@ -99,23 +99,37 @@ impl L1BlockInfo {
             .storage(Predeploys::L1_BLOCK_INFO, Self::DA_FOOTPRINT_GAS_SCALAR_SLOT)?
             .to_be_bytes::<32>();
 
-        // Extract the first 2 bytes directly as a u16 in big-endian format
-        let bytes = [
-            da_footprint_gas_scalar_slot[Self::DA_FOOTPRINT_GAS_SCALAR_OFFSET],
-            da_footprint_gas_scalar_slot[Self::DA_FOOTPRINT_GAS_SCALAR_OFFSET + 1],
-        ];
-        Ok(u16::from_be_bytes(bytes))
+        Ok(Self::da_footprint_gas_scalar_from_slot(&da_footprint_gas_scalar_slot))
+    }
+
+    fn da_footprint_gas_scalar_from_slot(slot: &[u8; 32]) -> u16 {
+        Self::u16_from_be_slice(
+            &slot[Self::DA_FOOTPRINT_GAS_SCALAR_OFFSET..Self::DA_FOOTPRINT_GAS_SCALAR_OFFSET + 2],
+        )
+    }
+
+    fn u16_from_be_slice(data: &[u8]) -> u16 {
+        u16::from_be_bytes([data[0], data[1]])
+    }
+
+    fn u256_from_be_u32(data: &[u8]) -> U256 {
+        U256::from(u32::from_be_bytes([data[0], data[1], data[2], data[3]]))
+    }
+
+    fn u256_from_be_u64(data: &[u8]) -> U256 {
+        U256::from(u64::from_be_bytes([
+            data[0], data[1], data[2], data[3], data[4], data[5], data[6], data[7],
+        ]))
     }
 
     /// Try to fetch the L1 block info from the database, post-Jovian.
-    fn try_fetch_jovian<DB: Database>(&mut self, db: &mut DB) -> Result<(), DB::Error> {
-        self.da_footprint_gas_scalar = Some(Self::fetch_da_footprint_gas_scalar(db)?);
-
-        Ok(())
+    fn try_fetch_jovian(&mut self, operator_fee_scalars: &[u8; 32]) {
+        self.da_footprint_gas_scalar =
+            Some(Self::da_footprint_gas_scalar_from_slot(operator_fee_scalars));
     }
 
     /// Try to fetch the L1 block info from the database, post-Isthmus.
-    fn try_fetch_isthmus<DB: Database>(&mut self, db: &mut DB) -> Result<(), DB::Error> {
+    fn try_fetch_isthmus<DB: Database>(&mut self, db: &mut DB) -> Result<[u8; 32], DB::Error> {
         // Post-isthmus L1 block info
         let operator_fee_scalars = db
             .storage(Predeploys::L1_BLOCK_INFO, Self::OPERATOR_FEE_SCALARS_SLOT)?
@@ -123,20 +137,18 @@ impl L1BlockInfo {
 
         // The `operator_fee_scalar` is stored as a big endian u32 at
         // OPERATOR_FEE_SCALAR_OFFSET.
-        self.operator_fee_scalar = Some(U256::from_be_slice(
-            operator_fee_scalars
-                [Self::OPERATOR_FEE_SCALAR_OFFSET..Self::OPERATOR_FEE_SCALAR_OFFSET + 4]
-                .as_ref(),
+        self.operator_fee_scalar = Some(Self::u256_from_be_u32(
+            &operator_fee_scalars
+                [Self::OPERATOR_FEE_SCALAR_OFFSET..Self::OPERATOR_FEE_SCALAR_OFFSET + 4],
         ));
         // The `operator_fee_constant` is stored as a big endian u64 at
         // OPERATOR_FEE_CONSTANT_OFFSET.
-        self.operator_fee_constant = Some(U256::from_be_slice(
-            operator_fee_scalars
-                [Self::OPERATOR_FEE_CONSTANT_OFFSET..Self::OPERATOR_FEE_CONSTANT_OFFSET + 8]
-                .as_ref(),
+        self.operator_fee_constant = Some(Self::u256_from_be_u64(
+            &operator_fee_scalars
+                [Self::OPERATOR_FEE_CONSTANT_OFFSET..Self::OPERATOR_FEE_CONSTANT_OFFSET + 8],
         ));
 
-        Ok(())
+        Ok(operator_fee_scalars)
     }
 
     /// Try to fetch the L1 block info from the database, post-Ecotone.
@@ -148,14 +160,13 @@ impl L1BlockInfo {
             .storage(Predeploys::L1_BLOCK_INFO, Self::ECOTONE_L1_FEE_SCALARS_SLOT)?
             .to_be_bytes::<32>();
 
-        self.l1_base_fee_scalar = U256::from_be_slice(
-            l1_fee_scalars[Self::BASE_FEE_SCALAR_OFFSET..Self::BASE_FEE_SCALAR_OFFSET + 4].as_ref(),
+        self.l1_base_fee_scalar = Self::u256_from_be_u32(
+            &l1_fee_scalars[Self::BASE_FEE_SCALAR_OFFSET..Self::BASE_FEE_SCALAR_OFFSET + 4],
         );
 
-        let l1_blob_base_fee = U256::from_be_slice(
-            l1_fee_scalars
-                [Self::BLOB_BASE_FEE_SCALAR_OFFSET..Self::BLOB_BASE_FEE_SCALAR_OFFSET + 4]
-                .as_ref(),
+        let l1_blob_base_fee = Self::u256_from_be_u32(
+            &l1_fee_scalars
+                [Self::BLOB_BASE_FEE_SCALAR_OFFSET..Self::BLOB_BASE_FEE_SCALAR_OFFSET + 4],
         );
         self.l1_blob_base_fee_scalar = Some(l1_blob_base_fee);
 
@@ -199,13 +210,18 @@ impl L1BlockInfo {
         out.try_fetch_ecotone(db)?;
 
         // Post-Isthmus L1 block info
-        if spec_id.is_enabled_in(BaseUpgrade::Isthmus) {
-            out.try_fetch_isthmus(db)?;
-        }
+        let operator_fee_scalars = if spec_id.is_enabled_in(BaseUpgrade::Isthmus) {
+            Some(out.try_fetch_isthmus(db)?)
+        } else {
+            None
+        };
 
-        // Pre-Jovian
-        if spec_id.is_enabled_in(BaseUpgrade::Jovian) {
-            out.try_fetch_jovian(db)?;
+        // The Jovian DA footprint scalar shares the same storage slot as the Isthmus operator fee
+        // scalars, so reuse the slot we already fetched above.
+        if spec_id.is_enabled_in(BaseUpgrade::Jovian)
+            && let Some(operator_fee_scalars) = operator_fee_scalars
+        {
+            out.try_fetch_jovian(&operator_fee_scalars);
         }
 
         Ok(out)
@@ -410,7 +426,11 @@ impl L1BlockInfo {
 
 #[cfg(test)]
 mod tests {
-    use revm::primitives::{bytes, hex};
+    use revm::{
+        database::InMemoryDB,
+        primitives::{bytes, hex},
+        state::AccountInfo,
+    };
 
     use super::*;
 
@@ -476,6 +496,71 @@ mod tests {
         // gas cost = 100 * 16 = 1600
         let fjord_data_gas = l1_block_info.data_gas(&input, BaseSpecId::new(BaseUpgrade::Fjord));
         assert_eq!(fjord_data_gas, U256::from(1600));
+    }
+
+    #[test]
+    fn test_try_fetch_jovian_decodes_shared_operator_fee_slot() {
+        const L2_BLOCK: U256 = uint!(100_U256);
+        const L1_BASE_FEE: U256 = uint!(1_U256);
+        const L1_BLOB_BASE_FEE: U256 = uint!(2_U256);
+        const L1_BASE_FEE_SCALAR: u32 = 3;
+        const L1_BLOB_BASE_FEE_SCALAR: u32 = 4;
+        const DA_FOOTPRINT_GAS_SCALAR: u16 = 5;
+        const OPERATOR_FEE_SCALAR: u32 = 6;
+        const OPERATOR_FEE_CONSTANT: u64 = 7;
+
+        let mut l1_fee_scalars = [0u8; 32];
+        l1_fee_scalars
+            [L1BlockInfo::BASE_FEE_SCALAR_OFFSET..L1BlockInfo::BASE_FEE_SCALAR_OFFSET + 4]
+            .copy_from_slice(&L1_BASE_FEE_SCALAR.to_be_bytes());
+        l1_fee_scalars[L1BlockInfo::BLOB_BASE_FEE_SCALAR_OFFSET
+            ..L1BlockInfo::BLOB_BASE_FEE_SCALAR_OFFSET + 4]
+            .copy_from_slice(&L1_BLOB_BASE_FEE_SCALAR.to_be_bytes());
+
+        let mut operator_fee_scalars = [0u8; 32];
+        operator_fee_scalars[L1BlockInfo::DA_FOOTPRINT_GAS_SCALAR_OFFSET
+            ..L1BlockInfo::DA_FOOTPRINT_GAS_SCALAR_OFFSET + 2]
+            .copy_from_slice(&DA_FOOTPRINT_GAS_SCALAR.to_be_bytes());
+        operator_fee_scalars
+            [L1BlockInfo::OPERATOR_FEE_SCALAR_OFFSET..L1BlockInfo::OPERATOR_FEE_SCALAR_OFFSET + 4]
+            .copy_from_slice(&OPERATOR_FEE_SCALAR.to_be_bytes());
+        operator_fee_scalars[L1BlockInfo::OPERATOR_FEE_CONSTANT_OFFSET
+            ..L1BlockInfo::OPERATOR_FEE_CONSTANT_OFFSET + 8]
+            .copy_from_slice(&OPERATOR_FEE_CONSTANT.to_be_bytes());
+
+        let mut db = InMemoryDB::default();
+        db.insert_account_info(Predeploys::L1_BLOCK_INFO, AccountInfo::default());
+        let l1_block_contract = db.load_account(Predeploys::L1_BLOCK_INFO).unwrap();
+        l1_block_contract.storage.insert(L1BlockInfo::L1_BASE_FEE_SLOT, L1_BASE_FEE);
+        l1_block_contract
+            .storage
+            .insert(L1BlockInfo::ECOTONE_L1_BLOB_BASE_FEE_SLOT, L1_BLOB_BASE_FEE);
+        l1_block_contract
+            .storage
+            .insert(L1BlockInfo::ECOTONE_L1_FEE_SCALARS_SLOT, U256::from_be_bytes(l1_fee_scalars));
+        l1_block_contract.storage.insert(
+            L1BlockInfo::OPERATOR_FEE_SCALARS_SLOT,
+            U256::from_be_bytes(operator_fee_scalars),
+        );
+
+        let l1_block_info =
+            L1BlockInfo::try_fetch(&mut db, L2_BLOCK, BaseSpecId::new(BaseUpgrade::Jovian))
+                .unwrap();
+
+        assert_eq!(
+            l1_block_info,
+            L1BlockInfo {
+                l2_block: Some(L2_BLOCK),
+                l1_base_fee: L1_BASE_FEE,
+                l1_base_fee_scalar: U256::from(L1_BASE_FEE_SCALAR),
+                l1_blob_base_fee: Some(L1_BLOB_BASE_FEE),
+                l1_blob_base_fee_scalar: Some(U256::from(L1_BLOB_BASE_FEE_SCALAR)),
+                operator_fee_scalar: Some(U256::from(OPERATOR_FEE_SCALAR)),
+                operator_fee_constant: Some(U256::from(OPERATOR_FEE_CONSTANT)),
+                da_footprint_gas_scalar: Some(DA_FOOTPRINT_GAS_SCALAR),
+                ..Default::default()
+            }
+        );
     }
 
     #[test]

--- a/crates/execution/evm/Cargo.toml
+++ b/crates/execution/evm/Cargo.toml
@@ -41,10 +41,15 @@ revm.workspace = true
 thiserror.workspace = true
 
 [dev-dependencies]
+criterion.workspace = true
 alloy-genesis.workspace = true
 reth-evm = { workspace = true, features = ["test-utils"] }
 reth-revm = { workspace = true, features = ["test-utils"] }
 base-common-consensus = { workspace = true, features = ["arbitrary"] }
+
+[[bench]]
+name = "l1_info"
+harness = false
 
 [features]
 default = [ "std" ]

--- a/crates/execution/evm/benches/l1_info.rs
+++ b/crates/execution/evm/benches/l1_info.rs
@@ -1,0 +1,57 @@
+//! Benchmarks for parsing L1 block-info calldata during EVM block execution.
+
+use std::hint::black_box;
+
+use alloy_primitives::hex_literal::hex;
+use base_execution_evm::parse_l1_info;
+use criterion::{Criterion, criterion_group, criterion_main};
+
+fn bedrock_input() -> Vec<u8> {
+    let mut input = vec![0u8; 4 + 256];
+    input[68..100]
+        .copy_from_slice(&hex!("000000000000000000000000000000000000000000000000000000000009f352"));
+    input[196..228]
+        .copy_from_slice(&hex!("0000000000000000000000000000000000000000000000000000000000000834"));
+    input[228..260]
+        .copy_from_slice(&hex!("00000000000000000000000000000000000000000000000000000000000f4240"));
+    input
+}
+
+fn ecotone_input() -> Vec<u8> {
+    hex!(
+        "440a5e200000146b000f79c500000000000000040000000066d052e700000000013ad8a3000000000000000000000000000000000000000000000000000000003ef1278700000000000000000000000000000000000000000000000000000000000000012fdf87b89884a61e74b322bbcf60386f543bfae7827725efaaf0ab1de2294a590000000000000000000000006887246668a3b87f54deb3b94ba47a6f63f32985"
+    )
+    .to_vec()
+}
+
+fn isthmus_input() -> Vec<u8> {
+    hex!(
+        "098999be00000558000c5fc500000000000000030000000067a9f765000000000000002900000000000000000000000000000000000000000000000000000000006a6d09000000000000000000000000000000000000000000000000000000000000000172fcc8e8886636bdbe96ba0e4baab67ea7e7811633f52b52e8cf7a5123213b6f000000000000000000000000d3f2c5afb2d76f5579f326b0cd7da5f5a4126c3500004e2000000000000001f4"
+    )
+    .to_vec()
+}
+
+fn jovian_input() -> Vec<u8> {
+    hex!(
+        "3db6be2b00000558000c5fc500000000000000030000000067a9f765000000000000002900000000000000000000000000000000000000000000000000000000006a6d09000000000000000000000000000000000000000000000000000000000000000172fcc8e8886636bdbe96ba0e4baab67ea7e7811633f52b52e8cf7a5123213b6f000000000000000000000000d3f2c5afb2d76f5579f326b0cd7da5f5a4126c3500004e2000000000000001f4dead"
+    )
+    .to_vec()
+}
+
+fn bench_parse_l1_info(c: &mut Criterion) {
+    for (name, input) in [
+        ("bedrock", bedrock_input()),
+        ("ecotone", ecotone_input()),
+        ("isthmus", isthmus_input()),
+        ("jovian", jovian_input()),
+    ] {
+        c.bench_function(&format!("parse_l1_info/{name}"), |b| {
+            b.iter(|| {
+                black_box(parse_l1_info(black_box(&input)).unwrap());
+            });
+        });
+    }
+}
+
+criterion_group!(benches, bench_parse_l1_info);
+criterion_main!(benches);

--- a/crates/execution/evm/src/l1.rs
+++ b/crates/execution/evm/src/l1.rs
@@ -1,7 +1,7 @@
 //! Base-specific implementation and utilities for the executor
 
 use alloy_consensus::Transaction;
-use alloy_primitives::{U16, U256, hex};
+use alloy_primitives::{U256, hex};
 use base_common_chains::Upgrades;
 use base_common_evm::{BaseSpecId, L1BlockInfo};
 use reth_execution_errors::BlockExecutionError;
@@ -18,6 +18,23 @@ const L1_BLOCK_ISTHMUS_SELECTOR: [u8; 4] = hex!("098999be");
 /// The function selector of the "setL1BlockValuesJovian" function in the `L1Block` contract.
 /// This is the first 4 bytes of `keccak256("setL1BlockValuesJovian()")`.
 const L1_BLOCK_JOVIAN_SELECTOR: [u8; 4] = hex!("3db6be2b");
+
+#[inline]
+fn u256_from_be_u32(data: &[u8]) -> U256 {
+    U256::from(u32::from_be_bytes([data[0], data[1], data[2], data[3]]))
+}
+
+#[inline]
+fn u256_from_be_u64(data: &[u8]) -> U256 {
+    U256::from(u64::from_be_bytes([
+        data[0], data[1], data[2], data[3], data[4], data[5], data[6], data[7],
+    ]))
+}
+
+#[inline]
+fn u16_from_be_slice(data: &[u8]) -> u16 {
+    u16::from_be_bytes([data[0], data[1]])
+}
 
 /// Extracts the [`L1BlockInfo`] from the L2 block. The L1 info transaction is always the first
 /// transaction in the L2 block.
@@ -91,12 +108,9 @@ pub fn parse_l1_info_tx_bedrock(data: &[u8]) -> Result<L1BlockInfo, BaseBlockExe
         ));
     }
 
-    let l1_base_fee = U256::try_from_be_slice(&data[64..96])
-        .ok_or(BaseBlockExecutionError::L1BlockInfo(L1BlockInfoError::BaseFeeConversion))?;
-    let l1_fee_overhead = U256::try_from_be_slice(&data[192..224])
-        .ok_or(BaseBlockExecutionError::L1BlockInfo(L1BlockInfoError::FeeOverheadConversion))?;
-    let l1_fee_scalar = U256::try_from_be_slice(&data[224..256])
-        .ok_or(BaseBlockExecutionError::L1BlockInfo(L1BlockInfoError::FeeScalarConversion))?;
+    let l1_base_fee = U256::from_be_slice(&data[64..96]);
+    let l1_fee_overhead = U256::from_be_slice(&data[192..224]);
+    let l1_fee_scalar = U256::from_be_slice(&data[224..256]);
 
     Ok(L1BlockInfo {
         l1_base_fee,
@@ -142,15 +156,10 @@ pub fn parse_l1_info_tx_ecotone(data: &[u8]) -> Result<L1BlockInfo, BaseBlockExe
     // 100   bytes32 _hash,
     // 132   bytes32 _batcherHash,
 
-    let l1_base_fee_scalar = U256::try_from_be_slice(&data[..4])
-        .ok_or(BaseBlockExecutionError::L1BlockInfo(L1BlockInfoError::BaseFeeScalarConversion))?;
-    let l1_blob_base_fee_scalar = U256::try_from_be_slice(&data[4..8]).ok_or({
-        BaseBlockExecutionError::L1BlockInfo(L1BlockInfoError::BlobBaseFeeScalarConversion)
-    })?;
-    let l1_base_fee = U256::try_from_be_slice(&data[32..64])
-        .ok_or(BaseBlockExecutionError::L1BlockInfo(L1BlockInfoError::BaseFeeConversion))?;
-    let l1_blob_base_fee = U256::try_from_be_slice(&data[64..96])
-        .ok_or(BaseBlockExecutionError::L1BlockInfo(L1BlockInfoError::BlobBaseFeeConversion))?;
+    let l1_base_fee_scalar = u256_from_be_u32(&data[..4]);
+    let l1_blob_base_fee_scalar = u256_from_be_u32(&data[4..8]);
+    let l1_base_fee = U256::from_be_slice(&data[32..64]);
+    let l1_blob_base_fee = U256::from_be_slice(&data[64..96]);
 
     Ok(L1BlockInfo {
         l1_base_fee,
@@ -199,21 +208,12 @@ pub fn parse_l1_info_tx_isthmus(data: &[u8]) -> Result<L1BlockInfo, BaseBlockExe
     // 164   uint32 _operatorFeeScalar
     // 168   uint64 _operatorFeeConstant
 
-    let l1_base_fee_scalar = U256::try_from_be_slice(&data[..4])
-        .ok_or(BaseBlockExecutionError::L1BlockInfo(L1BlockInfoError::BaseFeeScalarConversion))?;
-    let l1_blob_base_fee_scalar = U256::try_from_be_slice(&data[4..8]).ok_or({
-        BaseBlockExecutionError::L1BlockInfo(L1BlockInfoError::BlobBaseFeeScalarConversion)
-    })?;
-    let l1_base_fee = U256::try_from_be_slice(&data[32..64])
-        .ok_or(BaseBlockExecutionError::L1BlockInfo(L1BlockInfoError::BaseFeeConversion))?;
-    let l1_blob_base_fee = U256::try_from_be_slice(&data[64..96])
-        .ok_or(BaseBlockExecutionError::L1BlockInfo(L1BlockInfoError::BlobBaseFeeConversion))?;
-    let operator_fee_scalar = U256::try_from_be_slice(&data[160..164]).ok_or({
-        BaseBlockExecutionError::L1BlockInfo(L1BlockInfoError::OperatorFeeScalarConversion)
-    })?;
-    let operator_fee_constant = U256::try_from_be_slice(&data[164..172]).ok_or({
-        BaseBlockExecutionError::L1BlockInfo(L1BlockInfoError::OperatorFeeConstantConversion)
-    })?;
+    let l1_base_fee_scalar = u256_from_be_u32(&data[..4]);
+    let l1_blob_base_fee_scalar = u256_from_be_u32(&data[4..8]);
+    let l1_base_fee = U256::from_be_slice(&data[32..64]);
+    let l1_blob_base_fee = U256::from_be_slice(&data[64..96]);
+    let operator_fee_scalar = u256_from_be_u32(&data[160..164]);
+    let operator_fee_constant = u256_from_be_u64(&data[164..172]);
 
     Ok(L1BlockInfo {
         l1_base_fee,
@@ -266,26 +266,13 @@ pub fn parse_l1_info_tx_jovian(data: &[u8]) -> Result<L1BlockInfo, BaseBlockExec
     // 168   uint64 _operatorFeeConstant
     // 176   uint16 _daFootprintGasScalar
 
-    let l1_base_fee_scalar = U256::try_from_be_slice(&data[..4])
-        .ok_or(BaseBlockExecutionError::L1BlockInfo(L1BlockInfoError::BaseFeeScalarConversion))?;
-    let l1_blob_base_fee_scalar = U256::try_from_be_slice(&data[4..8]).ok_or({
-        BaseBlockExecutionError::L1BlockInfo(L1BlockInfoError::BlobBaseFeeScalarConversion)
-    })?;
-    let l1_base_fee = U256::try_from_be_slice(&data[32..64])
-        .ok_or(BaseBlockExecutionError::L1BlockInfo(L1BlockInfoError::BaseFeeConversion))?;
-    let l1_blob_base_fee = U256::try_from_be_slice(&data[64..96])
-        .ok_or(BaseBlockExecutionError::L1BlockInfo(L1BlockInfoError::BlobBaseFeeConversion))?;
-    let operator_fee_scalar = U256::try_from_be_slice(&data[160..164]).ok_or({
-        BaseBlockExecutionError::L1BlockInfo(L1BlockInfoError::OperatorFeeScalarConversion)
-    })?;
-    let operator_fee_constant = U256::try_from_be_slice(&data[164..172]).ok_or({
-        BaseBlockExecutionError::L1BlockInfo(L1BlockInfoError::OperatorFeeConstantConversion)
-    })?;
-    let da_footprint_gas_scalar: u16 = U16::try_from_be_slice(&data[172..174])
-        .ok_or({
-            BaseBlockExecutionError::L1BlockInfo(L1BlockInfoError::DaFootprintGasScalarConversion)
-        })?
-        .to();
+    let l1_base_fee_scalar = u256_from_be_u32(&data[..4]);
+    let l1_blob_base_fee_scalar = u256_from_be_u32(&data[4..8]);
+    let l1_base_fee = U256::from_be_slice(&data[32..64]);
+    let l1_blob_base_fee = U256::from_be_slice(&data[64..96]);
+    let operator_fee_scalar = u256_from_be_u32(&data[160..164]);
+    let operator_fee_constant = u256_from_be_u64(&data[164..172]);
+    let da_footprint_gas_scalar = u16_from_be_slice(&data[172..174]);
 
     Ok(L1BlockInfo {
         l1_base_fee,
@@ -368,7 +355,7 @@ impl RethL1BlockInfo for L1BlockInfo {
 mod tests {
     use alloy_consensus::{Block, BlockBody, Header};
     use alloy_eips::eip2718::Decodable2718;
-    use alloy_primitives::{Bytes, hex_literal::hex, keccak256};
+    use alloy_primitives::{Bytes, U16, hex_literal::hex, keccak256};
     use base_common_chains::Upgrades;
     use base_common_consensus::BaseTransactionSigned;
     use base_execution_chainspec::BaseChainSpec;
@@ -529,5 +516,27 @@ mod tests {
         assert_eq!(l1_block_info.operator_fee_scalar, operator_fee_scalar);
         assert_eq!(l1_block_info.operator_fee_constant, operator_fee_constant);
         assert_eq!(l1_block_info.da_footprint_gas_scalar, da_footprint_gas_scalar);
+    }
+
+    #[test]
+    fn parse_l1_info_rejects_unexpected_lengths() {
+        for (selector, data_len) in [
+            ([0u8; 4], 256),
+            (L1_BLOCK_ECOTONE_SELECTOR, 160),
+            (L1_BLOCK_ISTHMUS_SELECTOR, 172),
+            (L1_BLOCK_JOVIAN_SELECTOR, 174),
+        ] {
+            for invalid_len in [data_len - 1, data_len + 1] {
+                let mut input = vec![0u8; 4 + invalid_len];
+                input[..4].copy_from_slice(&selector);
+
+                assert!(matches!(
+                    parse_l1_info(&input),
+                    Err(BaseBlockExecutionError::L1BlockInfo(
+                        L1BlockInfoError::UnexpectedCalldataLength
+                    ))
+                ));
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary

This PR speeds up two L1-info hot paths without changing the public execution semantics.

First, it makes upgraded L1 block-info calldata parsing use fixed-width reads after exact calldata length checks instead of fallible wide integer conversions. In the Criterion benchmark, Ecotone improved from 19.987 ns to 12.735 ns (36.3% faster), Isthmus from 18.269 ns to 13.134 ns (25.7% faster), and Jovian from 20.256 ns to 13.855 ns (32.0% faster), while Bedrock stayed flat at 11.298 ns to 11.249 ns.

Second, it tightens L1 block-info state loading for Jovian. Isthmus operator fee scalars and Jovian `daFootprintGasScalar` are both packed into slot 8, so `L1BlockInfo::try_fetch` now reuses the already-loaded Isthmus slot instead of doing a second storage lookup for Jovian. The before/after `l1block` benchmark reported Jovian `try_fetch` improving from 264.52 ns to 234.26 ns with Criterion's central change at 11.8% faster; a final rerun of this exact diff measured 238.45 ns, still 9.9% faster than that captured baseline. Isthmus remains effectively unchanged because it performs the same state reads: 228.72 ns baseline, 237.14 ns final rerun, with Criterion classifying the delta as within noise.

The change also adds benchmark coverage plus parser invalid-length coverage for Bedrock, Ecotone, Isthmus, and Jovian, and a focused Jovian state-loading test proving the shared packed slot decodes the operator fee fields and DA footprint scalar together.

## Validation

- `cargo fmt --check` (passes; emits existing stable-toolchain warnings for nightly rustfmt options)
- `cargo test -p base-execution-evm l1`
- `cargo test -p base-execution-evm`
- `cargo clippy -p base-execution-evm --all-targets -- -D warnings`
- `cargo bench -p base-execution-evm --bench l1_info -- --warm-up-time 1 --measurement-time 3 --sample-size 20`
- `cargo test -p base-common-evm`
- `cargo clippy -p base-common-evm --all-targets -- -D warnings`
- `cargo bench -p base-common-evm --bench l1block -- --warm-up-time 1 --measurement-time 3 --sample-size 20`
