### PR TITLE
chore(CHAIN-4357): log when stale FinalizeTask is skipped

### DIFF
--- a/crates/consensus/engine/src/task_queue/tasks/finalize/task.rs
+++ b/crates/consensus/engine/src/task_queue/tasks/finalize/task.rs
@@ -34,7 +34,14 @@ impl<EngineClient_: EngineClient> EngineTaskExt for FinalizeTask<EngineClient_> 
         // Monotonicity guard: BinaryHeap does not define ordering between same-variant tasks,
         // so a stale FinalizeTask with a lower block number may be popped after a higher one
         // has already been executed. Skip it to prevent finalized_head from regressing.
-        if self.block_number < state.sync_state.finalized_head().block_info.number {
+        let finalized_head = state.sync_state.finalized_head().block_info.number;
+        if self.block_number < finalized_head {
+            debug!(
+                target: "engine",
+                block_number = self.block_number,
+                finalized_head,
+                "skipping stale finalize task"
+            );
             return Ok(());
         }
 


### PR DESCRIPTION
[CHAIN-4357](https://linear.app/coinbase/issue/CHAIN-4357)

## Motivation

Follow-up to #2587, which added a monotonicity guard so a stale `FinalizeTask` popped from the `BinaryHeap` after a higher block number has already been finalized is dropped instead of regressing `finalized_head`. The guard is currently silent: the happy path logs at `info!` (task.rs:75) but a skipped stale task leaves no trace, which would make ordering issues hard to diagnose in production.

Addresses review comment https://github.com/base/base/pull/2587#discussion_r3210742590.

## What changed

Added a `debug!` log on the guard branch with the incoming `block_number` and current `finalized_head` so skipped stale tasks are observable in trace-level engine logs. No behavior change.

## What was tried / considered

- `warn!` instead of `debug!`: rejected. The guard firing is expected behavior under the documented `BinaryHeap` same-variant ordering, not an error condition; `warn!` would be noisy.
- Logging at the call site that enqueues the task: less precise. The guard is the only place that knows both the stale block number and the current `finalized_head` at decision time.
