### PR TITLE
fix(zk): requeue failed proof requests on deterministic session_id retry

### DIFF
--- a/bin/prover/zk/src/cli.rs
+++ b/bin/prover/zk/src/cli.rs
@@ -94,8 +94,13 @@ struct ZkArgs {
     #[arg(long, env = "STUCK_REQUEST_TIMEOUT_MINS", default_value_t = 10)]
     stuck_request_timeout_mins: i32,
 
-    #[arg(long, env = "MAX_PROOF_RETRIES", default_value_t = 3)]
-    max_proof_retries: u32,
+    #[arg(
+        long,
+        env = "MAX_PROOF_RETRIES",
+        default_value_t = 3,
+        value_parser = clap::value_parser!(i32).range(0..)
+    )]
+    max_proof_retries: i32,
 
     #[arg(long, env = "SP1_PROVER", default_value = "cluster")]
     prover_mode: String,
@@ -344,14 +349,14 @@ impl ZkArgs {
             manager.clone(),
             self.status_poller_interval_secs,
             self.stuck_request_timeout_mins,
-            self.max_proof_retries as i32,
+            self.max_proof_retries,
         );
         let status_handle = tokio::spawn(async move {
             status_poller.run().await;
         });
 
         let prover_server =
-            ProverServiceServer::new(repo.clone(), manager.clone(), self.max_proof_retries as i32);
+            ProverServiceServer::new(repo.clone(), manager.clone(), self.max_proof_retries);
 
         let addr = self.grpc_listen_addr.parse()?;
 

--- a/bin/prover/zk/src/cli.rs
+++ b/bin/prover/zk/src/cli.rs
@@ -350,7 +350,8 @@ impl ZkArgs {
             status_poller.run().await;
         });
 
-        let prover_server = ProverServiceServer::new(repo.clone(), manager.clone());
+        let prover_server =
+            ProverServiceServer::new(repo.clone(), manager.clone(), self.max_proof_retries as i32);
 
         let addr = self.grpc_listen_addr.parse()?;
 

--- a/crates/proof/challenge/src/test_utils.rs
+++ b/crates/proof/challenge/src/test_utils.rs
@@ -570,6 +570,8 @@ pub struct MockZkProofState {
     pub receipt: Vec<u8>,
     /// Error message returned when status is `Failed`.
     pub error_message: Option<String>,
+    /// Every [`ProveBlockRequest`] received by `prove_block`, in call order.
+    pub prove_block_log: Vec<ProveBlockRequest>,
 }
 
 impl Default for MockZkProofProvider {
@@ -582,8 +584,9 @@ impl Default for MockZkProofProvider {
 impl ZkProofProvider for MockZkProofProvider {
     async fn prove_block(
         &self,
-        _request: ProveBlockRequest,
+        request: ProveBlockRequest,
     ) -> Result<ProveBlockResponse, ZkProofError> {
+        self.state.lock().unwrap().prove_block_log.push(request);
         Ok(ProveBlockResponse { session_id: self.session_id.clone() })
     }
 

--- a/crates/proof/challenge/tests/driver.rs
+++ b/crates/proof/challenge/tests/driver.rs
@@ -591,6 +591,86 @@ async fn test_step_proof_retry_succeeds() {
     );
 }
 
+// Regression test for CHAIN-4297 / Immunefi #75829: after a FAILED proof, the
+// driver must re-invoke `prove_block` with the same deterministic
+// `session_id` so the service-side fix in `create_with_outbox` can requeue
+// the row. Independent of the DB layer; fails on a challenger-side regression
+// such as dropping the retry call or losing `derive_session_id` determinism.
+#[tokio::test]
+async fn test_step_proof_retry_reuses_deterministic_session_id() {
+    let (l2, factory, verifier) = invalid_game_mocks();
+
+    // Invalid index is 1 (see `invalid_game_mocks`: `vec![root_15, BOGUS_ROOT]`).
+    let expected_session_id = PendingProof::derive_session_id(addr(0), 1);
+
+    let zk = Arc::new(MockZkProofProvider {
+        session_id: expected_session_id.clone(),
+        state: Mutex::new(MockZkProofState {
+            proof_status: ProofJobStatus::Failed as i32,
+            error_message: Some("transient backend error".into()),
+            ..Default::default()
+        }),
+    });
+
+    let tx_manager = default_tx_manager();
+    let mut driver = test_driver(factory, Arc::clone(&verifier), l2, Arc::clone(&zk), tx_manager);
+
+    // Step 1: initial prove_block call from initiate_zk_proof.
+    driver.step().await.unwrap();
+    {
+        let log = &zk.state.lock().unwrap().prove_block_log;
+        assert_eq!(log.len(), 1, "exactly one prove_block call on initiation");
+        assert_eq!(
+            log[0].session_id.as_deref(),
+            Some(expected_session_id.as_str()),
+            "challenger must use the deterministic session_id on initiation",
+        );
+    }
+
+    // Step 2: poll observes Failed → NeedsRetry → handle_proof_retry must
+    // invoke prove_block again, reusing the same deterministic session_id.
+    driver.step().await.unwrap();
+    {
+        let log = &zk.state.lock().unwrap().prove_block_log;
+        assert_eq!(log.len(), 2, "retry must invoke prove_block a second time");
+        assert_eq!(
+            log[1].session_id.as_deref(),
+            Some(expected_session_id.as_str()),
+            "retry must reuse the deterministic session_id so the service can requeue",
+        );
+        assert_eq!(
+            log[0].session_id, log[1].session_id,
+            "the deterministic session_id must be stable across retries",
+        );
+    }
+
+    let entry = driver.pending_proofs.get(&addr(0)).expect("entry should be retained after retry");
+    assert!(
+        matches!(entry.phase, ProofPhase::AwaitingProof { ref session_id, .. } if session_id == &expected_session_id),
+        "post-retry phase must be AwaitingProof with the deterministic session_id",
+    );
+    assert_eq!(entry.retry_count, 1);
+
+    // Simulate the service requeuing on the second prove_block and the proof
+    // eventually succeeding on the retry session.
+    {
+        let mut state = zk.state.lock().unwrap();
+        state.proof_status = ProofJobStatus::Succeeded as i32;
+        state.receipt = vec![0xDE, 0xAD, 0xBE, 0xEF];
+        state.error_message = None;
+    }
+    verifier.update_game(
+        addr(0),
+        MockGameState { status: GameStatus::ChallengerWins, ..game_state(20) },
+    );
+
+    driver.step().await.unwrap();
+    assert!(
+        !driver.pending_proofs.contains_key(&addr(0)),
+        "entry should be removed after successful retry submission",
+    );
+}
+
 #[tokio::test]
 async fn test_step_proof_exceeds_max_retries() {
     let (l2, factory, verifier) = invalid_game_mocks();

--- a/crates/proof/zk/db/src/lib.rs
+++ b/crates/proof/zk/db/src/lib.rs
@@ -5,10 +5,10 @@ pub use config::DatabaseConfig;
 
 mod models;
 pub use models::{
-    CreateOutboxEntry, CreateProofRequest, CreateProofSession, MarkOutboxError,
-    MarkOutboxProcessed, OutboxEntry, ProofRequest, ProofRequestListItem, ProofRequestPage,
-    ProofSession, ProofStatus, ProofType, RetryOutcome, SessionStatus, SessionType,
-    UpdateProofSession, UpdateReceipt,
+    CreateOutboxEntry, CreateProofRequest, CreateProofRequestError, CreateProofRequestOutcome,
+    CreateProofSession, MarkOutboxError, MarkOutboxProcessed, OutboxEntry, ProofRequest,
+    ProofRequestListItem, ProofRequestPage, ProofSession, ProofStatus, ProofType, RetryOutcome,
+    SessionStatus, SessionType, UpdateProofSession, UpdateReceipt,
 };
 
 mod repo;

--- a/crates/proof/zk/db/src/models.rs
+++ b/crates/proof/zk/db/src/models.rs
@@ -146,6 +146,58 @@ pub enum RetryOutcome {
     Skipped,
 }
 
+/// Outcome of a `create_with_outbox` call.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CreateProofRequestOutcome {
+    /// A new proof request row and outbox entry were inserted.
+    Created(Uuid),
+    /// An existing terminal `FAILED` row was reset to `CREATED` and a fresh
+    /// outbox entry was inserted; the worker will pick it up again.
+    Requeued(Uuid),
+    /// An existing non-terminal or `SUCCEEDED` row was returned unchanged for
+    /// idempotent replay; no new outbox entry was inserted.
+    Replayed(Uuid),
+    /// An existing terminal `FAILED` row is at the retry cap; no requeue.
+    RetryExhausted(Uuid),
+}
+
+impl CreateProofRequestOutcome {
+    /// Returns the proof request UUID regardless of outcome variant.
+    pub const fn id(&self) -> Uuid {
+        match self {
+            Self::Created(id)
+            | Self::Requeued(id)
+            | Self::Replayed(id)
+            | Self::RetryExhausted(id) => *id,
+        }
+    }
+}
+
+/// Errors returned by `create_with_outbox`.
+#[derive(Debug, thiserror::Error)]
+pub enum CreateProofRequestError {
+    /// Persisted row disagrees with the new request for this `session_id`.
+    #[error(
+        "session_id {id} already exists with a different {field} \
+         (existing request parameters do not match the new request)"
+    )]
+    IdCollision {
+        /// Conflicting proof request UUID.
+        id: Uuid,
+        /// Name of the first mismatched field. Stable across runs.
+        field: &'static str,
+    },
+    /// Conflicting row disappeared after insert conflict; safe to retry.
+    #[error("session_id {id}: proof request row missing after insert conflict; retry prove_block")]
+    SessionRowMissingAfterConflict {
+        /// Proof request UUID that was expected to exist.
+        id: Uuid,
+    },
+    /// Underlying database error.
+    #[error(transparent)]
+    Sqlx(#[from] sqlx::Error),
+}
+
 /// Type of proof that determines success criteria
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, sqlx::Type)]
 #[sqlx(type_name = "VARCHAR")]

--- a/crates/proof/zk/db/src/repo.rs
+++ b/crates/proof/zk/db/src/repo.rs
@@ -2,10 +2,10 @@ use sqlx::{PgPool, Result, Row};
 use uuid::Uuid;
 
 use crate::{
-    CreateOutboxEntry, CreateProofRequest, CreateProofSession, MarkOutboxError,
-    MarkOutboxProcessed, OutboxEntry, ProofRequest, ProofRequestListItem, ProofRequestPage,
-    ProofSession, ProofStatus, ProofType, RetryOutcome, SessionStatus, SessionType,
-    UpdateProofSession, UpdateReceipt,
+    CreateOutboxEntry, CreateProofRequest, CreateProofRequestError, CreateProofRequestOutcome,
+    CreateProofSession, MarkOutboxError, MarkOutboxProcessed, OutboxEntry, ProofRequest,
+    ProofRequestListItem, ProofRequestPage, ProofSession, ProofStatus, ProofType, RetryOutcome,
+    SessionStatus, SessionType, UpdateProofSession, UpdateReceipt,
 };
 
 /// Repository for proof request database operations
@@ -73,10 +73,18 @@ impl ProofRequestRepo {
 
     /// Atomically create a proof request and outbox entry in a transaction.
     ///
-    /// When a `session_id` is provided in the request, it is used as the proof
-    /// request UUID and the insert uses `ON CONFLICT (id) DO NOTHING` so that
-    /// duplicate submissions return the existing request ID without error.
-    pub async fn create_with_outbox(&self, req: CreateProofRequest) -> Result<Uuid> {
+    /// On `session_id` conflict, lock the row `FOR UPDATE` and branch on state:
+    /// parameter mismatch → [`CreateProofRequestError::IdCollision`];
+    /// `CREATED` / `PENDING` / `RUNNING` / `SUCCEEDED` → [`CreateProofRequestOutcome::Replayed`];
+    /// `FAILED` with room under `max_retries` → reset, bump `retry_count`, new outbox row
+    /// ([`CreateProofRequestOutcome::Requeued`]); `FAILED` at cap → [`CreateProofRequestOutcome::RetryExhausted`].
+    ///
+    /// Use the same `max_retries` as [`Self::retry_or_fail_stuck_request`] (shared `retry_count` cap).
+    pub async fn create_with_outbox(
+        &self,
+        req: CreateProofRequest,
+        max_retries: i32,
+    ) -> std::result::Result<CreateProofRequestOutcome, CreateProofRequestError> {
         let id = req.session_id.unwrap_or_else(Uuid::new_v4);
 
         let start_block_number = i64::try_from(req.start_block_number)
@@ -111,7 +119,7 @@ impl ProofRequestRepo {
 
         let mut tx = self.pool.begin().await?;
 
-        let result = sqlx::query(
+        let insert_result = sqlx::query(
             r#"
             INSERT INTO proof_requests (
                 id, start_block_number, number_of_blocks_to_prove,
@@ -134,26 +142,108 @@ impl ProofRequestRepo {
         .execute(&mut *tx)
         .await?;
 
-        if result.rows_affected() == 0 {
-            tx.rollback().await?;
-            return Ok(id);
+        if insert_result.rows_affected() > 0 {
+            sqlx::query(
+                r#"
+                INSERT INTO proof_request_outbox (proof_request_id, request_params)
+                VALUES ($1, $2)
+                "#,
+            )
+            .bind(id)
+            .bind(&request_params)
+            .execute(&mut *tx)
+            .await?;
+
+            tx.commit().await?;
+            return Ok(CreateProofRequestOutcome::Created(id));
         }
 
-        sqlx::query(
+        // Conflict path: `FOR UPDATE` serializes with stuck recovery and workers.
+        let row = sqlx::query(
             r#"
-            INSERT INTO proof_request_outbox (proof_request_id, request_params)
-            VALUES ($1, $2)
+            SELECT start_block_number, number_of_blocks_to_prove, sequence_window,
+                   proof_type, status, prover_address, l1_head,
+                   intermediate_root_interval, retry_count
+            FROM proof_requests
+            WHERE id = $1
+            FOR UPDATE
             "#,
         )
         .bind(id)
-        .bind(&request_params)
-        .execute(&mut *tx)
+        .fetch_optional(&mut *tx)
         .await?;
 
-        // Commit transaction
-        tx.commit().await?;
+        let Some(row) = row else {
+            tx.rollback().await?;
+            return Err(CreateProofRequestError::SessionRowMissingAfterConflict { id });
+        };
 
-        Ok(id)
+        let params = CreateOutboxRequestParams {
+            start_block_number,
+            number_of_blocks_to_prove,
+            sequence_window,
+            proof_type: req.proof_type.as_str(),
+            prover_address: req.prover_address.as_deref(),
+            l1_head: req.l1_head.as_deref(),
+            intermediate_root_interval,
+        };
+        if let Some(field) = params.first_mismatch(&row) {
+            tx.rollback().await?;
+            return Err(CreateProofRequestError::IdCollision { id, field });
+        }
+
+        let status_str: &str = row.get("status");
+        let status = ProofStatus::try_from(status_str).map_err(|e| {
+            sqlx::Error::Protocol(format!("Unknown proof status '{status_str}': {e}"))
+        })?;
+
+        match status {
+            ProofStatus::Created
+            | ProofStatus::Pending
+            | ProofStatus::Running
+            | ProofStatus::Succeeded => {
+                tx.rollback().await?;
+                Ok(CreateProofRequestOutcome::Replayed(id))
+            }
+            ProofStatus::Failed => {
+                let retry_count: i32 = row.get("retry_count");
+                if retry_count >= max_retries {
+                    tx.rollback().await?;
+                    return Ok(CreateProofRequestOutcome::RetryExhausted(id));
+                }
+
+                sqlx::query(
+                    r#"
+                    UPDATE proof_requests
+                    SET status = $1,
+                        retry_count = retry_count + 1,
+                        error_message = NULL,
+                        stark_receipt = NULL,
+                        snark_receipt = NULL,
+                        completed_at = NULL
+                    WHERE id = $2
+                    "#,
+                )
+                .bind(ProofStatus::Created.as_str())
+                .bind(id)
+                .execute(&mut *tx)
+                .await?;
+
+                sqlx::query(
+                    r#"
+                    INSERT INTO proof_request_outbox (proof_request_id, request_params)
+                    VALUES ($1, $2)
+                    "#,
+                )
+                .bind(id)
+                .bind(&request_params)
+                .execute(&mut *tx)
+                .await?;
+
+                tx.commit().await?;
+                Ok(CreateProofRequestOutcome::Requeued(id))
+            }
+        }
     }
 
     /// Get a proof request by ID
@@ -1059,6 +1149,48 @@ fn row_to_proof_session(row: &sqlx::postgres::PgRow) -> Result<ProofSession> {
         created_at: row.get("created_at"),
         completed_at: row.get("completed_at"),
     })
+}
+
+/// Incoming fields compared to a locked `proof_requests` row for idempotency checks.
+#[derive(Debug, Clone)]
+struct CreateOutboxRequestParams<'a> {
+    start_block_number: i64,
+    number_of_blocks_to_prove: i64,
+    sequence_window: Option<i64>,
+    proof_type: &'a str,
+    prover_address: Option<&'a str>,
+    l1_head: Option<&'a str>,
+    intermediate_root_interval: Option<i64>,
+}
+
+impl CreateOutboxRequestParams<'_> {
+    /// First field name that disagrees with `row`, or `None`. Stable for [`CreateProofRequestError::IdCollision`].
+    fn first_mismatch(&self, row: &sqlx::postgres::PgRow) -> Option<&'static str> {
+        if row.get::<i64, _>("start_block_number") != self.start_block_number {
+            return Some("start_block_number");
+        }
+        if row.get::<i64, _>("number_of_blocks_to_prove") != self.number_of_blocks_to_prove {
+            return Some("number_of_blocks_to_prove");
+        }
+        if row.get::<Option<i64>, _>("sequence_window") != self.sequence_window {
+            return Some("sequence_window");
+        }
+        if row.get::<&str, _>("proof_type") != self.proof_type {
+            return Some("proof_type");
+        }
+        if row.get::<Option<&str>, _>("prover_address") != self.prover_address {
+            return Some("prover_address");
+        }
+        if row.get::<Option<&str>, _>("l1_head") != self.l1_head {
+            return Some("l1_head");
+        }
+        if row.get::<Option<i64>, _>("intermediate_root_interval")
+            != self.intermediate_root_interval
+        {
+            return Some("intermediate_root_interval");
+        }
+        None
+    }
 }
 
 /// Build the canonical JSON payload for outbox entries.

--- a/crates/proof/zk/db/tests/postgres_integration.rs
+++ b/crates/proof/zk/db/tests/postgres_integration.rs
@@ -16,12 +16,18 @@
 use std::time::Duration;
 
 use base_zk_db::{
-    CreateProofRequest, CreateProofSession, MarkOutboxError, MarkOutboxProcessed, ProofRequestRepo,
-    ProofStatus, ProofType, RetryOutcome, SessionStatus, SessionType, UpdateProofSession,
-    UpdateReceipt,
+    CreateProofRequest, CreateProofRequestError, CreateProofRequestOutcome, CreateProofSession,
+    MarkOutboxError, MarkOutboxProcessed, ProofRequestRepo, ProofStatus, ProofType, RetryOutcome,
+    SessionStatus, SessionType, UpdateProofSession, UpdateReceipt,
 };
 use sqlx::{PgPool, postgres::PgPoolOptions};
 use uuid::Uuid;
+
+/// `create_with_outbox` retry cap; must match prover `MAX_PROOF_RETRIES` default (`3`).
+const TEST_MAX_PROOF_RETRIES: i32 = 3;
+
+/// Outbox reader attempt cap (not proof `retry_count`).
+const TEST_OUTBOX_MAX_ATTEMPTS: i32 = 3;
 
 /// Connect to the test database using `DATABASE_URL` env var.
 async fn test_pool() -> PgPool {
@@ -742,7 +748,12 @@ async fn test_create_with_outbox() {
     let pool = test_pool().await;
     let repo = test_repo(pool);
 
-    let id = repo.create_with_outbox(compressed_request()).await.unwrap();
+    let outcome =
+        repo.create_with_outbox(compressed_request(), TEST_MAX_PROOF_RETRIES).await.unwrap();
+    let id = match outcome {
+        CreateProofRequestOutcome::Created(id) => id,
+        other => panic!("expected Created outcome, got {other:?}"),
+    };
 
     // Verify proof request exists
     let req = repo.get(id).await.unwrap().expect("should find request");
@@ -764,11 +775,17 @@ async fn test_create_with_outbox_idempotent() {
     let mut req = compressed_request();
     req.session_id = Some(explicit_id);
 
-    let id1 = repo.create_with_outbox(req.clone()).await.unwrap();
-    let id2 = repo.create_with_outbox(req).await.unwrap();
+    let first = repo.create_with_outbox(req.clone(), TEST_MAX_PROOF_RETRIES).await.unwrap();
+    let second = repo.create_with_outbox(req, TEST_MAX_PROOF_RETRIES).await.unwrap();
 
-    assert_eq!(id1, explicit_id);
-    assert_eq!(id2, explicit_id); // idempotent — same ID returned
+    assert!(matches!(first, CreateProofRequestOutcome::Created(id) if id == explicit_id));
+    assert!(matches!(second, CreateProofRequestOutcome::Replayed(id) if id == explicit_id));
+
+    // The second call must NOT enqueue a fresh outbox entry while the row is
+    // still in a non-terminal state.
+    let entries = repo.get_unprocessed_outbox_entries(100, 3).await.unwrap();
+    let outbox_count = entries.iter().filter(|e| e.proof_request_id == explicit_id).count();
+    assert_eq!(outbox_count, 1, "in-flight replay must not create another outbox row");
 }
 
 #[tokio::test]
@@ -777,7 +794,8 @@ async fn test_outbox_process_and_cleanup() {
     let pool = test_pool().await;
     let repo = test_repo(pool);
 
-    let id = repo.create_with_outbox(compressed_request()).await.unwrap();
+    let id =
+        repo.create_with_outbox(compressed_request(), TEST_MAX_PROOF_RETRIES).await.unwrap().id();
 
     // Get unprocessed entries
     let entries = repo.get_unprocessed_outbox_entries(10, 3).await.unwrap();
@@ -800,7 +818,8 @@ async fn test_outbox_error_tracking() {
     let pool = test_pool().await;
     let repo = test_repo(pool);
 
-    let id = repo.create_with_outbox(compressed_request()).await.unwrap();
+    let id =
+        repo.create_with_outbox(compressed_request(), TEST_MAX_PROOF_RETRIES).await.unwrap().id();
 
     let entries = repo.get_unprocessed_outbox_entries(100, 3).await.unwrap();
     let entry = entries.iter().find(|e| e.proof_request_id == id).expect("should find our entry");
@@ -827,6 +846,184 @@ async fn test_outbox_error_tracking() {
     let entry = entries.iter().find(|e| e.sequence_id == seq).expect("should still find entry");
     assert_eq!(entry.retry_count, 2);
     assert_eq!(entry.last_error.as_deref(), Some("second error"));
+}
+
+// create_with_outbox FAILED retry (CHAIN-4297 / Immunefi #75829)
+
+/// `CREATED` → `PENDING` → `FAILED` (same transitions as the worker on backend failure).
+async fn drive_to_failed(repo: &ProofRequestRepo, id: Uuid, error_message: &str) {
+    assert!(repo.atomic_claim_task(id).await.unwrap(), "claim CREATED -> PENDING");
+    assert!(
+        repo.transition_pending_to_failed(id, error_message.into()).await.unwrap(),
+        "transition PENDING -> FAILED",
+    );
+}
+
+#[tokio::test]
+#[ignore = "requires a running Postgres with the prover schema (set DATABASE_URL); run with `cargo nextest run --run-ignored all -p base-zk-db --test postgres_integration --test-threads=1`"]
+async fn test_create_with_outbox_requeues_failed_row() {
+    let pool = test_pool().await;
+    let repo = test_repo(pool);
+
+    let explicit_id = Uuid::new_v4();
+    let mut req = compressed_request();
+    req.session_id = Some(explicit_id);
+
+    // First attempt: create the row, then fail it via the same path the worker uses.
+    let first = repo.create_with_outbox(req.clone(), TEST_MAX_PROOF_RETRIES).await.unwrap();
+    assert!(matches!(first, CreateProofRequestOutcome::Created(id) if id == explicit_id));
+    drive_to_failed(&repo, explicit_id, "transient backend error").await;
+
+    // Sanity: the row is FAILED and the original outbox row exists.
+    let before = repo.get(explicit_id).await.unwrap().unwrap();
+    assert_eq!(before.status, ProofStatus::Failed);
+    assert_eq!(before.retry_count, 0);
+    let original_outbox =
+        repo.get_unprocessed_outbox_entries(100, TEST_OUTBOX_MAX_ATTEMPTS).await.unwrap();
+    let original_outbox_count =
+        original_outbox.iter().filter(|e| e.proof_request_id == explicit_id).count();
+
+    // Retry: same request, same id. The DB must reset the row and enqueue a new outbox entry.
+    let second = repo.create_with_outbox(req, TEST_MAX_PROOF_RETRIES).await.unwrap();
+    assert!(matches!(second, CreateProofRequestOutcome::Requeued(id) if id == explicit_id));
+
+    let after = repo.get(explicit_id).await.unwrap().unwrap();
+    assert_eq!(after.status, ProofStatus::Created, "row must be reset to CREATED for re-claim");
+    assert_eq!(after.retry_count, 1, "retry_count must increment");
+    assert!(after.error_message.is_none(), "stale error_message must be cleared");
+    assert!(after.completed_at.is_none(), "stale completed_at must be cleared");
+    assert!(after.stark_receipt.is_none(), "stale stark_receipt must be cleared");
+    assert!(after.snark_receipt.is_none(), "stale snark_receipt must be cleared");
+
+    // A new outbox entry must be present so the worker can claim the task again.
+    let after_outbox =
+        repo.get_unprocessed_outbox_entries(100, TEST_OUTBOX_MAX_ATTEMPTS).await.unwrap();
+    let after_outbox_count =
+        after_outbox.iter().filter(|e| e.proof_request_id == explicit_id).count();
+    assert_eq!(
+        after_outbox_count,
+        original_outbox_count + 1,
+        "requeue must insert exactly one new outbox row",
+    );
+}
+
+#[tokio::test]
+#[ignore = "requires a running Postgres with the prover schema (set DATABASE_URL); run with `cargo nextest run --run-ignored all -p base-zk-db --test postgres_integration --test-threads=1`"]
+async fn test_create_with_outbox_rejects_param_mismatch() {
+    let pool = test_pool().await;
+    let repo = test_repo(pool);
+
+    let explicit_id = Uuid::new_v4();
+    let mut req = compressed_request();
+    req.session_id = Some(explicit_id);
+    let _ = repo.create_with_outbox(req.clone(), TEST_MAX_PROOF_RETRIES).await.unwrap();
+
+    // Same id, different start_block_number — must be rejected, not silently masked.
+    let mut mismatched = req.clone();
+    mismatched.start_block_number = req.start_block_number + 1;
+
+    let err = repo
+        .create_with_outbox(mismatched, TEST_MAX_PROOF_RETRIES)
+        .await
+        .expect_err("param mismatch must produce IdCollision");
+
+    match err {
+        CreateProofRequestError::IdCollision { id, field } => {
+            assert_eq!(id, explicit_id);
+            assert_eq!(field, "start_block_number");
+        }
+        other => panic!("expected IdCollision, got {other:?}"),
+    }
+
+    // The original row must be untouched (no spurious requeue / state change).
+    let row = repo.get(explicit_id).await.unwrap().unwrap();
+    assert_eq!(row.status, ProofStatus::Created);
+    assert_eq!(row.retry_count, 0);
+}
+
+#[tokio::test]
+#[ignore = "requires a running Postgres with the prover schema (set DATABASE_URL); run with `cargo nextest run --run-ignored all -p base-zk-db --test postgres_integration --test-threads=1`"]
+async fn test_create_with_outbox_retry_cap() {
+    let pool = test_pool().await;
+    let repo = test_repo(pool);
+
+    let explicit_id = Uuid::new_v4();
+    let mut req = compressed_request();
+    req.session_id = Some(explicit_id);
+
+    let first = repo.create_with_outbox(req.clone(), TEST_MAX_PROOF_RETRIES).await.unwrap();
+    assert!(matches!(first, CreateProofRequestOutcome::Created(_)));
+
+    for expected in 1..=TEST_MAX_PROOF_RETRIES {
+        drive_to_failed(&repo, explicit_id, "transient backend error").await;
+        let outcome = repo.create_with_outbox(req.clone(), TEST_MAX_PROOF_RETRIES).await.unwrap();
+        assert!(matches!(outcome, CreateProofRequestOutcome::Requeued(_)));
+        let row = repo.get(explicit_id).await.unwrap().unwrap();
+        assert_eq!(row.retry_count, expected, "retry {expected} should reset and bump count");
+    }
+
+    // At cap: next create must not enqueue outbox.
+    drive_to_failed(&repo, explicit_id, "final backend error").await;
+    let outbox_before =
+        repo.get_unprocessed_outbox_entries(100, TEST_OUTBOX_MAX_ATTEMPTS).await.unwrap();
+    let outbox_count_before =
+        outbox_before.iter().filter(|e| e.proof_request_id == explicit_id).count();
+
+    let outcome = repo.create_with_outbox(req, TEST_MAX_PROOF_RETRIES).await.unwrap();
+    assert!(matches!(outcome, CreateProofRequestOutcome::RetryExhausted(id) if id == explicit_id));
+
+    let row = repo.get(explicit_id).await.unwrap().unwrap();
+    assert_eq!(row.status, ProofStatus::Failed, "row must stay FAILED at retry cap");
+    assert_eq!(row.retry_count, TEST_MAX_PROOF_RETRIES, "retry_count must not exceed cap");
+
+    let outbox_after =
+        repo.get_unprocessed_outbox_entries(100, TEST_OUTBOX_MAX_ATTEMPTS).await.unwrap();
+    let outbox_count_after =
+        outbox_after.iter().filter(|e| e.proof_request_id == explicit_id).count();
+    assert_eq!(
+        outbox_count_after, outbox_count_before,
+        "RetryExhausted must not enqueue a new outbox row",
+    );
+}
+
+#[tokio::test]
+#[ignore = "requires a running Postgres with the prover schema (set DATABASE_URL); run with `cargo nextest run --run-ignored all -p base-zk-db --test postgres_integration --test-threads=1`"]
+async fn test_create_with_outbox_idempotent_in_flight() {
+    let pool = test_pool().await;
+    let repo = test_repo(pool);
+
+    let explicit_id = Uuid::new_v4();
+    let mut req = compressed_request();
+    req.session_id = Some(explicit_id);
+    let _ = repo.create_with_outbox(req.clone(), TEST_MAX_PROOF_RETRIES).await.unwrap();
+
+    // CREATED: replay must not insert another outbox row.
+    let replayed = repo.create_with_outbox(req.clone(), TEST_MAX_PROOF_RETRIES).await.unwrap();
+    assert!(matches!(replayed, CreateProofRequestOutcome::Replayed(id) if id == explicit_id));
+
+    // PENDING: claim, then replay.
+    assert!(repo.atomic_claim_task(explicit_id).await.unwrap());
+    let replayed = repo.create_with_outbox(req.clone(), TEST_MAX_PROOF_RETRIES).await.unwrap();
+    assert!(matches!(replayed, CreateProofRequestOutcome::Replayed(id) if id == explicit_id));
+
+    // RUNNING: bring the row up via a STARK session, then replay.
+    let backend_id = format!("inflight-{}", Uuid::new_v4());
+    repo.transition_pending_to_running(CreateProofSession {
+        proof_request_id: explicit_id,
+        session_type: SessionType::Stark,
+        backend_session_id: backend_id,
+        metadata: None,
+    })
+    .await
+    .unwrap()
+    .expect("transition PENDING -> RUNNING");
+    let replayed = repo.create_with_outbox(req, TEST_MAX_PROOF_RETRIES).await.unwrap();
+    assert!(matches!(replayed, CreateProofRequestOutcome::Replayed(id) if id == explicit_id));
+
+    // Exactly one outbox row should exist for this id across all three replays.
+    let entries = repo.get_unprocessed_outbox_entries(100, TEST_OUTBOX_MAX_ATTEMPTS).await.unwrap();
+    let outbox_count = entries.iter().filter(|e| e.proof_request_id == explicit_id).count();
+    assert_eq!(outbox_count, 1, "in-flight replays must not enqueue new outbox rows");
 }
 
 // ============================================================

--- a/crates/proof/zk/service/src/server/mod.rs
+++ b/crates/proof/zk/service/src/server/mod.rs
@@ -20,18 +20,26 @@ mod prove_block;
 pub struct ProverServiceServer {
     repo: ProofRequestRepo,
     manager: ProofRequestManager,
+    /// Shared `retry_count` cap with [`crate::worker::StatusPoller`] (same as `retry_or_fail_stuck_request`).
+    max_proof_retries: i32,
 }
 
 impl fmt::Debug for ProverServiceServer {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("ProverServiceServer").finish_non_exhaustive()
+        f.debug_struct("ProverServiceServer")
+            .field("max_proof_retries", &self.max_proof_retries)
+            .finish_non_exhaustive()
     }
 }
 
 impl ProverServiceServer {
     /// Create a new prover service server.
-    pub const fn new(repo: ProofRequestRepo, manager: ProofRequestManager) -> Self {
-        Self { repo, manager }
+    pub const fn new(
+        repo: ProofRequestRepo,
+        manager: ProofRequestManager,
+        max_proof_retries: i32,
+    ) -> Self {
+        Self { repo, manager, max_proof_retries }
     }
 }
 

--- a/crates/proof/zk/service/src/server/prove_block.rs
+++ b/crates/proof/zk/service/src/server/prove_block.rs
@@ -1,7 +1,9 @@
 use base_zk_client::{ProveBlockRequest, ProveBlockResponse};
-use base_zk_db::{CreateProofRequest, ProofType};
+use base_zk_db::{
+    CreateProofRequest, CreateProofRequestError, CreateProofRequestOutcome, ProofType,
+};
 use tonic::{Request, Response, Status};
-use tracing::info;
+use tracing::{info, warn};
 use uuid::Uuid;
 
 use crate::{metrics, server::ProverServiceServer};
@@ -103,16 +105,61 @@ impl ProverServiceServer {
             intermediate_root_interval: prove_block_request.intermediate_root_interval,
         };
 
-        let proof_request_id = self
-            .repo
-            .create_with_outbox(db_request)
-            .await
-            .map_err(|e| Status::internal(format!("Database error: {e}")))?;
+        let outcome =
+            self.repo.create_with_outbox(db_request, self.max_proof_retries).await.map_err(|e| match e {
+            CreateProofRequestError::IdCollision { id, field } => {
+                warn!(
+                    proof_request_id = %id,
+                    mismatched_field = field,
+                    "rejected ProveBlock: session_id already bound to a different request"
+                );
+                Status::failed_precondition(format!(
+                    "session_id {id} already exists with a different {field}"
+                ))
+            }
+            CreateProofRequestError::SessionRowMissingAfterConflict { id } => {
+                warn!(
+                    proof_request_id = %id,
+                    "rejected ProveBlock: session_id row missing after insert conflict"
+                );
+                Status::unavailable(format!(
+                    "session_id {id} is temporarily unavailable after conflict; retry prove_block"
+                ))
+            }
+            CreateProofRequestError::Sqlx(e) => Status::internal(format!("Database error: {e}")),
+        })?;
 
-        info!(
-            proof_request_id = %proof_request_id,
-            "Created proof request and outbox entry"
-        );
+        let proof_request_id = outcome.id();
+        match outcome {
+            CreateProofRequestOutcome::RetryExhausted(id) => {
+                warn!(
+                    proof_request_id = %id,
+                    max_proof_retries = self.max_proof_retries,
+                    "rejected ProveBlock: proof request retry budget exhausted for this session_id",
+                );
+                return Err(Status::resource_exhausted(format!(
+                    "session_id {id}: proof request retry budget exhausted; use get_proof for the stored terminal failure",
+                )));
+            }
+            CreateProofRequestOutcome::Created(id) => {
+                info!(
+                    proof_request_id = %id,
+                    "Created proof request and outbox entry"
+                );
+            }
+            CreateProofRequestOutcome::Requeued(id) => {
+                info!(
+                    proof_request_id = %id,
+                    "Requeued previously failed proof request"
+                );
+            }
+            CreateProofRequestOutcome::Replayed(id) => {
+                info!(
+                    proof_request_id = %id,
+                    "Idempotent replay of in-flight or succeeded proof request"
+                );
+            }
+        }
 
         let response = ProveBlockResponse { session_id: proof_request_id.to_string() };
 
@@ -148,5 +195,10 @@ mod tests {
         assert_eq!(metrics::grpc_status_code_str(tonic::Code::InvalidArgument), "INVALID_ARGUMENT");
         assert_eq!(metrics::grpc_status_code_str(tonic::Code::Internal), "INTERNAL");
         assert_eq!(metrics::grpc_status_code_str(tonic::Code::NotFound), "NOT_FOUND");
+        assert_eq!(
+            metrics::grpc_status_code_str(tonic::Code::ResourceExhausted),
+            "RESOURCE_EXHAUSTED"
+        );
+        assert_eq!(metrics::grpc_status_code_str(tonic::Code::Unavailable), "UNAVAILABLE");
     }
 }


### PR DESCRIPTION
## Summary

Addresses **Immunefi #75829** (deterministic Challenger `session_id` reused on ZK proof retries while `create_with_outbox` treated `ON CONFLICT (id) DO NOTHING` as success without requeueing a terminal `FAILED` row).

## Changes

- **`ProofRequestRepo::create_with_outbox`**: On `session_id` conflict, `SELECT … FOR UPDATE`, compare request-defining fields → `CreateProofRequestError::IdCollision` on mismatch; `Replayed` for in-flight / succeeded; for `FAILED`, reset to `CREATED`, clear prior receipts / error / `completed_at`, bump `retry_count`, insert a new outbox row when under the retry cap, else `RetryExhausted`.
- **Retry cap**: Uses internal `MAX_RETRIES` (`3`) in the repo, aligned with the same `proof_requests.retry_count` budget as `retry_or_fail_stuck_request` (documented on the method).
- **`prove_block`**: Maps outcomes and `IdCollision` to appropriate gRPC statuses (`failed_precondition` for collision).
- **Tests**: Postgres integration tests for requeue, param mismatch, retry cap, and in-flight idempotency; Challenger driver regression for re-invoking `prove_block` with the same deterministic `session_id` after failure.

## Testing

- `cargo test -p base-challenger --test driver`
- Postgres integration tests are `#[ignore]`; run with `DATABASE_URL` as documented in each test attribute.

## Notes

- Complements (does not replace) outbox-authoritative / SNARK-dedup work on other branches: this fixes the **front-door** retry path for the same durable `session_id` after `FAILED`.

Made with [Cursor](https://cursor.com)