### PR TITLE
refactor(precompiles): Share Precompile Selector Decoding

### DIFF
--- a/crates/common/precompiles/src/activation/dispatch.rs
+++ b/crates/common/precompiles/src/activation/dispatch.rs
@@ -1,14 +1,15 @@
 //! ABI dispatch for the activation registry.
 
 use alloy_primitives::{Address, Bytes};
-use alloy_sol_types::{SolCall, SolInterface};
-use base_precompile_storage::{BasePrecompileError, IntoPrecompileResult, StorageCtx};
+use alloy_sol_types::SolCall;
+use base_precompile_storage::{IntoPrecompileResult, StorageCtx};
 use revm::precompile::PrecompileResult;
 
 use super::{
     ActivationRegistryStorage,
     IActivationRegistry::{self, IActivationRegistryCalls as C},
 };
+use crate::macros::decode_precompile_call;
 
 impl ActivationRegistryStorage<'_> {
     /// ABI-dispatches activation registry calldata.
@@ -30,29 +31,23 @@ impl ActivationRegistryStorage<'_> {
         calldata: &[u8],
         activation_admin_address: Option<Address>,
     ) -> base_precompile_storage::Result<Bytes> {
-        if calldata.len() < 4 {
-            return Err(BasePrecompileError::UnknownFunctionSelector([0u8; 4]));
-        }
-        let selector: [u8; 4] = calldata[..4].try_into().unwrap();
-
-        match IActivationRegistry::IActivationRegistryCalls::abi_decode(calldata) {
-            Ok(C::isActivated(call)) => {
+        match decode_precompile_call!(calldata, IActivationRegistry::IActivationRegistryCalls) {
+            C::isActivated(call) => {
                 let activated = self.is_activated(call.feature)?;
                 Ok(IActivationRegistry::isActivatedCall::abi_encode_returns(&activated).into())
             }
-            Ok(C::activate(call)) => {
+            C::activate(call) => {
                 self.activate(call.feature, activation_admin_address)?;
                 Ok(Bytes::new())
             }
-            Ok(C::deactivate(call)) => {
+            C::deactivate(call) => {
                 self.deactivate(call.feature, activation_admin_address)?;
                 Ok(Bytes::new())
             }
-            Ok(C::admin(_)) => Ok(IActivationRegistry::adminCall::abi_encode_returns(
+            C::admin(_) => Ok(IActivationRegistry::adminCall::abi_encode_returns(
                 &self.admin(activation_admin_address),
             )
             .into()),
-            Err(_) => Err(BasePrecompileError::UnknownFunctionSelector(selector)),
         }
     }
 }

--- a/crates/common/precompiles/src/b20/dispatch.rs
+++ b/crates/common/precompiles/src/b20/dispatch.rs
@@ -1,5 +1,5 @@
 use alloy_primitives::{Bytes, U256};
-use alloy_sol_types::{SolInterface, SolValue};
+use alloy_sol_types::SolValue;
 use base_precompile_storage::{BasePrecompileError, IntoPrecompileResult, StorageCtx};
 use revm::precompile::PrecompileResult;
 
@@ -9,7 +9,7 @@ use super::{
 };
 use crate::{
     ActivationRegistryStorage, Burnable, Configurable, Mintable, Pausable, Permittable, Policy,
-    Redeemable, TokenAccounting, Transferable,
+    Redeemable, TokenAccounting, Transferable, macros::decode_precompile_call,
 };
 
 impl<S: TokenAccounting, P: Policy> B20Token<S, P> {
@@ -39,12 +39,7 @@ impl<S: TokenAccounting, P: Policy> B20Token<S, P> {
         ActivationRegistryStorage::new(ctx)
             .ensure_activated(ActivationRegistryStorage::B20_TOKEN)?;
 
-        if calldata.len() < 4 {
-            return Err(BasePrecompileError::UnknownFunctionSelector([0u8; 4]));
-        }
-        let selector: [u8; 4] = calldata[..4].try_into().unwrap();
-        let call = IB20::IB20Calls::abi_decode(calldata)
-            .map_err(|_| BasePrecompileError::UnknownFunctionSelector(selector))?;
+        let call = decode_precompile_call!(calldata, IB20::IB20Calls);
 
         let encoded: Bytes = match call {
             // --- Pure reads: direct to accounting ---

--- a/crates/common/precompiles/src/factory/dispatch.rs
+++ b/crates/common/precompiles/src/factory/dispatch.rs
@@ -1,11 +1,14 @@
 //! ABI dispatch for the `TokenFactory` precompile.
 
 use alloy_primitives::Bytes;
-use alloy_sol_types::{SolCall, SolInterface};
+use alloy_sol_types::SolCall;
 use base_precompile_storage::{BasePrecompileError, IntoPrecompileResult, StorageCtx};
 use revm::precompile::PrecompileResult;
 
-use crate::{ActivationRegistryStorage, ITokenFactory, TokenFactoryStorage, TokenVariant};
+use crate::{
+    ActivationRegistryStorage, ITokenFactory, TokenFactoryStorage, TokenVariant,
+    macros::decode_precompile_call,
+};
 
 impl<'a> TokenFactoryStorage<'a> {
     /// ABI-dispatches `calldata` to the appropriate `ITokenFactory` handler.
@@ -26,34 +29,28 @@ impl<'a> TokenFactoryStorage<'a> {
         ActivationRegistryStorage::new(ctx)
             .ensure_activated(ActivationRegistryStorage::TOKEN_FACTORY)?;
 
-        if calldata.len() < 4 {
-            return Err(BasePrecompileError::UnknownFunctionSelector([0u8; 4]));
-        }
-        let selector: [u8; 4] = calldata[..4].try_into().unwrap();
-
-        match ITokenFactory::ITokenFactoryCalls::abi_decode(calldata) {
-            Ok(ITokenFactory::ITokenFactoryCalls::createToken(call)) => {
+        match decode_precompile_call!(calldata, ITokenFactory::ITokenFactoryCalls) {
+            ITokenFactory::ITokenFactoryCalls::createToken(call) => {
                 let caller = ctx.caller();
                 let token = self.create_token(caller, call)?;
                 Ok(ITokenFactory::createTokenCall::abi_encode_returns(&token).into())
             }
-            Ok(ITokenFactory::ITokenFactoryCalls::getTokenAddress(call)) => {
+            ITokenFactory::ITokenFactoryCalls::getTokenAddress(call) => {
                 let Some(variant) = TokenFactoryStorage::token_variant(call.variant) else {
                     return Err(BasePrecompileError::revert(ITokenFactory::InvalidVariant {}));
                 };
                 let (addr, _) = variant.compute_address(call.sender, call.decimals, call.salt);
                 Ok(ITokenFactory::getTokenAddressCall::abi_encode_returns(&addr).into())
             }
-            Ok(ITokenFactory::ITokenFactoryCalls::isB20(call)) => {
+            ITokenFactory::ITokenFactoryCalls::isB20(call) => {
                 let result = self.is_b20(call.token)?;
                 Ok(ITokenFactory::isB20Call::abi_encode_returns(&result).into())
             }
-            Ok(ITokenFactory::ITokenFactoryCalls::getTokenVariant(call)) => {
+            ITokenFactory::ITokenFactoryCalls::getTokenVariant(call) => {
                 let variant =
                     TokenFactoryStorage::abi_variant(TokenVariant::from_address(call.token));
                 Ok(ITokenFactory::getTokenVariantCall::abi_encode_returns(&variant).into())
             }
-            Err(_) => Err(BasePrecompileError::UnknownFunctionSelector(selector)),
         }
     }
 }

--- a/crates/common/precompiles/src/macros.rs
+++ b/crates/common/precompiles/src/macros.rs
@@ -44,3 +44,63 @@ macro_rules! base_precompile {
 }
 
 pub(crate) use base_precompile;
+
+macro_rules! decode_precompile_call {
+    ($calldata:expr, $call_ty:ty $(,)?) => {{
+        let calldata = $calldata;
+        let selector = match calldata.get(..4) {
+            Some(bytes) => {
+                let mut selector = [0u8; 4];
+                selector.copy_from_slice(bytes);
+                selector
+            }
+            None => {
+                return Err(
+                    ::base_precompile_storage::BasePrecompileError::UnknownFunctionSelector(
+                        [0u8; 4],
+                    ),
+                );
+            }
+        };
+
+        <$call_ty as ::alloy_sol_types::SolInterface>::abi_decode(calldata).map_err(|_| {
+            ::base_precompile_storage::BasePrecompileError::UnknownFunctionSelector(selector)
+        })?
+    }};
+}
+
+pub(crate) use decode_precompile_call;
+
+#[cfg(test)]
+mod tests {
+    use alloy_sol_types::SolCall;
+    use base_precompile_storage::{BasePrecompileError, Result};
+
+    use crate::IPolicyRegistry;
+
+    fn decode_policy_call(calldata: &[u8]) -> Result<IPolicyRegistry::IPolicyRegistryCalls> {
+        Ok(decode_precompile_call!(calldata, IPolicyRegistry::IPolicyRegistryCalls,))
+    }
+
+    #[test]
+    fn decode_precompile_call_rejects_short_calldata() {
+        let err = decode_policy_call(&[1, 2, 3]).unwrap_err();
+
+        assert_eq!(err, BasePrecompileError::UnknownFunctionSelector([0u8; 4]));
+    }
+
+    #[test]
+    fn decode_precompile_call_preserves_unknown_selector() {
+        let err = decode_policy_call(&[1, 2, 3, 4]).unwrap_err();
+
+        assert_eq!(err, BasePrecompileError::UnknownFunctionSelector([1, 2, 3, 4]));
+    }
+
+    #[test]
+    fn decode_precompile_call_decodes_known_call() {
+        let calldata = IPolicyRegistry::helloWorldCall {}.abi_encode();
+        let call = decode_policy_call(&calldata).unwrap();
+
+        assert!(matches!(call, IPolicyRegistry::IPolicyRegistryCalls::helloWorld(_)));
+    }
+}

--- a/crates/common/precompiles/src/policy/dispatch.rs
+++ b/crates/common/precompiles/src/policy/dispatch.rs
@@ -1,13 +1,13 @@
 use alloy_primitives::Bytes;
-use alloy_sol_types::{SolCall, SolInterface};
-use base_precompile_storage::{BasePrecompileError, IntoPrecompileResult, StorageCtx};
+use alloy_sol_types::SolCall;
+use base_precompile_storage::{IntoPrecompileResult, StorageCtx};
 use revm::precompile::PrecompileResult;
 
 use super::{
     abi::{IPolicyRegistry, IPolicyRegistry::IPolicyRegistryCalls as C},
     storage::PolicyRegistryStorage,
 };
-use crate::ActivationRegistryStorage;
+use crate::{ActivationRegistryStorage, macros::decode_precompile_call};
 
 impl PolicyRegistryStorage<'_> {
     /// ABI-dispatches `calldata` to the appropriate `IPolicyRegistry` handler.
@@ -22,16 +22,10 @@ impl PolicyRegistryStorage<'_> {
     }
 
     fn inner(&self, calldata: &[u8]) -> base_precompile_storage::Result<Bytes> {
-        if calldata.len() < 4 {
-            return Err(BasePrecompileError::UnknownFunctionSelector([0u8; 4]));
-        }
-        let selector: [u8; 4] = calldata[..4].try_into().unwrap();
-
-        match IPolicyRegistry::IPolicyRegistryCalls::abi_decode(calldata) {
-            Ok(C::helloWorld(_)) => {
+        match decode_precompile_call!(calldata, IPolicyRegistry::IPolicyRegistryCalls) {
+            C::helloWorld(_) => {
                 Ok(IPolicyRegistry::helloWorldCall::abi_encode_returns(&true).into())
             }
-            Err(_) => Err(BasePrecompileError::UnknownFunctionSelector(selector)),
         }
     }
 }


### PR DESCRIPTION
## Summary

This centralizes Base native precompile calldata selector validation in a shared macro next to `base_precompile!`. The B20, token factory, policy registry, and activation registry dispatchers now decode through the shared helper, with focused tests covering short calldata, unknown selectors, and a known call.