### PR TITLE
test(execution): Cover Beryl Native Precompiles

### DIFF
--- a/actions/harness/tests/beryl/activation.rs
+++ b/actions/harness/tests/beryl/activation.rs
@@ -1,0 +1,140 @@
+//! Activation registry precompile action tests across the Base Beryl boundary.
+
+use alloy_consensus::TxReceipt;
+use alloy_primitives::{Address, Bytes, TxKind, U256};
+use alloy_sol_types::{SolCall, SolEvent};
+use base_common_precompiles::{ActivationRegistryStorage, IActivationRegistry};
+
+use crate::env::BerylTestEnv;
+
+const GAS_LIMIT: u64 = 1_000_000;
+const FEATURE: alloy_primitives::B256 = ActivationRegistryStorage::SECURITIES_TOKEN_CREATION;
+
+#[tokio::test]
+async fn beryl_enables_activation_registry_admin_and_feature_lifecycle() {
+    let mut env = BerylTestEnv::new();
+    let (probe, deploy_probe) = env.deploy_staticcall_probe_tx(ActivationRegistryStorage::ADDRESS);
+
+    let admin_call = Bytes::from(IActivationRegistry::adminCall {}.abi_encode());
+    let pre_beryl_admin =
+        env.call_staticcall_probe_tx(probe, admin_call.clone(), BerylTestEnv::B20_PROBE_GAS_LIMIT);
+    let block1 =
+        env.sequencer.build_next_block_with_transactions(vec![deploy_probe, pre_beryl_admin]).await;
+
+    assert!(env.user_tx_succeeded(&block1, 0), "activation-registry probe must deploy");
+    assert_ne!(
+        env.probe_return_word(probe),
+        word_from_address(BerylTestEnv::alice()),
+        "activation registry admin must not be returned before Beryl"
+    );
+
+    let beryl_boundary = env.sequencer.build_empty_block().await;
+
+    let post_beryl_admin =
+        env.call_staticcall_probe_tx(probe, admin_call, BerylTestEnv::B20_PROBE_GAS_LIMIT);
+    let block2 = env.sequencer.build_next_block_with_transactions(vec![post_beryl_admin]).await;
+
+    assert!(env.probe_call_succeeded(probe), "admin() staticcall must succeed after Beryl");
+    assert_eq!(
+        env.probe_return_word(probe),
+        word_from_address(BerylTestEnv::alice()),
+        "admin() must return the harness activation admin"
+    );
+
+    let is_activated_call =
+        Bytes::from(IActivationRegistry::isActivatedCall { feature: FEATURE }.abi_encode());
+    let inactive_probe = env.call_staticcall_probe_tx(
+        probe,
+        is_activated_call.clone(),
+        BerylTestEnv::B20_PROBE_GAS_LIMIT,
+    );
+    let block3 = env.sequencer.build_next_block_with_transactions(vec![inactive_probe]).await;
+
+    assert!(env.probe_call_succeeded(probe), "isActivated() staticcall must succeed");
+    assert_eq!(env.probe_return_word(probe), U256::ZERO, "feature must start inactive");
+
+    let activate = env.activate_feature_tx(FEATURE);
+    let block4 = env.sequencer.build_next_block_with_transactions(vec![activate]).await;
+
+    assert!(env.user_tx_succeeded(&block4, 0), "admin activate(feature) must succeed");
+    assert_activation_log(&env, &block4, true);
+
+    let activate_again = env.activate_feature_tx(FEATURE);
+    let block5 = env.sequencer.build_next_block_with_transactions(vec![activate_again]).await;
+
+    assert!(!env.user_tx_succeeded(&block5, 0), "repeated activate(feature) must revert");
+
+    let active_probe = env.call_staticcall_probe_tx(
+        probe,
+        is_activated_call.clone(),
+        BerylTestEnv::B20_PROBE_GAS_LIMIT,
+    );
+    let block6 = env.sequencer.build_next_block_with_transactions(vec![active_probe]).await;
+
+    assert!(env.probe_call_succeeded(probe), "isActivated() staticcall must succeed");
+    assert_eq!(env.probe_return_word(probe), U256::ONE, "feature must be active");
+
+    let deactivate = env.deactivate_feature_tx(FEATURE);
+    let block7 = env.sequencer.build_next_block_with_transactions(vec![deactivate]).await;
+
+    assert!(env.user_tx_succeeded(&block7, 0), "admin deactivate(feature) must succeed");
+    assert_activation_log(&env, &block7, false);
+
+    let deactivate_again = env.deactivate_feature_tx(FEATURE);
+    let block8 = env.sequencer.build_next_block_with_transactions(vec![deactivate_again]).await;
+
+    assert!(!env.user_tx_succeeded(&block8, 0), "repeated deactivate(feature) must revert");
+
+    let unauthorized = env.create_bob_tx(
+        TxKind::Call(ActivationRegistryStorage::ADDRESS),
+        Bytes::from(IActivationRegistry::activateCall { feature: FEATURE }.abi_encode()),
+        GAS_LIMIT,
+    );
+    let block9 = env.sequencer.build_next_block_with_transactions(vec![unauthorized]).await;
+
+    assert!(!env.user_tx_succeeded(&block9, 0), "non-admin activate(feature) must revert");
+
+    env.derive_blocks(
+        [
+            (block1, 1),
+            (beryl_boundary, 2),
+            (block2, 3),
+            (block3, 4),
+            (block4, 5),
+            (block5, 6),
+            (block6, 7),
+            (block7, 8),
+            (block8, 9),
+            (block9, 10),
+        ],
+        10,
+    )
+    .await;
+}
+
+fn assert_activation_log(
+    env: &BerylTestEnv,
+    block: &base_common_consensus::BaseBlock,
+    active: bool,
+) {
+    let expected = if active {
+        IActivationRegistry::FeatureActivated { feature: FEATURE, caller: BerylTestEnv::alice() }
+            .encode_log_data()
+    } else {
+        IActivationRegistry::FeatureDeactivated { feature: FEATURE, caller: BerylTestEnv::alice() }
+            .encode_log_data()
+    };
+    assert!(
+        env.user_tx_receipt(block, 0)
+            .logs()
+            .iter()
+            .any(|log| log.address == ActivationRegistryStorage::ADDRESS && log.data == expected),
+        "activation transition must emit the expected event"
+    );
+}
+
+fn word_from_address(address: Address) -> U256 {
+    let mut word = [0u8; 32];
+    word[12..].copy_from_slice(address.as_slice());
+    U256::from_be_slice(&word)
+}

--- a/actions/harness/tests/beryl/b20.rs
+++ b/actions/harness/tests/beryl/b20.rs
@@ -1,9 +1,24 @@
 //! B-20 precompile action tests across the Base Beryl boundary.
 
-use alloy_primitives::{Address, U256};
+use alloy_consensus::TxReceipt;
+use alloy_primitives::{Address, B256, Bytes, TxKind, U256, keccak256};
+use alloy_signer::SignerSync;
+use alloy_signer_local::PrivateKeySigner;
+use alloy_sol_types::{SolCall, SolEvent, SolValue};
+use base_action_harness::TEST_ACCOUNT_KEY;
 use base_common_consensus::{BaseBlock, BaseTxEnvelope};
+use base_common_precompiles::{IB20, TokenFactoryStorage};
 
 use crate::env::BerylTestEnv;
+
+const PERMIT_TYPE: &[u8] =
+    b"Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)";
+const DOMAIN_TYPE: &[u8] = b"EIP712Domain(uint256 chainId,address verifyingContract)";
+const MEMO_TRANSFER: B256 = B256::repeat_byte(0x10);
+const MEMO_TRANSFER_FROM: B256 = B256::repeat_byte(0x11);
+const MEMO_MINT: B256 = B256::repeat_byte(0x12);
+const MEMO_BURN: B256 = B256::repeat_byte(0x13);
+const MEMO_REDEEM: B256 = B256::repeat_byte(0x14);
 
 #[tokio::test]
 async fn b20_transfers_update_balances_and_emit_events() {
@@ -239,6 +254,290 @@ async fn b20_transfer_reverts_while_token_feature_is_deactivated() {
     scenario.derive().await;
 }
 
+#[tokio::test]
+async fn b20_staticcall_abi_covers_all_read_methods() {
+    let mut scenario = B20TokenScenario::new().await;
+
+    let approve_bob = scenario.env.approve_b20_tx(
+        scenario.token,
+        BerylTestEnv::bob(),
+        U256::from(BerylTestEnv::B20_BOB_ALLOWANCE),
+    );
+    let block = scenario.build_block_with_transactions(vec![approve_bob]).await;
+    assert!(scenario.env.user_tx_succeeded(&block, 0), "Alice approval transaction must succeed");
+
+    scenario
+        .assert_staticcall_cases(vec![
+            StaticcallCase::word(
+                "capabilities",
+                IB20::capabilitiesCall {}.abi_encode(),
+                TokenFactoryStorage::DEFAULT_CAPABILITIES,
+            ),
+            StaticcallCase::word("isPausable", IB20::isPausableCall {}.abi_encode(), U256::ONE),
+            StaticcallCase::word("isCapMutable", IB20::isCapMutableCall {}.abi_encode(), U256::ONE),
+            StaticcallCase::word("name", IB20::nameCall {}.abi_encode(), U256::from(32)),
+            StaticcallCase::word("symbol", IB20::symbolCall {}.abi_encode(), U256::from(32)),
+            StaticcallCase::word(
+                "decimals",
+                IB20::decimalsCall {}.abi_encode(),
+                U256::from(BerylTestEnv::B20_DECIMALS),
+            ),
+            StaticcallCase::word(
+                "totalSupply",
+                IB20::totalSupplyCall {}.abi_encode(),
+                U256::from(BerylTestEnv::B20_INITIAL_SUPPLY),
+            ),
+            StaticcallCase::word(
+                "balanceOf",
+                IB20::balanceOfCall { account: BerylTestEnv::alice() }.abi_encode(),
+                U256::from(BerylTestEnv::B20_INITIAL_SUPPLY),
+            ),
+            StaticcallCase::word(
+                "allowance",
+                IB20::allowanceCall { owner: BerylTestEnv::alice(), spender: BerylTestEnv::bob() }
+                    .abi_encode(),
+                U256::from(BerylTestEnv::B20_BOB_ALLOWANCE),
+            ),
+            StaticcallCase::word(
+                "minimumRedeemable",
+                IB20::minimumRedeemableCall {}.abi_encode(),
+                U256::ZERO,
+            ),
+            StaticcallCase::word("paused", IB20::pausedCall {}.abi_encode(), U256::ZERO),
+            StaticcallCase::word(
+                "isPaused",
+                IB20::isPausedCall { vector: U256::ONE }.abi_encode(),
+                U256::ZERO,
+            ),
+            StaticcallCase::word("supplyCap", IB20::supplyCapCall {}.abi_encode(), U256::MAX),
+            StaticcallCase::word(
+                "DOMAIN_SEPARATOR",
+                IB20::DOMAIN_SEPARATORCall {}.abi_encode(),
+                domain_separator_word(scenario.env.chain_id(), scenario.token),
+            ),
+            StaticcallCase::word(
+                "nonces",
+                IB20::noncesCall { owner: BerylTestEnv::alice() }.abi_encode(),
+                U256::ZERO,
+            ),
+            StaticcallCase::word(
+                "eip712Domain",
+                IB20::eip712DomainCall {}.abi_encode(),
+                U256::from(32),
+            ),
+            StaticcallCase::word(
+                "contractURI",
+                IB20::contractURICall {}.abi_encode(),
+                U256::from(32),
+            ),
+        ])
+        .await;
+
+    scenario.derive().await;
+}
+
+#[tokio::test]
+async fn b20_extended_mutations_update_state_and_emit_events() {
+    let mut scenario = B20TokenScenario::new().await;
+    let initial = BerylTestEnv::B20_INITIAL_SUPPLY;
+    let new_cap = U256::from(initial + 1_000);
+
+    let transfer_with_memo = scenario.call_tx(IB20::transferWithMemoCall {
+        to: BerylTestEnv::bob(),
+        amount: U256::from(10),
+        memo: MEMO_TRANSFER,
+    });
+    let approve_bob = scenario
+        .call_tx(IB20::approveCall { spender: BerylTestEnv::bob(), amount: U256::from(50) });
+    let transfer_from_with_memo = scenario.bob_call_tx(IB20::transferFromWithMemoCall {
+        from: BerylTestEnv::alice(),
+        to: BerylTestEnv::carol(),
+        amount: U256::from(5),
+        memo: MEMO_TRANSFER_FROM,
+    });
+    let set_supply_cap = scenario.call_tx(IB20::setSupplyCapCall { newSupplyCap: new_cap });
+    let set_name =
+        scenario.call_tx(IB20::setNameCall { newName: "Action B20 Updated".to_string() });
+    let set_symbol = scenario.call_tx(IB20::setSymbolCall { newSymbol: "AB20U".to_string() });
+    let set_contract_uri =
+        scenario.call_tx(IB20::setContractURICall { newURI: "ipfs://action".to_string() });
+    let mint =
+        scenario.call_tx(IB20::mintCall { to: BerylTestEnv::alice(), amount: U256::from(20) });
+    let mint_with_memo = scenario.call_tx(IB20::mintWithMemoCall {
+        to: BerylTestEnv::bob(),
+        amount: U256::from(30),
+        memo: MEMO_MINT,
+    });
+    let burn = scenario.call_tx(IB20::burnCall { amount: U256::from(2) });
+    let burn_with_memo =
+        scenario.call_tx(IB20::burnWithMemoCall { amount: U256::from(3), memo: MEMO_BURN });
+    let set_minimum =
+        scenario.call_tx(IB20::setMinimumRedeemableCall { newMinimum: U256::from(4) });
+    let redeem = scenario.call_tx(IB20::redeemCall { amount: U256::from(4) });
+    let redeem_with_memo =
+        scenario.call_tx(IB20::redeemWithMemoCall { amount: U256::from(5), memo: MEMO_REDEEM });
+    let pause = scenario.call_tx(IB20::pauseCall { vectors: U256::ONE });
+    let unpause = scenario.call_tx(IB20::unpauseCall {});
+
+    let block = scenario
+        .build_block_with_transactions(vec![
+            transfer_with_memo,
+            approve_bob,
+            transfer_from_with_memo,
+            set_supply_cap,
+            set_name,
+            set_symbol,
+            set_contract_uri,
+            mint,
+            mint_with_memo,
+            burn,
+            burn_with_memo,
+            set_minimum,
+            redeem,
+            redeem_with_memo,
+            pause,
+            unpause,
+        ])
+        .await;
+
+    for index in 0..16 {
+        assert!(
+            scenario.env.user_tx_succeeded(&block, index),
+            "B-20 mutation {index} must succeed"
+        );
+    }
+
+    scenario.assert_log(&block, 0, IB20::Memo { memo: MEMO_TRANSFER }.encode_log_data());
+    scenario.assert_log(&block, 2, IB20::Memo { memo: MEMO_TRANSFER_FROM }.encode_log_data());
+    scenario.assert_log(
+        &block,
+        3,
+        IB20::SupplyCapUpdated {
+            updater: BerylTestEnv::alice(),
+            oldSupplyCap: U256::MAX,
+            newSupplyCap: new_cap,
+        }
+        .encode_log_data(),
+    );
+    scenario.assert_log(
+        &block,
+        4,
+        IB20::NameUpdated {
+            updater: BerylTestEnv::alice(),
+            newName: "Action B20 Updated".to_string(),
+        }
+        .encode_log_data(),
+    );
+    scenario.assert_log(
+        &block,
+        5,
+        IB20::SymbolUpdated { updater: BerylTestEnv::alice(), newSymbol: "AB20U".to_string() }
+            .encode_log_data(),
+    );
+    scenario.assert_log(&block, 6, IB20::ContractURIUpdated {}.encode_log_data());
+    scenario.assert_log(&block, 8, IB20::Memo { memo: MEMO_MINT }.encode_log_data());
+    scenario.assert_log(&block, 10, IB20::Memo { memo: MEMO_BURN }.encode_log_data());
+    scenario.assert_log(
+        &block,
+        11,
+        IB20::MinimumRedeemableUpdated {
+            updater: BerylTestEnv::alice(),
+            oldMinimum: U256::ZERO,
+            newMinimum: U256::from(4),
+        }
+        .encode_log_data(),
+    );
+    scenario.assert_log(
+        &block,
+        12,
+        IB20::Redeemed { holder: BerylTestEnv::alice(), amount: U256::from(4) }.encode_log_data(),
+    );
+    scenario.assert_log(&block, 13, IB20::Memo { memo: MEMO_REDEEM }.encode_log_data());
+    scenario.assert_log(
+        &block,
+        14,
+        IB20::Paused { updater: BerylTestEnv::alice(), vectors: U256::ONE }.encode_log_data(),
+    );
+    scenario.assert_log(
+        &block,
+        15,
+        IB20::Unpaused { updater: BerylTestEnv::alice() }.encode_log_data(),
+    );
+
+    scenario.assert_total_supply(initial + 20 + 30 - 2 - 3 - 4 - 5);
+    scenario.assert_allowance(BerylTestEnv::alice(), BerylTestEnv::bob(), 45);
+    scenario
+        .assert_staticcall_cases(vec![
+            StaticcallCase::word(
+                "paused after unpause",
+                IB20::pausedCall {}.abi_encode(),
+                U256::ZERO,
+            ),
+            StaticcallCase::word(
+                "supplyCap after update",
+                IB20::supplyCapCall {}.abi_encode(),
+                new_cap,
+            ),
+            StaticcallCase::word(
+                "minimumRedeemable after update",
+                IB20::minimumRedeemableCall {}.abi_encode(),
+                U256::from(4),
+            ),
+        ])
+        .await;
+
+    scenario.derive().await;
+}
+
+#[tokio::test]
+async fn b20_permit_updates_allowance_and_nonce() {
+    let mut scenario = B20TokenScenario::new().await;
+    let value = U256::from(123);
+    let deadline = U256::MAX;
+    let (v, r, s) = sign_permit(
+        scenario.env.chain_id(),
+        scenario.token,
+        BerylTestEnv::alice(),
+        BerylTestEnv::bob(),
+        value,
+        U256::ZERO,
+        deadline,
+    );
+
+    let permit = scenario.call_tx(IB20::permitCall {
+        owner: BerylTestEnv::alice(),
+        spender: BerylTestEnv::bob(),
+        value,
+        deadline,
+        v,
+        r,
+        s,
+    });
+    let block = scenario.build_block_with_transactions(vec![permit]).await;
+
+    assert!(scenario.env.user_tx_succeeded(&block, 0), "permit() transaction must succeed");
+    scenario.assert_log(
+        &block,
+        0,
+        IB20::Approval {
+            owner: BerylTestEnv::alice(),
+            spender: BerylTestEnv::bob(),
+            amount: value,
+        }
+        .encode_log_data(),
+    );
+    scenario.assert_allowance(BerylTestEnv::alice(), BerylTestEnv::bob(), 123);
+    scenario
+        .assert_staticcall_cases(vec![StaticcallCase::word(
+            "nonces after permit",
+            IB20::noncesCall { owner: BerylTestEnv::alice() }.abi_encode(),
+            U256::ONE,
+        )])
+        .await;
+
+    scenario.derive().await;
+}
+
 struct B20TokenScenario {
     env: BerylTestEnv,
     token: Address,
@@ -286,6 +585,73 @@ impl B20TokenScenario {
         block
     }
 
+    fn call_tx(&self, call: impl SolCall) -> BaseTxEnvelope {
+        self.env.create_tx(
+            TxKind::Call(self.token),
+            Bytes::from(call.abi_encode()),
+            BerylTestEnv::B20_GAS_LIMIT,
+        )
+    }
+
+    fn bob_call_tx(&mut self, call: impl SolCall) -> BaseTxEnvelope {
+        self.env.create_bob_tx(
+            TxKind::Call(self.token),
+            Bytes::from(call.abi_encode()),
+            BerylTestEnv::B20_GAS_LIMIT,
+        )
+    }
+
+    async fn assert_staticcall_cases(&mut self, cases: Vec<StaticcallCase>) {
+        let mut probes = Vec::with_capacity(cases.len());
+        let mut deployments = Vec::with_capacity(cases.len());
+        for _ in &cases {
+            let (probe, deploy) = self.env.deploy_staticcall_probe_tx(self.token);
+            probes.push(probe);
+            deployments.push(deploy);
+        }
+
+        let deploy_block = self.build_block_with_transactions(deployments).await;
+        for index in 0..cases.len() {
+            assert!(
+                self.env.user_tx_succeeded(&deploy_block, index),
+                "staticcall probe deployment {index} must succeed"
+            );
+        }
+
+        let calls = probes
+            .iter()
+            .zip(cases.iter())
+            .map(|(probe, case)| {
+                self.env.call_staticcall_probe_tx(
+                    *probe,
+                    Bytes::from(case.input.clone()),
+                    BerylTestEnv::B20_PROBE_GAS_LIMIT,
+                )
+            })
+            .collect();
+        let call_block = self.build_block_with_transactions(calls).await;
+        for (index, (probe, case)) in probes.iter().zip(cases.iter()).enumerate() {
+            assert!(
+                self.env.user_tx_succeeded(&call_block, index),
+                "{} probe transaction must succeed",
+                case.label
+            );
+            assert!(
+                self.env.probe_call_succeeded(*probe),
+                "{} staticcall must succeed",
+                case.label
+            );
+            if let Some(expected) = case.expected_word {
+                assert_eq!(
+                    self.env.probe_return_word(*probe),
+                    expected,
+                    "{} staticcall must return the expected first word",
+                    case.label
+                );
+            }
+        }
+    }
+
     fn assert_total_supply(&self, total_supply: u64) {
         assert_eq!(
             self.env.b20_total_supply(self.token),
@@ -320,6 +686,22 @@ impl B20TokenScenario {
         );
     }
 
+    fn assert_log(
+        &self,
+        block: &BaseBlock,
+        user_tx_index: usize,
+        expected: alloy_primitives::LogData,
+    ) {
+        assert!(
+            self.env
+                .user_tx_receipt(block, user_tx_index)
+                .logs()
+                .iter()
+                .any(|log| log.address == self.token && log.data == expected),
+            "B-20 transaction {user_tx_index} must emit the expected event"
+        );
+    }
+
     fn assert_transfer_log(&self, block: &BaseBlock, from: Address, to: Address, amount: u64) {
         assert!(
             self.env.b20_transfer_log_emitted(block, 0, self.token, from, to, U256::from(amount),),
@@ -351,6 +733,56 @@ impl B20TokenScenario {
         let expected_safe_head = self.blocks.len() as u64;
         self.env.derive_blocks(self.blocks, expected_safe_head).await;
     }
+}
+
+struct StaticcallCase {
+    label: &'static str,
+    input: Vec<u8>,
+    expected_word: Option<U256>,
+}
+
+impl StaticcallCase {
+    const fn word(label: &'static str, input: Vec<u8>, expected_word: U256) -> Self {
+        Self { label, input, expected_word: Some(expected_word) }
+    }
+}
+
+fn sign_permit(
+    chain_id: u64,
+    token: Address,
+    owner: Address,
+    spender: Address,
+    value: U256,
+    nonce: U256,
+    deadline: U256,
+) -> (u8, B256, B256) {
+    let domain_sep = domain_separator(chain_id, token);
+    let permit_typehash = keccak256(PERMIT_TYPE);
+    let struct_hash =
+        keccak256((permit_typehash, owner, spender, value, nonce, deadline).abi_encode());
+
+    let mut digest = [0u8; 66];
+    digest[0] = 0x19;
+    digest[1] = 0x01;
+    digest[2..34].copy_from_slice(domain_sep.as_slice());
+    digest[34..66].copy_from_slice(struct_hash.as_slice());
+    let hash = keccak256(digest);
+
+    let signer = PrivateKeySigner::from_bytes(&TEST_ACCOUNT_KEY).expect("valid test signer");
+    let sig = signer.sign_hash_sync(&hash).expect("permit signing must succeed");
+    let r = B256::from(sig.r().to_be_bytes::<32>());
+    let s = B256::from(sig.s().to_be_bytes::<32>());
+    let v = if sig.v() { 28 } else { 27 };
+    (v, r, s)
+}
+
+fn domain_separator(chain_id: u64, token: Address) -> B256 {
+    let domain_typehash = keccak256(DOMAIN_TYPE);
+    keccak256((domain_typehash, U256::from(chain_id), token).abi_encode())
+}
+
+fn domain_separator_word(chain_id: u64, token: Address) -> U256 {
+    U256::from_be_slice(domain_separator(chain_id, token).as_slice())
 }
 
 struct B20StaticcallProbes {

--- a/actions/harness/tests/beryl/env.rs
+++ b/actions/harness/tests/beryl/env.rs
@@ -9,7 +9,7 @@ use base_action_harness::{
     VerifierPipeline,
 };
 use base_batcher_encoder::{DaType, EncoderConfig};
-use base_common_consensus::{BaseBlock, BaseTxEnvelope};
+use base_common_consensus::{BaseBlock, BaseReceipt, BaseTxEnvelope};
 use base_common_precompiles::{
     ActivationRegistryStorage, IActivationRegistry, IB20, ITokenFactory, TokenFactoryStorage,
     TokenVariant,
@@ -129,6 +129,21 @@ impl BerylTestEnv {
         account.create_tx(self.chain_id, to, input, U256::ZERO, gas_limit)
     }
 
+    /// Creates and signs a transaction from Bob's account.
+    pub(crate) fn create_bob_tx(
+        &mut self,
+        to: TxKind,
+        input: Bytes,
+        gas_limit: u64,
+    ) -> BaseTxEnvelope {
+        Self::create_account_tx(self.chain_id, &mut self.bob_account, to, input, gas_limit)
+    }
+
+    /// Returns the L2 chain ID used by the Beryl test environment.
+    pub(crate) const fn chain_id(&self) -> u64 {
+        self.chain_id
+    }
+
     /// Activation registry feature ID for the token factory precompile.
     pub(crate) const fn token_factory_feature() -> B256 {
         ActivationRegistryStorage::TOKEN_FACTORY
@@ -186,6 +201,16 @@ impl BerylTestEnv {
             Self::B20_PROBE_GAS_LIMIT,
         );
         (address, tx)
+    }
+
+    /// Creates a transaction that calls a deployed staticcall probe with arbitrary calldata.
+    pub(crate) fn call_staticcall_probe_tx(
+        &self,
+        probe: Address,
+        input: Bytes,
+        gas_limit: u64,
+    ) -> BaseTxEnvelope {
+        self.create_tx(TxKind::Call(probe), input, gas_limit)
     }
 
     /// Creates a transaction that transfers B-20 tokens from Alice to `to`.
@@ -336,6 +361,24 @@ impl BerylTestEnv {
         self.user_tx_receipt(block, user_tx_index).status()
     }
 
+    /// Returns the receipt for a non-deposit transaction in `block`.
+    pub(crate) fn user_tx_receipt(&self, block: &BaseBlock, user_tx_index: usize) -> BaseReceipt {
+        let deposit_count = block
+            .body
+            .transactions
+            .iter()
+            .take_while(|tx| matches!(tx, BaseTxEnvelope::Deposit(_)))
+            .count();
+        let receipts = self
+            .sequencer
+            .receipts_at(block.header.number)
+            .unwrap_or_else(|| panic!("receipts must exist for L2 block {}", block.header.number));
+        receipts
+            .into_iter()
+            .nth(deposit_count + user_tx_index)
+            .unwrap_or_else(|| panic!("user tx receipt {user_tx_index} must exist"))
+    }
+
     /// Returns whether a user transaction emitted the expected B-20 `Transfer` event.
     pub(crate) fn b20_transfer_log_emitted(
         &self,
@@ -431,27 +474,6 @@ impl BerylTestEnv {
         init_code.extend_from_slice(&hex!("602f600c600039602f6000f3"));
         init_code.extend_from_slice(&runtime);
         Bytes::from(init_code)
-    }
-
-    fn user_tx_receipt(
-        &self,
-        block: &BaseBlock,
-        user_tx_index: usize,
-    ) -> base_common_consensus::BaseReceipt {
-        let deposit_count = block
-            .body
-            .transactions
-            .iter()
-            .take_while(|tx| matches!(tx, BaseTxEnvelope::Deposit(_)))
-            .count();
-        let receipts = self
-            .sequencer
-            .receipts_at(block.header.number)
-            .unwrap_or_else(|| panic!("receipts must exist for L2 block {}", block.header.number));
-        receipts
-            .into_iter()
-            .nth(deposit_count + user_tx_index)
-            .unwrap_or_else(|| panic!("user tx receipt {user_tx_index} must exist"))
     }
 
     fn b20_token_params(&self) -> ITokenFactory::B20CreateParams {

--- a/actions/harness/tests/beryl/factory.rs
+++ b/actions/harness/tests/beryl/factory.rs
@@ -1,7 +1,10 @@
 //! B-20 factory precompile action tests across the Base Beryl boundary.
 
-use alloy_primitives::U256;
+use alloy_consensus::TxReceipt;
+use alloy_primitives::{Address, Bytes, TxKind, U256};
+use alloy_sol_types::{SolCall, SolEvent};
 use base_common_consensus::BaseBlock;
+use base_common_precompiles::{ITokenFactory, TokenFactoryStorage};
 
 use crate::env::BerylTestEnv;
 
@@ -127,6 +130,132 @@ async fn b20_creation_reverts_while_factory_feature_is_deactivated() {
     .await;
 }
 
+#[tokio::test]
+async fn token_factory_views_and_events_are_available_after_beryl_activation() {
+    let mut env = BerylTestEnv::new();
+    let token = env.b20_token_address();
+
+    let block1 = env.sequencer.build_empty_block().await;
+    let activation_block = B20FactoryPrecompiles::activate(&mut env).await;
+
+    let create = env.create_b20_token_tx();
+    let block2 = env.sequencer.build_next_block_with_transactions(vec![create]).await;
+
+    assert!(env.user_tx_succeeded(&block2, 0), "B-20 creation transaction must succeed");
+    assert_token_created_log(&env, &block2, token);
+
+    let (probe, deploy_probe) = env.deploy_staticcall_probe_tx(TokenFactoryStorage::ADDRESS);
+    let block3 = env.sequencer.build_next_block_with_transactions(vec![deploy_probe]).await;
+    assert!(env.user_tx_succeeded(&block3, 0), "factory staticcall probe must deploy");
+
+    let get_token_address = env.call_staticcall_probe_tx(
+        probe,
+        Bytes::from(
+            ITokenFactory::getTokenAddressCall {
+                variant: ITokenFactory::TokenVariant::DEFAULT,
+                decimals: BerylTestEnv::B20_DECIMALS,
+                sender: BerylTestEnv::alice(),
+                salt: BerylTestEnv::b20_token_salt(),
+            }
+            .abi_encode(),
+        ),
+        BerylTestEnv::B20_PROBE_GAS_LIMIT,
+    );
+    let block4 = env.sequencer.build_next_block_with_transactions(vec![get_token_address]).await;
+
+    assert!(env.probe_call_succeeded(probe), "getTokenAddress() staticcall must succeed");
+    assert_eq!(
+        env.probe_return_word(probe),
+        word_from_address(token),
+        "getTokenAddress() must return the deterministic token address"
+    );
+
+    let is_b20 = env.call_staticcall_probe_tx(
+        probe,
+        Bytes::from(ITokenFactory::isB20Call { token }.abi_encode()),
+        BerylTestEnv::B20_PROBE_GAS_LIMIT,
+    );
+    let block5 = env.sequencer.build_next_block_with_transactions(vec![is_b20]).await;
+
+    assert!(env.probe_call_succeeded(probe), "isB20() staticcall must succeed");
+    assert_eq!(env.probe_return_word(probe), U256::ONE, "created token must be B-20");
+
+    let is_not_b20 = env.call_staticcall_probe_tx(
+        probe,
+        Bytes::from(ITokenFactory::isB20Call { token: TokenFactoryStorage::ADDRESS }.abi_encode()),
+        BerylTestEnv::B20_PROBE_GAS_LIMIT,
+    );
+    let block6 = env.sequencer.build_next_block_with_transactions(vec![is_not_b20]).await;
+
+    assert!(env.probe_call_succeeded(probe), "isB20(non-token) staticcall must succeed");
+    assert_eq!(env.probe_return_word(probe), U256::ZERO, "factory singleton must not be B-20");
+
+    let get_variant = env.call_staticcall_probe_tx(
+        probe,
+        Bytes::from(ITokenFactory::getTokenVariantCall { token }.abi_encode()),
+        BerylTestEnv::B20_PROBE_GAS_LIMIT,
+    );
+    let block7 = env.sequencer.build_next_block_with_transactions(vec![get_variant]).await;
+
+    assert!(env.probe_call_succeeded(probe), "getTokenVariant() staticcall must succeed");
+    assert_eq!(
+        env.probe_return_word(probe),
+        U256::from(ITokenFactory::TokenVariant::DEFAULT as u8),
+        "created token variant must be DEFAULT"
+    );
+
+    let get_none_variant = env.call_staticcall_probe_tx(
+        probe,
+        Bytes::from(
+            ITokenFactory::getTokenVariantCall { token: Address::repeat_byte(0xab) }.abi_encode(),
+        ),
+        BerylTestEnv::B20_PROBE_GAS_LIMIT,
+    );
+    let block8 = env.sequencer.build_next_block_with_transactions(vec![get_none_variant]).await;
+
+    assert!(env.probe_call_succeeded(probe), "getTokenVariant(non-token) staticcall must succeed");
+    assert_eq!(
+        env.probe_return_word(probe),
+        U256::from(ITokenFactory::TokenVariant::NONE as u8),
+        "non-token variant must be NONE"
+    );
+
+    let invalid_variant_create = env.create_tx(
+        TxKind::Call(TokenFactoryStorage::ADDRESS),
+        Bytes::from(
+            ITokenFactory::createTokenCall {
+                variant: ITokenFactory::TokenVariant::STABLECOIN,
+                salt: BerylTestEnv::ALT_SALT,
+                params: Bytes::new(),
+                initCalls: Vec::new(),
+            }
+            .abi_encode(),
+        ),
+        BerylTestEnv::B20_GAS_LIMIT,
+    );
+    let block9 =
+        env.sequencer.build_next_block_with_transactions(vec![invalid_variant_create]).await;
+
+    assert!(!env.user_tx_succeeded(&block9, 0), "unimplemented variants must revert");
+
+    env.derive_blocks(
+        [
+            (block1, 1),
+            (activation_block, 2),
+            (block2, 3),
+            (block3, 4),
+            (block4, 5),
+            (block5, 6),
+            (block6, 7),
+            (block7, 8),
+            (block8, 9),
+            (block9, 10),
+        ],
+        10,
+    )
+    .await;
+}
+
 struct B20FactoryPrecompiles;
 
 impl B20FactoryPrecompiles {
@@ -143,4 +272,28 @@ impl B20FactoryPrecompiles {
 
         block
     }
+}
+
+fn assert_token_created_log(env: &BerylTestEnv, block: &BaseBlock, token: Address) {
+    let expected = ITokenFactory::TokenCreated {
+        token,
+        variant: ITokenFactory::TokenVariant::DEFAULT,
+        name: "Action B20".to_string(),
+        symbol: "AB20".to_string(),
+        decimals: BerylTestEnv::B20_DECIMALS,
+    }
+    .encode_log_data();
+    assert!(
+        env.user_tx_receipt(block, 0)
+            .logs()
+            .iter()
+            .any(|log| log.address == TokenFactoryStorage::ADDRESS && log.data == expected),
+        "createToken() must emit TokenCreated"
+    );
+}
+
+fn word_from_address(address: Address) -> U256 {
+    let mut word = [0u8; 32];
+    word[12..].copy_from_slice(address.as_slice());
+    U256::from_be_slice(&word)
 }

--- a/actions/harness/tests/beryl/main.rs
+++ b/actions/harness/tests/beryl/main.rs
@@ -1,5 +1,6 @@
 //! Action tests for Base Beryl hardfork activation.
 
+mod activation;
 mod b20;
 mod env;
 mod factory;

--- a/actions/harness/tests/beryl/policy_registry.rs
+++ b/actions/harness/tests/beryl/policy_registry.rs
@@ -1,8 +1,10 @@
 //! Policy registry precompile action tests across the Base Beryl boundary.
 
+use alloy_consensus::TxReceipt;
 use alloy_primitives::{Bytes, TxKind, U256, hex};
-use alloy_sol_types::SolCall;
-use base_common_precompiles::IPolicyRegistry;
+use alloy_sol_types::{SolCall, SolEvent};
+use base_common_consensus::{BaseBlock, BaseTxEnvelope};
+use base_common_precompiles::{IPolicyRegistry, PolicyRegistryStorage};
 
 use crate::env::BerylTestEnv;
 
@@ -124,4 +126,364 @@ async fn beryl_enables_policy_registry_singleton_precompile() {
         8,
     )
     .await;
+}
+
+#[tokio::test]
+async fn policy_registry_action_tests_cover_policy_lifecycle_and_views() {
+    let mut scenario = PolicyRegistryScenario::new().await;
+    let allowlist_id = policy_id(IPolicyRegistry::PolicyType::ALLOWLIST, 0);
+    let blocklist_id = policy_id(IPolicyRegistry::PolicyType::BLOCKLIST, 1);
+
+    let create_allowlist = scenario.tx(IPolicyRegistry::createPolicyCall {
+        admin: BerylTestEnv::alice(),
+        policyType: IPolicyRegistry::PolicyType::ALLOWLIST,
+    });
+    let block = scenario.build_block_with_transactions(vec![create_allowlist]).await;
+
+    assert!(scenario.env.user_tx_succeeded(&block, 0), "createPolicy() must succeed");
+    scenario.assert_policy_log(
+        &block,
+        0,
+        IPolicyRegistry::PolicyCreated {
+            policyId: allowlist_id,
+            creator: BerylTestEnv::alice(),
+            policyType: IPolicyRegistry::PolicyType::ALLOWLIST as u8,
+        }
+        .encode_log_data(),
+    );
+    scenario.assert_policy_log(
+        &block,
+        0,
+        IPolicyRegistry::PolicyAdminUpdated {
+            policyId: allowlist_id,
+            previousAdmin: alloy_primitives::Address::ZERO,
+            newAdmin: BerylTestEnv::alice(),
+        }
+        .encode_log_data(),
+    );
+
+    scenario
+        .assert_probe_word(
+            "nextPolicyId(BLOCKLIST)",
+            IPolicyRegistry::nextPolicyIdCall {
+                policyType: IPolicyRegistry::PolicyType::BLOCKLIST,
+            }
+            .abi_encode(),
+            U256::from(blocklist_id),
+        )
+        .await;
+    scenario
+        .assert_probe_word(
+            "policyExists(allowlist)",
+            IPolicyRegistry::policyExistsCall { policyId: allowlist_id }.abi_encode(),
+            U256::ONE,
+        )
+        .await;
+    scenario
+        .assert_probe_word(
+            "policyType(allowlist)",
+            IPolicyRegistry::policyTypeCall { policyId: allowlist_id }.abi_encode(),
+            U256::from(IPolicyRegistry::PolicyType::ALLOWLIST as u8),
+        )
+        .await;
+    scenario
+        .assert_probe_word(
+            "policyAdmin(allowlist)",
+            IPolicyRegistry::policyAdminCall { policyId: allowlist_id }.abi_encode(),
+            word_from_address(BerylTestEnv::alice()),
+        )
+        .await;
+    scenario
+        .assert_probe_word(
+            "pendingPolicyAdmin(allowlist)",
+            IPolicyRegistry::pendingPolicyAdminCall { policyId: allowlist_id }.abi_encode(),
+            U256::ZERO,
+        )
+        .await;
+
+    let update_allowlist = scenario.tx(IPolicyRegistry::updateAllowlistCall {
+        policyId: allowlist_id,
+        allowed: true,
+        accounts: vec![BerylTestEnv::bob()],
+    });
+    let block = scenario.build_block_with_transactions(vec![update_allowlist]).await;
+
+    assert!(scenario.env.user_tx_succeeded(&block, 0), "updateAllowlist() must succeed");
+    scenario.assert_policy_log(
+        &block,
+        0,
+        IPolicyRegistry::AllowlistUpdated {
+            policyId: allowlist_id,
+            updater: BerylTestEnv::alice(),
+            allowed: true,
+            accounts: vec![BerylTestEnv::bob()],
+        }
+        .encode_log_data(),
+    );
+    scenario
+        .assert_probe_word(
+            "isAuthorized(allowlist member)",
+            IPolicyRegistry::isAuthorizedCall {
+                policyId: allowlist_id,
+                account: BerylTestEnv::bob(),
+            }
+            .abi_encode(),
+            U256::ONE,
+        )
+        .await;
+    scenario
+        .assert_probe_word(
+            "isAuthorized(allowlist non-member)",
+            IPolicyRegistry::isAuthorizedCall {
+                policyId: allowlist_id,
+                account: BerylTestEnv::carol(),
+            }
+            .abi_encode(),
+            U256::ZERO,
+        )
+        .await;
+
+    let stage_admin = scenario.tx(IPolicyRegistry::stageUpdateAdminCall {
+        policyId: allowlist_id,
+        newAdmin: BerylTestEnv::bob(),
+    });
+    let block = scenario.build_block_with_transactions(vec![stage_admin]).await;
+
+    assert!(scenario.env.user_tx_succeeded(&block, 0), "stageUpdateAdmin() must succeed");
+    scenario.assert_policy_log(
+        &block,
+        0,
+        IPolicyRegistry::PolicyAdminStaged {
+            policyId: allowlist_id,
+            previousAdmin: BerylTestEnv::alice(),
+            newAdmin: BerylTestEnv::bob(),
+        }
+        .encode_log_data(),
+    );
+    scenario
+        .assert_probe_word(
+            "pendingPolicyAdmin(staged)",
+            IPolicyRegistry::pendingPolicyAdminCall { policyId: allowlist_id }.abi_encode(),
+            word_from_address(BerylTestEnv::bob()),
+        )
+        .await;
+
+    let finalize_admin =
+        scenario.bob_tx(IPolicyRegistry::finalizeUpdateAdminCall { policyId: allowlist_id });
+    let block = scenario.build_block_with_transactions(vec![finalize_admin]).await;
+
+    assert!(scenario.env.user_tx_succeeded(&block, 0), "finalizeUpdateAdmin() must succeed");
+    scenario.assert_policy_log(
+        &block,
+        0,
+        IPolicyRegistry::PolicyAdminUpdated {
+            policyId: allowlist_id,
+            previousAdmin: BerylTestEnv::alice(),
+            newAdmin: BerylTestEnv::bob(),
+        }
+        .encode_log_data(),
+    );
+    scenario
+        .assert_probe_word(
+            "policyAdmin(after finalize)",
+            IPolicyRegistry::policyAdminCall { policyId: allowlist_id }.abi_encode(),
+            word_from_address(BerylTestEnv::bob()),
+        )
+        .await;
+
+    let create_blocklist = scenario.tx(IPolicyRegistry::createPolicyWithAccountsCall {
+        admin: BerylTestEnv::bob(),
+        policyType: IPolicyRegistry::PolicyType::BLOCKLIST,
+        accounts: vec![BerylTestEnv::bob()],
+    });
+    let block = scenario.build_block_with_transactions(vec![create_blocklist]).await;
+
+    assert!(scenario.env.user_tx_succeeded(&block, 0), "createPolicyWithAccounts() must succeed");
+    scenario.assert_policy_log(
+        &block,
+        0,
+        IPolicyRegistry::BlocklistUpdated {
+            policyId: blocklist_id,
+            updater: BerylTestEnv::alice(),
+            blocked: true,
+            accounts: vec![BerylTestEnv::bob()],
+        }
+        .encode_log_data(),
+    );
+    scenario
+        .assert_probe_word(
+            "isAuthorized(blocked member)",
+            IPolicyRegistry::isAuthorizedCall {
+                policyId: blocklist_id,
+                account: BerylTestEnv::bob(),
+            }
+            .abi_encode(),
+            U256::ZERO,
+        )
+        .await;
+
+    let update_blocklist = scenario.bob_tx(IPolicyRegistry::updateBlocklistCall {
+        policyId: blocklist_id,
+        blocked: false,
+        accounts: vec![BerylTestEnv::bob()],
+    });
+    let block = scenario.build_block_with_transactions(vec![update_blocklist]).await;
+
+    assert!(scenario.env.user_tx_succeeded(&block, 0), "updateBlocklist() must succeed");
+    scenario.assert_policy_log(
+        &block,
+        0,
+        IPolicyRegistry::BlocklistUpdated {
+            policyId: blocklist_id,
+            updater: BerylTestEnv::bob(),
+            blocked: false,
+            accounts: vec![BerylTestEnv::bob()],
+        }
+        .encode_log_data(),
+    );
+    scenario
+        .assert_probe_word(
+            "isAuthorized(unblocked member)",
+            IPolicyRegistry::isAuthorizedCall {
+                policyId: blocklist_id,
+                account: BerylTestEnv::bob(),
+            }
+            .abi_encode(),
+            U256::ONE,
+        )
+        .await;
+
+    let renounce_admin =
+        scenario.bob_tx(IPolicyRegistry::renounceAdminCall { policyId: allowlist_id });
+    let block = scenario.build_block_with_transactions(vec![renounce_admin]).await;
+
+    assert!(scenario.env.user_tx_succeeded(&block, 0), "renounceAdmin() must succeed");
+    scenario.assert_policy_log(
+        &block,
+        0,
+        IPolicyRegistry::PolicyAdminUpdated {
+            policyId: allowlist_id,
+            previousAdmin: BerylTestEnv::bob(),
+            newAdmin: alloy_primitives::Address::ZERO,
+        }
+        .encode_log_data(),
+    );
+    scenario
+        .assert_probe_word(
+            "policyAdmin(after renounce)",
+            IPolicyRegistry::policyAdminCall { policyId: allowlist_id }.abi_encode(),
+            U256::ZERO,
+        )
+        .await;
+
+    scenario.derive().await;
+}
+
+struct PolicyRegistryScenario {
+    env: BerylTestEnv,
+    probe: alloy_primitives::Address,
+    blocks: Vec<(BaseBlock, u64)>,
+}
+
+impl PolicyRegistryScenario {
+    async fn new() -> Self {
+        let env = BerylTestEnv::new();
+        let mut scenario = Self { env, probe: alloy_primitives::Address::ZERO, blocks: Vec::new() };
+
+        scenario.build_empty_block().await;
+
+        let activate = scenario.env.activate_feature_tx(BerylTestEnv::policy_registry_feature());
+        let block = scenario.build_block_with_transactions(vec![activate]).await;
+        assert!(
+            scenario.env.user_tx_succeeded(&block, 0),
+            "POLICY_REGISTRY activation must succeed"
+        );
+
+        let (probe, deploy_probe) =
+            scenario.env.deploy_staticcall_probe_tx(PolicyRegistryStorage::ADDRESS);
+        scenario.probe = probe;
+        let block = scenario.build_block_with_transactions(vec![deploy_probe]).await;
+        assert!(scenario.env.user_tx_succeeded(&block, 0), "policy probe deployment must succeed");
+
+        scenario
+    }
+
+    async fn build_empty_block(&mut self) {
+        let block = self.env.sequencer.build_empty_block().await;
+        self.push_block(block);
+    }
+
+    async fn build_block_with_transactions(&mut self, txs: Vec<BaseTxEnvelope>) -> BaseBlock {
+        let block = self.env.sequencer.build_next_block_with_transactions(txs).await;
+        self.push_block(block.clone());
+        block
+    }
+
+    fn tx(&self, call: impl SolCall) -> BaseTxEnvelope {
+        self.env.create_tx(
+            TxKind::Call(PolicyRegistryStorage::ADDRESS),
+            Bytes::from(call.abi_encode()),
+            GAS_LIMIT,
+        )
+    }
+
+    fn bob_tx(&mut self, call: impl SolCall) -> BaseTxEnvelope {
+        self.env.create_bob_tx(
+            TxKind::Call(PolicyRegistryStorage::ADDRESS),
+            Bytes::from(call.abi_encode()),
+            GAS_LIMIT,
+        )
+    }
+
+    async fn assert_probe_word(&mut self, label: &'static str, calldata: Vec<u8>, expected: U256) {
+        let tx = self.env.call_staticcall_probe_tx(
+            self.probe,
+            Bytes::from(calldata),
+            BerylTestEnv::B20_PROBE_GAS_LIMIT,
+        );
+        let block = self.build_block_with_transactions(vec![tx]).await;
+        assert!(self.env.user_tx_succeeded(&block, 0), "{label} probe tx must succeed");
+        assert!(self.env.probe_call_succeeded(self.probe), "{label} staticcall must succeed");
+        assert_eq!(
+            self.env.probe_return_word(self.probe),
+            expected,
+            "{label} staticcall must return the expected word"
+        );
+    }
+
+    fn assert_policy_log(
+        &self,
+        block: &BaseBlock,
+        user_tx_index: usize,
+        expected: alloy_primitives::LogData,
+    ) {
+        assert!(
+            self.env
+                .user_tx_receipt(block, user_tx_index)
+                .logs()
+                .iter()
+                .any(|log| log.address == PolicyRegistryStorage::ADDRESS && log.data == expected),
+            "policy-registry transaction {user_tx_index} must emit the expected event"
+        );
+    }
+
+    async fn derive(mut self) {
+        let expected_safe_head = self.blocks.len() as u64;
+        self.env.derive_blocks(self.blocks, expected_safe_head).await;
+    }
+
+    fn push_block(&mut self, block: BaseBlock) {
+        let block_number = self.blocks.len() as u64 + 1;
+        self.blocks.push((block, block_number));
+    }
+}
+
+const fn policy_id(policy_type: IPolicyRegistry::PolicyType, counter: u64) -> u64 {
+    (policy_type as u64) << 56 | counter
+}
+
+fn word_from_address(address: alloy_primitives::Address) -> U256 {
+    let mut word = [0u8; 32];
+    word[12..].copy_from_slice(address.as_slice());
+    U256::from_be_slice(&word)
 }

--- a/crates/common/precompiles/src/policy/storage.rs
+++ b/crates/common/precompiles/src/policy/storage.rs
@@ -93,6 +93,10 @@ impl PolicyRegistryStorage<'_> {
             return Err(BasePrecompileError::revert(IPolicyRegistry::ZeroAddress {}));
         }
 
+        // The registry account must be non-empty before the first policy storage write; otherwise
+        // the EVM path can prune writes made under an empty native-precompile account.
+        // TODO: Revisit this guard against the finalized Beryl gas model, since `is_initialized`
+        // charges warm/cold account-read gas before skipping repeated `set_code`.
         if !self.is_initialized()? {
             self.__initialize()?;
         }

--- a/crates/common/precompiles/src/policy/storage.rs
+++ b/crates/common/precompiles/src/policy/storage.rs
@@ -2,7 +2,7 @@ use alloc::vec::Vec;
 
 use alloy_primitives::{Address, U256, address};
 use base_precompile_macros::contract;
-use base_precompile_storage::{BasePrecompileError, Handler, Mapping, Result};
+use base_precompile_storage::{BasePrecompileError, ContractStorage, Handler, Mapping, Result};
 
 use super::{IPolicyRegistry, IPolicyRegistry::PolicyType};
 
@@ -91,6 +91,10 @@ impl PolicyRegistryStorage<'_> {
         let policy_type_u8 = policy_type.as_discriminant()?;
         if admin == Address::ZERO {
             return Err(BasePrecompileError::revert(IPolicyRegistry::ZeroAddress {}));
+        }
+
+        if !self.is_initialized()? {
+            self.__initialize()?;
         }
 
         let counter = self.next_counter.read()?;


### PR DESCRIPTION
## Summary

This closes the Beryl native-precompile action-test coverage gap across the activation registry, token factory, B-20 token, and policy registry surfaces. The new scenarios exercise every Beryl-native ABI entrypoint through the action harness and derive the produced blocks across the hardfork boundary. The policy-registry coverage also exposed and fixes first-write persistence by initializing the singleton account before custom policy storage updates.