### PR TITLE
test(devnet): add E2E tests for policy-gated token transfers

### DIFF
--- a/devnet/tests/policy_transfer.rs
+++ b/devnet/tests/policy_transfer.rs
@@ -3,7 +3,7 @@
 //! The policy registry precompile is live on Beryl, but B20 tokens do not yet
 //! expose a `setPolicy` method to wire a named policy to transfer enforcement.
 //! Until that wiring lands, tokens always transfer freely regardless of policy
-//! membership (the ALWAYS_ALLOW built-in is effectively in effect for every
+//! membership (the `ALWAYS_ALLOW` built-in is effectively in effect for every
 //! transfer).
 //!
 //! Each test below:
@@ -22,7 +22,7 @@ use alloy_signer_local::PrivateKeySigner;
 use alloy_sol_types::SolCall;
 use base_common_network::Base;
 use base_common_precompiles::{
-    ActivationRegistryStorage, IB20, IPolicyRegistry, PolicyRegistryStorage, TokenVariant,
+    ActivationFeature, IB20, IPolicyRegistry, PolicyRegistryStorage, TokenVariant,
 };
 use devnet::{
     B20PrecompileClient,
@@ -30,7 +30,6 @@ use devnet::{
 };
 use eyre::{Result, WrapErr};
 
-const TOKEN_DECIMALS: u8 = 6;
 const INITIAL_SUPPLY: u64 = 1_000_000;
 const TRANSFER_AMOUNT: u64 = 100_000;
 
@@ -39,7 +38,7 @@ const SALT_ALLOWLIST: B256 = B256::repeat_byte(0x50);
 const SALT_BLOCKLIST: B256 = B256::repeat_byte(0x51);
 const SALT_ALWAYS_BLOCK: B256 = B256::repeat_byte(0x52);
 
-/// Activates TOKEN_FACTORY, B20_TOKEN, and POLICY_REGISTRY features, then
+/// Activates `TOKEN_FACTORY`, `B20_TOKEN`, and `POLICY_REGISTRY` features, then
 /// returns a [`B20PrecompileClient`] ready for precompile calls.
 async fn activated_client<'a>(
     provider: &'a RootProvider<Base>,
@@ -47,25 +46,36 @@ async fn activated_client<'a>(
 ) -> Result<B20PrecompileClient<'a>> {
     let client = B20PrecompileClient::new(provider, admin, common::L2_CHAIN_ID)
         .with_receipt_timeout(common::TX_RECEIPT_TIMEOUT);
-    client.activate_feature(ActivationRegistryStorage::TOKEN_FACTORY).await?;
-    client.activate_feature(ActivationRegistryStorage::B20_TOKEN).await?;
-    client.activate_feature(ActivationRegistryStorage::POLICY_REGISTRY).await?;
+    client.activate_feature(ActivationFeature::TokenFactory.id()).await?;
+    client.activate_feature(ActivationFeature::B20Token.id()).await?;
+    client.activate_feature(ActivationFeature::PolicyRegistry.id()).await?;
     Ok(client)
 }
 
-/// Reads the next policy ID for `policy_type` from the policy registry.
-async fn next_policy_id(
+/// Creates a policy and returns its assigned ID.
+///
+/// Simulates the call first (`eth_call`) to obtain the ID the registry will
+/// assign, then dispatches the real transaction.  Because the devnet is
+/// single-sender the counter cannot advance between the simulation and the
+/// actual transaction.
+async fn create_policy(
     client: &B20PrecompileClient<'_>,
+    admin: Address,
     policy_type: IPolicyRegistry::PolicyType,
+    label: &'static str,
 ) -> Result<u64> {
-    let output = client
-        .call(
+    let call = IPolicyRegistry::createPolicyCall { admin, policyType: policy_type };
+    let output = client.call(PolicyRegistryStorage::ADDRESS, call).await?;
+    let policy_id = IPolicyRegistry::createPolicyCall::abi_decode_returns(output.as_ref())
+        .wrap_err("Failed to decode createPolicy return")?;
+    client
+        .send_call(
             PolicyRegistryStorage::ADDRESS,
-            IPolicyRegistry::nextPolicyIdCall { policyType: policy_type },
+            IPolicyRegistry::createPolicyCall { admin, policyType: policy_type },
+            label,
         )
         .await?;
-    IPolicyRegistry::nextPolicyIdCall::abi_decode_returns(output.as_ref())
-        .wrap_err("Failed to decode nextPolicyId")
+    Ok(policy_id)
 }
 
 /// Queries `isAuthorized(policy_id, account)` from the policy registry.
@@ -92,14 +102,8 @@ async fn create_token(
     name: &str,
     symbol: &str,
 ) -> Result<Address> {
-    let params = B20PrecompileClient::token_params(
-        name,
-        symbol,
-        TOKEN_DECIMALS,
-        admin,
-        U256::from(INITIAL_SUPPLY),
-        admin,
-    );
+    let params =
+        B20PrecompileClient::token_params(name, symbol, admin, U256::from(INITIAL_SUPPLY), admin);
     let token = client.create_token(TokenVariant::B20, params, salt).await?;
     client
         .wait_for_token_code(token, common::TX_RECEIPT_TIMEOUT, common::BLOCK_POLL_INTERVAL)
@@ -125,8 +129,7 @@ async fn create_token(
 async fn test_allowlist_gates_transfer() -> Result<()> {
     let (_devnet, provider) = common::start_beryl_devnet().await?;
 
-    let admin =
-        PrivateKeySigner::from_bytes(&ANVIL_ACCOUNT_5.private_key).wrap_err("admin key")?;
+    let admin = PrivateKeySigner::from_bytes(&ANVIL_ACCOUNT_5.private_key).wrap_err("admin key")?;
     let non_member =
         PrivateKeySigner::from_bytes(&ANVIL_ACCOUNT_7.private_key).wrap_err("non-member key")?;
     let recipient = ANVIL_ACCOUNT_6.address;
@@ -137,19 +140,13 @@ async fn test_allowlist_gates_transfer() -> Result<()> {
     let client = activated_client(&provider, &admin).await?;
 
     // --- Create ALLOWLIST policy ---
-    let predicted_id =
-        next_policy_id(&client, IPolicyRegistry::PolicyType::ALLOWLIST).await?;
-    client
-        .send_call(
-            PolicyRegistryStorage::ADDRESS,
-            IPolicyRegistry::createPolicyCall {
-                admin: admin.address(),
-                policyType: IPolicyRegistry::PolicyType::ALLOWLIST,
-            },
-            "createPolicy ALLOWLIST",
-        )
-        .await?;
-    let policy_id = predicted_id;
+    let policy_id = create_policy(
+        &client,
+        admin.address(),
+        IPolicyRegistry::PolicyType::ALLOWLIST,
+        "createPolicy ALLOWLIST",
+    )
+    .await?;
 
     // Non-member is not authorized under the allowlist.
     assert!(
@@ -158,15 +155,12 @@ async fn test_allowlist_gates_transfer() -> Result<()> {
     );
 
     // --- Create B20 token ---
-    let token = create_token(&client, admin.address(), SALT_ALLOWLIST, "Allowlist Token", "ALT")
-        .await?;
+    let token =
+        create_token(&client, admin.address(), SALT_ALLOWLIST, "Allowlist Token", "ALT").await?;
 
     // Seed the non-member with tokens so they have a balance to transfer from.
     client.transfer(token, non_member.address(), U256::from(TRANSFER_AMOUNT)).await?;
-    assert_eq!(
-        client.balance_of(token, non_member.address()).await?,
-        U256::from(TRANSFER_AMOUNT),
-    );
+    assert_eq!(client.balance_of(token, non_member.address()).await?, U256::from(TRANSFER_AMOUNT),);
 
     // Transfer from non-member succeeds today because IB20 has no setPolicy.
     // TODO(BOP-125): This should revert once the allowlist is wired to the token.
@@ -226,8 +220,7 @@ async fn test_allowlist_gates_transfer() -> Result<()> {
 async fn test_blocklist_gates_transfer() -> Result<()> {
     let (_devnet, provider) = common::start_beryl_devnet().await?;
 
-    let admin =
-        PrivateKeySigner::from_bytes(&ANVIL_ACCOUNT_5.private_key).wrap_err("admin key")?;
+    let admin = PrivateKeySigner::from_bytes(&ANVIL_ACCOUNT_5.private_key).wrap_err("admin key")?;
     let blocked_sender =
         PrivateKeySigner::from_bytes(&ANVIL_ACCOUNT_7.private_key).wrap_err("blocked key")?;
     let recipient = ANVIL_ACCOUNT_6.address;
@@ -238,19 +231,13 @@ async fn test_blocklist_gates_transfer() -> Result<()> {
     let client = activated_client(&provider, &admin).await?;
 
     // --- Create BLOCKLIST policy ---
-    let predicted_id =
-        next_policy_id(&client, IPolicyRegistry::PolicyType::BLOCKLIST).await?;
-    client
-        .send_call(
-            PolicyRegistryStorage::ADDRESS,
-            IPolicyRegistry::createPolicyCall {
-                admin: admin.address(),
-                policyType: IPolicyRegistry::PolicyType::BLOCKLIST,
-            },
-            "createPolicy BLOCKLIST",
-        )
-        .await?;
-    let policy_id = predicted_id;
+    let policy_id = create_policy(
+        &client,
+        admin.address(),
+        IPolicyRegistry::PolicyType::BLOCKLIST,
+        "createPolicy BLOCKLIST",
+    )
+    .await?;
 
     // The sender is not on the blocklist; they are authorized.
     assert!(
@@ -259,8 +246,8 @@ async fn test_blocklist_gates_transfer() -> Result<()> {
     );
 
     // --- Create B20 token ---
-    let token = create_token(&client, admin.address(), SALT_BLOCKLIST, "Blocklist Token", "BLT")
-        .await?;
+    let token =
+        create_token(&client, admin.address(), SALT_BLOCKLIST, "Blocklist Token", "BLT").await?;
 
     // Seed the sender with tokens.
     client.transfer(token, blocked_sender.address(), U256::from(TRANSFER_AMOUNT)).await?;
@@ -270,9 +257,8 @@ async fn test_blocklist_gates_transfer() -> Result<()> {
     );
 
     // Transfer from the (not-yet-blocked) sender succeeds.
-    let sender_client =
-        B20PrecompileClient::new(&provider, &blocked_sender, common::L2_CHAIN_ID)
-            .with_receipt_timeout(common::TX_RECEIPT_TIMEOUT);
+    let sender_client = B20PrecompileClient::new(&provider, &blocked_sender, common::L2_CHAIN_ID)
+        .with_receipt_timeout(common::TX_RECEIPT_TIMEOUT);
     let first_transfer = sender_client
         .try_send_call(
             token,
@@ -320,23 +306,22 @@ async fn test_blocklist_gates_transfer() -> Result<()> {
 
 /// `test_always_block_policy_blocks_transfer`
 ///
-/// Verifies that the built-in ALWAYS_BLOCK policy (id = 1) denies every
+/// Verifies that the built-in `ALWAYS_BLOCK` policy (id = 1) denies every
 /// account via `isAuthorized`.
 ///
 /// Also demonstrates that B20 transfers currently succeed even when the token
-/// is conceptually under an ALWAYS_BLOCK policy, because `IB20` does not yet
+/// is conceptually under an `ALWAYS_BLOCK` policy, because `IB20` does not yet
 /// expose `setPolicy`.
 ///
 /// TODO(BOP-125): Once `setPolicy` (or an init-call hook) lands on `IB20`,
 /// extend this test to:
-///   1. Wire ALWAYS_BLOCK_ID to the token via `setPolicy`.
+///   1. Wire `ALWAYS_BLOCK_ID` to the token via `setPolicy`.
 ///   2. Assert that ALL transfers from ANY address revert.
 #[tokio::test]
 async fn test_always_block_policy_blocks_transfer() -> Result<()> {
     let (_devnet, provider) = common::start_beryl_devnet().await?;
 
-    let admin =
-        PrivateKeySigner::from_bytes(&ANVIL_ACCOUNT_5.private_key).wrap_err("admin key")?;
+    let admin = PrivateKeySigner::from_bytes(&ANVIL_ACCOUNT_5.private_key).wrap_err("admin key")?;
     let anyone = ANVIL_ACCOUNT_6.address;
 
     common::wait_for_balance(&provider, admin.address()).await?;
@@ -366,8 +351,7 @@ async fn test_always_block_policy_blocks_transfer() -> Result<()> {
 
     // --- Create B20 token ---
     let token =
-        create_token(&client, admin.address(), SALT_ALWAYS_BLOCK, "Blocked Token", "BLKD")
-            .await?;
+        create_token(&client, admin.address(), SALT_ALWAYS_BLOCK, "Blocked Token", "BLKD").await?;
 
     // Transfer from admin succeeds today because IB20 has no setPolicy.
     // TODO(BOP-125): Once setPolicy exists, configure the token with
@@ -379,10 +363,7 @@ async fn test_always_block_policy_blocks_transfer() -> Result<()> {
             "transfer under ALWAYS_BLOCK (no wiring yet)",
         )
         .await?;
-    assert!(
-        transfer_succeeded,
-        "transfer must succeed today (ALWAYS_BLOCK not yet wired to IB20)",
-    );
+    assert!(transfer_succeeded, "transfer must succeed today (ALWAYS_BLOCK not yet wired to IB20)",);
 
     Ok(())
 }

--- a/devnet/tests/policy_transfer.rs
+++ b/devnet/tests/policy_transfer.rs
@@ -1,18 +1,10 @@
 //! End-to-end tests for policy-gated B20 token transfers over Base node RPC.
 //!
-//! The policy registry precompile is live on Beryl, but B20 tokens do not yet
-//! expose a `setPolicy` method to wire a named policy to transfer enforcement.
-//! Until that wiring lands, tokens always transfer freely regardless of policy
-//! membership (the `ALWAYS_ALLOW` built-in is effectively in effect for every
-//! transfer).
-//!
-//! Each test below:
-//!   - Exercises the policy registry over real RPC (create, membership, auth
-//!     queries).
-//!   - Creates a B20 token and demonstrates that transfers succeed regardless
-//!     of the associated policy state.
-//!   - Includes a TODO marking where the full gating assertion belongs once
-//!     `setPolicy` (or an equivalent init-call hook) lands on `IB20`.
+//! Each test:
+//!   - Creates a policy in the policy registry via RPC.
+//!   - Creates a B20 token and wires the policy to its `TRANSFER_SENDER_POLICY`
+//!     slot via `updatePolicy`.
+//!   - Exercises the full transfer-gate cycle: blocked → allowed (or vice versa).
 
 mod common;
 
@@ -22,7 +14,7 @@ use alloy_signer_local::PrivateKeySigner;
 use alloy_sol_types::SolCall;
 use base_common_network::Base;
 use base_common_precompiles::{
-    ActivationFeature, IB20, IPolicyRegistry, PolicyRegistryStorage, TokenVariant,
+    ActivationFeature, B20PolicyType, B20Variant, IB20, IPolicyRegistry, PolicyRegistryStorage,
 };
 use devnet::{
     B20PrecompileClient,
@@ -38,7 +30,7 @@ const SALT_ALLOWLIST: B256 = B256::repeat_byte(0x50);
 const SALT_BLOCKLIST: B256 = B256::repeat_byte(0x51);
 const SALT_ALWAYS_BLOCK: B256 = B256::repeat_byte(0x52);
 
-/// Activates `TOKEN_FACTORY`, `B20_TOKEN`, and `POLICY_REGISTRY` features, then
+/// Activates `B20_FACTORY`, `B20_TOKEN`, and `POLICY_REGISTRY` features, then
 /// returns a [`B20PrecompileClient`] ready for precompile calls.
 async fn activated_client<'a>(
     provider: &'a RootProvider<Base>,
@@ -46,7 +38,7 @@ async fn activated_client<'a>(
 ) -> Result<B20PrecompileClient<'a>> {
     let client = B20PrecompileClient::new(provider, admin, common::L2_CHAIN_ID)
         .with_receipt_timeout(common::TX_RECEIPT_TIMEOUT);
-    client.activate_feature(ActivationFeature::TokenFactory.id()).await?;
+    client.activate_feature(ActivationFeature::B20Factory.id()).await?;
     client.activate_feature(ActivationFeature::B20Token.id()).await?;
     client.activate_feature(ActivationFeature::PolicyRegistry.id()).await?;
     Ok(client)
@@ -104,27 +96,39 @@ async fn create_token(
 ) -> Result<Address> {
     let params =
         B20PrecompileClient::token_params(name, symbol, admin, U256::from(INITIAL_SUPPLY), admin);
-    let token = client.create_token(TokenVariant::B20, params, salt).await?;
+    let token = client.create_token(B20Variant::B20, params, salt).await?;
     client
         .wait_for_token_code(token, common::TX_RECEIPT_TIMEOUT, common::BLOCK_POLL_INTERVAL)
         .await?;
     Ok(token)
 }
 
+/// Wires a policy ID to the token's `TRANSFER_SENDER_POLICY` slot.
+async fn set_transfer_sender_policy(
+    client: &B20PrecompileClient<'_>,
+    token: Address,
+    policy_id: u64,
+) -> Result<()> {
+    client
+        .send_call(
+            token,
+            IB20::updatePolicyCall {
+                policyScope: B20PolicyType::TransferSender.id(),
+                newPolicyId: policy_id,
+            },
+            "updatePolicy TRANSFER_SENDER_POLICY",
+        )
+        .await
+}
+
 /// `test_allowlist_gates_transfer`
 ///
-/// Verifies the ALLOWLIST policy mechanics over RPC:
-///   - A non-member is not authorized.
-///   - After `updateAllowlist`, the member is authorized.
-///
-/// Also demonstrates that B20 transfers currently succeed for any sender
-/// because `IB20` does not yet expose `setPolicy`.
-///
-/// TODO(BOP-125): Once `setPolicy` (or an init-call hook) lands on `IB20`,
-/// extend this test to:
-///   1. Wire the ALLOWLIST policy to the token via `setPolicy`.
-///   2. Assert that a transfer FROM the non-member reverts.
-///   3. Assert that the same transfer succeeds after `updateAllowlist`.
+/// Full cycle:
+///   1. Create an ALLOWLIST policy.
+///   2. Wire it to the token's `TRANSFER_SENDER_POLICY` slot.
+///   3. Assert a non-member transfer reverts.
+///   4. Add the non-member to the allowlist.
+///   5. Assert the transfer now succeeds.
 #[tokio::test]
 async fn test_allowlist_gates_transfer() -> Result<()> {
     let (_devnet, provider) = common::start_beryl_devnet().await?;
@@ -154,26 +158,26 @@ async fn test_allowlist_gates_transfer() -> Result<()> {
         "non-member must not be authorized on a fresh ALLOWLIST policy",
     );
 
-    // --- Create B20 token ---
+    // --- Create B20 token and wire the allowlist policy ---
     let token =
         create_token(&client, admin.address(), SALT_ALLOWLIST, "Allowlist Token", "ALT").await?;
+    set_transfer_sender_policy(&client, token, policy_id).await?;
 
     // Seed the non-member with tokens so they have a balance to transfer from.
     client.transfer(token, non_member.address(), U256::from(TRANSFER_AMOUNT)).await?;
-    assert_eq!(client.balance_of(token, non_member.address()).await?, U256::from(TRANSFER_AMOUNT),);
+    assert_eq!(client.balance_of(token, non_member.address()).await?, U256::from(TRANSFER_AMOUNT));
 
-    // Transfer from non-member succeeds today because IB20 has no setPolicy.
-    // TODO(BOP-125): This should revert once the allowlist is wired to the token.
+    // Non-member is not on the allowlist: transfer must revert.
     let non_member_client = B20PrecompileClient::new(&provider, &non_member, common::L2_CHAIN_ID)
         .with_receipt_timeout(common::TX_RECEIPT_TIMEOUT);
-    let transfer_succeeded = non_member_client
+    let blocked = non_member_client
         .try_send_call(
             token,
             IB20::transferCall { to: recipient, amount: U256::from(TRANSFER_AMOUNT / 2) },
-            "transfer from non-member",
+            "transfer from non-member (should revert)",
         )
         .await?;
-    assert!(transfer_succeeded, "transfer from non-member must succeed (no policy wiring yet)");
+    assert!(!blocked, "transfer from non-member must revert when ALLOWLIST policy is wired");
 
     // --- Add non-member to the allowlist ---
     client
@@ -194,28 +198,27 @@ async fn test_allowlist_gates_transfer() -> Result<()> {
         "non-member must be authorized after being added to the allowlist",
     );
 
-    // TODO(BOP-125): Once setPolicy exists, assert the transfer from the
-    // newly-allowlisted sender succeeds.
+    // Transfer from the now-allowlisted sender must succeed.
+    let allowed = non_member_client
+        .try_send_call(
+            token,
+            IB20::transferCall { to: recipient, amount: U256::from(TRANSFER_AMOUNT / 2) },
+            "transfer from allowlisted sender",
+        )
+        .await?;
+    assert!(allowed, "transfer from allowlisted sender must succeed");
 
     Ok(())
 }
 
 /// `test_blocklist_gates_transfer`
 ///
-/// Verifies the BLOCKLIST policy mechanics over RPC:
-///   - A non-blocked account is authorized.
-///   - After `updateBlocklist`, the blocked account is not authorized.
-///
-/// Also demonstrates that B20 transfers currently succeed for any sender,
-/// including one on the blocklist, because `IB20` does not yet expose
-/// `setPolicy`.
-///
-/// TODO(BOP-125): Once `setPolicy` (or an init-call hook) lands on `IB20`,
-/// extend this test to:
-///   1. Wire the BLOCKLIST policy to the token via `setPolicy`.
-///   2. Assert that a transfer FROM the blocked sender reverts.
-///   3. Assert that the same transfer succeeds after `updateBlocklist` removes
-///      the sender from the blocklist.
+/// Full cycle:
+///   1. Create a BLOCKLIST policy.
+///   2. Wire it to the token's `TRANSFER_SENDER_POLICY` slot.
+///   3. Assert an unblocked sender can transfer.
+///   4. Block the sender.
+///   5. Assert their transfer now reverts.
 #[tokio::test]
 async fn test_blocklist_gates_transfer() -> Result<()> {
     let (_devnet, provider) = common::start_beryl_devnet().await?;
@@ -245,9 +248,10 @@ async fn test_blocklist_gates_transfer() -> Result<()> {
         "non-blocked account must be authorized on a fresh BLOCKLIST policy",
     );
 
-    // --- Create B20 token ---
+    // --- Create B20 token and wire the blocklist policy ---
     let token =
         create_token(&client, admin.address(), SALT_BLOCKLIST, "Blocklist Token", "BLT").await?;
+    set_transfer_sender_policy(&client, token, policy_id).await?;
 
     // Seed the sender with tokens.
     client.transfer(token, blocked_sender.address(), U256::from(TRANSFER_AMOUNT)).await?;
@@ -256,7 +260,7 @@ async fn test_blocklist_gates_transfer() -> Result<()> {
         U256::from(TRANSFER_AMOUNT),
     );
 
-    // Transfer from the (not-yet-blocked) sender succeeds.
+    // Transfer from the (not-yet-blocked) sender must succeed.
     let sender_client = B20PrecompileClient::new(&provider, &blocked_sender, common::L2_CHAIN_ID)
         .with_receipt_timeout(common::TX_RECEIPT_TIMEOUT);
     let first_transfer = sender_client
@@ -287,36 +291,24 @@ async fn test_blocklist_gates_transfer() -> Result<()> {
         "blocked account must not be authorized after being added to the blocklist",
     );
 
-    // Transfer still succeeds today because IB20 has no setPolicy.
-    // TODO(BOP-125): This should revert once the blocklist is wired to the token.
+    // Transfer from the blocked sender must revert.
     let second_transfer = sender_client
         .try_send_call(
             token,
             IB20::transferCall { to: recipient, amount: U256::from(TRANSFER_AMOUNT / 4) },
-            "transfer from blocked sender",
+            "transfer from blocked sender (should revert)",
         )
         .await?;
-    assert!(
-        second_transfer,
-        "transfer from blocked sender must still succeed (no policy wiring yet)",
-    );
+    assert!(!second_transfer, "transfer from blocked sender must revert");
 
     Ok(())
 }
 
 /// `test_always_block_policy_blocks_transfer`
 ///
-/// Verifies that the built-in `ALWAYS_BLOCK` policy (id = 1) denies every
-/// account via `isAuthorized`.
-///
-/// Also demonstrates that B20 transfers currently succeed even when the token
-/// is conceptually under an `ALWAYS_BLOCK` policy, because `IB20` does not yet
-/// expose `setPolicy`.
-///
-/// TODO(BOP-125): Once `setPolicy` (or an init-call hook) lands on `IB20`,
-/// extend this test to:
-///   1. Wire `ALWAYS_BLOCK_ID` to the token via `setPolicy`.
-///   2. Assert that ALL transfers from ANY address revert.
+/// Verifies that the built-in `ALWAYS_BLOCK` policy denies every account via
+/// `isAuthorized`, and that wiring it to a token's `TRANSFER_SENDER_POLICY`
+/// slot makes ALL transfers revert unconditionally.
 #[tokio::test]
 async fn test_always_block_policy_blocks_transfer() -> Result<()> {
     let (_devnet, provider) = common::start_beryl_devnet().await?;
@@ -328,7 +320,7 @@ async fn test_always_block_policy_blocks_transfer() -> Result<()> {
 
     let client = activated_client(&provider, &admin).await?;
 
-    // ALWAYS_BLOCK (id = 1) must deny every account unconditionally.
+    // ALWAYS_BLOCK must deny every account unconditionally.
     assert!(
         !is_authorized(&client, PolicyRegistryStorage::ALWAYS_BLOCK_ID, admin.address()).await?,
         "ALWAYS_BLOCK must deny the admin",
@@ -349,21 +341,20 @@ async fn test_always_block_policy_blocks_transfer() -> Result<()> {
         .wrap_err("Failed to decode policyExists")?;
     assert!(exists, "ALWAYS_BLOCK policy must exist");
 
-    // --- Create B20 token ---
+    // --- Create B20 token and wire ALWAYS_BLOCK to TRANSFER_SENDER_POLICY ---
     let token =
         create_token(&client, admin.address(), SALT_ALWAYS_BLOCK, "Blocked Token", "BLKD").await?;
+    set_transfer_sender_policy(&client, token, PolicyRegistryStorage::ALWAYS_BLOCK_ID).await?;
 
-    // Transfer from admin succeeds today because IB20 has no setPolicy.
-    // TODO(BOP-125): Once setPolicy exists, configure the token with
-    // ALWAYS_BLOCK_ID and assert ALL transfers revert.
-    let transfer_succeeded = client
+    // Transfer from admin must revert: ALWAYS_BLOCK denies every sender unconditionally.
+    let transfer_reverted = client
         .try_send_call(
             token,
             IB20::transferCall { to: anyone, amount: U256::from(TRANSFER_AMOUNT) },
-            "transfer under ALWAYS_BLOCK (no wiring yet)",
+            "transfer under ALWAYS_BLOCK (should revert)",
         )
         .await?;
-    assert!(transfer_succeeded, "transfer must succeed today (ALWAYS_BLOCK not yet wired to IB20)",);
+    assert!(!transfer_reverted, "transfer from admin must revert under ALWAYS_BLOCK policy");
 
     Ok(())
 }

--- a/devnet/tests/policy_transfer.rs
+++ b/devnet/tests/policy_transfer.rs
@@ -57,16 +57,10 @@ async fn create_policy(
     label: &'static str,
 ) -> Result<u64> {
     let call = IPolicyRegistry::createPolicyCall { admin, policyType: policy_type };
-    let output = client.call(PolicyRegistryStorage::ADDRESS, call).await?;
+    let output = client.call(PolicyRegistryStorage::ADDRESS, call.clone()).await?;
     let policy_id = IPolicyRegistry::createPolicyCall::abi_decode_returns(output.as_ref())
         .wrap_err("Failed to decode createPolicy return")?;
-    client
-        .send_call(
-            PolicyRegistryStorage::ADDRESS,
-            IPolicyRegistry::createPolicyCall { admin, policyType: policy_type },
-            label,
-        )
-        .await?;
+    client.send_call(PolicyRegistryStorage::ADDRESS, call, label).await?;
     Ok(policy_id)
 }
 
@@ -347,14 +341,14 @@ async fn test_always_block_policy_blocks_transfer() -> Result<()> {
     set_transfer_sender_policy(&client, token, PolicyRegistryStorage::ALWAYS_BLOCK_ID).await?;
 
     // Transfer from admin must revert: ALWAYS_BLOCK denies every sender unconditionally.
-    let transfer_reverted = client
+    let blocked = client
         .try_send_call(
             token,
             IB20::transferCall { to: anyone, amount: U256::from(TRANSFER_AMOUNT) },
             "transfer under ALWAYS_BLOCK (should revert)",
         )
         .await?;
-    assert!(!transfer_reverted, "transfer from admin must revert under ALWAYS_BLOCK policy");
+    assert!(!blocked, "transfer from admin must revert under ALWAYS_BLOCK policy");
 
     Ok(())
 }

--- a/devnet/tests/policy_transfer.rs
+++ b/devnet/tests/policy_transfer.rs
@@ -1,0 +1,388 @@
+//! End-to-end tests for policy-gated B20 token transfers over Base node RPC.
+//!
+//! The policy registry precompile is live on Beryl, but B20 tokens do not yet
+//! expose a `setPolicy` method to wire a named policy to transfer enforcement.
+//! Until that wiring lands, tokens always transfer freely regardless of policy
+//! membership (the ALWAYS_ALLOW built-in is effectively in effect for every
+//! transfer).
+//!
+//! Each test below:
+//!   - Exercises the policy registry over real RPC (create, membership, auth
+//!     queries).
+//!   - Creates a B20 token and demonstrates that transfers succeed regardless
+//!     of the associated policy state.
+//!   - Includes a TODO marking where the full gating assertion belongs once
+//!     `setPolicy` (or an equivalent init-call hook) lands on `IB20`.
+
+mod common;
+
+use alloy_primitives::{Address, B256, U256};
+use alloy_provider::RootProvider;
+use alloy_signer_local::PrivateKeySigner;
+use alloy_sol_types::SolCall;
+use base_common_network::Base;
+use base_common_precompiles::{
+    ActivationRegistryStorage, IB20, IPolicyRegistry, PolicyRegistryStorage, TokenVariant,
+};
+use devnet::{
+    B20PrecompileClient,
+    config::{ANVIL_ACCOUNT_5, ANVIL_ACCOUNT_6, ANVIL_ACCOUNT_7},
+};
+use eyre::{Result, WrapErr};
+
+const TOKEN_DECIMALS: u8 = 6;
+const INITIAL_SUPPLY: u64 = 1_000_000;
+const TRANSFER_AMOUNT: u64 = 100_000;
+
+// Salts must not overlap with those used in b20_precompile.rs (0x10–0x18, 0x42).
+const SALT_ALLOWLIST: B256 = B256::repeat_byte(0x50);
+const SALT_BLOCKLIST: B256 = B256::repeat_byte(0x51);
+const SALT_ALWAYS_BLOCK: B256 = B256::repeat_byte(0x52);
+
+/// Activates TOKEN_FACTORY, B20_TOKEN, and POLICY_REGISTRY features, then
+/// returns a [`B20PrecompileClient`] ready for precompile calls.
+async fn activated_client<'a>(
+    provider: &'a RootProvider<Base>,
+    admin: &'a PrivateKeySigner,
+) -> Result<B20PrecompileClient<'a>> {
+    let client = B20PrecompileClient::new(provider, admin, common::L2_CHAIN_ID)
+        .with_receipt_timeout(common::TX_RECEIPT_TIMEOUT);
+    client.activate_feature(ActivationRegistryStorage::TOKEN_FACTORY).await?;
+    client.activate_feature(ActivationRegistryStorage::B20_TOKEN).await?;
+    client.activate_feature(ActivationRegistryStorage::POLICY_REGISTRY).await?;
+    Ok(client)
+}
+
+/// Reads the next policy ID for `policy_type` from the policy registry.
+async fn next_policy_id(
+    client: &B20PrecompileClient<'_>,
+    policy_type: IPolicyRegistry::PolicyType,
+) -> Result<u64> {
+    let output = client
+        .call(
+            PolicyRegistryStorage::ADDRESS,
+            IPolicyRegistry::nextPolicyIdCall { policyType: policy_type },
+        )
+        .await?;
+    IPolicyRegistry::nextPolicyIdCall::abi_decode_returns(output.as_ref())
+        .wrap_err("Failed to decode nextPolicyId")
+}
+
+/// Queries `isAuthorized(policy_id, account)` from the policy registry.
+async fn is_authorized(
+    client: &B20PrecompileClient<'_>,
+    policy_id: u64,
+    account: Address,
+) -> Result<bool> {
+    let output = client
+        .call(
+            PolicyRegistryStorage::ADDRESS,
+            IPolicyRegistry::isAuthorizedCall { policyId: policy_id, account },
+        )
+        .await?;
+    IPolicyRegistry::isAuthorizedCall::abi_decode_returns(output.as_ref())
+        .wrap_err("Failed to decode isAuthorized")
+}
+
+/// Creates a B20 token with an initial supply minted to `admin`.
+async fn create_token(
+    client: &B20PrecompileClient<'_>,
+    admin: Address,
+    salt: B256,
+    name: &str,
+    symbol: &str,
+) -> Result<Address> {
+    let params = B20PrecompileClient::token_params(
+        name,
+        symbol,
+        TOKEN_DECIMALS,
+        admin,
+        U256::from(INITIAL_SUPPLY),
+        admin,
+    );
+    let token = client.create_token(TokenVariant::B20, params, salt).await?;
+    client
+        .wait_for_token_code(token, common::TX_RECEIPT_TIMEOUT, common::BLOCK_POLL_INTERVAL)
+        .await?;
+    Ok(token)
+}
+
+/// `test_allowlist_gates_transfer`
+///
+/// Verifies the ALLOWLIST policy mechanics over RPC:
+///   - A non-member is not authorized.
+///   - After `updateAllowlist`, the member is authorized.
+///
+/// Also demonstrates that B20 transfers currently succeed for any sender
+/// because `IB20` does not yet expose `setPolicy`.
+///
+/// TODO(BOP-125): Once `setPolicy` (or an init-call hook) lands on `IB20`,
+/// extend this test to:
+///   1. Wire the ALLOWLIST policy to the token via `setPolicy`.
+///   2. Assert that a transfer FROM the non-member reverts.
+///   3. Assert that the same transfer succeeds after `updateAllowlist`.
+#[tokio::test]
+async fn test_allowlist_gates_transfer() -> Result<()> {
+    let (_devnet, provider) = common::start_beryl_devnet().await?;
+
+    let admin =
+        PrivateKeySigner::from_bytes(&ANVIL_ACCOUNT_5.private_key).wrap_err("admin key")?;
+    let non_member =
+        PrivateKeySigner::from_bytes(&ANVIL_ACCOUNT_7.private_key).wrap_err("non-member key")?;
+    let recipient = ANVIL_ACCOUNT_6.address;
+
+    common::wait_for_balance(&provider, admin.address()).await?;
+    common::wait_for_balance(&provider, non_member.address()).await?;
+
+    let client = activated_client(&provider, &admin).await?;
+
+    // --- Create ALLOWLIST policy ---
+    let predicted_id =
+        next_policy_id(&client, IPolicyRegistry::PolicyType::ALLOWLIST).await?;
+    client
+        .send_call(
+            PolicyRegistryStorage::ADDRESS,
+            IPolicyRegistry::createPolicyCall {
+                admin: admin.address(),
+                policyType: IPolicyRegistry::PolicyType::ALLOWLIST,
+            },
+            "createPolicy ALLOWLIST",
+        )
+        .await?;
+    let policy_id = predicted_id;
+
+    // Non-member is not authorized under the allowlist.
+    assert!(
+        !is_authorized(&client, policy_id, non_member.address()).await?,
+        "non-member must not be authorized on a fresh ALLOWLIST policy",
+    );
+
+    // --- Create B20 token ---
+    let token = create_token(&client, admin.address(), SALT_ALLOWLIST, "Allowlist Token", "ALT")
+        .await?;
+
+    // Seed the non-member with tokens so they have a balance to transfer from.
+    client.transfer(token, non_member.address(), U256::from(TRANSFER_AMOUNT)).await?;
+    assert_eq!(
+        client.balance_of(token, non_member.address()).await?,
+        U256::from(TRANSFER_AMOUNT),
+    );
+
+    // Transfer from non-member succeeds today because IB20 has no setPolicy.
+    // TODO(BOP-125): This should revert once the allowlist is wired to the token.
+    let non_member_client = B20PrecompileClient::new(&provider, &non_member, common::L2_CHAIN_ID)
+        .with_receipt_timeout(common::TX_RECEIPT_TIMEOUT);
+    let transfer_succeeded = non_member_client
+        .try_send_call(
+            token,
+            IB20::transferCall { to: recipient, amount: U256::from(TRANSFER_AMOUNT / 2) },
+            "transfer from non-member",
+        )
+        .await?;
+    assert!(transfer_succeeded, "transfer from non-member must succeed (no policy wiring yet)");
+
+    // --- Add non-member to the allowlist ---
+    client
+        .send_call(
+            PolicyRegistryStorage::ADDRESS,
+            IPolicyRegistry::updateAllowlistCall {
+                policyId: policy_id,
+                allowed: true,
+                accounts: vec![non_member.address()],
+            },
+            "updateAllowlist add non-member",
+        )
+        .await?;
+
+    // Non-member is now authorized.
+    assert!(
+        is_authorized(&client, policy_id, non_member.address()).await?,
+        "non-member must be authorized after being added to the allowlist",
+    );
+
+    // TODO(BOP-125): Once setPolicy exists, assert the transfer from the
+    // newly-allowlisted sender succeeds.
+
+    Ok(())
+}
+
+/// `test_blocklist_gates_transfer`
+///
+/// Verifies the BLOCKLIST policy mechanics over RPC:
+///   - A non-blocked account is authorized.
+///   - After `updateBlocklist`, the blocked account is not authorized.
+///
+/// Also demonstrates that B20 transfers currently succeed for any sender,
+/// including one on the blocklist, because `IB20` does not yet expose
+/// `setPolicy`.
+///
+/// TODO(BOP-125): Once `setPolicy` (or an init-call hook) lands on `IB20`,
+/// extend this test to:
+///   1. Wire the BLOCKLIST policy to the token via `setPolicy`.
+///   2. Assert that a transfer FROM the blocked sender reverts.
+///   3. Assert that the same transfer succeeds after `updateBlocklist` removes
+///      the sender from the blocklist.
+#[tokio::test]
+async fn test_blocklist_gates_transfer() -> Result<()> {
+    let (_devnet, provider) = common::start_beryl_devnet().await?;
+
+    let admin =
+        PrivateKeySigner::from_bytes(&ANVIL_ACCOUNT_5.private_key).wrap_err("admin key")?;
+    let blocked_sender =
+        PrivateKeySigner::from_bytes(&ANVIL_ACCOUNT_7.private_key).wrap_err("blocked key")?;
+    let recipient = ANVIL_ACCOUNT_6.address;
+
+    common::wait_for_balance(&provider, admin.address()).await?;
+    common::wait_for_balance(&provider, blocked_sender.address()).await?;
+
+    let client = activated_client(&provider, &admin).await?;
+
+    // --- Create BLOCKLIST policy ---
+    let predicted_id =
+        next_policy_id(&client, IPolicyRegistry::PolicyType::BLOCKLIST).await?;
+    client
+        .send_call(
+            PolicyRegistryStorage::ADDRESS,
+            IPolicyRegistry::createPolicyCall {
+                admin: admin.address(),
+                policyType: IPolicyRegistry::PolicyType::BLOCKLIST,
+            },
+            "createPolicy BLOCKLIST",
+        )
+        .await?;
+    let policy_id = predicted_id;
+
+    // The sender is not on the blocklist; they are authorized.
+    assert!(
+        is_authorized(&client, policy_id, blocked_sender.address()).await?,
+        "non-blocked account must be authorized on a fresh BLOCKLIST policy",
+    );
+
+    // --- Create B20 token ---
+    let token = create_token(&client, admin.address(), SALT_BLOCKLIST, "Blocklist Token", "BLT")
+        .await?;
+
+    // Seed the sender with tokens.
+    client.transfer(token, blocked_sender.address(), U256::from(TRANSFER_AMOUNT)).await?;
+    assert_eq!(
+        client.balance_of(token, blocked_sender.address()).await?,
+        U256::from(TRANSFER_AMOUNT),
+    );
+
+    // Transfer from the (not-yet-blocked) sender succeeds.
+    let sender_client =
+        B20PrecompileClient::new(&provider, &blocked_sender, common::L2_CHAIN_ID)
+            .with_receipt_timeout(common::TX_RECEIPT_TIMEOUT);
+    let first_transfer = sender_client
+        .try_send_call(
+            token,
+            IB20::transferCall { to: recipient, amount: U256::from(TRANSFER_AMOUNT / 2) },
+            "transfer from non-blocked sender",
+        )
+        .await?;
+    assert!(first_transfer, "transfer from non-blocked sender must succeed");
+
+    // --- Block the sender ---
+    client
+        .send_call(
+            PolicyRegistryStorage::ADDRESS,
+            IPolicyRegistry::updateBlocklistCall {
+                policyId: policy_id,
+                blocked: true,
+                accounts: vec![blocked_sender.address()],
+            },
+            "updateBlocklist add sender",
+        )
+        .await?;
+
+    // Sender is now on the blocklist and must not be authorized.
+    assert!(
+        !is_authorized(&client, policy_id, blocked_sender.address()).await?,
+        "blocked account must not be authorized after being added to the blocklist",
+    );
+
+    // Transfer still succeeds today because IB20 has no setPolicy.
+    // TODO(BOP-125): This should revert once the blocklist is wired to the token.
+    let second_transfer = sender_client
+        .try_send_call(
+            token,
+            IB20::transferCall { to: recipient, amount: U256::from(TRANSFER_AMOUNT / 4) },
+            "transfer from blocked sender",
+        )
+        .await?;
+    assert!(
+        second_transfer,
+        "transfer from blocked sender must still succeed (no policy wiring yet)",
+    );
+
+    Ok(())
+}
+
+/// `test_always_block_policy_blocks_transfer`
+///
+/// Verifies that the built-in ALWAYS_BLOCK policy (id = 1) denies every
+/// account via `isAuthorized`.
+///
+/// Also demonstrates that B20 transfers currently succeed even when the token
+/// is conceptually under an ALWAYS_BLOCK policy, because `IB20` does not yet
+/// expose `setPolicy`.
+///
+/// TODO(BOP-125): Once `setPolicy` (or an init-call hook) lands on `IB20`,
+/// extend this test to:
+///   1. Wire ALWAYS_BLOCK_ID to the token via `setPolicy`.
+///   2. Assert that ALL transfers from ANY address revert.
+#[tokio::test]
+async fn test_always_block_policy_blocks_transfer() -> Result<()> {
+    let (_devnet, provider) = common::start_beryl_devnet().await?;
+
+    let admin =
+        PrivateKeySigner::from_bytes(&ANVIL_ACCOUNT_5.private_key).wrap_err("admin key")?;
+    let anyone = ANVIL_ACCOUNT_6.address;
+
+    common::wait_for_balance(&provider, admin.address()).await?;
+
+    let client = activated_client(&provider, &admin).await?;
+
+    // ALWAYS_BLOCK (id = 1) must deny every account unconditionally.
+    assert!(
+        !is_authorized(&client, PolicyRegistryStorage::ALWAYS_BLOCK_ID, admin.address()).await?,
+        "ALWAYS_BLOCK must deny the admin",
+    );
+    assert!(
+        !is_authorized(&client, PolicyRegistryStorage::ALWAYS_BLOCK_ID, anyone).await?,
+        "ALWAYS_BLOCK must deny any arbitrary account",
+    );
+
+    // The ALWAYS_BLOCK policy exists as a built-in.
+    let output = client
+        .call(
+            PolicyRegistryStorage::ADDRESS,
+            IPolicyRegistry::policyExistsCall { policyId: PolicyRegistryStorage::ALWAYS_BLOCK_ID },
+        )
+        .await?;
+    let exists = IPolicyRegistry::policyExistsCall::abi_decode_returns(output.as_ref())
+        .wrap_err("Failed to decode policyExists")?;
+    assert!(exists, "ALWAYS_BLOCK policy must exist");
+
+    // --- Create B20 token ---
+    let token =
+        create_token(&client, admin.address(), SALT_ALWAYS_BLOCK, "Blocked Token", "BLKD")
+            .await?;
+
+    // Transfer from admin succeeds today because IB20 has no setPolicy.
+    // TODO(BOP-125): Once setPolicy exists, configure the token with
+    // ALWAYS_BLOCK_ID and assert ALL transfers revert.
+    let transfer_succeeded = client
+        .try_send_call(
+            token,
+            IB20::transferCall { to: anyone, amount: U256::from(TRANSFER_AMOUNT) },
+            "transfer under ALWAYS_BLOCK (no wiring yet)",
+        )
+        .await?;
+    assert!(
+        transfer_succeeded,
+        "transfer must succeed today (ALWAYS_BLOCK not yet wired to IB20)",
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
[BOP-125](https://linear.app/coinbase/issue/BOP-125)

## Motivation

BOP-125 asks for full-stack proof that policy enforcement, token creation, and token transfers all work together against a live node. This PR adds the devnet E2E test file that exercises these three layers over real RPC to give that confidence and to pin the integration surface so regressions are caught early.

## What changed

Added `devnet/tests/policy_transfer.rs` with three `#[tokio::test]` integration tests:

- `test_allowlist_gates_transfer`: creates an ALLOWLIST policy, verifies `isAuthorized` returns false for a non-member, adds the member via `updateAllowlist`, verifies authorization flips to true, and shows that B20 transfers succeed at all points today.
- `test_blocklist_gates_transfer`: creates a BLOCKLIST policy, verifies non-blocked accounts are authorized, blocks an account via `updateBlocklist`, verifies authorization flips to false, and shows that transfers still succeed today.
- `test_always_block_policy_blocks_transfer`: asserts the built-in ALWAYS_BLOCK policy (id=1) denies every account unconditionally via `isAuthorized`, verifies it exists as a built-in, and shows that token transfers still succeed today.

Each test activates POLICY_REGISTRY alongside TOKEN_FACTORY and B20_TOKEN, exercises the full policy lifecycle over real RPC, and includes `TODO(BOP-125)` markers where the revert assertions belong once `setPolicy` lands.

## What was tried / considered

**Full gating assertions:** The original spec called for the round-trip where a non-authorized sender attempts a transfer and it reverts. Investigation of `IB20` and the `Transferable` trait shows that `transfer()` never calls `policy.is_authorized()`, and there is no `setPolicy` entry point on the token interface. The `Policy` field exists in `B20Token` but is not wired into any capability trait default implementation. The full gating assertions are stubbed as TODOs.

**Placement in existing file vs. new file:** The tests could have been appended to `b20_precompile.rs`, but a separate file keeps the policy-specific surface focused and easier to locate. Salt values (0x50-0x52) are chosen to avoid collision with salts already used across the existing test suite.