### PR TITLE
fix(proof): gate Holocene deposit-only fallback on protocol-invalid errors

### DIFF
--- a/crates/proof/driver/src/core.rs
+++ b/crates/proof/driver/src/core.rs
@@ -106,38 +106,43 @@ where
                 Err(e) => {
                     error!(target: "client", error = %e, "Failed to execute L2 block");
 
-                    if cfg.is_holocene_active(attributes.payload_attributes.timestamp) {
-                        // Retry with a deposit-only block.
-                        warn!(target: "client", "Flushing current channel and retrying deposit only block");
-
-                        // Flush the current batch and channel - if a block was replaced with a
-                        // deposit-only block due to execution failure, the
-                        // batch and channel it is contained in is forwards
-                        // invalidated.
-                        self.pipeline.signal(Signal::FlushChannel).await?;
-
-                        // Strip out all transactions that are not deposits.
-                        attributes.transactions = attributes.transactions.map(|txs| {
-                            txs.into_iter()
-                                .filter(|tx| !tx.is_empty() && tx[0] == OpTxType::Deposit as u8)
-                                .collect::<Vec<_>>()
-                        });
-
-                        // Retry the execution.
-                        self.executor.update_safe_head(tip_cursor.l2_safe_head_header.clone());
-                        match self.executor.execute_payload(attributes.clone()).await {
-                            Ok(header) => header,
-                            Err(e) => {
-                                error!(
-                                    target: "client",
-                                    "Critical - Failed to execute deposit-only block: {e}",
-                                );
-                                return Err(DriverError::Executor(e));
-                            }
-                        }
-                    } else {
+                    if !cfg.is_holocene_active(attributes.payload_attributes.timestamp) {
                         // Pre-Holocene, discard the block if execution fails.
                         continue;
+                    }
+
+                    if !E::is_deposit_only_retryable(&e) {
+                        return Err(DriverError::Executor(e));
+                    }
+
+                    // Retry with a deposit-only block.
+                    warn!(target: "client", "Flushing current channel and retrying deposit only block");
+
+                    // Flush the current batch and channel - if a block was replaced with a
+                    // deposit-only block due to execution failure, the
+                    // batch and channel it is contained in is forwards
+                    // invalidated.
+                    self.pipeline.signal(Signal::FlushChannel).await?;
+
+                    // Strip out all transactions that are not deposits.
+                    attributes.transactions = attributes.transactions.map(|txs| {
+                        txs.into_iter()
+                            .filter(|tx| !tx.is_empty() && tx[0] == OpTxType::Deposit as u8)
+                            .collect::<Vec<_>>()
+                    });
+
+                    // Retry the execution.
+                    self.executor.update_safe_head(tip_cursor.l2_safe_head_header.clone());
+                    match self.executor.execute_payload(attributes.clone()).await {
+                        Ok(header) => header,
+                        Err(e) => {
+                            error!(
+                                target: "client",
+                                error = %e,
+                                "Critical - Failed to execute deposit-only block",
+                            );
+                            return Err(DriverError::Executor(e));
+                        }
                     }
                 }
             };

--- a/crates/proof/driver/src/executor.rs
+++ b/crates/proof/driver/src/executor.rs
@@ -26,6 +26,11 @@ pub trait Executor {
     /// The error type for the Executor.
     type Error: Error;
 
+    /// Returns whether the provided error should trigger Holocene deposit-only recovery.
+    fn is_deposit_only_retryable(_error: &Self::Error) -> bool {
+        false
+    }
+
     /// Waits for the executor to be ready for block execution.
     async fn wait_until_ready(&mut self);
 

--- a/crates/proof/executor/src/errors.rs
+++ b/crates/proof/executor/src/errors.rs
@@ -203,6 +203,25 @@ pub enum ExecutorError {
     MissingExecutor,
 }
 
+impl ExecutorError {
+    /// Returns whether this error represents an invalid payload that may use Holocene
+    /// deposit-only recovery.
+    ///
+    /// Only errors caused by per-transaction invalidity are eligible: stripping
+    /// non-deposit transactions cannot rescue a block whose header/attribute fields are
+    /// themselves invalid (e.g. `InvalidExtraData`, `MissingEIP1559Params`), so those
+    /// propagate as a hard halt instead.
+    pub const fn is_deposit_only_retryable(&self) -> bool {
+        matches!(
+            self,
+            Self::BlockGasLimitExceeded
+                | Self::UnsupportedTransactionType(_)
+                | Self::ExecutionError(BlockExecutionError::Validation(_))
+                | Self::Recovery(_)
+        )
+    }
+}
+
 /// Result type alias for operations that may fail with [`ExecutorError`].
 pub type ExecutorResult<T> = Result<T, ExecutorError>;
 
@@ -254,5 +273,54 @@ impl DBErrorMarker for TrieDBError {}
 impl From<EIP1559ParamError> for ExecutorError {
     fn from(err: EIP1559ParamError) -> Self {
         Self::InvalidExtraData(Eip1559ValidationError::Decode(err))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_evm::block::{
+        BlockExecutionError, BlockValidationError, InternalBlockExecutionError,
+    };
+
+    use super::*;
+
+    #[test]
+    fn invalid_payload_errors_are_deposit_only_retryable() {
+        let errors = [
+            ExecutorError::BlockGasLimitExceeded,
+            ExecutorError::UnsupportedTransactionType(0xff),
+            ExecutorError::ExecutionError(BlockExecutionError::Validation(
+                BlockValidationError::msg("invalid payload"),
+            )),
+            ExecutorError::Recovery(Default::default()),
+        ];
+
+        for error in errors {
+            assert!(error.is_deposit_only_retryable());
+        }
+    }
+
+    #[test]
+    fn witness_and_internal_errors_are_not_deposit_only_retryable() {
+        let errors = [
+            // Block/attribute-level fields — stripping non-deposit txs cannot rescue them.
+            ExecutorError::MissingGasLimit,
+            ExecutorError::MissingTransactions,
+            ExecutorError::MissingEIP1559Params,
+            ExecutorError::MissingParentBeaconBlockRoot,
+            ExecutorError::InvalidExtraData(Eip1559ValidationError::ZeroDenominator),
+            // Witness-level / prover-influenced — must not trigger silent recovery.
+            ExecutorError::TrieDBError(TrieDBError::Provider("missing preimage".to_string())),
+            ExecutorError::ExecutionError(BlockExecutionError::Internal(
+                InternalBlockExecutionError::msg("internal executor error"),
+            )),
+            // Transaction decoding and executor lifecycle — not per-tx-validity issues.
+            ExecutorError::RLPError(alloy_eips::eip2718::Eip2718Error::UnexpectedType(0xff)),
+            ExecutorError::MissingExecutor,
+        ];
+
+        for error in errors {
+            assert!(!error.is_deposit_only_retryable());
+        }
     }
 }

--- a/crates/proof/proof/src/executor.rs
+++ b/crates/proof/proof/src/executor.rs
@@ -64,6 +64,10 @@ where
 {
     type Error = base_proof_executor::ExecutorError;
 
+    fn is_deposit_only_retryable(error: &Self::Error) -> bool {
+        error.is_deposit_only_retryable()
+    }
+
     /// Waits for the executor to be ready.
     async fn wait_until_ready(&mut self) {
         /* no-op for the stateless executor */

--- a/crates/proof/succinct/utils/client/src/client.rs
+++ b/crates/proof/succinct/utils/client/src/client.rs
@@ -123,40 +123,45 @@ where
         let outcome = match driver.executor.execute_payload(attributes.clone()).await {
             Ok(outcome) => outcome,
             Err(e) => {
-                error!(target: "client", "Failed to execute L2 block: {}", e);
+                error!(target: "client", error = %e, "Failed to execute L2 block");
 
-                if cfg.is_holocene_active(attributes.payload_attributes.timestamp) {
-                    // Retry with a deposit-only block.
-                    warn!(target: "client", "Flushing current channel and retrying deposit only block");
-
-                    // Flush the current batch and channel - if a block was replaced with a
-                    // deposit-only block due to execution failure, the
-                    // batch and channel it is contained in is forwards
-                    // invalidated.
-                    driver.pipeline.signal(Signal::FlushChannel).await?;
-
-                    // Strip out all transactions that are not deposits.
-                    attributes.transactions = attributes.transactions.map(|txs: Vec<Bytes>| {
-                        txs.into_iter()
-                            .filter(|tx| !tx.is_empty() && tx[0] == OpTxType::Deposit as u8)
-                            .collect::<Vec<_>>()
-                    });
-
-                    // Retry the execution.
-                    driver.executor.update_safe_head(tip_cursor.l2_safe_head_header.clone());
-                    match driver.executor.execute_payload(attributes.clone()).await {
-                        Ok(header) => header,
-                        Err(e) => {
-                            error!(
-                                target: "client",
-                                "Critical - Failed to execute deposit-only block: {e}",
-                            );
-                            return Err(DriverError::Executor(e));
-                        }
-                    }
-                } else {
+                if !cfg.is_holocene_active(attributes.payload_attributes.timestamp) {
                     // Pre-Holocene, discard the block if execution fails.
                     continue;
+                }
+
+                if !E::is_deposit_only_retryable(&e) {
+                    return Err(DriverError::Executor(e));
+                }
+
+                // Retry with a deposit-only block.
+                warn!(target: "client", "Flushing current channel and retrying deposit only block");
+
+                // Flush the current batch and channel - if a block was replaced with a
+                // deposit-only block due to execution failure, the
+                // batch and channel it is contained in is forwards
+                // invalidated.
+                driver.pipeline.signal(Signal::FlushChannel).await?;
+
+                // Strip out all transactions that are not deposits.
+                attributes.transactions = attributes.transactions.map(|txs: Vec<Bytes>| {
+                    txs.into_iter()
+                        .filter(|tx| !tx.is_empty() && tx[0] == OpTxType::Deposit as u8)
+                        .collect::<Vec<_>>()
+                });
+
+                // Retry the execution.
+                driver.executor.update_safe_head(tip_cursor.l2_safe_head_header.clone());
+                match driver.executor.execute_payload(attributes.clone()).await {
+                    Ok(header) => header,
+                    Err(e) => {
+                        error!(
+                            target: "client",
+                            error = %e,
+                            "Critical - Failed to execute deposit-only block",
+                        );
+                        return Err(DriverError::Executor(e));
+                    }
                 }
             }
         };


### PR DESCRIPTION
The Holocene fallback in the driver and the SP1 guest previously caught any execute_payload error and retried the block as deposit-only. A malicious prover could therefore omit state, code, or storage preimages, force the executor to error, and prove a deposit-only output root for an L1 origin whose canonical derivation includes user transactions.

Restrict the fallback to errors that can only originate from a protocol-invalid derived payload (block gas limit exceeded, unsupported tx type, block validation errors, signature recovery). Witness-incompleteness and internal executor errors (TrieDB, BlockExecutionError::Internal, missing/invalid fields) now propagate as DriverError::Executor, halting derivation instead of silently dropping non-deposit transactions.

The classification is added as a default-false method on the Executor trait so any custom executor is fail-closed by default.