### PR TITLE
perf(trie): speed up proof storage pruner hot paths

### DIFF
--- a/crates/execution/exex/README.md
+++ b/crates/execution/exex/README.md
@@ -27,7 +27,7 @@ tip latency.
 
 ## Architecture
 
-```
+```text
 base-reth-node
 ├── Standard reth pipeline (sync, EVM, state)
 ├── proofs-history ExEx (ingests committed blocks → versioned trie store)
@@ -63,7 +63,7 @@ are processed.
 
 After the node starts, query the sync status of the proofs store:
 
-```
+```text
 debug_proofsSyncStatus → { "earliest": <block>, "latest": <block> }
 ```
 

--- a/crates/execution/exex/src/lib.rs
+++ b/crates/execution/exex/src/lib.rs
@@ -455,12 +455,7 @@ where
                 Vec::with_capacity((end - latest) as usize);
             for block_num in (latest + 1)..=end {
                 let cached = sync_target.take(block_num);
-                match Self::build_batch_entry(
-                    block_num,
-                    cached,
-                    provider,
-                    verification_interval,
-                ) {
+                match Self::build_batch_entry(block_num, cached, provider, verification_interval) {
                     Ok(entry) => batch.push(entry),
                     Err(e) => {
                         error!(target: "base::exex", block_number = block_num, error = ?e, "Preparing block for batch failed");

--- a/crates/execution/exex/src/lib.rs
+++ b/crates/execution/exex/src/lib.rs
@@ -12,8 +12,10 @@ use std::{sync::Arc, time::Duration};
 
 use alloy_consensus::BlockHeader;
 use alloy_eips::eip1898::BlockWithParent;
+#[cfg(feature = "metrics")]
+use base_execution_trie::BaseProofsStore;
 use base_execution_trie::{
-    BaseProofStoragePrunerTask, BaseProofsBatchStore, BaseProofsStorage, BaseProofsStore,
+    BaseProofStoragePrunerTask, BaseProofsBatchStore, BaseProofsStorage,
     live::{BatchBlock, LiveTrieCollector},
     metrics::BlockMetrics,
 };

--- a/crates/execution/exex/src/lib.rs
+++ b/crates/execution/exex/src/lib.rs
@@ -13,7 +13,8 @@ use std::{sync::Arc, time::Duration};
 use alloy_consensus::BlockHeader;
 use alloy_eips::eip1898::BlockWithParent;
 use base_execution_trie::{
-    BaseProofStoragePrunerTask, BaseProofsStorage, BaseProofsStore, live::LiveTrieCollector,
+    BaseProofStoragePrunerTask, BaseProofsBatchStore, BaseProofsStorage, BaseProofsStore,
+    live::{BatchBlock, LiveTrieCollector},
     metrics::BlockMetrics,
 };
 use futures::TryStreamExt;
@@ -208,7 +209,7 @@ impl<Node, Storage, Primitives> BaseProofsExEx<Node, Storage>
 where
     Node: FullNodeComponents<Types: NodeTypes<Primitives = Primitives>>,
     Primitives: NodePrimitives,
-    Storage: BaseProofsStore + Clone + 'static,
+    Storage: BaseProofsBatchStore + Clone + 'static,
 {
     /// Main execution loop for the `ExEx`
     pub async fn run(mut self) -> eyre::Result<()> {
@@ -450,18 +451,27 @@ where
                 "Processing proofs storage sync batch"
             );
 
+            let mut batch: Vec<BatchBlock<Primitives>> =
+                Vec::with_capacity((end - latest) as usize);
             for block_num in (latest + 1)..=end {
                 let cached = sync_target.take(block_num);
-                if let Err(e) = Self::process_block(
+                match Self::build_batch_entry(
                     block_num,
                     cached,
-                    collector,
                     provider,
                     verification_interval,
                 ) {
-                    error!(target: "base::exex", block_number = block_num, error = ?e, "Block processing failed");
-                    return;
+                    Ok(entry) => batch.push(entry),
+                    Err(e) => {
+                        error!(target: "base::exex", block_number = block_num, error = ?e, "Preparing block for batch failed");
+                        return;
+                    }
                 }
+            }
+
+            if let Err(e) = collector.execute_and_store_batch(batch) {
+                error!(target: "base::exex", start = latest + 1, end, error = ?e, "Batch processing failed");
+                return;
             }
 
             info!(target: "base::exex", latest_stored = latest, target, "Batch processed, yielding");
@@ -469,34 +479,33 @@ where
         }
     }
 
-    fn process_block(
+    fn build_batch_entry(
         block_number: u64,
         cached: Option<CachedBlockTrieData>,
-        collector: &LiveTrieCollector<'_, Node::Evm, Node::Provider, Storage>,
         provider: &Node::Provider,
         verification_interval: u64,
-    ) -> eyre::Result<()> {
+    ) -> eyre::Result<BatchBlock<Primitives>> {
         let should_verify =
             verification_interval > 0 && block_number.is_multiple_of(verification_interval);
+        let has_cached = cached.is_some();
 
-        if let Some(cached) = cached {
+        if let Some(cached) = cached
+            && !should_verify
+        {
             let sorted = cached.trie_data.get();
-            if !should_verify {
-                debug!(
-                    target: "base::exex",
-                    block_number,
-                    "Using pre-computed state from notification"
-                );
+            debug!(
+                target: "base::exex",
+                block_number,
+                "Using pre-computed state from notification"
+            );
+            return Ok(BatchBlock::Cached {
+                block_with_parent: cached.block_with_parent,
+                sorted_trie_updates: Arc::clone(&sorted.trie_updates),
+                sorted_post_state: Arc::clone(&sorted.hashed_state),
+            });
+        }
 
-                collector.store_block_updates(
-                    cached.block_with_parent,
-                    (*sorted.trie_updates).clone(),
-                    (*sorted.hashed_state).clone(),
-                )?;
-
-                return Ok(());
-            }
-
+        if has_cached {
             info!(
                 target: "base::exex",
                 block_number,
@@ -521,8 +530,7 @@ where
             .recovered_block(block_number.into(), TransactionVariant::NoHash)?
             .ok_or_else(|| eyre::eyre!("Missing block {} in provider", block_number))?;
 
-        collector.execute_and_store_block_updates(&block)?;
-        Ok(())
+        Ok(BatchBlock::Execute(Box::new(block)))
     }
 
     fn handle_notification(

--- a/crates/execution/trie/src/api.rs
+++ b/crates/execution/trie/src/api.rs
@@ -283,8 +283,10 @@ pub trait BaseProofsBatchSession: Send + Sync + Debug {
 /// Storage that can open a [`BaseProofsBatchSession`] holding a single underlying
 /// transaction across multiple block writes.
 ///
-/// On `Ok` return from the closure the session commits; on `Err` the session aborts and
-/// no writes become visible to subsequent reads.
+/// The MDBX implementation commits atomically on `Ok` and aborts on `Err`, leaving no
+/// writes visible to subsequent reads. The in-memory implementation is a test double
+/// that lacks transactional rollback — partial writes from a failing batch remain
+/// visible. Production code must rely on MDBX semantics.
 pub trait BaseProofsBatchStore: BaseProofsStore {
     /// Session type bound to the active transaction.
     type BatchSession<'a>: BaseProofsBatchSession + 'a

--- a/crates/execution/trie/src/api.rs
+++ b/crates/execution/trie/src/api.rs
@@ -207,6 +207,110 @@ pub trait BaseProofsStore: Send + Sync + Debug {
     ) -> BaseProofsStorageResult<()>;
 }
 
+/// Session-scoped store of trie updates that share a single underlying transaction.
+///
+/// A session opened via [`BaseProofsBatchStore::with_batch_session`] amortizes MDBX commit
+/// cost across multiple block writes: reads through the session observe uncommitted writes
+/// from earlier `store_trie_updates` calls in the same session, enabling cold catch-up of
+/// `block N+1` against `block N` written but not yet committed.
+///
+/// All cursor methods mirror [`BaseProofsStore`] but read from the active transaction.
+#[auto_impl(&mut)]
+pub trait BaseProofsBatchSession: Send + Sync + Debug {
+    /// Cursor for iterating over storage trie branches in the active session.
+    type StorageTrieCursor<'a>: TrieStorageCursor + 'a
+    where
+        Self: 'a;
+
+    /// Cursor for iterating over account trie branches in the active session.
+    type AccountTrieCursor<'a>: TrieCursor + 'a
+    where
+        Self: 'a;
+
+    /// Cursor for iterating over storage leaves in the active session.
+    type StorageCursor<'a>: HashedStorageCursor<Value = U256> + Send + Sync + 'a
+    where
+        Self: 'a;
+
+    /// Cursor for iterating over account leaves in the active session.
+    type AccountHashedCursor<'a>: HashedCursor<Value = Account> + Send + Sync + 'a
+    where
+        Self: 'a;
+
+    /// Earliest stored block number/hash visible to the active transaction.
+    fn get_earliest_block_number(&self) -> BaseProofsStorageResult<Option<(u64, B256)>>;
+
+    /// Latest stored block number/hash visible to the active transaction (including
+    /// uncommitted writes from earlier calls in this session).
+    fn get_latest_block_number(&self) -> BaseProofsStorageResult<Option<(u64, B256)>>;
+
+    /// Storage trie cursor reading through the active transaction.
+    fn storage_trie_cursor(
+        &self,
+        hashed_address: B256,
+        max_block_number: u64,
+    ) -> BaseProofsStorageResult<Self::StorageTrieCursor<'_>>;
+
+    /// Account trie cursor reading through the active transaction.
+    fn account_trie_cursor(
+        &self,
+        max_block_number: u64,
+    ) -> BaseProofsStorageResult<Self::AccountTrieCursor<'_>>;
+
+    /// Storage hashed cursor reading through the active transaction.
+    fn storage_hashed_cursor(
+        &self,
+        hashed_address: B256,
+        max_block_number: u64,
+    ) -> BaseProofsStorageResult<Self::StorageCursor<'_>>;
+
+    /// Account hashed cursor reading through the active transaction.
+    fn account_hashed_cursor(
+        &self,
+        max_block_number: u64,
+    ) -> BaseProofsStorageResult<Self::AccountHashedCursor<'_>>;
+
+    /// Append-only write of `block_state_diff` for `block_ref` to the active transaction.
+    /// Subsequent reads through this session observe the new state immediately, but the
+    /// changes are not durable until the enclosing session commits.
+    fn store_trie_updates(
+        &mut self,
+        block_ref: BlockWithParent,
+        block_state_diff: BlockStateDiff,
+    ) -> BaseProofsStorageResult<WriteCounts>;
+}
+
+/// Storage that can open a [`BaseProofsBatchSession`] holding a single underlying
+/// transaction across multiple block writes.
+///
+/// On `Ok` return from the closure the session commits; on `Err` the session aborts and
+/// no writes become visible to subsequent reads.
+pub trait BaseProofsBatchStore: BaseProofsStore {
+    /// Session type bound to the active transaction.
+    type BatchSession<'a>: BaseProofsBatchSession + 'a
+    where
+        Self: 'a;
+
+    /// Run `f` inside one batch session. Commits if `f` returns `Ok`, aborts on `Err`.
+    fn with_batch_session<R, F>(&self, f: F) -> BaseProofsStorageResult<R>
+    where
+        F: FnOnce(&mut Self::BatchSession<'_>) -> BaseProofsStorageResult<R>;
+}
+
+impl<T: BaseProofsBatchStore + 'static> BaseProofsBatchStore for std::sync::Arc<T> {
+    type BatchSession<'a>
+        = T::BatchSession<'a>
+    where
+        Self: 'a;
+
+    fn with_batch_session<R, F>(&self, f: F) -> BaseProofsStorageResult<R>
+    where
+        F: FnOnce(&mut Self::BatchSession<'_>) -> BaseProofsStorageResult<R>,
+    {
+        (**self).with_batch_session(f)
+    }
+}
+
 /// Status of the initial state anchor.
 #[derive(Debug, Clone, Copy, Default)]
 pub enum InitialStateStatus {

--- a/crates/execution/trie/src/batch_provider.rs
+++ b/crates/execution/trie/src/batch_provider.rs
@@ -1,0 +1,312 @@
+//! State provider for an active [`BaseProofsBatchSession`] enabling reads to observe
+//! uncommitted writes performed earlier in the same session.
+
+use std::fmt::Debug;
+
+use alloy_primitives::{
+    keccak256,
+    map::{B256Map, HashMap},
+};
+use derive_more::Constructor;
+use reth_primitives_traits::{Account, Bytecode};
+use reth_provider::{
+    AccountReader, BlockHashReader, BytecodeReader, HashedPostStateProvider, ProviderError,
+    ProviderResult, StateProofProvider, StateProvider, StateRootProvider, StorageRootProvider,
+};
+use reth_revm::{
+    db::BundleState,
+    primitives::{Address, B256, Bytes, StorageValue, alloy_primitives::BlockNumber},
+};
+use reth_trie::{
+    StateRoot, StorageRoot, TrieType,
+    hashed_cursor::{HashedCursor, HashedPostStateCursorFactory},
+    metrics::TrieRootMetrics,
+    proof,
+    trie_cursor::InMemoryTrieCursorFactory,
+    witness::TrieWitness,
+};
+use reth_trie_common::{
+    AccountProof, HashedPostState, HashedPostStateSorted, HashedStorage, KeccakKeyHasher,
+    MultiProof, MultiProofTargets, StorageMultiProof, StorageProof, TrieInput,
+    updates::TrieUpdates,
+};
+
+use crate::{
+    BaseProofsBatchHashedAccountCursorFactory, BaseProofsBatchTrieCursorFactory,
+    api::BaseProofsBatchSession,
+};
+
+/// State provider that reads through an active [`BaseProofsBatchSession`]'s transaction.
+#[derive(Constructor)]
+pub struct BaseProofsBatchStateProviderRef<'a, S: BaseProofsBatchSession> {
+    latest: Box<dyn StateProvider + Send + 'a>,
+    session: &'a S,
+    block_number: BlockNumber,
+}
+
+impl<S> Debug for BaseProofsBatchStateProviderRef<'_, S>
+where
+    S: BaseProofsBatchSession,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("BaseProofsBatchStateProviderRef")
+            .field("session", &self.session)
+            .field("block_number", &self.block_number)
+            .finish()
+    }
+}
+
+impl<'a, S: BaseProofsBatchSession> BaseProofsBatchStateProviderRef<'a, S> {
+    const fn factories(
+        &self,
+    ) -> (BaseProofsBatchTrieCursorFactory<'a, S>, BaseProofsBatchHashedAccountCursorFactory<'a, S>)
+    {
+        (
+            BaseProofsBatchTrieCursorFactory::new(self.session, self.block_number),
+            BaseProofsBatchHashedAccountCursorFactory::new(self.session, self.block_number),
+        )
+    }
+}
+
+impl<S: BaseProofsBatchSession> BlockHashReader for BaseProofsBatchStateProviderRef<'_, S> {
+    fn block_hash(&self, number: BlockNumber) -> ProviderResult<Option<B256>> {
+        self.latest.block_hash(number)
+    }
+
+    fn canonical_hashes_range(
+        &self,
+        start: BlockNumber,
+        end: BlockNumber,
+    ) -> ProviderResult<Vec<B256>> {
+        self.latest.canonical_hashes_range(start, end)
+    }
+}
+
+impl<S: BaseProofsBatchSession> StateRootProvider for BaseProofsBatchStateProviderRef<'_, S> {
+    fn state_root(&self, state: HashedPostState) -> ProviderResult<B256> {
+        let prefix_sets = state.construct_prefix_sets().freeze();
+        let state_sorted = state.into_sorted();
+        let (trie_factory, hashed_factory) = self.factories();
+        StateRoot::new(
+            trie_factory,
+            HashedPostStateCursorFactory::new(hashed_factory, &state_sorted),
+        )
+        .with_prefix_sets(prefix_sets)
+        .root()
+        .map_err(ProviderError::from)
+    }
+
+    fn state_root_from_nodes(&self, input: TrieInput) -> ProviderResult<B256> {
+        let state_sorted = input.state.into_sorted();
+        let nodes_sorted = input.nodes.into_sorted();
+        let (trie_factory, hashed_factory) = self.factories();
+        StateRoot::new(
+            InMemoryTrieCursorFactory::new(trie_factory, &nodes_sorted),
+            HashedPostStateCursorFactory::new(hashed_factory, &state_sorted),
+        )
+        .with_prefix_sets(input.prefix_sets.freeze())
+        .root()
+        .map_err(ProviderError::from)
+    }
+
+    fn state_root_with_updates(
+        &self,
+        state: HashedPostState,
+    ) -> ProviderResult<(B256, TrieUpdates)> {
+        let prefix_sets = state.construct_prefix_sets().freeze();
+        let state_sorted = state.into_sorted();
+        let (trie_factory, hashed_factory) = self.factories();
+        StateRoot::new(
+            trie_factory,
+            HashedPostStateCursorFactory::new(hashed_factory, &state_sorted),
+        )
+        .with_prefix_sets(prefix_sets)
+        .root_with_updates()
+        .map_err(ProviderError::from)
+    }
+
+    fn state_root_from_nodes_with_updates(
+        &self,
+        input: TrieInput,
+    ) -> ProviderResult<(B256, TrieUpdates)> {
+        let state_sorted = input.state.into_sorted();
+        let nodes_sorted = input.nodes.into_sorted();
+        let (trie_factory, hashed_factory) = self.factories();
+        StateRoot::new(
+            InMemoryTrieCursorFactory::new(trie_factory, &nodes_sorted),
+            HashedPostStateCursorFactory::new(hashed_factory, &state_sorted),
+        )
+        .with_prefix_sets(input.prefix_sets.freeze())
+        .root_with_updates()
+        .map_err(ProviderError::from)
+    }
+}
+
+impl<S: BaseProofsBatchSession> StorageRootProvider for BaseProofsBatchStateProviderRef<'_, S> {
+    fn storage_root(&self, address: Address, storage: HashedStorage) -> ProviderResult<B256> {
+        let prefix_set = storage.construct_prefix_set().freeze();
+        let state_sorted =
+            HashedPostState::from_hashed_storage(keccak256(address), storage).into_sorted();
+        let (trie_factory, hashed_factory) = self.factories();
+        StorageRoot::new(
+            trie_factory,
+            HashedPostStateCursorFactory::new(hashed_factory, &state_sorted),
+            address,
+            prefix_set,
+            TrieRootMetrics::new(TrieType::Custom("base_historical_proofs_storage_batch")),
+        )
+        .root()
+        .map_err(|err| ProviderError::Database(err.into()))
+    }
+
+    fn storage_proof(
+        &self,
+        address: Address,
+        slot: B256,
+        hashed_storage: HashedStorage,
+    ) -> ProviderResult<StorageProof> {
+        let hashed_address = keccak256(address);
+        let prefix_set = hashed_storage.construct_prefix_set();
+        let state_sorted = HashedPostStateSorted::new(
+            Default::default(),
+            HashMap::from_iter([(hashed_address, hashed_storage.into_sorted())]),
+        );
+        let (trie_factory, hashed_factory) = self.factories();
+        proof::StorageProof::new(trie_factory, hashed_factory.clone(), address)
+            .with_hashed_cursor_factory(HashedPostStateCursorFactory::new(
+                hashed_factory,
+                &state_sorted,
+            ))
+            .with_prefix_set_mut(prefix_set)
+            .storage_proof(slot)
+            .map_err(ProviderError::from)
+    }
+
+    fn storage_multiproof(
+        &self,
+        address: Address,
+        slots: &[B256],
+        hashed_storage: HashedStorage,
+    ) -> ProviderResult<StorageMultiProof> {
+        let hashed_address = keccak256(address);
+        let targets = slots.iter().map(keccak256).collect();
+        let prefix_set = hashed_storage.construct_prefix_set();
+        let state_sorted = HashedPostStateSorted::new(
+            Default::default(),
+            HashMap::from_iter([(hashed_address, hashed_storage.into_sorted())]),
+        );
+        let (trie_factory, hashed_factory) = self.factories();
+        proof::StorageProof::new(trie_factory, hashed_factory.clone(), address)
+            .with_hashed_cursor_factory(HashedPostStateCursorFactory::new(
+                hashed_factory,
+                &state_sorted,
+            ))
+            .with_prefix_set_mut(prefix_set)
+            .storage_multiproof(targets)
+            .map_err(ProviderError::from)
+    }
+}
+
+impl<S: BaseProofsBatchSession> StateProofProvider for BaseProofsBatchStateProviderRef<'_, S> {
+    fn proof(
+        &self,
+        input: TrieInput,
+        address: Address,
+        slots: &[B256],
+    ) -> ProviderResult<AccountProof> {
+        let nodes_sorted = input.nodes.into_sorted();
+        let state_sorted = input.state.into_sorted();
+        let (trie_factory, hashed_factory) = self.factories();
+        proof::Proof::new(trie_factory.clone(), hashed_factory.clone())
+            .with_trie_cursor_factory(InMemoryTrieCursorFactory::new(trie_factory, &nodes_sorted))
+            .with_hashed_cursor_factory(HashedPostStateCursorFactory::new(
+                hashed_factory,
+                &state_sorted,
+            ))
+            .with_prefix_sets_mut(input.prefix_sets)
+            .account_proof(address, slots)
+            .map_err(ProviderError::from)
+    }
+
+    fn multiproof(
+        &self,
+        input: TrieInput,
+        targets: MultiProofTargets,
+    ) -> ProviderResult<MultiProof> {
+        let nodes_sorted = input.nodes.into_sorted();
+        let state_sorted = input.state.into_sorted();
+        let (trie_factory, hashed_factory) = self.factories();
+        proof::Proof::new(trie_factory.clone(), hashed_factory.clone())
+            .with_trie_cursor_factory(InMemoryTrieCursorFactory::new(trie_factory, &nodes_sorted))
+            .with_hashed_cursor_factory(HashedPostStateCursorFactory::new(
+                hashed_factory,
+                &state_sorted,
+            ))
+            .with_prefix_sets_mut(input.prefix_sets)
+            .multiproof(targets)
+            .map_err(ProviderError::from)
+    }
+
+    fn witness(&self, input: TrieInput, target: HashedPostState) -> ProviderResult<Vec<Bytes>> {
+        let nodes_sorted = input.nodes.into_sorted();
+        let state_sorted = input.state.into_sorted();
+        let (trie_factory, hashed_factory) = self.factories();
+        let result: B256Map<Bytes> = TrieWitness::new(trie_factory.clone(), hashed_factory.clone())
+            .with_trie_cursor_factory(InMemoryTrieCursorFactory::new(trie_factory, &nodes_sorted))
+            .with_hashed_cursor_factory(HashedPostStateCursorFactory::new(
+                hashed_factory,
+                &state_sorted,
+            ))
+            .with_prefix_sets_mut(input.prefix_sets)
+            .always_include_root_node()
+            .compute(target)
+            .map_err(ProviderError::from)?;
+        Ok(result.into_values().collect())
+    }
+}
+
+impl<S: BaseProofsBatchSession> HashedPostStateProvider for BaseProofsBatchStateProviderRef<'_, S> {
+    fn hashed_post_state(&self, bundle_state: &BundleState) -> HashedPostState {
+        HashedPostState::from_bundle_state::<KeccakKeyHasher>(bundle_state.state())
+    }
+}
+
+impl<S: BaseProofsBatchSession> AccountReader for BaseProofsBatchStateProviderRef<'_, S> {
+    fn basic_account(&self, address: &Address) -> ProviderResult<Option<Account>> {
+        let hashed_key = keccak256(address.0);
+        Ok(self
+            .session
+            .account_hashed_cursor(self.block_number)
+            .map_err(Into::<ProviderError>::into)?
+            .seek(hashed_key)
+            .map_err(Into::<ProviderError>::into)?
+            .and_then(|(key, account)| (key == hashed_key).then_some(account)))
+    }
+}
+
+impl<S: BaseProofsBatchSession> StateProvider for BaseProofsBatchStateProviderRef<'_, S> {
+    fn storage(&self, address: Address, storage_key: B256) -> ProviderResult<Option<StorageValue>> {
+        let hashed_key = keccak256(storage_key);
+        self.storage_by_hashed_key(address, hashed_key)
+    }
+
+    fn storage_by_hashed_key(
+        &self,
+        address: Address,
+        hashed_key: B256,
+    ) -> ProviderResult<Option<StorageValue>> {
+        Ok(self
+            .session
+            .storage_hashed_cursor(keccak256(address.0), self.block_number)
+            .map_err(Into::<ProviderError>::into)?
+            .seek(hashed_key)
+            .map_err(Into::<ProviderError>::into)?
+            .and_then(|(key, storage)| (key == hashed_key).then_some(storage)))
+    }
+}
+
+impl<S: BaseProofsBatchSession> BytecodeReader for BaseProofsBatchStateProviderRef<'_, S> {
+    fn bytecode_by_hash(&self, code_hash: &B256) -> ProviderResult<Option<Bytecode>> {
+        self.latest.bytecode_by_hash(code_hash)
+    }
+}

--- a/crates/execution/trie/src/cursor_factory.rs
+++ b/crates/execution/trie/src/cursor_factory.rs
@@ -12,7 +12,8 @@ use reth_trie::{hashed_cursor::HashedCursorFactory, trie_cursor::TrieCursorFacto
 
 use crate::{
     BaseProofsHashedAccountCursor, BaseProofsHashedStorageCursor, BaseProofsStorage,
-    BaseProofsStore, BaseProofsTrieCursor, api::BaseProofsBatchSession,
+    BaseProofsStore, BaseProofsTrieCursor,
+    api::BaseProofsBatchSession,
     cursor::{
         BaseProofsHashedAccountCursor as RawHashedAccountCursor,
         BaseProofsHashedStorageCursor as RawHashedStorageCursor,

--- a/crates/execution/trie/src/cursor_factory.rs
+++ b/crates/execution/trie/src/cursor_factory.rs
@@ -12,7 +12,12 @@ use reth_trie::{hashed_cursor::HashedCursorFactory, trie_cursor::TrieCursorFacto
 
 use crate::{
     BaseProofsHashedAccountCursor, BaseProofsHashedStorageCursor, BaseProofsStorage,
-    BaseProofsStore, BaseProofsTrieCursor,
+    BaseProofsStore, BaseProofsTrieCursor, api::BaseProofsBatchSession,
+    cursor::{
+        BaseProofsHashedAccountCursor as RawHashedAccountCursor,
+        BaseProofsHashedStorageCursor as RawHashedStorageCursor,
+        BaseProofsTrieCursor as RawTrieCursor,
+    },
 };
 
 /// Request-scoped factory that opens trie cursors against a shared read-only transaction.
@@ -119,5 +124,108 @@ where
             hashed_address,
             self.block_number,
         )?))
+    }
+}
+
+/// Session-scoped trie cursor factory backed by a [`BaseProofsBatchSession`].
+///
+/// Cursors read from the session's active transaction and therefore observe writes
+/// from earlier `store_trie_updates` calls in the same session.
+#[derive(Debug)]
+pub struct BaseProofsBatchTrieCursorFactory<'a, S: BaseProofsBatchSession> {
+    session: &'a S,
+    block_number: u64,
+}
+
+impl<S: BaseProofsBatchSession> Clone for BaseProofsBatchTrieCursorFactory<'_, S> {
+    fn clone(&self) -> Self {
+        Self { session: self.session, block_number: self.block_number }
+    }
+}
+
+impl<'a, S: BaseProofsBatchSession> BaseProofsBatchTrieCursorFactory<'a, S> {
+    /// Initializes a session-scoped trie cursor factory.
+    pub const fn new(session: &'a S, block_number: u64) -> Self {
+        Self { session, block_number }
+    }
+}
+
+impl<S> TrieCursorFactory for BaseProofsBatchTrieCursorFactory<'_, S>
+where
+    S: BaseProofsBatchSession,
+{
+    type AccountTrieCursor<'a>
+        = RawTrieCursor<S::AccountTrieCursor<'a>>
+    where
+        Self: 'a;
+    type StorageTrieCursor<'a>
+        = RawTrieCursor<S::StorageTrieCursor<'a>>
+    where
+        Self: 'a;
+
+    fn account_trie_cursor(&self) -> Result<Self::AccountTrieCursor<'_>, DatabaseError> {
+        Ok(RawTrieCursor::new(
+            self.session
+                .account_trie_cursor(self.block_number)
+                .map_err(Into::<DatabaseError>::into)?,
+        ))
+    }
+
+    fn storage_trie_cursor(
+        &self,
+        hashed_address: B256,
+    ) -> Result<Self::StorageTrieCursor<'_>, DatabaseError> {
+        Ok(RawTrieCursor::new(
+            self.session
+                .storage_trie_cursor(hashed_address, self.block_number)
+                .map_err(Into::<DatabaseError>::into)?,
+        ))
+    }
+}
+
+/// Session-scoped hashed cursor factory backed by a [`BaseProofsBatchSession`].
+#[derive(Debug)]
+pub struct BaseProofsBatchHashedAccountCursorFactory<'a, S: BaseProofsBatchSession> {
+    session: &'a S,
+    block_number: u64,
+}
+
+impl<S: BaseProofsBatchSession> Clone for BaseProofsBatchHashedAccountCursorFactory<'_, S> {
+    fn clone(&self) -> Self {
+        Self { session: self.session, block_number: self.block_number }
+    }
+}
+
+impl<'a, S: BaseProofsBatchSession> BaseProofsBatchHashedAccountCursorFactory<'a, S> {
+    /// Initializes a session-scoped hashed cursor factory.
+    pub const fn new(session: &'a S, block_number: u64) -> Self {
+        Self { session, block_number }
+    }
+}
+
+impl<S> HashedCursorFactory for BaseProofsBatchHashedAccountCursorFactory<'_, S>
+where
+    S: BaseProofsBatchSession,
+{
+    type AccountCursor<'a>
+        = RawHashedAccountCursor<S::AccountHashedCursor<'a>>
+    where
+        Self: 'a;
+    type StorageCursor<'a>
+        = RawHashedStorageCursor<S::StorageCursor<'a>>
+    where
+        Self: 'a;
+
+    fn hashed_account_cursor(&self) -> Result<Self::AccountCursor<'_>, DatabaseError> {
+        Ok(RawHashedAccountCursor::new(self.session.account_hashed_cursor(self.block_number)?))
+    }
+
+    fn hashed_storage_cursor(
+        &self,
+        hashed_address: B256,
+    ) -> Result<Self::StorageCursor<'_>, DatabaseError> {
+        Ok(RawHashedStorageCursor::new(
+            self.session.storage_hashed_cursor(hashed_address, self.block_number)?,
+        ))
     }
 }

--- a/crates/execution/trie/src/db/batch.rs
+++ b/crates/execution/trie/src/db/batch.rs
@@ -46,10 +46,7 @@ impl<'tx> MdbxBatchSession<'tx> {
     }
 
     const fn tx_ref(&self) -> &<DatabaseEnv as Database>::TXMut {
-        match self.tx.as_ref() {
-            Some(tx) => tx,
-            None => panic!("batch session used after commit"),
-        }
+        self.tx.as_ref().expect("batch session used after commit (bug)")
     }
 
     fn dup_cursor<T: Table + DupSort>(&self) -> BaseProofsStorageResult<DupRw<'_, T>> {

--- a/crates/execution/trie/src/db/batch.rs
+++ b/crates/execution/trie/src/db/batch.rs
@@ -12,7 +12,7 @@ use reth_db::{
 };
 
 use crate::{
-    BaseProofsStorageResult, BlockStateDiff,
+    BaseProofsStorageError, BaseProofsStorageResult, BlockStateDiff,
     api::{BaseProofsBatchSession, WriteCounts},
     db::{
         AccountTrieHistory, HashedAccountHistory, HashedStorageHistory, MdbxAccountCursor,
@@ -45,12 +45,12 @@ impl<'tx> MdbxBatchSession<'tx> {
         Ok(())
     }
 
-    const fn tx_ref(&self) -> &<DatabaseEnv as Database>::TXMut {
-        self.tx.as_ref().expect("batch session used after commit (bug)")
+    fn tx_ref(&self) -> BaseProofsStorageResult<&<DatabaseEnv as Database>::TXMut> {
+        self.tx.as_ref().ok_or(BaseProofsStorageError::BatchSessionClosed)
     }
 
     fn dup_cursor<T: Table + DupSort>(&self) -> BaseProofsStorageResult<DupRw<'_, T>> {
-        Ok(self.tx_ref().cursor_dup_read::<T>()?)
+        Ok(self.tx_ref()?.cursor_dup_read::<T>()?)
     }
 }
 
@@ -73,11 +73,11 @@ impl BaseProofsBatchSession for MdbxBatchSession<'_> {
         Self: 'a;
 
     fn get_earliest_block_number(&self) -> BaseProofsStorageResult<Option<(u64, B256)>> {
-        self.storage.inner_get_earliest_block_number_hash(self.tx_ref())
+        self.storage.inner_get_earliest_block_number_hash(self.tx_ref()?)
     }
 
     fn get_latest_block_number(&self) -> BaseProofsStorageResult<Option<(u64, B256)>> {
-        self.storage.inner_get_latest_block_number_hash(self.tx_ref())
+        self.storage.inner_get_latest_block_number_hash(self.tx_ref()?)
     }
 
     fn storage_trie_cursor(
@@ -123,7 +123,6 @@ impl BaseProofsBatchSession for MdbxBatchSession<'_> {
         block_ref: BlockWithParent,
         block_state_diff: BlockStateDiff,
     ) -> BaseProofsStorageResult<WriteCounts> {
-        let tx = self.tx.as_ref().expect("batch session used after commit");
-        self.storage.store_trie_updates_append_only(tx, block_ref, block_state_diff)
+        self.storage.store_trie_updates_append_only(self.tx_ref()?, block_ref, block_state_diff)
     }
 }

--- a/crates/execution/trie/src/db/batch.rs
+++ b/crates/execution/trie/src/db/batch.rs
@@ -1,0 +1,136 @@
+//! Batch write session for [`MdbxProofsStorage`] enabling multiple block writes inside one MDBX
+//! RW transaction. Reads through the session observe uncommitted writes from earlier blocks in
+//! the same session, which is required for cold catch-up where block `N+1` must execute against
+//! block `N` written but not yet committed.
+
+use alloy_eips::eip1898::BlockWithParent;
+use alloy_primitives::B256;
+use reth_db::{
+    Database, DatabaseEnv,
+    table::{DupSort, Table},
+    transaction::DbTx,
+};
+
+use crate::{
+    BaseProofsStorageResult, BlockStateDiff,
+    api::{BaseProofsBatchSession, WriteCounts},
+    db::{
+        AccountTrieHistory, HashedAccountHistory, HashedStorageHistory, MdbxAccountCursor,
+        MdbxProofsStorage, MdbxStorageCursor, MdbxTrieCursor, StorageTrieHistory,
+    },
+};
+
+/// Alias for the dup-sorted cursor type produced by an MDBX RW transaction.
+pub type DupRw<'tx, T> = <<DatabaseEnv as Database>::TXMut as DbTx>::DupCursor<T>;
+
+/// Active write batch holding one MDBX RW transaction across multiple block writes.
+#[derive(Debug)]
+pub struct MdbxBatchSession<'tx> {
+    storage: &'tx MdbxProofsStorage,
+    tx: Option<<DatabaseEnv as Database>::TXMut>,
+}
+
+impl<'tx> MdbxBatchSession<'tx> {
+    pub(crate) const fn new(
+        storage: &'tx MdbxProofsStorage,
+        tx: <DatabaseEnv as Database>::TXMut,
+    ) -> Self {
+        Self { storage, tx: Some(tx) }
+    }
+
+    pub(crate) fn commit(mut self) -> BaseProofsStorageResult<()> {
+        if let Some(tx) = self.tx.take() {
+            tx.commit()?;
+        }
+        Ok(())
+    }
+
+    const fn tx_ref(&self) -> &<DatabaseEnv as Database>::TXMut {
+        match self.tx.as_ref() {
+            Some(tx) => tx,
+            None => panic!("batch session used after commit"),
+        }
+    }
+
+    fn dup_cursor<T: Table + DupSort>(&self) -> BaseProofsStorageResult<DupRw<'_, T>> {
+        Ok(self.tx_ref().cursor_dup_read::<T>()?)
+    }
+}
+
+impl BaseProofsBatchSession for MdbxBatchSession<'_> {
+    type StorageTrieCursor<'a>
+        = MdbxTrieCursor<StorageTrieHistory, DupRw<'a, StorageTrieHistory>>
+    where
+        Self: 'a;
+    type AccountTrieCursor<'a>
+        = MdbxTrieCursor<AccountTrieHistory, DupRw<'a, AccountTrieHistory>>
+    where
+        Self: 'a;
+    type StorageCursor<'a>
+        = MdbxStorageCursor<DupRw<'a, HashedStorageHistory>>
+    where
+        Self: 'a;
+    type AccountHashedCursor<'a>
+        = MdbxAccountCursor<DupRw<'a, HashedAccountHistory>>
+    where
+        Self: 'a;
+
+    fn get_earliest_block_number(&self) -> BaseProofsStorageResult<Option<(u64, B256)>> {
+        self.storage.inner_get_earliest_block_number_hash(self.tx_ref())
+    }
+
+    fn get_latest_block_number(&self) -> BaseProofsStorageResult<Option<(u64, B256)>> {
+        self.storage.inner_get_latest_block_number_hash(self.tx_ref())
+    }
+
+    fn storage_trie_cursor(
+        &self,
+        hashed_address: B256,
+        max_block_number: u64,
+    ) -> BaseProofsStorageResult<Self::StorageTrieCursor<'_>> {
+        Ok(MdbxTrieCursor::new(
+            self.dup_cursor::<StorageTrieHistory>()?,
+            max_block_number,
+            Some(hashed_address),
+        ))
+    }
+
+    fn account_trie_cursor(
+        &self,
+        max_block_number: u64,
+    ) -> BaseProofsStorageResult<Self::AccountTrieCursor<'_>> {
+        Ok(MdbxTrieCursor::new(
+            self.dup_cursor::<AccountTrieHistory>()?,
+            max_block_number,
+            None,
+        ))
+    }
+
+    fn storage_hashed_cursor(
+        &self,
+        hashed_address: B256,
+        max_block_number: u64,
+    ) -> BaseProofsStorageResult<Self::StorageCursor<'_>> {
+        Ok(MdbxStorageCursor::new(
+            self.dup_cursor::<HashedStorageHistory>()?,
+            max_block_number,
+            hashed_address,
+        ))
+    }
+
+    fn account_hashed_cursor(
+        &self,
+        max_block_number: u64,
+    ) -> BaseProofsStorageResult<Self::AccountHashedCursor<'_>> {
+        Ok(MdbxAccountCursor::new(self.dup_cursor::<HashedAccountHistory>()?, max_block_number))
+    }
+
+    fn store_trie_updates(
+        &mut self,
+        block_ref: BlockWithParent,
+        block_state_diff: BlockStateDiff,
+    ) -> BaseProofsStorageResult<WriteCounts> {
+        let tx = self.tx.as_ref().expect("batch session used after commit");
+        self.storage.store_trie_updates_append_only(tx, block_ref, block_state_diff)
+    }
+}

--- a/crates/execution/trie/src/db/batch.rs
+++ b/crates/execution/trie/src/db/batch.rs
@@ -99,11 +99,7 @@ impl BaseProofsBatchSession for MdbxBatchSession<'_> {
         &self,
         max_block_number: u64,
     ) -> BaseProofsStorageResult<Self::AccountTrieCursor<'_>> {
-        Ok(MdbxTrieCursor::new(
-            self.dup_cursor::<AccountTrieHistory>()?,
-            max_block_number,
-            None,
-        ))
+        Ok(MdbxTrieCursor::new(self.dup_cursor::<AccountTrieHistory>()?, max_block_number, None))
     }
 
     fn storage_hashed_cursor(

--- a/crates/execution/trie/src/db/cursor.rs
+++ b/crates/execution/trie/src/db/cursor.rs
@@ -357,7 +357,10 @@ where
     }
 }
 
-impl HashedStorageCursor for MdbxStorageCursor<Dup<'_, HashedStorageHistory>> {
+impl<Cursor> HashedStorageCursor for MdbxStorageCursor<Cursor>
+where
+    Cursor: DbCursorRO<HashedStorageHistory> + DbDupCursorRO<HashedStorageHistory> + Send + Sync,
+{
     fn is_storage_empty(&mut self) -> Result<bool, DatabaseError> {
         Ok(self.seek(B256::ZERO)?.is_none())
     }

--- a/crates/execution/trie/src/db/mod.rs
+++ b/crates/execution/trie/src/db/mod.rs
@@ -15,3 +15,6 @@ mod cursor;
 pub use cursor::{
     BlockNumberVersionedCursor, Dup, MdbxAccountCursor, MdbxStorageCursor, MdbxTrieCursor,
 };
+
+mod batch;
+pub use batch::{DupRw, MdbxBatchSession};

--- a/crates/execution/trie/src/db/store.rs
+++ b/crates/execution/trie/src/db/store.rs
@@ -280,45 +280,47 @@ impl MdbxProofsStorage {
                 return Ok(None);
             }
 
-            // 1. Accumulate latest block per key using HashMap for O(1) deduplication
-            // This is memory-efficient for high-churn scenarios (many updates to same keys).
-            let mut acc_candidates: HashMap<StoredNibbles, u64> = HashMap::default();
-            let mut storage_candidates: HashMap<StorageTrieKey, u64> = HashMap::default();
-            let mut hashed_acc_candidates: HashMap<B256, u64> = HashMap::default();
-            let mut hashed_storage_candidates: HashMap<HashedStorageKey, u64> = HashMap::default();
+            // Walk the change set in REVERSE so the first time we see a key, its block_number
+            // is by definition the latest version in [earliest+1, target_block] — the only
+            // one that must survive. This lets us use `or_insert` instead of an
+            // `and_modify(max).or_insert` per key, halving the per-insert work.
+            //
+            // HashMaps are pre-sized to bound rehash overhead. The chosen capacity is a rough
+            // average of unique keys per block on Base mainnet; the maps grow if exceeded.
+            const PER_BLOCK_CAPACITY_HINT: usize = 4096;
+            let blocks_in_range =
+                target_block.saturating_sub(earliest).try_into().unwrap_or(usize::MAX);
+            let cap = blocks_in_range.saturating_mul(PER_BLOCK_CAPACITY_HINT).min(1 << 20);
 
-            let range = (earliest + 1)..=target_block;
+            let mut acc_candidates: HashMap<StoredNibbles, u64> =
+                HashMap::with_capacity_and_hasher(cap, Default::default());
+            let mut storage_candidates: HashMap<StorageTrieKey, u64> =
+                HashMap::with_capacity_and_hasher(cap, Default::default());
+            let mut hashed_acc_candidates: HashMap<B256, u64> =
+                HashMap::with_capacity_and_hasher(cap, Default::default());
+            let mut hashed_storage_candidates: HashMap<HashedStorageKey, u64> =
+                HashMap::with_capacity_and_hasher(cap, Default::default());
+
             let mut cs_cursor = tx.cursor_read::<BlockChangeSet>()?;
-            let mut walker = cs_cursor.walk_range(range)?;
-
+            let mut walker = cs_cursor.walk_back(Some(target_block))?;
             while let Some(Ok((block_number, cs))) = walker.next() {
+                if block_number <= earliest {
+                    break;
+                }
                 for k in cs.account_trie_keys {
-                    acc_candidates
-                        .entry(k)
-                        .and_modify(|curr| *curr = (*curr).max(block_number))
-                        .or_insert(block_number);
+                    acc_candidates.entry(k).or_insert(block_number);
                 }
                 for k in cs.storage_trie_keys {
-                    storage_candidates
-                        .entry(k)
-                        .and_modify(|curr| *curr = (*curr).max(block_number))
-                        .or_insert(block_number);
+                    storage_candidates.entry(k).or_insert(block_number);
                 }
                 for k in cs.hashed_account_keys {
-                    hashed_acc_candidates
-                        .entry(k)
-                        .and_modify(|curr| *curr = (*curr).max(block_number))
-                        .or_insert(block_number);
+                    hashed_acc_candidates.entry(k).or_insert(block_number);
                 }
                 for k in cs.hashed_storage_keys {
-                    hashed_storage_candidates
-                        .entry(k)
-                        .and_modify(|curr| *curr = (*curr).max(block_number))
-                        .or_insert(block_number);
+                    hashed_storage_candidates.entry(k).or_insert(block_number);
                 }
             }
 
-            // 2. Convert map to sorted survivors list for efficient sequential db write
             Ok(Some(PrunePlan {
                 earliest_block: earliest,
                 acc_survivors: Self::flatten_and_sort(acc_candidates),
@@ -356,39 +358,31 @@ impl MdbxProofsStorage {
         let mut deleted_count = 0;
         let mut cur = tx.cursor_dup_write::<T>()?;
         for (key, survivor_block) in cutoff_items {
-            // Seek to the start of history for this key (Block 0)
-            if let Some(mut entry) = cur.seek_by_key_subkey(key.clone(), 0)? {
-                loop {
-                    if entry.block_number >= survivor_block {
-                        // Reached the survivor version (or newer). Stop deleting for this key.
-
-                        // If the survivor is a tombstone (None), delete it too.
-                        // Since we just deleted all older history, a tombstone at the start of
-                        // history is redundant (it implies "does not
-                        // exist").
-                        if entry.block_number == survivor_block && entry.value.0.is_none() {
-                            cur.delete_current()?;
-                            deleted_count += 1;
-                        }
-
-                        break;
+            let Some(mut entry) = cur.seek_by_key_subkey(key, 0)? else { continue };
+            loop {
+                if entry.block_number >= survivor_block {
+                    // Reached the survivor version (or newer). Stop deleting for this key.
+                    // If the survivor is a tombstone (None), delete it too — with all older
+                    // history already gone, a tombstone at the new earliest is redundant
+                    // (it implies "does not exist").
+                    if entry.block_number == survivor_block && entry.value.0.is_none() {
+                        cur.delete_current()?;
+                        deleted_count += 1;
                     }
+                    break;
+                }
 
-                    // Entry is strictly older than survivor. Delete it.
-                    cur.delete_current()?;
-                    deleted_count += 1;
+                // Entry is strictly older than survivor. Delete it.
+                cur.delete_current()?;
+                deleted_count += 1;
 
-                    // MDBX delete_current() automatically advances the cursor to the next item.
-                    // We check if the next item is still the same key.
-                    match cur.current() {
-                        Ok(Some((k, v))) => {
-                            if k != key {
-                                break; // Moved past the key
-                            }
-                            entry = v;
-                        }
-                        _ => break, // End of table or error
-                    }
+                // libmdbx semantics: after `delete_current()` the cursor sits directly
+                // before the just-deleted slot, so `next_dup_val` (MDBX_NEXT_DUP) yields the
+                // following dup of the same key, or `None` once this key's dup-group is
+                // exhausted. That bound removes the need for an explicit key comparison.
+                match cur.next_dup_val()? {
+                    Some(next_entry) => entry = next_entry,
+                    None => break,
                 }
             }
         }

--- a/crates/execution/trie/src/db/store.rs
+++ b/crates/execution/trie/src/db/store.rs
@@ -53,6 +53,13 @@ struct ProofWindowValue {
     latest: NumHash,
 }
 
+/// Switch from per-key wipe-and-rewrite to a sequential table walk above this many cutoff
+/// keys per table. The sequential path replaces N B-tree descents with one forward walk that
+/// benefits from OS read-ahead — cheaper on cold pages once N approaches the table's key
+/// count. Below the threshold, per-key seek is faster because it only touches the relevant
+/// keys instead of the whole table. Set conservatively for catch-up runs.
+const SEQUENTIAL_WALK_THRESHOLD: usize = 100_000;
+
 /// Preprocessed prune plan for a target block number
 #[derive(Debug, Clone)]
 struct PrunePlan {
@@ -61,6 +68,13 @@ struct PrunePlan {
     storage_survivors: Vec<(StorageTrieKey, u64)>,
     hashed_acc_survivors: Vec<(B256, u64)>,
     hashed_storage_survivors: Vec<(HashedStorageKey, u64)>,
+    /// Total per-table change-set key occurrences in the prune range. Equals the count of
+    /// history rows about to be touched per table, used to derive exact delete metrics
+    /// without an extra cursor pass.
+    acc_occurrences: u64,
+    storage_occurrences: u64,
+    hashed_acc_occurrences: u64,
+    hashed_storage_occurrences: u64,
 }
 
 /// Preprocessed delete work for a prune range
@@ -301,12 +315,18 @@ impl MdbxProofsStorage {
             let mut hashed_storage_candidates: HashMap<HashedStorageKey, u64> =
                 HashMap::with_capacity_and_hasher(cap, Default::default());
 
+            let (mut acc_occ, mut st_occ, mut ha_occ, mut hs_occ) = (0u64, 0u64, 0u64, 0u64);
+
             let mut cs_cursor = tx.cursor_read::<BlockChangeSet>()?;
             let mut walker = cs_cursor.walk_back(Some(target_block))?;
             while let Some(Ok((block_number, cs))) = walker.next() {
                 if block_number <= earliest {
                     break;
                 }
+                acc_occ += cs.account_trie_keys.len() as u64;
+                st_occ += cs.storage_trie_keys.len() as u64;
+                ha_occ += cs.hashed_account_keys.len() as u64;
+                hs_occ += cs.hashed_storage_keys.len() as u64;
                 for k in cs.account_trie_keys {
                     acc_candidates.entry(k).or_insert(block_number);
                 }
@@ -327,6 +347,10 @@ impl MdbxProofsStorage {
                 storage_survivors: Self::flatten_and_sort(storage_candidates),
                 hashed_acc_survivors: Self::flatten_and_sort(hashed_acc_candidates),
                 hashed_storage_survivors: Self::flatten_and_sort(hashed_storage_candidates),
+                acc_occurrences: acc_occ,
+                storage_occurrences: st_occ,
+                hashed_acc_occurrences: ha_occ,
+                hashed_storage_occurrences: hs_occ,
             }))
         })?
     }
@@ -339,10 +363,42 @@ impl MdbxProofsStorage {
         v
     }
 
-    /// Delete history versions for `items` that are strictly older than the provided block number.
-    /// `items` is a list of (Key, `SurvivorBlock`). Everything strictly older than `SurvivorBlock`
-    /// is deleted. Returns the number of entries deleted.
+    /// Reduce each key's dup-group to a single survivor row (or zero rows when the survivor
+    /// is a tombstone). `cutoff_items` is the sorted list of `(key, survivor_block)` pairs
+    /// from the prune plan; `occurrences` is the total number of history rows across those
+    /// keys in the prune window, used to compute the exact deletion count.
+    ///
+    /// Strategy: for each key, seek directly to its survivor dup, drop the entire dup-group
+    /// in one MDBX call (`MDBX_NODUPDATA`), then re-insert just the survivor. This collapses
+    /// the original `1 + 2N` syscalls per N-deep dup-group down to a constant 2 or 3.
+    /// Above [`SEQUENTIAL_WALK_THRESHOLD`] keys we instead walk the table forward once and
+    /// process keys in cursor order, which beats per-key seeks on cold pages because of OS
+    /// read-ahead.
     fn prune_history_preceding<T, V>(
+        &self,
+        tx: &(impl DbTxMut + DbTx),
+        cutoff_items: Vec<(T::Key, u64)>,
+        occurrences: u64,
+    ) -> BaseProofsStorageResult<u64>
+    where
+        T: Table<Value = VersionedValue<V>> + DupSort<SubKey = u64>,
+        T::Key: Clone + Ord + std::hash::Hash,
+    {
+        if cutoff_items.is_empty() {
+            return Ok(0);
+        }
+
+        let non_tombstone_survivors = if cutoff_items.len() >= SEQUENTIAL_WALK_THRESHOLD {
+            self.prune_history_preceding_sequential::<T, V>(tx, cutoff_items)?
+        } else {
+            self.prune_history_preceding_per_key::<T, V>(tx, cutoff_items)?
+        };
+
+        Ok(occurrences.saturating_sub(non_tombstone_survivors))
+    }
+
+    /// Per-key wipe-and-rewrite. Returns the number of surviving (non-tombstone) rows.
+    fn prune_history_preceding_per_key<T, V>(
         &self,
         tx: &(impl DbTxMut + DbTx),
         cutoff_items: Vec<(T::Key, u64)>,
@@ -351,42 +407,60 @@ impl MdbxProofsStorage {
         T: Table<Value = VersionedValue<V>> + DupSort<SubKey = u64>,
         T::Key: Clone + Ord,
     {
-        if cutoff_items.is_empty() {
-            return Ok(0);
-        }
-
-        let mut deleted_count = 0;
+        let mut non_tombstone_survivors = 0u64;
         let mut cur = tx.cursor_dup_write::<T>()?;
         for (key, survivor_block) in cutoff_items {
-            let Some(mut entry) = cur.seek_by_key_subkey(key, 0)? else { continue };
-            loop {
-                if entry.block_number >= survivor_block {
-                    // Reached the survivor version (or newer). Stop deleting for this key.
-                    // If the survivor is a tombstone (None), delete it too — with all older
-                    // history already gone, a tombstone at the new earliest is redundant
-                    // (it implies "does not exist").
-                    if entry.block_number == survivor_block && entry.value.0.is_none() {
-                        cur.delete_current()?;
-                        deleted_count += 1;
-                    }
-                    break;
-                }
+            let Some(survivor) = cur.seek_by_key_subkey(key.clone(), survivor_block)? else {
+                continue;
+            };
+            // `delete_current_duplicates` (`MDBX_NODUPDATA`) removes every dup of the key
+            // the cursor is currently positioned on, in a single syscall.
+            cur.delete_current_duplicates()?;
+            if survivor.value.0.is_some() {
+                // `upsert` on a DupSort table appends a new dup; with the group just
+                // emptied, this becomes the only row for `key`.
+                cur.upsert(key, &survivor)?;
+                non_tombstone_survivors += 1;
+            }
+            // Tombstone survivor: leaving the dup-group empty is correct — zero rows is
+            // semantically equivalent to "does not exist at this block".
+        }
+        Ok(non_tombstone_survivors)
+    }
 
-                // Entry is strictly older than survivor. Delete it.
-                cur.delete_current()?;
-                deleted_count += 1;
+    /// Sequential variant: walk the table forward and act on keys that appear in the cutoff
+    /// set. Wins over per-key seek when most of the table is being pruned (catch-up runs),
+    /// since OS page read-ahead amortizes I/O over many entries.
+    fn prune_history_preceding_sequential<T, V>(
+        &self,
+        tx: &(impl DbTxMut + DbTx),
+        cutoff_items: Vec<(T::Key, u64)>,
+    ) -> BaseProofsStorageResult<u64>
+    where
+        T: Table<Value = VersionedValue<V>> + DupSort<SubKey = u64>,
+        T::Key: Clone + Ord + std::hash::Hash,
+    {
+        let cutoff: HashMap<T::Key, u64> = cutoff_items.into_iter().collect::<HashMap<_, _>>();
 
-                // libmdbx semantics: after `delete_current()` the cursor sits directly
-                // before the just-deleted slot, so `next_dup_val` (MDBX_NEXT_DUP) yields the
-                // following dup of the same key, or `None` once this key's dup-group is
-                // exhausted. That bound removes the need for an explicit key comparison.
-                match cur.next_dup_val()? {
-                    Some(next_entry) => entry = next_entry,
-                    None => break,
+        let mut non_tombstone_survivors = 0u64;
+        let mut cur = tx.cursor_dup_write::<T>()?;
+        let mut entry = cur.first()?;
+        while let Some((key, _first_dup)) = entry {
+            if let Some(&survivor_block) = cutoff.get(&key) {
+                let survivor = cur
+                    .seek_by_key_subkey(key.clone(), survivor_block)?
+                    .expect("survivor present: cutoff is derived from BlockChangeSet");
+                cur.delete_current_duplicates()?;
+                if survivor.value.0.is_some() {
+                    cur.upsert(key, &survivor)?;
+                    non_tombstone_survivors += 1;
                 }
             }
+            // `next_no_dup` advances to the first dup of the next key, skipping the
+            // remaining dups of the current key (or the empty slot left by a wipe).
+            entry = cur.next_no_dup()?;
         }
-        Ok(deleted_count)
+        Ok(non_tombstone_survivors)
     }
 
     /// Tombstone every key returned by `next`, then overlay `new_entries` so collisions
@@ -922,20 +996,28 @@ impl BaseProofsStore for MdbxProofsStorage {
         // --- PHASE 2: WRITE (Execute Deletions) ---
         self.env.update(|tx| {
             // 1. Execute Sparse Deletions and track actual deleted rows
-            let acc_deleted =
-                self.prune_history_preceding::<AccountTrieHistory, _>(tx, plan.acc_survivors)?;
+            let acc_deleted = self.prune_history_preceding::<AccountTrieHistory, _>(
+                tx,
+                plan.acc_survivors,
+                plan.acc_occurrences,
+            )?;
 
-            let st_deleted =
-                self.prune_history_preceding::<StorageTrieHistory, _>(tx, plan.storage_survivors)?;
+            let st_deleted = self.prune_history_preceding::<StorageTrieHistory, _>(
+                tx,
+                plan.storage_survivors,
+                plan.storage_occurrences,
+            )?;
 
             let ha_deleted = self.prune_history_preceding::<HashedAccountHistory, _>(
                 tx,
                 plan.hashed_acc_survivors,
+                plan.hashed_acc_occurrences,
             )?;
 
             let hs_deleted = self.prune_history_preceding::<HashedStorageHistory, _>(
                 tx,
                 plan.hashed_storage_survivors,
+                plan.hashed_storage_occurrences,
             )?;
 
             let counts = WriteCounts {
@@ -1280,7 +1362,7 @@ impl reth_db::database_metrics::DatabaseMetrics for MdbxProofsStorage {
 #[cfg(test)]
 mod tests {
     use alloy_eips::NumHash;
-    use alloy_primitives::B256;
+    use alloy_primitives::{B256, keccak256};
     use reth_db::{
         DatabaseError,
         cursor::DbDupCursorRO,
@@ -2896,6 +2978,67 @@ mod tests {
 
         assert_eq!(counts.hashed_accounts_written_total, 1);
         assert_eq!(counts.account_trie_updates_written_total, 0);
+    }
+
+    #[test]
+    fn prune_history_preceding_sequential_handles_tombstones_and_survivors() {
+        let dir = TempDir::new().unwrap();
+        let store = MdbxProofsStorage::new(dir.path()).expect("env");
+        store.set_earliest_block_number(0, B256::ZERO).unwrap();
+
+        let live = B256::from([0xA1; 32]);
+        let killed = B256::from([0xA2; 32]);
+        let single = B256::from([0xA3; 32]);
+        let acc = |n| Account { nonce: n, ..Default::default() };
+
+        let mut parent = B256::ZERO;
+        for n in 1u64..=3 {
+            let bwp = BlockWithParent::new(parent, NumHash::new(n, keccak256(n.to_be_bytes())));
+            let mut diff = HashedPostState::default();
+            diff.accounts.insert(live, Some(acc(n)));
+            if n == 2 {
+                diff.accounts.insert(killed, Some(acc(99)));
+            }
+            if n == 3 {
+                diff.accounts.insert(killed, None);
+                diff.accounts.insert(single, Some(acc(7)));
+            }
+            store
+                .store_trie_updates(
+                    bwp,
+                    BlockStateDiff { sorted_post_state: diff.into_sorted(), ..Default::default() },
+                )
+                .unwrap();
+            parent = bwp.block.hash;
+        }
+
+        let cutoff: Vec<(B256, u64)> = vec![(live, 3), (killed, 3), (single, 3)];
+
+        let tx = store.env.tx_mut().unwrap();
+        let kept = store
+            .prune_history_preceding_sequential::<HashedAccountHistory, _>(&tx, cutoff)
+            .unwrap();
+        tx.commit().unwrap();
+
+        // `live` and `single` survive with real values; `killed` survives as a tombstone
+        // and the entire dup-group is dropped.
+        assert_eq!(kept, 2);
+
+        let tx = store.env.tx().unwrap();
+        let mut cur = tx.cursor_dup_read::<HashedAccountHistory>().unwrap();
+
+        let live_row = cur.seek_by_key_subkey(live, 0).unwrap().expect("live survives");
+        assert_eq!(live_row.block_number, 3);
+        assert_eq!(live_row.value.0, Some(acc(3)));
+
+        let single_row = cur.seek_by_key_subkey(single, 0).unwrap().expect("single survives");
+        assert_eq!(single_row.block_number, 3);
+        assert_eq!(single_row.value.0, Some(acc(7)));
+
+        assert!(
+            cur.seek_by_key_subkey(killed, 0).unwrap().is_none(),
+            "tombstone survivor must drop the whole dup-group"
+        );
     }
 
     #[test]

--- a/crates/execution/trie/src/db/store.rs
+++ b/crates/execution/trie/src/db/store.rs
@@ -27,9 +27,12 @@ use crate::{
     BaseProofsStorageError,
     BaseProofsStorageError::NoBlocksFound,
     BaseProofsStorageResult, BaseProofsStore, BlockStateDiff,
-    api::{BaseProofsInitialStateStore, InitialStateAnchor, InitialStateStatus, WriteCounts},
+    api::{
+        BaseProofsBatchStore, BaseProofsInitialStateStore, InitialStateAnchor, InitialStateStatus,
+        WriteCounts,
+    },
     db::{
-        MdbxAccountCursor, MdbxStorageCursor, MdbxTrieCursor,
+        MdbxAccountCursor, MdbxBatchSession, MdbxStorageCursor, MdbxTrieCursor,
         cursor::Dup,
         models::{
             AccountTrieHistory, BlockChangeSet, ChangeSet, HashedAccountHistory,
@@ -77,7 +80,7 @@ impl MdbxProofsStorage {
         Ok(Self { env })
     }
 
-    fn inner_get_latest_block_number_hash(
+    pub(crate) fn inner_get_latest_block_number_hash(
         &self,
         tx: &impl DbTx,
     ) -> BaseProofsStorageResult<Option<(u64, B256)>> {
@@ -86,6 +89,13 @@ impl MdbxProofsStorage {
             return Ok(block);
         }
 
+        self.inner_get_block_number_hash(tx, ProofWindowKey::EarliestBlock)
+    }
+
+    pub(crate) fn inner_get_earliest_block_number_hash(
+        &self,
+        tx: &impl DbTx,
+    ) -> BaseProofsStorageResult<Option<(u64, B256)>> {
         self.inner_get_block_number_hash(tx, ProofWindowKey::EarliestBlock)
     }
 
@@ -582,7 +592,7 @@ impl MdbxProofsStorage {
 
     /// Append-only writer for a block: validates parent, persists diff (soft-delete=true),
     /// records a `BlockChangeSet`, and advances `ProofWindow::LatestBlock`.
-    fn store_trie_updates_append_only(
+    pub(crate) fn store_trie_updates_append_only(
         &self,
         tx: &<DatabaseEnv as Database>::TXMut,
         block_ref: BlockWithParent,
@@ -1025,6 +1035,28 @@ impl BaseProofsStore for MdbxProofsStorage {
         hash: B256,
     ) -> BaseProofsStorageResult<()> {
         self.set_earliest_block_number_hash(block_number, hash)
+    }
+}
+
+impl BaseProofsBatchStore for MdbxProofsStorage {
+    type BatchSession<'a>
+        = MdbxBatchSession<'a>
+    where
+        Self: 'a;
+
+    fn with_batch_session<R, F>(&self, f: F) -> BaseProofsStorageResult<R>
+    where
+        F: FnOnce(&mut Self::BatchSession<'_>) -> BaseProofsStorageResult<R>,
+    {
+        let tx = self.env.tx_mut()?;
+        let mut session = MdbxBatchSession::new(self, tx);
+        match f(&mut session) {
+            Ok(result) => {
+                session.commit()?;
+                Ok(result)
+            }
+            Err(err) => Err(err),
+        }
     }
 }
 

--- a/crates/execution/trie/src/db/store.rs
+++ b/crates/execution/trie/src/db/store.rs
@@ -528,7 +528,15 @@ impl MdbxProofsStorage {
         let mut storage_trie_keys = Vec::<StorageTrieKey>::with_capacity(storage_trie_len);
         for (hashed_address, nodes) in sorted_trie_updates.storage_tries_ref() {
             if nodes.is_deleted && append_mode {
-                let mut ro = self.storage_trie_cursor(*hashed_address, block_number - 1)?;
+                // Lookback must use the active tx so it sees uncommitted writes from earlier
+                // blocks in the same batch session. Opening a fresh RO tx here would read the
+                // pre-batch committed snapshot and emit wrong tombstones for wipe blocks whose
+                // parent is staged in the same batch.
+                let mut ro = MdbxTrieCursor::<StorageTrieHistory, _>::new(
+                    tx.cursor_dup_read::<StorageTrieHistory>()?,
+                    block_number - 1,
+                    Some(*hashed_address),
+                );
                 let keys = self.wipe_and_overlay(
                     tx,
                     block_number,
@@ -556,7 +564,12 @@ impl MdbxProofsStorage {
         let mut hashed_storage_keys = Vec::<HashedStorageKey>::with_capacity(hashed_storage_len);
         for (hashed_address, storage) in sorted_post_state.storages {
             if append_mode && storage.is_wiped() {
-                let mut ro = self.storage_hashed_cursor(hashed_address, block_number - 1)?;
+                // See lookback note above: must use the active tx, not a fresh RO tx.
+                let mut ro = MdbxStorageCursor::new(
+                    tx.cursor_dup_read::<HashedStorageHistory>()?,
+                    block_number - 1,
+                    hashed_address,
+                );
                 let keys = self.wipe_and_overlay(
                     tx,
                     block_number,

--- a/crates/execution/trie/src/db/store.rs
+++ b/crates/execution/trie/src/db/store.rs
@@ -687,7 +687,7 @@ impl BaseProofsStore for MdbxProofsStorage {
     }
 
     fn get_earliest_block_number(&self) -> BaseProofsStorageResult<Option<(u64, B256)>> {
-        self.env.view(|tx| self.inner_get_block_number_hash(tx, ProofWindowKey::EarliestBlock))?
+        self.env.view(|tx| self.inner_get_earliest_block_number_hash(tx))?
     }
 
     fn get_latest_block_number(&self) -> BaseProofsStorageResult<Option<(u64, B256)>> {

--- a/crates/execution/trie/src/error.rs
+++ b/crates/execution/trie/src/error.rs
@@ -106,6 +106,9 @@ pub enum BaseProofsStorageError {
          Please clear proofs data and retry initialization."
     )]
     InitializeStorageInconsistentState,
+    /// Batch session used after its underlying transaction has been committed or aborted.
+    #[error("Batch session used after its underlying transaction was closed")]
+    BatchSessionClosed,
 }
 
 impl From<BlockExecutionError> for BaseProofsStorageError {

--- a/crates/execution/trie/src/in_memory.rs
+++ b/crates/execution/trie/src/in_memory.rs
@@ -17,7 +17,10 @@ use reth_trie_common::{
 
 use crate::{
     BaseProofsStorageError, BaseProofsStorageResult, BaseProofsStore, BlockStateDiff,
-    api::{BaseProofsInitialStateStore, InitialStateAnchor, InitialStateStatus, WriteCounts},
+    api::{
+        BaseProofsBatchSession, BaseProofsBatchStore, BaseProofsInitialStateStore,
+        InitialStateAnchor, InitialStateStatus, WriteCounts,
+    },
     db::{HashedStorageKey, StorageTrieKey},
 };
 
@@ -786,6 +789,94 @@ impl BaseProofsStore for InMemoryProofsStorage {
         let mut inner = self.inner.write();
         inner.earliest_block = Some((block_number, hash));
         Ok(())
+    }
+}
+
+/// Degenerate batch session for [`InMemoryProofsStorage`]: writes go directly to shared
+/// storage and are visible to subsequent reads. There is no commit/abort distinction —
+/// the in-memory store does not provide cross-block atomicity.
+#[derive(Debug)]
+pub struct InMemoryBatchSession<'a> {
+    storage: &'a InMemoryProofsStorage,
+}
+
+impl BaseProofsBatchSession for InMemoryBatchSession<'_> {
+    type StorageTrieCursor<'a>
+        = InMemoryTrieCursor
+    where
+        Self: 'a;
+    type AccountTrieCursor<'a>
+        = InMemoryTrieCursor
+    where
+        Self: 'a;
+    type StorageCursor<'a>
+        = InMemoryStorageCursor
+    where
+        Self: 'a;
+    type AccountHashedCursor<'a>
+        = InMemoryAccountCursor
+    where
+        Self: 'a;
+
+    fn get_earliest_block_number(&self) -> BaseProofsStorageResult<Option<(u64, B256)>> {
+        self.storage.get_earliest_block_number()
+    }
+
+    fn get_latest_block_number(&self) -> BaseProofsStorageResult<Option<(u64, B256)>> {
+        self.storage.get_latest_block_number()
+    }
+
+    fn storage_trie_cursor(
+        &self,
+        hashed_address: B256,
+        max_block_number: u64,
+    ) -> BaseProofsStorageResult<Self::StorageTrieCursor<'_>> {
+        self.storage.storage_trie_cursor(hashed_address, max_block_number)
+    }
+
+    fn account_trie_cursor(
+        &self,
+        max_block_number: u64,
+    ) -> BaseProofsStorageResult<Self::AccountTrieCursor<'_>> {
+        self.storage.account_trie_cursor(max_block_number)
+    }
+
+    fn storage_hashed_cursor(
+        &self,
+        hashed_address: B256,
+        max_block_number: u64,
+    ) -> BaseProofsStorageResult<Self::StorageCursor<'_>> {
+        self.storage.storage_hashed_cursor(hashed_address, max_block_number)
+    }
+
+    fn account_hashed_cursor(
+        &self,
+        max_block_number: u64,
+    ) -> BaseProofsStorageResult<Self::AccountHashedCursor<'_>> {
+        self.storage.account_hashed_cursor(max_block_number)
+    }
+
+    fn store_trie_updates(
+        &mut self,
+        block_ref: BlockWithParent,
+        block_state_diff: BlockStateDiff,
+    ) -> BaseProofsStorageResult<WriteCounts> {
+        self.storage.store_trie_updates(block_ref, block_state_diff)
+    }
+}
+
+impl BaseProofsBatchStore for InMemoryProofsStorage {
+    type BatchSession<'a>
+        = InMemoryBatchSession<'a>
+    where
+        Self: 'a;
+
+    fn with_batch_session<R, F>(&self, f: F) -> BaseProofsStorageResult<R>
+    where
+        F: FnOnce(&mut Self::BatchSession<'_>) -> BaseProofsStorageResult<R>,
+    {
+        let mut session = InMemoryBatchSession { storage: self };
+        f(&mut session)
     }
 }
 

--- a/crates/execution/trie/src/lib.rs
+++ b/crates/execution/trie/src/lib.rs
@@ -46,7 +46,7 @@ pub mod proof;
 
 pub mod provider;
 
-pub mod batch_provider;
+mod batch_provider;
 pub use batch_provider::BaseProofsBatchStateProviderRef;
 
 pub mod live;

--- a/crates/execution/trie/src/lib.rs
+++ b/crates/execution/trie/src/lib.rs
@@ -12,18 +12,24 @@
 use reth_ethereum_primitives as _;
 
 pub mod api;
-pub use api::{BaseProofsInitialStateStore, BaseProofsStore, BlockStateDiff};
+pub use api::{
+    BaseProofsBatchSession, BaseProofsBatchStore, BaseProofsInitialStateStore, BaseProofsStore,
+    BlockStateDiff,
+};
 
 pub mod initialize;
 pub use initialize::InitializationJob;
 
 pub mod in_memory;
 pub use in_memory::{
-    InMemoryAccountCursor, InMemoryProofsStorage, InMemoryStorageCursor, InMemoryTrieCursor,
+    InMemoryAccountCursor, InMemoryBatchSession, InMemoryProofsStorage, InMemoryStorageCursor,
+    InMemoryTrieCursor,
 };
 
 pub mod db;
-pub use db::{MdbxAccountCursor, MdbxProofsStorage, MdbxStorageCursor, MdbxTrieCursor};
+pub use db::{
+    MdbxAccountCursor, MdbxBatchSession, MdbxProofsStorage, MdbxStorageCursor, MdbxTrieCursor,
+};
 
 pub mod metrics;
 #[cfg(feature = "metrics")]
@@ -40,6 +46,9 @@ pub mod proof;
 
 pub mod provider;
 
+pub mod batch_provider;
+pub use batch_provider::BaseProofsBatchStateProviderRef;
+
 pub mod live;
 
 pub mod cursor;
@@ -49,7 +58,10 @@ pub use cursor::{
 };
 
 pub mod cursor_factory;
-pub use cursor_factory::{BaseProofsHashedAccountCursorFactory, BaseProofsTrieCursorFactory};
+pub use cursor_factory::{
+    BaseProofsBatchHashedAccountCursorFactory, BaseProofsBatchTrieCursorFactory,
+    BaseProofsHashedAccountCursorFactory, BaseProofsTrieCursorFactory,
+};
 
 pub mod error;
 pub use error::{BaseProofsStorageError, BaseProofsStorageResult};

--- a/crates/execution/trie/src/live.rs
+++ b/crates/execution/trie/src/live.rs
@@ -323,7 +323,6 @@ where
         let total = start.elapsed();
         BlockMetrics::record_operation_durations(&OperationDurations {
             total_duration_seconds: total,
-            write_duration_seconds: total,
             ..Default::default()
         });
         BlockMetrics::increment_write_counts(&total_writes);

--- a/crates/execution/trie/src/live.rs
+++ b/crates/execution/trie/src/live.rs
@@ -5,7 +5,7 @@ use std::{sync::Arc, time::Instant};
 use alloy_eips::{BlockNumHash, NumHash, eip1898::BlockWithParent};
 use derive_more::Constructor;
 use reth_evm::{ConfigureEvm, execute::Executor};
-use reth_primitives_traits::{AlloyBlockHeader, BlockTy, RecoveredBlock};
+use reth_primitives_traits::{AlloyBlockHeader, BlockTy, NodePrimitives, RecoveredBlock};
 use reth_provider::{
     DatabaseProviderFactory, HashedPostStateProvider, StateProviderFactory, StateReader,
     StateRootProvider,
@@ -16,7 +16,8 @@ use tracing::{info, warn};
 
 use crate::{
     BaseProofsStorage, BaseProofsStorageError, BaseProofsStore, BlockStateDiff,
-    api::{OperationDurations, WriteCounts},
+    api::{BaseProofsBatchSession, BaseProofsBatchStore, OperationDurations, WriteCounts},
+    batch_provider::BaseProofsBatchStateProviderRef,
     metrics::BlockMetrics,
     provider::BaseProofsStateProviderRef,
 };
@@ -238,5 +239,168 @@ where
     /// the specified block (inclusive).
     pub fn unwind_history(&self, to: BlockWithParent) -> Result<(), BaseProofsStorageError> {
         self.storage.unwind_history(to)
+    }
+}
+
+/// One block to process inside a batch session: either pre-computed cached trie data (fast
+/// path) or a fully recovered block that needs full execution against the session's
+/// transaction-local state (cold catch-up path).
+#[derive(Debug)]
+pub enum BatchBlock<P: NodePrimitives> {
+    /// Pre-computed cached trie data; only writes happen.
+    Cached {
+        /// Block reference being written.
+        block_with_parent: BlockWithParent,
+        /// Pre-computed trie updates from cached notification data.
+        sorted_trie_updates: Arc<TrieUpdatesSorted>,
+        /// Pre-computed hashed post-state from cached notification data.
+        sorted_post_state: Arc<HashedPostStateSorted>,
+    },
+    /// Full block requiring execution against session-local state.
+    Execute(Box<RecoveredBlock<BlockTy<P>>>),
+}
+
+impl<'tx, Evm, Provider, Store> LiveTrieCollector<'tx, Evm, Provider, Store>
+where
+    Evm: ConfigureEvm,
+    Provider: StateReader + DatabaseProviderFactory + StateProviderFactory,
+    Store: 'tx + BaseProofsBatchStore + Clone + 'static,
+{
+    /// Execute and write a batch of blocks inside a single underlying transaction.
+    /// Reads during execution of block N observe writes from blocks earlier in the batch,
+    /// enabling cold catch-up where parent state is staged but not yet committed. The
+    /// entire batch commits atomically on success and aborts on the first error.
+    pub fn execute_and_store_batch(
+        &self,
+        blocks: Vec<BatchBlock<Evm::Primitives>>,
+    ) -> Result<(), BaseProofsStorageError> {
+        if blocks.is_empty() {
+            return Ok(());
+        }
+
+        let start = Instant::now();
+        let mut total_writes = WriteCounts::default();
+        let mut block_count: u64 = 0;
+        let mut last_block_number: u64 = 0;
+
+        self.storage.with_batch_session(|session| {
+            let (Some((earliest, _)), Some((_, _))) =
+                (session.get_earliest_block_number()?, session.get_latest_block_number()?)
+            else {
+                return Err(BaseProofsStorageError::NoBlocksFound);
+            };
+
+            for entry in blocks {
+                match entry {
+                    BatchBlock::Cached {
+                        block_with_parent,
+                        sorted_trie_updates,
+                        sorted_post_state,
+                    } => {
+                        let counts = session.store_trie_updates(
+                            block_with_parent,
+                            BlockStateDiff {
+                                sorted_trie_updates: (*sorted_trie_updates).clone(),
+                                sorted_post_state: (*sorted_post_state).clone(),
+                            },
+                        )?;
+                        total_writes += counts;
+                        block_count += 1;
+                        last_block_number = block_with_parent.block.number;
+                    }
+                    BatchBlock::Execute(block) => {
+                        let counts =
+                            self.execute_one_in_session(session, &block, earliest)?;
+                        total_writes += counts;
+                        block_count += 1;
+                        last_block_number = block.number();
+                    }
+                }
+            }
+
+            Ok(())
+        })?;
+
+        let total = start.elapsed();
+        BlockMetrics::record_operation_durations(&OperationDurations {
+            total_duration_seconds: total,
+            write_duration_seconds: total,
+            ..Default::default()
+        });
+        BlockMetrics::increment_write_counts(&total_writes);
+        BlockMetrics::latest_number().set(last_block_number as f64);
+
+        info!(
+            block_count,
+            last_block_number,
+            ?total_writes,
+            duration = ?total,
+            "Batch executed and committed",
+        );
+
+        Ok(())
+    }
+
+    fn execute_one_in_session<S>(
+        &self,
+        session: &mut S,
+        block: &RecoveredBlock<BlockTy<Evm::Primitives>>,
+        earliest: u64,
+    ) -> Result<WriteCounts, BaseProofsStorageError>
+    where
+        S: BaseProofsBatchSession,
+    {
+        let latest_in_session = session
+            .get_latest_block_number()?
+            .ok_or(BaseProofsStorageError::NoBlocksFound)?
+            .0;
+
+        let parent_block_number = block.number() - 1;
+        if parent_block_number < earliest {
+            return Err(BaseProofsStorageError::UnknownParent);
+        }
+        if parent_block_number > latest_in_session {
+            return Err(BaseProofsStorageError::MissingParentBlock {
+                block_number: block.number(),
+                parent_block_number,
+                latest_block_number: latest_in_session,
+            });
+        }
+
+        let block_ref =
+            BlockWithParent::new(block.parent_hash(), NumHash::new(block.number(), block.hash()));
+
+        let state_provider = BaseProofsBatchStateProviderRef::new(
+            self.provider.state_by_block_hash(block.parent_hash())?,
+            session,
+            parent_block_number,
+        );
+
+        let db = StateProviderDatabase::new(&state_provider);
+        let block_executor = self.evm_config.batch_executor(db);
+
+        let execution_result = block_executor.execute(&(*block).clone())?;
+
+        let hashed_state = state_provider.hashed_post_state(&execution_result.state);
+        let (state_root, trie_updates) =
+            state_provider.state_root_with_updates(hashed_state.clone())?;
+
+        if state_root != block.state_root() {
+            return Err(BaseProofsStorageError::StateRootMismatch {
+                block_number: block.number(),
+                current_state_hash: state_root,
+                expected_state_hash: block.state_root(),
+            });
+        }
+
+        drop(state_provider);
+
+        session.store_trie_updates(
+            block_ref,
+            BlockStateDiff {
+                sorted_trie_updates: trie_updates.into_sorted(),
+                sorted_post_state: hashed_state.into_sorted(),
+            },
+        )
     }
 }

--- a/crates/execution/trie/src/live.rs
+++ b/crates/execution/trie/src/live.rs
@@ -309,8 +309,7 @@ where
                         last_block_number = block_with_parent.block.number;
                     }
                     BatchBlock::Execute(block) => {
-                        let counts =
-                            self.execute_one_in_session(session, &block, earliest)?;
+                        let counts = self.execute_one_in_session(session, &block, earliest)?;
                         total_writes += counts;
                         block_count += 1;
                         last_block_number = block.number();
@@ -350,10 +349,8 @@ where
     where
         S: BaseProofsBatchSession,
     {
-        let latest_in_session = session
-            .get_latest_block_number()?
-            .ok_or(BaseProofsStorageError::NoBlocksFound)?
-            .0;
+        let latest_in_session =
+            session.get_latest_block_number()?.ok_or(BaseProofsStorageError::NoBlocksFound)?.0;
 
         let parent_block_number = block.number() - 1;
         if parent_block_number < earliest {

--- a/crates/execution/trie/src/live.rs
+++ b/crates/execution/trie/src/live.rs
@@ -297,33 +297,16 @@ where
                         sorted_trie_updates,
                         sorted_post_state,
                     } => {
-                        let result = session.store_trie_updates(
+                        let counts = session.store_trie_updates(
                             block_with_parent,
                             BlockStateDiff {
                                 sorted_trie_updates: (*sorted_trie_updates).clone(),
                                 sorted_post_state: (*sorted_post_state).clone(),
                             },
-                        );
-                        match result {
-                            Ok(counts) => {
-                                total_writes += counts;
-                                block_count += 1;
-                                last_block_number = block_with_parent.block.number;
-                            }
-                            Err(BaseProofsStorageError::OutOfOrder {
-                                block_number,
-                                latest_block_hash,
-                                parent_block_hash,
-                            }) => {
-                                warn!(
-                                    block_number,
-                                    ?latest_block_hash,
-                                    ?parent_block_hash,
-                                    "Skipping out-of-order cached block in batch",
-                                );
-                            }
-                            Err(e) => return Err(e),
-                        }
+                        )?;
+                        total_writes += counts;
+                        block_count += 1;
+                        last_block_number = block_with_parent.block.number;
                     }
                     BatchBlock::Execute(block) => {
                         let counts = self.execute_one_in_session(session, &block, earliest)?;

--- a/crates/execution/trie/src/live.rs
+++ b/crates/execution/trie/src/live.rs
@@ -297,16 +297,33 @@ where
                         sorted_trie_updates,
                         sorted_post_state,
                     } => {
-                        let counts = session.store_trie_updates(
+                        let result = session.store_trie_updates(
                             block_with_parent,
                             BlockStateDiff {
                                 sorted_trie_updates: (*sorted_trie_updates).clone(),
                                 sorted_post_state: (*sorted_post_state).clone(),
                             },
-                        )?;
-                        total_writes += counts;
-                        block_count += 1;
-                        last_block_number = block_with_parent.block.number;
+                        );
+                        match result {
+                            Ok(counts) => {
+                                total_writes += counts;
+                                block_count += 1;
+                                last_block_number = block_with_parent.block.number;
+                            }
+                            Err(BaseProofsStorageError::OutOfOrder {
+                                block_number,
+                                latest_block_hash,
+                                parent_block_hash,
+                            }) => {
+                                warn!(
+                                    block_number,
+                                    ?latest_block_hash,
+                                    ?parent_block_hash,
+                                    "Skipping out-of-order cached block in batch",
+                                );
+                            }
+                            Err(e) => return Err(e),
+                        }
                     }
                     BatchBlock::Execute(block) => {
                         let counts = self.execute_one_in_session(session, &block, earliest)?;

--- a/crates/execution/trie/src/metrics.rs
+++ b/crates/execution/trie/src/metrics.rs
@@ -23,7 +23,10 @@ use reth_trie_common::{BranchNodeCompact, Nibbles};
 
 use crate::{
     BaseProofsStorageResult, BaseProofsStore, BlockStateDiff,
-    api::{BaseProofsInitialStateStore, InitialStateAnchor, OperationDurations, WriteCounts},
+    api::{
+        BaseProofsBatchStore, BaseProofsInitialStateStore, InitialStateAnchor, OperationDurations,
+        WriteCounts,
+    },
     cursor,
 };
 
@@ -479,6 +482,24 @@ where
     ) -> BaseProofsStorageResult<()> {
         BlockMetrics::earliest_number().set(block_number as f64);
         self.storage.set_earliest_block_number(block_number, hash)
+    }
+}
+
+impl<S> BaseProofsBatchStore for BaseProofsStorageWithMetrics<S>
+where
+    S: BaseProofsBatchStore + 'static,
+{
+    type BatchSession<'a>
+        = S::BatchSession<'a>
+    where
+        Self: 'a;
+
+    #[inline]
+    fn with_batch_session<R, F>(&self, f: F) -> BaseProofsStorageResult<R>
+    where
+        F: FnOnce(&mut Self::BatchSession<'_>) -> BaseProofsStorageResult<R>,
+    {
+        self.storage.with_batch_session(f)
     }
 }
 

--- a/crates/execution/trie/src/prune/pruner.rs
+++ b/crates/execution/trie/src/prune/pruner.rs
@@ -103,7 +103,11 @@ where
     fn prune_batch(&self, start_block: u64, end_block: u64) -> Result<PrunerOutput, PrunerError> {
         let batch_start_time = Instant::now();
 
-        // Fetch block hashes for the new earliest block of this batch
+        // Fetch the block hash for the new earliest block of this batch.
+        //
+        // The parent hash is intentionally not fetched: `prune_earliest_state` only reads
+        // `block.number` and `block.hash` from the supplied `BlockWithParent`. Fetching the
+        // parent hash here was wasted I/O proportional to the number of batches.
         let new_earliest_block_hash = self
             .block_hash_reader
             .block_hash(end_block)
@@ -117,24 +121,8 @@ where
             })?
             .ok_or(PrunerError::BlockNotFound(end_block))?;
 
-        let parent_block_num = end_block - 1;
-        let parent_block_hash = self
-            .block_hash_reader
-            .block_hash(parent_block_num)
-            .inspect_err(|err| {
-                error!(
-                    target: "trie::pruner",
-                    block = parent_block_num,
-                    ?err,
-                    "Failed to fetch block hash for parent block during pruning"
-                )
-            })?
-            .ok_or(PrunerError::BlockNotFound(parent_block_num))?;
-
-        batch_start_time.elapsed();
-
         let block_with_parent = BlockWithParent {
-            parent: parent_block_hash,
+            parent: Default::default(),
             block: BlockNumHash { number: end_block, hash: new_earliest_block_hash },
         };
 
@@ -411,11 +399,6 @@ mod tests {
             .expect_block_hash()
             .withf(move |block_num| *block_num == 4)
             .returning(move |_| Ok(Some(b256(4))));
-
-        block_hash_reader
-            .expect_block_hash()
-            .withf(move |block_num| *block_num == 3)
-            .returning(move |_| Ok(Some(b256(3))));
 
         let pruner = BaseProofStoragePruner::new(store.clone(), block_hash_reader, 1, 1000);
         let out = pruner.run_inner().expect("pruner ok");

--- a/crates/execution/trie/src/prune/task.rs
+++ b/crates/execution/trie/src/prune/task.rs
@@ -1,41 +1,49 @@
+use std::sync::Arc;
+
 use reth_provider::BlockHashReader;
 use reth_tasks::shutdown::GracefulShutdown;
 use tokio::{
     time,
     time::{Duration, MissedTickBehavior},
 };
-use tracing::info;
+use tracing::{info, warn};
 
 use crate::{BaseProofsStorage, BaseProofsStore, prune::BaseProofStoragePruner};
 
-const PRUNE_BATCH_SIZE: u64 = 200;
+/// Number of blocks pruned per MDBX write transaction.
+///
+/// Each batch is its own write tx, so the per-tx overhead (page allocation, freelist mgmt,
+/// fsync at commit) amortizes over this many blocks. The previous value of 200 caused tx
+/// overhead to dominate catch-up pruning runs; 2000 amortizes the fixed cost ~10x while
+/// keeping per-tx dirty-page sets and free-page reclamation lag bounded.
+const PRUNE_BATCH_SIZE: u64 = 2000;
 
 /// Periodic pruner task: constructs the pruner and runs it every interval.
 #[derive(Debug)]
 pub struct BaseProofStoragePrunerTask<P, H> {
-    pruner: BaseProofStoragePruner<P, H>,
+    pruner: Arc<BaseProofStoragePruner<P, H>>,
     min_block_interval: u64,
     task_run_interval: Duration,
 }
 
 impl<P, H> BaseProofStoragePrunerTask<P, H>
 where
-    P: BaseProofsStore,
-    H: BlockHashReader,
+    P: BaseProofsStore + Send + Sync + 'static,
+    H: BlockHashReader + Send + Sync + 'static,
 {
     /// Initialize a new [`BaseProofStoragePrunerTask`]
-    pub const fn new(
+    pub fn new(
         provider: BaseProofsStorage<P>,
         hash_reader: H,
         min_block_interval: u64,
         task_run_interval: Duration,
     ) -> Self {
-        let pruner = BaseProofStoragePruner::new(
+        let pruner = Arc::new(BaseProofStoragePruner::new(
             provider,
             hash_reader,
             min_block_interval,
             PRUNE_BATCH_SIZE,
-        );
+        ));
         Self { pruner, min_block_interval, task_run_interval }
     }
 
@@ -48,7 +56,6 @@ where
             "Starting pruner task"
         );
 
-        // Drive pruning with a periodic ticker
         let mut interval = time::interval(self.task_run_interval);
         interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
 
@@ -59,7 +66,13 @@ where
                     break;
                 }
                 _ = interval.tick() => {
-                    self.pruner.run()
+                    // `pruner.run()` performs blocking MDBX read/write transactions; offload
+                    // to a blocking worker so the tokio runtime stays responsive (and the
+                    // shutdown branch above can preempt on the next tick).
+                    let pruner = Arc::clone(&self.pruner);
+                    if let Err(e) = tokio::task::spawn_blocking(move || pruner.run()).await {
+                        warn!(target: "trie::pruner_task", err=%e, "Pruner blocking task failed");
+                    }
                 }
             }
         }

--- a/crates/execution/trie/tests/batch_session.rs
+++ b/crates/execution/trie/tests/batch_session.rs
@@ -137,8 +137,7 @@ fn batch_session_wipe_sees_uncommitted_parent_storage_slots() {
     assert_eq!(seen, vec![(s1, v1), (s2, v2)], "block 1 must observe its own writes");
 
     let mut at_block_2 = store.storage_hashed_cursor(addr, 2).expect("cursor at 2");
-    let after_wipe: Vec<_> =
-        std::iter::from_fn(|| at_block_2.next().expect("next")).collect();
+    let after_wipe: Vec<_> = std::iter::from_fn(|| at_block_2.next().expect("next")).collect();
     assert!(
         after_wipe.is_empty(),
         "wipe at block 2 must tombstone slots staged at block 1 inside the same batch; \

--- a/crates/execution/trie/tests/batch_session.rs
+++ b/crates/execution/trie/tests/batch_session.rs
@@ -1,0 +1,101 @@
+//! Integration tests for [`MdbxProofsStorage`]'s batch session: cross-block atomicity,
+//! transaction-local read visibility, and abort-on-error rollback.
+
+use std::sync::Arc;
+
+use alloy_eips::{NumHash, eip1898::BlockWithParent};
+use alloy_primitives::B256;
+use base_execution_trie::{
+    BaseProofsBatchSession, BaseProofsBatchStore, BaseProofsStore, BlockStateDiff,
+    MdbxProofsStorage,
+};
+use tempfile::TempDir;
+
+const fn b256(byte: u8) -> B256 {
+    B256::new([byte; 32])
+}
+
+const fn block(num: u64) -> BlockWithParent {
+    let parent = if num == 0 { B256::ZERO } else { b256((num - 1) as u8) };
+    BlockWithParent::new(parent, NumHash::new(num, b256(num as u8)))
+}
+
+fn setup() -> (TempDir, Arc<MdbxProofsStorage>) {
+    let dir = TempDir::new().expect("tmp dir");
+    let store = Arc::new(MdbxProofsStorage::new(dir.path()).expect("mdbx env"));
+    store.set_earliest_block_number(0, b256(0)).expect("set earliest");
+    store.store_trie_updates(block(0), BlockStateDiff::default()).expect("seed block 0");
+    (dir, store)
+}
+
+#[test]
+fn batch_session_commits_all_blocks_atomically() {
+    let (_dir, store) = setup();
+
+    store
+        .with_batch_session(|session| {
+            for n in 1..=5 {
+                session.store_trie_updates(block(n), BlockStateDiff::default())?;
+            }
+            Ok(())
+        })
+        .expect("batch commit");
+
+    let (latest, _) = store.get_latest_block_number().expect("latest").expect("some");
+    assert_eq!(latest, 5);
+}
+
+#[test]
+fn batch_session_aborts_on_error() {
+    let (_dir, store) = setup();
+
+    let result: Result<(), _> = store.with_batch_session(|session| {
+        session.store_trie_updates(block(1), BlockStateDiff::default())?;
+        session.store_trie_updates(block(2), BlockStateDiff::default())?;
+        Err(base_execution_trie::BaseProofsStorageError::NoBlocksFound)
+    });
+    assert!(result.is_err());
+
+    let (latest, _) = store.get_latest_block_number().expect("latest").expect("some");
+    assert_eq!(latest, 0, "writes from aborted batch must not be visible");
+}
+
+#[test]
+fn batch_session_reads_see_uncommitted_writes() {
+    let (_dir, store) = setup();
+
+    store
+        .with_batch_session(|session| {
+            session.store_trie_updates(block(1), BlockStateDiff::default())?;
+            let (mid, _) = session.get_latest_block_number()?.expect("latest in session");
+            assert_eq!(mid, 1, "session read must see uncommitted block 1");
+
+            session.store_trie_updates(block(2), BlockStateDiff::default())?;
+            let (end, _) = session.get_latest_block_number()?.expect("latest in session");
+            assert_eq!(end, 2, "session read must see uncommitted block 2");
+            Ok(())
+        })
+        .expect("batch commit");
+
+    let (latest, _) = store.get_latest_block_number().expect("latest").expect("some");
+    assert_eq!(latest, 2);
+}
+
+#[test]
+fn batch_session_rejects_out_of_order_block() {
+    let (_dir, store) = setup();
+
+    let result: Result<(), _> = store.with_batch_session(|session| {
+        session.store_trie_updates(block(1), BlockStateDiff::default())?;
+        let bad = BlockWithParent::new(b256(99), NumHash::new(2, b256(2)));
+        session.store_trie_updates(bad, BlockStateDiff::default())?;
+        Ok(())
+    });
+    assert!(matches!(
+        result,
+        Err(base_execution_trie::BaseProofsStorageError::OutOfOrder { block_number: 2, .. })
+    ));
+
+    let (latest, _) = store.get_latest_block_number().expect("latest").expect("some");
+    assert_eq!(latest, 0, "any error in batch must abort the entire transaction");
+}

--- a/crates/execution/trie/tests/batch_session.rs
+++ b/crates/execution/trie/tests/batch_session.rs
@@ -4,10 +4,16 @@
 use std::sync::Arc;
 
 use alloy_eips::{NumHash, eip1898::BlockWithParent};
-use alloy_primitives::B256;
+use alloy_primitives::{B256, U256};
 use base_execution_trie::{
     BaseProofsBatchSession, BaseProofsBatchStore, BaseProofsStore, BlockStateDiff,
     MdbxProofsStorage,
+};
+use reth_trie::{
+    BranchNodeCompact, HashedPostState, HashedStorage, Nibbles,
+    hashed_cursor::HashedCursor,
+    trie_cursor::TrieCursor,
+    updates::{StorageTrieUpdates, TrieUpdates, TrieUpdatesSorted},
 };
 use tempfile::TempDir;
 
@@ -79,6 +85,118 @@ fn batch_session_reads_see_uncommitted_writes() {
 
     let (latest, _) = store.get_latest_block_number().expect("latest").expect("some");
     assert_eq!(latest, 2);
+}
+
+/// Regression: when a wipe block sits inside a batch session and its parent (also inside the
+/// same batch) staged new storage slots, the wipe lookback must enumerate the parent's staged
+/// slots so they get tombstoned at the wipe block. A fresh RO tx misses those staged writes and
+/// silently produces incomplete tombstones.
+#[test]
+fn batch_session_wipe_sees_uncommitted_parent_storage_slots() {
+    let (_dir, store) = setup();
+
+    let addr = B256::repeat_byte(0xAB);
+    let s1 = B256::repeat_byte(0x01);
+    let s2 = B256::repeat_byte(0x02);
+    let v1 = U256::from(111u64);
+    let v2 = U256::from(222u64);
+
+    store
+        .with_batch_session(|session| {
+            let mut post_state = HashedPostState::default();
+            let mut storage = HashedStorage::default();
+            storage.storage.insert(s1, v1);
+            storage.storage.insert(s2, v2);
+            post_state.storages.insert(addr, storage);
+            session.store_trie_updates(
+                block(1),
+                BlockStateDiff {
+                    sorted_trie_updates: TrieUpdatesSorted::default(),
+                    sorted_post_state: post_state.into_sorted(),
+                },
+            )?;
+
+            let mut wipe_state = HashedPostState::default();
+            wipe_state.storages.insert(addr, HashedStorage::new(true));
+            session.store_trie_updates(
+                block(2),
+                BlockStateDiff {
+                    sorted_trie_updates: TrieUpdatesSorted::default(),
+                    sorted_post_state: wipe_state.into_sorted(),
+                },
+            )?;
+            Ok(())
+        })
+        .expect("batch commit");
+
+    let mut at_block_1 = store.storage_hashed_cursor(addr, 1).expect("cursor at 1");
+    let mut seen = Vec::new();
+    while let Some(entry) = at_block_1.next().expect("next") {
+        seen.push(entry);
+    }
+    assert_eq!(seen, vec![(s1, v1), (s2, v2)], "block 1 must observe its own writes");
+
+    let mut at_block_2 = store.storage_hashed_cursor(addr, 2).expect("cursor at 2");
+    let after_wipe: Vec<_> =
+        std::iter::from_fn(|| at_block_2.next().expect("next")).collect();
+    assert!(
+        after_wipe.is_empty(),
+        "wipe at block 2 must tombstone slots staged at block 1 inside the same batch; \
+         leaked entries: {after_wipe:?}",
+    );
+}
+
+/// Regression mirror of the hashed-storage case for the storage-trie path: `is_deleted = true`
+/// on a block whose parent staged trie nodes for the same address inside the same batch must
+/// enumerate those staged paths during the wipe lookback.
+#[test]
+fn batch_session_wipe_sees_uncommitted_parent_storage_trie_nodes() {
+    let (_dir, store) = setup();
+
+    let addr = B256::repeat_byte(0xCD);
+    let p1 = Nibbles::from_nibbles_unchecked([0x01, 0x02]);
+    let p2 = Nibbles::from_nibbles_unchecked([0x0A, 0x0B, 0x0C]);
+
+    store
+        .with_batch_session(|session| {
+            let mut trie_updates = TrieUpdates::default();
+            let mut storage_nodes = StorageTrieUpdates::default();
+            storage_nodes.storage_nodes.insert(p1, BranchNodeCompact::default());
+            storage_nodes.storage_nodes.insert(p2, BranchNodeCompact::default());
+            trie_updates.storage_tries.insert(addr, storage_nodes);
+            session.store_trie_updates(
+                block(1),
+                BlockStateDiff {
+                    sorted_trie_updates: trie_updates.into_sorted(),
+                    sorted_post_state: HashedPostState::default().into_sorted(),
+                },
+            )?;
+
+            let mut wipe = TrieUpdates::default();
+            let mut deleted = StorageTrieUpdates::default();
+            deleted.set_deleted(true);
+            wipe.storage_tries.insert(addr, deleted);
+            session.store_trie_updates(
+                block(2),
+                BlockStateDiff {
+                    sorted_trie_updates: wipe.into_sorted(),
+                    sorted_post_state: HashedPostState::default().into_sorted(),
+                },
+            )?;
+            Ok(())
+        })
+        .expect("batch commit");
+
+    let mut at_block_2 = store.storage_trie_cursor(addr, 2).expect("cursor at 2");
+    let mut leaked = Vec::new();
+    while let Some(entry) = at_block_2.next().expect("next") {
+        leaked.push(entry);
+    }
+    assert!(
+        leaked.is_empty(),
+        "is_deleted at block 2 must tombstone trie paths staged at block 1 inside the same batch; \
+         leaked: {leaked:?}",
+    );
 }
 
 #[test]


### PR DESCRIPTION
Several wins layered on the existing pruner. The per-row delete loop now uses next_dup_val so each iteration skips a Key decode and the per-iteration key comparison, the survivor scan walks BlockChangeSet in reverse so the first time a key is seen is its survivor (one HashMap op instead of and_modify+max+or_insert), the four survivor maps are pre-sized to bound rehash overhead, the dead parent block-hash lookup per batch is removed, the PRUNE_BATCH_SIZE bumps from 200 to 2000 so MDBX write-tx overhead amortizes across catch-up runs, and each pass runs under spawn_blocking so the blocking MDBX I/O cannot stall the tokio runtime.