### PR TITLE
fix(proof): tolerate KeyNotFound when removing destroyed accounts in TrieDB

### DIFF
--- a/crates/proof/executor/src/db/mod.rs
+++ b/crates/proof/executor/src/db/mod.rs
@@ -176,15 +176,22 @@ where
             // Compute the path to the account in the trie.
             let account_path = Nibbles::unpack(hashed_address.as_slice());
 
-            // If the account was destroyed, delete it from the trie.
+            // If the account was destroyed, delete it from the trie and wipe its storage.
+            // For DestroyedChanged accounts the account was re-created after destruction, so
+            // fall through to re-insert the new state rather than skipping it.
+            let maybe_account_info = bundle_account.account_info();
             if bundle_account.was_destroyed() {
-                self.root_node.delete(&account_path, &self.fetcher)?;
+                match self.root_node.delete(&account_path, &self.fetcher) {
+                    Ok(()) | Err(TrieNodeError::KeyNotFound) => {}
+                    Err(e) => return Err(e.into()),
+                }
                 self.storage_roots.remove(address);
-                continue;
+                if maybe_account_info.is_none() {
+                    continue;
+                }
             }
 
-            let account_info =
-                bundle_account.account_info().ok_or(TrieDBError::MissingAccountInfo)?;
+            let account_info = maybe_account_info.ok_or(TrieDBError::MissingAccountInfo)?;
 
             let mut trie_account = TrieAccount {
                 balance: account_info.balance,
@@ -240,8 +247,12 @@ where
 
         let hashed_slot_key = Nibbles::unpack(hashed_key.as_slice());
         if value.present_value.is_zero() {
-            // If the storage slot is being set to zero, prune it from the trie.
-            storage_root.delete(&hashed_slot_key, fetcher)?;
+            // Prune the slot; tolerate a no-op delete (e.g. zeroing write after a
+            // DestroyedChanged storage wipe leaves an empty trie).
+            match storage_root.delete(&hashed_slot_key, fetcher) {
+                Ok(()) | Err(TrieNodeError::KeyNotFound) => {}
+                Err(e) => return Err(e.into()),
+            }
         } else {
             // RLP encode the storage slot value and update the trie.
             let mut rlp_buf = Vec::with_capacity(value.present_value.length());
@@ -349,8 +360,9 @@ where
 #[cfg(test)]
 mod tests {
     use alloy_consensus::Sealable;
-    use alloy_primitives::b256;
+    use alloy_primitives::{U256, b256};
     use base_proof_mpt::NoopTrieHinter;
+    use revm::database::{AccountStatus, BundleAccount, states::StorageSlot as RvmStorageSlot};
 
     use super::*;
 
@@ -408,5 +420,178 @@ mod tests {
             block_hash,
             b256!("78dec18c6d7da925bbe773c315653cdc70f6444ed6c1de9ac30bdb36cff74c3b")
         );
+    }
+
+    fn bundle_with_account(address: Address, account: BundleAccount) -> BundleState {
+        let mut state = revm::primitives::HashMap::default();
+        state.insert(address, account);
+        BundleState { state, ..Default::default() }
+    }
+
+    // Pre-populate the trie with a live account so that subsequent destroy bundles have
+    // something to delete (TrieNode::delete errors on a missing key).
+    fn insert_account(db: &mut TrieDB<NoopTrieDBProvider, NoopTrieHinter>, address: Address) {
+        let account = BundleAccount::new(
+            None,
+            Some(AccountInfo { balance: U256::from(100u64), ..Default::default() }),
+            Default::default(),
+            AccountStatus::InMemoryChange,
+        );
+        db.state_root(&bundle_with_account(address, account)).unwrap();
+    }
+
+    // A destroyed account (info = None) that already lived in the parent trie must be
+    // removed from the state root for every revm status that maps to "account is gone".
+    #[test]
+    fn test_destroyed_accounts_removed_from_trie() {
+        for status in [AccountStatus::Destroyed, AccountStatus::DestroyedAgain] {
+            let mut db = new_test_db();
+            let address = Address::repeat_byte(0x01);
+            insert_account(&mut db, address);
+
+            let root = db
+                .state_root(&bundle_with_account(
+                    address,
+                    BundleAccount::new(
+                        Some(AccountInfo::default()),
+                        None,
+                        Default::default(),
+                        status,
+                    ),
+                ))
+                .unwrap();
+            assert_eq!(root, EMPTY_ROOT_HASH, "{status:?} account must not appear in trie");
+        }
+    }
+
+    // A DestroyedChanged account (destroyed then given a new balance) must appear in the state
+    // root with its new state.
+    #[test]
+    fn test_destroyed_changed_account_reinserted() {
+        let mut db = new_test_db();
+        let address = Address::repeat_byte(0x02);
+        insert_account(&mut db, address);
+
+        let new_info =
+            AccountInfo { balance: U256::from(1_000_000_000_000_000_000u64), ..Default::default() };
+        let root = db
+            .state_root(&bundle_with_account(
+                address,
+                BundleAccount::new(
+                    Some(AccountInfo::default()),
+                    Some(new_info),
+                    Default::default(),
+                    AccountStatus::DestroyedChanged,
+                ),
+            ))
+            .unwrap();
+        assert_ne!(root, EMPTY_ROOT_HASH, "DestroyedChanged account must be re-inserted into trie");
+    }
+
+    // A DestroyedChanged account with new storage slots must have those slots present in the
+    // trie — this exercises the or_insert_with(EMPTY_ROOT_HASH) + storage loop path and
+    // confirms the old storage is wiped and only new slots survive.
+    #[test]
+    fn test_destroyed_changed_account_storage_wiped_and_reinserted() {
+        let mut db = new_test_db();
+        let address = Address::repeat_byte(0x04);
+        insert_account(&mut db, address);
+
+        // Re-create the account with one new storage slot.
+        let mut storage = revm::primitives::HashMap::default();
+        let slot_key = U256::from(1u64);
+        storage.insert(slot_key, RvmStorageSlot::new_changed(U256::ZERO, U256::from(42u64)));
+        let new_info =
+            AccountInfo { balance: U256::from(1_000_000_000_000_000_000u64), ..Default::default() };
+        let root = db
+            .state_root(&bundle_with_account(
+                address,
+                BundleAccount::new(
+                    Some(AccountInfo::default()),
+                    Some(new_info),
+                    storage,
+                    AccountStatus::DestroyedChanged,
+                ),
+            ))
+            .unwrap();
+        assert_ne!(
+            root, EMPTY_ROOT_HASH,
+            "DestroyedChanged account with storage must appear in trie"
+        );
+    }
+
+    // A DestroyedChanged account that was never in the parent trie (e.g. CREATE+SELFDESTRUCT+
+    // re-CREATE in a single block) must not fail when the delete is a no-op.
+    #[test]
+    fn test_destroyed_changed_new_account_never_in_trie() {
+        let mut db = new_test_db();
+        let address = Address::repeat_byte(0x05);
+        // No insert_account — this address has never existed in the parent trie.
+
+        let new_info =
+            AccountInfo { balance: U256::from(1_000_000_000_000_000_000u64), ..Default::default() };
+        let root = db
+            .state_root(&bundle_with_account(
+                address,
+                BundleAccount::new(
+                    None,
+                    Some(new_info),
+                    Default::default(),
+                    AccountStatus::DestroyedChanged,
+                ),
+            ))
+            .unwrap();
+        assert_ne!(
+            root, EMPTY_ROOT_HASH,
+            "DestroyedChanged account never in parent trie must be re-inserted"
+        );
+    }
+
+    // A zeroing storage write on a DestroyedChanged account must tolerate the
+    // post-wipe empty storage trie.
+    #[test]
+    fn test_destroyed_changed_account_zeroing_storage_on_empty_trie() {
+        let mut db = new_test_db();
+        let address = Address::repeat_byte(0x08);
+        insert_account(&mut db, address);
+
+        let mut storage = revm::primitives::HashMap::default();
+        storage.insert(U256::from(1u64), RvmStorageSlot::new_changed(U256::from(5u64), U256::ZERO));
+        let new_info =
+            AccountInfo { balance: U256::from(1_000_000_000_000_000_000u64), ..Default::default() };
+        let root = db
+            .state_root(&bundle_with_account(
+                address,
+                BundleAccount::new(
+                    Some(AccountInfo::default()),
+                    Some(new_info),
+                    storage,
+                    AccountStatus::DestroyedChanged,
+                ),
+            ))
+            .unwrap();
+        assert_ne!(
+            root, EMPTY_ROOT_HASH,
+            "DestroyedChanged account with a zeroing storage write must not abort state_root",
+        );
+    }
+
+    // A destroyed account whose address was never written to the parent trie (e.g.
+    // CREATE+SELFDESTRUCT within a single block) must not abort state_root when the
+    // delete is a no-op, for every revm status that maps to "account is gone".
+    #[test]
+    fn test_destroyed_accounts_never_in_trie() {
+        for status in [AccountStatus::Destroyed, AccountStatus::DestroyedAgain] {
+            let mut db = new_test_db();
+            let address = Address::repeat_byte(0x06);
+
+            let root = db
+                .state_root(&bundle_with_account(
+                    address,
+                    BundleAccount::new(None, None, Default::default(), status),
+                ))
+                .unwrap();
+            assert_eq!(root, EMPTY_ROOT_HASH, "fresh {status:?} account must not appear in trie");
+        }
     }
 }


### PR DESCRIPTION
## Summary

- `TrieDB::update_accounts` previously aborted `state_root` (and therefore block proving) whenever `TrieNode::delete` returned `KeyNotFound` for a destroyed account whose address was never written to the parent state trie. revm can produce such bundle entries when a warmup transaction promotes an entry to `Destroyed`/`DestroyedAgain` in the same block as a CREATE+SELFDESTRUCT pair, so this halts L1 finalization for routine on-chain activity.
- The destroyed-account branch now tolerates `KeyNotFound` on delete and only short-circuits when the bundle has no new account info. `DestroyedChanged` (account destroyed and re-created in the same block) now falls through to the regular re-insertion path with its new state.

Made with [Cursor](https://cursor.com)