### PR TITLE
perf(derive): Speed Up Derivation Pipeline

### DIFF
--- a/crates/consensus/derive/Cargo.toml
+++ b/crates/consensus/derive/Cargo.toml
@@ -58,6 +58,10 @@ name = "batch_queue"
 harness = false
 required-features = ["test-utils"]
 
+[[bench]]
+name = "derivation_pipeline"
+harness = false
+
 [features]
 default = []
 metrics = [ "base-metrics/metrics", "dep:metrics" ]

--- a/crates/consensus/derive/benches/derivation_pipeline.rs
+++ b/crates/consensus/derive/benches/derivation_pipeline.rs
@@ -1,0 +1,347 @@
+//! Derivation pipeline benchmarks.
+
+use std::fmt::{self, Display, Formatter};
+use std::hint::black_box;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use alloy_eips::BlockNumHash;
+use base_common_consensus::BaseBlock;
+use base_common_genesis::{HardForkConfig, RollupConfig, SystemConfig};
+use base_consensus_derive::{
+    BatchQueue, ChannelBank, FrameQueue, FrameQueueProvider, L2ChainProvider, NextBatchProvider,
+    NextFrameProvider, OriginAdvancer, OriginProvider, PipelineError, PipelineErrorKind,
+    PipelineResult, StageReset,
+};
+use base_protocol::{
+    Batch, BatchValidationProvider, BlockInfo, Channel, ChannelId, Frame, L2BlockInfo, SingleBatch,
+};
+use criterion::{BatchSize, Criterion, criterion_group, criterion_main};
+
+const FRAME_DATA_LEN: usize = 256;
+
+#[derive(Debug)]
+struct BenchFrameProvider {
+    origin: BlockInfo,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct BenchProviderError;
+
+impl Display for BenchProviderError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.write_str("bench provider error")
+    }
+}
+
+impl From<BenchProviderError> for PipelineErrorKind {
+    fn from(_: BenchProviderError) -> Self {
+        PipelineError::Provider("bench provider error".into()).temp()
+    }
+}
+
+#[derive(Debug, Default)]
+struct BenchBatchProvider {
+    origin: Option<BlockInfo>,
+}
+
+#[derive(Debug, Clone, Default)]
+struct BenchL2Provider;
+
+#[async_trait::async_trait]
+impl FrameQueueProvider for BenchFrameProvider {
+    type Item = Vec<u8>;
+
+    async fn next_data(&mut self) -> PipelineResult<Self::Item> {
+        unreachable!("prune benchmarks pre-populate the frame queue")
+    }
+}
+
+#[async_trait::async_trait]
+impl OriginAdvancer for BenchFrameProvider {
+    async fn advance_origin(&mut self) -> PipelineResult<()> {
+        Ok(())
+    }
+}
+
+#[async_trait::async_trait]
+impl NextFrameProvider for BenchFrameProvider {
+    async fn next_frame(&mut self) -> PipelineResult<Frame> {
+        unreachable!("channel-bank benchmarks call the stage directly")
+    }
+}
+
+impl OriginProvider for BenchFrameProvider {
+    fn origin(&self) -> Option<BlockInfo> {
+        Some(self.origin)
+    }
+}
+
+#[async_trait::async_trait]
+impl StageReset for BenchFrameProvider {
+    async fn reset(&mut self, _: BlockNumHash, _: SystemConfig) -> PipelineResult<()> {
+        Ok(())
+    }
+
+    async fn activate(&mut self) -> PipelineResult<()> {
+        Ok(())
+    }
+
+    async fn flush_channel(&mut self) -> PipelineResult<()> {
+        Ok(())
+    }
+}
+
+impl OriginProvider for BenchBatchProvider {
+    fn origin(&self) -> Option<BlockInfo> {
+        self.origin
+    }
+}
+
+#[async_trait::async_trait]
+impl OriginAdvancer for BenchBatchProvider {
+    async fn advance_origin(&mut self) -> PipelineResult<()> {
+        Ok(())
+    }
+}
+
+#[async_trait::async_trait]
+impl NextBatchProvider for BenchBatchProvider {
+    fn flush(&mut self) {}
+
+    fn span_buffer_size(&self) -> usize {
+        0
+    }
+
+    async fn next_batch(&mut self, _: L2BlockInfo, _: &[BlockInfo]) -> PipelineResult<Batch> {
+        Err(PipelineError::Eof.temp())
+    }
+}
+
+#[async_trait::async_trait]
+impl StageReset for BenchBatchProvider {
+    async fn reset(&mut self, _: BlockNumHash, _: SystemConfig) -> PipelineResult<()> {
+        Ok(())
+    }
+
+    async fn activate(&mut self) -> PipelineResult<()> {
+        Ok(())
+    }
+
+    async fn flush_channel(&mut self) -> PipelineResult<()> {
+        Ok(())
+    }
+}
+
+#[async_trait::async_trait]
+impl BatchValidationProvider for BenchL2Provider {
+    type Error = BenchProviderError;
+
+    async fn l2_block_info_by_number(&mut self, _: u64) -> Result<L2BlockInfo, Self::Error> {
+        Err(BenchProviderError)
+    }
+
+    async fn block_by_number(&mut self, _: u64) -> Result<BaseBlock, Self::Error> {
+        Err(BenchProviderError)
+    }
+}
+
+#[async_trait::async_trait]
+impl L2ChainProvider for BenchL2Provider {
+    type Error = BenchProviderError;
+
+    async fn system_config_by_number(
+        &mut self,
+        _: u64,
+        _: Arc<RollupConfig>,
+    ) -> Result<SystemConfig, <Self as L2ChainProvider>::Error> {
+        Err(BenchProviderError)
+    }
+}
+
+fn holocene_config() -> Arc<RollupConfig> {
+    Arc::new(RollupConfig {
+        hardforks: HardForkConfig { holocene_time: Some(0), ..Default::default() },
+        ..Default::default()
+    })
+}
+
+fn canyon_config() -> Arc<RollupConfig> {
+    Arc::new(RollupConfig {
+        hardforks: HardForkConfig { canyon_time: Some(0), ..Default::default() },
+        ..Default::default()
+    })
+}
+
+fn new_frame_queue(frames: Vec<Frame>) -> FrameQueue<BenchFrameProvider> {
+    let provider = BenchFrameProvider { origin: BlockInfo::default() };
+    let mut queue = FrameQueue::new(provider, holocene_config());
+    queue.queue.extend(frames);
+    queue
+}
+
+fn new_channel_bank(channel_count: u16) -> ChannelBank<BenchFrameProvider> {
+    let provider = BenchFrameProvider { origin: BlockInfo::default() };
+    let mut bank = ChannelBank::new(Arc::new(RollupConfig::default()), provider);
+    for seed in 0..channel_count {
+        let id = channel_id(seed);
+        let mut channel = Channel::new(id, BlockInfo::default());
+        channel.add_frame(new_frame(id, 0, false), BlockInfo::default()).unwrap();
+        bank.total_size += channel.size();
+        bank.channel_queue.push_back(id);
+        bank.channels.insert(id, channel);
+    }
+    bank
+}
+
+fn new_channel_bank_ready_last(channel_count: u16) -> ChannelBank<BenchFrameProvider> {
+    let provider = BenchFrameProvider { origin: BlockInfo::default() };
+    let mut bank = ChannelBank::new(canyon_config(), provider);
+    for seed in 0..channel_count {
+        let id = channel_id(seed);
+        let mut channel = Channel::new(id, BlockInfo::default());
+        channel
+            .add_frame(new_frame(id, 0, seed == channel_count - 1), BlockInfo::default())
+            .unwrap();
+        bank.total_size += channel.size();
+        bank.channel_queue.push_back(id);
+        bank.channels.insert(id, channel);
+    }
+    bank
+}
+
+fn new_batch_queue(span_count: u64) -> BatchQueue<BenchBatchProvider, BenchL2Provider> {
+    let prev = BenchBatchProvider { origin: Some(BlockInfo::default()) };
+    let mut queue = BatchQueue::new(Arc::new(RollupConfig::default()), prev, BenchL2Provider);
+    queue.next_spans =
+        (0..span_count).map(|timestamp| SingleBatch { timestamp, ..Default::default() }).collect();
+    queue
+}
+
+const fn channel_id(seed: u16) -> ChannelId {
+    let [first, second] = seed.to_be_bytes();
+    let mut id = [0; 16];
+    let mut i = 0;
+    while i < id.len() {
+        id[i] = if i % 2 == 0 { first } else { second };
+        i += 1;
+    }
+    id
+}
+
+fn new_frame(id: ChannelId, number: u16, is_last: bool) -> Frame {
+    Frame::new(id, number, vec![number as u8; FRAME_DATA_LEN], is_last)
+}
+
+fn valid_channel(frame_count: u16) -> Vec<Frame> {
+    let id = channel_id(1);
+    (0..frame_count).map(|number| new_frame(id, number, number == frame_count - 1)).collect()
+}
+
+fn alternating_incomplete_channels(channel_count: u16, frames_per_channel: u16) -> Vec<Frame> {
+    let mut frames = Vec::with_capacity(channel_count as usize * frames_per_channel as usize);
+    for channel in 0..channel_count {
+        for number in 0..frames_per_channel {
+            frames.push(new_frame(channel_id(channel), number, false));
+        }
+    }
+    frames
+}
+
+fn frame_queue_prune_benches(c: &mut Criterion) {
+    let mut group = c.benchmark_group("derive_frame_queue_prune");
+
+    group.bench_function("valid_512", |b| {
+        let frames = valid_channel(512);
+        b.iter_batched(
+            || new_frame_queue(frames.clone()),
+            |mut queue| queue.prune(BlockInfo::default()),
+            BatchSize::SmallInput,
+        );
+    });
+
+    group.bench_function("incomplete_channels_512", |b| {
+        let frames = alternating_incomplete_channels(64, 8);
+        b.iter_batched(
+            || new_frame_queue(frames.clone()),
+            |mut queue| queue.prune(BlockInfo::default()),
+            BatchSize::SmallInput,
+        );
+    });
+
+    group.finish();
+}
+
+fn channel_bank_benches(c: &mut Criterion) {
+    let mut group = c.benchmark_group("derive_channel_bank");
+
+    group.bench_function("prune_4096_channels_below_limit", |b| {
+        b.iter_custom(|iters| {
+            let mut bank = new_channel_bank(4096);
+            let start = Instant::now();
+            for _ in 0..iters {
+                black_box(bank.prune()).unwrap();
+            }
+            start.elapsed()
+        });
+    });
+
+    group.bench_function("ingest_frame_4096_channels", |b| {
+        b.iter_custom(|iters| {
+            let mut total = Duration::ZERO;
+            let mut remaining = iters;
+            while remaining > 0 {
+                let batch_iters = remaining.min(u64::from(u16::MAX - 1));
+                let mut bank = new_channel_bank(4096);
+                let id = channel_id(4095);
+
+                let start = Instant::now();
+                for number in 1..=batch_iters as u16 {
+                    black_box(bank.ingest_frame(black_box(new_frame(id, number, false)))).unwrap();
+                }
+                total += start.elapsed();
+                remaining -= batch_iters;
+            }
+            total
+        });
+    });
+
+    group.bench_function("read_ready_last_4096_channels", |b| {
+        b.iter_batched(
+            || new_channel_bank_ready_last(4096),
+            |mut bank| black_box(bank.read()).unwrap().unwrap(),
+            BatchSize::SmallInput,
+        );
+    });
+
+    group.finish();
+}
+
+fn batch_queue_benches(c: &mut Criterion) {
+    let mut group = c.benchmark_group("derive_batch_queue");
+
+    group.bench_function("pop_cached_span_batches_4096", |b| {
+        b.iter_custom(|iters| {
+            let mut total = Duration::ZERO;
+            let mut remaining = iters;
+            while remaining > 0 {
+                let batch_iters = remaining.min(4096);
+                let mut queue = new_batch_queue(batch_iters);
+                let parent = L2BlockInfo::default();
+
+                let start = Instant::now();
+                for _ in 0..batch_iters {
+                    black_box(queue.pop_next_batch(parent)).unwrap();
+                }
+                total += start.elapsed();
+                remaining -= batch_iters;
+            }
+            total
+        });
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, frame_queue_prune_benches, channel_bank_benches, batch_queue_benches);
+criterion_main!(benches);

--- a/crates/consensus/derive/src/stages/channel/channel_bank.rs
+++ b/crates/consensus/derive/src/stages/channel/channel_bank.rs
@@ -41,6 +41,8 @@ where
     pub channels: HashMap<ChannelId, Channel>,
     /// Channels in FIFO order.
     pub channel_queue: VecDeque<ChannelId>,
+    /// Cached sum of all channel sizes.
+    pub total_size: usize,
     /// The previous stage of the derivation pipeline.
     pub prev: P,
 }
@@ -51,29 +53,34 @@ where
 {
     /// Create a new [`ChannelBank`] stage.
     pub fn new(cfg: Arc<RollupConfig>, prev: P) -> Self {
-        Self { cfg, channels: HashMap::default(), channel_queue: VecDeque::new(), prev }
+        Self {
+            cfg,
+            channels: HashMap::default(),
+            channel_queue: VecDeque::new(),
+            total_size: 0,
+            prev,
+        }
     }
 
-    /// Returns the size of the channel bank by accumulating over all channels.
-    pub fn size(&self) -> usize {
-        self.channels.iter().fold(0, |acc, (_, c)| acc + c.size())
+    /// Returns the cached size of the channel bank.
+    pub const fn size(&self) -> usize {
+        self.total_size
     }
 
     /// Prunes the Channel bank, until it is below the max channel bank size.
     /// Prunes from the high-priority channel since it failed to be read.
     pub fn prune(&mut self) -> PipelineResult<()> {
-        let mut total_size = self.size();
         let origin = self.origin().ok_or(PipelineError::MissingOrigin.crit())?;
         let max_channel_bank_size = if self.cfg.is_fjord_active(origin.timestamp) {
             FJORD_MAX_CHANNEL_BANK_SIZE
         } else {
             MAX_CHANNEL_BANK_SIZE
         };
-        while total_size > max_channel_bank_size {
+        while self.total_size > max_channel_bank_size {
             let id =
                 self.channel_queue.pop_front().ok_or(PipelineError::ChannelProviderEmpty.crit())?;
             let channel = self.channels.remove(&id).ok_or(PipelineError::ChannelNotFound.crit())?;
-            total_size -= channel.size();
+            self.total_size = self.total_size.saturating_sub(channel.size());
         }
         Ok(())
     }
@@ -99,16 +106,24 @@ where
         {
             warn!(
                 target: "channel_bank",
-                "Channel (ID: {}) timed out", hex::encode(frame.id)
+                channel_id = %hex::encode(frame.id),
+                "channel timed out"
             );
             return Ok(());
         }
 
         // Ingest the frame. If it fails, ignore the frame.
         let frame_id = frame.id;
+        let size_before = current_channel.size();
         if current_channel.add_frame(frame, origin).is_err() {
             warn!(target: "channel_bank", frame_id = ?frame_id, "Failed to add frame to channel");
             return Ok(());
+        }
+        let size_after = current_channel.size();
+        if size_after >= size_before {
+            self.total_size = self.total_size.saturating_add(size_after - size_before);
+        } else {
+            self.total_size = self.total_size.saturating_sub(size_before - size_after);
         }
 
         self.prune()
@@ -134,9 +149,12 @@ where
         {
             warn!(
                 target: "channel_bank",
-                "Channel (ID: {}) timed out", hex::encode(first)
+                channel_id = %hex::encode(first),
+                "channel timed out"
             );
-            self.channels.remove(&first);
+            if let Some(channel) = self.channels.remove(&first) {
+                self.total_size = self.total_size.saturating_sub(channel.size());
+            }
             self.channel_queue.pop_front();
             return Ok(None);
         }
@@ -151,9 +169,19 @@ where
             return self.try_read_channel_at_index(0).map(Some);
         }
 
-        let channel_data =
-            (0..self.channel_queue.len()).find_map(|i| self.try_read_channel_at_index(i).ok());
-        channel_data.map_or_else(|| Err(PipelineError::Eof.temp()), |data| Ok(Some(data)))
+        let channel_timeout = self.cfg.channel_timeout(origin.timestamp);
+        let ready_index = self.channel_queue.iter().position(|id| {
+            self.channels.get(id).is_some_and(|channel| {
+                let timed_out = channel.open_block_number() + channel_timeout < origin.number;
+                !timed_out && channel.is_ready()
+            })
+        });
+
+        let Some(index) = ready_index else {
+            return Err(PipelineError::Eof.temp());
+        };
+
+        self.read_channel_at_index(index).map(Some)
     }
 
     /// Attempts to read the channel at the specified index. If the channel is not ready or timed
@@ -171,8 +199,18 @@ where
             return Err(PipelineError::Eof.temp());
         }
 
+        self.read_channel_at_index(index)
+    }
+
+    /// Reads and removes the channel at the specified index.
+    fn read_channel_at_index(&mut self, index: usize) -> PipelineResult<Bytes> {
+        let channel_id = self.channel_queue[index];
+        let channel =
+            self.channels.get(&channel_id).ok_or(PipelineError::ChannelProviderEmpty.crit())?;
+        let channel_size = channel.size();
         let frame_data = channel.frame_data();
         self.channels.remove(&channel_id);
+        self.total_size = self.total_size.saturating_sub(channel_size);
         self.channel_queue.remove(index);
 
         frame_data.ok_or(PipelineError::ChannelProviderEmpty.crit())
@@ -241,6 +279,7 @@ where
         self.prev.reset(l1_origin, system_config).await?;
         self.channels.clear();
         self.channel_queue = VecDeque::with_capacity(10);
+        self.total_size = 0;
         Ok(())
     }
 
@@ -248,6 +287,7 @@ where
         self.prev.activate().await?;
         self.channels.clear();
         self.channel_queue = VecDeque::with_capacity(10);
+        self.total_size = 0;
         Ok(())
     }
 
@@ -255,6 +295,7 @@ where
         self.prev.flush_channel().await?;
         self.channels.clear();
         self.channel_queue = VecDeque::with_capacity(10);
+        self.total_size = 0;
         Ok(())
     }
 }
@@ -332,12 +373,14 @@ mod tests {
             )
             .unwrap();
         assert!(channel.is_ready());
+        channel_bank.total_size = channel.size();
         channel_bank.channels.insert([0xFF; 16], channel);
         let frame_data = channel_bank.try_read_channel_at_index(0).unwrap();
         assert_eq!(
             frame_data,
             alloy_primitives::bytes!("736576656e5f5f736576656e5f5f736576656e5f5f")
         );
+        assert_eq!(channel_bank.size(), 0);
     }
 
     #[test]
@@ -367,12 +410,14 @@ mod tests {
             )
             .unwrap();
         assert!(channel.is_ready());
+        channel_bank.total_size = channel.size();
         channel_bank.channels.insert([0xFF; 16], channel);
         let frame_data = channel_bank.read().unwrap();
         assert_eq!(
             frame_data,
             Some(alloy_primitives::bytes!("736576656e5f5f736576656e5f5f736576656e5f5f"))
         );
+        assert_eq!(channel_bank.size(), 0);
     }
 
     #[test]
@@ -405,12 +450,14 @@ mod tests {
             )
             .unwrap();
         assert!(channel.is_ready());
+        channel_bank.total_size = channel.size();
         channel_bank.channels.insert([0xFF; 16], channel);
         let frame_data = channel_bank.read().unwrap();
         assert_eq!(
             frame_data,
             Some(alloy_primitives::bytes!("736576656e5f5f736576656e5f5f736576656e5f5f"))
         );
+        assert_eq!(channel_bank.size(), 0);
     }
 
     #[test]
@@ -431,10 +478,12 @@ mod tests {
         let mut channel_bank = ChannelBank::new(cfg, mock);
         channel_bank.channels.insert([0xFF; 16], Channel::default());
         channel_bank.channel_queue.push_back([0xFF; 16]);
+        channel_bank.total_size = 1;
         assert!(!channel_bank.prev.reset);
         channel_bank.reset(BlockNumHash::default(), SystemConfig::default()).await.unwrap();
         assert_eq!(channel_bank.channels.len(), 0);
         assert_eq!(channel_bank.channel_queue.len(), 0);
+        assert_eq!(channel_bank.size(), 0);
         assert!(channel_bank.prev.reset);
     }
 
@@ -447,10 +496,12 @@ mod tests {
         let mut channel_bank = ChannelBank::new(cfg, mock);
         channel_bank.channels.insert([0xFF; 16], Channel::default());
         channel_bank.channel_queue.push_back([0xFF; 16]);
+        channel_bank.total_size = 1;
         assert!(!channel_bank.prev.reset);
         channel_bank.activate().await.unwrap();
         assert_eq!(channel_bank.channels.len(), 0, "Activation must clear channels");
         assert_eq!(channel_bank.channel_queue.len(), 0, "Activation must clear channel queue");
+        assert_eq!(channel_bank.size(), 0, "Activation must clear cached channel size");
         assert!(channel_bank.prev.reset, "Activation must propagate to prev stage");
     }
 
@@ -463,10 +514,12 @@ mod tests {
         let mut channel_bank = ChannelBank::new(cfg, mock);
         channel_bank.channels.insert([0xFF; 16], Channel::default());
         channel_bank.channel_queue.push_back([0xFF; 16]);
+        channel_bank.total_size = 1;
         assert!(!channel_bank.prev.reset);
         channel_bank.flush_channel().await.unwrap();
         assert_eq!(channel_bank.channels.len(), 0, "FlushChannel must clear channels");
         assert_eq!(channel_bank.channel_queue.len(), 0, "FlushChannel must clear channel queue");
+        assert_eq!(channel_bank.size(), 0, "FlushChannel must clear cached channel size");
         assert!(channel_bank.prev.reset, "FlushChannel must propagate to prev stage");
     }
 


### PR DESCRIPTION
## Summary

This adds focused Criterion coverage for the derivation pipeline and speeds up hot paths in ChannelBank and BatchQueue. ChannelBank now tracks total buffered size incrementally, avoids repeated error construction while scanning for ready channels, and keeps its cached size consistent across resets and reads. BatchQueue now uses a VecDeque for cached span batches so popping the next derived batch no longer shifts the whole vector.