### PR TITLE
fix(succinct): Update manifest toml and cargo lock

### DIFF
--- a/crates/proof/succinct/elf/manifest.toml
+++ b/crates/proof/succinct/elf/manifest.toml
@@ -14,7 +14,7 @@
 
 [[elfs]]
 name = "range-elf-embedded"
-sha256 = "7cfc13db8b01bb1eb7a9ae26733c36f7f5895c2255929496e04d3a9b53289994"
+sha256 = "47d2f38c3f51601e9a528b64d9420354f3d44247637710e4337cce38cfdae338"
 
 [[elfs]]
 name = "aggregation-elf"

--- a/crates/proof/succinct/elf/manifest.toml
+++ b/crates/proof/succinct/elf/manifest.toml
@@ -14,7 +14,7 @@
 
 [[elfs]]
 name = "range-elf-embedded"
-sha256 = "40e1483c672d080608e79d59dc48a049c6f3c7c6fab7fc0b1384598cbc2b4bd2"
+sha256 = "7cfc13db8b01bb1eb7a9ae26733c36f7f5895c2255929496e04d3a9b53289994"
 
 [[elfs]]
 name = "aggregation-elf"

--- a/crates/proof/succinct/programs/Cargo.lock
+++ b/crates/proof/succinct/programs/Cargo.lock
@@ -867,6 +867,7 @@ dependencies = [
 name = "base-common-precompiles"
 version = "0.0.0"
 dependencies = [
+ "alloy-evm",
  "base-common-chains",
  "revm",
 ]


### PR DESCRIPTION
We update the manifest and cargo lock for succinct program.