### PR TITLE
test(devnet): Expand Precompile E2E Test Coverage

### DIFF
--- a/devnet/src/b20.rs
+++ b/devnet/src/b20.rs
@@ -190,6 +190,212 @@ impl<'a> B20PrecompileClient<'a> {
         self.send_call(token, IB20::transferCall { to, amount }, "transfer B-20 token").await
     }
 
+    /// Reads the token name.
+    pub async fn name(&self, token: Address) -> Result<String> {
+        let output = self.call(token, IB20::nameCall {}).await?;
+        IB20::nameCall::abi_decode_returns(output.as_ref()).wrap_err("Failed to decode name")
+    }
+
+    /// Reads the token symbol.
+    pub async fn symbol(&self, token: Address) -> Result<String> {
+        let output = self.call(token, IB20::symbolCall {}).await?;
+        IB20::symbolCall::abi_decode_returns(output.as_ref()).wrap_err("Failed to decode symbol")
+    }
+
+    /// Reads the token total supply.
+    pub async fn total_supply(&self, token: Address) -> Result<U256> {
+        let output = self.call(token, IB20::totalSupplyCall {}).await?;
+        IB20::totalSupplyCall::abi_decode_returns(output.as_ref())
+            .wrap_err("Failed to decode totalSupply")
+    }
+
+    /// Reads the allowance granted by `owner` to `spender`.
+    pub async fn allowance(
+        &self,
+        token: Address,
+        owner: Address,
+        spender: Address,
+    ) -> Result<U256> {
+        let output = self.call(token, IB20::allowanceCall { owner, spender }).await?;
+        IB20::allowanceCall::abi_decode_returns(output.as_ref())
+            .wrap_err("Failed to decode allowance")
+    }
+
+    /// Approves `spender` to transfer up to `amount` on behalf of the signer.
+    pub async fn approve(&self, token: Address, spender: Address, amount: U256) -> Result<()> {
+        self.send_call(token, IB20::approveCall { spender, amount }, "approve B-20 spender").await
+    }
+
+    /// Transfers tokens from `from` to `to` using the signer's allowance.
+    pub async fn transfer_from(
+        &self,
+        token: Address,
+        from: Address,
+        to: Address,
+        amount: U256,
+    ) -> Result<()> {
+        self.send_call(
+            token,
+            IB20::transferFromCall { from, to, amount },
+            "transferFrom B-20 token",
+        )
+        .await
+    }
+
+    /// Burns tokens from the signer's balance.
+    pub async fn burn(&self, token: Address, amount: U256) -> Result<()> {
+        self.send_call(token, IB20::burnCall { amount }, "burn B-20 token").await
+    }
+
+    /// Transfers tokens with a memo tag.
+    pub async fn transfer_with_memo(
+        &self,
+        token: Address,
+        to: Address,
+        amount: U256,
+        memo: B256,
+    ) -> Result<()> {
+        self.send_call(
+            token,
+            IB20::transferWithMemoCall { to, amount, memo },
+            "transferWithMemo B-20 token",
+        )
+        .await
+    }
+
+    /// Reads the supply cap.
+    pub async fn supply_cap(&self, token: Address) -> Result<U256> {
+        let output = self.call(token, IB20::supplyCapCall {}).await?;
+        IB20::supplyCapCall::abi_decode_returns(output.as_ref())
+            .wrap_err("Failed to decode supplyCap")
+    }
+
+    /// Sets the supply cap.
+    pub async fn set_supply_cap(&self, token: Address, new_cap: U256) -> Result<()> {
+        self.send_call(
+            token,
+            IB20::setSupplyCapCall { newSupplyCap: new_cap },
+            "setSupplyCap B-20 token",
+        )
+        .await
+    }
+
+    /// Sets the token name.
+    pub async fn set_name(&self, token: Address, new_name: &str) -> Result<()> {
+        self.send_call(
+            token,
+            IB20::setNameCall { newName: new_name.to_string() },
+            "setName B-20 token",
+        )
+        .await
+    }
+
+    /// Sets the token symbol.
+    pub async fn set_symbol(&self, token: Address, new_symbol: &str) -> Result<()> {
+        self.send_call(
+            token,
+            IB20::setSymbolCall { newSymbol: new_symbol.to_string() },
+            "setSymbol B-20 token",
+        )
+        .await
+    }
+
+    /// Reads the contract URI.
+    pub async fn contract_uri(&self, token: Address) -> Result<String> {
+        let output = self.call(token, IB20::contractURICall {}).await?;
+        IB20::contractURICall::abi_decode_returns(output.as_ref())
+            .wrap_err("Failed to decode contractURI")
+    }
+
+    /// Sets the contract URI.
+    pub async fn set_contract_uri(&self, token: Address, new_uri: &str) -> Result<()> {
+        self.send_call(
+            token,
+            IB20::setContractURICall { newURI: new_uri.to_string() },
+            "setContractURI B-20 token",
+        )
+        .await
+    }
+
+    /// Reads the pause vector flags.
+    pub async fn paused(&self, token: Address) -> Result<U256> {
+        let output = self.call(token, IB20::pausedCall {}).await?;
+        IB20::pausedCall::abi_decode_returns(output.as_ref()).wrap_err("Failed to decode paused")
+    }
+
+    /// Pauses the token for the given vector flags.
+    pub async fn pause(&self, token: Address, vectors: U256) -> Result<()> {
+        self.send_call(token, IB20::pauseCall { vectors }, "pause B-20 token").await
+    }
+
+    /// Unpauses all pause vectors on the token.
+    pub async fn unpause(&self, token: Address) -> Result<()> {
+        self.send_call(token, IB20::unpauseCall {}, "unpause B-20 token").await
+    }
+
+    /// Returns true if `token` is a deployed B-20 via the factory.
+    pub async fn is_b20(&self, token: Address) -> Result<bool> {
+        let output =
+            self.call(TokenFactory::ADDRESS, ITokenFactory::isB20Call { token }).await?;
+        ITokenFactory::isB20Call::abi_decode_returns(output.as_ref())
+            .wrap_err("Failed to decode isB20")
+    }
+
+    /// Calls `predictTokenAddress` on the factory precompile via RPC.
+    pub async fn predict_token_address_rpc(
+        &self,
+        creator: Address,
+        variant: TokenVariant,
+        decimals: u8,
+        salt: B256,
+    ) -> Result<Address> {
+        let output = self
+            .call(
+                TokenFactory::ADDRESS,
+                ITokenFactory::predictTokenAddressCall {
+                    creator,
+                    variant: variant.discriminant(),
+                    decimals,
+                    salt,
+                },
+            )
+            .await?;
+        ITokenFactory::predictTokenAddressCall::abi_decode_returns(output.as_ref())
+            .wrap_err("Failed to decode predictTokenAddress")
+    }
+
+    /// Sends a transaction and returns `true` if it succeeded, `false` if it reverted.
+    pub async fn try_send_call<C>(&self, to: Address, call: C) -> Result<bool>
+    where
+        C: SolCall,
+    {
+        let nonce = self.provider.get_transaction_count(self.signer.address()).await?;
+        let (raw_tx, _) = self
+            .create_signed_tx(to, nonce, Bytes::from(call.abi_encode()))
+            .wrap_err("Failed to sign transaction")?;
+
+        let pending_tx = self
+            .provider
+            .send_raw_transaction(&raw_tx)
+            .await
+            .wrap_err("Failed to send transaction")?;
+        let tx_hash = *pending_tx.tx_hash();
+
+        let receipt = timeout(self.receipt_timeout, async {
+            loop {
+                if let Some(r) = self.provider.get_transaction_receipt(tx_hash).await? {
+                    return Ok::<_, eyre::Error>(r);
+                }
+                sleep(Duration::from_secs(1)).await;
+            }
+        })
+        .await
+        .wrap_err("transaction receipt timed out")?
+        .wrap_err("Failed to get transaction receipt")?;
+
+        Ok(receipt.status())
+    }
+
     /// Executes an `eth_call` against `to`.
     pub async fn call<C>(&self, to: Address, call: C) -> Result<Bytes>
     where

--- a/devnet/src/b20.rs
+++ b/devnet/src/b20.rs
@@ -13,7 +13,7 @@ use alloy_signer_local::PrivateKeySigner;
 use alloy_sol_types::{SolCall, SolValue};
 use base_common_network::Base;
 use base_common_precompiles::{IB20, ITokenFactory, TokenFactory, TokenVariant};
-use base_common_rpc_types::BaseTransactionRequest;
+use base_common_rpc_types::{BaseTransactionReceipt, BaseTransactionRequest};
 use eyre::{Result, WrapErr, ensure};
 use tokio::time::{sleep, timeout};
 
@@ -368,31 +368,7 @@ impl<'a> B20PrecompileClient<'a> {
     where
         C: SolCall,
     {
-        let nonce = self.provider.get_transaction_count(self.signer.address()).await?;
-        let (raw_tx, _) = self
-            .create_signed_tx(to, nonce, Bytes::from(call.abi_encode()))
-            .wrap_err("Failed to sign transaction")?;
-
-        let pending_tx = self
-            .provider
-            .send_raw_transaction(&raw_tx)
-            .await
-            .wrap_err("Failed to send transaction")?;
-        let tx_hash = *pending_tx.tx_hash();
-
-        let receipt = timeout(self.receipt_timeout, async {
-            loop {
-                if let Some(r) = self.provider.get_transaction_receipt(tx_hash).await? {
-                    return Ok::<_, eyre::Error>(r);
-                }
-                sleep(Duration::from_secs(1)).await;
-            }
-        })
-        .await
-        .wrap_err("transaction receipt timed out")?
-        .wrap_err("Failed to get transaction receipt")?;
-
-        Ok(receipt.status())
+        Ok(self.send_and_wait(to, Bytes::from(call.abi_encode()), "try_send_call").await?.status())
     }
 
     /// Executes an `eth_call` against `to`.
@@ -413,9 +389,24 @@ impl<'a> B20PrecompileClient<'a> {
     where
         C: SolCall,
     {
+        let receipt = self.send_and_wait(to, Bytes::from(call.abi_encode()), label).await?;
+        ensure!(receipt.status(), "{label} transaction reverted");
+        ensure!(receipt.inner.to == Some(to), "{label} receipt target mismatch");
+        Ok(())
+    }
+
+    /// Signs, sends, and polls until a receipt is available.
+    ///
+    /// All error messages use `label`.  Both `send_call` and `try_send_call` delegate here so
+    /// the nonce-fetch / sign / send / poll-receipt pipeline stays in one place.
+    async fn send_and_wait(
+        &self,
+        to: Address,
+        input: Bytes,
+        label: &'static str,
+    ) -> Result<BaseTransactionReceipt> {
         let nonce = self.provider.get_transaction_count(self.signer.address()).await?;
-        let (raw_tx, expected_tx_hash) =
-            self.create_signed_tx(to, nonce, Bytes::from(call.abi_encode())).wrap_err(label)?;
+        let (raw_tx, expected_tx_hash) = self.create_signed_tx(to, nonce, input).wrap_err(label)?;
 
         let pending_tx = self
             .provider
@@ -425,7 +416,7 @@ impl<'a> B20PrecompileClient<'a> {
         let tx_hash = *pending_tx.tx_hash();
         ensure!(tx_hash == expected_tx_hash, "{label} transaction hash mismatch");
 
-        let receipt = timeout(self.receipt_timeout, async {
+        timeout(self.receipt_timeout, async {
             loop {
                 if let Some(receipt) = self.provider.get_transaction_receipt(tx_hash).await? {
                     return Ok::<_, eyre::Error>(receipt);
@@ -435,12 +426,7 @@ impl<'a> B20PrecompileClient<'a> {
         })
         .await
         .wrap_err_with(|| format!("{label} receipt timed out"))?
-        .wrap_err_with(|| format!("Failed to get {label} receipt"))?;
-
-        ensure!(receipt.status(), "{label} transaction reverted");
-        ensure!(receipt.inner.to == Some(to), "{label} receipt target mismatch");
-
-        Ok(())
+        .wrap_err_with(|| format!("Failed to get {label} receipt"))
     }
 
     /// Creates a signed transaction targeting `to`.

--- a/devnet/src/b20.rs
+++ b/devnet/src/b20.rs
@@ -364,11 +364,11 @@ impl<'a> B20PrecompileClient<'a> {
     }
 
     /// Sends a transaction and returns `true` if it succeeded, `false` if it reverted.
-    pub async fn try_send_call<C>(&self, to: Address, call: C) -> Result<bool>
+    pub async fn try_send_call<C>(&self, to: Address, call: C, label: &'static str) -> Result<bool>
     where
         C: SolCall,
     {
-        Ok(self.send_and_wait(to, Bytes::from(call.abi_encode()), "try_send_call").await?.status())
+        Ok(self.send_and_wait(to, Bytes::from(call.abi_encode()), label).await?.status())
     }
 
     /// Executes an `eth_call` against `to`.

--- a/devnet/src/b20.rs
+++ b/devnet/src/b20.rs
@@ -335,8 +335,7 @@ impl<'a> B20PrecompileClient<'a> {
 
     /// Returns true if `token` is a deployed B-20 via the factory.
     pub async fn is_b20(&self, token: Address) -> Result<bool> {
-        let output =
-            self.call(TokenFactory::ADDRESS, ITokenFactory::isB20Call { token }).await?;
+        let output = self.call(TokenFactory::ADDRESS, ITokenFactory::isB20Call { token }).await?;
         ITokenFactory::isB20Call::abi_decode_returns(output.as_ref())
             .wrap_err("Failed to decode isB20")
     }

--- a/devnet/tests/activation_registry.rs
+++ b/devnet/tests/activation_registry.rs
@@ -1,0 +1,164 @@
+//! End-to-end tests for the activation registry precompile over Base node RPC.
+
+use std::time::Duration;
+
+use alloy_primitives::U256;
+use alloy_provider::{Provider, RootProvider};
+use alloy_signer_local::PrivateKeySigner;
+use alloy_sol_types::SolCall;
+use base_common_network::Base;
+use base_common_precompiles::{ActivationRegistry, IActivationRegistry};
+use devnet::{
+    B20PrecompileClient, Devnet, DevnetBuilder,
+    config::ANVIL_ACCOUNT_5,
+};
+use eyre::{Result, WrapErr};
+use tokio::time::{sleep, timeout};
+
+const L1_CHAIN_ID: u64 = 1337;
+const L2_CHAIN_ID: u64 = 84538453;
+const BASE_AZUL_ACTIVATION_BLOCK: u64 = 0;
+const BASE_BERYL_ACTIVATION_BLOCK: u64 = 3;
+const BLOCK_PRODUCTION_TIMEOUT: Duration = Duration::from_secs(30);
+const BLOCK_POLL_INTERVAL: Duration = Duration::from_millis(500);
+const TX_RECEIPT_TIMEOUT: Duration = Duration::from_secs(60);
+
+/// `isActivated` returns `false` for every feature id by default.
+#[tokio::test]
+async fn test_activation_registry_is_activated_default() -> Result<()> {
+    let devnet = ActivationDevnet::start().await?;
+    let admin = PrivateKeySigner::from_bytes(&ANVIL_ACCOUNT_5.private_key)
+        .wrap_err("Failed to parse devnet private key")?;
+    devnet.wait_for_balance(admin.address()).await?;
+
+    let client = B20PrecompileClient::new(devnet.provider(), &admin, L2_CHAIN_ID)
+        .with_receipt_timeout(TX_RECEIPT_TIMEOUT);
+
+    let output = client
+        .call(
+            ActivationRegistry::ADDRESS,
+            IActivationRegistry::isActivatedCall {
+                feature: ActivationRegistry::SECURITIES_TOKEN_CREATION,
+            },
+        )
+        .await?;
+    let is_activated = IActivationRegistry::isActivatedCall::abi_decode_returns(output.as_ref())
+        .wrap_err("Failed to decode isActivated")?;
+
+    assert!(!is_activated, "feature should be inactive by default");
+
+    Ok(())
+}
+
+/// `admin()` returns the hardcoded activation admin address.
+#[tokio::test]
+async fn test_activation_registry_admin() -> Result<()> {
+    let devnet = ActivationDevnet::start().await?;
+    let caller = PrivateKeySigner::from_bytes(&ANVIL_ACCOUNT_5.private_key)
+        .wrap_err("Failed to parse devnet private key")?;
+    devnet.wait_for_balance(caller.address()).await?;
+
+    let client = B20PrecompileClient::new(devnet.provider(), &caller, L2_CHAIN_ID)
+        .with_receipt_timeout(TX_RECEIPT_TIMEOUT);
+
+    let output =
+        client.call(ActivationRegistry::ADDRESS, IActivationRegistry::adminCall {}).await?;
+    let admin_addr = IActivationRegistry::adminCall::abi_decode_returns(output.as_ref())
+        .wrap_err("Failed to decode admin")?;
+
+    assert_eq!(admin_addr, ActivationRegistry::ADMIN);
+
+    Ok(())
+}
+
+/// Calling `activate` from a non-admin account reverts with `Unauthorized`.
+#[tokio::test]
+async fn test_activation_registry_unauthorized_activate_reverts() -> Result<()> {
+    let devnet = ActivationDevnet::start().await?;
+    let non_admin = PrivateKeySigner::from_bytes(&ANVIL_ACCOUNT_5.private_key)
+        .wrap_err("Failed to parse devnet private key")?;
+    devnet.wait_for_balance(non_admin.address()).await?;
+
+    let client = B20PrecompileClient::new(devnet.provider(), &non_admin, L2_CHAIN_ID)
+        .with_receipt_timeout(TX_RECEIPT_TIMEOUT);
+
+    let succeeded = client
+        .try_send_call(
+            ActivationRegistry::ADDRESS,
+            IActivationRegistry::activateCall {
+                feature: ActivationRegistry::SECURITIES_TOKEN_CREATION,
+            },
+        )
+        .await?;
+
+    assert!(!succeeded, "activate from non-admin should revert");
+
+    // Feature remains inactive after the failed attempt.
+    let output = client
+        .call(
+            ActivationRegistry::ADDRESS,
+            IActivationRegistry::isActivatedCall {
+                feature: ActivationRegistry::SECURITIES_TOKEN_CREATION,
+            },
+        )
+        .await?;
+    let is_activated = IActivationRegistry::isActivatedCall::abi_decode_returns(output.as_ref())
+        .wrap_err("Failed to decode isActivated")?;
+    assert!(!is_activated, "feature should still be inactive after unauthorized activate");
+
+    Ok(())
+}
+
+struct ActivationDevnet {
+    _devnet: Devnet,
+    provider: RootProvider<Base>,
+}
+
+impl ActivationDevnet {
+    async fn start() -> Result<Self> {
+        let devnet = DevnetBuilder::new()
+            .with_l1_chain_id(L1_CHAIN_ID)
+            .with_l2_chain_id(L2_CHAIN_ID)
+            .with_base_azul_activation_block(BASE_AZUL_ACTIVATION_BLOCK)
+            .with_base_beryl_activation_block(BASE_BERYL_ACTIVATION_BLOCK)
+            .build()
+            .await?;
+
+        let provider = devnet.l2_builder_provider()?;
+        let this = Self { _devnet: devnet, provider };
+        this.wait_for_block(BASE_BERYL_ACTIVATION_BLOCK + 1).await?;
+        Ok(this)
+    }
+
+    const fn provider(&self) -> &RootProvider<Base> {
+        &self.provider
+    }
+
+    async fn wait_for_block(&self, min_block: u64) -> Result<u64> {
+        timeout(BLOCK_PRODUCTION_TIMEOUT, async {
+            loop {
+                let block = self.provider.get_block_number().await?;
+                if block >= min_block {
+                    return Ok::<_, eyre::Error>(block);
+                }
+                sleep(BLOCK_POLL_INTERVAL).await;
+            }
+        })
+        .await
+        .wrap_err("Block production timed out")?
+    }
+
+    async fn wait_for_balance(&self, address: alloy_primitives::Address) -> Result<()> {
+        timeout(Duration::from_secs(15), async {
+            loop {
+                let balance = self.provider.get_balance(address).await?;
+                if balance > U256::ZERO {
+                    return Ok::<_, eyre::Error>(());
+                }
+                sleep(BLOCK_POLL_INTERVAL).await;
+            }
+        })
+        .await
+        .wrap_err("Timed out waiting for funded devnet account")?
+    }
+}

--- a/devnet/tests/activation_registry.rs
+++ b/devnet/tests/activation_registry.rs
@@ -73,6 +73,7 @@ async fn test_activation_registry_unauthorized_activate_reverts() -> Result<()> 
             IActivationRegistry::activateCall {
                 feature: ActivationRegistry::SECURITIES_TOKEN_CREATION,
             },
+            "activate (unauthorized)",
         )
         .await?;
 

--- a/devnet/tests/activation_registry.rs
+++ b/devnet/tests/activation_registry.rs
@@ -1,35 +1,23 @@
 //! End-to-end tests for the activation registry precompile over Base node RPC.
 
-use std::time::Duration;
+mod common;
 
-use alloy_primitives::U256;
-use alloy_provider::{Provider, RootProvider};
 use alloy_signer_local::PrivateKeySigner;
 use alloy_sol_types::SolCall;
-use base_common_network::Base;
 use base_common_precompiles::{ActivationRegistry, IActivationRegistry};
-use devnet::{B20PrecompileClient, Devnet, DevnetBuilder, config::ANVIL_ACCOUNT_5};
+use devnet::{B20PrecompileClient, config::ANVIL_ACCOUNT_5};
 use eyre::{Result, WrapErr};
-use tokio::time::{sleep, timeout};
-
-const L1_CHAIN_ID: u64 = 1337;
-const L2_CHAIN_ID: u64 = 84538453;
-const BASE_AZUL_ACTIVATION_BLOCK: u64 = 0;
-const BASE_BERYL_ACTIVATION_BLOCK: u64 = 3;
-const BLOCK_PRODUCTION_TIMEOUT: Duration = Duration::from_secs(30);
-const BLOCK_POLL_INTERVAL: Duration = Duration::from_millis(500);
-const TX_RECEIPT_TIMEOUT: Duration = Duration::from_secs(60);
 
 /// `isActivated` returns `false` for every feature id by default.
 #[tokio::test]
 async fn test_activation_registry_is_activated_default() -> Result<()> {
-    let devnet = ActivationDevnet::start().await?;
+    let (_devnet, provider) = common::start_beryl_devnet().await?;
     let admin = PrivateKeySigner::from_bytes(&ANVIL_ACCOUNT_5.private_key)
         .wrap_err("Failed to parse devnet private key")?;
-    devnet.wait_for_balance(admin.address()).await?;
+    common::wait_for_balance(&provider, admin.address()).await?;
 
-    let client = B20PrecompileClient::new(devnet.provider(), &admin, L2_CHAIN_ID)
-        .with_receipt_timeout(TX_RECEIPT_TIMEOUT);
+    let client = B20PrecompileClient::new(&provider, &admin, common::L2_CHAIN_ID)
+        .with_receipt_timeout(common::TX_RECEIPT_TIMEOUT);
 
     let output = client
         .call(
@@ -50,13 +38,13 @@ async fn test_activation_registry_is_activated_default() -> Result<()> {
 /// `admin()` returns the hardcoded activation admin address.
 #[tokio::test]
 async fn test_activation_registry_admin() -> Result<()> {
-    let devnet = ActivationDevnet::start().await?;
+    let (_devnet, provider) = common::start_beryl_devnet().await?;
     let caller = PrivateKeySigner::from_bytes(&ANVIL_ACCOUNT_5.private_key)
         .wrap_err("Failed to parse devnet private key")?;
-    devnet.wait_for_balance(caller.address()).await?;
+    common::wait_for_balance(&provider, caller.address()).await?;
 
-    let client = B20PrecompileClient::new(devnet.provider(), &caller, L2_CHAIN_ID)
-        .with_receipt_timeout(TX_RECEIPT_TIMEOUT);
+    let client = B20PrecompileClient::new(&provider, &caller, common::L2_CHAIN_ID)
+        .with_receipt_timeout(common::TX_RECEIPT_TIMEOUT);
 
     let output =
         client.call(ActivationRegistry::ADDRESS, IActivationRegistry::adminCall {}).await?;
@@ -71,13 +59,13 @@ async fn test_activation_registry_admin() -> Result<()> {
 /// Calling `activate` from a non-admin account reverts with `Unauthorized`.
 #[tokio::test]
 async fn test_activation_registry_unauthorized_activate_reverts() -> Result<()> {
-    let devnet = ActivationDevnet::start().await?;
+    let (_devnet, provider) = common::start_beryl_devnet().await?;
     let non_admin = PrivateKeySigner::from_bytes(&ANVIL_ACCOUNT_5.private_key)
         .wrap_err("Failed to parse devnet private key")?;
-    devnet.wait_for_balance(non_admin.address()).await?;
+    common::wait_for_balance(&provider, non_admin.address()).await?;
 
-    let client = B20PrecompileClient::new(devnet.provider(), &non_admin, L2_CHAIN_ID)
-        .with_receipt_timeout(TX_RECEIPT_TIMEOUT);
+    let client = B20PrecompileClient::new(&provider, &non_admin, common::L2_CHAIN_ID)
+        .with_receipt_timeout(common::TX_RECEIPT_TIMEOUT);
 
     let succeeded = client
         .try_send_call(
@@ -104,58 +92,4 @@ async fn test_activation_registry_unauthorized_activate_reverts() -> Result<()> 
     assert!(!is_activated, "feature should still be inactive after unauthorized activate");
 
     Ok(())
-}
-
-struct ActivationDevnet {
-    _devnet: Devnet,
-    provider: RootProvider<Base>,
-}
-
-impl ActivationDevnet {
-    async fn start() -> Result<Self> {
-        let devnet = DevnetBuilder::new()
-            .with_l1_chain_id(L1_CHAIN_ID)
-            .with_l2_chain_id(L2_CHAIN_ID)
-            .with_base_azul_activation_block(BASE_AZUL_ACTIVATION_BLOCK)
-            .with_base_beryl_activation_block(BASE_BERYL_ACTIVATION_BLOCK)
-            .build()
-            .await?;
-
-        let provider = devnet.l2_builder_provider()?;
-        let this = Self { _devnet: devnet, provider };
-        this.wait_for_block(BASE_BERYL_ACTIVATION_BLOCK + 1).await?;
-        Ok(this)
-    }
-
-    const fn provider(&self) -> &RootProvider<Base> {
-        &self.provider
-    }
-
-    async fn wait_for_block(&self, min_block: u64) -> Result<u64> {
-        timeout(BLOCK_PRODUCTION_TIMEOUT, async {
-            loop {
-                let block = self.provider.get_block_number().await?;
-                if block >= min_block {
-                    return Ok::<_, eyre::Error>(block);
-                }
-                sleep(BLOCK_POLL_INTERVAL).await;
-            }
-        })
-        .await
-        .wrap_err("Block production timed out")?
-    }
-
-    async fn wait_for_balance(&self, address: alloy_primitives::Address) -> Result<()> {
-        timeout(Duration::from_secs(15), async {
-            loop {
-                let balance = self.provider.get_balance(address).await?;
-                if balance > U256::ZERO {
-                    return Ok::<_, eyre::Error>(());
-                }
-                sleep(BLOCK_POLL_INTERVAL).await;
-            }
-        })
-        .await
-        .wrap_err("Timed out waiting for funded devnet account")?
-    }
 }

--- a/devnet/tests/activation_registry.rs
+++ b/devnet/tests/activation_registry.rs
@@ -8,10 +8,7 @@ use alloy_signer_local::PrivateKeySigner;
 use alloy_sol_types::SolCall;
 use base_common_network::Base;
 use base_common_precompiles::{ActivationRegistry, IActivationRegistry};
-use devnet::{
-    B20PrecompileClient, Devnet, DevnetBuilder,
-    config::ANVIL_ACCOUNT_5,
-};
+use devnet::{B20PrecompileClient, Devnet, DevnetBuilder, config::ANVIL_ACCOUNT_5};
 use eyre::{Result, WrapErr};
 use tokio::time::{sleep, timeout};
 

--- a/devnet/tests/b20_precompile.rs
+++ b/devnet/tests/b20_precompile.rs
@@ -2,10 +2,11 @@
 
 mod common;
 
-use alloy_primitives::{Address, B256, U256};
+use alloy_primitives::{Address, B256, Bytes, U256};
 use alloy_signer_local::PrivateKeySigner;
+use alloy_sol_types::SolValue;
 use base_common_precompiles::{
-    CAPABILITY_CAP_MUTABLE, CAPABILITY_PAUSABLE, IB20, TokenFactory, TokenVariant,
+    CAPABILITY_CAP_MUTABLE, CAPABILITY_PAUSABLE, IB20, ITokenFactory, TokenFactory, TokenVariant,
 };
 use devnet::{
     B20PrecompileClient,
@@ -248,6 +249,7 @@ async fn test_b20_supply_cap() -> Result<()> {
         !b20.try_send_call(
             token,
             IB20::setSupplyCapCall { newSupplyCap: U256::from(INITIAL_SUPPLY - 1) },
+            "setSupplyCap below current supply",
         )
         .await?,
         "setSupplyCap below total supply should revert",
@@ -259,8 +261,12 @@ async fn test_b20_supply_cap() -> Result<()> {
 
     // Minting past the cap reverts.
     assert!(
-        !b20.try_send_call(token, IB20::mintCall { to: admin.address(), amount: U256::from(1) })
-            .await?,
+        !b20.try_send_call(
+            token,
+            IB20::mintCall { to: admin.address(), amount: U256::from(1) },
+            "mint past supply cap",
+        )
+        .await?,
         "mint past supply cap should revert",
     );
 
@@ -333,6 +339,7 @@ async fn test_b20_pause_and_unpause() -> Result<()> {
         !b20.try_send_call(
             token,
             IB20::transferCall { to: recipient, amount: U256::from(PAUSE_TRANSFER_AMOUNT) },
+            "transfer while paused",
         )
         .await?,
         "transfer should revert while paused",
@@ -405,10 +412,26 @@ async fn test_b20_create_token_duplicate_reverts() -> Result<()> {
         admin.address(),
     );
 
-    b20.create_token(TokenVariant::B20, params.clone(), salt).await?;
+    let token = b20.create_token(TokenVariant::B20, params.clone(), salt).await?;
+    b20.wait_for_token_code(token, common::TX_RECEIPT_TIMEOUT, common::BLOCK_POLL_INTERVAL).await?;
 
-    let second = b20.create_token(TokenVariant::B20, params, salt).await;
-    assert!(second.is_err(), "creating a token with the same salt should fail");
+    let succeeded = b20
+        .try_send_call(
+            TokenFactory::ADDRESS,
+            ITokenFactory::createTokenCall {
+                params: ITokenFactory::CreateTokenParams {
+                    version: TokenFactory::CREATE_TOKEN_VERSION,
+                    variant: TokenVariant::B20.discriminant(),
+                    requiredParams: params.abi_encode().into(),
+                    optionalParams: Bytes::new(),
+                    postCreateCalls: Vec::new(),
+                    salt,
+                },
+            },
+            "createToken (duplicate salt)",
+        )
+        .await?;
+    assert!(!succeeded, "creating a token with the same salt should revert on-chain");
 
     Ok(())
 }

--- a/devnet/tests/b20_precompile.rs
+++ b/devnet/tests/b20_precompile.rs
@@ -2,14 +2,16 @@
 
 use std::time::Duration;
 
-use alloy_primitives::{B256, U256};
+use alloy_primitives::{Address, B256, U256};
 use alloy_provider::{Provider, RootProvider};
 use alloy_signer_local::PrivateKeySigner;
 use base_common_network::Base;
-use base_common_precompiles::TokenVariant;
+use base_common_precompiles::{
+    CAPABILITY_CAP_MUTABLE, CAPABILITY_PAUSABLE, IB20, TokenFactory, TokenVariant,
+};
 use devnet::{
     B20PrecompileClient, Devnet, DevnetBuilder,
-    config::{ANVIL_ACCOUNT_5, ANVIL_ACCOUNT_6},
+    config::{ANVIL_ACCOUNT_5, ANVIL_ACCOUNT_6, ANVIL_ACCOUNT_7},
 };
 use eyre::{Result, WrapErr};
 use tokio::time::{sleep, timeout};
@@ -61,6 +63,361 @@ async fn test_b20_factory_create_and_transfer_via_rpc() -> Result<()> {
 
     assert_eq!(recipient_balance, U256::from(TRANSFER_AMOUNT));
     assert_eq!(admin_balance_before - admin_balance_after, U256::from(TRANSFER_AMOUNT));
+
+    Ok(())
+}
+
+const MINT_AMOUNT: u64 = 500_000;
+const BURN_AMOUNT: u64 = 200_000;
+const APPROVE_AMOUNT: u64 = 50_000_000;
+const SPENDER_TRANSFER_AMOUNT: u64 = 30_000_000;
+const MEMO_TRANSFER_AMOUNT: u64 = 111_000;
+const INITIAL_SUPPLY_CAP: u64 = 2_000_000_000;
+const PAUSE_TRANSFER_AMOUNT: u64 = 10_000;
+
+#[tokio::test]
+async fn test_b20_token_metadata() -> Result<()> {
+    let devnet = B20Devnet::start().await?;
+    let admin = PrivateKeySigner::from_bytes(&ANVIL_ACCOUNT_5.private_key)
+        .wrap_err("Failed to parse admin key")?;
+    devnet.wait_for_balance(admin.address()).await?;
+
+    let b20 = B20PrecompileClient::new(devnet.provider(), &admin, L2_CHAIN_ID)
+        .with_receipt_timeout(TX_RECEIPT_TIMEOUT);
+    let salt = B256::repeat_byte(0x10);
+    let params = B20PrecompileClient::token_params(
+        "Metadata Token",
+        "META",
+        TOKEN_DECIMALS,
+        U256::from(INITIAL_SUPPLY),
+        admin.address(),
+    );
+
+    let token = b20.create_token(TokenVariant::B20, params, salt).await?;
+    b20.wait_for_token_code(token, TX_RECEIPT_TIMEOUT, BLOCK_POLL_INTERVAL).await?;
+
+    assert_eq!(b20.name(token).await?, "Metadata Token");
+    assert_eq!(b20.symbol(token).await?, "META");
+    assert_eq!(b20.total_supply(token).await?, U256::from(INITIAL_SUPPLY));
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_b20_approve_and_transfer_from() -> Result<()> {
+    let devnet = B20Devnet::start().await?;
+    let admin = PrivateKeySigner::from_bytes(&ANVIL_ACCOUNT_5.private_key)
+        .wrap_err("Failed to parse admin key")?;
+    let spender =
+        PrivateKeySigner::from_bytes(&ANVIL_ACCOUNT_7.private_key).wrap_err("spender key")?;
+    let recipient = ANVIL_ACCOUNT_6.address;
+    devnet.wait_for_balance(admin.address()).await?;
+    devnet.wait_for_balance(spender.address()).await?;
+
+    let b20_admin = B20PrecompileClient::new(devnet.provider(), &admin, L2_CHAIN_ID)
+        .with_receipt_timeout(TX_RECEIPT_TIMEOUT);
+    let b20_spender = B20PrecompileClient::new(devnet.provider(), &spender, L2_CHAIN_ID)
+        .with_receipt_timeout(TX_RECEIPT_TIMEOUT);
+
+    let salt = B256::repeat_byte(0x11);
+    let params = B20PrecompileClient::token_params(
+        "Allowance Token",
+        "ALLW",
+        TOKEN_DECIMALS,
+        U256::from(INITIAL_SUPPLY),
+        admin.address(),
+    );
+    let token = b20_admin.create_token(TokenVariant::B20, params, salt).await?;
+    b20_admin.wait_for_token_code(token, TX_RECEIPT_TIMEOUT, BLOCK_POLL_INTERVAL).await?;
+
+    let approve_amount = U256::from(APPROVE_AMOUNT);
+    let transfer_amount = U256::from(SPENDER_TRANSFER_AMOUNT);
+
+    b20_admin.approve(token, spender.address(), approve_amount).await?;
+    assert_eq!(b20_admin.allowance(token, admin.address(), spender.address()).await?, approve_amount);
+
+    b20_spender.transfer_from(token, admin.address(), recipient, transfer_amount).await?;
+
+    assert_eq!(
+        b20_admin.balance_of(token, admin.address()).await?,
+        U256::from(INITIAL_SUPPLY) - transfer_amount,
+    );
+    assert_eq!(b20_admin.balance_of(token, recipient).await?, transfer_amount);
+    assert_eq!(
+        b20_admin.allowance(token, admin.address(), spender.address()).await?,
+        approve_amount - transfer_amount,
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_b20_mint_and_burn() -> Result<()> {
+    let devnet = B20Devnet::start().await?;
+    let admin = PrivateKeySigner::from_bytes(&ANVIL_ACCOUNT_5.private_key)
+        .wrap_err("Failed to parse admin key")?;
+    devnet.wait_for_balance(admin.address()).await?;
+
+    let b20 = B20PrecompileClient::new(devnet.provider(), &admin, L2_CHAIN_ID)
+        .with_receipt_timeout(TX_RECEIPT_TIMEOUT);
+    let salt = B256::repeat_byte(0x12);
+    let params = B20PrecompileClient::token_params(
+        "Mintable Token",
+        "MINT",
+        TOKEN_DECIMALS,
+        U256::from(INITIAL_SUPPLY),
+        admin.address(),
+    );
+    let token = b20.create_token(TokenVariant::B20, params, salt).await?;
+    b20.wait_for_token_code(token, TX_RECEIPT_TIMEOUT, BLOCK_POLL_INTERVAL).await?;
+
+    let supply_before = b20.total_supply(token).await?;
+
+    b20.mint(token, admin.address(), U256::from(MINT_AMOUNT)).await?;
+    assert_eq!(b20.total_supply(token).await?, supply_before + U256::from(MINT_AMOUNT));
+    assert_eq!(
+        b20.balance_of(token, admin.address()).await?,
+        U256::from(INITIAL_SUPPLY) + U256::from(MINT_AMOUNT),
+    );
+
+    b20.burn(token, U256::from(BURN_AMOUNT)).await?;
+    assert_eq!(
+        b20.total_supply(token).await?,
+        supply_before + U256::from(MINT_AMOUNT) - U256::from(BURN_AMOUNT),
+    );
+    assert_eq!(
+        b20.balance_of(token, admin.address()).await?,
+        U256::from(INITIAL_SUPPLY) + U256::from(MINT_AMOUNT) - U256::from(BURN_AMOUNT),
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_b20_transfer_with_memo() -> Result<()> {
+    let devnet = B20Devnet::start().await?;
+    let admin = PrivateKeySigner::from_bytes(&ANVIL_ACCOUNT_5.private_key)
+        .wrap_err("Failed to parse admin key")?;
+    let recipient = ANVIL_ACCOUNT_6.address;
+    devnet.wait_for_balance(admin.address()).await?;
+
+    let b20 = B20PrecompileClient::new(devnet.provider(), &admin, L2_CHAIN_ID)
+        .with_receipt_timeout(TX_RECEIPT_TIMEOUT);
+    let salt = B256::repeat_byte(0x13);
+    let params = B20PrecompileClient::token_params(
+        "Memo Token",
+        "MEMO",
+        TOKEN_DECIMALS,
+        U256::from(INITIAL_SUPPLY),
+        admin.address(),
+    );
+    let token = b20.create_token(TokenVariant::B20, params, salt).await?;
+    b20.wait_for_token_code(token, TX_RECEIPT_TIMEOUT, BLOCK_POLL_INTERVAL).await?;
+
+    let memo = B256::repeat_byte(0xde);
+    let amount = U256::from(MEMO_TRANSFER_AMOUNT);
+    b20.transfer_with_memo(token, recipient, amount, memo).await?;
+
+    assert_eq!(b20.balance_of(token, recipient).await?, amount);
+    assert_eq!(
+        b20.balance_of(token, admin.address()).await?,
+        U256::from(INITIAL_SUPPLY) - amount,
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_b20_supply_cap() -> Result<()> {
+    let devnet = B20Devnet::start().await?;
+    let admin = PrivateKeySigner::from_bytes(&ANVIL_ACCOUNT_5.private_key)
+        .wrap_err("Failed to parse admin key")?;
+    devnet.wait_for_balance(admin.address()).await?;
+
+    let b20 = B20PrecompileClient::new(devnet.provider(), &admin, L2_CHAIN_ID)
+        .with_receipt_timeout(TX_RECEIPT_TIMEOUT);
+    let salt = B256::repeat_byte(0x14);
+    let mut params = B20PrecompileClient::token_params(
+        "Capped Token",
+        "CAP",
+        TOKEN_DECIMALS,
+        U256::from(INITIAL_SUPPLY),
+        admin.address(),
+    );
+    params.capabilities = CAPABILITY_CAP_MUTABLE;
+    params.supplyCap = U256::from(INITIAL_SUPPLY_CAP);
+
+    let token = b20.create_token(TokenVariant::B20, params, salt).await?;
+    b20.wait_for_token_code(token, TX_RECEIPT_TIMEOUT, BLOCK_POLL_INTERVAL).await?;
+
+    assert_eq!(b20.supply_cap(token).await?, U256::from(INITIAL_SUPPLY_CAP));
+
+    // Cap below current total supply reverts.
+    assert!(
+        !b20.try_send_call(
+            token,
+            IB20::setSupplyCapCall { newSupplyCap: U256::from(INITIAL_SUPPLY - 1) },
+        )
+        .await?,
+        "setSupplyCap below total supply should revert",
+    );
+
+    // Tighten cap to exactly the current supply.
+    b20.set_supply_cap(token, U256::from(INITIAL_SUPPLY)).await?;
+    assert_eq!(b20.supply_cap(token).await?, U256::from(INITIAL_SUPPLY));
+
+    // Minting past the cap reverts.
+    assert!(
+        !b20.try_send_call(token, IB20::mintCall { to: admin.address(), amount: U256::from(1) })
+            .await?,
+        "mint past supply cap should revert",
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_b20_metadata_updates() -> Result<()> {
+    let devnet = B20Devnet::start().await?;
+    let admin = PrivateKeySigner::from_bytes(&ANVIL_ACCOUNT_5.private_key)
+        .wrap_err("Failed to parse admin key")?;
+    devnet.wait_for_balance(admin.address()).await?;
+
+    let b20 = B20PrecompileClient::new(devnet.provider(), &admin, L2_CHAIN_ID)
+        .with_receipt_timeout(TX_RECEIPT_TIMEOUT);
+    let salt = B256::repeat_byte(0x15);
+    let params = B20PrecompileClient::token_params(
+        "Old Name",
+        "OLD",
+        TOKEN_DECIMALS,
+        U256::from(INITIAL_SUPPLY),
+        admin.address(),
+    );
+    let token = b20.create_token(TokenVariant::B20, params, salt).await?;
+    b20.wait_for_token_code(token, TX_RECEIPT_TIMEOUT, BLOCK_POLL_INTERVAL).await?;
+
+    b20.set_name(token, "New Name").await?;
+    b20.set_symbol(token, "NEW").await?;
+    b20.set_contract_uri(token, "ipfs://QmTest").await?;
+
+    assert_eq!(b20.name(token).await?, "New Name");
+    assert_eq!(b20.symbol(token).await?, "NEW");
+    assert_eq!(b20.contract_uri(token).await?, "ipfs://QmTest");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_b20_pause_and_unpause() -> Result<()> {
+    let devnet = B20Devnet::start().await?;
+    let admin = PrivateKeySigner::from_bytes(&ANVIL_ACCOUNT_5.private_key)
+        .wrap_err("Failed to parse admin key")?;
+    let recipient = ANVIL_ACCOUNT_6.address;
+    devnet.wait_for_balance(admin.address()).await?;
+
+    let b20 = B20PrecompileClient::new(devnet.provider(), &admin, L2_CHAIN_ID)
+        .with_receipt_timeout(TX_RECEIPT_TIMEOUT);
+    let salt = B256::repeat_byte(0x16);
+    let mut params = B20PrecompileClient::token_params(
+        "Pausable Token",
+        "PAUS",
+        TOKEN_DECIMALS,
+        U256::from(INITIAL_SUPPLY),
+        admin.address(),
+    );
+    params.capabilities = CAPABILITY_PAUSABLE;
+
+    let token = b20.create_token(TokenVariant::B20, params, salt).await?;
+    b20.wait_for_token_code(token, TX_RECEIPT_TIMEOUT, BLOCK_POLL_INTERVAL).await?;
+
+    // Transfer succeeds before pause.
+    b20.transfer(token, recipient, U256::from(PAUSE_TRANSFER_AMOUNT)).await?;
+    assert_eq!(b20.balance_of(token, recipient).await?, U256::from(PAUSE_TRANSFER_AMOUNT));
+
+    b20.pause(token, U256::from(1)).await?;
+    assert_ne!(b20.paused(token).await?, U256::ZERO, "token should be paused");
+
+    // Transfer reverts while paused.
+    assert!(
+        !b20.try_send_call(
+            token,
+            IB20::transferCall { to: recipient, amount: U256::from(PAUSE_TRANSFER_AMOUNT) },
+        )
+        .await?,
+        "transfer should revert while paused",
+    );
+    assert_eq!(b20.balance_of(token, recipient).await?, U256::from(PAUSE_TRANSFER_AMOUNT));
+
+    b20.unpause(token).await?;
+    assert_eq!(b20.paused(token).await?, U256::ZERO, "token should be unpaused");
+
+    b20.transfer(token, recipient, U256::from(PAUSE_TRANSFER_AMOUNT)).await?;
+    assert_eq!(b20.balance_of(token, recipient).await?, U256::from(PAUSE_TRANSFER_AMOUNT * 2));
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_b20_factory_predict_and_is_b20() -> Result<()> {
+    let devnet = B20Devnet::start().await?;
+    let admin = PrivateKeySigner::from_bytes(&ANVIL_ACCOUNT_5.private_key)
+        .wrap_err("Failed to parse admin key")?;
+    devnet.wait_for_balance(admin.address()).await?;
+
+    let b20 = B20PrecompileClient::new(devnet.provider(), &admin, L2_CHAIN_ID)
+        .with_receipt_timeout(TX_RECEIPT_TIMEOUT);
+    let salt = B256::repeat_byte(0x17);
+    let params = B20PrecompileClient::token_params(
+        "Predict Token",
+        "PRD",
+        TOKEN_DECIMALS,
+        U256::from(INITIAL_SUPPLY),
+        admin.address(),
+    );
+
+    let local_prediction = b20.predict_token_address(TokenVariant::B20, TOKEN_DECIMALS, salt);
+    let rpc_prediction =
+        b20.predict_token_address_rpc(admin.address(), TokenVariant::B20, TOKEN_DECIMALS, salt)
+            .await?;
+    assert_eq!(local_prediction, rpc_prediction, "local and RPC predictions should match");
+
+    let token = b20.create_token(TokenVariant::B20, params, salt).await?;
+    b20.wait_for_token_code(token, TX_RECEIPT_TIMEOUT, BLOCK_POLL_INTERVAL).await?;
+
+    assert_eq!(token, rpc_prediction, "created token address should match prediction");
+
+    assert!(b20.is_b20(token).await?, "created token should be recognised as B-20");
+    assert!(!b20.is_b20(TokenFactory::ADDRESS).await?, "factory address is not a B-20 token");
+    assert!(
+        !b20.is_b20(Address::repeat_byte(0xab)).await?,
+        "arbitrary address is not a B-20 token",
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_b20_create_token_duplicate_reverts() -> Result<()> {
+    let devnet = B20Devnet::start().await?;
+    let admin = PrivateKeySigner::from_bytes(&ANVIL_ACCOUNT_5.private_key)
+        .wrap_err("Failed to parse admin key")?;
+    devnet.wait_for_balance(admin.address()).await?;
+
+    let b20 = B20PrecompileClient::new(devnet.provider(), &admin, L2_CHAIN_ID)
+        .with_receipt_timeout(TX_RECEIPT_TIMEOUT);
+    let salt = B256::repeat_byte(0x18);
+    let params = B20PrecompileClient::token_params(
+        "Dup Token",
+        "DUP",
+        TOKEN_DECIMALS,
+        U256::from(INITIAL_SUPPLY),
+        admin.address(),
+    );
+
+    b20.create_token(TokenVariant::B20, params.clone(), salt).await?;
+
+    let second = b20.create_token(TokenVariant::B20, params, salt).await;
+    assert!(second.is_err(), "creating a token with the same salt should fail");
 
     Ok(())
 }

--- a/devnet/tests/b20_precompile.rs
+++ b/devnet/tests/b20_precompile.rs
@@ -1,43 +1,40 @@
 //! End-to-end tests for B-20 precompiles over Base node RPC.
 
-use std::time::Duration;
+mod common;
 
 use alloy_primitives::{Address, B256, U256};
-use alloy_provider::{Provider, RootProvider};
 use alloy_signer_local::PrivateKeySigner;
-use base_common_network::Base;
 use base_common_precompiles::{
     CAPABILITY_CAP_MUTABLE, CAPABILITY_PAUSABLE, IB20, TokenFactory, TokenVariant,
 };
 use devnet::{
-    B20PrecompileClient, Devnet, DevnetBuilder,
+    B20PrecompileClient,
     config::{ANVIL_ACCOUNT_5, ANVIL_ACCOUNT_6, ANVIL_ACCOUNT_7},
 };
 use eyre::{Result, WrapErr};
-use tokio::time::{sleep, timeout};
 
-const L1_CHAIN_ID: u64 = 1337;
-const L2_CHAIN_ID: u64 = 84538453;
-const BASE_AZUL_ACTIVATION_BLOCK: u64 = 0;
-const BASE_BERYL_ACTIVATION_BLOCK: u64 = 3;
-const BLOCK_PRODUCTION_TIMEOUT: Duration = Duration::from_secs(30);
-const BLOCK_POLL_INTERVAL: Duration = Duration::from_millis(500);
-const TX_RECEIPT_TIMEOUT: Duration = Duration::from_secs(60);
 const TOKEN_DECIMALS: u8 = 6;
 const INITIAL_SUPPLY: u64 = 1_000_000_000;
 const TRANSFER_AMOUNT: u64 = 100_000_000;
+const MINT_AMOUNT: u64 = 500_000;
+const BURN_AMOUNT: u64 = 200_000;
+const APPROVE_AMOUNT: u64 = 50_000_000;
+const SPENDER_TRANSFER_AMOUNT: u64 = 30_000_000;
+const MEMO_TRANSFER_AMOUNT: u64 = 111_000;
+const INITIAL_SUPPLY_CAP: u64 = 2_000_000_000;
+const PAUSE_TRANSFER_AMOUNT: u64 = 10_000;
 
 #[tokio::test]
 async fn test_b20_factory_create_and_transfer_via_rpc() -> Result<()> {
-    let devnet = B20Devnet::start().await?;
+    let (_devnet, provider) = common::start_beryl_devnet().await?;
     let admin = PrivateKeySigner::from_bytes(&ANVIL_ACCOUNT_5.private_key)
         .wrap_err("Failed to parse devnet private key")?;
     let recipient = ANVIL_ACCOUNT_6.address;
 
-    devnet.wait_for_balance(admin.address()).await?;
+    common::wait_for_balance(&provider, admin.address()).await?;
 
-    let b20 = B20PrecompileClient::new(devnet.provider(), &admin, L2_CHAIN_ID)
-        .with_receipt_timeout(TX_RECEIPT_TIMEOUT);
+    let b20 = B20PrecompileClient::new(&provider, &admin, common::L2_CHAIN_ID)
+        .with_receipt_timeout(common::TX_RECEIPT_TIMEOUT);
     let salt = B256::repeat_byte(0x42);
     let params = B20PrecompileClient::token_params(
         "Devnet B20",
@@ -48,7 +45,7 @@ async fn test_b20_factory_create_and_transfer_via_rpc() -> Result<()> {
     );
 
     let token = b20.create_token(TokenVariant::B20, params, salt).await?;
-    b20.wait_for_token_code(token, TX_RECEIPT_TIMEOUT, BLOCK_POLL_INTERVAL).await?;
+    b20.wait_for_token_code(token, common::TX_RECEIPT_TIMEOUT, common::BLOCK_POLL_INTERVAL).await?;
 
     assert_eq!(b20.variant_of(token).await?, TokenVariant::B20.discriminant());
     assert_eq!(b20.decimals_of(token).await?, TOKEN_DECIMALS);
@@ -67,23 +64,15 @@ async fn test_b20_factory_create_and_transfer_via_rpc() -> Result<()> {
     Ok(())
 }
 
-const MINT_AMOUNT: u64 = 500_000;
-const BURN_AMOUNT: u64 = 200_000;
-const APPROVE_AMOUNT: u64 = 50_000_000;
-const SPENDER_TRANSFER_AMOUNT: u64 = 30_000_000;
-const MEMO_TRANSFER_AMOUNT: u64 = 111_000;
-const INITIAL_SUPPLY_CAP: u64 = 2_000_000_000;
-const PAUSE_TRANSFER_AMOUNT: u64 = 10_000;
-
 #[tokio::test]
 async fn test_b20_token_metadata() -> Result<()> {
-    let devnet = B20Devnet::start().await?;
+    let (_devnet, provider) = common::start_beryl_devnet().await?;
     let admin = PrivateKeySigner::from_bytes(&ANVIL_ACCOUNT_5.private_key)
         .wrap_err("Failed to parse admin key")?;
-    devnet.wait_for_balance(admin.address()).await?;
+    common::wait_for_balance(&provider, admin.address()).await?;
 
-    let b20 = B20PrecompileClient::new(devnet.provider(), &admin, L2_CHAIN_ID)
-        .with_receipt_timeout(TX_RECEIPT_TIMEOUT);
+    let b20 = B20PrecompileClient::new(&provider, &admin, common::L2_CHAIN_ID)
+        .with_receipt_timeout(common::TX_RECEIPT_TIMEOUT);
     let salt = B256::repeat_byte(0x10);
     let params = B20PrecompileClient::token_params(
         "Metadata Token",
@@ -94,7 +83,7 @@ async fn test_b20_token_metadata() -> Result<()> {
     );
 
     let token = b20.create_token(TokenVariant::B20, params, salt).await?;
-    b20.wait_for_token_code(token, TX_RECEIPT_TIMEOUT, BLOCK_POLL_INTERVAL).await?;
+    b20.wait_for_token_code(token, common::TX_RECEIPT_TIMEOUT, common::BLOCK_POLL_INTERVAL).await?;
 
     assert_eq!(b20.name(token).await?, "Metadata Token");
     assert_eq!(b20.symbol(token).await?, "META");
@@ -105,19 +94,19 @@ async fn test_b20_token_metadata() -> Result<()> {
 
 #[tokio::test]
 async fn test_b20_approve_and_transfer_from() -> Result<()> {
-    let devnet = B20Devnet::start().await?;
+    let (_devnet, provider) = common::start_beryl_devnet().await?;
     let admin = PrivateKeySigner::from_bytes(&ANVIL_ACCOUNT_5.private_key)
         .wrap_err("Failed to parse admin key")?;
     let spender =
         PrivateKeySigner::from_bytes(&ANVIL_ACCOUNT_7.private_key).wrap_err("spender key")?;
     let recipient = ANVIL_ACCOUNT_6.address;
-    devnet.wait_for_balance(admin.address()).await?;
-    devnet.wait_for_balance(spender.address()).await?;
+    common::wait_for_balance(&provider, admin.address()).await?;
+    common::wait_for_balance(&provider, spender.address()).await?;
 
-    let b20_admin = B20PrecompileClient::new(devnet.provider(), &admin, L2_CHAIN_ID)
-        .with_receipt_timeout(TX_RECEIPT_TIMEOUT);
-    let b20_spender = B20PrecompileClient::new(devnet.provider(), &spender, L2_CHAIN_ID)
-        .with_receipt_timeout(TX_RECEIPT_TIMEOUT);
+    let b20_admin = B20PrecompileClient::new(&provider, &admin, common::L2_CHAIN_ID)
+        .with_receipt_timeout(common::TX_RECEIPT_TIMEOUT);
+    let b20_spender = B20PrecompileClient::new(&provider, &spender, common::L2_CHAIN_ID)
+        .with_receipt_timeout(common::TX_RECEIPT_TIMEOUT);
 
     let salt = B256::repeat_byte(0x11);
     let params = B20PrecompileClient::token_params(
@@ -128,7 +117,9 @@ async fn test_b20_approve_and_transfer_from() -> Result<()> {
         admin.address(),
     );
     let token = b20_admin.create_token(TokenVariant::B20, params, salt).await?;
-    b20_admin.wait_for_token_code(token, TX_RECEIPT_TIMEOUT, BLOCK_POLL_INTERVAL).await?;
+    b20_admin
+        .wait_for_token_code(token, common::TX_RECEIPT_TIMEOUT, common::BLOCK_POLL_INTERVAL)
+        .await?;
 
     let approve_amount = U256::from(APPROVE_AMOUNT);
     let transfer_amount = U256::from(SPENDER_TRANSFER_AMOUNT);
@@ -156,13 +147,13 @@ async fn test_b20_approve_and_transfer_from() -> Result<()> {
 
 #[tokio::test]
 async fn test_b20_mint_and_burn() -> Result<()> {
-    let devnet = B20Devnet::start().await?;
+    let (_devnet, provider) = common::start_beryl_devnet().await?;
     let admin = PrivateKeySigner::from_bytes(&ANVIL_ACCOUNT_5.private_key)
         .wrap_err("Failed to parse admin key")?;
-    devnet.wait_for_balance(admin.address()).await?;
+    common::wait_for_balance(&provider, admin.address()).await?;
 
-    let b20 = B20PrecompileClient::new(devnet.provider(), &admin, L2_CHAIN_ID)
-        .with_receipt_timeout(TX_RECEIPT_TIMEOUT);
+    let b20 = B20PrecompileClient::new(&provider, &admin, common::L2_CHAIN_ID)
+        .with_receipt_timeout(common::TX_RECEIPT_TIMEOUT);
     let salt = B256::repeat_byte(0x12);
     let params = B20PrecompileClient::token_params(
         "Mintable Token",
@@ -172,7 +163,7 @@ async fn test_b20_mint_and_burn() -> Result<()> {
         admin.address(),
     );
     let token = b20.create_token(TokenVariant::B20, params, salt).await?;
-    b20.wait_for_token_code(token, TX_RECEIPT_TIMEOUT, BLOCK_POLL_INTERVAL).await?;
+    b20.wait_for_token_code(token, common::TX_RECEIPT_TIMEOUT, common::BLOCK_POLL_INTERVAL).await?;
 
     let supply_before = b20.total_supply(token).await?;
 
@@ -198,14 +189,14 @@ async fn test_b20_mint_and_burn() -> Result<()> {
 
 #[tokio::test]
 async fn test_b20_transfer_with_memo() -> Result<()> {
-    let devnet = B20Devnet::start().await?;
+    let (_devnet, provider) = common::start_beryl_devnet().await?;
     let admin = PrivateKeySigner::from_bytes(&ANVIL_ACCOUNT_5.private_key)
         .wrap_err("Failed to parse admin key")?;
     let recipient = ANVIL_ACCOUNT_6.address;
-    devnet.wait_for_balance(admin.address()).await?;
+    common::wait_for_balance(&provider, admin.address()).await?;
 
-    let b20 = B20PrecompileClient::new(devnet.provider(), &admin, L2_CHAIN_ID)
-        .with_receipt_timeout(TX_RECEIPT_TIMEOUT);
+    let b20 = B20PrecompileClient::new(&provider, &admin, common::L2_CHAIN_ID)
+        .with_receipt_timeout(common::TX_RECEIPT_TIMEOUT);
     let salt = B256::repeat_byte(0x13);
     let params = B20PrecompileClient::token_params(
         "Memo Token",
@@ -215,7 +206,7 @@ async fn test_b20_transfer_with_memo() -> Result<()> {
         admin.address(),
     );
     let token = b20.create_token(TokenVariant::B20, params, salt).await?;
-    b20.wait_for_token_code(token, TX_RECEIPT_TIMEOUT, BLOCK_POLL_INTERVAL).await?;
+    b20.wait_for_token_code(token, common::TX_RECEIPT_TIMEOUT, common::BLOCK_POLL_INTERVAL).await?;
 
     let memo = B256::repeat_byte(0xde);
     let amount = U256::from(MEMO_TRANSFER_AMOUNT);
@@ -229,13 +220,13 @@ async fn test_b20_transfer_with_memo() -> Result<()> {
 
 #[tokio::test]
 async fn test_b20_supply_cap() -> Result<()> {
-    let devnet = B20Devnet::start().await?;
+    let (_devnet, provider) = common::start_beryl_devnet().await?;
     let admin = PrivateKeySigner::from_bytes(&ANVIL_ACCOUNT_5.private_key)
         .wrap_err("Failed to parse admin key")?;
-    devnet.wait_for_balance(admin.address()).await?;
+    common::wait_for_balance(&provider, admin.address()).await?;
 
-    let b20 = B20PrecompileClient::new(devnet.provider(), &admin, L2_CHAIN_ID)
-        .with_receipt_timeout(TX_RECEIPT_TIMEOUT);
+    let b20 = B20PrecompileClient::new(&provider, &admin, common::L2_CHAIN_ID)
+        .with_receipt_timeout(common::TX_RECEIPT_TIMEOUT);
     let salt = B256::repeat_byte(0x14);
     let mut params = B20PrecompileClient::token_params(
         "Capped Token",
@@ -248,7 +239,7 @@ async fn test_b20_supply_cap() -> Result<()> {
     params.supplyCap = U256::from(INITIAL_SUPPLY_CAP);
 
     let token = b20.create_token(TokenVariant::B20, params, salt).await?;
-    b20.wait_for_token_code(token, TX_RECEIPT_TIMEOUT, BLOCK_POLL_INTERVAL).await?;
+    b20.wait_for_token_code(token, common::TX_RECEIPT_TIMEOUT, common::BLOCK_POLL_INTERVAL).await?;
 
     assert_eq!(b20.supply_cap(token).await?, U256::from(INITIAL_SUPPLY_CAP));
 
@@ -278,13 +269,13 @@ async fn test_b20_supply_cap() -> Result<()> {
 
 #[tokio::test]
 async fn test_b20_metadata_updates() -> Result<()> {
-    let devnet = B20Devnet::start().await?;
+    let (_devnet, provider) = common::start_beryl_devnet().await?;
     let admin = PrivateKeySigner::from_bytes(&ANVIL_ACCOUNT_5.private_key)
         .wrap_err("Failed to parse admin key")?;
-    devnet.wait_for_balance(admin.address()).await?;
+    common::wait_for_balance(&provider, admin.address()).await?;
 
-    let b20 = B20PrecompileClient::new(devnet.provider(), &admin, L2_CHAIN_ID)
-        .with_receipt_timeout(TX_RECEIPT_TIMEOUT);
+    let b20 = B20PrecompileClient::new(&provider, &admin, common::L2_CHAIN_ID)
+        .with_receipt_timeout(common::TX_RECEIPT_TIMEOUT);
     let salt = B256::repeat_byte(0x15);
     let params = B20PrecompileClient::token_params(
         "Old Name",
@@ -294,7 +285,7 @@ async fn test_b20_metadata_updates() -> Result<()> {
         admin.address(),
     );
     let token = b20.create_token(TokenVariant::B20, params, salt).await?;
-    b20.wait_for_token_code(token, TX_RECEIPT_TIMEOUT, BLOCK_POLL_INTERVAL).await?;
+    b20.wait_for_token_code(token, common::TX_RECEIPT_TIMEOUT, common::BLOCK_POLL_INTERVAL).await?;
 
     b20.set_name(token, "New Name").await?;
     b20.set_symbol(token, "NEW").await?;
@@ -309,14 +300,14 @@ async fn test_b20_metadata_updates() -> Result<()> {
 
 #[tokio::test]
 async fn test_b20_pause_and_unpause() -> Result<()> {
-    let devnet = B20Devnet::start().await?;
+    let (_devnet, provider) = common::start_beryl_devnet().await?;
     let admin = PrivateKeySigner::from_bytes(&ANVIL_ACCOUNT_5.private_key)
         .wrap_err("Failed to parse admin key")?;
     let recipient = ANVIL_ACCOUNT_6.address;
-    devnet.wait_for_balance(admin.address()).await?;
+    common::wait_for_balance(&provider, admin.address()).await?;
 
-    let b20 = B20PrecompileClient::new(devnet.provider(), &admin, L2_CHAIN_ID)
-        .with_receipt_timeout(TX_RECEIPT_TIMEOUT);
+    let b20 = B20PrecompileClient::new(&provider, &admin, common::L2_CHAIN_ID)
+        .with_receipt_timeout(common::TX_RECEIPT_TIMEOUT);
     let salt = B256::repeat_byte(0x16);
     let mut params = B20PrecompileClient::token_params(
         "Pausable Token",
@@ -328,7 +319,7 @@ async fn test_b20_pause_and_unpause() -> Result<()> {
     params.capabilities = CAPABILITY_PAUSABLE;
 
     let token = b20.create_token(TokenVariant::B20, params, salt).await?;
-    b20.wait_for_token_code(token, TX_RECEIPT_TIMEOUT, BLOCK_POLL_INTERVAL).await?;
+    b20.wait_for_token_code(token, common::TX_RECEIPT_TIMEOUT, common::BLOCK_POLL_INTERVAL).await?;
 
     // Transfer succeeds before pause.
     b20.transfer(token, recipient, U256::from(PAUSE_TRANSFER_AMOUNT)).await?;
@@ -359,13 +350,13 @@ async fn test_b20_pause_and_unpause() -> Result<()> {
 
 #[tokio::test]
 async fn test_b20_factory_predict_and_is_b20() -> Result<()> {
-    let devnet = B20Devnet::start().await?;
+    let (_devnet, provider) = common::start_beryl_devnet().await?;
     let admin = PrivateKeySigner::from_bytes(&ANVIL_ACCOUNT_5.private_key)
         .wrap_err("Failed to parse admin key")?;
-    devnet.wait_for_balance(admin.address()).await?;
+    common::wait_for_balance(&provider, admin.address()).await?;
 
-    let b20 = B20PrecompileClient::new(devnet.provider(), &admin, L2_CHAIN_ID)
-        .with_receipt_timeout(TX_RECEIPT_TIMEOUT);
+    let b20 = B20PrecompileClient::new(&provider, &admin, common::L2_CHAIN_ID)
+        .with_receipt_timeout(common::TX_RECEIPT_TIMEOUT);
     let salt = B256::repeat_byte(0x17);
     let params = B20PrecompileClient::token_params(
         "Predict Token",
@@ -382,7 +373,7 @@ async fn test_b20_factory_predict_and_is_b20() -> Result<()> {
     assert_eq!(local_prediction, rpc_prediction, "local and RPC predictions should match");
 
     let token = b20.create_token(TokenVariant::B20, params, salt).await?;
-    b20.wait_for_token_code(token, TX_RECEIPT_TIMEOUT, BLOCK_POLL_INTERVAL).await?;
+    b20.wait_for_token_code(token, common::TX_RECEIPT_TIMEOUT, common::BLOCK_POLL_INTERVAL).await?;
 
     assert_eq!(token, rpc_prediction, "created token address should match prediction");
 
@@ -398,13 +389,13 @@ async fn test_b20_factory_predict_and_is_b20() -> Result<()> {
 
 #[tokio::test]
 async fn test_b20_create_token_duplicate_reverts() -> Result<()> {
-    let devnet = B20Devnet::start().await?;
+    let (_devnet, provider) = common::start_beryl_devnet().await?;
     let admin = PrivateKeySigner::from_bytes(&ANVIL_ACCOUNT_5.private_key)
         .wrap_err("Failed to parse admin key")?;
-    devnet.wait_for_balance(admin.address()).await?;
+    common::wait_for_balance(&provider, admin.address()).await?;
 
-    let b20 = B20PrecompileClient::new(devnet.provider(), &admin, L2_CHAIN_ID)
-        .with_receipt_timeout(TX_RECEIPT_TIMEOUT);
+    let b20 = B20PrecompileClient::new(&provider, &admin, common::L2_CHAIN_ID)
+        .with_receipt_timeout(common::TX_RECEIPT_TIMEOUT);
     let salt = B256::repeat_byte(0x18);
     let params = B20PrecompileClient::token_params(
         "Dup Token",
@@ -420,58 +411,4 @@ async fn test_b20_create_token_duplicate_reverts() -> Result<()> {
     assert!(second.is_err(), "creating a token with the same salt should fail");
 
     Ok(())
-}
-
-struct B20Devnet {
-    _devnet: Devnet,
-    provider: RootProvider<Base>,
-}
-
-impl B20Devnet {
-    async fn start() -> Result<Self> {
-        let devnet = DevnetBuilder::new()
-            .with_l1_chain_id(L1_CHAIN_ID)
-            .with_l2_chain_id(L2_CHAIN_ID)
-            .with_base_azul_activation_block(BASE_AZUL_ACTIVATION_BLOCK)
-            .with_base_beryl_activation_block(BASE_BERYL_ACTIVATION_BLOCK)
-            .build()
-            .await?;
-
-        let provider = devnet.l2_builder_provider()?;
-        let this = Self { _devnet: devnet, provider };
-        this.wait_for_block(BASE_BERYL_ACTIVATION_BLOCK + 1).await?;
-        Ok(this)
-    }
-
-    const fn provider(&self) -> &RootProvider<Base> {
-        &self.provider
-    }
-
-    async fn wait_for_block(&self, min_block: u64) -> Result<u64> {
-        timeout(BLOCK_PRODUCTION_TIMEOUT, async {
-            loop {
-                let block = self.provider.get_block_number().await?;
-                if block >= min_block {
-                    return Ok::<_, eyre::Error>(block);
-                }
-                sleep(BLOCK_POLL_INTERVAL).await;
-            }
-        })
-        .await
-        .wrap_err("Block production timed out")?
-    }
-
-    async fn wait_for_balance(&self, address: alloy_primitives::Address) -> Result<()> {
-        timeout(Duration::from_secs(15), async {
-            loop {
-                let balance = self.provider.get_balance(address).await?;
-                if balance > U256::ZERO {
-                    return Ok::<_, eyre::Error>(());
-                }
-                sleep(BLOCK_POLL_INTERVAL).await;
-            }
-        })
-        .await
-        .wrap_err("Timed out waiting for funded devnet account")?
-    }
 }

--- a/devnet/tests/b20_precompile.rs
+++ b/devnet/tests/b20_precompile.rs
@@ -134,7 +134,10 @@ async fn test_b20_approve_and_transfer_from() -> Result<()> {
     let transfer_amount = U256::from(SPENDER_TRANSFER_AMOUNT);
 
     b20_admin.approve(token, spender.address(), approve_amount).await?;
-    assert_eq!(b20_admin.allowance(token, admin.address(), spender.address()).await?, approve_amount);
+    assert_eq!(
+        b20_admin.allowance(token, admin.address(), spender.address()).await?,
+        approve_amount
+    );
 
     b20_spender.transfer_from(token, admin.address(), recipient, transfer_amount).await?;
 
@@ -219,10 +222,7 @@ async fn test_b20_transfer_with_memo() -> Result<()> {
     b20.transfer_with_memo(token, recipient, amount, memo).await?;
 
     assert_eq!(b20.balance_of(token, recipient).await?, amount);
-    assert_eq!(
-        b20.balance_of(token, admin.address()).await?,
-        U256::from(INITIAL_SUPPLY) - amount,
-    );
+    assert_eq!(b20.balance_of(token, admin.address()).await?, U256::from(INITIAL_SUPPLY) - amount,);
 
     Ok(())
 }
@@ -376,9 +376,9 @@ async fn test_b20_factory_predict_and_is_b20() -> Result<()> {
     );
 
     let local_prediction = b20.predict_token_address(TokenVariant::B20, TOKEN_DECIMALS, salt);
-    let rpc_prediction =
-        b20.predict_token_address_rpc(admin.address(), TokenVariant::B20, TOKEN_DECIMALS, salt)
-            .await?;
+    let rpc_prediction = b20
+        .predict_token_address_rpc(admin.address(), TokenVariant::B20, TOKEN_DECIMALS, salt)
+        .await?;
     assert_eq!(local_prediction, rpc_prediction, "local and RPC predictions should match");
 
     let token = b20.create_token(TokenVariant::B20, params, salt).await?;

--- a/devnet/tests/common/mod.rs
+++ b/devnet/tests/common/mod.rs
@@ -1,0 +1,68 @@
+//! Shared helpers for devnet integration tests.
+
+use std::time::Duration;
+
+use alloy_primitives::{Address, U256};
+use alloy_provider::{Provider, RootProvider};
+use base_common_network::Base;
+use devnet::{Devnet, DevnetBuilder};
+use eyre::{Result, WrapErr};
+use tokio::time::{sleep, timeout};
+
+pub(crate) const L1_CHAIN_ID: u64 = 1337;
+pub(crate) const L2_CHAIN_ID: u64 = 84538453;
+pub(crate) const BASE_AZUL_ACTIVATION_BLOCK: u64 = 0;
+pub(crate) const BASE_BERYL_ACTIVATION_BLOCK: u64 = 3;
+pub(crate) const BLOCK_PRODUCTION_TIMEOUT: Duration = Duration::from_secs(30);
+pub(crate) const BLOCK_POLL_INTERVAL: Duration = Duration::from_millis(500);
+pub(crate) const TX_RECEIPT_TIMEOUT: Duration = Duration::from_secs(60);
+
+/// Starts a devnet with Beryl active at block 3 and waits for block 4.
+///
+/// The returned [`Devnet`] must be kept alive for the duration of the test;
+/// dropping it shuts down the underlying containers.
+pub(crate) async fn start_beryl_devnet() -> Result<(Devnet, RootProvider<Base>)> {
+    let devnet = DevnetBuilder::new()
+        .with_l1_chain_id(L1_CHAIN_ID)
+        .with_l2_chain_id(L2_CHAIN_ID)
+        .with_base_azul_activation_block(BASE_AZUL_ACTIVATION_BLOCK)
+        .with_base_beryl_activation_block(BASE_BERYL_ACTIVATION_BLOCK)
+        .build()
+        .await?;
+    let provider = devnet.l2_builder_provider()?;
+    wait_for_block(&provider, BASE_BERYL_ACTIVATION_BLOCK + 1).await?;
+    Ok((devnet, provider))
+}
+
+/// Polls until the L2 block number reaches `min_block`.
+pub(crate) async fn wait_for_block(provider: &RootProvider<Base>, min_block: u64) -> Result<u64> {
+    timeout(BLOCK_PRODUCTION_TIMEOUT, async {
+        loop {
+            let block = provider.get_block_number().await?;
+            if block >= min_block {
+                return Ok::<_, eyre::Error>(block);
+            }
+            sleep(BLOCK_POLL_INTERVAL).await;
+        }
+    })
+    .await
+    .wrap_err("Block production timed out")?
+}
+
+/// Polls until `address` has a non-zero ETH balance on the L2.
+pub(crate) async fn wait_for_balance(
+    provider: &RootProvider<Base>,
+    address: Address,
+) -> Result<()> {
+    timeout(Duration::from_secs(15), async {
+        loop {
+            let balance = provider.get_balance(address).await?;
+            if balance > U256::ZERO {
+                return Ok::<_, eyre::Error>(());
+            }
+            sleep(BLOCK_POLL_INTERVAL).await;
+        }
+    })
+    .await
+    .wrap_err("Timed out waiting for funded devnet account")?
+}

--- a/devnet/tests/policy_registry.rs
+++ b/devnet/tests/policy_registry.rs
@@ -1,35 +1,23 @@
 //! End-to-end tests for the policy registry precompile over Base node RPC.
 
-use std::time::Duration;
+mod common;
 
-use alloy_primitives::U256;
-use alloy_provider::{Provider, RootProvider};
 use alloy_signer_local::PrivateKeySigner;
 use alloy_sol_types::SolCall;
-use base_common_network::Base;
 use base_common_precompiles::{IPolicyRegistry, POLICY_REGISTRY_ADDRESS};
-use devnet::{B20PrecompileClient, Devnet, DevnetBuilder, config::ANVIL_ACCOUNT_5};
+use devnet::{B20PrecompileClient, config::ANVIL_ACCOUNT_5};
 use eyre::{Result, WrapErr};
-use tokio::time::{sleep, timeout};
-
-const L1_CHAIN_ID: u64 = 1337;
-const L2_CHAIN_ID: u64 = 84538453;
-const BASE_AZUL_ACTIVATION_BLOCK: u64 = 0;
-const BASE_BERYL_ACTIVATION_BLOCK: u64 = 3;
-const BLOCK_PRODUCTION_TIMEOUT: Duration = Duration::from_secs(30);
-const BLOCK_POLL_INTERVAL: Duration = Duration::from_millis(500);
-const TX_RECEIPT_TIMEOUT: Duration = Duration::from_secs(60);
 
 /// `helloWorld()` returns `true` once the Beryl fork is active.
 #[tokio::test]
 async fn test_policy_registry_hello_world() -> Result<()> {
-    let devnet = PolicyDevnet::start().await?;
+    let (_devnet, provider) = common::start_beryl_devnet().await?;
     let caller = PrivateKeySigner::from_bytes(&ANVIL_ACCOUNT_5.private_key)
         .wrap_err("Failed to parse devnet private key")?;
-    devnet.wait_for_balance(caller.address()).await?;
+    common::wait_for_balance(&provider, caller.address()).await?;
 
-    let client = B20PrecompileClient::new(devnet.provider(), &caller, L2_CHAIN_ID)
-        .with_receipt_timeout(TX_RECEIPT_TIMEOUT);
+    let client = B20PrecompileClient::new(&provider, &caller, common::L2_CHAIN_ID)
+        .with_receipt_timeout(common::TX_RECEIPT_TIMEOUT);
 
     let output = client.call(POLICY_REGISTRY_ADDRESS, IPolicyRegistry::helloWorldCall {}).await?;
     let result = IPolicyRegistry::helloWorldCall::abi_decode_returns(output.as_ref())
@@ -38,58 +26,4 @@ async fn test_policy_registry_hello_world() -> Result<()> {
     assert!(result, "helloWorld should return true after Beryl activation");
 
     Ok(())
-}
-
-struct PolicyDevnet {
-    _devnet: Devnet,
-    provider: RootProvider<Base>,
-}
-
-impl PolicyDevnet {
-    async fn start() -> Result<Self> {
-        let devnet = DevnetBuilder::new()
-            .with_l1_chain_id(L1_CHAIN_ID)
-            .with_l2_chain_id(L2_CHAIN_ID)
-            .with_base_azul_activation_block(BASE_AZUL_ACTIVATION_BLOCK)
-            .with_base_beryl_activation_block(BASE_BERYL_ACTIVATION_BLOCK)
-            .build()
-            .await?;
-
-        let provider = devnet.l2_builder_provider()?;
-        let this = Self { _devnet: devnet, provider };
-        this.wait_for_block(BASE_BERYL_ACTIVATION_BLOCK + 1).await?;
-        Ok(this)
-    }
-
-    const fn provider(&self) -> &RootProvider<Base> {
-        &self.provider
-    }
-
-    async fn wait_for_block(&self, min_block: u64) -> Result<u64> {
-        timeout(BLOCK_PRODUCTION_TIMEOUT, async {
-            loop {
-                let block = self.provider.get_block_number().await?;
-                if block >= min_block {
-                    return Ok::<_, eyre::Error>(block);
-                }
-                sleep(BLOCK_POLL_INTERVAL).await;
-            }
-        })
-        .await
-        .wrap_err("Block production timed out")?
-    }
-
-    async fn wait_for_balance(&self, address: alloy_primitives::Address) -> Result<()> {
-        timeout(Duration::from_secs(15), async {
-            loop {
-                let balance = self.provider.get_balance(address).await?;
-                if balance > U256::ZERO {
-                    return Ok::<_, eyre::Error>(());
-                }
-                sleep(BLOCK_POLL_INTERVAL).await;
-            }
-        })
-        .await
-        .wrap_err("Timed out waiting for funded devnet account")?
-    }
 }

--- a/devnet/tests/policy_registry.rs
+++ b/devnet/tests/policy_registry.rs
@@ -8,10 +8,7 @@ use alloy_signer_local::PrivateKeySigner;
 use alloy_sol_types::SolCall;
 use base_common_network::Base;
 use base_common_precompiles::{IPolicyRegistry, POLICY_REGISTRY_ADDRESS};
-use devnet::{
-    B20PrecompileClient, Devnet, DevnetBuilder,
-    config::ANVIL_ACCOUNT_5,
-};
+use devnet::{B20PrecompileClient, Devnet, DevnetBuilder, config::ANVIL_ACCOUNT_5};
 use eyre::{Result, WrapErr};
 use tokio::time::{sleep, timeout};
 
@@ -34,8 +31,7 @@ async fn test_policy_registry_hello_world() -> Result<()> {
     let client = B20PrecompileClient::new(devnet.provider(), &caller, L2_CHAIN_ID)
         .with_receipt_timeout(TX_RECEIPT_TIMEOUT);
 
-    let output =
-        client.call(POLICY_REGISTRY_ADDRESS, IPolicyRegistry::helloWorldCall {}).await?;
+    let output = client.call(POLICY_REGISTRY_ADDRESS, IPolicyRegistry::helloWorldCall {}).await?;
     let result = IPolicyRegistry::helloWorldCall::abi_decode_returns(output.as_ref())
         .wrap_err("Failed to decode helloWorld")?;
 

--- a/devnet/tests/policy_registry.rs
+++ b/devnet/tests/policy_registry.rs
@@ -1,0 +1,99 @@
+//! End-to-end tests for the policy registry precompile over Base node RPC.
+
+use std::time::Duration;
+
+use alloy_primitives::U256;
+use alloy_provider::{Provider, RootProvider};
+use alloy_signer_local::PrivateKeySigner;
+use alloy_sol_types::SolCall;
+use base_common_network::Base;
+use base_common_precompiles::{IPolicyRegistry, POLICY_REGISTRY_ADDRESS};
+use devnet::{
+    B20PrecompileClient, Devnet, DevnetBuilder,
+    config::ANVIL_ACCOUNT_5,
+};
+use eyre::{Result, WrapErr};
+use tokio::time::{sleep, timeout};
+
+const L1_CHAIN_ID: u64 = 1337;
+const L2_CHAIN_ID: u64 = 84538453;
+const BASE_AZUL_ACTIVATION_BLOCK: u64 = 0;
+const BASE_BERYL_ACTIVATION_BLOCK: u64 = 3;
+const BLOCK_PRODUCTION_TIMEOUT: Duration = Duration::from_secs(30);
+const BLOCK_POLL_INTERVAL: Duration = Duration::from_millis(500);
+const TX_RECEIPT_TIMEOUT: Duration = Duration::from_secs(60);
+
+/// `helloWorld()` returns `true` once the Beryl fork is active.
+#[tokio::test]
+async fn test_policy_registry_hello_world() -> Result<()> {
+    let devnet = PolicyDevnet::start().await?;
+    let caller = PrivateKeySigner::from_bytes(&ANVIL_ACCOUNT_5.private_key)
+        .wrap_err("Failed to parse devnet private key")?;
+    devnet.wait_for_balance(caller.address()).await?;
+
+    let client = B20PrecompileClient::new(devnet.provider(), &caller, L2_CHAIN_ID)
+        .with_receipt_timeout(TX_RECEIPT_TIMEOUT);
+
+    let output =
+        client.call(POLICY_REGISTRY_ADDRESS, IPolicyRegistry::helloWorldCall {}).await?;
+    let result = IPolicyRegistry::helloWorldCall::abi_decode_returns(output.as_ref())
+        .wrap_err("Failed to decode helloWorld")?;
+
+    assert!(result, "helloWorld should return true after Beryl activation");
+
+    Ok(())
+}
+
+struct PolicyDevnet {
+    _devnet: Devnet,
+    provider: RootProvider<Base>,
+}
+
+impl PolicyDevnet {
+    async fn start() -> Result<Self> {
+        let devnet = DevnetBuilder::new()
+            .with_l1_chain_id(L1_CHAIN_ID)
+            .with_l2_chain_id(L2_CHAIN_ID)
+            .with_base_azul_activation_block(BASE_AZUL_ACTIVATION_BLOCK)
+            .with_base_beryl_activation_block(BASE_BERYL_ACTIVATION_BLOCK)
+            .build()
+            .await?;
+
+        let provider = devnet.l2_builder_provider()?;
+        let this = Self { _devnet: devnet, provider };
+        this.wait_for_block(BASE_BERYL_ACTIVATION_BLOCK + 1).await?;
+        Ok(this)
+    }
+
+    const fn provider(&self) -> &RootProvider<Base> {
+        &self.provider
+    }
+
+    async fn wait_for_block(&self, min_block: u64) -> Result<u64> {
+        timeout(BLOCK_PRODUCTION_TIMEOUT, async {
+            loop {
+                let block = self.provider.get_block_number().await?;
+                if block >= min_block {
+                    return Ok::<_, eyre::Error>(block);
+                }
+                sleep(BLOCK_POLL_INTERVAL).await;
+            }
+        })
+        .await
+        .wrap_err("Block production timed out")?
+    }
+
+    async fn wait_for_balance(&self, address: alloy_primitives::Address) -> Result<()> {
+        timeout(Duration::from_secs(15), async {
+            loop {
+                let balance = self.provider.get_balance(address).await?;
+                if balance > U256::ZERO {
+                    return Ok::<_, eyre::Error>(());
+                }
+                sleep(BLOCK_POLL_INTERVAL).await;
+            }
+        })
+        .await
+        .wrap_err("Timed out waiting for funded devnet account")?
+    }
+}


### PR DESCRIPTION
## Summary

Adds 9 new end-to-end tests to the B-20 devnet suite covering ERC-20 allowance flows, mint/burn accounting, supply cap enforcement, pause/unpause gating, metadata updates, memo transfers, and token factory address prediction. Adds two new devnet test files for the activation registry (default state, admin constant, unauthorized revert) and policy registry (helloWorld post-Beryl). Extends B20PrecompileClient with 20 helper methods — including a generic try_send_call for expected-revert cases — so all precompile surfaces are exercisable from devnet tests.