### PR TITLE
refactor(load-tests): parameterize network in Justfile targets

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -32,7 +32,7 @@ alias ldc := load-test-continuous
 default:
     @just --list
 
-# Load test devnet in continuous mode (Ctrl-C to stop)
+# Load test a network in continuous mode (Ctrl-C to stop)
 load-test-continuous network='devnet':
     just load-test continuous {{network}}
 

--- a/Justfile
+++ b/Justfile
@@ -26,15 +26,15 @@ alias c := clean
 alias h := hack
 alias wt := watch-test
 alias wc := watch-check
-alias ldc := load-test-devnet-continuous
+alias ldc := load-test-continuous
 
 # Default to display help menu
 default:
     @just --list
 
 # Load test devnet in continuous mode (Ctrl-C to stop)
-load-test-devnet-continuous:
-    just load-test devnet-continuous
+load-test-continuous network='devnet':
+    just load-test continuous {{network}}
 
 # Runs the specs docs locally
 specs:

--- a/crates/infra/load-tests/Justfile
+++ b/crates/infra/load-tests/Justfile
@@ -1,11 +1,12 @@
 # Load test runner - transaction submission for network load testing
 #
 # Usage:
-#   just load-test devnet                                - Load test local devnet (uses Anvil Account #1)
-#   just load-test devnet --continuous                   - Load test devnet indefinitely (Ctrl-C to stop)
-#   just load-test devnet-continuous (jldc)              - Alias: devnet continuous mode
-#   FUNDER_KEY=0x... just load-test sepolia              - Load test sepolia
-#   FUNDER_KEY=0x... just load-test recover sepolia      - Recover funds from sepolia test accounts
+#   just load-test run                                   - Load test devnet (uses Anvil Account #1)
+#   just load-test run sepolia                           - Load test sepolia (requires FUNDER_KEY)
+#   just load-test continuous                            - Load test devnet indefinitely (Ctrl-C to stop)
+#   just load-test continuous sepolia                    - Load test sepolia indefinitely
+#   just load-test recover                               - Recover funds from devnet test accounts
+#   just load-test recover sepolia                       - Recover funds from sepolia test accounts
 
 set positional-arguments := true
 set working-directory := '../../..'
@@ -14,19 +15,18 @@ set working-directory := '../../..'
 default:
     @just --justfile {{source_file()}} --list
 
-# Run load test against devnet (local) - uses Anvil Account #1
-devnet *args:
-    FUNDER_KEY=0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d cargo run -p base-load-tester-bin --bin base-load-tester -- crates/infra/load-tests/examples/devnet.yaml {{args}}
+# Run load test against a network (devnet uses Anvil Account #1 by default)
+run network='devnet' *args:
+    #!/usr/bin/env bash
+    if [ -z "${FUNDER_KEY:-}" ] && [ "{{network}}" = "devnet" ]; then
+        export FUNDER_KEY=0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d
+    fi
+    cargo run -p base-load-tester-bin --bin base-load-tester -- crates/infra/load-tests/examples/{{network}}.yaml {{args}}
 
-# Run load test against devnet indefinitely (Ctrl-C to stop)
-devnet-continuous:
-    FUNDER_KEY=0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d cargo run -p base-load-tester-bin --bin base-load-tester -- crates/infra/load-tests/examples/devnet.yaml --continuous
+# Run load test against a network indefinitely (Ctrl-C to stop)
+continuous network='devnet':
+    just --justfile {{source_file()}} run {{network}} --continuous
 
-# Run load test against sepolia network (requires FUNDER_KEY env var)
-sepolia *args:
-    cargo run -p base-load-tester-bin --bin base-load-tester -- crates/infra/load-tests/examples/sepolia.yaml {{args}}
-
-# Recover/drain funds from load test accounts back to funder (requires FUNDER_KEY env var)
-# Usage: just load-test recover <network>  (e.g., just load-test recover sepolia)
-recover network:
-    cargo run -p base-load-tester-bin --bin base-load-tester -- crates/infra/load-tests/examples/{{network}}.yaml --drain-only
+# Recover/drain funds from load test accounts back to funder
+recover network='devnet':
+    just --justfile {{source_file()}} run {{network}} --drain-only

--- a/crates/infra/load-tests/README.md
+++ b/crates/infra/load-tests/README.md
@@ -19,10 +19,10 @@ Load testing and benchmarking framework for Base infrastructure.
 
 ```bash
 # Run load test against local devnet (uses Anvil Account #1)
-just load-test devnet
+just load-test run
 
 # Run load test against sepolia (requires funded key)
-FUNDER_KEY=0x... just load-test sepolia
+FUNDER_KEY=0x... just load-test run sepolia
 ```
 
 Or run directly with cargo:


### PR DESCRIPTION
Replace network-specific `devnet` and `sepolia` targets with a single `run network='devnet'` recipe; add `continuous` and `recover` wrappers that delegate to it.
Auto-sets FUNDER_KEY for devnet.
Update root Justfile alias and README Quick Start examples to match.