### PR TITLE
chore(tee): add build-host and build-enclave just commands

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -22,6 +22,7 @@ rustfmt.toml
 # Docker config (dockerfiles are sent separately by compose, not from context)
 etc/docker/
 !etc/docker/nitro-enclave/
+!etc/docker/nitro-host/
 
 # Devnet tooling not needed in container builds
 etc/scripts/devnet/grafana/

--- a/crates/proof/tee/Justfile
+++ b/crates/proof/tee/Justfile
@@ -31,12 +31,19 @@ nitro-local *args:
         --logs.stdout.format json \
         {{ args }}
 
-# Build the nitro host Docker image
+# Build the nitro host Docker image (full runtime image)
 build-host *args="":
     #!/usr/bin/env bash
     set -euo pipefail
     cd ../../..
     DOCKER_BUILDKIT=1 docker build --platform linux/amd64 {{ args }} -f etc/docker/Dockerfile.nitro-host -t base-prover-nitro-host .
+
+# Build the nitro enclave Docker image (full runtime image with EIF, nitro-cli, allocator, entrypoint)
+build-enclave *args="":
+    #!/usr/bin/env bash
+    set -euo pipefail
+    cd ../../..
+    DOCKER_BUILDKIT=1 docker build --platform linux/amd64 {{ args }} -f etc/docker/Dockerfile.nitro-enclave -t base-prover-nitro-enclave .
 
 # Print config hashes for all supported chains
 config-hashes:

--- a/crates/proof/tee/Justfile
+++ b/crates/proof/tee/Justfile
@@ -32,8 +32,8 @@ nitro-local *args:
         {{ args }}
 
 # Build the nitro host binary
-build-host profile='release':
-    cargo build --profile {{ profile }} --package base-prover-nitro-host --bin base-prover-nitro-host
+build-host profile='maxperf':
+    cargo build --profile {{ profile }} --locked --package base-prover-nitro-host --bin base-prover-nitro-host
 
 # Build the nitro enclave binary (static musl target for x86_64)
 build-enclave:

--- a/crates/proof/tee/Justfile
+++ b/crates/proof/tee/Justfile
@@ -31,6 +31,15 @@ nitro-local *args:
         --logs.stdout.format json \
         {{ args }}
 
+# Build the nitro host binary
+build-host profile='release':
+    cargo build --profile {{ profile }} --package base-prover-nitro-host --bin base-prover-nitro-host
+
+# Build the nitro enclave binary (static musl target for x86_64)
+build-enclave:
+    cargo build --release --locked --target x86_64-unknown-linux-musl \
+        --package base-prover-nitro-enclave --bin base-prover-nitro-enclave
+
 # Print config hashes for all supported chains
 config-hashes:
     cargo test -p base-enclave print_real_config_hashes -- --nocapture --ignored

--- a/crates/proof/tee/Justfile
+++ b/crates/proof/tee/Justfile
@@ -31,14 +31,25 @@ nitro-local *args:
         --logs.stdout.format json \
         {{ args }}
 
-# Build the nitro host binary
-build-host profile='maxperf':
-    cargo build --profile {{ profile }} --locked --package base-prover-nitro-host --bin base-prover-nitro-host
+# Build the nitro host Docker image
+build-host *args="":
+    #!/usr/bin/env bash
+    set -euo pipefail
+    cd ../../..
+    DOCKER_BUILDKIT=1 docker build --platform linux/amd64 {{ args }} -f etc/docker/Dockerfile.nitro-host -t base-prover-nitro-host .
 
-# Build the nitro enclave binary (static musl target for x86_64)
-build-enclave:
-    cargo build --release --locked --target x86_64-unknown-linux-musl \
-        --package base-prover-nitro-enclave --bin base-prover-nitro-enclave
+# Build the nitro enclave Docker image and extract EIF
+build-enclave *args="":
+    #!/usr/bin/env bash
+    set -euo pipefail
+    cd ../../..
+    DOCKER_BUILDKIT=1 docker build --platform linux/amd64 {{ args }} -f etc/docker/Dockerfile.nitro-enclave --target describe -t base-prover-nitro-enclave-describe .
+    docker rm -f enclave-extract 2>/dev/null || true
+    docker create --name enclave-extract base-prover-nitro-enclave-describe
+    docker cp enclave-extract:/app/eif.bin crates/proof/tee/eif.bin
+    docker rm enclave-extract
+    echo "Enclave built successfully: crates/proof/tee/eif.bin"
+    ls -lh crates/proof/tee/eif.bin
 
 # Print config hashes for all supported chains
 config-hashes:

--- a/crates/proof/tee/Justfile
+++ b/crates/proof/tee/Justfile
@@ -38,19 +38,6 @@ build-host *args="":
     cd ../../..
     DOCKER_BUILDKIT=1 docker build --platform linux/amd64 {{ args }} -f etc/docker/Dockerfile.nitro-host -t base-prover-nitro-host .
 
-# Build the nitro enclave Docker image and extract EIF
-build-enclave *args="":
-    #!/usr/bin/env bash
-    set -euo pipefail
-    cd ../../..
-    DOCKER_BUILDKIT=1 docker build --platform linux/amd64 {{ args }} -f etc/docker/Dockerfile.nitro-enclave --target describe -t base-prover-nitro-enclave-describe .
-    docker rm -f enclave-extract 2>/dev/null || true
-    docker create --name enclave-extract base-prover-nitro-enclave-describe
-    docker cp enclave-extract:/app/eif.bin crates/proof/tee/eif.bin
-    docker rm enclave-extract
-    echo "Enclave built successfully: crates/proof/tee/eif.bin"
-    ls -lh crates/proof/tee/eif.bin
-
 # Print config hashes for all supported chains
 config-hashes:
     cargo test -p base-enclave print_real_config_hashes -- --nocapture --ignored

--- a/etc/docker/Dockerfile.nitro-host
+++ b/etc/docker/Dockerfile.nitro-host
@@ -22,7 +22,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
     cp target/$([ "$PROFILE" = "dev" ] && echo debug || echo $PROFILE)/base-prover-nitro-host ./base-prover-nitro-host
 
 # --- Runtime ---
-FROM debian:trixie-slim@sha256:1d3c811171a08a5adaa4a163fbafd96b61b87aa871bbc7aa15431ac275d3d430
+FROM --platform=linux/amd64 debian:trixie-slim@sha256:1d3c811171a08a5adaa4a163fbafd96b61b87aa871bbc7aa15431ac275d3d430
 RUN apt-get update && \
     apt-get install -y --no-install-recommends ca-certificates curl && \
     rm -rf /var/lib/apt/lists/* && \

--- a/etc/docker/Dockerfile.nitro-host
+++ b/etc/docker/Dockerfile.nitro-host
@@ -1,0 +1,37 @@
+# syntax=docker/dockerfile:1
+
+# Builds base-prover-nitro-host — the JSON-RPC server that forwards proving
+# requests to the Nitro Enclave over vsock.
+
+# --- Builder ---
+FROM --platform=linux/amd64 rust:1.93-trixie@sha256:51c04d7a2b38418ba23ecbfb373c40d3bd493dec1ddfae00ab5669527320195e AS builder
+WORKDIR /app
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+      git libclang-dev pkg-config curl build-essential mold protobuf-compiler && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY . .
+
+ARG PROFILE=maxperf
+RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
+    --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
+    --mount=type=cache,target=/app/target,id=prover-nitro-host-target,sharing=locked \
+    cargo build --profile $PROFILE --locked --package base-prover-nitro-host --bin base-prover-nitro-host && \
+    cp target/$([ "$PROFILE" = "dev" ] && echo debug || echo $PROFILE)/base-prover-nitro-host ./base-prover-nitro-host
+
+# --- Runtime ---
+FROM debian:trixie-slim@sha256:1d3c811171a08a5adaa4a163fbafd96b61b87aa871bbc7aa15431ac275d3d430
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends ca-certificates curl && \
+    rm -rf /var/lib/apt/lists/* && \
+    useradd -r -m -s /sbin/nologin base
+
+WORKDIR /app
+COPY --from=builder /app/base-prover-nitro-host ./
+COPY etc/docker/nitro-host/entrypoint.sh ./entrypoint.sh
+
+USER base
+
+ENTRYPOINT ["./entrypoint.sh"]

--- a/etc/docker/nitro-host/entrypoint.sh
+++ b/etc/docker/nitro-host/entrypoint.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+set -eux
+
+: "${VSOCK_CID:?required}"
+: "${LISTEN_ADDR:?required}"
+: "${L1_ETH_URL:?required}"
+: "${L1_BEACON_URL:?required}"
+: "${L2_ETH_URL:?required}"
+: "${L2_CHAIN_ID:?required}"
+: "${PROOF_REQUEST_TIMEOUT_SECS:=3600}"
+
+ADDITIONAL_ARGS=""
+if [ -n "${TEE_PROVER_REGISTRY_ADDRESS:-}" ]; then
+    ADDITIONAL_ARGS="$ADDITIONAL_ARGS --tee-prover-registry-address=$TEE_PROVER_REGISTRY_ADDRESS"
+fi
+
+exec ./base-prover-nitro-host \
+    server \
+    --l1-eth-url "$L1_ETH_URL" \
+    --l1-beacon-url "$L1_BEACON_URL" \
+    --l2-eth-url "$L2_ETH_URL" \
+    --l2-chain-id "$L2_CHAIN_ID" \
+    --listen-addr "$LISTEN_ADDR" \
+    --vsock-cid "$VSOCK_CID" \
+    --proof-request-timeout-secs "$PROOF_REQUEST_TIMEOUT_SECS" \
+    --enable-experimental-witness-endpoint \
+    $ADDITIONAL_ARGS

--- a/etc/docker/nitro-host/entrypoint.sh
+++ b/etc/docker/nitro-host/entrypoint.sh
@@ -9,9 +9,9 @@ set -eux
 : "${L2_CHAIN_ID:?required}"
 : "${PROOF_REQUEST_TIMEOUT_SECS:=3600}"
 
-ADDITIONAL_ARGS=""
+ADDITIONAL_ARGS=()
 if [ -n "${TEE_PROVER_REGISTRY_ADDRESS:-}" ]; then
-    ADDITIONAL_ARGS="$ADDITIONAL_ARGS --tee-prover-registry-address=$TEE_PROVER_REGISTRY_ADDRESS"
+    ADDITIONAL_ARGS+=(--tee-prover-registry-address="$TEE_PROVER_REGISTRY_ADDRESS")
 fi
 
 exec ./base-prover-nitro-host \
@@ -24,4 +24,4 @@ exec ./base-prover-nitro-host \
     --vsock-cid "$VSOCK_CID" \
     --proof-request-timeout-secs "$PROOF_REQUEST_TIMEOUT_SECS" \
     --enable-experimental-witness-endpoint \
-    $ADDITIONAL_ARGS
+    "${ADDITIONAL_ARGS[@]}"


### PR DESCRIPTION
## Summary

Adds two new `just` recipes to the TEE Justfile for building the nitro prover binaries:

- `just tee build-host [profile]` — builds `base-prover-nitro-host` (defaults to release profile)
- `just tee build-enclave` — builds `base-prover-nitro-enclave` as a static musl binary for x86_64

These are used by the internal `base-proofs` deployment repo's Dockerfiles, which clone this repo at a pinned commit and invoke these commands. This keeps the build logic (package names, flags, targets) in this repo as the single source of truth, rather than duplicating `cargo build` invocations across repos.

## Context

The existing `nitro-server` and `nitro-enclave` recipes use `cargo run` (build + run), which isn't suitable for CI/Docker builds that only need the compiled binary. The new recipes fill that gap.