### PR TITLE
refactor(consensus): Share Azul Test Harness

### DIFF
--- a/actions/harness/tests/azul/clz.rs
+++ b/actions/harness/tests/azul/clz.rs
@@ -1,11 +1,8 @@
 //! CLZ opcode activation test across the Base Azul boundary.
 
 use alloy_primitives::{Bytes, TxKind, U256, hex};
-use base_action_harness::{
-    ActionL2Source, ActionTestHarness, Batcher, BatcherConfig, L1MinerConfig, SharedL1Chain,
-    TEST_ACCOUNT_ADDRESS, TestRollupConfigBuilder,
-};
-use base_batcher_encoder::{DaType, EncoderConfig};
+
+use crate::env::AzulTestEnv;
 
 /// CLZ probe-contract init code.
 ///
@@ -42,86 +39,47 @@ const CLZ_EXPECTED_GAS_DELTA: u64 = 12;
 
 #[tokio::test]
 async fn azul_clz_op_code() {
-    let batcher_cfg = BatcherConfig {
-        encoder: EncoderConfig { da_type: DaType::Calldata, ..EncoderConfig::default() },
-        ..Default::default()
-    };
-
-    // All forks through Jovian at genesis; Base Azul at ts=6 (block 3).
-    let base_azul_time = 6u64;
-    let rollup_cfg = TestRollupConfigBuilder::base_mainnet(&batcher_cfg)
-        .through_isthmus()
-        .with_jovian_at(0)
-        .with_azul_at(base_azul_time)
-        .build();
-    let chain_id = rollup_cfg.l2_chain_id.id();
-    let mut h = ActionTestHarness::new(L1MinerConfig::default(), rollup_cfg);
-
-    let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
-    let mut builder = h.create_l2_sequencer(l1_chain);
-
-    let (mut node, chain) = h.create_test_rollup_node_from_sequencer(
-        &mut builder,
-        SharedL1Chain::from_blocks(h.l1.chain().to_vec()),
-    );
-
-    let account = builder.test_account();
-    let contract_addr = TEST_ACCOUNT_ADDRESS.create(0);
+    let mut env = AzulTestEnv::new();
+    let contract_addr = env.first_contract_address();
 
     // ── Block 1 (ts=2, pre-fork): deploy CLZ probe contract ──────────
-    let deploy_tx = {
-        let mut acct = account.lock().expect("test account lock");
-        acct.create_tx(
-            chain_id,
-            TxKind::Create,
-            Bytes::from_static(&CLZ_INIT_CODE),
-            U256::ZERO,
-            100_000,
-        )
-    };
-    let block1 = builder.build_next_block_with_transactions(vec![deploy_tx]).await;
+    let deploy_tx =
+        env.create_tx(TxKind::Create, Bytes::from_static(&CLZ_INIT_CODE), U256::ZERO, 100_000);
+    let block1 = env.sequencer.build_next_block_with_transactions(vec![deploy_tx]).await;
 
     // Verify the contract code was deployed.
-    assert!(builder.has_code(contract_addr), "deployed contract must have non-empty code");
+    assert!(env.sequencer.has_code(contract_addr), "deployed contract must have non-empty code");
 
     // ── Block 2 (ts=4, pre-fork): call CLZ(1) — must abort ──────────
-    let call_pre = {
-        let mut acct = account.lock().expect("test account lock");
-        acct.create_tx(
-            chain_id,
-            TxKind::Call(contract_addr),
-            Bytes::from_static(&CLZ_INPUT_ONE),
-            U256::ZERO,
-            100_000,
-        )
-    };
-    let block2 = builder.build_next_block_with_transactions(vec![call_pre]).await;
+    let call_pre = env.create_tx(
+        TxKind::Call(contract_addr),
+        Bytes::from_static(&CLZ_INPUT_ONE),
+        U256::ZERO,
+        100_000,
+    );
+    let block2 = env.sequencer.build_next_block_with_transactions(vec![call_pre]).await;
 
     // Sentinel slot must remain zero — CLZ aborted before any SSTORE ran.
     assert_eq!(
-        builder.storage_at(contract_addr, CLZ_SENTINEL_SLOT),
+        env.sequencer.storage_at(contract_addr, CLZ_SENTINEL_SLOT),
         U256::ZERO,
         "sentinel must be zero: CLZ should abort as invalid opcode pre-fork"
     );
 
     // ── Block 3 (ts=6, post-fork): call CLZ(1) — must succeed ───────
-    let call_one = {
-        let mut acct = account.lock().expect("test account lock");
-        acct.create_tx(
-            chain_id,
-            TxKind::Call(contract_addr),
-            Bytes::from_static(&CLZ_INPUT_ONE),
-            U256::ZERO,
-            100_000,
-        )
-    };
-    let block3 = builder.build_next_block_with_transactions(vec![call_one]).await;
+    let call_one = env.create_tx(
+        TxKind::Call(contract_addr),
+        Bytes::from_static(&CLZ_INPUT_ONE),
+        U256::ZERO,
+        100_000,
+    );
+    let block3 = env.sequencer.build_next_block_with_transactions(vec![call_one]).await;
 
     // Sentinel must now be 1 (CLZ completed), result slot must be 255.
     {
-        let sentinel = builder.storage_at(contract_addr, CLZ_SENTINEL_SLOT);
-        let result = builder.storage_at(contract_addr, CLZ_RESULT_SLOT);
-        let gas_delta = builder.storage_at(contract_addr, CLZ_GAS_DELTA_SLOT);
+        let sentinel = env.sequencer.storage_at(contract_addr, CLZ_SENTINEL_SLOT);
+        let result = env.sequencer.storage_at(contract_addr, CLZ_RESULT_SLOT);
+        let gas_delta = env.sequencer.storage_at(contract_addr, CLZ_GAS_DELTA_SLOT);
         assert_eq!(sentinel, U256::from(1), "sentinel must be 1 after successful CLZ");
         assert_eq!(result, U256::from(255), "CLZ(1) must equal 255");
         assert_eq!(
@@ -132,22 +90,18 @@ async fn azul_clz_op_code() {
     }
 
     // ── Block 4 (ts=8, post-fork): call CLZ(0x8000…0) — result = 0 ──
-    let call_high = {
-        let mut acct = account.lock().expect("test account lock");
-        acct.create_tx(
-            chain_id,
-            TxKind::Call(contract_addr),
-            Bytes::from_static(&CLZ_INPUT_HIGH_BIT),
-            U256::ZERO,
-            100_000,
-        )
-    };
-    let block4 = builder.build_next_block_with_transactions(vec![call_high]).await;
+    let call_high = env.create_tx(
+        TxKind::Call(contract_addr),
+        Bytes::from_static(&CLZ_INPUT_HIGH_BIT),
+        U256::ZERO,
+        100_000,
+    );
+    let block4 = env.sequencer.build_next_block_with_transactions(vec![call_high]).await;
 
     {
-        let sentinel = builder.storage_at(contract_addr, CLZ_SENTINEL_SLOT);
-        let result = builder.storage_at(contract_addr, CLZ_RESULT_SLOT);
-        let gas_delta = builder.storage_at(contract_addr, CLZ_GAS_DELTA_SLOT);
+        let sentinel = env.sequencer.storage_at(contract_addr, CLZ_SENTINEL_SLOT);
+        let result = env.sequencer.storage_at(contract_addr, CLZ_RESULT_SLOT);
+        let gas_delta = env.sequencer.storage_at(contract_addr, CLZ_GAS_DELTA_SLOT);
         assert_eq!(sentinel, U256::from(1), "sentinel must remain 1");
         assert_eq!(result, U256::ZERO, "CLZ(0x8000…0) must equal 0");
         assert_eq!(
@@ -158,20 +112,5 @@ async fn azul_clz_op_code() {
     }
 
     // ── Batch and derive all 4 blocks ────────────────────────────────
-    let mut batcher = Batcher::new(ActionL2Source::new(), &h.rollup_config, batcher_cfg.clone());
-    node.initialize().await;
-
-    for (block, i) in [(block1, 1u64), (block2, 2), (block3, 3), (block4, 4)] {
-        batcher.push_block(block);
-        batcher.advance(&mut h.l1).await;
-        chain.push(h.l1.tip().clone());
-        let derived = node.run_until_idle().await;
-        assert_eq!(derived, 1, "L1 block {i} should derive exactly one L2 block");
-    }
-
-    assert_eq!(
-        node.l2_safe().block_info.number,
-        4,
-        "all 4 L2 blocks must derive through the Base V1 boundary"
-    );
+    env.derive_blocks([(block1, 1), (block2, 2), (block3, 3), (block4, 4)], 4, "Base V1").await;
 }

--- a/actions/harness/tests/azul/env.rs
+++ b/actions/harness/tests/azul/env.rs
@@ -1,0 +1,102 @@
+//! Shared test environment for Base Azul action tests.
+
+use alloy_primitives::{Address, Bytes, TxKind, U256};
+use base_action_harness::{
+    ActionL2Source, ActionTestHarness, Batcher, BatcherConfig, L1MinerConfig, L2Sequencer,
+    SharedL1Chain, TEST_ACCOUNT_ADDRESS, TestRollupConfigBuilder, TestRollupNode, VerifierPipeline,
+};
+use base_batcher_encoder::{DaType, EncoderConfig};
+use base_common_consensus::{BaseBlock, BaseTxEnvelope};
+
+/// Test environment preconfigured to cross the Base Azul activation at L2 block 3.
+pub(crate) struct AzulTestEnv {
+    /// Sequencer used to build probe deployment and call blocks.
+    pub(crate) sequencer: L2Sequencer,
+    harness: ActionTestHarness,
+    batcher_cfg: BatcherConfig,
+    node: TestRollupNode<VerifierPipeline>,
+    chain: SharedL1Chain,
+    chain_id: u64,
+}
+
+impl AzulTestEnv {
+    /// Creates an environment with all forks through Jovian active at genesis
+    /// and Base Azul active at timestamp 6.
+    pub(crate) fn new() -> Self {
+        let batcher_cfg = BatcherConfig {
+            encoder: EncoderConfig { da_type: DaType::Calldata, ..EncoderConfig::default() },
+            ..Default::default()
+        };
+
+        let rollup_cfg = TestRollupConfigBuilder::base_mainnet(&batcher_cfg)
+            .through_isthmus()
+            .with_jovian_at(0)
+            .with_azul_at(6)
+            .build();
+        let chain_id = rollup_cfg.l2_chain_id.id();
+        let harness = ActionTestHarness::new(L1MinerConfig::default(), rollup_cfg);
+
+        let l1_chain = SharedL1Chain::from_blocks(harness.l1.chain().to_vec());
+        let mut sequencer = harness.create_l2_sequencer(l1_chain);
+
+        let (node, chain) = harness.create_test_rollup_node_from_sequencer(
+            &mut sequencer,
+            SharedL1Chain::from_blocks(harness.l1.chain().to_vec()),
+        );
+
+        Self { sequencer, harness, batcher_cfg, node, chain, chain_id }
+    }
+
+    /// Returns the address created by the first test-account deployment.
+    pub(crate) fn first_contract_address(&self) -> Address {
+        TEST_ACCOUNT_ADDRESS.create(0)
+    }
+
+    /// Creates and signs a test-account transaction.
+    pub(crate) fn create_tx(
+        &self,
+        to: TxKind,
+        input: Bytes,
+        value: U256,
+        gas_limit: u64,
+    ) -> BaseTxEnvelope {
+        let account = self.sequencer.test_account();
+        let mut account = account.lock().expect("test account lock");
+        account.create_tx(self.chain_id, to, input, value, gas_limit)
+    }
+
+    /// Batches the supplied L2 blocks, derives each one, and asserts the final safe head.
+    pub(crate) async fn derive_blocks<const N: usize>(
+        &mut self,
+        blocks: [(BaseBlock, u64); N],
+        expected_safe_head: u64,
+        boundary: &str,
+    ) {
+        let mut batcher = Batcher::new(
+            ActionL2Source::new(),
+            &self.harness.rollup_config,
+            self.batcher_cfg.clone(),
+        );
+        self.node.initialize().await;
+
+        for (block, i) in blocks {
+            batcher.push_block(block);
+            batcher.advance(&mut self.harness.l1).await;
+            self.chain.push(self.harness.l1.tip().clone());
+            let derived = self.node.run_until_idle().await;
+            assert_eq!(derived, 1, "L1 block {i} should derive exactly one L2 block");
+        }
+
+        assert_eq!(
+            self.node.l2_safe_number(),
+            expected_safe_head,
+            "all {expected_safe_head} L2 blocks must derive through the {boundary} boundary"
+        );
+    }
+}
+
+impl Default for AzulTestEnv {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/actions/harness/tests/azul/main.rs
+++ b/actions/harness/tests/azul/main.rs
@@ -2,5 +2,6 @@
 
 mod clz;
 mod derivation;
+mod env;
 mod modexp;
 mod p256;

--- a/actions/harness/tests/azul/modexp.rs
+++ b/actions/harness/tests/azul/modexp.rs
@@ -1,11 +1,8 @@
 //! MODEXP precompile tests across the Base Azul boundary.
 
 use alloy_primitives::{Bytes, TxKind, U256, hex};
-use base_action_harness::{
-    ActionL2Source, ActionTestHarness, Batcher, BatcherConfig, L1MinerConfig, SharedL1Chain,
-    TEST_ACCOUNT_ADDRESS, TestRollupConfigBuilder,
-};
-use base_batcher_encoder::{DaType, EncoderConfig};
+
+use crate::env::AzulTestEnv;
 
 // ─── MODEXP probe contract ──────────────────────────────────────────
 //
@@ -74,87 +71,48 @@ impl ModexpInput {
 /// Pre-fork the oversized call succeeds; post-fork it fails.
 #[tokio::test]
 async fn azul_modexp_upper_bound() {
-    let batcher_cfg = BatcherConfig {
-        encoder: EncoderConfig { da_type: DaType::Calldata, ..EncoderConfig::default() },
-        ..Default::default()
-    };
-
-    // Base Azul activates at ts=6 (block 3).
-    let base_azul_time = 6u64;
-    let rollup_cfg = TestRollupConfigBuilder::base_mainnet(&batcher_cfg)
-        .through_isthmus()
-        .with_jovian_at(0)
-        .with_azul_at(base_azul_time)
-        .build();
-    let chain_id = rollup_cfg.l2_chain_id.id();
-    let mut h = ActionTestHarness::new(L1MinerConfig::default(), rollup_cfg);
-
-    let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
-    let mut builder = h.create_l2_sequencer(l1_chain);
-
-    let (mut node, chain) = h.create_test_rollup_node_from_sequencer(
-        &mut builder,
-        SharedL1Chain::from_blocks(h.l1.chain().to_vec()),
-    );
-
-    let account = builder.test_account();
-    let contract_addr = TEST_ACCOUNT_ADDRESS.create(0);
+    let mut env = AzulTestEnv::new();
+    let contract_addr = env.first_contract_address();
 
     // ── Block 1 (ts=2, pre-fork): deploy MODEXP probe contract ──────
-    let deploy_tx = {
-        let mut acct = account.lock().expect("test account lock");
-        acct.create_tx(
-            chain_id,
-            TxKind::Create,
-            Bytes::from_static(&MODEXP_INIT_CODE),
-            U256::ZERO,
-            100_000,
-        )
-    };
-    let block1 = builder.build_next_block_with_transactions(vec![deploy_tx]).await;
+    let deploy_tx =
+        env.create_tx(TxKind::Create, Bytes::from_static(&MODEXP_INIT_CODE), U256::ZERO, 100_000);
+    let block1 = env.sequencer.build_next_block_with_transactions(vec![deploy_tx]).await;
 
-    assert!(builder.has_code(contract_addr), "deployed contract must have non-empty code");
+    assert!(env.sequencer.has_code(contract_addr), "deployed contract must have non-empty code");
 
     // Oversized input: base_len = 1025 (> 1024-byte EIP-7823 limit).
     let oversized_input = ModexpInput::build(&vec![0u8; 1025], &[], &[2]);
 
     // ── Block 2 (ts=4, pre-fork): call MODEXP with oversized input ───
-    let call_pre = {
-        let mut acct = account.lock().expect("test account lock");
-        acct.create_tx(
-            chain_id,
-            TxKind::Call(contract_addr),
-            Bytes::from(oversized_input.clone()),
-            U256::ZERO,
-            1_000_000,
-        )
-    };
-    let block2 = builder.build_next_block_with_transactions(vec![call_pre]).await;
+    let call_pre = env.create_tx(
+        TxKind::Call(contract_addr),
+        Bytes::from(oversized_input.clone()),
+        U256::ZERO,
+        1_000_000,
+    );
+    let block2 = env.sequencer.build_next_block_with_transactions(vec![call_pre]).await;
 
     // Pre-fork: oversized MODEXP succeeds.
     {
-        let sentinel = builder.storage_at(contract_addr, MODEXP_SENTINEL_SLOT);
-        let success = builder.storage_at(contract_addr, MODEXP_SUCCESS_SLOT);
+        let sentinel = env.sequencer.storage_at(contract_addr, MODEXP_SENTINEL_SLOT);
+        let success = env.sequencer.storage_at(contract_addr, MODEXP_SUCCESS_SLOT);
         assert_eq!(sentinel, U256::from(1), "sentinel must be 1: probe completed pre-fork");
         assert_eq!(success, U256::from(1), "MODEXP with oversized input must succeed pre-fork");
     }
 
     // ── Block 3 (ts=6, post-fork): call MODEXP with oversized input ──
-    let call_post = {
-        let mut acct = account.lock().expect("test account lock");
-        acct.create_tx(
-            chain_id,
-            TxKind::Call(contract_addr),
-            Bytes::from(oversized_input),
-            U256::ZERO,
-            1_000_000,
-        )
-    };
-    let block3 = builder.build_next_block_with_transactions(vec![call_post]).await;
+    let call_post = env.create_tx(
+        TxKind::Call(contract_addr),
+        Bytes::from(oversized_input),
+        U256::ZERO,
+        1_000_000,
+    );
+    let block3 = env.sequencer.build_next_block_with_transactions(vec![call_post]).await;
 
     // Post-fork: oversized MODEXP must fail (EIP-7823).
     {
-        let success = builder.storage_at(contract_addr, MODEXP_SUCCESS_SLOT);
+        let success = env.sequencer.storage_at(contract_addr, MODEXP_SUCCESS_SLOT);
         assert_eq!(
             success,
             U256::ZERO,
@@ -163,110 +121,52 @@ async fn azul_modexp_upper_bound() {
     }
 
     // ── Batch and derive ─────────────────────────────────────────────
-    let mut batcher = Batcher::new(ActionL2Source::new(), &h.rollup_config, batcher_cfg.clone());
-    node.initialize().await;
-
-    for (block, i) in [(block1, 1u64), (block2, 2), (block3, 3)] {
-        batcher.push_block(block);
-        batcher.advance(&mut h.l1).await;
-        chain.push(h.l1.tip().clone());
-        let derived = node.run_until_idle().await;
-        assert_eq!(derived, 1, "L1 block {i} should derive exactly one L2 block");
-    }
-
-    assert_eq!(
-        node.l2_safe().block_info.number,
-        3,
-        "all 3 L2 blocks must derive through the Base Azul boundary"
-    );
+    env.derive_blocks([(block1, 1), (block2, 2), (block3, 3)], 3, "Base Azul").await;
 }
 
 /// EIP-7883: MODEXP gas cost increases after Base Azul (min 200→500, general cost tripled).
 #[tokio::test]
 async fn azul_modexp_gas_cost_increase() {
-    let batcher_cfg = BatcherConfig {
-        encoder: EncoderConfig { da_type: DaType::Calldata, ..EncoderConfig::default() },
-        ..Default::default()
-    };
-
-    // Base Azul activates at ts=6 (block 3).
-    let base_azul_time = 6u64;
-    let rollup_cfg = TestRollupConfigBuilder::base_mainnet(&batcher_cfg)
-        .through_isthmus()
-        .with_jovian_at(0)
-        .with_azul_at(base_azul_time)
-        .build();
-    let chain_id = rollup_cfg.l2_chain_id.id();
-    let mut h = ActionTestHarness::new(L1MinerConfig::default(), rollup_cfg);
-
-    let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
-    let mut builder = h.create_l2_sequencer(l1_chain);
-
-    let (mut node, chain) = h.create_test_rollup_node_from_sequencer(
-        &mut builder,
-        SharedL1Chain::from_blocks(h.l1.chain().to_vec()),
-    );
-
-    let account = builder.test_account();
-    let contract_addr = TEST_ACCOUNT_ADDRESS.create(0);
+    let mut env = AzulTestEnv::new();
+    let contract_addr = env.first_contract_address();
 
     // ── Block 1 (ts=2, pre-fork): deploy MODEXP probe contract ──────
-    let deploy_tx = {
-        let mut acct = account.lock().expect("test account lock");
-        acct.create_tx(
-            chain_id,
-            TxKind::Create,
-            Bytes::from_static(&MODEXP_INIT_CODE),
-            U256::ZERO,
-            100_000,
-        )
-    };
-    let block1 = builder.build_next_block_with_transactions(vec![deploy_tx]).await;
+    let deploy_tx =
+        env.create_tx(TxKind::Create, Bytes::from_static(&MODEXP_INIT_CODE), U256::ZERO, 100_000);
+    let block1 = env.sequencer.build_next_block_with_transactions(vec![deploy_tx]).await;
 
-    assert!(builder.has_code(contract_addr), "deployed contract must have non-empty code");
+    assert!(env.sequencer.has_code(contract_addr), "deployed contract must have non-empty code");
 
     // Small valid input: 2^3 mod 5 (= 3).
     let small_input = ModexpInput::build(&[2], &[3], &[5]);
 
     // ── Block 2 (ts=4, pre-fork): call MODEXP ────────────────────────
-    let call_pre = {
-        let mut acct = account.lock().expect("test account lock");
-        acct.create_tx(
-            chain_id,
-            TxKind::Call(contract_addr),
-            Bytes::from(small_input.clone()),
-            U256::ZERO,
-            100_000,
-        )
-    };
-    let block2 = builder.build_next_block_with_transactions(vec![call_pre]).await;
+    let call_pre = env.create_tx(
+        TxKind::Call(contract_addr),
+        Bytes::from(small_input.clone()),
+        U256::ZERO,
+        100_000,
+    );
+    let block2 = env.sequencer.build_next_block_with_transactions(vec![call_pre]).await;
 
     let gas_delta_pre;
     {
-        let sentinel = builder.storage_at(contract_addr, MODEXP_SENTINEL_SLOT);
-        let success = builder.storage_at(contract_addr, MODEXP_SUCCESS_SLOT);
-        gas_delta_pre = builder.storage_at(contract_addr, MODEXP_GAS_DELTA_SLOT);
+        let sentinel = env.sequencer.storage_at(contract_addr, MODEXP_SENTINEL_SLOT);
+        let success = env.sequencer.storage_at(contract_addr, MODEXP_SUCCESS_SLOT);
+        gas_delta_pre = env.sequencer.storage_at(contract_addr, MODEXP_GAS_DELTA_SLOT);
         assert_eq!(sentinel, U256::from(1), "sentinel must be 1: probe completed pre-fork");
         assert_eq!(success, U256::from(1), "MODEXP must succeed pre-fork");
     }
 
     // ── Block 3 (ts=6, post-fork): call MODEXP with same input ───────
-    let call_post = {
-        let mut acct = account.lock().expect("test account lock");
-        acct.create_tx(
-            chain_id,
-            TxKind::Call(contract_addr),
-            Bytes::from(small_input),
-            U256::ZERO,
-            100_000,
-        )
-    };
-    let block3 = builder.build_next_block_with_transactions(vec![call_post]).await;
+    let call_post =
+        env.create_tx(TxKind::Call(contract_addr), Bytes::from(small_input), U256::ZERO, 100_000);
+    let block3 = env.sequencer.build_next_block_with_transactions(vec![call_post]).await;
 
     let gas_delta_post;
     {
-        let success = builder.storage_at(contract_addr, MODEXP_SUCCESS_SLOT);
-        gas_delta_post = builder.storage_at(contract_addr, MODEXP_GAS_DELTA_SLOT);
+        let success = env.sequencer.storage_at(contract_addr, MODEXP_SUCCESS_SLOT);
+        gas_delta_post = env.sequencer.storage_at(contract_addr, MODEXP_GAS_DELTA_SLOT);
         assert_eq!(success, U256::from(1), "MODEXP must succeed post-fork");
     }
 
@@ -279,20 +179,5 @@ async fn azul_modexp_gas_cost_increase() {
     );
 
     // ── Batch and derive ─────────────────────────────────────────────
-    let mut batcher = Batcher::new(ActionL2Source::new(), &h.rollup_config, batcher_cfg.clone());
-    node.initialize().await;
-
-    for (block, i) in [(block1, 1u64), (block2, 2), (block3, 3)] {
-        batcher.push_block(block);
-        batcher.advance(&mut h.l1).await;
-        chain.push(h.l1.tip().clone());
-        let derived = node.run_until_idle().await;
-        assert_eq!(derived, 1, "L1 block {i} should derive exactly one L2 block");
-    }
-
-    assert_eq!(
-        node.l2_safe().block_info.number,
-        3,
-        "all 3 L2 blocks must derive through the Base V1 boundary"
-    );
+    env.derive_blocks([(block1, 1), (block2, 2), (block3, 3)], 3, "Base V1").await;
 }

--- a/actions/harness/tests/azul/p256.rs
+++ b/actions/harness/tests/azul/p256.rs
@@ -1,11 +1,8 @@
 //! P256VERIFY precompile gas cost test across the Base Azul boundary.
 
 use alloy_primitives::{Bytes, TxKind, U256, hex};
-use base_action_harness::{
-    ActionL2Source, ActionTestHarness, Batcher, BatcherConfig, L1MinerConfig, SharedL1Chain,
-    TEST_ACCOUNT_ADDRESS, TestRollupConfigBuilder,
-};
-use base_batcher_encoder::{DaType, EncoderConfig};
+
+use crate::env::AzulTestEnv;
 
 /// P256VERIFY probe-contract init code (12 bytes init + 34 bytes runtime).
 ///
@@ -33,84 +30,42 @@ const P256_SENTINEL_SLOT: U256 = U256::from_limbs([2, 0, 0, 0]);
 /// P256VERIFY gas cost doubles after Base Azul (3,450 → 6,900).
 #[tokio::test]
 async fn azul_p256_verify_gas_cost_increase() {
-    let batcher_cfg = BatcherConfig {
-        encoder: EncoderConfig { da_type: DaType::Calldata, ..EncoderConfig::default() },
-        ..Default::default()
-    };
-
-    // Base Azul activates at ts=6 (block 3).
-    let base_azul_time = 6u64;
-    let rollup_cfg = TestRollupConfigBuilder::base_mainnet(&batcher_cfg)
-        .through_isthmus()
-        .with_jovian_at(0)
-        .with_azul_at(base_azul_time)
-        .build();
-    let chain_id = rollup_cfg.l2_chain_id.id();
-    let mut h = ActionTestHarness::new(L1MinerConfig::default(), rollup_cfg);
-
-    let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
-    let mut builder = h.create_l2_sequencer(l1_chain);
-
-    let (mut node, chain) = h.create_test_rollup_node_from_sequencer(
-        &mut builder,
-        SharedL1Chain::from_blocks(h.l1.chain().to_vec()),
-    );
-
-    let account = builder.test_account();
-    let contract_addr = TEST_ACCOUNT_ADDRESS.create(0);
+    let mut env = AzulTestEnv::new();
+    let contract_addr = env.first_contract_address();
 
     // ── Block 1 (ts=2, pre-fork): deploy P256VERIFY probe contract ───
-    let deploy_tx = {
-        let mut acct = account.lock().expect("test account lock");
-        acct.create_tx(
-            chain_id,
-            TxKind::Create,
-            Bytes::from_static(&P256_INIT_CODE),
-            U256::ZERO,
-            100_000,
-        )
-    };
-    let block1 = builder.build_next_block_with_transactions(vec![deploy_tx]).await;
+    let deploy_tx =
+        env.create_tx(TxKind::Create, Bytes::from_static(&P256_INIT_CODE), U256::ZERO, 100_000);
+    let block1 = env.sequencer.build_next_block_with_transactions(vec![deploy_tx]).await;
 
-    assert!(builder.has_code(contract_addr), "deployed contract must have non-empty code");
+    assert!(env.sequencer.has_code(contract_addr), "deployed contract must have non-empty code");
 
     // Empty calldata — the precompile returns empty output (invalid sig) but
     // still charges its base gas fee, which is what we measure.
     let p256_input = Bytes::new();
 
     // ── Block 2 (ts=4, pre-fork): call P256VERIFY ────────────────────
-    let call_pre = {
-        let mut acct = account.lock().expect("test account lock");
-        acct.create_tx(
-            chain_id,
-            TxKind::Call(contract_addr),
-            p256_input.clone(),
-            U256::ZERO,
-            100_000,
-        )
-    };
-    let block2 = builder.build_next_block_with_transactions(vec![call_pre]).await;
+    let call_pre =
+        env.create_tx(TxKind::Call(contract_addr), p256_input.clone(), U256::ZERO, 100_000);
+    let block2 = env.sequencer.build_next_block_with_transactions(vec![call_pre]).await;
 
     let gas_delta_pre;
     {
-        let sentinel = builder.storage_at(contract_addr, P256_SENTINEL_SLOT);
-        let success = builder.storage_at(contract_addr, P256_SUCCESS_SLOT);
-        gas_delta_pre = builder.storage_at(contract_addr, P256_GAS_DELTA_SLOT);
+        let sentinel = env.sequencer.storage_at(contract_addr, P256_SENTINEL_SLOT);
+        let success = env.sequencer.storage_at(contract_addr, P256_SUCCESS_SLOT);
+        gas_delta_pre = env.sequencer.storage_at(contract_addr, P256_GAS_DELTA_SLOT);
         assert_eq!(sentinel, U256::from(1), "sentinel must be 1: probe completed pre-fork");
         assert_eq!(success, U256::from(1), "P256VERIFY must succeed pre-fork");
     }
 
     // ── Block 3 (ts=6, post-fork): call P256VERIFY with same input ───
-    let call_post = {
-        let mut acct = account.lock().expect("test account lock");
-        acct.create_tx(chain_id, TxKind::Call(contract_addr), p256_input, U256::ZERO, 100_000)
-    };
-    let block3 = builder.build_next_block_with_transactions(vec![call_post]).await;
+    let call_post = env.create_tx(TxKind::Call(contract_addr), p256_input, U256::ZERO, 100_000);
+    let block3 = env.sequencer.build_next_block_with_transactions(vec![call_post]).await;
 
     let gas_delta_post;
     {
-        let success = builder.storage_at(contract_addr, P256_SUCCESS_SLOT);
-        gas_delta_post = builder.storage_at(contract_addr, P256_GAS_DELTA_SLOT);
+        let success = env.sequencer.storage_at(contract_addr, P256_SUCCESS_SLOT);
+        gas_delta_post = env.sequencer.storage_at(contract_addr, P256_GAS_DELTA_SLOT);
         assert_eq!(success, U256::from(1), "P256VERIFY must succeed post-fork");
     }
 
@@ -122,20 +77,5 @@ async fn azul_p256_verify_gas_cost_increase() {
     );
 
     // ── Batch and derive ─────────────────────────────────────────────
-    let mut batcher = Batcher::new(ActionL2Source::new(), &h.rollup_config, batcher_cfg.clone());
-    node.initialize().await;
-
-    for (block, i) in [(block1, 1u64), (block2, 2), (block3, 3)] {
-        batcher.push_block(block);
-        batcher.advance(&mut h.l1).await;
-        chain.push(h.l1.tip().clone());
-        let derived = node.run_until_idle().await;
-        assert_eq!(derived, 1, "L1 block {i} should derive exactly one L2 block");
-    }
-
-    assert_eq!(
-        node.l2_safe().block_info.number,
-        3,
-        "all 3 L2 blocks must derive through the Base Azul boundary"
-    );
+    env.derive_blocks([(block1, 1), (block2, 2), (block3, 3)], 3, "Base Azul").await;
 }


### PR DESCRIPTION
## Summary

This refactors the Base Azul action tests to share their common harness setup, transaction creation, and derivation assertions. The probe-specific CLZ, P256, and MODEXP tests now focus on their individual bytecode, calls, and storage checks while reusing a single test environment helper.