### PR TITLE
Batch proofs sync writes with execution overlay

### DIFF
--- a/crates/execution/exex/src/lib.rs
+++ b/crates/execution/exex/src/lib.rs
@@ -13,8 +13,8 @@ use std::{sync::Arc, time::Duration};
 use alloy_consensus::BlockHeader;
 use alloy_eips::eip1898::BlockWithParent;
 use base_execution_trie::{
-    BaseProofStoragePrunerTask, BaseProofsStorage, BaseProofsStore, live::LiveTrieCollector,
-    metrics::BlockMetrics,
+    BaseProofStoragePrunerTask, BaseProofsStorage, BaseProofsStore, BlockStateDiff,
+    live::LiveTrieCollector, metrics::BlockMetrics,
 };
 use futures::TryStreamExt;
 use reth_execution_types::Chain;
@@ -32,6 +32,12 @@ const MAX_PRUNE_BLOCKS_STARTUP: u64 = 1000;
 
 /// How many blocks to process in a single batch before yielding. Default is 50 blocks.
 const SYNC_BLOCKS_BATCH_SIZE: usize = 50;
+
+/// Maximum number of consecutive cache-hit blocks to coalesce into a single
+/// proofs-storage write transaction. Larger values amortize commit/fsync over
+/// more blocks (the primary throughput win) but hold the MDBX writer lock
+/// longer, increasing pruner contention. Must be `<= SYNC_BLOCKS_BATCH_SIZE`.
+const STORE_BLOCKS_BATCH_SIZE: usize = 32;
 
 /// Default proofs history window: 1 month of blocks at 2s block time
 const DEFAULT_PROOFS_HISTORY_WINDOW: u64 = 1_296_000;
@@ -419,7 +425,6 @@ where
         target: u64,
     ) {
         loop {
-            // Check for higher-priority state (e.g. revert) before processing.
             if sync_target.has_pending_state() {
                 return;
             }
@@ -450,8 +455,41 @@ where
                 "Processing proofs storage sync batch"
             );
 
+            let mut pending: Vec<(BlockWithParent, BlockStateDiff)> =
+                Vec::with_capacity(STORE_BLOCKS_BATCH_SIZE);
+
             for block_num in (latest + 1)..=end {
+                let should_verify = verification_interval > 0
+                    && block_num.is_multiple_of(verification_interval);
                 let cached = sync_target.take(block_num);
+
+                if !should_verify
+                    && let Some(cached) = cached.as_ref()
+                {
+                    let sorted = cached.trie_data.get();
+                    pending.push((
+                        cached.block_with_parent,
+                        BlockStateDiff {
+                            sorted_trie_updates: (*sorted.trie_updates).clone(),
+                            sorted_post_state: (*sorted.hashed_state).clone(),
+                        },
+                    ));
+                    if pending.len() >= STORE_BLOCKS_BATCH_SIZE
+                        && let Err(e) = Self::flush_pending_batch(&mut pending, collector)
+                    {
+                        error!(target: "base::exex", error = ?e, "Batched block writes failed");
+                        return;
+                    }
+                    continue;
+                }
+
+                if !pending.is_empty()
+                    && let Err(e) = Self::flush_pending_batch(&mut pending, collector)
+                {
+                    error!(target: "base::exex", error = ?e, "Batched block writes failed");
+                    return;
+                }
+
                 if let Err(e) = Self::process_block(
                     block_num,
                     cached,
@@ -464,9 +502,29 @@ where
                 }
             }
 
+            if !pending.is_empty()
+                && let Err(e) = Self::flush_pending_batch(&mut pending, collector)
+            {
+                error!(target: "base::exex", error = ?e, "Batched block writes failed");
+                return;
+            }
+
             info!(target: "base::exex", latest_stored = latest, target, "Batch processed, yielding");
             task::yield_now().await;
         }
+    }
+
+    /// Persist any queued cache-hit blocks as a single proofs-storage transaction
+    /// and clear the queue. No-op when `pending` is empty.
+    fn flush_pending_batch(
+        pending: &mut Vec<(BlockWithParent, BlockStateDiff)>,
+        collector: &LiveTrieCollector<'_, Node::Evm, Node::Provider, Storage>,
+    ) -> eyre::Result<()> {
+        if pending.is_empty() {
+            return Ok(());
+        }
+        collector.store_block_updates_batch(std::mem::take(pending))?;
+        Ok(())
     }
 
     fn process_block(

--- a/crates/execution/exex/src/lib.rs
+++ b/crates/execution/exex/src/lib.rs
@@ -31,13 +31,10 @@ use tracing::{debug, error, info};
 const MAX_PRUNE_BLOCKS_STARTUP: u64 = 1000;
 
 /// How many blocks to process in a single batch before yielding. Default is 50 blocks.
+///
+/// Also bounds the MDBX write transaction size when batching consecutive
+/// cache-hit blocks: at most this many blocks share a single commit/fsync.
 const SYNC_BLOCKS_BATCH_SIZE: usize = 50;
-
-/// Maximum number of consecutive cache-hit blocks to coalesce into a single
-/// proofs-storage write transaction. Larger values amortize commit/fsync over
-/// more blocks (the primary throughput win) but hold the MDBX writer lock
-/// longer, increasing pruner contention. Must be `<= SYNC_BLOCKS_BATCH_SIZE`.
-const STORE_BLOCKS_BATCH_SIZE: usize = 32;
 
 /// Default proofs history window: 1 month of blocks at 2s block time
 const DEFAULT_PROOFS_HISTORY_WINDOW: u64 = 1_296_000;
@@ -456,7 +453,7 @@ where
             );
 
             let mut pending: Vec<(BlockWithParent, BlockStateDiff)> =
-                Vec::with_capacity(STORE_BLOCKS_BATCH_SIZE);
+                Vec::with_capacity(SYNC_BLOCKS_BATCH_SIZE);
 
             for block_num in (latest + 1)..=end {
                 let should_verify = verification_interval > 0
@@ -474,12 +471,6 @@ where
                             sorted_post_state: (*sorted.hashed_state).clone(),
                         },
                     ));
-                    if pending.len() >= STORE_BLOCKS_BATCH_SIZE
-                        && let Err(e) = Self::flush_pending_batch(&mut pending, collector)
-                    {
-                        error!(target: "base::exex", error = ?e, "Batched block writes failed");
-                        return;
-                    }
                     continue;
                 }
 

--- a/crates/execution/exex/src/lib.rs
+++ b/crates/execution/exex/src/lib.rs
@@ -13,7 +13,7 @@ use std::{sync::Arc, time::Duration};
 use alloy_consensus::BlockHeader;
 use alloy_eips::eip1898::BlockWithParent;
 use base_execution_trie::{
-    BaseProofStoragePrunerTask, BaseProofsStorage, BaseProofsStore, BlockStateDiff,
+    BaseProofStoragePrunerTask, BaseProofsStorage, BaseProofsStore, ProofsBatchOverlay,
     live::LiveTrieCollector, metrics::BlockMetrics,
 };
 use futures::TryStreamExt;
@@ -452,128 +452,82 @@ where
                 "Processing proofs storage sync batch"
             );
 
-            let mut pending: Vec<(BlockWithParent, BlockStateDiff)> =
-                Vec::with_capacity(SYNC_BLOCKS_BATCH_SIZE);
+            let mut overlay = ProofsBatchOverlay::new();
 
             for block_num in (latest + 1)..=end {
-                let should_verify = verification_interval > 0
-                    && block_num.is_multiple_of(verification_interval);
+                let should_verify =
+                    verification_interval > 0 && block_num.is_multiple_of(verification_interval);
                 let cached = sync_target.take(block_num);
 
-                if !should_verify
-                    && let Some(cached) = cached.as_ref()
-                {
+                if !should_verify && let Some(cached) = cached.as_ref() {
                     let sorted = cached.trie_data.get();
-                    pending.push((
+                    overlay.append_cached(
                         cached.block_with_parent,
-                        BlockStateDiff {
-                            sorted_trie_updates: (*sorted.trie_updates).clone(),
-                            sorted_post_state: (*sorted.hashed_state).clone(),
-                        },
-                    ));
+                        &sorted.hashed_state,
+                        &sorted.trie_updates,
+                    );
                     continue;
                 }
 
-                if !pending.is_empty()
-                    && let Err(e) = Self::flush_pending_batch(&mut pending, collector)
-                {
-                    error!(target: "base::exex", error = ?e, "Batched block writes failed");
-                    return;
+                if cached.is_some() {
+                    info!(
+                        target: "base::exex",
+                        block_number = block_num,
+                        verification_interval,
+                        "Periodic verification: performing full block execution despite cached data"
+                    );
+                } else {
+                    debug!(
+                        target: "base::exex",
+                        block_number = block_num,
+                        "No cached trie data, falling back to full execution"
+                    );
                 }
 
-                if let Err(e) = Self::process_block(
-                    block_num,
-                    cached,
-                    collector,
-                    provider,
-                    verification_interval,
-                ) {
-                    error!(target: "base::exex", block_number = block_num, error = ?e, "Block processing failed");
-                    return;
-                }
+                debug!(
+                    target: "base::exex",
+                    block_number = block_num,
+                    "Fetching block from provider for execution",
+                );
+
+                let block = match provider
+                    .recovered_block(block_num.into(), TransactionVariant::NoHash)
+                {
+                    Ok(Some(block)) => block,
+                    Ok(None) => {
+                        error!(target: "base::exex", block_number = block_num, "Missing block in provider");
+                        return;
+                    }
+                    Err(e) => {
+                        error!(target: "base::exex", block_number = block_num, error = ?e, "Failed to fetch block from provider");
+                        return;
+                    }
+                };
+
+                let (hashed_state, trie_updates) = match collector
+                    .execute_block_with_overlay(&block, &overlay)
+                {
+                    Ok(result) => result,
+                    Err(e) => {
+                        error!(target: "base::exex", block_number = block_num, error = ?e, "Block processing failed");
+                        return;
+                    }
+                };
+
+                overlay.append_executed(block.block_with_parent(), hashed_state, trie_updates);
             }
 
-            if !pending.is_empty()
-                && let Err(e) = Self::flush_pending_batch(&mut pending, collector)
+            if !overlay.is_empty()
+                && let Err(e) = collector.store_block_updates_batch(overlay.into_pending())
             {
                 error!(target: "base::exex", error = ?e, "Batched block writes failed");
                 return;
             }
 
-            info!(target: "base::exex", latest_stored = latest, target, "Batch processed, yielding");
+            info!(target: "base::exex", latest_stored = end, target, "Batch processed, yielding");
             task::yield_now().await;
         }
     }
-
-    /// Persist any queued cache-hit blocks as a single proofs-storage transaction
-    /// and clear the queue. No-op when `pending` is empty.
-    fn flush_pending_batch(
-        pending: &mut Vec<(BlockWithParent, BlockStateDiff)>,
-        collector: &LiveTrieCollector<'_, Node::Evm, Node::Provider, Storage>,
-    ) -> eyre::Result<()> {
-        if pending.is_empty() {
-            return Ok(());
-        }
-        collector.store_block_updates_batch(std::mem::take(pending))?;
-        Ok(())
-    }
-
-    fn process_block(
-        block_number: u64,
-        cached: Option<CachedBlockTrieData>,
-        collector: &LiveTrieCollector<'_, Node::Evm, Node::Provider, Storage>,
-        provider: &Node::Provider,
-        verification_interval: u64,
-    ) -> eyre::Result<()> {
-        let should_verify =
-            verification_interval > 0 && block_number.is_multiple_of(verification_interval);
-
-        if let Some(cached) = cached {
-            let sorted = cached.trie_data.get();
-            if !should_verify {
-                debug!(
-                    target: "base::exex",
-                    block_number,
-                    "Using pre-computed state from notification"
-                );
-
-                collector.store_block_updates(
-                    cached.block_with_parent,
-                    (*sorted.trie_updates).clone(),
-                    (*sorted.hashed_state).clone(),
-                )?;
-
-                return Ok(());
-            }
-
-            info!(
-                target: "base::exex",
-                block_number,
-                verification_interval,
-                "Periodic verification: performing full block execution despite cached data"
-            );
-        } else {
-            debug!(
-                target: "base::exex",
-                block_number,
-                "No cached trie data, falling back to full execution"
-            );
-        }
-
-        debug!(
-            target: "base::exex",
-            block_number,
-            "Fetching block from provider for execution",
-        );
-
-        let block = provider
-            .recovered_block(block_number.into(), TransactionVariant::NoHash)?
-            .ok_or_else(|| eyre::eyre!("Missing block {} in provider", block_number))?;
-
-        collector.execute_and_store_block_updates(&block)?;
-        Ok(())
-    }
-
     fn handle_notification(
         &self,
         notification: ExExNotification<Primitives>,

--- a/crates/execution/exex/src/lib.rs
+++ b/crates/execution/exex/src/lib.rs
@@ -524,10 +524,16 @@ where
                 return;
             }
 
-            info!(target: "base::exex", latest_stored = end, target, "Batch processed, yielding");
+            let latest_stored = storage
+                .get_latest_block_number()
+                .ok()
+                .flatten()
+                .map_or(end, |(block_number, _)| block_number);
+            info!(target: "base::exex", latest_stored, target, "Batch processed, yielding");
             task::yield_now().await;
         }
     }
+
     fn handle_notification(
         &self,
         notification: ExExNotification<Primitives>,

--- a/crates/execution/trie/src/api.rs
+++ b/crates/execution/trie/src/api.rs
@@ -178,6 +178,28 @@ pub trait BaseProofsStore: Send + Sync + Debug {
         block_state_diff: BlockStateDiff,
     ) -> BaseProofsStorageResult<WriteCounts>;
 
+    /// Store a contiguous batch of consecutive blocks atomically.
+    ///
+    /// All blocks must form a chain (`block[i+1].parent == block[i].hash`) and the
+    /// first block's parent must match the storage's current latest block hash.
+    /// On any error, no entries from the batch are persisted.
+    ///
+    /// Backends with transactional storage (e.g. MDBX) should override this to
+    /// use a single transaction so the entire batch shares one commit/fsync.
+    /// The default implementation falls through to per-block
+    /// [`store_trie_updates`](Self::store_trie_updates) calls; that is correct
+    /// for non-durable backends but yields no perf benefit on durable ones.
+    fn store_trie_updates_batch(
+        &self,
+        blocks: Vec<(BlockWithParent, BlockStateDiff)>,
+    ) -> BaseProofsStorageResult<WriteCounts> {
+        let mut total = WriteCounts::default();
+        for (block_ref, diff) in blocks {
+            total += self.store_trie_updates(block_ref, diff)?;
+        }
+        Ok(total)
+    }
+
     /// Fetch all updates for a given block number.
     fn fetch_trie_updates(&self, block_number: u64) -> BaseProofsStorageResult<BlockStateDiff>;
 

--- a/crates/execution/trie/src/api.rs
+++ b/crates/execution/trie/src/api.rs
@@ -182,7 +182,7 @@ pub trait BaseProofsStore: Send + Sync + Debug {
     ///
     /// All blocks must form a chain (`block[i+1].parent == block[i].hash`) and the
     /// first block's parent must match the storage's current latest block hash.
-    /// On any error, no entries from the batch are persisted.
+    /// Transactional backends should ensure that no entries from the batch are persisted on error.
     ///
     /// Backends with transactional storage (e.g. MDBX) should override this to
     /// use a single transaction so the entire batch shares one commit/fsync.

--- a/crates/execution/trie/src/db/store.rs
+++ b/crates/execution/trie/src/db/store.rs
@@ -157,7 +157,7 @@ impl MdbxProofsStorage {
     /// # Parameters
     /// - `block_number`: Target block number for versioning entries
     /// - `items`: **Must be sorted** by key - iterator of entries to persist
-    /// - `append_mode`: `true` = MDBX_APPENDDUP fast path (caller must guarantee
+    /// - `append_mode`: `true` = `MDBX_APPENDDUP` fast path (caller must guarantee
     ///   subkey monotonicity, satisfied by single-block writes via the
     ///   `OutOfOrder` parent check). `false` = upsert; required for batched
     ///   cross-block writes where keys may not be lex-sorted across blocks.
@@ -633,7 +633,7 @@ impl MdbxProofsStorage {
     /// first block's parent must match the storage's current latest block hash.
     /// On any error, the entire transaction is aborted so no entries persist.
     ///
-    /// Uses upsert (not MDBX_APPENDDUP) because successive blocks within the same
+    /// Uses upsert (not `MDBX_APPENDDUP`) because successive blocks within the same
     /// transaction may write keys lexicographically smaller than keys written by
     /// earlier blocks, which would violate `MDBX_APPENDDUP`.
     ///

--- a/crates/execution/trie/src/db/store.rs
+++ b/crates/execution/trie/src/db/store.rs
@@ -484,7 +484,10 @@ impl MdbxProofsStorage {
         let mut storage_trie_keys = Vec::<StorageTrieKey>::with_capacity(storage_trie_len);
         for (hashed_address, nodes) in sorted_trie_updates.storage_tries_ref() {
             if nodes.is_deleted {
-                let mut ro = self.storage_trie_cursor(*hashed_address, block_number - 1)?;
+                // Use the write transaction for wipe reads so batch-local writes from earlier
+                // blocks are visible when constructing tombstones.
+                let cursor = tx.cursor_dup_read::<StorageTrieHistory>()?;
+                let mut ro = MdbxTrieCursor::new(cursor, block_number - 1, Some(*hashed_address));
                 let keys = self.wipe_and_overlay(
                     tx,
                     block_number,
@@ -513,7 +516,10 @@ impl MdbxProofsStorage {
         let mut hashed_storage_keys = Vec::<HashedStorageKey>::with_capacity(hashed_storage_len);
         for (hashed_address, storage) in sorted_post_state.storages {
             if storage.is_wiped() {
-                let mut ro = self.storage_hashed_cursor(hashed_address, block_number - 1)?;
+                // Use the write transaction for wipe reads so batch-local writes from earlier
+                // blocks are visible when constructing tombstones.
+                let cursor = tx.cursor_dup_read::<HashedStorageHistory>()?;
+                let mut ro = MdbxStorageCursor::new(cursor, block_number - 1, hashed_address);
                 let keys = self.wipe_and_overlay(
                     tx,
                     block_number,

--- a/crates/execution/trie/src/db/store.rs
+++ b/crates/execution/trie/src/db/store.rs
@@ -611,8 +611,8 @@ impl MdbxProofsStorage {
             });
         }
 
-        let change_set = &self
-            .store_trie_updates_for_block(tx, block_number, block_state_diff, append_mode)?;
+        let change_set =
+            &self.store_trie_updates_for_block(tx, block_number, block_state_diff, append_mode)?;
 
         let mut change_set_cursor = tx.new_cursor::<BlockChangeSet>()?;
         change_set_cursor.append(block_number, change_set)?;

--- a/crates/execution/trie/src/db/store.rs
+++ b/crates/execution/trie/src/db/store.rs
@@ -157,7 +157,7 @@ impl MdbxProofsStorage {
     /// # Parameters
     /// - `block_number`: Target block number for versioning entries
     /// - `items`: **Must be sorted** by key - iterator of entries to persist
-    /// - `append_only`: `true` = MDBX_APPENDDUP fast path (caller must guarantee
+    /// - `append_mode`: `true` = MDBX_APPENDDUP fast path (caller must guarantee
     ///   subkey monotonicity, satisfied by single-block writes via the
     ///   `OutOfOrder` parent check). `false` = upsert; required for batched
     ///   cross-block writes where keys may not be lex-sorted across blocks.
@@ -166,7 +166,7 @@ impl MdbxProofsStorage {
         tx: &(impl DbTxMut + DbTx),
         block_number: T::SubKey,
         items: I,
-        append_only: bool,
+        append_mode: bool,
     ) -> BaseProofsStorageResult<Vec<T::Key>>
     where
         T: Table<Value = VersionedValue<V>> + DupSort<SubKey = u64>,
@@ -178,7 +178,7 @@ impl MdbxProofsStorage {
         let mut keys = Vec::<T::Key>::new();
         for it in items {
             let (k, vv) = it.into_kv(block_number);
-            if append_only {
+            if append_mode {
                 cur.append_dup(k.clone(), vv)?;
             } else {
                 cur.upsert(k.clone(), &vv)?;
@@ -358,7 +358,7 @@ impl MdbxProofsStorage {
         hashed_address: B256,
         mut next: Next,
         new_entries: I,
-        append_only: bool,
+        append_mode: bool,
     ) -> BaseProofsStorageResult<Vec<T::Key>>
     where
         T: Table<Value = VersionedValue<V>> + DupSort,
@@ -381,7 +381,7 @@ impl MdbxProofsStorage {
         for (k, value) in merged {
             let key: T::Key = (hashed_address, k, Option::<V>::None).into_key();
             let vv: T::Value = VersionedValue { block_number, value: MaybeDeleted(value) };
-            if append_only {
+            if append_mode {
                 cur.append_dup(key.clone(), vv)?;
             } else {
                 cur.upsert(key.clone(), &vv)?;
@@ -455,13 +455,13 @@ impl MdbxProofsStorage {
     }
 
     /// Write trie/state history for `block_number` from `block_state_diff`. See
-    /// [`Self::persist_history_batch`] for the meaning of `append_only`.
+    /// [`Self::persist_history_batch`] for the meaning of `append_mode`.
     fn store_trie_updates_for_block(
         &self,
         tx: &<DatabaseEnv as Database>::TXMut,
         block_number: u64,
         block_state_diff: BlockStateDiff,
-        append_only: bool,
+        append_mode: bool,
     ) -> BaseProofsStorageResult<ChangeSet> {
         let BlockStateDiff { sorted_trie_updates, sorted_post_state } = block_state_diff;
 
@@ -472,13 +472,13 @@ impl MdbxProofsStorage {
             tx,
             block_number,
             sorted_trie_updates.account_nodes_ref().iter().cloned(),
-            append_only,
+            append_mode,
         )?;
         let hashed_account_keys = self.persist_history_batch(
             tx,
             block_number,
             sorted_post_state.accounts.iter().copied(),
-            append_only,
+            append_mode,
         )?;
 
         let mut storage_trie_keys = Vec::<StorageTrieKey>::with_capacity(storage_trie_len);
@@ -491,7 +491,7 @@ impl MdbxProofsStorage {
                     *hashed_address,
                     || Ok(ro.next()?),
                     nodes.storage_nodes_ref().iter().cloned(),
-                    append_only,
+                    append_mode,
                 )?;
                 storage_trie_keys.extend(keys);
                 continue;
@@ -505,7 +505,7 @@ impl MdbxProofsStorage {
                     .iter()
                     .cloned()
                     .map(|(path, node)| (*hashed_address, path, node)),
-                append_only,
+                append_mode,
             )?;
             storage_trie_keys.extend(keys);
         }
@@ -523,7 +523,7 @@ impl MdbxProofsStorage {
                         .storage_slots_ref()
                         .iter()
                         .map(|(slot, val)| (*slot, Some(StorageValue(*val)))),
-                    append_only,
+                    append_mode,
                 )?;
                 hashed_storage_keys.extend(keys);
                 continue;
@@ -535,7 +535,7 @@ impl MdbxProofsStorage {
                     .storage_slots_ref()
                     .iter()
                     .map(|(key, val)| (hashed_address, *key, Some(StorageValue(*val)))),
-                append_only,
+                append_mode,
             )?;
             hashed_storage_keys.extend(keys);
         }
@@ -599,7 +599,7 @@ impl MdbxProofsStorage {
         block_ref: BlockWithParent,
         block_state_diff: BlockStateDiff,
         expected_parent_hash: B256,
-        append_only: bool,
+        append_mode: bool,
     ) -> BaseProofsStorageResult<WriteCounts> {
         let block_number = block_ref.block.number;
 
@@ -612,7 +612,7 @@ impl MdbxProofsStorage {
         }
 
         let change_set = &self
-            .store_trie_updates_for_block(tx, block_number, block_state_diff, append_only)?;
+            .store_trie_updates_for_block(tx, block_number, block_state_diff, append_mode)?;
 
         let mut change_set_cursor = tx.new_cursor::<BlockChangeSet>()?;
         change_set_cursor.append(block_number, change_set)?;

--- a/crates/execution/trie/src/db/store.rs
+++ b/crates/execution/trie/src/db/store.rs
@@ -69,29 +69,6 @@ struct HistoryDeleteBatch {
     hashed_storage: Vec<(<HashedStorageHistory as Table>::Key, u64)>,
 }
 
-/// Strategy for writing versioned history entries to a `DupSort` table.
-///
-/// Different code paths have different ordering guarantees and need different
-/// MDBX write primitives.
-#[derive(Debug, Clone, Copy)]
-pub(crate) enum WriteMode {
-    /// Use MDBX `MDBX_APPENDDUP` fast-path append.
-    ///
-    /// Caller guarantees that per-key subkeys are monotonically increasing across
-    /// all entries currently in the table plus this batch. This holds for
-    /// single-block writes: every entry uses the same subkey == new `block_number`,
-    /// and that `block_number` is strictly greater than any previously written
-    /// `block_number` for these keys (enforced by `OutOfOrder` parent validation).
-    Append,
-    /// Use MDBX `upsert` (B-tree search + insert/update). No ordering constraints.
-    ///
-    /// Used when batching multiple consecutive blocks into a single transaction:
-    /// subsequent blocks within the same transaction may write keys lexicographically
-    /// smaller than keys written by earlier blocks, which would violate the
-    /// `MDBX_APPENDDUP` table-wide ordering check.
-    Upsert,
-}
-
 impl MdbxProofsStorage {
     /// Creates a new [`MdbxProofsStorage`] instance with the given path.
     pub fn new(path: &Path) -> Result<Self, BaseProofsStorageError> {
@@ -180,13 +157,16 @@ impl MdbxProofsStorage {
     /// # Parameters
     /// - `block_number`: Target block number for versioning entries
     /// - `items`: **Must be sorted** by key - iterator of entries to persist
-    /// - `mode`: Write strategy. See [`WriteMode`] for the per-variant contract.
+    /// - `append_only`: `true` = MDBX_APPENDDUP fast path (caller must guarantee
+    ///   subkey monotonicity, satisfied by single-block writes via the
+    ///   `OutOfOrder` parent check). `false` = upsert; required for batched
+    ///   cross-block writes where keys may not be lex-sorted across blocks.
     fn persist_history_batch<T, I, V>(
         &self,
         tx: &(impl DbTxMut + DbTx),
         block_number: T::SubKey,
         items: I,
-        mode: WriteMode,
+        append_only: bool,
     ) -> BaseProofsStorageResult<Vec<T::Key>>
     where
         T: Table<Value = VersionedValue<V>> + DupSort<SubKey = u64>,
@@ -198,9 +178,10 @@ impl MdbxProofsStorage {
         let mut keys = Vec::<T::Key>::new();
         for it in items {
             let (k, vv) = it.into_kv(block_number);
-            match mode {
-                WriteMode::Append => cur.append_dup(k.clone(), vv)?,
-                WriteMode::Upsert => cur.upsert(k.clone(), &vv)?,
+            if append_only {
+                cur.append_dup(k.clone(), vv)?;
+            } else {
+                cur.upsert(k.clone(), &vv)?;
             }
             keys.push(k);
         }
@@ -377,7 +358,7 @@ impl MdbxProofsStorage {
         hashed_address: B256,
         mut next: Next,
         new_entries: I,
-        mode: WriteMode,
+        append_only: bool,
     ) -> BaseProofsStorageResult<Vec<T::Key>>
     where
         T: Table<Value = VersionedValue<V>> + DupSort,
@@ -400,9 +381,10 @@ impl MdbxProofsStorage {
         for (k, value) in merged {
             let key: T::Key = (hashed_address, k, Option::<V>::None).into_key();
             let vv: T::Value = VersionedValue { block_number, value: MaybeDeleted(value) };
-            match mode {
-                WriteMode::Append => cur.append_dup(key.clone(), vv)?,
-                WriteMode::Upsert => cur.upsert(key.clone(), &vv)?,
+            if append_only {
+                cur.append_dup(key.clone(), vv)?;
+            } else {
+                cur.upsert(key.clone(), &vv)?;
             }
             keys.push(key);
         }
@@ -472,14 +454,14 @@ impl MdbxProofsStorage {
         })
     }
 
-    /// Write trie/state history for `block_number` from `block_state_diff` using
-    /// the given `mode` (see [`WriteMode`] for the per-variant contract).
+    /// Write trie/state history for `block_number` from `block_state_diff`. See
+    /// [`Self::persist_history_batch`] for the meaning of `append_only`.
     fn store_trie_updates_for_block(
         &self,
         tx: &<DatabaseEnv as Database>::TXMut,
         block_number: u64,
         block_state_diff: BlockStateDiff,
-        mode: WriteMode,
+        append_only: bool,
     ) -> BaseProofsStorageResult<ChangeSet> {
         let BlockStateDiff { sorted_trie_updates, sorted_post_state } = block_state_diff;
 
@@ -490,13 +472,13 @@ impl MdbxProofsStorage {
             tx,
             block_number,
             sorted_trie_updates.account_nodes_ref().iter().cloned(),
-            mode,
+            append_only,
         )?;
         let hashed_account_keys = self.persist_history_batch(
             tx,
             block_number,
             sorted_post_state.accounts.iter().copied(),
-            mode,
+            append_only,
         )?;
 
         let mut storage_trie_keys = Vec::<StorageTrieKey>::with_capacity(storage_trie_len);
@@ -509,7 +491,7 @@ impl MdbxProofsStorage {
                     *hashed_address,
                     || Ok(ro.next()?),
                     nodes.storage_nodes_ref().iter().cloned(),
-                    mode,
+                    append_only,
                 )?;
                 storage_trie_keys.extend(keys);
                 continue;
@@ -523,7 +505,7 @@ impl MdbxProofsStorage {
                     .iter()
                     .cloned()
                     .map(|(path, node)| (*hashed_address, path, node)),
-                mode,
+                append_only,
             )?;
             storage_trie_keys.extend(keys);
         }
@@ -541,7 +523,7 @@ impl MdbxProofsStorage {
                         .storage_slots_ref()
                         .iter()
                         .map(|(slot, val)| (*slot, Some(StorageValue(*val)))),
-                    mode,
+                    append_only,
                 )?;
                 hashed_storage_keys.extend(keys);
                 continue;
@@ -553,7 +535,7 @@ impl MdbxProofsStorage {
                     .storage_slots_ref()
                     .iter()
                     .map(|(key, val)| (hashed_address, *key, Some(StorageValue(*val)))),
-                mode,
+                append_only,
             )?;
             hashed_storage_keys.extend(keys);
         }
@@ -588,12 +570,8 @@ impl MdbxProofsStorage {
             });
         }
 
-        let change_set = &self.store_trie_updates_for_block(
-            tx,
-            block_number,
-            block_state_diff,
-            WriteMode::Append,
-        )?;
+        let change_set =
+            &self.store_trie_updates_for_block(tx, block_number, block_state_diff, true)?;
 
         let mut change_set_cursor = tx.new_cursor::<BlockChangeSet>()?;
         change_set_cursor.append(block_number, change_set)?;
@@ -611,8 +589,8 @@ impl MdbxProofsStorage {
     /// Apply one block's writes inside an already-open MDBX write transaction.
     ///
     /// Validates the block's parent against `expected_parent_hash` (returning
-    /// [`BaseProofsStorageError::OutOfOrder`] on mismatch), persists the diff using
-    /// `mode`, appends the per-block [`BlockChangeSet`], and advances
+    /// [`BaseProofsStorageError::OutOfOrder`] on mismatch), persists the diff,
+    /// appends the per-block [`BlockChangeSet`], and advances
     /// `ProofWindow::LatestBlock`. Used by both single-block and batched writers
     /// so the per-block correctness invariants live in one place.
     fn apply_block_in_txn(
@@ -621,7 +599,7 @@ impl MdbxProofsStorage {
         block_ref: BlockWithParent,
         block_state_diff: BlockStateDiff,
         expected_parent_hash: B256,
-        mode: WriteMode,
+        append_only: bool,
     ) -> BaseProofsStorageResult<WriteCounts> {
         let block_number = block_ref.block.number;
 
@@ -633,8 +611,8 @@ impl MdbxProofsStorage {
             });
         }
 
-        let change_set =
-            &self.store_trie_updates_for_block(tx, block_number, block_state_diff, mode)?;
+        let change_set = &self
+            .store_trie_updates_for_block(tx, block_number, block_state_diff, append_only)?;
 
         let mut change_set_cursor = tx.new_cursor::<BlockChangeSet>()?;
         change_set_cursor.append(block_number, change_set)?;
@@ -655,7 +633,7 @@ impl MdbxProofsStorage {
     /// first block's parent must match the storage's current latest block hash.
     /// On any error, the entire transaction is aborted so no entries persist.
     ///
-    /// Uses [`WriteMode::Upsert`] because successive blocks within the same
+    /// Uses upsert (not MDBX_APPENDDUP) because successive blocks within the same
     /// transaction may write keys lexicographically smaller than keys written by
     /// earlier blocks, which would violate `MDBX_APPENDDUP`.
     ///
@@ -679,13 +657,8 @@ impl MdbxProofsStorage {
 
             for (block_ref, diff) in blocks {
                 let next_parent = block_ref.block.hash;
-                let counts = self.apply_block_in_txn(
-                    &tx,
-                    block_ref,
-                    diff,
-                    expected_parent,
-                    WriteMode::Upsert,
-                )?;
+                let counts =
+                    self.apply_block_in_txn(&tx, block_ref, diff, expected_parent, false)?;
                 total += counts;
                 expected_parent = next_parent;
             }
@@ -1165,7 +1138,7 @@ impl BaseProofsInitialStateStore for MdbxProofsStorage {
         account_nodes.sort_by_key(|(key, _)| *key);
 
         self.env.update(|tx| {
-            self.persist_history_batch(tx, 0, account_nodes.into_iter(), WriteMode::Append)?;
+            self.persist_history_batch(tx, 0, account_nodes.into_iter(), true)?;
             Ok(())
         })?
     }
@@ -1187,7 +1160,7 @@ impl BaseProofsInitialStateStore for MdbxProofsStorage {
                 tx,
                 0,
                 storage_nodes.into_iter().map(|(path, node)| (hashed_address, path, node)),
-                WriteMode::Append,
+                true,
             )?;
             Ok(())
         })?
@@ -1205,7 +1178,7 @@ impl BaseProofsInitialStateStore for MdbxProofsStorage {
         accounts.sort_by_key(|(key, _)| *key);
 
         self.env.update(|tx| {
-            self.persist_history_batch(tx, 0, accounts.into_iter(), WriteMode::Append)?;
+            self.persist_history_batch(tx, 0, accounts.into_iter(), true)?;
             Ok(())
         })?
     }
@@ -1229,7 +1202,7 @@ impl BaseProofsInitialStateStore for MdbxProofsStorage {
                 storages
                     .into_iter()
                     .map(|(key, val)| (hashed_address, key, Some(StorageValue(val)))),
-                WriteMode::Append,
+                true,
             )?;
             Ok(())
         })?

--- a/crates/execution/trie/src/db/store.rs
+++ b/crates/execution/trie/src/db/store.rs
@@ -69,6 +69,29 @@ struct HistoryDeleteBatch {
     hashed_storage: Vec<(<HashedStorageHistory as Table>::Key, u64)>,
 }
 
+/// Strategy for writing versioned history entries to a `DupSort` table.
+///
+/// Different code paths have different ordering guarantees and need different
+/// MDBX write primitives.
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum WriteMode {
+    /// Use MDBX `MDBX_APPENDDUP` fast-path append.
+    ///
+    /// Caller guarantees that per-key subkeys are monotonically increasing across
+    /// all entries currently in the table plus this batch. This holds for
+    /// single-block writes: every entry uses the same subkey == new `block_number`,
+    /// and that `block_number` is strictly greater than any previously written
+    /// `block_number` for these keys (enforced by `OutOfOrder` parent validation).
+    Append,
+    /// Use MDBX `upsert` (B-tree search + insert/update). No ordering constraints.
+    ///
+    /// Used when batching multiple consecutive blocks into a single transaction:
+    /// subsequent blocks within the same transaction may write keys lexicographically
+    /// smaller than keys written by earlier blocks, which would violate the
+    /// `MDBX_APPENDDUP` table-wide ordering check.
+    Upsert,
+}
+
 impl MdbxProofsStorage {
     /// Creates a new [`MdbxProofsStorage`] instance with the given path.
     pub fn new(path: &Path) -> Result<Self, BaseProofsStorageError> {
@@ -156,21 +179,14 @@ impl MdbxProofsStorage {
     ///
     /// # Parameters
     /// - `block_number`: Target block number for versioning entries
-    /// - `items`: **Must be sorted** - iterator of entries to persist
-    /// - `append_mode`: Mode selector for write strategy:
-    ///   - `true` (Append): Appends all entries including tombstones for forward progress
-    ///   - `false` (Prune): Removes tombstones, writes non-tombstones to block 0
-    ///
-    /// The cost of pruning is the cost of (append + deleting tombstones + deleting old block 0).
-    /// The tombstones deletion is expensive as it requires a seek for each (key + subkey).
-    ///
-    /// Uses [`reth_db::mdbx::cursor::Cursor::upsert`] for upsert operation.
+    /// - `items`: **Must be sorted** by key - iterator of entries to persist
+    /// - `mode`: Write strategy. See [`WriteMode`] for the per-variant contract.
     fn persist_history_batch<T, I, V>(
         &self,
         tx: &(impl DbTxMut + DbTx),
         block_number: T::SubKey,
         items: I,
-        append_mode: bool,
+        mode: WriteMode,
     ) -> BaseProofsStorageResult<Vec<T::Key>>
     where
         T: Table<Value = VersionedValue<V>> + DupSort<SubKey = u64>,
@@ -180,51 +196,14 @@ impl MdbxProofsStorage {
     {
         let mut cur = tx.cursor_dup_write::<T>()?;
         let mut keys = Vec::<T::Key>::new();
-
-        // Materialize iterator to enable partitioning and collect keys
-        let mut pairs: Vec<(T::Key, T::Value)> = Vec::new();
         for it in items {
             let (k, vv) = it.into_kv(block_number);
-            pairs.push((k.clone(), vv));
-            keys.push(k)
-        }
-
-        if append_mode {
-            // Append all entries (including tombstones) to preserve full history
-            for (k, vv) in pairs {
-                cur.append_dup(k.clone(), vv)?;
+            match mode {
+                WriteMode::Append => cur.append_dup(k.clone(), vv)?,
+                WriteMode::Upsert => cur.upsert(k.clone(), &vv)?,
             }
-            return Ok(keys);
+            keys.push(k);
         }
-
-        // Drop current cursor to start clean for Phase 1
-        drop(cur);
-
-        // Phase 1: Batch Delete (Sequential)
-        // Remove all existing state at Block 0 for these keys.
-        {
-            let mut del_cur = tx.cursor_dup_write::<T>()?;
-            for (k, _) in &pairs {
-                // Seek to (Key, Block 0)
-                if let Some(vv) = del_cur.seek_by_key_subkey(k.clone(), 0)?
-                    && vv.block_number == 0
-                {
-                    del_cur.delete_current()?;
-                }
-            }
-        }
-
-        // Phase 2: Batch Write (Sequential)
-        // Write new values (skipping tombstones).
-        {
-            let mut write_cur = tx.cursor_dup_write::<T>()?;
-            for (k, vv) in pairs {
-                if vv.value.0.is_some() {
-                    write_cur.upsert(k, &vv)?;
-                }
-            }
-        }
-
         Ok(keys)
     }
 
@@ -398,6 +377,7 @@ impl MdbxProofsStorage {
         hashed_address: B256,
         mut next: Next,
         new_entries: I,
+        mode: WriteMode,
     ) -> BaseProofsStorageResult<Vec<T::Key>>
     where
         T: Table<Value = VersionedValue<V>> + DupSort,
@@ -420,7 +400,10 @@ impl MdbxProofsStorage {
         for (k, value) in merged {
             let key: T::Key = (hashed_address, k, Option::<V>::None).into_key();
             let vv: T::Value = VersionedValue { block_number, value: MaybeDeleted(value) };
-            cur.append_dup(key.clone(), vv)?;
+            match mode {
+                WriteMode::Append => cur.append_dup(key.clone(), vv)?,
+                WriteMode::Upsert => cur.upsert(key.clone(), &vv)?,
+            }
             keys.push(key);
         }
         Ok(keys)
@@ -489,13 +472,14 @@ impl MdbxProofsStorage {
         })
     }
 
-    /// Write trie/state history for `block_number` from `block_state_diff`.
+    /// Write trie/state history for `block_number` from `block_state_diff` using
+    /// the given `mode` (see [`WriteMode`] for the per-variant contract).
     fn store_trie_updates_for_block(
         &self,
         tx: &<DatabaseEnv as Database>::TXMut,
         block_number: u64,
         block_state_diff: BlockStateDiff,
-        append_mode: bool,
+        mode: WriteMode,
     ) -> BaseProofsStorageResult<ChangeSet> {
         let BlockStateDiff { sorted_trie_updates, sorted_post_state } = block_state_diff;
 
@@ -506,18 +490,18 @@ impl MdbxProofsStorage {
             tx,
             block_number,
             sorted_trie_updates.account_nodes_ref().iter().cloned(),
-            append_mode,
+            mode,
         )?;
         let hashed_account_keys = self.persist_history_batch(
             tx,
             block_number,
             sorted_post_state.accounts.iter().copied(),
-            append_mode,
+            mode,
         )?;
 
         let mut storage_trie_keys = Vec::<StorageTrieKey>::with_capacity(storage_trie_len);
         for (hashed_address, nodes) in sorted_trie_updates.storage_tries_ref() {
-            if nodes.is_deleted && append_mode {
+            if nodes.is_deleted {
                 let mut ro = self.storage_trie_cursor(*hashed_address, block_number - 1)?;
                 let keys = self.wipe_and_overlay(
                     tx,
@@ -525,6 +509,7 @@ impl MdbxProofsStorage {
                     *hashed_address,
                     || Ok(ro.next()?),
                     nodes.storage_nodes_ref().iter().cloned(),
+                    mode,
                 )?;
                 storage_trie_keys.extend(keys);
                 continue;
@@ -538,14 +523,14 @@ impl MdbxProofsStorage {
                     .iter()
                     .cloned()
                     .map(|(path, node)| (*hashed_address, path, node)),
-                append_mode,
+                mode,
             )?;
             storage_trie_keys.extend(keys);
         }
 
         let mut hashed_storage_keys = Vec::<HashedStorageKey>::with_capacity(hashed_storage_len);
         for (hashed_address, storage) in sorted_post_state.storages {
-            if append_mode && storage.is_wiped() {
+            if storage.is_wiped() {
                 let mut ro = self.storage_hashed_cursor(hashed_address, block_number - 1)?;
                 let keys = self.wipe_and_overlay(
                     tx,
@@ -556,6 +541,7 @@ impl MdbxProofsStorage {
                         .storage_slots_ref()
                         .iter()
                         .map(|(slot, val)| (*slot, Some(StorageValue(*val)))),
+                    mode,
                 )?;
                 hashed_storage_keys.extend(keys);
                 continue;
@@ -567,7 +553,7 @@ impl MdbxProofsStorage {
                     .storage_slots_ref()
                     .iter()
                     .map(|(key, val)| (hashed_address, *key, Some(StorageValue(*val)))),
-                append_mode,
+                mode,
             )?;
             hashed_storage_keys.extend(keys);
         }
@@ -603,13 +589,11 @@ impl MdbxProofsStorage {
         }
 
         let change_set =
-            &self.store_trie_updates_for_block(tx, block_number, block_state_diff, true)?;
+            &self.store_trie_updates_for_block(tx, block_number, block_state_diff, WriteMode::Append)?;
 
-        // Cursor for recording all changes made in this block for all history tables
         let mut change_set_cursor = tx.new_cursor::<BlockChangeSet>()?;
         change_set_cursor.append(block_number, change_set)?;
 
-        // Update proof window's latest block
         Self::inner_set_latest_block_number(tx, block_number, block_ref.block.hash)?;
 
         Ok(WriteCounts {
@@ -618,6 +602,103 @@ impl MdbxProofsStorage {
             hashed_accounts_written_total: change_set.hashed_account_keys.len() as u64,
             hashed_storages_written_total: change_set.hashed_storage_keys.len() as u64,
         })
+    }
+
+    /// Apply one block's writes inside an already-open MDBX write transaction.
+    ///
+    /// Validates the block's parent against `expected_parent_hash` (returning
+    /// [`BaseProofsStorageError::OutOfOrder`] on mismatch), persists the diff using
+    /// `mode`, appends the per-block [`BlockChangeSet`], and advances
+    /// `ProofWindow::LatestBlock`. Used by both single-block and batched writers
+    /// so the per-block correctness invariants live in one place.
+    fn apply_block_in_txn(
+        &self,
+        tx: &<DatabaseEnv as Database>::TXMut,
+        block_ref: BlockWithParent,
+        block_state_diff: BlockStateDiff,
+        expected_parent_hash: B256,
+        mode: WriteMode,
+    ) -> BaseProofsStorageResult<WriteCounts> {
+        let block_number = block_ref.block.number;
+
+        if expected_parent_hash != block_ref.parent {
+            return Err(BaseProofsStorageError::OutOfOrder {
+                block_number,
+                parent_block_hash: block_ref.parent,
+                latest_block_hash: expected_parent_hash,
+            });
+        }
+
+        let change_set =
+            &self.store_trie_updates_for_block(tx, block_number, block_state_diff, mode)?;
+
+        let mut change_set_cursor = tx.new_cursor::<BlockChangeSet>()?;
+        change_set_cursor.append(block_number, change_set)?;
+
+        Self::inner_set_latest_block_number(tx, block_number, block_ref.block.hash)?;
+
+        Ok(WriteCounts {
+            account_trie_updates_written_total: change_set.account_trie_keys.len() as u64,
+            storage_trie_updates_written_total: change_set.storage_trie_keys.len() as u64,
+            hashed_accounts_written_total: change_set.hashed_account_keys.len() as u64,
+            hashed_storages_written_total: change_set.hashed_storage_keys.len() as u64,
+        })
+    }
+
+    /// Write a contiguous batch of blocks inside a single MDBX write transaction.
+    ///
+    /// All blocks must form a chain (block[i+1].parent == block[i].hash) and the
+    /// first block's parent must match the storage's current latest block hash.
+    /// On any error, the entire transaction is aborted so no entries persist.
+    ///
+    /// Uses [`WriteMode::Upsert`] because successive blocks within the same
+    /// transaction may write keys lexicographically smaller than keys written by
+    /// earlier blocks, which would violate `MDBX_APPENDDUP`.
+    ///
+    /// Note on commit semantics: [`reth_db::Database::update`] commits
+    /// unconditionally, so we drive the transaction manually here to abort on
+    /// the first per-block error.
+    fn store_trie_updates_batch_inner(
+        &self,
+        blocks: Vec<(BlockWithParent, BlockStateDiff)>,
+    ) -> BaseProofsStorageResult<WriteCounts> {
+        if blocks.is_empty() {
+            return Ok(WriteCounts::default());
+        }
+
+        let tx = self.env.tx_mut()?;
+
+        let outcome: BaseProofsStorageResult<WriteCounts> = (|| {
+            let mut total = WriteCounts::default();
+            let mut expected_parent =
+                self.inner_get_latest_block_number_hash(&tx)?.map_or(B256::ZERO, |(_, h)| h);
+
+            for (block_ref, diff) in blocks {
+                let next_parent = block_ref.block.hash;
+                let counts = self.apply_block_in_txn(
+                    &tx,
+                    block_ref,
+                    diff,
+                    expected_parent,
+                    WriteMode::Upsert,
+                )?;
+                total += counts;
+                expected_parent = next_parent;
+            }
+
+            Ok(total)
+        })();
+
+        match outcome {
+            Ok(counts) => {
+                tx.commit()?;
+                Ok(counts)
+            }
+            Err(e) => {
+                tx.abort();
+                Err(e)
+            }
+        }
     }
 
     /// Return `BlockNumHash` for the initial state anchor.
@@ -774,6 +855,13 @@ impl BaseProofsStore for MdbxProofsStorage {
     ) -> BaseProofsStorageResult<WriteCounts> {
         self.env
             .update(|tx| self.store_trie_updates_append_only(tx, block_ref, block_state_diff))?
+    }
+
+    fn store_trie_updates_batch(
+        &self,
+        blocks: Vec<(BlockWithParent, BlockStateDiff)>,
+    ) -> BaseProofsStorageResult<WriteCounts> {
+        self.store_trie_updates_batch_inner(blocks)
     }
 
     fn fetch_trie_updates(&self, block_number: u64) -> BaseProofsStorageResult<BlockStateDiff> {
@@ -1073,7 +1161,7 @@ impl BaseProofsInitialStateStore for MdbxProofsStorage {
         account_nodes.sort_by_key(|(key, _)| *key);
 
         self.env.update(|tx| {
-            self.persist_history_batch(tx, 0, account_nodes.into_iter(), true)?;
+            self.persist_history_batch(tx, 0, account_nodes.into_iter(), WriteMode::Append)?;
             Ok(())
         })?
     }
@@ -1095,7 +1183,7 @@ impl BaseProofsInitialStateStore for MdbxProofsStorage {
                 tx,
                 0,
                 storage_nodes.into_iter().map(|(path, node)| (hashed_address, path, node)),
-                true,
+                WriteMode::Append,
             )?;
             Ok(())
         })?
@@ -1110,11 +1198,10 @@ impl BaseProofsInitialStateStore for MdbxProofsStorage {
             return Ok(());
         }
 
-        // sort the accounts by key to ensure insertion is efficient
         accounts.sort_by_key(|(key, _)| *key);
 
         self.env.update(|tx| {
-            self.persist_history_batch(tx, 0, accounts.into_iter(), true)?;
+            self.persist_history_batch(tx, 0, accounts.into_iter(), WriteMode::Append)?;
             Ok(())
         })?
     }
@@ -1129,7 +1216,6 @@ impl BaseProofsInitialStateStore for MdbxProofsStorage {
             return Ok(());
         }
 
-        // sort the storages by key to ensure insertion is efficient
         storages.sort_by_key(|(key, _)| *key);
 
         self.env.update(|tx| {
@@ -1139,7 +1225,7 @@ impl BaseProofsInitialStateStore for MdbxProofsStorage {
                 storages
                     .into_iter()
                     .map(|(key, val)| (hashed_address, key, Some(StorageValue(val)))),
-                true,
+                WriteMode::Append,
             )?;
             Ok(())
         })?

--- a/crates/execution/trie/src/db/store.rs
+++ b/crates/execution/trie/src/db/store.rs
@@ -588,8 +588,12 @@ impl MdbxProofsStorage {
             });
         }
 
-        let change_set =
-            &self.store_trie_updates_for_block(tx, block_number, block_state_diff, WriteMode::Append)?;
+        let change_set = &self.store_trie_updates_for_block(
+            tx,
+            block_number,
+            block_state_diff,
+            WriteMode::Append,
+        )?;
 
         let mut change_set_cursor = tx.new_cursor::<BlockChangeSet>()?;
         change_set_cursor.append(block_number, change_set)?;

--- a/crates/execution/trie/src/lib.rs
+++ b/crates/execution/trie/src/lib.rs
@@ -12,7 +12,7 @@
 use reth_ethereum_primitives as _;
 
 pub mod api;
-pub use api::{BaseProofsInitialStateStore, BaseProofsStore, BlockStateDiff};
+pub use api::{BaseProofsInitialStateStore, BaseProofsStore, BlockStateDiff, WriteCounts};
 
 pub mod initialize;
 pub use initialize::InitializationJob;

--- a/crates/execution/trie/src/lib.rs
+++ b/crates/execution/trie/src/lib.rs
@@ -42,6 +42,9 @@ pub mod provider;
 
 pub mod live;
 
+mod overlay;
+pub use overlay::ProofsBatchOverlay;
+
 pub mod cursor;
 #[cfg(not(feature = "metrics"))]
 pub use cursor::{

--- a/crates/execution/trie/src/live.rs
+++ b/crates/execution/trie/src/live.rs
@@ -182,6 +182,65 @@ where
         Ok(())
     }
 
+    /// Store trie updates for a contiguous batch of blocks atomically in a single
+    /// underlying storage transaction.
+    ///
+    /// On `OutOfOrder` (parent mismatch on the first block, or any chain break
+    /// inside the batch), the entire batch is silently skipped — matching the
+    /// per-block [`store_block_updates`] behavior used when notifications race
+    /// with already-stored data.
+    pub fn store_block_updates_batch(
+        &self,
+        blocks: Vec<(BlockWithParent, BlockStateDiff)>,
+    ) -> Result<(), BaseProofsStorageError> {
+        if blocks.is_empty() {
+            return Ok(());
+        }
+
+        let start = Instant::now();
+        let mut operation_durations = OperationDurations::default();
+
+        let first_block_number = blocks.first().map(|(b, _)| b.block.number);
+        let last_block_number = blocks.last().map(|(b, _)| b.block.number);
+        let batch_len = blocks.len();
+
+        let storage_result = match self.storage.store_trie_updates_batch(blocks) {
+            Ok(res) => res,
+            Err(BaseProofsStorageError::OutOfOrder {
+                block_number,
+                latest_block_hash,
+                parent_block_hash,
+            }) => {
+                warn!(
+                    block_number,
+                    ?latest_block_hash,
+                    ?parent_block_hash,
+                    batch_len,
+                    "Skipping out of order block batch"
+                );
+                return Ok(());
+            }
+            Err(e) => return Err(e),
+        };
+
+        let write_duration = start.elapsed();
+        operation_durations.total_duration_seconds = write_duration;
+        operation_durations.write_duration_seconds = write_duration;
+
+        Self::record_storage_metrics(&operation_durations, Some(&storage_result));
+
+        info!(
+            ?first_block_number,
+            ?last_block_number,
+            batch_len,
+            ?operation_durations,
+            ?storage_result,
+            "Trie updates batch stored successfully",
+        );
+
+        Ok(())
+    }
+
     /// Handles chain reorganizations by replacing block updates after a common ancestor.
     ///
     /// This method removes all block updates after the latest common ancestor (the block before

--- a/crates/execution/trie/src/live.rs
+++ b/crates/execution/trie/src/live.rs
@@ -11,14 +11,17 @@ use reth_provider::{
     StateRootProvider,
 };
 use reth_revm::database::StateProviderDatabase;
-use reth_trie_common::{HashedPostStateSorted, updates::TrieUpdatesSorted};
+use reth_trie_common::{
+    HashedPostState, HashedPostStateSorted,
+    updates::{TrieUpdates, TrieUpdatesSorted},
+};
 use tracing::{info, warn};
 
 use crate::{
-    BaseProofsStorage, BaseProofsStorageError, BaseProofsStore, BlockStateDiff,
+    BaseProofsStorage, BaseProofsStorageError, BaseProofsStore, BlockStateDiff, ProofsBatchOverlay,
     api::{OperationDurations, WriteCounts},
     metrics::BlockMetrics,
-    provider::BaseProofsStateProviderRef,
+    provider::{BaseProofsStateProviderRef, OverlayedBaseProofsStateProviderRef},
 };
 
 /// Live trie collector for external proofs storage.
@@ -133,6 +136,39 @@ where
         );
 
         Ok(())
+    }
+
+    /// Execute a block against a batch-local overlay without storing updates.
+    pub fn execute_block_with_overlay(
+        &self,
+        block: &RecoveredBlock<BlockTy<Evm::Primitives>>,
+        overlay: &ProofsBatchOverlay,
+    ) -> Result<(HashedPostState, TrieUpdates), BaseProofsStorageError> {
+        let parent_block_number = block.number() - 1;
+        let state_provider = OverlayedBaseProofsStateProviderRef::new(
+            self.provider.state_by_block_hash(block.parent_hash())?,
+            self.storage,
+            parent_block_number,
+            overlay,
+        );
+
+        let db = StateProviderDatabase::new(&state_provider);
+        let block_executor = self.evm_config.batch_executor(db);
+        let execution_result = block_executor.execute(&(*block).clone())?;
+
+        let hashed_state = state_provider.hashed_post_state(&execution_result.state);
+        let (state_root, trie_updates) =
+            state_provider.state_root_with_updates(hashed_state.clone())?;
+
+        if state_root != block.state_root() {
+            return Err(BaseProofsStorageError::StateRootMismatch {
+                block_number: block.number(),
+                current_state_hash: state_root,
+                expected_state_hash: block.state_root(),
+            });
+        }
+
+        Ok((hashed_state, trie_updates))
     }
 
     /// Store trie updates for a given block.

--- a/crates/execution/trie/src/live.rs
+++ b/crates/execution/trie/src/live.rs
@@ -144,7 +144,26 @@ where
         block: &RecoveredBlock<BlockTy<Evm::Primitives>>,
         overlay: &ProofsBatchOverlay,
     ) -> Result<(HashedPostState, TrieUpdates), BaseProofsStorageError> {
-        let parent_block_number = block.number() - 1;
+        let parent_block_number =
+            block.number().checked_sub(1).ok_or(BaseProofsStorageError::UnknownParent)?;
+        let (Some((earliest, _)), Some((latest, _))) =
+            (self.storage.get_earliest_block_number()?, self.storage.get_latest_block_number()?)
+        else {
+            return Err(BaseProofsStorageError::NoBlocksFound);
+        };
+
+        if parent_block_number < earliest {
+            return Err(BaseProofsStorageError::UnknownParent);
+        }
+
+        if overlay.is_empty() && parent_block_number > latest {
+            return Err(BaseProofsStorageError::MissingParentBlock {
+                block_number: block.number(),
+                parent_block_number,
+                latest_block_number: latest,
+            });
+        }
+
         let state_provider = OverlayedBaseProofsStateProviderRef::new(
             self.provider.state_by_block_hash(block.parent_hash())?,
             self.storage,

--- a/crates/execution/trie/src/metrics.rs
+++ b/crates/execution/trie/src/metrics.rs
@@ -445,6 +445,19 @@ where
     }
 
     #[inline]
+    fn store_trie_updates_batch(
+        &self,
+        blocks: Vec<(BlockWithParent, BlockStateDiff)>,
+    ) -> BaseProofsStorageResult<WriteCounts> {
+        let last_block_number = blocks.last().map(|(block_ref, _)| block_ref.block.number);
+        let result = self.storage.store_trie_updates_batch(blocks)?;
+        if let Some(n) = last_block_number {
+            BlockMetrics::latest_number().set(n as f64);
+        }
+        Ok(result)
+    }
+
+    #[inline]
     fn fetch_trie_updates(&self, block_number: u64) -> BaseProofsStorageResult<BlockStateDiff> {
         self.storage.fetch_trie_updates(block_number)
     }

--- a/crates/execution/trie/src/overlay.rs
+++ b/crates/execution/trie/src/overlay.rs
@@ -1,0 +1,256 @@
+//! Batch-local overlay for proofs sync execution.
+
+use alloy_eips::{BlockNumHash, eip1898::BlockWithParent};
+use reth_trie_common::{
+    HashedPostState, HashedPostStateSorted,
+    updates::{TrieUpdates, TrieUpdatesSorted},
+};
+
+use crate::BlockStateDiff;
+
+/// Batch-local read overlay and pending write buffer for proofs sync.
+#[derive(Debug, Default)]
+pub struct ProofsBatchOverlay {
+    /// Cumulative hashed post-state from prior blocks in this batch.
+    read_state: HashedPostState,
+    /// Cumulative trie node updates from prior blocks in this batch.
+    parent_trie: TrieUpdates,
+    /// Per-block diffs in append order, used at flush time.
+    pending: Vec<(BlockWithParent, BlockStateDiff)>,
+    /// Highest block appended to this overlay.
+    last_block: Option<BlockNumHash>,
+}
+
+impl ProofsBatchOverlay {
+    /// Creates an empty batch overlay.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Appends a re-executed block's block-local state and trie diff.
+    pub fn append_executed(
+        &mut self,
+        block: BlockWithParent,
+        hashed_state: HashedPostState,
+        trie_updates: TrieUpdates,
+    ) {
+        self.assert_next_block(block);
+
+        let sorted_post_state = hashed_state.clone_into_sorted();
+        let sorted_trie_updates = trie_updates.clone_into_sorted();
+
+        self.read_state.extend(hashed_state);
+        self.parent_trie.extend(trie_updates);
+        self.pending.push((block, BlockStateDiff { sorted_trie_updates, sorted_post_state }));
+        self.last_block = Some(block.block);
+    }
+
+    /// Appends a cached block's block-local state and trie diff.
+    pub fn append_cached(
+        &mut self,
+        block: BlockWithParent,
+        sorted_post_state: &HashedPostStateSorted,
+        sorted_trie_updates: &TrieUpdatesSorted,
+    ) {
+        self.assert_next_block(block);
+
+        self.read_state.extend_from_sorted(sorted_post_state);
+        self.parent_trie.extend_from_sorted(sorted_trie_updates);
+        self.pending.push((
+            block,
+            BlockStateDiff {
+                sorted_trie_updates: sorted_trie_updates.clone(),
+                sorted_post_state: sorted_post_state.clone(),
+            },
+        ));
+        self.last_block = Some(block.block);
+    }
+
+    /// Returns true when no blocks have been appended.
+    pub fn is_empty(&self) -> bool {
+        self.pending.is_empty()
+    }
+
+    /// Returns the number of blocks appended to this overlay.
+    pub fn len(&self) -> usize {
+        self.pending.len()
+    }
+
+    /// Consumes this overlay and returns the block-local diffs in append order.
+    pub fn into_pending(self) -> Vec<(BlockWithParent, BlockStateDiff)> {
+        self.pending
+    }
+
+    /// Returns the cumulative hashed post-state for prior blocks in this batch.
+    pub fn read_state(&self) -> &HashedPostState {
+        &self.read_state
+    }
+
+    /// Returns the cumulative trie node updates for prior blocks in this batch.
+    pub fn parent_trie(&self) -> &TrieUpdates {
+        &self.parent_trie
+    }
+
+    fn assert_next_block(&self, block: BlockWithParent) {
+        if let Some(last_block) = self.last_block {
+            debug_assert_eq!(last_block.hash, block.parent);
+            debug_assert_eq!(last_block.number + 1, block.block.number);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use alloy_primitives::{B256, U256};
+    use reth_primitives_traits::Account;
+    use reth_trie_common::{BranchNodeCompact, HashedStorage, Nibbles, TrieMask};
+
+    use super::*;
+
+    fn block(number: u64) -> BlockWithParent {
+        BlockWithParent::new(
+            if number == 1 { B256::ZERO } else { B256::repeat_byte((number - 1) as u8) },
+            alloy_eips::NumHash::new(number, B256::repeat_byte(number as u8)),
+        )
+    }
+
+    fn account(nonce: u64) -> Account {
+        Account { nonce, balance: U256::from(nonce), bytecode_hash: None }
+    }
+
+    fn branch(bit: u8) -> BranchNodeCompact {
+        let mut state_mask = TrieMask::default();
+        state_mask.set_bit(bit);
+        BranchNodeCompact {
+            state_mask,
+            tree_mask: TrieMask::default(),
+            hash_mask: TrieMask::default(),
+            hashes: Arc::new(vec![]),
+            root_hash: None,
+        }
+    }
+
+    fn nibbles(value: u8) -> Nibbles {
+        Nibbles::from_nibbles_unchecked([value])
+    }
+
+    #[test]
+    fn append_executed_then_into_pending_yields_appended_diff() {
+        let mut overlay = ProofsBatchOverlay::new();
+        let mut state = HashedPostState::default();
+        state.accounts.insert(B256::repeat_byte(0x01), Some(account(1)));
+        let mut trie = TrieUpdates::default();
+        trie.account_nodes.insert(nibbles(1), branch(1));
+
+        overlay.append_executed(block(1), state, trie);
+
+        let pending = overlay.into_pending();
+        assert_eq!(pending.len(), 1);
+        assert_eq!(pending[0].0.block.number, 1);
+        assert_eq!(pending[0].1.sorted_post_state.accounts.len(), 1);
+        assert_eq!(pending[0].1.sorted_trie_updates.account_nodes_ref().len(), 1);
+    }
+
+    #[test]
+    fn append_cached_extends_read_state_correctly() {
+        let mut overlay = ProofsBatchOverlay::new();
+        let mut state = HashedPostState::default();
+        let hashed_address = B256::repeat_byte(0x01);
+        state.accounts.insert(hashed_address, Some(account(1)));
+        let sorted_state = state.into_sorted();
+        let sorted_trie = TrieUpdates::default().into_sorted();
+
+        overlay.append_cached(block(1), &sorted_state, &sorted_trie);
+
+        assert_eq!(overlay.read_state().accounts.get(&hashed_address), Some(&Some(account(1))));
+    }
+
+    #[test]
+    fn multiple_appends_preserve_oldest_to_newest_order() {
+        let mut overlay = ProofsBatchOverlay::new();
+        overlay.append_executed(block(1), HashedPostState::default(), TrieUpdates::default());
+        overlay.append_executed(block(2), HashedPostState::default(), TrieUpdates::default());
+
+        let pending = overlay.into_pending();
+        assert_eq!(pending[0].0.block.number, 1);
+        assert_eq!(pending[1].0.block.number, 2);
+    }
+
+    #[test]
+    fn read_state_destroyed_account_propagates() {
+        let mut overlay = ProofsBatchOverlay::new();
+        let hashed_address = B256::repeat_byte(0x01);
+        let mut state = HashedPostState::default();
+        state.accounts.insert(hashed_address, None);
+
+        overlay.append_executed(block(1), state, TrieUpdates::default());
+
+        assert_eq!(overlay.read_state().accounts.get(&hashed_address), Some(&None));
+    }
+
+    #[test]
+    fn read_state_wiped_storage_sticky() {
+        let mut overlay = ProofsBatchOverlay::new();
+        let hashed_address = B256::repeat_byte(0x01);
+        let hashed_slot = B256::repeat_byte(0x02);
+        let mut wiped = HashedPostState::default();
+        wiped.storages.insert(hashed_address, HashedStorage::new(true));
+        let mut write = HashedPostState::default();
+        write.storages.insert(
+            hashed_address,
+            HashedStorage::from_iter(false, [(hashed_slot, U256::from(7))]),
+        );
+
+        overlay.append_executed(block(1), wiped, TrieUpdates::default());
+        overlay.append_executed(block(2), write, TrieUpdates::default());
+
+        let storage = overlay.read_state().storages.get(&hashed_address).unwrap();
+        assert!(storage.wiped);
+        assert_eq!(storage.storage.get(&hashed_slot), Some(&U256::from(7)));
+    }
+
+    #[test]
+    fn parent_trie_updates_accumulate_with_latest_wins() {
+        let mut overlay = ProofsBatchOverlay::new();
+        let path = nibbles(1);
+        let mut first = TrieUpdates::default();
+        first.account_nodes.insert(path, branch(1));
+        let mut second = TrieUpdates::default();
+        second.account_nodes.insert(path, branch(2));
+
+        overlay.append_executed(block(1), HashedPostState::default(), first);
+        overlay.append_executed(block(2), HashedPostState::default(), second);
+
+        assert_eq!(overlay.parent_trie().account_nodes.get(&path), Some(&branch(2)));
+    }
+
+    #[test]
+    fn len_and_is_empty_track_pending() {
+        let mut overlay = ProofsBatchOverlay::new();
+        assert!(overlay.is_empty());
+        assert_eq!(overlay.len(), 0);
+
+        overlay.append_executed(block(1), HashedPostState::default(), TrieUpdates::default());
+
+        assert!(!overlay.is_empty());
+        assert_eq!(overlay.len(), 1);
+    }
+
+    #[test]
+    fn pending_keeps_each_block_diff_local() {
+        let mut overlay = ProofsBatchOverlay::new();
+        let mut first = HashedPostState::default();
+        first.accounts.insert(B256::repeat_byte(0x01), Some(account(1)));
+        let mut second = HashedPostState::default();
+        second.accounts.insert(B256::repeat_byte(0x02), Some(account(2)));
+
+        overlay.append_executed(block(1), first, TrieUpdates::default());
+        overlay.append_executed(block(2), second, TrieUpdates::default());
+
+        let pending = overlay.into_pending();
+        assert_eq!(pending[1].1.sorted_post_state.accounts.len(), 1);
+        assert_eq!(pending[1].1.sorted_post_state.accounts[0].0, B256::repeat_byte(0x02));
+    }
+}

--- a/crates/execution/trie/src/overlay.rs
+++ b/crates/execution/trie/src/overlay.rs
@@ -67,12 +67,12 @@ impl ProofsBatchOverlay {
     }
 
     /// Returns true when no blocks have been appended.
-    pub fn is_empty(&self) -> bool {
+    pub const fn is_empty(&self) -> bool {
         self.pending.is_empty()
     }
 
     /// Returns the number of blocks appended to this overlay.
-    pub fn len(&self) -> usize {
+    pub const fn len(&self) -> usize {
         self.pending.len()
     }
 
@@ -82,12 +82,12 @@ impl ProofsBatchOverlay {
     }
 
     /// Returns the cumulative hashed post-state for prior blocks in this batch.
-    pub fn read_state(&self) -> &HashedPostState {
+    pub const fn read_state(&self) -> &HashedPostState {
         &self.read_state
     }
 
     /// Returns the cumulative trie node updates for prior blocks in this batch.
-    pub fn parent_trie(&self) -> &TrieUpdates {
+    pub const fn parent_trie(&self) -> &TrieUpdates {
         &self.parent_trie
     }
 

--- a/crates/execution/trie/src/overlay.rs
+++ b/crates/execution/trie/src/overlay.rs
@@ -93,8 +93,8 @@ impl ProofsBatchOverlay {
 
     fn assert_next_block(&self, block: BlockWithParent) {
         if let Some(last_block) = self.last_block {
-            debug_assert_eq!(last_block.hash, block.parent);
-            debug_assert_eq!(last_block.number + 1, block.block.number);
+            assert_eq!(last_block.hash, block.parent);
+            assert_eq!(last_block.number + 1, block.block.number);
         }
     }
 }

--- a/crates/execution/trie/src/provider.rs
+++ b/crates/execution/trie/src/provider.rs
@@ -13,10 +13,9 @@ use reth_revm::{
     db::BundleState,
     primitives::{Address, B256, Bytes, StorageValue, alloy_primitives::BlockNumber},
 };
-use reth_trie::hashed_cursor::HashedPostStateCursorFactory;
 use reth_trie::{
     StateRoot, StorageRoot,
-    hashed_cursor::HashedCursor,
+    hashed_cursor::{HashedCursor, HashedPostStateCursorFactory},
     proof::{self, Proof},
     trie_cursor::InMemoryTrieCursorFactory,
     witness::TrieWitness,

--- a/crates/execution/trie/src/provider.rs
+++ b/crates/execution/trie/src/provider.rs
@@ -387,9 +387,7 @@ impl<'a, Storage: BaseProofsStore + Clone> StorageRootProvider
     for OverlayedBaseProofsStateProviderRef<'a, Storage>
 {
     fn storage_root(&self, _address: Address, _storage: HashedStorage) -> ProviderResult<B256> {
-        unreachable!(
-            "OverlayedBaseProofsStateProviderRef is sync-forward only and does not support StorageRootProvider"
-        )
+        Err(ProviderError::UnsupportedProvider)
     }
 
     fn storage_proof(
@@ -398,9 +396,7 @@ impl<'a, Storage: BaseProofsStore + Clone> StorageRootProvider
         _slot: B256,
         _storage: HashedStorage,
     ) -> ProviderResult<StorageProof> {
-        unreachable!(
-            "OverlayedBaseProofsStateProviderRef is sync-forward only and does not support StorageRootProvider"
-        )
+        Err(ProviderError::UnsupportedProvider)
     }
 
     fn storage_multiproof(
@@ -409,9 +405,7 @@ impl<'a, Storage: BaseProofsStore + Clone> StorageRootProvider
         _slots: &[B256],
         _storage: HashedStorage,
     ) -> ProviderResult<StorageMultiProof> {
-        unreachable!(
-            "OverlayedBaseProofsStateProviderRef is sync-forward only and does not support StorageRootProvider"
-        )
+        Err(ProviderError::UnsupportedProvider)
     }
 }
 
@@ -424,9 +418,7 @@ impl<'a, Storage: BaseProofsStore + Clone> StateProofProvider
         _address: Address,
         _slots: &[B256],
     ) -> ProviderResult<AccountProof> {
-        unreachable!(
-            "OverlayedBaseProofsStateProviderRef is sync-forward only and does not support StateProofProvider"
-        )
+        Err(ProviderError::UnsupportedProvider)
     }
 
     fn multiproof(
@@ -434,15 +426,11 @@ impl<'a, Storage: BaseProofsStore + Clone> StateProofProvider
         _input: TrieInput,
         _targets: MultiProofTargets,
     ) -> ProviderResult<MultiProof> {
-        unreachable!(
-            "OverlayedBaseProofsStateProviderRef is sync-forward only and does not support StateProofProvider"
-        )
+        Err(ProviderError::UnsupportedProvider)
     }
 
     fn witness(&self, _input: TrieInput, _target: HashedPostState) -> ProviderResult<Vec<Bytes>> {
-        unreachable!(
-            "OverlayedBaseProofsStateProviderRef is sync-forward only and does not support StateProofProvider"
-        )
+        Err(ProviderError::UnsupportedProvider)
     }
 }
 

--- a/crates/execution/trie/src/provider.rs
+++ b/crates/execution/trie/src/provider.rs
@@ -13,10 +13,12 @@ use reth_revm::{
     db::BundleState,
     primitives::{Address, B256, Bytes, StorageValue, alloy_primitives::BlockNumber},
 };
+use reth_trie::hashed_cursor::HashedPostStateCursorFactory;
 use reth_trie::{
     StateRoot, StorageRoot,
     hashed_cursor::HashedCursor,
     proof::{self, Proof},
+    trie_cursor::InMemoryTrieCursorFactory,
     witness::TrieWitness,
 };
 use reth_trie_common::{
@@ -25,7 +27,8 @@ use reth_trie_common::{
 };
 
 use crate::{
-    BaseProofsStorage, BaseProofsStorageError, BaseProofsStore,
+    BaseProofsHashedAccountCursorFactory, BaseProofsStorage, BaseProofsStorageError,
+    BaseProofsStore, BaseProofsTrieCursorFactory, ProofsBatchOverlay,
     proof::{
         DatabaseProof, DatabaseStateRoot, DatabaseStorageProof, DatabaseStorageRoot,
         DatabaseTrieWitness,
@@ -45,6 +48,22 @@ pub struct BaseProofsStateProviderRef<'a, Storage: BaseProofsStore> {
     block_number: BlockNumber,
 }
 
+/// Overlay-aware state provider for batched proofs sync execution.
+#[derive(Constructor)]
+pub struct OverlayedBaseProofsStateProviderRef<'a, Storage: BaseProofsStore> {
+    /// Historical state provider for non-state related tasks.
+    latest: Box<dyn StateProvider + Send + 'a>,
+
+    /// Storage provider for persisted state lookups.
+    storage: &'a BaseProofsStorage<Storage>,
+
+    /// Max block number that can be used for persisted state lookups.
+    block_number: BlockNumber,
+
+    /// Batch-local parent-state read overlay.
+    overlay: &'a ProofsBatchOverlay,
+}
+
 impl<'a, Storage> Debug for BaseProofsStateProviderRef<'a, Storage>
 where
     Storage: BaseProofsStore + 'a + Debug,
@@ -53,6 +72,19 @@ where
         f.debug_struct("BaseProofsStateProviderRef")
             .field("storage", &self.storage)
             .field("block_number", &self.block_number)
+            .finish()
+    }
+}
+
+impl<'a, Storage> Debug for OverlayedBaseProofsStateProviderRef<'a, Storage>
+where
+    Storage: BaseProofsStore + 'a + Debug,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("OverlayedBaseProofsStateProviderRef")
+            .field("storage", &self.storage)
+            .field("block_number", &self.block_number)
+            .field("overlay_len", &self.overlay.len())
             .finish()
     }
 }
@@ -224,8 +256,266 @@ impl<'a, Storage: BaseProofsStore> BytecodeReader for BaseProofsStateProviderRef
     }
 }
 
+impl<'a, Storage: BaseProofsStore> BlockHashReader
+    for OverlayedBaseProofsStateProviderRef<'a, Storage>
+{
+    fn block_hash(&self, number: BlockNumber) -> ProviderResult<Option<B256>> {
+        self.latest.block_hash(number)
+    }
+
+    fn canonical_hashes_range(
+        &self,
+        start: BlockNumber,
+        end: BlockNumber,
+    ) -> ProviderResult<Vec<B256>> {
+        self.latest.canonical_hashes_range(start, end)
+    }
+}
+
+impl<'a, Storage: BaseProofsStore + Clone> StateRootProvider
+    for OverlayedBaseProofsStateProviderRef<'a, Storage>
+{
+    fn state_root(&self, state: HashedPostState) -> ProviderResult<B256> {
+        let prefix_sets = state.construct_prefix_sets().freeze();
+        let overlay_nodes_sorted = self.overlay.parent_trie().clone_into_sorted();
+        let overlay_state_sorted = self.overlay.read_state().clone_into_sorted();
+        let state_sorted = state.into_sorted();
+
+        Ok(StateRoot::new(
+            InMemoryTrieCursorFactory::new(
+                BaseProofsTrieCursorFactory::new(self.storage, self.block_number),
+                &overlay_nodes_sorted,
+            ),
+            HashedPostStateCursorFactory::new(
+                HashedPostStateCursorFactory::new(
+                    BaseProofsHashedAccountCursorFactory::new(self.storage, self.block_number),
+                    &overlay_state_sorted,
+                ),
+                &state_sorted,
+            ),
+        )
+        .with_prefix_sets(prefix_sets)
+        .root()?)
+    }
+
+    fn state_root_from_nodes(&self, input: TrieInput) -> ProviderResult<B256> {
+        let overlay_nodes_sorted = self.overlay.parent_trie().clone_into_sorted();
+        let overlay_state_sorted = self.overlay.read_state().clone_into_sorted();
+        let nodes_sorted = input.nodes.into_sorted();
+        let state_sorted = input.state.into_sorted();
+
+        Ok(StateRoot::new(
+            InMemoryTrieCursorFactory::new(
+                InMemoryTrieCursorFactory::new(
+                    BaseProofsTrieCursorFactory::new(self.storage, self.block_number),
+                    &overlay_nodes_sorted,
+                ),
+                &nodes_sorted,
+            ),
+            HashedPostStateCursorFactory::new(
+                HashedPostStateCursorFactory::new(
+                    BaseProofsHashedAccountCursorFactory::new(self.storage, self.block_number),
+                    &overlay_state_sorted,
+                ),
+                &state_sorted,
+            ),
+        )
+        .with_prefix_sets(input.prefix_sets.freeze())
+        .root()?)
+    }
+
+    fn state_root_with_updates(
+        &self,
+        state: HashedPostState,
+    ) -> ProviderResult<(B256, TrieUpdates)> {
+        let prefix_sets = state.construct_prefix_sets().freeze();
+        let overlay_nodes_sorted = self.overlay.parent_trie().clone_into_sorted();
+        let overlay_state_sorted = self.overlay.read_state().clone_into_sorted();
+        let state_sorted = state.into_sorted();
+
+        Ok(StateRoot::new(
+            InMemoryTrieCursorFactory::new(
+                BaseProofsTrieCursorFactory::new(self.storage, self.block_number),
+                &overlay_nodes_sorted,
+            ),
+            HashedPostStateCursorFactory::new(
+                HashedPostStateCursorFactory::new(
+                    BaseProofsHashedAccountCursorFactory::new(self.storage, self.block_number),
+                    &overlay_state_sorted,
+                ),
+                &state_sorted,
+            ),
+        )
+        .with_prefix_sets(prefix_sets)
+        .root_with_updates()?)
+    }
+
+    fn state_root_from_nodes_with_updates(
+        &self,
+        input: TrieInput,
+    ) -> ProviderResult<(B256, TrieUpdates)> {
+        let overlay_nodes_sorted = self.overlay.parent_trie().clone_into_sorted();
+        let overlay_state_sorted = self.overlay.read_state().clone_into_sorted();
+        let nodes_sorted = input.nodes.into_sorted();
+        let state_sorted = input.state.into_sorted();
+
+        Ok(StateRoot::new(
+            InMemoryTrieCursorFactory::new(
+                InMemoryTrieCursorFactory::new(
+                    BaseProofsTrieCursorFactory::new(self.storage, self.block_number),
+                    &overlay_nodes_sorted,
+                ),
+                &nodes_sorted,
+            ),
+            HashedPostStateCursorFactory::new(
+                HashedPostStateCursorFactory::new(
+                    BaseProofsHashedAccountCursorFactory::new(self.storage, self.block_number),
+                    &overlay_state_sorted,
+                ),
+                &state_sorted,
+            ),
+        )
+        .with_prefix_sets(input.prefix_sets.freeze())
+        .root_with_updates()?)
+    }
+}
+
+impl<'a, Storage: BaseProofsStore + Clone> StorageRootProvider
+    for OverlayedBaseProofsStateProviderRef<'a, Storage>
+{
+    fn storage_root(&self, _address: Address, _storage: HashedStorage) -> ProviderResult<B256> {
+        unreachable!(
+            "OverlayedBaseProofsStateProviderRef is sync-forward only and does not support StorageRootProvider"
+        )
+    }
+
+    fn storage_proof(
+        &self,
+        _address: Address,
+        _slot: B256,
+        _storage: HashedStorage,
+    ) -> ProviderResult<StorageProof> {
+        unreachable!(
+            "OverlayedBaseProofsStateProviderRef is sync-forward only and does not support StorageRootProvider"
+        )
+    }
+
+    fn storage_multiproof(
+        &self,
+        _address: Address,
+        _slots: &[B256],
+        _storage: HashedStorage,
+    ) -> ProviderResult<StorageMultiProof> {
+        unreachable!(
+            "OverlayedBaseProofsStateProviderRef is sync-forward only and does not support StorageRootProvider"
+        )
+    }
+}
+
+impl<'a, Storage: BaseProofsStore + Clone> StateProofProvider
+    for OverlayedBaseProofsStateProviderRef<'a, Storage>
+{
+    fn proof(
+        &self,
+        _input: TrieInput,
+        _address: Address,
+        _slots: &[B256],
+    ) -> ProviderResult<AccountProof> {
+        unreachable!(
+            "OverlayedBaseProofsStateProviderRef is sync-forward only and does not support StateProofProvider"
+        )
+    }
+
+    fn multiproof(
+        &self,
+        _input: TrieInput,
+        _targets: MultiProofTargets,
+    ) -> ProviderResult<MultiProof> {
+        unreachable!(
+            "OverlayedBaseProofsStateProviderRef is sync-forward only and does not support StateProofProvider"
+        )
+    }
+
+    fn witness(&self, _input: TrieInput, _target: HashedPostState) -> ProviderResult<Vec<Bytes>> {
+        unreachable!(
+            "OverlayedBaseProofsStateProviderRef is sync-forward only and does not support StateProofProvider"
+        )
+    }
+}
+
+impl<'a, Storage: BaseProofsStore> HashedPostStateProvider
+    for OverlayedBaseProofsStateProviderRef<'a, Storage>
+{
+    fn hashed_post_state(&self, bundle_state: &BundleState) -> HashedPostState {
+        HashedPostState::from_bundle_state::<KeccakKeyHasher>(bundle_state.state())
+    }
+}
+
+impl<'a, Storage: BaseProofsStore> AccountReader
+    for OverlayedBaseProofsStateProviderRef<'a, Storage>
+{
+    fn basic_account(&self, address: &Address) -> ProviderResult<Option<Account>> {
+        let hashed_key = keccak256(address.0);
+        if let Some(account) = self.overlay.read_state().accounts.get(&hashed_key) {
+            return Ok(*account);
+        }
+
+        Ok(self
+            .storage
+            .account_hashed_cursor(self.block_number)
+            .map_err(Into::<ProviderError>::into)?
+            .seek(hashed_key)
+            .map_err(Into::<ProviderError>::into)?
+            .and_then(|(key, account)| (key == hashed_key).then_some(account)))
+    }
+}
+
+impl<'a, Storage> StateProvider for OverlayedBaseProofsStateProviderRef<'a, Storage>
+where
+    Storage: BaseProofsStore + Clone,
+{
+    fn storage(&self, address: Address, storage_key: B256) -> ProviderResult<Option<StorageValue>> {
+        let hashed_key = keccak256(storage_key);
+        self.storage_by_hashed_key(address, hashed_key)
+    }
+
+    fn storage_by_hashed_key(
+        &self,
+        address: Address,
+        hashed_key: B256,
+    ) -> ProviderResult<Option<StorageValue>> {
+        let hashed_address = keccak256(address.0);
+        if let Some(storage) = self.overlay.read_state().storages.get(&hashed_address) {
+            if let Some(value) = storage.storage.get(&hashed_key) {
+                return Ok(Some(*value));
+            }
+            if storage.wiped {
+                return Ok(Some(StorageValue::ZERO));
+            }
+        }
+
+        Ok(self
+            .storage
+            .storage_hashed_cursor(hashed_address, self.block_number)
+            .map_err(Into::<ProviderError>::into)?
+            .seek(hashed_key)
+            .map_err(Into::<ProviderError>::into)?
+            .and_then(|(key, storage)| (key == hashed_key).then_some(storage)))
+    }
+}
+
+impl<'a, Storage: BaseProofsStore> BytecodeReader
+    for OverlayedBaseProofsStateProviderRef<'a, Storage>
+{
+    fn bytecode_by_hash(&self, code_hash: &B256) -> ProviderResult<Option<Bytecode>> {
+        self.latest.bytecode_by_hash(code_hash)
+    }
+}
+
 #[cfg(all(test, not(feature = "metrics")))]
 mod tests {
+    use alloy_eips::eip1898::BlockWithParent;
+    use alloy_primitives::U256;
     use reth_provider::noop::NoopProvider;
 
     use super::*;
@@ -243,6 +533,47 @@ mod tests {
         assert_eq!(
             format!("{:?}", provider),
             "BaseProofsStateProviderRef { storage: InMemoryProofsStorage { inner: RwLock { data: InMemoryStorageInner { account_branches: {}, storage_branches: {}, hashed_accounts: {}, hashed_storages: {}, trie_updates: {}, post_states: {}, earliest_block: None, anchor_block: None } } }, block_number: 42 }"
+        );
+    }
+
+    #[test]
+    fn test_overlayed_provider_returns_destroyed_account_from_overlay() {
+        let latest: Box<dyn StateProvider + Send> = Box::<NoopProvider>::default();
+        let storage: crate::BaseProofsStorage<InMemoryProofsStorage> =
+            InMemoryProofsStorage::new().into();
+        let address = Address::repeat_byte(0x11);
+        let mut state = HashedPostState::default();
+        state.accounts.insert(keccak256(address.0), None);
+        let mut overlay = ProofsBatchOverlay::new();
+        overlay.append_executed(
+            BlockWithParent::new(B256::ZERO, alloy_eips::NumHash::new(1, B256::repeat_byte(1))),
+            state,
+            TrieUpdates::default(),
+        );
+        let provider = OverlayedBaseProofsStateProviderRef::new(latest, &storage, 0, &overlay);
+
+        assert_eq!(provider.basic_account(&address).unwrap(), None);
+    }
+
+    #[test]
+    fn test_overlayed_provider_returns_zero_for_unwritten_slot_after_wipe() {
+        let latest: Box<dyn StateProvider + Send> = Box::<NoopProvider>::default();
+        let storage: crate::BaseProofsStorage<InMemoryProofsStorage> =
+            InMemoryProofsStorage::new().into();
+        let address = Address::repeat_byte(0x22);
+        let mut state = HashedPostState::default();
+        state.storages.insert(keccak256(address.0), HashedStorage::new(true));
+        let mut overlay = ProofsBatchOverlay::new();
+        overlay.append_executed(
+            BlockWithParent::new(B256::ZERO, alloy_eips::NumHash::new(1, B256::repeat_byte(1))),
+            state,
+            TrieUpdates::default(),
+        );
+        let provider = OverlayedBaseProofsStateProviderRef::new(latest, &storage, 0, &overlay);
+
+        assert_eq!(
+            provider.storage_by_hashed_key(address, B256::repeat_byte(0x33)).unwrap(),
+            Some(U256::ZERO)
         );
     }
 }

--- a/crates/execution/trie/src/provider.rs
+++ b/crates/execution/trie/src/provider.rs
@@ -279,15 +279,16 @@ impl<'a, Storage: BaseProofsStore + Clone> StateRootProvider
         let overlay_nodes_sorted = self.overlay.parent_trie().clone_into_sorted();
         let overlay_state_sorted = self.overlay.read_state().clone_into_sorted();
         let state_sorted = state.into_sorted();
+        let tx = self.storage.ro_tx().map_err(Into::<ProviderError>::into)?;
 
         Ok(StateRoot::new(
             InMemoryTrieCursorFactory::new(
-                BaseProofsTrieCursorFactory::new(self.storage, self.block_number),
+                BaseProofsTrieCursorFactory::new(self.storage, &tx, self.block_number),
                 &overlay_nodes_sorted,
             ),
             HashedPostStateCursorFactory::new(
                 HashedPostStateCursorFactory::new(
-                    BaseProofsHashedAccountCursorFactory::new(self.storage, self.block_number),
+                    BaseProofsHashedAccountCursorFactory::new(self.storage, &tx, self.block_number),
                     &overlay_state_sorted,
                 ),
                 &state_sorted,
@@ -302,18 +303,19 @@ impl<'a, Storage: BaseProofsStore + Clone> StateRootProvider
         let overlay_state_sorted = self.overlay.read_state().clone_into_sorted();
         let nodes_sorted = input.nodes.into_sorted();
         let state_sorted = input.state.into_sorted();
+        let tx = self.storage.ro_tx().map_err(Into::<ProviderError>::into)?;
 
         Ok(StateRoot::new(
             InMemoryTrieCursorFactory::new(
                 InMemoryTrieCursorFactory::new(
-                    BaseProofsTrieCursorFactory::new(self.storage, self.block_number),
+                    BaseProofsTrieCursorFactory::new(self.storage, &tx, self.block_number),
                     &overlay_nodes_sorted,
                 ),
                 &nodes_sorted,
             ),
             HashedPostStateCursorFactory::new(
                 HashedPostStateCursorFactory::new(
-                    BaseProofsHashedAccountCursorFactory::new(self.storage, self.block_number),
+                    BaseProofsHashedAccountCursorFactory::new(self.storage, &tx, self.block_number),
                     &overlay_state_sorted,
                 ),
                 &state_sorted,
@@ -331,15 +333,16 @@ impl<'a, Storage: BaseProofsStore + Clone> StateRootProvider
         let overlay_nodes_sorted = self.overlay.parent_trie().clone_into_sorted();
         let overlay_state_sorted = self.overlay.read_state().clone_into_sorted();
         let state_sorted = state.into_sorted();
+        let tx = self.storage.ro_tx().map_err(Into::<ProviderError>::into)?;
 
         Ok(StateRoot::new(
             InMemoryTrieCursorFactory::new(
-                BaseProofsTrieCursorFactory::new(self.storage, self.block_number),
+                BaseProofsTrieCursorFactory::new(self.storage, &tx, self.block_number),
                 &overlay_nodes_sorted,
             ),
             HashedPostStateCursorFactory::new(
                 HashedPostStateCursorFactory::new(
-                    BaseProofsHashedAccountCursorFactory::new(self.storage, self.block_number),
+                    BaseProofsHashedAccountCursorFactory::new(self.storage, &tx, self.block_number),
                     &overlay_state_sorted,
                 ),
                 &state_sorted,
@@ -357,18 +360,19 @@ impl<'a, Storage: BaseProofsStore + Clone> StateRootProvider
         let overlay_state_sorted = self.overlay.read_state().clone_into_sorted();
         let nodes_sorted = input.nodes.into_sorted();
         let state_sorted = input.state.into_sorted();
+        let tx = self.storage.ro_tx().map_err(Into::<ProviderError>::into)?;
 
         Ok(StateRoot::new(
             InMemoryTrieCursorFactory::new(
                 InMemoryTrieCursorFactory::new(
-                    BaseProofsTrieCursorFactory::new(self.storage, self.block_number),
+                    BaseProofsTrieCursorFactory::new(self.storage, &tx, self.block_number),
                     &overlay_nodes_sorted,
                 ),
                 &nodes_sorted,
             ),
             HashedPostStateCursorFactory::new(
                 HashedPostStateCursorFactory::new(
-                    BaseProofsHashedAccountCursorFactory::new(self.storage, self.block_number),
+                    BaseProofsHashedAccountCursorFactory::new(self.storage, &tx, self.block_number),
                     &overlay_state_sorted,
                 ),
                 &state_sorted,

--- a/crates/execution/trie/tests/lib.rs
+++ b/crates/execution/trie/tests/lib.rs
@@ -2176,6 +2176,50 @@ fn test_store_trie_updates_batch_keeps_block_diffs_local<
     Ok(())
 }
 
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[serial]
+fn test_store_trie_updates_batch_wipe_sees_prior_batch_writes<
+    S: BaseProofsStore + BaseProofsInitialStateStore,
+>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let earliest_hash = B256::repeat_byte(90);
+    storage.set_earliest_block_number(90, earliest_hash)?;
+
+    let hashed_address = B256::repeat_byte(0x90);
+    let hashed_slot = B256::repeat_byte(0x91);
+    let mut write_state = HashedPostState::default();
+    write_state
+        .storages
+        .insert(hashed_address, HashedStorage::from_iter(false, [(hashed_slot, U256::from(91))]));
+    let mut wipe_state = HashedPostState::default();
+    wipe_state.storages.insert(hashed_address, HashedStorage::new(true));
+
+    let block_91 = batch_block(91, earliest_hash);
+    let block_92 = batch_block(92, block_91.block.hash);
+    storage.store_trie_updates_batch(vec![
+        (
+            block_91,
+            BlockStateDiff {
+                sorted_trie_updates: TrieUpdatesSorted::default(),
+                sorted_post_state: write_state.into_sorted(),
+            },
+        ),
+        (
+            block_92,
+            BlockStateDiff {
+                sorted_trie_updates: TrieUpdatesSorted::default(),
+                sorted_post_state: wipe_state.into_sorted(),
+            },
+        ),
+    ])?;
+
+    let mut cursor = storage.storage_hashed_cursor(hashed_address, 92)?;
+    assert!(cursor.seek(hashed_slot)?.is_none());
+
+    Ok(())
+}
+
 #[test_case(InMemoryProofsStorage::new(); "InMemory")]
 #[test_case(create_mdbx_proofs_storage(); "Mdbx")]
 #[serial]

--- a/crates/execution/trie/tests/lib.rs
+++ b/crates/execution/trie/tests/lib.rs
@@ -2131,6 +2131,54 @@ fn test_store_trie_updates_batch_persists_each_block<
 #[test_case(InMemoryProofsStorage::new(); "InMemory")]
 #[test_case(create_mdbx_proofs_storage(); "Mdbx")]
 #[serial]
+fn test_store_trie_updates_batch_single_item_matches_single_block_flow<
+    S: BaseProofsStore + BaseProofsInitialStateStore,
+>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let earliest_hash = B256::repeat_byte(60);
+    storage.set_earliest_block_number(60, earliest_hash)?;
+
+    let block_61 = batch_block(61, earliest_hash);
+    storage.store_trie_updates_batch(vec![(block_61, diff_with_account(0x61, 61))])?;
+
+    let (latest_block, _) = storage.get_latest_block_number()?.expect("latest block tracked");
+    assert_eq!(latest_block, 61);
+    let mut cursor = storage.account_hashed_cursor(61)?;
+    let entry = cursor.seek(B256::repeat_byte(0x61))?.expect("account present");
+    assert_eq!(entry.1.nonce, 61);
+
+    Ok(())
+}
+
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[serial]
+fn test_store_trie_updates_batch_keeps_block_diffs_local<
+    S: BaseProofsStore + BaseProofsInitialStateStore,
+>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let earliest_hash = B256::repeat_byte(80);
+    storage.set_earliest_block_number(80, earliest_hash)?;
+
+    let block_81 = batch_block(81, earliest_hash);
+    let block_82 = batch_block(82, block_81.block.hash);
+    storage.store_trie_updates_batch(vec![
+        (block_81, diff_with_account(0x81, 81)),
+        (block_82, diff_with_account(0x82, 82)),
+    ])?;
+
+    let block_82_diff = storage.fetch_trie_updates(82)?;
+    assert_eq!(block_82_diff.sorted_post_state.accounts.len(), 1);
+    assert_eq!(block_82_diff.sorted_post_state.accounts[0].0, B256::repeat_byte(0x82));
+
+    Ok(())
+}
+
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[serial]
 fn test_store_trie_updates_batch_empty_is_noop<S: BaseProofsStore + BaseProofsInitialStateStore>(
     storage: S,
 ) -> Result<(), BaseProofsStorageError> {

--- a/crates/execution/trie/tests/lib.rs
+++ b/crates/execution/trie/tests/lib.rs
@@ -6,7 +6,7 @@ use alloy_eips::{BlockNumHash, NumHash, eip1898::BlockWithParent};
 use alloy_primitives::{B256, U256};
 use base_execution_trie::{
     BaseProofsInitialStateStore, BaseProofsStorageError, BaseProofsStore, BlockStateDiff,
-    InMemoryProofsStorage, db::MdbxProofsStorage,
+    InMemoryProofsStorage, WriteCounts, db::MdbxProofsStorage,
 };
 use reth_primitives_traits::Account;
 use reth_trie::{
@@ -2049,6 +2049,193 @@ fn test_updates_take_precedence_over_removals<S: BaseProofsStore + BaseProofsIni
         branch_75.state_mask, initial_branch.state_mask,
         "Block 75 should see the initial branch, not the updated one"
     );
+
+    Ok(())
+}
+
+const fn batch_block(num: u64, parent: B256) -> BlockWithParent {
+    BlockWithParent::new(parent, NumHash::new(num, B256::repeat_byte(num as u8)))
+}
+
+fn diff_with_account(addr_byte: u8, nonce: u64) -> BlockStateDiff {
+    let mut post_state = HashedPostState::default();
+    post_state
+        .accounts
+        .insert(B256::repeat_byte(addr_byte), Some(create_test_account_with_values(nonce, 0, 0)));
+    BlockStateDiff {
+        sorted_trie_updates: TrieUpdatesSorted::default(),
+        sorted_post_state: post_state.into_sorted(),
+    }
+}
+
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[serial]
+fn test_store_trie_updates_batch_advances_proof_window<
+    S: BaseProofsStore + BaseProofsInitialStateStore,
+>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let earliest_hash = B256::repeat_byte(100);
+    storage.set_earliest_block_number(100, earliest_hash)?;
+
+    let block_101 = batch_block(101, earliest_hash);
+    let block_102 = batch_block(102, block_101.block.hash);
+    let block_103 = batch_block(103, block_102.block.hash);
+
+    let counts = storage.store_trie_updates_batch(vec![
+        (block_101, BlockStateDiff::default()),
+        (block_102, BlockStateDiff::default()),
+        (block_103, BlockStateDiff::default()),
+    ])?;
+
+    let (latest_num, _latest_hash) =
+        storage.get_latest_block_number()?.expect("latest block tracked");
+    assert_eq!(latest_num, 103);
+    assert_eq!(counts, WriteCounts::default());
+
+    Ok(())
+}
+
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[serial]
+fn test_store_trie_updates_batch_persists_each_block<
+    S: BaseProofsStore + BaseProofsInitialStateStore,
+>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let earliest_hash = B256::repeat_byte(50);
+    storage.set_earliest_block_number(50, earliest_hash)?;
+
+    let block_51 = batch_block(51, earliest_hash);
+    let block_52 = batch_block(52, block_51.block.hash);
+    let block_53 = batch_block(53, block_52.block.hash);
+
+    storage.store_trie_updates_batch(vec![
+        (block_51, diff_with_account(0xA1, 51)),
+        (block_52, diff_with_account(0xA2, 52)),
+        (block_53, diff_with_account(0xA3, 53)),
+    ])?;
+
+    for (n, addr_byte, nonce) in [(51, 0xA1, 51), (52, 0xA2, 52), (53, 0xA3, 53)] {
+        let mut cursor = storage.account_hashed_cursor(n)?;
+        let entry = cursor.seek(B256::repeat_byte(addr_byte))?.expect("account present");
+        assert_eq!(entry.0, B256::repeat_byte(addr_byte));
+        assert_eq!(entry.1.nonce, nonce, "block {n} account should have nonce {nonce}");
+    }
+
+    Ok(())
+}
+
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[serial]
+fn test_store_trie_updates_batch_empty_is_noop<
+    S: BaseProofsStore + BaseProofsInitialStateStore,
+>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    storage.set_earliest_block_number(0, B256::ZERO)?;
+
+    let counts = storage.store_trie_updates_batch(Vec::new())?;
+    assert_eq!(counts, WriteCounts::default());
+    assert_eq!(storage.get_latest_block_number()?, Some((0, B256::ZERO)));
+
+    Ok(())
+}
+
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[serial]
+fn test_store_trie_updates_batch_rejects_bad_first_parent_mdbx<
+    S: BaseProofsStore + BaseProofsInitialStateStore,
+>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let earliest_hash = B256::repeat_byte(70);
+    storage.set_earliest_block_number(70, earliest_hash)?;
+
+    let bad_parent = B256::repeat_byte(0xEE);
+    let block_71 = batch_block(71, bad_parent);
+
+    let res = storage
+        .store_trie_updates_batch(vec![(block_71, BlockStateDiff::default())]);
+    assert!(matches!(res, Err(BaseProofsStorageError::OutOfOrder { .. })));
+
+    assert_eq!(storage.get_latest_block_number()?, Some((70, earliest_hash)));
+
+    Ok(())
+}
+
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[serial]
+fn test_store_trie_updates_batch_atomic_on_chain_break_mdbx<
+    S: BaseProofsStore + BaseProofsInitialStateStore,
+>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let earliest_hash = B256::repeat_byte(200);
+    storage.set_earliest_block_number(200, earliest_hash)?;
+
+    let block_201 = batch_block(201, earliest_hash);
+    let block_202_bad_parent = BlockWithParent::new(
+        B256::repeat_byte(0xEE),
+        NumHash::new(202, B256::repeat_byte(202)),
+    );
+    let block_203 = batch_block(203, block_202_bad_parent.block.hash);
+
+    let res = storage.store_trie_updates_batch(vec![
+        (block_201, diff_with_account(0xB1, 1)),
+        (block_202_bad_parent, diff_with_account(0xB2, 2)),
+        (block_203, diff_with_account(0xB3, 3)),
+    ]);
+    assert!(matches!(res, Err(BaseProofsStorageError::OutOfOrder { .. })));
+
+    assert_eq!(storage.get_latest_block_number()?, Some((200, earliest_hash)));
+
+    let mut cursor = storage.account_hashed_cursor(300)?;
+    assert!(
+        cursor.seek(B256::repeat_byte(0xB1))?.is_none(),
+        "block 201 account must NOT be visible after rollback"
+    );
+
+    Ok(())
+}
+
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[serial]
+fn test_store_trie_updates_batch_handles_cross_block_unsorted_keys<
+    S: BaseProofsStore + BaseProofsInitialStateStore,
+>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let earliest_hash = B256::repeat_byte(10);
+    storage.set_earliest_block_number(10, earliest_hash)?;
+
+    let mut diff_high = BlockStateDiff::default();
+    let mut post_high = HashedPostState::default();
+    post_high
+        .accounts
+        .insert(B256::repeat_byte(0xF0), Some(create_test_account_with_values(11, 0, 0)));
+    diff_high.sorted_post_state = post_high.into_sorted();
+
+    let mut diff_low = BlockStateDiff::default();
+    let mut post_low = HashedPostState::default();
+    post_low
+        .accounts
+        .insert(B256::repeat_byte(0x10), Some(create_test_account_with_values(12, 0, 0)));
+    diff_low.sorted_post_state = post_low.into_sorted();
+
+    let block_11 = batch_block(11, earliest_hash);
+    let block_12 = batch_block(12, block_11.block.hash);
+
+    storage.store_trie_updates_batch(vec![(block_11, diff_high), (block_12, diff_low)])?;
+
+    let mut cursor = storage.account_hashed_cursor(12)?;
+    assert!(cursor.seek(B256::repeat_byte(0x10))?.is_some());
+    let mut cursor = storage.account_hashed_cursor(12)?;
+    assert!(cursor.seek(B256::repeat_byte(0xF0))?.is_some());
 
     Ok(())
 }

--- a/crates/execution/trie/tests/lib.rs
+++ b/crates/execution/trie/tests/lib.rs
@@ -2131,9 +2131,7 @@ fn test_store_trie_updates_batch_persists_each_block<
 #[test_case(InMemoryProofsStorage::new(); "InMemory")]
 #[test_case(create_mdbx_proofs_storage(); "Mdbx")]
 #[serial]
-fn test_store_trie_updates_batch_empty_is_noop<
-    S: BaseProofsStore + BaseProofsInitialStateStore,
->(
+fn test_store_trie_updates_batch_empty_is_noop<S: BaseProofsStore + BaseProofsInitialStateStore>(
     storage: S,
 ) -> Result<(), BaseProofsStorageError> {
     storage.set_earliest_block_number(0, B256::ZERO)?;
@@ -2158,8 +2156,7 @@ fn test_store_trie_updates_batch_rejects_bad_first_parent_mdbx<
     let bad_parent = B256::repeat_byte(0xEE);
     let block_71 = batch_block(71, bad_parent);
 
-    let res = storage
-        .store_trie_updates_batch(vec![(block_71, BlockStateDiff::default())]);
+    let res = storage.store_trie_updates_batch(vec![(block_71, BlockStateDiff::default())]);
     assert!(matches!(res, Err(BaseProofsStorageError::OutOfOrder { .. })));
 
     assert_eq!(storage.get_latest_block_number()?, Some((70, earliest_hash)));
@@ -2178,10 +2175,8 @@ fn test_store_trie_updates_batch_atomic_on_chain_break_mdbx<
     storage.set_earliest_block_number(200, earliest_hash)?;
 
     let block_201 = batch_block(201, earliest_hash);
-    let block_202_bad_parent = BlockWithParent::new(
-        B256::repeat_byte(0xEE),
-        NumHash::new(202, B256::repeat_byte(202)),
-    );
+    let block_202_bad_parent =
+        BlockWithParent::new(B256::repeat_byte(0xEE), NumHash::new(202, B256::repeat_byte(202)));
     let block_203 = batch_block(203, block_202_bad_parent.block.hash);
 
     let res = storage.store_trie_updates_batch(vec![

--- a/crates/execution/trie/tests/lib.rs
+++ b/crates/execution/trie/tests/lib.rs
@@ -2176,6 +2176,7 @@ fn test_store_trie_updates_batch_keeps_block_diffs_local<
     Ok(())
 }
 
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
 #[test_case(create_mdbx_proofs_storage(); "Mdbx")]
 #[serial]
 fn test_store_trie_updates_batch_wipe_sees_prior_batch_writes<


### PR DESCRIPTION
Cold catch-up currently commits cache misses one block at a time. This adds a batch-local proofs overlay so slow-path execution can read prior in-batch diffs and flush the whole sync batch in one proofs-storage transaction.