### PR TITLE
feat(common): Add Namespaced Precompile Storage

### DIFF
--- a/crates/common/precompile-macros/README.md
+++ b/crates/common/precompile-macros/README.md
@@ -5,6 +5,7 @@ Procedural macros for type-safe EVM storage abstractions for Base native precomp
 ## Macros
 
 - `#[contract]` — transforms a storage layout struct into a full contract
+- `#[namespace("id")]` — starts a `#[contract]` field or layout at an ERC-7201 namespace root
 - `#[derive(Storable)]` — generates storage I/O for structs and `#[repr(u8)]` enums
 - `storable_rust_ints!()`, `storable_alloy_ints!()`, `storable_alloy_bytes!()` — primitive impls
 - `storable_arrays!()`, `storable_nested_arrays!()` — fixed-size array impls

--- a/crates/common/precompile-macros/src/contract.rs
+++ b/crates/common/precompile-macros/src/contract.rs
@@ -5,7 +5,10 @@ use proc_macro2::TokenStream;
 use quote::quote;
 use syn::{Data, DeriveInput, Expr, Fields, Ident, Token, Type, Visibility, parse::ParseStream};
 
-use crate::{layout, packing, utils::extract_attributes};
+use crate::{
+    layout, packing,
+    utils::{NamespaceInfo, extract_attributes, extract_namespace},
+};
 
 pub(crate) struct ContractConfig {
     pub(crate) address: Option<Expr>,
@@ -37,6 +40,7 @@ pub(crate) struct FieldInfo {
     pub(crate) ty: Type,
     pub(crate) slot: Option<U256>,
     pub(crate) base_slot: Option<U256>,
+    pub(crate) namespace: Option<NamespaceInfo>,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -54,13 +58,17 @@ pub(crate) fn generate(input: DeriveInput, address: Option<&Expr>) -> proc_macro
 
 fn gen_output(input: DeriveInput, address: Option<&Expr>) -> syn::Result<TokenStream> {
     let (ident, vis) = (input.ident.clone(), input.vis.clone());
-    let fields = parse_fields(input)?;
+    let namespace = extract_namespace(&input.attrs)?;
+    let fields = parse_fields(input, namespace.is_some())?;
 
-    let storage_output = gen_storage(&ident, &vis, &fields, address)?;
+    let storage_output = gen_storage(&ident, &vis, &fields, address, namespace.as_ref())?;
     Ok(quote! { #storage_output })
 }
 
-pub(crate) fn parse_fields(input: DeriveInput) -> syn::Result<Vec<FieldInfo>> {
+pub(crate) fn parse_fields(
+    input: DeriveInput,
+    namespace_enabled: bool,
+) -> syn::Result<Vec<FieldInfo>> {
     if !input.generics.params.is_empty() {
         return Err(syn::Error::new_spanned(
             &input.generics,
@@ -94,8 +102,14 @@ pub(crate) fn parse_fields(input: DeriveInput) -> syn::Result<Vec<FieldInfo>> {
                 ));
             }
 
-            let (slot, base_slot) = extract_attributes(&field.attrs)?;
-            Ok(FieldInfo { name: name.to_owned(), ty: field.ty, slot, base_slot })
+            let (slot, base_slot, namespace) = extract_attributes(&field.attrs)?;
+            if namespace_enabled && (slot.is_some() || base_slot.is_some() || namespace.is_some()) {
+                return Err(syn::Error::new_spanned(
+                    name,
+                    "field-level `slot`, `base_slot`, and `namespace` attributes cannot be used with contract-level `namespace`",
+                ));
+            }
+            Ok(FieldInfo { name: name.to_owned(), ty: field.ty, slot, base_slot, namespace })
         })
         .collect()
 }
@@ -105,12 +119,16 @@ fn gen_storage(
     vis: &Visibility,
     fields: &[FieldInfo],
     address: Option<&Expr>,
+    namespace: Option<&NamespaceInfo>,
 ) -> syn::Result<TokenStream> {
-    let allocated_fields = packing::allocate_slots(fields)?;
+    let allocated_fields = packing::allocate_slots_from(
+        fields,
+        namespace.map_or(U256::ZERO, |namespace| namespace.root),
+    )?;
     let transformed_struct = layout::gen_struct(ident, vis, &allocated_fields);
     let storage_trait = layout::gen_contract_storage_impl(ident);
     let constructor = layout::gen_constructor(ident, &allocated_fields, address);
-    let slots_module = layout::gen_slots_module(&allocated_fields);
+    let slots_module = layout::gen_slots_module(&allocated_fields, namespace);
 
     Ok(quote! {
         #slots_module

--- a/crates/common/precompile-macros/src/layout.rs
+++ b/crates/common/precompile-macros/src/layout.rs
@@ -4,6 +4,7 @@ use syn::{Expr, Ident, Visibility};
 use crate::{
     FieldKind,
     packing::{self, LayoutField, PackingConstants, SlotAssignment},
+    utils::NamespaceInfo,
 };
 
 pub(crate) fn gen_handler_field_decl(field: &LayoutField<'_>) -> proc_macro2::TokenStream {
@@ -46,13 +47,11 @@ pub(crate) fn gen_handler_field_init(
 
     match &field.kind {
         FieldKind::Direct(ty) => {
-            let (prev_slot_const_ref, next_slot_const_ref) = packing::get_neighbor_slot_refs(
-                field_idx,
-                all_fields,
-                const_mod,
-                |f| f.name,
-                is_contract,
-            );
+            let (prev_slot_const_ref, next_slot_const_ref) = if is_contract {
+                packing::get_same_root_neighbor_slot_refs(field_idx, all_fields, const_mod)
+            } else {
+                packing::get_neighbor_slot_refs(field_idx, all_fields, const_mod, |f| f.name, false)
+            };
 
             let layout_ctx = if is_contract {
                 packing::gen_layout_ctx_expr(
@@ -203,7 +202,11 @@ pub(crate) fn gen_contract_storage_impl(name: &Ident) -> proc_macro2::TokenStrea
     }
 }
 
-pub(crate) fn gen_slots_module(allocated_fields: &[LayoutField<'_>]) -> proc_macro2::TokenStream {
+pub(crate) fn gen_slots_module(
+    allocated_fields: &[LayoutField<'_>],
+    namespace: Option<&NamespaceInfo>,
+) -> proc_macro2::TokenStream {
+    let namespace_constants = namespace.map(gen_namespace_constants);
     let constants = packing::gen_constants_from_ir(allocated_fields, false);
     let collision_checks = gen_collision_checks(allocated_fields);
 
@@ -212,9 +215,24 @@ pub(crate) fn gen_slots_module(allocated_fields: &[LayoutField<'_>]) -> proc_mac
         pub mod slots {
             use super::*;
 
+            #namespace_constants
             #constants
             #collision_checks
         }
+    }
+}
+
+fn gen_namespace_constants(namespace: &NamespaceInfo) -> proc_macro2::TokenStream {
+    let id = &namespace.id;
+    let limbs = *namespace.root.as_limbs();
+
+    quote! {
+        /// ERC-7201 namespace identifier for this contract storage layout.
+        pub const NAMESPACE_ID: &str = #id;
+
+        /// ERC-7201 namespace root slot for this contract storage layout.
+        pub const NAMESPACE_ROOT: ::alloy_primitives::U256 =
+            ::alloy_primitives::U256::from_limbs([#(#limbs),*]);
     }
 }
 

--- a/crates/common/precompile-macros/src/lib.rs
+++ b/crates/common/precompile-macros/src/lib.rs
@@ -4,6 +4,7 @@ mod contract;
 pub(crate) use contract::{FieldInfo, FieldKind};
 
 mod layout;
+mod namespace;
 mod packing;
 mod storable;
 mod storable_primitives;
@@ -22,6 +23,12 @@ pub fn contract(attr: TokenStream, item: TokenStream) -> TokenStream {
     let config = parse_macro_input!(attr as contract::ContractConfig);
     let input = parse_macro_input!(item as DeriveInput);
     contract::generate(input, config.address.as_ref())
+}
+
+/// Namespaces a `#[contract]` storage struct using an ERC-7201 storage root.
+#[proc_macro_attribute]
+pub fn namespace(attr: TokenStream, item: TokenStream) -> TokenStream {
+    namespace::expand(attr, item)
 }
 
 /// Derives the `Storable` trait for structs with named fields and `#[repr(u8)]` unit enums.

--- a/crates/common/precompile-macros/src/namespace.rs
+++ b/crates/common/precompile-macros/src/namespace.rs
@@ -1,0 +1,42 @@
+//! Implementation of the `#[namespace]` attribute macro.
+
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{DeriveInput, LitStr};
+
+use crate::utils::{attr_path_is, parse_namespace_id};
+
+pub(crate) fn expand(attr: TokenStream, item: TokenStream) -> TokenStream {
+    match expand_impl(attr.into(), item.into()) {
+        Ok(tokens) => tokens.into(),
+        Err(err) => err.to_compile_error().into(),
+    }
+}
+
+fn expand_impl(
+    attr: proc_macro2::TokenStream,
+    item: proc_macro2::TokenStream,
+) -> syn::Result<proc_macro2::TokenStream> {
+    let namespace_id: LitStr = syn::parse2(attr)?;
+    let mut input: DeriveInput = syn::parse2(item)?;
+
+    parse_namespace_id(namespace_id.clone())?;
+
+    if input.attrs.iter().any(|attr| attr_path_is(attr.path(), "namespace")) {
+        return Err(syn::Error::new_spanned(&input.ident, "duplicate `namespace` attribute"));
+    }
+
+    let contract_index =
+        input.attrs.iter().position(|attr| attr_path_is(attr.path(), "contract")).ok_or_else(
+            || {
+                syn::Error::new_spanned(
+                    &input.ident,
+                    "`#[namespace]` must be paired with `#[contract]`",
+                )
+            },
+        )?;
+
+    input.attrs.insert(contract_index + 1, syn::parse_quote!(#[namespace(#namespace_id)]));
+
+    Ok(quote! { #input })
+}

--- a/crates/common/precompile-macros/src/packing.rs
+++ b/crates/common/precompile-macros/src/packing.rs
@@ -66,19 +66,28 @@ pub(crate) struct LayoutField<'a> {
 
 /// Build layout IR from field information.
 pub(crate) fn allocate_slots(fields: &[FieldInfo]) -> syn::Result<Vec<LayoutField<'_>>> {
+    allocate_slots_from(fields, U256::ZERO)
+}
+
+/// Build layout IR from field information, starting auto-allocation at `initial_base_slot`.
+pub(crate) fn allocate_slots_from(
+    fields: &[FieldInfo],
+    initial_base_slot: U256,
+) -> syn::Result<Vec<LayoutField<'_>>> {
     let mut result = Vec::with_capacity(fields.len());
-    let mut current_base_slot = U256::ZERO;
+    let mut current_base_slot = initial_base_slot;
 
     for field in fields {
         let kind = classify_field_type(&field.ty)?;
 
-        let assigned_slot = match (field.slot, field.base_slot) {
-            (Some(explicit), _) => SlotAssignment::Manual(explicit),
-            (None, Some(new_base)) => {
+        let assigned_slot = match (field.slot, field.base_slot, field.namespace.as_ref()) {
+            (Some(explicit), _, _) => SlotAssignment::Manual(explicit),
+            (None, Some(new_base), _) => {
                 current_base_slot = new_base;
                 SlotAssignment::Auto { base_slot: new_base }
             }
-            (None, None) => SlotAssignment::Auto { base_slot: current_base_slot },
+            (None, None, Some(namespace)) => SlotAssignment::Auto { base_slot: namespace.root },
+            (None, None, None) => SlotAssignment::Auto { base_slot: current_base_slot },
         };
 
         result.push(LayoutField { name: &field.name, ty: &field.ty, kind, assigned_slot });
@@ -90,7 +99,7 @@ pub(crate) fn allocate_slots(fields: &[FieldInfo]) -> syn::Result<Vec<LayoutFiel
 /// Generate packing constants from layout IR.
 pub(crate) fn gen_constants_from_ir(fields: &[LayoutField<'_>], gen_location: bool) -> TokenStream {
     let mut constants = TokenStream::new();
-    let mut current_base_slot: Option<&LayoutField<'_>> = None;
+    let mut last_auto_fields = Vec::<&LayoutField<'_>>::new();
 
     for field in fields {
         let ty = field.ty;
@@ -115,27 +124,32 @@ pub(crate) fn gen_constants_from_ir(fields: &[LayoutField<'_>], gen_location: bo
                 (slot_expr, quote! { 0 })
             }
             SlotAssignment::Auto { base_slot, .. } => {
-                let output = if let Some(current_base) = current_base_slot
-                    && current_base.assigned_slot.ref_slot() == field.assigned_slot.ref_slot()
-                {
-                    let (prev_slot, prev_offset) =
-                        PackingConstants::new(current_base.name).into_tuple();
-                    gen_slot_packing_logic(
-                        current_base.ty,
-                        field.ty,
-                        quote! { #prev_slot },
-                        quote! { #prev_offset },
-                    )
-                } else {
-                    let limbs = *base_slot.as_limbs();
-                    let slot_expr = quote! {
-                        ::alloy_primitives::U256::from_limbs([#(#limbs),*])
-                            .checked_add(#slots_to_end).expect("slot overflow")
-                            .saturating_sub(#slots_to_end)
-                    };
-                    (slot_expr, quote! { 0 })
-                };
-                current_base_slot = Some(field);
+                let output = last_auto_fields
+                    .iter()
+                    .rev()
+                    .find(|candidate| candidate.assigned_slot.ref_slot() == base_slot)
+                    .map_or_else(
+                        || {
+                            let limbs = *base_slot.as_limbs();
+                            let slot_expr = quote! {
+                                ::alloy_primitives::U256::from_limbs([#(#limbs),*])
+                                    .checked_add(#slots_to_end).expect("slot overflow")
+                                    .saturating_sub(#slots_to_end)
+                            };
+                            (slot_expr, quote! { 0 })
+                        },
+                        |current_base| {
+                            let (prev_slot, prev_offset) =
+                                PackingConstants::new(current_base.name).into_tuple();
+                            gen_slot_packing_logic(
+                                current_base.ty,
+                                field.ty,
+                                quote! { #prev_slot },
+                                quote! { #prev_offset },
+                            )
+                        },
+                    );
+                last_auto_fields.push(field);
                 output
             }
         };
@@ -219,6 +233,43 @@ where
     } else {
         None
     };
+
+    (prev_slot_ref, next_slot_ref)
+}
+
+/// Returns previous and next slot constants for fields that share the same auto-allocation root.
+pub(crate) fn get_same_root_neighbor_slot_refs(
+    idx: usize,
+    fields: &[LayoutField<'_>],
+    packing: &Ident,
+) -> (Option<TokenStream>, Option<TokenStream>) {
+    if !matches!(fields[idx].assigned_slot, SlotAssignment::Auto { .. }) {
+        return (None, None);
+    }
+
+    let root = fields[idx].assigned_slot.ref_slot();
+    let prev_slot_ref = fields[..idx]
+        .iter()
+        .rev()
+        .find(|field| {
+            matches!(field.assigned_slot, SlotAssignment::Auto { .. })
+                && field.assigned_slot.ref_slot() == root
+        })
+        .map(|field| {
+            let prev_slot = PackingConstants::new(field.name).slot();
+            quote! { #packing::#prev_slot }
+        });
+
+    let next_slot_ref = fields[idx + 1..]
+        .iter()
+        .find(|field| {
+            matches!(field.assigned_slot, SlotAssignment::Auto { .. })
+                && field.assigned_slot.ref_slot() == root
+        })
+        .map(|field| {
+            let next_slot = PackingConstants::new(field.name).slot();
+            quote! { #packing::#next_slot }
+        });
 
     (prev_slot_ref, next_slot_ref)
 }

--- a/crates/common/precompile-macros/src/storable.rs
+++ b/crates/common/precompile-macros/src/storable.rs
@@ -59,6 +59,7 @@ fn derive_struct_impl(input: &DeriveInput, data_struct: &DataStruct) -> syn::Res
             ty: f.ty.clone(),
             slot: None,
             base_slot: None,
+            namespace: None,
         })
         .collect();
 

--- a/crates/common/precompile-macros/src/utils.rs
+++ b/crates/common/precompile-macros/src/utils.rs
@@ -1,10 +1,17 @@
 //! Utility functions for the contract macro implementation.
 
 use alloy_primitives::{U256, keccak256};
-use syn::{Attribute, Lit, Type};
+use syn::{Attribute, Lit, LitStr, Path, Type};
 
-/// Return type for [`extract_attributes`]: (`slot`, `base_slot`)
-type ExtractedAttributes = (Option<U256>, Option<U256>);
+/// Parsed `#[namespace("...")]` metadata.
+#[derive(Debug, Clone)]
+pub(crate) struct NamespaceInfo {
+    pub(crate) id: LitStr,
+    pub(crate) root: U256,
+}
+
+/// Return type for [`extract_attributes`]: (`slot`, `base_slot`, `namespace`)
+type ExtractedAttributes = (Option<U256>, Option<U256>, Option<NamespaceInfo>);
 
 /// Parses a slot value from a literal.
 ///
@@ -30,6 +37,34 @@ fn parse_slot_value(value: &Lit) -> syn::Result<U256> {
             "slot attribute must be an integer or a string literal",
         )),
     }
+}
+
+/// Returns whether an attribute path ends with the provided identifier.
+pub(crate) fn attr_path_is(path: &Path, ident: &str) -> bool {
+    path.segments.last().is_some_and(|segment| segment.ident == ident)
+}
+
+/// Parses and validates a namespace id string.
+pub(crate) fn parse_namespace_id(id: LitStr) -> syn::Result<NamespaceInfo> {
+    let value = id.value();
+    if value.is_empty() {
+        return Err(syn::Error::new(id.span(), "namespace id cannot be empty"));
+    }
+    if value.chars().any(char::is_whitespace) {
+        return Err(syn::Error::new(id.span(), "namespace id must not contain whitespace"));
+    }
+
+    Ok(NamespaceInfo { root: erc7201_root(&id)?, id })
+}
+
+/// Computes the ERC-7201 namespace root for `id`.
+pub(crate) fn erc7201_root(id: &LitStr) -> syn::Result<U256> {
+    let id_hash = U256::from_be_bytes(keccak256(id.value().as_bytes()).0);
+    let shifted = id_hash.checked_sub(U256::ONE).ok_or_else(|| {
+        syn::Error::new(id.span(), "namespace root underflow while applying ERC-7201 formula")
+    })?;
+    let root = U256::from_be_bytes(keccak256(shifted.to_be_bytes::<32>()).0);
+    Ok(root & (U256::MAX - U256::from(0xffu64)))
 }
 
 /// Converts a string from `CamelCase` or `snake_case` to `snake_case`.
@@ -89,16 +124,17 @@ pub(crate) fn to_camel_case(s: &str) -> String {
 pub(crate) fn extract_attributes(attrs: &[Attribute]) -> syn::Result<ExtractedAttributes> {
     let mut slot_attr: Option<U256> = None;
     let mut base_slot_attr: Option<U256> = None;
+    let mut namespace_attr: Option<NamespaceInfo> = None;
 
     for attr in attrs {
         if attr.path().is_ident("slot") {
             if slot_attr.is_some() {
                 return Err(syn::Error::new_spanned(attr, "duplicate `slot` attribute"));
             }
-            if base_slot_attr.is_some() {
+            if base_slot_attr.is_some() || namespace_attr.is_some() {
                 return Err(syn::Error::new_spanned(
                     attr,
-                    "cannot use both `slot` and `base_slot` attributes on the same field",
+                    "cannot combine `slot`, `base_slot`, and `namespace` attributes on the same field",
                 ));
             }
             let value: Lit = attr.parse_args()?;
@@ -107,18 +143,47 @@ pub(crate) fn extract_attributes(attrs: &[Attribute]) -> syn::Result<ExtractedAt
             if base_slot_attr.is_some() {
                 return Err(syn::Error::new_spanned(attr, "duplicate `base_slot` attribute"));
             }
-            if slot_attr.is_some() {
+            if slot_attr.is_some() || namespace_attr.is_some() {
                 return Err(syn::Error::new_spanned(
                     attr,
-                    "cannot use both `slot` and `base_slot` attributes on the same field",
+                    "cannot combine `slot`, `base_slot`, and `namespace` attributes on the same field",
                 ));
             }
             let value: Lit = attr.parse_args()?;
             base_slot_attr = Some(parse_slot_value(&value)?);
+        } else if attr_path_is(attr.path(), "namespace") {
+            if namespace_attr.is_some() {
+                return Err(syn::Error::new_spanned(attr, "duplicate `namespace` attribute"));
+            }
+            if slot_attr.is_some() || base_slot_attr.is_some() {
+                return Err(syn::Error::new_spanned(
+                    attr,
+                    "cannot combine `slot`, `base_slot`, and `namespace` attributes on the same field",
+                ));
+            }
+            namespace_attr = Some(parse_namespace_id(attr.parse_args()?)?);
         }
     }
 
-    Ok((slot_attr, base_slot_attr))
+    Ok((slot_attr, base_slot_attr, namespace_attr))
+}
+
+/// Extracts a contract-level `#[namespace("...")]` attribute.
+pub(crate) fn extract_namespace(attrs: &[Attribute]) -> syn::Result<Option<NamespaceInfo>> {
+    let mut namespace = None;
+
+    for attr in attrs {
+        if !attr_path_is(attr.path(), "namespace") {
+            continue;
+        }
+        if namespace.is_some() {
+            return Err(syn::Error::new_spanned(attr, "duplicate `namespace` attribute"));
+        }
+
+        namespace = Some(parse_namespace_id(attr.parse_args()?)?);
+    }
+
+    Ok(namespace)
 }
 
 /// Extracts array sizes from the `#[storable_arrays(...)]` attribute.
@@ -211,6 +276,7 @@ pub(crate) fn extract_mapping_types(ty: &Type) -> Option<(&Type, &Type)> {
 
 #[cfg(test)]
 mod tests {
+    use alloy_primitives::uint;
     use syn::parse_quote;
 
     use super::*;
@@ -247,5 +313,20 @@ mod tests {
 
         let ty: Type = parse_quote!(Vec<u8>);
         assert!(extract_mapping_types(&ty).is_none());
+    }
+
+    #[test]
+    fn test_erc7201_root() {
+        let id: LitStr = parse_quote!("b20.policy");
+        assert_eq!(
+            erc7201_root(&id).unwrap(),
+            uint!(0x50861ae81a7f4392b927efbaeecf8f091f3bd39245aa45ea91499a137b8b3100_U256)
+        );
+    }
+
+    #[test]
+    fn test_parse_namespace_id_rejects_whitespace() {
+        let id: LitStr = parse_quote!("b20 policy");
+        assert!(parse_namespace_id(id).is_err());
     }
 }

--- a/crates/common/precompile-storage/README.md
+++ b/crates/common/precompile-storage/README.md
@@ -26,6 +26,14 @@ pub struct MyToken {
 - `#[base_slot(N)]` — resets the auto-allocation chain starting from slot N.
 - `#[slot("key")]` — computes `keccak256("key")` at macro expansion time.
 
+### Namespaced layouts
+
+- `#[namespace("id")]` — starts a `#[contract]` field at the ERC-7201 root for `id`.
+
+Multiple fields with the same namespace use normal Solidity offsets from that root without advancing
+the surrounding contract layout. `#[slot]` and `#[base_slot]` overrides cannot be combined with
+`#[namespace]` on the same field.
+
 ### Mapping slot derivation
 
 ```text

--- a/crates/common/precompile-storage/tests/contract.rs
+++ b/crates/common/precompile-storage/tests/contract.rs
@@ -2,11 +2,23 @@
 //!
 //! Validates that the macro generates correct storage layout,
 //! typed getter/setter fields work round-trip, and collision detection fires.
-use alloy_primitives::{Address, U256, address};
+use alloy_primitives::{Address, U256, address, keccak256};
 use base_precompile_macros::contract;
 use base_precompile_storage::{Handler, Mapping, StorageCtx, StorageKey, setup_storage};
 
 const TEST_ADDR: Address = address!("0000000000000000000000000000000000001234");
+
+fn data_slot(slot: U256) -> U256 {
+    U256::from_be_bytes(keccak256(slot.to_be_bytes::<32>()).0)
+}
+
+fn word_from_chunk(data: &[u8], chunk_index: usize) -> U256 {
+    let mut word = [0u8; 32];
+    let start = chunk_index * 32;
+    let end = (start + 32).min(data.len());
+    word[..end - start].copy_from_slice(&data[start..end]);
+    U256::from_be_bytes(word)
+}
 
 /// A minimal token storage layout for integration testing.
 #[contract(addr = TEST_ADDR)]
@@ -92,4 +104,257 @@ fn test_contract_multiple_instances_independent() {
         // storage2 is independent — balance should be zero.
         assert_eq!(t2.balances.at(&alice).read().unwrap(), U256::ZERO);
     });
+}
+
+mod namespaced_layout {
+    use alloy_primitives::{Address, U256, address, uint};
+    use base_precompile_macros::{Storable, contract};
+    use base_precompile_storage::{Handler, Mapping, StorageCtx, StorageKey, setup_storage};
+
+    use super::{data_slot, word_from_chunk};
+
+    const NAMESPACED_ADDR: Address = address!("0000000000000000000000000000000000004321");
+    const EXPECTED_ROOT: U256 =
+        uint!(0x50861ae81a7f4392b927efbaeecf8f091f3bd39245aa45ea91499a137b8b3100_U256);
+
+    /// A storage section embedded into the token storage layout.
+    #[derive(Debug, Clone, Storable)]
+    struct PolicyNamespace {
+        label: String,
+        balances: Mapping<Address, U256>,
+        checkpoints: [U256; 3],
+        packed_flags: [u16; 20],
+        amounts: Vec<U256>,
+    }
+
+    /// Token storage with an embedded policy section rooted at the ERC-7201 namespace.
+    #[contract(addr = NAMESPACED_ADDR)]
+    pub struct NamespacedStorage {
+        pub admin: Address,
+        #[namespace("b20.policy")]
+        pub policy: PolicyNamespace,
+        pub total_supply: U256,
+        #[namespace("b20.policy")]
+        pub policy_owner: Address,
+    }
+
+    #[test]
+    fn namespace_root_and_offsets_are_deterministic() {
+        assert_eq!(slots::ADMIN, U256::ZERO);
+        assert_eq!(slots::POLICY, EXPECTED_ROOT);
+        assert_eq!(slots::TOTAL_SUPPLY, U256::ONE);
+        assert_eq!(
+            slots::POLICY_OWNER,
+            EXPECTED_ROOT + U256::from(__packing_policy_namespace::SLOT_COUNT)
+        );
+    }
+
+    #[test]
+    fn namespaced_struct_field_handles_dynamic_mapping_and_array_storage() {
+        let (mut storage, _) = setup_storage();
+        let owner = Address::from([0xaa; 20]);
+        let policy_owner = Address::from([0xcc; 20]);
+        let long_label =
+            "namespaced-string-storage-value-that-spans-more-than-one-word-for-layout".to_owned();
+        assert!(long_label.len() > 64);
+        let amounts = vec![U256::from(11), U256::from(22), U256::from(33)];
+        let policy_value = PolicyNamespace {
+            label: long_label.clone(),
+            balances: Mapping::default(),
+            checkpoints: [U256::from(1), U256::from(2), U256::from(3)],
+            packed_flags: [0; 20],
+            amounts: amounts.clone(),
+        };
+        let _ = (
+            &policy_value.label,
+            &policy_value.balances,
+            &policy_value.checkpoints,
+            &policy_value.packed_flags,
+            &policy_value.amounts,
+        );
+
+        StorageCtx::enter(&mut storage, |ctx| {
+            let mut layout = NamespacedStorage::new(ctx);
+            layout.admin.write(owner).unwrap();
+            layout.policy.label.write(long_label.clone()).unwrap();
+            layout.policy.balances.at_mut(&owner).write(U256::from(500)).unwrap();
+            layout.policy.checkpoints.write([U256::from(1), U256::from(2), U256::from(3)]).unwrap();
+            layout.policy.packed_flags[0].write(0x1111).unwrap();
+            layout.policy.packed_flags[16].write(0x2222).unwrap();
+            layout.policy.amounts.write(amounts.clone()).unwrap();
+            layout.total_supply.write(U256::from(1_000)).unwrap();
+            layout.policy_owner.write(policy_owner).unwrap();
+
+            assert_eq!(layout.admin.read().unwrap(), owner);
+            assert_eq!(layout.policy.label.read().unwrap(), long_label);
+            assert_eq!(layout.policy.balances.at(&owner).read().unwrap(), U256::from(500));
+            assert_eq!(layout.policy.checkpoints[2].read().unwrap(), U256::from(3));
+            assert_eq!(layout.policy.packed_flags[0].read().unwrap(), 0x1111);
+            assert_eq!(layout.policy.packed_flags[16].read().unwrap(), 0x2222);
+            assert_eq!(layout.policy.amounts.read().unwrap(), amounts);
+            assert_eq!(layout.total_supply.read().unwrap(), U256::from(1_000));
+            assert_eq!(layout.policy_owner.read().unwrap(), policy_owner);
+
+            let label_slot =
+                slots::POLICY + U256::from(__packing_policy_namespace::LABEL_LOC.offset_slots);
+            let balance_slot = owner.mapping_slot(
+                slots::POLICY + U256::from(__packing_policy_namespace::BALANCES_LOC.offset_slots),
+            );
+            let checkpoints_slot = slots::POLICY
+                + U256::from(__packing_policy_namespace::CHECKPOINTS_LOC.offset_slots);
+            let packed_flags_slot = slots::POLICY
+                + U256::from(__packing_policy_namespace::PACKED_FLAGS_LOC.offset_slots);
+            let amounts_slot =
+                slots::POLICY + U256::from(__packing_policy_namespace::AMOUNTS_LOC.offset_slots);
+
+            assert_eq!(ctx.sload(NAMESPACED_ADDR, balance_slot).unwrap(), U256::from(500));
+            assert_eq!(
+                ctx.sload(NAMESPACED_ADDR, slots::ADMIN).unwrap(),
+                U256::from_be_bytes({
+                    let mut word = [0u8; 32];
+                    word[12..].copy_from_slice(owner.as_slice());
+                    word
+                })
+            );
+            assert_eq!(ctx.sload(NAMESPACED_ADDR, slots::TOTAL_SUPPLY).unwrap(), U256::from(1_000));
+            assert_eq!(
+                ctx.sload(NAMESPACED_ADDR, slots::POLICY_OWNER).unwrap(),
+                U256::from_be_bytes({
+                    let mut word = [0u8; 32];
+                    word[12..].copy_from_slice(policy_owner.as_slice());
+                    word
+                })
+            );
+
+            assert_eq!(
+                ctx.sload(NAMESPACED_ADDR, label_slot).unwrap(),
+                U256::from(long_label.len() * 2 + 1)
+            );
+            let label_data_slot = data_slot(label_slot);
+            for chunk_index in 0..long_label.len().div_ceil(32) {
+                assert_eq!(
+                    ctx.sload(NAMESPACED_ADDR, label_data_slot + U256::from(chunk_index)).unwrap(),
+                    word_from_chunk(long_label.as_bytes(), chunk_index)
+                );
+            }
+
+            assert_eq!(ctx.sload(NAMESPACED_ADDR, checkpoints_slot).unwrap(), U256::from(1));
+            assert_eq!(
+                ctx.sload(NAMESPACED_ADDR, checkpoints_slot + U256::ONE).unwrap(),
+                U256::from(2)
+            );
+            assert_eq!(
+                ctx.sload(NAMESPACED_ADDR, checkpoints_slot + U256::from(2)).unwrap(),
+                U256::from(3)
+            );
+
+            let packed_first_slot = ctx.sload(NAMESPACED_ADDR, packed_flags_slot).unwrap();
+            let packed_second_slot =
+                ctx.sload(NAMESPACED_ADDR, packed_flags_slot + U256::ONE).unwrap();
+            assert_eq!(packed_first_slot & U256::from(0xffff), U256::from(0x1111));
+            assert_eq!(packed_second_slot & U256::from(0xffff), U256::from(0x2222));
+
+            assert_eq!(ctx.sload(NAMESPACED_ADDR, amounts_slot).unwrap(), U256::from(3));
+            let amounts_data_slot = data_slot(amounts_slot);
+            assert_eq!(ctx.sload(NAMESPACED_ADDR, amounts_data_slot).unwrap(), U256::from(11));
+            assert_eq!(
+                ctx.sload(NAMESPACED_ADDR, amounts_data_slot + U256::ONE).unwrap(),
+                U256::from(22)
+            );
+            assert_eq!(
+                ctx.sload(NAMESPACED_ADDR, amounts_data_slot + U256::from(2)).unwrap(),
+                U256::from(33)
+            );
+        });
+    }
+}
+
+mod namespaced_fields {
+    use alloy_primitives::{Address, U256, address, uint};
+    use base_precompile_macros::contract;
+    use base_precompile_storage::{Handler, Mapping, StorageCtx, StorageKey, setup_storage};
+
+    use super::{data_slot, word_from_chunk};
+
+    const FIELD_NAMESPACE_ADDR: Address = address!("0000000000000000000000000000000000008765");
+    const EXPECTED_ROOT: U256 =
+        uint!(0x50861ae81a7f4392b927efbaeecf8f091f3bd39245aa45ea91499a137b8b3100_U256);
+
+    /// Token storage with individual fields routed into a shared namespace-local layout.
+    #[contract(addr = FIELD_NAMESPACE_ADDR)]
+    pub struct FieldNamespacedStorage {
+        pub admin: Address,
+        #[namespace("b20.policy")]
+        pub policy_label: String,
+        pub total_supply: U256,
+        #[namespace("b20.policy")]
+        pub policy_balances: Mapping<Address, U256>,
+    }
+
+    #[test]
+    fn namespaced_fields_share_namespace_layout_without_advancing_contract_slots() {
+        assert_eq!(slots::ADMIN, U256::ZERO);
+        assert_eq!(slots::POLICY_LABEL, EXPECTED_ROOT);
+        assert_eq!(slots::TOTAL_SUPPLY, U256::ONE);
+        assert_eq!(slots::POLICY_BALANCES, EXPECTED_ROOT + U256::ONE);
+
+        let (mut storage, _) = setup_storage();
+        let owner = Address::from([0xbb; 20]);
+        let label = "field-level-namespaced-policy-label-that-spans-two-slots".to_owned();
+
+        StorageCtx::enter(&mut storage, |ctx| {
+            let mut layout = FieldNamespacedStorage::new(ctx);
+            layout.policy_label.write(label.clone()).unwrap();
+            layout.policy_balances.at_mut(&owner).write(U256::from(700)).unwrap();
+            layout.total_supply.write(U256::from(2_000)).unwrap();
+
+            assert_eq!(layout.policy_label.read().unwrap(), label);
+            assert_eq!(layout.policy_balances.at(&owner).read().unwrap(), U256::from(700));
+            assert_eq!(layout.total_supply.read().unwrap(), U256::from(2_000));
+
+            assert_eq!(
+                ctx.sload(FIELD_NAMESPACE_ADDR, slots::POLICY_LABEL).unwrap(),
+                U256::from(label.len() * 2 + 1)
+            );
+            let label_data_slot = data_slot(slots::POLICY_LABEL);
+            for chunk_index in 0..label.len().div_ceil(32) {
+                assert_eq!(
+                    ctx.sload(FIELD_NAMESPACE_ADDR, label_data_slot + U256::from(chunk_index))
+                        .unwrap(),
+                    word_from_chunk(label.as_bytes(), chunk_index)
+                );
+            }
+
+            let balance_slot = owner.mapping_slot(slots::POLICY_BALANCES);
+            assert_eq!(ctx.sload(FIELD_NAMESPACE_ADDR, balance_slot).unwrap(), U256::from(700));
+            assert_eq!(
+                ctx.sload(FIELD_NAMESPACE_ADDR, slots::TOTAL_SUPPLY).unwrap(),
+                U256::from(2_000)
+            );
+        });
+    }
+}
+
+mod namespace_outer_order {
+    use alloy_primitives::{Address, U256, address, uint};
+    use base_precompile_macros::{contract, namespace};
+
+    const ORDER_ADDR: Address = address!("0000000000000000000000000000000000005678");
+
+    #[namespace("b20.outer-order")]
+    #[contract(addr = ORDER_ADDR)]
+    pub struct OuterOrderStorage {
+        pub value: U256,
+    }
+
+    #[test]
+    fn namespace_macro_reorders_above_contract() {
+        assert_eq!(ORDER_ADDR, address!("0000000000000000000000000000000000005678"));
+        assert_eq!(slots::NAMESPACE_ID, "b20.outer-order");
+        assert_eq!(
+            slots::NAMESPACE_ROOT,
+            uint!(0xf06e16fd945cfdfdb627e60cabea1fb8bb965382c21574655d1e8bb28bdfcf00_U256)
+        );
+        assert_eq!(slots::VALUE, slots::NAMESPACE_ROOT);
+    }
 }


### PR DESCRIPTION
## Summary

This adds a new precompile macro attribute for ERC-7201-inspired namespaced storage roots on contract storage fields. The contract macro can now route an embedded `Storable` section, or individual fields, into a namespace-local Solidity layout without advancing the surrounding contract layout. Integration coverage verifies namespaced embedded structs, individual fields, mappings, fixed arrays, packed arrays, strings spanning multiple data slots, and dynamic vectors.

Usage looks like:

```rust
use alloy_primitives::{Address, U256};
use base_precompile_macros::{Storable, contract};
use base_precompile_storage::Mapping;

#[derive(Debug, Clone, Storable)]
pub struct B20Policy {
    pub members: Mapping<u64, Mapping<Address, bool>>,
    pub label: String,
    pub checkpoints: [U256; 3],
}

#[contract]
pub struct B20TokenStorage {
    pub total_supply: U256,

    #[namespace("b20.policy")]
    pub policy: B20Policy,
}
```

The `policy` field starts at `erc7201("b20.policy")`, and the fields inside `B20Policy` use normal Solidity offsets from that namespace root. Individual fields can also be tagged with the same `#[namespace("b20.policy")]` attribute when a separate section type is not needed.