### PR TITLE
refactor(common): Add Base Precompile Macro

### DIFF
--- a/crates/common/precompiles/src/lib.rs
+++ b/crates/common/precompiles/src/lib.rs
@@ -5,6 +5,8 @@
 
 extern crate alloc;
 
+mod macros;
+
 mod provider;
 pub use provider::BasePrecompiles;
 

--- a/crates/common/precompiles/src/macros.rs
+++ b/crates/common/precompiles/src/macros.rs
@@ -1,0 +1,44 @@
+//! Runtime helpers for wrapping native precompile dispatch.
+
+macro_rules! base_precompile {
+    ($id:expr, |$ctx:ident, $calldata:ident| $impl:expr $(,)?) => {{
+        ::alloy_evm::precompiles::DynPrecompile::new_stateful(
+            ::revm::precompile::PrecompileId::Custom($id.into()),
+            move |input| {
+                if !input.is_direct_call() {
+                    return Ok(::revm::precompile::PrecompileOutput::new_reverted(
+                        0,
+                        ::alloy_primitives::Bytes::new(),
+                    ));
+                }
+
+                let $calldata: ::alloy_primitives::Bytes = input.data.to_vec().into();
+                let mut provider =
+                    ::base_precompile_storage::EvmPrecompileStorageProvider::new(input);
+
+                ::base_precompile_storage::StorageCtx::enter(&mut provider, |$ctx| $impl)
+            },
+        )
+    }};
+    ($id:expr, |$input:ident, $ctx:ident, $calldata:ident| $impl:expr $(,)?) => {{
+        ::alloy_evm::precompiles::DynPrecompile::new_stateful(
+            ::revm::precompile::PrecompileId::Custom($id.into()),
+            move |$input| {
+                if !$input.is_direct_call() {
+                    return Ok(::revm::precompile::PrecompileOutput::new_reverted(
+                        0,
+                        ::alloy_primitives::Bytes::new(),
+                    ));
+                }
+
+                let $calldata: ::alloy_primitives::Bytes = $input.data.to_vec().into();
+                let mut provider =
+                    ::base_precompile_storage::EvmPrecompileStorageProvider::new($input);
+
+                ::base_precompile_storage::StorageCtx::enter(&mut provider, |$ctx| $impl)
+            },
+        )
+    }};
+}
+
+pub(crate) use base_precompile;

--- a/crates/common/precompiles/src/token/default_token/evm.rs
+++ b/crates/common/precompiles/src/token/default_token/evm.rs
@@ -1,11 +1,10 @@
 //! EVM wiring for the `DefaultToken` precompile.
 
-use alloy_evm::precompiles::{DynPrecompile, PrecompileInput};
-use alloy_primitives::{Address, Bytes};
-use base_precompile_storage::{EvmPrecompileStorageProvider, StorageCtx};
-use revm::precompile::{PrecompileId, PrecompileOutput, PrecompileResult};
+use alloy_evm::precompiles::DynPrecompile;
+use alloy_primitives::Address;
 
 use super::{DefaultToken, storage::DefaultTokenStorage};
+use crate::macros::base_precompile;
 
 /// EVM entry point for the `DefaultToken` precompile.
 ///
@@ -19,19 +18,7 @@ impl DefaultTokenEvm {
     ///
     /// Used by the precompile-lookup fallback to route calls to any B-20 token address.
     pub fn create_precompile(token_address: Address) -> DynPrecompile {
-        DynPrecompile::new_stateful(
-            PrecompileId::Custom(alloc::format!("DefaultToken@{token_address}").into()),
-            move |input| Self::run_at(input, token_address),
-        )
-    }
-
-    fn run_at(input: PrecompileInput<'_>, token_address: Address) -> PrecompileResult {
-        if !input.is_direct_call() {
-            return Ok(PrecompileOutput::new_reverted(0, Bytes::new()));
-        }
-        let calldata: Bytes = input.data.to_vec().into();
-        let mut provider = EvmPrecompileStorageProvider::new(input);
-        StorageCtx::enter(&mut provider, |ctx| {
+        base_precompile!(alloc::format!("DefaultToken@{token_address}"), |ctx, calldata| {
             DefaultToken::with_storage(DefaultTokenStorage::from_address(token_address, ctx))
                 .dispatch(ctx, &calldata)
         })

--- a/crates/common/precompiles/src/token/factory/evm.rs
+++ b/crates/common/precompiles/src/token/factory/evm.rs
@@ -1,11 +1,9 @@
 //! EVM entry point for the `TokenFactory` precompile.
 
-use alloy_evm::precompiles::{DynPrecompile, PrecompileInput};
-use alloy_primitives::Bytes;
-use base_precompile_storage::{EvmPrecompileStorageProvider, StorageCtx};
-use revm::precompile::{PrecompileId, PrecompileOutput, PrecompileResult};
+use alloy_evm::precompiles::DynPrecompile;
 
 use super::storage::TokenFactory;
+use crate::macros::base_precompile;
 
 /// EVM entry point for the `TokenFactory` precompile.
 #[derive(Debug, Default, Clone, Copy)]
@@ -14,15 +12,8 @@ pub struct TokenFactoryEvm;
 impl TokenFactoryEvm {
     /// Returns a [`DynPrecompile`] registerable with a [`PrecompilesMap`].
     pub fn precompile() -> DynPrecompile {
-        DynPrecompile::new_stateful(PrecompileId::Custom("TokenFactory".into()), Self::run)
-    }
-
-    fn run(input: PrecompileInput<'_>) -> PrecompileResult {
-        if !input.is_direct_call() {
-            return Ok(PrecompileOutput::new_reverted(0, Bytes::new()));
-        }
-        let calldata: Bytes = input.data.to_vec().into();
-        let mut provider = EvmPrecompileStorageProvider::new(input);
-        StorageCtx::enter(&mut provider, |ctx| TokenFactory::new(ctx).dispatch(ctx, &calldata))
+        base_precompile!("TokenFactory", |ctx, calldata| {
+            TokenFactory::new(ctx).dispatch(ctx, &calldata)
+        })
     }
 }

--- a/crates/common/precompiles/src/token/factory/mod.rs
+++ b/crates/common/precompiles/src/token/factory/mod.rs
@@ -1,10 +1,11 @@
 //! `TokenFactory` native precompile — creates B-20 tokens at deterministic prefix-encoded addresses.
 
 mod dispatch;
-mod evm;
-mod storage;
 
+mod evm;
 pub use evm::TokenFactoryEvm;
+
+mod storage;
 pub use storage::{
     DEFAULT_PREFIX, FACTORY_ADDRESS, RESERVED_SIZE, SECURITY_PREFIX, STABLECOIN_PREFIX,
     TokenFactory, VARIANT_DEFAULT, VARIANT_NONE, VARIANT_SECURITY, VARIANT_STABLECOIN,


### PR DESCRIPTION
## Summary

This adds a local base_precompile! macro in base-common-precompiles to centralize native precompile wrapper boilerplate. The B-20 TokenFactory and DefaultToken EVM entrypoints now use the macro while preserving the existing direct-call guard, storage provider setup, and StorageCtx dispatch flow.