### PR TITLE
fix(flashblocks): fix unwrap panic and u64 underflow in build_pending_state

### DIFF
--- a/crates/execution/flashblocks/src/processor.rs
+++ b/crates/execution/flashblocks/src/processor.rs
@@ -356,8 +356,11 @@ where
                 .push(flashblock.clone());
         }
 
-        let earliest_block_number = flashblocks_per_block.keys().min().unwrap();
-        let canonical_block = earliest_block_number - 1;
+        let earliest_block_number = match flashblocks_per_block.keys().min() {
+            Some(n) => *n,
+            None => return Ok(None),
+        };
+        let canonical_block = earliest_block_number.saturating_sub(1);
         let mut last_block_header = self
             .client
             .header_by_number(canonical_block)


### PR DESCRIPTION
## Summary

Fixes two bugs in `build_pending_state` (`crates/execution/flashblocks/src/processor.rs` lines 359–360) reported in #2617.

## Bug 1 — Panic on empty input

```rust
let earliest_block_number = flashblocks_per_block.keys().min().unwrap(); // panics on empty
```

When the `flashblocks` slice is empty (malformed upstream message or sequencer restart), `keys().min()` returns `None` and `.unwrap()` panics. Since `build_pending_state` is called from the core async `StateProcessor::start()` event loop, this panic takes down the entire pending-state subsystem.

## Bug 2 — u64 underflow

```rust
let canonical_block = earliest_block_number - 1; // wraps to u64::MAX when block_number == 0
```

If a flashblock arrives with `block_number == 0`, this wraps to `u64::MAX`, producing a corrupted provider lookup instead of a clean error.

## Fix

```rust
let earliest_block_number = match flashblocks_per_block.keys().min() {
    Some(n) => *n,
    None => return Ok(None),
};
let canonical_block = earliest_block_number.saturating_sub(1);
```

- Empty input returns `Ok(None)` cleanly instead of panicking
- `saturating_sub(1)` is consistent with `db/store.rs` line 918 which already uses this pattern

Fixes #2617