### PR TITLE
feat(cli): Add Base Update Command

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -16,13 +16,16 @@ on:
 env:
   REGISTRY_IMAGE: ghcr.io/${{ github.repository_owner }}/node-reth-dev
   RELEASE_BINS: |
+    base
     base-reth-node
-    basectl
     base-consensus
+    basectl
 
 permissions:
   contents: write
   packages: write
+  id-token: write
+  attestations: write
 
 jobs:
   # Build native binaries for release artifacts
@@ -105,6 +108,31 @@ jobs:
             fi
           done <<< "${RELEASE_BINS}"
 
+      - name: Sign archives
+        env:
+          GPG_SIGNING_KEY: ${{ secrets.GPG_SIGNING_KEY }}
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+        run: |
+          if [[ -z "$GPG_SIGNING_KEY" || -z "$GPG_PASSPHRASE" ]]; then
+            echo "::error::GPG_SIGNING_KEY and GPG_PASSPHRASE secrets are required to sign release binaries"
+            exit 1
+          fi
+
+          GNUPGHOME="$(mktemp -d)"
+          export GNUPGHOME
+          trap 'rm -rf "$GNUPGHOME"' EXIT
+
+          echo -n "$GPG_SIGNING_KEY" | base64 --decode | gpg --batch --import
+          for archive in *.tar.gz; do
+            printf '%s' "$GPG_PASSPHRASE" | \
+              gpg --batch --yes --pinentry-mode loopback --passphrase-fd 0 --armor --detach-sign "$archive"
+          done
+
+      - name: Attest build provenance
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
+        with:
+          subject-path: "*.tar.gz"
+
       - name: Upload artifacts
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
@@ -112,6 +140,7 @@ jobs:
           path: |
             *.tar.gz
             *.tar.gz.sha256
+            *.tar.gz.asc
           if-no-files-found: error
           retention-days: 1
 
@@ -287,7 +316,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           TAG="${{ inputs.tag }}"
-          gh release upload "$TAG" ${{ runner.temp }}/binaries/*.tar.gz ${{ runner.temp }}/binaries/*.tar.gz.sha256
+          gh release upload "$TAG" ${{ runner.temp }}/binaries/*.tar.gz ${{ runner.temp }}/binaries/*.tar.gz.sha256 ${{ runner.temp }}/binaries/*.tar.gz.asc
 
       - name: Summary
         run: |

--- a/baseup/README.md
+++ b/baseup/README.md
@@ -15,7 +15,9 @@ curl -fsSL https://raw.githubusercontent.com/base/base/main/baseup/install | bas
 ```bash
 baseup                                # Install the latest release binaries
 baseup -i v0.6.0                      # Install a specific release tag
+baseup --bin base                     # Install only the unified base binary
 baseup --bin base-reth-node           # Install only the node binary
+baseup --bin base-consensus           # Install only the consensus binary
 baseup --bin basectl                  # Install only basectl
 baseup --bin all                      # Install all published binaries
 baseup -v                             # Print the baseup installer version
@@ -27,8 +29,21 @@ baseup --help                         # Show help
 
 By default, `baseup` installs every binary this repo publishes in GitHub releases today:
 
+- `base`
 - `base-reth-node`
+- `base-consensus`
 - `basectl`
+
+## Verification
+
+`baseup` verifies every release archive before installing it:
+
+- downloads `<binary>-<version>-<target>.tar.gz`
+- checks `<archive>.sha256`
+- verifies `<archive>.asc` with GPG
+- verifies GitHub SLSA provenance when `gh` is installed and authenticated
+
+Use `--unsafe-skip-verify` only for local testing; checksum verification is still required.
 
 ## Supported Targets
 

--- a/baseup/baseup
+++ b/baseup/baseup
@@ -5,7 +5,7 @@ set -e
 # Downloads release binaries from GitHub releases and installs them locally.
 
 # NOTE: If you change this script, increment the version below.
-BASEUP_INSTALLER_VERSION="0.1.3"
+BASEUP_INSTALLER_VERSION="0.1.4"
 
 BASEUP_REPO="${BASEUP_REPO:-base/base}"
 BASEUP_REPO_REF="${BASEUP_REPO_REF:-main}"
@@ -14,11 +14,14 @@ BIN_DIR="${BASE_BIN_DIR:-$BASEUP_HOME/bin}"
 BASEUP_HOST_BASE_URL="${BASEUP_HOST_BASE_URL:-https://raw.githubusercontent.com/${BASEUP_REPO}/${BASEUP_REPO_REF}/baseup}"
 BASEUP_BIN_URL="${BASEUP_BIN_URL:-${BASEUP_HOST_BASE_URL}/baseup}"
 BASEUP_BIN_PATH="$BIN_DIR/baseup"
+BASEUP_RELEASE_GPG_FINGERPRINT="${BASEUP_RELEASE_GPG_FINGERPRINT:-}"
+BASEUP_RELEASE_GPG_KEY_URL="${BASEUP_RELEASE_GPG_KEY_URL:-}"
 
-DEFAULT_BINS=("base-reth-node" "basectl")
+DEFAULT_BINS=("base" "base-reth-node" "base-consensus" "basectl")
 SELECTED_BINS=()
 VERSION=""
 VERSION_EXPLICIT=0
+UNSAFE_SKIP_VERIFY=0
 UPDATE_TMP_FILE=""
 MAIN_TMP_DIR=""
 UPDATE_CHECK_CACHE_FILE="$BASEUP_HOME/baseup-update-check"
@@ -199,6 +202,96 @@ compute_sha256() {
     fi
 }
 
+normalize_fingerprint() {
+    printf '%s' "$1" | tr -d '[:space:]' | tr '[:lower:]' '[:upper:]'
+}
+
+ensure_gpg_key() {
+    local fingerprint
+    fingerprint="$(normalize_fingerprint "$BASEUP_RELEASE_GPG_FINGERPRINT")"
+
+    [[ -n "$fingerprint" ]] || return 0
+
+    if gpg --batch --list-keys "$fingerprint" >/dev/null 2>&1; then
+        return 0
+    fi
+
+    if [[ -z "$BASEUP_RELEASE_GPG_KEY_URL" ]]; then
+        error "Base release signing key $fingerprint is not in your keyring. Set BASEUP_RELEASE_GPG_KEY_URL or import the key before installing."
+    fi
+
+    info "Fetching Base release signing key..."
+    if ! fetch_text "$BASEUP_RELEASE_GPG_KEY_URL" | gpg --batch --import >/dev/null 2>&1; then
+        error "Failed to import Base release signing key"
+    fi
+
+    if ! gpg --batch --list-keys "$fingerprint" >/dev/null 2>&1; then
+        error "Imported key does not match Base release signing fingerprint $fingerprint"
+    fi
+}
+
+verify_gpg_signature() {
+    local archive_name="$1"
+    local archive_path="$2"
+    local signature_path="$3"
+    local expected_fingerprint
+    local actual_fingerprint
+    local status_output
+
+    if [[ "$UNSAFE_SKIP_VERIFY" -eq 1 ]]; then
+        warn "Skipping GPG signature verification for $archive_name (--unsafe-skip-verify)."
+        return
+    fi
+
+    if ! command -v gpg >/dev/null 2>&1; then
+        error "gpg not found. Install gpg, or re-run with --unsafe-skip-verify to bypass signature verification."
+    fi
+
+    ensure_gpg_key
+
+    if ! status_output="$(gpg --batch --status-fd 1 --verify "$signature_path" "$archive_path" 2>/dev/null)"; then
+        error "GPG signature verification failed for $archive_name"
+    fi
+
+    expected_fingerprint="$(normalize_fingerprint "$BASEUP_RELEASE_GPG_FINGERPRINT")"
+    if [[ -n "$expected_fingerprint" ]]; then
+        actual_fingerprint="$(printf '%s\n' "$status_output" | awk '/^\[GNUPG:\] VALIDSIG / { print $3; exit }')"
+        actual_fingerprint="$(normalize_fingerprint "$actual_fingerprint")"
+
+        if [[ "$actual_fingerprint" != "$expected_fingerprint" ]]; then
+            error "GPG signature for $archive_name was made by $actual_fingerprint, expected $expected_fingerprint"
+        fi
+    else
+        warn "BASEUP_RELEASE_GPG_FINGERPRINT is not set; accepted any locally available GPG signing key."
+    fi
+
+    info "GPG signature verified for $archive_name"
+}
+
+verify_attestation() {
+    local archive_name="$1"
+    local archive_path="$2"
+
+    if [[ "$UNSAFE_SKIP_VERIFY" -eq 1 ]]; then
+        warn "Skipping SLSA attestation verification for $archive_name (--unsafe-skip-verify)."
+        return
+    fi
+
+    if command -v gh >/dev/null 2>&1 && gh auth status >/dev/null 2>&1; then
+        info "Verifying SLSA build provenance for $archive_name..."
+        if gh attestation verify "$archive_path" --repo "$BASEUP_REPO" \
+            --predicate-type https://slsa.dev/provenance/v1 >/dev/null 2>&1; then
+            info "SLSA provenance verified for $archive_name"
+        else
+            warn "SLSA provenance attestation not found or failed verification for $archive_name."
+        fi
+    elif command -v gh >/dev/null 2>&1; then
+        warn "gh is not authenticated; skipping optional SLSA attestation verification for $archive_name."
+    else
+        info "gh not found; skipping optional SLSA attestation verification for $archive_name."
+    fi
+}
+
 validate_archive() {
     local archive_path="$1"
     local archive_listing
@@ -375,8 +468,14 @@ normalize_bin_name() {
         all)
             echo "all"
             ;;
+        base)
+            echo "base"
+            ;;
         node | reth-node | base-reth-node)
             echo "base-reth-node"
+            ;;
+        consensus | base-consensus)
+            echo "base-consensus"
             ;;
         ctl | basectl)
             echo "basectl"
@@ -389,7 +488,7 @@ normalize_bin_name() {
 
 add_selected_bin() {
     local normalized
-    normalized="$(normalize_bin_name "$1")" || error "Unknown binary '$1'. Valid values: base-reth-node, basectl, all."
+    normalized="$(normalize_bin_name "$1")" || error "Unknown binary '$1'. Valid values: base, base-reth-node, base-consensus, basectl, all."
 
     if [[ "$normalized" == "all" ]]; then
         local item
@@ -553,13 +652,16 @@ Usage: baseup [OPTIONS]
 Options:
   -v, --version         Print the baseup installer version
   -i, --install <VER>   Install a specific release tag (for example: v0.6.0)
-  -b, --bin <NAME>      Install only one binary (base-reth-node, basectl, all)
+  -b, --bin <NAME>      Install only one binary (base, base-reth-node, base-consensus, basectl, all)
   -U, --update          Update baseup itself
+      --unsafe-skip-verify
+                         Skip GPG signature and SLSA attestation verification
   -h, --help            Show this help message
 
 Examples:
   baseup
   baseup -i v0.6.0
+  baseup --bin base
   baseup --bin base-reth-node
   baseup --bin basectl
   baseup --update
@@ -585,6 +687,10 @@ while [[ $# -gt 0 ]]; do
             ;;
         -U | --update)
             update_baseup
+            ;;
+        --unsafe-skip-verify)
+            UNSAFE_SKIP_VERIFY=1
+            shift
             ;;
         -h | --help)
             usage
@@ -628,6 +734,7 @@ main() {
         local archive_name
         local archive_path
         local checksum_path
+        local signature_path
         local expected_checksum
         local actual_checksum
         local extract_dir
@@ -636,10 +743,14 @@ main() {
         archive_name="${binary_name}-${VERSION}-${target}.tar.gz"
         archive_path="$MAIN_TMP_DIR/$archive_name"
         checksum_path="${archive_path}.sha256"
+        signature_path="${archive_path}.asc"
         extract_dir="$MAIN_TMP_DIR/${binary_name}-extract"
 
         download_file "$VERSION" "$archive_name" "$MAIN_TMP_DIR"
         download_file "$VERSION" "${archive_name}.sha256" "$MAIN_TMP_DIR"
+        if [[ "$UNSAFE_SKIP_VERIFY" -eq 0 ]]; then
+            download_file "$VERSION" "${archive_name}.asc" "$MAIN_TMP_DIR"
+        fi
 
         expected_checksum="$(head -n 1 "$checksum_path" | awk '{print $1}')"
         actual_checksum="$(compute_sha256 "$archive_path")"
@@ -649,6 +760,8 @@ main() {
         fi
 
         info "Checksum verified for $archive_name"
+        verify_gpg_signature "$archive_name" "$archive_path" "$signature_path"
+        verify_attestation "$archive_name" "$archive_path"
 
         mkdir -p "$extract_dir"
         extract_archive "$archive_path" "$extract_dir"

--- a/bin/base/README.md
+++ b/bin/base/README.md
@@ -33,7 +33,7 @@ base rpc --execution-chain dev
 ## `base update`
 
 `base update` updates the installed `base` binary by running `baseup --bin base` against the same
-directory as the currently running executable. `baseup` downloads the GitHub release artifact,
+directory as the currently running executable. `baseup` downloads the `GitHub` release artifact,
 checks the archive checksum, verifies the release signature, and installs the verified binary.
 
 Supported forms:

--- a/bin/base/README.md
+++ b/bin/base/README.md
@@ -30,6 +30,20 @@ for consensus chain resolution:
 base rpc --execution-chain dev
 ```
 
+## `base update`
+
+`base update` updates the installed `base` binary by running `baseup --bin base` against the same
+directory as the currently running executable. `baseup` downloads the GitHub release artifact,
+checks the archive checksum, verifies the release signature, and installs the verified binary.
+
+Supported forms:
+
+```text
+base update
+base update --install v0.6.0
+base update --update-installer
+```
+
 ## Chain Selection
 
 Chain selection supports:

--- a/bin/base/src/cli.rs
+++ b/bin/base/src/cli.rs
@@ -52,8 +52,7 @@ impl BaseCli {
             })
             .wrap_err("failed to install Prometheus recorder")?;
 
-        let resolved_chain = ChainResolver::new(chain).resolve()?;
-        command.run(resolved_chain)
+        command.run(ChainResolver::new(chain))
     }
 }
 #[cfg(test)]

--- a/bin/base/src/commands/command.rs
+++ b/bin/base/src/commands/command.rs
@@ -3,8 +3,8 @@
 use clap::Subcommand;
 
 use crate::{
-    commands::{bootnode::BootnodeCommand, rpc::RpcCommand},
-    config::ResolvedChainConfig,
+    commands::{bootnode::BootnodeCommand, rpc::RpcCommand, update::UpdateCommand},
+    config::ChainResolver,
 };
 
 /// Top-level commands for `base`.
@@ -17,14 +17,18 @@ pub(crate) enum BaseCommand {
     /// Run the integrated node in RPC mode.
     #[command(name = "rpc")]
     Rpc(Box<RpcCommand>),
+    /// Update the base binary to the latest release.
+    #[command(name = "update")]
+    Update(Box<UpdateCommand>),
 }
 
 impl BaseCommand {
     /// Runs the selected top-level command.
-    pub(crate) fn run(self, resolved_chain: ResolvedChainConfig) -> eyre::Result<()> {
+    pub(crate) fn run(self, chain_resolver: ChainResolver) -> eyre::Result<()> {
         match self {
-            Self::Bootnode(bootnode) => (*bootnode).run(resolved_chain),
-            Self::Rpc(rpc) => (*rpc).run(resolved_chain),
+            Self::Bootnode(bootnode) => (*bootnode).run(chain_resolver.resolve()?),
+            Self::Rpc(rpc) => (*rpc).run(chain_resolver.resolve()?),
+            Self::Update(update) => (*update).run(),
         }
     }
 }

--- a/bin/base/src/commands/mod.rs
+++ b/bin/base/src/commands/mod.rs
@@ -4,3 +4,4 @@ mod bootnode;
 mod command;
 pub(crate) use command::BaseCommand;
 mod rpc;
+mod update;

--- a/bin/base/src/commands/update.rs
+++ b/bin/base/src/commands/update.rs
@@ -1,0 +1,113 @@
+//! Base binary update command.
+
+use std::{ffi::OsString, path::Path, process::Command};
+
+use clap::Args;
+use eyre::{OptionExt, WrapErr};
+
+/// Arguments for `base update`.
+#[derive(Args, Clone, Debug)]
+pub(crate) struct UpdateCommand {
+    /// Install a specific release tag instead of the latest release.
+    #[arg(short = 'i', long = "install", value_name = "VER")]
+    pub(crate) version: Option<String>,
+
+    /// Update the baseup installer instead of the base binary.
+    #[arg(long, conflicts_with = "version")]
+    pub(crate) update_installer: bool,
+
+    /// Skip release signature and attestation verification.
+    #[arg(long)]
+    pub(crate) unsafe_skip_verify: bool,
+}
+
+impl UpdateCommand {
+    /// Updates the `base` binary by delegating release fetch and verification to `baseup`.
+    pub(crate) fn run(self) -> eyre::Result<()> {
+        let bin_dir = std::env::current_exe()
+            .wrap_err("failed to locate current base executable")?
+            .parent()
+            .map(Path::to_path_buf)
+            .ok_or_eyre("failed to locate current base executable directory")?;
+
+        let mut command = Command::new(Self::baseup_path(&bin_dir));
+        command.env("BASE_BIN_DIR", &bin_dir);
+
+        if self.update_installer {
+            command.arg("--update");
+        } else {
+            command.args(["--bin", "base"]);
+            if let Some(version) = self.version {
+                command.arg("--install").arg(version);
+            }
+        }
+
+        if self.unsafe_skip_verify {
+            command.arg("--unsafe-skip-verify");
+        }
+
+        let status = command
+            .status()
+            .wrap_err("failed to execute baseup; install it with the baseup bootstrap first")?;
+
+        if !status.success() {
+            eyre::bail!("baseup exited with status {status}");
+        }
+
+        Ok(())
+    }
+
+    fn baseup_path(bin_dir: &Path) -> OsString {
+        let sibling = bin_dir.join("baseup");
+        if sibling.is_file() { sibling.into_os_string() } else { OsString::from("baseup") }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use clap::Parser;
+
+    use crate::{cli::BaseCli, commands::BaseCommand};
+
+    #[test]
+    fn parses_update_command() {
+        let cli = BaseCli::parse_from(["base", "update"]);
+
+        assert!(matches!(cli.command, BaseCommand::Update(_)));
+    }
+
+    #[test]
+    fn parses_update_command_with_version() {
+        let cli = BaseCli::parse_from(["base", "update", "--install", "v0.6.0"]);
+        let BaseCommand::Update(update) = cli.command else {
+            panic!("expected update command");
+        };
+
+        assert_eq!(update.version.as_deref(), Some("v0.6.0"));
+    }
+
+    #[test]
+    fn parses_update_installer_command() {
+        let cli = BaseCli::parse_from(["base", "update", "--update-installer"]);
+        let BaseCommand::Update(update) = cli.command else {
+            panic!("expected update command");
+        };
+
+        assert!(update.update_installer);
+    }
+
+    #[test]
+    fn rejects_update_installer_with_version() {
+        let err = BaseCli::try_parse_from([
+            "base",
+            "update",
+            "--update-installer",
+            "--install",
+            "v0.6.0",
+        ])
+        .unwrap_err();
+
+        let rendered = err.to_string();
+        assert!(rendered.contains("cannot be used with"));
+    }
+}


### PR DESCRIPTION
## Summary

This adds a `base update` subcommand that delegates verified binary updates to `baseup` in the same install directory as the running executable. It also updates `baseup` to install the unified `base` binary, verify signed release archives, and optionally check GitHub SLSA provenance. The release workflow now publishes the `base` artifact with checksums, GPG signatures, and attestations so the command has a signed artifact to install.