### PR TITLE
refactor(proofs): Share Contract Call Errors

### DIFF
--- a/crates/proof/contracts/src/aggregate_verifier.rs
+++ b/crates/proof/contracts/src/aggregate_verifier.rs
@@ -335,29 +335,14 @@ impl AggregateVerifierClient for AggregateVerifierContractClient {
             IAggregateVerifier::IAggregateVerifierInstance::new(game_address, &self.provider);
 
         let (root_claim, l2_seq, parent_address) = futures::try_join!(
-            async {
-                contract.rootClaim().call().await.map_err(|e| ContractError::Call {
-                    context: "rootClaim failed".into(),
-                    source: e,
-                })
-            },
-            async {
-                contract.l2SequenceNumber().call().await.map_err(|e| ContractError::Call {
-                    context: "l2SequenceNumber failed".into(),
-                    source: e,
-                })
-            },
-            async {
-                contract.parentAddress().call().await.map_err(|e| ContractError::Call {
-                    context: "parentAddress failed".into(),
-                    source: e,
-                })
-            },
+            async { contract_call!(contract.rootClaim().call(), "rootClaim failed") },
+            async { contract_call!(contract.l2SequenceNumber().call(), "l2SequenceNumber failed") },
+            async { contract_call!(contract.parentAddress().call(), "parentAddress failed") },
         )?;
 
         let l2_block_number: u64 = l2_seq
             .try_into()
-            .map_err(|_| ContractError::Validation("l2SequenceNumber overflows u64".into()))?;
+            .map_err(|_| ContractError::validation("l2SequenceNumber overflows u64"))?;
 
         Ok(GameInfo { root_claim, l2_block_number, parent_address })
     }
@@ -366,14 +351,10 @@ impl AggregateVerifierClient for AggregateVerifierContractClient {
         let contract =
             IAggregateVerifier::IAggregateVerifierInstance::new(game_address, &self.provider);
 
-        let raw: u8 = contract
-            .status()
-            .call()
-            .await
-            .map_err(|e| ContractError::Call { context: "status failed".into(), source: e })?;
+        let raw: u8 = contract_call!(contract.status().call(), "status failed")?;
 
         GameStatus::try_from(raw).map_err(|unknown| {
-            ContractError::Validation(format!(
+            ContractError::validation(format!(
                 "game {game_address} returned unrecognized status {unknown}"
             ))
         })
@@ -383,64 +364,49 @@ impl AggregateVerifierClient for AggregateVerifierContractClient {
         let contract =
             IAggregateVerifier::IAggregateVerifierInstance::new(game_address, &self.provider);
 
-        contract
-            .zkProver()
-            .call()
-            .await
-            .map_err(|e| ContractError::Call { context: "zkProver failed".into(), source: e })
+        contract_call!(contract.zkProver().call(), "zkProver failed")
     }
 
     async fn tee_prover(&self, game_address: Address) -> Result<Address, ContractError> {
         let contract =
             IAggregateVerifier::IAggregateVerifierInstance::new(game_address, &self.provider);
 
-        contract
-            .teeProver()
-            .call()
-            .await
-            .map_err(|e| ContractError::Call { context: "teeProver failed".into(), source: e })
+        contract_call!(contract.teeProver().call(), "teeProver failed")
     }
 
     async fn starting_block_number(&self, game_address: Address) -> Result<u64, ContractError> {
         let contract =
             IAggregateVerifier::IAggregateVerifierInstance::new(game_address, &self.provider);
 
-        let block_u256: U256 = contract.startingBlockNumber().call().await.map_err(|e| {
-            ContractError::Call { context: "startingBlockNumber failed".into(), source: e }
-        })?;
+        let block_u256: U256 =
+            contract_call!(contract.startingBlockNumber().call(), "startingBlockNumber failed")?;
 
         block_u256
             .try_into()
-            .map_err(|_| ContractError::Validation("startingBlockNumber overflows u64".into()))
+            .map_err(|_| ContractError::validation("startingBlockNumber overflows u64"))
     }
 
     async fn l1_head(&self, game_address: Address) -> Result<B256, ContractError> {
         let contract =
             IAggregateVerifier::IAggregateVerifierInstance::new(game_address, &self.provider);
 
-        contract
-            .l1Head()
-            .call()
-            .await
-            .map_err(|e| ContractError::Call { context: "l1Head failed".into(), source: e })
+        contract_call!(contract.l1Head().call(), "l1Head failed")
     }
 
     async fn read_block_interval(&self, impl_address: Address) -> Result<u64, ContractError> {
         let contract =
             IAggregateVerifier::IAggregateVerifierInstance::new(impl_address, &self.provider);
-        let interval_u256: U256 = contract.BLOCK_INTERVAL().call().await.map_err(|e| {
-            ContractError::Call { context: "BLOCK_INTERVAL failed".into(), source: e }
-        })?;
+        let interval_u256: U256 =
+            contract_call!(contract.BLOCK_INTERVAL().call(), "BLOCK_INTERVAL failed")?;
 
         let interval: u64 = interval_u256
             .try_into()
-            .map_err(|_| ContractError::Validation("BLOCK_INTERVAL overflows u64".into()))?;
+            .map_err(|_| ContractError::validation("BLOCK_INTERVAL overflows u64"))?;
 
         // Also validated at startup in main.rs; duplicated here for defense-in-depth.
         if interval < 2 {
-            return Err(ContractError::Validation(
-                "BLOCK_INTERVAL must be at least 2 (single-block proposals are not supported)"
-                    .into(),
+            return Err(ContractError::validation(
+                "BLOCK_INTERVAL must be at least 2 (single-block proposals are not supported)",
             ));
         }
 
@@ -453,22 +419,17 @@ impl AggregateVerifierClient for AggregateVerifierContractClient {
     ) -> Result<u64, ContractError> {
         let contract =
             IAggregateVerifier::IAggregateVerifierInstance::new(impl_address, &self.provider);
-        let interval_u256: U256 =
-            contract.INTERMEDIATE_BLOCK_INTERVAL().call().await.map_err(|e| {
-                ContractError::Call {
-                    context: "INTERMEDIATE_BLOCK_INTERVAL failed".into(),
-                    source: e,
-                }
-            })?;
+        let interval_u256: U256 = contract_call!(
+            contract.INTERMEDIATE_BLOCK_INTERVAL().call(),
+            "INTERMEDIATE_BLOCK_INTERVAL failed"
+        )?;
 
-        let interval: u64 = interval_u256.try_into().map_err(|_| {
-            ContractError::Validation("INTERMEDIATE_BLOCK_INTERVAL overflows u64".into())
-        })?;
+        let interval: u64 = interval_u256
+            .try_into()
+            .map_err(|_| ContractError::validation("INTERMEDIATE_BLOCK_INTERVAL overflows u64"))?;
 
         if interval == 0 {
-            return Err(ContractError::Validation(
-                "INTERMEDIATE_BLOCK_INTERVAL cannot be 0".into(),
-            ));
+            return Err(ContractError::validation("INTERMEDIATE_BLOCK_INTERVAL cannot be 0"));
         }
 
         Ok(interval)
@@ -481,12 +442,13 @@ impl AggregateVerifierClient for AggregateVerifierContractClient {
         let contract =
             IAggregateVerifier::IAggregateVerifierInstance::new(game_address, &self.provider);
 
-        let raw: Bytes = contract.intermediateOutputRoots().call().await.map_err(|e| {
-            ContractError::Call { context: "intermediateOutputRoots failed".into(), source: e }
-        })?;
+        let raw: Bytes = contract_call!(
+            contract.intermediateOutputRoots().call(),
+            "intermediateOutputRoots failed"
+        )?;
 
         if !raw.len().is_multiple_of(32) {
-            return Err(ContractError::Validation(format!(
+            return Err(ContractError::validation(format!(
                 "intermediateOutputRoots length {} is not a multiple of 32",
                 raw.len()
             )));
@@ -505,10 +467,10 @@ impl AggregateVerifierClient for AggregateVerifierContractClient {
         let contract =
             IAggregateVerifier::IAggregateVerifierInstance::new(game_address, &self.provider);
 
-        let root =
-            contract.intermediateOutputRoot(U256::from(index)).call().await.map_err(|e| {
-                ContractError::Call { context: "intermediateOutputRoot failed".into(), source: e }
-            })?;
+        let root = contract_call!(
+            contract.intermediateOutputRoot(U256::from(index)).call(),
+            "intermediateOutputRoot failed"
+        )?;
 
         Ok(root)
     }
@@ -517,18 +479,13 @@ impl AggregateVerifierClient for AggregateVerifierContractClient {
         let contract =
             IAggregateVerifier::IAggregateVerifierInstance::new(game_address, &self.provider);
 
-        let value: U256 =
-            contract.counteredByIntermediateRootIndexPlusOne().call().await.map_err(|e| {
-                ContractError::Call {
-                    context: "counteredByIntermediateRootIndexPlusOne failed".into(),
-                    source: e,
-                }
-            })?;
+        let value: U256 = contract_call!(
+            contract.counteredByIntermediateRootIndexPlusOne().call(),
+            "counteredByIntermediateRootIndexPlusOne failed"
+        )?;
 
         value.try_into().map_err(|_| {
-            ContractError::Validation(
-                "counteredByIntermediateRootIndexPlusOne overflows u64".into(),
-            )
+            ContractError::validation("counteredByIntermediateRootIndexPlusOne overflows u64")
         })
     }
 
@@ -536,108 +493,70 @@ impl AggregateVerifierClient for AggregateVerifierContractClient {
         let contract =
             IAggregateVerifier::IAggregateVerifierInstance::new(game_address, &self.provider);
 
-        contract
-            .gameOver()
-            .call()
-            .await
-            .map_err(|e| ContractError::Call { context: "gameOver failed".into(), source: e })
+        contract_call!(contract.gameOver().call(), "gameOver failed")
     }
 
     async fn resolved_at(&self, game_address: Address) -> Result<u64, ContractError> {
         let contract =
             IAggregateVerifier::IAggregateVerifierInstance::new(game_address, &self.provider);
 
-        contract
-            .resolvedAt()
-            .call()
-            .await
-            .map_err(|e| ContractError::Call { context: "resolvedAt failed".into(), source: e })
+        contract_call!(contract.resolvedAt().call(), "resolvedAt failed")
     }
 
     async fn bond_recipient(&self, game_address: Address) -> Result<Address, ContractError> {
         let contract =
             IAggregateVerifier::IAggregateVerifierInstance::new(game_address, &self.provider);
 
-        contract
-            .bondRecipient()
-            .call()
-            .await
-            .map_err(|e| ContractError::Call { context: "bondRecipient failed".into(), source: e })
+        contract_call!(contract.bondRecipient().call(), "bondRecipient failed")
     }
 
     async fn bond_unlocked(&self, game_address: Address) -> Result<bool, ContractError> {
         let contract =
             IAggregateVerifier::IAggregateVerifierInstance::new(game_address, &self.provider);
 
-        contract
-            .bondUnlocked()
-            .call()
-            .await
-            .map_err(|e| ContractError::Call { context: "bondUnlocked failed".into(), source: e })
+        contract_call!(contract.bondUnlocked().call(), "bondUnlocked failed")
     }
 
     async fn bond_claimed(&self, game_address: Address) -> Result<bool, ContractError> {
         let contract =
             IAggregateVerifier::IAggregateVerifierInstance::new(game_address, &self.provider);
 
-        contract
-            .bondClaimed()
-            .call()
-            .await
-            .map_err(|e| ContractError::Call { context: "bondClaimed failed".into(), source: e })
+        contract_call!(contract.bondClaimed().call(), "bondClaimed failed")
     }
 
     async fn expected_resolution(&self, game_address: Address) -> Result<u64, ContractError> {
         let contract =
             IAggregateVerifier::IAggregateVerifierInstance::new(game_address, &self.provider);
 
-        contract.expectedResolution().call().await.map_err(|e| ContractError::Call {
-            context: "expectedResolution failed".into(),
-            source: e,
-        })
+        contract_call!(contract.expectedResolution().call(), "expectedResolution failed")
     }
 
     async fn proof_count(&self, game_address: Address) -> Result<u8, ContractError> {
         let contract =
             IAggregateVerifier::IAggregateVerifierInstance::new(game_address, &self.provider);
 
-        contract
-            .proofCount()
-            .call()
-            .await
-            .map_err(|e| ContractError::Call { context: "proofCount failed".into(), source: e })
+        contract_call!(contract.proofCount().call(), "proofCount failed")
     }
 
     async fn created_at(&self, game_address: Address) -> Result<u64, ContractError> {
         let contract =
             IAggregateVerifier::IAggregateVerifierInstance::new(game_address, &self.provider);
 
-        contract
-            .createdAt()
-            .call()
-            .await
-            .map_err(|e| ContractError::Call { context: "createdAt failed".into(), source: e })
+        contract_call!(contract.createdAt().call(), "createdAt failed")
     }
 
     async fn delayed_weth(&self, game_address: Address) -> Result<Address, ContractError> {
         let contract =
             IAggregateVerifier::IAggregateVerifierInstance::new(game_address, &self.provider);
 
-        contract
-            .DELAYED_WETH()
-            .call()
-            .await
-            .map_err(|e| ContractError::Call { context: "DELAYED_WETH failed".into(), source: e })
+        contract_call!(contract.DELAYED_WETH().call(), "DELAYED_WETH failed")
     }
 
     async fn anchor_state_registry(&self, game_address: Address) -> Result<Address, ContractError> {
         let contract =
             IAggregateVerifier::IAggregateVerifierInstance::new(game_address, &self.provider);
 
-        contract.anchorStateRegistry().call().await.map_err(|e| ContractError::Call {
-            context: "anchorStateRegistry failed".into(),
-            source: e,
-        })
+        contract_call!(contract.anchorStateRegistry().call(), "anchorStateRegistry failed")
     }
 
     async fn is_game_finalized(
@@ -648,10 +567,7 @@ impl AggregateVerifierClient for AggregateVerifierContractClient {
         let contract =
             IAnchorStateRegistry::IAnchorStateRegistryInstance::new(asr_address, &self.provider);
 
-        contract.isGameFinalized(game_address).call().await.map_err(|e| ContractError::Call {
-            context: "isGameFinalized failed".into(),
-            source: e,
-        })
+        contract_call!(contract.isGameFinalized(game_address).call(), "isGameFinalized failed")
     }
 
     async fn anchor_preflight(
@@ -664,39 +580,28 @@ impl AggregateVerifierClient for AggregateVerifierContractClient {
 
         let (blacklisted, retired, respected, paused, anchor) = futures::try_join!(
             async {
-                contract.isGameBlacklisted(game_address).call().await.map_err(|e| {
-                    ContractError::Call { context: "isGameBlacklisted failed".into(), source: e }
-                })
+                contract_call!(
+                    contract.isGameBlacklisted(game_address).call(),
+                    "isGameBlacklisted failed"
+                )
             },
             async {
-                contract.isGameRetired(game_address).call().await.map_err(|e| ContractError::Call {
-                    context: "isGameRetired failed".into(),
-                    source: e,
-                })
+                contract_call!(contract.isGameRetired(game_address).call(), "isGameRetired failed")
             },
             async {
-                contract.isGameRespected(game_address).call().await.map_err(|e| {
-                    ContractError::Call { context: "isGameRespected failed".into(), source: e }
-                })
+                contract_call!(
+                    contract.isGameRespected(game_address).call(),
+                    "isGameRespected failed"
+                )
             },
-            async {
-                contract
-                    .paused()
-                    .call()
-                    .await
-                    .map_err(|e| ContractError::Call { context: "paused failed".into(), source: e })
-            },
-            async {
-                contract.getAnchorRoot().call().await.map_err(|e| ContractError::Call {
-                    context: "getAnchorRoot failed".into(),
-                    source: e,
-                })
-            },
+            async { contract_call!(contract.paused().call(), "paused failed") },
+            async { contract_call!(contract.getAnchorRoot().call(), "getAnchorRoot failed") },
         )?;
 
-        let l2_block_number: u64 = anchor.l2SequenceNumber.try_into().map_err(|_| {
-            ContractError::Validation("anchor l2SequenceNumber overflows u64".into())
-        })?;
+        let l2_block_number: u64 = anchor
+            .l2SequenceNumber
+            .try_into()
+            .map_err(|_| ContractError::validation("anchor l2SequenceNumber overflows u64"))?;
 
         Ok(AnchorPreflight {
             blacklisted,

--- a/crates/proof/contracts/src/anchor_state_registry.rs
+++ b/crates/proof/contracts/src/anchor_state_registry.rs
@@ -130,28 +130,29 @@ impl AnchorStateRegistryContractClient {
 #[async_trait]
 impl AnchorStateRegistryClient for AnchorStateRegistryContractClient {
     async fn anchor_snapshot(&self) -> Result<AnchorSnapshot, ContractError> {
-        let block_number =
-            self.provider.get_block_number().await.map_err(|e| ContractError::Provider {
-                context: "get block number for anchor snapshot failed".into(),
-                source: e,
-            })?;
+        let block_number = self.provider.get_block_number().await.map_err(|e| {
+            ContractError::provider("get block number for anchor snapshot failed", e)
+        })?;
 
         let (anchor, anchor_game) = futures::try_join!(
             async {
-                self.contract.getAnchorRoot().block(block_number.into()).call().await.map_err(|e| {
-                    ContractError::Call { context: "getAnchorRoot failed".into(), source: e }
-                })
+                contract_call!(
+                    self.contract.getAnchorRoot().block(block_number.into()).call(),
+                    "getAnchorRoot failed"
+                )
             },
             async {
-                self.contract.anchorGame().block(block_number.into()).call().await.map_err(|e| {
-                    ContractError::Call { context: "anchorGame failed".into(), source: e }
-                })
+                contract_call!(
+                    self.contract.anchorGame().block(block_number.into()).call(),
+                    "anchorGame failed"
+                )
             },
         )?;
 
-        let l2_block_number: u64 = anchor.l2SequenceNumber.try_into().map_err(|_| {
-            ContractError::Validation("anchor l2SequenceNumber overflows u64".into())
-        })?;
+        let l2_block_number: u64 = anchor
+            .l2SequenceNumber
+            .try_into()
+            .map_err(|_| ContractError::validation("anchor l2SequenceNumber overflows u64"))?;
 
         tracing::info!(
             block_number,

--- a/crates/proof/contracts/src/delayed_weth.rs
+++ b/crates/proof/contracts/src/delayed_weth.rs
@@ -47,16 +47,10 @@ impl DelayedWETHContractClient {
 #[async_trait]
 impl DelayedWETHClient for DelayedWETHContractClient {
     async fn delay(&self) -> Result<Duration, ContractError> {
-        let delay_u256: U256 = self
-            .contract
-            .delay()
-            .call()
-            .await
-            .map_err(|e| ContractError::Call { context: "delay failed".into(), source: e })?;
+        let delay_u256: U256 = contract_call!(self.contract.delay().call(), "delay failed")?;
 
-        let delay_secs: u64 = delay_u256
-            .try_into()
-            .map_err(|_| ContractError::Validation("delay overflows u64".into()))?;
+        let delay_secs: u64 =
+            delay_u256.try_into().map_err(|_| ContractError::validation("delay overflows u64"))?;
 
         Ok(Duration::from_secs(delay_secs))
     }

--- a/crates/proof/contracts/src/dispute_game_factory.rs
+++ b/crates/proof/contracts/src/dispute_game_factory.rs
@@ -111,19 +111,16 @@ impl DisputeGameFactoryContractClient {
 #[async_trait]
 impl DisputeGameFactoryClient for DisputeGameFactoryContractClient {
     async fn game_count(&self) -> Result<u64, ContractError> {
-        let result =
-            self.contract.gameCount().call().await.map_err(|e| ContractError::Call {
-                context: "gameCount failed".into(),
-                source: e,
-            })?;
+        let result = contract_call!(self.contract.gameCount().call(), "gameCount failed")?;
 
-        result.try_into().map_err(|_| ContractError::Validation("gameCount overflows u64".into()))
+        result.try_into().map_err(|_| ContractError::validation("gameCount overflows u64"))
     }
 
     async fn game_at_index(&self, index: u64) -> Result<GameAtIndex, ContractError> {
-        let result = self.contract.gameAtIndex(U256::from(index)).call().await.map_err(|e| {
-            ContractError::Call { context: format!("gameAtIndex({index}) failed"), source: e }
-        })?;
+        let result = contract_call!(
+            self.contract.gameAtIndex(U256::from(index)).call(),
+            format!("gameAtIndex({index}) failed")
+        )?;
 
         Ok(GameAtIndex {
             game_type: result.gameType,
@@ -133,21 +130,13 @@ impl DisputeGameFactoryClient for DisputeGameFactoryContractClient {
     }
 
     async fn init_bonds(&self, game_type: u32) -> Result<U256, ContractError> {
-        let result =
-            self.contract.initBonds(game_type).call().await.map_err(|e| ContractError::Call {
-                context: "initBonds failed".into(),
-                source: e,
-            })?;
+        let result = contract_call!(self.contract.initBonds(game_type).call(), "initBonds failed")?;
 
         Ok(result)
     }
 
     async fn game_impls(&self, game_type: u32) -> Result<Address, ContractError> {
-        let result =
-            self.contract.gameImpls(game_type).call().await.map_err(|e| ContractError::Call {
-                context: "gameImpls failed".into(),
-                source: e,
-            })?;
+        let result = contract_call!(self.contract.gameImpls(game_type).call(), "gameImpls failed")?;
 
         Ok(result)
     }
@@ -158,10 +147,10 @@ impl DisputeGameFactoryClient for DisputeGameFactoryContractClient {
         root_claim: B256,
         extra_data: Bytes,
     ) -> Result<Address, ContractError> {
-        let result =
-            self.contract.games(game_type, root_claim, extra_data).call().await.map_err(|e| {
-                ContractError::Call { context: "games lookup failed".into(), source: e }
-            })?;
+        let result = contract_call!(
+            self.contract.games(game_type, root_claim, extra_data).call(),
+            "games lookup failed"
+        )?;
 
         Ok(result.proxy)
     }

--- a/crates/proof/contracts/src/error.rs
+++ b/crates/proof/contracts/src/error.rs
@@ -27,3 +27,20 @@ pub enum ContractError {
     #[error("{0}")]
     Validation(String),
 }
+
+impl ContractError {
+    /// Creates an error for a failed contract call.
+    pub fn call(context: impl Into<String>, source: alloy_contract::Error) -> Self {
+        Self::Call { context: context.into(), source }
+    }
+
+    /// Creates an error for a failed provider request.
+    pub fn provider(context: impl Into<String>, source: alloy_transport::TransportError) -> Self {
+        Self::Provider { context: context.into(), source }
+    }
+
+    /// Creates an error for a failed contract value validation.
+    pub fn validation(context: impl Into<String>) -> Self {
+        Self::Validation(context.into())
+    }
+}

--- a/crates/proof/contracts/src/lib.rs
+++ b/crates/proof/contracts/src/lib.rs
@@ -6,6 +6,9 @@
 )]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
+#[macro_use]
+mod macros;
+
 mod aggregate_verifier;
 pub use aggregate_verifier::{
     AggregateVerifierClient, AggregateVerifierContractClient, GameInfo, GameStatus,

--- a/crates/proof/contracts/src/macros.rs
+++ b/crates/proof/contracts/src/macros.rs
@@ -1,0 +1,7 @@
+//! Macros for shared contract client boilerplate.
+
+macro_rules! contract_call {
+    ($call:expr, $context:expr) => {
+        $call.await.map_err(|error| $crate::ContractError::call($context, error))
+    };
+}

--- a/crates/proof/contracts/src/nitro_enclave_verifier.rs
+++ b/crates/proof/contracts/src/nitro_enclave_verifier.rs
@@ -62,10 +62,10 @@ impl NitroEnclaveVerifierClient for NitroEnclaveVerifierContractClient {
     }
 
     async fn is_revoked(&self, cert_hash: FixedBytes<32>) -> Result<bool, ContractError> {
-        self.contract.revokedCerts(cert_hash).call().await.map_err(|e| ContractError::Call {
-            context: format!("revokedCerts({cert_hash})"),
-            source: e,
-        })
+        contract_call!(
+            self.contract.revokedCerts(cert_hash).call(),
+            format!("revokedCerts({cert_hash})")
+        )
     }
 }
 

--- a/crates/proof/contracts/src/tee_prover_registry.rs
+++ b/crates/proof/contracts/src/tee_prover_registry.rs
@@ -68,24 +68,21 @@ impl TEEProverRegistryContractClient {
 #[async_trait]
 impl TEEProverRegistryClient for TEEProverRegistryContractClient {
     async fn is_valid_signer(&self, signer: Address) -> Result<bool, ContractError> {
-        self.contract.isValidSigner(signer).call().await.map_err(|e| ContractError::Call {
-            context: format!("isValidSigner({signer})"),
-            source: e,
-        })
+        contract_call!(
+            self.contract.isValidSigner(signer).call(),
+            format!("isValidSigner({signer})")
+        )
     }
 
     async fn is_registered_signer(&self, signer: Address) -> Result<bool, ContractError> {
-        self.contract.isRegisteredSigner(signer).call().await.map_err(|e| ContractError::Call {
-            context: format!("isRegisteredSigner({signer})"),
-            source: e,
-        })
+        contract_call!(
+            self.contract.isRegisteredSigner(signer).call(),
+            format!("isRegisteredSigner({signer})")
+        )
     }
 
     async fn get_registered_signers(&self) -> Result<Vec<Address>, ContractError> {
-        self.contract.getRegisteredSigners().call().await.map_err(|e| ContractError::Call {
-            context: "getRegisteredSigners()".into(),
-            source: e,
-        })
+        contract_call!(self.contract.getRegisteredSigners().call(), "getRegisteredSigners()")
     }
 }
 


### PR DESCRIPTION
## Summary

This refactor adds a crate-local helper macro for Alloy contract calls in base-proof-contracts. The contract clients now share the same error mapping path for failed calls while preserving the existing context strings and validation behavior. It keeps the change separate from the broader common macro cleanup PR.