### PR TITLE
fix(mempool-rebroadcaster): replace unwrap() with safe fallback for non-JSON-RPC errors

### DIFF
--- a/crates/infra/mempool-rebroadcaster/src/rebroadcaster.rs
+++ b/crates/infra/mempool-rebroadcaster/src/rebroadcaster.rs
@@ -112,7 +112,7 @@ impl Rebroadcaster {
                 .await;
 
             if let Err(e) = result {
-                let err_msg = e.as_error_resp().unwrap().message.to_string();
+                let err_msg = e.as_error_resp().map(|r| r.message.to_string()).unwrap_or_else(|| e.to_string());
                 if !IGNORED_ERRORS.contains(&err_msg.as_str()) {
                     output.unexpected_failed_geth_to_reth += 1;
                     error!(
@@ -138,7 +138,7 @@ impl Rebroadcaster {
                 .await;
 
             if let Err(e) = result {
-                let err_msg = e.as_error_resp().unwrap().message.to_string();
+                let err_msg = e.as_error_resp().map(|r| r.message.to_string()).unwrap_or_else(|| e.to_string());
                 if !IGNORED_ERRORS.contains(&err_msg.as_str()) {
                     output.unexpected_failed_reth_to_geth += 1;
                     error!(


### PR DESCRIPTION
Fixes #2616

## Problem
`as_error_resp()` returns `Option<&ErrorPayload>` and returns `None` for non-JSON-RPC errors (TCP resets, timeouts, HTTP 5xx). The unconditional `.unwrap()` panics and crashes the rebroadcaster process on any transient network error inside the hot rebroadcast loop.

## Fix
Replaced both occurrences (lines 115 and 141) with safe fallback:
```rust
let err_msg = e.as_error_resp()
    .map(|r| r.message.to_string())
    .unwrap_or_else(|| e.to_string());
```

This preserves the existing `IGNORED_ERRORS` filtering logic while ensuring the service survives transport-level errors.