### PR TITLE
refactor(batcher): Share Subscription Wrappers

### DIFF
--- a/crates/batcher/service/src/l1_source.rs
+++ b/crates/batcher/service/src/l1_source.rs
@@ -4,8 +4,7 @@ use std::sync::Arc;
 
 use alloy_provider::Provider;
 use async_trait::async_trait;
-use base_batcher_source::{L1HeadPolling, L1HeadSubscription, SourceError};
-use futures::{StreamExt, stream::BoxStream};
+use base_batcher_source::{KeepAliveSubscription, L1HeadPolling, PendingSubscription, SourceError};
 
 /// Polling source that fetches the latest L1 head block number from an L1 RPC endpoint.
 #[derive(derive_more::Debug)]
@@ -28,49 +27,18 @@ impl L1HeadPolling for RpcL1HeadPollingSource {
     }
 }
 
-/// An [`L1HeadSubscription`] backed by a WebSocket provider.
+/// A WebSocket-backed L1 head subscription.
 ///
-/// Owns the WS provider via a type-erased [`Arc`] so the underlying connection
-/// is not dropped when the stream is handed to [`HybridL1HeadSource`]. The stream
-/// is produced once at construction; [`take_stream`] moves it out on the first call.
+/// Owns the WS provider so the underlying connection is not dropped when the
+/// stream is handed to [`HybridL1HeadSource`].
 ///
 /// [`HybridL1HeadSource`]: base_batcher_source::HybridL1HeadSource
-/// [`take_stream`]: L1HeadSubscription::take_stream
-#[derive(derive_more::Debug)]
-pub struct WsL1HeadSubscription {
-    #[debug(skip)]
-    _provider: Arc<dyn std::any::Any + Send + Sync>,
-    #[debug("{:?}", stream.as_ref().map(|_| "<stream>"))]
-    stream: Option<BoxStream<'static, Result<u64, SourceError>>>,
-}
+pub type WsL1HeadSubscription = KeepAliveSubscription<u64>;
 
-impl WsL1HeadSubscription {
-    /// Create a new [`WsL1HeadSubscription`] from a provider and its head number stream.
-    pub fn new<P: std::any::Any + Send + Sync + 'static>(
-        provider: Arc<P>,
-        stream: BoxStream<'static, Result<u64, SourceError>>,
-    ) -> Self {
-        Self { _provider: provider, stream: Some(stream) }
-    }
-}
-
-impl L1HeadSubscription for WsL1HeadSubscription {
-    fn take_stream(&mut self) -> BoxStream<'static, Result<u64, SourceError>> {
-        self.stream.take().expect("take_stream called more than once")
-    }
-}
-
-/// A no-op [`L1HeadSubscription`] that never yields head numbers.
+/// A no-op L1 head subscription that never yields head numbers.
 ///
 /// Used when no L1 WebSocket URL is configured; [`HybridL1HeadSource`] falls
 /// back entirely to the polling path.
 ///
 /// [`HybridL1HeadSource`]: base_batcher_source::HybridL1HeadSource
-#[derive(Debug)]
-pub struct NullL1HeadSubscription;
-
-impl L1HeadSubscription for NullL1HeadSubscription {
-    fn take_stream(&mut self) -> BoxStream<'static, Result<u64, SourceError>> {
-        futures::stream::pending().boxed()
-    }
-}
+pub type NullL1HeadSubscription = PendingSubscription<u64>;

--- a/crates/batcher/service/src/service.rs
+++ b/crates/batcher/service/src/service.rs
@@ -167,14 +167,14 @@ impl BatcherService {
         fetch_provider: Arc<dyn Provider<Base> + Send + Sync>,
     ) -> Subscription {
         let Some(url) = url else {
-            return Subscription::Null(NullSubscription);
+            return Subscription::Null(NullSubscription::new());
         };
 
         let ws_provider = match ProviderBuilder::new().connect(url.as_str()).await {
             Ok(p) => Arc::new(p),
             Err(e) => {
                 warn!(error = %e, l2_rpc = %url, "failed to connect L2 WS provider; falling back to polling");
-                return Subscription::Null(NullSubscription);
+                return Subscription::Null(NullSubscription::new());
             }
         };
 
@@ -182,7 +182,7 @@ impl BatcherService {
             Ok(s) => s,
             Err(e) => {
                 warn!(error = %e, "failed to subscribe to new L2 blocks; falling back to polling");
-                return Subscription::Null(NullSubscription);
+                return Subscription::Null(NullSubscription::new());
             }
         };
 
@@ -222,14 +222,14 @@ impl BatcherService {
     /// [`HybridL1HeadSource`]: base_batcher_source::HybridL1HeadSource
     async fn build_l1_subscription(url: Option<&Url>) -> L1Subscription {
         let Some(url) = url else {
-            return L1Subscription::Null(NullL1HeadSubscription);
+            return L1Subscription::Null(NullL1HeadSubscription::new());
         };
 
         let ws_provider = match ProviderBuilder::new().connect(url.as_str()).await {
             Ok(p) => Arc::new(p),
             Err(e) => {
                 warn!(error = %e, l1_ws = %url, "failed to connect L1 WS provider; falling back to polling");
-                return L1Subscription::Null(NullL1HeadSubscription);
+                return L1Subscription::Null(NullL1HeadSubscription::new());
             }
         };
 
@@ -237,7 +237,7 @@ impl BatcherService {
             Ok(s) => s,
             Err(e) => {
                 warn!(error = %e, "failed to subscribe to new L1 blocks; falling back to polling");
-                return L1Subscription::Null(NullL1HeadSubscription);
+                return L1Subscription::Null(NullL1HeadSubscription::new());
             }
         };
 

--- a/crates/batcher/service/src/subscription.rs
+++ b/crates/batcher/service/src/subscription.rs
@@ -1,61 +1,20 @@
 //! Block subscription implementations for the batcher service.
 
-use std::sync::Arc;
-
-use base_batcher_source::{BlockSubscription, SourceError};
+use base_batcher_source::{KeepAliveSubscription, PendingSubscription};
 use base_common_consensus::BaseBlock;
-use futures::{StreamExt, stream::BoxStream};
 
-/// A [`BlockSubscription`] backed by a WebSocket provider.
+/// A WebSocket-backed block subscription.
 ///
-/// Owns the WS provider via a type-erased [`Arc`] so the underlying connection
-/// is not dropped when the stream is handed to [`HybridBlockSource`]. The stream
-/// is produced once at construction; [`take_stream`] moves it out on the first call.
-///
-/// The provider is stored as `Arc<dyn Any + Send + Sync>` because the exact
-/// alloy provider type varies by transport and we only need to hold a reference
-/// for keepalive purposes, not to call any methods on it.
+/// Owns the WS provider so the underlying connection is not dropped when the
+/// stream is handed to [`HybridBlockSource`].
 ///
 /// [`HybridBlockSource`]: base_batcher_source::HybridBlockSource
-/// [`take_stream`]: BlockSubscription::take_stream
-#[derive(derive_more::Debug)]
-pub struct WsBlockSubscription {
-    #[debug(skip)]
-    _provider: Arc<dyn std::any::Any + Send + Sync>,
-    #[debug("{:?}", stream.as_ref().map(|_| "<stream>"))]
-    stream: Option<BoxStream<'static, Result<BaseBlock, SourceError>>>,
-}
+pub type WsBlockSubscription = KeepAliveSubscription<BaseBlock>;
 
-impl WsBlockSubscription {
-    /// Create a new [`WsBlockSubscription`] from a provider and its subscription stream.
-    ///
-    /// `provider` can be any `Send + Sync + 'static` type — typically the alloy
-    /// WS root provider returned by [`ProviderBuilder::connect`].
-    pub fn new<P: std::any::Any + Send + Sync + 'static>(
-        provider: Arc<P>,
-        stream: BoxStream<'static, Result<BaseBlock, SourceError>>,
-    ) -> Self {
-        Self { _provider: provider, stream: Some(stream) }
-    }
-}
-
-impl BlockSubscription for WsBlockSubscription {
-    fn take_stream(&mut self) -> BoxStream<'static, Result<BaseBlock, SourceError>> {
-        self.stream.take().expect("take_stream called more than once")
-    }
-}
-
-/// A no-op [`BlockSubscription`] that never yields blocks.
+/// A no-op block subscription that never yields blocks.
 ///
 /// Used when the L2 RPC is not a WebSocket URL and subscription is unavailable;
 /// [`HybridBlockSource`] will rely entirely on the polling path.
 ///
 /// [`HybridBlockSource`]: base_batcher_source::HybridBlockSource
-#[derive(Debug)]
-pub struct NullSubscription;
-
-impl BlockSubscription for NullSubscription {
-    fn take_stream(&mut self) -> BoxStream<'static, Result<BaseBlock, SourceError>> {
-        futures::stream::pending().boxed()
-    }
-}
+pub type NullSubscription = PendingSubscription<BaseBlock>;

--- a/crates/batcher/source/src/l1_subscription.rs
+++ b/crates/batcher/source/src/l1_subscription.rs
@@ -2,7 +2,7 @@
 
 use futures::stream::BoxStream;
 
-use crate::SourceError;
+use crate::{KeepAliveSubscription, PendingSubscription, SourceError, StreamSubscription};
 
 /// A source of an L1 head number stream that may hold ancillary resources.
 ///
@@ -19,4 +19,22 @@ pub trait L1HeadSubscription: Send {
     ///
     /// Must be called at most once; implementors may panic on a second call.
     fn take_stream(&mut self) -> BoxStream<'static, Result<u64, SourceError>>;
+}
+
+impl L1HeadSubscription for StreamSubscription<u64> {
+    fn take_stream(&mut self) -> BoxStream<'static, Result<u64, SourceError>> {
+        StreamSubscription::take_stream(self)
+    }
+}
+
+impl L1HeadSubscription for KeepAliveSubscription<u64> {
+    fn take_stream(&mut self) -> BoxStream<'static, Result<u64, SourceError>> {
+        KeepAliveSubscription::take_stream(self)
+    }
+}
+
+impl L1HeadSubscription for PendingSubscription<u64> {
+    fn take_stream(&mut self) -> BoxStream<'static, Result<u64, SourceError>> {
+        PendingSubscription::take_stream(self)
+    }
 }

--- a/crates/batcher/source/src/l1_subscription.rs
+++ b/crates/batcher/source/src/l1_subscription.rs
@@ -23,18 +23,18 @@ pub trait L1HeadSubscription: Send {
 
 impl L1HeadSubscription for StreamSubscription<u64> {
     fn take_stream(&mut self) -> BoxStream<'static, Result<u64, SourceError>> {
-        StreamSubscription::take_stream(self)
+        Self::take_stream(self)
     }
 }
 
 impl L1HeadSubscription for KeepAliveSubscription<u64> {
     fn take_stream(&mut self) -> BoxStream<'static, Result<u64, SourceError>> {
-        KeepAliveSubscription::take_stream(self)
+        Self::take_stream(self)
     }
 }
 
 impl L1HeadSubscription for PendingSubscription<u64> {
     fn take_stream(&mut self) -> BoxStream<'static, Result<u64, SourceError>> {
-        PendingSubscription::take_stream(self)
+        Self::take_stream(self)
     }
 }

--- a/crates/batcher/source/src/lib.rs
+++ b/crates/batcher/source/src/lib.rs
@@ -22,6 +22,9 @@ pub use polling::PollingSource;
 mod subscription;
 pub use subscription::BlockSubscription;
 
+mod stream_subscription;
+pub use stream_subscription::{KeepAliveSubscription, PendingSubscription, StreamSubscription};
+
 mod hybrid;
 pub use hybrid::HybridBlockSource;
 

--- a/crates/batcher/source/src/stream_subscription.rs
+++ b/crates/batcher/source/src/stream_subscription.rs
@@ -1,0 +1,89 @@
+//! Generic stream subscription wrappers.
+
+use std::{any::Any, sync::Arc};
+
+use futures::{StreamExt, stream::BoxStream};
+
+use crate::SourceError;
+
+/// A subscription backed directly by a stream.
+#[derive(derive_more::Debug)]
+pub struct StreamSubscription<T> {
+    #[debug("{:?}", stream.as_ref().map(|_| "<stream>"))]
+    stream: Option<BoxStream<'static, Result<T, SourceError>>>,
+}
+
+impl<T> StreamSubscription<T> {
+    /// Creates a subscription from a stream.
+    pub fn new(stream: BoxStream<'static, Result<T, SourceError>>) -> Self {
+        Self { stream: Some(stream) }
+    }
+
+    /// Extracts the underlying stream.
+    ///
+    /// # Panics
+    ///
+    /// Panics if called more than once.
+    pub fn take_stream(&mut self) -> BoxStream<'static, Result<T, SourceError>> {
+        self.stream.take().expect("take_stream called more than once")
+    }
+}
+
+/// A [`StreamSubscription`] that keeps an ancillary resource alive.
+///
+/// This is used for WebSocket subscriptions where the provider connection must
+/// outlive the stream handed to a hybrid source.
+#[derive(derive_more::Debug)]
+pub struct KeepAliveSubscription<T> {
+    #[debug(skip)]
+    _resource: Arc<dyn Any + Send + Sync>,
+    inner: StreamSubscription<T>,
+}
+
+impl<T> KeepAliveSubscription<T> {
+    /// Creates a subscription from a resource and stream.
+    pub fn new<P: Any + Send + Sync + 'static>(
+        resource: Arc<P>,
+        stream: BoxStream<'static, Result<T, SourceError>>,
+    ) -> Self {
+        Self { _resource: resource, inner: StreamSubscription::new(stream) }
+    }
+
+    /// Extracts the underlying stream.
+    ///
+    /// # Panics
+    ///
+    /// Panics if called more than once.
+    pub fn take_stream(&mut self) -> BoxStream<'static, Result<T, SourceError>> {
+        self.inner.take_stream()
+    }
+}
+
+/// A subscription that never yields items.
+#[derive(Debug)]
+pub struct PendingSubscription<T> {
+    _marker: std::marker::PhantomData<T>,
+}
+
+impl<T> PendingSubscription<T> {
+    /// Creates a pending subscription.
+    pub const fn new() -> Self {
+        Self { _marker: std::marker::PhantomData }
+    }
+}
+
+impl<T> PendingSubscription<T>
+where
+    T: Send + 'static,
+{
+    /// Returns a stream that never yields.
+    pub fn take_stream(&mut self) -> BoxStream<'static, Result<T, SourceError>> {
+        futures::stream::pending().boxed()
+    }
+}
+
+impl<T> Default for PendingSubscription<T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/batcher/source/src/subscription.rs
+++ b/crates/batcher/source/src/subscription.rs
@@ -3,7 +3,7 @@
 use base_common_consensus::BaseBlock;
 use futures::stream::BoxStream;
 
-use crate::SourceError;
+use crate::{KeepAliveSubscription, PendingSubscription, SourceError, StreamSubscription};
 
 /// A source of an unsafe-block stream that may hold ancillary resources.
 ///
@@ -20,4 +20,22 @@ pub trait BlockSubscription: Send {
     ///
     /// Must be called at most once; implementors may panic on a second call.
     fn take_stream(&mut self) -> BoxStream<'static, Result<BaseBlock, SourceError>>;
+}
+
+impl BlockSubscription for StreamSubscription<BaseBlock> {
+    fn take_stream(&mut self) -> BoxStream<'static, Result<BaseBlock, SourceError>> {
+        StreamSubscription::take_stream(self)
+    }
+}
+
+impl BlockSubscription for KeepAliveSubscription<BaseBlock> {
+    fn take_stream(&mut self) -> BoxStream<'static, Result<BaseBlock, SourceError>> {
+        KeepAliveSubscription::take_stream(self)
+    }
+}
+
+impl BlockSubscription for PendingSubscription<BaseBlock> {
+    fn take_stream(&mut self) -> BoxStream<'static, Result<BaseBlock, SourceError>> {
+        PendingSubscription::take_stream(self)
+    }
 }

--- a/crates/batcher/source/src/subscription.rs
+++ b/crates/batcher/source/src/subscription.rs
@@ -24,18 +24,18 @@ pub trait BlockSubscription: Send {
 
 impl BlockSubscription for StreamSubscription<BaseBlock> {
     fn take_stream(&mut self) -> BoxStream<'static, Result<BaseBlock, SourceError>> {
-        StreamSubscription::take_stream(self)
+        Self::take_stream(self)
     }
 }
 
 impl BlockSubscription for KeepAliveSubscription<BaseBlock> {
     fn take_stream(&mut self) -> BoxStream<'static, Result<BaseBlock, SourceError>> {
-        KeepAliveSubscription::take_stream(self)
+        Self::take_stream(self)
     }
 }
 
 impl BlockSubscription for PendingSubscription<BaseBlock> {
     fn take_stream(&mut self) -> BoxStream<'static, Result<BaseBlock, SourceError>> {
-        PendingSubscription::take_stream(self)
+        Self::take_stream(self)
     }
 }


### PR DESCRIPTION
## Summary

This refactors batcher subscription wrappers to share generic stream, keepalive, and pending subscription implementations. The L2 block and L1 head subscription APIs remain unchanged while the duplicated WebSocket and no-op wrapper mechanics move into base-batcher-source.