### PR TITLE
refactor(precompiles): Move B20 Role Ops

### DIFF
--- a/crates/common/precompiles/src/b20/dispatch.rs
+++ b/crates/common/precompiles/src/b20/dispatch.rs
@@ -8,8 +8,8 @@ use super::{
     abi::{IB20, IB20::IB20Calls as C},
 };
 use crate::{
-    ActivationRegistryStorage, Burnable, Configurable, Mintable, Pausable, Permittable, Policy,
-    TokenAccounting, Transferable,
+    ActivationRegistryStorage, B20TokenRole, Burnable, Configurable, Mintable, Pausable,
+    Permittable, Policy, RoleManaged, TokenAccounting, Transferable,
     macros::{decode_precompile_call, deduct_calldata_cost},
 };
 
@@ -66,13 +66,13 @@ impl<S: TokenAccounting, P: Policy> B20Token<S, P> {
             C::supplyCap(_) => self.accounting.supply_cap()?.abi_encode().into(),
             C::nonces(c) => self.accounting.nonce(c.owner)?.abi_encode().into(),
             C::contractURI(_) => self.accounting.contract_uri()?.abi_encode().into(),
-            C::DEFAULT_ADMIN_ROLE(_) => Self::default_admin_role().abi_encode().into(),
-            C::MINT_ROLE(_) => Self::mint_role().abi_encode().into(),
-            C::BURN_ROLE(_) => Self::burn_role().abi_encode().into(),
-            C::BURN_BLOCKED_ROLE(_) => Self::burn_blocked_role().abi_encode().into(),
-            C::PAUSE_ROLE(_) => Self::pause_role().abi_encode().into(),
-            C::UNPAUSE_ROLE(_) => Self::unpause_role().abi_encode().into(),
-            C::METADATA_ROLE(_) => Self::metadata_role().abi_encode().into(),
+            C::DEFAULT_ADMIN_ROLE(_) => B20TokenRole::DefaultAdmin.id().abi_encode().into(),
+            C::MINT_ROLE(_) => B20TokenRole::Mint.id().abi_encode().into(),
+            C::BURN_ROLE(_) => B20TokenRole::Burn.id().abi_encode().into(),
+            C::BURN_BLOCKED_ROLE(_) => B20TokenRole::BurnBlocked.id().abi_encode().into(),
+            C::PAUSE_ROLE(_) => B20TokenRole::Pause.id().abi_encode().into(),
+            C::UNPAUSE_ROLE(_) => B20TokenRole::Unpause.id().abi_encode().into(),
+            C::METADATA_ROLE(_) => B20TokenRole::Metadata.id().abi_encode().into(),
             C::TRANSFER_SENDER_POLICY(_) => Self::transfer_sender_policy().abi_encode().into(),
             C::TRANSFER_RECEIVER_POLICY(_) => Self::transfer_receiver_policy().abi_encode().into(),
             C::TRANSFER_EXECUTOR_POLICY(_) => Self::transfer_executor_policy().abi_encode().into(),

--- a/crates/common/precompiles/src/b20/mod.rs
+++ b/crates/common/precompiles/src/b20/mod.rs
@@ -13,9 +13,6 @@ pub use policies::{B20PolicyType, POLICY_ALWAYS_ALLOW, POLICY_ALWAYS_BLOCK};
 mod precompile;
 pub use precompile::B20TokenPrecompile;
 
-mod roles;
-pub use roles::B20TokenRole;
-
 mod storage;
 pub use storage::B20TokenStorage;
 

--- a/crates/common/precompiles/src/b20/policies.rs
+++ b/crates/common/precompiles/src/b20/policies.rs
@@ -5,7 +5,7 @@ use alloy_sol_types::SolEvent;
 use base_precompile_storage::{BasePrecompileError, Result};
 
 use super::token::B20Token;
-use crate::{IB20, Policy, Token, TokenAccounting};
+use crate::{B20Guards, B20TokenRole, IB20, Policy, Token, TokenAccounting};
 
 /// Built-in policy ID that authorizes every account.
 pub const POLICY_ALWAYS_ALLOW: u64 = 0;
@@ -97,7 +97,7 @@ impl<S: TokenAccounting, P: Policy> B20Token<S, P> {
         privileged: bool,
     ) -> Result<()> {
         if !privileged {
-            self.ensure_role(caller, Self::default_admin_role())?;
+            B20Guards::ensure_token_role(self, caller, B20TokenRole::DefaultAdmin)?;
         }
         let old_policy_id = self.policy_id(policy_type)?;
         if !self.policy.policy_exists(new_policy_id)? {

--- a/crates/common/precompiles/src/b20/token.rs
+++ b/crates/common/precompiles/src/b20/token.rs
@@ -3,8 +3,8 @@
 use alloy_primitives::Address;
 
 use crate::{
-    Burnable, Configurable, Mintable, Pausable, Permittable, Policy, Token, TokenAccounting,
-    Transferable,
+    Burnable, Configurable, Mintable, Pausable, Permittable, Policy, RoleManaged, Token,
+    TokenAccounting, Transferable,
 };
 
 /// EVM precompile for the Default B-20 token variant.
@@ -68,3 +68,4 @@ impl<S: TokenAccounting, P: Policy> Burnable for B20Token<S, P> {}
 impl<S: TokenAccounting, P: Policy> Pausable for B20Token<S, P> {}
 impl<S: TokenAccounting, P: Policy> Configurable for B20Token<S, P> {}
 impl<S: TokenAccounting, P: Policy> Permittable for B20Token<S, P> {}
+impl<S: TokenAccounting, P: Policy> RoleManaged for B20Token<S, P> {}

--- a/crates/common/precompiles/src/common/mod.rs
+++ b/crates/common/precompiles/src/common/mod.rs
@@ -1,7 +1,10 @@
 //! Shared business logic for all Base-native token variants.
 
 mod ops;
-pub use ops::{B20Guards, Burnable, Configurable, Mintable, Pausable, Permittable, Transferable};
+pub use ops::{
+    B20Guards, B20TokenRole, Burnable, Configurable, Mintable, Pausable, Permittable, RoleManaged,
+    Transferable,
+};
 
 mod policy;
 #[cfg(any(test, feature = "test-utils"))]

--- a/crates/common/precompiles/src/common/ops/mod.rs
+++ b/crates/common/precompiles/src/common/ops/mod.rs
@@ -25,5 +25,8 @@ pub use pausable::Pausable;
 mod permittable;
 pub use permittable::Permittable;
 
+mod roles;
+pub use roles::{B20TokenRole, RoleManaged};
+
 mod transferable;
 pub use transferable::Transferable;

--- a/crates/common/precompiles/src/common/ops/roles.rs
+++ b/crates/common/precompiles/src/common/ops/roles.rs
@@ -1,11 +1,11 @@
-//! Role helpers for B-20 tokens.
+//! Role-management operations for B-20 tokens.
 
 use alloy_primitives::{Address, B256, U256, b256};
 use alloy_sol_types::SolEvent;
 use base_precompile_storage::{BasePrecompileError, Result};
 
-use super::token::B20Token;
-use crate::{IB20, Policy, Token, TokenAccounting};
+use super::guards::B20Guards;
+use crate::{IB20, Token, TokenAccounting};
 
 const MINT_ROLE: B256 = b256!("154c00819833dac601ee5ddded6fda79d9d8b506b911b3dbd54cdb95fe6c3686");
 const BURN_ROLE: B256 = b256!("e97b137254058bd94f28d2f3eb79e2d34074ffb488d042e3bc958e0a57d2fa22");
@@ -51,63 +51,67 @@ impl B20TokenRole {
     }
 }
 
-impl<S: TokenAccounting, P: Policy> B20Token<S, P> {
+/// Role-management operations.
+///
+/// All methods have default implementations that go through [`Token::accounting`].
+/// Implement with an empty body to opt in.
+pub trait RoleManaged: Token {
     /// The default top-level admin role.
-    pub const fn default_admin_role() -> B256 {
+    fn default_admin_role() -> B256 {
         B20TokenRole::DefaultAdmin.id()
     }
 
     /// Role required for `mint` and `mintWithMemo`.
-    pub const fn mint_role() -> B256 {
+    fn mint_role() -> B256 {
         B20TokenRole::Mint.id()
     }
 
     /// Role required for `burn` and `burnWithMemo`.
-    pub const fn burn_role() -> B256 {
+    fn burn_role() -> B256 {
         B20TokenRole::Burn.id()
     }
 
     /// Role required for `burnBlocked`; permits burning from blocked accounts without `BURN_ROLE`.
-    pub const fn burn_blocked_role() -> B256 {
+    fn burn_blocked_role() -> B256 {
         B20TokenRole::BurnBlocked.id()
     }
 
     /// Role required for `pause`.
-    pub const fn pause_role() -> B256 {
+    fn pause_role() -> B256 {
         B20TokenRole::Pause.id()
     }
 
     /// Role required for `unpause`.
-    pub const fn unpause_role() -> B256 {
+    fn unpause_role() -> B256 {
         B20TokenRole::Unpause.id()
     }
 
     /// Role required for `setName` and `setSymbol`.
-    pub const fn metadata_role() -> B256 {
+    fn metadata_role() -> B256 {
         B20TokenRole::Metadata.id()
     }
 
     /// Returns the admin role for `role`.
-    pub fn role_admin(&self, role: B256) -> Result<B256> {
-        self.accounting.role_admin(role)
+    fn role_admin(&self, role: B256) -> Result<B256> {
+        self.accounting().role_admin(role)
     }
 
     /// Returns whether `account` has `role`.
-    pub fn has_role(&self, role: B256, account: Address) -> Result<bool> {
-        self.accounting.has_role(role, account)
+    fn has_role(&self, role: B256, account: Address) -> Result<bool> {
+        self.accounting().has_role(role, account)
     }
 
     /// Grants `role` to `account` without checking caller authorization.
-    pub fn grant_role_unchecked(
+    fn grant_role_unchecked(
         &mut self,
         role: B256,
         account: Address,
         sender: Address,
     ) -> Result<()> {
-        if self.accounting.has_role(role, account)? {
+        if self.accounting().has_role(role, account)? {
             return Ok(());
         }
-        let current = self.accounting.role_member_count(role)?;
+        let current = self.accounting().role_member_count(role)?;
         let next =
             current.checked_add(U256::ONE).ok_or_else(BasePrecompileError::under_overflow)?;
         self.accounting_mut().set_role(role, account, true)?;
@@ -117,16 +121,16 @@ impl<S: TokenAccounting, P: Policy> B20Token<S, P> {
     }
 
     /// Revokes `role` from `account` without checking caller authorization.
-    pub fn revoke_role_unchecked(
+    fn revoke_role_unchecked(
         &mut self,
         role: B256,
         account: Address,
         sender: Address,
     ) -> Result<()> {
-        if !self.accounting.has_role(role, account)? {
+        if !self.accounting().has_role(role, account)? {
             return Ok(());
         }
-        let current = self.accounting.role_member_count(role)?;
+        let current = self.accounting().role_member_count(role)?;
         let next =
             current.checked_sub(U256::ONE).ok_or_else(BasePrecompileError::under_overflow)?;
         self.accounting_mut().set_role(role, account, false)?;
@@ -136,19 +140,12 @@ impl<S: TokenAccounting, P: Policy> B20Token<S, P> {
     }
 
     /// Ensures `caller` has `role`.
-    pub fn ensure_role(&self, caller: Address, role: B256) -> Result<()> {
-        if self.accounting.has_role(role, caller)? {
-            Ok(())
-        } else {
-            Err(BasePrecompileError::revert(IB20::AccessControlUnauthorizedAccount {
-                account: caller,
-                neededRole: role,
-            }))
-        }
+    fn ensure_role(&self, caller: Address, role: B256) -> Result<()> {
+        B20Guards::ensure_role(self, caller, role)
     }
 
     /// Grants `role` to `account`, optionally bypassing authorization during factory init.
-    pub fn grant_role(
+    fn grant_role(
         &mut self,
         caller: Address,
         role: B256,
@@ -162,7 +159,7 @@ impl<S: TokenAccounting, P: Policy> B20Token<S, P> {
     }
 
     /// Revokes `role` from `account`, optionally bypassing authorization during factory init.
-    pub fn revoke_role(
+    fn revoke_role(
         &mut self,
         caller: Address,
         role: B256,
@@ -180,18 +177,13 @@ impl<S: TokenAccounting, P: Policy> B20Token<S, P> {
     /// Matches `AccessControl` no-op semantics for accounts that do not hold `role`: the call
     /// succeeds and emits no `RoleRevoked` event. The only stricter path is the final
     /// `DEFAULT_ADMIN_ROLE` holder, which must use [`Self::renounce_last_admin`].
-    pub fn renounce_role(
-        &mut self,
-        caller: Address,
-        role: B256,
-        confirmation: Address,
-    ) -> Result<()> {
+    fn renounce_role(&mut self, caller: Address, role: B256, confirmation: Address) -> Result<()> {
         if confirmation != caller {
             return Err(BasePrecompileError::revert(IB20::AccessControlBadConfirmation {}));
         }
         if role == Self::default_admin_role()
-            && self.accounting.has_role(role, caller)?
-            && self.accounting.role_member_count(role)? == U256::ONE
+            && self.accounting().has_role(role, caller)?
+            && self.accounting().role_member_count(role)? == U256::ONE
         {
             return Err(BasePrecompileError::revert(IB20::LastAdminCannotRenounce {}));
         }
@@ -199,10 +191,10 @@ impl<S: TokenAccounting, P: Policy> B20Token<S, P> {
     }
 
     /// Permanently removes the final default admin.
-    pub fn renounce_last_admin(&mut self, caller: Address) -> Result<()> {
+    fn renounce_last_admin(&mut self, caller: Address) -> Result<()> {
         let admin_role = Self::default_admin_role();
         self.ensure_role(caller, admin_role)?;
-        if self.accounting.role_member_count(admin_role)? != U256::ONE {
+        if self.accounting().role_member_count(admin_role)? != U256::ONE {
             return Err(BasePrecompileError::revert(IB20::NotSoleAdmin {}));
         }
         self.revoke_role_unchecked(admin_role, caller, caller)?;
@@ -216,7 +208,7 @@ impl<S: TokenAccounting, P: Policy> B20Token<S, P> {
     /// `DEFAULT_ADMIN_ROLE`. Setting its admin to a role with no members can make ordinary admin
     /// recovery impossible; [`Self::renounce_last_admin`] remains the explicit terminal path for
     /// burning the final admin.
-    pub fn set_role_admin(
+    fn set_role_admin(
         &mut self,
         caller: Address,
         role: B256,
@@ -236,5 +228,113 @@ impl<S: TokenAccounting, P: Policy> B20Token<S, P> {
             }
             .encode_log_data(),
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_primitives::{Address, B256, U256};
+    use alloy_sol_types::SolEvent;
+    use base_precompile_storage::BasePrecompileError;
+
+    use super::{B20TokenRole, RoleManaged};
+    use crate::{
+        IB20, Token, TokenAccounting,
+        common::test_utils::{InMemoryPolicy, InMemoryTokenAccounting, TestToken},
+    };
+
+    const ADMIN: Address = Address::repeat_byte(0xaa);
+    const ALICE: Address = Address::repeat_byte(0xbb);
+    const TOKEN_ADDR: Address = Address::repeat_byte(0x11);
+    const CUSTOM_ROLE: B256 = B256::repeat_byte(0x42);
+
+    fn make_token() -> TestToken {
+        TestToken::with_storage_and_policy(
+            InMemoryTokenAccounting::new(TOKEN_ADDR),
+            InMemoryPolicy::new(),
+        )
+    }
+
+    fn token_with_default_admin() -> TestToken {
+        let mut accounting = InMemoryTokenAccounting::new(TOKEN_ADDR);
+        accounting.roles.insert((B20TokenRole::DefaultAdmin.id(), ADMIN), true);
+        accounting.role_member_counts.insert(B20TokenRole::DefaultAdmin.id(), U256::ONE);
+        TestToken::with_storage_and_policy(accounting, InMemoryPolicy::new())
+    }
+
+    #[test]
+    fn grant_role_authorizes_against_role_admin_and_emits_event() {
+        let mut token = token_with_default_admin();
+
+        token.grant_role(ADMIN, B20TokenRole::Mint.id(), ALICE, false).unwrap();
+
+        assert!(token.has_role(B20TokenRole::Mint.id(), ALICE).unwrap());
+        assert_eq!(
+            token.accounting().role_member_count(B20TokenRole::Mint.id()).unwrap(),
+            U256::ONE
+        );
+        assert_eq!(
+            token.accounting().events[0],
+            IB20::RoleGranted { role: B20TokenRole::Mint.id(), account: ALICE, sender: ADMIN }
+                .encode_log_data()
+        );
+    }
+
+    #[test]
+    fn grant_role_without_admin_reverts() {
+        let mut token = make_token();
+
+        assert_eq!(
+            token.grant_role(ADMIN, B20TokenRole::Mint.id(), ALICE, false).unwrap_err(),
+            BasePrecompileError::revert(IB20::AccessControlUnauthorizedAccount {
+                account: ADMIN,
+                neededRole: B256::ZERO,
+            })
+        );
+    }
+
+    #[test]
+    fn renounce_role_rejects_final_default_admin() {
+        let mut token = token_with_default_admin();
+
+        assert_eq!(
+            token.renounce_role(ADMIN, B20TokenRole::DefaultAdmin.id(), ADMIN).unwrap_err(),
+            BasePrecompileError::revert(IB20::LastAdminCannotRenounce {})
+        );
+    }
+
+    #[test]
+    fn renounce_last_admin_revokes_and_emits_terminal_event() {
+        let mut token = token_with_default_admin();
+
+        token.renounce_last_admin(ADMIN).unwrap();
+
+        assert!(!token.has_role(B20TokenRole::DefaultAdmin.id(), ADMIN).unwrap());
+        assert_eq!(
+            token.accounting().role_member_count(B20TokenRole::DefaultAdmin.id()).unwrap(),
+            U256::ZERO
+        );
+        assert_eq!(
+            token.accounting().events.last().unwrap(),
+            &IB20::LastAdminRenounced { previousAdmin: ADMIN }.encode_log_data()
+        );
+    }
+
+    #[test]
+    fn set_role_admin_emits_previous_and_new_admin_roles() {
+        let mut token = token_with_default_admin();
+
+        token.set_role_admin(ADMIN, CUSTOM_ROLE, B20TokenRole::Mint.id(), false).unwrap();
+
+        assert_eq!(token.role_admin(CUSTOM_ROLE).unwrap(), B20TokenRole::Mint.id());
+        assert_eq!(
+            token.accounting().events[0],
+            IB20::RoleAdminChanged {
+                role: CUSTOM_ROLE,
+                previousAdminRole: B256::ZERO,
+                newAdminRole: B20TokenRole::Mint.id(),
+            }
+            .encode_log_data()
+        );
     }
 }

--- a/crates/common/precompiles/src/factory/storage.rs
+++ b/crates/common/precompiles/src/factory/storage.rs
@@ -7,7 +7,9 @@ use base_precompile_storage::{BasePrecompileError, Handler, Result};
 use revm::state::Bytecode;
 
 use super::variant::TokenVariant;
-use crate::{B20Token, B20TokenStorage, ITokenFactory, PolicyHandle, Token};
+use crate::{
+    B20Token, B20TokenRole, B20TokenStorage, ITokenFactory, PolicyHandle, RoleManaged, Token,
+};
 
 /// The B-20 token factory precompile.
 #[contract(addr = Self::ADDRESS)]
@@ -70,7 +72,7 @@ impl<'a> TokenFactoryStorage<'a> {
 
         if !token_params.initial_admin.is_zero() {
             token.grant_role_unchecked(
-                B20Token::<B20TokenStorage<'_>, PolicyHandle<'_>>::default_admin_role(),
+                B20TokenRole::DefaultAdmin.id(),
                 token_params.initial_admin,
                 Self::ADDRESS,
             )?;

--- a/crates/common/precompiles/src/lib.rs
+++ b/crates/common/precompiles/src/lib.rs
@@ -22,16 +22,16 @@ mod bls12_381;
 
 mod common;
 pub use common::{
-    B20Guards, Burnable, Configurable, Mintable, Pausable, Permittable, Policy, PolicyRegistry,
-    Token, TokenAccounting, Transferable,
+    B20Guards, B20TokenRole, Burnable, Configurable, Mintable, Pausable, Permittable, Policy,
+    PolicyRegistry, RoleManaged, Token, TokenAccounting, Transferable,
 };
 #[cfg(any(test, feature = "test-utils"))]
 pub use common::{InMemoryPolicy, InMemoryTokenAccounting, TestToken};
 
 mod b20;
 pub use b20::{
-    B20PausableFeature, B20PolicyType, B20Token, B20TokenPrecompile, B20TokenRole, B20TokenStorage,
-    IB20, POLICY_ALWAYS_ALLOW, POLICY_ALWAYS_BLOCK,
+    B20PausableFeature, B20PolicyType, B20Token, B20TokenPrecompile, B20TokenStorage, IB20,
+    POLICY_ALWAYS_ALLOW, POLICY_ALWAYS_BLOCK,
 };
 
 mod factory;


### PR DESCRIPTION
## Summary

This refactors B-20 role management into the shared common ops layer so roles follow the same opt-in trait pattern as mint, burn, pause, and configurable behavior. The public B20TokenRole export remains available while B20Token now implements RoleManaged. This branch is stacked on rf/feat/align-b20-base-std-interface.