### PR TITLE
feat(cli): Add Unified Bootnode Command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2739,6 +2739,7 @@ dependencies = [
  "serde",
  "tokio",
  "tokio-util",
+ "tracing",
  "url",
 ]
 

--- a/bin/base/Cargo.toml
+++ b/bin/base/Cargo.toml
@@ -36,6 +36,7 @@ clap = { workspace = true, features = ["env"] }
 url.workspace = true
 eyre.workspace = true
 tokio.workspace = true
+tracing.workspace = true
 tokio-util.workspace = true
 serde = { workspace = true, features = ["derive"] }
 figment = { workspace = true, features = ["env", "toml"] }

--- a/bin/base/src/cli.rs
+++ b/bin/base/src/cli.rs
@@ -2,8 +2,10 @@ use base_cli_utils::{LogConfig, MetricsConfig};
 use clap::Parser;
 use eyre::WrapErr;
 
-use crate::commands::BaseCommand;
-use crate::config::{ChainArg, ChainResolver};
+use crate::{
+    commands::BaseCommand,
+    config::{ChainArg, ChainResolver},
+};
 
 base_cli_utils::define_log_args!("BASE_NODE");
 base_cli_utils::define_metrics_args!("BASE_NODE", 9090);

--- a/bin/base/src/cli.rs
+++ b/bin/base/src/cli.rs
@@ -1,18 +1,9 @@
-use std::{path::Path, sync::Arc};
-
 use base_cli_utils::{LogConfig, MetricsConfig};
-use base_consensus_cli::{
-    ConsensusNodeArgs, ConsensusNodeOverrides, EmbeddedConsensusNodeConfigArgs,
-};
-use base_execution_chainspec::BaseChainSpec;
-use base_execution_cli::{ExecutionNodeArgs, chainspec::chain_value_parser};
-use clap::{Args, Parser, Subcommand};
+use clap::Parser;
 use eyre::WrapErr;
-use reth_cli_runner::CliRunner;
-use tokio_util::sync::CancellationToken;
-use url::Url;
 
-use crate::config::{ChainArg, ChainResolver, ResolvedChainConfig};
+use crate::commands::BaseCommand;
+use crate::config::{ChainArg, ChainResolver};
 
 base_cli_utils::define_log_args!("BASE_NODE");
 base_cli_utils::define_metrics_args!("BASE_NODE", 9090);
@@ -63,117 +54,6 @@ impl BaseCli {
         command.run(resolved_chain)
     }
 }
-
-/// Top-level commands for `base`.
-#[derive(Subcommand, Clone, Debug)]
-#[non_exhaustive]
-pub(crate) enum BaseCommand {
-    /// Run the integrated node in RPC mode.
-    #[command(name = "rpc")]
-    Rpc(RpcCommand),
-}
-
-impl BaseCommand {
-    /// Runs the selected top-level command.
-    pub(crate) fn run(self, resolved_chain: ResolvedChainConfig) -> eyre::Result<()> {
-        match self {
-            Self::Rpc(rpc) => rpc.run(resolved_chain),
-        }
-    }
-}
-
-/// Arguments for `base rpc`.
-#[derive(Args, Clone, Debug)]
-#[command(
-    mut_arg("builder_disallow", |arg| arg.hide(true).long("__builder-disallow-disabled")),
-    mut_arg("sequencer", |arg| arg.hide(true).long("__rollup-sequencer-disabled")),
-    mut_arg("sequencer_headers", |arg| arg.hide(true).long("__rollup-sequencer-headers-disabled"))
-)]
-pub(crate) struct RpcCommand {
-    /// Execution chain spec to use instead of the root chain selection.
-    #[arg(long = "execution-chain", value_parser = chain_value_parser)]
-    pub(crate) execution_chain: Option<Arc<BaseChainSpec>>,
-
-    /// Execution node arguments.
-    #[command(flatten)]
-    pub(crate) execution: ExecutionNodeArgs,
-
-    /// Consensus node arguments.
-    #[command(flatten)]
-    pub(crate) consensus: EmbeddedConsensusNodeConfigArgs,
-}
-
-impl RpcCommand {
-    /// Runs the `rpc` flavor.
-    pub(crate) fn run(self, resolved_chain: ResolvedChainConfig) -> eyre::Result<()> {
-        let execution_chain = match self.execution_chain {
-            Some(chain) => chain,
-            None => resolved_chain.execution_chain_spec()?,
-        };
-        let consensus_chain = resolved_chain.consensus_chain_args();
-        let consensus_args = ConsensusNodeArgs::new(consensus_chain, self.consensus.into());
-        let rollup_config = consensus_args.load_rollup_config()?;
-
-        let execution = self.execution.into_launch_config(execution_chain).with_auth_ipc();
-        let l2_engine_rpc = engine_ipc_url(execution.auth_ipc_path())?;
-
-        CliRunner::try_default_runtime()?.run_command_until_exit(|ctx| async move {
-            let task_executor = ctx.task_executor.clone();
-            let launched = execution.launch_default(ctx).await?;
-            let handle = launched.handle;
-            // Keep the execution node handle alive until both services have coordinated shutdown.
-            let execution_node = handle.node;
-            let execution_exit = handle.node_exit_future;
-
-            let overrides = ConsensusNodeOverrides {
-                l2_engine_rpc: Some(l2_engine_rpc),
-                l2_engine_jwt_secret: None,
-            };
-
-            let consensus_cancellation = CancellationToken::new();
-            let consensus_exit = consensus_args.start_with_overrides_and_cancellation(
-                rollup_config,
-                overrides,
-                consensus_cancellation.clone(),
-            );
-            tokio::pin!(execution_exit);
-            tokio::pin!(consensus_exit);
-
-            let result = tokio::select! {
-                result = &mut execution_exit => {
-                    consensus_cancellation.cancel();
-                    let consensus_result = consensus_exit.await;
-                    result?;
-                    consensus_result
-                }
-                result = &mut consensus_exit => {
-                    let consensus_result = result;
-                    task_executor
-                        .initiate_graceful_shutdown()
-                        .map_err(|e| eyre::eyre!("failed to signal execution node shutdown: {e}"))?
-                        .ignore_guard()
-                        .await;
-                    let execution_result = execution_exit.await;
-                    consensus_result?;
-                    execution_result
-                }
-            };
-
-            drop(execution_node);
-            result
-        })
-    }
-}
-
-fn engine_ipc_url(path: &str) -> eyre::Result<Url> {
-    let path = Path::new(path);
-    let path =
-        if path.is_absolute() { path.to_path_buf() } else { std::env::current_dir()?.join(path) };
-    Url::from_file_path(&path).map_err(|()| {
-        eyre::eyre!("failed to convert auth IPC path to file URL: {}", path.display())
-    })
-}
-
 #[cfg(test)]
 mod tests {
     use std::ffi::OsStr;
@@ -183,18 +63,16 @@ mod tests {
     use super::*;
     use crate::config::BuiltInChain;
 
-    const REQUIRED_CONSENSUS_ARGS: &[&str] =
-        &["--l1-eth-rpc", "http://localhost:8545", "--l1-beacon", "http://localhost:5052"];
-
-    fn rpc_args(args: &'static [&'static str]) -> Vec<&'static str> {
-        let mut full_args = Vec::from(args);
-        full_args.extend_from_slice(REQUIRED_CONSENSUS_ARGS);
-        full_args
-    }
-
     #[test]
     fn parses_default_chain_for_rpc() {
-        let cli = BaseCli::parse_from(rpc_args(&["base", "rpc"]));
+        let cli = BaseCli::parse_from([
+            "base",
+            "rpc",
+            "--l1-eth-rpc",
+            "http://localhost:8545",
+            "--l1-beacon",
+            "http://localhost:5052",
+        ]);
 
         assert!(matches!(cli.chain, ChainArg::BuiltIn(BuiltInChain::Mainnet)));
         assert!(matches!(cli.command, BaseCommand::Rpc(_)));
@@ -202,118 +80,23 @@ mod tests {
 
     #[test]
     fn parses_named_chain_selector() {
-        let cli = BaseCli::parse_from(rpc_args(&["base", "-c", "sepolia", "rpc"]));
+        let cli = BaseCli::parse_from(["base", "-c", "sepolia", "bootnode"]);
 
         assert!(matches!(cli.chain, ChainArg::BuiltIn(BuiltInChain::Sepolia)));
     }
 
     #[test]
-    fn parses_global_chain_after_rpc_subcommand() {
-        let cli = BaseCli::parse_from(rpc_args(&["base", "rpc", "--chain", "sepolia"]));
+    fn parses_global_chain_after_subcommand() {
+        let cli = BaseCli::parse_from(["base", "bootnode", "--chain", "sepolia"]);
 
         assert!(matches!(cli.chain, ChainArg::BuiltIn(BuiltInChain::Sepolia)));
     }
 
     #[test]
     fn parses_path_chain_selector() {
-        let cli = BaseCli::parse_from(rpc_args(&["base", "--chain", "./chain.toml", "rpc"]));
+        let cli = BaseCli::parse_from(["base", "--chain", "./chain.toml", "bootnode"]);
 
         assert!(matches!(cli.chain, ChainArg::File(_)));
-    }
-
-    #[test]
-    fn parses_execution_port_and_consensus_rpc_port() {
-        let cli = BaseCli::parse_from(rpc_args(&[
-            "base",
-            "rpc",
-            "--port",
-            "30333",
-            "--rpc.port",
-            "9546",
-        ]));
-
-        let BaseCommand::Rpc(rpc) = cli.command;
-
-        assert_eq!(rpc.execution.network.port, 30333);
-        assert_eq!(rpc.consensus.rpc_flags.listen_port, 9546);
-    }
-
-    #[test]
-    fn parses_devnet_unified_client_args() {
-        let cli = BaseCli::parse_from([
-            "base",
-            "rpc",
-            "--chain",
-            "dev",
-            "--execution-chain",
-            "dev",
-            "--datadir=/data",
-            "--http",
-            "--http.addr=0.0.0.0",
-            "--http.port=8545",
-            "--ws",
-            "--ws.addr=0.0.0.0",
-            "--ws.port=8546",
-            "--authrpc.port=8551",
-            "--authrpc.addr=0.0.0.0",
-            "--authrpc.jwtsecret=/genesis/jwt.hex",
-            "--auth-ipc.path=/data/engine.ipc",
-            "--port=30303",
-            "--discovery.port=30303",
-            "--metrics=0.0.0.0:8090",
-            "--txpool.nolocals",
-            "--rollup.txpool-max-inflight-delegated-slots=32768",
-            "--txpool.pending-max-count=200000",
-            "--txpool.pending-max-size=512",
-            "--txpool.basefee-max-count=200000",
-            "--txpool.basefee-max-size=512",
-            "--txpool.queued-max-count=200000",
-            "--txpool.queued-max-size=512",
-            "--txpool.max-account-slots=256",
-            "--txpool.max-batch-size=1024",
-            "--rpc.txfeecap=0",
-            "--rpc.gascap=600000000",
-            "--rpc.eth-proof-window=1209600",
-            "--flashblocks-url=ws://base-builder:7111",
-            "--bootnodes=enode://4f355bdcb7cc0af728ef3cceb9615d90684bb5b2ca5f859ab0f0b704075871aa385b6b1b8ead809ca67454d9683fcf2ba03456d6fe2c4abe2b07f0fbdbb2f1c1@172.30.0.10:9303",
-            "--rollup.discovery.v4",
-            "--l1-eth-rpc",
-            "http://l1-el:8545",
-            "--l1-beacon",
-            "http://l1-cl:5052",
-            "--l2-config-file",
-            "/genesis/l2/rollup.json",
-            "--l1-config-file",
-            "/genesis/el/chain-config.json",
-            "--l1-slot-duration-override",
-            "4",
-            "--rpc.addr",
-            "0.0.0.0",
-            "--rpc.port",
-            "8549",
-            "--p2p.listen.tcp",
-            "8003",
-            "--p2p.listen.udp",
-            "8003",
-            "--p2p.advertise.ip",
-            "127.0.0.1",
-            "--p2p.bootnodes-file",
-            "/bootnodes/enr.txt",
-            "--p2p.scoring",
-            "Off",
-            "--l1.verifier-confs",
-            "15",
-            "-vvv",
-        ]);
-
-        assert!(matches!(cli.chain, ChainArg::File(_)));
-        let BaseCommand::Rpc(rpc) = cli.command;
-
-        assert_eq!(rpc.execution.rpc.auth_ipc_path, "/data/engine.ipc");
-        assert_eq!(rpc.execution.network.port, 30303);
-        assert!(rpc.execution_chain.is_some());
-        assert_eq!(rpc.consensus.rpc_flags.listen_port, 8549);
-        assert_eq!(rpc.consensus.p2p_flags.network.listen_tcp_port, 8003);
     }
 
     #[test]
@@ -327,117 +110,11 @@ mod tests {
 
     #[test]
     fn rejects_multiple_chain_selectors() {
-        let err = BaseCli::try_parse_from(rpc_args(&[
-            "base", "-c", "mainnet", "--chain", "sepolia", "rpc",
-        ]))
-        .unwrap_err();
-
-        let rendered = err.to_string();
-        assert!(rendered.contains("cannot be used multiple times"));
-    }
-
-    #[test]
-    fn rejects_legacy_node_rpc_path() {
-        let err = BaseCli::try_parse_from(rpc_args(&["base", "node", "rpc"])).unwrap_err();
-
-        let rendered = err.to_string();
-        assert!(rendered.contains("node"));
-    }
-
-    #[test]
-    fn rejects_rpc_mode_arg() {
         let err =
-            BaseCli::try_parse_from(rpc_args(&["base", "rpc", "--mode", "sequencer"])).unwrap_err();
-
-        let rendered = err.to_string();
-        assert!(rendered.contains("--mode"));
-    }
-
-    #[test]
-    fn rejects_rpc_sequencer_args() {
-        let err =
-            BaseCli::try_parse_from(rpc_args(&["base", "rpc", "--sequencer.stopped"])).unwrap_err();
-
-        let rendered = err.to_string();
-        assert!(rendered.contains("--sequencer.stopped"));
-    }
-
-    #[test]
-    fn rejects_rpc_conductor_args() {
-        let err = BaseCli::try_parse_from(rpc_args(&[
-            "base",
-            "rpc",
-            "--conductor.rpc",
-            "http://localhost:9090",
-        ]))
-        .unwrap_err();
-
-        let rendered = err.to_string();
-        assert!(rendered.contains("--conductor.rpc"));
-    }
-
-    #[test]
-    fn rejects_rpc_builder_args() {
-        let err = BaseCli::try_parse_from(rpc_args(&["base", "rpc", "--builder.max-tasks", "1"]))
-            .unwrap_err();
-
-        let rendered = err.to_string();
-        assert!(rendered.contains("--builder.max-tasks"));
-    }
-
-    #[test]
-    fn rejects_rpc_builder_disallow_arg() {
-        let err =
-            BaseCli::try_parse_from(rpc_args(&["base", "rpc", "--builder.disallow", "deny.json"]))
+            BaseCli::try_parse_from(["base", "-c", "mainnet", "--chain", "sepolia", "bootnode"])
                 .unwrap_err();
 
         let rendered = err.to_string();
-        assert!(rendered.contains("--builder.disallow"));
-    }
-
-    #[test]
-    fn rejects_rpc_rollup_sequencer_arg() {
-        let err = BaseCli::try_parse_from(rpc_args(&[
-            "base",
-            "rpc",
-            "--rollup.sequencer",
-            "http://localhost:8545",
-        ]))
-        .unwrap_err();
-
-        let rendered = err.to_string();
-        assert!(rendered.contains("--rollup.sequencer"));
-    }
-
-    #[test]
-    fn rejects_rpc_metering_args() {
-        let err =
-            BaseCli::try_parse_from(rpc_args(&["base", "rpc", "--enable-metering"])).unwrap_err();
-
-        let rendered = err.to_string();
-        assert!(rendered.contains("--enable-metering"));
-    }
-
-    #[test]
-    fn rejects_rpc_tx_forwarding_args() {
-        let err = BaseCli::try_parse_from(rpc_args(&["base", "rpc", "--enable-tx-forwarding"]))
-            .unwrap_err();
-
-        let rendered = err.to_string();
-        assert!(rendered.contains("--enable-tx-forwarding"));
-    }
-
-    #[test]
-    fn rejects_rpc_p2p_signer_args() {
-        let err = BaseCli::try_parse_from(rpc_args(&[
-            "base",
-            "rpc",
-            "--p2p.sequencer.key",
-            "bcc617ea05150ff60490d3c6058630ba94ae9f12a02a87efd291349ca0e54e0a",
-        ]))
-        .unwrap_err();
-
-        let rendered = err.to_string();
-        assert!(rendered.contains("--p2p.sequencer.key"));
+        assert!(rendered.contains("cannot be used multiple times"));
     }
 }

--- a/bin/base/src/commands/bootnode.rs
+++ b/bin/base/src/commands/bootnode.rs
@@ -47,12 +47,16 @@ impl BootnodeCommand {
             tokio::select! {
                 result = &mut consensus_bootnode => {
                     warn!(layer = "consensus", "bootnode task exited");
-                    Self::stop_task("execution", execution_bootnode).await?;
+                    if let Err(error) = Self::stop_task("execution", execution_bootnode).await {
+                        warn!(error = %error, "failed to stop execution bootnode");
+                    }
                     Self::task_result("consensus", result)
                 }
                 result = &mut execution_bootnode => {
                     warn!(layer = "execution", "bootnode task exited");
-                    Self::stop_task("consensus", consensus_bootnode).await?;
+                    if let Err(error) = Self::stop_task("consensus", consensus_bootnode).await {
+                        warn!(error = %error, "failed to stop consensus bootnode");
+                    }
                     Self::task_result("execution", result)
                 }
             }

--- a/bin/base/src/commands/bootnode.rs
+++ b/bin/base/src/commands/bootnode.rs
@@ -1,0 +1,135 @@
+//! Combined consensus and execution bootnode command.
+
+use base_consensus_cli::{BootnodeP2PArgs, CliMetrics, L2ConfigFile};
+use base_execution_cli::commands::p2p::bootnode::Command as ExecutionBootnodeCommand;
+use clap::Args;
+use eyre::WrapErr;
+use reth_cli_runner::CliRunner;
+use tokio::task::JoinHandle;
+use tracing::{debug, info, warn};
+
+use crate::config::ResolvedChainConfig;
+
+/// Arguments for `base bootnode`.
+#[derive(Args, Clone, Debug)]
+pub(crate) struct BootnodeCommand {
+    /// L2 configuration file.
+    #[clap(flatten)]
+    pub(crate) l2_config: L2ConfigFile,
+
+    /// Consensus bootnode P2P discovery arguments.
+    #[command(flatten)]
+    pub(crate) consensus: BootnodeP2PArgs,
+
+    /// Execution bootnode discovery arguments.
+    #[command(flatten)]
+    pub(crate) execution: ExecutionBootnodeCommand,
+}
+
+impl BootnodeCommand {
+    /// Runs both discovery-only bootnodes.
+    pub(crate) fn run(self, resolved_chain: ResolvedChainConfig) -> eyre::Result<()> {
+        let consensus_chain = resolved_chain.consensus_chain_args();
+        let rollup_config =
+            self.l2_config.load(&consensus_chain.l2_chain_id).map_err(|e| eyre::eyre!(e))?;
+
+        CliMetrics::init_rollup_config(&rollup_config);
+        CliMetrics::init_bootnode_p2p(&self.consensus);
+
+        CliRunner::try_default_runtime()?.run_command_until_exit(|_| async move {
+            let chain_id = rollup_config.l2_chain_id.id();
+            self.consensus.check_ports()?;
+
+            let mut consensus_bootnode =
+                tokio::spawn(Self::run_consensus(self.consensus, chain_id));
+            let mut execution_bootnode = tokio::spawn(Self::run_execution(self.execution));
+
+            tokio::select! {
+                result = &mut consensus_bootnode => {
+                    warn!(layer = "consensus", "bootnode task exited");
+                    Self::stop_task("execution", execution_bootnode).await?;
+                    Self::task_result("consensus", result)
+                }
+                result = &mut execution_bootnode => {
+                    warn!(layer = "execution", "bootnode task exited");
+                    Self::stop_task("consensus", consensus_bootnode).await?;
+                    Self::task_result("execution", result)
+                }
+            }
+        })
+    }
+
+    async fn run_consensus(consensus: BootnodeP2PArgs, chain_id: u64) -> eyre::Result<()> {
+        let driver = consensus.discovery_driver(chain_id)?;
+        let (handler, mut discovered_enrs) = driver.start();
+        let local_enr = handler.local_enr().await.wrap_err("discovery service stopped")?;
+        consensus.write_enr_output(&local_enr)?;
+
+        info!(
+            target: "rollup_node::bootnode",
+            chain_id = chain_id,
+            enr = %local_enr,
+            "Consensus bootnode started"
+        );
+        CliMetrics::record_bootnode_up();
+
+        while let Some(enr) = discovered_enrs.recv().await {
+            debug!(
+                target: "rollup_node::bootnode",
+                peer_id = %enr.node_id(),
+                enr = %enr,
+                "Discovered consensus peer"
+            );
+        }
+
+        warn!(target: "rollup_node::bootnode", "Discovery ENR stream closed");
+        Ok(())
+    }
+
+    async fn run_execution(execution: ExecutionBootnodeCommand) -> eyre::Result<()> {
+        execution.execute().await
+    }
+
+    async fn stop_task(
+        layer: &'static str,
+        task: JoinHandle<eyre::Result<()>>,
+    ) -> eyre::Result<()> {
+        task.abort();
+        match task.await {
+            Ok(result) => {
+                result.wrap_err_with(|| format!("{layer} bootnode exited while stopping"))
+            }
+            Err(error) if error.is_cancelled() => Ok(()),
+            Err(error) => Err(eyre::eyre!("{layer} bootnode task failed while stopping: {error}")),
+        }
+    }
+
+    fn task_result(
+        layer: &'static str,
+        result: Result<eyre::Result<()>, tokio::task::JoinError>,
+    ) -> eyre::Result<()> {
+        match result {
+            Ok(result) => result.wrap_err_with(|| format!("{layer} bootnode exited with an error")),
+            Err(error) => Err(eyre::eyre!("{layer} bootnode task failed: {error}")),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use clap::Parser;
+
+    use crate::{cli::BaseCli, commands::BaseCommand, config::ChainArg};
+
+    #[test]
+    fn parses_bootnode_command() {
+        let cli = BaseCli::parse_from(["base", "bootnode"]);
+
+        assert!(matches!(cli.chain, ChainArg::BuiltIn(_)));
+        let BaseCommand::Bootnode(bootnode) = cli.command else {
+            panic!("expected bootnode command");
+        };
+        assert_eq!(bootnode.consensus.listen_tcp_port, 9222);
+        assert_eq!(bootnode.execution.v4_addr.to_string(), "0.0.0.0:30301");
+    }
+}

--- a/bin/base/src/commands/bootnode.rs
+++ b/bin/base/src/commands/bootnode.rs
@@ -30,8 +30,7 @@ impl BootnodeCommand {
     /// Runs both discovery-only bootnodes.
     pub(crate) fn run(self, resolved_chain: ResolvedChainConfig) -> eyre::Result<()> {
         let consensus_chain = resolved_chain.consensus_chain_args();
-        let rollup_config =
-            self.l2_config.load(&consensus_chain.l2_chain_id).map_err(|e| eyre::eyre!(e))?;
+        let rollup_config = self.l2_config.load(&consensus_chain.l2_chain_id)?;
 
         CliMetrics::init_rollup_config(&rollup_config);
         CliMetrics::init_bootnode_p2p(&self.consensus);

--- a/bin/base/src/commands/command.rs
+++ b/bin/base/src/commands/command.rs
@@ -1,0 +1,45 @@
+//! Top-level command dispatch for the unified Base binary.
+
+use clap::Subcommand;
+
+use crate::{
+    commands::{bootnode::BootnodeCommand, rpc::RpcCommand},
+    config::ResolvedChainConfig,
+};
+
+/// Top-level commands for `base`.
+#[derive(Subcommand, Clone, Debug)]
+#[non_exhaustive]
+pub(crate) enum BaseCommand {
+    /// Run consensus and execution discovery-only bootnodes.
+    #[command(name = "bootnode")]
+    Bootnode(Box<BootnodeCommand>),
+    /// Run the integrated node in RPC mode.
+    #[command(name = "rpc")]
+    Rpc(Box<RpcCommand>),
+}
+
+impl BaseCommand {
+    /// Runs the selected top-level command.
+    pub(crate) fn run(self, resolved_chain: ResolvedChainConfig) -> eyre::Result<()> {
+        match self {
+            Self::Bootnode(bootnode) => (*bootnode).run(resolved_chain),
+            Self::Rpc(rpc) => (*rpc).run(resolved_chain),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use clap::Parser;
+
+    use crate::cli::BaseCli;
+
+    #[test]
+    fn rejects_legacy_node_rpc_path() {
+        let err = BaseCli::try_parse_from(["base", "node", "rpc"]).unwrap_err();
+
+        let rendered = err.to_string();
+        assert!(rendered.contains("node"));
+    }
+}

--- a/bin/base/src/commands/mod.rs
+++ b/bin/base/src/commands/mod.rs
@@ -1,0 +1,6 @@
+//! Top-level command implementations for the unified Base binary.
+
+mod bootnode;
+mod command;
+pub(crate) use command::BaseCommand;
+mod rpc;

--- a/bin/base/src/commands/rpc.rs
+++ b/bin/base/src/commands/rpc.rs
@@ -1,0 +1,319 @@
+//! Integrated RPC node command.
+
+use std::{path::Path, sync::Arc};
+
+use base_consensus_cli::{
+    ConsensusNodeArgs, ConsensusNodeOverrides, EmbeddedConsensusNodeConfigArgs,
+};
+use base_execution_chainspec::BaseChainSpec;
+use base_execution_cli::{ExecutionNodeArgs, chainspec::chain_value_parser};
+use clap::Args;
+use reth_cli_runner::CliRunner;
+use tokio_util::sync::CancellationToken;
+use url::Url;
+
+use crate::config::ResolvedChainConfig;
+
+/// Arguments for `base rpc`.
+#[derive(Args, Clone, Debug)]
+#[command(
+    mut_arg("builder_disallow", |arg| arg.hide(true).long("__builder-disallow-disabled")),
+    mut_arg("sequencer", |arg| arg.hide(true).long("__rollup-sequencer-disabled")),
+    mut_arg("sequencer_headers", |arg| arg.hide(true).long("__rollup-sequencer-headers-disabled"))
+)]
+pub(crate) struct RpcCommand {
+    /// Execution chain spec to use instead of the root chain selection.
+    #[arg(long = "execution-chain", value_parser = chain_value_parser)]
+    pub(crate) execution_chain: Option<Arc<BaseChainSpec>>,
+
+    /// Execution node arguments.
+    #[command(flatten)]
+    pub(crate) execution: ExecutionNodeArgs,
+
+    /// Consensus node arguments.
+    #[command(flatten)]
+    pub(crate) consensus: EmbeddedConsensusNodeConfigArgs,
+}
+
+impl RpcCommand {
+    /// Runs the `rpc` flavor.
+    pub(crate) fn run(self, resolved_chain: ResolvedChainConfig) -> eyre::Result<()> {
+        let execution_chain = match self.execution_chain {
+            Some(chain) => chain,
+            None => resolved_chain.execution_chain_spec()?,
+        };
+        let consensus_chain = resolved_chain.consensus_chain_args();
+        let consensus_args = ConsensusNodeArgs::new(consensus_chain, self.consensus.into());
+        let rollup_config = consensus_args.load_rollup_config()?;
+
+        let execution = self.execution.into_launch_config(execution_chain).with_auth_ipc();
+        let l2_engine_rpc = engine_ipc_url(execution.auth_ipc_path())?;
+
+        CliRunner::try_default_runtime()?.run_command_until_exit(|ctx| async move {
+            let task_executor = ctx.task_executor.clone();
+            let launched = execution.launch_default(ctx).await?;
+            let handle = launched.handle;
+            // Keep the execution node handle alive until both services have coordinated shutdown.
+            let execution_node = handle.node;
+            let execution_exit = handle.node_exit_future;
+
+            let overrides = ConsensusNodeOverrides {
+                l2_engine_rpc: Some(l2_engine_rpc),
+                l2_engine_jwt_secret: None,
+            };
+
+            let consensus_cancellation = CancellationToken::new();
+            let consensus_exit = consensus_args.start_with_overrides_and_cancellation(
+                rollup_config,
+                overrides,
+                consensus_cancellation.clone(),
+            );
+            tokio::pin!(execution_exit);
+            tokio::pin!(consensus_exit);
+
+            let result = tokio::select! {
+                result = &mut execution_exit => {
+                    consensus_cancellation.cancel();
+                    let consensus_result = consensus_exit.await;
+                    result?;
+                    consensus_result
+                }
+                result = &mut consensus_exit => {
+                    let consensus_result = result;
+                    task_executor
+                        .initiate_graceful_shutdown()
+                        .map_err(|e| eyre::eyre!("failed to signal execution node shutdown: {e}"))?
+                        .ignore_guard()
+                        .await;
+                    let execution_result = execution_exit.await;
+                    consensus_result?;
+                    execution_result
+                }
+            };
+
+            drop(execution_node);
+            result
+        })
+    }
+}
+
+fn engine_ipc_url(path: &str) -> eyre::Result<Url> {
+    let path = Path::new(path);
+    let path =
+        if path.is_absolute() { path.to_path_buf() } else { std::env::current_dir()?.join(path) };
+    Url::from_file_path(&path).map_err(|()| {
+        eyre::eyre!("failed to convert auth IPC path to file URL: {}", path.display())
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use clap::Parser;
+
+    use crate::{cli::BaseCli, commands::BaseCommand, config::ChainArg};
+
+    const REQUIRED_CONSENSUS_ARGS: &[&str] =
+        &["--l1-eth-rpc", "http://localhost:8545", "--l1-beacon", "http://localhost:5052"];
+
+    fn rpc_args(args: &'static [&'static str]) -> Vec<&'static str> {
+        let mut full_args = Vec::from(args);
+        full_args.extend_from_slice(REQUIRED_CONSENSUS_ARGS);
+        full_args
+    }
+
+    #[test]
+    fn parses_execution_port_and_consensus_rpc_port() {
+        let cli = BaseCli::parse_from(rpc_args(&[
+            "base",
+            "rpc",
+            "--port",
+            "30333",
+            "--rpc.port",
+            "9546",
+        ]));
+
+        let BaseCommand::Rpc(rpc) = cli.command else {
+            panic!("expected rpc command");
+        };
+
+        assert_eq!(rpc.execution.network.port, 30333);
+        assert_eq!(rpc.consensus.rpc_flags.listen_port, 9546);
+    }
+
+    #[test]
+    fn parses_devnet_unified_client_args() {
+        let cli = BaseCli::parse_from([
+            "base",
+            "rpc",
+            "--chain",
+            "dev",
+            "--execution-chain",
+            "dev",
+            "--datadir=/data",
+            "--http",
+            "--http.addr=0.0.0.0",
+            "--http.port=8545",
+            "--ws",
+            "--ws.addr=0.0.0.0",
+            "--ws.port=8546",
+            "--authrpc.port=8551",
+            "--authrpc.addr=0.0.0.0",
+            "--authrpc.jwtsecret=/genesis/jwt.hex",
+            "--auth-ipc.path=/data/engine.ipc",
+            "--port=30303",
+            "--discovery.port=30303",
+            "--metrics=0.0.0.0:8090",
+            "--txpool.nolocals",
+            "--rollup.txpool-max-inflight-delegated-slots=32768",
+            "--txpool.pending-max-count=200000",
+            "--txpool.pending-max-size=512",
+            "--txpool.basefee-max-count=200000",
+            "--txpool.basefee-max-size=512",
+            "--txpool.queued-max-count=200000",
+            "--txpool.queued-max-size=512",
+            "--txpool.max-account-slots=256",
+            "--txpool.max-batch-size=1024",
+            "--rpc.txfeecap=0",
+            "--rpc.gascap=600000000",
+            "--rpc.eth-proof-window=1209600",
+            "--flashblocks-url=ws://base-builder:7111",
+            "--bootnodes=enode://4f355bdcb7cc0af728ef3cceb9615d90684bb5b2ca5f859ab0f0b704075871aa385b6b1b8ead809ca67454d9683fcf2ba03456d6fe2c4abe2b07f0fbdbb2f1c1@172.30.0.10:9303",
+            "--rollup.discovery.v4",
+            "--l1-eth-rpc",
+            "http://l1-el:8545",
+            "--l1-beacon",
+            "http://l1-cl:5052",
+            "--l2-config-file",
+            "/genesis/l2/rollup.json",
+            "--l1-config-file",
+            "/genesis/el/chain-config.json",
+            "--l1-slot-duration-override",
+            "4",
+            "--rpc.addr",
+            "0.0.0.0",
+            "--rpc.port",
+            "8549",
+            "--p2p.listen.tcp",
+            "8003",
+            "--p2p.listen.udp",
+            "8003",
+            "--p2p.advertise.ip",
+            "127.0.0.1",
+            "--p2p.bootnodes-file",
+            "/bootnodes/enr.txt",
+            "--p2p.scoring",
+            "Off",
+            "--l1.verifier-confs",
+            "15",
+            "-vvv",
+        ]);
+
+        assert!(matches!(cli.chain, ChainArg::File(_)));
+        let BaseCommand::Rpc(rpc) = cli.command else {
+            panic!("expected rpc command");
+        };
+
+        assert_eq!(rpc.execution.rpc.auth_ipc_path, "/data/engine.ipc");
+        assert_eq!(rpc.execution.network.port, 30303);
+        assert!(rpc.execution_chain.is_some());
+        assert_eq!(rpc.consensus.rpc_flags.listen_port, 8549);
+        assert_eq!(rpc.consensus.p2p_flags.network.listen_tcp_port, 8003);
+    }
+
+    #[test]
+    fn rejects_rpc_mode_arg() {
+        let err =
+            BaseCli::try_parse_from(rpc_args(&["base", "rpc", "--mode", "sequencer"])).unwrap_err();
+
+        let rendered = err.to_string();
+        assert!(rendered.contains("--mode"));
+    }
+
+    #[test]
+    fn rejects_rpc_sequencer_args() {
+        let err =
+            BaseCli::try_parse_from(rpc_args(&["base", "rpc", "--sequencer.stopped"])).unwrap_err();
+
+        let rendered = err.to_string();
+        assert!(rendered.contains("--sequencer.stopped"));
+    }
+
+    #[test]
+    fn rejects_rpc_conductor_args() {
+        let err = BaseCli::try_parse_from(rpc_args(&[
+            "base",
+            "rpc",
+            "--conductor.rpc",
+            "http://localhost:9090",
+        ]))
+        .unwrap_err();
+
+        let rendered = err.to_string();
+        assert!(rendered.contains("--conductor.rpc"));
+    }
+
+    #[test]
+    fn rejects_rpc_builder_args() {
+        let err = BaseCli::try_parse_from(rpc_args(&["base", "rpc", "--builder.max-tasks", "1"]))
+            .unwrap_err();
+
+        let rendered = err.to_string();
+        assert!(rendered.contains("--builder.max-tasks"));
+    }
+
+    #[test]
+    fn rejects_rpc_builder_disallow_arg() {
+        let err =
+            BaseCli::try_parse_from(rpc_args(&["base", "rpc", "--builder.disallow", "deny.json"]))
+                .unwrap_err();
+
+        let rendered = err.to_string();
+        assert!(rendered.contains("--builder.disallow"));
+    }
+
+    #[test]
+    fn rejects_rpc_rollup_sequencer_arg() {
+        let err = BaseCli::try_parse_from(rpc_args(&[
+            "base",
+            "rpc",
+            "--rollup.sequencer",
+            "http://localhost:8545",
+        ]))
+        .unwrap_err();
+
+        let rendered = err.to_string();
+        assert!(rendered.contains("--rollup.sequencer"));
+    }
+
+    #[test]
+    fn rejects_rpc_metering_args() {
+        let err =
+            BaseCli::try_parse_from(rpc_args(&["base", "rpc", "--enable-metering"])).unwrap_err();
+
+        let rendered = err.to_string();
+        assert!(rendered.contains("--enable-metering"));
+    }
+
+    #[test]
+    fn rejects_rpc_tx_forwarding_args() {
+        let err = BaseCli::try_parse_from(rpc_args(&["base", "rpc", "--enable-tx-forwarding"]))
+            .unwrap_err();
+
+        let rendered = err.to_string();
+        assert!(rendered.contains("--enable-tx-forwarding"));
+    }
+
+    #[test]
+    fn rejects_rpc_p2p_signer_args() {
+        let err = BaseCli::try_parse_from(rpc_args(&[
+            "base",
+            "rpc",
+            "--p2p.sequencer.key",
+            "bcc617ea05150ff60490d3c6058630ba94ae9f12a02a87efd291349ca0e54e0a",
+        ]))
+        .unwrap_err();
+
+        let rendered = err.to_string();
+        assert!(rendered.contains("--p2p.sequencer.key"));
+    }
+}

--- a/bin/base/src/main.rs
+++ b/bin/base/src/main.rs
@@ -6,14 +6,13 @@
 use clap::Parser;
 
 mod cli;
+mod commands;
 mod config;
-
-use cli::BaseCli;
 
 fn main() {
     base_cli_utils::init_common!();
 
-    if let Err(err) = BaseCli::parse().run() {
+    if let Err(err) = cli::BaseCli::parse().run() {
         eprintln!("Error: {err:?}");
         std::process::exit(1);
     }

--- a/crates/execution/cli/src/commands/p2p/bootnode.rs
+++ b/crates/execution/cli/src/commands/p2p/bootnode.rs
@@ -18,7 +18,7 @@ use tokio_stream::StreamExt;
 use tracing::{info, warn};
 
 /// Start a discovery-only bootnode.
-#[derive(Parser, Debug)]
+#[derive(Parser, Clone, Debug)]
 pub struct Command {
     /// Listen address for the bootnode for discv4
     #[arg(long, default_value = "0.0.0.0:30301")]


### PR DESCRIPTION
## Summary

This adds a unified base bootnode command that runs the consensus and execution discovery bootnodes together. The base binary command handling is split into command modules so the rpc command and its tests live with the RPC implementation. The new bootnode command reuses the existing consensus and execution bootnode implementations instead of duplicating discovery logic.