### PR TITLE
feat(load-test): add real-token setup for swap load tests

### DIFF
--- a/bin/load-tester/src/cli.rs
+++ b/bin/load-tester/src/cli.rs
@@ -72,6 +72,11 @@ impl Cli {
 
 /// Load test command arguments.
 #[derive(Args, Clone, Debug)]
+#[command(group(
+    ArgGroup::new("load_mode")
+        .multiple(false)
+        .args(["drain_only", "recover_real_tokens"])
+))]
 struct LoadArgs {
     /// Run continuously until interrupted.
     #[arg(long)]
@@ -90,6 +95,25 @@ struct LoadArgs {
     config: PathBuf,
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum LoadMode {
+    Run,
+    DrainOnly,
+    RecoverRealTokens,
+}
+
+impl LoadMode {
+    const fn from_args(args: &LoadArgs) -> Self {
+        if args.drain_only {
+            Self::DrainOnly
+        } else if args.recover_real_tokens {
+            Self::RecoverRealTokens
+        } else {
+            Self::Run
+        }
+    }
+}
+
 /// Load tester subcommands.
 #[derive(Subcommand, Clone, Debug)]
 enum Command {
@@ -99,6 +123,7 @@ enum Command {
 
 async fn run_load_test(args: LoadArgs) -> Result<()> {
     let mp = LoadTestDisplay::init_tracing();
+    let mode = LoadMode::from_args(&args);
     let config_path = args.config;
 
     if !config_path.exists() {
@@ -125,51 +150,51 @@ async fn run_load_test(args: LoadArgs) -> Result<()> {
 
     let funding_key = TestConfig::funder_key()?;
 
-    if args.drain_only && args.recover_real_tokens {
-        bail!("--drain-only and --recover-real-tokens cannot be used together");
-    }
-
-    // Drain-only mode: recover funds from a previous interrupted run.
-    if args.drain_only {
-        println!("=== Drain-Only Mode ===");
-        println!(
-            "Re-deriving {} accounts from config and draining to funder...",
-            load_config.account_count
-        );
-        let runner = LoadRunner::new(load_config)?;
-        match runner.drain_accounts(funding_key).await {
-            Ok(drained) => println!("Drained {} ETH back to funder.", format_ether(drained)),
-            Err(e) => bail!("drain failed: {e}"),
-        }
-        return Ok(());
-    }
-
-    if args.recover_real_tokens {
-        let Some(real_token_setup) = real_token_setup.as_ref() else {
-            bail!("--recover-real-tokens requires real_token_setup in {}", config_path.display());
-        };
-
-        println!("=== Real-Token Recovery Mode ===");
-        println!(
-            "Re-deriving {} accounts from config and recovering real-token balances to funder...",
-            load_config.account_count
-        );
-        let runner = LoadRunner::new(load_config)?;
-        match runner.recover_real_tokens(real_token_setup).await {
-            Ok(summary) => {
-                println!(
-                    "Recovered {} pair-token raw units and unwrapped {} WETH.",
-                    summary.pair_token_swapped,
-                    format_ether(summary.weth_unwrapped)
-                );
+    match mode {
+        LoadMode::DrainOnly => {
+            println!("=== Drain-Only Mode ===");
+            println!(
+                "Re-deriving {} accounts from config and draining to funder...",
+                load_config.account_count
+            );
+            let runner = LoadRunner::new(load_config)?;
+            match runner.drain_accounts(funding_key).await {
+                Ok(drained) => println!("Drained {} ETH back to funder.", format_ether(drained)),
+                Err(e) => bail!("drain failed: {e}"),
             }
-            Err(e) => bail!("real-token recovery failed: {e}"),
+            return Ok(());
         }
-        match runner.drain_accounts(funding_key).await {
-            Ok(drained) => println!("Drained {} ETH back to funder.", format_ether(drained)),
-            Err(e) => bail!("drain failed: {e}"),
+        LoadMode::RecoverRealTokens => {
+            let Some(real_token_setup) = real_token_setup.as_ref() else {
+                bail!(
+                    "--recover-real-tokens requires real_token_setup in {}",
+                    config_path.display()
+                );
+            };
+
+            println!("=== Real-Token Recovery Mode ===");
+            println!(
+                "Re-deriving {} accounts from config and recovering real-token balances to funder...",
+                load_config.account_count
+            );
+            let runner = LoadRunner::new(load_config)?;
+            match runner.recover_real_tokens(real_token_setup).await {
+                Ok(summary) => {
+                    println!(
+                        "Recovered {} pair-token raw units and unwrapped {} WETH.",
+                        summary.pair_token_swapped,
+                        format_ether(summary.weth_unwrapped)
+                    );
+                }
+                Err(e) => bail!("real-token recovery failed: {e}"),
+            }
+            match runner.drain_accounts(funding_key).await {
+                Ok(drained) => println!("Drained {} ETH back to funder.", format_ether(drained)),
+                Err(e) => bail!("drain failed: {e}"),
+            }
+            return Ok(());
         }
-        return Ok(());
+        LoadMode::Run => {}
     }
 
     println!("=== Base Load Test Runner ===");

--- a/bin/load-tester/src/cli.rs
+++ b/bin/load-tester/src/cli.rs
@@ -81,6 +81,10 @@ struct LoadArgs {
     #[arg(long)]
     drain_only: bool,
 
+    /// Recover real-token WETH/pair-token balances, then drain native ETH.
+    #[arg(long)]
+    recover_real_tokens: bool,
+
     /// Load test YAML configuration.
     #[arg(value_name = "CONFIG")]
     config: PathBuf,
@@ -121,6 +125,10 @@ async fn run_load_test(args: LoadArgs) -> Result<()> {
 
     let funding_key = TestConfig::funder_key()?;
 
+    if args.drain_only && args.recover_real_tokens {
+        bail!("--drain-only and --recover-real-tokens cannot be used together");
+    }
+
     // Drain-only mode: recover funds from a previous interrupted run.
     if args.drain_only {
         println!("=== Drain-Only Mode ===");
@@ -129,6 +137,34 @@ async fn run_load_test(args: LoadArgs) -> Result<()> {
             load_config.account_count
         );
         let runner = LoadRunner::new(load_config)?;
+        match runner.drain_accounts(funding_key).await {
+            Ok(drained) => println!("Drained {} ETH back to funder.", format_ether(drained)),
+            Err(e) => bail!("drain failed: {e}"),
+        }
+        return Ok(());
+    }
+
+    if args.recover_real_tokens {
+        let Some(real_token_setup) = real_token_setup.as_ref() else {
+            bail!("--recover-real-tokens requires real_token_setup in {}", config_path.display());
+        };
+
+        println!("=== Real-Token Recovery Mode ===");
+        println!(
+            "Re-deriving {} accounts from config and recovering real-token balances to funder...",
+            load_config.account_count
+        );
+        let runner = LoadRunner::new(load_config)?;
+        match runner.recover_real_tokens(real_token_setup).await {
+            Ok(summary) => {
+                println!(
+                    "Recovered {} pair-token raw units and unwrapped {} WETH.",
+                    summary.pair_token_swapped,
+                    format_ether(summary.weth_unwrapped)
+                );
+            }
+            Err(e) => bail!("real-token recovery failed: {e}"),
+        }
         match runner.drain_accounts(funding_key).await {
             Ok(drained) => println!("Drained {} ETH back to funder.", format_ether(drained)),
             Err(e) => bail!("drain failed: {e}"),

--- a/bin/load-tester/src/cli.rs
+++ b/bin/load-tester/src/cli.rs
@@ -17,7 +17,7 @@ use alloy_signer_local::PrivateKeySigner;
 use base_cli_utils::RuntimeManager;
 use base_load_tests::{
     AccountPool, BaselineError, FundedAccount, LoadRunner, LoadTestDisplay, MetricsSummary,
-    QueryProvider, Result as LoadResult, RpcProviders, RpcResultExt, TestConfig,
+    QueryProvider, RealTokenSetup, Result as LoadResult, RpcProviders, RpcResultExt, TestConfig,
     create_wallet_provider,
 };
 use clap::{ArgGroup, Args, Parser, Subcommand};
@@ -162,6 +162,7 @@ async fn run_load_test(args: LoadArgs) -> Result<()> {
     let funding_amount = test_config.parse_funding_amount()?;
     let swap_token_amount = test_config.parse_swap_token_amount()?;
     let b20_mint_amount = test_config.parse_b20_mint_amount()?;
+    let real_token_setup = test_config.parse_real_token_setup(load_config.chain_id)?;
 
     let config_summary = test_config.to_summary();
     let mut runner = LoadRunner::new(load_config.clone())?;
@@ -178,6 +179,7 @@ async fn run_load_test(args: LoadArgs) -> Result<()> {
         funding_amount,
         swap_token_amount,
         b20_mint_amount,
+        real_token_setup.as_ref(),
         &mp,
         load_config.duration,
     )
@@ -301,6 +303,7 @@ async fn run_test_phases(
     funding_amount: U256,
     swap_token_amount: U256,
     b20_mint_amount: U256,
+    real_token_setup: Option<&RealTokenSetup>,
     mp: &indicatif::MultiProgress,
     duration: Option<Duration>,
 ) -> LoadResult<MetricsSummary> {
@@ -314,7 +317,11 @@ async fn run_test_phases(
     runner.fund_accounts(funding_key.clone(), funding_amount).await?;
     println!("Accounts funded.");
 
-    if !runner.collect_swap_tokens().is_empty() {
+    if let Some(setup) = real_token_setup {
+        println!("Preparing real-token swap balances...");
+        runner.setup_real_tokens(setup).await?;
+        println!("Real-token swap balances prepared.");
+    } else if !runner.collect_swap_tokens().is_empty() {
         println!("Distributing swap tokens...");
         runner.setup_swap_tokens(funding_key.clone(), swap_token_amount).await?;
         println!("Swap tokens distributed.");

--- a/bin/load-tester/src/cli.rs
+++ b/bin/load-tester/src/cli.rs
@@ -165,6 +165,7 @@ async fn run_load_test(args: LoadArgs) -> Result<()> {
             return Ok(());
         }
         LoadMode::RecoverRealTokens => {
+            let real_token_setup = test_config.parse_real_token_setup(load_config.chain_id)?;
             let Some(real_token_setup) = real_token_setup.as_ref() else {
                 bail!(
                     "--recover-real-tokens requires real_token_setup in {}",
@@ -196,6 +197,8 @@ async fn run_load_test(args: LoadArgs) -> Result<()> {
         }
         LoadMode::Run => {}
     }
+
+    let real_token_setup = test_config.parse_real_token_setup(load_config.chain_id)?;
 
     println!("=== Base Load Test Runner ===");
 

--- a/bin/load-tester/src/cli.rs
+++ b/bin/load-tester/src/cli.rs
@@ -198,8 +198,6 @@ async fn run_load_test(args: LoadArgs) -> Result<()> {
         LoadMode::Run => {}
     }
 
-    let real_token_setup = test_config.parse_real_token_setup(load_config.chain_id)?;
-
     println!("=== Base Load Test Runner ===");
 
     println!("Set RPCs to internal endpoints to avoid rate limiting");
@@ -240,9 +238,11 @@ async fn run_load_test(args: LoadArgs) -> Result<()> {
     let run_result = run_test_phases(
         &mut runner,
         &funding_key,
-        funding_amount,
-        swap_token_amount,
-        b20_mint_amount,
+        SetupAmounts {
+            funding: funding_amount,
+            swap_token: swap_token_amount,
+            b20_mint: b20_mint_amount,
+        },
         real_token_setup.as_ref(),
         &mp,
         load_config.duration,
@@ -360,13 +360,17 @@ async fn run_load_test(args: LoadArgs) -> Result<()> {
     Ok(())
 }
 
+struct SetupAmounts {
+    funding: U256,
+    swap_token: U256,
+    b20_mint: U256,
+}
+
 /// Runs funding, token setup, and the load test loop, returning the metrics summary.
 async fn run_test_phases(
     runner: &mut LoadRunner,
     funding_key: &PrivateKeySigner,
-    funding_amount: U256,
-    swap_token_amount: U256,
-    b20_mint_amount: U256,
+    amounts: SetupAmounts,
     real_token_setup: Option<&RealTokenSetup>,
     mp: &indicatif::MultiProgress,
     duration: Option<Duration>,
@@ -378,7 +382,7 @@ async fn run_test_phases(
     }
 
     println!("Funding test accounts...");
-    runner.fund_accounts(funding_key.clone(), funding_amount).await?;
+    runner.fund_accounts(funding_key.clone(), amounts.funding).await?;
     println!("Accounts funded.");
 
     if let Some(setup) = real_token_setup {
@@ -387,13 +391,13 @@ async fn run_test_phases(
         println!("Real-token swap balances prepared.");
     } else if !runner.collect_swap_tokens().is_empty() {
         println!("Distributing swap tokens...");
-        runner.setup_swap_tokens(funding_key.clone(), swap_token_amount).await?;
+        runner.setup_swap_tokens(funding_key.clone(), amounts.swap_token).await?;
         println!("Swap tokens distributed.");
     }
 
     if runner.needs_b20_setup() {
         println!("Setting up B-20 tokens...");
-        runner.setup_b20_tokens(funding_key.clone(), b20_mint_amount).await?;
+        runner.setup_b20_tokens(funding_key.clone(), amounts.b20_mint).await?;
         println!("B-20 tokens ready.");
     }
     println!();

--- a/crates/infra/load-tests/Justfile
+++ b/crates/infra/load-tests/Justfile
@@ -5,8 +5,11 @@
 #   just load-test run sepolia                           - Load test sepolia (requires FUNDER_KEY)
 #   just load-test continuous                            - Load test devnet indefinitely (Ctrl-C to stop)
 #   just load-test continuous sepolia                    - Load test sepolia indefinitely
+#   just load-test real-token                            - Real-token swap load test on devnet
+#   just load-test real-token sepolia                    - Real-token swap load test on sepolia
 #   just load-test recover                               - Recover funds from devnet test accounts
 #   just load-test recover sepolia                       - Recover funds from sepolia test accounts
+#   just load-test real-token-recover sepolia            - Recover real-token funds from sepolia test accounts
 
 set positional-arguments := true
 set working-directory := '../../..'
@@ -23,6 +26,63 @@ run network='devnet' *args:
     fi
     cargo run -p base-load-tester-bin --bin base-load-tester -- crates/infra/load-tests/examples/{{network}}.yaml {{args}}
 
+# Devnet deploys a local WETH/USDC harness and renders dynamic addresses.
+# Other networks use examples/real-token-<network>.yaml and expect contracts
+# to already be deployed.
+# Run real-token swap load test against a network.
+real-token network='devnet' *args:
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    if [ -z "${FUNDER_KEY:-}" ] && [ "{{network}}" = "devnet" ]; then
+        export FUNDER_KEY=0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d
+    fi
+
+    if [ "{{network}}" != "devnet" ]; then
+        config="crates/infra/load-tests/examples/real-token-{{network}}.yaml"
+        if [ ! -f "$config" ]; then
+            echo "real-token config not found: $config" >&2
+            exit 1
+        fi
+        cargo run -p base-load-tester-bin --bin base-load-tester -- "$config" {{args}}
+        exit 0
+    fi
+
+    contracts_dir="crates/utilities/test-utils/contracts"
+    template="crates/infra/load-tests/examples/real-token-devnet.yaml.template"
+    rendered_config="$(mktemp "${TMPDIR:-/tmp}/base-real-token-devnet.XXXXXX")"
+
+    echo "Installing Foundry dependencies..."
+    (cd "$contracts_dir" && forge soldeer install)
+
+    echo "Deploying real-token devnet swap harness..."
+    deploy_output="$(
+        cd "$contracts_dir"
+        forge script script/DeployRealTokenSwapDevnet.s.sol:DeployRealTokenSwapDevnet \
+            --rpc-url http://localhost:7545 \
+            --private-key "$FUNDER_KEY" \
+            --broadcast 2>&1
+    )"
+    printf '%s\n' "$deploy_output"
+
+    usdc="$(printf '%s\n' "$deploy_output" | awk '$1 == "USDC:" { print $2; exit }')"
+    uniswap_router="$(printf '%s\n' "$deploy_output" | awk '$1 == "Uniswap" && $2 == "router" && $3 == "shim:" { print $4; exit }')"
+    aerodrome_router="$(printf '%s\n' "$deploy_output" | awk '$1 == "Aerodrome" && $2 == "router" && $3 == "shim:" { print $4; exit }')"
+
+    if [ -z "$usdc" ] || [ -z "$uniswap_router" ] || [ -z "$aerodrome_router" ]; then
+        echo "failed to parse deployed harness addresses from forge output" >&2
+        exit 1
+    fi
+
+    sed \
+        -e "s|__USDC__|$usdc|g" \
+        -e "s|__UNISWAP_ROUTER__|$uniswap_router|g" \
+        -e "s|__AERODROME_ROUTER__|$aerodrome_router|g" \
+        "$template" > "$rendered_config"
+
+    echo "Running real-token devnet load test with rendered config: $rendered_config"
+    cargo run -p base-load-tester-bin --bin base-load-tester -- "$rendered_config" {{args}}
+
 # Run load test against a network indefinitely (Ctrl-C to stop)
 continuous network='devnet':
     just --justfile {{source_file()}} run {{network}} --continuous
@@ -30,3 +90,15 @@ continuous network='devnet':
 # Recover/drain funds from load test accounts back to funder
 recover network='devnet':
     just --justfile {{source_file()}} run {{network}} --drain-only
+
+# Recover real-token balances from load test accounts, then drain native ETH.
+real-token-recover network='sepolia':
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    config="crates/infra/load-tests/examples/real-token-{{network}}.yaml"
+    if [ ! -f "$config" ]; then
+        echo "real-token config not found: $config" >&2
+        exit 1
+    fi
+    cargo run -p base-load-tester-bin --bin base-load-tester -- "$config" --recover-real-tokens

--- a/crates/infra/load-tests/README.md
+++ b/crates/infra/load-tests/README.md
@@ -21,6 +21,15 @@ Load testing and benchmarking framework for Base infrastructure.
 # Run load test against local devnet (uses Anvil Account #1)
 just load-test run
 
+# Deploy the devnet WETH/USDC harness and run real-token swaps
+just load-test real-token
+
+# Run real-token swaps against a network with predeployed contracts
+FUNDER_KEY=0x... just load-test real-token sepolia
+
+# Swap real-token balances back to WETH, unwrap, and drain ETH
+FUNDER_KEY=0x... just load-test real-token-recover sepolia
+
 # Run load test against sepolia (requires funded key)
 FUNDER_KEY=0x... just load-test run sepolia
 ```
@@ -70,8 +79,10 @@ fetching `eth_getBlockReceipts` for each observed block, so `query_rpc` must sup
 | Config | Target | Notes |
 |--------|--------|-------|
 | `devnet.yaml` | Local devnet | Uses Anvil Account #1 |
+| `real-token-devnet.yaml.template` | Local devnet | Rendered by `just load-test real-token` after deploying the devnet WETH/USDC harness |
 | `sepolia.yaml` | Base Sepolia | Requires `FUNDER_KEY` |
-| `mainnet-state-weth-usdc-swaps.yaml` | Local/shadow Base mainnet state | Wraps funded ETH into WETH, acquires USDC, then runs random-direction Uniswap V3 and Aerodrome CL swaps |
+| `real-token-sepolia.yaml` | Base Sepolia | Uses predeployed WETH/USDC and the Uniswap V3 swap router; run with `just load-test real-token sepolia`; recover with `just load-test real-token-recover sepolia` |
+| `real-token-mainnet-snapshot.yaml` | Local/shadow Base mainnet snapshot | Wraps funded ETH into WETH, acquires USDC, then runs random-direction Uniswap V3 and Aerodrome CL swaps; run with `just load-test real-token mainnet-snapshot` |
 
 ### Contract Addresses
 
@@ -82,7 +93,6 @@ Contract addresses for swap testing and related tokens.
 | Contract | Address |
 |----------|---------|
 | Uniswap V3 Router | `0x94cC0AaC535CCDB3C01d6787D6413C739ae12bc4` |
-| Aerodrome CL `SwapRouter` | `0xD75e6a0C801F24ebb3125E360a5A064f6b9FEFaC` |
 | Load Test Token A (LTTA) | `0x15948C3043A980A8d980d4D615A5E4c9514B0D64` |
 | Load Test Token B (LTTB) | `0x4dc9ccF2C5A346c4032B648006B4774Ad2a021c4` |
 
@@ -96,9 +106,11 @@ Contract addresses for swap testing and related tokens.
 
 These tokens are deployed via `DeployTestTokenPair.s.sol` and use `FreeTransferERC20` which allows permissionless minting for load testing.
 
-#### Base Mainnet State (Chain ID: 8453)
+#### Base Mainnet Snapshot (Chain ID: 8453)
 
-The `mainnet-state-weth-usdc-swaps.yaml` example is for local or shadow-builder environments restored from Base mainnet state. Do not point it at public Base mainnet RPCs with a real key.
+The `real-token-mainnet-snapshot.yaml` example is for local or shadow-builder environments restored from a Base mainnet snapshot. Do not point it at public Base mainnet RPCs with a real key.
+
+The Sepolia real-token example is Uniswap-only. Aerodrome Slipstream's Sepolia router from `examples/sepolia.yaml` is deployed at `0xD75e6a0C801F24ebb3125E360a5A064f6b9FEFaC`, but its factory does not have a WETH/USDC pool, so adding an Aerodrome WETH/USDC leg will revert until that pool is deployed.
 
 | Contract | Address |
 |----------|---------|

--- a/crates/infra/load-tests/README.md
+++ b/crates/infra/load-tests/README.md
@@ -71,6 +71,7 @@ fetching `eth_getBlockReceipts` for each observed block, so `query_rpc` must sup
 |--------|--------|-------|
 | `devnet.yaml` | Local devnet | Uses Anvil Account #1 |
 | `sepolia.yaml` | Base Sepolia | Requires `FUNDER_KEY` |
+| `mainnet-state-weth-usdc-swaps.yaml` | Local/shadow Base mainnet state | Wraps funded ETH into WETH, acquires USDC, then runs random-direction Uniswap V3 and Aerodrome CL swaps |
 
 ### Contract Addresses
 
@@ -94,6 +95,17 @@ Contract addresses for swap testing and related tokens.
 | Load Test Token B (LTTB) | `0xc411b5f78fadab5880a287f21bb7997a192975f3` |
 
 These tokens are deployed via `DeployTestTokenPair.s.sol` and use `FreeTransferERC20` which allows permissionless minting for load testing.
+
+#### Base Mainnet State (Chain ID: 8453)
+
+The `mainnet-state-weth-usdc-swaps.yaml` example is for local or shadow-builder environments restored from Base mainnet state. Do not point it at public Base mainnet RPCs with a real key.
+
+| Contract | Address |
+|----------|---------|
+| WETH | `0x4200000000000000000000000000000000000006` |
+| USDC | `0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913` |
+| Uniswap V3 `SwapRouter02` | `0x2626664c2603336E57B271c5C0b26F421741e481` |
+| Aerodrome CL Router | `0xBE6D8f0d05cC4be24d5167a3eF062215bE6D18a5` |
 
 ### Environment Variables
 
@@ -165,3 +177,28 @@ transactions:
     type: b20
     contract: "0x..."
 ```
+
+#### Swap Testing
+
+Swap payloads randomly choose direction for each generated transaction, alternating between `token_in → token_out` and `token_out → token_in`.
+
+`real_token_setup` runs a pre-test phase before the measured loop: it wraps sender ETH into WETH, acquires the paired token through the configured acquisition route if the sender's balance is below `amount_per_sender`, and approves all measured routers for both tokens. When present and enabled, it replaces fixture-token minting (`swap_token_amount`).
+
+```yaml
+real_token_setup:
+  enabled: true
+  allow_chain_id_8453: true
+  weth: "0x4200000000000000000000000000000000000006"
+  weth_amount_per_sender: "50000000000000000"
+  pair_token:
+    token: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
+    amount_per_sender: "10000000"
+    acquisition:
+      type: uniswap_v3_exact_input
+      router: "0x2626664c2603336E57B271c5C0b26F421741e481"
+      fee: 500
+      amount_in: "10000000000000000"
+      min_amount_out: "0"
+```
+
+`reverse_min_amount` and `reverse_max_amount` on `uniswap_v3` and `aerodrome_cl` set the amount range for `token_out → token_in` swaps. Use these when the two tokens have different decimal scales; when omitted, the reverse range matches the forward range.

--- a/crates/infra/load-tests/examples/mainnet-state-weth-usdc-swaps.yaml
+++ b/crates/infra/load-tests/examples/mainnet-state-weth-usdc-swaps.yaml
@@ -1,0 +1,69 @@
+# Load Test Configuration - Local/Shadow Mainnet State WETH/USDC Swaps
+#
+# This config is for a local or shadow-builder environment restored from Base
+# mainnet state. Do not point it at public Base mainnet RPCs with a real key.
+#
+# Requires FUNDER_KEY with enough local/shadow ETH to fund deterministic
+# sender accounts. Setup wraps sender ETH into WETH, swaps WETH into USDC
+# through the explicit acquisition route, approves both measured routers, and
+# then runs the existing random-direction Uniswap V3 + Aerodrome CL swap mix.
+
+transaction_submission_rpcs:
+  - "http://127.0.0.1:8545"
+query_rpc: "http://127.0.0.1:8545"
+txpool_nodes: []
+flashblocks_ws: "ws://127.0.0.1:7111"
+
+chain_id: 8453
+sender_count: 10
+target_gps: 20000000
+in_flight_per_sender: 64
+batch_size: 20
+batch_timeout: "10ms"
+duration: "60s"
+seed: 654789
+
+# 0.2 ETH per account covers WETH setup plus local/shadow setup and swap gas.
+funding_amount: "200000000000000000"
+
+real_token_setup:
+  enabled: true
+  allow_chain_id_8453: true
+  weth: "0x4200000000000000000000000000000000000006"
+  # Target WETH balance left after pair-token acquisition.
+  weth_amount_per_sender: "50000000000000000" # 0.05 WETH
+  pair_token:
+    token: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913" # USDC
+    amount_per_sender: "10000000" # 10 USDC raw units
+    acquisition:
+      type: uniswap_v3_exact_input
+      router: "0x2626664c2603336E57B271c5C0b26F421741e481"
+      fee: 500
+      amount_in: "10000000000000000" # 0.01 WETH
+      min_amount_out: "0"
+
+transactions:
+  - weight: 50
+    type: uniswap_v3
+    router: "0x2626664c2603336E57B271c5C0b26F421741e481"
+    token_in: "0x4200000000000000000000000000000000000006"
+    token_out: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
+    fee: 500
+    # WETH -> USDC amount range, denominated in WETH wei.
+    min_amount: "10000000000000"
+    max_amount: "100000000000000"
+    # USDC -> WETH amount range, denominated in USDC raw units.
+    reverse_min_amount: "100000"
+    reverse_max_amount: "1000000"
+  - weight: 50
+    type: aerodrome_cl
+    router: "0xBE6D8f0d05cC4be24d5167a3eF062215bE6D18a5"
+    token_in: "0x4200000000000000000000000000000000000006"
+    token_out: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
+    tick_spacing: 100
+    # WETH -> USDC amount range, denominated in WETH wei.
+    min_amount: "10000000000000"
+    max_amount: "100000000000000"
+    # USDC -> WETH amount range, denominated in USDC raw units.
+    reverse_min_amount: "100000"
+    reverse_max_amount: "1000000"

--- a/crates/infra/load-tests/examples/real-token-devnet.yaml.template
+++ b/crates/infra/load-tests/examples/real-token-devnet.yaml.template
@@ -1,0 +1,65 @@
+# Load Test Configuration - Local Devnet Real-Token WETH/USDC Swaps
+#
+# This template is rendered by `just load-test real-token`.
+# The command deploys a devnet USDC token plus Uniswap/Aerodrome router shims,
+# substitutes the addresses below, and runs the rendered config.
+
+transaction_submission_rpcs:
+  - "http://localhost:7545"
+query_rpc: "http://localhost:8545"
+txpool_nodes:
+  - "http://localhost:7545"
+  - "http://localhost:8545"
+flashblocks_ws: "ws://localhost:7111"
+
+sender_count: 10
+target_gps: 20000000
+in_flight_per_sender: 64
+batch_size: 20
+batch_timeout: "10ms"
+duration: "30s"
+seed: 654789
+
+# 0.2 ETH per account covers WETH setup plus local devnet setup and swap gas.
+funding_amount: "200000000000000000"
+
+real_token_setup:
+  enabled: true
+  weth: "0x4200000000000000000000000000000000000006"
+  # Target WETH balance left after pair-token acquisition.
+  weth_amount_per_sender: "50000000000000000" # 0.05 WETH
+  pair_token:
+    token: "__USDC__"
+    amount_per_sender: "10000000" # 10 USDC raw units
+    acquisition:
+      type: uniswap_v3_exact_input
+      router: "__UNISWAP_ROUTER__"
+      fee: 500
+      amount_in: "10000000000000000" # 0.01 WETH
+      min_amount_out: "0"
+
+transactions:
+  - weight: 50
+    type: uniswap_v3
+    router: "__UNISWAP_ROUTER__"
+    token_in: "0x4200000000000000000000000000000000000006"
+    token_out: "__USDC__"
+    fee: 500
+    # WETH -> USDC amount range, denominated in WETH wei.
+    min_amount: "10000000000000"
+    max_amount: "100000000000000"
+    # USDC -> WETH amount range, denominated in USDC raw units.
+    reverse_min_amount: "10000"
+    reverse_max_amount: "100000"
+  - weight: 50
+    type: aerodrome_cl
+    router: "__AERODROME_ROUTER__"
+    token_in: "0x4200000000000000000000000000000000000006"
+    token_out: "__USDC__"
+    tick_spacing: 100
+    # WETH -> USDC amount range, denominated in WETH wei.
+    min_amount: "10000000000000"
+    max_amount: "100000000000000"
+    # USDC -> WETH amount range, denominated in USDC raw units.
+    reverse_min_amount: "10000"
+    reverse_max_amount: "100000"

--- a/crates/infra/load-tests/examples/real-token-mainnet-snapshot.yaml
+++ b/crates/infra/load-tests/examples/real-token-mainnet-snapshot.yaml
@@ -1,7 +1,7 @@
-# Load Test Configuration - Local/Shadow Mainnet State WETH/USDC Swaps
+# Load Test Configuration - Local/Shadow Mainnet Snapshot WETH/USDC Swaps
 #
-# This config is for a local or shadow-builder environment restored from Base
-# mainnet state. Do not point it at public Base mainnet RPCs with a real key.
+# This config is for a local or shadow-builder environment restored from a Base
+# mainnet snapshot. Do not point it at public Base mainnet RPCs with a real key.
 #
 # Requires FUNDER_KEY with enough local/shadow ETH to fund deterministic
 # sender accounts. Setup wraps sender ETH into WETH, swaps WETH into USDC
@@ -53,8 +53,8 @@ transactions:
     min_amount: "10000000000000"
     max_amount: "100000000000000"
     # USDC -> WETH amount range, denominated in USDC raw units.
-    reverse_min_amount: "100000"
-    reverse_max_amount: "1000000"
+    reverse_min_amount: "10000"
+    reverse_max_amount: "100000"
   - weight: 50
     type: aerodrome_cl
     router: "0xBE6D8f0d05cC4be24d5167a3eF062215bE6D18a5"
@@ -65,5 +65,5 @@ transactions:
     min_amount: "10000000000000"
     max_amount: "100000000000000"
     # USDC -> WETH amount range, denominated in USDC raw units.
-    reverse_min_amount: "100000"
-    reverse_max_amount: "1000000"
+    reverse_min_amount: "10000"
+    reverse_max_amount: "100000"

--- a/crates/infra/load-tests/examples/real-token-sepolia.yaml
+++ b/crates/infra/load-tests/examples/real-token-sepolia.yaml
@@ -9,8 +9,9 @@
 # deployed, but its factory does not currently have a WETH/USDC pool.
 
 transaction_submission_rpcs:
-  - "https://c3-chainproxy-base-sepolia-archive-dev.cbhq.net"
-query_rpc: "https://c3-chainproxy-base-sepolia-archive-dev.cbhq.net"
+  - "https://sepolia.base.org/"
+# Must point at an RPC that supports eth_getBlockReceipts for confirmation tracking.
+query_rpc: "https://base-sepolia-rpc.publicnode.com"
 txpool_nodes: []
 flashblocks_ws: "wss://sepolia.flashblocks.base.org/ws"
 

--- a/crates/infra/load-tests/examples/real-token-sepolia.yaml
+++ b/crates/infra/load-tests/examples/real-token-sepolia.yaml
@@ -1,0 +1,56 @@
+# Load Test Configuration - Base Sepolia Real-Token WETH/USDC Swaps
+#
+# Requires FUNDER_KEY with enough Base Sepolia ETH to fund deterministic
+# sender accounts. WETH, USDC, and the Uniswap pool are expected to already
+# be deployed on the network.
+#
+# Aerodrome Slipstream is intentionally omitted for this WETH/USDC config:
+# the Base Sepolia Slipstream router from the generic Sepolia example is
+# deployed, but its factory does not currently have a WETH/USDC pool.
+
+transaction_submission_rpcs:
+  - "https://c3-chainproxy-base-sepolia-archive-dev.cbhq.net"
+query_rpc: "https://c3-chainproxy-base-sepolia-archive-dev.cbhq.net"
+txpool_nodes: []
+flashblocks_ws: "wss://sepolia.flashblocks.base.org/ws"
+
+chain_id: 84532
+sender_count: 5
+target_gps: 20000000
+in_flight_per_sender: 64
+batch_size: 20
+batch_timeout: "10ms"
+duration: "30s"
+seed: 654789
+
+# 0.1 ETH per account covers WETH setup plus swap gas.
+funding_amount: "100000000000000000"
+
+real_token_setup:
+  enabled: true
+  weth: "0x4200000000000000000000000000000000000006"
+  # Target WETH balance left after pair-token acquisition.
+  weth_amount_per_sender: "50000000000000000" # 0.05 WETH
+  pair_token:
+    token: "0x036CbD53842c5426634e7929541eC2318f3dCF7e" # Base Sepolia USDC
+    amount_per_sender: "5000000" # 5 USDC raw units
+    acquisition:
+      type: uniswap_v3_exact_input
+      router: "0x94cC0AaC535CCDB3C01d6787D6413C739ae12bc4"
+      fee: 3000
+      amount_in: "10000000000000000" # 0.01 WETH
+      min_amount_out: "0"
+
+transactions:
+  - weight: 100
+    type: uniswap_v3
+    router: "0x94cC0AaC535CCDB3C01d6787D6413C739ae12bc4"
+    token_in: "0x4200000000000000000000000000000000000006"
+    token_out: "0x036CbD53842c5426634e7929541eC2318f3dCF7e"
+    fee: 3000
+    # WETH -> USDC amount range, denominated in WETH wei.
+    min_amount: "10000000000000"
+    max_amount: "100000000000000"
+    # USDC -> WETH amount range, denominated in USDC raw units.
+    reverse_min_amount: "10000"
+    reverse_max_amount: "100000"

--- a/crates/infra/load-tests/src/config/mod.rs
+++ b/crates/infra/load-tests/src/config/mod.rs
@@ -4,4 +4,7 @@ mod workload;
 pub use workload::WorkloadConfig;
 
 mod test_config;
-pub use test_config::{OsakaTarget, PrecompileTarget, TestConfig, TxTypeConfig, WeightedTxType};
+pub use test_config::{
+    OsakaTarget, PrecompileTarget, RealTokenAcquisitionConfig, RealTokenPairTokenConfig,
+    RealTokenSetupConfig, TestConfig, TxTypeConfig, WeightedTxType,
+};

--- a/crates/infra/load-tests/src/config/mod.rs
+++ b/crates/infra/load-tests/src/config/mod.rs
@@ -3,8 +3,13 @@
 mod workload;
 pub use workload::WorkloadConfig;
 
+mod parsing;
+
+mod precompile;
+pub use precompile::PrecompileTarget;
+
+mod real_token;
+pub use real_token::{RealTokenAcquisitionConfig, RealTokenPairTokenConfig, RealTokenSetupConfig};
+
 mod test_config;
-pub use test_config::{
-    OsakaTarget, PrecompileTarget, RealTokenAcquisitionConfig, RealTokenPairTokenConfig,
-    RealTokenSetupConfig, TestConfig, TxTypeConfig, WeightedTxType,
-};
+pub use test_config::{OsakaTarget, TestConfig, TxTypeConfig, WeightedTxType};

--- a/crates/infra/load-tests/src/config/parsing.rs
+++ b/crates/infra/load-tests/src/config/parsing.rs
@@ -1,0 +1,32 @@
+use alloy_primitives::{Address, U256};
+
+use crate::utils::{BaselineError, Result};
+
+pub(super) fn parse_address(s: &str, field: &str) -> Result<Address> {
+    s.parse::<Address>()
+        .map_err(|e| BaselineError::Config(format!("invalid {field} address '{s}': {e}")))
+}
+
+pub(super) fn parse_amount(s: &str, field: &str) -> Result<U256> {
+    s.parse::<U256>().map_err(|e| BaselineError::Config(format!("invalid {field} '{s}': {e}")))
+}
+
+pub(super) fn validate_swap_amounts(min: U256, max: U256, tx_type: &str) -> Result<()> {
+    if min > max {
+        return Err(BaselineError::Config(format!(
+            "{tx_type} min_amount ({min}) exceeds max_amount ({max})"
+        )));
+    }
+    let u128_max = U256::from(u128::MAX);
+    if min > u128_max {
+        return Err(BaselineError::Config(format!(
+            "{tx_type} min_amount ({min}) exceeds u128::MAX — swap calls require u128 amounts"
+        )));
+    }
+    if max > u128_max {
+        return Err(BaselineError::Config(format!(
+            "{tx_type} max_amount ({max}) exceeds u128::MAX — swap calls require u128 amounts"
+        )));
+    }
+    Ok(())
+}

--- a/crates/infra/load-tests/src/config/precompile.rs
+++ b/crates/infra/load-tests/src/config/precompile.rs
@@ -1,0 +1,62 @@
+use revm::precompile::PrecompileId;
+use serde::{Deserialize, Serialize};
+
+/// Typed precompile target for load test configuration.
+///
+/// Deserializes from a `target` string field with optional precompile-specific
+/// parameters (e.g. `rounds` for blake2f).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "target", rename_all = "snake_case")]
+pub enum PrecompileTarget {
+    /// ECDSA public key recovery (`ecrecover`, address `0x01`).
+    Ecrecover,
+    /// SHA-256 hash (`sha256`, address `0x02`).
+    Sha256,
+    /// RIPEMD-160 hash (`ripemd160`, address `0x03`).
+    Ripemd160,
+    /// Identity / data copy (`identity`, address `0x04`).
+    Identity,
+    /// Modular exponentiation (`modexp`, address `0x05`).
+    Modexp,
+    /// BN254 elliptic curve addition (`bn254_add`, address `0x06`).
+    Bn254Add,
+    /// BN254 scalar multiplication (`bn254_mul`, address `0x07`).
+    Bn254Mul,
+    /// BN254 pairing check (`bn254_pairing`, address `0x08`).
+    Bn254Pairing,
+    /// `BLAKE2f` compression (`blake2f`, address `0x09`).
+    Blake2f {
+        /// Fixed number of compression rounds. Random if `None`.
+        #[serde(default)]
+        rounds: Option<u32>,
+    },
+    /// KZG point evaluation (`kzg_point_evaluation`, address `0x0a`).
+    #[serde(rename = "kzg_point_evaluation")]
+    KzgPointEvaluation,
+}
+
+impl PrecompileTarget {
+    /// Converts to the corresponding `revm` [`PrecompileId`].
+    pub const fn to_precompile_id(&self) -> PrecompileId {
+        match self {
+            Self::Ecrecover => PrecompileId::EcRec,
+            Self::Sha256 => PrecompileId::Sha256,
+            Self::Ripemd160 => PrecompileId::Ripemd160,
+            Self::Identity => PrecompileId::Identity,
+            Self::Modexp => PrecompileId::ModExp,
+            Self::Bn254Add => PrecompileId::Bn254Add,
+            Self::Bn254Mul => PrecompileId::Bn254Mul,
+            Self::Bn254Pairing => PrecompileId::Bn254Pairing,
+            Self::Blake2f { .. } => PrecompileId::Blake2F,
+            Self::KzgPointEvaluation => PrecompileId::KzgPointEvaluation,
+        }
+    }
+
+    /// Returns the fixed blake2f round count, if configured.
+    pub const fn blake2f_rounds(&self) -> Option<u32> {
+        match self {
+            Self::Blake2f { rounds } => *rounds,
+            _ => None,
+        }
+    }
+}

--- a/crates/infra/load-tests/src/config/real_token.rs
+++ b/crates/infra/load-tests/src/config/real_token.rs
@@ -1,0 +1,370 @@
+use alloy_primitives::{Address, U256};
+use serde::{Deserialize, Serialize};
+
+use super::{
+    parsing::{parse_address, parse_amount},
+    test_config::{TxTypeConfig, WeightedTxType},
+};
+use crate::{
+    runner::{RealTokenAcquisition, RealTokenPairTokenSetup, RealTokenSetup},
+    utils::{BaselineError, Result},
+};
+
+/// Optional setup for real-token bidirectional swap workloads.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RealTokenSetupConfig {
+    /// Enables the real-token setup path.
+    pub enabled: bool,
+    /// Explicit guard required when running against chain ID 8453.
+    #[serde(default)]
+    pub allow_chain_id_8453: bool,
+    /// WETH contract address.
+    pub weth: String,
+    /// Target WETH balance to leave each sender with after setup.
+    pub weth_amount_per_sender: String,
+    /// Non-WETH token setup.
+    pub pair_token: RealTokenPairTokenConfig,
+    /// Router allowance amount. Defaults to `max`.
+    #[serde(default)]
+    pub approval_amount: Option<String>,
+}
+
+/// Non-WETH side of the real-token pair.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RealTokenPairTokenConfig {
+    /// Token contract address.
+    pub token: String,
+    /// Target pair-token balance per sender.
+    pub amount_per_sender: String,
+    /// Explicit setup route for acquiring the pair token.
+    pub acquisition: RealTokenAcquisitionConfig,
+}
+
+/// Explicit setup route for acquiring pair tokens from WETH.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum RealTokenAcquisitionConfig {
+    /// Uniswap V3 `exactInputSingle` route.
+    UniswapV3ExactInput {
+        /// Router contract address.
+        router: String,
+        /// Fee tier.
+        #[serde(default = "default_uniswap_v3_fee")]
+        fee: u32,
+        /// WETH input amount per sender.
+        amount_in: String,
+        /// Minimum pair-token output amount.
+        #[serde(default = "default_zero_amount")]
+        min_amount_out: String,
+    },
+    /// Aerodrome Slipstream `exactInputSingle` route.
+    AerodromeClExactInput {
+        /// Router contract address.
+        router: String,
+        /// Tick spacing.
+        #[serde(default = "default_aerodrome_tick_spacing")]
+        tick_spacing: i32,
+        /// WETH input amount per sender.
+        amount_in: String,
+        /// Minimum pair-token output amount.
+        #[serde(default = "default_zero_amount")]
+        min_amount_out: String,
+    },
+}
+
+pub(super) fn parse_real_token_setup(
+    setup: Option<&RealTokenSetupConfig>,
+    transactions: &[WeightedTxType],
+    chain_id: u64,
+) -> Result<Option<RealTokenSetup>> {
+    let Some(setup) = setup else {
+        return Ok(None);
+    };
+    if !setup.enabled {
+        return Ok(None);
+    }
+    if chain_id == 8453 && !setup.allow_chain_id_8453 {
+        return Err(BaselineError::Config(
+            "real_token_setup on chain_id 8453 requires allow_chain_id_8453: true".into(),
+        ));
+    }
+
+    let weth = parse_address(&setup.weth, "real_token_setup weth")?;
+    let weth_amount_per_sender =
+        parse_amount(&setup.weth_amount_per_sender, "real_token_setup weth_amount_per_sender")?;
+    if weth_amount_per_sender == U256::ZERO {
+        return Err(BaselineError::Config(
+            "real_token_setup weth_amount_per_sender must be > 0".into(),
+        ));
+    }
+
+    let pair_token = parse_address(&setup.pair_token.token, "real_token_setup pair_token")?;
+    if pair_token == weth {
+        return Err(BaselineError::Config(
+            "real_token_setup pair_token must differ from weth".into(),
+        ));
+    }
+    let pair_amount_per_sender = parse_amount(
+        &setup.pair_token.amount_per_sender,
+        "real_token_setup pair_token amount_per_sender",
+    )?;
+    if pair_amount_per_sender == U256::ZERO {
+        return Err(BaselineError::Config(
+            "real_token_setup pair_token amount_per_sender must be > 0".into(),
+        ));
+    }
+
+    validate_real_token_pair_matches_swaps(transactions, weth, pair_token)?;
+
+    let acquisition = parse_real_token_acquisition(&setup.pair_token.acquisition)?;
+    let approval_amount = match setup.approval_amount.as_deref() {
+        None | Some("max") => U256::MAX,
+        Some(amount) => parse_amount(amount, "real_token_setup approval_amount")?,
+    };
+    if approval_amount == U256::ZERO {
+        return Err(BaselineError::Config("real_token_setup approval_amount must be > 0".into()));
+    }
+
+    Ok(Some(RealTokenSetup {
+        allow_chain_id_8453: setup.allow_chain_id_8453,
+        weth,
+        weth_amount_per_sender,
+        pair_token: RealTokenPairTokenSetup {
+            token: pair_token,
+            amount_per_sender: pair_amount_per_sender,
+            acquisition,
+        },
+        approval_amount,
+    }))
+}
+
+fn validate_real_token_pair_matches_swaps(
+    transactions: &[WeightedTxType],
+    weth: Address,
+    pair_token: Address,
+) -> Result<()> {
+    let mut saw_swap = false;
+    for tx in transactions {
+        let (token_in, token_out) = match &tx.tx_type {
+            TxTypeConfig::UniswapV3 { token_in, token_out, .. }
+            | TxTypeConfig::AerodromeCl { token_in, token_out, .. } => (
+                parse_address(token_in, "real_token_setup swap token_in")?,
+                parse_address(token_out, "real_token_setup swap token_out")?,
+            ),
+            TxTypeConfig::Transfer
+            | TxTypeConfig::Calldata { .. }
+            | TxTypeConfig::Erc20 { .. }
+            | TxTypeConfig::Precompile { .. }
+            | TxTypeConfig::Osaka { .. } => continue,
+        };
+        saw_swap = true;
+        let matches_forward = token_in == weth && token_out == pair_token;
+        let matches_reverse = token_in == pair_token && token_out == weth;
+        if !matches_forward && !matches_reverse {
+            return Err(BaselineError::Config(format!(
+                "real_token_setup only supports the configured WETH/pair token across swap txs; found {token_in} -> {token_out}"
+            )));
+        }
+    }
+
+    if !saw_swap {
+        return Err(BaselineError::Config(
+            "real_token_setup requires at least one uniswap_v3 or aerodrome_cl transaction".into(),
+        ));
+    }
+
+    Ok(())
+}
+
+fn parse_real_token_acquisition(
+    config: &RealTokenAcquisitionConfig,
+) -> Result<RealTokenAcquisition> {
+    match config {
+        RealTokenAcquisitionConfig::UniswapV3ExactInput {
+            router,
+            fee,
+            amount_in,
+            min_amount_out,
+        } => {
+            let max_u24: u32 = (1 << 24) - 1;
+            if *fee > max_u24 {
+                return Err(BaselineError::Config(format!(
+                    "real_token_setup acquisition fee {fee} exceeds u24 max ({max_u24})"
+                )));
+            }
+            let amount_in = parse_amount(amount_in, "real_token_setup acquisition amount_in")?;
+            if amount_in == U256::ZERO {
+                return Err(BaselineError::Config(
+                    "real_token_setup acquisition amount_in must be > 0".into(),
+                ));
+            }
+            Ok(RealTokenAcquisition::UniswapV3ExactInput {
+                router: parse_address(router, "real_token_setup acquisition router")?,
+                fee: *fee,
+                amount_in,
+                min_amount_out: parse_amount(
+                    min_amount_out,
+                    "real_token_setup acquisition min_amount_out",
+                )?,
+            })
+        }
+        RealTokenAcquisitionConfig::AerodromeClExactInput {
+            router,
+            tick_spacing,
+            amount_in,
+            min_amount_out,
+        } => {
+            if !(-8_388_608..=8_388_607).contains(tick_spacing) {
+                return Err(BaselineError::Config(format!(
+                    "real_token_setup acquisition tick_spacing {tick_spacing} exceeds i24 range"
+                )));
+            }
+            let amount_in = parse_amount(amount_in, "real_token_setup acquisition amount_in")?;
+            if amount_in == U256::ZERO {
+                return Err(BaselineError::Config(
+                    "real_token_setup acquisition amount_in must be > 0".into(),
+                ));
+            }
+            Ok(RealTokenAcquisition::AerodromeClExactInput {
+                router: parse_address(router, "real_token_setup acquisition router")?,
+                tick_spacing: *tick_spacing,
+                amount_in,
+                min_amount_out: parse_amount(
+                    min_amount_out,
+                    "real_token_setup acquisition min_amount_out",
+                )?,
+            })
+        }
+    }
+}
+
+fn default_zero_amount() -> String {
+    "0".to_string()
+}
+
+const fn default_uniswap_v3_fee() -> u32 {
+    3000
+}
+
+const fn default_aerodrome_tick_spacing() -> i32 {
+    100
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_primitives::{Address, U256};
+
+    use super::super::test_config::TestConfig;
+    use crate::runner::RealTokenAcquisition;
+
+    #[test]
+    fn parse_real_token_setup_for_random_direction_swap_parity() {
+        let yaml = r#"
+transaction_submission_rpcs: http://localhost:8545
+flashblocks_ws: ws://localhost:7111
+chain_id: 8453
+real_token_setup:
+  enabled: true
+  allow_chain_id_8453: true
+  weth: "0x4200000000000000000000000000000000000006"
+  weth_amount_per_sender: "800000000000000000"
+  pair_token:
+    token: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
+    amount_per_sender: "1000000000"
+    acquisition:
+      type: uniswap_v3_exact_input
+      router: "0x2626664c2603336E57B271c5C0b26F421741e481"
+      fee: 500
+      amount_in: "10000000000000000"
+transactions:
+  - weight: 50
+    type: uniswap_v3
+    router: "0x2626664c2603336E57B271c5C0b26F421741e481"
+    token_in: "0x4200000000000000000000000000000000000006"
+    token_out: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
+    fee: 500
+  - weight: 50
+    type: aerodrome_cl
+    router: "0xBE6D8f0d05cC4be24d5167a3eF062215bE6D18a5"
+    token_in: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
+    token_out: "0x4200000000000000000000000000000000000006"
+    tick_spacing: 100
+"#;
+        let config = TestConfig::from_yaml(yaml).unwrap();
+        let setup = config.parse_real_token_setup(8453).unwrap().unwrap();
+        assert_eq!(
+            setup.weth,
+            "0x4200000000000000000000000000000000000006".parse::<Address>().unwrap()
+        );
+        assert_eq!(
+            setup.pair_token.token,
+            "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913".parse::<Address>().unwrap()
+        );
+        assert_eq!(setup.pair_token.amount_per_sender, U256::from(1_000_000_000u64));
+        assert!(matches!(
+            setup.pair_token.acquisition,
+            RealTokenAcquisition::UniswapV3ExactInput { fee: 500, .. }
+        ));
+    }
+
+    #[test]
+    fn real_token_setup_requires_mainnet_guard() {
+        let yaml = r#"
+transaction_submission_rpcs: http://localhost:8545
+flashblocks_ws: ws://localhost:7111
+real_token_setup:
+  enabled: true
+  weth: "0x4200000000000000000000000000000000000006"
+  weth_amount_per_sender: "800000000000000000"
+  pair_token:
+    token: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
+    amount_per_sender: "1000000000"
+    acquisition:
+      type: aerodrome_cl_exact_input
+      router: "0xBE6D8f0d05cC4be24d5167a3eF062215bE6D18a5"
+      tick_spacing: 100
+      amount_in: "10000000000000000"
+transactions:
+  - weight: 100
+    type: uniswap_v3
+    router: "0x2626664c2603336E57B271c5C0b26F421741e481"
+    token_in: "0x4200000000000000000000000000000000000006"
+    token_out: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
+    fee: 500
+"#;
+        let config = TestConfig::from_yaml(yaml).unwrap();
+        let err = config.parse_real_token_setup(8453).unwrap_err();
+        assert!(err.to_string().contains("allow_chain_id_8453"));
+    }
+
+    #[test]
+    fn real_token_setup_rejects_non_pair_swap_tokens() {
+        let yaml = r#"
+transaction_submission_rpcs: http://localhost:8545
+flashblocks_ws: ws://localhost:7111
+real_token_setup:
+  enabled: true
+  allow_chain_id_8453: true
+  weth: "0x4200000000000000000000000000000000000006"
+  weth_amount_per_sender: "800000000000000000"
+  pair_token:
+    token: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
+    amount_per_sender: "1000000000"
+    acquisition:
+      type: uniswap_v3_exact_input
+      router: "0x2626664c2603336E57B271c5C0b26F421741e481"
+      fee: 500
+      amount_in: "10000000000000000"
+transactions:
+  - weight: 100
+    type: uniswap_v3
+    router: "0x2626664c2603336E57B271c5C0b26F421741e481"
+    token_in: "0x4200000000000000000000000000000000000006"
+    token_out: "0x1111111111111111111111111111111111111111"
+    fee: 500
+"#;
+        let config = TestConfig::from_yaml(yaml).unwrap();
+        let err = config.parse_real_token_setup(8453).unwrap_err();
+        assert!(err.to_string().contains("WETH/pair token"));
+    }
+}

--- a/crates/infra/load-tests/src/config/real_token.rs
+++ b/crates/infra/load-tests/src/config/real_token.rs
@@ -154,6 +154,7 @@ fn validate_real_token_pair_matches_swaps(
             TxTypeConfig::Transfer
             | TxTypeConfig::Calldata { .. }
             | TxTypeConfig::Erc20 { .. }
+            | TxTypeConfig::B20 { .. }
             | TxTypeConfig::Precompile { .. }
             | TxTypeConfig::Osaka { .. } => continue,
         };

--- a/crates/infra/load-tests/src/config/test_config.rs
+++ b/crates/infra/load-tests/src/config/test_config.rs
@@ -212,7 +212,7 @@ pub struct TestConfig {
     #[serde(default = "default_b20_mint_amount")]
     pub b20_mint_amount: String,
 
-    /// Optional real-token setup for mainnet-state bidirectional swap workloads.
+    /// Optional real-token setup for mainnet-snapshot bidirectional swap workloads.
     #[serde(default)]
     pub real_token_setup: Option<RealTokenSetupConfig>,
 }

--- a/crates/infra/load-tests/src/config/test_config.rs
+++ b/crates/infra/load-tests/src/config/test_config.rs
@@ -1,138 +1,20 @@
 use std::{fmt, path::Path, time::Duration};
 
-use alloy_primitives::{Address, U256};
+use alloy_primitives::Address;
 use alloy_signer_local::PrivateKeySigner;
-use revm::precompile::PrecompileId;
 use serde::{Deserialize, Deserializer, Serialize, de::Error as SerdeError};
 use url::Url;
 
+use super::{
+    parsing::{parse_address, parse_amount, validate_swap_amounts},
+    precompile::PrecompileTarget,
+    real_token::{RealTokenSetupConfig, parse_real_token_setup},
+};
 use crate::{
     metrics::ConfigSummary,
-    runner::{RealTokenAcquisition, RealTokenPairTokenSetup, RealTokenSetup, TxConfig, TxType},
+    runner::{RealTokenSetup, TxConfig, TxType},
     utils::{BaselineError, Result},
 };
-
-/// Typed precompile target for load test configuration.
-///
-/// Deserializes from a `target` string field with optional precompile-specific
-/// parameters (e.g. `rounds` for blake2f).
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(tag = "target", rename_all = "snake_case")]
-pub enum PrecompileTarget {
-    /// ECDSA public key recovery (`ecrecover`, address `0x01`).
-    Ecrecover,
-    /// SHA-256 hash (`sha256`, address `0x02`).
-    Sha256,
-    /// RIPEMD-160 hash (`ripemd160`, address `0x03`).
-    Ripemd160,
-    /// Identity / data copy (`identity`, address `0x04`).
-    Identity,
-    /// Modular exponentiation (`modexp`, address `0x05`).
-    Modexp,
-    /// BN254 elliptic curve addition (`bn254_add`, address `0x06`).
-    Bn254Add,
-    /// BN254 scalar multiplication (`bn254_mul`, address `0x07`).
-    Bn254Mul,
-    /// BN254 pairing check (`bn254_pairing`, address `0x08`).
-    Bn254Pairing,
-    /// `BLAKE2f` compression (`blake2f`, address `0x09`).
-    Blake2f {
-        /// Fixed number of compression rounds. Random if `None`.
-        #[serde(default)]
-        rounds: Option<u32>,
-    },
-    /// KZG point evaluation (`kzg_point_evaluation`, address `0x0a`).
-    #[serde(rename = "kzg_point_evaluation")]
-    KzgPointEvaluation,
-}
-
-impl PrecompileTarget {
-    /// Converts to the corresponding `revm` [`PrecompileId`].
-    pub const fn to_precompile_id(&self) -> PrecompileId {
-        match self {
-            Self::Ecrecover => PrecompileId::EcRec,
-            Self::Sha256 => PrecompileId::Sha256,
-            Self::Ripemd160 => PrecompileId::Ripemd160,
-            Self::Identity => PrecompileId::Identity,
-            Self::Modexp => PrecompileId::ModExp,
-            Self::Bn254Add => PrecompileId::Bn254Add,
-            Self::Bn254Mul => PrecompileId::Bn254Mul,
-            Self::Bn254Pairing => PrecompileId::Bn254Pairing,
-            Self::Blake2f { .. } => PrecompileId::Blake2F,
-            Self::KzgPointEvaluation => PrecompileId::KzgPointEvaluation,
-        }
-    }
-
-    /// Returns the fixed blake2f round count, if configured.
-    pub const fn blake2f_rounds(&self) -> Option<u32> {
-        match self {
-            Self::Blake2f { rounds } => *rounds,
-            _ => None,
-        }
-    }
-}
-
-/// Optional setup for real-token bidirectional swap workloads.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct RealTokenSetupConfig {
-    /// Enables the real-token setup path.
-    pub enabled: bool,
-    /// Explicit guard required when running against chain ID 8453.
-    #[serde(default)]
-    pub allow_chain_id_8453: bool,
-    /// WETH contract address.
-    pub weth: String,
-    /// Target WETH balance to leave each sender with after setup.
-    pub weth_amount_per_sender: String,
-    /// Non-WETH token setup.
-    pub pair_token: RealTokenPairTokenConfig,
-    /// Router allowance amount. Defaults to `max`.
-    #[serde(default)]
-    pub approval_amount: Option<String>,
-}
-
-/// Non-WETH side of the real-token pair.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct RealTokenPairTokenConfig {
-    /// Token contract address.
-    pub token: String,
-    /// Target pair-token balance per sender.
-    pub amount_per_sender: String,
-    /// Explicit setup route for acquiring the pair token.
-    pub acquisition: RealTokenAcquisitionConfig,
-}
-
-/// Explicit setup route for acquiring pair tokens from WETH.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(tag = "type", rename_all = "snake_case")]
-pub enum RealTokenAcquisitionConfig {
-    /// Uniswap V3 `exactInputSingle` route.
-    UniswapV3ExactInput {
-        /// Router contract address.
-        router: String,
-        /// Fee tier.
-        #[serde(default = "default_uniswap_v3_fee")]
-        fee: u32,
-        /// WETH input amount per sender.
-        amount_in: String,
-        /// Minimum pair-token output amount.
-        #[serde(default = "default_zero_amount")]
-        min_amount_out: String,
-    },
-    /// Aerodrome Slipstream `exactInputSingle` route.
-    AerodromeClExactInput {
-        /// Router contract address.
-        router: String,
-        /// Tick spacing.
-        #[serde(default = "default_aerodrome_tick_spacing")]
-        tick_spacing: i32,
-        /// WETH input amount per sender.
-        amount_in: String,
-        /// Minimum pair-token output amount.
-        #[serde(default = "default_zero_amount")]
-        min_amount_out: String,
-    },
-}
 
 /// Configuration for a load test, loadable from YAML.
 #[derive(Clone, Serialize, Deserialize)]
@@ -411,10 +293,6 @@ fn default_swap_max_amount() -> String {
     "10000000000000000".to_string()
 }
 
-fn default_zero_amount() -> String {
-    "0".to_string()
-}
-
 const fn default_uniswap_v3_fee() -> u32 {
     3000
 }
@@ -583,107 +461,7 @@ impl TestConfig {
 
     /// Parses the optional real-token setup config.
     pub fn parse_real_token_setup(&self, chain_id: u64) -> Result<Option<RealTokenSetup>> {
-        let Some(setup) = &self.real_token_setup else {
-            return Ok(None);
-        };
-        if !setup.enabled {
-            return Ok(None);
-        }
-        if chain_id == 8453 && !setup.allow_chain_id_8453 {
-            return Err(BaselineError::Config(
-                "real_token_setup on chain_id 8453 requires allow_chain_id_8453: true".into(),
-            ));
-        }
-
-        let weth = parse_address(&setup.weth, "real_token_setup weth")?;
-        let weth_amount_per_sender =
-            parse_amount(&setup.weth_amount_per_sender, "real_token_setup weth_amount_per_sender")?;
-        if weth_amount_per_sender == U256::ZERO {
-            return Err(BaselineError::Config(
-                "real_token_setup weth_amount_per_sender must be > 0".into(),
-            ));
-        }
-
-        let pair_token = parse_address(&setup.pair_token.token, "real_token_setup pair_token")?;
-        if pair_token == weth {
-            return Err(BaselineError::Config(
-                "real_token_setup pair_token must differ from weth".into(),
-            ));
-        }
-        let pair_amount_per_sender = parse_amount(
-            &setup.pair_token.amount_per_sender,
-            "real_token_setup pair_token amount_per_sender",
-        )?;
-        if pair_amount_per_sender == U256::ZERO {
-            return Err(BaselineError::Config(
-                "real_token_setup pair_token amount_per_sender must be > 0".into(),
-            ));
-        }
-
-        self.validate_real_token_pair_matches_swaps(weth, pair_token)?;
-
-        let acquisition = parse_real_token_acquisition(&setup.pair_token.acquisition)?;
-        let approval_amount = match setup.approval_amount.as_deref() {
-            None | Some("max") => U256::MAX,
-            Some(amount) => parse_amount(amount, "real_token_setup approval_amount")?,
-        };
-        if approval_amount == U256::ZERO {
-            return Err(BaselineError::Config(
-                "real_token_setup approval_amount must be > 0".into(),
-            ));
-        }
-
-        Ok(Some(RealTokenSetup {
-            allow_chain_id_8453: setup.allow_chain_id_8453,
-            weth,
-            weth_amount_per_sender,
-            pair_token: RealTokenPairTokenSetup {
-                token: pair_token,
-                amount_per_sender: pair_amount_per_sender,
-                acquisition,
-            },
-            approval_amount,
-        }))
-    }
-
-    fn validate_real_token_pair_matches_swaps(
-        &self,
-        weth: Address,
-        pair_token: Address,
-    ) -> Result<()> {
-        let mut saw_swap = false;
-        for tx in &self.transactions {
-            let (token_in, token_out) = match &tx.tx_type {
-                TxTypeConfig::UniswapV3 { token_in, token_out, .. }
-                | TxTypeConfig::AerodromeCl { token_in, token_out, .. } => (
-                    parse_address(token_in, "real_token_setup swap token_in")?,
-                    parse_address(token_out, "real_token_setup swap token_out")?,
-                ),
-                TxTypeConfig::Transfer
-                | TxTypeConfig::Calldata { .. }
-                | TxTypeConfig::Erc20 { .. }
-                | TxTypeConfig::B20 { .. }
-                | TxTypeConfig::Precompile { .. }
-                | TxTypeConfig::Osaka { .. } => continue,
-            };
-            saw_swap = true;
-            let matches_forward = token_in == weth && token_out == pair_token;
-            let matches_reverse = token_in == pair_token && token_out == weth;
-            if !matches_forward && !matches_reverse {
-                return Err(BaselineError::Config(format!(
-                    "real_token_setup only supports the configured WETH/pair token across swap txs; found {token_in} -> {token_out}"
-                )));
-            }
-        }
-
-        if !saw_swap {
-            return Err(BaselineError::Config(
-                "real_token_setup requires at least one uniswap_v3 or aerodrome_cl transaction"
-                    .into(),
-            ));
-        }
-
-        Ok(())
+        parse_real_token_setup(self.real_token_setup.as_ref(), &self.transactions, chain_id)
     }
 
     /// Returns a summary of the config for JSON output (excludes URLs and secrets).
@@ -958,97 +736,6 @@ where
     E: SerdeError,
 {
     Url::parse(url).map_err(|e| E::custom(format!("invalid URL '{url}': {e}")))
-}
-
-fn parse_address(s: &str, field: &str) -> Result<Address> {
-    s.parse::<Address>()
-        .map_err(|e| BaselineError::Config(format!("invalid {field} address '{s}': {e}")))
-}
-
-fn parse_amount(s: &str, field: &str) -> Result<U256> {
-    s.parse::<U256>().map_err(|e| BaselineError::Config(format!("invalid {field} '{s}': {e}")))
-}
-
-fn parse_real_token_acquisition(
-    config: &RealTokenAcquisitionConfig,
-) -> Result<RealTokenAcquisition> {
-    match config {
-        RealTokenAcquisitionConfig::UniswapV3ExactInput {
-            router,
-            fee,
-            amount_in,
-            min_amount_out,
-        } => {
-            let max_u24: u32 = (1 << 24) - 1;
-            if *fee > max_u24 {
-                return Err(BaselineError::Config(format!(
-                    "real_token_setup acquisition fee {fee} exceeds u24 max ({max_u24})"
-                )));
-            }
-            let amount_in = parse_amount(amount_in, "real_token_setup acquisition amount_in")?;
-            if amount_in == U256::ZERO {
-                return Err(BaselineError::Config(
-                    "real_token_setup acquisition amount_in must be > 0".into(),
-                ));
-            }
-            Ok(RealTokenAcquisition::UniswapV3ExactInput {
-                router: parse_address(router, "real_token_setup acquisition router")?,
-                fee: *fee,
-                amount_in,
-                min_amount_out: parse_amount(
-                    min_amount_out,
-                    "real_token_setup acquisition min_amount_out",
-                )?,
-            })
-        }
-        RealTokenAcquisitionConfig::AerodromeClExactInput {
-            router,
-            tick_spacing,
-            amount_in,
-            min_amount_out,
-        } => {
-            if !(-8_388_608..=8_388_607).contains(tick_spacing) {
-                return Err(BaselineError::Config(format!(
-                    "real_token_setup acquisition tick_spacing {tick_spacing} exceeds i24 range"
-                )));
-            }
-            let amount_in = parse_amount(amount_in, "real_token_setup acquisition amount_in")?;
-            if amount_in == U256::ZERO {
-                return Err(BaselineError::Config(
-                    "real_token_setup acquisition amount_in must be > 0".into(),
-                ));
-            }
-            Ok(RealTokenAcquisition::AerodromeClExactInput {
-                router: parse_address(router, "real_token_setup acquisition router")?,
-                tick_spacing: *tick_spacing,
-                amount_in,
-                min_amount_out: parse_amount(
-                    min_amount_out,
-                    "real_token_setup acquisition min_amount_out",
-                )?,
-            })
-        }
-    }
-}
-
-fn validate_swap_amounts(min: U256, max: U256, tx_type: &str) -> Result<()> {
-    if min > max {
-        return Err(BaselineError::Config(format!(
-            "{tx_type} min_amount ({min}) exceeds max_amount ({max})"
-        )));
-    }
-    let u128_max = U256::from(u128::MAX);
-    if min > u128_max {
-        return Err(BaselineError::Config(format!(
-            "{tx_type} min_amount ({min}) exceeds u128::MAX — swap calls require u128 amounts"
-        )));
-    }
-    if max > u128_max {
-        return Err(BaselineError::Config(format!(
-            "{tx_type} max_amount ({max}) exceeds u128::MAX — swap calls require u128 amounts"
-        )));
-    }
-    Ok(())
 }
 
 #[cfg(test)]
@@ -1344,116 +1031,5 @@ transactions:
             }
             _ => panic!("expected AerodromeCl"),
         }
-    }
-
-    #[test]
-    fn parse_real_token_setup_for_random_direction_swap_parity() {
-        let yaml = r#"
-transaction_submission_rpcs: http://localhost:8545
-flashblocks_ws: ws://localhost:7111
-chain_id: 8453
-real_token_setup:
-  enabled: true
-  allow_chain_id_8453: true
-  weth: "0x4200000000000000000000000000000000000006"
-  weth_amount_per_sender: "800000000000000000"
-  pair_token:
-    token: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
-    amount_per_sender: "1000000000"
-    acquisition:
-      type: uniswap_v3_exact_input
-      router: "0x2626664c2603336E57B271c5C0b26F421741e481"
-      fee: 500
-      amount_in: "10000000000000000"
-transactions:
-  - weight: 50
-    type: uniswap_v3
-    router: "0x2626664c2603336E57B271c5C0b26F421741e481"
-    token_in: "0x4200000000000000000000000000000000000006"
-    token_out: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
-    fee: 500
-  - weight: 50
-    type: aerodrome_cl
-    router: "0xBE6D8f0d05cC4be24d5167a3eF062215bE6D18a5"
-    token_in: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
-    token_out: "0x4200000000000000000000000000000000000006"
-    tick_spacing: 100
-"#;
-        let config = TestConfig::from_yaml(yaml).unwrap();
-        let setup = config.parse_real_token_setup(8453).unwrap().unwrap();
-        assert_eq!(
-            setup.weth,
-            "0x4200000000000000000000000000000000000006".parse::<Address>().unwrap()
-        );
-        assert_eq!(
-            setup.pair_token.token,
-            "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913".parse::<Address>().unwrap()
-        );
-        assert_eq!(setup.pair_token.amount_per_sender, U256::from(1_000_000_000u64));
-        assert!(matches!(
-            setup.pair_token.acquisition,
-            RealTokenAcquisition::UniswapV3ExactInput { fee: 500, .. }
-        ));
-    }
-
-    #[test]
-    fn real_token_setup_requires_mainnet_guard() {
-        let yaml = r#"
-transaction_submission_rpcs: http://localhost:8545
-flashblocks_ws: ws://localhost:7111
-real_token_setup:
-  enabled: true
-  weth: "0x4200000000000000000000000000000000000006"
-  weth_amount_per_sender: "800000000000000000"
-  pair_token:
-    token: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
-    amount_per_sender: "1000000000"
-    acquisition:
-      type: aerodrome_cl_exact_input
-      router: "0xBE6D8f0d05cC4be24d5167a3eF062215bE6D18a5"
-      tick_spacing: 100
-      amount_in: "10000000000000000"
-transactions:
-  - weight: 100
-    type: uniswap_v3
-    router: "0x2626664c2603336E57B271c5C0b26F421741e481"
-    token_in: "0x4200000000000000000000000000000000000006"
-    token_out: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
-    fee: 500
-"#;
-        let config = TestConfig::from_yaml(yaml).unwrap();
-        let err = config.parse_real_token_setup(8453).unwrap_err();
-        assert!(err.to_string().contains("allow_chain_id_8453"));
-    }
-
-    #[test]
-    fn real_token_setup_rejects_non_pair_swap_tokens() {
-        let yaml = r#"
-transaction_submission_rpcs: http://localhost:8545
-flashblocks_ws: ws://localhost:7111
-real_token_setup:
-  enabled: true
-  allow_chain_id_8453: true
-  weth: "0x4200000000000000000000000000000000000006"
-  weth_amount_per_sender: "800000000000000000"
-  pair_token:
-    token: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
-    amount_per_sender: "1000000000"
-    acquisition:
-      type: uniswap_v3_exact_input
-      router: "0x2626664c2603336E57B271c5C0b26F421741e481"
-      fee: 500
-      amount_in: "10000000000000000"
-transactions:
-  - weight: 100
-    type: uniswap_v3
-    router: "0x2626664c2603336E57B271c5C0b26F421741e481"
-    token_in: "0x4200000000000000000000000000000000000006"
-    token_out: "0x1111111111111111111111111111111111111111"
-    fee: 500
-"#;
-        let config = TestConfig::from_yaml(yaml).unwrap();
-        let err = config.parse_real_token_setup(8453).unwrap_err();
-        assert!(err.to_string().contains("WETH/pair token"));
     }
 }

--- a/crates/infra/load-tests/src/config/test_config.rs
+++ b/crates/infra/load-tests/src/config/test_config.rs
@@ -8,7 +8,7 @@ use url::Url;
 
 use crate::{
     metrics::ConfigSummary,
-    runner::{TxConfig, TxType},
+    runner::{RealTokenAcquisition, RealTokenPairTokenSetup, RealTokenSetup, TxConfig, TxType},
     utils::{BaselineError, Result},
 };
 
@@ -70,6 +70,68 @@ impl PrecompileTarget {
             _ => None,
         }
     }
+}
+
+/// Optional setup for real-token bidirectional swap workloads.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RealTokenSetupConfig {
+    /// Enables the real-token setup path.
+    pub enabled: bool,
+    /// Explicit guard required when running against chain ID 8453.
+    #[serde(default)]
+    pub allow_chain_id_8453: bool,
+    /// WETH contract address.
+    pub weth: String,
+    /// Target WETH balance to leave each sender with after setup.
+    pub weth_amount_per_sender: String,
+    /// Non-WETH token setup.
+    pub pair_token: RealTokenPairTokenConfig,
+    /// Router allowance amount. Defaults to `max`.
+    #[serde(default)]
+    pub approval_amount: Option<String>,
+}
+
+/// Non-WETH side of the real-token pair.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RealTokenPairTokenConfig {
+    /// Token contract address.
+    pub token: String,
+    /// Target pair-token balance per sender.
+    pub amount_per_sender: String,
+    /// Explicit setup route for acquiring the pair token.
+    pub acquisition: RealTokenAcquisitionConfig,
+}
+
+/// Explicit setup route for acquiring pair tokens from WETH.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum RealTokenAcquisitionConfig {
+    /// Uniswap V3 `exactInputSingle` route.
+    UniswapV3ExactInput {
+        /// Router contract address.
+        router: String,
+        /// Fee tier.
+        #[serde(default = "default_uniswap_v3_fee")]
+        fee: u32,
+        /// WETH input amount per sender.
+        amount_in: String,
+        /// Minimum pair-token output amount.
+        #[serde(default = "default_zero_amount")]
+        min_amount_out: String,
+    },
+    /// Aerodrome Slipstream `exactInputSingle` route.
+    AerodromeClExactInput {
+        /// Router contract address.
+        router: String,
+        /// Tick spacing.
+        #[serde(default = "default_aerodrome_tick_spacing")]
+        tick_spacing: i32,
+        /// WETH input amount per sender.
+        amount_in: String,
+        /// Minimum pair-token output amount.
+        #[serde(default = "default_zero_amount")]
+        min_amount_out: String,
+    },
 }
 
 /// Configuration for a load test, loadable from YAML.
@@ -149,6 +211,10 @@ pub struct TestConfig {
     /// Only used when B-20 transaction types are configured.
     #[serde(default = "default_b20_mint_amount")]
     pub b20_mint_amount: String,
+
+    /// Optional real-token setup for mainnet-state bidirectional swap workloads.
+    #[serde(default)]
+    pub real_token_setup: Option<RealTokenSetupConfig>,
 }
 
 impl Default for TestConfig {
@@ -175,6 +241,7 @@ impl Default for TestConfig {
             looper_contract: None,
             swap_token_amount: default_swap_token_amount(),
             b20_mint_amount: default_b20_mint_amount(),
+            real_token_setup: None,
         }
     }
 }
@@ -199,6 +266,7 @@ impl fmt::Debug for TestConfig {
             .field("looper_contract", &self.looper_contract)
             .field("swap_token_amount", &self.swap_token_amount)
             .field("b20_mint_amount", &self.b20_mint_amount)
+            .field("real_token_setup", &self.real_token_setup)
             .finish()
     }
 }
@@ -282,6 +350,12 @@ pub enum TxTypeConfig {
         /// Maximum swap amount in wei.
         #[serde(default = "default_swap_max_amount")]
         max_amount: String,
+        /// Minimum amount when swapping `token_out` to `token_in`.
+        #[serde(default)]
+        reverse_min_amount: Option<String>,
+        /// Maximum amount when swapping `token_out` to `token_in`.
+        #[serde(default)]
+        reverse_max_amount: Option<String>,
     },
     /// B-20 precompile token transfer.
     B20 {
@@ -308,6 +382,12 @@ pub enum TxTypeConfig {
         /// Maximum swap amount in wei.
         #[serde(default = "default_swap_max_amount")]
         max_amount: String,
+        /// Minimum amount when swapping `token_out` to `token_in`.
+        #[serde(default)]
+        reverse_min_amount: Option<String>,
+        /// Maximum amount when swapping `token_out` to `token_in`.
+        #[serde(default)]
+        reverse_max_amount: Option<String>,
     },
 }
 
@@ -329,6 +409,10 @@ fn default_swap_min_amount() -> String {
 
 fn default_swap_max_amount() -> String {
     "10000000000000000".to_string()
+}
+
+fn default_zero_amount() -> String {
+    "0".to_string()
 }
 
 const fn default_uniswap_v3_fee() -> u32 {
@@ -497,6 +581,111 @@ impl TestConfig {
         })
     }
 
+    /// Parses the optional real-token setup config.
+    pub fn parse_real_token_setup(&self, chain_id: u64) -> Result<Option<RealTokenSetup>> {
+        let Some(setup) = &self.real_token_setup else {
+            return Ok(None);
+        };
+        if !setup.enabled {
+            return Ok(None);
+        }
+        if chain_id == 8453 && !setup.allow_chain_id_8453 {
+            return Err(BaselineError::Config(
+                "real_token_setup on chain_id 8453 requires allow_chain_id_8453: true".into(),
+            ));
+        }
+
+        let weth = parse_address(&setup.weth, "real_token_setup weth")?;
+        let weth_amount_per_sender =
+            parse_amount(&setup.weth_amount_per_sender, "real_token_setup weth_amount_per_sender")?;
+        if weth_amount_per_sender == U256::ZERO {
+            return Err(BaselineError::Config(
+                "real_token_setup weth_amount_per_sender must be > 0".into(),
+            ));
+        }
+
+        let pair_token = parse_address(&setup.pair_token.token, "real_token_setup pair_token")?;
+        if pair_token == weth {
+            return Err(BaselineError::Config(
+                "real_token_setup pair_token must differ from weth".into(),
+            ));
+        }
+        let pair_amount_per_sender = parse_amount(
+            &setup.pair_token.amount_per_sender,
+            "real_token_setup pair_token amount_per_sender",
+        )?;
+        if pair_amount_per_sender == U256::ZERO {
+            return Err(BaselineError::Config(
+                "real_token_setup pair_token amount_per_sender must be > 0".into(),
+            ));
+        }
+
+        self.validate_real_token_pair_matches_swaps(weth, pair_token)?;
+
+        let acquisition = parse_real_token_acquisition(&setup.pair_token.acquisition)?;
+        let approval_amount = match setup.approval_amount.as_deref() {
+            None | Some("max") => U256::MAX,
+            Some(amount) => parse_amount(amount, "real_token_setup approval_amount")?,
+        };
+        if approval_amount == U256::ZERO {
+            return Err(BaselineError::Config(
+                "real_token_setup approval_amount must be > 0".into(),
+            ));
+        }
+
+        Ok(Some(RealTokenSetup {
+            allow_chain_id_8453: setup.allow_chain_id_8453,
+            weth,
+            weth_amount_per_sender,
+            pair_token: RealTokenPairTokenSetup {
+                token: pair_token,
+                amount_per_sender: pair_amount_per_sender,
+                acquisition,
+            },
+            approval_amount,
+        }))
+    }
+
+    fn validate_real_token_pair_matches_swaps(
+        &self,
+        weth: Address,
+        pair_token: Address,
+    ) -> Result<()> {
+        let mut saw_swap = false;
+        for tx in &self.transactions {
+            let (token_in, token_out) = match &tx.tx_type {
+                TxTypeConfig::UniswapV3 { token_in, token_out, .. }
+                | TxTypeConfig::AerodromeCl { token_in, token_out, .. } => (
+                    parse_address(token_in, "real_token_setup swap token_in")?,
+                    parse_address(token_out, "real_token_setup swap token_out")?,
+                ),
+                TxTypeConfig::Transfer
+                | TxTypeConfig::Calldata { .. }
+                | TxTypeConfig::Erc20 { .. }
+                | TxTypeConfig::B20 { .. }
+                | TxTypeConfig::Precompile { .. }
+                | TxTypeConfig::Osaka { .. } => continue,
+            };
+            saw_swap = true;
+            let matches_forward = token_in == weth && token_out == pair_token;
+            let matches_reverse = token_in == pair_token && token_out == weth;
+            if !matches_forward && !matches_reverse {
+                return Err(BaselineError::Config(format!(
+                    "real_token_setup only supports the configured WETH/pair token across swap txs; found {token_in} -> {token_out}"
+                )));
+            }
+        }
+
+        if !saw_swap {
+            return Err(BaselineError::Config(
+                "real_token_setup requires at least one uniswap_v3 or aerodrome_cl transaction"
+                    .into(),
+            ));
+        }
+
+        Ok(())
+    }
+
     /// Returns a summary of the config for JSON output (excludes URLs and secrets).
     pub fn to_summary(&self) -> ConfigSummary {
         ConfigSummary {
@@ -521,6 +710,20 @@ impl TestConfig {
             looper_contract: self.looper_contract.clone(),
             swap_token_amount: self.swap_token_amount.clone(),
             b20_mint_amount: self.b20_mint_amount.clone(),
+            real_token_setup: self
+                .real_token_setup
+                .as_ref()
+                .filter(|setup| setup.enabled)
+                .and_then(|setup| {
+                    serde_json::to_value(setup)
+                        .inspect_err(|e| {
+                            tracing::warn!(
+                                error = %e,
+                                "failed to serialize real-token setup for config summary"
+                            );
+                        })
+                        .ok()
+                }),
         }
     }
 
@@ -636,6 +839,8 @@ impl TestConfig {
                 fee,
                 min_amount,
                 max_amount,
+                reverse_min_amount,
+                reverse_max_amount,
             } => {
                 let router = parse_address(router, "uniswap_v3 router")?;
                 let token_in = parse_address(token_in, "uniswap_v3 token_in")?;
@@ -649,7 +854,29 @@ impl TestConfig {
                 let min_amount = parse_amount(min_amount, "uniswap_v3 min_amount")?;
                 let max_amount = parse_amount(max_amount, "uniswap_v3 max_amount")?;
                 validate_swap_amounts(min_amount, max_amount, "uniswap_v3")?;
-                TxType::UniswapV3 { router, token_in, token_out, fee: *fee, min_amount, max_amount }
+                let reverse_min_amount = match reverse_min_amount {
+                    Some(amount) => parse_amount(amount, "uniswap_v3 reverse_min_amount")?,
+                    None => min_amount,
+                };
+                let reverse_max_amount = match reverse_max_amount {
+                    Some(amount) => parse_amount(amount, "uniswap_v3 reverse_max_amount")?,
+                    None => max_amount,
+                };
+                validate_swap_amounts(
+                    reverse_min_amount,
+                    reverse_max_amount,
+                    "uniswap_v3 reverse",
+                )?;
+                TxType::UniswapV3 {
+                    router,
+                    token_in,
+                    token_out,
+                    fee: *fee,
+                    min_amount,
+                    max_amount,
+                    reverse_min_amount,
+                    reverse_max_amount,
+                }
             }
             TxTypeConfig::AerodromeCl {
                 router,
@@ -658,6 +885,8 @@ impl TestConfig {
                 tick_spacing,
                 min_amount,
                 max_amount,
+                reverse_min_amount,
+                reverse_max_amount,
             } => {
                 let router = parse_address(router, "aerodrome_cl router")?;
                 let token_in = parse_address(token_in, "aerodrome_cl token_in")?;
@@ -665,6 +894,19 @@ impl TestConfig {
                 let min_amount = parse_amount(min_amount, "aerodrome_cl min_amount")?;
                 let max_amount = parse_amount(max_amount, "aerodrome_cl max_amount")?;
                 validate_swap_amounts(min_amount, max_amount, "aerodrome_cl")?;
+                let reverse_min_amount = match reverse_min_amount {
+                    Some(amount) => parse_amount(amount, "aerodrome_cl reverse_min_amount")?,
+                    None => min_amount,
+                };
+                let reverse_max_amount = match reverse_max_amount {
+                    Some(amount) => parse_amount(amount, "aerodrome_cl reverse_max_amount")?,
+                    None => max_amount,
+                };
+                validate_swap_amounts(
+                    reverse_min_amount,
+                    reverse_max_amount,
+                    "aerodrome_cl reverse",
+                )?;
                 if !(-8_388_608..=8_388_607).contains(tick_spacing) {
                     return Err(BaselineError::Config(format!(
                         "aerodrome_cl tick_spacing {tick_spacing} exceeds i24 range"
@@ -677,6 +919,8 @@ impl TestConfig {
                     tick_spacing: *tick_spacing,
                     min_amount,
                     max_amount,
+                    reverse_min_amount,
+                    reverse_max_amount,
                 }
             }
         };
@@ -723,6 +967,68 @@ fn parse_address(s: &str, field: &str) -> Result<Address> {
 
 fn parse_amount(s: &str, field: &str) -> Result<U256> {
     s.parse::<U256>().map_err(|e| BaselineError::Config(format!("invalid {field} '{s}': {e}")))
+}
+
+fn parse_real_token_acquisition(
+    config: &RealTokenAcquisitionConfig,
+) -> Result<RealTokenAcquisition> {
+    match config {
+        RealTokenAcquisitionConfig::UniswapV3ExactInput {
+            router,
+            fee,
+            amount_in,
+            min_amount_out,
+        } => {
+            let max_u24: u32 = (1 << 24) - 1;
+            if *fee > max_u24 {
+                return Err(BaselineError::Config(format!(
+                    "real_token_setup acquisition fee {fee} exceeds u24 max ({max_u24})"
+                )));
+            }
+            let amount_in = parse_amount(amount_in, "real_token_setup acquisition amount_in")?;
+            if amount_in == U256::ZERO {
+                return Err(BaselineError::Config(
+                    "real_token_setup acquisition amount_in must be > 0".into(),
+                ));
+            }
+            Ok(RealTokenAcquisition::UniswapV3ExactInput {
+                router: parse_address(router, "real_token_setup acquisition router")?,
+                fee: *fee,
+                amount_in,
+                min_amount_out: parse_amount(
+                    min_amount_out,
+                    "real_token_setup acquisition min_amount_out",
+                )?,
+            })
+        }
+        RealTokenAcquisitionConfig::AerodromeClExactInput {
+            router,
+            tick_spacing,
+            amount_in,
+            min_amount_out,
+        } => {
+            if !(-8_388_608..=8_388_607).contains(tick_spacing) {
+                return Err(BaselineError::Config(format!(
+                    "real_token_setup acquisition tick_spacing {tick_spacing} exceeds i24 range"
+                )));
+            }
+            let amount_in = parse_amount(amount_in, "real_token_setup acquisition amount_in")?;
+            if amount_in == U256::ZERO {
+                return Err(BaselineError::Config(
+                    "real_token_setup acquisition amount_in must be > 0".into(),
+                ));
+            }
+            Ok(RealTokenAcquisition::AerodromeClExactInput {
+                router: parse_address(router, "real_token_setup acquisition router")?,
+                tick_spacing: *tick_spacing,
+                amount_in,
+                min_amount_out: parse_amount(
+                    min_amount_out,
+                    "real_token_setup acquisition min_amount_out",
+                )?,
+            })
+        }
+    }
 }
 
 fn validate_swap_amounts(min: U256, max: U256, tx_type: &str) -> Result<()> {
@@ -1038,5 +1344,116 @@ transactions:
             }
             _ => panic!("expected AerodromeCl"),
         }
+    }
+
+    #[test]
+    fn parse_real_token_setup_for_random_direction_swap_parity() {
+        let yaml = r#"
+transaction_submission_rpcs: http://localhost:8545
+flashblocks_ws: ws://localhost:7111
+chain_id: 8453
+real_token_setup:
+  enabled: true
+  allow_chain_id_8453: true
+  weth: "0x4200000000000000000000000000000000000006"
+  weth_amount_per_sender: "800000000000000000"
+  pair_token:
+    token: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
+    amount_per_sender: "1000000000"
+    acquisition:
+      type: uniswap_v3_exact_input
+      router: "0x2626664c2603336E57B271c5C0b26F421741e481"
+      fee: 500
+      amount_in: "10000000000000000"
+transactions:
+  - weight: 50
+    type: uniswap_v3
+    router: "0x2626664c2603336E57B271c5C0b26F421741e481"
+    token_in: "0x4200000000000000000000000000000000000006"
+    token_out: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
+    fee: 500
+  - weight: 50
+    type: aerodrome_cl
+    router: "0xBE6D8f0d05cC4be24d5167a3eF062215bE6D18a5"
+    token_in: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
+    token_out: "0x4200000000000000000000000000000000000006"
+    tick_spacing: 100
+"#;
+        let config = TestConfig::from_yaml(yaml).unwrap();
+        let setup = config.parse_real_token_setup(8453).unwrap().unwrap();
+        assert_eq!(
+            setup.weth,
+            "0x4200000000000000000000000000000000000006".parse::<Address>().unwrap()
+        );
+        assert_eq!(
+            setup.pair_token.token,
+            "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913".parse::<Address>().unwrap()
+        );
+        assert_eq!(setup.pair_token.amount_per_sender, U256::from(1_000_000_000u64));
+        assert!(matches!(
+            setup.pair_token.acquisition,
+            RealTokenAcquisition::UniswapV3ExactInput { fee: 500, .. }
+        ));
+    }
+
+    #[test]
+    fn real_token_setup_requires_mainnet_guard() {
+        let yaml = r#"
+transaction_submission_rpcs: http://localhost:8545
+flashblocks_ws: ws://localhost:7111
+real_token_setup:
+  enabled: true
+  weth: "0x4200000000000000000000000000000000000006"
+  weth_amount_per_sender: "800000000000000000"
+  pair_token:
+    token: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
+    amount_per_sender: "1000000000"
+    acquisition:
+      type: aerodrome_cl_exact_input
+      router: "0xBE6D8f0d05cC4be24d5167a3eF062215bE6D18a5"
+      tick_spacing: 100
+      amount_in: "10000000000000000"
+transactions:
+  - weight: 100
+    type: uniswap_v3
+    router: "0x2626664c2603336E57B271c5C0b26F421741e481"
+    token_in: "0x4200000000000000000000000000000000000006"
+    token_out: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
+    fee: 500
+"#;
+        let config = TestConfig::from_yaml(yaml).unwrap();
+        let err = config.parse_real_token_setup(8453).unwrap_err();
+        assert!(err.to_string().contains("allow_chain_id_8453"));
+    }
+
+    #[test]
+    fn real_token_setup_rejects_non_pair_swap_tokens() {
+        let yaml = r#"
+transaction_submission_rpcs: http://localhost:8545
+flashblocks_ws: ws://localhost:7111
+real_token_setup:
+  enabled: true
+  allow_chain_id_8453: true
+  weth: "0x4200000000000000000000000000000000000006"
+  weth_amount_per_sender: "800000000000000000"
+  pair_token:
+    token: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
+    amount_per_sender: "1000000000"
+    acquisition:
+      type: uniswap_v3_exact_input
+      router: "0x2626664c2603336E57B271c5C0b26F421741e481"
+      fee: 500
+      amount_in: "10000000000000000"
+transactions:
+  - weight: 100
+    type: uniswap_v3
+    router: "0x2626664c2603336E57B271c5C0b26F421741e481"
+    token_in: "0x4200000000000000000000000000000000000006"
+    token_out: "0x1111111111111111111111111111111111111111"
+    fee: 500
+"#;
+        let config = TestConfig::from_yaml(yaml).unwrap();
+        let err = config.parse_real_token_setup(8453).unwrap_err();
+        assert!(err.to_string().contains("WETH/pair token"));
     }
 }

--- a/crates/infra/load-tests/src/lib.rs
+++ b/crates/infra/load-tests/src/lib.rs
@@ -4,7 +4,8 @@
 
 mod config;
 pub use config::{
-    OsakaTarget, PrecompileTarget, TestConfig, TxTypeConfig, WeightedTxType, WorkloadConfig,
+    OsakaTarget, PrecompileTarget, RealTokenAcquisitionConfig, RealTokenPairTokenConfig,
+    RealTokenSetupConfig, TestConfig, TxTypeConfig, WeightedTxType, WorkloadConfig,
 };
 
 mod utils;
@@ -35,8 +36,9 @@ pub use runner::{
     AdaptiveBackoff, BatchTxError, BlockObservation, BlockReceipt, BlockWatcher,
     DEFAULT_MAX_GAS_PRICE, DisplaySnapshot, FlashblockInclusion, FlashblockWatcher, LoadConfig,
     LoadRunner, LoadTestDisplay, MAX_SENDER_WORKER_COUNT, MAX_SIGNER_WORKER_COUNT, PipelineQueue,
-    PreparedBatch, PreparedTransaction, QueuedSubmitFailures, RateLimiter, ResultsTracker,
-    SENDER_WORKERS_PER_RPC, SIGNER_WORKERS_PER_RPC, SUBMIT_BATCH_QUEUE_BUFFER, SUBMIT_MAX_ATTEMPTS,
-    SenderContext, SentTransaction, SignedBatch, SignedTransaction, SignerContext,
-    SubmissionPipeline, SubmitEvent, TxConfig, TxType,
+    PreparedBatch, PreparedTransaction, QueuedSubmitFailures, RateLimiter, RealTokenAcquisition,
+    RealTokenPairTokenSetup, RealTokenSetup, ResultsTracker, SENDER_WORKERS_PER_RPC,
+    SIGNER_WORKERS_PER_RPC, SUBMIT_BATCH_QUEUE_BUFFER, SUBMIT_MAX_ATTEMPTS, SenderContext,
+    SentTransaction, SignedBatch, SignedTransaction, SignerContext, SubmissionPipeline,
+    SubmitEvent, TxConfig, TxType,
 };

--- a/crates/infra/load-tests/src/lib.rs
+++ b/crates/infra/load-tests/src/lib.rs
@@ -37,8 +37,8 @@ pub use runner::{
     DEFAULT_MAX_GAS_PRICE, DisplaySnapshot, FlashblockInclusion, FlashblockWatcher, LoadConfig,
     LoadRunner, LoadTestDisplay, MAX_SENDER_WORKER_COUNT, MAX_SIGNER_WORKER_COUNT, PipelineQueue,
     PreparedBatch, PreparedTransaction, QueuedSubmitFailures, RateLimiter, RealTokenAcquisition,
-    RealTokenPairTokenSetup, RealTokenSetup, ResultsTracker, SENDER_WORKERS_PER_RPC,
-    SIGNER_WORKERS_PER_RPC, SUBMIT_BATCH_QUEUE_BUFFER, SUBMIT_MAX_ATTEMPTS, SenderContext,
-    SentTransaction, SignedBatch, SignedTransaction, SignerContext, SubmissionPipeline,
-    SubmitEvent, TxConfig, TxType,
+    RealTokenPairTokenSetup, RealTokenRecoverySummary, RealTokenSetup, ResultsTracker,
+    SENDER_WORKERS_PER_RPC, SIGNER_WORKERS_PER_RPC, SUBMIT_BATCH_QUEUE_BUFFER, SUBMIT_MAX_ATTEMPTS,
+    SenderContext, SentTransaction, SignedBatch, SignedTransaction, SignerContext,
+    SubmissionPipeline, SubmitEvent, TxConfig, TxType,
 };

--- a/crates/infra/load-tests/src/metrics/types.rs
+++ b/crates/infra/load-tests/src/metrics/types.rs
@@ -227,4 +227,8 @@ pub struct ConfigSummary {
     pub swap_token_amount: String,
     /// Amount of B-20 tokens to mint per sender (in wei, as string).
     pub b20_mint_amount: String,
+
+    /// Real-token setup configuration, when enabled.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub real_token_setup: Option<serde_json::Value>,
 }

--- a/crates/infra/load-tests/src/runner/config.rs
+++ b/crates/infra/load-tests/src/runner/config.rs
@@ -113,6 +113,15 @@ pub struct RealTokenSetup {
     pub approval_amount: U256,
 }
 
+/// Summary of real-token balances recovered before native ETH drain.
+#[derive(Debug, Clone, Default)]
+pub struct RealTokenRecoverySummary {
+    /// Pair-token raw units swapped back into WETH.
+    pub pair_token_swapped: U256,
+    /// WETH unwrapped back into native ETH.
+    pub weth_unwrapped: U256,
+}
+
 /// Non-WETH side of the real-token pair.
 #[derive(Debug, Clone)]
 pub struct RealTokenPairTokenSetup {

--- a/crates/infra/load-tests/src/runner/config.rs
+++ b/crates/infra/load-tests/src/runner/config.rs
@@ -176,6 +176,14 @@ impl RealTokenAcquisition {
             | Self::AerodromeClExactInput { amount_in, .. } => *amount_in,
         }
     }
+
+    /// Returns the minimum output amount expected by this setup route.
+    pub const fn min_amount_out(&self) -> U256 {
+        match self {
+            Self::UniswapV3ExactInput { min_amount_out, .. }
+            | Self::AerodromeClExactInput { min_amount_out, .. } => *min_amount_out,
+        }
+    }
 }
 
 /// Default maximum gas price cap (1000 gwei).

--- a/crates/infra/load-tests/src/runner/config.rs
+++ b/crates/infra/load-tests/src/runner/config.rs
@@ -72,6 +72,10 @@ pub enum TxType {
         min_amount: U256,
         /// Maximum swap amount.
         max_amount: U256,
+        /// Minimum amount when swapping `token_out` to `token_in`.
+        reverse_min_amount: U256,
+        /// Maximum amount when swapping `token_out` to `token_in`.
+        reverse_max_amount: U256,
     },
     /// Aerodrome Slipstream (concentrated liquidity) swap.
     AerodromeCl {
@@ -87,7 +91,82 @@ pub enum TxType {
         min_amount: U256,
         /// Maximum swap amount.
         max_amount: U256,
+        /// Minimum amount when swapping `token_out` to `token_in`.
+        reverse_min_amount: U256,
+        /// Maximum amount when swapping `token_out` to `token_in`.
+        reverse_max_amount: U256,
     },
+}
+
+/// Real-token setup executed before measured swap workloads.
+#[derive(Debug, Clone)]
+pub struct RealTokenSetup {
+    /// Whether chain ID 8453 is allowed for this setup.
+    pub allow_chain_id_8453: bool,
+    /// WETH contract address.
+    pub weth: Address,
+    /// Target WETH balance to leave each sender with after setup.
+    pub weth_amount_per_sender: U256,
+    /// Non-WETH token setup for bidirectional swap parity.
+    pub pair_token: RealTokenPairTokenSetup,
+    /// Allowance amount to approve for each measured router.
+    pub approval_amount: U256,
+}
+
+/// Non-WETH side of the real-token pair.
+#[derive(Debug, Clone)]
+pub struct RealTokenPairTokenSetup {
+    /// Pair token contract address.
+    pub token: Address,
+    /// Target pair-token balance per sender.
+    pub amount_per_sender: U256,
+    /// How to acquire pair-token balances during setup.
+    pub acquisition: RealTokenAcquisition,
+}
+
+/// Explicit setup route for acquiring the pair token.
+#[derive(Debug, Clone)]
+pub enum RealTokenAcquisition {
+    /// Uniswap V3 `exactInputSingle` route.
+    UniswapV3ExactInput {
+        /// Router contract address.
+        router: Address,
+        /// Fee tier.
+        fee: u32,
+        /// WETH input amount per sender.
+        amount_in: U256,
+        /// Minimum pair-token output amount.
+        min_amount_out: U256,
+    },
+    /// Aerodrome Slipstream `exactInputSingle` route.
+    AerodromeClExactInput {
+        /// Router contract address.
+        router: Address,
+        /// Tick spacing.
+        tick_spacing: i32,
+        /// WETH input amount per sender.
+        amount_in: U256,
+        /// Minimum pair-token output amount.
+        min_amount_out: U256,
+    },
+}
+
+impl RealTokenAcquisition {
+    /// Returns the router used by this setup route.
+    pub const fn router(&self) -> Address {
+        match self {
+            Self::UniswapV3ExactInput { router, .. }
+            | Self::AerodromeClExactInput { router, .. } => *router,
+        }
+    }
+
+    /// Returns the input amount consumed by this setup route.
+    pub const fn amount_in(&self) -> U256 {
+        match self {
+            Self::UniswapV3ExactInput { amount_in, .. }
+            | Self::AerodromeClExactInput { amount_in, .. } => *amount_in,
+        }
+    }
 }
 
 /// Default maximum gas price cap (1000 gwei).

--- a/crates/infra/load-tests/src/runner/load_runner.rs
+++ b/crates/infra/load-tests/src/runner/load_runner.rs
@@ -8,9 +8,7 @@ use std::{
 };
 
 use alloy_network::{Ethereum, EthereumWallet, TransactionBuilder};
-use alloy_primitives::{
-    Address, B256, Bytes, Signed, TxHash, U160, U256, Uint, utils::format_ether,
-};
+use alloy_primitives::{Address, B256, Bytes, TxHash, U256, utils::format_ether};
 use alloy_provider::{Provider, RootProvider};
 use alloy_rpc_types::{BlockNumberOrTag, TransactionRequest};
 use alloy_signer_local::PrivateKeySigner;
@@ -29,20 +27,18 @@ use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info, instrument, warn};
 
 /// Maximum number of concurrent RPC requests during funding/draining operations.
-const FUNDING_CONCURRENCY: usize = 32;
+pub(super) const FUNDING_CONCURRENCY: usize = 32;
 
 /// Maximum number of TXs to send before waiting for confirmation.
 /// Kept below typical per-sender txpool limits (e.g. reth default is 16) to
 /// avoid "txpool is full" rejections when all TXs originate from one funder.
-const BATCH_SIZE: usize = 16;
-type U24 = Uint<24, 1>;
-type I24 = Signed<24, 1>;
+const FUNDING_BATCH_SIZE: usize = 16;
+const BATCH_SIZE: usize = FUNDING_BATCH_SIZE;
 
 use super::{
     BlockWatcher, DisplaySnapshot, FlashblockWatcher, LoadConfig, LoadTestDisplay, PreparedBatch,
-    PreparedTransaction, QueuedSubmitFailures, RateLimiter, RealTokenAcquisition,
-    RealTokenRecoverySummary, RealTokenSetup, ResultsTracker, SubmissionPipeline, SubmitEvent,
-    TxType,
+    PreparedTransaction, QueuedSubmitFailures, RateLimiter, ResultsTracker, SubmissionPipeline,
+    SubmitEvent, TxType,
 };
 use crate::{
     BaselineError, Result,
@@ -64,17 +60,12 @@ const SUBMIT_WORKER_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(12);
 const PENDING_CONFIRMATION_TIMEOUT: Duration = Duration::from_secs(60);
 const CONFIRMATION_DRAIN_TIMEOUT: Duration = Duration::from_secs(65);
 const TXPOOL_CLEAR_CONCURRENCY: usize = 64;
-const WETH_DEPOSIT_GAS_LIMIT: u64 = 100_000;
-const WETH_WITHDRAW_GAS_LIMIT: u64 = 45_000;
-const ERC20_APPROVE_GAS_LIMIT: u64 = 65_000;
-const SETUP_SWAP_GAS_LIMIT: u64 = 250_000;
-
 /// Executes load tests by generating and submitting transactions at a target rate.
 pub struct LoadRunner {
-    config: LoadConfig,
+    pub(super) config: LoadConfig,
     config_summary: Option<ConfigSummary>,
-    client: QueryProvider,
-    accounts: AccountPool,
+    pub(super) client: QueryProvider,
+    pub(super) accounts: AccountPool,
     generator: WorkloadGenerator,
     collector: MetricsCollector,
     stop_flag: Arc<AtomicBool>,
@@ -692,19 +683,6 @@ impl LoadRunner {
         routers.into_iter().collect()
     }
 
-    fn collect_real_token_setup_approvals(
-        &self,
-        setup: &RealTokenSetup,
-    ) -> Vec<(Address, Address)> {
-        let mut approvals = HashSet::new();
-        for router in self.collect_swap_routers() {
-            approvals.insert((setup.weth, router));
-            approvals.insert((setup.pair_token.token, router));
-        }
-        approvals.insert((setup.weth, setup.pair_token.acquisition.router()));
-        approvals.into_iter().collect()
-    }
-
     /// Clears pending transactions from all configured txpool nodes for every test sender.
     #[instrument(skip(self), fields(nodes = self.config.txpool_nodes.len(), accounts = self.accounts.len()))]
     pub async fn clear_txpools(&self) -> Result<u64> {
@@ -979,7 +957,7 @@ impl LoadRunner {
         Bytes::from(mintCall { to, amount }.abi_encode())
     }
 
-    fn encode_erc20_balance_of(account: Address) -> Bytes {
+    pub(super) fn encode_erc20_balance_of(account: Address) -> Bytes {
         sol! {
             function balanceOf(address account) external view returns (uint256);
         }
@@ -1443,472 +1421,6 @@ impl LoadRunner {
 
         info!(burned = burn_count, failed = burn_failed, "B-20 teardown complete");
         Ok(())
-    }
-
-    pub async fn setup_real_tokens(&mut self, setup: &RealTokenSetup) -> Result<()> {
-        if self.config.chain_id == 8453 && !setup.allow_chain_id_8453 {
-            return Err(BaselineError::Config(
-                "real-token setup on chain_id 8453 requires allow_chain_id_8453".into(),
-            ));
-        }
-
-        let swap_routers = self.collect_swap_routers();
-        if swap_routers.is_empty() {
-            return Err(BaselineError::Config(
-                "real-token setup requires at least one swap router".into(),
-            ));
-        }
-        let approval_targets = self.collect_real_token_setup_approvals(setup);
-
-        let gas_price = self.client.get_gas_price().await.rpc("get gas price")?;
-        let max_priority_fee = (gas_price / 10).max(1);
-        let max_fee =
-            gas_price.saturating_mul(2).max(max_priority_fee).min(self.config.max_gas_price);
-
-        let account_data: Vec<_> =
-            self.accounts.accounts().iter().map(|a| (a.address, a.signer.clone())).collect();
-        let client = self.client.clone();
-        let primary_submission_rpc = self.config.primary_submission_rpc().clone();
-        let chain_id = self.config.chain_id;
-        let setup = setup.clone();
-        let total_accounts = account_data.len();
-
-        info!(
-            accounts = total_accounts,
-            weth = %setup.weth,
-            pair_token = %setup.pair_token.token,
-            measured_routers = swap_routers.len(),
-            approval_targets = approval_targets.len(),
-            "setting up real-token swap balances"
-        );
-
-        let pb_setup = self.progress_bar(total_accounts as u64, "Setting up real tokens");
-        let setup_futs = account_data.into_iter().map(|(sender, signer)| {
-            let client = client.clone();
-            let primary_submission_rpc = primary_submission_rpc.clone();
-            let setup = setup.clone();
-            let approval_targets = approval_targets.clone();
-            async move {
-                let weth_balance = Self::read_erc20_balance(&client, setup.weth, sender).await?;
-                let pair_balance =
-                    Self::read_erc20_balance(&client, setup.pair_token.token, sender).await?;
-                let needs_pair_token = pair_balance < setup.pair_token.amount_per_sender;
-                let acquisition_amount = if needs_pair_token {
-                    setup.pair_token.acquisition.amount_in()
-                } else {
-                    U256::ZERO
-                };
-                let required_weth =
-                    setup.weth_amount_per_sender.saturating_add(acquisition_amount);
-                let deposit_deficit = required_weth.saturating_sub(weth_balance);
-
-                let mut approvals = Vec::new();
-                for (token, router) in &approval_targets {
-                    let allowance =
-                        Self::read_erc20_allowance(&client, *token, sender, *router).await?;
-                    if allowance < setup.approval_amount {
-                        approvals.push((*token, *router));
-                    }
-                }
-
-                let mut setup_gas_limit = approvals
-                    .len()
-                    .saturating_mul(ERC20_APPROVE_GAS_LIMIT as usize)
-                    as u64;
-                if deposit_deficit > U256::ZERO {
-                    setup_gas_limit = setup_gas_limit.saturating_add(WETH_DEPOSIT_GAS_LIMIT);
-                }
-                if needs_pair_token {
-                    setup_gas_limit = setup_gas_limit.saturating_add(SETUP_SWAP_GAS_LIMIT);
-                }
-
-                let native_balance = client
-                    .get_balance(sender)
-                    .block_id(BlockNumberOrTag::Pending.into())
-                    .await
-                    .rpc("get pending balance")?;
-                let setup_gas_cost = U256::from(setup_gas_limit).saturating_mul(U256::from(max_fee));
-                let total_setup_cost = deposit_deficit.saturating_add(setup_gas_cost);
-                if native_balance < total_setup_cost {
-                    return Err(BaselineError::Transaction(format!(
-                        "sender {} has insufficient balance for real-token setup: has {} ETH, needs {} ETH (deposit {} ETH + setup gas {} ETH)",
-                        sender,
-                        format_ether(native_balance),
-                        format_ether(total_setup_cost),
-                        format_ether(deposit_deficit),
-                        format_ether(setup_gas_cost),
-                    )));
-                }
-
-                let wallet = EthereumWallet::from(signer);
-                let provider = create_wallet_provider(primary_submission_rpc, wallet);
-                let mut nonce = provider
-                    .get_transaction_count(sender)
-                    .pending()
-                    .await
-                    .rpc("get pending transaction count")?;
-                let mut sent = 0usize;
-
-                if deposit_deficit > U256::ZERO {
-                    let tx = TransactionRequest::default()
-                        .with_to(setup.weth)
-                        .with_value(deposit_deficit)
-                        .with_input(Self::encode_weth_deposit())
-                        .with_nonce(nonce)
-                        .with_chain_id(chain_id)
-                        .with_gas_limit(WETH_DEPOSIT_GAS_LIMIT)
-                        .with_max_fee_per_gas(max_fee)
-                        .with_max_priority_fee_per_gas(max_priority_fee);
-                    let pending = provider.send_transaction(tx).await.rpc("send WETH deposit")?;
-                    debug!(
-                        sender = %sender,
-                        tx_hash = %pending.tx_hash(),
-                        amount = %deposit_deficit,
-                        "WETH deposit sent"
-                    );
-                    nonce += 1;
-                    sent += 1;
-                }
-
-                for (token, router) in approvals {
-                    let tx = TransactionRequest::default()
-                        .with_to(token)
-                        .with_input(Self::encode_erc20_approve(router, setup.approval_amount))
-                        .with_nonce(nonce)
-                        .with_chain_id(chain_id)
-                        .with_gas_limit(ERC20_APPROVE_GAS_LIMIT)
-                        .with_max_fee_per_gas(max_fee)
-                        .with_max_priority_fee_per_gas(max_priority_fee);
-                    let pending = provider.send_transaction(tx).await.rpc("send ERC20 approval")?;
-                    debug!(
-                        sender = %sender,
-                        token = %token,
-                        router = %router,
-                        tx_hash = %pending.tx_hash(),
-                        "router approval sent"
-                    );
-                    nonce += 1;
-                    sent += 1;
-                }
-
-                if needs_pair_token {
-                    let (router, data) = Self::encode_pair_token_acquisition(&setup, sender)?;
-                    let tx = TransactionRequest::default()
-                        .with_to(router)
-                        .with_input(data)
-                        .with_nonce(nonce)
-                        .with_chain_id(chain_id)
-                        .with_gas_limit(SETUP_SWAP_GAS_LIMIT)
-                        .with_max_fee_per_gas(max_fee)
-                        .with_max_priority_fee_per_gas(max_priority_fee);
-                    let pending = provider.send_transaction(tx).await.rpc("send setup swap")?;
-                    debug!(
-                        sender = %sender,
-                        router = %router,
-                        tx_hash = %pending.tx_hash(),
-                        "pair-token acquisition swap sent"
-                    );
-                    sent += 1;
-                }
-
-                Ok::<_, BaselineError>((sender, sent))
-            }
-        });
-
-        let setup_results: Vec<_> = stream::iter(setup_futs)
-            .buffer_unordered(FUNDING_CONCURRENCY)
-            .inspect(|_| pb_setup.inc(1))
-            .collect()
-            .await;
-        pb_setup.finish_and_clear();
-
-        let mut sent_total = 0usize;
-        for result in setup_results {
-            let (_, sent) = result?;
-            sent_total += sent;
-        }
-
-        let sender_addresses: Vec<Address> =
-            self.accounts.accounts().iter().map(|a| a.address).collect();
-
-        let mut weth_pending: Vec<_> =
-            sender_addresses.iter().map(|sender| (setup.weth, *sender)).collect();
-        let pb_weth = self.progress_bar(weth_pending.len() as u64, "Waiting for WETH balances");
-        Self::await_token_balances(
-            &self.client,
-            &mut weth_pending,
-            setup.weth_amount_per_sender,
-            &pb_weth,
-        )
-        .await?;
-        pb_weth.finish_and_clear();
-
-        let mut pair_pending: Vec<_> =
-            sender_addresses.iter().map(|sender| (setup.pair_token.token, *sender)).collect();
-        let pb_pair =
-            self.progress_bar(pair_pending.len() as u64, "Waiting for pair-token balances");
-        Self::await_token_balances(
-            &self.client,
-            &mut pair_pending,
-            setup.pair_token.amount_per_sender,
-            &pb_pair,
-        )
-        .await?;
-        pb_pair.finish_and_clear();
-
-        let mut allowance_pending = Vec::new();
-        for sender in &sender_addresses {
-            for (token, router) in &approval_targets {
-                allowance_pending.push((*token, *sender, *router));
-            }
-        }
-        let pb_allowance =
-            self.progress_bar(allowance_pending.len() as u64, "Waiting for router allowances");
-        Self::await_erc20_allowances(
-            &self.client,
-            &mut allowance_pending,
-            setup.approval_amount,
-            &pb_allowance,
-        )
-        .await?;
-        pb_allowance.finish_and_clear();
-
-        self.refresh_sender_state().await?;
-
-        info!(
-            accounts = total_accounts,
-            setup_transactions = sent_total,
-            "real-token setup complete"
-        );
-        Ok(())
-    }
-
-    async fn read_erc20_balance(
-        client: &QueryProvider,
-        token: Address,
-        owner: Address,
-    ) -> Result<U256> {
-        client
-            .call(
-                TransactionRequest::default()
-                    .with_to(token)
-                    .with_input(Self::encode_erc20_balance_of(owner))
-                    .into(),
-            )
-            .await
-            .rpc("eth_call balanceOf")
-            .map(|bytes| U256::from_be_slice(bytes.as_ref()))
-    }
-
-    async fn read_erc20_allowance(
-        client: &QueryProvider,
-        token: Address,
-        owner: Address,
-        spender: Address,
-    ) -> Result<U256> {
-        client
-            .call(
-                TransactionRequest::default()
-                    .with_to(token)
-                    .with_input(Self::encode_erc20_allowance(owner, spender))
-                    .into(),
-            )
-            .await
-            .rpc("eth_call allowance")
-            .map(|bytes| U256::from_be_slice(bytes.as_ref()))
-    }
-
-    fn encode_weth_deposit() -> Bytes {
-        sol! {
-            function deposit() external payable;
-        }
-        Bytes::from(depositCall {}.abi_encode())
-    }
-
-    fn encode_weth_withdraw(amount: U256) -> Bytes {
-        sol! {
-            function withdraw(uint256 wad) external;
-        }
-        Bytes::from(withdrawCall { wad: amount }.abi_encode())
-    }
-
-    fn encode_erc20_approve(spender: Address, amount: U256) -> Bytes {
-        sol! {
-            function approve(address spender, uint256 amount) external returns (bool);
-        }
-        Bytes::from(approveCall { spender, amount }.abi_encode())
-    }
-
-    fn encode_erc20_allowance(owner: Address, spender: Address) -> Bytes {
-        sol! {
-            function allowance(address owner, address spender) external view returns (uint256);
-        }
-        Bytes::from(allowanceCall { owner, spender }.abi_encode())
-    }
-
-    fn encode_pair_token_acquisition(
-        setup: &RealTokenSetup,
-        recipient: Address,
-    ) -> Result<(Address, Bytes)> {
-        match &setup.pair_token.acquisition {
-            RealTokenAcquisition::UniswapV3ExactInput {
-                router,
-                fee,
-                amount_in,
-                min_amount_out,
-            } => {
-                sol! {
-                    interface ISetupUniswapV3Router {
-                        struct ExactInputSingleParams {
-                            address tokenIn;
-                            address tokenOut;
-                            uint24 fee;
-                            address recipient;
-                            uint256 amountIn;
-                            uint256 amountOutMinimum;
-                            uint160 sqrtPriceLimitX96;
-                        }
-
-                        function exactInputSingle(
-                            ExactInputSingleParams calldata params
-                        ) external payable returns (uint256 amountOut);
-                    }
-                }
-                let call = ISetupUniswapV3Router::exactInputSingleCall {
-                    params: ISetupUniswapV3Router::ExactInputSingleParams {
-                        tokenIn: setup.weth,
-                        tokenOut: setup.pair_token.token,
-                        fee: U24::from(*fee),
-                        recipient,
-                        amountIn: *amount_in,
-                        amountOutMinimum: *min_amount_out,
-                        sqrtPriceLimitX96: U160::ZERO,
-                    },
-                };
-                Ok((*router, Bytes::from(call.abi_encode())))
-            }
-            RealTokenAcquisition::AerodromeClExactInput {
-                router,
-                tick_spacing,
-                amount_in,
-                min_amount_out,
-            } => {
-                sol! {
-                    interface ISetupAerodromeClRouter {
-                        struct ExactInputSingleParams {
-                            address tokenIn;
-                            address tokenOut;
-                            int24 tickSpacing;
-                            address recipient;
-                            uint256 deadline;
-                            uint256 amountIn;
-                            uint256 amountOutMinimum;
-                            uint160 sqrtPriceLimitX96;
-                        }
-
-                        function exactInputSingle(
-                            ExactInputSingleParams calldata params
-                        ) external payable returns (uint256 amountOut);
-                    }
-                }
-                let tick_spacing = I24::try_from(*tick_spacing).map_err(|e| {
-                    BaselineError::Config(format!(
-                        "real-token setup tick spacing does not fit i24: {e}"
-                    ))
-                })?;
-                let call = ISetupAerodromeClRouter::exactInputSingleCall {
-                    params: ISetupAerodromeClRouter::ExactInputSingleParams {
-                        tokenIn: setup.weth,
-                        tokenOut: setup.pair_token.token,
-                        tickSpacing: tick_spacing,
-                        recipient,
-                        deadline: U256::from(u64::MAX),
-                        amountIn: *amount_in,
-                        amountOutMinimum: *min_amount_out,
-                        sqrtPriceLimitX96: U160::ZERO,
-                    },
-                };
-                Ok((*router, Bytes::from(call.abi_encode())))
-            }
-        }
-    }
-
-    fn encode_pair_token_recovery(
-        setup: &RealTokenSetup,
-        recipient: Address,
-        amount_in: U256,
-    ) -> Result<(Address, Bytes)> {
-        match &setup.pair_token.acquisition {
-            RealTokenAcquisition::UniswapV3ExactInput { router, fee, .. } => {
-                sol! {
-                    interface IRecoverUniswapV3Router {
-                        struct ExactInputSingleParams {
-                            address tokenIn;
-                            address tokenOut;
-                            uint24 fee;
-                            address recipient;
-                            uint256 amountIn;
-                            uint256 amountOutMinimum;
-                            uint160 sqrtPriceLimitX96;
-                        }
-
-                        function exactInputSingle(
-                            ExactInputSingleParams calldata params
-                        ) external payable returns (uint256 amountOut);
-                    }
-                }
-                let call = IRecoverUniswapV3Router::exactInputSingleCall {
-                    params: IRecoverUniswapV3Router::ExactInputSingleParams {
-                        tokenIn: setup.pair_token.token,
-                        tokenOut: setup.weth,
-                        fee: U24::from(*fee),
-                        recipient,
-                        amountIn: amount_in,
-                        amountOutMinimum: U256::ZERO,
-                        sqrtPriceLimitX96: U160::ZERO,
-                    },
-                };
-                Ok((*router, Bytes::from(call.abi_encode())))
-            }
-            RealTokenAcquisition::AerodromeClExactInput { router, tick_spacing, .. } => {
-                sol! {
-                    interface IRecoverAerodromeClRouter {
-                        struct ExactInputSingleParams {
-                            address tokenIn;
-                            address tokenOut;
-                            int24 tickSpacing;
-                            address recipient;
-                            uint256 deadline;
-                            uint256 amountIn;
-                            uint256 amountOutMinimum;
-                            uint160 sqrtPriceLimitX96;
-                        }
-
-                        function exactInputSingle(
-                            ExactInputSingleParams calldata params
-                        ) external payable returns (uint256 amountOut);
-                    }
-                }
-                let tick_spacing = I24::try_from(*tick_spacing).map_err(|e| {
-                    BaselineError::Config(format!(
-                        "real-token recovery tick spacing does not fit i24: {e}"
-                    ))
-                })?;
-                let call = IRecoverAerodromeClRouter::exactInputSingleCall {
-                    params: IRecoverAerodromeClRouter::ExactInputSingleParams {
-                        tokenIn: setup.pair_token.token,
-                        tokenOut: setup.weth,
-                        tickSpacing: tick_spacing,
-                        recipient,
-                        deadline: U256::from(u64::MAX),
-                        amountIn: amount_in,
-                        amountOutMinimum: U256::ZERO,
-                        sqrtPriceLimitX96: U160::ZERO,
-                    },
-                };
-                Ok((*router, Bytes::from(call.abi_encode())))
-            }
-        }
     }
 
     /// Runs the load test and returns metrics summary.
@@ -2429,182 +1941,6 @@ impl LoadRunner {
         }
     }
 
-    /// Recovers real-token balances by swapping the configured pair token back
-    /// into WETH, unwrapping WETH to native ETH, and leaving native drain to
-    /// [`Self::drain_accounts`].
-    pub async fn recover_real_tokens(
-        &self,
-        setup: &RealTokenSetup,
-    ) -> Result<RealTokenRecoverySummary> {
-        let client = self.client.clone();
-        let primary_submission_rpc = self.config.primary_submission_rpc().clone();
-        let chain_id = self.config.chain_id;
-
-        let gas_price = client.get_gas_price().await.rpc("get gas price")?;
-        let max_priority_fee = (gas_price / 10).max(1);
-        let max_fee =
-            gas_price.saturating_mul(2).max(max_priority_fee).min(self.config.max_gas_price);
-
-        let account_data: Vec<_> =
-            self.accounts.accounts().iter().map(|a| (a.address, a.signer.clone())).collect();
-        let total_accounts = account_data.len();
-        let pb_recover = self.progress_bar(total_accounts as u64, "Recovering real tokens");
-
-        let recover_futs: Vec<_> = account_data
-            .into_iter()
-            .map(|(sender, signer)| {
-                let client = client.clone();
-                let primary_submission_rpc = primary_submission_rpc.clone();
-                let setup = setup.clone();
-                async move {
-                    let mut summary = RealTokenRecoverySummary::default();
-                    let wallet = EthereumWallet::from(signer);
-                    let provider = create_wallet_provider(primary_submission_rpc, wallet);
-                    let mut nonce = provider
-                        .get_transaction_count(sender)
-                        .pending()
-                        .await
-                        .rpc("get pending transaction count")?;
-
-                    let pair_balance =
-                        Self::read_erc20_balance(&client, setup.pair_token.token, sender).await?;
-                    if pair_balance > U256::ZERO {
-                        let recovery_router = setup.pair_token.acquisition.router();
-                        let allowance = Self::read_erc20_allowance(
-                            &client,
-                            setup.pair_token.token,
-                            sender,
-                            recovery_router,
-                        )
-                        .await?;
-
-                        if allowance < pair_balance {
-                            let approval_amount = if setup.approval_amount > pair_balance {
-                                setup.approval_amount
-                            } else {
-                                pair_balance
-                            };
-                            let tx = TransactionRequest::default()
-                                .with_to(setup.pair_token.token)
-                                .with_input(Self::encode_erc20_approve(
-                                    recovery_router,
-                                    approval_amount,
-                                ))
-                                .with_nonce(nonce)
-                                .with_chain_id(chain_id)
-                                .with_gas_limit(ERC20_APPROVE_GAS_LIMIT)
-                                .with_max_fee_per_gas(max_fee)
-                                .with_max_priority_fee_per_gas(max_priority_fee);
-                            let pending =
-                                provider.send_transaction(tx).await.rpc("send pair approval")?;
-                            debug!(
-                                sender = %sender,
-                                token = %setup.pair_token.token,
-                                router = %recovery_router,
-                                tx_hash = %pending.tx_hash(),
-                                "recovery pair-token approval sent"
-                            );
-                            let receipt =
-                                pending.get_receipt().await.rpc("confirm pair approval")?;
-                            if !receipt.status() {
-                                return Err(BaselineError::Transaction(format!(
-                                    "pair-token approval reverted for sender {sender}"
-                                )));
-                            }
-                            nonce += 1;
-                        }
-
-                        let (router, data) =
-                            Self::encode_pair_token_recovery(&setup, sender, pair_balance)?;
-                        let tx = TransactionRequest::default()
-                            .with_to(router)
-                            .with_input(data)
-                            .with_nonce(nonce)
-                            .with_chain_id(chain_id)
-                            .with_gas_limit(SETUP_SWAP_GAS_LIMIT)
-                            .with_max_fee_per_gas(max_fee)
-                            .with_max_priority_fee_per_gas(max_priority_fee);
-                        let pending = provider
-                            .send_transaction(tx)
-                            .await
-                            .rpc("send pair-token recovery swap")?;
-                        debug!(
-                            sender = %sender,
-                            router = %router,
-                            amount = %pair_balance,
-                            tx_hash = %pending.tx_hash(),
-                            "pair-token recovery swap sent"
-                        );
-                        let receipt =
-                            pending.get_receipt().await.rpc("confirm pair-token recovery swap")?;
-                        if !receipt.status() {
-                            return Err(BaselineError::Transaction(format!(
-                                "pair-token recovery swap reverted for sender {sender}"
-                            )));
-                        }
-                        nonce += 1;
-                        summary.pair_token_swapped =
-                            summary.pair_token_swapped.saturating_add(pair_balance);
-                    }
-
-                    let weth_balance =
-                        Self::read_erc20_balance(&client, setup.weth, sender).await?;
-                    if weth_balance > U256::ZERO {
-                        let tx = TransactionRequest::default()
-                            .with_to(setup.weth)
-                            .with_input(Self::encode_weth_withdraw(weth_balance))
-                            .with_nonce(nonce)
-                            .with_chain_id(chain_id)
-                            .with_gas_limit(WETH_WITHDRAW_GAS_LIMIT)
-                            .with_max_fee_per_gas(max_fee)
-                            .with_max_priority_fee_per_gas(max_priority_fee);
-                        let pending =
-                            provider.send_transaction(tx).await.rpc("send WETH withdraw")?;
-                        debug!(
-                            sender = %sender,
-                            amount = %weth_balance,
-                            tx_hash = %pending.tx_hash(),
-                            "recovery WETH withdraw sent"
-                        );
-                        let receipt = pending.get_receipt().await.rpc("confirm WETH withdraw")?;
-                        if !receipt.status() {
-                            return Err(BaselineError::Transaction(format!(
-                                "WETH withdraw reverted for sender {sender}"
-                            )));
-                        }
-                        summary.weth_unwrapped =
-                            summary.weth_unwrapped.saturating_add(weth_balance);
-                    }
-
-                    Ok::<_, BaselineError>(summary)
-                }
-            })
-            .collect();
-
-        let recover_results: Vec<_> = stream::iter(recover_futs)
-            .buffer_unordered(FUNDING_CONCURRENCY)
-            .inspect(|_| pb_recover.inc(1))
-            .collect()
-            .await;
-        pb_recover.finish_and_clear();
-
-        let mut summary = RealTokenRecoverySummary::default();
-        for result in recover_results {
-            let account_summary = result?;
-            summary.pair_token_swapped =
-                summary.pair_token_swapped.saturating_add(account_summary.pair_token_swapped);
-            summary.weth_unwrapped =
-                summary.weth_unwrapped.saturating_add(account_summary.weth_unwrapped);
-        }
-
-        info!(
-            pair_token_swapped = %summary.pair_token_swapped,
-            weth_unwrapped = %summary.weth_unwrapped,
-            "real-token recovery complete"
-        );
-        Ok(summary)
-    }
-
     /// Drains all test account balances back to the funder address.
     ///
     /// Each account sends its entire balance minus gas costs back to the funder.
@@ -2728,7 +2064,7 @@ impl LoadRunner {
         Ok(total_drained)
     }
 
-    fn progress_bar(&self, total: u64, prefix: &str) -> ProgressBar {
+    pub(super) fn progress_bar(&self, total: u64, prefix: &str) -> ProgressBar {
         if self.snapshot_tx.is_some() {
             return ProgressBar::hidden();
         }
@@ -2788,7 +2124,7 @@ impl LoadRunner {
     }
 
     /// Waits for token balances to reach a target after mint/distribution transactions.
-    async fn await_token_balances(
+    pub(super) async fn await_token_balances(
         client: &QueryProvider,
         pending_accounts: &mut Vec<(Address, Address)>,
         target_balance: U256,
@@ -2841,57 +2177,7 @@ impl LoadRunner {
         Ok(settled)
     }
 
-    /// Waits for ERC20 allowances to reach a target.
-    async fn await_erc20_allowances(
-        client: &QueryProvider,
-        pending_allowances: &mut Vec<(Address, Address, Address)>,
-        target_allowance: U256,
-        pb: &ProgressBar,
-    ) -> Result<usize> {
-        let timeout = Duration::from_secs(60);
-        let poll_interval = Duration::from_millis(500);
-        let start = Instant::now();
-        let mut settled = 0usize;
-
-        while !pending_allowances.is_empty() && start.elapsed() < timeout {
-            tokio::time::sleep(poll_interval).await;
-
-            let mut still_pending = Vec::new();
-            for (token, owner, spender) in pending_allowances.drain(..) {
-                match Self::read_erc20_allowance(client, token, owner, spender).await {
-                    Ok(allowance) if allowance >= target_allowance => {
-                        debug!(token = %token, owner = %owner, spender = %spender, "allowance settled");
-                        settled += 1;
-                        pb.inc(1);
-                    }
-                    Ok(_) => {
-                        still_pending.push((token, owner, spender));
-                    }
-                    Err(e) => {
-                        warn!(
-                            token = %token,
-                            owner = %owner,
-                            spender = %spender,
-                            error = %e,
-                            "failed to check allowance"
-                        );
-                        still_pending.push((token, owner, spender));
-                    }
-                }
-            }
-            *pending_allowances = still_pending;
-        }
-
-        if !pending_allowances.is_empty() {
-            return Err(BaselineError::Transaction(format!(
-                "allowances did not reach target within timeout: {pending_allowances:?}"
-            )));
-        }
-
-        Ok(settled)
-    }
-
-    async fn refresh_sender_state(&mut self) -> Result<()> {
+    pub(super) async fn refresh_sender_state(&mut self) -> Result<()> {
         let total_accounts = self.accounts.len();
         let client = self.client.clone();
         let pb_refresh = self.progress_bar(total_accounts as u64, "Refreshing account state");

--- a/crates/infra/load-tests/src/runner/load_runner.rs
+++ b/crates/infra/load-tests/src/runner/load_runner.rs
@@ -40,8 +40,9 @@ type I24 = Signed<24, 1>;
 
 use super::{
     BlockWatcher, DisplaySnapshot, FlashblockWatcher, LoadConfig, LoadTestDisplay, PreparedBatch,
-    PreparedTransaction, QueuedSubmitFailures, RateLimiter, ResultsTracker, SubmissionPipeline,
-    SubmitEvent, TxType,
+    PreparedTransaction, QueuedSubmitFailures, RateLimiter, RealTokenAcquisition,
+    RealTokenRecoverySummary, RealTokenSetup, ResultsTracker, SubmissionPipeline, SubmitEvent,
+    TxType,
 };
 use crate::{
     BaselineError, Result,
@@ -63,6 +64,10 @@ const SUBMIT_WORKER_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(12);
 const PENDING_CONFIRMATION_TIMEOUT: Duration = Duration::from_secs(60);
 const CONFIRMATION_DRAIN_TIMEOUT: Duration = Duration::from_secs(65);
 const TXPOOL_CLEAR_CONCURRENCY: usize = 64;
+const WETH_DEPOSIT_GAS_LIMIT: u64 = 100_000;
+const WETH_WITHDRAW_GAS_LIMIT: u64 = 45_000;
+const ERC20_APPROVE_GAS_LIMIT: u64 = 65_000;
+const SETUP_SWAP_GAS_LIMIT: u64 = 250_000;
 
 /// Executes load tests by generating and submitting transactions at a target rate.
 pub struct LoadRunner {
@@ -626,6 +631,8 @@ impl LoadRunner {
         let addr_to_idx: HashMap<Address, usize> =
             self.accounts.accounts().iter().enumerate().map(|(i, a)| (a.address, i)).collect();
 
+        let refresh_provider = RootProvider::<Ethereum>::new_http(self.config.query_rpc.clone());
+
         for result in refresh_results {
             let (addr, balance, account_nonce) = result?;
             let idx = addr_to_idx[&addr];
@@ -633,9 +640,9 @@ impl LoadRunner {
             account.balance = balance;
             account.nonce = account_nonce;
 
-            let provider = RootProvider::<Ethereum>::new_http(self.config.query_rpc.clone());
             let nonce_manager =
-                NonceManager::new(provider, addr, NONCE_RPC_TIMEOUT).with_pending_tag();
+                NonceManager::new(refresh_provider.clone(), addr, NONCE_RPC_TIMEOUT)
+                    .with_pending_tag();
             Arc::make_mut(&mut self.nonce_managers).insert(addr, nonce_manager);
 
             debug!(address = %addr, balance = %balance, nonce = account_nonce, "account state refreshed");
@@ -1718,6 +1725,13 @@ impl LoadRunner {
         Bytes::from(depositCall {}.abi_encode())
     }
 
+    fn encode_weth_withdraw(amount: U256) -> Bytes {
+        sol! {
+            function withdraw(uint256 wad) external;
+        }
+        Bytes::from(withdrawCall { wad: amount }.abi_encode())
+    }
+
     fn encode_erc20_approve(spender: Address, amount: U256) -> Bytes {
         sol! {
             function approve(address spender, uint256 amount) external returns (bool);
@@ -1811,6 +1825,84 @@ impl LoadRunner {
                         deadline: U256::from(u64::MAX),
                         amountIn: *amount_in,
                         amountOutMinimum: *min_amount_out,
+                        sqrtPriceLimitX96: U160::ZERO,
+                    },
+                };
+                Ok((*router, Bytes::from(call.abi_encode())))
+            }
+        }
+    }
+
+    fn encode_pair_token_recovery(
+        setup: &RealTokenSetup,
+        recipient: Address,
+        amount_in: U256,
+    ) -> Result<(Address, Bytes)> {
+        match &setup.pair_token.acquisition {
+            RealTokenAcquisition::UniswapV3ExactInput { router, fee, .. } => {
+                sol! {
+                    interface IRecoverUniswapV3Router {
+                        struct ExactInputSingleParams {
+                            address tokenIn;
+                            address tokenOut;
+                            uint24 fee;
+                            address recipient;
+                            uint256 amountIn;
+                            uint256 amountOutMinimum;
+                            uint160 sqrtPriceLimitX96;
+                        }
+
+                        function exactInputSingle(
+                            ExactInputSingleParams calldata params
+                        ) external payable returns (uint256 amountOut);
+                    }
+                }
+                let call = IRecoverUniswapV3Router::exactInputSingleCall {
+                    params: IRecoverUniswapV3Router::ExactInputSingleParams {
+                        tokenIn: setup.pair_token.token,
+                        tokenOut: setup.weth,
+                        fee: U24::from(*fee),
+                        recipient,
+                        amountIn: amount_in,
+                        amountOutMinimum: U256::ZERO,
+                        sqrtPriceLimitX96: U160::ZERO,
+                    },
+                };
+                Ok((*router, Bytes::from(call.abi_encode())))
+            }
+            RealTokenAcquisition::AerodromeClExactInput { router, tick_spacing, .. } => {
+                sol! {
+                    interface IRecoverAerodromeClRouter {
+                        struct ExactInputSingleParams {
+                            address tokenIn;
+                            address tokenOut;
+                            int24 tickSpacing;
+                            address recipient;
+                            uint256 deadline;
+                            uint256 amountIn;
+                            uint256 amountOutMinimum;
+                            uint160 sqrtPriceLimitX96;
+                        }
+
+                        function exactInputSingle(
+                            ExactInputSingleParams calldata params
+                        ) external payable returns (uint256 amountOut);
+                    }
+                }
+                let tick_spacing = I24::try_from(*tick_spacing).map_err(|e| {
+                    BaselineError::Config(format!(
+                        "real-token recovery tick spacing does not fit i24: {e}"
+                    ))
+                })?;
+                let call = IRecoverAerodromeClRouter::exactInputSingleCall {
+                    params: IRecoverAerodromeClRouter::ExactInputSingleParams {
+                        tokenIn: setup.pair_token.token,
+                        tokenOut: setup.weth,
+                        tickSpacing: tick_spacing,
+                        recipient,
+                        deadline: U256::from(u64::MAX),
+                        amountIn: amount_in,
+                        amountOutMinimum: U256::ZERO,
                         sqrtPriceLimitX96: U160::ZERO,
                     },
                 };
@@ -2337,6 +2429,182 @@ impl LoadRunner {
         }
     }
 
+    /// Recovers real-token balances by swapping the configured pair token back
+    /// into WETH, unwrapping WETH to native ETH, and leaving native drain to
+    /// [`Self::drain_accounts`].
+    pub async fn recover_real_tokens(
+        &self,
+        setup: &RealTokenSetup,
+    ) -> Result<RealTokenRecoverySummary> {
+        let client = self.client.clone();
+        let primary_submission_rpc = self.config.primary_submission_rpc().clone();
+        let chain_id = self.config.chain_id;
+
+        let gas_price = client.get_gas_price().await.rpc("get gas price")?;
+        let max_priority_fee = (gas_price / 10).max(1);
+        let max_fee =
+            gas_price.saturating_mul(2).max(max_priority_fee).min(self.config.max_gas_price);
+
+        let account_data: Vec<_> =
+            self.accounts.accounts().iter().map(|a| (a.address, a.signer.clone())).collect();
+        let total_accounts = account_data.len();
+        let pb_recover = self.progress_bar(total_accounts as u64, "Recovering real tokens");
+
+        let recover_futs: Vec<_> = account_data
+            .into_iter()
+            .map(|(sender, signer)| {
+                let client = client.clone();
+                let primary_submission_rpc = primary_submission_rpc.clone();
+                let setup = setup.clone();
+                async move {
+                    let mut summary = RealTokenRecoverySummary::default();
+                    let wallet = EthereumWallet::from(signer);
+                    let provider = create_wallet_provider(primary_submission_rpc, wallet);
+                    let mut nonce = provider
+                        .get_transaction_count(sender)
+                        .pending()
+                        .await
+                        .rpc("get pending transaction count")?;
+
+                    let pair_balance =
+                        Self::read_erc20_balance(&client, setup.pair_token.token, sender).await?;
+                    if pair_balance > U256::ZERO {
+                        let recovery_router = setup.pair_token.acquisition.router();
+                        let allowance = Self::read_erc20_allowance(
+                            &client,
+                            setup.pair_token.token,
+                            sender,
+                            recovery_router,
+                        )
+                        .await?;
+
+                        if allowance < pair_balance {
+                            let approval_amount = if setup.approval_amount > pair_balance {
+                                setup.approval_amount
+                            } else {
+                                pair_balance
+                            };
+                            let tx = TransactionRequest::default()
+                                .with_to(setup.pair_token.token)
+                                .with_input(Self::encode_erc20_approve(
+                                    recovery_router,
+                                    approval_amount,
+                                ))
+                                .with_nonce(nonce)
+                                .with_chain_id(chain_id)
+                                .with_gas_limit(ERC20_APPROVE_GAS_LIMIT)
+                                .with_max_fee_per_gas(max_fee)
+                                .with_max_priority_fee_per_gas(max_priority_fee);
+                            let pending =
+                                provider.send_transaction(tx).await.rpc("send pair approval")?;
+                            debug!(
+                                sender = %sender,
+                                token = %setup.pair_token.token,
+                                router = %recovery_router,
+                                tx_hash = %pending.tx_hash(),
+                                "recovery pair-token approval sent"
+                            );
+                            let receipt =
+                                pending.get_receipt().await.rpc("confirm pair approval")?;
+                            if !receipt.status() {
+                                return Err(BaselineError::Transaction(format!(
+                                    "pair-token approval reverted for sender {sender}"
+                                )));
+                            }
+                            nonce += 1;
+                        }
+
+                        let (router, data) =
+                            Self::encode_pair_token_recovery(&setup, sender, pair_balance)?;
+                        let tx = TransactionRequest::default()
+                            .with_to(router)
+                            .with_input(data)
+                            .with_nonce(nonce)
+                            .with_chain_id(chain_id)
+                            .with_gas_limit(SETUP_SWAP_GAS_LIMIT)
+                            .with_max_fee_per_gas(max_fee)
+                            .with_max_priority_fee_per_gas(max_priority_fee);
+                        let pending = provider
+                            .send_transaction(tx)
+                            .await
+                            .rpc("send pair-token recovery swap")?;
+                        debug!(
+                            sender = %sender,
+                            router = %router,
+                            amount = %pair_balance,
+                            tx_hash = %pending.tx_hash(),
+                            "pair-token recovery swap sent"
+                        );
+                        let receipt =
+                            pending.get_receipt().await.rpc("confirm pair-token recovery swap")?;
+                        if !receipt.status() {
+                            return Err(BaselineError::Transaction(format!(
+                                "pair-token recovery swap reverted for sender {sender}"
+                            )));
+                        }
+                        nonce += 1;
+                        summary.pair_token_swapped =
+                            summary.pair_token_swapped.saturating_add(pair_balance);
+                    }
+
+                    let weth_balance =
+                        Self::read_erc20_balance(&client, setup.weth, sender).await?;
+                    if weth_balance > U256::ZERO {
+                        let tx = TransactionRequest::default()
+                            .with_to(setup.weth)
+                            .with_input(Self::encode_weth_withdraw(weth_balance))
+                            .with_nonce(nonce)
+                            .with_chain_id(chain_id)
+                            .with_gas_limit(WETH_WITHDRAW_GAS_LIMIT)
+                            .with_max_fee_per_gas(max_fee)
+                            .with_max_priority_fee_per_gas(max_priority_fee);
+                        let pending =
+                            provider.send_transaction(tx).await.rpc("send WETH withdraw")?;
+                        debug!(
+                            sender = %sender,
+                            amount = %weth_balance,
+                            tx_hash = %pending.tx_hash(),
+                            "recovery WETH withdraw sent"
+                        );
+                        let receipt = pending.get_receipt().await.rpc("confirm WETH withdraw")?;
+                        if !receipt.status() {
+                            return Err(BaselineError::Transaction(format!(
+                                "WETH withdraw reverted for sender {sender}"
+                            )));
+                        }
+                        summary.weth_unwrapped =
+                            summary.weth_unwrapped.saturating_add(weth_balance);
+                    }
+
+                    Ok::<_, BaselineError>(summary)
+                }
+            })
+            .collect();
+
+        let recover_results: Vec<_> = stream::iter(recover_futs)
+            .buffer_unordered(FUNDING_CONCURRENCY)
+            .inspect(|_| pb_recover.inc(1))
+            .collect()
+            .await;
+        pb_recover.finish_and_clear();
+
+        let mut summary = RealTokenRecoverySummary::default();
+        for result in recover_results {
+            let account_summary = result?;
+            summary.pair_token_swapped =
+                summary.pair_token_swapped.saturating_add(account_summary.pair_token_swapped);
+            summary.weth_unwrapped =
+                summary.weth_unwrapped.saturating_add(account_summary.weth_unwrapped);
+        }
+
+        info!(
+            pair_token_swapped = %summary.pair_token_swapped,
+            weth_unwrapped = %summary.weth_unwrapped,
+            "real-token recovery complete"
+        );
+        Ok(summary)
+    }
+
     /// Drains all test account balances back to the funder address.
     ///
     /// Each account sends its entire balance minus gas costs back to the funder.
@@ -2654,6 +2922,8 @@ impl LoadRunner {
         let addr_to_idx: HashMap<Address, usize> =
             self.accounts.accounts().iter().enumerate().map(|(i, a)| (a.address, i)).collect();
 
+        let refresh_provider = RootProvider::<Ethereum>::new_http(self.config.query_rpc.clone());
+
         for result in refresh_results {
             let (addr, balance, account_nonce) = result?;
             let idx = addr_to_idx[&addr];
@@ -2661,9 +2931,9 @@ impl LoadRunner {
             account.balance = balance;
             account.nonce = account_nonce;
 
-            let provider = RootProvider::<Ethereum>::new_http(self.config.query_rpc.clone());
             let nonce_manager =
-                NonceManager::new(provider, addr, NONCE_RPC_TIMEOUT).with_pending_tag();
+                NonceManager::new(refresh_provider.clone(), addr, NONCE_RPC_TIMEOUT)
+                    .with_pending_tag();
             Arc::make_mut(&mut self.nonce_managers).insert(addr, nonce_manager);
 
             debug!(address = %addr, balance = %balance, nonce = account_nonce, "account state refreshed");

--- a/crates/infra/load-tests/src/runner/load_runner.rs
+++ b/crates/infra/load-tests/src/runner/load_runner.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     sync::{
         Arc,
         atomic::{AtomicBool, AtomicU64, Ordering},
@@ -8,7 +8,9 @@ use std::{
 };
 
 use alloy_network::{Ethereum, EthereumWallet, TransactionBuilder};
-use alloy_primitives::{Address, B256, Bytes, TxHash, U256, utils::format_ether};
+use alloy_primitives::{
+    Address, B256, Bytes, Signed, TxHash, U160, U256, Uint, utils::format_ether,
+};
 use alloy_provider::{Provider, RootProvider};
 use alloy_rpc_types::{BlockNumberOrTag, TransactionRequest};
 use alloy_signer_local::PrivateKeySigner;
@@ -33,6 +35,8 @@ const FUNDING_CONCURRENCY: usize = 32;
 /// Kept below typical per-sender txpool limits (e.g. reth default is 16) to
 /// avoid "txpool is full" rejections when all TXs originate from one funder.
 const BATCH_SIZE: usize = 16;
+type U24 = Uint<24, 1>;
+type I24 = Signed<24, 1>;
 
 use super::{
     BlockWatcher, DisplaySnapshot, FlashblockWatcher, LoadConfig, LoadTestDisplay, PreparedBatch,
@@ -643,7 +647,7 @@ impl LoadRunner {
 
     /// Collects unique token addresses from configured swap transaction types.
     pub fn collect_swap_tokens(&self) -> Vec<Address> {
-        let mut tokens = std::collections::HashSet::new();
+        let mut tokens = HashSet::new();
         for tx_config in &self.config.transactions {
             match &tx_config.tx_type {
                 TxType::UniswapV3 { token_in, token_out, .. }
@@ -660,6 +664,38 @@ impl LoadRunner {
             }
         }
         tokens.into_iter().collect()
+    }
+
+    /// Collects unique router addresses from configured swap transaction types.
+    pub fn collect_swap_routers(&self) -> Vec<Address> {
+        let mut routers = HashSet::new();
+        for tx_config in &self.config.transactions {
+            match &tx_config.tx_type {
+                TxType::UniswapV3 { router, .. } | TxType::AerodromeCl { router, .. } => {
+                    routers.insert(*router);
+                }
+                TxType::Transfer
+                | TxType::Calldata { .. }
+                | TxType::Erc20 { .. }
+                | TxType::B20 { .. }
+                | TxType::Precompile { .. }
+                | TxType::Osaka { .. } => {}
+            }
+        }
+        routers.into_iter().collect()
+    }
+
+    fn collect_real_token_setup_approvals(
+        &self,
+        setup: &RealTokenSetup,
+    ) -> Vec<(Address, Address)> {
+        let mut approvals = HashSet::new();
+        for router in self.collect_swap_routers() {
+            approvals.insert((setup.weth, router));
+            approvals.insert((setup.pair_token.token, router));
+        }
+        approvals.insert((setup.weth, setup.pair_token.acquisition.router()));
+        approvals.into_iter().collect()
     }
 
     /// Clears pending transactions from all configured txpool nodes for every test sender.
@@ -1400,6 +1436,387 @@ impl LoadRunner {
 
         info!(burned = burn_count, failed = burn_failed, "B-20 teardown complete");
         Ok(())
+    }
+
+    pub async fn setup_real_tokens(&mut self, setup: &RealTokenSetup) -> Result<()> {
+        if self.config.chain_id == 8453 && !setup.allow_chain_id_8453 {
+            return Err(BaselineError::Config(
+                "real-token setup on chain_id 8453 requires allow_chain_id_8453".into(),
+            ));
+        }
+
+        let swap_routers = self.collect_swap_routers();
+        if swap_routers.is_empty() {
+            return Err(BaselineError::Config(
+                "real-token setup requires at least one swap router".into(),
+            ));
+        }
+        let approval_targets = self.collect_real_token_setup_approvals(setup);
+
+        let gas_price = self.client.get_gas_price().await.rpc("get gas price")?;
+        let max_priority_fee = (gas_price / 10).max(1);
+        let max_fee =
+            gas_price.saturating_mul(2).max(max_priority_fee).min(self.config.max_gas_price);
+
+        let account_data: Vec<_> =
+            self.accounts.accounts().iter().map(|a| (a.address, a.signer.clone())).collect();
+        let client = self.client.clone();
+        let primary_submission_rpc = self.config.primary_submission_rpc().clone();
+        let chain_id = self.config.chain_id;
+        let setup = setup.clone();
+        let total_accounts = account_data.len();
+
+        info!(
+            accounts = total_accounts,
+            weth = %setup.weth,
+            pair_token = %setup.pair_token.token,
+            measured_routers = swap_routers.len(),
+            approval_targets = approval_targets.len(),
+            "setting up real-token swap balances"
+        );
+
+        let pb_setup = self.progress_bar(total_accounts as u64, "Setting up real tokens");
+        let setup_futs = account_data.into_iter().map(|(sender, signer)| {
+            let client = client.clone();
+            let primary_submission_rpc = primary_submission_rpc.clone();
+            let setup = setup.clone();
+            let approval_targets = approval_targets.clone();
+            async move {
+                let weth_balance = Self::read_erc20_balance(&client, setup.weth, sender).await?;
+                let pair_balance =
+                    Self::read_erc20_balance(&client, setup.pair_token.token, sender).await?;
+                let needs_pair_token = pair_balance < setup.pair_token.amount_per_sender;
+                let acquisition_amount = if needs_pair_token {
+                    setup.pair_token.acquisition.amount_in()
+                } else {
+                    U256::ZERO
+                };
+                let required_weth =
+                    setup.weth_amount_per_sender.saturating_add(acquisition_amount);
+                let deposit_deficit = required_weth.saturating_sub(weth_balance);
+
+                let mut approvals = Vec::new();
+                for (token, router) in &approval_targets {
+                    let allowance =
+                        Self::read_erc20_allowance(&client, *token, sender, *router).await?;
+                    if allowance < setup.approval_amount {
+                        approvals.push((*token, *router));
+                    }
+                }
+
+                let mut setup_gas_limit = approvals
+                    .len()
+                    .saturating_mul(ERC20_APPROVE_GAS_LIMIT as usize)
+                    as u64;
+                if deposit_deficit > U256::ZERO {
+                    setup_gas_limit = setup_gas_limit.saturating_add(WETH_DEPOSIT_GAS_LIMIT);
+                }
+                if needs_pair_token {
+                    setup_gas_limit = setup_gas_limit.saturating_add(SETUP_SWAP_GAS_LIMIT);
+                }
+
+                let native_balance = client
+                    .get_balance(sender)
+                    .block_id(BlockNumberOrTag::Pending.into())
+                    .await
+                    .rpc("get pending balance")?;
+                let setup_gas_cost = U256::from(setup_gas_limit).saturating_mul(U256::from(max_fee));
+                let total_setup_cost = deposit_deficit.saturating_add(setup_gas_cost);
+                if native_balance < total_setup_cost {
+                    return Err(BaselineError::Transaction(format!(
+                        "sender {} has insufficient balance for real-token setup: has {} ETH, needs {} ETH (deposit {} ETH + setup gas {} ETH)",
+                        sender,
+                        format_ether(native_balance),
+                        format_ether(total_setup_cost),
+                        format_ether(deposit_deficit),
+                        format_ether(setup_gas_cost),
+                    )));
+                }
+
+                let wallet = EthereumWallet::from(signer);
+                let provider = create_wallet_provider(primary_submission_rpc, wallet);
+                let mut nonce = provider
+                    .get_transaction_count(sender)
+                    .pending()
+                    .await
+                    .rpc("get pending transaction count")?;
+                let mut sent = 0usize;
+
+                if deposit_deficit > U256::ZERO {
+                    let tx = TransactionRequest::default()
+                        .with_to(setup.weth)
+                        .with_value(deposit_deficit)
+                        .with_input(Self::encode_weth_deposit())
+                        .with_nonce(nonce)
+                        .with_chain_id(chain_id)
+                        .with_gas_limit(WETH_DEPOSIT_GAS_LIMIT)
+                        .with_max_fee_per_gas(max_fee)
+                        .with_max_priority_fee_per_gas(max_priority_fee);
+                    let pending = provider.send_transaction(tx).await.rpc("send WETH deposit")?;
+                    debug!(
+                        sender = %sender,
+                        tx_hash = %pending.tx_hash(),
+                        amount = %deposit_deficit,
+                        "WETH deposit sent"
+                    );
+                    nonce += 1;
+                    sent += 1;
+                }
+
+                for (token, router) in approvals {
+                    let tx = TransactionRequest::default()
+                        .with_to(token)
+                        .with_input(Self::encode_erc20_approve(router, setup.approval_amount))
+                        .with_nonce(nonce)
+                        .with_chain_id(chain_id)
+                        .with_gas_limit(ERC20_APPROVE_GAS_LIMIT)
+                        .with_max_fee_per_gas(max_fee)
+                        .with_max_priority_fee_per_gas(max_priority_fee);
+                    let pending = provider.send_transaction(tx).await.rpc("send ERC20 approval")?;
+                    debug!(
+                        sender = %sender,
+                        token = %token,
+                        router = %router,
+                        tx_hash = %pending.tx_hash(),
+                        "router approval sent"
+                    );
+                    nonce += 1;
+                    sent += 1;
+                }
+
+                if needs_pair_token {
+                    let (router, data) = Self::encode_pair_token_acquisition(&setup, sender)?;
+                    let tx = TransactionRequest::default()
+                        .with_to(router)
+                        .with_input(data)
+                        .with_nonce(nonce)
+                        .with_chain_id(chain_id)
+                        .with_gas_limit(SETUP_SWAP_GAS_LIMIT)
+                        .with_max_fee_per_gas(max_fee)
+                        .with_max_priority_fee_per_gas(max_priority_fee);
+                    let pending = provider.send_transaction(tx).await.rpc("send setup swap")?;
+                    debug!(
+                        sender = %sender,
+                        router = %router,
+                        tx_hash = %pending.tx_hash(),
+                        "pair-token acquisition swap sent"
+                    );
+                    sent += 1;
+                }
+
+                Ok::<_, BaselineError>((sender, sent))
+            }
+        });
+
+        let setup_results: Vec<_> = stream::iter(setup_futs)
+            .buffer_unordered(FUNDING_CONCURRENCY)
+            .inspect(|_| pb_setup.inc(1))
+            .collect()
+            .await;
+        pb_setup.finish_and_clear();
+
+        let mut sent_total = 0usize;
+        for result in setup_results {
+            let (_, sent) = result?;
+            sent_total += sent;
+        }
+
+        let sender_addresses: Vec<Address> =
+            self.accounts.accounts().iter().map(|a| a.address).collect();
+
+        let mut weth_pending: Vec<_> =
+            sender_addresses.iter().map(|sender| (setup.weth, *sender)).collect();
+        let pb_weth = self.progress_bar(weth_pending.len() as u64, "Waiting for WETH balances");
+        Self::await_token_balances(
+            &self.client,
+            &mut weth_pending,
+            setup.weth_amount_per_sender,
+            &pb_weth,
+        )
+        .await?;
+        pb_weth.finish_and_clear();
+
+        let mut pair_pending: Vec<_> =
+            sender_addresses.iter().map(|sender| (setup.pair_token.token, *sender)).collect();
+        let pb_pair =
+            self.progress_bar(pair_pending.len() as u64, "Waiting for pair-token balances");
+        Self::await_token_balances(
+            &self.client,
+            &mut pair_pending,
+            setup.pair_token.amount_per_sender,
+            &pb_pair,
+        )
+        .await?;
+        pb_pair.finish_and_clear();
+
+        let mut allowance_pending = Vec::new();
+        for sender in &sender_addresses {
+            for (token, router) in &approval_targets {
+                allowance_pending.push((*token, *sender, *router));
+            }
+        }
+        let pb_allowance =
+            self.progress_bar(allowance_pending.len() as u64, "Waiting for router allowances");
+        Self::await_erc20_allowances(
+            &self.client,
+            &mut allowance_pending,
+            setup.approval_amount,
+            &pb_allowance,
+        )
+        .await?;
+        pb_allowance.finish_and_clear();
+
+        self.refresh_sender_state().await?;
+
+        info!(
+            accounts = total_accounts,
+            setup_transactions = sent_total,
+            "real-token setup complete"
+        );
+        Ok(())
+    }
+
+    async fn read_erc20_balance(
+        client: &QueryProvider,
+        token: Address,
+        owner: Address,
+    ) -> Result<U256> {
+        client
+            .call(
+                TransactionRequest::default()
+                    .with_to(token)
+                    .with_input(Self::encode_erc20_balance_of(owner))
+                    .into(),
+            )
+            .await
+            .rpc("eth_call balanceOf")
+            .map(|bytes| U256::from_be_slice(bytes.as_ref()))
+    }
+
+    async fn read_erc20_allowance(
+        client: &QueryProvider,
+        token: Address,
+        owner: Address,
+        spender: Address,
+    ) -> Result<U256> {
+        client
+            .call(
+                TransactionRequest::default()
+                    .with_to(token)
+                    .with_input(Self::encode_erc20_allowance(owner, spender))
+                    .into(),
+            )
+            .await
+            .rpc("eth_call allowance")
+            .map(|bytes| U256::from_be_slice(bytes.as_ref()))
+    }
+
+    fn encode_weth_deposit() -> Bytes {
+        sol! {
+            function deposit() external payable;
+        }
+        Bytes::from(depositCall {}.abi_encode())
+    }
+
+    fn encode_erc20_approve(spender: Address, amount: U256) -> Bytes {
+        sol! {
+            function approve(address spender, uint256 amount) external returns (bool);
+        }
+        Bytes::from(approveCall { spender, amount }.abi_encode())
+    }
+
+    fn encode_erc20_allowance(owner: Address, spender: Address) -> Bytes {
+        sol! {
+            function allowance(address owner, address spender) external view returns (uint256);
+        }
+        Bytes::from(allowanceCall { owner, spender }.abi_encode())
+    }
+
+    fn encode_pair_token_acquisition(
+        setup: &RealTokenSetup,
+        recipient: Address,
+    ) -> Result<(Address, Bytes)> {
+        match &setup.pair_token.acquisition {
+            RealTokenAcquisition::UniswapV3ExactInput {
+                router,
+                fee,
+                amount_in,
+                min_amount_out,
+            } => {
+                sol! {
+                    interface ISetupUniswapV3Router {
+                        struct ExactInputSingleParams {
+                            address tokenIn;
+                            address tokenOut;
+                            uint24 fee;
+                            address recipient;
+                            uint256 amountIn;
+                            uint256 amountOutMinimum;
+                            uint160 sqrtPriceLimitX96;
+                        }
+
+                        function exactInputSingle(
+                            ExactInputSingleParams calldata params
+                        ) external payable returns (uint256 amountOut);
+                    }
+                }
+                let call = ISetupUniswapV3Router::exactInputSingleCall {
+                    params: ISetupUniswapV3Router::ExactInputSingleParams {
+                        tokenIn: setup.weth,
+                        tokenOut: setup.pair_token.token,
+                        fee: U24::from(*fee),
+                        recipient,
+                        amountIn: *amount_in,
+                        amountOutMinimum: *min_amount_out,
+                        sqrtPriceLimitX96: U160::ZERO,
+                    },
+                };
+                Ok((*router, Bytes::from(call.abi_encode())))
+            }
+            RealTokenAcquisition::AerodromeClExactInput {
+                router,
+                tick_spacing,
+                amount_in,
+                min_amount_out,
+            } => {
+                sol! {
+                    interface ISetupAerodromeClRouter {
+                        struct ExactInputSingleParams {
+                            address tokenIn;
+                            address tokenOut;
+                            int24 tickSpacing;
+                            address recipient;
+                            uint256 deadline;
+                            uint256 amountIn;
+                            uint256 amountOutMinimum;
+                            uint160 sqrtPriceLimitX96;
+                        }
+
+                        function exactInputSingle(
+                            ExactInputSingleParams calldata params
+                        ) external payable returns (uint256 amountOut);
+                    }
+                }
+                let tick_spacing = I24::try_from(*tick_spacing).map_err(|e| {
+                    BaselineError::Config(format!(
+                        "real-token setup tick spacing does not fit i24: {e}"
+                    ))
+                })?;
+                let call = ISetupAerodromeClRouter::exactInputSingleCall {
+                    params: ISetupAerodromeClRouter::ExactInputSingleParams {
+                        tokenIn: setup.weth,
+                        tokenOut: setup.pair_token.token,
+                        tickSpacing: tick_spacing,
+                        recipient,
+                        deadline: U256::from(u64::MAX),
+                        amountIn: *amount_in,
+                        amountOutMinimum: *min_amount_out,
+                        sqrtPriceLimitX96: U160::ZERO,
+                    },
+                };
+                Ok((*router, Bytes::from(call.abi_encode())))
+            }
+        }
     }
 
     /// Runs the load test and returns metrics summary.
@@ -2154,6 +2571,105 @@ impl LoadRunner {
         }
 
         Ok(settled)
+    }
+
+    /// Waits for ERC20 allowances to reach a target.
+    async fn await_erc20_allowances(
+        client: &QueryProvider,
+        pending_allowances: &mut Vec<(Address, Address, Address)>,
+        target_allowance: U256,
+        pb: &ProgressBar,
+    ) -> Result<usize> {
+        let timeout = Duration::from_secs(60);
+        let poll_interval = Duration::from_millis(500);
+        let start = Instant::now();
+        let mut settled = 0usize;
+
+        while !pending_allowances.is_empty() && start.elapsed() < timeout {
+            tokio::time::sleep(poll_interval).await;
+
+            let mut still_pending = Vec::new();
+            for (token, owner, spender) in pending_allowances.drain(..) {
+                match Self::read_erc20_allowance(client, token, owner, spender).await {
+                    Ok(allowance) if allowance >= target_allowance => {
+                        debug!(token = %token, owner = %owner, spender = %spender, "allowance settled");
+                        settled += 1;
+                        pb.inc(1);
+                    }
+                    Ok(_) => {
+                        still_pending.push((token, owner, spender));
+                    }
+                    Err(e) => {
+                        warn!(
+                            token = %token,
+                            owner = %owner,
+                            spender = %spender,
+                            error = %e,
+                            "failed to check allowance"
+                        );
+                        still_pending.push((token, owner, spender));
+                    }
+                }
+            }
+            *pending_allowances = still_pending;
+        }
+
+        if !pending_allowances.is_empty() {
+            return Err(BaselineError::Transaction(format!(
+                "allowances did not reach target within timeout: {pending_allowances:?}"
+            )));
+        }
+
+        Ok(settled)
+    }
+
+    async fn refresh_sender_state(&mut self) -> Result<()> {
+        let total_accounts = self.accounts.len();
+        let client = self.client.clone();
+        let pb_refresh = self.progress_bar(total_accounts as u64, "Refreshing account state");
+
+        let refresh_futs: Vec<_> = self
+            .accounts
+            .accounts()
+            .iter()
+            .map(|a| {
+                let client = client.clone();
+                let addr = a.address;
+                async move {
+                    let balance = client.get_balance(addr).await.rpc("get balance")?;
+                    let nonce =
+                        client.get_transaction_count(addr).await.rpc("get transaction count")?;
+                    Ok::<_, BaselineError>((addr, balance, nonce))
+                }
+            })
+            .collect();
+
+        let refresh_results: Vec<_> = stream::iter(refresh_futs)
+            .buffer_unordered(FUNDING_CONCURRENCY)
+            .inspect(|_| pb_refresh.inc(1))
+            .collect()
+            .await;
+        pb_refresh.finish_and_clear();
+
+        let addr_to_idx: HashMap<Address, usize> =
+            self.accounts.accounts().iter().enumerate().map(|(i, a)| (a.address, i)).collect();
+
+        for result in refresh_results {
+            let (addr, balance, account_nonce) = result?;
+            let idx = addr_to_idx[&addr];
+            let account = &mut self.accounts.accounts_mut()[idx];
+            account.balance = balance;
+            account.nonce = account_nonce;
+
+            let provider = RootProvider::<Ethereum>::new_http(self.config.query_rpc.clone());
+            let nonce_manager =
+                NonceManager::new(provider, addr, NONCE_RPC_TIMEOUT).with_pending_tag();
+            Arc::make_mut(&mut self.nonce_managers).insert(addr, nonce_manager);
+
+            debug!(address = %addr, balance = %balance, nonce = account_nonce, "account state refreshed");
+        }
+
+        Ok(())
     }
 
     /// Waits for source account balances to drop to the post-drain dust threshold.

--- a/crates/infra/load-tests/src/runner/load_runner.rs
+++ b/crates/infra/load-tests/src/runner/load_runner.rs
@@ -228,7 +228,16 @@ impl LoadRunner {
                     generator =
                         generator.with_payload(OsakaPayload::new(target.clone()), weight_pct);
                 }
-                TxType::UniswapV3 { router, token_in, token_out, fee, min_amount, max_amount } => {
+                TxType::UniswapV3 {
+                    router,
+                    token_in,
+                    token_out,
+                    fee,
+                    min_amount,
+                    max_amount,
+                    reverse_min_amount,
+                    reverse_max_amount,
+                } => {
                     generator = generator.with_payload(
                         UniswapV3Payload::new(
                             *router,
@@ -237,6 +246,7 @@ impl LoadRunner {
                             *fee,
                             *min_amount,
                             *max_amount,
+                            Some((*reverse_min_amount, *reverse_max_amount)),
                         ),
                         weight_pct,
                     );
@@ -248,6 +258,8 @@ impl LoadRunner {
                     tick_spacing,
                     min_amount,
                     max_amount,
+                    reverse_min_amount,
+                    reverse_max_amount,
                 } => {
                     generator = generator.with_payload(
                         AerodromeClPayload::new(
@@ -257,6 +269,7 @@ impl LoadRunner {
                             *tick_spacing,
                             *min_amount,
                             *max_amount,
+                            Some((*reverse_min_amount, *reverse_max_amount)),
                         ),
                         weight_pct,
                     );

--- a/crates/infra/load-tests/src/runner/mod.rs
+++ b/crates/infra/load-tests/src/runner/mod.rs
@@ -36,3 +36,5 @@ pub use status::{DisplaySnapshot, LoadTestDisplay};
 
 mod load_runner;
 pub use load_runner::LoadRunner;
+
+mod real_tokens;

--- a/crates/infra/load-tests/src/runner/mod.rs
+++ b/crates/infra/load-tests/src/runner/mod.rs
@@ -3,7 +3,7 @@
 mod config;
 pub use config::{
     DEFAULT_MAX_GAS_PRICE, LoadConfig, RealTokenAcquisition, RealTokenPairTokenSetup,
-    RealTokenSetup, TxConfig, TxType,
+    RealTokenRecoverySummary, RealTokenSetup, TxConfig, TxType,
 };
 
 mod rate_limiter;

--- a/crates/infra/load-tests/src/runner/mod.rs
+++ b/crates/infra/load-tests/src/runner/mod.rs
@@ -1,7 +1,10 @@
 //! Load test execution, rate limiting, and transaction confirmation.
 
 mod config;
-pub use config::{DEFAULT_MAX_GAS_PRICE, LoadConfig, TxConfig, TxType};
+pub use config::{
+    DEFAULT_MAX_GAS_PRICE, LoadConfig, RealTokenAcquisition, RealTokenPairTokenSetup,
+    RealTokenSetup, TxConfig, TxType,
+};
 
 mod rate_limiter;
 pub use rate_limiter::RateLimiter;

--- a/crates/infra/load-tests/src/runner/real_tokens.rs
+++ b/crates/infra/load-tests/src/runner/real_tokens.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::HashSet,
+    collections::BTreeSet,
     time::{Duration, Instant},
 };
 
@@ -83,7 +83,7 @@ impl LoadRunner {
         &self,
         setup: &RealTokenSetup,
     ) -> Vec<(Address, Address)> {
-        let mut approvals = HashSet::new();
+        let mut approvals = BTreeSet::new();
         for router in self.collect_swap_routers() {
             approvals.insert((setup.weth, router));
             approvals.insert((setup.pair_token.token, router));
@@ -219,6 +219,12 @@ impl LoadRunner {
                         amount = %deposit_deficit,
                         "WETH deposit sent"
                     );
+                    let receipt = pending.get_receipt().await.rpc("confirm WETH deposit")?;
+                    if !receipt.status() {
+                        return Err(BaselineError::Transaction(format!(
+                            "WETH deposit reverted for sender {sender}"
+                        )));
+                    }
                     nonce += 1;
                     sent += 1;
                 }
@@ -240,6 +246,12 @@ impl LoadRunner {
                         tx_hash = %pending.tx_hash(),
                         "router approval sent"
                     );
+                    let receipt = pending.get_receipt().await.rpc("confirm ERC20 approval")?;
+                    if !receipt.status() {
+                        return Err(BaselineError::Transaction(format!(
+                            "ERC20 approval reverted for sender {sender}"
+                        )));
+                    }
                     nonce += 1;
                     sent += 1;
                 }
@@ -267,6 +279,12 @@ impl LoadRunner {
                         tx_hash = %pending.tx_hash(),
                         "pair-token acquisition swap sent"
                     );
+                    let receipt = pending.get_receipt().await.rpc("confirm setup swap")?;
+                    if !receipt.status() {
+                        return Err(BaselineError::Transaction(format!(
+                            "pair-token acquisition swap reverted for sender {sender}"
+                        )));
+                    }
                     sent += 1;
                 }
 

--- a/crates/infra/load-tests/src/runner/real_tokens.rs
+++ b/crates/infra/load-tests/src/runner/real_tokens.rs
@@ -99,12 +99,6 @@ impl LoadRunner {
     /// measured loop starts.
     #[instrument(skip(self, setup), fields(accounts = self.accounts.len()))]
     pub async fn setup_real_tokens(&mut self, setup: &RealTokenSetup) -> Result<()> {
-        if self.config.chain_id == 8453 && !setup.allow_chain_id_8453 {
-            return Err(BaselineError::Config(
-                "real-token setup on chain_id 8453 requires allow_chain_id_8453".into(),
-            ));
-        }
-
         let swap_routers = self.collect_swap_routers();
         if swap_routers.is_empty() {
             return Err(BaselineError::Config(

--- a/crates/infra/load-tests/src/runner/real_tokens.rs
+++ b/crates/infra/load-tests/src/runner/real_tokens.rs
@@ -70,7 +70,7 @@ enum PairSwapDirection {
 }
 
 impl PairSwapDirection {
-    fn tokens(&self, setup: &RealTokenSetup) -> (Address, Address) {
+    const fn tokens(&self, setup: &RealTokenSetup) -> (Address, Address) {
         match self {
             Self::AcquirePairToken => (setup.weth, setup.pair_token.token),
             Self::RecoverWeth => (setup.pair_token.token, setup.weth),

--- a/crates/infra/load-tests/src/runner/real_tokens.rs
+++ b/crates/infra/load-tests/src/runner/real_tokens.rs
@@ -1,0 +1,680 @@
+use std::{
+    collections::HashSet,
+    time::{Duration, Instant},
+};
+
+use alloy_network::{EthereumWallet, TransactionBuilder};
+use alloy_primitives::{Address, Bytes, Signed, U160, U256, Uint, utils::format_ether};
+use alloy_provider::Provider;
+use alloy_rpc_types::{BlockNumberOrTag, TransactionRequest};
+use alloy_sol_types::{SolCall, sol};
+use futures::{StreamExt, stream};
+use indicatif::ProgressBar;
+use tracing::{debug, info, instrument, warn};
+
+use super::{
+    RealTokenAcquisition, RealTokenRecoverySummary, RealTokenSetup,
+    load_runner::{FUNDING_CONCURRENCY, LoadRunner},
+};
+use crate::{
+    BaselineError, Result,
+    rpc::{QueryProvider, RpcResultExt, create_wallet_provider},
+};
+
+const WETH_DEPOSIT_GAS_LIMIT: u64 = 100_000;
+const WETH_WITHDRAW_GAS_LIMIT: u64 = 45_000;
+const ERC20_APPROVE_GAS_LIMIT: u64 = 65_000;
+const SETUP_SWAP_GAS_LIMIT: u64 = 250_000;
+
+type U24 = Uint<24, 1>;
+type I24 = Signed<24, 1>;
+
+sol! {
+    interface IRealTokenUniswapV3Router {
+        struct ExactInputSingleParams {
+            address tokenIn;
+            address tokenOut;
+            uint24 fee;
+            address recipient;
+            uint256 amountIn;
+            uint256 amountOutMinimum;
+            uint160 sqrtPriceLimitX96;
+        }
+
+        function exactInputSingle(
+            ExactInputSingleParams calldata params
+        ) external payable returns (uint256 amountOut);
+    }
+
+    interface IRealTokenAerodromeClRouter {
+        struct ExactInputSingleParams {
+            address tokenIn;
+            address tokenOut;
+            int24 tickSpacing;
+            address recipient;
+            uint256 deadline;
+            uint256 amountIn;
+            uint256 amountOutMinimum;
+            uint160 sqrtPriceLimitX96;
+        }
+
+        function exactInputSingle(
+            ExactInputSingleParams calldata params
+        ) external payable returns (uint256 amountOut);
+    }
+}
+
+enum PairSwapDirection {
+    AcquirePairToken,
+    RecoverWeth,
+}
+
+impl PairSwapDirection {
+    fn tokens(&self, setup: &RealTokenSetup) -> (Address, Address) {
+        match self {
+            Self::AcquirePairToken => (setup.weth, setup.pair_token.token),
+            Self::RecoverWeth => (setup.pair_token.token, setup.weth),
+        }
+    }
+}
+
+impl LoadRunner {
+    fn collect_real_token_setup_approvals(
+        &self,
+        setup: &RealTokenSetup,
+    ) -> Vec<(Address, Address)> {
+        let mut approvals = HashSet::new();
+        for router in self.collect_swap_routers() {
+            approvals.insert((setup.weth, router));
+            approvals.insert((setup.pair_token.token, router));
+        }
+        approvals.insert((setup.weth, setup.pair_token.acquisition.router()));
+        approvals.into_iter().collect()
+    }
+
+    /// Sets up real-token balances and approvals for bidirectional swap workloads.
+    ///
+    /// This preserves the existing random-direction swap payload semantics by
+    /// ensuring every sender has both WETH and the paired token before the
+    /// measured loop starts.
+    #[instrument(skip(self, setup), fields(accounts = self.accounts.len()))]
+    pub async fn setup_real_tokens(&mut self, setup: &RealTokenSetup) -> Result<()> {
+        if self.config.chain_id == 8453 && !setup.allow_chain_id_8453 {
+            return Err(BaselineError::Config(
+                "real-token setup on chain_id 8453 requires allow_chain_id_8453".into(),
+            ));
+        }
+
+        let swap_routers = self.collect_swap_routers();
+        if swap_routers.is_empty() {
+            return Err(BaselineError::Config(
+                "real-token setup requires at least one swap router".into(),
+            ));
+        }
+        let approval_targets = self.collect_real_token_setup_approvals(setup);
+
+        let gas_price = self.client.get_gas_price().await.rpc("get gas price")?;
+        let max_priority_fee = (gas_price / 10).max(1);
+        let max_fee =
+            gas_price.saturating_mul(2).max(max_priority_fee).min(self.config.max_gas_price);
+
+        let account_data: Vec<_> =
+            self.accounts.accounts().iter().map(|a| (a.address, a.signer.clone())).collect();
+        let client = self.client.clone();
+        let primary_submission_rpc = self.config.primary_submission_rpc().clone();
+        let chain_id = self.config.chain_id;
+        let setup = setup.clone();
+        let total_accounts = account_data.len();
+
+        info!(
+            accounts = total_accounts,
+            weth = %setup.weth,
+            pair_token = %setup.pair_token.token,
+            measured_routers = swap_routers.len(),
+            approval_targets = approval_targets.len(),
+            "setting up real-token swap balances"
+        );
+
+        let pb_setup = self.progress_bar(total_accounts as u64, "Setting up real tokens");
+        let setup_futs = account_data.into_iter().map(|(sender, signer)| {
+            let client = client.clone();
+            let primary_submission_rpc = primary_submission_rpc.clone();
+            let setup = setup.clone();
+            let approval_targets = approval_targets.clone();
+            async move {
+                let weth_balance = Self::read_erc20_balance(&client, setup.weth, sender).await?;
+                let pair_balance =
+                    Self::read_erc20_balance(&client, setup.pair_token.token, sender).await?;
+                let needs_pair_token = pair_balance < setup.pair_token.amount_per_sender;
+                let acquisition_amount = if needs_pair_token {
+                    setup.pair_token.acquisition.amount_in()
+                } else {
+                    U256::ZERO
+                };
+                let required_weth =
+                    setup.weth_amount_per_sender.saturating_add(acquisition_amount);
+                let deposit_deficit = required_weth.saturating_sub(weth_balance);
+
+                let mut approvals = Vec::new();
+                for (token, router) in &approval_targets {
+                    let allowance =
+                        Self::read_erc20_allowance(&client, *token, sender, *router).await?;
+                    if allowance < setup.approval_amount {
+                        approvals.push((*token, *router));
+                    }
+                }
+
+                let mut setup_gas_limit = approvals
+                    .len()
+                    .saturating_mul(ERC20_APPROVE_GAS_LIMIT as usize)
+                    as u64;
+                if deposit_deficit > U256::ZERO {
+                    setup_gas_limit = setup_gas_limit.saturating_add(WETH_DEPOSIT_GAS_LIMIT);
+                }
+                if needs_pair_token {
+                    setup_gas_limit = setup_gas_limit.saturating_add(SETUP_SWAP_GAS_LIMIT);
+                }
+
+                let native_balance = client
+                    .get_balance(sender)
+                    .block_id(BlockNumberOrTag::Pending.into())
+                    .await
+                    .rpc("get pending balance")?;
+                let setup_gas_cost = U256::from(setup_gas_limit).saturating_mul(U256::from(max_fee));
+                let total_setup_cost = deposit_deficit.saturating_add(setup_gas_cost);
+                if native_balance < total_setup_cost {
+                    return Err(BaselineError::Transaction(format!(
+                        "sender {} has insufficient balance for real-token setup: has {} ETH, needs {} ETH (deposit {} ETH + setup gas {} ETH)",
+                        sender,
+                        format_ether(native_balance),
+                        format_ether(total_setup_cost),
+                        format_ether(deposit_deficit),
+                        format_ether(setup_gas_cost),
+                    )));
+                }
+
+                let wallet = EthereumWallet::from(signer);
+                let provider = create_wallet_provider(primary_submission_rpc, wallet);
+                let mut nonce = provider
+                    .get_transaction_count(sender)
+                    .pending()
+                    .await
+                    .rpc("get pending transaction count")?;
+                let mut sent = 0usize;
+
+                if deposit_deficit > U256::ZERO {
+                    let tx = TransactionRequest::default()
+                        .with_to(setup.weth)
+                        .with_value(deposit_deficit)
+                        .with_input(Self::encode_weth_deposit())
+                        .with_nonce(nonce)
+                        .with_chain_id(chain_id)
+                        .with_gas_limit(WETH_DEPOSIT_GAS_LIMIT)
+                        .with_max_fee_per_gas(max_fee)
+                        .with_max_priority_fee_per_gas(max_priority_fee);
+                    let pending = provider.send_transaction(tx).await.rpc("send WETH deposit")?;
+                    debug!(
+                        sender = %sender,
+                        tx_hash = %pending.tx_hash(),
+                        amount = %deposit_deficit,
+                        "WETH deposit sent"
+                    );
+                    nonce += 1;
+                    sent += 1;
+                }
+
+                for (token, router) in approvals {
+                    let tx = TransactionRequest::default()
+                        .with_to(token)
+                        .with_input(Self::encode_erc20_approve(router, setup.approval_amount))
+                        .with_nonce(nonce)
+                        .with_chain_id(chain_id)
+                        .with_gas_limit(ERC20_APPROVE_GAS_LIMIT)
+                        .with_max_fee_per_gas(max_fee)
+                        .with_max_priority_fee_per_gas(max_priority_fee);
+                    let pending = provider.send_transaction(tx).await.rpc("send ERC20 approval")?;
+                    debug!(
+                        sender = %sender,
+                        token = %token,
+                        router = %router,
+                        tx_hash = %pending.tx_hash(),
+                        "router approval sent"
+                    );
+                    nonce += 1;
+                    sent += 1;
+                }
+
+                if needs_pair_token {
+                    let (router, data) = Self::encode_pair_token_swap(
+                        &setup,
+                        sender,
+                        PairSwapDirection::AcquirePairToken,
+                        setup.pair_token.acquisition.amount_in(),
+                        setup.pair_token.acquisition.min_amount_out(),
+                    )?;
+                    let tx = TransactionRequest::default()
+                        .with_to(router)
+                        .with_input(data)
+                        .with_nonce(nonce)
+                        .with_chain_id(chain_id)
+                        .with_gas_limit(SETUP_SWAP_GAS_LIMIT)
+                        .with_max_fee_per_gas(max_fee)
+                        .with_max_priority_fee_per_gas(max_priority_fee);
+                    let pending = provider.send_transaction(tx).await.rpc("send setup swap")?;
+                    debug!(
+                        sender = %sender,
+                        router = %router,
+                        tx_hash = %pending.tx_hash(),
+                        "pair-token acquisition swap sent"
+                    );
+                    sent += 1;
+                }
+
+                Ok::<_, BaselineError>((sender, sent))
+            }
+        });
+
+        let setup_results: Vec<_> = stream::iter(setup_futs)
+            .buffer_unordered(FUNDING_CONCURRENCY)
+            .inspect(|_| pb_setup.inc(1))
+            .collect()
+            .await;
+        pb_setup.finish_and_clear();
+
+        let mut sent_total = 0usize;
+        for result in setup_results {
+            let (_, sent) = result?;
+            sent_total += sent;
+        }
+
+        let sender_addresses: Vec<Address> =
+            self.accounts.accounts().iter().map(|a| a.address).collect();
+
+        let mut weth_pending: Vec<_> =
+            sender_addresses.iter().map(|sender| (setup.weth, *sender)).collect();
+        let pb_weth = self.progress_bar(weth_pending.len() as u64, "Waiting for WETH balances");
+        Self::await_token_balances(
+            &self.client,
+            &mut weth_pending,
+            setup.weth_amount_per_sender,
+            &pb_weth,
+        )
+        .await?;
+        pb_weth.finish_and_clear();
+
+        let mut pair_pending: Vec<_> =
+            sender_addresses.iter().map(|sender| (setup.pair_token.token, *sender)).collect();
+        let pb_pair =
+            self.progress_bar(pair_pending.len() as u64, "Waiting for pair-token balances");
+        Self::await_token_balances(
+            &self.client,
+            &mut pair_pending,
+            setup.pair_token.amount_per_sender,
+            &pb_pair,
+        )
+        .await?;
+        pb_pair.finish_and_clear();
+
+        let mut allowance_pending = Vec::new();
+        for sender in &sender_addresses {
+            for (token, router) in &approval_targets {
+                allowance_pending.push((*token, *sender, *router));
+            }
+        }
+        let pb_allowance =
+            self.progress_bar(allowance_pending.len() as u64, "Waiting for router allowances");
+        Self::await_erc20_allowances(
+            &self.client,
+            &mut allowance_pending,
+            setup.approval_amount,
+            &pb_allowance,
+        )
+        .await?;
+        pb_allowance.finish_and_clear();
+
+        self.refresh_sender_state().await?;
+
+        info!(
+            accounts = total_accounts,
+            setup_transactions = sent_total,
+            "real-token setup complete"
+        );
+        Ok(())
+    }
+
+    /// Recovers real-token balances by swapping the configured pair token back
+    /// into WETH, unwrapping WETH to native ETH, and leaving native drain to
+    /// [`Self::drain_accounts`].
+    pub async fn recover_real_tokens(
+        &self,
+        setup: &RealTokenSetup,
+    ) -> Result<RealTokenRecoverySummary> {
+        let client = self.client.clone();
+        let primary_submission_rpc = self.config.primary_submission_rpc().clone();
+        let chain_id = self.config.chain_id;
+
+        let gas_price = client.get_gas_price().await.rpc("get gas price")?;
+        let max_priority_fee = (gas_price / 10).max(1);
+        let max_fee =
+            gas_price.saturating_mul(2).max(max_priority_fee).min(self.config.max_gas_price);
+
+        let account_data: Vec<_> =
+            self.accounts.accounts().iter().map(|a| (a.address, a.signer.clone())).collect();
+        let total_accounts = account_data.len();
+        let pb_recover = self.progress_bar(total_accounts as u64, "Recovering real tokens");
+
+        let recover_futs: Vec<_> = account_data
+            .into_iter()
+            .map(|(sender, signer)| {
+                let client = client.clone();
+                let primary_submission_rpc = primary_submission_rpc.clone();
+                let setup = setup.clone();
+                async move {
+                    let mut summary = RealTokenRecoverySummary::default();
+                    let wallet = EthereumWallet::from(signer);
+                    let provider = create_wallet_provider(primary_submission_rpc, wallet);
+                    let mut nonce = provider
+                        .get_transaction_count(sender)
+                        .pending()
+                        .await
+                        .rpc("get pending transaction count")?;
+
+                    let pair_balance =
+                        Self::read_erc20_balance(&client, setup.pair_token.token, sender).await?;
+                    if pair_balance > U256::ZERO {
+                        let recovery_router = setup.pair_token.acquisition.router();
+                        let allowance = Self::read_erc20_allowance(
+                            &client,
+                            setup.pair_token.token,
+                            sender,
+                            recovery_router,
+                        )
+                        .await?;
+
+                        if allowance < pair_balance {
+                            let approval_amount = setup.approval_amount.max(pair_balance);
+                            let tx = TransactionRequest::default()
+                                .with_to(setup.pair_token.token)
+                                .with_input(Self::encode_erc20_approve(
+                                    recovery_router,
+                                    approval_amount,
+                                ))
+                                .with_nonce(nonce)
+                                .with_chain_id(chain_id)
+                                .with_gas_limit(ERC20_APPROVE_GAS_LIMIT)
+                                .with_max_fee_per_gas(max_fee)
+                                .with_max_priority_fee_per_gas(max_priority_fee);
+                            let pending =
+                                provider.send_transaction(tx).await.rpc("send pair approval")?;
+                            debug!(
+                                sender = %sender,
+                                token = %setup.pair_token.token,
+                                router = %recovery_router,
+                                tx_hash = %pending.tx_hash(),
+                                "recovery pair-token approval sent"
+                            );
+                            let receipt =
+                                pending.get_receipt().await.rpc("confirm pair approval")?;
+                            if !receipt.status() {
+                                return Err(BaselineError::Transaction(format!(
+                                    "pair-token approval reverted for sender {sender}"
+                                )));
+                            }
+                            nonce += 1;
+                        }
+
+                        let (router, data) = Self::encode_pair_token_swap(
+                            &setup,
+                            sender,
+                            PairSwapDirection::RecoverWeth,
+                            pair_balance,
+                            U256::ZERO,
+                        )?;
+                        let tx = TransactionRequest::default()
+                            .with_to(router)
+                            .with_input(data)
+                            .with_nonce(nonce)
+                            .with_chain_id(chain_id)
+                            .with_gas_limit(SETUP_SWAP_GAS_LIMIT)
+                            .with_max_fee_per_gas(max_fee)
+                            .with_max_priority_fee_per_gas(max_priority_fee);
+                        let pending = provider
+                            .send_transaction(tx)
+                            .await
+                            .rpc("send pair-token recovery swap")?;
+                        debug!(
+                            sender = %sender,
+                            router = %router,
+                            amount = %pair_balance,
+                            tx_hash = %pending.tx_hash(),
+                            "pair-token recovery swap sent"
+                        );
+                        let receipt =
+                            pending.get_receipt().await.rpc("confirm pair-token recovery swap")?;
+                        if !receipt.status() {
+                            return Err(BaselineError::Transaction(format!(
+                                "pair-token recovery swap reverted for sender {sender}"
+                            )));
+                        }
+                        nonce += 1;
+                        summary.pair_token_swapped =
+                            summary.pair_token_swapped.saturating_add(pair_balance);
+                    }
+
+                    let weth_balance =
+                        Self::read_erc20_balance(&client, setup.weth, sender).await?;
+                    if weth_balance > U256::ZERO {
+                        let tx = TransactionRequest::default()
+                            .with_to(setup.weth)
+                            .with_input(Self::encode_weth_withdraw(weth_balance))
+                            .with_nonce(nonce)
+                            .with_chain_id(chain_id)
+                            .with_gas_limit(WETH_WITHDRAW_GAS_LIMIT)
+                            .with_max_fee_per_gas(max_fee)
+                            .with_max_priority_fee_per_gas(max_priority_fee);
+                        let pending =
+                            provider.send_transaction(tx).await.rpc("send WETH withdraw")?;
+                        debug!(
+                            sender = %sender,
+                            amount = %weth_balance,
+                            tx_hash = %pending.tx_hash(),
+                            "recovery WETH withdraw sent"
+                        );
+                        let receipt = pending.get_receipt().await.rpc("confirm WETH withdraw")?;
+                        if !receipt.status() {
+                            return Err(BaselineError::Transaction(format!(
+                                "WETH withdraw reverted for sender {sender}"
+                            )));
+                        }
+                        summary.weth_unwrapped =
+                            summary.weth_unwrapped.saturating_add(weth_balance);
+                    }
+
+                    Ok::<_, BaselineError>(summary)
+                }
+            })
+            .collect();
+
+        let recover_results: Vec<_> = stream::iter(recover_futs)
+            .buffer_unordered(FUNDING_CONCURRENCY)
+            .inspect(|_| pb_recover.inc(1))
+            .collect()
+            .await;
+        pb_recover.finish_and_clear();
+
+        let mut summary = RealTokenRecoverySummary::default();
+        for result in recover_results {
+            let account_summary = result?;
+            summary.pair_token_swapped =
+                summary.pair_token_swapped.saturating_add(account_summary.pair_token_swapped);
+            summary.weth_unwrapped =
+                summary.weth_unwrapped.saturating_add(account_summary.weth_unwrapped);
+        }
+
+        info!(
+            pair_token_swapped = %summary.pair_token_swapped,
+            weth_unwrapped = %summary.weth_unwrapped,
+            "real-token recovery complete"
+        );
+        Ok(summary)
+    }
+
+    async fn read_erc20_balance(
+        client: &QueryProvider,
+        token: Address,
+        owner: Address,
+    ) -> Result<U256> {
+        client
+            .call(
+                TransactionRequest::default()
+                    .with_to(token)
+                    .with_input(Self::encode_erc20_balance_of(owner))
+                    .into(),
+            )
+            .await
+            .rpc("eth_call balanceOf")
+            .map(|bytes| U256::from_be_slice(bytes.as_ref()))
+    }
+
+    async fn read_erc20_allowance(
+        client: &QueryProvider,
+        token: Address,
+        owner: Address,
+        spender: Address,
+    ) -> Result<U256> {
+        client
+            .call(
+                TransactionRequest::default()
+                    .with_to(token)
+                    .with_input(Self::encode_erc20_allowance(owner, spender))
+                    .into(),
+            )
+            .await
+            .rpc("eth_call allowance")
+            .map(|bytes| U256::from_be_slice(bytes.as_ref()))
+    }
+
+    fn encode_weth_deposit() -> Bytes {
+        sol! {
+            function deposit() external payable;
+        }
+        Bytes::from(depositCall {}.abi_encode())
+    }
+
+    fn encode_weth_withdraw(amount: U256) -> Bytes {
+        sol! {
+            function withdraw(uint256 wad) external;
+        }
+        Bytes::from(withdrawCall { wad: amount }.abi_encode())
+    }
+
+    fn encode_erc20_approve(spender: Address, amount: U256) -> Bytes {
+        sol! {
+            function approve(address spender, uint256 amount) external returns (bool);
+        }
+        Bytes::from(approveCall { spender, amount }.abi_encode())
+    }
+
+    fn encode_erc20_allowance(owner: Address, spender: Address) -> Bytes {
+        sol! {
+            function allowance(address owner, address spender) external view returns (uint256);
+        }
+        Bytes::from(allowanceCall { owner, spender }.abi_encode())
+    }
+
+    fn encode_pair_token_swap(
+        setup: &RealTokenSetup,
+        recipient: Address,
+        direction: PairSwapDirection,
+        amount_in: U256,
+        min_amount_out: U256,
+    ) -> Result<(Address, Bytes)> {
+        let (token_in, token_out) = direction.tokens(setup);
+        match &setup.pair_token.acquisition {
+            RealTokenAcquisition::UniswapV3ExactInput { router, fee, .. } => {
+                let call = IRealTokenUniswapV3Router::exactInputSingleCall {
+                    params: IRealTokenUniswapV3Router::ExactInputSingleParams {
+                        tokenIn: token_in,
+                        tokenOut: token_out,
+                        fee: U24::from(*fee),
+                        recipient,
+                        amountIn: amount_in,
+                        amountOutMinimum: min_amount_out,
+                        sqrtPriceLimitX96: U160::ZERO,
+                    },
+                };
+                Ok((*router, Bytes::from(call.abi_encode())))
+            }
+            RealTokenAcquisition::AerodromeClExactInput { router, tick_spacing, .. } => {
+                let tick_spacing = I24::try_from(*tick_spacing).map_err(|e| {
+                    BaselineError::Config(format!(
+                        "real-token swap tick spacing does not fit i24: {e}"
+                    ))
+                })?;
+                let call = IRealTokenAerodromeClRouter::exactInputSingleCall {
+                    params: IRealTokenAerodromeClRouter::ExactInputSingleParams {
+                        tokenIn: token_in,
+                        tokenOut: token_out,
+                        tickSpacing: tick_spacing,
+                        recipient,
+                        deadline: U256::from(u64::MAX),
+                        amountIn: amount_in,
+                        amountOutMinimum: min_amount_out,
+                        sqrtPriceLimitX96: U160::ZERO,
+                    },
+                };
+                Ok((*router, Bytes::from(call.abi_encode())))
+            }
+        }
+    }
+
+    /// Waits for ERC20 allowances to reach a target.
+    async fn await_erc20_allowances(
+        client: &QueryProvider,
+        pending_allowances: &mut Vec<(Address, Address, Address)>,
+        target_allowance: U256,
+        pb: &ProgressBar,
+    ) -> Result<usize> {
+        let timeout = Duration::from_secs(60);
+        let poll_interval = Duration::from_millis(500);
+        let start = Instant::now();
+        let mut settled = 0usize;
+
+        while !pending_allowances.is_empty() && start.elapsed() < timeout {
+            tokio::time::sleep(poll_interval).await;
+
+            let mut still_pending = Vec::new();
+            for (token, owner, spender) in pending_allowances.drain(..) {
+                match Self::read_erc20_allowance(client, token, owner, spender).await {
+                    Ok(allowance) if allowance >= target_allowance => {
+                        debug!(token = %token, owner = %owner, spender = %spender, "allowance settled");
+                        settled += 1;
+                        pb.inc(1);
+                    }
+                    Ok(_) => {
+                        still_pending.push((token, owner, spender));
+                    }
+                    Err(e) => {
+                        warn!(
+                            token = %token,
+                            owner = %owner,
+                            spender = %spender,
+                            error = %e,
+                            "failed to check allowance"
+                        );
+                        still_pending.push((token, owner, spender));
+                    }
+                }
+            }
+            *pending_allowances = still_pending;
+        }
+
+        if !pending_allowances.is_empty() {
+            return Err(BaselineError::Transaction(format!(
+                "allowances did not reach target within timeout: {pending_allowances:?}"
+            )));
+        }
+
+        Ok(settled)
+    }
+}

--- a/crates/infra/load-tests/src/workload/payloads/aerodrome.rs
+++ b/crates/infra/load-tests/src/workload/payloads/aerodrome.rs
@@ -120,3 +120,52 @@ impl Payload for AerodromeClPayload {
             .with_gas_limit(250_000)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn generated_calldata_uses_direction_specific_amounts() {
+        let router = Address::repeat_byte(0x10);
+        let token_in = Address::repeat_byte(0x11);
+        let token_out = Address::repeat_byte(0x22);
+        let sender = Address::repeat_byte(0x33);
+        let forward_amount = U256::from(10_000_000_000_000u64);
+        let reverse_amount = U256::from(100_000u64);
+        let payload = AerodromeClPayload::new(
+            router,
+            token_in,
+            token_out,
+            100,
+            forward_amount,
+            forward_amount,
+            Some((reverse_amount, reverse_amount)),
+        );
+        let mut rng = SeededRng::new(42);
+        let mut saw_forward = false;
+        let mut saw_reverse = false;
+
+        for _ in 0..32 {
+            let tx = payload.generate(&mut rng, sender, Address::ZERO);
+            let input = tx.input.input().expect("swap calldata should be set");
+            let decoded = IAerodromeClRouter::exactInputSingleCall::abi_decode(input)
+                .expect("swap calldata should decode");
+
+            if decoded.params.tokenIn == token_in {
+                saw_forward = true;
+                assert_eq!(decoded.params.tokenOut, token_out);
+                assert_eq!(decoded.params.amountIn, forward_amount);
+            } else if decoded.params.tokenIn == token_out {
+                saw_reverse = true;
+                assert_eq!(decoded.params.tokenOut, token_in);
+                assert_eq!(decoded.params.amountIn, reverse_amount);
+            } else {
+                panic!("unexpected tokenIn {}", decoded.params.tokenIn);
+            }
+        }
+
+        assert!(saw_forward, "expected at least one forward swap");
+        assert!(saw_reverse, "expected at least one reverse swap");
+    }
+}

--- a/crates/infra/load-tests/src/workload/payloads/aerodrome.rs
+++ b/crates/infra/load-tests/src/workload/payloads/aerodrome.rs
@@ -42,6 +42,10 @@ pub struct AerodromeClPayload {
     pub min_amount: U256,
     /// Maximum swap amount.
     pub max_amount: U256,
+    /// Minimum amount when swapping `token_out` to `token_in`.
+    pub reverse_min_amount: U256,
+    /// Maximum amount when swapping `token_out` to `token_in`.
+    pub reverse_max_amount: U256,
 }
 
 impl AerodromeClPayload {
@@ -58,10 +62,22 @@ impl AerodromeClPayload {
         tick_spacing: i32,
         min_amount: U256,
         max_amount: U256,
+        reverse_amounts: Option<(U256, U256)>,
     ) -> Self {
         let tick_spacing =
             I24::try_from(tick_spacing).expect("tick_spacing validated to fit i24 at config parse");
-        Self { router, token_in, token_out, tick_spacing, min_amount, max_amount }
+        let (reverse_min_amount, reverse_max_amount) =
+            reverse_amounts.unwrap_or((min_amount, max_amount));
+        Self {
+            router,
+            token_in,
+            token_out,
+            tick_spacing,
+            min_amount,
+            max_amount,
+            reverse_min_amount,
+            reverse_max_amount,
+        }
     }
 }
 
@@ -71,20 +87,18 @@ impl Payload for AerodromeClPayload {
     }
 
     fn generate(&self, rng: &mut SeededRng, from: Address, _to: Address) -> TransactionRequest {
-        let amount = if self.min_amount == self.max_amount {
-            self.min_amount
+        let (input, output, min_amount, max_amount) = if rng.random::<bool>() {
+            (self.token_in, self.token_out, self.min_amount, self.max_amount)
         } else {
-            let min: u128 =
-                self.min_amount.try_into().expect("validated <= u128::MAX at config parse");
-            let max: u128 =
-                self.max_amount.try_into().expect("validated <= u128::MAX at config parse");
-            U256::from(rng.gen_range(min..=max))
+            (self.token_out, self.token_in, self.reverse_min_amount, self.reverse_max_amount)
         };
 
-        let (input, output) = if rng.random::<bool>() {
-            (self.token_in, self.token_out)
+        let amount = if min_amount == max_amount {
+            min_amount
         } else {
-            (self.token_out, self.token_in)
+            let min: u128 = min_amount.try_into().expect("validated <= u128::MAX at config parse");
+            let max: u128 = max_amount.try_into().expect("validated <= u128::MAX at config parse");
+            U256::from(rng.gen_range(min..=max))
         };
 
         let call = IAerodromeClRouter::exactInputSingleCall {

--- a/crates/infra/load-tests/src/workload/payloads/uniswap.rs
+++ b/crates/infra/load-tests/src/workload/payloads/uniswap.rs
@@ -108,3 +108,52 @@ impl Payload for UniswapV3Payload {
             .with_gas_limit(250_000)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn generated_calldata_uses_direction_specific_amounts() {
+        let router = Address::repeat_byte(0x10);
+        let token_in = Address::repeat_byte(0x11);
+        let token_out = Address::repeat_byte(0x22);
+        let sender = Address::repeat_byte(0x33);
+        let forward_amount = U256::from(10_000_000_000_000u64);
+        let reverse_amount = U256::from(100_000u64);
+        let payload = UniswapV3Payload::new(
+            router,
+            token_in,
+            token_out,
+            500,
+            forward_amount,
+            forward_amount,
+            Some((reverse_amount, reverse_amount)),
+        );
+        let mut rng = SeededRng::new(42);
+        let mut saw_forward = false;
+        let mut saw_reverse = false;
+
+        for _ in 0..32 {
+            let tx = payload.generate(&mut rng, sender, Address::ZERO);
+            let input = tx.input.input().expect("swap calldata should be set");
+            let decoded = IUniswapV3Router::exactInputSingleCall::abi_decode(input)
+                .expect("swap calldata should decode");
+
+            if decoded.params.tokenIn == token_in {
+                saw_forward = true;
+                assert_eq!(decoded.params.tokenOut, token_out);
+                assert_eq!(decoded.params.amountIn, forward_amount);
+            } else if decoded.params.tokenIn == token_out {
+                saw_reverse = true;
+                assert_eq!(decoded.params.tokenOut, token_in);
+                assert_eq!(decoded.params.amountIn, reverse_amount);
+            } else {
+                panic!("unexpected tokenIn {}", decoded.params.tokenIn);
+            }
+        }
+
+        assert!(saw_forward, "expected at least one forward swap");
+        assert!(saw_reverse, "expected at least one reverse swap");
+    }
+}

--- a/crates/infra/load-tests/src/workload/payloads/uniswap.rs
+++ b/crates/infra/load-tests/src/workload/payloads/uniswap.rs
@@ -35,6 +35,8 @@ pub struct UniswapV3Payload {
     fee: u32,
     min_amount: U256,
     max_amount: U256,
+    reverse_min_amount: U256,
+    reverse_max_amount: U256,
 }
 
 impl UniswapV3Payload {
@@ -46,8 +48,22 @@ impl UniswapV3Payload {
         fee: u32,
         min_amount: U256,
         max_amount: U256,
+        reverse_amounts: Option<(U256, U256)>,
     ) -> Self {
-        Self { router, token_in, token_out, fee, min_amount, max_amount }
+        let (reverse_min_amount, reverse_max_amount) = match reverse_amounts {
+            Some(amounts) => amounts,
+            None => (min_amount, max_amount),
+        };
+        Self {
+            router,
+            token_in,
+            token_out,
+            fee,
+            min_amount,
+            max_amount,
+            reverse_min_amount,
+            reverse_max_amount,
+        }
     }
 }
 
@@ -57,23 +73,21 @@ impl Payload for UniswapV3Payload {
     }
 
     fn generate(&self, rng: &mut SeededRng, from: Address, _to: Address) -> TransactionRequest {
-        let amount = if self.min_amount == self.max_amount {
-            self.min_amount
-        } else {
-            let min: u128 =
-                self.min_amount.try_into().expect("validated <= u128::MAX at config parse");
-            let max: u128 =
-                self.max_amount.try_into().expect("validated <= u128::MAX at config parse");
-            U256::from(rng.gen_range(min..=max))
-        };
-
         // Randomly swap direction to exercise both sides of the pool.
         // V3 pools are keyed by (token0, token1, fee) with token0 < token1,
         // so the fee tier is direction-agnostic and this is safe.
-        let (input, output) = if rng.random::<bool>() {
-            (self.token_in, self.token_out)
+        let (input, output, min_amount, max_amount) = if rng.random::<bool>() {
+            (self.token_in, self.token_out, self.min_amount, self.max_amount)
         } else {
-            (self.token_out, self.token_in)
+            (self.token_out, self.token_in, self.reverse_min_amount, self.reverse_max_amount)
+        };
+
+        let amount = if min_amount == max_amount {
+            min_amount
+        } else {
+            let min: u128 = min_amount.try_into().expect("validated <= u128::MAX at config parse");
+            let max: u128 = max_amount.try_into().expect("validated <= u128::MAX at config parse");
+            U256::from(rng.gen_range(min..=max))
         };
 
         let call = IUniswapV3Router::exactInputSingleCall {

--- a/crates/utilities/test-utils/contracts/README.md
+++ b/crates/utilities/test-utils/contracts/README.md
@@ -53,7 +53,13 @@ $ forge script script/Counter.s.sol:CounterScript --rpc-url <your_rpc_url> --pri
 
 ### Real-Token Swap Devnet Harness
 
-Deploy a local WETH/USDC swap harness for validating `base-load-test` real-token setup on the Docker devnet:
+The load-test Justfile can deploy a local WETH/USDC swap harness, render the load-test config with the deployed addresses, and run the Docker devnet swap load test:
+
+```shell
+just load-test real-token
+```
+
+To deploy only the harness for manual validation:
 
 ```shell
 export FUNDER_KEY=0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d

--- a/crates/utilities/test-utils/contracts/README.md
+++ b/crates/utilities/test-utils/contracts/README.md
@@ -51,6 +51,28 @@ $ anvil
 $ forge script script/Counter.s.sol:CounterScript --rpc-url <your_rpc_url> --private-key <your_private_key>
 ```
 
+### Real-Token Swap Devnet Harness
+
+Deploy a local WETH/USDC swap harness for validating `base-load-test` real-token setup on the Docker devnet:
+
+```shell
+export FUNDER_KEY=0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d
+forge script script/DeployRealTokenSwapDevnet.s.sol:DeployRealTokenSwapDevnet \
+  --rpc-url http://localhost:7545 \
+  --private-key "$FUNDER_KEY" \
+  --broadcast
+```
+
+The script verifies the WETH predeploy at `0x4200000000000000000000000000000000000006`, deploys a standard 6-decimal mock USDC token, deploys two router shims, and seeds both shims with WETH and USDC liquidity. Use the printed USDC, Uniswap router shim, and Aerodrome router shim addresses in the devnet load-test config.
+
+Optional liquidity overrides:
+
+```shell
+DEVNET_USDC_PER_WETH=1000000000
+DEVNET_ROUTER_USDC_LIQUIDITY=100000000000
+DEVNET_ROUTER_WETH_LIQUIDITY=100000000000000000000
+```
+
 ### Cast
 
 ```shell

--- a/crates/utilities/test-utils/contracts/script/DeployRealTokenSwapDevnet.s.sol
+++ b/crates/utilities/test-utils/contracts/script/DeployRealTokenSwapDevnet.s.sol
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.0;
+
+import {Script} from "forge-std/Script.sol";
+import {console} from "forge-std/console.sol";
+import {DevnetSwapRouterShim} from "../src/DevnetSwapRouterShim.sol";
+import {DevnetUSDC} from "../src/DevnetUSDC.sol";
+
+interface IWETH {
+    function deposit() external payable;
+    function transfer(address to, uint256 amount) external returns (bool);
+}
+
+contract DeployRealTokenSwapDevnet is Script {
+    address internal constant WETH = 0x4200000000000000000000000000000000000006;
+
+    uint256 internal constant DEFAULT_USDC_PER_WETH = 1_000e6;
+    uint256 internal constant DEFAULT_ROUTER_USDC_LIQUIDITY = 100_000e6;
+    uint256 internal constant DEFAULT_ROUTER_WETH_LIQUIDITY = 100 ether;
+
+    error MissingWethPredeploy(address weth);
+    error WethTransferFailed(address router, uint256 amount);
+
+    function run() public {
+        if (WETH.code.length == 0) {
+            revert MissingWethPredeploy(WETH);
+        }
+
+        uint256 usdcPerWeth = vm.envOr("DEVNET_USDC_PER_WETH", DEFAULT_USDC_PER_WETH);
+        uint256 routerUsdcLiquidity = vm.envOr("DEVNET_ROUTER_USDC_LIQUIDITY", DEFAULT_ROUTER_USDC_LIQUIDITY);
+        uint256 routerWethLiquidity = vm.envOr("DEVNET_ROUTER_WETH_LIQUIDITY", DEFAULT_ROUTER_WETH_LIQUIDITY);
+
+        vm.startBroadcast();
+
+        DevnetUSDC usdc = new DevnetUSDC();
+        DevnetSwapRouterShim uniswapRouter = new DevnetSwapRouterShim(WETH, address(usdc), usdcPerWeth);
+        DevnetSwapRouterShim aerodromeRouter = new DevnetSwapRouterShim(WETH, address(usdc), usdcPerWeth);
+
+        usdc.mint(address(uniswapRouter), routerUsdcLiquidity);
+        usdc.mint(address(aerodromeRouter), routerUsdcLiquidity);
+
+        uint256 totalWethLiquidity = routerWethLiquidity * 2;
+        IWETH(WETH).deposit{value: totalWethLiquidity}();
+
+        if (!IWETH(WETH).transfer(address(uniswapRouter), routerWethLiquidity)) {
+            revert WethTransferFailed(address(uniswapRouter), routerWethLiquidity);
+        }
+        if (!IWETH(WETH).transfer(address(aerodromeRouter), routerWethLiquidity)) {
+            revert WethTransferFailed(address(aerodromeRouter), routerWethLiquidity);
+        }
+
+        console.log("WETH:", WETH);
+        console.log("USDC:", address(usdc));
+        console.log("Uniswap router shim:", address(uniswapRouter));
+        console.log("Aerodrome router shim:", address(aerodromeRouter));
+        console.log("USDC per WETH:", usdcPerWeth);
+        console.log("USDC liquidity per router:", routerUsdcLiquidity);
+        console.log("WETH liquidity per router:", routerWethLiquidity);
+
+        vm.stopBroadcast();
+    }
+}

--- a/crates/utilities/test-utils/contracts/src/DevnetSwapRouterShim.sol
+++ b/crates/utilities/test-utils/contracts/src/DevnetSwapRouterShim.sol
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.0;
+
+interface IERC20Like {
+    function transfer(address to, uint256 amount) external returns (bool);
+    function transferFrom(address from, address to, uint256 amount) external returns (bool);
+}
+
+/// @notice Minimal router shim for devnet WETH/USDC load-test validation.
+/// @dev Supports the exact calldata shapes generated for Uniswap V3 and Aerodrome CL swaps.
+contract DevnetSwapRouterShim {
+    struct UniswapExactInputSingleParams {
+        address tokenIn;
+        address tokenOut;
+        uint24 fee;
+        address recipient;
+        uint256 amountIn;
+        uint256 amountOutMinimum;
+        uint160 sqrtPriceLimitX96;
+    }
+
+    struct AerodromeExactInputSingleParams {
+        address tokenIn;
+        address tokenOut;
+        int24 tickSpacing;
+        address recipient;
+        uint256 deadline;
+        uint256 amountIn;
+        uint256 amountOutMinimum;
+        uint160 sqrtPriceLimitX96;
+    }
+
+    event Swap(
+        address indexed caller,
+        address indexed tokenIn,
+        address indexed tokenOut,
+        address recipient,
+        uint256 amountIn,
+        uint256 amountOut,
+        bytes4 selector
+    );
+
+    error DeadlineExpired(uint256 deadline, uint256 timestamp);
+    error InsufficientOutput(uint256 amountOut, uint256 amountOutMinimum);
+    error MissingTokenAddress();
+    error TransferFailed(address token, address from, address to, uint256 amount);
+    error UnexpectedValue(uint256 value);
+    error UnsupportedPair(address tokenIn, address tokenOut);
+    error ZeroAmount();
+    error ZeroRecipient();
+
+    address public immutable WETH;
+    address public immutable USDC;
+    uint256 public immutable USDC_PER_WETH;
+
+    constructor(address weth_, address usdc_, uint256 usdcPerWeth_) {
+        if (weth_ == address(0) || usdc_ == address(0)) {
+            revert MissingTokenAddress();
+        }
+        if (usdcPerWeth_ == 0) {
+            revert ZeroAmount();
+        }
+
+        WETH = weth_;
+        USDC = usdc_;
+        USDC_PER_WETH = usdcPerWeth_;
+    }
+
+    function exactInputSingle(UniswapExactInputSingleParams calldata params)
+        external
+        payable
+        returns (uint256 amountOut)
+    {
+        amountOut = _swap(
+            params.tokenIn, params.tokenOut, params.recipient, params.amountIn, params.amountOutMinimum, msg.sig
+        );
+    }
+
+    function exactInputSingle(AerodromeExactInputSingleParams calldata params)
+        external
+        payable
+        returns (uint256 amountOut)
+    {
+        if (params.deadline < block.timestamp) {
+            revert DeadlineExpired(params.deadline, block.timestamp);
+        }
+
+        amountOut =
+            _swap(params.tokenIn, params.tokenOut, params.recipient, params.amountIn, params.amountOutMinimum, msg.sig);
+    }
+
+    function quoteExactInput(address tokenIn, address tokenOut, uint256 amountIn)
+        public
+        view
+        returns (uint256 amountOut)
+    {
+        if (amountIn == 0) {
+            revert ZeroAmount();
+        }
+
+        if (tokenIn == WETH && tokenOut == USDC) {
+            return amountIn * USDC_PER_WETH / 1 ether;
+        }
+        if (tokenIn == USDC && tokenOut == WETH) {
+            return amountIn * 1 ether / USDC_PER_WETH;
+        }
+
+        revert UnsupportedPair(tokenIn, tokenOut);
+    }
+
+    function _swap(
+        address tokenIn,
+        address tokenOut,
+        address recipient,
+        uint256 amountIn,
+        uint256 amountOutMinimum,
+        bytes4 selector
+    ) internal returns (uint256 amountOut) {
+        if (msg.value != 0) {
+            revert UnexpectedValue(msg.value);
+        }
+        if (recipient == address(0)) {
+            revert ZeroRecipient();
+        }
+
+        amountOut = quoteExactInput(tokenIn, tokenOut, amountIn);
+        if (amountOut < amountOutMinimum) {
+            revert InsufficientOutput(amountOut, amountOutMinimum);
+        }
+
+        bool pulled = IERC20Like(tokenIn).transferFrom(msg.sender, address(this), amountIn);
+        if (!pulled) {
+            revert TransferFailed(tokenIn, msg.sender, address(this), amountIn);
+        }
+
+        bool paid = IERC20Like(tokenOut).transfer(recipient, amountOut);
+        if (!paid) {
+            revert TransferFailed(tokenOut, address(this), recipient, amountOut);
+        }
+
+        emit Swap(msg.sender, tokenIn, tokenOut, recipient, amountIn, amountOut, selector);
+    }
+}

--- a/crates/utilities/test-utils/contracts/src/DevnetUSDC.sol
+++ b/crates/utilities/test-utils/contracts/src/DevnetUSDC.sol
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.0;
+
+import {MockERC20} from "solmate/test/utils/mocks/MockERC20.sol";
+
+/// @notice Standard 6-decimal USDC-like token for local real-token load-test setup.
+contract DevnetUSDC is MockERC20 {
+    constructor() MockERC20("Devnet USDC", "USDC", 6) {}
+}

--- a/crates/utilities/test-utils/contracts/test/DevnetSwapRouterShim.t.sol
+++ b/crates/utilities/test-utils/contracts/test/DevnetSwapRouterShim.t.sol
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.0;
+
+import {Test} from "forge-std/Test.sol";
+import {MockERC20} from "solmate/test/utils/mocks/MockERC20.sol";
+import {DevnetSwapRouterShim} from "../src/DevnetSwapRouterShim.sol";
+import {DevnetUSDC} from "../src/DevnetUSDC.sol";
+
+contract DevnetSwapRouterShimTest is Test {
+    uint256 internal constant USDC_PER_WETH = 1_000e6;
+
+    address internal user = address(0x1234);
+
+    MockERC20 internal weth;
+    DevnetUSDC internal usdc;
+    DevnetSwapRouterShim internal router;
+
+    function setUp() public {
+        weth = new MockERC20("Wrapped Ether", "WETH", 18);
+        usdc = new DevnetUSDC();
+        router = new DevnetSwapRouterShim(address(weth), address(usdc), USDC_PER_WETH);
+
+        weth.mint(user, 1 ether);
+        usdc.mint(user, 100e6);
+
+        weth.mint(address(router), 10 ether);
+        usdc.mint(address(router), 10_000e6);
+    }
+
+    function testUniswapExactInputSingleWethToUsdc() public {
+        vm.startPrank(user);
+        weth.approve(address(router), type(uint256).max);
+
+        uint256 amountOut = router.exactInputSingle(
+            DevnetSwapRouterShim.UniswapExactInputSingleParams({
+                tokenIn: address(weth),
+                tokenOut: address(usdc),
+                fee: 500,
+                recipient: user,
+                amountIn: 0.01 ether,
+                amountOutMinimum: 10e6,
+                sqrtPriceLimitX96: 0
+            })
+        );
+
+        vm.stopPrank();
+
+        assertEq(amountOut, 10e6);
+        assertEq(weth.balanceOf(user), 0.99 ether);
+        assertEq(usdc.balanceOf(user), 110e6);
+    }
+
+    function testAerodromeExactInputSingleUsdcToWeth() public {
+        vm.startPrank(user);
+        usdc.approve(address(router), type(uint256).max);
+
+        uint256 amountOut = router.exactInputSingle(
+            DevnetSwapRouterShim.AerodromeExactInputSingleParams({
+                tokenIn: address(usdc),
+                tokenOut: address(weth),
+                tickSpacing: 100,
+                recipient: user,
+                deadline: block.timestamp,
+                amountIn: 1e6,
+                amountOutMinimum: 0.001 ether,
+                sqrtPriceLimitX96: 0
+            })
+        );
+
+        vm.stopPrank();
+
+        assertEq(amountOut, 0.001 ether);
+        assertEq(usdc.balanceOf(user), 99e6);
+        assertEq(weth.balanceOf(user), 1.001 ether);
+    }
+
+    function testRevertsWhenAllowanceIsMissing() public {
+        vm.expectRevert();
+        vm.prank(user);
+        router.exactInputSingle(
+            DevnetSwapRouterShim.UniswapExactInputSingleParams({
+                tokenIn: address(weth),
+                tokenOut: address(usdc),
+                fee: 500,
+                recipient: user,
+                amountIn: 0.01 ether,
+                amountOutMinimum: 10e6,
+                sqrtPriceLimitX96: 0
+            })
+        );
+    }
+
+    function testRevertsOnUnsupportedPair() public {
+        MockERC20 other = new MockERC20("Other", "OTHER", 18);
+        other.mint(user, 1 ether);
+
+        vm.startPrank(user);
+        other.approve(address(router), type(uint256).max);
+        vm.expectRevert(
+            abi.encodeWithSelector(DevnetSwapRouterShim.UnsupportedPair.selector, address(other), address(usdc))
+        );
+        router.exactInputSingle(
+            DevnetSwapRouterShim.UniswapExactInputSingleParams({
+                tokenIn: address(other),
+                tokenOut: address(usdc),
+                fee: 500,
+                recipient: user,
+                amountIn: 0.01 ether,
+                amountOutMinimum: 0,
+                sqrtPriceLimitX96: 0
+            })
+        );
+        vm.stopPrank();
+    }
+}


### PR DESCRIPTION
## Summary

- Add optional `real_token_setup` support for `base-load-tester`, including WETH wrapping, paired-token acquisition, router approvals, and real-token recovery.
- Keep real-token setup config-driven rather than adding new scenario enums; measured traffic still uses the existing Uniswap V3 and Aerodrome CL payloads.
- Add direction-specific swap amount ranges so WETH -> USDC and USDC -> WETH use amounts in the correct token units.
- Add network-agnostic real-token Justfile workflows:
  - `just load-test real-token [network]`
  - `just load-test real-token-recover [network]`
- Add real-token configs for devnet, Base Sepolia, and mainnet snapshot.
- Add a Foundry devnet harness for local WETH/USDC swaps using shim routers.
- Split real-token config parsing and runner logic into smaller modules.

## Validation

- `cargo check -p base-load-tester-bin`
- `cargo test -p base-load-tests -- --nocapture`
- `cargo fmt --check`
- `forge test --match-contract DevnetSwapRouterShimTest`
- `just check::format`
- `just check::clippy-affected-ci origin/main`
- `just load-test real-token`
  - Submitted: 5520
  - Confirmed: 5520
  - Failed: 0
  - Reverted: 0
  - Success: 100.0%
- `just load-test real-token sepolia`
  - Submitted: 3111
  - Confirmed: 3111
  - Failed: 0
  - Reverted: 0
  - Success: 100.0%
- `just load-test real-token-recover sepolia`
  - Recovered remaining USDC/WETH balances and drained ETH back to the funder.

## Metadata

type=routine
risk=low
impact=sev5
