### PR TITLE
chore: delay azul to 28th may

### DIFF
--- a/crates/common/chains/src/chain.rs
+++ b/crates/common/chains/src/chain.rs
@@ -269,11 +269,11 @@ mod tests {
 
     #[test]
     fn is_azul_active_at_timestamp() {
-        // Azul is scheduled on mainnet at 1779386400
+        // Azul is scheduled on mainnet at 1779991200
         let base_mainnet_forks = ChainUpgrades::mainnet();
         assert!(!base_mainnet_forks.is_azul_active_at_timestamp(0));
-        assert!(!base_mainnet_forks.is_azul_active_at_timestamp(1_779_386_399));
-        assert!(base_mainnet_forks.is_azul_active_at_timestamp(1_779_386_400));
+        assert!(!base_mainnet_forks.is_azul_active_at_timestamp(1_779_991_199));
+        assert!(base_mainnet_forks.is_azul_active_at_timestamp(1_779_991_200));
         assert!(base_mainnet_forks.is_azul_active_at_timestamp(u64::MAX));
 
         // Azul is scheduled on sepolia at 1776708000
@@ -313,7 +313,7 @@ mod tests {
         let base_mainnet_forks = ChainUpgrades::mainnet();
         assert_eq!(
             base_mainnet_forks.ethereum_fork_activation(EthereumHardfork::Osaka),
-            ForkCondition::Timestamp(1_779_386_400)
+            ForkCondition::Timestamp(1_779_991_200)
         );
 
         let base_sepolia_forks = ChainUpgrades::sepolia();

--- a/crates/common/chains/src/config.rs
+++ b/crates/common/chains/src/config.rs
@@ -317,7 +317,7 @@ const MAINNET: ChainConfig = ChainConfig {
     pectra_blob_schedule_timestamp: None,
     isthmus_timestamp: 1_746_806_401,
     jovian_timestamp: 1_764_691_201,
-    azul_timestamp: Some(1_779_386_400),
+    azul_timestamp: Some(1_779_991_200),
     beryl_timestamp: None,
 
     genesis_l1_hash: b256!("5c13d307623a926cd31415036c8b7fa14572f9dac64528e857a470511fc30771"),

--- a/docs/specs/pages/upgrades/azul/overview.md
+++ b/docs/specs/pages/upgrades/azul/overview.md
@@ -17,7 +17,7 @@ date.
 
 | Network   | Activation timestamp                   |
 | --------- | -------------------------------------- |
-| `mainnet` | `1779386400` (2026-05-21 18:00:00 UTC) |
+| `mainnet` | TBD                                    |
 | `sepolia` | `1776708000` (2026-04-20 18:00:00 UTC) |
 
 ## Execution Layer


### PR DESCRIPTION
## Summary
Backport Azul mainnet activation delay to the v0.9.0 release branch