### PR TITLE
feat(consensus-rpc): add conductor pause/health/membership API

### DIFF
--- a/crates/consensus/rpc/src/jsonrpsee.rs
+++ b/crates/consensus/rpc/src/jsonrpsee.rs
@@ -16,8 +16,79 @@ use jsonrpsee::{
     core::{RpcResult, SubscriptionResult},
     proc_macros::rpc,
 };
+use serde::{Deserialize, Serialize};
 
 use crate::{OutputResponse, health::HealthzResponse};
+
+/// Live Raft cluster membership snapshot returned by `conductor_clusterMembership`.
+///
+/// Mirrors the upstream op-conductor `ClusterMembership` struct.
+/// See: <https://github.com/ethereum-optimism/optimism/blob/develop/op-conductor/consensus/iface.go>
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ClusterMembership {
+    /// All servers currently known to the Raft configuration.
+    pub servers: Vec<ServerInfo>,
+    /// Raft configuration index — increments on every membership change.
+    pub version: u64,
+}
+
+/// A single member of the Raft cluster.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ServerInfo {
+    /// Stable Raft server identifier (e.g. `"sequencer-1"`).
+    ///
+    /// Matches the `server_id` operators configure per node and the parameter
+    /// expected by `conductor_transferLeaderToServer`.
+    pub id: String,
+    /// Raft binary-protocol address (e.g. `"op-conductor-1:5051"`).
+    ///
+    /// **NOT** the JSON-RPC URL — the Raft consensus port is distinct from the
+    /// HTTP RPC port. Callers that need to talk JSON-RPC to a peer must derive
+    /// the RPC URL separately (typically by extracting the host and applying a
+    /// port template from local configuration).
+    pub addr: String,
+    /// Whether this server can vote in Raft elections.
+    pub suffrage: ServerSuffrage,
+}
+
+/// Raft suffrage (voting eligibility) for a cluster member.
+///
+/// Wire format is an integer (`0` = voter, `1` = nonvoter), matching the
+/// upstream `ServerSuffrage` enum in op-conductor.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(try_from = "u8", into = "u8")]
+pub enum ServerSuffrage {
+    /// Server is eligible to vote in Raft elections.
+    Voter,
+    /// Server is a non-voting member (replica only).
+    Nonvoter,
+}
+
+impl TryFrom<u8> for ServerSuffrage {
+    type Error = UnknownServerSuffrage;
+
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        match value {
+            0 => Ok(Self::Voter),
+            1 => Ok(Self::Nonvoter),
+            other => Err(UnknownServerSuffrage(other)),
+        }
+    }
+}
+
+impl From<ServerSuffrage> for u8 {
+    fn from(value: ServerSuffrage) -> Self {
+        match value {
+            ServerSuffrage::Voter => 0,
+            ServerSuffrage::Nonvoter => 1,
+        }
+    }
+}
+
+/// Error returned when an unknown `ServerSuffrage` discriminant is decoded.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+#[error("unknown server suffrage discriminant: {0}")]
+pub struct UnknownServerSuffrage(pub u8);
 
 /// Base rollup node RPC interface.
 ///
@@ -250,6 +321,30 @@ pub trait ConductorApi {
         server_id: String,
         raft_addr: String,
     ) -> RpcResult<()>;
+
+    /// Pauses the conductor control loop.
+    #[method(name = "pause")]
+    async fn conductor_pause(&self) -> RpcResult<()>;
+
+    /// Resumes the conductor control loop.
+    #[method(name = "resume")]
+    async fn conductor_resume(&self) -> RpcResult<()>;
+
+    /// Returns true if the conductor control loop is paused.
+    #[method(name = "paused")]
+    async fn conductor_paused(&self) -> RpcResult<bool>;
+
+    /// Returns true if the conductor process is stopped.
+    #[method(name = "stopped")]
+    async fn conductor_stopped(&self) -> RpcResult<bool>;
+
+    /// Returns true if the sequencer this conductor manages reports healthy.
+    #[method(name = "sequencerHealthy")]
+    async fn conductor_sequencer_healthy(&self) -> RpcResult<bool>;
+
+    /// Returns the live Raft cluster membership snapshot.
+    #[method(name = "clusterMembership")]
+    async fn conductor_cluster_membership(&self) -> RpcResult<ClusterMembership>;
 }
 
 #[cfg(test)]
@@ -272,8 +367,8 @@ mod tests {
     use rstest::rstest;
 
     use super::{
-        AdminApiServer, BaseP2PApiServer, ConductorApiServer, DevEngineApiServer, HealthzApiServer,
-        RollupNodeApiServer, WsServer,
+        AdminApiServer, BaseP2PApiServer, ClusterMembership, ConductorApiServer, DevEngineApiServer,
+        HealthzApiServer, RollupNodeApiServer, ServerSuffrage, WsServer,
     };
     use crate::{OutputResponse, health::HealthzResponse};
 
@@ -585,6 +680,30 @@ mod tests {
         async fn conductor_transfer_leader_to_server(&self, _: String, _: String) -> RpcResult<()> {
             unimplemented!()
         }
+
+        async fn conductor_pause(&self) -> RpcResult<()> {
+            unimplemented!()
+        }
+
+        async fn conductor_resume(&self) -> RpcResult<()> {
+            unimplemented!()
+        }
+
+        async fn conductor_paused(&self) -> RpcResult<bool> {
+            unimplemented!()
+        }
+
+        async fn conductor_stopped(&self) -> RpcResult<bool> {
+            unimplemented!()
+        }
+
+        async fn conductor_sequencer_healthy(&self) -> RpcResult<bool> {
+            unimplemented!()
+        }
+
+        async fn conductor_cluster_membership(&self) -> RpcResult<ClusterMembership> {
+            unimplemented!()
+        }
     }
 
     #[rstest]
@@ -594,9 +713,47 @@ mod tests {
     #[case("conductor_overrideLeader")]
     #[case("conductor_transferLeader")]
     #[case("conductor_transferLeaderToServer")]
+    #[case("conductor_pause")]
+    #[case("conductor_resume")]
+    #[case("conductor_paused")]
+    #[case("conductor_stopped")]
+    #[case("conductor_sequencerHealthy")]
+    #[case("conductor_clusterMembership")]
     fn conductor_api_wire_names(#[case] expected: &str) {
         let module = StubConductorApi.into_rpc();
         let names: Vec<&str> = module.method_names().collect();
         assert!(names.contains(&expected), "missing method {expected}, got: {names:?}");
+    }
+
+    #[test]
+    fn server_suffrage_wire_format_is_numeric() {
+        assert_eq!(serde_json::to_string(&ServerSuffrage::Voter).unwrap(), "0");
+        assert_eq!(serde_json::to_string(&ServerSuffrage::Nonvoter).unwrap(), "1");
+        assert_eq!(serde_json::from_str::<ServerSuffrage>("0").unwrap(), ServerSuffrage::Voter);
+        assert_eq!(serde_json::from_str::<ServerSuffrage>("1").unwrap(), ServerSuffrage::Nonvoter);
+        assert!(serde_json::from_str::<ServerSuffrage>("2").is_err());
+    }
+
+    #[test]
+    fn cluster_membership_round_trips_upstream_wire_format() {
+        let json = r#"{
+            "servers": [
+                {"id": "sequencer-1", "addr": "10.0.1.10:50050", "suffrage": 0},
+                {"id": "sequencer-2", "addr": "10.0.1.11:50050", "suffrage": 0},
+                {"id": "sequencer-3", "addr": "10.0.1.12:50050", "suffrage": 1}
+            ],
+            "version": 42
+        }"#;
+        let membership: ClusterMembership = serde_json::from_str(json).unwrap();
+        assert_eq!(membership.version, 42);
+        assert_eq!(membership.servers.len(), 3);
+        assert_eq!(membership.servers[0].id, "sequencer-1");
+        assert_eq!(membership.servers[0].addr, "10.0.1.10:50050");
+        assert_eq!(membership.servers[0].suffrage, ServerSuffrage::Voter);
+        assert_eq!(membership.servers[2].suffrage, ServerSuffrage::Nonvoter);
+
+        let reserialized = serde_json::to_value(&membership).unwrap();
+        let original: serde_json::Value = serde_json::from_str(json).unwrap();
+        assert_eq!(reserialized, original);
     }
 }

--- a/crates/consensus/rpc/src/jsonrpsee.rs
+++ b/crates/consensus/rpc/src/jsonrpsee.rs
@@ -367,8 +367,8 @@ mod tests {
     use rstest::rstest;
 
     use super::{
-        AdminApiServer, BaseP2PApiServer, ClusterMembership, ConductorApiServer, DevEngineApiServer,
-        HealthzApiServer, RollupNodeApiServer, ServerSuffrage, WsServer,
+        AdminApiServer, BaseP2PApiServer, ClusterMembership, ConductorApiServer,
+        DevEngineApiServer, HealthzApiServer, RollupNodeApiServer, ServerSuffrage, WsServer,
     };
     use crate::{OutputResponse, health::HealthzResponse};
 

--- a/crates/consensus/rpc/src/lib.rs
+++ b/crates/consensus/rpc/src/lib.rs
@@ -29,8 +29,9 @@ mod jsonrpsee;
 #[cfg(feature = "client")]
 pub use jsonrpsee::{AdminApiClient, BaseP2PApiClient, ConductorApiClient, RollupNodeApiClient};
 pub use jsonrpsee::{
-    AdminApiServer, BaseP2PApiServer, ConductorApiServer, DevEngineApiServer, HealthzApiServer,
-    RollupNodeApiServer, WsServer,
+    AdminApiServer, BaseP2PApiServer, ClusterMembership, ConductorApiServer, DevEngineApiServer,
+    HealthzApiServer, RollupNodeApiServer, ServerInfo, ServerSuffrage, UnknownServerSuffrage,
+    WsServer,
 };
 
 mod l1_watcher;


### PR DESCRIPTION
## Summary

Extends the `ConductorApi` jsonrpsee client trait with the upstream
op-conductor methods needed by `basectl` to surface cluster state and
control sequencing.

This is **PR A of a 4-PR split** for the basectl conductor controls
feature.
PRs B/C/D will land the basectl wiring; this PR has no callers yet,
intentionally — it's the foundation that everything else depends on.

## What

**6 new \`ConductorApi\` trait methods** (matching upstream Optimism
[\`op-conductor/rpc/api.go\`](https://github.com/ethereum-optimism/optimism/blob/main/op-conductor/rpc/api.go)):

| Wire name             | Rust binding                       | Returns               |
| --------------------- | ---------------------------------- | --------------------- |
| \`pause\`               | \`conductor_pause\`                  | \`()\`                  |
| \`resume\`              | \`conductor_resume\`                 | \`()\`                  |
| \`paused\`              | \`conductor_paused\`                 | \`bool\`                |
| \`stopped\`             | \`conductor_stopped\`                | \`bool\`                |
| \`sequencerHealthy\`    | \`conductor_sequencer_healthy\`      | \`bool\`                |
| \`clusterMembership\`   | \`conductor_cluster_membership\`     | \`ClusterMembership\`   |

**4 new public types** for \`clusterMembership\`:
- \`ClusterMembership { servers, version }\`
- \`ServerInfo { id, addr, suffrage }\` — the \`addr\` docstring loudly warns it's the **Raft binary protocol port** (e.g. \`op-conductor-1:5051\`), NOT the JSON-RPC URL (verified against devnet: raft 5051 vs RPC 6545)
- \`ServerSuffrage { Voter, Nonvoter }\` — wire format is numeric (0/1) via \`#[serde(try_from = \"u8\", into = \"u8\")]\`, matching upstream Go's int enum
- \`UnknownServerSuffrage\` — thiserror error type for unknown discriminants

## Tests

Two new tests in addition to the 6 wire-name cases appended to the existing rstest:
- \`server_suffrage_wire_format_is_numeric\` — verifies 0/1 round-trip and rejects 2
- \`cluster_membership_round_trips_upstream_wire_format\` — round-trips the upstream-format JSON example with 3 servers (Voter/Nonvoter mix), asserts version + suffrage + full reserialize equality

\`cargo test -p base-consensus-rpc --lib\` → 55 passed.
\`cargo clippy -p base-consensus-rpc --all-targets\` → clean.