### PR TITLE
test(common): Add Precompile Integration Coverage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3408,6 +3408,7 @@ dependencies = [
  "base-precompile-storage",
  "criterion",
  "revm",
+ "rstest",
 ]
 
 [[package]]

--- a/crates/common/precompiles/Cargo.toml
+++ b/crates/common/precompiles/Cargo.toml
@@ -26,6 +26,7 @@ base-precompile-storage.workspace = true
 revm.workspace = true
 
 [dev-dependencies]
+rstest.workspace = true
 criterion.workspace = true
 base-precompile-storage = { workspace = true, features = ["test-utils"] }
 

--- a/crates/common/precompiles/src/bls12_381.rs
+++ b/crates/common/precompiles/src/bls12_381.rs
@@ -99,54 +99,25 @@ pub(crate) const JOVIAN_PAIRING: Precompile = Precompile::new(
 #[cfg(test)]
 mod tests {
     use revm::{precompile::PrecompileError, primitives::Bytes};
+    use rstest::rstest;
 
     use super::*;
 
-    #[test]
-    fn test_g1_msm_isthmus_max_size() {
-        let input = Bytes::from(vec![0u8; ISTHMUS_G1_MSM_MAX_INPUT_SIZE + 1]);
+    #[rstest]
+    #[case::g1_msm_isthmus(ISTHMUS_G1_MSM, ISTHMUS_G1_MSM_MAX_INPUT_SIZE, 260_000)]
+    #[case::g1_msm_jovian(JOVIAN_G1_MSM, JOVIAN_G1_MSM_MAX_INPUT_SIZE, u64::MAX)]
+    #[case::g2_msm_isthmus(ISTHMUS_G2_MSM, ISTHMUS_G2_MSM_MAX_INPUT_SIZE, 260_000)]
+    #[case::g2_msm_jovian(JOVIAN_G2_MSM, JOVIAN_G2_MSM_MAX_INPUT_SIZE, u64::MAX)]
+    #[case::pairing_isthmus(ISTHMUS_PAIRING, ISTHMUS_PAIRING_MAX_INPUT_SIZE, 260_000)]
+    #[case::pairing_jovian(JOVIAN_PAIRING, JOVIAN_PAIRING_MAX_INPUT_SIZE, u64::MAX)]
+    fn test_max_size_rejects_oversized_input(
+        #[case] precompile: Precompile,
+        #[case] max_input_size: usize,
+        #[case] gas_limit: u64,
+    ) {
+        let input = Bytes::from(vec![0u8; max_input_size + 1]);
         assert!(
-            matches!(ISTHMUS_G1_MSM.execute(&input, 260_000), Err(PrecompileError::Other(msg)) if msg.contains("input length too long"))
-        );
-    }
-
-    #[test]
-    fn test_g1_msm_jovian_max_size() {
-        let input = Bytes::from(vec![0u8; JOVIAN_G1_MSM_MAX_INPUT_SIZE + 1]);
-        assert!(
-            matches!(JOVIAN_G1_MSM.execute(&input, u64::MAX), Err(PrecompileError::Other(msg)) if msg.contains("input length too long"))
-        );
-    }
-
-    #[test]
-    fn test_g2_msm_isthmus_max_size() {
-        let input = Bytes::from(vec![0u8; ISTHMUS_G2_MSM_MAX_INPUT_SIZE + 1]);
-        assert!(
-            matches!(ISTHMUS_G2_MSM.execute(&input, 260_000), Err(PrecompileError::Other(msg)) if msg.contains("input length too long"))
-        );
-    }
-
-    #[test]
-    fn test_g2_msm_jovian_max_size() {
-        let input = Bytes::from(vec![0u8; JOVIAN_G2_MSM_MAX_INPUT_SIZE + 1]);
-        assert!(
-            matches!(JOVIAN_G2_MSM.execute(&input, u64::MAX), Err(PrecompileError::Other(msg)) if msg.contains("input length too long"))
-        );
-    }
-
-    #[test]
-    fn test_pairing_isthmus_max_size() {
-        let input = Bytes::from(vec![0u8; ISTHMUS_PAIRING_MAX_INPUT_SIZE + 1]);
-        assert!(
-            matches!(ISTHMUS_PAIRING.execute(&input, 260_000), Err(PrecompileError::Other(msg)) if msg.contains("input length too long"))
-        );
-    }
-
-    #[test]
-    fn test_pairing_jovian_max_size() {
-        let input = Bytes::from(vec![0u8; JOVIAN_PAIRING_MAX_INPUT_SIZE + 1]);
-        assert!(
-            matches!(JOVIAN_PAIRING.execute(&input, u64::MAX), Err(PrecompileError::Other(msg)) if msg.contains("input length too long"))
+            matches!(precompile.execute(&input, gas_limit), Err(PrecompileError::Other(msg)) if msg.contains("input length too long"))
         );
     }
 }

--- a/crates/common/precompiles/src/installer.rs
+++ b/crates/common/precompiles/src/installer.rs
@@ -59,9 +59,8 @@ mod tests {
     use revm::precompile::{bn254, secp256r1};
     use rstest::rstest;
 
-    use crate::token::{FACTORY_ADDRESS, compute_default_address};
-
     use super::*;
+    use crate::token::{FACTORY_ADDRESS, compute_default_address};
 
     #[test]
     fn installer_preserves_base_precompile_set() {

--- a/crates/common/precompiles/src/installer.rs
+++ b/crates/common/precompiles/src/installer.rs
@@ -55,7 +55,11 @@ fn b20_lookup(address: &Address) -> Option<DynPrecompile> {
 
 #[cfg(test)]
 mod tests {
+    use alloy_primitives::B256;
     use revm::precompile::{bn254, secp256r1};
+    use rstest::rstest;
+
+    use crate::token::{FACTORY_ADDRESS, compute_default_address};
 
     use super::*;
 
@@ -72,5 +76,18 @@ mod tests {
         let installer = BasePrecompileInstaller::new(BaseUpgrade::LATEST);
 
         assert_eq!(installer.spec(), BaseUpgrade::LATEST);
+    }
+
+    #[rstest]
+    #[case::azul(BaseUpgrade::Azul, false)]
+    #[case::beryl(BaseUpgrade::Beryl, true)]
+    fn installer_routes_b20_precompiles_by_fork(#[case] spec: BaseUpgrade, #[case] expected: bool) {
+        let precompiles = BasePrecompileInstaller::new(spec).install();
+        let (token, _) =
+            compute_default_address(Address::repeat_byte(0x11), B256::repeat_byte(0x22));
+
+        assert_eq!(precompiles.get(&FACTORY_ADDRESS).is_some(), expected);
+        assert_eq!(precompiles.get(&token).is_some(), expected);
+        assert!(precompiles.get(&Address::repeat_byte(0x42)).is_none());
     }
 }

--- a/crates/common/precompiles/src/installer.rs
+++ b/crates/common/precompiles/src/installer.rs
@@ -60,7 +60,7 @@ mod tests {
     use rstest::rstest;
 
     use super::*;
-    use crate::token::{FACTORY_ADDRESS, compute_default_address};
+    use crate::token::{FACTORY_ADDRESS, VARIANT_DEFAULT, compute_b20_address};
 
     #[test]
     fn installer_preserves_base_precompile_set() {
@@ -82,8 +82,12 @@ mod tests {
     #[case::beryl(BaseUpgrade::Beryl, true)]
     fn installer_routes_b20_precompiles_by_fork(#[case] spec: BaseUpgrade, #[case] expected: bool) {
         let precompiles = BasePrecompileInstaller::new(spec).install();
-        let (token, _) =
-            compute_default_address(Address::repeat_byte(0x11), B256::repeat_byte(0x22));
+        let (token, _) = compute_b20_address(
+            Address::repeat_byte(0x11),
+            VARIANT_DEFAULT,
+            18,
+            B256::repeat_byte(0x22),
+        );
 
         assert_eq!(precompiles.get(&FACTORY_ADDRESS).is_some(), expected);
         assert_eq!(precompiles.get(&token).is_some(), expected);

--- a/crates/common/precompiles/src/provider.rs
+++ b/crates/common/precompiles/src/provider.rs
@@ -183,6 +183,7 @@ mod tests {
         precompile::{PrecompileError, Precompiles, bls12_381_const, bn254, modexp, secp256r1},
         primitives::eip7823,
     };
+    use rstest::rstest;
 
     use super::*;
     use crate::{bls12_381, bn254_pair};
@@ -287,24 +288,18 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_get_jovian_precompile_at_max_input_len() {
-        assert_jovian_input_limits_accept_max(BaseUpgrade::Jovian);
+    #[rstest]
+    #[case::jovian(BaseUpgrade::Jovian)]
+    #[case::azul(BaseUpgrade::Azul)]
+    fn test_get_precompile_at_max_input_len(#[case] spec: BaseUpgrade) {
+        assert_jovian_input_limits_accept_max(spec);
     }
 
-    #[test]
-    fn test_get_jovian_precompile_with_bad_input_len() {
-        assert_jovian_input_limits(BaseUpgrade::Jovian);
-    }
-
-    #[test]
-    fn test_get_azul_precompile_at_max_input_len() {
-        assert_jovian_input_limits_accept_max(BaseUpgrade::Azul);
-    }
-
-    #[test]
-    fn test_get_azul_precompile_with_bad_input_len() {
-        assert_jovian_input_limits(BaseUpgrade::Azul);
+    #[rstest]
+    #[case::jovian(BaseUpgrade::Jovian)]
+    #[case::azul(BaseUpgrade::Azul)]
+    fn test_get_precompile_with_bad_input_len(#[case] spec: BaseUpgrade) {
+        assert_jovian_input_limits(spec);
     }
 
     #[test]
@@ -406,20 +401,17 @@ mod tests {
         ));
     }
 
-    #[test]
-    fn test_modexp_eip7823_each_field_rejects() {
-        let over = eip7823::INPUT_SIZE_LIMIT + 1;
-
+    #[rstest]
+    #[case::base_len(eip7823::INPUT_SIZE_LIMIT + 1, 0, 1)]
+    #[case::exp_len(0, eip7823::INPUT_SIZE_LIMIT + 1, 1)]
+    #[case::mod_len(0, 0, eip7823::INPUT_SIZE_LIMIT + 1)]
+    fn test_modexp_eip7823_each_field_rejects(
+        #[case] base_len: usize,
+        #[case] exp_len: usize,
+        #[case] mod_len: usize,
+    ) {
         assert!(matches!(
-            modexp::osaka_run(&modexp_input(over, 0, 1), u64::MAX),
-            Err(PrecompileError::ModexpEip7823LimitSize)
-        ));
-        assert!(matches!(
-            modexp::osaka_run(&modexp_input(0, over, 1), u64::MAX),
-            Err(PrecompileError::ModexpEip7823LimitSize)
-        ));
-        assert!(matches!(
-            modexp::osaka_run(&modexp_input(0, 0, over), u64::MAX),
+            modexp::osaka_run(&modexp_input(base_len, exp_len, mod_len), u64::MAX),
             Err(PrecompileError::ModexpEip7823LimitSize)
         ));
     }

--- a/crates/common/precompiles/src/token/factory/storage.rs
+++ b/crates/common/precompiles/src/token/factory/storage.rs
@@ -590,7 +590,7 @@ mod tests {
             );
             assert_output(
                 dispatch_b20_success(ctx, expected_token, IB20::decimalsCall {}),
-                6u8.abi_encode(),
+                IB20::decimalsCall::abi_encode_returns(&6u8),
             );
             assert_output(
                 dispatch_b20_success(ctx, expected_token, IB20::totalSupplyCall {}),
@@ -642,8 +642,7 @@ mod tests {
         let charlie = Address::repeat_byte(0xCC);
         let salt = B256::repeat_byte(0x32);
         let (token_addr, _) = compute_b20_address(creator, VARIANT_DEFAULT, 18, salt);
-        let params =
-            token_params("Dispatch Token", "DSP", 18, U256::from(1_000u64), U256::MAX);
+        let params = token_params("Dispatch Token", "DSP", 18, U256::from(1_000u64), U256::MAX);
 
         let mut storage = HashMapStorageProvider::new(1);
         storage.set_caller(creator);
@@ -680,11 +679,7 @@ mod tests {
                 dispatch_b20_success(
                     ctx,
                     token_addr,
-                    IB20::transferFromCall {
-                        from: alice,
-                        to: charlie,
-                        amount: U256::from(200u64),
-                    },
+                    IB20::transferFromCall { from: alice, to: charlie, amount: U256::from(200u64) },
                 ),
                 true.abi_encode(),
             );
@@ -701,7 +696,11 @@ mod tests {
                 U256::from(200u64).abi_encode(),
             );
             assert_output(
-                dispatch_b20_success(ctx, token_addr, IB20::allowanceCall { owner: alice, spender }),
+                dispatch_b20_success(
+                    ctx,
+                    token_addr,
+                    IB20::allowanceCall { owner: alice, spender },
+                ),
                 U256::from(50u64).abi_encode(),
             );
         });

--- a/crates/common/precompiles/src/token/factory/storage.rs
+++ b/crates/common/precompiles/src/token/factory/storage.rs
@@ -196,7 +196,7 @@ impl<'a> TokenFactory<'a> {
 
 #[cfg(test)]
 mod tests {
-    use alloy_sol_types::{SolCall, SolError};
+    use alloy_sol_types::{SolCall, SolError, SolValue};
     use base_precompile_storage::{HashMapStorageProvider, StorageCtx};
 
     use super::*;
@@ -253,6 +253,31 @@ mod tests {
 
     fn token_at<'a>(addr: Address, ctx: StorageCtx<'a>) -> B20Token<B20TokenStorage<'a>> {
         B20Token::with_storage(B20TokenStorage::from_address(addr, ctx))
+    }
+
+    fn assert_output(output: Bytes, expected: impl AsRef<[u8]>) {
+        assert_eq!(output.as_ref(), expected.as_ref());
+    }
+
+    fn dispatch_factory_success(ctx: StorageCtx<'_>, call: impl SolCall) -> Bytes {
+        let mut factory = TokenFactory::new(ctx);
+        let output = factory.dispatch(ctx, &call.abi_encode()).unwrap();
+        assert!(!output.reverted, "factory call reverted: {:?}", output.bytes);
+        output.bytes
+    }
+
+    fn dispatch_factory_revert(ctx: StorageCtx<'_>, call: impl SolCall) -> Bytes {
+        let mut factory = TokenFactory::new(ctx);
+        let output = factory.dispatch(ctx, &call.abi_encode()).unwrap();
+        assert!(output.reverted, "factory call unexpectedly succeeded");
+        output.bytes
+    }
+
+    fn dispatch_b20_success(ctx: StorageCtx<'_>, token_addr: Address, call: impl SolCall) -> Bytes {
+        let mut token = token_at(token_addr, ctx);
+        let output = token.dispatch(ctx, &call.abi_encode()).unwrap();
+        assert!(!output.reverted, "token call reverted: {:?}", output.bytes);
+        output.bytes
     }
 
     #[test]
@@ -429,6 +454,17 @@ mod tests {
     }
 
     #[test]
+    fn test_is_b20_false_for_non_prefix_address() {
+        let mut storage = HashMapStorageProvider::new(1);
+        let random_addr = Address::repeat_byte(0x42);
+
+        StorageCtx::enter(&mut storage, |ctx| {
+            let factory = TokenFactory::new(ctx);
+            assert!(!factory.is_b20(random_addr).unwrap());
+        });
+    }
+
+    #[test]
     fn test_transfer_and_mint_lifecycle() {
         let mut storage = HashMapStorageProvider::new(1);
         StorageCtx::enter(&mut storage, |ctx| {
@@ -490,6 +526,96 @@ mod tests {
     }
 
     #[test]
+    fn test_factory_dispatch_create_token_predicts_and_initializes_token() {
+        let creator = Address::repeat_byte(0xCA);
+        let salt = B256::repeat_byte(0x31);
+        let (expected_token, _) = compute_b20_address(creator, VARIANT_DEFAULT, 6, salt);
+        let mut params =
+            token_params("Dispatch Token", "DSP", 6, U256::from(1_000u64), U256::from(10_000u64));
+        params.minimumRedeemable = U256::from(25u64);
+        params.contractURI = "ipfs://dispatch".to_string();
+
+        let mut storage = HashMapStorageProvider::new(1);
+        storage.set_caller(creator);
+
+        StorageCtx::enter(&mut storage, |ctx| {
+            assert_output(
+                dispatch_factory_success(
+                    ctx,
+                    ITokenFactory::predictTokenAddressCall {
+                        creator,
+                        variant: VARIANT_DEFAULT,
+                        decimals: 6,
+                        salt,
+                    },
+                ),
+                ITokenFactory::predictTokenAddressCall::abi_encode_returns(&expected_token),
+            );
+
+            assert_output(
+                dispatch_factory_success(
+                    ctx,
+                    create_call(VARIANT_DEFAULT, params, B256::repeat_byte(0x31)),
+                ),
+                ITokenFactory::createTokenCall::abi_encode_returns(&expected_token),
+            );
+            assert!(ctx.has_bytecode(expected_token).unwrap());
+
+            assert_output(
+                dispatch_factory_success(ctx, ITokenFactory::isB20Call { token: expected_token }),
+                ITokenFactory::isB20Call::abi_encode_returns(&true),
+            );
+            assert_output(
+                dispatch_factory_success(
+                    ctx,
+                    ITokenFactory::variantOfCall { token: expected_token },
+                ),
+                ITokenFactory::variantOfCall::abi_encode_returns(&VARIANT_DEFAULT),
+            );
+            assert_output(
+                dispatch_factory_success(
+                    ctx,
+                    ITokenFactory::decimalsOfCall { token: expected_token },
+                ),
+                ITokenFactory::decimalsOfCall::abi_encode_returns(&6u8),
+            );
+
+            assert_output(
+                dispatch_b20_success(ctx, expected_token, IB20::nameCall {}),
+                "Dispatch Token".to_string().abi_encode(),
+            );
+            assert_output(
+                dispatch_b20_success(ctx, expected_token, IB20::symbolCall {}),
+                "DSP".to_string().abi_encode(),
+            );
+            assert_output(
+                dispatch_b20_success(ctx, expected_token, IB20::decimalsCall {}),
+                6u8.abi_encode(),
+            );
+            assert_output(
+                dispatch_b20_success(ctx, expected_token, IB20::totalSupplyCall {}),
+                U256::from(1_000u64).abi_encode(),
+            );
+            assert_output(
+                dispatch_b20_success(
+                    ctx,
+                    expected_token,
+                    IB20::balanceOfCall { account: Address::repeat_byte(0xCD) },
+                ),
+                U256::from(1_000u64).abi_encode(),
+            );
+            assert_output(
+                dispatch_b20_success(ctx, expected_token, IB20::minimumRedeemableCall {}),
+                U256::from(25u64).abi_encode(),
+            );
+            assert_output(
+                dispatch_b20_success(ctx, expected_token, IB20::contractURICall {}),
+                "ipfs://dispatch".to_string().abi_encode(),
+            );
+        });
+    }
+
+    #[test]
     fn test_uninitialized_prefix_token_reverts() {
         let mut storage = HashMapStorageProvider::new(1);
         StorageCtx::enter(&mut storage, |ctx| {
@@ -504,6 +630,98 @@ mod tests {
 
             assert!(result.reverted);
             assert_eq!(result.bytes.as_ref(), IB20::Uninitialized {}.abi_encode());
+        });
+    }
+
+    #[test]
+    fn test_b20_dispatch_transfer_approve_transfer_from() {
+        let creator = Address::repeat_byte(0xCA);
+        let alice = Address::repeat_byte(0xCD);
+        let bob = Address::repeat_byte(0xBB);
+        let spender = Address::repeat_byte(0xEE);
+        let charlie = Address::repeat_byte(0xCC);
+        let salt = B256::repeat_byte(0x32);
+        let (token_addr, _) = compute_b20_address(creator, VARIANT_DEFAULT, 18, salt);
+        let params =
+            token_params("Dispatch Token", "DSP", 18, U256::from(1_000u64), U256::MAX);
+
+        let mut storage = HashMapStorageProvider::new(1);
+        storage.set_caller(creator);
+        StorageCtx::enter(&mut storage, |ctx| {
+            assert_output(
+                dispatch_factory_success(ctx, create_call(VARIANT_DEFAULT, params, salt)),
+                ITokenFactory::createTokenCall::abi_encode_returns(&token_addr),
+            );
+        });
+
+        storage.set_caller(alice);
+        StorageCtx::enter(&mut storage, |ctx| {
+            assert_output(
+                dispatch_b20_success(
+                    ctx,
+                    token_addr,
+                    IB20::transferCall { to: bob, amount: U256::from(300u64) },
+                ),
+                true.abi_encode(),
+            );
+            assert_output(
+                dispatch_b20_success(
+                    ctx,
+                    token_addr,
+                    IB20::approveCall { spender, amount: U256::from(250u64) },
+                ),
+                true.abi_encode(),
+            );
+        });
+
+        storage.set_caller(spender);
+        StorageCtx::enter(&mut storage, |ctx| {
+            assert_output(
+                dispatch_b20_success(
+                    ctx,
+                    token_addr,
+                    IB20::transferFromCall {
+                        from: alice,
+                        to: charlie,
+                        amount: U256::from(200u64),
+                    },
+                ),
+                true.abi_encode(),
+            );
+            assert_output(
+                dispatch_b20_success(ctx, token_addr, IB20::balanceOfCall { account: alice }),
+                U256::from(500u64).abi_encode(),
+            );
+            assert_output(
+                dispatch_b20_success(ctx, token_addr, IB20::balanceOfCall { account: bob }),
+                U256::from(300u64).abi_encode(),
+            );
+            assert_output(
+                dispatch_b20_success(ctx, token_addr, IB20::balanceOfCall { account: charlie }),
+                U256::from(200u64).abi_encode(),
+            );
+            assert_output(
+                dispatch_b20_success(ctx, token_addr, IB20::allowanceCall { owner: alice, spender }),
+                U256::from(50u64).abi_encode(),
+            );
+        });
+    }
+
+    #[test]
+    fn test_factory_dispatch_reverts_with_abi_error() {
+        let creator = Address::repeat_byte(0xCA);
+        let salt = B256::repeat_byte(0x33);
+        let mut params = token_params("Bad Token", "BAD", 18, U256::ZERO, U256::MAX);
+        params.admin = Address::ZERO;
+
+        let mut storage = HashMapStorageProvider::new(1);
+        storage.set_caller(creator);
+
+        StorageCtx::enter(&mut storage, |ctx| {
+            assert_output(
+                dispatch_factory_revert(ctx, create_call(VARIANT_DEFAULT, params, salt)),
+                ITokenFactory::ZeroAddress {}.abi_encode(),
+            );
         });
     }
 }


### PR DESCRIPTION
## Summary

This adds ABI-level coverage for the B20 token factory and default token precompile paths, including creation, readback, transfers, approvals, and ABI-encoded reverts. It also covers Beryl installer routing for the factory and B20 token prefixes. The repetitive precompile limit and fork-gating tests are collapsed with rstest while keeping token lifecycle scenarios explicit.