### PR TITLE
chore(deny): remove duplicate Windows crate entries in skip list

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -104,12 +104,6 @@ skip = [
     "socket2",
     "bitflags",
     "redox_users",
-    "windows",
-    "windows-core",
-    "windows-implement",
-    "windows-link",
-    "windows-result",
-    "windows-strings",
 
     # Network crates
     "tungstenite",


### PR DESCRIPTION
Fixes #2747

Removes 7 duplicate Windows crate entries from the `[bans]` skip list in `deny.toml`. These crates were listed under both `# Windows platform crates` and `# System/platform crates` sections.