### PR TITLE
refactor(common): Refactor Extra Data Modules

### DIFF
--- a/crates/common/consensus/src/extra/encoder.rs
+++ b/crates/common/consensus/src/extra/encoder.rs
@@ -1,0 +1,56 @@
+use alloy_eips::eip1559::BaseFeeParams;
+use alloy_primitives::B64;
+
+use super::{EIP1559ParamError, HoloceneExtraData};
+
+/// Encoder for EIP-1559 extra-data parameters.
+#[derive(Debug)]
+pub struct EIP1559ParamEncoder;
+
+impl EIP1559ParamEncoder {
+    /// Encodes the EIP-1559 parameters into `extra_data`.
+    ///
+    /// If `eip_1559_params` is zero, uses `default_base_fee_params` instead.
+    /// Requires `extra_data` to be at least 9 bytes.
+    pub fn encode(
+        eip_1559_params: B64,
+        default_base_fee_params: BaseFeeParams,
+        extra_data: &mut [u8],
+    ) -> Result<(), EIP1559ParamError> {
+        if extra_data.len() < 9 {
+            return Err(EIP1559ParamError::InvalidExtraDataLength);
+        }
+        if eip_1559_params.is_zero() {
+            let max_change_denominator: u32 = (default_base_fee_params.max_change_denominator)
+                .try_into()
+                .map_err(|_| EIP1559ParamError::DenominatorOverflow)?;
+            let elasticity_multiplier: u32 = (default_base_fee_params.elasticity_multiplier)
+                .try_into()
+                .map_err(|_| EIP1559ParamError::ElasticityOverflow)?;
+            extra_data[1..5].copy_from_slice(&max_change_denominator.to_be_bytes());
+            extra_data[5..9].copy_from_slice(&elasticity_multiplier.to_be_bytes());
+        } else {
+            let (elasticity, denominator) = HoloceneExtraData::decode_params(eip_1559_params);
+            extra_data[1..5].copy_from_slice(&denominator.to_be_bytes());
+            extra_data[5..9].copy_from_slice(&elasticity.to_be_bytes());
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_eips::eip1559::BaseFeeParams;
+    use alloy_primitives::B64;
+
+    use super::EIP1559ParamEncoder;
+    use crate::extra::EIP1559ParamError;
+
+    #[test]
+    fn test_encode_eip_1559_params_invalid_length() {
+        let mut extra_data = [0u8; 8];
+        let result =
+            EIP1559ParamEncoder::encode(B64::ZERO, BaseFeeParams::new(80, 60), &mut extra_data);
+        assert_eq!(result.unwrap_err(), EIP1559ParamError::InvalidExtraDataLength);
+    }
+}

--- a/crates/common/consensus/src/extra/error.rs
+++ b/crates/common/consensus/src/extra/error.rs
@@ -1,0 +1,28 @@
+/// Error type for EIP-1559 parameters.
+#[derive(Debug, thiserror::Error, Clone, Copy, PartialEq, Eq)]
+pub enum EIP1559ParamError {
+    /// Thrown if the extra data begins with the wrong version byte.
+    #[error("Invalid EIP1559 version byte: {0}")]
+    InvalidVersion(u8),
+    /// No EIP-1559 parameters provided.
+    #[error("No EIP1559 parameters provided")]
+    NoEIP1559Params,
+    /// Denominator overflow.
+    #[error("Denominator overflow")]
+    DenominatorOverflow,
+    /// Elasticity overflow.
+    #[error("Elasticity overflow")]
+    ElasticityOverflow,
+    /// Extra data is not the correct length.
+    #[error("Extra data is not the correct length")]
+    InvalidExtraDataLength,
+    /// Invalid EIP-1559 parameter combination.
+    #[error("EIP-1559 denominator and elasticity must both be zero or both be non-zero")]
+    InvalidParams,
+    /// Minimum base fee must be None before Jovian.
+    #[error("Minimum base fee must be None before Jovian")]
+    MinBaseFeeMustBeNone,
+    /// Minimum base fee cannot be None after Jovian.
+    #[error("Minimum base fee cannot be None after Jovian")]
+    MinBaseFeeNotSet,
+}

--- a/crates/common/consensus/src/extra/holocene.rs
+++ b/crates/common/consensus/src/extra/holocene.rs
@@ -1,7 +1,7 @@
 use alloy_eips::eip1559::BaseFeeParams;
 use alloy_primitives::{B64, Bytes};
 
-use super::{EIP1559ParamError, encode_eip_1559_params};
+use super::{EIP1559ParamEncoder, EIP1559ParamError};
 
 const VERSION_BYTE: u8 = 0;
 
@@ -49,7 +49,7 @@ impl HoloceneExtraData {
         default_base_fee_params: BaseFeeParams,
     ) -> Result<Bytes, EIP1559ParamError> {
         let mut extra_data = [0u8; 9];
-        encode_eip_1559_params(eip_1559_params, default_base_fee_params, &mut extra_data)?;
+        EIP1559ParamEncoder::encode(eip_1559_params, default_base_fee_params, &mut extra_data)?;
         Ok(Bytes::copy_from_slice(&extra_data))
     }
 }

--- a/crates/common/consensus/src/extra/jovian.rs
+++ b/crates/common/consensus/src/extra/jovian.rs
@@ -1,7 +1,7 @@
 use alloy_eips::eip1559::BaseFeeParams;
 use alloy_primitives::{B64, Bytes};
 
-use super::{EIP1559ParamError, encode_eip_1559_params};
+use super::{EIP1559ParamEncoder, EIP1559ParamError};
 
 const VERSION_BYTE: u8 = 1;
 
@@ -50,7 +50,7 @@ impl JovianExtraData {
     ) -> Result<Bytes, EIP1559ParamError> {
         let mut extra_data = [0u8; 17];
         extra_data[0] = VERSION_BYTE;
-        encode_eip_1559_params(eip_1559_params, default_base_fee_params, &mut extra_data)?;
+        EIP1559ParamEncoder::encode(eip_1559_params, default_base_fee_params, &mut extra_data)?;
         extra_data[9..17].copy_from_slice(&min_base_fee.to_be_bytes());
         Ok(Bytes::copy_from_slice(&extra_data))
     }

--- a/crates/common/consensus/src/extra/mod.rs
+++ b/crates/common/consensus/src/extra/mod.rs
@@ -1,82 +1,13 @@
 //! Block extra-data encodings for Holocene and Jovian fork upgrades.
 
+mod encoder;
+pub use encoder::EIP1559ParamEncoder;
+
+mod error;
+pub use error::EIP1559ParamError;
+
 mod holocene;
 pub use holocene::HoloceneExtraData;
 
 mod jovian;
-use alloy_eips::eip1559::BaseFeeParams;
-use alloy_primitives::B64;
 pub use jovian::JovianExtraData;
-
-/// Error type for EIP-1559 parameters.
-#[derive(Debug, thiserror::Error, Clone, Copy, PartialEq, Eq)]
-pub enum EIP1559ParamError {
-    /// Thrown if the extra data begins with the wrong version byte.
-    #[error("Invalid EIP1559 version byte: {0}")]
-    InvalidVersion(u8),
-    /// No EIP-1559 parameters provided.
-    #[error("No EIP1559 parameters provided")]
-    NoEIP1559Params,
-    /// Denominator overflow.
-    #[error("Denominator overflow")]
-    DenominatorOverflow,
-    /// Elasticity overflow.
-    #[error("Elasticity overflow")]
-    ElasticityOverflow,
-    /// Extra data is not the correct length.
-    #[error("Extra data is not the correct length")]
-    InvalidExtraDataLength,
-    /// Invalid EIP-1559 parameter combination.
-    #[error("EIP-1559 denominator and elasticity must both be zero or both be non-zero")]
-    InvalidParams,
-    /// Minimum base fee must be None before Jovian.
-    #[error("Minimum base fee must be None before Jovian")]
-    MinBaseFeeMustBeNone,
-    /// Minimum base fee cannot be None after Jovian.
-    #[error("Minimum base fee cannot be None after Jovian")]
-    MinBaseFeeNotSet,
-}
-
-/// Encodes the EIP-1559 parameters into `extra_data`.
-///
-/// If `eip_1559_params` is zero, uses `default_base_fee_params` instead.
-/// Requires `extra_data` to be at least 9 bytes.
-fn encode_eip_1559_params(
-    eip_1559_params: B64,
-    default_base_fee_params: BaseFeeParams,
-    extra_data: &mut [u8],
-) -> Result<(), EIP1559ParamError> {
-    if extra_data.len() < 9 {
-        return Err(EIP1559ParamError::InvalidExtraDataLength);
-    }
-    if eip_1559_params.is_zero() {
-        let max_change_denominator: u32 = (default_base_fee_params.max_change_denominator)
-            .try_into()
-            .map_err(|_| EIP1559ParamError::DenominatorOverflow)?;
-        let elasticity_multiplier: u32 = (default_base_fee_params.elasticity_multiplier)
-            .try_into()
-            .map_err(|_| EIP1559ParamError::ElasticityOverflow)?;
-        extra_data[1..5].copy_from_slice(&max_change_denominator.to_be_bytes());
-        extra_data[5..9].copy_from_slice(&elasticity_multiplier.to_be_bytes());
-    } else {
-        let (elasticity, denominator) = HoloceneExtraData::decode_params(eip_1559_params);
-        extra_data[1..5].copy_from_slice(&denominator.to_be_bytes());
-        extra_data[5..9].copy_from_slice(&elasticity.to_be_bytes());
-    }
-    Ok(())
-}
-
-#[cfg(test)]
-mod tests {
-    use alloy_eips::eip1559::BaseFeeParams;
-    use alloy_primitives::B64;
-
-    use super::{EIP1559ParamError, encode_eip_1559_params};
-
-    #[test]
-    fn test_encode_eip_1559_params_invalid_length() {
-        let mut extra_data = [0u8; 8];
-        let result = encode_eip_1559_params(B64::ZERO, BaseFeeParams::new(80, 60), &mut extra_data);
-        assert_eq!(result.unwrap_err(), EIP1559ParamError::InvalidExtraDataLength);
-    }
-}

--- a/crates/common/consensus/src/lib.rs
+++ b/crates/common/consensus/src/lib.rs
@@ -29,7 +29,7 @@ pub use transaction::{
 };
 
 mod extra;
-pub use extra::{EIP1559ParamError, HoloceneExtraData, JovianExtraData};
+pub use extra::{EIP1559ParamEncoder, EIP1559ParamError, HoloceneExtraData, JovianExtraData};
 
 mod source;
 pub use source::{


### PR DESCRIPTION
## Summary

This refactors the common consensus extra-data module so mod.rs only declares and re-exports modules. The EIP-1559 error type now lives in its own module, and the shared encoding helper is exposed through an encoder unit type. Holocene and Jovian encoding continue to use the same shared implementation through that type.