### PR TITLE
fix(proposer): discard proofs with invalid signers

### DIFF
--- a/crates/proof/contracts/src/aggregate_verifier.rs
+++ b/crates/proof/contracts/src/aggregate_verifier.rs
@@ -30,6 +30,9 @@ sol! {
         /// unrespected, blacklisted, retired, or resolved as `CHALLENGER_WINS`.
         error InvalidParentGame();
 
+        /// Error bubbled from `TEEVerifier` when a proof signer is not registered.
+        error InvalidSigner(address signer);
+
         /// Returns the root claim (output root) of this game.
         function rootClaim() external pure returns (bytes32);
 
@@ -304,6 +307,11 @@ pub const fn l1_origin_too_old_selector() -> [u8; 4] {
 /// The 4-byte selector for `InvalidParentGame()`.
 pub const fn invalid_parent_game_selector() -> [u8; 4] {
     IAggregateVerifier::InvalidParentGame::SELECTOR
+}
+
+/// The 4-byte selector for `TEEVerifier.InvalidSigner(address)`.
+pub const fn invalid_signer_selector() -> [u8; 4] {
+    IAggregateVerifier::InvalidSigner::SELECTOR
 }
 
 /// Concrete implementation backed by Alloy's sol-generated contract bindings.
@@ -861,6 +869,15 @@ mod tests {
         assert_eq!(selector.len(), 4);
         assert_ne!(selector, [0u8; 4]);
         assert_ne!(selector, l1_origin_too_old_selector());
+    }
+
+    #[test]
+    fn test_invalid_signer_selector() {
+        let selector = invalid_signer_selector();
+        assert_eq!(selector.len(), 4);
+        assert_ne!(selector, [0u8; 4]);
+        assert_ne!(selector, l1_origin_too_old_selector());
+        assert_ne!(selector, invalid_parent_game_selector());
     }
 
     #[test]

--- a/crates/proof/contracts/src/lib.rs
+++ b/crates/proof/contracts/src/lib.rs
@@ -10,7 +10,8 @@ mod aggregate_verifier;
 pub use aggregate_verifier::{
     AggregateVerifierClient, AggregateVerifierContractClient, GameInfo, GameStatus,
     encode_challenge_calldata, encode_claim_credit_calldata, encode_nullify_calldata,
-    encode_resolve_calldata, invalid_parent_game_selector, l1_origin_too_old_selector,
+    encode_resolve_calldata, invalid_parent_game_selector, invalid_signer_selector,
+    l1_origin_too_old_selector,
 };
 
 mod delayed_weth;

--- a/crates/proof/proposer/src/error.rs
+++ b/crates/proof/proposer/src/error.rs
@@ -34,6 +34,10 @@ pub enum ProposerError {
     #[error("invalid parent game")]
     InvalidParentGame,
 
+    /// The proof signer is not valid on-chain (`TEEVerifier.InvalidSigner(address)`).
+    #[error("invalid signer")]
+    InvalidSigner,
+
     /// Configuration error.
     #[error("config error: {0}")]
     Config(String),
@@ -68,6 +72,8 @@ impl ProposerError {
     pub const ERROR_TYPE_L1_ORIGIN_TOO_OLD: &str = "l1_origin_too_old";
     /// Metric label for invalid parent game rejections.
     pub const ERROR_TYPE_INVALID_PARENT_GAME: &str = "invalid_parent_game";
+    /// Metric label for invalid proof signer rejections.
+    pub const ERROR_TYPE_INVALID_SIGNER: &str = "invalid_signer";
 
     /// Returns true if this error indicates the game already exists.
     pub const fn is_game_already_exists(&self) -> bool {
@@ -84,6 +90,11 @@ impl ProposerError {
         matches!(self, Self::InvalidParentGame)
     }
 
+    /// Returns true if this error indicates the proof signer is not valid on-chain.
+    pub const fn is_invalid_signer(&self) -> bool {
+        matches!(self, Self::InvalidSigner)
+    }
+
     /// Returns the metrics label for this error variant.
     pub const fn metric_label(&self) -> &'static str {
         match self {
@@ -94,6 +105,7 @@ impl ProposerError {
             Self::GameAlreadyExists => Self::ERROR_TYPE_GAME_ALREADY_EXISTS,
             Self::L1OriginTooOld => Self::ERROR_TYPE_L1_ORIGIN_TOO_OLD,
             Self::InvalidParentGame => Self::ERROR_TYPE_INVALID_PARENT_GAME,
+            Self::InvalidSigner => Self::ERROR_TYPE_INVALID_SIGNER,
             Self::Config(_) => Self::ERROR_TYPE_CONFIG,
             Self::Internal(_) => Self::ERROR_TYPE_INTERNAL,
             Self::TxManager(_) => Self::ERROR_TYPE_TX_MANAGER,

--- a/crates/proof/proposer/src/output_proposer.rs
+++ b/crates/proof/proposer/src/output_proposer.rs
@@ -30,7 +30,7 @@ fn classify_tx_manager_error(err: TxManagerError) -> ProposerError {
     let game_exists_selector = game_already_exists_selector();
     let l1_origin_selector = l1_origin_too_old_selector();
     let invalid_parent_selector = invalid_parent_game_selector();
-    let invalid_signer_selector = invalid_signer_selector();
+    let invalid_signer = invalid_signer_selector();
 
     if let TxManagerError::ExecutionReverted { ref reason, ref data } = err {
         if reason.as_deref().is_some_and(|r| r.contains(GAME_ALREADY_EXISTS)) {
@@ -54,7 +54,7 @@ fn classify_tx_manager_error(err: TxManagerError) -> ProposerError {
         if reason.as_deref().is_some_and(|r| r.contains(INVALID_SIGNER)) {
             return ProposerError::InvalidSigner;
         }
-        if data.as_ref().is_some_and(|d| d.starts_with(&invalid_signer_selector)) {
+        if data.as_ref().is_some_and(|d| d.starts_with(&invalid_signer)) {
             return ProposerError::InvalidSigner;
         }
         return ProposerError::TxManager(err);
@@ -76,7 +76,7 @@ fn classify_tx_manager_error(err: TxManagerError) -> ProposerError {
     {
         return ProposerError::InvalidParentGame;
     }
-    if msg.contains(&alloy_primitives::hex::encode(invalid_signer_selector))
+    if msg.contains(&alloy_primitives::hex::encode(invalid_signer))
         || msg.contains(INVALID_SIGNER)
     {
         return ProposerError::InvalidSigner;

--- a/crates/proof/proposer/src/output_proposer.rs
+++ b/crates/proof/proposer/src/output_proposer.rs
@@ -76,8 +76,7 @@ fn classify_tx_manager_error(err: TxManagerError) -> ProposerError {
     {
         return ProposerError::InvalidParentGame;
     }
-    if msg.contains(&alloy_primitives::hex::encode(invalid_signer))
-        || msg.contains(INVALID_SIGNER)
+    if msg.contains(&alloy_primitives::hex::encode(invalid_signer)) || msg.contains(INVALID_SIGNER)
     {
         return ProposerError::InvalidSigner;
     }

--- a/crates/proof/proposer/src/output_proposer.rs
+++ b/crates/proof/proposer/src/output_proposer.rs
@@ -8,7 +8,7 @@ use alloy_primitives::{Address, B256, U256};
 use async_trait::async_trait;
 use base_proof_contracts::{
     encode_create_calldata, encode_extra_data, game_already_exists_selector,
-    invalid_parent_game_selector, l1_origin_too_old_selector,
+    invalid_parent_game_selector, invalid_signer_selector, l1_origin_too_old_selector,
 };
 use base_proof_primitives::Proposal;
 use base_tx_manager::{TxCandidate, TxManager, TxManagerError};
@@ -19,6 +19,7 @@ use crate::error::ProposerError;
 const GAME_ALREADY_EXISTS: &str = "GameAlreadyExists";
 const L1_ORIGIN_TOO_OLD: &str = "L1OriginTooOld";
 const INVALID_PARENT_GAME: &str = "InvalidParentGame";
+const INVALID_SIGNER: &str = "InvalidSigner";
 
 /// Classifies a [`TxManagerError`] into a [`ProposerError`].
 ///
@@ -29,6 +30,7 @@ fn classify_tx_manager_error(err: TxManagerError) -> ProposerError {
     let game_exists_selector = game_already_exists_selector();
     let l1_origin_selector = l1_origin_too_old_selector();
     let invalid_parent_selector = invalid_parent_game_selector();
+    let invalid_signer_selector = invalid_signer_selector();
 
     if let TxManagerError::ExecutionReverted { ref reason, ref data } = err {
         if reason.as_deref().is_some_and(|r| r.contains(GAME_ALREADY_EXISTS)) {
@@ -49,6 +51,12 @@ fn classify_tx_manager_error(err: TxManagerError) -> ProposerError {
         if data.as_ref().is_some_and(|d| d.starts_with(&invalid_parent_selector)) {
             return ProposerError::InvalidParentGame;
         }
+        if reason.as_deref().is_some_and(|r| r.contains(INVALID_SIGNER)) {
+            return ProposerError::InvalidSigner;
+        }
+        if data.as_ref().is_some_and(|d| d.starts_with(&invalid_signer_selector)) {
+            return ProposerError::InvalidSigner;
+        }
         return ProposerError::TxManager(err);
     }
 
@@ -67,6 +75,11 @@ fn classify_tx_manager_error(err: TxManagerError) -> ProposerError {
         || msg.contains(INVALID_PARENT_GAME)
     {
         return ProposerError::InvalidParentGame;
+    }
+    if msg.contains(&alloy_primitives::hex::encode(invalid_signer_selector))
+        || msg.contains(INVALID_SIGNER)
+    {
+        return ProposerError::InvalidSigner;
     }
     ProposerError::TxManager(err)
 }
@@ -368,6 +381,7 @@ mod tests {
         GameAlreadyExists,
         L1OriginTooOld,
         InvalidParentGame,
+        InvalidSigner,
         TxManager,
     }
 
@@ -454,6 +468,36 @@ mod tests {
         ExpectedClassification::InvalidParentGame,
         "InvalidParentGame raw data contains selector"
     )]
+    #[case::rpc_with_invalid_signer_selector_hex(
+        TxManagerError::Rpc(format!("execution reverted: 0x{}", alloy_primitives::hex::encode(base_proof_contracts::invalid_signer_selector()))),
+        ExpectedClassification::InvalidSigner,
+        "InvalidSigner selector hex in Rpc message"
+    )]
+    #[case::rpc_with_invalid_signer_name(
+        TxManagerError::Rpc(format!("{INVALID_SIGNER}(0x0000000000000000000000000000000000000000)")),
+        ExpectedClassification::InvalidSigner,
+        "InvalidSigner name in Rpc message"
+    )]
+    #[case::reverted_with_invalid_signer_reason(
+        TxManagerError::ExecutionReverted {
+            reason: Some(format!("{INVALID_SIGNER}(0x0000000000000000000000000000000000000000)")),
+            data: None,
+        },
+        ExpectedClassification::InvalidSigner,
+        "InvalidSigner reason string contains name"
+    )]
+    #[case::reverted_with_invalid_signer_selector_data(
+        {
+            let mut data = base_proof_contracts::invalid_signer_selector().to_vec();
+            data.extend_from_slice(Address::ZERO.as_slice());
+            TxManagerError::ExecutionReverted {
+                reason: None,
+                data: Some(Bytes::from(data)),
+            }
+        },
+        ExpectedClassification::InvalidSigner,
+        "InvalidSigner raw data contains selector"
+    )]
     #[case::reverted_other_error(
         TxManagerError::ExecutionReverted {
             reason: Some("SomeOtherError()".to_string()),
@@ -486,6 +530,10 @@ mod tests {
                 matches!(result, ProposerError::InvalidParentGame),
                 "{scenario}: expected InvalidParentGame, got {result:?}"
             ),
+            ExpectedClassification::InvalidSigner => assert!(
+                matches!(result, ProposerError::InvalidSigner),
+                "{scenario}: expected InvalidSigner, got {result:?}"
+            ),
             ExpectedClassification::TxManager => assert!(
                 matches!(result, ProposerError::TxManager(_)),
                 "{scenario}: expected TxManager, got {result:?}"
@@ -514,5 +562,14 @@ mod tests {
     #[case::other_error(ProposerError::Contract("other".into()), false)]
     fn test_is_invalid_parent_game(#[case] err: ProposerError, #[case] expected: bool) {
         assert_eq!(err.is_invalid_parent_game(), expected);
+    }
+
+    #[rstest]
+    #[case::invalid_signer(ProposerError::InvalidSigner, true)]
+    #[case::invalid_parent_game(ProposerError::InvalidParentGame, false)]
+    #[case::l1_origin_too_old(ProposerError::L1OriginTooOld, false)]
+    #[case::other_error(ProposerError::Contract("other".into()), false)]
+    fn test_is_invalid_signer(#[case] err: ProposerError, #[case] expected: bool) {
+        assert_eq!(err.is_invalid_signer(), expected);
     }
 }

--- a/crates/proof/proposer/src/pipeline.rs
+++ b/crates/proof/proposer/src/pipeline.rs
@@ -1378,6 +1378,15 @@ where
                         "Proof L1 origin is too old, discarding proof to re-prove"
                     );
                     Err(SubmitAction::Discard(e))
+                } else if e.is_invalid_signer() {
+                    propose_timer.disarm();
+                    warn!(
+                        error = %e,
+                        target_block,
+                        "Proof signer is invalid on-chain, discarding proof to re-prove"
+                    );
+                    Metrics::tee_signer_invalid_total().increment(1);
+                    Err(SubmitAction::Discard(e))
                 } else {
                     propose_timer.disarm();
                     Err(SubmitAction::Failed(e))
@@ -2668,6 +2677,21 @@ mod tests {
         }
     }
 
+    #[derive(Debug)]
+    struct InvalidSignerOutputProposer;
+
+    #[async_trait]
+    impl OutputProposer for InvalidSignerOutputProposer {
+        async fn propose_output(
+            &self,
+            _proposal: &Proposal,
+            _parent_address: Address,
+            _intermediate_roots: &[B256],
+        ) -> Result<(), ProposerError> {
+            Err(ProposerError::InvalidSigner)
+        }
+    }
+
     #[tokio::test(flavor = "current_thread", start_paused = true)]
     async fn test_validate_and_submit_intermediate_roots_match() {
         // MockRollupClient returns B256::repeat_byte(n) for blocks without
@@ -2721,6 +2745,27 @@ mod tests {
         assert!(
             matches!(result, Err(SubmitAction::Discard(ProposerError::L1OriginTooOld))),
             "stale L1 origin should discard the proof, got {result:?}"
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn test_validate_and_submit_discards_invalid_signer() {
+        let pipeline = recovery_pipeline_full_with_output_proposer(
+            MockDisputeGameFactory::with_games(vec![]),
+            HashMap::new(),
+            TEST_ANCHOR_BLOCK,
+            SUBMIT_BLOCK_INTERVAL,
+            SUBMIT_INTERMEDIATE_INTERVAL,
+            Arc::new(InvalidSignerOutputProposer),
+        );
+        let proof_result = submit_proof_result(SUBMIT_BLOCK_INTERVAL);
+
+        let result =
+            pipeline.validate_and_submit(&proof_result, SUBMIT_BLOCK_INTERVAL, Address::ZERO).await;
+
+        assert!(
+            matches!(result, Err(SubmitAction::Discard(ProposerError::InvalidSigner))),
+            "invalid signer should discard the proof, got {result:?}"
         );
     }
 


### PR DESCRIPTION
## Summary
- Classify `TEEVerifier.InvalidSigner(address)` reverts from `DisputeGameFactory.createWithInitData` as a dedicated proposer error.
- Discard invalid-signer proofs instead of re-queueing submission retries, and increment the existing invalid signer metric.
- Add selector, classification, and pipeline discard tests.

## Tests
- `cargo test -p base-proof-contracts && cargo test -p base-proposer`
- `cargo clippy -p base-proof-contracts -p base-proposer --all-targets -- -D warnings`