### PR TITLE
refactor(common): Remove Static B20 Address

### DIFF
--- a/crates/common/precompiles/src/lib.rs
+++ b/crates/common/precompiles/src/lib.rs
@@ -22,9 +22,9 @@ mod bls12_381;
 
 mod token;
 pub use token::{
-    B20_TOKEN_ADDRESS, B20Token, B20TokenPrecompile, B20TokenStorage, Burnable,
-    CAPABILITY_CAP_MUTABLE, CAPABILITY_PAUSABLE, Configurable, IB20, IPolicyRegistry,
-    ITokenFactory, Mintable, POLICY_REGISTRY_ADDRESS, Pausable, Permittable, Policy, PolicyHandle,
-    PolicyRegistryEvm, Redeemable, Token, TokenAccounting, TokenFactory, TokenFactoryPrecompile,
-    TokenVariant, Transferable,
+    B20Token, B20TokenPrecompile, B20TokenStorage, Burnable, CAPABILITY_CAP_MUTABLE,
+    CAPABILITY_PAUSABLE, Configurable, IB20, IPolicyRegistry, ITokenFactory, Mintable,
+    POLICY_REGISTRY_ADDRESS, Pausable, Permittable, Policy, PolicyHandle, PolicyRegistryEvm,
+    Redeemable, Token, TokenAccounting, TokenFactory, TokenFactoryPrecompile, TokenVariant,
+    Transferable,
 };

--- a/crates/common/precompiles/src/token/b20/mod.rs
+++ b/crates/common/precompiles/src/token/b20/mod.rs
@@ -6,7 +6,7 @@ mod precompile;
 pub use precompile::B20TokenPrecompile;
 
 mod storage;
-pub use storage::{B20_TOKEN_ADDRESS, B20TokenStorage};
+pub use storage::B20TokenStorage;
 
 mod token;
 pub use token::B20Token;

--- a/crates/common/precompiles/src/token/b20/storage.rs
+++ b/crates/common/precompiles/src/token/b20/storage.rs
@@ -1,6 +1,6 @@
 use alloc::string::String;
 
-use alloy_primitives::{Address, LogData, U256, address};
+use alloy_primitives::{Address, LogData, U256};
 use base_precompile_macros::contract;
 use base_precompile_storage::{
     BasePrecompileError, ContractStorage, Handler, Mapping, Result, StorageCtx,
@@ -8,10 +8,7 @@ use base_precompile_storage::{
 
 use crate::token::{TokenVariant, common::TokenAccounting};
 
-/// Canonical precompile address for the `B20Token` (placeholder — replace before deployment).
-pub const B20_TOKEN_ADDRESS: Address = address!("0000000000000000000000000000000000000900");
-
-#[contract(addr = B20_TOKEN_ADDRESS)]
+#[contract]
 pub struct B20TokenStorage {
     pub total_supply: U256,                                   // slot 0
     pub supply_cap: U256,                                     // slot 1

--- a/crates/common/precompiles/src/token/mod.rs
+++ b/crates/common/precompiles/src/token/mod.rs
@@ -10,7 +10,7 @@ pub use common::{
 };
 
 mod b20;
-pub use b20::{B20_TOKEN_ADDRESS, B20Token, B20TokenPrecompile, B20TokenStorage};
+pub use b20::{B20Token, B20TokenPrecompile, B20TokenStorage};
 
 mod factory;
 pub use factory::{TokenFactory, TokenFactoryPrecompile, TokenVariant};


### PR DESCRIPTION
## Summary

This removes the placeholder B-20 contract address from the B20 storage layout and stops re-exporting it from the precompiles crate. The storage layout now only supports the dynamic address path used by the factory and precompile lookup, which avoids suggesting that B-20 has a canonical fixed deployment address.