### PR TITLE
feat(zk): add dry-run prover backend

### DIFF
--- a/bin/prover/zk/README.md
+++ b/bin/prover/zk/README.md
@@ -3,3 +3,5 @@
 ZK prover service binary.
 
 Runs the gRPC ZK prover server. Reads proof requests from a database outbox, dispatches them to a cluster backend, and stores artifacts in Redis, S3, or GCS.
+
+Set `SP1_PROVER=dry-run` to generate a real witness and execute the SP1 range program locally without producing a proof. Dry-run results are returned from `GetProofResponse.execution_stats`.

--- a/bin/prover/zk/src/cli.rs
+++ b/bin/prover/zk/src/cli.rs
@@ -9,9 +9,9 @@ use base_zk_db::{DatabaseConfig, ProofRequestRepo};
 use base_zk_outbox::{DatabaseOutboxReader, OutboxProcessor};
 use base_zk_service::{
     ArtifactClientWrapper, ArtifactStorageConfig, BackendConfig, BackendRegistry,
-    OpSuccinctClusterBackend, OpSuccinctMockBackend, OpSuccinctNetworkBackend, OpSuccinctProvider,
-    ProofRequestManager, ProverServiceServer, ProverWorkerPool, ProxyConfigs, RateLimitConfig,
-    StatusPoller, start_all_proxies,
+    OpSuccinctClusterBackend, OpSuccinctDryRunBackend, OpSuccinctMockBackend,
+    OpSuccinctNetworkBackend, OpSuccinctProvider, ProofRequestManager, ProverServiceServer,
+    ProverWorkerPool, ProxyConfigs, RateLimitConfig, StatusPoller, start_all_proxies,
 };
 use clap::Parser;
 use eyre::eyre;
@@ -206,21 +206,41 @@ impl ZkArgs {
                 .map_err(|e| eyre!("invalid L2 node RPC URL: {e}"))?,
         };
 
-        info!("computing range and aggregation verifying keys");
-        let (range_pk, range_vk, agg_pk, agg_vk) =
-            base_proof_succinct_proof_utils::cluster_setup_keys()
-                .await
-                .map_err(|e| eyre!("failed to compute verifying keys: {e}"))?;
-        info!("verifying keys computed successfully");
-
         let mut backend_registry = BackendRegistry::new();
 
-        if self.prover_mode == "mock" {
+        if self.prover_mode == "dry-run" {
+            info!("SP1_PROVER=dry-run: using local SP1 execution backend");
+
+            let fetcher = Arc::new(
+                base_proof_succinct_host_utils::fetcher::OPSuccinctDataFetcher::from_rpc_config_with_rollup_config(rpc_config)
+                    .await
+                    .map_err(|e| eyre!("failed to create OPSuccinctDataFetcher: {e}"))?,
+            );
+            let provider = OpSuccinctProvider::new(fetcher);
+            let backend = OpSuccinctDryRunBackend::new(
+                provider,
+                self.base_consensus_address.clone(),
+                l1_url.clone(),
+                self.default_sequence_window,
+            );
+            backend_registry.register(Arc::new(backend));
+        } else if self.prover_mode == "mock" {
             info!("SP1_PROVER=mock: using MockBackend (instant fake proofs, no cluster)");
+            info!("computing range and aggregation verifying keys");
+            let (range_vk, agg_vk) = base_proof_succinct_proof_utils::cluster_setup_vkeys()
+                .await
+                .map_err(|e| eyre!("failed to compute verifying keys: {e}"))?;
+            info!("verifying keys computed successfully");
             let mock_backend = OpSuccinctMockBackend::new(range_vk, agg_vk);
             backend_registry.register(Arc::new(mock_backend));
         } else if self.prover_mode == "network" {
             info!("SP1_PROVER=network: using Succinct SP1 Network backend");
+            info!("computing range and aggregation proving keys");
+            let (range_pk, range_vk, agg_pk, agg_vk) =
+                base_proof_succinct_proof_utils::cluster_setup_keys()
+                    .await
+                    .map_err(|e| eyre!("failed to compute proving keys: {e}"))?;
+            info!("proving keys computed successfully");
 
             let fetcher = Arc::new(
                 base_proof_succinct_host_utils::fetcher::OPSuccinctDataFetcher::from_rpc_config_with_rollup_config(rpc_config)
@@ -280,6 +300,11 @@ impl ZkArgs {
             backend_registry.register(backend);
         } else {
             info!("SP1_PROVER=cluster: using Succinct cluster backend");
+            info!("computing range and aggregation verifying keys");
+            let (range_vk, _) = base_proof_succinct_proof_utils::cluster_setup_vkeys()
+                .await
+                .map_err(|e| eyre!("failed to compute verifying keys: {e}"))?;
+            info!("verifying keys computed successfully");
 
             info!("creating Succinct data fetcher");
             let fetcher = Arc::new(
@@ -434,15 +459,15 @@ impl ZkArgs {
     }
 
     fn validate_config(&self) -> eyre::Result<()> {
-        if !matches!(self.prover_mode.as_str(), "cluster" | "mock" | "network") {
+        if !matches!(self.prover_mode.as_str(), "cluster" | "mock" | "network" | "dry-run") {
             eyre::bail!(
-                "SP1_PROVER must be set to 'cluster', 'mock', or 'network', got '{}'",
+                "SP1_PROVER must be set to 'cluster', 'mock', 'network', or 'dry-run', got '{}'",
                 self.prover_mode
             );
         }
 
-        if self.prover_mode == "mock" {
-            info!(prover_mode = "mock", "configuration validated");
+        if matches!(self.prover_mode.as_str(), "mock" | "dry-run") {
+            info!(prover_mode = %self.prover_mode, "configuration validated");
             return Ok(());
         }
 

--- a/crates/proof/challenge/src/test_utils.rs
+++ b/crates/proof/challenge/src/test_utils.rs
@@ -721,6 +721,7 @@ impl ZkProofProvider for MockZkProofProvider {
             status: state.proof_status,
             receipt: state.receipt,
             error_message: state.error_message,
+            execution_stats: None,
         })
     }
 }

--- a/crates/proof/zk/client/README.md
+++ b/crates/proof/zk/client/README.md
@@ -107,6 +107,7 @@ impl ZkProofProvider for MockProvider {
             status: ProofJobStatus::Succeeded.into(),
             receipt: vec![1, 2, 3],
             error_message: None,
+            execution_stats: None,
         })
     }
 }

--- a/crates/proof/zk/client/proto/zk_prover.proto
+++ b/crates/proof/zk/client/proto/zk_prover.proto
@@ -65,6 +65,15 @@ message GetProofResponse {
   Status status = 1;
   bytes receipt = 2; // the actual zk proof, only populated if status is SUCCEEDED
   optional string error_message = 3; // populated when status is STATUS_FAILED
+  optional ExecutionStats execution_stats = 4; // populated by dry-run backends
+}
+
+message ExecutionStats {
+  uint64 total_instruction_cycles = 1;
+  uint64 total_sp1_gas = 2;
+  map<string, uint64> cycle_tracker = 3;
+  double witness_generation_ms = 4;
+  double execution_ms = 5;
 }
 
 message ListProofsRequest {

--- a/crates/proof/zk/client/src/lib.rs
+++ b/crates/proof/zk/client/src/lib.rs
@@ -28,9 +28,9 @@ pub const PROVER_FILE_DESCRIPTOR_SET: &[u8] =
     tonic::include_file_descriptor_set!("prover_descriptor");
 
 pub use proto::{
-    GetProofRequest, GetProofResponse, ListProofsRequest, ListProofsResponse, ProofSummary,
-    ProofType, ProveBlockRequest, ProveBlockResponse, ReceiptType, get_proof_response,
-    get_proof_response::Status as ProofJobStatus, prover_service_client,
+    ExecutionStats, GetProofRequest, GetProofResponse, ListProofsRequest, ListProofsResponse,
+    ProofSummary, ProofType, ProveBlockRequest, ProveBlockResponse, ReceiptType,
+    get_proof_response, get_proof_response::Status as ProofJobStatus, prover_service_client,
 };
 
 mod client;

--- a/crates/proof/zk/client/tests/mock_provider.rs
+++ b/crates/proof/zk/client/tests/mock_provider.rs
@@ -25,6 +25,7 @@ impl ZkProofProvider for MockZkProvider {
             status: ProofJobStatus::Succeeded.into(),
             receipt: vec![0xDE, 0xAD, 0xBE, 0xEF],
             error_message: None,
+            execution_stats: None,
         })
     }
 }

--- a/crates/proof/zk/service/src/backends/mod.rs
+++ b/crates/proof/zk/service/src/backends/mod.rs
@@ -3,8 +3,10 @@
 mod op_succinct;
 pub use op_succinct::{
     ClusterBackend as OpSuccinctClusterBackend, DryRunBackend as OpSuccinctDryRunBackend,
+    EXECUTION_STATS_METADATA_KEY as OP_SUCCINCT_EXECUTION_STATS_METADATA_KEY,
     MockBackend as OpSuccinctMockBackend, NetworkBackend as OpSuccinctNetworkBackend,
-    OpSuccinctProvider, WitnessParams as OpSuccinctWitnessParams,
+    OpSuccinctProvider, StoredExecutionStats as OpSuccinctStoredExecutionStats,
+    WitnessParams as OpSuccinctWitnessParams,
 };
 
 mod traits;

--- a/crates/proof/zk/service/src/backends/mod.rs
+++ b/crates/proof/zk/service/src/backends/mod.rs
@@ -2,7 +2,9 @@
 
 mod op_succinct;
 pub use op_succinct::{
-    ClusterBackend as OpSuccinctClusterBackend, DryRunBackend as OpSuccinctDryRunBackend,
+    ClusterBackend as OpSuccinctClusterBackend,
+    DRY_RUN_METADATA_KEY as OP_SUCCINCT_DRY_RUN_METADATA_KEY,
+    DryRunBackend as OpSuccinctDryRunBackend,
     EXECUTION_STATS_METADATA_KEY as OP_SUCCINCT_EXECUTION_STATS_METADATA_KEY,
     MockBackend as OpSuccinctMockBackend, NetworkBackend as OpSuccinctNetworkBackend,
     OpSuccinctProvider, StoredExecutionStats as OpSuccinctStoredExecutionStats,

--- a/crates/proof/zk/service/src/backends/mod.rs
+++ b/crates/proof/zk/service/src/backends/mod.rs
@@ -2,9 +2,9 @@
 
 mod op_succinct;
 pub use op_succinct::{
-    ClusterBackend as OpSuccinctClusterBackend, MockBackend as OpSuccinctMockBackend,
-    NetworkBackend as OpSuccinctNetworkBackend, OpSuccinctProvider,
-    WitnessParams as OpSuccinctWitnessParams,
+    ClusterBackend as OpSuccinctClusterBackend, DryRunBackend as OpSuccinctDryRunBackend,
+    MockBackend as OpSuccinctMockBackend, NetworkBackend as OpSuccinctNetworkBackend,
+    OpSuccinctProvider, WitnessParams as OpSuccinctWitnessParams,
 };
 
 mod traits;

--- a/crates/proof/zk/service/src/backends/op_succinct/dry_run.rs
+++ b/crates/proof/zk/service/src/backends/op_succinct/dry_run.rs
@@ -12,7 +12,7 @@ use base_proof_succinct_proof_utils::get_range_elf_embedded;
 use base_zk_client::{ExecutionStats, ProveBlockRequest};
 use base_zk_db::{
     ProofRequest, ProofRequestRepo, ProofSession, ProofStatus, ProofType,
-    SessionStatus as DbSessionStatus, UpdateReceipt,
+    SessionStatus as DbSessionStatus, UpdateProofSession,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::json;
@@ -32,7 +32,7 @@ use crate::backends::traits::{
 pub const EXECUTION_STATS_METADATA_KEY: &str = "execution_stats";
 
 /// Metadata key indicating that a session was produced by the dry-run backend.
-const DRY_RUN_METADATA_KEY: &str = "dry_run";
+pub const DRY_RUN_METADATA_KEY: &str = "dry_run";
 
 /// Local execution backend that returns SP1 execution statistics.
 #[derive(Clone)]
@@ -254,22 +254,20 @@ impl ProvingBackend for DryRunBackend {
             }
         }
 
-        for session in &sessions {
-            if session.status == DbSessionStatus::Running {
-                let update_receipt = UpdateReceipt {
-                    id: proof_request.id,
-                    stark_receipt: None,
-                    snark_receipt: None,
-                    status: ProofStatus::Running,
-                    error_message: None,
-                };
+        let running_sessions =
+            sessions.iter().filter(|session| session.status == DbSessionStatus::Running);
 
-                repo.complete_session_and_update_receipt(
-                    &session.backend_session_id,
-                    update_receipt,
-                )
+        for session in running_sessions {
+            let updated = repo
+                .update_proof_session_if_non_terminal(UpdateProofSession {
+                    backend_session_id: session.backend_session_id.clone(),
+                    status: DbSessionStatus::Completed,
+                    error_message: None,
+                    metadata: None,
+                })
                 .await?;
 
+            if updated {
                 info!(
                     proof_request_id = %proof_request.id,
                     session_id = %session.backend_session_id,

--- a/crates/proof/zk/service/src/backends/op_succinct/dry_run.rs
+++ b/crates/proof/zk/service/src/backends/op_succinct/dry_run.rs
@@ -1,7 +1,7 @@
 //! Dry-run backend for local SP1 execution statistics.
 //!
 //! This backend generates a real witness and executes the range program with
-//! `CpuProver`, but it does not produce or submit a proof.
+//! `MockProver`, but it does not produce or submit a proof.
 
 use std::{collections::HashMap, fmt};
 
@@ -20,7 +20,7 @@ use sp1_sdk::{
     Elf, SP1Stdin,
     blocking::{MockProver, Prover},
 };
-use tracing::{error, info};
+use tracing::{error, info, warn};
 use uuid::Uuid;
 
 use super::provider::{OpSuccinctProvider, WitnessParams};
@@ -99,7 +99,7 @@ impl DryRunBackend {
         Self { provider, base_consensus_url, l1_node_url, default_sequence_window }
     }
 
-    async fn execute_range_program(stdin: SP1Stdin) -> anyhow::Result<(ExecutionStats, f64)> {
+    async fn execute_range_program(stdin: SP1Stdin) -> anyhow::Result<ExecutionStats> {
         let execution_start = std::time::Instant::now();
         let (_, report) = tokio::task::spawn_blocking(move || {
             info!("starting local SP1 zkVM execution");
@@ -117,13 +117,16 @@ impl DryRunBackend {
         let execution_ms = execution_start.elapsed().as_secs_f64() * 1000.0;
         let stats = ExecutionStats {
             total_instruction_cycles: report.total_instruction_count(),
-            total_sp1_gas: report.gas().unwrap_or(0),
+            total_sp1_gas: report.gas().unwrap_or_else(|| {
+                warn!("gas calculation returned None despite calculate_gas(true)");
+                0
+            }),
             cycle_tracker: report.cycle_tracker.into_iter().collect(),
             witness_generation_ms: 0.0,
             execution_ms,
         };
 
-        Ok((stats, execution_ms))
+        Ok(stats)
     }
 }
 
@@ -195,14 +198,14 @@ impl ProvingBackend for DryRunBackend {
             })?;
         let witness_generation_ms = witness_start.elapsed().as_secs_f64() * 1000.0;
 
-        let (mut execution_stats, execution_ms) = Self::execute_range_program(stdin).await?;
+        let mut execution_stats = Self::execute_range_program(stdin).await?;
         execution_stats.witness_generation_ms = witness_generation_ms;
 
         info!(
             total_instruction_cycles = execution_stats.total_instruction_cycles,
             total_sp1_gas = execution_stats.total_sp1_gas,
             witness_generation_ms = witness_generation_ms,
-            execution_ms = execution_ms,
+            execution_ms = execution_stats.execution_ms,
             tracked_sections = execution_stats.cycle_tracker.len(),
             "dry-run SP1 execution completed"
         );

--- a/crates/proof/zk/service/src/backends/op_succinct/dry_run.rs
+++ b/crates/proof/zk/service/src/backends/op_succinct/dry_run.rs
@@ -3,7 +3,7 @@
 //! This backend generates a real witness and executes the range program with
 //! `CpuProver`, but it does not produce or submit a proof.
 
-use std::fmt;
+use std::{collections::HashMap, fmt};
 
 use alloy_primitives::B256;
 use async_trait::async_trait;
@@ -11,8 +11,8 @@ use base_proof_succinct_client_utils::client::DEFAULT_INTERMEDIATE_ROOT_INTERVAL
 use base_proof_succinct_proof_utils::get_range_elf_embedded;
 use base_zk_client::{ExecutionStats, ProveBlockRequest};
 use base_zk_db::{
-    ProofRequest, ProofRequestRepo, ProofSession, ProofStatus, SessionStatus as DbSessionStatus,
-    UpdateReceipt,
+    ProofRequest, ProofRequestRepo, ProofSession, ProofStatus, ProofType,
+    SessionStatus as DbSessionStatus, UpdateReceipt,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::json;
@@ -29,7 +29,7 @@ use crate::backends::traits::{
 };
 
 /// Metadata key where dry-run execution stats are stored on proof sessions.
-pub(crate) const EXECUTION_STATS_METADATA_KEY: &str = "execution_stats";
+pub const EXECUTION_STATS_METADATA_KEY: &str = "execution_stats";
 
 /// Metadata key indicating that a session was produced by the dry-run backend.
 pub(crate) const DRY_RUN_METADATA_KEY: &str = "dry_run";
@@ -43,13 +43,19 @@ pub struct DryRunBackend {
     default_sequence_window: u64,
 }
 
+/// Execution statistics persisted in proof-session metadata.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub(crate) struct StoredExecutionStats {
-    pub(crate) total_instruction_cycles: u64,
-    pub(crate) total_sp1_gas: u64,
-    pub(crate) cycle_tracker: std::collections::HashMap<String, u64>,
-    pub(crate) witness_generation_ms: f64,
-    pub(crate) execution_ms: f64,
+pub struct StoredExecutionStats {
+    /// Total RISC-V instruction cycles reported by SP1.
+    pub total_instruction_cycles: u64,
+    /// Total SP1 gas reported by SP1.
+    pub total_sp1_gas: u64,
+    /// Per-section cycle tracker values reported by the range program.
+    pub cycle_tracker: HashMap<String, u64>,
+    /// Time spent generating the witness, in milliseconds.
+    pub witness_generation_ms: f64,
+    /// Time spent executing the SP1 range program, in milliseconds.
+    pub execution_ms: f64,
 }
 
 impl From<ExecutionStats> for StoredExecutionStats {
@@ -84,7 +90,7 @@ impl fmt::Debug for DryRunBackend {
 
 impl DryRunBackend {
     /// Create a dry-run backend using the shared OP Succinct witness provider.
-    pub fn new(
+    pub const fn new(
         provider: OpSuccinctProvider,
         base_consensus_url: String,
         l1_node_url: String,
@@ -132,9 +138,19 @@ impl ProvingBackend for DryRunBackend {
             anyhow::bail!("number_of_blocks_to_prove must be > 0");
         }
 
+        let proof_type = ProofType::try_from(request.proof_type)
+            .map_err(|e| anyhow::anyhow!("invalid proof_type: {e}"))?;
+        if proof_type == ProofType::OpSuccinctSp1ClusterSnarkGroth16 {
+            anyhow::bail!(
+                "dry-run backend only supports compressed proof types; SNARK_GROTH16 requires a proof-producing backend"
+            );
+        }
+
         let start_block = request.start_block_number;
         let num_blocks = request.number_of_blocks_to_prove;
-        let end_block = start_block + num_blocks;
+        let end_block = start_block.checked_add(num_blocks).ok_or_else(|| {
+            anyhow::anyhow!("block range overflow: start={start_block} + count={num_blocks}")
+        })?;
         let sequence_window = request.sequence_window.unwrap_or(self.default_sequence_window);
         let intermediate_root_interval =
             request.intermediate_root_interval.unwrap_or(DEFAULT_INTERMEDIATE_ROOT_INTERVAL);
@@ -210,6 +226,16 @@ impl ProvingBackend for DryRunBackend {
         proof_request: &ProofRequest,
         repo: &ProofRequestRepo,
     ) -> anyhow::Result<ProofProcessingResult> {
+        if proof_request.proof_type == ProofType::OpSuccinctSp1ClusterSnarkGroth16 {
+            return Ok(ProofProcessingResult {
+                status: ProofStatus::Failed,
+                error_message: Some(
+                    "dry-run backend only supports compressed proof types; SNARK_GROTH16 requires a proof-producing backend"
+                        .to_string(),
+                ),
+            });
+        }
+
         let sessions = repo.get_sessions_for_request(proof_request.id).await?;
 
         if sessions.is_empty() {

--- a/crates/proof/zk/service/src/backends/op_succinct/dry_run.rs
+++ b/crates/proof/zk/service/src/backends/op_succinct/dry_run.rs
@@ -1,0 +1,266 @@
+//! Dry-run backend for local SP1 execution statistics.
+//!
+//! This backend generates a real witness and executes the range program with
+//! `CpuProver`, but it does not produce or submit a proof.
+
+use std::fmt;
+
+use alloy_primitives::B256;
+use async_trait::async_trait;
+use base_proof_succinct_client_utils::client::DEFAULT_INTERMEDIATE_ROOT_INTERVAL;
+use base_proof_succinct_proof_utils::get_range_elf_embedded;
+use base_zk_client::{ExecutionStats, ProveBlockRequest};
+use base_zk_db::{
+    ProofRequest, ProofRequestRepo, ProofSession, ProofStatus, SessionStatus as DbSessionStatus,
+    UpdateReceipt,
+};
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use sp1_sdk::{
+    Elf, SP1Stdin,
+    blocking::{MockProver, Prover},
+};
+use tracing::{error, info};
+use uuid::Uuid;
+
+use super::provider::{OpSuccinctProvider, WitnessParams};
+use crate::backends::traits::{
+    BackendType, ProofProcessingResult, ProveResult, ProvingBackend, SessionStatus,
+};
+
+/// Metadata key where dry-run execution stats are stored on proof sessions.
+pub(crate) const EXECUTION_STATS_METADATA_KEY: &str = "execution_stats";
+
+/// Metadata key indicating that a session was produced by the dry-run backend.
+pub(crate) const DRY_RUN_METADATA_KEY: &str = "dry_run";
+
+/// Local execution backend that returns SP1 execution statistics.
+#[derive(Clone)]
+pub struct DryRunBackend {
+    provider: OpSuccinctProvider,
+    base_consensus_url: String,
+    l1_node_url: String,
+    default_sequence_window: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct StoredExecutionStats {
+    pub(crate) total_instruction_cycles: u64,
+    pub(crate) total_sp1_gas: u64,
+    pub(crate) cycle_tracker: std::collections::HashMap<String, u64>,
+    pub(crate) witness_generation_ms: f64,
+    pub(crate) execution_ms: f64,
+}
+
+impl From<ExecutionStats> for StoredExecutionStats {
+    fn from(value: ExecutionStats) -> Self {
+        Self {
+            total_instruction_cycles: value.total_instruction_cycles,
+            total_sp1_gas: value.total_sp1_gas,
+            cycle_tracker: value.cycle_tracker,
+            witness_generation_ms: value.witness_generation_ms,
+            execution_ms: value.execution_ms,
+        }
+    }
+}
+
+impl From<StoredExecutionStats> for ExecutionStats {
+    fn from(value: StoredExecutionStats) -> Self {
+        Self {
+            total_instruction_cycles: value.total_instruction_cycles,
+            total_sp1_gas: value.total_sp1_gas,
+            cycle_tracker: value.cycle_tracker,
+            witness_generation_ms: value.witness_generation_ms,
+            execution_ms: value.execution_ms,
+        }
+    }
+}
+
+impl fmt::Debug for DryRunBackend {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("DryRunBackend").finish_non_exhaustive()
+    }
+}
+
+impl DryRunBackend {
+    /// Create a dry-run backend using the shared OP Succinct witness provider.
+    pub fn new(
+        provider: OpSuccinctProvider,
+        base_consensus_url: String,
+        l1_node_url: String,
+        default_sequence_window: u64,
+    ) -> Self {
+        Self { provider, base_consensus_url, l1_node_url, default_sequence_window }
+    }
+
+    async fn execute_range_program(stdin: SP1Stdin) -> anyhow::Result<(ExecutionStats, f64)> {
+        let execution_start = std::time::Instant::now();
+        let (_, report) = tokio::task::spawn_blocking(move || {
+            info!("starting local SP1 zkVM execution");
+
+            let prover = MockProver::new();
+            prover
+                .execute(Elf::Static(get_range_elf_embedded()), stdin)
+                .calculate_gas(true)
+                .deferred_proof_verification(false)
+                .run()
+        })
+        .await
+        .map_err(|e| anyhow::anyhow!("SP1 execution task failed to join: {e}"))??;
+
+        let execution_ms = execution_start.elapsed().as_secs_f64() * 1000.0;
+        let stats = ExecutionStats {
+            total_instruction_cycles: report.total_instruction_count(),
+            total_sp1_gas: report.gas().unwrap_or(0),
+            cycle_tracker: report.cycle_tracker.into_iter().collect(),
+            witness_generation_ms: 0.0,
+            execution_ms,
+        };
+
+        Ok((stats, execution_ms))
+    }
+}
+
+#[async_trait]
+impl ProvingBackend for DryRunBackend {
+    fn backend_type(&self) -> BackendType {
+        BackendType::OpSuccinct
+    }
+
+    async fn prove(&self, request: &ProveBlockRequest) -> anyhow::Result<ProveResult> {
+        if request.number_of_blocks_to_prove == 0 {
+            anyhow::bail!("number_of_blocks_to_prove must be > 0");
+        }
+
+        let start_block = request.start_block_number;
+        let num_blocks = request.number_of_blocks_to_prove;
+        let end_block = start_block + num_blocks;
+        let sequence_window = request.sequence_window.unwrap_or(self.default_sequence_window);
+        let intermediate_root_interval =
+            request.intermediate_root_interval.unwrap_or(DEFAULT_INTERMEDIATE_ROOT_INTERVAL);
+        let l1_head: Option<B256> = request
+            .l1_head
+            .as_ref()
+            .map(|h| h.parse::<B256>())
+            .transpose()
+            .map_err(|e| anyhow::anyhow!("invalid l1_head hash: {e}"))?;
+
+        info!(
+            start_block = start_block,
+            end_block = end_block,
+            num_blocks = num_blocks,
+            sequence_window = sequence_window,
+            intermediate_root_interval = intermediate_root_interval,
+            l1_head = ?l1_head,
+            "starting dry-run SP1 execution"
+        );
+
+        let witness_start = std::time::Instant::now();
+        let stdin = self
+            .provider
+            .generate_witness(WitnessParams {
+                start_block,
+                end_block,
+                sequence_window,
+                l1_node_url: &self.l1_node_url,
+                base_consensus_url: &self.base_consensus_url,
+                l1_head,
+                intermediate_root_interval,
+            })
+            .await
+            .map_err(|e| {
+                error!(
+                    start_block = start_block,
+                    end_block = end_block,
+                    error = %e,
+                    "dry-run witness generation failed"
+                );
+                anyhow::anyhow!("witness generation failed: {e}")
+            })?;
+        let witness_generation_ms = witness_start.elapsed().as_secs_f64() * 1000.0;
+
+        let (mut execution_stats, execution_ms) = Self::execute_range_program(stdin).await?;
+        execution_stats.witness_generation_ms = witness_generation_ms;
+
+        info!(
+            total_instruction_cycles = execution_stats.total_instruction_cycles,
+            total_sp1_gas = execution_stats.total_sp1_gas,
+            witness_generation_ms = witness_generation_ms,
+            execution_ms = execution_ms,
+            tracked_sections = execution_stats.cycle_tracker.len(),
+            "dry-run SP1 execution completed"
+        );
+
+        let session_id = format!("dry-run-{}", Uuid::new_v4());
+        let stored_stats = StoredExecutionStats::from(execution_stats);
+        let metadata = json!({
+            DRY_RUN_METADATA_KEY: true,
+            EXECUTION_STATS_METADATA_KEY: stored_stats,
+        });
+
+        Ok(ProveResult {
+            session_id: Some(session_id),
+            metadata: Some(metadata),
+            witness_gen_duration_ms: Some(witness_generation_ms),
+        })
+    }
+
+    async fn process_proof_request(
+        &self,
+        proof_request: &ProofRequest,
+        repo: &ProofRequestRepo,
+    ) -> anyhow::Result<ProofProcessingResult> {
+        let sessions = repo.get_sessions_for_request(proof_request.id).await?;
+
+        if sessions.is_empty() {
+            return Ok(ProofProcessingResult { status: ProofStatus::Pending, error_message: None });
+        }
+
+        for session in &sessions {
+            if session.status == DbSessionStatus::Failed {
+                return Ok(ProofProcessingResult {
+                    status: ProofStatus::Failed,
+                    error_message: session.error_message.clone(),
+                });
+            }
+        }
+
+        for session in &sessions {
+            if session.status == DbSessionStatus::Running {
+                let update_receipt = UpdateReceipt {
+                    id: proof_request.id,
+                    stark_receipt: None,
+                    snark_receipt: None,
+                    status: ProofStatus::Running,
+                    error_message: None,
+                };
+
+                repo.complete_session_and_update_receipt(
+                    &session.backend_session_id,
+                    update_receipt,
+                )
+                .await?;
+
+                info!(
+                    proof_request_id = %proof_request.id,
+                    session_id = %session.backend_session_id,
+                    "dry-run session completed"
+                );
+            }
+        }
+
+        let updated_sessions = repo.get_sessions_for_request(proof_request.id).await?;
+        let all_complete = updated_sessions.iter().all(|s| s.status == DbSessionStatus::Completed);
+        let status = if all_complete { ProofStatus::Succeeded } else { ProofStatus::Running };
+
+        Ok(ProofProcessingResult { status, error_message: None })
+    }
+
+    async fn get_session_status(&self, _session: &ProofSession) -> anyhow::Result<SessionStatus> {
+        Ok(SessionStatus::Completed)
+    }
+
+    fn name(&self) -> &'static str {
+        "Dry-run (local SP1 execution stats)"
+    }
+}

--- a/crates/proof/zk/service/src/backends/op_succinct/dry_run.rs
+++ b/crates/proof/zk/service/src/backends/op_succinct/dry_run.rs
@@ -32,7 +32,7 @@ use crate::backends::traits::{
 pub const EXECUTION_STATS_METADATA_KEY: &str = "execution_stats";
 
 /// Metadata key indicating that a session was produced by the dry-run backend.
-pub(crate) const DRY_RUN_METADATA_KEY: &str = "dry_run";
+const DRY_RUN_METADATA_KEY: &str = "dry_run";
 
 /// Local execution backend that returns SP1 execution statistics.
 #[derive(Clone)]

--- a/crates/proof/zk/service/src/backends/op_succinct/mod.rs
+++ b/crates/proof/zk/service/src/backends/op_succinct/mod.rs
@@ -4,7 +4,9 @@ mod cluster;
 pub use cluster::ClusterBackend;
 
 mod dry_run;
-pub use dry_run::{DryRunBackend, EXECUTION_STATS_METADATA_KEY, StoredExecutionStats};
+pub use dry_run::{
+    DRY_RUN_METADATA_KEY, DryRunBackend, EXECUTION_STATS_METADATA_KEY, StoredExecutionStats,
+};
 
 mod mock;
 pub use mock::MockBackend;

--- a/crates/proof/zk/service/src/backends/op_succinct/mod.rs
+++ b/crates/proof/zk/service/src/backends/op_succinct/mod.rs
@@ -3,6 +3,9 @@
 mod cluster;
 pub use cluster::ClusterBackend;
 
+mod dry_run;
+pub use dry_run::DryRunBackend;
+
 mod mock;
 pub use mock::MockBackend;
 

--- a/crates/proof/zk/service/src/backends/op_succinct/mod.rs
+++ b/crates/proof/zk/service/src/backends/op_succinct/mod.rs
@@ -4,7 +4,7 @@ mod cluster;
 pub use cluster::ClusterBackend;
 
 mod dry_run;
-pub use dry_run::DryRunBackend;
+pub use dry_run::{DryRunBackend, EXECUTION_STATS_METADATA_KEY, StoredExecutionStats};
 
 mod mock;
 pub use mock::MockBackend;

--- a/crates/proof/zk/service/src/lib.rs
+++ b/crates/proof/zk/service/src/lib.rs
@@ -4,9 +4,10 @@
 mod backends;
 pub use backends::{
     ArtifactClientWrapper, ArtifactStorageConfig, BackendConfig, BackendRegistry, BackendType,
-    L1HeadCalculator, OpSuccinctClusterBackend, OpSuccinctDryRunBackend, OpSuccinctMockBackend,
-    OpSuccinctNetworkBackend, OpSuccinctProvider, OpSuccinctWitnessParams, ProofProcessingResult,
-    ProveResult, ProvingBackend, SessionStatus,
+    L1HeadCalculator, OP_SUCCINCT_EXECUTION_STATS_METADATA_KEY, OpSuccinctClusterBackend,
+    OpSuccinctDryRunBackend, OpSuccinctMockBackend, OpSuccinctNetworkBackend, OpSuccinctProvider,
+    OpSuccinctStoredExecutionStats, OpSuccinctWitnessParams, ProofProcessingResult, ProveResult,
+    ProvingBackend, SessionStatus,
 };
 
 pub mod metrics;

--- a/crates/proof/zk/service/src/lib.rs
+++ b/crates/proof/zk/service/src/lib.rs
@@ -4,10 +4,10 @@
 mod backends;
 pub use backends::{
     ArtifactClientWrapper, ArtifactStorageConfig, BackendConfig, BackendRegistry, BackendType,
-    L1HeadCalculator, OP_SUCCINCT_EXECUTION_STATS_METADATA_KEY, OpSuccinctClusterBackend,
-    OpSuccinctDryRunBackend, OpSuccinctMockBackend, OpSuccinctNetworkBackend, OpSuccinctProvider,
-    OpSuccinctStoredExecutionStats, OpSuccinctWitnessParams, ProofProcessingResult, ProveResult,
-    ProvingBackend, SessionStatus,
+    L1HeadCalculator, OP_SUCCINCT_DRY_RUN_METADATA_KEY, OP_SUCCINCT_EXECUTION_STATS_METADATA_KEY,
+    OpSuccinctClusterBackend, OpSuccinctDryRunBackend, OpSuccinctMockBackend,
+    OpSuccinctNetworkBackend, OpSuccinctProvider, OpSuccinctStoredExecutionStats,
+    OpSuccinctWitnessParams, ProofProcessingResult, ProveResult, ProvingBackend, SessionStatus,
 };
 
 pub mod metrics;

--- a/crates/proof/zk/service/src/lib.rs
+++ b/crates/proof/zk/service/src/lib.rs
@@ -4,9 +4,9 @@
 mod backends;
 pub use backends::{
     ArtifactClientWrapper, ArtifactStorageConfig, BackendConfig, BackendRegistry, BackendType,
-    L1HeadCalculator, OpSuccinctClusterBackend, OpSuccinctMockBackend, OpSuccinctNetworkBackend,
-    OpSuccinctProvider, OpSuccinctWitnessParams, ProofProcessingResult, ProveResult,
-    ProvingBackend, SessionStatus,
+    L1HeadCalculator, OpSuccinctClusterBackend, OpSuccinctDryRunBackend, OpSuccinctMockBackend,
+    OpSuccinctNetworkBackend, OpSuccinctProvider, OpSuccinctWitnessParams, ProofProcessingResult,
+    ProveResult, ProvingBackend, SessionStatus,
 };
 
 pub mod metrics;

--- a/crates/proof/zk/service/src/server/get_proof.rs
+++ b/crates/proof/zk/service/src/server/get_proof.rs
@@ -1,5 +1,3 @@
-use std::collections::HashMap;
-
 use base_zk_client::{
     ExecutionStats, GetProofRequest, GetProofResponse, ProofJobStatus, ReceiptType,
 };
@@ -9,9 +7,11 @@ use tonic::{Request, Response, Status};
 use tracing::{Instrument, info};
 use uuid::Uuid;
 
-use crate::{metrics, server::ProverServiceServer};
-
-const EXECUTION_STATS_METADATA_KEY: &str = "execution_stats";
+use crate::{
+    backends::{OP_SUCCINCT_EXECUTION_STATS_METADATA_KEY, OpSuccinctStoredExecutionStats},
+    metrics,
+    server::ProverServiceServer,
+};
 
 /// Helper function to get the appropriate receipt based on requested type.
 fn get_receipt_by_type(
@@ -45,17 +45,9 @@ fn get_receipt_by_type(
 }
 
 fn execution_stats_from_metadata(metadata: &serde_json::Value) -> Option<ExecutionStats> {
-    let stats = metadata.get(EXECUTION_STATS_METADATA_KEY)?;
-    let cycle_tracker =
-        serde_json::from_value::<HashMap<String, u64>>(stats.get("cycle_tracker")?.clone()).ok()?;
-
-    Some(ExecutionStats {
-        total_instruction_cycles: stats.get("total_instruction_cycles")?.as_u64()?,
-        total_sp1_gas: stats.get("total_sp1_gas")?.as_u64()?,
-        cycle_tracker,
-        witness_generation_ms: stats.get("witness_generation_ms")?.as_f64()?,
-        execution_ms: stats.get("execution_ms")?.as_f64()?,
-    })
+    let stats = metadata.get(OP_SUCCINCT_EXECUTION_STATS_METADATA_KEY)?;
+    let stored = serde_json::from_value::<OpSuccinctStoredExecutionStats>(stats.clone()).ok()?;
+    Some(stored.into())
 }
 
 impl ProverServiceServer {
@@ -203,10 +195,18 @@ impl ProverServiceServer {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
+
     use base_zk_db::{ProofRequest, ProofType};
     use chrono::Utc;
 
     use super::*;
+
+    fn metadata_with_execution_stats(stats: serde_json::Value) -> serde_json::Value {
+        let mut metadata = serde_json::Map::new();
+        metadata.insert(OP_SUCCINCT_EXECUTION_STATS_METADATA_KEY.to_string(), stats);
+        serde_json::Value::Object(metadata)
+    }
 
     fn load_snark_fixture() -> Vec<u8> {
         let path =
@@ -237,6 +237,40 @@ mod tests {
             completed_at: Some(now),
             retry_count: 0,
         }
+    }
+
+    #[test]
+    fn test_execution_stats_from_metadata_deserializes_stored_stats() {
+        let stored_stats = OpSuccinctStoredExecutionStats {
+            total_instruction_cycles: 100,
+            total_sp1_gas: 200,
+            cycle_tracker: HashMap::from([("range".to_string(), 42)]),
+            witness_generation_ms: 12.5,
+            execution_ms: 34.5,
+        };
+        let metadata =
+            metadata_with_execution_stats(serde_json::to_value(stored_stats).expect("serialize"));
+
+        let stats = execution_stats_from_metadata(&metadata).expect("execution stats");
+
+        assert_eq!(stats.total_instruction_cycles, 100);
+        assert_eq!(stats.total_sp1_gas, 200);
+        assert_eq!(stats.cycle_tracker.get("range"), Some(&42));
+        assert_eq!(stats.witness_generation_ms, 12.5);
+        assert_eq!(stats.execution_ms, 34.5);
+    }
+
+    #[test]
+    fn test_execution_stats_from_metadata_rejects_invalid_schema() {
+        let metadata = metadata_with_execution_stats(serde_json::json!({
+            "total_instruction_cycles": "100",
+            "total_sp1_gas": 200,
+            "cycle_tracker": {},
+            "witness_generation_ms": 12.5,
+            "execution_ms": 34.5,
+        }));
+
+        assert!(execution_stats_from_metadata(&metadata).is_none());
     }
 
     #[test]

--- a/crates/proof/zk/service/src/server/get_proof.rs
+++ b/crates/proof/zk/service/src/server/get_proof.rs
@@ -8,7 +8,10 @@ use tracing::{Instrument, info};
 use uuid::Uuid;
 
 use crate::{
-    backends::{OP_SUCCINCT_EXECUTION_STATS_METADATA_KEY, OpSuccinctStoredExecutionStats},
+    backends::{
+        OP_SUCCINCT_DRY_RUN_METADATA_KEY, OP_SUCCINCT_EXECUTION_STATS_METADATA_KEY,
+        OpSuccinctStoredExecutionStats,
+    },
     metrics,
     server::ProverServiceServer,
 };
@@ -45,6 +48,10 @@ fn get_receipt_by_type(
 }
 
 fn execution_stats_from_metadata(metadata: &serde_json::Value) -> Option<ExecutionStats> {
+    if !metadata.get(OP_SUCCINCT_DRY_RUN_METADATA_KEY)?.as_bool()? {
+        return None;
+    }
+
     let stats = metadata.get(OP_SUCCINCT_EXECUTION_STATS_METADATA_KEY)?;
     let stored = serde_json::from_value::<OpSuccinctStoredExecutionStats>(stats.clone()).ok()?;
     Some(stored.into())
@@ -93,6 +100,8 @@ impl ProverServiceServer {
         requested_receipt_type: ReceiptType,
     ) -> Result<(Vec<u8>, Option<ExecutionStats>), Status> {
         if proof_req.stark_receipt.is_none() && proof_req.snark_receipt.is_none() {
+            // Receipt absence is only a fast path before touching session metadata; the dry-run
+            // marker remains the authoritative check inside `execution_stats_from_metadata`.
             let execution_stats = self.execution_stats_for_request(proof_req.id).await?;
             if execution_stats.is_some() {
                 return Ok((vec![], execution_stats));
@@ -205,6 +214,8 @@ mod tests {
 
     fn metadata_with_execution_stats(stats: serde_json::Value) -> serde_json::Value {
         let mut metadata = serde_json::Map::new();
+        metadata
+            .insert(OP_SUCCINCT_DRY_RUN_METADATA_KEY.to_string(), serde_json::Value::Bool(true));
         metadata.insert(OP_SUCCINCT_EXECUTION_STATS_METADATA_KEY.to_string(), stats);
         serde_json::Value::Object(metadata)
     }
@@ -272,6 +283,24 @@ mod tests {
         }));
 
         assert!(execution_stats_from_metadata(&metadata).is_none());
+    }
+
+    #[test]
+    fn test_execution_stats_from_metadata_requires_dry_run_marker() {
+        let stored_stats = OpSuccinctStoredExecutionStats {
+            total_instruction_cycles: 100,
+            total_sp1_gas: 200,
+            cycle_tracker: HashMap::new(),
+            witness_generation_ms: 12.5,
+            execution_ms: 34.5,
+        };
+        let mut metadata = serde_json::Map::new();
+        metadata.insert(
+            OP_SUCCINCT_EXECUTION_STATS_METADATA_KEY.to_string(),
+            serde_json::to_value(stored_stats).expect("serialize"),
+        );
+
+        assert!(execution_stats_from_metadata(&serde_json::Value::Object(metadata)).is_none());
     }
 
     #[test]

--- a/crates/proof/zk/service/src/server/get_proof.rs
+++ b/crates/proof/zk/service/src/server/get_proof.rs
@@ -1,4 +1,8 @@
-use base_zk_client::{GetProofRequest, GetProofResponse, ProofJobStatus, ReceiptType};
+use std::collections::HashMap;
+
+use base_zk_client::{
+    ExecutionStats, GetProofRequest, GetProofResponse, ProofJobStatus, ReceiptType,
+};
 use base_zk_db::ProofStatus;
 use sp1_sdk::SP1ProofWithPublicValues;
 use tonic::{Request, Response, Status};
@@ -6,6 +10,8 @@ use tracing::{Instrument, info};
 use uuid::Uuid;
 
 use crate::{metrics, server::ProverServiceServer};
+
+const EXECUTION_STATS_METADATA_KEY: &str = "execution_stats";
 
 /// Helper function to get the appropriate receipt based on requested type.
 fn get_receipt_by_type(
@@ -38,6 +44,20 @@ fn get_receipt_by_type(
     }
 }
 
+fn execution_stats_from_metadata(metadata: &serde_json::Value) -> Option<ExecutionStats> {
+    let stats = metadata.get(EXECUTION_STATS_METADATA_KEY)?;
+    let cycle_tracker =
+        serde_json::from_value::<HashMap<String, u64>>(stats.get("cycle_tracker")?.clone()).ok()?;
+
+    Some(ExecutionStats {
+        total_instruction_cycles: stats.get("total_instruction_cycles")?.as_u64()?,
+        total_sp1_gas: stats.get("total_sp1_gas")?.as_u64()?,
+        cycle_tracker,
+        witness_generation_ms: stats.get("witness_generation_ms")?.as_f64()?,
+        execution_ms: stats.get("execution_ms")?.as_f64()?,
+    })
+}
+
 impl ProverServiceServer {
     /// Returns current proof status and receipt bytes for `session_id=<uuid>`.
     pub async fn get_proof_impl(
@@ -57,6 +77,37 @@ impl ProverServiceServer {
         metrics::record_response_latency("GetProof", success, elapsed_ms);
 
         result
+    }
+
+    async fn execution_stats_for_request(
+        &self,
+        proof_request_id: Uuid,
+    ) -> Result<Option<ExecutionStats>, Status> {
+        let sessions = self
+            .repo
+            .get_sessions_for_request(proof_request_id)
+            .await
+            .map_err(|e| Status::internal(format!("Database error: {e}")))?;
+
+        Ok(sessions
+            .iter()
+            .filter_map(|session| session.metadata.as_ref())
+            .find_map(execution_stats_from_metadata))
+    }
+
+    async fn succeeded_payload(
+        &self,
+        proof_req: &base_zk_db::ProofRequest,
+        requested_receipt_type: ReceiptType,
+    ) -> Result<(Vec<u8>, Option<ExecutionStats>), Status> {
+        let execution_stats = self.execution_stats_for_request(proof_req.id).await?;
+
+        if execution_stats.is_some() {
+            return Ok((vec![], execution_stats));
+        }
+
+        let receipt = get_receipt_by_type(proof_req, requested_receipt_type)?;
+        Ok((receipt, None))
     }
 
     async fn get_proof_inner(
@@ -90,9 +141,9 @@ impl ProverServiceServer {
             .ok_or_else(|| Status::not_found("Proof request not found"))?;
 
         // Map database status to proto status
-        let (proto_status, receipt_bytes, error_message) = match proof_req.status {
-            ProofStatus::Created => (ProofJobStatus::Created, vec![], None),
-            ProofStatus::Pending => (ProofJobStatus::Pending, vec![], None),
+        let (proto_status, receipt_bytes, error_message, execution_stats) = match proof_req.status {
+            ProofStatus::Created => (ProofJobStatus::Created, vec![], None, None),
+            ProofStatus::Pending => (ProofJobStatus::Pending, vec![], None, None),
             ProofStatus::Running => {
                 // Sync sessions and update proof status, with a tracing span so all
                 // nested log lines carry proof_request_id.
@@ -117,28 +168,34 @@ impl ProverServiceServer {
                 // Map updated status to response
                 match updated_proof_req.status {
                     ProofStatus::Succeeded => {
-                        let receipt =
-                            get_receipt_by_type(&updated_proof_req, requested_receipt_type)?;
-                        (ProofJobStatus::Succeeded, receipt, None)
+                        let (receipt, execution_stats) = self
+                            .succeeded_payload(&updated_proof_req, requested_receipt_type)
+                            .await?;
+                        (ProofJobStatus::Succeeded, receipt, None, execution_stats)
                     }
                     ProofStatus::Failed => {
-                        (ProofJobStatus::Failed, vec![], updated_proof_req.error_message)
+                        (ProofJobStatus::Failed, vec![], updated_proof_req.error_message, None)
                     }
                     _ => {
                         // Still RUNNING or PENDING
-                        (ProofJobStatus::Running, vec![], None)
+                        (ProofJobStatus::Running, vec![], None, None)
                     }
                 }
             }
             ProofStatus::Succeeded => {
-                let receipt_buf = get_receipt_by_type(&proof_req, requested_receipt_type)?;
-                (ProofJobStatus::Succeeded, receipt_buf, None)
+                let (receipt, execution_stats) =
+                    self.succeeded_payload(&proof_req, requested_receipt_type).await?;
+                (ProofJobStatus::Succeeded, receipt, None, execution_stats)
             }
-            ProofStatus::Failed => (ProofJobStatus::Failed, vec![], proof_req.error_message),
+            ProofStatus::Failed => (ProofJobStatus::Failed, vec![], proof_req.error_message, None),
         };
 
-        let response =
-            GetProofResponse { status: proto_status.into(), receipt: receipt_bytes, error_message };
+        let response = GetProofResponse {
+            status: proto_status.into(),
+            receipt: receipt_bytes,
+            error_message,
+            execution_stats,
+        };
 
         Ok(Response::new(response))
     }

--- a/crates/proof/zk/service/src/server/get_proof.rs
+++ b/crates/proof/zk/service/src/server/get_proof.rs
@@ -92,10 +92,11 @@ impl ProverServiceServer {
         proof_req: &base_zk_db::ProofRequest,
         requested_receipt_type: ReceiptType,
     ) -> Result<(Vec<u8>, Option<ExecutionStats>), Status> {
-        let execution_stats = self.execution_stats_for_request(proof_req.id).await?;
-
-        if execution_stats.is_some() {
-            return Ok((vec![], execution_stats));
+        if proof_req.stark_receipt.is_none() && proof_req.snark_receipt.is_none() {
+            let execution_stats = self.execution_stats_for_request(proof_req.id).await?;
+            if execution_stats.is_some() {
+                return Ok((vec![], execution_stats));
+            }
         }
 
         let receipt = get_receipt_by_type(proof_req, requested_receipt_type)?;


### PR DESCRIPTION
Run the OP Succinct witness path and SP1 range program locally so developers can inspect cycle stats without submitting a proof. Return those stats through GetProofResponse.execution_stats while leaving proof-producing backends unchanged.