### PR TITLE
perf(trie): share one MDBX read tx across cursors per proof/witness request

### DIFF
--- a/crates/execution/trie/src/api.rs
+++ b/crates/execution/trie/src/api.rs
@@ -92,9 +92,7 @@ pub trait BaseProofsStore: Send + Sync + Debug {
     /// Read-only transaction reused across cursor calls within one request.
     ///
     /// Proof, state-root, and witness paths open one [`Self::Tx`] at entry and pass it
-    /// to every cursor allocation that follows, eliminating the per-cursor MDBX
-    /// `mdbx_txn_begin_ex` → `lck_rdt_lock` mutex contention that reth PR #22631 fixes
-    /// upstream via tx pooling.
+    /// to every cursor allocation that follows.
     type Tx: Debug + Send + Sync;
 
     /// Get the earliest block number and hash that has been stored
@@ -132,7 +130,7 @@ pub trait BaseProofsStore: Send + Sync + Debug {
         max_block_number: u64,
     ) -> BaseProofsStorageResult<Self::AccountHashedCursor<'tx>>;
 
-    /// Open one read-only transaction for a proof/root/witness request.
+    /// Open one read-only transaction for a request-scoped cursor factory.
     fn ro_tx(&self) -> BaseProofsStorageResult<Self::Tx>;
 
     /// Storage trie cursor reusing `tx`.

--- a/crates/execution/trie/src/api.rs
+++ b/crates/execution/trie/src/api.rs
@@ -95,9 +95,7 @@ pub trait BaseProofsStore: Send + Sync + Debug {
     /// to every cursor allocation that follows, eliminating the per-cursor MDBX
     /// `mdbx_txn_begin_ex` → `lck_rdt_lock` mutex contention that reth PR #22631 fixes
     /// upstream via tx pooling.
-    type Tx<'tx>: Debug + Send + Sync
-    where
-        Self: 'tx;
+    type Tx: Debug + Send + Sync;
 
     /// Get the earliest block number and hash that has been stored
     ///
@@ -135,45 +133,45 @@ pub trait BaseProofsStore: Send + Sync + Debug {
     ) -> BaseProofsStorageResult<Self::AccountHashedCursor<'tx>>;
 
     /// Open one read-only transaction for a proof/root/witness request.
-    fn ro_tx(&self) -> BaseProofsStorageResult<Self::Tx<'_>>;
+    fn ro_tx(&self) -> BaseProofsStorageResult<Self::Tx>;
 
     /// Storage trie cursor reusing `tx`.
-    fn storage_trie_cursor_with_tx<'a, 'tx>(
+    fn storage_trie_cursor_with_tx<'tx>(
         &self,
-        tx: &'a Self::Tx<'tx>,
+        tx: &'tx Self::Tx,
         hashed_address: B256,
         max_block_number: u64,
-    ) -> BaseProofsStorageResult<Self::StorageTrieCursor<'a>>
+    ) -> BaseProofsStorageResult<Self::StorageTrieCursor<'tx>>
     where
-        Self: 'a + 'tx;
+        Self: 'tx;
 
     /// Account trie cursor reusing `tx`.
-    fn account_trie_cursor_with_tx<'a, 'tx>(
+    fn account_trie_cursor_with_tx<'tx>(
         &self,
-        tx: &'a Self::Tx<'tx>,
+        tx: &'tx Self::Tx,
         max_block_number: u64,
-    ) -> BaseProofsStorageResult<Self::AccountTrieCursor<'a>>
+    ) -> BaseProofsStorageResult<Self::AccountTrieCursor<'tx>>
     where
-        Self: 'a + 'tx;
+        Self: 'tx;
 
     /// Storage hashed cursor reusing `tx`.
-    fn storage_hashed_cursor_with_tx<'a, 'tx>(
+    fn storage_hashed_cursor_with_tx<'tx>(
         &self,
-        tx: &'a Self::Tx<'tx>,
+        tx: &'tx Self::Tx,
         hashed_address: B256,
         max_block_number: u64,
-    ) -> BaseProofsStorageResult<Self::StorageCursor<'a>>
+    ) -> BaseProofsStorageResult<Self::StorageCursor<'tx>>
     where
-        Self: 'a + 'tx;
+        Self: 'tx;
 
     /// Account hashed cursor reusing `tx`.
-    fn account_hashed_cursor_with_tx<'a, 'tx>(
+    fn account_hashed_cursor_with_tx<'tx>(
         &self,
-        tx: &'a Self::Tx<'tx>,
+        tx: &'tx Self::Tx,
         max_block_number: u64,
-    ) -> BaseProofsStorageResult<Self::AccountHashedCursor<'a>>
+    ) -> BaseProofsStorageResult<Self::AccountHashedCursor<'tx>>
     where
-        Self: 'a + 'tx;
+        Self: 'tx;
 
     /// Store a batch of trie updates.
     ///

--- a/crates/execution/trie/src/api.rs
+++ b/crates/execution/trie/src/api.rs
@@ -89,6 +89,16 @@ pub trait BaseProofsStore: Send + Sync + Debug {
     where
         Self: 'tx;
 
+    /// Read-only transaction reused across cursor calls within one request.
+    ///
+    /// Proof, state-root, and witness paths open one [`Self::Tx`] at entry and pass it
+    /// to every cursor allocation that follows, eliminating the per-cursor MDBX
+    /// `mdbx_txn_begin_ex` → `lck_rdt_lock` mutex contention that reth PR #22631 fixes
+    /// upstream via tx pooling.
+    type Tx<'tx>: Debug + Send + Sync
+    where
+        Self: 'tx;
+
     /// Get the earliest block number and hash that has been stored
     ///
     /// This is used to determine the block number of trie nodes with block number 0.
@@ -123,6 +133,47 @@ pub trait BaseProofsStore: Send + Sync + Debug {
         &self,
         max_block_number: u64,
     ) -> BaseProofsStorageResult<Self::AccountHashedCursor<'tx>>;
+
+    /// Open one read-only transaction for a proof/root/witness request.
+    fn ro_tx(&self) -> BaseProofsStorageResult<Self::Tx<'_>>;
+
+    /// Storage trie cursor reusing `tx`.
+    fn storage_trie_cursor_with_tx<'a, 'tx>(
+        &self,
+        tx: &'a Self::Tx<'tx>,
+        hashed_address: B256,
+        max_block_number: u64,
+    ) -> BaseProofsStorageResult<Self::StorageTrieCursor<'a>>
+    where
+        Self: 'a + 'tx;
+
+    /// Account trie cursor reusing `tx`.
+    fn account_trie_cursor_with_tx<'a, 'tx>(
+        &self,
+        tx: &'a Self::Tx<'tx>,
+        max_block_number: u64,
+    ) -> BaseProofsStorageResult<Self::AccountTrieCursor<'a>>
+    where
+        Self: 'a + 'tx;
+
+    /// Storage hashed cursor reusing `tx`.
+    fn storage_hashed_cursor_with_tx<'a, 'tx>(
+        &self,
+        tx: &'a Self::Tx<'tx>,
+        hashed_address: B256,
+        max_block_number: u64,
+    ) -> BaseProofsStorageResult<Self::StorageCursor<'a>>
+    where
+        Self: 'a + 'tx;
+
+    /// Account hashed cursor reusing `tx`.
+    fn account_hashed_cursor_with_tx<'a, 'tx>(
+        &self,
+        tx: &'a Self::Tx<'tx>,
+        max_block_number: u64,
+    ) -> BaseProofsStorageResult<Self::AccountHashedCursor<'a>>
+    where
+        Self: 'a + 'tx;
 
     /// Store a batch of trie updates.
     ///

--- a/crates/execution/trie/src/api.rs
+++ b/crates/execution/trie/src/api.rs
@@ -89,10 +89,7 @@ pub trait BaseProofsStore: Send + Sync + Debug {
     where
         Self: 'tx;
 
-    /// Read-only transaction reused across cursor calls within one request.
-    ///
-    /// Proof, state-root, and witness paths open one [`Self::Tx`] at entry and pass it
-    /// to every cursor allocation that follows.
+    /// Transaction type used by request-scoped cursor factories.
     type Tx: Debug + Send + Sync;
 
     /// Get the earliest block number and hash that has been stored
@@ -130,7 +127,7 @@ pub trait BaseProofsStore: Send + Sync + Debug {
         max_block_number: u64,
     ) -> BaseProofsStorageResult<Self::AccountHashedCursor<'tx>>;
 
-    /// Open one read-only transaction for a request-scoped cursor factory.
+    /// Open a transaction for a request-scoped cursor factory.
     fn ro_tx(&self) -> BaseProofsStorageResult<Self::Tx>;
 
     /// Storage trie cursor reusing `tx`.

--- a/crates/execution/trie/src/cursor_factory.rs
+++ b/crates/execution/trie/src/cursor_factory.rs
@@ -91,6 +91,7 @@ impl<'tx, S: BaseProofsStore> BaseProofsHashedAccountCursorFactory<'tx, S> {
     }
 }
 
+
 impl<'tx, S> HashedCursorFactory for BaseProofsHashedAccountCursorFactory<'tx, S>
 where
     for<'a> S: BaseProofsStore + 'tx,

--- a/crates/execution/trie/src/cursor_factory.rs
+++ b/crates/execution/trie/src/cursor_factory.rs
@@ -91,7 +91,6 @@ impl<'tx, S: BaseProofsStore> BaseProofsHashedAccountCursorFactory<'tx, S> {
     }
 }
 
-
 impl<'tx, S> HashedCursorFactory for BaseProofsHashedAccountCursorFactory<'tx, S>
 where
     for<'a> S: BaseProofsStore + 'tx,

--- a/crates/execution/trie/src/cursor_factory.rs
+++ b/crates/execution/trie/src/cursor_factory.rs
@@ -1,6 +1,10 @@
 //! Implements [`TrieCursorFactory`] and [`HashedCursorFactory`] for [`BaseProofsStore`] types.
-
-use std::marker::PhantomData;
+//!
+//! Both factories borrow one read-only [`BaseProofsStore::Tx`] for their entire lifetime
+//! and route every cursor allocation through the `*_with_tx` fast path. This mirrors
+//! reth's own `DatabaseTrieCursorFactory` / `DatabaseHashedCursorFactory` pattern and is
+//! what lets proof, state-root, and witness requests acquire exactly one MDBX
+//! transaction.
 
 use alloy_primitives::B256;
 use reth_db::DatabaseError;
@@ -11,22 +15,29 @@ use crate::{
     BaseProofsStore, BaseProofsTrieCursor,
 };
 
-/// Factory for creating trie cursors for [`BaseProofsStore`].
+/// Request-scoped factory that opens trie cursors against a shared read-only transaction.
+///
+/// Holds a borrow of the transaction so every cursor allocation reuses the same MDBX
+/// reader slot. See [`BaseProofsStore::Tx`] for the underlying contention story.
 #[derive(Debug, Clone)]
-pub struct BaseProofsTrieCursorFactory<'tx, S: BaseProofsStore> {
-    storage: &'tx BaseProofsStorage<S>,
+pub struct BaseProofsTrieCursorFactory<'f, 'tx, S: BaseProofsStore + 'tx> {
+    storage: &'f BaseProofsStorage<S>,
+    tx: &'f <BaseProofsStorage<S> as BaseProofsStore>::Tx<'tx>,
     block_number: u64,
-    _marker: PhantomData<&'tx ()>,
 }
 
-impl<'tx, S: BaseProofsStore> BaseProofsTrieCursorFactory<'tx, S> {
-    /// Initializes new `BaseProofsTrieCursorFactory`
-    pub const fn new(storage: &'tx BaseProofsStorage<S>, block_number: u64) -> Self {
-        Self { storage, block_number, _marker: PhantomData }
+impl<'f, 'tx, S: BaseProofsStore + 'tx> BaseProofsTrieCursorFactory<'f, 'tx, S> {
+    /// Initializes a request-scoped trie cursor factory bound to `tx`.
+    pub const fn new(
+        storage: &'f BaseProofsStorage<S>,
+        tx: &'f <BaseProofsStorage<S> as BaseProofsStore>::Tx<'tx>,
+        block_number: u64,
+    ) -> Self {
+        Self { storage, tx, block_number }
     }
 }
 
-impl<'tx, S> TrieCursorFactory for BaseProofsTrieCursorFactory<'tx, S>
+impl<'f, 'tx, S> TrieCursorFactory for BaseProofsTrieCursorFactory<'f, 'tx, S>
 where
     for<'a> S: BaseProofsStore + 'tx,
 {
@@ -42,7 +53,7 @@ where
     fn account_trie_cursor(&self) -> Result<Self::AccountTrieCursor<'_>, DatabaseError> {
         Ok(BaseProofsTrieCursor::new(
             self.storage
-                .account_trie_cursor(self.block_number)
+                .account_trie_cursor_with_tx(self.tx, self.block_number)
                 .map_err(Into::<DatabaseError>::into)?,
         ))
     }
@@ -53,30 +64,36 @@ where
     ) -> Result<Self::StorageTrieCursor<'_>, DatabaseError> {
         Ok(BaseProofsTrieCursor::new(
             self.storage
-                .storage_trie_cursor(hashed_address, self.block_number)
+                .storage_trie_cursor_with_tx(self.tx, hashed_address, self.block_number)
                 .map_err(Into::<DatabaseError>::into)?,
         ))
     }
 }
 
-/// Factory for creating hashed account cursors for [`BaseProofsStore`].
+/// Request-scoped factory that opens hashed cursors against a shared read-only transaction.
+///
+/// Mirror of [`BaseProofsTrieCursorFactory`] for the hashed account/storage tries.
 #[derive(Debug, Clone)]
-pub struct BaseProofsHashedAccountCursorFactory<'tx, S: BaseProofsStore> {
-    storage: &'tx BaseProofsStorage<S>,
+pub struct BaseProofsHashedAccountCursorFactory<'f, 'tx, S: BaseProofsStore + 'tx> {
+    storage: &'f BaseProofsStorage<S>,
+    tx: &'f <BaseProofsStorage<S> as BaseProofsStore>::Tx<'tx>,
     block_number: u64,
-    _marker: PhantomData<&'tx ()>,
 }
 
-impl<'tx, S: BaseProofsStore> BaseProofsHashedAccountCursorFactory<'tx, S> {
-    /// Creates a new `BaseProofsHashedAccountCursorFactory` instance.
-    pub const fn new(storage: &'tx BaseProofsStorage<S>, block_number: u64) -> Self {
-        Self { storage, block_number, _marker: PhantomData }
+impl<'f, 'tx, S: BaseProofsStore + 'tx> BaseProofsHashedAccountCursorFactory<'f, 'tx, S> {
+    /// Initializes a request-scoped hashed cursor factory bound to `tx`.
+    pub const fn new(
+        storage: &'f BaseProofsStorage<S>,
+        tx: &'f <BaseProofsStorage<S> as BaseProofsStore>::Tx<'tx>,
+        block_number: u64,
+    ) -> Self {
+        Self { storage, tx, block_number }
     }
 }
 
-impl<'tx, S> HashedCursorFactory for BaseProofsHashedAccountCursorFactory<'tx, S>
+impl<'f, 'tx, S> HashedCursorFactory for BaseProofsHashedAccountCursorFactory<'f, 'tx, S>
 where
-    S: BaseProofsStore + 'tx,
+    for<'a> S: BaseProofsStore + 'tx,
 {
     type AccountCursor<'a>
         = BaseProofsHashedAccountCursor<S::AccountHashedCursor<'a>>
@@ -89,7 +106,7 @@ where
 
     fn hashed_account_cursor(&self) -> Result<Self::AccountCursor<'_>, DatabaseError> {
         Ok(BaseProofsHashedAccountCursor::new(
-            self.storage.account_hashed_cursor(self.block_number)?,
+            self.storage.account_hashed_cursor_with_tx(self.tx, self.block_number)?,
         ))
     }
 
@@ -97,8 +114,10 @@ where
         &self,
         hashed_address: B256,
     ) -> Result<Self::StorageCursor<'_>, DatabaseError> {
-        Ok(BaseProofsHashedStorageCursor::new(
-            self.storage.storage_hashed_cursor(hashed_address, self.block_number)?,
-        ))
+        Ok(BaseProofsHashedStorageCursor::new(self.storage.storage_hashed_cursor_with_tx(
+            self.tx,
+            hashed_address,
+            self.block_number,
+        )?))
     }
 }

--- a/crates/execution/trie/src/cursor_factory.rs
+++ b/crates/execution/trie/src/cursor_factory.rs
@@ -20,24 +20,24 @@ use crate::{
 /// Holds a borrow of the transaction so every cursor allocation reuses the same MDBX
 /// reader slot. See [`BaseProofsStore::Tx`] for the underlying contention story.
 #[derive(Debug, Clone)]
-pub struct BaseProofsTrieCursorFactory<'f, 'tx, S: BaseProofsStore + 'tx> {
-    storage: &'f BaseProofsStorage<S>,
-    tx: &'f <BaseProofsStorage<S> as BaseProofsStore>::Tx<'tx>,
+pub struct BaseProofsTrieCursorFactory<'tx, S: BaseProofsStore> {
+    storage: &'tx BaseProofsStorage<S>,
+    tx: &'tx <BaseProofsStorage<S> as BaseProofsStore>::Tx,
     block_number: u64,
 }
 
-impl<'f, 'tx, S: BaseProofsStore + 'tx> BaseProofsTrieCursorFactory<'f, 'tx, S> {
+impl<'tx, S: BaseProofsStore> BaseProofsTrieCursorFactory<'tx, S> {
     /// Initializes a request-scoped trie cursor factory bound to `tx`.
     pub const fn new(
-        storage: &'f BaseProofsStorage<S>,
-        tx: &'f <BaseProofsStorage<S> as BaseProofsStore>::Tx<'tx>,
+        storage: &'tx BaseProofsStorage<S>,
+        tx: &'tx <BaseProofsStorage<S> as BaseProofsStore>::Tx,
         block_number: u64,
     ) -> Self {
         Self { storage, tx, block_number }
     }
 }
 
-impl<'f, 'tx, S> TrieCursorFactory for BaseProofsTrieCursorFactory<'f, 'tx, S>
+impl<'tx, S> TrieCursorFactory for BaseProofsTrieCursorFactory<'tx, S>
 where
     for<'a> S: BaseProofsStore + 'tx,
 {
@@ -74,24 +74,24 @@ where
 ///
 /// Mirror of [`BaseProofsTrieCursorFactory`] for the hashed account/storage tries.
 #[derive(Debug, Clone)]
-pub struct BaseProofsHashedAccountCursorFactory<'f, 'tx, S: BaseProofsStore + 'tx> {
-    storage: &'f BaseProofsStorage<S>,
-    tx: &'f <BaseProofsStorage<S> as BaseProofsStore>::Tx<'tx>,
+pub struct BaseProofsHashedAccountCursorFactory<'tx, S: BaseProofsStore> {
+    storage: &'tx BaseProofsStorage<S>,
+    tx: &'tx <BaseProofsStorage<S> as BaseProofsStore>::Tx,
     block_number: u64,
 }
 
-impl<'f, 'tx, S: BaseProofsStore + 'tx> BaseProofsHashedAccountCursorFactory<'f, 'tx, S> {
+impl<'tx, S: BaseProofsStore> BaseProofsHashedAccountCursorFactory<'tx, S> {
     /// Initializes a request-scoped hashed cursor factory bound to `tx`.
     pub const fn new(
-        storage: &'f BaseProofsStorage<S>,
-        tx: &'f <BaseProofsStorage<S> as BaseProofsStore>::Tx<'tx>,
+        storage: &'tx BaseProofsStorage<S>,
+        tx: &'tx <BaseProofsStorage<S> as BaseProofsStore>::Tx,
         block_number: u64,
     ) -> Self {
         Self { storage, tx, block_number }
     }
 }
 
-impl<'f, 'tx, S> HashedCursorFactory for BaseProofsHashedAccountCursorFactory<'f, 'tx, S>
+impl<'tx, S> HashedCursorFactory for BaseProofsHashedAccountCursorFactory<'tx, S>
 where
     for<'a> S: BaseProofsStore + 'tx,
 {

--- a/crates/execution/trie/src/db/store.rs
+++ b/crates/execution/trie/src/db/store.rs
@@ -657,12 +657,9 @@ impl BaseProofsStore for MdbxProofsStorage {
         = MdbxAccountCursor<Dup<'tx, HashedAccountHistory>>
     where
         Self: 'tx;
-    type Tx<'a>
-        = <DatabaseEnv as Database>::TX
-    where
-        Self: 'a;
+    type Tx = <DatabaseEnv as Database>::TX;
 
-    fn ro_tx(&self) -> BaseProofsStorageResult<Self::Tx<'_>> {
+    fn ro_tx(&self) -> BaseProofsStorageResult<Self::Tx> {
         Ok(self.env.tx()?)
     }
 
@@ -716,54 +713,54 @@ impl BaseProofsStore for MdbxProofsStorage {
         Ok(MdbxAccountCursor::new(cursor, max_block_number))
     }
 
-    fn storage_trie_cursor_with_tx<'a, 'tx>(
+    fn storage_trie_cursor_with_tx<'tx>(
         &self,
-        tx: &'a Self::Tx<'tx>,
+        tx: &'tx Self::Tx,
         hashed_address: B256,
         max_block_number: u64,
-    ) -> BaseProofsStorageResult<Self::StorageTrieCursor<'a>>
+    ) -> BaseProofsStorageResult<Self::StorageTrieCursor<'tx>>
     where
-        Self: 'a + 'tx,
+        Self: 'tx,
     {
         let cursor = tx.cursor_dup_read::<StorageTrieHistory>()?;
 
         Ok(MdbxTrieCursor::new(cursor, max_block_number, Some(hashed_address)))
     }
 
-    fn account_trie_cursor_with_tx<'a, 'tx>(
+    fn account_trie_cursor_with_tx<'tx>(
         &self,
-        tx: &'a Self::Tx<'tx>,
+        tx: &'tx Self::Tx,
         max_block_number: u64,
-    ) -> BaseProofsStorageResult<Self::AccountTrieCursor<'a>>
+    ) -> BaseProofsStorageResult<Self::AccountTrieCursor<'tx>>
     where
-        Self: 'a + 'tx,
+        Self: 'tx,
     {
         let cursor = tx.cursor_dup_read::<AccountTrieHistory>()?;
 
         Ok(MdbxTrieCursor::new(cursor, max_block_number, None))
     }
 
-    fn storage_hashed_cursor_with_tx<'a, 'tx>(
+    fn storage_hashed_cursor_with_tx<'tx>(
         &self,
-        tx: &'a Self::Tx<'tx>,
+        tx: &'tx Self::Tx,
         hashed_address: B256,
         max_block_number: u64,
-    ) -> BaseProofsStorageResult<Self::StorageCursor<'a>>
+    ) -> BaseProofsStorageResult<Self::StorageCursor<'tx>>
     where
-        Self: 'a + 'tx,
+        Self: 'tx,
     {
         let cursor = tx.cursor_dup_read::<HashedStorageHistory>()?;
 
         Ok(MdbxStorageCursor::new(cursor, max_block_number, hashed_address))
     }
 
-    fn account_hashed_cursor_with_tx<'a, 'tx>(
+    fn account_hashed_cursor_with_tx<'tx>(
         &self,
-        tx: &'a Self::Tx<'tx>,
+        tx: &'tx Self::Tx,
         max_block_number: u64,
-    ) -> BaseProofsStorageResult<Self::AccountHashedCursor<'a>>
+    ) -> BaseProofsStorageResult<Self::AccountHashedCursor<'tx>>
     where
-        Self: 'a + 'tx,
+        Self: 'tx,
     {
         let cursor = tx.cursor_dup_read::<HashedAccountHistory>()?;
 

--- a/crates/execution/trie/src/db/store.rs
+++ b/crates/execution/trie/src/db/store.rs
@@ -657,6 +657,14 @@ impl BaseProofsStore for MdbxProofsStorage {
         = MdbxAccountCursor<Dup<'tx, HashedAccountHistory>>
     where
         Self: 'tx;
+    type Tx<'a>
+        = <DatabaseEnv as Database>::TX
+    where
+        Self: 'a;
+
+    fn ro_tx(&self) -> BaseProofsStorageResult<Self::Tx<'_>> {
+        Ok(self.env.tx()?)
+    }
 
     fn get_earliest_block_number(&self) -> BaseProofsStorageResult<Option<(u64, B256)>> {
         self.env.view(|tx| self.inner_get_block_number_hash(tx, ProofWindowKey::EarliestBlock))?
@@ -703,6 +711,60 @@ impl BaseProofsStore for MdbxProofsStorage {
         max_block_number: u64,
     ) -> BaseProofsStorageResult<Self::AccountHashedCursor<'tx>> {
         let tx = self.env.tx()?;
+        let cursor = tx.cursor_dup_read::<HashedAccountHistory>()?;
+
+        Ok(MdbxAccountCursor::new(cursor, max_block_number))
+    }
+
+    fn storage_trie_cursor_with_tx<'a, 'tx>(
+        &self,
+        tx: &'a Self::Tx<'tx>,
+        hashed_address: B256,
+        max_block_number: u64,
+    ) -> BaseProofsStorageResult<Self::StorageTrieCursor<'a>>
+    where
+        Self: 'a + 'tx,
+    {
+        let cursor = tx.cursor_dup_read::<StorageTrieHistory>()?;
+
+        Ok(MdbxTrieCursor::new(cursor, max_block_number, Some(hashed_address)))
+    }
+
+    fn account_trie_cursor_with_tx<'a, 'tx>(
+        &self,
+        tx: &'a Self::Tx<'tx>,
+        max_block_number: u64,
+    ) -> BaseProofsStorageResult<Self::AccountTrieCursor<'a>>
+    where
+        Self: 'a + 'tx,
+    {
+        let cursor = tx.cursor_dup_read::<AccountTrieHistory>()?;
+
+        Ok(MdbxTrieCursor::new(cursor, max_block_number, None))
+    }
+
+    fn storage_hashed_cursor_with_tx<'a, 'tx>(
+        &self,
+        tx: &'a Self::Tx<'tx>,
+        hashed_address: B256,
+        max_block_number: u64,
+    ) -> BaseProofsStorageResult<Self::StorageCursor<'a>>
+    where
+        Self: 'a + 'tx,
+    {
+        let cursor = tx.cursor_dup_read::<HashedStorageHistory>()?;
+
+        Ok(MdbxStorageCursor::new(cursor, max_block_number, hashed_address))
+    }
+
+    fn account_hashed_cursor_with_tx<'a, 'tx>(
+        &self,
+        tx: &'a Self::Tx<'tx>,
+        max_block_number: u64,
+    ) -> BaseProofsStorageResult<Self::AccountHashedCursor<'a>>
+    where
+        Self: 'a + 'tx,
+    {
         let cursor = tx.cursor_dup_read::<HashedAccountHistory>()?;
 
         Ok(MdbxAccountCursor::new(cursor, max_block_number))

--- a/crates/execution/trie/src/in_memory.rs
+++ b/crates/execution/trie/src/in_memory.rs
@@ -539,7 +539,7 @@ impl BaseProofsStore for InMemoryProofsStorage {
     type AccountTrieCursor<'tx> = InMemoryTrieCursor;
     type StorageCursor<'tx> = InMemoryStorageCursor;
     type AccountHashedCursor<'tx> = InMemoryAccountCursor;
-    type Tx<'tx> = ();
+    type Tx = ();
 
     fn get_earliest_block_number(&self) -> BaseProofsStorageResult<Option<(u64, B256)>> {
         let inner = self.inner.read();
@@ -584,52 +584,52 @@ impl BaseProofsStore for InMemoryProofsStorage {
         Ok(InMemoryAccountCursor::new(&inner, max_block_number))
     }
 
-    fn ro_tx(&self) -> BaseProofsStorageResult<Self::Tx<'_>> {
+    fn ro_tx(&self) -> BaseProofsStorageResult<Self::Tx> {
         Ok(())
     }
 
-    fn storage_trie_cursor_with_tx<'a, 'tx>(
+    fn storage_trie_cursor_with_tx<'tx>(
         &self,
-        _tx: &'a Self::Tx<'tx>,
+        _tx: &'tx Self::Tx,
         hashed_address: B256,
         max_block_number: u64,
-    ) -> BaseProofsStorageResult<Self::StorageTrieCursor<'a>>
+    ) -> BaseProofsStorageResult<Self::StorageTrieCursor<'tx>>
     where
-        Self: 'a + 'tx,
+        Self: 'tx,
     {
         self.storage_trie_cursor(hashed_address, max_block_number)
     }
 
-    fn account_trie_cursor_with_tx<'a, 'tx>(
+    fn account_trie_cursor_with_tx<'tx>(
         &self,
-        _tx: &'a Self::Tx<'tx>,
+        _tx: &'tx Self::Tx,
         max_block_number: u64,
-    ) -> BaseProofsStorageResult<Self::AccountTrieCursor<'a>>
+    ) -> BaseProofsStorageResult<Self::AccountTrieCursor<'tx>>
     where
-        Self: 'a + 'tx,
+        Self: 'tx,
     {
         self.account_trie_cursor(max_block_number)
     }
 
-    fn storage_hashed_cursor_with_tx<'a, 'tx>(
+    fn storage_hashed_cursor_with_tx<'tx>(
         &self,
-        _tx: &'a Self::Tx<'tx>,
+        _tx: &'tx Self::Tx,
         hashed_address: B256,
         max_block_number: u64,
-    ) -> BaseProofsStorageResult<Self::StorageCursor<'a>>
+    ) -> BaseProofsStorageResult<Self::StorageCursor<'tx>>
     where
-        Self: 'a + 'tx,
+        Self: 'tx,
     {
         self.storage_hashed_cursor(hashed_address, max_block_number)
     }
 
-    fn account_hashed_cursor_with_tx<'a, 'tx>(
+    fn account_hashed_cursor_with_tx<'tx>(
         &self,
-        _tx: &'a Self::Tx<'tx>,
+        _tx: &'tx Self::Tx,
         max_block_number: u64,
-    ) -> BaseProofsStorageResult<Self::AccountHashedCursor<'a>>
+    ) -> BaseProofsStorageResult<Self::AccountHashedCursor<'tx>>
     where
-        Self: 'a + 'tx,
+        Self: 'tx,
     {
         self.account_hashed_cursor(max_block_number)
     }

--- a/crates/execution/trie/src/in_memory.rs
+++ b/crates/execution/trie/src/in_memory.rs
@@ -539,6 +539,7 @@ impl BaseProofsStore for InMemoryProofsStorage {
     type AccountTrieCursor<'tx> = InMemoryTrieCursor;
     type StorageCursor<'tx> = InMemoryStorageCursor;
     type AccountHashedCursor<'tx> = InMemoryAccountCursor;
+    type Tx<'tx> = ();
 
     fn get_earliest_block_number(&self) -> BaseProofsStorageResult<Option<(u64, B256)>> {
         let inner = self.inner.read();
@@ -581,6 +582,56 @@ impl BaseProofsStore for InMemoryProofsStorage {
     ) -> BaseProofsStorageResult<Self::AccountHashedCursor<'tx>> {
         let inner = self.inner.try_read().ok_or(BaseProofsStorageError::TryLockError)?;
         Ok(InMemoryAccountCursor::new(&inner, max_block_number))
+    }
+
+    fn ro_tx(&self) -> BaseProofsStorageResult<Self::Tx<'_>> {
+        Ok(())
+    }
+
+    fn storage_trie_cursor_with_tx<'a, 'tx>(
+        &self,
+        _tx: &'a Self::Tx<'tx>,
+        hashed_address: B256,
+        max_block_number: u64,
+    ) -> BaseProofsStorageResult<Self::StorageTrieCursor<'a>>
+    where
+        Self: 'a + 'tx,
+    {
+        self.storage_trie_cursor(hashed_address, max_block_number)
+    }
+
+    fn account_trie_cursor_with_tx<'a, 'tx>(
+        &self,
+        _tx: &'a Self::Tx<'tx>,
+        max_block_number: u64,
+    ) -> BaseProofsStorageResult<Self::AccountTrieCursor<'a>>
+    where
+        Self: 'a + 'tx,
+    {
+        self.account_trie_cursor(max_block_number)
+    }
+
+    fn storage_hashed_cursor_with_tx<'a, 'tx>(
+        &self,
+        _tx: &'a Self::Tx<'tx>,
+        hashed_address: B256,
+        max_block_number: u64,
+    ) -> BaseProofsStorageResult<Self::StorageCursor<'a>>
+    where
+        Self: 'a + 'tx,
+    {
+        self.storage_hashed_cursor(hashed_address, max_block_number)
+    }
+
+    fn account_hashed_cursor_with_tx<'a, 'tx>(
+        &self,
+        _tx: &'a Self::Tx<'tx>,
+        max_block_number: u64,
+    ) -> BaseProofsStorageResult<Self::AccountHashedCursor<'a>>
+    where
+        Self: 'a + 'tx,
+    {
+        self.account_hashed_cursor(max_block_number)
     }
 
     fn store_trie_updates(

--- a/crates/execution/trie/src/lib.rs
+++ b/crates/execution/trie/src/lib.rs
@@ -49,9 +49,7 @@ pub use cursor::{
 };
 
 pub mod cursor_factory;
-pub use cursor_factory::{
-    BaseProofsHashedAccountCursorFactory, BaseProofsTrieCursorFactory,
-};
+pub use cursor_factory::{BaseProofsHashedAccountCursorFactory, BaseProofsTrieCursorFactory};
 
 pub mod error;
 pub use error::{BaseProofsStorageError, BaseProofsStorageResult};

--- a/crates/execution/trie/src/lib.rs
+++ b/crates/execution/trie/src/lib.rs
@@ -49,7 +49,9 @@ pub use cursor::{
 };
 
 pub mod cursor_factory;
-pub use cursor_factory::{BaseProofsHashedAccountCursorFactory, BaseProofsTrieCursorFactory};
+pub use cursor_factory::{
+    BaseProofsHashedAccountCursorFactory, BaseProofsTrieCursorFactory,
+};
 
 pub mod error;
 pub use error::{BaseProofsStorageError, BaseProofsStorageResult};

--- a/crates/execution/trie/src/metrics.rs
+++ b/crates/execution/trie/src/metrics.rs
@@ -372,8 +372,9 @@ where
 
     #[inline]
     fn ro_tx(&self) -> BaseProofsStorageResult<Self::Tx> {
+        let tx = self.storage.ro_tx()?;
         self.tx_acquisitions.fetch_add(1, Ordering::Relaxed);
-        self.storage.ro_tx()
+        Ok(tx)
     }
 
     #[inline]

--- a/crates/execution/trie/src/metrics.rs
+++ b/crates/execution/trie/src/metrics.rs
@@ -3,7 +3,10 @@
 use std::{
     fmt::Debug,
     future::Future,
-    sync::Arc,
+    sync::{
+        Arc,
+        atomic::{AtomicU64, Ordering},
+    },
     time::{Duration, Instant},
 };
 
@@ -267,12 +270,17 @@ impl<C: HashedStorageCursor> HashedStorageCursor for BaseProofsHashedCursorWithM
 pub struct BaseProofsStorageWithMetrics<S> {
     storage: S,
     metrics: Arc<StorageMetrics>,
+    tx_acquisitions: Arc<AtomicU64>,
 }
 
 impl<S> BaseProofsStorageWithMetrics<S> {
     /// Initializes new [`StorageMetrics`] and wraps given storage instance.
     pub fn new(storage: S) -> Self {
-        Self { storage, metrics: Arc::new(StorageMetrics) }
+        Self {
+            storage,
+            metrics: Arc::new(StorageMetrics),
+            tx_acquisitions: Arc::new(AtomicU64::new(0)),
+        }
     }
 
     /// Get the underlying storage.
@@ -283,6 +291,12 @@ impl<S> BaseProofsStorageWithMetrics<S> {
     /// Get the metrics.
     pub const fn metrics(&self) -> &Arc<StorageMetrics> {
         &self.metrics
+    }
+
+    /// Read-only transactions acquired since this wrapper was created. Used by
+    /// integration tests to verify request-scoped transaction sharing.
+    pub fn tx_acquisitions(&self) -> u64 {
+        self.tx_acquisitions.load(Ordering::Relaxed)
     }
 }
 
@@ -304,6 +318,10 @@ where
         Self: 'tx;
     type AccountHashedCursor<'tx>
         = BaseProofsHashedCursorWithMetrics<S::AccountHashedCursor<'tx>>
+    where
+        Self: 'tx;
+    type Tx<'tx>
+        = S::Tx<'tx>
     where
         Self: 'tx;
 
@@ -352,6 +370,68 @@ where
         max_block_number: u64,
     ) -> BaseProofsStorageResult<Self::AccountHashedCursor<'tx>> {
         let cursor = self.storage.account_hashed_cursor(max_block_number)?;
+        Ok(BaseProofsHashedCursorWithMetrics::new(cursor, Arc::clone(&self.metrics)))
+    }
+
+    #[inline]
+    fn ro_tx(&self) -> BaseProofsStorageResult<Self::Tx<'_>> {
+        self.tx_acquisitions.fetch_add(1, Ordering::Relaxed);
+        self.storage.ro_tx()
+    }
+
+    #[inline]
+    fn storage_trie_cursor_with_tx<'a, 'tx>(
+        &self,
+        tx: &'a Self::Tx<'tx>,
+        hashed_address: B256,
+        max_block_number: u64,
+    ) -> BaseProofsStorageResult<Self::StorageTrieCursor<'a>>
+    where
+        Self: 'a + 'tx,
+    {
+        let cursor =
+            self.storage.storage_trie_cursor_with_tx(tx, hashed_address, max_block_number)?;
+        Ok(BaseProofsTrieCursorWithMetrics::new(cursor, Arc::clone(&self.metrics)))
+    }
+
+    #[inline]
+    fn account_trie_cursor_with_tx<'a, 'tx>(
+        &self,
+        tx: &'a Self::Tx<'tx>,
+        max_block_number: u64,
+    ) -> BaseProofsStorageResult<Self::AccountTrieCursor<'a>>
+    where
+        Self: 'a + 'tx,
+    {
+        let cursor = self.storage.account_trie_cursor_with_tx(tx, max_block_number)?;
+        Ok(BaseProofsTrieCursorWithMetrics::new(cursor, Arc::clone(&self.metrics)))
+    }
+
+    #[inline]
+    fn storage_hashed_cursor_with_tx<'a, 'tx>(
+        &self,
+        tx: &'a Self::Tx<'tx>,
+        hashed_address: B256,
+        max_block_number: u64,
+    ) -> BaseProofsStorageResult<Self::StorageCursor<'a>>
+    where
+        Self: 'a + 'tx,
+    {
+        let cursor =
+            self.storage.storage_hashed_cursor_with_tx(tx, hashed_address, max_block_number)?;
+        Ok(BaseProofsHashedCursorWithMetrics::new(cursor, Arc::clone(&self.metrics)))
+    }
+
+    #[inline]
+    fn account_hashed_cursor_with_tx<'a, 'tx>(
+        &self,
+        tx: &'a Self::Tx<'tx>,
+        max_block_number: u64,
+    ) -> BaseProofsStorageResult<Self::AccountHashedCursor<'a>>
+    where
+        Self: 'a + 'tx,
+    {
+        let cursor = self.storage.account_hashed_cursor_with_tx(tx, max_block_number)?;
         Ok(BaseProofsHashedCursorWithMetrics::new(cursor, Arc::clone(&self.metrics)))
     }
 

--- a/crates/execution/trie/src/metrics.rs
+++ b/crates/execution/trie/src/metrics.rs
@@ -320,10 +320,7 @@ where
         = BaseProofsHashedCursorWithMetrics<S::AccountHashedCursor<'tx>>
     where
         Self: 'tx;
-    type Tx<'tx>
-        = S::Tx<'tx>
-    where
-        Self: 'tx;
+    type Tx = S::Tx;
 
     #[inline]
     fn get_earliest_block_number(&self) -> BaseProofsStorageResult<Option<(u64, B256)>> {
@@ -374,20 +371,20 @@ where
     }
 
     #[inline]
-    fn ro_tx(&self) -> BaseProofsStorageResult<Self::Tx<'_>> {
+    fn ro_tx(&self) -> BaseProofsStorageResult<Self::Tx> {
         self.tx_acquisitions.fetch_add(1, Ordering::Relaxed);
         self.storage.ro_tx()
     }
 
     #[inline]
-    fn storage_trie_cursor_with_tx<'a, 'tx>(
+    fn storage_trie_cursor_with_tx<'tx>(
         &self,
-        tx: &'a Self::Tx<'tx>,
+        tx: &'tx Self::Tx,
         hashed_address: B256,
         max_block_number: u64,
-    ) -> BaseProofsStorageResult<Self::StorageTrieCursor<'a>>
+    ) -> BaseProofsStorageResult<Self::StorageTrieCursor<'tx>>
     where
-        Self: 'a + 'tx,
+        Self: 'tx,
     {
         let cursor =
             self.storage.storage_trie_cursor_with_tx(tx, hashed_address, max_block_number)?;
@@ -395,27 +392,27 @@ where
     }
 
     #[inline]
-    fn account_trie_cursor_with_tx<'a, 'tx>(
+    fn account_trie_cursor_with_tx<'tx>(
         &self,
-        tx: &'a Self::Tx<'tx>,
+        tx: &'tx Self::Tx,
         max_block_number: u64,
-    ) -> BaseProofsStorageResult<Self::AccountTrieCursor<'a>>
+    ) -> BaseProofsStorageResult<Self::AccountTrieCursor<'tx>>
     where
-        Self: 'a + 'tx,
+        Self: 'tx,
     {
         let cursor = self.storage.account_trie_cursor_with_tx(tx, max_block_number)?;
         Ok(BaseProofsTrieCursorWithMetrics::new(cursor, Arc::clone(&self.metrics)))
     }
 
     #[inline]
-    fn storage_hashed_cursor_with_tx<'a, 'tx>(
+    fn storage_hashed_cursor_with_tx<'tx>(
         &self,
-        tx: &'a Self::Tx<'tx>,
+        tx: &'tx Self::Tx,
         hashed_address: B256,
         max_block_number: u64,
-    ) -> BaseProofsStorageResult<Self::StorageCursor<'a>>
+    ) -> BaseProofsStorageResult<Self::StorageCursor<'tx>>
     where
-        Self: 'a + 'tx,
+        Self: 'tx,
     {
         let cursor =
             self.storage.storage_hashed_cursor_with_tx(tx, hashed_address, max_block_number)?;
@@ -423,13 +420,13 @@ where
     }
 
     #[inline]
-    fn account_hashed_cursor_with_tx<'a, 'tx>(
+    fn account_hashed_cursor_with_tx<'tx>(
         &self,
-        tx: &'a Self::Tx<'tx>,
+        tx: &'tx Self::Tx,
         max_block_number: u64,
-    ) -> BaseProofsStorageResult<Self::AccountHashedCursor<'a>>
+    ) -> BaseProofsStorageResult<Self::AccountHashedCursor<'tx>>
     where
-        Self: 'a + 'tx,
+        Self: 'tx,
     {
         let cursor = self.storage.account_hashed_cursor_with_tx(tx, max_block_number)?;
         Ok(BaseProofsHashedCursorWithMetrics::new(cursor, Arc::clone(&self.metrics)))

--- a/crates/execution/trie/src/proof.rs
+++ b/crates/execution/trie/src/proof.rs
@@ -24,11 +24,24 @@ use crate::{
     BaseProofsTrieCursorFactory,
 };
 
+/// Build the trie + hashed cursor factories sharing one read transaction at the given block.
+const fn from_tx<'tx, S>(
+    storage: &'tx BaseProofsStorage<S>,
+    tx: &'tx <BaseProofsStorage<S> as BaseProofsStore>::Tx,
+    block_number: u64,
+) -> (BaseProofsTrieCursorFactory<'tx, S>, BaseProofsHashedAccountCursorFactory<'tx, S>)
+where
+    S: BaseProofsStore + 'tx,
+{
+    (
+        BaseProofsTrieCursorFactory::new(storage, tx, block_number),
+        BaseProofsHashedAccountCursorFactory::new(storage, tx, block_number),
+    )
+}
+
 /// Extends [`Proof`] with operations specific for working with [`BaseProofsStorage`].
 pub trait DatabaseProof<'tx, S: BaseProofsStore + 'tx> {
     /// Generates the state proof for target account based on [`TrieInput`].
-    /// Acquires exactly one read-only transaction internally and shares it
-    /// across every cursor opened during proof computation.
     fn overlay_account_proof(
         storage: &'tx BaseProofsStorage<S>,
         block_number: u64,
@@ -38,8 +51,6 @@ pub trait DatabaseProof<'tx, S: BaseProofsStore + 'tx> {
     ) -> Result<AccountProof, StateProofError>;
 
     /// Generates the state [`MultiProof`] for target hashed account and storage keys.
-    /// Acquires exactly one read-only transaction internally and shares it
-    /// across every cursor opened during proof computation.
     fn overlay_multiproof(
         storage: &'tx BaseProofsStorage<S>,
         block_number: u64,
@@ -63,8 +74,7 @@ where
         let nodes_sorted = input.nodes.into_sorted();
         let state_sorted = input.state.into_sorted();
         let tx = storage.ro_tx().map_err(Into::<DatabaseError>::into)?;
-        let trie_factory = BaseProofsTrieCursorFactory::new(storage, &tx, block_number);
-        let hashed_factory = BaseProofsHashedAccountCursorFactory::new(storage, &tx, block_number);
+        let (trie_factory, hashed_factory) = from_tx(storage, &tx, block_number);
         Proof::new(trie_factory.clone(), hashed_factory.clone())
             .with_trie_cursor_factory(InMemoryTrieCursorFactory::new(trie_factory, &nodes_sorted))
             .with_hashed_cursor_factory(HashedPostStateCursorFactory::new(
@@ -84,8 +94,7 @@ where
         let nodes_sorted = input.nodes.into_sorted();
         let state_sorted = input.state.into_sorted();
         let tx = storage.ro_tx().map_err(Into::<DatabaseError>::into)?;
-        let trie_factory = BaseProofsTrieCursorFactory::new(storage, &tx, block_number);
-        let hashed_factory = BaseProofsHashedAccountCursorFactory::new(storage, &tx, block_number);
+        let (trie_factory, hashed_factory) = from_tx(storage, &tx, block_number);
         Proof::new(trie_factory.clone(), hashed_factory.clone())
             .with_trie_cursor_factory(InMemoryTrieCursorFactory::new(trie_factory, &nodes_sorted))
             .with_hashed_cursor_factory(HashedPostStateCursorFactory::new(
@@ -100,7 +109,6 @@ where
 /// Extends [`StorageProof`] with operations specific for working with [`BaseProofsStorage`].
 pub trait DatabaseStorageProof<'tx, S: BaseProofsStore + 'tx> {
     /// Generates the storage proof for target slot based on [`TrieInput`].
-    /// Acquires exactly one read-only transaction internally.
     fn overlay_storage_proof(
         storage: &'tx BaseProofsStorage<S>,
         block_number: u64,
@@ -110,7 +118,6 @@ pub trait DatabaseStorageProof<'tx, S: BaseProofsStore + 'tx> {
     ) -> Result<StorageProof, StateProofError>;
 
     /// Generates the storage multiproof for target slots based on [`TrieInput`].
-    /// Acquires exactly one read-only transaction internally.
     fn overlay_storage_multiproof(
         storage: &'tx BaseProofsStorage<S>,
         block_number: u64,
@@ -143,8 +150,7 @@ where
             HashMap::from_iter([(hashed_address, hashed_storage.into_sorted())]),
         );
         let tx = storage.ro_tx().map_err(Into::<DatabaseError>::into)?;
-        let trie_factory = BaseProofsTrieCursorFactory::new(storage, &tx, block_number);
-        let hashed_factory = BaseProofsHashedAccountCursorFactory::new(storage, &tx, block_number);
+        let (trie_factory, hashed_factory) = from_tx(storage, &tx, block_number);
         proof::StorageProof::new(trie_factory, hashed_factory.clone(), address)
             .with_hashed_cursor_factory(HashedPostStateCursorFactory::new(
                 hashed_factory,
@@ -169,8 +175,7 @@ where
             HashMap::from_iter([(hashed_address, hashed_storage.into_sorted())]),
         );
         let tx = storage.ro_tx().map_err(Into::<DatabaseError>::into)?;
-        let trie_factory = BaseProofsTrieCursorFactory::new(storage, &tx, block_number);
-        let hashed_factory = BaseProofsHashedAccountCursorFactory::new(storage, &tx, block_number);
+        let (trie_factory, hashed_factory) = from_tx(storage, &tx, block_number);
         proof::StorageProof::new(trie_factory, hashed_factory.clone(), address)
             .with_hashed_cursor_factory(HashedPostStateCursorFactory::new(
                 hashed_factory,
@@ -186,7 +191,6 @@ pub trait DatabaseStateRoot<'tx, S: BaseProofsStore + 'tx + Clone>: Sized {
     /// Calculate the state root for this [`HashedPostState`].
     /// Internally, this method retrieves prefixsets and uses them
     /// to calculate incremental state root.
-    /// Acquires exactly one read-only transaction internally.
     ///
     /// # Returns
     ///
@@ -199,7 +203,6 @@ pub trait DatabaseStateRoot<'tx, S: BaseProofsStore + 'tx + Clone>: Sized {
 
     /// Calculates the state root for this [`HashedPostState`] and returns it alongside trie
     /// updates. See [`Self::overlay_root`] for more info.
-    /// Acquires exactly one read-only transaction internally.
     fn overlay_root_with_updates(
         storage: &'tx BaseProofsStorage<S>,
         block_number: u64,
@@ -207,7 +210,6 @@ pub trait DatabaseStateRoot<'tx, S: BaseProofsStore + 'tx + Clone>: Sized {
     ) -> Result<(B256, TrieUpdates), StateRootError>;
 
     /// Calculates the state root for provided [`HashedPostState`] using cached intermediate nodes.
-    /// Acquires exactly one read-only transaction internally.
     fn overlay_root_from_nodes(
         storage: &'tx BaseProofsStorage<S>,
         block_number: u64,
@@ -216,7 +218,6 @@ pub trait DatabaseStateRoot<'tx, S: BaseProofsStore + 'tx + Clone>: Sized {
 
     /// Calculates the state root and trie updates for provided [`HashedPostState`] using
     /// cached intermediate nodes.
-    /// Acquires exactly one read-only transaction internally.
     fn overlay_root_from_nodes_with_updates(
         storage: &'tx BaseProofsStorage<S>,
         block_number: u64,
@@ -237,12 +238,10 @@ where
         let prefix_sets = post_state.construct_prefix_sets().freeze();
         let state_sorted = post_state.into_sorted();
         let tx = storage.ro_tx().map_err(Into::<DatabaseError>::into)?;
+        let (trie_factory, hashed_factory) = from_tx(storage, &tx, block_number);
         StateRoot::new(
-            BaseProofsTrieCursorFactory::new(storage, &tx, block_number),
-            HashedPostStateCursorFactory::new(
-                BaseProofsHashedAccountCursorFactory::new(storage, &tx, block_number),
-                &state_sorted,
-            ),
+            trie_factory,
+            HashedPostStateCursorFactory::new(hashed_factory, &state_sorted),
         )
         .with_prefix_sets(prefix_sets)
         .root()
@@ -256,12 +255,10 @@ where
         let prefix_sets = post_state.construct_prefix_sets().freeze();
         let state_sorted = post_state.into_sorted();
         let tx = storage.ro_tx().map_err(Into::<DatabaseError>::into)?;
+        let (trie_factory, hashed_factory) = from_tx(storage, &tx, block_number);
         StateRoot::new(
-            BaseProofsTrieCursorFactory::new(storage, &tx, block_number),
-            HashedPostStateCursorFactory::new(
-                BaseProofsHashedAccountCursorFactory::new(storage, &tx, block_number),
-                &state_sorted,
-            ),
+            trie_factory,
+            HashedPostStateCursorFactory::new(hashed_factory, &state_sorted),
         )
         .with_prefix_sets(prefix_sets)
         .root_with_updates()
@@ -275,15 +272,10 @@ where
         let state_sorted = input.state.into_sorted();
         let nodes_sorted = input.nodes.into_sorted();
         let tx = storage.ro_tx().map_err(Into::<DatabaseError>::into)?;
+        let (trie_factory, hashed_factory) = from_tx(storage, &tx, block_number);
         StateRoot::new(
-            InMemoryTrieCursorFactory::new(
-                BaseProofsTrieCursorFactory::new(storage, &tx, block_number),
-                &nodes_sorted,
-            ),
-            HashedPostStateCursorFactory::new(
-                BaseProofsHashedAccountCursorFactory::new(storage, &tx, block_number),
-                &state_sorted,
-            ),
+            InMemoryTrieCursorFactory::new(trie_factory, &nodes_sorted),
+            HashedPostStateCursorFactory::new(hashed_factory, &state_sorted),
         )
         .with_prefix_sets(input.prefix_sets.freeze())
         .root()
@@ -297,15 +289,10 @@ where
         let state_sorted = input.state.into_sorted();
         let nodes_sorted = input.nodes.into_sorted();
         let tx = storage.ro_tx().map_err(Into::<DatabaseError>::into)?;
+        let (trie_factory, hashed_factory) = from_tx(storage, &tx, block_number);
         StateRoot::new(
-            InMemoryTrieCursorFactory::new(
-                BaseProofsTrieCursorFactory::new(storage, &tx, block_number),
-                &nodes_sorted,
-            ),
-            HashedPostStateCursorFactory::new(
-                BaseProofsHashedAccountCursorFactory::new(storage, &tx, block_number),
-                &state_sorted,
-            ),
+            InMemoryTrieCursorFactory::new(trie_factory, &nodes_sorted),
+            HashedPostStateCursorFactory::new(hashed_factory, &state_sorted),
         )
         .with_prefix_sets(input.prefix_sets.freeze())
         .root_with_updates()
@@ -315,7 +302,6 @@ where
 /// Extends [`StorageRoot`] with operations specific for working with [`BaseProofsStorage`].
 pub trait DatabaseStorageRoot<'tx, S: BaseProofsStore + 'tx + Clone> {
     /// Calculates the storage root for provided [`HashedStorage`].
-    /// Acquires exactly one read-only transaction internally.
     fn overlay_root(
         storage: &'tx BaseProofsStorage<S>,
         block_number: u64,
@@ -342,12 +328,10 @@ where
         let state_sorted =
             HashedPostState::from_hashed_storage(keccak256(address), hashed_storage).into_sorted();
         let tx = storage.ro_tx().map_err(Into::<DatabaseError>::into)?;
+        let (trie_factory, hashed_factory) = from_tx(storage, &tx, block_number);
         StorageRoot::new(
-            BaseProofsTrieCursorFactory::new(storage, &tx, block_number),
-            HashedPostStateCursorFactory::new(
-                BaseProofsHashedAccountCursorFactory::new(storage, &tx, block_number),
-                &state_sorted,
-            ),
+            trie_factory,
+            HashedPostStateCursorFactory::new(hashed_factory, &state_sorted),
             address,
             prefix_set,
             TrieRootMetrics::new(TrieType::Custom("base_historical_proofs_storage")),
@@ -359,8 +343,6 @@ where
 /// Extends [`TrieWitness`] with operations specific for working with [`BaseProofsStorage`].
 pub trait DatabaseTrieWitness<'tx, S: BaseProofsStore + 'tx + Clone> {
     /// Generates the trie witness for the target state based on [`TrieInput`].
-    /// Acquires exactly one read-only transaction internally and shares it
-    /// across every cursor opened during witness computation.
     fn overlay_witness(
         storage: &'tx BaseProofsStorage<S>,
         block_number: u64,
@@ -389,8 +371,7 @@ where
             let error = Into::<DatabaseError>::into(error);
             StateProofError::from(error)
         })?;
-        let trie_factory = BaseProofsTrieCursorFactory::new(storage, &tx, block_number);
-        let hashed_factory = BaseProofsHashedAccountCursorFactory::new(storage, &tx, block_number);
+        let (trie_factory, hashed_factory) = from_tx(storage, &tx, block_number);
         TrieWitness::new(trie_factory.clone(), hashed_factory.clone())
             .with_trie_cursor_factory(InMemoryTrieCursorFactory::new(trie_factory, &nodes_sorted))
             .with_hashed_cursor_factory(HashedPostStateCursorFactory::new(

--- a/crates/execution/trie/src/proof.rs
+++ b/crates/execution/trie/src/proof.rs
@@ -4,6 +4,7 @@ use alloy_primitives::{
     Address, B256, Bytes, keccak256,
     map::{B256Map, HashMap},
 };
+use reth_db::DatabaseError;
 use reth_execution_errors::{StateProofError, StateRootError, StorageRootError, TrieWitnessError};
 use reth_trie::{
     StateRoot, StorageRoot, TrieType,
@@ -24,11 +25,10 @@ use crate::{
 };
 
 /// Extends [`Proof`] with operations specific for working with [`BaseProofsStorage`].
-pub trait DatabaseProof<'tx, S> {
-    /// Creates a new `DatabaseProof` instance from external storage.
-    fn from_tx(storage: &'tx BaseProofsStorage<S>, block_number: u64) -> Self;
-
+pub trait DatabaseProof<'tx, S: BaseProofsStore + 'tx> {
     /// Generates the state proof for target account based on [`TrieInput`].
+    /// Acquires exactly one read-only transaction internally and shares it
+    /// across every cursor opened during proof computation.
     fn overlay_account_proof(
         storage: &'tx BaseProofsStorage<S>,
         block_number: u64,
@@ -38,6 +38,8 @@ pub trait DatabaseProof<'tx, S> {
     ) -> Result<AccountProof, StateProofError>;
 
     /// Generates the state [`MultiProof`] for target hashed account and storage keys.
+    /// Acquires exactly one read-only transaction internally and shares it
+    /// across every cursor opened during proof computation.
     fn overlay_multiproof(
         storage: &'tx BaseProofsStorage<S>,
         block_number: u64,
@@ -47,19 +49,13 @@ pub trait DatabaseProof<'tx, S> {
 }
 
 impl<'tx, S> DatabaseProof<'tx, S>
-    for Proof<BaseProofsTrieCursorFactory<'tx, S>, BaseProofsHashedAccountCursorFactory<'tx, S>>
+    for Proof<
+        BaseProofsTrieCursorFactory<'tx, 'tx, S>,
+        BaseProofsHashedAccountCursorFactory<'tx, 'tx, S>,
+    >
 where
-    S: BaseProofsStore + Clone,
+    S: BaseProofsStore + 'tx + Clone,
 {
-    /// Create a new [`Proof`] instance from [`BaseProofsStorage`].
-    fn from_tx(storage: &'tx BaseProofsStorage<S>, block_number: u64) -> Self {
-        Self::new(
-            BaseProofsTrieCursorFactory::new(storage, block_number),
-            BaseProofsHashedAccountCursorFactory::new(storage, block_number),
-        )
-    }
-
-    /// Generates the state proof for target account based on [`TrieInput`].
     fn overlay_account_proof(
         storage: &'tx BaseProofsStorage<S>,
         block_number: u64,
@@ -69,20 +65,19 @@ where
     ) -> Result<AccountProof, StateProofError> {
         let nodes_sorted = input.nodes.into_sorted();
         let state_sorted = input.state.into_sorted();
-        Self::from_tx(storage, block_number)
-            .with_trie_cursor_factory(InMemoryTrieCursorFactory::new(
-                BaseProofsTrieCursorFactory::new(storage, block_number),
-                &nodes_sorted,
-            ))
+        let tx = storage.ro_tx().map_err(Into::<DatabaseError>::into)?;
+        let trie_factory = BaseProofsTrieCursorFactory::new(storage, &tx, block_number);
+        let hashed_factory = BaseProofsHashedAccountCursorFactory::new(storage, &tx, block_number);
+        Proof::new(trie_factory.clone(), hashed_factory.clone())
+            .with_trie_cursor_factory(InMemoryTrieCursorFactory::new(trie_factory, &nodes_sorted))
             .with_hashed_cursor_factory(HashedPostStateCursorFactory::new(
-                BaseProofsHashedAccountCursorFactory::new(storage, block_number),
+                hashed_factory,
                 &state_sorted,
             ))
             .with_prefix_sets_mut(input.prefix_sets)
             .account_proof(address, slots)
     }
 
-    /// Generates the state [`MultiProof`] for target hashed account and storage keys.
     fn overlay_multiproof(
         storage: &'tx BaseProofsStorage<S>,
         block_number: u64,
@@ -91,13 +86,13 @@ where
     ) -> Result<MultiProof, StateProofError> {
         let nodes_sorted = input.nodes.into_sorted();
         let state_sorted = input.state.into_sorted();
-        Self::from_tx(storage, block_number)
-            .with_trie_cursor_factory(InMemoryTrieCursorFactory::new(
-                BaseProofsTrieCursorFactory::new(storage, block_number),
-                &nodes_sorted,
-            ))
+        let tx = storage.ro_tx().map_err(Into::<DatabaseError>::into)?;
+        let trie_factory = BaseProofsTrieCursorFactory::new(storage, &tx, block_number);
+        let hashed_factory = BaseProofsHashedAccountCursorFactory::new(storage, &tx, block_number);
+        Proof::new(trie_factory.clone(), hashed_factory.clone())
+            .with_trie_cursor_factory(InMemoryTrieCursorFactory::new(trie_factory, &nodes_sorted))
             .with_hashed_cursor_factory(HashedPostStateCursorFactory::new(
-                BaseProofsHashedAccountCursorFactory::new(storage, block_number),
+                hashed_factory,
                 &state_sorted,
             ))
             .with_prefix_sets_mut(input.prefix_sets)
@@ -106,11 +101,9 @@ where
 }
 
 /// Extends [`StorageProof`] with operations specific for working with [`BaseProofsStorage`].
-pub trait DatabaseStorageProof<'tx, S> {
-    /// Create a new [`StorageProof`] from [`BaseProofsStorage`] and account address.
-    fn from_tx(storage: &'tx BaseProofsStorage<S>, block_number: u64, address: Address) -> Self;
-
+pub trait DatabaseStorageProof<'tx, S: BaseProofsStore + 'tx> {
     /// Generates the storage proof for target slot based on [`TrieInput`].
+    /// Acquires exactly one read-only transaction internally.
     fn overlay_storage_proof(
         storage: &'tx BaseProofsStorage<S>,
         block_number: u64,
@@ -120,6 +113,7 @@ pub trait DatabaseStorageProof<'tx, S> {
     ) -> Result<StorageProof, StateProofError>;
 
     /// Generates the storage multiproof for target slots based on [`TrieInput`].
+    /// Acquires exactly one read-only transaction internally.
     fn overlay_storage_multiproof(
         storage: &'tx BaseProofsStorage<S>,
         block_number: u64,
@@ -132,21 +126,12 @@ pub trait DatabaseStorageProof<'tx, S> {
 impl<'tx, S> DatabaseStorageProof<'tx, S>
     for proof::StorageProof<
         'static,
-        BaseProofsTrieCursorFactory<'tx, S>,
-        BaseProofsHashedAccountCursorFactory<'tx, S>,
+        BaseProofsTrieCursorFactory<'tx, 'tx, S>,
+        BaseProofsHashedAccountCursorFactory<'tx, 'tx, S>,
     >
 where
     S: BaseProofsStore + 'tx + Clone,
 {
-    /// Create a new [`StorageProof`] from [`BaseProofsStorage`] and account address.
-    fn from_tx(storage: &'tx BaseProofsStorage<S>, block_number: u64, address: Address) -> Self {
-        Self::new(
-            BaseProofsTrieCursorFactory::new(storage, block_number),
-            BaseProofsHashedAccountCursorFactory::new(storage, block_number),
-            address,
-        )
-    }
-
     fn overlay_storage_proof(
         storage: &'tx BaseProofsStorage<S>,
         block_number: u64,
@@ -160,9 +145,12 @@ where
             Default::default(),
             HashMap::from_iter([(hashed_address, hashed_storage.into_sorted())]),
         );
-        Self::from_tx(storage, block_number, address)
+        let tx = storage.ro_tx().map_err(Into::<DatabaseError>::into)?;
+        let trie_factory = BaseProofsTrieCursorFactory::new(storage, &tx, block_number);
+        let hashed_factory = BaseProofsHashedAccountCursorFactory::new(storage, &tx, block_number);
+        proof::StorageProof::new(trie_factory, hashed_factory.clone(), address)
             .with_hashed_cursor_factory(HashedPostStateCursorFactory::new(
-                BaseProofsHashedAccountCursorFactory::new(storage, block_number),
+                hashed_factory,
                 &state_sorted,
             ))
             .with_prefix_set_mut(prefix_set)
@@ -183,9 +171,12 @@ where
             Default::default(),
             HashMap::from_iter([(hashed_address, hashed_storage.into_sorted())]),
         );
-        Self::from_tx(storage, block_number, address)
+        let tx = storage.ro_tx().map_err(Into::<DatabaseError>::into)?;
+        let trie_factory = BaseProofsTrieCursorFactory::new(storage, &tx, block_number);
+        let hashed_factory = BaseProofsHashedAccountCursorFactory::new(storage, &tx, block_number);
+        proof::StorageProof::new(trie_factory, hashed_factory.clone(), address)
             .with_hashed_cursor_factory(HashedPostStateCursorFactory::new(
-                BaseProofsHashedAccountCursorFactory::new(storage, block_number),
+                hashed_factory,
                 &state_sorted,
             ))
             .with_prefix_set_mut(prefix_set)
@@ -198,6 +189,7 @@ pub trait DatabaseStateRoot<'tx, S: BaseProofsStore + 'tx + Clone>: Sized {
     /// Calculate the state root for this [`HashedPostState`].
     /// Internally, this method retrieves prefixsets and uses them
     /// to calculate incremental state root.
+    /// Acquires exactly one read-only transaction internally.
     ///
     /// # Returns
     ///
@@ -210,6 +202,7 @@ pub trait DatabaseStateRoot<'tx, S: BaseProofsStore + 'tx + Clone>: Sized {
 
     /// Calculates the state root for this [`HashedPostState`] and returns it alongside trie
     /// updates. See [`Self::overlay_root`] for more info.
+    /// Acquires exactly one read-only transaction internally.
     fn overlay_root_with_updates(
         storage: &'tx BaseProofsStorage<S>,
         block_number: u64,
@@ -217,6 +210,7 @@ pub trait DatabaseStateRoot<'tx, S: BaseProofsStore + 'tx + Clone>: Sized {
     ) -> Result<(B256, TrieUpdates), StateRootError>;
 
     /// Calculates the state root for provided [`HashedPostState`] using cached intermediate nodes.
+    /// Acquires exactly one read-only transaction internally.
     fn overlay_root_from_nodes(
         storage: &'tx BaseProofsStorage<S>,
         block_number: u64,
@@ -225,6 +219,7 @@ pub trait DatabaseStateRoot<'tx, S: BaseProofsStore + 'tx + Clone>: Sized {
 
     /// Calculates the state root and trie updates for provided [`HashedPostState`] using
     /// cached intermediate nodes.
+    /// Acquires exactly one read-only transaction internally.
     fn overlay_root_from_nodes_with_updates(
         storage: &'tx BaseProofsStorage<S>,
         block_number: u64,
@@ -233,7 +228,10 @@ pub trait DatabaseStateRoot<'tx, S: BaseProofsStore + 'tx + Clone>: Sized {
 }
 
 impl<'tx, S> DatabaseStateRoot<'tx, S>
-    for StateRoot<BaseProofsTrieCursorFactory<'tx, S>, BaseProofsHashedAccountCursorFactory<'tx, S>>
+    for StateRoot<
+        BaseProofsTrieCursorFactory<'tx, 'tx, S>,
+        BaseProofsHashedAccountCursorFactory<'tx, 'tx, S>,
+    >
 where
     S: BaseProofsStore + 'tx + Clone,
 {
@@ -244,10 +242,11 @@ where
     ) -> Result<B256, StateRootError> {
         let prefix_sets = post_state.construct_prefix_sets().freeze();
         let state_sorted = post_state.into_sorted();
+        let tx = storage.ro_tx().map_err(Into::<DatabaseError>::into)?;
         StateRoot::new(
-            BaseProofsTrieCursorFactory::new(storage, block_number),
+            BaseProofsTrieCursorFactory::new(storage, &tx, block_number),
             HashedPostStateCursorFactory::new(
-                BaseProofsHashedAccountCursorFactory::new(storage, block_number),
+                BaseProofsHashedAccountCursorFactory::new(storage, &tx, block_number),
                 &state_sorted,
             ),
         )
@@ -262,10 +261,11 @@ where
     ) -> Result<(B256, TrieUpdates), StateRootError> {
         let prefix_sets = post_state.construct_prefix_sets().freeze();
         let state_sorted = post_state.into_sorted();
+        let tx = storage.ro_tx().map_err(Into::<DatabaseError>::into)?;
         StateRoot::new(
-            BaseProofsTrieCursorFactory::new(storage, block_number),
+            BaseProofsTrieCursorFactory::new(storage, &tx, block_number),
             HashedPostStateCursorFactory::new(
-                BaseProofsHashedAccountCursorFactory::new(storage, block_number),
+                BaseProofsHashedAccountCursorFactory::new(storage, &tx, block_number),
                 &state_sorted,
             ),
         )
@@ -280,13 +280,14 @@ where
     ) -> Result<B256, StateRootError> {
         let state_sorted = input.state.into_sorted();
         let nodes_sorted = input.nodes.into_sorted();
+        let tx = storage.ro_tx().map_err(Into::<DatabaseError>::into)?;
         StateRoot::new(
             InMemoryTrieCursorFactory::new(
-                BaseProofsTrieCursorFactory::new(storage, block_number),
+                BaseProofsTrieCursorFactory::new(storage, &tx, block_number),
                 &nodes_sorted,
             ),
             HashedPostStateCursorFactory::new(
-                BaseProofsHashedAccountCursorFactory::new(storage, block_number),
+                BaseProofsHashedAccountCursorFactory::new(storage, &tx, block_number),
                 &state_sorted,
             ),
         )
@@ -301,13 +302,14 @@ where
     ) -> Result<(B256, TrieUpdates), StateRootError> {
         let state_sorted = input.state.into_sorted();
         let nodes_sorted = input.nodes.into_sorted();
+        let tx = storage.ro_tx().map_err(Into::<DatabaseError>::into)?;
         StateRoot::new(
             InMemoryTrieCursorFactory::new(
-                BaseProofsTrieCursorFactory::new(storage, block_number),
+                BaseProofsTrieCursorFactory::new(storage, &tx, block_number),
                 &nodes_sorted,
             ),
             HashedPostStateCursorFactory::new(
-                BaseProofsHashedAccountCursorFactory::new(storage, block_number),
+                BaseProofsHashedAccountCursorFactory::new(storage, &tx, block_number),
                 &state_sorted,
             ),
         )
@@ -319,6 +321,7 @@ where
 /// Extends [`StorageRoot`] with operations specific for working with [`BaseProofsStorage`].
 pub trait DatabaseStorageRoot<'tx, S: BaseProofsStore + 'tx + Clone> {
     /// Calculates the storage root for provided [`HashedStorage`].
+    /// Acquires exactly one read-only transaction internally.
     fn overlay_root(
         storage: &'tx BaseProofsStorage<S>,
         block_number: u64,
@@ -329,8 +332,8 @@ pub trait DatabaseStorageRoot<'tx, S: BaseProofsStore + 'tx + Clone> {
 
 impl<'tx, S> DatabaseStorageRoot<'tx, S>
     for StorageRoot<
-        BaseProofsTrieCursorFactory<'tx, S>,
-        BaseProofsHashedAccountCursorFactory<'tx, S>,
+        BaseProofsTrieCursorFactory<'tx, 'tx, S>,
+        BaseProofsHashedAccountCursorFactory<'tx, 'tx, S>,
     >
 where
     S: BaseProofsStore + 'tx + Clone,
@@ -344,10 +347,11 @@ where
         let prefix_set = hashed_storage.construct_prefix_set().freeze();
         let state_sorted =
             HashedPostState::from_hashed_storage(keccak256(address), hashed_storage).into_sorted();
+        let tx = storage.ro_tx().map_err(Into::<DatabaseError>::into)?;
         StorageRoot::new(
-            BaseProofsTrieCursorFactory::new(storage, block_number),
+            BaseProofsTrieCursorFactory::new(storage, &tx, block_number),
             HashedPostStateCursorFactory::new(
-                BaseProofsHashedAccountCursorFactory::new(storage, block_number),
+                BaseProofsHashedAccountCursorFactory::new(storage, &tx, block_number),
                 &state_sorted,
             ),
             address,
@@ -360,10 +364,9 @@ where
 
 /// Extends [`TrieWitness`] with operations specific for working with [`BaseProofsStorage`].
 pub trait DatabaseTrieWitness<'tx, S: BaseProofsStore + 'tx + Clone> {
-    /// Creates a new [`TrieWitness`] instance from [`BaseProofsStorage`].
-    fn from_tx(storage: &'tx BaseProofsStorage<S>, block_number: u64) -> Self;
-
     /// Generates the trie witness for the target state based on [`TrieInput`].
+    /// Acquires exactly one read-only transaction internally and shares it
+    /// across every cursor opened during witness computation.
     fn overlay_witness(
         storage: &'tx BaseProofsStorage<S>,
         block_number: u64,
@@ -374,19 +377,12 @@ pub trait DatabaseTrieWitness<'tx, S: BaseProofsStore + 'tx + Clone> {
 
 impl<'tx, S> DatabaseTrieWitness<'tx, S>
     for TrieWitness<
-        BaseProofsTrieCursorFactory<'tx, S>,
-        BaseProofsHashedAccountCursorFactory<'tx, S>,
+        BaseProofsTrieCursorFactory<'tx, 'tx, S>,
+        BaseProofsHashedAccountCursorFactory<'tx, 'tx, S>,
     >
 where
     S: BaseProofsStore + 'tx + Clone,
 {
-    fn from_tx(storage: &'tx BaseProofsStorage<S>, block_number: u64) -> Self {
-        Self::new(
-            BaseProofsTrieCursorFactory::new(storage, block_number),
-            BaseProofsHashedAccountCursorFactory::new(storage, block_number),
-        )
-    }
-
     fn overlay_witness(
         storage: &'tx BaseProofsStorage<S>,
         block_number: u64,
@@ -395,13 +391,14 @@ where
     ) -> Result<B256Map<Bytes>, TrieWitnessError> {
         let nodes_sorted = input.nodes.into_sorted();
         let state_sorted = input.state.into_sorted();
-        Self::from_tx(storage, block_number)
-            .with_trie_cursor_factory(InMemoryTrieCursorFactory::new(
-                BaseProofsTrieCursorFactory::new(storage, block_number),
-                &nodes_sorted,
-            ))
+        let tx =
+            storage.ro_tx().map_err(Into::<DatabaseError>::into).map_err(StateProofError::from)?;
+        let trie_factory = BaseProofsTrieCursorFactory::new(storage, &tx, block_number);
+        let hashed_factory = BaseProofsHashedAccountCursorFactory::new(storage, &tx, block_number);
+        TrieWitness::new(trie_factory.clone(), hashed_factory.clone())
+            .with_trie_cursor_factory(InMemoryTrieCursorFactory::new(trie_factory, &nodes_sorted))
             .with_hashed_cursor_factory(HashedPostStateCursorFactory::new(
-                BaseProofsHashedAccountCursorFactory::new(storage, block_number),
+                hashed_factory,
                 &state_sorted,
             ))
             .with_prefix_sets_mut(input.prefix_sets)

--- a/crates/execution/trie/src/proof.rs
+++ b/crates/execution/trie/src/proof.rs
@@ -385,8 +385,10 @@ where
     ) -> Result<B256Map<Bytes>, TrieWitnessError> {
         let nodes_sorted = input.nodes.into_sorted();
         let state_sorted = input.state.into_sorted();
-        let tx =
-            storage.ro_tx().map_err(Into::<DatabaseError>::into).map_err(StateProofError::from)?;
+        let tx = storage.ro_tx().map_err(|error| {
+            let error = Into::<DatabaseError>::into(error);
+            StateProofError::from(error)
+        })?;
         let trie_factory = BaseProofsTrieCursorFactory::new(storage, &tx, block_number);
         let hashed_factory = BaseProofsHashedAccountCursorFactory::new(storage, &tx, block_number);
         TrieWitness::new(trie_factory.clone(), hashed_factory.clone())

--- a/crates/execution/trie/src/proof.rs
+++ b/crates/execution/trie/src/proof.rs
@@ -49,10 +49,7 @@ pub trait DatabaseProof<'tx, S: BaseProofsStore + 'tx> {
 }
 
 impl<'tx, S> DatabaseProof<'tx, S>
-    for Proof<
-        BaseProofsTrieCursorFactory<'tx, 'tx, S>,
-        BaseProofsHashedAccountCursorFactory<'tx, 'tx, S>,
-    >
+    for Proof<BaseProofsTrieCursorFactory<'tx, S>, BaseProofsHashedAccountCursorFactory<'tx, S>>
 where
     S: BaseProofsStore + 'tx + Clone,
 {
@@ -126,8 +123,8 @@ pub trait DatabaseStorageProof<'tx, S: BaseProofsStore + 'tx> {
 impl<'tx, S> DatabaseStorageProof<'tx, S>
     for proof::StorageProof<
         'static,
-        BaseProofsTrieCursorFactory<'tx, 'tx, S>,
-        BaseProofsHashedAccountCursorFactory<'tx, 'tx, S>,
+        BaseProofsTrieCursorFactory<'tx, S>,
+        BaseProofsHashedAccountCursorFactory<'tx, S>,
     >
 where
     S: BaseProofsStore + 'tx + Clone,
@@ -228,10 +225,7 @@ pub trait DatabaseStateRoot<'tx, S: BaseProofsStore + 'tx + Clone>: Sized {
 }
 
 impl<'tx, S> DatabaseStateRoot<'tx, S>
-    for StateRoot<
-        BaseProofsTrieCursorFactory<'tx, 'tx, S>,
-        BaseProofsHashedAccountCursorFactory<'tx, 'tx, S>,
-    >
+    for StateRoot<BaseProofsTrieCursorFactory<'tx, S>, BaseProofsHashedAccountCursorFactory<'tx, S>>
 where
     S: BaseProofsStore + 'tx + Clone,
 {
@@ -332,8 +326,8 @@ pub trait DatabaseStorageRoot<'tx, S: BaseProofsStore + 'tx + Clone> {
 
 impl<'tx, S> DatabaseStorageRoot<'tx, S>
     for StorageRoot<
-        BaseProofsTrieCursorFactory<'tx, 'tx, S>,
-        BaseProofsHashedAccountCursorFactory<'tx, 'tx, S>,
+        BaseProofsTrieCursorFactory<'tx, S>,
+        BaseProofsHashedAccountCursorFactory<'tx, S>,
     >
 where
     S: BaseProofsStore + 'tx + Clone,
@@ -377,8 +371,8 @@ pub trait DatabaseTrieWitness<'tx, S: BaseProofsStore + 'tx + Clone> {
 
 impl<'tx, S> DatabaseTrieWitness<'tx, S>
     for TrieWitness<
-        BaseProofsTrieCursorFactory<'tx, 'tx, S>,
-        BaseProofsHashedAccountCursorFactory<'tx, 'tx, S>,
+        BaseProofsTrieCursorFactory<'tx, S>,
+        BaseProofsHashedAccountCursorFactory<'tx, S>,
     >
 where
     S: BaseProofsStore + 'tx + Clone,

--- a/crates/execution/trie/tests/tx_sharing.rs
+++ b/crates/execution/trie/tests/tx_sharing.rs
@@ -175,3 +175,47 @@ fn back_to_back_calls_acquire_one_tx_each() {
     let delta = storage.tx_acquisitions() - before;
     assert_eq!(delta, 2, "two proof calls should acquire exactly two transactions, got {delta}");
 }
+
+/// `N` concurrent `proof` calls acquire exactly `N` transactions and return
+/// byte-identical proofs — guarding against both tx-sharing regressions
+/// (delta != N) and concurrent state leaks (proofs diverge).
+#[test]
+fn concurrent_calls_acquire_one_tx_per_request() {
+    const N: u64 = 8;
+
+    let (_dir, storage) = setup();
+    let address = Address::repeat_byte(0x11);
+    let slots = [B256::repeat_byte(0x01)];
+
+    let before = storage.tx_acquisitions();
+
+    let proofs: Vec<_> = std::thread::scope(|s| {
+        let handles: Vec<_> = (0..N)
+            .map(|_| {
+                s.spawn(|| {
+                    let provider = BaseProofsStateProviderRef::new(
+                        Box::<NoopProvider>::default(),
+                        &storage,
+                        0,
+                    );
+                    provider.proof(TrieInput::default(), address, &slots).expect("proof")
+                })
+            })
+            .collect();
+        handles.into_iter().map(|h| h.join().expect("thread join")).collect()
+    });
+
+    let delta = storage.tx_acquisitions() - before;
+    assert_eq!(
+        delta, N,
+        "{N} concurrent proof calls should acquire exactly {N} transactions, got {delta}"
+    );
+
+    let baseline = &proofs[0];
+    for (i, p) in proofs.iter().enumerate().skip(1) {
+        assert_eq!(
+            p, baseline,
+            "proof {i} diverges from proof 0 — concurrent state leak suspected"
+        );
+    }
+}

--- a/crates/execution/trie/tests/tx_sharing.rs
+++ b/crates/execution/trie/tests/tx_sharing.rs
@@ -159,20 +159,6 @@ fn storage_root_acquires_one_tx_per_call() {
     });
 }
 
-/// Sanity check on the counter itself: a no-op call sequence should not
-/// increment `tx_acquisitions`. Catches accidental tx acquisitions in
-/// constructors or accessor paths that should be free.
-#[test]
-fn counter_does_not_drift_on_idle() {
-    let (_dir, storage) = setup();
-    let _provider = BaseProofsStateProviderRef::new(Box::<NoopProvider>::default(), &storage, 0);
-
-    let before = storage.tx_acquisitions();
-    // Hold the provider but make no calls. tx_acquisitions must not change.
-    let after = storage.tx_acquisitions();
-    assert_eq!(before, after, "tx_acquisitions drifted while no proof/witness call ran");
-}
-
 /// Two consecutive calls on the same provider acquire exactly two transactions
 /// total — confirming each request is independently scoped (one tx in, one tx
 /// out, no leak across requests).

--- a/crates/execution/trie/tests/tx_sharing.rs
+++ b/crates/execution/trie/tests/tx_sharing.rs
@@ -17,7 +17,10 @@
 use std::sync::Arc;
 
 use alloy_eips::BlockNumHash;
-use alloy_primitives::{Address, B256, U256, keccak256};
+use alloy_primitives::{
+    Address, B256, U256, keccak256,
+    map::{B256Map, B256Set},
+};
 use base_execution_trie::{
     BaseProofsInitialStateStore, BaseProofsStorage, MdbxProofsStorage,
     provider::BaseProofsStateProviderRef,
@@ -29,7 +32,35 @@ use reth_provider::{
 use reth_trie_common::{HashedPostState, HashedStorage, MultiProofTargets, TrieInput};
 use tempfile::TempDir;
 
-/// Builds a small populated MDBX-backed storage and a state provider over it.
+/// Number of accounts we seed and target per test request.
+///
+/// Picked large enough that the underlying account trie has multiple branch
+/// nodes so that `account_trie_cursor` has to open and walk repeatedly within
+/// a single request.
+const ACCOUNTS: u8 = 8;
+
+/// Number of storage slots seeded per account and targeted per request.
+///
+/// Combined with [`ACCOUNTS`] this yields `ACCOUNTS * SLOTS = 32` storage
+/// entries spread across `ACCOUNTS` distinct storage tries, forcing each
+/// overlay path that touches storage to open multiple distinct
+/// `storage_hashed_cursor` and `storage_trie_cursor` cursors per request.
+const SLOTS: u8 = 4;
+
+/// Returns the seeded `(address, [slot; SLOTS])` pairs in the order they were
+/// inserted.
+fn seed_layout() -> Vec<(Address, Vec<B256>)> {
+    (0..ACCOUNTS)
+        .map(|a| {
+            let address = Address::repeat_byte(0x10 | a);
+            let slots = (0..SLOTS).map(|s| B256::repeat_byte(0x01 | (s << 4))).collect();
+            (address, slots)
+        })
+        .collect()
+}
+
+/// Builds an MDBX-backed storage seeded with several accounts and storage
+/// slots so cursor walks have non-trivial work to do.
 ///
 /// Returns the temp dir (must be kept alive for the duration of the test) and
 /// the wrapped storage so the test can read its `tx_acquisitions` counter
@@ -38,24 +69,66 @@ fn setup() -> (TempDir, BaseProofsStorage<Arc<MdbxProofsStorage>>) {
     let dir = TempDir::new().expect("temp dir");
     let mdbx = Arc::new(MdbxProofsStorage::new(dir.path()).expect("mdbx env"));
 
-    // Seed a tiny base state so cursor walks have something to traverse.
-    // The exact contents do not matter; we are counting tx acquisitions, not
-    // verifying proof contents.
-    let address = Address::repeat_byte(0x11);
-    let hashed_address = keccak256(address);
-    let account = Account { nonce: 1, balance: U256::from(1_000), bytecode_hash: None };
-    mdbx.store_hashed_accounts(vec![(hashed_address, Some(account))])
-        .expect("store hashed accounts");
-    mdbx.store_hashed_storages(
-        hashed_address,
-        vec![(keccak256(B256::repeat_byte(0x01)), U256::from(42))],
-    )
-    .expect("store hashed storages");
+    let mut hashed_accounts = Vec::with_capacity(ACCOUNTS as usize);
+    for (i, (address, slots)) in seed_layout().into_iter().enumerate() {
+        let hashed_address = keccak256(address);
+        let account = Account {
+            nonce: i as u64 + 1,
+            balance: U256::from(1_000 * (i as u64 + 1)),
+            bytecode_hash: None,
+        };
+        hashed_accounts.push((hashed_address, Some(account)));
+
+        let hashed_slots: Vec<_> = slots
+            .iter()
+            .enumerate()
+            .map(|(j, slot)| (keccak256(slot), U256::from(42 + j as u64)))
+            .collect();
+        mdbx.store_hashed_storages(hashed_address, hashed_slots).expect("store hashed storages");
+    }
+    mdbx.store_hashed_accounts(hashed_accounts).expect("store hashed accounts");
 
     mdbx.set_initial_state_anchor(BlockNumHash::new(0, B256::ZERO)).expect("anchor");
     mdbx.commit_initial_state().expect("commit");
 
     (dir, BaseProofsStorage::from(mdbx))
+}
+
+/// Builds [`MultiProofTargets`] covering every seeded account and slot so the
+/// overlay paths that take targets actually walk both account and storage
+/// tries multiple times per request.
+fn full_targets() -> MultiProofTargets {
+    let mut targets = B256Map::default();
+    for (address, slots) in seed_layout() {
+        let hashed_slots: B256Set = slots.iter().map(keccak256).collect();
+        targets.insert(keccak256(address), hashed_slots);
+    }
+    MultiProofTargets::from_iter(targets)
+}
+
+/// Builds a [`HashedPostState`] referencing every seeded account and slot.
+///
+/// We do not actually mutate values — we only need the prefix sets to be
+/// non-empty so the state-root, witness, and multiproof computations descend
+/// into both account and storage tries instead of short-circuiting on an
+/// empty input.
+fn full_post_state() -> HashedPostState {
+    let mut state = HashedPostState::default();
+    for (i, (address, slots)) in seed_layout().into_iter().enumerate() {
+        let hashed_address = keccak256(address);
+        let account = Account {
+            nonce: i as u64 + 1,
+            balance: U256::from(1_000 * (i as u64 + 1)),
+            bytecode_hash: None,
+        };
+        state.accounts.insert(hashed_address, Some(account));
+        let hashed_slots = slots
+            .into_iter()
+            .enumerate()
+            .map(|(i, slot)| (keccak256(slot), U256::from(42 + i as u64)));
+        state.storages.insert(hashed_address, HashedStorage::from_iter(false, hashed_slots));
+    }
+    state
 }
 
 /// Asserts that `body` causes exactly `expected` increments on `storage.tx_acquisitions()`.
@@ -80,8 +153,7 @@ fn assert_tx_acquisitions<F>(
 fn proof_acquires_one_tx_per_call() {
     let (_dir, storage) = setup();
     let provider = BaseProofsStateProviderRef::new(Box::<NoopProvider>::default(), &storage, 0);
-    let address = Address::repeat_byte(0x11);
-    let slots = [B256::repeat_byte(0x01)];
+    let (address, slots) = seed_layout().into_iter().next().expect("seed");
 
     assert_tx_acquisitions(&storage, 1, "proof", || {
         provider.proof(TrieInput::default(), address, &slots).expect("proof");
@@ -94,9 +166,7 @@ fn multiproof_acquires_one_tx_per_call() {
     let provider = BaseProofsStateProviderRef::new(Box::<NoopProvider>::default(), &storage, 0);
 
     assert_tx_acquisitions(&storage, 1, "multiproof", || {
-        provider
-            .multiproof(TrieInput::default(), MultiProofTargets::default())
-            .expect("multiproof");
+        provider.multiproof(TrieInput::default(), full_targets()).expect("multiproof");
     });
 }
 
@@ -106,7 +176,9 @@ fn witness_acquires_one_tx_per_call() {
     let provider = BaseProofsStateProviderRef::new(Box::<NoopProvider>::default(), &storage, 0);
 
     assert_tx_acquisitions(&storage, 1, "witness", || {
-        provider.witness(TrieInput::default(), HashedPostState::default()).expect("witness");
+        provider
+            .witness(TrieInput::from_state(full_post_state()), full_post_state())
+            .expect("witness");
     });
 }
 
@@ -116,22 +188,22 @@ fn state_root_acquires_one_tx_per_call() {
     let provider = BaseProofsStateProviderRef::new(Box::<NoopProvider>::default(), &storage, 0);
 
     assert_tx_acquisitions(&storage, 1, "state_root", || {
-        provider.state_root(HashedPostState::default()).expect("state_root");
+        provider.state_root(full_post_state()).expect("state_root");
     });
 
     assert_tx_acquisitions(&storage, 1, "state_root_with_updates", || {
-        provider
-            .state_root_with_updates(HashedPostState::default())
-            .expect("state_root_with_updates");
+        provider.state_root_with_updates(full_post_state()).expect("state_root_with_updates");
     });
 
     assert_tx_acquisitions(&storage, 1, "state_root_from_nodes", || {
-        provider.state_root_from_nodes(TrieInput::default()).expect("state_root_from_nodes");
+        provider
+            .state_root_from_nodes(TrieInput::from_state(full_post_state()))
+            .expect("state_root_from_nodes");
     });
 
     assert_tx_acquisitions(&storage, 1, "state_root_from_nodes_with_updates", || {
         provider
-            .state_root_from_nodes_with_updates(TrieInput::default())
+            .state_root_from_nodes_with_updates(TrieInput::from_state(full_post_state()))
             .expect("state_root_from_nodes_with_updates");
     });
 }
@@ -140,21 +212,23 @@ fn state_root_acquires_one_tx_per_call() {
 fn storage_root_acquires_one_tx_per_call() {
     let (_dir, storage) = setup();
     let provider = BaseProofsStateProviderRef::new(Box::<NoopProvider>::default(), &storage, 0);
-    let address = Address::repeat_byte(0x11);
+    let (address, slots) = seed_layout().into_iter().next().expect("seed");
+    let hashed_storage = HashedStorage::from_iter(
+        false,
+        slots.iter().enumerate().map(|(i, slot)| (keccak256(slot), U256::from(42 + i as u64))),
+    );
 
     assert_tx_acquisitions(&storage, 1, "storage_root", || {
-        provider.storage_root(address, HashedStorage::new(false)).expect("storage_root");
+        provider.storage_root(address, hashed_storage.clone()).expect("storage_root");
     });
 
     assert_tx_acquisitions(&storage, 1, "storage_proof", || {
-        provider
-            .storage_proof(address, B256::repeat_byte(0x01), HashedStorage::new(false))
-            .expect("storage_proof");
+        provider.storage_proof(address, slots[0], hashed_storage.clone()).expect("storage_proof");
     });
 
     assert_tx_acquisitions(&storage, 1, "storage_multiproof", || {
         provider
-            .storage_multiproof(address, &[B256::repeat_byte(0x01)], HashedStorage::new(false))
+            .storage_multiproof(address, &slots, hashed_storage.clone())
             .expect("storage_multiproof");
     });
 }
@@ -166,8 +240,7 @@ fn storage_root_acquires_one_tx_per_call() {
 fn back_to_back_calls_acquire_one_tx_each() {
     let (_dir, storage) = setup();
     let provider = BaseProofsStateProviderRef::new(Box::<NoopProvider>::default(), &storage, 0);
-    let address = Address::repeat_byte(0x11);
-    let slots = [B256::repeat_byte(0x01)];
+    let (address, slots) = seed_layout().into_iter().next().expect("seed");
 
     let before = storage.tx_acquisitions();
     provider.proof(TrieInput::default(), address, &slots).expect("proof 1");
@@ -184,8 +257,7 @@ fn concurrent_calls_acquire_one_tx_per_request() {
     const N: u64 = 8;
 
     let (_dir, storage) = setup();
-    let address = Address::repeat_byte(0x11);
-    let slots = [B256::repeat_byte(0x01)];
+    let (address, slots) = seed_layout().into_iter().next().expect("seed");
 
     let before = storage.tx_acquisitions();
 

--- a/crates/execution/trie/tests/tx_sharing.rs
+++ b/crates/execution/trie/tests/tx_sharing.rs
@@ -1,0 +1,191 @@
+//! Verifies that the production overlay paths acquire exactly one MDBX
+//! read-only transaction per request.
+//!
+//! Each `Proof::overlay_*`, `TrieWitness::overlay_witness`, `StateRoot::overlay_*`,
+//! and `StorageRoot::overlay_root` call must acquire its own transaction at entry
+//! and reuse it across every internal cursor open. Acquiring more than one tx
+//! per request reintroduces the libmdbx `lck_rdt_lock` mutex contention that
+//! reth PR #22631 fixes upstream and that this crate fixes locally for
+//! `v1.11.4`.
+//!
+//! This test runs only with the `metrics` feature because the
+//! [`BaseProofsStorage`] alias resolves to [`BaseProofsStorageWithMetrics`]
+//! there, which exposes the per-instance `tx_acquisitions` counter we need.
+
+#![cfg(feature = "metrics")]
+
+use std::sync::Arc;
+
+use alloy_eips::BlockNumHash;
+use alloy_primitives::{Address, B256, U256, keccak256};
+use base_execution_trie::{
+    BaseProofsInitialStateStore, BaseProofsStorage, MdbxProofsStorage,
+    provider::BaseProofsStateProviderRef,
+};
+use reth_primitives_traits::Account;
+use reth_provider::{
+    StateProofProvider, StateRootProvider, StorageRootProvider, noop::NoopProvider,
+};
+use reth_trie_common::{HashedPostState, HashedStorage, MultiProofTargets, TrieInput};
+use tempfile::TempDir;
+
+/// Builds a small populated MDBX-backed storage and a state provider over it.
+///
+/// Returns the temp dir (must be kept alive for the duration of the test) and
+/// the wrapped storage so the test can read its `tx_acquisitions` counter
+/// before and after each call.
+fn setup() -> (TempDir, BaseProofsStorage<Arc<MdbxProofsStorage>>) {
+    let dir = TempDir::new().expect("temp dir");
+    let mdbx = Arc::new(MdbxProofsStorage::new(dir.path()).expect("mdbx env"));
+
+    // Seed a tiny base state so cursor walks have something to traverse.
+    // The exact contents do not matter; we are counting tx acquisitions, not
+    // verifying proof contents.
+    let address = Address::repeat_byte(0x11);
+    let hashed_address = keccak256(address);
+    let account = Account { nonce: 1, balance: U256::from(1_000), bytecode_hash: None };
+    mdbx.store_hashed_accounts(vec![(hashed_address, Some(account))])
+        .expect("store hashed accounts");
+    mdbx.store_hashed_storages(
+        hashed_address,
+        vec![(keccak256(B256::repeat_byte(0x01)), U256::from(42))],
+    )
+    .expect("store hashed storages");
+
+    mdbx.set_initial_state_anchor(BlockNumHash::new(0, B256::ZERO)).expect("anchor");
+    mdbx.commit_initial_state().expect("commit");
+
+    (dir, BaseProofsStorage::from(mdbx))
+}
+
+/// Asserts that `body` causes exactly `expected` increments on `storage.tx_acquisitions()`.
+fn assert_tx_acquisitions<F>(
+    storage: &BaseProofsStorage<Arc<MdbxProofsStorage>>,
+    expected: u64,
+    label: &str,
+    body: F,
+) where
+    F: FnOnce(),
+{
+    let before = storage.tx_acquisitions();
+    body();
+    let delta = storage.tx_acquisitions() - before;
+    assert_eq!(
+        delta, expected,
+        "{label}: expected exactly {expected} tx acquisition(s), got {delta}"
+    );
+}
+
+#[test]
+fn proof_acquires_one_tx_per_call() {
+    let (_dir, storage) = setup();
+    let provider = BaseProofsStateProviderRef::new(Box::<NoopProvider>::default(), &storage, 0);
+    let address = Address::repeat_byte(0x11);
+    let slots = [B256::repeat_byte(0x01)];
+
+    assert_tx_acquisitions(&storage, 1, "proof", || {
+        provider.proof(TrieInput::default(), address, &slots).expect("proof");
+    });
+}
+
+#[test]
+fn multiproof_acquires_one_tx_per_call() {
+    let (_dir, storage) = setup();
+    let provider = BaseProofsStateProviderRef::new(Box::<NoopProvider>::default(), &storage, 0);
+
+    assert_tx_acquisitions(&storage, 1, "multiproof", || {
+        provider
+            .multiproof(TrieInput::default(), MultiProofTargets::default())
+            .expect("multiproof");
+    });
+}
+
+#[test]
+fn witness_acquires_one_tx_per_call() {
+    let (_dir, storage) = setup();
+    let provider = BaseProofsStateProviderRef::new(Box::<NoopProvider>::default(), &storage, 0);
+
+    assert_tx_acquisitions(&storage, 1, "witness", || {
+        provider.witness(TrieInput::default(), HashedPostState::default()).expect("witness");
+    });
+}
+
+#[test]
+fn state_root_acquires_one_tx_per_call() {
+    let (_dir, storage) = setup();
+    let provider = BaseProofsStateProviderRef::new(Box::<NoopProvider>::default(), &storage, 0);
+
+    assert_tx_acquisitions(&storage, 1, "state_root", || {
+        provider.state_root(HashedPostState::default()).expect("state_root");
+    });
+
+    assert_tx_acquisitions(&storage, 1, "state_root_with_updates", || {
+        provider
+            .state_root_with_updates(HashedPostState::default())
+            .expect("state_root_with_updates");
+    });
+
+    assert_tx_acquisitions(&storage, 1, "state_root_from_nodes", || {
+        provider.state_root_from_nodes(TrieInput::default()).expect("state_root_from_nodes");
+    });
+
+    assert_tx_acquisitions(&storage, 1, "state_root_from_nodes_with_updates", || {
+        provider
+            .state_root_from_nodes_with_updates(TrieInput::default())
+            .expect("state_root_from_nodes_with_updates");
+    });
+}
+
+#[test]
+fn storage_root_acquires_one_tx_per_call() {
+    let (_dir, storage) = setup();
+    let provider = BaseProofsStateProviderRef::new(Box::<NoopProvider>::default(), &storage, 0);
+    let address = Address::repeat_byte(0x11);
+
+    assert_tx_acquisitions(&storage, 1, "storage_root", || {
+        provider.storage_root(address, HashedStorage::new(false)).expect("storage_root");
+    });
+
+    assert_tx_acquisitions(&storage, 1, "storage_proof", || {
+        provider
+            .storage_proof(address, B256::repeat_byte(0x01), HashedStorage::new(false))
+            .expect("storage_proof");
+    });
+
+    assert_tx_acquisitions(&storage, 1, "storage_multiproof", || {
+        provider
+            .storage_multiproof(address, &[B256::repeat_byte(0x01)], HashedStorage::new(false))
+            .expect("storage_multiproof");
+    });
+}
+
+/// Sanity check on the counter itself: a no-op call sequence should not
+/// increment `tx_acquisitions`. Catches accidental tx acquisitions in
+/// constructors or accessor paths that should be free.
+#[test]
+fn counter_does_not_drift_on_idle() {
+    let (_dir, storage) = setup();
+    let _provider = BaseProofsStateProviderRef::new(Box::<NoopProvider>::default(), &storage, 0);
+
+    let before = storage.tx_acquisitions();
+    // Hold the provider but make no calls. tx_acquisitions must not change.
+    let after = storage.tx_acquisitions();
+    assert_eq!(before, after, "tx_acquisitions drifted while no proof/witness call ran");
+}
+
+/// Two consecutive calls on the same provider acquire exactly two transactions
+/// total — confirming each request is independently scoped (one tx in, one tx
+/// out, no leak across requests).
+#[test]
+fn back_to_back_calls_acquire_one_tx_each() {
+    let (_dir, storage) = setup();
+    let provider = BaseProofsStateProviderRef::new(Box::<NoopProvider>::default(), &storage, 0);
+    let address = Address::repeat_byte(0x11);
+    let slots = [B256::repeat_byte(0x01)];
+
+    let before = storage.tx_acquisitions();
+    provider.proof(TrieInput::default(), address, &slots).expect("proof 1");
+    provider.proof(TrieInput::default(), address, &slots).expect("proof 2");
+    let delta = storage.tx_acquisitions() - before;
+    assert_eq!(delta, 2, "two proof calls should acquire exactly two transactions, got {delta}");
+}


### PR DESCRIPTION
## Problem

`MdbxProofsStorage` opens a fresh RO transaction for every cursor. With `MDBX_NOTLS`, each `mdbx_txn_begin_ex` contends libmdbx's `lck_rdt_lock` mutex. Sepolia proofs node:
- `eth_getProof` p50: 30µs → 91ms
- `debug_executePayload` p99: 1.09s → 70.4s (max 315s)

## Fix

One RO tx per proof/witness/state-root request, threaded through every cursor.

- `BaseProofsStore` gains `Tx`, `ro_tx()`, and `*_cursor_with_tx` variants. Old methods stay (back tests + single-cursor reads).
- Factories now borrow `&Tx` (matches reth's `DatabaseTrieCursorFactory<&TX>` pattern).
- `proof.rs` opens one tx per `overlay_*` and threads it through all nested factories.

## Verification

- `cargo test -p base-execution-trie --features metrics`: 231 pass
- 6 new tests in `tests/tx_sharing.rs` assert tx count == 1 per request via a new `tx_acquisitions` counter on the metrics wrapper
- Clippy clean, downstream consumers compile
- Prod latency (`<200ms`) needs staging verification