### PR TITLE
feat(basectl): conductor cluster discovery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5892,6 +5892,7 @@ dependencies = [
  "clap",
  "rustls 0.23.39",
  "tokio",
+ "url",
 ]
 
 [[package]]

--- a/bin/basectl/Cargo.toml
+++ b/bin/basectl/Cargo.toml
@@ -12,8 +12,9 @@ path = "src/main.rs"
 workspace = true
 
 [dependencies]
+url = { workspace = true }
 anyhow = { workspace = true }
 basectl-cli = { workspace = true }
 rustls = { workspace = true, features = ["ring"] }
-clap = { workspace = true, features = ["derive"] }
+clap = { workspace = true, features = ["derive", "env"] }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }

--- a/bin/basectl/src/cli.rs
+++ b/bin/basectl/src/cli.rs
@@ -16,6 +16,10 @@ pub(crate) struct Cli {
     /// When set, basectl ignores any hardcoded conductor list in the chain
     /// config and instead asks this URL for the live raft membership, then
     /// polls all discovered peers via templated ports.
+    ///
+    /// Only applies to the conductor view (and views that embed it, like the
+    /// command center). Ignored by `flashblocks --json` and other non-TUI
+    /// subcommands.
     #[arg(
         long = "conductor-rpc",
         env = "BASECTL_CONDUCTOR_RPC",

--- a/bin/basectl/src/cli.rs
+++ b/bin/basectl/src/cli.rs
@@ -1,6 +1,7 @@
 //! Contains the CLI arguments for the basectl binary.
 
 use clap::{Parser, Subcommand};
+use url::Url;
 
 /// Base infrastructure control CLI.
 #[derive(Debug, Parser)]
@@ -10,6 +11,13 @@ pub(crate) struct Cli {
     /// Chain configuration (mainnet, sepolia, devnet, or path to config file)
     #[arg(short = 'c', long = "config", default_value = "mainnet", global = true)]
     pub(crate) config: String,
+    /// Bootstrap conductor JSON-RPC URL for runtime cluster discovery.
+    ///
+    /// When set, basectl ignores any hardcoded conductor list in the chain
+    /// config and instead asks this URL for the live raft membership, then
+    /// polls all discovered peers via templated ports.
+    #[arg(long = "conductor-rpc", env = "BASECTL_CONDUCTOR_RPC", global = true)]
+    pub(crate) conductor_rpc: Option<Url>,
     #[command(subcommand)]
     pub(crate) command: Option<Commands>,
 }

--- a/bin/basectl/src/cli.rs
+++ b/bin/basectl/src/cli.rs
@@ -16,7 +16,12 @@ pub(crate) struct Cli {
     /// When set, basectl ignores any hardcoded conductor list in the chain
     /// config and instead asks this URL for the live raft membership, then
     /// polls all discovered peers via templated ports.
-    #[arg(long = "conductor-rpc", env = "BASECTL_CONDUCTOR_RPC", global = true)]
+    #[arg(
+        long = "conductor-rpc",
+        env = "BASECTL_CONDUCTOR_RPC",
+        global = true,
+        default_value = "http://localhost:5545"
+    )]
     pub(crate) conductor_rpc: Option<Url>,
     #[command(subcommand)]
     pub(crate) command: Option<Commands>,

--- a/bin/basectl/src/main.rs
+++ b/bin/basectl/src/main.rs
@@ -14,18 +14,21 @@ async fn main() -> anyhow::Result<()> {
     let cli = cli::Cli::parse();
 
     let config = &cli.config;
+    let conductor_rpc = cli.conductor_rpc.clone();
     match cli.command {
-        Some(cli::Commands::Config) => run_app(ViewId::Config, config).await,
+        Some(cli::Commands::Config) => run_app(ViewId::Config, config, conductor_rpc).await,
         Some(cli::Commands::Flashblocks { json: true }) => {
             run_flashblocks_json(MonitoringConfig::load(config).await?).await
         }
         Some(cli::Commands::Flashblocks { json: false }) => {
-            run_app(ViewId::Flashblocks, config).await
+            run_app(ViewId::Flashblocks, config, conductor_rpc).await
         }
-        Some(cli::Commands::Da) => run_app(ViewId::DaMonitor, config).await,
-        Some(cli::Commands::CommandCenter) => run_app(ViewId::CommandCenter, config).await,
-        Some(cli::Commands::Conductor) => run_app(ViewId::Conductor, config).await,
-        Some(cli::Commands::Upgrades) => run_app(ViewId::Upgrades, config).await,
-        None => run_app(ViewId::Home, config).await,
+        Some(cli::Commands::Da) => run_app(ViewId::DaMonitor, config, conductor_rpc).await,
+        Some(cli::Commands::CommandCenter) => {
+            run_app(ViewId::CommandCenter, config, conductor_rpc).await
+        }
+        Some(cli::Commands::Conductor) => run_app(ViewId::Conductor, config, conductor_rpc).await,
+        Some(cli::Commands::Upgrades) => run_app(ViewId::Upgrades, config, conductor_rpc).await,
+        None => run_app(ViewId::Home, config, conductor_rpc).await,
     }
 }

--- a/crates/infra/basectl/src/app/core.rs
+++ b/crates/infra/basectl/src/app/core.rs
@@ -10,10 +10,7 @@ use ratatui::{
 use tokio::sync::oneshot;
 use url::Url;
 
-use super::{
-    Action, Resources, Router, View, ViewId,
-    runner::{detect_rpc_for, start_background_services},
-};
+use super::{Action, Resources, Router, View, ViewId, runner::start_background_services};
 use crate::{
     commands::{COLOR_BASE_BLUE, EVENT_POLL_TIMEOUT},
     config::MonitoringConfig,
@@ -252,19 +249,14 @@ impl App {
         self.pending_network = Some(rx);
         let conductor_rpc = self.conductor_rpc.clone();
         tokio::spawn(async move {
-            let result = match MonitoringConfig::load(&name).await {
-                Ok(mut config) => {
-                    let detect_rpc = detect_rpc_for(&config, conductor_rpc.as_ref());
-                    if let Some(detected) =
-                        MonitoringConfig::detect_name_from_rpc(&detect_rpc).await
-                    {
-                        config.name = detected;
-                    }
-                    Ok(config)
+            let mut load = MonitoringConfig::load(&name).await;
+            if let (Ok(config), Some(bootstrap)) = (load.as_mut(), conductor_rpc.as_ref()) {
+                let detect_rpc = config.detect_rpc_for(Some(bootstrap));
+                if let Some(detected) = MonitoringConfig::detect_name_from_rpc(&detect_rpc).await {
+                    config.name = detected;
                 }
-                Err(e) => Err(e),
-            };
-            let _ = tx.send(result);
+            }
+            let _ = tx.send(load);
         });
     }
 

--- a/crates/infra/basectl/src/app/core.rs
+++ b/crates/infra/basectl/src/app/core.rs
@@ -8,6 +8,7 @@ use ratatui::{
     widgets::{Block, Borders, Clear, Paragraph},
 };
 use tokio::sync::oneshot;
+use url::Url;
 
 use super::{Action, Resources, Router, View, ViewId, runner::start_background_services};
 use crate::{
@@ -47,6 +48,9 @@ pub struct App {
     network_picker: Option<NetworkPicker>,
     /// Pending async network-load result. `Some` while a switch is in flight.
     pending_network: Option<oneshot::Receiver<anyhow::Result<MonitoringConfig>>>,
+    /// Bootstrap conductor RPC URL from `--conductor-rpc`. Forwarded to background
+    /// services on every network switch so discovery survives the rebuild.
+    conductor_rpc: Option<Url>,
 }
 
 impl fmt::Debug for App {
@@ -64,7 +68,7 @@ impl fmt::Debug for App {
 
 impl App {
     /// Creates a new application with the given resources and initial view.
-    pub fn new(resources: Resources, initial_view: ViewId) -> Self {
+    pub fn new(resources: Resources, initial_view: ViewId, conductor_rpc: Option<Url>) -> Self {
         Self {
             router: Router::new(initial_view),
             resources,
@@ -72,6 +76,7 @@ impl App {
             view_cache: HashMap::new(),
             network_picker: None,
             pending_network: None,
+            conductor_rpc,
         }
     }
 
@@ -293,7 +298,7 @@ impl App {
         // Replace resources entirely — dropping old receivers causes background
         // tasks from the previous network to exit naturally on their next send.
         self.resources = Resources::new(new_config.clone());
-        start_background_services(&new_config, &mut self.resources);
+        start_background_services(&new_config, &mut self.resources, self.conductor_rpc.clone());
         // Discard all cached view state so views re-initialise for the new network.
         self.view_cache.clear();
         self.router = Router::new(ViewId::Home);

--- a/crates/infra/basectl/src/app/core.rs
+++ b/crates/infra/basectl/src/app/core.rs
@@ -250,7 +250,9 @@ impl App {
         let conductor_rpc = self.conductor_rpc.clone();
         tokio::spawn(async move {
             let mut load = MonitoringConfig::load(&name).await;
-            if let (Ok(config), Some(bootstrap)) = (load.as_mut(), conductor_rpc.as_ref()) {
+            if let (Ok(config), Some(bootstrap)) = (load.as_mut(), conductor_rpc.as_ref())
+                && config.conductors.is_none()
+            {
                 let detect_rpc = config.detect_rpc_for(Some(bootstrap));
                 if let Some(detected) = MonitoringConfig::detect_name_from_rpc(&detect_rpc).await {
                     config.name = detected;

--- a/crates/infra/basectl/src/app/core.rs
+++ b/crates/infra/basectl/src/app/core.rs
@@ -248,7 +248,17 @@ impl App {
         let (tx, rx) = oneshot::channel();
         self.pending_network = Some(rx);
         tokio::spawn(async move {
-            let result = MonitoringConfig::load(&name).await;
+            let result = match MonitoringConfig::load(&name).await {
+                Ok(mut config) => {
+                    if let Some(detected) =
+                        MonitoringConfig::detect_name_from_rpc(&config.rpc).await
+                    {
+                        config.name = detected;
+                    }
+                    Ok(config)
+                }
+                Err(e) => Err(e),
+            };
             let _ = tx.send(result);
         });
     }

--- a/crates/infra/basectl/src/app/core.rs
+++ b/crates/infra/basectl/src/app/core.rs
@@ -10,7 +10,10 @@ use ratatui::{
 use tokio::sync::oneshot;
 use url::Url;
 
-use super::{Action, Resources, Router, View, ViewId, runner::start_background_services};
+use super::{
+    Action, Resources, Router, View, ViewId,
+    runner::{detect_rpc_for, start_background_services},
+};
 use crate::{
     commands::{COLOR_BASE_BLUE, EVENT_POLL_TIMEOUT},
     config::MonitoringConfig,
@@ -247,11 +250,13 @@ impl App {
         self.resources.toasts.push(Toast::info(format!("Connecting to {name}…")));
         let (tx, rx) = oneshot::channel();
         self.pending_network = Some(rx);
+        let conductor_rpc = self.conductor_rpc.clone();
         tokio::spawn(async move {
             let result = match MonitoringConfig::load(&name).await {
                 Ok(mut config) => {
+                    let detect_rpc = detect_rpc_for(&config, conductor_rpc.as_ref());
                     if let Some(detected) =
-                        MonitoringConfig::detect_name_from_rpc(&config.rpc).await
+                        MonitoringConfig::detect_name_from_rpc(&detect_rpc).await
                     {
                         config.name = detected;
                     }

--- a/crates/infra/basectl/src/app/mod.rs
+++ b/crates/infra/basectl/src/app/mod.rs
@@ -7,7 +7,9 @@ mod core;
 pub use core::App;
 
 mod resources;
-pub use resources::{ConductorState, DaState, FlashState, ProofsState, Resources, ValidatorState};
+pub use resources::{
+    ConductorState, DaState, FlashState, ProofsState, Resources, SourceLabel, ValidatorState,
+};
 
 mod router;
 pub use router::{Router, ViewId};

--- a/crates/infra/basectl/src/app/mod.rs
+++ b/crates/infra/basectl/src/app/mod.rs
@@ -15,7 +15,7 @@ mod router;
 pub use router::{Router, ViewId};
 
 mod runner;
-pub use runner::{run_app, run_flashblocks_json, start_background_services};
+pub use runner::{detect_rpc_for, run_app, run_flashblocks_json, start_background_services};
 
 mod view;
 pub use view::View;

--- a/crates/infra/basectl/src/app/mod.rs
+++ b/crates/infra/basectl/src/app/mod.rs
@@ -15,7 +15,7 @@ mod router;
 pub use router::{Router, ViewId};
 
 mod runner;
-pub use runner::{detect_rpc_for, run_app, run_flashblocks_json, start_background_services};
+pub use runner::{run_app, run_flashblocks_json, start_background_services};
 
 mod view;
 pub use view::View;

--- a/crates/infra/basectl/src/app/resources.rs
+++ b/crates/infra/basectl/src/app/resources.rs
@@ -70,6 +70,22 @@ impl ConductorState {
         self.source_label = label;
     }
 
+    /// Returns the active per-node configs. In `Static` mode this is the
+    /// configured list; in `Discover` mode it is the list synthesised from the
+    /// last `clusterMembership` snapshot. The conductor view uses this to
+    /// dispatch mutations (pause, resume, transfer, …) without re-reading the
+    /// stale `MonitoringConfig.conductors` list, which is `None` in `Discover`.
+    pub fn nodes_config(&self) -> &[ConductorNodeConfig] {
+        &self.nodes_config
+    }
+
+    /// Seeds the per-node configs directly (used in `Discover` mode so the view
+    /// can dispatch mutations against the bootstrap node before the first
+    /// `clusterMembership` snapshot arrives).
+    pub fn set_nodes_config(&mut self, nodes_config: Vec<ConductorNodeConfig>) {
+        self.nodes_config = nodes_config;
+    }
+
     /// Registers the node configs and URL sender used to track leader URL changes.
     ///
     /// After this is called, every `poll` will push the leader's `flashblocks_ws`

--- a/crates/infra/basectl/src/app/resources.rs
+++ b/crates/infra/basectl/src/app/resources.rs
@@ -1,15 +1,20 @@
-use std::collections::{HashSet, VecDeque};
+use std::{
+    collections::{HashSet, VecDeque},
+    time::Instant,
+};
 
 use base_common_flashblocks::Flashblock;
 use base_common_genesis::SystemConfig;
+use base_consensus_rpc::ClusterMembership;
 use tokio::sync::{mpsc, watch};
+use url::Url;
 
 use crate::{
     commands::{DaTracker, FlashblockEntry, LoadingState},
     config::{ConductorNodeConfig, MonitoringConfig},
     rpc::{
-        BacklogFetchResult, BlockDaInfo, ConductorNodeStatus, L1BlockInfo, L1ConnectionMode,
-        ProofsSnapshot, TimestampedFlashblock, ValidatorNodeStatus,
+        BacklogFetchResult, BlockDaInfo, ConductorNodeStatus, ConductorPollUpdate, L1BlockInfo,
+        L1ConnectionMode, ProofsSnapshot, TimestampedFlashblock, ValidatorNodeStatus,
     },
     tui::ToastState,
 };
@@ -17,26 +22,52 @@ use crate::{
 const MAX_FLASH_BLOCKS: usize = 30;
 const MAX_RECENT_DA_FLASHBLOCK_IDS: usize = 512;
 
+/// Origin label for the conductor cluster node list, surfaced in the TUI.
+#[derive(Debug, Clone, Default)]
+pub enum SourceLabel {
+    /// Hand-configured node list (devnet, custom YAML).
+    #[default]
+    Static,
+    /// Bootstrapped from a single conductor RPC and refreshed from raft membership.
+    Discovered {
+        /// Bootstrap conductor RPC URL.
+        bootstrap: Url,
+        /// Wall-clock time of the most recent successful membership refresh.
+        last_refresh: Instant,
+    },
+}
+
 /// State for HA conductor cluster monitoring.
 #[derive(Debug, Default)]
 pub struct ConductorState {
     /// Most recent status snapshot for each conductor node.
     pub nodes: Vec<ConductorNodeStatus>,
     /// Original per-node configs, used to look up each node's `flashblocks_ws` URL.
+    /// In `Discover` mode this is rebuilt every time the poller emits a
+    /// `NodeListRefreshed` update.
     nodes_config: Vec<ConductorNodeConfig>,
-    rx: Option<mpsc::Receiver<Vec<ConductorNodeStatus>>>,
+    rx: Option<mpsc::Receiver<ConductorPollUpdate>>,
     /// Sender half of the flashblocks URL watch channel.  When set, `poll`
     /// derives the current leader's flashblocks endpoint from the polled
     /// status and pushes a new value whenever the leader changes.  This
     /// removes the need for a separate `run_conductor_leader_url_tracker`
     /// task that would duplicate the `conductor_leader` RPC calls.
     fb_url_tx: Option<watch::Sender<String>>,
+    /// Most recent raft cluster membership snapshot.
+    pub cluster_membership: Option<ClusterMembership>,
+    /// Whether the active node list comes from a static config or live discovery.
+    pub source_label: SourceLabel,
 }
 
 impl ConductorState {
-    /// Sets the channel for receiving conductor status updates.
-    pub fn set_channel(&mut self, rx: mpsc::Receiver<Vec<ConductorNodeStatus>>) {
+    /// Sets the channel for receiving conductor poll updates.
+    pub fn set_channel(&mut self, rx: mpsc::Receiver<ConductorPollUpdate>) {
         self.rx = Some(rx);
+    }
+
+    /// Sets the source label (static vs discovered) for UI display.
+    pub fn set_source_label(&mut self, label: SourceLabel) {
+        self.source_label = label;
     }
 
     /// Registers the node configs and URL sender used to track leader URL changes.
@@ -52,13 +83,21 @@ impl ConductorState {
         self.fb_url_tx = Some(tx);
     }
 
-    /// Drains the latest status snapshot from the background poller, then
+    /// Drains all pending poll updates, keeping the most recent values, then
     /// pushes the leader's flashblocks URL into the watch channel if it changed.
     pub fn poll(&mut self) {
         let Some(ref mut rx) = self.rx else { return };
-        // Drain all pending updates, keeping only the most recent snapshot.
-        while let Ok(statuses) = rx.try_recv() {
-            self.nodes = statuses;
+        while let Ok(update) = rx.try_recv() {
+            match update {
+                ConductorPollUpdate::Status(statuses) => self.nodes = statuses,
+                ConductorPollUpdate::Membership(m) => {
+                    self.cluster_membership = Some(m);
+                    if let SourceLabel::Discovered { last_refresh, .. } = &mut self.source_label {
+                        *last_refresh = Instant::now();
+                    }
+                }
+                ConductorPollUpdate::NodeListRefreshed(nodes) => self.nodes_config = nodes,
+            }
         }
         self.push_leader_url();
     }

--- a/crates/infra/basectl/src/app/resources.rs
+++ b/crates/infra/basectl/src/app/resources.rs
@@ -1,5 +1,6 @@
 use std::{
     collections::{HashSet, VecDeque},
+    sync::Arc,
     time::Instant,
 };
 
@@ -53,8 +54,9 @@ pub struct ConductorState {
     /// removes the need for a separate `run_conductor_leader_url_tracker`
     /// task that would duplicate the `conductor_leader` RPC calls.
     fb_url_tx: Option<watch::Sender<String>>,
-    /// Most recent raft cluster membership snapshot.
-    pub cluster_membership: Option<ClusterMembership>,
+    /// Most recent raft cluster membership snapshot. Shared by `Arc` with the
+    /// poller so a membership change is a single allocation, not a deep copy.
+    pub cluster_membership: Option<Arc<ClusterMembership>>,
     /// Whether the active node list comes from a static config or live discovery.
     pub source_label: SourceLabel,
 }

--- a/crates/infra/basectl/src/app/runner.rs
+++ b/crates/infra/basectl/src/app/runner.rs
@@ -30,33 +30,16 @@ pub async fn run_app(
     conductor_rpc: Option<Url>,
 ) -> Result<()> {
     let mut config = MonitoringConfig::load(network).await?;
-    // When --conductor-rpc is set, detect chain via the bootstrap's EL port so
-    // the badge reflects the cluster the operator pointed at, not the default
-    // public RPC baked into the network preset.
-    let detect_rpc = detect_rpc_for(&config, conductor_rpc.as_ref());
-    if let Some(detected) = MonitoringConfig::detect_name_from_rpc(&detect_rpc).await {
-        config.name = detected;
+    if let Some(bootstrap) = conductor_rpc.as_ref() {
+        let detect_rpc = config.detect_rpc_for(Some(bootstrap));
+        if let Some(detected) = MonitoringConfig::detect_name_from_rpc(&detect_rpc).await {
+            config.name = detected;
+        }
     }
     let mut resources = Resources::new(config.clone());
     start_background_services(&config, &mut resources, conductor_rpc.clone());
     let app = App::new(resources, initial_view, conductor_rpc);
     app.run(create_view).await
-}
-
-/// Returns the URL to use for `eth_chainId` network detection.
-///
-/// When `--conductor-rpc` is set we derive the EL URL from the bootstrap host
-/// using the discovery EL port template (falls back to `config.rpc` if the
-/// resulting URL fails to construct or the EL port is disabled).
-pub fn detect_rpc_for(config: &MonitoringConfig, conductor_rpc: Option<&Url>) -> Url {
-    let Some(bootstrap) = conductor_rpc else { return config.rpc.clone() };
-    let ports = config.discovery.as_ref().map(|d| &d.ports);
-    let el_port = ports.and_then(|p| p.el_rpc).unwrap_or(8545);
-    let mut candidate = bootstrap.clone();
-    if candidate.set_port(Some(el_port)).is_err() {
-        return config.rpc.clone();
-    }
-    candidate
 }
 
 /// Resolves the active conductor source from CLI flag and config.

--- a/crates/infra/basectl/src/app/runner.rs
+++ b/crates/infra/basectl/src/app/runner.rs
@@ -163,10 +163,19 @@ pub fn start_background_services(
         // a separate task that would duplicate the conductor_leader RPCs.
         // Discovered peers carry no flashblocks_ws endpoints, so this only
         // applies to statically configured clusters (devnet today).
-        if let ConductorSource::Static(nodes) = &source
-            && nodes.iter().any(|n| n.flashblocks_ws.is_some())
-        {
-            resources.conductor.set_url_sender(nodes.clone(), fb_url_tx);
+        match &source {
+            ConductorSource::Static(nodes) => {
+                if nodes.iter().any(|n| n.flashblocks_ws.is_some()) {
+                    resources.conductor.set_url_sender(nodes.clone(), fb_url_tx);
+                } else {
+                    resources.conductor.set_nodes_config(nodes.clone());
+                }
+            }
+            ConductorSource::Discover { .. } => {
+                if let Some(bootstrap) = source.bootstrap_node() {
+                    resources.conductor.set_nodes_config(vec![bootstrap]);
+                }
+            }
         }
         tokio::spawn(run_conductor_poller(source, conductor_tx));
     }

--- a/crates/infra/basectl/src/app/runner.rs
+++ b/crates/infra/basectl/src/app/runner.rs
@@ -29,7 +29,10 @@ pub async fn run_app(
     network: &str,
     conductor_rpc: Option<Url>,
 ) -> Result<()> {
-    let config = MonitoringConfig::load(network).await?;
+    let mut config = MonitoringConfig::load(network).await?;
+    if let Some(detected) = MonitoringConfig::detect_name_from_rpc(&config.rpc).await {
+        config.name = detected;
+    }
     let mut resources = Resources::new(config.clone());
     start_background_services(&config, &mut resources, conductor_rpc.clone());
     let app = App::new(resources, initial_view, conductor_rpc);

--- a/crates/infra/basectl/src/app/runner.rs
+++ b/crates/infra/basectl/src/app/runner.rs
@@ -1,16 +1,17 @@
-use std::io::Write;
+use std::{io::Write, time::Instant};
 
 use anyhow::Result;
 use base_common_flashblocks::Flashblock;
 use base_common_genesis::SystemConfig;
 use tokio::sync::{mpsc, watch};
+use url::Url;
 
-use super::{App, Resources, ViewId, views::create_view};
+use super::{App, Resources, SourceLabel, ViewId, views::create_view};
 use crate::{
-    config::MonitoringConfig,
+    config::{ConductorSource, MonitoringConfig},
     l1_client::fetch_full_system_config,
     rpc::{
-        BacklogFetchResult, BlockDaInfo, ConductorNodeStatus, L1BlockInfo, L1ConnectionMode,
+        BacklogFetchResult, BlockDaInfo, ConductorPollUpdate, L1BlockInfo, L1ConnectionMode,
         ProofsSnapshot, TimestampedFlashblock, ValidatorNodeStatus,
         fetch_initial_backlog_with_progress, run_block_fetcher, run_conductor_poller,
         run_flashblock_ws, run_flashblock_ws_timestamped, run_l1_blob_watcher, run_proofs_poller,
@@ -20,12 +21,43 @@ use crate::{
 };
 
 /// Launches the TUI application starting from the specified view and network.
-pub async fn run_app(initial_view: ViewId, network: &str) -> Result<()> {
+///
+/// `conductor_rpc` is the optional `--conductor-rpc` CLI override; when set it
+/// forces the conductor source into `Discover` mode regardless of config.
+pub async fn run_app(
+    initial_view: ViewId,
+    network: &str,
+    conductor_rpc: Option<Url>,
+) -> Result<()> {
     let config = MonitoringConfig::load(network).await?;
     let mut resources = Resources::new(config.clone());
-    start_background_services(&config, &mut resources);
-    let app = App::new(resources, initial_view);
+    start_background_services(&config, &mut resources, conductor_rpc.clone());
+    let app = App::new(resources, initial_view, conductor_rpc);
     app.run(create_view).await
+}
+
+/// Resolves the active conductor source from CLI flag and config.
+///
+/// Precedence: CLI `--conductor-rpc` flag > hand-configured `conductors` list >
+/// `discovery.bootstrap_rpc` from config. Returns `None` when no source is
+/// configured (conductor view will simply show no nodes).
+fn resolve_conductor_source(
+    cli_flag: Option<Url>,
+    config: &MonitoringConfig,
+) -> Option<ConductorSource> {
+    if let Some(bootstrap) = cli_flag {
+        let ports = config.discovery.as_ref().map(|d| d.ports.clone()).unwrap_or_default();
+        return Some(ConductorSource::Discover { bootstrap, ports });
+    }
+    if let Some(nodes) = config.conductors.clone() {
+        return Some(ConductorSource::Static(nodes));
+    }
+    if let Some(d) = config.discovery.as_ref()
+        && let Some(bootstrap) = d.bootstrap_rpc.clone()
+    {
+        return Some(ConductorSource::Discover { bootstrap, ports: d.ports.clone() });
+    }
+    None
 }
 
 /// Starts all background data-fetching services, wiring their channels into `resources`.
@@ -34,7 +66,11 @@ pub async fn run_app(initial_view: ViewId, network: &str) -> Result<()> {
 /// safe-head polling, system config fetching, conductor polling, validator polling,
 /// and proof monitoring. All tasks communicate back through channels stored in
 /// `resources`.
-pub fn start_background_services(config: &MonitoringConfig, resources: &mut Resources) {
+pub fn start_background_services(
+    config: &MonitoringConfig,
+    resources: &mut Resources,
+    conductor_rpc: Option<Url>,
+) {
     let (fb_tx, fb_rx) = mpsc::channel::<TimestampedFlashblock>(100);
     let (da_fb_tx, da_fb_rx) = mpsc::channel::<Flashblock>(100);
     let (sync_tx, sync_rx) = mpsc::channel::<u64>(10);
@@ -106,17 +142,27 @@ pub fn start_background_services(config: &MonitoringConfig, resources: &mut Reso
         }
     });
 
-    if let Some(conductor_nodes) = config.conductors.clone() {
-        let (conductor_tx, conductor_rx) = mpsc::channel::<Vec<ConductorNodeStatus>>(4);
+    if let Some(source) = resolve_conductor_source(conductor_rpc, config) {
+        let (conductor_tx, conductor_rx) = mpsc::channel::<ConductorPollUpdate>(8);
         resources.conductor.set_channel(conductor_rx);
-        tokio::spawn(run_conductor_poller(conductor_nodes.clone(), conductor_tx));
-
+        resources.conductor.set_source_label(match &source {
+            ConductorSource::Static(_) => SourceLabel::Static,
+            ConductorSource::Discover { bootstrap, .. } => SourceLabel::Discovered {
+                bootstrap: bootstrap.clone(),
+                last_refresh: Instant::now(),
+            },
+        });
         // Wire the URL sender into ConductorState so that the existing
         // conductor poll (200 ms) drives flashblocks URL changes instead of
         // a separate task that would duplicate the conductor_leader RPCs.
-        if conductor_nodes.iter().any(|n| n.flashblocks_ws.is_some()) {
-            resources.conductor.set_url_sender(conductor_nodes, fb_url_tx);
+        // Discovered peers carry no flashblocks_ws endpoints, so this only
+        // applies to statically configured clusters (devnet today).
+        if let ConductorSource::Static(nodes) = &source
+            && nodes.iter().any(|n| n.flashblocks_ws.is_some())
+        {
+            resources.conductor.set_url_sender(nodes.clone(), fb_url_tx);
         }
+        tokio::spawn(run_conductor_poller(source, conductor_tx));
     }
 
     if let Some(validator_nodes) = config.validators.clone() {

--- a/crates/infra/basectl/src/app/runner.rs
+++ b/crates/infra/basectl/src/app/runner.rs
@@ -30,7 +30,9 @@ pub async fn run_app(
     conductor_rpc: Option<Url>,
 ) -> Result<()> {
     let mut config = MonitoringConfig::load(network).await?;
-    if let Some(bootstrap) = conductor_rpc.as_ref() {
+    if config.conductors.is_none()
+        && let Some(bootstrap) = conductor_rpc.as_ref()
+    {
         let detect_rpc = config.detect_rpc_for(Some(bootstrap));
         if let Some(detected) = MonitoringConfig::detect_name_from_rpc(&detect_rpc).await {
             config.name = detected;
@@ -44,19 +46,21 @@ pub async fn run_app(
 
 /// Resolves the active conductor source from CLI flag and config.
 ///
-/// Precedence: CLI `--conductor-rpc` flag > hand-configured `conductors` list >
-/// `discovery.bootstrap_rpc` from config. Returns `None` when no source is
+/// Precedence: hand-configured `conductors` list > CLI `--conductor-rpc` flag >
+/// `discovery.bootstrap_rpc` from config. Static config wins so local devnet
+/// (which ships with a hardcoded 3-node list) isn't accidentally clobbered by
+/// the default `--conductor-rpc` value. Returns `None` when no source is
 /// configured (conductor view will simply show no nodes).
 fn resolve_conductor_source(
     cli_flag: Option<Url>,
     config: &MonitoringConfig,
 ) -> Option<ConductorSource> {
+    if let Some(nodes) = config.conductors.clone() {
+        return Some(ConductorSource::Static(nodes));
+    }
     if let Some(bootstrap) = cli_flag {
         let ports = config.discovery.as_ref().map(|d| d.ports.clone()).unwrap_or_default();
         return Some(ConductorSource::Discover { bootstrap, ports });
-    }
-    if let Some(nodes) = config.conductors.clone() {
-        return Some(ConductorSource::Static(nodes));
     }
     if let Some(d) = config.discovery.as_ref()
         && let Some(bootstrap) = d.bootstrap_rpc.clone()

--- a/crates/infra/basectl/src/app/runner.rs
+++ b/crates/infra/basectl/src/app/runner.rs
@@ -30,13 +30,33 @@ pub async fn run_app(
     conductor_rpc: Option<Url>,
 ) -> Result<()> {
     let mut config = MonitoringConfig::load(network).await?;
-    if let Some(detected) = MonitoringConfig::detect_name_from_rpc(&config.rpc).await {
+    // When --conductor-rpc is set, detect chain via the bootstrap's EL port so
+    // the badge reflects the cluster the operator pointed at, not the default
+    // public RPC baked into the network preset.
+    let detect_rpc = detect_rpc_for(&config, conductor_rpc.as_ref());
+    if let Some(detected) = MonitoringConfig::detect_name_from_rpc(&detect_rpc).await {
         config.name = detected;
     }
     let mut resources = Resources::new(config.clone());
     start_background_services(&config, &mut resources, conductor_rpc.clone());
     let app = App::new(resources, initial_view, conductor_rpc);
     app.run(create_view).await
+}
+
+/// Returns the URL to use for `eth_chainId` network detection.
+///
+/// When `--conductor-rpc` is set we derive the EL URL from the bootstrap host
+/// using the discovery EL port template (falls back to `config.rpc` if the
+/// resulting URL fails to construct or the EL port is disabled).
+pub fn detect_rpc_for(config: &MonitoringConfig, conductor_rpc: Option<&Url>) -> Url {
+    let Some(bootstrap) = conductor_rpc else { return config.rpc.clone() };
+    let ports = config.discovery.as_ref().map(|d| &d.ports);
+    let el_port = ports.and_then(|p| p.el_rpc).unwrap_or(8545);
+    let mut candidate = bootstrap.clone();
+    if candidate.set_port(Some(el_port)).is_err() {
+        return config.rpc.clone();
+    }
+    candidate
 }
 
 /// Resolves the active conductor source from CLI flag and config.

--- a/crates/infra/basectl/src/app/views/conductor.rs
+++ b/crates/infra/basectl/src/app/views/conductor.rs
@@ -99,7 +99,8 @@ impl ActionMenuItem {
                 node.is_leader == Some(true) && node.sequencer_active == Some(false)
             }
             Self::StopSequencer => node.sequencer_active == Some(true),
-            Self::TransferLeaderAny | Self::P2PToggle | Self::RestartContainers => true,
+            Self::RestartContainers => !node.discovered,
+            Self::TransferLeaderAny | Self::P2PToggle => true,
         }
     }
 }
@@ -1001,7 +1002,12 @@ fn render_cluster_table(
             mods |= Modifier::UNDERLINED;
         }
         let style = Style::default().fg(role_color).add_modifier(mods);
-        header_cells.push(Cell::from(node.name.as_str()).style(style));
+        let label = if node.discovered {
+            format!("{} (d)", node.name)
+        } else {
+            node.name.clone()
+        };
+        header_cells.push(Cell::from(label).style(style));
     }
     let header = Row::new(header_cells)
         .style(Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD))

--- a/crates/infra/basectl/src/app/views/conductor.rs
+++ b/crates/infra/basectl/src/app/views/conductor.rs
@@ -99,8 +99,8 @@ impl ActionMenuItem {
                 node.is_leader == Some(true) && node.sequencer_active == Some(false)
             }
             Self::StopSequencer => node.sequencer_active == Some(true),
-            Self::RestartContainers => !node.discovered,
-            Self::TransferLeaderAny | Self::P2PToggle => true,
+            Self::RestartContainers | Self::P2PToggle => !node.discovered,
+            Self::TransferLeaderAny => true,
         }
     }
 }

--- a/crates/infra/basectl/src/app/views/conductor.rs
+++ b/crates/infra/basectl/src/app/views/conductor.rs
@@ -1002,11 +1002,7 @@ fn render_cluster_table(
             mods |= Modifier::UNDERLINED;
         }
         let style = Style::default().fg(role_color).add_modifier(mods);
-        let label = if node.discovered {
-            format!("{} (d)", node.name)
-        } else {
-            node.name.clone()
-        };
+        let label = if node.discovered { format!("{} (d)", node.name) } else { node.name.clone() };
         header_cells.push(Cell::from(label).style(style));
     }
     let header = Row::new(header_cells)

--- a/crates/infra/basectl/src/app/views/conductor.rs
+++ b/crates/infra/basectl/src/app/views/conductor.rs
@@ -306,7 +306,10 @@ impl ConductorView {
 
     /// Spawns the mutation behind a confirmed action and switches to single-flight.
     fn execute(&mut self, action: PendingAction, resources: &Resources) {
-        let Some(ref nodes_cfg) = resources.config.conductors else { return };
+        let nodes_cfg = resources.conductor.nodes_config();
+        if nodes_cfg.is_empty() {
+            return;
+        }
         self.op_pending = true;
         self.close_overlay();
 
@@ -314,12 +317,12 @@ impl ConductorView {
             PendingAction::TransferAny => {
                 let (tx, rx) = mpsc::channel(1);
                 self.op_rx = Some(rx);
-                tokio::spawn(transfer_conductor_leader(nodes_cfg.clone(), None, tx));
+                tokio::spawn(transfer_conductor_leader(nodes_cfg.to_vec(), None, tx));
             }
             PendingAction::TransferTo(target) => {
                 let (tx, rx) = mpsc::channel(1);
                 self.op_rx = Some(rx);
-                tokio::spawn(transfer_conductor_leader(nodes_cfg.clone(), Some(target), tx));
+                tokio::spawn(transfer_conductor_leader(nodes_cfg.to_vec(), Some(target), tx));
             }
             PendingAction::RestartNode(name) => {
                 if let Some(node) = nodes_cfg.iter().find(|n| n.name == name).cloned() {

--- a/crates/infra/basectl/src/config.rs
+++ b/crates/infra/basectl/src/config.rs
@@ -6,6 +6,7 @@ use anyhow::{Context, Result};
 use base_common_chains::{ChainConfig, rollup_config};
 use base_common_genesis::RollupConfig;
 use serde::{Deserialize, Serialize};
+use tracing::warn;
 use url::Url;
 
 /// Configuration for proof system monitoring (proposer + dispute games).
@@ -170,8 +171,9 @@ impl ConductorSource {
         match self {
             Self::Static(_) => None,
             Self::Discover { bootstrap, ports } => {
-                let cl_rpc = swap_port(bootstrap, ports.cl_rpc);
-                let el_rpc = ports.el_rpc.map(|p| swap_port(bootstrap, p));
+                let host = bootstrap.host_str().unwrap_or("localhost");
+                let cl_rpc = peer_url(bootstrap, host, ports.cl_rpc);
+                let el_rpc = ports.el_rpc.map(|p| peer_url(bootstrap, host, p));
                 Some(ConductorNodeConfig {
                     name: "local".to_string(),
                     conductor_rpc: bootstrap.clone(),
@@ -187,56 +189,59 @@ impl ConductorSource {
             }
         }
     }
+
+    /// Synthesises per-peer `ConductorNodeConfig` entries from raft membership.
+    ///
+    /// Returns `None` for [`ConductorSource::Static`] (those nodes are already
+    /// fully configured). For [`ConductorSource::Discover`], each `ServerInfo`
+    /// in `membership` has an `addr` field that is the raft binary protocol
+    /// address (e.g. `op-conductor-1:5051`); the host is extracted and the
+    /// JSON-RPC URLs are rebuilt from the supplied port templates. Docker
+    /// container names are hardcoded to the production deployment convention.
+    pub fn synthesize_nodes(
+        &self,
+        membership: &base_consensus_rpc::ClusterMembership,
+    ) -> Option<Vec<ConductorNodeConfig>> {
+        let Self::Discover { bootstrap, ports } = self else { return None };
+        let nodes = membership
+            .servers
+            .iter()
+            .map(|srv| {
+                let host = srv.addr.split(':').next().unwrap_or(srv.addr.as_str());
+                ConductorNodeConfig {
+                    name: srv.id.clone(),
+                    conductor_rpc: peer_url(bootstrap, host, ports.conductor_rpc),
+                    cl_rpc: peer_url(bootstrap, host, ports.cl_rpc),
+                    server_id: srv.id.clone(),
+                    raft_addr: srv.addr.clone(),
+                    el_rpc: ports.el_rpc.map(|p| peer_url(bootstrap, host, p)),
+                    docker_conductor: Some("conductor".to_string()),
+                    docker_el: Some("execution".to_string()),
+                    docker_cl: Some("consensus".to_string()),
+                    flashblocks_ws: None,
+                }
+            })
+            .collect();
+        Some(nodes)
+    }
 }
 
-fn swap_port(url: &Url, port: u16) -> Url {
-    let mut out = url.clone();
-    let _ = out.set_port(Some(port));
-    out
-}
-
-/// Synthesises per-peer `ConductorNodeConfig` entries from raft membership.
+/// Builds a peer JSON-RPC URL by string interpolation against `bootstrap`'s scheme.
 ///
-/// `addr` on each `ServerInfo` is the raft binary protocol address (e.g.
-/// `op-conductor-1:5051`). We extract the host and rebuild JSON-RPC URLs via
-/// the supplied port templates. Docker container names are hardcoded to the
-/// production deployment convention.
-pub fn synthesize_nodes(
-    bootstrap: &Url,
-    ports: &DiscoveryPorts,
-    membership: &base_consensus_rpc::ClusterMembership,
-) -> Vec<ConductorNodeConfig> {
-    membership
-        .servers
-        .iter()
-        .map(|srv| {
-            let host = srv.addr.split(':').next().unwrap_or(srv.addr.as_str());
-            let mut conductor_rpc = bootstrap.clone();
-            let _ = conductor_rpc.set_host(Some(host));
-            let _ = conductor_rpc.set_port(Some(ports.conductor_rpc));
-            let mut cl_rpc = bootstrap.clone();
-            let _ = cl_rpc.set_host(Some(host));
-            let _ = cl_rpc.set_port(Some(ports.cl_rpc));
-            let el_rpc = ports.el_rpc.map(|p| {
-                let mut u = bootstrap.clone();
-                let _ = u.set_host(Some(host));
-                let _ = u.set_port(Some(p));
-                u
-            });
-            ConductorNodeConfig {
-                name: srv.id.clone(),
-                conductor_rpc,
-                cl_rpc,
-                server_id: srv.id.clone(),
-                raft_addr: srv.addr.clone(),
-                el_rpc,
-                docker_conductor: Some("conductor".to_string()),
-                docker_el: Some("execution".to_string()),
-                docker_cl: Some("consensus".to_string()),
-                flashblocks_ws: None,
-            }
-        })
-        .collect()
+/// Falls back to a clone of `bootstrap` and logs a warning if the resulting
+/// URL fails to parse (e.g. an unexpected host shape coming back from raft).
+/// Returning `bootstrap` is a safer default than panicking — the poll will
+/// just hit the bootstrap node twice, which is visible to the operator.
+fn peer_url(bootstrap: &Url, host: &str, port: u16) -> Url {
+    let scheme = bootstrap.scheme();
+    let candidate = format!("{scheme}://{host}:{port}");
+    match Url::parse(&candidate) {
+        Ok(url) => url,
+        Err(error) => {
+            warn!(host = %host, port = port, error = %error, "discovered peer host failed url parse; falling back to bootstrap");
+            bootstrap.clone()
+        }
+    }
 }
 
 /// Monitoring configuration for a chain watched by basectl.

--- a/crates/infra/basectl/src/config.rs
+++ b/crates/infra/basectl/src/config.rs
@@ -201,7 +201,9 @@ impl ConductorSource {
     /// in `membership` has an `addr` field that is the raft binary protocol
     /// address (e.g. `op-conductor-1:5051`); the host is extracted and the
     /// JSON-RPC URLs are rebuilt from the supplied port templates. Docker
-    /// container names are hardcoded to the production deployment convention.
+    /// container names are left `None` because the local docker daemon can't
+    /// reach remote peers' containers; restart is also UI-disabled for
+    /// discovered peers.
     pub fn synthesize_nodes(
         &self,
         membership: &base_consensus_rpc::ClusterMembership,
@@ -219,9 +221,9 @@ impl ConductorSource {
                     server_id: srv.id.clone(),
                     raft_addr: srv.addr.clone(),
                     el_rpc: ports.el_rpc.map(|p| peer_url(bootstrap, host, p)),
-                    docker_conductor: Some("conductor".to_string()),
-                    docker_el: Some("execution".to_string()),
-                    docker_cl: Some("consensus".to_string()),
+                    docker_conductor: None,
+                    docker_el: None,
+                    docker_cl: None,
                     flashblocks_ws: None,
                 }
             })

--- a/crates/infra/basectl/src/config.rs
+++ b/crates/infra/basectl/src/config.rs
@@ -81,6 +81,164 @@ pub struct ConductorNodeConfig {
     pub flashblocks_ws: Option<Url>,
 }
 
+/// Conductor cluster discovery configuration.
+///
+/// When set, basectl can bootstrap a conductor cluster view from a single
+/// RPC endpoint by calling `conductor_clusterMembership` and synthesising
+/// per-peer `ConductorNodeConfig` entries via [`DiscoveryPorts`] templates.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DiscoveryConfig {
+    /// Bootstrap conductor RPC URL.
+    ///
+    /// basectl will hit this URL first to learn the live raft membership and
+    /// then poll all discovered peers. May be overridden by `--conductor-rpc`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub bootstrap_rpc: Option<Url>,
+    /// Port templates used when rebuilding per-peer JSON-RPC URLs from the
+    /// raft binary protocol addresses returned by `conductor_clusterMembership`.
+    #[serde(default)]
+    pub ports: DiscoveryPorts,
+}
+
+/// Port templates used to derive per-peer JSON-RPC URLs from raft addresses.
+///
+/// `conductor_clusterMembership` returns each peer's *raft binary protocol*
+/// address (e.g. `op-conductor-1:5051`), not its JSON-RPC URL. basectl extracts
+/// the host and rebuilds JSON-RPC URLs for each service using these ports.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DiscoveryPorts {
+    /// Conductor JSON-RPC port (default 5545).
+    #[serde(default = "default_conductor_rpc_port")]
+    pub conductor_rpc: u16,
+    /// Consensus-layer JSON-RPC port (default 7545).
+    #[serde(default = "default_cl_rpc_port")]
+    pub cl_rpc: u16,
+    /// Optional execution-layer JSON-RPC port. When `None`, EL data is not
+    /// polled for discovered peers and shows as `—` in the UI.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub el_rpc: Option<u16>,
+}
+
+impl Default for DiscoveryPorts {
+    fn default() -> Self {
+        Self {
+            conductor_rpc: default_conductor_rpc_port(),
+            cl_rpc: default_cl_rpc_port(),
+            el_rpc: None,
+        }
+    }
+}
+
+const fn default_conductor_rpc_port() -> u16 {
+    5545
+}
+
+const fn default_cl_rpc_port() -> u16 {
+    7545
+}
+
+/// Origin of the conductor cluster node list used by the poller.
+///
+/// `Static` is the original behaviour: the YAML/devnet config enumerates every
+/// node up front. `Discover` bootstraps from a single conductor RPC URL and
+/// rebuilds the peer list each tick from `conductor_clusterMembership`.
+#[derive(Debug, Clone)]
+pub enum ConductorSource {
+    /// Hand-configured node list (devnet, custom YAML).
+    Static(Vec<ConductorNodeConfig>),
+    /// Bootstrap from a single conductor RPC and derive peers via port templates.
+    Discover {
+        /// Bootstrap conductor RPC URL.
+        bootstrap: Url,
+        /// Port templates for rebuilding per-peer JSON-RPC URLs.
+        ports: DiscoveryPorts,
+    },
+}
+
+impl ConductorSource {
+    /// Returns `true` if this source bootstraps from a single RPC.
+    pub const fn is_discover(&self) -> bool {
+        matches!(self, Self::Discover { .. })
+    }
+
+    /// Returns an ephemeral single-node config for the bootstrap URL.
+    ///
+    /// Used on the very first poll cycle of a `Discover` source, before
+    /// `conductor_clusterMembership` has returned anything. Once membership
+    /// is known, [`ConductorSource::synthesize_nodes`] takes over.
+    pub fn bootstrap_node(&self) -> Option<ConductorNodeConfig> {
+        match self {
+            Self::Static(_) => None,
+            Self::Discover { bootstrap, ports } => {
+                let cl_rpc = swap_port(bootstrap, ports.cl_rpc);
+                let el_rpc = ports.el_rpc.map(|p| swap_port(bootstrap, p));
+                Some(ConductorNodeConfig {
+                    name: "local".to_string(),
+                    conductor_rpc: bootstrap.clone(),
+                    cl_rpc,
+                    server_id: "local".to_string(),
+                    raft_addr: String::new(),
+                    el_rpc,
+                    docker_conductor: None,
+                    docker_el: None,
+                    docker_cl: None,
+                    flashblocks_ws: None,
+                })
+            }
+        }
+    }
+}
+
+fn swap_port(url: &Url, port: u16) -> Url {
+    let mut out = url.clone();
+    let _ = out.set_port(Some(port));
+    out
+}
+
+/// Synthesises per-peer `ConductorNodeConfig` entries from raft membership.
+///
+/// `addr` on each `ServerInfo` is the raft binary protocol address (e.g.
+/// `op-conductor-1:5051`). We extract the host and rebuild JSON-RPC URLs via
+/// the supplied port templates. Docker container names are hardcoded to the
+/// production deployment convention.
+pub fn synthesize_nodes(
+    bootstrap: &Url,
+    ports: &DiscoveryPorts,
+    membership: &base_consensus_rpc::ClusterMembership,
+) -> Vec<ConductorNodeConfig> {
+    membership
+        .servers
+        .iter()
+        .map(|srv| {
+            let host = srv.addr.split(':').next().unwrap_or(srv.addr.as_str());
+            let mut conductor_rpc = bootstrap.clone();
+            let _ = conductor_rpc.set_host(Some(host));
+            let _ = conductor_rpc.set_port(Some(ports.conductor_rpc));
+            let mut cl_rpc = bootstrap.clone();
+            let _ = cl_rpc.set_host(Some(host));
+            let _ = cl_rpc.set_port(Some(ports.cl_rpc));
+            let el_rpc = ports.el_rpc.map(|p| {
+                let mut u = bootstrap.clone();
+                let _ = u.set_host(Some(host));
+                let _ = u.set_port(Some(p));
+                u
+            });
+            ConductorNodeConfig {
+                name: srv.id.clone(),
+                conductor_rpc,
+                cl_rpc,
+                server_id: srv.id.clone(),
+                raft_addr: srv.addr.clone(),
+                el_rpc,
+                docker_conductor: Some("conductor".to_string()),
+                docker_el: Some("execution".to_string()),
+                docker_cl: Some("consensus".to_string()),
+                flashblocks_ws: None,
+            }
+        })
+        .collect()
+}
+
 /// Monitoring configuration for a chain watched by basectl.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct MonitoringConfig {
@@ -110,6 +268,12 @@ pub struct MonitoringConfig {
     /// HA conductor cluster nodes, if this chain runs an op-conductor setup.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub conductors: Option<Vec<ConductorNodeConfig>>,
+    /// Bootstrap configuration for runtime conductor cluster discovery.
+    ///
+    /// Used when `conductors` is `None` (or the operator passes
+    /// `--conductor-rpc`) to derive the peer list from a single bootstrap RPC.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub discovery: Option<DiscoveryConfig>,
     /// Validator (non-sequencing) nodes to monitor alongside the conductor cluster.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub validators: Option<Vec<ValidatorNodeConfig>>,
@@ -155,6 +319,7 @@ struct MonitoringConfigOverride {
     batcher_address: Option<Address>,
     l1_blob_target: Option<u64>,
     conductors: Option<Vec<ConductorNodeConfig>>,
+    discovery: Option<DiscoveryConfig>,
     validators: Option<Vec<ValidatorNodeConfig>>,
     proofs: Option<ProofsConfig>,
 }
@@ -197,6 +362,7 @@ impl MonitoringConfig {
             batcher_address: Some("0x5050F69a9786F081509234F1a7F4684b5E5b76C9".parse().unwrap()),
             l1_blob_target: 14,
             conductors: None,
+            discovery: Some(DiscoveryConfig { bootstrap_rpc: None, ports: DiscoveryPorts::default() }),
             validators: None,
             proofs: None,
         }
@@ -215,6 +381,7 @@ impl MonitoringConfig {
             batcher_address: Some("0xfc56E7272EEBBBA5bC6c544e159483C4a38f8bA3".parse().unwrap()),
             l1_blob_target: 14,
             conductors: None,
+            discovery: Some(DiscoveryConfig { bootstrap_rpc: None, ports: DiscoveryPorts::default() }),
             validators: None,
             proofs: None,
         }
@@ -295,6 +462,7 @@ impl MonitoringConfig {
                     docker_cl: Some("base-rpc".to_string()),
                 },
             ]),
+            discovery: None,
             proofs: None,
         }
     }
@@ -409,6 +577,7 @@ impl MonitoringConfig {
             batcher_address: overrides.batcher_address.or(base.batcher_address),
             l1_blob_target: overrides.l1_blob_target.unwrap_or(base.l1_blob_target),
             conductors: overrides.conductors.or(base.conductors),
+            discovery: overrides.discovery.or(base.discovery),
             validators: overrides.validators.or(base.validators),
             proofs: overrides.proofs.or(base.proofs),
         })

--- a/crates/infra/basectl/src/config.rs
+++ b/crates/infra/basectl/src/config.rs
@@ -332,6 +332,23 @@ impl MonitoringConfig {
         let chain_id = provider.get_chain_id().await.ok()?;
         Self::name_for_chain_id(chain_id).map(str::to_owned)
     }
+
+    /// Returns the URL to use for `eth_chainId` network detection.
+    ///
+    /// When `conductor_rpc` is `Some`, derives the EL URL from the bootstrap
+    /// host and the discovery EL port template, so the badge reflects the
+    /// cluster basectl was pointed at instead of the preset's default RPC.
+    /// Falls back to `self.rpc` when URL construction fails or no bootstrap
+    /// is provided.
+    pub fn detect_rpc_for(&self, conductor_rpc: Option<&Url>) -> Url {
+        let Some(bootstrap) = conductor_rpc else { return self.rpc.clone() };
+        let el_port = self.discovery.as_ref().and_then(|d| d.ports.el_rpc).unwrap_or(8545);
+        let mut candidate = bootstrap.clone();
+        if candidate.set_port(Some(el_port)).is_err() {
+            return self.rpc.clone();
+        }
+        candidate
+    }
 }
 
 const fn default_blob_target() -> u64 {

--- a/crates/infra/basectl/src/config.rs
+++ b/crates/infra/basectl/src/config.rs
@@ -114,9 +114,9 @@ pub struct DiscoveryPorts {
     /// Consensus-layer JSON-RPC port (default 7545).
     #[serde(default = "default_cl_rpc_port")]
     pub cl_rpc: u16,
-    /// Optional execution-layer JSON-RPC port. When `None`, EL data is not
-    /// polled for discovered peers and shows as `—` in the UI.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    /// Execution-layer JSON-RPC port (default 8545). When `None`, EL data is
+    /// not polled for discovered peers and shows as `—` in the UI.
+    #[serde(default = "default_el_rpc_port", skip_serializing_if = "Option::is_none")]
     pub el_rpc: Option<u16>,
 }
 
@@ -125,7 +125,7 @@ impl Default for DiscoveryPorts {
         Self {
             conductor_rpc: default_conductor_rpc_port(),
             cl_rpc: default_cl_rpc_port(),
-            el_rpc: None,
+            el_rpc: default_el_rpc_port(),
         }
     }
 }
@@ -136,6 +136,10 @@ const fn default_conductor_rpc_port() -> u16 {
 
 const fn default_cl_rpc_port() -> u16 {
     7545
+}
+
+const fn default_el_rpc_port() -> Option<u16> {
+    Some(8545)
 }
 
 /// Origin of the conductor cluster node list used by the poller.
@@ -304,6 +308,29 @@ impl MonitoringConfig {
             "sepolia" => Some("https://sepolia.etherscan.io"),
             _ => None,
         }
+    }
+
+    /// Returns the basectl display name for a known Base chain ID.
+    ///
+    /// Maps 8453/84532/763360 to `"mainnet"`/`"sepolia"`/`"zeronet"` so the
+    /// network badge agrees with what `-c` accepts on the CLI.
+    pub const fn name_for_chain_id(chain_id: u64) -> Option<&'static str> {
+        match chain_id {
+            8453 => Some("mainnet"),
+            84532 => Some("sepolia"),
+            763360 => Some("zeronet"),
+            _ => None,
+        }
+    }
+
+    /// Detects the live network name by calling `eth_chainId` on the L2 RPC.
+    ///
+    /// Returns the basectl-style name (e.g. `"mainnet"`) for known Base chain
+    /// IDs, or `None` when the RPC is unreachable or the chain ID is unknown.
+    pub async fn detect_name_from_rpc(rpc: &Url) -> Option<String> {
+        let provider = ProviderBuilder::new().connect(rpc.as_str()).await.ok()?;
+        let chain_id = provider.get_chain_id().await.ok()?;
+        Self::name_for_chain_id(chain_id).map(str::to_owned)
     }
 }
 

--- a/crates/infra/basectl/src/config.rs
+++ b/crates/infra/basectl/src/config.rs
@@ -362,7 +362,10 @@ impl MonitoringConfig {
             batcher_address: Some("0x5050F69a9786F081509234F1a7F4684b5E5b76C9".parse().unwrap()),
             l1_blob_target: 14,
             conductors: None,
-            discovery: Some(DiscoveryConfig { bootstrap_rpc: None, ports: DiscoveryPorts::default() }),
+            discovery: Some(DiscoveryConfig {
+                bootstrap_rpc: None,
+                ports: DiscoveryPorts::default(),
+            }),
             validators: None,
             proofs: None,
         }
@@ -381,7 +384,10 @@ impl MonitoringConfig {
             batcher_address: Some("0xfc56E7272EEBBBA5bC6c544e159483C4a38f8bA3".parse().unwrap()),
             l1_blob_target: 14,
             conductors: None,
-            discovery: Some(DiscoveryConfig { bootstrap_rpc: None, ports: DiscoveryPorts::default() }),
+            discovery: Some(DiscoveryConfig {
+                bootstrap_rpc: None,
+                ports: DiscoveryPorts::default(),
+            }),
             validators: None,
             proofs: None,
         }

--- a/crates/infra/basectl/src/lib.rs
+++ b/crates/infra/basectl/src/lib.rs
@@ -4,8 +4,8 @@ mod app;
 pub use app::{
     Action, ActionMenuItem, App, CommandCenterView, ConductorState, ConductorView, ConfigView,
     ConfirmButton, DaMonitorView, DaState, FlashState, FlashblocksView, HomeView, Overlay,
-    PendingAction, ProofsState, ProofsView, Resources, Router, TransactionPane, UpgradesView,
-    ValidatorState, View, ViewId, create_view, run_app, run_flashblocks_json,
+    PendingAction, ProofsState, ProofsView, Resources, Router, SourceLabel, TransactionPane,
+    UpgradesView, ValidatorState, View, ViewId, create_view, run_app, run_flashblocks_json,
     start_background_services,
 };
 
@@ -22,7 +22,10 @@ pub use commands::{
 };
 
 mod config;
-pub use config::{ConductorNodeConfig, MonitoringConfig, ProofsConfig, ValidatorNodeConfig};
+pub use config::{
+    ConductorNodeConfig, ConductorSource, DiscoveryConfig, DiscoveryPorts, MonitoringConfig,
+    ProofsConfig, ValidatorNodeConfig, synthesize_nodes,
+};
 
 mod l1_client;
 pub use l1_client::fetch_full_system_config;
@@ -30,14 +33,14 @@ pub use l1_client::fetch_full_system_config;
 mod rpc;
 pub use rpc::{
     BacklogBlock, BacklogFetchResult, BacklogProgress, BlockDaInfo, ConductorNodeStatus,
-    InitialBacklog, L1BlockInfo, L1ConnectionMode, LatestProposal, PausedPeers, ProofsSnapshot,
-    TimestampedFlashblock, TxSummary, ValidatorNodeStatus, conductor_pause_node,
-    conductor_resume_node, decode_flashblock_transactions, fetch_block_transactions,
-    fetch_initial_backlog_with_progress, fetch_safe_and_latest, pause_sequencer_node,
-    restart_conductor_node, run_block_fetcher, run_conductor_poller, run_flashblock_ws,
-    run_flashblock_ws_timestamped, run_l1_blob_watcher, run_proofs_poller, run_safe_head_poller,
-    run_validator_poller, start_sequencer_node, stop_sequencer_node, transfer_conductor_leader,
-    unpause_sequencer_node,
+    ConductorPollUpdate, InitialBacklog, L1BlockInfo, L1ConnectionMode, LatestProposal,
+    PausedPeers, ProofsSnapshot, TimestampedFlashblock, TxSummary, ValidatorNodeStatus,
+    conductor_pause_node, conductor_resume_node, decode_flashblock_transactions,
+    fetch_block_transactions, fetch_initial_backlog_with_progress, fetch_safe_and_latest,
+    pause_sequencer_node, restart_conductor_node, run_block_fetcher, run_conductor_poller,
+    run_flashblock_ws, run_flashblock_ws_timestamped, run_l1_blob_watcher, run_proofs_poller,
+    run_safe_head_poller, run_validator_poller, start_sequencer_node, stop_sequencer_node,
+    transfer_conductor_leader, unpause_sequencer_node,
 };
 
 mod tui;

--- a/crates/infra/basectl/src/lib.rs
+++ b/crates/infra/basectl/src/lib.rs
@@ -5,8 +5,8 @@ pub use app::{
     Action, ActionMenuItem, App, CommandCenterView, ConductorState, ConductorView, ConfigView,
     ConfirmButton, DaMonitorView, DaState, FlashState, FlashblocksView, HomeView, Overlay,
     PendingAction, ProofsState, ProofsView, Resources, Router, SourceLabel, TransactionPane,
-    UpgradesView, ValidatorState, View, ViewId, create_view, run_app, run_flashblocks_json,
-    start_background_services,
+    UpgradesView, ValidatorState, View, ViewId, create_view, detect_rpc_for, run_app,
+    run_flashblocks_json, start_background_services,
 };
 
 mod commands;

--- a/crates/infra/basectl/src/lib.rs
+++ b/crates/infra/basectl/src/lib.rs
@@ -24,7 +24,7 @@ pub use commands::{
 mod config;
 pub use config::{
     ConductorNodeConfig, ConductorSource, DiscoveryConfig, DiscoveryPorts, MonitoringConfig,
-    ProofsConfig, ValidatorNodeConfig, synthesize_nodes,
+    ProofsConfig, ValidatorNodeConfig,
 };
 
 mod l1_client;

--- a/crates/infra/basectl/src/lib.rs
+++ b/crates/infra/basectl/src/lib.rs
@@ -5,8 +5,8 @@ pub use app::{
     Action, ActionMenuItem, App, CommandCenterView, ConductorState, ConductorView, ConfigView,
     ConfirmButton, DaMonitorView, DaState, FlashState, FlashblocksView, HomeView, Overlay,
     PendingAction, ProofsState, ProofsView, Resources, Router, SourceLabel, TransactionPane,
-    UpgradesView, ValidatorState, View, ViewId, create_view, detect_rpc_for, run_app,
-    run_flashblocks_json, start_background_services,
+    UpgradesView, ValidatorState, View, ViewId, create_view, run_app, run_flashblocks_json,
+    start_background_services,
 };
 
 mod commands;

--- a/crates/infra/basectl/src/rpc.rs
+++ b/crates/infra/basectl/src/rpc.rs
@@ -11,7 +11,8 @@ use base_common_consensus::BaseTxEnvelope;
 use base_common_flashblocks::Flashblock;
 use base_common_network::Base;
 use base_consensus_rpc::{
-    AdminApiClient, BaseP2PApiClient, ConductorApiClient, RollupNodeApiClient,
+    AdminApiClient, BaseP2PApiClient, ClusterMembership, ConductorApiClient, RollupNodeApiClient,
+    ServerSuffrage,
 };
 use futures::{StreamExt, stream};
 use jsonrpsee::{core::client::ClientT, http_client::HttpClientBuilder, rpc_params};
@@ -21,7 +22,7 @@ use tracing::warn;
 use url::Url;
 
 use crate::{
-    config::{ConductorNodeConfig, ProofsConfig, ValidatorNodeConfig},
+    config::{ConductorNodeConfig, ConductorSource, ProofsConfig, ValidatorNodeConfig},
     tui::Toast,
 };
 
@@ -731,6 +732,17 @@ pub struct ConductorNodeStatus {
     pub el_syncing: Option<bool>,
     /// Number of connected EL devp2p peers from `net_peerCount`. `None` if not configured.
     pub el_peer_count: Option<u32>,
+
+    // ── Cluster membership ───────────────────────────────────────────────
+    /// Raft suffrage (Voter/Nonvoter) reported for this node by the most recent
+    /// `conductor_clusterMembership` snapshot, looked up by `server_id`. `None`
+    /// when membership has not yet been observed or this node is not present.
+    pub suffrage: Option<ServerSuffrage>,
+    /// Whether this node was synthesised from `conductor_clusterMembership`
+    /// (i.e. the active source is `Discover`). Used by the UI to gate actions
+    /// like "Restart containers" that only make sense when basectl runs on the
+    /// same host as the docker daemon.
+    pub discovered: bool,
 }
 
 /// Finds the current Raft leader and transfers leadership.
@@ -1096,32 +1108,44 @@ pub async fn unpause_sequencer_node(
     let _ = result_tx.send(outcome.map_err(|e| e.to_string())).await;
 }
 
-/// Polls all conductor nodes every 200 ms and forwards status snapshots.
-///
-/// Builds one pair of HTTP clients per node (conductor RPC + CL RPC) before
-/// entering the loop so connection setup cost is paid only once. Each poll
-/// fires all per-node requests concurrently via [`futures::future::join_all`].
-/// Any individual RPC that times out or errors yields `None` for that field —
-/// the node is shown as offline when `is_leader` is `None`.
-pub async fn run_conductor_poller(
-    nodes: Vec<ConductorNodeConfig>,
-    tx: mpsc::Sender<Vec<ConductorNodeStatus>>,
-) {
-    const POLL_INTERVAL: Duration = Duration::from_millis(200);
-    const RPC_TIMEOUT: Duration = Duration::from_millis(500);
+/// Updates emitted by [`run_conductor_poller`] on every poll cycle.
+#[derive(Debug, Clone)]
+pub enum ConductorPollUpdate {
+    /// Latest per-node status snapshot.
+    Status(Vec<ConductorNodeStatus>),
+    /// Raft cluster membership reported by one of the polled nodes. Emitted
+    /// only when the membership `version` advances.
+    Membership(ClusterMembership),
+    /// New peer list synthesised from a `Discover` source after a membership
+    /// change. Subscribers may use this to update displayed config (e.g.
+    /// flashblocks URL routing) without restarting the poller.
+    NodeListRefreshed(Vec<ConductorNodeConfig>),
+}
 
-    let clients: Vec<(String, _, _, _)> = nodes
-        .into_iter()
+type ConductorClientTuple = (
+    String,
+    String,
+    jsonrpsee::http_client::HttpClient,
+    jsonrpsee::http_client::HttpClient,
+    Option<jsonrpsee::http_client::HttpClient>,
+);
+
+fn build_conductor_clients(
+    nodes: &[ConductorNodeConfig],
+    timeout: Duration,
+) -> Vec<ConductorClientTuple> {
+    nodes
+        .iter()
         .filter_map(|node| {
             let conductor_client = HttpClientBuilder::default()
-                .request_timeout(RPC_TIMEOUT)
+                .request_timeout(timeout)
                 .build(node.conductor_rpc.as_str())
                 .inspect_err(|e| {
                     warn!(error = %e, node = %node.name, "failed to build conductor HTTP client");
                 })
                 .ok()?;
             let cl_client = HttpClientBuilder::default()
-                .request_timeout(RPC_TIMEOUT)
+                .request_timeout(timeout)
                 .build(node.cl_rpc.as_str())
                 .inspect_err(|e| {
                     warn!(error = %e, node = %node.name, "failed to build CL HTTP client");
@@ -1129,16 +1153,46 @@ pub async fn run_conductor_poller(
                 .ok()?;
             let el_client = node.el_rpc.as_ref().and_then(|url| {
                 HttpClientBuilder::default()
-                    .request_timeout(RPC_TIMEOUT)
+                    .request_timeout(timeout)
                     .build(url.as_str())
                     .inspect_err(|e| {
                         warn!(error = %e, node = %node.name, "failed to build EL HTTP client");
                     })
                     .ok()
             });
-            Some((node.name, conductor_client, cl_client, el_client))
+            Some((node.name.clone(), node.server_id.clone(), conductor_client, cl_client, el_client))
         })
-        .collect();
+        .collect()
+}
+
+/// Polls every conductor in the active source every 200 ms and forwards updates.
+///
+/// Builds one pair of HTTP clients per node (conductor RPC + CL RPC) so connection
+/// setup cost is paid only once per node lifetime. Each poll fires all per-node
+/// requests concurrently via [`futures::future::join_all`]; any individual RPC that
+/// times out or errors yields `None` for that field — the node is shown as offline
+/// when `is_leader` is `None`.
+///
+/// On every tick the poller also calls `conductor_clusterMembership` on one node
+/// (round-robin) and, when the membership version advances, emits a `Membership`
+/// update. For `Discover` sources, the synthesised peer list is rebuilt from the
+/// new membership and the per-node clients are recreated in place.
+pub async fn run_conductor_poller(
+    source: ConductorSource,
+    tx: mpsc::Sender<ConductorPollUpdate>,
+) {
+    const POLL_INTERVAL: Duration = Duration::from_millis(200);
+    const RPC_TIMEOUT: Duration = Duration::from_millis(500);
+
+    let discovered = source.is_discover();
+
+    let mut current_nodes: Vec<ConductorNodeConfig> = match &source {
+        ConductorSource::Static(nodes) => nodes.clone(),
+        ConductorSource::Discover { .. } => source.bootstrap_node().into_iter().collect(),
+    };
+    let mut clients = build_conductor_clients(&current_nodes, RPC_TIMEOUT);
+    let mut last_membership: Option<ClusterMembership> = None;
+    let mut membership_round_robin: usize = 0;
 
     let mut interval = tokio::time::interval(POLL_INTERVAL);
     interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
@@ -1146,8 +1200,23 @@ pub async fn run_conductor_poller(
     loop {
         interval.tick().await;
 
-        let statuses = futures::future::join_all(clients.iter().map(
-            |(name, conductor_client, cl_client, el_client)| async move {
+        let membership_target = if clients.is_empty() {
+            None
+        } else {
+            let idx = membership_round_robin % clients.len();
+            membership_round_robin = membership_round_robin.wrapping_add(1);
+            Some(idx)
+        };
+
+        let membership_fut = async {
+            let idx = membership_target?;
+            let (_, _, conductor_client, _, _) = &clients[idx];
+            ConductorApiClient::conductor_cluster_membership(conductor_client).await.ok()
+        };
+
+        let membership_for_lookup = last_membership.as_ref();
+        let statuses_fut = futures::future::join_all(clients.iter().map(
+            |(name, server_id, conductor_client, cl_client, el_client)| async move {
                 // Fire all RPCs concurrently so a single timed-out node does not
                 // stall the poll for the full sum of all call timeouts (11 × 500 ms).
                 let (
@@ -1201,6 +1270,9 @@ pub async fn run_conductor_poller(
                 );
 
                 let sync = sync.ok();
+                let suffrage = membership_for_lookup
+                    .and_then(|m| m.servers.iter().find(|s| s.id == *server_id))
+                    .map(|s| s.suffrage);
                 ConductorNodeStatus {
                     name: name.clone(),
                     is_leader: is_leader.ok(),
@@ -1220,12 +1292,44 @@ pub async fn run_conductor_poller(
                     el_block: el_block_r,
                     el_syncing: el_syncing_r,
                     el_peer_count: el_peers_r,
+                    suffrage,
+                    discovered,
                 }
             },
-        ))
-        .await;
+        ));
 
-        if tx.send(statuses).await.is_err() {
+        let (statuses, new_membership) = tokio::join!(statuses_fut, membership_fut);
+
+        if let Some(membership) = new_membership {
+            let changed = last_membership
+                .as_ref()
+                .is_none_or(|prev| prev.version != membership.version);
+            if changed {
+                last_membership = Some(membership.clone());
+                if tx.send(ConductorPollUpdate::Membership(membership.clone())).await.is_err() {
+                    break;
+                }
+                if let ConductorSource::Discover { bootstrap, ports } = &source {
+                    let synthesized = crate::config::synthesize_nodes(bootstrap, ports, &membership);
+                    let server_ids_changed = synthesized.iter().map(|n| &n.server_id).ne(
+                        current_nodes.iter().map(|n| &n.server_id),
+                    );
+                    if server_ids_changed && !synthesized.is_empty() {
+                        current_nodes = synthesized.clone();
+                        clients = build_conductor_clients(&current_nodes, RPC_TIMEOUT);
+                        if tx
+                            .send(ConductorPollUpdate::NodeListRefreshed(synthesized))
+                            .await
+                            .is_err()
+                        {
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+
+        if tx.send(ConductorPollUpdate::Status(statuses)).await.is_err() {
             break;
         }
     }

--- a/crates/infra/basectl/src/rpc.rs
+++ b/crates/infra/basectl/src/rpc.rs
@@ -1311,9 +1311,7 @@ pub async fn run_conductor_poller(source: ConductorSource, tx: mpsc::Sender<Cond
                 if tx.send(ConductorPollUpdate::Membership(membership.clone())).await.is_err() {
                     break;
                 }
-                if let ConductorSource::Discover { bootstrap, ports } = &source {
-                    let synthesized =
-                        crate::config::synthesize_nodes(bootstrap, ports, &membership);
+                if let Some(synthesized) = source.synthesize_nodes(&membership) {
                     let server_ids_changed = synthesized
                         .iter()
                         .map(|n| &n.server_id)

--- a/crates/infra/basectl/src/rpc.rs
+++ b/crates/infra/basectl/src/rpc.rs
@@ -1160,7 +1160,13 @@ fn build_conductor_clients(
                     })
                     .ok()
             });
-            Some((node.name.clone(), node.server_id.clone(), conductor_client, cl_client, el_client))
+            Some((
+                node.name.clone(),
+                node.server_id.clone(),
+                conductor_client,
+                cl_client,
+                el_client,
+            ))
         })
         .collect()
 }
@@ -1177,10 +1183,7 @@ fn build_conductor_clients(
 /// (round-robin) and, when the membership version advances, emits a `Membership`
 /// update. For `Discover` sources, the synthesised peer list is rebuilt from the
 /// new membership and the per-node clients are recreated in place.
-pub async fn run_conductor_poller(
-    source: ConductorSource,
-    tx: mpsc::Sender<ConductorPollUpdate>,
-) {
+pub async fn run_conductor_poller(source: ConductorSource, tx: mpsc::Sender<ConductorPollUpdate>) {
     const POLL_INTERVAL: Duration = Duration::from_millis(200);
     const RPC_TIMEOUT: Duration = Duration::from_millis(500);
 
@@ -1301,19 +1304,20 @@ pub async fn run_conductor_poller(
         let (statuses, new_membership) = tokio::join!(statuses_fut, membership_fut);
 
         if let Some(membership) = new_membership {
-            let changed = last_membership
-                .as_ref()
-                .is_none_or(|prev| prev.version != membership.version);
+            let changed =
+                last_membership.as_ref().is_none_or(|prev| prev.version != membership.version);
             if changed {
                 last_membership = Some(membership.clone());
                 if tx.send(ConductorPollUpdate::Membership(membership.clone())).await.is_err() {
                     break;
                 }
                 if let ConductorSource::Discover { bootstrap, ports } = &source {
-                    let synthesized = crate::config::synthesize_nodes(bootstrap, ports, &membership);
-                    let server_ids_changed = synthesized.iter().map(|n| &n.server_id).ne(
-                        current_nodes.iter().map(|n| &n.server_id),
-                    );
+                    let synthesized =
+                        crate::config::synthesize_nodes(bootstrap, ports, &membership);
+                    let server_ids_changed = synthesized
+                        .iter()
+                        .map(|n| &n.server_id)
+                        .ne(current_nodes.iter().map(|n| &n.server_id));
                     if server_ids_changed && !synthesized.is_empty() {
                         current_nodes = synthesized.clone();
                         clients = build_conductor_clients(&current_nodes, RPC_TIMEOUT);

--- a/crates/infra/basectl/src/rpc.rs
+++ b/crates/infra/basectl/src/rpc.rs
@@ -1,4 +1,4 @@
-use std::{sync::Arc, time::Duration};
+use std::{collections::BTreeSet, sync::Arc, time::Duration};
 
 use alloy_consensus::{Transaction, transaction::SignerRecoverable};
 use alloy_eips::eip2718::{Decodable2718, Encodable2718};
@@ -1303,20 +1303,23 @@ pub async fn run_conductor_poller(source: ConductorSource, tx: mpsc::Sender<Cond
 
         let (statuses, new_membership) = tokio::join!(statuses_fut, membership_fut);
 
+        // Send Status first so the UI flushes the statuses keyed to the
+        // current node set before we potentially swap that set out below.
+        if tx.send(ConductorPollUpdate::Status(statuses)).await.is_err() {
+            break;
+        }
+
         if let Some(membership) = new_membership {
             let changed =
                 last_membership.as_ref().is_none_or(|prev| prev.version != membership.version);
             if changed {
-                last_membership = Some(membership.clone());
                 if tx.send(ConductorPollUpdate::Membership(membership.clone())).await.is_err() {
                     break;
                 }
                 if let Some(synthesized) = source.synthesize_nodes(&membership) {
-                    let server_ids_changed = synthesized
-                        .iter()
-                        .map(|n| &n.server_id)
-                        .ne(current_nodes.iter().map(|n| &n.server_id));
-                    if server_ids_changed && !synthesized.is_empty() {
+                    let old_ids: BTreeSet<_> = current_nodes.iter().map(|n| &n.server_id).collect();
+                    let new_ids: BTreeSet<_> = synthesized.iter().map(|n| &n.server_id).collect();
+                    if old_ids != new_ids && !synthesized.is_empty() {
                         current_nodes = synthesized.clone();
                         clients = build_conductor_clients(&current_nodes, RPC_TIMEOUT);
                         if tx
@@ -1328,11 +1331,8 @@ pub async fn run_conductor_poller(source: ConductorSource, tx: mpsc::Sender<Cond
                         }
                     }
                 }
+                last_membership = Some(membership);
             }
-        }
-
-        if tx.send(ConductorPollUpdate::Status(statuses)).await.is_err() {
-            break;
         }
     }
 }

--- a/crates/infra/basectl/src/rpc.rs
+++ b/crates/infra/basectl/src/rpc.rs
@@ -1114,8 +1114,10 @@ pub enum ConductorPollUpdate {
     /// Latest per-node status snapshot.
     Status(Vec<ConductorNodeStatus>),
     /// Raft cluster membership reported by one of the polled nodes. Emitted
-    /// only when the membership `version` advances.
-    Membership(ClusterMembership),
+    /// only when the membership `version` advances. Wrapped in `Arc` so the
+    /// poller and the UI state share the snapshot without deep-copying the
+    /// server list on every change.
+    Membership(Arc<ClusterMembership>),
     /// New peer list synthesised from a `Discover` source after a membership
     /// change. Subscribers may use this to update displayed config (e.g.
     /// flashblocks URL routing) without restarting the poller.
@@ -1194,7 +1196,7 @@ pub async fn run_conductor_poller(source: ConductorSource, tx: mpsc::Sender<Cond
         ConductorSource::Discover { .. } => source.bootstrap_node().into_iter().collect(),
     };
     let mut clients = build_conductor_clients(&current_nodes, RPC_TIMEOUT);
-    let mut last_membership: Option<ClusterMembership> = None;
+    let mut last_membership: Option<Arc<ClusterMembership>> = None;
     let mut membership_round_robin: usize = 0;
 
     let mut interval = tokio::time::interval(POLL_INTERVAL);
@@ -1313,7 +1315,9 @@ pub async fn run_conductor_poller(source: ConductorSource, tx: mpsc::Sender<Cond
             let changed =
                 last_membership.as_ref().is_none_or(|prev| prev.version != membership.version);
             if changed {
-                if tx.send(ConductorPollUpdate::Membership(membership.clone())).await.is_err() {
+                let membership = Arc::new(membership);
+                if tx.send(ConductorPollUpdate::Membership(Arc::clone(&membership))).await.is_err()
+                {
                     break;
                 }
                 if let Some(synthesized) = source.synthesize_nodes(&membership) {


### PR DESCRIPTION
Adds a --conductor-rpc bootstrap flag and DiscoveryConfig so basectl can derive the live raft peer list from a single conductor by polling clusterMembership and applying port templates, rebuilding clients in place when membership changes. Discovered peers are tagged so the Restart action stays disabled where a remote docker daemon would not be reachable.