### PR TITLE
refactor(common): Deduplicate Calldata Gas Cost

### DIFF
--- a/crates/common/precompiles/src/activation/dispatch.rs
+++ b/crates/common/precompiles/src/activation/dispatch.rs
@@ -9,7 +9,7 @@ use super::{
     ActivationRegistryStorage,
     IActivationRegistry::{self, IActivationRegistryCalls as C},
 };
-use crate::macros::decode_precompile_call;
+use crate::macros::{decode_precompile_call, deduct_calldata_cost};
 
 impl ActivationRegistryStorage<'_> {
     /// ABI-dispatches activation registry calldata.
@@ -19,9 +19,7 @@ impl ActivationRegistryStorage<'_> {
         calldata: &[u8],
         activation_admin_address: Option<Address>,
     ) -> PrecompileResult {
-        if let Err(e) = ctx.deduct_gas(crate::input_cost(calldata.len())) {
-            return e.into_precompile_result(ctx.gas_used());
-        }
+        deduct_calldata_cost!(ctx, calldata);
         self.inner(calldata, activation_admin_address)
             .into_precompile_result(ctx.gas_used(), |output| output)
     }

--- a/crates/common/precompiles/src/b20/dispatch.rs
+++ b/crates/common/precompiles/src/b20/dispatch.rs
@@ -9,15 +9,14 @@ use super::{
 };
 use crate::{
     ActivationRegistryStorage, Burnable, Configurable, Mintable, Pausable, Permittable, Policy,
-    Redeemable, TokenAccounting, Transferable, macros::decode_precompile_call,
+    Redeemable, TokenAccounting, Transferable,
+    macros::{decode_precompile_call, deduct_calldata_cost},
 };
 
 impl<S: TokenAccounting, P: Policy> B20Token<S, P> {
     /// ABI-dispatches `calldata` to the appropriate `IB20` handler.
     pub fn dispatch(&mut self, ctx: StorageCtx<'_>, calldata: &[u8]) -> PrecompileResult {
-        if let Err(e) = ctx.deduct_gas(crate::input_cost(calldata.len())) {
-            return e.into_precompile_result(ctx.gas_used());
-        }
+        deduct_calldata_cost!(ctx, calldata);
         // Ensure the token has been deployed (has bytecode at its address).
         match self.accounting.is_initialized() {
             Ok(true) => {}

--- a/crates/common/precompiles/src/common/policy.rs
+++ b/crates/common/precompiles/src/common/policy.rs
@@ -3,7 +3,7 @@
 use alloy_primitives::Address;
 use base_precompile_storage::Result;
 
-use crate::PolicyType;
+use crate::IPolicyRegistry::PolicyType;
 
 /// Minimal read-only policy interface consulted by B-20 tokens on every transfer, mint, and redeem.
 pub trait Policy {

--- a/crates/common/precompiles/src/factory/dispatch.rs
+++ b/crates/common/precompiles/src/factory/dispatch.rs
@@ -7,15 +7,13 @@ use revm::precompile::PrecompileResult;
 
 use crate::{
     ActivationRegistryStorage, ITokenFactory, TokenFactoryStorage, TokenVariant,
-    macros::decode_precompile_call,
+    macros::{decode_precompile_call, deduct_calldata_cost},
 };
 
 impl<'a> TokenFactoryStorage<'a> {
     /// ABI-dispatches `calldata` to the appropriate `ITokenFactory` handler.
     pub fn dispatch(&mut self, ctx: StorageCtx<'_>, calldata: &[u8]) -> PrecompileResult {
-        if let Err(e) = ctx.deduct_gas(crate::input_cost(calldata.len())) {
-            return e.into_precompile_result(ctx.gas_used());
-        }
+        deduct_calldata_cost!(ctx, calldata);
         let result = self.inner(ctx, calldata);
         let gas = ctx.gas_used();
         result.into_precompile_result(gas, |b| b)

--- a/crates/common/precompiles/src/lib.rs
+++ b/crates/common/precompiles/src/lib.rs
@@ -7,17 +7,6 @@ extern crate alloc;
 
 mod macros;
 
-/// Returns the EIP-3860-style input cost for calldata of the given length.
-///
-/// Charges `G_sha3word` (6 gas) per 32-byte word of calldata. This mirrors the cost model used
-/// by EIP-3860 for initcode and prevents callers from passing arbitrarily large calldata to
-/// precompiles at near-zero cost — without this, an attacker could force expensive ABI decoding
-/// with a single transaction.
-pub const fn input_cost(calldata_len: usize) -> u64 {
-    const G_SHA3WORD: u64 = 6;
-    calldata_len.div_ceil(32).saturating_mul(G_SHA3WORD as usize) as u64
-}
-
 mod provider;
 pub use provider::BasePrecompiles;
 
@@ -46,12 +35,4 @@ mod factory;
 pub use factory::{ITokenFactory, TokenFactory, TokenFactoryStorage, TokenVariant};
 
 mod policy;
-pub use policy::{
-    IPolicyRegistry,
-    // PolicyType is re-exported directly for ergonomics — callers write `PolicyType::ALLOWLIST`
-    // rather than `IPolicyRegistry::PolicyType::ALLOWLIST`.
-    IPolicyRegistry::PolicyType,
-    PolicyHandle,
-    PolicyRegistryPrecompile,
-    PolicyRegistryStorage,
-};
+pub use policy::{IPolicyRegistry, PolicyHandle, PolicyRegistryPrecompile, PolicyRegistryStorage};

--- a/crates/common/precompiles/src/macros.rs
+++ b/crates/common/precompiles/src/macros.rs
@@ -45,6 +45,20 @@ macro_rules! base_precompile {
 
 pub(crate) use base_precompile;
 
+macro_rules! deduct_calldata_cost {
+    ($ctx:expr, $calldata:expr $(,)?) => {{
+        const G_SHA3WORD: u64 = 6;
+
+        let calldata_len = $calldata.len();
+        let calldata_cost = calldata_len.div_ceil(32).saturating_mul(G_SHA3WORD as usize) as u64;
+        if let Err(e) = $ctx.deduct_gas(calldata_cost) {
+            return e.into_precompile_result($ctx.gas_used());
+        }
+    }};
+}
+
+pub(crate) use deduct_calldata_cost;
+
 macro_rules! decode_precompile_call {
     ($calldata:expr, $call_ty:ty $(,)?) => {{
         let calldata = $calldata;

--- a/crates/common/precompiles/src/policy/dispatch.rs
+++ b/crates/common/precompiles/src/policy/dispatch.rs
@@ -7,13 +7,14 @@ use super::{
     abi::{IPolicyRegistry, IPolicyRegistry::IPolicyRegistryCalls as C},
     storage::PolicyRegistryStorage,
 };
-use crate::{ActivationRegistryStorage, macros::decode_precompile_call};
+use crate::{
+    ActivationRegistryStorage,
+    macros::{decode_precompile_call, deduct_calldata_cost},
+};
 
 impl PolicyRegistryStorage<'_> {
     pub(super) fn dispatch(&mut self, ctx: StorageCtx<'_>, calldata: &[u8]) -> PrecompileResult {
-        if let Err(e) = ctx.deduct_gas(crate::input_cost(calldata.len())) {
-            return e.into_precompile_result(ctx.gas_used());
-        }
+        deduct_calldata_cost!(ctx, calldata);
         ActivationRegistryStorage::new(ctx)
             .ensure_activated(ActivationRegistryStorage::POLICY_REGISTRY)
             .and_then(|()| self.inner(calldata))

--- a/crates/common/precompiles/src/policy/handle.rs
+++ b/crates/common/precompiles/src/policy/handle.rs
@@ -10,7 +10,7 @@ use alloy_primitives::Address;
 use base_precompile_storage::{Result, StorageCtx};
 
 use super::storage::PolicyRegistryStorage;
-use crate::{Policy, PolicyRegistry, PolicyType};
+use crate::{IPolicyRegistry::PolicyType, Policy, PolicyRegistry};
 
 /// Wraps [`PolicyRegistryStorage`] and implements [`Policy`] and [`PolicyRegistry`],
 /// separating authorization decisions from raw storage reads.


### PR DESCRIPTION
## Summary

This refactors the Base precompile dispatch paths to use a shared `deduct_calldata_cost!` macro for calldata gas accounting. The macro keeps the existing per-32-byte cost calculation local to `macros.rs` and removes the exported `input_cost` helper from `lib.rs`. It also updates the remaining policy type imports to use the ABI namespace directly after dropping the root re-export.