### PR TITLE
refactor(common): Group Token Variant Addressing

### DIFF
--- a/crates/common/precompiles/benches/base_precompiles.rs
+++ b/crates/common/precompiles/benches/base_precompiles.rs
@@ -5,9 +5,9 @@ use std::hint::black_box;
 use alloy_primitives::{Address, B256, Bytes, U256};
 use alloy_sol_types::SolValue;
 use base_common_precompiles::{
-    B20Token, B20TokenStorage, Burnable, CAPABILITY_CAP_MUTABLE, CAPABILITY_PAUSABLE,
-    CREATE_TOKEN_VERSION, Configurable, ITokenFactory, Mintable, Pausable, Token, TokenAccounting,
-    TokenFactory, Transferable, VARIANT_DEFAULT, compute_b20_address,
+    B20Token, B20TokenStorage, Burnable, CAPABILITY_CAP_MUTABLE, CAPABILITY_PAUSABLE, Configurable,
+    ITokenFactory, Mintable, Pausable, Token, TokenAccounting, TokenFactory, TokenVariant,
+    Transferable,
 };
 use base_precompile_storage::{HashMapStorageProvider, StorageCtx};
 use criterion::{Criterion, criterion_group, criterion_main};
@@ -47,28 +47,24 @@ impl BaseTokenBenchSetup {
         }
     }
 
-    fn create_b20(
+    fn create_default(
         ctx: StorageCtx<'_>,
         caller: Address,
         params: ITokenFactory::B20TokenParams,
         salt: B256,
     ) -> Address {
+        let call = ITokenFactory::createTokenCall {
+            params: ITokenFactory::CreateTokenParams {
+                version: TokenFactory::CREATE_TOKEN_VERSION,
+                variant: TokenVariant::Default.discriminant(),
+                requiredParams: params.abi_encode().into(),
+                optionalParams: Bytes::new(),
+                postCreateCalls: Vec::new(),
+                salt,
+            },
+        };
         let mut factory = TokenFactory::new(ctx);
-        factory
-            .create_token(
-                caller,
-                ITokenFactory::createTokenCall {
-                    params: ITokenFactory::CreateTokenParams {
-                        version: CREATE_TOKEN_VERSION,
-                        variant: VARIANT_DEFAULT,
-                        requiredParams: params.abi_encode().into(),
-                        optionalParams: Bytes::new(),
-                        postCreateCalls: Vec::new(),
-                        salt,
-                    },
-                },
-            )
-            .unwrap()
+        factory.create_token(caller, call).unwrap()
     }
 
     fn create_token<'a>(
@@ -79,7 +75,7 @@ impl BaseTokenBenchSetup {
         let mut params = Self::token_params("BaseToken", "BASE", 18, initial_supply);
         params.minimumRedeemable = U256::ONE;
 
-        let token_address = Self::create_b20(ctx, Self::caller(), params, salt);
+        let token_address = Self::create_default(ctx, Self::caller(), params, salt);
         Self::token_at(ctx, token_address)
     }
 
@@ -446,7 +442,7 @@ fn base_token_factory_mutate(c: &mut Criterion) {
                 let salt = B256::from(U256::from(counter));
                 let params =
                     BaseTokenBenchSetup::token_params("FactoryToken", "FACT", 18, U256::ZERO);
-                let token = BaseTokenBenchSetup::create_b20(ctx, caller, params, salt);
+                let token = BaseTokenBenchSetup::create_default(ctx, caller, params, salt);
                 black_box(token);
             });
         });
@@ -461,7 +457,7 @@ fn base_token_factory_view(c: &mut Criterion) {
         b.iter(|| {
             let caller = black_box(caller);
             let salt = black_box(salt);
-            let result = compute_b20_address(caller, VARIANT_DEFAULT, 18, salt);
+            let result = TokenVariant::Default.compute_address(caller, 18, salt);
             black_box(result);
         });
     });
@@ -473,7 +469,7 @@ fn base_token_factory_view(c: &mut Criterion) {
         b.iter(|| {
             let caller = black_box(caller);
             let salt = black_box(salt);
-            let result = compute_b20_address(caller, VARIANT_DEFAULT, 6, salt);
+            let result = TokenVariant::Default.compute_address(caller, 6, salt);
             black_box(result);
         });
     });
@@ -485,7 +481,7 @@ fn base_token_factory_view(c: &mut Criterion) {
         b.iter(|| {
             let caller = black_box(caller);
             let salt = black_box(salt);
-            let result = compute_b20_address(caller, VARIANT_DEFAULT, 0, salt);
+            let result = TokenVariant::Default.compute_address(caller, 0, salt);
             black_box(result);
         });
     });
@@ -494,7 +490,7 @@ fn base_token_factory_view(c: &mut Criterion) {
         let mut storage = HashMapStorageProvider::new(1);
         StorageCtx::enter(&mut storage, |ctx| {
             let params = BaseTokenBenchSetup::token_params("FactoryToken", "FACT", 18, U256::ZERO);
-            let token_address = BaseTokenBenchSetup::create_b20(
+            let token_address = BaseTokenBenchSetup::create_default(
                 ctx,
                 BaseTokenBenchSetup::caller(),
                 params,
@@ -515,9 +511,8 @@ fn base_token_factory_view(c: &mut Criterion) {
         let mut storage = HashMapStorageProvider::new(1);
         StorageCtx::enter(&mut storage, |ctx| {
             let factory = TokenFactory::new(ctx);
-            let (token_address, _) = compute_b20_address(
+            let (token_address, _) = TokenVariant::Default.compute_address(
                 BaseTokenBenchSetup::caller(),
-                VARIANT_DEFAULT,
                 18,
                 B256::repeat_byte(0x25),
             );

--- a/crates/common/precompiles/benches/base_precompiles.rs
+++ b/crates/common/precompiles/benches/base_precompiles.rs
@@ -47,7 +47,7 @@ impl BaseTokenBenchSetup {
         }
     }
 
-    fn create_default(
+    fn create_b20(
         ctx: StorageCtx<'_>,
         caller: Address,
         params: ITokenFactory::B20TokenParams,
@@ -56,7 +56,7 @@ impl BaseTokenBenchSetup {
         let call = ITokenFactory::createTokenCall {
             params: ITokenFactory::CreateTokenParams {
                 version: TokenFactory::CREATE_TOKEN_VERSION,
-                variant: TokenVariant::Default.discriminant(),
+                variant: TokenVariant::B20.discriminant(),
                 requiredParams: params.abi_encode().into(),
                 optionalParams: Bytes::new(),
                 postCreateCalls: Vec::new(),
@@ -75,7 +75,7 @@ impl BaseTokenBenchSetup {
         let mut params = Self::token_params("BaseToken", "BASE", 18, initial_supply);
         params.minimumRedeemable = U256::ONE;
 
-        let token_address = Self::create_default(ctx, Self::caller(), params, salt);
+        let token_address = Self::create_b20(ctx, Self::caller(), params, salt);
         Self::token_at(ctx, token_address)
     }
 
@@ -442,7 +442,7 @@ fn base_token_factory_mutate(c: &mut Criterion) {
                 let salt = B256::from(U256::from(counter));
                 let params =
                     BaseTokenBenchSetup::token_params("FactoryToken", "FACT", 18, U256::ZERO);
-                let token = BaseTokenBenchSetup::create_default(ctx, caller, params, salt);
+                let token = BaseTokenBenchSetup::create_b20(ctx, caller, params, salt);
                 black_box(token);
             });
         });
@@ -457,7 +457,7 @@ fn base_token_factory_view(c: &mut Criterion) {
         b.iter(|| {
             let caller = black_box(caller);
             let salt = black_box(salt);
-            let result = TokenVariant::Default.compute_address(caller, 18, salt);
+            let result = TokenVariant::B20.compute_address(caller, 18, salt);
             black_box(result);
         });
     });
@@ -469,7 +469,7 @@ fn base_token_factory_view(c: &mut Criterion) {
         b.iter(|| {
             let caller = black_box(caller);
             let salt = black_box(salt);
-            let result = TokenVariant::Default.compute_address(caller, 6, salt);
+            let result = TokenVariant::B20.compute_address(caller, 6, salt);
             black_box(result);
         });
     });
@@ -481,7 +481,7 @@ fn base_token_factory_view(c: &mut Criterion) {
         b.iter(|| {
             let caller = black_box(caller);
             let salt = black_box(salt);
-            let result = TokenVariant::Default.compute_address(caller, 0, salt);
+            let result = TokenVariant::B20.compute_address(caller, 0, salt);
             black_box(result);
         });
     });
@@ -490,7 +490,7 @@ fn base_token_factory_view(c: &mut Criterion) {
         let mut storage = HashMapStorageProvider::new(1);
         StorageCtx::enter(&mut storage, |ctx| {
             let params = BaseTokenBenchSetup::token_params("FactoryToken", "FACT", 18, U256::ZERO);
-            let token_address = BaseTokenBenchSetup::create_default(
+            let token_address = BaseTokenBenchSetup::create_b20(
                 ctx,
                 BaseTokenBenchSetup::caller(),
                 params,
@@ -511,7 +511,7 @@ fn base_token_factory_view(c: &mut Criterion) {
         let mut storage = HashMapStorageProvider::new(1);
         StorageCtx::enter(&mut storage, |ctx| {
             let factory = TokenFactory::new(ctx);
-            let (token_address, _) = TokenVariant::Default.compute_address(
+            let (token_address, _) = TokenVariant::B20.compute_address(
                 BaseTokenBenchSetup::caller(),
                 18,
                 B256::repeat_byte(0x25),

--- a/crates/common/precompiles/src/installer.rs
+++ b/crates/common/precompiles/src/installer.rs
@@ -45,7 +45,7 @@ fn b20_lookup(address: &Address) -> Option<DynPrecompile> {
         Some(crate::token::TokenFactoryPrecompile::precompile())
     } else {
         crate::token::TokenVariant::from_address(*address).map(|variant| match variant {
-            crate::token::TokenVariant::Default => {
+            crate::token::TokenVariant::B20 => {
                 crate::token::B20TokenPrecompile::create_precompile(*address)
             }
         })
@@ -81,7 +81,7 @@ mod tests {
     #[case::beryl(BaseUpgrade::Beryl, true)]
     fn installer_routes_b20_precompiles_by_fork(#[case] spec: BaseUpgrade, #[case] expected: bool) {
         let precompiles = BasePrecompileInstaller::new(spec).install();
-        let (token, _) = TokenVariant::Default.compute_address(
+        let (token, _) = TokenVariant::B20.compute_address(
             Address::repeat_byte(0x11),
             18,
             B256::repeat_byte(0x22),

--- a/crates/common/precompiles/src/installer.rs
+++ b/crates/common/precompiles/src/installer.rs
@@ -41,14 +41,14 @@ impl<S: BasePrecompileSpec> BasePrecompileInstaller<S> {
 // Function pointer (not a closure) satisfies the HRTB `for<'a> Fn(&'a Address) -> Option<DynPrecompile>`
 // required by `set_precompile_lookup`.
 fn b20_lookup(address: &Address) -> Option<DynPrecompile> {
-    if *address == crate::token::FACTORY_ADDRESS {
+    if *address == crate::token::TokenFactory::ADDRESS {
         Some(crate::token::TokenFactoryPrecompile::precompile())
     } else {
-        match crate::token::variant_of(address) {
-            crate::token::VARIANT_DEFAULT => {
+        match crate::token::TokenVariant::from_address(*address) {
+            Some(crate::token::TokenVariant::Default) => {
                 Some(crate::token::B20TokenPrecompile::create_precompile(*address))
             }
-            _ => None,
+            None => None,
         }
     }
 }

--- a/crates/common/precompiles/src/installer.rs
+++ b/crates/common/precompiles/src/installer.rs
@@ -59,7 +59,7 @@ mod tests {
     use rstest::rstest;
 
     use super::*;
-    use crate::token::{FACTORY_ADDRESS, VARIANT_DEFAULT, compute_b20_address};
+    use crate::token::{TokenFactory, TokenVariant};
 
     #[test]
     fn installer_preserves_base_precompile_set() {
@@ -81,14 +81,13 @@ mod tests {
     #[case::beryl(BaseUpgrade::Beryl, true)]
     fn installer_routes_b20_precompiles_by_fork(#[case] spec: BaseUpgrade, #[case] expected: bool) {
         let precompiles = BasePrecompileInstaller::new(spec).install();
-        let (token, _) = compute_b20_address(
+        let (token, _) = TokenVariant::Default.compute_address(
             Address::repeat_byte(0x11),
-            VARIANT_DEFAULT,
             18,
             B256::repeat_byte(0x22),
         );
 
-        assert_eq!(precompiles.get(&FACTORY_ADDRESS).is_some(), expected);
+        assert_eq!(precompiles.get(&TokenFactory::ADDRESS).is_some(), expected);
         assert_eq!(precompiles.get(&token).is_some(), expected);
         assert!(precompiles.get(&Address::repeat_byte(0x42)).is_none());
     }

--- a/crates/common/precompiles/src/installer.rs
+++ b/crates/common/precompiles/src/installer.rs
@@ -44,12 +44,11 @@ fn b20_lookup(address: &Address) -> Option<DynPrecompile> {
     if *address == crate::token::TokenFactory::ADDRESS {
         Some(crate::token::TokenFactoryPrecompile::precompile())
     } else {
-        match crate::token::TokenVariant::from_address(*address) {
-            Some(crate::token::TokenVariant::Default) => {
-                Some(crate::token::B20TokenPrecompile::create_precompile(*address))
+        crate::token::TokenVariant::from_address(*address).map(|variant| match variant {
+            crate::token::TokenVariant::Default => {
+                crate::token::B20TokenPrecompile::create_precompile(*address)
             }
-            None => None,
-        }
+        })
     }
 }
 

--- a/crates/common/precompiles/src/lib.rs
+++ b/crates/common/precompiles/src/lib.rs
@@ -22,10 +22,8 @@ mod bls12_381;
 
 mod token;
 pub use token::{
-    B20_PREFIX_BYTE, B20_PREFIX_MARKER, B20_TOKEN_ADDRESS, B20Token, B20TokenPrecompile,
-    B20TokenStorage, Burnable, CAPABILITY_CAP_MUTABLE, CAPABILITY_PAUSABLE, CREATE_TOKEN_VERSION,
-    Configurable, FACTORY_ADDRESS, IB20, ITokenFactory, Mintable, Pausable, Permittable,
-    RESERVED_SIZE, Redeemable, Token, TokenAccounting, TokenFactory, TokenFactoryPrecompile,
-    Transferable, VARIANT_DEFAULT, VARIANT_NONE, address_prefix, compute_b20_address, decimals_of,
-    has_b20_prefix, is_supported_variant, variant_of,
+    B20_TOKEN_ADDRESS, B20Token, B20TokenPrecompile, B20TokenStorage, Burnable,
+    CAPABILITY_CAP_MUTABLE, CAPABILITY_PAUSABLE, Configurable, IB20, ITokenFactory, Mintable,
+    Pausable, Permittable, Redeemable, Token, TokenAccounting, TokenFactory,
+    TokenFactoryPrecompile, TokenVariant, Transferable,
 };

--- a/crates/common/precompiles/src/token/b20/mod.rs
+++ b/crates/common/precompiles/src/token/b20/mod.rs
@@ -1,10 +1,12 @@
 //! `B20Token` native precompile — the core B-20 token implementation.
 
 mod dispatch;
-mod precompile;
-mod storage;
-mod token;
 
+mod precompile;
 pub use precompile::B20TokenPrecompile;
+
+mod storage;
 pub use storage::{B20_TOKEN_ADDRESS, B20TokenStorage};
+
+mod token;
 pub use token::B20Token;

--- a/crates/common/precompiles/src/token/b20/storage.rs
+++ b/crates/common/precompiles/src/token/b20/storage.rs
@@ -6,7 +6,7 @@ use base_precompile_storage::{
     BasePrecompileError, ContractStorage, Handler, Mapping, Result, StorageCtx,
 };
 
-use crate::token::{common::TokenAccounting, decimals_of};
+use crate::token::{TokenVariant, common::TokenAccounting};
 
 /// Canonical precompile address for the `B20Token` (placeholder — replace before deployment).
 pub const B20_TOKEN_ADDRESS: Address = address!("0000000000000000000000000000000000000900");
@@ -93,7 +93,7 @@ impl TokenAccounting for B20TokenStorage<'_> {
     }
 
     fn decimals(&self) -> Result<u8> {
-        Ok(decimals_of(&self.address))
+        Ok(TokenVariant::decimals_of(self.address).unwrap_or(0))
     }
 
     fn paused(&self) -> Result<U256> {

--- a/crates/common/precompiles/src/token/b20/token.rs
+++ b/crates/common/precompiles/src/token/b20/token.rs
@@ -9,7 +9,7 @@ use crate::token::common::{
     Transferable,
 };
 
-/// EVM precompile for the Default B-20 token variant.
+/// EVM precompile for the B-20 token variant.
 ///
 /// The generic `S` lets callers swap in an in-memory [`TokenAccounting`]
 /// implementation for unit tests without touching real EVM storage. In

--- a/crates/common/precompiles/src/token/factory/dispatch.rs
+++ b/crates/common/precompiles/src/token/factory/dispatch.rs
@@ -5,7 +5,7 @@ use alloy_sol_types::{SolCall, SolInterface};
 use base_precompile_storage::{BasePrecompileError, IntoPrecompileResult, StorageCtx};
 use revm::precompile::PrecompileResult;
 
-use super::storage::{TokenFactory, compute_b20_address};
+use super::{storage::TokenFactory, variant::TokenVariant};
 use crate::token::abi::ITokenFactory;
 
 impl<'a> TokenFactory<'a> {
@@ -33,8 +33,12 @@ impl<'a> TokenFactory<'a> {
                 Ok(ITokenFactory::createTokenCall::abi_encode_returns(&token).into())
             }
             Ok(ITokenFactory::ITokenFactoryCalls::predictTokenAddress(call)) => {
-                let (addr, _) =
-                    compute_b20_address(call.creator, call.variant, call.decimals, call.salt);
+                let (addr, _) = TokenVariant::compute_address_for_discriminant(
+                    call.creator,
+                    call.variant,
+                    call.decimals,
+                    call.salt,
+                );
                 Ok(ITokenFactory::predictTokenAddressCall::abi_encode_returns(&addr).into())
             }
             Ok(ITokenFactory::ITokenFactoryCalls::isB20(call)) => {

--- a/crates/common/precompiles/src/token/factory/mod.rs
+++ b/crates/common/precompiles/src/token/factory/mod.rs
@@ -1,12 +1,12 @@
 //! `TokenFactory` native precompile — creates B-20 tokens at deterministic prefix-encoded addresses.
 
 mod dispatch;
-mod precompile;
-mod storage;
 
+mod precompile;
 pub use precompile::TokenFactoryPrecompile;
-pub use storage::{
-    B20_PREFIX_BYTE, B20_PREFIX_MARKER, CREATE_TOKEN_VERSION, FACTORY_ADDRESS, RESERVED_SIZE,
-    TokenFactory, VARIANT_DEFAULT, VARIANT_NONE, address_prefix, compute_b20_address, decimals_of,
-    has_b20_prefix, is_supported_variant, variant_of,
-};
+
+mod storage;
+pub use storage::TokenFactory;
+
+mod variant;
+pub use variant::TokenVariant;

--- a/crates/common/precompiles/src/token/factory/storage.rs
+++ b/crates/common/precompiles/src/token/factory/storage.rs
@@ -481,7 +481,7 @@ mod tests {
     fn test_factory_dispatch_create_token_predicts_and_initializes_token() {
         let creator = Address::repeat_byte(0xCA);
         let salt = B256::repeat_byte(0x31);
-        let (expected_token, _) = compute_b20_address(creator, VARIANT_DEFAULT, 6, salt);
+        let (expected_token, _) = TokenVariant::Default.compute_address(creator, 6, salt);
         let mut params =
             token_params("Dispatch Token", "DSP", 6, U256::from(1_000u64), U256::from(10_000u64));
         params.minimumRedeemable = U256::from(25u64);
@@ -496,7 +496,7 @@ mod tests {
                     ctx,
                     ITokenFactory::predictTokenAddressCall {
                         creator,
-                        variant: VARIANT_DEFAULT,
+                        variant: TokenVariant::DEFAULT_DISCRIMINANT,
                         decimals: 6,
                         salt,
                     },
@@ -507,7 +507,11 @@ mod tests {
             assert_output(
                 dispatch_factory_success(
                     ctx,
-                    create_call(VARIANT_DEFAULT, params, B256::repeat_byte(0x31)),
+                    create_call(
+                        TokenVariant::DEFAULT_DISCRIMINANT,
+                        params,
+                        B256::repeat_byte(0x31),
+                    ),
                 ),
                 ITokenFactory::createTokenCall::abi_encode_returns(&expected_token),
             );
@@ -522,7 +526,9 @@ mod tests {
                     ctx,
                     ITokenFactory::variantOfCall { token: expected_token },
                 ),
-                ITokenFactory::variantOfCall::abi_encode_returns(&VARIANT_DEFAULT),
+                ITokenFactory::variantOfCall::abi_encode_returns(
+                    &TokenVariant::DEFAULT_DISCRIMINANT,
+                ),
             );
             assert_output(
                 dispatch_factory_success(
@@ -593,14 +599,17 @@ mod tests {
         let spender = Address::repeat_byte(0xEE);
         let charlie = Address::repeat_byte(0xCC);
         let salt = B256::repeat_byte(0x32);
-        let (token_addr, _) = compute_b20_address(creator, VARIANT_DEFAULT, 18, salt);
+        let (token_addr, _) = TokenVariant::Default.compute_address(creator, 18, salt);
         let params = token_params("Dispatch Token", "DSP", 18, U256::from(1_000u64), U256::MAX);
 
         let mut storage = HashMapStorageProvider::new(1);
         storage.set_caller(creator);
         StorageCtx::enter(&mut storage, |ctx| {
             assert_output(
-                dispatch_factory_success(ctx, create_call(VARIANT_DEFAULT, params, salt)),
+                dispatch_factory_success(
+                    ctx,
+                    create_call(TokenVariant::DEFAULT_DISCRIMINANT, params, salt),
+                ),
                 ITokenFactory::createTokenCall::abi_encode_returns(&token_addr),
             );
         });
@@ -670,7 +679,10 @@ mod tests {
 
         StorageCtx::enter(&mut storage, |ctx| {
             assert_output(
-                dispatch_factory_revert(ctx, create_call(VARIANT_DEFAULT, params, salt)),
+                dispatch_factory_revert(
+                    ctx,
+                    create_call(TokenVariant::DEFAULT_DISCRIMINANT, params, salt),
+                ),
                 ITokenFactory::ZeroAddress {}.abi_encode(),
             );
         });

--- a/crates/common/precompiles/src/token/factory/storage.rs
+++ b/crates/common/precompiles/src/token/factory/storage.rs
@@ -447,8 +447,8 @@ mod tests {
         StorageCtx::enter(&mut storage, |ctx| {
             let caller = Address::repeat_byte(0xCA);
             let (token_addr, lower_bytes) =
-                compute_b20_address(caller, VARIANT_DEFAULT, 18, B256::repeat_byte(0x09));
-            assert!(lower_bytes >= RESERVED_SIZE);
+                TokenVariant::Default.compute_address(caller, 18, B256::repeat_byte(0x09));
+            assert!(lower_bytes >= TokenFactory::RESERVED_SIZE);
             assert!(!ctx.has_bytecode(token_addr).unwrap());
 
             let mut token = token_at(token_addr, ctx);

--- a/crates/common/precompiles/src/token/factory/storage.rs
+++ b/crates/common/precompiles/src/token/factory/storage.rs
@@ -186,9 +186,9 @@ mod tests {
         }
     }
 
-    fn default_call(salt: B256) -> ITokenFactory::createTokenCall {
+    fn b20_call(salt: B256) -> ITokenFactory::createTokenCall {
         create_call(
-            TokenVariant::Default.discriminant(),
+            TokenVariant::B20.discriminant(),
             token_params("Test", "TST", 18, U256::from(1000), U256::MAX),
             salt,
         )
@@ -227,11 +227,11 @@ mod tests {
     fn test_token_variant_compute_address_encodes_variant_and_decimals() {
         let creator = Address::repeat_byte(0x11);
         let salt = B256::repeat_byte(0x22);
-        let (addr, lower_bytes) = TokenVariant::Default.compute_address(creator, 6, salt);
+        let (addr, lower_bytes) = TokenVariant::B20.compute_address(creator, 6, salt);
 
         assert!(lower_bytes >= TokenFactory::RESERVED_SIZE);
         assert!(TokenVariant::is_b20_address(addr));
-        assert_eq!(TokenVariant::from_address(addr), Some(TokenVariant::Default));
+        assert_eq!(TokenVariant::from_address(addr), Some(TokenVariant::B20));
         assert_eq!(TokenVariant::decimals_of(addr), Some(6));
     }
 
@@ -239,8 +239,8 @@ mod tests {
     fn test_different_decimals_produce_different_addresses() {
         let creator = Address::repeat_byte(0x11);
         let salt = B256::repeat_byte(0x33);
-        let (six, _) = TokenVariant::Default.compute_address(creator, 6, salt);
-        let (eighteen, _) = TokenVariant::Default.compute_address(creator, 18, salt);
+        let (six, _) = TokenVariant::B20.compute_address(creator, 6, salt);
+        let (eighteen, _) = TokenVariant::B20.compute_address(creator, 18, salt);
 
         assert_ne!(six, eighteen);
         assert_eq!(TokenVariant::decimals_of(six), Some(6));
@@ -269,11 +269,11 @@ mod tests {
         let mut storage = HashMapStorageProvider::new(1);
         let caller = Address::repeat_byte(0x55);
         let salt = B256::repeat_byte(0xAA);
-        let (expected_addr, _) = TokenVariant::Default.compute_address(caller, 18, salt);
+        let (expected_addr, _) = TokenVariant::B20.compute_address(caller, 18, salt);
 
         StorageCtx::enter(&mut storage, |ctx| {
             let mut factory = TokenFactory::new(ctx);
-            let token = factory.create_token(caller, default_call(salt)).unwrap();
+            let token = factory.create_token(caller, b20_call(salt)).unwrap();
 
             assert_eq!(token, expected_addr);
             assert!(ctx.has_bytecode(expected_addr).unwrap());
@@ -286,7 +286,7 @@ mod tests {
         let caller = Address::repeat_byte(0x55);
         let salt = B256::repeat_byte(0xBB);
         let call = create_call(
-            TokenVariant::Default.discriminant(),
+            TokenVariant::B20.discriminant(),
             token_params("My Token", "MYT", 6, U256::ZERO, U256::MAX),
             salt,
         );
@@ -311,7 +311,7 @@ mod tests {
         let recipient = Address::repeat_byte(0xCD);
         let supply = U256::from(5_000u64);
         let call = create_call(
-            TokenVariant::Default.discriminant(),
+            TokenVariant::B20.discriminant(),
             token_params("Supply Token", "SUP", 18, supply, U256::MAX),
             salt,
         );
@@ -334,8 +334,8 @@ mod tests {
 
         StorageCtx::enter(&mut storage, |ctx| {
             let mut factory = TokenFactory::new(ctx);
-            factory.create_token(caller, default_call(salt)).unwrap();
-            let result = factory.create_token(caller, default_call(salt));
+            factory.create_token(caller, b20_call(salt)).unwrap();
+            let result = factory.create_token(caller, b20_call(salt));
             assert!(result.is_err());
         });
     }
@@ -348,15 +348,15 @@ mod tests {
         StorageCtx::enter(&mut storage, |ctx| {
             let mut factory = TokenFactory::new(ctx);
 
-            let mut bad_version = default_call(B256::repeat_byte(0x01));
+            let mut bad_version = b20_call(B256::repeat_byte(0x01));
             bad_version.params.version = TokenFactory::CREATE_TOKEN_VERSION + 1;
             assert!(factory.create_token(caller, bad_version).is_err());
 
-            let mut bad_variant = default_call(B256::repeat_byte(0x02));
+            let mut bad_variant = b20_call(B256::repeat_byte(0x02));
             bad_variant.params.variant = 2;
             assert!(factory.create_token(caller, bad_variant).is_err());
 
-            let mut unsupported_optional = default_call(B256::repeat_byte(0x03));
+            let mut unsupported_optional = b20_call(B256::repeat_byte(0x03));
             unsupported_optional.params.optionalParams = Bytes::from_static(&[0x01]);
             assert!(factory.create_token(caller, unsupported_optional).is_err());
         });
@@ -367,7 +367,7 @@ mod tests {
         let mut storage = HashMapStorageProvider::new(1);
         let caller = Address::repeat_byte(0x55);
         let salt = B256::repeat_byte(0xDD);
-        let mut call = default_call(salt);
+        let mut call = b20_call(salt);
         call.params
             .postCreateCalls
             .push(IB20::setNameCall { newName: "Configured".to_string() }.abi_encode().into());
@@ -386,17 +386,17 @@ mod tests {
         let mut storage = HashMapStorageProvider::new(1);
         let caller = Address::repeat_byte(0x55);
         let salt = B256::repeat_byte(0x11);
-        let (addr, _) = TokenVariant::Default.compute_address(caller, 18, salt);
+        let (addr, _) = TokenVariant::B20.compute_address(caller, 18, salt);
 
         StorageCtx::enter(&mut storage, |ctx| {
             let mut factory = TokenFactory::new(ctx);
             assert!(!factory.is_b20(addr).unwrap());
 
-            let token = factory.create_token(caller, default_call(salt)).unwrap();
+            let token = factory.create_token(caller, b20_call(salt)).unwrap();
             assert!(factory.is_b20(token).unwrap());
             assert_eq!(
                 factory.variant_of_token(token).unwrap(),
-                TokenVariant::Default.discriminant()
+                TokenVariant::B20.discriminant()
             );
         });
     }
@@ -423,7 +423,7 @@ mod tests {
                 .create_token(
                     Address::repeat_byte(0xCA),
                     create_call(
-                        TokenVariant::Default.discriminant(),
+                        TokenVariant::B20.discriminant(),
                         params,
                         B256::repeat_byte(0x12),
                     ),
@@ -449,10 +449,10 @@ mod tests {
         StorageCtx::enter(&mut storage, |ctx| {
             let mut factory = TokenFactory::new(ctx);
             let first = factory
-                .create_token(Address::repeat_byte(0xCA), default_call(B256::repeat_byte(0x07)))
+                .create_token(Address::repeat_byte(0xCA), b20_call(B256::repeat_byte(0x07)))
                 .unwrap();
             let second = factory
-                .create_token(Address::repeat_byte(0xCA), default_call(B256::repeat_byte(0x08)))
+                .create_token(Address::repeat_byte(0xCA), b20_call(B256::repeat_byte(0x08)))
                 .unwrap();
 
             assert_ne!(first, second);
@@ -481,7 +481,7 @@ mod tests {
     fn test_factory_dispatch_create_token_predicts_and_initializes_token() {
         let creator = Address::repeat_byte(0xCA);
         let salt = B256::repeat_byte(0x31);
-        let (expected_token, _) = TokenVariant::Default.compute_address(creator, 6, salt);
+        let (expected_token, _) = TokenVariant::B20.compute_address(creator, 6, salt);
         let mut params =
             token_params("Dispatch Token", "DSP", 6, U256::from(1_000u64), U256::from(10_000u64));
         params.minimumRedeemable = U256::from(25u64);
@@ -496,7 +496,7 @@ mod tests {
                     ctx,
                     ITokenFactory::predictTokenAddressCall {
                         creator,
-                        variant: TokenVariant::DEFAULT_DISCRIMINANT,
+                        variant: TokenVariant::B20_DISCRIMINANT,
                         decimals: 6,
                         salt,
                     },
@@ -508,7 +508,7 @@ mod tests {
                 dispatch_factory_success(
                     ctx,
                     create_call(
-                        TokenVariant::DEFAULT_DISCRIMINANT,
+                        TokenVariant::B20_DISCRIMINANT,
                         params,
                         B256::repeat_byte(0x31),
                     ),
@@ -527,7 +527,7 @@ mod tests {
                     ITokenFactory::variantOfCall { token: expected_token },
                 ),
                 ITokenFactory::variantOfCall::abi_encode_returns(
-                    &TokenVariant::DEFAULT_DISCRIMINANT,
+                    &TokenVariant::B20_DISCRIMINANT,
                 ),
             );
             assert_output(
@@ -579,7 +579,7 @@ mod tests {
         StorageCtx::enter(&mut storage, |ctx| {
             let caller = Address::repeat_byte(0xCA);
             let (token_addr, lower_bytes) =
-                TokenVariant::Default.compute_address(caller, 18, B256::repeat_byte(0x09));
+                TokenVariant::B20.compute_address(caller, 18, B256::repeat_byte(0x09));
             assert!(lower_bytes >= TokenFactory::RESERVED_SIZE);
             assert!(!ctx.has_bytecode(token_addr).unwrap());
 
@@ -599,7 +599,7 @@ mod tests {
         let spender = Address::repeat_byte(0xEE);
         let charlie = Address::repeat_byte(0xCC);
         let salt = B256::repeat_byte(0x32);
-        let (token_addr, _) = TokenVariant::Default.compute_address(creator, 18, salt);
+        let (token_addr, _) = TokenVariant::B20.compute_address(creator, 18, salt);
         let params = token_params("Dispatch Token", "DSP", 18, U256::from(1_000u64), U256::MAX);
 
         let mut storage = HashMapStorageProvider::new(1);
@@ -608,7 +608,7 @@ mod tests {
             assert_output(
                 dispatch_factory_success(
                     ctx,
-                    create_call(TokenVariant::DEFAULT_DISCRIMINANT, params, salt),
+                    create_call(TokenVariant::B20_DISCRIMINANT, params, salt),
                 ),
                 ITokenFactory::createTokenCall::abi_encode_returns(&token_addr),
             );
@@ -681,7 +681,7 @@ mod tests {
             assert_output(
                 dispatch_factory_revert(
                     ctx,
-                    create_call(TokenVariant::DEFAULT_DISCRIMINANT, params, salt),
+                    create_call(TokenVariant::B20_DISCRIMINANT, params, salt),
                 ),
                 ITokenFactory::ZeroAddress {}.abi_encode(),
             );

--- a/crates/common/precompiles/src/token/factory/storage.rs
+++ b/crates/common/precompiles/src/token/factory/storage.rs
@@ -394,10 +394,7 @@ mod tests {
 
             let token = factory.create_token(caller, b20_call(salt)).unwrap();
             assert!(factory.is_b20(token).unwrap());
-            assert_eq!(
-                factory.variant_of_token(token).unwrap(),
-                TokenVariant::B20.discriminant()
-            );
+            assert_eq!(factory.variant_of_token(token).unwrap(), TokenVariant::B20.discriminant());
         });
     }
 
@@ -422,11 +419,7 @@ mod tests {
             let token_addr = factory
                 .create_token(
                     Address::repeat_byte(0xCA),
-                    create_call(
-                        TokenVariant::B20.discriminant(),
-                        params,
-                        B256::repeat_byte(0x12),
-                    ),
+                    create_call(TokenVariant::B20.discriminant(), params, B256::repeat_byte(0x12)),
                 )
                 .unwrap();
 
@@ -507,11 +500,7 @@ mod tests {
             assert_output(
                 dispatch_factory_success(
                     ctx,
-                    create_call(
-                        TokenVariant::B20_DISCRIMINANT,
-                        params,
-                        B256::repeat_byte(0x31),
-                    ),
+                    create_call(TokenVariant::B20_DISCRIMINANT, params, B256::repeat_byte(0x31)),
                 ),
                 ITokenFactory::createTokenCall::abi_encode_returns(&expected_token),
             );
@@ -526,9 +515,7 @@ mod tests {
                     ctx,
                     ITokenFactory::variantOfCall { token: expected_token },
                 ),
-                ITokenFactory::variantOfCall::abi_encode_returns(
-                    &TokenVariant::B20_DISCRIMINANT,
-                ),
+                ITokenFactory::variantOfCall::abi_encode_returns(&TokenVariant::B20_DISCRIMINANT),
             );
             assert_output(
                 dispatch_factory_success(

--- a/crates/common/precompiles/src/token/factory/storage.rs
+++ b/crates/common/precompiles/src/token/factory/storage.rs
@@ -1,90 +1,29 @@
-use alloy_primitives::{Address, B256, Bytes, U256, address, keccak256};
+use alloy_primitives::{Address, Bytes, U256, address};
 use alloy_sol_types::SolValue;
 use base_precompile_macros::contract;
 use base_precompile_storage::{BasePrecompileError, Handler, Result};
 use revm::state::Bytecode;
 
+use super::variant::TokenVariant;
 use crate::token::{B20Token, B20TokenStorage, TokenAccounting, abi::ITokenFactory};
 
 /// Singleton precompile address for the `TokenFactory`.
-pub const FACTORY_ADDRESS: Address = address!("b02f000000000000000000000000000000000000");
-
-/// First byte of every B-20 address.
-pub const B20_PREFIX_BYTE: u8 = 0xb0;
-/// Second byte of every B-20 address.
-pub const B20_PREFIX_MARKER: u8 = 0x20;
-/// Current token creation parameter version.
-pub const CREATE_TOKEN_VERSION: u8 = 1;
-
-/// Addresses whose lower-8-byte value (as `u64`) is less than this are reserved for
-/// protocol-level bootstrap tokens and cannot be created by public `create*` calls.
-pub const RESERVED_SIZE: u64 = 1024;
-
-/// Variant discriminant returned by `variantOf` when address has no B-20 prefix.
-pub const VARIANT_NONE: u8 = 0;
-/// Variant discriminant for default B-20 tokens.
-pub const VARIANT_DEFAULT: u8 = 1;
-
-/// Returns `true` if `addr` has the address prefix of any B-20 token variant.
-pub fn has_b20_prefix(addr: &Address) -> bool {
-    let b = addr.as_slice();
-    b[0] == B20_PREFIX_BYTE
-        && b[1] == B20_PREFIX_MARKER
-        && b[2] == VARIANT_DEFAULT
-        && b[4..12] == [0u8; 8]
-}
-
-/// Returns the variant discriminant for `addr` based on its address prefix.
-pub fn variant_of(addr: &Address) -> u8 {
-    if !has_b20_prefix(addr) {
-        return VARIANT_NONE;
-    }
-    addr.as_slice()[2]
-}
-
-/// Returns the decimal count encoded in `addr`.
-pub fn decimals_of(addr: &Address) -> u8 {
-    if !has_b20_prefix(addr) {
-        return 0;
-    }
-    addr.as_slice()[3]
-}
-
-/// Builds the B-20 address prefix for `variant` and `decimals`.
-pub const fn address_prefix(variant: u8, decimals: u8) -> [u8; 12] {
-    [B20_PREFIX_BYTE, B20_PREFIX_MARKER, variant, decimals, 0, 0, 0, 0, 0, 0, 0, 0]
-}
-
-/// Computes the deterministic address for a B-20 token.
-pub fn compute_b20_address(
-    creator: Address,
-    variant: u8,
-    decimals: u8,
-    salt: B256,
-) -> (Address, u64) {
-    let hash = keccak256((creator, salt).abi_encode());
-
-    let mut lower_bytes_buf = [0u8; 8];
-    lower_bytes_buf.copy_from_slice(&hash[..8]);
-    let lower_bytes = u64::from_be_bytes(lower_bytes_buf);
-
-    let mut addr_bytes = [0u8; 20];
-    addr_bytes[..12].copy_from_slice(&address_prefix(variant, decimals));
-    addr_bytes[12..].copy_from_slice(&hash[..8]);
-
-    (Address::from(addr_bytes), lower_bytes)
-}
-
-/// Returns whether `variant` is supported by this factory.
-pub const fn is_supported_variant(variant: u8) -> bool {
-    variant == VARIANT_DEFAULT
-}
+const FACTORY_ADDRESS: Address = address!("b02f000000000000000000000000000000000000");
 
 /// The B-20 token factory precompile.
 #[contract(addr = FACTORY_ADDRESS)]
 pub struct TokenFactory {}
 
 impl<'a> TokenFactory<'a> {
+    /// Singleton precompile address for the `TokenFactory`.
+    pub const ADDRESS: Address = FACTORY_ADDRESS;
+
+    /// Current token creation parameter version.
+    pub const CREATE_TOKEN_VERSION: u8 = 1;
+
+    /// Addresses whose lower-8-byte value is reserved for protocol bootstrap tokens.
+    pub const RESERVED_SIZE: u64 = 1024;
+
     /// Creates a token at a deterministic address derived from `(caller, variant, decimals, salt)`.
     pub fn create_token(
         &mut self,
@@ -92,16 +31,16 @@ impl<'a> TokenFactory<'a> {
         call: ITokenFactory::createTokenCall,
     ) -> Result<Address> {
         let p = call.params;
-        if p.version != CREATE_TOKEN_VERSION {
+        if p.version != Self::CREATE_TOKEN_VERSION {
             return Err(BasePrecompileError::revert(ITokenFactory::UnsupportedTokenVersion {
                 version: p.version,
             }));
         }
-        if !is_supported_variant(p.variant) {
+        let Some(variant) = TokenVariant::from_discriminant(p.variant) else {
             return Err(BasePrecompileError::revert(ITokenFactory::UnsupportedTokenVariant {
                 variant: p.variant,
             }));
-        }
+        };
         if !p.optionalParams.is_empty() {
             return Err(BasePrecompileError::revert(ITokenFactory::UnsupportedOptionalParams {}));
         }
@@ -117,9 +56,9 @@ impl<'a> TokenFactory<'a> {
         }
 
         let (token_address, lower_bytes) =
-            compute_b20_address(caller, p.variant, token_params.decimals, p.salt);
+            variant.compute_address(caller, token_params.decimals, p.salt);
 
-        if lower_bytes < RESERVED_SIZE {
+        if lower_bytes < Self::RESERVED_SIZE {
             return Err(BasePrecompileError::revert(ITokenFactory::AddressReserved {
                 token: token_address,
             }));
@@ -177,7 +116,7 @@ impl<'a> TokenFactory<'a> {
 
     /// Returns whether `token` is a deployed B-20 token (prefix match + non-empty code).
     pub fn is_b20(&self, token: Address) -> Result<bool> {
-        if !has_b20_prefix(&token) {
+        if !TokenVariant::is_b20_address(token) {
             return Ok(false);
         }
         self.storage.with_account_info(token, |info| Ok(!info.is_empty_code_hash()))
@@ -185,18 +124,22 @@ impl<'a> TokenFactory<'a> {
 
     /// Returns the variant discriminant for `token` decoded from its address prefix.
     pub fn variant_of_token(&self, token: Address) -> Result<u8> {
-        Ok(variant_of(&token))
+        let Some(variant) = TokenVariant::from_address(token) else {
+            return Ok(TokenVariant::NONE_DISCRIMINANT);
+        };
+        Ok(variant.discriminant())
     }
 
     /// Returns the decimals encoded in `token`.
     pub fn decimals_of_token(&self, token: Address) -> Result<u8> {
-        Ok(decimals_of(&token))
+        Ok(TokenVariant::decimals_of(token).unwrap_or(0))
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use alloy_sol_types::{SolCall, SolError};
+    use alloy_primitives::B256;
+    use alloy_sol_types::{SolCall, SolError, SolValue};
     use base_precompile_storage::{HashMapStorageProvider, StorageCtx};
 
     use super::*;
@@ -233,7 +176,7 @@ mod tests {
     ) -> ITokenFactory::createTokenCall {
         ITokenFactory::createTokenCall {
             params: ITokenFactory::CreateTokenParams {
-                version: CREATE_TOKEN_VERSION,
+                version: TokenFactory::CREATE_TOKEN_VERSION,
                 variant,
                 requiredParams: params.abi_encode().into(),
                 optionalParams: Bytes::new(),
@@ -245,7 +188,7 @@ mod tests {
 
     fn default_call(salt: B256) -> ITokenFactory::createTokenCall {
         create_call(
-            VARIANT_DEFAULT,
+            TokenVariant::Default.discriminant(),
             token_params("Test", "TST", 18, U256::from(1000), U256::MAX),
             salt,
         )
@@ -256,42 +199,44 @@ mod tests {
     }
 
     #[test]
-    fn test_compute_b20_address_encodes_variant_and_decimals() {
+    fn test_token_variant_compute_address_encodes_variant_and_decimals() {
         let creator = Address::repeat_byte(0x11);
         let salt = B256::repeat_byte(0x22);
-        let (addr, lower_bytes) = compute_b20_address(creator, VARIANT_DEFAULT, 6, salt);
+        let (addr, lower_bytes) = TokenVariant::Default.compute_address(creator, 6, salt);
 
-        assert!(lower_bytes >= RESERVED_SIZE);
-        assert!(has_b20_prefix(&addr));
-        assert_eq!(variant_of(&addr), VARIANT_DEFAULT);
-        assert_eq!(decimals_of(&addr), 6);
+        assert!(lower_bytes >= TokenFactory::RESERVED_SIZE);
+        assert!(TokenVariant::is_b20_address(addr));
+        assert_eq!(TokenVariant::from_address(addr), Some(TokenVariant::Default));
+        assert_eq!(TokenVariant::decimals_of(addr), Some(6));
     }
 
     #[test]
     fn test_different_decimals_produce_different_addresses() {
         let creator = Address::repeat_byte(0x11);
         let salt = B256::repeat_byte(0x33);
-        let (six, _) = compute_b20_address(creator, VARIANT_DEFAULT, 6, salt);
-        let (eighteen, _) = compute_b20_address(creator, VARIANT_DEFAULT, 18, salt);
+        let (six, _) = TokenVariant::Default.compute_address(creator, 6, salt);
+        let (eighteen, _) = TokenVariant::Default.compute_address(creator, 18, salt);
 
         assert_ne!(six, eighteen);
-        assert_eq!(decimals_of(&six), 6);
-        assert_eq!(decimals_of(&eighteen), 18);
+        assert_eq!(TokenVariant::decimals_of(six), Some(6));
+        assert_eq!(TokenVariant::decimals_of(eighteen), Some(18));
     }
 
     #[test]
     fn test_unsupported_variants_are_not_b20_prefixes() {
         let creator = Address::repeat_byte(0x11);
         let salt = B256::repeat_byte(0x44);
-        let (unsupported_stablecoin, _) = compute_b20_address(creator, 2, 18, salt);
-        let (unsupported_security, _) = compute_b20_address(creator, 3, 18, salt);
+        let (unsupported_stablecoin, _) =
+            TokenVariant::compute_address_for_discriminant(creator, 2, 18, salt);
+        let (unsupported_security, _) =
+            TokenVariant::compute_address_for_discriminant(creator, 3, 18, salt);
 
-        assert!(!is_supported_variant(2));
-        assert!(!is_supported_variant(3));
-        assert!(!has_b20_prefix(&unsupported_stablecoin));
-        assert!(!has_b20_prefix(&unsupported_security));
-        assert_eq!(variant_of(&unsupported_stablecoin), VARIANT_NONE);
-        assert_eq!(variant_of(&unsupported_security), VARIANT_NONE);
+        assert!(!TokenVariant::is_supported_discriminant(2));
+        assert!(!TokenVariant::is_supported_discriminant(3));
+        assert!(!TokenVariant::is_b20_address(unsupported_stablecoin));
+        assert!(!TokenVariant::is_b20_address(unsupported_security));
+        assert_eq!(TokenVariant::from_address(unsupported_stablecoin), None);
+        assert_eq!(TokenVariant::from_address(unsupported_security), None);
     }
 
     #[test]
@@ -299,7 +244,7 @@ mod tests {
         let mut storage = HashMapStorageProvider::new(1);
         let caller = Address::repeat_byte(0x55);
         let salt = B256::repeat_byte(0xAA);
-        let (expected_addr, _) = compute_b20_address(caller, VARIANT_DEFAULT, 18, salt);
+        let (expected_addr, _) = TokenVariant::Default.compute_address(caller, 18, salt);
 
         StorageCtx::enter(&mut storage, |ctx| {
             let mut factory = TokenFactory::new(ctx);
@@ -316,7 +261,7 @@ mod tests {
         let caller = Address::repeat_byte(0x55);
         let salt = B256::repeat_byte(0xBB);
         let call = create_call(
-            VARIANT_DEFAULT,
+            TokenVariant::Default.discriminant(),
             token_params("My Token", "MYT", 6, U256::ZERO, U256::MAX),
             salt,
         );
@@ -341,7 +286,7 @@ mod tests {
         let recipient = Address::repeat_byte(0xCD);
         let supply = U256::from(5_000u64);
         let call = create_call(
-            VARIANT_DEFAULT,
+            TokenVariant::Default.discriminant(),
             token_params("Supply Token", "SUP", 18, supply, U256::MAX),
             salt,
         );
@@ -379,7 +324,7 @@ mod tests {
             let mut factory = TokenFactory::new(ctx);
 
             let mut bad_version = default_call(B256::repeat_byte(0x01));
-            bad_version.params.version = CREATE_TOKEN_VERSION + 1;
+            bad_version.params.version = TokenFactory::CREATE_TOKEN_VERSION + 1;
             assert!(factory.create_token(caller, bad_version).is_err());
 
             let mut bad_variant = default_call(B256::repeat_byte(0x02));
@@ -416,7 +361,7 @@ mod tests {
         let mut storage = HashMapStorageProvider::new(1);
         let caller = Address::repeat_byte(0x55);
         let salt = B256::repeat_byte(0x11);
-        let (addr, _) = compute_b20_address(caller, VARIANT_DEFAULT, 18, salt);
+        let (addr, _) = TokenVariant::Default.compute_address(caller, 18, salt);
 
         StorageCtx::enter(&mut storage, |ctx| {
             let mut factory = TokenFactory::new(ctx);
@@ -424,7 +369,10 @@ mod tests {
 
             let token = factory.create_token(caller, default_call(salt)).unwrap();
             assert!(factory.is_b20(token).unwrap());
-            assert_eq!(factory.variant_of_token(token).unwrap(), VARIANT_DEFAULT);
+            assert_eq!(
+                factory.variant_of_token(token).unwrap(),
+                TokenVariant::Default.discriminant()
+            );
         });
     }
 
@@ -438,7 +386,11 @@ mod tests {
             let token_addr = factory
                 .create_token(
                     Address::repeat_byte(0xCA),
-                    create_call(VARIANT_DEFAULT, params, B256::repeat_byte(0x12)),
+                    create_call(
+                        TokenVariant::Default.discriminant(),
+                        params,
+                        B256::repeat_byte(0x12),
+                    ),
                 )
                 .unwrap();
 

--- a/crates/common/precompiles/src/token/factory/variant.rs
+++ b/crates/common/precompiles/src/token/factory/variant.rs
@@ -7,8 +7,8 @@ use alloy_sol_types::SolValue;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
 pub enum TokenVariant {
-    /// Default B-20 token.
-    Default = 1,
+    /// B-20 token.
+    B20 = 1,
 }
 
 impl TokenVariant {
@@ -21,13 +21,13 @@ impl TokenVariant {
     /// Variant discriminant returned by `variantOf` when address has no B-20 prefix.
     pub const NONE_DISCRIMINANT: u8 = 0;
 
-    /// Variant discriminant for default B-20 tokens.
-    pub const DEFAULT_DISCRIMINANT: u8 = Self::Default as u8;
+    /// Variant discriminant for B-20 tokens.
+    pub const B20_DISCRIMINANT: u8 = Self::B20 as u8;
 
     /// Returns the supported token variant for `variant`, if any.
     pub const fn from_discriminant(variant: u8) -> Option<Self> {
         match variant {
-            Self::DEFAULT_DISCRIMINANT => Some(Self::Default),
+            Self::B20_DISCRIMINANT => Some(Self::B20),
             _ => None,
         }
     }

--- a/crates/common/precompiles/src/token/factory/variant.rs
+++ b/crates/common/precompiles/src/token/factory/variant.rs
@@ -1,0 +1,127 @@
+//! B-20 token variant address derivation.
+
+use alloy_primitives::{Address, B256, keccak256};
+use alloy_sol_types::SolValue;
+
+/// B-20 token variant encoded in the token address prefix.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum TokenVariant {
+    /// Default B-20 token.
+    Default = 1,
+}
+
+impl TokenVariant {
+    /// First byte of every B-20 address.
+    pub const PREFIX_BYTE: u8 = 0xb0;
+
+    /// Second byte of every B-20 address.
+    pub const PREFIX_MARKER: u8 = 0x20;
+
+    /// Variant discriminant returned by `variantOf` when address has no B-20 prefix.
+    pub const NONE_DISCRIMINANT: u8 = 0;
+
+    /// Variant discriminant for default B-20 tokens.
+    pub const DEFAULT_DISCRIMINANT: u8 = Self::Default as u8;
+
+    /// Returns the supported token variant for `variant`, if any.
+    pub const fn from_discriminant(variant: u8) -> Option<Self> {
+        match variant {
+            Self::DEFAULT_DISCRIMINANT => Some(Self::Default),
+            _ => None,
+        }
+    }
+
+    /// Returns whether `variant` is supported by this factory.
+    pub const fn is_supported_discriminant(variant: u8) -> bool {
+        Self::from_discriminant(variant).is_some()
+    }
+
+    /// Returns the token variant encoded in `address`, if it has a supported B-20 prefix.
+    pub fn from_address(address: Address) -> Option<Self> {
+        let bytes = address.as_slice();
+        if bytes[0] != Self::PREFIX_BYTE
+            || bytes[1] != Self::PREFIX_MARKER
+            || bytes[4..12] != [0u8; 8]
+        {
+            return None;
+        }
+
+        Self::from_discriminant(bytes[2])
+    }
+
+    /// Returns this variant's ABI discriminant.
+    pub const fn discriminant(self) -> u8 {
+        self as u8
+    }
+
+    /// Builds this variant's B-20 address prefix for `decimals`.
+    pub const fn address_prefix(self, decimals: u8) -> [u8; 12] {
+        [
+            Self::PREFIX_BYTE,
+            Self::PREFIX_MARKER,
+            self.discriminant(),
+            decimals,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+        ]
+    }
+
+    /// Computes this variant's deterministic token address for `creator`, `decimals`, and `salt`.
+    ///
+    /// Returns the address and the lower 8 bytes of the hash as a `u64` for the reserved-range
+    /// check.
+    pub fn compute_address(self, creator: Address, decimals: u8, salt: B256) -> (Address, u64) {
+        let hash = keccak256((creator, salt).abi_encode());
+
+        let mut lower_bytes_buf = [0u8; 8];
+        lower_bytes_buf.copy_from_slice(&hash[..8]);
+        let lower_bytes = u64::from_be_bytes(lower_bytes_buf);
+
+        let mut addr_bytes = [0u8; 20];
+        addr_bytes[..12].copy_from_slice(&self.address_prefix(decimals));
+        addr_bytes[12..].copy_from_slice(&hash[..8]);
+
+        (Address::from(addr_bytes), lower_bytes)
+    }
+
+    /// Computes a deterministic B-20 token address for an ABI discriminant.
+    pub fn compute_address_for_discriminant(
+        creator: Address,
+        variant: u8,
+        decimals: u8,
+        salt: B256,
+    ) -> (Address, u64) {
+        let hash = keccak256((creator, salt).abi_encode());
+
+        let mut lower_bytes_buf = [0u8; 8];
+        lower_bytes_buf.copy_from_slice(&hash[..8]);
+        let lower_bytes = u64::from_be_bytes(lower_bytes_buf);
+
+        let mut addr_bytes = [0u8; 20];
+        addr_bytes[0] = Self::PREFIX_BYTE;
+        addr_bytes[1] = Self::PREFIX_MARKER;
+        addr_bytes[2] = variant;
+        addr_bytes[3] = decimals;
+        addr_bytes[12..].copy_from_slice(&hash[..8]);
+
+        (Address::from(addr_bytes), lower_bytes)
+    }
+
+    /// Returns `true` when `address` has a supported B-20 token variant prefix.
+    pub fn is_b20_address(address: Address) -> bool {
+        Self::from_address(address).is_some()
+    }
+
+    /// Returns the decimals encoded in `address` when it has a supported B-20 prefix.
+    pub fn decimals_of(address: Address) -> Option<u8> {
+        Self::from_address(address)?;
+        Some(address.as_slice()[3])
+    }
+}

--- a/crates/common/precompiles/src/token/mod.rs
+++ b/crates/common/precompiles/src/token/mod.rs
@@ -13,8 +13,4 @@ mod b20;
 pub use b20::{B20_TOKEN_ADDRESS, B20Token, B20TokenPrecompile, B20TokenStorage};
 
 mod factory;
-pub use factory::{
-    B20_PREFIX_BYTE, B20_PREFIX_MARKER, CREATE_TOKEN_VERSION, FACTORY_ADDRESS, RESERVED_SIZE,
-    TokenFactory, TokenFactoryPrecompile, VARIANT_DEFAULT, VARIANT_NONE, address_prefix,
-    compute_b20_address, decimals_of, has_b20_prefix, is_supported_variant, variant_of,
-};
+pub use factory::{TokenFactory, TokenFactoryPrecompile, TokenVariant};

--- a/devnet/src/b20.rs
+++ b/devnet/src/b20.rs
@@ -12,9 +12,7 @@ use alloy_signer::SignerSync;
 use alloy_signer_local::PrivateKeySigner;
 use alloy_sol_types::{SolCall, SolValue};
 use base_common_network::Base;
-use base_common_precompiles::{
-    CREATE_TOKEN_VERSION, FACTORY_ADDRESS, IB20, ITokenFactory, compute_b20_address,
-};
+use base_common_precompiles::{IB20, ITokenFactory, TokenFactory, TokenVariant};
 use base_common_rpc_types::BaseTransactionRequest;
 use eyre::{Result, WrapErr, ensure};
 use tokio::time::{sleep, timeout};
@@ -110,28 +108,33 @@ impl<'a> B20PrecompileClient<'a> {
     /// Creates a B-20 token through the factory and returns the deterministic token address.
     pub async fn create_token(
         &self,
-        variant: u8,
+        variant: TokenVariant,
         params: ITokenFactory::B20TokenParams,
         salt: B256,
     ) -> Result<Address> {
         let token = self.predict_token_address(variant, params.decimals, salt);
         let call = ITokenFactory::createTokenCall {
             params: ITokenFactory::CreateTokenParams {
-                version: CREATE_TOKEN_VERSION,
-                variant,
+                version: TokenFactory::CREATE_TOKEN_VERSION,
+                variant: variant.discriminant(),
                 requiredParams: params.abi_encode().into(),
                 optionalParams: Bytes::new(),
                 postCreateCalls: Vec::new(),
                 salt,
             },
         };
-        self.send_call(FACTORY_ADDRESS, call, "create B-20 token").await?;
+        self.send_call(TokenFactory::ADDRESS, call, "create B-20 token").await?;
         Ok(token)
     }
 
     /// Computes the token address a factory creation call will use.
-    pub fn predict_token_address(&self, variant: u8, decimals: u8, salt: B256) -> Address {
-        compute_b20_address(self.signer.address(), variant, decimals, salt).0
+    pub fn predict_token_address(
+        &self,
+        variant: TokenVariant,
+        decimals: u8,
+        salt: B256,
+    ) -> Address {
+        variant.compute_address(self.signer.address(), decimals, salt).0
     }
 
     /// Waits for a created token address to return non-empty bytecode.
@@ -163,14 +166,16 @@ impl<'a> B20PrecompileClient<'a> {
 
     /// Reads the variant encoded in a token address via the factory.
     pub async fn variant_of(&self, token: Address) -> Result<u8> {
-        let output = self.call(FACTORY_ADDRESS, ITokenFactory::variantOfCall { token }).await?;
+        let output =
+            self.call(TokenFactory::ADDRESS, ITokenFactory::variantOfCall { token }).await?;
         ITokenFactory::variantOfCall::abi_decode_returns(output.as_ref())
             .wrap_err("Failed to decode variantOf")
     }
 
     /// Reads the decimals encoded in a token address via the factory.
     pub async fn decimals_of(&self, token: Address) -> Result<u8> {
-        let output = self.call(FACTORY_ADDRESS, ITokenFactory::decimalsOfCall { token }).await?;
+        let output =
+            self.call(TokenFactory::ADDRESS, ITokenFactory::decimalsOfCall { token }).await?;
         ITokenFactory::decimalsOfCall::abi_decode_returns(output.as_ref())
             .wrap_err("Failed to decode decimalsOf")
     }

--- a/devnet/tests/b20_precompile.rs
+++ b/devnet/tests/b20_precompile.rs
@@ -45,10 +45,10 @@ async fn test_b20_factory_create_and_transfer_via_rpc() -> Result<()> {
         admin.address(),
     );
 
-    let token = b20.create_token(TokenVariant::Default, params, salt).await?;
+    let token = b20.create_token(TokenVariant::B20, params, salt).await?;
     b20.wait_for_token_code(token, TX_RECEIPT_TIMEOUT, BLOCK_POLL_INTERVAL).await?;
 
-    assert_eq!(b20.variant_of(token).await?, TokenVariant::Default.discriminant());
+    assert_eq!(b20.variant_of(token).await?, TokenVariant::B20.discriminant());
     assert_eq!(b20.decimals_of(token).await?, TOKEN_DECIMALS);
 
     let admin_balance_before = b20.balance_of(token, admin.address()).await?;

--- a/devnet/tests/b20_precompile.rs
+++ b/devnet/tests/b20_precompile.rs
@@ -6,7 +6,7 @@ use alloy_primitives::{B256, U256};
 use alloy_provider::{Provider, RootProvider};
 use alloy_signer_local::PrivateKeySigner;
 use base_common_network::Base;
-use base_common_precompiles::VARIANT_DEFAULT;
+use base_common_precompiles::TokenVariant;
 use devnet::{
     B20PrecompileClient, Devnet, DevnetBuilder,
     config::{ANVIL_ACCOUNT_5, ANVIL_ACCOUNT_6},
@@ -45,10 +45,10 @@ async fn test_b20_factory_create_and_transfer_via_rpc() -> Result<()> {
         admin.address(),
     );
 
-    let token = b20.create_token(VARIANT_DEFAULT, params, salt).await?;
+    let token = b20.create_token(TokenVariant::Default, params, salt).await?;
     b20.wait_for_token_code(token, TX_RECEIPT_TIMEOUT, BLOCK_POLL_INTERVAL).await?;
 
-    assert_eq!(b20.variant_of(token).await?, VARIANT_DEFAULT);
+    assert_eq!(b20.variant_of(token).await?, TokenVariant::Default.discriminant());
     assert_eq!(b20.decimals_of(token).await?, TOKEN_DECIMALS);
 
     let admin_balance_before = b20.balance_of(token, admin.address()).await?;


### PR DESCRIPTION
## Summary

This refactors B-20 token address derivation around the TokenVariant type instead of free-floating helper functions in factory storage. The factory, dispatch path, and dynamic precompile lookup now use TokenVariant methods for address prediction, prefix validation, and ABI discriminants while preserving the existing exported constants.