### PR TITLE
fix(flashblocks): fix unwrap panic and u64 underflow in build_pending_state

### DIFF
--- a/crates/execution/flashblocks/src/processor.rs
+++ b/crates/execution/flashblocks/src/processor.rs
@@ -356,8 +356,11 @@ where
                 .push(flashblock.clone());
         }
 
-        let earliest_block_number = flashblocks_per_block.keys().min().unwrap();
-        let canonical_block = earliest_block_number - 1;
+        let earliest_block_number = match flashblocks_per_block.keys().min() {
+            Some(n) => *n,
+            None => return Ok(None),
+        };
+        let canonical_block = earliest_block_number.saturating_sub(1);
         let mut last_block_header = self
             .client
             .header_by_number(canonical_block)


### PR DESCRIPTION
Fixes #2669

## Problem
- `unwrap()` panic on non-JSON-RPC errors
- u64 underflow in build_pending_state

## Fix
- Replaced unwrap() with safe fallback
- Fixed u64 underflow with saturating arithmetic

Signed commits with GPG.