### PR TITLE
refactor(common): Add Base Precompile Installer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3399,6 +3399,7 @@ dependencies = [
 name = "base-common-precompiles"
 version = "0.0.0"
 dependencies = [
+ "alloy-evm",
  "base-common-chains",
  "revm",
 ]

--- a/crates/common/evm/src/factory.rs
+++ b/crates/common/evm/src/factory.rs
@@ -7,15 +7,14 @@ use revm::{
 };
 
 use crate::{
-    BaseContext, BaseEvm, BaseHaltReason, BasePrecompiles, BaseSpecId, BaseTransaction,
+    BaseContext, BaseEvm, BaseHaltReason, BasePrecompileInstaller, BaseSpecId, BaseTransaction,
     BaseTransactionError, Builder, DefaultBase,
 };
 
 /// Factory that produces [`BaseEvm`] instances backed by a [`PrecompilesMap`].
 ///
-/// [`BasePrecompiles`] are eagerly flattened into a [`PrecompilesMap`] on construction
-/// so that precompile dispatch is a single hash-map lookup rather than a spec-aware
-/// branch on every call.
+/// Base precompiles are eagerly flattened into a [`PrecompilesMap`] on construction so that
+/// precompile dispatch is a single hash-map lookup rather than a spec-aware branch on every call.
 #[derive(Debug, Default, Clone, Copy)]
 #[non_exhaustive]
 pub struct BaseEvmFactory;
@@ -43,9 +42,7 @@ impl EvmFactory for BaseEvmFactory {
             .with_cfg(input.cfg_env)
             .build_base()
             .with_inspector(NoOpInspector {})
-            .with_precompiles(PrecompilesMap::from_static(
-                BasePrecompiles::new_with_spec(spec_id).precompiles(),
-            ))
+            .with_precompiles(BasePrecompileInstaller::new(spec_id).install())
     }
 
     fn create_evm_with_inspector<DB: Database, I: Inspector<Self::Context<DB>>>(
@@ -60,8 +57,6 @@ impl EvmFactory for BaseEvmFactory {
             .with_block(input.block_env)
             .with_cfg(input.cfg_env)
             .build_with_inspector(inspector)
-            .with_precompiles(PrecompilesMap::from_static(
-                BasePrecompiles::new_with_spec(spec_id).precompiles(),
-            ))
+            .with_precompiles(BasePrecompileInstaller::new(spec_id).install())
     }
 }

--- a/crates/common/evm/src/lib.rs
+++ b/crates/common/evm/src/lib.rs
@@ -26,7 +26,7 @@ mod handler;
 pub use handler::{BaseHandler, IsTxError};
 
 mod precompiles;
-pub use precompiles::BasePrecompiles;
+pub use precompiles::{BasePrecompileInstaller, BasePrecompiles};
 
 mod api;
 pub use api::{BaseContext, BaseContextTr, BaseError, Builder, DefaultBase};

--- a/crates/common/evm/src/precompiles.rs
+++ b/crates/common/evm/src/precompiles.rs
@@ -2,6 +2,9 @@
 
 use crate::BaseSpecId;
 
+/// Base precompile installer for the Base EVM spec.
+pub type BasePrecompileInstaller = base_common_precompiles::BasePrecompileInstaller<BaseSpecId>;
+
 /// Base precompile provider for the Base EVM spec.
 pub type BasePrecompiles = base_common_precompiles::BasePrecompiles<BaseSpecId>;
 

--- a/crates/common/precompiles/Cargo.toml
+++ b/crates/common/precompiles/Cargo.toml
@@ -13,6 +13,9 @@ exclude.workspace = true
 workspace = true
 
 [dependencies]
+# alloy
+alloy-evm.workspace = true
+
 # base
 base-common-chains.workspace = true
 
@@ -21,7 +24,7 @@ revm.workspace = true
 
 [features]
 default = [ "blst", "c-kzg", "portable", "secp256k1", "std" ]
-std = [ "base-common-chains/std", "revm/std" ]
+std = [ "alloy-evm/std", "base-common-chains/std", "revm/std" ]
 bn = [ "revm/bn" ]
 blst = [ "revm/blst" ]
 c-kzg = [ "revm/c-kzg" ]

--- a/crates/common/precompiles/src/installer.rs
+++ b/crates/common/precompiles/src/installer.rs
@@ -1,0 +1,62 @@
+use alloy_evm::precompiles::PrecompilesMap;
+use base_common_chains::BaseUpgrade;
+
+use crate::{BasePrecompileSpec, BasePrecompiles};
+
+/// Installs the full Base precompile set for a given spec.
+#[derive(Debug, Clone, Copy)]
+pub struct BasePrecompileInstaller<S = BaseUpgrade> {
+    /// Spec used to select the Base precompile set.
+    spec: S,
+}
+
+impl<S: BasePrecompileSpec> BasePrecompileInstaller<S> {
+    /// Creates a new installer for the given spec.
+    pub const fn new(spec: S) -> Self {
+        Self { spec }
+    }
+
+    /// Returns the spec used by this installer.
+    pub const fn spec(&self) -> S {
+        self.spec
+    }
+
+    /// Builds a [`PrecompilesMap`] with all Base precompiles installed.
+    pub fn install(self) -> PrecompilesMap {
+        let mut precompiles =
+            PrecompilesMap::from_static(BasePrecompiles::new_with_spec(self.spec).precompiles());
+        self.install_into(&mut precompiles);
+        precompiles
+    }
+
+    /// Installs Base-specific dynamic precompiles into an existing [`PrecompilesMap`].
+    pub fn install_into(self, _precompiles: &mut PrecompilesMap) {}
+}
+
+impl<S: BasePrecompileSpec> Default for BasePrecompileInstaller<S> {
+    fn default() -> Self {
+        Self::new(S::default_precompile_spec())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use revm::precompile::{bn254, secp256r1};
+
+    use super::*;
+
+    #[test]
+    fn installer_preserves_base_precompile_set() {
+        let precompiles = BasePrecompileInstaller::new(BaseUpgrade::Jovian).install();
+
+        assert!(precompiles.get(&bn254::pair::ADDRESS).is_some());
+        assert!(precompiles.get(secp256r1::P256VERIFY.address()).is_some());
+    }
+
+    #[test]
+    fn default_installer_uses_default_precompile_spec() {
+        let installer = BasePrecompileInstaller::<BaseUpgrade>::default();
+
+        assert_eq!(installer.spec(), BaseUpgrade::LATEST);
+    }
+}

--- a/crates/common/precompiles/src/installer.rs
+++ b/crates/common/precompiles/src/installer.rs
@@ -30,7 +30,7 @@ impl<S: BasePrecompileSpec> BasePrecompileInstaller<S> {
     }
 
     /// Installs Base-specific dynamic precompiles into an existing [`PrecompilesMap`].
-    pub fn install_into(self, _precompiles: &mut PrecompilesMap) {}
+    pub const fn install_into(self, _precompiles: &mut PrecompilesMap) {}
 }
 
 impl<S: BasePrecompileSpec> Default for BasePrecompileInstaller<S> {

--- a/crates/common/precompiles/src/lib.rs
+++ b/crates/common/precompiles/src/lib.rs
@@ -8,6 +8,9 @@ extern crate alloc;
 mod provider;
 pub use provider::BasePrecompiles;
 
+mod installer;
+pub use installer::BasePrecompileInstaller;
+
 mod spec;
 pub use spec::BasePrecompileSpec;
 


### PR DESCRIPTION
## Summary

Adds a Base precompile installer that builds the full precompile map for a selected Base spec. The EVM factory now uses the installer in both construction paths, giving future Base-native precompile registrations a single extension point without changing the active precompile set.