### PR TITLE
fix(common): Align Token Factory ABI

### DIFF
--- a/actions/harness/tests/beryl/env.rs
+++ b/actions/harness/tests/beryl/env.rs
@@ -400,14 +400,14 @@ impl BerylTestEnv {
 
     fn create_b20_token_call_with_salt(&self, salt: B256) -> ITokenFactory::createTokenCall {
         ITokenFactory::createTokenCall {
-            params: ITokenFactory::CreateTokenParams {
-                version: TokenFactoryStorage::CREATE_TOKEN_VERSION,
-                variant: TokenVariant::B20.discriminant(),
-                requiredParams: self.b20_token_params().abi_encode().into(),
-                optionalParams: Bytes::new(),
-                postCreateCalls: Vec::new(),
-                salt,
-            },
+            variant: ITokenFactory::TokenVariant::DEFAULT,
+            salt,
+            params: self.b20_token_params().abi_encode().into(),
+            initCalls: vec![
+                IB20::mintCall { to: Self::alice(), amount: U256::from(Self::B20_INITIAL_SUPPLY) }
+                    .abi_encode()
+                    .into(),
+            ],
         }
     }
 
@@ -454,18 +454,13 @@ impl BerylTestEnv {
             .unwrap_or_else(|| panic!("user tx receipt {user_tx_index} must exist"))
     }
 
-    fn b20_token_params(&self) -> ITokenFactory::B20TokenParams {
-        ITokenFactory::B20TokenParams {
+    fn b20_token_params(&self) -> ITokenFactory::B20CreateParams {
+        ITokenFactory::B20CreateParams {
+            version: TokenFactoryStorage::CREATE_TOKEN_VERSION,
             name: "Action B20".to_string(),
             symbol: "AB20".to_string(),
+            initialAdmin: Self::alice(),
             decimals: Self::B20_DECIMALS,
-            admin: Self::alice(),
-            capabilities: U256::ZERO,
-            initialSupply: U256::from(Self::B20_INITIAL_SUPPLY),
-            initialSupplyRecipient: Self::alice(),
-            supplyCap: U256::MAX,
-            minimumRedeemable: U256::ZERO,
-            contractURI: String::new(),
         }
     }
 

--- a/crates/common/precompiles/benches/base_precompiles.rs
+++ b/crates/common/precompiles/benches/base_precompiles.rs
@@ -2,12 +2,11 @@
 
 use std::hint::black_box;
 
-use alloy_primitives::{Address, B256, Bytes, U256};
+use alloy_primitives::{Address, B256, U256};
 use alloy_sol_types::SolValue;
 use base_common_precompiles::{
-    B20Token, B20TokenStorage, Burnable, CAPABILITY_CAP_MUTABLE, CAPABILITY_PAUSABLE, Configurable,
-    ITokenFactory, Mintable, Pausable, PolicyHandle, Token, TokenAccounting, TokenFactoryStorage,
-    TokenVariant, Transferable,
+    B20Token, B20TokenStorage, Burnable, Configurable, ITokenFactory, Mintable, Pausable,
+    PolicyHandle, Token, TokenAccounting, TokenFactoryStorage, TokenVariant, Transferable,
 };
 use base_precompile_storage::{HashMapStorageProvider, StorageCtx};
 use criterion::{Criterion, criterion_group, criterion_main};
@@ -27,41 +26,39 @@ impl BaseTokenBenchSetup {
         Address::repeat_byte(0xcd)
     }
 
-    fn token_params(
-        name: &str,
-        symbol: &str,
-        decimals: u8,
-        initial_supply: U256,
-    ) -> ITokenFactory::B20TokenParams {
-        ITokenFactory::B20TokenParams {
+    fn token_params(name: &str, symbol: &str, decimals: u8) -> ITokenFactory::B20CreateParams {
+        ITokenFactory::B20CreateParams {
+            version: TokenFactoryStorage::CREATE_TOKEN_VERSION,
             name: name.to_string(),
             symbol: symbol.to_string(),
+            initialAdmin: Self::admin(),
             decimals,
-            admin: Self::admin(),
-            capabilities: CAPABILITY_PAUSABLE | CAPABILITY_CAP_MUTABLE,
-            initialSupply: initial_supply,
-            initialSupplyRecipient: Self::initial_supply_recipient(),
-            supplyCap: U256::MAX,
-            minimumRedeemable: U256::ZERO,
-            contractURI: "ipfs://base-token".to_string(),
         }
     }
 
     fn create_b20(
         ctx: StorageCtx<'_>,
         caller: Address,
-        params: ITokenFactory::B20TokenParams,
+        params: ITokenFactory::B20CreateParams,
         salt: B256,
+        initial_supply: U256,
     ) -> Address {
+        let mut init_calls = Vec::new();
+        if initial_supply > U256::ZERO {
+            init_calls.push(
+                base_common_precompiles::IB20::mintCall {
+                    to: Self::initial_supply_recipient(),
+                    amount: initial_supply,
+                }
+                .abi_encode()
+                .into(),
+            );
+        }
         let call = ITokenFactory::createTokenCall {
-            params: ITokenFactory::CreateTokenParams {
-                version: TokenFactoryStorage::CREATE_TOKEN_VERSION,
-                variant: TokenVariant::B20.discriminant(),
-                requiredParams: params.abi_encode().into(),
-                optionalParams: Bytes::new(),
-                postCreateCalls: Vec::new(),
-                salt,
-            },
+            variant: ITokenFactory::TokenVariant::DEFAULT,
+            salt,
+            params: params.abi_encode().into(),
+            initCalls: init_calls,
         };
         let mut factory = TokenFactoryStorage::new(ctx);
         factory.create_token(caller, call).unwrap()
@@ -72,10 +69,9 @@ impl BaseTokenBenchSetup {
         salt: B256,
         initial_supply: U256,
     ) -> B20Token<B20TokenStorage<'a>, PolicyHandle<'a>> {
-        let mut params = Self::token_params("BaseToken", "BASE", 18, initial_supply);
-        params.minimumRedeemable = U256::ONE;
+        let params = Self::token_params("BaseToken", "BASE", 18);
 
-        let token_address = Self::create_b20(ctx, Self::caller(), params, salt);
+        let token_address = Self::create_b20(ctx, Self::caller(), params, salt, initial_supply);
         Self::token_at(ctx, token_address)
     }
 
@@ -446,9 +442,8 @@ fn base_token_factory_mutate(c: &mut Criterion) {
             b.iter(|| {
                 counter += 1;
                 let salt = B256::from(U256::from(counter));
-                let params =
-                    BaseTokenBenchSetup::token_params("FactoryToken", "FACT", 18, U256::ZERO);
-                let token = BaseTokenBenchSetup::create_b20(ctx, caller, params, salt);
+                let params = BaseTokenBenchSetup::token_params("FactoryToken", "FACT", 18);
+                let token = BaseTokenBenchSetup::create_b20(ctx, caller, params, salt, U256::ZERO);
                 black_box(token);
             });
         });
@@ -495,12 +490,13 @@ fn base_token_factory_view(c: &mut Criterion) {
     c.bench_function("base_token_factory_is_b20", |b| {
         let mut storage = HashMapStorageProvider::new(1);
         StorageCtx::enter(&mut storage, |ctx| {
-            let params = BaseTokenBenchSetup::token_params("FactoryToken", "FACT", 18, U256::ZERO);
+            let params = BaseTokenBenchSetup::token_params("FactoryToken", "FACT", 18);
             let token_address = BaseTokenBenchSetup::create_b20(
                 ctx,
                 BaseTokenBenchSetup::caller(),
                 params,
                 B256::repeat_byte(0x24),
+                U256::ZERO,
             );
             let factory = TokenFactoryStorage::new(ctx);
 

--- a/crates/common/precompiles/benches/base_precompiles.rs
+++ b/crates/common/precompiles/benches/base_precompiles.rs
@@ -3,7 +3,7 @@
 use std::hint::black_box;
 
 use alloy_primitives::{Address, B256, U256};
-use alloy_sol_types::SolValue;
+use alloy_sol_types::{SolCall, SolValue};
 use base_common_precompiles::{
     B20Token, B20TokenStorage, Burnable, Configurable, ITokenFactory, Mintable, Pausable,
     PolicyHandle, Token, TokenAccounting, TokenFactoryStorage, TokenVariant, Transferable,
@@ -509,22 +509,17 @@ fn base_token_factory_view(c: &mut Criterion) {
         });
     });
 
-    c.bench_function("base_token_factory_variant_of", |b| {
-        let mut storage = HashMapStorageProvider::new(1);
-        StorageCtx::enter(&mut storage, |ctx| {
-            let factory = TokenFactoryStorage::new(ctx);
-            let (token_address, _) = TokenVariant::B20.compute_address(
-                BaseTokenBenchSetup::caller(),
-                18,
-                B256::repeat_byte(0x25),
-            );
+    c.bench_function("base_token_factory_get_token_variant", |b| {
+        let (token_address, _) = TokenVariant::B20.compute_address(
+            BaseTokenBenchSetup::caller(),
+            18,
+            B256::repeat_byte(0x25),
+        );
 
-            b.iter(|| {
-                let factory = black_box(&factory);
-                let token_address = black_box(token_address);
-                let result = factory.variant_of_token(token_address).unwrap();
-                black_box(result);
-            });
+        b.iter(|| {
+            let token_address = black_box(token_address);
+            let result = TokenVariant::from_address(token_address);
+            black_box(result);
         });
     });
 }

--- a/crates/common/precompiles/src/b20/precompile.rs
+++ b/crates/common/precompiles/src/b20/precompile.rs
@@ -20,6 +20,10 @@ impl B20TokenPrecompile {
     }
 
     /// Returns the B-20 token precompile for `address`, if the address encodes a supported token.
+    ///
+    /// Stablecoin and security discriminants route through the shared B-20 dispatcher because those
+    /// variants inherit the base B-20 surface. Until their factory creation arms are enabled, calls
+    /// to undeployed addresses still fail the token initialization guard.
     pub fn lookup(address: &Address) -> Option<DynPrecompile> {
         TokenVariant::from_address(*address).map(|variant| match variant {
             TokenVariant::B20 | TokenVariant::Stablecoin | TokenVariant::Security => {

--- a/crates/common/precompiles/src/b20/precompile.rs
+++ b/crates/common/precompiles/src/b20/precompile.rs
@@ -22,7 +22,9 @@ impl B20TokenPrecompile {
     /// Returns the B-20 token precompile for `address`, if the address encodes a supported token.
     pub fn lookup(address: &Address) -> Option<DynPrecompile> {
         TokenVariant::from_address(*address).map(|variant| match variant {
-            TokenVariant::B20 => Self::create_precompile(*address),
+            TokenVariant::B20 | TokenVariant::Stablecoin | TokenVariant::Security => {
+                Self::create_precompile(*address)
+            }
         })
     }
 

--- a/crates/common/precompiles/src/factory/abi.rs
+++ b/crates/common/precompiles/src/factory/abi.rs
@@ -79,6 +79,11 @@ sol! {
         // ── Functions ────────────────────────────────────────────────────────
 
         /// Creates a B-20 token of the requested variant at a deterministic address.
+        ///
+        /// Default tokens start with an unbounded supply cap and the pausable plus mutable-cap
+        /// capability bits enabled. Callers configure optional launch state atomically through
+        /// `initCalls`, such as minting initial supply, lowering the supply cap, pausing, or setting
+        /// metadata.
         function createToken(
             TokenVariant variant,
             bytes32 salt,

--- a/crates/common/precompiles/src/factory/abi.rs
+++ b/crates/common/precompiles/src/factory/abi.rs
@@ -60,6 +60,9 @@ sol! {
         /// A required string argument was empty.
         error MissingRequiredField();
 
+        /// `params` could not be decoded for the requested token variant.
+        error InvalidTokenParams();
+
         /// One of the post-creation init calls failed.
         error InitCallFailed(uint256 index);
 

--- a/crates/common/precompiles/src/factory/abi.rs
+++ b/crates/common/precompiles/src/factory/abi.rs
@@ -7,86 +7,90 @@ sol! {
     interface ITokenFactory {
         // ── Structs ─────────────────────────────────────────────────────────
 
-        struct B20TokenParams {
-            string name;
-            string symbol;
-            uint8 decimals;
-            address admin;
-            uint256 capabilities;
-            uint256 initialSupply;
-            address initialSupplyRecipient;
-            uint256 supplyCap;
-            uint256 minimumRedeemable;
-            string contractURI;
+        enum TokenVariant {
+            /// Address is not a factory-created B-20 token.
+            NONE,
+            /// Default B-20 token variant.
+            DEFAULT,
+            /// Stablecoin B-20 token variant.
+            STABLECOIN,
+            /// Security B-20 token variant.
+            SECURITY
         }
 
-        struct CreateTokenParams {
+        struct B20CreateParams {
             uint8 version;
-            uint8 variant;
-            bytes requiredParams;
-            bytes optionalParams;
-            bytes[] postCreateCalls;
-            bytes32 salt;
+            string name;
+            string symbol;
+            address initialAdmin;
+            uint8 decimals;
+        }
+
+        struct B20StablecoinCreateParams {
+            uint8 version;
+            string name;
+            string symbol;
+            address initialAdmin;
+            string currency;
+        }
+
+        struct B20SecurityCreateParams {
+            uint8 version;
+            string name;
+            string symbol;
+            address initialAdmin;
+            string isin;
+            uint256 minimumRedeemable;
         }
 
         // ── Errors ───────────────────────────────────────────────────────────
 
-        /// A token is already deployed at the address derived from `(variant, caller, salt)`.
+        /// A token already exists at the address derived from `(variant, decimals, msg.sender, salt)`.
         error TokenAlreadyExists(address token);
 
-        /// The derived address falls in the reserved range (lower 8 bytes < 1024).
-        error AddressReserved(address token);
+        /// `variant` is not recognized or is `NONE`.
+        error InvalidVariant();
 
-        /// `supplyCap` is below `initialSupply`.
-        error InvalidSupplyCap();
+        /// `version` is not supported for the requested variant.
+        error UnsupportedVersion(uint8 version);
 
-        /// A required address argument was `address(0)`.
-        error ZeroAddress();
+        /// `decimals` is outside the supported range.
+        error InvalidDecimals(uint8 decimals);
 
-        /// `version` is not supported by this factory.
-        error UnsupportedTokenVersion(uint8 version);
+        /// A required string argument was empty.
+        error MissingRequiredField();
 
-        /// `variant` is not supported by this factory.
-        error UnsupportedTokenVariant(uint8 variant);
-
-        /// Optional parameter bytes are reserved for future versions.
-        error UnsupportedOptionalParams();
-
-        /// `requiredParams` could not be decoded for the requested token shape.
-        error InvalidTokenParams();
+        /// One of the post-creation init calls failed.
+        error InitCallFailed(uint256 index);
 
         // ── Events ───────────────────────────────────────────────────────────
 
         event TokenCreated(
             address indexed token,
-            address indexed creator,
-            address indexed admin,
-            uint8 variant,
-            uint8 decimals,
+            TokenVariant indexed variant,
             string name,
             string symbol,
-            uint256 capabilities,
-            uint256 initialSupply,
-            bytes32 salt
+            uint8 decimals
         );
 
         // ── Functions ────────────────────────────────────────────────────────
 
-        /// Creates a token at a deterministic address.
-        function createToken(CreateTokenParams calldata params) external returns (address token);
+        /// Creates a B-20 token of the requested variant at a deterministic address.
+        function createToken(
+            TokenVariant variant,
+            bytes32 salt,
+            bytes calldata params,
+            bytes[] calldata initCalls
+        ) external returns (address token);
 
         /// Returns the address a `createToken` call would produce.
-        function predictTokenAddress(address creator, uint8 variant, uint8 decimals, bytes32 salt) external view returns (address);
+        function getTokenAddress(TokenVariant variant, uint8 decimals, address sender, bytes32 salt) external view returns (address);
 
-        /// Returns `true` if `token` is a deployed B-20 token (correct prefix + code at address).
+        /// Returns `true` if `token` has the B-20 address prefix.
         function isB20(address token) external view returns (bool);
 
-        /// Returns the variant of `token` (0=NONE, 1=DEFAULT).
+        /// Returns the variant of `token` or `NONE` if it is not a B-20 token.
         /// Decoded from the address prefix with no storage read.
-        function variantOf(address token) external view returns (uint8);
-
-        /// Returns the decimals encoded in `token`.
-        /// Decoded from the address prefix with no storage read.
-        function decimalsOf(address token) external view returns (uint8);
+        function getTokenVariant(address token) external view returns (TokenVariant);
     }
 }

--- a/crates/common/precompiles/src/factory/dispatch.rs
+++ b/crates/common/precompiles/src/factory/dispatch.rs
@@ -35,13 +35,10 @@ impl<'a> TokenFactoryStorage<'a> {
                 Ok(ITokenFactory::createTokenCall::abi_encode_returns(&token).into())
             }
             Ok(ITokenFactory::ITokenFactoryCalls::getTokenAddress(call)) => {
-                let variant = call.variant as u8;
-                let (addr, _) = TokenVariant::compute_address_for_discriminant(
-                    call.sender,
-                    variant,
-                    call.decimals,
-                    call.salt,
-                );
+                let Some(variant) = TokenFactoryStorage::token_variant(call.variant) else {
+                    return Err(BasePrecompileError::revert(ITokenFactory::InvalidVariant {}));
+                };
+                let (addr, _) = variant.compute_address(call.sender, call.decimals, call.salt);
                 Ok(ITokenFactory::getTokenAddressCall::abi_encode_returns(&addr).into())
             }
             Ok(ITokenFactory::ITokenFactoryCalls::isB20(call)) => {

--- a/crates/common/precompiles/src/factory/dispatch.rs
+++ b/crates/common/precompiles/src/factory/dispatch.rs
@@ -34,26 +34,24 @@ impl<'a> TokenFactoryStorage<'a> {
                 let token = self.create_token(caller, call)?;
                 Ok(ITokenFactory::createTokenCall::abi_encode_returns(&token).into())
             }
-            Ok(ITokenFactory::ITokenFactoryCalls::predictTokenAddress(call)) => {
+            Ok(ITokenFactory::ITokenFactoryCalls::getTokenAddress(call)) => {
+                let variant = call.variant as u8;
                 let (addr, _) = TokenVariant::compute_address_for_discriminant(
-                    call.creator,
-                    call.variant,
+                    call.sender,
+                    variant,
                     call.decimals,
                     call.salt,
                 );
-                Ok(ITokenFactory::predictTokenAddressCall::abi_encode_returns(&addr).into())
+                Ok(ITokenFactory::getTokenAddressCall::abi_encode_returns(&addr).into())
             }
             Ok(ITokenFactory::ITokenFactoryCalls::isB20(call)) => {
                 let result = self.is_b20(call.token)?;
                 Ok(ITokenFactory::isB20Call::abi_encode_returns(&result).into())
             }
-            Ok(ITokenFactory::ITokenFactoryCalls::variantOf(call)) => {
-                let v = self.variant_of_token(call.token)?;
-                Ok(ITokenFactory::variantOfCall::abi_encode_returns(&v).into())
-            }
-            Ok(ITokenFactory::ITokenFactoryCalls::decimalsOf(call)) => {
-                let decimals = self.decimals_of_token(call.token)?;
-                Ok(ITokenFactory::decimalsOfCall::abi_encode_returns(&decimals).into())
+            Ok(ITokenFactory::ITokenFactoryCalls::getTokenVariant(call)) => {
+                let variant =
+                    TokenFactoryStorage::abi_variant(TokenVariant::from_address(call.token));
+                Ok(ITokenFactory::getTokenVariantCall::abi_encode_returns(&variant).into())
             }
             Err(_) => Err(BasePrecompileError::UnknownFunctionSelector(selector)),
         }

--- a/crates/common/precompiles/src/factory/storage.rs
+++ b/crates/common/precompiles/src/factory/storage.rs
@@ -7,10 +7,7 @@ use base_precompile_storage::{BasePrecompileError, Handler, Result};
 use revm::state::Bytecode;
 
 use super::variant::TokenVariant;
-use crate::{
-    B20Token, B20TokenStorage, CAPABILITY_CAP_MUTABLE, CAPABILITY_PAUSABLE, ITokenFactory,
-    PolicyHandle,
-};
+use crate::{B20Token, B20TokenStorage, ITokenFactory, PolicyHandle};
 
 /// The B-20 token factory precompile.
 #[contract(addr = Self::ADDRESS)]
@@ -22,6 +19,12 @@ impl<'a> TokenFactoryStorage<'a> {
 
     /// Current token creation parameter version.
     pub const CREATE_TOKEN_VERSION: u8 = 1;
+
+    /// Initial supply cap for newly created default B-20 tokens.
+    pub const DEFAULT_SUPPLY_CAP: U256 = U256::MAX;
+
+    /// Initial capability bits for newly created default B-20 tokens.
+    pub const DEFAULT_CAPABILITIES: U256 = U256::from_limbs([3, 0, 0, 0]);
 
     /// Creates a token at a deterministic address derived from `(caller, variant, decimals, salt)`.
     pub fn create_token(
@@ -50,8 +53,8 @@ impl<'a> TokenFactoryStorage<'a> {
         let mut token = B20TokenStorage::from_address(token_address, self.storage);
         token.name.write(token_params.0.clone())?;
         token.symbol.write(token_params.1.clone())?;
-        token.supply_cap.write(U256::MAX)?;
-        token.capabilities.write(CAPABILITY_CAP_MUTABLE | CAPABILITY_PAUSABLE)?;
+        token.supply_cap.write(Self::DEFAULT_SUPPLY_CAP)?;
+        token.capabilities.write(Self::DEFAULT_CAPABILITIES)?;
 
         self.emit_event(ITokenFactory::TokenCreated {
             token: token_address,
@@ -304,6 +307,8 @@ mod tests {
             assert_eq!(token.name.read().unwrap(), "My Token");
             assert_eq!(token.symbol.read().unwrap(), "MYT");
             assert_eq!(token.decimals().unwrap(), 6);
+            assert_eq!(token.supply_cap().unwrap(), TokenFactoryStorage::DEFAULT_SUPPLY_CAP);
+            assert_eq!(token.capabilities().unwrap(), TokenFactoryStorage::DEFAULT_CAPABILITIES);
             assert_eq!(TokenVariant::decimals_of(token_addr), Some(6));
         });
     }

--- a/crates/common/precompiles/src/factory/storage.rs
+++ b/crates/common/precompiles/src/factory/storage.rs
@@ -316,6 +316,7 @@ mod tests {
     #[test]
     fn test_create_token_init_calls_can_mint_supply() {
         let mut storage = HashMapStorageProvider::new(1);
+        activate_precompiles(&mut storage);
         let caller = Address::repeat_byte(0x55);
         let salt = B256::repeat_byte(0xCC);
         let recipient = Address::repeat_byte(0xCD);
@@ -388,6 +389,7 @@ mod tests {
     #[test]
     fn test_create_token_reverts_for_invalid_params_encoding() {
         let mut storage = HashMapStorageProvider::new(1);
+        activate_precompiles(&mut storage);
         let call = ITokenFactory::createTokenCall {
             variant: ITokenFactory::TokenVariant::DEFAULT,
             salt: B256::repeat_byte(0x04),
@@ -406,6 +408,7 @@ mod tests {
     #[test]
     fn test_create_token_reverts_for_missing_required_fields() {
         let mut storage = HashMapStorageProvider::new(1);
+        activate_precompiles(&mut storage);
 
         StorageCtx::enter(&mut storage, |ctx| {
             let missing_name = create_call(
@@ -433,6 +436,7 @@ mod tests {
     #[test]
     fn test_create_token_reverts_for_unimplemented_variants() {
         let mut storage = HashMapStorageProvider::new(1);
+        activate_precompiles(&mut storage);
 
         let stablecoin_params = ITokenFactory::B20StablecoinCreateParams {
             version: TokenFactoryStorage::CREATE_TOKEN_VERSION,

--- a/crates/common/precompiles/src/factory/storage.rs
+++ b/crates/common/precompiles/src/factory/storage.rs
@@ -78,17 +78,11 @@ impl<'a> TokenFactoryStorage<'a> {
         Ok(token_address)
     }
 
-    /// Returns whether `token` has the B-20 prefix.
+    /// Returns whether `token` has the structural B-20 prefix.
+    ///
+    /// This includes reserved or future variant discriminants in the B-20 address range.
     pub fn is_b20(&self, token: Address) -> Result<bool> {
         Ok(TokenVariant::has_b20_prefix(token))
-    }
-
-    /// Returns the variant discriminant for `token` decoded from its address prefix.
-    pub fn variant_of_token(&self, token: Address) -> Result<u8> {
-        let Some(variant) = TokenVariant::from_address(token) else {
-            return Ok(TokenVariant::NONE_DISCRIMINANT);
-        };
-        Ok(variant.discriminant())
     }
 
     pub(super) const fn token_variant(
@@ -96,9 +90,10 @@ impl<'a> TokenFactoryStorage<'a> {
     ) -> Option<TokenVariant> {
         match variant {
             ITokenFactory::TokenVariant::DEFAULT => Some(TokenVariant::B20),
-            ITokenFactory::TokenVariant::STABLECOIN => Some(TokenVariant::Stablecoin),
-            ITokenFactory::TokenVariant::SECURITY => Some(TokenVariant::Security),
-            ITokenFactory::TokenVariant::NONE | ITokenFactory::TokenVariant::__Invalid => None,
+            ITokenFactory::TokenVariant::NONE
+            | ITokenFactory::TokenVariant::STABLECOIN
+            | ITokenFactory::TokenVariant::SECURITY
+            | ITokenFactory::TokenVariant::__Invalid => None,
         }
     }
 
@@ -114,9 +109,15 @@ impl<'a> TokenFactoryStorage<'a> {
     fn decode_create_params(variant: TokenVariant, params: &Bytes) -> Result<(String, String, u8)> {
         match variant {
             TokenVariant::B20 => {
-                let params = ITokenFactory::B20CreateParams::abi_decode(params)
-                    .map_err(|_| BasePrecompileError::revert(ITokenFactory::InvalidVariant {}))?;
+                let params = ITokenFactory::B20CreateParams::abi_decode(params).map_err(|_| {
+                    BasePrecompileError::revert(ITokenFactory::InvalidTokenParams {})
+                })?;
                 Self::check_version(params.version)?;
+                if params.name.is_empty() || params.symbol.is_empty() {
+                    return Err(BasePrecompileError::revert(
+                        ITokenFactory::MissingRequiredField {},
+                    ));
+                }
                 if params.decimals < 2 || params.decimals > 18 {
                     return Err(BasePrecompileError::revert(ITokenFactory::InvalidDecimals {
                         decimals: params.decimals,
@@ -125,20 +126,8 @@ impl<'a> TokenFactoryStorage<'a> {
                 // TODO: validate and wire initialAdmin into token ownership/policy setup.
                 Ok((params.name, params.symbol, params.decimals))
             }
-            TokenVariant::Stablecoin => {
-                let params = ITokenFactory::B20StablecoinCreateParams::abi_decode(params)
-                    .map_err(|_| BasePrecompileError::revert(ITokenFactory::InvalidVariant {}))?;
-                Self::check_version(params.version)?;
-                if params.currency.is_empty() {
-                    return Err(BasePrecompileError::revert(
-                        ITokenFactory::MissingRequiredField {},
-                    ));
-                }
-                // TODO: validate and wire initialAdmin into token ownership/policy setup.
-                Ok((params.name, params.symbol, 6))
-            }
-            TokenVariant::Security => {
-                Err(BasePrecompileError::revert(ITokenFactory::UnsupportedVersion { version: 0 }))
+            TokenVariant::Stablecoin | TokenVariant::Security => {
+                Err(BasePrecompileError::revert(ITokenFactory::InvalidVariant {}))
             }
         }
     }
@@ -392,9 +381,67 @@ mod tests {
     }
 
     #[test]
-    fn test_create_token_reverts_for_security_variant_as_deferred() {
+    fn test_create_token_reverts_for_invalid_params_encoding() {
+        let mut storage = HashMapStorageProvider::new(1);
+        let call = ITokenFactory::createTokenCall {
+            variant: ITokenFactory::TokenVariant::DEFAULT,
+            salt: B256::repeat_byte(0x04),
+            params: Bytes::from_static(&[0xde, 0xad, 0xbe, 0xef]),
+            initCalls: Vec::new(),
+        };
+
+        StorageCtx::enter(&mut storage, |ctx| {
+            assert_output(
+                dispatch_factory_revert(ctx, call),
+                ITokenFactory::InvalidTokenParams {}.abi_encode(),
+            );
+        });
+    }
+
+    #[test]
+    fn test_create_token_reverts_for_missing_required_fields() {
         let mut storage = HashMapStorageProvider::new(1);
 
+        StorageCtx::enter(&mut storage, |ctx| {
+            let missing_name = create_call(
+                ITokenFactory::TokenVariant::DEFAULT,
+                token_params("", "BAD", 18),
+                B256::repeat_byte(0x05),
+            );
+            let missing_symbol = create_call(
+                ITokenFactory::TokenVariant::DEFAULT,
+                token_params("Bad Symbol", "", 18),
+                B256::repeat_byte(0x06),
+            );
+
+            assert_output(
+                dispatch_factory_revert(ctx, missing_name),
+                ITokenFactory::MissingRequiredField {}.abi_encode(),
+            );
+            assert_output(
+                dispatch_factory_revert(ctx, missing_symbol),
+                ITokenFactory::MissingRequiredField {}.abi_encode(),
+            );
+        });
+    }
+
+    #[test]
+    fn test_create_token_reverts_for_unimplemented_variants() {
+        let mut storage = HashMapStorageProvider::new(1);
+
+        let stablecoin_params = ITokenFactory::B20StablecoinCreateParams {
+            version: TokenFactoryStorage::CREATE_TOKEN_VERSION,
+            name: "Stablecoin Token".to_string(),
+            symbol: "USD".to_string(),
+            initialAdmin: Address::repeat_byte(0xAB),
+            currency: "USD".to_string(),
+        };
+        let stablecoin_call = ITokenFactory::createTokenCall {
+            variant: ITokenFactory::TokenVariant::STABLECOIN,
+            salt: B256::repeat_byte(0x06),
+            params: stablecoin_params.abi_encode().into(),
+            initCalls: Vec::new(),
+        };
         let security_params = ITokenFactory::B20SecurityCreateParams {
             version: TokenFactoryStorage::CREATE_TOKEN_VERSION,
             name: "Security Token".to_string(),
@@ -405,15 +452,19 @@ mod tests {
         };
         let security_call = ITokenFactory::createTokenCall {
             variant: ITokenFactory::TokenVariant::SECURITY,
-            salt: B256::repeat_byte(0x06),
+            salt: B256::repeat_byte(0x07),
             params: security_params.abi_encode().into(),
             initCalls: Vec::new(),
         };
 
         StorageCtx::enter(&mut storage, |ctx| {
             assert_output(
+                dispatch_factory_revert(ctx, stablecoin_call),
+                ITokenFactory::InvalidVariant {}.abi_encode(),
+            );
+            assert_output(
                 dispatch_factory_revert(ctx, security_call),
-                ITokenFactory::UnsupportedVersion { version: 0 }.abi_encode(),
+                ITokenFactory::InvalidVariant {}.abi_encode(),
             );
         });
     }
@@ -450,7 +501,22 @@ mod tests {
 
             let token = factory.create_token(caller, b20_call(salt)).unwrap();
             assert!(factory.is_b20(token).unwrap());
-            assert_eq!(factory.variant_of_token(token).unwrap(), TokenVariant::B20.discriminant());
+            assert_eq!(TokenVariant::from_address(token), Some(TokenVariant::B20));
+        });
+    }
+
+    #[test]
+    fn test_is_b20_accepts_future_structural_prefixes() {
+        let mut storage = HashMapStorageProvider::new(1);
+        let caller = Address::repeat_byte(0x55);
+        let salt = B256::repeat_byte(0x13);
+        let (future_variant, _) =
+            TokenVariant::compute_address_for_discriminant(caller, 0xff, 18, salt);
+
+        StorageCtx::enter(&mut storage, |ctx| {
+            let factory = TokenFactoryStorage::new(ctx);
+            assert!(factory.is_b20(future_variant).unwrap());
+            assert_eq!(TokenVariant::from_address(future_variant), None);
         });
     }
 
@@ -568,6 +634,18 @@ mod tests {
                     },
                 ),
                 ITokenFactory::getTokenAddressCall::abi_encode_returns(&expected_token),
+            );
+            assert_output(
+                dispatch_factory_revert(
+                    ctx,
+                    ITokenFactory::getTokenAddressCall {
+                        variant: ITokenFactory::TokenVariant::NONE,
+                        decimals: 6,
+                        sender: creator,
+                        salt,
+                    },
+                ),
+                ITokenFactory::InvalidVariant {}.abi_encode(),
             );
 
             assert_output(

--- a/crates/common/precompiles/src/factory/storage.rs
+++ b/crates/common/precompiles/src/factory/storage.rs
@@ -1,3 +1,5 @@
+use alloc::string::String;
+
 use alloy_primitives::{Address, Bytes, U256, address};
 use alloy_sol_types::SolValue;
 use base_precompile_macros::contract;
@@ -5,7 +7,10 @@ use base_precompile_storage::{BasePrecompileError, Handler, Result};
 use revm::state::Bytecode;
 
 use super::variant::TokenVariant;
-use crate::{B20Token, B20TokenStorage, ITokenFactory, PolicyHandle, TokenAccounting};
+use crate::{
+    B20Token, B20TokenStorage, CAPABILITY_CAP_MUTABLE, CAPABILITY_PAUSABLE, ITokenFactory,
+    PolicyHandle,
+};
 
 /// The B-20 token factory precompile.
 #[contract(addr = Self::ADDRESS)]
@@ -13,13 +18,10 @@ pub struct TokenFactoryStorage {}
 
 impl<'a> TokenFactoryStorage<'a> {
     /// Singleton precompile address for the `TokenFactory`.
-    pub const ADDRESS: Address = address!("b02f000000000000000000000000000000000000");
+    pub const ADDRESS: Address = address!("b20f00000000000000000000000000000000000f");
 
     /// Current token creation parameter version.
     pub const CREATE_TOKEN_VERSION: u8 = 1;
-
-    /// Addresses whose lower-8-byte value is reserved for protocol bootstrap tokens.
-    pub const RESERVED_SIZE: u64 = 1024;
 
     /// Creates a token at a deterministic address derived from `(caller, variant, decimals, salt)`.
     pub fn create_token(
@@ -27,39 +29,11 @@ impl<'a> TokenFactoryStorage<'a> {
         caller: Address,
         call: ITokenFactory::createTokenCall,
     ) -> Result<Address> {
-        let p = call.params;
-        if p.version != Self::CREATE_TOKEN_VERSION {
-            return Err(BasePrecompileError::revert(ITokenFactory::UnsupportedTokenVersion {
-                version: p.version,
-            }));
-        }
-        let Some(variant) = TokenVariant::from_discriminant(p.variant) else {
-            return Err(BasePrecompileError::revert(ITokenFactory::UnsupportedTokenVariant {
-                variant: p.variant,
-            }));
+        let Some(variant) = Self::token_variant(call.variant) else {
+            return Err(BasePrecompileError::revert(ITokenFactory::InvalidVariant {}));
         };
-        if !p.optionalParams.is_empty() {
-            return Err(BasePrecompileError::revert(ITokenFactory::UnsupportedOptionalParams {}));
-        }
-
-        let token_params = ITokenFactory::B20TokenParams::abi_decode(&p.requiredParams)
-            .map_err(|_| BasePrecompileError::revert(ITokenFactory::InvalidTokenParams {}))?;
-
-        if token_params.admin.is_zero() {
-            return Err(BasePrecompileError::revert(ITokenFactory::ZeroAddress {}));
-        }
-        if token_params.supplyCap < token_params.initialSupply {
-            return Err(BasePrecompileError::revert(ITokenFactory::InvalidSupplyCap {}));
-        }
-
-        let (token_address, lower_bytes) =
-            variant.compute_address(caller, token_params.decimals, p.salt);
-
-        if lower_bytes < Self::RESERVED_SIZE {
-            return Err(BasePrecompileError::revert(ITokenFactory::AddressReserved {
-                token: token_address,
-            }));
-        }
+        let token_params = Self::decode_create_params(variant, &call.params)?;
+        let (token_address, _) = variant.compute_address(caller, token_params.2, call.salt);
 
         let already_deployed =
             self.storage.with_account_info(token_address, |info| Ok(!info.is_empty_code_hash()))?;
@@ -74,52 +48,39 @@ impl<'a> TokenFactoryStorage<'a> {
         self.storage.set_code(token_address, stub)?;
 
         let mut token = B20TokenStorage::from_address(token_address, self.storage);
-        token.name.write(token_params.name.clone())?;
-        token.symbol.write(token_params.symbol.clone())?;
-        token.supply_cap.write(token_params.supplyCap)?;
-        token.capabilities.write(token_params.capabilities)?;
-        token.minimum_redeemable.write(token_params.minimumRedeemable)?;
-        token.contract_uri.write(token_params.contractURI.clone())?;
+        token.name.write(token_params.0.clone())?;
+        token.symbol.write(token_params.1.clone())?;
+        token.supply_cap.write(U256::MAX)?;
+        token.capabilities.write(CAPABILITY_CAP_MUTABLE | CAPABILITY_PAUSABLE)?;
 
-        if token_params.initialSupply > U256::ZERO {
-            if token_params.initialSupplyRecipient.is_zero() {
-                return Err(BasePrecompileError::revert(ITokenFactory::ZeroAddress {}));
-            }
-            token.total_supply.write(token_params.initialSupply)?;
-            token.set_balance(token_params.initialSupplyRecipient, token_params.initialSupply)?;
-        }
+        self.emit_event(ITokenFactory::TokenCreated {
+            token: token_address,
+            variant: call.variant,
+            name: token_params.0,
+            symbol: token_params.1,
+            decimals: token_params.2,
+        })?;
 
-        for calldata in p.postCreateCalls {
+        for (index, calldata) in call.initCalls.into_iter().enumerate() {
             B20Token::with_storage_and_policy(
                 B20TokenStorage::from_address(token_address, self.storage),
                 PolicyHandle::new(self.storage),
             )
-            .inner(self.storage, &calldata)?;
+            .inner(self.storage, &calldata)
+            .map_err(|_| {
+                BasePrecompileError::revert(ITokenFactory::InitCallFailed {
+                    index: U256::from(index),
+                })
+            })?;
         }
-
-        self.emit_event(ITokenFactory::TokenCreated {
-            token: token_address,
-            creator: caller,
-            admin: token_params.admin,
-            variant: p.variant,
-            decimals: token_params.decimals,
-            name: token_params.name,
-            symbol: token_params.symbol,
-            capabilities: token_params.capabilities,
-            initialSupply: token_params.initialSupply,
-            salt: p.salt,
-        })?;
 
         checkpoint.commit();
         Ok(token_address)
     }
 
-    /// Returns whether `token` is a deployed B-20 token (prefix match + non-empty code).
+    /// Returns whether `token` has the B-20 prefix.
     pub fn is_b20(&self, token: Address) -> Result<bool> {
-        if !TokenVariant::is_b20_address(token) {
-            return Ok(false);
-        }
-        self.storage.with_account_info(token, |info| Ok(!info.is_empty_code_hash()))
+        Ok(TokenVariant::has_b20_prefix(token))
     }
 
     /// Returns the variant discriminant for `token` decoded from its address prefix.
@@ -130,9 +91,63 @@ impl<'a> TokenFactoryStorage<'a> {
         Ok(variant.discriminant())
     }
 
-    /// Returns the decimals encoded in `token`.
-    pub fn decimals_of_token(&self, token: Address) -> Result<u8> {
-        Ok(TokenVariant::decimals_of(token).unwrap_or(0))
+    pub(super) const fn token_variant(
+        variant: ITokenFactory::TokenVariant,
+    ) -> Option<TokenVariant> {
+        match variant {
+            ITokenFactory::TokenVariant::DEFAULT => Some(TokenVariant::B20),
+            ITokenFactory::TokenVariant::STABLECOIN => Some(TokenVariant::Stablecoin),
+            ITokenFactory::TokenVariant::SECURITY => Some(TokenVariant::Security),
+            ITokenFactory::TokenVariant::NONE | ITokenFactory::TokenVariant::__Invalid => None,
+        }
+    }
+
+    pub(super) const fn abi_variant(variant: Option<TokenVariant>) -> ITokenFactory::TokenVariant {
+        match variant {
+            Some(TokenVariant::B20) => ITokenFactory::TokenVariant::DEFAULT,
+            Some(TokenVariant::Stablecoin) => ITokenFactory::TokenVariant::STABLECOIN,
+            Some(TokenVariant::Security) => ITokenFactory::TokenVariant::SECURITY,
+            None => ITokenFactory::TokenVariant::NONE,
+        }
+    }
+
+    fn decode_create_params(variant: TokenVariant, params: &Bytes) -> Result<(String, String, u8)> {
+        match variant {
+            TokenVariant::B20 => {
+                let params = ITokenFactory::B20CreateParams::abi_decode(params)
+                    .map_err(|_| BasePrecompileError::revert(ITokenFactory::InvalidVariant {}))?;
+                Self::check_version(params.version)?;
+                if params.decimals < 2 || params.decimals > 18 {
+                    return Err(BasePrecompileError::revert(ITokenFactory::InvalidDecimals {
+                        decimals: params.decimals,
+                    }));
+                }
+                // TODO: validate and wire initialAdmin into token ownership/policy setup.
+                Ok((params.name, params.symbol, params.decimals))
+            }
+            TokenVariant::Stablecoin => {
+                let params = ITokenFactory::B20StablecoinCreateParams::abi_decode(params)
+                    .map_err(|_| BasePrecompileError::revert(ITokenFactory::InvalidVariant {}))?;
+                Self::check_version(params.version)?;
+                if params.currency.is_empty() {
+                    return Err(BasePrecompileError::revert(
+                        ITokenFactory::MissingRequiredField {},
+                    ));
+                }
+                // TODO: validate and wire initialAdmin into token ownership/policy setup.
+                Ok((params.name, params.symbol, 6))
+            }
+            TokenVariant::Security => {
+                Err(BasePrecompileError::revert(ITokenFactory::UnsupportedVersion { version: 0 }))
+            }
+        }
+    }
+
+    fn check_version(version: u8) -> Result<()> {
+        if version != Self::CREATE_TOKEN_VERSION {
+            return Err(BasePrecompileError::revert(ITokenFactory::UnsupportedVersion { version }));
+        }
+        Ok(())
     }
 }
 
@@ -164,50 +179,31 @@ mod tests {
         });
     }
 
-    fn token_params(
-        name: &str,
-        symbol: &str,
-        decimals: u8,
-        initial_supply: U256,
-        supply_cap: U256,
-    ) -> ITokenFactory::B20TokenParams {
-        ITokenFactory::B20TokenParams {
+    fn token_params(name: &str, symbol: &str, decimals: u8) -> ITokenFactory::B20CreateParams {
+        ITokenFactory::B20CreateParams {
+            version: TokenFactoryStorage::CREATE_TOKEN_VERSION,
             name: name.to_string(),
             symbol: symbol.to_string(),
+            initialAdmin: Address::repeat_byte(0xAB),
             decimals,
-            admin: Address::repeat_byte(0xAB),
-            capabilities: U256::ZERO,
-            initialSupply: initial_supply,
-            initialSupplyRecipient: Address::repeat_byte(0xCD),
-            supplyCap: supply_cap,
-            minimumRedeemable: U256::ZERO,
-            contractURI: "ipfs://test".to_string(),
         }
     }
 
     fn create_call(
-        variant: u8,
-        params: ITokenFactory::B20TokenParams,
+        variant: ITokenFactory::TokenVariant,
+        params: ITokenFactory::B20CreateParams,
         salt: B256,
     ) -> ITokenFactory::createTokenCall {
         ITokenFactory::createTokenCall {
-            params: ITokenFactory::CreateTokenParams {
-                version: TokenFactoryStorage::CREATE_TOKEN_VERSION,
-                variant,
-                requiredParams: params.abi_encode().into(),
-                optionalParams: Bytes::new(),
-                postCreateCalls: Vec::new(),
-                salt,
-            },
+            variant,
+            salt,
+            params: params.abi_encode().into(),
+            initCalls: Vec::new(),
         }
     }
 
     fn b20_call(salt: B256) -> ITokenFactory::createTokenCall {
-        create_call(
-            TokenVariant::B20.discriminant(),
-            token_params("Test", "TST", 18, U256::from(1000), U256::MAX),
-            salt,
-        )
+        create_call(ITokenFactory::TokenVariant::DEFAULT, token_params("Test", "TST", 18), salt)
     }
 
     fn token_at<'a>(
@@ -251,7 +247,7 @@ mod tests {
         let salt = B256::repeat_byte(0x22);
         let (addr, lower_bytes) = TokenVariant::B20.compute_address(creator, 6, salt);
 
-        assert!(lower_bytes >= TokenFactoryStorage::RESERVED_SIZE);
+        assert_eq!(addr.as_slice()[12..], lower_bytes.to_be_bytes());
         assert!(TokenVariant::is_b20_address(addr));
         assert_eq!(TokenVariant::from_address(addr), Some(TokenVariant::B20));
         assert_eq!(TokenVariant::decimals_of(addr), Some(6));
@@ -270,20 +266,18 @@ mod tests {
     }
 
     #[test]
-    fn test_unsupported_variants_are_not_b20_prefixes() {
+    fn test_supported_variants_are_b20_prefixes() {
         let creator = Address::repeat_byte(0x11);
         let salt = B256::repeat_byte(0x44);
-        let (unsupported_stablecoin, _) =
-            TokenVariant::compute_address_for_discriminant(creator, 2, 18, salt);
-        let (unsupported_security, _) =
-            TokenVariant::compute_address_for_discriminant(creator, 3, 18, salt);
+        let (stablecoin, _) = TokenVariant::compute_address_for_discriminant(creator, 2, 18, salt);
+        let (security, _) = TokenVariant::compute_address_for_discriminant(creator, 3, 18, salt);
 
-        assert!(!TokenVariant::is_supported_discriminant(2));
-        assert!(!TokenVariant::is_supported_discriminant(3));
-        assert!(!TokenVariant::is_b20_address(unsupported_stablecoin));
-        assert!(!TokenVariant::is_b20_address(unsupported_security));
-        assert_eq!(TokenVariant::from_address(unsupported_stablecoin), None);
-        assert_eq!(TokenVariant::from_address(unsupported_security), None);
+        assert!(TokenVariant::is_supported_discriminant(2));
+        assert!(TokenVariant::is_supported_discriminant(3));
+        assert!(TokenVariant::is_b20_address(stablecoin));
+        assert!(TokenVariant::is_b20_address(security));
+        assert_eq!(TokenVariant::from_address(stablecoin), Some(TokenVariant::Stablecoin));
+        assert_eq!(TokenVariant::from_address(security), Some(TokenVariant::Security));
     }
 
     #[test]
@@ -308,8 +302,8 @@ mod tests {
         let caller = Address::repeat_byte(0x55);
         let salt = B256::repeat_byte(0xBB);
         let call = create_call(
-            TokenVariant::B20.discriminant(),
-            token_params("My Token", "MYT", 6, U256::ZERO, U256::MAX),
+            ITokenFactory::TokenVariant::DEFAULT,
+            token_params("My Token", "MYT", 6),
             salt,
         );
 
@@ -321,22 +315,23 @@ mod tests {
             assert_eq!(token.name.read().unwrap(), "My Token");
             assert_eq!(token.symbol.read().unwrap(), "MYT");
             assert_eq!(token.decimals().unwrap(), 6);
-            assert_eq!(factory.decimals_of_token(token_addr).unwrap(), 6);
+            assert_eq!(TokenVariant::decimals_of(token_addr), Some(6));
         });
     }
 
     #[test]
-    fn test_create_token_mints_initial_supply() {
+    fn test_create_token_init_calls_can_mint_supply() {
         let mut storage = HashMapStorageProvider::new(1);
         let caller = Address::repeat_byte(0x55);
         let salt = B256::repeat_byte(0xCC);
         let recipient = Address::repeat_byte(0xCD);
         let supply = U256::from(5_000u64);
-        let call = create_call(
-            TokenVariant::B20.discriminant(),
-            token_params("Supply Token", "SUP", 18, supply, U256::MAX),
+        let mut call = create_call(
+            ITokenFactory::TokenVariant::DEFAULT,
+            token_params("Supply Token", "SUP", 18),
             salt,
         );
+        call.initCalls.push(IB20::mintCall { to: recipient, amount: supply }.abi_encode().into());
 
         StorageCtx::enter(&mut storage, |ctx| {
             let mut factory = TokenFactoryStorage::new(ctx);
@@ -363,24 +358,63 @@ mod tests {
     }
 
     #[test]
-    fn test_create_token_reverts_for_invalid_version_variant_and_optional_params() {
+    fn test_create_token_reverts_for_invalid_version_variant_and_decimals() {
         let mut storage = HashMapStorageProvider::new(1);
         let caller = Address::repeat_byte(0x55);
 
         StorageCtx::enter(&mut storage, |ctx| {
             let mut factory = TokenFactoryStorage::new(ctx);
 
-            let mut bad_version = b20_call(B256::repeat_byte(0x01));
-            bad_version.params.version = TokenFactoryStorage::CREATE_TOKEN_VERSION + 1;
+            let mut bad_params = token_params("Bad Version", "BAD", 18);
+            bad_params.version = TokenFactoryStorage::CREATE_TOKEN_VERSION + 1;
+            let bad_version = create_call(
+                ITokenFactory::TokenVariant::DEFAULT,
+                bad_params,
+                B256::repeat_byte(0x01),
+            );
             assert!(factory.create_token(caller, bad_version).is_err());
 
-            let mut bad_variant = b20_call(B256::repeat_byte(0x02));
-            bad_variant.params.variant = 2;
+            let bad_variant = ITokenFactory::createTokenCall {
+                variant: ITokenFactory::TokenVariant::NONE,
+                salt: B256::repeat_byte(0x02),
+                params: token_params("Bad Variant", "BAD", 18).abi_encode().into(),
+                initCalls: Vec::new(),
+            };
             assert!(factory.create_token(caller, bad_variant).is_err());
 
-            let mut unsupported_optional = b20_call(B256::repeat_byte(0x03));
-            unsupported_optional.params.optionalParams = Bytes::from_static(&[0x01]);
-            assert!(factory.create_token(caller, unsupported_optional).is_err());
+            let invalid_decimals = create_call(
+                ITokenFactory::TokenVariant::DEFAULT,
+                token_params("Bad Decimals", "BAD", 1),
+                B256::repeat_byte(0x03),
+            );
+            assert!(factory.create_token(caller, invalid_decimals).is_err());
+        });
+    }
+
+    #[test]
+    fn test_create_token_reverts_for_security_variant_as_deferred() {
+        let mut storage = HashMapStorageProvider::new(1);
+
+        let security_params = ITokenFactory::B20SecurityCreateParams {
+            version: TokenFactoryStorage::CREATE_TOKEN_VERSION,
+            name: "Security Token".to_string(),
+            symbol: "SEC".to_string(),
+            initialAdmin: Address::repeat_byte(0xAB),
+            isin: "US0000000000".to_string(),
+            minimumRedeemable: U256::ONE,
+        };
+        let security_call = ITokenFactory::createTokenCall {
+            variant: ITokenFactory::TokenVariant::SECURITY,
+            salt: B256::repeat_byte(0x06),
+            params: security_params.abi_encode().into(),
+            initCalls: Vec::new(),
+        };
+
+        StorageCtx::enter(&mut storage, |ctx| {
+            assert_output(
+                dispatch_factory_revert(ctx, security_call),
+                ITokenFactory::UnsupportedVersion { version: 0 }.abi_encode(),
+            );
         });
     }
 
@@ -391,8 +425,7 @@ mod tests {
         let caller = Address::repeat_byte(0x55);
         let salt = B256::repeat_byte(0xDD);
         let mut call = b20_call(salt);
-        call.params
-            .postCreateCalls
+        call.initCalls
             .push(IB20::setNameCall { newName: "Configured".to_string() }.abi_encode().into());
 
         StorageCtx::enter(&mut storage, |ctx| {
@@ -405,7 +438,7 @@ mod tests {
     }
 
     #[test]
-    fn test_is_b20_and_variant_false_before_create_true_after_create() {
+    fn test_is_b20_and_variant_prefix_before_and_after_create() {
         let mut storage = HashMapStorageProvider::new(1);
         let caller = Address::repeat_byte(0x55);
         let salt = B256::repeat_byte(0x11);
@@ -413,7 +446,7 @@ mod tests {
 
         StorageCtx::enter(&mut storage, |ctx| {
             let mut factory = TokenFactoryStorage::new(ctx);
-            assert!(!factory.is_b20(addr).unwrap());
+            assert!(factory.is_b20(addr).unwrap());
 
             let token = factory.create_token(caller, b20_call(salt)).unwrap();
             assert!(factory.is_b20(token).unwrap());
@@ -437,12 +470,15 @@ mod tests {
         let mut storage = HashMapStorageProvider::new(1);
         StorageCtx::enter(&mut storage, |ctx| {
             let mut factory = TokenFactoryStorage::new(ctx);
-            let mut params = token_params("Lifecycle", "LIFE", 18, U256::from(1_000u64), U256::MAX);
-            params.capabilities = U256::from(0b11u64);
+            let params = token_params("Lifecycle", "LIFE", 18);
             let token_addr = factory
                 .create_token(
                     Address::repeat_byte(0xCA),
-                    create_call(TokenVariant::B20.discriminant(), params, B256::repeat_byte(0x12)),
+                    create_call(
+                        ITokenFactory::TokenVariant::DEFAULT,
+                        params,
+                        B256::repeat_byte(0x12),
+                    ),
                 )
                 .unwrap();
 
@@ -450,6 +486,7 @@ mod tests {
             let bob = Address::repeat_byte(0xBB);
             let mut token = token_at(token_addr, ctx);
 
+            token.mint(alice, U256::from(1_000u64)).unwrap();
             token.transfer(alice, bob, U256::from(300u64)).unwrap();
             token.mint(alice, U256::from(200u64)).unwrap();
 
@@ -498,10 +535,22 @@ mod tests {
         let creator = Address::repeat_byte(0xCA);
         let salt = B256::repeat_byte(0x31);
         let (expected_token, _) = TokenVariant::B20.compute_address(creator, 6, salt);
-        let mut params =
-            token_params("Dispatch Token", "DSP", 6, U256::from(1_000u64), U256::from(10_000u64));
-        params.minimumRedeemable = U256::from(25u64);
-        params.contractURI = "ipfs://dispatch".to_string();
+        let mut call = create_call(
+            ITokenFactory::TokenVariant::DEFAULT,
+            token_params("Dispatch Token", "DSP", 6),
+            salt,
+        );
+        call.initCalls.push(
+            IB20::mintCall { to: Address::repeat_byte(0xCD), amount: U256::from(1_000u64) }
+                .abi_encode()
+                .into(),
+        );
+        call.initCalls.push(
+            IB20::setMinimumRedeemableCall { newMinimum: U256::from(25u64) }.abi_encode().into(),
+        );
+        call.initCalls.push(
+            IB20::setContractURICall { newURI: "ipfs://dispatch".to_string() }.abi_encode().into(),
+        );
 
         let mut storage = HashMapStorageProvider::new(1);
         activate_precompiles(&mut storage);
@@ -511,21 +560,18 @@ mod tests {
             assert_output(
                 dispatch_factory_success(
                     ctx,
-                    ITokenFactory::predictTokenAddressCall {
-                        creator,
-                        variant: TokenVariant::B20_DISCRIMINANT,
+                    ITokenFactory::getTokenAddressCall {
+                        variant: ITokenFactory::TokenVariant::DEFAULT,
                         decimals: 6,
+                        sender: creator,
                         salt,
                     },
                 ),
-                ITokenFactory::predictTokenAddressCall::abi_encode_returns(&expected_token),
+                ITokenFactory::getTokenAddressCall::abi_encode_returns(&expected_token),
             );
 
             assert_output(
-                dispatch_factory_success(
-                    ctx,
-                    create_call(TokenVariant::B20_DISCRIMINANT, params, B256::repeat_byte(0x31)),
-                ),
+                dispatch_factory_success(ctx, call),
                 ITokenFactory::createTokenCall::abi_encode_returns(&expected_token),
             );
             assert!(ctx.has_bytecode(expected_token).unwrap());
@@ -537,16 +583,11 @@ mod tests {
             assert_output(
                 dispatch_factory_success(
                     ctx,
-                    ITokenFactory::variantOfCall { token: expected_token },
+                    ITokenFactory::getTokenVariantCall { token: expected_token },
                 ),
-                ITokenFactory::variantOfCall::abi_encode_returns(&TokenVariant::B20_DISCRIMINANT),
-            );
-            assert_output(
-                dispatch_factory_success(
-                    ctx,
-                    ITokenFactory::decimalsOfCall { token: expected_token },
+                ITokenFactory::getTokenVariantCall::abi_encode_returns(
+                    &ITokenFactory::TokenVariant::DEFAULT,
                 ),
-                ITokenFactory::decimalsOfCall::abi_encode_returns(&6u8),
             );
 
             assert_output(
@@ -592,7 +633,7 @@ mod tests {
             let caller = Address::repeat_byte(0xCA);
             let (token_addr, lower_bytes) =
                 TokenVariant::B20.compute_address(caller, 18, B256::repeat_byte(0x09));
-            assert!(lower_bytes >= TokenFactoryStorage::RESERVED_SIZE);
+            assert_eq!(token_addr.as_slice()[12..], lower_bytes.to_be_bytes());
             assert!(!ctx.has_bytecode(token_addr).unwrap());
 
             let mut token = token_at(token_addr, ctx);
@@ -612,17 +653,20 @@ mod tests {
         let charlie = Address::repeat_byte(0xCC);
         let salt = B256::repeat_byte(0x32);
         let (token_addr, _) = TokenVariant::B20.compute_address(creator, 18, salt);
-        let params = token_params("Dispatch Token", "DSP", 18, U256::from(1_000u64), U256::MAX);
+        let mut call = create_call(
+            ITokenFactory::TokenVariant::DEFAULT,
+            token_params("Dispatch Token", "DSP", 18),
+            salt,
+        );
+        call.initCalls
+            .push(IB20::mintCall { to: alice, amount: U256::from(1_000u64) }.abi_encode().into());
 
         let mut storage = HashMapStorageProvider::new(1);
         activate_precompiles(&mut storage);
         storage.set_caller(creator);
         StorageCtx::enter(&mut storage, |ctx| {
             assert_output(
-                dispatch_factory_success(
-                    ctx,
-                    create_call(TokenVariant::B20_DISCRIMINANT, params, salt),
-                ),
+                dispatch_factory_success(ctx, call),
                 ITokenFactory::createTokenCall::abi_encode_returns(&token_addr),
             );
         });
@@ -684,8 +728,7 @@ mod tests {
     fn test_factory_dispatch_reverts_with_abi_error() {
         let creator = Address::repeat_byte(0xCA);
         let salt = B256::repeat_byte(0x33);
-        let mut params = token_params("Bad Token", "BAD", 18, U256::ZERO, U256::MAX);
-        params.admin = Address::ZERO;
+        let params = token_params("Bad Token", "BAD", 1);
 
         let mut storage = HashMapStorageProvider::new(1);
         activate_precompiles(&mut storage);
@@ -695,9 +738,9 @@ mod tests {
             assert_output(
                 dispatch_factory_revert(
                     ctx,
-                    create_call(TokenVariant::B20_DISCRIMINANT, params, salt),
+                    create_call(ITokenFactory::TokenVariant::DEFAULT, params, salt),
                 ),
-                ITokenFactory::ZeroAddress {}.abi_encode(),
+                ITokenFactory::InvalidDecimals { decimals: 1 }.abi_encode(),
             );
         });
     }

--- a/crates/common/precompiles/src/factory/variant.rs
+++ b/crates/common/precompiles/src/factory/variant.rs
@@ -9,25 +9,34 @@ use alloy_sol_types::SolValue;
 pub enum TokenVariant {
     /// B-20 token.
     B20 = 1,
+    /// Stablecoin B-20 token.
+    Stablecoin = 2,
+    /// Security B-20 token.
+    Security = 3,
 }
 
 impl TokenVariant {
     /// First byte of every B-20 address.
-    pub const PREFIX_BYTE: u8 = 0xb0;
+    pub const PREFIX_BYTE: u8 = 0xb2;
 
-    /// Second byte of every B-20 address.
-    pub const PREFIX_MARKER: u8 = 0x20;
-
-    /// Variant discriminant returned by `variantOf` when address has no B-20 prefix.
+    /// Variant discriminant returned by `getTokenVariant` when address has no B-20 prefix.
     pub const NONE_DISCRIMINANT: u8 = 0;
 
-    /// Variant discriminant for B-20 tokens.
+    /// Variant discriminant for default B-20 tokens.
     pub const B20_DISCRIMINANT: u8 = Self::B20 as u8;
+
+    /// Variant discriminant for stablecoin B-20 tokens.
+    pub const STABLECOIN_DISCRIMINANT: u8 = Self::Stablecoin as u8;
+
+    /// Variant discriminant for security B-20 tokens.
+    pub const SECURITY_DISCRIMINANT: u8 = Self::Security as u8;
 
     /// Returns the supported token variant for `variant`, if any.
     pub const fn from_discriminant(variant: u8) -> Option<Self> {
         match variant {
             Self::B20_DISCRIMINANT => Some(Self::B20),
+            Self::STABLECOIN_DISCRIMINANT => Some(Self::Stablecoin),
+            Self::SECURITY_DISCRIMINANT => Some(Self::Security),
             _ => None,
         }
     }
@@ -40,14 +49,19 @@ impl TokenVariant {
     /// Returns the token variant encoded in `address`, if it has a supported B-20 prefix.
     pub fn from_address(address: Address) -> Option<Self> {
         let bytes = address.as_slice();
-        if bytes[0] != Self::PREFIX_BYTE
-            || bytes[1] != Self::PREFIX_MARKER
-            || bytes[4..12] != [0u8; 8]
-        {
+        if bytes[0] != Self::PREFIX_BYTE || bytes[1..10] != [0u8; 9] {
             return None;
         }
 
-        Self::from_discriminant(bytes[2])
+        Self::from_discriminant(bytes[10])
+    }
+
+    /// Returns whether `address` has the structural B-20 token prefix.
+    ///
+    /// This intentionally does not validate the encoded variant discriminant.
+    pub fn has_b20_prefix(address: Address) -> bool {
+        let bytes = address.as_slice();
+        bytes[0] == Self::PREFIX_BYTE && bytes[1..10] == [0u8; 9]
     }
 
     /// Returns this variant's ABI discriminant.
@@ -57,26 +71,12 @@ impl TokenVariant {
 
     /// Builds this variant's B-20 address prefix for `decimals`.
     pub const fn address_prefix(self, decimals: u8) -> [u8; 12] {
-        [
-            Self::PREFIX_BYTE,
-            Self::PREFIX_MARKER,
-            self.discriminant(),
-            decimals,
-            0,
-            0,
-            0,
-            0,
-            0,
-            0,
-            0,
-            0,
-        ]
+        [Self::PREFIX_BYTE, 0, 0, 0, 0, 0, 0, 0, 0, 0, self.discriminant(), decimals]
     }
 
     /// Computes this variant's deterministic token address for `creator`, `decimals`, and `salt`.
     ///
-    /// Returns the address and the lower 8 bytes of the hash as a `u64` for the reserved-range
-    /// check.
+    /// Returns the address and the lower 8 bytes of the hash as a `u64`.
     pub fn compute_address(self, creator: Address, decimals: u8, salt: B256) -> (Address, u64) {
         let hash = keccak256((creator, salt).abi_encode());
 
@@ -106,9 +106,8 @@ impl TokenVariant {
 
         let mut addr_bytes = [0u8; 20];
         addr_bytes[0] = Self::PREFIX_BYTE;
-        addr_bytes[1] = Self::PREFIX_MARKER;
-        addr_bytes[2] = variant;
-        addr_bytes[3] = decimals;
+        addr_bytes[10] = variant;
+        addr_bytes[11] = decimals;
         addr_bytes[12..].copy_from_slice(&hash[..8]);
 
         (Address::from(addr_bytes), lower_bytes)
@@ -122,6 +121,6 @@ impl TokenVariant {
     /// Returns the decimals encoded in `address` when it has a supported B-20 prefix.
     pub fn decimals_of(address: Address) -> Option<u8> {
         Self::from_address(address)?;
-        Some(address.as_slice()[3])
+        Some(address.as_slice()[11])
     }
 }

--- a/devnet/src/b20.rs
+++ b/devnet/src/b20.rs
@@ -429,7 +429,7 @@ impl<'a> B20PrecompileClient<'a> {
             .wrap_err("Failed to decode getTokenAddress")
     }
 
-    fn abi_variant(variant: TokenVariant) -> ITokenFactory::TokenVariant {
+    const fn abi_variant(variant: TokenVariant) -> ITokenFactory::TokenVariant {
         match variant {
             TokenVariant::B20 => ITokenFactory::TokenVariant::DEFAULT,
             TokenVariant::Stablecoin => ITokenFactory::TokenVariant::STABLECOIN,

--- a/devnet/src/b20.rs
+++ b/devnet/src/b20.rs
@@ -108,6 +108,7 @@ impl<'a> B20PrecompileClient<'a> {
         name: &str,
         symbol: &str,
         decimals: u8,
+        initial_admin: Address,
         initial_supply: U256,
         initial_supply_recipient: Address,
     ) -> B20CreateConfig {
@@ -116,7 +117,7 @@ impl<'a> B20PrecompileClient<'a> {
                 version: TokenFactoryStorage::CREATE_TOKEN_VERSION,
                 name: name.to_string(),
                 symbol: symbol.to_string(),
-                initialAdmin: initial_supply_recipient,
+                initialAdmin: initial_admin,
                 decimals,
             },
             initial_supply,

--- a/devnet/src/b20.rs
+++ b/devnet/src/b20.rs
@@ -17,8 +17,25 @@ use base_common_precompiles::{
     TokenVariant,
 };
 use base_common_rpc_types::{BaseTransactionReceipt, BaseTransactionRequest};
-use eyre::{Result, WrapErr, ensure};
+use eyre::{ContextCompat, Result, WrapErr, ensure};
 use tokio::time::{sleep, timeout};
+
+/// Creation settings used by the devnet B-20 factory client.
+#[derive(Debug, Clone)]
+pub struct B20CreateConfig {
+    /// ABI-level creation params sent to `ITokenFactory.createToken`.
+    pub create: ITokenFactory::B20CreateParams,
+    /// Initial supply to mint during the factory init-call window.
+    pub initial_supply: U256,
+    /// Account receiving the initial supply.
+    pub initial_supply_recipient: Address,
+    /// Initial supply cap to configure during the factory init-call window.
+    pub supply_cap: U256,
+    /// Initial minimum redeemable amount.
+    pub minimum_redeemable: U256,
+    /// Initial ERC-7572 contract URI.
+    pub contract_uri: String,
+}
 
 /// RPC client for the B-20 token factory and created token precompiles.
 #[derive(Debug)]
@@ -93,18 +110,20 @@ impl<'a> B20PrecompileClient<'a> {
         decimals: u8,
         initial_supply: U256,
         initial_supply_recipient: Address,
-    ) -> ITokenFactory::B20TokenParams {
-        ITokenFactory::B20TokenParams {
-            name: name.to_string(),
-            symbol: symbol.to_string(),
-            decimals,
-            admin: initial_supply_recipient,
-            capabilities: U256::ZERO,
-            initialSupply: initial_supply,
-            initialSupplyRecipient: initial_supply_recipient,
-            supplyCap: U256::MAX,
-            minimumRedeemable: U256::ZERO,
-            contractURI: String::new(),
+    ) -> B20CreateConfig {
+        B20CreateConfig {
+            create: ITokenFactory::B20CreateParams {
+                version: TokenFactoryStorage::CREATE_TOKEN_VERSION,
+                name: name.to_string(),
+                symbol: symbol.to_string(),
+                initialAdmin: initial_supply_recipient,
+                decimals,
+            },
+            initial_supply,
+            initial_supply_recipient,
+            supply_cap: U256::MAX,
+            minimum_redeemable: U256::ZERO,
+            contract_uri: String::new(),
         }
     }
 
@@ -112,19 +131,42 @@ impl<'a> B20PrecompileClient<'a> {
     pub async fn create_token(
         &self,
         variant: TokenVariant,
-        params: ITokenFactory::B20TokenParams,
+        params: B20CreateConfig,
         salt: B256,
     ) -> Result<Address> {
-        let token = self.predict_token_address(variant, params.decimals, salt);
+        let token = self.predict_token_address(variant, params.create.decimals, salt);
+        let mut init_calls = Vec::new();
+        if params.initial_supply > U256::ZERO {
+            init_calls.push(
+                IB20::mintCall {
+                    to: params.initial_supply_recipient,
+                    amount: params.initial_supply,
+                }
+                .abi_encode()
+                .into(),
+            );
+        }
+        if params.supply_cap != U256::MAX {
+            init_calls.push(
+                IB20::setSupplyCapCall { newSupplyCap: params.supply_cap }.abi_encode().into(),
+            );
+        }
+        if params.minimum_redeemable > U256::ZERO {
+            init_calls.push(
+                IB20::setMinimumRedeemableCall { newMinimum: params.minimum_redeemable }
+                    .abi_encode()
+                    .into(),
+            );
+        }
+        if !params.contract_uri.is_empty() {
+            init_calls
+                .push(IB20::setContractURICall { newURI: params.contract_uri }.abi_encode().into());
+        }
         let call = ITokenFactory::createTokenCall {
-            params: ITokenFactory::CreateTokenParams {
-                version: TokenFactoryStorage::CREATE_TOKEN_VERSION,
-                variant: variant.discriminant(),
-                requiredParams: params.abi_encode().into(),
-                optionalParams: Bytes::new(),
-                postCreateCalls: Vec::new(),
-                salt,
-            },
+            variant: Self::abi_variant(variant),
+            salt,
+            params: params.create.abi_encode().into(),
+            initCalls: init_calls,
         };
         self.send_call(TokenFactoryStorage::ADDRESS, call, "create B-20 token").await?;
         Ok(token)
@@ -189,19 +231,17 @@ impl<'a> B20PrecompileClient<'a> {
 
     /// Reads the variant encoded in a token address via the factory.
     pub async fn variant_of(&self, token: Address) -> Result<u8> {
-        let output =
-            self.call(TokenFactoryStorage::ADDRESS, ITokenFactory::variantOfCall { token }).await?;
-        ITokenFactory::variantOfCall::abi_decode_returns(output.as_ref())
-            .wrap_err("Failed to decode variantOf")
+        let output = self
+            .call(TokenFactoryStorage::ADDRESS, ITokenFactory::getTokenVariantCall { token })
+            .await?;
+        let variant = ITokenFactory::getTokenVariantCall::abi_decode_returns(output.as_ref())
+            .wrap_err("Failed to decode getTokenVariant")?;
+        Ok(variant as u8)
     }
 
-    /// Reads the decimals encoded in a token address via the factory.
+    /// Reads the decimals encoded in a token address.
     pub async fn decimals_of(&self, token: Address) -> Result<u8> {
-        let output = self
-            .call(TokenFactoryStorage::ADDRESS, ITokenFactory::decimalsOfCall { token })
-            .await?;
-        ITokenFactory::decimalsOfCall::abi_decode_returns(output.as_ref())
-            .wrap_err("Failed to decode decimalsOf")
+        TokenVariant::decimals_of(token).wrap_err("Token address is not a supported B-20 token")
     }
 
     /// Mints B-20 tokens to an account.
@@ -365,7 +405,7 @@ impl<'a> B20PrecompileClient<'a> {
             .wrap_err("Failed to decode isB20")
     }
 
-    /// Calls `predictTokenAddress` on the factory precompile via RPC.
+    /// Calls `getTokenAddress` on the factory precompile via RPC.
     pub async fn predict_token_address_rpc(
         &self,
         creator: Address,
@@ -376,16 +416,24 @@ impl<'a> B20PrecompileClient<'a> {
         let output = self
             .call(
                 TokenFactoryStorage::ADDRESS,
-                ITokenFactory::predictTokenAddressCall {
-                    creator,
-                    variant: variant.discriminant(),
+                ITokenFactory::getTokenAddressCall {
+                    variant: Self::abi_variant(variant),
                     decimals,
+                    sender: creator,
                     salt,
                 },
             )
             .await?;
-        ITokenFactory::predictTokenAddressCall::abi_decode_returns(output.as_ref())
-            .wrap_err("Failed to decode predictTokenAddress")
+        ITokenFactory::getTokenAddressCall::abi_decode_returns(output.as_ref())
+            .wrap_err("Failed to decode getTokenAddress")
+    }
+
+    fn abi_variant(variant: TokenVariant) -> ITokenFactory::TokenVariant {
+        match variant {
+            TokenVariant::B20 => ITokenFactory::TokenVariant::DEFAULT,
+            TokenVariant::Stablecoin => ITokenFactory::TokenVariant::STABLECOIN,
+            TokenVariant::Security => ITokenFactory::TokenVariant::SECURITY,
+        }
     }
 
     /// Sends a transaction and returns `true` if it succeeded, `false` if it reverted.

--- a/devnet/src/lib.rs
+++ b/devnet/src/lib.rs
@@ -11,7 +11,7 @@ mod utils;
 pub use utils::unique_name;
 
 mod b20;
-pub use b20::B20PrecompileClient;
+pub use b20::{B20CreateConfig, B20PrecompileClient};
 
 pub mod config;
 pub mod containers;

--- a/devnet/tests/b20_precompile.rs
+++ b/devnet/tests/b20_precompile.rs
@@ -2,14 +2,13 @@
 
 mod common;
 
-use alloy_primitives::{Address, B256, Bytes, U256};
+use alloy_primitives::{Address, B256, U256};
 use alloy_provider::RootProvider;
 use alloy_signer_local::PrivateKeySigner;
 use alloy_sol_types::SolValue;
 use base_common_network::Base;
 use base_common_precompiles::{
-    ActivationRegistryStorage, CAPABILITY_CAP_MUTABLE, CAPABILITY_PAUSABLE, IB20, ITokenFactory,
-    TokenFactoryStorage, TokenVariant,
+    ActivationRegistryStorage, IB20, ITokenFactory, TokenFactoryStorage, TokenVariant,
 };
 use devnet::{
     B20PrecompileClient,
@@ -244,8 +243,7 @@ async fn test_b20_supply_cap() -> Result<()> {
         U256::from(INITIAL_SUPPLY),
         admin.address(),
     );
-    params.capabilities = CAPABILITY_CAP_MUTABLE;
-    params.supplyCap = U256::from(INITIAL_SUPPLY_CAP);
+    params.supply_cap = U256::from(INITIAL_SUPPLY_CAP);
 
     let token = b20.create_token(TokenVariant::B20, params, salt).await?;
     b20.wait_for_token_code(token, common::TX_RECEIPT_TIMEOUT, common::BLOCK_POLL_INTERVAL).await?;
@@ -321,15 +319,13 @@ async fn test_b20_pause_and_unpause() -> Result<()> {
 
     let b20 = activated_b20_client(&provider, &admin).await?;
     let salt = B256::repeat_byte(0x16);
-    let mut params = B20PrecompileClient::token_params(
+    let params = B20PrecompileClient::token_params(
         "Pausable Token",
         "PAUS",
         TOKEN_DECIMALS,
         U256::from(INITIAL_SUPPLY),
         admin.address(),
     );
-    params.capabilities = CAPABILITY_PAUSABLE;
-
     let token = b20.create_token(TokenVariant::B20, params, salt).await?;
     b20.wait_for_token_code(token, common::TX_RECEIPT_TIMEOUT, common::BLOCK_POLL_INTERVAL).await?;
 
@@ -426,14 +422,10 @@ async fn test_b20_create_token_duplicate_reverts() -> Result<()> {
         .try_send_call(
             TokenFactoryStorage::ADDRESS,
             ITokenFactory::createTokenCall {
-                params: ITokenFactory::CreateTokenParams {
-                    version: TokenFactoryStorage::CREATE_TOKEN_VERSION,
-                    variant: TokenVariant::B20.discriminant(),
-                    requiredParams: params.abi_encode().into(),
-                    optionalParams: Bytes::new(),
-                    postCreateCalls: Vec::new(),
-                    salt,
-                },
+                variant: ITokenFactory::TokenVariant::DEFAULT,
+                salt,
+                params: params.create.abi_encode().into(),
+                initCalls: Vec::new(),
             },
             "createToken (duplicate salt)",
         )

--- a/devnet/tests/b20_precompile.rs
+++ b/devnet/tests/b20_precompile.rs
@@ -53,6 +53,7 @@ async fn test_b20_factory_create_and_transfer_via_rpc() -> Result<()> {
         "Devnet B20",
         "DB20",
         TOKEN_DECIMALS,
+        admin.address(),
         U256::from(INITIAL_SUPPLY),
         admin.address(),
     );
@@ -90,6 +91,7 @@ async fn test_b20_token_metadata() -> Result<()> {
         "Metadata Token",
         "META",
         TOKEN_DECIMALS,
+        admin.address(),
         U256::from(INITIAL_SUPPLY),
         admin.address(),
     );
@@ -124,6 +126,7 @@ async fn test_b20_approve_and_transfer_from() -> Result<()> {
         "Allowance Token",
         "ALLW",
         TOKEN_DECIMALS,
+        admin.address(),
         U256::from(INITIAL_SUPPLY),
         admin.address(),
     );
@@ -169,6 +172,7 @@ async fn test_b20_mint_and_burn() -> Result<()> {
         "Mintable Token",
         "MINT",
         TOKEN_DECIMALS,
+        admin.address(),
         U256::from(INITIAL_SUPPLY),
         admin.address(),
     );
@@ -211,6 +215,7 @@ async fn test_b20_transfer_with_memo() -> Result<()> {
         "Memo Token",
         "MEMO",
         TOKEN_DECIMALS,
+        admin.address(),
         U256::from(INITIAL_SUPPLY),
         admin.address(),
     );
@@ -240,6 +245,7 @@ async fn test_b20_supply_cap() -> Result<()> {
         "Capped Token",
         "CAP",
         TOKEN_DECIMALS,
+        admin.address(),
         U256::from(INITIAL_SUPPLY),
         admin.address(),
     );
@@ -292,6 +298,7 @@ async fn test_b20_metadata_updates() -> Result<()> {
         "Old Name",
         "OLD",
         TOKEN_DECIMALS,
+        admin.address(),
         U256::from(INITIAL_SUPPLY),
         admin.address(),
     );
@@ -323,6 +330,7 @@ async fn test_b20_pause_and_unpause() -> Result<()> {
         "Pausable Token",
         "PAUS",
         TOKEN_DECIMALS,
+        admin.address(),
         U256::from(INITIAL_SUPPLY),
         admin.address(),
     );
@@ -370,6 +378,7 @@ async fn test_b20_factory_predict_and_is_b20() -> Result<()> {
         "Predict Token",
         "PRD",
         TOKEN_DECIMALS,
+        admin.address(),
         U256::from(INITIAL_SUPPLY),
         admin.address(),
     );
@@ -411,6 +420,7 @@ async fn test_b20_create_token_duplicate_reverts() -> Result<()> {
         "Dup Token",
         "DUP",
         TOKEN_DECIMALS,
+        admin.address(),
         U256::from(INITIAL_SUPPLY),
         admin.address(),
     );

--- a/etc/scripts/devnet/check-factory-live.sh
+++ b/etc/scripts/devnet/check-factory-live.sh
@@ -78,7 +78,7 @@ done
 [[ -n "$BOB_ADDR" ]] || BOB_ADDR="0x70997970C51812dc3A010C7d01b50e0d17dc79C8"
 
 # Factory precompile (singleton, fixed at chain genesis)
-FACTORY="0xb02f000000000000000000000000000000000000"
+FACTORY="0xb20f00000000000000000000000000000000000f"
 
 # Token creation parameters
 TOKEN_NAME="Base USD"
@@ -134,40 +134,39 @@ pass "Alice is funded ($ALICE_ADDR)" "balance=$(cast from-wei "$ALICE_BAL") ETH"
 section "1/5  Predict token address (read-only)"
 
 PREDICTED=$(ccall "$FACTORY" \
-    "predictTokenAddress(address,uint8,uint8,bytes32)(address)" \
-    "$ALICE_ADDR" 1 "$TOKEN_DECIMALS" "$SALT") || fail "predictTokenAddress call failed" "$PREDICTED"
+    "getTokenAddress(uint8,uint8,address,bytes32)(address)" \
+    1 "$TOKEN_DECIMALS" "$ALICE_ADDR" "$SALT") || fail "getTokenAddress call failed" "$PREDICTED"
 PREDICTED=$(trim "$PREDICTED")
 [[ "$PREDICTED" =~ ^0x[0-9a-fA-F]{40}$ ]] || \
-    fail "predictTokenAddress returned bad address" "$PREDICTED"
+    fail "getTokenAddress returned bad address" "$PREDICTED"
 info "Predicted token address: $PREDICTED"
-pass "predictTokenAddress returned a valid address"
+pass "getTokenAddress returned a valid address"
 
 # Verify the prefix encodes the B-20 marker, variant=DEFAULT, and decimals.
-PREFIX=$(echo "${PREDICTED:2:8}" | tr '[:upper:]' '[:lower:]')
-EXPECTED_PREFIX=$(printf "b02001%02x" "$TOKEN_DECIMALS")
+PREFIX=$(echo "${PREDICTED:2:24}" | tr '[:upper:]' '[:lower:]')
+EXPECTED_PREFIX=$(printf "b200000000000000000001%02x" "$TOKEN_DECIMALS")
 [[ "$PREFIX" == "$EXPECTED_PREFIX" ]] || \
     fail "Token address does not encode DEFAULT variant and decimals" "expected prefix: 0x$EXPECTED_PREFIX got prefix: 0x$PREFIX"
 pass "Address prefix encodes B-20 marker, DEFAULT variant, and decimals"
 
-# isB20 must be false before creation (no code yet)
+# isB20 is a prefix check and returns true before bytecode is installed.
 IS_B20_BEFORE=$(ccall "$FACTORY" "isB20(address)(bool)" "$PREDICTED")
 IS_B20_BEFORE=$(trim "$IS_B20_BEFORE")
-assert_eq "isB20 is false before creation" "false" "$IS_B20_BEFORE"
+assert_eq "isB20 is true before creation" "true" "$IS_B20_BEFORE"
 
 # ── 2. Create token ───────────────────────────────────────────────────────────
 
 section "2/5  Create token (real transaction)"
 
-# Build B20TokenParams, then pass it as requiredParams into CreateTokenParams.
-# B20TokenParams field order: name,symbol,decimals,admin,capabilities,initialSupply,
-#                            initialSupplyRecipient,supplyCap,minimumRedeemable,contractURI
-REQUIRED_PARAMS=$(cast abi-encode \
-    "params(string,string,uint8,address,uint256,uint256,address,uint256,uint256,string)" \
-    "$TOKEN_NAME" "$TOKEN_SYMBOL" "$TOKEN_DECIMALS" "$ALICE_ADDR" 3 "$INITIAL_SUPPLY" \
-    "$ALICE_ADDR" "$SUPPLY_CAP" 0 "ipfs://check-factory-live")
+# Build B20CreateParams, then configure optional state through initCalls.
+CREATE_PARAMS=$(cast abi-encode \
+    "params(uint8,string,string,address,uint8)" \
+    1 "$TOKEN_NAME" "$TOKEN_SYMBOL" "$ALICE_ADDR" "$TOKEN_DECIMALS")
 
-# CreateTokenParams field order: version,variant,requiredParams,optionalParams,postCreateCalls,salt
-PARAMS="(1,1,$REQUIRED_PARAMS,0x,[],$SALT)"
+MINT_CALL=$(cast calldata "mint(address,uint256)" "$ALICE_ADDR" "$INITIAL_SUPPLY")
+SUPPLY_CAP_CALL=$(cast calldata "setSupplyCap(uint256)" "$SUPPLY_CAP")
+CONTRACT_URI_CALL=$(cast calldata "setContractURI(string)" "ipfs://check-factory-live")
+INIT_CALLS="[$MINT_CALL,$SUPPLY_CAP_CALL,$CONTRACT_URI_CALL]"
 
 info "Sending createToken transaction …"
 TX_OUTPUT=$(cast send \
@@ -176,8 +175,8 @@ TX_OUTPUT=$(cast send \
     --json \
     --confirmations 2 \
     "$FACTORY" \
-    "createToken((uint8,uint8,bytes,bytes,bytes[],bytes32))" \
-    "$PARAMS") || fail "createToken transaction failed" "$TX_OUTPUT"
+    "createToken(uint8,bytes32,bytes,bytes[])" \
+    1 "$SALT" "$CREATE_PARAMS" "$INIT_CALLS") || fail "createToken transaction failed" "$TX_OUTPUT"
 
 TX_HASH=$(echo "$TX_OUTPUT" | grep -o '"transactionHash":"[^"]*"' | cut -d'"' -f4)
 TX_STATUS=$(echo "$TX_OUTPUT" | grep -o '"status":"[^"]*"' | cut -d'"' -f4)
@@ -198,14 +197,10 @@ IS_B20=$(ccall "$FACTORY" "isB20(address)(bool)" "$TOKEN")
 IS_B20=$(trim "$IS_B20")
 assert_eq "isB20 is true after creation" "true" "$IS_B20"
 
-# variantOf must return 1 (VARIANT_DEFAULT)
-VARIANT=$(ccall "$FACTORY" "variantOf(address)(uint8)" "$TOKEN")
+# getTokenVariant must return 1 (VARIANT_DEFAULT)
+VARIANT=$(ccall "$FACTORY" "getTokenVariant(address)(uint8)" "$TOKEN")
 VARIANT=$(trim "$VARIANT")
-assert_eq "variantOf returns 1 (DEFAULT)" "1" "$VARIANT"
-
-FACTORY_DECIMALS=$(ccall "$FACTORY" "decimalsOf(address)(uint8)" "$TOKEN")
-FACTORY_DECIMALS=$(trim "$FACTORY_DECIMALS")
-assert_eq "decimalsOf returns encoded decimals" "$TOKEN_DECIMALS" "$FACTORY_DECIMALS"
+assert_eq "getTokenVariant returns 1 (DEFAULT)" "1" "$VARIANT"
 
 pass "Factory state is correct"
 
@@ -275,10 +270,9 @@ echo ""
 echo "Token: $TOKEN  (chain $CHAIN_ID, RPC $RPC_URL)"
 echo ""
 echo "Verified:"
-echo "  • predictTokenAddress → deterministic address with B-20 marker, variant, and decimals"
-echo "  • isB20 = false before creation, true after"
-echo "  • variantOf = 1 (DEFAULT)"
-echo "  • decimalsOf = $TOKEN_DECIMALS"
+echo "  • getTokenAddress → deterministic address with B-20 marker, variant, and decimals"
+echo "  • isB20 = true before and after creation"
+echo "  • getTokenVariant = 1 (DEFAULT)"
 echo "  • name='$TOKEN_NAME'  symbol='$TOKEN_SYMBOL'  decimals=$TOKEN_DECIMALS"
 echo "  • totalSupply=$INITIAL_SUPPLY  balanceOf(alice)=$ALICE_TOKEN_BAL"
 echo "  • transfer($TRANSFER_AMOUNT to bob) → alice=$EXPECTED_ALICE  bob=$TRANSFER_AMOUNT"


### PR DESCRIPTION
## Summary

This aligns the Rust token factory precompile ABI with the current ITokenFactory interface in base-std. It updates creation decoding, address derivation, factory views, and downstream devnet/action-harness/script callers to use the new createToken and query shapes. The precompile tests, devnet checks, benches, and action harness checks have been updated around the new ABI.