### PR TITLE
fix(rpc): add concurrency limit to eth_getProof override (CHAIN-4462)

### DIFF
--- a/crates/execution/node/src/args.rs
+++ b/crates/execution/node/src/args.rs
@@ -2,9 +2,29 @@
 
 //! clap [Args](clap::Args) for Base rollup configuration
 
-use std::{path::PathBuf, time::Duration};
+use std::{num::NonZeroUsize, path::PathBuf, time::Duration};
 
 use clap::{ValueEnum, builder::ArgPredicate};
+use tokio::sync::Semaphore;
+
+/// Default maximum concurrent `eth_getProof` requests served by the Base proofs override.
+pub const DEFAULT_PROOFS_GET_PROOF_PERMITS: NonZeroUsize =
+    NonZeroUsize::new(32).expect("default getProof permits must be non-zero");
+
+/// Parser for the `eth_getProof` concurrency-limit CLI flag.
+#[derive(Debug)]
+pub struct GetProofPermitsParser;
+
+impl GetProofPermitsParser {
+    /// Parses a positive permit count and rejects values that exceed [`Semaphore::MAX_PERMITS`].
+    pub fn parse(value: &str) -> Result<NonZeroUsize, String> {
+        let permits = value.parse::<NonZeroUsize>().map_err(|err| err.to_string())?;
+        if permits.get() > Semaphore::MAX_PERMITS {
+            return Err(format!("value must be less than or equal to {}", Semaphore::MAX_PERMITS));
+        }
+        Ok(permits)
+    }
+}
 
 /// Transaction ordering strategy for the mempool.
 ///
@@ -134,6 +154,18 @@ pub struct RollupArgs {
     )]
     pub proofs_history_verification_interval: u64,
 
+    /// Maximum concurrent `eth_getProof` requests served by the Base proofs override.
+    /// Start at 32 and watch `base_rpc.eth_api_ext.get_proof_semaphore_wait_duration` before
+    /// raising; scale up only after the shared-MDBX-read-tx proof path is deployed and MDBX lock
+    /// contention is healthy.
+    #[arg(
+        long = "proofs.get-proof-permits",
+        value_name = "PROOFS_GET_PROOF_PERMITS",
+        default_value_t = DEFAULT_PROOFS_GET_PROOF_PERMITS,
+        value_parser = GetProofPermitsParser::parse
+    )]
+    pub proofs_get_proof_permits: NonZeroUsize,
+
     /// Enable the Base discv5 protocol identity.
     ///
     /// When enabled, the node advertises itself with the `basev0` protocol ID in discv5,
@@ -158,6 +190,7 @@ impl Default for RollupArgs {
             proofs_history_window: 1_296_000,
             proofs_history_prune_interval: Duration::from_secs(15),
             proofs_history_verification_interval: 0,
+            proofs_get_proof_permits: DEFAULT_PROOFS_GET_PROOF_PERMITS,
             base_protocol: true,
         }
     }
@@ -295,5 +328,50 @@ mod tests {
         ])
         .args;
         assert!(!args.base_protocol);
+    }
+
+    #[test]
+    fn test_parse_proofs_get_proof_permits_default() {
+        let args = CommandParser::<RollupArgs>::parse_from(["reth"]).args;
+        assert_eq!(args.proofs_get_proof_permits, DEFAULT_PROOFS_GET_PROOF_PERMITS);
+    }
+
+    #[test]
+    fn test_parse_proofs_get_proof_permits() {
+        let expected_args = RollupArgs {
+            proofs_get_proof_permits: NonZeroUsize::new(64).expect("non-zero"),
+            ..Default::default()
+        };
+        let args =
+            CommandParser::<RollupArgs>::parse_from(["reth", "--proofs.get-proof-permits", "64"])
+                .args;
+        assert_eq!(args, expected_args);
+    }
+
+    #[test]
+    fn test_parse_proofs_get_proof_permits_rejects_zero() {
+        let err = match CommandParser::<RollupArgs>::try_parse_from([
+            "reth",
+            "--proofs.get-proof-permits",
+            "0",
+        ]) {
+            Ok(_) => panic!("zero permits should be rejected"),
+            Err(err) => err,
+        };
+        assert_eq!(err.kind(), clap::error::ErrorKind::ValueValidation);
+    }
+
+    #[test]
+    fn test_parse_proofs_get_proof_permits_rejects_too_large() {
+        let oversized = (Semaphore::MAX_PERMITS + 1).to_string();
+        let err = match CommandParser::<RollupArgs>::try_parse_from([
+            "reth",
+            "--proofs.get-proof-permits",
+            oversized.as_str(),
+        ]) {
+            Ok(_) => panic!("oversized permits should be rejected"),
+            Err(err) => err,
+        };
+        assert_eq!(err.kind(), clap::error::ErrorKind::ValueValidation);
     }
 }

--- a/crates/execution/node/src/args.rs
+++ b/crates/execution/node/src/args.rs
@@ -199,6 +199,7 @@ impl Default for RollupArgs {
 #[cfg(test)]
 mod tests {
     use clap::{Args, Parser};
+    use rstest::rstest;
 
     use super::*;
 
@@ -330,46 +331,30 @@ mod tests {
         assert!(!args.base_protocol);
     }
 
-    #[test]
-    fn test_parse_proofs_get_proof_permits_default() {
-        let args = CommandParser::<RollupArgs>::parse_from(["reth"]).args;
-        assert_eq!(args.proofs_get_proof_permits, DEFAULT_PROOFS_GET_PROOF_PERMITS);
+    #[rstest]
+    #[case::default(vec!["reth"], DEFAULT_PROOFS_GET_PROOF_PERMITS)]
+    #[case::explicit(
+        vec!["reth", "--proofs.get-proof-permits", "64"],
+        NonZeroUsize::new(64).expect("non-zero")
+    )]
+    fn test_parse_proofs_get_proof_permits(
+        #[case] args: Vec<&str>,
+        #[case] expected_permits: NonZeroUsize,
+    ) {
+        let args = CommandParser::<RollupArgs>::parse_from(args).args;
+        assert_eq!(args.proofs_get_proof_permits, expected_permits);
     }
 
-    #[test]
-    fn test_parse_proofs_get_proof_permits() {
-        let expected_args = RollupArgs {
-            proofs_get_proof_permits: NonZeroUsize::new(64).expect("non-zero"),
-            ..Default::default()
-        };
-        let args =
-            CommandParser::<RollupArgs>::parse_from(["reth", "--proofs.get-proof-permits", "64"])
-                .args;
-        assert_eq!(args, expected_args);
-    }
-
-    #[test]
-    fn test_parse_proofs_get_proof_permits_rejects_zero() {
+    #[rstest]
+    #[case::zero("0".to_string())]
+    #[case::too_large((Semaphore::MAX_PERMITS + 1).to_string())]
+    fn test_parse_proofs_get_proof_permits_rejects_invalid(#[case] permits: String) {
         let err = match CommandParser::<RollupArgs>::try_parse_from([
             "reth",
             "--proofs.get-proof-permits",
-            "0",
+            permits.as_str(),
         ]) {
-            Ok(_) => panic!("zero permits should be rejected"),
-            Err(err) => err,
-        };
-        assert_eq!(err.kind(), clap::error::ErrorKind::ValueValidation);
-    }
-
-    #[test]
-    fn test_parse_proofs_get_proof_permits_rejects_too_large() {
-        let oversized = (Semaphore::MAX_PERMITS + 1).to_string();
-        let err = match CommandParser::<RollupArgs>::try_parse_from([
-            "reth",
-            "--proofs.get-proof-permits",
-            oversized.as_str(),
-        ]) {
-            Ok(_) => panic!("oversized permits should be rejected"),
+            Ok(_) => panic!("invalid permits should be rejected"),
             Err(err) => err,
         };
         assert_eq!(err.kind(), clap::error::ErrorKind::ValueValidation);

--- a/crates/execution/node/src/proof_history.rs
+++ b/crates/execution/node/src/proof_history.rs
@@ -32,6 +32,7 @@ pub async fn launch_node_with_proof_history(
         proofs_history_window,
         proofs_history_prune_interval,
         proofs_history_verification_interval,
+        proofs_get_proof_permits,
         ..
     } = args;
 
@@ -72,7 +73,11 @@ pub async fn launch_node_with_proof_history(
                     .boxed())
             })
             .extend_rpc_modules(move |ctx| {
-                let api_ext = EthApiExt::new(ctx.registry.eth_api().clone(), storage.clone());
+                let api_ext = EthApiExt::new(
+                    ctx.registry.eth_api().clone(),
+                    storage.clone(),
+                    proofs_get_proof_permits,
+                );
                 let debug_ext = DebugApiExt::new(
                     ctx.node().provider().clone(),
                     ctx.registry.eth_api().clone(),

--- a/crates/execution/proofs/src/proofs.rs
+++ b/crates/execution/proofs/src/proofs.rs
@@ -40,6 +40,7 @@ impl BaseNodeExtension for ProofsHistoryExtension {
         let proofs_history_window = args.proofs_history_window;
         let proofs_history_prune_interval = args.proofs_history_prune_interval;
         let proofs_history_verification_interval = args.proofs_history_verification_interval;
+        let proofs_get_proof_permits = args.proofs_get_proof_permits;
 
         if proofs_history_enabled {
             let path = args
@@ -81,7 +82,11 @@ impl BaseNodeExtension for ProofsHistoryExtension {
                         .run())
                 })
                 .add_rpc_module(move |ctx| {
-                    let api_ext = EthApiExt::new(ctx.registry.eth_api().clone(), storage.clone());
+                    let api_ext = EthApiExt::new(
+                        ctx.registry.eth_api().clone(),
+                        storage.clone(),
+                        proofs_get_proof_permits,
+                    );
                     let debug_ext = DebugApiExt::new(
                         ctx.node().provider().clone(),
                         ctx.registry.eth_api().clone(),

--- a/crates/execution/rpc/src/eth/proofs.rs
+++ b/crates/execution/rpc/src/eth/proofs.rs
@@ -14,7 +14,7 @@ use jsonrpsee_types::error::{ErrorCode, ErrorObject};
 use reth_provider::StateProofProvider;
 use reth_rpc_api::eth::helpers::FullEthApi;
 use reth_rpc_server_types::result::internal_rpc_err;
-use tokio::sync::{OwnedSemaphorePermit, Semaphore};
+use tokio::sync::{Semaphore, SemaphorePermit};
 
 use crate::{metrics::EthApiExtMetrics, state::BaseStateProviderFactory};
 
@@ -62,19 +62,16 @@ pub struct EthApiExt<Eth, P> {
 
 /// Holds one `eth_getProof` concurrency permit and records available permits on release.
 #[derive(Debug)]
-pub struct GetProofPermit {
-    semaphore: Arc<Semaphore>,
-    permit: Option<OwnedSemaphorePermit>,
+pub struct GetProofPermit<'a> {
+    semaphore: &'a Semaphore,
+    permit: Option<SemaphorePermit<'a>>,
 }
 
-impl GetProofPermit {
+impl<'a> GetProofPermit<'a> {
     /// Acquires one `eth_getProof` concurrency permit and records wait/availability metrics.
-    pub async fn acquire(semaphore: Arc<Semaphore>) -> RpcResult<Self> {
+    pub async fn acquire(semaphore: &'a Semaphore) -> RpcResult<Self> {
         let semaphore_wait_start = Instant::now();
-        let permit = Arc::clone(&semaphore)
-            .acquire_owned()
-            .await
-            .map_err(|err| internal_rpc_err(err.to_string()))?;
+        let permit = semaphore.acquire().await.map_err(|err| internal_rpc_err(err.to_string()))?;
 
         EthApiExtMetrics::get_proof_semaphore_wait_duration()
             .record(semaphore_wait_start.elapsed().as_secs_f64());
@@ -85,7 +82,7 @@ impl GetProofPermit {
     }
 }
 
-impl Drop for GetProofPermit {
+impl Drop for GetProofPermit<'_> {
     fn drop(&mut self) {
         drop(self.permit.take());
         EthApiExtMetrics::get_proof_semaphore_available_permits()
@@ -136,7 +133,7 @@ where
         EthApiExtMetrics::get_proof_requests().increment(1);
 
         let result = async {
-            let _permit = GetProofPermit::acquire(Arc::clone(&self.get_proof_semaphore)).await?;
+            let _permit = GetProofPermit::acquire(&self.get_proof_semaphore).await?;
             let storage_keys = keys.iter().map(|key| key.as_b256()).collect::<Vec<_>>();
             let proof = self
                 .state_provider_factory

--- a/crates/execution/rpc/src/eth/proofs.rs
+++ b/crates/execution/rpc/src/eth/proofs.rs
@@ -1,6 +1,6 @@
 //! Historical proofs RPC server implementation.
 
-use std::time::Instant;
+use std::{num::NonZeroUsize, sync::Arc, time::Instant};
 
 use alloy_eips::BlockId;
 use alloy_primitives::Address;
@@ -13,6 +13,8 @@ use jsonrpsee_core::RpcResult;
 use jsonrpsee_types::error::{ErrorCode, ErrorObject};
 use reth_provider::StateProofProvider;
 use reth_rpc_api::eth::helpers::FullEthApi;
+use reth_rpc_server_types::result::internal_rpc_err;
+use tokio::sync::{OwnedSemaphorePermit, Semaphore};
 
 use crate::{metrics::EthApiExtMetrics, state::BaseStateProviderFactory};
 
@@ -51,10 +53,44 @@ pub trait EthApiOverride {
     ) -> RpcResult<EIP1186AccountProofResponse>;
 }
 
-#[derive(Debug)]
 /// Overrides applied to the `eth_` namespace of the RPC API for historical proofs `ExEx`.
+#[derive(Debug)]
 pub struct EthApiExt<Eth, P> {
     state_provider_factory: BaseStateProviderFactory<Eth, P>,
+    get_proof_semaphore: Arc<Semaphore>,
+}
+
+/// Holds one `eth_getProof` concurrency permit and records available permits on release.
+#[derive(Debug)]
+pub struct GetProofPermit {
+    semaphore: Arc<Semaphore>,
+    permit: Option<OwnedSemaphorePermit>,
+}
+
+impl GetProofPermit {
+    /// Acquires one `eth_getProof` concurrency permit and records wait/availability metrics.
+    pub async fn acquire(semaphore: Arc<Semaphore>) -> RpcResult<Self> {
+        let semaphore_wait_start = Instant::now();
+        let permit = Arc::clone(&semaphore)
+            .acquire_owned()
+            .await
+            .map_err(|err| internal_rpc_err(err.to_string()))?;
+
+        EthApiExtMetrics::get_proof_semaphore_wait_duration()
+            .record(semaphore_wait_start.elapsed().as_secs_f64());
+        EthApiExtMetrics::get_proof_semaphore_available_permits()
+            .set(semaphore.available_permits() as f64);
+
+        Ok(Self { semaphore, permit: Some(permit) })
+    }
+}
+
+impl Drop for GetProofPermit {
+    fn drop(&mut self) {
+        drop(self.permit.take());
+        EthApiExtMetrics::get_proof_semaphore_available_permits()
+            .set(self.semaphore.available_permits() as f64);
+    }
 }
 
 impl<Eth, P> EthApiExt<Eth, P>
@@ -64,8 +100,19 @@ where
     P: BaseProofsStore + Clone + 'static,
 {
     /// Creates a new instance of the `EthApiExt`.
-    pub const fn new(eth_api: Eth, preimage_store: BaseProofsStorage<P>) -> Self {
-        Self { state_provider_factory: BaseStateProviderFactory::new(eth_api, preimage_store) }
+    pub fn new(
+        eth_api: Eth,
+        preimage_store: BaseProofsStorage<P>,
+        max_concurrent: NonZeroUsize,
+    ) -> Self {
+        let max_concurrent = max_concurrent.get();
+        let get_proof_semaphore = Arc::new(Semaphore::new(max_concurrent));
+        EthApiExtMetrics::get_proof_semaphore_available_permits().set(max_concurrent as f64);
+
+        Self {
+            state_provider_factory: BaseStateProviderFactory::new(eth_api, preimage_store),
+            get_proof_semaphore,
+        }
     }
 }
 
@@ -88,9 +135,9 @@ where
         let start = Instant::now();
         EthApiExtMetrics::get_proof_requests().increment(1);
 
-        let storage_keys = keys.iter().map(|key| key.as_b256()).collect::<Vec<_>>();
-
         let result = async {
+            let _permit = GetProofPermit::acquire(Arc::clone(&self.get_proof_semaphore)).await?;
+            let storage_keys = keys.iter().map(|key| key.as_b256()).collect::<Vec<_>>();
             let proof = self
                 .state_provider_factory
                 .state_provider(block_number)
@@ -98,7 +145,6 @@ where
                 .map_err(Into::into)?
                 .proof(Default::default(), address, &storage_keys)
                 .map_err(Into::into)?;
-
             Ok(proof.into_eip1186_response(keys))
         }
         .await;

--- a/crates/execution/rpc/src/metrics.rs
+++ b/crates/execution/rpc/src/metrics.rs
@@ -28,6 +28,10 @@ base_metrics::define_metrics! {
     get_proof_successful_responses: counter,
     #[describe("Total number of failures handling eth_getProof requests")]
     get_proof_failures: counter,
+    #[describe("How long eth_getProof requests wait for a concurrency permit")]
+    get_proof_semaphore_wait_duration: histogram,
+    #[describe("Currently available eth_getProof concurrency permits")]
+    get_proof_semaphore_available_permits: gauge,
 }
 
 /// Types of debug apis


### PR DESCRIPTION
## Summary

The Base custom `EthApiExt::get_proof` override (`crates/execution/rpc/src/eth/proofs.rs`) replaces upstream reth's `eth_getProof` via `replace_configured(api_ext.into_rpc())`, which inadvertently removed both upstream safety nets:

| Protection | Upstream reth | Base override (before) |
| -- | -- | -- |
| `acquire_owned_tracing()` semaphore (`num_cpus - 2`) | Yes | No |
| `--rpc.proof-permits` (default 25) | Yes | No |

This let unlimited concurrent `eth_getProof` requests hit MDBX directly with zero throttle, contributing to the 5/10 16:30 UTC traffic surge (15K -> 4M req/30min) that drove `eth_getProof` p50 from 30us to 91ms and triggered MDBX `lck_rdt_lock` contention.

This PR restores a configurable concurrency cap on the Base override.

## Changes

- `EthApiExt` now owns an `Arc<Semaphore>`; `get_proof` acquires an `OwnedSemaphorePermit` (RAII via new `GetProofPermit` helper) before opening the state provider.
- New CLI flag `--proofs.get-proof-permits` (`NonZeroUsize`, default `32`, bounded by `Semaphore::MAX_PERMITS`) wired through `RollupArgs` -> `EthApiExt::new` in both `node/src/proof_history.rs` and `proofs/src/proofs.rs`.
- New metrics on the `eth_api_ext` namespace:
  - `get_proof_semaphore_wait_duration` (histogram) - permit wait time, lets us see queueing.
  - `get_proof_semaphore_available_permits` (gauge) - currently free permits.
- Tests for default value, custom value, zero rejection, and oversized rejection of the new flag.

## Tuning Guidance

Per the Oracle/P0a coordination notes in CHAIN-4462: keep the default at 32 and watch `get_proof_semaphore_wait_duration` before raising. Only scale up after the shared MDBX read-tx proof path (P0a, #2681) is deployed and lock contention is healthy.

## Local Benchmark Results

I compared `main` (`base/`) against this PR branch (`base-chain-4462/`) with a temporary local integration-test harness that benchmarks the proof-generation workload behind `eth_getProof`. The harness detects this PR's `DEFAULT_PROOFS_GET_PROOF_PERMITS` and runs the PR branch with the default 32-permit cap; `main` runs unlimited.

Default workload: `256` requests, `128` caller concurrency, `128` storage slots/request.

| Branch | Mode | Wall | Throughput | Max In-Flight | p95 Latency | p99 Latency |
| -- | -- | --: | --: | --: | --: | --: |
| `main` | unlimited | `234.378ms` | `1092.25 rps` | `128` | `203.990ms` | `214.396ms` |
| PR #2696 | `32` permits | `270.525ms` | `946.31 rps` | `32` | `257.659ms` | `260.756ms` |

Heavier saturation workload: `1024` requests, `512` caller concurrency, `256` storage slots/request.

| Branch / Permits | Wall | Throughput | Max In-Flight | Mean Latency | p95 Latency | p99 Latency |
| -- | --: | --: | --: | --: | --: | --: |
| `main` unlimited | `1573.810ms` | `650.65 rps` | `512` | `702.930ms` | `1167.588ms` | `1367.037ms` |
| PR default `32` | `1708.598ms` | `599.32 rps` | `32` | `654.120ms` | `1646.393ms` | `1694.916ms` |
| PR forced `64` | `1588.990ms` | `644.43 rps` | `64` | `622.904ms` | `1551.908ms` | `1577.926ms` |
| PR forced `128` | `1604.893ms` | `638.05 rps` | `128` | `648.601ms` | `1574.037ms` | `1596.256ms` |
| PR forced `256` | `1591.121ms` | `643.57 rps` | `256` | `687.914ms` | `1547.637ms` | `1577.309ms` |

Interpretation: the cap is active and bounds proof work (`max_inflight=32` by default instead of 128/512). Under the heavier workload, actual proof service time dropped sharply: service p95 was `1167.588ms` on `main` versus `104.611ms` with the PR default. End-to-end p95/p99 and wall throughput were not better in this synthetic local run because queue wait dominates when 512 callers are forced through 32 permits. This supports treating `32` as a protective default, then tuning via `get_proof_semaphore_wait_duration` under production-like load.

## Linear

CHAIN-4462
