### PR TITLE
chore(follow): reduce max ahead proofs default

### DIFF
--- a/crates/consensus/cli/src/follow.rs
+++ b/crates/consensus/cli/src/follow.rs
@@ -114,8 +114,9 @@ pub struct ConsensusFollowNodeConfigArgs {
     /// `ExEx` head. Only effective when `--proofs` is enabled.
     #[arg(
         long = "proofs.max-blocks-ahead",
-        default_value_t = 512,
-        env = "BASE_NODE_PROOFS_MAX_BLOCKS_AHEAD"
+        default_value_t = 8,
+        env = "BASE_NODE_PROOFS_MAX_BLOCKS_AHEAD",
+        value_parser = clap::value_parser!(u64).range(1..32),
     )]
     pub proofs_max_blocks_ahead: u64,
 

--- a/crates/consensus/service/src/actors/derivation/delegate_l2/actor.rs
+++ b/crates/consensus/service/src/actors/derivation/delegate_l2/actor.rs
@@ -18,7 +18,7 @@ use crate::{
     actors::derivation::{DerivationError, delegate_l2::L2SourceClient},
 };
 
-const DEFAULT_PROOFS_MAX_BLOCKS_AHEAD: u64 = 512;
+const DEFAULT_PROOFS_MAX_BLOCKS_AHEAD: u64 = 8;
 
 #[derive(Debug, Deserialize)]
 struct ProofsSyncStatus {

--- a/crates/consensus/service/src/service/follow.rs
+++ b/crates/consensus/service/src/service/follow.rs
@@ -57,7 +57,7 @@ impl FollowNode {
             rpc_builder,
             l1_config,
             proofs_enabled: false,
-            proofs_max_blocks_ahead: 512,
+            proofs_max_blocks_ahead: 8,
         }
     }
 


### PR DESCRIPTION
### Description
Reduce max ahead proofs default. With the migration to rocks db proof insertion is now quick, there's no real reason to allow the node to get 512 blocks (~20m ahead).

Allowing the node to be 512 blocks ahead also has issues if there's a failure, for example it takes ~1m to load/calc/insert a ~20m old block.