### PR TITLE
chore: delay azul to 28th may

### DIFF
--- a/crates/common/chains/src/chain.rs
+++ b/crates/common/chains/src/chain.rs
@@ -269,11 +269,11 @@ mod tests {
 
     #[test]
     fn is_azul_active_at_timestamp() {
-        // Azul is scheduled on mainnet at 1779386400
+        // Azul is scheduled on mainnet at 1779991200
         let base_mainnet_forks = ChainUpgrades::mainnet();
         assert!(!base_mainnet_forks.is_azul_active_at_timestamp(0));
-        assert!(!base_mainnet_forks.is_azul_active_at_timestamp(1_779_386_399));
-        assert!(base_mainnet_forks.is_azul_active_at_timestamp(1_779_386_400));
+        assert!(!base_mainnet_forks.is_azul_active_at_timestamp(1_779_991_199));
+        assert!(base_mainnet_forks.is_azul_active_at_timestamp(1_779_991_200));
         assert!(base_mainnet_forks.is_azul_active_at_timestamp(u64::MAX));
 
         // Azul is scheduled on sepolia at 1776708000
@@ -313,7 +313,7 @@ mod tests {
         let base_mainnet_forks = ChainUpgrades::mainnet();
         assert_eq!(
             base_mainnet_forks.ethereum_fork_activation(EthereumHardfork::Osaka),
-            ForkCondition::Timestamp(1_779_386_400)
+            ForkCondition::Timestamp(1_779_991_200)
         );
 
         let base_sepolia_forks = ChainUpgrades::sepolia();

--- a/crates/common/chains/src/config.rs
+++ b/crates/common/chains/src/config.rs
@@ -317,7 +317,7 @@ const MAINNET: ChainConfig = ChainConfig {
     pectra_blob_schedule_timestamp: None,
     isthmus_timestamp: 1_746_806_401,
     jovian_timestamp: 1_764_691_201,
-    azul_timestamp: Some(1_779_386_400),
+    azul_timestamp: Some(1_779_991_200),
     beryl_timestamp: None,
 
     genesis_l1_hash: b256!("5c13d307623a926cd31415036c8b7fa14572f9dac64528e857a470511fc30771"),

--- a/crates/proof/succinct/elf/manifest.toml
+++ b/crates/proof/succinct/elf/manifest.toml
@@ -14,7 +14,7 @@
 
 [[elfs]]
 name = "range-elf-embedded"
-sha256 = "47d2f38c3f51601e9a528b64d9420354f3d44247637710e4337cce38cfdae338"
+sha256 = "5c2d9215dd28b4ee5a5ad12588e839dcc62fd4116b87f15f81226db20386072c"
 
 [[elfs]]
 name = "aggregation-elf"

--- a/docs/specs/pages/upgrades/azul/overview.md
+++ b/docs/specs/pages/upgrades/azul/overview.md
@@ -17,7 +17,7 @@ date.
 
 | Network   | Activation timestamp                   |
 | --------- | -------------------------------------- |
-| `mainnet` | `1779386400` (2026-05-21 18:00:00 UTC) |
+| `mainnet` | TBD                                    |
 | `sepolia` | `1776708000` (2026-04-20 18:00:00 UTC) |
 
 ## Execution Layer


### PR DESCRIPTION
## Summary
delay mainnet Azul activation to May 28, 2026 at 1:00 PM CT