### PR TITLE
test(policy): add devnet E2E tests for full PolicyRegistry lifecycle (BOP-111)

### DIFF
--- a/devnet/tests/policy_registry.rs
+++ b/devnet/tests/policy_registry.rs
@@ -14,18 +14,21 @@ use eyre::{Result, WrapErr};
 
 // --- read helpers ---
 
-async fn read_next_policy_id(
+/// Predicts the policy ID that a `createPolicy(admin, policy_type)` call would return,
+/// without committing state (uses `eth_call` simulation).
+async fn predict_policy_id(
     client: &B20PrecompileClient<'_>,
+    admin: Address,
     policy_type: IPolicyRegistry::PolicyType,
 ) -> Result<u64> {
     let out = client
         .call(
             PolicyRegistryStorage::ADDRESS,
-            IPolicyRegistry::nextPolicyIdCall { policyType: policy_type },
+            IPolicyRegistry::createPolicyCall { admin, policyType: policy_type },
         )
         .await?;
-    IPolicyRegistry::nextPolicyIdCall::abi_decode_returns(out.as_ref())
-        .wrap_err("Failed to decode nextPolicyId")
+    IPolicyRegistry::createPolicyCall::abi_decode_returns(out.as_ref())
+        .wrap_err("Failed to predict policy ID via createPolicy simulation")
 }
 
 async fn read_is_authorized(
@@ -68,20 +71,6 @@ async fn read_pending_policy_admin(
         .wrap_err("Failed to decode pendingPolicyAdmin")
 }
 
-async fn read_policy_type(
-    client: &B20PrecompileClient<'_>,
-    policy_id: u64,
-) -> Result<IPolicyRegistry::PolicyType> {
-    let out = client
-        .call(
-            PolicyRegistryStorage::ADDRESS,
-            IPolicyRegistry::policyTypeCall { policyId: policy_id },
-        )
-        .await?;
-    IPolicyRegistry::policyTypeCall::abi_decode_returns(out.as_ref())
-        .wrap_err("Failed to decode policyType")
-}
-
 // --- existing test ---
 
 /// `policyExists(0)` returns `true` once the Beryl fork is active.
@@ -122,7 +111,8 @@ async fn test_create_allowlist_policy_and_authorize() -> Result<()> {
     let client = B20PrecompileClient::new(&provider, &admin, common::L2_CHAIN_ID)
         .with_receipt_timeout(common::TX_RECEIPT_TIMEOUT);
 
-    let policy_id = read_next_policy_id(&client, IPolicyRegistry::PolicyType::ALLOWLIST).await?;
+    let policy_id =
+        predict_policy_id(&client, admin.address(), IPolicyRegistry::PolicyType::ALLOWLIST).await?;
 
     client
         .send_call(
@@ -173,7 +163,8 @@ async fn test_create_blocklist_policy_and_block() -> Result<()> {
     let client = B20PrecompileClient::new(&provider, &admin, common::L2_CHAIN_ID)
         .with_receipt_timeout(common::TX_RECEIPT_TIMEOUT);
 
-    let policy_id = read_next_policy_id(&client, IPolicyRegistry::PolicyType::BLOCKLIST).await?;
+    let policy_id =
+        predict_policy_id(&client, admin.address(), IPolicyRegistry::PolicyType::BLOCKLIST).await?;
 
     client
         .send_call(
@@ -228,7 +219,8 @@ async fn test_two_step_admin_transfer() -> Result<()> {
         .with_receipt_timeout(common::TX_RECEIPT_TIMEOUT);
 
     let policy_id =
-        read_next_policy_id(&client_admin, IPolicyRegistry::PolicyType::ALLOWLIST).await?;
+        predict_policy_id(&client_admin, admin.address(), IPolicyRegistry::PolicyType::ALLOWLIST)
+            .await?;
 
     client_admin
         .send_call(
@@ -296,7 +288,8 @@ async fn test_renounce_admin() -> Result<()> {
     let client = B20PrecompileClient::new(&provider, &admin, common::L2_CHAIN_ID)
         .with_receipt_timeout(common::TX_RECEIPT_TIMEOUT);
 
-    let policy_id = read_next_policy_id(&client, IPolicyRegistry::PolicyType::ALLOWLIST).await?;
+    let policy_id =
+        predict_policy_id(&client, admin.address(), IPolicyRegistry::PolicyType::ALLOWLIST).await?;
 
     client
         .send_call(
@@ -326,8 +319,8 @@ async fn test_renounce_admin() -> Result<()> {
     Ok(())
 }
 
-/// Verifies that `nextPolicyId`, `policyType`, `policyAdmin`, and `pendingPolicyAdmin` all return
-/// correct values after policy creation.
+/// Verifies that `policyAdmin` and `pendingPolicyAdmin` return correct values after policy
+/// creation, and that the policy ID counter advances after each creation.
 #[tokio::test]
 async fn test_policy_views() -> Result<()> {
     let (_devnet, provider) = common::start_beryl_devnet().await?;
@@ -338,7 +331,8 @@ async fn test_policy_views() -> Result<()> {
         .with_receipt_timeout(common::TX_RECEIPT_TIMEOUT);
 
     // Snapshot the predicted policy ID before any creation.
-    let predicted_id = read_next_policy_id(&client, IPolicyRegistry::PolicyType::ALLOWLIST).await?;
+    let predicted_id =
+        predict_policy_id(&client, admin.address(), IPolicyRegistry::PolicyType::ALLOWLIST).await?;
 
     client
         .send_call(
@@ -350,12 +344,6 @@ async fn test_policy_views() -> Result<()> {
             "createPolicy(ALLOWLIST)",
         )
         .await?;
-
-    assert_eq!(
-        read_policy_type(&client, predicted_id).await?,
-        IPolicyRegistry::PolicyType::ALLOWLIST,
-        "policyType should be ALLOWLIST",
-    );
 
     assert_eq!(
         read_policy_admin(&client, predicted_id).await?,
@@ -371,7 +359,7 @@ async fn test_policy_views() -> Result<()> {
 
     // The counter must have advanced so the next ID differs from the one we just created.
     let next_id_after =
-        read_next_policy_id(&client, IPolicyRegistry::PolicyType::ALLOWLIST).await?;
+        predict_policy_id(&client, admin.address(), IPolicyRegistry::PolicyType::ALLOWLIST).await?;
     assert_ne!(next_id_after, predicted_id, "nextPolicyId should advance after createPolicy",);
 
     Ok(())

--- a/devnet/tests/policy_registry.rs
+++ b/devnet/tests/policy_registry.rs
@@ -2,13 +2,92 @@
 
 mod common;
 
+use alloy_primitives::Address;
 use alloy_signer_local::PrivateKeySigner;
 use alloy_sol_types::SolCall;
-use base_common_precompiles::{ActivationFeature, IPolicyRegistry, PolicyRegistryStorage};
-use devnet::{B20PrecompileClient, config::ANVIL_ACCOUNT_5};
+use base_common_precompiles::{IPolicyRegistry, PolicyRegistryStorage};
+use devnet::{
+    B20PrecompileClient,
+    config::{ANVIL_ACCOUNT_5, ANVIL_ACCOUNT_6, ANVIL_ACCOUNT_7, ANVIL_ACCOUNT_8},
+};
 use eyre::{Result, WrapErr};
 
-/// `policyExists(ALWAYS_ALLOW_ID)` returns `true` once the policy registry is active.
+// --- read helpers ---
+
+async fn read_next_policy_id(
+    client: &B20PrecompileClient<'_>,
+    policy_type: IPolicyRegistry::PolicyType,
+) -> Result<u64> {
+    let out = client
+        .call(
+            PolicyRegistryStorage::ADDRESS,
+            IPolicyRegistry::nextPolicyIdCall { policyType: policy_type },
+        )
+        .await?;
+    IPolicyRegistry::nextPolicyIdCall::abi_decode_returns(out.as_ref())
+        .wrap_err("Failed to decode nextPolicyId")
+}
+
+async fn read_is_authorized(
+    client: &B20PrecompileClient<'_>,
+    policy_id: u64,
+    account: Address,
+) -> Result<bool> {
+    let out = client
+        .call(
+            PolicyRegistryStorage::ADDRESS,
+            IPolicyRegistry::isAuthorizedCall { policyId: policy_id, account },
+        )
+        .await?;
+    IPolicyRegistry::isAuthorizedCall::abi_decode_returns(out.as_ref())
+        .wrap_err("Failed to decode isAuthorized")
+}
+
+async fn read_policy_admin(
+    client: &B20PrecompileClient<'_>,
+    policy_id: u64,
+) -> Result<Address> {
+    let out = client
+        .call(
+            PolicyRegistryStorage::ADDRESS,
+            IPolicyRegistry::policyAdminCall { policyId: policy_id },
+        )
+        .await?;
+    IPolicyRegistry::policyAdminCall::abi_decode_returns(out.as_ref())
+        .wrap_err("Failed to decode policyAdmin")
+}
+
+async fn read_pending_policy_admin(
+    client: &B20PrecompileClient<'_>,
+    policy_id: u64,
+) -> Result<Address> {
+    let out = client
+        .call(
+            PolicyRegistryStorage::ADDRESS,
+            IPolicyRegistry::pendingPolicyAdminCall { policyId: policy_id },
+        )
+        .await?;
+    IPolicyRegistry::pendingPolicyAdminCall::abi_decode_returns(out.as_ref())
+        .wrap_err("Failed to decode pendingPolicyAdmin")
+}
+
+async fn read_policy_type(
+    client: &B20PrecompileClient<'_>,
+    policy_id: u64,
+) -> Result<IPolicyRegistry::PolicyType> {
+    let out = client
+        .call(
+            PolicyRegistryStorage::ADDRESS,
+            IPolicyRegistry::policyTypeCall { policyId: policy_id },
+        )
+        .await?;
+    IPolicyRegistry::policyTypeCall::abi_decode_returns(out.as_ref())
+        .wrap_err("Failed to decode policyType")
+}
+
+// --- existing test ---
+
+/// `policyExists(0)` returns `true` once the Beryl fork is active.
 #[tokio::test]
 async fn test_policy_registry_policy_exists() -> Result<()> {
     let (_devnet, provider) = common::start_beryl_devnet().await?;
@@ -18,18 +97,297 @@ async fn test_policy_registry_policy_exists() -> Result<()> {
 
     let client = B20PrecompileClient::new(&provider, &caller, common::L2_CHAIN_ID)
         .with_receipt_timeout(common::TX_RECEIPT_TIMEOUT);
-    client.activate_feature(ActivationFeature::PolicyRegistry.id()).await?;
 
     let output = client
-        .call(
-            PolicyRegistryStorage::ADDRESS,
-            IPolicyRegistry::policyExistsCall { policyId: PolicyRegistryStorage::ALWAYS_ALLOW_ID },
-        )
+        .call(PolicyRegistryStorage::ADDRESS, IPolicyRegistry::policyExistsCall { policyId: 0 })
         .await?;
     let result = IPolicyRegistry::policyExistsCall::abi_decode_returns(output.as_ref())
         .wrap_err("Failed to decode policyExists")?;
 
     assert!(result, "policyExists(0) should return true after Beryl activation");
+
+    Ok(())
+}
+
+// --- new lifecycle tests ---
+
+/// Creates an ALLOWLIST policy, adds a member via `updateAllowlist`, and checks `isAuthorized`.
+///
+/// Verifies that the member is authorized and a non-member is not.
+#[tokio::test]
+async fn test_create_allowlist_policy_and_authorize() -> Result<()> {
+    let (_devnet, provider) = common::start_beryl_devnet().await?;
+    let admin =
+        PrivateKeySigner::from_bytes(&ANVIL_ACCOUNT_5.private_key).wrap_err("admin key")?;
+    let member = ANVIL_ACCOUNT_7.address;
+    let non_member = ANVIL_ACCOUNT_8.address;
+    common::wait_for_balance(&provider, admin.address()).await?;
+
+    let client = B20PrecompileClient::new(&provider, &admin, common::L2_CHAIN_ID)
+        .with_receipt_timeout(common::TX_RECEIPT_TIMEOUT);
+
+    let policy_id =
+        read_next_policy_id(&client, IPolicyRegistry::PolicyType::ALLOWLIST).await?;
+
+    client
+        .send_call(
+            PolicyRegistryStorage::ADDRESS,
+            IPolicyRegistry::createPolicyCall {
+                admin: admin.address(),
+                policyType: IPolicyRegistry::PolicyType::ALLOWLIST,
+            },
+            "createPolicy(ALLOWLIST)",
+        )
+        .await?;
+
+    client
+        .send_call(
+            PolicyRegistryStorage::ADDRESS,
+            IPolicyRegistry::updateAllowlistCall {
+                policyId: policy_id,
+                allowed: true,
+                accounts: vec![member],
+            },
+            "updateAllowlist(add member)",
+        )
+        .await?;
+
+    assert!(
+        read_is_authorized(&client, policy_id, member).await?,
+        "allowlist member should be authorized",
+    );
+    assert!(
+        !read_is_authorized(&client, policy_id, non_member).await?,
+        "non-member should not be authorized on allowlist policy",
+    );
+
+    Ok(())
+}
+
+/// Creates a BLOCKLIST policy, adds a member via `updateBlocklist`, and checks `isAuthorized`.
+///
+/// Verifies that the blocked account is not authorized while an unlisted account is.
+#[tokio::test]
+async fn test_create_blocklist_policy_and_block() -> Result<()> {
+    let (_devnet, provider) = common::start_beryl_devnet().await?;
+    let admin =
+        PrivateKeySigner::from_bytes(&ANVIL_ACCOUNT_5.private_key).wrap_err("admin key")?;
+    let blocked = ANVIL_ACCOUNT_7.address;
+    let non_blocked = ANVIL_ACCOUNT_8.address;
+    common::wait_for_balance(&provider, admin.address()).await?;
+
+    let client = B20PrecompileClient::new(&provider, &admin, common::L2_CHAIN_ID)
+        .with_receipt_timeout(common::TX_RECEIPT_TIMEOUT);
+
+    let policy_id =
+        read_next_policy_id(&client, IPolicyRegistry::PolicyType::BLOCKLIST).await?;
+
+    client
+        .send_call(
+            PolicyRegistryStorage::ADDRESS,
+            IPolicyRegistry::createPolicyCall {
+                admin: admin.address(),
+                policyType: IPolicyRegistry::PolicyType::BLOCKLIST,
+            },
+            "createPolicy(BLOCKLIST)",
+        )
+        .await?;
+
+    client
+        .send_call(
+            PolicyRegistryStorage::ADDRESS,
+            IPolicyRegistry::updateBlocklistCall {
+                policyId: policy_id,
+                blocked: true,
+                accounts: vec![blocked],
+            },
+            "updateBlocklist(add blocked)",
+        )
+        .await?;
+
+    assert!(
+        !read_is_authorized(&client, policy_id, blocked).await?,
+        "blocklisted account should not be authorized",
+    );
+    assert!(
+        read_is_authorized(&client, policy_id, non_blocked).await?,
+        "non-blocked account should be authorized on blocklist policy",
+    );
+
+    Ok(())
+}
+
+/// Exercises the two-step admin transfer: `stageUpdateAdmin` then `finalizeUpdateAdmin`.
+///
+/// Verifies that `policyAdmin` updates to the new admin and the pending slot is cleared.
+#[tokio::test]
+async fn test_two_step_admin_transfer() -> Result<()> {
+    let (_devnet, provider) = common::start_beryl_devnet().await?;
+    let admin =
+        PrivateKeySigner::from_bytes(&ANVIL_ACCOUNT_5.private_key).wrap_err("admin key")?;
+    let new_admin =
+        PrivateKeySigner::from_bytes(&ANVIL_ACCOUNT_6.private_key).wrap_err("new_admin key")?;
+    common::wait_for_balance(&provider, admin.address()).await?;
+    common::wait_for_balance(&provider, new_admin.address()).await?;
+
+    let client_admin = B20PrecompileClient::new(&provider, &admin, common::L2_CHAIN_ID)
+        .with_receipt_timeout(common::TX_RECEIPT_TIMEOUT);
+    let client_new_admin = B20PrecompileClient::new(&provider, &new_admin, common::L2_CHAIN_ID)
+        .with_receipt_timeout(common::TX_RECEIPT_TIMEOUT);
+
+    let policy_id =
+        read_next_policy_id(&client_admin, IPolicyRegistry::PolicyType::ALLOWLIST).await?;
+
+    client_admin
+        .send_call(
+            PolicyRegistryStorage::ADDRESS,
+            IPolicyRegistry::createPolicyCall {
+                admin: admin.address(),
+                policyType: IPolicyRegistry::PolicyType::ALLOWLIST,
+            },
+            "createPolicy(ALLOWLIST)",
+        )
+        .await?;
+
+    assert_eq!(
+        read_policy_admin(&client_admin, policy_id).await?,
+        admin.address(),
+        "policyAdmin should be the creator after createPolicy",
+    );
+
+    client_admin
+        .send_call(
+            PolicyRegistryStorage::ADDRESS,
+            IPolicyRegistry::stageUpdateAdminCall {
+                policyId: policy_id,
+                newAdmin: new_admin.address(),
+            },
+            "stageUpdateAdmin",
+        )
+        .await?;
+
+    assert_eq!(
+        read_pending_policy_admin(&client_admin, policy_id).await?,
+        new_admin.address(),
+        "pendingPolicyAdmin should be set after stageUpdateAdmin",
+    );
+
+    client_new_admin
+        .send_call(
+            PolicyRegistryStorage::ADDRESS,
+            IPolicyRegistry::finalizeUpdateAdminCall { policyId: policy_id },
+            "finalizeUpdateAdmin",
+        )
+        .await?;
+
+    assert_eq!(
+        read_policy_admin(&client_admin, policy_id).await?,
+        new_admin.address(),
+        "policyAdmin should be new_admin after finalizeUpdateAdmin",
+    );
+    assert_eq!(
+        read_pending_policy_admin(&client_admin, policy_id).await?,
+        Address::ZERO,
+        "pendingPolicyAdmin should be cleared after finalizeUpdateAdmin",
+    );
+
+    Ok(())
+}
+
+/// Creates a policy and calls `renounceAdmin`, verifying `policyAdmin` becomes the zero address.
+#[tokio::test]
+async fn test_renounce_admin() -> Result<()> {
+    let (_devnet, provider) = common::start_beryl_devnet().await?;
+    let admin =
+        PrivateKeySigner::from_bytes(&ANVIL_ACCOUNT_5.private_key).wrap_err("admin key")?;
+    common::wait_for_balance(&provider, admin.address()).await?;
+
+    let client = B20PrecompileClient::new(&provider, &admin, common::L2_CHAIN_ID)
+        .with_receipt_timeout(common::TX_RECEIPT_TIMEOUT);
+
+    let policy_id =
+        read_next_policy_id(&client, IPolicyRegistry::PolicyType::ALLOWLIST).await?;
+
+    client
+        .send_call(
+            PolicyRegistryStorage::ADDRESS,
+            IPolicyRegistry::createPolicyCall {
+                admin: admin.address(),
+                policyType: IPolicyRegistry::PolicyType::ALLOWLIST,
+            },
+            "createPolicy(ALLOWLIST)",
+        )
+        .await?;
+
+    client
+        .send_call(
+            PolicyRegistryStorage::ADDRESS,
+            IPolicyRegistry::renounceAdminCall { policyId: policy_id },
+            "renounceAdmin",
+        )
+        .await?;
+
+    assert_eq!(
+        read_policy_admin(&client, policy_id).await?,
+        Address::ZERO,
+        "policyAdmin should be zero address after renounceAdmin",
+    );
+
+    Ok(())
+}
+
+/// Verifies that `nextPolicyId`, `policyType`, `policyAdmin`, and `pendingPolicyAdmin` all return
+/// correct values after policy creation.
+#[tokio::test]
+async fn test_policy_views() -> Result<()> {
+    let (_devnet, provider) = common::start_beryl_devnet().await?;
+    let admin =
+        PrivateKeySigner::from_bytes(&ANVIL_ACCOUNT_5.private_key).wrap_err("admin key")?;
+    common::wait_for_balance(&provider, admin.address()).await?;
+
+    let client = B20PrecompileClient::new(&provider, &admin, common::L2_CHAIN_ID)
+        .with_receipt_timeout(common::TX_RECEIPT_TIMEOUT);
+
+    // Snapshot the predicted policy ID before any creation.
+    let predicted_id =
+        read_next_policy_id(&client, IPolicyRegistry::PolicyType::ALLOWLIST).await?;
+
+    client
+        .send_call(
+            PolicyRegistryStorage::ADDRESS,
+            IPolicyRegistry::createPolicyCall {
+                admin: admin.address(),
+                policyType: IPolicyRegistry::PolicyType::ALLOWLIST,
+            },
+            "createPolicy(ALLOWLIST)",
+        )
+        .await?;
+
+    assert_eq!(
+        read_policy_type(&client, predicted_id).await?,
+        IPolicyRegistry::PolicyType::ALLOWLIST,
+        "policyType should be ALLOWLIST",
+    );
+
+    assert_eq!(
+        read_policy_admin(&client, predicted_id).await?,
+        admin.address(),
+        "policyAdmin should match the admin set at creation",
+    );
+
+    assert_eq!(
+        read_pending_policy_admin(&client, predicted_id).await?,
+        Address::ZERO,
+        "pendingPolicyAdmin should be zero before any staging",
+    );
+
+    // The counter must have advanced so the next ID differs from the one we just created.
+    let next_id_after =
+        read_next_policy_id(&client, IPolicyRegistry::PolicyType::ALLOWLIST).await?;
+    assert_ne!(
+        next_id_after, predicted_id,
+        "nextPolicyId should advance after createPolicy",
+    );
 
     Ok(())
 }

--- a/devnet/tests/policy_registry.rs
+++ b/devnet/tests/policy_registry.rs
@@ -43,10 +43,7 @@ async fn read_is_authorized(
         .wrap_err("Failed to decode isAuthorized")
 }
 
-async fn read_policy_admin(
-    client: &B20PrecompileClient<'_>,
-    policy_id: u64,
-) -> Result<Address> {
+async fn read_policy_admin(client: &B20PrecompileClient<'_>, policy_id: u64) -> Result<Address> {
     let out = client
         .call(
             PolicyRegistryStorage::ADDRESS,
@@ -117,8 +114,7 @@ async fn test_policy_registry_policy_exists() -> Result<()> {
 #[tokio::test]
 async fn test_create_allowlist_policy_and_authorize() -> Result<()> {
     let (_devnet, provider) = common::start_beryl_devnet().await?;
-    let admin =
-        PrivateKeySigner::from_bytes(&ANVIL_ACCOUNT_5.private_key).wrap_err("admin key")?;
+    let admin = PrivateKeySigner::from_bytes(&ANVIL_ACCOUNT_5.private_key).wrap_err("admin key")?;
     let member = ANVIL_ACCOUNT_7.address;
     let non_member = ANVIL_ACCOUNT_8.address;
     common::wait_for_balance(&provider, admin.address()).await?;
@@ -126,8 +122,7 @@ async fn test_create_allowlist_policy_and_authorize() -> Result<()> {
     let client = B20PrecompileClient::new(&provider, &admin, common::L2_CHAIN_ID)
         .with_receipt_timeout(common::TX_RECEIPT_TIMEOUT);
 
-    let policy_id =
-        read_next_policy_id(&client, IPolicyRegistry::PolicyType::ALLOWLIST).await?;
+    let policy_id = read_next_policy_id(&client, IPolicyRegistry::PolicyType::ALLOWLIST).await?;
 
     client
         .send_call(
@@ -170,8 +165,7 @@ async fn test_create_allowlist_policy_and_authorize() -> Result<()> {
 #[tokio::test]
 async fn test_create_blocklist_policy_and_block() -> Result<()> {
     let (_devnet, provider) = common::start_beryl_devnet().await?;
-    let admin =
-        PrivateKeySigner::from_bytes(&ANVIL_ACCOUNT_5.private_key).wrap_err("admin key")?;
+    let admin = PrivateKeySigner::from_bytes(&ANVIL_ACCOUNT_5.private_key).wrap_err("admin key")?;
     let blocked = ANVIL_ACCOUNT_7.address;
     let non_blocked = ANVIL_ACCOUNT_8.address;
     common::wait_for_balance(&provider, admin.address()).await?;
@@ -179,8 +173,7 @@ async fn test_create_blocklist_policy_and_block() -> Result<()> {
     let client = B20PrecompileClient::new(&provider, &admin, common::L2_CHAIN_ID)
         .with_receipt_timeout(common::TX_RECEIPT_TIMEOUT);
 
-    let policy_id =
-        read_next_policy_id(&client, IPolicyRegistry::PolicyType::BLOCKLIST).await?;
+    let policy_id = read_next_policy_id(&client, IPolicyRegistry::PolicyType::BLOCKLIST).await?;
 
     client
         .send_call(
@@ -223,8 +216,7 @@ async fn test_create_blocklist_policy_and_block() -> Result<()> {
 #[tokio::test]
 async fn test_two_step_admin_transfer() -> Result<()> {
     let (_devnet, provider) = common::start_beryl_devnet().await?;
-    let admin =
-        PrivateKeySigner::from_bytes(&ANVIL_ACCOUNT_5.private_key).wrap_err("admin key")?;
+    let admin = PrivateKeySigner::from_bytes(&ANVIL_ACCOUNT_5.private_key).wrap_err("admin key")?;
     let new_admin =
         PrivateKeySigner::from_bytes(&ANVIL_ACCOUNT_6.private_key).wrap_err("new_admin key")?;
     common::wait_for_balance(&provider, admin.address()).await?;
@@ -298,15 +290,13 @@ async fn test_two_step_admin_transfer() -> Result<()> {
 #[tokio::test]
 async fn test_renounce_admin() -> Result<()> {
     let (_devnet, provider) = common::start_beryl_devnet().await?;
-    let admin =
-        PrivateKeySigner::from_bytes(&ANVIL_ACCOUNT_5.private_key).wrap_err("admin key")?;
+    let admin = PrivateKeySigner::from_bytes(&ANVIL_ACCOUNT_5.private_key).wrap_err("admin key")?;
     common::wait_for_balance(&provider, admin.address()).await?;
 
     let client = B20PrecompileClient::new(&provider, &admin, common::L2_CHAIN_ID)
         .with_receipt_timeout(common::TX_RECEIPT_TIMEOUT);
 
-    let policy_id =
-        read_next_policy_id(&client, IPolicyRegistry::PolicyType::ALLOWLIST).await?;
+    let policy_id = read_next_policy_id(&client, IPolicyRegistry::PolicyType::ALLOWLIST).await?;
 
     client
         .send_call(
@@ -341,16 +331,14 @@ async fn test_renounce_admin() -> Result<()> {
 #[tokio::test]
 async fn test_policy_views() -> Result<()> {
     let (_devnet, provider) = common::start_beryl_devnet().await?;
-    let admin =
-        PrivateKeySigner::from_bytes(&ANVIL_ACCOUNT_5.private_key).wrap_err("admin key")?;
+    let admin = PrivateKeySigner::from_bytes(&ANVIL_ACCOUNT_5.private_key).wrap_err("admin key")?;
     common::wait_for_balance(&provider, admin.address()).await?;
 
     let client = B20PrecompileClient::new(&provider, &admin, common::L2_CHAIN_ID)
         .with_receipt_timeout(common::TX_RECEIPT_TIMEOUT);
 
     // Snapshot the predicted policy ID before any creation.
-    let predicted_id =
-        read_next_policy_id(&client, IPolicyRegistry::PolicyType::ALLOWLIST).await?;
+    let predicted_id = read_next_policy_id(&client, IPolicyRegistry::PolicyType::ALLOWLIST).await?;
 
     client
         .send_call(
@@ -384,10 +372,7 @@ async fn test_policy_views() -> Result<()> {
     // The counter must have advanced so the next ID differs from the one we just created.
     let next_id_after =
         read_next_policy_id(&client, IPolicyRegistry::PolicyType::ALLOWLIST).await?;
-    assert_ne!(
-        next_id_after, predicted_id,
-        "nextPolicyId should advance after createPolicy",
-    );
+    assert_ne!(next_id_after, predicted_id, "nextPolicyId should advance after createPolicy",);
 
     Ok(())
 }

--- a/devnet/tests/policy_registry.rs
+++ b/devnet/tests/policy_registry.rs
@@ -85,12 +85,15 @@ async fn test_policy_registry_policy_exists() -> Result<()> {
         .with_receipt_timeout(common::TX_RECEIPT_TIMEOUT);
 
     let output = client
-        .call(PolicyRegistryStorage::ADDRESS, IPolicyRegistry::policyExistsCall { policyId: 0 })
+        .call(
+            PolicyRegistryStorage::ADDRESS,
+            IPolicyRegistry::policyExistsCall { policyId: PolicyRegistryStorage::ALWAYS_ALLOW_ID },
+        )
         .await?;
     let result = IPolicyRegistry::policyExistsCall::abi_decode_returns(output.as_ref())
         .wrap_err("Failed to decode policyExists")?;
 
-    assert!(result, "policyExists(0) should return true after Beryl activation");
+    assert!(result, "policyExists(ALWAYS_ALLOW_ID) should return true after Beryl activation");
 
     Ok(())
 }


### PR DESCRIPTION
[BOP-111](https://linear.app/coinbase/issue/BOP-111)

## Motivation

The dispatch-level tests added in #2808 verify `PolicyRegistry` logic in isolation against an in-memory storage provider. This PR confirms the precompile is correctly wired into a live node and reachable over the standard JSON-RPC interface, covering every callable function surface at the E2E layer.

## What changed

- `devnet/tests/policy_registry.rs`: expanded from the existing `test_policy_registry_policy_exists` smoke test to 13 tests covering the full interface:
  - `test_create_allowlist_policy_and_authorize`: `createPolicy(ALLOWLIST)` + `updateAllowlist(add)`, verifies `isAuthorized` for member and non-member.
  - `test_create_blocklist_policy_and_block`: `createPolicy(BLOCKLIST)` + `updateBlocklist(block)`, verifies blocked account is not authorized while an unlisted account is.
  - `test_create_policy_with_accounts`: `createPolicyWithAccounts` seeds members atomically; verifies pre-seeded accounts are immediately authorized without a separate `updateAllowlist`.
  - `test_update_allowlist_remove_member`: adds then removes a member via `updateAllowlist(allowed=false)`; verifies authorization tracks both transitions.
  - `test_update_blocklist_remove_member`: blocks then unblocks an account via `updateBlocklist(blocked=false)`; verifies authorization is restored after unblock.
  - `test_cancel_staged_admin_transfer`: stages an admin transfer then calls `stageUpdateAdmin(address(0))` to cancel; verifies `pendingPolicyAdmin` clears and `policyAdmin` is unchanged.
  - `test_two_step_admin_transfer`: `stageUpdateAdmin` + `finalizeUpdateAdmin` from the new admin; verifies `policyAdmin` updates and the pending slot is cleared.
  - `test_renounce_admin`: `renounceAdmin` sets `policyAdmin` to the zero address.
  - `test_policy_exists_for_created_policy`: `policyExists` returns false before creation and true after; complements the built-in sentinel check.
  - `test_builtin_always_allow_policy`: `isAuthorized(ALWAYS_ALLOW_ID, ...)` returns true for any account.
  - `test_builtin_always_block_policy`: `isAuthorized(ALWAYS_BLOCK_ID, ...)` returns false for any account.
  - `test_batch_membership_update`: `updateAllowlist` and `updateBlocklist` each receive a three-account batch; verifies all entries are applied atomically.
  - `test_policy_views`: `policyAdmin` and `pendingPolicyAdmin` reflect creation state; policy ID counter advances after `createPolicy`.
- Adds `read_policy_exists` helper alongside the existing `read_is_authorized`, `read_policy_admin`, and `read_pending_policy_admin` helpers.

## What was tried / considered

- Extending the dispatch-level tests was considered, but devnet tests are the right layer for confirming RPC reachability and full node wiring. The dispatch tests cover revert paths and storage layout; the devnet tests verify the happy paths all the way through JSON-RPC.
- `createPolicyWithAccounts`, the `allowed=false` and `blocked=false` mutation paths, the `stageUpdateAdmin(address(0))` cancellation, and the built-in sentinel policies were absent from the original five tests. All are now covered.

## Test plan

- [ ] `cargo test -p devnet --test policy_registry` passes against a running devnet node.
- [ ] All 13 test names appear in the output with `ok`.
- [ ] Existing devnet tests are unaffected.