### PR TITLE
chore(devnet): pass -c devnet to basectl conductor

### DIFF
--- a/etc/docker/Justfile
+++ b/etc/docker/Justfile
@@ -72,7 +72,7 @@ transfer-leader to='':
 
 # TUI dashboard: HA conductor cluster monitor (requires devnet running)
 conductor:
-    cargo run --quiet -p basectl -- conductor
+    cargo run --quiet -p basectl -- -c devnet conductor
 
 # Stops devnet+ingress, deletes data, and starts fresh with full ingress stack
 ingress: ingress-down _build-setup-image (_build-rust-images "ingress" "dev")


### PR DESCRIPTION
## Summary
- `just conductor` now invokes `basectl -c devnet conductor` so the TUI targets the devnet cluster by default.