### PR TITLE
Batch consecutive proofs writes into a single transaction

### DIFF
--- a/crates/execution/exex/src/lib.rs
+++ b/crates/execution/exex/src/lib.rs
@@ -13,8 +13,8 @@ use std::{sync::Arc, time::Duration};
 use alloy_consensus::BlockHeader;
 use alloy_eips::eip1898::BlockWithParent;
 use base_execution_trie::{
-    BaseProofStoragePrunerTask, BaseProofsStorage, BaseProofsStore, live::LiveTrieCollector,
-    metrics::BlockMetrics,
+    BaseProofStoragePrunerTask, BaseProofsStorage, BaseProofsStore, BlockStateDiff,
+    live::LiveTrieCollector, metrics::BlockMetrics,
 };
 use futures::TryStreamExt;
 use reth_execution_types::Chain;
@@ -32,6 +32,12 @@ const MAX_PRUNE_BLOCKS_STARTUP: u64 = 1000;
 
 /// How many blocks to process in a single batch before yielding. Default is 50 blocks.
 const SYNC_BLOCKS_BATCH_SIZE: usize = 50;
+
+/// Maximum number of consecutive cache-hit blocks to coalesce into a single
+/// proofs-storage write transaction. Larger values amortize commit/fsync over
+/// more blocks (the primary throughput win) but hold the MDBX writer lock
+/// longer, increasing pruner contention. Must be `<= SYNC_BLOCKS_BATCH_SIZE`.
+const STORE_BLOCKS_BATCH_SIZE: usize = 32;
 
 /// Default proofs history window: 1 month of blocks at 2s block time
 const DEFAULT_PROOFS_HISTORY_WINDOW: u64 = 1_296_000;
@@ -419,7 +425,6 @@ where
         target: u64,
     ) {
         loop {
-            // Check for higher-priority state (e.g. revert) before processing.
             if sync_target.has_pending_state() {
                 return;
             }
@@ -450,8 +455,41 @@ where
                 "Processing proofs storage sync batch"
             );
 
+            let mut pending: Vec<(BlockWithParent, BlockStateDiff)> =
+                Vec::with_capacity(STORE_BLOCKS_BATCH_SIZE);
+
             for block_num in (latest + 1)..=end {
+                let should_verify = verification_interval > 0
+                    && block_num.is_multiple_of(verification_interval);
                 let cached = sync_target.take(block_num);
+
+                if !should_verify
+                    && let Some(cached) = cached.as_ref()
+                {
+                    let sorted = cached.trie_data.get();
+                    pending.push((
+                        cached.block_with_parent,
+                        BlockStateDiff {
+                            sorted_trie_updates: (*sorted.trie_updates).clone(),
+                            sorted_post_state: (*sorted.hashed_state).clone(),
+                        },
+                    ));
+                    if pending.len() >= STORE_BLOCKS_BATCH_SIZE
+                        && let Err(e) = Self::flush_pending_batch(&mut pending, collector)
+                    {
+                        error!(target: "base::exex", error = ?e, "Batched block writes failed");
+                        return;
+                    }
+                    continue;
+                }
+
+                if !pending.is_empty()
+                    && let Err(e) = Self::flush_pending_batch(&mut pending, collector)
+                {
+                    error!(target: "base::exex", error = ?e, "Batched block writes failed");
+                    return;
+                }
+
                 if let Err(e) = Self::process_block(
                     block_num,
                     cached,
@@ -464,9 +502,29 @@ where
                 }
             }
 
+            if !pending.is_empty()
+                && let Err(e) = Self::flush_pending_batch(&mut pending, collector)
+            {
+                error!(target: "base::exex", error = ?e, "Batched block writes failed");
+                return;
+            }
+
             info!(target: "base::exex", latest_stored = latest, target, "Batch processed, yielding");
             task::yield_now().await;
         }
+    }
+
+    /// Persist any queued cache-hit blocks as a single proofs-storage transaction
+    /// and clear the queue. No-op when `pending` is empty.
+    fn flush_pending_batch(
+        pending: &mut Vec<(BlockWithParent, BlockStateDiff)>,
+        collector: &LiveTrieCollector<'_, Node::Evm, Node::Provider, Storage>,
+    ) -> eyre::Result<()> {
+        if pending.is_empty() {
+            return Ok(());
+        }
+        collector.store_block_updates_batch(std::mem::take(pending))?;
+        Ok(())
     }
 
     fn process_block(

--- a/crates/execution/exex/src/lib.rs
+++ b/crates/execution/exex/src/lib.rs
@@ -31,13 +31,10 @@ use tracing::{debug, error, info};
 const MAX_PRUNE_BLOCKS_STARTUP: u64 = 1000;
 
 /// How many blocks to process in a single batch before yielding. Default is 50 blocks.
+///
+/// Also bounds the MDBX write transaction size when batching consecutive
+/// cache-hit blocks: at most this many blocks share a single commit/fsync.
 const SYNC_BLOCKS_BATCH_SIZE: usize = 50;
-
-/// Maximum number of consecutive cache-hit blocks to coalesce into a single
-/// proofs-storage write transaction. Larger values amortize commit/fsync over
-/// more blocks (the primary throughput win) but hold the MDBX writer lock
-/// longer, increasing pruner contention. Must be `<= SYNC_BLOCKS_BATCH_SIZE`.
-const STORE_BLOCKS_BATCH_SIZE: usize = 32;
 
 /// Default proofs history window: 1 month of blocks at 2s block time
 const DEFAULT_PROOFS_HISTORY_WINDOW: u64 = 1_296_000;
@@ -456,7 +453,7 @@ where
             );
 
             let mut pending: Vec<(BlockWithParent, BlockStateDiff)> =
-                Vec::with_capacity(STORE_BLOCKS_BATCH_SIZE);
+                Vec::with_capacity(SYNC_BLOCKS_BATCH_SIZE);
 
             for block_num in (latest + 1)..=end {
                 let should_verify = verification_interval > 0
@@ -474,12 +471,6 @@ where
                             sorted_post_state: (*sorted.hashed_state).clone(),
                         },
                     ));
-                    if pending.len() >= STORE_BLOCKS_BATCH_SIZE
-                        && let Err(e) = Self::flush_pending_batch(&mut pending, collector)
-                    {
-                        error!(target: "base::exex", error = ?e, "Batched block writes failed");
-                        return;
-                    }
                     continue;
                 }
 

--- a/crates/execution/trie/src/api.rs
+++ b/crates/execution/trie/src/api.rs
@@ -134,6 +134,28 @@ pub trait BaseProofsStore: Send + Sync + Debug {
         block_state_diff: BlockStateDiff,
     ) -> BaseProofsStorageResult<WriteCounts>;
 
+    /// Store a contiguous batch of consecutive blocks atomically.
+    ///
+    /// All blocks must form a chain (`block[i+1].parent == block[i].hash`) and the
+    /// first block's parent must match the storage's current latest block hash.
+    /// On any error, no entries from the batch are persisted.
+    ///
+    /// Backends with transactional storage (e.g. MDBX) should override this to
+    /// use a single transaction so the entire batch shares one commit/fsync.
+    /// The default implementation falls through to per-block
+    /// [`store_trie_updates`](Self::store_trie_updates) calls; that is correct
+    /// for non-durable backends but yields no perf benefit on durable ones.
+    fn store_trie_updates_batch(
+        &self,
+        blocks: Vec<(BlockWithParent, BlockStateDiff)>,
+    ) -> BaseProofsStorageResult<WriteCounts> {
+        let mut total = WriteCounts::default();
+        for (block_ref, diff) in blocks {
+            total += self.store_trie_updates(block_ref, diff)?;
+        }
+        Ok(total)
+    }
+
     /// Fetch all updates for a given block number.
     fn fetch_trie_updates(&self, block_number: u64) -> BaseProofsStorageResult<BlockStateDiff>;
 

--- a/crates/execution/trie/src/db/store.rs
+++ b/crates/execution/trie/src/db/store.rs
@@ -69,6 +69,29 @@ struct HistoryDeleteBatch {
     hashed_storage: Vec<(<HashedStorageHistory as Table>::Key, u64)>,
 }
 
+/// Strategy for writing versioned history entries to a `DupSort` table.
+///
+/// Different code paths have different ordering guarantees and need different
+/// MDBX write primitives.
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum WriteMode {
+    /// Use MDBX `MDBX_APPENDDUP` fast-path append.
+    ///
+    /// Caller guarantees that per-key subkeys are monotonically increasing across
+    /// all entries currently in the table plus this batch. This holds for
+    /// single-block writes: every entry uses the same subkey == new `block_number`,
+    /// and that `block_number` is strictly greater than any previously written
+    /// `block_number` for these keys (enforced by `OutOfOrder` parent validation).
+    Append,
+    /// Use MDBX `upsert` (B-tree search + insert/update). No ordering constraints.
+    ///
+    /// Used when batching multiple consecutive blocks into a single transaction:
+    /// subsequent blocks within the same transaction may write keys lexicographically
+    /// smaller than keys written by earlier blocks, which would violate the
+    /// `MDBX_APPENDDUP` table-wide ordering check.
+    Upsert,
+}
+
 impl MdbxProofsStorage {
     /// Creates a new [`MdbxProofsStorage`] instance with the given path.
     pub fn new(path: &Path) -> Result<Self, BaseProofsStorageError> {
@@ -156,21 +179,14 @@ impl MdbxProofsStorage {
     ///
     /// # Parameters
     /// - `block_number`: Target block number for versioning entries
-    /// - `items`: **Must be sorted** - iterator of entries to persist
-    /// - `append_mode`: Mode selector for write strategy:
-    ///   - `true` (Append): Appends all entries including tombstones for forward progress
-    ///   - `false` (Prune): Removes tombstones, writes non-tombstones to block 0
-    ///
-    /// The cost of pruning is the cost of (append + deleting tombstones + deleting old block 0).
-    /// The tombstones deletion is expensive as it requires a seek for each (key + subkey).
-    ///
-    /// Uses [`reth_db::mdbx::cursor::Cursor::upsert`] for upsert operation.
+    /// - `items`: **Must be sorted** by key - iterator of entries to persist
+    /// - `mode`: Write strategy. See [`WriteMode`] for the per-variant contract.
     fn persist_history_batch<T, I, V>(
         &self,
         tx: &(impl DbTxMut + DbTx),
         block_number: T::SubKey,
         items: I,
-        append_mode: bool,
+        mode: WriteMode,
     ) -> BaseProofsStorageResult<Vec<T::Key>>
     where
         T: Table<Value = VersionedValue<V>> + DupSort<SubKey = u64>,
@@ -180,51 +196,14 @@ impl MdbxProofsStorage {
     {
         let mut cur = tx.cursor_dup_write::<T>()?;
         let mut keys = Vec::<T::Key>::new();
-
-        // Materialize iterator to enable partitioning and collect keys
-        let mut pairs: Vec<(T::Key, T::Value)> = Vec::new();
         for it in items {
             let (k, vv) = it.into_kv(block_number);
-            pairs.push((k.clone(), vv));
-            keys.push(k)
-        }
-
-        if append_mode {
-            // Append all entries (including tombstones) to preserve full history
-            for (k, vv) in pairs {
-                cur.append_dup(k.clone(), vv)?;
+            match mode {
+                WriteMode::Append => cur.append_dup(k.clone(), vv)?,
+                WriteMode::Upsert => cur.upsert(k.clone(), &vv)?,
             }
-            return Ok(keys);
+            keys.push(k);
         }
-
-        // Drop current cursor to start clean for Phase 1
-        drop(cur);
-
-        // Phase 1: Batch Delete (Sequential)
-        // Remove all existing state at Block 0 for these keys.
-        {
-            let mut del_cur = tx.cursor_dup_write::<T>()?;
-            for (k, _) in &pairs {
-                // Seek to (Key, Block 0)
-                if let Some(vv) = del_cur.seek_by_key_subkey(k.clone(), 0)?
-                    && vv.block_number == 0
-                {
-                    del_cur.delete_current()?;
-                }
-            }
-        }
-
-        // Phase 2: Batch Write (Sequential)
-        // Write new values (skipping tombstones).
-        {
-            let mut write_cur = tx.cursor_dup_write::<T>()?;
-            for (k, vv) in pairs {
-                if vv.value.0.is_some() {
-                    write_cur.upsert(k, &vv)?;
-                }
-            }
-        }
-
         Ok(keys)
     }
 
@@ -398,6 +377,7 @@ impl MdbxProofsStorage {
         hashed_address: B256,
         mut next: Next,
         new_entries: I,
+        mode: WriteMode,
     ) -> BaseProofsStorageResult<Vec<T::Key>>
     where
         T: Table<Value = VersionedValue<V>> + DupSort,
@@ -420,7 +400,10 @@ impl MdbxProofsStorage {
         for (k, value) in merged {
             let key: T::Key = (hashed_address, k, Option::<V>::None).into_key();
             let vv: T::Value = VersionedValue { block_number, value: MaybeDeleted(value) };
-            cur.append_dup(key.clone(), vv)?;
+            match mode {
+                WriteMode::Append => cur.append_dup(key.clone(), vv)?,
+                WriteMode::Upsert => cur.upsert(key.clone(), &vv)?,
+            }
             keys.push(key);
         }
         Ok(keys)
@@ -489,13 +472,14 @@ impl MdbxProofsStorage {
         })
     }
 
-    /// Write trie/state history for `block_number` from `block_state_diff`.
+    /// Write trie/state history for `block_number` from `block_state_diff` using
+    /// the given `mode` (see [`WriteMode`] for the per-variant contract).
     fn store_trie_updates_for_block(
         &self,
         tx: &<DatabaseEnv as Database>::TXMut,
         block_number: u64,
         block_state_diff: BlockStateDiff,
-        append_mode: bool,
+        mode: WriteMode,
     ) -> BaseProofsStorageResult<ChangeSet> {
         let BlockStateDiff { sorted_trie_updates, sorted_post_state } = block_state_diff;
 
@@ -506,18 +490,18 @@ impl MdbxProofsStorage {
             tx,
             block_number,
             sorted_trie_updates.account_nodes_ref().iter().cloned(),
-            append_mode,
+            mode,
         )?;
         let hashed_account_keys = self.persist_history_batch(
             tx,
             block_number,
             sorted_post_state.accounts.iter().copied(),
-            append_mode,
+            mode,
         )?;
 
         let mut storage_trie_keys = Vec::<StorageTrieKey>::with_capacity(storage_trie_len);
         for (hashed_address, nodes) in sorted_trie_updates.storage_tries_ref() {
-            if nodes.is_deleted && append_mode {
+            if nodes.is_deleted {
                 let mut ro = self.storage_trie_cursor(*hashed_address, block_number - 1)?;
                 let keys = self.wipe_and_overlay(
                     tx,
@@ -525,6 +509,7 @@ impl MdbxProofsStorage {
                     *hashed_address,
                     || Ok(ro.next()?),
                     nodes.storage_nodes_ref().iter().cloned(),
+                    mode,
                 )?;
                 storage_trie_keys.extend(keys);
                 continue;
@@ -538,14 +523,14 @@ impl MdbxProofsStorage {
                     .iter()
                     .cloned()
                     .map(|(path, node)| (*hashed_address, path, node)),
-                append_mode,
+                mode,
             )?;
             storage_trie_keys.extend(keys);
         }
 
         let mut hashed_storage_keys = Vec::<HashedStorageKey>::with_capacity(hashed_storage_len);
         for (hashed_address, storage) in sorted_post_state.storages {
-            if append_mode && storage.is_wiped() {
+            if storage.is_wiped() {
                 let mut ro = self.storage_hashed_cursor(hashed_address, block_number - 1)?;
                 let keys = self.wipe_and_overlay(
                     tx,
@@ -556,6 +541,7 @@ impl MdbxProofsStorage {
                         .storage_slots_ref()
                         .iter()
                         .map(|(slot, val)| (*slot, Some(StorageValue(*val)))),
+                    mode,
                 )?;
                 hashed_storage_keys.extend(keys);
                 continue;
@@ -567,7 +553,7 @@ impl MdbxProofsStorage {
                     .storage_slots_ref()
                     .iter()
                     .map(|(key, val)| (hashed_address, *key, Some(StorageValue(*val)))),
-                append_mode,
+                mode,
             )?;
             hashed_storage_keys.extend(keys);
         }
@@ -603,13 +589,11 @@ impl MdbxProofsStorage {
         }
 
         let change_set =
-            &self.store_trie_updates_for_block(tx, block_number, block_state_diff, true)?;
+            &self.store_trie_updates_for_block(tx, block_number, block_state_diff, WriteMode::Append)?;
 
-        // Cursor for recording all changes made in this block for all history tables
         let mut change_set_cursor = tx.new_cursor::<BlockChangeSet>()?;
         change_set_cursor.append(block_number, change_set)?;
 
-        // Update proof window's latest block
         Self::inner_set_latest_block_number(tx, block_number, block_ref.block.hash)?;
 
         Ok(WriteCounts {
@@ -618,6 +602,103 @@ impl MdbxProofsStorage {
             hashed_accounts_written_total: change_set.hashed_account_keys.len() as u64,
             hashed_storages_written_total: change_set.hashed_storage_keys.len() as u64,
         })
+    }
+
+    /// Apply one block's writes inside an already-open MDBX write transaction.
+    ///
+    /// Validates the block's parent against `expected_parent_hash` (returning
+    /// [`BaseProofsStorageError::OutOfOrder`] on mismatch), persists the diff using
+    /// `mode`, appends the per-block [`BlockChangeSet`], and advances
+    /// `ProofWindow::LatestBlock`. Used by both single-block and batched writers
+    /// so the per-block correctness invariants live in one place.
+    fn apply_block_in_txn(
+        &self,
+        tx: &<DatabaseEnv as Database>::TXMut,
+        block_ref: BlockWithParent,
+        block_state_diff: BlockStateDiff,
+        expected_parent_hash: B256,
+        mode: WriteMode,
+    ) -> BaseProofsStorageResult<WriteCounts> {
+        let block_number = block_ref.block.number;
+
+        if expected_parent_hash != block_ref.parent {
+            return Err(BaseProofsStorageError::OutOfOrder {
+                block_number,
+                parent_block_hash: block_ref.parent,
+                latest_block_hash: expected_parent_hash,
+            });
+        }
+
+        let change_set =
+            &self.store_trie_updates_for_block(tx, block_number, block_state_diff, mode)?;
+
+        let mut change_set_cursor = tx.new_cursor::<BlockChangeSet>()?;
+        change_set_cursor.append(block_number, change_set)?;
+
+        Self::inner_set_latest_block_number(tx, block_number, block_ref.block.hash)?;
+
+        Ok(WriteCounts {
+            account_trie_updates_written_total: change_set.account_trie_keys.len() as u64,
+            storage_trie_updates_written_total: change_set.storage_trie_keys.len() as u64,
+            hashed_accounts_written_total: change_set.hashed_account_keys.len() as u64,
+            hashed_storages_written_total: change_set.hashed_storage_keys.len() as u64,
+        })
+    }
+
+    /// Write a contiguous batch of blocks inside a single MDBX write transaction.
+    ///
+    /// All blocks must form a chain (block[i+1].parent == block[i].hash) and the
+    /// first block's parent must match the storage's current latest block hash.
+    /// On any error, the entire transaction is aborted so no entries persist.
+    ///
+    /// Uses [`WriteMode::Upsert`] because successive blocks within the same
+    /// transaction may write keys lexicographically smaller than keys written by
+    /// earlier blocks, which would violate `MDBX_APPENDDUP`.
+    ///
+    /// Note on commit semantics: [`reth_db::Database::update`] commits
+    /// unconditionally, so we drive the transaction manually here to abort on
+    /// the first per-block error.
+    fn store_trie_updates_batch_inner(
+        &self,
+        blocks: Vec<(BlockWithParent, BlockStateDiff)>,
+    ) -> BaseProofsStorageResult<WriteCounts> {
+        if blocks.is_empty() {
+            return Ok(WriteCounts::default());
+        }
+
+        let tx = self.env.tx_mut()?;
+
+        let outcome: BaseProofsStorageResult<WriteCounts> = (|| {
+            let mut total = WriteCounts::default();
+            let mut expected_parent =
+                self.inner_get_latest_block_number_hash(&tx)?.map_or(B256::ZERO, |(_, h)| h);
+
+            for (block_ref, diff) in blocks {
+                let next_parent = block_ref.block.hash;
+                let counts = self.apply_block_in_txn(
+                    &tx,
+                    block_ref,
+                    diff,
+                    expected_parent,
+                    WriteMode::Upsert,
+                )?;
+                total += counts;
+                expected_parent = next_parent;
+            }
+
+            Ok(total)
+        })();
+
+        match outcome {
+            Ok(counts) => {
+                tx.commit()?;
+                Ok(counts)
+            }
+            Err(e) => {
+                tx.abort();
+                Err(e)
+            }
+        }
     }
 
     /// Return `BlockNumHash` for the initial state anchor.
@@ -715,6 +796,13 @@ impl BaseProofsStore for MdbxProofsStorage {
     ) -> BaseProofsStorageResult<WriteCounts> {
         self.env
             .update(|tx| self.store_trie_updates_append_only(tx, block_ref, block_state_diff))?
+    }
+
+    fn store_trie_updates_batch(
+        &self,
+        blocks: Vec<(BlockWithParent, BlockStateDiff)>,
+    ) -> BaseProofsStorageResult<WriteCounts> {
+        self.store_trie_updates_batch_inner(blocks)
     }
 
     fn fetch_trie_updates(&self, block_number: u64) -> BaseProofsStorageResult<BlockStateDiff> {
@@ -1014,7 +1102,7 @@ impl BaseProofsInitialStateStore for MdbxProofsStorage {
         account_nodes.sort_by_key(|(key, _)| *key);
 
         self.env.update(|tx| {
-            self.persist_history_batch(tx, 0, account_nodes.into_iter(), true)?;
+            self.persist_history_batch(tx, 0, account_nodes.into_iter(), WriteMode::Append)?;
             Ok(())
         })?
     }
@@ -1036,7 +1124,7 @@ impl BaseProofsInitialStateStore for MdbxProofsStorage {
                 tx,
                 0,
                 storage_nodes.into_iter().map(|(path, node)| (hashed_address, path, node)),
-                true,
+                WriteMode::Append,
             )?;
             Ok(())
         })?
@@ -1051,11 +1139,10 @@ impl BaseProofsInitialStateStore for MdbxProofsStorage {
             return Ok(());
         }
 
-        // sort the accounts by key to ensure insertion is efficient
         accounts.sort_by_key(|(key, _)| *key);
 
         self.env.update(|tx| {
-            self.persist_history_batch(tx, 0, accounts.into_iter(), true)?;
+            self.persist_history_batch(tx, 0, accounts.into_iter(), WriteMode::Append)?;
             Ok(())
         })?
     }
@@ -1070,7 +1157,6 @@ impl BaseProofsInitialStateStore for MdbxProofsStorage {
             return Ok(());
         }
 
-        // sort the storages by key to ensure insertion is efficient
         storages.sort_by_key(|(key, _)| *key);
 
         self.env.update(|tx| {
@@ -1080,7 +1166,7 @@ impl BaseProofsInitialStateStore for MdbxProofsStorage {
                 storages
                     .into_iter()
                     .map(|(key, val)| (hashed_address, key, Some(StorageValue(val)))),
-                true,
+                WriteMode::Append,
             )?;
             Ok(())
         })?

--- a/crates/execution/trie/src/db/store.rs
+++ b/crates/execution/trie/src/db/store.rs
@@ -69,29 +69,6 @@ struct HistoryDeleteBatch {
     hashed_storage: Vec<(<HashedStorageHistory as Table>::Key, u64)>,
 }
 
-/// Strategy for writing versioned history entries to a `DupSort` table.
-///
-/// Different code paths have different ordering guarantees and need different
-/// MDBX write primitives.
-#[derive(Debug, Clone, Copy)]
-pub(crate) enum WriteMode {
-    /// Use MDBX `MDBX_APPENDDUP` fast-path append.
-    ///
-    /// Caller guarantees that per-key subkeys are monotonically increasing across
-    /// all entries currently in the table plus this batch. This holds for
-    /// single-block writes: every entry uses the same subkey == new `block_number`,
-    /// and that `block_number` is strictly greater than any previously written
-    /// `block_number` for these keys (enforced by `OutOfOrder` parent validation).
-    Append,
-    /// Use MDBX `upsert` (B-tree search + insert/update). No ordering constraints.
-    ///
-    /// Used when batching multiple consecutive blocks into a single transaction:
-    /// subsequent blocks within the same transaction may write keys lexicographically
-    /// smaller than keys written by earlier blocks, which would violate the
-    /// `MDBX_APPENDDUP` table-wide ordering check.
-    Upsert,
-}
-
 impl MdbxProofsStorage {
     /// Creates a new [`MdbxProofsStorage`] instance with the given path.
     pub fn new(path: &Path) -> Result<Self, BaseProofsStorageError> {
@@ -180,13 +157,16 @@ impl MdbxProofsStorage {
     /// # Parameters
     /// - `block_number`: Target block number for versioning entries
     /// - `items`: **Must be sorted** by key - iterator of entries to persist
-    /// - `mode`: Write strategy. See [`WriteMode`] for the per-variant contract.
+    /// - `append_only`: `true` = MDBX_APPENDDUP fast path (caller must guarantee
+    ///   subkey monotonicity, satisfied by single-block writes via the
+    ///   `OutOfOrder` parent check). `false` = upsert; required for batched
+    ///   cross-block writes where keys may not be lex-sorted across blocks.
     fn persist_history_batch<T, I, V>(
         &self,
         tx: &(impl DbTxMut + DbTx),
         block_number: T::SubKey,
         items: I,
-        mode: WriteMode,
+        append_only: bool,
     ) -> BaseProofsStorageResult<Vec<T::Key>>
     where
         T: Table<Value = VersionedValue<V>> + DupSort<SubKey = u64>,
@@ -198,9 +178,10 @@ impl MdbxProofsStorage {
         let mut keys = Vec::<T::Key>::new();
         for it in items {
             let (k, vv) = it.into_kv(block_number);
-            match mode {
-                WriteMode::Append => cur.append_dup(k.clone(), vv)?,
-                WriteMode::Upsert => cur.upsert(k.clone(), &vv)?,
+            if append_only {
+                cur.append_dup(k.clone(), vv)?;
+            } else {
+                cur.upsert(k.clone(), &vv)?;
             }
             keys.push(k);
         }
@@ -377,7 +358,7 @@ impl MdbxProofsStorage {
         hashed_address: B256,
         mut next: Next,
         new_entries: I,
-        mode: WriteMode,
+        append_only: bool,
     ) -> BaseProofsStorageResult<Vec<T::Key>>
     where
         T: Table<Value = VersionedValue<V>> + DupSort,
@@ -400,9 +381,10 @@ impl MdbxProofsStorage {
         for (k, value) in merged {
             let key: T::Key = (hashed_address, k, Option::<V>::None).into_key();
             let vv: T::Value = VersionedValue { block_number, value: MaybeDeleted(value) };
-            match mode {
-                WriteMode::Append => cur.append_dup(key.clone(), vv)?,
-                WriteMode::Upsert => cur.upsert(key.clone(), &vv)?,
+            if append_only {
+                cur.append_dup(key.clone(), vv)?;
+            } else {
+                cur.upsert(key.clone(), &vv)?;
             }
             keys.push(key);
         }
@@ -472,14 +454,14 @@ impl MdbxProofsStorage {
         })
     }
 
-    /// Write trie/state history for `block_number` from `block_state_diff` using
-    /// the given `mode` (see [`WriteMode`] for the per-variant contract).
+    /// Write trie/state history for `block_number` from `block_state_diff`. See
+    /// [`Self::persist_history_batch`] for the meaning of `append_only`.
     fn store_trie_updates_for_block(
         &self,
         tx: &<DatabaseEnv as Database>::TXMut,
         block_number: u64,
         block_state_diff: BlockStateDiff,
-        mode: WriteMode,
+        append_only: bool,
     ) -> BaseProofsStorageResult<ChangeSet> {
         let BlockStateDiff { sorted_trie_updates, sorted_post_state } = block_state_diff;
 
@@ -490,13 +472,13 @@ impl MdbxProofsStorage {
             tx,
             block_number,
             sorted_trie_updates.account_nodes_ref().iter().cloned(),
-            mode,
+            append_only,
         )?;
         let hashed_account_keys = self.persist_history_batch(
             tx,
             block_number,
             sorted_post_state.accounts.iter().copied(),
-            mode,
+            append_only,
         )?;
 
         let mut storage_trie_keys = Vec::<StorageTrieKey>::with_capacity(storage_trie_len);
@@ -509,7 +491,7 @@ impl MdbxProofsStorage {
                     *hashed_address,
                     || Ok(ro.next()?),
                     nodes.storage_nodes_ref().iter().cloned(),
-                    mode,
+                    append_only,
                 )?;
                 storage_trie_keys.extend(keys);
                 continue;
@@ -523,7 +505,7 @@ impl MdbxProofsStorage {
                     .iter()
                     .cloned()
                     .map(|(path, node)| (*hashed_address, path, node)),
-                mode,
+                append_only,
             )?;
             storage_trie_keys.extend(keys);
         }
@@ -541,7 +523,7 @@ impl MdbxProofsStorage {
                         .storage_slots_ref()
                         .iter()
                         .map(|(slot, val)| (*slot, Some(StorageValue(*val)))),
-                    mode,
+                    append_only,
                 )?;
                 hashed_storage_keys.extend(keys);
                 continue;
@@ -553,7 +535,7 @@ impl MdbxProofsStorage {
                     .storage_slots_ref()
                     .iter()
                     .map(|(key, val)| (hashed_address, *key, Some(StorageValue(*val)))),
-                mode,
+                append_only,
             )?;
             hashed_storage_keys.extend(keys);
         }
@@ -588,12 +570,8 @@ impl MdbxProofsStorage {
             });
         }
 
-        let change_set = &self.store_trie_updates_for_block(
-            tx,
-            block_number,
-            block_state_diff,
-            WriteMode::Append,
-        )?;
+        let change_set =
+            &self.store_trie_updates_for_block(tx, block_number, block_state_diff, true)?;
 
         let mut change_set_cursor = tx.new_cursor::<BlockChangeSet>()?;
         change_set_cursor.append(block_number, change_set)?;
@@ -611,8 +589,8 @@ impl MdbxProofsStorage {
     /// Apply one block's writes inside an already-open MDBX write transaction.
     ///
     /// Validates the block's parent against `expected_parent_hash` (returning
-    /// [`BaseProofsStorageError::OutOfOrder`] on mismatch), persists the diff using
-    /// `mode`, appends the per-block [`BlockChangeSet`], and advances
+    /// [`BaseProofsStorageError::OutOfOrder`] on mismatch), persists the diff,
+    /// appends the per-block [`BlockChangeSet`], and advances
     /// `ProofWindow::LatestBlock`. Used by both single-block and batched writers
     /// so the per-block correctness invariants live in one place.
     fn apply_block_in_txn(
@@ -621,7 +599,7 @@ impl MdbxProofsStorage {
         block_ref: BlockWithParent,
         block_state_diff: BlockStateDiff,
         expected_parent_hash: B256,
-        mode: WriteMode,
+        append_only: bool,
     ) -> BaseProofsStorageResult<WriteCounts> {
         let block_number = block_ref.block.number;
 
@@ -633,8 +611,8 @@ impl MdbxProofsStorage {
             });
         }
 
-        let change_set =
-            &self.store_trie_updates_for_block(tx, block_number, block_state_diff, mode)?;
+        let change_set = &self
+            .store_trie_updates_for_block(tx, block_number, block_state_diff, append_only)?;
 
         let mut change_set_cursor = tx.new_cursor::<BlockChangeSet>()?;
         change_set_cursor.append(block_number, change_set)?;
@@ -655,7 +633,7 @@ impl MdbxProofsStorage {
     /// first block's parent must match the storage's current latest block hash.
     /// On any error, the entire transaction is aborted so no entries persist.
     ///
-    /// Uses [`WriteMode::Upsert`] because successive blocks within the same
+    /// Uses upsert (not MDBX_APPENDDUP) because successive blocks within the same
     /// transaction may write keys lexicographically smaller than keys written by
     /// earlier blocks, which would violate `MDBX_APPENDDUP`.
     ///
@@ -679,13 +657,8 @@ impl MdbxProofsStorage {
 
             for (block_ref, diff) in blocks {
                 let next_parent = block_ref.block.hash;
-                let counts = self.apply_block_in_txn(
-                    &tx,
-                    block_ref,
-                    diff,
-                    expected_parent,
-                    WriteMode::Upsert,
-                )?;
+                let counts =
+                    self.apply_block_in_txn(&tx, block_ref, diff, expected_parent, false)?;
                 total += counts;
                 expected_parent = next_parent;
             }
@@ -1106,7 +1079,7 @@ impl BaseProofsInitialStateStore for MdbxProofsStorage {
         account_nodes.sort_by_key(|(key, _)| *key);
 
         self.env.update(|tx| {
-            self.persist_history_batch(tx, 0, account_nodes.into_iter(), WriteMode::Append)?;
+            self.persist_history_batch(tx, 0, account_nodes.into_iter(), true)?;
             Ok(())
         })?
     }
@@ -1128,7 +1101,7 @@ impl BaseProofsInitialStateStore for MdbxProofsStorage {
                 tx,
                 0,
                 storage_nodes.into_iter().map(|(path, node)| (hashed_address, path, node)),
-                WriteMode::Append,
+                true,
             )?;
             Ok(())
         })?
@@ -1146,7 +1119,7 @@ impl BaseProofsInitialStateStore for MdbxProofsStorage {
         accounts.sort_by_key(|(key, _)| *key);
 
         self.env.update(|tx| {
-            self.persist_history_batch(tx, 0, accounts.into_iter(), WriteMode::Append)?;
+            self.persist_history_batch(tx, 0, accounts.into_iter(), true)?;
             Ok(())
         })?
     }
@@ -1170,7 +1143,7 @@ impl BaseProofsInitialStateStore for MdbxProofsStorage {
                 storages
                     .into_iter()
                     .map(|(key, val)| (hashed_address, key, Some(StorageValue(val)))),
-                WriteMode::Append,
+                true,
             )?;
             Ok(())
         })?

--- a/crates/execution/trie/src/db/store.rs
+++ b/crates/execution/trie/src/db/store.rs
@@ -157,7 +157,7 @@ impl MdbxProofsStorage {
     /// # Parameters
     /// - `block_number`: Target block number for versioning entries
     /// - `items`: **Must be sorted** by key - iterator of entries to persist
-    /// - `append_only`: `true` = MDBX_APPENDDUP fast path (caller must guarantee
+    /// - `append_mode`: `true` = MDBX_APPENDDUP fast path (caller must guarantee
     ///   subkey monotonicity, satisfied by single-block writes via the
     ///   `OutOfOrder` parent check). `false` = upsert; required for batched
     ///   cross-block writes where keys may not be lex-sorted across blocks.
@@ -166,7 +166,7 @@ impl MdbxProofsStorage {
         tx: &(impl DbTxMut + DbTx),
         block_number: T::SubKey,
         items: I,
-        append_only: bool,
+        append_mode: bool,
     ) -> BaseProofsStorageResult<Vec<T::Key>>
     where
         T: Table<Value = VersionedValue<V>> + DupSort<SubKey = u64>,
@@ -178,7 +178,7 @@ impl MdbxProofsStorage {
         let mut keys = Vec::<T::Key>::new();
         for it in items {
             let (k, vv) = it.into_kv(block_number);
-            if append_only {
+            if append_mode {
                 cur.append_dup(k.clone(), vv)?;
             } else {
                 cur.upsert(k.clone(), &vv)?;
@@ -358,7 +358,7 @@ impl MdbxProofsStorage {
         hashed_address: B256,
         mut next: Next,
         new_entries: I,
-        append_only: bool,
+        append_mode: bool,
     ) -> BaseProofsStorageResult<Vec<T::Key>>
     where
         T: Table<Value = VersionedValue<V>> + DupSort,
@@ -381,7 +381,7 @@ impl MdbxProofsStorage {
         for (k, value) in merged {
             let key: T::Key = (hashed_address, k, Option::<V>::None).into_key();
             let vv: T::Value = VersionedValue { block_number, value: MaybeDeleted(value) };
-            if append_only {
+            if append_mode {
                 cur.append_dup(key.clone(), vv)?;
             } else {
                 cur.upsert(key.clone(), &vv)?;
@@ -455,13 +455,13 @@ impl MdbxProofsStorage {
     }
 
     /// Write trie/state history for `block_number` from `block_state_diff`. See
-    /// [`Self::persist_history_batch`] for the meaning of `append_only`.
+    /// [`Self::persist_history_batch`] for the meaning of `append_mode`.
     fn store_trie_updates_for_block(
         &self,
         tx: &<DatabaseEnv as Database>::TXMut,
         block_number: u64,
         block_state_diff: BlockStateDiff,
-        append_only: bool,
+        append_mode: bool,
     ) -> BaseProofsStorageResult<ChangeSet> {
         let BlockStateDiff { sorted_trie_updates, sorted_post_state } = block_state_diff;
 
@@ -472,13 +472,13 @@ impl MdbxProofsStorage {
             tx,
             block_number,
             sorted_trie_updates.account_nodes_ref().iter().cloned(),
-            append_only,
+            append_mode,
         )?;
         let hashed_account_keys = self.persist_history_batch(
             tx,
             block_number,
             sorted_post_state.accounts.iter().copied(),
-            append_only,
+            append_mode,
         )?;
 
         let mut storage_trie_keys = Vec::<StorageTrieKey>::with_capacity(storage_trie_len);
@@ -491,7 +491,7 @@ impl MdbxProofsStorage {
                     *hashed_address,
                     || Ok(ro.next()?),
                     nodes.storage_nodes_ref().iter().cloned(),
-                    append_only,
+                    append_mode,
                 )?;
                 storage_trie_keys.extend(keys);
                 continue;
@@ -505,7 +505,7 @@ impl MdbxProofsStorage {
                     .iter()
                     .cloned()
                     .map(|(path, node)| (*hashed_address, path, node)),
-                append_only,
+                append_mode,
             )?;
             storage_trie_keys.extend(keys);
         }
@@ -523,7 +523,7 @@ impl MdbxProofsStorage {
                         .storage_slots_ref()
                         .iter()
                         .map(|(slot, val)| (*slot, Some(StorageValue(*val)))),
-                    append_only,
+                    append_mode,
                 )?;
                 hashed_storage_keys.extend(keys);
                 continue;
@@ -535,7 +535,7 @@ impl MdbxProofsStorage {
                     .storage_slots_ref()
                     .iter()
                     .map(|(key, val)| (hashed_address, *key, Some(StorageValue(*val)))),
-                append_only,
+                append_mode,
             )?;
             hashed_storage_keys.extend(keys);
         }
@@ -599,7 +599,7 @@ impl MdbxProofsStorage {
         block_ref: BlockWithParent,
         block_state_diff: BlockStateDiff,
         expected_parent_hash: B256,
-        append_only: bool,
+        append_mode: bool,
     ) -> BaseProofsStorageResult<WriteCounts> {
         let block_number = block_ref.block.number;
 
@@ -612,7 +612,7 @@ impl MdbxProofsStorage {
         }
 
         let change_set = &self
-            .store_trie_updates_for_block(tx, block_number, block_state_diff, append_only)?;
+            .store_trie_updates_for_block(tx, block_number, block_state_diff, append_mode)?;
 
         let mut change_set_cursor = tx.new_cursor::<BlockChangeSet>()?;
         change_set_cursor.append(block_number, change_set)?;

--- a/crates/execution/trie/src/db/store.rs
+++ b/crates/execution/trie/src/db/store.rs
@@ -588,8 +588,12 @@ impl MdbxProofsStorage {
             });
         }
 
-        let change_set =
-            &self.store_trie_updates_for_block(tx, block_number, block_state_diff, WriteMode::Append)?;
+        let change_set = &self.store_trie_updates_for_block(
+            tx,
+            block_number,
+            block_state_diff,
+            WriteMode::Append,
+        )?;
 
         let mut change_set_cursor = tx.new_cursor::<BlockChangeSet>()?;
         change_set_cursor.append(block_number, change_set)?;

--- a/crates/execution/trie/src/lib.rs
+++ b/crates/execution/trie/src/lib.rs
@@ -12,7 +12,7 @@
 use reth_ethereum_primitives as _;
 
 pub mod api;
-pub use api::{BaseProofsInitialStateStore, BaseProofsStore, BlockStateDiff};
+pub use api::{BaseProofsInitialStateStore, BaseProofsStore, BlockStateDiff, WriteCounts};
 
 pub mod initialize;
 pub use initialize::InitializationJob;

--- a/crates/execution/trie/src/live.rs
+++ b/crates/execution/trie/src/live.rs
@@ -182,6 +182,65 @@ where
         Ok(())
     }
 
+    /// Store trie updates for a contiguous batch of blocks atomically in a single
+    /// underlying storage transaction.
+    ///
+    /// On `OutOfOrder` (parent mismatch on the first block, or any chain break
+    /// inside the batch), the entire batch is silently skipped — matching the
+    /// per-block [`store_block_updates`] behavior used when notifications race
+    /// with already-stored data.
+    pub fn store_block_updates_batch(
+        &self,
+        blocks: Vec<(BlockWithParent, BlockStateDiff)>,
+    ) -> Result<(), BaseProofsStorageError> {
+        if blocks.is_empty() {
+            return Ok(());
+        }
+
+        let start = Instant::now();
+        let mut operation_durations = OperationDurations::default();
+
+        let first_block_number = blocks.first().map(|(b, _)| b.block.number);
+        let last_block_number = blocks.last().map(|(b, _)| b.block.number);
+        let batch_len = blocks.len();
+
+        let storage_result = match self.storage.store_trie_updates_batch(blocks) {
+            Ok(res) => res,
+            Err(BaseProofsStorageError::OutOfOrder {
+                block_number,
+                latest_block_hash,
+                parent_block_hash,
+            }) => {
+                warn!(
+                    block_number,
+                    ?latest_block_hash,
+                    ?parent_block_hash,
+                    batch_len,
+                    "Skipping out of order block batch"
+                );
+                return Ok(());
+            }
+            Err(e) => return Err(e),
+        };
+
+        let write_duration = start.elapsed();
+        operation_durations.total_duration_seconds = write_duration;
+        operation_durations.write_duration_seconds = write_duration;
+
+        Self::record_storage_metrics(&operation_durations, Some(&storage_result));
+
+        info!(
+            ?first_block_number,
+            ?last_block_number,
+            batch_len,
+            ?operation_durations,
+            ?storage_result,
+            "Trie updates batch stored successfully",
+        );
+
+        Ok(())
+    }
+
     /// Handles chain reorganizations by replacing block updates after a common ancestor.
     ///
     /// This method removes all block updates after the latest common ancestor (the block before

--- a/crates/execution/trie/src/metrics.rs
+++ b/crates/execution/trie/src/metrics.rs
@@ -367,6 +367,19 @@ where
     }
 
     #[inline]
+    fn store_trie_updates_batch(
+        &self,
+        blocks: Vec<(BlockWithParent, BlockStateDiff)>,
+    ) -> BaseProofsStorageResult<WriteCounts> {
+        let last_block_number = blocks.last().map(|(block_ref, _)| block_ref.block.number);
+        let result = self.storage.store_trie_updates_batch(blocks)?;
+        if let Some(n) = last_block_number {
+            BlockMetrics::latest_number().set(n as f64);
+        }
+        Ok(result)
+    }
+
+    #[inline]
     fn fetch_trie_updates(&self, block_number: u64) -> BaseProofsStorageResult<BlockStateDiff> {
         self.storage.fetch_trie_updates(block_number)
     }

--- a/crates/execution/trie/tests/lib.rs
+++ b/crates/execution/trie/tests/lib.rs
@@ -6,7 +6,7 @@ use alloy_eips::{BlockNumHash, NumHash, eip1898::BlockWithParent};
 use alloy_primitives::{B256, U256};
 use base_execution_trie::{
     BaseProofsInitialStateStore, BaseProofsStorageError, BaseProofsStore, BlockStateDiff,
-    InMemoryProofsStorage, db::MdbxProofsStorage,
+    InMemoryProofsStorage, WriteCounts, db::MdbxProofsStorage,
 };
 use reth_primitives_traits::Account;
 use reth_trie::{
@@ -2049,6 +2049,193 @@ fn test_updates_take_precedence_over_removals<S: BaseProofsStore + BaseProofsIni
         branch_75.state_mask, initial_branch.state_mask,
         "Block 75 should see the initial branch, not the updated one"
     );
+
+    Ok(())
+}
+
+const fn batch_block(num: u64, parent: B256) -> BlockWithParent {
+    BlockWithParent::new(parent, NumHash::new(num, B256::repeat_byte(num as u8)))
+}
+
+fn diff_with_account(addr_byte: u8, nonce: u64) -> BlockStateDiff {
+    let mut post_state = HashedPostState::default();
+    post_state
+        .accounts
+        .insert(B256::repeat_byte(addr_byte), Some(create_test_account_with_values(nonce, 0, 0)));
+    BlockStateDiff {
+        sorted_trie_updates: TrieUpdatesSorted::default(),
+        sorted_post_state: post_state.into_sorted(),
+    }
+}
+
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[serial]
+fn test_store_trie_updates_batch_advances_proof_window<
+    S: BaseProofsStore + BaseProofsInitialStateStore,
+>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let earliest_hash = B256::repeat_byte(100);
+    storage.set_earliest_block_number(100, earliest_hash)?;
+
+    let block_101 = batch_block(101, earliest_hash);
+    let block_102 = batch_block(102, block_101.block.hash);
+    let block_103 = batch_block(103, block_102.block.hash);
+
+    let counts = storage.store_trie_updates_batch(vec![
+        (block_101, BlockStateDiff::default()),
+        (block_102, BlockStateDiff::default()),
+        (block_103, BlockStateDiff::default()),
+    ])?;
+
+    let (latest_num, _latest_hash) =
+        storage.get_latest_block_number()?.expect("latest block tracked");
+    assert_eq!(latest_num, 103);
+    assert_eq!(counts, WriteCounts::default());
+
+    Ok(())
+}
+
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[serial]
+fn test_store_trie_updates_batch_persists_each_block<
+    S: BaseProofsStore + BaseProofsInitialStateStore,
+>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let earliest_hash = B256::repeat_byte(50);
+    storage.set_earliest_block_number(50, earliest_hash)?;
+
+    let block_51 = batch_block(51, earliest_hash);
+    let block_52 = batch_block(52, block_51.block.hash);
+    let block_53 = batch_block(53, block_52.block.hash);
+
+    storage.store_trie_updates_batch(vec![
+        (block_51, diff_with_account(0xA1, 51)),
+        (block_52, diff_with_account(0xA2, 52)),
+        (block_53, diff_with_account(0xA3, 53)),
+    ])?;
+
+    for (n, addr_byte, nonce) in [(51, 0xA1, 51), (52, 0xA2, 52), (53, 0xA3, 53)] {
+        let mut cursor = storage.account_hashed_cursor(n)?;
+        let entry = cursor.seek(B256::repeat_byte(addr_byte))?.expect("account present");
+        assert_eq!(entry.0, B256::repeat_byte(addr_byte));
+        assert_eq!(entry.1.nonce, nonce, "block {n} account should have nonce {nonce}");
+    }
+
+    Ok(())
+}
+
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[serial]
+fn test_store_trie_updates_batch_empty_is_noop<
+    S: BaseProofsStore + BaseProofsInitialStateStore,
+>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    storage.set_earliest_block_number(0, B256::ZERO)?;
+
+    let counts = storage.store_trie_updates_batch(Vec::new())?;
+    assert_eq!(counts, WriteCounts::default());
+    assert_eq!(storage.get_latest_block_number()?, Some((0, B256::ZERO)));
+
+    Ok(())
+}
+
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[serial]
+fn test_store_trie_updates_batch_rejects_bad_first_parent_mdbx<
+    S: BaseProofsStore + BaseProofsInitialStateStore,
+>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let earliest_hash = B256::repeat_byte(70);
+    storage.set_earliest_block_number(70, earliest_hash)?;
+
+    let bad_parent = B256::repeat_byte(0xEE);
+    let block_71 = batch_block(71, bad_parent);
+
+    let res = storage
+        .store_trie_updates_batch(vec![(block_71, BlockStateDiff::default())]);
+    assert!(matches!(res, Err(BaseProofsStorageError::OutOfOrder { .. })));
+
+    assert_eq!(storage.get_latest_block_number()?, Some((70, earliest_hash)));
+
+    Ok(())
+}
+
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[serial]
+fn test_store_trie_updates_batch_atomic_on_chain_break_mdbx<
+    S: BaseProofsStore + BaseProofsInitialStateStore,
+>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let earliest_hash = B256::repeat_byte(200);
+    storage.set_earliest_block_number(200, earliest_hash)?;
+
+    let block_201 = batch_block(201, earliest_hash);
+    let block_202_bad_parent = BlockWithParent::new(
+        B256::repeat_byte(0xEE),
+        NumHash::new(202, B256::repeat_byte(202)),
+    );
+    let block_203 = batch_block(203, block_202_bad_parent.block.hash);
+
+    let res = storage.store_trie_updates_batch(vec![
+        (block_201, diff_with_account(0xB1, 1)),
+        (block_202_bad_parent, diff_with_account(0xB2, 2)),
+        (block_203, diff_with_account(0xB3, 3)),
+    ]);
+    assert!(matches!(res, Err(BaseProofsStorageError::OutOfOrder { .. })));
+
+    assert_eq!(storage.get_latest_block_number()?, Some((200, earliest_hash)));
+
+    let mut cursor = storage.account_hashed_cursor(300)?;
+    assert!(
+        cursor.seek(B256::repeat_byte(0xB1))?.is_none(),
+        "block 201 account must NOT be visible after rollback"
+    );
+
+    Ok(())
+}
+
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[serial]
+fn test_store_trie_updates_batch_handles_cross_block_unsorted_keys<
+    S: BaseProofsStore + BaseProofsInitialStateStore,
+>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let earliest_hash = B256::repeat_byte(10);
+    storage.set_earliest_block_number(10, earliest_hash)?;
+
+    let mut diff_high = BlockStateDiff::default();
+    let mut post_high = HashedPostState::default();
+    post_high
+        .accounts
+        .insert(B256::repeat_byte(0xF0), Some(create_test_account_with_values(11, 0, 0)));
+    diff_high.sorted_post_state = post_high.into_sorted();
+
+    let mut diff_low = BlockStateDiff::default();
+    let mut post_low = HashedPostState::default();
+    post_low
+        .accounts
+        .insert(B256::repeat_byte(0x10), Some(create_test_account_with_values(12, 0, 0)));
+    diff_low.sorted_post_state = post_low.into_sorted();
+
+    let block_11 = batch_block(11, earliest_hash);
+    let block_12 = batch_block(12, block_11.block.hash);
+
+    storage.store_trie_updates_batch(vec![(block_11, diff_high), (block_12, diff_low)])?;
+
+    let mut cursor = storage.account_hashed_cursor(12)?;
+    assert!(cursor.seek(B256::repeat_byte(0x10))?.is_some());
+    let mut cursor = storage.account_hashed_cursor(12)?;
+    assert!(cursor.seek(B256::repeat_byte(0xF0))?.is_some());
 
     Ok(())
 }

--- a/crates/execution/trie/tests/lib.rs
+++ b/crates/execution/trie/tests/lib.rs
@@ -2131,9 +2131,7 @@ fn test_store_trie_updates_batch_persists_each_block<
 #[test_case(InMemoryProofsStorage::new(); "InMemory")]
 #[test_case(create_mdbx_proofs_storage(); "Mdbx")]
 #[serial]
-fn test_store_trie_updates_batch_empty_is_noop<
-    S: BaseProofsStore + BaseProofsInitialStateStore,
->(
+fn test_store_trie_updates_batch_empty_is_noop<S: BaseProofsStore + BaseProofsInitialStateStore>(
     storage: S,
 ) -> Result<(), BaseProofsStorageError> {
     storage.set_earliest_block_number(0, B256::ZERO)?;
@@ -2158,8 +2156,7 @@ fn test_store_trie_updates_batch_rejects_bad_first_parent_mdbx<
     let bad_parent = B256::repeat_byte(0xEE);
     let block_71 = batch_block(71, bad_parent);
 
-    let res = storage
-        .store_trie_updates_batch(vec![(block_71, BlockStateDiff::default())]);
+    let res = storage.store_trie_updates_batch(vec![(block_71, BlockStateDiff::default())]);
     assert!(matches!(res, Err(BaseProofsStorageError::OutOfOrder { .. })));
 
     assert_eq!(storage.get_latest_block_number()?, Some((70, earliest_hash)));
@@ -2178,10 +2175,8 @@ fn test_store_trie_updates_batch_atomic_on_chain_break_mdbx<
     storage.set_earliest_block_number(200, earliest_hash)?;
 
     let block_201 = batch_block(201, earliest_hash);
-    let block_202_bad_parent = BlockWithParent::new(
-        B256::repeat_byte(0xEE),
-        NumHash::new(202, B256::repeat_byte(202)),
-    );
+    let block_202_bad_parent =
+        BlockWithParent::new(B256::repeat_byte(0xEE), NumHash::new(202, B256::repeat_byte(202)));
     let block_203 = batch_block(203, block_202_bad_parent.block.hash);
 
     let res = storage.store_trie_updates_batch(vec![


### PR DESCRIPTION
Each cache-hit block in the proofs sync loop currently opens its own write transaction, paying a full commit and disk sync per block. This change groups up to 32 consecutive blocks into one write, sharing the commit cost across the group.