### PR TITLE
fix(precompiles): Dynamic Native Token Addresses

### DIFF
--- a/crates/common/precompiles/benches/base_precompiles.rs
+++ b/crates/common/precompiles/benches/base_precompiles.rs
@@ -6,8 +6,8 @@ use alloy_primitives::{Address, B256, Bytes, U256};
 use alloy_sol_types::SolValue;
 use base_common_precompiles::{
     B20Token, B20TokenStorage, Burnable, CAPABILITY_CAP_MUTABLE, CAPABILITY_PAUSABLE,
-    CREATE_TOKEN_VERSION, Configurable, ITokenFactory, Mintable, Pausable, Token,
-    TokenAccounting, TokenFactory, Transferable, VARIANT_DEFAULT, compute_b20_address,
+    CREATE_TOKEN_VERSION, Configurable, ITokenFactory, Mintable, Pausable, Token, TokenAccounting,
+    TokenFactory, Transferable, VARIANT_DEFAULT, compute_b20_address,
 };
 use base_precompile_storage::{HashMapStorageProvider, StorageCtx};
 use criterion::{Criterion, criterion_group, criterion_main};
@@ -493,8 +493,7 @@ fn base_token_factory_view(c: &mut Criterion) {
     c.bench_function("base_token_factory_is_b20", |b| {
         let mut storage = HashMapStorageProvider::new(1);
         StorageCtx::enter(&mut storage, |ctx| {
-            let params =
-                BaseTokenBenchSetup::token_params("FactoryToken", "FACT", 18, U256::ZERO);
+            let params = BaseTokenBenchSetup::token_params("FactoryToken", "FACT", 18, U256::ZERO);
             let token_address = BaseTokenBenchSetup::create_b20(
                 ctx,
                 BaseTokenBenchSetup::caller(),

--- a/crates/common/precompiles/benches/base_precompiles.rs
+++ b/crates/common/precompiles/benches/base_precompiles.rs
@@ -2,11 +2,12 @@
 
 use std::hint::black_box;
 
-use alloy_primitives::{Address, B256, U256};
+use alloy_primitives::{Address, B256, Bytes, U256};
+use alloy_sol_types::SolValue;
 use base_common_precompiles::{
-    Burnable, CAPABILITY_CAP_MUTABLE, CAPABILITY_PAUSABLE, Configurable, DefaultToken,
-    DefaultTokenStorage, ITokenFactory, Mintable, Pausable, Token, TokenAccounting, TokenFactory,
-    Transferable, compute_default_address, compute_security_address, compute_stablecoin_address,
+    B20Token, B20TokenStorage, Burnable, CAPABILITY_CAP_MUTABLE, CAPABILITY_PAUSABLE,
+    CREATE_TOKEN_VERSION, Configurable, ITokenFactory, Mintable, Pausable, Token,
+    TokenAccounting, TokenFactory, Transferable, VARIANT_DEFAULT, compute_b20_address,
 };
 use base_precompile_storage::{HashMapStorageProvider, StorageCtx};
 use criterion::{Criterion, criterion_group, criterion_main};
@@ -26,55 +27,64 @@ impl BaseTokenBenchSetup {
         Address::repeat_byte(0xcd)
     }
 
-    fn default_params(
+    fn token_params(
         name: &str,
         symbol: &str,
-        salt: B256,
-    ) -> ITokenFactory::CreateDefaultTokenParams {
-        ITokenFactory::CreateDefaultTokenParams {
+        decimals: u8,
+        initial_supply: U256,
+    ) -> ITokenFactory::B20TokenParams {
+        ITokenFactory::B20TokenParams {
             name: name.to_string(),
             symbol: symbol.to_string(),
-            decimals: 18,
+            decimals,
             admin: Self::admin(),
             capabilities: CAPABILITY_PAUSABLE | CAPABILITY_CAP_MUTABLE,
-            initialSupply: U256::ZERO,
+            initialSupply: initial_supply,
             initialSupplyRecipient: Self::initial_supply_recipient(),
-            transferPolicyId: 1,
             supplyCap: U256::MAX,
             minimumRedeemable: U256::ZERO,
             contractURI: "ipfs://base-token".to_string(),
-            salt,
         }
     }
 
-    fn create_default(
+    fn create_b20(
         ctx: StorageCtx<'_>,
         caller: Address,
-        params: ITokenFactory::CreateDefaultTokenParams,
+        params: ITokenFactory::B20TokenParams,
+        salt: B256,
     ) -> Address {
         let mut factory = TokenFactory::new(ctx);
-        factory.create_default(caller, ITokenFactory::createDefaultCall { params }).unwrap()
+        factory
+            .create_token(
+                caller,
+                ITokenFactory::createTokenCall {
+                    params: ITokenFactory::CreateTokenParams {
+                        version: CREATE_TOKEN_VERSION,
+                        variant: VARIANT_DEFAULT,
+                        requiredParams: params.abi_encode().into(),
+                        optionalParams: Bytes::new(),
+                        postCreateCalls: Vec::new(),
+                        salt,
+                    },
+                },
+            )
+            .unwrap()
     }
 
     fn create_token<'a>(
         ctx: StorageCtx<'a>,
         salt: B256,
         initial_supply: U256,
-    ) -> DefaultToken<DefaultTokenStorage<'a>> {
-        let mut params = Self::default_params("BaseToken", "BASE", salt);
-        params.initialSupply = initial_supply;
-        params.supplyCap = U256::MAX;
+    ) -> B20Token<B20TokenStorage<'a>> {
+        let mut params = Self::token_params("BaseToken", "BASE", 18, initial_supply);
         params.minimumRedeemable = U256::ONE;
 
-        let token_address = Self::create_default(ctx, Self::caller(), params);
+        let token_address = Self::create_b20(ctx, Self::caller(), params, salt);
         Self::token_at(ctx, token_address)
     }
 
-    fn token_at<'a>(
-        ctx: StorageCtx<'a>,
-        token_address: Address,
-    ) -> DefaultToken<DefaultTokenStorage<'a>> {
-        DefaultToken::with_storage(DefaultTokenStorage::from_address(token_address, ctx))
+    fn token_at<'a>(ctx: StorageCtx<'a>, token_address: Address) -> B20Token<B20TokenStorage<'a>> {
+        B20Token::with_storage(B20TokenStorage::from_address(token_address, ctx))
     }
 }
 
@@ -425,7 +435,7 @@ fn base_token_mutate(c: &mut Criterion) {
 }
 
 fn base_token_factory_mutate(c: &mut Criterion) {
-    c.bench_function("base_token_factory_create_default", |b| {
+    c.bench_function("base_token_factory_create_b20", |b| {
         let mut storage = HashMapStorageProvider::new(1);
         StorageCtx::enter(&mut storage, |ctx| {
             let caller = BaseTokenBenchSetup::caller();
@@ -434,8 +444,9 @@ fn base_token_factory_mutate(c: &mut Criterion) {
             b.iter(|| {
                 counter += 1;
                 let salt = B256::from(U256::from(counter));
-                let params = BaseTokenBenchSetup::default_params("FactoryToken", "FACT", salt);
-                let token = BaseTokenBenchSetup::create_default(ctx, caller, params);
+                let params =
+                    BaseTokenBenchSetup::token_params("FactoryToken", "FACT", 18, U256::ZERO);
+                let token = BaseTokenBenchSetup::create_b20(ctx, caller, params, salt);
                 black_box(token);
             });
         });
@@ -443,38 +454,38 @@ fn base_token_factory_mutate(c: &mut Criterion) {
 }
 
 fn base_token_factory_view(c: &mut Criterion) {
-    c.bench_function("base_token_factory_predict_default_address", |b| {
+    c.bench_function("base_token_factory_predict_b20_address_18_decimals", |b| {
         let caller = BaseTokenBenchSetup::caller();
         let salt = B256::repeat_byte(0x21);
 
         b.iter(|| {
             let caller = black_box(caller);
             let salt = black_box(salt);
-            let result = compute_default_address(caller, salt);
+            let result = compute_b20_address(caller, VARIANT_DEFAULT, 18, salt);
             black_box(result);
         });
     });
 
-    c.bench_function("base_token_factory_predict_stablecoin_address", |b| {
+    c.bench_function("base_token_factory_predict_b20_address_6_decimals", |b| {
         let caller = BaseTokenBenchSetup::caller();
         let salt = B256::repeat_byte(0x22);
 
         b.iter(|| {
             let caller = black_box(caller);
             let salt = black_box(salt);
-            let result = compute_stablecoin_address(caller, salt);
+            let result = compute_b20_address(caller, VARIANT_DEFAULT, 6, salt);
             black_box(result);
         });
     });
 
-    c.bench_function("base_token_factory_predict_security_address", |b| {
+    c.bench_function("base_token_factory_predict_b20_address_0_decimals", |b| {
         let caller = BaseTokenBenchSetup::caller();
         let salt = B256::repeat_byte(0x23);
 
         b.iter(|| {
             let caller = black_box(caller);
             let salt = black_box(salt);
-            let result = compute_security_address(caller, salt);
+            let result = compute_b20_address(caller, VARIANT_DEFAULT, 0, salt);
             black_box(result);
         });
     });
@@ -482,13 +493,14 @@ fn base_token_factory_view(c: &mut Criterion) {
     c.bench_function("base_token_factory_is_b20", |b| {
         let mut storage = HashMapStorageProvider::new(1);
         StorageCtx::enter(&mut storage, |ctx| {
-            let params = BaseTokenBenchSetup::default_params(
-                "FactoryToken",
-                "FACT",
+            let params =
+                BaseTokenBenchSetup::token_params("FactoryToken", "FACT", 18, U256::ZERO);
+            let token_address = BaseTokenBenchSetup::create_b20(
+                ctx,
+                BaseTokenBenchSetup::caller(),
+                params,
                 B256::repeat_byte(0x24),
             );
-            let token_address =
-                BaseTokenBenchSetup::create_default(ctx, BaseTokenBenchSetup::caller(), params);
             let factory = TokenFactory::new(ctx);
 
             b.iter(|| {
@@ -504,8 +516,12 @@ fn base_token_factory_view(c: &mut Criterion) {
         let mut storage = HashMapStorageProvider::new(1);
         StorageCtx::enter(&mut storage, |ctx| {
             let factory = TokenFactory::new(ctx);
-            let (token_address, _) =
-                compute_default_address(BaseTokenBenchSetup::caller(), B256::repeat_byte(0x25));
+            let (token_address, _) = compute_b20_address(
+                BaseTokenBenchSetup::caller(),
+                VARIANT_DEFAULT,
+                18,
+                B256::repeat_byte(0x25),
+            );
 
             b.iter(|| {
                 let factory = black_box(&factory);

--- a/crates/common/precompiles/src/token/abi/b20.rs
+++ b/crates/common/precompiles/src/token/abi/b20.rs
@@ -20,6 +20,7 @@ sol! {
         error InvalidSigner(address signer, address owner);
         error FeatureDisabled(uint256 capability);
         error MinimumRedeemableNotMet(uint256 amount, uint256 minimum);
+        error Uninitialized();
 
         // Events
         event Transfer(address indexed from, address indexed to, uint256 amount);

--- a/crates/common/precompiles/src/token/b20/dispatch.rs
+++ b/crates/common/precompiles/src/token/b20/dispatch.rs
@@ -24,9 +24,10 @@ impl<S: TokenAccounting> B20Token<S> {
         ctx: StorageCtx<'_>,
         calldata: &[u8],
     ) -> base_precompile_storage::Result<Bytes> {
-        // TODO: Reject calls to uninitialized tokens (empty code hash), mirroring the check
-        // in tempo's TIP-20 dispatch. A token with no bytecode should return an error rather
-        // than silently operating on zeroed-out storage.
+        if !self.accounting.is_initialized()? {
+            return Err(BasePrecompileError::revert(IB20::Uninitialized {}));
+        }
+
         if calldata.len() < 4 {
             return Err(BasePrecompileError::UnknownFunctionSelector([0u8; 4]));
         }

--- a/crates/common/precompiles/src/token/b20/storage.rs
+++ b/crates/common/precompiles/src/token/b20/storage.rs
@@ -2,7 +2,9 @@ use alloc::string::String;
 
 use alloy_primitives::{Address, LogData, U256, address};
 use base_precompile_macros::contract;
-use base_precompile_storage::{BasePrecompileError, Handler, Mapping, Result, StorageCtx};
+use base_precompile_storage::{
+    BasePrecompileError, ContractStorage, Handler, Mapping, Result, StorageCtx,
+};
 
 use crate::token::{common::TokenAccounting, decimals_of};
 
@@ -34,6 +36,14 @@ impl<'a> B20TokenStorage<'a> {
 }
 
 impl TokenAccounting for B20TokenStorage<'_> {
+    fn token_address(&self) -> Address {
+        ContractStorage::address(self)
+    }
+
+    fn is_initialized(&self) -> Result<bool> {
+        ContractStorage::is_initialized(self)
+    }
+
     fn balance_of(&self, account: Address) -> Result<U256> {
         self.balances.at(&account).read()
     }

--- a/crates/common/precompiles/src/token/b20/token.rs
+++ b/crates/common/precompiles/src/token/b20/token.rs
@@ -3,7 +3,7 @@
 use alloy_primitives::Address;
 use base_precompile_storage::StorageCtx;
 
-use super::storage::{B20_TOKEN_ADDRESS, B20TokenStorage};
+use super::storage::B20TokenStorage;
 use crate::token::common::{
     Burnable, Configurable, Mintable, Pausable, Permittable, Redeemable, Token, TokenAccounting,
     Transferable,
@@ -13,7 +13,8 @@ use crate::token::common::{
 ///
 /// The generic `S` lets callers swap in an in-memory [`TokenAccounting`]
 /// implementation for unit tests without touching real EVM storage. In
-/// production, [`B20Token::new`] wires in [`B20TokenStorage`].
+/// production, the storage adapter is bound to the address selected by the
+/// dynamic precompile lookup.
 #[derive(Debug, Clone)]
 pub struct B20Token<S: TokenAccounting> {
     pub(super) accounting: S,
@@ -36,7 +37,7 @@ impl<S: TokenAccounting> B20Token<S> {
 }
 
 // ---------------------------------------------------------------------------
-// Token: wire the accounting field and fix the precompile address
+// Token: wire the accounting field and dynamic token address
 // ---------------------------------------------------------------------------
 
 impl<S: TokenAccounting> Token for B20Token<S> {
@@ -51,7 +52,7 @@ impl<S: TokenAccounting> Token for B20Token<S> {
     }
 
     fn token_address(&self) -> Address {
-        B20_TOKEN_ADDRESS
+        self.accounting.token_address()
     }
 }
 

--- a/crates/common/precompiles/src/token/common/token.rs
+++ b/crates/common/precompiles/src/token/common/token.rs
@@ -8,10 +8,10 @@ use super::TokenAccounting;
 /// - Accessors to the underlying storage ([`Self::accounting`] /
 ///   [`Self::accounting_mut`]) that all capability trait default impls use to
 ///   read and write state without the 22-method delegation block.
-/// - [`Self::token_address`], the fixed on-chain address of this token.
+/// - [`Self::token_address`], the on-chain address of this token.
 ///
 /// All capability traits extend `Token`. Implement it on a token struct by
-/// wiring the `accounting` field and providing the precompile address.
+/// wiring the `accounting` field and delegating address identity to the backing storage.
 ///
 /// The associated type `Accounting` is resolved at compile time, so all
 /// storage calls in the capability traits are monomorphized — no vtable

--- a/crates/common/precompiles/src/token/common/token_accounting.rs
+++ b/crates/common/precompiles/src/token/common/token_accounting.rs
@@ -11,6 +11,12 @@ use base_precompile_storage::Result;
 /// Capability trait default implementations only depend on this interface, never on EVM storage
 /// directly.
 pub trait TokenAccounting {
+    /// Returns the on-chain address backing this token's storage.
+    fn token_address(&self) -> Address;
+
+    /// Returns whether marker bytecode is deployed at this token's address.
+    fn is_initialized(&self) -> Result<bool>;
+
     // --- Balances ---
 
     /// Returns the token balance of `account`.

--- a/crates/common/precompiles/src/token/factory/storage.rs
+++ b/crates/common/precompiles/src/token/factory/storage.rs
@@ -196,12 +196,13 @@ impl<'a> TokenFactory<'a> {
 
 #[cfg(test)]
 mod tests {
-    use alloy_sol_types::SolCall;
+    use alloy_sol_types::{SolCall, SolError};
     use base_precompile_storage::{HashMapStorageProvider, StorageCtx};
 
     use super::*;
     use crate::token::{
-        B20Token, B20TokenStorage, IB20, Mintable, Token, TokenAccounting, Transferable,
+        B20Token, B20TokenStorage, IB20, Mintable, Permittable, Token, TokenAccounting,
+        Transferable,
     };
 
     fn token_params(
@@ -451,6 +452,58 @@ mod tests {
             assert_eq!(token.accounting().balance_of(alice).unwrap(), U256::from(900u64));
             assert_eq!(token.accounting().balance_of(bob).unwrap(), U256::from(300u64));
             assert_eq!(token.accounting().total_supply().unwrap(), U256::from(1_200u64));
+        });
+    }
+
+    #[test]
+    fn test_token_identity_uses_dynamic_address() {
+        let mut storage = HashMapStorageProvider::new(1);
+        StorageCtx::enter(&mut storage, |ctx| {
+            let mut factory = TokenFactory::new(ctx);
+            let first = factory
+                .create_token(Address::repeat_byte(0xCA), default_call(B256::repeat_byte(0x07)))
+                .unwrap();
+            let second = factory
+                .create_token(Address::repeat_byte(0xCA), default_call(B256::repeat_byte(0x08)))
+                .unwrap();
+
+            assert_ne!(first, second);
+
+            let first_token = token_at(first, ctx);
+            let second_token = token_at(second, ctx);
+
+            assert_eq!(first_token.token_address(), first);
+            assert_eq!(second_token.token_address(), second);
+
+            let (_, _, _, _, first_domain_address, _, _) =
+                first_token.eip712_domain(ctx.chain_id()).unwrap();
+            let (_, _, _, _, second_domain_address, _, _) =
+                second_token.eip712_domain(ctx.chain_id()).unwrap();
+
+            assert_eq!(first_domain_address, first);
+            assert_eq!(second_domain_address, second);
+            assert_ne!(
+                first_token.domain_separator(ctx.chain_id()).unwrap(),
+                second_token.domain_separator(ctx.chain_id()).unwrap()
+            );
+        });
+    }
+
+    #[test]
+    fn test_uninitialized_prefix_token_reverts() {
+        let mut storage = HashMapStorageProvider::new(1);
+        StorageCtx::enter(&mut storage, |ctx| {
+            let caller = Address::repeat_byte(0xCA);
+            let (token_addr, lower_bytes) =
+                compute_b20_address(caller, VARIANT_DEFAULT, 18, B256::repeat_byte(0x09));
+            assert!(lower_bytes >= RESERVED_SIZE);
+            assert!(!ctx.has_bytecode(token_addr).unwrap());
+
+            let mut token = token_at(token_addr, ctx);
+            let result = token.dispatch(ctx, &IB20::nameCall {}.abi_encode()).unwrap();
+
+            assert!(result.reverted);
+            assert_eq!(result.bytes.as_ref(), IB20::Uninitialized {}.abi_encode());
         });
     }
 }


### PR DESCRIPTION
## Summary

This switches B-20 default tokens fully to dynamic factory-created addresses instead of retaining a singleton default token address path. Token identity now comes from the storage adapter bound to the called address, and uninitialized prefix addresses revert before dispatch. The devnet native ERC20 helper now creates a token through the factory and targets the returned token address.