### PR TITLE
docs(contributing): update Getting Help link to docs root

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -114,4 +114,4 @@ If you have questions:
 
 - Open a discussion in the repository
 - Comment on the relevant issue
-- Check existing [documentation](https://docs.base.org/base-chain/quickstart/why-base) and issues first
+- Check existing [documentation](https://docs.base.org) and issues first


### PR DESCRIPTION
Fixes #2746

Updates the Getting Help documentation link from the "Why Base?" marketing page to the docs root, which is more useful for contributors seeking technical help.