### PR TITLE
feat(native-dex): Demonstrate Native DEX Swaps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3397,6 +3397,7 @@ dependencies = [
  "alloy-sol-types",
  "base-common-chains",
  "revm",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8060,6 +8060,7 @@ dependencies = [
  "base-bundle-extension",
  "base-common-genesis",
  "base-common-network",
+ "base-common-precompiles",
  "base-common-rpc-types",
  "base-consensus-disc",
  "base-consensus-gossip",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3392,6 +3392,9 @@ dependencies = [
 name = "base-common-precompiles"
 version = "0.0.0"
 dependencies = [
+ "alloy-evm",
+ "alloy-primitives",
+ "alloy-sol-types",
  "base-common-chains",
  "revm",
 ]
@@ -8048,8 +8051,10 @@ dependencies = [
  "alloy-provider",
  "alloy-rpc-client",
  "alloy-rpc-types-engine",
+ "alloy-rpc-types-eth",
  "alloy-signer",
  "alloy-signer-local",
+ "alloy-sol-types",
  "base-batcher-service",
  "base-builder-core",
  "base-bundle-extension",

--- a/actions/harness/Cargo.toml
+++ b/actions/harness/Cargo.toml
@@ -81,3 +81,6 @@ serde_json.workspace = true
 base-blobs.workspace = true
 tokio = { workspace = true, features = ["rt", "macros"] }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
+
+[features]
+native-dex = [ "base-execution-evm/native-dex" ]

--- a/crates/builder/core/Cargo.toml
+++ b/crates/builder/core/Cargo.toml
@@ -189,6 +189,7 @@ http-body-util.workspace = true
 
 [features]
 default = [ "jemalloc", "metrics" ]
+native-dex = [ "base-execution-evm/native-dex" ]
 metrics = [
 	"base-metrics/metrics",
 	"dep:metrics",

--- a/crates/common/evm/Cargo.toml
+++ b/crates/common/evm/Cargo.toml
@@ -46,6 +46,7 @@ serde_json = { workspace = true, default-features = false, features = ["alloc", 
 
 [features]
 default = [ "blst", "c-kzg", "portable", "secp256k1", "std" ]
+native-dex = [ "base-common-precompiles/native-dex" ]
 std = [
 	"alloy-consensus/std",
 	"alloy-eips/std",

--- a/crates/common/evm/src/factory.rs
+++ b/crates/common/evm/src/factory.rs
@@ -1,4 +1,8 @@
 use alloy_evm::{Database, EvmEnv, EvmFactory, precompiles::PrecompilesMap};
+#[cfg(feature = "native-dex")]
+use base_common_chains::BaseUpgrade;
+#[cfg(feature = "native-dex")]
+use base_common_precompiles::{BASE_DEX_ADDRESS, BaseDexPrecompile};
 use revm::{
     Context, Inspector,
     context::{BlockEnv, TxEnv},
@@ -20,6 +24,27 @@ use crate::{
 #[non_exhaustive]
 pub struct BaseEvmFactory;
 
+impl BaseEvmFactory {
+    fn precompiles(input: &EvmEnv<BaseSpecId>) -> PrecompilesMap {
+        Self::precompiles_for_spec(input.cfg_env.spec)
+    }
+
+    fn precompiles_for_spec(spec: BaseSpecId) -> PrecompilesMap {
+        let precompiles =
+            PrecompilesMap::from_static(BasePrecompiles::new_with_spec(spec).precompiles());
+
+        #[cfg(feature = "native-dex")]
+        let mut precompiles = precompiles;
+
+        #[cfg(feature = "native-dex")]
+        if spec.is_enabled_in(BaseUpgrade::Beryl) {
+            precompiles.extend_precompiles([(BASE_DEX_ADDRESS, BaseDexPrecompile::precompile())]);
+        }
+
+        precompiles
+    }
+}
+
 impl EvmFactory for BaseEvmFactory {
     type Evm<DB: Database, I: Inspector<BaseContext<DB>>> = BaseEvm<DB, I, PrecompilesMap>;
     type Context<DB: Database> = BaseContext<DB>;
@@ -36,16 +61,14 @@ impl EvmFactory for BaseEvmFactory {
         db: DB,
         input: EvmEnv<BaseSpecId>,
     ) -> Self::Evm<DB, NoOpInspector> {
-        let spec_id = input.cfg_env.spec;
+        let precompiles = Self::precompiles(&input);
         Context::base()
             .with_db(db)
             .with_block(input.block_env)
             .with_cfg(input.cfg_env)
             .build_base()
             .with_inspector(NoOpInspector {})
-            .with_precompiles(PrecompilesMap::from_static(
-                BasePrecompiles::new_with_spec(spec_id).precompiles(),
-            ))
+            .with_precompiles(precompiles)
     }
 
     fn create_evm_with_inspector<DB: Database, I: Inspector<Self::Context<DB>>>(
@@ -54,14 +77,31 @@ impl EvmFactory for BaseEvmFactory {
         input: EvmEnv<BaseSpecId>,
         inspector: I,
     ) -> Self::Evm<DB, I> {
-        let spec_id = input.cfg_env.spec;
+        let precompiles = Self::precompiles(&input);
         Context::base()
             .with_db(db)
             .with_block(input.block_env)
             .with_cfg(input.cfg_env)
             .build_with_inspector(inspector)
-            .with_precompiles(PrecompilesMap::from_static(
-                BasePrecompiles::new_with_spec(spec_id).precompiles(),
-            ))
+            .with_precompiles(precompiles)
+    }
+}
+
+#[cfg(all(test, feature = "native-dex"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn native_dex_precompile_is_absent_before_beryl() {
+        let precompiles = BaseEvmFactory::precompiles_for_spec(BaseSpecId::new(BaseUpgrade::Azul));
+
+        assert!(precompiles.get(&BASE_DEX_ADDRESS).is_none());
+    }
+
+    #[test]
+    fn native_dex_precompile_is_present_at_beryl() {
+        let precompiles = BaseEvmFactory::precompiles_for_spec(BaseSpecId::new(BaseUpgrade::Beryl));
+
+        assert!(precompiles.get(&BASE_DEX_ADDRESS).is_some());
     }
 }

--- a/crates/common/precompiles/Cargo.toml
+++ b/crates/common/precompiles/Cargo.toml
@@ -29,7 +29,12 @@ tracing = { workspace = true, optional = true }
 
 [features]
 default = [ "blst", "c-kzg", "portable", "secp256k1", "std" ]
-native-dex = [ "dep:alloy-evm", "dep:alloy-primitives", "dep:alloy-sol-types", "dep:tracing" ]
+native-dex = [
+	"dep:alloy-evm",
+	"dep:alloy-primitives",
+	"dep:alloy-sol-types",
+	"dep:tracing",
+]
 std = [
 	"alloy-evm?/std",
 	"alloy-primitives?/std",

--- a/crates/common/precompiles/Cargo.toml
+++ b/crates/common/precompiles/Cargo.toml
@@ -24,9 +24,12 @@ base-common-chains.workspace = true
 # revm
 revm.workspace = true
 
+# misc
+tracing = { workspace = true, optional = true }
+
 [features]
 default = [ "blst", "c-kzg", "portable", "secp256k1", "std" ]
-native-dex = [ "dep:alloy-evm", "dep:alloy-primitives", "dep:alloy-sol-types" ]
+native-dex = [ "dep:alloy-evm", "dep:alloy-primitives", "dep:alloy-sol-types", "dep:tracing" ]
 std = [
 	"alloy-evm?/std",
 	"alloy-primitives?/std",

--- a/crates/common/precompiles/Cargo.toml
+++ b/crates/common/precompiles/Cargo.toml
@@ -13,6 +13,11 @@ exclude.workspace = true
 workspace = true
 
 [dependencies]
+# alloy
+alloy-evm = { workspace = true, optional = true }
+alloy-primitives = { workspace = true, optional = true }
+alloy-sol-types = { workspace = true, optional = true, default-features = false }
+
 # base
 base-common-chains.workspace = true
 
@@ -21,7 +26,14 @@ revm.workspace = true
 
 [features]
 default = [ "blst", "c-kzg", "portable", "secp256k1", "std" ]
-std = [ "base-common-chains/std", "revm/std" ]
+native-dex = [ "dep:alloy-evm", "dep:alloy-primitives", "dep:alloy-sol-types" ]
+std = [
+	"alloy-evm?/std",
+	"alloy-primitives?/std",
+	"alloy-sol-types?/std",
+	"base-common-chains/std",
+	"revm/std",
+]
 bn = [ "revm/bn" ]
 blst = [ "revm/blst" ]
 c-kzg = [ "revm/c-kzg" ]

--- a/crates/common/precompiles/src/dex/abi.rs
+++ b/crates/common/precompiles/src/dex/abi.rs
@@ -1,0 +1,89 @@
+//! ABI types for the native DEX precompile.
+
+use alloy_primitives::{Address, address};
+use alloy_sol_types::sol;
+
+/// Native DEX singleton precompile address.
+pub const BASE_DEX_ADDRESS: Address = address!("0000000000000000000000000000000000000dE7");
+
+pub(crate) const BASE_TOKEN_ADDRESS: Address = Address::ZERO;
+
+sol! {
+    #[derive(Debug, PartialEq, Eq)]
+    interface IBaseDex {
+        struct Pool {
+            uint128 reserveToken;
+            uint128 reserveBase;
+            uint256 totalSupply;
+        }
+
+        function BASE_TOKEN() external view returns (address);
+        function getPool(address token) external view returns (Pool memory);
+        function quoteExactInput(address tokenIn, address tokenOut, uint256 amountIn)
+            external view returns (uint256 amountOut);
+
+        function addLiquidity(address token, uint256 amountToken, uint256 amountBase, address to)
+            external returns (uint256 liquidity);
+        function removeLiquidity(address token, uint256 liquidity, address to)
+            external returns (uint256 amountToken, uint256 amountBase);
+        function swapExactTokensForTokens(
+            address tokenIn,
+            address tokenOut,
+            uint256 amountIn,
+            uint256 minAmountOut,
+            address to
+        ) external returns (uint256 amountOut);
+
+        event Mint(address indexed sender, address indexed token, uint256 amountToken, uint256 amountBase, uint256 liquidity, address indexed to);
+        event Burn(address indexed sender, address indexed token, uint256 amountToken, uint256 amountBase, uint256 liquidity, address to);
+        event Swap(address indexed sender, address indexed tokenIn, address indexed tokenOut, uint256 amountIn, uint256 amountOut, address to);
+
+        error IdenticalTokens();
+        error InvalidToken();
+        error InvalidAmount();
+        error InsufficientLiquidity();
+        error InsufficientOutputAmount();
+        error InvalidSwapPath();
+        error StaticCallNotAllowed();
+        error DelegateCallNotAllowed();
+    }
+}
+
+pub(crate) use IBaseDex::{IBaseDexCalls, IBaseDexErrors as BaseDexError};
+
+#[cfg(test)]
+mod tests {
+    use alloy_primitives::{U256, address};
+    use alloy_sol_types::{SolCall, SolError, SolInterface};
+
+    use super::*;
+
+    #[test]
+    fn decodes_quote_exact_input_call() {
+        let token_in = address!("1111111111111111111111111111111111111111");
+        let token_out = address!("2222222222222222222222222222222222222222");
+        let calldata = IBaseDex::quoteExactInputCall {
+            tokenIn: token_in,
+            tokenOut: token_out,
+            amountIn: U256::from(123),
+        }
+        .abi_encode();
+
+        assert_eq!(
+            IBaseDexCalls::abi_decode(&calldata),
+            Ok(IBaseDexCalls::quoteExactInput(IBaseDex::quoteExactInputCall {
+                tokenIn: token_in,
+                tokenOut: token_out,
+                amountIn: U256::from(123),
+            }))
+        );
+    }
+
+    #[test]
+    fn encodes_custom_error_selector() {
+        assert_eq!(
+            BaseDexError::InvalidToken(IBaseDex::InvalidToken {}).abi_encode().as_slice(),
+            &IBaseDex::InvalidToken::SELECTOR
+        );
+    }
+}

--- a/crates/common/precompiles/src/dex/dispatch.rs
+++ b/crates/common/precompiles/src/dex/dispatch.rs
@@ -171,7 +171,7 @@ impl BaseDexPrecompile {
         None
     }
 
-    fn is_mutating(call: &IBaseDexCalls) -> bool {
+    const fn is_mutating(call: &IBaseDexCalls) -> bool {
         matches!(
             call,
             IBaseDexCalls::addLiquidity(_)

--- a/crates/common/precompiles/src/dex/dispatch.rs
+++ b/crates/common/precompiles/src/dex/dispatch.rs
@@ -1,0 +1,307 @@
+//! Dispatch for the native DEX precompile.
+
+use alloy_evm::precompiles::{DynPrecompile, PrecompileInput};
+use alloy_primitives::{Address, Bytes};
+use alloy_sol_types::{SolCall, SolInterface};
+use revm::precompile::{PrecompileId, PrecompileOutput, PrecompileResult};
+
+use super::{BASE_DEX_ADDRESS, BaseDex, BaseDexError, DexStorage, IBaseDex, IBaseDexCalls};
+
+/// Native DEX stateful precompile.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct BaseDexPrecompile;
+
+impl BaseDexPrecompile {
+    /// Returns this precompile as a stateful dynamic precompile.
+    pub fn precompile() -> DynPrecompile {
+        DynPrecompile::new_stateful(PrecompileId::Custom("BaseDex".into()), Self::run)
+    }
+
+    fn run(input: PrecompileInput<'_>) -> PrecompileResult {
+        if !input.is_direct_call() {
+            return Ok(Self::revert(BaseDexError::DelegateCallNotAllowed(
+                IBaseDex::DelegateCallNotAllowed {},
+            )));
+        }
+
+        let storage = DexStorage::new(BASE_DEX_ADDRESS, input.internals);
+        Self::dispatch(storage, input.data, input.caller, input.is_static)
+    }
+
+    fn dispatch(
+        storage: DexStorage<'_>,
+        calldata: &[u8],
+        caller: Address,
+        is_static: bool,
+    ) -> PrecompileResult {
+        let call = match IBaseDexCalls::abi_decode(calldata) {
+            Ok(call) => call,
+            Err(_) => return Ok(PrecompileOutput::new_reverted(0, Bytes::new())),
+        };
+
+        if let Some(output) = Self::static_revert(&call, is_static) {
+            return Ok(output);
+        }
+
+        let mut dex = BaseDex::new(storage);
+        match call {
+            IBaseDexCalls::BASE_TOKEN(_) => {
+                Ok(Self::success(IBaseDex::BASE_TOKENCall::abi_encode_returns(&dex.base_token())))
+            }
+            IBaseDexCalls::getPool(call) => Self::get_pool(&mut dex, call.token),
+            IBaseDexCalls::quoteExactInput(call) => {
+                Self::quote_exact_input(&mut dex, call.tokenIn, call.tokenOut, call.amountIn)
+            }
+            IBaseDexCalls::addLiquidity(call) => Self::add_liquidity(
+                &mut dex,
+                caller,
+                call.token,
+                call.amountToken,
+                call.amountBase,
+                call.to,
+            ),
+            IBaseDexCalls::removeLiquidity(call) => {
+                Self::remove_liquidity(&mut dex, caller, call.token, call.liquidity, call.to)
+            }
+            IBaseDexCalls::swapExactTokensForTokens(call) => Self::swap_exact_tokens_for_tokens(
+                &mut dex,
+                caller,
+                call.tokenIn,
+                call.tokenOut,
+                call.amountIn,
+                call.minAmountOut,
+                call.to,
+            ),
+        }
+    }
+
+    fn get_pool(dex: &mut BaseDex<'_>, token: Address) -> PrecompileResult {
+        match dex.get_pool(token) {
+            Ok(pool) => {
+                Ok(Self::success(IBaseDex::getPoolCall::abi_encode_returns(&IBaseDex::Pool {
+                    reserveToken: pool.reserve_token,
+                    reserveBase: pool.reserve_base,
+                    totalSupply: pool.total_lp_supply,
+                })))
+            }
+            Err(error) => Ok(Self::revert(error)),
+        }
+    }
+
+    fn quote_exact_input(
+        dex: &mut BaseDex<'_>,
+        token_in: Address,
+        token_out: Address,
+        amount_in: alloy_primitives::U256,
+    ) -> PrecompileResult {
+        match dex.quote_exact_input(token_in, token_out, amount_in) {
+            Ok(amount_out) => {
+                Ok(Self::success(IBaseDex::quoteExactInputCall::abi_encode_returns(&amount_out)))
+            }
+            Err(error) => Ok(Self::revert(error)),
+        }
+    }
+
+    fn add_liquidity(
+        dex: &mut BaseDex<'_>,
+        caller: Address,
+        token: Address,
+        amount_token: alloy_primitives::U256,
+        amount_base: alloy_primitives::U256,
+        to: Address,
+    ) -> PrecompileResult {
+        match dex.add_liquidity(caller, token, amount_token, amount_base, to) {
+            Ok(liquidity) => {
+                Ok(Self::success(IBaseDex::addLiquidityCall::abi_encode_returns(&liquidity)))
+            }
+            Err(error) => Ok(Self::revert(error)),
+        }
+    }
+
+    fn remove_liquidity(
+        dex: &mut BaseDex<'_>,
+        caller: Address,
+        token: Address,
+        liquidity: alloy_primitives::U256,
+        to: Address,
+    ) -> PrecompileResult {
+        match dex.remove_liquidity(caller, token, liquidity, to) {
+            Ok((amount_token, amount_base)) => {
+                Ok(Self::success(IBaseDex::removeLiquidityCall::abi_encode_returns(
+                    &IBaseDex::removeLiquidityReturn {
+                        amountToken: amount_token,
+                        amountBase: amount_base,
+                    },
+                )))
+            }
+            Err(error) => Ok(Self::revert(error)),
+        }
+    }
+
+    fn swap_exact_tokens_for_tokens(
+        dex: &mut BaseDex<'_>,
+        caller: Address,
+        token_in: Address,
+        token_out: Address,
+        amount_in: alloy_primitives::U256,
+        min_amount_out: alloy_primitives::U256,
+        to: Address,
+    ) -> PrecompileResult {
+        match dex.swap_exact_tokens_for_tokens(
+            caller,
+            token_in,
+            token_out,
+            amount_in,
+            min_amount_out,
+            to,
+        ) {
+            Ok(amount_out) => Ok(Self::success(
+                IBaseDex::swapExactTokensForTokensCall::abi_encode_returns(&amount_out),
+            )),
+            Err(error) => Ok(Self::revert(error)),
+        }
+    }
+
+    fn static_revert(call: &IBaseDexCalls, is_static: bool) -> Option<PrecompileOutput> {
+        if is_static && Self::is_mutating(call) {
+            return Some(Self::revert(BaseDexError::StaticCallNotAllowed(
+                IBaseDex::StaticCallNotAllowed {},
+            )));
+        }
+        None
+    }
+
+    fn is_mutating(call: &IBaseDexCalls) -> bool {
+        matches!(
+            call,
+            IBaseDexCalls::addLiquidity(_)
+                | IBaseDexCalls::removeLiquidity(_)
+                | IBaseDexCalls::swapExactTokensForTokens(_)
+        )
+    }
+
+    fn success(bytes: impl Into<Bytes>) -> PrecompileOutput {
+        PrecompileOutput::new(0, bytes.into())
+    }
+
+    fn revert(error: BaseDexError) -> PrecompileOutput {
+        PrecompileOutput::new_reverted(0, error.abi_encode().into())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_evm::{
+        EvmInternals,
+        eth::EthEvmContext,
+        precompiles::{Precompile, PrecompileInput},
+    };
+    use alloy_primitives::{Address, U256, address};
+    use alloy_sol_types::SolCall;
+    use revm::database::EmptyDB;
+
+    use super::*;
+
+    #[test]
+    fn static_mutating_call_reverts_with_generated_error() {
+        let call = IBaseDexCalls::addLiquidity(IBaseDex::addLiquidityCall {
+            token: address!("1111111111111111111111111111111111111111"),
+            amountToken: U256::from(1),
+            amountBase: U256::from(1),
+            to: address!("2222222222222222222222222222222222222222"),
+        });
+
+        let output = BaseDexPrecompile::static_revert(&call, true).unwrap();
+
+        assert!(output.reverted);
+        assert_eq!(
+            output.bytes.as_ref(),
+            BaseDexError::StaticCallNotAllowed(IBaseDex::StaticCallNotAllowed {})
+                .abi_encode()
+                .as_slice()
+        );
+    }
+
+    #[test]
+    fn view_call_is_not_rejected_in_static_context() {
+        let call = IBaseDexCalls::BASE_TOKEN(IBaseDex::BASE_TOKENCall {});
+
+        assert!(BaseDexPrecompile::static_revert(&call, true).is_none());
+    }
+
+    #[test]
+    fn add_liquidity_reaches_stubbed_token_boundary() {
+        let calldata = IBaseDex::addLiquidityCall {
+            token: address!("1111111111111111111111111111111111111111"),
+            amountToken: U256::from(1),
+            amountBase: U256::from(1),
+            to: address!("2222222222222222222222222222222222222222"),
+        }
+        .abi_encode();
+        let mut context = EthEvmContext::new(EmptyDB::default(), Default::default());
+        let result = BaseDexPrecompile::precompile()
+            .call(PrecompileInput {
+                data: &calldata,
+                gas: u64::MAX,
+                caller: Address::ZERO,
+                value: U256::ZERO,
+                target_address: BASE_DEX_ADDRESS,
+                is_static: false,
+                bytecode_address: BASE_DEX_ADDRESS,
+                internals: EvmInternals::from_context(&mut context),
+            })
+            .unwrap();
+
+        assert!(result.reverted);
+        assert_eq!(
+            result.bytes.as_ref(),
+            BaseDexError::InvalidToken(IBaseDex::InvalidToken {}).abi_encode().as_slice()
+        );
+    }
+
+    #[test]
+    fn successful_liquidity_call_updates_pool_storage() {
+        let token = address!("0000000000000000000000000000000000000dE8");
+        let caller = address!("1111111111111111111111111111111111111111");
+        let add_liquidity = IBaseDex::addLiquidityCall {
+            token,
+            amountToken: U256::from(1_000_000),
+            amountBase: U256::from(1_000_000),
+            to: caller,
+        }
+        .abi_encode();
+        let get_pool = IBaseDex::getPoolCall { token }.abi_encode();
+        let mut context = EthEvmContext::new(EmptyDB::default(), Default::default());
+        let add_result = BaseDexPrecompile::precompile()
+            .call(PrecompileInput {
+                data: &add_liquidity,
+                gas: u64::MAX,
+                caller,
+                value: U256::ZERO,
+                target_address: BASE_DEX_ADDRESS,
+                is_static: false,
+                bytecode_address: BASE_DEX_ADDRESS,
+                internals: EvmInternals::from_context(&mut context),
+            })
+            .unwrap();
+
+        assert!(!add_result.reverted);
+
+        let get_result = BaseDexPrecompile::precompile()
+            .call(PrecompileInput {
+                data: &get_pool,
+                gas: u64::MAX,
+                caller,
+                value: U256::ZERO,
+                target_address: BASE_DEX_ADDRESS,
+                is_static: true,
+                bytecode_address: BASE_DEX_ADDRESS,
+                internals: EvmInternals::from_context(&mut context),
+            })
+            .unwrap();
+        let pool = IBaseDex::getPoolCall::abi_decode_returns(&get_result.bytes).unwrap();
+
+        assert_eq!(pool.reserveToken, 1_000_000);
+        assert_eq!(pool.reserveBase, 1_000_000);
+    }
+}

--- a/crates/common/precompiles/src/dex/dispatch.rs
+++ b/crates/common/precompiles/src/dex/dispatch.rs
@@ -323,6 +323,38 @@ mod tests {
     }
 
     #[test]
+    fn swap_rejects_unknown_token_as_invalid_token() {
+        let calldata = IBaseDex::swapExactTokensForTokensCall {
+            tokenIn: address!("1111111111111111111111111111111111111111"),
+            tokenOut: address!("0000000000000000000000000000000000000dE9"),
+            amountIn: U256::from(1),
+            minAmountOut: U256::ZERO,
+            to: address!("2222222222222222222222222222222222222222"),
+        }
+        .abi_encode();
+        let mut context = EthEvmContext::new(EmptyDB::default(), Default::default());
+        let result = BaseDexPrecompile::precompile()
+            .call(PrecompileInput {
+                data: &calldata,
+                gas: u64::MAX,
+                caller: Address::ZERO,
+                value: U256::ZERO,
+                target_address: BASE_DEX_ADDRESS,
+                is_static: false,
+                bytecode_address: BASE_DEX_ADDRESS,
+                internals: EvmInternals::from_context(&mut context),
+            })
+            .unwrap();
+
+        assert!(result.reverted);
+        assert!(result.gas_used > 0);
+        assert_eq!(
+            result.bytes.as_ref(),
+            BaseDexError::InvalidToken(IBaseDex::InvalidToken {}).abi_encode().as_slice()
+        );
+    }
+
+    #[test]
     fn successful_liquidity_call_updates_pool_storage() {
         let token = address!("0000000000000000000000000000000000000dE8");
         let caller = address!("1111111111111111111111111111111111111111");

--- a/crates/common/precompiles/src/dex/dispatch.rs
+++ b/crates/common/precompiles/src/dex/dispatch.rs
@@ -5,7 +5,9 @@ use alloy_primitives::{Address, Bytes};
 use alloy_sol_types::{SolCall, SolInterface};
 use revm::precompile::{PrecompileId, PrecompileOutput, PrecompileResult};
 
-use super::{BASE_DEX_ADDRESS, BaseDex, BaseDexError, DexStorage, IBaseDex, IBaseDexCalls};
+use super::{
+    BASE_DEX_ADDRESS, BaseDex, BaseDexError, DexGasMeter, DexStorage, IBaseDex, IBaseDexCalls,
+};
 
 /// Native DEX stateful precompile.
 #[derive(Debug, Default, Clone, Copy)]
@@ -18,42 +20,51 @@ impl BaseDexPrecompile {
     }
 
     fn run(input: PrecompileInput<'_>) -> PrecompileResult {
+        let mut gas = DexGasMeter::new(input.gas);
+        gas.charge_calldata(input.data)?;
+
         if !input.is_direct_call() {
-            return Ok(Self::revert(BaseDexError::DelegateCallNotAllowed(
-                IBaseDex::DelegateCallNotAllowed {},
-            )));
+            return Ok(Self::revert(
+                &gas,
+                BaseDexError::DelegateCallNotAllowed(IBaseDex::DelegateCallNotAllowed {}),
+            ));
         }
 
         let storage = DexStorage::new(BASE_DEX_ADDRESS, input.internals);
-        Self::dispatch(storage, input.data, input.caller, input.is_static)
+        Self::dispatch(storage, &mut gas, input.data, input.caller, input.is_static)
     }
 
     fn dispatch(
         storage: DexStorage<'_>,
+        gas: &mut DexGasMeter,
         calldata: &[u8],
         caller: Address,
         is_static: bool,
     ) -> PrecompileResult {
         let call = match IBaseDexCalls::abi_decode(calldata) {
             Ok(call) => call,
-            Err(_) => return Ok(PrecompileOutput::new_reverted(0, Bytes::new())),
+            Err(_) => return Ok(Self::raw_revert(gas.used(), Bytes::new())),
         };
 
-        if let Some(output) = Self::static_revert(&call, is_static) {
-            return Ok(output);
+        gas.charge_call(&call)?;
+
+        if let Some(error) = Self::static_revert(&call, is_static) {
+            return Ok(Self::revert(gas, error));
         }
 
         let mut dex = BaseDex::new(storage);
         match call {
-            IBaseDexCalls::BASE_TOKEN(_) => {
-                Ok(Self::success(IBaseDex::BASE_TOKENCall::abi_encode_returns(&dex.base_token())))
-            }
-            IBaseDexCalls::getPool(call) => Self::get_pool(&mut dex, call.token),
+            IBaseDexCalls::BASE_TOKEN(_) => Ok(Self::success(
+                gas,
+                IBaseDex::BASE_TOKENCall::abi_encode_returns(&dex.base_token()),
+            )),
+            IBaseDexCalls::getPool(call) => Self::get_pool(&mut dex, gas, call.token),
             IBaseDexCalls::quoteExactInput(call) => {
-                Self::quote_exact_input(&mut dex, call.tokenIn, call.tokenOut, call.amountIn)
+                Self::quote_exact_input(&mut dex, gas, call.tokenIn, call.tokenOut, call.amountIn)
             }
             IBaseDexCalls::addLiquidity(call) => Self::add_liquidity(
                 &mut dex,
+                gas,
                 caller,
                 call.token,
                 call.amountToken,
@@ -61,49 +72,47 @@ impl BaseDexPrecompile {
                 call.to,
             ),
             IBaseDexCalls::removeLiquidity(call) => {
-                Self::remove_liquidity(&mut dex, caller, call.token, call.liquidity, call.to)
+                Self::remove_liquidity(&mut dex, gas, caller, call.token, call.liquidity, call.to)
             }
-            IBaseDexCalls::swapExactTokensForTokens(call) => Self::swap_exact_tokens_for_tokens(
-                &mut dex,
-                caller,
-                call.tokenIn,
-                call.tokenOut,
-                call.amountIn,
-                call.minAmountOut,
-                call.to,
-            ),
+            IBaseDexCalls::swapExactTokensForTokens(call) => {
+                Self::swap_exact_tokens_for_tokens(&mut dex, gas, caller, call)
+            }
         }
     }
 
-    fn get_pool(dex: &mut BaseDex<'_>, token: Address) -> PrecompileResult {
+    fn get_pool(dex: &mut BaseDex<'_>, gas: &DexGasMeter, token: Address) -> PrecompileResult {
         match dex.get_pool(token) {
-            Ok(pool) => {
-                Ok(Self::success(IBaseDex::getPoolCall::abi_encode_returns(&IBaseDex::Pool {
+            Ok(pool) => Ok(Self::success(
+                gas,
+                IBaseDex::getPoolCall::abi_encode_returns(&IBaseDex::Pool {
                     reserveToken: pool.reserve_token,
                     reserveBase: pool.reserve_base,
                     totalSupply: pool.total_lp_supply,
-                })))
-            }
-            Err(error) => Ok(Self::revert(error)),
+                }),
+            )),
+            Err(error) => Ok(Self::revert(gas, error)),
         }
     }
 
     fn quote_exact_input(
         dex: &mut BaseDex<'_>,
+        gas: &DexGasMeter,
         token_in: Address,
         token_out: Address,
         amount_in: alloy_primitives::U256,
     ) -> PrecompileResult {
         match dex.quote_exact_input(token_in, token_out, amount_in) {
-            Ok(amount_out) => {
-                Ok(Self::success(IBaseDex::quoteExactInputCall::abi_encode_returns(&amount_out)))
-            }
-            Err(error) => Ok(Self::revert(error)),
+            Ok(amount_out) => Ok(Self::success(
+                gas,
+                IBaseDex::quoteExactInputCall::abi_encode_returns(&amount_out),
+            )),
+            Err(error) => Ok(Self::revert(gas, error)),
         }
     }
 
     fn add_liquidity(
         dex: &mut BaseDex<'_>,
+        gas: &DexGasMeter,
         caller: Address,
         token: Address,
         amount_token: alloy_primitives::U256,
@@ -112,61 +121,59 @@ impl BaseDexPrecompile {
     ) -> PrecompileResult {
         match dex.add_liquidity(caller, token, amount_token, amount_base, to) {
             Ok(liquidity) => {
-                Ok(Self::success(IBaseDex::addLiquidityCall::abi_encode_returns(&liquidity)))
+                Ok(Self::success(gas, IBaseDex::addLiquidityCall::abi_encode_returns(&liquidity)))
             }
-            Err(error) => Ok(Self::revert(error)),
+            Err(error) => Ok(Self::revert(gas, error)),
         }
     }
 
     fn remove_liquidity(
         dex: &mut BaseDex<'_>,
+        gas: &DexGasMeter,
         caller: Address,
         token: Address,
         liquidity: alloy_primitives::U256,
         to: Address,
     ) -> PrecompileResult {
         match dex.remove_liquidity(caller, token, liquidity, to) {
-            Ok((amount_token, amount_base)) => {
-                Ok(Self::success(IBaseDex::removeLiquidityCall::abi_encode_returns(
+            Ok((amount_token, amount_base)) => Ok(Self::success(
+                gas,
+                IBaseDex::removeLiquidityCall::abi_encode_returns(
                     &IBaseDex::removeLiquidityReturn {
                         amountToken: amount_token,
                         amountBase: amount_base,
                     },
-                )))
-            }
-            Err(error) => Ok(Self::revert(error)),
+                ),
+            )),
+            Err(error) => Ok(Self::revert(gas, error)),
         }
     }
 
     fn swap_exact_tokens_for_tokens(
         dex: &mut BaseDex<'_>,
+        gas: &DexGasMeter,
         caller: Address,
-        token_in: Address,
-        token_out: Address,
-        amount_in: alloy_primitives::U256,
-        min_amount_out: alloy_primitives::U256,
-        to: Address,
+        call: IBaseDex::swapExactTokensForTokensCall,
     ) -> PrecompileResult {
         match dex.swap_exact_tokens_for_tokens(
             caller,
-            token_in,
-            token_out,
-            amount_in,
-            min_amount_out,
-            to,
+            call.tokenIn,
+            call.tokenOut,
+            call.amountIn,
+            call.minAmountOut,
+            call.to,
         ) {
             Ok(amount_out) => Ok(Self::success(
+                gas,
                 IBaseDex::swapExactTokensForTokensCall::abi_encode_returns(&amount_out),
             )),
-            Err(error) => Ok(Self::revert(error)),
+            Err(error) => Ok(Self::revert(gas, error)),
         }
     }
 
-    fn static_revert(call: &IBaseDexCalls, is_static: bool) -> Option<PrecompileOutput> {
+    const fn static_revert(call: &IBaseDexCalls, is_static: bool) -> Option<BaseDexError> {
         if is_static && Self::is_mutating(call) {
-            return Some(Self::revert(BaseDexError::StaticCallNotAllowed(
-                IBaseDex::StaticCallNotAllowed {},
-            )));
+            return Some(BaseDexError::StaticCallNotAllowed(IBaseDex::StaticCallNotAllowed {}));
         }
         None
     }
@@ -180,12 +187,16 @@ impl BaseDexPrecompile {
         )
     }
 
-    fn success(bytes: impl Into<Bytes>) -> PrecompileOutput {
-        PrecompileOutput::new(0, bytes.into())
+    fn success(gas: &DexGasMeter, bytes: impl Into<Bytes>) -> PrecompileOutput {
+        PrecompileOutput::new(gas.used(), bytes.into())
     }
 
-    fn revert(error: BaseDexError) -> PrecompileOutput {
-        PrecompileOutput::new_reverted(0, error.abi_encode().into())
+    fn revert(gas: &DexGasMeter, error: BaseDexError) -> PrecompileOutput {
+        Self::raw_revert(gas.used(), error.abi_encode())
+    }
+
+    fn raw_revert(gas_used: u64, bytes: impl Into<Bytes>) -> PrecompileOutput {
+        PrecompileOutput::new_reverted(gas_used, bytes.into())
     }
 }
 
@@ -198,7 +209,7 @@ mod tests {
     };
     use alloy_primitives::{Address, U256, address};
     use alloy_sol_types::SolCall;
-    use revm::database::EmptyDB;
+    use revm::{database::EmptyDB, precompile::PrecompileError};
 
     use super::*;
 
@@ -211,14 +222,9 @@ mod tests {
             to: address!("2222222222222222222222222222222222222222"),
         });
 
-        let output = BaseDexPrecompile::static_revert(&call, true).unwrap();
-
-        assert!(output.reverted);
         assert_eq!(
-            output.bytes.as_ref(),
-            BaseDexError::StaticCallNotAllowed(IBaseDex::StaticCallNotAllowed {})
-                .abi_encode()
-                .as_slice()
+            BaseDexPrecompile::static_revert(&call, true),
+            Some(BaseDexError::StaticCallNotAllowed(IBaseDex::StaticCallNotAllowed {}))
         );
     }
 
@@ -253,6 +259,7 @@ mod tests {
             .unwrap();
 
         assert!(result.reverted);
+        assert!(result.gas_used > 0);
         assert_eq!(
             result.bytes.as_ref(),
             BaseDexError::InvalidToken(IBaseDex::InvalidToken {}).abi_encode().as_slice()
@@ -286,6 +293,7 @@ mod tests {
             .unwrap();
 
         assert!(!add_result.reverted);
+        assert!(add_result.gas_used > 0);
 
         let get_result = BaseDexPrecompile::precompile()
             .call(PrecompileInput {
@@ -301,7 +309,54 @@ mod tests {
             .unwrap();
         let pool = IBaseDex::getPoolCall::abi_decode_returns(&get_result.bytes).unwrap();
 
+        assert!(get_result.gas_used > 0);
         assert_eq!(pool.reserveToken, 1_000_000);
         assert_eq!(pool.reserveBase, 1_000_000);
+    }
+
+    #[test]
+    fn insufficient_gas_halts_before_state_mutation() {
+        let token = address!("0000000000000000000000000000000000000dE8");
+        let caller = address!("1111111111111111111111111111111111111111");
+        let add_liquidity = IBaseDex::addLiquidityCall {
+            token,
+            amountToken: U256::from(1_000_000),
+            amountBase: U256::from(1_000_000),
+            to: caller,
+        }
+        .abi_encode();
+        let get_pool = IBaseDex::getPoolCall { token }.abi_encode();
+        let mut context = EthEvmContext::new(EmptyDB::default(), Default::default());
+        let err = BaseDexPrecompile::precompile()
+            .call(PrecompileInput {
+                data: &add_liquidity,
+                gas: 1,
+                caller,
+                value: U256::ZERO,
+                target_address: BASE_DEX_ADDRESS,
+                is_static: false,
+                bytecode_address: BASE_DEX_ADDRESS,
+                internals: EvmInternals::from_context(&mut context),
+            })
+            .unwrap_err();
+
+        assert_eq!(err, PrecompileError::OutOfGas);
+
+        let get_result = BaseDexPrecompile::precompile()
+            .call(PrecompileInput {
+                data: &get_pool,
+                gas: u64::MAX,
+                caller,
+                value: U256::ZERO,
+                target_address: BASE_DEX_ADDRESS,
+                is_static: true,
+                bytecode_address: BASE_DEX_ADDRESS,
+                internals: EvmInternals::from_context(&mut context),
+            })
+            .unwrap();
+        let pool = IBaseDex::getPoolCall::abi_decode_returns(&get_result.bytes).unwrap();
+
+        assert_eq!(pool.reserveToken, 0);
+        assert_eq!(pool.reserveBase, 0);
     }
 }

--- a/crates/common/precompiles/src/dex/dispatch.rs
+++ b/crates/common/precompiles/src/dex/dispatch.rs
@@ -312,6 +312,7 @@ mod tests {
         assert!(get_result.gas_used > 0);
         assert_eq!(pool.reserveToken, 1_000_000);
         assert_eq!(pool.reserveBase, 1_000_000);
+        assert_eq!(pool.totalSupply, U256::from(1_000_000));
     }
 
     #[test]
@@ -358,5 +359,6 @@ mod tests {
 
         assert_eq!(pool.reserveToken, 0);
         assert_eq!(pool.reserveBase, 0);
+        assert_eq!(pool.totalSupply, U256::ZERO);
     }
 }

--- a/crates/common/precompiles/src/dex/dispatch.rs
+++ b/crates/common/precompiles/src/dex/dispatch.rs
@@ -30,6 +30,10 @@ impl BaseDexPrecompile {
             ));
         }
 
+        if !input.value.is_zero() {
+            return Ok(Self::raw_revert(gas.used(), Bytes::new()));
+        }
+
         let storage = DexStorage::new(BASE_DEX_ADDRESS, input.internals);
         Self::dispatch(storage, &mut gas, input.data, input.caller, input.is_static)
     }
@@ -233,6 +237,28 @@ mod tests {
         let call = IBaseDexCalls::BASE_TOKEN(IBaseDex::BASE_TOKENCall {});
 
         assert!(BaseDexPrecompile::static_revert(&call, true).is_none());
+    }
+
+    #[test]
+    fn nonzero_value_reverts_before_dispatch() {
+        let calldata = IBaseDex::BASE_TOKENCall {}.abi_encode();
+        let mut context = EthEvmContext::new(EmptyDB::default(), Default::default());
+        let result = BaseDexPrecompile::precompile()
+            .call(PrecompileInput {
+                data: &calldata,
+                gas: u64::MAX,
+                caller: Address::ZERO,
+                value: U256::from(1),
+                target_address: BASE_DEX_ADDRESS,
+                is_static: false,
+                bytecode_address: BASE_DEX_ADDRESS,
+                internals: EvmInternals::from_context(&mut context),
+            })
+            .unwrap();
+
+        assert!(result.reverted);
+        assert!(result.gas_used > 0);
+        assert!(result.bytes.is_empty());
     }
 
     #[test]

--- a/crates/common/precompiles/src/dex/dispatch.rs
+++ b/crates/common/precompiles/src/dex/dispatch.rs
@@ -293,6 +293,36 @@ mod tests {
     }
 
     #[test]
+    fn remove_liquidity_rejects_base_token_as_invalid_token() {
+        let calldata = IBaseDex::removeLiquidityCall {
+            token: Address::ZERO,
+            liquidity: U256::from(1),
+            to: address!("2222222222222222222222222222222222222222"),
+        }
+        .abi_encode();
+        let mut context = EthEvmContext::new(EmptyDB::default(), Default::default());
+        let result = BaseDexPrecompile::precompile()
+            .call(PrecompileInput {
+                data: &calldata,
+                gas: u64::MAX,
+                caller: Address::ZERO,
+                value: U256::ZERO,
+                target_address: BASE_DEX_ADDRESS,
+                is_static: false,
+                bytecode_address: BASE_DEX_ADDRESS,
+                internals: EvmInternals::from_context(&mut context),
+            })
+            .unwrap();
+
+        assert!(result.reverted);
+        assert!(result.gas_used > 0);
+        assert_eq!(
+            result.bytes.as_ref(),
+            BaseDexError::InvalidToken(IBaseDex::InvalidToken {}).abi_encode().as_slice()
+        );
+    }
+
+    #[test]
     fn successful_liquidity_call_updates_pool_storage() {
         let token = address!("0000000000000000000000000000000000000dE8");
         let caller = address!("1111111111111111111111111111111111111111");

--- a/crates/common/precompiles/src/dex/gas.rs
+++ b/crates/common/precompiles/src/dex/gas.rs
@@ -1,0 +1,145 @@
+//! Gas schedule for the native DEX precompile.
+
+use revm::{context_interface::cfg::gas, precompile::PrecompileError};
+
+use super::IBaseDexCalls;
+
+const INPUT_PER_WORD_COST: u64 = 6;
+const SELECTOR_DISPATCH_COST: u64 = 100;
+const ARITHMETIC_COST: u64 = 500;
+const STORAGE_ACCOUNT_TOUCH_COST: u64 = gas::COLD_ACCOUNT_ACCESS_COST;
+const STORAGE_READ_COST: u64 = gas::COLD_SLOAD_COST;
+const STORAGE_WRITE_COST: u64 = gas::COLD_SLOAD_COST + gas::SSTORE_SET;
+
+/// Narrow gas meter for the feature-gated DEX scaffold.
+///
+/// This intentionally prices the current method-level storage footprint rather than trying to
+/// replicate Tempo's full `StorageCtx` abstraction. Once token adapters and dynamic storage
+/// accounting are added, this meter should move closer to the storage operation boundary so cold
+/// versus warm SLOAD/SSTORE costs can be calculated from the actual journal results.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct DexGasMeter {
+    limit: u64,
+    used: u64,
+}
+
+impl DexGasMeter {
+    pub(crate) const fn new(limit: u64) -> Self {
+        Self { limit, used: 0 }
+    }
+
+    pub(crate) const fn charge_calldata(&mut self, calldata: &[u8]) -> Result<(), PrecompileError> {
+        self.charge(Self::input_cost(calldata.len()))
+    }
+
+    pub(crate) const fn charge_call(
+        &mut self,
+        call: &IBaseDexCalls,
+    ) -> Result<(), PrecompileError> {
+        self.charge(Self::call_cost(call))
+    }
+
+    pub(crate) const fn used(&self) -> u64 {
+        self.used
+    }
+
+    const fn charge(&mut self, amount: u64) -> Result<(), PrecompileError> {
+        let Some(used) = self.used.checked_add(amount) else {
+            return Err(PrecompileError::OutOfGas);
+        };
+        if used > self.limit {
+            return Err(PrecompileError::OutOfGas);
+        }
+        self.used = used;
+        Ok(())
+    }
+
+    const fn input_cost(calldata_len: usize) -> u64 {
+        calldata_len.saturating_add(31) as u64 / 32 * INPUT_PER_WORD_COST
+    }
+
+    const fn call_cost(call: &IBaseDexCalls) -> u64 {
+        match call {
+            IBaseDexCalls::BASE_TOKEN(_) => SELECTOR_DISPATCH_COST,
+            IBaseDexCalls::getPool(_) => SELECTOR_DISPATCH_COST + pool_read_cost(),
+            IBaseDexCalls::quoteExactInput(_) => {
+                SELECTOR_DISPATCH_COST + ARITHMETIC_COST + pool_read_cost() * 2
+            }
+            IBaseDexCalls::addLiquidity(_) => {
+                SELECTOR_DISPATCH_COST + lp_update_cost() + log_cost(4, 96)
+            }
+            IBaseDexCalls::removeLiquidity(_) => {
+                SELECTOR_DISPATCH_COST + lp_update_cost() + log_cost(3, 128)
+            }
+            IBaseDexCalls::swapExactTokensForTokens(_) => {
+                SELECTOR_DISPATCH_COST
+                    + ARITHMETIC_COST
+                    + pool_read_cost() * 5
+                    + pool_write_cost() * 2
+                    + log_cost(4, 96)
+            }
+        }
+    }
+}
+
+const fn pool_read_cost() -> u64 {
+    slot_hash_cost(2) + STORAGE_READ_COST * 3
+}
+
+const fn pool_write_cost() -> u64 {
+    slot_hash_cost(2) + STORAGE_ACCOUNT_TOUCH_COST + STORAGE_WRITE_COST * 3
+}
+
+const fn lp_update_cost() -> u64 {
+    pool_read_cost()
+        + slot_hash_cost(3)
+        + STORAGE_READ_COST
+        + STORAGE_WRITE_COST
+        + pool_write_cost()
+}
+
+const fn slot_hash_cost(words: u64) -> u64 {
+    gas::KECCAK256 + gas::KECCAK256WORD * words
+}
+
+const fn log_cost(topics: u64, data_bytes: u64) -> u64 {
+    gas::LOG + gas::LOGTOPIC * topics + gas::LOGDATA * data_bytes
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_primitives::{U256, address};
+
+    use super::*;
+    use crate::dex::IBaseDex;
+
+    #[test]
+    fn input_cost_rounds_up_to_words() {
+        assert_eq!(DexGasMeter::input_cost(0), 0);
+        assert_eq!(DexGasMeter::input_cost(1), INPUT_PER_WORD_COST);
+        assert_eq!(DexGasMeter::input_cost(32), INPUT_PER_WORD_COST);
+        assert_eq!(DexGasMeter::input_cost(33), INPUT_PER_WORD_COST * 2);
+    }
+
+    #[test]
+    fn mutating_calls_cost_more_than_views() {
+        let token = address!("0000000000000000000000000000000000000dE8");
+        let view = IBaseDexCalls::getPool(IBaseDex::getPoolCall { token });
+        let add = IBaseDexCalls::addLiquidity(IBaseDex::addLiquidityCall {
+            token,
+            amountToken: U256::from(1),
+            amountBase: U256::from(1),
+            to: token,
+        });
+
+        assert!(DexGasMeter::call_cost(&add) > DexGasMeter::call_cost(&view));
+    }
+
+    #[test]
+    fn charge_fails_when_limit_is_exceeded() {
+        let mut meter = DexGasMeter::new(1);
+
+        assert_eq!(meter.charge(2), Err(PrecompileError::OutOfGas));
+        assert_eq!(meter.used(), 0);
+    }
+}

--- a/crates/common/precompiles/src/dex/gas.rs
+++ b/crates/common/precompiles/src/dex/gas.rs
@@ -83,11 +83,11 @@ impl DexGasMeter {
 }
 
 const fn pool_read_cost() -> u64 {
-    slot_hash_cost(2) + STORAGE_READ_COST * 3
+    slot_hash_cost(2) * 3 + STORAGE_READ_COST * 3
 }
 
 const fn pool_write_cost() -> u64 {
-    slot_hash_cost(2) + STORAGE_ACCOUNT_TOUCH_COST + STORAGE_WRITE_COST * 3
+    slot_hash_cost(2) * 3 + STORAGE_ACCOUNT_TOUCH_COST + STORAGE_WRITE_COST * 3
 }
 
 const fn lp_update_cost() -> u64 {

--- a/crates/common/precompiles/src/dex/gas.rs
+++ b/crates/common/precompiles/src/dex/gas.rs
@@ -1,8 +1,9 @@
 //! Gas schedule for the native DEX precompile.
 
+use alloy_primitives::Address;
 use revm::{context_interface::cfg::gas, precompile::PrecompileError};
 
-use super::IBaseDexCalls;
+use super::{IBaseDex, IBaseDexCalls, abi::BASE_TOKEN_ADDRESS};
 
 const INPUT_PER_WORD_COST: u64 = 6;
 const SELECTOR_DISPATCH_COST: u64 = 100;
@@ -32,10 +33,7 @@ impl DexGasMeter {
         self.charge(Self::input_cost(calldata.len()))
     }
 
-    pub(crate) const fn charge_call(
-        &mut self,
-        call: &IBaseDexCalls,
-    ) -> Result<(), PrecompileError> {
+    pub(crate) fn charge_call(&mut self, call: &IBaseDexCalls) -> Result<(), PrecompileError> {
         self.charge(Self::call_cost(call))
     }
 
@@ -58,12 +56,12 @@ impl DexGasMeter {
         calldata_len.div_ceil(32) as u64 * INPUT_PER_WORD_COST
     }
 
-    const fn call_cost(call: &IBaseDexCalls) -> u64 {
+    fn call_cost(call: &IBaseDexCalls) -> u64 {
         match call {
             IBaseDexCalls::BASE_TOKEN(_) => SELECTOR_DISPATCH_COST,
             IBaseDexCalls::getPool(_) => SELECTOR_DISPATCH_COST + pool_read_cost(),
-            IBaseDexCalls::quoteExactInput(_) => {
-                SELECTOR_DISPATCH_COST + ARITHMETIC_COST + pool_read_cost() * 2
+            IBaseDexCalls::quoteExactInput(call) => {
+                SELECTOR_DISPATCH_COST + ARITHMETIC_COST + Self::quote_pool_access_cost(call)
             }
             IBaseDexCalls::addLiquidity(_) => {
                 SELECTOR_DISPATCH_COST + lp_update_cost() + log_cost(4, 96)
@@ -71,15 +69,32 @@ impl DexGasMeter {
             IBaseDexCalls::removeLiquidity(_) => {
                 SELECTOR_DISPATCH_COST + lp_update_cost() + log_cost(3, 128)
             }
-            IBaseDexCalls::swapExactTokensForTokens(_) => {
+            IBaseDexCalls::swapExactTokensForTokens(call) => {
                 SELECTOR_DISPATCH_COST
                     + ARITHMETIC_COST
-                    + pool_read_cost() * 5
-                    + pool_write_cost() * 2
+                    + Self::swap_pool_access_cost(call)
                     + log_cost(4, 96)
             }
         }
     }
+
+    fn quote_pool_access_cost(call: &IBaseDex::quoteExactInputCall) -> u64 {
+        if is_single_hop_swap(call.tokenIn, call.tokenOut) {
+            return pool_read_cost();
+        }
+        pool_read_cost() * 2
+    }
+
+    fn swap_pool_access_cost(call: &IBaseDex::swapExactTokensForTokensCall) -> u64 {
+        if is_single_hop_swap(call.tokenIn, call.tokenOut) {
+            return pool_read_cost() * 2 + pool_write_cost();
+        }
+        pool_read_cost() * 5 + pool_write_cost() * 2
+    }
+}
+
+fn is_single_hop_swap(token_in: Address, token_out: Address) -> bool {
+    token_in == BASE_TOKEN_ADDRESS || token_out == BASE_TOKEN_ADDRESS
 }
 
 const fn pool_read_cost() -> u64 {
@@ -133,6 +148,57 @@ mod tests {
         });
 
         assert!(DexGasMeter::call_cost(&add) > DexGasMeter::call_cost(&view));
+    }
+
+    #[test]
+    fn swap_cost_tracks_single_and_two_hop_paths() {
+        let token_a = address!("0000000000000000000000000000000000000dE8");
+        let token_b = address!("0000000000000000000000000000000000000dE9");
+        let two_hop =
+            IBaseDexCalls::swapExactTokensForTokens(IBaseDex::swapExactTokensForTokensCall {
+                tokenIn: token_a,
+                tokenOut: token_b,
+                amountIn: U256::from(1),
+                minAmountOut: U256::ZERO,
+                to: token_b,
+            });
+        let token_to_base =
+            IBaseDexCalls::swapExactTokensForTokens(IBaseDex::swapExactTokensForTokensCall {
+                tokenIn: token_a,
+                tokenOut: BASE_TOKEN_ADDRESS,
+                amountIn: U256::from(1),
+                minAmountOut: U256::ZERO,
+                to: token_b,
+            });
+        let base_to_token =
+            IBaseDexCalls::swapExactTokensForTokens(IBaseDex::swapExactTokensForTokensCall {
+                tokenIn: BASE_TOKEN_ADDRESS,
+                tokenOut: token_b,
+                amountIn: U256::from(1),
+                minAmountOut: U256::ZERO,
+                to: token_b,
+            });
+
+        assert_eq!(DexGasMeter::call_cost(&token_to_base), DexGasMeter::call_cost(&base_to_token));
+        assert!(DexGasMeter::call_cost(&token_to_base) < DexGasMeter::call_cost(&two_hop));
+    }
+
+    #[test]
+    fn quote_cost_tracks_single_and_two_hop_paths() {
+        let token_a = address!("0000000000000000000000000000000000000dE8");
+        let token_b = address!("0000000000000000000000000000000000000dE9");
+        let two_hop = IBaseDexCalls::quoteExactInput(IBaseDex::quoteExactInputCall {
+            tokenIn: token_a,
+            tokenOut: token_b,
+            amountIn: U256::from(1),
+        });
+        let single_hop = IBaseDexCalls::quoteExactInput(IBaseDex::quoteExactInputCall {
+            tokenIn: token_a,
+            tokenOut: BASE_TOKEN_ADDRESS,
+            amountIn: U256::from(1),
+        });
+
+        assert!(DexGasMeter::call_cost(&single_hop) < DexGasMeter::call_cost(&two_hop));
     }
 
     #[test]

--- a/crates/common/precompiles/src/dex/gas.rs
+++ b/crates/common/precompiles/src/dex/gas.rs
@@ -55,7 +55,7 @@ impl DexGasMeter {
     }
 
     const fn input_cost(calldata_len: usize) -> u64 {
-        calldata_len.saturating_add(31) as u64 / 32 * INPUT_PER_WORD_COST
+        calldata_len.div_ceil(32) as u64 * INPUT_PER_WORD_COST
     }
 
     const fn call_cost(call: &IBaseDexCalls) -> u64 {

--- a/crates/common/precompiles/src/dex/math.rs
+++ b/crates/common/precompiles/src/dex/math.rs
@@ -26,14 +26,14 @@ impl ConstantProduct {
 
         let amount_in_with_fee = amount_in
             .checked_mul(FEE_NUMERATOR)
-            .ok_or_else(|| BaseDexError::InvalidAmount(IBaseDex::InvalidAmount {}))?;
+            .ok_or(BaseDexError::InvalidAmount(IBaseDex::InvalidAmount {}))?;
         let numerator = amount_in_with_fee
             .checked_mul(reserve_out)
-            .ok_or_else(|| BaseDexError::InvalidAmount(IBaseDex::InvalidAmount {}))?;
+            .ok_or(BaseDexError::InvalidAmount(IBaseDex::InvalidAmount {}))?;
         let denominator = reserve_in
             .checked_mul(FEE_DENOMINATOR)
             .and_then(|value| value.checked_add(amount_in_with_fee))
-            .ok_or_else(|| BaseDexError::InvalidAmount(IBaseDex::InvalidAmount {}))?;
+            .ok_or(BaseDexError::InvalidAmount(IBaseDex::InvalidAmount {}))?;
 
         let amount_out = numerator / denominator;
         if amount_out.is_zero() {
@@ -54,11 +54,11 @@ impl ConstantProduct {
 
         let product = amount_token
             .checked_mul(amount_base)
-            .ok_or_else(|| BaseDexError::InvalidAmount(IBaseDex::InvalidAmount {}))?;
+            .ok_or(BaseDexError::InvalidAmount(IBaseDex::InvalidAmount {}))?;
         Self::sqrt(product)
             .checked_sub(MINIMUM_LIQUIDITY)
             .filter(|liquidity| !liquidity.is_zero())
-            .ok_or_else(|| BaseDexError::InsufficientLiquidity(IBaseDex::InsufficientLiquidity {}))
+            .ok_or(BaseDexError::InsufficientLiquidity(IBaseDex::InsufficientLiquidity {}))
     }
 
     pub(crate) fn minted_liquidity(
@@ -78,11 +78,11 @@ impl ConstantProduct {
         let token_liquidity = amount_token
             .checked_mul(total_supply)
             .and_then(|value| value.checked_div(reserve_token))
-            .ok_or_else(|| BaseDexError::InvalidAmount(IBaseDex::InvalidAmount {}))?;
+            .ok_or(BaseDexError::InvalidAmount(IBaseDex::InvalidAmount {}))?;
         let base_liquidity = amount_base
             .checked_mul(total_supply)
             .and_then(|value| value.checked_div(reserve_base))
-            .ok_or_else(|| BaseDexError::InvalidAmount(IBaseDex::InvalidAmount {}))?;
+            .ok_or(BaseDexError::InvalidAmount(IBaseDex::InvalidAmount {}))?;
         let liquidity = token_liquidity.min(base_liquidity);
 
         if liquidity.is_zero() {
@@ -107,11 +107,11 @@ impl ConstantProduct {
         let amount_token = liquidity
             .checked_mul(reserve_token)
             .and_then(|value| value.checked_div(total_supply))
-            .ok_or_else(|| BaseDexError::InvalidAmount(IBaseDex::InvalidAmount {}))?;
+            .ok_or(BaseDexError::InvalidAmount(IBaseDex::InvalidAmount {}))?;
         let amount_base = liquidity
             .checked_mul(reserve_base)
             .and_then(|value| value.checked_div(total_supply))
-            .ok_or_else(|| BaseDexError::InvalidAmount(IBaseDex::InvalidAmount {}))?;
+            .ok_or(BaseDexError::InvalidAmount(IBaseDex::InvalidAmount {}))?;
 
         if amount_token.is_zero() || amount_base.is_zero() {
             return Err(BaseDexError::InsufficientLiquidity(IBaseDex::InsufficientLiquidity {}));

--- a/crates/common/precompiles/src/dex/math.rs
+++ b/crates/common/precompiles/src/dex/math.rs
@@ -1,0 +1,204 @@
+//! Constant-product AMM math for the native DEX.
+
+use alloy_primitives::{U256, uint};
+
+use super::{BaseDexError, IBaseDex};
+
+pub(crate) const FEE_NUMERATOR: U256 = uint!(997_U256);
+pub(crate) const FEE_DENOMINATOR: U256 = uint!(1000_U256);
+pub(crate) const MINIMUM_LIQUIDITY: U256 = uint!(1000_U256);
+
+#[derive(Debug, Default, Clone, Copy)]
+pub(crate) struct ConstantProduct;
+
+impl ConstantProduct {
+    pub(crate) fn amount_out(
+        amount_in: U256,
+        reserve_in: U256,
+        reserve_out: U256,
+    ) -> Result<U256, BaseDexError> {
+        if amount_in.is_zero() {
+            return Err(BaseDexError::InvalidAmount(IBaseDex::InvalidAmount {}));
+        }
+        if reserve_in.is_zero() || reserve_out.is_zero() {
+            return Err(BaseDexError::InsufficientLiquidity(IBaseDex::InsufficientLiquidity {}));
+        }
+
+        let amount_in_with_fee = amount_in
+            .checked_mul(FEE_NUMERATOR)
+            .ok_or_else(|| BaseDexError::InvalidAmount(IBaseDex::InvalidAmount {}))?;
+        let numerator = amount_in_with_fee
+            .checked_mul(reserve_out)
+            .ok_or_else(|| BaseDexError::InvalidAmount(IBaseDex::InvalidAmount {}))?;
+        let denominator = reserve_in
+            .checked_mul(FEE_DENOMINATOR)
+            .and_then(|value| value.checked_add(amount_in_with_fee))
+            .ok_or_else(|| BaseDexError::InvalidAmount(IBaseDex::InvalidAmount {}))?;
+
+        let amount_out = numerator / denominator;
+        if amount_out.is_zero() {
+            return Err(BaseDexError::InsufficientOutputAmount(
+                IBaseDex::InsufficientOutputAmount {},
+            ));
+        }
+        Ok(amount_out)
+    }
+
+    pub(crate) fn initial_liquidity(
+        amount_token: U256,
+        amount_base: U256,
+    ) -> Result<U256, BaseDexError> {
+        if amount_token.is_zero() || amount_base.is_zero() {
+            return Err(BaseDexError::InvalidAmount(IBaseDex::InvalidAmount {}));
+        }
+
+        let product = amount_token
+            .checked_mul(amount_base)
+            .ok_or_else(|| BaseDexError::InvalidAmount(IBaseDex::InvalidAmount {}))?;
+        Self::sqrt(product)
+            .checked_sub(MINIMUM_LIQUIDITY)
+            .filter(|liquidity| !liquidity.is_zero())
+            .ok_or_else(|| BaseDexError::InsufficientLiquidity(IBaseDex::InsufficientLiquidity {}))
+    }
+
+    pub(crate) fn minted_liquidity(
+        amount_token: U256,
+        amount_base: U256,
+        reserve_token: U256,
+        reserve_base: U256,
+        total_supply: U256,
+    ) -> Result<U256, BaseDexError> {
+        if amount_token.is_zero() || amount_base.is_zero() {
+            return Err(BaseDexError::InvalidAmount(IBaseDex::InvalidAmount {}));
+        }
+        if reserve_token.is_zero() || reserve_base.is_zero() || total_supply.is_zero() {
+            return Err(BaseDexError::InsufficientLiquidity(IBaseDex::InsufficientLiquidity {}));
+        }
+
+        let token_liquidity = amount_token
+            .checked_mul(total_supply)
+            .and_then(|value| value.checked_div(reserve_token))
+            .ok_or_else(|| BaseDexError::InvalidAmount(IBaseDex::InvalidAmount {}))?;
+        let base_liquidity = amount_base
+            .checked_mul(total_supply)
+            .and_then(|value| value.checked_div(reserve_base))
+            .ok_or_else(|| BaseDexError::InvalidAmount(IBaseDex::InvalidAmount {}))?;
+        let liquidity = token_liquidity.min(base_liquidity);
+
+        if liquidity.is_zero() {
+            return Err(BaseDexError::InsufficientLiquidity(IBaseDex::InsufficientLiquidity {}));
+        }
+        Ok(liquidity)
+    }
+
+    pub(crate) fn burn_amounts(
+        liquidity: U256,
+        reserve_token: U256,
+        reserve_base: U256,
+        total_supply: U256,
+    ) -> Result<(U256, U256), BaseDexError> {
+        if liquidity.is_zero() {
+            return Err(BaseDexError::InvalidAmount(IBaseDex::InvalidAmount {}));
+        }
+        if reserve_token.is_zero() || reserve_base.is_zero() || total_supply.is_zero() {
+            return Err(BaseDexError::InsufficientLiquidity(IBaseDex::InsufficientLiquidity {}));
+        }
+
+        let amount_token = liquidity
+            .checked_mul(reserve_token)
+            .and_then(|value| value.checked_div(total_supply))
+            .ok_or_else(|| BaseDexError::InvalidAmount(IBaseDex::InvalidAmount {}))?;
+        let amount_base = liquidity
+            .checked_mul(reserve_base)
+            .and_then(|value| value.checked_div(total_supply))
+            .ok_or_else(|| BaseDexError::InvalidAmount(IBaseDex::InvalidAmount {}))?;
+
+        if amount_token.is_zero() || amount_base.is_zero() {
+            return Err(BaseDexError::InsufficientLiquidity(IBaseDex::InsufficientLiquidity {}));
+        }
+        Ok((amount_token, amount_base))
+    }
+
+    fn sqrt(value: U256) -> U256 {
+        if value <= U256::from(3) {
+            return if value.is_zero() { U256::ZERO } else { U256::from(1) };
+        }
+
+        let mut root = value;
+        let mut candidate = value / U256::from(2) + U256::from(1);
+        while candidate < root {
+            root = candidate;
+            candidate = (value / candidate + candidate) / U256::from(2);
+        }
+        root
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_primitives::{U256, uint};
+
+    use super::*;
+
+    #[test]
+    fn amount_out_matches_constant_product_fee() {
+        let amount_in = uint!(1000_U256);
+        let reserve_in = uint!(100_000_U256);
+        let reserve_out = uint!(100_000_U256);
+
+        let expected = amount_in
+            .checked_mul(FEE_NUMERATOR)
+            .and_then(|amount_in_with_fee| {
+                amount_in_with_fee
+                    .checked_mul(reserve_out)
+                    .zip(
+                        reserve_in
+                            .checked_mul(FEE_DENOMINATOR)
+                            .and_then(|denominator| denominator.checked_add(amount_in_with_fee)),
+                    )
+                    .map(|(numerator, denominator)| numerator / denominator)
+            })
+            .expect("test values do not overflow");
+
+        let actual = ConstantProduct::amount_out(amount_in, reserve_in, reserve_out).unwrap();
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn amount_out_rejects_zero_input() {
+        assert!(matches!(
+            ConstantProduct::amount_out(U256::ZERO, U256::from(1), U256::from(1)),
+            Err(BaseDexError::InvalidAmount(_))
+        ));
+    }
+
+    #[test]
+    fn amount_out_rejects_empty_reserves() {
+        assert!(matches!(
+            ConstantProduct::amount_out(U256::from(1), U256::ZERO, U256::from(1)),
+            Err(BaseDexError::InsufficientLiquidity(_))
+        ));
+    }
+
+    #[test]
+    fn initial_liquidity_subtracts_minimum_liquidity() {
+        assert_eq!(
+            ConstantProduct::initial_liquidity(U256::from(1_000_000), U256::from(1_000_000)),
+            Ok(U256::from(999_000))
+        );
+    }
+
+    #[test]
+    fn burn_amounts_are_pro_rata() {
+        assert_eq!(
+            ConstantProduct::burn_amounts(
+                U256::from(10),
+                U256::from(1_000),
+                U256::from(2_000),
+                U256::from(100),
+            ),
+            Ok((U256::from(100), U256::from(200)))
+        );
+    }
+}

--- a/crates/common/precompiles/src/dex/mod.rs
+++ b/crates/common/precompiles/src/dex/mod.rs
@@ -3,8 +3,8 @@
 use alloy_primitives::{Address, U256};
 
 mod abi;
-pub use abi::BASE_DEX_ADDRESS;
-use abi::{BASE_TOKEN_ADDRESS, BaseDexError, IBaseDex, IBaseDexCalls};
+pub use abi::{BASE_DEX_ADDRESS, IBaseDex};
+use abi::{BASE_TOKEN_ADDRESS, BaseDexError, IBaseDexCalls};
 
 mod dispatch;
 pub use dispatch::BaseDexPrecompile;
@@ -13,7 +13,7 @@ mod gas;
 use gas::DexGasMeter;
 
 mod math;
-use math::ConstantProduct;
+use math::{ConstantProduct, MINIMUM_LIQUIDITY};
 
 mod storage;
 use storage::{DexStorage, PoolState};
@@ -45,7 +45,7 @@ impl<'a> BaseDex<'a> {
         token_out: Address,
         amount_in: U256,
     ) -> Result<U256, BaseDexError> {
-        self.validate_path(token_in, token_out)?;
+        Self::validate_path(token_in, token_out)?;
 
         if token_in == self.base_token() {
             let pool = self.get_pool(token_out)?;
@@ -86,16 +86,21 @@ impl<'a> BaseDex<'a> {
         DexToken::pull(self.base_token(), caller, BASE_DEX_ADDRESS, amount_base)?;
 
         let mut pool = self.get_pool(token)?;
-        let liquidity = if pool.total_lp_supply.is_zero() {
-            ConstantProduct::initial_liquidity(amount_token, amount_base)?
+        let (liquidity, supply_delta) = if pool.total_lp_supply.is_zero() {
+            let liquidity = ConstantProduct::initial_liquidity(amount_token, amount_base)?;
+            let supply_delta = liquidity
+                .checked_add(MINIMUM_LIQUIDITY)
+                .ok_or(BaseDexError::InvalidAmount(IBaseDex::InvalidAmount {}))?;
+            (liquidity, supply_delta)
         } else {
-            ConstantProduct::minted_liquidity(
+            let liquidity = ConstantProduct::minted_liquidity(
                 amount_token,
                 amount_base,
                 U256::from(pool.reserve_token),
                 U256::from(pool.reserve_base),
                 pool.total_lp_supply,
-            )?
+            )?;
+            (liquidity, liquidity)
         };
 
         pool.reserve_token = Self::u128_amount(
@@ -110,7 +115,7 @@ impl<'a> BaseDex<'a> {
         )?;
         pool.total_lp_supply = pool
             .total_lp_supply
-            .checked_add(liquidity)
+            .checked_add(supply_delta)
             .ok_or(BaseDexError::InvalidAmount(IBaseDex::InvalidAmount {}))?;
 
         let lp_balance = self
@@ -211,7 +216,8 @@ impl<'a> BaseDex<'a> {
         min_amount_out: U256,
         to: Address,
     ) -> Result<U256, BaseDexError> {
-        let amount_out = self.quote_exact_input(token_in, token_out, amount_in)?;
+        let (amount_out, intermediate_base_out) =
+            self.quote_exact_input_with_intermediate(token_in, token_out, amount_in)?;
         if amount_out < min_amount_out {
             return Err(BaseDexError::InsufficientOutputAmount(
                 IBaseDex::InsufficientOutputAmount {},
@@ -220,7 +226,7 @@ impl<'a> BaseDex<'a> {
 
         DexToken::pull(token_in, caller, BASE_DEX_ADDRESS, amount_in)?;
         DexToken::push(token_out, BASE_DEX_ADDRESS, to, amount_out)?;
-        self.apply_swap(token_in, token_out, amount_in, amount_out)?;
+        self.apply_swap(token_in, token_out, amount_in, amount_out, intermediate_base_out)?;
         self.storage.emit(IBaseDex::Swap {
             sender: caller,
             tokenIn: token_in,
@@ -233,12 +239,32 @@ impl<'a> BaseDex<'a> {
         Ok(amount_out)
     }
 
+    fn quote_exact_input_with_intermediate(
+        &mut self,
+        token_in: Address,
+        token_out: Address,
+        amount_in: U256,
+    ) -> Result<(U256, Option<U256>), BaseDexError> {
+        Self::validate_path(token_in, token_out)?;
+
+        if token_in == self.base_token() || token_out == self.base_token() {
+            return self
+                .quote_exact_input(token_in, token_out, amount_in)
+                .map(|amount_out| (amount_out, None));
+        }
+
+        let base_out = self.quote_exact_input(token_in, self.base_token(), amount_in)?;
+        let amount_out = self.quote_exact_input(self.base_token(), token_out, base_out)?;
+        Ok((amount_out, Some(base_out)))
+    }
+
     fn apply_swap(
         &mut self,
         token_in: Address,
         token_out: Address,
         amount_in: U256,
         amount_out: U256,
+        intermediate_base_out: Option<U256>,
     ) -> Result<(), BaseDexError> {
         if token_in == self.base_token() {
             return self.apply_base_to_token_swap(token_out, amount_in, amount_out);
@@ -248,7 +274,8 @@ impl<'a> BaseDex<'a> {
             return self.apply_token_to_base_swap(token_in, amount_in, amount_out);
         }
 
-        let base_out = self.quote_exact_input(token_in, self.base_token(), amount_in)?;
+        let base_out = intermediate_base_out
+            .ok_or(BaseDexError::InvalidSwapPath(IBaseDex::InvalidSwapPath {}))?;
         self.apply_token_to_base_swap(token_in, amount_in, base_out)?;
         self.apply_base_to_token_swap(token_out, base_out, amount_out)
     }
@@ -297,17 +324,42 @@ impl<'a> BaseDex<'a> {
             .map_err(|_| BaseDexError::InvalidToken(IBaseDex::InvalidToken {}))
     }
 
-    fn validate_path(&self, token_in: Address, token_out: Address) -> Result<(), BaseDexError> {
+    fn validate_path(token_in: Address, token_out: Address) -> Result<(), BaseDexError> {
+        if token_in == BASE_TOKEN_ADDRESS && token_out == BASE_TOKEN_ADDRESS {
+            return Err(BaseDexError::InvalidSwapPath(IBaseDex::InvalidSwapPath {}));
+        }
         if token_in == token_out {
             return Err(BaseDexError::IdenticalTokens(IBaseDex::IdenticalTokens {}));
-        }
-        if token_in == self.base_token() && token_out == self.base_token() {
-            return Err(BaseDexError::InvalidSwapPath(IBaseDex::InvalidSwapPath {}));
         }
         Ok(())
     }
 
     fn u128_amount(amount: U256) -> Result<u128, BaseDexError> {
         amount.try_into().map_err(|_| BaseDexError::InvalidAmount(IBaseDex::InvalidAmount {}))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_primitives::address;
+
+    use super::*;
+
+    #[test]
+    fn validate_path_rejects_base_to_base_as_invalid_path() {
+        assert!(matches!(
+            BaseDex::validate_path(BASE_TOKEN_ADDRESS, BASE_TOKEN_ADDRESS),
+            Err(BaseDexError::InvalidSwapPath(_))
+        ));
+    }
+
+    #[test]
+    fn validate_path_rejects_identical_non_base_tokens() {
+        let token = address!("0000000000000000000000000000000000000dE8");
+
+        assert!(matches!(
+            BaseDex::validate_path(token, token),
+            Err(BaseDexError::IdenticalTokens(_))
+        ));
     }
 }

--- a/crates/common/precompiles/src/dex/mod.rs
+++ b/crates/common/precompiles/src/dex/mod.rs
@@ -1,6 +1,7 @@
 //! Native DEX precompile implementation.
 
 use alloy_primitives::{Address, U256};
+use tracing::warn;
 
 mod abi;
 pub use abi::{BASE_DEX_ADDRESS, IBaseDex};
@@ -16,7 +17,7 @@ mod math;
 use math::{ConstantProduct, MINIMUM_LIQUIDITY};
 
 mod storage;
-use storage::{DexStorage, PoolState};
+use storage::{DexStorage, DexStorageError, PoolState};
 
 mod token;
 use token::DexToken;
@@ -36,7 +37,7 @@ impl<'a> BaseDex<'a> {
     }
 
     fn get_pool(&mut self, token: Address) -> Result<PoolState, BaseDexError> {
-        self.storage.pool(token).map_err(|_| BaseDexError::InvalidToken(IBaseDex::InvalidToken {}))
+        self.storage.pool(token).map_err(|error| Self::storage_error("pool", error))
     }
 
     fn quote_exact_input(
@@ -121,15 +122,15 @@ impl<'a> BaseDex<'a> {
         let lp_balance = self
             .storage
             .lp_balance(token, to)
-            .map_err(|_| BaseDexError::InvalidToken(IBaseDex::InvalidToken {}))?
+            .map_err(|error| Self::storage_error("lp_balance", error))?
             .checked_add(liquidity)
             .ok_or(BaseDexError::InvalidAmount(IBaseDex::InvalidAmount {}))?;
         self.storage
             .write_lp_balance(token, to, lp_balance)
-            .map_err(|_| BaseDexError::InvalidToken(IBaseDex::InvalidToken {}))?;
+            .map_err(|error| Self::storage_error("write_lp_balance", error))?;
         self.storage
             .write_pool(token, pool)
-            .map_err(|_| BaseDexError::InvalidToken(IBaseDex::InvalidToken {}))?;
+            .map_err(|error| Self::storage_error("write_pool", error))?;
         self.storage.emit(IBaseDex::Mint {
             sender: caller,
             token,
@@ -159,7 +160,7 @@ impl<'a> BaseDex<'a> {
         let lp_balance = self
             .storage
             .lp_balance(token, caller)
-            .map_err(|_| BaseDexError::InvalidToken(IBaseDex::InvalidToken {}))?;
+            .map_err(|error| Self::storage_error("lp_balance", error))?;
         if lp_balance < liquidity {
             return Err(BaseDexError::InsufficientLiquidity(IBaseDex::InsufficientLiquidity {}));
         }
@@ -189,12 +190,15 @@ impl<'a> BaseDex<'a> {
             .checked_sub(liquidity)
             .ok_or(BaseDexError::InsufficientLiquidity(IBaseDex::InsufficientLiquidity {}))?;
 
+        let updated_lp_balance = lp_balance
+            .checked_sub(liquidity)
+            .ok_or(BaseDexError::InsufficientLiquidity(IBaseDex::InsufficientLiquidity {}))?;
         self.storage
-            .write_lp_balance(token, caller, lp_balance - liquidity)
-            .map_err(|_| BaseDexError::InvalidToken(IBaseDex::InvalidToken {}))?;
+            .write_lp_balance(token, caller, updated_lp_balance)
+            .map_err(|error| Self::storage_error("write_lp_balance", error))?;
         self.storage
             .write_pool(token, pool)
-            .map_err(|_| BaseDexError::InvalidToken(IBaseDex::InvalidToken {}))?;
+            .map_err(|error| Self::storage_error("write_pool", error))?;
         self.storage.emit(IBaseDex::Burn {
             sender: caller,
             token,
@@ -299,7 +303,7 @@ impl<'a> BaseDex<'a> {
         )?;
         self.storage
             .write_pool(token, pool)
-            .map_err(|_| BaseDexError::InvalidToken(IBaseDex::InvalidToken {}))
+            .map_err(|error| Self::storage_error("write_pool", error))
     }
 
     fn apply_base_to_token_swap(
@@ -321,7 +325,7 @@ impl<'a> BaseDex<'a> {
         )?;
         self.storage
             .write_pool(token, pool)
-            .map_err(|_| BaseDexError::InvalidToken(IBaseDex::InvalidToken {}))
+            .map_err(|error| Self::storage_error("write_pool", error))
     }
 
     fn validate_path(token_in: Address, token_out: Address) -> Result<(), BaseDexError> {
@@ -336,6 +340,11 @@ impl<'a> BaseDex<'a> {
 
     fn u128_amount(amount: U256) -> Result<u128, BaseDexError> {
         amount.try_into().map_err(|_| BaseDexError::InvalidAmount(IBaseDex::InvalidAmount {}))
+    }
+
+    fn storage_error(operation: &'static str, error: DexStorageError) -> BaseDexError {
+        warn!(operation, error = %error, "native DEX storage operation failed");
+        BaseDexError::InvalidToken(IBaseDex::InvalidToken {})
     }
 }
 

--- a/crates/common/precompiles/src/dex/mod.rs
+++ b/crates/common/precompiles/src/dex/mod.rs
@@ -47,6 +47,7 @@ impl<'a> BaseDex<'a> {
         amount_in: U256,
     ) -> Result<U256, BaseDexError> {
         Self::validate_path(token_in, token_out)?;
+        self.validate_swap_tokens(token_in, token_out)?;
 
         if token_in == self.base_token() {
             let pool = self.get_pool(token_out)?;
@@ -253,6 +254,7 @@ impl<'a> BaseDex<'a> {
         amount_in: U256,
     ) -> Result<(U256, Option<U256>), BaseDexError> {
         Self::validate_path(token_in, token_out)?;
+        self.validate_swap_tokens(token_in, token_out)?;
 
         if token_in == self.base_token() || token_out == self.base_token() {
             return self
@@ -337,6 +339,20 @@ impl<'a> BaseDex<'a> {
         }
         if token_in == token_out {
             return Err(BaseDexError::IdenticalTokens(IBaseDex::IdenticalTokens {}));
+        }
+        Ok(())
+    }
+
+    fn validate_swap_tokens(
+        &self,
+        token_in: Address,
+        token_out: Address,
+    ) -> Result<(), BaseDexError> {
+        if token_in != self.base_token() {
+            DexToken::validate(token_in)?;
+        }
+        if token_out != self.base_token() {
+            DexToken::validate(token_out)?;
         }
         Ok(())
     }

--- a/crates/common/precompiles/src/dex/mod.rs
+++ b/crates/common/precompiles/src/dex/mod.rs
@@ -150,7 +150,10 @@ impl<'a> BaseDex<'a> {
         liquidity: U256,
         to: Address,
     ) -> Result<(U256, U256), BaseDexError> {
-        if token == self.base_token() || liquidity.is_zero() {
+        if token == self.base_token() {
+            return Err(BaseDexError::InvalidToken(IBaseDex::InvalidToken {}));
+        }
+        if liquidity.is_zero() {
             return Err(BaseDexError::InvalidAmount(IBaseDex::InvalidAmount {}));
         }
 

--- a/crates/common/precompiles/src/dex/mod.rs
+++ b/crates/common/precompiles/src/dex/mod.rs
@@ -98,24 +98,24 @@ impl<'a> BaseDex<'a> {
         pool.reserve_token = Self::u128_amount(
             U256::from(pool.reserve_token)
                 .checked_add(amount_token)
-                .ok_or_else(|| BaseDexError::InvalidAmount(IBaseDex::InvalidAmount {}))?,
+                .ok_or(BaseDexError::InvalidAmount(IBaseDex::InvalidAmount {}))?,
         )?;
         pool.reserve_base = Self::u128_amount(
             U256::from(pool.reserve_base)
                 .checked_add(amount_base)
-                .ok_or_else(|| BaseDexError::InvalidAmount(IBaseDex::InvalidAmount {}))?,
+                .ok_or(BaseDexError::InvalidAmount(IBaseDex::InvalidAmount {}))?,
         )?;
         pool.total_lp_supply = pool
             .total_lp_supply
             .checked_add(liquidity)
-            .ok_or_else(|| BaseDexError::InvalidAmount(IBaseDex::InvalidAmount {}))?;
+            .ok_or(BaseDexError::InvalidAmount(IBaseDex::InvalidAmount {}))?;
 
         let lp_balance = self
             .storage
             .lp_balance(token, to)
             .map_err(|_| BaseDexError::InvalidToken(IBaseDex::InvalidToken {}))?
             .checked_add(liquidity)
-            .ok_or_else(|| BaseDexError::InvalidAmount(IBaseDex::InvalidAmount {}))?;
+            .ok_or(BaseDexError::InvalidAmount(IBaseDex::InvalidAmount {}))?;
         self.storage
             .write_lp_balance(token, to, lp_balance)
             .map_err(|_| BaseDexError::InvalidToken(IBaseDex::InvalidToken {}))?;
@@ -258,12 +258,12 @@ impl<'a> BaseDex<'a> {
         pool.reserve_token = Self::u128_amount(
             U256::from(pool.reserve_token)
                 .checked_add(amount_token_in)
-                .ok_or_else(|| BaseDexError::InvalidAmount(IBaseDex::InvalidAmount {}))?,
+                .ok_or(BaseDexError::InvalidAmount(IBaseDex::InvalidAmount {}))?,
         )?;
         pool.reserve_base = Self::u128_amount(
-            U256::from(pool.reserve_base).checked_sub(amount_base_out).ok_or_else(|| {
-                BaseDexError::InsufficientLiquidity(IBaseDex::InsufficientLiquidity {})
-            })?,
+            U256::from(pool.reserve_base)
+                .checked_sub(amount_base_out)
+                .ok_or(BaseDexError::InsufficientLiquidity(IBaseDex::InsufficientLiquidity {}))?,
         )?;
         self.storage
             .write_pool(token, pool)
@@ -280,12 +280,12 @@ impl<'a> BaseDex<'a> {
         pool.reserve_base = Self::u128_amount(
             U256::from(pool.reserve_base)
                 .checked_add(amount_base_in)
-                .ok_or_else(|| BaseDexError::InvalidAmount(IBaseDex::InvalidAmount {}))?,
+                .ok_or(BaseDexError::InvalidAmount(IBaseDex::InvalidAmount {}))?,
         )?;
         pool.reserve_token = Self::u128_amount(
-            U256::from(pool.reserve_token).checked_sub(amount_token_out).ok_or_else(|| {
-                BaseDexError::InsufficientLiquidity(IBaseDex::InsufficientLiquidity {})
-            })?,
+            U256::from(pool.reserve_token)
+                .checked_sub(amount_token_out)
+                .ok_or(BaseDexError::InsufficientLiquidity(IBaseDex::InsufficientLiquidity {}))?,
         )?;
         self.storage
             .write_pool(token, pool)

--- a/crates/common/precompiles/src/dex/mod.rs
+++ b/crates/common/precompiles/src/dex/mod.rs
@@ -1,0 +1,308 @@
+//! Native DEX precompile implementation.
+
+use alloy_primitives::{Address, U256};
+
+mod abi;
+pub use abi::BASE_DEX_ADDRESS;
+use abi::{BASE_TOKEN_ADDRESS, BaseDexError, IBaseDex, IBaseDexCalls};
+
+mod dispatch;
+pub use dispatch::BaseDexPrecompile;
+
+mod math;
+use math::ConstantProduct;
+
+mod storage;
+use storage::{DexStorage, PoolState};
+
+mod token;
+use token::DexToken;
+
+#[derive(Debug)]
+struct BaseDex<'a> {
+    storage: DexStorage<'a>,
+}
+
+impl<'a> BaseDex<'a> {
+    const fn new(storage: DexStorage<'a>) -> Self {
+        Self { storage }
+    }
+
+    const fn base_token(&self) -> Address {
+        BASE_TOKEN_ADDRESS
+    }
+
+    fn get_pool(&mut self, token: Address) -> Result<PoolState, BaseDexError> {
+        self.storage.pool(token).map_err(|_| BaseDexError::InvalidToken(IBaseDex::InvalidToken {}))
+    }
+
+    fn quote_exact_input(
+        &mut self,
+        token_in: Address,
+        token_out: Address,
+        amount_in: U256,
+    ) -> Result<U256, BaseDexError> {
+        self.validate_path(token_in, token_out)?;
+
+        if token_in == self.base_token() {
+            let pool = self.get_pool(token_out)?;
+            return ConstantProduct::amount_out(
+                amount_in,
+                U256::from(pool.reserve_base),
+                U256::from(pool.reserve_token),
+            );
+        }
+
+        if token_out == self.base_token() {
+            let pool = self.get_pool(token_in)?;
+            return ConstantProduct::amount_out(
+                amount_in,
+                U256::from(pool.reserve_token),
+                U256::from(pool.reserve_base),
+            );
+        }
+
+        let base_out = self.quote_exact_input(token_in, self.base_token(), amount_in)?;
+        self.quote_exact_input(self.base_token(), token_out, base_out)
+    }
+
+    fn add_liquidity(
+        &mut self,
+        caller: Address,
+        token: Address,
+        amount_token: U256,
+        amount_base: U256,
+        to: Address,
+    ) -> Result<U256, BaseDexError> {
+        if token == self.base_token() {
+            return Err(BaseDexError::InvalidToken(IBaseDex::InvalidToken {}));
+        }
+
+        DexToken::validate(token)?;
+        DexToken::pull(token, caller, BASE_DEX_ADDRESS, amount_token)?;
+        DexToken::pull(self.base_token(), caller, BASE_DEX_ADDRESS, amount_base)?;
+
+        let mut pool = self.get_pool(token)?;
+        let liquidity = if pool.total_lp_supply.is_zero() {
+            ConstantProduct::initial_liquidity(amount_token, amount_base)?
+        } else {
+            ConstantProduct::minted_liquidity(
+                amount_token,
+                amount_base,
+                U256::from(pool.reserve_token),
+                U256::from(pool.reserve_base),
+                pool.total_lp_supply,
+            )?
+        };
+
+        pool.reserve_token = Self::u128_amount(
+            U256::from(pool.reserve_token)
+                .checked_add(amount_token)
+                .ok_or_else(|| BaseDexError::InvalidAmount(IBaseDex::InvalidAmount {}))?,
+        )?;
+        pool.reserve_base = Self::u128_amount(
+            U256::from(pool.reserve_base)
+                .checked_add(amount_base)
+                .ok_or_else(|| BaseDexError::InvalidAmount(IBaseDex::InvalidAmount {}))?,
+        )?;
+        pool.total_lp_supply = pool
+            .total_lp_supply
+            .checked_add(liquidity)
+            .ok_or_else(|| BaseDexError::InvalidAmount(IBaseDex::InvalidAmount {}))?;
+
+        let lp_balance = self
+            .storage
+            .lp_balance(token, to)
+            .map_err(|_| BaseDexError::InvalidToken(IBaseDex::InvalidToken {}))?
+            .checked_add(liquidity)
+            .ok_or_else(|| BaseDexError::InvalidAmount(IBaseDex::InvalidAmount {}))?;
+        self.storage
+            .write_lp_balance(token, to, lp_balance)
+            .map_err(|_| BaseDexError::InvalidToken(IBaseDex::InvalidToken {}))?;
+        self.storage
+            .write_pool(token, pool)
+            .map_err(|_| BaseDexError::InvalidToken(IBaseDex::InvalidToken {}))?;
+        self.storage.emit(IBaseDex::Mint {
+            sender: caller,
+            token,
+            amountToken: amount_token,
+            amountBase: amount_base,
+            liquidity,
+            to,
+        });
+
+        Ok(liquidity)
+    }
+
+    fn remove_liquidity(
+        &mut self,
+        caller: Address,
+        token: Address,
+        liquidity: U256,
+        to: Address,
+    ) -> Result<(U256, U256), BaseDexError> {
+        if token == self.base_token() || liquidity.is_zero() {
+            return Err(BaseDexError::InvalidAmount(IBaseDex::InvalidAmount {}));
+        }
+
+        DexToken::validate(token)?;
+
+        let mut pool = self.get_pool(token)?;
+        let lp_balance = self
+            .storage
+            .lp_balance(token, caller)
+            .map_err(|_| BaseDexError::InvalidToken(IBaseDex::InvalidToken {}))?;
+        if lp_balance < liquidity {
+            return Err(BaseDexError::InsufficientLiquidity(IBaseDex::InsufficientLiquidity {}));
+        }
+
+        let (amount_token, amount_base) = ConstantProduct::burn_amounts(
+            liquidity,
+            U256::from(pool.reserve_token),
+            U256::from(pool.reserve_base),
+            pool.total_lp_supply,
+        )?;
+
+        DexToken::push(token, BASE_DEX_ADDRESS, to, amount_token)?;
+        DexToken::push(self.base_token(), BASE_DEX_ADDRESS, to, amount_base)?;
+
+        pool.reserve_token = Self::u128_amount(
+            U256::from(pool.reserve_token).checked_sub(amount_token).ok_or_else(|| {
+                BaseDexError::InsufficientLiquidity(IBaseDex::InsufficientLiquidity {})
+            })?,
+        )?;
+        pool.reserve_base =
+            Self::u128_amount(U256::from(pool.reserve_base).checked_sub(amount_base).ok_or_else(
+                || BaseDexError::InsufficientLiquidity(IBaseDex::InsufficientLiquidity {}),
+            )?)?;
+        pool.total_lp_supply = pool.total_lp_supply.checked_sub(liquidity).ok_or_else(|| {
+            BaseDexError::InsufficientLiquidity(IBaseDex::InsufficientLiquidity {})
+        })?;
+
+        self.storage
+            .write_lp_balance(token, caller, lp_balance - liquidity)
+            .map_err(|_| BaseDexError::InvalidToken(IBaseDex::InvalidToken {}))?;
+        self.storage
+            .write_pool(token, pool)
+            .map_err(|_| BaseDexError::InvalidToken(IBaseDex::InvalidToken {}))?;
+        self.storage.emit(IBaseDex::Burn {
+            sender: caller,
+            token,
+            amountToken: amount_token,
+            amountBase: amount_base,
+            liquidity,
+            to,
+        });
+
+        Ok((amount_token, amount_base))
+    }
+
+    fn swap_exact_tokens_for_tokens(
+        &mut self,
+        caller: Address,
+        token_in: Address,
+        token_out: Address,
+        amount_in: U256,
+        min_amount_out: U256,
+        to: Address,
+    ) -> Result<U256, BaseDexError> {
+        let amount_out = self.quote_exact_input(token_in, token_out, amount_in)?;
+        if amount_out < min_amount_out {
+            return Err(BaseDexError::InsufficientOutputAmount(
+                IBaseDex::InsufficientOutputAmount {},
+            ));
+        }
+
+        DexToken::pull(token_in, caller, BASE_DEX_ADDRESS, amount_in)?;
+        DexToken::push(token_out, BASE_DEX_ADDRESS, to, amount_out)?;
+        self.apply_swap(token_in, token_out, amount_in, amount_out)?;
+        self.storage.emit(IBaseDex::Swap {
+            sender: caller,
+            tokenIn: token_in,
+            tokenOut: token_out,
+            amountIn: amount_in,
+            amountOut: amount_out,
+            to,
+        });
+
+        Ok(amount_out)
+    }
+
+    fn apply_swap(
+        &mut self,
+        token_in: Address,
+        token_out: Address,
+        amount_in: U256,
+        amount_out: U256,
+    ) -> Result<(), BaseDexError> {
+        if token_in == self.base_token() {
+            return self.apply_base_to_token_swap(token_out, amount_in, amount_out);
+        }
+
+        if token_out == self.base_token() {
+            return self.apply_token_to_base_swap(token_in, amount_in, amount_out);
+        }
+
+        let base_out = self.quote_exact_input(token_in, self.base_token(), amount_in)?;
+        self.apply_token_to_base_swap(token_in, amount_in, base_out)?;
+        self.apply_base_to_token_swap(token_out, base_out, amount_out)
+    }
+
+    fn apply_token_to_base_swap(
+        &mut self,
+        token: Address,
+        amount_token_in: U256,
+        amount_base_out: U256,
+    ) -> Result<(), BaseDexError> {
+        let mut pool = self.get_pool(token)?;
+        pool.reserve_token = Self::u128_amount(
+            U256::from(pool.reserve_token)
+                .checked_add(amount_token_in)
+                .ok_or_else(|| BaseDexError::InvalidAmount(IBaseDex::InvalidAmount {}))?,
+        )?;
+        pool.reserve_base = Self::u128_amount(
+            U256::from(pool.reserve_base).checked_sub(amount_base_out).ok_or_else(|| {
+                BaseDexError::InsufficientLiquidity(IBaseDex::InsufficientLiquidity {})
+            })?,
+        )?;
+        self.storage
+            .write_pool(token, pool)
+            .map_err(|_| BaseDexError::InvalidToken(IBaseDex::InvalidToken {}))
+    }
+
+    fn apply_base_to_token_swap(
+        &mut self,
+        token: Address,
+        amount_base_in: U256,
+        amount_token_out: U256,
+    ) -> Result<(), BaseDexError> {
+        let mut pool = self.get_pool(token)?;
+        pool.reserve_base = Self::u128_amount(
+            U256::from(pool.reserve_base)
+                .checked_add(amount_base_in)
+                .ok_or_else(|| BaseDexError::InvalidAmount(IBaseDex::InvalidAmount {}))?,
+        )?;
+        pool.reserve_token = Self::u128_amount(
+            U256::from(pool.reserve_token).checked_sub(amount_token_out).ok_or_else(|| {
+                BaseDexError::InsufficientLiquidity(IBaseDex::InsufficientLiquidity {})
+            })?,
+        )?;
+        self.storage
+            .write_pool(token, pool)
+            .map_err(|_| BaseDexError::InvalidToken(IBaseDex::InvalidToken {}))
+    }
+
+    fn validate_path(&self, token_in: Address, token_out: Address) -> Result<(), BaseDexError> {
+        if token_in == token_out {
+            return Err(BaseDexError::IdenticalTokens(IBaseDex::IdenticalTokens {}));
+        }
+        if token_in == self.base_token() && token_out == self.base_token() {
+            return Err(BaseDexError::InvalidSwapPath(IBaseDex::InvalidSwapPath {}));
+        }
+        Ok(())
+    }
+
+    fn u128_amount(amount: U256) -> Result<u128, BaseDexError> {
+        amount.try_into().map_err(|_| BaseDexError::InvalidAmount(IBaseDex::InvalidAmount {}))
+    }
+}

--- a/crates/common/precompiles/src/dex/mod.rs
+++ b/crates/common/precompiles/src/dex/mod.rs
@@ -9,6 +9,9 @@ use abi::{BASE_TOKEN_ADDRESS, BaseDexError, IBaseDex, IBaseDexCalls};
 mod dispatch;
 pub use dispatch::BaseDexPrecompile;
 
+mod gas;
+use gas::DexGasMeter;
+
 mod math;
 use math::ConstantProduct;
 
@@ -167,17 +170,19 @@ impl<'a> BaseDex<'a> {
         DexToken::push(self.base_token(), BASE_DEX_ADDRESS, to, amount_base)?;
 
         pool.reserve_token = Self::u128_amount(
-            U256::from(pool.reserve_token).checked_sub(amount_token).ok_or_else(|| {
-                BaseDexError::InsufficientLiquidity(IBaseDex::InsufficientLiquidity {})
-            })?,
+            U256::from(pool.reserve_token)
+                .checked_sub(amount_token)
+                .ok_or(BaseDexError::InsufficientLiquidity(IBaseDex::InsufficientLiquidity {}))?,
         )?;
-        pool.reserve_base =
-            Self::u128_amount(U256::from(pool.reserve_base).checked_sub(amount_base).ok_or_else(
-                || BaseDexError::InsufficientLiquidity(IBaseDex::InsufficientLiquidity {}),
-            )?)?;
-        pool.total_lp_supply = pool.total_lp_supply.checked_sub(liquidity).ok_or_else(|| {
-            BaseDexError::InsufficientLiquidity(IBaseDex::InsufficientLiquidity {})
-        })?;
+        pool.reserve_base = Self::u128_amount(
+            U256::from(pool.reserve_base)
+                .checked_sub(amount_base)
+                .ok_or(BaseDexError::InsufficientLiquidity(IBaseDex::InsufficientLiquidity {}))?,
+        )?;
+        pool.total_lp_supply = pool
+            .total_lp_supply
+            .checked_sub(liquidity)
+            .ok_or(BaseDexError::InsufficientLiquidity(IBaseDex::InsufficientLiquidity {}))?;
 
         self.storage
             .write_lp_balance(token, caller, lp_balance - liquidity)

--- a/crates/common/precompiles/src/dex/storage.rs
+++ b/crates/common/precompiles/src/dex/storage.rs
@@ -21,34 +21,33 @@ pub(crate) struct PoolState {
 pub(crate) struct DexStorage<'a> {
     address: Address,
     internals: EvmInternals<'a>,
+    storage_account_initialized: bool,
 }
 
 impl<'a> DexStorage<'a> {
     pub(crate) const fn new(address: Address, internals: EvmInternals<'a>) -> Self {
-        Self { address, internals }
+        Self { address, internals, storage_account_initialized: false }
     }
 
     pub(crate) fn pool(&mut self, token: Address) -> Result<PoolState, String> {
-        let slot = Self::pool_slot(token);
         Ok(PoolState {
             reserve_token: self
-                .read(slot)?
+                .read(Self::pool_reserve_token_slot(token))?
                 .try_into()
                 .map_err(|_| "reserve token overflow".to_string())?,
             reserve_base: self
-                .read(slot + U256::from(1))?
+                .read(Self::pool_reserve_base_slot(token))?
                 .try_into()
                 .map_err(|_| "reserve base overflow".to_string())?,
-            total_lp_supply: self.read(slot + U256::from(2))?,
+            total_lp_supply: self.read(Self::pool_total_supply_slot(token))?,
         })
     }
 
     pub(crate) fn write_pool(&mut self, token: Address, pool: PoolState) -> Result<(), String> {
         self.ensure_storage_account()?;
-        let slot = Self::pool_slot(token);
-        self.write(slot, U256::from(pool.reserve_token))?;
-        self.write(slot + U256::from(1), U256::from(pool.reserve_base))?;
-        self.write(slot + U256::from(2), pool.total_lp_supply)
+        self.write(Self::pool_reserve_token_slot(token), U256::from(pool.reserve_token))?;
+        self.write(Self::pool_reserve_base_slot(token), U256::from(pool.reserve_base))?;
+        self.write(Self::pool_total_supply_slot(token), pool.total_lp_supply)
     }
 
     pub(crate) fn lp_balance(&mut self, token: Address, user: Address) -> Result<U256, String> {
@@ -69,8 +68,16 @@ impl<'a> DexStorage<'a> {
         self.internals.log(Log { address: self.address, data: event.encode_log_data() });
     }
 
-    pub(crate) fn pool_slot(token: Address) -> U256 {
+    pub(crate) fn pool_reserve_token_slot(token: Address) -> U256 {
         U256::from_be_bytes(keccak256((token, U256::ZERO).abi_encode()).0)
+    }
+
+    pub(crate) fn pool_reserve_base_slot(token: Address) -> U256 {
+        U256::from_be_bytes(keccak256((token, U256::from(1)).abi_encode()).0)
+    }
+
+    pub(crate) fn pool_total_supply_slot(token: Address) -> U256 {
+        U256::from_be_bytes(keccak256((token, U256::from(2)).abi_encode()).0)
     }
 
     pub(crate) fn lp_balance_slot(token: Address, user: Address) -> U256 {
@@ -92,10 +99,16 @@ impl<'a> DexStorage<'a> {
     }
 
     fn ensure_storage_account(&mut self) -> Result<(), String> {
+        if self.storage_account_initialized {
+            return Ok(());
+        }
+
         // Keep the DEX account non-empty so storage writes survive EIP-161 empty-account pruning.
         self.internals
             .set_code(self.address, Bytecode::new_legacy(Bytes::from_static(&[0x00])))
-            .map_err(|error| error.to_string())
+            .map_err(|error| error.to_string())?;
+        self.storage_account_initialized = true;
+        Ok(())
     }
 }
 
@@ -109,23 +122,33 @@ mod tests {
     const USER: Address = address!("2222222222222222222222222222222222222222");
 
     #[test]
-    fn pool_slot_is_stable() {
+    fn pool_slots_are_stable_and_independent() {
         assert_eq!(
-            DexStorage::pool_slot(TOKEN),
+            DexStorage::pool_reserve_token_slot(TOKEN),
             U256::from_be_bytes(hex!(
                 "f043c50fe795c69f30b8ff78b84032dc53a9d87ca283ae10a1dacfbb648e83ef"
             ))
         );
+
+        let reserve_token_slot = DexStorage::pool_reserve_token_slot(TOKEN);
+        let reserve_base_slot = DexStorage::pool_reserve_base_slot(TOKEN);
+        let total_supply_slot = DexStorage::pool_total_supply_slot(TOKEN);
+
+        assert_ne!(reserve_token_slot + U256::from(1), reserve_base_slot);
+        assert_ne!(reserve_token_slot + U256::from(2), total_supply_slot);
+        assert_ne!(reserve_base_slot, total_supply_slot);
     }
 
     #[test]
     fn lp_balance_slot_is_stable_and_separate_from_pool() {
-        let pool_slot = DexStorage::pool_slot(TOKEN);
+        let reserve_token_slot = DexStorage::pool_reserve_token_slot(TOKEN);
+        let reserve_base_slot = DexStorage::pool_reserve_base_slot(TOKEN);
+        let total_supply_slot = DexStorage::pool_total_supply_slot(TOKEN);
         let lp_slot = DexStorage::lp_balance_slot(TOKEN, USER);
 
-        assert_ne!(pool_slot, lp_slot);
-        assert_ne!(pool_slot + U256::from(1), lp_slot);
-        assert_ne!(pool_slot + U256::from(2), lp_slot);
+        assert_ne!(reserve_token_slot, lp_slot);
+        assert_ne!(reserve_base_slot, lp_slot);
+        assert_ne!(total_supply_slot, lp_slot);
         assert_eq!(
             lp_slot,
             U256::from_be_bytes(hex!(

--- a/crates/common/precompiles/src/dex/storage.rs
+++ b/crates/common/precompiles/src/dex/storage.rs
@@ -1,6 +1,7 @@
 //! Storage layout for the native DEX precompile.
 
-use alloc::string::ToString;
+use alloc::string::{String, ToString};
+use core::fmt;
 
 use alloy_evm::EvmInternals;
 use alloy_primitives::{Address, Bytes, U256, keccak256};
@@ -17,6 +18,23 @@ pub(crate) struct PoolState {
     pub total_lp_supply: U256,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum DexStorageError {
+    Database(String),
+    ReserveTokenOverflow,
+    ReserveBaseOverflow,
+}
+
+impl fmt::Display for DexStorageError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Database(error) => write!(f, "database error: {error}"),
+            Self::ReserveTokenOverflow => f.write_str("reserve token overflow"),
+            Self::ReserveBaseOverflow => f.write_str("reserve base overflow"),
+        }
+    }
+}
+
 #[derive(Debug)]
 pub(crate) struct DexStorage<'a> {
     address: Address,
@@ -29,28 +47,36 @@ impl<'a> DexStorage<'a> {
         Self { address, internals, storage_account_initialized: false }
     }
 
-    pub(crate) fn pool(&mut self, token: Address) -> Result<PoolState, String> {
+    pub(crate) fn pool(&mut self, token: Address) -> Result<PoolState, DexStorageError> {
         Ok(PoolState {
             reserve_token: self
                 .read(Self::pool_reserve_token_slot(token))?
                 .try_into()
-                .map_err(|_| "reserve token overflow".to_string())?,
+                .map_err(|_| DexStorageError::ReserveTokenOverflow)?,
             reserve_base: self
                 .read(Self::pool_reserve_base_slot(token))?
                 .try_into()
-                .map_err(|_| "reserve base overflow".to_string())?,
+                .map_err(|_| DexStorageError::ReserveBaseOverflow)?,
             total_lp_supply: self.read(Self::pool_total_supply_slot(token))?,
         })
     }
 
-    pub(crate) fn write_pool(&mut self, token: Address, pool: PoolState) -> Result<(), String> {
+    pub(crate) fn write_pool(
+        &mut self,
+        token: Address,
+        pool: PoolState,
+    ) -> Result<(), DexStorageError> {
         self.ensure_storage_account()?;
         self.write(Self::pool_reserve_token_slot(token), U256::from(pool.reserve_token))?;
         self.write(Self::pool_reserve_base_slot(token), U256::from(pool.reserve_base))?;
         self.write(Self::pool_total_supply_slot(token), pool.total_lp_supply)
     }
 
-    pub(crate) fn lp_balance(&mut self, token: Address, user: Address) -> Result<U256, String> {
+    pub(crate) fn lp_balance(
+        &mut self,
+        token: Address,
+        user: Address,
+    ) -> Result<U256, DexStorageError> {
         self.read(Self::lp_balance_slot(token, user))
     }
 
@@ -59,7 +85,7 @@ impl<'a> DexStorage<'a> {
         token: Address,
         user: Address,
         balance: U256,
-    ) -> Result<(), String> {
+    ) -> Result<(), DexStorageError> {
         self.ensure_storage_account()?;
         self.write(Self::lp_balance_slot(token, user), balance)
     }
@@ -84,21 +110,21 @@ impl<'a> DexStorage<'a> {
         U256::from_be_bytes(keccak256((token, user, U256::from(1)).abi_encode()).0)
     }
 
-    fn read(&mut self, slot: U256) -> Result<U256, String> {
+    fn read(&mut self, slot: U256) -> Result<U256, DexStorageError> {
         self.internals
             .sload(self.address, StorageKey::from(slot))
             .map(|value| value.data)
-            .map_err(|error| error.to_string())
+            .map_err(|error| DexStorageError::Database(error.to_string()))
     }
 
-    fn write(&mut self, slot: U256, value: U256) -> Result<(), String> {
+    fn write(&mut self, slot: U256, value: U256) -> Result<(), DexStorageError> {
         self.internals
             .sstore(self.address, StorageKey::from(slot), StorageValue::from(value))
             .map(|_| ())
-            .map_err(|error| error.to_string())
+            .map_err(|error| DexStorageError::Database(error.to_string()))
     }
 
-    fn ensure_storage_account(&mut self) -> Result<(), String> {
+    fn ensure_storage_account(&mut self) -> Result<(), DexStorageError> {
         if self.storage_account_initialized {
             return Ok(());
         }
@@ -106,7 +132,7 @@ impl<'a> DexStorage<'a> {
         // Keep the DEX account non-empty so storage writes survive EIP-161 empty-account pruning.
         self.internals
             .set_code(self.address, Bytecode::new_legacy(Bytes::from_static(&[0x00])))
-            .map_err(|error| error.to_string())?;
+            .map_err(|error| DexStorageError::Database(error.to_string()))?;
         self.storage_account_initialized = true;
         Ok(())
     }

--- a/crates/common/precompiles/src/dex/storage.rs
+++ b/crates/common/precompiles/src/dex/storage.rs
@@ -1,0 +1,136 @@
+//! Storage layout for the native DEX precompile.
+
+use alloc::string::ToString;
+
+use alloy_evm::EvmInternals;
+use alloy_primitives::{Address, Bytes, U256, keccak256};
+use alloy_sol_types::{SolEvent, SolValue};
+use revm::{
+    bytecode::Bytecode,
+    primitives::{Log, StorageKey, StorageValue},
+};
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub(crate) struct PoolState {
+    pub reserve_token: u128,
+    pub reserve_base: u128,
+    pub total_lp_supply: U256,
+}
+
+#[derive(Debug)]
+pub(crate) struct DexStorage<'a> {
+    address: Address,
+    internals: EvmInternals<'a>,
+}
+
+impl<'a> DexStorage<'a> {
+    pub(crate) const fn new(address: Address, internals: EvmInternals<'a>) -> Self {
+        Self { address, internals }
+    }
+
+    pub(crate) fn pool(&mut self, token: Address) -> Result<PoolState, String> {
+        let slot = Self::pool_slot(token);
+        Ok(PoolState {
+            reserve_token: self
+                .read(slot)?
+                .try_into()
+                .map_err(|_| "reserve token overflow".to_string())?,
+            reserve_base: self
+                .read(slot + U256::from(1))?
+                .try_into()
+                .map_err(|_| "reserve base overflow".to_string())?,
+            total_lp_supply: self.read(slot + U256::from(2))?,
+        })
+    }
+
+    pub(crate) fn write_pool(&mut self, token: Address, pool: PoolState) -> Result<(), String> {
+        self.ensure_storage_account()?;
+        let slot = Self::pool_slot(token);
+        self.write(slot, U256::from(pool.reserve_token))?;
+        self.write(slot + U256::from(1), U256::from(pool.reserve_base))?;
+        self.write(slot + U256::from(2), pool.total_lp_supply)
+    }
+
+    pub(crate) fn lp_balance(&mut self, token: Address, user: Address) -> Result<U256, String> {
+        self.read(Self::lp_balance_slot(token, user))
+    }
+
+    pub(crate) fn write_lp_balance(
+        &mut self,
+        token: Address,
+        user: Address,
+        balance: U256,
+    ) -> Result<(), String> {
+        self.ensure_storage_account()?;
+        self.write(Self::lp_balance_slot(token, user), balance)
+    }
+
+    pub(crate) fn emit(&mut self, event: impl SolEvent) {
+        self.internals.log(Log { address: self.address, data: event.encode_log_data() });
+    }
+
+    pub(crate) fn pool_slot(token: Address) -> U256 {
+        U256::from_be_bytes(keccak256((token, U256::ZERO).abi_encode()).0)
+    }
+
+    pub(crate) fn lp_balance_slot(token: Address, user: Address) -> U256 {
+        U256::from_be_bytes(keccak256((token, user, U256::from(1)).abi_encode()).0)
+    }
+
+    fn read(&mut self, slot: U256) -> Result<U256, String> {
+        self.internals
+            .sload(self.address, StorageKey::from(slot))
+            .map(|value| value.data)
+            .map_err(|error| error.to_string())
+    }
+
+    fn write(&mut self, slot: U256, value: U256) -> Result<(), String> {
+        self.internals
+            .sstore(self.address, StorageKey::from(slot), StorageValue::from(value))
+            .map(|_| ())
+            .map_err(|error| error.to_string())
+    }
+
+    fn ensure_storage_account(&mut self) -> Result<(), String> {
+        // Keep the DEX account non-empty so storage writes survive EIP-161 empty-account pruning.
+        self.internals
+            .set_code(self.address, Bytecode::new_legacy(Bytes::from_static(&[0x00])))
+            .map_err(|error| error.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_primitives::{Address, U256, address, hex};
+
+    use super::*;
+
+    const TOKEN: Address = address!("1111111111111111111111111111111111111111");
+    const USER: Address = address!("2222222222222222222222222222222222222222");
+
+    #[test]
+    fn pool_slot_is_stable() {
+        assert_eq!(
+            DexStorage::pool_slot(TOKEN),
+            U256::from_be_bytes(hex!(
+                "f043c50fe795c69f30b8ff78b84032dc53a9d87ca283ae10a1dacfbb648e83ef"
+            ))
+        );
+    }
+
+    #[test]
+    fn lp_balance_slot_is_stable_and_separate_from_pool() {
+        let pool_slot = DexStorage::pool_slot(TOKEN);
+        let lp_slot = DexStorage::lp_balance_slot(TOKEN, USER);
+
+        assert_ne!(pool_slot, lp_slot);
+        assert_ne!(pool_slot + U256::from(1), lp_slot);
+        assert_ne!(pool_slot + U256::from(2), lp_slot);
+        assert_eq!(
+            lp_slot,
+            U256::from_be_bytes(hex!(
+                "34bbbd721609e5bb442b61609b7b532682b16796bedbe1f30aaeefe6aab8c77c"
+            ))
+        );
+    }
+}

--- a/crates/common/precompiles/src/dex/token.rs
+++ b/crates/common/precompiles/src/dex/token.rs
@@ -1,0 +1,74 @@
+//! Token movement boundary for the native DEX.
+
+use alloy_primitives::{Address, U256, address};
+
+use super::{BASE_TOKEN_ADDRESS, BaseDexError, IBaseDex};
+
+/// First demo native token supported by the feature-gated DEX scaffold.
+pub(crate) const DEMO_TOKEN_A: Address = address!("0000000000000000000000000000000000000dE8");
+/// Second demo native token supported by the feature-gated DEX scaffold.
+pub(crate) const DEMO_TOKEN_B: Address = address!("0000000000000000000000000000000000000dE9");
+
+#[derive(Debug, Default, Clone, Copy)]
+pub(crate) struct DexToken;
+
+impl DexToken {
+    pub(crate) fn validate(token: Address) -> Result<(), BaseDexError> {
+        if token == DEMO_TOKEN_A || token == DEMO_TOKEN_B {
+            return Ok(());
+        }
+        Err(BaseDexError::InvalidToken(IBaseDex::InvalidToken {}))
+    }
+
+    pub(crate) fn pull(
+        token: Address,
+        _from: Address,
+        _to: Address,
+        _amount: U256,
+    ) -> Result<(), BaseDexError> {
+        Self::validate_transfer_token(token)
+    }
+
+    pub(crate) fn push(
+        token: Address,
+        _from: Address,
+        _to: Address,
+        _amount: U256,
+    ) -> Result<(), BaseDexError> {
+        Self::validate_transfer_token(token)
+    }
+
+    fn validate_transfer_token(token: Address) -> Result<(), BaseDexError> {
+        if token == BASE_TOKEN_ADDRESS {
+            return Ok(());
+        }
+        Self::validate(token)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn token_adapter_accepts_demo_tokens() {
+        assert_eq!(DexToken::validate(DEMO_TOKEN_A), Ok(()));
+        assert_eq!(DexToken::validate(DEMO_TOKEN_B), Ok(()));
+    }
+
+    #[test]
+    fn token_adapter_accepts_base_for_transfers() {
+        assert_eq!(
+            DexToken::pull(BASE_TOKEN_ADDRESS, Address::ZERO, Address::ZERO, U256::ZERO),
+            Ok(())
+        );
+    }
+
+    #[test]
+    fn token_adapter_rejects_unknown_tokens() {
+        assert!(matches!(
+            DexToken::validate(address!("1111111111111111111111111111111111111111")),
+            Err(BaseDexError::InvalidToken(_))
+        ));
+    }
+}

--- a/crates/common/precompiles/src/dex/token.rs
+++ b/crates/common/precompiles/src/dex/token.rs
@@ -9,6 +9,10 @@ pub(crate) const DEMO_TOKEN_A: Address = address!("00000000000000000000000000000
 /// Second demo native token supported by the feature-gated DEX scaffold.
 pub(crate) const DEMO_TOKEN_B: Address = address!("0000000000000000000000000000000000000dE9");
 
+/// Validation-only token boundary for the demo scaffold.
+///
+/// `pull` and `push` intentionally do not mutate balances yet. Native balance storage and ERC-20
+/// adapter calls should be wired here before this DEX supports production token movement.
 #[derive(Debug, Default, Clone, Copy)]
 pub(crate) struct DexToken;
 

--- a/crates/common/precompiles/src/lib.rs
+++ b/crates/common/precompiles/src/lib.rs
@@ -14,7 +14,7 @@ pub use spec::BasePrecompileSpec;
 #[cfg(feature = "native-dex")]
 mod dex;
 #[cfg(feature = "native-dex")]
-pub use dex::{BASE_DEX_ADDRESS, BaseDexPrecompile};
+pub use dex::{BASE_DEX_ADDRESS, BaseDexPrecompile, IBaseDex};
 
 mod bn254_pair;
 

--- a/crates/common/precompiles/src/lib.rs
+++ b/crates/common/precompiles/src/lib.rs
@@ -11,6 +11,11 @@ pub use provider::BasePrecompiles;
 mod spec;
 pub use spec::BasePrecompileSpec;
 
+#[cfg(feature = "native-dex")]
+mod dex;
+#[cfg(feature = "native-dex")]
+pub use dex::{BASE_DEX_ADDRESS, BaseDexPrecompile};
+
 mod bn254_pair;
 
 mod bls12_381;

--- a/crates/execution/evm/Cargo.toml
+++ b/crates/execution/evm/Cargo.toml
@@ -48,6 +48,7 @@ base-common-consensus = { workspace = true, features = ["arbitrary"] }
 
 [features]
 default = [ "std" ]
+native-dex = [ "base-common-evm/native-dex" ]
 std = [
 	"alloy-consensus/std",
 	"alloy-eips/std",

--- a/devnet/Cargo.toml
+++ b/devnet/Cargo.toml
@@ -94,4 +94,7 @@ base-common-rpc-types.workspace = true
 base-common-precompiles.workspace = true
 
 [features]
-native-dex = [ "base-builder-core/native-dex", "base-common-precompiles/native-dex" ]
+native-dex = [
+	"base-builder-core/native-dex",
+	"base-common-precompiles/native-dex",
+]

--- a/devnet/Cargo.toml
+++ b/devnet/Cargo.toml
@@ -91,6 +91,7 @@ alloy-rpc-types-eth = { workspace = true, features = ["std"] }
 
 # base-alloy
 base-common-rpc-types.workspace = true
+base-common-precompiles.workspace = true
 
 [features]
-native-dex = [ "base-builder-core/native-dex" ]
+native-dex = [ "base-builder-core/native-dex", "base-common-precompiles/native-dex" ]

--- a/devnet/Cargo.toml
+++ b/devnet/Cargo.toml
@@ -84,8 +84,13 @@ testcontainers = { workspace = true, features = ["blocking", "host-port-exposure
 [dev-dependencies]
 # alloy
 alloy-signer.workspace = true
+alloy-sol-types.workspace = true
 alloy-eips = { workspace = true, features = ["std"] }
 alloy-consensus = { workspace = true, features = ["std"] }
+alloy-rpc-types-eth = { workspace = true, features = ["std"] }
 
 # base-alloy
 base-common-rpc-types.workspace = true
+
+[features]
+native-dex = [ "base-builder-core/native-dex" ]

--- a/devnet/src/smoke.rs
+++ b/devnet/src/smoke.rs
@@ -9,6 +9,7 @@ use alloy_rpc_types_engine::JwtSecret;
 use base_common_network::Base;
 use base_tx_forwarding::TxForwardingConfig;
 use eyre::{Result, WrapErr};
+use serde_json::{Value, json};
 use tempfile::TempDir;
 use url::Url;
 
@@ -130,6 +131,8 @@ pub struct DevnetBuilder {
     output_dir: Option<PathBuf>,
     stable_config: Option<StableDevnetConfig>,
     tx_forwarding_config: Option<TxForwardingConfig>,
+    base_azul_time: Option<u64>,
+    base_beryl_time: Option<u64>,
     verifier_l1_confs: u64,
 }
 
@@ -174,6 +177,24 @@ impl DevnetBuilder {
     /// the `base_insertValidatedTransaction` RPC endpoint.
     pub fn with_tx_forwarding(mut self, config: TxForwardingConfig) -> Self {
         self.tx_forwarding_config = Some(config);
+        self
+    }
+
+    /// Sets the Base Azul activation timestamp in generated L2 artifacts.
+    pub const fn with_azul_at(mut self, timestamp: u64) -> Self {
+        self.base_azul_time = Some(timestamp);
+        self
+    }
+
+    /// Sets the Base Beryl activation timestamp in generated L2 artifacts.
+    ///
+    /// Beryl requires Azul, so this defaults Azul to the same timestamp when Azul has not been
+    /// configured explicitly.
+    pub const fn with_beryl_at(mut self, timestamp: u64) -> Self {
+        self.base_beryl_time = Some(timestamp);
+        if self.base_azul_time.is_none() {
+            self.base_azul_time = Some(timestamp);
+        }
         self
     }
 
@@ -263,12 +284,19 @@ impl DevnetBuilder {
 
         let jwt_secret = JwtSecret::random();
 
-        let l2_genesis_bytes =
+        let mut l2_genesis_bytes =
             std::fs::read(l2_deployment.genesis_path()).wrap_err("Failed to read L2 genesis")?;
-        let rollup_config_bytes = std::fs::read(l2_deployment.rollup_config_path())
+        let mut rollup_config_bytes = std::fs::read(l2_deployment.rollup_config_path())
             .wrap_err("Failed to read rollup config")?;
         let l1_genesis_bytes =
             std::fs::read(l1_genesis.el_genesis_path()).wrap_err("Failed to read L1 genesis")?;
+
+        apply_base_hardfork_overrides(
+            &mut l2_genesis_bytes,
+            &mut rollup_config_bytes,
+            self.base_azul_time,
+            self.base_beryl_time,
+        )?;
 
         let l2_config = L2StackConfig {
             l2_genesis: l2_genesis_bytes,
@@ -289,4 +317,66 @@ impl DevnetBuilder {
 
         Ok(Devnet { _temp_dir: temp_dir, l1_genesis, l2_deployment, l1_stack, l2_stack })
     }
+}
+
+fn apply_base_hardfork_overrides(
+    l2_genesis_bytes: &mut Vec<u8>,
+    rollup_config_bytes: &mut Vec<u8>,
+    azul_time: Option<u64>,
+    beryl_time: Option<u64>,
+) -> Result<()> {
+    if azul_time.is_none() && beryl_time.is_none() {
+        return Ok(());
+    }
+
+    if let Some(beryl) = beryl_time
+        && let Some(azul) = azul_time
+    {
+        eyre::ensure!(azul <= beryl, "Base Azul activation must be before or at Beryl");
+    }
+
+    let mut l2_genesis: Value =
+        serde_json::from_slice(l2_genesis_bytes).wrap_err("Failed to parse L2 genesis")?;
+    let genesis_config = l2_genesis
+        .get_mut("config")
+        .and_then(Value::as_object_mut)
+        .ok_or_else(|| eyre::eyre!("L2 genesis config must be an object"))?;
+    if let Some(azul) = azul_time {
+        genesis_config.insert("osakaTime".to_string(), json!(azul));
+    }
+
+    let base_config = genesis_config.entry("base").or_insert_with(|| json!({}));
+    let base_config = base_config
+        .as_object_mut()
+        .ok_or_else(|| eyre::eyre!("L2 genesis config.base must be an object"))?;
+
+    if let Some(azul) = azul_time {
+        base_config.insert("azul".to_string(), json!(azul));
+    }
+    if let Some(beryl) = beryl_time {
+        base_config.insert("beryl".to_string(), json!(beryl));
+    }
+    *l2_genesis_bytes =
+        serde_json::to_vec_pretty(&l2_genesis).wrap_err("Failed to serialize L2 genesis")?;
+
+    let mut rollup_config: Value =
+        serde_json::from_slice(rollup_config_bytes).wrap_err("Failed to parse rollup config")?;
+    let rollup_object = rollup_config
+        .as_object_mut()
+        .ok_or_else(|| eyre::eyre!("Rollup config must be an object"))?;
+    let base_config = rollup_object.entry("base").or_insert_with(|| json!({}));
+    let base_config = base_config
+        .as_object_mut()
+        .ok_or_else(|| eyre::eyre!("Rollup config base field must be an object"))?;
+
+    if let Some(azul) = azul_time {
+        base_config.insert("azul".to_string(), json!(azul));
+    }
+    if let Some(beryl) = beryl_time {
+        base_config.insert("beryl".to_string(), json!(beryl));
+    }
+    *rollup_config_bytes =
+        serde_json::to_vec_pretty(&rollup_config).wrap_err("Failed to serialize rollup config")?;
+
+    Ok(())
 }

--- a/devnet/tests/native_dex.rs
+++ b/devnet/tests/native_dex.rs
@@ -12,8 +12,9 @@ use alloy_provider::{Provider, RootProvider};
 use alloy_rpc_types_eth::TransactionInput;
 use alloy_signer::SignerSync;
 use alloy_signer_local::PrivateKeySigner;
-use alloy_sol_types::{SolCall, sol};
+use alloy_sol_types::SolCall;
 use base_common_network::Base;
+use base_common_precompiles::{BASE_DEX_ADDRESS, IBaseDex};
 use base_common_rpc_types::{BaseTransactionReceipt, BaseTransactionRequest};
 use devnet::{
     DevnetBuilder,
@@ -46,37 +47,8 @@ const DEX_FEE_DENOMINATOR: U256 = U256::from_limbs([1_000, 0, 0, 0]);
 const DEX_MINIMUM_LIQUIDITY: U256 = U256::from_limbs([1_000, 0, 0, 0]);
 const TX_RECEIPT_TIMEOUT: Duration = Duration::from_secs(60);
 const BLOCK_PRODUCTION_TIMEOUT: Duration = Duration::from_secs(20);
-const BASE_DEX_ADDRESS: Address = address!("0000000000000000000000000000000000000dE7");
 const DEMO_TOKEN_A: Address = address!("0000000000000000000000000000000000000dE8");
 const DEMO_TOKEN_B: Address = address!("0000000000000000000000000000000000000dE9");
-
-sol! {
-    #[derive(Debug, PartialEq, Eq)]
-    interface IBaseDex {
-        struct Pool {
-            uint128 reserveToken;
-            uint128 reserveBase;
-            uint256 totalSupply;
-        }
-
-        function BASE_TOKEN() external view returns (address);
-        function getPool(address token) external view returns (Pool memory);
-        function quoteExactInput(address tokenIn, address tokenOut, uint256 amountIn)
-            external view returns (uint256 amountOut);
-        function addLiquidity(address token, uint256 amountToken, uint256 amountBase, address to)
-            external returns (uint256 liquidity);
-        function swapExactTokensForTokens(
-            address tokenIn,
-            address tokenOut,
-            uint256 amountIn,
-            uint256 minAmountOut,
-            address to
-        ) external returns (uint256 amountOut);
-
-        event Mint(address indexed sender, address indexed token, uint256 amountToken, uint256 amountBase, uint256 liquidity, address indexed to);
-        event Swap(address indexed sender, address indexed tokenIn, address indexed tokenOut, uint256 amountIn, uint256 amountOut, address to);
-    }
-}
 
 #[tokio::test]
 async fn native_dex_swap_through_user_rpc_flow() -> Result<()> {
@@ -164,8 +136,16 @@ async fn native_dex_swap_through_user_rpc_flow() -> Result<()> {
         call_get_pool(&provider, liquidity_provider.address(), DEMO_TOKEN_B).await?;
     assert_eq!(pool_a_before.reserveToken, 1_000_000);
     assert_eq!(pool_a_before.reserveBase, 1_000_000);
+    assert_eq!(
+        pool_a_before.totalSupply,
+        expected_initial_total_supply(U256::from(1_000_000u64), U256::from(1_000_000u64))
+    );
     assert_eq!(pool_b_before.reserveToken, 2_000_000);
     assert_eq!(pool_b_before.reserveBase, 1_000_000);
+    assert_eq!(
+        pool_b_before.totalSupply,
+        expected_initial_total_supply(U256::from(2_000_000u64), U256::from(1_000_000u64))
+    );
 
     let amount_in = U256::from(10_000u64);
     let expected_base_out = expected_amount_out(
@@ -439,11 +419,11 @@ const fn dex_lp_update_gas() -> u64 {
 }
 
 const fn dex_pool_read_gas() -> u64 {
-    dex_slot_hash_gas(2) + DEX_STORAGE_READ_COST * 3
+    dex_slot_hash_gas(2) * 3 + DEX_STORAGE_READ_COST * 3
 }
 
 const fn dex_pool_write_gas() -> u64 {
-    dex_slot_hash_gas(2) + DEX_STORAGE_ACCOUNT_TOUCH_COST + DEX_STORAGE_WRITE_COST * 3
+    dex_slot_hash_gas(2) * 3 + DEX_STORAGE_ACCOUNT_TOUCH_COST + DEX_STORAGE_WRITE_COST * 3
 }
 
 const fn dex_slot_hash_gas(words: u64) -> u64 {
@@ -463,6 +443,10 @@ fn expected_amount_out(amount_in: U256, reserve_in: U256, reserve_out: U256) -> 
 
 fn expected_initial_liquidity(amount_token: U256, amount_base: U256) -> U256 {
     integer_sqrt(amount_token * amount_base) - DEX_MINIMUM_LIQUIDITY
+}
+
+fn expected_initial_total_supply(amount_token: U256, amount_base: U256) -> U256 {
+    integer_sqrt(amount_token * amount_base)
 }
 
 fn integer_sqrt(value: U256) -> U256 {

--- a/devnet/tests/native_dex.rs
+++ b/devnet/tests/native_dex.rs
@@ -1,0 +1,312 @@
+#![cfg(feature = "native-dex")]
+
+//! End-user RPC demonstration for the feature-gated native DEX.
+
+use std::time::Duration;
+
+use alloy_consensus::{SignableTransaction, TxReceipt};
+use alloy_eips::{BlockNumberOrTag, eip2718::Encodable2718};
+use alloy_network::{ReceiptResponse, TransactionBuilder};
+use alloy_primitives::{Address, B256, Bytes, U256, address};
+use alloy_provider::{Provider, RootProvider};
+use alloy_rpc_types_eth::TransactionInput;
+use alloy_signer::SignerSync;
+use alloy_signer_local::PrivateKeySigner;
+use alloy_sol_types::{SolCall, sol};
+use base_common_network::Base;
+use base_common_rpc_types::{BaseTransactionReceipt, BaseTransactionRequest};
+use devnet::{
+    DevnetBuilder,
+    config::{ANVIL_ACCOUNT_1, ANVIL_ACCOUNT_2},
+};
+use eyre::{Result, WrapErr};
+use tokio::time::{sleep, timeout};
+
+const L1_CHAIN_ID: u64 = 1337;
+const L2_CHAIN_ID: u64 = 84538453;
+const TX_RECEIPT_TIMEOUT: Duration = Duration::from_secs(60);
+const BLOCK_PRODUCTION_TIMEOUT: Duration = Duration::from_secs(20);
+const BASE_DEX_ADDRESS: Address = address!("0000000000000000000000000000000000000dE7");
+const DEMO_TOKEN_A: Address = address!("0000000000000000000000000000000000000dE8");
+const DEMO_TOKEN_B: Address = address!("0000000000000000000000000000000000000dE9");
+
+sol! {
+    #[derive(Debug, PartialEq, Eq)]
+    interface IBaseDex {
+        struct Pool {
+            uint128 reserveToken;
+            uint128 reserveBase;
+            uint256 totalSupply;
+        }
+
+        function BASE_TOKEN() external view returns (address);
+        function getPool(address token) external view returns (Pool memory);
+        function quoteExactInput(address tokenIn, address tokenOut, uint256 amountIn)
+            external view returns (uint256 amountOut);
+        function addLiquidity(address token, uint256 amountToken, uint256 amountBase, address to)
+            external returns (uint256 liquidity);
+        function swapExactTokensForTokens(
+            address tokenIn,
+            address tokenOut,
+            uint256 amountIn,
+            uint256 minAmountOut,
+            address to
+        ) external returns (uint256 amountOut);
+
+        event Mint(address indexed sender, address indexed token, uint256 amountToken, uint256 amountBase, uint256 liquidity, address indexed to);
+        event Swap(address indexed sender, address indexed tokenIn, address indexed tokenOut, uint256 amountIn, uint256 amountOut, address to);
+    }
+}
+
+#[tokio::test]
+async fn native_dex_swap_through_user_rpc_flow() -> Result<()> {
+    let devnet = DevnetBuilder::new()
+        .with_l1_chain_id(L1_CHAIN_ID)
+        .with_l2_chain_id(L2_CHAIN_ID)
+        .with_beryl_at(0)
+        .build()
+        .await?;
+
+    let provider = devnet.l2_builder_provider()?;
+    wait_for_l2_block(&provider, 2).await?;
+
+    let liquidity_provider = signer(&ANVIL_ACCOUNT_1.private_key)?;
+    let swapper = signer(&ANVIL_ACCOUNT_2.private_key)?;
+    let base_token = call_base_token(&provider, liquidity_provider.address()).await?;
+    assert_eq!(base_token, Address::ZERO);
+
+    let empty_pool = call_get_pool(&provider, liquidity_provider.address(), DEMO_TOKEN_A).await?;
+    assert_eq!(empty_pool.reserveToken, 0);
+    assert_eq!(empty_pool.reserveBase, 0);
+    assert_eq!(empty_pool.totalSupply, U256::ZERO);
+
+    let mut liquidity_nonce = provider.get_transaction_count(liquidity_provider.address()).await?;
+    let seed_token_a = IBaseDex::addLiquidityCall {
+        token: DEMO_TOKEN_A,
+        amountToken: U256::from(1_000_000u64),
+        amountBase: U256::from(1_000_000u64),
+        to: liquidity_provider.address(),
+    };
+    let seed_token_a_receipt = send_dex_transaction(
+        &provider,
+        &liquidity_provider,
+        liquidity_nonce,
+        seed_token_a.abi_encode(),
+    )
+    .await
+    .wrap_err("seed token A liquidity")?;
+    assert_mint_receipt(
+        &seed_token_a_receipt,
+        DEMO_TOKEN_A,
+        U256::from(1_000_000u64),
+        U256::from(1_000_000u64),
+    )?;
+    liquidity_nonce += 1;
+
+    let seed_token_b = IBaseDex::addLiquidityCall {
+        token: DEMO_TOKEN_B,
+        amountToken: U256::from(2_000_000u64),
+        amountBase: U256::from(1_000_000u64),
+        to: liquidity_provider.address(),
+    };
+    let seed_token_b_receipt = send_dex_transaction(
+        &provider,
+        &liquidity_provider,
+        liquidity_nonce,
+        seed_token_b.abi_encode(),
+    )
+    .await
+    .wrap_err("seed token B liquidity")?;
+    assert_mint_receipt(
+        &seed_token_b_receipt,
+        DEMO_TOKEN_B,
+        U256::from(2_000_000u64),
+        U256::from(1_000_000u64),
+    )?;
+
+    let pool_a_before =
+        call_get_pool(&provider, liquidity_provider.address(), DEMO_TOKEN_A).await?;
+    let pool_b_before =
+        call_get_pool(&provider, liquidity_provider.address(), DEMO_TOKEN_B).await?;
+    assert_eq!(pool_a_before.reserveToken, 1_000_000);
+    assert_eq!(pool_a_before.reserveBase, 1_000_000);
+    assert_eq!(pool_b_before.reserveToken, 2_000_000);
+    assert_eq!(pool_b_before.reserveBase, 1_000_000);
+
+    let amount_in = U256::from(10_000u64);
+    let quoted_amount_out =
+        call_quote_exact_input(&provider, swapper.address(), DEMO_TOKEN_A, DEMO_TOKEN_B, amount_in)
+            .await?;
+    assert!(quoted_amount_out > U256::ZERO);
+
+    let min_amount_out = quoted_amount_out - U256::from(1u64);
+    let swap = IBaseDex::swapExactTokensForTokensCall {
+        tokenIn: DEMO_TOKEN_A,
+        tokenOut: DEMO_TOKEN_B,
+        amountIn: amount_in,
+        minAmountOut: min_amount_out,
+        to: swapper.address(),
+    };
+    let swap_calldata = swap.abi_encode();
+    let gas = provider
+        .estimate_gas(dex_request(swapper.address(), swap_calldata.clone()))
+        .await
+        .wrap_err("estimate swap gas")?;
+    assert!(gas > 0);
+
+    let swap_nonce = provider.get_transaction_count(swapper.address()).await?;
+    let swap_receipt = send_dex_transaction(&provider, &swapper, swap_nonce, swap_calldata)
+        .await
+        .wrap_err("swap token A for token B")?;
+    assert_swap_receipt(&swap_receipt, DEMO_TOKEN_A, DEMO_TOKEN_B, amount_in, quoted_amount_out)?;
+
+    let pool_a_after = call_get_pool(&provider, swapper.address(), DEMO_TOKEN_A).await?;
+    let pool_b_after = call_get_pool(&provider, swapper.address(), DEMO_TOKEN_B).await?;
+
+    assert_eq!(pool_a_after.reserveToken, pool_a_before.reserveToken + 10_000);
+    assert!(pool_a_after.reserveBase < pool_a_before.reserveBase);
+    assert!(pool_b_after.reserveBase > pool_b_before.reserveBase);
+    assert!(pool_b_after.reserveToken < pool_b_before.reserveToken);
+
+    Ok(())
+}
+
+fn signer(private_key: &B256) -> Result<PrivateKeySigner> {
+    let private_key_hex = format!("0x{}", hex::encode(private_key.as_slice()));
+    Ok(private_key_hex.parse()?)
+}
+
+async fn wait_for_l2_block(provider: &RootProvider<Base>, min_block: u64) -> Result<()> {
+    timeout(BLOCK_PRODUCTION_TIMEOUT, async {
+        loop {
+            let block = provider.get_block_number().await?;
+            if block >= min_block {
+                return Ok::<_, eyre::Error>(());
+            }
+            sleep(Duration::from_millis(500)).await;
+        }
+    })
+    .await
+    .wrap_err("L2 block production timed out")?
+}
+
+async fn call_base_token(provider: &RootProvider<Base>, from: Address) -> Result<Address> {
+    let calldata = IBaseDex::BASE_TOKENCall {}.abi_encode();
+    let result =
+        provider.call(dex_request(from, calldata)).block(BlockNumberOrTag::Latest.into()).await?;
+    Ok(IBaseDex::BASE_TOKENCall::abi_decode_returns(&result)?)
+}
+
+async fn call_get_pool(
+    provider: &RootProvider<Base>,
+    from: Address,
+    token: Address,
+) -> Result<IBaseDex::Pool> {
+    let calldata = IBaseDex::getPoolCall { token }.abi_encode();
+    let result =
+        provider.call(dex_request(from, calldata)).block(BlockNumberOrTag::Latest.into()).await?;
+    Ok(IBaseDex::getPoolCall::abi_decode_returns(&result)?)
+}
+
+async fn call_quote_exact_input(
+    provider: &RootProvider<Base>,
+    from: Address,
+    token_in: Address,
+    token_out: Address,
+    amount_in: U256,
+) -> Result<U256> {
+    let calldata = IBaseDex::quoteExactInputCall {
+        tokenIn: token_in,
+        tokenOut: token_out,
+        amountIn: amount_in,
+    }
+    .abi_encode();
+    let result =
+        provider.call(dex_request(from, calldata)).block(BlockNumberOrTag::Latest.into()).await?;
+    Ok(IBaseDex::quoteExactInputCall::abi_decode_returns(&result)?)
+}
+
+async fn send_dex_transaction(
+    provider: &RootProvider<Base>,
+    signer: &PrivateKeySigner,
+    nonce: u64,
+    calldata: Vec<u8>,
+) -> Result<BaseTransactionReceipt> {
+    let request = dex_request(signer.address(), calldata)
+        .transaction_type(2)
+        .with_gas_limit(1_000_000)
+        .with_max_fee_per_gas(1_000_000_000)
+        .with_max_priority_fee_per_gas(1_000_000)
+        .with_chain_id(L2_CHAIN_ID)
+        .with_nonce(nonce);
+
+    let tx = request
+        .build_typed_tx()
+        .map_err(|request| eyre::eyre!("invalid DEX transaction request: {request:?}"))?;
+    let signature = signer.sign_hash_sync(&tx.signature_hash())?;
+    let signed_tx = tx.into_signed(signature);
+    let tx_hash = *signed_tx.hash();
+    let raw_tx: Bytes = signed_tx.encoded_2718().into();
+    let pending_tx = provider.send_raw_transaction(&raw_tx).await?;
+    assert_eq!(*pending_tx.tx_hash(), tx_hash);
+
+    timeout(TX_RECEIPT_TIMEOUT, async {
+        loop {
+            if let Some(receipt) = provider.get_transaction_receipt(tx_hash).await? {
+                assert!(receipt.status(), "DEX transaction {tx_hash} must succeed");
+                assert_eq!(receipt.inner.to, Some(BASE_DEX_ADDRESS));
+                return Ok::<_, eyre::Error>(receipt);
+            }
+            sleep(Duration::from_secs(1)).await;
+        }
+    })
+    .await
+    .wrap_err("DEX transaction receipt timed out")?
+}
+
+fn dex_request(from: Address, calldata: Vec<u8>) -> BaseTransactionRequest {
+    BaseTransactionRequest::default()
+        .from(from)
+        .to(BASE_DEX_ADDRESS)
+        .value(U256::ZERO)
+        .input(TransactionInput::new(Bytes::from(calldata)))
+}
+
+fn assert_mint_receipt(
+    receipt: &BaseTransactionReceipt,
+    token: Address,
+    amount_token: U256,
+    amount_base: U256,
+) -> Result<()> {
+    let logs = receipt.inner.inner.logs();
+    assert_eq!(logs.len(), 1);
+    let mint = logs[0].log_decode_validate::<IBaseDex::Mint>()?;
+
+    assert_eq!(mint.address(), BASE_DEX_ADDRESS);
+    assert_eq!(mint.inner.data.token, token);
+    assert_eq!(mint.inner.data.amountToken, amount_token);
+    assert_eq!(mint.inner.data.amountBase, amount_base);
+    assert!(mint.inner.data.liquidity > U256::ZERO);
+
+    Ok(())
+}
+
+fn assert_swap_receipt(
+    receipt: &BaseTransactionReceipt,
+    token_in: Address,
+    token_out: Address,
+    amount_in: U256,
+    amount_out: U256,
+) -> Result<()> {
+    let logs = receipt.inner.inner.logs();
+    assert_eq!(logs.len(), 1);
+    let swap = logs[0].log_decode_validate::<IBaseDex::Swap>()?;
+
+    assert_eq!(swap.address(), BASE_DEX_ADDRESS);
+    assert_eq!(swap.inner.data.tokenIn, token_in);
+    assert_eq!(swap.inner.data.tokenOut, token_out);
+    assert_eq!(swap.inner.data.amountIn, amount_in);
+    assert_eq!(swap.inner.data.amountOut, amount_out);
+
+    Ok(())
+}

--- a/devnet/tests/native_dex.rs
+++ b/devnet/tests/native_dex.rs
@@ -24,6 +24,26 @@ use tokio::time::{sleep, timeout};
 
 const L1_CHAIN_ID: u64 = 1337;
 const L2_CHAIN_ID: u64 = 84538453;
+const TX_BASE_GAS: u64 = 21_000;
+const TX_STANDARD_TOKEN_COST: u64 = 4;
+const TX_NON_ZERO_BYTE_MULTIPLIER_ISTANBUL: u64 = 4;
+const TX_FLOOR_COST_PER_TOKEN: u64 = 10;
+const ESTIMATE_CALL_STIPEND_GAS: u64 = 2_300;
+const ESTIMATE_GAS_ERROR_RATIO: f64 = 0.015;
+const DEX_INPUT_PER_WORD_COST: u64 = 6;
+const DEX_SELECTOR_DISPATCH_COST: u64 = 100;
+const DEX_ARITHMETIC_COST: u64 = 500;
+const DEX_STORAGE_ACCOUNT_TOUCH_COST: u64 = 2_600;
+const DEX_STORAGE_READ_COST: u64 = 2_100;
+const DEX_STORAGE_WRITE_COST: u64 = 22_100;
+const DEX_KECCAK_BASE_COST: u64 = 30;
+const DEX_KECCAK_WORD_COST: u64 = 6;
+const DEX_LOG_BASE_COST: u64 = 375;
+const DEX_LOG_TOPIC_COST: u64 = 375;
+const DEX_LOG_DATA_COST: u64 = 8;
+const DEX_FEE_NUMERATOR: U256 = U256::from_limbs([997, 0, 0, 0]);
+const DEX_FEE_DENOMINATOR: U256 = U256::from_limbs([1_000, 0, 0, 0]);
+const DEX_MINIMUM_LIQUIDITY: U256 = U256::from_limbs([1_000, 0, 0, 0]);
 const TX_RECEIPT_TIMEOUT: Duration = Duration::from_secs(60);
 const BLOCK_PRODUCTION_TIMEOUT: Duration = Duration::from_secs(20);
 const BASE_DEX_ADDRESS: Address = address!("0000000000000000000000000000000000000dE7");
@@ -87,11 +107,12 @@ async fn native_dex_swap_through_user_rpc_flow() -> Result<()> {
         amountBase: U256::from(1_000_000u64),
         to: liquidity_provider.address(),
     };
+    let seed_token_a_calldata = seed_token_a.abi_encode();
     let seed_token_a_receipt = send_dex_transaction(
         &provider,
         &liquidity_provider,
         liquidity_nonce,
-        seed_token_a.abi_encode(),
+        seed_token_a_calldata.clone(),
     )
     .await
     .wrap_err("seed token A liquidity")?;
@@ -100,7 +121,13 @@ async fn native_dex_swap_through_user_rpc_flow() -> Result<()> {
         DEMO_TOKEN_A,
         U256::from(1_000_000u64),
         U256::from(1_000_000u64),
+        expected_initial_liquidity(U256::from(1_000_000u64), U256::from(1_000_000u64)),
     )?;
+    assert_exact_dex_gas(
+        &seed_token_a_receipt,
+        &seed_token_a_calldata,
+        dex_add_liquidity_call_gas(),
+    );
     liquidity_nonce += 1;
 
     let seed_token_b = IBaseDex::addLiquidityCall {
@@ -109,11 +136,12 @@ async fn native_dex_swap_through_user_rpc_flow() -> Result<()> {
         amountBase: U256::from(1_000_000u64),
         to: liquidity_provider.address(),
     };
+    let seed_token_b_calldata = seed_token_b.abi_encode();
     let seed_token_b_receipt = send_dex_transaction(
         &provider,
         &liquidity_provider,
         liquidity_nonce,
-        seed_token_b.abi_encode(),
+        seed_token_b_calldata.clone(),
     )
     .await
     .wrap_err("seed token B liquidity")?;
@@ -122,7 +150,13 @@ async fn native_dex_swap_through_user_rpc_flow() -> Result<()> {
         DEMO_TOKEN_B,
         U256::from(2_000_000u64),
         U256::from(1_000_000u64),
+        expected_initial_liquidity(U256::from(2_000_000u64), U256::from(1_000_000u64)),
     )?;
+    assert_exact_dex_gas(
+        &seed_token_b_receipt,
+        &seed_token_b_calldata,
+        dex_add_liquidity_call_gas(),
+    );
 
     let pool_a_before =
         call_get_pool(&provider, liquidity_provider.address(), DEMO_TOKEN_A).await?;
@@ -134,10 +168,20 @@ async fn native_dex_swap_through_user_rpc_flow() -> Result<()> {
     assert_eq!(pool_b_before.reserveBase, 1_000_000);
 
     let amount_in = U256::from(10_000u64);
+    let expected_base_out = expected_amount_out(
+        amount_in,
+        U256::from(pool_a_before.reserveToken),
+        U256::from(pool_a_before.reserveBase),
+    );
+    let expected_amount_out = expected_amount_out(
+        expected_base_out,
+        U256::from(pool_b_before.reserveBase),
+        U256::from(pool_b_before.reserveToken),
+    );
     let quoted_amount_out =
         call_quote_exact_input(&provider, swapper.address(), DEMO_TOKEN_A, DEMO_TOKEN_B, amount_in)
             .await?;
-    assert!(quoted_amount_out > U256::ZERO);
+    assert_eq!(quoted_amount_out, expected_amount_out);
 
     let min_amount_out = quoted_amount_out - U256::from(1u64);
     let swap = IBaseDex::swapExactTokensForTokensCall {
@@ -152,21 +196,32 @@ async fn native_dex_swap_through_user_rpc_flow() -> Result<()> {
         .estimate_gas(dex_request(swapper.address(), swap_calldata.clone()))
         .await
         .wrap_err("estimate swap gas")?;
-    assert!(gas > 0);
+    let expected_swap_gas = expected_dex_transaction_gas(&swap_calldata, dex_swap_call_gas());
+    assert_eq!(gas, expected_reth_estimate_gas(expected_swap_gas));
 
     let swap_nonce = provider.get_transaction_count(swapper.address()).await?;
-    let swap_receipt = send_dex_transaction(&provider, &swapper, swap_nonce, swap_calldata)
+    let swap_receipt = send_dex_transaction(&provider, &swapper, swap_nonce, swap_calldata.clone())
         .await
         .wrap_err("swap token A for token B")?;
     assert_swap_receipt(&swap_receipt, DEMO_TOKEN_A, DEMO_TOKEN_B, amount_in, quoted_amount_out)?;
+    assert_exact_dex_gas(&swap_receipt, &swap_calldata, dex_swap_call_gas());
 
     let pool_a_after = call_get_pool(&provider, swapper.address(), DEMO_TOKEN_A).await?;
     let pool_b_after = call_get_pool(&provider, swapper.address(), DEMO_TOKEN_B).await?;
 
-    assert_eq!(pool_a_after.reserveToken, pool_a_before.reserveToken + 10_000);
-    assert!(pool_a_after.reserveBase < pool_a_before.reserveBase);
-    assert!(pool_b_after.reserveBase > pool_b_before.reserveBase);
-    assert!(pool_b_after.reserveToken < pool_b_before.reserveToken);
+    assert_eq!(pool_a_after.reserveToken, pool_a_before.reserveToken + u128_amount(amount_in));
+    assert_eq!(
+        pool_a_after.reserveBase,
+        pool_a_before.reserveBase - u128_amount(expected_base_out)
+    );
+    assert_eq!(
+        pool_b_after.reserveBase,
+        pool_b_before.reserveBase + u128_amount(expected_base_out)
+    );
+    assert_eq!(
+        pool_b_after.reserveToken,
+        pool_b_before.reserveToken - u128_amount(expected_amount_out)
+    );
 
     Ok(())
 }
@@ -277,6 +332,7 @@ fn assert_mint_receipt(
     token: Address,
     amount_token: U256,
     amount_base: U256,
+    liquidity: U256,
 ) -> Result<()> {
     let logs = receipt.inner.inner.logs();
     assert_eq!(logs.len(), 1);
@@ -286,7 +342,7 @@ fn assert_mint_receipt(
     assert_eq!(mint.inner.data.token, token);
     assert_eq!(mint.inner.data.amountToken, amount_token);
     assert_eq!(mint.inner.data.amountBase, amount_base);
-    assert!(mint.inner.data.liquidity > U256::ZERO);
+    assert_eq!(mint.inner.data.liquidity, liquidity);
 
     Ok(())
 }
@@ -309,4 +365,120 @@ fn assert_swap_receipt(
     assert_eq!(swap.inner.data.amountOut, amount_out);
 
     Ok(())
+}
+
+fn assert_exact_dex_gas(receipt: &BaseTransactionReceipt, calldata: &[u8], call_gas: u64) {
+    assert_eq!(receipt.gas_used(), expected_dex_transaction_gas(calldata, call_gas));
+}
+
+fn expected_dex_transaction_gas(calldata: &[u8], call_gas: u64) -> u64 {
+    let precompile_gas = native_dex_input_gas(calldata.len()) + call_gas;
+    let total_gas = intrinsic_transaction_gas(calldata) + precompile_gas;
+    total_gas.max(eip7623_floor_gas(calldata))
+}
+
+fn expected_reth_estimate_gas(minimum_gas_limit: u64) -> u64 {
+    let mut highest_gas_limit = (minimum_gas_limit + ESTIMATE_CALL_STIPEND_GAS) * 64 / 63;
+    let mut lowest_gas_limit = minimum_gas_limit.saturating_sub(1);
+    let mut mid_gas_limit = (minimum_gas_limit * 3)
+        .min(((highest_gas_limit as u128 + lowest_gas_limit as u128) / 2) as u64);
+
+    while lowest_gas_limit + 1 < highest_gas_limit {
+        let ratio = (highest_gas_limit - lowest_gas_limit) as f64 / highest_gas_limit as f64;
+        if ratio < ESTIMATE_GAS_ERROR_RATIO {
+            break;
+        }
+
+        if mid_gas_limit >= minimum_gas_limit {
+            highest_gas_limit = mid_gas_limit;
+        } else {
+            lowest_gas_limit = mid_gas_limit;
+        }
+        mid_gas_limit = ((highest_gas_limit as u128 + lowest_gas_limit as u128) / 2) as u64;
+    }
+
+    highest_gas_limit
+}
+
+fn intrinsic_transaction_gas(calldata: &[u8]) -> u64 {
+    TX_BASE_GAS + calldata_token_count(calldata) * TX_STANDARD_TOKEN_COST
+}
+
+fn eip7623_floor_gas(calldata: &[u8]) -> u64 {
+    TX_BASE_GAS + calldata_token_count(calldata) * TX_FLOOR_COST_PER_TOKEN
+}
+
+fn calldata_token_count(calldata: &[u8]) -> u64 {
+    let zero_bytes = calldata.iter().filter(|byte| **byte == 0).count() as u64;
+    let non_zero_bytes = calldata.len() as u64 - zero_bytes;
+    zero_bytes + non_zero_bytes * TX_NON_ZERO_BYTE_MULTIPLIER_ISTANBUL
+}
+
+const fn native_dex_input_gas(calldata_len: usize) -> u64 {
+    calldata_len.div_ceil(32) as u64 * DEX_INPUT_PER_WORD_COST
+}
+
+const fn dex_add_liquidity_call_gas() -> u64 {
+    DEX_SELECTOR_DISPATCH_COST + dex_lp_update_gas() + dex_log_gas(4, 96)
+}
+
+const fn dex_swap_call_gas() -> u64 {
+    DEX_SELECTOR_DISPATCH_COST
+        + DEX_ARITHMETIC_COST
+        + dex_pool_read_gas() * 5
+        + dex_pool_write_gas() * 2
+        + dex_log_gas(4, 96)
+}
+
+const fn dex_lp_update_gas() -> u64 {
+    dex_pool_read_gas()
+        + dex_slot_hash_gas(3)
+        + DEX_STORAGE_READ_COST
+        + DEX_STORAGE_WRITE_COST
+        + dex_pool_write_gas()
+}
+
+const fn dex_pool_read_gas() -> u64 {
+    dex_slot_hash_gas(2) + DEX_STORAGE_READ_COST * 3
+}
+
+const fn dex_pool_write_gas() -> u64 {
+    dex_slot_hash_gas(2) + DEX_STORAGE_ACCOUNT_TOUCH_COST + DEX_STORAGE_WRITE_COST * 3
+}
+
+const fn dex_slot_hash_gas(words: u64) -> u64 {
+    DEX_KECCAK_BASE_COST + DEX_KECCAK_WORD_COST * words
+}
+
+const fn dex_log_gas(topics: u64, data_bytes: u64) -> u64 {
+    DEX_LOG_BASE_COST + DEX_LOG_TOPIC_COST * topics + DEX_LOG_DATA_COST * data_bytes
+}
+
+fn expected_amount_out(amount_in: U256, reserve_in: U256, reserve_out: U256) -> U256 {
+    let amount_in_with_fee = amount_in * DEX_FEE_NUMERATOR;
+    let numerator = amount_in_with_fee * reserve_out;
+    let denominator = reserve_in * DEX_FEE_DENOMINATOR + amount_in_with_fee;
+    numerator / denominator
+}
+
+fn expected_initial_liquidity(amount_token: U256, amount_base: U256) -> U256 {
+    integer_sqrt(amount_token * amount_base) - DEX_MINIMUM_LIQUIDITY
+}
+
+fn integer_sqrt(value: U256) -> U256 {
+    if value <= U256::from(3u64) {
+        return if value.is_zero() { U256::ZERO } else { U256::from(1u64) };
+    }
+
+    let mut root = value;
+    let mut candidate = value / U256::from(2u64) + U256::from(1u64);
+    while candidate < root {
+        root = candidate;
+        candidate = (value / candidate + candidate) / U256::from(2u64);
+    }
+    root
+}
+
+fn u128_amount(amount: U256) -> u128 {
+    amount.try_into().expect("demo amount fits u128")
 }


### PR DESCRIPTION
## Summary

This adds a feature-gated native DEX precompile path and wires it into Base EVM registration at Beryl. It keeps the first token boundary intentionally narrow with two demo native tokens while preserving the future adapter seam. The devnet demonstration exercises the end-user RPC flow by seeding liquidity, estimating gas, sending signed raw transactions, decoding receipts, and verifying token swap reserve changes.