### PR TITLE
feat(basectl): pause/resume conductor on all nodes

### DIFF
--- a/crates/infra/basectl/src/app/views/conductor.rs
+++ b/crates/infra/basectl/src/app/views/conductor.rs
@@ -13,9 +13,10 @@ use crate::{
     app::{Action, Resources, View},
     commands::COLOR_BASE_BLUE,
     rpc::{
-        ConductorNodeStatus, PausedPeers, ValidatorNodeStatus, conductor_pause_node,
-        conductor_resume_node, pause_sequencer_node, restart_conductor_node, start_sequencer_node,
-        stop_sequencer_node, transfer_conductor_leader, unpause_sequencer_node,
+        ConductorNodeStatus, PausedPeers, ValidatorNodeStatus, conductor_pause_all_nodes,
+        conductor_pause_node, conductor_resume_all_nodes, conductor_resume_node,
+        pause_sequencer_node, restart_conductor_node, start_sequencer_node, stop_sequencer_node,
+        transfer_conductor_leader, unpause_sequencer_node,
     },
     tui::{Keybinding, Toast},
 };
@@ -24,6 +25,8 @@ const KEYBINDINGS: &[Keybinding] = &[
     Keybinding { key: "←/→", description: "Select node" },
     Keybinding { key: "Enter", description: "Open action menu" },
     Keybinding { key: "t", description: "Transfer leader (any)" },
+    Keybinding { key: "P", description: "Pause conductor on all nodes" },
+    Keybinding { key: "R", description: "Resume conductor on all nodes" },
     Keybinding { key: "Esc", description: "Back to home" },
     Keybinding { key: "?", description: "Toggle help" },
 ];
@@ -131,6 +134,12 @@ pub enum PendingAction {
     ConductorPause(String),
     /// Resume the conductor's control loop on the named node.
     ConductorResume(String),
+    /// Pause the conductor's control loop on every node in the cluster.
+    ///
+    /// Carries the node count so the confirmation prompt can show it.
+    ConductorPauseAll(usize),
+    /// Resume the conductor's control loop on every node in the cluster.
+    ConductorResumeAll(usize),
     /// Start the sequencer at the given unsafe head hash.
     StartSequencer {
         /// Target conductor / sequencer node name.
@@ -155,6 +164,12 @@ impl PendingAction {
             Self::P2PReconnect(name) => format!("Reconnect saved peers on {name}?"),
             Self::ConductorPause(name) => format!("Pause conductor control loop on {name}?"),
             Self::ConductorResume(name) => format!("Resume conductor control loop on {name}?"),
+            Self::ConductorPauseAll(count) => {
+                format!("Pause conductor control loop on ALL {count} nodes?")
+            }
+            Self::ConductorResumeAll(count) => {
+                format!("Resume conductor control loop on ALL {count} nodes?")
+            }
             Self::StartSequencer { node, hash } => {
                 format!("Start sequencer on {node} at {hash}?")
             }
@@ -171,6 +186,7 @@ impl PendingAction {
                 | Self::RestartNode(_)
                 | Self::P2PIsolate(_)
                 | Self::ConductorPause(_)
+                | Self::ConductorPauseAll(_)
                 | Self::StopSequencer(_)
         )
     }
@@ -371,6 +387,16 @@ impl ConductorView {
                 } else {
                     self.op_pending = false;
                 }
+            }
+            PendingAction::ConductorPauseAll(_) => {
+                let (tx, rx) = mpsc::channel(1);
+                self.op_rx = Some(rx);
+                tokio::spawn(conductor_pause_all_nodes(nodes_cfg.to_vec(), tx));
+            }
+            PendingAction::ConductorResumeAll(_) => {
+                let (tx, rx) = mpsc::channel(1);
+                self.op_rx = Some(rx);
+                tokio::spawn(conductor_resume_all_nodes(nodes_cfg.to_vec(), tx));
             }
             PendingAction::StartSequencer { node: name, hash } => {
                 if let Some(node) = nodes_cfg.iter().find(|n| n.name == name).cloned() {
@@ -597,6 +623,18 @@ impl View for ConductorView {
                     button: ConfirmButton::No,
                 };
             }
+            KeyCode::Char('P') if !self.op_pending && node_count > 0 => {
+                self.overlay = Overlay::Confirm {
+                    action: PendingAction::ConductorPauseAll(node_count),
+                    button: ConfirmButton::No,
+                };
+            }
+            KeyCode::Char('R') if !self.op_pending && node_count > 0 => {
+                self.overlay = Overlay::Confirm {
+                    action: PendingAction::ConductorResumeAll(node_count),
+                    button: ConfirmButton::No,
+                };
+            }
             _ => {}
         }
 
@@ -630,7 +668,7 @@ impl View for ConductorView {
                 );
             }
         } else {
-            let conductor_height = 23u16;
+            let conductor_height = 25u16;
             let sections = Layout::default()
                 .direction(Direction::Vertical)
                 .constraints([Constraint::Length(conductor_height), Constraint::Min(0)])
@@ -722,6 +760,10 @@ fn render_footer(f: &mut Frame<'_>, area: Rect, overlay: &Overlay, op_pending: b
                 push_pair(&mut spans, "Enter", "actions");
                 spans.push(sep.clone());
                 push_pair(&mut spans, "t", "transfer (any)");
+                spans.push(sep.clone());
+                push_pair(&mut spans, "P", "pause all");
+                spans.push(sep.clone());
+                push_pair(&mut spans, "R", "resume all");
             }
         }
         Overlay::ActionMenu { .. } => {
@@ -972,6 +1014,13 @@ fn render_cluster_table(
 
     let inner = block.inner(area);
     f.render_widget(block, area);
+
+    let inner_chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Length(1), Constraint::Length(1), Constraint::Min(0)])
+        .split(inner);
+    render_pause_all_banner(f, inner_chunks[0], nodes, op_pending);
+    let inner = inner_chunks[2];
 
     debug_assert!(!nodes.is_empty(), "render_cluster_table requires at least one node");
     let node_count = nodes.len();
@@ -1317,6 +1366,57 @@ fn render_cluster_table(
     let table = Table::new(rows, constraints).header(header).row_highlight_style(Style::default());
 
     f.render_stateful_widget(table, inner, &mut TableState::default());
+}
+
+/// Renders the cluster-wide control-loop status and the always-visible
+/// `[ P ] Pause all` / `[ R ] Resume all` button strip.
+///
+/// The status segment summarises `conductor_paused` across every node so the
+/// affordance for "pause all" is obvious without remembering a shortcut.
+fn render_pause_all_banner(
+    f: &mut Frame<'_>,
+    area: Rect,
+    nodes: &[ConductorNodeStatus],
+    op_pending: bool,
+) {
+    let total = nodes.len();
+    let paused = nodes.iter().filter(|n| n.conductor_paused == Some(true)).count();
+    let known = nodes.iter().filter(|n| n.conductor_paused.is_some()).count();
+
+    let (status_label, status_color) = if known == 0 {
+        ("control loop: status unknown".to_string(), Color::DarkGray)
+    } else if paused == total {
+        (format!("control loop: ALL PAUSED ({paused}/{total})"), Color::Cyan)
+    } else if paused == 0 {
+        (format!("control loop: ALL ACTIVE ({total}/{total})"), Color::Green)
+    } else {
+        (format!("control loop: MIXED ({paused}/{total} paused)"), Color::Yellow)
+    };
+
+    let key_style =
+        Style::default().fg(Color::Black).bg(COLOR_BASE_BLUE).add_modifier(Modifier::BOLD);
+    let label_style = Style::default().fg(COLOR_BASE_BLUE).add_modifier(Modifier::BOLD);
+    let dim = Style::default().fg(Color::DarkGray);
+    let working = Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD);
+
+    let mut spans: Vec<Span<'_>> = vec![
+        Span::styled(status_label, Style::default().fg(status_color).add_modifier(Modifier::BOLD)),
+        Span::styled("   ·   ", dim),
+    ];
+
+    if op_pending {
+        spans.push(Span::styled("[ working… ]", working));
+    } else {
+        spans.push(Span::styled(" P ", key_style));
+        spans.push(Span::raw(" "));
+        spans.push(Span::styled("Pause all", label_style));
+        spans.push(Span::styled("    ", dim));
+        spans.push(Span::styled(" R ", key_style));
+        spans.push(Span::raw(" "));
+        spans.push(Span::styled("Resume all", label_style));
+    }
+
+    f.render_widget(Paragraph::new(Line::from(spans)).alignment(Alignment::Center), area);
 }
 
 /// Builds a row that renders a tri-state `Option<bool>` per node.

--- a/crates/infra/basectl/src/app/views/conductor.rs
+++ b/crates/infra/basectl/src/app/views/conductor.rs
@@ -1383,8 +1383,17 @@ fn render_pause_all_banner(
     let paused = nodes.iter().filter(|n| n.conductor_paused == Some(true)).count();
     let known = nodes.iter().filter(|n| n.conductor_paused.is_some()).count();
 
+    let active = known - paused;
     let (status_label, status_color) = if known == 0 {
         ("control loop: status unknown".to_string(), Color::DarkGray)
+    } else if known < total {
+        (
+            format!(
+                "control loop: PARTIAL REPORT ({paused} paused, {active} active, {} unknown of {total})",
+                total - known
+            ),
+            Color::DarkGray,
+        )
     } else if paused == total {
         (format!("control loop: ALL PAUSED ({paused}/{total})"), Color::Cyan)
     } else if paused == 0 {

--- a/crates/infra/basectl/src/lib.rs
+++ b/crates/infra/basectl/src/lib.rs
@@ -35,12 +35,13 @@ pub use rpc::{
     BacklogBlock, BacklogFetchResult, BacklogProgress, BlockDaInfo, ConductorNodeStatus,
     ConductorPollUpdate, InitialBacklog, L1BlockInfo, L1ConnectionMode, LatestProposal,
     PausedPeers, ProofsSnapshot, TimestampedFlashblock, TxSummary, ValidatorNodeStatus,
-    conductor_pause_node, conductor_resume_node, decode_flashblock_transactions,
-    fetch_block_transactions, fetch_initial_backlog_with_progress, fetch_safe_and_latest,
-    pause_sequencer_node, restart_conductor_node, run_block_fetcher, run_conductor_poller,
-    run_flashblock_ws, run_flashblock_ws_timestamped, run_l1_blob_watcher, run_proofs_poller,
-    run_safe_head_poller, run_validator_poller, start_sequencer_node, stop_sequencer_node,
-    transfer_conductor_leader, unpause_sequencer_node,
+    conductor_pause_all_nodes, conductor_pause_node, conductor_resume_all_nodes,
+    conductor_resume_node, decode_flashblock_transactions, fetch_block_transactions,
+    fetch_initial_backlog_with_progress, fetch_safe_and_latest, pause_sequencer_node,
+    restart_conductor_node, run_block_fetcher, run_conductor_poller, run_flashblock_ws,
+    run_flashblock_ws_timestamped, run_l1_blob_watcher, run_proofs_poller, run_safe_head_poller,
+    run_validator_poller, start_sequencer_node, stop_sequencer_node, transfer_conductor_leader,
+    unpause_sequencer_node,
 };
 
 mod tui;

--- a/crates/infra/basectl/src/rpc.rs
+++ b/crates/infra/basectl/src/rpc.rs
@@ -849,6 +849,95 @@ pub async fn conductor_resume_node(
     let _ = result_tx.send(outcome.map_err(|e| e.to_string())).await;
 }
 
+/// Pauses op-conductor's control loop on every node in `nodes` in parallel.
+///
+/// Returns a single summary string suitable for a toast. Per-node errors are
+/// collated into the summary so an operator sees both the success count and
+/// the names of any nodes that failed. Returns `Ok` only when every node
+/// succeeded; otherwise returns `Err` with the same summary text so the TUI
+/// surfaces it as a warning.
+pub async fn conductor_pause_all_nodes(
+    nodes: Vec<ConductorNodeConfig>,
+    result_tx: mpsc::Sender<Result<String, String>>,
+) {
+    let summary = fan_out_conductor_control(nodes, "paused", |client| async move {
+        ConductorApiClient::conductor_pause(&client).await.map_err(|e| anyhow::anyhow!("{e}"))
+    })
+    .await;
+    let _ = result_tx.send(summary).await;
+}
+
+/// Resumes op-conductor's control loop on every node in `nodes` in parallel.
+///
+/// Mirrors [`conductor_pause_all_nodes`] in error handling and summary format.
+pub async fn conductor_resume_all_nodes(
+    nodes: Vec<ConductorNodeConfig>,
+    result_tx: mpsc::Sender<Result<String, String>>,
+) {
+    let summary = fan_out_conductor_control(nodes, "resumed", |client| async move {
+        ConductorApiClient::conductor_resume(&client).await.map_err(|e| anyhow::anyhow!("{e}"))
+    })
+    .await;
+    let _ = result_tx.send(summary).await;
+}
+
+/// Runs a per-node conductor control RPC against every node concurrently and
+/// builds a single summary toast string.
+///
+/// `verb` is the past-tense action ("paused" / "resumed") used in the message.
+async fn fan_out_conductor_control<F, Fut>(
+    nodes: Vec<ConductorNodeConfig>,
+    verb: &'static str,
+    call: F,
+) -> Result<String, String>
+where
+    F: Fn(jsonrpsee::http_client::HttpClient) -> Fut + Send + Sync + Clone + 'static,
+    Fut: std::future::Future<Output = anyhow::Result<()>> + Send,
+{
+    const TIMEOUT: Duration = Duration::from_secs(5);
+
+    if nodes.is_empty() {
+        return Err(format!("no conductor nodes to {verb}"));
+    }
+    let total = nodes.len();
+
+    let results: Vec<(String, anyhow::Result<()>)> = stream::iter(nodes.into_iter())
+        .map(|node| {
+            let call = call.clone();
+            async move {
+                let outcome: anyhow::Result<()> = async {
+                    let client = HttpClientBuilder::default()
+                        .request_timeout(TIMEOUT)
+                        .build(node.conductor_rpc.as_str())
+                        .map_err(|e| anyhow::anyhow!("{e}"))?;
+                    call(client).await
+                }
+                .await;
+                (node.name, outcome)
+            }
+        })
+        .buffer_unordered(total.max(1))
+        .collect()
+        .await;
+
+    let (ok, failures): (Vec<_>, Vec<_>) = results.into_iter().partition(|(_, r)| r.is_ok());
+    let ok_count = ok.len();
+
+    if failures.is_empty() {
+        Ok(format!("conductor {verb} on {ok_count}/{total} nodes"))
+    } else {
+        let detail = failures
+            .iter()
+            .map(|(name, r)| {
+                let err = r.as_ref().err().map_or_else(String::new, ToString::to_string);
+                format!("{name}: {err}")
+            })
+            .collect::<Vec<_>>()
+            .join("; ");
+        Err(format!("conductor {verb} on {ok_count}/{total} nodes; failures: {detail}"))
+    }
+}
+
 /// Starts the sequencer on a single node via `admin_startSequencer`.
 ///
 /// The `unsafe_head` hash must match the node's current engine unsafe head; the

--- a/crates/infra/basectl/src/rpc.rs
+++ b/crates/infra/basectl/src/rpc.rs
@@ -901,7 +901,7 @@ where
     }
     let total = nodes.len();
 
-    let results: Vec<(String, anyhow::Result<()>)> = stream::iter(nodes.into_iter())
+    let results: Vec<(String, anyhow::Result<()>)> = stream::iter(nodes)
         .map(|node| {
             let call = call.clone();
             async move {


### PR DESCRIPTION
## Summary

Adds a cluster-wide pause/resume capability for the op-conductor control loop to the `basectl` conductor view, with a deliberately visible UI so operators don't need to remember a shortcut.

- New `conductor_pause_all_nodes` / `conductor_resume_all_nodes` RPC helpers fan out in parallel across every configured conductor node (works for both static and discovered cluster modes) and emit a single summary toast. If any node errors, the summary lists per-node failures and the toast is rendered as a warning.
- New `P` / `R` shortcuts on the conductor view open the existing confirm overlay (pause-all is treated as destructive  red Yes).
- Visibility (the main ask of this PR):
  - An always-visible banner at the top of the `HA Conductor` block summarises the cluster-wide control-loop state (`ALL ACTIVE` / `ALL PAUSED (n/total)` / `MIXED (paused/total paused)` / `status unknown`, colour-coded) and renders the `[ P ] Pause all` and `[ R ] Resume all` button affordances directly next to it.
  - The footer hint adds `P pause all  R resume all`.
  - The `?` help adds the two new keybindings.
  - When an op is in flight, the banner replaces the buttons with `[ working ]`, consistent with the existing `op_pending` single-flight gate.

## Non-goals

- No per-node `P`/`R` shortcuts (per-node pause/resume is already reachable via `Enter`  Conductor Pause / Resume).
- No auto-resume timers.
- Validator nodes are untouched (no conductor to drive).

## Testing

- `cargo check -p basectl-cli`
- `cargo clippy -p basectl-cli --all-targets -- -D warnings`
- `cargo test -p basectl-cli` (20 passed, 0 failed)
- `cargo fmt -p basectl-cli -- --check`