### PR TITLE
feat(trie): add rocksdb proofs storage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4223,6 +4223,7 @@ dependencies = [
  "reth-tasks",
  "reth-trie",
  "reth-trie-common",
+ "rocksdb",
  "secp256k1 0.30.0",
  "serde",
  "serial_test",

--- a/crates/builder/core/benches/state_root.rs
+++ b/crates/builder/core/benches/state_root.rs
@@ -10,7 +10,7 @@
 //! - `per_flashblock` (`calculate_state_root = true`) — state root
 //!   recomputed from scratch after every flashblock.
 //!
-//! The benchmarks use an MDBX-backed [`MdbxProofsStorage`] pre-populated with
+//! The benchmarks use a RocksDB-backed [`RocksdbProofsStorage`] pre-populated with
 //! 50k base-state accounts so that state root computation exercises real disk
 //! I/O through the production trie overlay path.
 //!
@@ -25,7 +25,7 @@ use std::{hint::black_box, sync::Arc};
 use alloy_eips::BlockNumHash;
 use alloy_primitives::{B256, U256, keccak256};
 use base_execution_trie::{
-    BaseProofsInitialStateStore, BaseProofsStorage, MdbxProofsStorage,
+    BaseProofsInitialStateStore, BaseProofsStorage, RocksdbProofsStorage,
     provider::BaseProofsStateProviderRef,
 };
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
@@ -41,7 +41,7 @@ const FLASHBLOCKS: usize = 10;
 /// Storage slots per account.
 const SLOTS_PER_ACCOUNT: usize = 5;
 
-/// Number of pre-existing accounts in the MDBX base state.
+/// Number of pre-existing accounts in the `RocksDB` base state.
 ///
 /// This simulates a realistic chain state where the trie already contains
 /// existing accounts before any flashblock deltas are applied.
@@ -105,12 +105,13 @@ fn setup_flashblock_data(
     (deltas, full_state)
 }
 
-/// Creates an MDBX-backed proofs storage pre-populated with [`BASE_STATE_ACCOUNTS`]
+/// Creates a RocksDB-backed proofs storage pre-populated with [`BASE_STATE_ACCOUNTS`]
 /// accounts and their storage slots. Returns the temp directory handle (must be
 /// kept alive) and the wrapped storage.
-fn create_populated_storage() -> (TempDir, BaseProofsStorage<Arc<MdbxProofsStorage>>) {
+fn create_populated_storage() -> (TempDir, BaseProofsStorage<Arc<RocksdbProofsStorage>>) {
     let dir = TempDir::new().expect("failed to create temp dir");
-    let mdbx = Arc::new(MdbxProofsStorage::new(dir.path()).expect("failed to create MDBX storage"));
+    let rocksdb =
+        Arc::new(RocksdbProofsStorage::new(dir.path()).expect("failed to create RocksDB storage"));
 
     // Generate base state accounts.
     let mut rng = StdRng::seed_from_u64(42);
@@ -119,19 +120,21 @@ fn create_populated_storage() -> (TempDir, BaseProofsStorage<Arc<MdbxProofsStora
     // Pre-populate hashed accounts.
     let hashed_accounts: Vec<(B256, Option<Account>)> =
         accounts.iter().map(|(addr, acct, _)| (*addr, Some(*acct))).collect();
-    mdbx.store_hashed_accounts(hashed_accounts).expect("failed to store hashed accounts");
+    rocksdb.store_hashed_accounts(hashed_accounts).expect("failed to store hashed accounts");
 
     // Pre-populate hashed storages.
     for (addr, _, slots) in &accounts {
         let slot_data: Vec<(B256, U256)> = slots.iter().map(|(k, v)| (*k, *v)).collect();
-        mdbx.store_hashed_storages(*addr, slot_data).expect("failed to store hashed storages");
+        rocksdb.store_hashed_storages(*addr, slot_data).expect("failed to store hashed storages");
     }
 
     // Set initial state anchor and commit.
-    mdbx.set_initial_state_anchor(BlockNumHash::new(0, B256::ZERO)).expect("failed to set anchor");
-    mdbx.commit_initial_state().expect("failed to commit initial state");
+    rocksdb
+        .set_initial_state_anchor(BlockNumHash::new(0, B256::ZERO))
+        .expect("failed to set anchor");
+    rocksdb.commit_initial_state().expect("failed to commit initial state");
 
-    let storage = BaseProofsStorage::from(mdbx);
+    let storage = BaseProofsStorage::from(rocksdb);
     (dir, storage)
 }
 

--- a/crates/execution/cli/src/commands/base_proofs/init.rs
+++ b/crates/execution/cli/src/commands/base_proofs/init.rs
@@ -5,8 +5,10 @@ use std::{path::PathBuf, sync::Arc};
 use base_common_consensus::BasePrimitives;
 use base_execution_chainspec::BaseChainSpec;
 use base_execution_trie::{
-    BaseProofsStorage, BaseProofsStore, InitializationJob, db::MdbxProofsStorage,
+    BaseProofsInitialStateStore, BaseProofsStorage, BaseProofsStore, InitializationJob,
+    MdbxProofsStorage, RocksdbProofsStorage,
 };
+use base_node_core::args::ProofsHistoryDbBackend;
 use clap::Parser;
 use reth_chainspec::ChainInfo;
 use reth_cli::chainspec::ChainSpecParser;
@@ -34,6 +36,10 @@ pub struct InitCommand<C: ChainSpecParser> {
         required = true
     )]
     pub storage_path: PathBuf,
+
+    /// The on-disk database backend for proofs history.
+    #[arg(long = "proofs-history.db", value_name = "PROOFS_HISTORY_DB", default_value = "rocksdb")]
+    pub proofs_history_db: ProofsHistoryDbBackend,
 }
 
 impl<C: ChainSpecParser<ChainSpec = BaseChainSpec>> InitCommand<C> {
@@ -41,19 +47,49 @@ impl<C: ChainSpecParser<ChainSpec = BaseChainSpec>> InitCommand<C> {
     pub async fn execute<N: CliNodeTypes<ChainSpec = C::ChainSpec, Primitives = BasePrimitives>>(
         self,
     ) -> eyre::Result<()> {
+        let Self { env, storage_path, proofs_history_db } = self;
+
         info!(target: "reth::cli", version = %version_metadata().short_version, "reth starting");
-        info!(target: "reth::cli", path = ?self.storage_path, "Initializing Base proofs storage");
+        info!(
+            target: "reth::cli",
+            path = ?storage_path,
+            backend = ?proofs_history_db,
+            "Initializing Base proofs storage"
+        );
 
         // Initialize the environment with read-only access
-        let Environment { provider_factory, .. } = self.env.init::<N>(AccessRights::RO)?;
+        let Environment { provider_factory, .. } = env.init::<N>(AccessRights::RO)?;
 
-        // Create the proofs storage
-        let storage: BaseProofsStorage<Arc<MdbxProofsStorage>> = Arc::new(
-            MdbxProofsStorage::new(&self.storage_path)
-                .map_err(|e| eyre::eyre!("Failed to create MdbxProofsStorage: {e}"))?,
-        )
-        .into();
+        match proofs_history_db {
+            ProofsHistoryDbBackend::Rocksdb => {
+                let storage: BaseProofsStorage<Arc<RocksdbProofsStorage>> = Arc::new(
+                    RocksdbProofsStorage::new(&storage_path)
+                        .map_err(|e| eyre::eyre!("Failed to create RocksdbProofsStorage: {e}"))?,
+                )
+                .into();
+                Self::initialize_storage(storage, &provider_factory)?;
+            }
+            ProofsHistoryDbBackend::Mdbx => {
+                let storage: BaseProofsStorage<Arc<MdbxProofsStorage>> = Arc::new(
+                    MdbxProofsStorage::new(&storage_path)
+                        .map_err(|e| eyre::eyre!("Failed to create MdbxProofsStorage: {e}"))?,
+                )
+                .into();
+                Self::initialize_storage(storage, &provider_factory)?;
+            }
+        }
 
+        Ok(())
+    }
+
+    fn initialize_storage<S, F>(
+        storage: BaseProofsStorage<Arc<S>>,
+        provider_factory: &F,
+    ) -> eyre::Result<()>
+    where
+        S: BaseProofsInitialStateStore + BaseProofsStore + 'static,
+        F: BlockNumReader + DatabaseProviderFactory,
+    {
         // Check if already initialized
         if let Some((block_number, block_hash)) = storage.get_earliest_block_number()? {
             info!(

--- a/crates/execution/cli/src/commands/base_proofs/prune.rs
+++ b/crates/execution/cli/src/commands/base_proofs/prune.rs
@@ -5,7 +5,11 @@ use std::{path::PathBuf, sync::Arc};
 use base_common_consensus::BasePrimitives;
 use base_execution_chainspec::BaseChainSpec;
 use base_execution_trie::{
-    BaseProofStoragePruner, BaseProofsStorage, BaseProofsStore, db::MdbxProofsStorage,
+    BaseProofStoragePruner, BaseProofsStorage, BaseProofsStore, MdbxProofsStorage,
+    RocksdbProofsStorage,
+};
+use base_node_core::{
+    DEFAULT_PROOFS_HISTORY_WINDOW_BLOCKS, ProofsHistoryDbBackend, TWELVE_HOURS_IN_BLOCKS,
 };
 use clap::Parser;
 use reth_cli::chainspec::ChainSpecParser;
@@ -27,21 +31,32 @@ pub struct PruneCommand<C: ChainSpecParser> {
     )]
     pub storage_path: PathBuf,
 
+    /// The on-disk database backend for proofs history.
+    #[arg(long = "proofs-history.db", value_name = "PROOFS_HISTORY_DB", default_value = "rocksdb")]
+    pub proofs_history_db: ProofsHistoryDbBackend,
+
     /// The window to span blocks for proofs history. Value is the number of blocks.
     /// Default is 1 month of blocks based on 2 seconds block time.
     /// 30 * 24 * 60 * 60 / 2 = `1_296_000`
+    ///
+    /// Must be greater than 12 hours of blocks based on 2 seconds block time.
     #[arg(
         long = "proofs-history.window",
-        default_value_t = 1_296_000,
-        value_name = "PROOFS_HISTORY_WINDOW"
+        default_value_t = DEFAULT_PROOFS_HISTORY_WINDOW_BLOCKS,
+        value_name = "PROOFS_HISTORY_WINDOW",
+        value_parser = clap::value_parser!(u64).range((TWELVE_HOURS_IN_BLOCKS + 1)..)
     )]
     pub proofs_history_window: u64,
 
     /// The batch size for pruning operations.
+    ///
+    /// Each batch materializes up to this many blocks of change-set keys before committing, so
+    /// reduce this value to bound memory usage when pruning a large range.
     #[arg(
         long = "proofs-history.prune-batch-size",
         default_value_t = 1000,
-        value_name = "PROOFS_HISTORY_PRUNE_BATCH_SIZE"
+        value_name = "PROOFS_HISTORY_PRUNE_BATCH_SIZE",
+        value_parser = clap::value_parser!(u64).range(1..)
     )]
     pub proofs_history_prune_batch_size: u64,
 }
@@ -51,18 +66,66 @@ impl<C: ChainSpecParser<ChainSpec = BaseChainSpec>> PruneCommand<C> {
     pub async fn execute<N: CliNodeTypes<ChainSpec = C::ChainSpec, Primitives = BasePrimitives>>(
         self,
     ) -> eyre::Result<()> {
+        let Self {
+            env,
+            storage_path,
+            proofs_history_db,
+            proofs_history_window,
+            proofs_history_prune_batch_size,
+        } = self;
+
         info!(target: "reth::cli", version = %version_metadata().short_version, "reth starting");
-        info!(target: "reth::cli", path = ?self.storage_path, "Pruning Base proofs storage");
+        info!(
+            target: "reth::cli",
+            path = ?storage_path,
+            backend = ?proofs_history_db,
+            "Pruning Base proofs storage"
+        );
 
         // Initialize the environment with read-only access
-        let Environment { provider_factory, .. } = self.env.init::<N>(AccessRights::RO)?;
+        let Environment { provider_factory, .. } = env.init::<N>(AccessRights::RO)?;
 
-        let storage: BaseProofsStorage<Arc<MdbxProofsStorage>> = Arc::new(
-            MdbxProofsStorage::new(&self.storage_path)
-                .map_err(|e| eyre::eyre!("Failed to create MdbxProofsStorage: {e}"))?,
-        )
-        .into();
+        match proofs_history_db {
+            ProofsHistoryDbBackend::Rocksdb => {
+                let storage: BaseProofsStorage<Arc<RocksdbProofsStorage>> = Arc::new(
+                    RocksdbProofsStorage::new(&storage_path)
+                        .map_err(|e| eyre::eyre!("Failed to create RocksdbProofsStorage: {e}"))?,
+                )
+                .into();
+                Self::prune_storage(
+                    storage,
+                    provider_factory,
+                    proofs_history_window,
+                    proofs_history_prune_batch_size,
+                )?;
+            }
+            ProofsHistoryDbBackend::Mdbx => {
+                let storage: BaseProofsStorage<Arc<MdbxProofsStorage>> = Arc::new(
+                    MdbxProofsStorage::new(&storage_path)
+                        .map_err(|e| eyre::eyre!("Failed to create MdbxProofsStorage: {e}"))?,
+                )
+                .into();
+                Self::prune_storage(
+                    storage,
+                    provider_factory,
+                    proofs_history_window,
+                    proofs_history_prune_batch_size,
+                )?;
+            }
+        }
 
+        Ok(())
+    }
+    fn prune_storage<S, H>(
+        storage: BaseProofsStorage<Arc<S>>,
+        hash_reader: H,
+        proofs_history_window: u64,
+        proofs_history_prune_batch_size: u64,
+    ) -> eyre::Result<()>
+    where
+        S: BaseProofsStore + 'static,
+        H: reth_provider::BlockHashReader,
+    {
         let earliest_block = storage.get_earliest_block_number()?;
         let latest_block = storage.get_latest_block_number()?;
         info!(
@@ -74,9 +137,9 @@ impl<C: ChainSpecParser<ChainSpec = BaseChainSpec>> PruneCommand<C> {
 
         let pruner = BaseProofStoragePruner::new(
             storage,
-            provider_factory,
-            self.proofs_history_window,
-            self.proofs_history_prune_batch_size,
+            hash_reader,
+            proofs_history_window,
+            proofs_history_prune_batch_size,
         );
         pruner.run();
         Ok(())

--- a/crates/execution/cli/src/commands/base_proofs/unwind.rs
+++ b/crates/execution/cli/src/commands/base_proofs/unwind.rs
@@ -4,11 +4,14 @@ use std::{path::PathBuf, sync::Arc};
 
 use base_common_consensus::BasePrimitives;
 use base_execution_chainspec::BaseChainSpec;
-use base_execution_trie::{BaseProofsStorage, BaseProofsStore, db::MdbxProofsStorage};
+use base_execution_trie::{
+    BaseProofsStorage, BaseProofsStore, MdbxProofsStorage, RocksdbProofsStorage,
+};
+use base_node_core::args::ProofsHistoryDbBackend;
 use clap::Parser;
 use reth_cli::chainspec::ChainSpecParser;
 use reth_cli_commands::common::{AccessRights, CliNodeTypes, Environment, EnvironmentArgs};
-use reth_node_core::version::version_metadata;
+use reth_node_core::{primitives::AlloyBlockHeader as _, version::version_metadata};
 use reth_provider::{BlockReader, TransactionVariant};
 use tracing::{info, warn};
 
@@ -28,6 +31,10 @@ pub struct UnwindCommand<C: ChainSpecParser> {
     )]
     pub storage_path: PathBuf,
 
+    /// The on-disk database backend for proofs history.
+    #[arg(long = "proofs-history.db", value_name = "PROOFS_HISTORY_DB", default_value = "rocksdb")]
+    pub proofs_history_db: ProofsHistoryDbBackend,
+
     /// The target block number to unwind to.
     ///
     /// All history *after* this block will be removed.
@@ -35,10 +42,78 @@ pub struct UnwindCommand<C: ChainSpecParser> {
     pub target: u64,
 }
 
-impl<C: ChainSpecParser> UnwindCommand<C> {
+impl<C: ChainSpecParser<ChainSpec = BaseChainSpec>> UnwindCommand<C> {
+    /// Execute [`UnwindCommand`].
+    pub async fn execute<N: CliNodeTypes<ChainSpec = C::ChainSpec, Primitives = BasePrimitives>>(
+        self,
+    ) -> eyre::Result<()> {
+        let Self { env, storage_path, proofs_history_db, target } = self;
+
+        info!(target: "reth::cli", version = %version_metadata().short_version, "reth starting");
+        info!(
+            target: "reth::cli",
+            path = ?storage_path,
+            backend = ?proofs_history_db,
+            "Unwinding Base proofs storage"
+        );
+
+        // Initialize the environment with read-only access
+        let Environment { provider_factory, .. } = env.init::<N>(AccessRights::RO)?;
+
+        match proofs_history_db {
+            ProofsHistoryDbBackend::Rocksdb => {
+                let storage: BaseProofsStorage<Arc<RocksdbProofsStorage>> = Arc::new(
+                    RocksdbProofsStorage::new(&storage_path)
+                        .map_err(|e| eyre::eyre!("Failed to create RocksdbProofsStorage: {e}"))?,
+                )
+                .into();
+                Self::unwind_storage(target, &provider_factory, storage)?;
+            }
+            ProofsHistoryDbBackend::Mdbx => {
+                let storage: BaseProofsStorage<Arc<MdbxProofsStorage>> = Arc::new(
+                    MdbxProofsStorage::new(&storage_path)
+                        .map_err(|e| eyre::eyre!("Failed to create MdbxProofsStorage: {e}"))?,
+                )
+                .into();
+                Self::unwind_storage(target, &provider_factory, storage)?;
+            }
+        }
+
+        Ok(())
+    }
+
+    fn unwind_storage<S, P>(
+        target: u64,
+        provider_factory: &P,
+        storage: BaseProofsStorage<Arc<S>>,
+    ) -> eyre::Result<()>
+    where
+        S: BaseProofsStore + 'static,
+        P: BlockReader,
+    {
+        // Validate that the target block is within a valid range for unwinding
+        if !Self::validate_unwind_range(target, &storage)? {
+            return Ok(());
+        }
+
+        // Get the target block from the main database
+        let block = provider_factory
+            .recovered_block(target.into(), TransactionVariant::NoHash)?
+            .ok_or_else(|| eyre::eyre!("Target block {} not found in the main database", target))?;
+
+        info!(
+            target: "reth::cli",
+            block_number = block.number(),
+            block_hash = %block.hash(),
+            "Unwinding to target block"
+        );
+        storage.unwind_history(block.block_with_parent())?;
+        Ok(())
+    }
+
     /// Validates that the target block number is within a valid range for unwinding.
     fn validate_unwind_range<Store: BaseProofsStore>(
-        &self,
+        target: u64,
         storage: &BaseProofsStorage<Store>,
     ) -> eyre::Result<bool> {
         let (Some((earliest, _)), Some((latest, _))) =
@@ -48,54 +123,17 @@ impl<C: ChainSpecParser> UnwindCommand<C> {
             return Ok(false);
         };
 
-        if self.target <= earliest {
-            warn!(target: "reth::cli", unwind_target = ?self.target, ?earliest, "Target block is less than the earliest block in proofs storage. Nothing to unwind.");
+        if target <= earliest {
+            warn!(target: "reth::cli", unwind_target = ?target, ?earliest, "Target block is less than the earliest block in proofs storage. Nothing to unwind.");
             return Ok(false);
         }
 
-        if self.target > latest {
-            warn!(target: "reth::cli", unwind_target = ?self.target, ?latest, "Target block is not less than the latest block in proofs storage. Nothing to unwind.");
+        if target > latest {
+            warn!(target: "reth::cli", unwind_target = ?target, ?latest, "Target block is not less than the latest block in proofs storage. Nothing to unwind.");
             return Ok(false);
         }
 
         Ok(true)
-    }
-}
-
-impl<C: ChainSpecParser<ChainSpec = BaseChainSpec>> UnwindCommand<C> {
-    /// Execute [`UnwindCommand`].
-    pub async fn execute<N: CliNodeTypes<ChainSpec = C::ChainSpec, Primitives = BasePrimitives>>(
-        self,
-    ) -> eyre::Result<()> {
-        info!(target: "reth::cli", version = %version_metadata().short_version, "reth starting");
-        info!(target: "reth::cli", path = ?self.storage_path, "Unwinding Base proofs storage");
-
-        // Initialize the environment with read-only access
-        let Environment { provider_factory, .. } = self.env.init::<N>(AccessRights::RO)?;
-
-        // Create the proofs storage
-        let storage: BaseProofsStorage<Arc<MdbxProofsStorage>> = Arc::new(
-            MdbxProofsStorage::new(&self.storage_path)
-                .map_err(|e| eyre::eyre!("Failed to create MdbxProofsStorage: {e}"))?,
-        )
-        .into();
-
-        // Validate that the target block is within a valid range for unwinding
-        if !self.validate_unwind_range(&storage)? {
-            return Ok(());
-        }
-
-        // Get the target block from the main database
-        let block = provider_factory
-            .recovered_block(self.target.into(), TransactionVariant::NoHash)?
-            .ok_or_else(|| {
-                eyre::eyre!("Target block {} not found in the main database", self.target)
-            })?;
-
-        info!(target: "reth::cli", block_number = block.number, block_hash = %block.hash(), "Unwinding to target block");
-        storage.unwind_history(block.block_with_parent())?;
-
-        Ok(())
     }
 }
 

--- a/crates/execution/exex/src/lib.rs
+++ b/crates/execution/exex/src/lib.rs
@@ -119,7 +119,7 @@ where
 /// use base_execution_chainspec::BaseChainSpec;
 /// use base_execution_exex::BaseProofsExEx;
 /// use base_node_core::{BaseNode, args::RollupArgs};
-/// use base_execution_trie::{InMemoryProofsStorage, BaseProofsStorage, db::MdbxProofsStorage};
+/// use base_execution_trie::{InMemoryProofsStorage, BaseProofsStorage, RocksdbProofsStorage};
 /// use reth_provider::providers::BlockchainProvider;
 /// use std::{sync::Arc, time::Duration};
 ///
@@ -136,8 +136,8 @@ where
 /// # let temp_dir = tempfile::tempdir().expect("Failed to create temp dir");
 /// # let storage_path = temp_dir.path().join("proofs_storage");
 ///
-/// # let storage: BaseProofsStorage<Arc<MdbxProofsStorage>> = Arc::new(
-/// #    MdbxProofsStorage::new(&storage_path).expect("Failed to create MdbxProofsStorage"),
+/// # let storage: BaseProofsStorage<Arc<RocksdbProofsStorage>> = Arc::new(
+/// #    RocksdbProofsStorage::new(&storage_path).expect("Failed to create RocksdbProofsStorage"),
 /// # ).into();
 ///
 /// let storage_exec = storage.clone();
@@ -688,7 +688,7 @@ mod tests {
     use alloy_consensus::private::alloy_primitives::B256;
     use alloy_eips::{BlockNumHash, NumHash, eip1898::BlockWithParent};
     use base_execution_trie::{
-        BaseProofsStorage, BaseProofsStore, BlockStateDiff, db::MdbxProofsStorage,
+        BaseProofsStorage, BaseProofsStore, BlockStateDiff, RocksdbProofsStorage,
     };
     use reth_db::test_utils::tempdir_path;
     use reth_ethereum_primitives::{Block, Receipt};
@@ -800,8 +800,8 @@ mod tests {
     async fn handle_notification_chain_committed() {
         // MDBX proofs storage
         let dir = tempdir_path();
-        let store = Arc::new(MdbxProofsStorage::new(dir.as_path()).expect("env"));
-        let proofs: BaseProofsStorage<Arc<MdbxProofsStorage>> = Arc::clone(&store).into();
+        let store = Arc::new(RocksdbProofsStorage::new(dir.as_path()).expect("env"));
+        let proofs: BaseProofsStorage<Arc<RocksdbProofsStorage>> = Arc::clone(&store).into();
 
         init_storage(proofs.clone());
 
@@ -827,8 +827,8 @@ mod tests {
     async fn handle_notification_chain_committed_caches_already_stored_blocks() {
         // MDBX proofs storage
         let dir = tempdir_path();
-        let store = Arc::new(MdbxProofsStorage::new(dir.as_path()).expect("env"));
-        let proofs: BaseProofsStorage<Arc<MdbxProofsStorage>> = Arc::clone(&store).into();
+        let store = Arc::new(RocksdbProofsStorage::new(dir.as_path()).expect("env"));
+        let proofs: BaseProofsStorage<Arc<RocksdbProofsStorage>> = Arc::clone(&store).into();
 
         init_storage(proofs.clone());
 
@@ -861,8 +861,8 @@ mod tests {
     async fn handle_notification_chain_reorged() {
         // MDBX proofs storage
         let dir = tempdir_path();
-        let store = Arc::new(MdbxProofsStorage::new(dir.as_path()).expect("env"));
-        let proofs: BaseProofsStorage<Arc<MdbxProofsStorage>> = Arc::clone(&store).into();
+        let store = Arc::new(RocksdbProofsStorage::new(dir.as_path()).expect("env"));
+        let proofs: BaseProofsStorage<Arc<RocksdbProofsStorage>> = Arc::clone(&store).into();
 
         init_storage(proofs.clone());
         store_blocks(1, 10, &proofs);
@@ -905,8 +905,8 @@ mod tests {
     async fn handle_notification_chain_reorged_beyond_stored_blocks() {
         // MDBX proofs storage
         let dir = tempdir_path();
-        let store = Arc::new(MdbxProofsStorage::new(dir.as_path()).expect("env"));
-        let proofs: BaseProofsStorage<Arc<MdbxProofsStorage>> = Arc::clone(&store).into();
+        let store = Arc::new(RocksdbProofsStorage::new(dir.as_path()).expect("env"));
+        let proofs: BaseProofsStorage<Arc<RocksdbProofsStorage>> = Arc::clone(&store).into();
 
         init_storage(proofs.clone());
         store_blocks(1, 10, &proofs);
@@ -945,8 +945,8 @@ mod tests {
     async fn handle_notification_chain_reverted() {
         // MDBX proofs storage
         let dir = tempdir_path();
-        let store = Arc::new(MdbxProofsStorage::new(dir.as_path()).expect("env"));
-        let proofs: BaseProofsStorage<Arc<MdbxProofsStorage>> = Arc::clone(&store).into();
+        let store = Arc::new(RocksdbProofsStorage::new(dir.as_path()).expect("env"));
+        let proofs: BaseProofsStorage<Arc<RocksdbProofsStorage>> = Arc::clone(&store).into();
 
         init_storage(proofs.clone());
         store_blocks(1, 10, &proofs);
@@ -983,8 +983,8 @@ mod tests {
     async fn handle_notification_chain_reverted_beyond_stored_blocks() {
         // MDBX proofs storage
         let dir = tempdir_path();
-        let store = Arc::new(MdbxProofsStorage::new(dir.as_path()).expect("env"));
-        let proofs: BaseProofsStorage<Arc<MdbxProofsStorage>> = Arc::clone(&store).into();
+        let store = Arc::new(RocksdbProofsStorage::new(dir.as_path()).expect("env"));
+        let proofs: BaseProofsStorage<Arc<RocksdbProofsStorage>> = Arc::clone(&store).into();
 
         init_storage(proofs.clone());
         store_blocks(1, 5, &proofs);
@@ -1021,8 +1021,8 @@ mod tests {
     async fn ensure_initialized_errors_on_storage_not_initialized() {
         // MDBX proofs storage
         let dir = tempdir_path();
-        let store = Arc::new(MdbxProofsStorage::new(dir.as_path()).expect("env"));
-        let proofs: BaseProofsStorage<Arc<MdbxProofsStorage>> = Arc::clone(&store).into();
+        let store = Arc::new(RocksdbProofsStorage::new(dir.as_path()).expect("env"));
+        let proofs: BaseProofsStorage<Arc<RocksdbProofsStorage>> = Arc::clone(&store).into();
 
         let (ctx, _handle) =
             reth_exex_test_utils::test_exex_context().await.expect("exex test context");
@@ -1035,8 +1035,8 @@ mod tests {
     async fn ensure_initialized_errors_when_prune_exceeds_threshold() {
         // MDBX proofs storage
         let dir = tempdir_path();
-        let store = Arc::new(MdbxProofsStorage::new(dir.as_path()).expect("env"));
-        let proofs: BaseProofsStorage<Arc<MdbxProofsStorage>> = Arc::clone(&store).into();
+        let store = Arc::new(RocksdbProofsStorage::new(dir.as_path()).expect("env"));
+        let proofs: BaseProofsStorage<Arc<RocksdbProofsStorage>> = Arc::clone(&store).into();
 
         init_storage(proofs.clone());
 
@@ -1063,8 +1063,8 @@ mod tests {
     async fn ensure_initialized_succeeds() {
         // MDBX proofs storage
         let dir = tempdir_path();
-        let store = Arc::new(MdbxProofsStorage::new(dir.as_path()).expect("env"));
-        let proofs: BaseProofsStorage<Arc<MdbxProofsStorage>> = Arc::clone(&store).into();
+        let store = Arc::new(RocksdbProofsStorage::new(dir.as_path()).expect("env"));
+        let proofs: BaseProofsStorage<Arc<RocksdbProofsStorage>> = Arc::clone(&store).into();
 
         init_storage(proofs.clone());
 
@@ -1079,8 +1079,8 @@ mod tests {
     async fn handle_notification_schedules_async_on_gap() {
         // MDBX proofs storage
         let dir = tempdir_path();
-        let store = Arc::new(MdbxProofsStorage::new(dir.as_path()).expect("env"));
-        let proofs: BaseProofsStorage<Arc<MdbxProofsStorage>> = Arc::clone(&store).into();
+        let store = Arc::new(RocksdbProofsStorage::new(dir.as_path()).expect("env"));
+        let proofs: BaseProofsStorage<Arc<RocksdbProofsStorage>> = Arc::clone(&store).into();
 
         init_storage(proofs.clone());
 

--- a/crates/execution/node/src/args.rs
+++ b/crates/execution/node/src/args.rs
@@ -6,6 +6,12 @@ use std::{path::PathBuf, time::Duration};
 
 use clap::{ValueEnum, builder::ArgPredicate};
 
+/// Default proofs history window: 1 month of blocks at 2s block time.
+pub const DEFAULT_PROOFS_HISTORY_WINDOW_BLOCKS: u64 = 1_296_000;
+
+/// Twelve hours of blocks at 2s block time.
+pub const TWELVE_HOURS_IN_BLOCKS: u64 = 21_600;
+
 /// Transaction ordering strategy for the mempool.
 ///
 /// Determines how transactions are prioritized when building blocks.
@@ -23,6 +29,17 @@ pub enum TxpoolOrdering {
     /// Transactions are ordered by when they were received by the mempool,
     /// regardless of the fees they offer.
     Timestamp,
+}
+
+/// On-disk database backend for proofs history.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, ValueEnum)]
+#[value(rename_all = "kebab-case")]
+pub enum ProofsHistoryDbBackend {
+    /// Store proofs history in `RocksDB`.
+    #[default]
+    Rocksdb,
+    /// Store proofs history in `MDBX`.
+    Mdbx,
 }
 
 /// Parameters for rollup configuration
@@ -89,13 +106,20 @@ pub struct RollupArgs {
     #[arg(long = "proofs-history.storage-path", value_name = "PROOFS_HISTORY_STORAGE_PATH")]
     pub proofs_history_storage_path: Option<PathBuf>,
 
+    /// The on-disk database backend for proofs history.
+    #[arg(long = "proofs-history.db", value_name = "PROOFS_HISTORY_DB", default_value = "rocksdb")]
+    pub proofs_history_db: ProofsHistoryDbBackend,
+
     /// The window to span blocks for proofs history. Value is the number of blocks.
     /// Default is 1 month of blocks based on 2 seconds block time.
     /// 30 * 24 * 60 * 60 / 2 = `1_296_000`
+    ///
+    /// Must be greater than 12 hours of blocks based on 2 seconds block time.
     #[arg(
         long = "proofs-history.window",
-        default_value_t = 1_296_000,
-        value_name = "PROOFS_HISTORY_WINDOW"
+        default_value_t = DEFAULT_PROOFS_HISTORY_WINDOW_BLOCKS,
+        value_name = "PROOFS_HISTORY_WINDOW",
+        value_parser = clap::value_parser!(u64).range((TWELVE_HOURS_IN_BLOCKS + 1)..)
     )]
     pub proofs_history_window: u64,
 
@@ -118,6 +142,7 @@ pub struct RollupArgs {
         value_parser = humantime::parse_duration
     )]
     pub proofs_history_prune_interval: Duration,
+
     /// Verification interval: perform full block execution every N blocks for data integrity.
     /// - 0: Disabled (Default) (always use fast path with pre-computed data from notifications)
     /// - 1: Always verify (always execute blocks, slowest)
@@ -155,7 +180,8 @@ impl Default for RollupArgs {
             max_inflight_delegated_slots: 1,
             proofs_history: false,
             proofs_history_storage_path: None,
-            proofs_history_window: 1_296_000,
+            proofs_history_db: ProofsHistoryDbBackend::default(),
+            proofs_history_window: DEFAULT_PROOFS_HISTORY_WINDOW_BLOCKS,
             proofs_history_prune_interval: Duration::from_secs(15),
             proofs_history_verification_interval: 0,
             base_protocol: true,
@@ -278,6 +304,51 @@ mod tests {
         ])
         .args;
         assert_eq!(args.txpool_ordering, TxpoolOrdering::Timestamp);
+    }
+
+    #[test]
+    fn test_parse_proofs_history_db_default() {
+        let args = CommandParser::<RollupArgs>::parse_from(["reth"]).args;
+        assert_eq!(args.proofs_history_db, ProofsHistoryDbBackend::Rocksdb);
+    }
+
+    #[test]
+    fn test_parse_proofs_history_db_mdbx() {
+        let args = CommandParser::<RollupArgs>::parse_from([
+            "reth",
+            "--proofs-history",
+            "--proofs-history.db",
+            "mdbx",
+        ])
+        .args;
+        assert!(args.proofs_history);
+        assert_eq!(args.proofs_history_db, ProofsHistoryDbBackend::Mdbx);
+    }
+
+    #[test]
+    fn test_parse_proofs_history_db_without_enabling_history() {
+        let args =
+            CommandParser::<RollupArgs>::parse_from(["reth", "--proofs-history.db", "mdbx"]).args;
+        assert!(!args.proofs_history);
+        assert_eq!(args.proofs_history_db, ProofsHistoryDbBackend::Mdbx);
+    }
+
+    #[test]
+    fn test_parse_proofs_history_window() {
+        let args =
+            CommandParser::<RollupArgs>::parse_from(["reth", "--proofs-history.window", "21601"])
+                .args;
+        assert_eq!(args.proofs_history_window, 21_601);
+    }
+
+    #[test]
+    fn test_parse_proofs_history_window_rejects_twelve_hours_or_less() {
+        let result = CommandParser::<RollupArgs>::try_parse_from([
+            "reth",
+            "--proofs-history.window",
+            "21600",
+        ]);
+        assert!(result.is_err());
     }
 
     #[test]

--- a/crates/execution/node/src/lib.rs
+++ b/crates/execution/node/src/lib.rs
@@ -12,7 +12,10 @@ use reth_db_api as _;
 
 /// CLI argument parsing for the Base node.
 pub mod args;
-pub use args::TxpoolOrdering;
+pub use args::{
+    DEFAULT_PROOFS_HISTORY_WINDOW_BLOCKS, ProofsHistoryDbBackend, TWELVE_HOURS_IN_BLOCKS,
+    TxpoolOrdering,
+};
 
 /// Exports Base-specific implementations of the [`EngineTypes`](reth_node_api::EngineTypes)
 /// trait.

--- a/crates/execution/node/src/proof_history.rs
+++ b/crates/execution/node/src/proof_history.rs
@@ -1,4 +1,4 @@
-//! Node luncher with proof history support.
+//! Node launcher with proof history support.
 
 use std::{sync::Arc, time::Duration};
 
@@ -8,27 +8,45 @@ use base_execution_rpc::{
     debug::{DebugApiExt, DebugApiOverrideServer},
     eth::proofs::{EthApiExt, EthApiOverrideServer},
 };
-use base_execution_trie::{BaseProofsStorage, db::MdbxProofsStorage};
+use base_execution_trie::{
+    BaseProofsStorage, BaseProofsStore, MdbxProofsStorage, RocksdbProofsStorage,
+};
 use eyre::ErrReport;
 use futures::FutureExt;
 use reth_db::DatabaseEnv;
 use reth_db_api::database_metrics::DatabaseMetrics;
-use reth_node_builder::{FullNodeComponents, NodeBuilder, WithLaunchContext};
+use reth_node_builder::{
+    FullNodeComponents, Node as RethNode, NodeBuilder, NodeBuilderWithComponents, RethFullAdapter,
+    WithLaunchContext,
+};
 use reth_tasks::TaskExecutor;
 use tokio::time::sleep;
 use tracing::info;
 
-use crate::{BaseNode, args::RollupArgs};
+use crate::{
+    BaseNode, BaseNodeComponentBuilder,
+    args::{ProofsHistoryDbBackend, RollupArgs},
+};
+
+type ProofHistoryNodeTypes = RethFullAdapter<Arc<DatabaseEnv>, BaseNode>;
+type ProofHistoryNodeBuilder = WithLaunchContext<
+    NodeBuilderWithComponents<
+        ProofHistoryNodeTypes,
+        BaseNodeComponentBuilder<ProofHistoryNodeTypes>,
+        <BaseNode as RethNode<ProofHistoryNodeTypes>>::AddOns,
+    >,
+>;
 
 /// - no proofs history (plain node),
 /// - in-mem proofs storage,
-/// - MDBX proofs storage.
+/// - on-disk proofs storage.
 pub async fn launch_node_with_proof_history(
     builder: WithLaunchContext<NodeBuilder<Arc<DatabaseEnv>, BaseChainSpec>>,
     args: RollupArgs,
 ) -> eyre::Result<(), ErrReport> {
     let RollupArgs {
         proofs_history,
+        proofs_history_db,
         proofs_history_window,
         proofs_history_prune_interval,
         proofs_history_verification_interval,
@@ -39,63 +57,100 @@ pub async fn launch_node_with_proof_history(
     let mut node_builder = builder.node(BaseNode::new(args.clone()));
 
     if proofs_history {
-        let path = args
-            .proofs_history_storage_path
-            .clone()
-            .expect("Path must be provided if not using in-memory storage");
+        let path = args.proofs_history_storage_path.clone().ok_or_else(|| {
+            eyre::eyre!("--proofs-history requires --proofs-history.storage-path")
+        })?;
         info!(target: "reth::cli", "Using on-disk storage for proofs history");
 
-        let mdbx = Arc::new(
-            MdbxProofsStorage::new(&path)
-                .map_err(|e| eyre::eyre!("Failed to create MdbxProofsStorage: {e}"))?,
-        );
-        let storage: BaseProofsStorage<Arc<MdbxProofsStorage>> = Arc::clone(&mdbx).into();
-
-        let storage_exec = storage.clone();
-
-        node_builder = node_builder
-            .on_node_started(move |node| {
-                spawn_proofs_db_metrics(
-                    node.task_executor,
+        match proofs_history_db {
+            ProofsHistoryDbBackend::Rocksdb => {
+                let rocksdb = Arc::new(
+                    RocksdbProofsStorage::new(&path)
+                        .map_err(|e| eyre::eyre!("Failed to create RocksdbProofsStorage: {e}"))?,
+                );
+                node_builder = install_proofs_history(
+                    node_builder,
+                    rocksdb,
+                    proofs_history_window,
+                    proofs_history_prune_interval,
+                    proofs_history_verification_interval,
+                );
+            }
+            ProofsHistoryDbBackend::Mdbx => {
+                let mdbx = Arc::new(
+                    MdbxProofsStorage::new(&path)
+                        .map_err(|e| eyre::eyre!("Failed to create MdbxProofsStorage: {e}"))?,
+                );
+                node_builder = install_proofs_history(
+                    node_builder,
                     mdbx,
-                    node.config.metrics.push_gateway_interval,
+                    proofs_history_window,
+                    proofs_history_prune_interval,
+                    proofs_history_verification_interval,
                 );
-                Ok(())
-            })
-            .install_exex("proofs-history", async move |exex_context| {
-                Ok(BaseProofsExEx::builder(exex_context, storage_exec)
-                    .with_proofs_history_window(proofs_history_window)
-                    .with_proofs_history_prune_interval(proofs_history_prune_interval)
-                    .with_verification_interval(proofs_history_verification_interval)
-                    .build()
-                    .run()
-                    .boxed())
-            })
-            .extend_rpc_modules(move |ctx| {
-                let api_ext = EthApiExt::new(ctx.registry.eth_api().clone(), storage.clone());
-                let debug_ext = DebugApiExt::new(
-                    ctx.node().provider().clone(),
-                    ctx.registry.eth_api().clone(),
-                    storage,
-                    Box::new(ctx.node().task_executor().clone()),
-                    ctx.node().evm_config().clone(),
-                );
-                ctx.modules.replace_configured(api_ext.into_rpc())?;
-                ctx.modules.replace_configured(debug_ext.into_rpc())?;
-                Ok(())
-            });
+            }
+        }
     }
 
     // In all cases (with or without proofs), launch the node.
     let handle = node_builder.launch_with_debug_capabilities().await?;
     handle.node_exit_future.await
 }
+
+fn install_proofs_history<S>(
+    node_builder: ProofHistoryNodeBuilder,
+    storage_backend: Arc<S>,
+    proofs_history_window: u64,
+    proofs_history_prune_interval: Duration,
+    proofs_history_verification_interval: u64,
+) -> ProofHistoryNodeBuilder
+where
+    S: BaseProofsStore + DatabaseMetrics + Send + Sync + 'static,
+{
+    let storage: BaseProofsStorage<Arc<S>> = Arc::clone(&storage_backend).into();
+    let storage_exec = storage.clone();
+
+    node_builder
+        .on_node_started(move |node| {
+            spawn_proofs_db_metrics(
+                node.task_executor,
+                storage_backend,
+                node.config.metrics.push_gateway_interval,
+            );
+            Ok(())
+        })
+        .install_exex("proofs-history", async move |exex_context| {
+            Ok(BaseProofsExEx::builder(exex_context, storage_exec)
+                .with_proofs_history_window(proofs_history_window)
+                .with_proofs_history_prune_interval(proofs_history_prune_interval)
+                .with_verification_interval(proofs_history_verification_interval)
+                .build()
+                .run()
+                .boxed())
+        })
+        .extend_rpc_modules(move |ctx| {
+            let api_ext = EthApiExt::new(ctx.registry.eth_api().clone(), storage.clone());
+            let debug_ext = DebugApiExt::new(
+                ctx.node().provider().clone(),
+                ctx.registry.eth_api().clone(),
+                storage,
+                Box::new(ctx.node().task_executor().clone()),
+                ctx.node().evm_config().clone(),
+            );
+            ctx.modules.replace_configured(api_ext.into_rpc())?;
+            ctx.modules.replace_configured(debug_ext.into_rpc())?;
+            Ok(())
+        })
+}
+
 /// Spawns a task that periodically reports metrics for the proofs DB.
-fn spawn_proofs_db_metrics(
+fn spawn_proofs_db_metrics<S>(
     executor: TaskExecutor,
-    storage: Arc<MdbxProofsStorage>,
+    storage: Arc<S>,
     metrics_report_interval: Duration,
-) {
+) where
+    S: DatabaseMetrics + Send + Sync + 'static,
+{
     executor.spawn_critical_task("base-proofs-storage-metrics", async move {
         info!(
             target: "reth::cli",

--- a/crates/execution/proofs/src/proofs.rs
+++ b/crates/execution/proofs/src/proofs.rs
@@ -5,8 +5,10 @@ use base_execution_rpc::{
     debug::{DebugApiExt, DebugApiOverrideServer},
     eth::proofs::{EthApiExt, EthApiOverrideServer},
 };
-use base_execution_trie::{BaseProofsStorage, MdbxProofsStorage};
-use base_node_core::args::RollupArgs;
+use base_execution_trie::{
+    BaseProofsStorage, BaseProofsStore, MdbxProofsStorage, RocksdbProofsStorage,
+};
+use base_node_core::args::{ProofsHistoryDbBackend, RollupArgs};
 use base_node_runner::{BaseNodeExtension, FromExtensionConfig, NodeHooks};
 use reth_db::database_metrics::DatabaseMetrics;
 use reth_node_api::FullNodeComponents;
@@ -37,62 +39,69 @@ impl BaseNodeExtension for ProofsHistoryExtension {
         // TODO: if NodeHooks exposes the underlying Builder, we can call launch_node_with_proof_history
         let args = self.config;
         let proofs_history_enabled = args.proofs_history;
+        let proofs_history_db = args.proofs_history_db;
         let proofs_history_window = args.proofs_history_window;
         let proofs_history_prune_interval = args.proofs_history_prune_interval;
         let proofs_history_verification_interval = args.proofs_history_verification_interval;
 
         if proofs_history_enabled {
-            let path = args
-                .proofs_history_storage_path
-                .expect("Path must be provided if not using in-memory storage");
+            let Some(path) = args.proofs_history_storage_path else {
+                error!(
+                    target: "reth::cli",
+                    "--proofs-history requires --proofs-history.storage-path"
+                );
+                return hooks.add_node_started_hook(|_| {
+                    Err(eyre::eyre!("--proofs-history requires --proofs-history.storage-path"))
+                });
+            };
             info!(target: "reth::cli", "Using on-disk storage for proofs history");
 
-            let mdbx = match MdbxProofsStorage::new(&path)
-                .map_err(|e| eyre::eyre!("Failed to create MdbxProofsStorage: {e}"))
-            {
-                Ok(mdbx) => mdbx,
-                Err(e) => {
-                    error!(target: "reth::cli", error = ?e, "Failed to create MdbxProofsStorage, continuing without proofs history");
-                    return hooks;
-                }
-            };
-            let mdbx = Arc::new(mdbx);
-            let storage: BaseProofsStorage<Arc<MdbxProofsStorage>> = Arc::clone(&mdbx).into();
-
-            let storage_exec = storage.clone();
-
-            // ignore unused if metrics feature is disabled
-            hooks = hooks.add_node_started_hook(move |node| {
-                spawn_proofs_db_metrics(
-                    node.task_executor,
-                    mdbx,
-                    node.config.metrics.push_gateway_interval,
-                );
-                Ok(())
-            });
-
-            hooks = hooks
-                .install_exex("proofs-history", async move |exex_context| {
-                    Ok(BaseProofsExEx::builder(exex_context, storage_exec)
-                        .with_proofs_history_prune_interval(proofs_history_prune_interval)
-                        .with_proofs_history_window(proofs_history_window)
-                        .with_verification_interval(proofs_history_verification_interval)
-                        .build()
-                        .run())
-                })
-                .add_rpc_module(move |ctx| {
-                    let api_ext = EthApiExt::new(ctx.registry.eth_api().clone(), storage.clone());
-                    let debug_ext = DebugApiExt::new(
-                        ctx.node().provider().clone(),
-                        ctx.registry.eth_api().clone(),
-                        storage,
-                        Box::new(ctx.node().task_executor().clone()),
-                        ctx.node().evm_config().clone(),
+            match proofs_history_db {
+                ProofsHistoryDbBackend::Rocksdb => {
+                    let rocksdb = match RocksdbProofsStorage::new(&path)
+                        .map_err(|e| eyre::eyre!("Failed to create RocksdbProofsStorage: {e}"))
+                    {
+                        Ok(rocksdb) => rocksdb,
+                        Err(e) => {
+                            error!(
+                                target: "reth::cli",
+                                error = ?e,
+                                "Failed to create RocksdbProofsStorage"
+                            );
+                            return hooks.add_node_started_hook(move |_| Err(e));
+                        }
+                    };
+                    hooks = install_proofs_history(
+                        hooks,
+                        Arc::new(rocksdb),
+                        proofs_history_window,
+                        proofs_history_prune_interval,
+                        proofs_history_verification_interval,
                     );
-                    ctx.modules.replace_configured(api_ext.into_rpc())?;
-                    ctx.modules.replace_configured(debug_ext.into_rpc())?;
-                    Ok(())
-                });
+                }
+                ProofsHistoryDbBackend::Mdbx => {
+                    let mdbx = match MdbxProofsStorage::new(&path)
+                        .map_err(|e| eyre::eyre!("Failed to create MdbxProofsStorage: {e}"))
+                    {
+                        Ok(mdbx) => mdbx,
+                        Err(e) => {
+                            error!(
+                                target: "reth::cli",
+                                error = ?e,
+                                "Failed to create MdbxProofsStorage"
+                            );
+                            return hooks.add_node_started_hook(move |_| Err(e));
+                        }
+                    };
+                    hooks = install_proofs_history(
+                        hooks,
+                        Arc::new(mdbx),
+                        proofs_history_window,
+                        proofs_history_prune_interval,
+                        proofs_history_verification_interval,
+                    );
+                }
+            }
         }
         hooks
     }
@@ -106,12 +115,60 @@ impl FromExtensionConfig for ProofsHistoryExtension {
     }
 }
 
+fn install_proofs_history<S>(
+    mut hooks: NodeHooks,
+    storage_backend: Arc<S>,
+    proofs_history_window: u64,
+    proofs_history_prune_interval: Duration,
+    proofs_history_verification_interval: u64,
+) -> NodeHooks
+where
+    S: BaseProofsStore + DatabaseMetrics + Send + Sync + 'static,
+{
+    let storage: BaseProofsStorage<Arc<S>> = Arc::clone(&storage_backend).into();
+    let storage_exec = storage.clone();
+
+    hooks = hooks.add_node_started_hook(move |node| {
+        spawn_proofs_db_metrics(
+            node.task_executor,
+            storage_backend,
+            node.config.metrics.push_gateway_interval,
+        );
+        Ok(())
+    });
+
+    hooks
+        .install_exex("proofs-history", async move |exex_context| {
+            Ok(BaseProofsExEx::builder(exex_context, storage_exec)
+                .with_proofs_history_prune_interval(proofs_history_prune_interval)
+                .with_proofs_history_window(proofs_history_window)
+                .with_verification_interval(proofs_history_verification_interval)
+                .build()
+                .run())
+        })
+        .add_rpc_module(move |ctx| {
+            let api_ext = EthApiExt::new(ctx.registry.eth_api().clone(), storage.clone());
+            let debug_ext = DebugApiExt::new(
+                ctx.node().provider().clone(),
+                ctx.registry.eth_api().clone(),
+                storage,
+                Box::new(ctx.node().task_executor().clone()),
+                ctx.node().evm_config().clone(),
+            );
+            ctx.modules.replace_configured(api_ext.into_rpc())?;
+            ctx.modules.replace_configured(debug_ext.into_rpc())?;
+            Ok(())
+        })
+}
+
 /// Spawns a task that periodically reports metrics for the proofs DB.
-fn spawn_proofs_db_metrics(
+fn spawn_proofs_db_metrics<S>(
     executor: TaskExecutor,
-    storage: Arc<MdbxProofsStorage>,
+    storage: Arc<S>,
     metrics_report_interval: Duration,
-) {
+) where
+    S: DatabaseMetrics + Send + Sync + 'static,
+{
     executor.spawn_critical_task("base-proofs-storage-metrics", async move {
         info!(
             target: "reth::cli",

--- a/crates/execution/trie/Cargo.toml
+++ b/crates/execution/trie/Cargo.toml
@@ -52,11 +52,12 @@ parking_lot.workspace = true
 derive_more.workspace = true
 eyre = { workspace = true, optional = true }
 strum = { workspace = true, features = ["derive"] }
+rocksdb = { workspace = true, features = ["lz4", "zstd"] }
 
 [dev-dependencies]
 eyre.workspace = true
-rand_08.workspace = true
 mockall.workspace = true
+rand_08.workspace = true
 tempfile.workspace = true
 test-case.workspace = true
 reth-node-api.workspace = true

--- a/crates/execution/trie/README.md
+++ b/crates/execution/trie/README.md
@@ -20,9 +20,9 @@ base-execution-trie = { workspace = true }
 ```
 
 ```rust,ignore
-use base_execution_trie::{BaseProofStoragePruner, MdbxProofsStorage};
+use base_execution_trie::{BaseProofStoragePruner, RocksdbProofsStorage};
 
-let storage = MdbxProofsStorage::open(db_path)?;
+let storage = RocksdbProofsStorage::new(db_path)?;
 let pruner = BaseProofStoragePruner::new(storage.clone(), retention_blocks);
 ```
 

--- a/crates/execution/trie/src/api.rs
+++ b/crates/execution/trie/src/api.rs
@@ -90,7 +90,9 @@ pub trait BaseProofsStore: Send + Sync + Debug {
         Self: 'tx;
 
     /// Transaction type used by request-scoped cursor factories.
-    type Tx: Debug + Send + Sync;
+    type Tx<'tx>: Debug + Send + Sync
+    where
+        Self: 'tx;
 
     /// Get the earliest block number and hash that has been stored
     ///
@@ -103,70 +105,74 @@ pub trait BaseProofsStore: Send + Sync + Debug {
 
     /// Get a trie cursor for the storage backend
     fn storage_trie_cursor<'tx>(
-        &self,
+        &'tx self,
         hashed_address: B256,
         max_block_number: u64,
     ) -> BaseProofsStorageResult<Self::StorageTrieCursor<'tx>>;
 
     /// Get a trie cursor for the account backend
     fn account_trie_cursor<'tx>(
-        &self,
+        &'tx self,
         max_block_number: u64,
     ) -> BaseProofsStorageResult<Self::AccountTrieCursor<'tx>>;
 
     /// Get a storage cursor for the storage backend
     fn storage_hashed_cursor<'tx>(
-        &self,
+        &'tx self,
         hashed_address: B256,
         max_block_number: u64,
     ) -> BaseProofsStorageResult<Self::StorageCursor<'tx>>;
 
     /// Get an account hashed cursor for the storage backend
     fn account_hashed_cursor<'tx>(
-        &self,
+        &'tx self,
         max_block_number: u64,
     ) -> BaseProofsStorageResult<Self::AccountHashedCursor<'tx>>;
 
     /// Open a transaction for a request-scoped cursor factory.
-    fn ro_tx(&self) -> BaseProofsStorageResult<Self::Tx>;
+    fn ro_tx<'tx>(&'tx self) -> BaseProofsStorageResult<Self::Tx<'tx>>;
 
     /// Storage trie cursor reusing `tx`.
-    fn storage_trie_cursor_with_tx<'tx>(
+    fn storage_trie_cursor_with_tx<'tx, 'db>(
         &self,
-        tx: &'tx Self::Tx,
+        tx: &'tx Self::Tx<'db>,
         hashed_address: B256,
         max_block_number: u64,
     ) -> BaseProofsStorageResult<Self::StorageTrieCursor<'tx>>
     where
-        Self: 'tx;
+        Self: 'db,
+        'db: 'tx;
 
     /// Account trie cursor reusing `tx`.
-    fn account_trie_cursor_with_tx<'tx>(
+    fn account_trie_cursor_with_tx<'tx, 'db>(
         &self,
-        tx: &'tx Self::Tx,
+        tx: &'tx Self::Tx<'db>,
         max_block_number: u64,
     ) -> BaseProofsStorageResult<Self::AccountTrieCursor<'tx>>
     where
-        Self: 'tx;
+        Self: 'db,
+        'db: 'tx;
 
     /// Storage hashed cursor reusing `tx`.
-    fn storage_hashed_cursor_with_tx<'tx>(
+    fn storage_hashed_cursor_with_tx<'tx, 'db>(
         &self,
-        tx: &'tx Self::Tx,
+        tx: &'tx Self::Tx<'db>,
         hashed_address: B256,
         max_block_number: u64,
     ) -> BaseProofsStorageResult<Self::StorageCursor<'tx>>
     where
-        Self: 'tx;
+        Self: 'db,
+        'db: 'tx;
 
     /// Account hashed cursor reusing `tx`.
-    fn account_hashed_cursor_with_tx<'tx>(
+    fn account_hashed_cursor_with_tx<'tx, 'db>(
         &self,
-        tx: &'tx Self::Tx,
+        tx: &'tx Self::Tx<'db>,
         max_block_number: u64,
     ) -> BaseProofsStorageResult<Self::AccountHashedCursor<'tx>>
     where
-        Self: 'tx;
+        Self: 'db,
+        'db: 'tx;
 
     /// Store a batch of trie updates.
     ///

--- a/crates/execution/trie/src/cursor_factory.rs
+++ b/crates/execution/trie/src/cursor_factory.rs
@@ -20,26 +20,27 @@ use crate::{
 /// Holds a borrow of the transaction so every cursor allocation reuses the same MDBX
 /// reader slot. See [`BaseProofsStore::Tx`] for the underlying contention story.
 #[derive(Debug, Clone)]
-pub struct BaseProofsTrieCursorFactory<'tx, S: BaseProofsStore> {
-    storage: &'tx BaseProofsStorage<S>,
-    tx: &'tx <BaseProofsStorage<S> as BaseProofsStore>::Tx,
+pub struct BaseProofsTrieCursorFactory<'tx, 'db, S: BaseProofsStore> {
+    storage: &'db BaseProofsStorage<S>,
+    tx: &'tx <BaseProofsStorage<S> as BaseProofsStore>::Tx<'db>,
     block_number: u64,
 }
 
-impl<'tx, S: BaseProofsStore> BaseProofsTrieCursorFactory<'tx, S> {
+impl<'tx, 'db, S: BaseProofsStore> BaseProofsTrieCursorFactory<'tx, 'db, S> {
     /// Initializes a request-scoped trie cursor factory bound to `tx`.
     pub const fn new(
-        storage: &'tx BaseProofsStorage<S>,
-        tx: &'tx <BaseProofsStorage<S> as BaseProofsStore>::Tx,
+        storage: &'db BaseProofsStorage<S>,
+        tx: &'tx <BaseProofsStorage<S> as BaseProofsStore>::Tx<'db>,
         block_number: u64,
     ) -> Self {
         Self { storage, tx, block_number }
     }
 }
 
-impl<'tx, S> TrieCursorFactory for BaseProofsTrieCursorFactory<'tx, S>
+impl<'tx, 'db, S> TrieCursorFactory for BaseProofsTrieCursorFactory<'tx, 'db, S>
 where
-    for<'a> S: BaseProofsStore + 'tx,
+    for<'a> S: BaseProofsStore + 'db,
+    'db: 'tx,
 {
     type AccountTrieCursor<'a>
         = BaseProofsTrieCursor<S::AccountTrieCursor<'a>>
@@ -74,26 +75,27 @@ where
 ///
 /// Mirror of [`BaseProofsTrieCursorFactory`] for the hashed account/storage tries.
 #[derive(Debug, Clone)]
-pub struct BaseProofsHashedAccountCursorFactory<'tx, S: BaseProofsStore> {
-    storage: &'tx BaseProofsStorage<S>,
-    tx: &'tx <BaseProofsStorage<S> as BaseProofsStore>::Tx,
+pub struct BaseProofsHashedAccountCursorFactory<'tx, 'db, S: BaseProofsStore> {
+    storage: &'db BaseProofsStorage<S>,
+    tx: &'tx <BaseProofsStorage<S> as BaseProofsStore>::Tx<'db>,
     block_number: u64,
 }
 
-impl<'tx, S: BaseProofsStore> BaseProofsHashedAccountCursorFactory<'tx, S> {
+impl<'tx, 'db, S: BaseProofsStore> BaseProofsHashedAccountCursorFactory<'tx, 'db, S> {
     /// Initializes a request-scoped hashed cursor factory bound to `tx`.
     pub const fn new(
-        storage: &'tx BaseProofsStorage<S>,
-        tx: &'tx <BaseProofsStorage<S> as BaseProofsStore>::Tx,
+        storage: &'db BaseProofsStorage<S>,
+        tx: &'tx <BaseProofsStorage<S> as BaseProofsStore>::Tx<'db>,
         block_number: u64,
     ) -> Self {
         Self { storage, tx, block_number }
     }
 }
 
-impl<'tx, S> HashedCursorFactory for BaseProofsHashedAccountCursorFactory<'tx, S>
+impl<'tx, 'db, S> HashedCursorFactory for BaseProofsHashedAccountCursorFactory<'tx, 'db, S>
 where
-    for<'a> S: BaseProofsStore + 'tx,
+    for<'a> S: BaseProofsStore + 'db,
+    'db: 'tx,
 {
     type AccountCursor<'a>
         = BaseProofsHashedAccountCursor<S::AccountHashedCursor<'a>>

--- a/crates/execution/trie/src/db/mod.rs
+++ b/crates/execution/trie/src/db/mod.rs
@@ -1,15 +1,19 @@
-//! MDBX implementation of [`BaseProofsStore`](crate::BaseProofsStore).
+//! Database-backed implementations of [`BaseProofsStore`](crate::BaseProofsStore).
 //!
-//! This module provides a complete MDBX implementation of the
-//! [`BaseProofsStore`](crate::BaseProofsStore) trait. It uses the [`reth_db`]
-//! crate for database interactions and defines the necessary tables and models for storing trie
-//! branches, accounts, and storage leaves.
+//! This module defines the schema models and storage backends used for storing trie branches,
+//! accounts, and storage leaves.
 
 mod models;
 pub use models::*;
 
 mod store;
 pub use store::MdbxProofsStorage;
+
+mod rocksdb;
+pub use rocksdb::{
+    RocksdbAccountCursor, RocksdbProofsStorage, RocksdbReadSnapshot, RocksdbStorageCursor,
+    RocksdbTrieCursor,
+};
 
 mod cursor;
 pub use cursor::{

--- a/crates/execution/trie/src/db/rocksdb.rs
+++ b/crates/execution/trie/src/db/rocksdb.rs
@@ -1,0 +1,2886 @@
+//! `RocksDB` implementation of proofs storage.
+
+use std::{
+    collections::BTreeMap,
+    fmt,
+    marker::PhantomData,
+    ops::{Bound, RangeBounds},
+    path::Path,
+    sync::Arc,
+    time::Instant,
+};
+
+use alloy_eips::{BlockNumHash, NumHash, eip1898::BlockWithParent};
+use alloy_primitives::{B256, U256, map::HashMap};
+#[cfg(feature = "metrics")]
+use metrics::Label;
+use parking_lot::{Mutex, RwLock};
+use reth_db::{
+    DatabaseError,
+    table::{Compress, Decompress, DupSort, Encode, Table},
+};
+use reth_primitives_traits::Account;
+use reth_trie::{
+    hashed_cursor::{HashedCursor, HashedStorageCursor},
+    trie_cursor::{TrieCursor, TrieStorageCursor},
+};
+use reth_trie_common::{
+    BranchNodeCompact, HashedPostState, Nibbles, StoredNibbles,
+    updates::{StorageTrieUpdates, TrieUpdates},
+};
+use rocksdb::{
+    BlockBasedOptions, BoundColumnFamily, Cache, ColumnFamilyDescriptor, CompactionPri,
+    DBCompressionType, DBWithThreadMode, Direction, IteratorMode, MultiThreaded, Options,
+    ReadOptions, SnapshotWithThreadMode, WriteBatch, WriteOptions,
+};
+use tracing::info;
+
+use super::{BlockNumberHash, ProofWindow, ProofWindowKey};
+use crate::{
+    BaseProofsStorageError,
+    BaseProofsStorageError::NoBlocksFound,
+    BaseProofsStorageResult, BaseProofsStore, BlockStateDiff,
+    api::{BaseProofsInitialStateStore, InitialStateAnchor, InitialStateStatus, WriteCounts},
+    db::{
+        AccountTrieHistory, BlockChangeSet, ChangeSet, HashedAccountHistory, HashedStorageHistory,
+        HashedStorageKey, IntoKV, MaybeDeleted, StorageTrieHistory, StorageTrieKey, StorageValue,
+        VersionedValue,
+    },
+};
+
+type RocksDb = DBWithThreadMode<MultiThreaded>;
+type RocksDbLatestVersionResult<T> =
+    Result<Option<(<T as Table>::Key, <T as Table>::Value)>, DatabaseError>;
+
+const HASH_KEY_LEN: usize = 32;
+const PACKED_NIBBLES_KEY_LEN: usize = 33;
+const BLOCK_NUMBER_KEY_LEN: usize = 8;
+const DEFAULT_BLOCK_CACHE_SIZE: usize = 128 << 20;
+const DEFAULT_BLOCK_SIZE: usize = 16 * 1024;
+const DEFAULT_BYTES_PER_SYNC: u64 = 1_048_576;
+const DEFAULT_MAX_OPEN_FILES: i32 = -1;
+const DEFAULT_MIN_BACKGROUND_JOBS: i32 = 8;
+const DEFAULT_MAX_BACKGROUND_JOBS: i32 = 32;
+const DEFAULT_MAX_WRITE_BUFFER_NUMBER: i32 = 6;
+const DEFAULT_TARGET_FILE_SIZE_BASE: u64 = 256 * 1024 * 1024;
+const DEFAULT_WRITE_BUFFER_SIZE: usize = 128 * 1024 * 1024;
+
+trait RocksDbHistoryTable: Table + DupSort<SubKey = u64> {
+    /// Fixed encoded table-key length before the block-number suffix.
+    const KEY_LEN: usize;
+
+    /// Encodes the table key prefix used before the block-number suffix.
+    fn encode_history_key_prefix(key: &Self::Key) -> Vec<u8>;
+
+    /// Decodes the table key prefix used before the block-number suffix.
+    fn decode_history_key_prefix(raw_key: &[u8]) -> Result<Self::Key, DatabaseError>;
+}
+
+/// `RocksDB` implementation of [`BaseProofsStore`].
+pub struct RocksdbProofsStorage {
+    db: Arc<RocksDb>,
+    write_options: WriteOptions,
+    // Serializes append-only writers that read LatestBlock before writing LatestBlock + 1.
+    append_lock: Mutex<()>,
+    // Serializes prune plans that assume a stable EarliestBlock across prepare and commit.
+    prune_lock: Mutex<()>,
+    // Append and prune share read access. History rewrites take write access.
+    history_gate: RwLock<()>,
+}
+
+/// Preprocessed prune plan for a target block number.
+#[derive(Debug, Clone)]
+struct RocksdbPrunePlan {
+    earliest_block: u64,
+    earliest_hash: B256,
+    acc_survivors: Vec<(StoredNibbles, u64)>,
+    storage_survivors: Vec<(StorageTrieKey, u64)>,
+    hashed_acc_survivors: Vec<(B256, u64)>,
+    hashed_storage_survivors: Vec<(HashedStorageKey, u64)>,
+}
+
+impl RocksdbPrunePlan {
+    const fn total_survivors(&self) -> usize {
+        self.acc_survivors.len()
+            + self.storage_survivors.len()
+            + self.hashed_acc_survivors.len()
+            + self.hashed_storage_survivors.len()
+    }
+}
+
+/// Preprocessed delete work for a prune commit.
+#[derive(Debug, Clone)]
+struct RocksdbPreparedPrune {
+    expected_earliest_block: u64,
+    expected_earliest_hash: B256,
+    target_block: u64,
+    target_hash: B256,
+    deletes: RocksdbPreparedHistoryDeletes,
+    counts: WriteCounts,
+}
+
+/// Raw history keys to delete during a prune commit.
+#[derive(Debug, Default, Clone)]
+struct RocksdbPreparedHistoryDeletes {
+    account_trie: Vec<Vec<u8>>,
+    storage_trie: Vec<Vec<u8>>,
+    hashed_account: Vec<Vec<u8>>,
+    hashed_storage: Vec<Vec<u8>>,
+}
+
+impl RocksdbPreparedHistoryDeletes {
+    const fn total(&self) -> usize {
+        self.account_trie.len()
+            + self.storage_trie.len()
+            + self.hashed_account.len()
+            + self.hashed_storage.len()
+    }
+}
+
+/// Preprocessed delete work for a prune range.
+#[derive(Debug, Default)]
+struct RocksdbHistoryDeleteBatch {
+    block_numbers: Vec<u64>,
+    account_trie: Vec<(<AccountTrieHistory as Table>::Key, u64)>,
+    storage_trie: Vec<(<StorageTrieHistory as Table>::Key, u64)>,
+    hashed_account: Vec<(<HashedAccountHistory as Table>::Key, u64)>,
+    hashed_storage: Vec<(<HashedStorageHistory as Table>::Key, u64)>,
+}
+
+/// Request-scoped read snapshot for [`RocksdbProofsStorage`].
+///
+/// This type is public because it is the [`BaseProofsStore::Tx`] associated type for the
+/// `RocksDB` backend. Callers that need several cursors to read the same database view should
+/// acquire one snapshot with [`BaseProofsStore::ro_tx`] and pass it to the `*_with_tx` cursor
+/// factories.
+pub struct RocksdbReadSnapshot<'db> {
+    db: &'db RocksDb,
+    snapshot: SnapshotWithThreadMode<'db, RocksDb>,
+}
+
+/// Cursor over `RocksDB` versioned history rows.
+struct RocksdbVersionedCursor<'db, T: Table + DupSort> {
+    snapshot: Arc<RocksdbReadSnapshot<'db>>,
+    max_block_number: u64,
+    current_key: Option<T::Key>,
+    _table: PhantomData<T>,
+}
+
+/// `RocksDB` implementation of [`TrieCursor`].
+pub struct RocksdbTrieCursor<'db, T: Table + DupSort> {
+    inner: RocksdbVersionedCursor<'db, T>,
+    hashed_address: Option<B256>,
+}
+
+/// `RocksDB` implementation of [`HashedCursor`] for storage state.
+pub struct RocksdbStorageCursor<'db> {
+    inner: RocksdbVersionedCursor<'db, HashedStorageHistory>,
+    hashed_address: B256,
+}
+
+/// `RocksDB` implementation of [`HashedCursor`] for account state.
+pub struct RocksdbAccountCursor<'db> {
+    inner: RocksdbVersionedCursor<'db, HashedAccountHistory>,
+}
+
+#[derive(Debug, Default)]
+struct RocksdbReplacementState {
+    storage_trie: BTreeMap<StorageTrieKey, Option<BranchNodeCompact>>,
+    hashed_storage: BTreeMap<HashedStorageKey, Option<StorageValue>>,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct ProofWindowValue {
+    earliest: NumHash,
+    latest: NumHash,
+}
+
+impl fmt::Debug for RocksdbProofsStorage {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("RocksdbProofsStorage").finish_non_exhaustive()
+    }
+}
+
+impl<'db> RocksdbReadSnapshot<'db> {
+    fn new(db: &'db RocksDb) -> Self {
+        Self::assert_send_sync();
+
+        let snapshot = db.snapshot();
+        Self { db, snapshot }
+    }
+
+    const fn assert_send_sync()
+    where
+        Self: Send + Sync,
+    {
+    }
+
+    fn cf(&self, name: &'static str) -> Result<Arc<BoundColumnFamily<'_>>, DatabaseError> {
+        self.db
+            .cf_handle(name)
+            .ok_or_else(|| DatabaseError::Other(format!("missing RocksDB column family {name}")))
+    }
+
+    const fn snapshot(&self) -> &SnapshotWithThreadMode<'db, RocksDb> {
+        &self.snapshot
+    }
+}
+
+impl fmt::Debug for RocksdbReadSnapshot<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("RocksdbReadSnapshot").finish_non_exhaustive()
+    }
+}
+
+impl<T> fmt::Debug for RocksdbVersionedCursor<'_, T>
+where
+    T: Table + DupSort,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("RocksdbVersionedCursor")
+            .field("max_block_number", &self.max_block_number)
+            .finish_non_exhaustive()
+    }
+}
+
+impl<T> fmt::Debug for RocksdbTrieCursor<'_, T>
+where
+    T: Table + DupSort,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("RocksdbTrieCursor")
+            .field("hashed_address", &self.hashed_address)
+            .finish_non_exhaustive()
+    }
+}
+
+impl fmt::Debug for RocksdbStorageCursor<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("RocksdbStorageCursor")
+            .field("hashed_address", &self.hashed_address)
+            .finish_non_exhaustive()
+    }
+}
+
+impl fmt::Debug for RocksdbAccountCursor<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("RocksdbAccountCursor").finish_non_exhaustive()
+    }
+}
+
+impl RocksdbReplacementState {
+    fn storage_trie_wipe_entries(
+        &self,
+        storage: &RocksdbProofsStorage,
+        base_block_number: u64,
+        hashed_address: B256,
+    ) -> BaseProofsStorageResult<BTreeMap<Nibbles, Option<BranchNodeCompact>>> {
+        let mut entries = BTreeMap::new();
+        let mut cursor = storage.storage_trie_cursor(hashed_address, base_block_number)?;
+
+        while let Some((path, _)) = cursor.next()? {
+            entries.insert(path, None);
+        }
+
+        for (key, value) in &self.storage_trie {
+            if key.hashed_address != hashed_address {
+                continue;
+            }
+
+            let path = key.path.0;
+            if value.is_some() {
+                entries.insert(path, None);
+            } else {
+                entries.remove(&path);
+            }
+        }
+
+        Ok(entries)
+    }
+
+    fn apply_storage_trie_entries(
+        &mut self,
+        hashed_address: B256,
+        entries: impl IntoIterator<Item = (Nibbles, Option<BranchNodeCompact>)>,
+    ) {
+        for (path, node) in entries {
+            self.storage_trie
+                .insert(StorageTrieKey::new(hashed_address, StoredNibbles::from(path)), node);
+        }
+    }
+
+    fn hashed_storage_wipe_entries(
+        &self,
+        storage: &RocksdbProofsStorage,
+        base_block_number: u64,
+        hashed_address: B256,
+    ) -> BaseProofsStorageResult<BTreeMap<B256, Option<StorageValue>>> {
+        let mut entries = BTreeMap::new();
+        let mut cursor = storage.storage_hashed_cursor(hashed_address, base_block_number)?;
+
+        while let Some((slot, _)) = cursor.next()? {
+            entries.insert(slot, None);
+        }
+
+        for (key, value) in &self.hashed_storage {
+            if key.hashed_address != hashed_address {
+                continue;
+            }
+
+            if let Some(value) = value
+                && !value.0.is_zero()
+            {
+                entries.insert(key.hashed_storage_key, None);
+            } else {
+                entries.remove(&key.hashed_storage_key);
+            }
+        }
+
+        Ok(entries)
+    }
+
+    fn apply_hashed_storage_entries(
+        &mut self,
+        hashed_address: B256,
+        entries: impl IntoIterator<Item = (B256, Option<StorageValue>)>,
+    ) {
+        for (hashed_storage_key, value) in entries {
+            self.hashed_storage
+                .insert(HashedStorageKey::new(hashed_address, hashed_storage_key), value);
+        }
+    }
+}
+
+impl RocksdbProofsStorage {
+    /// Creates a new [`RocksdbProofsStorage`] instance with the given path.
+    pub fn new(path: &Path) -> Result<Self, BaseProofsStorageError> {
+        let block_cache = Cache::new_lru_cache(DEFAULT_BLOCK_CACHE_SIZE);
+        let db_options = Self::db_options(&block_cache);
+        let descriptors = Self::column_families()
+            .into_iter()
+            .map(|name| ColumnFamilyDescriptor::new(name, Self::cf_options(name, &block_cache)));
+        let db = RocksDb::open_cf_descriptors(&db_options, path, descriptors)
+            .map_err(|e| DatabaseError::Other(format!("failed to open RocksDB database: {e}")))?;
+
+        let mut write_options = WriteOptions::default();
+        // Proof history is derivable from the canonical chain, so use async WAL writes for
+        // throughput. RocksDB write batches still keep committed updates internally consistent.
+        write_options.set_sync(false);
+
+        Ok(Self {
+            db: Arc::new(db),
+            write_options,
+            append_lock: Mutex::new(()),
+            prune_lock: Mutex::new(()),
+            history_gate: RwLock::new(()),
+        })
+    }
+
+    fn db_options(block_cache: &Cache) -> Options {
+        let table_options = Self::table_options(block_cache);
+        let mut options = Options::default();
+        options.set_block_based_table_factory(&table_options);
+        options.create_if_missing(true);
+        options.create_missing_column_families(true);
+        options.set_max_background_jobs(Self::max_background_jobs());
+        options.set_bytes_per_sync(DEFAULT_BYTES_PER_SYNC);
+        options.set_compaction_pri(CompactionPri::MinOverlappingRatio);
+        options.set_max_open_files(DEFAULT_MAX_OPEN_FILES);
+        options.set_max_total_wal_size(Self::max_total_wal_size());
+        options.set_wal_ttl_seconds(0);
+        options.set_wal_size_limit_mb(0);
+        options
+    }
+
+    const fn max_total_wal_size() -> u64 {
+        Self::column_families().len() as u64
+            * DEFAULT_WRITE_BUFFER_SIZE as u64
+            * DEFAULT_MAX_WRITE_BUFFER_NUMBER as u64
+    }
+
+    fn max_background_jobs() -> i32 {
+        let available_parallelism = std::thread::available_parallelism()
+            .map(usize::from)
+            .unwrap_or(DEFAULT_MIN_BACKGROUND_JOBS as usize);
+
+        available_parallelism
+            .clamp(DEFAULT_MIN_BACKGROUND_JOBS as usize, DEFAULT_MAX_BACKGROUND_JOBS as usize)
+            as i32
+    }
+
+    fn table_options(block_cache: &Cache) -> BlockBasedOptions {
+        let mut table_options = BlockBasedOptions::default();
+        table_options.set_block_size(DEFAULT_BLOCK_SIZE);
+        table_options.set_cache_index_and_filter_blocks(true);
+        table_options.set_pin_l0_filter_and_index_blocks_in_cache(true);
+        table_options.set_block_cache(block_cache);
+        table_options
+    }
+
+    fn cf_options(name: &'static str, block_cache: &Cache) -> Options {
+        let table_options = Self::table_options(block_cache);
+        let mut options = Options::default();
+        options.set_block_based_table_factory(&table_options);
+        options.set_level_compaction_dynamic_level_bytes(true);
+        options.set_max_write_buffer_number(DEFAULT_MAX_WRITE_BUFFER_NUMBER);
+        options.set_target_file_size_base(DEFAULT_TARGET_FILE_SIZE_BASE);
+        options.set_write_buffer_size(DEFAULT_WRITE_BUFFER_SIZE);
+        if name == <ProofWindow as Table>::NAME {
+            options.set_compression_type(DBCompressionType::None);
+            options.set_bottommost_compression_type(DBCompressionType::None);
+        } else {
+            options.set_compression_type(DBCompressionType::Lz4);
+            options.set_bottommost_compression_type(DBCompressionType::Zstd);
+            options.set_bottommost_zstd_max_train_bytes(0, true);
+        }
+        options
+    }
+
+    const fn column_families() -> [&'static str; 6] {
+        [
+            <AccountTrieHistory as Table>::NAME,
+            <StorageTrieHistory as Table>::NAME,
+            <HashedAccountHistory as Table>::NAME,
+            <HashedStorageHistory as Table>::NAME,
+            <ProofWindow as Table>::NAME,
+            <BlockChangeSet as Table>::NAME,
+        ]
+    }
+
+    fn cf(&self, name: &'static str) -> BaseProofsStorageResult<Arc<BoundColumnFamily<'_>>> {
+        self.db
+            .cf_handle(name)
+            .ok_or_else(|| DatabaseError::Other(format!("missing RocksDB column family {name}")))
+            .map_err(Into::into)
+    }
+
+    fn put_table<T: Table>(
+        &self,
+        batch: &mut WriteBatch,
+        key: T::Key,
+        value: &T::Value,
+    ) -> BaseProofsStorageResult<()> {
+        let cf = self.cf(T::NAME)?;
+        batch.put_cf(&cf, encode_table_key::<T>(key), encode_table_value::<T>(value));
+        Ok(())
+    }
+
+    fn get_table<T: Table>(&self, key: T::Key) -> BaseProofsStorageResult<Option<T::Value>> {
+        let cf = self.cf(T::NAME)?;
+        self.db
+            .get_cf(&cf, encode_table_key::<T>(key))
+            .map_err(rocksdb_error)?
+            .map(|value| T::Value::decompress(&value).map_err(Into::into))
+            .transpose()
+    }
+
+    fn get_table_from_snapshot<T: Table>(
+        &self,
+        snapshot: &SnapshotWithThreadMode<'_, RocksDb>,
+        key: T::Key,
+    ) -> BaseProofsStorageResult<Option<T::Value>> {
+        let cf = self.cf(T::NAME)?;
+        snapshot
+            .get_cf(&cf, encode_table_key::<T>(key))
+            .map_err(rocksdb_error)?
+            .map(|value| T::Value::decompress(&value).map_err(Into::into))
+            .transpose()
+    }
+
+    fn persist_history_batch<T, I, V>(
+        &self,
+        batch: &mut WriteBatch,
+        block_number: u64,
+        items: I,
+        append_mode: bool,
+    ) -> BaseProofsStorageResult<Vec<T::Key>>
+    where
+        T: Table<Value = VersionedValue<V>> + DupSort<SubKey = u64>,
+        T: RocksDbHistoryTable,
+        T::Key: Clone,
+        I: IntoIterator,
+        I::Item: IntoKV<T>,
+    {
+        let cf = self.cf(T::NAME)?;
+        let mut keys = Vec::<T::Key>::new();
+        let mut pairs = Vec::<(T::Key, T::Value)>::new();
+
+        for item in items {
+            let (key, value) = item.into_kv(block_number);
+            keys.push(key.clone());
+            pairs.push((key, value));
+        }
+
+        if append_mode {
+            for (key, value) in pairs {
+                batch.put_cf(
+                    &cf,
+                    encode_history_key::<T>(&key, value.block_number),
+                    encode_table_value::<T>(&value),
+                );
+            }
+            return Ok(keys);
+        }
+
+        for (key, value) in pairs {
+            batch.delete_cf(&cf, encode_history_key::<T>(&key, 0));
+            if value.value.0.is_some() {
+                batch.put_cf(
+                    &cf,
+                    encode_history_key::<T>(&key, 0),
+                    encode_table_value::<T>(&value),
+                );
+            }
+        }
+
+        Ok(keys)
+    }
+
+    fn delete_dup_sorted<T, I, V>(
+        &self,
+        batch: &mut WriteBatch,
+        items: I,
+    ) -> BaseProofsStorageResult<()>
+    where
+        T: Table<Value = VersionedValue<V>> + DupSort<SubKey = u64>,
+        T: RocksDbHistoryTable,
+        T::Key: Clone,
+        I: IntoIterator<Item = (T::Key, u64)>,
+    {
+        let cf = self.cf(T::NAME)?;
+        for (key, block_number) in items {
+            batch.delete_cf(&cf, encode_history_key::<T>(&key, block_number));
+        }
+        Ok(())
+    }
+
+    fn collect_history_preceding_deletes<T, V>(
+        &self,
+        snapshot: &SnapshotWithThreadMode<'_, RocksDb>,
+        cutoff_items: Vec<(T::Key, u64)>,
+    ) -> BaseProofsStorageResult<Vec<Vec<u8>>>
+    where
+        T: Table<Value = VersionedValue<V>> + DupSort<SubKey = u64>,
+        T: RocksDbHistoryTable,
+        T::Key: Clone + Ord,
+        T::Value: Decompress,
+    {
+        let started = Instant::now();
+        let cutoff_items_len = cutoff_items.len();
+        info!(
+            target: "trie::pruner",
+            table = T::NAME,
+            cutoff_items = cutoff_items_len,
+            "Collecting RocksDB proof storage prune deletes",
+        );
+        if cutoff_items.is_empty() {
+            info!(
+                target: "trie::pruner",
+                table = T::NAME,
+                cutoff_items = cutoff_items_len,
+                deletes = 0usize,
+                elapsed = ?started.elapsed(),
+                "Collected RocksDB proof storage prune deletes",
+            );
+            return Ok(Vec::new());
+        }
+
+        let cf = self.cf(T::NAME)?;
+        let mut deletes = Vec::new();
+
+        for (key, survivor_block) in cutoff_items {
+            let prefix = encode_history_key_prefix::<T>(&key);
+            let start_key = encode_history_key::<T>(&key, 0);
+            let mut read_options = ReadOptions::default();
+            if let Some(upper_bound) = prefix_upper_bound(&prefix) {
+                read_options.set_iterate_upper_bound(upper_bound);
+            }
+            let iter = snapshot.iterator_cf_opt(
+                &cf,
+                read_options,
+                IteratorMode::From(&start_key, Direction::Forward),
+            );
+
+            for item in iter {
+                let (raw_key, raw_value) = item.map_err(rocksdb_error)?;
+                if !raw_key.starts_with(&prefix) {
+                    break;
+                }
+
+                let (_, block_number) = decode_history_key::<T>(&raw_key)?;
+                if block_number >= survivor_block {
+                    let value = T::Value::decompress(&raw_value)?;
+                    if block_number == survivor_block && value.value.0.is_none() {
+                        deletes.push(raw_key.to_vec());
+                    }
+                    break;
+                }
+
+                deletes.push(raw_key.to_vec());
+            }
+        }
+
+        info!(
+            target: "trie::pruner",
+            table = T::NAME,
+            cutoff_items = cutoff_items_len,
+            deletes = deletes.len(),
+            elapsed = ?started.elapsed(),
+            "Collected RocksDB proof storage prune deletes",
+        );
+
+        Ok(deletes)
+    }
+
+    fn delete_raw_history_keys<T>(
+        &self,
+        batch: &mut WriteBatch,
+        keys: Vec<Vec<u8>>,
+    ) -> BaseProofsStorageResult<()>
+    where
+        T: Table,
+    {
+        let cf = self.cf(T::NAME)?;
+        for key in keys {
+            batch.delete_cf(&cf, key);
+        }
+        Ok(())
+    }
+
+    fn wipe_and_overlay<T, Next, I, K, VV, V>(
+        &self,
+        batch: &mut WriteBatch,
+        block_number: u64,
+        hashed_address: B256,
+        mut next: Next,
+        new_entries: I,
+    ) -> BaseProofsStorageResult<Vec<T::Key>>
+    where
+        T: Table<Value = VersionedValue<V>> + DupSort<SubKey = u64>,
+        T: RocksDbHistoryTable,
+        Next: FnMut() -> BaseProofsStorageResult<Option<(K, VV)>>,
+        I: IntoIterator<Item = (K, Option<V>)>,
+        (B256, K, Option<V>): IntoKV<T>,
+        T::Key: Clone,
+        K: Ord,
+    {
+        let cf = self.cf(T::NAME)?;
+        let mut merged: BTreeMap<K, Option<V>> = BTreeMap::new();
+        while let Some((key, _)) = next()? {
+            merged.insert(key, None);
+        }
+        for (key, value) in new_entries {
+            merged.insert(key, value);
+        }
+
+        let mut keys = Vec::with_capacity(merged.len());
+        for (key, value) in merged {
+            let db_key: T::Key = (hashed_address, key, Option::<V>::None).into_key();
+            let db_value: T::Value = VersionedValue { block_number, value: MaybeDeleted(value) };
+            batch.put_cf(
+                &cf,
+                encode_history_key::<T>(&db_key, block_number),
+                encode_table_value::<T>(&db_value),
+            );
+            keys.push(db_key);
+        }
+
+        Ok(keys)
+    }
+
+    fn store_trie_updates_for_block(
+        &self,
+        batch: &mut WriteBatch,
+        block_number: u64,
+        block_state_diff: BlockStateDiff,
+        append_mode: bool,
+    ) -> BaseProofsStorageResult<ChangeSet> {
+        let BlockStateDiff { sorted_trie_updates, sorted_post_state } = block_state_diff;
+
+        let storage_trie_len = sorted_trie_updates.storage_tries_ref().len();
+        let hashed_storage_len = sorted_post_state.storages.len();
+
+        let account_trie_keys = self.persist_history_batch::<AccountTrieHistory, _, _>(
+            batch,
+            block_number,
+            sorted_trie_updates.account_nodes_ref().iter().cloned(),
+            append_mode,
+        )?;
+        let hashed_account_keys = self.persist_history_batch::<HashedAccountHistory, _, _>(
+            batch,
+            block_number,
+            sorted_post_state.accounts.iter().copied(),
+            append_mode,
+        )?;
+
+        let mut storage_trie_keys = Vec::with_capacity(storage_trie_len);
+        for (hashed_address, nodes) in sorted_trie_updates.storage_tries_ref() {
+            if nodes.is_deleted && append_mode {
+                let mut cursor =
+                    self.storage_trie_cursor(*hashed_address, block_number.saturating_sub(1))?;
+                let keys = self.wipe_and_overlay::<StorageTrieHistory, _, _, _, _, _>(
+                    batch,
+                    block_number,
+                    *hashed_address,
+                    || Ok(cursor.next()?),
+                    nodes.storage_nodes_ref().iter().cloned(),
+                )?;
+                storage_trie_keys.extend(keys);
+                continue;
+            }
+
+            let keys = self.persist_history_batch::<StorageTrieHistory, _, _>(
+                batch,
+                block_number,
+                nodes
+                    .storage_nodes_ref()
+                    .iter()
+                    .cloned()
+                    .map(|(path, node)| (*hashed_address, path, node)),
+                append_mode,
+            )?;
+            storage_trie_keys.extend(keys);
+        }
+
+        let mut hashed_storage_keys = Vec::with_capacity(hashed_storage_len);
+        for (hashed_address, storage) in sorted_post_state.storages {
+            if append_mode && storage.is_wiped() {
+                let mut cursor =
+                    self.storage_hashed_cursor(hashed_address, block_number.saturating_sub(1))?;
+                let keys = self.wipe_and_overlay::<HashedStorageHistory, _, _, _, _, _>(
+                    batch,
+                    block_number,
+                    hashed_address,
+                    || Ok(cursor.next()?),
+                    storage
+                        .storage_slots_ref()
+                        .iter()
+                        .map(|(slot, value)| (*slot, Some(StorageValue(*value)))),
+                )?;
+                hashed_storage_keys.extend(keys);
+                continue;
+            }
+
+            let keys = self.persist_history_batch::<HashedStorageHistory, _, _>(
+                batch,
+                block_number,
+                storage
+                    .storage_slots_ref()
+                    .iter()
+                    .map(|(key, value)| (hashed_address, *key, Some(StorageValue(*value)))),
+                append_mode,
+            )?;
+            hashed_storage_keys.extend(keys);
+        }
+
+        Ok(ChangeSet {
+            account_trie_keys,
+            storage_trie_keys,
+            hashed_account_keys,
+            hashed_storage_keys,
+        })
+    }
+
+    fn store_trie_updates_append_only(
+        &self,
+        batch: &mut WriteBatch,
+        block_ref: BlockWithParent,
+        block_state_diff: BlockStateDiff,
+    ) -> BaseProofsStorageResult<WriteCounts> {
+        let block_number = block_ref.block.number;
+        // This DB read intentionally assumes `batch` has no pending `LatestBlock` update. RocksDB
+        // reads do not observe uncommitted `WriteBatch` entries.
+        let latest_block_hash =
+            self.get_latest_block_number_hash()?.map_or(B256::ZERO, |(_, hash)| hash);
+
+        if latest_block_hash != block_ref.parent {
+            return Err(BaseProofsStorageError::OutOfOrder {
+                block_number,
+                parent_block_hash: block_ref.parent,
+                latest_block_hash,
+            });
+        }
+
+        let change_set =
+            self.store_trie_updates_for_block(batch, block_number, block_state_diff, true)?;
+        self.put_table::<BlockChangeSet>(batch, block_number, &change_set)?;
+        self.put_proof_window(
+            batch,
+            ProofWindowKey::LatestBlock,
+            block_number,
+            block_ref.block.hash,
+        )?;
+
+        Ok(WriteCounts {
+            account_trie_updates_written_total: change_set.account_trie_keys.len() as u64,
+            storage_trie_updates_written_total: change_set.storage_trie_keys.len() as u64,
+            hashed_accounts_written_total: change_set.hashed_account_keys.len() as u64,
+            hashed_storages_written_total: change_set.hashed_storage_keys.len() as u64,
+        })
+    }
+
+    fn store_replacement_trie_updates_append_only(
+        &self,
+        batch: &mut WriteBatch,
+        base_block_number: u64,
+        replacement_state: &mut RocksdbReplacementState,
+        block_ref: BlockWithParent,
+        block_state_diff: BlockStateDiff,
+    ) -> BaseProofsStorageResult<WriteCounts> {
+        let block_number = block_ref.block.number;
+        let change_set = self.store_replacement_trie_updates_for_block(
+            batch,
+            base_block_number,
+            replacement_state,
+            block_number,
+            block_state_diff,
+        )?;
+
+        self.put_table::<BlockChangeSet>(batch, block_number, &change_set)?;
+        self.put_proof_window(
+            batch,
+            ProofWindowKey::LatestBlock,
+            block_number,
+            block_ref.block.hash,
+        )?;
+
+        Ok(WriteCounts {
+            account_trie_updates_written_total: change_set.account_trie_keys.len() as u64,
+            storage_trie_updates_written_total: change_set.storage_trie_keys.len() as u64,
+            hashed_accounts_written_total: change_set.hashed_account_keys.len() as u64,
+            hashed_storages_written_total: change_set.hashed_storage_keys.len() as u64,
+        })
+    }
+
+    fn store_replacement_trie_updates_for_block(
+        &self,
+        batch: &mut WriteBatch,
+        base_block_number: u64,
+        replacement_state: &mut RocksdbReplacementState,
+        block_number: u64,
+        block_state_diff: BlockStateDiff,
+    ) -> BaseProofsStorageResult<ChangeSet> {
+        let BlockStateDiff { sorted_trie_updates, sorted_post_state } = block_state_diff;
+
+        let storage_trie_len = sorted_trie_updates.storage_tries_ref().len();
+        let hashed_storage_len = sorted_post_state.storages.len();
+
+        let account_trie_keys = self.persist_history_batch::<AccountTrieHistory, _, _>(
+            batch,
+            block_number,
+            sorted_trie_updates.account_nodes_ref().iter().cloned(),
+            true,
+        )?;
+        let hashed_account_keys = self.persist_history_batch::<HashedAccountHistory, _, _>(
+            batch,
+            block_number,
+            sorted_post_state.accounts.iter().copied(),
+            true,
+        )?;
+
+        let mut storage_trie_keys = Vec::with_capacity(storage_trie_len);
+        for (hashed_address, nodes) in sorted_trie_updates.storage_tries_ref() {
+            let storage_entries = if nodes.is_deleted {
+                let mut entries = replacement_state.storage_trie_wipe_entries(
+                    self,
+                    base_block_number,
+                    *hashed_address,
+                )?;
+                for (path, node) in nodes.storage_nodes_ref().iter().cloned() {
+                    entries.insert(path, node);
+                }
+                entries.into_iter().collect::<Vec<_>>()
+            } else {
+                nodes.storage_nodes_ref().to_vec()
+            };
+
+            let keys = self.persist_history_batch::<StorageTrieHistory, _, _>(
+                batch,
+                block_number,
+                storage_entries.iter().cloned().map(|(path, node)| (*hashed_address, path, node)),
+                true,
+            )?;
+            replacement_state.apply_storage_trie_entries(*hashed_address, storage_entries);
+            storage_trie_keys.extend(keys);
+        }
+
+        let mut hashed_storage_keys = Vec::with_capacity(hashed_storage_len);
+        for (hashed_address, storage) in sorted_post_state.storages {
+            let storage_entries = if storage.is_wiped() {
+                let mut entries = replacement_state.hashed_storage_wipe_entries(
+                    self,
+                    base_block_number,
+                    hashed_address,
+                )?;
+                for (slot, value) in storage.storage_slots_ref() {
+                    entries.insert(*slot, Some(StorageValue(*value)));
+                }
+                entries.into_iter().collect::<Vec<_>>()
+            } else {
+                storage
+                    .storage_slots_ref()
+                    .iter()
+                    .map(|(key, value)| (*key, Some(StorageValue(*value))))
+                    .collect::<Vec<_>>()
+            };
+
+            let keys = self.persist_history_batch::<HashedStorageHistory, _, _>(
+                batch,
+                block_number,
+                storage_entries.iter().map(|(key, value)| (hashed_address, *key, *value)),
+                true,
+            )?;
+            replacement_state.apply_hashed_storage_entries(hashed_address, storage_entries);
+            hashed_storage_keys.extend(keys);
+        }
+
+        Ok(ChangeSet {
+            account_trie_keys,
+            storage_trie_keys,
+            hashed_account_keys,
+            hashed_storage_keys,
+        })
+    }
+
+    fn get_block_number_hash(
+        &self,
+        key: ProofWindowKey,
+    ) -> BaseProofsStorageResult<Option<(u64, B256)>> {
+        Ok(self.get_table::<ProofWindow>(key)?.map(|value| (value.number(), *value.hash())))
+    }
+
+    fn get_block_number_hash_from_snapshot(
+        &self,
+        snapshot: &SnapshotWithThreadMode<'_, RocksDb>,
+        key: ProofWindowKey,
+    ) -> BaseProofsStorageResult<Option<(u64, B256)>> {
+        Ok(self
+            .get_table_from_snapshot::<ProofWindow>(snapshot, key)?
+            .map(|value| (value.number(), *value.hash())))
+    }
+
+    fn get_latest_block_number_hash(&self) -> BaseProofsStorageResult<Option<(u64, B256)>> {
+        let block = self.get_block_number_hash(ProofWindowKey::LatestBlock)?;
+        if block.is_some() {
+            return Ok(block);
+        }
+
+        self.get_block_number_hash(ProofWindowKey::EarliestBlock)
+    }
+
+    fn get_proof_window(&self) -> BaseProofsStorageResult<Option<ProofWindowValue>> {
+        let Some((earliest_number, earliest_hash)) =
+            self.get_block_number_hash(ProofWindowKey::EarliestBlock)?
+        else {
+            return Ok(None);
+        };
+
+        let latest = self.get_block_number_hash(ProofWindowKey::LatestBlock)?.map_or_else(
+            || NumHash::new(earliest_number, earliest_hash),
+            |(number, hash)| NumHash::new(number, hash),
+        );
+
+        Ok(Some(ProofWindowValue {
+            earliest: NumHash::new(earliest_number, earliest_hash),
+            latest,
+        }))
+    }
+
+    fn put_proof_window(
+        &self,
+        batch: &mut WriteBatch,
+        key: ProofWindowKey,
+        block_number: u64,
+        hash: B256,
+    ) -> BaseProofsStorageResult<()> {
+        self.put_table::<ProofWindow>(batch, key, &BlockNumberHash::new(block_number, hash))
+    }
+
+    fn set_earliest_block_number_hash(
+        &self,
+        block_number: u64,
+        hash: B256,
+    ) -> BaseProofsStorageResult<()> {
+        let _guard = self.history_gate.write();
+        self.set_earliest_block_number_hash_unlocked(block_number, hash)
+    }
+
+    fn set_earliest_block_number_hash_unlocked(
+        &self,
+        block_number: u64,
+        hash: B256,
+    ) -> BaseProofsStorageResult<()> {
+        let mut batch = WriteBatch::default();
+        self.put_proof_window(&mut batch, ProofWindowKey::EarliestBlock, block_number, hash)?;
+        self.db.write_opt(batch, &self.write_options).map_err(rocksdb_error)?;
+        Ok(())
+    }
+
+    fn calculate_prune_plan(
+        &self,
+        snapshot: &SnapshotWithThreadMode<'_, RocksDb>,
+        target_block: u64,
+    ) -> BaseProofsStorageResult<Option<RocksdbPrunePlan>> {
+        let started = Instant::now();
+        info!(
+            target: "trie::pruner",
+            target_block,
+            "Calculating RocksDB proof storage prune plan",
+        );
+        let Some((earliest, earliest_hash)) =
+            self.get_block_number_hash_from_snapshot(snapshot, ProofWindowKey::EarliestBlock)?
+        else {
+            info!(
+                target: "trie::pruner",
+                target_block,
+                elapsed = ?started.elapsed(),
+                "Skipped RocksDB proof storage prune plan because earliest block is missing",
+            );
+            return Ok(None);
+        };
+
+        if earliest >= target_block {
+            info!(
+                target: "trie::pruner",
+                earliest_block = earliest,
+                target_block,
+                elapsed = ?started.elapsed(),
+                "Skipped RocksDB proof storage prune plan because target is not newer",
+            );
+            return Ok(None);
+        }
+
+        let mut acc_candidates: HashMap<StoredNibbles, u64> = HashMap::default();
+        let mut storage_candidates: HashMap<StorageTrieKey, u64> = HashMap::default();
+        let mut hashed_acc_candidates: HashMap<B256, u64> = HashMap::default();
+        let mut hashed_storage_candidates: HashMap<HashedStorageKey, u64> = HashMap::default();
+
+        for (block_number, change_set) in
+            self.iter_change_sets_from_snapshot(snapshot, (earliest + 1)..=target_block)?
+        {
+            for key in change_set.account_trie_keys {
+                acc_candidates
+                    .entry(key)
+                    .and_modify(|current| *current = (*current).max(block_number))
+                    .or_insert(block_number);
+            }
+            for key in change_set.storage_trie_keys {
+                storage_candidates
+                    .entry(key)
+                    .and_modify(|current| *current = (*current).max(block_number))
+                    .or_insert(block_number);
+            }
+            for key in change_set.hashed_account_keys {
+                hashed_acc_candidates
+                    .entry(key)
+                    .and_modify(|current| *current = (*current).max(block_number))
+                    .or_insert(block_number);
+            }
+            for key in change_set.hashed_storage_keys {
+                hashed_storage_candidates
+                    .entry(key)
+                    .and_modify(|current| *current = (*current).max(block_number))
+                    .or_insert(block_number);
+            }
+        }
+
+        let plan = RocksdbPrunePlan {
+            earliest_block: earliest,
+            earliest_hash,
+            acc_survivors: flatten_and_sort(acc_candidates),
+            storage_survivors: flatten_and_sort(storage_candidates),
+            hashed_acc_survivors: flatten_and_sort(hashed_acc_candidates),
+            hashed_storage_survivors: flatten_and_sort(hashed_storage_candidates),
+        };
+
+        info!(
+            target: "trie::pruner",
+            earliest_block = plan.earliest_block,
+            target_block,
+            account_trie_survivors = plan.acc_survivors.len(),
+            storage_trie_survivors = plan.storage_survivors.len(),
+            hashed_account_survivors = plan.hashed_acc_survivors.len(),
+            hashed_storage_survivors = plan.hashed_storage_survivors.len(),
+            total_survivors = plan.total_survivors(),
+            elapsed = ?started.elapsed(),
+            "Calculated RocksDB proof storage prune plan",
+        );
+
+        Ok(Some(plan))
+    }
+
+    fn collect_history_ranged(
+        &self,
+        block_range: impl RangeBounds<u64>,
+    ) -> BaseProofsStorageResult<RocksdbHistoryDeleteBatch> {
+        let mut history = RocksdbHistoryDeleteBatch::default();
+
+        for (block_number, change_set) in self.iter_change_sets(block_range)? {
+            history.block_numbers.push(block_number);
+            history
+                .account_trie
+                .extend(change_set.account_trie_keys.into_iter().map(|key| (key, block_number)));
+            history
+                .storage_trie
+                .extend(change_set.storage_trie_keys.into_iter().map(|key| (key, block_number)));
+            history
+                .hashed_account
+                .extend(change_set.hashed_account_keys.into_iter().map(|key| (key, block_number)));
+            history
+                .hashed_storage
+                .extend(change_set.hashed_storage_keys.into_iter().map(|key| (key, block_number)));
+        }
+
+        history.account_trie.sort_by(|(k1, b1), (k2, b2)| k1.cmp(k2).then_with(|| b1.cmp(b2)));
+        history.storage_trie.sort_by(|(k1, b1), (k2, b2)| k1.cmp(k2).then_with(|| b1.cmp(b2)));
+        history.hashed_account.sort_by(|(k1, b1), (k2, b2)| k1.cmp(k2).then_with(|| b1.cmp(b2)));
+        history.hashed_storage.sort_by(|(k1, b1), (k2, b2)| k1.cmp(k2).then_with(|| b1.cmp(b2)));
+
+        Ok(history)
+    }
+
+    fn delete_history_ranged(
+        &self,
+        batch: &mut WriteBatch,
+        history: RocksdbHistoryDeleteBatch,
+    ) -> BaseProofsStorageResult<WriteCounts> {
+        let cf = self.cf(<BlockChangeSet as Table>::NAME)?;
+        for block_number in &history.block_numbers {
+            batch.delete_cf(&cf, encode_block_number(*block_number));
+        }
+
+        let RocksdbHistoryDeleteBatch {
+            block_numbers: _,
+            account_trie,
+            storage_trie,
+            hashed_account,
+            hashed_storage,
+        } = history;
+        let counts = WriteCounts {
+            account_trie_updates_written_total: account_trie.len() as u64,
+            storage_trie_updates_written_total: storage_trie.len() as u64,
+            hashed_accounts_written_total: hashed_account.len() as u64,
+            hashed_storages_written_total: hashed_storage.len() as u64,
+        };
+
+        self.delete_dup_sorted::<AccountTrieHistory, _, _>(batch, account_trie)?;
+        self.delete_dup_sorted::<StorageTrieHistory, _, _>(batch, storage_trie)?;
+        self.delete_dup_sorted::<HashedAccountHistory, _, _>(batch, hashed_account)?;
+        self.delete_dup_sorted::<HashedStorageHistory, _, _>(batch, hashed_storage)?;
+
+        Ok(counts)
+    }
+
+    fn iter_change_sets(
+        &self,
+        block_range: impl RangeBounds<u64>,
+    ) -> BaseProofsStorageResult<Vec<(u64, ChangeSet)>> {
+        let cf = self.cf(<BlockChangeSet as Table>::NAME)?;
+        let start = range_start(&block_range);
+        let start_key = encode_block_number(start);
+        let iter = self.db.iterator_cf(&cf, IteratorMode::From(&start_key, Direction::Forward));
+        let mut rows = Vec::new();
+
+        for item in iter {
+            let (raw_key, raw_value) = item.map_err(rocksdb_error)?;
+            let block_number = decode_block_number(&raw_key)?;
+            if !block_range.contains(&block_number) {
+                break;
+            }
+            rows.push((block_number, ChangeSet::decompress(&raw_value)?));
+        }
+
+        Ok(rows)
+    }
+
+    fn iter_change_sets_from_snapshot(
+        &self,
+        snapshot: &SnapshotWithThreadMode<'_, RocksDb>,
+        block_range: impl RangeBounds<u64>,
+    ) -> BaseProofsStorageResult<Vec<(u64, ChangeSet)>> {
+        let cf = self.cf(<BlockChangeSet as Table>::NAME)?;
+        let start = range_start(&block_range);
+        let start_key = encode_block_number(start);
+        let iter = snapshot.iterator_cf(&cf, IteratorMode::From(&start_key, Direction::Forward));
+        let mut rows = Vec::new();
+
+        for item in iter {
+            let (raw_key, raw_value) = item.map_err(rocksdb_error)?;
+            let block_number = decode_block_number(&raw_key)?;
+            if !block_range.contains(&block_number) {
+                break;
+            }
+            rows.push((block_number, ChangeSet::decompress(&raw_value)?));
+        }
+
+        Ok(rows)
+    }
+
+    fn prepare_prune(
+        &self,
+        new_earliest_block_ref: BlockWithParent,
+    ) -> BaseProofsStorageResult<Option<RocksdbPreparedPrune>> {
+        let started = Instant::now();
+        let requested_target = new_earliest_block_ref.block.number;
+        info!(
+            target: "trie::pruner",
+            requested_target,
+            "Preparing RocksDB proof storage prune",
+        );
+        let snapshot = self.db.snapshot();
+        let Some((earliest_block, earliest_hash)) =
+            self.get_block_number_hash_from_snapshot(&snapshot, ProofWindowKey::EarliestBlock)?
+        else {
+            info!(
+                target: "trie::pruner",
+                requested_target,
+                elapsed = ?started.elapsed(),
+                "Skipped RocksDB proof storage prune because earliest block is missing",
+            );
+            return Ok(None);
+        };
+
+        let (latest_block, latest_hash) = self
+            .get_block_number_hash_from_snapshot(&snapshot, ProofWindowKey::LatestBlock)?
+            .unwrap_or((earliest_block, earliest_hash));
+
+        // Bound the prune to rows visible in this snapshot. Appends may commit while pruning, but
+        // they must always land above this effective target.
+        let (target_block, target_hash) = if requested_target > latest_block {
+            (latest_block, latest_hash)
+        } else {
+            (requested_target, new_earliest_block_ref.block.hash)
+        };
+
+        info!(
+            target: "trie::pruner",
+            earliest_block,
+            latest_block,
+            requested_target,
+            target_block,
+            clamped_to_latest = requested_target > latest_block,
+            "Calculated RocksDB proof storage prune target",
+        );
+
+        if earliest_block >= target_block {
+            info!(
+                target: "trie::pruner",
+                earliest_block,
+                target_block,
+                elapsed = ?started.elapsed(),
+                "Skipped RocksDB proof storage prune because target is not newer",
+            );
+            return Ok(None);
+        }
+
+        let Some(plan) = self.calculate_prune_plan(&snapshot, target_block)? else {
+            return Ok(None);
+        };
+
+        let account_trie = self.collect_history_preceding_deletes::<AccountTrieHistory, _>(
+            &snapshot,
+            plan.acc_survivors,
+        )?;
+        let storage_trie = self.collect_history_preceding_deletes::<StorageTrieHistory, _>(
+            &snapshot,
+            plan.storage_survivors,
+        )?;
+        let hashed_account = self.collect_history_preceding_deletes::<HashedAccountHistory, _>(
+            &snapshot,
+            plan.hashed_acc_survivors,
+        )?;
+        let hashed_storage = self.collect_history_preceding_deletes::<HashedStorageHistory, _>(
+            &snapshot,
+            plan.hashed_storage_survivors,
+        )?;
+
+        let counts = WriteCounts {
+            account_trie_updates_written_total: account_trie.len() as u64,
+            storage_trie_updates_written_total: storage_trie.len() as u64,
+            hashed_accounts_written_total: hashed_account.len() as u64,
+            hashed_storages_written_total: hashed_storage.len() as u64,
+        };
+
+        info!(
+            target: "trie::pruner",
+            expected_earliest_block = plan.earliest_block,
+            target_block,
+            account_trie_deletes = account_trie.len(),
+            storage_trie_deletes = storage_trie.len(),
+            hashed_account_deletes = hashed_account.len(),
+            hashed_storage_deletes = hashed_storage.len(),
+            total_deletes = counts.account_trie_updates_written_total
+                + counts.storage_trie_updates_written_total
+                + counts.hashed_accounts_written_total
+                + counts.hashed_storages_written_total,
+            elapsed = ?started.elapsed(),
+            "Prepared RocksDB proof storage prune",
+        );
+
+        Ok(Some(RocksdbPreparedPrune {
+            expected_earliest_block: plan.earliest_block,
+            expected_earliest_hash: plan.earliest_hash,
+            target_block,
+            target_hash,
+            deletes: RocksdbPreparedHistoryDeletes {
+                account_trie,
+                storage_trie,
+                hashed_account,
+                hashed_storage,
+            },
+            counts,
+        }))
+    }
+
+    fn commit_prepared_prune(
+        &self,
+        prepared: RocksdbPreparedPrune,
+    ) -> BaseProofsStorageResult<WriteCounts> {
+        let started = Instant::now();
+        let RocksdbPreparedPrune {
+            expected_earliest_block,
+            expected_earliest_hash,
+            target_block,
+            target_hash,
+            deletes,
+            counts,
+        } = prepared;
+        info!(
+            target: "trie::pruner",
+            expected_earliest_block,
+            target_block,
+            account_trie_deletes = deletes.account_trie.len(),
+            storage_trie_deletes = deletes.storage_trie.len(),
+            hashed_account_deletes = deletes.hashed_account.len(),
+            hashed_storage_deletes = deletes.hashed_storage.len(),
+            total_deletes = deletes.total(),
+            "Committing RocksDB proof storage prune",
+        );
+        let expected_earliest = Some((expected_earliest_block, expected_earliest_hash));
+        let current_earliest = self.get_block_number_hash(ProofWindowKey::EarliestBlock)?;
+        if current_earliest != expected_earliest {
+            info!(
+                target: "trie::pruner",
+                current_earliest = ?current_earliest,
+                expected_earliest = ?expected_earliest,
+                target_block,
+                elapsed = ?started.elapsed(),
+                "skipping stale prune plan"
+            );
+            return Ok(WriteCounts::default());
+        }
+
+        let mut batch = WriteBatch::default();
+
+        self.delete_raw_history_keys::<AccountTrieHistory>(&mut batch, deletes.account_trie)?;
+        self.delete_raw_history_keys::<StorageTrieHistory>(&mut batch, deletes.storage_trie)?;
+        self.delete_raw_history_keys::<HashedAccountHistory>(&mut batch, deletes.hashed_account)?;
+        self.delete_raw_history_keys::<HashedStorageHistory>(&mut batch, deletes.hashed_storage)?;
+
+        let cf = self.cf(<BlockChangeSet as Table>::NAME)?;
+        let start = encode_block_number(expected_earliest_block.saturating_add(1));
+        if let Some(end_block) = target_block.checked_add(1) {
+            batch.delete_range_cf(&cf, start, encode_block_number(end_block));
+        } else {
+            batch.delete_range_cf(&cf, start, encode_block_number(u64::MAX));
+            batch.delete_cf(&cf, encode_block_number(u64::MAX));
+        }
+
+        self.put_proof_window(
+            &mut batch,
+            ProofWindowKey::EarliestBlock,
+            target_block,
+            target_hash,
+        )?;
+
+        info!(
+            target: "trie::pruner",
+            expected_earliest_block,
+            target_block,
+            elapsed = ?started.elapsed(),
+            "Writing RocksDB proof storage prune batch",
+        );
+        self.db.write_opt(batch, &self.write_options).map_err(rocksdb_error)?;
+        info!(
+            target: "trie::pruner",
+            expected_earliest_block,
+            target_block,
+            account_trie_deletes = counts.account_trie_updates_written_total,
+            storage_trie_deletes = counts.storage_trie_updates_written_total,
+            hashed_account_deletes = counts.hashed_accounts_written_total,
+            hashed_storage_deletes = counts.hashed_storages_written_total,
+            total_deletes = counts.account_trie_updates_written_total
+                + counts.storage_trie_updates_written_total
+                + counts.hashed_accounts_written_total
+                + counts.hashed_storages_written_total,
+            elapsed = ?started.elapsed(),
+            "Committed RocksDB proof storage prune",
+        );
+        Ok(counts)
+    }
+
+    fn get_initial_state_anchor(&self) -> BaseProofsStorageResult<Option<BlockNumHash>> {
+        Ok(self.get_table::<ProofWindow>(ProofWindowKey::InitialStateAnchor)?.map(Into::into))
+    }
+
+    fn get_latest_history_key<T>(&self) -> BaseProofsStorageResult<Option<T::Key>>
+    where
+        T: RocksDbHistoryTable,
+    {
+        let cf = self.cf(T::NAME)?;
+        let mut iter = self.db.iterator_cf(&cf, IteratorMode::End);
+        let Some(item) = iter.next() else {
+            return Ok(None);
+        };
+        let (raw_key, _) = item.map_err(rocksdb_error)?;
+        decode_history_key::<T>(&raw_key).map(|(key, _)| Some(key)).map_err(Into::into)
+    }
+}
+
+impl BaseProofsStore for RocksdbProofsStorage {
+    type StorageTrieCursor<'tx>
+        = RocksdbTrieCursor<'tx, StorageTrieHistory>
+    where
+        Self: 'tx;
+    type AccountTrieCursor<'tx>
+        = RocksdbTrieCursor<'tx, AccountTrieHistory>
+    where
+        Self: 'tx;
+    type StorageCursor<'tx>
+        = RocksdbStorageCursor<'tx>
+    where
+        Self: 'tx;
+    type AccountHashedCursor<'tx>
+        = RocksdbAccountCursor<'tx>
+    where
+        Self: 'tx;
+    type Tx<'tx>
+        = Arc<RocksdbReadSnapshot<'tx>>
+    where
+        Self: 'tx;
+
+    fn ro_tx<'tx>(&'tx self) -> BaseProofsStorageResult<Self::Tx<'tx>> {
+        Ok(Arc::new(RocksdbReadSnapshot::new(self.db.as_ref())))
+    }
+
+    fn get_earliest_block_number(&self) -> BaseProofsStorageResult<Option<(u64, B256)>> {
+        self.get_block_number_hash(ProofWindowKey::EarliestBlock)
+    }
+
+    fn get_latest_block_number(&self) -> BaseProofsStorageResult<Option<(u64, B256)>> {
+        self.get_latest_block_number_hash()
+    }
+
+    fn storage_trie_cursor<'tx>(
+        &'tx self,
+        hashed_address: B256,
+        max_block_number: u64,
+    ) -> BaseProofsStorageResult<Self::StorageTrieCursor<'tx>> {
+        // Standalone cursor factories intentionally create independent snapshots. Use `ro_tx` and
+        // the `*_with_tx` factories when multiple cursors need one consistent view.
+        Ok(RocksdbTrieCursor::<StorageTrieHistory>::new(
+            self.db.as_ref(),
+            max_block_number,
+            Some(hashed_address),
+        ))
+    }
+
+    fn account_trie_cursor<'tx>(
+        &'tx self,
+        max_block_number: u64,
+    ) -> BaseProofsStorageResult<Self::AccountTrieCursor<'tx>> {
+        Ok(RocksdbTrieCursor::<AccountTrieHistory>::new(self.db.as_ref(), max_block_number, None))
+    }
+
+    fn storage_hashed_cursor<'tx>(
+        &'tx self,
+        hashed_address: B256,
+        max_block_number: u64,
+    ) -> BaseProofsStorageResult<Self::StorageCursor<'tx>> {
+        Ok(RocksdbStorageCursor::new(self.db.as_ref(), max_block_number, hashed_address))
+    }
+
+    fn account_hashed_cursor<'tx>(
+        &'tx self,
+        max_block_number: u64,
+    ) -> BaseProofsStorageResult<Self::AccountHashedCursor<'tx>> {
+        Ok(RocksdbAccountCursor::new(self.db.as_ref(), max_block_number))
+    }
+
+    fn storage_trie_cursor_with_tx<'tx, 'db>(
+        &self,
+        tx: &'tx Self::Tx<'db>,
+        hashed_address: B256,
+        max_block_number: u64,
+    ) -> BaseProofsStorageResult<Self::StorageTrieCursor<'tx>>
+    where
+        Self: 'db,
+        'db: 'tx,
+    {
+        Ok(RocksdbTrieCursor::<StorageTrieHistory>::new_with_snapshot(
+            Arc::clone(tx),
+            max_block_number,
+            Some(hashed_address),
+        ))
+    }
+
+    fn account_trie_cursor_with_tx<'tx, 'db>(
+        &self,
+        tx: &'tx Self::Tx<'db>,
+        max_block_number: u64,
+    ) -> BaseProofsStorageResult<Self::AccountTrieCursor<'tx>>
+    where
+        Self: 'db,
+        'db: 'tx,
+    {
+        Ok(RocksdbTrieCursor::<AccountTrieHistory>::new_with_snapshot(
+            Arc::clone(tx),
+            max_block_number,
+            None,
+        ))
+    }
+
+    fn storage_hashed_cursor_with_tx<'tx, 'db>(
+        &self,
+        tx: &'tx Self::Tx<'db>,
+        hashed_address: B256,
+        max_block_number: u64,
+    ) -> BaseProofsStorageResult<Self::StorageCursor<'tx>>
+    where
+        Self: 'db,
+        'db: 'tx,
+    {
+        Ok(RocksdbStorageCursor::new_with_snapshot(
+            Arc::clone(tx),
+            max_block_number,
+            hashed_address,
+        ))
+    }
+
+    fn account_hashed_cursor_with_tx<'tx, 'db>(
+        &self,
+        tx: &'tx Self::Tx<'db>,
+        max_block_number: u64,
+    ) -> BaseProofsStorageResult<Self::AccountHashedCursor<'tx>>
+    where
+        Self: 'db,
+        'db: 'tx,
+    {
+        Ok(RocksdbAccountCursor::new_with_snapshot(Arc::clone(tx), max_block_number))
+    }
+
+    fn store_trie_updates(
+        &self,
+        block_ref: BlockWithParent,
+        block_state_diff: BlockStateDiff,
+    ) -> BaseProofsStorageResult<WriteCounts> {
+        let _append_guard = self.append_lock.lock();
+        let _history_guard = self.history_gate.read();
+        let mut batch = WriteBatch::default();
+        let counts =
+            self.store_trie_updates_append_only(&mut batch, block_ref, block_state_diff)?;
+        self.db.write_opt(batch, &self.write_options).map_err(rocksdb_error)?;
+        Ok(counts)
+    }
+
+    fn fetch_trie_updates(&self, block_number: u64) -> BaseProofsStorageResult<BlockStateDiff> {
+        let snapshot = self.db.snapshot();
+        let change_set = self
+            .get_table_from_snapshot::<BlockChangeSet>(&snapshot, block_number)?
+            .ok_or(BaseProofsStorageError::NoChangeSetForBlock(block_number))?;
+
+        let mut trie_updates = TrieUpdates::default();
+        for key in change_set.account_trie_keys {
+            let entry = match get_history_exact::<AccountTrieHistory, _>(
+                &snapshot,
+                &self.db,
+                key.clone(),
+                block_number,
+            )? {
+                Some(value) if value.block_number == block_number => value.value.0,
+                _ => {
+                    return Err(BaseProofsStorageError::MissingAccountTrieHistory(
+                        key.0,
+                        block_number,
+                    ));
+                }
+            };
+
+            if let Some(value) = entry {
+                trie_updates.account_nodes.insert(key.0, value);
+            } else {
+                trie_updates.removed_nodes.insert(key.0);
+            }
+        }
+
+        for key in change_set.storage_trie_keys {
+            let entry = match get_history_exact::<StorageTrieHistory, _>(
+                &snapshot,
+                &self.db,
+                key.clone(),
+                block_number,
+            )? {
+                Some(value) if value.block_number == block_number => value.value.0,
+                _ => {
+                    return Err(BaseProofsStorageError::MissingStorageTrieHistory(
+                        key.hashed_address,
+                        key.path.0,
+                        block_number,
+                    ));
+                }
+            };
+
+            let storage_updates = trie_updates
+                .storage_tries
+                .entry(key.hashed_address)
+                .or_insert_with(StorageTrieUpdates::default);
+            if let Some(value) = entry {
+                storage_updates.storage_nodes.insert(key.path.0, value);
+            } else {
+                storage_updates.removed_nodes.insert(key.path.0);
+            }
+        }
+
+        let mut post_state = HashedPostState::with_capacity(change_set.hashed_account_keys.len());
+        for key in change_set.hashed_account_keys {
+            let entry = match get_history_exact::<HashedAccountHistory, _>(
+                &snapshot,
+                &self.db,
+                key,
+                block_number,
+            )? {
+                Some(value) if value.block_number == block_number => value.value.0,
+                _ => {
+                    return Err(BaseProofsStorageError::MissingHashedAccountHistory(
+                        key,
+                        block_number,
+                    ));
+                }
+            };
+            post_state.accounts.insert(key, entry);
+        }
+
+        for key in change_set.hashed_storage_keys {
+            let entry = match get_history_exact::<HashedStorageHistory, _>(
+                &snapshot,
+                &self.db,
+                key.clone(),
+                block_number,
+            )? {
+                Some(value) if value.block_number == block_number => value.value.0,
+                _ => {
+                    return Err(BaseProofsStorageError::MissingHashedStorageHistory {
+                        hashed_address: key.hashed_address,
+                        hashed_storage_key: key.hashed_storage_key,
+                        block_number,
+                    });
+                }
+            };
+
+            let storage = post_state.storages.entry(key.hashed_address).or_default();
+            if let Some(value) = entry {
+                storage.storage.insert(key.hashed_storage_key, value.0);
+            } else {
+                storage.storage.insert(key.hashed_storage_key, U256::ZERO);
+            }
+        }
+
+        Ok(BlockStateDiff {
+            sorted_trie_updates: trie_updates.into_sorted(),
+            sorted_post_state: post_state.into_sorted(),
+        })
+    }
+
+    fn prune_earliest_state(
+        &self,
+        new_earliest_block_ref: BlockWithParent,
+    ) -> BaseProofsStorageResult<WriteCounts> {
+        let started = Instant::now();
+        info!(
+            target: "trie::pruner",
+            target_block = new_earliest_block_ref.block.number,
+            "Acquiring RocksDB proof storage prune locks",
+        );
+        let _prune_guard = self.prune_lock.lock();
+        let _history_guard = self.history_gate.read();
+        info!(
+            target: "trie::pruner",
+            target_block = new_earliest_block_ref.block.number,
+            elapsed = ?started.elapsed(),
+            "Acquired RocksDB proof storage prune locks",
+        );
+        let Some(prepared) = self.prepare_prune(new_earliest_block_ref)? else {
+            info!(
+                target: "trie::pruner",
+                target_block = new_earliest_block_ref.block.number,
+                elapsed = ?started.elapsed(),
+                "No RocksDB proof storage prune work prepared",
+            );
+            return Ok(WriteCounts::default());
+        };
+
+        let counts = self.commit_prepared_prune(prepared)?;
+        info!(
+            target: "trie::pruner",
+            target_block = new_earliest_block_ref.block.number,
+            elapsed = ?started.elapsed(),
+            "Finished RocksDB proof storage prune request",
+        );
+        Ok(counts)
+    }
+
+    fn unwind_history(&self, to: BlockWithParent) -> BaseProofsStorageResult<()> {
+        let _guard = self.history_gate.write();
+        let Some(proof_window) = self.get_proof_window()? else {
+            return Ok(());
+        };
+
+        if to.block.number > proof_window.latest.number {
+            return Ok(());
+        }
+
+        if to.block.number <= proof_window.earliest.number {
+            return Err(BaseProofsStorageError::UnwindBeyondEarliest {
+                unwind_block_number: to.block.number,
+                earliest_block_number: proof_window.earliest.number,
+            });
+        }
+
+        // Keep collection and deletion under the same exclusive history gate so another history
+        // rewrite cannot change the proof window or history rows between choosing keys and
+        // committing the batch.
+        let history_to_delete = self.collect_history_ranged(to.block.number..)?;
+        let mut batch = WriteBatch::default();
+        self.delete_history_ranged(&mut batch, history_to_delete)?;
+        self.put_proof_window(
+            &mut batch,
+            ProofWindowKey::LatestBlock,
+            to.block.number.saturating_sub(1),
+            to.parent,
+        )?;
+        self.db.write_opt(batch, &self.write_options).map_err(rocksdb_error)?;
+        Ok(())
+    }
+
+    fn replace_updates(
+        &self,
+        latest_common_block: BlockNumHash,
+        mut blocks_to_add: Vec<(BlockWithParent, BlockStateDiff)>,
+    ) -> BaseProofsStorageResult<()> {
+        blocks_to_add.sort_unstable_by_key(|(block, _)| block.block.number);
+
+        let mut latest_block_hash = latest_common_block.hash;
+        for (block_with_parent, _) in &blocks_to_add {
+            let block_number = block_with_parent.block.number;
+            if latest_block_hash != block_with_parent.parent {
+                return Err(BaseProofsStorageError::OutOfOrder {
+                    block_number,
+                    parent_block_hash: block_with_parent.parent,
+                    latest_block_hash,
+                });
+            }
+            latest_block_hash = block_with_parent.block.hash;
+        }
+
+        let _guard = self.history_gate.write();
+        let history_to_delete = if let Some(start_block) = latest_common_block.number.checked_add(1)
+        {
+            self.collect_history_ranged(start_block..)?
+        } else {
+            RocksdbHistoryDeleteBatch::default()
+        };
+        let mut batch = WriteBatch::default();
+        self.delete_history_ranged(&mut batch, history_to_delete)?;
+        self.put_proof_window(
+            &mut batch,
+            ProofWindowKey::LatestBlock,
+            latest_common_block.number,
+            latest_common_block.hash,
+        )?;
+
+        let mut replacement_state = RocksdbReplacementState::default();
+        for (block_with_parent, diff) in blocks_to_add {
+            self.store_replacement_trie_updates_append_only(
+                &mut batch,
+                latest_common_block.number,
+                &mut replacement_state,
+                block_with_parent,
+                diff,
+            )?;
+        }
+
+        self.db.write_opt(batch, &self.write_options).map_err(rocksdb_error)?;
+        Ok(())
+    }
+
+    fn set_earliest_block_number(
+        &self,
+        block_number: u64,
+        hash: B256,
+    ) -> BaseProofsStorageResult<()> {
+        self.set_earliest_block_number_hash(block_number, hash)
+    }
+}
+
+impl BaseProofsInitialStateStore for RocksdbProofsStorage {
+    fn initial_state_anchor(&self) -> BaseProofsStorageResult<InitialStateAnchor> {
+        let Some(block) = self.get_initial_state_anchor()? else {
+            return Ok(InitialStateAnchor::default());
+        };
+
+        let completed = self.get_earliest_block_number()?.is_some();
+
+        Ok(InitialStateAnchor {
+            block: Some(block),
+            status: if completed {
+                InitialStateStatus::Completed
+            } else {
+                InitialStateStatus::InProgress
+            },
+            latest_account_trie_key: self.get_latest_history_key::<AccountTrieHistory>()?,
+            latest_storage_trie_key: self.get_latest_history_key::<StorageTrieHistory>()?,
+            latest_hashed_account_key: self.get_latest_history_key::<HashedAccountHistory>()?,
+            latest_hashed_storage_key: self.get_latest_history_key::<HashedStorageHistory>()?,
+        })
+    }
+
+    fn set_initial_state_anchor(&self, anchor: BlockNumHash) -> BaseProofsStorageResult<()> {
+        let _guard = self.history_gate.write();
+        if self.get_initial_state_anchor()?.is_some() {
+            return Err(DatabaseError::Other("initial state anchor already set".to_owned()).into());
+        }
+
+        let mut batch = WriteBatch::default();
+        self.put_table::<ProofWindow>(
+            &mut batch,
+            ProofWindowKey::InitialStateAnchor,
+            &anchor.into(),
+        )?;
+        self.db.write_opt(batch, &self.write_options).map_err(rocksdb_error)?;
+        Ok(())
+    }
+
+    fn store_account_branches(
+        &self,
+        account_nodes: Vec<(Nibbles, Option<BranchNodeCompact>)>,
+    ) -> BaseProofsStorageResult<()> {
+        let mut account_nodes = account_nodes;
+        if account_nodes.is_empty() {
+            return Ok(());
+        }
+
+        account_nodes.sort_by_key(|(key, _)| *key);
+        let _guard = self.history_gate.write();
+        let mut batch = WriteBatch::default();
+        self.persist_history_batch::<AccountTrieHistory, _, _>(
+            &mut batch,
+            0,
+            account_nodes.into_iter(),
+            true,
+        )?;
+        self.db.write_opt(batch, &self.write_options).map_err(rocksdb_error)?;
+        Ok(())
+    }
+
+    fn store_storage_branches(
+        &self,
+        hashed_address: B256,
+        storage_nodes: Vec<(Nibbles, Option<BranchNodeCompact>)>,
+    ) -> BaseProofsStorageResult<()> {
+        let mut storage_nodes = storage_nodes;
+        if storage_nodes.is_empty() {
+            return Ok(());
+        }
+
+        storage_nodes.sort_by_key(|(key, _)| *key);
+        let _guard = self.history_gate.write();
+        let mut batch = WriteBatch::default();
+        self.persist_history_batch::<StorageTrieHistory, _, _>(
+            &mut batch,
+            0,
+            storage_nodes.into_iter().map(|(path, node)| (hashed_address, path, node)),
+            true,
+        )?;
+        self.db.write_opt(batch, &self.write_options).map_err(rocksdb_error)?;
+        Ok(())
+    }
+
+    fn store_hashed_accounts(
+        &self,
+        accounts: Vec<(B256, Option<Account>)>,
+    ) -> BaseProofsStorageResult<()> {
+        let mut accounts = accounts;
+        if accounts.is_empty() {
+            return Ok(());
+        }
+
+        accounts.sort_by_key(|(key, _)| *key);
+        let _guard = self.history_gate.write();
+        let mut batch = WriteBatch::default();
+        self.persist_history_batch::<HashedAccountHistory, _, _>(
+            &mut batch,
+            0,
+            accounts.into_iter(),
+            true,
+        )?;
+        self.db.write_opt(batch, &self.write_options).map_err(rocksdb_error)?;
+        Ok(())
+    }
+
+    fn store_hashed_storages(
+        &self,
+        hashed_address: B256,
+        storages: Vec<(B256, U256)>,
+    ) -> BaseProofsStorageResult<()> {
+        let mut storages = storages;
+        if storages.is_empty() {
+            return Ok(());
+        }
+
+        storages.sort_by_key(|(key, _)| *key);
+        let _guard = self.history_gate.write();
+        let mut batch = WriteBatch::default();
+        self.persist_history_batch::<HashedStorageHistory, _, _>(
+            &mut batch,
+            0,
+            storages
+                .into_iter()
+                .map(|(key, value)| (hashed_address, key, Some(StorageValue(value)))),
+            true,
+        )?;
+        self.db.write_opt(batch, &self.write_options).map_err(rocksdb_error)?;
+        Ok(())
+    }
+
+    fn commit_initial_state(&self) -> BaseProofsStorageResult<BlockNumHash> {
+        let _guard = self.history_gate.write();
+        let anchor = self.get_initial_state_anchor()?.ok_or(NoBlocksFound)?;
+        self.set_earliest_block_number_hash_unlocked(anchor.number, anchor.hash)?;
+        Ok(anchor)
+    }
+}
+
+#[cfg(feature = "metrics")]
+impl reth_db::database_metrics::DatabaseMetrics for RocksdbProofsStorage {
+    fn gauge_metrics(&self) -> Vec<(&'static str, f64, Vec<Label>)> {
+        let mut metrics = Vec::new();
+
+        for table in Self::column_families() {
+            let Some(cf) = self.db.cf_handle(table) else {
+                continue;
+            };
+
+            let estimated_num_keys = self
+                .db
+                .property_int_value_cf(&cf, rocksdb::properties::ESTIMATE_NUM_KEYS)
+                .ok()
+                .flatten()
+                .unwrap_or(0);
+            let sst_size = self
+                .db
+                .property_int_value_cf(&cf, rocksdb::properties::LIVE_SST_FILES_SIZE)
+                .ok()
+                .flatten()
+                .unwrap_or(0);
+            let memtable_size = self
+                .db
+                .property_int_value_cf(&cf, rocksdb::properties::SIZE_ALL_MEM_TABLES)
+                .ok()
+                .flatten()
+                .unwrap_or(0);
+            let pending_compaction_bytes = self
+                .db
+                .property_int_value_cf(&cf, rocksdb::properties::ESTIMATE_PENDING_COMPACTION_BYTES)
+                .ok()
+                .flatten()
+                .unwrap_or(0);
+
+            metrics.push((
+                "base_proof_storage.table_size",
+                (sst_size + memtable_size) as f64,
+                vec![Label::new("table", table)],
+            ));
+            metrics.push((
+                "base_proof_storage.table_entries",
+                estimated_num_keys as f64,
+                vec![Label::new("table", table)],
+            ));
+            metrics.push((
+                "base_proof_storage.pending_compaction_bytes",
+                pending_compaction_bytes as f64,
+                vec![Label::new("table", table)],
+            ));
+            metrics.push((
+                "base_proof_storage.sst_size",
+                sst_size as f64,
+                vec![Label::new("table", table)],
+            ));
+            metrics.push((
+                "base_proof_storage.memtable_size",
+                memtable_size as f64,
+                vec![Label::new("table", table)],
+            ));
+        }
+
+        let wal_size: u64 = std::fs::read_dir(self.db.path())
+            .map(|entries| {
+                entries
+                    .filter_map(Result::ok)
+                    .filter(|entry| entry.path().extension().is_some_and(|ext| ext == "log"))
+                    .filter_map(|entry| entry.metadata().ok())
+                    .map(|metadata| metadata.len())
+                    .sum()
+            })
+            .unwrap_or(0);
+
+        metrics.push(("base_proof_storage.wal_size", wal_size as f64, vec![]));
+
+        metrics
+    }
+}
+
+#[cfg(not(feature = "metrics"))]
+impl reth_db::database_metrics::DatabaseMetrics for RocksdbProofsStorage {}
+
+impl<'db, T, V> RocksdbVersionedCursor<'db, T>
+where
+    T: Table<Value = VersionedValue<V>> + DupSort<SubKey = u64>,
+    T: RocksDbHistoryTable,
+    T::Key: Clone + Default + Ord,
+    T::Value: Decompress,
+{
+    /// Creates a cursor over a `RocksDB` history column family.
+    fn new(db: &'db RocksDb, max_block_number: u64) -> Self {
+        let snapshot = Arc::new(RocksdbReadSnapshot::new(db));
+        Self::new_with_snapshot(snapshot, max_block_number)
+    }
+
+    const fn new_with_snapshot(
+        snapshot: Arc<RocksdbReadSnapshot<'db>>,
+        max_block_number: u64,
+    ) -> Self {
+        Self { snapshot, max_block_number, current_key: None, _table: PhantomData }
+    }
+
+    fn cf(&self) -> Result<Arc<BoundColumnFamily<'_>>, DatabaseError> {
+        self.snapshot.cf(T::NAME)
+    }
+
+    fn latest_version_for_key(&self, key: T::Key) -> RocksDbLatestVersionResult<T> {
+        let cf = self.cf()?;
+        let prefix = encode_history_key_prefix::<T>(&key);
+        let target = encode_history_key::<T>(&key, self.max_block_number);
+        let mut iter = self
+            .snapshot
+            .snapshot()
+            .iterator_cf(&cf, IteratorMode::From(&target, Direction::Reverse));
+
+        let Some(item) = iter.next() else {
+            return Ok(None);
+        };
+        let (raw_key, raw_value) = item.map_err(rocksdb_error)?;
+        if !raw_key.starts_with(&prefix) {
+            return Ok(None);
+        }
+
+        let (decoded_key, _) = decode_history_key::<T>(&raw_key)?;
+        let value = T::Value::decompress(&raw_value)?;
+        Ok(Some((decoded_key, value)))
+    }
+
+    fn seek_exact(&mut self, key: T::Key) -> Result<Option<(T::Key, V)>, DatabaseError> {
+        self.current_key = Some(key.clone());
+        if let Some((latest_key, latest_value)) = self.latest_version_for_key(key)?
+            && let MaybeDeleted(Some(value)) = latest_value.value
+        {
+            return Ok(Some((latest_key, value)));
+        }
+        Ok(None)
+    }
+
+    fn seek(&mut self, start_key: T::Key) -> Result<Option<(T::Key, V)>, DatabaseError> {
+        self.next_live_from(start_key)
+    }
+
+    fn next(&mut self) -> Result<Option<(T::Key, V)>, DatabaseError> {
+        if let Some(key) = self.current_key.clone() {
+            self.next_live_after(key)
+        } else {
+            self.next_live_from(T::Key::default())
+        }
+    }
+
+    fn next_live_from(&mut self, key: T::Key) -> Result<Option<(T::Key, V)>, DatabaseError> {
+        self.next_live_candidate(key, false)
+    }
+
+    fn next_live_after(&mut self, key: T::Key) -> Result<Option<(T::Key, V)>, DatabaseError> {
+        self.next_live_candidate(key, true)
+    }
+
+    fn next_live_candidate(
+        &mut self,
+        key: T::Key,
+        exclusive: bool,
+    ) -> Result<Option<(T::Key, V)>, DatabaseError> {
+        let found = {
+            let cf = self.cf()?;
+            let start_block = if exclusive { u64::MAX } else { 0 };
+            let start_key = encode_history_key::<T>(&key, start_block);
+            let iter = self
+                .snapshot
+                .snapshot()
+                .iterator_cf(&cf, IteratorMode::From(&start_key, Direction::Forward));
+            let mut last_candidate = None;
+            let mut found = None;
+
+            for item in iter {
+                let (raw_key, _) = item.map_err(rocksdb_error)?;
+                let (candidate, _) = decode_history_key::<T>(&raw_key)?;
+                let before_start = if exclusive { candidate <= key } else { candidate < key };
+                if before_start || last_candidate.as_ref() == Some(&candidate) {
+                    continue;
+                }
+
+                last_candidate = Some(candidate.clone());
+                if let Some((live_key, latest_value)) = self.latest_version_for_key(candidate)?
+                    && let MaybeDeleted(Some(value)) = latest_value.value
+                {
+                    found = Some((live_key, value));
+                    break;
+                }
+            }
+
+            found
+        };
+
+        if let Some((key, value)) = found {
+            self.current_key = Some(key.clone());
+            return Ok(Some((key, value)));
+        }
+
+        self.current_key = None;
+        Ok(None)
+    }
+
+    const fn is_positioned(&self) -> bool {
+        self.current_key.is_some()
+    }
+}
+
+impl<'db> RocksdbTrieCursor<'db, AccountTrieHistory> {
+    /// Creates a `RocksDB` trie cursor.
+    pub fn new(db: &'db RocksDb, max_block_number: u64, hashed_address: Option<B256>) -> Self {
+        Self { inner: RocksdbVersionedCursor::new(db, max_block_number), hashed_address }
+    }
+
+    const fn new_with_snapshot(
+        snapshot: Arc<RocksdbReadSnapshot<'db>>,
+        max_block_number: u64,
+        hashed_address: Option<B256>,
+    ) -> Self {
+        Self {
+            inner: RocksdbVersionedCursor::new_with_snapshot(snapshot, max_block_number),
+            hashed_address,
+        }
+    }
+}
+
+impl<'db> RocksdbTrieCursor<'db, StorageTrieHistory> {
+    /// Creates a `RocksDB` trie cursor.
+    pub fn new(db: &'db RocksDb, max_block_number: u64, hashed_address: Option<B256>) -> Self {
+        Self { inner: RocksdbVersionedCursor::new(db, max_block_number), hashed_address }
+    }
+
+    const fn new_with_snapshot(
+        snapshot: Arc<RocksdbReadSnapshot<'db>>,
+        max_block_number: u64,
+        hashed_address: Option<B256>,
+    ) -> Self {
+        Self {
+            inner: RocksdbVersionedCursor::new_with_snapshot(snapshot, max_block_number),
+            hashed_address,
+        }
+    }
+}
+
+impl TrieCursor for RocksdbTrieCursor<'_, AccountTrieHistory> {
+    fn seek_exact(
+        &mut self,
+        path: Nibbles,
+    ) -> Result<Option<(Nibbles, BranchNodeCompact)>, DatabaseError> {
+        Ok(self
+            .inner
+            .seek_exact(StoredNibbles(path))?
+            .map(|(StoredNibbles(nibbles), node)| (nibbles, node)))
+    }
+
+    fn seek(
+        &mut self,
+        path: Nibbles,
+    ) -> Result<Option<(Nibbles, BranchNodeCompact)>, DatabaseError> {
+        Ok(self
+            .inner
+            .seek(StoredNibbles(path))?
+            .map(|(StoredNibbles(nibbles), node)| (nibbles, node)))
+    }
+
+    fn next(&mut self) -> Result<Option<(Nibbles, BranchNodeCompact)>, DatabaseError> {
+        Ok(self.inner.next()?.map(|(StoredNibbles(nibbles), node)| (nibbles, node)))
+    }
+
+    fn current(&mut self) -> Result<Option<Nibbles>, DatabaseError> {
+        Ok(self.inner.current_key.clone().map(|StoredNibbles(nibbles)| nibbles))
+    }
+
+    fn reset(&mut self) {
+        self.inner.current_key = None;
+    }
+}
+
+impl TrieCursor for RocksdbTrieCursor<'_, StorageTrieHistory> {
+    fn seek_exact(
+        &mut self,
+        path: Nibbles,
+    ) -> Result<Option<(Nibbles, BranchNodeCompact)>, DatabaseError> {
+        let Some(address) = self.hashed_address else {
+            return Ok(None);
+        };
+        let key = StorageTrieKey::new(address, StoredNibbles(path));
+        Ok(self
+            .inner
+            .seek_exact(key)?
+            .and_then(|(key, node)| (key.hashed_address == address).then_some((key.path.0, node))))
+    }
+
+    fn seek(
+        &mut self,
+        path: Nibbles,
+    ) -> Result<Option<(Nibbles, BranchNodeCompact)>, DatabaseError> {
+        let Some(address) = self.hashed_address else {
+            return Ok(None);
+        };
+        let key = StorageTrieKey::new(address, StoredNibbles(path));
+        Ok(self
+            .inner
+            .seek(key)?
+            .and_then(|(key, node)| (key.hashed_address == address).then_some((key.path.0, node))))
+    }
+
+    fn next(&mut self) -> Result<Option<(Nibbles, BranchNodeCompact)>, DatabaseError> {
+        let Some(address) = self.hashed_address else {
+            return Ok(None);
+        };
+        if !self.inner.is_positioned() {
+            return self.seek(Nibbles::default());
+        }
+        Ok(self
+            .inner
+            .next()?
+            .and_then(|(key, node)| (key.hashed_address == address).then_some((key.path.0, node))))
+    }
+
+    fn current(&mut self) -> Result<Option<Nibbles>, DatabaseError> {
+        let Some(address) = self.hashed_address else {
+            return Ok(None);
+        };
+        Ok(self
+            .inner
+            .current_key
+            .clone()
+            .and_then(|key| (key.hashed_address == address).then_some(key.path.0)))
+    }
+
+    fn reset(&mut self) {
+        self.inner.current_key = None;
+    }
+}
+
+impl TrieStorageCursor for RocksdbTrieCursor<'_, StorageTrieHistory> {
+    fn set_hashed_address(&mut self, hashed_address: B256) {
+        self.hashed_address = Some(hashed_address);
+        self.inner.current_key = None;
+    }
+}
+
+impl<'db> RocksdbStorageCursor<'db> {
+    /// Creates a `RocksDB` storage cursor.
+    pub fn new(db: &'db RocksDb, max_block_number: u64, hashed_address: B256) -> Self {
+        Self { inner: RocksdbVersionedCursor::new(db, max_block_number), hashed_address }
+    }
+
+    const fn new_with_snapshot(
+        snapshot: Arc<RocksdbReadSnapshot<'db>>,
+        max_block_number: u64,
+        hashed_address: B256,
+    ) -> Self {
+        Self {
+            inner: RocksdbVersionedCursor::new_with_snapshot(snapshot, max_block_number),
+            hashed_address,
+        }
+    }
+}
+
+impl HashedCursor for RocksdbStorageCursor<'_> {
+    type Value = U256;
+
+    fn seek(&mut self, key: B256) -> Result<Option<(B256, Self::Value)>, DatabaseError> {
+        let storage_key = HashedStorageKey::new(self.hashed_address, key);
+        let result = self.inner.seek(storage_key)?.and_then(|(key, value)| {
+            (key.hashed_address == self.hashed_address).then_some((key.hashed_storage_key, value.0))
+        });
+
+        if let Some((_, value)) = result
+            && value.is_zero()
+        {
+            return self.next();
+        }
+
+        Ok(result)
+    }
+
+    fn next(&mut self) -> Result<Option<(B256, Self::Value)>, DatabaseError> {
+        if !self.inner.is_positioned() {
+            return self.seek(B256::ZERO);
+        }
+
+        loop {
+            let result = self.inner.next()?.and_then(|(key, value)| {
+                (key.hashed_address == self.hashed_address)
+                    .then_some((key.hashed_storage_key, value.0))
+            });
+
+            let Some((key, value)) = result else {
+                return Ok(None);
+            };
+            if value.is_zero() {
+                continue;
+            }
+            return Ok(Some((key, value)));
+        }
+    }
+
+    fn reset(&mut self) {
+        self.inner.current_key = None;
+    }
+}
+
+impl HashedStorageCursor for RocksdbStorageCursor<'_> {
+    fn is_storage_empty(&mut self) -> Result<bool, DatabaseError> {
+        Ok(self.seek(B256::ZERO)?.is_none())
+    }
+
+    fn set_hashed_address(&mut self, hashed_address: B256) {
+        self.hashed_address = hashed_address;
+        self.inner.current_key = None;
+    }
+}
+
+impl<'db> RocksdbAccountCursor<'db> {
+    /// Creates a `RocksDB` account cursor.
+    pub fn new(db: &'db RocksDb, max_block_number: u64) -> Self {
+        Self { inner: RocksdbVersionedCursor::new(db, max_block_number) }
+    }
+
+    const fn new_with_snapshot(
+        snapshot: Arc<RocksdbReadSnapshot<'db>>,
+        max_block_number: u64,
+    ) -> Self {
+        Self { inner: RocksdbVersionedCursor::new_with_snapshot(snapshot, max_block_number) }
+    }
+}
+
+impl HashedCursor for RocksdbAccountCursor<'_> {
+    type Value = Account;
+
+    fn seek(&mut self, key: B256) -> Result<Option<(B256, Self::Value)>, DatabaseError> {
+        self.inner.seek(key)
+    }
+
+    fn next(&mut self) -> Result<Option<(B256, Self::Value)>, DatabaseError> {
+        self.inner.next()
+    }
+
+    fn reset(&mut self) {
+        self.inner.current_key = None;
+    }
+}
+
+fn rocksdb_error(error: rocksdb::Error) -> DatabaseError {
+    DatabaseError::Other(error.to_string())
+}
+
+fn encode_table_key<T: Table>(key: T::Key) -> Vec<u8> {
+    key.encode().as_ref().to_vec()
+}
+
+fn encode_table_value<T: Table>(value: &T::Value) -> Vec<u8> {
+    let mut encoded = <T::Value as Compress>::Compressed::default();
+    value.compress_to_buf(&mut encoded);
+    encoded.into()
+}
+
+fn encode_history_key<T>(key: &T::Key, block_number: u64) -> Vec<u8>
+where
+    T: RocksDbHistoryTable,
+{
+    let mut encoded = encode_history_key_prefix::<T>(key);
+    encoded.extend_from_slice(&block_number.to_be_bytes());
+    encoded
+}
+
+fn encode_history_key_prefix<T>(key: &T::Key) -> Vec<u8>
+where
+    T: RocksDbHistoryTable,
+{
+    T::encode_history_key_prefix(key)
+}
+
+fn decode_history_key<T>(raw_key: &[u8]) -> Result<(T::Key, u64), DatabaseError>
+where
+    T: RocksDbHistoryTable,
+{
+    if raw_key.len() != T::KEY_LEN + BLOCK_NUMBER_KEY_LEN {
+        return Err(DatabaseError::Decode);
+    }
+    let split = T::KEY_LEN;
+    let key = T::decode_history_key_prefix(&raw_key[..split])?;
+    let block_number =
+        u64::from_be_bytes(raw_key[split..].try_into().map_err(|_| DatabaseError::Decode)?);
+    Ok((key, block_number))
+}
+
+fn get_history_exact<T, V>(
+    snapshot: &SnapshotWithThreadMode<'_, RocksDb>,
+    db: &Arc<RocksDb>,
+    key: T::Key,
+    block_number: u64,
+) -> BaseProofsStorageResult<Option<T::Value>>
+where
+    T: Table<Value = VersionedValue<V>> + DupSort<SubKey = u64>,
+    T::Key: Clone,
+    T::Value: Decompress,
+    T: RocksDbHistoryTable,
+{
+    let cf = db.cf_handle(T::NAME).ok_or_else(|| {
+        DatabaseError::Other(format!("missing RocksDB column family {}", T::NAME))
+    })?;
+    snapshot
+        .get_cf(&cf, encode_history_key::<T>(&key, block_number))
+        .map_err(rocksdb_error)?
+        .map(|value| T::Value::decompress(&value).map_err(Into::into))
+        .transpose()
+}
+
+impl RocksDbHistoryTable for AccountTrieHistory {
+    const KEY_LEN: usize = PACKED_NIBBLES_KEY_LEN;
+
+    fn encode_history_key_prefix(key: &Self::Key) -> Vec<u8> {
+        encode_packed_nibbles(&key.0).to_vec()
+    }
+
+    fn decode_history_key_prefix(raw_key: &[u8]) -> Result<Self::Key, DatabaseError> {
+        decode_packed_nibbles(raw_key).map(StoredNibbles)
+    }
+}
+
+impl RocksDbHistoryTable for StorageTrieHistory {
+    const KEY_LEN: usize = HASH_KEY_LEN + PACKED_NIBBLES_KEY_LEN;
+
+    fn encode_history_key_prefix(key: &Self::Key) -> Vec<u8> {
+        let mut encoded = Vec::with_capacity(Self::KEY_LEN);
+        encoded.extend_from_slice(key.hashed_address.as_slice());
+        encoded.extend_from_slice(&encode_packed_nibbles(&key.path.0));
+        encoded
+    }
+
+    fn decode_history_key_prefix(raw_key: &[u8]) -> Result<Self::Key, DatabaseError> {
+        if raw_key.len() != Self::KEY_LEN {
+            return Err(DatabaseError::Decode);
+        }
+        let hashed_address = B256::from_slice(&raw_key[..HASH_KEY_LEN]);
+        let path = StoredNibbles(decode_packed_nibbles(&raw_key[HASH_KEY_LEN..])?);
+        Ok(StorageTrieKey::new(hashed_address, path))
+    }
+}
+
+impl RocksDbHistoryTable for HashedAccountHistory {
+    const KEY_LEN: usize = HASH_KEY_LEN;
+
+    fn encode_history_key_prefix(key: &Self::Key) -> Vec<u8> {
+        key.as_slice().to_vec()
+    }
+
+    fn decode_history_key_prefix(raw_key: &[u8]) -> Result<Self::Key, DatabaseError> {
+        if raw_key.len() != Self::KEY_LEN {
+            return Err(DatabaseError::Decode);
+        }
+        Ok(B256::from_slice(raw_key))
+    }
+}
+
+impl RocksDbHistoryTable for HashedStorageHistory {
+    const KEY_LEN: usize = HASH_KEY_LEN * 2;
+
+    fn encode_history_key_prefix(key: &Self::Key) -> Vec<u8> {
+        let mut encoded = Vec::with_capacity(Self::KEY_LEN);
+        encoded.extend_from_slice(key.hashed_address.as_slice());
+        encoded.extend_from_slice(key.hashed_storage_key.as_slice());
+        encoded
+    }
+
+    fn decode_history_key_prefix(raw_key: &[u8]) -> Result<Self::Key, DatabaseError> {
+        if raw_key.len() != Self::KEY_LEN {
+            return Err(DatabaseError::Decode);
+        }
+        Ok(HashedStorageKey::new(
+            B256::from_slice(&raw_key[..HASH_KEY_LEN]),
+            B256::from_slice(&raw_key[HASH_KEY_LEN..]),
+        ))
+    }
+}
+
+fn encode_packed_nibbles(nibbles: &Nibbles) -> [u8; PACKED_NIBBLES_KEY_LEN] {
+    assert!(nibbles.len() <= 64, "trie paths must fit within 64 nibbles");
+
+    let mut encoded = [0; PACKED_NIBBLES_KEY_LEN];
+    nibbles.pack_to(&mut encoded[..HASH_KEY_LEN]);
+    encoded[HASH_KEY_LEN] = nibbles.len() as u8;
+    encoded
+}
+
+fn decode_packed_nibbles(raw_key: &[u8]) -> Result<Nibbles, DatabaseError> {
+    if raw_key.len() != PACKED_NIBBLES_KEY_LEN {
+        return Err(DatabaseError::Decode);
+    }
+
+    let nibble_count = raw_key[HASH_KEY_LEN] as usize;
+    if nibble_count > 64 {
+        return Err(DatabaseError::Decode);
+    }
+
+    let packed_len = nibble_count.div_ceil(2);
+    if nibble_count % 2 == 1 && raw_key[packed_len - 1] & 0x0f != 0 {
+        return Err(DatabaseError::Decode);
+    }
+    if raw_key[packed_len..HASH_KEY_LEN].iter().any(|byte| *byte != 0) {
+        return Err(DatabaseError::Decode);
+    }
+
+    let mut nibbles = Vec::with_capacity(nibble_count);
+    for index in 0..nibble_count {
+        let byte = raw_key[index / 2];
+        let nibble = if index % 2 == 0 { byte >> 4 } else { byte & 0x0f };
+        nibbles.push(nibble);
+    }
+    Ok(Nibbles::from_nibbles_unchecked(nibbles))
+}
+
+const fn encode_block_number(block_number: u64) -> [u8; 8] {
+    block_number.to_be_bytes()
+}
+
+fn decode_block_number(raw_key: &[u8]) -> Result<u64, DatabaseError> {
+    if raw_key.len() != 8 {
+        return Err(DatabaseError::Decode);
+    }
+    Ok(u64::from_be_bytes(raw_key.try_into().map_err(|_| DatabaseError::Decode)?))
+}
+
+fn range_start(range: &impl RangeBounds<u64>) -> u64 {
+    match range.start_bound() {
+        Bound::Included(start) => *start,
+        Bound::Excluded(start) => start.saturating_add(1),
+        Bound::Unbounded => 0,
+    }
+}
+
+fn flatten_and_sort<K: Ord>(map: HashMap<K, u64>) -> Vec<(K, u64)> {
+    let mut values: Vec<_> = map.into_iter().collect();
+    values.sort_unstable_by(|a, b| a.0.cmp(&b.0));
+    values
+}
+
+fn prefix_upper_bound(prefix: &[u8]) -> Option<Vec<u8>> {
+    let mut upper_bound = prefix.to_vec();
+    for index in (0..upper_bound.len()).rev() {
+        if upper_bound[index] != u8::MAX {
+            upper_bound[index] += 1;
+            upper_bound.truncate(index + 1);
+            return Some(upper_bound);
+        }
+    }
+
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        sync::{Arc, mpsc},
+        thread,
+        time::Duration,
+    };
+
+    use tempfile::TempDir;
+
+    use super::*;
+
+    fn temp_storage() -> (Arc<RocksdbProofsStorage>, TempDir) {
+        let dir = TempDir::new().unwrap();
+        let storage = Arc::new(RocksdbProofsStorage::new(dir.path()).unwrap());
+        (storage, dir)
+    }
+
+    #[test]
+    fn max_total_wal_size_tracks_column_family_write_buffers() {
+        assert_eq!(
+            RocksdbProofsStorage::max_total_wal_size(),
+            RocksdbProofsStorage::column_families().len() as u64
+                * DEFAULT_WRITE_BUFFER_SIZE as u64
+                * DEFAULT_MAX_WRITE_BUFFER_NUMBER as u64
+        );
+    }
+
+    fn block(number: u64, parent: B256) -> BlockWithParent {
+        BlockWithParent {
+            parent,
+            block: BlockNumHash {
+                number,
+                hash: if number == 0 { B256::ZERO } else { B256::repeat_byte(number as u8) },
+            },
+        }
+    }
+
+    fn account_update(address: B256, nonce: u64) -> BlockStateDiff {
+        let mut post_state = HashedPostState::default();
+        post_state.accounts.insert(address, Some(Account { nonce, ..Default::default() }));
+
+        BlockStateDiff {
+            sorted_trie_updates: TrieUpdates::default().into_sorted(),
+            sorted_post_state: post_state.into_sorted(),
+        }
+    }
+
+    fn assert_completes(rx: mpsc::Receiver<BaseProofsStorageResult<()>>) {
+        rx.recv_timeout(Duration::from_secs(2))
+            .expect("operation should complete")
+            .expect("operation should succeed");
+    }
+
+    #[test]
+    fn packed_nibbles_round_trip() {
+        let nibbles = Nibbles::from_nibbles_unchecked([0, 1, 0, 2, 15, 0, 3]);
+        let encoded = encode_packed_nibbles(&nibbles);
+
+        assert_eq!(encoded[HASH_KEY_LEN], 7);
+        assert_eq!(decode_packed_nibbles(&encoded).unwrap(), nibbles);
+    }
+
+    #[test]
+    fn packed_nibbles_preserve_lexicographic_order() {
+        let keys = [
+            vec![],
+            vec![0],
+            vec![0, 0],
+            vec![0, 1],
+            vec![1],
+            vec![1, 0],
+            vec![1, 1],
+            vec![2],
+            vec![15],
+            vec![15, 15],
+        ];
+
+        for left in &keys {
+            for right in &keys {
+                let left = Nibbles::from_nibbles_unchecked(left);
+                let right = Nibbles::from_nibbles_unchecked(right);
+                assert_eq!(
+                    left.cmp(&right),
+                    encode_packed_nibbles(&left).cmp(&encode_packed_nibbles(&right))
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn hashed_history_keys_preserve_full_byte_ordering() {
+        let keys = [B256::ZERO, B256::repeat_byte(2), B256::repeat_byte(255)];
+
+        for left in keys {
+            for right in keys {
+                assert_eq!(
+                    left.cmp(&right),
+                    encode_history_key_prefix::<HashedAccountHistory>(&left)
+                        .cmp(&encode_history_key_prefix::<HashedAccountHistory>(&right))
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn packed_nibbles_reject_invalid_padding() {
+        let mut encoded = encode_packed_nibbles(&Nibbles::from_nibbles_unchecked([1, 2, 3]));
+        encoded[HASH_KEY_LEN - 1] = 1;
+        assert!(decode_packed_nibbles(&encoded).is_err());
+
+        let mut encoded = encode_packed_nibbles(&Nibbles::from_nibbles_unchecked([1]));
+        encoded[0] |= 1;
+        assert!(decode_packed_nibbles(&encoded).is_err());
+    }
+
+    #[test]
+    fn append_can_run_while_prune_holds_history_read_gate() {
+        let (storage, _dir) = temp_storage();
+        storage.set_earliest_block_number_hash(0, B256::ZERO).unwrap();
+
+        let _prune_guard = storage.prune_lock.lock();
+        let _history_guard = storage.history_gate.read();
+        let (tx, rx) = mpsc::channel();
+        let task_storage = Arc::clone(&storage);
+
+        thread::spawn(move || {
+            let result = task_storage
+                .store_trie_updates(block(1, B256::ZERO), BlockStateDiff::default())
+                .map(|_| ());
+            tx.send(result).unwrap();
+        });
+
+        assert_completes(rx);
+        assert_eq!(storage.get_latest_block_number().unwrap(), Some((1, B256::repeat_byte(1))));
+    }
+
+    #[test]
+    fn exclusive_history_gate_blocks_append() {
+        let (storage, _dir) = temp_storage();
+        storage.set_earliest_block_number_hash(0, B256::ZERO).unwrap();
+
+        let history_guard = storage.history_gate.write();
+        let (tx, rx) = mpsc::channel();
+        let task_storage = Arc::clone(&storage);
+
+        thread::spawn(move || {
+            let result = task_storage
+                .store_trie_updates(block(1, B256::ZERO), BlockStateDiff::default())
+                .map(|_| ());
+            tx.send(result).unwrap();
+        });
+
+        assert!(rx.recv_timeout(Duration::from_millis(50)).is_err());
+        drop(history_guard);
+        assert_completes(rx);
+    }
+
+    #[test]
+    fn append_lock_serializes_append_writers() {
+        let (storage, _dir) = temp_storage();
+        storage.set_earliest_block_number_hash(0, B256::ZERO).unwrap();
+
+        let append_guard = storage.append_lock.lock();
+        let (tx, rx) = mpsc::channel();
+        let task_storage = Arc::clone(&storage);
+
+        thread::spawn(move || {
+            let result = task_storage
+                .store_trie_updates(block(1, B256::ZERO), BlockStateDiff::default())
+                .map(|_| ());
+            tx.send(result).unwrap();
+        });
+
+        assert!(rx.recv_timeout(Duration::from_millis(50)).is_err());
+        drop(append_guard);
+        assert_completes(rx);
+    }
+
+    #[test]
+    fn prune_history_read_gate_blocks_history_rewrite() {
+        let (storage, _dir) = temp_storage();
+        storage.set_earliest_block_number_hash(0, B256::ZERO).unwrap();
+
+        let _prune_guard = storage.prune_lock.lock();
+        let history_guard = storage.history_gate.read();
+        let (tx, rx) = mpsc::channel();
+        let task_storage = Arc::clone(&storage);
+
+        thread::spawn(move || {
+            let result = task_storage.replace_updates(BlockNumHash::new(0, B256::ZERO), vec![]);
+            tx.send(result).unwrap();
+        });
+
+        assert!(rx.recv_timeout(Duration::from_millis(50)).is_err());
+        drop(history_guard);
+        assert_completes(rx);
+    }
+
+    #[test]
+    fn append_during_prepared_prune_preserves_latest_block() {
+        let (storage, _dir) = temp_storage();
+        storage.set_earliest_block_number_hash(0, B256::ZERO).unwrap();
+        storage.store_trie_updates(block(1, B256::ZERO), BlockStateDiff::default()).unwrap();
+        storage
+            .store_trie_updates(block(2, B256::repeat_byte(1)), BlockStateDiff::default())
+            .unwrap();
+
+        let _prune_guard = storage.prune_lock.lock();
+        let _history_guard = storage.history_gate.read();
+        let prepared =
+            storage.prepare_prune(block(1, B256::ZERO)).unwrap().expect("prepared prune");
+
+        storage
+            .store_trie_updates(block(3, B256::repeat_byte(2)), BlockStateDiff::default())
+            .unwrap();
+        storage.commit_prepared_prune(prepared).unwrap();
+
+        assert_eq!(storage.get_earliest_block_number().unwrap(), Some((1, B256::repeat_byte(1))));
+        assert_eq!(storage.get_latest_block_number().unwrap(), Some((3, B256::repeat_byte(3))));
+        let latest_diff = storage.fetch_trie_updates(3).unwrap();
+        assert!(latest_diff.sorted_trie_updates.account_nodes_ref().is_empty());
+        assert!(latest_diff.sorted_trie_updates.storage_tries_ref().is_empty());
+        assert!(latest_diff.sorted_post_state.accounts.is_empty());
+        assert!(latest_diff.sorted_post_state.storages.is_empty());
+    }
+
+    #[test]
+    fn append_inside_requested_prune_range_survives() {
+        let (storage, _dir) = temp_storage();
+        storage.set_earliest_block_number_hash(0, B256::ZERO).unwrap();
+
+        let address = B256::repeat_byte(0xAA);
+        storage.store_trie_updates(block(1, B256::ZERO), account_update(address, 1)).unwrap();
+        storage
+            .store_trie_updates(block(2, B256::repeat_byte(1)), account_update(address, 2))
+            .unwrap();
+
+        let _prune_guard = storage.prune_lock.lock();
+        let _history_guard = storage.history_gate.read();
+        let prepared = storage
+            .prepare_prune(block(10, B256::repeat_byte(2)))
+            .unwrap()
+            .expect("prepared prune");
+
+        storage
+            .store_trie_updates(block(3, B256::repeat_byte(2)), account_update(address, 3))
+            .unwrap();
+        let counts = storage.commit_prepared_prune(prepared).unwrap();
+
+        assert_eq!(counts.hashed_accounts_written_total, 1);
+        assert_eq!(counts.account_trie_updates_written_total, 0);
+        assert_eq!(counts.storage_trie_updates_written_total, 0);
+        assert_eq!(counts.hashed_storages_written_total, 0);
+        assert_eq!(storage.get_earliest_block_number().unwrap(), Some((2, B256::repeat_byte(2))));
+        assert_eq!(storage.get_latest_block_number().unwrap(), Some((3, B256::repeat_byte(3))));
+
+        let latest_diff = storage.fetch_trie_updates(3).unwrap();
+        assert_eq!(
+            &latest_diff.sorted_post_state.accounts[..],
+            &[(address, Some(Account { nonce: 3, ..Default::default() }))]
+        );
+
+        let mut cursor = storage.account_hashed_cursor(3).unwrap();
+        assert_eq!(
+            cursor.seek(address).unwrap(),
+            Some((address, Account { nonce: 3, ..Default::default() }))
+        );
+    }
+}

--- a/crates/execution/trie/src/db/store.rs
+++ b/crates/execution/trie/src/db/store.rs
@@ -518,7 +518,8 @@ impl MdbxProofsStorage {
         let mut storage_trie_keys = Vec::<StorageTrieKey>::with_capacity(storage_trie_len);
         for (hashed_address, nodes) in sorted_trie_updates.storage_tries_ref() {
             if nodes.is_deleted && append_mode {
-                let mut ro = self.storage_trie_cursor(*hashed_address, block_number - 1)?;
+                let cursor = tx.cursor_dup_read::<StorageTrieHistory>()?;
+                let mut ro = MdbxTrieCursor::new(cursor, block_number - 1, Some(*hashed_address));
                 let keys = self.wipe_and_overlay(
                     tx,
                     block_number,
@@ -546,7 +547,8 @@ impl MdbxProofsStorage {
         let mut hashed_storage_keys = Vec::<HashedStorageKey>::with_capacity(hashed_storage_len);
         for (hashed_address, storage) in sorted_post_state.storages {
             if append_mode && storage.is_wiped() {
-                let mut ro = self.storage_hashed_cursor(hashed_address, block_number - 1)?;
+                let cursor = tx.cursor_dup_read::<HashedStorageHistory>()?;
+                let mut ro = MdbxStorageCursor::new(cursor, block_number - 1, hashed_address);
                 let keys = self.wipe_and_overlay(
                     tx,
                     block_number,
@@ -657,9 +659,12 @@ impl BaseProofsStore for MdbxProofsStorage {
         = MdbxAccountCursor<Dup<'tx, HashedAccountHistory>>
     where
         Self: 'tx;
-    type Tx = <DatabaseEnv as Database>::TX;
+    type Tx<'tx>
+        = <DatabaseEnv as Database>::TX
+    where
+        Self: 'tx;
 
-    fn ro_tx(&self) -> BaseProofsStorageResult<Self::Tx> {
+    fn ro_tx<'tx>(&'tx self) -> BaseProofsStorageResult<Self::Tx<'tx>> {
         Ok(self.env.tx()?)
     }
 
@@ -672,7 +677,7 @@ impl BaseProofsStore for MdbxProofsStorage {
     }
 
     fn storage_trie_cursor<'tx>(
-        &self,
+        &'tx self,
         hashed_address: B256,
         max_block_number: u64,
     ) -> BaseProofsStorageResult<Self::StorageTrieCursor<'tx>> {
@@ -683,7 +688,7 @@ impl BaseProofsStore for MdbxProofsStorage {
     }
 
     fn account_trie_cursor<'tx>(
-        &self,
+        &'tx self,
         max_block_number: u64,
     ) -> BaseProofsStorageResult<Self::AccountTrieCursor<'tx>> {
         let tx = self.env.tx()?;
@@ -693,7 +698,7 @@ impl BaseProofsStore for MdbxProofsStorage {
     }
 
     fn storage_hashed_cursor<'tx>(
-        &self,
+        &'tx self,
         hashed_address: B256,
         max_block_number: u64,
     ) -> BaseProofsStorageResult<Self::StorageCursor<'tx>> {
@@ -704,7 +709,7 @@ impl BaseProofsStore for MdbxProofsStorage {
     }
 
     fn account_hashed_cursor<'tx>(
-        &self,
+        &'tx self,
         max_block_number: u64,
     ) -> BaseProofsStorageResult<Self::AccountHashedCursor<'tx>> {
         let tx = self.env.tx()?;
@@ -713,54 +718,58 @@ impl BaseProofsStore for MdbxProofsStorage {
         Ok(MdbxAccountCursor::new(cursor, max_block_number))
     }
 
-    fn storage_trie_cursor_with_tx<'tx>(
+    fn storage_trie_cursor_with_tx<'tx, 'db>(
         &self,
-        tx: &'tx Self::Tx,
+        tx: &'tx Self::Tx<'db>,
         hashed_address: B256,
         max_block_number: u64,
     ) -> BaseProofsStorageResult<Self::StorageTrieCursor<'tx>>
     where
-        Self: 'tx,
+        Self: 'db,
+        'db: 'tx,
     {
         let cursor = tx.cursor_dup_read::<StorageTrieHistory>()?;
 
         Ok(MdbxTrieCursor::new(cursor, max_block_number, Some(hashed_address)))
     }
 
-    fn account_trie_cursor_with_tx<'tx>(
+    fn account_trie_cursor_with_tx<'tx, 'db>(
         &self,
-        tx: &'tx Self::Tx,
+        tx: &'tx Self::Tx<'db>,
         max_block_number: u64,
     ) -> BaseProofsStorageResult<Self::AccountTrieCursor<'tx>>
     where
-        Self: 'tx,
+        Self: 'db,
+        'db: 'tx,
     {
         let cursor = tx.cursor_dup_read::<AccountTrieHistory>()?;
 
         Ok(MdbxTrieCursor::new(cursor, max_block_number, None))
     }
 
-    fn storage_hashed_cursor_with_tx<'tx>(
+    fn storage_hashed_cursor_with_tx<'tx, 'db>(
         &self,
-        tx: &'tx Self::Tx,
+        tx: &'tx Self::Tx<'db>,
         hashed_address: B256,
         max_block_number: u64,
     ) -> BaseProofsStorageResult<Self::StorageCursor<'tx>>
     where
-        Self: 'tx,
+        Self: 'db,
+        'db: 'tx,
     {
         let cursor = tx.cursor_dup_read::<HashedStorageHistory>()?;
 
         Ok(MdbxStorageCursor::new(cursor, max_block_number, hashed_address))
     }
 
-    fn account_hashed_cursor_with_tx<'tx>(
+    fn account_hashed_cursor_with_tx<'tx, 'db>(
         &self,
-        tx: &'tx Self::Tx,
+        tx: &'tx Self::Tx<'db>,
         max_block_number: u64,
     ) -> BaseProofsStorageResult<Self::AccountHashedCursor<'tx>>
     where
-        Self: 'tx,
+        Self: 'db,
+        'db: 'tx,
     {
         let cursor = tx.cursor_dup_read::<HashedAccountHistory>()?;
 

--- a/crates/execution/trie/src/in_memory.rs
+++ b/crates/execution/trie/src/in_memory.rs
@@ -539,7 +539,10 @@ impl BaseProofsStore for InMemoryProofsStorage {
     type AccountTrieCursor<'tx> = InMemoryTrieCursor;
     type StorageCursor<'tx> = InMemoryStorageCursor;
     type AccountHashedCursor<'tx> = InMemoryAccountCursor;
-    type Tx = ();
+    type Tx<'tx>
+        = ()
+    where
+        Self: 'tx;
 
     fn get_earliest_block_number(&self) -> BaseProofsStorageResult<Option<(u64, B256)>> {
         let inner = self.inner.read();
@@ -554,7 +557,7 @@ impl BaseProofsStore for InMemoryProofsStorage {
     }
 
     fn storage_trie_cursor<'tx>(
-        &self,
+        &'tx self,
         hashed_address: B256,
         max_block_number: u64,
     ) -> BaseProofsStorageResult<Self::StorageTrieCursor<'tx>> {
@@ -562,14 +565,14 @@ impl BaseProofsStore for InMemoryProofsStorage {
     }
 
     fn account_trie_cursor<'tx>(
-        &self,
+        &'tx self,
         max_block_number: u64,
     ) -> BaseProofsStorageResult<Self::AccountTrieCursor<'tx>> {
         Ok(InMemoryTrieCursor::new(Arc::clone(&self.inner), None, max_block_number))
     }
 
     fn storage_hashed_cursor<'tx>(
-        &self,
+        &'tx self,
         hashed_address: B256,
         max_block_number: u64,
     ) -> BaseProofsStorageResult<Self::StorageCursor<'tx>> {
@@ -577,59 +580,63 @@ impl BaseProofsStore for InMemoryProofsStorage {
     }
 
     fn account_hashed_cursor<'tx>(
-        &self,
+        &'tx self,
         max_block_number: u64,
     ) -> BaseProofsStorageResult<Self::AccountHashedCursor<'tx>> {
         let inner = self.inner.try_read().ok_or(BaseProofsStorageError::TryLockError)?;
         Ok(InMemoryAccountCursor::new(&inner, max_block_number))
     }
 
-    fn ro_tx(&self) -> BaseProofsStorageResult<Self::Tx> {
+    fn ro_tx<'tx>(&'tx self) -> BaseProofsStorageResult<Self::Tx<'tx>> {
         Ok(())
     }
 
-    fn storage_trie_cursor_with_tx<'tx>(
+    fn storage_trie_cursor_with_tx<'tx, 'db>(
         &self,
-        _tx: &'tx Self::Tx,
+        _tx: &'tx Self::Tx<'db>,
         hashed_address: B256,
         max_block_number: u64,
     ) -> BaseProofsStorageResult<Self::StorageTrieCursor<'tx>>
     where
-        Self: 'tx,
+        Self: 'db,
+        'db: 'tx,
     {
         self.storage_trie_cursor(hashed_address, max_block_number)
     }
 
-    fn account_trie_cursor_with_tx<'tx>(
+    fn account_trie_cursor_with_tx<'tx, 'db>(
         &self,
-        _tx: &'tx Self::Tx,
+        _tx: &'tx Self::Tx<'db>,
         max_block_number: u64,
     ) -> BaseProofsStorageResult<Self::AccountTrieCursor<'tx>>
     where
-        Self: 'tx,
+        Self: 'db,
+        'db: 'tx,
     {
         self.account_trie_cursor(max_block_number)
     }
 
-    fn storage_hashed_cursor_with_tx<'tx>(
+    fn storage_hashed_cursor_with_tx<'tx, 'db>(
         &self,
-        _tx: &'tx Self::Tx,
+        _tx: &'tx Self::Tx<'db>,
         hashed_address: B256,
         max_block_number: u64,
     ) -> BaseProofsStorageResult<Self::StorageCursor<'tx>>
     where
-        Self: 'tx,
+        Self: 'db,
+        'db: 'tx,
     {
         self.storage_hashed_cursor(hashed_address, max_block_number)
     }
 
-    fn account_hashed_cursor_with_tx<'tx>(
+    fn account_hashed_cursor_with_tx<'tx, 'db>(
         &self,
-        _tx: &'tx Self::Tx,
+        _tx: &'tx Self::Tx<'db>,
         max_block_number: u64,
     ) -> BaseProofsStorageResult<Self::AccountHashedCursor<'tx>>
     where
-        Self: 'tx,
+        Self: 'db,
+        'db: 'tx,
     {
         self.account_hashed_cursor(max_block_number)
     }

--- a/crates/execution/trie/src/initialize.rs
+++ b/crates/execution/trie/src/initialize.rs
@@ -481,7 +481,7 @@ mod tests {
     use tempfile::TempDir;
 
     use super::*;
-    use crate::MdbxProofsStorage;
+    use crate::RocksdbProofsStorage;
 
     /// Helper function to create a key
     fn k(b: u8) -> B256 {
@@ -509,7 +509,7 @@ mod tests {
     fn test_initialize_hashed_accounts() {
         let db = create_test_rw_db();
         let dir = TempDir::new().unwrap();
-        let storage = Arc::new(MdbxProofsStorage::new(dir.path()).expect("env"));
+        let storage = Arc::new(RocksdbProofsStorage::new(dir.path()).expect("env"));
 
         // Insert test accounts into database
         let tx = db.tx_mut().unwrap();
@@ -560,7 +560,7 @@ mod tests {
     fn test_initialize_hashed_storage() {
         let db = create_test_rw_db();
         let dir = TempDir::new().unwrap();
-        let storage = Arc::new(MdbxProofsStorage::new(dir.path()).expect("env"));
+        let storage = Arc::new(RocksdbProofsStorage::new(dir.path()).expect("env"));
 
         // Insert test storage into database
         let tx = db.tx_mut().unwrap();
@@ -619,7 +619,7 @@ mod tests {
     fn test_initialize_accounts_trie() {
         let db = create_test_rw_db();
         let dir = TempDir::new().unwrap();
-        let storage = Arc::new(MdbxProofsStorage::new(dir.path()).expect("env"));
+        let storage = Arc::new(RocksdbProofsStorage::new(dir.path()).expect("env"));
 
         // Insert test trie nodes into database
         let tx = db.tx_mut().unwrap();
@@ -657,7 +657,7 @@ mod tests {
     fn test_initialize_storages_trie() {
         let db = create_test_rw_db();
         let dir = TempDir::new().unwrap();
-        let storage = Arc::new(MdbxProofsStorage::new(dir.path()).expect("env"));
+        let storage = Arc::new(RocksdbProofsStorage::new(dir.path()).expect("env"));
 
         // Insert test storage trie nodes into database
         let tx = db.tx_mut().unwrap();
@@ -726,7 +726,7 @@ mod tests {
     fn test_full_initialize_run() {
         let db = create_test_rw_db();
         let dir = TempDir::new().unwrap();
-        let storage = Arc::new(MdbxProofsStorage::new(dir.path()).expect("env"));
+        let storage = Arc::new(RocksdbProofsStorage::new(dir.path()).expect("env"));
 
         // Insert some test data
         let tx = db.tx_mut().unwrap();
@@ -807,7 +807,7 @@ mod tests {
     fn test_initialize_run_skips_if_already_done() {
         let db = create_test_rw_db();
         let dir = TempDir::new().unwrap();
-        let storage = Arc::new(MdbxProofsStorage::new(dir.path()).expect("env"));
+        let storage = Arc::new(RocksdbProofsStorage::new(dir.path()).expect("env"));
 
         // set and commit initial state anchor
         storage
@@ -840,7 +840,7 @@ mod tests {
     fn test_initialize_resumes_hashed_accounts_with_no_dups() {
         let db = create_test_rw_db();
         let dir = TempDir::new().unwrap();
-        let store = Arc::new(MdbxProofsStorage::new(dir.path()).expect("env"));
+        let store = Arc::new(RocksdbProofsStorage::new(dir.path()).expect("env"));
 
         store.set_initial_state_anchor(BlockNumHash::new(0, B256::default())).expect("set anchor");
 
@@ -920,7 +920,7 @@ mod tests {
     fn test_initialize_resumes_hashed_storages_with_no_dups() {
         let db = create_test_rw_db();
         let dir = TempDir::new().unwrap();
-        let store = Arc::new(MdbxProofsStorage::new(dir.path()).expect("env"));
+        let store = Arc::new(RocksdbProofsStorage::new(dir.path()).expect("env"));
 
         store.set_initial_state_anchor(BlockNumHash::new(0, B256::default())).expect("set anchor");
 
@@ -1011,7 +1011,7 @@ mod tests {
     fn test_initialize_resumes_accounts_trie_with_no_dups() {
         let db = create_test_rw_db();
         let dir = TempDir::new().unwrap();
-        let store = Arc::new(MdbxProofsStorage::new(dir.path()).expect("env"));
+        let store = Arc::new(RocksdbProofsStorage::new(dir.path()).expect("env"));
 
         store.set_initial_state_anchor(BlockNumHash::new(0, B256::default())).expect("set anchor");
 
@@ -1079,7 +1079,7 @@ mod tests {
     fn test_initialize_resumes_storages_trie_with_no_dups() {
         let db = create_test_rw_db();
         let dir = TempDir::new().unwrap();
-        let store = Arc::new(MdbxProofsStorage::new(dir.path()).expect("env"));
+        let store = Arc::new(RocksdbProofsStorage::new(dir.path()).expect("env"));
 
         store.set_initial_state_anchor(BlockNumHash::new(0, B256::default())).expect("set anchor");
 

--- a/crates/execution/trie/src/lib.rs
+++ b/crates/execution/trie/src/lib.rs
@@ -23,7 +23,10 @@ pub use in_memory::{
 };
 
 pub mod db;
-pub use db::{MdbxAccountCursor, MdbxProofsStorage, MdbxStorageCursor, MdbxTrieCursor};
+pub use db::{
+    MdbxAccountCursor, MdbxProofsStorage, MdbxStorageCursor, MdbxTrieCursor, RocksdbAccountCursor,
+    RocksdbProofsStorage, RocksdbReadSnapshot, RocksdbStorageCursor, RocksdbTrieCursor,
+};
 
 pub mod metrics;
 #[cfg(feature = "metrics")]

--- a/crates/execution/trie/src/metrics.rs
+++ b/crates/execution/trie/src/metrics.rs
@@ -320,7 +320,10 @@ where
         = BaseProofsHashedCursorWithMetrics<S::AccountHashedCursor<'tx>>
     where
         Self: 'tx;
-    type Tx = S::Tx;
+    type Tx<'tx>
+        = S::Tx<'tx>
+    where
+        Self: 'tx;
 
     #[inline]
     fn get_earliest_block_number(&self) -> BaseProofsStorageResult<Option<(u64, B256)>> {
@@ -334,7 +337,7 @@ where
 
     #[inline]
     fn storage_trie_cursor<'tx>(
-        &self,
+        &'tx self,
         hashed_address: B256,
         max_block_number: u64,
     ) -> BaseProofsStorageResult<Self::StorageTrieCursor<'tx>> {
@@ -344,7 +347,7 @@ where
 
     #[inline]
     fn account_trie_cursor<'tx>(
-        &self,
+        &'tx self,
         max_block_number: u64,
     ) -> BaseProofsStorageResult<Self::AccountTrieCursor<'tx>> {
         let cursor = self.storage.account_trie_cursor(max_block_number)?;
@@ -353,7 +356,7 @@ where
 
     #[inline]
     fn storage_hashed_cursor<'tx>(
-        &self,
+        &'tx self,
         hashed_address: B256,
         max_block_number: u64,
     ) -> BaseProofsStorageResult<Self::StorageCursor<'tx>> {
@@ -363,7 +366,7 @@ where
 
     #[inline]
     fn account_hashed_cursor<'tx>(
-        &self,
+        &'tx self,
         max_block_number: u64,
     ) -> BaseProofsStorageResult<Self::AccountHashedCursor<'tx>> {
         let cursor = self.storage.account_hashed_cursor(max_block_number)?;
@@ -371,21 +374,22 @@ where
     }
 
     #[inline]
-    fn ro_tx(&self) -> BaseProofsStorageResult<Self::Tx> {
+    fn ro_tx<'tx>(&'tx self) -> BaseProofsStorageResult<Self::Tx<'tx>> {
         let tx = self.storage.ro_tx()?;
         self.tx_acquisitions.fetch_add(1, Ordering::Relaxed);
         Ok(tx)
     }
 
     #[inline]
-    fn storage_trie_cursor_with_tx<'tx>(
+    fn storage_trie_cursor_with_tx<'tx, 'db>(
         &self,
-        tx: &'tx Self::Tx,
+        tx: &'tx Self::Tx<'db>,
         hashed_address: B256,
         max_block_number: u64,
     ) -> BaseProofsStorageResult<Self::StorageTrieCursor<'tx>>
     where
-        Self: 'tx,
+        Self: 'db,
+        'db: 'tx,
     {
         let cursor =
             self.storage.storage_trie_cursor_with_tx(tx, hashed_address, max_block_number)?;
@@ -393,27 +397,29 @@ where
     }
 
     #[inline]
-    fn account_trie_cursor_with_tx<'tx>(
+    fn account_trie_cursor_with_tx<'tx, 'db>(
         &self,
-        tx: &'tx Self::Tx,
+        tx: &'tx Self::Tx<'db>,
         max_block_number: u64,
     ) -> BaseProofsStorageResult<Self::AccountTrieCursor<'tx>>
     where
-        Self: 'tx,
+        Self: 'db,
+        'db: 'tx,
     {
         let cursor = self.storage.account_trie_cursor_with_tx(tx, max_block_number)?;
         Ok(BaseProofsTrieCursorWithMetrics::new(cursor, Arc::clone(&self.metrics)))
     }
 
     #[inline]
-    fn storage_hashed_cursor_with_tx<'tx>(
+    fn storage_hashed_cursor_with_tx<'tx, 'db>(
         &self,
-        tx: &'tx Self::Tx,
+        tx: &'tx Self::Tx<'db>,
         hashed_address: B256,
         max_block_number: u64,
     ) -> BaseProofsStorageResult<Self::StorageCursor<'tx>>
     where
-        Self: 'tx,
+        Self: 'db,
+        'db: 'tx,
     {
         let cursor =
             self.storage.storage_hashed_cursor_with_tx(tx, hashed_address, max_block_number)?;
@@ -421,13 +427,14 @@ where
     }
 
     #[inline]
-    fn account_hashed_cursor_with_tx<'tx>(
+    fn account_hashed_cursor_with_tx<'tx, 'db>(
         &self,
-        tx: &'tx Self::Tx,
+        tx: &'tx Self::Tx<'db>,
         max_block_number: u64,
     ) -> BaseProofsStorageResult<Self::AccountHashedCursor<'tx>>
     where
-        Self: 'tx,
+        Self: 'db,
+        'db: 'tx,
     {
         let cursor = self.storage.account_hashed_cursor_with_tx(tx, max_block_number)?;
         Ok(BaseProofsHashedCursorWithMetrics::new(cursor, Arc::clone(&self.metrics)))
@@ -453,8 +460,11 @@ where
         &self,
         new_earliest_block_ref: BlockWithParent,
     ) -> BaseProofsStorageResult<WriteCounts> {
-        BlockMetrics::earliest_number().set(new_earliest_block_ref.block.number as f64);
-        self.storage.prune_earliest_state(new_earliest_block_ref)
+        let result = self.storage.prune_earliest_state(new_earliest_block_ref)?;
+        if let Some((block_number, _)) = self.storage.get_earliest_block_number()? {
+            BlockMetrics::earliest_number().set(block_number as f64);
+        }
+        Ok(result)
     }
 
     #[inline]

--- a/crates/execution/trie/src/proof.rs
+++ b/crates/execution/trie/src/proof.rs
@@ -25,13 +25,14 @@ use crate::{
 };
 
 /// Build the trie + hashed cursor factories sharing one read transaction at the given block.
-const fn from_tx<'tx, S>(
-    storage: &'tx BaseProofsStorage<S>,
-    tx: &'tx <BaseProofsStorage<S> as BaseProofsStore>::Tx,
+const fn from_tx<'tx, 'db, S>(
+    storage: &'db BaseProofsStorage<S>,
+    tx: &'tx <BaseProofsStorage<S> as BaseProofsStore>::Tx<'db>,
     block_number: u64,
-) -> (BaseProofsTrieCursorFactory<'tx, S>, BaseProofsHashedAccountCursorFactory<'tx, S>)
+) -> (BaseProofsTrieCursorFactory<'tx, 'db, S>, BaseProofsHashedAccountCursorFactory<'tx, 'db, S>)
 where
-    S: BaseProofsStore + 'tx,
+    S: BaseProofsStore + 'db,
+    'db: 'tx,
 {
     (
         BaseProofsTrieCursorFactory::new(storage, tx, block_number),
@@ -60,7 +61,10 @@ pub trait DatabaseProof<'tx, S: BaseProofsStore + 'tx> {
 }
 
 impl<'tx, S> DatabaseProof<'tx, S>
-    for Proof<BaseProofsTrieCursorFactory<'tx, S>, BaseProofsHashedAccountCursorFactory<'tx, S>>
+    for Proof<
+        BaseProofsTrieCursorFactory<'tx, 'tx, S>,
+        BaseProofsHashedAccountCursorFactory<'tx, 'tx, S>,
+    >
 where
     S: BaseProofsStore + 'tx + Clone,
 {
@@ -130,8 +134,8 @@ pub trait DatabaseStorageProof<'tx, S: BaseProofsStore + 'tx> {
 impl<'tx, S> DatabaseStorageProof<'tx, S>
     for proof::StorageProof<
         'static,
-        BaseProofsTrieCursorFactory<'tx, S>,
-        BaseProofsHashedAccountCursorFactory<'tx, S>,
+        BaseProofsTrieCursorFactory<'tx, 'tx, S>,
+        BaseProofsHashedAccountCursorFactory<'tx, 'tx, S>,
     >
 where
     S: BaseProofsStore + 'tx + Clone,
@@ -226,7 +230,10 @@ pub trait DatabaseStateRoot<'tx, S: BaseProofsStore + 'tx + Clone>: Sized {
 }
 
 impl<'tx, S> DatabaseStateRoot<'tx, S>
-    for StateRoot<BaseProofsTrieCursorFactory<'tx, S>, BaseProofsHashedAccountCursorFactory<'tx, S>>
+    for StateRoot<
+        BaseProofsTrieCursorFactory<'tx, 'tx, S>,
+        BaseProofsHashedAccountCursorFactory<'tx, 'tx, S>,
+    >
 where
     S: BaseProofsStore + 'tx + Clone,
 {
@@ -312,8 +319,8 @@ pub trait DatabaseStorageRoot<'tx, S: BaseProofsStore + 'tx + Clone> {
 
 impl<'tx, S> DatabaseStorageRoot<'tx, S>
     for StorageRoot<
-        BaseProofsTrieCursorFactory<'tx, S>,
-        BaseProofsHashedAccountCursorFactory<'tx, S>,
+        BaseProofsTrieCursorFactory<'tx, 'tx, S>,
+        BaseProofsHashedAccountCursorFactory<'tx, 'tx, S>,
     >
 where
     S: BaseProofsStore + 'tx + Clone,
@@ -353,8 +360,8 @@ pub trait DatabaseTrieWitness<'tx, S: BaseProofsStore + 'tx + Clone> {
 
 impl<'tx, S> DatabaseTrieWitness<'tx, S>
     for TrieWitness<
-        BaseProofsTrieCursorFactory<'tx, S>,
-        BaseProofsHashedAccountCursorFactory<'tx, S>,
+        BaseProofsTrieCursorFactory<'tx, 'tx, S>,
+        BaseProofsHashedAccountCursorFactory<'tx, 'tx, S>,
     >
 where
     S: BaseProofsStore + 'tx + Clone,

--- a/crates/execution/trie/src/provider.rs
+++ b/crates/execution/trie/src/provider.rs
@@ -234,14 +234,13 @@ mod tests {
     #[test]
     fn test_base_proofs_state_provider_ref_debug() {
         let latest: Box<dyn StateProvider + Send> = Box::<NoopProvider>::default();
-        let storage: crate::BaseProofsStorage<InMemoryProofsStorage> =
-            InMemoryProofsStorage::new().into();
+        let storage: crate::BaseProofsStorage<InMemoryProofsStorage> = InMemoryProofsStorage::new();
         let block_number = 42u64;
 
         let provider = BaseProofsStateProviderRef::new(latest, &storage, block_number);
 
         assert_eq!(
-            format!("{:?}", provider),
+            format!("{provider:?}"),
             "BaseProofsStateProviderRef { storage: InMemoryProofsStorage { inner: RwLock { data: InMemoryStorageInner { account_branches: {}, storage_branches: {}, hashed_accounts: {}, hashed_storages: {}, trie_updates: {}, post_states: {}, earliest_block: None, anchor_block: None } } }, block_number: 42 }"
         );
     }

--- a/crates/execution/trie/src/prune/pruner.rs
+++ b/crates/execution/trie/src/prune/pruner.rs
@@ -20,8 +20,8 @@ pub struct BaseProofStoragePruner<P, H> {
     provider: BaseProofsStorage<P>,
     /// Reader to fetch block hash by block number
     block_hash_reader: H,
-    /// Keep at least these many recent blocks
-    min_block_interval: u64,
+    /// Keep at least these many recent blocks.
+    retention_blocks: u64,
     /// Maximum number of blocks to prune in one database transaction
     prune_batch_size: u64,
 }
@@ -31,10 +31,15 @@ impl<P, H> BaseProofStoragePruner<P, H> {
     pub const fn new(
         provider: BaseProofsStorage<P>,
         block_hash_reader: H,
-        min_block_interval: u64,
+        retention_blocks: u64,
         prune_batch_size: u64,
     ) -> Self {
-        Self { provider, block_hash_reader, min_block_interval, prune_batch_size }
+        assert!(prune_batch_size > 0, "prune batch size must be greater than zero");
+        Self { provider, block_hash_reader, retention_blocks, prune_batch_size }
+    }
+
+    const fn target_earliest_block(&self, latest_block: u64) -> u64 {
+        latest_block.saturating_sub(self.retention_blocks)
     }
 }
 
@@ -59,19 +64,27 @@ where
         let latest_block = latest_block_opt.unwrap().0;
         let earliest_block = earliest_block_opt.unwrap().0;
 
-        let interval = latest_block.saturating_sub(earliest_block);
-        if interval <= self.min_block_interval {
+        let target_earliest_block = self.target_earliest_block(latest_block);
+        info!(
+            target: "trie::pruner",
+            earliest_block,
+            latest_block,
+            target_earliest_block,
+            retention_blocks = self.retention_blocks,
+            prune_batch_size = self.prune_batch_size,
+            "Calculated proof storage pruning target",
+        );
+        if earliest_block >= target_earliest_block {
             trace!(target: "trie::pruner", "Nothing to prune");
             return Ok(PrunerOutput::default());
         }
-
-        // at this point `latest_block` is always greater than `min_block_interval`
-        let target_earliest_block = latest_block - self.min_block_interval;
 
         info!(
             target: "trie::pruner",
             from_block = earliest_block,
             to_block = target_earliest_block,
+            latest_block,
+            retention_blocks = self.retention_blocks,
            "Starting pruning proof storage",
         );
 
@@ -85,8 +98,18 @@ where
         // Prune in batches
         while current_earliest_block < target_earliest_block {
             // Calculate the end of this batch
-            let batch_end_block =
-                cmp::min(current_earliest_block + self.prune_batch_size, target_earliest_block);
+            let batch_end_block = cmp::min(
+                current_earliest_block.saturating_add(self.prune_batch_size),
+                target_earliest_block,
+            );
+            info!(
+                target: "trie::pruner",
+                start_block = current_earliest_block,
+                end_block = batch_end_block,
+                target_earliest_block,
+                batch_size = batch_end_block.saturating_sub(current_earliest_block),
+                "Starting proof storage prune batch",
+            );
 
             let batch_output = self.prune_batch(current_earliest_block, batch_end_block)?;
 
@@ -102,6 +125,26 @@ where
     /// Prunes a single batch of blocks.
     fn prune_batch(&self, start_block: u64, end_block: u64) -> Result<PrunerOutput, PrunerError> {
         let batch_start_time = Instant::now();
+        info!(
+            target: "trie::pruner",
+            start_block,
+            end_block,
+            "Resolving proof storage prune batch block hashes",
+        );
+        if end_block == 0 {
+            trace!(
+                target: "trie::pruner",
+                start_block,
+                end_block,
+                "Skipping proof storage prune batch at genesis block",
+            );
+            return Ok(PrunerOutput {
+                duration: batch_start_time.elapsed(),
+                start_block,
+                end_block,
+                ..Default::default()
+            });
+        }
 
         // Fetch block hashes for the new earliest block of this batch
         let new_earliest_block_hash = self
@@ -131,14 +174,27 @@ where
             })?
             .ok_or(PrunerError::BlockNotFound(parent_block_num))?;
 
-        batch_start_time.elapsed();
-
         let block_with_parent = BlockWithParent {
             parent: parent_block_hash,
             block: BlockNumHash { number: end_block, hash: new_earliest_block_hash },
         };
 
-        // Commit this batch
+        info!(
+            target: "trie::pruner",
+            start_block,
+            end_block,
+            block_hash = ?new_earliest_block_hash,
+            parent_block = parent_block_num,
+            parent_hash = ?parent_block_hash,
+            "Resolved proof storage prune batch block hashes",
+        );
+
+        info!(
+            target: "trie::pruner",
+            start_block,
+            end_block,
+            "Applying proof storage prune batch",
+        );
         let write_counts = self.provider.prune_earliest_state(block_with_parent)?;
 
         let duration = batch_start_time.elapsed();
@@ -183,7 +239,7 @@ mod tests {
     use tempfile::TempDir;
 
     use super::*;
-    use crate::{BlockStateDiff, db::MdbxProofsStorage};
+    use crate::{BlockStateDiff, db::RocksdbProofsStorage};
 
     mock! (
         #[derive(Debug)]
@@ -209,6 +265,20 @@ mod tests {
         keccak256(n.to_be_bytes())
     }
 
+    #[cfg(not(feature = "metrics"))]
+    fn clone_storage(
+        storage: &BaseProofsStorage<Arc<RocksdbProofsStorage>>,
+    ) -> BaseProofsStorage<Arc<RocksdbProofsStorage>> {
+        Arc::clone(storage)
+    }
+
+    #[cfg(feature = "metrics")]
+    fn clone_storage(
+        storage: &BaseProofsStorage<Arc<RocksdbProofsStorage>>,
+    ) -> BaseProofsStorage<Arc<RocksdbProofsStorage>> {
+        storage.clone()
+    }
+
     /// Build a block-with-parent for number `n` with deterministic hash.
     fn block(n: u64, parent: B256) -> BlockWithParent {
         BlockWithParent::new(parent, NumHash::new(n, b256(n)))
@@ -218,8 +288,8 @@ mod tests {
     async fn run_inner_and_and_verify_updated_state() {
         // --- env/store ---
         let dir = TempDir::new().unwrap();
-        let store: BaseProofsStorage<Arc<MdbxProofsStorage>> =
-            BaseProofsStorage::from(Arc::new(MdbxProofsStorage::new(dir.path()).expect("env")));
+        let store: BaseProofsStorage<Arc<RocksdbProofsStorage>> =
+            BaseProofsStorage::from(Arc::new(RocksdbProofsStorage::new(dir.path()).expect("env")));
 
         store.set_earliest_block_number(0, B256::ZERO).expect("set earliest");
 
@@ -417,7 +487,7 @@ mod tests {
             .withf(move |block_num| *block_num == 3)
             .returning(move |_| Ok(Some(b256(3))));
 
-        let pruner = BaseProofStoragePruner::new(store.clone(), block_hash_reader, 1, 1000);
+        let pruner = BaseProofStoragePruner::new(clone_storage(&store), block_hash_reader, 1, 1000);
         let out = pruner.run_inner().expect("pruner ok");
         assert_eq!(out.start_block, 0);
         assert_eq!(out.end_block, 4, "pruned up to 4 (inclusive); new earliest is 4");
@@ -506,8 +576,8 @@ mod tests {
     #[tokio::test]
     async fn run_inner_where_latest_block_is_none() {
         let dir = TempDir::new().unwrap();
-        let store: BaseProofsStorage<Arc<MdbxProofsStorage>> =
-            BaseProofsStorage::from(Arc::new(MdbxProofsStorage::new(dir.path()).expect("env")));
+        let store: BaseProofsStorage<Arc<RocksdbProofsStorage>> =
+            BaseProofsStorage::from(Arc::new(RocksdbProofsStorage::new(dir.path()).expect("env")));
 
         let earliest = store.get_earliest_block_number().unwrap();
         let latest = store.get_latest_block_number().unwrap();
@@ -524,8 +594,8 @@ mod tests {
     #[tokio::test]
     async fn run_inner_earliest_none_real_db() {
         let dir = TempDir::new().unwrap();
-        let store: BaseProofsStorage<Arc<MdbxProofsStorage>> =
-            BaseProofsStorage::from(Arc::new(MdbxProofsStorage::new(dir.path()).expect("env")));
+        let store: BaseProofsStorage<Arc<RocksdbProofsStorage>> =
+            BaseProofsStorage::from(Arc::new(RocksdbProofsStorage::new(dir.path()).expect("env")));
 
         // Write a single block to set *latest* only.
         store
@@ -547,8 +617,8 @@ mod tests {
     #[tokio::test]
     async fn run_inner_interval_too_small_real_db() {
         let dir = TempDir::new().unwrap();
-        let store: BaseProofsStorage<Arc<MdbxProofsStorage>> =
-            BaseProofsStorage::from(Arc::new(MdbxProofsStorage::new(dir.path()).expect("env")));
+        let store: BaseProofsStorage<Arc<RocksdbProofsStorage>> =
+            BaseProofsStorage::from(Arc::new(RocksdbProofsStorage::new(dir.path()).expect("env")));
 
         // Set earliest=4 explicitly
         let earliest_num = 4u64;

--- a/crates/execution/trie/src/prune/task.rs
+++ b/crates/execution/trie/src/prune/task.rs
@@ -14,7 +14,7 @@ const PRUNE_BATCH_SIZE: u64 = 200;
 #[derive(Debug)]
 pub struct BaseProofStoragePrunerTask<P, H> {
     pruner: BaseProofStoragePruner<P, H>,
-    min_block_interval: u64,
+    retention_blocks: u64,
     task_run_interval: Duration,
 }
 
@@ -27,23 +27,19 @@ where
     pub const fn new(
         provider: BaseProofsStorage<P>,
         hash_reader: H,
-        min_block_interval: u64,
+        retention_blocks: u64,
         task_run_interval: Duration,
     ) -> Self {
-        let pruner = BaseProofStoragePruner::new(
-            provider,
-            hash_reader,
-            min_block_interval,
-            PRUNE_BATCH_SIZE,
-        );
-        Self { pruner, min_block_interval, task_run_interval }
+        let pruner =
+            BaseProofStoragePruner::new(provider, hash_reader, retention_blocks, PRUNE_BATCH_SIZE);
+        Self { pruner, retention_blocks, task_run_interval }
     }
 
     /// Run forever (until `cancel`), executing one prune pass per `task_run_interval`.
     pub async fn run(self, mut signal: GracefulShutdown) {
         info!(
             target: "trie::pruner_task",
-            min_block_interval = self.min_block_interval,
+            retention_blocks = self.retention_blocks,
             interval_secs = self.task_run_interval.as_secs(),
             "Starting pruner task"
         );

--- a/crates/execution/trie/tests/branch_cursors/mod.rs
+++ b/crates/execution/trie/tests/branch_cursors/mod.rs
@@ -1,0 +1,693 @@
+//! Branch trie cursor behavior tests.
+
+use serial_test::serial;
+use test_case::test_case;
+
+use super::*;
+
+// =============================================================================
+// 1. Basic Cursor Operations
+// =============================================================================
+
+/// Test cursor operations on empty trie
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_cursor_empty_trie<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let mut cursor = storage.account_trie_cursor(100)?;
+
+    // All operations should return None on empty trie
+    assert!(cursor.seek_exact(Nibbles::default())?.is_none());
+    assert!(cursor.seek(Nibbles::default())?.is_none());
+    assert!(cursor.next()?.is_none());
+    assert!(cursor.current()?.is_none());
+
+    Ok(())
+}
+
+/// Test cursor operations with single entry
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_cursor_single_entry<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let path = nibbles_from(vec![1, 2, 3]);
+    let branch = create_test_branch();
+
+    // Store single entry
+    storage.store_account_branches(vec![(path, Some(branch))])?;
+
+    let mut cursor = storage.account_trie_cursor(100)?;
+
+    // Test seek_exact
+    let result = cursor.seek_exact(path)?.unwrap();
+    assert_eq!(result.0, path);
+
+    // Test current position
+    assert_eq!(cursor.current()?.unwrap(), path);
+
+    // Test next from end should return None
+    assert!(cursor.next()?.is_none());
+
+    Ok(())
+}
+
+/// Test cursor operations with multiple entries
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_cursor_multiple_entries<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let paths = vec![
+        nibbles_from(vec![1]),
+        nibbles_from(vec![1, 2]),
+        nibbles_from(vec![2]),
+        nibbles_from(vec![2, 3]),
+    ];
+    let branch = create_test_branch();
+
+    // Store multiple entries
+    for path in &paths {
+        storage.store_account_branches(vec![(*path, Some(branch.clone()))])?;
+    }
+
+    let mut cursor = storage.account_trie_cursor(100)?;
+
+    // Test that we can iterate through all entries
+    let mut found_paths = Vec::new();
+    while let Some((path, _)) = cursor.next()? {
+        found_paths.push(path);
+    }
+
+    assert_eq!(found_paths.len(), 4);
+    // Paths should be in lexicographic order
+    for i in 0..paths.len() {
+        assert_eq!(found_paths[i], paths[i]);
+    }
+
+    Ok(())
+}
+
+// =============================================================================
+// 2. Seek Operations
+// =============================================================================
+
+/// Test `seek_exact` with existing path
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_seek_exact_existing_path<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let path = nibbles_from(vec![1, 2, 3]);
+    let branch = create_test_branch();
+
+    storage.store_account_branches(vec![(path, Some(branch))])?;
+
+    let mut cursor = storage.account_trie_cursor(100)?;
+    let result = cursor.seek_exact(path)?.unwrap();
+    assert_eq!(result.0, path);
+
+    Ok(())
+}
+
+/// Test `seek_exact` with non-existing path
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_seek_exact_non_existing_path<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let path = nibbles_from(vec![1, 2, 3]);
+    let branch = create_test_branch();
+
+    storage.store_account_branches(vec![(path, Some(branch))])?;
+
+    let mut cursor = storage.account_trie_cursor(100)?;
+    let non_existing = nibbles_from(vec![4, 5, 6]);
+    assert!(cursor.seek_exact(non_existing)?.is_none());
+
+    Ok(())
+}
+
+/// Test `seek_exact` with empty path
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_seek_exact_empty_path<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let path = nibbles_from(vec![]);
+    let branch = create_test_branch();
+
+    storage.store_account_branches(vec![(path, Some(branch))])?;
+
+    let mut cursor = storage.account_trie_cursor(100)?;
+    let result = cursor.seek_exact(Nibbles::default())?.unwrap();
+    assert_eq!(result.0, Nibbles::default());
+
+    Ok(())
+}
+
+/// Test seek to existing path
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_seek_to_existing_path<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let path = nibbles_from(vec![1, 2, 3]);
+    let branch = create_test_branch();
+
+    storage.store_account_branches(vec![(path, Some(branch))])?;
+
+    let mut cursor = storage.account_trie_cursor(100)?;
+    let result = cursor.seek(path)?.unwrap();
+    assert_eq!(result.0, path);
+
+    Ok(())
+}
+
+/// Test seek between existing nodes
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_seek_between_existing_nodes<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let path1 = nibbles_from(vec![1]);
+    let path2 = nibbles_from(vec![3]);
+    let branch = create_test_branch();
+
+    storage.store_account_branches(vec![(path1, Some(branch.clone()))])?;
+    storage.store_account_branches(vec![(path2, Some(branch))])?;
+
+    let mut cursor = storage.account_trie_cursor(100)?;
+    // Seek to path between 1 and 3, should return path 3
+    let seek_path = nibbles_from(vec![2]);
+    let result = cursor.seek(seek_path)?.unwrap();
+    assert_eq!(result.0, path2);
+
+    Ok(())
+}
+
+/// Test seek after all nodes
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_seek_after_all_nodes<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let path = nibbles_from(vec![1]);
+    let branch = create_test_branch();
+
+    storage.store_account_branches(vec![(path, Some(branch))])?;
+
+    let mut cursor = storage.account_trie_cursor(100)?;
+    // Seek to path after all nodes
+    let seek_path = nibbles_from(vec![9]);
+    assert!(cursor.seek(seek_path)?.is_none());
+
+    Ok(())
+}
+
+/// Test seek before all nodes
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_seek_before_all_nodes<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let path = nibbles_from(vec![5]);
+    let branch = create_test_branch();
+
+    storage.store_account_branches(vec![(path, Some(branch))])?;
+
+    let mut cursor = storage.account_trie_cursor(100)?;
+    // Seek to path before all nodes, should return first node
+    let seek_path = nibbles_from(vec![1]);
+    let result = cursor.seek(seek_path)?.unwrap();
+    assert_eq!(result.0, path);
+
+    Ok(())
+}
+
+// =============================================================================
+// 3. Navigation Tests
+// =============================================================================
+
+/// Test next without prior seek
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_next_without_prior_seek<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let path = nibbles_from(vec![1, 2]);
+    let branch = create_test_branch();
+
+    storage.store_account_branches(vec![(path, Some(branch))])?;
+
+    let mut cursor = storage.account_trie_cursor(100)?;
+    // next() without prior seek should start from beginning
+    let result = cursor.next()?.unwrap();
+    assert_eq!(result.0, path);
+
+    Ok(())
+}
+
+/// Test next after seek
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_next_after_seek<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let path1 = nibbles_from(vec![1]);
+    let path2 = nibbles_from(vec![2]);
+    let branch = create_test_branch();
+
+    storage.store_account_branches(vec![(path1, Some(branch.clone()))])?;
+    storage.store_account_branches(vec![(path2, Some(branch))])?;
+
+    let mut cursor = storage.account_trie_cursor(100)?;
+    cursor.seek(path1)?;
+
+    // next() should return second node
+    let result = cursor.next()?.unwrap();
+    assert_eq!(result.0, path2);
+
+    Ok(())
+}
+
+/// Test next at end of trie
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_next_at_end_of_trie<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let path = nibbles_from(vec![1]);
+    let branch = create_test_branch();
+
+    storage.store_account_branches(vec![(path, Some(branch))])?;
+
+    let mut cursor = storage.account_trie_cursor(100)?;
+    cursor.seek(path)?;
+
+    // next() at end should return None
+    assert!(cursor.next()?.is_none());
+
+    Ok(())
+}
+
+/// Test multiple consecutive next calls
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_multiple_consecutive_next<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let paths = vec![nibbles_from(vec![1]), nibbles_from(vec![2]), nibbles_from(vec![3])];
+    let branch = create_test_branch();
+
+    for path in &paths {
+        storage.store_account_branches(vec![(*path, Some(branch.clone()))])?;
+    }
+
+    let mut cursor = storage.account_trie_cursor(100)?;
+
+    // Iterate through all with consecutive next() calls
+    for expected_path in &paths {
+        let result = cursor.next()?.unwrap();
+        assert_eq!(result.0, *expected_path);
+    }
+
+    // Final next() should return None
+    assert!(cursor.next()?.is_none());
+
+    Ok(())
+}
+
+/// Test current after operations
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_current_after_operations<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let path1 = nibbles_from(vec![1]);
+    let path2 = nibbles_from(vec![2]);
+    let branch = create_test_branch();
+
+    storage.store_account_branches(vec![(path1, Some(branch.clone()))])?;
+    storage.store_account_branches(vec![(path2, Some(branch))])?;
+
+    let mut cursor = storage.account_trie_cursor(100)?;
+
+    // Current should be None initially
+    assert!(cursor.current()?.is_none());
+
+    // After seek, current should track position
+    cursor.seek(path1)?;
+    assert_eq!(cursor.current()?.unwrap(), path1);
+
+    // After next, current should update
+    cursor.next()?;
+    assert_eq!(cursor.current()?.unwrap(), path2);
+
+    Ok(())
+}
+
+/// Test current with no prior operations
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_current_no_prior_operations<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let mut cursor = storage.account_trie_cursor(100)?;
+
+    // Current should be None when no operations performed
+    assert!(cursor.current()?.is_none());
+
+    Ok(())
+}
+
+// =============================================================================
+// 4. Block Number Filtering
+// =============================================================================
+
+/// Test same path with different blocks
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_same_path_different_blocks<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let path = nibbles_from(vec![1, 2]);
+    let branch1 = create_test_branch();
+    let branch2 = create_test_branch_variant();
+
+    // Store same path at different blocks
+    storage.store_account_branches(vec![(path, Some(branch1))])?;
+    storage.store_account_branches(vec![(path, Some(branch2))])?;
+
+    // Cursor with max_block_number=75 should see only block 50 data
+    let mut cursor75 = storage.account_trie_cursor(75)?;
+    let result75 = cursor75.seek_exact(path)?.unwrap();
+    assert_eq!(result75.0, path);
+
+    // Cursor with max_block_number=150 should see block 100 data (latest)
+    let mut cursor150 = storage.account_trie_cursor(150)?;
+    let result150 = cursor150.seek_exact(path)?.unwrap();
+    assert_eq!(result150.0, path);
+
+    Ok(())
+}
+
+/// Test deleted branch nodes
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_deleted_branch_nodes<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let path = nibbles_from(vec![1, 2]);
+    let branch = create_test_branch();
+    let block_ref = BlockWithParent::new(B256::ZERO, NumHash::new(100, B256::repeat_byte(0x96)));
+
+    // Store branch node, then delete it (store None)
+    storage.store_account_branches(vec![(path, Some(branch))])?;
+
+    // Cursor before deletion should see the node
+    let mut cursor75 = storage.account_trie_cursor(75)?;
+    assert!(cursor75.seek_exact(path)?.is_some());
+
+    let mut block_state_diff_trie_updates = TrieUpdates::default();
+    block_state_diff_trie_updates.removed_nodes.insert(path);
+    let block_state_diff = BlockStateDiff {
+        sorted_trie_updates: block_state_diff_trie_updates.into_sorted(),
+        sorted_post_state: HashedPostStateSorted::default(),
+    };
+    storage.store_trie_updates(block_ref, block_state_diff)?;
+
+    // Cursor after deletion should not see the node
+    let mut cursor150 = storage.account_trie_cursor(150)?;
+    assert!(cursor150.seek_exact(path)?.is_none());
+
+    Ok(())
+}
+
+// =============================================================================
+// 5. Hashed Address Filtering
+// =============================================================================
+
+/// Test account-specific cursor
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_account_specific_cursor<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let path = nibbles_from(vec![1, 2]);
+    let addr1 = B256::repeat_byte(0x01);
+    let addr2 = B256::repeat_byte(0x02);
+    let branch = create_test_branch();
+
+    // Store same path for different accounts (using storage branches)
+    storage.store_storage_branches(addr1, vec![(path, Some(branch.clone()))])?;
+    storage.store_storage_branches(addr2, vec![(path, Some(branch))])?;
+
+    // Cursor for addr1 should only see addr1 data
+    let mut cursor1 = storage.storage_trie_cursor(addr1, 100)?;
+    let result1 = cursor1.seek_exact(path)?.unwrap();
+    assert_eq!(result1.0, path);
+
+    // Cursor for addr2 should only see addr2 data
+    let mut cursor2 = storage.storage_trie_cursor(addr2, 100)?;
+    let result2 = cursor2.seek_exact(path)?.unwrap();
+    assert_eq!(result2.0, path);
+
+    // Cursor for addr1 should not see addr2 data when iterating
+    let mut cursor1_iter = storage.storage_trie_cursor(addr1, 100)?;
+    let mut found_count = 0;
+    while cursor1_iter.next()?.is_some() {
+        found_count += 1;
+    }
+    assert_eq!(found_count, 1); // Should only see one entry (for addr1)
+
+    Ok(())
+}
+
+/// Test state trie cursor
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_state_trie_cursor<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let path = nibbles_from(vec![1, 2]);
+    let addr = B256::repeat_byte(0x01);
+    let branch = create_test_branch();
+
+    // Store data for account trie and state trie
+    storage.store_storage_branches(addr, vec![(path, Some(branch.clone()))])?;
+    storage.store_account_branches(vec![(path, Some(branch))])?;
+
+    // State trie cursor (None address) should only see state trie data
+    let mut state_cursor = storage.account_trie_cursor(100)?;
+    let result = state_cursor.seek_exact(path)?.unwrap();
+    assert_eq!(result.0, path);
+
+    // Verify state cursor doesn't see account data when iterating
+    let mut state_cursor_iter = storage.account_trie_cursor(100)?;
+    let mut found_count = 0;
+    while state_cursor_iter.next()?.is_some() {
+        found_count += 1;
+    }
+
+    assert_eq!(found_count, 1); // Should only see state trie entry
+
+    Ok(())
+}
+
+/// Test mixed account and state data
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_mixed_account_state_data<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let path1 = nibbles_from(vec![1]);
+    let path2 = nibbles_from(vec![2]);
+    let addr = B256::repeat_byte(0x01);
+    let branch = create_test_branch();
+
+    // Store mixed account and state trie data
+    storage.store_storage_branches(addr, vec![(path1, Some(branch.clone()))])?;
+    storage.store_account_branches(vec![(path2, Some(branch))])?;
+
+    // Account cursor should only see account data
+    let mut account_cursor = storage.storage_trie_cursor(addr, 100)?;
+    let mut account_paths = Vec::new();
+    while let Some((path, _)) = account_cursor.next()? {
+        account_paths.push(path);
+    }
+    assert_eq!(account_paths.len(), 1);
+    assert_eq!(account_paths[0], path1);
+
+    // State cursor should only see state data
+    let mut state_cursor = storage.account_trie_cursor(100)?;
+    let mut state_paths = Vec::new();
+    while let Some((path, _)) = state_cursor.next()? {
+        state_paths.push(path);
+    }
+    assert_eq!(state_paths.len(), 1);
+    assert_eq!(state_paths[0], path2);
+
+    Ok(())
+}
+
+// =============================================================================
+// 6. Path Ordering Tests
+// =============================================================================
+
+/// Test lexicographic ordering
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_lexicographic_ordering<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let paths = vec![
+        nibbles_from(vec![3, 1]),
+        nibbles_from(vec![1, 2]),
+        nibbles_from(vec![2]),
+        nibbles_from(vec![1]),
+    ];
+    let branch = create_test_branch();
+
+    // Store paths in random order
+    for path in &paths {
+        storage.store_account_branches(vec![(*path, Some(branch.clone()))])?;
+    }
+
+    let mut cursor = storage.account_trie_cursor(100)?;
+    let mut found_paths = Vec::new();
+    while let Some((path, _)) = cursor.next()? {
+        found_paths.push(path);
+    }
+
+    // Should be returned in lexicographic order: [1], [1,2], [2], [3,1]
+    let expected_order = vec![
+        nibbles_from(vec![1]),
+        nibbles_from(vec![1, 2]),
+        nibbles_from(vec![2]),
+        nibbles_from(vec![3, 1]),
+    ];
+
+    assert_eq!(found_paths, expected_order);
+
+    Ok(())
+}
+
+/// Test path prefix scenarios
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_path_prefix_scenarios<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let paths = vec![
+        nibbles_from(vec![1]),       // Prefix of next
+        nibbles_from(vec![1, 2]),    // Extends first
+        nibbles_from(vec![1, 2, 3]), // Extends second
+    ];
+    let branch = create_test_branch();
+
+    for path in &paths {
+        storage.store_account_branches(vec![(*path, Some(branch.clone()))])?;
+    }
+
+    let mut cursor = storage.account_trie_cursor(100)?;
+
+    // Seek to prefix should find exact match
+    let result = cursor.seek_exact(paths[0])?.unwrap();
+    assert_eq!(result.0, paths[0]);
+
+    // Next should go to next path, not skip prefixed paths
+    let result = cursor.next()?.unwrap();
+    assert_eq!(result.0, paths[1]);
+
+    let result = cursor.next()?.unwrap();
+    assert_eq!(result.0, paths[2]);
+
+    Ok(())
+}
+
+/// Test complex nibble combinations
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_complex_nibble_combinations<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    // Test various nibble patterns including edge values
+    let paths = vec![
+        nibbles_from(vec![0]),
+        nibbles_from(vec![0, 15]),
+        nibbles_from(vec![15]),
+        nibbles_from(vec![15, 0]),
+        nibbles_from(vec![7, 8, 9]),
+    ];
+    let branch = create_test_branch();
+
+    for path in &paths {
+        storage.store_account_branches(vec![(*path, Some(branch.clone()))])?;
+    }
+
+    let mut cursor = storage.account_trie_cursor(100)?;
+    let mut found_paths = Vec::new();
+    while let Some((path, _)) = cursor.next()? {
+        found_paths.push(path);
+    }
+
+    // All paths should be found and in correct order
+    assert_eq!(found_paths.len(), 5);
+
+    // Verify specific ordering for edge cases
+    assert_eq!(found_paths[0], nibbles_from(vec![0]));
+    assert_eq!(found_paths[1], nibbles_from(vec![0, 15]));
+    assert_eq!(found_paths[4], nibbles_from(vec![15, 0]));
+
+    Ok(())
+}

--- a/crates/execution/trie/tests/hashed_cursors/mod.rs
+++ b/crates/execution/trie/tests/hashed_cursors/mod.rs
@@ -1,0 +1,467 @@
+//! Hashed account and storage cursor behavior tests.
+
+use serial_test::serial;
+use test_case::test_case;
+
+use super::*;
+
+// =============================================================================
+// 7. Leaf Node Tests (Hashed Accounts and Storage)
+// =============================================================================
+
+/// Test store and retrieve single account
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_store_and_retrieve_single_account<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let account_key = B256::repeat_byte(0x01);
+    let account = create_test_account();
+
+    // Store account
+    storage.store_hashed_accounts(vec![(account_key, Some(account))])?;
+
+    // Retrieve via cursor
+    let mut cursor = storage.account_hashed_cursor(100)?;
+    let result = cursor.seek(account_key)?.unwrap();
+
+    assert_eq!(result.0, account_key);
+    assert_eq!(result.1.nonce, account.nonce);
+    assert_eq!(result.1.balance, account.balance);
+    assert_eq!(result.1.bytecode_hash, account.bytecode_hash);
+
+    Ok(())
+}
+
+/// Test account cursor navigation
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_account_cursor_navigation<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let accounts = [
+        (B256::repeat_byte(0x01), create_test_account()),
+        (B256::repeat_byte(0x03), create_test_account()),
+        (B256::repeat_byte(0x05), create_test_account()),
+    ];
+
+    // Store accounts
+    let accounts_to_store: Vec<_> = accounts.iter().map(|(k, v)| (*k, Some(*v))).collect();
+    storage.store_hashed_accounts(accounts_to_store)?;
+
+    let mut cursor = storage.account_hashed_cursor(100)?;
+
+    // Test seeking to exact key
+    let result = cursor.seek(accounts[1].0)?.unwrap();
+    assert_eq!(result.0, accounts[1].0);
+
+    // Test seeking to key that doesn't exist (should return next greater)
+    let seek_key = B256::repeat_byte(0x02);
+    let result = cursor.seek(seek_key)?.unwrap();
+    assert_eq!(result.0, accounts[1].0); // Should find 0x03
+
+    // Test next() navigation
+    let result = cursor.next()?.unwrap();
+    assert_eq!(result.0, accounts[2].0); // Should find 0x05
+
+    // Test next() at end
+    assert!(cursor.next()?.is_none());
+
+    Ok(())
+}
+
+/// Test that a `RocksDB` cursor reads from the snapshot captured when it is created.
+#[test]
+#[serial]
+fn test_rocksdb_account_cursor_uses_creation_snapshot() -> Result<(), BaseProofsStorageError> {
+    let storage = create_rocksdb_proofs_storage();
+    let key1 = B256::repeat_byte(0x01);
+    let key2 = B256::repeat_byte(0x02);
+    let account1 = create_test_account_with_values(1, 100, 0xAA);
+    let account2 = create_test_account_with_values(2, 200, 0xBB);
+
+    let block1 = BlockWithParent::new(B256::ZERO, NumHash::new(1, B256::repeat_byte(0x11)));
+    let mut post_state = HashedPostState::default();
+    post_state.accounts.insert(key1, Some(account1));
+    post_state.accounts.insert(key2, Some(account2));
+    storage.store_trie_updates(
+        block1,
+        BlockStateDiff {
+            sorted_trie_updates: TrieUpdatesSorted::default(),
+            sorted_post_state: post_state.into_sorted(),
+        },
+    )?;
+
+    let mut cursor = storage.account_hashed_cursor(1)?;
+    let first = cursor.seek(key1)?.expect("first account exists");
+    assert_eq!(first.0, key1);
+
+    let replacement_block1 =
+        BlockWithParent::new(B256::ZERO, NumHash::new(1, B256::repeat_byte(0x22)));
+    let mut replacement_post_state = HashedPostState::default();
+    replacement_post_state.accounts.insert(key1, Some(account1));
+    storage.replace_updates(
+        BlockNumHash::new(0, B256::ZERO),
+        vec![(
+            replacement_block1,
+            BlockStateDiff {
+                sorted_trie_updates: TrieUpdatesSorted::default(),
+                sorted_post_state: replacement_post_state.into_sorted(),
+            },
+        )],
+    )?;
+
+    let next = cursor.next()?.expect("existing cursor keeps its original snapshot");
+    assert_eq!(next.0, key2);
+    assert_eq!(next.1.nonce, account2.nonce);
+
+    let mut fresh_cursor = storage.account_hashed_cursor(1)?;
+    let fresh_result = fresh_cursor.seek(key2)?;
+    assert!(
+        !matches!(fresh_result, Some((found_key, _)) if found_key == key2),
+        "fresh cursor should not see the replaced account"
+    );
+
+    Ok(())
+}
+
+/// Test account block versioning
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_account_block_versioning<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let account_key = B256::repeat_byte(0x01);
+    let account_v1 = create_test_account_with_values(1, 100, 0xBB);
+    let account_v2 = create_test_account_with_values(2, 200, 0xDD);
+
+    // Store account at different blocks
+    storage.store_hashed_accounts(vec![(account_key, Some(account_v1))])?;
+
+    // Cursor with max_block_number=75 should see v1
+    let mut cursor75 = storage.account_hashed_cursor(75)?;
+    let result75 = cursor75.seek(account_key)?.unwrap();
+    assert_eq!(result75.1.nonce, account_v1.nonce);
+    assert_eq!(result75.1.balance, account_v1.balance);
+
+    storage.store_hashed_accounts(vec![(account_key, Some(account_v2))])?;
+
+    // After update, Cursor with max_block_number=150 should see v2
+    let mut cursor150 = storage.account_hashed_cursor(150)?;
+    let result150 = cursor150.seek(account_key)?.unwrap();
+    assert_eq!(result150.1.nonce, account_v2.nonce);
+    assert_eq!(result150.1.balance, account_v2.balance);
+
+    Ok(())
+}
+
+/// Test store and retrieve storage
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+
+fn test_store_and_retrieve_storage<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let hashed_address = B256::repeat_byte(0x01);
+    let storage_slots = vec![
+        (B256::repeat_byte(0x10), U256::from(100)),
+        (B256::repeat_byte(0x20), U256::from(200)),
+        (B256::repeat_byte(0x30), U256::from(300)),
+    ];
+
+    // Store storage slots
+    storage.store_hashed_storages(hashed_address, storage_slots.clone())?;
+
+    // Retrieve via cursor
+    let mut cursor = storage.storage_hashed_cursor(hashed_address, 100)?;
+
+    // Test seeking to each slot
+    for (key, expected_value) in &storage_slots {
+        let result = cursor.seek(*key)?.unwrap();
+        assert_eq!(result.0, *key);
+        assert_eq!(result.1, *expected_value);
+    }
+
+    Ok(())
+}
+
+/// Test storage cursor navigation
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_storage_cursor_navigation<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let hashed_address = B256::repeat_byte(0x01);
+    let storage_slots = vec![
+        (B256::repeat_byte(0x10), U256::from(100)),
+        (B256::repeat_byte(0x30), U256::from(300)),
+        (B256::repeat_byte(0x50), U256::from(500)),
+    ];
+
+    storage.store_hashed_storages(hashed_address, storage_slots.clone())?;
+
+    let mut cursor = storage.storage_hashed_cursor(hashed_address, 100)?;
+
+    // Start from beginning with next()
+    let mut found_slots = Vec::new();
+    while let Some((key, value)) = cursor.next()? {
+        found_slots.push((key, value));
+    }
+
+    assert_eq!(found_slots.len(), 3);
+    assert_eq!(found_slots[0], storage_slots[0]);
+    assert_eq!(found_slots[1], storage_slots[1]);
+    assert_eq!(found_slots[2], storage_slots[2]);
+
+    Ok(())
+}
+
+/// Test storage account isolation
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_storage_account_isolation<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let address1 = B256::repeat_byte(0x01);
+    let address2 = B256::repeat_byte(0x02);
+    let storage_key = B256::repeat_byte(0x10);
+
+    // Store same storage key for different accounts
+    storage.store_hashed_storages(address1, vec![(storage_key, U256::from(100))])?;
+    storage.store_hashed_storages(address2, vec![(storage_key, U256::from(200))])?;
+
+    // Verify each account sees only its own storage
+    let mut cursor1 = storage.storage_hashed_cursor(address1, 100)?;
+    let result1 = cursor1.seek(storage_key)?.unwrap();
+    assert_eq!(result1.1, U256::from(100));
+
+    let mut cursor2 = storage.storage_hashed_cursor(address2, 100)?;
+    let result2 = cursor2.seek(storage_key)?.unwrap();
+    assert_eq!(result2.1, U256::from(200));
+
+    // Verify cursor1 doesn't see address2's storage
+    let mut cursor1_iter = storage.storage_hashed_cursor(address1, 100)?;
+    let mut count = 0;
+    while cursor1_iter.next()?.is_some() {
+        count += 1;
+    }
+    assert_eq!(count, 1); // Should only see one entry
+
+    Ok(())
+}
+
+/// Test storage block versioning
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_storage_block_versioning<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let hashed_address = B256::repeat_byte(0x01);
+    let storage_key = B256::repeat_byte(0x10);
+
+    // Store storage at different blocks
+    storage.store_hashed_storages(hashed_address, vec![(storage_key, U256::from(100))])?;
+
+    // Cursor with max_block_number=75 should see old value
+    let mut cursor75 = storage.storage_hashed_cursor(hashed_address, 75)?;
+    let result75 = cursor75.seek(storage_key)?.unwrap();
+    assert_eq!(result75.1, U256::from(100));
+
+    storage.store_hashed_storages(hashed_address, vec![(storage_key, U256::from(200))])?;
+    // Cursor with max_block_number=150 should see new value
+    let mut cursor150 = storage.storage_hashed_cursor(hashed_address, 150)?;
+    let result150 = cursor150.seek(storage_key)?.unwrap();
+    assert_eq!(result150.1, U256::from(200));
+
+    Ok(())
+}
+
+/// Test storage zero value deletion
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_storage_zero_value_deletion<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let hashed_address = B256::repeat_byte(0x01);
+    let storage_key = B256::repeat_byte(0x10);
+
+    // Store non-zero value
+    storage.store_hashed_storages(hashed_address, vec![(storage_key, U256::from(100))])?;
+
+    // Cursor before deletion should see the value
+    let mut cursor75 = storage.storage_hashed_cursor(hashed_address, 75)?;
+    let result75 = cursor75.seek(storage_key)?.unwrap();
+    assert_eq!(result75.1, U256::from(100));
+
+    // "Delete" by storing zero value at block 100
+    let mut block_state_diff_post_state = HashedPostState::default();
+    let mut hashed_storage = HashedStorage::default();
+    hashed_storage.storage.insert(storage_key, U256::ZERO);
+    block_state_diff_post_state.storages.insert(hashed_address, hashed_storage);
+
+    let block_ref = BlockWithParent::new(B256::ZERO, NumHash::new(100, B256::repeat_byte(0x96)));
+    let block_state_diff = BlockStateDiff {
+        sorted_trie_updates: TrieUpdatesSorted::default(),
+        sorted_post_state: block_state_diff_post_state.into_sorted(),
+    };
+    storage.store_trie_updates(block_ref, block_state_diff)?;
+
+    // Cursor after deletion should NOT see the entry (zero values are skipped)
+    let mut cursor150 = storage.storage_hashed_cursor(hashed_address, 150)?;
+    let result150 = cursor150.seek(storage_key)?;
+    assert!(result150.is_none(), "Zero values should be skipped/deleted");
+
+    Ok(())
+}
+
+/// Test that zero values are skipped during iteration
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_storage_cursor_skips_zero_values<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let hashed_address = B256::repeat_byte(0x01);
+
+    // Create a mix of non-zero and zero value storage slots
+    let storage_slots = vec![
+        (B256::repeat_byte(0x10), U256::from(100)), // Non-zero
+        (B256::repeat_byte(0x20), U256::ZERO),      // Zero value - should be skipped
+        (B256::repeat_byte(0x30), U256::from(300)), // Non-zero
+        (B256::repeat_byte(0x40), U256::ZERO),      // Zero value - should be skipped
+        (B256::repeat_byte(0x50), U256::from(500)), // Non-zero
+    ];
+
+    // Store all slots
+    storage.store_hashed_storages(hashed_address, storage_slots)?;
+
+    // Create cursor and iterate through all entries
+    let mut cursor = storage.storage_hashed_cursor(hashed_address, 100)?;
+    let mut found_slots = Vec::new();
+    while let Some((key, value)) = cursor.next()? {
+        found_slots.push((key, value));
+    }
+
+    // Should only find 3 non-zero values
+    assert_eq!(found_slots.len(), 3, "Zero values should be skipped during iteration");
+
+    // Verify the non-zero values are the ones we stored
+    assert_eq!(found_slots[0], (B256::repeat_byte(0x10), U256::from(100)));
+    assert_eq!(found_slots[1], (B256::repeat_byte(0x30), U256::from(300)));
+    assert_eq!(found_slots[2], (B256::repeat_byte(0x50), U256::from(500)));
+
+    // Verify seeking to a zero-value slot returns None or skips to next non-zero
+    let mut seek_cursor = storage.storage_hashed_cursor(hashed_address, 100)?;
+    let seek_result = seek_cursor.seek(B256::repeat_byte(0x20))?;
+
+    // Should either return None or skip to the next non-zero value (0x30)
+    if let Some((key, value)) = seek_result {
+        assert_eq!(key, B256::repeat_byte(0x30), "Should skip zero value and find next non-zero");
+        assert_eq!(value, U256::from(300));
+    }
+
+    Ok(())
+}
+
+/// Test empty cursors
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_empty_cursors<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    // Test empty account cursor
+    let mut account_cursor = storage.account_hashed_cursor(100)?;
+    assert!(account_cursor.seek(B256::repeat_byte(0x01))?.is_none());
+    assert!(account_cursor.next()?.is_none());
+
+    // Test empty storage cursor
+    let mut storage_cursor = storage.storage_hashed_cursor(B256::repeat_byte(0x01), 100)?;
+    assert!(storage_cursor.seek(B256::repeat_byte(0x10))?.is_none());
+    assert!(storage_cursor.next()?.is_none());
+
+    Ok(())
+}
+
+/// Test cursor boundary conditions
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_cursor_boundary_conditions<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let account_key = B256::repeat_byte(0x80); // Middle value
+    let account = create_test_account();
+
+    storage.store_hashed_accounts(vec![(account_key, Some(account))])?;
+
+    let mut cursor = storage.account_hashed_cursor(100)?;
+
+    // Seek to minimum key should find our account
+    let result = cursor.seek(B256::ZERO)?.unwrap();
+    assert_eq!(result.0, account_key);
+
+    // Seek to maximum key should find nothing
+    assert!(cursor.seek(B256::repeat_byte(0xFF))?.is_none());
+
+    // Seek to key just before our account should find our account
+    let just_before = B256::repeat_byte(0x7F);
+    let result = cursor.seek(just_before)?.unwrap();
+    assert_eq!(result.0, account_key);
+
+    Ok(())
+}
+
+/// Test large batch operations
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_large_batch_operations<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    // Create large batch of accounts
+    let mut accounts = Vec::new();
+    for i in 0..100 {
+        let key = B256::from([i as u8; 32]);
+        let account = create_test_account_with_values(i, i * 1000, (i + 1) as u8);
+        accounts.push((key, Some(account)));
+    }
+
+    // Store in batch
+    storage.store_hashed_accounts(accounts.clone())?;
+
+    // Verify all accounts can be retrieved
+    let mut cursor = storage.account_hashed_cursor(100)?;
+    let mut found_count = 0;
+    while cursor.next()?.is_some() {
+        found_count += 1;
+    }
+    assert_eq!(found_count, 100);
+
+    // Test specific account retrieval
+    let test_key = B256::from([42u8; 32]);
+    let result = cursor.seek(test_key)?.unwrap();
+    assert_eq!(result.0, test_key);
+    assert_eq!(result.1.nonce, 42);
+
+    Ok(())
+}

--- a/crates/execution/trie/tests/history/mod.rs
+++ b/crates/execution/trie/tests/history/mod.rs
@@ -1,0 +1,292 @@
+//! History fetch, prune, and unwind behavior tests.
+
+use serial_test::serial;
+use test_case::test_case;
+
+use super::*;
+
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_fetch_trie_updates_basic<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let block_ref = test_block(B256::ZERO, 1, 0x11);
+    let account_address = B256::repeat_byte(0x11);
+    let deleted_account = B256::repeat_byte(0x22);
+    let storage_address = B256::repeat_byte(0x33);
+    let trie_storage_address = B256::repeat_byte(0x44);
+    let slot = B256::repeat_byte(0xA1);
+    let account = Account { nonce: 1, balance: U256::from(100), ..Default::default() };
+
+    let mut trie_updates = TrieUpdates::default();
+    trie_updates.account_nodes.insert(nibbles_from(vec![0, 1, 2, 3]), BranchNodeCompact::default());
+    let mut storage_trie_updates = StorageTrieUpdates::default();
+    storage_trie_updates
+        .storage_nodes
+        .insert(nibbles_from(vec![1, 2, 3, 4]), BranchNodeCompact::default());
+    trie_updates.storage_tries.insert(trie_storage_address, storage_trie_updates);
+
+    let mut post_state = HashedPostState::default();
+    post_state.accounts.insert(account_address, Some(account));
+    post_state.accounts.insert(deleted_account, None);
+    let mut hashed_storage = HashedStorage::default();
+    hashed_storage.storage.insert(slot, U256::from(1234));
+    post_state.storages.insert(storage_address, hashed_storage);
+
+    let expected = BlockStateDiff {
+        sorted_trie_updates: trie_updates.into_sorted(),
+        sorted_post_state: post_state.into_sorted(),
+    };
+    storage.store_trie_updates(block_ref, expected.clone())?;
+
+    let actual = storage.fetch_trie_updates(block_ref.block.number)?;
+    assert_eq!(
+        actual.sorted_trie_updates.account_nodes_ref(),
+        expected.sorted_trie_updates.account_nodes_ref()
+    );
+    assert_eq!(
+        actual.sorted_trie_updates.storage_tries_ref(),
+        expected.sorted_trie_updates.storage_tries_ref()
+    );
+    assert_eq!(actual.sorted_post_state.accounts, expected.sorted_post_state.accounts);
+    assert_eq!(actual.sorted_post_state.storages, expected.sorted_post_state.storages);
+    Ok(())
+}
+
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_store_trie_updates_out_of_order_rejects<
+    S: BaseProofsStore + BaseProofsInitialStateStore,
+>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    storage.set_earliest_block_number(0, B256::ZERO)?;
+    let block_42 = test_block(B256::ZERO, 42, 0x42);
+    storage.store_trie_updates(block_42, BlockStateDiff::default())?;
+
+    let bad_block = test_block(B256::repeat_byte(0xFF), 99, 0x99);
+    let error = storage.store_trie_updates(bad_block, BlockStateDiff::default()).unwrap_err();
+    assert!(matches!(error, BaseProofsStorageError::OutOfOrder { .. }));
+    Ok(())
+}
+
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_prune_earliest_state_comprehensive<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    storage.set_earliest_block_number(0, B256::ZERO)?;
+    let account_address = B256::repeat_byte(1);
+    let storage_slot = B256::repeat_byte(2);
+    let account_path = nibbles_from(vec![1]);
+    let storage_path = nibbles_from(vec![3]);
+    let account_v1 = Account { nonce: 1, balance: U256::from(100), ..Default::default() };
+    let account_v2 = Account { nonce: 2, balance: U256::from(200), ..Default::default() };
+    let block_1 = test_block(B256::ZERO, 1, 1);
+    let block_2 = test_block(block_1.block.hash, 2, 2);
+    let block_3 = test_block(block_2.block.hash, 3, 3);
+
+    let mut trie_updates = TrieUpdates::default();
+    trie_updates.account_nodes.insert(account_path, BranchNodeCompact::default());
+    let mut storage_trie_updates = StorageTrieUpdates::default();
+    storage_trie_updates.storage_nodes.insert(storage_path, BranchNodeCompact::default());
+    trie_updates.storage_tries.insert(account_address, storage_trie_updates);
+
+    let mut post_state_1 = HashedPostState::default();
+    post_state_1.accounts.insert(account_address, Some(account_v1));
+    let mut hashed_storage = HashedStorage::default();
+    hashed_storage.storage.insert(storage_slot, U256::from(1234));
+    post_state_1.storages.insert(account_address, hashed_storage);
+
+    let mut post_state_2 = HashedPostState::default();
+    post_state_2.accounts.insert(account_address, Some(account_v2));
+
+    storage.store_trie_updates(
+        block_1,
+        BlockStateDiff {
+            sorted_trie_updates: trie_updates.into_sorted(),
+            sorted_post_state: post_state_1.into_sorted(),
+        },
+    )?;
+    storage.store_trie_updates(
+        block_2,
+        BlockStateDiff {
+            sorted_trie_updates: TrieUpdatesSorted::default(),
+            sorted_post_state: post_state_2.into_sorted(),
+        },
+    )?;
+    storage.prune_earliest_state(block_3)?;
+
+    assert_account_at(&storage, 3, account_address, account_v2)?;
+    assert_storage_at(&storage, account_address, 3, storage_slot, U256::from(1234))?;
+    assert_account_branch_present(&storage, 3, account_path)?;
+
+    let mut storage_cursor = storage.storage_trie_cursor(account_address, 3)?;
+    assert!(storage_cursor.seek_exact(storage_path)?.is_some());
+    Ok(())
+}
+
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_prune_earliest_state_returns_correct_counts<
+    S: BaseProofsStore + BaseProofsInitialStateStore,
+>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    storage.set_earliest_block_number(0, B256::ZERO)?;
+    let address = B256::repeat_byte(4);
+    let block_1 = test_block(B256::ZERO, 1, 1);
+    let block_2 = test_block(block_1.block.hash, 2, 2);
+
+    let mut post_state_1 = HashedPostState::default();
+    post_state_1.accounts.insert(address, Some(Account { nonce: 1, ..Default::default() }));
+    let mut post_state_2 = HashedPostState::default();
+    post_state_2.accounts.insert(address, Some(Account { nonce: 2, ..Default::default() }));
+
+    storage.store_trie_updates(
+        block_1,
+        BlockStateDiff {
+            sorted_trie_updates: TrieUpdatesSorted::default(),
+            sorted_post_state: post_state_1.into_sorted(),
+        },
+    )?;
+    storage.store_trie_updates(
+        block_2,
+        BlockStateDiff {
+            sorted_trie_updates: TrieUpdatesSorted::default(),
+            sorted_post_state: post_state_2.into_sorted(),
+        },
+    )?;
+
+    let counts = storage.prune_earliest_state(block_2)?;
+    assert_eq!(counts.hashed_accounts_written_total, 1);
+    assert_eq!(counts.account_trie_updates_written_total, 0);
+    Ok(())
+}
+
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_unwind_history_with_trie_nodes<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    storage.set_earliest_block_number(0, B256::ZERO)?;
+    let path_1 = nibbles_from(vec![1]);
+    let path_2 = nibbles_from(vec![2]);
+    let block_1 = test_block(B256::ZERO, 1, 1);
+    let block_2 = test_block(block_1.block.hash, 2, 2);
+    let block_3 = test_block(block_2.block.hash, 3, 3);
+
+    for (block, path) in [(block_1, path_1), (block_2, path_2), (block_3, path_1)] {
+        let mut trie_updates = TrieUpdates::default();
+        trie_updates.account_nodes.insert(path, BranchNodeCompact::default());
+        storage.store_trie_updates(
+            block,
+            BlockStateDiff {
+                sorted_trie_updates: trie_updates.into_sorted(),
+                sorted_post_state: HashedPostStateSorted::default(),
+            },
+        )?;
+    }
+
+    storage.unwind_history(block_2)?;
+    assert_account_branch_present(&storage, 10, path_1)?;
+    assert_account_branch_missing(&storage, 10, path_2)
+}
+
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_unwind_history_comprehensive<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    storage.set_earliest_block_number(0, B256::ZERO)?;
+    let account_1 = B256::repeat_byte(1);
+    let account_2 = B256::repeat_byte(2);
+    let slot_1 = B256::repeat_byte(3);
+    let slot_2 = B256::repeat_byte(4);
+    let block_1 = test_block(B256::ZERO, 1, 1);
+    let block_2 = test_block(block_1.block.hash, 2, 2);
+    let block_3 = test_block(block_2.block.hash, 3, 3);
+
+    let mut post_state_1 = HashedPostState::default();
+    post_state_1.accounts.insert(account_1, Some(Account::default()));
+    let mut storage_1 = HashedStorage::default();
+    storage_1.storage.insert(slot_1, U256::from(1111));
+    post_state_1.storages.insert(account_1, storage_1);
+
+    let mut post_state_2 = HashedPostState::default();
+    post_state_2.accounts.insert(account_2, Some(Account::default()));
+    let mut storage_2 = HashedStorage::default();
+    storage_2.storage.insert(slot_2, U256::from(2222));
+    post_state_2.storages.insert(account_2, storage_2);
+
+    let mut post_state_3 = HashedPostState::default();
+    post_state_3.accounts.insert(account_1, Some(Account { nonce: 9, ..Default::default() }));
+
+    storage.store_trie_updates(
+        block_1,
+        BlockStateDiff {
+            sorted_trie_updates: TrieUpdatesSorted::default(),
+            sorted_post_state: post_state_1.into_sorted(),
+        },
+    )?;
+    storage.store_trie_updates(
+        block_2,
+        BlockStateDiff {
+            sorted_trie_updates: TrieUpdatesSorted::default(),
+            sorted_post_state: post_state_2.into_sorted(),
+        },
+    )?;
+    storage.store_trie_updates(
+        block_3,
+        BlockStateDiff {
+            sorted_trie_updates: TrieUpdatesSorted::default(),
+            sorted_post_state: post_state_3.into_sorted(),
+        },
+    )?;
+
+    storage.unwind_history(block_2)?;
+    assert!(storage.fetch_trie_updates(1).is_ok());
+    assert!(storage.fetch_trie_updates(2).is_err());
+    assert!(storage.fetch_trie_updates(3).is_err());
+    assert_eq!(storage.get_latest_block_number()?, Some((1, block_1.block.hash)));
+    Ok(())
+}
+
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_unwind_history_idempotent<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    storage.set_earliest_block_number(0, B256::ZERO)?;
+    let address = B256::repeat_byte(1);
+    let make_diff = |nonce| {
+        let mut post_state = HashedPostState::default();
+        post_state.accounts.insert(address, Some(Account { nonce, ..Default::default() }));
+        BlockStateDiff {
+            sorted_trie_updates: TrieUpdatesSorted::default(),
+            sorted_post_state: post_state.into_sorted(),
+        }
+    };
+    let block_1 = test_block(B256::ZERO, 1, 1);
+    let block_2 = test_block(block_1.block.hash, 2, 2);
+    let block_3 = test_block(block_2.block.hash, 3, 3);
+
+    storage.store_trie_updates(block_1, make_diff(10))?;
+    storage.store_trie_updates(block_2, make_diff(20))?;
+    storage.store_trie_updates(block_3, make_diff(30))?;
+
+    storage.unwind_history(block_2)?;
+    storage.unwind_history(block_2)?;
+    assert!(storage.fetch_trie_updates(1).is_ok());
+    assert!(storage.fetch_trie_updates(2).is_err());
+    assert!(storage.fetch_trie_updates(3).is_err());
+    Ok(())
+}

--- a/crates/execution/trie/tests/lib.rs
+++ b/crates/execution/trie/tests/lib.rs
@@ -5,19 +5,19 @@ use std::sync::Arc;
 use alloy_eips::{BlockNumHash, NumHash, eip1898::BlockWithParent};
 use alloy_primitives::{B256, U256};
 use base_execution_trie::{
-    BaseProofsInitialStateStore, BaseProofsStorageError, BaseProofsStore, BlockStateDiff,
-    InMemoryProofsStorage, db::MdbxProofsStorage,
+    BaseProofsInitialStateStore, BaseProofsStorageError, BaseProofsStorageResult, BaseProofsStore,
+    BlockStateDiff, InMemoryProofsStorage,
+    api::{InitialStateAnchor, WriteCounts},
+    db::{MdbxProofsStorage, RocksdbProofsStorage},
 };
 use reth_primitives_traits::Account;
 use reth_trie::{
     BranchNodeCompact, HashedPostState, HashedPostStateSorted, HashedStorage, Nibbles, TrieMask,
     hashed_cursor::HashedCursor,
     trie_cursor::TrieCursor,
-    updates::{TrieUpdates, TrieUpdatesSorted},
+    updates::{StorageTrieUpdates, TrieUpdates, TrieUpdatesSorted},
 };
-use serial_test::serial;
 use tempfile::TempDir;
-use test_case::test_case;
 
 /// Helper to create a simple test branch node
 fn create_test_branch() -> BranchNodeCompact {
@@ -77,1978 +77,265 @@ fn create_mdbx_proofs_storage() -> MdbxProofsStorage {
     MdbxProofsStorage::new(path.path()).unwrap()
 }
 
-/// Test basic storage and retrieval of earliest block number
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_earliest_block_operations<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    // Initially should be None
-    let earliest = storage.get_earliest_block_number()?;
-    assert!(earliest.is_none());
-
-    // Set earliest block
-    let block_hash = B256::repeat_byte(0x42);
-    storage.set_earliest_block_number(100, block_hash)?;
-
-    // Should retrieve the same values
-    let earliest = storage.get_earliest_block_number()?;
-    assert_eq!(earliest, Some((100, block_hash)));
-
-    Ok(())
+#[derive(Debug)]
+struct TestRocksdbProofsStorage {
+    storage: RocksdbProofsStorage,
+    _dir: TempDir,
 }
 
-/// Test storing and retrieving trie updates
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_trie_updates_operations<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    let block_ref = BlockWithParent::new(B256::ZERO, NumHash::new(50, B256::repeat_byte(0x96)));
-    let sorted_trie_updates = TrieUpdatesSorted::default();
-    let sorted_post_state = HashedPostStateSorted::default();
-    let block_state_diff = BlockStateDiff {
-        sorted_trie_updates: sorted_trie_updates.clone(),
-        sorted_post_state: sorted_post_state.clone(),
-    };
-
-    // Store trie updates
-    storage.store_trie_updates(block_ref, block_state_diff)?;
-
-    // Retrieve and verify
-    let retrieved_diff = storage.fetch_trie_updates(block_ref.block.number)?;
-    assert_eq!(retrieved_diff.sorted_trie_updates, sorted_trie_updates);
-    assert_eq!(retrieved_diff.sorted_post_state, sorted_post_state);
-
-    Ok(())
+fn create_rocksdb_proofs_storage() -> TestRocksdbProofsStorage {
+    let dir = TempDir::new().unwrap();
+    let storage = RocksdbProofsStorage::new(dir.path()).unwrap();
+    TestRocksdbProofsStorage { storage, _dir: dir }
 }
 
-// =============================================================================
-// 1. Basic Cursor Operations
-// =============================================================================
+impl BaseProofsStore for TestRocksdbProofsStorage {
+    type StorageTrieCursor<'tx>
+        = <RocksdbProofsStorage as BaseProofsStore>::StorageTrieCursor<'tx>
+    where
+        Self: 'tx;
+    type AccountTrieCursor<'tx>
+        = <RocksdbProofsStorage as BaseProofsStore>::AccountTrieCursor<'tx>
+    where
+        Self: 'tx;
+    type StorageCursor<'tx>
+        = <RocksdbProofsStorage as BaseProofsStore>::StorageCursor<'tx>
+    where
+        Self: 'tx;
+    type AccountHashedCursor<'tx>
+        = <RocksdbProofsStorage as BaseProofsStore>::AccountHashedCursor<'tx>
+    where
+        Self: 'tx;
+    type Tx<'tx>
+        = <RocksdbProofsStorage as BaseProofsStore>::Tx<'tx>
+    where
+        Self: 'tx;
 
-/// Test cursor operations on empty trie
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_cursor_empty_trie<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    let mut cursor = storage.account_trie_cursor(100)?;
-
-    // All operations should return None on empty trie
-    assert!(cursor.seek_exact(Nibbles::default())?.is_none());
-    assert!(cursor.seek(Nibbles::default())?.is_none());
-    assert!(cursor.next()?.is_none());
-    assert!(cursor.current()?.is_none());
-
-    Ok(())
-}
-
-/// Test cursor operations with single entry
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_cursor_single_entry<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    let path = nibbles_from(vec![1, 2, 3]);
-    let branch = create_test_branch();
-
-    // Store single entry
-    storage.store_account_branches(vec![(path, Some(branch))])?;
-
-    let mut cursor = storage.account_trie_cursor(100)?;
-
-    // Test seek_exact
-    let result = cursor.seek_exact(path)?.unwrap();
-    assert_eq!(result.0, path);
-
-    // Test current position
-    assert_eq!(cursor.current()?.unwrap(), path);
-
-    // Test next from end should return None
-    assert!(cursor.next()?.is_none());
-
-    Ok(())
-}
-
-/// Test cursor operations with multiple entries
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_cursor_multiple_entries<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    let paths = vec![
-        nibbles_from(vec![1]),
-        nibbles_from(vec![1, 2]),
-        nibbles_from(vec![2]),
-        nibbles_from(vec![2, 3]),
-    ];
-    let branch = create_test_branch();
-
-    // Store multiple entries
-    for path in &paths {
-        storage.store_account_branches(vec![(*path, Some(branch.clone()))])?;
+    fn get_earliest_block_number(&self) -> BaseProofsStorageResult<Option<(u64, B256)>> {
+        self.storage.get_earliest_block_number()
     }
 
-    let mut cursor = storage.account_trie_cursor(100)?;
-
-    // Test that we can iterate through all entries
-    let mut found_paths = Vec::new();
-    while let Some((path, _)) = cursor.next()? {
-        found_paths.push(path);
+    fn get_latest_block_number(&self) -> BaseProofsStorageResult<Option<(u64, B256)>> {
+        self.storage.get_latest_block_number()
     }
 
-    assert_eq!(found_paths.len(), 4);
-    // Paths should be in lexicographic order
-    for i in 0..paths.len() {
-        assert_eq!(found_paths[i], paths[i]);
+    fn storage_trie_cursor<'tx>(
+        &'tx self,
+        hashed_address: B256,
+        max_block_number: u64,
+    ) -> BaseProofsStorageResult<Self::StorageTrieCursor<'tx>> {
+        self.storage.storage_trie_cursor(hashed_address, max_block_number)
     }
 
-    Ok(())
-}
-
-// =============================================================================
-// 2. Seek Operations
-// =============================================================================
-
-/// Test `seek_exact` with existing path
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_seek_exact_existing_path<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    let path = nibbles_from(vec![1, 2, 3]);
-    let branch = create_test_branch();
-
-    storage.store_account_branches(vec![(path, Some(branch))])?;
-
-    let mut cursor = storage.account_trie_cursor(100)?;
-    let result = cursor.seek_exact(path)?.unwrap();
-    assert_eq!(result.0, path);
-
-    Ok(())
-}
-
-/// Test `seek_exact` with non-existing path
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_seek_exact_non_existing_path<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    let path = nibbles_from(vec![1, 2, 3]);
-    let branch = create_test_branch();
-
-    storage.store_account_branches(vec![(path, Some(branch))])?;
-
-    let mut cursor = storage.account_trie_cursor(100)?;
-    let non_existing = nibbles_from(vec![4, 5, 6]);
-    assert!(cursor.seek_exact(non_existing)?.is_none());
-
-    Ok(())
-}
-
-/// Test `seek_exact` with empty path
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_seek_exact_empty_path<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    let path = nibbles_from(vec![]);
-    let branch = create_test_branch();
-
-    storage.store_account_branches(vec![(path, Some(branch))])?;
-
-    let mut cursor = storage.account_trie_cursor(100)?;
-    let result = cursor.seek_exact(Nibbles::default())?.unwrap();
-    assert_eq!(result.0, Nibbles::default());
-
-    Ok(())
-}
-
-/// Test seek to existing path
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_seek_to_existing_path<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    let path = nibbles_from(vec![1, 2, 3]);
-    let branch = create_test_branch();
-
-    storage.store_account_branches(vec![(path, Some(branch))])?;
-
-    let mut cursor = storage.account_trie_cursor(100)?;
-    let result = cursor.seek(path)?.unwrap();
-    assert_eq!(result.0, path);
-
-    Ok(())
-}
-
-/// Test seek between existing nodes
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_seek_between_existing_nodes<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    let path1 = nibbles_from(vec![1]);
-    let path2 = nibbles_from(vec![3]);
-    let branch = create_test_branch();
-
-    storage.store_account_branches(vec![(path1, Some(branch.clone()))])?;
-    storage.store_account_branches(vec![(path2, Some(branch))])?;
-
-    let mut cursor = storage.account_trie_cursor(100)?;
-    // Seek to path between 1 and 3, should return path 3
-    let seek_path = nibbles_from(vec![2]);
-    let result = cursor.seek(seek_path)?.unwrap();
-    assert_eq!(result.0, path2);
-
-    Ok(())
-}
-
-/// Test seek after all nodes
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_seek_after_all_nodes<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    let path = nibbles_from(vec![1]);
-    let branch = create_test_branch();
-
-    storage.store_account_branches(vec![(path, Some(branch))])?;
-
-    let mut cursor = storage.account_trie_cursor(100)?;
-    // Seek to path after all nodes
-    let seek_path = nibbles_from(vec![9]);
-    assert!(cursor.seek(seek_path)?.is_none());
-
-    Ok(())
-}
-
-/// Test seek before all nodes
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_seek_before_all_nodes<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    let path = nibbles_from(vec![5]);
-    let branch = create_test_branch();
-
-    storage.store_account_branches(vec![(path, Some(branch))])?;
-
-    let mut cursor = storage.account_trie_cursor(100)?;
-    // Seek to path before all nodes, should return first node
-    let seek_path = nibbles_from(vec![1]);
-    let result = cursor.seek(seek_path)?.unwrap();
-    assert_eq!(result.0, path);
-
-    Ok(())
-}
-
-// =============================================================================
-// 3. Navigation Tests
-// =============================================================================
-
-/// Test next without prior seek
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_next_without_prior_seek<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    let path = nibbles_from(vec![1, 2]);
-    let branch = create_test_branch();
-
-    storage.store_account_branches(vec![(path, Some(branch))])?;
-
-    let mut cursor = storage.account_trie_cursor(100)?;
-    // next() without prior seek should start from beginning
-    let result = cursor.next()?.unwrap();
-    assert_eq!(result.0, path);
-
-    Ok(())
-}
-
-/// Test next after seek
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_next_after_seek<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    let path1 = nibbles_from(vec![1]);
-    let path2 = nibbles_from(vec![2]);
-    let branch = create_test_branch();
-
-    storage.store_account_branches(vec![(path1, Some(branch.clone()))])?;
-    storage.store_account_branches(vec![(path2, Some(branch))])?;
-
-    let mut cursor = storage.account_trie_cursor(100)?;
-    cursor.seek(path1)?;
-
-    // next() should return second node
-    let result = cursor.next()?.unwrap();
-    assert_eq!(result.0, path2);
-
-    Ok(())
-}
-
-/// Test next at end of trie
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_next_at_end_of_trie<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    let path = nibbles_from(vec![1]);
-    let branch = create_test_branch();
-
-    storage.store_account_branches(vec![(path, Some(branch))])?;
-
-    let mut cursor = storage.account_trie_cursor(100)?;
-    cursor.seek(path)?;
-
-    // next() at end should return None
-    assert!(cursor.next()?.is_none());
-
-    Ok(())
-}
-
-/// Test multiple consecutive next calls
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_multiple_consecutive_next<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    let paths = vec![nibbles_from(vec![1]), nibbles_from(vec![2]), nibbles_from(vec![3])];
-    let branch = create_test_branch();
-
-    for path in &paths {
-        storage.store_account_branches(vec![(*path, Some(branch.clone()))])?;
+    fn account_trie_cursor<'tx>(
+        &'tx self,
+        max_block_number: u64,
+    ) -> BaseProofsStorageResult<Self::AccountTrieCursor<'tx>> {
+        self.storage.account_trie_cursor(max_block_number)
     }
 
-    let mut cursor = storage.account_trie_cursor(100)?;
-
-    // Iterate through all with consecutive next() calls
-    for expected_path in &paths {
-        let result = cursor.next()?.unwrap();
-        assert_eq!(result.0, *expected_path);
+    fn storage_hashed_cursor<'tx>(
+        &'tx self,
+        hashed_address: B256,
+        max_block_number: u64,
+    ) -> BaseProofsStorageResult<Self::StorageCursor<'tx>> {
+        self.storage.storage_hashed_cursor(hashed_address, max_block_number)
     }
 
-    // Final next() should return None
-    assert!(cursor.next()?.is_none());
-
-    Ok(())
-}
-
-/// Test current after operations
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_current_after_operations<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    let path1 = nibbles_from(vec![1]);
-    let path2 = nibbles_from(vec![2]);
-    let branch = create_test_branch();
-
-    storage.store_account_branches(vec![(path1, Some(branch.clone()))])?;
-    storage.store_account_branches(vec![(path2, Some(branch))])?;
-
-    let mut cursor = storage.account_trie_cursor(100)?;
-
-    // Current should be None initially
-    assert!(cursor.current()?.is_none());
-
-    // After seek, current should track position
-    cursor.seek(path1)?;
-    assert_eq!(cursor.current()?.unwrap(), path1);
-
-    // After next, current should update
-    cursor.next()?;
-    assert_eq!(cursor.current()?.unwrap(), path2);
-
-    Ok(())
-}
-
-/// Test current with no prior operations
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_current_no_prior_operations<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    let mut cursor = storage.account_trie_cursor(100)?;
-
-    // Current should be None when no operations performed
-    assert!(cursor.current()?.is_none());
-
-    Ok(())
-}
-
-// =============================================================================
-// 4. Block Number Filtering
-// =============================================================================
-
-/// Test same path with different blocks
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_same_path_different_blocks<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    let path = nibbles_from(vec![1, 2]);
-    let branch1 = create_test_branch();
-    let branch2 = create_test_branch_variant();
-
-    // Store same path at different blocks
-    storage.store_account_branches(vec![(path, Some(branch1))])?;
-    storage.store_account_branches(vec![(path, Some(branch2))])?;
-
-    // Cursor with max_block_number=75 should see only block 50 data
-    let mut cursor75 = storage.account_trie_cursor(75)?;
-    let result75 = cursor75.seek_exact(path)?.unwrap();
-    assert_eq!(result75.0, path);
-
-    // Cursor with max_block_number=150 should see block 100 data (latest)
-    let mut cursor150 = storage.account_trie_cursor(150)?;
-    let result150 = cursor150.seek_exact(path)?.unwrap();
-    assert_eq!(result150.0, path);
-
-    Ok(())
-}
-
-/// Test deleted branch nodes
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_deleted_branch_nodes<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    let path = nibbles_from(vec![1, 2]);
-    let branch = create_test_branch();
-    let block_ref = BlockWithParent::new(B256::ZERO, NumHash::new(100, B256::repeat_byte(0x96)));
-
-    // Store branch node, then delete it (store None)
-    storage.store_account_branches(vec![(path, Some(branch))])?;
-
-    // Cursor before deletion should see the node
-    let mut cursor75 = storage.account_trie_cursor(75)?;
-    assert!(cursor75.seek_exact(path)?.is_some());
-
-    let mut block_state_diff_trie_updates = TrieUpdates::default();
-    block_state_diff_trie_updates.removed_nodes.insert(path);
-    let block_state_diff = BlockStateDiff {
-        sorted_trie_updates: block_state_diff_trie_updates.into_sorted(),
-        sorted_post_state: HashedPostStateSorted::default(),
-    };
-    storage.store_trie_updates(block_ref, block_state_diff)?;
-
-    // Cursor after deletion should not see the node
-    let mut cursor150 = storage.account_trie_cursor(150)?;
-    assert!(cursor150.seek_exact(path)?.is_none());
-
-    Ok(())
-}
-
-// =============================================================================
-// 5. Hashed Address Filtering
-// =============================================================================
-
-/// Test account-specific cursor
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_account_specific_cursor<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    let path = nibbles_from(vec![1, 2]);
-    let addr1 = B256::repeat_byte(0x01);
-    let addr2 = B256::repeat_byte(0x02);
-    let branch = create_test_branch();
-
-    // Store same path for different accounts (using storage branches)
-    storage.store_storage_branches(addr1, vec![(path, Some(branch.clone()))])?;
-    storage.store_storage_branches(addr2, vec![(path, Some(branch))])?;
-
-    // Cursor for addr1 should only see addr1 data
-    let mut cursor1 = storage.storage_trie_cursor(addr1, 100)?;
-    let result1 = cursor1.seek_exact(path)?.unwrap();
-    assert_eq!(result1.0, path);
-
-    // Cursor for addr2 should only see addr2 data
-    let mut cursor2 = storage.storage_trie_cursor(addr2, 100)?;
-    let result2 = cursor2.seek_exact(path)?.unwrap();
-    assert_eq!(result2.0, path);
-
-    // Cursor for addr1 should not see addr2 data when iterating
-    let mut cursor1_iter = storage.storage_trie_cursor(addr1, 100)?;
-    let mut found_count = 0;
-    while cursor1_iter.next()?.is_some() {
-        found_count += 1;
-    }
-    assert_eq!(found_count, 1); // Should only see one entry (for addr1)
-
-    Ok(())
-}
-
-/// Test state trie cursor
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_state_trie_cursor<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    let path = nibbles_from(vec![1, 2]);
-    let addr = B256::repeat_byte(0x01);
-    let branch = create_test_branch();
-
-    // Store data for account trie and state trie
-    storage.store_storage_branches(addr, vec![(path, Some(branch.clone()))])?;
-    storage.store_account_branches(vec![(path, Some(branch))])?;
-
-    // State trie cursor (None address) should only see state trie data
-    let mut state_cursor = storage.account_trie_cursor(100)?;
-    let result = state_cursor.seek_exact(path)?.unwrap();
-    assert_eq!(result.0, path);
-
-    // Verify state cursor doesn't see account data when iterating
-    let mut state_cursor_iter = storage.account_trie_cursor(100)?;
-    let mut found_count = 0;
-    while state_cursor_iter.next()?.is_some() {
-        found_count += 1;
+    fn account_hashed_cursor<'tx>(
+        &'tx self,
+        max_block_number: u64,
+    ) -> BaseProofsStorageResult<Self::AccountHashedCursor<'tx>> {
+        self.storage.account_hashed_cursor(max_block_number)
     }
 
-    assert_eq!(found_count, 1); // Should only see state trie entry
-
-    Ok(())
-}
-
-/// Test mixed account and state data
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_mixed_account_state_data<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    let path1 = nibbles_from(vec![1]);
-    let path2 = nibbles_from(vec![2]);
-    let addr = B256::repeat_byte(0x01);
-    let branch = create_test_branch();
-
-    // Store mixed account and state trie data
-    storage.store_storage_branches(addr, vec![(path1, Some(branch.clone()))])?;
-    storage.store_account_branches(vec![(path2, Some(branch))])?;
-
-    // Account cursor should only see account data
-    let mut account_cursor = storage.storage_trie_cursor(addr, 100)?;
-    let mut account_paths = Vec::new();
-    while let Some((path, _)) = account_cursor.next()? {
-        account_paths.push(path);
-    }
-    assert_eq!(account_paths.len(), 1);
-    assert_eq!(account_paths[0], path1);
-
-    // State cursor should only see state data
-    let mut state_cursor = storage.account_trie_cursor(100)?;
-    let mut state_paths = Vec::new();
-    while let Some((path, _)) = state_cursor.next()? {
-        state_paths.push(path);
-    }
-    assert_eq!(state_paths.len(), 1);
-    assert_eq!(state_paths[0], path2);
-
-    Ok(())
-}
-
-// =============================================================================
-// 6. Path Ordering Tests
-// =============================================================================
-
-/// Test lexicographic ordering
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_lexicographic_ordering<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    let paths = vec![
-        nibbles_from(vec![3, 1]),
-        nibbles_from(vec![1, 2]),
-        nibbles_from(vec![2]),
-        nibbles_from(vec![1]),
-    ];
-    let branch = create_test_branch();
-
-    // Store paths in random order
-    for path in &paths {
-        storage.store_account_branches(vec![(*path, Some(branch.clone()))])?;
+    fn ro_tx<'tx>(&'tx self) -> BaseProofsStorageResult<Self::Tx<'tx>> {
+        self.storage.ro_tx()
     }
 
-    let mut cursor = storage.account_trie_cursor(100)?;
-    let mut found_paths = Vec::new();
-    while let Some((path, _)) = cursor.next()? {
-        found_paths.push(path);
+    fn storage_trie_cursor_with_tx<'tx, 'db>(
+        &self,
+        tx: &'tx Self::Tx<'db>,
+        hashed_address: B256,
+        max_block_number: u64,
+    ) -> BaseProofsStorageResult<Self::StorageTrieCursor<'tx>>
+    where
+        Self: 'db,
+        'db: 'tx,
+    {
+        self.storage.storage_trie_cursor_with_tx(tx, hashed_address, max_block_number)
     }
 
-    // Should be returned in lexicographic order: [1], [1,2], [2], [3,1]
-    let expected_order = vec![
-        nibbles_from(vec![1]),
-        nibbles_from(vec![1, 2]),
-        nibbles_from(vec![2]),
-        nibbles_from(vec![3, 1]),
-    ];
-
-    assert_eq!(found_paths, expected_order);
-
-    Ok(())
-}
-
-/// Test path prefix scenarios
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_path_prefix_scenarios<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    let paths = vec![
-        nibbles_from(vec![1]),       // Prefix of next
-        nibbles_from(vec![1, 2]),    // Extends first
-        nibbles_from(vec![1, 2, 3]), // Extends second
-    ];
-    let branch = create_test_branch();
-
-    for path in &paths {
-        storage.store_account_branches(vec![(*path, Some(branch.clone()))])?;
+    fn account_trie_cursor_with_tx<'tx, 'db>(
+        &self,
+        tx: &'tx Self::Tx<'db>,
+        max_block_number: u64,
+    ) -> BaseProofsStorageResult<Self::AccountTrieCursor<'tx>>
+    where
+        Self: 'db,
+        'db: 'tx,
+    {
+        self.storage.account_trie_cursor_with_tx(tx, max_block_number)
     }
 
-    let mut cursor = storage.account_trie_cursor(100)?;
-
-    // Seek to prefix should find exact match
-    let result = cursor.seek_exact(paths[0])?.unwrap();
-    assert_eq!(result.0, paths[0]);
-
-    // Next should go to next path, not skip prefixed paths
-    let result = cursor.next()?.unwrap();
-    assert_eq!(result.0, paths[1]);
-
-    let result = cursor.next()?.unwrap();
-    assert_eq!(result.0, paths[2]);
-
-    Ok(())
-}
-
-/// Test complex nibble combinations
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_complex_nibble_combinations<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    // Test various nibble patterns including edge values
-    let paths = vec![
-        nibbles_from(vec![0]),
-        nibbles_from(vec![0, 15]),
-        nibbles_from(vec![15]),
-        nibbles_from(vec![15, 0]),
-        nibbles_from(vec![7, 8, 9]),
-    ];
-    let branch = create_test_branch();
-
-    for path in &paths {
-        storage.store_account_branches(vec![(*path, Some(branch.clone()))])?;
+    fn storage_hashed_cursor_with_tx<'tx, 'db>(
+        &self,
+        tx: &'tx Self::Tx<'db>,
+        hashed_address: B256,
+        max_block_number: u64,
+    ) -> BaseProofsStorageResult<Self::StorageCursor<'tx>>
+    where
+        Self: 'db,
+        'db: 'tx,
+    {
+        self.storage.storage_hashed_cursor_with_tx(tx, hashed_address, max_block_number)
     }
 
-    let mut cursor = storage.account_trie_cursor(100)?;
-    let mut found_paths = Vec::new();
-    while let Some((path, _)) = cursor.next()? {
-        found_paths.push(path);
+    fn account_hashed_cursor_with_tx<'tx, 'db>(
+        &self,
+        tx: &'tx Self::Tx<'db>,
+        max_block_number: u64,
+    ) -> BaseProofsStorageResult<Self::AccountHashedCursor<'tx>>
+    where
+        Self: 'db,
+        'db: 'tx,
+    {
+        self.storage.account_hashed_cursor_with_tx(tx, max_block_number)
     }
 
-    // All paths should be found and in correct order
-    assert_eq!(found_paths.len(), 5);
-
-    // Verify specific ordering for edge cases
-    assert_eq!(found_paths[0], nibbles_from(vec![0]));
-    assert_eq!(found_paths[1], nibbles_from(vec![0, 15]));
-    assert_eq!(found_paths[4], nibbles_from(vec![15, 0]));
-
-    Ok(())
-}
-
-// =============================================================================
-// 7. Leaf Node Tests (Hashed Accounts and Storage)
-// =============================================================================
-
-/// Test store and retrieve single account
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_store_and_retrieve_single_account<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    let account_key = B256::repeat_byte(0x01);
-    let account = create_test_account();
-
-    // Store account
-    storage.store_hashed_accounts(vec![(account_key, Some(account))])?;
-
-    // Retrieve via cursor
-    let mut cursor = storage.account_hashed_cursor(100)?;
-    let result = cursor.seek(account_key)?.unwrap();
-
-    assert_eq!(result.0, account_key);
-    assert_eq!(result.1.nonce, account.nonce);
-    assert_eq!(result.1.balance, account.balance);
-    assert_eq!(result.1.bytecode_hash, account.bytecode_hash);
-
-    Ok(())
-}
-
-/// Test account cursor navigation
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_account_cursor_navigation<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    let accounts = [
-        (B256::repeat_byte(0x01), create_test_account()),
-        (B256::repeat_byte(0x03), create_test_account()),
-        (B256::repeat_byte(0x05), create_test_account()),
-    ];
-
-    // Store accounts
-    let accounts_to_store: Vec<_> = accounts.iter().map(|(k, v)| (*k, Some(*v))).collect();
-    storage.store_hashed_accounts(accounts_to_store)?;
-
-    let mut cursor = storage.account_hashed_cursor(100)?;
-
-    // Test seeking to exact key
-    let result = cursor.seek(accounts[1].0)?.unwrap();
-    assert_eq!(result.0, accounts[1].0);
-
-    // Test seeking to key that doesn't exist (should return next greater)
-    let seek_key = B256::repeat_byte(0x02);
-    let result = cursor.seek(seek_key)?.unwrap();
-    assert_eq!(result.0, accounts[1].0); // Should find 0x03
-
-    // Test next() navigation
-    let result = cursor.next()?.unwrap();
-    assert_eq!(result.0, accounts[2].0); // Should find 0x05
-
-    // Test next() at end
-    assert!(cursor.next()?.is_none());
-
-    Ok(())
-}
-
-/// Test account block versioning
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_account_block_versioning<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    let account_key = B256::repeat_byte(0x01);
-    let account_v1 = create_test_account_with_values(1, 100, 0xBB);
-    let account_v2 = create_test_account_with_values(2, 200, 0xDD);
-
-    // Store account at different blocks
-    storage.store_hashed_accounts(vec![(account_key, Some(account_v1))])?;
-
-    // Cursor with max_block_number=75 should see v1
-    let mut cursor75 = storage.account_hashed_cursor(75)?;
-    let result75 = cursor75.seek(account_key)?.unwrap();
-    assert_eq!(result75.1.nonce, account_v1.nonce);
-    assert_eq!(result75.1.balance, account_v1.balance);
-
-    storage.store_hashed_accounts(vec![(account_key, Some(account_v2))])?;
-
-    // After update, Cursor with max_block_number=150 should see v2
-    let mut cursor150 = storage.account_hashed_cursor(150)?;
-    let result150 = cursor150.seek(account_key)?.unwrap();
-    assert_eq!(result150.1.nonce, account_v2.nonce);
-    assert_eq!(result150.1.balance, account_v2.balance);
-
-    Ok(())
-}
-
-/// Test store and retrieve storage
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-
-fn test_store_and_retrieve_storage<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    let hashed_address = B256::repeat_byte(0x01);
-    let storage_slots = vec![
-        (B256::repeat_byte(0x10), U256::from(100)),
-        (B256::repeat_byte(0x20), U256::from(200)),
-        (B256::repeat_byte(0x30), U256::from(300)),
-    ];
-
-    // Store storage slots
-    storage.store_hashed_storages(hashed_address, storage_slots.clone())?;
-
-    // Retrieve via cursor
-    let mut cursor = storage.storage_hashed_cursor(hashed_address, 100)?;
-
-    // Test seeking to each slot
-    for (key, expected_value) in &storage_slots {
-        let result = cursor.seek(*key)?.unwrap();
-        assert_eq!(result.0, *key);
-        assert_eq!(result.1, *expected_value);
+    fn store_trie_updates(
+        &self,
+        block_ref: BlockWithParent,
+        block_state_diff: BlockStateDiff,
+    ) -> BaseProofsStorageResult<WriteCounts> {
+        self.storage.store_trie_updates(block_ref, block_state_diff)
     }
 
-    Ok(())
-}
-
-/// Test storage cursor navigation
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_storage_cursor_navigation<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    let hashed_address = B256::repeat_byte(0x01);
-    let storage_slots = vec![
-        (B256::repeat_byte(0x10), U256::from(100)),
-        (B256::repeat_byte(0x30), U256::from(300)),
-        (B256::repeat_byte(0x50), U256::from(500)),
-    ];
-
-    storage.store_hashed_storages(hashed_address, storage_slots.clone())?;
-
-    let mut cursor = storage.storage_hashed_cursor(hashed_address, 100)?;
-
-    // Start from beginning with next()
-    let mut found_slots = Vec::new();
-    while let Some((key, value)) = cursor.next()? {
-        found_slots.push((key, value));
+    fn fetch_trie_updates(&self, block_number: u64) -> BaseProofsStorageResult<BlockStateDiff> {
+        self.storage.fetch_trie_updates(block_number)
     }
 
-    assert_eq!(found_slots.len(), 3);
-    assert_eq!(found_slots[0], storage_slots[0]);
-    assert_eq!(found_slots[1], storage_slots[1]);
-    assert_eq!(found_slots[2], storage_slots[2]);
-
-    Ok(())
-}
-
-/// Test storage account isolation
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_storage_account_isolation<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    let address1 = B256::repeat_byte(0x01);
-    let address2 = B256::repeat_byte(0x02);
-    let storage_key = B256::repeat_byte(0x10);
-
-    // Store same storage key for different accounts
-    storage.store_hashed_storages(address1, vec![(storage_key, U256::from(100))])?;
-    storage.store_hashed_storages(address2, vec![(storage_key, U256::from(200))])?;
-
-    // Verify each account sees only its own storage
-    let mut cursor1 = storage.storage_hashed_cursor(address1, 100)?;
-    let result1 = cursor1.seek(storage_key)?.unwrap();
-    assert_eq!(result1.1, U256::from(100));
-
-    let mut cursor2 = storage.storage_hashed_cursor(address2, 100)?;
-    let result2 = cursor2.seek(storage_key)?.unwrap();
-    assert_eq!(result2.1, U256::from(200));
-
-    // Verify cursor1 doesn't see address2's storage
-    let mut cursor1_iter = storage.storage_hashed_cursor(address1, 100)?;
-    let mut count = 0;
-    while cursor1_iter.next()?.is_some() {
-        count += 1;
-    }
-    assert_eq!(count, 1); // Should only see one entry
-
-    Ok(())
-}
-
-/// Test storage block versioning
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_storage_block_versioning<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    let hashed_address = B256::repeat_byte(0x01);
-    let storage_key = B256::repeat_byte(0x10);
-
-    // Store storage at different blocks
-    storage.store_hashed_storages(hashed_address, vec![(storage_key, U256::from(100))])?;
-
-    // Cursor with max_block_number=75 should see old value
-    let mut cursor75 = storage.storage_hashed_cursor(hashed_address, 75)?;
-    let result75 = cursor75.seek(storage_key)?.unwrap();
-    assert_eq!(result75.1, U256::from(100));
-
-    storage.store_hashed_storages(hashed_address, vec![(storage_key, U256::from(200))])?;
-    // Cursor with max_block_number=150 should see new value
-    let mut cursor150 = storage.storage_hashed_cursor(hashed_address, 150)?;
-    let result150 = cursor150.seek(storage_key)?.unwrap();
-    assert_eq!(result150.1, U256::from(200));
-
-    Ok(())
-}
-
-/// Test storage zero value deletion
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_storage_zero_value_deletion<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    let hashed_address = B256::repeat_byte(0x01);
-    let storage_key = B256::repeat_byte(0x10);
-
-    // Store non-zero value
-    storage.store_hashed_storages(hashed_address, vec![(storage_key, U256::from(100))])?;
-
-    // Cursor before deletion should see the value
-    let mut cursor75 = storage.storage_hashed_cursor(hashed_address, 75)?;
-    let result75 = cursor75.seek(storage_key)?.unwrap();
-    assert_eq!(result75.1, U256::from(100));
-
-    // "Delete" by storing zero value at block 100
-    let mut block_state_diff_post_state = HashedPostState::default();
-    let mut hashed_storage = HashedStorage::default();
-    hashed_storage.storage.insert(storage_key, U256::ZERO);
-    block_state_diff_post_state.storages.insert(hashed_address, hashed_storage);
-
-    let block_ref = BlockWithParent::new(B256::ZERO, NumHash::new(100, B256::repeat_byte(0x96)));
-    let block_state_diff = BlockStateDiff {
-        sorted_trie_updates: TrieUpdatesSorted::default(),
-        sorted_post_state: block_state_diff_post_state.into_sorted(),
-    };
-    storage.store_trie_updates(block_ref, block_state_diff)?;
-
-    // Cursor after deletion should NOT see the entry (zero values are skipped)
-    let mut cursor150 = storage.storage_hashed_cursor(hashed_address, 150)?;
-    let result150 = cursor150.seek(storage_key)?;
-    assert!(result150.is_none(), "Zero values should be skipped/deleted");
-
-    Ok(())
-}
-
-/// Test that zero values are skipped during iteration
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_storage_cursor_skips_zero_values<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    let hashed_address = B256::repeat_byte(0x01);
-
-    // Create a mix of non-zero and zero value storage slots
-    let storage_slots = vec![
-        (B256::repeat_byte(0x10), U256::from(100)), // Non-zero
-        (B256::repeat_byte(0x20), U256::ZERO),      // Zero value - should be skipped
-        (B256::repeat_byte(0x30), U256::from(300)), // Non-zero
-        (B256::repeat_byte(0x40), U256::ZERO),      // Zero value - should be skipped
-        (B256::repeat_byte(0x50), U256::from(500)), // Non-zero
-    ];
-
-    // Store all slots
-    storage.store_hashed_storages(hashed_address, storage_slots)?;
-
-    // Create cursor and iterate through all entries
-    let mut cursor = storage.storage_hashed_cursor(hashed_address, 100)?;
-    let mut found_slots = Vec::new();
-    while let Some((key, value)) = cursor.next()? {
-        found_slots.push((key, value));
+    fn prune_earliest_state(
+        &self,
+        new_earliest_block_ref: BlockWithParent,
+    ) -> BaseProofsStorageResult<WriteCounts> {
+        self.storage.prune_earliest_state(new_earliest_block_ref)
     }
 
-    // Should only find 3 non-zero values
-    assert_eq!(found_slots.len(), 3, "Zero values should be skipped during iteration");
-
-    // Verify the non-zero values are the ones we stored
-    assert_eq!(found_slots[0], (B256::repeat_byte(0x10), U256::from(100)));
-    assert_eq!(found_slots[1], (B256::repeat_byte(0x30), U256::from(300)));
-    assert_eq!(found_slots[2], (B256::repeat_byte(0x50), U256::from(500)));
-
-    // Verify seeking to a zero-value slot returns None or skips to next non-zero
-    let mut seek_cursor = storage.storage_hashed_cursor(hashed_address, 100)?;
-    let seek_result = seek_cursor.seek(B256::repeat_byte(0x20))?;
-
-    // Should either return None or skip to the next non-zero value (0x30)
-    if let Some((key, value)) = seek_result {
-        assert_eq!(key, B256::repeat_byte(0x30), "Should skip zero value and find next non-zero");
-        assert_eq!(value, U256::from(300));
+    fn unwind_history(&self, to: BlockWithParent) -> BaseProofsStorageResult<()> {
+        self.storage.unwind_history(to)
     }
 
-    Ok(())
+    fn replace_updates(
+        &self,
+        latest_common_block: BlockNumHash,
+        blocks_to_add: Vec<(BlockWithParent, BlockStateDiff)>,
+    ) -> BaseProofsStorageResult<()> {
+        self.storage.replace_updates(latest_common_block, blocks_to_add)
+    }
+
+    fn set_earliest_block_number(
+        &self,
+        block_number: u64,
+        hash: B256,
+    ) -> BaseProofsStorageResult<()> {
+        self.storage.set_earliest_block_number(block_number, hash)
+    }
 }
 
-/// Test empty cursors
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_empty_cursors<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
+impl BaseProofsInitialStateStore for TestRocksdbProofsStorage {
+    fn initial_state_anchor(&self) -> BaseProofsStorageResult<InitialStateAnchor> {
+        self.storage.initial_state_anchor()
+    }
+
+    fn set_initial_state_anchor(&self, anchor: BlockNumHash) -> BaseProofsStorageResult<()> {
+        self.storage.set_initial_state_anchor(anchor)
+    }
+
+    fn store_account_branches(
+        &self,
+        account_nodes: Vec<(Nibbles, Option<BranchNodeCompact>)>,
+    ) -> BaseProofsStorageResult<()> {
+        self.storage.store_account_branches(account_nodes)
+    }
+
+    fn store_storage_branches(
+        &self,
+        hashed_address: B256,
+        storage_nodes: Vec<(Nibbles, Option<BranchNodeCompact>)>,
+    ) -> BaseProofsStorageResult<()> {
+        self.storage.store_storage_branches(hashed_address, storage_nodes)
+    }
+
+    fn store_hashed_accounts(
+        &self,
+        accounts: Vec<(B256, Option<Account>)>,
+    ) -> BaseProofsStorageResult<()> {
+        self.storage.store_hashed_accounts(accounts)
+    }
+
+    fn store_hashed_storages(
+        &self,
+        hashed_address: B256,
+        storages: Vec<(B256, U256)>,
+    ) -> BaseProofsStorageResult<()> {
+        self.storage.store_hashed_storages(hashed_address, storages)
+    }
+
+    fn commit_initial_state(&self) -> BaseProofsStorageResult<BlockNumHash> {
+        self.storage.commit_initial_state()
+    }
+}
+
+const fn test_block(parent: B256, number: u64, hash_byte: u8) -> BlockWithParent {
+    BlockWithParent::new(parent, NumHash::new(number, B256::repeat_byte(hash_byte)))
+}
+
+fn assert_account_at<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: &S,
+    at: u64,
+    key: B256,
+    expected: Account,
 ) -> Result<(), BaseProofsStorageError> {
-    // Test empty account cursor
-    let mut account_cursor = storage.account_hashed_cursor(100)?;
-    assert!(account_cursor.seek(B256::repeat_byte(0x01))?.is_none());
-    assert!(account_cursor.next()?.is_none());
-
-    // Test empty storage cursor
-    let mut storage_cursor = storage.storage_hashed_cursor(B256::repeat_byte(0x01), 100)?;
-    assert!(storage_cursor.seek(B256::repeat_byte(0x10))?.is_none());
-    assert!(storage_cursor.next()?.is_none());
-
+    let mut cursor = storage.account_hashed_cursor(at)?;
+    assert_eq!(cursor.seek(key)?, Some((key, expected)));
     Ok(())
 }
 
-/// Test cursor boundary conditions
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_cursor_boundary_conditions<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
+fn assert_account_branch_present<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: &S,
+    at: u64,
+    path: Nibbles,
 ) -> Result<(), BaseProofsStorageError> {
-    let account_key = B256::repeat_byte(0x80); // Middle value
-    let account = create_test_account();
-
-    storage.store_hashed_accounts(vec![(account_key, Some(account))])?;
-
-    let mut cursor = storage.account_hashed_cursor(100)?;
-
-    // Seek to minimum key should find our account
-    let result = cursor.seek(B256::ZERO)?.unwrap();
-    assert_eq!(result.0, account_key);
-
-    // Seek to maximum key should find nothing
-    assert!(cursor.seek(B256::repeat_byte(0xFF))?.is_none());
-
-    // Seek to key just before our account should find our account
-    let just_before = B256::repeat_byte(0x7F);
-    let result = cursor.seek(just_before)?.unwrap();
-    assert_eq!(result.0, account_key);
-
+    let mut cursor = storage.account_trie_cursor(at)?;
+    assert!(cursor.seek_exact(path)?.is_some());
     Ok(())
 }
 
-/// Test large batch operations
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_large_batch_operations<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
+fn assert_account_branch_missing<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: &S,
+    at: u64,
+    path: Nibbles,
 ) -> Result<(), BaseProofsStorageError> {
-    // Create large batch of accounts
-    let mut accounts = Vec::new();
-    for i in 0..100 {
-        let key = B256::from([i as u8; 32]);
-        let account = create_test_account_with_values(i, i * 1000, (i + 1) as u8);
-        accounts.push((key, Some(account)));
-    }
-
-    // Store in batch
-    storage.store_hashed_accounts(accounts.clone())?;
-
-    // Verify all accounts can be retrieved
-    let mut cursor = storage.account_hashed_cursor(100)?;
-    let mut found_count = 0;
-    while cursor.next()?.is_some() {
-        found_count += 1;
-    }
-    assert_eq!(found_count, 100);
-
-    // Test specific account retrieval
-    let test_key = B256::from([42u8; 32]);
-    let result = cursor.seek(test_key)?.unwrap();
-    assert_eq!(result.0, test_key);
-    assert_eq!(result.1.nonce, 42);
-
+    let mut cursor = storage.account_trie_cursor(at)?;
+    assert!(cursor.seek_exact(path)?.is_none());
     Ok(())
 }
 
-/// Test wiped storage in [`HashedPostState`]
-///
-/// When `store_trie_updates` receives a [`HashedPostState`] with wiped=true for a storage entry,
-/// it should iterate all existing values for that address and create deletion entries for them.
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_store_trie_updates_with_wiped_storage<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
+fn assert_storage_at<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: &S,
+    hashed_address: B256,
+    at: u64,
+    slot: B256,
+    expected: U256,
 ) -> Result<(), BaseProofsStorageError> {
-    use reth_trie::HashedStorage;
-
-    let hashed_address = B256::repeat_byte(0x01);
-    let block_ref = BlockWithParent::new(B256::ZERO, NumHash::new(100, B256::repeat_byte(0x96)));
-
-    // First, store some storage values at block 50
-    let storage_slots = vec![
-        (B256::repeat_byte(0x10), U256::from(100)),
-        (B256::repeat_byte(0x20), U256::from(200)),
-        (B256::repeat_byte(0x30), U256::from(300)),
-        (B256::repeat_byte(0x40), U256::from(400)),
-    ];
-
-    storage.store_hashed_storages(hashed_address, storage_slots.clone())?;
-
-    // Verify all values are present at block 75
-    let mut cursor75 = storage.storage_hashed_cursor(hashed_address, 75)?;
-    let mut found_slots = Vec::new();
-    while let Some((key, value)) = cursor75.next()? {
-        found_slots.push((key, value));
-    }
-    assert_eq!(found_slots.len(), 4, "All storage slots should be present before wipe");
-    assert_eq!(found_slots[0], (B256::repeat_byte(0x10), U256::from(100)));
-    assert_eq!(found_slots[1], (B256::repeat_byte(0x20), U256::from(200)));
-    assert_eq!(found_slots[2], (B256::repeat_byte(0x30), U256::from(300)));
-    assert_eq!(found_slots[3], (B256::repeat_byte(0x40), U256::from(400)));
-
-    // Now create a HashedPostState with wiped=true for this address at block 100
-    let mut post_state = HashedPostState::default();
-    let wiped_storage = HashedStorage::new(true); // wiped=true, empty storage map
-    post_state.storages.insert(hashed_address, wiped_storage);
-
-    let block_state_diff = BlockStateDiff {
-        sorted_trie_updates: TrieUpdatesSorted::default(),
-        sorted_post_state: post_state.into_sorted(),
-    };
-
-    // Store the wiped state
-    storage.store_trie_updates(block_ref, block_state_diff)?;
-
-    // After wiping, cursor at block 150 should see NO storage values
-    let mut cursor150 = storage.storage_hashed_cursor(hashed_address, 150)?;
-    let mut found_slots_after_wipe = Vec::new();
-    while let Some((key, value)) = cursor150.next()? {
-        found_slots_after_wipe.push((key, value));
-    }
-
-    assert_eq!(
-        found_slots_after_wipe.len(),
-        0,
-        "All storage slots should be deleted after wipe. Found: {found_slots_after_wipe:?}"
-    );
-
-    // Verify individual seeks also return None
-    for (slot, _) in &storage_slots {
-        let mut seek_cursor = storage.storage_hashed_cursor(hashed_address, 150)?;
-        let result = seek_cursor.seek(*slot)?;
-        assert!(
-            result.is_none() || result.unwrap().0 != *slot,
-            "Storage slot {slot:?} should be deleted after wipe"
-        );
-    }
-
-    // Verify cursor at block 75 (before wipe) still sees all values
-    let mut cursor75_after = storage.storage_hashed_cursor(hashed_address, 75)?;
-    let mut found_slots_before_wipe = Vec::new();
-    while let Some((key, value)) = cursor75_after.next()? {
-        found_slots_before_wipe.push((key, value));
-    }
-    assert_eq!(
-        found_slots_before_wipe.len(),
-        4,
-        "All storage slots should still be present when querying before wipe block"
-    );
-
+    let mut cursor = storage.storage_hashed_cursor(hashed_address, at)?;
+    assert_eq!(cursor.seek(slot)?, Some((slot, expected)));
     Ok(())
 }
 
-/// When a [`HashedPostState`] entry has `wiped = true` AND non-empty `storage` (the shape revm
-/// produces for `AccountStatus::DestroyedChanged` accounts that are destroyed and recreated in
-/// the same block), `store_trie_updates` must tombstone every prior storage slot for the address
-/// at `block_number` AND persist the new post-recreation slot values from `storage`. Dropping
-/// the new slots corrupts `HashedStorageHistory` and makes `BaseProofsStateProviderRef::storage`
-/// return `None` for the new slots, producing divergent storage / state / output roots
-/// downstream of `LiveTrieCollector`.
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_store_trie_updates_with_wiped_storage_and_new_slots<
-    S: BaseProofsStore + BaseProofsInitialStateStore,
->(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    let hashed_address = B256::repeat_byte(0x01);
-    let block_ref = BlockWithParent::new(B256::ZERO, NumHash::new(100, B256::repeat_byte(0x96)));
-
-    let pre_existing_slots = vec![
-        (B256::repeat_byte(0x10), U256::from(100)),
-        (B256::repeat_byte(0x20), U256::from(200)),
-    ];
-    storage.store_hashed_storages(hashed_address, pre_existing_slots.clone())?;
-
-    let new_slot_kept = (B256::repeat_byte(0x30), U256::from(0xCAFE));
-    let new_slot_overwriting_old = (B256::repeat_byte(0x10), U256::from(0xBEEF));
-
-    let mut post_state = HashedPostState::default();
-    let wiped_with_new =
-        HashedStorage::from_iter(true, vec![new_slot_kept, new_slot_overwriting_old]);
-    post_state.storages.insert(hashed_address, wiped_with_new);
-
-    let block_state_diff = BlockStateDiff {
-        sorted_trie_updates: TrieUpdatesSorted::default(),
-        sorted_post_state: post_state.into_sorted(),
-    };
-
-    storage.store_trie_updates(block_ref, block_state_diff)?;
-
-    let mut cursor150 = storage.storage_hashed_cursor(hashed_address, 150)?;
-    let mut found = Vec::new();
-    while let Some((key, value)) = cursor150.next()? {
-        found.push((key, value));
-    }
-
-    assert_eq!(
-        found,
-        vec![new_slot_overwriting_old, new_slot_kept],
-        "After wipe+recreate, only the new post-recreation slots must be visible",
-    );
-
-    let mut seek_kept = storage.storage_hashed_cursor(hashed_address, 150)?;
-    assert_eq!(
-        seek_kept.seek(new_slot_kept.0)?,
-        Some(new_slot_kept),
-        "New slot 0x30 = 0xCAFE must round-trip through the cursor",
-    );
-
-    let mut seek_overwritten = storage.storage_hashed_cursor(hashed_address, 150)?;
-    assert_eq!(
-        seek_overwritten.seek(new_slot_overwriting_old.0)?,
-        Some(new_slot_overwriting_old),
-        "Reused slot 0x10 must reflect the new post-recreation value 0xBEEF, not the wiped 100",
-    );
-
-    let mut seek_dropped = storage.storage_hashed_cursor(hashed_address, 150)?;
-    assert_eq!(
-        seek_dropped.seek(B256::repeat_byte(0x20))?,
-        Some(new_slot_kept),
-        "seek(0x20) must skip the tombstoned old slot and advance to the next visible entry \
-         (0x30 = 0xCAFE), proving 0x20 is not visible at block 150",
-    );
-
-    let mut cursor75 = storage.storage_hashed_cursor(hashed_address, 75)?;
-    let mut pre_wipe_found = Vec::new();
-    while let Some((key, value)) = cursor75.next()? {
-        pre_wipe_found.push((key, value));
-    }
-    assert_eq!(
-        pre_wipe_found, pre_existing_slots,
-        "Cursor positioned before the wipe block must still see the original slot values",
-    );
-
-    Ok(())
-}
-
-/// Test that `store_trie_updates` properly stores branch nodes, leaf nodes, and removals
-///
-/// This test verifies that all data stored via `store_trie_updates` can be read back
-/// through the cursor APIs.
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_store_trie_updates_comprehensive<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    use reth_trie::{HashedStorage, updates::StorageTrieUpdates};
-
-    let block_ref = BlockWithParent::new(B256::ZERO, NumHash::new(100, B256::repeat_byte(0x96)));
-
-    // Create comprehensive trie updates with branches, leaves, and removals
-    let mut trie_updates = TrieUpdates::default();
-
-    // Add account branch nodes
-    let account_path1 = nibbles_from(vec![1, 2, 3]);
-    let account_path2 = nibbles_from(vec![4, 5, 6]);
-    let account_branch1 = create_test_branch();
-    let account_branch2 = create_test_branch_variant();
-
-    trie_updates.account_nodes.insert(account_path1, account_branch1);
-    trie_updates.account_nodes.insert(account_path2, account_branch2);
-
-    // Add removed account nodes
-    let removed_account_path = nibbles_from(vec![7, 8, 9]);
-    trie_updates.removed_nodes.insert(removed_account_path);
-
-    // Add storage branch nodes for an address
-    let hashed_address = B256::repeat_byte(0x42);
-    let storage_path1 = nibbles_from(vec![1, 1]);
-    let storage_path2 = nibbles_from(vec![2, 2]);
-    let storage_branch = create_test_branch();
-
-    let mut storage_trie = StorageTrieUpdates::default();
-    storage_trie.storage_nodes.insert(storage_path1, storage_branch.clone());
-    storage_trie.storage_nodes.insert(storage_path2, storage_branch);
-
-    // Add removed storage node
-    let removed_storage_path = nibbles_from(vec![3, 3]);
-    storage_trie.removed_nodes.insert(removed_storage_path);
-
-    trie_updates.insert_storage_updates(hashed_address, storage_trie);
-
-    // Create post state with accounts and storage
-    let mut post_state = HashedPostState::default();
-
-    // Add accounts
-    let account1_addr = B256::repeat_byte(0x10);
-    let account2_addr = B256::repeat_byte(0x20);
-    let account1 = create_test_account_with_values(1, 1000, 0xAA);
-    let account2 = create_test_account_with_values(2, 2000, 0xBB);
-
-    post_state.accounts.insert(account1_addr, Some(account1));
-    post_state.accounts.insert(account2_addr, Some(account2));
-
-    // Add deleted account
-    let deleted_account_addr = B256::repeat_byte(0x30);
-    post_state.accounts.insert(deleted_account_addr, None);
-
-    // Add storage for an address
-    let storage_addr = B256::repeat_byte(0x50);
-    let mut hashed_storage = HashedStorage::new(false);
-    hashed_storage.storage.insert(B256::repeat_byte(0x01), U256::from(111));
-    hashed_storage.storage.insert(B256::repeat_byte(0x02), U256::from(222));
-    hashed_storage.storage.insert(B256::repeat_byte(0x03), U256::ZERO); // Deleted storage
-    post_state.storages.insert(storage_addr, hashed_storage);
-
-    let block_state_diff = BlockStateDiff {
-        sorted_trie_updates: trie_updates.into_sorted(),
-        sorted_post_state: post_state.into_sorted(),
-    };
-
-    // Store the updates
-    storage.store_trie_updates(block_ref, block_state_diff)?;
-
-    // ========== Verify Account Branch Nodes ==========
-    let mut account_trie_cursor = storage.account_trie_cursor(block_ref.block.number + 10)?;
-
-    // Should find the added branches
-    let result1 = account_trie_cursor.seek_exact(account_path1)?;
-    assert!(result1.is_some(), "Account branch node 1 should be found");
-    assert_eq!(result1.unwrap().0, account_path1);
-
-    let result2 = account_trie_cursor.seek_exact(account_path2)?;
-    assert!(result2.is_some(), "Account branch node 2 should be found");
-    assert_eq!(result2.unwrap().0, account_path2);
-
-    // Removed node should not be found
-    let removed_result = account_trie_cursor.seek_exact(removed_account_path)?;
-    assert!(removed_result.is_none(), "Removed account node should not be found");
-
-    // ========== Verify Storage Branch Nodes ==========
-    let mut storage_trie_cursor =
-        storage.storage_trie_cursor(hashed_address, block_ref.block.number + 10)?;
-
-    let storage_result1 = storage_trie_cursor.seek_exact(storage_path1)?;
-    assert!(storage_result1.is_some(), "Storage branch node 1 should be found");
-
-    let storage_result2 = storage_trie_cursor.seek_exact(storage_path2)?;
-    assert!(storage_result2.is_some(), "Storage branch node 2 should be found");
-
-    // Removed storage node should not be found
-    let removed_storage_result = storage_trie_cursor.seek_exact(removed_storage_path)?;
-    assert!(removed_storage_result.is_none(), "Removed storage node should not be found");
-
-    // ========== Verify Account Leaves ==========
-    let mut account_cursor = storage.account_hashed_cursor(block_ref.block.number + 10)?;
-
-    let acc1_result = account_cursor.seek(account1_addr)?;
-    assert!(acc1_result.is_some(), "Account 1 should be found");
-    assert_eq!(acc1_result.unwrap().0, account1_addr);
-    assert_eq!(acc1_result.unwrap().1.nonce, 1);
-    assert_eq!(acc1_result.unwrap().1.balance, U256::from(1000));
-
-    let acc2_result = account_cursor.seek(account2_addr)?;
-    assert!(acc2_result.is_some(), "Account 2 should be found");
-    assert_eq!(acc2_result.unwrap().1.nonce, 2);
-
-    // Deleted account should not be found
-    let deleted_acc_result = account_cursor.seek(deleted_account_addr)?;
-    assert!(
-        deleted_acc_result.is_none() || deleted_acc_result.unwrap().0 != deleted_account_addr,
-        "Deleted account should not be found"
-    );
-
-    // ========== Verify Storage Leaves ==========
-    let mut storage_cursor =
-        storage.storage_hashed_cursor(storage_addr, block_ref.block.number + 10)?;
-
-    let slot1_result = storage_cursor.seek(B256::repeat_byte(0x01))?;
-    assert!(slot1_result.is_some(), "Storage slot 1 should be found");
-    assert_eq!(slot1_result.unwrap().1, U256::from(111));
-
-    let slot2_result = storage_cursor.seek(B256::repeat_byte(0x02))?;
-    assert!(slot2_result.is_some(), "Storage slot 2 should be found");
-    assert_eq!(slot2_result.unwrap().1, U256::from(222));
-
-    // Zero-valued storage should not be found (deleted)
-    let slot3_result = storage_cursor.seek(B256::repeat_byte(0x03))?;
-    assert!(
-        slot3_result.is_none() || slot3_result.unwrap().0 != B256::repeat_byte(0x03),
-        "Zero-valued storage slot should not be found"
-    );
-
-    // ========== Verify fetch_trie_updates can retrieve the data ==========
-    let fetched_diff = storage.fetch_trie_updates(block_ref.block.number)?;
-
-    // Check that trie updates are stored
-    assert_eq!(
-        fetched_diff.sorted_trie_updates.account_nodes_ref().len(),
-        3,
-        "Should have 3 account nodes, including removed"
-    );
-    assert_eq!(
-        fetched_diff.sorted_trie_updates.storage_tries_ref().len(),
-        1,
-        "Should have 1 storage trie"
-    );
-
-    // Check that post state is stored
-    assert_eq!(
-        fetched_diff.sorted_post_state.accounts.len(),
-        3,
-        "Should have 3 accounts (including deleted)"
-    );
-    assert_eq!(fetched_diff.sorted_post_state.storages.len(), 1, "Should have 1 storage entry");
-
-    Ok(())
-}
-
-/// Test that `replace_updates` properly applies hashed/trie storage updates to the DB
-///
-/// This test verifies the bug fix where `replace_updates` was only storing `trie_updates`
-/// and `post_states` directly without populating the internal data structures
-/// (`hashed_accounts`, `hashed_storages`, `account_branches`, `storage_branches`).
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_replace_updates_applies_all_updates<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    use reth_trie::{HashedStorage, updates::StorageTrieUpdates};
-
-    let block_ref_50 = BlockWithParent::new(B256::ZERO, NumHash::new(50, B256::repeat_byte(0x96)));
-
-    // ========== Setup: Store initial state at blocks 50, 100, 101 ==========
-    let initial_account_addr = B256::repeat_byte(0x10);
-    let initial_account = create_test_account_with_values(1, 1000, 0xAA);
-
-    let initial_storage_addr = B256::repeat_byte(0x20);
-    let initial_storage_slot = B256::repeat_byte(0x01);
-    let initial_storage_value = U256::from(100);
-
-    let initial_branch_path = nibbles_from(vec![1, 2, 3]);
-    let initial_branch = create_test_branch();
-
-    // Store initial data at block 50
-    let mut initial_trie_updates_50 = TrieUpdates::default();
-    initial_trie_updates_50.account_nodes.insert(initial_branch_path, initial_branch.clone());
-
-    let mut initial_post_state_50 = HashedPostState::default();
-    initial_post_state_50.accounts.insert(initial_account_addr, Some(initial_account));
-
-    let initial_diff_50 = BlockStateDiff {
-        sorted_trie_updates: initial_trie_updates_50.into_sorted(),
-        sorted_post_state: initial_post_state_50.into_sorted(),
-    };
-    storage.store_trie_updates(block_ref_50, initial_diff_50)?;
-
-    // Store data at block 100 (common block)
-    let mut initial_trie_updates_100 = TrieUpdates::default();
-    let common_branch_path = nibbles_from(vec![4, 5, 6]);
-    initial_trie_updates_100.account_nodes.insert(common_branch_path, initial_branch.clone());
-
-    let mut initial_post_state_100 = HashedPostState::default();
-    let mut initial_storage_100 = HashedStorage::new(false);
-    initial_storage_100.storage.insert(initial_storage_slot, initial_storage_value);
-    initial_post_state_100.storages.insert(initial_storage_addr, initial_storage_100);
-
-    let initial_diff_100 = BlockStateDiff {
-        sorted_trie_updates: initial_trie_updates_100.into_sorted(),
-        sorted_post_state: initial_post_state_100.into_sorted(),
-    };
-
-    let block_ref_100 =
-        BlockWithParent::new(block_ref_50.block.hash, NumHash::new(100, B256::repeat_byte(0x97)));
-
-    storage.store_trie_updates(block_ref_100, initial_diff_100)?;
-
-    // Store data at block 101 (will be replaced)
-    let mut initial_trie_updates_101 = TrieUpdates::default();
-    let old_branch_path = nibbles_from(vec![7, 8, 9]);
-    initial_trie_updates_101.account_nodes.insert(old_branch_path, initial_branch);
-
-    let mut initial_post_state_101 = HashedPostState::default();
-    let old_account_addr = B256::repeat_byte(0x30);
-    let old_account = create_test_account_with_values(99, 9999, 0xFF);
-    initial_post_state_101.accounts.insert(old_account_addr, Some(old_account));
-
-    let initial_diff_101 = BlockStateDiff {
-        sorted_trie_updates: initial_trie_updates_101.into_sorted(),
-        sorted_post_state: initial_post_state_101.into_sorted(),
-    };
-    let block_ref_101 =
-        BlockWithParent::new(block_ref_100.block.hash, NumHash::new(101, B256::repeat_byte(0x98)));
-    storage.store_trie_updates(block_ref_101, initial_diff_101)?;
-
-    let block_ref_102 =
-        BlockWithParent::new(block_ref_101.block.hash, NumHash::new(102, B256::repeat_byte(0x99)));
-
-    // ========== Verify initial state exists ==========
-    // Verify block 50 data exists
-    let mut cursor_initial = storage.account_trie_cursor(75)?;
-    assert!(
-        cursor_initial.seek_exact(initial_branch_path)?.is_some(),
-        "Initial branch should exist before replace"
-    );
-
-    // Verify block 101 old data exists
-    let mut cursor_old = storage.account_trie_cursor(150)?;
-    assert!(
-        cursor_old.seek_exact(old_branch_path)?.is_some(),
-        "Old branch at block 101 should exist before replace"
-    );
-
-    let mut account_cursor_old = storage.account_hashed_cursor(150)?;
-    assert!(
-        account_cursor_old.seek(old_account_addr)?.is_some(),
-        "Old account at block 101 should exist before replace"
-    );
-
-    // ========== Call replace_updates to replace blocks after 100 ==========
-    let mut blocks_to_add: Vec<(BlockWithParent, BlockStateDiff)> = Vec::default();
-
-    // New data for block 101
-    let new_account_addr = B256::repeat_byte(0x40);
-    let new_account = create_test_account_with_values(5, 5000, 0xCC);
-
-    let new_storage_addr = B256::repeat_byte(0x50);
-    let new_storage_slot = B256::repeat_byte(0x02);
-    let new_storage_value = U256::from(999);
-
-    let new_branch_path = nibbles_from(vec![10, 11, 12]);
-    let new_branch = create_test_branch_variant();
-
-    let storage_branch_path = nibbles_from(vec![5, 5]);
-    let storage_hashed_addr = B256::repeat_byte(0x60);
-
-    let mut new_trie_updates = TrieUpdates::default();
-    new_trie_updates.account_nodes.insert(new_branch_path, new_branch.clone());
-
-    // Add storage trie updates
-    let mut storage_trie = StorageTrieUpdates::default();
-    storage_trie.storage_nodes.insert(storage_branch_path, new_branch.clone());
-    new_trie_updates.insert_storage_updates(storage_hashed_addr, storage_trie);
-
-    let mut new_post_state = HashedPostState::default();
-    new_post_state.accounts.insert(new_account_addr, Some(new_account));
-
-    let mut new_storage = HashedStorage::new(false);
-    new_storage.storage.insert(new_storage_slot, new_storage_value);
-    new_post_state.storages.insert(new_storage_addr, new_storage);
-
-    blocks_to_add.push((
-        block_ref_101,
-        BlockStateDiff {
-            sorted_trie_updates: new_trie_updates.into_sorted(),
-            sorted_post_state: new_post_state.into_sorted(),
-        },
-    ));
-
-    // New data for block 102
-    let block_102_account_addr = B256::repeat_byte(0x70);
-    let block_102_account = create_test_account_with_values(10, 10000, 0xDD);
-
-    let mut trie_updates_102 = TrieUpdates::default();
-    let block_102_branch_path = nibbles_from(vec![15, 14, 13]);
-    trie_updates_102.account_nodes.insert(block_102_branch_path, new_branch);
-
-    let mut post_state_102 = HashedPostState::default();
-    post_state_102.accounts.insert(block_102_account_addr, Some(block_102_account));
-
-    blocks_to_add.push((
-        block_ref_102,
-        BlockStateDiff {
-            sorted_trie_updates: trie_updates_102.into_sorted(),
-            sorted_post_state: post_state_102.into_sorted(),
-        },
-    ));
-
-    // Execute replace_updates
-    storage.replace_updates(BlockNumHash::new(100, block_ref_100.block.hash), blocks_to_add)?;
-    // ========== Verify that data up to block 100 still exists ==========
-    let mut cursor_50 = storage.account_trie_cursor(75)?;
-    assert!(
-        cursor_50.seek_exact(initial_branch_path)?.is_some(),
-        "Block 50 branch should still exist after replace"
-    );
-
-    let mut cursor_100 = storage.account_trie_cursor(100)?;
-    assert!(
-        cursor_100.seek_exact(common_branch_path)?.is_some(),
-        "Block 100 branch should still exist after replace"
-    );
-
-    let mut storage_cursor_100 = storage.storage_hashed_cursor(initial_storage_addr, 100)?;
-    let result_100 = storage_cursor_100.seek(initial_storage_slot)?;
-    assert!(result_100.is_some(), "Block 100 storage should still exist after replace");
-    assert_eq!(
-        result_100.unwrap().1,
-        initial_storage_value,
-        "Block 100 storage value should be unchanged"
-    );
-
-    // ========== Verify that old data after block 100 is gone ==========
-    let mut cursor_old_gone = storage.account_trie_cursor(150)?;
-    assert!(
-        cursor_old_gone.seek_exact(old_branch_path)?.is_none(),
-        "Old branch at block 101 should be removed after replace"
-    );
-
-    let mut account_cursor_old_gone = storage.account_hashed_cursor(150)?;
-    let old_acc_result = account_cursor_old_gone.seek(old_account_addr)?;
-    assert!(
-        old_acc_result.is_none() || old_acc_result.unwrap().0 != old_account_addr,
-        "Old account at block 101 should be removed after replace"
-    );
-
-    // ========== Verify new data is properly accessible via cursors ==========
-
-    // Verify new account branch nodes
-    let mut trie_cursor = storage.account_trie_cursor(150)?;
-    let branch_result = trie_cursor.seek_exact(new_branch_path)?;
-    assert!(branch_result.is_some(), "New account branch should be accessible via cursor");
-    assert_eq!(branch_result.unwrap().0, new_branch_path);
-
-    // Verify new storage branch nodes
-    let mut storage_trie_cursor = storage.storage_trie_cursor(storage_hashed_addr, 150)?;
-    let storage_branch_result = storage_trie_cursor.seek_exact(storage_branch_path)?;
-    assert!(storage_branch_result.is_some(), "New storage branch should be accessible via cursor");
-    assert_eq!(storage_branch_result.unwrap().0, storage_branch_path);
-
-    // Verify new hashed accounts
-    let mut account_cursor = storage.account_hashed_cursor(150)?;
-    let account_result = account_cursor.seek(new_account_addr)?;
-    assert!(account_result.is_some(), "New account should be accessible via cursor");
-    assert_eq!(account_result.as_ref().unwrap().0, new_account_addr);
-    assert_eq!(account_result.as_ref().unwrap().1.nonce, new_account.nonce);
-    assert_eq!(account_result.as_ref().unwrap().1.balance, new_account.balance);
-    assert_eq!(account_result.as_ref().unwrap().1.bytecode_hash, new_account.bytecode_hash);
-
-    // Verify new hashed storages
-    let mut storage_cursor = storage.storage_hashed_cursor(new_storage_addr, 150)?;
-    let storage_result = storage_cursor.seek(new_storage_slot)?;
-    assert!(storage_result.is_some(), "New storage should be accessible via cursor");
-    assert_eq!(storage_result.as_ref().unwrap().0, new_storage_slot);
-    assert_eq!(storage_result.as_ref().unwrap().1, new_storage_value);
-
-    // Verify block 102 data
-    let mut trie_cursor_102 = storage.account_trie_cursor(150)?;
-    let branch_result_102 = trie_cursor_102.seek_exact(block_102_branch_path)?;
-    assert!(branch_result_102.is_some(), "Block 102 branch should be accessible");
-    assert_eq!(branch_result_102.unwrap().0, block_102_branch_path);
-
-    let mut account_cursor_102 = storage.account_hashed_cursor(150)?;
-    let account_result_102 = account_cursor_102.seek(block_102_account_addr)?;
-    assert!(account_result_102.is_some(), "Block 102 account should be accessible");
-    assert_eq!(account_result_102.as_ref().unwrap().0, block_102_account_addr);
-    assert_eq!(account_result_102.as_ref().unwrap().1.nonce, block_102_account.nonce);
-
-    // Verify fetch_trie_updates returns the new data
-    let fetched_101 = storage.fetch_trie_updates(101)?;
-    assert_eq!(
-        fetched_101.sorted_trie_updates.account_nodes_ref().len(),
-        1,
-        "Should have 1 account branch node at block 101"
-    );
-    assert!(
-        fetched_101
-            .sorted_trie_updates
-            .account_nodes_ref()
-            .iter()
-            .any(|(addr, _)| *addr == new_branch_path),
-        "New branch path should be in trie_updates"
-    );
-    assert_eq!(
-        fetched_101.sorted_post_state.accounts.len(),
-        1,
-        "Should have 1 account at block 101"
-    );
-    assert!(
-        fetched_101.sorted_post_state.accounts.iter().any(|(addr, _)| *addr == new_account_addr),
-        "New account should be in post_state"
-    );
-
-    Ok(())
-}
-
-/// Test that pure deletions (nodes only in `removed_nodes`) are properly stored
-///
-/// This test verifies that when a node appears only in `removed_nodes` (not in updates),
-/// it is properly stored as a deletion and subsequent queries return None for that path.
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_pure_deletions_stored_correctly<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    use reth_trie::updates::StorageTrieUpdates;
-
-    // ========== Setup: Store initial branch nodes at block 50 ==========
-    let account_path1 = nibbles_from(vec![1, 2, 3]);
-    let account_path2 = nibbles_from(vec![4, 5, 6]);
-    let storage_path1 = nibbles_from(vec![7, 8, 9]);
-    let storage_path2 = nibbles_from(vec![10, 11, 12]);
-    let storage_address = B256::repeat_byte(0x42);
-
-    let initial_branch = create_test_branch();
-
-    let mut initial_trie_updates = TrieUpdates::default();
-    initial_trie_updates.account_nodes.insert(account_path1, initial_branch.clone());
-    initial_trie_updates.account_nodes.insert(account_path2, initial_branch.clone());
-
-    let mut storage_trie = StorageTrieUpdates::default();
-    storage_trie.storage_nodes.insert(storage_path1, initial_branch.clone());
-    storage_trie.storage_nodes.insert(storage_path2, initial_branch);
-    initial_trie_updates.insert_storage_updates(storage_address, storage_trie);
-
-    let initial_diff = BlockStateDiff {
-        sorted_trie_updates: initial_trie_updates.into_sorted(),
-        sorted_post_state: HashedPostStateSorted::default(),
-    };
-
-    let block_ref_50 = BlockWithParent::new(B256::ZERO, NumHash::new(50, B256::repeat_byte(0x96)));
-
-    storage.store_trie_updates(block_ref_50, initial_diff)?;
-
-    // Verify initial state exists at block 75
-    let mut cursor_75 = storage.account_trie_cursor(75)?;
-    assert!(
-        cursor_75.seek_exact(account_path1)?.is_some(),
-        "Initial account branch 1 should exist at block 75"
-    );
-    assert!(
-        cursor_75.seek_exact(account_path2)?.is_some(),
-        "Initial account branch 2 should exist at block 75"
-    );
-
-    let mut storage_cursor_75 = storage.storage_trie_cursor(storage_address, 75)?;
-    assert!(
-        storage_cursor_75.seek_exact(storage_path1)?.is_some(),
-        "Initial storage branch 1 should exist at block 75"
-    );
-    assert!(
-        storage_cursor_75.seek_exact(storage_path2)?.is_some(),
-        "Initial storage branch 2 should exist at block 75"
-    );
-
-    // ========== At block 100: Mark paths as deleted (ONLY in removed_nodes) ==========
-    let mut deletion_trie_updates = TrieUpdates::default();
-
-    // Add to removed_nodes ONLY (no updates)
-    deletion_trie_updates.removed_nodes.insert(account_path1);
-
-    // Do the same for storage branch
-    let mut deletion_storage_trie = StorageTrieUpdates::default();
-    deletion_storage_trie.removed_nodes.insert(storage_path1);
-    deletion_trie_updates.insert_storage_updates(storage_address, deletion_storage_trie);
-
-    let deletion_diff = BlockStateDiff {
-        sorted_trie_updates: deletion_trie_updates.into_sorted(),
-        sorted_post_state: HashedPostStateSorted::default(),
-    };
-
-    let block_ref_100 =
-        BlockWithParent::new(B256::repeat_byte(0x96), NumHash::new(100, B256::repeat_byte(0x97)));
-
-    storage.store_trie_updates(block_ref_100, deletion_diff)?;
-
-    // ========== Verify that deleted nodes return None at block 150 ==========
-
-    // Deleted account branch should not be found
-    let mut cursor_150 = storage.account_trie_cursor(150)?;
-    let account_result = cursor_150.seek_exact(account_path1)?;
-    assert!(account_result.is_none(), "Deleted account branch should return None at block 150");
-
-    // Non-deleted account branch should still exist
-    let account_result2 = cursor_150.seek_exact(account_path2)?;
-    assert!(
-        account_result2.is_some(),
-        "Non-deleted account branch should still exist at block 150"
-    );
-
-    // Deleted storage branch should not be found
-    let mut storage_cursor_150 = storage.storage_trie_cursor(storage_address, 150)?;
-    let storage_result = storage_cursor_150.seek_exact(storage_path1)?;
-    assert!(storage_result.is_none(), "Deleted storage branch should return None at block 150");
-
-    // Non-deleted storage branch should still exist
-    let storage_result2 = storage_cursor_150.seek_exact(storage_path2)?;
-    assert!(
-        storage_result2.is_some(),
-        "Non-deleted storage branch should still exist at block 150"
-    );
-
-    // ========== Verify that the nodes still exist at block 75 (before deletion) ==========
-    let mut cursor_75_after = storage.account_trie_cursor(75)?;
-    assert!(
-        cursor_75_after.seek_exact(account_path1)?.is_some(),
-        "Deleted node should still exist at block 75 (before deletion)"
-    );
-
-    let mut storage_cursor_75_after = storage.storage_trie_cursor(storage_address, 75)?;
-    assert!(
-        storage_cursor_75_after.seek_exact(storage_path1)?.is_some(),
-        "Deleted storage node should still exist at block 75 (before deletion)"
-    );
-
-    // ========== Verify iteration skips deleted nodes ==========
-    let mut cursor_iter = storage.account_trie_cursor(150)?;
-    let mut found_paths = Vec::new();
-    while let Some((path, _)) = cursor_iter.next()? {
-        found_paths.push(path);
-    }
-
-    assert!(!found_paths.contains(&account_path1), "Iteration should skip deleted node");
-    assert!(found_paths.contains(&account_path2), "Iteration should include non-deleted node");
-
-    Ok(())
-}
-
-/// Test that updates take precedence over removals when both are present
-///
-/// This test verifies that when a path appears in both `removed_nodes` and `account_nodes`,
-/// the update from `account_nodes` takes precedence. This is critical for correctness
-/// when processing trie updates that both remove and update the same node.
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_updates_take_precedence_over_removals<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    use reth_trie::updates::StorageTrieUpdates;
-
-    // ========== Setup: Store initial branch nodes at block 50 ==========
-    let account_path = nibbles_from(vec![1, 2, 3]);
-    let storage_path = nibbles_from(vec![4, 5, 6]);
-    let storage_address = B256::repeat_byte(0x42);
-
-    let initial_branch = create_test_branch();
-
-    let mut initial_trie_updates = TrieUpdates::default();
-    initial_trie_updates.account_nodes.insert(account_path, initial_branch.clone());
-
-    let mut storage_trie = StorageTrieUpdates::default();
-    storage_trie.storage_nodes.insert(storage_path, initial_branch.clone());
-    initial_trie_updates.insert_storage_updates(storage_address, storage_trie);
-
-    let initial_diff = BlockStateDiff {
-        sorted_trie_updates: initial_trie_updates.into_sorted(),
-        sorted_post_state: HashedPostStateSorted::default(),
-    };
-
-    let block_ref_50 = BlockWithParent::new(B256::ZERO, NumHash::new(50, B256::repeat_byte(0x96)));
-
-    storage.store_trie_updates(block_ref_50, initial_diff)?;
-
-    // Verify initial state exists at block 75
-    let mut cursor_75 = storage.account_trie_cursor(75)?;
-    assert!(
-        cursor_75.seek_exact(account_path)?.is_some(),
-        "Initial account branch should exist at block 75"
-    );
-
-    let mut storage_cursor_75 = storage.storage_trie_cursor(storage_address, 75)?;
-    assert!(
-        storage_cursor_75.seek_exact(storage_path)?.is_some(),
-        "Initial storage branch should exist at block 75"
-    );
-
-    // ========== At block 100: Add paths to BOTH removed_nodes AND account_nodes ==========
-    // This simulates a scenario where a node is both removed and updated
-    // The update should take precedence
-    let updated_branch = create_test_branch_variant();
-
-    let mut conflicting_trie_updates = TrieUpdates::default();
-
-    // Add to removed_nodes
-    conflicting_trie_updates.removed_nodes.insert(account_path);
-
-    // Also add to account_nodes (this should take precedence)
-    conflicting_trie_updates.account_nodes.insert(account_path, updated_branch.clone());
-
-    // Do the same for storage branch
-    let mut conflicting_storage_trie = StorageTrieUpdates::default();
-    conflicting_storage_trie.removed_nodes.insert(storage_path);
-    conflicting_storage_trie.storage_nodes.insert(storage_path, updated_branch.clone());
-    conflicting_trie_updates.insert_storage_updates(storage_address, conflicting_storage_trie);
-
-    let conflicting_diff = BlockStateDiff {
-        sorted_trie_updates: conflicting_trie_updates.into_sorted(),
-        sorted_post_state: HashedPostStateSorted::default(),
-    };
-
-    let block_ref_100 =
-        BlockWithParent::new(B256::repeat_byte(0x96), NumHash::new(100, B256::repeat_byte(0x97)));
-
-    storage.store_trie_updates(block_ref_100, conflicting_diff)?;
-
-    // ========== Verify that updates took precedence at block 150 ==========
-
-    // Account branch should exist (not deleted) with the updated value
-    let mut cursor_150 = storage.account_trie_cursor(150)?;
-    let account_result = cursor_150.seek_exact(account_path)?;
-    assert!(
-        account_result.is_some(),
-        "Account branch should exist at block 150 (update should take precedence over removal)"
-    );
-    let (found_path, found_branch) = account_result.unwrap();
-    assert_eq!(found_path, account_path);
-    // Verify it's the updated branch, not the initial one
-    assert_eq!(
-        found_branch.state_mask, updated_branch.state_mask,
-        "Account branch should be the updated version, not the initial one"
-    );
-
-    // Storage branch should exist (not deleted) with the updated value
-    let mut storage_cursor_150 = storage.storage_trie_cursor(storage_address, 150)?;
-    let storage_result = storage_cursor_150.seek_exact(storage_path)?;
-    assert!(
-        storage_result.is_some(),
-        "Storage branch should exist at block 150 (update should take precedence over removal)"
-    );
-    let (found_storage_path, found_storage_branch) = storage_result.unwrap();
-    assert_eq!(found_storage_path, storage_path);
-    // Verify it's the updated branch
-    assert_eq!(
-        found_storage_branch.state_mask, updated_branch.state_mask,
-        "Storage branch should be the updated version, not the initial one"
-    );
-
-    // ========== Verify that the old version still exists at block 75 ==========
-    let mut cursor_75_after = storage.account_trie_cursor(75)?;
-    let result_75 = cursor_75_after.seek_exact(account_path)?;
-    assert!(result_75.is_some(), "Initial version should still exist at block 75");
-    let (_, branch_75) = result_75.unwrap();
-    assert_eq!(
-        branch_75.state_mask, initial_branch.state_mask,
-        "Block 75 should see the initial branch, not the updated one"
-    );
-
-    Ok(())
-}
+mod branch_cursors;
+mod hashed_cursors;
+mod history;
+mod proof_window;
+mod trie_updates;

--- a/crates/execution/trie/tests/live.rs
+++ b/crates/execution/trie/tests/live.rs
@@ -1,12 +1,12 @@
 //! End-to-end test of the live trie collector.
 
-use std::sync::Arc;
+use std::{path::Path, sync::Arc};
 
-use alloy_consensus::{BlockHeader, Header, TxEip2930, constants::ETH_TO_WEI};
+use alloy_consensus::{BlockHeader, Header, SignableTransaction, TxEip2930, constants::ETH_TO_WEI};
 use alloy_genesis::{Genesis, GenesisAccount};
 use alloy_primitives::{Address, B256, TxKind, U256, keccak256};
 use base_execution_trie::{
-    BaseProofsStorage, BaseProofsStorageError, MdbxProofsStorage, initialize::InitializationJob,
+    BaseProofsStorage, BaseProofsStorageError, RocksdbProofsStorage, initialize::InitializationJob,
     live::LiveTrieCollector,
 };
 use derive_more::Constructor;
@@ -17,7 +17,7 @@ use reth_ethereum_primitives::{Block, BlockBody, Receipt, Transaction, Transacti
 use reth_evm::{ConfigureEvm, execute::Executor};
 use reth_evm_ethereum::EthEvmConfig;
 use reth_node_api::{NodePrimitives, NodeTypesWithDB};
-use reth_primitives_traits::{Block as _, RecoveredBlock};
+use reth_primitives_traits::{Block as _, RecoveredBlock, crypto::secp256k1::sign_message};
 use reth_provider::{
     BlockWriter as _, ExecutionOutcome, HashedPostStateProvider, LatestStateProviderRef,
     ProviderFactory, StateRootProvider,
@@ -28,6 +28,30 @@ use reth_revm::database::StateProviderDatabase;
 use secp256k1::{Keypair, Secp256k1};
 use tempfile::TempDir;
 
+#[cfg(not(feature = "metrics"))]
+fn rocksdb_storage(path: &Path) -> BaseProofsStorage<Arc<RocksdbProofsStorage>> {
+    Arc::new(RocksdbProofsStorage::new(path).expect("env"))
+}
+
+#[cfg(feature = "metrics")]
+fn rocksdb_storage(path: &Path) -> BaseProofsStorage<Arc<RocksdbProofsStorage>> {
+    Arc::new(RocksdbProofsStorage::new(path).expect("env")).into()
+}
+
+#[cfg(not(feature = "metrics"))]
+fn clone_storage(
+    storage: &BaseProofsStorage<Arc<RocksdbProofsStorage>>,
+) -> BaseProofsStorage<Arc<RocksdbProofsStorage>> {
+    Arc::clone(storage)
+}
+
+#[cfg(feature = "metrics")]
+fn clone_storage(
+    storage: &BaseProofsStorage<Arc<RocksdbProofsStorage>>,
+) -> BaseProofsStorage<Arc<RocksdbProofsStorage>> {
+    storage.clone()
+}
+
 /// Converts a secp256k1 public key to an Ethereum address.
 fn public_key_to_address(pubkey: secp256k1::PublicKey) -> Address {
     let hash = keccak256(&pubkey.serialize_uncompressed()[1..]);
@@ -36,8 +60,6 @@ fn public_key_to_address(pubkey: secp256k1::PublicKey) -> Address {
 
 /// Signs a transaction with the given keypair.
 fn sign_tx_with_key_pair(key_pair: Keypair, tx: Transaction) -> TransactionSigned {
-    use alloy_consensus::SignableTransaction;
-    use reth_primitives_traits::crypto::secp256k1::sign_message;
     let secret = B256::from_slice(&key_pair.secret_bytes());
     let sig = sign_message(secret, tx.signature_hash()).unwrap();
     tx.into_signed(sig).into()
@@ -220,7 +242,7 @@ fn run_test_scenario<N>(
     provider_factory: ProviderFactory<N>,
     chain_spec: Arc<ChainSpec>,
     key_pair: Keypair,
-    storage: BaseProofsStorage<Arc<MdbxProofsStorage>>,
+    storage: BaseProofsStorage<Arc<RocksdbProofsStorage>>,
 ) -> eyre::Result<()>
 where
     N: ProviderNodeTypes<
@@ -254,7 +276,7 @@ where
     {
         let provider = provider_factory.db_ref();
         let tx = provider.tx()?;
-        let initialization_job = InitializationJob::new(storage.clone(), tx);
+        let initialization_job = InitializationJob::new(clone_storage(&storage), tx);
         initialization_job.run(last_block_number, last_block_hash)?;
     }
 
@@ -299,7 +321,7 @@ where
 #[test]
 fn test_execute_and_store_block_updates() {
     let dir = TempDir::new().unwrap();
-    let storage = Arc::new(MdbxProofsStorage::new(dir.path()).expect("env")).into();
+    let storage: BaseProofsStorage<Arc<RocksdbProofsStorage>> = rocksdb_storage(dir.path());
 
     // Create a keypair for signing transactions
     let secp = Secp256k1::new();
@@ -331,8 +353,7 @@ fn test_execute_and_store_block_updates() {
 #[test]
 fn test_execute_and_store_block_updates_missing_parent_block() {
     let dir = TempDir::new().unwrap();
-    let storage: BaseProofsStorage<Arc<MdbxProofsStorage>> =
-        Arc::new(MdbxProofsStorage::new(dir.path()).expect("env")).into();
+    let storage: BaseProofsStorage<Arc<RocksdbProofsStorage>> = rocksdb_storage(dir.path());
 
     let secp = Secp256k1::new();
     let key_pair = Keypair::new(&secp, &mut rand_08::thread_rng());
@@ -351,7 +372,7 @@ fn test_execute_and_store_block_updates_missing_parent_block() {
         provider_factory.clone(),
         Arc::clone(&chain_spec),
         key_pair,
-        storage.clone(),
+        clone_storage(&storage),
     )
     .unwrap();
 
@@ -385,8 +406,7 @@ fn test_execute_and_store_block_updates_missing_parent_block() {
 #[test]
 fn test_execute_and_store_block_updates_state_root_mismatch() {
     let dir = TempDir::new().unwrap();
-    let storage: BaseProofsStorage<Arc<MdbxProofsStorage>> =
-        Arc::new(MdbxProofsStorage::new(dir.path()).expect("env")).into();
+    let storage: BaseProofsStorage<Arc<RocksdbProofsStorage>> = rocksdb_storage(dir.path());
 
     let secp = Secp256k1::new();
     let key_pair = Keypair::new(&secp, &mut rand_08::thread_rng());
@@ -408,7 +428,7 @@ fn test_execute_and_store_block_updates_state_root_mismatch() {
         provider_factory.clone(),
         Arc::clone(&chain_spec),
         key_pair,
-        storage.clone(),
+        clone_storage(&storage),
     )
     .unwrap();
 
@@ -450,7 +470,7 @@ fn test_execute_and_store_block_updates_state_root_mismatch() {
 #[test]
 fn test_multiple_blocks_before_and_after_initialization() {
     let dir = TempDir::new().unwrap();
-    let storage = Arc::new(MdbxProofsStorage::new(dir.path()).expect("env")).into();
+    let storage: BaseProofsStorage<Arc<RocksdbProofsStorage>> = rocksdb_storage(dir.path());
 
     let secp = Secp256k1::new();
     let key_pair = Keypair::new(&secp, &mut rand_08::thread_rng());
@@ -487,7 +507,7 @@ fn test_multiple_blocks_before_and_after_initialization() {
 #[test]
 fn test_blocks_with_multiple_transactions() {
     let dir = TempDir::new().unwrap();
-    let storage = Arc::new(MdbxProofsStorage::new(dir.path()).expect("env")).into();
+    let storage: BaseProofsStorage<Arc<RocksdbProofsStorage>> = rocksdb_storage(dir.path());
 
     let secp = Secp256k1::new();
     let key_pair = Keypair::new(&secp, &mut rand_08::thread_rng());

--- a/crates/execution/trie/tests/proof_window/mod.rs
+++ b/crates/execution/trie/tests/proof_window/mod.rs
@@ -1,0 +1,48 @@
+//! Proof window metadata behavior tests.
+
+use serial_test::serial;
+use test_case::test_case;
+
+use super::*;
+
+/// Test basic storage and retrieval of earliest block number
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_earliest_block_operations<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    // Initially should be None
+    let earliest = storage.get_earliest_block_number()?;
+    assert!(earliest.is_none());
+
+    // Set earliest block
+    let block_hash = B256::repeat_byte(0x42);
+    storage.set_earliest_block_number(100, block_hash)?;
+
+    // Should retrieve the same values
+    let earliest = storage.get_earliest_block_number()?;
+    assert_eq!(earliest, Some((100, block_hash)));
+
+    Ok(())
+}
+
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_proof_window<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    assert_eq!(storage.get_earliest_block_number()?, None);
+    let block_hash_42 = B256::repeat_byte(0x42);
+    storage.set_earliest_block_number(42, block_hash_42)?;
+    assert_eq!(storage.get_earliest_block_number()?, Some((42, block_hash_42)));
+
+    let block_hash_100 = B256::repeat_byte(0x64);
+    storage.set_earliest_block_number(100, block_hash_100)?;
+    assert_eq!(storage.get_earliest_block_number()?, Some((100, block_hash_100)));
+    assert_eq!(storage.get_latest_block_number()?, Some((100, block_hash_100)));
+    Ok(())
+}

--- a/crates/execution/trie/tests/trie_updates/mod.rs
+++ b/crates/execution/trie/tests/trie_updates/mod.rs
@@ -1,0 +1,970 @@
+//! Trie update storage and replacement behavior tests.
+
+use serial_test::serial;
+use test_case::test_case;
+
+use super::*;
+
+/// Test storing and retrieving trie updates
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_trie_updates_operations<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let block_ref = BlockWithParent::new(B256::ZERO, NumHash::new(50, B256::repeat_byte(0x96)));
+    let sorted_trie_updates = TrieUpdatesSorted::default();
+    let sorted_post_state = HashedPostStateSorted::default();
+    let block_state_diff = BlockStateDiff {
+        sorted_trie_updates: sorted_trie_updates.clone(),
+        sorted_post_state: sorted_post_state.clone(),
+    };
+
+    // Store trie updates
+    storage.store_trie_updates(block_ref, block_state_diff)?;
+
+    // Retrieve and verify
+    let retrieved_diff = storage.fetch_trie_updates(block_ref.block.number)?;
+    assert_eq!(retrieved_diff.sorted_trie_updates, sorted_trie_updates);
+    assert_eq!(retrieved_diff.sorted_post_state, sorted_post_state);
+
+    Ok(())
+}
+
+/// Test wiped storage in [`HashedPostState`]
+///
+/// When `store_trie_updates` receives a [`HashedPostState`] with wiped=true for a storage entry,
+/// it should iterate all existing values for that address and create deletion entries for them.
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_store_trie_updates_with_wiped_storage<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let hashed_address = B256::repeat_byte(0x01);
+    let block_ref = BlockWithParent::new(B256::ZERO, NumHash::new(100, B256::repeat_byte(0x96)));
+
+    // First, store some storage values at block 50
+    let storage_slots = vec![
+        (B256::repeat_byte(0x10), U256::from(100)),
+        (B256::repeat_byte(0x20), U256::from(200)),
+        (B256::repeat_byte(0x30), U256::from(300)),
+        (B256::repeat_byte(0x40), U256::from(400)),
+    ];
+
+    storage.store_hashed_storages(hashed_address, storage_slots.clone())?;
+
+    // Verify all values are present at block 75
+    let mut cursor75 = storage.storage_hashed_cursor(hashed_address, 75)?;
+    let mut found_slots = Vec::new();
+    while let Some((key, value)) = cursor75.next()? {
+        found_slots.push((key, value));
+    }
+    assert_eq!(found_slots.len(), 4, "All storage slots should be present before wipe");
+    assert_eq!(found_slots[0], (B256::repeat_byte(0x10), U256::from(100)));
+    assert_eq!(found_slots[1], (B256::repeat_byte(0x20), U256::from(200)));
+    assert_eq!(found_slots[2], (B256::repeat_byte(0x30), U256::from(300)));
+    assert_eq!(found_slots[3], (B256::repeat_byte(0x40), U256::from(400)));
+
+    // Now create a HashedPostState with wiped=true for this address at block 100
+    let mut post_state = HashedPostState::default();
+    let wiped_storage = HashedStorage::new(true); // wiped=true, empty storage map
+    post_state.storages.insert(hashed_address, wiped_storage);
+
+    let block_state_diff = BlockStateDiff {
+        sorted_trie_updates: TrieUpdatesSorted::default(),
+        sorted_post_state: post_state.into_sorted(),
+    };
+
+    // Store the wiped state
+    storage.store_trie_updates(block_ref, block_state_diff)?;
+
+    // After wiping, cursor at block 150 should see NO storage values
+    let mut cursor150 = storage.storage_hashed_cursor(hashed_address, 150)?;
+    let mut found_slots_after_wipe = Vec::new();
+    while let Some((key, value)) = cursor150.next()? {
+        found_slots_after_wipe.push((key, value));
+    }
+
+    assert_eq!(
+        found_slots_after_wipe.len(),
+        0,
+        "All storage slots should be deleted after wipe. Found: {found_slots_after_wipe:?}"
+    );
+
+    // Verify individual seeks also return None
+    for (slot, _) in &storage_slots {
+        let mut seek_cursor = storage.storage_hashed_cursor(hashed_address, 150)?;
+        let result = seek_cursor.seek(*slot)?;
+        assert!(
+            result.is_none() || result.unwrap().0 != *slot,
+            "Storage slot {slot:?} should be deleted after wipe"
+        );
+    }
+
+    // Verify cursor at block 75 (before wipe) still sees all values
+    let mut cursor75_after = storage.storage_hashed_cursor(hashed_address, 75)?;
+    let mut found_slots_before_wipe = Vec::new();
+    while let Some((key, value)) = cursor75_after.next()? {
+        found_slots_before_wipe.push((key, value));
+    }
+    assert_eq!(
+        found_slots_before_wipe.len(),
+        4,
+        "All storage slots should still be present when querying before wipe block"
+    );
+
+    Ok(())
+}
+
+/// When a [`HashedPostState`] entry has `wiped = true` AND non-empty `storage` (the shape revm
+/// produces for `AccountStatus::DestroyedChanged` accounts that are destroyed and recreated in
+/// the same block), `store_trie_updates` must tombstone every prior storage slot for the address
+/// at `block_number` AND persist the new post-recreation slot values from `storage`. Dropping
+/// the new slots corrupts `HashedStorageHistory` and makes `BaseProofsStateProviderRef::storage`
+/// return `None` for the new slots, producing divergent storage / state / output roots
+/// downstream of `LiveTrieCollector`.
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_store_trie_updates_with_wiped_storage_and_new_slots<
+    S: BaseProofsStore + BaseProofsInitialStateStore,
+>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let hashed_address = B256::repeat_byte(0x01);
+    let block_ref = BlockWithParent::new(B256::ZERO, NumHash::new(100, B256::repeat_byte(0x96)));
+
+    let pre_existing_slots = vec![
+        (B256::repeat_byte(0x10), U256::from(100)),
+        (B256::repeat_byte(0x20), U256::from(200)),
+    ];
+    storage.store_hashed_storages(hashed_address, pre_existing_slots.clone())?;
+
+    let new_slot_kept = (B256::repeat_byte(0x30), U256::from(0xCAFE));
+    let new_slot_overwriting_old = (B256::repeat_byte(0x10), U256::from(0xBEEF));
+
+    let mut post_state = HashedPostState::default();
+    let wiped_with_new =
+        HashedStorage::from_iter(true, vec![new_slot_kept, new_slot_overwriting_old]);
+    post_state.storages.insert(hashed_address, wiped_with_new);
+
+    let block_state_diff = BlockStateDiff {
+        sorted_trie_updates: TrieUpdatesSorted::default(),
+        sorted_post_state: post_state.into_sorted(),
+    };
+
+    storage.store_trie_updates(block_ref, block_state_diff)?;
+
+    let mut cursor150 = storage.storage_hashed_cursor(hashed_address, 150)?;
+    let mut found = Vec::new();
+    while let Some((key, value)) = cursor150.next()? {
+        found.push((key, value));
+    }
+
+    assert_eq!(
+        found,
+        vec![new_slot_overwriting_old, new_slot_kept],
+        "After wipe+recreate, only the new post-recreation slots must be visible",
+    );
+
+    let mut seek_kept = storage.storage_hashed_cursor(hashed_address, 150)?;
+    assert_eq!(
+        seek_kept.seek(new_slot_kept.0)?,
+        Some(new_slot_kept),
+        "New slot 0x30 = 0xCAFE must round-trip through the cursor",
+    );
+
+    let mut seek_overwritten = storage.storage_hashed_cursor(hashed_address, 150)?;
+    assert_eq!(
+        seek_overwritten.seek(new_slot_overwriting_old.0)?,
+        Some(new_slot_overwriting_old),
+        "Reused slot 0x10 must reflect the new post-recreation value 0xBEEF, not the wiped 100",
+    );
+
+    let mut seek_dropped = storage.storage_hashed_cursor(hashed_address, 150)?;
+    assert_eq!(
+        seek_dropped.seek(B256::repeat_byte(0x20))?,
+        Some(new_slot_kept),
+        "seek(0x20) must skip the tombstoned old slot and advance to the next visible entry \
+         (0x30 = 0xCAFE), proving 0x20 is not visible at block 150",
+    );
+
+    let mut cursor75 = storage.storage_hashed_cursor(hashed_address, 75)?;
+    let mut pre_wipe_found = Vec::new();
+    while let Some((key, value)) = cursor75.next()? {
+        pre_wipe_found.push((key, value));
+    }
+    assert_eq!(
+        pre_wipe_found, pre_existing_slots,
+        "Cursor positioned before the wipe block must still see the original slot values",
+    );
+
+    Ok(())
+}
+
+/// Test that `store_trie_updates` properly stores branch nodes, leaf nodes, and removals
+///
+/// This test verifies that all data stored via `store_trie_updates` can be read back
+/// through the cursor APIs.
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_store_trie_updates_comprehensive<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let block_ref = BlockWithParent::new(B256::ZERO, NumHash::new(100, B256::repeat_byte(0x96)));
+
+    // Create comprehensive trie updates with branches, leaves, and removals
+    let mut trie_updates = TrieUpdates::default();
+
+    // Add account branch nodes
+    let account_path1 = nibbles_from(vec![1, 2, 3]);
+    let account_path2 = nibbles_from(vec![4, 5, 6]);
+    let account_branch1 = create_test_branch();
+    let account_branch2 = create_test_branch_variant();
+
+    trie_updates.account_nodes.insert(account_path1, account_branch1);
+    trie_updates.account_nodes.insert(account_path2, account_branch2);
+
+    // Add removed account nodes
+    let removed_account_path = nibbles_from(vec![7, 8, 9]);
+    trie_updates.removed_nodes.insert(removed_account_path);
+
+    // Add storage branch nodes for an address
+    let hashed_address = B256::repeat_byte(0x42);
+    let storage_path1 = nibbles_from(vec![1, 1]);
+    let storage_path2 = nibbles_from(vec![2, 2]);
+    let storage_branch = create_test_branch();
+
+    let mut storage_trie = StorageTrieUpdates::default();
+    storage_trie.storage_nodes.insert(storage_path1, storage_branch.clone());
+    storage_trie.storage_nodes.insert(storage_path2, storage_branch);
+
+    // Add removed storage node
+    let removed_storage_path = nibbles_from(vec![3, 3]);
+    storage_trie.removed_nodes.insert(removed_storage_path);
+
+    trie_updates.insert_storage_updates(hashed_address, storage_trie);
+
+    // Create post state with accounts and storage
+    let mut post_state = HashedPostState::default();
+
+    // Add accounts
+    let account1_addr = B256::repeat_byte(0x10);
+    let account2_addr = B256::repeat_byte(0x20);
+    let account1 = create_test_account_with_values(1, 1000, 0xAA);
+    let account2 = create_test_account_with_values(2, 2000, 0xBB);
+
+    post_state.accounts.insert(account1_addr, Some(account1));
+    post_state.accounts.insert(account2_addr, Some(account2));
+
+    // Add deleted account
+    let deleted_account_addr = B256::repeat_byte(0x30);
+    post_state.accounts.insert(deleted_account_addr, None);
+
+    // Add storage for an address
+    let storage_addr = B256::repeat_byte(0x50);
+    let mut hashed_storage = HashedStorage::new(false);
+    hashed_storage.storage.insert(B256::repeat_byte(0x01), U256::from(111));
+    hashed_storage.storage.insert(B256::repeat_byte(0x02), U256::from(222));
+    hashed_storage.storage.insert(B256::repeat_byte(0x03), U256::ZERO); // Deleted storage
+    post_state.storages.insert(storage_addr, hashed_storage);
+
+    let block_state_diff = BlockStateDiff {
+        sorted_trie_updates: trie_updates.into_sorted(),
+        sorted_post_state: post_state.into_sorted(),
+    };
+
+    // Store the updates
+    storage.store_trie_updates(block_ref, block_state_diff)?;
+
+    // ========== Verify Account Branch Nodes ==========
+    let mut account_trie_cursor = storage.account_trie_cursor(block_ref.block.number + 10)?;
+
+    // Should find the added branches
+    let result1 = account_trie_cursor.seek_exact(account_path1)?;
+    assert!(result1.is_some(), "Account branch node 1 should be found");
+    assert_eq!(result1.unwrap().0, account_path1);
+
+    let result2 = account_trie_cursor.seek_exact(account_path2)?;
+    assert!(result2.is_some(), "Account branch node 2 should be found");
+    assert_eq!(result2.unwrap().0, account_path2);
+
+    // Removed node should not be found
+    let removed_result = account_trie_cursor.seek_exact(removed_account_path)?;
+    assert!(removed_result.is_none(), "Removed account node should not be found");
+
+    // ========== Verify Storage Branch Nodes ==========
+    let mut storage_trie_cursor =
+        storage.storage_trie_cursor(hashed_address, block_ref.block.number + 10)?;
+
+    let storage_result1 = storage_trie_cursor.seek_exact(storage_path1)?;
+    assert!(storage_result1.is_some(), "Storage branch node 1 should be found");
+
+    let storage_result2 = storage_trie_cursor.seek_exact(storage_path2)?;
+    assert!(storage_result2.is_some(), "Storage branch node 2 should be found");
+
+    // Removed storage node should not be found
+    let removed_storage_result = storage_trie_cursor.seek_exact(removed_storage_path)?;
+    assert!(removed_storage_result.is_none(), "Removed storage node should not be found");
+
+    // ========== Verify Account Leaves ==========
+    let mut account_cursor = storage.account_hashed_cursor(block_ref.block.number + 10)?;
+
+    let acc1_result = account_cursor.seek(account1_addr)?;
+    assert!(acc1_result.is_some(), "Account 1 should be found");
+    assert_eq!(acc1_result.unwrap().0, account1_addr);
+    assert_eq!(acc1_result.unwrap().1.nonce, 1);
+    assert_eq!(acc1_result.unwrap().1.balance, U256::from(1000));
+
+    let acc2_result = account_cursor.seek(account2_addr)?;
+    assert!(acc2_result.is_some(), "Account 2 should be found");
+    assert_eq!(acc2_result.unwrap().1.nonce, 2);
+
+    // Deleted account should not be found
+    let deleted_acc_result = account_cursor.seek(deleted_account_addr)?;
+    assert!(
+        deleted_acc_result.is_none() || deleted_acc_result.unwrap().0 != deleted_account_addr,
+        "Deleted account should not be found"
+    );
+
+    // ========== Verify Storage Leaves ==========
+    let mut storage_cursor =
+        storage.storage_hashed_cursor(storage_addr, block_ref.block.number + 10)?;
+
+    let slot1_result = storage_cursor.seek(B256::repeat_byte(0x01))?;
+    assert!(slot1_result.is_some(), "Storage slot 1 should be found");
+    assert_eq!(slot1_result.unwrap().1, U256::from(111));
+
+    let slot2_result = storage_cursor.seek(B256::repeat_byte(0x02))?;
+    assert!(slot2_result.is_some(), "Storage slot 2 should be found");
+    assert_eq!(slot2_result.unwrap().1, U256::from(222));
+
+    // Zero-valued storage should not be found (deleted)
+    let slot3_result = storage_cursor.seek(B256::repeat_byte(0x03))?;
+    assert!(
+        slot3_result.is_none() || slot3_result.unwrap().0 != B256::repeat_byte(0x03),
+        "Zero-valued storage slot should not be found"
+    );
+
+    // ========== Verify fetch_trie_updates can retrieve the data ==========
+    let fetched_diff = storage.fetch_trie_updates(block_ref.block.number)?;
+
+    // Check that trie updates are stored
+    assert_eq!(
+        fetched_diff.sorted_trie_updates.account_nodes_ref().len(),
+        3,
+        "Should have 3 account nodes, including removed"
+    );
+    assert_eq!(
+        fetched_diff.sorted_trie_updates.storage_tries_ref().len(),
+        1,
+        "Should have 1 storage trie"
+    );
+
+    // Check that post state is stored
+    assert_eq!(
+        fetched_diff.sorted_post_state.accounts.len(),
+        3,
+        "Should have 3 accounts (including deleted)"
+    );
+    assert_eq!(fetched_diff.sorted_post_state.storages.len(), 1, "Should have 1 storage entry");
+
+    Ok(())
+}
+
+/// Test that `replace_updates` properly applies hashed/trie storage updates to the DB
+///
+/// This test verifies the bug fix where `replace_updates` was only storing `trie_updates`
+/// and `post_states` directly without populating the internal data structures
+/// (`hashed_accounts`, `hashed_storages`, `account_branches`, `storage_branches`).
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_replace_updates_applies_all_updates<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let block_ref_50 = BlockWithParent::new(B256::ZERO, NumHash::new(50, B256::repeat_byte(0x96)));
+
+    // ========== Setup: Store initial state at blocks 50, 100, 101 ==========
+    let initial_account_addr = B256::repeat_byte(0x10);
+    let initial_account = create_test_account_with_values(1, 1000, 0xAA);
+
+    let initial_storage_addr = B256::repeat_byte(0x20);
+    let initial_storage_slot = B256::repeat_byte(0x01);
+    let initial_storage_value = U256::from(100);
+
+    let initial_branch_path = nibbles_from(vec![1, 2, 3]);
+    let initial_branch = create_test_branch();
+
+    // Store initial data at block 50
+    let mut initial_trie_updates_50 = TrieUpdates::default();
+    initial_trie_updates_50.account_nodes.insert(initial_branch_path, initial_branch.clone());
+
+    let mut initial_post_state_50 = HashedPostState::default();
+    initial_post_state_50.accounts.insert(initial_account_addr, Some(initial_account));
+
+    let initial_diff_50 = BlockStateDiff {
+        sorted_trie_updates: initial_trie_updates_50.into_sorted(),
+        sorted_post_state: initial_post_state_50.into_sorted(),
+    };
+    storage.store_trie_updates(block_ref_50, initial_diff_50)?;
+
+    // Store data at block 100 (common block)
+    let mut initial_trie_updates_100 = TrieUpdates::default();
+    let common_branch_path = nibbles_from(vec![4, 5, 6]);
+    initial_trie_updates_100.account_nodes.insert(common_branch_path, initial_branch.clone());
+
+    let mut initial_post_state_100 = HashedPostState::default();
+    let mut initial_storage_100 = HashedStorage::new(false);
+    initial_storage_100.storage.insert(initial_storage_slot, initial_storage_value);
+    initial_post_state_100.storages.insert(initial_storage_addr, initial_storage_100);
+
+    let initial_diff_100 = BlockStateDiff {
+        sorted_trie_updates: initial_trie_updates_100.into_sorted(),
+        sorted_post_state: initial_post_state_100.into_sorted(),
+    };
+
+    let block_ref_100 =
+        BlockWithParent::new(block_ref_50.block.hash, NumHash::new(100, B256::repeat_byte(0x97)));
+
+    storage.store_trie_updates(block_ref_100, initial_diff_100)?;
+
+    // Store data at block 101 (will be replaced)
+    let mut initial_trie_updates_101 = TrieUpdates::default();
+    let old_branch_path = nibbles_from(vec![7, 8, 9]);
+    initial_trie_updates_101.account_nodes.insert(old_branch_path, initial_branch);
+
+    let mut initial_post_state_101 = HashedPostState::default();
+    let old_account_addr = B256::repeat_byte(0x30);
+    let old_account = create_test_account_with_values(99, 9999, 0xFF);
+    initial_post_state_101.accounts.insert(old_account_addr, Some(old_account));
+
+    let initial_diff_101 = BlockStateDiff {
+        sorted_trie_updates: initial_trie_updates_101.into_sorted(),
+        sorted_post_state: initial_post_state_101.into_sorted(),
+    };
+    let block_ref_101 =
+        BlockWithParent::new(block_ref_100.block.hash, NumHash::new(101, B256::repeat_byte(0x98)));
+    storage.store_trie_updates(block_ref_101, initial_diff_101)?;
+
+    let block_ref_102 =
+        BlockWithParent::new(block_ref_101.block.hash, NumHash::new(102, B256::repeat_byte(0x99)));
+
+    // ========== Verify initial state exists ==========
+    // Verify block 50 data exists
+    let mut cursor_initial = storage.account_trie_cursor(75)?;
+    assert!(
+        cursor_initial.seek_exact(initial_branch_path)?.is_some(),
+        "Initial branch should exist before replace"
+    );
+
+    // Verify block 101 old data exists
+    let mut cursor_old = storage.account_trie_cursor(150)?;
+    assert!(
+        cursor_old.seek_exact(old_branch_path)?.is_some(),
+        "Old branch at block 101 should exist before replace"
+    );
+
+    let mut account_cursor_old = storage.account_hashed_cursor(150)?;
+    assert!(
+        account_cursor_old.seek(old_account_addr)?.is_some(),
+        "Old account at block 101 should exist before replace"
+    );
+
+    // ========== Call replace_updates to replace blocks after 100 ==========
+    let mut blocks_to_add: Vec<(BlockWithParent, BlockStateDiff)> = Vec::default();
+
+    // New data for block 101
+    let new_account_addr = B256::repeat_byte(0x40);
+    let new_account = create_test_account_with_values(5, 5000, 0xCC);
+
+    let new_storage_addr = B256::repeat_byte(0x50);
+    let new_storage_slot = B256::repeat_byte(0x02);
+    let new_storage_value = U256::from(999);
+
+    let new_branch_path = nibbles_from(vec![10, 11, 12]);
+    let new_branch = create_test_branch_variant();
+
+    let storage_branch_path = nibbles_from(vec![5, 5]);
+    let storage_hashed_addr = B256::repeat_byte(0x60);
+
+    let mut new_trie_updates = TrieUpdates::default();
+    new_trie_updates.account_nodes.insert(new_branch_path, new_branch.clone());
+
+    // Add storage trie updates
+    let mut storage_trie = StorageTrieUpdates::default();
+    storage_trie.storage_nodes.insert(storage_branch_path, new_branch.clone());
+    new_trie_updates.insert_storage_updates(storage_hashed_addr, storage_trie);
+
+    let mut new_post_state = HashedPostState::default();
+    new_post_state.accounts.insert(new_account_addr, Some(new_account));
+
+    let mut new_storage = HashedStorage::new(false);
+    new_storage.storage.insert(new_storage_slot, new_storage_value);
+    new_post_state.storages.insert(new_storage_addr, new_storage);
+
+    blocks_to_add.push((
+        block_ref_101,
+        BlockStateDiff {
+            sorted_trie_updates: new_trie_updates.into_sorted(),
+            sorted_post_state: new_post_state.into_sorted(),
+        },
+    ));
+
+    // New data for block 102
+    let block_102_account_addr = B256::repeat_byte(0x70);
+    let block_102_account = create_test_account_with_values(10, 10000, 0xDD);
+
+    let mut trie_updates_102 = TrieUpdates::default();
+    let block_102_branch_path = nibbles_from(vec![15, 14, 13]);
+    trie_updates_102.account_nodes.insert(block_102_branch_path, new_branch);
+
+    let mut post_state_102 = HashedPostState::default();
+    post_state_102.accounts.insert(block_102_account_addr, Some(block_102_account));
+
+    blocks_to_add.push((
+        block_ref_102,
+        BlockStateDiff {
+            sorted_trie_updates: trie_updates_102.into_sorted(),
+            sorted_post_state: post_state_102.into_sorted(),
+        },
+    ));
+
+    // Execute replace_updates
+    storage.replace_updates(BlockNumHash::new(100, block_ref_100.block.hash), blocks_to_add)?;
+    // ========== Verify that data up to block 100 still exists ==========
+    let mut cursor_50 = storage.account_trie_cursor(75)?;
+    assert!(
+        cursor_50.seek_exact(initial_branch_path)?.is_some(),
+        "Block 50 branch should still exist after replace"
+    );
+
+    let mut cursor_100 = storage.account_trie_cursor(100)?;
+    assert!(
+        cursor_100.seek_exact(common_branch_path)?.is_some(),
+        "Block 100 branch should still exist after replace"
+    );
+
+    let mut storage_cursor_100 = storage.storage_hashed_cursor(initial_storage_addr, 100)?;
+    let result_100 = storage_cursor_100.seek(initial_storage_slot)?;
+    assert!(result_100.is_some(), "Block 100 storage should still exist after replace");
+    assert_eq!(
+        result_100.unwrap().1,
+        initial_storage_value,
+        "Block 100 storage value should be unchanged"
+    );
+
+    // ========== Verify that old data after block 100 is gone ==========
+    let mut cursor_old_gone = storage.account_trie_cursor(150)?;
+    assert!(
+        cursor_old_gone.seek_exact(old_branch_path)?.is_none(),
+        "Old branch at block 101 should be removed after replace"
+    );
+
+    let mut account_cursor_old_gone = storage.account_hashed_cursor(150)?;
+    let old_acc_result = account_cursor_old_gone.seek(old_account_addr)?;
+    assert!(
+        old_acc_result.is_none() || old_acc_result.unwrap().0 != old_account_addr,
+        "Old account at block 101 should be removed after replace"
+    );
+
+    // ========== Verify new data is properly accessible via cursors ==========
+
+    // Verify new account branch nodes
+    let mut trie_cursor = storage.account_trie_cursor(150)?;
+    let branch_result = trie_cursor.seek_exact(new_branch_path)?;
+    assert!(branch_result.is_some(), "New account branch should be accessible via cursor");
+    assert_eq!(branch_result.unwrap().0, new_branch_path);
+
+    // Verify new storage branch nodes
+    let mut storage_trie_cursor = storage.storage_trie_cursor(storage_hashed_addr, 150)?;
+    let storage_branch_result = storage_trie_cursor.seek_exact(storage_branch_path)?;
+    assert!(storage_branch_result.is_some(), "New storage branch should be accessible via cursor");
+    assert_eq!(storage_branch_result.unwrap().0, storage_branch_path);
+
+    // Verify new hashed accounts
+    let mut account_cursor = storage.account_hashed_cursor(150)?;
+    let account_result = account_cursor.seek(new_account_addr)?;
+    assert!(account_result.is_some(), "New account should be accessible via cursor");
+    assert_eq!(account_result.as_ref().unwrap().0, new_account_addr);
+    assert_eq!(account_result.as_ref().unwrap().1.nonce, new_account.nonce);
+    assert_eq!(account_result.as_ref().unwrap().1.balance, new_account.balance);
+    assert_eq!(account_result.as_ref().unwrap().1.bytecode_hash, new_account.bytecode_hash);
+
+    // Verify new hashed storages
+    let mut storage_cursor = storage.storage_hashed_cursor(new_storage_addr, 150)?;
+    let storage_result = storage_cursor.seek(new_storage_slot)?;
+    assert!(storage_result.is_some(), "New storage should be accessible via cursor");
+    assert_eq!(storage_result.as_ref().unwrap().0, new_storage_slot);
+    assert_eq!(storage_result.as_ref().unwrap().1, new_storage_value);
+
+    // Verify block 102 data
+    let mut trie_cursor_102 = storage.account_trie_cursor(150)?;
+    let branch_result_102 = trie_cursor_102.seek_exact(block_102_branch_path)?;
+    assert!(branch_result_102.is_some(), "Block 102 branch should be accessible");
+    assert_eq!(branch_result_102.unwrap().0, block_102_branch_path);
+
+    let mut account_cursor_102 = storage.account_hashed_cursor(150)?;
+    let account_result_102 = account_cursor_102.seek(block_102_account_addr)?;
+    assert!(account_result_102.is_some(), "Block 102 account should be accessible");
+    assert_eq!(account_result_102.as_ref().unwrap().0, block_102_account_addr);
+    assert_eq!(account_result_102.as_ref().unwrap().1.nonce, block_102_account.nonce);
+
+    // Verify fetch_trie_updates returns the new data
+    let fetched_101 = storage.fetch_trie_updates(101)?;
+    assert_eq!(
+        fetched_101.sorted_trie_updates.account_nodes_ref().len(),
+        1,
+        "Should have 1 account branch node at block 101"
+    );
+    assert!(
+        fetched_101
+            .sorted_trie_updates
+            .account_nodes_ref()
+            .iter()
+            .any(|(addr, _)| *addr == new_branch_path),
+        "New branch path should be in trie_updates"
+    );
+    assert_eq!(
+        fetched_101.sorted_post_state.accounts.len(),
+        1,
+        "Should have 1 account at block 101"
+    );
+    assert!(
+        fetched_101.sorted_post_state.accounts.iter().any(|(addr, _)| *addr == new_account_addr),
+        "New account should be in post_state"
+    );
+
+    Ok(())
+}
+
+/// Test that multi-block replacements make wiped storage see storage added earlier in the
+/// replacement chain.
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_replace_updates_wipes_storage_added_by_prior_replacement_block<
+    S: BaseProofsStore + BaseProofsInitialStateStore,
+>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let common_block = BlockWithParent::new(B256::ZERO, NumHash::new(1, B256::repeat_byte(0xA1)));
+    storage.store_trie_updates(common_block, BlockStateDiff::default())?;
+
+    let old_block_2 =
+        BlockWithParent::new(common_block.block.hash, NumHash::new(2, B256::repeat_byte(0xB2)));
+    let old_block_3 =
+        BlockWithParent::new(old_block_2.block.hash, NumHash::new(3, B256::repeat_byte(0xB3)));
+    storage.store_trie_updates(old_block_2, BlockStateDiff::default())?;
+    storage.store_trie_updates(old_block_3, BlockStateDiff::default())?;
+
+    let storage_address = B256::repeat_byte(0x44);
+    let storage_slot = B256::repeat_byte(0x55);
+    let storage_value = U256::from(0x1234);
+
+    let replacement_block_2 =
+        BlockWithParent::new(common_block.block.hash, NumHash::new(2, B256::repeat_byte(0xC2)));
+    let replacement_block_3 = BlockWithParent::new(
+        replacement_block_2.block.hash,
+        NumHash::new(3, B256::repeat_byte(0xC3)),
+    );
+
+    let mut replacement_post_state_2 = HashedPostState::default();
+    let mut replacement_storage_2 = HashedStorage::new(false);
+    replacement_storage_2.storage.insert(storage_slot, storage_value);
+    replacement_post_state_2.storages.insert(storage_address, replacement_storage_2);
+
+    let mut replacement_post_state_3 = HashedPostState::default();
+    replacement_post_state_3.storages.insert(storage_address, HashedStorage::new(true));
+
+    storage.replace_updates(
+        BlockNumHash::new(common_block.block.number, common_block.block.hash),
+        vec![
+            (
+                replacement_block_2,
+                BlockStateDiff {
+                    sorted_trie_updates: TrieUpdatesSorted::default(),
+                    sorted_post_state: replacement_post_state_2.into_sorted(),
+                },
+            ),
+            (
+                replacement_block_3,
+                BlockStateDiff {
+                    sorted_trie_updates: TrieUpdatesSorted::default(),
+                    sorted_post_state: replacement_post_state_3.into_sorted(),
+                },
+            ),
+        ],
+    )?;
+
+    let mut storage_cursor = storage.storage_hashed_cursor(storage_address, 3)?;
+    let storage_result = storage_cursor.seek(storage_slot)?;
+    assert!(
+        !matches!(storage_result, Some((found_slot, _)) if found_slot == storage_slot),
+        "storage added by replacement block 2 should be wiped by replacement block 3"
+    );
+
+    Ok(())
+}
+
+/// Test that pure deletions (nodes only in `removed_nodes`) are properly stored
+///
+/// This test verifies that when a node appears only in `removed_nodes` (not in updates),
+/// it is properly stored as a deletion and subsequent queries return None for that path.
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_pure_deletions_stored_correctly<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    // ========== Setup: Store initial branch nodes at block 50 ==========
+    let account_path1 = nibbles_from(vec![1, 2, 3]);
+    let account_path2 = nibbles_from(vec![4, 5, 6]);
+    let storage_path1 = nibbles_from(vec![7, 8, 9]);
+    let storage_path2 = nibbles_from(vec![10, 11, 12]);
+    let storage_address = B256::repeat_byte(0x42);
+
+    let initial_branch = create_test_branch();
+
+    let mut initial_trie_updates = TrieUpdates::default();
+    initial_trie_updates.account_nodes.insert(account_path1, initial_branch.clone());
+    initial_trie_updates.account_nodes.insert(account_path2, initial_branch.clone());
+
+    let mut storage_trie = StorageTrieUpdates::default();
+    storage_trie.storage_nodes.insert(storage_path1, initial_branch.clone());
+    storage_trie.storage_nodes.insert(storage_path2, initial_branch);
+    initial_trie_updates.insert_storage_updates(storage_address, storage_trie);
+
+    let initial_diff = BlockStateDiff {
+        sorted_trie_updates: initial_trie_updates.into_sorted(),
+        sorted_post_state: HashedPostStateSorted::default(),
+    };
+
+    let block_ref_50 = BlockWithParent::new(B256::ZERO, NumHash::new(50, B256::repeat_byte(0x96)));
+
+    storage.store_trie_updates(block_ref_50, initial_diff)?;
+
+    // Verify initial state exists at block 75
+    let mut cursor_75 = storage.account_trie_cursor(75)?;
+    assert!(
+        cursor_75.seek_exact(account_path1)?.is_some(),
+        "Initial account branch 1 should exist at block 75"
+    );
+    assert!(
+        cursor_75.seek_exact(account_path2)?.is_some(),
+        "Initial account branch 2 should exist at block 75"
+    );
+
+    let mut storage_cursor_75 = storage.storage_trie_cursor(storage_address, 75)?;
+    assert!(
+        storage_cursor_75.seek_exact(storage_path1)?.is_some(),
+        "Initial storage branch 1 should exist at block 75"
+    );
+    assert!(
+        storage_cursor_75.seek_exact(storage_path2)?.is_some(),
+        "Initial storage branch 2 should exist at block 75"
+    );
+
+    // ========== At block 100: Mark paths as deleted (ONLY in removed_nodes) ==========
+    let mut deletion_trie_updates = TrieUpdates::default();
+
+    // Add to removed_nodes ONLY (no updates)
+    deletion_trie_updates.removed_nodes.insert(account_path1);
+
+    // Do the same for storage branch
+    let mut deletion_storage_trie = StorageTrieUpdates::default();
+    deletion_storage_trie.removed_nodes.insert(storage_path1);
+    deletion_trie_updates.insert_storage_updates(storage_address, deletion_storage_trie);
+
+    let deletion_diff = BlockStateDiff {
+        sorted_trie_updates: deletion_trie_updates.into_sorted(),
+        sorted_post_state: HashedPostStateSorted::default(),
+    };
+
+    let block_ref_100 =
+        BlockWithParent::new(B256::repeat_byte(0x96), NumHash::new(100, B256::repeat_byte(0x97)));
+
+    storage.store_trie_updates(block_ref_100, deletion_diff)?;
+
+    // ========== Verify that deleted nodes return None at block 150 ==========
+
+    // Deleted account branch should not be found
+    let mut cursor_150 = storage.account_trie_cursor(150)?;
+    let account_result = cursor_150.seek_exact(account_path1)?;
+    assert!(account_result.is_none(), "Deleted account branch should return None at block 150");
+
+    // Non-deleted account branch should still exist
+    let account_result2 = cursor_150.seek_exact(account_path2)?;
+    assert!(
+        account_result2.is_some(),
+        "Non-deleted account branch should still exist at block 150"
+    );
+
+    // Deleted storage branch should not be found
+    let mut storage_cursor_150 = storage.storage_trie_cursor(storage_address, 150)?;
+    let storage_result = storage_cursor_150.seek_exact(storage_path1)?;
+    assert!(storage_result.is_none(), "Deleted storage branch should return None at block 150");
+
+    // Non-deleted storage branch should still exist
+    let storage_result2 = storage_cursor_150.seek_exact(storage_path2)?;
+    assert!(
+        storage_result2.is_some(),
+        "Non-deleted storage branch should still exist at block 150"
+    );
+
+    // ========== Verify that the nodes still exist at block 75 (before deletion) ==========
+    let mut cursor_75_after = storage.account_trie_cursor(75)?;
+    assert!(
+        cursor_75_after.seek_exact(account_path1)?.is_some(),
+        "Deleted node should still exist at block 75 (before deletion)"
+    );
+
+    let mut storage_cursor_75_after = storage.storage_trie_cursor(storage_address, 75)?;
+    assert!(
+        storage_cursor_75_after.seek_exact(storage_path1)?.is_some(),
+        "Deleted storage node should still exist at block 75 (before deletion)"
+    );
+
+    // ========== Verify iteration skips deleted nodes ==========
+    let mut cursor_iter = storage.account_trie_cursor(150)?;
+    let mut found_paths = Vec::new();
+    while let Some((path, _)) = cursor_iter.next()? {
+        found_paths.push(path);
+    }
+
+    assert!(!found_paths.contains(&account_path1), "Iteration should skip deleted node");
+    assert!(found_paths.contains(&account_path2), "Iteration should include non-deleted node");
+
+    Ok(())
+}
+
+/// Test that updates take precedence over removals when both are present
+///
+/// This test verifies that when a path appears in both `removed_nodes` and `account_nodes`,
+/// the update from `account_nodes` takes precedence. This is critical for correctness
+/// when processing trie updates that both remove and update the same node.
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_updates_take_precedence_over_removals<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    // ========== Setup: Store initial branch nodes at block 50 ==========
+    let account_path = nibbles_from(vec![1, 2, 3]);
+    let storage_path = nibbles_from(vec![4, 5, 6]);
+    let storage_address = B256::repeat_byte(0x42);
+
+    let initial_branch = create_test_branch();
+
+    let mut initial_trie_updates = TrieUpdates::default();
+    initial_trie_updates.account_nodes.insert(account_path, initial_branch.clone());
+
+    let mut storage_trie = StorageTrieUpdates::default();
+    storage_trie.storage_nodes.insert(storage_path, initial_branch.clone());
+    initial_trie_updates.insert_storage_updates(storage_address, storage_trie);
+
+    let initial_diff = BlockStateDiff {
+        sorted_trie_updates: initial_trie_updates.into_sorted(),
+        sorted_post_state: HashedPostStateSorted::default(),
+    };
+
+    let block_ref_50 = BlockWithParent::new(B256::ZERO, NumHash::new(50, B256::repeat_byte(0x96)));
+
+    storage.store_trie_updates(block_ref_50, initial_diff)?;
+
+    // Verify initial state exists at block 75
+    let mut cursor_75 = storage.account_trie_cursor(75)?;
+    assert!(
+        cursor_75.seek_exact(account_path)?.is_some(),
+        "Initial account branch should exist at block 75"
+    );
+
+    let mut storage_cursor_75 = storage.storage_trie_cursor(storage_address, 75)?;
+    assert!(
+        storage_cursor_75.seek_exact(storage_path)?.is_some(),
+        "Initial storage branch should exist at block 75"
+    );
+
+    // ========== At block 100: Add paths to BOTH removed_nodes AND account_nodes ==========
+    // This simulates a scenario where a node is both removed and updated
+    // The update should take precedence
+    let updated_branch = create_test_branch_variant();
+
+    let mut conflicting_trie_updates = TrieUpdates::default();
+
+    // Add to removed_nodes
+    conflicting_trie_updates.removed_nodes.insert(account_path);
+
+    // Also add to account_nodes (this should take precedence)
+    conflicting_trie_updates.account_nodes.insert(account_path, updated_branch.clone());
+
+    // Do the same for storage branch
+    let mut conflicting_storage_trie = StorageTrieUpdates::default();
+    conflicting_storage_trie.removed_nodes.insert(storage_path);
+    conflicting_storage_trie.storage_nodes.insert(storage_path, updated_branch.clone());
+    conflicting_trie_updates.insert_storage_updates(storage_address, conflicting_storage_trie);
+
+    let conflicting_diff = BlockStateDiff {
+        sorted_trie_updates: conflicting_trie_updates.into_sorted(),
+        sorted_post_state: HashedPostStateSorted::default(),
+    };
+
+    let block_ref_100 =
+        BlockWithParent::new(B256::repeat_byte(0x96), NumHash::new(100, B256::repeat_byte(0x97)));
+
+    storage.store_trie_updates(block_ref_100, conflicting_diff)?;
+
+    // ========== Verify that updates took precedence at block 150 ==========
+
+    // Account branch should exist (not deleted) with the updated value
+    let mut cursor_150 = storage.account_trie_cursor(150)?;
+    let account_result = cursor_150.seek_exact(account_path)?;
+    assert!(
+        account_result.is_some(),
+        "Account branch should exist at block 150 (update should take precedence over removal)"
+    );
+    let (found_path, found_branch) = account_result.unwrap();
+    assert_eq!(found_path, account_path);
+    // Verify it's the updated branch, not the initial one
+    assert_eq!(
+        found_branch.state_mask, updated_branch.state_mask,
+        "Account branch should be the updated version, not the initial one"
+    );
+
+    // Storage branch should exist (not deleted) with the updated value
+    let mut storage_cursor_150 = storage.storage_trie_cursor(storage_address, 150)?;
+    let storage_result = storage_cursor_150.seek_exact(storage_path)?;
+    assert!(
+        storage_result.is_some(),
+        "Storage branch should exist at block 150 (update should take precedence over removal)"
+    );
+    let (found_storage_path, found_storage_branch) = storage_result.unwrap();
+    assert_eq!(found_storage_path, storage_path);
+    // Verify it's the updated branch
+    assert_eq!(
+        found_storage_branch.state_mask, updated_branch.state_mask,
+        "Storage branch should be the updated version, not the initial one"
+    );
+
+    // ========== Verify that the old version still exists at block 75 ==========
+    let mut cursor_75_after = storage.account_trie_cursor(75)?;
+    let result_75 = cursor_75_after.seek_exact(account_path)?;
+    assert!(result_75.is_some(), "Initial version should still exist at block 75");
+    let (_, branch_75) = result_75.unwrap();
+    assert_eq!(
+        branch_75.state_mask, initial_branch.state_mask,
+        "Block 75 should see the initial branch, not the updated one"
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
Switch proofs history defaults to RocksDB, add the RocksDB-backed storage implementation, and add write benchmark coverage.