### PR TITLE
feat(vibenet): public devnet stack (Caddy + Next.js UI)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ docs/specs/.vocs/
 *.log
 .vscode/
 *.env
+etc/vibenet/vibenet-env
 # SP1 ELF binaries are built on demand and not committed.
 crates/proof/succinct/elf/range-elf-embedded
 crates/proof/succinct/elf/aggregation-elf

--- a/etc/docker/Justfile
+++ b/etc/docker/Justfile
@@ -74,6 +74,143 @@ transfer-leader to='':
 conductor:
     cargo run --quiet -p basectl -- conductor
 
+# Vibenet: public devnet — single sequencer + Caddy gateway + Next.js UI
+# + faucet + contract deployer. Requires etc/vibenet/vibenet-env (copy
+# from vibenet-env.example and fill in secrets before running).
+#
+# On production hosts that have had a Cloudflare Origin CA certificate
+# installed at /etc/vibenet/tls/origin.{crt,key}, the Caddy overlay is
+# auto-included to expose the :443 TLS listener that Cloudflare connects
+# to. Laptops without that cert get the local-dev stack only (loopback ports):
+#   http://localhost:18080  UI (landing / faucet / explorer)
+#   ws://localhost:18081    WebSocket RPC (base-client direct)
+#   http://localhost:18082  HTTP RPC (proxyd)
+#
+# The UI is served by the base/ui Next.js app. Either clone that repo as a
+# sibling of this one (so `../ui` exists) and we'll build the image from
+# source, or set VIBENET_UI_IMAGE to pull a pre-built image instead:
+#   VIBENET_UI_IMAGE=ghcr.io/base/ui:main just vibe
+vibe: vibe-down _build-setup-image (_build-rust-images "devnet" "dev")
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if [ ! -f etc/vibenet/vibenet-env ]; then
+      echo "ERROR: etc/vibenet/vibenet-env missing. Copy from etc/vibenet/vibenet-env.example." >&2
+      exit 1
+    fi
+    # Verify sibling base/ui repo exists unless a pre-built image is specified.
+    # When VIBENET_UI_IMAGE is set we skip `--build` so docker compose doesn't
+    # try to resolve the next-app `build.context` path that may not exist on
+    # disk; it pulls/uses the pinned image instead.
+    build_flag="--build"
+    if [ -n "${VIBENET_UI_IMAGE:-}" ]; then
+      build_flag="--pull missing"
+    elif [ ! -f "$(pwd)/../ui/package.json" ]; then
+      echo "ERROR: base/ui repo not found at $(pwd)/../ui" >&2
+      echo "  Clone it: git clone git@github.com:base/ui.git $(pwd)/../ui" >&2
+      echo "  Or use a pre-built image: VIBENET_UI_IMAGE=ghcr.io/base/ui:main just vibe" >&2
+      exit 1
+    fi
+    export VIBENET_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+    export VIBENET_COMMIT="$(git rev-parse --short HEAD)"
+    caddy_overlay=
+    if [ -f /etc/vibenet/tls/origin.crt ]; then
+      caddy_overlay="-f etc/vibenet/docker-compose.caddy.yml"
+      echo "[vibe] Caddy TLS overlay enabled (/etc/vibenet/tls/origin.crt found)"
+    fi
+    docker compose \
+      --env-file etc/docker/devnet-env \
+      --env-file etc/vibenet/vibenet-env \
+      -f etc/docker/docker-compose.yml \
+      -f etc/vibenet/docker-compose.vibenet.yml \
+      $caddy_overlay \
+      up -d $build_flag
+
+# Stops vibenet and deletes all data. `-v` wipes the named volumes so the
+# vibescan SQLite DB and shared contracts.json don't survive a chain reset.
+vibe-down:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    caddy_overlay=
+    if [ -f /etc/vibenet/tls/origin.crt ]; then
+      caddy_overlay="-f etc/vibenet/docker-compose.caddy.yml"
+    fi
+    docker compose \
+      --env-file etc/docker/devnet-env \
+      --env-file etc/vibenet/vibenet-env \
+      -f etc/docker/docker-compose.yml \
+      -f etc/vibenet/docker-compose.vibenet.yml \
+      $caddy_overlay \
+      down --remove-orphans -v || true
+    docker run --rm -v "$(pwd)/.devnet:/devnet" alpine sh -c 'rm -rf /devnet/*' || true
+
+# Rebuild just the Next.js UI container. Leaves the chain running so block
+# history, explorer index, and deployed contracts all survive.
+# Use this when iterating on:
+#   - base/ui source (pages, API routes, styles)
+#   - etc/vibenet/config/vibenet.yaml (also re-runs vibenet-config-renderer)
+#
+# For chain-level changes (base-client, setup, proxyd) you still need a
+# full `just vibe` to wipe state and start fresh.
+vibe-ui:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if [ ! -f etc/vibenet/vibenet-env ]; then
+      echo "ERROR: etc/vibenet/vibenet-env missing." >&2
+      exit 1
+    fi
+    export VIBENET_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+    export VIBENET_COMMIT="$(git rev-parse --short HEAD)"
+    caddy_overlay=
+    if [ -f /etc/vibenet/tls/origin.crt ]; then
+      caddy_overlay="-f etc/vibenet/docker-compose.caddy.yml"
+    fi
+    docker compose \
+      --env-file etc/docker/devnet-env \
+      --env-file etc/vibenet/vibenet-env \
+      -f etc/docker/docker-compose.yml \
+      -f etc/vibenet/docker-compose.vibenet.yml \
+      $caddy_overlay \
+      up -d --no-deps --build --force-recreate next-app
+    docker compose \
+      --env-file etc/docker/devnet-env \
+      --env-file etc/vibenet/vibenet-env \
+      -f etc/docker/docker-compose.yml \
+      -f etc/vibenet/docker-compose.vibenet.yml \
+      $caddy_overlay \
+      up -d --no-deps --force-recreate vibenet-config-renderer
+
+# Stream logs from vibenet containers (optionally specify container names)
+vibe-logs *containers:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    caddy_overlay=
+    if [ -f /etc/vibenet/tls/origin.crt ]; then
+      caddy_overlay="-f etc/vibenet/docker-compose.caddy.yml"
+    fi
+    docker compose \
+      --env-file etc/docker/devnet-env \
+      --env-file etc/vibenet/vibenet-env \
+      -f etc/docker/docker-compose.yml \
+      -f etc/vibenet/docker-compose.vibenet.yml \
+      $caddy_overlay \
+      logs -f {{ containers }}
+
+# Shows vibenet container status
+vibe-ps *services:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    caddy_overlay=
+    if [ -f /etc/vibenet/tls/origin.crt ]; then
+      caddy_overlay="-f etc/vibenet/docker-compose.caddy.yml"
+    fi
+    docker compose \
+      --env-file etc/docker/devnet-env \
+      --env-file etc/vibenet/vibenet-env \
+      -f etc/docker/docker-compose.yml \
+      -f etc/vibenet/docker-compose.vibenet.yml \
+      $caddy_overlay \
+      ps {{ services }}
+
 # Stops devnet+ingress, deletes data, and starts fresh with full ingress stack
 ingress: ingress-down _build-setup-image (_build-rust-images "ingress" "dev")
     docker compose {{ _env }} {{ _ha }} -f etc/docker/docker-compose.ingress.yml up -d --no-build

--- a/etc/scripts/devnet/setup-l1.sh
+++ b/etc/scripts/devnet/setup-l1.sh
@@ -54,6 +54,20 @@ echo "=== Generating Execution Layer Genesis ==="
 export CHAIN_ID GENESIS_TIME_HEX BALANCE
 
 envsubst < "$TEMPLATE_DIR/l1-el-genesis.json.template" > "$OUTPUT_DIR/el/genesis.json"
+
+# Inject faucet address with a large starting balance. Enabled whenever FAUCET_ADDR is set.
+if [ -n "${FAUCET_ADDR:-}" ]; then
+  FAUCET_BALANCE="0x84595161401484a000000"  # 10,000,000 ETH
+  echo "Injecting FAUCET_ADDR $FAUCET_ADDR into L1 genesis with 10M ETH..."
+  TMP_L1=$(mktemp)
+  jq --arg addr "$FAUCET_ADDR" --arg bal "$FAUCET_BALANCE" \
+    '.alloc[$addr] = {"balance": $bal}' \
+    "$OUTPUT_DIR/el/genesis.json" > "$TMP_L1"
+  mv "$TMP_L1" "$OUTPUT_DIR/el/genesis.json"
+fi
+
+# NOTE: L1 intentionally keeps the standard anvil account allocs funded.
+
 jq '.config' "$OUTPUT_DIR/el/genesis.json" > "$OUTPUT_DIR/el/chain-config.json"
 
 echo "EL genesis written to $OUTPUT_DIR/el/genesis.json"

--- a/etc/vibenet/README.md
+++ b/etc/vibenet/README.md
@@ -1,0 +1,178 @@
+# vibenet
+
+A public, ephemeral devnet for showing off in-flight Base features.
+
+- Single L1 (anvil) + single L2 sequencer (same as `just up-single`)
+- Optional public TLS gateway (Caddy) for the hosted environment
+- Per-method JSON-RPC rate limiting at proxyd
+- Open RPC (no API key)
+- One prefunded faucet address; standard anvil EOAs are swept into it
+- Test contracts (`USDV` — public-mint ERC-20, `NFV` — public-mint
+  ERC-721) auto-deployed on boot
+- Landing page + faucet UI + block explorer, all served by the Next.js
+  app from the [`base/ui`](https://github.com/base/ui) repo
+
+## Public hostnames
+
+| Hostname                   | What it serves              |
+| -------------------------- | --------------------------- |
+| `vibes.base.org`           | Landing page                |
+| `rpc.vibes.base.org`       | JSON-RPC + WebSocket        |
+| `explorer.vibes.base.org`  | Block explorer              |
+| `faucet.vibes.base.org`    | Faucet UI + drip API        |
+
+All UI subdomains route to the same Next.js app; the app reads the
+`Host` header and rewrites internally to the right page.
+
+## Quick links
+
+- Host env template: [`vibenet-env.example`](./vibenet-env.example)
+- UI content (editable per branch): [`config/vibenet.yaml`](./config/vibenet.yaml)
+- Contract list (editable per branch): [`setup/contracts.yaml`](./setup/contracts.yaml)
+- Caddyfile (production gateway): [`caddy/Caddyfile`](./caddy/Caddyfile)
+
+## Running locally
+
+Vibenet can run locally or on a hosted environment. Local runs skip the
+`:443` Caddy overlay entirely — `just vibe` only enables it on hosts
+that have TLS files installed under `/etc/vibenet/tls`.
+
+```bash
+# One-time: clone base/ui as a sibling of this repo
+git clone git@github.com:base/ui.git ../ui
+
+# One-time: copy the example env and fill in values. FAUCET_PRIVATE_KEY /
+# FAUCET_ADDR are required; the public listener knobs are only used in
+# production.
+cp etc/vibenet/vibenet-env.example etc/vibenet/vibenet-env
+${EDITOR} etc/vibenet/vibenet-env
+
+just vibe
+```
+
+The Next.js container publishes loopback-only host ports:
+
+| URL                                 | Service                                       |
+| ----------------------------------- | --------------------------------------------- |
+| `http://localhost:18080/`           | Landing page                                  |
+| `http://localhost:18080/faucet`     | Faucet UI + API                               |
+| `http://localhost:18080/explorer`   | Block explorer                                |
+| `http://localhost:18080/api/...`    | Faucet + explorer + config/contracts APIs     |
+| `ws://localhost:18081/`             | WebSocket RPC (base-client direct)            |
+| `http://localhost:18082/`           | HTTP RPC (proxyd)                             |
+
+Override the bindings with `VIBENET_HOST_PORT` / `VIBENET_WS_HOST_PORT` /
+`VIBENET_RPC_HOST_PORT` in `vibenet-env` if those collide with something
+else on your machine.
+
+Quick smoke test once `just vibe` is up:
+
+```bash
+curl -s http://localhost:18080/api/vibenet/config | jq .title
+
+curl -s -X POST -H 'Content-Type: application/json' \
+  --data '{"jsonrpc":"2.0","method":"eth_chainId","params":[],"id":1}' \
+  http://localhost:18082
+```
+
+To skip cloning `base/ui` and use a pre-built image instead:
+
+```bash
+VIBENET_UI_IMAGE=ghcr.io/base/ui:main just vibe
+```
+
+## Iterating on the UI
+
+Use `just vibe-ui` to rebuild just the Next.js container without resetting
+the chain. Block history, deployed contracts, and the explorer index all
+survive. The vibenet-config-renderer is also restarted so changes to
+`config/vibenet.yaml` take effect.
+
+## Customizing what appears on the landing page
+
+Edit [`config/vibenet.yaml`](./config/vibenet.yaml). The
+`vibenet-config-renderer` container reads it at startup, converts to
+JSON, and writes it to a shared volume that the Next.js app serves at
+`/api/vibenet/config`. No image rebuild required.
+
+Fields:
+
+- `title`, `subtitle` — page header
+- `features` — array of `{title, description, link?}` cards
+- `branch`, `commit` — auto-overwritten by `just vibe` from `git rev-parse`
+
+## Customizing deployed contracts
+
+Edit [`setup/contracts.yaml`](./setup/contracts.yaml) and drop any new
+Solidity sources into [`setup/contracts/src/`](./setup/contracts/). Each
+entry is:
+
+```yaml
+- name: myDemo                              # key in contracts.json
+  artifact: src/MyDemo.sol:MyDemo           # forge target
+  args: ["0x1234...", "{{ usdv }}"]         # optional; {{ }} resolves from
+                                            # previously-deployed entries
+```
+
+Deployed addresses are published at `/api/vibenet/contracts` and surfaced
+on the landing page automatically.
+
+## Faucet integration
+
+The faucet's hot wallet (`FAUCET_ADDR`) is prefunded on L1 via the
+genesis injection in `setup-l1.sh`, then topped up on L2 by `vibenet-setup`
+sweeping the standard anvil EOAs into it at boot.
+
+Drips supported:
+- ETH (`POST /api/vibenet/faucet/drip`)
+- USDV mint (`POST /api/vibenet/faucet/drip-usdv`) — calls `mint(addr, amount)`
+- NFV mint (`POST /api/vibenet/faucet/drip-nfv`) — calls `mint(addr)`
+
+## RPC access
+
+The RPC is currently open; no API key is required.
+
+```bash
+curl -s -X POST -H 'Content-Type: application/json' \
+  --data '{"jsonrpc":"2.0","method":"eth_chainId","params":[],"id":1}' \
+  https://rpc.vibes.base.org
+```
+
+WebSocket:
+
+```javascript
+new WebSocket("wss://rpc.vibes.base.org/ws");
+```
+
+Rate limits are configured in proxyd.
+
+## Components
+
+| Container                 | Image                                | Role |
+| ------------------------- | ------------------------------------ | ---- |
+| `next-app`                | `vibenet-ui:local` (built from `../ui`) | Landing page, faucet UI+API, block explorer (Next.js + better-sqlite3) |
+| `vibenet-setup`           | `vibenet-setup:local` (foundry)      | One-shot: waits for L2, sweeps anvil balances, deploys demo contracts |
+| `vibenet-config-renderer` | `mikefarah/yq`                       | Converts `vibenet.yaml` to `config.json` |
+| `proxyd`                  | `proxyd:local`                       | Per-method JSON-RPC rate limits |
+| `caddy` (prod only)       | `caddy:2.9-alpine`                   | TLS termination + subdomain routing |
+| `base-client/builder/...` | same as `just up-single`             | Core devnet |
+
+## File map
+
+```
+etc/vibenet/
+  README.md                            (this file)
+  vibenet-env.example                  host env template
+  docker-compose.vibenet.yml           overlay on etc/docker/docker-compose.yml
+  docker-compose.caddy.yml             prod-only overlay: Caddy TLS gateway
+  config/vibenet.yaml                  editable UI content
+  caddy/Caddyfile                      production TLS + subdomain routing
+  proxyd/proxyd-ratelimit.toml         per-method rate limits
+  setup/Dockerfile                     build image for foundry-based deployer
+  setup/contracts.yaml                 list of contracts to deploy
+  setup/contracts/                     foundry project: src/*.sol
+  setup/deploy-contracts.sh            entrypoint for vibenet-setup
+
+# UI source lives in a separate repo:
+../ui/                                 base/ui (Next.js app)
+```

--- a/etc/vibenet/caddy/Caddyfile
+++ b/etc/vibenet/caddy/Caddyfile
@@ -1,0 +1,36 @@
+# Caddy TLS termination + subdomain routing for vibenet.
+# Uses Cloudflare Origin CA certificate (not ACME) so Caddy never
+# needs to reach Let's Encrypt — works even if the host isn't directly
+# reachable from the internet (Cloudflare proxies traffic orange-cloud).
+
+(tls_cf) {
+  tls /etc/caddy/tls/origin.crt /etc/caddy/tls/origin.key
+}
+
+# Landing page, faucet UI/API, and block explorer.
+# Next.js proxy.ts reads the Host header and routes internally:
+#   vibes.base.org          → serves /  (landing)
+#   faucet.vibes.base.org   → rewrites to /faucet
+#   explorer.vibes.base.org → rewrites to /explorer/*
+vibes.base.org faucet.vibes.base.org explorer.vibes.base.org {
+  import tls_cf
+  reverse_proxy next-app:3000
+}
+
+# JSON-RPC (HTTP + WebSocket).
+# proxyd handles HTTP; base-client handles WebSocket upgrades directly.
+rpc.vibes.base.org {
+  import tls_cf
+
+  # WebSocket RPC. base-client's WS port is fixed at 8546 in
+  # etc/docker/devnet-env (L2_CLIENT_WS_PORT) — hardcoded here because
+  # Caddy env interpolation needs the var passed into the caddy container,
+  # and this value never changes per deployment.
+  handle /ws {
+    reverse_proxy base-client:8546
+  }
+
+  handle {
+    reverse_proxy proxyd:8080
+  }
+}

--- a/etc/vibenet/config/vibenet.yaml
+++ b/etc/vibenet/config/vibenet.yaml
@@ -1,0 +1,27 @@
+# Vibenet UI content + per-branch config.
+# This file is mounted into the nginx container and exposed at:
+#   https://vibes.base.org/config.json
+#
+# Edit this file and re-run `just vibe` (or just restart nginx-gateway) to
+# update what devs see. No rebuild of the UI is required.
+#
+# NOTE: The `branch` and `commit` fields are overwritten at container build
+# time by etc/vibenet/scripts/render-config.sh. Do not rely on values set
+# here for those two fields.
+
+title: "base vibenet"
+subtitle: "An ephemeral Base devnet for trying out in-flight features."
+
+# Things unique to this devnet branch. Each item has a title,
+# one-sentence description, and optional link. Keep the baseline vibenet
+# tools as a single card; branch owners can add their feature-specific
+# "what's new" cards above or below it.
+features:
+  - title: "Vibenet faucet + explorer"
+    description: "Request test funds, browse blocks, inspect transactions, and follow token activity."
+  - title: "What's new on this vibe"
+    description: "Branch-specific updates will show up here when a vibe is deployed to preview what's upcoming or experimental."
+
+# Override injected at build time. Do not edit.
+branch: "unknown"
+commit: "unknown"

--- a/etc/vibenet/docker-compose.caddy.yml
+++ b/etc/vibenet/docker-compose.caddy.yml
@@ -1,0 +1,41 @@
+# Production TLS + subdomain routing overlay for vibenet.
+#
+# Activated automatically by `just vibe` when Cloudflare Origin CA
+# certificates are present at /etc/vibenet/tls/origin.{crt,key}.
+#
+# Replaces the original docker-compose.public.yml nginx TLS overlay.
+# Caddy is strictly simpler: subdomain routing and TLS termination in
+# a single ~10-line Caddyfile with no template escaping required.
+#
+# Subdomain routing:
+#   vibes.base.org          → next-app:3000  (landing, config, contracts)
+#   faucet.vibes.base.org   → next-app:3000  (Next.js proxy.ts rewrites to /faucet)
+#   explorer.vibes.base.org → next-app:3000  (Next.js proxy.ts rewrites to /explorer)
+#   rpc.vibes.base.org      → proxyd:8080    (HTTP JSON-RPC)
+#   rpc.vibes.base.org/ws   → base-client:WS (WebSocket RPC upgrade)
+
+services:
+  caddy:
+    image: caddy:2.9-alpine
+    container_name: vibenet-caddy
+    ports:
+      - "${VIBENET_PUBLIC_BIND_ADDR:-0.0.0.0}:443:443"
+      - "${VIBENET_PUBLIC_BIND_ADDR:-0.0.0.0}:80:80"
+    volumes:
+      - ../vibenet/caddy/Caddyfile:/etc/caddy/Caddyfile:ro
+      - /etc/vibenet/tls/origin.crt:/etc/caddy/tls/origin.crt:ro
+      - /etc/vibenet/tls/origin.key:/etc/caddy/tls/origin.key:ro
+      - caddy-data:/data
+      - caddy-config:/config
+    depends_on:
+      next-app:
+        condition: service_started
+      proxyd:
+        condition: service_healthy
+    mem_limit: 256m
+    memswap_limit: 256m
+    restart: unless-stopped
+
+volumes:
+  caddy-data:
+  caddy-config:

--- a/etc/vibenet/docker-compose.vibenet.yml
+++ b/etc/vibenet/docker-compose.vibenet.yml
@@ -1,0 +1,174 @@
+# Vibenet overlay on top of etc/docker/docker-compose.yml.
+#
+# IMPORTANT: docker compose resolves all relative paths against the project
+# directory, which defaults to the directory of the first -f file
+# (etc/docker/). That means `./foo` and `../../bar` in THIS file are both
+# relative to etc/docker/, NOT etc/vibenet/.
+#
+# Layers on:
+#   - FAUCET_ADDR propagated into setup-l1 so the faucet EOA is prefunded on L1.
+#   - next-app: Next.js app serving landing, faucet UI+API, and block explorer.
+#     Built from the sibling base/ui repo (../../../ui from etc/docker/).
+#     Override with VIBENET_UI_IMAGE to pull a pre-built image instead.
+#   - vibenet-setup: one-shot. Sweeps anvil balances -> faucet on L2, then
+#     deploys demo contracts and writes /shared/contracts.json.
+#   - vibenet-config-renderer: renders vibenet.yaml -> config.json for the UI.
+#   - proxyd: per-method JSON-RPC rate limits.
+#   - base-client: WS port exposed directly (no nginx proxy).
+#
+# Public TLS + subdomain routing can be layered with docker-compose.caddy.yml.
+
+services:
+  # --- Prefund the faucet on L1 via the existing setup-l1 anvil genesis ----
+  setup-l1:
+    environment:
+      - FAUCET_ADDR=${FAUCET_ADDR}
+
+  # --- Defense-in-depth memory caps on long-running core services ----------
+  base-client:
+    mem_limit: 96g
+    memswap_limit: 96g
+    # Expose WebSocket RPC directly — no nginx proxy needed.
+    ports:
+      - "127.0.0.1:${VIBENET_WS_HOST_PORT:-18081}:${L2_CLIENT_WS_PORT}"
+  base-client-cl:
+    mem_limit: 16g
+    memswap_limit: 16g
+  base-builder:
+    mem_limit: 24g
+    memswap_limit: 24g
+  base-builder-cl:
+    mem_limit: 16g
+    memswap_limit: 16g
+  base-batcher:
+    mem_limit: 8g
+    memswap_limit: 8g
+
+  # --- Next.js app: landing page, faucet, block explorer -------------------
+  # Replaces nginx-gateway + vibenet-faucet + vibescan from the original Rust stack.
+  # Built from the sibling base/ui repo at ../../../ui (relative to etc/docker/).
+  # Set VIBENET_UI_IMAGE to skip the local build and pull a pre-built image:
+  #   VIBENET_UI_IMAGE=ghcr.io/base/ui:main just vibe
+  next-app:
+    image: ${VIBENET_UI_IMAGE:-vibenet-ui:local}
+    build:
+      context: ../../../ui
+      dockerfile: Dockerfile
+    container_name: vibenet-next-app
+    depends_on:
+      base-client:
+        condition: service_healthy
+      vibenet-config-renderer:
+        condition: service_completed_successfully
+    environment:
+      # Explorer indexer (background process inside the container)
+      - VIBESCAN_RPC_HTTP_URL=http://base-client:${L2_CLIENT_HTTP_PORT}
+      - VIBESCAN_RPC_WS_URL=ws://base-client:${L2_CLIENT_WS_PORT}
+      - VIBESCAN_CHAIN_ID=${L2_CHAIN_ID}
+      - VIBESCAN_DB_PATH=/data/vibescan.db
+      - VIBESCAN_START_BLOCK=${VIBESCAN_START_BLOCK:-0}
+      - VIBESCAN_BACKFILL_CONCURRENCY=${VIBESCAN_BACKFILL_CONCURRENCY:-16}
+      # Faucet signer
+      - VIBENET_FAUCET_RPC_URL=http://base-client:${L2_CLIENT_HTTP_PORT}
+      - VIBENET_FAUCET_CHAIN_ID=${L2_CHAIN_ID}
+      - VIBENET_FAUCET_PRIVATE_KEY=${FAUCET_PRIVATE_KEY}
+      - VIBENET_FAUCET_DRIP_WEI=${VIBENET_FAUCET_DRIP_WEI:-100000000000000000}
+      - VIBENET_FAUCET_IP_COOLDOWN_SECS=${VIBENET_FAUCET_IP_COOLDOWN_SECS:-3600}
+      - VIBENET_FAUCET_ADDR_COOLDOWN_SECS=${VIBENET_FAUCET_ADDR_COOLDOWN_SECS:-3600}
+      - VIBENET_FAUCET_USDV_DRIP_UNITS=${VIBENET_FAUCET_USDV_DRIP_UNITS:-1000000000}
+      # Rendered config + contract addresses (written by renderer/setup containers).
+      # VIBENET_CONTRACTS_PATH is read by both the faucet (to resolve the USDV
+      # token address before calling mint) and the /api/vibenet/contracts API
+      # route (to surface the deployed addresses on the landing page).
+      - VIBENET_CONFIG_PATH=/config/config.json
+      - VIBENET_CONTRACTS_PATH=/shared/contracts.json
+      # Branch/commit info surfaced in the landing page footer
+      - VIBENET_BRANCH=${VIBENET_BRANCH:-unknown}
+      - VIBENET_COMMIT=${VIBENET_COMMIT:-unknown}
+    ports:
+      # UI + faucet + explorer all on a single port for local dev.
+      # In production the caddy overlay routes subdomains to this port.
+      - "127.0.0.1:${VIBENET_HOST_PORT:-18080}:3000"
+    volumes:
+      - vibenet-shared:/shared:ro
+      - vibenet-config:/config:ro
+      - vibescan-data:/data
+    mem_limit: 1g
+    memswap_limit: 1g
+    restart: unless-stopped
+
+  # --- One-shot contract deployer ------------------------------------------
+  vibenet-setup:
+    image: vibenet-setup:local
+    build:
+      context: ../..
+      dockerfile: etc/vibenet/setup/Dockerfile
+    container_name: vibenet-setup
+    depends_on:
+      base-client:
+        condition: service_healthy
+    environment:
+      - L2_RPC_URL=http://base-client:${L2_CLIENT_HTTP_PORT}
+      - L2_CHAIN_ID=${L2_CHAIN_ID}
+      - FAUCET_ADDR=${FAUCET_ADDR}
+      - FAUCET_PRIVATE_KEY=${FAUCET_PRIVATE_KEY}
+      - OUT_FILE=/shared/contracts.json
+      - VIBENET_BRANCH=${VIBENET_BRANCH:-unknown}
+      - VIBENET_COMMIT=${VIBENET_COMMIT:-unknown}
+    volumes:
+      - vibenet-shared:/shared
+      - ../vibenet/setup/contracts.yaml:/setup/contracts.yaml:ro
+    entrypoint: ["/usr/local/bin/deploy-contracts.sh"]
+
+  # --- Renders vibenet.yaml into config.json for the UI --------------------
+  vibenet-config-renderer:
+    image: mikefarah/yq:4.44.3
+    container_name: vibenet-config-renderer
+    user: "0:0"
+    volumes:
+      - ../vibenet/config/vibenet.yaml:/in/vibenet.yaml:ro
+      - vibenet-config:/out
+    environment:
+      - VIBENET_BRANCH=${VIBENET_BRANCH:-unknown}
+      - VIBENET_COMMIT=${VIBENET_COMMIT:-unknown}
+    entrypoint:
+      - /bin/sh
+      - -c
+      - |
+        yq -o=json \
+          'with(.branch; . = strenv(VIBENET_BRANCH)) |
+           with(.commit; . = strenv(VIBENET_COMMIT))' \
+          /in/vibenet.yaml > /out/config.json
+        echo "Wrote /out/config.json"
+    restart: "no"
+
+  # --- proxyd: per-method JSON-RPC rate limits -----------------------------
+  proxyd:
+    image: proxyd:local
+    build:
+      context: .
+      dockerfile: Dockerfile.proxyd
+    container_name: vibenet-proxyd
+    depends_on:
+      base-client:
+        condition: service_healthy
+    ports:
+      # HTTP RPC exposed directly (WS goes straight to base-client above).
+      - "127.0.0.1:${VIBENET_RPC_HOST_PORT:-18082}:8080"
+    volumes:
+      - ../vibenet/proxyd/proxyd-ratelimit.toml:/config/proxyd-ratelimit.toml:ro
+    command: ["/config/proxyd-ratelimit.toml"]
+    healthcheck:
+      test: ["CMD", "curl", "-sf", "-X", "POST", "-H", "Content-Type: application/json", "-H", "X-Forwarded-For: 127.0.0.1", "--data", "{\"jsonrpc\":\"2.0\",\"method\":\"eth_chainId\",\"params\":[],\"id\":1}", "http://localhost:8080"]
+      interval: 5s
+      timeout: 5s
+      retries: 30
+      start_period: 10s
+    mem_limit: 512m
+    memswap_limit: 512m
+    restart: unless-stopped
+
+volumes:
+  vibenet-shared:
+  vibenet-config:
+  vibescan-data:

--- a/etc/vibenet/proxyd/proxyd-ratelimit.toml
+++ b/etc/vibenet/proxyd/proxyd-ratelimit.toml
@@ -1,0 +1,76 @@
+# proxyd config for vibenet - per-method rate limits applied after the
+# per-IP limits in the nginx gateway. 
+# routes eth_sendRawTransaction to the builder and
+# everything else to the client.
+
+[server]
+rpc_host = "0.0.0.0"
+rpc_port = 8080
+max_body_size_bytes = 10485760
+max_concurrent_rpcs = 100
+
+[backend]
+response_timeout_seconds = 30
+max_response_size_bytes = 5242880
+max_retries = 3
+out_of_service_seconds = 10
+
+[rate_limit]
+base_rate = 50
+base_interval = "1s"
+
+[rate_limit.method_overrides]
+[rate_limit.method_overrides.eth_sendRawTransaction]
+limit = 20
+interval = "1s"
+[rate_limit.method_overrides.eth_call]
+limit = 100
+interval = "1s"
+[rate_limit.method_overrides.eth_getLogs]
+limit = 20
+interval = "1s"
+
+[backends]
+[backends.builder]
+rpc_url = "http://base-builder:7545"
+max_rps = 100
+
+[backends.client]
+rpc_url = "http://base-client:8545"
+max_rps = 200
+
+[backend_groups]
+[backend_groups.builder]
+backends = ["builder"]
+
+[backend_groups.client]
+backends = ["client"]
+
+[rpc_method_mappings]
+eth_sendRawTransaction = "builder"
+eth_chainId = "client"
+eth_blockNumber = "client"
+eth_syncing = "client"
+eth_call = "client"
+eth_estimateGas = "client"
+eth_createAccessList = "client"
+eth_gasPrice = "client"
+eth_maxPriorityFeePerGas = "client"
+eth_feeHistory = "client"
+eth_getLogs = "client"
+eth_getBalance = "client"
+eth_getStorageAt = "client"
+eth_getTransactionCount = "client"
+eth_getCode = "client"
+eth_getProof = "client"
+eth_getBlockByHash = "client"
+eth_getBlockByNumber = "client"
+eth_getBlockTransactionCountByHash = "client"
+eth_getBlockTransactionCountByNumber = "client"
+eth_getTransactionByHash = "client"
+eth_getTransactionByBlockHashAndIndex = "client"
+eth_getTransactionByBlockNumberAndIndex = "client"
+eth_getTransactionReceipt = "client"
+net_version = "client"
+web3_clientVersion = "client"
+base_transactionStatus = "client"

--- a/etc/vibenet/setup/Dockerfile
+++ b/etc/vibenet/setup/Dockerfile
@@ -1,0 +1,42 @@
+# Vibenet setup image: foundry (forge + cast) + yq + jq + bash.
+# Pre-builds the demo contracts so container start only needs to broadcast.
+#
+# The foundry:stable image is debian-based, so we use apt for extras.
+
+FROM ghcr.io/foundry-rs/foundry:stable AS builder
+
+USER root
+WORKDIR /setup
+
+COPY etc/vibenet/setup/contracts/foundry.toml /setup/contracts/foundry.toml
+COPY etc/vibenet/setup/contracts/src/ /setup/contracts/src/
+
+RUN cd /setup/contracts && forge build --silent
+
+FROM ghcr.io/foundry-rs/foundry:stable
+
+USER root
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends bash bc curl ca-certificates jq \
+ && rm -rf /var/lib/apt/lists/*
+# yq has a static binary per-arch; pick the one that matches this container.
+RUN set -eux; \
+    case "$(uname -m)" in \
+      x86_64) YQ_ARCH=amd64 ;; \
+      aarch64|arm64) YQ_ARCH=arm64 ;; \
+      *) echo "unsupported architecture: $(uname -m)" >&2; exit 1 ;; \
+    esac; \
+    curl -fsSL -o /usr/local/bin/yq \
+      "https://github.com/mikefarah/yq/releases/download/v4.44.3/yq_linux_${YQ_ARCH}"; \
+    chmod +x /usr/local/bin/yq
+
+WORKDIR /setup
+
+# Bring in the already-built artifacts + sources (forge create needs both).
+COPY --from=builder /setup/contracts /setup/contracts
+
+COPY etc/vibenet/setup/contracts.yaml /setup/contracts.yaml
+COPY etc/vibenet/setup/deploy-contracts.sh /usr/local/bin/deploy-contracts.sh
+RUN chmod +x /usr/local/bin/deploy-contracts.sh
+
+ENTRYPOINT ["/usr/local/bin/deploy-contracts.sh"]

--- a/etc/vibenet/setup/contracts.yaml
+++ b/etc/vibenet/setup/contracts.yaml
@@ -1,0 +1,30 @@
+# Contracts deployed by vibenet-setup after the L2 chain is live.
+#
+# Each entry names a contract, its forge artifact identifier
+# (src/<file>.sol:<contract>), and optional constructor args (templating:
+# "{{ otherContract }}" resolves to a previously-deployed address).
+#
+# Output: every entry adds `{ name: address }` to /shared/contracts.json.
+#
+# To add a demo contract on a branch, drop a .sol file into
+# etc/vibenet/setup/contracts/src/ and add an entry here. Re-run `just vibe`.
+#
+# TODO: add canonical ERC-4337 EntryPoint v0.7 / v0.8 deploys. These require
+# pulling the audited bytecode (eth-infinitism/account-abstraction) and
+# CREATE2-ing to the canonical address; leaving as follow-up work.
+#
+# TODO: add the Coinbase Smart Wallet factory. The factory bytecode lives in
+# coinbase/smart-wallet and is CREATE2-deployable at a canonical address.
+# Leaving as follow-up work so we don't block vibenet on pulling that repo
+# into our docker build context.
+
+contracts:
+  # USDV (Vibe USD): public-mint ERC-20 with USDC-compatible 6 decimals.
+  # Replaces the older MockUSDC name so nobody mistakes it for real USDC.
+  - name: usdv
+    artifact: src/USDV.sol:USDV
+    args: []
+  # NFV (Non-Fungible Vibe): public-mint ERC-721 for NFT-flow demos.
+  - name: nfv
+    artifact: src/NFV.sol:NFV
+    args: []

--- a/etc/vibenet/setup/contracts/foundry.toml
+++ b/etc/vibenet/setup/contracts/foundry.toml
@@ -1,0 +1,7 @@
+[profile.default]
+src = "src"
+out = "out"
+libs = ["lib"]
+solc_version = "0.8.26"
+optimizer = true
+optimizer_runs = 200

--- a/etc/vibenet/setup/contracts/src/NFV.sol
+++ b/etc/vibenet/setup/contracts/src/NFV.sol
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+/// @title NFV - Non-Fungible Vibe
+/// @notice Minimal public-mint ERC-721 used on vibenet for demos. Anyone can
+///         mint the next token to any address. Not audited; no metadata.
+contract NFV {
+    string public constant name = "Non-Fungible Vibe";
+    string public constant symbol = "NFV";
+
+    uint256 public nextTokenId;
+
+    mapping(uint256 => address) private _owners;
+    mapping(address => uint256) private _balances;
+    mapping(uint256 => address) private _tokenApprovals;
+    mapping(address => mapping(address => bool)) private _operatorApprovals;
+
+    event Transfer(address indexed from, address indexed to, uint256 indexed tokenId);
+    event Approval(address indexed owner, address indexed approved, uint256 indexed tokenId);
+    event ApprovalForAll(address indexed owner, address indexed operator, bool approved);
+
+    function mint(address to) external returns (uint256 tokenId) {
+        tokenId = nextTokenId++;
+        _owners[tokenId] = to;
+        _balances[to] += 1;
+        emit Transfer(address(0), to, tokenId);
+    }
+
+    function ownerOf(uint256 tokenId) external view returns (address) {
+        address owner = _owners[tokenId];
+        require(owner != address(0), "nonexistent");
+        return owner;
+    }
+
+    function balanceOf(address owner) external view returns (uint256) {
+        require(owner != address(0), "zero");
+        return _balances[owner];
+    }
+
+    function approve(address to, uint256 tokenId) external {
+        address owner = _owners[tokenId];
+        require(
+            owner == msg.sender || _operatorApprovals[owner][msg.sender],
+            "not authorized"
+        );
+        _tokenApprovals[tokenId] = to;
+        emit Approval(owner, to, tokenId);
+    }
+
+    function getApproved(uint256 tokenId) external view returns (address) {
+        require(_owners[tokenId] != address(0), "nonexistent");
+        return _tokenApprovals[tokenId];
+    }
+
+    function setApprovalForAll(address operator, bool approved) external {
+        _operatorApprovals[msg.sender][operator] = approved;
+        emit ApprovalForAll(msg.sender, operator, approved);
+    }
+
+    function isApprovedForAll(address owner, address operator) external view returns (bool) {
+        return _operatorApprovals[owner][operator];
+    }
+
+    function transferFrom(address from, address to, uint256 tokenId) external {
+        require(_owners[tokenId] == from, "wrong from");
+        require(
+            msg.sender == from
+                || _tokenApprovals[tokenId] == msg.sender
+                || _operatorApprovals[from][msg.sender],
+            "not authorized"
+        );
+        _tokenApprovals[tokenId] = address(0);
+        _owners[tokenId] = to;
+        unchecked {
+            _balances[from] -= 1;
+            _balances[to] += 1;
+        }
+        emit Transfer(from, to, tokenId);
+    }
+
+    function supportsInterface(bytes4 iid) external pure returns (bool) {
+        return iid == 0x80ac58cd // ERC-721
+            || iid == 0x01ffc9a7; // ERC-165
+    }
+}

--- a/etc/vibenet/setup/contracts/src/USDV.sol
+++ b/etc/vibenet/setup/contracts/src/USDV.sol
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+/// @title USDV - Vibe USD
+/// @notice Public-mint ERC-20 used on vibenet as a stand-in for USDC. Anyone
+///         can mint up to `MAX_MINT_PER_CALL` to any address; the faucet
+///         service uses this to "drip" test dollars, but any caller may do
+///         the same directly. Not audited - do not deploy to production.
+/// @dev    6 decimals to match USDC so UIs and integrations can treat it as
+///         a drop-in replacement. The symbol is USDV to make it obvious the
+///         balance is worthless.
+contract USDV {
+    string public constant name = "Vibe USD";
+    string public constant symbol = "USDV";
+    uint8 public constant decimals = 6;
+    uint256 public constant MAX_MINT_PER_CALL = 1_000_000 * 10 ** 6;
+
+    uint256 public totalSupply;
+    mapping(address => uint256) public balanceOf;
+    mapping(address => mapping(address => uint256)) public allowance;
+
+    event Transfer(address indexed from, address indexed to, uint256 value);
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+
+    function mint(address to, uint256 amount) external {
+        require(amount <= MAX_MINT_PER_CALL, "mint too large");
+        balanceOf[to] += amount;
+        totalSupply += amount;
+        emit Transfer(address(0), to, amount);
+    }
+
+    function transfer(address to, uint256 amount) external returns (bool) {
+        _transfer(msg.sender, to, amount);
+        return true;
+    }
+
+    function approve(address spender, uint256 amount) external returns (bool) {
+        allowance[msg.sender][spender] = amount;
+        emit Approval(msg.sender, spender, amount);
+        return true;
+    }
+
+    function transferFrom(address from, address to, uint256 amount) external returns (bool) {
+        uint256 allowed = allowance[from][msg.sender];
+        require(allowed >= amount, "allowance");
+        if (allowed != type(uint256).max) {
+            allowance[from][msg.sender] = allowed - amount;
+        }
+        _transfer(from, to, amount);
+        return true;
+    }
+
+    function _transfer(address from, address to, uint256 amount) internal {
+        require(balanceOf[from] >= amount, "balance");
+        unchecked {
+            balanceOf[from] -= amount;
+            balanceOf[to] += amount;
+        }
+        emit Transfer(from, to, amount);
+    }
+}

--- a/etc/vibenet/setup/deploy-contracts.sh
+++ b/etc/vibenet/setup/deploy-contracts.sh
@@ -1,0 +1,156 @@
+#!/bin/bash
+# Vibenet post-setup: deploys demo contracts onto the L2 once base-client is
+# reachable, then writes their addresses to /shared/contracts.json for the
+# UI.
+#
+# Inputs (env):
+#   L2_RPC_URL            JSON-RPC endpoint of the vibenet L2 client.
+#   L2_CHAIN_ID           Numeric L2 chain id.
+#   FAUCET_ADDR           Deployer EOA (must be the prefunded faucet).
+#   FAUCET_PRIVATE_KEY    Private key for FAUCET_ADDR.
+#   OUT_FILE              Where to write contracts.json. Default /shared/contracts.json.
+#   VIBENET_BRANCH        Branch name, written into contracts.json for dev visibility.
+#   VIBENET_COMMIT        Commit sha, written into contracts.json.
+#
+# The contract list comes from /setup/contracts.yaml.
+
+set -euo pipefail
+
+OUT_FILE="${OUT_FILE:-/shared/contracts.json}"
+CONTRACTS_YAML="${CONTRACTS_YAML:-/setup/contracts.yaml}"
+FORGE_ROOT="${FORGE_ROOT:-/setup/contracts}"
+
+: "${L2_RPC_URL:?L2_RPC_URL required}"
+: "${L2_CHAIN_ID:?L2_CHAIN_ID required}"
+: "${FAUCET_PRIVATE_KEY:?FAUCET_PRIVATE_KEY required}"
+: "${FAUCET_ADDR:?FAUCET_ADDR required}"
+
+echo "=== vibenet-setup: waiting for L2 RPC at $L2_RPC_URL ==="
+for i in $(seq 1 120); do
+  if curl -sf --max-time 2 -X POST -H 'Content-Type: application/json' \
+      --data '{"jsonrpc":"2.0","method":"eth_chainId","params":[],"id":1}' \
+      "$L2_RPC_URL" | jq -e '.result' >/dev/null 2>&1; then
+    echo "L2 RPC ready"
+    break
+  fi
+  sleep 1
+  if [ "$i" = 120 ]; then echo "ERROR: L2 RPC never came up"; exit 1; fi
+done
+
+# Sweep the standard anvil EOAs on L2 into the faucet. op-deployer prefunds
+# them via fundDevAccounts so vibenet inherits big balances; vibenet makes
+# that liquidity available to users by consolidating it into the faucet.
+ANVIL_KEYS=(
+  "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
+  "0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d"
+  "0x5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a"
+  "0x7c852118294e51e653712a81e05800f419141751be58f605c371e15141b007a6"
+  "0x47e179ec197488593b187f80a00eb0da91f1b9d0b13f8733639f19c30a34926a"
+  "0x8b3a350cf5c34c9194ca85829a2df0ec3153be0318b5e2d3348e872092edffba"
+  "0x92db14e403b83dfe3df233f83dfa3a0d7096f21ca9b0d6d6b8d88b2b4ec1564e"
+  "0x4bbbf85ce3377467afe5d46f804f221813b2bb87f24d81f60f1fcdbf7cbf4356"
+  "0xdbda1821b80551c9d65939329250298aa3472ba22feea921c0cf5d620ea67b97"
+  "0x2a871d0798f97d79848a013d4936a73bf4cc922c825d33c1cf7073dff6d409c6"
+)
+
+echo ""
+echo "=== sweeping residual anvil balances to faucet ==="
+# Anvil pre-funds each account with 10_000 ETH = 1e22 wei which overflows
+# 64-bit bash arithmetic. Delegate the math to bc.
+for key in "${ANVIL_KEYS[@]}"; do
+  addr=$(cast wallet address --private-key "$key")
+  bal=$(cast balance "$addr" --rpc-url "$L2_RPC_URL")
+  if [ "$bal" = "0" ]; then
+    continue
+  fi
+  gas_price=$(cast gas-price --rpc-url "$L2_RPC_URL")
+  # Pad the reserve generously (10x 21k) so EIP-1559 priority tips don't drop
+  # us below zero.
+  reserve=$(echo "$gas_price * 21000 * 10" | bc)
+  send=$(echo "$bal - $reserve" | bc)
+  if [ "$(echo "$send <= 0" | bc)" = "1" ]; then
+    continue
+  fi
+  echo "sweep $addr -> $FAUCET_ADDR ($send wei)"
+  cast send --rpc-url "$L2_RPC_URL" --private-key "$key" \
+    --value "$send" "$FAUCET_ADDR" >/dev/null \
+    || echo "  (sweep failed, continuing)"
+done
+
+echo ""
+echo "=== building contracts ==="
+cd "$FORGE_ROOT"
+forge build --silent
+
+echo ""
+echo "=== deploying contracts from $CONTRACTS_YAML ==="
+mkdir -p "$(dirname "$OUT_FILE")"
+# Start the output with metadata so the UI always has something to show even
+# if deploys fail partway through.
+echo "{\"_branch\":\"${VIBENET_BRANCH:-unknown}\",\"_commit\":\"${VIBENET_COMMIT:-unknown}\",\"faucetAddress\":\"${FAUCET_ADDR}\"}" \
+  | jq '.' > "$OUT_FILE"
+
+count=$(yq '.contracts | length' "$CONTRACTS_YAML")
+for i in $(seq 0 $((count - 1))); do
+  name=$(yq ".contracts[$i].name" "$CONTRACTS_YAML")
+  artifact=$(yq ".contracts[$i].artifact" "$CONTRACTS_YAML")
+  args_json=$(yq -o=json ".contracts[$i].args // []" "$CONTRACTS_YAML")
+
+  # Resolve {{ otherContract }} templates from already-deployed addresses.
+  resolved_args=()
+  while IFS= read -r a; do
+    if [[ "$a" =~ ^\{\{[[:space:]]*(.+)[[:space:]]*\}\}$ ]]; then
+      ref="${BASH_REMATCH[1]}"
+      addr=$(jq -r --arg k "$ref" '.[$k] // empty' "$OUT_FILE")
+      if [ -z "$addr" ]; then
+        echo "ERROR: $name references {{ $ref }} but it hasn't been deployed yet"
+        exit 1
+      fi
+      resolved_args+=("$addr")
+    else
+      resolved_args+=("$a")
+    fi
+  done < <(echo "$args_json" | jq -r '.[]')
+
+  echo "-> deploying $name ($artifact) with args [${resolved_args[*]:-}]"
+  # forge create sometimes reads a stale pending nonce when deploys run back
+  # to back. Pin the nonce explicitly using the faucet's current tx count.
+  nonce_hex=$(cast rpc --rpc-url "$L2_RPC_URL" eth_getTransactionCount "$FAUCET_ADDR" pending | tr -d '"')
+  nonce=$((nonce_hex))
+  # Retry on transient "nonce too low" / "already known" races.
+  for attempt in 1 2 3 4 5; do
+    if out=$(forge create "$artifact" \
+        --rpc-url "$L2_RPC_URL" \
+        --private-key "$FAUCET_PRIVATE_KEY" \
+        --nonce "$nonce" \
+        --broadcast \
+        --json \
+        ${resolved_args[@]:+--constructor-args "${resolved_args[@]}"} 2>&1); then
+      break
+    fi
+    echo "   deploy attempt $attempt failed, retrying: ${out##*: }"
+    sleep 2
+    nonce_hex=$(cast rpc --rpc-url "$L2_RPC_URL" eth_getTransactionCount "$FAUCET_ADDR" pending | tr -d '"')
+    nonce=$((nonce_hex))
+    if [ "$attempt" = 5 ]; then
+      echo "ERROR: could not deploy $name: $out"
+      exit 1
+    fi
+  done
+  addr=$(echo "$out" | jq -r '.deployedTo')
+  echo "   $name = $addr"
+
+  TMP=$(mktemp)
+  jq --arg k "$name" --arg v "$addr" '. + {($k): $v}' "$OUT_FILE" > "$TMP"
+  mv "$TMP" "$OUT_FILE"
+done
+
+echo ""
+echo "=== contracts.json ==="
+cat "$OUT_FILE"
+# nginx runs as the nginx user and needs read access. The shared volume is
+# owned by root with the restrictive default umask of the foundry image, so
+# loosen perms explicitly here.
+chmod 0644 "$OUT_FILE"
+echo ""
+echo "vibenet-setup: done"

--- a/etc/vibenet/vibenet-env.example
+++ b/etc/vibenet/vibenet-env.example
@@ -1,0 +1,68 @@
+# Vibenet host-specific configuration.
+#
+# Copy this file to `etc/vibenet/vibenet-env` on the host and fill in the real
+# values. Never commit the populated file.
+
+# === Public TLS listener (production only) ===
+# On the production host, Cloudflare proxies public traffic (orange-cloud)
+# to Caddy's :443 listener. Caddy is activated by `just vibe` when
+# /etc/vibenet/tls/origin.crt (a Cloudflare Origin CA certificate) is present.
+#
+# Generate the cert pair from the Cloudflare dashboard:
+#   SSL/TLS -> Origin Server -> Create Certificate
+# Covering hostnames: vibes.base.org, *.vibes.base.org
+# Then on the host:
+#   sudo install -d -m 0755 /etc/vibenet/tls
+#   sudo tee /etc/vibenet/tls/origin.crt > /dev/null  # paste cert
+#   sudo tee /etc/vibenet/tls/origin.key > /dev/null  # paste key
+#   sudo chmod 0644 /etc/vibenet/tls/origin.crt
+#   sudo chmod 0600 /etc/vibenet/tls/origin.key
+#
+# VIBENET_PUBLIC_BIND_ADDR is the host IP :443 is published on. Leave unset
+# on laptops; set to the Cloudflare-reachable public IP on prod.
+# VIBENET_PUBLIC_BIND_ADDR=
+
+# === UI image ===
+# By default `just vibe` builds the Next.js UI from the sibling base/ui repo
+# at ../ui (relative to this repo). To use a pre-built image instead:
+# VIBENET_UI_IMAGE=ghcr.io/base/ui:main
+
+# === Faucet ===
+# Address that funds every public drip. Prefunded with 10M ETH in the L1
+# genesis (setup-l1.sh) and topped up on L2 by vibenet-setup sweeping the
+# standard anvil EOAs into it at boot.
+#
+# Generate a fresh key for each deployment:
+#   cast wallet new
+# Local default: the first standard Anvil/Foundry account. Production hosts
+# should replace this with a fresh generated key.
+FAUCET_ADDR=0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266
+FAUCET_PRIVATE_KEY=0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
+
+# === Faucet rate limits ===
+# How much to drip per request, how often a given IP / address may drip.
+# USDV drip is in *base units* (6 decimals); 1_000_000_000 = 1000 USDV.
+#
+# Cooldowns are namespaced per asset: a successful ETH drip does not put the
+# caller into cooldown for USDV. In practice this means a fresh caller can get
+# one ETH drip and one USDV drip back-to-back, then waits `*_COOLDOWN_SECS`
+# before the next drip of either asset. Default is 1 hour for both.
+VIBENET_FAUCET_DRIP_WEI=100000000000000000
+VIBENET_FAUCET_USDV_DRIP_UNITS=1000000000
+VIBENET_FAUCET_IP_COOLDOWN_SECS=3600
+VIBENET_FAUCET_ADDR_COOLDOWN_SECS=3600
+
+# === Optional: contract list override path ===
+# Defaults to etc/vibenet/setup/contracts.yaml. Override on a per-branch basis
+# to add demo-specific contracts without modifying the setup script.
+VIBENET_CONTRACTS_YAML=etc/vibenet/setup/contracts.yaml
+
+# === Optional: local-dev host ports ===
+# Loopback-only bindings on `just vibe`. In production Caddy binds :443.
+# VIBENET_HOST_PORT=18080     # Next.js app (landing / faucet / explorer)
+# VIBENET_WS_HOST_PORT=18081  # WebSocket RPC (base-client direct)
+# VIBENET_RPC_HOST_PORT=18082 # HTTP RPC (proxyd)
+
+# === Optional: explorer indexer tuning ===
+# VIBESCAN_START_BLOCK=0
+# VIBESCAN_BACKFILL_CONCURRENCY=16


### PR DESCRIPTION
## Summary

Adds the **vibenet** public devnet integration as a pure-additive overlay on the existing devnet stack:

| New | What it does |
|---|---|
| `etc/vibenet/docker-compose.vibenet.yml` | Overlays on `etc/docker/docker-compose.yml`: adds `next-app` (Next.js UI from sibling `../ui` or `VIBENET_UI_IMAGE`), `vibenet-setup` (Foundry contract deployer), `vibenet-config-renderer` (yq → config.json), `proxyd` (RPC rate limits). Exposes WS RPC directly from base-client and HTTP RPC from proxyd on loopback. |
| `etc/vibenet/docker-compose.caddy.yml` + `caddy/Caddyfile` | Production TLS overlay. Cloudflare Origin CA cert + subdomain routing for `vibes/faucet/explorer/rpc.vibes.base.org`. Auto-enabled when `/etc/vibenet/tls/origin.crt` exists. |
| `etc/vibenet/setup/` | Foundry deployer: sweeps anvil EOA balances → faucet on L2, deploys public-mint USDV (6-decimal ERC-20) and NFV (ERC-721), writes addresses to `/shared/contracts.json`. |
| `etc/vibenet/config/vibenet.yaml` | Editable UI content (title, subtitle, features) rendered to JSON for the landing page. |
| `etc/vibenet/proxyd/proxyd-ratelimit.toml` | Per-method JSON-RPC rate limits. |
| `etc/vibenet/vibenet-env.example` | Host env template (`FAUCET_*`, cooldowns, optional `VIBENET_UI_IMAGE`). |

| Additive edit | What changes |
|---|---|
| `etc/docker/Justfile` | Adds `vibe`, `vibe-down`, `vibe-ui` (rebuild just the Next.js container without resetting chain state), `vibe-logs`, `vibe-ps` recipes. |
| `etc/scripts/devnet/setup-l1.sh` | If `FAUCET_ADDR` is set, injects it into the L1 anvil genesis with a large balance. Guarded — base devnet behavior unchanged. |
| `.gitignore` | Exclude the populated `etc/vibenet/vibenet-env` file. |

**The UI itself lives in the [base/ui](https://github.com/base/ui) repo (PR #165).** This PR is the infra integration only. No edits to base devnet code paths.

## Local quickstart

```bash
git clone git@github.com:base/ui.git ../ui          # sibling
cp etc/vibenet/vibenet-env.example etc/vibenet/vibenet-env
just devnet vibe
```

Then:
- http://localhost:18080/ — landing
- http://localhost:18080/faucet — faucet UI + API
- http://localhost:18080/explorer — block explorer
- ws://localhost:18081/ — WebSocket RPC
- http://localhost:18082/ — HTTP RPC (proxyd)

## Public hostname routing

Production (set by Caddy overlay):

| Subdomain | Routes to |
|---|---|
| `vibes.base.org` | `next-app:3000` → landing |
| `faucet.vibes.base.org` | `next-app:3000` → faucet (Next.js proxy.ts rewrites Host header to `/faucet`) |
| `explorer.vibes.base.org` | `next-app:3000` → explorer |
| `rpc.vibes.base.org` | `proxyd:8080` HTTP, `base-client:8546` WS |

## Test plan

- [x] `just devnet vibe` brings up the full stack locally
- [x] All three faucet drips (ETH / USDV / NFV) land on-chain
- [x] Explorer indexes blocks + decoded ERC-20 Transfer events
- [x] Subdomain routing via `Host` header spoofing
- [x] `just devnet vibe-ui` rebuilds the Next.js container without losing chain state
- [ ] Production Caddy TLS with real Cloudflare Origin CA cert

## Depends on

[base/ui#165](https://github.com/base/ui/pull/165) — the Next.js app

🤖 Generated with [Claude Code](https://claude.com/claude-code)