### PR TITLE
refactor(cli): Reuse Shared Rpc Flags

### DIFF
--- a/bin/base/README.md
+++ b/bin/base/README.md
@@ -1,15 +1,18 @@
 # `base`
 
-Minimal scaffolding for the unified Base node binary.
+Unified Base node binary.
 
-The current implementation only does four things:
+## `base rpc`
 
-- parses the public `base` CLI surface for `--chain` and `rpc`
-- initializes workspace-standard logging
-- initializes the Prometheus recorder when metrics are enabled
-- logs `Hello, I'm running this chain` with the resolved chain config
+`base rpc` starts a validator-oriented node by launching an embedded execution node and an embedded
+consensus node in the same process. The execution node exposes the Engine API over auth IPC, and the
+consensus node connects to that IPC endpoint internally.
 
-Supported CLI forms:
+The execution CLI surface is shared with the standalone execution binaries through
+`base-execution-cli`. `base rpc` intentionally filters out flags for roles it does not run, including
+sequencer, builder, conductor, metering, and transaction-forwarding options.
+
+Supported forms:
 
 ```text
 base rpc
@@ -20,10 +23,18 @@ base --chain ./chain.toml rpc
 base -c ./chain.toml rpc
 ```
 
-Chain selection currently supports:
+The command also accepts an execution chain override when the root `--chain` selection is used only
+for consensus chain resolution:
+
+```text
+base rpc --execution-chain dev
+```
+
+## Chain Selection
+
+Chain selection supports:
 
 - built-in names: `mainnet`, `sepolia`, `zeronet`
-- TOML files with optional fields:
 - TOML files for custom chains:
 
 ```toml
@@ -31,3 +42,5 @@ name = "custom-chain"
 l2_chain_id = 84532
 l1_chain_id = 11155111
 ```
+
+TOML values can be overridden with environment variables using the `BASE_CHAIN_` prefix.

--- a/crates/execution/cli/src/standard_node.rs
+++ b/crates/execution/cli/src/standard_node.rs
@@ -19,39 +19,9 @@ use url::Url;
 #[derive(Debug, Clone, PartialEq, Eq, clap::Args)]
 #[command(next_help_heading = "Rollup")]
 pub struct StandardNodeArgs {
-    /// Rollup arguments.
+    /// Shared execution node arguments.
     #[command(flatten)]
-    pub rollup_args: RollupArgs,
-
-    /// A URL pointing to a secure websocket subscription that streams out flashblocks.
-    ///
-    /// If given, the flashblocks are received to build pending block. All request with "pending"
-    /// block tag will use the pending state based on flashblocks.
-    #[arg(long, alias = "websocket-url")]
-    pub flashblocks_url: Option<Url>,
-
-    /// The max pending blocks depth.
-    #[arg(
-        long = "max-pending-blocks-depth",
-        value_name = "MAX_PENDING_BLOCKS_DEPTH",
-        default_value = "3"
-    )]
-    pub max_pending_blocks_depth: u64,
-
-    /// Enable cached execution via the flashblocks-aware engine validator.
-    #[arg(long = "flashblocks.cached-execution", requires = "flashblocks_url")]
-    pub flashblocks_cached_execution: bool,
-
-    /// Enable transaction tracing for mempool-to-block timing analysis
-    #[arg(long = "enable-transaction-tracing", value_name = "ENABLE_TRANSACTION_TRACING")]
-    pub enable_transaction_tracing: bool,
-
-    /// Enable `info` logs for transaction tracing
-    #[arg(
-        long = "enable-transaction-tracing-logs",
-        value_name = "ENABLE_TRANSACTION_TRACING_LOGS"
-    )]
-    pub enable_transaction_tracing_logs: bool,
+    pub rpc: RpcStandardNodeArgs,
 
     /// Enable metering RPC for transaction bundle simulation
     #[arg(long = "enable-metering", value_name = "ENABLE_METERING")]
@@ -181,12 +151,7 @@ pub struct RpcStandardNodeArgs {
 impl From<RpcStandardNodeArgs> for StandardNodeArgs {
     fn from(args: RpcStandardNodeArgs) -> Self {
         Self {
-            rollup_args: args.rollup_args,
-            flashblocks_url: args.flashblocks_url,
-            max_pending_blocks_depth: args.max_pending_blocks_depth,
-            flashblocks_cached_execution: args.flashblocks_cached_execution,
-            enable_transaction_tracing: args.enable_transaction_tracing,
-            enable_transaction_tracing_logs: args.enable_transaction_tracing_logs,
+            rpc: args,
             enable_metering: false,
             metering_gas_limit: None,
             metering_execution_time_us: None,
@@ -205,9 +170,9 @@ impl From<RpcStandardNodeArgs> for StandardNodeArgs {
 
 impl From<&StandardNodeArgs> for Option<FlashblocksConfig> {
     fn from(args: &StandardNodeArgs) -> Self {
-        args.flashblocks_url.clone().map(|url| {
-            let mut config = FlashblocksConfig::new(url, args.max_pending_blocks_depth);
-            config.cached_execution = args.flashblocks_cached_execution;
+        args.rpc.flashblocks_url.clone().map(|url| {
+            let mut config = FlashblocksConfig::new(url, args.rpc.max_pending_blocks_depth);
+            config.cached_execution = args.rpc.flashblocks_cached_execution;
             config
         })
     }
@@ -233,18 +198,18 @@ pub struct StandardBaseRethNode;
 impl StandardBaseRethNode {
     /// Builds a runner with the standard Base execution-node extensions installed.
     pub fn runner(args: StandardNodeArgs) -> eyre::Result<BaseNodeRunner> {
-        let mut runner = BaseNodeRunner::new(args.rollup_args.clone());
+        let mut runner = BaseNodeRunner::new(args.rpc.rollup_args.clone());
 
         // Create flashblocks config first so we can share its state with metering.
         let flashblocks_config: Option<FlashblocksConfig> = (&args).into();
 
         // Feature extensions (FlashblocksExtension must be last - uses replace_configured).
         runner.install_ext::<TxPoolRpcExtension>(TxPoolRpcConfig {
-            sequencer_rpc: args.rollup_args.sequencer.clone(),
+            sequencer_rpc: args.rpc.rollup_args.sequencer.clone(),
         });
         runner.install_ext::<TxPoolExtension>(TxpoolConfig {
-            tracing_enabled: args.enable_transaction_tracing,
-            tracing_logs_enabled: args.enable_transaction_tracing_logs,
+            tracing_enabled: args.rpc.enable_transaction_tracing,
+            tracing_logs_enabled: args.rpc.enable_transaction_tracing_logs,
             flashblocks_config: flashblocks_config.clone(),
         });
 
@@ -278,7 +243,7 @@ impl StandardBaseRethNode {
         runner.install_ext::<BundleExtension>(());
         runner.install_ext::<TxForwardingExtension>((&args).into());
         runner.install_ext::<FlashblocksExtension>(flashblocks_config);
-        runner.install_ext::<ProofsHistoryExtension>(args.rollup_args);
+        runner.install_ext::<ProofsHistoryExtension>(args.rpc.rollup_args);
 
         Ok(runner)
     }

--- a/etc/docker/docker-compose.ha.yml
+++ b/etc/docker/docker-compose.ha.yml
@@ -71,8 +71,6 @@ services:
       - /genesis/el/chain-config.json
       - --l1-slot-duration-override
       - "4"
-      - --rpc.addr
-      - "0.0.0.0"
       - --rpc.port
       - "${L2_BUILDER_CL_RPC_PORT}"
       - --rpc.enable-admin
@@ -87,8 +85,6 @@ services:
       - --p2p.bootnodes-file
       - "${L2_CL_BOOTNODE_ENR_PATH}"
       - --metrics.enabled
-      - --metrics.addr
-      - "0.0.0.0"
       - --metrics.port
       - "${L2_BUILDER_CL_METRICS_PORT}"
       - --mode
@@ -236,8 +232,6 @@ services:
       - /genesis/el/chain-config.json
       - --l1-slot-duration-override
       - "4"
-      - --rpc.addr
-      - "0.0.0.0"
       - --rpc.port
       - "${L2_SEQ1_CL_RPC_PORT}"
       - --rpc.enable-admin
@@ -250,8 +244,6 @@ services:
       - --p2p.priv.path
       - /genesis/l2/sequencer-1-p2p-key.txt
       - --metrics.enabled
-      - --metrics.addr
-      - "0.0.0.0"
       - --metrics.port
       - "${L2_SEQ1_CL_METRICS_PORT}"
       - --mode
@@ -378,8 +370,6 @@ services:
       - /genesis/el/chain-config.json
       - --l1-slot-duration-override
       - "4"
-      - --rpc.addr
-      - "0.0.0.0"
       - --rpc.port
       - "${L2_SEQ2_CL_RPC_PORT}"
       - --rpc.enable-admin
@@ -392,8 +382,6 @@ services:
       - --p2p.priv.path
       - /genesis/l2/sequencer-2-p2p-key.txt
       - --metrics.enabled
-      - --metrics.addr
-      - "0.0.0.0"
       - --metrics.port
       - "${L2_SEQ2_CL_METRICS_PORT}"
       - --mode

--- a/etc/docker/docker-compose.yml
+++ b/etc/docker/docker-compose.yml
@@ -226,8 +226,6 @@ services:
       - ${L2_CHAIN_ID}
       - --l2-config-file
       - /genesis/l2/rollup.json
-      - --p2p.listen.ip
-      - 0.0.0.0
       - --p2p.listen.tcp
       - "${L2_CL_BOOTNODE_P2P_PORT}"
       - --p2p.listen.udp
@@ -377,8 +375,6 @@ services:
       - /genesis/el/chain-config.json
       - --l1-slot-duration-override
       - "4"
-      - --rpc.addr
-      - "0.0.0.0"
       - --rpc.port
       - "${L2_BUILDER_CL_RPC_PORT}"
       - --rpc.enable-admin
@@ -393,8 +389,6 @@ services:
       - --p2p.bootnodes-file
       - "${L2_CL_BOOTNODE_ENR_PATH}"
       - --metrics.enabled
-      - --metrics.addr
-      - "0.0.0.0"
       - --metrics.port
       - "${L2_BUILDER_CL_METRICS_PORT}"
       - --mode
@@ -576,8 +570,6 @@ services:
       - /genesis/el/chain-config.json
       - --l1-slot-duration-override
       - "4"
-      - --rpc.addr
-      - "0.0.0.0"
       - --rpc.port
       - "${L2_CLIENT_CL_RPC_PORT}"
       - --p2p.listen.tcp
@@ -587,8 +579,6 @@ services:
       - --p2p.advertise.ip
       - base-client-cl
       - --metrics.enabled
-      - --metrics.addr
-      - "0.0.0.0"
       - --metrics.port
       - "${L2_CLIENT_CL_METRICS_PORT}"
       - --p2p.bootnodes-file
@@ -678,8 +668,6 @@ services:
       - /genesis/el/chain-config.json
       - --l1-slot-duration-override
       - "4"
-      - --rpc.addr
-      - "0.0.0.0"
       - --rpc.port
       - "${L2_UNIFIED_CL_RPC_PORT}"
       - --rpc.enable-admin


### PR DESCRIPTION
## Summary

This limits the unified base rpc command to validator-only execution flags while reusing the shared execution CLI argument structs. The base rpc command hides and rejects sequencer-only and builder-only flags at the unified binary boundary instead of maintaining a duplicated validator rollup argument set. It also trims default-valued local devnet consensus flags so the compose config only carries values that actually differ from defaults.