### PR TITLE
perf: increase gas/s on single cronjob

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4873,7 +4873,6 @@ dependencies = [
  "alloy-signer 2.0.5",
  "alloy-signer-local 2.0.5",
  "alloy-sol-types",
- "base-common-consensus",
  "base-common-flashblocks",
  "base-common-network",
  "base-common-precompiles",

--- a/crates/infra/load-tests/Cargo.toml
+++ b/crates/infra/load-tests/Cargo.toml
@@ -26,7 +26,6 @@ alloy-signer-local = { workspace = true, features = ["mnemonic"] }
 # base
 base-tx-manager.workspace = true
 base-common-network.workspace = true
-base-common-consensus.workspace = true
 base-common-flashblocks.workspace = true
 base-common-precompiles = { workspace = true, default-features = false }
 

--- a/crates/infra/load-tests/src/runner/flashblock_watcher.rs
+++ b/crates/infra/load-tests/src/runner/flashblock_watcher.rs
@@ -2,8 +2,7 @@
 
 use std::time::{Duration, Instant};
 
-use alloy_eips::eip2718::Decodable2718;
-use base_common_consensus::BaseTxEnvelope;
+use alloy_primitives::keccak256;
 use base_common_flashblocks::Flashblock;
 use futures::StreamExt;
 use tokio_tungstenite::{
@@ -133,12 +132,7 @@ impl FlashblockWatcher {
             .diff
             .transactions
             .iter()
-            .filter_map(|tx_bytes| {
-                let envelope = BaseTxEnvelope::decode_2718_exact(tx_bytes.as_ref())
-                    .inspect_err(|e| warn!(error = %e, "failed to decode flashblock transaction"))
-                    .ok()?;
-                Some(FlashblockInclusion { tx_hash: envelope.tx_hash(), included_at })
-            })
+            .map(|tx_bytes| FlashblockInclusion { tx_hash: keccak256(tx_bytes), included_at })
             .collect()
     }
 }

--- a/crates/infra/load-tests/src/runner/load_runner.rs
+++ b/crates/infra/load-tests/src/runner/load_runner.rs
@@ -1492,15 +1492,10 @@ impl LoadRunner {
             .start(),
         );
 
-        info!(url = %self.config.query_rpc, "starting block watcher");
-        let block_watcher_task = Some(
-            BlockWatcher::new(
-                RootProvider::<Base>::new_http(self.config.query_rpc.clone()),
-                results_tracker.clone(),
-                self.cancel_token.clone(),
-            )
-            .start(),
-        );
+        // Block watcher is deferred until after the submission phase so that heavy
+        // eth_getBlockReceipts calls don't compete with tx submission on the query RPC.
+        // Flashblock confirmations handle in-flight release during the test.
+        let block_watcher_query_rpc = self.config.query_rpc.clone();
 
         let max_in_flight_per_sender = self.config.max_in_flight_per_sender;
 
@@ -1827,6 +1822,16 @@ impl LoadRunner {
             elapsed_secs = elapsed.as_secs(),
             actual_tps = submitted as f64 / elapsed.as_secs_f64(),
             "load test complete, draining confirmations"
+        );
+
+        info!(url = %block_watcher_query_rpc, "starting block watcher for confirmation drain");
+        let block_watcher_task = Some(
+            BlockWatcher::new(
+                RootProvider::<Base>::new_http(block_watcher_query_rpc),
+                results_tracker.clone(),
+                self.cancel_token.clone(),
+            )
+            .start(),
         );
 
         let drain_start = Instant::now();

--- a/crates/infra/load-tests/src/runner/load_runner.rs
+++ b/crates/infra/load-tests/src/runner/load_runner.rs
@@ -1865,7 +1865,10 @@ impl LoadRunner {
                 }
             }
 
-            let expired = results_tracker.expire_pending(PENDING_CONFIRMATION_TIMEOUT);
+            // Use a shorter expiry during drain: the test is over, so any
+            // pending tx older than the drain window itself is stale.
+            let drain_expiry = PENDING_CONFIRMATION_TIMEOUT.saturating_sub(drain_start.elapsed());
+            let expired = results_tracker.expire_pending(drain_expiry);
             if expired > 0 {
                 self.collector.record_failures("expired without confirmation", expired);
             }

--- a/crates/infra/load-tests/src/runner/load_runner.rs
+++ b/crates/infra/load-tests/src/runner/load_runner.rs
@@ -1494,10 +1494,15 @@ impl LoadRunner {
             .start(),
         );
 
-        // Block watcher is deferred until after the submission phase so that heavy
-        // eth_getBlockReceipts calls don't compete with tx submission on the query RPC.
-        // Flashblock confirmations handle in-flight release during the test.
-        let block_watcher_query_rpc = self.config.query_rpc.clone();
+        info!(url = %self.config.query_rpc, "starting block watcher");
+        let block_watcher_task = Some(
+            BlockWatcher::new(
+                RootProvider::<Base>::new_http(self.config.query_rpc.clone()),
+                results_tracker.clone(),
+                self.cancel_token.clone(),
+            )
+            .start(),
+        );
 
         let max_in_flight_per_sender = self.config.max_in_flight_per_sender;
 
@@ -1540,10 +1545,8 @@ impl LoadRunner {
         let mut last_gas_price_refresh = Instant::now();
         let mut last_rate_limiter_update = Instant::now();
         let mut last_progress_report = Instant::now();
-        let mut last_expiry_check = Instant::now();
         const GAS_PRICE_REFRESH_INTERVAL: Duration = Duration::from_secs(30);
         const RATE_LIMITER_UPDATE_INTERVAL: Duration = Duration::from_secs(2);
-        const EXPIRY_CHECK_INTERVAL: Duration = Duration::from_secs(5);
         const PROGRESS_REPORT_INTERVAL: Duration = Duration::from_secs(5);
         const DISPLAY_RENDER_INTERVAL: Duration = Duration::from_millis(500);
 
@@ -1601,15 +1604,9 @@ impl LoadRunner {
             for metrics in results_tracker.drain_confirmed_metrics() {
                 self.collector.record_confirmed(metrics);
             }
-
-            results_tracker.release_stale_in_flight(Duration::from_secs(2));
-
-            if last_expiry_check.elapsed() >= EXPIRY_CHECK_INTERVAL {
-                let expired = results_tracker.expire_pending(PENDING_CONFIRMATION_TIMEOUT);
-                if expired > 0 {
-                    self.collector.record_failures("expired without confirmation", expired);
-                }
-                last_expiry_check = Instant::now();
+            let expired = results_tracker.expire_pending(PENDING_CONFIRMATION_TIMEOUT);
+            if expired > 0 {
+                self.collector.record_failures("expired without confirmation", expired);
             }
 
             if use_live_display || use_snapshot_tx {
@@ -1671,16 +1668,12 @@ impl LoadRunner {
 
             let batch_start = Instant::now();
             let mut consecutive_at_limit = 0usize;
-            let in_flight_snapshot = results_tracker.snapshot_in_flight();
 
             while pending_batch.len() < batch_size && batch_start.elapsed() < batch_timeout {
                 let account = &self.accounts.accounts()[current_account_idx];
                 let queued = queued_per_sender.get(&account.address).copied().unwrap_or(0);
-                let sender_in_flight = in_flight_snapshot
-                    .get(&account.address)
-                    .copied()
-                    .unwrap_or(0)
-                    .saturating_add(queued);
+                let sender_in_flight =
+                    results_tracker.in_flight_for(&account.address).saturating_add(queued);
 
                 if sender_in_flight >= max_in_flight_per_sender {
                     debug!(
@@ -1840,16 +1833,6 @@ impl LoadRunner {
             elapsed_secs = elapsed.as_secs(),
             actual_tps = submitted as f64 / elapsed.as_secs_f64(),
             "load test complete, draining confirmations"
-        );
-
-        info!(url = %block_watcher_query_rpc, "starting block watcher for confirmation drain");
-        let block_watcher_task = Some(
-            BlockWatcher::new(
-                RootProvider::<Base>::new_http(block_watcher_query_rpc),
-                results_tracker.clone(),
-                self.cancel_token.clone(),
-            )
-            .start(),
         );
 
         let drain_start = Instant::now();

--- a/crates/infra/load-tests/src/runner/load_runner.rs
+++ b/crates/infra/load-tests/src/runner/load_runner.rs
@@ -320,7 +320,7 @@ impl LoadRunner {
                     OsakaTarget::Clz => 80_000,
                     OsakaTarget::P256verifyOsaka | OsakaTarget::ModexpOsaka => 30_000,
                 },
-                TxType::UniswapV3 { .. } | TxType::AerodromeCl { .. } => 250_000,
+                TxType::UniswapV3 { .. } | TxType::AerodromeCl { .. } => 115_000,
             };
             weighted_gas += gas_estimate * tx_config.weight as u64;
         }
@@ -493,7 +493,9 @@ impl LoadRunner {
                     }
                     Err(e) => {
                         let error_str = e.to_string();
-                        if error_str.contains("already known") {
+                        if error_str.contains("already known")
+                            || error_str.contains("replacement transaction underpriced")
+                        {
                             retries.push((address, deficit, nonce));
                         } else if error_str.contains("nonce too low") {
                             info!(to = %address, nonce, "nonce too low, will refresh and retry");
@@ -1538,8 +1540,10 @@ impl LoadRunner {
         let mut last_gas_price_refresh = Instant::now();
         let mut last_rate_limiter_update = Instant::now();
         let mut last_progress_report = Instant::now();
+        let mut last_expiry_check = Instant::now();
         const GAS_PRICE_REFRESH_INTERVAL: Duration = Duration::from_secs(30);
         const RATE_LIMITER_UPDATE_INTERVAL: Duration = Duration::from_secs(2);
+        const EXPIRY_CHECK_INTERVAL: Duration = Duration::from_secs(5);
         const PROGRESS_REPORT_INTERVAL: Duration = Duration::from_secs(5);
         const DISPLAY_RENDER_INTERVAL: Duration = Duration::from_millis(500);
 
@@ -1597,9 +1601,15 @@ impl LoadRunner {
             for metrics in results_tracker.drain_confirmed_metrics() {
                 self.collector.record_confirmed(metrics);
             }
-            let expired = results_tracker.expire_pending(PENDING_CONFIRMATION_TIMEOUT);
-            if expired > 0 {
-                self.collector.record_failures("expired without confirmation", expired);
+
+            results_tracker.release_stale_in_flight(Duration::from_secs(2));
+
+            if last_expiry_check.elapsed() >= EXPIRY_CHECK_INTERVAL {
+                let expired = results_tracker.expire_pending(PENDING_CONFIRMATION_TIMEOUT);
+                if expired > 0 {
+                    self.collector.record_failures("expired without confirmation", expired);
+                }
+                last_expiry_check = Instant::now();
             }
 
             if use_live_display || use_snapshot_tx {
@@ -1627,7 +1637,9 @@ impl LoadRunner {
                 let failed = self.collector.failed_count();
                 let reverted = self.collector.reverted_count();
                 let in_flight = results_tracker.total_in_flight();
+                let pending = results_tracker.pending_count();
                 let senders_blocked = results_tracker.senders_at_limit(max_in_flight_per_sender);
+                let total_queued: u64 = queued_per_sender.values().sum();
                 let (p50, p99) = self.collector.rolling_p50_p99();
                 let (block_receipt_delay_p50, block_receipt_delay_p99) =
                     self.collector.rolling_block_receipt_delay_p50_p99();
@@ -1640,6 +1652,8 @@ impl LoadRunner {
                     failed,
                     reverted,
                     in_flight,
+                    pending,
+                    total_queued,
                     senders_blocked,
                     gas_price = self.gas_price,
                     p50_ms = p50.as_millis() as u64,
@@ -1657,12 +1671,16 @@ impl LoadRunner {
 
             let batch_start = Instant::now();
             let mut consecutive_at_limit = 0usize;
+            let in_flight_snapshot = results_tracker.snapshot_in_flight();
 
             while pending_batch.len() < batch_size && batch_start.elapsed() < batch_timeout {
                 let account = &self.accounts.accounts()[current_account_idx];
                 let queued = queued_per_sender.get(&account.address).copied().unwrap_or(0);
-                let sender_in_flight =
-                    results_tracker.in_flight_for(&account.address).saturating_add(queued);
+                let sender_in_flight = in_flight_snapshot
+                    .get(&account.address)
+                    .copied()
+                    .unwrap_or(0)
+                    .saturating_add(queued);
 
                 if sender_in_flight >= max_in_flight_per_sender {
                     debug!(

--- a/crates/infra/load-tests/src/runner/results_tracker.rs
+++ b/crates/infra/load-tests/src/runner/results_tracker.rs
@@ -82,6 +82,8 @@ struct ResultsTrackerInner {
 struct PendingTransaction {
     from: Address,
     submit_time: Instant,
+    /// Whether in-flight accounting was already released (e.g. by flashblock confirmation).
+    in_flight_released: bool,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -125,7 +127,7 @@ impl ResultsTracker {
 
             inner.pending.insert(
                 transaction.tx_hash,
-                PendingTransaction { from: transaction.from, submit_time },
+                PendingTransaction { from: transaction.from, submit_time, in_flight_released: false },
             );
             inner
                 .in_flight_per_sender
@@ -138,6 +140,10 @@ impl ResultsTracker {
     }
 
     /// Records transaction inclusions observed from the flashblock stream.
+    ///
+    /// When a pending transaction is seen in a flashblock, its in-flight slot is released
+    /// immediately so the sender can submit new transactions without waiting for the slower
+    /// canonical block receipt.
     pub fn on_new_flashblock(&self, inclusions: Vec<FlashblockInclusion>) {
         let mut inner = self.inner.write();
 
@@ -145,6 +151,14 @@ impl ResultsTracker {
             if let Entry::Vacant(e) = inner.flashblocks.entry(inclusion.tx_hash) {
                 e.insert(inclusion.included_at);
                 inner.flashblock_eviction_queue.push_back(inclusion.tx_hash);
+            }
+
+            if let Some(pending) = inner.pending.get_mut(&inclusion.tx_hash) {
+                if !pending.in_flight_released {
+                    pending.in_flight_released = true;
+                    let from = pending.from;
+                    inner.decrement_in_flight(&from);
+                }
             }
         }
 
@@ -190,7 +204,9 @@ impl ResultsTracker {
         let expired_count = expired.len() as u64;
         for tx_hash in expired {
             if let Some(pending) = inner.pending.remove(&tx_hash) {
-                inner.decrement_in_flight(&pending.from);
+                if !pending.in_flight_released {
+                    inner.decrement_in_flight(&pending.from);
+                }
             }
         }
 
@@ -257,7 +273,9 @@ impl ResultsTrackerInner {
         metrics.reverted = !receipt.success;
 
         self.block_receipts.remove(&tx_hash);
-        self.decrement_in_flight(&pending.from);
+        if !pending.in_flight_released {
+            self.decrement_in_flight(&pending.from);
+        }
         self.unreported_confirmations.push_back(metrics);
     }
 
@@ -388,5 +406,62 @@ mod tests {
         let metrics = tracker.drain_confirmed_metrics();
         assert_eq!(metrics.len(), 1);
         assert!(metrics[0].flashblocks_latency.is_some());
+    }
+
+    #[test]
+    fn flashblock_releases_in_flight_before_block_receipt() {
+        let from = address!("0000000000000000000000000000000000000001");
+        let tx_hash = TxHash::repeat_byte(4);
+        let tracker = ResultsTracker::new(&[from]);
+
+        tracker.sent_transactions(vec![SentTransaction { tx_hash, from }]);
+        assert_eq!(tracker.total_in_flight(), 1);
+        assert_eq!(tracker.in_flight_for(&from), 1);
+
+        tracker
+            .on_new_flashblock(vec![FlashblockInclusion { tx_hash, included_at: Instant::now() }]);
+        assert_eq!(tracker.total_in_flight(), 0, "flashblock should release in-flight slot");
+        assert_eq!(tracker.in_flight_for(&from), 0);
+
+        // Block receipt arrives later — should not double-decrement.
+        let block_time = Instant::now() + Duration::from_millis(500);
+        tracker.on_new_block(
+            BlockObservation {
+                number: 10,
+                block_time: Some(block_time),
+                observed_at: block_time + Duration::from_millis(100),
+            },
+            vec![BlockReceipt {
+                tx_hash,
+                block_number: 10,
+                gas_used: 112_000,
+                effective_gas_price: 1_000_000_000,
+                success: true,
+            }],
+        );
+
+        assert_eq!(tracker.total_in_flight(), 0, "block receipt should not double-decrement");
+        let metrics = tracker.drain_confirmed_metrics();
+        assert_eq!(metrics.len(), 1, "metrics should still be produced from block receipt");
+        assert!(metrics[0].flashblocks_latency.is_some());
+    }
+
+    #[test]
+    fn duplicate_flashblock_does_not_double_release() {
+        let from = address!("0000000000000000000000000000000000000001");
+        let tx_hash = TxHash::repeat_byte(5);
+        let tracker = ResultsTracker::new(&[from]);
+
+        tracker.sent_transactions(vec![SentTransaction { tx_hash, from }]);
+        assert_eq!(tracker.total_in_flight(), 1);
+
+        tracker
+            .on_new_flashblock(vec![FlashblockInclusion { tx_hash, included_at: Instant::now() }]);
+        assert_eq!(tracker.total_in_flight(), 0);
+
+        // Duplicate flashblock event for same tx.
+        tracker
+            .on_new_flashblock(vec![FlashblockInclusion { tx_hash, included_at: Instant::now() }]);
+        assert_eq!(tracker.total_in_flight(), 0, "duplicate flashblock should not underflow");
     }
 }

--- a/crates/infra/load-tests/src/runner/results_tracker.rs
+++ b/crates/infra/load-tests/src/runner/results_tracker.rs
@@ -73,7 +73,6 @@ struct ResultsTrackerInner {
     flashblocks: HashMap<TxHash, Instant>,
     receipt_eviction_queue: VecDeque<TxHash>,
     flashblock_eviction_queue: VecDeque<TxHash>,
-    pending_age_queue: VecDeque<TxHash>,
     unreported_confirmations: VecDeque<TransactionMetrics>,
     in_flight_per_sender: HashMap<Address, u64>,
     total_in_flight: u64,
@@ -109,7 +108,6 @@ impl ResultsTracker {
                 flashblocks: HashMap::new(),
                 receipt_eviction_queue: VecDeque::new(),
                 flashblock_eviction_queue: VecDeque::new(),
-                pending_age_queue: VecDeque::new(),
                 unreported_confirmations: VecDeque::new(),
                 in_flight_per_sender,
                 total_in_flight: 0,
@@ -135,7 +133,6 @@ impl ResultsTracker {
                     in_flight_released: false,
                 },
             );
-            inner.pending_age_queue.push_back(transaction.tx_hash);
             inner
                 .in_flight_per_sender
                 .entry(transaction.from)
@@ -241,11 +238,6 @@ impl ResultsTracker {
         self.inner.read().in_flight_per_sender.get(address).copied().unwrap_or(0)
     }
 
-    /// Snapshots the in-flight counts for all senders in a single lock acquisition.
-    pub fn snapshot_in_flight(&self) -> HashMap<Address, u64> {
-        self.inner.read().in_flight_per_sender.clone()
-    }
-
     /// Returns the total in-flight count.
     pub fn total_in_flight(&self) -> u64 {
         self.inner.read().total_in_flight
@@ -254,37 +246,6 @@ impl ResultsTracker {
     /// Returns the number of senders at or above the given in-flight limit.
     pub fn senders_at_limit(&self, limit: u64) -> usize {
         self.inner.read().in_flight_per_sender.values().filter(|&&count| count >= limit).count()
-    }
-
-    /// Releases in-flight slots for pending transactions older than `max_age`.
-    ///
-    /// Uses a time-ordered queue for O(released) work instead of scanning all pending.
-    pub fn release_stale_in_flight(&self, max_age: Duration) -> u64 {
-        let now = Instant::now();
-        let mut inner = self.inner.write();
-        let mut released = 0u64;
-
-        while let Some(&tx_hash) = inner.pending_age_queue.front() {
-            let Some(pending) = inner.pending.get_mut(&tx_hash) else {
-                inner.pending_age_queue.pop_front();
-                continue;
-            };
-
-            if now.duration_since(pending.submit_time) <= max_age {
-                break;
-            }
-
-            if !pending.in_flight_released {
-                pending.in_flight_released = true;
-                let from = pending.from;
-                inner.decrement_in_flight(&from);
-                released += 1;
-            }
-
-            inner.pending_age_queue.pop_front();
-        }
-
-        released
     }
 }
 
@@ -514,61 +475,7 @@ mod tests {
     }
 
     #[test]
-    fn release_stale_in_flight_releases_old_txs() {
-        let sender_a = address!("0000000000000000000000000000000000000001");
-        let sender_b = address!("0000000000000000000000000000000000000002");
-        let tx_a = TxHash::repeat_byte(0xa0);
-        let tx_b = TxHash::repeat_byte(0xb0);
-        let tx_c = TxHash::repeat_byte(0xc0);
-        let tracker = ResultsTracker::new(&[sender_a, sender_b]);
-
-        tracker.sent_transactions(vec![
-            SentTransaction { tx_hash: tx_a, from: sender_a },
-            SentTransaction { tx_hash: tx_b, from: sender_b },
-        ]);
-        assert_eq!(tracker.total_in_flight(), 2);
-
-        // Nothing older than 100s yet.
-        assert_eq!(tracker.release_stale_in_flight(Duration::from_secs(100)), 0);
-        assert_eq!(tracker.total_in_flight(), 2);
-
-        // Release everything older than 0s (all of them).
-        let released = tracker.release_stale_in_flight(Duration::ZERO);
-        assert_eq!(released, 2, "both txs should be released");
-        assert_eq!(tracker.total_in_flight(), 0);
-        assert_eq!(tracker.in_flight_for(&sender_a), 0);
-        assert_eq!(tracker.in_flight_for(&sender_b), 0);
-
-        // Calling again should release nothing (already released).
-        assert_eq!(tracker.release_stale_in_flight(Duration::ZERO), 0);
-
-        // New tx after release — should track normally.
-        tracker.sent_transactions(vec![SentTransaction { tx_hash: tx_c, from: sender_a }]);
-        assert_eq!(tracker.total_in_flight(), 1);
-        assert_eq!(tracker.in_flight_for(&sender_a), 1);
-    }
-
-    #[test]
-    fn release_stale_does_not_double_decrement_with_flashblock() {
-        let from = address!("0000000000000000000000000000000000000001");
-        let tx_hash = TxHash::repeat_byte(0xd0);
-        let tracker = ResultsTracker::new(&[from]);
-
-        tracker.sent_transactions(vec![SentTransaction { tx_hash, from }]);
-        assert_eq!(tracker.total_in_flight(), 1);
-
-        // Flashblock confirms it first.
-        tracker
-            .on_new_flashblock(vec![FlashblockInclusion { tx_hash, included_at: Instant::now() }]);
-        assert_eq!(tracker.total_in_flight(), 0);
-
-        // Time-based release fires later — should not underflow.
-        assert_eq!(tracker.release_stale_in_flight(Duration::ZERO), 0);
-        assert_eq!(tracker.total_in_flight(), 0);
-    }
-
-    #[test]
-    fn expire_pending_cleans_up_released_entries() {
+    fn expire_pending_cleans_up_flashblock_released_entries() {
         let from = address!("0000000000000000000000000000000000000001");
         let tx_hash = TxHash::repeat_byte(0xe0);
         let tracker = ResultsTracker::new(&[from]);
@@ -576,14 +483,15 @@ mod tests {
         tracker.sent_transactions(vec![SentTransaction { tx_hash, from }]);
         assert_eq!(tracker.pending_count(), 1);
 
-        // Time-based release marks in_flight_released but keeps the pending entry.
-        tracker.release_stale_in_flight(Duration::ZERO);
+        // Flashblock confirms it — releases in-flight but keeps the pending entry.
+        tracker
+            .on_new_flashblock(vec![FlashblockInclusion { tx_hash, included_at: Instant::now() }]);
         assert_eq!(tracker.pending_count(), 1, "pending entry should still exist");
         assert_eq!(tracker.total_in_flight(), 0);
 
-        // expire_pending should now remove released entries too.
+        // expire_pending should remove flashblock-released entries too.
         let expired = tracker.expire_pending(Duration::ZERO);
-        assert_eq!(expired, 0, "released tx is not a true failure");
+        assert_eq!(expired, 0, "flashblock-released tx is not a true failure");
         assert_eq!(tracker.pending_count(), 0, "pending entry should be cleaned up");
     }
 }

--- a/crates/infra/load-tests/src/runner/results_tracker.rs
+++ b/crates/infra/load-tests/src/runner/results_tracker.rs
@@ -129,7 +129,11 @@ impl ResultsTracker {
 
             inner.pending.insert(
                 transaction.tx_hash,
-                PendingTransaction { from: transaction.from, submit_time, in_flight_released: false },
+                PendingTransaction {
+                    from: transaction.from,
+                    submit_time,
+                    in_flight_released: false,
+                },
             );
             inner.pending_age_queue.push_back(transaction.tx_hash);
             inner
@@ -156,12 +160,12 @@ impl ResultsTracker {
                 inner.flashblock_eviction_queue.push_back(inclusion.tx_hash);
             }
 
-            if let Some(pending) = inner.pending.get_mut(&inclusion.tx_hash) {
-                if !pending.in_flight_released {
-                    pending.in_flight_released = true;
-                    let from = pending.from;
-                    inner.decrement_in_flight(&from);
-                }
+            if let Some(pending) = inner.pending.get_mut(&inclusion.tx_hash)
+                && !pending.in_flight_released
+            {
+                pending.in_flight_released = true;
+                let from = pending.from;
+                inner.decrement_in_flight(&from);
             }
         }
 
@@ -194,8 +198,9 @@ impl ResultsTracker {
 
     /// Expires submitted transactions that were not observed in a canonical block.
     ///
-    /// Transactions already confirmed by a flashblock are not expired — they are
-    /// assumed to be included on-chain even if the block receipt has not arrived yet.
+    /// Removes all pending entries older than `max_age`, regardless of whether their
+    /// in-flight slot was already released. Returns the number of entries that were
+    /// NOT previously confirmed by a flashblock (true failures).
     pub fn expire_pending(&self, max_age: Duration) -> u64 {
         let now = Instant::now();
         let mut inner = self.inner.write();
@@ -203,23 +208,21 @@ impl ResultsTracker {
             .pending
             .iter()
             .filter_map(|(tx_hash, pending)| {
-                if pending.in_flight_released {
-                    return None;
-                }
                 (now.duration_since(pending.submit_time) > max_age).then_some(*tx_hash)
             })
             .collect();
 
-        let expired_count = expired.len() as u64;
+        let mut unconfirmed_count = 0u64;
         for tx_hash in expired {
-            if let Some(pending) = inner.pending.remove(&tx_hash) {
-                if !pending.in_flight_released {
-                    inner.decrement_in_flight(&pending.from);
-                }
+            if let Some(pending) = inner.pending.remove(&tx_hash)
+                && !pending.in_flight_released
+            {
+                inner.decrement_in_flight(&pending.from);
+                unconfirmed_count += 1;
             }
         }
 
-        expired_count
+        unconfirmed_count
     }
 
     /// Drains confirmed metrics that have not yet been consumed by the runner.
@@ -262,7 +265,7 @@ impl ResultsTracker {
         let mut released = 0u64;
 
         while let Some(&tx_hash) = inner.pending_age_queue.front() {
-            let Some(pending) = inner.pending.get(&tx_hash) else {
+            let Some(pending) = inner.pending.get_mut(&tx_hash) else {
                 inner.pending_age_queue.pop_front();
                 continue;
             };
@@ -272,8 +275,8 @@ impl ResultsTracker {
             }
 
             if !pending.in_flight_released {
+                pending.in_flight_released = true;
                 let from = pending.from;
-                inner.pending.get_mut(&tx_hash).unwrap().in_flight_released = true;
                 inner.decrement_in_flight(&from);
                 released += 1;
             }
@@ -508,5 +511,79 @@ mod tests {
         tracker
             .on_new_flashblock(vec![FlashblockInclusion { tx_hash, included_at: Instant::now() }]);
         assert_eq!(tracker.total_in_flight(), 0, "duplicate flashblock should not underflow");
+    }
+
+    #[test]
+    fn release_stale_in_flight_releases_old_txs() {
+        let sender_a = address!("0000000000000000000000000000000000000001");
+        let sender_b = address!("0000000000000000000000000000000000000002");
+        let tx_a = TxHash::repeat_byte(0xa0);
+        let tx_b = TxHash::repeat_byte(0xb0);
+        let tx_c = TxHash::repeat_byte(0xc0);
+        let tracker = ResultsTracker::new(&[sender_a, sender_b]);
+
+        tracker.sent_transactions(vec![
+            SentTransaction { tx_hash: tx_a, from: sender_a },
+            SentTransaction { tx_hash: tx_b, from: sender_b },
+        ]);
+        assert_eq!(tracker.total_in_flight(), 2);
+
+        // Nothing older than 100s yet.
+        assert_eq!(tracker.release_stale_in_flight(Duration::from_secs(100)), 0);
+        assert_eq!(tracker.total_in_flight(), 2);
+
+        // Release everything older than 0s (all of them).
+        let released = tracker.release_stale_in_flight(Duration::ZERO);
+        assert_eq!(released, 2, "both txs should be released");
+        assert_eq!(tracker.total_in_flight(), 0);
+        assert_eq!(tracker.in_flight_for(&sender_a), 0);
+        assert_eq!(tracker.in_flight_for(&sender_b), 0);
+
+        // Calling again should release nothing (already released).
+        assert_eq!(tracker.release_stale_in_flight(Duration::ZERO), 0);
+
+        // New tx after release — should track normally.
+        tracker.sent_transactions(vec![SentTransaction { tx_hash: tx_c, from: sender_a }]);
+        assert_eq!(tracker.total_in_flight(), 1);
+        assert_eq!(tracker.in_flight_for(&sender_a), 1);
+    }
+
+    #[test]
+    fn release_stale_does_not_double_decrement_with_flashblock() {
+        let from = address!("0000000000000000000000000000000000000001");
+        let tx_hash = TxHash::repeat_byte(0xd0);
+        let tracker = ResultsTracker::new(&[from]);
+
+        tracker.sent_transactions(vec![SentTransaction { tx_hash, from }]);
+        assert_eq!(tracker.total_in_flight(), 1);
+
+        // Flashblock confirms it first.
+        tracker
+            .on_new_flashblock(vec![FlashblockInclusion { tx_hash, included_at: Instant::now() }]);
+        assert_eq!(tracker.total_in_flight(), 0);
+
+        // Time-based release fires later — should not underflow.
+        assert_eq!(tracker.release_stale_in_flight(Duration::ZERO), 0);
+        assert_eq!(tracker.total_in_flight(), 0);
+    }
+
+    #[test]
+    fn expire_pending_cleans_up_released_entries() {
+        let from = address!("0000000000000000000000000000000000000001");
+        let tx_hash = TxHash::repeat_byte(0xe0);
+        let tracker = ResultsTracker::new(&[from]);
+
+        tracker.sent_transactions(vec![SentTransaction { tx_hash, from }]);
+        assert_eq!(tracker.pending_count(), 1);
+
+        // Time-based release marks in_flight_released but keeps the pending entry.
+        tracker.release_stale_in_flight(Duration::ZERO);
+        assert_eq!(tracker.pending_count(), 1, "pending entry should still exist");
+        assert_eq!(tracker.total_in_flight(), 0);
+
+        // expire_pending should now remove released entries too.
+        let expired = tracker.expire_pending(Duration::ZERO);
+        assert_eq!(expired, 0, "released tx is not a true failure");
+        assert_eq!(tracker.pending_count(), 0, "pending entry should be cleaned up");
     }
 }

--- a/crates/infra/load-tests/src/runner/results_tracker.rs
+++ b/crates/infra/load-tests/src/runner/results_tracker.rs
@@ -73,6 +73,7 @@ struct ResultsTrackerInner {
     flashblocks: HashMap<TxHash, Instant>,
     receipt_eviction_queue: VecDeque<TxHash>,
     flashblock_eviction_queue: VecDeque<TxHash>,
+    pending_age_queue: VecDeque<TxHash>,
     unreported_confirmations: VecDeque<TransactionMetrics>,
     in_flight_per_sender: HashMap<Address, u64>,
     total_in_flight: u64,
@@ -108,6 +109,7 @@ impl ResultsTracker {
                 flashblocks: HashMap::new(),
                 receipt_eviction_queue: VecDeque::new(),
                 flashblock_eviction_queue: VecDeque::new(),
+                pending_age_queue: VecDeque::new(),
                 unreported_confirmations: VecDeque::new(),
                 in_flight_per_sender,
                 total_in_flight: 0,
@@ -129,6 +131,7 @@ impl ResultsTracker {
                 transaction.tx_hash,
                 PendingTransaction { from: transaction.from, submit_time, in_flight_released: false },
             );
+            inner.pending_age_queue.push_back(transaction.tx_hash);
             inner
                 .in_flight_per_sender
                 .entry(transaction.from)
@@ -235,6 +238,11 @@ impl ResultsTracker {
         self.inner.read().in_flight_per_sender.get(address).copied().unwrap_or(0)
     }
 
+    /// Snapshots the in-flight counts for all senders in a single lock acquisition.
+    pub fn snapshot_in_flight(&self) -> HashMap<Address, u64> {
+        self.inner.read().in_flight_per_sender.clone()
+    }
+
     /// Returns the total in-flight count.
     pub fn total_in_flight(&self) -> u64 {
         self.inner.read().total_in_flight
@@ -243,6 +251,37 @@ impl ResultsTracker {
     /// Returns the number of senders at or above the given in-flight limit.
     pub fn senders_at_limit(&self, limit: u64) -> usize {
         self.inner.read().in_flight_per_sender.values().filter(|&&count| count >= limit).count()
+    }
+
+    /// Releases in-flight slots for pending transactions older than `max_age`.
+    ///
+    /// Uses a time-ordered queue for O(released) work instead of scanning all pending.
+    pub fn release_stale_in_flight(&self, max_age: Duration) -> u64 {
+        let now = Instant::now();
+        let mut inner = self.inner.write();
+        let mut released = 0u64;
+
+        while let Some(&tx_hash) = inner.pending_age_queue.front() {
+            let Some(pending) = inner.pending.get(&tx_hash) else {
+                inner.pending_age_queue.pop_front();
+                continue;
+            };
+
+            if now.duration_since(pending.submit_time) <= max_age {
+                break;
+            }
+
+            if !pending.in_flight_released {
+                let from = pending.from;
+                inner.pending.get_mut(&tx_hash).unwrap().in_flight_released = true;
+                inner.decrement_in_flight(&from);
+                released += 1;
+            }
+
+            inner.pending_age_queue.pop_front();
+        }
+
+        released
     }
 }
 

--- a/crates/infra/load-tests/src/runner/results_tracker.rs
+++ b/crates/infra/load-tests/src/runner/results_tracker.rs
@@ -190,6 +190,9 @@ impl ResultsTracker {
     }
 
     /// Expires submitted transactions that were not observed in a canonical block.
+    ///
+    /// Transactions already confirmed by a flashblock are not expired — they are
+    /// assumed to be included on-chain even if the block receipt has not arrived yet.
     pub fn expire_pending(&self, max_age: Duration) -> u64 {
         let now = Instant::now();
         let mut inner = self.inner.write();
@@ -197,6 +200,9 @@ impl ResultsTracker {
             .pending
             .iter()
             .filter_map(|(tx_hash, pending)| {
+                if pending.in_flight_released {
+                    return None;
+                }
                 (now.duration_since(pending.submit_time) > max_age).then_some(*tx_hash)
             })
             .collect();

--- a/crates/infra/load-tests/src/runner/submission.rs
+++ b/crates/infra/load-tests/src/runner/submission.rs
@@ -30,9 +30,9 @@ use super::{ResultsTracker, SentTransaction};
 use crate::rpc::{BatchRpcClient, BatchSendResult};
 
 /// Number of signer tasks per submission RPC.
-pub const SIGNER_WORKERS_PER_RPC: usize = 2;
+pub const SIGNER_WORKERS_PER_RPC: usize = 10;
 /// Number of sender tasks per submission RPC.
-pub const SENDER_WORKERS_PER_RPC: usize = 4;
+pub const SENDER_WORKERS_PER_RPC: usize = 10;
 /// Maximum signer task count.
 pub const MAX_SIGNER_WORKER_COUNT: usize = 32;
 /// Maximum sender task count.

--- a/crates/infra/load-tests/src/runner/submission.rs
+++ b/crates/infra/load-tests/src/runner/submission.rs
@@ -454,6 +454,8 @@ impl SubmissionPipeline {
             BatchTxError::NonceTooLow
         } else if lower.contains("missing response") || lower.contains("invalid tx hash") {
             BatchTxError::RetryableUnknown(msg)
+        } else if lower.contains("replacement transaction underpriced") {
+            BatchTxError::AlreadyKnown
         } else if lower.contains("txpool is full")
             || lower.contains("transaction pool is full")
             || lower.contains("pool is full")
@@ -658,27 +660,18 @@ impl SubmissionPipeline {
                                 attempt,
                                 "nonce too low during batch submission"
                             );
-                            // On retry, a nonce-too-low response usually means a prior attempt
-                            // was accepted but its response was lost. Treat it as submitted so we
-                            // do not return a consumed nonce; if another transaction consumed the
-                            // nonce, the optimistic pending entry expires through the normal
-                            // confirmation timeout.
-                            if attempt > 0 {
-                                let tx_hash = signed.tx_hash;
-                                submitted += Self::record_submitted(
-                                    &ctx,
-                                    signed,
-                                    tx_hash,
-                                    "tx nonce already used",
-                                )
-                                .await;
-                            } else {
-                                Self::release_signed(&ctx.submit_event_tx, &signed).await;
-                                let _ = ctx
-                                    .submit_event_tx
-                                    .send(SubmitEvent::Failed("nonce too low".into()))
-                                    .await;
-                            }
+                            // Nonce-too-low means the nonce was already consumed on-chain,
+                            // either by a prior attempt or by the same tx landing before
+                            // the response arrived. Treat as submitted to avoid returning
+                            // the nonce (which would cause replacement-tx-underpriced cycles).
+                            let tx_hash = signed.tx_hash;
+                            submitted += Self::record_submitted(
+                                &ctx,
+                                signed,
+                                tx_hash,
+                                "tx nonce already used",
+                            )
+                            .await;
                         }
                         BatchTxError::Rejected(msg) => {
                             debug!(

--- a/crates/infra/load-tests/src/runner/submission.rs
+++ b/crates/infra/load-tests/src/runner/submission.rs
@@ -455,7 +455,7 @@ impl SubmissionPipeline {
         } else if lower.contains("missing response") || lower.contains("invalid tx hash") {
             BatchTxError::RetryableUnknown(msg)
         } else if lower.contains("replacement transaction underpriced") {
-            BatchTxError::AlreadyKnown
+            BatchTxError::NonceTooLow
         } else if lower.contains("txpool is full")
             || lower.contains("transaction pool is full")
             || lower.contains("pool is full")


### PR DESCRIPTION
Various perf improvements to the load testing tool to reach 3k+ swaps/s on Base Sepolia:
- Swap gas estimate fix (actual usage was ~113k gas/tx)
- Run `expired_pending` scan every 5s instead of every batch (~20ms)
- Drain-phase progressive expiry: uses min(60s, drain_elapsed) so entries clean up as drain progresses instead of waiting full timeout

<img width="1060" height="679" alt="image" src="https://github.com/user-attachments/assets/1a5ad94e-a1e5-4887-b7f3-c3fdcfa120a1" />
