### PR TITLE
feat(common): Add Activation Registry

### DIFF
--- a/crates/common/precompile-storage/src/error.rs
+++ b/crates/common/precompile-storage/src/error.rs
@@ -88,6 +88,9 @@ impl BasePrecompileError {
     }
 
     /// ABI-encodes this error and wraps it as a [`PrecompileResult`] (revert or fatal error).
+    ///
+    /// Internal dispatch diagnostics use compact, non-ABI revert data: unknown selectors return the
+    /// raw selector bytes, and decode failures return `selector || utf8_error_string`.
     pub fn into_precompile_result(self, gas: u64) -> PrecompileResult {
         let bytes: Bytes = match self {
             Self::Revert(bytes) => bytes,

--- a/crates/common/precompile-storage/src/error.rs
+++ b/crates/common/precompile-storage/src/error.rs
@@ -25,6 +25,15 @@ pub enum BasePrecompileError {
     #[error("Unknown function selector: {0:?}")]
     UnknownFunctionSelector([u8; 4]),
 
+    /// The calldata selector is known, but its arguments failed ABI decoding.
+    #[error("ABI decode failed for selector {selector:?}: {error}")]
+    AbiDecodeFailed {
+        /// The matched calldata selector.
+        selector: [u8; 4],
+        /// The ABI decoder error.
+        error: String,
+    },
+
     /// Storage slot arithmetic overflow.
     #[error("Slot overflow")]
     SlotOverflow,
@@ -94,6 +103,11 @@ impl BasePrecompileError {
                 return Err(PrecompileError::Fatal(msg));
             }
             Self::UnknownFunctionSelector(sel) => sel.to_vec().into(),
+            Self::AbiDecodeFailed { selector, error } => {
+                let mut bytes = selector.to_vec();
+                bytes.extend_from_slice(error.as_bytes());
+                bytes.into()
+            }
         };
         // revm 32.x: revert is Ok with reverted=true
         Ok(PrecompileOutput::new_reverted(gas, bytes))

--- a/crates/common/precompile-storage/src/types/mod.rs
+++ b/crates/common/precompile-storage/src/types/mod.rs
@@ -24,6 +24,10 @@ pub use vec::VecHandler;
 ///
 /// Enables `Index` implementations on handlers by storing child handlers and
 /// returning references that remain valid across insertions.
+///
+/// INVARIANT: Once an entry is pushed, it must never be removed or replaced.
+/// `get_or_insert` returns references into heap-allocated handlers that would
+/// dangle if entries were evicted.
 #[derive(Debug, Default)]
 pub struct HandlerCache<K, H> {
     inner: RefCell<BTreeMap<K, Box<H>>>,

--- a/crates/common/precompiles/Cargo.toml
+++ b/crates/common/precompiles/Cargo.toml
@@ -17,6 +17,7 @@ workspace = true
 alloy-evm.workspace = true
 alloy-sol-types.workspace = true
 alloy-primitives.workspace = true
+
 # base
 base-common-chains.workspace = true
 base-precompile-macros.workspace = true
@@ -39,6 +40,7 @@ required-features = ["test-utils"]
 default = [ "blst", "c-kzg", "portable", "secp256k1", "std" ]
 std = [
 	"alloy-evm/std",
+	"alloy-primitives/std",
 	"alloy-sol-types/std",
 	"base-common-chains/std",
 	"base-precompile-storage/std",

--- a/crates/common/precompiles/README.md
+++ b/crates/common/precompiles/README.md
@@ -24,9 +24,9 @@ known Base precompile set until they are explicitly mapped.
 
 Starting in Beryl, `BasePrecompileInstaller` also installs the activation registry precompile at
 `0x84530000000000000000000000000000000000ff`. The registry stores runtime feature flags keyed by
-`bytes32`, defaults every feature to disabled, and exposes `isEnabled(bytes32)`,
-`enable(bytes32)`, `disable(bytes32)`, and `activationAdmin()`. Only the configured activation admin
-can mutate feature state, and repeated no-op transitions revert.
+`bytes32`, defaults every feature to inactive, and exposes `isActivated(bytes32)`, `admin()`,
+`activate(bytes32)`, and `deactive(bytes32)`. Only the configured activation admin can mutate
+feature state, and repeated no-op transitions revert.
 
 ## Usage
 

--- a/crates/common/precompiles/README.md
+++ b/crates/common/precompiles/README.md
@@ -22,6 +22,12 @@ Isthmus adds the Prague BLS12-381 precompiles with Base-specific limits, and Jov
 variable-input bn254 and BLS12-381 limits. Azul, Beryl, and newer Base upgrades inherit the latest
 known Base precompile set until they are explicitly mapped.
 
+Starting in Beryl, `BasePrecompileInstaller` also installs the activation registry precompile at
+`0x84530000000000000000000000000000000000ff`. The registry stores runtime feature flags keyed by
+`bytes32`, defaults every feature to disabled, and exposes `isEnabled(bytes32)`,
+`enable(bytes32)`, `disable(bytes32)`, and `activationAdmin()`. Only the configured activation admin
+can mutate feature state, and repeated no-op transitions revert.
+
 ## Usage
 
 Add the dependency to your `Cargo.toml`:

--- a/crates/common/precompiles/README.md
+++ b/crates/common/precompiles/README.md
@@ -25,7 +25,7 @@ known Base precompile set until they are explicitly mapped.
 Starting in Beryl, `BasePrecompileInstaller` also installs the activation registry precompile at
 `0x84530000000000000000000000000000000000ff`. The registry stores runtime feature flags keyed by
 `bytes32`, defaults every feature to inactive, and exposes `isActivated(bytes32)`, `admin()`,
-`activate(bytes32)`, and `deactive(bytes32)`. Only the configured activation admin can mutate
+`activate(bytes32)`, and `deactivate(bytes32)`. Only the configured activation admin can mutate
 feature state, and repeated no-op transitions revert.
 
 ## Usage

--- a/crates/common/precompiles/src/activation.rs
+++ b/crates/common/precompiles/src/activation.rs
@@ -86,38 +86,37 @@ impl ActivationRegistry {
 
         let data = input.data;
         let mut storage = EvmPrecompileStorageProvider::new(input);
-        StorageCtx::enter(&mut storage, || Self::new().dispatch(data))
+        StorageCtx::enter(&mut storage, |ctx| Self::new().dispatch(ctx, data))
     }
 
     /// ABI-dispatches activation registry calldata.
-    pub fn dispatch(self, calldata: &[u8]) -> PrecompileResult {
-        match self.inner(calldata) {
+    pub fn dispatch(self, ctx: StorageCtx<'_>, calldata: &[u8]) -> PrecompileResult {
+        match self.inner(ctx, calldata) {
             Ok(output) => Ok(output),
-            Err(error) => StorageCtx.error_result(error),
+            Err(error) => ctx.error_result(error),
         }
     }
 
     /// Returns true when the feature is enabled.
-    pub fn is_enabled(self, feature: B256) -> Result<bool> {
-        ActivationRegistryStorage::new().features.at(&feature).read()
+    pub fn is_enabled(self, ctx: StorageCtx<'_>, feature: B256) -> Result<bool> {
+        ActivationRegistryStorage::new(ctx).features.at(&feature).read()
     }
 
     /// Reverts unless the feature is enabled.
-    pub fn assert_enabled(self, feature: B256) -> PrecompileResult {
-        match self.is_enabled(feature) {
-            Ok(true) => Ok(StorageCtx.success_output(Bytes::new())),
-            Ok(false) => Ok(StorageCtx.abi_revert(
+    pub fn assert_enabled(self, ctx: StorageCtx<'_>, feature: B256) -> PrecompileResult {
+        match self.is_enabled(ctx, feature) {
+            Ok(true) => Ok(ctx.success_output(Bytes::new())),
+            Ok(false) => Ok(ctx.abi_revert(
                 IActivationRegistry::IActivationRegistryErrors::FeatureNotEnabled(
                     IActivationRegistry::FeatureNotEnabled { feature },
                 ),
             )),
-            Err(error) => StorageCtx.error_result(error),
+            Err(error) => ctx.error_result(error),
         }
     }
 
     /// Enables the feature.
-    pub fn enable(self, feature: B256) -> Result<PrecompileOutput> {
-        let mut ctx = StorageCtx;
+    pub fn enable(self, ctx: StorageCtx<'_>, feature: B256) -> Result<PrecompileOutput> {
         if ctx.is_static() {
             return Ok(ctx.abi_revert(
                 IActivationRegistry::IActivationRegistryErrors::StaticCallNotAllowed(
@@ -135,7 +134,7 @@ impl ActivationRegistry {
             ));
         }
 
-        let mut storage = ActivationRegistryStorage::new();
+        let mut storage = ActivationRegistryStorage::new(ctx);
         if storage.features.at(&feature).read()? {
             return Ok(ctx.abi_revert(
                 IActivationRegistry::IActivationRegistryErrors::AlreadyEnabled(
@@ -159,7 +158,7 @@ impl ActivationRegistry {
     }
 
     /// Runs the decoded activation registry call.
-    pub fn inner(self, calldata: &[u8]) -> Result<PrecompileOutput> {
+    pub fn inner(self, ctx: StorageCtx<'_>, calldata: &[u8]) -> Result<PrecompileOutput> {
         if calldata.len() < 4 {
             return Err(BasePrecompileError::UnknownFunctionSelector([0u8; 4]));
         }
@@ -170,15 +169,15 @@ impl ActivationRegistry {
 
         match call {
             IActivationRegistry::IActivationRegistryCalls::isEnabled(call) => {
-                let enabled = self.is_enabled(call.feature)?;
-                Ok(StorageCtx.success_output(
+                let enabled = self.is_enabled(ctx, call.feature)?;
+                Ok(ctx.success_output(
                     IActivationRegistry::isEnabledCall::abi_encode_returns(&enabled).into(),
                 ))
             }
             IActivationRegistry::IActivationRegistryCalls::enable(call) => {
-                self.enable(call.feature)
+                self.enable(ctx, call.feature)
             }
-            IActivationRegistry::IActivationRegistryCalls::activationAdmin(_) => Ok(StorageCtx
+            IActivationRegistry::IActivationRegistryCalls::activationAdmin(_) => Ok(ctx
                 .success_output(
                     IActivationRegistry::activationAdminCall::abi_encode_returns(
                         &self.activation_admin(),
@@ -201,15 +200,15 @@ mod tests {
         calldata: Bytes,
     ) -> PrecompileOutput {
         storage.set_caller(caller);
-        StorageCtx::enter(storage, || ActivationRegistry::new().dispatch(&calldata))
+        StorageCtx::enter(storage, |ctx| ActivationRegistry::new().dispatch(ctx, &calldata))
             .expect("precompile execution should not fail fatally")
     }
 
     fn assert_enabled(storage: &mut HashMapStorageProvider, expected: bool) {
-        StorageCtx::enter(storage, || {
+        StorageCtx::enter(storage, |ctx| {
             assert_eq!(
                 ActivationRegistry::new()
-                    .is_enabled(SECURITIES_TOKEN_CREATION)
+                    .is_enabled(ctx, SECURITIES_TOKEN_CREATION)
                     .expect("storage read succeeds"),
                 expected
             );

--- a/crates/common/precompiles/src/activation.rs
+++ b/crates/common/precompiles/src/activation.rs
@@ -1,0 +1,294 @@
+use alloy_evm::precompiles::{DynPrecompile, PrecompileInput};
+use alloy_primitives::{Address, B256, Bytes, address, b256};
+use alloy_sol_types::{SolCall, SolError, SolEvent, SolInterface, sol};
+use base_precompile_macros::contract;
+use base_precompile_storage::{
+    BasePrecompileError, EvmPrecompileStorageProvider, Handler, Mapping, Result, StorageCtx,
+};
+use revm::precompile::{PrecompileId, PrecompileOutput, PrecompileResult};
+
+/// Activation registry precompile address.
+pub const ACTIVATION_REGISTRY_ADDRESS: Address =
+    address!("0x84530000000000000000000000000000000000ff");
+
+/// Temporary activation admin address.
+///
+/// Replace this with the final Base-controlled activation signer before deployment.
+pub const ACTIVATION_ADMIN_ADDRESS: Address =
+    address!("0xcb00000000000000000000000000000000000000");
+
+/// Security-token factory creation feature id.
+pub const SECURITIES_TOKEN_CREATION: B256 =
+    b256!("0x89e4523f0886ce01d76094212ed707081da92a45221e22c15c5689be470db63e");
+
+sol! {
+    /// Activation registry ABI.
+    interface IActivationRegistry {
+        /// Emitted when a feature is enabled.
+        event FeatureEnabled(bytes32 indexed feature, address indexed caller);
+
+        /// Caller is not authorized to enable features.
+        error Unauthorized(address caller);
+
+        /// Feature is already enabled.
+        error AlreadyEnabled(bytes32 feature);
+
+        /// Feature is not enabled.
+        error FeatureNotEnabled(bytes32 feature);
+
+        /// Precompile cannot be executed via delegatecall or callcode.
+        error DelegateCallNotAllowed();
+
+        /// State-mutating call was attempted in a static context.
+        error StaticCallNotAllowed();
+
+        /// Returns true when `feature` is enabled.
+        function isEnabled(bytes32 feature) external view returns (bool);
+
+        /// Enables `feature`.
+        function enable(bytes32 feature) external;
+
+        /// Returns the activation admin.
+        function activationAdmin() external view returns (address);
+    }
+}
+
+/// Storage layout for the activation registry.
+#[contract(addr = ACTIVATION_REGISTRY_ADDRESS)]
+pub struct ActivationRegistryStorage {
+    /// Runtime activation flags keyed by feature id.
+    pub features: Mapping<B256, bool>,
+}
+
+/// Runtime activation registry for Base-native features.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct ActivationRegistry;
+
+impl ActivationRegistry {
+    /// Creates a new activation registry handle.
+    pub const fn new() -> Self {
+        Self
+    }
+
+    /// Creates the EVM precompile wrapper for the activation registry.
+    pub fn create_precompile() -> DynPrecompile {
+        DynPrecompile::new_stateful(PrecompileId::Custom("ActivationRegistry".into()), Self::run)
+    }
+
+    /// Executes the activation registry precompile.
+    pub fn run(input: PrecompileInput<'_>) -> PrecompileResult {
+        if !input.is_direct_call() {
+            return Ok(PrecompileOutput::new_reverted(
+                0,
+                IActivationRegistry::DelegateCallNotAllowed {}.abi_encode().into(),
+            ));
+        }
+
+        let data = input.data;
+        let mut storage = EvmPrecompileStorageProvider::new(input);
+        StorageCtx::enter(&mut storage, || Self::new().dispatch(data))
+    }
+
+    /// ABI-dispatches activation registry calldata.
+    pub fn dispatch(self, calldata: &[u8]) -> PrecompileResult {
+        match self.inner(calldata) {
+            Ok(output) => Ok(output),
+            Err(error) => StorageCtx.error_result(error),
+        }
+    }
+
+    /// Returns true when the feature is enabled.
+    pub fn is_enabled(self, feature: B256) -> Result<bool> {
+        ActivationRegistryStorage::new().features.at(&feature).read()
+    }
+
+    /// Reverts unless the feature is enabled.
+    pub fn assert_enabled(self, feature: B256) -> PrecompileResult {
+        match self.is_enabled(feature) {
+            Ok(true) => Ok(StorageCtx.success_output(Bytes::new())),
+            Ok(false) => Ok(StorageCtx.abi_revert(
+                IActivationRegistry::IActivationRegistryErrors::FeatureNotEnabled(
+                    IActivationRegistry::FeatureNotEnabled { feature },
+                ),
+            )),
+            Err(error) => StorageCtx.error_result(error),
+        }
+    }
+
+    /// Enables the feature.
+    pub fn enable(self, feature: B256) -> Result<PrecompileOutput> {
+        let mut ctx = StorageCtx;
+        if ctx.is_static() {
+            return Ok(ctx.abi_revert(
+                IActivationRegistry::IActivationRegistryErrors::StaticCallNotAllowed(
+                    IActivationRegistry::StaticCallNotAllowed {},
+                ),
+            ));
+        }
+
+        let caller = ctx.caller();
+        if caller != ACTIVATION_ADMIN_ADDRESS {
+            return Ok(ctx.abi_revert(
+                IActivationRegistry::IActivationRegistryErrors::Unauthorized(
+                    IActivationRegistry::Unauthorized { caller },
+                ),
+            ));
+        }
+
+        let mut storage = ActivationRegistryStorage::new();
+        if storage.features.at(&feature).read()? {
+            return Ok(ctx.abi_revert(
+                IActivationRegistry::IActivationRegistryErrors::AlreadyEnabled(
+                    IActivationRegistry::AlreadyEnabled { feature },
+                ),
+            ));
+        }
+
+        storage.features.at_mut(&feature).write(true)?;
+        ctx.emit_event(
+            ACTIVATION_REGISTRY_ADDRESS,
+            IActivationRegistry::FeatureEnabled { feature, caller }.encode_log_data(),
+        )?;
+
+        Ok(ctx.success_output(Bytes::new()))
+    }
+
+    /// Returns the activation admin.
+    pub const fn activation_admin(self) -> Address {
+        ACTIVATION_ADMIN_ADDRESS
+    }
+
+    /// Runs the decoded activation registry call.
+    pub fn inner(self, calldata: &[u8]) -> Result<PrecompileOutput> {
+        if calldata.len() < 4 {
+            return Err(BasePrecompileError::UnknownFunctionSelector([0u8; 4]));
+        }
+
+        let selector: [u8; 4] = calldata[..4].try_into().expect("selector length checked above");
+        let call = IActivationRegistry::IActivationRegistryCalls::abi_decode(calldata)
+            .map_err(|_| BasePrecompileError::UnknownFunctionSelector(selector))?;
+
+        match call {
+            IActivationRegistry::IActivationRegistryCalls::isEnabled(call) => {
+                let enabled = self.is_enabled(call.feature)?;
+                Ok(StorageCtx.success_output(
+                    IActivationRegistry::isEnabledCall::abi_encode_returns(&enabled).into(),
+                ))
+            }
+            IActivationRegistry::IActivationRegistryCalls::enable(call) => {
+                self.enable(call.feature)
+            }
+            IActivationRegistry::IActivationRegistryCalls::activationAdmin(_) => Ok(StorageCtx
+                .success_output(
+                    IActivationRegistry::activationAdminCall::abi_encode_returns(
+                        &self.activation_admin(),
+                    )
+                    .into(),
+                )),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use base_precompile_storage::{HashMapStorageProvider, StorageCtx};
+
+    use super::*;
+
+    fn execute_with(
+        storage: &mut HashMapStorageProvider,
+        caller: Address,
+        calldata: Bytes,
+    ) -> PrecompileOutput {
+        storage.set_caller(caller);
+        StorageCtx::enter(storage, || ActivationRegistry::new().dispatch(&calldata))
+            .expect("precompile execution should not fail fatally")
+    }
+
+    fn assert_enabled(storage: &mut HashMapStorageProvider, expected: bool) {
+        StorageCtx::enter(storage, || {
+            assert_eq!(
+                ActivationRegistry::new()
+                    .is_enabled(SECURITIES_TOKEN_CREATION)
+                    .expect("storage read succeeds"),
+                expected
+            );
+        });
+    }
+
+    #[test]
+    fn feature_is_disabled_by_default() {
+        let mut storage = HashMapStorageProvider::new(1);
+
+        assert_enabled(&mut storage, false);
+    }
+
+    #[test]
+    fn activation_admin_can_enable_feature() {
+        let mut storage = HashMapStorageProvider::new(1);
+        let calldata =
+            IActivationRegistry::enableCall { feature: SECURITIES_TOKEN_CREATION }.abi_encode();
+
+        let output = execute_with(&mut storage, ACTIVATION_ADMIN_ADDRESS, calldata.into());
+
+        assert!(!output.reverted);
+        assert_enabled(&mut storage, true);
+        assert_eq!(storage.get_events(ACTIVATION_REGISTRY_ADDRESS).len(), 1);
+    }
+
+    #[test]
+    fn unauthorized_caller_cannot_enable_feature() {
+        let mut storage = HashMapStorageProvider::new(1);
+        let caller = address!("0x0000000000000000000000000000000000000001");
+        let calldata =
+            IActivationRegistry::enableCall { feature: SECURITIES_TOKEN_CREATION }.abi_encode();
+
+        let output = execute_with(&mut storage, caller, calldata.into());
+
+        assert!(output.reverted);
+        assert_enabled(&mut storage, false);
+    }
+
+    #[test]
+    fn enabled_feature_cannot_be_enabled_again() {
+        let mut storage = HashMapStorageProvider::new(1);
+        let calldata: Bytes =
+            IActivationRegistry::enableCall { feature: SECURITIES_TOKEN_CREATION }
+                .abi_encode()
+                .into();
+
+        let first = execute_with(&mut storage, ACTIVATION_ADMIN_ADDRESS, calldata.clone());
+        let second = execute_with(&mut storage, ACTIVATION_ADMIN_ADDRESS, calldata);
+
+        assert!(!first.reverted);
+        assert!(second.reverted);
+        assert_enabled(&mut storage, true);
+    }
+
+    #[test]
+    fn static_call_cannot_enable_feature() {
+        let mut storage = HashMapStorageProvider::new(1);
+        storage.set_static(true);
+        let calldata =
+            IActivationRegistry::enableCall { feature: SECURITIES_TOKEN_CREATION }.abi_encode();
+
+        let output = execute_with(&mut storage, ACTIVATION_ADMIN_ADDRESS, calldata.into());
+
+        assert!(output.reverted);
+        assert_enabled(&mut storage, false);
+    }
+
+    #[test]
+    fn view_call_returns_activation_state() {
+        let mut storage = HashMapStorageProvider::new(1);
+        let calldata =
+            IActivationRegistry::isEnabledCall { feature: SECURITIES_TOKEN_CREATION }.abi_encode();
+
+        let output = execute_with(&mut storage, Address::ZERO, calldata.into());
+        let enabled = IActivationRegistry::isEnabledCall::abi_decode_returns(&output.bytes)
+            .expect("return data decodes");
+
+        assert!(!output.reverted);
+        assert!(!enabled);
+    }
+}

--- a/crates/common/precompiles/src/activation.rs
+++ b/crates/common/precompiles/src/activation.rs
@@ -29,11 +29,17 @@ sol! {
         /// Emitted when a feature is enabled.
         event FeatureEnabled(bytes32 indexed feature, address indexed caller);
 
+        /// Emitted when a feature is disabled.
+        event FeatureDisabled(bytes32 indexed feature, address indexed caller);
+
         /// Caller is not authorized to enable features.
         error Unauthorized(address caller);
 
         /// Feature is already enabled.
         error AlreadyEnabled(bytes32 feature);
+
+        /// Feature is already disabled.
+        error AlreadyDisabled(bytes32 feature);
 
         /// Feature is not enabled.
         error FeatureNotEnabled(bytes32 feature);
@@ -49,6 +55,9 @@ sol! {
 
         /// Enables `feature`.
         function enable(bytes32 feature) external;
+
+        /// Disables `feature`.
+        function disable(bytes32 feature) external;
 
         /// Returns the activation admin.
         function activationAdmin() external view returns (address);
@@ -123,6 +132,21 @@ impl ActivationRegistry {
 
     /// Enables the feature.
     pub fn enable(self, ctx: StorageCtx<'_>, feature: B256) -> Result<PrecompileOutput> {
+        self.set_enabled(ctx, feature, true)
+    }
+
+    /// Disables the feature.
+    pub fn disable(self, ctx: StorageCtx<'_>, feature: B256) -> Result<PrecompileOutput> {
+        self.set_enabled(ctx, feature, false)
+    }
+
+    /// Sets the feature state.
+    pub fn set_enabled(
+        self,
+        ctx: StorageCtx<'_>,
+        feature: B256,
+        enabled: bool,
+    ) -> Result<PrecompileOutput> {
         if ctx.is_static() {
             return Ok(ctx.abi_revert(
                 IActivationRegistry::IActivationRegistryErrors::StaticCallNotAllowed(
@@ -141,19 +165,33 @@ impl ActivationRegistry {
         }
 
         let mut storage = ActivationRegistryStorage::new(ctx);
-        if storage.features.at(&feature).read()? {
-            return Ok(ctx.abi_revert(
+        let current = storage.features.at(&feature).read()?;
+        if current == enabled {
+            let error = if enabled {
                 IActivationRegistry::IActivationRegistryErrors::AlreadyEnabled(
                     IActivationRegistry::AlreadyEnabled { feature },
-                ),
-            ));
+                )
+            } else {
+                IActivationRegistry::IActivationRegistryErrors::AlreadyDisabled(
+                    IActivationRegistry::AlreadyDisabled { feature },
+                )
+            };
+            return Ok(ctx.abi_revert(error));
         }
 
-        storage.features.at_mut(&feature).write(true)?;
-        ctx.emit_event(
-            ACTIVATION_REGISTRY_ADDRESS,
-            IActivationRegistry::FeatureEnabled { feature, caller }.encode_log_data(),
-        )?;
+        if enabled {
+            storage.features.at_mut(&feature).write(true)?;
+            ctx.emit_event(
+                ACTIVATION_REGISTRY_ADDRESS,
+                IActivationRegistry::FeatureEnabled { feature, caller }.encode_log_data(),
+            )?;
+        } else {
+            storage.features.at_mut(&feature).delete()?;
+            ctx.emit_event(
+                ACTIVATION_REGISTRY_ADDRESS,
+                IActivationRegistry::FeatureDisabled { feature, caller }.encode_log_data(),
+            )?;
+        }
 
         Ok(ctx.success_output(Bytes::new()))
     }
@@ -195,6 +233,14 @@ impl ActivationRegistry {
                         error: error.to_string(),
                     })
             }
+            IActivationRegistry::disableCall::SELECTOR => {
+                IActivationRegistry::disableCall::abi_decode(calldata)
+                    .map(IActivationRegistry::IActivationRegistryCalls::disable)
+                    .map_err(|error| BasePrecompileError::AbiDecodeFailed {
+                        selector,
+                        error: error.to_string(),
+                    })
+            }
             IActivationRegistry::activationAdminCall::SELECTOR => {
                 IActivationRegistry::activationAdminCall::abi_decode(calldata)
                     .map(IActivationRegistry::IActivationRegistryCalls::activationAdmin)
@@ -220,6 +266,9 @@ impl ActivationRegistry {
             }
             IActivationRegistry::IActivationRegistryCalls::enable(call) => {
                 self.enable(ctx, call.feature)
+            }
+            IActivationRegistry::IActivationRegistryCalls::disable(call) => {
+                self.disable(ctx, call.feature)
             }
             IActivationRegistry::IActivationRegistryCalls::activationAdmin(_) => Ok(ctx
                 .success_output(
@@ -259,6 +308,18 @@ mod tests {
         });
     }
 
+    fn enable_feature(storage: &mut HashMapStorageProvider) -> PrecompileOutput {
+        let calldata =
+            IActivationRegistry::enableCall { feature: SECURITIES_TOKEN_CREATION }.abi_encode();
+        execute_with(storage, ACTIVATION_ADMIN_ADDRESS, calldata.into())
+    }
+
+    fn disable_feature(storage: &mut HashMapStorageProvider) -> PrecompileOutput {
+        let calldata =
+            IActivationRegistry::disableCall { feature: SECURITIES_TOKEN_CREATION }.abi_encode();
+        execute_with(storage, ACTIVATION_ADMIN_ADDRESS, calldata.into())
+    }
+
     #[test]
     fn feature_is_disabled_by_default() {
         let mut storage = HashMapStorageProvider::new(1);
@@ -269,10 +330,8 @@ mod tests {
     #[test]
     fn activation_admin_can_enable_feature() {
         let mut storage = HashMapStorageProvider::new(1);
-        let calldata =
-            IActivationRegistry::enableCall { feature: SECURITIES_TOKEN_CREATION }.abi_encode();
 
-        let output = execute_with(&mut storage, ACTIVATION_ADMIN_ADDRESS, calldata.into());
+        let output = enable_feature(&mut storage);
 
         assert!(!output.reverted);
         assert_enabled(&mut storage, true);
@@ -309,6 +368,59 @@ mod tests {
     }
 
     #[test]
+    fn activation_admin_can_disable_feature() {
+        let mut storage = HashMapStorageProvider::new(1);
+
+        let first = enable_feature(&mut storage);
+        let second = disable_feature(&mut storage);
+
+        assert!(!first.reverted);
+        assert!(!second.reverted);
+        assert_enabled(&mut storage, false);
+        assert_eq!(storage.get_events(ACTIVATION_REGISTRY_ADDRESS).len(), 2);
+    }
+
+    #[test]
+    fn disabled_feature_can_be_reenabled() {
+        let mut storage = HashMapStorageProvider::new(1);
+
+        let first = enable_feature(&mut storage);
+        let second = disable_feature(&mut storage);
+        let third = enable_feature(&mut storage);
+
+        assert!(!first.reverted);
+        assert!(!second.reverted);
+        assert!(!third.reverted);
+        assert_enabled(&mut storage, true);
+        assert_eq!(storage.get_events(ACTIVATION_REGISTRY_ADDRESS).len(), 3);
+    }
+
+    #[test]
+    fn disabled_feature_cannot_be_disabled_again() {
+        let mut storage = HashMapStorageProvider::new(1);
+
+        let output = disable_feature(&mut storage);
+
+        assert!(output.reverted);
+        assert_enabled(&mut storage, false);
+        assert_eq!(storage.get_events(ACTIVATION_REGISTRY_ADDRESS).len(), 0);
+    }
+
+    #[test]
+    fn unauthorized_caller_cannot_disable_feature() {
+        let mut storage = HashMapStorageProvider::new(1);
+        let caller = address!("0x0000000000000000000000000000000000000001");
+        let calldata =
+            IActivationRegistry::disableCall { feature: SECURITIES_TOKEN_CREATION }.abi_encode();
+
+        enable_feature(&mut storage);
+        let output = execute_with(&mut storage, caller, calldata.into());
+
+        assert!(output.reverted);
+        assert_enabled(&mut storage, true);
+    }
+
+    #[test]
     fn static_call_cannot_enable_feature() {
         let mut storage = HashMapStorageProvider::new(1);
         storage.set_static(true);
@@ -319,6 +431,20 @@ mod tests {
 
         assert!(output.reverted);
         assert_enabled(&mut storage, false);
+    }
+
+    #[test]
+    fn static_call_cannot_disable_feature() {
+        let mut storage = HashMapStorageProvider::new(1);
+        enable_feature(&mut storage);
+        storage.set_static(true);
+        let calldata =
+            IActivationRegistry::disableCall { feature: SECURITIES_TOKEN_CREATION }.abi_encode();
+
+        let output = execute_with(&mut storage, ACTIVATION_ADMIN_ADDRESS, calldata.into());
+
+        assert!(output.reverted);
+        assert_enabled(&mut storage, true);
     }
 
     #[test]
@@ -333,6 +459,47 @@ mod tests {
 
         assert!(!output.reverted);
         assert!(!enabled);
+    }
+
+    #[test]
+    fn view_call_reflects_disabled_state_after_enable() {
+        let mut storage = HashMapStorageProvider::new(1);
+        let calldata =
+            IActivationRegistry::isEnabledCall { feature: SECURITIES_TOKEN_CREATION }.abi_encode();
+
+        enable_feature(&mut storage);
+        let enabled_output = execute_with(&mut storage, Address::ZERO, calldata.clone().into());
+        let enabled = IActivationRegistry::isEnabledCall::abi_decode_returns(&enabled_output.bytes)
+            .expect("return data decodes");
+        disable_feature(&mut storage);
+        let disabled_output = execute_with(&mut storage, Address::ZERO, calldata.into());
+        let disabled =
+            IActivationRegistry::isEnabledCall::abi_decode_returns(&disabled_output.bytes)
+                .expect("return data decodes");
+
+        assert!(!enabled_output.reverted);
+        assert!(enabled);
+        assert!(!disabled_output.reverted);
+        assert!(!disabled);
+    }
+
+    #[test]
+    fn assert_enabled_reverts_after_disable() {
+        let mut storage = HashMapStorageProvider::new(1);
+
+        enable_feature(&mut storage);
+        let enabled_output = StorageCtx::enter(&mut storage, |ctx| {
+            ActivationRegistry::new().assert_enabled(ctx, SECURITIES_TOKEN_CREATION)
+        })
+        .expect("feature should be enabled");
+        disable_feature(&mut storage);
+        let disabled_output = StorageCtx::enter(&mut storage, |ctx| {
+            ActivationRegistry::new().assert_enabled(ctx, SECURITIES_TOKEN_CREATION)
+        })
+        .expect("disabled feature should return an ABI revert");
+
+        assert!(!enabled_output.reverted);
+        assert!(disabled_output.reverted);
     }
 
     #[test]
@@ -356,6 +523,23 @@ mod tests {
             error,
             BasePrecompileError::AbiDecodeFailed {
                 selector: IActivationRegistry::isEnabledCall::SELECTOR,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn malformed_disable_selector_returns_decode_error() {
+        let Err(error) =
+            ActivationRegistry::decode_call(&IActivationRegistry::disableCall::SELECTOR)
+        else {
+            panic!("arguments are missing");
+        };
+
+        assert!(matches!(
+            error,
+            BasePrecompileError::AbiDecodeFailed {
+                selector: IActivationRegistry::disableCall::SELECTOR,
                 ..
             }
         ));

--- a/crates/common/precompiles/src/activation.rs
+++ b/crates/common/precompiles/src/activation.rs
@@ -1,6 +1,8 @@
+use alloc::string::ToString;
+
 use alloy_evm::precompiles::{DynPrecompile, PrecompileInput};
 use alloy_primitives::{Address, B256, Bytes, address, b256};
-use alloy_sol_types::{SolCall, SolError, SolEvent, SolInterface, sol};
+use alloy_sol_types::{SolCall, SolError as _, SolEvent as _, sol};
 use base_precompile_macros::contract;
 use base_precompile_storage::{
     BasePrecompileError, EvmPrecompileStorageProvider, Handler, Mapping, Result, StorageCtx,
@@ -78,6 +80,7 @@ impl ActivationRegistry {
     /// Executes the activation registry precompile.
     pub fn run(input: PrecompileInput<'_>) -> PrecompileResult {
         if !input.is_direct_call() {
+            // No gas charged: the call type is invalid before any work is performed.
             return Ok(PrecompileOutput::new_reverted(
                 0,
                 IActivationRegistry::DelegateCallNotAllowed {}.abi_encode().into(),
@@ -103,6 +106,9 @@ impl ActivationRegistry {
     }
 
     /// Reverts unless the feature is enabled.
+    ///
+    /// Both the enabled and disabled paths return `Ok`; callers must inspect
+    /// [`PrecompileOutput::reverted`] to distinguish an enabled feature from an ABI revert.
     pub fn assert_enabled(self, ctx: StorageCtx<'_>, feature: B256) -> PrecompileResult {
         match self.is_enabled(ctx, feature) {
             Ok(true) => Ok(ctx.success_output(Bytes::new())),
@@ -157,15 +163,53 @@ impl ActivationRegistry {
         ACTIVATION_ADMIN_ADDRESS
     }
 
-    /// Runs the decoded activation registry call.
-    pub fn inner(self, ctx: StorageCtx<'_>, calldata: &[u8]) -> Result<PrecompileOutput> {
+    /// Returns the calldata selector, padding short calldata with zeroes.
+    pub fn calldata_selector(calldata: &[u8]) -> [u8; 4] {
+        let mut selector = [0u8; 4];
+        let len = calldata.len().min(selector.len());
+        selector[..len].copy_from_slice(&calldata[..len]);
+        selector
+    }
+
+    /// Decodes an activation registry call.
+    pub fn decode_call(calldata: &[u8]) -> Result<IActivationRegistry::IActivationRegistryCalls> {
+        let selector = Self::calldata_selector(calldata);
         if calldata.len() < 4 {
-            return Err(BasePrecompileError::UnknownFunctionSelector([0u8; 4]));
+            return Err(BasePrecompileError::UnknownFunctionSelector(selector));
         }
 
-        let selector: [u8; 4] = calldata[..4].try_into().expect("selector length checked above");
-        let call = IActivationRegistry::IActivationRegistryCalls::abi_decode(calldata)
-            .map_err(|_| BasePrecompileError::UnknownFunctionSelector(selector))?;
+        match selector {
+            IActivationRegistry::isEnabledCall::SELECTOR => {
+                IActivationRegistry::isEnabledCall::abi_decode(calldata)
+                    .map(IActivationRegistry::IActivationRegistryCalls::isEnabled)
+                    .map_err(|error| BasePrecompileError::AbiDecodeFailed {
+                        selector,
+                        error: error.to_string(),
+                    })
+            }
+            IActivationRegistry::enableCall::SELECTOR => {
+                IActivationRegistry::enableCall::abi_decode(calldata)
+                    .map(IActivationRegistry::IActivationRegistryCalls::enable)
+                    .map_err(|error| BasePrecompileError::AbiDecodeFailed {
+                        selector,
+                        error: error.to_string(),
+                    })
+            }
+            IActivationRegistry::activationAdminCall::SELECTOR => {
+                IActivationRegistry::activationAdminCall::abi_decode(calldata)
+                    .map(IActivationRegistry::IActivationRegistryCalls::activationAdmin)
+                    .map_err(|error| BasePrecompileError::AbiDecodeFailed {
+                        selector,
+                        error: error.to_string(),
+                    })
+            }
+            _ => Err(BasePrecompileError::UnknownFunctionSelector(selector)),
+        }
+    }
+
+    /// Runs the decoded activation registry call.
+    pub fn inner(self, ctx: StorageCtx<'_>, calldata: &[u8]) -> Result<PrecompileOutput> {
+        let call = Self::decode_call(calldata)?;
 
         match call {
             IActivationRegistry::IActivationRegistryCalls::isEnabled(call) => {
@@ -289,5 +333,31 @@ mod tests {
 
         assert!(!output.reverted);
         assert!(!enabled);
+    }
+
+    #[test]
+    fn short_calldata_preserves_partial_selector() {
+        let Err(error) = ActivationRegistry::decode_call(&[0xab, 0xcd]) else {
+            panic!("selector is short");
+        };
+
+        assert_eq!(error, BasePrecompileError::UnknownFunctionSelector([0xab, 0xcd, 0, 0]));
+    }
+
+    #[test]
+    fn malformed_known_selector_returns_decode_error() {
+        let Err(error) =
+            ActivationRegistry::decode_call(&IActivationRegistry::isEnabledCall::SELECTOR)
+        else {
+            panic!("arguments are missing");
+        };
+
+        assert!(matches!(
+            error,
+            BasePrecompileError::AbiDecodeFailed {
+                selector: IActivationRegistry::isEnabledCall::SELECTOR,
+                ..
+            }
+        ));
     }
 }

--- a/crates/common/precompiles/src/activation/abi.rs
+++ b/crates/common/precompiles/src/activation/abi.rs
@@ -39,6 +39,6 @@ sol! {
         function activate(bytes32 feature) external;
 
         /// Deactivates `feature`.
-        function deactive(bytes32 feature) external;
+        function deactivate(bytes32 feature) external;
     }
 }

--- a/crates/common/precompiles/src/activation/abi.rs
+++ b/crates/common/precompiles/src/activation/abi.rs
@@ -5,23 +5,23 @@ use alloy_sol_types::sol;
 sol! {
     /// Activation registry ABI.
     interface IActivationRegistry {
-        /// Emitted when a feature is enabled.
-        event FeatureEnabled(bytes32 indexed feature, address indexed caller);
+        /// Emitted when a feature is activated.
+        event FeatureActivated(bytes32 indexed feature, address indexed caller);
 
-        /// Emitted when a feature is disabled.
-        event FeatureDisabled(bytes32 indexed feature, address indexed caller);
+        /// Emitted when a feature is deactivated.
+        event FeatureDeactivated(bytes32 indexed feature, address indexed caller);
 
-        /// Caller is not authorized to enable features.
+        /// Caller is not authorized to activate features.
         error Unauthorized(address caller);
 
-        /// Feature is already enabled.
-        error AlreadyEnabled(bytes32 feature);
+        /// Feature is already activated.
+        error AlreadyActivated(bytes32 feature);
 
-        /// Feature is already disabled.
-        error AlreadyDisabled(bytes32 feature);
+        /// Feature is already deactivated.
+        error AlreadyDeactivated(bytes32 feature);
 
-        /// Feature is not enabled.
-        error FeatureNotEnabled(bytes32 feature);
+        /// Feature is not activated.
+        error FeatureNotActivated(bytes32 feature);
 
         /// Precompile cannot be executed via delegatecall or callcode.
         error DelegateCallNotAllowed();
@@ -29,16 +29,16 @@ sol! {
         /// State-mutating call was attempted in a static context.
         error StaticCallNotAllowed();
 
-        /// Returns true when `feature` is enabled.
-        function isEnabled(bytes32 feature) external view returns (bool);
-
-        /// Enables `feature`.
-        function enable(bytes32 feature) external;
-
-        /// Disables `feature`.
-        function disable(bytes32 feature) external;
+        /// Returns true when `feature` is activated.
+        function isActivated(bytes32 feature) external view returns (bool);
 
         /// Returns the activation admin.
-        function activationAdmin() external view returns (address);
+        function admin() external view returns (address);
+
+        /// Activates `feature`.
+        function activate(bytes32 feature) external;
+
+        /// Deactivates `feature`.
+        function deactive(bytes32 feature) external;
     }
 }

--- a/crates/common/precompiles/src/activation/abi.rs
+++ b/crates/common/precompiles/src/activation/abi.rs
@@ -1,0 +1,44 @@
+//! ABI definitions for the activation registry precompile.
+
+use alloy_sol_types::sol;
+
+sol! {
+    /// Activation registry ABI.
+    interface IActivationRegistry {
+        /// Emitted when a feature is enabled.
+        event FeatureEnabled(bytes32 indexed feature, address indexed caller);
+
+        /// Emitted when a feature is disabled.
+        event FeatureDisabled(bytes32 indexed feature, address indexed caller);
+
+        /// Caller is not authorized to enable features.
+        error Unauthorized(address caller);
+
+        /// Feature is already enabled.
+        error AlreadyEnabled(bytes32 feature);
+
+        /// Feature is already disabled.
+        error AlreadyDisabled(bytes32 feature);
+
+        /// Feature is not enabled.
+        error FeatureNotEnabled(bytes32 feature);
+
+        /// Precompile cannot be executed via delegatecall or callcode.
+        error DelegateCallNotAllowed();
+
+        /// State-mutating call was attempted in a static context.
+        error StaticCallNotAllowed();
+
+        /// Returns true when `feature` is enabled.
+        function isEnabled(bytes32 feature) external view returns (bool);
+
+        /// Enables `feature`.
+        function enable(bytes32 feature) external;
+
+        /// Disables `feature`.
+        function disable(bytes32 feature) external;
+
+        /// Returns the activation admin.
+        function activationAdmin() external view returns (address);
+    }
+}

--- a/crates/common/precompiles/src/activation/dispatch.rs
+++ b/crates/common/precompiles/src/activation/dispatch.rs
@@ -21,46 +21,46 @@ impl ActivationRegistry {
         }
     }
 
-    /// Returns true when the feature is enabled.
-    pub fn is_enabled(self, ctx: StorageCtx<'_>, feature: B256) -> Result<bool> {
+    /// Returns true when the feature is activated.
+    pub fn is_activated(self, ctx: StorageCtx<'_>, feature: B256) -> Result<bool> {
         ActivationRegistryStorage::new(ctx).features.at(&feature).read()
     }
 
-    /// Reverts unless the feature is enabled.
+    /// Reverts unless the feature is activated.
     ///
-    /// Both the enabled and disabled paths return `Ok`; callers must inspect
-    /// [`PrecompileOutput::reverted`] to distinguish an enabled feature from an ABI revert.
-    pub fn assert_enabled(self, ctx: StorageCtx<'_>, feature: B256) -> PrecompileResult {
-        match self.is_enabled(ctx, feature) {
+    /// Both the activated and deactivated paths return `Ok`; callers must inspect
+    /// [`PrecompileOutput::reverted`] to distinguish an activated feature from an ABI revert.
+    pub fn assert_activated(self, ctx: StorageCtx<'_>, feature: B256) -> PrecompileResult {
+        match self.is_activated(ctx, feature) {
             Ok(true) => Ok(ctx.success_output(Bytes::new())),
             Ok(false) => Ok(ctx.abi_revert(
-                IActivationRegistry::IActivationRegistryErrors::FeatureNotEnabled(
-                    IActivationRegistry::FeatureNotEnabled { feature },
+                IActivationRegistry::IActivationRegistryErrors::FeatureNotActivated(
+                    IActivationRegistry::FeatureNotActivated { feature },
                 ),
             )),
             Err(error) => ctx.error_result(error),
         }
     }
 
-    /// Enables the feature.
-    pub fn enable(self, ctx: StorageCtx<'_>, feature: B256) -> Result<PrecompileOutput> {
-        self.set_enabled(ctx, feature, true)
+    /// Activates the feature.
+    pub fn activate(self, ctx: StorageCtx<'_>, feature: B256) -> Result<PrecompileOutput> {
+        self.set_activated(ctx, feature, true)
     }
 
-    /// Disables the feature.
-    pub fn disable(self, ctx: StorageCtx<'_>, feature: B256) -> Result<PrecompileOutput> {
-        self.set_enabled(ctx, feature, false)
+    /// Deactivates the feature.
+    pub fn deactive(self, ctx: StorageCtx<'_>, feature: B256) -> Result<PrecompileOutput> {
+        self.set_activated(ctx, feature, false)
     }
 
-    /// Sets the feature state.
-    pub fn set_enabled(
+    /// Sets the feature activation state.
+    pub fn set_activated(
         self,
         ctx: StorageCtx<'_>,
         feature: B256,
-        enabled: bool,
+        activated: bool,
     ) -> Result<PrecompileOutput> {
-        // Keep this guard at the shared mutation boundary so `enable`, `disable`, and direct
-        // `set_enabled` callers all get the same static-call behavior after calldata validation.
+        // Keep this guard at the shared mutation boundary so `activate`, `deactive`, and direct
+        // `set_activated` callers all get the same static-call behavior after calldata validation.
         if ctx.is_static() {
             return Ok(ctx.abi_revert(
                 IActivationRegistry::IActivationRegistryErrors::StaticCallNotAllowed(
@@ -80,30 +80,30 @@ impl ActivationRegistry {
 
         let mut storage = ActivationRegistryStorage::new(ctx);
         let current = storage.features.at(&feature).read()?;
-        if current == enabled {
-            let error = if enabled {
-                IActivationRegistry::IActivationRegistryErrors::AlreadyEnabled(
-                    IActivationRegistry::AlreadyEnabled { feature },
+        if current == activated {
+            let error = if activated {
+                IActivationRegistry::IActivationRegistryErrors::AlreadyActivated(
+                    IActivationRegistry::AlreadyActivated { feature },
                 )
             } else {
-                IActivationRegistry::IActivationRegistryErrors::AlreadyDisabled(
-                    IActivationRegistry::AlreadyDisabled { feature },
+                IActivationRegistry::IActivationRegistryErrors::AlreadyDeactivated(
+                    IActivationRegistry::AlreadyDeactivated { feature },
                 )
             };
             return Ok(ctx.abi_revert(error));
         }
 
-        if enabled {
+        if activated {
             storage.features.at_mut(&feature).write(true)?;
             ctx.emit_event(
                 ACTIVATION_REGISTRY_ADDRESS,
-                IActivationRegistry::FeatureEnabled { feature, caller }.encode_log_data(),
+                IActivationRegistry::FeatureActivated { feature, caller }.encode_log_data(),
             )?;
         } else {
             storage.features.at_mut(&feature).delete()?;
             ctx.emit_event(
                 ACTIVATION_REGISTRY_ADDRESS,
-                IActivationRegistry::FeatureDisabled { feature, caller }.encode_log_data(),
+                IActivationRegistry::FeatureDeactivated { feature, caller }.encode_log_data(),
             )?;
         }
 
@@ -128,33 +128,33 @@ impl ActivationRegistry {
         // Match selectors explicitly so unknown selectors remain distinct from known selectors
         // whose arguments fail ABI decoding.
         match selector {
-            IActivationRegistry::isEnabledCall::SELECTOR => {
-                IActivationRegistry::isEnabledCall::abi_decode(calldata)
-                    .map(IActivationRegistry::IActivationRegistryCalls::isEnabled)
+            IActivationRegistry::isActivatedCall::SELECTOR => {
+                IActivationRegistry::isActivatedCall::abi_decode(calldata)
+                    .map(IActivationRegistry::IActivationRegistryCalls::isActivated)
                     .map_err(|error| BasePrecompileError::AbiDecodeFailed {
                         selector,
                         error: error.to_string(),
                     })
             }
-            IActivationRegistry::enableCall::SELECTOR => {
-                IActivationRegistry::enableCall::abi_decode(calldata)
-                    .map(IActivationRegistry::IActivationRegistryCalls::enable)
+            IActivationRegistry::activateCall::SELECTOR => {
+                IActivationRegistry::activateCall::abi_decode(calldata)
+                    .map(IActivationRegistry::IActivationRegistryCalls::activate)
                     .map_err(|error| BasePrecompileError::AbiDecodeFailed {
                         selector,
                         error: error.to_string(),
                     })
             }
-            IActivationRegistry::disableCall::SELECTOR => {
-                IActivationRegistry::disableCall::abi_decode(calldata)
-                    .map(IActivationRegistry::IActivationRegistryCalls::disable)
+            IActivationRegistry::deactiveCall::SELECTOR => {
+                IActivationRegistry::deactiveCall::abi_decode(calldata)
+                    .map(IActivationRegistry::IActivationRegistryCalls::deactive)
                     .map_err(|error| BasePrecompileError::AbiDecodeFailed {
                         selector,
                         error: error.to_string(),
                     })
             }
-            IActivationRegistry::activationAdminCall::SELECTOR => {
-                IActivationRegistry::activationAdminCall::abi_decode(calldata)
-                    .map(IActivationRegistry::IActivationRegistryCalls::activationAdmin)
+            IActivationRegistry::adminCall::SELECTOR => {
+                IActivationRegistry::adminCall::abi_decode(calldata)
+                    .map(IActivationRegistry::IActivationRegistryCalls::admin)
                     .map_err(|error| BasePrecompileError::AbiDecodeFailed {
                         selector,
                         error: error.to_string(),
@@ -169,25 +169,21 @@ impl ActivationRegistry {
         let call = Self::decode_call(calldata)?;
 
         match call {
-            IActivationRegistry::IActivationRegistryCalls::isEnabled(call) => {
-                let enabled = self.is_enabled(ctx, call.feature)?;
+            IActivationRegistry::IActivationRegistryCalls::isActivated(call) => {
+                let activated = self.is_activated(ctx, call.feature)?;
                 Ok(ctx.success_output(
-                    IActivationRegistry::isEnabledCall::abi_encode_returns(&enabled).into(),
+                    IActivationRegistry::isActivatedCall::abi_encode_returns(&activated).into(),
                 ))
             }
-            IActivationRegistry::IActivationRegistryCalls::enable(call) => {
-                self.enable(ctx, call.feature)
+            IActivationRegistry::IActivationRegistryCalls::activate(call) => {
+                self.activate(ctx, call.feature)
             }
-            IActivationRegistry::IActivationRegistryCalls::disable(call) => {
-                self.disable(ctx, call.feature)
+            IActivationRegistry::IActivationRegistryCalls::deactive(call) => {
+                self.deactive(ctx, call.feature)
             }
-            IActivationRegistry::IActivationRegistryCalls::activationAdmin(_) => Ok(ctx
-                .success_output(
-                    IActivationRegistry::activationAdminCall::abi_encode_returns(
-                        &self.activation_admin(),
-                    )
-                    .into(),
-                )),
+            IActivationRegistry::IActivationRegistryCalls::admin(_) => Ok(ctx.success_output(
+                IActivationRegistry::adminCall::abi_encode_returns(&self.admin()).into(),
+            )),
         }
     }
 }
@@ -212,65 +208,65 @@ mod tests {
             .expect("precompile execution should not fail fatally")
     }
 
-    fn assert_enabled(storage: &mut HashMapStorageProvider, expected: bool) {
+    fn assert_activated(storage: &mut HashMapStorageProvider, expected: bool) {
         StorageCtx::enter(storage, |ctx| {
             assert_eq!(
                 ActivationRegistry::new()
-                    .is_enabled(ctx, SECURITIES_TOKEN_CREATION)
+                    .is_activated(ctx, SECURITIES_TOKEN_CREATION)
                     .expect("storage read succeeds"),
                 expected
             );
         });
     }
 
-    fn enable_feature(storage: &mut HashMapStorageProvider) -> PrecompileOutput {
+    fn activate_feature(storage: &mut HashMapStorageProvider) -> PrecompileOutput {
         let calldata =
-            IActivationRegistry::enableCall { feature: SECURITIES_TOKEN_CREATION }.abi_encode();
+            IActivationRegistry::activateCall { feature: SECURITIES_TOKEN_CREATION }.abi_encode();
         execute_with(storage, ACTIVATION_ADMIN_ADDRESS, calldata.into())
     }
 
-    fn disable_feature(storage: &mut HashMapStorageProvider) -> PrecompileOutput {
+    fn deactive_feature(storage: &mut HashMapStorageProvider) -> PrecompileOutput {
         let calldata =
-            IActivationRegistry::disableCall { feature: SECURITIES_TOKEN_CREATION }.abi_encode();
+            IActivationRegistry::deactiveCall { feature: SECURITIES_TOKEN_CREATION }.abi_encode();
         execute_with(storage, ACTIVATION_ADMIN_ADDRESS, calldata.into())
     }
 
     #[test]
-    fn feature_is_disabled_by_default() {
+    fn feature_is_inactive_by_default() {
         let mut storage = HashMapStorageProvider::new(1);
 
-        assert_enabled(&mut storage, false);
+        assert_activated(&mut storage, false);
     }
 
     #[test]
-    fn activation_admin_can_enable_feature() {
+    fn admin_can_activate_feature() {
         let mut storage = HashMapStorageProvider::new(1);
 
-        let output = enable_feature(&mut storage);
+        let output = activate_feature(&mut storage);
 
         assert!(!output.reverted);
-        assert_enabled(&mut storage, true);
+        assert_activated(&mut storage, true);
         assert_eq!(storage.get_events(ACTIVATION_REGISTRY_ADDRESS).len(), 1);
     }
 
     #[test]
-    fn unauthorized_caller_cannot_enable_feature() {
+    fn unauthorized_caller_cannot_activate_feature() {
         let mut storage = HashMapStorageProvider::new(1);
         let caller = address!("0x0000000000000000000000000000000000000001");
         let calldata =
-            IActivationRegistry::enableCall { feature: SECURITIES_TOKEN_CREATION }.abi_encode();
+            IActivationRegistry::activateCall { feature: SECURITIES_TOKEN_CREATION }.abi_encode();
 
         let output = execute_with(&mut storage, caller, calldata.into());
 
         assert!(output.reverted);
-        assert_enabled(&mut storage, false);
+        assert_activated(&mut storage, false);
     }
 
     #[test]
-    fn enabled_feature_cannot_be_enabled_again() {
+    fn activated_feature_cannot_be_activated_again() {
         let mut storage = HashMapStorageProvider::new(1);
         let calldata: Bytes =
-            IActivationRegistry::enableCall { feature: SECURITIES_TOKEN_CREATION }
+            IActivationRegistry::activateCall { feature: SECURITIES_TOKEN_CREATION }
                 .abi_encode()
                 .into();
 
@@ -279,142 +275,143 @@ mod tests {
 
         assert!(!first.reverted);
         assert!(second.reverted);
-        assert_enabled(&mut storage, true);
+        assert_activated(&mut storage, true);
     }
 
     #[test]
-    fn activation_admin_can_disable_feature() {
+    fn admin_can_deactive_feature() {
         let mut storage = HashMapStorageProvider::new(1);
 
-        let first = enable_feature(&mut storage);
-        let second = disable_feature(&mut storage);
+        let first = activate_feature(&mut storage);
+        let second = deactive_feature(&mut storage);
 
         assert!(!first.reverted);
         assert!(!second.reverted);
-        assert_enabled(&mut storage, false);
+        assert_activated(&mut storage, false);
         assert_eq!(storage.get_events(ACTIVATION_REGISTRY_ADDRESS).len(), 2);
     }
 
     #[test]
-    fn disabled_feature_can_be_reenabled() {
+    fn deactivated_feature_can_be_reactivated() {
         let mut storage = HashMapStorageProvider::new(1);
 
-        let first = enable_feature(&mut storage);
-        let second = disable_feature(&mut storage);
-        let third = enable_feature(&mut storage);
+        let first = activate_feature(&mut storage);
+        let second = deactive_feature(&mut storage);
+        let third = activate_feature(&mut storage);
 
         assert!(!first.reverted);
         assert!(!second.reverted);
         assert!(!third.reverted);
-        assert_enabled(&mut storage, true);
+        assert_activated(&mut storage, true);
         assert_eq!(storage.get_events(ACTIVATION_REGISTRY_ADDRESS).len(), 3);
     }
 
     #[test]
-    fn disabled_feature_cannot_be_disabled_again() {
+    fn deactivated_feature_cannot_be_deactivated_again() {
         let mut storage = HashMapStorageProvider::new(1);
 
-        let output = disable_feature(&mut storage);
+        let output = deactive_feature(&mut storage);
 
         assert!(output.reverted);
-        assert_enabled(&mut storage, false);
+        assert_activated(&mut storage, false);
         assert_eq!(storage.get_events(ACTIVATION_REGISTRY_ADDRESS).len(), 0);
     }
 
     #[test]
-    fn unauthorized_caller_cannot_disable_feature() {
+    fn unauthorized_caller_cannot_deactive_feature() {
         let mut storage = HashMapStorageProvider::new(1);
         let caller = address!("0x0000000000000000000000000000000000000001");
         let calldata =
-            IActivationRegistry::disableCall { feature: SECURITIES_TOKEN_CREATION }.abi_encode();
+            IActivationRegistry::deactiveCall { feature: SECURITIES_TOKEN_CREATION }.abi_encode();
 
-        enable_feature(&mut storage);
+        activate_feature(&mut storage);
         let output = execute_with(&mut storage, caller, calldata.into());
 
         assert!(output.reverted);
-        assert_enabled(&mut storage, true);
+        assert_activated(&mut storage, true);
     }
 
     #[test]
-    fn static_call_cannot_enable_feature() {
+    fn static_call_cannot_activate_feature() {
         let mut storage = HashMapStorageProvider::new(1);
         storage.set_static(true);
         let calldata =
-            IActivationRegistry::enableCall { feature: SECURITIES_TOKEN_CREATION }.abi_encode();
+            IActivationRegistry::activateCall { feature: SECURITIES_TOKEN_CREATION }.abi_encode();
 
         let output = execute_with(&mut storage, ACTIVATION_ADMIN_ADDRESS, calldata.into());
 
         assert!(output.reverted);
-        assert_enabled(&mut storage, false);
+        assert_activated(&mut storage, false);
     }
 
     #[test]
-    fn static_call_cannot_disable_feature() {
+    fn static_call_cannot_deactive_feature() {
         let mut storage = HashMapStorageProvider::new(1);
-        enable_feature(&mut storage);
+        activate_feature(&mut storage);
         storage.set_static(true);
         let calldata =
-            IActivationRegistry::disableCall { feature: SECURITIES_TOKEN_CREATION }.abi_encode();
+            IActivationRegistry::deactiveCall { feature: SECURITIES_TOKEN_CREATION }.abi_encode();
 
         let output = execute_with(&mut storage, ACTIVATION_ADMIN_ADDRESS, calldata.into());
 
         assert!(output.reverted);
-        assert_enabled(&mut storage, true);
+        assert_activated(&mut storage, true);
     }
 
     #[test]
     fn view_call_returns_activation_state() {
         let mut storage = HashMapStorageProvider::new(1);
-        let calldata =
-            IActivationRegistry::isEnabledCall { feature: SECURITIES_TOKEN_CREATION }.abi_encode();
+        let calldata = IActivationRegistry::isActivatedCall { feature: SECURITIES_TOKEN_CREATION }
+            .abi_encode();
 
         let output = execute_with(&mut storage, Address::ZERO, calldata.into());
-        let enabled = IActivationRegistry::isEnabledCall::abi_decode_returns(&output.bytes)
+        let activated = IActivationRegistry::isActivatedCall::abi_decode_returns(&output.bytes)
             .expect("return data decodes");
 
         assert!(!output.reverted);
-        assert!(!enabled);
+        assert!(!activated);
     }
 
     #[test]
-    fn view_call_reflects_disabled_state_after_enable() {
+    fn view_call_reflects_activated_state() {
         let mut storage = HashMapStorageProvider::new(1);
-        let calldata =
-            IActivationRegistry::isEnabledCall { feature: SECURITIES_TOKEN_CREATION }.abi_encode();
+        let calldata = IActivationRegistry::isActivatedCall { feature: SECURITIES_TOKEN_CREATION }
+            .abi_encode();
 
-        enable_feature(&mut storage);
-        let enabled_output = execute_with(&mut storage, Address::ZERO, calldata.clone().into());
-        let enabled = IActivationRegistry::isEnabledCall::abi_decode_returns(&enabled_output.bytes)
-            .expect("return data decodes");
-        disable_feature(&mut storage);
-        let disabled_output = execute_with(&mut storage, Address::ZERO, calldata.into());
-        let disabled =
-            IActivationRegistry::isEnabledCall::abi_decode_returns(&disabled_output.bytes)
+        activate_feature(&mut storage);
+        let activated_output = execute_with(&mut storage, Address::ZERO, calldata.clone().into());
+        let activated =
+            IActivationRegistry::isActivatedCall::abi_decode_returns(&activated_output.bytes)
+                .expect("return data decodes");
+        deactive_feature(&mut storage);
+        let deactivated_output = execute_with(&mut storage, Address::ZERO, calldata.into());
+        let deactivated =
+            IActivationRegistry::isActivatedCall::abi_decode_returns(&deactivated_output.bytes)
                 .expect("return data decodes");
 
-        assert!(!enabled_output.reverted);
-        assert!(enabled);
-        assert!(!disabled_output.reverted);
-        assert!(!disabled);
+        assert!(!activated_output.reverted);
+        assert!(activated);
+        assert!(!deactivated_output.reverted);
+        assert!(!deactivated);
     }
 
     #[test]
-    fn assert_enabled_reverts_after_disable() {
+    fn assert_activated_reverts_after_deactive() {
         let mut storage = HashMapStorageProvider::new(1);
 
-        enable_feature(&mut storage);
-        let enabled_output = StorageCtx::enter(&mut storage, |ctx| {
-            ActivationRegistry::new().assert_enabled(ctx, SECURITIES_TOKEN_CREATION)
+        activate_feature(&mut storage);
+        let activated_output = StorageCtx::enter(&mut storage, |ctx| {
+            ActivationRegistry::new().assert_activated(ctx, SECURITIES_TOKEN_CREATION)
         })
-        .expect("feature should be enabled");
-        disable_feature(&mut storage);
-        let disabled_output = StorageCtx::enter(&mut storage, |ctx| {
-            ActivationRegistry::new().assert_enabled(ctx, SECURITIES_TOKEN_CREATION)
+        .expect("feature should be activated");
+        deactive_feature(&mut storage);
+        let deactivated_output = StorageCtx::enter(&mut storage, |ctx| {
+            ActivationRegistry::new().assert_activated(ctx, SECURITIES_TOKEN_CREATION)
         })
-        .expect("disabled feature should return an ABI revert");
+        .expect("deactivated feature should return an ABI revert");
 
-        assert!(!enabled_output.reverted);
-        assert!(disabled_output.reverted);
+        assert!(!activated_output.reverted);
+        assert!(deactivated_output.reverted);
     }
 
     #[test]
@@ -429,7 +426,7 @@ mod tests {
     #[test]
     fn malformed_known_selector_returns_decode_error() {
         let Err(error) =
-            ActivationRegistry::decode_call(&IActivationRegistry::isEnabledCall::SELECTOR)
+            ActivationRegistry::decode_call(&IActivationRegistry::isActivatedCall::SELECTOR)
         else {
             panic!("arguments are missing");
         };
@@ -437,16 +434,16 @@ mod tests {
         assert!(matches!(
             error,
             BasePrecompileError::AbiDecodeFailed {
-                selector: IActivationRegistry::isEnabledCall::SELECTOR,
+                selector: IActivationRegistry::isActivatedCall::SELECTOR,
                 ..
             }
         ));
     }
 
     #[test]
-    fn malformed_disable_selector_returns_decode_error() {
+    fn malformed_deactive_selector_returns_decode_error() {
         let Err(error) =
-            ActivationRegistry::decode_call(&IActivationRegistry::disableCall::SELECTOR)
+            ActivationRegistry::decode_call(&IActivationRegistry::deactiveCall::SELECTOR)
         else {
             panic!("arguments are missing");
         };
@@ -454,7 +451,7 @@ mod tests {
         assert!(matches!(
             error,
             BasePrecompileError::AbiDecodeFailed {
-                selector: IActivationRegistry::disableCall::SELECTOR,
+                selector: IActivationRegistry::deactiveCall::SELECTOR,
                 ..
             }
         ));

--- a/crates/common/precompiles/src/activation/dispatch.rs
+++ b/crates/common/precompiles/src/activation/dispatch.rs
@@ -1,166 +1,44 @@
 //! ABI dispatch for the activation registry.
 
-use alloc::string::ToString;
-
 use alloy_primitives::Bytes;
-use alloy_sol_types::SolCall;
-use base_precompile_storage::{BasePrecompileError, IntoPrecompileResult, Result, StorageCtx};
+use alloy_sol_types::{SolCall, SolInterface};
+use base_precompile_storage::{BasePrecompileError, IntoPrecompileResult, StorageCtx};
 use revm::precompile::PrecompileResult;
 
-use super::{ActivationRegistry, IActivationRegistry};
+use super::{
+    ActivationRegistry,
+    IActivationRegistry::{self, IActivationRegistryCalls as C},
+};
 
-impl ActivationRegistry {
+impl ActivationRegistry<'_> {
     /// ABI-dispatches activation registry calldata.
-    pub fn dispatch(self, ctx: StorageCtx<'_>, calldata: &[u8]) -> PrecompileResult {
-        self.handle_call(ctx, calldata).into_precompile_result(ctx.gas_used(), |output| output)
+    pub fn dispatch(&mut self, ctx: StorageCtx<'_>, calldata: &[u8]) -> PrecompileResult {
+        self.inner(calldata).into_precompile_result(ctx.gas_used(), |output| output)
     }
 
-    /// Returns the calldata selector, padding short calldata with zeroes.
-    pub fn calldata_selector(calldata: &[u8]) -> [u8; 4] {
-        let mut selector = [0u8; 4];
-        let len = calldata.len().min(selector.len());
-        selector[..len].copy_from_slice(&calldata[..len]);
-        selector
-    }
-
-    /// Decodes an activation registry call.
-    pub fn decode_call(calldata: &[u8]) -> Result<IActivationRegistry::IActivationRegistryCalls> {
-        let selector = Self::calldata_selector(calldata);
+    fn inner(&mut self, calldata: &[u8]) -> base_precompile_storage::Result<Bytes> {
         if calldata.len() < 4 {
-            return Err(BasePrecompileError::UnknownFunctionSelector(selector));
+            return Err(BasePrecompileError::UnknownFunctionSelector([0u8; 4]));
         }
+        let selector: [u8; 4] = calldata[..4].try_into().unwrap();
 
-        // Match selectors explicitly so unknown selectors remain distinct from known selectors
-        // whose arguments fail ABI decoding.
-        match selector {
-            IActivationRegistry::isActivatedCall::SELECTOR => {
-                IActivationRegistry::isActivatedCall::abi_decode(calldata)
-                    .map(IActivationRegistry::IActivationRegistryCalls::isActivated)
-                    .map_err(|error| BasePrecompileError::AbiDecodeFailed {
-                        selector,
-                        error: error.to_string(),
-                    })
-            }
-            IActivationRegistry::activateCall::SELECTOR => {
-                IActivationRegistry::activateCall::abi_decode(calldata)
-                    .map(IActivationRegistry::IActivationRegistryCalls::activate)
-                    .map_err(|error| BasePrecompileError::AbiDecodeFailed {
-                        selector,
-                        error: error.to_string(),
-                    })
-            }
-            IActivationRegistry::deactivateCall::SELECTOR => {
-                IActivationRegistry::deactivateCall::abi_decode(calldata)
-                    .map(IActivationRegistry::IActivationRegistryCalls::deactivate)
-                    .map_err(|error| BasePrecompileError::AbiDecodeFailed {
-                        selector,
-                        error: error.to_string(),
-                    })
-            }
-            IActivationRegistry::adminCall::SELECTOR => {
-                IActivationRegistry::adminCall::abi_decode(calldata)
-                    .map(IActivationRegistry::IActivationRegistryCalls::admin)
-                    .map_err(|error| BasePrecompileError::AbiDecodeFailed {
-                        selector,
-                        error: error.to_string(),
-                    })
-            }
-            _ => Err(BasePrecompileError::UnknownFunctionSelector(selector)),
-        }
-    }
-
-    /// Handles the decoded activation registry call.
-    pub fn handle_call(self, ctx: StorageCtx<'_>, calldata: &[u8]) -> Result<Bytes> {
-        let call = Self::decode_call(calldata)?;
-
-        match call {
-            IActivationRegistry::IActivationRegistryCalls::isActivated(call) => {
-                let activated = self.is_activated(ctx, call.feature)?;
+        match IActivationRegistry::IActivationRegistryCalls::abi_decode(calldata) {
+            Ok(C::isActivated(call)) => {
+                let activated = self.is_activated(call.feature)?;
                 Ok(IActivationRegistry::isActivatedCall::abi_encode_returns(&activated).into())
             }
-            IActivationRegistry::IActivationRegistryCalls::activate(call) => {
-                self.activate(ctx, call.feature)?;
+            Ok(C::activate(call)) => {
+                self.activate(call.feature)?;
                 Ok(Bytes::new())
             }
-            IActivationRegistry::IActivationRegistryCalls::deactivate(call) => {
-                self.deactivate(ctx, call.feature)?;
+            Ok(C::deactivate(call)) => {
+                self.deactivate(call.feature)?;
                 Ok(Bytes::new())
             }
-            IActivationRegistry::IActivationRegistryCalls::admin(_) => {
+            Ok(C::admin(_)) => {
                 Ok(IActivationRegistry::adminCall::abi_encode_returns(&self.admin()).into())
             }
+            Err(_) => Err(BasePrecompileError::UnknownFunctionSelector(selector)),
         }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use alloy_primitives::{Address, B256, Bytes};
-    use alloy_sol_types::SolCall;
-    use base_precompile_storage::{BasePrecompileError, HashMapStorageProvider, StorageCtx};
-    use revm::precompile::PrecompileOutput;
-    use rstest::rstest;
-
-    use super::*;
-
-    const FEATURE: B256 = ActivationRegistry::SECURITIES_TOKEN_CREATION;
-
-    fn execute_with(
-        storage: &mut HashMapStorageProvider,
-        caller: Address,
-        calldata: Bytes,
-    ) -> PrecompileOutput {
-        storage.set_caller(caller);
-        StorageCtx::enter(storage, |ctx| ActivationRegistry::new().dispatch(ctx, &calldata))
-            .expect("precompile execution should not fail fatally")
-    }
-
-    fn activate_feature(storage: &mut HashMapStorageProvider) -> PrecompileOutput {
-        let calldata = IActivationRegistry::activateCall { feature: FEATURE }.abi_encode();
-        execute_with(storage, ActivationRegistry::ADMIN, calldata.into())
-    }
-
-    #[rstest]
-    #[case::inactive(false)]
-    #[case::active(true)]
-    fn view_call_returns_activation_state(#[case] initially_active: bool) {
-        let mut storage = HashMapStorageProvider::new(1);
-        let calldata = IActivationRegistry::isActivatedCall { feature: FEATURE }.abi_encode();
-
-        if initially_active {
-            activate_feature(&mut storage);
-        }
-        let output = execute_with(&mut storage, Address::ZERO, calldata.into());
-        let activated = IActivationRegistry::isActivatedCall::abi_decode_returns(&output.bytes)
-            .expect("return data decodes");
-
-        assert!(!output.reverted);
-        assert_eq!(activated, initially_active);
-    }
-
-    #[test]
-    fn short_calldata_preserves_partial_selector() {
-        let Err(error) = ActivationRegistry::decode_call(&[0xab, 0xcd]) else {
-            panic!("selector is short");
-        };
-
-        assert_eq!(error, BasePrecompileError::UnknownFunctionSelector([0xab, 0xcd, 0, 0]));
-    }
-
-    #[rstest]
-    #[case::is_activated(IActivationRegistry::isActivatedCall::SELECTOR)]
-    #[case::deactivate(IActivationRegistry::deactivateCall::SELECTOR)]
-    fn malformed_known_selector_returns_decode_error(#[case] selector: [u8; 4]) {
-        let Err(error) = ActivationRegistry::decode_call(&selector) else {
-            panic!("arguments are missing");
-        };
-
-        assert!(matches!(
-            error,
-            BasePrecompileError::AbiDecodeFailed {
-                selector: decoded_selector,
-                ..
-            } if decoded_selector == selector
-        ));
     }
 }

--- a/crates/common/precompiles/src/activation/dispatch.rs
+++ b/crates/common/precompiles/src/activation/dispatch.rs
@@ -15,7 +15,7 @@ use super::{
 impl ActivationRegistry {
     /// ABI-dispatches activation registry calldata.
     pub fn dispatch(self, ctx: StorageCtx<'_>, calldata: &[u8]) -> PrecompileResult {
-        match self.inner(ctx, calldata) {
+        match self.handle_call(ctx, calldata) {
             Ok(output) => Ok(output),
             Err(error) => ctx.error_result(error),
         }
@@ -160,8 +160,8 @@ impl ActivationRegistry {
         }
     }
 
-    /// Runs the decoded activation registry call.
-    pub fn inner(self, ctx: StorageCtx<'_>, calldata: &[u8]) -> Result<PrecompileOutput> {
+    /// Handles the decoded activation registry call.
+    pub fn handle_call(self, ctx: StorageCtx<'_>, calldata: &[u8]) -> Result<PrecompileOutput> {
         let call = Self::decode_call(calldata)?;
 
         match call {

--- a/crates/common/precompiles/src/activation/dispatch.rs
+++ b/crates/common/precompiles/src/activation/dispatch.rs
@@ -1,106 +1,18 @@
+//! ABI dispatch and state transitions for the activation registry.
+
 use alloc::string::ToString;
 
-use alloy_evm::precompiles::{DynPrecompile, PrecompileInput};
-use alloy_primitives::{Address, B256, Bytes, address, b256};
-use alloy_sol_types::{SolCall, SolError as _, SolEvent as _, sol};
-use base_precompile_macros::contract;
-use base_precompile_storage::{
-    BasePrecompileError, EvmPrecompileStorageProvider, Handler, Mapping, Result, StorageCtx,
+use alloy_primitives::{B256, Bytes};
+use alloy_sol_types::{SolCall, SolEvent as _};
+use base_precompile_storage::{BasePrecompileError, Handler, Result, StorageCtx};
+use revm::precompile::{PrecompileOutput, PrecompileResult};
+
+use super::{
+    ACTIVATION_ADMIN_ADDRESS, ACTIVATION_REGISTRY_ADDRESS, ActivationRegistry,
+    ActivationRegistryStorage, IActivationRegistry,
 };
-use revm::precompile::{PrecompileId, PrecompileOutput, PrecompileResult};
-
-/// Activation registry precompile address.
-pub const ACTIVATION_REGISTRY_ADDRESS: Address =
-    address!("0x84530000000000000000000000000000000000ff");
-
-/// Temporary activation admin address.
-///
-/// Replace this with the final Base-controlled activation signer before deployment.
-pub const ACTIVATION_ADMIN_ADDRESS: Address =
-    address!("0xcb00000000000000000000000000000000000000");
-
-/// Security-token factory creation feature id.
-pub const SECURITIES_TOKEN_CREATION: B256 =
-    b256!("0x89e4523f0886ce01d76094212ed707081da92a45221e22c15c5689be470db63e");
-
-sol! {
-    /// Activation registry ABI.
-    interface IActivationRegistry {
-        /// Emitted when a feature is enabled.
-        event FeatureEnabled(bytes32 indexed feature, address indexed caller);
-
-        /// Emitted when a feature is disabled.
-        event FeatureDisabled(bytes32 indexed feature, address indexed caller);
-
-        /// Caller is not authorized to enable features.
-        error Unauthorized(address caller);
-
-        /// Feature is already enabled.
-        error AlreadyEnabled(bytes32 feature);
-
-        /// Feature is already disabled.
-        error AlreadyDisabled(bytes32 feature);
-
-        /// Feature is not enabled.
-        error FeatureNotEnabled(bytes32 feature);
-
-        /// Precompile cannot be executed via delegatecall or callcode.
-        error DelegateCallNotAllowed();
-
-        /// State-mutating call was attempted in a static context.
-        error StaticCallNotAllowed();
-
-        /// Returns true when `feature` is enabled.
-        function isEnabled(bytes32 feature) external view returns (bool);
-
-        /// Enables `feature`.
-        function enable(bytes32 feature) external;
-
-        /// Disables `feature`.
-        function disable(bytes32 feature) external;
-
-        /// Returns the activation admin.
-        function activationAdmin() external view returns (address);
-    }
-}
-
-/// Storage layout for the activation registry.
-#[contract(addr = ACTIVATION_REGISTRY_ADDRESS)]
-pub struct ActivationRegistryStorage {
-    /// Runtime activation flags keyed by feature id.
-    pub features: Mapping<B256, bool>,
-}
-
-/// Runtime activation registry for Base-native features.
-#[derive(Debug, Default, Clone, Copy)]
-pub struct ActivationRegistry;
 
 impl ActivationRegistry {
-    /// Creates a new activation registry handle.
-    pub const fn new() -> Self {
-        Self
-    }
-
-    /// Creates the EVM precompile wrapper for the activation registry.
-    pub fn create_precompile() -> DynPrecompile {
-        DynPrecompile::new_stateful(PrecompileId::Custom("ActivationRegistry".into()), Self::run)
-    }
-
-    /// Executes the activation registry precompile.
-    pub fn run(input: PrecompileInput<'_>) -> PrecompileResult {
-        if !input.is_direct_call() {
-            // No gas charged: the call type is invalid before any work is performed.
-            return Ok(PrecompileOutput::new_reverted(
-                0,
-                IActivationRegistry::DelegateCallNotAllowed {}.abi_encode().into(),
-            ));
-        }
-
-        let data = input.data;
-        let mut storage = EvmPrecompileStorageProvider::new(input);
-        StorageCtx::enter(&mut storage, |ctx| Self::new().dispatch(ctx, data))
-    }
-
     /// ABI-dispatches activation registry calldata.
     pub fn dispatch(self, ctx: StorageCtx<'_>, calldata: &[u8]) -> PrecompileResult {
         match self.inner(ctx, calldata) {
@@ -196,11 +108,6 @@ impl ActivationRegistry {
         Ok(ctx.success_output(Bytes::new()))
     }
 
-    /// Returns the activation admin.
-    pub const fn activation_admin(self) -> Address {
-        ACTIVATION_ADMIN_ADDRESS
-    }
-
     /// Returns the calldata selector, padding short calldata with zeroes.
     pub fn calldata_selector(calldata: &[u8]) -> [u8; 4] {
         let mut selector = [0u8; 4];
@@ -283,9 +190,13 @@ impl ActivationRegistry {
 
 #[cfg(test)]
 mod tests {
-    use base_precompile_storage::{HashMapStorageProvider, StorageCtx};
+    use alloy_primitives::{Address, Bytes, address};
+    use alloy_sol_types::SolCall;
+    use base_precompile_storage::{BasePrecompileError, HashMapStorageProvider, StorageCtx};
+    use revm::precompile::PrecompileOutput;
 
     use super::*;
+    use crate::SECURITIES_TOKEN_CREATION;
 
     fn execute_with(
         storage: &mut HashMapStorageProvider,

--- a/crates/common/precompiles/src/activation/dispatch.rs
+++ b/crates/common/precompiles/src/activation/dispatch.rs
@@ -1,113 +1,18 @@
-//! ABI dispatch and state transitions for the activation registry.
+//! ABI dispatch for the activation registry.
 
 use alloc::string::ToString;
 
-use alloy_primitives::{B256, Bytes};
-use alloy_sol_types::{SolCall, SolEvent as _};
-use base_precompile_storage::{BasePrecompileError, Handler, Result, StorageCtx};
-use revm::precompile::{PrecompileOutput, PrecompileResult};
+use alloy_primitives::Bytes;
+use alloy_sol_types::SolCall;
+use base_precompile_storage::{BasePrecompileError, IntoPrecompileResult, Result, StorageCtx};
+use revm::precompile::PrecompileResult;
 
-use super::{
-    ACTIVATION_ADMIN_ADDRESS, ACTIVATION_REGISTRY_ADDRESS, ActivationRegistry,
-    ActivationRegistryStorage, IActivationRegistry,
-};
+use super::{ActivationRegistry, IActivationRegistry};
 
 impl ActivationRegistry {
     /// ABI-dispatches activation registry calldata.
     pub fn dispatch(self, ctx: StorageCtx<'_>, calldata: &[u8]) -> PrecompileResult {
-        match self.handle_call(ctx, calldata) {
-            Ok(output) => Ok(output),
-            Err(error) => ctx.error_result(error),
-        }
-    }
-
-    /// Returns true when the feature is activated.
-    pub fn is_activated(self, ctx: StorageCtx<'_>, feature: B256) -> Result<bool> {
-        ActivationRegistryStorage::new(ctx).features.at(&feature).read()
-    }
-
-    /// Reverts unless the feature is activated.
-    ///
-    /// Both the activated and deactivated paths return `Ok`; callers must inspect
-    /// [`PrecompileOutput::reverted`] to distinguish an activated feature from an ABI revert.
-    pub fn assert_activated(self, ctx: StorageCtx<'_>, feature: B256) -> PrecompileResult {
-        match self.is_activated(ctx, feature) {
-            Ok(true) => Ok(ctx.success_output(Bytes::new())),
-            Ok(false) => Ok(ctx.abi_revert(
-                IActivationRegistry::IActivationRegistryErrors::FeatureNotActivated(
-                    IActivationRegistry::FeatureNotActivated { feature },
-                ),
-            )),
-            Err(error) => ctx.error_result(error),
-        }
-    }
-
-    /// Activates the feature.
-    pub fn activate(self, ctx: StorageCtx<'_>, feature: B256) -> Result<PrecompileOutput> {
-        self.set_activated(ctx, feature, true)
-    }
-
-    /// Deactivates the feature.
-    pub fn deactive(self, ctx: StorageCtx<'_>, feature: B256) -> Result<PrecompileOutput> {
-        self.set_activated(ctx, feature, false)
-    }
-
-    /// Sets the feature activation state.
-    pub fn set_activated(
-        self,
-        ctx: StorageCtx<'_>,
-        feature: B256,
-        activated: bool,
-    ) -> Result<PrecompileOutput> {
-        // Keep this guard at the shared mutation boundary so `activate`, `deactive`, and direct
-        // `set_activated` callers all get the same static-call behavior after calldata validation.
-        if ctx.is_static() {
-            return Ok(ctx.abi_revert(
-                IActivationRegistry::IActivationRegistryErrors::StaticCallNotAllowed(
-                    IActivationRegistry::StaticCallNotAllowed {},
-                ),
-            ));
-        }
-
-        let caller = ctx.caller();
-        if caller != ACTIVATION_ADMIN_ADDRESS {
-            return Ok(ctx.abi_revert(
-                IActivationRegistry::IActivationRegistryErrors::Unauthorized(
-                    IActivationRegistry::Unauthorized { caller },
-                ),
-            ));
-        }
-
-        let mut storage = ActivationRegistryStorage::new(ctx);
-        let current = storage.features.at(&feature).read()?;
-        if current == activated {
-            let error = if activated {
-                IActivationRegistry::IActivationRegistryErrors::AlreadyActivated(
-                    IActivationRegistry::AlreadyActivated { feature },
-                )
-            } else {
-                IActivationRegistry::IActivationRegistryErrors::AlreadyDeactivated(
-                    IActivationRegistry::AlreadyDeactivated { feature },
-                )
-            };
-            return Ok(ctx.abi_revert(error));
-        }
-
-        if activated {
-            storage.features.at_mut(&feature).write(true)?;
-            ctx.emit_event(
-                ACTIVATION_REGISTRY_ADDRESS,
-                IActivationRegistry::FeatureActivated { feature, caller }.encode_log_data(),
-            )?;
-        } else {
-            storage.features.at_mut(&feature).delete()?;
-            ctx.emit_event(
-                ACTIVATION_REGISTRY_ADDRESS,
-                IActivationRegistry::FeatureDeactivated { feature, caller }.encode_log_data(),
-            )?;
-        }
-
-        Ok(ctx.success_output(Bytes::new()))
+        self.handle_call(ctx, calldata).into_precompile_result(ctx.gas_used(), |output| output)
     }
 
     /// Returns the calldata selector, padding short calldata with zeroes.
@@ -144,9 +49,9 @@ impl ActivationRegistry {
                         error: error.to_string(),
                     })
             }
-            IActivationRegistry::deactiveCall::SELECTOR => {
-                IActivationRegistry::deactiveCall::abi_decode(calldata)
-                    .map(IActivationRegistry::IActivationRegistryCalls::deactive)
+            IActivationRegistry::deactivateCall::SELECTOR => {
+                IActivationRegistry::deactivateCall::abi_decode(calldata)
+                    .map(IActivationRegistry::IActivationRegistryCalls::deactivate)
                     .map_err(|error| BasePrecompileError::AbiDecodeFailed {
                         selector,
                         error: error.to_string(),
@@ -165,38 +70,40 @@ impl ActivationRegistry {
     }
 
     /// Handles the decoded activation registry call.
-    pub fn handle_call(self, ctx: StorageCtx<'_>, calldata: &[u8]) -> Result<PrecompileOutput> {
+    pub fn handle_call(self, ctx: StorageCtx<'_>, calldata: &[u8]) -> Result<Bytes> {
         let call = Self::decode_call(calldata)?;
 
         match call {
             IActivationRegistry::IActivationRegistryCalls::isActivated(call) => {
                 let activated = self.is_activated(ctx, call.feature)?;
-                Ok(ctx.success_output(
-                    IActivationRegistry::isActivatedCall::abi_encode_returns(&activated).into(),
-                ))
+                Ok(IActivationRegistry::isActivatedCall::abi_encode_returns(&activated).into())
             }
             IActivationRegistry::IActivationRegistryCalls::activate(call) => {
-                self.activate(ctx, call.feature)
+                self.activate(ctx, call.feature)?;
+                Ok(Bytes::new())
             }
-            IActivationRegistry::IActivationRegistryCalls::deactive(call) => {
-                self.deactive(ctx, call.feature)
+            IActivationRegistry::IActivationRegistryCalls::deactivate(call) => {
+                self.deactivate(ctx, call.feature)?;
+                Ok(Bytes::new())
             }
-            IActivationRegistry::IActivationRegistryCalls::admin(_) => Ok(ctx.success_output(
-                IActivationRegistry::adminCall::abi_encode_returns(&self.admin()).into(),
-            )),
+            IActivationRegistry::IActivationRegistryCalls::admin(_) => {
+                Ok(IActivationRegistry::adminCall::abi_encode_returns(&self.admin()).into())
+            }
         }
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use alloy_primitives::{Address, Bytes, address};
+    use alloy_primitives::{Address, B256, Bytes};
     use alloy_sol_types::SolCall;
     use base_precompile_storage::{BasePrecompileError, HashMapStorageProvider, StorageCtx};
     use revm::precompile::PrecompileOutput;
+    use rstest::rstest;
 
     use super::*;
-    use crate::SECURITIES_TOKEN_CREATION;
+
+    const FEATURE: B256 = ActivationRegistry::SECURITIES_TOKEN_CREATION;
 
     fn execute_with(
         storage: &mut HashMapStorageProvider,
@@ -208,210 +115,27 @@ mod tests {
             .expect("precompile execution should not fail fatally")
     }
 
-    fn assert_activated(storage: &mut HashMapStorageProvider, expected: bool) {
-        StorageCtx::enter(storage, |ctx| {
-            assert_eq!(
-                ActivationRegistry::new()
-                    .is_activated(ctx, SECURITIES_TOKEN_CREATION)
-                    .expect("storage read succeeds"),
-                expected
-            );
-        });
-    }
-
     fn activate_feature(storage: &mut HashMapStorageProvider) -> PrecompileOutput {
-        let calldata =
-            IActivationRegistry::activateCall { feature: SECURITIES_TOKEN_CREATION }.abi_encode();
-        execute_with(storage, ACTIVATION_ADMIN_ADDRESS, calldata.into())
+        let calldata = IActivationRegistry::activateCall { feature: FEATURE }.abi_encode();
+        execute_with(storage, ActivationRegistry::ADMIN, calldata.into())
     }
 
-    fn deactive_feature(storage: &mut HashMapStorageProvider) -> PrecompileOutput {
-        let calldata =
-            IActivationRegistry::deactiveCall { feature: SECURITIES_TOKEN_CREATION }.abi_encode();
-        execute_with(storage, ACTIVATION_ADMIN_ADDRESS, calldata.into())
-    }
-
-    #[test]
-    fn feature_is_inactive_by_default() {
+    #[rstest]
+    #[case::inactive(false)]
+    #[case::active(true)]
+    fn view_call_returns_activation_state(#[case] initially_active: bool) {
         let mut storage = HashMapStorageProvider::new(1);
+        let calldata = IActivationRegistry::isActivatedCall { feature: FEATURE }.abi_encode();
 
-        assert_activated(&mut storage, false);
-    }
-
-    #[test]
-    fn admin_can_activate_feature() {
-        let mut storage = HashMapStorageProvider::new(1);
-
-        let output = activate_feature(&mut storage);
-
-        assert!(!output.reverted);
-        assert_activated(&mut storage, true);
-        assert_eq!(storage.get_events(ACTIVATION_REGISTRY_ADDRESS).len(), 1);
-    }
-
-    #[test]
-    fn unauthorized_caller_cannot_activate_feature() {
-        let mut storage = HashMapStorageProvider::new(1);
-        let caller = address!("0x0000000000000000000000000000000000000001");
-        let calldata =
-            IActivationRegistry::activateCall { feature: SECURITIES_TOKEN_CREATION }.abi_encode();
-
-        let output = execute_with(&mut storage, caller, calldata.into());
-
-        assert!(output.reverted);
-        assert_activated(&mut storage, false);
-    }
-
-    #[test]
-    fn activated_feature_cannot_be_activated_again() {
-        let mut storage = HashMapStorageProvider::new(1);
-        let calldata: Bytes =
-            IActivationRegistry::activateCall { feature: SECURITIES_TOKEN_CREATION }
-                .abi_encode()
-                .into();
-
-        let first = execute_with(&mut storage, ACTIVATION_ADMIN_ADDRESS, calldata.clone());
-        let second = execute_with(&mut storage, ACTIVATION_ADMIN_ADDRESS, calldata);
-
-        assert!(!first.reverted);
-        assert!(second.reverted);
-        assert_activated(&mut storage, true);
-    }
-
-    #[test]
-    fn admin_can_deactive_feature() {
-        let mut storage = HashMapStorageProvider::new(1);
-
-        let first = activate_feature(&mut storage);
-        let second = deactive_feature(&mut storage);
-
-        assert!(!first.reverted);
-        assert!(!second.reverted);
-        assert_activated(&mut storage, false);
-        assert_eq!(storage.get_events(ACTIVATION_REGISTRY_ADDRESS).len(), 2);
-    }
-
-    #[test]
-    fn deactivated_feature_can_be_reactivated() {
-        let mut storage = HashMapStorageProvider::new(1);
-
-        let first = activate_feature(&mut storage);
-        let second = deactive_feature(&mut storage);
-        let third = activate_feature(&mut storage);
-
-        assert!(!first.reverted);
-        assert!(!second.reverted);
-        assert!(!third.reverted);
-        assert_activated(&mut storage, true);
-        assert_eq!(storage.get_events(ACTIVATION_REGISTRY_ADDRESS).len(), 3);
-    }
-
-    #[test]
-    fn deactivated_feature_cannot_be_deactivated_again() {
-        let mut storage = HashMapStorageProvider::new(1);
-
-        let output = deactive_feature(&mut storage);
-
-        assert!(output.reverted);
-        assert_activated(&mut storage, false);
-        assert_eq!(storage.get_events(ACTIVATION_REGISTRY_ADDRESS).len(), 0);
-    }
-
-    #[test]
-    fn unauthorized_caller_cannot_deactive_feature() {
-        let mut storage = HashMapStorageProvider::new(1);
-        let caller = address!("0x0000000000000000000000000000000000000001");
-        let calldata =
-            IActivationRegistry::deactiveCall { feature: SECURITIES_TOKEN_CREATION }.abi_encode();
-
-        activate_feature(&mut storage);
-        let output = execute_with(&mut storage, caller, calldata.into());
-
-        assert!(output.reverted);
-        assert_activated(&mut storage, true);
-    }
-
-    #[test]
-    fn static_call_cannot_activate_feature() {
-        let mut storage = HashMapStorageProvider::new(1);
-        storage.set_static(true);
-        let calldata =
-            IActivationRegistry::activateCall { feature: SECURITIES_TOKEN_CREATION }.abi_encode();
-
-        let output = execute_with(&mut storage, ACTIVATION_ADMIN_ADDRESS, calldata.into());
-
-        assert!(output.reverted);
-        assert_activated(&mut storage, false);
-    }
-
-    #[test]
-    fn static_call_cannot_deactive_feature() {
-        let mut storage = HashMapStorageProvider::new(1);
-        activate_feature(&mut storage);
-        storage.set_static(true);
-        let calldata =
-            IActivationRegistry::deactiveCall { feature: SECURITIES_TOKEN_CREATION }.abi_encode();
-
-        let output = execute_with(&mut storage, ACTIVATION_ADMIN_ADDRESS, calldata.into());
-
-        assert!(output.reverted);
-        assert_activated(&mut storage, true);
-    }
-
-    #[test]
-    fn view_call_returns_activation_state() {
-        let mut storage = HashMapStorageProvider::new(1);
-        let calldata = IActivationRegistry::isActivatedCall { feature: SECURITIES_TOKEN_CREATION }
-            .abi_encode();
-
+        if initially_active {
+            activate_feature(&mut storage);
+        }
         let output = execute_with(&mut storage, Address::ZERO, calldata.into());
         let activated = IActivationRegistry::isActivatedCall::abi_decode_returns(&output.bytes)
             .expect("return data decodes");
 
         assert!(!output.reverted);
-        assert!(!activated);
-    }
-
-    #[test]
-    fn view_call_reflects_activated_state() {
-        let mut storage = HashMapStorageProvider::new(1);
-        let calldata = IActivationRegistry::isActivatedCall { feature: SECURITIES_TOKEN_CREATION }
-            .abi_encode();
-
-        activate_feature(&mut storage);
-        let activated_output = execute_with(&mut storage, Address::ZERO, calldata.clone().into());
-        let activated =
-            IActivationRegistry::isActivatedCall::abi_decode_returns(&activated_output.bytes)
-                .expect("return data decodes");
-        deactive_feature(&mut storage);
-        let deactivated_output = execute_with(&mut storage, Address::ZERO, calldata.into());
-        let deactivated =
-            IActivationRegistry::isActivatedCall::abi_decode_returns(&deactivated_output.bytes)
-                .expect("return data decodes");
-
-        assert!(!activated_output.reverted);
-        assert!(activated);
-        assert!(!deactivated_output.reverted);
-        assert!(!deactivated);
-    }
-
-    #[test]
-    fn assert_activated_reverts_after_deactive() {
-        let mut storage = HashMapStorageProvider::new(1);
-
-        activate_feature(&mut storage);
-        let activated_output = StorageCtx::enter(&mut storage, |ctx| {
-            ActivationRegistry::new().assert_activated(ctx, SECURITIES_TOKEN_CREATION)
-        })
-        .expect("feature should be activated");
-        deactive_feature(&mut storage);
-        let deactivated_output = StorageCtx::enter(&mut storage, |ctx| {
-            ActivationRegistry::new().assert_activated(ctx, SECURITIES_TOKEN_CREATION)
-        })
-        .expect("deactivated feature should return an ABI revert");
-
-        assert!(!activated_output.reverted);
-        assert!(deactivated_output.reverted);
+        assert_eq!(activated, initially_active);
     }
 
     #[test]
@@ -423,37 +147,20 @@ mod tests {
         assert_eq!(error, BasePrecompileError::UnknownFunctionSelector([0xab, 0xcd, 0, 0]));
     }
 
-    #[test]
-    fn malformed_known_selector_returns_decode_error() {
-        let Err(error) =
-            ActivationRegistry::decode_call(&IActivationRegistry::isActivatedCall::SELECTOR)
-        else {
+    #[rstest]
+    #[case::is_activated(IActivationRegistry::isActivatedCall::SELECTOR)]
+    #[case::deactivate(IActivationRegistry::deactivateCall::SELECTOR)]
+    fn malformed_known_selector_returns_decode_error(#[case] selector: [u8; 4]) {
+        let Err(error) = ActivationRegistry::decode_call(&selector) else {
             panic!("arguments are missing");
         };
 
         assert!(matches!(
             error,
             BasePrecompileError::AbiDecodeFailed {
-                selector: IActivationRegistry::isActivatedCall::SELECTOR,
+                selector: decoded_selector,
                 ..
-            }
-        ));
-    }
-
-    #[test]
-    fn malformed_deactive_selector_returns_decode_error() {
-        let Err(error) =
-            ActivationRegistry::decode_call(&IActivationRegistry::deactiveCall::SELECTOR)
-        else {
-            panic!("arguments are missing");
-        };
-
-        assert!(matches!(
-            error,
-            BasePrecompileError::AbiDecodeFailed {
-                selector: IActivationRegistry::deactiveCall::SELECTOR,
-                ..
-            }
+            } if decoded_selector == selector
         ));
     }
 }

--- a/crates/common/precompiles/src/activation/dispatch.rs
+++ b/crates/common/precompiles/src/activation/dispatch.rs
@@ -59,6 +59,8 @@ impl ActivationRegistry {
         feature: B256,
         enabled: bool,
     ) -> Result<PrecompileOutput> {
+        // Keep this guard at the shared mutation boundary so `enable`, `disable`, and direct
+        // `set_enabled` callers all get the same static-call behavior after calldata validation.
         if ctx.is_static() {
             return Ok(ctx.abi_revert(
                 IActivationRegistry::IActivationRegistryErrors::StaticCallNotAllowed(
@@ -123,6 +125,8 @@ impl ActivationRegistry {
             return Err(BasePrecompileError::UnknownFunctionSelector(selector));
         }
 
+        // Match selectors explicitly so unknown selectors remain distinct from known selectors
+        // whose arguments fail ABI decoding.
         match selector {
             IActivationRegistry::isEnabledCall::SELECTOR => {
                 IActivationRegistry::isEnabledCall::abi_decode(calldata)

--- a/crates/common/precompiles/src/activation/mod.rs
+++ b/crates/common/precompiles/src/activation/mod.rs
@@ -4,10 +4,7 @@ mod abi;
 pub use abi::IActivationRegistry;
 
 mod storage;
-pub use storage::{
-    ACTIVATION_ADMIN_ADDRESS, ACTIVATION_REGISTRY_ADDRESS, ActivationRegistry,
-    ActivationRegistryStorage, SECURITIES_TOKEN_CREATION,
-};
+pub use storage::{ActivationRegistry, ActivationRegistryStorage};
 
 mod dispatch;
 

--- a/crates/common/precompiles/src/activation/mod.rs
+++ b/crates/common/precompiles/src/activation/mod.rs
@@ -1,0 +1,14 @@
+//! Runtime activation registry native precompile.
+
+mod abi;
+pub use abi::IActivationRegistry;
+
+mod storage;
+pub use storage::{
+    ACTIVATION_ADMIN_ADDRESS, ACTIVATION_REGISTRY_ADDRESS, ActivationRegistry,
+    ActivationRegistryStorage, SECURITIES_TOKEN_CREATION,
+};
+
+mod dispatch;
+
+mod precompile;

--- a/crates/common/precompiles/src/activation/mod.rs
+++ b/crates/common/precompiles/src/activation/mod.rs
@@ -4,8 +4,9 @@ mod abi;
 pub use abi::IActivationRegistry;
 
 mod storage;
-pub use storage::{ActivationRegistry, ActivationRegistryStorage};
+pub use storage::ActivationRegistry;
 
 mod dispatch;
 
 mod precompile;
+pub use precompile::ActivationRegistryPrecompile;

--- a/crates/common/precompiles/src/activation/precompile.rs
+++ b/crates/common/precompiles/src/activation/precompile.rs
@@ -5,11 +5,15 @@ use alloy_evm::precompiles::DynPrecompile;
 use super::ActivationRegistry;
 use crate::macros::base_precompile;
 
-impl ActivationRegistry {
+/// Entry point for the activation registry precompile.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct ActivationRegistryPrecompile;
+
+impl ActivationRegistryPrecompile {
     /// Creates the EVM precompile wrapper for the activation registry.
-    pub fn create_precompile() -> DynPrecompile {
+    pub fn precompile() -> DynPrecompile {
         base_precompile!("ActivationRegistry", |ctx, calldata| {
-            Self::new().dispatch(ctx, &calldata)
+            ActivationRegistry::new(ctx).dispatch(ctx, &calldata)
         })
     }
 }

--- a/crates/common/precompiles/src/activation/precompile.rs
+++ b/crates/common/precompiles/src/activation/precompile.rs
@@ -1,0 +1,30 @@
+//! Precompile entry point for the activation registry.
+
+use alloy_evm::precompiles::{DynPrecompile, PrecompileInput};
+use alloy_sol_types::SolError as _;
+use base_precompile_storage::{EvmPrecompileStorageProvider, StorageCtx};
+use revm::precompile::{PrecompileId, PrecompileOutput, PrecompileResult};
+
+use super::{ActivationRegistry, IActivationRegistry};
+
+impl ActivationRegistry {
+    /// Creates the EVM precompile wrapper for the activation registry.
+    pub fn create_precompile() -> DynPrecompile {
+        DynPrecompile::new_stateful(PrecompileId::Custom("ActivationRegistry".into()), Self::run)
+    }
+
+    /// Executes the activation registry precompile.
+    pub fn run(input: PrecompileInput<'_>) -> PrecompileResult {
+        if !input.is_direct_call() {
+            // No gas charged: the call type is invalid before any work is performed.
+            return Ok(PrecompileOutput::new_reverted(
+                0,
+                IActivationRegistry::DelegateCallNotAllowed {}.abi_encode().into(),
+            ));
+        }
+
+        let data = input.data;
+        let mut storage = EvmPrecompileStorageProvider::new(input);
+        StorageCtx::enter(&mut storage, |ctx| Self::new().dispatch(ctx, data))
+    }
+}

--- a/crates/common/precompiles/src/activation/precompile.rs
+++ b/crates/common/precompiles/src/activation/precompile.rs
@@ -1,11 +1,11 @@
 //! Precompile entry point for the activation registry.
 
 use alloy_evm::precompiles::{DynPrecompile, PrecompileInput};
-use alloy_sol_types::SolError as _;
+use alloy_primitives::Bytes;
 use base_precompile_storage::{EvmPrecompileStorageProvider, StorageCtx};
 use revm::precompile::{PrecompileId, PrecompileOutput, PrecompileResult};
 
-use super::{ActivationRegistry, IActivationRegistry};
+use super::ActivationRegistry;
 
 impl ActivationRegistry {
     /// Creates the EVM precompile wrapper for the activation registry.
@@ -16,15 +16,13 @@ impl ActivationRegistry {
     /// Executes the activation registry precompile.
     pub fn run(input: PrecompileInput<'_>) -> PrecompileResult {
         if !input.is_direct_call() {
-            // No gas charged: the call type is invalid before any work is performed.
-            return Ok(PrecompileOutput::new_reverted(
-                0,
-                IActivationRegistry::DelegateCallNotAllowed {}.abi_encode().into(),
-            ));
+            // Match the shared `base_precompile!` wrapper: invalid call types revert before
+            // any work is performed, with no gas charged and no diagnostic revert data.
+            return Ok(PrecompileOutput::new_reverted(0, Bytes::new()));
         }
 
-        let data = input.data;
+        let data: Bytes = input.data.to_vec().into();
         let mut storage = EvmPrecompileStorageProvider::new(input);
-        StorageCtx::enter(&mut storage, |ctx| Self::new().dispatch(ctx, data))
+        StorageCtx::enter(&mut storage, |ctx| Self::new().dispatch(ctx, &data))
     }
 }

--- a/crates/common/precompiles/src/activation/precompile.rs
+++ b/crates/common/precompiles/src/activation/precompile.rs
@@ -1,28 +1,15 @@
 //! Precompile entry point for the activation registry.
 
-use alloy_evm::precompiles::{DynPrecompile, PrecompileInput};
-use alloy_primitives::Bytes;
-use base_precompile_storage::{EvmPrecompileStorageProvider, StorageCtx};
-use revm::precompile::{PrecompileId, PrecompileOutput, PrecompileResult};
+use alloy_evm::precompiles::DynPrecompile;
 
 use super::ActivationRegistry;
+use crate::macros::base_precompile;
 
 impl ActivationRegistry {
     /// Creates the EVM precompile wrapper for the activation registry.
     pub fn create_precompile() -> DynPrecompile {
-        DynPrecompile::new_stateful(PrecompileId::Custom("ActivationRegistry".into()), Self::run)
-    }
-
-    /// Executes the activation registry precompile.
-    pub fn run(input: PrecompileInput<'_>) -> PrecompileResult {
-        if !input.is_direct_call() {
-            // Match the shared `base_precompile!` wrapper: invalid call types revert before
-            // any work is performed, with no gas charged and no diagnostic revert data.
-            return Ok(PrecompileOutput::new_reverted(0, Bytes::new()));
-        }
-
-        let data: Bytes = input.data.to_vec().into();
-        let mut storage = EvmPrecompileStorageProvider::new(input);
-        StorageCtx::enter(&mut storage, |ctx| Self::new().dispatch(ctx, &data))
+        base_precompile!("ActivationRegistry", |ctx, calldata| {
+            Self::new().dispatch(ctx, &calldata)
+        })
     }
 }

--- a/crates/common/precompiles/src/activation/storage.rs
+++ b/crates/common/precompiles/src/activation/storage.rs
@@ -10,7 +10,8 @@ pub const ACTIVATION_REGISTRY_ADDRESS: Address =
 
 /// Temporary activation admin address.
 ///
-/// Replace this with the final Base-controlled activation signer before deployment.
+/// Replace this with the final Base-controlled activation signer before deployment. The admin is
+/// protocol configuration: changing it after deployment requires a coordinated binary upgrade.
 pub const ACTIVATION_ADMIN_ADDRESS: Address =
     address!("0xcb00000000000000000000000000000000000000");
 

--- a/crates/common/precompiles/src/activation/storage.rs
+++ b/crates/common/precompiles/src/activation/storage.rs
@@ -1,34 +1,40 @@
 //! Storage layout and constants for the activation registry.
 
-use alloy_primitives::{Address, B256, address, b256};
+use alloy_primitives::{Address, B256, Bytes, address, b256};
+use alloy_sol_types::SolEvent as _;
 use base_precompile_macros::contract;
-use base_precompile_storage::Mapping;
+use base_precompile_storage::{
+    BasePrecompileError, Handler, IntoPrecompileResult, Mapping, Result, StorageCtx,
+};
+use revm::precompile::PrecompileResult;
 
-/// Activation registry precompile address.
-pub const ACTIVATION_REGISTRY_ADDRESS: Address =
-    address!("0x84530000000000000000000000000000000000ff");
-
-/// Temporary activation admin address.
-///
-/// Replace this with the final Base-controlled activation signer before deployment. The admin is
-/// protocol configuration: changing it after deployment requires a coordinated binary upgrade.
-pub const ACTIVATION_ADMIN_ADDRESS: Address =
-    address!("0xcb00000000000000000000000000000000000000");
-
-/// Security-token factory creation feature id.
-pub const SECURITIES_TOKEN_CREATION: B256 =
-    b256!("0x89e4523f0886ce01d76094212ed707081da92a45221e22c15c5689be470db63e");
-
-/// Storage layout for the activation registry.
-#[contract(addr = ACTIVATION_REGISTRY_ADDRESS)]
-pub struct ActivationRegistryStorage {
-    /// Runtime activation flags keyed by feature id.
-    pub features: Mapping<B256, bool>,
-}
+use super::IActivationRegistry;
 
 /// Runtime activation registry for Base-native features.
 #[derive(Debug, Default, Clone, Copy)]
 pub struct ActivationRegistry;
+
+impl ActivationRegistry {
+    /// Activation registry precompile address.
+    pub const ADDRESS: Address = address!("0x84530000000000000000000000000000000000ff");
+
+    /// Temporary activation admin address.
+    ///
+    /// Replace this with the final Base-controlled activation signer before deployment. The admin is
+    /// protocol configuration: changing it after deployment requires a coordinated binary upgrade.
+    pub const ADMIN: Address = address!("0xcb00000000000000000000000000000000000000");
+
+    /// Security-token factory creation feature id.
+    pub const SECURITIES_TOKEN_CREATION: B256 =
+        b256!("0x89e4523f0886ce01d76094212ed707081da92a45221e22c15c5689be470db63e");
+}
+
+/// Storage layout for the activation registry.
+#[contract(addr = ActivationRegistry::ADDRESS)]
+pub struct ActivationRegistryStorage {
+    /// Runtime activation flags keyed by feature id.
+    pub features: Mapping<B256, bool>,
+}
 
 impl ActivationRegistry {
     /// Creates a new activation registry handle.
@@ -38,6 +44,242 @@ impl ActivationRegistry {
 
     /// Returns the activation admin.
     pub const fn admin(self) -> Address {
-        ACTIVATION_ADMIN_ADDRESS
+        Self::ADMIN
+    }
+
+    /// Returns true when the feature is activated.
+    pub fn is_activated(self, ctx: StorageCtx<'_>, feature: B256) -> Result<bool> {
+        ActivationRegistryStorage::new(ctx).features.at(&feature).read()
+    }
+
+    /// Reverts unless the feature is activated.
+    ///
+    /// Both the activated and deactivated paths return `Ok`; callers must inspect
+    /// [`revm::precompile::PrecompileOutput::reverted`] to distinguish an activated feature from an
+    /// ABI revert.
+    pub fn assert_activated(self, ctx: StorageCtx<'_>, feature: B256) -> PrecompileResult {
+        self.ensure_activated(ctx, feature)
+            .into_precompile_result(ctx.gas_used(), |()| Bytes::new())
+    }
+
+    /// Returns `Ok(())` when the feature is activated.
+    pub fn ensure_activated(self, ctx: StorageCtx<'_>, feature: B256) -> Result<()> {
+        if self.is_activated(ctx, feature)? {
+            return Ok(());
+        }
+
+        Err(BasePrecompileError::revert(IActivationRegistry::FeatureNotActivated { feature }))
+    }
+
+    /// Activates the feature.
+    pub fn activate(self, ctx: StorageCtx<'_>, feature: B256) -> Result<()> {
+        self.set_activated(ctx, feature, true)
+    }
+
+    /// Deactivates the feature.
+    pub fn deactivate(self, ctx: StorageCtx<'_>, feature: B256) -> Result<()> {
+        self.set_activated(ctx, feature, false)
+    }
+
+    /// Sets the feature activation state.
+    pub fn set_activated(self, ctx: StorageCtx<'_>, feature: B256, activated: bool) -> Result<()> {
+        // Keep this guard at the shared mutation boundary so `activate`, `deactivate`, and direct
+        // `set_activated` callers all get the same static-call behavior after calldata validation.
+        if ctx.is_static() {
+            return Err(BasePrecompileError::revert(IActivationRegistry::StaticCallNotAllowed {}));
+        }
+
+        let caller = ctx.caller();
+        if caller != Self::ADMIN {
+            return Err(BasePrecompileError::revert(IActivationRegistry::Unauthorized { caller }));
+        }
+
+        let mut storage = ActivationRegistryStorage::new(ctx);
+        let current = storage.features.at(&feature).read()?;
+        if current == activated {
+            if activated {
+                return Err(BasePrecompileError::revert(IActivationRegistry::AlreadyActivated {
+                    feature,
+                }));
+            }
+
+            return Err(BasePrecompileError::revert(IActivationRegistry::AlreadyDeactivated {
+                feature,
+            }));
+        }
+
+        if activated {
+            storage.features.at_mut(&feature).write(true)?;
+            ctx.emit_event(
+                Self::ADDRESS,
+                IActivationRegistry::FeatureActivated { feature, caller }.encode_log_data(),
+            )?;
+        } else {
+            storage.features.at_mut(&feature).delete()?;
+            ctx.emit_event(
+                Self::ADDRESS,
+                IActivationRegistry::FeatureDeactivated { feature, caller }.encode_log_data(),
+            )?;
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_primitives::{B256, address};
+    use base_precompile_storage::{HashMapStorageProvider, Result, StorageCtx};
+    use revm::precompile::PrecompileOutput;
+    use rstest::rstest;
+
+    use super::*;
+
+    const FEATURE: B256 = ActivationRegistry::SECURITIES_TOKEN_CREATION;
+
+    #[derive(Debug, Clone, Copy)]
+    enum Transition {
+        Activate,
+        Deactivate,
+    }
+
+    #[derive(Debug, Clone, Copy)]
+    enum InvalidContext {
+        Static,
+        Unauthorized,
+    }
+
+    fn apply_transition(
+        storage: &mut HashMapStorageProvider,
+        transition: Transition,
+    ) -> Result<()> {
+        match transition {
+            Transition::Activate => activate_feature(storage),
+            Transition::Deactivate => deactivate_feature(storage),
+        }
+    }
+
+    fn apply_transition_with_current_context(
+        storage: &mut HashMapStorageProvider,
+        transition: Transition,
+    ) -> Result<()> {
+        StorageCtx::enter(storage, |ctx| match transition {
+            Transition::Activate => ActivationRegistry::new().activate(ctx, FEATURE),
+            Transition::Deactivate => ActivationRegistry::new().deactivate(ctx, FEATURE),
+        })
+    }
+
+    fn set_active(storage: &mut HashMapStorageProvider, active: bool) {
+        if active {
+            activate_feature(storage).unwrap();
+        }
+    }
+
+    fn set_invalid_context(storage: &mut HashMapStorageProvider, context: InvalidContext) {
+        match context {
+            InvalidContext::Static => {
+                storage.set_caller(ActivationRegistry::ADMIN);
+                storage.set_static(true);
+            }
+            InvalidContext::Unauthorized => {
+                storage.set_caller(address!("0x0000000000000000000000000000000000000001"));
+            }
+        }
+    }
+
+    fn activate_feature(storage: &mut HashMapStorageProvider) -> Result<()> {
+        storage.set_caller(ActivationRegistry::ADMIN);
+        StorageCtx::enter(storage, |ctx| ActivationRegistry::new().activate(ctx, FEATURE))
+    }
+
+    fn deactivate_feature(storage: &mut HashMapStorageProvider) -> Result<()> {
+        storage.set_caller(ActivationRegistry::ADMIN);
+        StorageCtx::enter(storage, |ctx| ActivationRegistry::new().deactivate(ctx, FEATURE))
+    }
+
+    fn assert_activated(storage: &mut HashMapStorageProvider, expected: bool) {
+        StorageCtx::enter(storage, |ctx| {
+            assert_eq!(
+                ActivationRegistry::new()
+                    .is_activated(ctx, FEATURE)
+                    .expect("storage read succeeds"),
+                expected
+            );
+        });
+    }
+
+    fn assert_activated_output(storage: &mut HashMapStorageProvider) -> PrecompileOutput {
+        StorageCtx::enter(storage, |ctx| ActivationRegistry::new().assert_activated(ctx, FEATURE))
+            .expect("activation assertion should not fail fatally")
+    }
+
+    #[test]
+    fn feature_is_inactive_by_default() {
+        let mut storage = HashMapStorageProvider::new(1);
+
+        assert_activated(&mut storage, false);
+    }
+
+    #[test]
+    fn admin_can_activate_deactivate_and_reactivate_feature() {
+        let mut storage = HashMapStorageProvider::new(1);
+
+        activate_feature(&mut storage).unwrap();
+        assert_activated(&mut storage, true);
+        assert_eq!(storage.get_events(ActivationRegistry::ADDRESS).len(), 1);
+
+        deactivate_feature(&mut storage).unwrap();
+        assert_activated(&mut storage, false);
+        assert_eq!(storage.get_events(ActivationRegistry::ADDRESS).len(), 2);
+
+        activate_feature(&mut storage).unwrap();
+        assert_activated(&mut storage, true);
+        assert_eq!(storage.get_events(ActivationRegistry::ADDRESS).len(), 3);
+    }
+
+    #[rstest]
+    #[case::activate_when_active(Transition::Activate, true)]
+    #[case::deactivate_when_inactive(Transition::Deactivate, false)]
+    fn repeated_transition_reverts(#[case] transition: Transition, #[case] initially_active: bool) {
+        let mut storage = HashMapStorageProvider::new(1);
+
+        set_active(&mut storage, initially_active);
+        let result = apply_transition(&mut storage, transition);
+
+        assert!(result.is_err());
+        assert_activated(&mut storage, initially_active);
+    }
+
+    #[rstest]
+    #[case::activate_unauthorized(Transition::Activate, InvalidContext::Unauthorized, false)]
+    #[case::deactivate_unauthorized(Transition::Deactivate, InvalidContext::Unauthorized, true)]
+    #[case::activate_static(Transition::Activate, InvalidContext::Static, false)]
+    #[case::deactivate_static(Transition::Deactivate, InvalidContext::Static, true)]
+    fn invalid_context_cannot_change_activation(
+        #[case] transition: Transition,
+        #[case] context: InvalidContext,
+        #[case] initially_active: bool,
+    ) {
+        let mut storage = HashMapStorageProvider::new(1);
+
+        set_active(&mut storage, initially_active);
+        set_invalid_context(&mut storage, context);
+        let result = apply_transition_with_current_context(&mut storage, transition);
+
+        assert!(result.is_err());
+        assert_activated(&mut storage, initially_active);
+    }
+
+    #[test]
+    fn assert_activated_reverts_after_deactivate() {
+        let mut storage = HashMapStorageProvider::new(1);
+
+        activate_feature(&mut storage).unwrap();
+        let activated_output = assert_activated_output(&mut storage);
+        deactivate_feature(&mut storage).unwrap();
+        let deactivated_output = assert_activated_output(&mut storage);
+
+        assert!(!activated_output.reverted);
+        assert!(deactivated_output.reverted);
     }
 }

--- a/crates/common/precompiles/src/activation/storage.rs
+++ b/crates/common/precompiles/src/activation/storage.rs
@@ -1,20 +1,22 @@
 //! Storage layout and constants for the activation registry.
 
 use alloy_primitives::{Address, B256, Bytes, address, b256};
-use alloy_sol_types::SolEvent as _;
 use base_precompile_macros::contract;
 use base_precompile_storage::{
-    BasePrecompileError, Handler, IntoPrecompileResult, Mapping, Result, StorageCtx,
+    BasePrecompileError, Handler, IntoPrecompileResult, Mapping, Result,
 };
 use revm::precompile::PrecompileResult;
 
 use super::IActivationRegistry;
 
 /// Runtime activation registry for Base-native features.
-#[derive(Debug, Default, Clone, Copy)]
-pub struct ActivationRegistry;
+#[contract(addr = ActivationRegistry::ADDRESS)]
+pub struct ActivationRegistry {
+    /// Runtime activation flags keyed by feature id.
+    pub features: Mapping<B256, bool>,
+}
 
-impl ActivationRegistry {
+impl ActivationRegistry<'_> {
     /// Activation registry precompile address.
     pub const ADDRESS: Address = address!("0x84530000000000000000000000000000000000ff");
 
@@ -27,29 +29,15 @@ impl ActivationRegistry {
     /// Security-token factory creation feature id.
     pub const SECURITIES_TOKEN_CREATION: B256 =
         b256!("0x89e4523f0886ce01d76094212ed707081da92a45221e22c15c5689be470db63e");
-}
-
-/// Storage layout for the activation registry.
-#[contract(addr = ActivationRegistry::ADDRESS)]
-pub struct ActivationRegistryStorage {
-    /// Runtime activation flags keyed by feature id.
-    pub features: Mapping<B256, bool>,
-}
-
-impl ActivationRegistry {
-    /// Creates a new activation registry handle.
-    pub const fn new() -> Self {
-        Self
-    }
 
     /// Returns the activation admin.
-    pub const fn admin(self) -> Address {
+    pub const fn admin(&self) -> Address {
         Self::ADMIN
     }
 
     /// Returns true when the feature is activated.
-    pub fn is_activated(self, ctx: StorageCtx<'_>, feature: B256) -> Result<bool> {
-        ActivationRegistryStorage::new(ctx).features.at(&feature).read()
+    pub fn is_activated(&self, feature: B256) -> Result<bool> {
+        self.features.at(&feature).read()
     }
 
     /// Reverts unless the feature is activated.
@@ -57,14 +45,14 @@ impl ActivationRegistry {
     /// Both the activated and deactivated paths return `Ok`; callers must inspect
     /// [`revm::precompile::PrecompileOutput::reverted`] to distinguish an activated feature from an
     /// ABI revert.
-    pub fn assert_activated(self, ctx: StorageCtx<'_>, feature: B256) -> PrecompileResult {
-        self.ensure_activated(ctx, feature)
-            .into_precompile_result(ctx.gas_used(), |()| Bytes::new())
+    pub fn assert_activated(&self, feature: B256) -> PrecompileResult {
+        self.ensure_activated(feature)
+            .into_precompile_result(self.storage.gas_used(), |()| Bytes::new())
     }
 
     /// Returns `Ok(())` when the feature is activated.
-    pub fn ensure_activated(self, ctx: StorageCtx<'_>, feature: B256) -> Result<()> {
-        if self.is_activated(ctx, feature)? {
+    pub fn ensure_activated(&self, feature: B256) -> Result<()> {
+        if self.is_activated(feature)? {
             return Ok(());
         }
 
@@ -72,30 +60,29 @@ impl ActivationRegistry {
     }
 
     /// Activates the feature.
-    pub fn activate(self, ctx: StorageCtx<'_>, feature: B256) -> Result<()> {
-        self.set_activated(ctx, feature, true)
+    pub fn activate(&mut self, feature: B256) -> Result<()> {
+        self.set_activated(feature, true)
     }
 
     /// Deactivates the feature.
-    pub fn deactivate(self, ctx: StorageCtx<'_>, feature: B256) -> Result<()> {
-        self.set_activated(ctx, feature, false)
+    pub fn deactivate(&mut self, feature: B256) -> Result<()> {
+        self.set_activated(feature, false)
     }
 
     /// Sets the feature activation state.
-    pub fn set_activated(self, ctx: StorageCtx<'_>, feature: B256, activated: bool) -> Result<()> {
+    pub fn set_activated(&mut self, feature: B256, activated: bool) -> Result<()> {
         // Keep this guard at the shared mutation boundary so `activate`, `deactivate`, and direct
         // `set_activated` callers all get the same static-call behavior after calldata validation.
-        if ctx.is_static() {
+        if self.storage.is_static() {
             return Err(BasePrecompileError::revert(IActivationRegistry::StaticCallNotAllowed {}));
         }
 
-        let caller = ctx.caller();
+        let caller = self.storage.caller();
         if caller != Self::ADMIN {
             return Err(BasePrecompileError::revert(IActivationRegistry::Unauthorized { caller }));
         }
 
-        let mut storage = ActivationRegistryStorage::new(ctx);
-        let current = storage.features.at(&feature).read()?;
+        let current = self.features.at(&feature).read()?;
         if current == activated {
             if activated {
                 return Err(BasePrecompileError::revert(IActivationRegistry::AlreadyActivated {
@@ -109,17 +96,11 @@ impl ActivationRegistry {
         }
 
         if activated {
-            storage.features.at_mut(&feature).write(true)?;
-            ctx.emit_event(
-                Self::ADDRESS,
-                IActivationRegistry::FeatureActivated { feature, caller }.encode_log_data(),
-            )?;
+            self.features.at_mut(&feature).write(true)?;
+            self.emit_event(IActivationRegistry::FeatureActivated { feature, caller })?;
         } else {
-            storage.features.at_mut(&feature).delete()?;
-            ctx.emit_event(
-                Self::ADDRESS,
-                IActivationRegistry::FeatureDeactivated { feature, caller }.encode_log_data(),
-            )?;
+            self.features.at_mut(&feature).delete()?;
+            self.emit_event(IActivationRegistry::FeatureDeactivated { feature, caller })?;
         }
 
         Ok(())
@@ -163,9 +144,12 @@ mod tests {
         storage: &mut HashMapStorageProvider,
         transition: Transition,
     ) -> Result<()> {
-        StorageCtx::enter(storage, |ctx| match transition {
-            Transition::Activate => ActivationRegistry::new().activate(ctx, FEATURE),
-            Transition::Deactivate => ActivationRegistry::new().deactivate(ctx, FEATURE),
+        StorageCtx::enter(storage, |ctx| {
+            let mut registry = ActivationRegistry::new(ctx);
+            match transition {
+                Transition::Activate => registry.activate(FEATURE),
+                Transition::Deactivate => registry.deactivate(FEATURE),
+            }
         })
     }
 
@@ -189,27 +173,25 @@ mod tests {
 
     fn activate_feature(storage: &mut HashMapStorageProvider) -> Result<()> {
         storage.set_caller(ActivationRegistry::ADMIN);
-        StorageCtx::enter(storage, |ctx| ActivationRegistry::new().activate(ctx, FEATURE))
+        StorageCtx::enter(storage, |ctx| ActivationRegistry::new(ctx).activate(FEATURE))
     }
 
     fn deactivate_feature(storage: &mut HashMapStorageProvider) -> Result<()> {
         storage.set_caller(ActivationRegistry::ADMIN);
-        StorageCtx::enter(storage, |ctx| ActivationRegistry::new().deactivate(ctx, FEATURE))
+        StorageCtx::enter(storage, |ctx| ActivationRegistry::new(ctx).deactivate(FEATURE))
     }
 
     fn assert_activated(storage: &mut HashMapStorageProvider, expected: bool) {
         StorageCtx::enter(storage, |ctx| {
             assert_eq!(
-                ActivationRegistry::new()
-                    .is_activated(ctx, FEATURE)
-                    .expect("storage read succeeds"),
+                ActivationRegistry::new(ctx).is_activated(FEATURE).expect("storage read succeeds"),
                 expected
             );
         });
     }
 
     fn assert_activated_output(storage: &mut HashMapStorageProvider) -> PrecompileOutput {
-        StorageCtx::enter(storage, |ctx| ActivationRegistry::new().assert_activated(ctx, FEATURE))
+        StorageCtx::enter(storage, |ctx| ActivationRegistry::new(ctx).assert_activated(FEATURE))
             .expect("activation assertion should not fail fatally")
     }
 

--- a/crates/common/precompiles/src/activation/storage.rs
+++ b/crates/common/precompiles/src/activation/storage.rs
@@ -1,0 +1,42 @@
+//! Storage layout and constants for the activation registry.
+
+use alloy_primitives::{Address, B256, address, b256};
+use base_precompile_macros::contract;
+use base_precompile_storage::Mapping;
+
+/// Activation registry precompile address.
+pub const ACTIVATION_REGISTRY_ADDRESS: Address =
+    address!("0x84530000000000000000000000000000000000ff");
+
+/// Temporary activation admin address.
+///
+/// Replace this with the final Base-controlled activation signer before deployment.
+pub const ACTIVATION_ADMIN_ADDRESS: Address =
+    address!("0xcb00000000000000000000000000000000000000");
+
+/// Security-token factory creation feature id.
+pub const SECURITIES_TOKEN_CREATION: B256 =
+    b256!("0x89e4523f0886ce01d76094212ed707081da92a45221e22c15c5689be470db63e");
+
+/// Storage layout for the activation registry.
+#[contract(addr = ACTIVATION_REGISTRY_ADDRESS)]
+pub struct ActivationRegistryStorage {
+    /// Runtime activation flags keyed by feature id.
+    pub features: Mapping<B256, bool>,
+}
+
+/// Runtime activation registry for Base-native features.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct ActivationRegistry;
+
+impl ActivationRegistry {
+    /// Creates a new activation registry handle.
+    pub const fn new() -> Self {
+        Self
+    }
+
+    /// Returns the activation admin.
+    pub const fn activation_admin(self) -> Address {
+        ACTIVATION_ADMIN_ADDRESS
+    }
+}

--- a/crates/common/precompiles/src/activation/storage.rs
+++ b/crates/common/precompiles/src/activation/storage.rs
@@ -37,7 +37,7 @@ impl ActivationRegistry {
     }
 
     /// Returns the activation admin.
-    pub const fn activation_admin(self) -> Address {
+    pub const fn admin(self) -> Address {
         ACTIVATION_ADMIN_ADDRESS
     }
 }

--- a/crates/common/precompiles/src/installer.rs
+++ b/crates/common/precompiles/src/installer.rs
@@ -1,11 +1,7 @@
 use alloy_evm::precompiles::{DynPrecompile, PrecompilesMap};
 use alloy_primitives::Address;
 use base_common_chains::BaseUpgrade;
-
-use crate::{BasePrecompileSpec, BasePrecompiles};
-
-#[cfg(feature = "std")]
-use crate::{ACTIVATION_REGISTRY_ADDRESS, ActivationRegistry};
+use crate::{ACTIVATION_REGISTRY_ADDRESS, ActivationRegistry, BasePrecompileSpec, BasePrecompiles};
 
 /// Installs the full Base precompile set for a given spec.
 #[derive(Debug, Clone, Copy)]
@@ -42,7 +38,6 @@ impl<S: BasePrecompileSpec> BasePrecompileInstaller<S> {
                 crate::token::PolicyRegistryEvm::precompile(),
             )));
 
-            #[cfg(feature = "std")]
             precompiles.extend_precompiles(core::iter::once((
                 ACTIVATION_REGISTRY_ADDRESS,
                 ActivationRegistry::create_precompile(),
@@ -112,7 +107,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "std")]
     fn activation_registry_is_not_installed_before_beryl() {
         let precompiles = BasePrecompileInstaller::new(BaseUpgrade::Azul).install();
 
@@ -120,7 +114,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "std")]
     fn activation_registry_is_installed_at_beryl() {
         let precompiles = BasePrecompileInstaller::new(BaseUpgrade::Beryl).install();
 

--- a/crates/common/precompiles/src/installer.rs
+++ b/crates/common/precompiles/src/installer.rs
@@ -1,7 +1,8 @@
 use alloy_evm::precompiles::{DynPrecompile, PrecompilesMap};
 use alloy_primitives::Address;
 use base_common_chains::BaseUpgrade;
-use crate::{ACTIVATION_REGISTRY_ADDRESS, ActivationRegistry, BasePrecompileSpec, BasePrecompiles};
+
+use crate::{ActivationRegistry, BasePrecompileSpec, BasePrecompiles};
 
 /// Installs the full Base precompile set for a given spec.
 #[derive(Debug, Clone, Copy)]
@@ -39,7 +40,7 @@ impl<S: BasePrecompileSpec> BasePrecompileInstaller<S> {
             )));
 
             precompiles.extend_precompiles(core::iter::once((
-                ACTIVATION_REGISTRY_ADDRESS,
+                ActivationRegistry::ADDRESS,
                 ActivationRegistry::create_precompile(),
             )));
         }
@@ -110,13 +111,13 @@ mod tests {
     fn activation_registry_is_not_installed_before_beryl() {
         let precompiles = BasePrecompileInstaller::new(BaseUpgrade::Azul).install();
 
-        assert!(precompiles.get(&ACTIVATION_REGISTRY_ADDRESS).is_none());
+        assert!(precompiles.get(&ActivationRegistry::ADDRESS).is_none());
     }
 
     #[test]
     fn activation_registry_is_installed_at_beryl() {
         let precompiles = BasePrecompileInstaller::new(BaseUpgrade::Beryl).install();
 
-        assert!(precompiles.get(&ACTIVATION_REGISTRY_ADDRESS).is_some());
+        assert!(precompiles.get(&ActivationRegistry::ADDRESS).is_some());
     }
 }

--- a/crates/common/precompiles/src/installer.rs
+++ b/crates/common/precompiles/src/installer.rs
@@ -4,6 +4,9 @@ use base_common_chains::BaseUpgrade;
 
 use crate::{BasePrecompileSpec, BasePrecompiles};
 
+#[cfg(feature = "std")]
+use crate::{ACTIVATION_REGISTRY_ADDRESS, ActivationRegistry};
+
 /// Installs the full Base precompile set for a given spec.
 #[derive(Debug, Clone, Copy)]
 pub struct BasePrecompileInstaller<S = BaseUpgrade> {
@@ -38,6 +41,12 @@ impl<S: BasePrecompileSpec> BasePrecompileInstaller<S> {
                 crate::token::POLICY_REGISTRY_ADDRESS,
                 crate::token::PolicyRegistryEvm::precompile(),
             )));
+
+            #[cfg(feature = "std")]
+            precompiles.extend_precompiles(core::iter::once((
+                ACTIVATION_REGISTRY_ADDRESS,
+                ActivationRegistry::create_precompile(),
+            )));
         }
     }
 }
@@ -53,6 +62,12 @@ fn b20_lookup(address: &Address) -> Option<DynPrecompile> {
                 crate::token::B20TokenPrecompile::create_precompile(*address)
             }
         })
+    }
+}
+
+impl<S: BasePrecompileSpec> Default for BasePrecompileInstaller<S> {
+    fn default() -> Self {
+        Self::new(S::default_precompile_spec())
     }
 }
 
@@ -94,5 +109,21 @@ mod tests {
         assert_eq!(precompiles.get(&TokenFactory::ADDRESS).is_some(), expected);
         assert_eq!(precompiles.get(&token).is_some(), expected);
         assert!(precompiles.get(&Address::repeat_byte(0x42)).is_none());
+    }
+
+    #[test]
+    #[cfg(feature = "std")]
+    fn activation_registry_is_not_installed_before_beryl() {
+        let precompiles = BasePrecompileInstaller::new(BaseUpgrade::Azul).install();
+
+        assert!(precompiles.get(&ACTIVATION_REGISTRY_ADDRESS).is_none());
+    }
+
+    #[test]
+    #[cfg(feature = "std")]
+    fn activation_registry_is_installed_at_beryl() {
+        let precompiles = BasePrecompileInstaller::new(BaseUpgrade::Beryl).install();
+
+        assert!(precompiles.get(&ACTIVATION_REGISTRY_ADDRESS).is_some());
     }
 }

--- a/crates/common/precompiles/src/installer.rs
+++ b/crates/common/precompiles/src/installer.rs
@@ -2,7 +2,9 @@ use alloy_evm::precompiles::{DynPrecompile, PrecompilesMap};
 use alloy_primitives::Address;
 use base_common_chains::BaseUpgrade;
 
-use crate::{ActivationRegistry, BasePrecompileSpec, BasePrecompiles};
+use crate::{
+    ActivationRegistry, ActivationRegistryPrecompile, BasePrecompileSpec, BasePrecompiles,
+};
 
 /// Installs the full Base precompile set for a given spec.
 #[derive(Debug, Clone, Copy)]
@@ -41,7 +43,7 @@ impl<S: BasePrecompileSpec> BasePrecompileInstaller<S> {
 
             precompiles.extend_precompiles(core::iter::once((
                 ActivationRegistry::ADDRESS,
-                ActivationRegistry::create_precompile(),
+                ActivationRegistryPrecompile::precompile(),
             )));
         }
     }

--- a/crates/common/precompiles/src/lib.rs
+++ b/crates/common/precompiles/src/lib.rs
@@ -17,10 +17,7 @@ mod spec;
 pub use spec::BasePrecompileSpec;
 
 mod activation;
-pub use activation::{
-    ACTIVATION_ADMIN_ADDRESS, ACTIVATION_REGISTRY_ADDRESS, ActivationRegistry,
-    ActivationRegistryStorage, IActivationRegistry, SECURITIES_TOKEN_CREATION,
-};
+pub use activation::{ActivationRegistry, ActivationRegistryStorage, IActivationRegistry};
 
 mod bn254_pair;
 

--- a/crates/common/precompiles/src/lib.rs
+++ b/crates/common/precompiles/src/lib.rs
@@ -16,9 +16,7 @@ pub use installer::BasePrecompileInstaller;
 mod spec;
 pub use spec::BasePrecompileSpec;
 
-#[cfg(feature = "std")]
 mod activation;
-#[cfg(feature = "std")]
 pub use activation::{
     ACTIVATION_ADMIN_ADDRESS, ACTIVATION_REGISTRY_ADDRESS, ActivationRegistry,
     ActivationRegistryStorage, IActivationRegistry, SECURITIES_TOKEN_CREATION,

--- a/crates/common/precompiles/src/lib.rs
+++ b/crates/common/precompiles/src/lib.rs
@@ -16,6 +16,14 @@ pub use installer::BasePrecompileInstaller;
 mod spec;
 pub use spec::BasePrecompileSpec;
 
+#[cfg(feature = "std")]
+mod activation;
+#[cfg(feature = "std")]
+pub use activation::{
+    ACTIVATION_ADMIN_ADDRESS, ACTIVATION_REGISTRY_ADDRESS, ActivationRegistry,
+    ActivationRegistryStorage, IActivationRegistry, SECURITIES_TOKEN_CREATION,
+};
+
 mod bn254_pair;
 
 mod bls12_381;

--- a/crates/common/precompiles/src/lib.rs
+++ b/crates/common/precompiles/src/lib.rs
@@ -17,7 +17,7 @@ mod spec;
 pub use spec::BasePrecompileSpec;
 
 mod activation;
-pub use activation::{ActivationRegistry, ActivationRegistryStorage, IActivationRegistry};
+pub use activation::{ActivationRegistry, ActivationRegistryPrecompile, IActivationRegistry};
 
 mod bn254_pair;
 


### PR DESCRIPTION
## Summary

This adds a Beryl-gated activation registry precompile for runtime feature activation. The registry exposes ABI calls to check and enable feature ids, defaults features to disabled, and enforces a one-way enable path restricted to the configured activation admin. It is wired through the Base precompile installer and covered with targeted activation and installer tests.