### PR TITLE
feat(precompiles): TokenFactory precompile + B-20 address routing

### DIFF
--- a/crates/common/precompiles/Cargo.toml
+++ b/crates/common/precompiles/Cargo.toml
@@ -47,3 +47,6 @@ optional_fee_charge = [ "revm/optional_fee_charge" ]
 optional_balance_check = [ "revm/optional_balance_check" ]
 optional_block_gas_limit = [ "revm/optional_block_gas_limit" ]
 test-utils = [ "base-precompile-storage/test-utils" ]
+
+[dev-dependencies]
+base-precompile-storage = { workspace = true, features = ["test-utils"] }

--- a/crates/common/precompiles/src/installer.rs
+++ b/crates/common/precompiles/src/installer.rs
@@ -42,6 +42,7 @@ impl<S: BasePrecompileSpec> BasePrecompileInstaller<S> {
 // required by `set_precompile_lookup`.
 fn b20_lookup(address: &Address) -> Option<DynPrecompile> {
     if crate::token::has_b20_prefix(address) {
+        // TODO: Check if the token has byte code deployed at the address
         Some(crate::token::DefaultTokenEvm::create_precompile(*address))
     } else if *address == crate::token::FACTORY_ADDRESS {
         Some(crate::token::TokenFactoryEvm::precompile())

--- a/crates/common/precompiles/src/installer.rs
+++ b/crates/common/precompiles/src/installer.rs
@@ -1,4 +1,5 @@
-use alloy_evm::precompiles::PrecompilesMap;
+use alloy_evm::precompiles::{DynPrecompile, PrecompilesMap};
+use alloy_primitives::Address;
 use base_common_chains::BaseUpgrade;
 
 use crate::{BasePrecompileSpec, BasePrecompiles};
@@ -32,10 +33,20 @@ impl<S: BasePrecompileSpec> BasePrecompileInstaller<S> {
     /// Installs Base-specific dynamic precompiles into an existing [`PrecompilesMap`].
     pub fn install_into(self, precompiles: &mut PrecompilesMap) {
         if self.spec.upgrade() >= BaseUpgrade::Beryl {
-            precompiles.apply_precompile(&crate::token::DEFAULT_TOKEN_ADDRESS, |_| {
-                Some(crate::token::DefaultTokenEvm::precompile())
-            });
+            precompiles.set_precompile_lookup(b20_lookup);
         }
+    }
+}
+
+// Function pointer (not a closure) satisfies the HRTB `for<'a> Fn(&'a Address) -> Option<DynPrecompile>`
+// required by `set_precompile_lookup`.
+fn b20_lookup(address: &Address) -> Option<DynPrecompile> {
+    if crate::token::has_b20_prefix(address) {
+        Some(crate::token::DefaultTokenEvm::create_precompile(*address))
+    } else if *address == crate::token::FACTORY_ADDRESS {
+        Some(crate::token::TokenFactoryEvm::precompile())
+    } else {
+        None
     }
 }
 

--- a/crates/common/precompiles/src/installer.rs
+++ b/crates/common/precompiles/src/installer.rs
@@ -41,7 +41,7 @@ impl<S: BasePrecompileSpec> BasePrecompileInstaller<S> {
 // Function pointer (not a closure) satisfies the HRTB `for<'a> Fn(&'a Address) -> Option<DynPrecompile>`
 // required by `set_precompile_lookup`.
 fn b20_lookup(address: &Address) -> Option<DynPrecompile> {
-    if crate::token::TokenFactory::is_b20(address)
+    if crate::token::has_b20_prefix(address) {
         // TODO: Check if the token has byte code deployed at the address
         Some(crate::token::DefaultTokenEvm::create_precompile(*address))
     } else if *address == crate::token::FACTORY_ADDRESS {

--- a/crates/common/precompiles/src/installer.rs
+++ b/crates/common/precompiles/src/installer.rs
@@ -41,7 +41,7 @@ impl<S: BasePrecompileSpec> BasePrecompileInstaller<S> {
 // Function pointer (not a closure) satisfies the HRTB `for<'a> Fn(&'a Address) -> Option<DynPrecompile>`
 // required by `set_precompile_lookup`.
 fn b20_lookup(address: &Address) -> Option<DynPrecompile> {
-    if crate::token::has_b20_prefix(address) {
+    if crate::token::TokenFactory::is_b20(address)
         // TODO: Check if the token has byte code deployed at the address
         Some(crate::token::DefaultTokenEvm::create_precompile(*address))
     } else if *address == crate::token::FACTORY_ADDRESS {

--- a/crates/common/precompiles/src/lib.rs
+++ b/crates/common/precompiles/src/lib.rs
@@ -20,7 +20,11 @@ mod bls12_381;
 
 mod token;
 pub use token::{
-    Burnable, CAPABILITY_CAP_MUTABLE, CAPABILITY_PAUSABLE, Configurable, DEFAULT_TOKEN_ADDRESS,
-    DefaultToken, DefaultTokenEvm, DefaultTokenStorage, IDefaultToken, Mintable, Pausable,
-    Permittable, Redeemable, Token, TokenAccounting, Transferable,
+    Burnable, CAPABILITY_CAP_MUTABLE, CAPABILITY_PAUSABLE, Configurable, DEFAULT_PREFIX,
+    DEFAULT_TOKEN_ADDRESS, DefaultToken, DefaultTokenEvm, DefaultTokenStorage, FACTORY_ADDRESS,
+    IDefaultToken, ITokenFactory, Mintable, Pausable, Permittable, RESERVED_SIZE, Redeemable,
+    SECURITY_PREFIX, STABLECOIN_PREFIX, Token, TokenAccounting, TokenFactory, TokenFactoryEvm,
+    Transferable, VARIANT_DEFAULT, VARIANT_NONE, VARIANT_SECURITY, VARIANT_STABLECOIN,
+    compute_default_address, compute_security_address, compute_stablecoin_address, has_b20_prefix,
+    variant_of,
 };

--- a/crates/common/precompiles/src/token/abi/factory.rs
+++ b/crates/common/precompiles/src/token/abi/factory.rs
@@ -1,0 +1,74 @@
+//! ABI definition for the `ITokenFactory` interface.
+
+use alloy_sol_types::sol;
+
+sol! {
+    #[derive(Debug, PartialEq, Eq)]
+    interface ITokenFactory {
+        // ── Structs ─────────────────────────────────────────────────────────
+
+        struct CreateDefaultTokenParams {
+            string name;
+            string symbol;
+            uint8 decimals;
+            address admin;
+            uint256 capabilities;
+            uint256 initialSupply;
+            address initialSupplyRecipient;
+            uint64 transferPolicyId;
+            uint256 supplyCap;
+            uint256 minimumRedeemable;
+            string contractURI;
+            bytes32 salt;
+        }
+
+        // ── Errors ───────────────────────────────────────────────────────────
+
+        /// A token is already deployed at the address derived from `(variant, caller, salt)`.
+        error TokenAlreadyExists(address token);
+
+        /// The derived address falls in the reserved range (lower 8 bytes < 1024).
+        error AddressReserved(address token);
+
+        /// `supplyCap` is below `initialSupply`.
+        error InvalidSupplyCap();
+
+        /// A required address argument was `address(0)`.
+        error ZeroAddress();
+
+        // ── Events ───────────────────────────────────────────────────────────
+
+        event DefaultTokenCreated(
+            address indexed token,
+            address indexed creator,
+            address indexed admin,
+            string name,
+            string symbol,
+            uint8 decimals,
+            uint256 capabilities,
+            uint256 initialSupply,
+            bytes32 salt
+        );
+
+        // ── Functions ────────────────────────────────────────────────────────
+
+        /// Creates a Default-variant token at a deterministic address.
+        function createDefault(CreateDefaultTokenParams calldata params) external returns (address token);
+
+        /// Returns the address a `createDefault` call would produce for `(creator, salt)`.
+        function predictDefaultAddress(address creator, bytes32 salt) external view returns (address);
+
+        /// Returns the address a `createStablecoin` call would produce for `(creator, salt)`.
+        function predictStablecoinAddress(address creator, bytes32 salt) external view returns (address);
+
+        /// Returns the address a `createSecurity` call would produce for `(creator, salt)`.
+        function predictSecurityAddress(address creator, bytes32 salt) external view returns (address);
+
+        /// Returns `true` if `token` is a deployed B-20 token (correct prefix + code at address).
+        function isB20(address token) external view returns (bool);
+
+        /// Returns the variant of `token` (0=NONE, 1=DEFAULT, 2=STABLECOIN, 3=SECURITY).
+        /// Decoded from the address prefix with no storage read.
+        function variantOf(address token) external view returns (uint8);
+    }
+}

--- a/crates/common/precompiles/src/token/abi/mod.rs
+++ b/crates/common/precompiles/src/token/abi/mod.rs
@@ -2,3 +2,6 @@
 
 mod default_token;
 pub use default_token::IDefaultToken;
+
+mod factory;
+pub use factory::ITokenFactory;

--- a/crates/common/precompiles/src/token/default_token/dispatch.rs
+++ b/crates/common/precompiles/src/token/default_token/dispatch.rs
@@ -24,6 +24,9 @@ impl<S: TokenAccounting> DefaultToken<S> {
         ctx: StorageCtx<'_>,
         calldata: &[u8],
     ) -> base_precompile_storage::Result<Bytes> {
+        // TODO: Reject calls to uninitialized tokens (empty code hash), mirroring the check
+        // in tempo's TIP-20 dispatch. A token with no bytecode should return an error rather
+        // than silently operating on zeroed-out storage.
         if calldata.len() < 4 {
             return Err(BasePrecompileError::UnknownFunctionSelector([0u8; 4]));
         }

--- a/crates/common/precompiles/src/token/default_token/evm.rs
+++ b/crates/common/precompiles/src/token/default_token/evm.rs
@@ -1,11 +1,11 @@
 //! EVM wiring for the `DefaultToken` precompile.
 
 use alloy_evm::precompiles::{DynPrecompile, PrecompileInput};
-use alloy_primitives::Bytes;
+use alloy_primitives::{Address, Bytes};
 use base_precompile_storage::{EvmPrecompileStorageProvider, StorageCtx};
 use revm::precompile::{PrecompileId, PrecompileOutput, PrecompileResult};
 
-use super::DefaultToken;
+use super::{DefaultToken, storage::DefaultTokenStorage};
 
 /// EVM entry point for the `DefaultToken` precompile.
 ///
@@ -15,17 +15,25 @@ use super::DefaultToken;
 pub struct DefaultTokenEvm;
 
 impl DefaultTokenEvm {
-    /// Returns a [`DynPrecompile`] that routes calldata through [`DefaultToken`].
-    pub fn precompile() -> DynPrecompile {
-        DynPrecompile::new_stateful(PrecompileId::Custom("DefaultToken".into()), Self::run)
+    /// Returns a [`DynPrecompile`] that dispatches to the [`DefaultToken`] logic at `token_address`.
+    ///
+    /// Used by the precompile-lookup fallback to route calls to any B-20 token address.
+    pub fn create_precompile(token_address: Address) -> DynPrecompile {
+        DynPrecompile::new_stateful(
+            PrecompileId::Custom(alloc::format!("DefaultToken@{token_address}").into()),
+            move |input| Self::run_at(input, token_address),
+        )
     }
 
-    fn run(input: PrecompileInput<'_>) -> PrecompileResult {
+    fn run_at(input: PrecompileInput<'_>, token_address: Address) -> PrecompileResult {
         if !input.is_direct_call() {
             return Ok(PrecompileOutput::new_reverted(0, Bytes::new()));
         }
         let calldata: Bytes = input.data.to_vec().into();
         let mut provider = EvmPrecompileStorageProvider::new(input);
-        StorageCtx::enter(&mut provider, |ctx| DefaultToken::new(ctx).dispatch(ctx, &calldata))
+        StorageCtx::enter(&mut provider, |ctx| {
+            DefaultToken::with_storage(DefaultTokenStorage::from_address(token_address, ctx))
+                .dispatch(ctx, &calldata)
+        })
     }
 }

--- a/crates/common/precompiles/src/token/default_token/storage.rs
+++ b/crates/common/precompiles/src/token/default_token/storage.rs
@@ -25,6 +25,15 @@ pub struct DefaultTokenStorage {
     pub capabilities: U256,                                   // slot 11
 }
 
+impl<'a> DefaultTokenStorage<'a> {
+    /// Creates a `DefaultTokenStorage` instance targeting `addr`.
+    ///
+    /// Used by the factory to initialize token storage at a dynamically computed address.
+    pub fn from_address(addr: Address, storage: base_precompile_storage::StorageCtx<'a>) -> Self {
+        Self::__new(addr, storage)
+    }
+}
+
 impl TokenAccounting for DefaultTokenStorage<'_> {
     fn balance_of(&self, account: Address) -> Result<U256> {
         self.balances.at(&account).read()

--- a/crates/common/precompiles/src/token/default_token/storage.rs
+++ b/crates/common/precompiles/src/token/default_token/storage.rs
@@ -2,7 +2,7 @@ use alloc::string::String;
 
 use alloy_primitives::{Address, LogData, U256, address};
 use base_precompile_macros::contract;
-use base_precompile_storage::{BasePrecompileError, Handler, Mapping, Result, StorageCtx};
+use base_precompile_storage::{BasePrecompileError, Handler, Mapping, Result};
 
 use crate::token::common::TokenAccounting;
 

--- a/crates/common/precompiles/src/token/default_token/storage.rs
+++ b/crates/common/precompiles/src/token/default_token/storage.rs
@@ -2,7 +2,7 @@ use alloc::string::String;
 
 use alloy_primitives::{Address, LogData, U256, address};
 use base_precompile_macros::contract;
-use base_precompile_storage::{BasePrecompileError, Handler, Mapping, Result};
+use base_precompile_storage::{BasePrecompileError, Handler, Mapping, Result, StorageCtx};
 
 use crate::token::common::TokenAccounting;
 

--- a/crates/common/precompiles/src/token/default_token/storage.rs
+++ b/crates/common/precompiles/src/token/default_token/storage.rs
@@ -2,7 +2,7 @@ use alloc::string::String;
 
 use alloy_primitives::{Address, LogData, U256, address};
 use base_precompile_macros::contract;
-use base_precompile_storage::{BasePrecompileError, Handler, Mapping, Result};
+use base_precompile_storage::{BasePrecompileError, Handler, Mapping, Result, StorageCtx};
 
 use crate::token::common::TokenAccounting;
 
@@ -29,7 +29,7 @@ impl<'a> DefaultTokenStorage<'a> {
     /// Creates a `DefaultTokenStorage` instance targeting `addr`.
     ///
     /// Used by the factory to initialize token storage at a dynamically computed address.
-    pub fn from_address(addr: Address, storage: base_precompile_storage::StorageCtx<'a>) -> Self {
+    pub fn from_address(addr: Address, storage: StorageCtx<'a>) -> Self {
         Self::__new(addr, storage)
     }
 }

--- a/crates/common/precompiles/src/token/factory/dispatch.rs
+++ b/crates/common/precompiles/src/token/factory/dispatch.rs
@@ -5,11 +5,10 @@ use alloy_sol_types::{SolCall, SolInterface};
 use base_precompile_storage::{BasePrecompileError, IntoPrecompileResult, StorageCtx};
 use revm::precompile::PrecompileResult;
 
-use crate::token::abi::ITokenFactory;
-
 use super::storage::{
     TokenFactory, compute_default_address, compute_security_address, compute_stablecoin_address,
 };
+use crate::token::abi::ITokenFactory;
 
 impl<'a> TokenFactory<'a> {
     /// ABI-dispatches `calldata` to the appropriate `ITokenFactory` handler.

--- a/crates/common/precompiles/src/token/factory/dispatch.rs
+++ b/crates/common/precompiles/src/token/factory/dispatch.rs
@@ -11,10 +11,12 @@ use super::storage::{
     TokenFactory, compute_default_address, compute_security_address, compute_stablecoin_address,
 };
 
-impl TokenFactory<'_> {
+impl<'a> TokenFactory<'a> {
     /// ABI-dispatches `calldata` to the appropriate `ITokenFactory` handler.
     pub fn dispatch(&mut self, ctx: StorageCtx<'_>, calldata: &[u8]) -> PrecompileResult {
-        self.inner(ctx, calldata).into_precompile_result(ctx.gas_used(), |b| b)
+        let result = self.inner(ctx, calldata);
+        let gas = ctx.gas_used();
+        result.into_precompile_result(gas, |b| b)
     }
 
     fn inner(

--- a/crates/common/precompiles/src/token/factory/dispatch.rs
+++ b/crates/common/precompiles/src/token/factory/dispatch.rs
@@ -1,0 +1,59 @@
+//! ABI dispatch for the `TokenFactory` precompile.
+
+use alloy_primitives::Bytes;
+use alloy_sol_types::{SolCall, SolInterface};
+use base_precompile_storage::{BasePrecompileError, IntoPrecompileResult, StorageCtx};
+use revm::precompile::PrecompileResult;
+
+use crate::token::abi::ITokenFactory;
+
+use super::storage::{
+    TokenFactory, compute_default_address, compute_security_address, compute_stablecoin_address,
+};
+
+impl TokenFactory<'_> {
+    /// ABI-dispatches `calldata` to the appropriate `ITokenFactory` handler.
+    pub fn dispatch(&mut self, ctx: StorageCtx<'_>, calldata: &[u8]) -> PrecompileResult {
+        self.inner(ctx, calldata).into_precompile_result(ctx.gas_used(), |b| b)
+    }
+
+    fn inner(
+        &mut self,
+        ctx: StorageCtx<'_>,
+        calldata: &[u8],
+    ) -> base_precompile_storage::Result<Bytes> {
+        if calldata.len() < 4 {
+            return Err(BasePrecompileError::UnknownFunctionSelector([0u8; 4]));
+        }
+        let selector: [u8; 4] = calldata[..4].try_into().unwrap();
+
+        match ITokenFactory::ITokenFactoryCalls::abi_decode(calldata) {
+            Ok(ITokenFactory::ITokenFactoryCalls::createDefault(call)) => {
+                let caller = ctx.caller();
+                let token = self.create_default(caller, call)?;
+                Ok(ITokenFactory::createDefaultCall::abi_encode_returns(&token).into())
+            }
+            Ok(ITokenFactory::ITokenFactoryCalls::predictDefaultAddress(call)) => {
+                let (addr, _) = compute_default_address(call.creator, call.salt);
+                Ok(ITokenFactory::predictDefaultAddressCall::abi_encode_returns(&addr).into())
+            }
+            Ok(ITokenFactory::ITokenFactoryCalls::predictStablecoinAddress(call)) => {
+                let (addr, _) = compute_stablecoin_address(call.creator, call.salt);
+                Ok(ITokenFactory::predictStablecoinAddressCall::abi_encode_returns(&addr).into())
+            }
+            Ok(ITokenFactory::ITokenFactoryCalls::predictSecurityAddress(call)) => {
+                let (addr, _) = compute_security_address(call.creator, call.salt);
+                Ok(ITokenFactory::predictSecurityAddressCall::abi_encode_returns(&addr).into())
+            }
+            Ok(ITokenFactory::ITokenFactoryCalls::isB20(call)) => {
+                let result = self.is_b20(call.token)?;
+                Ok(ITokenFactory::isB20Call::abi_encode_returns(&result).into())
+            }
+            Ok(ITokenFactory::ITokenFactoryCalls::variantOf(call)) => {
+                let v = self.variant_of_token(call.token)?;
+                Ok(ITokenFactory::variantOfCall::abi_encode_returns(&v).into())
+            }
+            Err(_) => Err(BasePrecompileError::UnknownFunctionSelector(selector)),
+        }
+    }
+}

--- a/crates/common/precompiles/src/token/factory/evm.rs
+++ b/crates/common/precompiles/src/token/factory/evm.rs
@@ -1,0 +1,28 @@
+//! EVM entry point for the `TokenFactory` precompile.
+
+use alloy_evm::precompiles::{DynPrecompile, PrecompileInput};
+use alloy_primitives::Bytes;
+use base_precompile_storage::{EvmPrecompileStorageProvider, StorageCtx};
+use revm::precompile::{PrecompileId, PrecompileOutput, PrecompileResult};
+
+use super::storage::TokenFactory;
+
+/// EVM entry point for the `TokenFactory` precompile.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct TokenFactoryEvm;
+
+impl TokenFactoryEvm {
+    /// Returns a [`DynPrecompile`] registerable with a [`PrecompilesMap`].
+    pub fn precompile() -> DynPrecompile {
+        DynPrecompile::new_stateful(PrecompileId::Custom("TokenFactory".into()), Self::run)
+    }
+
+    fn run(input: PrecompileInput<'_>) -> PrecompileResult {
+        if !input.is_direct_call() {
+            return Ok(PrecompileOutput::new_reverted(0, Bytes::new()));
+        }
+        let calldata: Bytes = input.data.to_vec().into();
+        let mut provider = EvmPrecompileStorageProvider::new(input);
+        StorageCtx::enter(&mut provider, |ctx| TokenFactory::new(ctx).dispatch(ctx, &calldata))
+    }
+}

--- a/crates/common/precompiles/src/token/factory/mod.rs
+++ b/crates/common/precompiles/src/token/factory/mod.rs
@@ -1,0 +1,13 @@
+//! `TokenFactory` native precompile — creates B-20 tokens at deterministic prefix-encoded addresses.
+
+mod dispatch;
+mod evm;
+mod storage;
+
+pub use evm::TokenFactoryEvm;
+pub use storage::{
+    DEFAULT_PREFIX, FACTORY_ADDRESS, RESERVED_SIZE, SECURITY_PREFIX, STABLECOIN_PREFIX,
+    TokenFactory, VARIANT_DEFAULT, VARIANT_NONE, VARIANT_SECURITY, VARIANT_STABLECOIN,
+    compute_default_address, compute_security_address, compute_stablecoin_address, has_b20_prefix,
+    variant_of,
+};

--- a/crates/common/precompiles/src/token/factory/storage.rs
+++ b/crates/common/precompiles/src/token/factory/storage.rs
@@ -1,0 +1,709 @@
+use alloy_primitives::{Address, B256, Bytes, U256, address, keccak256};
+use alloy_sol_types::SolValue;
+use base_precompile_macros::contract;
+use base_precompile_storage::{BasePrecompileError, Handler, Result};
+use revm::state::Bytecode;
+
+use crate::token::{
+    DefaultTokenStorage, TokenAccounting,
+    abi::ITokenFactory,
+};
+
+// ── Addresses ────────────────────────────────────────────────────────────────
+
+/// Singleton precompile address for the `TokenFactory`.
+pub const FACTORY_ADDRESS: Address = address!("b02f000000000000000000000000000000000000");
+
+// ── Address prefixes (12 bytes each) ─────────────────────────────────────────
+
+/// Address prefix for Default-variant tokens.
+pub const DEFAULT_PREFIX: [u8; 12] = [0xb0, 0x20, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+/// Address prefix for Stablecoin-variant tokens.
+pub const STABLECOIN_PREFIX: [u8; 12] = [0xb0, 0x21, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+/// Address prefix for Security-variant tokens.
+pub const SECURITY_PREFIX: [u8; 12] = [0xb0, 0x22, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+
+// ── Reserved range ───────────────────────────────────────────────────────────
+
+/// Addresses whose lower-8-byte value (as `u64`) is less than this are reserved for
+/// protocol-level bootstrap tokens and cannot be created by public `create*` calls.
+pub const RESERVED_SIZE: u64 = 1024;
+
+// ── Variant discriminants ─────────────────────────────────────────────────────
+
+/// Variant discriminant returned by `variantOf` when address has no B-20 prefix.
+pub const VARIANT_NONE: u8 = 0;
+/// Variant discriminant for Default-variant tokens.
+pub const VARIANT_DEFAULT: u8 = 1;
+/// Variant discriminant for Stablecoin-variant tokens.
+pub const VARIANT_STABLECOIN: u8 = 2;
+/// Variant discriminant for Security-variant tokens.
+pub const VARIANT_SECURITY: u8 = 3;
+
+// ── Address utilities ─────────────────────────────────────────────────────────
+
+/// Returns `true` if `addr` has the address prefix of any B-20 token variant.
+///
+/// This is a pure prefix check. The caller is responsible for also verifying that code
+/// is deployed at the address (which is the full `isB20` check).
+pub fn has_b20_prefix(addr: &Address) -> bool {
+    let b = addr.as_slice();
+    b[0] == 0xb0 && matches!(b[1], 0x20 | 0x21 | 0x22) && b[2..12] == [0u8; 10]
+}
+
+/// Returns the variant discriminant for `addr` based on its address prefix.
+/// Returns `VARIANT_NONE` if the address does not match any B-20 prefix.
+pub fn variant_of(addr: &Address) -> u8 {
+    let b = addr.as_slice();
+    if b[0] != 0xb0 || b[2..12] != [0u8; 10] {
+        return VARIANT_NONE;
+    }
+    match b[1] {
+        0x20 => VARIANT_DEFAULT,
+        0x21 => VARIANT_STABLECOIN,
+        0x22 => VARIANT_SECURITY,
+        _ => VARIANT_NONE,
+    }
+}
+
+/// Computes the deterministic token address from a 12-byte prefix, `creator`, and `salt`.
+///
+/// Returns the address and the lower 8 bytes of the hash (as `u64`) used for the reserved-range
+/// check.
+fn compute_address(prefix: [u8; 12], creator: Address, salt: B256) -> (Address, u64) {
+    let hash = keccak256((creator, salt).abi_encode());
+
+    let mut lower_bytes_buf = [0u8; 8];
+    lower_bytes_buf.copy_from_slice(&hash[..8]);
+    let lower_bytes = u64::from_be_bytes(lower_bytes_buf);
+
+    let mut addr_bytes = [0u8; 20];
+    addr_bytes[..12].copy_from_slice(&prefix);
+    addr_bytes[12..].copy_from_slice(&hash[..8]);
+
+    (Address::from(addr_bytes), lower_bytes)
+}
+
+/// Computes the deterministic address for a Default-variant token.
+pub fn compute_default_address(creator: Address, salt: B256) -> (Address, u64) {
+    compute_address(DEFAULT_PREFIX, creator, salt)
+}
+
+/// Computes the deterministic address for a Stablecoin-variant token.
+pub fn compute_stablecoin_address(creator: Address, salt: B256) -> (Address, u64) {
+    compute_address(STABLECOIN_PREFIX, creator, salt)
+}
+
+/// Computes the deterministic address for a Security-variant token.
+pub fn compute_security_address(creator: Address, salt: B256) -> (Address, u64) {
+    compute_address(SECURITY_PREFIX, creator, salt)
+}
+
+// ── Factory struct ────────────────────────────────────────────────────────────
+
+/// The B-20 token factory precompile.
+///
+/// A stateless singleton — all token state lives at the individual token addresses.
+/// This struct exists purely to group the factory logic and provide `emit_event` via the
+/// `#[contract]` macro.
+#[contract(addr = FACTORY_ADDRESS)]
+pub struct TokenFactory {}
+
+// ── Factory methods ───────────────────────────────────────────────────────────
+
+impl TokenFactory<'_> {
+    /// Creates a Default-variant token at a deterministic address derived from `(caller, salt)`.
+    pub fn create_default(
+        &mut self,
+        caller: Address,
+        call: ITokenFactory::createDefaultCall,
+    ) -> Result<Address> {
+        let p = call.params;
+
+        // Input validation.
+        if p.admin.is_zero() {
+            return Err(BasePrecompileError::revert(ITokenFactory::ZeroAddress {}));
+        }
+        if p.supplyCap < p.initialSupply {
+            return Err(BasePrecompileError::revert(ITokenFactory::InvalidSupplyCap {}));
+        }
+
+        let (token_address, lower_bytes) = compute_default_address(caller, p.salt);
+
+        // Reserved-range guard.
+        if lower_bytes < RESERVED_SIZE {
+            return Err(BasePrecompileError::revert(ITokenFactory::AddressReserved {
+                token: token_address,
+            }));
+        }
+
+        // Collision guard: revert if code already exists at the target address.
+        let already_deployed = self
+            .storage
+            .with_account_info(token_address, |info| Ok(!info.is_empty_code_hash()))?;
+        if already_deployed {
+            return Err(BasePrecompileError::revert(ITokenFactory::TokenAlreadyExists {
+                token: token_address,
+            }));
+        }
+
+        // Write the 0xEF stub — marks the address as occupied and signals the precompile fallback.
+        let stub = Bytecode::new_legacy(Bytes::from_static(&[0xef]));
+        self.storage.set_code(token_address, stub)?;
+
+        // Initialize token storage at the token's own address.
+        let mut token = DefaultTokenStorage::from_address(token_address, self.storage);
+        token.name.write(p.name.clone())?;
+        token.symbol.write(p.symbol.clone())?;
+        token.decimals.write(p.decimals)?;
+        token.supply_cap.write(p.supplyCap)?;
+        token.capabilities.write(p.capabilities)?;
+        token.minimum_redeemable.write(p.minimumRedeemable)?;
+        token.contract_uri.write(p.contractURI.clone())?;
+
+        if p.initialSupply > U256::ZERO {
+            if p.initialSupplyRecipient.is_zero() {
+                return Err(BasePrecompileError::revert(ITokenFactory::ZeroAddress {}));
+            }
+            token.total_supply.write(p.initialSupply)?;
+            token.set_balance(p.initialSupplyRecipient, p.initialSupply)?;
+        }
+
+        self.emit_event(ITokenFactory::DefaultTokenCreated {
+            token: token_address,
+            creator: caller,
+            admin: p.admin,
+            name: p.name,
+            symbol: p.symbol,
+            decimals: p.decimals,
+            capabilities: p.capabilities,
+            initialSupply: p.initialSupply,
+            salt: p.salt,
+        })?;
+
+        Ok(token_address)
+    }
+
+    /// Returns whether `token` is a deployed B-20 token (prefix match + non-empty code).
+    pub fn is_b20(&self, token: Address) -> Result<bool> {
+        if !has_b20_prefix(&token) {
+            return Ok(false);
+        }
+        self.storage.with_account_info(token, |info| Ok(!info.is_empty_code_hash()))
+    }
+
+    /// Returns the variant discriminant for `token` decoded from its address prefix.
+    pub fn variant_of_token(&self, token: Address) -> Result<u8> {
+        Ok(variant_of(&token))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use base_precompile_storage::{HashMapStorageProvider, StorageCtx};
+
+    use super::*;
+
+    fn make_params(
+        name: &str,
+        symbol: &str,
+        salt: B256,
+        initial_supply: U256,
+        supply_cap: U256,
+    ) -> ITokenFactory::createDefaultCall {
+        ITokenFactory::createDefaultCall {
+            params: ITokenFactory::CreateDefaultTokenParams {
+                name: name.to_string(),
+                symbol: symbol.to_string(),
+                decimals: 18,
+                admin: Address::repeat_byte(0xAB),
+                capabilities: U256::ZERO,
+                initialSupply: initial_supply,
+                initialSupplyRecipient: Address::repeat_byte(0xCD),
+                transferPolicyId: 1,
+                supplyCap: supply_cap,
+                minimumRedeemable: U256::ZERO,
+                contractURI: "ipfs://test".to_string(),
+                salt,
+            },
+        }
+    }
+
+    fn default_call(salt: B256) -> ITokenFactory::createDefaultCall {
+        make_params("Test", "TST", salt, U256::from(1000), U256::MAX)
+    }
+
+    #[test]
+    fn test_compute_default_address_is_deterministic() {
+        let creator = Address::repeat_byte(0x11);
+        let salt = B256::repeat_byte(0x22);
+        let (a1, l1) = compute_default_address(creator, salt);
+        let (a2, l2) = compute_default_address(creator, salt);
+        assert_eq!(a1, a2);
+        assert_eq!(l1, l2);
+        assert!(has_b20_prefix(&a1));
+        assert_eq!(variant_of(&a1), VARIANT_DEFAULT);
+    }
+
+    #[test]
+    fn test_different_salts_produce_different_addresses() {
+        let creator = Address::repeat_byte(0x11);
+        let (a1, _) = compute_default_address(creator, B256::repeat_byte(0x01));
+        let (a2, _) = compute_default_address(creator, B256::repeat_byte(0x02));
+        assert_ne!(a1, a2);
+    }
+
+    #[test]
+    fn test_variants_produce_different_addresses_for_same_input() {
+        let creator = Address::repeat_byte(0x11);
+        let salt = B256::repeat_byte(0x33);
+        let (def, _) = compute_default_address(creator, salt);
+        let (sc, _) = compute_stablecoin_address(creator, salt);
+        let (sec, _) = compute_security_address(creator, salt);
+        assert_ne!(def, sc);
+        assert_ne!(def, sec);
+        assert_ne!(sc, sec);
+        assert_eq!(variant_of(&def), VARIANT_DEFAULT);
+        assert_eq!(variant_of(&sc), VARIANT_STABLECOIN);
+        assert_eq!(variant_of(&sec), VARIANT_SECURITY);
+    }
+
+    #[test]
+    fn test_create_default_deploys_ef_stub() {
+        let mut storage = HashMapStorageProvider::new(1);
+        let caller = Address::repeat_byte(0x55);
+        let salt = B256::repeat_byte(0xAA);
+        let call = default_call(salt);
+        let (expected_addr, _) = compute_default_address(caller, salt);
+
+        StorageCtx::enter(&mut storage, |ctx| {
+            let mut factory = TokenFactory::new(ctx);
+            factory.create_default(caller, call).unwrap();
+            assert!(ctx.has_bytecode(expected_addr).unwrap());
+        });
+    }
+
+    #[test]
+    fn test_create_default_stores_metadata() {
+        let mut storage = HashMapStorageProvider::new(1);
+        let caller = Address::repeat_byte(0x55);
+        let salt = B256::repeat_byte(0xBB);
+        let call = make_params("My Token", "MYT", salt, U256::ZERO, U256::MAX);
+        let (expected_addr, _) = compute_default_address(caller, salt);
+
+        StorageCtx::enter(&mut storage, |ctx| {
+            let mut factory = TokenFactory::new(ctx);
+            factory.create_default(caller, call).unwrap();
+
+            let token = DefaultTokenStorage::from_address(expected_addr, ctx);
+            assert_eq!(token.name.read().unwrap(), "My Token");
+            assert_eq!(token.symbol.read().unwrap(), "MYT");
+            assert_eq!(token.decimals.read().unwrap(), 18u8);
+        });
+    }
+
+    #[test]
+    fn test_create_default_mints_initial_supply() {
+        let mut storage = HashMapStorageProvider::new(1);
+        let caller = Address::repeat_byte(0x55);
+        let salt = B256::repeat_byte(0xCC);
+        let recipient = Address::repeat_byte(0xCD);
+        let supply = U256::from(5_000u64);
+        let call = make_params("Supply Token", "SUP", salt, supply, U256::MAX);
+        let (expected_addr, _) = compute_default_address(caller, salt);
+
+        StorageCtx::enter(&mut storage, |ctx| {
+            let mut factory = TokenFactory::new(ctx);
+            factory.create_default(caller, call).unwrap();
+
+            let token = DefaultTokenStorage::from_address(expected_addr, ctx);
+            assert_eq!(token.total_supply.read().unwrap(), supply);
+            assert_eq!(token.balance_of(recipient).unwrap(), supply);
+        });
+    }
+
+    #[test]
+    fn test_create_default_emits_event() {
+        let mut storage = HashMapStorageProvider::new(1);
+        let caller = Address::repeat_byte(0x55);
+        let salt = B256::repeat_byte(0xDD);
+        let call = default_call(salt);
+
+        StorageCtx::enter(&mut storage, |ctx| {
+            let mut factory = TokenFactory::new(ctx);
+            factory.create_default(caller, call).unwrap();
+            let events = ctx.get_events(FACTORY_ADDRESS);
+            assert_eq!(events.len(), 1);
+        });
+    }
+
+    #[test]
+    fn test_create_default_revert_if_salt_reused() {
+        let mut storage = HashMapStorageProvider::new(1);
+        let caller = Address::repeat_byte(0x55);
+        let salt = B256::repeat_byte(0xEE);
+
+        StorageCtx::enter(&mut storage, |ctx| {
+            let mut factory = TokenFactory::new(ctx);
+            factory.create_default(caller, default_call(salt)).unwrap();
+            let result = factory.create_default(caller, default_call(salt));
+            assert!(result.is_err());
+        });
+    }
+
+    #[test]
+    fn test_create_default_revert_zero_admin() {
+        let mut storage = HashMapStorageProvider::new(1);
+        let caller = Address::repeat_byte(0x55);
+        let mut call = default_call(B256::repeat_byte(0x01));
+        call.params.admin = Address::ZERO;
+
+        StorageCtx::enter(&mut storage, |ctx| {
+            let mut factory = TokenFactory::new(ctx);
+            let result = factory.create_default(caller, call);
+            assert!(result.is_err());
+        });
+    }
+
+    #[test]
+    fn test_create_default_revert_supply_cap_below_initial() {
+        let mut storage = HashMapStorageProvider::new(1);
+        let caller = Address::repeat_byte(0x55);
+        let call = make_params("T", "T", B256::repeat_byte(0x02), U256::from(100), U256::from(50));
+
+        StorageCtx::enter(&mut storage, |ctx| {
+            let mut factory = TokenFactory::new(ctx);
+            let result = factory.create_default(caller, call);
+            assert!(result.is_err());
+        });
+    }
+
+    #[test]
+    fn test_is_b20_false_before_create() {
+        let mut storage = HashMapStorageProvider::new(1);
+        let creator = Address::repeat_byte(0x55);
+        let (addr, _) = compute_default_address(creator, B256::repeat_byte(0xFF));
+
+        StorageCtx::enter(&mut storage, |ctx| {
+            let factory = TokenFactory::new(ctx);
+            assert!(!factory.is_b20(addr).unwrap());
+        });
+    }
+
+    #[test]
+    fn test_is_b20_true_after_create() {
+        let mut storage = HashMapStorageProvider::new(1);
+        let caller = Address::repeat_byte(0x55);
+        let salt = B256::repeat_byte(0x11);
+
+        StorageCtx::enter(&mut storage, |ctx| {
+            let mut factory = TokenFactory::new(ctx);
+            let token = factory.create_default(caller, default_call(salt)).unwrap();
+            assert!(factory.is_b20(token).unwrap());
+        });
+    }
+
+    #[test]
+    fn test_variant_of_default_after_create() {
+        let mut storage = HashMapStorageProvider::new(1);
+        let caller = Address::repeat_byte(0x55);
+        let salt = B256::repeat_byte(0x12);
+
+        StorageCtx::enter(&mut storage, |ctx| {
+            let mut factory = TokenFactory::new(ctx);
+            let token = factory.create_default(caller, default_call(salt)).unwrap();
+            assert_eq!(factory.variant_of_token(token).unwrap(), VARIANT_DEFAULT);
+        });
+    }
+
+    #[test]
+    fn test_is_b20_false_for_non_prefix_address() {
+        let mut storage = HashMapStorageProvider::new(1);
+        let random_addr = Address::repeat_byte(0x42);
+
+        StorageCtx::enter(&mut storage, |ctx| {
+            let factory = TokenFactory::new(ctx);
+            assert!(!factory.is_b20(random_addr).unwrap());
+        });
+    }
+}
+
+// ── Integration tests ─────────────────────────────────────────────────────────
+//
+// These tests exercise the full token lifecycle: factory creation → metadata
+// verification → mint → transfer → balance/supply accounting.
+//
+// The DefaultToken instance is constructed via `DefaultToken::with_storage(
+// DefaultTokenStorage::from_address(token, ctx))`, which mirrors what the
+// precompile-lookup fallback does when a call is routed to a B-20 address.
+
+#[cfg(test)]
+mod integration {
+    use base_precompile_storage::{HashMapStorageProvider, StorageCtx};
+
+    use super::*;
+    use crate::token::{
+        DefaultToken, DefaultTokenStorage, Mintable, Token, Transferable,
+    };
+
+    /// Creates a token at the given address and returns a usable `DefaultToken` handle.
+    fn token_at<'a>(addr: Address, ctx: StorageCtx<'a>) -> DefaultToken<DefaultTokenStorage<'a>> {
+        DefaultToken::with_storage(DefaultTokenStorage::from_address(addr, ctx))
+    }
+
+    fn create_token(
+        factory: &mut TokenFactory<'_>,
+        name: &str,
+        symbol: &str,
+        decimals: u8,
+        initial_supply: U256,
+        capabilities: U256,
+        supply_cap: U256,
+        salt: B256,
+    ) -> Address {
+        let caller = Address::repeat_byte(0xCA);
+        let call = ITokenFactory::createDefaultCall {
+            params: ITokenFactory::CreateDefaultTokenParams {
+                name: name.to_string(),
+                symbol: symbol.to_string(),
+                decimals,
+                admin: Address::repeat_byte(0xAD),
+                capabilities,
+                initialSupply: initial_supply,
+                initialSupplyRecipient: Address::repeat_byte(0xCD),
+                transferPolicyId: 1,
+                supplyCap: supply_cap,
+                minimumRedeemable: U256::from(10u64),
+                contractURI: "ipfs://QmTest".to_string(),
+                salt,
+            },
+        };
+        factory.create_default(caller, call).unwrap()
+    }
+
+    // ── metadata ──────────────────────────────────────────────────────────────
+
+    /// All metadata fields set at creation must be readable from the token address.
+    #[test]
+    fn test_metadata_all_fields() {
+        let mut storage = HashMapStorageProvider::new(1);
+        StorageCtx::enter(&mut storage, |ctx| {
+            let mut factory = TokenFactory::new(ctx);
+            let token_addr = create_token(
+                &mut factory,
+                "USD Coin",
+                "USDC",
+                6,
+                U256::from(1_000_000u64),
+                U256::from(0b11u64), // PAUSABLE | CAP_MUTABLE
+                U256::from(u128::MAX),
+                B256::repeat_byte(0x01),
+            );
+
+            let t = DefaultTokenStorage::from_address(token_addr, ctx);
+
+            assert_eq!(t.name.read().unwrap(),         "USD Coin");
+            assert_eq!(t.symbol.read().unwrap(),        "USDC");
+            assert_eq!(t.decimals.read().unwrap(),      6u8);
+            assert_eq!(t.capabilities.read().unwrap(),  U256::from(0b11u64));
+            assert_eq!(t.supply_cap.read().unwrap(),    U256::from(u128::MAX));
+            assert_eq!(t.minimum_redeemable.read().unwrap(), U256::from(10u64));
+            assert_eq!(t.contract_uri.read().unwrap(), "ipfs://QmTest");
+            assert_eq!(t.total_supply.read().unwrap(), U256::from(1_000_000u64));
+        });
+    }
+
+    // ── transfer ──────────────────────────────────────────────────────────────
+
+    /// A successful transfer moves balance from sender to receiver and leaves
+    /// total supply unchanged.
+    #[test]
+    fn test_transfer_moves_balance() {
+        let mut storage = HashMapStorageProvider::new(1);
+        StorageCtx::enter(&mut storage, |ctx| {
+            let mut factory = TokenFactory::new(ctx);
+            let token_addr = create_token(
+                &mut factory,
+                "Test Token",
+                "TST",
+                18,
+                U256::from(1_000u64),
+                U256::ZERO,
+                U256::MAX,
+                B256::repeat_byte(0x02),
+            );
+
+            let sender   = Address::repeat_byte(0xCD); // initialSupplyRecipient
+            let receiver = Address::repeat_byte(0xBB);
+            let amount   = U256::from(300u64);
+
+            let mut token = token_at(token_addr, ctx);
+
+            // Pre-transfer state.
+            assert_eq!(token.accounting().balance_of(sender).unwrap(),   U256::from(1_000u64));
+            assert_eq!(token.accounting().balance_of(receiver).unwrap(),  U256::ZERO);
+            assert_eq!(token.accounting().total_supply().unwrap(),        U256::from(1_000u64));
+
+            token.transfer(sender, receiver, amount).unwrap();
+
+            // Post-transfer state.
+            assert_eq!(token.accounting().balance_of(sender).unwrap(),   U256::from(700u64));
+            assert_eq!(token.accounting().balance_of(receiver).unwrap(),  U256::from(300u64));
+            assert_eq!(token.accounting().total_supply().unwrap(),        U256::from(1_000u64));
+        });
+    }
+
+    /// Transferring more than the sender's balance reverts.
+    #[test]
+    fn test_transfer_insufficient_balance_reverts() {
+        let mut storage = HashMapStorageProvider::new(1);
+        StorageCtx::enter(&mut storage, |ctx| {
+            let mut factory = TokenFactory::new(ctx);
+            let token_addr = create_token(
+                &mut factory,
+                "T",
+                "T",
+                18,
+                U256::from(100u64),
+                U256::ZERO,
+                U256::MAX,
+                B256::repeat_byte(0x03),
+            );
+
+            let sender   = Address::repeat_byte(0xCD);
+            let receiver = Address::repeat_byte(0xBB);
+
+            let mut token = token_at(token_addr, ctx);
+            let result = token.transfer(sender, receiver, U256::from(101u64));
+            assert!(result.is_err());
+
+            // Balance must be unchanged.
+            assert_eq!(token.accounting().balance_of(sender).unwrap(), U256::from(100u64));
+        });
+    }
+
+    // ── mint ──────────────────────────────────────────────────────────────────
+
+    /// Minting increases total supply and credits the recipient.
+    #[test]
+    fn test_mint_increases_supply() {
+        let mut storage = HashMapStorageProvider::new(1);
+        StorageCtx::enter(&mut storage, |ctx| {
+            let mut factory = TokenFactory::new(ctx);
+            let token_addr = create_token(
+                &mut factory,
+                "Mintable",
+                "MNT",
+                18,
+                U256::from(500u64),
+                U256::ZERO,
+                U256::MAX,
+                B256::repeat_byte(0x04),
+            );
+
+            let recipient = Address::repeat_byte(0xEE);
+            let mut token = token_at(token_addr, ctx);
+
+            token.mint(recipient, U256::from(200u64)).unwrap();
+
+            assert_eq!(token.accounting().total_supply().unwrap(), U256::from(700u64));
+            assert_eq!(token.accounting().balance_of(recipient).unwrap(), U256::from(200u64));
+        });
+    }
+
+    /// Minting beyond the supply cap reverts.
+    #[test]
+    fn test_mint_beyond_supply_cap_reverts() {
+        let mut storage = HashMapStorageProvider::new(1);
+        StorageCtx::enter(&mut storage, |ctx| {
+            let mut factory = TokenFactory::new(ctx);
+            let cap = U256::from(1_000u64);
+            let token_addr = create_token(
+                &mut factory,
+                "Capped",
+                "CAP",
+                18,
+                U256::from(900u64),
+                U256::ZERO,
+                cap,
+                B256::repeat_byte(0x05),
+            );
+
+            let recipient = Address::repeat_byte(0xEE);
+            let mut token = token_at(token_addr, ctx);
+
+            // 101 would push supply to 1_001 > cap 1_000.
+            let result = token.mint(recipient, U256::from(101u64));
+            assert!(result.is_err());
+
+            assert_eq!(token.accounting().total_supply().unwrap(), U256::from(900u64));
+        });
+    }
+
+    // ── end-to-end ────────────────────────────────────────────────────────────
+
+    /// Full lifecycle: create → verify metadata → transfer partial → mint more →
+    /// verify final balances and supply.
+    #[test]
+    fn test_full_lifecycle() {
+        let mut storage = HashMapStorageProvider::new(1);
+        StorageCtx::enter(&mut storage, |ctx| {
+            let mut factory = TokenFactory::new(ctx);
+            let alice   = Address::repeat_byte(0xCD); // initialSupplyRecipient
+            let bob     = Address::repeat_byte(0xBB);
+            let charlie = Address::repeat_byte(0xCC);
+
+            let token_addr = create_token(
+                &mut factory,
+                "My Stablecoin",
+                "MSC",
+                6,
+                U256::from(10_000u64),
+                U256::from(0b11u64),
+                U256::from(1_000_000u64),
+                B256::repeat_byte(0x06),
+            );
+
+            // ── verify factory state ──────────────────────────────────────────
+            assert!(factory.is_b20(token_addr).unwrap(),         "should be B-20");
+            assert_eq!(factory.variant_of_token(token_addr).unwrap(), VARIANT_DEFAULT);
+
+            // ── verify 0xEF stub at token address ────────────────────────────
+            assert!(ctx.has_bytecode(token_addr).unwrap(), "0xEF stub should be present");
+
+            // ── verify metadata ───────────────────────────────────────────────
+            let storage_handle = DefaultTokenStorage::from_address(token_addr, ctx);
+            assert_eq!(storage_handle.name.read().unwrap(),   "My Stablecoin");
+            assert_eq!(storage_handle.symbol.read().unwrap(), "MSC");
+            assert_eq!(storage_handle.decimals.read().unwrap(), 6u8);
+            assert_eq!(storage_handle.supply_cap.read().unwrap(), U256::from(1_000_000u64));
+            assert_eq!(storage_handle.capabilities.read().unwrap(), U256::from(0b11u64));
+
+            // ── alice → bob: 4_000 tokens ─────────────────────────────────────
+            let mut token = token_at(token_addr, ctx);
+            token.transfer(alice, bob, U256::from(4_000u64)).unwrap();
+
+            assert_eq!(token.accounting().balance_of(alice).unwrap(), U256::from(6_000u64));
+            assert_eq!(token.accounting().balance_of(bob).unwrap(),   U256::from(4_000u64));
+            assert_eq!(token.accounting().total_supply().unwrap(),     U256::from(10_000u64));
+
+            // ── bob → charlie: 1_500 tokens ───────────────────────────────────
+            token.transfer(bob, charlie, U256::from(1_500u64)).unwrap();
+
+            assert_eq!(token.accounting().balance_of(bob).unwrap(),     U256::from(2_500u64));
+            assert_eq!(token.accounting().balance_of(charlie).unwrap(), U256::from(1_500u64));
+
+            // ── mint 5_000 more to alice ───────────────────────────────────────
+            token.mint(alice, U256::from(5_000u64)).unwrap();
+
+            assert_eq!(token.accounting().balance_of(alice).unwrap(), U256::from(11_000u64));
+            assert_eq!(token.accounting().total_supply().unwrap(),     U256::from(15_000u64));
+
+            // Final balances must sum to total supply.
+            let alice_bal   = token.accounting().balance_of(alice).unwrap();
+            let bob_bal     = token.accounting().balance_of(bob).unwrap();
+            let charlie_bal = token.accounting().balance_of(charlie).unwrap();
+            assert_eq!(alice_bal + bob_bal + charlie_bal, U256::from(15_000u64));
+        });
+    }
+}

--- a/crates/common/precompiles/src/token/factory/storage.rs
+++ b/crates/common/precompiles/src/token/factory/storage.rs
@@ -446,33 +446,33 @@ mod integration {
         DefaultToken::with_storage(DefaultTokenStorage::from_address(addr, ctx))
     }
 
-    fn create_token(
-        factory: &mut TokenFactory<'_>,
+    fn default_token_params(
         name: &str,
         symbol: &str,
-        decimals: u8,
-        initial_supply: U256,
-        capabilities: U256,
-        supply_cap: U256,
         salt: B256,
+    ) -> ITokenFactory::CreateDefaultTokenParams {
+        ITokenFactory::CreateDefaultTokenParams {
+            name: name.to_string(),
+            symbol: symbol.to_string(),
+            decimals: 18,
+            admin: Address::repeat_byte(0xAD),
+            capabilities: U256::ZERO,
+            initialSupply: U256::ZERO,
+            initialSupplyRecipient: Address::repeat_byte(0xCD),
+            transferPolicyId: 1,
+            supplyCap: U256::MAX,
+            minimumRedeemable: U256::from(10u64),
+            contractURI: "ipfs://QmTest".to_string(),
+            salt,
+        }
+    }
+
+    fn create_token(
+        factory: &mut TokenFactory<'_>,
+        params: ITokenFactory::CreateDefaultTokenParams,
     ) -> Address {
         let caller = Address::repeat_byte(0xCA);
-        let call = ITokenFactory::createDefaultCall {
-            params: ITokenFactory::CreateDefaultTokenParams {
-                name: name.to_string(),
-                symbol: symbol.to_string(),
-                decimals,
-                admin: Address::repeat_byte(0xAD),
-                capabilities,
-                initialSupply: initial_supply,
-                initialSupplyRecipient: Address::repeat_byte(0xCD),
-                transferPolicyId: 1,
-                supplyCap: supply_cap,
-                minimumRedeemable: U256::from(10u64),
-                contractURI: "ipfs://QmTest".to_string(),
-                salt,
-            },
-        };
+        let call = ITokenFactory::createDefaultCall { params };
         factory.create_default(caller, call).unwrap()
     }
 
@@ -484,16 +484,12 @@ mod integration {
         let mut storage = HashMapStorageProvider::new(1);
         StorageCtx::enter(&mut storage, |ctx| {
             let mut factory = TokenFactory::new(ctx);
-            let token_addr = create_token(
-                &mut factory,
-                "USD Coin",
-                "USDC",
-                6,
-                U256::from(1_000_000u64),
-                U256::from(0b11u64), // PAUSABLE | CAP_MUTABLE
-                U256::from(u128::MAX),
-                B256::repeat_byte(0x01),
-            );
+            let mut params = default_token_params("USD Coin", "USDC", B256::repeat_byte(0x01));
+            params.decimals = 6;
+            params.initialSupply = U256::from(1_000_000u64);
+            params.capabilities = U256::from(0b11u64); // PAUSABLE | CAP_MUTABLE
+            params.supplyCap = U256::from(u128::MAX);
+            let token_addr = create_token(&mut factory, params);
 
             let t = DefaultTokenStorage::from_address(token_addr, ctx);
 
@@ -517,16 +513,9 @@ mod integration {
         let mut storage = HashMapStorageProvider::new(1);
         StorageCtx::enter(&mut storage, |ctx| {
             let mut factory = TokenFactory::new(ctx);
-            let token_addr = create_token(
-                &mut factory,
-                "Test Token",
-                "TST",
-                18,
-                U256::from(1_000u64),
-                U256::ZERO,
-                U256::MAX,
-                B256::repeat_byte(0x02),
-            );
+            let mut params = default_token_params("Test Token", "TST", B256::repeat_byte(0x02));
+            params.initialSupply = U256::from(1_000u64);
+            let token_addr = create_token(&mut factory, params);
 
             let sender = Address::repeat_byte(0xCD); // initialSupplyRecipient
             let receiver = Address::repeat_byte(0xBB);
@@ -554,16 +543,9 @@ mod integration {
         let mut storage = HashMapStorageProvider::new(1);
         StorageCtx::enter(&mut storage, |ctx| {
             let mut factory = TokenFactory::new(ctx);
-            let token_addr = create_token(
-                &mut factory,
-                "T",
-                "T",
-                18,
-                U256::from(100u64),
-                U256::ZERO,
-                U256::MAX,
-                B256::repeat_byte(0x03),
-            );
+            let mut params = default_token_params("T", "T", B256::repeat_byte(0x03));
+            params.initialSupply = U256::from(100u64);
+            let token_addr = create_token(&mut factory, params);
 
             let sender = Address::repeat_byte(0xCD);
             let receiver = Address::repeat_byte(0xBB);
@@ -585,16 +567,9 @@ mod integration {
         let mut storage = HashMapStorageProvider::new(1);
         StorageCtx::enter(&mut storage, |ctx| {
             let mut factory = TokenFactory::new(ctx);
-            let token_addr = create_token(
-                &mut factory,
-                "Mintable",
-                "MNT",
-                18,
-                U256::from(500u64),
-                U256::ZERO,
-                U256::MAX,
-                B256::repeat_byte(0x04),
-            );
+            let mut params = default_token_params("Mintable", "MNT", B256::repeat_byte(0x04));
+            params.initialSupply = U256::from(500u64);
+            let token_addr = create_token(&mut factory, params);
 
             let recipient = Address::repeat_byte(0xEE);
             let mut token = token_at(token_addr, ctx);
@@ -613,16 +588,10 @@ mod integration {
         StorageCtx::enter(&mut storage, |ctx| {
             let mut factory = TokenFactory::new(ctx);
             let cap = U256::from(1_000u64);
-            let token_addr = create_token(
-                &mut factory,
-                "Capped",
-                "CAP",
-                18,
-                U256::from(900u64),
-                U256::ZERO,
-                cap,
-                B256::repeat_byte(0x05),
-            );
+            let mut params = default_token_params("Capped", "CAP", B256::repeat_byte(0x05));
+            params.initialSupply = U256::from(900u64);
+            params.supplyCap = cap;
+            let token_addr = create_token(&mut factory, params);
 
             let recipient = Address::repeat_byte(0xEE);
             let mut token = token_at(token_addr, ctx);
@@ -648,16 +617,12 @@ mod integration {
             let bob = Address::repeat_byte(0xBB);
             let charlie = Address::repeat_byte(0xCC);
 
-            let token_addr = create_token(
-                &mut factory,
-                "My Stablecoin",
-                "MSC",
-                6,
-                U256::from(10_000u64),
-                U256::from(0b11u64),
-                U256::from(1_000_000u64),
-                B256::repeat_byte(0x06),
-            );
+            let mut params = default_token_params("My Stablecoin", "MSC", B256::repeat_byte(0x06));
+            params.decimals = 6;
+            params.initialSupply = U256::from(10_000u64);
+            params.capabilities = U256::from(0b11u64);
+            params.supplyCap = U256::from(1_000_000u64);
+            let token_addr = create_token(&mut factory, params);
 
             // ── verify factory state ──────────────────────────────────────────
             assert!(factory.is_b20(token_addr).unwrap(), "should be B-20");

--- a/crates/common/precompiles/src/token/factory/storage.rs
+++ b/crates/common/precompiles/src/token/factory/storage.rs
@@ -4,10 +4,7 @@ use base_precompile_macros::contract;
 use base_precompile_storage::{BasePrecompileError, Handler, Result};
 use revm::state::Bytecode;
 
-use crate::token::{
-    DefaultTokenStorage, TokenAccounting,
-    abi::ITokenFactory,
-};
+use crate::token::{DefaultTokenStorage, TokenAccounting, abi::ITokenFactory};
 
 // ── Addresses ────────────────────────────────────────────────────────────────
 
@@ -111,7 +108,7 @@ pub struct TokenFactory {}
 
 // ── Factory methods ───────────────────────────────────────────────────────────
 
-impl TokenFactory<'_> {
+impl<'a> TokenFactory<'a> {
     /// Creates a Default-variant token at a deterministic address derived from `(caller, salt)`.
     pub fn create_default(
         &mut self,
@@ -138,9 +135,8 @@ impl TokenFactory<'_> {
         }
 
         // Collision guard: revert if code already exists at the target address.
-        let already_deployed = self
-            .storage
-            .with_account_info(token_address, |info| Ok(!info.is_empty_code_hash()))?;
+        let already_deployed =
+            self.storage.with_account_info(token_address, |info| Ok(!info.is_empty_code_hash()))?;
         if already_deployed {
             return Err(BasePrecompileError::revert(ITokenFactory::TokenAlreadyExists {
                 token: token_address,
@@ -442,9 +438,7 @@ mod integration {
     use base_precompile_storage::{HashMapStorageProvider, StorageCtx};
 
     use super::*;
-    use crate::token::{
-        DefaultToken, DefaultTokenStorage, Mintable, Token, Transferable,
-    };
+    use crate::token::{DefaultToken, DefaultTokenStorage, Mintable, Token, Transferable};
 
     /// Creates a token at the given address and returns a usable `DefaultToken` handle.
     fn token_at<'a>(addr: Address, ctx: StorageCtx<'a>) -> DefaultToken<DefaultTokenStorage<'a>> {
@@ -502,11 +496,11 @@ mod integration {
 
             let t = DefaultTokenStorage::from_address(token_addr, ctx);
 
-            assert_eq!(t.name.read().unwrap(),         "USD Coin");
-            assert_eq!(t.symbol.read().unwrap(),        "USDC");
-            assert_eq!(t.decimals.read().unwrap(),      6u8);
-            assert_eq!(t.capabilities.read().unwrap(),  U256::from(0b11u64));
-            assert_eq!(t.supply_cap.read().unwrap(),    U256::from(u128::MAX));
+            assert_eq!(t.name.read().unwrap(), "USD Coin");
+            assert_eq!(t.symbol.read().unwrap(), "USDC");
+            assert_eq!(t.decimals.read().unwrap(), 6u8);
+            assert_eq!(t.capabilities.read().unwrap(), U256::from(0b11u64));
+            assert_eq!(t.supply_cap.read().unwrap(), U256::from(u128::MAX));
             assert_eq!(t.minimum_redeemable.read().unwrap(), U256::from(10u64));
             assert_eq!(t.contract_uri.read().unwrap(), "ipfs://QmTest");
             assert_eq!(t.total_supply.read().unwrap(), U256::from(1_000_000u64));
@@ -533,23 +527,23 @@ mod integration {
                 B256::repeat_byte(0x02),
             );
 
-            let sender   = Address::repeat_byte(0xCD); // initialSupplyRecipient
+            let sender = Address::repeat_byte(0xCD); // initialSupplyRecipient
             let receiver = Address::repeat_byte(0xBB);
-            let amount   = U256::from(300u64);
+            let amount = U256::from(300u64);
 
             let mut token = token_at(token_addr, ctx);
 
             // Pre-transfer state.
-            assert_eq!(token.accounting().balance_of(sender).unwrap(),   U256::from(1_000u64));
-            assert_eq!(token.accounting().balance_of(receiver).unwrap(),  U256::ZERO);
-            assert_eq!(token.accounting().total_supply().unwrap(),        U256::from(1_000u64));
+            assert_eq!(token.accounting().balance_of(sender).unwrap(), U256::from(1_000u64));
+            assert_eq!(token.accounting().balance_of(receiver).unwrap(), U256::ZERO);
+            assert_eq!(token.accounting().total_supply().unwrap(), U256::from(1_000u64));
 
             token.transfer(sender, receiver, amount).unwrap();
 
             // Post-transfer state.
-            assert_eq!(token.accounting().balance_of(sender).unwrap(),   U256::from(700u64));
-            assert_eq!(token.accounting().balance_of(receiver).unwrap(),  U256::from(300u64));
-            assert_eq!(token.accounting().total_supply().unwrap(),        U256::from(1_000u64));
+            assert_eq!(token.accounting().balance_of(sender).unwrap(), U256::from(700u64));
+            assert_eq!(token.accounting().balance_of(receiver).unwrap(), U256::from(300u64));
+            assert_eq!(token.accounting().total_supply().unwrap(), U256::from(1_000u64));
         });
     }
 
@@ -570,7 +564,7 @@ mod integration {
                 B256::repeat_byte(0x03),
             );
 
-            let sender   = Address::repeat_byte(0xCD);
+            let sender = Address::repeat_byte(0xCD);
             let receiver = Address::repeat_byte(0xBB);
 
             let mut token = token_at(token_addr, ctx);
@@ -649,8 +643,8 @@ mod integration {
         let mut storage = HashMapStorageProvider::new(1);
         StorageCtx::enter(&mut storage, |ctx| {
             let mut factory = TokenFactory::new(ctx);
-            let alice   = Address::repeat_byte(0xCD); // initialSupplyRecipient
-            let bob     = Address::repeat_byte(0xBB);
+            let alice = Address::repeat_byte(0xCD); // initialSupplyRecipient
+            let bob = Address::repeat_byte(0xBB);
             let charlie = Address::repeat_byte(0xCC);
 
             let token_addr = create_token(
@@ -665,7 +659,7 @@ mod integration {
             );
 
             // ── verify factory state ──────────────────────────────────────────
-            assert!(factory.is_b20(token_addr).unwrap(),         "should be B-20");
+            assert!(factory.is_b20(token_addr).unwrap(), "should be B-20");
             assert_eq!(factory.variant_of_token(token_addr).unwrap(), VARIANT_DEFAULT);
 
             // ── verify 0xEF stub at token address ────────────────────────────
@@ -673,7 +667,7 @@ mod integration {
 
             // ── verify metadata ───────────────────────────────────────────────
             let storage_handle = DefaultTokenStorage::from_address(token_addr, ctx);
-            assert_eq!(storage_handle.name.read().unwrap(),   "My Stablecoin");
+            assert_eq!(storage_handle.name.read().unwrap(), "My Stablecoin");
             assert_eq!(storage_handle.symbol.read().unwrap(), "MSC");
             assert_eq!(storage_handle.decimals.read().unwrap(), 6u8);
             assert_eq!(storage_handle.supply_cap.read().unwrap(), U256::from(1_000_000u64));
@@ -684,24 +678,24 @@ mod integration {
             token.transfer(alice, bob, U256::from(4_000u64)).unwrap();
 
             assert_eq!(token.accounting().balance_of(alice).unwrap(), U256::from(6_000u64));
-            assert_eq!(token.accounting().balance_of(bob).unwrap(),   U256::from(4_000u64));
-            assert_eq!(token.accounting().total_supply().unwrap(),     U256::from(10_000u64));
+            assert_eq!(token.accounting().balance_of(bob).unwrap(), U256::from(4_000u64));
+            assert_eq!(token.accounting().total_supply().unwrap(), U256::from(10_000u64));
 
             // ── bob → charlie: 1_500 tokens ───────────────────────────────────
             token.transfer(bob, charlie, U256::from(1_500u64)).unwrap();
 
-            assert_eq!(token.accounting().balance_of(bob).unwrap(),     U256::from(2_500u64));
+            assert_eq!(token.accounting().balance_of(bob).unwrap(), U256::from(2_500u64));
             assert_eq!(token.accounting().balance_of(charlie).unwrap(), U256::from(1_500u64));
 
             // ── mint 5_000 more to alice ───────────────────────────────────────
             token.mint(alice, U256::from(5_000u64)).unwrap();
 
             assert_eq!(token.accounting().balance_of(alice).unwrap(), U256::from(11_000u64));
-            assert_eq!(token.accounting().total_supply().unwrap(),     U256::from(15_000u64));
+            assert_eq!(token.accounting().total_supply().unwrap(), U256::from(15_000u64));
 
             // Final balances must sum to total supply.
-            let alice_bal   = token.accounting().balance_of(alice).unwrap();
-            let bob_bal     = token.accounting().balance_of(bob).unwrap();
+            let alice_bal = token.accounting().balance_of(alice).unwrap();
+            let bob_bal = token.accounting().balance_of(bob).unwrap();
             let charlie_bal = token.accounting().balance_of(charlie).unwrap();
             assert_eq!(alice_bal + bob_bal + charlie_bal, U256::from(15_000u64));
         });

--- a/crates/common/precompiles/src/token/factory/storage.rs
+++ b/crates/common/precompiles/src/token/factory/storage.rs
@@ -162,7 +162,7 @@ impl<'a> TokenFactory<'a> {
                 return Err(BasePrecompileError::revert(ITokenFactory::ZeroAddress {}));
             }
             token.total_supply.write(p.initialSupply)?;
-            // TODO: Check if should emit a Transfer event 
+            // TODO: Check if should emit a Transfer event
             token.set_balance(p.initialSupplyRecipient, p.initialSupply)?;
         }
 

--- a/crates/common/precompiles/src/token/factory/storage.rs
+++ b/crates/common/precompiles/src/token/factory/storage.rs
@@ -162,6 +162,7 @@ impl<'a> TokenFactory<'a> {
                 return Err(BasePrecompileError::revert(ITokenFactory::ZeroAddress {}));
             }
             token.total_supply.write(p.initialSupply)?;
+            // TODO: Check if should emit a Transfer event 
             token.set_balance(p.initialSupplyRecipient, p.initialSupply)?;
         }
 

--- a/crates/common/precompiles/src/token/factory/storage.rs
+++ b/crates/common/precompiles/src/token/factory/storage.rs
@@ -45,7 +45,7 @@ pub const VARIANT_SECURITY: u8 = 3;
 /// is deployed at the address (which is the full `isB20` check).
 pub fn has_b20_prefix(addr: &Address) -> bool {
     let b = addr.as_slice();
-    b[0] == 0xb0 && matches!(b[1], 0x20 | 0x21 | 0x22) && b[2..12] == [0u8; 10]
+    b[0] == 0xb0 && matches!(b[1], 0x20..=0x22) && b[2..12] == [0u8; 10]
 }
 
 /// Returns the variant discriminant for `addr` based on its address prefix.

--- a/crates/common/precompiles/src/token/mod.rs
+++ b/crates/common/precompiles/src/token/mod.rs
@@ -1,7 +1,7 @@
 //! Native precompiles for Base-native tokens (B-20).
 
 mod abi;
-pub use abi::IDefaultToken;
+pub use abi::{IDefaultToken, ITokenFactory};
 
 mod common;
 pub use common::{
@@ -12,4 +12,12 @@ pub use common::{
 mod default_token;
 pub use default_token::{
     DEFAULT_TOKEN_ADDRESS, DefaultToken, DefaultTokenEvm, DefaultTokenStorage,
+};
+
+mod factory;
+pub use factory::{
+    DEFAULT_PREFIX, FACTORY_ADDRESS, RESERVED_SIZE, SECURITY_PREFIX, STABLECOIN_PREFIX,
+    TokenFactory, TokenFactoryEvm, VARIANT_DEFAULT, VARIANT_NONE, VARIANT_SECURITY,
+    VARIANT_STABLECOIN, compute_default_address, compute_security_address,
+    compute_stablecoin_address, has_b20_prefix, variant_of,
 };

--- a/etc/docker/devnet-env
+++ b/etc/docker/devnet-env
@@ -183,7 +183,7 @@ L2_CHAIN_ID=84538453
 L2_BASE_AZUL_BLOCK=20
 # Optional: set to a non-negative block number to schedule Base Beryl in devnet.
 # Leave unset to avoid setting base.beryl during genesis generation.
-L2_BASE_BERYL_BLOCK=
+L2_BASE_BERYL_BLOCK=21
 
 # Metering Resource Limits
 # Whole-block budgets for gas/state-root/DA, plus a per-flashblock execution budget.

--- a/etc/scripts/devnet/check-factory-live.sh
+++ b/etc/scripts/devnet/check-factory-live.sh
@@ -1,0 +1,274 @@
+#!/usr/bin/env bash
+# check-factory-live.sh — end-to-end validation of the B-20 TokenFactory precompile
+# against a running devnet node using real cast transactions.
+#
+# Prerequisites:
+#   • Node running at RPC_URL (default: http://localhost:8545)
+#   • cast (foundry) in PATH
+#
+# Usage:
+#   ./check-factory-live.sh [rpc-url]
+#
+# Examples:
+#   ./check-factory-live.sh
+#   ./check-factory-live.sh http://localhost:8545
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# ── Colours ───────────────────────────────────────────────────────────────────
+RED='\033[0;31m'; GREEN='\033[0;32m'; CYAN='\033[0;36m'; YELLOW='\033[0;33m'; NC='\033[0m'
+
+pass() {
+    echo -e "${GREEN}  [PASS] $1${NC}"
+    if [[ $# -gt 1 ]]; then shift; echo -e "         $*"; fi
+}
+fail() {
+    echo -e "${RED}  [FAIL] $1${NC}" >&2
+    if [[ $# -gt 1 ]]; then shift; echo -e "         $*" >&2; fi
+    exit 1
+}
+section() { echo -e "\n${CYAN}=== $1 ===${NC}"; }
+info()    { echo -e "${YELLOW}  →  $1${NC}"; }
+
+# ── Config ────────────────────────────────────────────────────────────────────
+
+# Source devnet accounts if the env file exists
+ENV_FILE="$REPO_ROOT/etc/docker/devnet-env"
+[[ -f "$ENV_FILE" ]] && source "$ENV_FILE"
+
+RPC_URL="${1:-${L2_CLIENT_RPC_URL:-http://localhost:8545}}"
+
+# Pick the first account pair that actually has ETH on this node.
+# The devnet genesis may fund different accounts than the standard Anvil set.
+ALICE_ADDR=""
+ALICE_KEY=""
+BOB_ADDR=""
+
+declare -a CANDIDATE_PAIRS=(
+    "${ANVIL_ACCOUNT_7_ADDR:-}:${ANVIL_ACCOUNT_7_KEY:-}"
+    "${ANVIL_ACCOUNT_2_ADDR:-}:${ANVIL_ACCOUNT_2_KEY:-}"
+    "${ANVIL_ACCOUNT_4_ADDR:-}:${ANVIL_ACCOUNT_4_KEY:-}"
+    "${ANVIL_ACCOUNT_0_ADDR:-0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266}:${ANVIL_ACCOUNT_0_KEY:-0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80}"
+)
+
+for pair in "${CANDIDATE_PAIRS[@]}"; do
+    addr="${pair%%:*}"; key="${pair##*:}"
+    [[ -z "$addr" || -z "$key" ]] && continue
+    bal=$(cast balance --rpc-url "$RPC_URL" "$addr" 2>/dev/null || echo "0")
+    # Compare as string: non-zero and not empty means funded
+    if [[ -n "$bal" && "$bal" != "0" ]]; then
+        ALICE_ADDR="$addr"; ALICE_KEY="$key"; break
+    fi
+done
+[[ -n "$ALICE_ADDR" ]] || { echo "No funded account found — check devnet genesis"; exit 1; }
+
+# Bob: pick a different funded account for the transfer recipient
+declare -a BOB_CANDIDATES=(
+    "${ANVIL_ACCOUNT_8_ADDR:-}:${ANVIL_ACCOUNT_8_KEY:-}"
+    "${ANVIL_ACCOUNT_3_ADDR:-}:${ANVIL_ACCOUNT_3_KEY:-}"
+    "${ANVIL_ACCOUNT_1_ADDR:-0x70997970C51812dc3A010C7d01b50e0d17dc79C8}:${ANVIL_ACCOUNT_1_KEY:-}"
+)
+for pair in "${BOB_CANDIDATES[@]}"; do
+    addr="${pair%%:*}"
+    [[ -z "$addr" || "$addr" == "$ALICE_ADDR" ]] && continue
+    BOB_ADDR="$addr"; break
+done
+[[ -n "$BOB_ADDR" ]] || BOB_ADDR="0x70997970C51812dc3A010C7d01b50e0d17dc79C8"
+
+# Factory precompile (singleton, fixed at chain genesis)
+FACTORY="0xb02f000000000000000000000000000000000000"
+
+# Token creation parameters
+TOKEN_NAME="Base USD"
+TOKEN_SYMBOL="BUSD"
+TOKEN_DECIMALS=6
+INITIAL_SUPPLY=1000000          # 1 BUSD (6 decimals → 1.000000)
+SUPPLY_CAP=1000000000000        # 1 000 000 BUSD
+# Unique salt per run so repeated executions always create a fresh token.
+SALT="0x$(cast keccak "check-factory-live-$$-$(date +%s)" | sed 's/0x//')"
+
+# Transfer amount: 300_000 micro-BUSD = 0.3 BUSD
+TRANSFER_AMOUNT=300000
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+# Trim whitespace, quotes, and cast's pretty-print suffix (e.g. "1000000 [1e6]" → "1000000")
+trim() { echo "$1" | tr -d '"' | sed 's/ \[.*\]$//' | xargs; }
+
+# cast call wrapper — always read-only, does not consume gas
+ccall() {
+    local addr="$1"; local sig="$2"; shift 2
+    cast call --rpc-url "$RPC_URL" "$addr" "$sig" "$@" 2>&1
+}
+
+
+assert_eq() {
+    local label="$1" expected="$2" actual="$3"
+    if [[ "$actual" == "$expected" ]]; then
+        pass "$label" "expected=$expected actual=$actual"
+    else
+        fail "$label" "expected=$expected  actual=$actual"
+    fi
+}
+
+# ── 0. Pre-flight ─────────────────────────────────────────────────────────────
+
+section "0/5  Pre-flight checks"
+
+command -v cast >/dev/null 2>&1 || fail "cast not found — install foundry: https://getfoundry.sh"
+
+CHAIN_ID=$(cast chain-id --rpc-url "$RPC_URL" 2>&1) || \
+    fail "Node not reachable at $RPC_URL — start the devnet first (just devnet up)"
+info "Connected to chain $CHAIN_ID at $RPC_URL"
+pass "node is reachable"
+
+ALICE_BAL=$(cast balance --rpc-url "$RPC_URL" "$ALICE_ADDR" 2>&1)
+[[ -n "$ALICE_BAL" && "$ALICE_BAL" != "0" ]] || \
+    fail "Alice ($ALICE_ADDR) has no ETH — check genesis allocation"
+pass "Alice is funded ($ALICE_ADDR)" "balance=$(cast from-wei "$ALICE_BAL") ETH"
+
+# ── 1. Address prediction ─────────────────────────────────────────────────────
+
+section "1/5  Predict token address (read-only)"
+
+PREDICTED=$(ccall "$FACTORY" \
+    "predictDefaultAddress(address,bytes32)(address)" \
+    "$ALICE_ADDR" "$SALT") || fail "predictDefaultAddress call failed" "$PREDICTED"
+PREDICTED=$(trim "$PREDICTED")
+[[ "$PREDICTED" =~ ^0x[0-9a-fA-F]{40}$ ]] || \
+    fail "predictDefaultAddress returned bad address" "$PREDICTED"
+info "Predicted token address: $PREDICTED"
+pass "predictDefaultAddress returned a valid address"
+
+# Verify the prefix encodes variant=DEFAULT (first byte 0xb0, second byte 0x20)
+PREFIX=$(echo "${PREDICTED:2:4}" | tr '[:upper:]' '[:lower:]')
+[[ "$PREFIX" == "b020" ]] || \
+    fail "Token address does not have DEFAULT prefix (0xb020...)" "got prefix: 0x$PREFIX"
+pass "Address prefix is 0xb020 (DEFAULT variant)"
+
+# isB20 must be false before creation (no code yet)
+IS_B20_BEFORE=$(ccall "$FACTORY" "isB20(address)(bool)" "$PREDICTED")
+IS_B20_BEFORE=$(trim "$IS_B20_BEFORE")
+assert_eq "isB20 is false before creation" "false" "$IS_B20_BEFORE"
+
+# ── 2. Create token ───────────────────────────────────────────────────────────
+
+section "2/5  Create token (real transaction)"
+
+# Build the CreateDefaultTokenParams tuple.
+# Field order: name,symbol,decimals,admin,capabilities,initialSupply,
+#              initialSupplyRecipient,transferPolicyId,supplyCap,
+#              minimumRedeemable,contractURI,salt
+PARAMS="(\"$TOKEN_NAME\",\"$TOKEN_SYMBOL\",$TOKEN_DECIMALS,$ALICE_ADDR,3,$INITIAL_SUPPLY,$ALICE_ADDR,1,$SUPPLY_CAP,0,\"ipfs://check-factory-live\",$SALT)"
+
+info "Sending createDefault transaction …"
+TX_OUTPUT=$(cast send \
+    --rpc-url "$RPC_URL" \
+    --private-key "$ALICE_KEY" \
+    --json \
+    --confirmations 2 \
+    "$FACTORY" \
+    "createDefault((string,string,uint8,address,uint256,uint256,address,uint64,uint256,uint256,string,bytes32))" \
+    "$PARAMS") || fail "createDefault transaction failed" "$TX_OUTPUT"
+
+TX_HASH=$(echo "$TX_OUTPUT" | grep -o '"transactionHash":"[^"]*"' | cut -d'"' -f4)
+TX_STATUS=$(echo "$TX_OUTPUT" | grep -o '"status":"[^"]*"' | cut -d'"' -f4)
+[[ "$TX_STATUS" == "0x1" ]] || fail "createDefault reverted (status=$TX_STATUS)" "tx=$TX_HASH"
+info "Transaction: $TX_HASH  (status=$TX_STATUS)"
+pass "createDefault transaction mined and succeeded"
+
+# The token address must match the prediction
+TOKEN="$PREDICTED"
+info "Token deployed at: $TOKEN"
+
+# ── 3. Verify factory state ───────────────────────────────────────────────────
+
+section "3/5  Verify factory state (read-only calls)"
+
+# isB20 must now be true
+IS_B20=$(ccall "$FACTORY" "isB20(address)(bool)" "$TOKEN")
+IS_B20=$(trim "$IS_B20")
+assert_eq "isB20 is true after creation" "true" "$IS_B20"
+
+# variantOf must return 1 (VARIANT_DEFAULT)
+VARIANT=$(ccall "$FACTORY" "variantOf(address)(uint8)" "$TOKEN")
+VARIANT=$(trim "$VARIANT")
+assert_eq "variantOf returns 1 (DEFAULT)" "1" "$VARIANT"
+
+pass "Factory state is correct"
+
+# ── 4. Verify token metadata ──────────────────────────────────────────────────
+
+section "4/5  Verify token metadata (calls to token address)"
+
+NAME=$(trim "$(ccall "$TOKEN" "name()(string)")")
+assert_eq "name()" "$TOKEN_NAME" "$NAME"
+
+SYMBOL=$(trim "$(ccall "$TOKEN" "symbol()(string)")")
+assert_eq "symbol()" "$TOKEN_SYMBOL" "$SYMBOL"
+
+DECIMALS=$(trim "$(ccall "$TOKEN" "decimals()(uint8)")")
+assert_eq "decimals()" "$TOKEN_DECIMALS" "$DECIMALS"
+
+TOTAL_SUPPLY=$(trim "$(ccall "$TOKEN" "totalSupply()(uint256)")")
+assert_eq "totalSupply()" "$INITIAL_SUPPLY" "$TOTAL_SUPPLY"
+
+ALICE_TOKEN_BAL=$(trim "$(ccall "$TOKEN" "balanceOf(address)(uint256)" "$ALICE_ADDR")")
+assert_eq "balanceOf(alice) = initialSupply" "$INITIAL_SUPPLY" "$ALICE_TOKEN_BAL"
+
+BOB_TOKEN_BAL=$(trim "$(ccall "$TOKEN" "balanceOf(address)(uint256)" "$BOB_ADDR")")
+assert_eq "balanceOf(bob) = 0 before transfer" "0" "$BOB_TOKEN_BAL"
+
+pass "All metadata fields match creation parameters"
+
+# ── 5. Transfer tokens ────────────────────────────────────────────────────────
+
+section "5/5  Transfer tokens (real transaction)"
+
+info "Sending transfer($BOB_ADDR, $TRANSFER_AMOUNT) from Alice …"
+XFER_OUTPUT=$(cast send \
+    --rpc-url "$RPC_URL" \
+    --private-key "$ALICE_KEY" \
+    --json \
+    --confirmations 2 \
+    "$TOKEN" \
+    "transfer(address,uint256)" \
+    "$BOB_ADDR" "$TRANSFER_AMOUNT") || fail "transfer transaction failed" "$XFER_OUTPUT"
+
+XFER_HASH=$(echo "$XFER_OUTPUT" | grep -o '"transactionHash":"[^"]*"' | cut -d'"' -f4)
+XFER_STATUS=$(echo "$XFER_OUTPUT" | grep -o '"status":"[^"]*"' | cut -d'"' -f4)
+[[ "$XFER_STATUS" == "0x1" ]] || fail "transfer reverted (status=$XFER_STATUS)" "tx=$XFER_HASH"
+info "Transaction: $XFER_HASH  (status=$XFER_STATUS)"
+pass "transfer transaction mined and succeeded"
+
+# Verify balances changed correctly
+EXPECTED_ALICE=$((INITIAL_SUPPLY - TRANSFER_AMOUNT))
+ALICE_BAL_AFTER=$(trim "$(ccall "$TOKEN" "balanceOf(address)(uint256)" "$ALICE_ADDR")")
+assert_eq "Alice balance after transfer" "$EXPECTED_ALICE" "$ALICE_BAL_AFTER"
+
+BOB_BAL_AFTER=$(trim "$(ccall "$TOKEN" "balanceOf(address)(uint256)" "$BOB_ADDR")")
+assert_eq "Bob balance after transfer" "$TRANSFER_AMOUNT" "$BOB_BAL_AFTER"
+
+# Total supply must be unchanged by a transfer
+TOTAL_AFTER=$(trim "$(ccall "$TOKEN" "totalSupply()(uint256)")")
+assert_eq "totalSupply unchanged after transfer" "$INITIAL_SUPPLY" "$TOTAL_AFTER"
+
+pass "Balances updated correctly; total supply preserved"
+
+# ── Summary ───────────────────────────────────────────────────────────────────
+
+echo ""
+echo -e "${GREEN}All live checks passed.${NC}"
+echo ""
+echo "Token: $TOKEN  (chain $CHAIN_ID, RPC $RPC_URL)"
+echo ""
+echo "Verified:"
+echo "  • predictDefaultAddress → deterministic 0xb020-prefix address"
+echo "  • isB20 = false before creation, true after"
+echo "  • variantOf = 1 (DEFAULT)"
+echo "  • name='$TOKEN_NAME'  symbol='$TOKEN_SYMBOL'  decimals=$TOKEN_DECIMALS"
+echo "  • totalSupply=$INITIAL_SUPPLY  balanceOf(alice)=$ALICE_TOKEN_BAL"
+echo "  • transfer($TRANSFER_AMOUNT to bob) → alice=$EXPECTED_ALICE  bob=$TRANSFER_AMOUNT"
+echo "  • totalSupply unchanged after transfer"


### PR DESCRIPTION
## Summary

- Adds the singleton `TokenFactory` precompile at `0xb02f000000000000000000000000000000000000`, activated at Beryl, supporting `createDefault`, `predict{Default,Stablecoin,Security}Address`, `isB20`, and `variantOf`.
- Wires `set_precompile_lookup` in `BasePrecompileInstaller` so every call to a `0xb020/21/22`-prefix address is dynamically routed to `DefaultToken` (address-specific storage) without pre-registration in the precompile map.
- Adds `DefaultTokenStorage::from_address` for factory-side token initialization and `ITokenFactory` ABI bindings.
- Removes dead `DefaultTokenEvm::precompile()`/`run()` pair (replaced by `create_precompile(addr)`).
- Enables Beryl at devnet block 21; moves `check-factory-live.sh` E2E validation script to `etc/scripts/devnet/`.

## Test plan

- [ ] Unit tests in `token/factory/storage.rs` cover: deterministic address derivation, variant prefix correctness, reserved-range guard, collision guard, metadata initialization, initial-supply minting, event emission.
- [ ] Integration tests in `storage.rs::integration` cover: metadata round-trip, transfer, mint, supply-cap enforcement, and full create→transfer→mint lifecycle.
- [ ] `cargo test -p base-common-precompiles` passes with zero warnings.
- [ ] `cargo check -p base-common-precompiles` produces no warnings or errors.
- [ ] Start devnet (`just devnet up`) and run `./etc/scripts/devnet/check-factory-live.sh` to validate address prediction, creation, `isB20`, `variantOf`, metadata, and transfer end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)