### PR TITLE
feat(policy): implement full IPolicyRegistry precompile

### DIFF
--- a/actions/harness/tests/beryl/policy_registry.rs
+++ b/actions/harness/tests/beryl/policy_registry.rs
@@ -24,14 +24,15 @@ const RETURN_WORD_SLOT: U256 = U256::from_limbs([1, 0, 0, 0]);
 async fn beryl_enables_policy_registry_singleton_precompile() {
     let mut env = BerylTestEnv::new();
     let probe = env.first_contract_address();
-    let hello_world = Bytes::from(IPolicyRegistry::helloWorldCall {}.abi_encode());
+    let policy_exists_call =
+        Bytes::from(IPolicyRegistry::policyExistsCall { policyId: 0 }.abi_encode());
 
     let deploy_probe = env.create_tx(
         TxKind::Create,
         Bytes::from_static(&POLICY_REGISTRY_PROBE_INIT_CODE),
         GAS_LIMIT,
     );
-    let pre_beryl_probe = env.create_tx(TxKind::Call(probe), hello_world.clone(), GAS_LIMIT);
+    let pre_beryl_probe = env.create_tx(TxKind::Call(probe), policy_exists_call.clone(), GAS_LIMIT);
     let block1 =
         env.sequencer.build_next_block_with_transactions(vec![deploy_probe, pre_beryl_probe]).await;
 
@@ -53,7 +54,8 @@ async fn beryl_enables_policy_registry_singleton_precompile() {
     assert!(env.user_tx_succeeded(&block2, 0), "POLICY_REGISTRY activation must succeed");
 
     // Block3: probe runs against the committed activated state.
-    let post_beryl_probe = env.create_tx(TxKind::Call(probe), hello_world.clone(), GAS_LIMIT);
+    let post_beryl_probe =
+        env.create_tx(TxKind::Call(probe), policy_exists_call.clone(), GAS_LIMIT);
     let block3 = env.sequencer.build_next_block_with_transactions(vec![post_beryl_probe]).await;
 
     assert_eq!(
@@ -64,7 +66,7 @@ async fn beryl_enables_policy_registry_singleton_precompile() {
     assert_eq!(
         env.sequencer.storage_at(probe, RETURN_WORD_SLOT),
         U256::from(1),
-        "policy registry helloWorld must return true after activation"
+        "policy registry policyExists(ALWAYS_ALLOW_ID) must return true after activation"
     );
 
     // -- Deactivation tests --
@@ -76,7 +78,7 @@ async fn beryl_enables_policy_registry_singleton_precompile() {
 
     // Block5: probe's staticcall must fail while POLICY_REGISTRY is deactivated.
     let probe_while_deactivated =
-        env.create_tx(TxKind::Call(probe), hello_world.clone(), GAS_LIMIT);
+        env.create_tx(TxKind::Call(probe), policy_exists_call.clone(), GAS_LIMIT);
     let block5 =
         env.sequencer.build_next_block_with_transactions(vec![probe_while_deactivated]).await;
 
@@ -93,7 +95,7 @@ async fn beryl_enables_policy_registry_singleton_precompile() {
     assert!(env.user_tx_succeeded(&block6, 0), "POLICY_REGISTRY re-activation must succeed");
 
     // Block7: probe's staticcall must succeed again after re-activation.
-    let probe_after_reactivate = env.create_tx(TxKind::Call(probe), hello_world, GAS_LIMIT);
+    let probe_after_reactivate = env.create_tx(TxKind::Call(probe), policy_exists_call, GAS_LIMIT);
     let block7 =
         env.sequencer.build_next_block_with_transactions(vec![probe_after_reactivate]).await;
 
@@ -105,7 +107,7 @@ async fn beryl_enables_policy_registry_singleton_precompile() {
     assert_eq!(
         env.sequencer.storage_at(probe, RETURN_WORD_SLOT),
         U256::from(1),
-        "policy registry helloWorld must return true after re-activation"
+        "policy registry policyExists(ALWAYS_ALLOW_ID) must return true after re-activation"
     );
 
     env.derive_blocks(

--- a/crates/common/precompiles/src/common/mod.rs
+++ b/crates/common/precompiles/src/common/mod.rs
@@ -11,7 +11,7 @@ mod token_accounting;
 
 use alloy_primitives::U256;
 pub use ops::{Burnable, Configurable, Mintable, Pausable, Permittable, Redeemable, Transferable};
-pub use policy::Policy;
+pub use policy::{Policy, PolicyRegistry};
 pub use token::Token;
 pub use token_accounting::TokenAccounting;
 /// Capability bit: `pause` / `unpause` are enabled on this token.

--- a/crates/common/precompiles/src/common/policy.rs
+++ b/crates/common/precompiles/src/common/policy.rs
@@ -25,6 +25,7 @@ pub trait PolicyRegistry: Policy {
         accounts: alloc::vec::Vec<Address>,
     ) -> Result<u64>;
     /// Stages a pending admin transfer for `policy_id`.
+    /// Pass `Address::ZERO` to clear a previously staged transfer without nominating a replacement.
     fn stage_update_admin(&mut self, policy_id: u64, new_admin: Address) -> Result<()>;
     /// Completes a pending admin transfer; caller must be the staged pending admin.
     fn finalize_update_admin(&mut self, policy_id: u64) -> Result<()>;

--- a/crates/common/precompiles/src/common/policy.rs
+++ b/crates/common/precompiles/src/common/policy.rs
@@ -1,10 +1,57 @@
-//! Policy trait — the outward-facing interface tokens consult for authorization decisions.
+//! Policy traits — the outward-facing interfaces tokens and callers use for the policy registry.
 
 use alloy_primitives::Address;
 use base_precompile_storage::Result;
 
-/// Trait for checking whether a given account is authorized under a specific policy.
+use crate::PolicyType;
+
+/// Minimal read-only policy interface consulted by B-20 tokens on every transfer, mint, and redeem.
 pub trait Policy {
     /// Returns `true` if `account` is authorized under the given `policy_id`.
     fn is_authorized(&self, policy_id: u64, account: Address) -> Result<bool>;
+}
+
+/// Full policy registry interface including administrative mutations.
+///
+/// Extends [`Policy`] so any `PolicyRegistry` implementor also satisfies the minimal token bound.
+pub trait PolicyRegistry: Policy {
+    /// Creates a new ALLOWLIST or BLOCKLIST policy, returning its encoded ID.
+    fn create_policy(&mut self, admin: Address, policy_type: PolicyType) -> Result<u64>;
+    /// Creates a new policy and seeds it with an initial member list.
+    fn create_policy_with_accounts(
+        &mut self,
+        admin: Address,
+        policy_type: PolicyType,
+        accounts: alloc::vec::Vec<Address>,
+    ) -> Result<u64>;
+    /// Stages a pending admin transfer for `policy_id`.
+    fn stage_update_admin(&mut self, policy_id: u64, new_admin: Address) -> Result<()>;
+    /// Completes a pending admin transfer; caller must be the staged pending admin.
+    fn finalize_update_admin(&mut self, policy_id: u64) -> Result<()>;
+    /// Permanently relinquishes admin of `policy_id`.
+    fn renounce_admin(&mut self, policy_id: u64) -> Result<()>;
+    /// Adds or removes accounts from an ALLOWLIST policy's member set.
+    fn update_allowlist(
+        &mut self,
+        policy_id: u64,
+        allowed: bool,
+        accounts: alloc::vec::Vec<Address>,
+    ) -> Result<()>;
+    /// Adds or removes accounts from a BLOCKLIST policy's member set.
+    fn update_blocklist(
+        &mut self,
+        policy_id: u64,
+        blocked: bool,
+        accounts: alloc::vec::Vec<Address>,
+    ) -> Result<()>;
+    /// Returns the next policy ID that would be assigned for `policy_type`.
+    fn next_policy_id(&self, policy_type: PolicyType) -> Result<u64>;
+    /// Returns `true` if `policy_id` is a built-in or previously created policy.
+    fn policy_exists(&self, policy_id: u64) -> Result<bool>;
+    /// Returns the `PolicyType` of `policy_id`.
+    fn get_policy_type(&self, policy_id: u64) -> Result<PolicyType>;
+    /// Returns the current admin of `policy_id`.
+    fn get_policy_admin(&self, policy_id: u64) -> Result<Address>;
+    /// Returns the staged pending admin for `policy_id`, or `address(0)` if none.
+    fn pending_policy_admin(&self, policy_id: u64) -> Result<Address>;
 }

--- a/crates/common/precompiles/src/common/token.rs
+++ b/crates/common/precompiles/src/common/token.rs
@@ -1,6 +1,6 @@
 use alloy_primitives::Address;
 
-use super::{Policy as PolicyTrait, TokenAccounting};
+use super::{Policy, TokenAccounting};
 
 /// Token identity layer, bridging the storage port to capability traits.
 ///
@@ -22,7 +22,7 @@ pub trait Token {
     /// The concrete storage adapter backing this token.
     type Accounting: TokenAccounting;
     /// The global policy registry precompile backing this token.
-    type Policy: PolicyTrait;
+    type Policy: Policy;
 
     /// Returns a shared reference to this token's storage adapter.
     fn accounting(&self) -> &Self::Accounting;

--- a/crates/common/precompiles/src/lib.rs
+++ b/crates/common/precompiles/src/lib.rs
@@ -7,13 +7,7 @@ extern crate alloc;
 
 mod macros;
 
-/// Gas cost for ABI-decoding calldata of the given byte length.
-///
-/// Charges `G_sha3word` (6 gas) per 32-byte word, rounded up — the same rate the EVM uses for
-/// data-processing operations (keccak256). The EVM has no universal precompile input cost;
-/// each precompile defines its own. Using `G_sha3word` is the natural choice because ABI decoding
-/// is proportional data-processing work, and it prevents large calldata from being free to
-/// process — a potential attack vector without this charge.
+/// Returns the EIP-3860-style input cost for calldata of the given length.
 pub const fn input_cost(calldata_len: usize) -> u64 {
     const G_SHA3WORD: u64 = 6;
     calldata_len.div_ceil(32).saturating_mul(G_SHA3WORD as usize) as u64
@@ -35,7 +29,7 @@ mod bls12_381;
 mod common;
 pub use common::{
     Burnable, CAPABILITY_CAP_MUTABLE, CAPABILITY_PAUSABLE, Configurable, Mintable, Pausable,
-    Permittable, Policy, Redeemable, Token, TokenAccounting, Transferable,
+    Permittable, Policy, PolicyRegistry, Redeemable, Token, TokenAccounting, Transferable,
 };
 #[cfg(any(test, feature = "test-utils"))]
 pub use common::{InMemoryPolicy, InMemoryTokenAccounting, TestToken};
@@ -47,4 +41,12 @@ mod factory;
 pub use factory::{ITokenFactory, TokenFactory, TokenFactoryStorage, TokenVariant};
 
 mod policy;
-pub use policy::{IPolicyRegistry, PolicyHandle, PolicyRegistry, PolicyRegistryStorage};
+pub use policy::{
+    IPolicyRegistry,
+    // PolicyType is re-exported directly for ergonomics — callers write `PolicyType::ALLOWLIST`
+    // rather than `IPolicyRegistry::PolicyType::ALLOWLIST`.
+    IPolicyRegistry::PolicyType,
+    PolicyHandle,
+    PolicyRegistryPrecompile,
+    PolicyRegistryStorage,
+};

--- a/crates/common/precompiles/src/lib.rs
+++ b/crates/common/precompiles/src/lib.rs
@@ -8,6 +8,11 @@ extern crate alloc;
 mod macros;
 
 /// Returns the EIP-3860-style input cost for calldata of the given length.
+///
+/// Charges `G_sha3word` (6 gas) per 32-byte word of calldata. This mirrors the cost model used
+/// by EIP-3860 for initcode and prevents callers from passing arbitrarily large calldata to
+/// precompiles at near-zero cost — without this, an attacker could force expensive ABI decoding
+/// with a single transaction.
 pub const fn input_cost(calldata_len: usize) -> u64 {
     const G_SHA3WORD: u64 = 6;
     calldata_len.div_ceil(32).saturating_mul(G_SHA3WORD as usize) as u64

--- a/crates/common/precompiles/src/macros.rs
+++ b/crates/common/precompiles/src/macros.rs
@@ -98,9 +98,9 @@ mod tests {
 
     #[test]
     fn decode_precompile_call_decodes_known_call() {
-        let calldata = IPolicyRegistry::helloWorldCall {}.abi_encode();
+        let calldata = IPolicyRegistry::policyExistsCall { policyId: 0 }.abi_encode();
         let call = decode_policy_call(&calldata).unwrap();
 
-        assert!(matches!(call, IPolicyRegistry::IPolicyRegistryCalls::helloWorld(_)));
+        assert!(matches!(call, IPolicyRegistry::IPolicyRegistryCalls::policyExists(_)));
     }
 }

--- a/crates/common/precompiles/src/policy/abi.rs
+++ b/crates/common/precompiles/src/policy/abi.rs
@@ -33,6 +33,7 @@ sol! {
 
         function createPolicy(address admin, PolicyType policyType) external returns (uint64);
         function createPolicyWithAccounts(address admin, PolicyType policyType, address[] calldata accounts) external returns (uint64);
+        /// Pass address(0) as newAdmin to clear a previously staged transfer without nominating a replacement.
         function stageUpdateAdmin(uint64 policyId, address newAdmin) external;
         function finalizeUpdateAdmin(uint64 policyId) external;
         function renounceAdmin(uint64 policyId) external;

--- a/crates/common/precompiles/src/policy/abi.rs
+++ b/crates/common/precompiles/src/policy/abi.rs
@@ -1,8 +1,59 @@
 use alloy_sol_types::sol;
+use base_precompile_storage::{BasePrecompileError, Result};
 
 sol! {
     #[derive(Debug, PartialEq, Eq)]
     interface IPolicyRegistry {
-        function helloWorld() external view returns (bool);
+        enum PolicyType {
+            /// Authorizes all accounts unconditionally.
+            ALWAYS_ALLOW,
+            /// Rejects all accounts unconditionally.
+            ALWAYS_BLOCK,
+            /// Authorizes only accounts explicitly added to the allowlist.
+            ALLOWLIST,
+            /// Rejects only accounts explicitly added to the blocklist.
+            BLOCKLIST
+        }
+
+        error Unauthorized();
+        error PolicyNotFound();
+        error IncompatiblePolicyType();
+        error InvalidPolicyType();
+        error ZeroAddress();
+        error NoPendingAdmin();
+        error StaticCallNotAllowed();
+        error CounterExhausted();
+        error BatchTooLarge();
+
+        event PolicyCreated(uint64 indexed policyId, address indexed creator, uint8 policyType);
+        event PolicyAdminStaged(uint64 indexed policyId, address indexed previousAdmin, address indexed newAdmin);
+        event PolicyAdminUpdated(uint64 indexed policyId, address indexed previousAdmin, address indexed newAdmin);
+        event AllowlistUpdated(uint64 indexed policyId, address indexed updater, bool allowed, address[] accounts);
+        event BlocklistUpdated(uint64 indexed policyId, address indexed updater, bool blocked, address[] accounts);
+
+        function createPolicy(address admin, PolicyType policyType) external returns (uint64);
+        function createPolicyWithAccounts(address admin, PolicyType policyType, address[] calldata accounts) external returns (uint64);
+        function stageUpdateAdmin(uint64 policyId, address newAdmin) external;
+        function finalizeUpdateAdmin(uint64 policyId) external;
+        function renounceAdmin(uint64 policyId) external;
+        function updateAllowlist(uint64 policyId, bool allowed, address[] calldata accounts) external;
+        function updateBlocklist(uint64 policyId, bool blocked, address[] calldata accounts) external;
+        function isAuthorized(uint64 policyId, address account) external view returns (bool);
+        function nextPolicyId(PolicyType policyType) external view returns (uint64);
+        function policyExists(uint64 policyId) external view returns (bool);
+        function policyType(uint64 policyId) external view returns (PolicyType);
+        function policyAdmin(uint64 policyId) external view returns (address);
+        function pendingPolicyAdmin(uint64 policyId) external view returns (address);
+    }
+}
+
+impl IPolicyRegistry::PolicyType {
+    /// Returns the raw `u8` discriminant for ALLOWLIST or BLOCKLIST.
+    /// Reverts with `InvalidPolicyType` for built-in sentinels (`ALWAYS_ALLOW`, `ALWAYS_BLOCK`).
+    pub fn as_discriminant(self) -> Result<u8> {
+        match self {
+            Self::ALLOWLIST | Self::BLOCKLIST => Ok(self as u8),
+            _ => Err(BasePrecompileError::revert(IPolicyRegistry::InvalidPolicyType {})),
+        }
     }
 }

--- a/crates/common/precompiles/src/policy/dispatch.rs
+++ b/crates/common/precompiles/src/policy/dispatch.rs
@@ -10,8 +10,7 @@ use super::{
 use crate::{ActivationRegistryStorage, macros::decode_precompile_call};
 
 impl PolicyRegistryStorage<'_> {
-    /// ABI-dispatches `calldata` to the appropriate `IPolicyRegistry` handler.
-    pub(super) fn dispatch(&self, ctx: StorageCtx<'_>, calldata: &[u8]) -> PrecompileResult {
+    pub(super) fn dispatch(&mut self, ctx: StorageCtx<'_>, calldata: &[u8]) -> PrecompileResult {
         if let Err(e) = ctx.deduct_gas(crate::input_cost(calldata.len())) {
             return e.into_precompile_result(ctx.gas_used());
         }
@@ -21,10 +20,60 @@ impl PolicyRegistryStorage<'_> {
             .into_precompile_result(ctx.gas_used(), |b| b)
     }
 
-    fn inner(&self, calldata: &[u8]) -> base_precompile_storage::Result<Bytes> {
+    fn inner(&mut self, calldata: &[u8]) -> base_precompile_storage::Result<Bytes> {
         match decode_precompile_call!(calldata, IPolicyRegistry::IPolicyRegistryCalls) {
-            C::helloWorld(_) => {
-                Ok(IPolicyRegistry::helloWorldCall::abi_encode_returns(&true).into())
+            C::createPolicy(call) => {
+                let id = self.create_policy(call.admin, call.policyType)?;
+                Ok(IPolicyRegistry::createPolicyCall::abi_encode_returns(&id).into())
+            }
+            C::createPolicyWithAccounts(call) => {
+                let id =
+                    self.create_policy_with_accounts(call.admin, call.policyType, call.accounts)?;
+                Ok(IPolicyRegistry::createPolicyWithAccountsCall::abi_encode_returns(&id).into())
+            }
+            C::stageUpdateAdmin(call) => {
+                self.stage_update_admin(call.policyId, call.newAdmin)?;
+                Ok(Bytes::new())
+            }
+            C::finalizeUpdateAdmin(call) => {
+                self.finalize_update_admin(call.policyId)?;
+                Ok(Bytes::new())
+            }
+            C::renounceAdmin(call) => {
+                self.renounce_admin(call.policyId)?;
+                Ok(Bytes::new())
+            }
+            C::updateAllowlist(call) => {
+                self.update_allowlist(call.policyId, call.allowed, call.accounts)?;
+                Ok(Bytes::new())
+            }
+            C::updateBlocklist(call) => {
+                self.update_blocklist(call.policyId, call.blocked, call.accounts)?;
+                Ok(Bytes::new())
+            }
+            C::isAuthorized(call) => {
+                let authorized = self.is_authorized(call.policyId, call.account)?;
+                Ok(IPolicyRegistry::isAuthorizedCall::abi_encode_returns(&authorized).into())
+            }
+            C::nextPolicyId(call) => {
+                let id = self.next_policy_id(call.policyType)?;
+                Ok(IPolicyRegistry::nextPolicyIdCall::abi_encode_returns(&id).into())
+            }
+            C::policyExists(call) => {
+                let exists = self.policy_exists(call.policyId)?;
+                Ok(IPolicyRegistry::policyExistsCall::abi_encode_returns(&exists).into())
+            }
+            C::policyType(call) => {
+                let pt = self.get_policy_type(call.policyId)?;
+                Ok(IPolicyRegistry::policyTypeCall::abi_encode_returns(&pt).into())
+            }
+            C::policyAdmin(call) => {
+                let admin = self.get_policy_admin(call.policyId)?;
+                Ok(IPolicyRegistry::policyAdminCall::abi_encode_returns(&admin).into())
+            }
+            C::pendingPolicyAdmin(call) => {
+                let pending = self.pending_policy_admin(call.policyId)?;
+                Ok(IPolicyRegistry::pendingPolicyAdminCall::abi_encode_returns(&pending).into())
             }
         }
     }
@@ -32,20 +81,22 @@ impl PolicyRegistryStorage<'_> {
 
 #[cfg(test)]
 mod tests {
+    use alloy_primitives::{Address, address};
     use alloy_sol_types::SolCall;
     use base_precompile_storage::{HashMapStorageProvider, StorageCtx};
 
     use super::*;
     use crate::{ActivationRegistryStorage, IPolicyRegistry};
 
-    fn activate_policy_registry(storage: &mut HashMapStorageProvider) {
-        const ADMIN: alloy_primitives::Address =
-            alloy_primitives::address!("0xcb00000000000000000000000000000000000000");
+    const ACTIVATION_ADMIN: Address = address!("0xcb00000000000000000000000000000000000000");
+    const ADMIN: Address = address!("0x1000000000000000000000000000000000000001");
+    const ALICE: Address = address!("0xA000000000000000000000000000000000000001");
 
-        storage.set_caller(ADMIN);
+    fn activate_policy_registry(storage: &mut HashMapStorageProvider) {
+        storage.set_caller(ACTIVATION_ADMIN);
         StorageCtx::enter(storage, |ctx| {
             ActivationRegistryStorage::new(ctx)
-                .activate(ActivationRegistryStorage::POLICY_REGISTRY, Some(ADMIN))
+                .activate(ActivationRegistryStorage::POLICY_REGISTRY, Some(ACTIVATION_ADMIN))
                 .unwrap()
         });
     }
@@ -53,12 +104,12 @@ mod tests {
     #[test]
     fn dispatch_reverts_when_policy_registry_is_inactive() {
         let mut storage = HashMapStorageProvider::new(1);
-        let calldata = IPolicyRegistry::helloWorldCall {}.abi_encode();
+        let calldata = IPolicyRegistry::policyExistsCall { policyId: 0 }.abi_encode();
 
         let output = StorageCtx::enter(&mut storage, |ctx| {
             PolicyRegistryStorage::new(ctx).dispatch(ctx, &calldata)
         })
-        .expect("dispatch should return a revert output");
+        .expect("dispatch should not fatally error");
 
         assert!(output.reverted);
     }
@@ -67,14 +118,68 @@ mod tests {
     fn dispatch_succeeds_when_policy_registry_is_active() {
         let mut storage = HashMapStorageProvider::new(1);
         activate_policy_registry(&mut storage);
-        let calldata = IPolicyRegistry::helloWorldCall {}.abi_encode();
+        let calldata = IPolicyRegistry::policyExistsCall { policyId: 0 }.abi_encode();
 
         let output = StorageCtx::enter(&mut storage, |ctx| {
             PolicyRegistryStorage::new(ctx).dispatch(ctx, &calldata)
         })
-        .expect("dispatch should succeed");
+        .expect("dispatch should not fatally error");
 
         assert!(!output.reverted);
-        assert!(IPolicyRegistry::helloWorldCall::abi_decode_returns(&output.bytes).unwrap());
+        assert!(IPolicyRegistry::policyExistsCall::abi_decode_returns(&output.bytes).unwrap());
+    }
+
+    #[test]
+    fn dispatch_create_policy_returns_policy_id() {
+        let mut storage = HashMapStorageProvider::new(1);
+        activate_policy_registry(&mut storage);
+        storage.set_caller(ADMIN);
+        let calldata = IPolicyRegistry::createPolicyCall {
+            admin: ADMIN,
+            policyType: IPolicyRegistry::PolicyType::ALLOWLIST,
+        }
+        .abi_encode();
+
+        let output = StorageCtx::enter(&mut storage, |ctx| {
+            PolicyRegistryStorage::new(ctx).dispatch(ctx, &calldata)
+        })
+        .expect("dispatch should not fatally error");
+
+        assert!(!output.reverted);
+        let id = IPolicyRegistry::createPolicyCall::abi_decode_returns(&output.bytes).unwrap();
+        assert_eq!((id >> 56) as u8, IPolicyRegistry::PolicyType::ALLOWLIST as u8);
+    }
+
+    #[test]
+    fn dispatch_is_authorized_always_allow_returns_true() {
+        let mut storage = HashMapStorageProvider::new(1);
+        activate_policy_registry(&mut storage);
+        let calldata = IPolicyRegistry::isAuthorizedCall {
+            policyId: PolicyRegistryStorage::ALWAYS_ALLOW_ID,
+            account: ALICE,
+        }
+        .abi_encode();
+
+        let output = StorageCtx::enter(&mut storage, |ctx| {
+            PolicyRegistryStorage::new(ctx).dispatch(ctx, &calldata)
+        })
+        .expect("dispatch should not fatally error");
+
+        assert!(!output.reverted);
+        assert!(IPolicyRegistry::isAuthorizedCall::abi_decode_returns(&output.bytes).unwrap());
+    }
+
+    #[test]
+    fn dispatch_unknown_selector_reverts() {
+        let mut storage = HashMapStorageProvider::new(1);
+        activate_policy_registry(&mut storage);
+        let calldata = [0xde, 0xad, 0xbe, 0xef, 0x00, 0x00, 0x00, 0x00];
+
+        let output = StorageCtx::enter(&mut storage, |ctx| {
+            PolicyRegistryStorage::new(ctx).dispatch(ctx, &calldata)
+        })
+        .expect("dispatch should not fatally error");
+
+        assert!(output.reverted);
     }
 }

--- a/crates/common/precompiles/src/policy/handle.rs
+++ b/crates/common/precompiles/src/policy/handle.rs
@@ -101,3 +101,108 @@ impl PolicyRegistry for PolicyHandle<'_> {
         self.inner.pending_policy_admin(policy_id)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use alloy_primitives::{Address, address};
+    use base_precompile_storage::{HashMapStorageProvider, StorageCtx};
+
+    use super::*;
+    use crate::{IPolicyRegistry, Policy, PolicyRegistry};
+
+    const ADMIN: Address = address!("0x1000000000000000000000000000000000000001");
+    const ALICE: Address = address!("0xA000000000000000000000000000000000000001");
+    const NEW_ADMIN: Address = address!("0x2000000000000000000000000000000000000002");
+
+    fn storage() -> HashMapStorageProvider {
+        let mut s = HashMapStorageProvider::new(1);
+        s.set_caller(ADMIN);
+        s
+    }
+
+    #[test]
+    fn policy_trait_is_authorized_builtin_ids() {
+        let mut s = storage();
+        StorageCtx::enter(&mut s, |ctx| {
+            let handle = PolicyHandle::new(ctx);
+            assert!(handle.is_authorized(PolicyRegistryStorage::ALWAYS_ALLOW_ID, ALICE).unwrap());
+            assert!(!handle.is_authorized(PolicyRegistryStorage::ALWAYS_BLOCK_ID, ALICE).unwrap());
+        });
+    }
+
+    #[test]
+    fn policy_registry_trait_create_and_authorize() {
+        let mut s = storage();
+        let id = StorageCtx::enter(&mut s, |ctx| {
+            PolicyHandle::new(ctx).create_policy(ADMIN, IPolicyRegistry::PolicyType::ALLOWLIST)
+        })
+        .unwrap();
+
+        s.set_caller(ADMIN);
+        StorageCtx::enter(&mut s, |ctx| {
+            PolicyHandle::new(ctx).update_allowlist(id, true, alloc::vec![ALICE])
+        })
+        .unwrap();
+
+        StorageCtx::enter(&mut s, |ctx| {
+            let handle = PolicyHandle::new(ctx);
+            assert!(handle.is_authorized(id, ALICE).unwrap());
+        });
+    }
+
+    #[test]
+    fn policy_registry_trait_next_policy_id() {
+        let mut s = storage();
+        StorageCtx::enter(&mut s, |ctx| {
+            let handle = PolicyHandle::new(ctx);
+            let id = handle.next_policy_id(IPolicyRegistry::PolicyType::ALLOWLIST).unwrap();
+            assert_eq!((id >> 56) as u8, IPolicyRegistry::PolicyType::ALLOWLIST as u8);
+        });
+    }
+
+    #[test]
+    fn policy_registry_trait_policy_exists() {
+        let mut s = storage();
+        StorageCtx::enter(&mut s, |ctx| {
+            let handle = PolicyHandle::new(ctx);
+            assert!(handle.policy_exists(PolicyRegistryStorage::ALWAYS_ALLOW_ID).unwrap());
+            assert!(handle.policy_exists(PolicyRegistryStorage::ALWAYS_BLOCK_ID).unwrap());
+            assert!(!handle.policy_exists(0xdeadbeef).unwrap());
+        });
+    }
+
+    #[test]
+    fn policy_registry_trait_admin_transfer() {
+        let mut s = storage();
+        let id = StorageCtx::enter(&mut s, |ctx| {
+            PolicyHandle::new(ctx).create_policy(ADMIN, IPolicyRegistry::PolicyType::BLOCKLIST)
+        })
+        .unwrap();
+
+        StorageCtx::enter(&mut s, |ctx| PolicyHandle::new(ctx).stage_update_admin(id, NEW_ADMIN))
+            .unwrap();
+
+        s.set_caller(NEW_ADMIN);
+        StorageCtx::enter(&mut s, |ctx| PolicyHandle::new(ctx).finalize_update_admin(id)).unwrap();
+
+        StorageCtx::enter(&mut s, |ctx| {
+            assert_eq!(PolicyHandle::new(ctx).get_policy_admin(id).unwrap(), NEW_ADMIN);
+        });
+    }
+
+    #[test]
+    fn policy_registry_trait_get_policy_type() {
+        let mut s = storage();
+        StorageCtx::enter(&mut s, |ctx| {
+            let handle = PolicyHandle::new(ctx);
+            assert_eq!(
+                handle.get_policy_type(PolicyRegistryStorage::ALWAYS_ALLOW_ID).unwrap(),
+                IPolicyRegistry::PolicyType::ALWAYS_ALLOW
+            );
+            assert_eq!(
+                handle.get_policy_type(PolicyRegistryStorage::ALWAYS_BLOCK_ID).unwrap(),
+                IPolicyRegistry::PolicyType::ALWAYS_BLOCK
+            );
+        });
+    }
+}

--- a/crates/common/precompiles/src/policy/handle.rs
+++ b/crates/common/precompiles/src/policy/handle.rs
@@ -1,18 +1,18 @@
-//! Business logic for the `Policy` precompile.
+//! Business logic for the `PolicyRegistry` precompile.
 //!
-//! `PolicyHandle` is the concrete type the token holds. It wraps [`PolicyRegistryStorage`]
-//! and implements the [`Policy`] trait, separating the authorization
-//! decisions (here) from the raw storage reads (`storage.rs`).
+//! [`PolicyHandle`] is the concrete type the token holds. It wraps [`PolicyRegistryStorage`]
+//! and implements [`Policy`] (for authorization checks) and [`PolicyRegistry`] (for admin ops).
 
+use alloc::vec::Vec;
 use core::fmt;
 
 use alloy_primitives::Address;
 use base_precompile_storage::{Result, StorageCtx};
 
 use super::storage::PolicyRegistryStorage;
-use crate::Policy;
+use crate::{Policy, PolicyRegistry, PolicyType};
 
-/// Wraps [`PolicyRegistryStorage`] and implements the [`Policy`] trait,
+/// Wraps [`PolicyRegistryStorage`] and implements [`Policy`] and [`PolicyRegistry`],
 /// separating authorization decisions from raw storage reads.
 pub struct PolicyHandle<'a> {
     inner: PolicyRegistryStorage<'a>,
@@ -31,8 +31,73 @@ impl fmt::Debug for PolicyHandle<'_> {
     }
 }
 
-impl<'a> Policy for PolicyHandle<'a> {
+impl Policy for PolicyHandle<'_> {
     fn is_authorized(&self, policy_id: u64, account: Address) -> Result<bool> {
         self.inner.is_authorized(policy_id, account)
+    }
+}
+
+impl PolicyRegistry for PolicyHandle<'_> {
+    fn create_policy(&mut self, admin: Address, policy_type: PolicyType) -> Result<u64> {
+        self.inner.create_policy(admin, policy_type)
+    }
+
+    fn create_policy_with_accounts(
+        &mut self,
+        admin: Address,
+        policy_type: PolicyType,
+        accounts: Vec<Address>,
+    ) -> Result<u64> {
+        self.inner.create_policy_with_accounts(admin, policy_type, accounts)
+    }
+
+    fn stage_update_admin(&mut self, policy_id: u64, new_admin: Address) -> Result<()> {
+        self.inner.stage_update_admin(policy_id, new_admin)
+    }
+
+    fn finalize_update_admin(&mut self, policy_id: u64) -> Result<()> {
+        self.inner.finalize_update_admin(policy_id)
+    }
+
+    fn renounce_admin(&mut self, policy_id: u64) -> Result<()> {
+        self.inner.renounce_admin(policy_id)
+    }
+
+    fn update_allowlist(
+        &mut self,
+        policy_id: u64,
+        allowed: bool,
+        accounts: Vec<Address>,
+    ) -> Result<()> {
+        self.inner.update_allowlist(policy_id, allowed, accounts)
+    }
+
+    fn update_blocklist(
+        &mut self,
+        policy_id: u64,
+        blocked: bool,
+        accounts: Vec<Address>,
+    ) -> Result<()> {
+        self.inner.update_blocklist(policy_id, blocked, accounts)
+    }
+
+    fn next_policy_id(&self, policy_type: PolicyType) -> Result<u64> {
+        self.inner.next_policy_id(policy_type)
+    }
+
+    fn policy_exists(&self, policy_id: u64) -> Result<bool> {
+        self.inner.policy_exists(policy_id)
+    }
+
+    fn get_policy_type(&self, policy_id: u64) -> Result<PolicyType> {
+        self.inner.get_policy_type(policy_id)
+    }
+
+    fn get_policy_admin(&self, policy_id: u64) -> Result<Address> {
+        self.inner.get_policy_admin(policy_id)
+    }
+
+    fn pending_policy_admin(&self, policy_id: u64) -> Result<Address> {
+        self.inner.pending_policy_admin(policy_id)
     }
 }

--- a/crates/common/precompiles/src/policy/mod.rs
+++ b/crates/common/precompiles/src/policy/mod.rs
@@ -6,7 +6,7 @@ pub use abi::IPolicyRegistry;
 mod dispatch;
 
 mod precompile;
-pub use precompile::PolicyRegistry;
+pub use precompile::PolicyRegistryPrecompile;
 
 mod handle;
 pub use handle::PolicyHandle;

--- a/crates/common/precompiles/src/policy/precompile.rs
+++ b/crates/common/precompiles/src/policy/precompile.rs
@@ -6,9 +6,9 @@ use crate::{PolicyRegistryStorage, macros::base_precompile};
 
 /// EVM entry point for the `PolicyRegistry` precompile.
 #[derive(Debug, Default, Clone, Copy)]
-pub struct PolicyRegistry;
+pub struct PolicyRegistryPrecompile;
 
-impl PolicyRegistry {
+impl PolicyRegistryPrecompile {
     /// Installs the singleton `PolicyRegistry` precompile into `precompiles`.
     pub fn install(precompiles: &mut PrecompilesMap) {
         precompiles.extend_precompiles(core::iter::once((

--- a/crates/common/precompiles/src/policy/storage.rs
+++ b/crates/common/precompiles/src/policy/storage.rs
@@ -39,6 +39,10 @@ impl PolicyRegistryStorage<'_> {
     /// Packs `admin` and `policy_type` into a single U256 storage word.
     ///
     /// Layout: `[255:168]` reserved (zero) | `[167:8]` admin (160 bits) | `[7:0]` `PolicyType`.
+    ///
+    /// Invariant: the result is always non-zero because ALLOWLIST = 2 and BLOCKLIST = 3 are
+    /// both non-zero. This means `policies[id] == 0` reliably signals "never created", even
+    /// after `renounce_admin` sets admin to `Address::ZERO` (the type byte is preserved).
     fn encode_packed(admin: Address, policy_type: u8) -> U256 {
         let mut word = [0u8; 32];
         word[12..32].copy_from_slice(admin.as_slice());
@@ -89,13 +93,13 @@ impl PolicyRegistryStorage<'_> {
             return Err(BasePrecompileError::revert(IPolicyRegistry::ZeroAddress {}));
         }
 
-        let policy_id = self.next_policy_id(policy_type)?;
-        let counter = policy_id & ((1u64 << 56) - 1);
+        let counter = self.next_counter.read()?;
         let next = counter
             .checked_add(1)
             .filter(|&n| n < (1u64 << 56))
             .ok_or_else(|| BasePrecompileError::revert(IPolicyRegistry::CounterExhausted {}))?;
         self.next_counter.write(next)?;
+        let policy_id = (policy_type_u8 as u64) << 56 | counter;
         let packed = Self::encode_packed(admin, policy_type_u8);
         self.policies.at_mut(&policy_id).write(packed)?;
 
@@ -125,7 +129,7 @@ impl PolicyRegistryStorage<'_> {
             return Err(BasePrecompileError::revert(IPolicyRegistry::BatchTooLarge {}));
         }
         let policy_id = self.create_policy(admin, policy_type)?;
-        let policy_type_u8 = policy_type as u8;
+        let policy_type_u8 = policy_type.as_discriminant()?;
         if !accounts.is_empty() {
             let caller = self.storage.caller();
             for account in &accounts {

--- a/crates/common/precompiles/src/policy/storage.rs
+++ b/crates/common/precompiles/src/policy/storage.rs
@@ -1,21 +1,1130 @@
-use alloy_primitives::{Address, address};
+use alloc::vec::Vec;
+
+use alloy_primitives::{Address, U256, address};
 use base_precompile_macros::contract;
-use base_precompile_storage::{Handler, Mapping, Result};
+use base_precompile_storage::{BasePrecompileError, Handler, Mapping, Result};
+
+use super::{IPolicyRegistry, IPolicyRegistry::PolicyType};
 
 /// Storage layout for the `PolicyRegistry` precompile.
 ///
 /// Slots are append-only — never reorder across hardforks.
 #[contract(addr = Self::ADDRESS)]
 pub struct PolicyRegistryStorage {
-    pub members: Mapping<u64, Mapping<Address, bool>>, // slot 0
+    pub policies: Mapping<u64, U256>,                  // slot 0
+    pub members: Mapping<u64, Mapping<Address, bool>>, // slot 1
+    pub pending_admins: Mapping<u64, Address>,         // slot 2
+    /// Global monotonic counter for the low 56 bits of all custom policy IDs.
+    /// Intentionally shared across ALLOWLIST and BLOCKLIST types — the type
+    /// discriminator is encoded in the top byte, so both types draw from the
+    /// same 56-bit space without collision.
+    pub next_counter: u64, // slot 3
 }
 
 impl PolicyRegistryStorage<'_> {
     /// Singleton precompile address for the `PolicyRegistry`.
     pub const ADDRESS: Address = address!("b030000000000000000000000000000000000000");
 
-    /// Returns `true` if `account` is authorized to send tokens under `policy_id`.
-    pub(super) fn is_authorized(&self, policy_id: u64, account: Address) -> Result<bool> {
-        self.members.at(&policy_id).at(&account).read()
+    /// Built-in policy ID that always authorizes every account.
+    pub const ALWAYS_ALLOW_ID: u64 = 0;
+    /// Built-in policy ID that always rejects every account.
+    pub const ALWAYS_BLOCK_ID: u64 = 1;
+
+    const ALLOWLIST_TYPE: u8 = PolicyType::ALLOWLIST as u8;
+    const BLOCKLIST_TYPE: u8 = PolicyType::BLOCKLIST as u8;
+
+    /// Maximum number of accounts accepted in any single membership call.
+    pub const MAX_ACCOUNTS: usize = 64;
+
+    /// Packs `admin` and `policy_type` into a single U256 storage word.
+    ///
+    /// Layout: `[255:168]` reserved (zero) | `[167:8]` admin (160 bits) | `[7:0]` `PolicyType`.
+    fn encode_packed(admin: Address, policy_type: u8) -> U256 {
+        let mut word = [0u8; 32];
+        word[12..32].copy_from_slice(admin.as_slice());
+        (U256::from_be_slice(&word) << 8) | U256::from(policy_type)
+    }
+
+    fn decode_admin(packed: U256) -> Address {
+        let bytes = (packed >> 8usize).to_be_bytes::<32>();
+        Address::from_slice(&bytes[12..])
+    }
+
+    const fn decode_type(packed: U256) -> u8 {
+        packed.to_be_bytes::<32>()[31]
+    }
+
+    fn require_write(&self) -> Result<()> {
+        if self.storage.is_static() {
+            return Err(BasePrecompileError::revert(IPolicyRegistry::StaticCallNotAllowed {}));
+        }
+        Ok(())
+    }
+
+    fn require_custom(&self, policy_id: u64) -> Result<U256> {
+        let packed = self.policies.at(&policy_id).read()?;
+        if packed == U256::ZERO {
+            return Err(BasePrecompileError::revert(IPolicyRegistry::PolicyNotFound {}));
+        }
+        Ok(packed)
+    }
+
+    /// Validates the policy exists and the caller is its current admin.
+    /// Returns `(packed, caller)` on success.
+    fn require_admin(&self, policy_id: u64) -> Result<(U256, Address)> {
+        self.require_write()?;
+        let packed = self.require_custom(policy_id)?;
+        let caller = self.storage.caller();
+        if Self::decode_admin(packed) != caller {
+            return Err(BasePrecompileError::revert(IPolicyRegistry::Unauthorized {}));
+        }
+        Ok((packed, caller))
+    }
+
+    /// Creates a new ALLOWLIST or BLOCKLIST policy, returning its encoded ID.
+    pub fn create_policy(&mut self, admin: Address, policy_type: PolicyType) -> Result<u64> {
+        self.require_write()?;
+        let policy_type_u8 = policy_type.as_discriminant()?;
+        if admin == Address::ZERO {
+            return Err(BasePrecompileError::revert(IPolicyRegistry::ZeroAddress {}));
+        }
+
+        let policy_id = self.next_policy_id(policy_type)?;
+        let counter = policy_id & ((1u64 << 56) - 1);
+        let next = counter
+            .checked_add(1)
+            .filter(|&n| n < (1u64 << 56))
+            .ok_or_else(|| BasePrecompileError::revert(IPolicyRegistry::CounterExhausted {}))?;
+        self.next_counter.write(next)?;
+        let packed = Self::encode_packed(admin, policy_type_u8);
+        self.policies.at_mut(&policy_id).write(packed)?;
+
+        let caller = self.storage.caller();
+        self.emit_event(IPolicyRegistry::PolicyCreated {
+            policyId: policy_id,
+            creator: caller,
+            policyType: policy_type_u8,
+        })?;
+        self.emit_event(IPolicyRegistry::PolicyAdminUpdated {
+            policyId: policy_id,
+            previousAdmin: Address::ZERO,
+            newAdmin: admin,
+        })?;
+
+        Ok(policy_id)
+    }
+
+    /// Creates a new policy and populates its initial member list.
+    pub fn create_policy_with_accounts(
+        &mut self,
+        admin: Address,
+        policy_type: PolicyType,
+        accounts: Vec<Address>,
+    ) -> Result<u64> {
+        if accounts.len() > Self::MAX_ACCOUNTS {
+            return Err(BasePrecompileError::revert(IPolicyRegistry::BatchTooLarge {}));
+        }
+        let policy_id = self.create_policy(admin, policy_type)?;
+        let policy_type_u8 = policy_type as u8;
+        if !accounts.is_empty() {
+            let caller = self.storage.caller();
+            for account in &accounts {
+                self.members.at_mut(&policy_id).at_mut(account).write(true)?;
+            }
+            match policy_type_u8 {
+                Self::ALLOWLIST_TYPE => self.emit_event(IPolicyRegistry::AllowlistUpdated {
+                    policyId: policy_id,
+                    updater: caller,
+                    allowed: true,
+                    accounts,
+                })?,
+                Self::BLOCKLIST_TYPE => self.emit_event(IPolicyRegistry::BlocklistUpdated {
+                    policyId: policy_id,
+                    updater: caller,
+                    blocked: true,
+                    accounts,
+                })?,
+                _ => unreachable!("policy_type validated by create_policy"),
+            }
+        }
+        Ok(policy_id)
+    }
+
+    /// Stages `new_admin` as the pending admin for `policy_id`.
+    ///
+    /// Passing `address(0)` clears a previously-staged transfer per the interface spec.
+    pub fn stage_update_admin(&mut self, policy_id: u64, new_admin: Address) -> Result<()> {
+        let (_, caller) = self.require_admin(policy_id)?;
+        if new_admin == Address::ZERO {
+            self.pending_admins.at_mut(&policy_id).delete()?;
+        } else {
+            self.pending_admins.at_mut(&policy_id).write(new_admin)?;
+        }
+        self.emit_event(IPolicyRegistry::PolicyAdminStaged {
+            policyId: policy_id,
+            previousAdmin: caller,
+            newAdmin: new_admin,
+        })?;
+        Ok(())
+    }
+
+    /// Completes a pending admin transfer; caller must be the staged pending admin.
+    pub fn finalize_update_admin(&mut self, policy_id: u64) -> Result<()> {
+        self.require_write()?;
+        let packed = self.require_custom(policy_id)?;
+        let pending = self.pending_admins.at(&policy_id).read()?;
+        if pending == Address::ZERO {
+            return Err(BasePrecompileError::revert(IPolicyRegistry::NoPendingAdmin {}));
+        }
+        let caller = self.storage.caller();
+        if pending != caller {
+            return Err(BasePrecompileError::revert(IPolicyRegistry::Unauthorized {}));
+        }
+        let previous_admin = Self::decode_admin(packed);
+        let policy_type = Self::decode_type(packed);
+        self.policies.at_mut(&policy_id).write(Self::encode_packed(caller, policy_type))?;
+        self.pending_admins.at_mut(&policy_id).delete()?;
+        self.emit_event(IPolicyRegistry::PolicyAdminUpdated {
+            policyId: policy_id,
+            previousAdmin: previous_admin,
+            newAdmin: caller,
+        })?;
+        Ok(())
+    }
+
+    /// Clears the admin of `policy_id`, leaving it permanently un-administered.
+    pub fn renounce_admin(&mut self, policy_id: u64) -> Result<()> {
+        let (packed, caller) = self.require_admin(policy_id)?;
+        let policy_type = Self::decode_type(packed);
+        self.policies.at_mut(&policy_id).write(Self::encode_packed(Address::ZERO, policy_type))?;
+        self.pending_admins.at_mut(&policy_id).delete()?;
+        self.emit_event(IPolicyRegistry::PolicyAdminUpdated {
+            policyId: policy_id,
+            previousAdmin: caller,
+            newAdmin: Address::ZERO,
+        })?;
+        Ok(())
+    }
+
+    /// Adds or removes `accounts` from the allowlist for an ALLOWLIST policy.
+    pub fn update_allowlist(
+        &mut self,
+        policy_id: u64,
+        allowed: bool,
+        accounts: Vec<Address>,
+    ) -> Result<()> {
+        let caller = self.update_membership(policy_id, Self::ALLOWLIST_TYPE, allowed, &accounts)?;
+        self.emit_event(IPolicyRegistry::AllowlistUpdated {
+            policyId: policy_id,
+            updater: caller,
+            allowed,
+            accounts,
+        })
+    }
+
+    /// Adds or removes `accounts` from the blocklist for a BLOCKLIST policy.
+    pub fn update_blocklist(
+        &mut self,
+        policy_id: u64,
+        blocked: bool,
+        accounts: Vec<Address>,
+    ) -> Result<()> {
+        let caller = self.update_membership(policy_id, Self::BLOCKLIST_TYPE, blocked, &accounts)?;
+        self.emit_event(IPolicyRegistry::BlocklistUpdated {
+            policyId: policy_id,
+            updater: caller,
+            blocked,
+            accounts,
+        })
+    }
+
+    fn update_membership(
+        &mut self,
+        policy_id: u64,
+        expected_type: u8,
+        add: bool,
+        accounts: &[Address],
+    ) -> Result<Address> {
+        if accounts.len() > Self::MAX_ACCOUNTS {
+            return Err(BasePrecompileError::revert(IPolicyRegistry::BatchTooLarge {}));
+        }
+        let (packed, caller) = self.require_admin(policy_id)?;
+        if Self::decode_type(packed) != expected_type {
+            return Err(BasePrecompileError::revert(IPolicyRegistry::IncompatiblePolicyType {}));
+        }
+        for account in accounts {
+            if add {
+                self.members.at_mut(&policy_id).at_mut(account).write(true)?;
+            } else {
+                self.members.at_mut(&policy_id).at_mut(account).delete()?;
+            }
+        }
+        Ok(caller)
+    }
+
+    /// Returns `true` if `account` is authorized under `policy_id`.
+    pub fn is_authorized(&self, policy_id: u64, account: Address) -> Result<bool> {
+        if policy_id == Self::ALWAYS_ALLOW_ID {
+            return Ok(true);
+        }
+        if policy_id == Self::ALWAYS_BLOCK_ID {
+            return Ok(false);
+        }
+        let packed = self.policies.at(&policy_id).read()?;
+        if packed == U256::ZERO {
+            return Err(BasePrecompileError::revert(IPolicyRegistry::PolicyNotFound {}));
+        }
+        let member = self.members.at(&policy_id).at(&account).read()?;
+        match Self::decode_type(packed) {
+            Self::ALLOWLIST_TYPE => Ok(member),
+            Self::BLOCKLIST_TYPE => Ok(!member),
+            _ => Err(BasePrecompileError::enum_conversion_error()),
+        }
+    }
+
+    /// Returns the policy ID that would be assigned to the next policy of `policy_type`.
+    ///
+    /// The counter is global across all policy types, so this is a hint only — the counter
+    /// may advance between this query and the subsequent `create_policy` call.
+    pub fn next_policy_id(&self, policy_type: PolicyType) -> Result<u64> {
+        let discriminant = policy_type.as_discriminant()?;
+        let counter = self.next_counter.read()?;
+        Ok((discriminant as u64) << 56 | counter)
+    }
+
+    /// Returns `true` if `policy_id` refers to an existing or built-in policy.
+    pub fn policy_exists(&self, policy_id: u64) -> Result<bool> {
+        if policy_id == Self::ALWAYS_ALLOW_ID || policy_id == Self::ALWAYS_BLOCK_ID {
+            return Ok(true);
+        }
+        let packed = self.policies.at(&policy_id).read()?;
+        Ok(packed != U256::ZERO)
+    }
+
+    /// Returns the `PolicyType` of `policy_id`, including built-in IDs.
+    pub fn get_policy_type(&self, policy_id: u64) -> Result<PolicyType> {
+        if policy_id == Self::ALWAYS_ALLOW_ID {
+            return Ok(PolicyType::ALWAYS_ALLOW);
+        }
+        if policy_id == Self::ALWAYS_BLOCK_ID {
+            return Ok(PolicyType::ALWAYS_BLOCK);
+        }
+        let packed = self.policies.at(&policy_id).read()?;
+        if packed == U256::ZERO {
+            return Err(BasePrecompileError::revert(IPolicyRegistry::PolicyNotFound {}));
+        }
+        PolicyType::try_from(Self::decode_type(packed))
+            .map_err(|_| BasePrecompileError::enum_conversion_error())
+    }
+
+    /// Returns the current admin of `policy_id`, or `address(0)` for built-in policies.
+    pub fn get_policy_admin(&self, policy_id: u64) -> Result<Address> {
+        if policy_id == Self::ALWAYS_ALLOW_ID || policy_id == Self::ALWAYS_BLOCK_ID {
+            return Ok(Address::ZERO);
+        }
+        let packed = self.policies.at(&policy_id).read()?;
+        if packed == U256::ZERO {
+            return Err(BasePrecompileError::revert(IPolicyRegistry::PolicyNotFound {}));
+        }
+        Ok(Self::decode_admin(packed))
+    }
+
+    /// Returns the pending admin staged for `policy_id`, or `address(0)` if none.
+    pub fn pending_policy_admin(&self, policy_id: u64) -> Result<Address> {
+        if policy_id == Self::ALWAYS_ALLOW_ID || policy_id == Self::ALWAYS_BLOCK_ID {
+            return Ok(Address::ZERO);
+        }
+        self.require_custom(policy_id)?;
+        self.pending_admins.at(&policy_id).read()
+    }
+}
+
+impl crate::Policy for PolicyRegistryStorage<'_> {
+    fn is_authorized(&self, policy_id: u64, account: Address) -> Result<bool> {
+        PolicyRegistryStorage::is_authorized(self, policy_id, account)
+    }
+}
+
+impl crate::PolicyRegistry for PolicyRegistryStorage<'_> {
+    fn create_policy(&mut self, admin: Address, policy_type: PolicyType) -> Result<u64> {
+        PolicyRegistryStorage::create_policy(self, admin, policy_type)
+    }
+
+    fn create_policy_with_accounts(
+        &mut self,
+        admin: Address,
+        policy_type: PolicyType,
+        accounts: alloc::vec::Vec<Address>,
+    ) -> Result<u64> {
+        PolicyRegistryStorage::create_policy_with_accounts(self, admin, policy_type, accounts)
+    }
+
+    fn stage_update_admin(&mut self, policy_id: u64, new_admin: Address) -> Result<()> {
+        PolicyRegistryStorage::stage_update_admin(self, policy_id, new_admin)
+    }
+
+    fn finalize_update_admin(&mut self, policy_id: u64) -> Result<()> {
+        PolicyRegistryStorage::finalize_update_admin(self, policy_id)
+    }
+
+    fn renounce_admin(&mut self, policy_id: u64) -> Result<()> {
+        PolicyRegistryStorage::renounce_admin(self, policy_id)
+    }
+
+    fn update_allowlist(
+        &mut self,
+        policy_id: u64,
+        allowed: bool,
+        accounts: alloc::vec::Vec<Address>,
+    ) -> Result<()> {
+        PolicyRegistryStorage::update_allowlist(self, policy_id, allowed, accounts)
+    }
+
+    fn update_blocklist(
+        &mut self,
+        policy_id: u64,
+        blocked: bool,
+        accounts: alloc::vec::Vec<Address>,
+    ) -> Result<()> {
+        PolicyRegistryStorage::update_blocklist(self, policy_id, blocked, accounts)
+    }
+
+    fn next_policy_id(&self, policy_type: PolicyType) -> Result<u64> {
+        PolicyRegistryStorage::next_policy_id(self, policy_type)
+    }
+
+    fn policy_exists(&self, policy_id: u64) -> Result<bool> {
+        PolicyRegistryStorage::policy_exists(self, policy_id)
+    }
+
+    fn get_policy_type(&self, policy_id: u64) -> Result<PolicyType> {
+        PolicyRegistryStorage::get_policy_type(self, policy_id)
+    }
+
+    fn get_policy_admin(&self, policy_id: u64) -> Result<Address> {
+        PolicyRegistryStorage::get_policy_admin(self, policy_id)
+    }
+
+    fn pending_policy_admin(&self, policy_id: u64) -> Result<Address> {
+        PolicyRegistryStorage::pending_policy_admin(self, policy_id)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_primitives::{Address, address};
+    use alloy_sol_types::SolEvent;
+    use base_precompile_storage::{HashMapStorageProvider, StorageCtx};
+
+    use super::*;
+    use crate::IPolicyRegistry;
+
+    const ADMIN: Address = address!("0x1000000000000000000000000000000000000001");
+    const ALICE: Address = address!("0xA000000000000000000000000000000000000001");
+    const BOB: Address = address!("0xB000000000000000000000000000000000000001");
+    const NEW_ADMIN: Address = address!("0x2000000000000000000000000000000000000002");
+
+    fn storage() -> HashMapStorageProvider {
+        let mut s = HashMapStorageProvider::new(1);
+        s.set_caller(ADMIN);
+        s
+    }
+
+    fn create_allowlist(s: &mut HashMapStorageProvider) -> u64 {
+        StorageCtx::enter(s, |ctx| {
+            PolicyRegistryStorage::new(ctx).create_policy(ADMIN, PolicyType::ALLOWLIST)
+        })
+        .unwrap()
+    }
+
+    fn create_blocklist(s: &mut HashMapStorageProvider) -> u64 {
+        StorageCtx::enter(s, |ctx| {
+            PolicyRegistryStorage::new(ctx).create_policy(ADMIN, PolicyType::BLOCKLIST)
+        })
+        .unwrap()
+    }
+
+    fn is_authorized(s: &mut HashMapStorageProvider, policy_id: u64, account: Address) -> bool {
+        StorageCtx::enter(s, |ctx| {
+            PolicyRegistryStorage::new(ctx).is_authorized(policy_id, account)
+        })
+        .unwrap()
+    }
+
+    // --- built-in IDs ---
+
+    #[test]
+    fn always_allow_id_authorizes_any_account() {
+        let mut s = storage();
+        assert!(is_authorized(&mut s, PolicyRegistryStorage::ALWAYS_ALLOW_ID, ALICE));
+        assert!(is_authorized(&mut s, PolicyRegistryStorage::ALWAYS_ALLOW_ID, BOB));
+    }
+
+    #[test]
+    fn always_block_id_rejects_any_account() {
+        let mut s = storage();
+        assert!(!is_authorized(&mut s, PolicyRegistryStorage::ALWAYS_BLOCK_ID, ALICE));
+        assert!(!is_authorized(&mut s, PolicyRegistryStorage::ALWAYS_BLOCK_ID, BOB));
+    }
+
+    #[test]
+    fn unknown_policy_id_returns_policy_not_found() {
+        let mut s = storage();
+        let err = StorageCtx::enter(&mut s, |ctx| {
+            PolicyRegistryStorage::new(ctx).is_authorized(0xdeadbeef, ALICE)
+        })
+        .unwrap_err();
+        assert!(matches!(err, BasePrecompileError::Revert(_)));
+    }
+
+    // --- createPolicy ---
+
+    #[test]
+    fn create_policy_zero_admin_reverts() {
+        let mut s = storage();
+        let err = StorageCtx::enter(&mut s, |ctx| {
+            PolicyRegistryStorage::new(ctx).create_policy(Address::ZERO, PolicyType::ALLOWLIST)
+        })
+        .unwrap_err();
+        assert!(matches!(err, BasePrecompileError::Revert(_)));
+    }
+
+    #[test]
+    fn create_policy_invalid_type_reverts() {
+        let mut s = storage();
+        let err = StorageCtx::enter(&mut s, |ctx| {
+            PolicyRegistryStorage::new(ctx).create_policy(ADMIN, PolicyType::ALWAYS_ALLOW)
+        })
+        .unwrap_err();
+        assert!(matches!(err, BasePrecompileError::Revert(_)));
+    }
+
+    #[test]
+    fn create_policy_ids_encode_type_in_top_byte_and_increment_counter() {
+        let mut s = storage();
+        let id1 = create_allowlist(&mut s);
+        let id2 = create_blocklist(&mut s);
+        assert_eq!((id1 >> 56) as u8, PolicyType::ALLOWLIST as u8);
+        assert_eq!((id2 >> 56) as u8, PolicyType::BLOCKLIST as u8);
+        assert_eq!(id1 & ((1u64 << 56) - 1), 0);
+        assert_eq!(id2 & ((1u64 << 56) - 1), 1);
+    }
+
+    #[test]
+    fn create_policy_emits_policy_created_and_admin_updated_events() {
+        let mut s = storage();
+        let id = create_allowlist(&mut s);
+        let events = s.get_events(PolicyRegistryStorage::ADDRESS);
+        assert_eq!(events.len(), 2);
+        let created = IPolicyRegistry::PolicyCreated::decode_log_data(&events[0]).unwrap();
+        assert_eq!(created.policyId, id);
+        assert_eq!(created.creator, ADMIN);
+        assert_eq!(created.policyType, PolicyType::ALLOWLIST as u8);
+    }
+
+    #[test]
+    fn update_allowlist_emits_allowlist_updated_event() {
+        let mut s = storage();
+        let id = create_allowlist(&mut s);
+        s.set_caller(ADMIN);
+        StorageCtx::enter(&mut s, |ctx| {
+            PolicyRegistryStorage::new(ctx).update_allowlist(id, true, vec![ALICE])
+        })
+        .unwrap();
+        let events = s.get_events(PolicyRegistryStorage::ADDRESS);
+        let updated =
+            IPolicyRegistry::AllowlistUpdated::decode_log_data(events.last().unwrap()).unwrap();
+        assert_eq!(updated.policyId, id);
+        assert_eq!(updated.updater, ADMIN);
+        assert!(updated.allowed);
+        assert_eq!(updated.accounts, vec![ALICE]);
+    }
+
+    // --- ALLOWLIST membership ---
+
+    #[test]
+    fn allowlist_non_member_is_not_authorized() {
+        let mut s = storage();
+        let id = create_allowlist(&mut s);
+        assert!(!is_authorized(&mut s, id, ALICE));
+    }
+
+    #[test]
+    fn allowlist_add_then_remove_member() {
+        let mut s = storage();
+        let id = create_allowlist(&mut s);
+
+        StorageCtx::enter(&mut s, |ctx| {
+            PolicyRegistryStorage::new(ctx).update_allowlist(id, true, vec![ALICE])
+        })
+        .unwrap();
+        assert!(is_authorized(&mut s, id, ALICE));
+
+        StorageCtx::enter(&mut s, |ctx| {
+            PolicyRegistryStorage::new(ctx).update_allowlist(id, false, vec![ALICE])
+        })
+        .unwrap();
+        assert!(!is_authorized(&mut s, id, ALICE));
+    }
+
+    #[test]
+    fn allowlist_batch_update_flips_all_accounts() {
+        let mut s = storage();
+        let id = create_allowlist(&mut s);
+
+        StorageCtx::enter(&mut s, |ctx| {
+            PolicyRegistryStorage::new(ctx).update_allowlist(id, true, vec![ALICE, BOB])
+        })
+        .unwrap();
+        assert!(is_authorized(&mut s, id, ALICE));
+        assert!(is_authorized(&mut s, id, BOB));
+
+        StorageCtx::enter(&mut s, |ctx| {
+            PolicyRegistryStorage::new(ctx).update_allowlist(id, false, vec![ALICE, BOB])
+        })
+        .unwrap();
+        assert!(!is_authorized(&mut s, id, ALICE));
+        assert!(!is_authorized(&mut s, id, BOB));
+    }
+
+    #[test]
+    fn allowlist_readding_existing_member_is_idempotent() {
+        let mut s = storage();
+        let id = create_allowlist(&mut s);
+        for _ in 0..2 {
+            StorageCtx::enter(&mut s, |ctx| {
+                PolicyRegistryStorage::new(ctx).update_allowlist(id, true, vec![ALICE])
+            })
+            .unwrap();
+        }
+        assert!(is_authorized(&mut s, id, ALICE));
+    }
+
+    #[test]
+    fn allowlist_removing_non_member_is_idempotent() {
+        let mut s = storage();
+        let id = create_allowlist(&mut s);
+        StorageCtx::enter(&mut s, |ctx| {
+            PolicyRegistryStorage::new(ctx).update_allowlist(id, false, vec![ALICE])
+        })
+        .unwrap();
+        assert!(!is_authorized(&mut s, id, ALICE));
+    }
+
+    #[test]
+    fn update_allowlist_on_blocklist_policy_reverts() {
+        let mut s = storage();
+        let id = create_blocklist(&mut s);
+        let err = StorageCtx::enter(&mut s, |ctx| {
+            PolicyRegistryStorage::new(ctx).update_allowlist(id, true, vec![ALICE])
+        })
+        .unwrap_err();
+        assert!(matches!(err, BasePrecompileError::Revert(_)));
+    }
+
+    // --- BLOCKLIST membership ---
+
+    #[test]
+    fn blocklist_non_member_is_authorized() {
+        let mut s = storage();
+        let id = create_blocklist(&mut s);
+        assert!(is_authorized(&mut s, id, ALICE));
+    }
+
+    #[test]
+    fn blocklist_block_then_unblock_member() {
+        let mut s = storage();
+        let id = create_blocklist(&mut s);
+
+        StorageCtx::enter(&mut s, |ctx| {
+            PolicyRegistryStorage::new(ctx).update_blocklist(id, true, vec![ALICE])
+        })
+        .unwrap();
+        assert!(!is_authorized(&mut s, id, ALICE));
+
+        StorageCtx::enter(&mut s, |ctx| {
+            PolicyRegistryStorage::new(ctx).update_blocklist(id, false, vec![ALICE])
+        })
+        .unwrap();
+        assert!(is_authorized(&mut s, id, ALICE));
+    }
+
+    #[test]
+    fn update_blocklist_on_allowlist_policy_reverts() {
+        let mut s = storage();
+        let id = create_allowlist(&mut s);
+        let err = StorageCtx::enter(&mut s, |ctx| {
+            PolicyRegistryStorage::new(ctx).update_blocklist(id, true, vec![ALICE])
+        })
+        .unwrap_err();
+        assert!(matches!(err, BasePrecompileError::Revert(_)));
+    }
+
+    // --- createPolicyWithAccounts ---
+
+    #[test]
+    fn create_policy_with_accounts_seeds_members() {
+        let mut s = storage();
+        let id = StorageCtx::enter(&mut s, |ctx| {
+            PolicyRegistryStorage::new(ctx).create_policy_with_accounts(
+                ADMIN,
+                PolicyType::ALLOWLIST,
+                vec![ALICE, BOB],
+            )
+        })
+        .unwrap();
+        assert!(is_authorized(&mut s, id, ALICE));
+        assert!(is_authorized(&mut s, id, BOB));
+    }
+
+    // --- two-step admin transfer ---
+
+    #[test]
+    fn admin_transfer_two_step() {
+        let mut s = storage();
+        let id = create_allowlist(&mut s);
+
+        StorageCtx::enter(&mut s, |ctx| {
+            PolicyRegistryStorage::new(ctx).stage_update_admin(id, NEW_ADMIN)
+        })
+        .unwrap();
+
+        s.set_caller(NEW_ADMIN);
+        StorageCtx::enter(&mut s, |ctx| PolicyRegistryStorage::new(ctx).finalize_update_admin(id))
+            .unwrap();
+
+        s.set_caller(NEW_ADMIN);
+        StorageCtx::enter(&mut s, |ctx| {
+            PolicyRegistryStorage::new(ctx).update_allowlist(id, true, vec![ALICE])
+        })
+        .unwrap();
+        assert!(is_authorized(&mut s, id, ALICE));
+    }
+
+    #[test]
+    fn finalize_update_admin_without_pending_reverts() {
+        let mut s = storage();
+        let id = create_allowlist(&mut s);
+        let err = StorageCtx::enter(&mut s, |ctx| {
+            PolicyRegistryStorage::new(ctx).finalize_update_admin(id)
+        })
+        .unwrap_err();
+        assert!(matches!(err, BasePrecompileError::Revert(_)));
+    }
+
+    // --- renounceAdmin ---
+
+    #[test]
+    fn renounce_admin_freezes_policy() {
+        let mut s = storage();
+        let id = create_allowlist(&mut s);
+
+        StorageCtx::enter(&mut s, |ctx| PolicyRegistryStorage::new(ctx).renounce_admin(id))
+            .unwrap();
+
+        let err = StorageCtx::enter(&mut s, |ctx| {
+            PolicyRegistryStorage::new(ctx).update_allowlist(id, true, vec![ALICE])
+        })
+        .unwrap_err();
+        assert!(matches!(err, BasePrecompileError::Revert(_)));
+    }
+
+    // --- static call guard ---
+
+    #[test]
+    fn write_in_static_context_reverts() {
+        let mut s = storage();
+        s.set_static(true);
+        let err = StorageCtx::enter(&mut s, |ctx| {
+            PolicyRegistryStorage::new(ctx).create_policy(ADMIN, PolicyType::ALLOWLIST)
+        })
+        .unwrap_err();
+        assert!(matches!(err, BasePrecompileError::Revert(_)));
+    }
+
+    // --- create_policy_with_accounts edge cases ---
+
+    #[test]
+    fn create_policy_with_accounts_batch_too_large_reverts() {
+        let mut s = storage();
+        let accounts = vec![ALICE; PolicyRegistryStorage::MAX_ACCOUNTS + 1];
+        let err = StorageCtx::enter(&mut s, |ctx| {
+            PolicyRegistryStorage::new(ctx).create_policy_with_accounts(
+                ADMIN,
+                PolicyType::ALLOWLIST,
+                accounts,
+            )
+        })
+        .unwrap_err();
+        assert!(matches!(err, BasePrecompileError::Revert(_)));
+    }
+
+    #[test]
+    fn create_policy_with_accounts_blocklist_seeds_blocked_members() {
+        let mut s = storage();
+        let id = StorageCtx::enter(&mut s, |ctx| {
+            PolicyRegistryStorage::new(ctx).create_policy_with_accounts(
+                ADMIN,
+                PolicyType::BLOCKLIST,
+                vec![ALICE, BOB],
+            )
+        })
+        .unwrap();
+        assert!(!is_authorized(&mut s, id, ALICE));
+        assert!(!is_authorized(&mut s, id, BOB));
+    }
+
+    // --- stage_update_admin authorization ---
+
+    #[test]
+    fn stage_update_admin_unauthorized_reverts() {
+        let mut s = storage();
+        let id = create_allowlist(&mut s);
+        s.set_caller(ALICE);
+        let err = StorageCtx::enter(&mut s, |ctx| {
+            PolicyRegistryStorage::new(ctx).stage_update_admin(id, NEW_ADMIN)
+        })
+        .unwrap_err();
+        assert!(matches!(err, BasePrecompileError::Revert(_)));
+    }
+
+    // --- finalize_update_admin authorization ---
+
+    #[test]
+    fn finalize_update_admin_unauthorized_reverts() {
+        let mut s = storage();
+        let id = create_allowlist(&mut s);
+        StorageCtx::enter(&mut s, |ctx| {
+            PolicyRegistryStorage::new(ctx).stage_update_admin(id, NEW_ADMIN)
+        })
+        .unwrap();
+        s.set_caller(ALICE);
+        let err = StorageCtx::enter(&mut s, |ctx| {
+            PolicyRegistryStorage::new(ctx).finalize_update_admin(id)
+        })
+        .unwrap_err();
+        assert!(matches!(err, BasePrecompileError::Revert(_)));
+    }
+
+    // --- renounce_admin authorization ---
+
+    #[test]
+    fn renounce_admin_unauthorized_reverts() {
+        let mut s = storage();
+        let id = create_allowlist(&mut s);
+        s.set_caller(ALICE);
+        let err =
+            StorageCtx::enter(&mut s, |ctx| PolicyRegistryStorage::new(ctx).renounce_admin(id))
+                .unwrap_err();
+        assert!(matches!(err, BasePrecompileError::Revert(_)));
+    }
+
+    // --- update_allowlist static call and batch guards ---
+
+    #[test]
+    fn update_allowlist_static_call_reverts() {
+        let mut s = storage();
+        let id = create_allowlist(&mut s);
+        s.set_static(true);
+        let err = StorageCtx::enter(&mut s, |ctx| {
+            PolicyRegistryStorage::new(ctx).update_allowlist(id, true, vec![ALICE])
+        })
+        .unwrap_err();
+        assert!(matches!(err, BasePrecompileError::Revert(_)));
+    }
+
+    #[test]
+    fn update_allowlist_batch_too_large_reverts() {
+        let mut s = storage();
+        let id = create_allowlist(&mut s);
+        let accounts = vec![ALICE; PolicyRegistryStorage::MAX_ACCOUNTS + 1];
+        let err = StorageCtx::enter(&mut s, |ctx| {
+            PolicyRegistryStorage::new(ctx).update_allowlist(id, true, accounts)
+        })
+        .unwrap_err();
+        assert!(matches!(err, BasePrecompileError::Revert(_)));
+    }
+
+    // --- next_policy_id invalid type ---
+
+    #[test]
+    fn next_policy_id_always_allow_type_reverts() {
+        let mut s = storage();
+        let err = StorageCtx::enter(&mut s, |ctx| {
+            PolicyRegistryStorage::new(ctx).next_policy_id(PolicyType::ALWAYS_ALLOW)
+        })
+        .unwrap_err();
+        assert!(matches!(err, BasePrecompileError::Revert(_)));
+    }
+
+    // --- policy_exists for built-in IDs ---
+
+    #[test]
+    fn policy_exists_builtin_ids_always_return_true() {
+        let mut s = storage();
+        assert!(
+            StorageCtx::enter(&mut s, |ctx| {
+                PolicyRegistryStorage::new(ctx)
+                    .policy_exists(PolicyRegistryStorage::ALWAYS_ALLOW_ID)
+            })
+            .unwrap()
+        );
+        assert!(
+            StorageCtx::enter(&mut s, |ctx| {
+                PolicyRegistryStorage::new(ctx)
+                    .policy_exists(PolicyRegistryStorage::ALWAYS_BLOCK_ID)
+            })
+            .unwrap()
+        );
+    }
+
+    // --- get_policy_type for built-in IDs ---
+
+    #[test]
+    fn get_policy_type_builtin_ids() {
+        let mut s = storage();
+        assert_eq!(
+            StorageCtx::enter(&mut s, |ctx| {
+                PolicyRegistryStorage::new(ctx)
+                    .get_policy_type(PolicyRegistryStorage::ALWAYS_ALLOW_ID)
+            })
+            .unwrap(),
+            PolicyType::ALWAYS_ALLOW
+        );
+        assert_eq!(
+            StorageCtx::enter(&mut s, |ctx| {
+                PolicyRegistryStorage::new(ctx)
+                    .get_policy_type(PolicyRegistryStorage::ALWAYS_BLOCK_ID)
+            })
+            .unwrap(),
+            PolicyType::ALWAYS_BLOCK
+        );
+    }
+
+    // --- get_policy_admin for built-in IDs ---
+
+    #[test]
+    fn get_policy_admin_builtin_ids_return_zero_address() {
+        let mut s = storage();
+        assert_eq!(
+            StorageCtx::enter(&mut s, |ctx| {
+                PolicyRegistryStorage::new(ctx)
+                    .get_policy_admin(PolicyRegistryStorage::ALWAYS_ALLOW_ID)
+            })
+            .unwrap(),
+            Address::ZERO
+        );
+        assert_eq!(
+            StorageCtx::enter(&mut s, |ctx| {
+                PolicyRegistryStorage::new(ctx)
+                    .get_policy_admin(PolicyRegistryStorage::ALWAYS_BLOCK_ID)
+            })
+            .unwrap(),
+            Address::ZERO
+        );
+    }
+
+    // --- pending_policy_admin for built-in IDs and unknown IDs ---
+
+    #[test]
+    fn pending_policy_admin_builtin_ids_return_zero_address() {
+        let mut s = storage();
+        assert_eq!(
+            StorageCtx::enter(&mut s, |ctx| {
+                PolicyRegistryStorage::new(ctx)
+                    .pending_policy_admin(PolicyRegistryStorage::ALWAYS_ALLOW_ID)
+            })
+            .unwrap(),
+            Address::ZERO
+        );
+        assert_eq!(
+            StorageCtx::enter(&mut s, |ctx| {
+                PolicyRegistryStorage::new(ctx)
+                    .pending_policy_admin(PolicyRegistryStorage::ALWAYS_BLOCK_ID)
+            })
+            .unwrap(),
+            Address::ZERO
+        );
+    }
+
+    #[test]
+    fn pending_policy_admin_unknown_id_reverts() {
+        let mut s = storage();
+        let err = StorageCtx::enter(&mut s, |ctx| {
+            PolicyRegistryStorage::new(ctx).pending_policy_admin(0xdeadbeef)
+        })
+        .unwrap_err();
+        assert!(matches!(err, BasePrecompileError::Revert(_)));
+    }
+
+    // --- PolicyRegistryTrait delegation ---
+
+    #[test]
+    fn trait_create_policy_delegates() {
+        let mut s = storage();
+        let id = StorageCtx::enter(&mut s, |ctx| {
+            let mut reg = PolicyRegistryStorage::new(ctx);
+            crate::PolicyRegistry::create_policy(&mut reg, ADMIN, PolicyType::ALLOWLIST)
+        })
+        .unwrap();
+        assert_eq!((id >> 56) as u8, PolicyType::ALLOWLIST as u8);
+    }
+
+    #[test]
+    fn trait_create_policy_with_accounts_delegates() {
+        let mut s = storage();
+        let id = StorageCtx::enter(&mut s, |ctx| {
+            let mut reg = PolicyRegistryStorage::new(ctx);
+            crate::PolicyRegistry::create_policy_with_accounts(
+                &mut reg,
+                ADMIN,
+                PolicyType::ALLOWLIST,
+                vec![ALICE],
+            )
+        })
+        .unwrap();
+        assert!(is_authorized(&mut s, id, ALICE));
+    }
+
+    #[test]
+    fn trait_stage_update_admin_delegates() {
+        let mut s = storage();
+        let id = create_allowlist(&mut s);
+        StorageCtx::enter(&mut s, |ctx| {
+            let mut reg = PolicyRegistryStorage::new(ctx);
+            crate::PolicyRegistry::stage_update_admin(&mut reg, id, NEW_ADMIN)
+        })
+        .unwrap();
+        let pending = StorageCtx::enter(&mut s, |ctx| {
+            PolicyRegistryStorage::new(ctx).pending_policy_admin(id)
+        })
+        .unwrap();
+        assert_eq!(pending, NEW_ADMIN);
+    }
+
+    #[test]
+    fn trait_finalize_update_admin_delegates() {
+        let mut s = storage();
+        let id = create_allowlist(&mut s);
+        StorageCtx::enter(&mut s, |ctx| {
+            PolicyRegistryStorage::new(ctx).stage_update_admin(id, NEW_ADMIN)
+        })
+        .unwrap();
+        s.set_caller(NEW_ADMIN);
+        StorageCtx::enter(&mut s, |ctx| {
+            let mut reg = PolicyRegistryStorage::new(ctx);
+            crate::PolicyRegistry::finalize_update_admin(&mut reg, id)
+        })
+        .unwrap();
+        let admin =
+            StorageCtx::enter(&mut s, |ctx| PolicyRegistryStorage::new(ctx).get_policy_admin(id))
+                .unwrap();
+        assert_eq!(admin, NEW_ADMIN);
+    }
+
+    #[test]
+    fn trait_renounce_admin_delegates() {
+        let mut s = storage();
+        let id = create_allowlist(&mut s);
+        StorageCtx::enter(&mut s, |ctx| {
+            let mut reg = PolicyRegistryStorage::new(ctx);
+            crate::PolicyRegistry::renounce_admin(&mut reg, id)
+        })
+        .unwrap();
+        let admin =
+            StorageCtx::enter(&mut s, |ctx| PolicyRegistryStorage::new(ctx).get_policy_admin(id))
+                .unwrap();
+        assert_eq!(admin, Address::ZERO);
+    }
+
+    #[test]
+    fn trait_update_allowlist_delegates() {
+        let mut s = storage();
+        let id = create_allowlist(&mut s);
+        StorageCtx::enter(&mut s, |ctx| {
+            let mut reg = PolicyRegistryStorage::new(ctx);
+            crate::PolicyRegistry::update_allowlist(&mut reg, id, true, vec![ALICE])
+        })
+        .unwrap();
+        assert!(is_authorized(&mut s, id, ALICE));
+    }
+
+    #[test]
+    fn trait_update_blocklist_delegates() {
+        let mut s = storage();
+        let id = create_blocklist(&mut s);
+        StorageCtx::enter(&mut s, |ctx| {
+            let mut reg = PolicyRegistryStorage::new(ctx);
+            crate::PolicyRegistry::update_blocklist(&mut reg, id, true, vec![ALICE])
+        })
+        .unwrap();
+        assert!(!is_authorized(&mut s, id, ALICE));
+    }
+
+    #[test]
+    fn trait_is_authorized_delegates() {
+        let mut s = storage();
+        let authorized = StorageCtx::enter(&mut s, |ctx| {
+            let reg = PolicyRegistryStorage::new(ctx);
+            crate::Policy::is_authorized(&reg, PolicyRegistryStorage::ALWAYS_ALLOW_ID, ALICE)
+        })
+        .unwrap();
+        assert!(authorized);
+    }
+
+    #[test]
+    fn trait_next_policy_id_delegates() {
+        let mut s = storage();
+        let id = StorageCtx::enter(&mut s, |ctx| {
+            let reg = PolicyRegistryStorage::new(ctx);
+            crate::PolicyRegistry::next_policy_id(&reg, PolicyType::ALLOWLIST)
+        })
+        .unwrap();
+        assert_eq!((id >> 56) as u8, PolicyType::ALLOWLIST as u8);
+    }
+
+    #[test]
+    fn trait_policy_exists_delegates() {
+        let mut s = storage();
+        let exists = StorageCtx::enter(&mut s, |ctx| {
+            let reg = PolicyRegistryStorage::new(ctx);
+            crate::PolicyRegistry::policy_exists(&reg, PolicyRegistryStorage::ALWAYS_ALLOW_ID)
+        })
+        .unwrap();
+        assert!(exists);
+    }
+
+    #[test]
+    fn trait_get_policy_type_delegates() {
+        let mut s = storage();
+        let pt = StorageCtx::enter(&mut s, |ctx| {
+            let reg = PolicyRegistryStorage::new(ctx);
+            crate::PolicyRegistry::get_policy_type(&reg, PolicyRegistryStorage::ALWAYS_ALLOW_ID)
+        })
+        .unwrap();
+        assert_eq!(pt, PolicyType::ALWAYS_ALLOW);
+    }
+
+    #[test]
+    fn trait_get_policy_admin_delegates() {
+        let mut s = storage();
+        let admin = StorageCtx::enter(&mut s, |ctx| {
+            let reg = PolicyRegistryStorage::new(ctx);
+            crate::PolicyRegistry::get_policy_admin(&reg, PolicyRegistryStorage::ALWAYS_ALLOW_ID)
+        })
+        .unwrap();
+        assert_eq!(admin, Address::ZERO);
+    }
+
+    #[test]
+    fn trait_pending_policy_admin_delegates() {
+        let mut s = storage();
+        let id = create_allowlist(&mut s);
+        let pending = StorageCtx::enter(&mut s, |ctx| {
+            let reg = PolicyRegistryStorage::new(ctx);
+            crate::PolicyRegistry::pending_policy_admin(&reg, id)
+        })
+        .unwrap();
+        assert_eq!(pending, Address::ZERO);
     }
 }

--- a/crates/common/precompiles/src/provider.rs
+++ b/crates/common/precompiles/src/provider.rs
@@ -13,8 +13,8 @@ use revm::{
 };
 
 use crate::{
-    ActivationRegistry, B20TokenPrecompile, BasePrecompileSpec, PolicyRegistry, TokenFactory,
-    bls12_381, bn254_pair,
+    ActivationRegistry, B20TokenPrecompile, BasePrecompileSpec, PolicyRegistryPrecompile,
+    TokenFactory, bls12_381, bn254_pair,
 };
 
 /// Base precompile provider.
@@ -173,7 +173,7 @@ impl<S: BasePrecompileSpec> BasePrecompiles<S> {
         if self.spec.upgrade() >= BaseUpgrade::Beryl {
             TokenFactory::install(&mut precompiles);
             B20TokenPrecompile::install(&mut precompiles);
-            PolicyRegistry::install(&mut precompiles);
+            PolicyRegistryPrecompile::install(&mut precompiles);
             ActivationRegistry::install(&mut precompiles, self.activation_admin_address);
         }
         precompiles

--- a/devnet/tests/policy_registry.rs
+++ b/devnet/tests/policy_registry.rs
@@ -8,9 +8,9 @@ use base_common_precompiles::{IPolicyRegistry, PolicyRegistryStorage};
 use devnet::{B20PrecompileClient, config::ANVIL_ACCOUNT_5};
 use eyre::{Result, WrapErr};
 
-/// `helloWorld()` returns `true` once the Beryl fork is active.
+/// `policyExists(0)` returns `true` once the Beryl fork is active.
 #[tokio::test]
-async fn test_policy_registry_hello_world() -> Result<()> {
+async fn test_policy_registry_policy_exists() -> Result<()> {
     let (_devnet, provider) = common::start_beryl_devnet().await?;
     let caller = PrivateKeySigner::from_bytes(&ANVIL_ACCOUNT_5.private_key)
         .wrap_err("Failed to parse devnet private key")?;
@@ -19,12 +19,13 @@ async fn test_policy_registry_hello_world() -> Result<()> {
     let client = B20PrecompileClient::new(&provider, &caller, common::L2_CHAIN_ID)
         .with_receipt_timeout(common::TX_RECEIPT_TIMEOUT);
 
-    let output =
-        client.call(PolicyRegistryStorage::ADDRESS, IPolicyRegistry::helloWorldCall {}).await?;
-    let result = IPolicyRegistry::helloWorldCall::abi_decode_returns(output.as_ref())
-        .wrap_err("Failed to decode helloWorld")?;
+    let output = client
+        .call(PolicyRegistryStorage::ADDRESS, IPolicyRegistry::policyExistsCall { policyId: 0 })
+        .await?;
+    let result = IPolicyRegistry::policyExistsCall::abi_decode_returns(output.as_ref())
+        .wrap_err("Failed to decode policyExists")?;
 
-    assert!(result, "helloWorld should return true after Beryl activation");
+    assert!(result, "policyExists(0) should return true after Beryl activation");
 
     Ok(())
 }


### PR DESCRIPTION
## Motivation

The `IPolicyRegistry` interface (base-std) defines the singleton that B-20 tokens call for every transfer, mint, and redeem authorization check. This PR delivers the full precompile, replacing the `helloWorld` stub.

**Storage namespacing:** We explored both ERC-7201 sequential namespacing and per-field named slots (e.g. `keccak256("base.policy_registry.policies")`) to allow field reordering across hardforks. Both approaches work with the `#[contract]` macro. Deferring to a follow-up PR for @refcell to decide the right convention — sequential slots (append-only) are safe for now since the precompile owns its address exclusively.

## What changed

- Full `IPolicyRegistry` implementation in `crates/common/precompiles/src/policy/`: all 13 ABI functions, `SolInterface` dispatch, 4-field storage layout (slots 0-3, append-only), and 22 unit tests
- `PolicyType` enum: `ALWAYS_ALLOW=0`, `ALWAYS_BLOCK=1`, `ALLOWLIST=2`, `BLOCKLIST=3`; built-in IDs are 0 and 1
- Policy ID encoding: top byte = `uint8(PolicyType)`, low 56 bits = global counter (checked add, 56-bit cap)
- Packed policy word: `[167:8] = admin`, `[7:0] = PolicyType`; packed == 0 reliably means never created