### PR TITLE
feat: record reverts in load tester as failure for better viz

### DIFF
--- a/bin/load-tester/src/cli.rs
+++ b/bin/load-tester/src/cli.rs
@@ -200,10 +200,11 @@ async fn run_load_test(args: LoadArgs) -> Result<()> {
             println!("Error: {err}");
         }
         println!(
-            "Submitted: {} | Confirmed: {} | Failed: {}",
+            "Submitted: {} | Confirmed: {} | Failed: {} | Reverted: {}",
             summary.throughput.total_submitted,
             summary.throughput.total_confirmed,
-            summary.throughput.total_failed
+            summary.throughput.total_failed,
+            summary.throughput.total_reverted
         );
         println!(
             "TPS: {:.2} | GPS: {:.0} | Success: {:.1}%",

--- a/crates/execution/txpool/src/pool_error_label.rs
+++ b/crates/execution/txpool/src/pool_error_label.rs
@@ -8,7 +8,7 @@ pub struct PoolRejectionLabel;
 
 impl PoolRejectionLabel {
     /// Returns a `&'static str` label for the given [`PoolError`].
-    pub fn from_error(err: &PoolError) -> &'static str {
+    pub const fn from_error(err: &PoolError) -> &'static str {
         match &err.kind {
             PoolErrorKind::AlreadyImported => "already_imported",
             PoolErrorKind::ReplacementUnderpriced => "replacement_underpriced",

--- a/crates/infra/load-tests/src/metrics/aggregator.rs
+++ b/crates/infra/load-tests/src/metrics/aggregator.rs
@@ -129,6 +129,7 @@ impl<'a> MetricsAggregator<'a> {
         failed: u64,
     ) -> ThroughputMetrics {
         let confirmed = self.transactions.len() as u64;
+        let total_reverted = self.transactions.iter().filter(|t| t.reverted).count() as u64;
         let total_gas: u64 = self.transactions.iter().map(|t| t.gas_used).sum();
         let duration_secs = duration.as_secs_f64();
 
@@ -142,6 +143,7 @@ impl<'a> MetricsAggregator<'a> {
             total_submitted: submitted,
             total_confirmed: confirmed,
             total_failed: failed,
+            total_reverted,
             tps,
             gps,
             duration,

--- a/crates/infra/load-tests/src/metrics/collector.rs
+++ b/crates/infra/load-tests/src/metrics/collector.rs
@@ -17,6 +17,7 @@ pub struct MetricsCollector {
     transactions: Vec<TransactionMetrics>,
     submitted_count: u64,
     failed_count: u64,
+    reverted_count: u64,
     failure_reasons: HashMap<String, u64>,
     rolling: RollingWindow,
     block_receipt_delay_rolling: RollingWindow,
@@ -31,6 +32,7 @@ impl MetricsCollector {
             transactions: Vec::new(),
             submitted_count: 0,
             failed_count: 0,
+            reverted_count: 0,
             failure_reasons: HashMap::new(),
             rolling: RollingWindow::new(),
             block_receipt_delay_rolling: RollingWindow::new(),
@@ -46,7 +48,15 @@ impl MetricsCollector {
 
     /// Records a confirmed transaction with metrics.
     pub fn record_confirmed(&mut self, metrics: TransactionMetrics) {
-        debug!(tx_hash = %metrics.tx_hash, block_latency_ms = ?metrics.block_latency.map(|d| d.as_millis()), "tx confirmed");
+        debug!(
+            tx_hash = %metrics.tx_hash,
+            block_latency_ms = ?metrics.block_latency.map(|d| d.as_millis()),
+            reverted = metrics.reverted,
+            "tx confirmed"
+        );
+        if metrics.reverted {
+            self.reverted_count += 1;
+        }
         let at = metrics.confirmed_at.unwrap_or_else(Instant::now);
         if let Some(latency) = metrics.block_latency {
             self.rolling.push(metrics.gas_used, latency, at);
@@ -89,6 +99,11 @@ impl MetricsCollector {
         self.failed_count
     }
 
+    /// Returns the number of confirmed transactions that reverted.
+    pub const fn reverted_count(&self) -> u64 {
+        self.reverted_count
+    }
+
     /// Generates a summary of collected metrics.
     ///
     /// `duration` should span from first submission to last confirmation
@@ -110,6 +125,7 @@ impl MetricsCollector {
         self.transactions.clear();
         self.submitted_count = 0;
         self.failed_count = 0;
+        self.reverted_count = 0;
         self.failure_reasons.clear();
         self.rolling = RollingWindow::new();
         self.block_receipt_delay_rolling = RollingWindow::new();

--- a/crates/infra/load-tests/src/metrics/types.rs
+++ b/crates/infra/load-tests/src/metrics/types.rs
@@ -20,6 +20,8 @@ pub struct TransactionMetrics {
     pub gas_price: u128,
     /// Block number where transaction was included.
     pub block_number: Option<u64>,
+    /// Whether the transaction reverted during execution.
+    pub reverted: bool,
     /// When canonical inclusion was observed (used by the rolling window).
     #[serde(skip)]
     pub confirmed_at: Option<Instant>,
@@ -43,6 +45,7 @@ impl TransactionMetrics {
             gas_used,
             gas_price,
             block_number,
+            reverted: false,
             confirmed_at: None,
         }
     }
@@ -79,6 +82,8 @@ pub struct ThroughputMetrics {
     pub total_confirmed: u64,
     /// Total transactions failed.
     pub total_failed: u64,
+    /// Total confirmed transactions that reverted during execution.
+    pub total_reverted: u64,
     /// Transactions per second achieved.
     pub tps: f64,
     /// Gas per second achieved.

--- a/crates/infra/load-tests/src/runner/block_watcher.rs
+++ b/crates/infra/load-tests/src/runner/block_watcher.rs
@@ -188,6 +188,7 @@ impl BlockWatcher {
                 block_number: receipt.block_number().unwrap_or(block_number),
                 gas_used: receipt.gas_used(),
                 effective_gas_price: receipt.effective_gas_price(),
+                success: receipt.status(),
             })
             .collect())
     }

--- a/crates/infra/load-tests/src/runner/load_runner.rs
+++ b/crates/infra/load-tests/src/runner/load_runner.rs
@@ -1117,6 +1117,7 @@ impl LoadRunner {
                 let submitted = self.collector.submitted_count();
                 let confirmed = self.collector.confirmed_count();
                 let failed = self.collector.failed_count();
+                let reverted = self.collector.reverted_count();
                 let in_flight = results_tracker.total_in_flight();
                 let senders_blocked = results_tracker.senders_at_limit(max_in_flight_per_sender);
                 let (p50, p99) = self.collector.rolling_p50_p99();
@@ -1129,6 +1130,7 @@ impl LoadRunner {
                     submitted,
                     confirmed,
                     failed,
+                    reverted,
                     in_flight,
                     senders_blocked,
                     gas_price = self.gas_price,
@@ -1383,6 +1385,7 @@ impl LoadRunner {
             submitted: self.collector.submitted_count(),
             confirmed: self.collector.confirmed_count(),
             failed: self.collector.failed_count(),
+            reverted: self.collector.reverted_count(),
             in_flight: results_tracker.total_in_flight(),
             senders_blocked: results_tracker.senders_at_limit(max_in_flight_per_sender),
             total_senders: account_count,

--- a/crates/infra/load-tests/src/runner/results_tracker.rs
+++ b/crates/infra/load-tests/src/runner/results_tracker.rs
@@ -47,6 +47,8 @@ pub struct BlockReceipt {
     pub gas_used: u64,
     /// Effective gas price in wei.
     pub effective_gas_price: u128,
+    /// Whether the transaction executed successfully (`false` = reverted).
+    pub success: bool,
 }
 
 /// Transaction data observed from the builder flashblocks broadcast stream.
@@ -89,6 +91,7 @@ struct BlockReceiptInclusion {
     block_number: u64,
     gas_used: u64,
     effective_gas_price: u128,
+    success: bool,
 }
 
 impl ResultsTracker {
@@ -159,6 +162,7 @@ impl ResultsTracker {
                 block_number: receipt.block_number,
                 gas_used: receipt.gas_used,
                 effective_gas_price: receipt.effective_gas_price,
+                success: receipt.success,
             };
 
             if let Entry::Vacant(e) = inner.block_receipts.entry(receipt.tx_hash) {
@@ -250,6 +254,7 @@ impl ResultsTrackerInner {
         );
         metrics.block_receipt_delay = block_receipt_delay;
         metrics.confirmed_at = Some(receipt.observed_at);
+        metrics.reverted = !receipt.success;
 
         self.block_receipts.remove(&tx_hash);
         self.decrement_in_flight(&pending.from);
@@ -311,6 +316,7 @@ mod tests {
                 block_number: 7,
                 gas_used: 21_000,
                 effective_gas_price: 1_000_000_000,
+                success: true,
             }],
         );
 
@@ -319,7 +325,39 @@ mod tests {
         assert_eq!(metrics[0].tx_hash, tx_hash);
         assert_eq!(metrics[0].block_number, Some(7));
         assert_eq!(metrics[0].gas_used, 21_000);
+        assert!(!metrics[0].reverted);
         assert_eq!(metrics[0].block_receipt_delay, Some(Duration::from_millis(250)));
+        assert_eq!(tracker.total_in_flight(), 0);
+    }
+
+    #[test]
+    fn marks_reverted_transaction() {
+        let from = address!("0000000000000000000000000000000000000001");
+        let tx_hash = TxHash::repeat_byte(3);
+        let tracker = ResultsTracker::new(&[from]);
+
+        tracker.sent_transactions(vec![SentTransaction { tx_hash, from }]);
+        let block_time = Instant::now() + Duration::from_millis(50);
+        tracker.on_new_block(
+            BlockObservation {
+                number: 9,
+                block_time: Some(block_time),
+                observed_at: block_time + Duration::from_millis(100),
+            },
+            vec![BlockReceipt {
+                tx_hash,
+                block_number: 9,
+                gas_used: 45_000,
+                effective_gas_price: 1_000_000_000,
+                success: false,
+            }],
+        );
+
+        let metrics = tracker.drain_confirmed_metrics();
+        assert_eq!(metrics.len(), 1, "reverted tx should still produce metrics");
+        assert_eq!(metrics[0].tx_hash, tx_hash);
+        assert!(metrics[0].reverted, "reverted flag should be set");
+        assert_eq!(metrics[0].gas_used, 45_000);
         assert_eq!(tracker.total_in_flight(), 0);
     }
 
@@ -343,6 +381,7 @@ mod tests {
                 block_number: 8,
                 gas_used: 21_000,
                 effective_gas_price: 1_000_000_000,
+                success: true,
             }],
         );
 

--- a/crates/infra/load-tests/src/runner/status.rs
+++ b/crates/infra/load-tests/src/runner/status.rs
@@ -18,6 +18,8 @@ pub struct DisplaySnapshot {
     pub confirmed: usize,
     /// Total transactions failed.
     pub failed: u64,
+    /// Total confirmed transactions that reverted.
+    pub reverted: u64,
     /// Total in-flight (unconfirmed) transactions.
     pub in_flight: u64,
     /// Number of senders at the in-flight limit.
@@ -161,12 +163,22 @@ impl LoadTestDisplay {
             self.header.set_message(format!("Base Load Test  elapsed {elapsed_str}   continuous"));
         }
 
-        self.txs.set_message(format!(
-            "txs     sub {}   conf {}   failed {}",
-            fmt_num(snap.submitted),
-            fmt_num(snap.confirmed as u64),
-            fmt_num(snap.failed),
-        ));
+        self.txs.set_message(if snap.reverted > 0 {
+            format!(
+                "txs     sub {}   conf {}   failed {}   reverted {}",
+                fmt_num(snap.submitted),
+                fmt_num(snap.confirmed as u64),
+                fmt_num(snap.failed),
+                fmt_num(snap.reverted),
+            )
+        } else {
+            format!(
+                "txs     sub {}   conf {}   failed {}",
+                fmt_num(snap.submitted),
+                fmt_num(snap.confirmed as u64),
+                fmt_num(snap.failed),
+            )
+        });
 
         let success_rate = if snap.submitted > 0 {
             snap.confirmed as f64 / snap.submitted as f64 * 100.0


### PR DESCRIPTION
Classifies reverts as a "failure" mode for viz

Tested on old aerodrome contract that would revert:

```
=== Results ===
Submitted: 2650 | Confirmed: 2650 | Failed: 0 | Reverted: 1384
TPS: 127.52 | GPS: 11633108 | Success: 100.0%
TPS Rolling:   p50=111  p90=263  p99=395  max=395
GPS Rolling:   p50=10070240  p90=23957045  p99=36132591  max=36132591
Block Latency: min=536.7ms  p50=1.5s  mean=1.5s  p99=2.4s  max=2.4s
Block Receipt Delay: min=2.5s  p50=2.9s  mean=2.9s  p99=3.3s  max=3.3s
FB Latency:    min=252.9µs  p50=139.4ms  mean=168.3ms  p99=558.2ms  max=558.3ms  (n=2646)
Gas: total=241740428  avg/tx=91222
Blocks: first=41417391  last=41417399  span=9 block(s)
```

https://sepolia.basescan.org/txs?block=41417392 

