### PR TITLE
perf: skip compression on finalized static files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5950,17 +5950,21 @@ dependencies = [
  "async-trait",
  "aws-config",
  "aws-sdk-s3",
+ "blake3",
  "bollard",
  "clap",
  "futures",
- "reth-cli-commands",
+ "rayon",
+ "serde",
  "serde_json",
  "serial_test",
+ "tar",
  "tempfile",
  "testcontainers",
  "testcontainers-modules",
  "tokio",
  "tracing",
+ "zstd",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -514,6 +514,10 @@ testcontainers-modules = { version = "0.13", default-features = false }
 # docker
 bollard = "0.19.4"
 
+# compression
+zstd = "0.13"
+blake3 = "1.8"
+
 # misc
 snap = "1"
 redb = "2"

--- a/crates/infra/snapshotter/Cargo.toml
+++ b/crates/infra/snapshotter/Cargo.toml
@@ -11,14 +11,19 @@ repository.workspace = true
 workspace = true
 
 [dependencies]
+tar = { workspace = true }
+zstd = { workspace = true }
 anyhow = { workspace = true }
+blake3 = { workspace = true }
+rayon = { workspace = true }
 bollard = { workspace = true }
 futures = { workspace = true }
 tracing = { workspace = true }
 async-trait = { workspace = true }
-reth-cli-commands = { workspace = true }
+serde_json = { workspace = true }
 tokio = { workspace = true, features = ["rt"] }
 clap = { workspace = true, features = ["derive", "env"] }
+serde = { workspace = true, features = ["std", "derive"] }
 aws-sdk-s3 = { workspace = true, features = ["rustls", "default-https-client", "rt-tokio"] }
 
 [dev-dependencies]

--- a/crates/infra/snapshotter/src/lib.rs
+++ b/crates/infra/snapshotter/src/lib.rs
@@ -14,7 +14,7 @@ mod container;
 pub use container::{ContainerManager, DockerContainerManager};
 
 mod snapshot;
-pub use snapshot::SnapshotGenerator;
+pub use snapshot::{OutputFileChecksum, SnapshotGenerator, SnapshotManifest};
 
 mod upload;
 pub use upload::{SnapshotUploader, UploadStrategy};

--- a/crates/infra/snapshotter/src/orchestrator.rs
+++ b/crates/infra/snapshotter/src/orchestrator.rs
@@ -94,26 +94,16 @@ impl<C: ContainerManager> Snapshotter<C> {
 
         let run_output_dir = create_run_output_dir(&self.config.output_dir, run_timestamp)?;
 
-        let remote_static_files = self.uploader.remote_static_filenames().await?;
+        let remote_static_files = self.uploader.list_remote_static_files().await?;
 
-        let blocks_per_file = self.config.blocks_per_file.unwrap_or(500_000);
-        let block = self.config.block;
-        let skip_ranges = match block {
-            Some(b) => {
-                SnapshotGenerator::compute_skip_ranges(&remote_static_files, b, blocks_per_file)
-            }
-            None => std::collections::HashSet::new(),
-        };
-
-        info!(
-            skip_count = skip_ranges.len(),
-            remote_files = remote_static_files.len(),
-            "computed compression skip ranges"
-        );
+        info!(remote_files = remote_static_files.len(), "fetched remote static file listing");
 
         let source_datadir = self.config.source_datadir.clone();
         let output_dir_for_gen = run_output_dir.clone();
         let chain_id = self.config.chain_id;
+        let block = self.config.block;
+        let blocks_per_file = self.config.blocks_per_file;
+        let remote_for_gen = remote_static_files.clone();
 
         let files = tokio::task::spawn_blocking(move || {
             SnapshotGenerator::generate_manifest(
@@ -121,8 +111,8 @@ impl<C: ContainerManager> Snapshotter<C> {
                 &output_dir_for_gen,
                 chain_id,
                 block,
-                Some(blocks_per_file),
-                &skip_ranges,
+                blocks_per_file,
+                &remote_for_gen,
             )
         })
         .await
@@ -134,7 +124,7 @@ impl<C: ContainerManager> Snapshotter<C> {
         }
 
         self.uploader
-            .upload(&run_output_dir, &files, run_timestamp)
+            .upload(&run_output_dir, &files, run_timestamp, &remote_static_files)
             .await
             .context("snapshot upload failed")?;
 

--- a/crates/infra/snapshotter/src/orchestrator.rs
+++ b/crates/infra/snapshotter/src/orchestrator.rs
@@ -94,19 +94,35 @@ impl<C: ContainerManager> Snapshotter<C> {
 
         let run_output_dir = create_run_output_dir(&self.config.output_dir, run_timestamp)?;
 
+        let remote_static_files = self.uploader.remote_static_filenames().await?;
+
+        let blocks_per_file = self.config.blocks_per_file.unwrap_or(500_000);
+        let block = self.config.block;
+        let skip_ranges = match block {
+            Some(b) => {
+                SnapshotGenerator::compute_skip_ranges(&remote_static_files, b, blocks_per_file)
+            }
+            None => std::collections::HashSet::new(),
+        };
+
+        info!(
+            skip_count = skip_ranges.len(),
+            remote_files = remote_static_files.len(),
+            "computed compression skip ranges"
+        );
+
         let source_datadir = self.config.source_datadir.clone();
         let output_dir_for_gen = run_output_dir.clone();
         let chain_id = self.config.chain_id;
-        let block = self.config.block;
-        let blocks_per_file = self.config.blocks_per_file;
 
         let files = tokio::task::spawn_blocking(move || {
-            SnapshotGenerator::generate(
+            SnapshotGenerator::generate_manifest(
                 &source_datadir,
                 &output_dir_for_gen,
                 chain_id,
                 block,
-                blocks_per_file,
+                Some(blocks_per_file),
+                &skip_ranges,
             )
         })
         .await

--- a/crates/infra/snapshotter/src/snapshot.rs
+++ b/crates/infra/snapshotter/src/snapshot.rs
@@ -9,7 +9,7 @@
 //! buffer of recent chunks are compressed.
 
 use std::{
-    collections::{BTreeMap, HashSet},
+    collections::{BTreeMap, HashMap, HashSet},
     io::Read,
     path::{Path, PathBuf},
 };
@@ -25,6 +25,10 @@ const DEFAULT_BLOCKS_PER_FILE: u64 = 500_000;
 /// Number of extra chunks beyond the tip to compress as a safety buffer.
 const EXTRA_CHUNKS_BUFFER: u64 = 2;
 
+/// Maximum number of chunks allowed before bailing to prevent OOM.
+/// At 500k blocks per file, 100k chunks covers 50 billion blocks.
+const MAX_CHUNKS: u64 = 100_000;
+
 /// Static file component types that produce chunked archives.
 const CHUNKED_COMPONENTS: &[(&str, &str)] = &[
     ("headers", "headers"),
@@ -39,7 +43,7 @@ const CHUNKED_COMPONENTS: &[(&str, &str)] = &[
 ///
 /// Matches reth's `SnapshotManifest` JSON format.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub(crate) struct SnapshotManifest {
+pub struct SnapshotManifest {
     /// Block number this snapshot was taken at.
     pub block: u64,
     /// Chain ID.
@@ -54,7 +58,7 @@ pub(crate) struct SnapshotManifest {
 
 /// Checksum metadata for an extracted file within an archive.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub(crate) struct OutputFileChecksum {
+pub struct OutputFileChecksum {
     /// Relative path under the target datadir.
     pub path: String,
     /// File size in bytes.
@@ -77,13 +81,15 @@ impl SnapshotGenerator {
     /// remotely and don't need to be re-compressed.
     ///
     /// Returns the list of files created in the output directory.
+    ///
+    /// From <https://github.com/paradigmxyz/reth/blob/420693521fccd1437071a15a4a54a3a98b5492cf/crates/cli/commands/src/download/manifest.rs>
     pub fn generate_manifest(
         source_datadir: &Path,
         output_dir: &Path,
         chain_id: u64,
         block: Option<u64>,
         blocks_per_file: Option<u64>,
-        skip_ranges: &HashSet<(u64, u64)>,
+        remote_static_files: &HashMap<String, u64>,
     ) -> Result<Vec<PathBuf>> {
         std::fs::create_dir_all(output_dir)
             .with_context(|| format!("failed to create output dir {}", output_dir.display()))?;
@@ -93,6 +99,10 @@ impl SnapshotGenerator {
             Some(b) => b,
             None => infer_block_from_headers(source_datadir)?,
         };
+
+        let remote_filenames: HashSet<&str> =
+            remote_static_files.keys().map(String::as_str).collect();
+        let skip_ranges = Self::compute_skip_ranges(&remote_filenames, block, blocks_per_file)?;
 
         info!(
             source = %source_datadir.display(),
@@ -104,17 +114,29 @@ impl SnapshotGenerator {
             "generating snapshot archives"
         );
 
+        let static_files_dir = source_datadir.join("static_files");
+        let static_dir =
+            if static_files_dir.exists() { static_files_dir } else { source_datadir.to_path_buf() };
+        let dir_listing = read_static_dir(&static_dir)?;
+
         let mut components = BTreeMap::new();
 
+        let num_chunks = block.div_ceil(blocks_per_file);
+        if num_chunks > MAX_CHUNKS {
+            bail!(
+                "too many chunks ({num_chunks}) for block {block} with blocks_per_file \
+                 {blocks_per_file} — increase --blocks-per-file or check --block"
+            );
+        }
+
         for &(key, segment_name) in CHUNKED_COMPONENTS {
-            let num_chunks = block.div_ceil(blocks_per_file);
             let mut planned = Vec::new();
             let mut found_any = false;
 
             for i in 0..num_chunks {
                 let start = i * blocks_per_file;
-                let end = (i + 1) * blocks_per_file - 1;
-                let source_files = find_source_files(source_datadir, segment_name, start, end)?;
+                let end = start.checked_add(blocks_per_file - 1).context("block range overflow")?;
+                let source_files = filter_source_files(&dir_listing, segment_name, start, end);
 
                 if source_files.is_empty() {
                     if found_any {
@@ -135,7 +157,9 @@ impl SnapshotGenerator {
                 });
             }
 
-            if found_any {
+            if !found_any {
+                info!(component = key, "no static files found, skipping component");
+            } else {
                 let packaged: Vec<PackagedChunk> = planned
                     .into_par_iter()
                     .map(|p| {
@@ -206,8 +230,10 @@ impl SnapshotGenerator {
             );
         }
 
-        let timestamp =
-            std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH)?.as_secs();
+        let timestamp = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .context("system clock is before UNIX epoch")?
+            .as_secs();
 
         let manifest =
             SnapshotManifest { block, chain_id, storage_version: 2, timestamp, components };
@@ -224,10 +250,10 @@ impl SnapshotGenerator {
     /// Determines which chunk ranges can be skipped based on what already exists
     /// remotely. Keeps the tip chunk and `EXTRA_CHUNKS_BUFFER` additional chunks.
     pub fn compute_skip_ranges(
-        remote_filenames: &HashSet<String>,
+        remote_filenames: &HashSet<&str>,
         block: u64,
         blocks_per_file: u64,
-    ) -> HashSet<(u64, u64)> {
+    ) -> Result<HashSet<(u64, u64)>> {
         let num_chunks = block.div_ceil(blocks_per_file);
         let keep_from = num_chunks.saturating_sub(1 + EXTRA_CHUNKS_BUFFER);
 
@@ -237,11 +263,13 @@ impl SnapshotGenerator {
                 continue;
             }
             let start = i * blocks_per_file;
-            let end = (i + 1) * blocks_per_file - 1;
+            let end = start
+                .checked_add(blocks_per_file - 1)
+                .context("block range overflow in skip computation")?;
 
             let dominated_by_remote = CHUNKED_COMPONENTS.iter().all(|&(key, _)| {
                 let filename = chunk_filename(key, start, end);
-                remote_filenames.contains(&filename)
+                remote_filenames.contains(filename.as_str())
             });
 
             if dominated_by_remote {
@@ -249,7 +277,7 @@ impl SnapshotGenerator {
             }
         }
 
-        skip
+        Ok(skip)
     }
 }
 
@@ -304,30 +332,39 @@ struct PlannedFile {
     relative_path: PathBuf,
 }
 
-fn find_source_files(
-    source_datadir: &Path,
-    segment_name: &str,
-    start: u64,
-    end: u64,
-) -> Result<Vec<PathBuf>> {
-    let static_files_dir = source_datadir.join("static_files");
-    let dir =
-        if static_files_dir.exists() { static_files_dir } else { source_datadir.to_path_buf() };
-    let prefix = format!("static_file_{segment_name}_{start}_{end}");
+/// Cached directory entry: (filename, full path).
+type DirEntry = (String, PathBuf);
 
-    let mut files = Vec::new();
-    for entry in std::fs::read_dir(&dir)? {
+/// Reads a directory once, returning all file entries as (name, path) pairs.
+fn read_static_dir(dir: &Path) -> Result<Vec<DirEntry>> {
+    let mut entries = Vec::new();
+    for entry in
+        std::fs::read_dir(dir).with_context(|| format!("failed to read {}", dir.display()))?
+    {
         let entry = entry?;
         if !entry.file_type()?.is_file() {
             continue;
         }
-        if entry.file_name().to_string_lossy().starts_with(&prefix) {
-            files.push(entry.path());
-        }
+        let name = entry.file_name().to_string_lossy().to_string();
+        entries.push((name, entry.path()));
     }
+    entries.sort_unstable_by(|a, b| a.0.cmp(&b.0));
+    Ok(entries)
+}
 
-    files.sort_unstable();
-    Ok(files)
+/// Filters the cached directory listing for files matching a chunk prefix.
+fn filter_source_files(
+    dir_listing: &[DirEntry],
+    segment_name: &str,
+    start: u64,
+    end: u64,
+) -> Vec<PathBuf> {
+    let prefix = format!("static_file_{segment_name}_{start}_{end}");
+    dir_listing
+        .iter()
+        .filter(|(name, _)| name.starts_with(&prefix))
+        .map(|(_, path)| path.clone())
+        .collect()
 }
 
 fn state_source_files(source_datadir: &Path) -> Result<Vec<PlannedFile>> {
@@ -441,14 +478,23 @@ fn write_archive_from_planned_files(
 
     let mut output_files = Vec::with_capacity(files.len());
     for planned in files {
+        let expected_size = std::fs::metadata(&planned.source_path)?.len();
         let mut header = tar::Header::new_gnu();
-        header.set_size(std::fs::metadata(&planned.source_path)?.len());
+        header.set_size(expected_size);
         header.set_mode(0o644);
         header.set_cksum();
 
         let source_file = std::fs::File::open(&planned.source_path)?;
         let mut reader = HashingReader::new(source_file);
         builder.append_data(&mut header, &planned.relative_path, &mut reader)?;
+
+        if reader.bytes_read != expected_size {
+            bail!(
+                "file size changed during archiving: {} (expected {expected_size}, read {})",
+                planned.source_path.display(),
+                reader.bytes_read
+            );
+        }
 
         output_files.push(OutputFileChecksum {
             path: planned.relative_path.to_string_lossy().to_string(),
@@ -457,7 +503,6 @@ fn write_archive_from_planned_files(
         });
     }
 
-    builder.finish()?;
     let encoder = builder.into_inner()?;
     encoder.finish()?;
 
@@ -565,7 +610,8 @@ mod tests {
 
         // block=2_000_000, blocks_per_file=500_000 → 4 chunks (indices 0-3)
         // tip = chunk 3, buffer = 2 → keep chunks 1,2,3 → skip chunk 0
-        let skip = SnapshotGenerator::compute_skip_ranges(&remote, 2_000_000, 500_000);
+        let refs: HashSet<&str> = remote.iter().map(String::as_str).collect();
+        let skip = SnapshotGenerator::compute_skip_ranges(&refs, 2_000_000, 500_000).unwrap();
 
         assert!(skip.contains(&(0, 499_999)), "chunk 0 should be skipped");
         assert!(!skip.contains(&(500_000, 999_999)), "chunk 1 should NOT be skipped (in buffer)");
@@ -585,14 +631,16 @@ mod tests {
         }
 
         // block=1_000_000 → 2 chunks, tip + buffer(2) = 3 → keep all
-        let skip = SnapshotGenerator::compute_skip_ranges(&remote, 1_000_000, 500_000);
+        let refs: HashSet<&str> = remote.iter().map(String::as_str).collect();
+        let skip = SnapshotGenerator::compute_skip_ranges(&refs, 1_000_000, 500_000).unwrap();
         assert!(skip.is_empty(), "should keep all chunks when count <= tip + buffer");
     }
 
     #[test]
     fn compute_skip_ranges_skips_nothing_when_remote_empty() {
         let remote = HashSet::new();
-        let skip = SnapshotGenerator::compute_skip_ranges(&remote, 5_000_000, 500_000);
+        let refs: HashSet<&str> = remote.iter().map(String::as_str).collect();
+        let skip = SnapshotGenerator::compute_skip_ranges(&refs, 5_000_000, 500_000).unwrap();
         assert!(skip.is_empty(), "nothing to skip when remote is empty");
     }
 
@@ -602,7 +650,8 @@ mod tests {
         // Only add headers, not other components
         remote.insert(chunk_filename("headers", 0, 499_999));
 
-        let skip = SnapshotGenerator::compute_skip_ranges(&remote, 5_000_000, 500_000);
+        let refs: HashSet<&str> = remote.iter().map(String::as_str).collect();
+        let skip = SnapshotGenerator::compute_skip_ranges(&refs, 5_000_000, 500_000).unwrap();
         assert!(
             !skip.contains(&(0, 499_999)),
             "should not skip range if not all components are present remotely"
@@ -617,14 +666,14 @@ mod tests {
         std::fs::create_dir_all(&db_dir).unwrap();
         std::fs::write(db_dir.join("mdbx.dat"), b"state-data").unwrap();
 
-        let skip = HashSet::new();
+        let remote = HashMap::new();
         let files = SnapshotGenerator::generate_manifest(
             source.path(),
             output.path(),
             8453,
             Some(0),
             Some(500_000),
-            &skip,
+            &remote,
         )
         .unwrap();
 
@@ -639,7 +688,7 @@ mod tests {
     }
 
     #[test]
-    fn generate_manifest_skips_specified_ranges() {
+    fn generate_manifest_skips_finalized_ranges_via_remote() {
         let source = tempfile::tempdir().unwrap();
         let output = tempfile::tempdir().unwrap();
 
@@ -647,21 +696,29 @@ mod tests {
         std::fs::create_dir_all(&db_dir).unwrap();
         std::fs::write(db_dir.join("mdbx.dat"), b"state").unwrap();
 
+        // 4 header chunks → block=2M, bpf=500k
+        // tip=chunk3, buffer=2 → keep 1,2,3 → skip chunk 0
         let sf = source.path().join("static_files");
         std::fs::create_dir_all(&sf).unwrap();
-        std::fs::write(sf.join("static_file_headers_0_499999"), b"h0").unwrap();
-        std::fs::write(sf.join("static_file_headers_500000_999999"), b"h1").unwrap();
+        for i in 0..4u64 {
+            let start = i * 500_000;
+            let end = (i + 1) * 500_000 - 1;
+            std::fs::write(sf.join(format!("static_file_headers_{start}_{end}")), b"data").unwrap();
+        }
 
-        let mut skip = HashSet::new();
-        skip.insert((0u64, 499_999u64));
+        // Simulate all chunked components existing remotely for range 0-499999
+        let mut remote = HashMap::new();
+        for &(key, _) in CHUNKED_COMPONENTS {
+            remote.insert(chunk_filename(key, 0, 499_999), 0u64);
+        }
 
         let files = SnapshotGenerator::generate_manifest(
             source.path(),
             output.path(),
             8453,
-            Some(1_000_000),
+            Some(2_000_000),
             Some(500_000),
-            &skip,
+            &remote,
         )
         .unwrap();
 
@@ -672,11 +729,15 @@ mod tests {
 
         assert!(
             !filenames.contains(&"headers-0-499999.tar.zst".to_string()),
-            "skipped range should not produce an archive"
+            "finalized range 0 should be skipped (all components exist remotely)"
         );
         assert!(
             filenames.contains(&"headers-500000-999999.tar.zst".to_string()),
-            "non-skipped range should produce an archive"
+            "buffer range should be compressed"
+        );
+        assert!(
+            filenames.contains(&"headers-1500000-1999999.tar.zst".to_string()),
+            "tip range should be compressed"
         );
     }
 }

--- a/crates/infra/snapshotter/src/snapshot.rs
+++ b/crates/infra/snapshotter/src/snapshot.rs
@@ -1,65 +1,493 @@
-//! Snapshot manifest generation via reth's `SnapshotManifestCommand`.
+//! Snapshot archive generation with selective compression.
+//!
+//! Archive creation, BLAKE3 hashing, and manifest structure are derived from
+//! [reth](https://github.com/paradigmxyz/reth) (`crates/cli/commands/src/download/manifest.rs`,
+//! commit `d58c6e3`, tag `v2.1.0`), licensed under Apache-2.0.
+//!
+//! Modified to support skipping compression of finalized static file chunks
+//! that already exist in remote storage. Only the tip chunk and a configurable
+//! buffer of recent chunks are compressed.
 
-use std::path::{Path, PathBuf};
+use std::{
+    collections::{BTreeMap, HashSet},
+    io::Read,
+    path::{Path, PathBuf},
+};
 
-use anyhow::{Context, Result};
-use clap::Parser;
-use reth_cli_commands::download::manifest_cmd::SnapshotManifestCommand;
+use anyhow::{Context, Result, bail};
+use rayon::prelude::*;
+use serde::{Deserialize, Serialize};
 use tracing::info;
 
-/// Generates snapshot archives and a manifest from a reth datadir.
+/// Default blocks per static file segment.
+const DEFAULT_BLOCKS_PER_FILE: u64 = 500_000;
+
+/// Number of extra chunks beyond the tip to compress as a safety buffer.
+const EXTRA_CHUNKS_BUFFER: u64 = 2;
+
+/// Static file component types that produce chunked archives.
+const CHUNKED_COMPONENTS: &[(&str, &str)] = &[
+    ("headers", "headers"),
+    ("transactions", "transactions"),
+    ("transaction_senders", "transaction-senders"),
+    ("receipts", "receipts"),
+    ("account_changesets", "account-change-sets"),
+    ("storage_changesets", "storage-change-sets"),
+];
+
+/// A snapshot manifest describing available components.
 ///
-/// Delegates to reth's `SnapshotManifestCommand` which handles block number
-/// and blocks-per-file inference from the source datadir when not provided.
+/// Matches reth's `SnapshotManifest` JSON format.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct SnapshotManifest {
+    /// Block number this snapshot was taken at.
+    pub block: u64,
+    /// Chain ID.
+    pub chain_id: u64,
+    /// Storage version.
+    pub storage_version: u64,
+    /// Unix timestamp.
+    pub timestamp: u64,
+    /// Available snapshot components.
+    pub components: BTreeMap<String, serde_json::Value>,
+}
+
+/// Checksum metadata for an extracted file within an archive.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct OutputFileChecksum {
+    /// Relative path under the target datadir.
+    pub path: String,
+    /// File size in bytes.
+    pub size: u64,
+    /// BLAKE3 checksum.
+    pub blake3: String,
+}
+
+/// Generates snapshot archives with selective compression.
+///
+/// Static file chunks whose block ranges are in `skip_ranges` are not
+/// compressed or written to the output directory.
 #[derive(Debug)]
 pub struct SnapshotGenerator;
 
 impl SnapshotGenerator {
-    /// Runs reth's `SnapshotManifestCommand` to produce `manifest.json` and
-    /// `*.tar.zst` archives in `output_dir`.
+    /// Generates snapshot archives, skipping compression for chunks in `skip_ranges`.
+    ///
+    /// `skip_ranges` contains `(start, end)` block ranges that already exist
+    /// remotely and don't need to be re-compressed.
     ///
     /// Returns the list of files created in the output directory.
-    pub fn generate(
+    pub fn generate_manifest(
         source_datadir: &Path,
         output_dir: &Path,
         chain_id: u64,
         block: Option<u64>,
         blocks_per_file: Option<u64>,
+        skip_ranges: &HashSet<(u64, u64)>,
     ) -> Result<Vec<PathBuf>> {
         std::fs::create_dir_all(output_dir)
             .with_context(|| format!("failed to create output dir {}", output_dir.display()))?;
 
-        let source = source_datadir.to_str().context("source_datadir is not valid UTF-8")?;
-        let output = output_dir.to_str().context("output_dir is not valid UTF-8")?;
-        let chain_id_str = chain_id.to_string();
-
-        let mut args: Vec<&str> =
-            vec!["snapshot-manifest", "-d", source, "-o", output, "--chain-id", &chain_id_str];
-
-        let block_str = block.map(|b| b.to_string());
-        if let Some(ref b) = block_str {
-            args.extend(["--block", b]);
-        }
-
-        let bpf_str = blocks_per_file.map(|b| b.to_string());
-        if let Some(ref b) = bpf_str {
-            args.extend(["--blocks-per-file", b]);
-        }
+        let blocks_per_file = blocks_per_file.unwrap_or(DEFAULT_BLOCKS_PER_FILE);
+        let block = match block {
+            Some(b) => b,
+            None => infer_block_from_headers(source_datadir)?,
+        };
 
         info!(
             source = %source_datadir.display(),
             output = %output_dir.display(),
             chain_id,
-            block = ?block,
-            "generating snapshot manifest"
+            block,
+            blocks_per_file,
+            skip_count = skip_ranges.len(),
+            "generating snapshot archives"
         );
 
-        let cmd = SnapshotManifestCommand::parse_from(args);
-        cmd.execute().map_err(|e| anyhow::anyhow!(e)).context("SnapshotManifestCommand failed")?;
+        let mut components = BTreeMap::new();
+
+        for &(key, segment_name) in CHUNKED_COMPONENTS {
+            let num_chunks = block.div_ceil(blocks_per_file);
+            let mut planned = Vec::new();
+            let mut found_any = false;
+
+            for i in 0..num_chunks {
+                let start = i * blocks_per_file;
+                let end = (i + 1) * blocks_per_file - 1;
+                let source_files = find_source_files(source_datadir, segment_name, start, end)?;
+
+                if source_files.is_empty() {
+                    if found_any {
+                        bail!("missing source files for {key} chunk {start}-{end}");
+                    }
+                    continue;
+                }
+                found_any = true;
+
+                if skip_ranges.contains(&(start, end)) {
+                    continue;
+                }
+
+                planned.push(PlannedChunk {
+                    chunk_idx: i,
+                    archive_path: output_dir.join(chunk_filename(key, start, end)),
+                    source_files,
+                });
+            }
+
+            if found_any {
+                let packaged: Vec<PackagedChunk> = planned
+                    .into_par_iter()
+                    .map(|p| {
+                        let output_files = write_chunk_archive(&p.archive_path, &p.source_files)?;
+                        let size = std::fs::metadata(&p.archive_path)?.len();
+                        Ok(PackagedChunk { chunk_idx: p.chunk_idx, size, output_files })
+                    })
+                    .collect::<Result<Vec<_>>>()?;
+
+                let mut chunk_sizes = vec![0u64; num_chunks as usize];
+                let mut chunk_decompressed = vec![0u64; num_chunks as usize];
+                let mut chunk_output_files: Vec<Vec<OutputFileChecksum>> =
+                    (0..num_chunks).map(|_| Vec::new()).collect();
+
+                for p in packaged {
+                    let idx = p.chunk_idx as usize;
+                    chunk_sizes[idx] = p.size;
+                    chunk_decompressed[idx] = p.output_files.iter().map(|f| f.size).sum();
+                    chunk_output_files[idx] = p.output_files;
+                }
+
+                let total_size: u64 = chunk_sizes.iter().sum();
+                info!(
+                    component = key,
+                    compressed_size = total_size,
+                    total_blocks = block,
+                    "packaged chunked component"
+                );
+
+                components.insert(
+                    key.to_string(),
+                    serde_json::json!({
+                        "blocks_per_file": blocks_per_file,
+                        "total_blocks": block,
+                        "chunk_sizes": chunk_sizes,
+                        "chunk_decompressed_sizes": chunk_decompressed,
+                        "chunk_output_files": chunk_output_files,
+                    }),
+                );
+            }
+        }
+
+        let state_files = state_source_files(source_datadir)?;
+        let (state_size, state_output_files) =
+            package_single_component(output_dir, "state.tar.zst", &state_files)?;
+        components.insert(
+            "state".to_string(),
+            serde_json::json!({
+                "file": "state.tar.zst",
+                "size": state_size,
+                "decompressed_size": state_output_files.iter().map(|f| f.size).sum::<u64>(),
+                "output_files": state_output_files,
+            }),
+        );
+
+        let rocksdb_files = rocksdb_source_files(source_datadir)?;
+        if !rocksdb_files.is_empty() {
+            let (rocksdb_size, rocksdb_output_files) =
+                package_single_component(output_dir, "rocksdb_indices.tar.zst", &rocksdb_files)?;
+            components.insert(
+                "rocksdb_indices".to_string(),
+                serde_json::json!({
+                    "file": "rocksdb_indices.tar.zst",
+                    "size": rocksdb_size,
+                    "decompressed_size": rocksdb_output_files.iter().map(|f| f.size).sum::<u64>(),
+                    "output_files": rocksdb_output_files,
+                }),
+            );
+        }
+
+        let timestamp =
+            std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH)?.as_secs();
+
+        let manifest =
+            SnapshotManifest { block, chain_id, storage_version: 2, timestamp, components };
+
+        let manifest_path = output_dir.join("manifest.json");
+        std::fs::write(&manifest_path, serde_json::to_string_pretty(&manifest)?)?;
+        info!(block, components = manifest.components.len(), "manifest written");
 
         let files = collect_output_files(output_dir)?;
         info!(file_count = files.len(), "snapshot generation complete");
         Ok(files)
+    }
+
+    /// Determines which chunk ranges can be skipped based on what already exists
+    /// remotely. Keeps the tip chunk and `EXTRA_CHUNKS_BUFFER` additional chunks.
+    pub fn compute_skip_ranges(
+        remote_filenames: &HashSet<String>,
+        block: u64,
+        blocks_per_file: u64,
+    ) -> HashSet<(u64, u64)> {
+        let num_chunks = block.div_ceil(blocks_per_file);
+        let keep_from = num_chunks.saturating_sub(1 + EXTRA_CHUNKS_BUFFER);
+
+        let mut skip = HashSet::new();
+        for i in 0..num_chunks {
+            if i >= keep_from {
+                continue;
+            }
+            let start = i * blocks_per_file;
+            let end = (i + 1) * blocks_per_file - 1;
+
+            let dominated_by_remote = CHUNKED_COMPONENTS.iter().all(|&(key, _)| {
+                let filename = chunk_filename(key, start, end);
+                remote_filenames.contains(&filename)
+            });
+
+            if dominated_by_remote {
+                skip.insert((start, end));
+            }
+        }
+
+        skip
+    }
+}
+
+fn chunk_filename(component_key: &str, start: u64, end: u64) -> String {
+    format!("{component_key}-{start}-{end}.tar.zst")
+}
+
+/// Infers the snapshot block from the highest header static file range.
+fn infer_block_from_headers(source_datadir: &Path) -> Result<u64> {
+    let static_files_dir = source_datadir.join("static_files");
+    let dir =
+        if static_files_dir.exists() { static_files_dir } else { source_datadir.to_path_buf() };
+
+    let mut max_end = None;
+    for entry in
+        std::fs::read_dir(&dir).with_context(|| format!("failed to read {}", dir.display()))?
+    {
+        let entry = entry?;
+        let name = entry.file_name();
+        let name = name.to_string_lossy();
+        if let Some(range) = parse_headers_range(&name) {
+            max_end = Some(max_end.map_or(range.1, |prev: u64| prev.max(range.1)));
+        }
+    }
+
+    max_end.ok_or_else(|| anyhow::anyhow!("no header static files found to infer --block"))
+}
+
+fn parse_headers_range(file_name: &str) -> Option<(u64, u64)> {
+    let remainder = file_name.strip_prefix("static_file_headers_")?;
+    let (start, end_with_suffix) = remainder.split_once('_')?;
+    let start = start.parse::<u64>().ok()?;
+    let end_digits: String = end_with_suffix.chars().take_while(|ch| ch.is_ascii_digit()).collect();
+    let end = end_digits.parse::<u64>().ok()?;
+    Some((start, end))
+}
+
+struct PlannedChunk {
+    chunk_idx: u64,
+    archive_path: PathBuf,
+    source_files: Vec<PathBuf>,
+}
+
+struct PackagedChunk {
+    chunk_idx: u64,
+    size: u64,
+    output_files: Vec<OutputFileChecksum>,
+}
+
+struct PlannedFile {
+    source_path: PathBuf,
+    relative_path: PathBuf,
+}
+
+fn find_source_files(
+    source_datadir: &Path,
+    segment_name: &str,
+    start: u64,
+    end: u64,
+) -> Result<Vec<PathBuf>> {
+    let static_files_dir = source_datadir.join("static_files");
+    let dir =
+        if static_files_dir.exists() { static_files_dir } else { source_datadir.to_path_buf() };
+    let prefix = format!("static_file_{segment_name}_{start}_{end}");
+
+    let mut files = Vec::new();
+    for entry in std::fs::read_dir(&dir)? {
+        let entry = entry?;
+        if !entry.file_type()?.is_file() {
+            continue;
+        }
+        if entry.file_name().to_string_lossy().starts_with(&prefix) {
+            files.push(entry.path());
+        }
+    }
+
+    files.sort_unstable();
+    Ok(files)
+}
+
+fn state_source_files(source_datadir: &Path) -> Result<Vec<PlannedFile>> {
+    let db_dir = source_datadir.join("db");
+    if db_dir.exists() {
+        return collect_files_recursive(&db_dir, Path::new("db"));
+    }
+
+    if looks_like_db_dir(source_datadir)? {
+        return collect_files_recursive(source_datadir, Path::new("db"));
+    }
+
+    bail!("could not find source state DB directory under {}", source_datadir.display())
+}
+
+fn rocksdb_source_files(source_datadir: &Path) -> Result<Vec<PlannedFile>> {
+    let rocksdb_dir = source_datadir.join("rocksdb");
+    if !rocksdb_dir.exists() {
+        return Ok(Vec::new());
+    }
+    collect_files_recursive(&rocksdb_dir, Path::new("rocksdb"))
+}
+
+fn looks_like_db_dir(path: &Path) -> Result<bool> {
+    let entries = match std::fs::read_dir(path) {
+        Ok(entries) => entries,
+        Err(_) => return Ok(false),
+    };
+    for entry in entries {
+        let entry = entry?;
+        if !entry.file_type()?.is_file() {
+            continue;
+        }
+        let name = entry.file_name();
+        let name = name.to_string_lossy();
+        if name == "mdbx.dat" || name == "lock.mdb" || name == "data.mdb" {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
+fn collect_files_recursive(root: &Path, output_prefix: &Path) -> Result<Vec<PlannedFile>> {
+    let mut files = Vec::new();
+    collect_files_inner(root, root, output_prefix, &mut files)?;
+    files.sort_unstable_by(|a, b| a.relative_path.cmp(&b.relative_path));
+    Ok(files)
+}
+
+fn collect_files_inner(
+    root: &Path,
+    dir: &Path,
+    output_prefix: &Path,
+    files: &mut Vec<PlannedFile>,
+) -> Result<()> {
+    for entry in std::fs::read_dir(dir)? {
+        let entry = entry?;
+        let path = entry.path();
+        let ft = entry.file_type()?;
+        if ft.is_dir() {
+            collect_files_inner(root, &path, output_prefix, files)?;
+        } else if ft.is_file() {
+            let relative = path.strip_prefix(root)?.to_path_buf();
+            files.push(PlannedFile {
+                source_path: path,
+                relative_path: output_prefix.join(relative),
+            });
+        }
+    }
+    Ok(())
+}
+
+fn package_single_component(
+    output_dir: &Path,
+    archive_name: &str,
+    files: &[PlannedFile],
+) -> Result<(u64, Vec<OutputFileChecksum>)> {
+    if files.is_empty() {
+        bail!("cannot package empty archive: {archive_name}");
+    }
+    let archive_path = output_dir.join(archive_name);
+    let output_files = write_archive_from_planned_files(&archive_path, files)?;
+    let size = std::fs::metadata(&archive_path)?.len();
+    Ok((size, output_files))
+}
+
+fn write_chunk_archive(path: &Path, source_files: &[PathBuf]) -> Result<Vec<OutputFileChecksum>> {
+    let planned: Vec<PlannedFile> = source_files
+        .iter()
+        .map(|p| {
+            let file_name =
+                p.file_name().ok_or_else(|| anyhow::anyhow!("invalid path: {}", p.display()))?;
+            Ok(PlannedFile {
+                source_path: p.clone(),
+                relative_path: PathBuf::from("static_files").join(file_name),
+            })
+        })
+        .collect::<Result<Vec<_>>>()?;
+
+    write_archive_from_planned_files(path, &planned)
+}
+
+fn write_archive_from_planned_files(
+    path: &Path,
+    files: &[PlannedFile],
+) -> Result<Vec<OutputFileChecksum>> {
+    let file = std::fs::File::create(path)?;
+    let mut encoder = zstd::Encoder::new(file, 0)?;
+    encoder.include_checksum(true)?;
+    let mut builder = tar::Builder::new(encoder);
+
+    let mut output_files = Vec::with_capacity(files.len());
+    for planned in files {
+        let mut header = tar::Header::new_gnu();
+        header.set_size(std::fs::metadata(&planned.source_path)?.len());
+        header.set_mode(0o644);
+        header.set_cksum();
+
+        let source_file = std::fs::File::open(&planned.source_path)?;
+        let mut reader = HashingReader::new(source_file);
+        builder.append_data(&mut header, &planned.relative_path, &mut reader)?;
+
+        output_files.push(OutputFileChecksum {
+            path: planned.relative_path.to_string_lossy().to_string(),
+            size: reader.bytes_read,
+            blake3: reader.finalize(),
+        });
+    }
+
+    builder.finish()?;
+    let encoder = builder.into_inner()?;
+    encoder.finish()?;
+
+    Ok(output_files)
+}
+
+struct HashingReader<R> {
+    inner: R,
+    hasher: blake3::Hasher,
+    bytes_read: u64,
+}
+
+impl<R: Read> HashingReader<R> {
+    fn new(inner: R) -> Self {
+        Self { inner, hasher: blake3::Hasher::new(), bytes_read: 0 }
+    }
+
+    fn finalize(self) -> String {
+        self.hasher.finalize().to_hex().to_string()
+    }
+}
+
+impl<R: Read> Read for HashingReader<R> {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        let n = self.inner.read(buf)?;
+        if n > 0 {
+            self.bytes_read += n as u64;
+            self.hasher.update(&buf[..n]);
+        }
+        Ok(n)
     }
 }
 

--- a/crates/infra/snapshotter/src/snapshot.rs
+++ b/crates/infra/snapshotter/src/snapshot.rs
@@ -505,3 +505,178 @@ fn collect_output_files(dir: &Path) -> Result<Vec<PathBuf>> {
     files.sort_unstable();
     Ok(files)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_headers_range_valid() {
+        assert_eq!(parse_headers_range("static_file_headers_0_499999"), Some((0, 499_999)));
+        assert_eq!(
+            parse_headers_range("static_file_headers_500000_999999"),
+            Some((500_000, 999_999))
+        );
+    }
+
+    #[test]
+    fn parse_headers_range_with_suffix() {
+        assert_eq!(
+            parse_headers_range("static_file_headers_500000_999999.jar"),
+            Some((500_000, 999_999))
+        );
+    }
+
+    #[test]
+    fn parse_headers_range_non_header_files() {
+        assert_eq!(parse_headers_range("static_file_transactions_0_499999"), None);
+        assert_eq!(parse_headers_range("mdbx.dat"), None);
+        assert_eq!(parse_headers_range(""), None);
+    }
+
+    #[test]
+    fn infer_block_from_headers_uses_max_end() {
+        let dir = tempfile::tempdir().unwrap();
+        let sf = dir.path().join("static_files");
+        std::fs::create_dir_all(&sf).unwrap();
+        std::fs::write(sf.join("static_file_headers_0_499999"), []).unwrap();
+        std::fs::write(sf.join("static_file_headers_500000_999999"), []).unwrap();
+
+        assert_eq!(infer_block_from_headers(dir.path()).unwrap(), 999_999);
+    }
+
+    #[test]
+    fn infer_block_from_headers_fails_when_no_files() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join("static_files")).unwrap();
+
+        assert!(infer_block_from_headers(dir.path()).is_err());
+    }
+
+    #[test]
+    fn compute_skip_ranges_skips_finalized_chunks() {
+        let mut remote = HashSet::new();
+        for &(key, _) in CHUNKED_COMPONENTS {
+            remote.insert(chunk_filename(key, 0, 499_999));
+            remote.insert(chunk_filename(key, 500_000, 999_999));
+            remote.insert(chunk_filename(key, 1_000_000, 1_499_999));
+            remote.insert(chunk_filename(key, 1_500_000, 1_999_999));
+        }
+
+        // block=2_000_000, blocks_per_file=500_000 → 4 chunks (indices 0-3)
+        // tip = chunk 3, buffer = 2 → keep chunks 1,2,3 → skip chunk 0
+        let skip = SnapshotGenerator::compute_skip_ranges(&remote, 2_000_000, 500_000);
+
+        assert!(skip.contains(&(0, 499_999)), "chunk 0 should be skipped");
+        assert!(!skip.contains(&(500_000, 999_999)), "chunk 1 should NOT be skipped (in buffer)");
+        assert!(
+            !skip.contains(&(1_000_000, 1_499_999)),
+            "chunk 2 should NOT be skipped (in buffer)"
+        );
+        assert!(!skip.contains(&(1_500_000, 1_999_999)), "chunk 3 (tip) should NOT be skipped");
+    }
+
+    #[test]
+    fn compute_skip_ranges_keeps_all_when_few_chunks() {
+        let mut remote = HashSet::new();
+        for &(key, _) in CHUNKED_COMPONENTS {
+            remote.insert(chunk_filename(key, 0, 499_999));
+            remote.insert(chunk_filename(key, 500_000, 999_999));
+        }
+
+        // block=1_000_000 → 2 chunks, tip + buffer(2) = 3 → keep all
+        let skip = SnapshotGenerator::compute_skip_ranges(&remote, 1_000_000, 500_000);
+        assert!(skip.is_empty(), "should keep all chunks when count <= tip + buffer");
+    }
+
+    #[test]
+    fn compute_skip_ranges_skips_nothing_when_remote_empty() {
+        let remote = HashSet::new();
+        let skip = SnapshotGenerator::compute_skip_ranges(&remote, 5_000_000, 500_000);
+        assert!(skip.is_empty(), "nothing to skip when remote is empty");
+    }
+
+    #[test]
+    fn compute_skip_ranges_requires_all_components_present() {
+        let mut remote = HashSet::new();
+        // Only add headers, not other components
+        remote.insert(chunk_filename("headers", 0, 499_999));
+
+        let skip = SnapshotGenerator::compute_skip_ranges(&remote, 5_000_000, 500_000);
+        assert!(
+            !skip.contains(&(0, 499_999)),
+            "should not skip range if not all components are present remotely"
+        );
+    }
+
+    #[test]
+    fn generate_manifest_creates_state_archive() {
+        let source = tempfile::tempdir().unwrap();
+        let output = tempfile::tempdir().unwrap();
+        let db_dir = source.path().join("db");
+        std::fs::create_dir_all(&db_dir).unwrap();
+        std::fs::write(db_dir.join("mdbx.dat"), b"state-data").unwrap();
+
+        let skip = HashSet::new();
+        let files = SnapshotGenerator::generate_manifest(
+            source.path(),
+            output.path(),
+            8453,
+            Some(0),
+            Some(500_000),
+            &skip,
+        )
+        .unwrap();
+
+        assert!(
+            files.iter().any(|f| f.file_name().unwrap() == "state.tar.zst"),
+            "should produce state.tar.zst"
+        );
+        assert!(
+            files.iter().any(|f| f.file_name().unwrap() == "manifest.json"),
+            "should produce manifest.json"
+        );
+    }
+
+    #[test]
+    fn generate_manifest_skips_specified_ranges() {
+        let source = tempfile::tempdir().unwrap();
+        let output = tempfile::tempdir().unwrap();
+
+        let db_dir = source.path().join("db");
+        std::fs::create_dir_all(&db_dir).unwrap();
+        std::fs::write(db_dir.join("mdbx.dat"), b"state").unwrap();
+
+        let sf = source.path().join("static_files");
+        std::fs::create_dir_all(&sf).unwrap();
+        std::fs::write(sf.join("static_file_headers_0_499999"), b"h0").unwrap();
+        std::fs::write(sf.join("static_file_headers_500000_999999"), b"h1").unwrap();
+
+        let mut skip = HashSet::new();
+        skip.insert((0u64, 499_999u64));
+
+        let files = SnapshotGenerator::generate_manifest(
+            source.path(),
+            output.path(),
+            8453,
+            Some(1_000_000),
+            Some(500_000),
+            &skip,
+        )
+        .unwrap();
+
+        let filenames: Vec<String> = files
+            .iter()
+            .filter_map(|f| f.file_name().map(|n| n.to_string_lossy().to_string()))
+            .collect();
+
+        assert!(
+            !filenames.contains(&"headers-0-499999.tar.zst".to_string()),
+            "skipped range should not produce an archive"
+        );
+        assert!(
+            filenames.contains(&"headers-500000-999999.tar.zst".to_string()),
+            "non-skipped range should produce an archive"
+        );
+    }
+}

--- a/crates/infra/snapshotter/src/upload.rs
+++ b/crates/infra/snapshotter/src/upload.rs
@@ -10,7 +10,7 @@
 //!   These are always re-uploaded since they change every snapshot.
 
 use std::{
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     path::{Path, PathBuf},
 };
 
@@ -85,6 +85,12 @@ impl SnapshotUploader {
     /// Creates a new uploader.
     pub const fn new(client: S3Client, bucket: String, prefix: String) -> Self {
         Self { client, bucket, prefix }
+    }
+
+    /// Returns the set of filenames that exist in `{prefix}/static_files/`.
+    pub async fn remote_static_filenames(&self) -> Result<HashSet<String>> {
+        let remote = self.list_remote_objects(&self.static_files_prefix()).await?;
+        Ok(remote.into_keys().collect())
     }
 
     /// Uploads snapshot artifacts with diff-based optimization.

--- a/crates/infra/snapshotter/src/upload.rs
+++ b/crates/infra/snapshotter/src/upload.rs
@@ -10,7 +10,7 @@
 //!   These are always re-uploaded since they change every snapshot.
 
 use std::{
-    collections::{HashMap, HashSet},
+    collections::HashMap,
     path::{Path, PathBuf},
 };
 
@@ -87,14 +87,15 @@ impl SnapshotUploader {
         Self { client, bucket, prefix }
     }
 
-    /// Returns the set of filenames that exist in `{prefix}/static_files/`.
-    pub async fn remote_static_filenames(&self) -> Result<HashSet<String>> {
-        let remote = self.list_remote_objects(&self.static_files_prefix()).await?;
-        Ok(remote.into_keys().collect())
+    /// Lists remote static files with their sizes. Call once and pass the result
+    /// to both `generate_manifest` (for skip ranges) and `upload` (for diff).
+    pub async fn list_remote_static_files(&self) -> Result<HashMap<String, u64>> {
+        self.list_remote_objects(&self.static_files_prefix()).await
     }
 
     /// Uploads snapshot artifacts with diff-based optimization.
     ///
+    /// `remote_static_files` is the pre-fetched listing from `list_remote_static_files`.
     /// Static file chunks go to `{prefix}/static_files/` and are skipped if the
     /// remote object already exists with the same size. State, rocksdb, and
     /// manifest go to `{prefix}/{date}/` and are always re-uploaded.
@@ -104,6 +105,7 @@ impl SnapshotUploader {
         output_dir: &Path,
         files: &[PathBuf],
         timestamp: u64,
+        remote_static_files: &HashMap<String, u64>,
     ) -> Result<String> {
         let static_prefix = self.static_files_prefix();
         let run_prefix = self.run_prefix(timestamp);
@@ -115,8 +117,6 @@ impl SnapshotUploader {
             bucket = %self.bucket,
             "uploading snapshot artifacts"
         );
-
-        let remote_static_files = self.list_remote_objects(&static_prefix).await?;
 
         let manifest_path = output_dir.join("manifest.json");
         let mut static_uploads = Vec::new();

--- a/crates/infra/snapshotter/tests/e2e_test.rs
+++ b/crates/infra/snapshotter/tests/e2e_test.rs
@@ -1,13 +1,16 @@
 //! E2E tests for the snapshotter upload flow using `MinIO`.
 
 use std::{
+    collections::HashMap,
     path::{Path, PathBuf},
     sync::atomic::{AtomicBool, Ordering},
 };
 
 use anyhow::Result;
 use async_trait::async_trait;
-use base_snapshotter::{ContainerManager, DockerContainerManager, SnapshotUploader};
+use base_snapshotter::{
+    ContainerManager, DockerContainerManager, SnapshotGenerator, SnapshotUploader,
+};
 use bollard::{
     Docker,
     models::ContainerCreateBody,
@@ -179,7 +182,9 @@ async fn upload_artifacts_to_minio() -> Result<()> {
     let output_dir = tmp.path().join("output");
     let files = create_fake_snapshot(&output_dir, 1_000_000)?;
 
-    let upload_prefix = uploader.upload(&output_dir, &files, 1_700_000_000).await?;
+    let upload_prefix = uploader
+        .upload(&output_dir, &files, 1_700_000_000, &std::collections::HashMap::new())
+        .await?;
     assert_eq!(upload_prefix, "mainnet/1700000000", "run prefix should be date-based");
 
     let s3 = &harness.storage_client;
@@ -234,7 +239,9 @@ async fn upload_with_empty_prefix() -> Result<()> {
     let output_dir = tmp.path().join("output");
     let files = create_fake_snapshot(&output_dir, 100)?;
 
-    let upload_prefix = uploader.upload(&output_dir, &files, 1_700_000_000).await?;
+    let upload_prefix = uploader
+        .upload(&output_dir, &files, 1_700_000_000, &std::collections::HashMap::new())
+        .await?;
     assert_eq!(upload_prefix, "1700000000", "empty prefix should produce bare date");
 
     let s3 = &harness.storage_client;
@@ -324,7 +331,9 @@ async fn diff_upload_skips_unchanged_static_file_chunks() -> Result<()> {
         .collect();
     files.sort_unstable();
 
-    let upload_prefix = uploader.upload(&output_dir, &files, 1_700_000_000).await?;
+    let remote_listing = uploader.list_remote_static_files().await?;
+    let upload_prefix =
+        uploader.upload(&output_dir, &files, 1_700_000_000, &remote_listing).await?;
     assert_eq!(upload_prefix, "diff-test/1700000000");
 
     // Verify AlwaysUpload: mdbx + rocksdb in date dir
@@ -367,11 +376,8 @@ async fn diff_upload_skips_unchanged_static_file_chunks() -> Result<()> {
 #[tokio::test]
 #[serial]
 async fn selective_compression_skips_finalized_chunks() -> Result<()> {
-    use std::collections::HashSet;
-
-    use base_snapshotter::SnapshotGenerator;
-
-    // Create a real datadir with mdbx + static files spanning 2 block ranges
+    // Create a real datadir with mdbx + 4 header chunk ranges
+    // block=2M, bpf=500k → 4 chunks, tip=chunk3, buffer=2 → skip chunk 0
     let source = tempfile::tempdir()?;
     let db_dir = source.path().join("db");
     std::fs::create_dir_all(&db_dir)?;
@@ -387,21 +393,35 @@ async fn selective_compression_skips_finalized_chunks() -> Result<()> {
         "account-change-sets",
         "storage-change-sets",
     ] {
-        std::fs::write(sf_dir.join(format!("static_file_{component}_0_499999")), b"finalized")?;
-        std::fs::write(sf_dir.join(format!("static_file_{component}_500000_999999")), b"tip")?;
+        for i in 0..4u64 {
+            let start = i * 500_000;
+            let end = (i + 1) * 500_000 - 1;
+            std::fs::write(sf_dir.join(format!("static_file_{component}_{start}_{end}")), b"data")?;
+        }
     }
 
-    // Skip range 0-499999 (simulates it already existing in remote storage)
-    let skip = HashSet::from([(0u64, 499_999u64)]);
+    // Simulate all chunked components existing remotely for range 0-499999
+    let chunk_components = [
+        "headers",
+        "transactions",
+        "transaction_senders",
+        "receipts",
+        "account_changesets",
+        "storage_changesets",
+    ];
+    let mut remote: HashMap<String, u64> = HashMap::new();
+    for component in chunk_components {
+        remote.insert(format!("{component}-0-499999.tar.zst"), 0);
+    }
 
     let output = tempfile::tempdir()?;
     let files = SnapshotGenerator::generate_manifest(
         source.path(),
         output.path(),
         8453,
-        Some(1_000_000),
+        Some(2_000_000),
         Some(500_000),
-        &skip,
+        &remote,
     )?;
 
     let filenames: Vec<String> = files
@@ -409,30 +429,16 @@ async fn selective_compression_skips_finalized_chunks() -> Result<()> {
         .filter_map(|f| f.file_name().map(|n| n.to_string_lossy().to_string()))
         .collect();
 
-    // Skipped range: no archive produced
-    for component in [
-        "headers",
-        "transactions",
-        "transaction_senders",
-        "receipts",
-        "account_changesets",
-        "storage_changesets",
-    ] {
+    // Skipped range: chunk 0 should NOT be compressed (all components exist remotely)
+    for component in chunk_components {
         assert!(
             !filenames.contains(&format!("{component}-0-499999.tar.zst")),
-            "{component} skipped range should not produce an archive"
+            "{component} finalized range should not produce an archive"
         );
     }
 
-    // Tip range: archives produced
-    for component in [
-        "headers",
-        "transactions",
-        "transaction_senders",
-        "receipts",
-        "account_changesets",
-        "storage_changesets",
-    ] {
+    // Buffer + tip ranges: should be compressed
+    for component in chunk_components {
         assert!(
             filenames.contains(&format!("{component}-500000-999999.tar.zst")),
             "{component} tip range should produce an archive"
@@ -495,7 +501,9 @@ async fn always_upload_overwrites_existing_state_and_rocksdb() -> Result<()> {
         output_dir.join("state.tar.zst"),
     ];
 
-    let upload_prefix = uploader.upload(&output_dir, &files, 1_700_000_000).await?;
+    let upload_prefix = uploader
+        .upload(&output_dir, &files, 1_700_000_000, &std::collections::HashMap::new())
+        .await?;
     assert_eq!(upload_prefix, "overwrite-test/1700000000");
 
     // Verify new state in new date dir
@@ -623,7 +631,9 @@ async fn e2e_stop_upload_restart_real_container() -> Result<()> {
         harness.bucket_name.clone(),
         "e2e-test".to_string(),
     );
-    let upload_prefix = uploader.upload(&output_dir, &files, 1_700_000_000).await?;
+    let upload_prefix = uploader
+        .upload(&output_dir, &files, 1_700_000_000, &std::collections::HashMap::new())
+        .await?;
 
     let manifest_body = get_object_bytes(
         &harness.storage_client,

--- a/crates/infra/snapshotter/tests/e2e_test.rs
+++ b/crates/infra/snapshotter/tests/e2e_test.rs
@@ -362,6 +362,94 @@ async fn diff_upload_skips_unchanged_static_file_chunks() -> Result<()> {
     Ok(())
 }
 
+/// E2E test: creates a real datadir with mdbx + static files, skips compression
+/// for a finalized chunk range, and verifies only the tip chunk is compressed.
+#[tokio::test]
+#[serial]
+async fn selective_compression_skips_finalized_chunks() -> Result<()> {
+    use std::collections::HashSet;
+
+    use base_snapshotter::SnapshotGenerator;
+
+    // Create a real datadir with mdbx + static files spanning 2 block ranges
+    let source = tempfile::tempdir()?;
+    let db_dir = source.path().join("db");
+    std::fs::create_dir_all(&db_dir)?;
+    std::fs::write(db_dir.join("mdbx.dat"), b"test-state-data")?;
+
+    let sf_dir = source.path().join("static_files");
+    std::fs::create_dir_all(&sf_dir)?;
+    for component in [
+        "headers",
+        "transactions",
+        "transaction-senders",
+        "receipts",
+        "account-change-sets",
+        "storage-change-sets",
+    ] {
+        std::fs::write(sf_dir.join(format!("static_file_{component}_0_499999")), b"finalized")?;
+        std::fs::write(sf_dir.join(format!("static_file_{component}_500000_999999")), b"tip")?;
+    }
+
+    // Skip range 0-499999 (simulates it already existing in remote storage)
+    let skip = HashSet::from([(0u64, 499_999u64)]);
+
+    let output = tempfile::tempdir()?;
+    let files = SnapshotGenerator::generate_manifest(
+        source.path(),
+        output.path(),
+        8453,
+        Some(1_000_000),
+        Some(500_000),
+        &skip,
+    )?;
+
+    let filenames: Vec<String> = files
+        .iter()
+        .filter_map(|f| f.file_name().map(|n| n.to_string_lossy().to_string()))
+        .collect();
+
+    // Skipped range: no archive produced
+    for component in [
+        "headers",
+        "transactions",
+        "transaction_senders",
+        "receipts",
+        "account_changesets",
+        "storage_changesets",
+    ] {
+        assert!(
+            !filenames.contains(&format!("{component}-0-499999.tar.zst")),
+            "{component} skipped range should not produce an archive"
+        );
+    }
+
+    // Tip range: archives produced
+    for component in [
+        "headers",
+        "transactions",
+        "transaction_senders",
+        "receipts",
+        "account_changesets",
+        "storage_changesets",
+    ] {
+        assert!(
+            filenames.contains(&format!("{component}-500000-999999.tar.zst")),
+            "{component} tip range should produce an archive"
+        );
+    }
+
+    // Always-upload: state + manifest
+    assert!(filenames.contains(&"state.tar.zst".to_string()), "state should always be produced");
+    assert!(filenames.contains(&"manifest.json".to_string()), "manifest should always be produced");
+
+    // Verify tip archive is a valid compressed file (not empty)
+    let tip_path = output.path().join("headers-500000-999999.tar.zst");
+    assert!(std::fs::metadata(&tip_path)?.len() > 0, "tip archive should not be empty");
+
+    Ok(())
+}
+
 #[tokio::test]
 #[serial]
 async fn always_upload_overwrites_existing_state_and_rocksdb() -> Result<()> {


### PR DESCRIPTION
- static files that have been finalized (i.e., past the block range) should not even need to be compressed 
- only upload the latest static file being written to and 1-2 extra static files 
- requires forking the `generate_manifest` command that Reth's `SnapshotManifestCommand` uses under the hood (attribution is credited properly). file for reference: https://github.com/paradigmxyz/reth/blob/420693521fccd1437071a15a4a54a3a98b5492cf/crates/cli/commands/src/download/manifest.rs
   - `generate_manifest` is modified to be storage-aware and compare remote files against local 
- added unit tests for the `generate_manifest` extended functionality and added e2e test to verify behaviour 
