### PR TITLE
feat(basectl): per-node mutation overlay (PR B)

### DIFF
--- a/crates/infra/basectl/src/app/mod.rs
+++ b/crates/infra/basectl/src/app/mod.rs
@@ -21,6 +21,7 @@ pub use view::View;
 /// TUI view implementations.
 mod views;
 pub use views::{
-    CommandCenterView, ConductorView, ConfigView, DaMonitorView, FlashblocksView, HomeView,
-    ProofsView, TransactionPane, UpgradesView, create_view,
+    ActionMenuItem, CommandCenterView, ConductorView, ConfigView, ConfirmButton, DaMonitorView,
+    FlashblocksView, HomeView, Overlay, PendingAction, ProofsView, TransactionPane, UpgradesView,
+    create_view,
 };

--- a/crates/infra/basectl/src/app/views/conductor.rs
+++ b/crates/infra/basectl/src/app/views/conductor.rs
@@ -95,8 +95,10 @@ impl ActionMenuItem {
             Self::TransferLeaderHere => node.is_leader == Some(false),
             Self::ConductorPause => node.conductor_paused == Some(false),
             Self::ConductorResume => node.conductor_paused == Some(true),
-            Self::StartSequencer => node.sequencer_active != Some(true),
-            Self::StopSequencer => node.sequencer_active == Some(true),
+            Self::StartSequencer => {
+                node.is_leader == Some(true) && node.sequencer_active == Some(false)
+            }
+            Self::StopSequencer => node.sequencer_active.is_some(),
             Self::TransferLeaderAny | Self::P2PToggle | Self::RestartContainers => true,
         }
     }
@@ -899,7 +901,7 @@ fn render_hash_input(
         .split(inner);
 
     let prompt = Paragraph::new(Line::from(vec![Span::styled(
-        "Unsafe head hash (64 hex chars, with or without 0x)",
+        "Unsafe head hash (64 hex chars; 0x shown automatically)",
         Style::default().fg(Color::White),
     )]));
     f.render_widget(prompt, layout[0]);

--- a/crates/infra/basectl/src/app/views/conductor.rs
+++ b/crates/infra/basectl/src/app/views/conductor.rs
@@ -98,7 +98,7 @@ impl ActionMenuItem {
             Self::StartSequencer => {
                 node.is_leader == Some(true) && node.sequencer_active == Some(false)
             }
-            Self::StopSequencer => node.sequencer_active.is_some(),
+            Self::StopSequencer => node.sequencer_active == Some(true),
             Self::TransferLeaderAny | Self::P2PToggle | Self::RestartContainers => true,
         }
     }

--- a/crates/infra/basectl/src/app/views/conductor.rs
+++ b/crates/infra/basectl/src/app/views/conductor.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::{collections::HashMap, str::FromStr};
 
 use alloy_primitives::B256;
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
@@ -230,6 +230,10 @@ pub struct ConductorView {
     pause_rx: PauseRx,
     /// In-flight result channel for the soft P2P-reconnect operation.
     unpause_rx: Option<mpsc::Receiver<Result<String, String>>>,
+    /// Name of the node currently being reconnected, if any. Used to remove the saved
+    /// peer list from `paused_node_peers` only after a successful reconnect, so a
+    /// failed RPC leaves the saved peers intact for retry.
+    reconnecting_node: Option<String>,
     /// Saved peer lists for each soft-isolated node, keyed by node name.
     /// Presence in this map means the node is currently P2P-isolated.
     paused_node_peers: HashMap<String, PausedPeers>,
@@ -334,10 +338,11 @@ impl ConductorView {
             }
             PendingAction::P2PReconnect(name) => {
                 let node = nodes_cfg.iter().find(|n| n.name == name).cloned();
-                let peers = self.paused_node_peers.remove(&name);
+                let peers = self.paused_node_peers.get(&name).cloned();
                 if let (Some(node), Some(peers)) = (node, peers) {
                     let (tx, rx) = mpsc::channel(1);
                     self.unpause_rx = Some(rx);
+                    self.reconnecting_node = Some(name);
                     tokio::spawn(unpause_sequencer_node(node, peers, tx));
                 } else {
                     self.op_pending = false;
@@ -397,7 +402,10 @@ impl View for ConductorView {
     }
 
     fn captures_char_input(&self) -> bool {
-        matches!(self.overlay, Overlay::HashInput { .. })
+        // Any open overlay handles its own keys (including Confirm's y/n shortcuts and
+        // ActionMenu's j/k navigation), so the framework should not intercept Char keys
+        // for its own bindings while an overlay is open.
+        self.is_overlay_open()
     }
 
     fn tick(&mut self, resources: &mut Resources) -> Action {
@@ -431,8 +439,14 @@ impl View for ConductorView {
         {
             self.op_pending = false;
             self.unpause_rx = None;
+            let node_name = self.reconnecting_node.take();
             match result {
-                Ok(msg) => resources.toasts.push(Toast::info(msg)),
+                Ok(msg) => {
+                    if let Some(name) = node_name {
+                        self.paused_node_peers.remove(&name);
+                    }
+                    resources.toasts.push(Toast::info(msg));
+                }
                 Err(msg) => resources.toasts.push(Toast::warning(msg)),
             }
         }
@@ -441,8 +455,7 @@ impl View for ConductorView {
     }
 
     fn handle_key(&mut self, key: KeyEvent, resources: &mut Resources) -> Action {
-        let nodes = resources.conductor.nodes.clone();
-        let node_count = nodes.len();
+        let node_count = resources.conductor.nodes.len();
 
         match &mut self.overlay {
             Overlay::HashInput { node: target, input, cursor, prefilled } => {
@@ -468,8 +481,12 @@ impl View for ConductorView {
                     KeyCode::Home => *cursor = 0,
                     KeyCode::End => *cursor = input.len(),
                     KeyCode::F(5) => {
-                        if let Some(hash) =
-                            nodes.iter().find(|n| n.name == *target).and_then(|n| n.unsafe_l2_hash)
+                        if let Some(hash) = resources
+                            .conductor
+                            .nodes
+                            .iter()
+                            .find(|n| n.name == *target)
+                            .and_then(|n| n.unsafe_l2_hash)
                         {
                             *input = format!("{hash:x}");
                             *cursor = input.len();
@@ -544,7 +561,8 @@ impl View for ConductorView {
                     }
                     KeyCode::Enter => {
                         let cursor_idx = *cursor;
-                        if let Some(node) = self.selected_node(&nodes).cloned() {
+                        if let Some(node) = self.selected_node(&resources.conductor.nodes).cloned()
+                        {
                             let item = MENU_ITEMS[cursor_idx];
                             let is_p2p_isolated = self.paused_node_peers.contains_key(&node.name);
                             self.select_menu_item(item, &node, is_p2p_isolated);
@@ -649,19 +667,8 @@ impl View for ConductorView {
 }
 
 /// Parses a hex-encoded 32-byte hash, accepting both `0x`-prefixed and bare forms.
-///
-/// Returns `None` if the input (after stripping `0x`/`0X`) is not exactly 64
-/// hex characters.
 fn parse_hex_hash(input: &str) -> Option<B256> {
-    let trimmed = input.strip_prefix("0x").or_else(|| input.strip_prefix("0X")).unwrap_or(input);
-    if trimmed.len() != 64 || !trimmed.chars().all(|c| c.is_ascii_hexdigit()) {
-        return None;
-    }
-    let mut buf = [0u8; 32];
-    for i in 0..32 {
-        buf[i] = u8::from_str_radix(&trimmed[i * 2..i * 2 + 2], 16).ok()?;
-    }
-    Some(B256::from(buf))
+    B256::from_str(input).ok()
 }
 
 fn render_unconfigured(f: &mut Frame<'_>, area: Rect) {
@@ -777,9 +784,7 @@ fn render_action_menu(
             (true, true) => Style::default()
                 .fg(COLOR_BASE_BLUE)
                 .add_modifier(Modifier::BOLD | Modifier::REVERSED),
-            (true, false) => {
-                Style::default().fg(Color::DarkGray).add_modifier(Modifier::REVERSED)
-            }
+            (true, false) => Style::default().fg(Color::DarkGray).add_modifier(Modifier::REVERSED),
             (false, true) => Style::default().fg(Color::White),
             (false, false) => Style::default().fg(Color::DarkGray),
         };
@@ -912,7 +917,10 @@ fn render_hash_input(
         layout[2],
     );
 
-    let cursor_col = inner.x + 2 + cursor as u16;
+    // `cursor` is bounded by the input length, which the key handler caps at 64
+    // hex chars, so the conversion never truncates in practice; the saturating
+    // cast guards against future changes to that invariant.
+    let cursor_col = inner.x + 2 + u16::try_from(cursor).unwrap_or(u16::MAX);
     let cursor_col = cursor_col.min(inner.x + inner.width.saturating_sub(1));
     f.set_cursor_position((cursor_col, layout[2].y));
 
@@ -959,9 +967,10 @@ fn render_cluster_table(
     let inner = block.inner(area);
     f.render_widget(block, area);
 
+    debug_assert!(!nodes.is_empty(), "render_cluster_table requires at least one node");
     let node_count = nodes.len();
     let label_pct = 15u16;
-    let node_pct = (100u16 - label_pct) / node_count as u16;
+    let node_pct = (100u16 - label_pct) / node_count.max(1) as u16;
 
     let mut constraints = vec![Constraint::Percentage(label_pct)];
     for _ in 0..node_count {
@@ -1338,9 +1347,10 @@ fn render_validator_table(f: &mut Frame<'_>, area: Rect, nodes: &[ValidatorNodeS
     let inner = block.inner(area);
     f.render_widget(block, area);
 
+    debug_assert!(!nodes.is_empty(), "render_validator_table requires at least one node");
     let node_count = nodes.len();
     let label_pct = 15u16;
-    let node_pct = (100u16 - label_pct) / node_count as u16;
+    let node_pct = (100u16 - label_pct) / node_count.max(1) as u16;
 
     let mut constraints = vec![Constraint::Percentage(label_pct)];
     for _ in 0..node_count {
@@ -1567,4 +1577,36 @@ fn section_row(label: &str, node_count: usize) -> Row<'static> {
         cells.push(Cell::from("──────────────").style(sep_style));
     }
     Row::new(cells).height(1)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SAMPLE_HEX: &str = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
+    #[test]
+    fn parses_bare_hex_hash() {
+        let parsed = parse_hex_hash(SAMPLE_HEX).expect("bare 64-char hex parses");
+        assert_eq!(parsed, B256::from_str(SAMPLE_HEX).unwrap());
+    }
+
+    #[test]
+    fn parses_0x_prefixed_hex_hash() {
+        let prefixed = format!("0x{SAMPLE_HEX}");
+        let parsed = parse_hex_hash(&prefixed).expect("0x-prefixed 64-char hex parses");
+        assert_eq!(parsed, B256::from_str(SAMPLE_HEX).unwrap());
+    }
+
+    #[test]
+    fn rejects_wrong_length() {
+        assert!(parse_hex_hash("dead").is_none());
+        assert!(parse_hex_hash(&format!("0x{SAMPLE_HEX}ff")).is_none());
+    }
+
+    #[test]
+    fn rejects_non_hex() {
+        let bad = "g".repeat(64);
+        assert!(parse_hex_hash(&bad).is_none());
+    }
 }

--- a/crates/infra/basectl/src/app/views/conductor.rs
+++ b/crates/infra/basectl/src/app/views/conductor.rs
@@ -1,10 +1,11 @@
 use std::collections::HashMap;
 
-use crossterm::event::{KeyCode, KeyEvent};
+use alloy_primitives::B256;
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use ratatui::{
     layout::{Alignment, Constraint, Direction, Layout, Rect},
     prelude::*,
-    widgets::{Block, Borders, Cell, Paragraph, Row, Table, TableState},
+    widgets::{Block, Borders, Cell, Clear, Paragraph, Row, Table, TableState, Wrap},
 };
 use tokio::sync::mpsc;
 
@@ -12,87 +13,372 @@ use crate::{
     app::{Action, Resources, View},
     commands::COLOR_BASE_BLUE,
     rpc::{
-        ConductorNodeStatus, PausedPeers, ValidatorNodeStatus, pause_sequencer_node,
-        restart_conductor_node, transfer_conductor_leader, unpause_sequencer_node,
+        ConductorNodeStatus, PausedPeers, ValidatorNodeStatus, conductor_pause_node,
+        conductor_resume_node, pause_sequencer_node, restart_conductor_node, start_sequencer_node,
+        stop_sequencer_node, transfer_conductor_leader, unpause_sequencer_node,
     },
     tui::{Keybinding, Toast},
 };
 
 const KEYBINDINGS: &[Keybinding] = &[
     Keybinding { key: "←/→", description: "Select node" },
-    Keybinding { key: "t", description: "Transfer (any peer)" },
-    Keybinding { key: "Enter", description: "Transfer to selected" },
-    Keybinding { key: "r", description: "Restart selected node" },
-    Keybinding { key: "p", description: "Pause/unpause conductor" },
+    Keybinding { key: "Enter", description: "Open action menu" },
+    Keybinding { key: "t", description: "Transfer leader (any)" },
     Keybinding { key: "Esc", description: "Back to home" },
     Keybinding { key: "?", description: "Toggle help" },
 ];
 
 type PauseRx = Option<(String, mpsc::Receiver<Result<(String, PausedPeers), String>>)>;
 
-/// HA conductor cluster status view.
+/// Items rendered in the per-node action menu.
+///
+/// Each variant maps either to a [`PendingAction`] (after confirmation) or to a
+/// transition into [`Overlay::HashInput`] (for inputs that require a value).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ActionMenuItem {
+    /// Transfer leadership to an unspecified healthy peer.
+    TransferLeaderAny,
+    /// Transfer leadership to the currently-selected node.
+    TransferLeaderHere,
+    /// Pause the conductor's control loop on the selected node.
+    ConductorPause,
+    /// Resume the conductor's control loop on the selected node.
+    ConductorResume,
+    /// Start the sequencer on the selected node at a chosen unsafe head.
+    StartSequencer,
+    /// Stop the sequencer on the selected node.
+    StopSequencer,
+    /// Toggle soft P2P isolation (disconnect / reconnect every CL+EL peer).
+    P2PToggle,
+    /// Restart the EL/CL/conductor docker containers in dependency order.
+    RestartContainers,
+}
+
+const MENU_ITEMS: &[ActionMenuItem] = &[
+    ActionMenuItem::TransferLeaderAny,
+    ActionMenuItem::TransferLeaderHere,
+    ActionMenuItem::ConductorPause,
+    ActionMenuItem::ConductorResume,
+    ActionMenuItem::StartSequencer,
+    ActionMenuItem::StopSequencer,
+    ActionMenuItem::P2PToggle,
+    ActionMenuItem::RestartContainers,
+];
+
+impl ActionMenuItem {
+    /// Returns the menu label, contextualized by node state where relevant.
+    pub const fn label(self, _node: &ConductorNodeStatus, is_p2p_isolated: bool) -> &'static str {
+        match self {
+            Self::TransferLeaderAny => "Transfer leader (any peer)",
+            Self::TransferLeaderHere => "Transfer leader here",
+            Self::ConductorPause => "Conductor pause",
+            Self::ConductorResume => "Conductor resume",
+            Self::StartSequencer => "Start sequencer…",
+            Self::StopSequencer => "Stop sequencer",
+            Self::P2PToggle => {
+                if is_p2p_isolated {
+                    "P2P reconnect"
+                } else {
+                    "P2P isolate"
+                }
+            }
+            Self::RestartContainers => "Restart containers",
+        }
+    }
+
+    /// Returns whether the action makes sense given the current node state.
+    ///
+    /// Disabled items remain visible (greyed out) so operators always see the
+    /// full menu and don't have to guess what's missing.
+    pub fn enabled(self, node: &ConductorNodeStatus, _is_p2p_isolated: bool) -> bool {
+        match self {
+            Self::TransferLeaderHere => node.is_leader == Some(false),
+            Self::ConductorPause => node.conductor_paused == Some(false),
+            Self::ConductorResume => node.conductor_paused == Some(true),
+            Self::StartSequencer => node.sequencer_active != Some(true),
+            Self::StopSequencer => node.sequencer_active == Some(true),
+            Self::TransferLeaderAny | Self::P2PToggle | Self::RestartContainers => true,
+        }
+    }
+}
+
+/// Yes / No selector inside the confirmation overlay.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConfirmButton {
+    /// Confirm and execute the action.
+    Yes,
+    /// Cancel and return to the previous overlay.
+    No,
+}
+
+/// A mutation queued behind a confirmation prompt.
+#[derive(Debug, Clone)]
+pub enum PendingAction {
+    /// Transfer leadership to any healthy peer.
+    TransferAny,
+    /// Transfer leadership to the named node.
+    TransferTo(String),
+    /// Restart docker containers on the named node.
+    RestartNode(String),
+    /// Soft-isolate the named node by disconnecting every CL+EL peer.
+    P2PIsolate(String),
+    /// Reconnect a previously isolated node using its saved peers.
+    P2PReconnect(String),
+    /// Pause the conductor's control loop on the named node.
+    ConductorPause(String),
+    /// Resume the conductor's control loop on the named node.
+    ConductorResume(String),
+    /// Start the sequencer at the given unsafe head hash.
+    StartSequencer {
+        /// Target conductor / sequencer node name.
+        node: String,
+        /// Unsafe head hash to start from. Server rejects [`B256::ZERO`].
+        hash: B256,
+    },
+    /// Stop the sequencer on the named node.
+    StopSequencer(String),
+}
+
+impl PendingAction {
+    /// Human-readable description shown inside the confirmation overlay.
+    pub fn description(&self) -> String {
+        match self {
+            Self::TransferAny => "Transfer leadership to any healthy peer?".to_string(),
+            Self::TransferTo(name) => format!("Transfer leadership to {name}?"),
+            Self::RestartNode(name) => format!("Restart EL/CL/conductor containers on {name}?"),
+            Self::P2PIsolate(name) => {
+                format!("Disconnect every CL+EL peer on {name}? (soft pause)")
+            }
+            Self::P2PReconnect(name) => format!("Reconnect saved peers on {name}?"),
+            Self::ConductorPause(name) => format!("Pause conductor control loop on {name}?"),
+            Self::ConductorResume(name) => format!("Resume conductor control loop on {name}?"),
+            Self::StartSequencer { node, hash } => {
+                format!("Start sequencer on {node} at {hash}?")
+            }
+            Self::StopSequencer(name) => format!("Stop sequencer on {name}?"),
+        }
+    }
+
+    /// Whether the action is destructive enough to warrant a red confirm button.
+    pub const fn is_destructive(&self) -> bool {
+        matches!(
+            self,
+            Self::TransferAny
+                | Self::TransferTo(_)
+                | Self::RestartNode(_)
+                | Self::P2PIsolate(_)
+                | Self::ConductorPause(_)
+                | Self::StopSequencer(_)
+        )
+    }
+}
+
+/// Modal overlay state for [`ConductorView`].
+///
+/// Only one overlay can be active at a time. While active, key handling and
+/// rendering route through the overlay's branch instead of the underlying
+/// status table.
+#[derive(Debug, Default)]
+pub enum Overlay {
+    /// No overlay; status table is interactive.
+    #[default]
+    None,
+    /// Per-node action menu, with `cursor` indexing into [`MENU_ITEMS`].
+    ActionMenu {
+        /// Currently-highlighted menu item index.
+        cursor: usize,
+    },
+    /// Yes/No confirmation prompt for a pending action.
+    Confirm {
+        /// The action to execute on `Yes`.
+        action: PendingAction,
+        /// Currently-highlighted confirm button.
+        button: ConfirmButton,
+    },
+    /// Free-text hex input used for `admin_startSequencer`.
+    HashInput {
+        /// Target node name (carried so we can spawn the mutation directly).
+        node: String,
+        /// Current input buffer (without the leading `0x`).
+        input: String,
+        /// Cursor offset within `input`.
+        cursor: usize,
+        /// True when the buffer was prefilled from a poll snapshot.
+        prefilled: bool,
+    },
+}
+
+/// HA conductor cluster status view with per-node action overlay.
 ///
 /// Renders a fixed grid with one column per conductor node and rows for
-/// role (leader / follower / offline), unsafe/safe/finalized L2 block, and P2P peer count.
-/// The user can navigate columns with `←`/`→` and trigger leadership transfers
-/// with `t` (any peer) or `Enter` (selected node). A footer bar always shows
-/// the available key bindings. When no conductor configuration is present
-/// (e.g. mainnet), a placeholder message is shown instead.
+/// role, conductor state (paused / stopped / healthy / sequencer-active),
+/// CL block heads, and EL block heads. The user navigates columns with
+/// `←`/`→` and opens a per-node action menu with `Enter`. Mutating actions
+/// are gated behind a `Yes` / `No` confirmation overlay; `Start sequencer`
+/// additionally prompts for an unsafe head hash, prefilled from the latest
+/// poll snapshot.
 #[derive(Debug, Default)]
 pub struct ConductorView {
     selected: usize,
+    overlay: Overlay,
     op_pending: bool,
-    /// In-flight result channel for transfer / restart operations.
+    /// In-flight result channel for any mutation returning `Result<String, String>`
+    /// (transfer, restart, conductor pause/resume, sequencer start/stop).
     op_rx: Option<mpsc::Receiver<Result<String, String>>>,
-    /// In-flight result channel for pause operations.
-    /// Carries `(node_name, result)` where `Ok` includes the peers that were saved.
+    /// In-flight result channel for the soft P2P-isolate operation.
+    /// Carries `(node_name, result)` where `Ok` includes the saved peers.
     pause_rx: PauseRx,
-    /// In-flight result channel for unpause operations.
+    /// In-flight result channel for the soft P2P-reconnect operation.
     unpause_rx: Option<mpsc::Receiver<Result<String, String>>>,
-    /// Saved peer lists for each paused node, keyed by node name.
-    /// Presence in this map means the node is currently paused.
+    /// Saved peer lists for each soft-isolated node, keyed by node name.
+    /// Presence in this map means the node is currently P2P-isolated.
     paused_node_peers: HashMap<String, PausedPeers>,
 }
 
 impl ConductorView {
-    /// Creates a new conductor view.
+    /// Creates a new conductor view with no overlay open.
     pub fn new() -> Self {
         Self::default()
     }
 
-    fn start_transfer(&mut self, resources: &Resources, target_name: Option<String>) {
-        let Some(ref nodes) = resources.config.conductors else { return };
-        let (tx, rx) = mpsc::channel(1);
-        self.op_rx = Some(rx);
-        self.op_pending = true;
-        tokio::spawn(transfer_conductor_leader(nodes.clone(), target_name, tx));
+    const fn is_overlay_open(&self) -> bool {
+        !matches!(self.overlay, Overlay::None)
     }
 
-    fn start_restart(&mut self, resources: &Resources) {
-        let Some(ref nodes) = resources.config.conductors else { return };
-        let idx = self.selected.min(nodes.len().saturating_sub(1));
-        let node = nodes[idx].clone();
-        let (tx, rx) = mpsc::channel(1);
-        self.op_rx = Some(rx);
-        self.op_pending = true;
-        tokio::spawn(restart_conductor_node(node, tx));
+    fn close_overlay(&mut self) {
+        self.overlay = Overlay::None;
     }
 
-    fn start_pause_toggle(&mut self, resources: &Resources) {
-        let Some(ref nodes) = resources.config.conductors else { return };
-        let idx = self.selected.min(nodes.len().saturating_sub(1));
-        let node = nodes[idx].clone();
+    fn selected_node<'a>(
+        &self,
+        nodes: &'a [ConductorNodeStatus],
+    ) -> Option<&'a ConductorNodeStatus> {
+        if nodes.is_empty() { None } else { Some(&nodes[self.selected.min(nodes.len() - 1)]) }
+    }
+
+    fn open_action_menu(&mut self) {
+        self.overlay = Overlay::ActionMenu { cursor: 0 };
+    }
+
+    /// Resolves a menu item into an overlay transition (or a no-op).
+    fn select_menu_item(
+        &mut self,
+        item: ActionMenuItem,
+        node: &ConductorNodeStatus,
+        is_p2p_isolated: bool,
+    ) {
+        if !item.enabled(node, is_p2p_isolated) {
+            return;
+        }
+        let name = node.name.clone();
+        let action = match item {
+            ActionMenuItem::TransferLeaderAny => Some(PendingAction::TransferAny),
+            ActionMenuItem::TransferLeaderHere => Some(PendingAction::TransferTo(name)),
+            ActionMenuItem::ConductorPause => Some(PendingAction::ConductorPause(name)),
+            ActionMenuItem::ConductorResume => Some(PendingAction::ConductorResume(name)),
+            ActionMenuItem::StopSequencer => Some(PendingAction::StopSequencer(name)),
+            ActionMenuItem::RestartContainers => Some(PendingAction::RestartNode(name)),
+            ActionMenuItem::P2PToggle => Some(if is_p2p_isolated {
+                PendingAction::P2PReconnect(name)
+            } else {
+                PendingAction::P2PIsolate(name)
+            }),
+            ActionMenuItem::StartSequencer => {
+                let (input, prefilled) = node
+                    .unsafe_l2_hash
+                    .map_or_else(|| (String::new(), false), |h| (format!("{h:x}"), true));
+                let cursor = input.len();
+                self.overlay = Overlay::HashInput { node: name, input, cursor, prefilled };
+                None
+            }
+        };
+        if let Some(action) = action {
+            self.overlay = Overlay::Confirm { action, button: ConfirmButton::No };
+        }
+    }
+
+    /// Spawns the mutation behind a confirmed action and switches to single-flight.
+    fn execute(&mut self, action: PendingAction, resources: &Resources) {
+        let Some(ref nodes_cfg) = resources.config.conductors else { return };
         self.op_pending = true;
-        if let Some(peers) = self.paused_node_peers.remove(&node.name) {
-            // Already paused — unpause by reconnecting saved peers.
-            let (tx, rx) = mpsc::channel(1);
-            self.unpause_rx = Some(rx);
-            tokio::spawn(unpause_sequencer_node(node, peers, tx));
-        } else {
-            // Not paused — disconnect all peers and save them.
-            let (tx, rx) = mpsc::channel(1);
-            self.pause_rx = Some((node.name.clone(), rx));
-            tokio::spawn(pause_sequencer_node(node, tx));
+        self.close_overlay();
+
+        match action {
+            PendingAction::TransferAny => {
+                let (tx, rx) = mpsc::channel(1);
+                self.op_rx = Some(rx);
+                tokio::spawn(transfer_conductor_leader(nodes_cfg.clone(), None, tx));
+            }
+            PendingAction::TransferTo(target) => {
+                let (tx, rx) = mpsc::channel(1);
+                self.op_rx = Some(rx);
+                tokio::spawn(transfer_conductor_leader(nodes_cfg.clone(), Some(target), tx));
+            }
+            PendingAction::RestartNode(name) => {
+                if let Some(node) = nodes_cfg.iter().find(|n| n.name == name).cloned() {
+                    let (tx, rx) = mpsc::channel(1);
+                    self.op_rx = Some(rx);
+                    tokio::spawn(restart_conductor_node(node, tx));
+                } else {
+                    self.op_pending = false;
+                }
+            }
+            PendingAction::P2PIsolate(name) => {
+                if let Some(node) = nodes_cfg.iter().find(|n| n.name == name).cloned() {
+                    let (tx, rx) = mpsc::channel(1);
+                    self.pause_rx = Some((node.name.clone(), rx));
+                    tokio::spawn(pause_sequencer_node(node, tx));
+                } else {
+                    self.op_pending = false;
+                }
+            }
+            PendingAction::P2PReconnect(name) => {
+                let node = nodes_cfg.iter().find(|n| n.name == name).cloned();
+                let peers = self.paused_node_peers.remove(&name);
+                if let (Some(node), Some(peers)) = (node, peers) {
+                    let (tx, rx) = mpsc::channel(1);
+                    self.unpause_rx = Some(rx);
+                    tokio::spawn(unpause_sequencer_node(node, peers, tx));
+                } else {
+                    self.op_pending = false;
+                }
+            }
+            PendingAction::ConductorPause(name) => {
+                if let Some(node) = nodes_cfg.iter().find(|n| n.name == name).cloned() {
+                    let (tx, rx) = mpsc::channel(1);
+                    self.op_rx = Some(rx);
+                    tokio::spawn(conductor_pause_node(node, tx));
+                } else {
+                    self.op_pending = false;
+                }
+            }
+            PendingAction::ConductorResume(name) => {
+                if let Some(node) = nodes_cfg.iter().find(|n| n.name == name).cloned() {
+                    let (tx, rx) = mpsc::channel(1);
+                    self.op_rx = Some(rx);
+                    tokio::spawn(conductor_resume_node(node, tx));
+                } else {
+                    self.op_pending = false;
+                }
+            }
+            PendingAction::StartSequencer { node: name, hash } => {
+                if let Some(node) = nodes_cfg.iter().find(|n| n.name == name).cloned() {
+                    let (tx, rx) = mpsc::channel(1);
+                    self.op_rx = Some(rx);
+                    tokio::spawn(start_sequencer_node(node, hash, tx));
+                } else {
+                    self.op_pending = false;
+                }
+            }
+            PendingAction::StopSequencer(name) => {
+                if let Some(node) = nodes_cfg.iter().find(|n| n.name == name).cloned() {
+                    let (tx, rx) = mpsc::channel(1);
+                    self.op_rx = Some(rx);
+                    tokio::spawn(stop_sequencer_node(node, tx));
+                } else {
+                    self.op_pending = false;
+                }
+            }
         }
     }
 }
@@ -100,6 +386,18 @@ impl ConductorView {
 impl View for ConductorView {
     fn keybindings(&self) -> &'static [Keybinding] {
         KEYBINDINGS
+    }
+
+    fn consumes_esc(&self) -> bool {
+        self.is_overlay_open()
+    }
+
+    fn consumes_quit(&self) -> bool {
+        self.is_overlay_open()
+    }
+
+    fn captures_char_input(&self) -> bool {
+        matches!(self.overlay, Overlay::HashInput { .. })
     }
 
     fn tick(&mut self, resources: &mut Resources) -> Action {
@@ -143,7 +441,121 @@ impl View for ConductorView {
     }
 
     fn handle_key(&mut self, key: KeyEvent, resources: &mut Resources) -> Action {
-        let node_count = resources.conductor.nodes.len();
+        let nodes = resources.conductor.nodes.clone();
+        let node_count = nodes.len();
+
+        match &mut self.overlay {
+            Overlay::HashInput { node: target, input, cursor, prefilled } => {
+                match key.code {
+                    KeyCode::Esc => self.close_overlay(),
+                    KeyCode::Backspace => {
+                        if *cursor > 0 {
+                            *cursor -= 1;
+                            input.remove(*cursor);
+                            *prefilled = false;
+                        }
+                    }
+                    KeyCode::Left => {
+                        if *cursor > 0 {
+                            *cursor -= 1;
+                        }
+                    }
+                    KeyCode::Right => {
+                        if *cursor < input.len() {
+                            *cursor += 1;
+                        }
+                    }
+                    KeyCode::Home => *cursor = 0,
+                    KeyCode::End => *cursor = input.len(),
+                    KeyCode::F(5) => {
+                        if let Some(hash) =
+                            nodes.iter().find(|n| n.name == *target).and_then(|n| n.unsafe_l2_hash)
+                        {
+                            *input = format!("{hash:x}");
+                            *cursor = input.len();
+                            *prefilled = true;
+                        }
+                    }
+                    KeyCode::Char(c) if !key.modifiers.contains(KeyModifiers::CONTROL) => {
+                        if c.is_ascii_hexdigit() && input.len() < 64 {
+                            input.insert(*cursor, c);
+                            *cursor += 1;
+                            *prefilled = false;
+                        }
+                    }
+                    KeyCode::Enter => {
+                        if let Some(hash) = parse_hex_hash(input) {
+                            if hash == B256::ZERO {
+                                resources
+                                    .toasts
+                                    .push(Toast::warning("Refusing to start at zero hash"));
+                            } else {
+                                let target_clone = target.clone();
+                                self.overlay = Overlay::Confirm {
+                                    action: PendingAction::StartSequencer {
+                                        node: target_clone,
+                                        hash,
+                                    },
+                                    button: ConfirmButton::No,
+                                };
+                            }
+                        } else {
+                            resources.toasts.push(Toast::warning(
+                                "Invalid hash: need 64 hex chars (with or without 0x)".to_string(),
+                            ));
+                        }
+                    }
+                    _ => {}
+                }
+                return Action::None;
+            }
+            Overlay::Confirm { action, button } => {
+                match key.code {
+                    KeyCode::Esc | KeyCode::Char('n' | 'N') => self.close_overlay(),
+                    KeyCode::Left | KeyCode::Right | KeyCode::Tab => {
+                        *button = match *button {
+                            ConfirmButton::Yes => ConfirmButton::No,
+                            ConfirmButton::No => ConfirmButton::Yes,
+                        };
+                    }
+                    KeyCode::Char('y' | 'Y') => {
+                        let action = action.clone();
+                        self.execute(action, resources);
+                    }
+                    KeyCode::Enter => match button {
+                        ConfirmButton::Yes => {
+                            let action = action.clone();
+                            self.execute(action, resources);
+                        }
+                        ConfirmButton::No => self.close_overlay(),
+                    },
+                    _ => {}
+                }
+                return Action::None;
+            }
+            Overlay::ActionMenu { cursor } => {
+                match key.code {
+                    KeyCode::Esc => self.overlay = Overlay::None,
+                    KeyCode::Up | KeyCode::Char('k') => {
+                        *cursor = (*cursor + MENU_ITEMS.len() - 1) % MENU_ITEMS.len();
+                    }
+                    KeyCode::Down | KeyCode::Char('j') => {
+                        *cursor = (*cursor + 1) % MENU_ITEMS.len();
+                    }
+                    KeyCode::Enter => {
+                        let cursor_idx = *cursor;
+                        if let Some(node) = self.selected_node(&nodes).cloned() {
+                            let item = MENU_ITEMS[cursor_idx];
+                            let is_p2p_isolated = self.paused_node_peers.contains_key(&node.name);
+                            self.select_menu_item(item, &node, is_p2p_isolated);
+                        }
+                    }
+                    _ => {}
+                }
+                return Action::None;
+            }
+            Overlay::None => {}
+        }
 
         match key.code {
             KeyCode::Left | KeyCode::Char('h') if node_count > 0 => {
@@ -152,19 +564,14 @@ impl View for ConductorView {
             KeyCode::Right | KeyCode::Char('l') if node_count > 0 => {
                 self.selected = (self.selected + 1) % node_count;
             }
-            KeyCode::Char('t') if !self.op_pending => {
-                self.start_transfer(resources, None);
-            }
             KeyCode::Enter if !self.op_pending && node_count > 0 => {
-                let idx = self.selected.min(node_count - 1);
-                let target = resources.conductor.nodes[idx].name.clone();
-                self.start_transfer(resources, Some(target));
+                self.open_action_menu();
             }
-            KeyCode::Char('r') if !self.op_pending && node_count > 0 => {
-                self.start_restart(resources);
-            }
-            KeyCode::Char('p') if !self.op_pending && node_count > 0 => {
-                self.start_pause_toggle(resources);
+            KeyCode::Char('t') if !self.op_pending => {
+                self.overlay = Overlay::Confirm {
+                    action: PendingAction::TransferAny,
+                    button: ConfirmButton::No,
+                };
             }
             _ => {}
         }
@@ -199,17 +606,10 @@ impl View for ConductorView {
                 );
             }
         } else {
-            // Conductor table: 2 border + 1 header + 16 data rows = 19 lines.
-            // Validator table: 2 border + 1 header + 14 data rows = 17 lines.
-            let conductor_height = 19u16;
-            let validator_height = 17u16;
+            let conductor_height = 23u16;
             let sections = Layout::default()
                 .direction(Direction::Vertical)
-                .constraints([
-                    Constraint::Length(conductor_height),
-                    Constraint::Length(validator_height),
-                    Constraint::Min(0),
-                ])
+                .constraints([Constraint::Length(conductor_height), Constraint::Min(0)])
                 .split(content_area);
 
             if nodes.is_empty() {
@@ -228,8 +628,40 @@ impl View for ConductorView {
             render_validator_table(frame, sections[1], validators);
         }
 
-        render_footer(frame, footer_area, self.op_pending);
+        render_footer(frame, footer_area, &self.overlay, self.op_pending);
+
+        match &self.overlay {
+            Overlay::None => {}
+            Overlay::ActionMenu { cursor } => {
+                if let Some(node) = self.selected_node(nodes) {
+                    let is_p2p_isolated = self.paused_node_peers.contains_key(&node.name);
+                    render_action_menu(frame, area, node, *cursor, is_p2p_isolated);
+                }
+            }
+            Overlay::Confirm { action, button } => {
+                render_confirm(frame, area, action, *button);
+            }
+            Overlay::HashInput { node, input, cursor, prefilled } => {
+                render_hash_input(frame, area, node, input, *cursor, *prefilled);
+            }
+        }
     }
+}
+
+/// Parses a hex-encoded 32-byte hash, accepting both `0x`-prefixed and bare forms.
+///
+/// Returns `None` if the input (after stripping `0x`/`0X`) is not exactly 64
+/// hex characters.
+fn parse_hex_hash(input: &str) -> Option<B256> {
+    let trimmed = input.strip_prefix("0x").or_else(|| input.strip_prefix("0X")).unwrap_or(input);
+    if trimmed.len() != 64 || !trimmed.chars().all(|c| c.is_ascii_hexdigit()) {
+        return None;
+    }
+    let mut buf = [0u8; 32];
+    for i in 0..32 {
+        buf[i] = u8::from_str_radix(&trimmed[i * 2..i * 2 + 2], 16).ok()?;
+    }
+    Some(B256::from(buf))
 }
 
 fn render_unconfigured(f: &mut Frame<'_>, area: Rect) {
@@ -253,51 +685,260 @@ fn render_unconfigured(f: &mut Frame<'_>, area: Rect) {
     f.render_widget(msg, chunks[1]);
 }
 
-fn render_footer(f: &mut Frame<'_>, area: Rect, op_pending: bool) {
+fn render_footer(f: &mut Frame<'_>, area: Rect, overlay: &Overlay, op_pending: bool) {
     let key_style = Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD);
     let desc_style = Style::default().fg(Color::DarkGray);
-    let sep_style = Style::default().fg(Color::DarkGray);
+    let sep = Span::styled("  │  ", desc_style);
 
-    let sep = Span::styled("  │  ", sep_style);
+    let mut spans: Vec<Span<'_>> = Vec::new();
+    let push_pair = |spans: &mut Vec<Span<'_>>, key: &'static str, desc: &'static str| {
+        spans.push(Span::styled(format!("[{key}]"), key_style));
+        spans.push(Span::raw(" "));
+        spans.push(Span::styled(desc, desc_style));
+    };
 
-    let mut spans = vec![
-        Span::styled("[Esc]", key_style),
-        Span::raw(" "),
-        Span::styled("back", desc_style),
-        sep.clone(),
-        Span::styled("[←/→]", key_style),
-        Span::raw(" "),
-        Span::styled("select node", desc_style),
-    ];
-
-    spans.push(sep.clone());
-    if op_pending {
-        spans.push(Span::styled("working…", Style::default().fg(Color::Yellow)));
-    } else {
-        spans.push(Span::styled("[t]", key_style));
-        spans.push(Span::raw(" "));
-        spans.push(Span::styled("transfer to any peer", desc_style));
-        spans.push(sep.clone());
-        spans.push(Span::styled("[Enter]", key_style));
-        spans.push(Span::raw(" "));
-        spans.push(Span::styled("transfer to selected", desc_style));
-        spans.push(sep.clone());
-        spans.push(Span::styled("[r]", key_style));
-        spans.push(Span::raw(" "));
-        spans.push(Span::styled("restart selected", desc_style));
-        spans.push(sep.clone());
-        spans.push(Span::styled("[p]", key_style));
-        spans.push(Span::raw(" "));
-        spans.push(Span::styled("pause/unpause conductor", desc_style));
+    match overlay {
+        Overlay::None => {
+            push_pair(&mut spans, "Esc", "back");
+            spans.push(sep.clone());
+            push_pair(&mut spans, "←/→", "select node");
+            spans.push(sep.clone());
+            if op_pending {
+                spans.push(Span::styled("working…", Style::default().fg(Color::Yellow)));
+            } else {
+                push_pair(&mut spans, "Enter", "actions");
+                spans.push(sep.clone());
+                push_pair(&mut spans, "t", "transfer (any)");
+            }
+        }
+        Overlay::ActionMenu { .. } => {
+            push_pair(&mut spans, "↑/↓", "move");
+            spans.push(sep.clone());
+            push_pair(&mut spans, "Enter", "select");
+            spans.push(sep.clone());
+            push_pair(&mut spans, "Esc", "cancel");
+        }
+        Overlay::Confirm { .. } => {
+            push_pair(&mut spans, "←/→", "Yes / No");
+            spans.push(sep.clone());
+            push_pair(&mut spans, "Enter", "confirm");
+            spans.push(sep.clone());
+            push_pair(&mut spans, "y/n", "shortcut");
+            spans.push(sep.clone());
+            push_pair(&mut spans, "Esc", "cancel");
+        }
+        Overlay::HashInput { .. } => {
+            push_pair(&mut spans, "0-9 a-f", "hex");
+            spans.push(sep.clone());
+            push_pair(&mut spans, "F5", "refresh prefill");
+            spans.push(sep.clone());
+            push_pair(&mut spans, "Enter", "confirm");
+            spans.push(sep.clone());
+            push_pair(&mut spans, "Esc", "cancel");
+        }
     }
 
     spans.push(sep);
-    spans.push(Span::styled("[?]", key_style));
-    spans.push(Span::raw(" "));
-    spans.push(Span::styled("help", desc_style));
+    push_pair(&mut spans, "?", "help");
 
     let footer = Paragraph::new(Line::from(spans));
     f.render_widget(footer, area);
+}
+
+fn render_action_menu(
+    f: &mut Frame<'_>,
+    area: Rect,
+    node: &ConductorNodeStatus,
+    cursor: usize,
+    is_p2p_isolated: bool,
+) {
+    let popup_w = 44u16.min(area.width.saturating_sub(4));
+    let popup_h = (MENU_ITEMS.len() as u16 + 5).min(area.height.saturating_sub(4));
+    let x = area.x + area.width.saturating_sub(popup_w) / 2;
+    let y = area.y + area.height.saturating_sub(popup_h) / 2;
+    let popup = Rect { x, y, width: popup_w, height: popup_h };
+
+    f.render_widget(Clear, popup);
+
+    let title = format!(" Actions: {} ", node.name);
+    let block = Block::default()
+        .title(title)
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(COLOR_BASE_BLUE));
+    let inner = block.inner(popup);
+    f.render_widget(block, popup);
+
+    let mut lines: Vec<Line<'_>> = Vec::with_capacity(MENU_ITEMS.len() + 2);
+    for (i, item) in MENU_ITEMS.iter().enumerate() {
+        let enabled = item.enabled(node, is_p2p_isolated);
+        let label = item.label(node, is_p2p_isolated);
+        let marker = if i == cursor { "› " } else { "  " };
+        let style = match (i == cursor, enabled) {
+            (true, true) => Style::default()
+                .fg(COLOR_BASE_BLUE)
+                .add_modifier(Modifier::BOLD | Modifier::REVERSED),
+            (true, false) => {
+                Style::default().fg(Color::DarkGray).add_modifier(Modifier::REVERSED)
+            }
+            (false, true) => Style::default().fg(Color::White),
+            (false, false) => Style::default().fg(Color::DarkGray),
+        };
+        lines.push(Line::from(vec![Span::styled(format!("{marker}{label}"), style)]));
+    }
+
+    lines.push(Line::raw(""));
+    lines.push(Line::from(vec![Span::styled(
+        "  ↑/↓ move   Enter select   Esc cancel",
+        Style::default().fg(Color::DarkGray),
+    )]));
+
+    f.render_widget(Paragraph::new(lines), inner);
+}
+
+fn render_confirm(f: &mut Frame<'_>, area: Rect, action: &PendingAction, button: ConfirmButton) {
+    let popup_w = 60u16.min(area.width.saturating_sub(4));
+    let popup_h = 8u16.min(area.height.saturating_sub(4));
+    let x = area.x + area.width.saturating_sub(popup_w) / 2;
+    let y = area.y + area.height.saturating_sub(popup_h) / 2;
+    let popup = Rect { x, y, width: popup_w, height: popup_h };
+
+    f.render_widget(Clear, popup);
+
+    let block = Block::default()
+        .title(" Confirm ")
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(COLOR_BASE_BLUE));
+    let inner = block.inner(popup);
+    f.render_widget(block, popup);
+
+    let body = Paragraph::new(action.description())
+        .style(Style::default().fg(Color::White))
+        .alignment(Alignment::Center)
+        .wrap(Wrap { trim: true });
+
+    let layout = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(2),
+            Constraint::Length(1),
+            Constraint::Length(1),
+            Constraint::Length(1),
+        ])
+        .split(inner);
+
+    f.render_widget(body, layout[0]);
+
+    let yes_color = if action.is_destructive() { Color::Red } else { Color::Green };
+    let yes_style = match button {
+        ConfirmButton::Yes => {
+            Style::default().fg(yes_color).add_modifier(Modifier::BOLD | Modifier::REVERSED)
+        }
+        ConfirmButton::No => Style::default().fg(yes_color),
+    };
+    let no_style = match button {
+        ConfirmButton::No => {
+            Style::default().fg(Color::White).add_modifier(Modifier::BOLD | Modifier::REVERSED)
+        }
+        ConfirmButton::Yes => Style::default().fg(Color::White),
+    };
+
+    let buttons = Line::from(vec![
+        Span::styled("[ Yes ]", yes_style),
+        Span::raw("    "),
+        Span::styled("[ No ]", no_style),
+    ]);
+    f.render_widget(Paragraph::new(buttons).alignment(Alignment::Center), layout[2]);
+
+    let hint = Line::from(vec![Span::styled(
+        "←/→ select   Enter confirm   y/n shortcut   Esc cancel",
+        Style::default().fg(Color::DarkGray),
+    )]);
+    f.render_widget(Paragraph::new(hint).alignment(Alignment::Center), layout[3]);
+}
+
+fn render_hash_input(
+    f: &mut Frame<'_>,
+    area: Rect,
+    node: &str,
+    input: &str,
+    cursor: usize,
+    prefilled: bool,
+) {
+    let popup_w = 76u16.min(area.width.saturating_sub(4));
+    let popup_h = 9u16.min(area.height.saturating_sub(4));
+    let x = area.x + area.width.saturating_sub(popup_w) / 2;
+    let y = area.y + area.height.saturating_sub(popup_h) / 2;
+    let popup = Rect { x, y, width: popup_w, height: popup_h };
+
+    f.render_widget(Clear, popup);
+
+    let title = format!(" Start sequencer on {node} ");
+    let block = Block::default()
+        .title(title)
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(COLOR_BASE_BLUE));
+    let inner = block.inner(popup);
+    f.render_widget(block, popup);
+
+    let layout = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(1),
+            Constraint::Length(1),
+            Constraint::Length(1),
+            Constraint::Length(1),
+            Constraint::Length(1),
+            Constraint::Length(1),
+            Constraint::Length(1),
+        ])
+        .split(inner);
+
+    let prompt = Paragraph::new(Line::from(vec![Span::styled(
+        "Unsafe head hash (64 hex chars, with or without 0x)",
+        Style::default().fg(Color::White),
+    )]));
+    f.render_widget(prompt, layout[0]);
+
+    let trimmed = trim_prefix(input);
+    let display = format!("0x{trimmed}");
+    let valid = parse_hex_hash(input).is_some_and(|h| h != B256::ZERO);
+    let progress = format!("({} / 64 hex chars)", trimmed.len());
+    let progress_color = if valid { Color::Green } else { Color::Yellow };
+
+    let value_style =
+        if valid { Style::default().fg(Color::Green) } else { Style::default().fg(Color::White) };
+    f.render_widget(
+        Paragraph::new(Line::from(vec![Span::styled(display, value_style)])),
+        layout[2],
+    );
+
+    let cursor_col = inner.x + 2 + cursor as u16;
+    let cursor_col = cursor_col.min(inner.x + inner.width.saturating_sub(1));
+    f.set_cursor_position((cursor_col, layout[2].y));
+
+    let progress_line = Paragraph::new(Line::from(vec![Span::styled(
+        progress,
+        Style::default().fg(progress_color),
+    )]));
+    f.render_widget(progress_line, layout[3]);
+
+    if prefilled {
+        let prefill_hint = Paragraph::new(Line::from(vec![Span::styled(
+            "Prefilled from latest poll. F5 to refresh, edit to override.",
+            Style::default().fg(Color::Cyan),
+        )]));
+        f.render_widget(prefill_hint, layout[5]);
+    }
+
+    let hint = Paragraph::new(Line::from(vec![Span::styled(
+        "Enter confirm   F5 refresh   Esc cancel",
+        Style::default().fg(Color::DarkGray),
+    )]));
+    f.render_widget(hint, layout[6]);
+}
+
+fn trim_prefix(input: &str) -> &str {
+    input.strip_prefix("0x").or_else(|| input.strip_prefix("0X")).unwrap_or(input)
 }
 
 fn render_cluster_table(
@@ -318,7 +959,6 @@ fn render_cluster_table(
     let inner = block.inner(area);
     f.render_widget(block, area);
 
-    // Column widths: one fixed label column + one equal-width column per node.
     let node_count = nodes.len();
     let label_pct = 15u16;
     let node_pct = (100u16 - label_pct) / node_count as u16;
@@ -340,7 +980,6 @@ fn render_cluster_table(
     let mut header_cells = vec![Cell::from("")];
     for (i, node) in nodes.iter().enumerate() {
         let is_selected = i == selected;
-        // Role-driven color; selection adds underline independently.
         let role_color = match node.is_leader {
             Some(true) => Color::Yellow,
             Some(false) => Color::DarkGray,
@@ -363,7 +1002,7 @@ fn render_cluster_table(
     ];
     for node in nodes {
         let (label, style) = if paused_nodes.contains_key(&node.name) {
-            ("⏸  paused", Style::default().fg(Color::Cyan))
+            ("⏸  isolated", Style::default().fg(Color::Cyan))
         } else {
             match node.is_leader {
                 Some(true) => {
@@ -376,6 +1015,75 @@ fn render_cluster_table(
         role_cells.push(Cell::from(label).style(style));
     }
     let role_row = Row::new(role_cells).height(1);
+
+    // ── Active row (conductor) ─────────────────────────────────────────────
+    let mut active_cells = vec![
+        Cell::from("  Active")
+            .style(Style::default().fg(Color::White).add_modifier(Modifier::BOLD)),
+    ];
+    for node in nodes {
+        let (label, style) = if paused_nodes.contains_key(&node.name) {
+            ("   isolated", Style::default().fg(Color::Cyan))
+        } else {
+            match (node.is_leader, node.conductor_active) {
+                (Some(true), Some(true)) => ("   yes", Style::default().fg(Color::Green)),
+                (Some(true), Some(false)) => ("   no", Style::default().fg(Color::Red)),
+                (Some(false), Some(false)) => ("   no", Style::default().fg(Color::DarkGray)),
+                (Some(false), Some(true)) => ("   yes", Style::default().fg(Color::Yellow)),
+                _ => ("   ?", Style::default().fg(Color::DarkGray)),
+            }
+        };
+        active_cells.push(Cell::from(label).style(style));
+    }
+    let active_row = Row::new(active_cells).height(1);
+
+    let paused_row = bool_row(
+        "  Paused",
+        nodes,
+        |n| n.conductor_paused,
+        Color::Cyan,
+        Color::Green,
+        ("   yes", "   no"),
+    );
+
+    let stopped_row = bool_row(
+        "  Stopped",
+        nodes,
+        |n| n.conductor_stopped,
+        Color::Red,
+        Color::Green,
+        ("   yes", "   no"),
+    );
+
+    let healthy_row = bool_row(
+        "  Healthy",
+        nodes,
+        |n| n.sequencer_healthy,
+        Color::Green,
+        Color::Red,
+        ("   yes", "   no"),
+    );
+
+    // ── Seq active row (admin RPC) ─────────────────────────────────────────
+    let mut seq_active_cells = vec![
+        Cell::from("  Seq active")
+            .style(Style::default().fg(Color::White).add_modifier(Modifier::BOLD)),
+    ];
+    for node in nodes {
+        let (label, style) = if paused_nodes.contains_key(&node.name) {
+            ("   isolated", Style::default().fg(Color::Cyan))
+        } else {
+            match (node.is_leader, node.sequencer_active) {
+                (Some(true), Some(true)) => ("   yes", Style::default().fg(Color::Green)),
+                (Some(true), Some(false)) => ("   no", Style::default().fg(Color::Red)),
+                (Some(false), Some(false)) => ("   no", Style::default().fg(Color::DarkGray)),
+                (Some(false), Some(true)) => ("   yes", Style::default().fg(Color::Yellow)),
+                _ => ("   ?", Style::default().fg(Color::DarkGray)),
+            }
+        };
+        seq_active_cells.push(Cell::from(label).style(style));
+    }
+    let seq_active_row = Row::new(seq_active_cells).height(1);
 
     // ── Unsafe L2 row ──────────────────────────────────────────────────────
     let mut l2_cells = vec![
@@ -407,7 +1115,6 @@ fn render_cluster_table(
             }
             Some(h) => {
                 let hex = format!("{h:x}");
-                // Fork: same block number as leader but different hash.
                 let is_fork = leader_unsafe
                     .is_some_and(|(lnum, lhash)| node.unsafe_l2_block == Some(lnum) && h != lhash);
                 if is_fork {
@@ -483,33 +1190,6 @@ fn render_cluster_table(
     }
     let finalized_l2_row = Row::new(finalized_l2_cells).height(1);
 
-    // ── Active row (conductor) ─────────────────────────────────────────────
-    // `conductor_active` = "sequencer is currently sequencing".
-    // Followers stop their sequencer intentionally — active=false is expected.
-    // Only flag red when the *leader* reports active=false.
-    let mut active_cells = vec![
-        Cell::from("  Active")
-            .style(Style::default().fg(Color::White).add_modifier(Modifier::BOLD)),
-    ];
-    for node in nodes {
-        let (label, style) = if paused_nodes.contains_key(&node.name) {
-            ("   paused", Style::default().fg(Color::Cyan))
-        } else {
-            match (node.is_leader, node.conductor_active) {
-                (Some(true), Some(true)) => ("   yes", Style::default().fg(Color::Green)),
-                (Some(true), Some(false)) => ("   no", Style::default().fg(Color::Red)),
-                (Some(false), Some(false)) => ("   stopped", Style::default().fg(Color::DarkGray)),
-                (Some(false), Some(true)) => ("   active?", Style::default().fg(Color::Yellow)),
-                _ => ("   ?", Style::default().fg(Color::DarkGray)),
-            }
-        };
-        active_cells.push(Cell::from(label).style(style));
-    }
-    let active_row = Row::new(active_cells).height(1);
-
-    // ── CL section header ──────────────────────────────────────────────────
-    let cl_section = section_row("CL", node_count);
-
     // ── L1 derivation row ──────────────────────────────────────────────────
     let mut l1_cells = vec![
         Cell::from("  L1 Derived")
@@ -542,9 +1222,6 @@ fn render_cluster_table(
         cl_peers_cells.push(Cell::from(label).style(style));
     }
     let cl_peers_row = Row::new(cl_peers_cells).height(1);
-
-    // ── EL section header ──────────────────────────────────────────────────
-    let el_section = section_row("EL", node_count);
 
     // ── EL block row ───────────────────────────────────────────────────────
     let mut el_block_cells = vec![
@@ -592,12 +1269,18 @@ fn render_cluster_table(
     }
     let el_peers_row = Row::new(el_peers_cells).height(1);
 
+    let cl_section = section_row("CL", node_count);
+    let el_section = section_row("EL", node_count);
     let spacer = Row::new(vec![Cell::from("")]).height(1);
 
     let rows = vec![
         // ── Conductor ────────────────────────────────────────────────────
         role_row,
         active_row,
+        paused_row,
+        stopped_row,
+        healthy_row,
+        seq_active_row,
         // ── CL ───────────────────────────────────────────────────────────
         spacer.clone(),
         cl_section,
@@ -618,6 +1301,32 @@ fn render_cluster_table(
     let table = Table::new(rows, constraints).header(header).row_highlight_style(Style::default());
 
     f.render_stateful_widget(table, inner, &mut TableState::default());
+}
+
+/// Builds a row that renders a tri-state `Option<bool>` per node.
+///
+/// `true_color` and `false_color` style the corresponding labels;
+/// `None` always renders as a grey `?`.
+fn bool_row<'a>(
+    label: &'static str,
+    nodes: &[ConductorNodeStatus],
+    extract: impl Fn(&ConductorNodeStatus) -> Option<bool>,
+    true_color: Color,
+    false_color: Color,
+    labels: (&'static str, &'static str),
+) -> Row<'a> {
+    let mut cells = vec![
+        Cell::from(label).style(Style::default().fg(Color::White).add_modifier(Modifier::BOLD)),
+    ];
+    for node in nodes {
+        let (text, style) = match extract(node) {
+            Some(true) => (labels.0, Style::default().fg(true_color)),
+            Some(false) => (labels.1, Style::default().fg(false_color)),
+            None => ("   ?", Style::default().fg(Color::DarkGray)),
+        };
+        cells.push(Cell::from(text).style(style));
+    }
+    Row::new(cells).height(1)
 }
 
 fn render_validator_table(f: &mut Frame<'_>, area: Rect, nodes: &[ValidatorNodeStatus]) {

--- a/crates/infra/basectl/src/app/views/mod.rs
+++ b/crates/infra/basectl/src/app/views/mod.rs
@@ -4,7 +4,7 @@ mod command_center;
 pub use command_center::CommandCenterView;
 
 mod conductor;
-pub use conductor::ConductorView;
+pub use conductor::{ActionMenuItem, ConductorView, ConfirmButton, Overlay, PendingAction};
 
 mod config;
 pub use config::ConfigView;

--- a/crates/infra/basectl/src/lib.rs
+++ b/crates/infra/basectl/src/lib.rs
@@ -2,10 +2,11 @@
 
 mod app;
 pub use app::{
-    Action, App, CommandCenterView, ConductorState, ConductorView, ConfigView, DaMonitorView,
-    DaState, FlashState, FlashblocksView, HomeView, ProofsState, ProofsView, Resources, Router,
-    TransactionPane, UpgradesView, ValidatorState, View, ViewId, create_view, run_app,
-    run_flashblocks_json, start_background_services,
+    Action, ActionMenuItem, App, CommandCenterView, ConductorState, ConductorView, ConfigView,
+    ConfirmButton, DaMonitorView, DaState, FlashState, FlashblocksView, HomeView, Overlay,
+    PendingAction, ProofsState, ProofsView, Resources, Router, TransactionPane, UpgradesView,
+    ValidatorState, View, ViewId, create_view, run_app, run_flashblocks_json,
+    start_background_services,
 };
 
 mod commands;
@@ -30,11 +31,13 @@ mod rpc;
 pub use rpc::{
     BacklogBlock, BacklogFetchResult, BacklogProgress, BlockDaInfo, ConductorNodeStatus,
     InitialBacklog, L1BlockInfo, L1ConnectionMode, LatestProposal, PausedPeers, ProofsSnapshot,
-    TimestampedFlashblock, TxSummary, ValidatorNodeStatus, decode_flashblock_transactions,
-    fetch_block_transactions, fetch_initial_backlog_with_progress, fetch_safe_and_latest,
-    pause_sequencer_node, restart_conductor_node, run_block_fetcher, run_conductor_poller,
-    run_flashblock_ws, run_flashblock_ws_timestamped, run_l1_blob_watcher, run_proofs_poller,
-    run_safe_head_poller, run_validator_poller, transfer_conductor_leader, unpause_sequencer_node,
+    TimestampedFlashblock, TxSummary, ValidatorNodeStatus, conductor_pause_node,
+    conductor_resume_node, decode_flashblock_transactions, fetch_block_transactions,
+    fetch_initial_backlog_with_progress, fetch_safe_and_latest, pause_sequencer_node,
+    restart_conductor_node, run_block_fetcher, run_conductor_poller, run_flashblock_ws,
+    run_flashblock_ws_timestamped, run_l1_blob_watcher, run_proofs_poller, run_safe_head_poller,
+    run_validator_poller, start_sequencer_node, stop_sequencer_node, transfer_conductor_leader,
+    unpause_sequencer_node,
 };
 
 mod tui;

--- a/crates/infra/basectl/src/rpc.rs
+++ b/crates/infra/basectl/src/rpc.rs
@@ -10,7 +10,9 @@ use anyhow::Result;
 use base_common_consensus::BaseTxEnvelope;
 use base_common_flashblocks::Flashblock;
 use base_common_network::Base;
-use base_consensus_rpc::{BaseP2PApiClient, ConductorApiClient, RollupNodeApiClient};
+use base_consensus_rpc::{
+    AdminApiClient, BaseP2PApiClient, ConductorApiClient, RollupNodeApiClient,
+};
 use futures::{StreamExt, stream};
 use jsonrpsee::{core::client::ClientT, http_client::HttpClientBuilder, rpc_params};
 use tokio::sync::{mpsc, watch};
@@ -688,6 +690,20 @@ pub struct ConductorNodeStatus {
     /// Whether the conductor's sequencer is actively sequencing (`conductor_active`).
     /// Expected to be `false` for followers. `None` means unreachable.
     pub conductor_active: Option<bool>,
+    /// Whether op-conductor's control loop is paused (`conductor_paused`). When paused,
+    /// the conductor stops driving leader election and health checks. `None` means
+    /// unreachable.
+    pub conductor_paused: Option<bool>,
+    /// Whether op-conductor has been fully stopped (`conductor_stopped`). `None` means
+    /// unreachable.
+    pub conductor_stopped: Option<bool>,
+    /// Whether the sequencer is reporting healthy via `conductor_sequencerHealthy`.
+    /// `None` means unreachable.
+    pub sequencer_healthy: Option<bool>,
+    /// Whether the sequencer is currently producing blocks (`admin_sequencerActive`).
+    /// Sourced from the consensus node's admin namespace on `cl_rpc`. `None` means
+    /// unreachable.
+    pub sequencer_active: Option<bool>,
 
     // ── CL (consensus layer) ─────────────────────────────────────────────
     /// Unsafe L2 block number from `optimism_syncStatus`.
@@ -771,6 +787,105 @@ pub async fn transfer_conductor_leader(
                 Ok(format!("leadership transferred to {target}"))
             }
         }
+    }
+    .await;
+
+    let _ = result_tx.send(outcome.map_err(|e| e.to_string())).await;
+}
+
+/// Pauses op-conductor's control loop on a single node via `conductor_pause`.
+///
+/// While paused, the conductor stops driving leader election and sequencer
+/// health checks, but the underlying Raft membership is preserved. Paired with
+/// [`conductor_resume_node`].
+pub async fn conductor_pause_node(
+    node: ConductorNodeConfig,
+    result_tx: mpsc::Sender<Result<String, String>>,
+) {
+    const TIMEOUT: Duration = Duration::from_secs(5);
+
+    let outcome: anyhow::Result<String> = async {
+        let client = HttpClientBuilder::default()
+            .request_timeout(TIMEOUT)
+            .build(node.conductor_rpc.as_str())
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
+        ConductorApiClient::conductor_pause(&client).await.map_err(|e| anyhow::anyhow!("{e}"))?;
+        Ok(format!("conductor paused on {}", node.name))
+    }
+    .await;
+
+    let _ = result_tx.send(outcome.map_err(|e| e.to_string())).await;
+}
+
+/// Resumes op-conductor's control loop on a single node via `conductor_resume`.
+pub async fn conductor_resume_node(
+    node: ConductorNodeConfig,
+    result_tx: mpsc::Sender<Result<String, String>>,
+) {
+    const TIMEOUT: Duration = Duration::from_secs(5);
+
+    let outcome: anyhow::Result<String> = async {
+        let client = HttpClientBuilder::default()
+            .request_timeout(TIMEOUT)
+            .build(node.conductor_rpc.as_str())
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
+        ConductorApiClient::conductor_resume(&client).await.map_err(|e| anyhow::anyhow!("{e}"))?;
+        Ok(format!("conductor resumed on {}", node.name))
+    }
+    .await;
+
+    let _ = result_tx.send(outcome.map_err(|e| e.to_string())).await;
+}
+
+/// Starts the sequencer on a single node via `admin_startSequencer`.
+///
+/// The `unsafe_head` hash must match the node's current engine unsafe head; the
+/// server rejects mismatches and `B256::ZERO`. When op-conductor is enabled,
+/// this only succeeds if the target node is the Raft leader.
+pub async fn start_sequencer_node(
+    node: ConductorNodeConfig,
+    unsafe_head: B256,
+    result_tx: mpsc::Sender<Result<String, String>>,
+) {
+    const TIMEOUT: Duration = Duration::from_secs(5);
+
+    let outcome: anyhow::Result<String> = async {
+        if unsafe_head == B256::ZERO {
+            return Err(anyhow::anyhow!("unsafe_head must not be zero"));
+        }
+        let client = HttpClientBuilder::default()
+            .request_timeout(TIMEOUT)
+            .build(node.cl_rpc.as_str())
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
+        AdminApiClient::admin_start_sequencer(&client, unsafe_head)
+            .await
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
+        Ok(format!("sequencer started on {} at {unsafe_head}", node.name))
+    }
+    .await;
+
+    let _ = result_tx.send(outcome.map_err(|e| e.to_string())).await;
+}
+
+/// Stops the sequencer on a single node via `admin_stopSequencer`.
+///
+/// Returns the unsafe head hash captured at the moment the sequencer was
+/// stopped, suitable for passing back into [`start_sequencer_node`] later.
+pub async fn stop_sequencer_node(
+    node: ConductorNodeConfig,
+    result_tx: mpsc::Sender<Result<String, String>>,
+) {
+    const TIMEOUT: Duration = Duration::from_secs(5);
+
+    let outcome: anyhow::Result<String> = async {
+        let client = HttpClientBuilder::default()
+            .request_timeout(TIMEOUT)
+            .build(node.cl_rpc.as_str())
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
+        let head = AdminApiClient::admin_stop_sequencer(&client)
+            .await
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
+        Ok(format!("sequencer stopped on {} at {head}", node.name))
     }
     .await;
 
@@ -1029,6 +1144,10 @@ pub async fn run_conductor_poller(
                 let (
                     is_leader,
                     conductor_active,
+                    conductor_paused,
+                    conductor_stopped,
+                    sequencer_healthy,
+                    sequencer_active,
                     sync,
                     cl_peer_stats,
                     el_block_r,
@@ -1037,6 +1156,10 @@ pub async fn run_conductor_poller(
                 ) = tokio::join!(
                     ConductorApiClient::conductor_leader(conductor_client),
                     ConductorApiClient::conductor_active(conductor_client),
+                    ConductorApiClient::conductor_paused(conductor_client),
+                    ConductorApiClient::conductor_stopped(conductor_client),
+                    ConductorApiClient::conductor_sequencer_healthy(conductor_client),
+                    AdminApiClient::admin_sequencer_active(cl_client),
                     RollupNodeApiClient::sync_status(cl_client),
                     BaseP2PApiClient::opp2p_peer_stats(cl_client),
                     async {
@@ -1073,6 +1196,10 @@ pub async fn run_conductor_poller(
                     name: name.clone(),
                     is_leader: is_leader.ok(),
                     conductor_active: conductor_active.ok(),
+                    conductor_paused: conductor_paused.ok(),
+                    conductor_stopped: conductor_stopped.ok(),
+                    sequencer_healthy: sequencer_healthy.ok(),
+                    sequencer_active: sequencer_active.ok(),
                     unsafe_l2_block: sync.as_ref().map(|s| s.unsafe_l2.block_info.number),
                     unsafe_l2_hash: sync.as_ref().map(|s| s.unsafe_l2.block_info.hash),
                     safe_l2_block: sync.as_ref().map(|s| s.safe_l2.block_info.number),

--- a/crates/infra/basectl/src/rpc.rs
+++ b/crates/infra/basectl/src/rpc.rs
@@ -1069,10 +1069,19 @@ pub async fn unpause_sequencer_node(
             for enode in &peers.el_enodes {
                 let r: Result<bool, _> =
                     ClientT::request(&el_client, "admin_addPeer", rpc_params![enode]).await;
-                if r.is_ok() {
+                if matches!(r, Ok(true)) {
                     el_ok += 1;
                 }
             }
+        }
+
+        if cl_ok != peers.cl_addrs.len() || el_ok != peers.el_enodes.len() {
+            anyhow::bail!(
+                "unpaused {} — reconnected {cl_ok}/{} CL peer(s), {el_ok}/{} EL peer(s); saved peers kept for retry",
+                node.name,
+                peers.cl_addrs.len(),
+                peers.el_enodes.len()
+            );
         }
 
         Ok(format!(
@@ -1140,7 +1149,7 @@ pub async fn run_conductor_poller(
         let statuses = futures::future::join_all(clients.iter().map(
             |(name, conductor_client, cl_client, el_client)| async move {
                 // Fire all RPCs concurrently so a single timed-out node does not
-                // stall the poll for the full sum of all call timeouts (7 × 500 ms).
+                // stall the poll for the full sum of all call timeouts (11 × 500 ms).
                 let (
                     is_leader,
                     conductor_active,


### PR DESCRIPTION
Adds an action-menu overlay (`Enter` on a node) exposing per-node conductor & sequencer mutations:

- Conductor pause / resume
- Sequencer start (hex-input overlay, F5 prefill from latest poll) / stop
- Existing transfer / restart / soft P2P-isolate / reconnect

Status table grows 4 rows (Paused / Stopped / Healthy / Seq active); poller now does 11 RPCs/node in one `tokio::join!` batch (was 7).


https://github.com/user-attachments/assets/fe26ce08-0118-47de-92b7-0b389da5f134