### PR TITLE
fix(zk): prevent duplicate SNARK submissions via DB reservation

### DIFF
--- a/crates/proof/zk/db/migrations/009_add_unique_proof_sessions.sql
+++ b/crates/proof/zk/db/migrations/009_add_unique_proof_sessions.sql
@@ -1,0 +1,36 @@
+-- Migration 009: Enforce at most one ACTIVE session per (proof_request, session_type)
+-- Prevents concurrent status pollers from creating duplicate SNARK aggregation jobs.
+--
+-- The index is partial on SUBMITTING/RUNNING so terminal sessions (FAILED/COMPLETED)
+-- remain as audit history without blocking a retried request from creating a fresh
+-- session for the same (proof_request_id, session_type) pair.
+
+-- Resolve any pre-existing duplicates among ACTIVE sessions before adding the constraint.
+-- Terminal-state duplicates are left alone since the partial index does not see them.
+WITH ranked_active AS (
+    SELECT
+        id,
+        ROW_NUMBER() OVER (
+            PARTITION BY proof_request_id, session_type
+            ORDER BY
+                CASE status
+                    WHEN 'RUNNING' THEN 0
+                    WHEN 'SUBMITTING' THEN 1
+                    ELSE 2
+                END,
+                created_at ASC,
+                id ASC
+        ) AS row_num
+    FROM proof_sessions
+    WHERE status IN ('SUBMITTING', 'RUNNING')
+)
+DELETE FROM proof_sessions
+USING ranked_active
+WHERE proof_sessions.id = ranked_active.id
+  AND ranked_active.row_num > 1;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_proof_sessions_request_type_active_unique
+ON proof_sessions(proof_request_id, session_type)
+WHERE status IN ('SUBMITTING', 'RUNNING');
+
+COMMENT ON COLUMN proof_sessions.status IS 'Session status: SUBMITTING, RUNNING, COMPLETED, FAILED';

--- a/crates/proof/zk/db/src/models.rs
+++ b/crates/proof/zk/db/src/models.rs
@@ -59,6 +59,8 @@ impl TryFrom<&str> for ProofStatus {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, sqlx::Type)]
 #[sqlx(type_name = "VARCHAR", rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum SessionStatus {
+    /// Backend session is being submitted and does not have a backend ID yet.
+    Submitting,
     /// Backend session is actively running.
     Running,
     /// Backend session completed successfully.
@@ -71,6 +73,7 @@ impl SessionStatus {
     /// Convert enum to static string representation
     pub const fn as_str(&self) -> &'static str {
         match self {
+            Self::Submitting => "SUBMITTING",
             Self::Running => "RUNNING",
             Self::Completed => "COMPLETED",
             Self::Failed => "FAILED",
@@ -89,6 +92,7 @@ impl TryFrom<&str> for SessionStatus {
 
     fn try_from(s: &str) -> Result<Self, Self::Error> {
         match s {
+            "SUBMITTING" => Ok(Self::Submitting),
             "RUNNING" => Ok(Self::Running),
             "COMPLETED" => Ok(Self::Completed),
             "FAILED" => Ok(Self::Failed),

--- a/crates/proof/zk/db/src/repo.rs
+++ b/crates/proof/zk/db/src/repo.rs
@@ -237,8 +237,9 @@ impl ProofRequestRepo {
     }
 
     /// Atomically create a proof session and transition proof request PENDING → RUNNING.
-    /// Returns `Ok(Some(session_id))` if the request was in PENDING state.
-    /// Returns `Ok(None)` if the request was NOT in PENDING state (race lost).
+    ///
+    /// Returns `Ok(None)` if the request was not pending, or if the session row was not inserted
+    /// because another active (`SUBMITTING`/`RUNNING`) session exists (transaction rolled back).
     pub async fn transition_pending_to_running(
         &self,
         session: CreateProofSession,
@@ -269,6 +270,9 @@ impl ProofRequestRepo {
                 proof_request_id, session_type, backend_session_id, status, metadata
             )
             VALUES ($1, $2, $3, $4, $5)
+            ON CONFLICT (proof_request_id, session_type)
+                WHERE status IN ('SUBMITTING', 'RUNNING')
+                DO NOTHING
             RETURNING id
             "#,
         )
@@ -277,8 +281,13 @@ impl ProofRequestRepo {
         .bind(&session.backend_session_id)
         .bind(SessionStatus::Running.as_str())
         .bind(&session.metadata)
-        .fetch_one(&mut *tx)
+        .fetch_optional(&mut *tx)
         .await?;
+
+        let Some(row) = row else {
+            tx.rollback().await?;
+            return Ok(None);
+        };
 
         let session_id: i64 = row.get("id");
         tx.commit().await?;
@@ -492,14 +501,123 @@ impl ProofRequestRepo {
 
     // ========== Proof Session Methods ==========
 
-    /// Create a new proof session
-    pub async fn create_proof_session(&self, session: CreateProofSession) -> Result<i64> {
+    /// Reserve a proof session slot before submitting work to the backend.
+    ///
+    /// Returns `Some(reservation_id)` if this caller created the reservation and should submit the
+    /// backend job. Returns `None` if another caller already reserved or created this session type.
+    pub async fn reserve_proof_session(
+        &self,
+        proof_request_id: Uuid,
+        session_type: SessionType,
+    ) -> Result<Option<String>> {
+        let reservation_id =
+            format!("submitting-{}-{}", session_type.as_str().to_ascii_lowercase(), Uuid::new_v4());
+
+        // The partial unique index `idx_proof_sessions_request_type_active_unique` is
+        // restricted to rows with status IN ('SUBMITTING', 'RUNNING'); the matching
+        // predicate must be repeated here so Postgres infers that index for ON CONFLICT.
+        let row = sqlx::query(
+            r#"
+            INSERT INTO proof_sessions (
+                proof_request_id, session_type, backend_session_id, status, metadata
+            )
+            VALUES ($1, $2, $3, $4, NULL)
+            ON CONFLICT (proof_request_id, session_type)
+                WHERE status IN ('SUBMITTING', 'RUNNING')
+                DO NOTHING
+            RETURNING backend_session_id
+            "#,
+        )
+        .bind(proof_request_id)
+        .bind(session_type.as_str())
+        .bind(&reservation_id)
+        .bind(SessionStatus::Submitting.as_str())
+        .fetch_optional(&self.pool)
+        .await?;
+
+        Ok(row.map(|r| r.get("backend_session_id")))
+    }
+
+    /// Activate a reserved proof session after the backend returns its session ID.
+    ///
+    /// Returns `true` when the reservation was found and updated.
+    pub async fn activate_reserved_proof_session(
+        &self,
+        reservation_id: &str,
+        session: CreateProofSession,
+    ) -> Result<bool> {
+        let result = sqlx::query(
+            r#"
+            UPDATE proof_sessions
+            SET backend_session_id = $1,
+                status = $2,
+                metadata = $3,
+                error_message = NULL
+            WHERE backend_session_id = $4
+              AND proof_request_id = $5
+              AND session_type = $6
+              AND status = $7
+            "#,
+        )
+        .bind(&session.backend_session_id)
+        .bind(SessionStatus::Running.as_str())
+        .bind(&session.metadata)
+        .bind(reservation_id)
+        .bind(session.proof_request_id)
+        .bind(session.session_type.as_str())
+        .bind(SessionStatus::Submitting.as_str())
+        .execute(&self.pool)
+        .await?;
+
+        Ok(result.rows_affected() > 0)
+    }
+
+    /// Mark a reserved proof session as failed when backend submission fails.
+    pub async fn fail_reserved_proof_session(
+        &self,
+        proof_request_id: Uuid,
+        session_type: SessionType,
+        reservation_id: &str,
+        error_message: &str,
+    ) -> Result<bool> {
+        let result = sqlx::query(
+            r#"
+            UPDATE proof_sessions
+            SET status = $1,
+                error_message = $2,
+                completed_at = NOW()
+            WHERE backend_session_id = $3
+              AND proof_request_id = $4
+              AND session_type = $5
+              AND status = $6
+            "#,
+        )
+        .bind(SessionStatus::Failed.as_str())
+        .bind(error_message)
+        .bind(reservation_id)
+        .bind(proof_request_id)
+        .bind(session_type.as_str())
+        .bind(SessionStatus::Submitting.as_str())
+        .execute(&self.pool)
+        .await?;
+
+        Ok(result.rows_affected() > 0)
+    }
+
+    /// Create a new proof session.
+    ///
+    /// Returns `None` when an active (`SUBMITTING`/`RUNNING`) row already exists for the same
+    /// `(proof_request_id, session_type)`.
+    pub async fn create_proof_session(&self, session: CreateProofSession) -> Result<Option<i64>> {
         let row = sqlx::query(
             r#"
             INSERT INTO proof_sessions (
                 proof_request_id, session_type, backend_session_id, status, metadata
             )
             VALUES ($1, $2, $3, $4, $5)
+            ON CONFLICT (proof_request_id, session_type)
+                WHERE status IN ('SUBMITTING', 'RUNNING')
+                DO NOTHING
             RETURNING id
             "#,
         )
@@ -508,11 +626,10 @@ impl ProofRequestRepo {
         .bind(&session.backend_session_id)
         .bind(SessionStatus::Running.as_str())
         .bind(&session.metadata)
-        .fetch_one(&self.pool)
+        .fetch_optional(&self.pool)
         .await?;
 
-        let id: i64 = row.get("id");
-        Ok(id)
+        Ok(row.map(|r| r.get("id")))
     }
 
     /// Get a proof session by backend session ID
@@ -595,10 +712,10 @@ impl ProofRequestRepo {
         rows.iter().map(row_to_proof_request).collect()
     }
 
-    /// Get proof requests that are stuck in PENDING without a running session.
+    /// Get proof requests that are stuck in PENDING without an active session.
     /// These are likely orphaned due to crashes before session creation.
-    /// Only checks for active (RUNNING) sessions so that retried requests
-    /// with old COMPLETED/FAILED sessions are still detected as stuck.
+    /// Treats `SUBMITTING` like `RUNNING` so SNARK reservations in flight are not misclassified
+    /// as stuck. Terminal sessions (`COMPLETED`/`FAILED`) do not satisfy the guard.
     pub async fn get_stuck_requests(&self, stuck_timeout_mins: i32) -> Result<Vec<ProofRequest>> {
         let rows = sqlx::query(
             r#"
@@ -614,7 +731,7 @@ impl ProofRequestRepo {
               AND NOT EXISTS (
                   SELECT 1 FROM proof_sessions ps
                   WHERE ps.proof_request_id = pr.id
-                    AND ps.status = 'RUNNING'
+                    AND ps.status IN ('RUNNING', 'SUBMITTING')
               )
             ORDER BY pr.created_at ASC
             "#,

--- a/crates/proof/zk/db/tests/postgres_integration.rs
+++ b/crates/proof/zk/db/tests/postgres_integration.rs
@@ -68,6 +68,10 @@ fn snark_request() -> CreateProofRequest {
     }
 }
 
+fn expect_inserted_session_id(result: sqlx::Result<Option<i64>>) -> i64 {
+    result.expect("create_proof_session").expect("inserted row")
+}
+
 /// Create a request in RUNNING state with an associated proof session.
 /// Returns `(request_id, backend_session_id)`.
 async fn setup_running_request(repo: &ProofRequestRepo) -> (Uuid, String) {
@@ -379,15 +383,15 @@ async fn test_create_proof_session() {
     let repo = test_repo(pool);
 
     let req_id = repo.create(compressed_request()).await.unwrap();
-    let session_id = repo
-        .create_proof_session(CreateProofSession {
+    let session_id = expect_inserted_session_id(
+        repo.create_proof_session(CreateProofSession {
             proof_request_id: req_id,
             session_type: SessionType::Stark,
             backend_session_id: format!("test-session-{}", Uuid::new_v4()),
             metadata: Some(serde_json::json!({"key": "value"})),
         })
-        .await
-        .unwrap();
+        .await,
+    );
 
     assert!(session_id > 0);
 }
@@ -401,14 +405,15 @@ async fn test_get_session_by_backend_id() {
     let req_id = repo.create(compressed_request()).await.unwrap();
     let backend_id = format!("backend-{}", Uuid::new_v4());
 
-    repo.create_proof_session(CreateProofSession {
-        proof_request_id: req_id,
-        session_type: SessionType::Stark,
-        backend_session_id: backend_id.clone(),
-        metadata: None,
-    })
-    .await
-    .unwrap();
+    expect_inserted_session_id(
+        repo.create_proof_session(CreateProofSession {
+            proof_request_id: req_id,
+            session_type: SessionType::Stark,
+            backend_session_id: backend_id.clone(),
+            metadata: None,
+        })
+        .await,
+    );
 
     let session =
         repo.get_session_by_backend_id(&backend_id).await.unwrap().expect("should find session");
@@ -427,29 +432,87 @@ async fn test_get_sessions_for_request() {
     let req_id = repo.create(snark_request()).await.unwrap();
 
     // Create STARK session
-    repo.create_proof_session(CreateProofSession {
-        proof_request_id: req_id,
-        session_type: SessionType::Stark,
-        backend_session_id: format!("stark-{}", Uuid::new_v4()),
-        metadata: None,
-    })
-    .await
-    .unwrap();
+    expect_inserted_session_id(
+        repo.create_proof_session(CreateProofSession {
+            proof_request_id: req_id,
+            session_type: SessionType::Stark,
+            backend_session_id: format!("stark-{}", Uuid::new_v4()),
+            metadata: None,
+        })
+        .await,
+    );
 
     // Create SNARK session
-    repo.create_proof_session(CreateProofSession {
-        proof_request_id: req_id,
-        session_type: SessionType::Snark,
-        backend_session_id: format!("snark-{}", Uuid::new_v4()),
-        metadata: None,
-    })
-    .await
-    .unwrap();
+    expect_inserted_session_id(
+        repo.create_proof_session(CreateProofSession {
+            proof_request_id: req_id,
+            session_type: SessionType::Snark,
+            backend_session_id: format!("snark-{}", Uuid::new_v4()),
+            metadata: None,
+        })
+        .await,
+    );
 
     let sessions = repo.get_sessions_for_request(req_id).await.unwrap();
     assert_eq!(sessions.len(), 2);
     assert_eq!(sessions[0].session_type, SessionType::Stark);
     assert_eq!(sessions[1].session_type, SessionType::Snark);
+}
+
+#[tokio::test]
+#[ignore = "requires a running Postgres with the prover schema (set DATABASE_URL); run with `cargo nextest run --run-ignored all -p base-zk-db --test postgres_integration --test-threads=1`"]
+async fn test_reserve_proof_session_is_single_winner() {
+    let pool = test_pool().await;
+    let repo = test_repo(pool);
+
+    let req_id = repo.create(snark_request()).await.unwrap();
+
+    let first = repo.reserve_proof_session(req_id, SessionType::Snark).await.unwrap();
+    let second = repo.reserve_proof_session(req_id, SessionType::Snark).await.unwrap();
+
+    assert!(first.is_some(), "first reservation should win");
+    assert!(second.is_none(), "second reservation should observe existing session");
+
+    let sessions = repo.get_sessions_for_request(req_id).await.unwrap();
+    assert_eq!(sessions.len(), 1);
+    assert_eq!(sessions[0].session_type, SessionType::Snark);
+    assert_eq!(sessions[0].status, SessionStatus::Submitting);
+}
+
+#[tokio::test]
+#[ignore = "requires a running Postgres with the prover schema (set DATABASE_URL); run with `cargo nextest run --run-ignored all -p base-zk-db --test postgres_integration --test-threads=1`"]
+async fn test_activate_reserved_proof_session() {
+    let pool = test_pool().await;
+    let repo = test_repo(pool);
+
+    let req_id = repo.create(snark_request()).await.unwrap();
+    let reservation_id = repo
+        .reserve_proof_session(req_id, SessionType::Snark)
+        .await
+        .unwrap()
+        .expect("reservation should win");
+    let backend_id = format!("snark-{}", Uuid::new_v4());
+
+    let activated = repo
+        .activate_reserved_proof_session(
+            &reservation_id,
+            CreateProofSession {
+                proof_request_id: req_id,
+                session_type: SessionType::Snark,
+                backend_session_id: backend_id.clone(),
+                metadata: Some(serde_json::json!({"proof_id": backend_id.clone()})),
+            },
+        )
+        .await
+        .unwrap();
+
+    assert!(activated);
+
+    let sessions = repo.get_sessions_for_request(req_id).await.unwrap();
+    assert_eq!(sessions.len(), 1);
+    assert_eq!(sessions[0].backend_session_id, backend_id);
+    assert_eq!(sessions[0].status, SessionStatus::Running);
+    assert!(sessions[0].metadata.is_some());
 }
 
 #[tokio::test]
@@ -461,14 +524,15 @@ async fn test_update_proof_session() {
     let req_id = repo.create(compressed_request()).await.unwrap();
     let backend_id = format!("session-update-{}", Uuid::new_v4());
 
-    repo.create_proof_session(CreateProofSession {
-        proof_request_id: req_id,
-        session_type: SessionType::Stark,
-        backend_session_id: backend_id.clone(),
-        metadata: None,
-    })
-    .await
-    .unwrap();
+    expect_inserted_session_id(
+        repo.create_proof_session(CreateProofSession {
+            proof_request_id: req_id,
+            session_type: SessionType::Stark,
+            backend_session_id: backend_id.clone(),
+            metadata: None,
+        })
+        .await,
+    );
 
     repo.update_proof_session(UpdateProofSession {
         backend_session_id: backend_id.clone(),
@@ -494,14 +558,15 @@ async fn test_update_proof_session_if_non_terminal() {
     let req_id = repo.create(compressed_request()).await.unwrap();
     let backend_id = format!("session-nonterminal-{}", Uuid::new_v4());
 
-    repo.create_proof_session(CreateProofSession {
-        proof_request_id: req_id,
-        session_type: SessionType::Stark,
-        backend_session_id: backend_id.clone(),
-        metadata: None,
-    })
-    .await
-    .unwrap();
+    expect_inserted_session_id(
+        repo.create_proof_session(CreateProofSession {
+            proof_request_id: req_id,
+            session_type: SessionType::Stark,
+            backend_session_id: backend_id.clone(),
+            metadata: None,
+        })
+        .await,
+    );
 
     // First update: RUNNING -> COMPLETED (should succeed)
     let updated = repo
@@ -638,14 +703,15 @@ async fn test_complete_session_and_update_receipt_skips_non_running() {
     repo.atomic_claim_task(id).await.unwrap();
     // Request is PENDING, not RUNNING
     let backend_id = format!("complete-pending-{}", Uuid::new_v4());
-    repo.create_proof_session(CreateProofSession {
-        proof_request_id: id,
-        session_type: SessionType::Stark,
-        backend_session_id: backend_id.clone(),
-        metadata: None,
-    })
-    .await
-    .unwrap();
+    expect_inserted_session_id(
+        repo.create_proof_session(CreateProofSession {
+            proof_request_id: id,
+            session_type: SessionType::Stark,
+            backend_session_id: backend_id.clone(),
+            metadata: None,
+        })
+        .await,
+    );
 
     let updated = repo
         .complete_session_and_update_receipt(
@@ -844,24 +910,26 @@ async fn test_get_running_sessions() {
     let completed_id = format!("completed-session-{}", Uuid::new_v4());
 
     // Create a running session
-    repo.create_proof_session(CreateProofSession {
-        proof_request_id: req_id,
-        session_type: SessionType::Stark,
-        backend_session_id: running_id.clone(),
-        metadata: None,
-    })
-    .await
-    .unwrap();
+    expect_inserted_session_id(
+        repo.create_proof_session(CreateProofSession {
+            proof_request_id: req_id,
+            session_type: SessionType::Stark,
+            backend_session_id: running_id.clone(),
+            metadata: None,
+        })
+        .await,
+    );
 
     // Create and complete another session
-    repo.create_proof_session(CreateProofSession {
-        proof_request_id: req_id,
-        session_type: SessionType::Snark,
-        backend_session_id: completed_id.clone(),
-        metadata: None,
-    })
-    .await
-    .unwrap();
+    expect_inserted_session_id(
+        repo.create_proof_session(CreateProofSession {
+            proof_request_id: req_id,
+            session_type: SessionType::Snark,
+            backend_session_id: completed_id.clone(),
+            metadata: None,
+        })
+        .await,
+    );
     repo.update_proof_session(UpdateProofSession {
         backend_session_id: completed_id.clone(),
         status: SessionStatus::Completed,
@@ -964,14 +1032,15 @@ async fn test_full_snark_pipeline() {
 
     // 5. Submit SNARK session
     let snark_backend_id = format!("snark-pipeline-{}", Uuid::new_v4());
-    repo.create_proof_session(CreateProofSession {
-        proof_request_id: req_id,
-        session_type: SessionType::Snark,
-        backend_session_id: snark_backend_id.clone(),
-        metadata: None,
-    })
-    .await
-    .unwrap();
+    expect_inserted_session_id(
+        repo.create_proof_session(CreateProofSession {
+            proof_request_id: req_id,
+            session_type: SessionType::Snark,
+            backend_session_id: snark_backend_id.clone(),
+            metadata: None,
+        })
+        .await,
+    );
 
     // 6. SNARK completes — store receipt, mark SUCCEEDED
     let snark_receipt = vec![0xAA, 0xBB, 0xCC];

--- a/crates/proof/zk/service/src/backends/mod.rs
+++ b/crates/proof/zk/service/src/backends/mod.rs
@@ -4,6 +4,8 @@ mod op_succinct;
 pub use op_succinct::{
     ClusterBackend as OpSuccinctClusterBackend, MockBackend as OpSuccinctMockBackend,
     NetworkBackend as OpSuccinctNetworkBackend, OpSuccinctProvider,
+    SnarkSession as OpSuccinctSnarkSession,
+    SnarkSessionRunOutcome as OpSuccinctSnarkSessionRunOutcome,
     WitnessParams as OpSuccinctWitnessParams,
 };
 

--- a/crates/proof/zk/service/src/backends/op_succinct/cluster.rs
+++ b/crates/proof/zk/service/src/backends/op_succinct/cluster.rs
@@ -22,7 +22,10 @@ use sp1_sdk::{ProofFromNetwork, SP1ProofWithPublicValues, network::proto::types:
 use tracing::{error, info, warn};
 use uuid::Uuid;
 
-use super::provider::{OpSuccinctProvider, WitnessParams};
+use super::{
+    SnarkSession, SnarkSessionRunOutcome,
+    provider::{OpSuccinctProvider, WitnessParams},
+};
 use crate::backends::traits::{
     ArtifactClientWrapper, BackendConfig, BackendType, ProofProcessingResult, ProveResult,
     ProvingBackend, SessionStatus,
@@ -210,41 +213,41 @@ impl ProvingBackend for ClusterBackend {
         // 3. Re-query sessions to get updated state.
         let updated_sessions = repo.get_sessions_for_request(proof_request.id).await?;
 
-        // 4. If SNARK requested, check if STARK completed and SNARK session needs
-        //    to be triggered.
-        if proof_request.proof_type == ProofType::OpSuccinctSp1ClusterSnarkGroth16 {
-            let has_stark_completed = updated_sessions.iter().any(|s| {
-                s.session_type == SessionType::Stark && s.status == DbSessionStatus::Completed
-            });
-            let has_snark_session =
-                updated_sessions.iter().any(|s| s.session_type == SessionType::Snark);
-
-            if has_stark_completed && !has_snark_session {
+        // 4. If SNARK requested, atomically reserve and submit the aggregation stage so
+        //    concurrent pollers cannot enqueue duplicate Groth16 jobs.
+        let snark_run =
+            SnarkSession::run_if_needed(repo, proof_request, &updated_sessions, || async {
                 info!(
                     proof_request_id = %proof_request.id,
                     "STARK completed, triggering stage-2 aggregation proof (SNARK Groth16)"
                 );
-                let fresh_proof_request = repo.get(proof_request.id).await?.ok_or_else(|| {
+                let fresh = repo.get(proof_request.id).await?.ok_or_else(|| {
                     anyhow::anyhow!("Proof request not found after STARK completion")
                 })?;
-                if let Err(e) = self.submit_aggregation_proof(&fresh_proof_request, repo).await {
-                    error!(
-                        proof_request_id = %proof_request.id,
-                        error = %e,
-                        "failed to submit aggregation proof"
-                    );
-                    return Ok(ProofProcessingResult {
-                        status: ProofStatus::Failed,
-                        error_message: Some(format!("Failed to submit aggregation proof: {e}")),
-                    });
-                }
+                self.build_aggregation_session(&fresh).await
+            })
+            .await;
+
+        match snark_run {
+            Ok(SnarkSessionRunOutcome::NotNeeded) => {
+                Ok(Self::determine_status(proof_request.proof_type, &updated_sessions))
+            }
+            Ok(_) => {
                 let updated_sessions = repo.get_sessions_for_request(proof_request.id).await?;
-                return Ok(Self::determine_status(proof_request.proof_type, &updated_sessions));
+                Ok(Self::determine_status(proof_request.proof_type, &updated_sessions))
+            }
+            Err(e) => {
+                error!(
+                    proof_request_id = %proof_request.id,
+                    error = %e,
+                    "failed to submit aggregation proof"
+                );
+                Ok(ProofProcessingResult {
+                    status: ProofStatus::Failed,
+                    error_message: Some(format!("Failed to submit aggregation proof: {e}")),
+                })
             }
         }
-
-        // 5. Determine final status.
-        Ok(Self::determine_status(proof_request.proof_type, &updated_sessions))
     }
 
     async fn get_session_status(&self, session: &ProofSession) -> anyhow::Result<SessionStatus> {
@@ -610,12 +613,13 @@ impl ClusterBackend {
         }
     }
 
-    /// Submit an aggregation proof (stage 2) after the STARK proof completes.
-    async fn submit_aggregation_proof(
+    /// Submit a stage-2 aggregation proof to the SP1 cluster and return the
+    /// [`CreateProofSession`] describing the resulting SNARK row. The caller (via
+    /// [`SnarkSession::run_if_needed`]) is responsible for activating the reserved DB row.
+    async fn build_aggregation_session(
         &self,
         proof_request: &ProofRequest,
-        repo: &ProofRequestRepo,
-    ) -> anyhow::Result<()> {
+    ) -> anyhow::Result<CreateProofSession> {
         let BackendConfig::OpSuccinct {
             cluster_rpc,
             artifact_client,
@@ -709,7 +713,7 @@ impl ClusterBackend {
             "aggregation proof (Groth16) submitted to SP1 cluster"
         );
 
-        // 6. Create SNARK session in DB.
+        // 6. Build the SNARK session descriptor (DB write happens via the reservation).
         let start_time_secs = SystemTime::now()
             .duration_since(SystemTime::UNIX_EPOCH)
             .expect("system time before UNIX epoch")
@@ -724,21 +728,17 @@ impl ClusterBackend {
             "start_time_secs": start_time_secs,
         });
 
-        let session = CreateProofSession {
+        info!(
+            proof_request_id = %proof_request.id,
+            "built SNARK proof session for aggregation"
+        );
+
+        Ok(CreateProofSession {
             proof_request_id: proof_request.id,
             session_type: SessionType::Snark,
             backend_session_id: cluster_proof_request.proof_id,
             metadata: Some(metadata),
-        };
-
-        repo.create_proof_session(session).await?;
-
-        info!(
-            proof_request_id = %proof_request.id,
-            "created SNARK proof session for aggregation"
-        );
-
-        Ok(())
+        })
     }
 }
 

--- a/crates/proof/zk/service/src/backends/op_succinct/mock.rs
+++ b/crates/proof/zk/service/src/backends/op_succinct/mock.rs
@@ -18,9 +18,10 @@ use serde_json::json;
 use sp1_sdk::{
     SP1_CIRCUIT_VERSION, SP1ProofMode, SP1ProofWithPublicValues, SP1PublicValues, SP1VerifyingKey,
 };
-use tracing::info;
+use tracing::{error, info};
 use uuid::Uuid;
 
+use super::{SnarkSession, SnarkSessionRunOutcome};
 use crate::backends::traits::{
     BackendType, ProofProcessingResult, ProveResult, ProvingBackend, SessionStatus,
 };
@@ -210,43 +211,50 @@ impl ProvingBackend for MockBackend {
         // Re-query sessions after updates.
         let updated_sessions = repo.get_sessions_for_request(proof_request.id).await?;
 
-        // For SNARK_GROTH16, check if STARK is done and SNARK session needs creation.
-        if proof_request.proof_type == ProofType::OpSuccinctSp1ClusterSnarkGroth16 {
-            let has_stark_completed = updated_sessions.iter().any(|s| {
-                s.session_type == SessionType::Stark && s.status == DbSessionStatus::Completed
-            });
-            let has_snark_session =
-                updated_sessions.iter().any(|s| s.session_type == SessionType::Snark);
-
-            if has_stark_completed && !has_snark_session {
+        // For SNARK_GROTH16, atomically reserve and "submit" the mock SNARK session so
+        // concurrent pollers never create duplicate rows.
+        let snark_run =
+            SnarkSession::run_if_needed(repo, proof_request, &updated_sessions, || async {
                 info!(
                     proof_request_id = %proof_request.id,
                     "MockBackend: STARK done, creating SNARK session"
                 );
-
-                let snark_session_id = format!("mock-snark-{}", Uuid::new_v4());
-                let metadata = json!({
-                    "mock": true,
-                    "proof_output_id": format!("mock-snark-output-{}", Uuid::new_v4()),
-                    "deadline_secs": 0u64,
-                    "start_time_secs": 0u64,
-                });
-
-                let session = CreateProofSession {
+                Ok(CreateProofSession {
                     proof_request_id: proof_request.id,
                     session_type: SessionType::Snark,
-                    backend_session_id: snark_session_id,
-                    metadata: Some(metadata),
-                };
+                    backend_session_id: format!("mock-snark-{}", Uuid::new_v4()),
+                    metadata: Some(json!({
+                        "mock": true,
+                        "proof_output_id": format!("mock-snark-output-{}", Uuid::new_v4()),
+                        "deadline_secs": 0u64,
+                        "start_time_secs": 0u64,
+                    })),
+                })
+            })
+            .await;
 
-                repo.create_proof_session(session).await?;
-
+        match snark_run {
+            Ok(SnarkSessionRunOutcome::NotNeeded) => {
+                Ok(determine_mock_status(proof_request.proof_type, &updated_sessions))
+            }
+            Ok(_) => {
                 let final_sessions = repo.get_sessions_for_request(proof_request.id).await?;
-                return Ok(determine_mock_status(proof_request.proof_type, &final_sessions));
+                Ok(determine_mock_status(proof_request.proof_type, &final_sessions))
+            }
+            Err(e) => {
+                error!(
+                    proof_request_id = %proof_request.id,
+                    error = %e,
+                    "MockBackend: failed to create SNARK session"
+                );
+                Ok(ProofProcessingResult {
+                    status: ProofStatus::Failed,
+                    error_message: Some(format!(
+                        "MockBackend: failed to create SNARK session: {e}"
+                    )),
+                })
             }
         }
-
-        Ok(determine_mock_status(proof_request.proof_type, &updated_sessions))
     }
 
     async fn get_session_status(&self, _session: &ProofSession) -> anyhow::Result<SessionStatus> {

--- a/crates/proof/zk/service/src/backends/op_succinct/mod.rs
+++ b/crates/proof/zk/service/src/backends/op_succinct/mod.rs
@@ -11,3 +11,6 @@ pub use network::NetworkBackend;
 
 mod provider;
 pub use provider::{OpSuccinctProvider, WitnessParams};
+
+mod snark_session;
+pub use snark_session::{SnarkSession, SnarkSessionRunOutcome};

--- a/crates/proof/zk/service/src/backends/op_succinct/network.rs
+++ b/crates/proof/zk/service/src/backends/op_succinct/network.rs
@@ -23,7 +23,10 @@ use sp1_sdk::{
 };
 use tracing::{error, info, warn};
 
-use super::provider::{OpSuccinctProvider, WitnessParams};
+use super::{
+    SnarkSession, SnarkSessionRunOutcome,
+    provider::{OpSuccinctProvider, WitnessParams},
+};
 use crate::backends::traits::{
     BackendConfig, BackendType, ProofProcessingResult, ProveResult, ProvingBackend, SessionStatus,
 };
@@ -210,39 +213,41 @@ impl ProvingBackend for NetworkBackend {
 
         let updated_sessions = repo.get_sessions_for_request(proof_request.id).await?;
 
-        // If SNARK requested, check if STARK completed and SNARK session needs triggering.
-        if proof_request.proof_type == ProofType::OpSuccinctSp1ClusterSnarkGroth16 {
-            let has_stark_completed = updated_sessions.iter().any(|s| {
-                s.session_type == SessionType::Stark && s.status == DbSessionStatus::Completed
-            });
-            let has_snark_session =
-                updated_sessions.iter().any(|s| s.session_type == SessionType::Snark);
-
-            if has_stark_completed && !has_snark_session {
+        // If SNARK requested, atomically reserve and submit the aggregation stage so
+        // concurrent pollers cannot enqueue duplicate Groth16 jobs.
+        let snark_run =
+            SnarkSession::run_if_needed(repo, proof_request, &updated_sessions, || async {
                 info!(
                     proof_request_id = %proof_request.id,
                     "STARK completed, triggering stage-2 aggregation proof via SP1 Network"
                 );
-                let fresh_proof_request = repo.get(proof_request.id).await?.ok_or_else(|| {
+                let fresh = repo.get(proof_request.id).await?.ok_or_else(|| {
                     anyhow::anyhow!("proof request not found after STARK completion")
                 })?;
-                if let Err(e) = self.submit_aggregation_proof(&fresh_proof_request, repo).await {
-                    error!(
-                        proof_request_id = %proof_request.id,
-                        error = %e,
-                        "failed to submit aggregation proof"
-                    );
-                    return Ok(ProofProcessingResult {
-                        status: ProofStatus::Failed,
-                        error_message: Some(format!("failed to submit aggregation proof: {e}")),
-                    });
-                }
+                self.build_aggregation_session(&fresh).await
+            })
+            .await;
+
+        match snark_run {
+            Ok(SnarkSessionRunOutcome::NotNeeded) => {
+                Ok(Self::determine_status(proof_request.proof_type, &updated_sessions))
+            }
+            Ok(_) => {
                 let updated_sessions = repo.get_sessions_for_request(proof_request.id).await?;
-                return Ok(Self::determine_status(proof_request.proof_type, &updated_sessions));
+                Ok(Self::determine_status(proof_request.proof_type, &updated_sessions))
+            }
+            Err(e) => {
+                error!(
+                    proof_request_id = %proof_request.id,
+                    error = %e,
+                    "failed to submit aggregation proof"
+                );
+                Ok(ProofProcessingResult {
+                    status: ProofStatus::Failed,
+                    error_message: Some(format!("failed to submit aggregation proof: {e}")),
+                })
             }
         }
-
-        Ok(Self::determine_status(proof_request.proof_type, &updated_sessions))
     }
 
     async fn get_session_status(&self, session: &ProofSession) -> anyhow::Result<SessionStatus> {
@@ -413,11 +418,13 @@ impl NetworkBackend {
         }
     }
 
-    async fn submit_aggregation_proof(
+    /// Submit a stage-2 aggregation proof to the SP1 Network and return the
+    /// [`CreateProofSession`] describing the resulting SNARK row. The caller (via
+    /// [`SnarkSession::run_if_needed`]) is responsible for activating the reserved DB row.
+    async fn build_aggregation_session(
         &self,
         proof_request: &ProofRequest,
-        repo: &ProofRequestRepo,
-    ) -> anyhow::Result<()> {
+    ) -> anyhow::Result<CreateProofSession> {
         let BackendConfig::Network { network_prover, agg_pk, range_vk, .. } = &self.config else {
             unreachable!("validated in constructor");
         };
@@ -504,21 +511,17 @@ impl NetworkBackend {
             "proof_id": proof_id.to_string(),
         });
 
-        let session = CreateProofSession {
+        info!(
+            proof_request_id = %proof_request.id,
+            "built SNARK proof session for aggregation"
+        );
+
+        Ok(CreateProofSession {
             proof_request_id: proof_request.id,
             session_type: SessionType::Snark,
             backend_session_id: proof_id.to_string(),
             metadata: Some(metadata),
-        };
-
-        repo.create_proof_session(session).await?;
-
-        info!(
-            proof_request_id = %proof_request.id,
-            "created SNARK proof session for aggregation"
-        );
-
-        Ok(())
+        })
     }
 }
 

--- a/crates/proof/zk/service/src/backends/op_succinct/snark_session.rs
+++ b/crates/proof/zk/service/src/backends/op_succinct/snark_session.rs
@@ -1,0 +1,142 @@
+//! SNARK session reservation helpers.
+
+use std::future::Future;
+
+use base_zk_db::{
+    CreateProofSession, ProofRequest, ProofRequestRepo, ProofSession, ProofType,
+    SessionStatus as DbSessionStatus, SessionType,
+};
+use tracing::warn;
+
+/// Result of [`SnarkSession::run_if_needed`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SnarkSessionRunOutcome {
+    /// No SNARK stage to start for this proof request and session list.
+    NotNeeded,
+    /// Another worker holds the active reservation or session; this caller did not insert a row.
+    ReservationNotAcquired,
+    /// Reserved row was updated to `RUNNING` with the backend session id from `submit`.
+    Activated,
+    /// `submit` succeeded but the reservation row was no longer eligible to activate (reaper or race).
+    ActivationDidNotApply,
+}
+
+impl SnarkSessionRunOutcome {
+    /// Whether the caller should re-load sessions from the database before inferring status.
+    pub const fn should_refresh_sessions(self) -> bool {
+        !matches!(self, Self::NotNeeded)
+    }
+}
+
+/// Helper for atomically claiming and activating the SNARK aggregation stage.
+#[derive(Debug)]
+pub struct SnarkSession;
+
+impl SnarkSession {
+    /// Return true when a proof request has completed STARK work and needs a SNARK session.
+    ///
+    /// Any existing SNARK session (including `Failed`) is treated as "already done": a failed
+    /// SNARK is intentionally terminal, and retries happen by creating a new proof request.
+    pub fn should_start(proof_request: &ProofRequest, sessions: &[ProofSession]) -> bool {
+        if proof_request.proof_type != ProofType::OpSuccinctSp1ClusterSnarkGroth16 {
+            return false;
+        }
+
+        let has_stark_completed = sessions.iter().any(|s| {
+            s.session_type == SessionType::Stark && s.status == DbSessionStatus::Completed
+        });
+        let has_snark_session = sessions.iter().any(|s| s.session_type == SessionType::Snark);
+
+        has_stark_completed && !has_snark_session
+    }
+
+    /// Reserve the SNARK slot, run `submit`, and activate (or fail) the row atomically.
+    ///
+    /// `submit` is only invoked when this caller wins the reservation race, which is what
+    /// prevents duplicate Groth16 jobs from being enqueued.
+    pub async fn run_if_needed<F, Fut>(
+        repo: &ProofRequestRepo,
+        proof_request: &ProofRequest,
+        sessions: &[ProofSession],
+        submit: F,
+    ) -> anyhow::Result<SnarkSessionRunOutcome>
+    where
+        F: FnOnce() -> Fut,
+        Fut: Future<Output = anyhow::Result<CreateProofSession>>,
+    {
+        if !Self::should_start(proof_request, sessions) {
+            return Ok(SnarkSessionRunOutcome::NotNeeded);
+        }
+
+        let Some(reservation_id) =
+            repo.reserve_proof_session(proof_request.id, SessionType::Snark).await?
+        else {
+            return Ok(SnarkSessionRunOutcome::ReservationNotAcquired);
+        };
+
+        match submit().await {
+            Ok(session) => {
+                let backend_session_id = session.backend_session_id.clone();
+                let activated = match repo
+                    .activate_reserved_proof_session(&reservation_id, session)
+                    .await
+                {
+                    Ok(v) => v,
+                    Err(e) => {
+                        let error_message = format!(
+                            "failed to activate reserved SNARK session after submission: {e}"
+                        );
+                        if let Err(fail_err) = repo
+                            .fail_reserved_proof_session(
+                                proof_request.id,
+                                SessionType::Snark,
+                                &reservation_id,
+                                &error_message,
+                            )
+                            .await
+                        {
+                            warn!(
+                                proof_request_id = %proof_request.id,
+                                reservation_id = %reservation_id,
+                                error = %fail_err,
+                                "failed to mark reserved SNARK proof session as failed after activation error"
+                            );
+                        }
+                        return Err(e.into());
+                    }
+                };
+
+                if !activated {
+                    warn!(
+                        proof_request_id = %proof_request.id,
+                        reservation_id = %reservation_id,
+                        backend_session_id = %backend_session_id,
+                        "SNARK reservation was cleaned up before activation; backend job may still run"
+                    );
+                    return Ok(SnarkSessionRunOutcome::ActivationDidNotApply);
+                }
+                Ok(SnarkSessionRunOutcome::Activated)
+            }
+            Err(e) => {
+                let error_message = format!("failed to submit aggregation proof: {e}");
+                if let Err(fail_err) = repo
+                    .fail_reserved_proof_session(
+                        proof_request.id,
+                        SessionType::Snark,
+                        &reservation_id,
+                        &error_message,
+                    )
+                    .await
+                {
+                    warn!(
+                        proof_request_id = %proof_request.id,
+                        reservation_id = %reservation_id,
+                        error = %fail_err,
+                        "failed to mark reserved SNARK proof session as failed"
+                    );
+                }
+                Err(e)
+            }
+        }
+    }
+}

--- a/crates/proof/zk/service/src/lib.rs
+++ b/crates/proof/zk/service/src/lib.rs
@@ -5,8 +5,8 @@ mod backends;
 pub use backends::{
     ArtifactClientWrapper, ArtifactStorageConfig, BackendConfig, BackendRegistry, BackendType,
     L1HeadCalculator, OpSuccinctClusterBackend, OpSuccinctMockBackend, OpSuccinctNetworkBackend,
-    OpSuccinctProvider, OpSuccinctWitnessParams, ProofProcessingResult, ProveResult,
-    ProvingBackend, SessionStatus,
+    OpSuccinctProvider, OpSuccinctSnarkSession, OpSuccinctSnarkSessionRunOutcome,
+    OpSuccinctWitnessParams, ProofProcessingResult, ProveResult, ProvingBackend, SessionStatus,
 };
 
 pub mod metrics;

--- a/crates/proof/zk/service/src/worker/prover_worker.rs
+++ b/crates/proof/zk/service/src/worker/prover_worker.rs
@@ -113,7 +113,7 @@ impl ProverWorker {
                             warn!(
                                 proof_request_id = %self.proof_request_id,
                                 backend_session_id = %session_id,
-                                "Could not transition to RUNNING — request no longer PENDING (race with stuck detector?)"
+                                "Could not transition to RUNNING — request not pending or concurrent active session"
                             );
                             return Ok(());
                         }


### PR DESCRIPTION
Add partial unique index on (proof_request_id, session_type) for active (SUBMITTING/RUNNING) sessions so retries keep terminal rows as history.

Add reserve_proof_session / activate_reserved_proof_session / fail_reserved_proof_session and SnarkSession::run_if_needed so cluster, network, and mock backends serialize SNARK aggregation enqueue.

Extend SessionStatus with Submitting; treat SUBMITTING like RUNNING when detecting stuck PENDING requests.

Includes succinct ELF manifest update for bundled artifacts.