### PR TITLE
test(policy): action tests for policy-gated B20 transfers (BOP-110, BOP-129)

### DIFF
--- a/actions/harness/tests/beryl/b20_policy.rs
+++ b/actions/harness/tests/beryl/b20_policy.rs
@@ -14,10 +14,8 @@ use crate::env::BerylTestEnv;
 /// Transfer amount used in setup (seeding bob with tokens).
 const SEED_AMOUNT: U256 = U256::from_limbs([100_000, 0, 0, 0]);
 
-/// First custom policy has counter=2 (IDs 0 and 1 are reserved built-ins).
-const fn policy_id(policy_type: IPolicyRegistry::PolicyType, counter: u64) -> u64 {
-    (policy_type as u64) << 56 | counter
-}
+/// Amount transferred in each policy-gated transfer assertion.
+const TRANSFER_AMOUNT: U256 = U256::from_limbs([1, 0, 0, 0]);
 
 /// ALLOWLIST policy wired to TransferSender blocks non-members from sending.
 ///
@@ -34,8 +32,10 @@ async fn b20_allowlist_sender_policy_blocks_non_members() {
         scenario.token_tx(IB20::transferCall { to: BerylTestEnv::bob(), amount: SEED_AMOUNT });
     let block = scenario.build_block(vec![seed_bob]).await;
     assert!(scenario.env.user_tx_succeeded(&block, 0), "seeding bob must succeed");
+    scenario.assert_balance(BerylTestEnv::alice(), BerylTestEnv::B20_INITIAL_SUPPLY - 100_000);
+    scenario.assert_balance(BerylTestEnv::bob(), 100_000);
 
-    let allowlist_id = policy_id(IPolicyRegistry::PolicyType::ALLOWLIST, 2);
+    let allowlist_id = BerylTestEnv::policy_id(IPolicyRegistry::PolicyType::ALLOWLIST, 2);
     let create_policy = scenario.policy_tx(IPolicyRegistry::createPolicyCall {
         admin: BerylTestEnv::alice(),
         policyType: IPolicyRegistry::PolicyType::ALLOWLIST,
@@ -51,12 +51,14 @@ async fn b20_allowlist_sender_policy_blocks_non_members() {
     assert!(scenario.env.user_tx_succeeded(&block, 0), "updatePolicy must succeed");
 
     let blocked = scenario
-        .bob_token_tx(IB20::transferCall { to: BerylTestEnv::carol(), amount: U256::from(1u64) });
+        .bob_token_tx(IB20::transferCall { to: BerylTestEnv::carol(), amount: TRANSFER_AMOUNT });
     let block = scenario.build_block(vec![blocked]).await;
     assert!(
         !scenario.env.user_tx_succeeded(&block, 0),
         "transfer from non-member must revert when ALLOWLIST sender policy is set"
     );
+    scenario.assert_balance(BerylTestEnv::bob(), 100_000);
+    scenario.assert_balance(BerylTestEnv::carol(), 0);
 
     let add_bob = scenario.policy_tx(IPolicyRegistry::updateAllowlistCall {
         policyId: allowlist_id,
@@ -67,12 +69,14 @@ async fn b20_allowlist_sender_policy_blocks_non_members() {
     assert!(scenario.env.user_tx_succeeded(&block, 0), "updateAllowlist must succeed");
 
     let allowed = scenario
-        .bob_token_tx(IB20::transferCall { to: BerylTestEnv::carol(), amount: U256::from(1u64) });
+        .bob_token_tx(IB20::transferCall { to: BerylTestEnv::carol(), amount: TRANSFER_AMOUNT });
     let block = scenario.build_block(vec![allowed]).await;
     assert!(
         scenario.env.user_tx_succeeded(&block, 0),
         "transfer from allowlisted member must succeed"
     );
+    scenario.assert_balance(BerylTestEnv::bob(), 99_999);
+    scenario.assert_balance(BerylTestEnv::carol(), 1);
 
     scenario.derive().await;
 }
@@ -92,8 +96,10 @@ async fn b20_blocklist_sender_policy_blocks_listed_accounts() {
         scenario.token_tx(IB20::transferCall { to: BerylTestEnv::bob(), amount: SEED_AMOUNT });
     let block = scenario.build_block(vec![seed_bob]).await;
     assert!(scenario.env.user_tx_succeeded(&block, 0), "seeding bob must succeed");
+    scenario.assert_balance(BerylTestEnv::alice(), BerylTestEnv::B20_INITIAL_SUPPLY - 100_000);
+    scenario.assert_balance(BerylTestEnv::bob(), 100_000);
 
-    let blocklist_id = policy_id(IPolicyRegistry::PolicyType::BLOCKLIST, 2);
+    let blocklist_id = BerylTestEnv::policy_id(IPolicyRegistry::PolicyType::BLOCKLIST, 2);
     let create_policy = scenario.policy_tx(IPolicyRegistry::createPolicyCall {
         admin: BerylTestEnv::alice(),
         policyType: IPolicyRegistry::PolicyType::BLOCKLIST,
@@ -109,12 +115,14 @@ async fn b20_blocklist_sender_policy_blocks_listed_accounts() {
     assert!(scenario.env.user_tx_succeeded(&block, 0), "updatePolicy must succeed");
 
     let first_transfer = scenario
-        .bob_token_tx(IB20::transferCall { to: BerylTestEnv::carol(), amount: U256::from(1u64) });
+        .bob_token_tx(IB20::transferCall { to: BerylTestEnv::carol(), amount: TRANSFER_AMOUNT });
     let block = scenario.build_block(vec![first_transfer]).await;
     assert!(
         scenario.env.user_tx_succeeded(&block, 0),
         "transfer from non-blocked account must succeed"
     );
+    scenario.assert_balance(BerylTestEnv::bob(), 99_999);
+    scenario.assert_balance(BerylTestEnv::carol(), 1);
 
     let block_bob = scenario.policy_tx(IPolicyRegistry::updateBlocklistCall {
         policyId: blocklist_id,
@@ -125,12 +133,14 @@ async fn b20_blocklist_sender_policy_blocks_listed_accounts() {
     assert!(scenario.env.user_tx_succeeded(&block, 0), "updateBlocklist must succeed");
 
     let blocked = scenario
-        .bob_token_tx(IB20::transferCall { to: BerylTestEnv::carol(), amount: U256::from(1u64) });
+        .bob_token_tx(IB20::transferCall { to: BerylTestEnv::carol(), amount: TRANSFER_AMOUNT });
     let block = scenario.build_block(vec![blocked]).await;
     assert!(
         !scenario.env.user_tx_succeeded(&block, 0),
         "transfer from blocked account must revert"
     );
+    scenario.assert_balance(BerylTestEnv::bob(), 99_999);
+    scenario.assert_balance(BerylTestEnv::carol(), 1);
 
     scenario.derive().await;
 }
@@ -150,12 +160,14 @@ async fn b20_always_block_sender_policy_blocks_all_transfers() {
     assert!(scenario.env.user_tx_succeeded(&block, 0), "updatePolicy must succeed");
 
     let blocked =
-        scenario.token_tx(IB20::transferCall { to: BerylTestEnv::bob(), amount: U256::from(1u64) });
+        scenario.token_tx(IB20::transferCall { to: BerylTestEnv::bob(), amount: TRANSFER_AMOUNT });
     let block = scenario.build_block(vec![blocked]).await;
     assert!(
         !scenario.env.user_tx_succeeded(&block, 0),
         "transfer must revert when ALWAYS_BLOCK sender policy is set"
     );
+    scenario.assert_balance(BerylTestEnv::alice(), BerylTestEnv::B20_INITIAL_SUPPLY);
+    scenario.assert_balance(BerylTestEnv::bob(), 0);
 
     scenario.derive().await;
 }
@@ -165,7 +177,7 @@ async fn b20_always_block_sender_policy_blocks_all_transfers() {
 async fn b20_allowlist_receiver_policy_blocks_non_members() {
     let mut scenario = B20PolicyScenario::new().await;
 
-    let allowlist_id = policy_id(IPolicyRegistry::PolicyType::ALLOWLIST, 2);
+    let allowlist_id = BerylTestEnv::policy_id(IPolicyRegistry::PolicyType::ALLOWLIST, 2);
     let create_policy = scenario.policy_tx(IPolicyRegistry::createPolicyCall {
         admin: BerylTestEnv::alice(),
         policyType: IPolicyRegistry::PolicyType::ALLOWLIST,
@@ -181,12 +193,14 @@ async fn b20_allowlist_receiver_policy_blocks_non_members() {
     assert!(scenario.env.user_tx_succeeded(&block, 0), "updatePolicy must succeed");
 
     let blocked =
-        scenario.token_tx(IB20::transferCall { to: BerylTestEnv::bob(), amount: U256::from(1u64) });
+        scenario.token_tx(IB20::transferCall { to: BerylTestEnv::bob(), amount: TRANSFER_AMOUNT });
     let block = scenario.build_block(vec![blocked]).await;
     assert!(
         !scenario.env.user_tx_succeeded(&block, 0),
         "transfer to non-member must revert when ALLOWLIST receiver policy is set"
     );
+    scenario.assert_balance(BerylTestEnv::alice(), BerylTestEnv::B20_INITIAL_SUPPLY);
+    scenario.assert_balance(BerylTestEnv::bob(), 0);
 
     let add_bob = scenario.policy_tx(IPolicyRegistry::updateAllowlistCall {
         policyId: allowlist_id,
@@ -197,12 +211,14 @@ async fn b20_allowlist_receiver_policy_blocks_non_members() {
     assert!(scenario.env.user_tx_succeeded(&block, 0), "updateAllowlist must succeed");
 
     let allowed =
-        scenario.token_tx(IB20::transferCall { to: BerylTestEnv::bob(), amount: U256::from(1u64) });
+        scenario.token_tx(IB20::transferCall { to: BerylTestEnv::bob(), amount: TRANSFER_AMOUNT });
     let block = scenario.build_block(vec![allowed]).await;
     assert!(
         scenario.env.user_tx_succeeded(&block, 0),
         "transfer to allowlisted receiver must succeed"
     );
+    scenario.assert_balance(BerylTestEnv::alice(), BerylTestEnv::B20_INITIAL_SUPPLY - 1);
+    scenario.assert_balance(BerylTestEnv::bob(), 1);
 
     scenario.derive().await;
 }
@@ -268,6 +284,14 @@ impl B20PolicyScenario {
             Bytes::from(call.abi_encode()),
             BerylTestEnv::B20_GAS_LIMIT,
         )
+    }
+
+    fn assert_balance(&self, account: Address, expected: u64) {
+        assert_eq!(
+            self.env.b20_balance(self.token, account),
+            U256::from(expected),
+            "B-20 balance for {account} must match expected value"
+        );
     }
 
     async fn derive(mut self) {

--- a/actions/harness/tests/beryl/b20_policy.rs
+++ b/actions/harness/tests/beryl/b20_policy.rs
@@ -1,0 +1,277 @@
+//! Action tests proving that B20 token transfers are gated by the policy registry.
+//!
+//! Each test activates TOKEN_FACTORY, B20_TOKEN, and POLICY_REGISTRY together,
+//! creates a token, wires a policy via `updatePolicy`, and asserts that transfers
+//! revert or succeed based on policy membership.
+
+use alloy_primitives::{Address, Bytes, TxKind, U256};
+use alloy_sol_types::SolCall;
+use base_common_consensus::{BaseBlock, BaseTxEnvelope};
+use base_common_precompiles::{B20PolicyType, IB20, IPolicyRegistry, PolicyRegistryStorage};
+
+use crate::env::BerylTestEnv;
+
+/// Transfer amount used in setup (seeding bob with tokens).
+const SEED_AMOUNT: U256 = U256::from_limbs([100_000, 0, 0, 0]);
+
+/// First custom policy has counter=2 (IDs 0 and 1 are reserved built-ins).
+const fn policy_id(policy_type: IPolicyRegistry::PolicyType, counter: u64) -> u64 {
+    (policy_type as u64) << 56 | counter
+}
+
+/// ALLOWLIST policy wired to TransferSender blocks non-members from sending.
+///
+/// 1. Alice seeds bob with tokens (default ALWAYS_ALLOW policy, succeeds).
+/// 2. Create ALLOWLIST policy; wire it to TransferSender.
+/// 3. Bob tries to transfer; reverts (not in allowlist).
+/// 4. Admin adds bob to the allowlist.
+/// 5. Bob transfers again; succeeds.
+#[tokio::test]
+async fn b20_allowlist_sender_policy_blocks_non_members() {
+    let mut scenario = B20PolicyScenario::new().await;
+
+    let seed_bob =
+        scenario.token_tx(IB20::transferCall { to: BerylTestEnv::bob(), amount: SEED_AMOUNT });
+    let block = scenario.build_block(vec![seed_bob]).await;
+    assert!(scenario.env.user_tx_succeeded(&block, 0), "seeding bob must succeed");
+
+    let allowlist_id = policy_id(IPolicyRegistry::PolicyType::ALLOWLIST, 2);
+    let create_policy = scenario.policy_tx(IPolicyRegistry::createPolicyCall {
+        admin: BerylTestEnv::alice(),
+        policyType: IPolicyRegistry::PolicyType::ALLOWLIST,
+    });
+    let block = scenario.build_block(vec![create_policy]).await;
+    assert!(scenario.env.user_tx_succeeded(&block, 0), "createPolicy(ALLOWLIST) must succeed");
+
+    let wire = scenario.token_tx(IB20::updatePolicyCall {
+        policyType: B20PolicyType::TransferSender.id(),
+        newPolicyId: allowlist_id,
+    });
+    let block = scenario.build_block(vec![wire]).await;
+    assert!(scenario.env.user_tx_succeeded(&block, 0), "updatePolicy must succeed");
+
+    let blocked = scenario
+        .bob_token_tx(IB20::transferCall { to: BerylTestEnv::carol(), amount: U256::from(1u64) });
+    let block = scenario.build_block(vec![blocked]).await;
+    assert!(
+        !scenario.env.user_tx_succeeded(&block, 0),
+        "transfer from non-member must revert when ALLOWLIST sender policy is set"
+    );
+
+    let add_bob = scenario.policy_tx(IPolicyRegistry::updateAllowlistCall {
+        policyId: allowlist_id,
+        allowed: true,
+        accounts: vec![BerylTestEnv::bob()],
+    });
+    let block = scenario.build_block(vec![add_bob]).await;
+    assert!(scenario.env.user_tx_succeeded(&block, 0), "updateAllowlist must succeed");
+
+    let allowed = scenario
+        .bob_token_tx(IB20::transferCall { to: BerylTestEnv::carol(), amount: U256::from(1u64) });
+    let block = scenario.build_block(vec![allowed]).await;
+    assert!(
+        scenario.env.user_tx_succeeded(&block, 0),
+        "transfer from allowlisted member must succeed"
+    );
+
+    scenario.derive().await;
+}
+
+/// BLOCKLIST policy wired to TransferSender blocks listed accounts from sending.
+///
+/// 1. Alice seeds bob with tokens (default ALWAYS_ALLOW policy, succeeds).
+/// 2. Create BLOCKLIST policy; wire it to TransferSender.
+/// 3. Bob transfers; succeeds (not in blocklist).
+/// 4. Admin adds bob to the blocklist.
+/// 5. Bob tries to transfer; reverts.
+#[tokio::test]
+async fn b20_blocklist_sender_policy_blocks_listed_accounts() {
+    let mut scenario = B20PolicyScenario::new().await;
+
+    let seed_bob =
+        scenario.token_tx(IB20::transferCall { to: BerylTestEnv::bob(), amount: SEED_AMOUNT });
+    let block = scenario.build_block(vec![seed_bob]).await;
+    assert!(scenario.env.user_tx_succeeded(&block, 0), "seeding bob must succeed");
+
+    let blocklist_id = policy_id(IPolicyRegistry::PolicyType::BLOCKLIST, 2);
+    let create_policy = scenario.policy_tx(IPolicyRegistry::createPolicyCall {
+        admin: BerylTestEnv::alice(),
+        policyType: IPolicyRegistry::PolicyType::BLOCKLIST,
+    });
+    let block = scenario.build_block(vec![create_policy]).await;
+    assert!(scenario.env.user_tx_succeeded(&block, 0), "createPolicy(BLOCKLIST) must succeed");
+
+    let wire = scenario.token_tx(IB20::updatePolicyCall {
+        policyType: B20PolicyType::TransferSender.id(),
+        newPolicyId: blocklist_id,
+    });
+    let block = scenario.build_block(vec![wire]).await;
+    assert!(scenario.env.user_tx_succeeded(&block, 0), "updatePolicy must succeed");
+
+    let first_transfer = scenario
+        .bob_token_tx(IB20::transferCall { to: BerylTestEnv::carol(), amount: U256::from(1u64) });
+    let block = scenario.build_block(vec![first_transfer]).await;
+    assert!(
+        scenario.env.user_tx_succeeded(&block, 0),
+        "transfer from non-blocked account must succeed"
+    );
+
+    let block_bob = scenario.policy_tx(IPolicyRegistry::updateBlocklistCall {
+        policyId: blocklist_id,
+        blocked: true,
+        accounts: vec![BerylTestEnv::bob()],
+    });
+    let block = scenario.build_block(vec![block_bob]).await;
+    assert!(scenario.env.user_tx_succeeded(&block, 0), "updateBlocklist must succeed");
+
+    let blocked = scenario
+        .bob_token_tx(IB20::transferCall { to: BerylTestEnv::carol(), amount: U256::from(1u64) });
+    let block = scenario.build_block(vec![blocked]).await;
+    assert!(
+        !scenario.env.user_tx_succeeded(&block, 0),
+        "transfer from blocked account must revert"
+    );
+
+    scenario.derive().await;
+}
+
+/// Wiring the built-in ALWAYS_BLOCK policy to TransferSender blocks every sender immediately.
+///
+/// No allowlist entries are needed: ALWAYS_BLOCK_ID denies all accounts unconditionally.
+#[tokio::test]
+async fn b20_always_block_sender_policy_blocks_all_transfers() {
+    let mut scenario = B20PolicyScenario::new().await;
+
+    let wire = scenario.token_tx(IB20::updatePolicyCall {
+        policyType: B20PolicyType::TransferSender.id(),
+        newPolicyId: PolicyRegistryStorage::ALWAYS_BLOCK_ID,
+    });
+    let block = scenario.build_block(vec![wire]).await;
+    assert!(scenario.env.user_tx_succeeded(&block, 0), "updatePolicy must succeed");
+
+    let blocked =
+        scenario.token_tx(IB20::transferCall { to: BerylTestEnv::bob(), amount: U256::from(1u64) });
+    let block = scenario.build_block(vec![blocked]).await;
+    assert!(
+        !scenario.env.user_tx_succeeded(&block, 0),
+        "transfer must revert when ALWAYS_BLOCK sender policy is set"
+    );
+
+    scenario.derive().await;
+}
+
+/// ALLOWLIST policy wired to TransferReceiver blocks non-members from receiving.
+#[tokio::test]
+async fn b20_allowlist_receiver_policy_blocks_non_members() {
+    let mut scenario = B20PolicyScenario::new().await;
+
+    let allowlist_id = policy_id(IPolicyRegistry::PolicyType::ALLOWLIST, 2);
+    let create_policy = scenario.policy_tx(IPolicyRegistry::createPolicyCall {
+        admin: BerylTestEnv::alice(),
+        policyType: IPolicyRegistry::PolicyType::ALLOWLIST,
+    });
+    let block = scenario.build_block(vec![create_policy]).await;
+    assert!(scenario.env.user_tx_succeeded(&block, 0), "createPolicy(ALLOWLIST) must succeed");
+
+    let wire = scenario.token_tx(IB20::updatePolicyCall {
+        policyType: B20PolicyType::TransferReceiver.id(),
+        newPolicyId: allowlist_id,
+    });
+    let block = scenario.build_block(vec![wire]).await;
+    assert!(scenario.env.user_tx_succeeded(&block, 0), "updatePolicy must succeed");
+
+    let blocked =
+        scenario.token_tx(IB20::transferCall { to: BerylTestEnv::bob(), amount: U256::from(1u64) });
+    let block = scenario.build_block(vec![blocked]).await;
+    assert!(
+        !scenario.env.user_tx_succeeded(&block, 0),
+        "transfer to non-member must revert when ALLOWLIST receiver policy is set"
+    );
+
+    let add_bob = scenario.policy_tx(IPolicyRegistry::updateAllowlistCall {
+        policyId: allowlist_id,
+        allowed: true,
+        accounts: vec![BerylTestEnv::bob()],
+    });
+    let block = scenario.build_block(vec![add_bob]).await;
+    assert!(scenario.env.user_tx_succeeded(&block, 0), "updateAllowlist must succeed");
+
+    let allowed =
+        scenario.token_tx(IB20::transferCall { to: BerylTestEnv::bob(), amount: U256::from(1u64) });
+    let block = scenario.build_block(vec![allowed]).await;
+    assert!(
+        scenario.env.user_tx_succeeded(&block, 0),
+        "transfer to allowlisted receiver must succeed"
+    );
+
+    scenario.derive().await;
+}
+
+struct B20PolicyScenario {
+    env: BerylTestEnv,
+    token: Address,
+    blocks: Vec<(BaseBlock, u64)>,
+}
+
+impl B20PolicyScenario {
+    async fn new() -> Self {
+        let env = BerylTestEnv::new();
+        let token = env.b20_token_address();
+        let mut scenario = Self { env, token, blocks: Vec::new() };
+
+        scenario.build_block(vec![]).await;
+
+        let act_factory = scenario.env.activate_feature_tx(BerylTestEnv::token_factory_feature());
+        let act_b20 = scenario.env.activate_feature_tx(BerylTestEnv::b20_token_feature());
+        let act_policy = scenario.env.activate_feature_tx(BerylTestEnv::policy_registry_feature());
+        let block = scenario.build_block(vec![act_factory, act_b20, act_policy]).await;
+        assert!(scenario.env.user_tx_succeeded(&block, 0), "TOKEN_FACTORY activation must succeed");
+        assert!(scenario.env.user_tx_succeeded(&block, 1), "B20_TOKEN activation must succeed");
+        assert!(
+            scenario.env.user_tx_succeeded(&block, 2),
+            "POLICY_REGISTRY activation must succeed"
+        );
+
+        let create = scenario.env.create_b20_token_tx();
+        let block = scenario.build_block(vec![create]).await;
+        assert!(scenario.env.user_tx_succeeded(&block, 0), "B20 token creation must succeed");
+
+        scenario
+    }
+
+    async fn build_block(&mut self, txs: Vec<BaseTxEnvelope>) -> BaseBlock {
+        let block = self.env.sequencer.build_next_block_with_transactions(txs).await;
+        let block_number = self.blocks.len() as u64 + 1;
+        self.blocks.push((block.clone(), block_number));
+        block
+    }
+
+    fn token_tx(&self, call: impl SolCall) -> BaseTxEnvelope {
+        self.env.create_tx(
+            TxKind::Call(self.token),
+            Bytes::from(call.abi_encode()),
+            BerylTestEnv::B20_GAS_LIMIT,
+        )
+    }
+
+    fn bob_token_tx(&mut self, call: impl SolCall) -> BaseTxEnvelope {
+        self.env.create_bob_tx(
+            TxKind::Call(self.token),
+            Bytes::from(call.abi_encode()),
+            BerylTestEnv::B20_GAS_LIMIT,
+        )
+    }
+
+    fn policy_tx(&self, call: impl SolCall) -> BaseTxEnvelope {
+        self.env.create_tx(
+            TxKind::Call(PolicyRegistryStorage::ADDRESS),
+            Bytes::from(call.abi_encode()),
+            BerylTestEnv::B20_GAS_LIMIT,
+        )
+    }
+
+    async fn derive(mut self) {
+        let expected_safe_head = self.blocks.len() as u64;
+        self.env.derive_blocks(self.blocks, expected_safe_head).await;
+    }
+}

--- a/actions/harness/tests/beryl/b20_policy.rs
+++ b/actions/harness/tests/beryl/b20_policy.rs
@@ -44,7 +44,7 @@ async fn b20_allowlist_sender_policy_blocks_non_members() {
     assert!(scenario.env.user_tx_succeeded(&block, 0), "createPolicy(ALLOWLIST) must succeed");
 
     let wire = scenario.token_tx(IB20::updatePolicyCall {
-        policyType: B20PolicyType::TransferSender.id(),
+        policyScope: B20PolicyType::TransferSender.id(),
         newPolicyId: allowlist_id,
     });
     let block = scenario.build_block(vec![wire]).await;
@@ -102,7 +102,7 @@ async fn b20_blocklist_sender_policy_blocks_listed_accounts() {
     assert!(scenario.env.user_tx_succeeded(&block, 0), "createPolicy(BLOCKLIST) must succeed");
 
     let wire = scenario.token_tx(IB20::updatePolicyCall {
-        policyType: B20PolicyType::TransferSender.id(),
+        policyScope: B20PolicyType::TransferSender.id(),
         newPolicyId: blocklist_id,
     });
     let block = scenario.build_block(vec![wire]).await;
@@ -143,7 +143,7 @@ async fn b20_always_block_sender_policy_blocks_all_transfers() {
     let mut scenario = B20PolicyScenario::new().await;
 
     let wire = scenario.token_tx(IB20::updatePolicyCall {
-        policyType: B20PolicyType::TransferSender.id(),
+        policyScope: B20PolicyType::TransferSender.id(),
         newPolicyId: PolicyRegistryStorage::ALWAYS_BLOCK_ID,
     });
     let block = scenario.build_block(vec![wire]).await;
@@ -174,7 +174,7 @@ async fn b20_allowlist_receiver_policy_blocks_non_members() {
     assert!(scenario.env.user_tx_succeeded(&block, 0), "createPolicy(ALLOWLIST) must succeed");
 
     let wire = scenario.token_tx(IB20::updatePolicyCall {
-        policyType: B20PolicyType::TransferReceiver.id(),
+        policyScope: B20PolicyType::TransferReceiver.id(),
         newPolicyId: allowlist_id,
     });
     let block = scenario.build_block(vec![wire]).await;

--- a/actions/harness/tests/beryl/b20_policy.rs
+++ b/actions/harness/tests/beryl/b20_policy.rs
@@ -221,7 +221,7 @@ impl B20PolicyScenario {
 
         scenario.build_block(vec![]).await;
 
-        let act_factory = scenario.env.activate_feature_tx(BerylTestEnv::token_factory_feature());
+        let act_factory = scenario.env.activate_feature_tx(BerylTestEnv::b20_factory_feature());
         let act_b20 = scenario.env.activate_feature_tx(BerylTestEnv::b20_token_feature());
         let act_policy = scenario.env.activate_feature_tx(BerylTestEnv::policy_registry_feature());
         let block = scenario.build_block(vec![act_factory, act_b20, act_policy]).await;

--- a/actions/harness/tests/beryl/b20_policy.rs
+++ b/actions/harness/tests/beryl/b20_policy.rs
@@ -1,6 +1,6 @@
 //! Action tests proving that B20 token transfers are gated by the policy registry.
 //!
-//! Each test activates TOKEN_FACTORY, B20_TOKEN, and POLICY_REGISTRY together,
+//! Each test activates `TOKEN_FACTORY`, `B20_TOKEN`, and `POLICY_REGISTRY` together,
 //! creates a token, wires a policy via `updatePolicy`, and asserts that transfers
 //! revert or succeed based on policy membership.
 
@@ -17,10 +17,10 @@ const SEED_AMOUNT: U256 = U256::from_limbs([100_000, 0, 0, 0]);
 /// Amount transferred in each policy-gated transfer assertion.
 const TRANSFER_AMOUNT: U256 = U256::from_limbs([1, 0, 0, 0]);
 
-/// ALLOWLIST policy wired to TransferSender blocks non-members from sending.
+/// ALLOWLIST policy wired to `TransferSender` blocks non-members from sending.
 ///
-/// 1. Alice seeds bob with tokens (default ALWAYS_ALLOW policy, succeeds).
-/// 2. Create ALLOWLIST policy; wire it to TransferSender.
+/// 1. Alice seeds bob with tokens (default `ALWAYS_ALLOW` policy, succeeds).
+/// 2. Create ALLOWLIST policy; wire it to `TransferSender`.
 /// 3. Bob tries to transfer; reverts (not in allowlist).
 /// 4. Admin adds bob to the allowlist.
 /// 5. Bob transfers again; succeeds.
@@ -81,10 +81,10 @@ async fn b20_allowlist_sender_policy_blocks_non_members() {
     scenario.derive().await;
 }
 
-/// BLOCKLIST policy wired to TransferSender blocks listed accounts from sending.
+/// BLOCKLIST policy wired to `TransferSender` blocks listed accounts from sending.
 ///
-/// 1. Alice seeds bob with tokens (default ALWAYS_ALLOW policy, succeeds).
-/// 2. Create BLOCKLIST policy; wire it to TransferSender.
+/// 1. Alice seeds bob with tokens (default `ALWAYS_ALLOW` policy, succeeds).
+/// 2. Create BLOCKLIST policy; wire it to `TransferSender`.
 /// 3. Bob transfers; succeeds (not in blocklist).
 /// 4. Admin adds bob to the blocklist.
 /// 5. Bob tries to transfer; reverts.
@@ -145,9 +145,9 @@ async fn b20_blocklist_sender_policy_blocks_listed_accounts() {
     scenario.derive().await;
 }
 
-/// Wiring the built-in ALWAYS_BLOCK policy to TransferSender blocks every sender immediately.
+/// Wiring the built-in `ALWAYS_BLOCK` policy to `TransferSender` blocks every sender immediately.
 ///
-/// No allowlist entries are needed: ALWAYS_BLOCK_ID denies all accounts unconditionally.
+/// No allowlist entries are needed: `ALWAYS_BLOCK_ID` denies all accounts unconditionally.
 #[tokio::test]
 async fn b20_always_block_sender_policy_blocks_all_transfers() {
     let mut scenario = B20PolicyScenario::new().await;
@@ -172,7 +172,7 @@ async fn b20_always_block_sender_policy_blocks_all_transfers() {
     scenario.derive().await;
 }
 
-/// ALLOWLIST policy wired to TransferReceiver blocks non-members from receiving.
+/// ALLOWLIST policy wired to `TransferReceiver` blocks non-members from receiving.
 #[tokio::test]
 async fn b20_allowlist_receiver_policy_blocks_non_members() {
     let mut scenario = B20PolicyScenario::new().await;

--- a/actions/harness/tests/beryl/env.rs
+++ b/actions/harness/tests/beryl/env.rs
@@ -12,7 +12,7 @@ use base_batcher_encoder::{DaType, EncoderConfig};
 use base_common_consensus::{BaseBlock, BaseReceipt, BaseTxEnvelope};
 use base_common_precompiles::{
     ActivationFeature, ActivationRegistryStorage, B20FactoryStorage, B20Variant,
-    IActivationRegistry, IB20, IB20Factory,
+    IActivationRegistry, IB20, IB20Factory, IPolicyRegistry,
 };
 use base_precompile_storage::StorageKey;
 use base_test_utils::Account;
@@ -160,6 +160,15 @@ impl BerylTestEnv {
     /// Activation registry feature ID for the policy registry precompile.
     pub(crate) const fn policy_registry_feature() -> B256 {
         ActivationFeature::PolicyRegistry.id()
+    }
+
+    /// Computes the expected policy ID for a custom policy.
+    ///
+    /// IDs are encoded as `(type_discriminant << 56) | counter` where the counter is a
+    /// global monotonic sequence. Counters 0 and 1 are reserved for the built-in policies,
+    /// so the first custom policy always gets counter 2.
+    pub(crate) const fn policy_id(policy_type: IPolicyRegistry::PolicyType, counter: u64) -> u64 {
+        (policy_type as u64) << 56 | counter
     }
 
     /// Alternate salt for a second token creation used in deactivation/re-activation tests.

--- a/actions/harness/tests/beryl/main.rs
+++ b/actions/harness/tests/beryl/main.rs
@@ -5,3 +5,4 @@ mod b20;
 mod env;
 mod factory;
 mod policy_registry;
+mod policy_transfer;

--- a/actions/harness/tests/beryl/main.rs
+++ b/actions/harness/tests/beryl/main.rs
@@ -2,6 +2,7 @@
 
 mod activation;
 mod b20;
+mod b20_policy;
 mod env;
 mod factory;
 mod policy_registry;

--- a/actions/harness/tests/beryl/policy_registry.rs
+++ b/actions/harness/tests/beryl/policy_registry.rs
@@ -131,8 +131,8 @@ async fn beryl_enables_policy_registry_singleton_precompile() {
 #[tokio::test]
 async fn policy_registry_action_tests_cover_policy_lifecycle_and_views() {
     let mut scenario = PolicyRegistryScenario::new().await;
-    let allowlist_id = policy_id(IPolicyRegistry::PolicyType::ALLOWLIST, 2);
-    let blocklist_id = policy_id(IPolicyRegistry::PolicyType::BLOCKLIST, 3);
+    let allowlist_id = BerylTestEnv::policy_id(IPolicyRegistry::PolicyType::ALLOWLIST, 2);
+    let blocklist_id = BerylTestEnv::policy_id(IPolicyRegistry::PolicyType::BLOCKLIST, 3);
 
     let create_allowlist = scenario.tx(IPolicyRegistry::createPolicyCall {
         admin: BerylTestEnv::alice(),
@@ -375,8 +375,8 @@ async fn policy_registry_action_tests_cover_policy_lifecycle_and_views() {
 #[tokio::test]
 async fn policy_registry_action_tests_cover_error_paths() {
     let mut scenario = PolicyRegistryScenario::new().await;
-    let allowlist_id = policy_id(IPolicyRegistry::PolicyType::ALLOWLIST, 2);
-    let blocklist_id = policy_id(IPolicyRegistry::PolicyType::BLOCKLIST, 3);
+    let allowlist_id = BerylTestEnv::policy_id(IPolicyRegistry::PolicyType::ALLOWLIST, 2);
+    let blocklist_id = BerylTestEnv::policy_id(IPolicyRegistry::PolicyType::BLOCKLIST, 3);
 
     // Setup: create an allowlist policy and a blocklist policy, both with alice as admin.
     let create_allowlist = scenario.tx(IPolicyRegistry::createPolicyCall {
@@ -487,8 +487,8 @@ async fn policy_registry_action_tests_cover_error_paths() {
 #[tokio::test]
 async fn policy_registry_renounced_policy_is_frozen() {
     let mut scenario = PolicyRegistryScenario::new().await;
-    let allowlist_id = policy_id(IPolicyRegistry::PolicyType::ALLOWLIST, 2);
-    let blocklist_id = policy_id(IPolicyRegistry::PolicyType::BLOCKLIST, 3);
+    let allowlist_id = BerylTestEnv::policy_id(IPolicyRegistry::PolicyType::ALLOWLIST, 2);
+    let blocklist_id = BerylTestEnv::policy_id(IPolicyRegistry::PolicyType::BLOCKLIST, 3);
 
     // Setup: alice creates an ALLOWLIST policy.
     let create_allowlist = scenario.tx(IPolicyRegistry::createPolicyCall {
@@ -724,10 +724,6 @@ impl PolicyRegistryScenario {
         let block_number = self.blocks.len() as u64 + 1;
         self.blocks.push((block, block_number));
     }
-}
-
-const fn policy_id(policy_type: IPolicyRegistry::PolicyType, counter: u64) -> u64 {
-    (policy_type as u64) << 56 | counter
 }
 
 fn word_from_address(address: alloy_primitives::Address) -> U256 {

--- a/actions/harness/tests/beryl/policy_transfer.rs
+++ b/actions/harness/tests/beryl/policy_transfer.rs
@@ -8,7 +8,7 @@ use alloy_primitives::{Address, Bytes, TxKind, U256};
 use alloy_sol_types::{SolCall, SolValue};
 use base_common_consensus::{BaseBlock, BaseTxEnvelope};
 use base_common_precompiles::{
-    B20PolicyType, IB20, IPolicyRegistry, ITokenFactory, PolicyRegistryStorage, TokenFactoryStorage,
+    B20FactoryStorage, B20PolicyType, IB20, IB20Factory, IPolicyRegistry, PolicyRegistryStorage,
 };
 
 use crate::env::BerylTestEnv;
@@ -255,7 +255,7 @@ impl PolicyTransferScenario {
 
         // Activate all three features in one block.
         let activate_factory =
-            scenario.env.activate_feature_tx(BerylTestEnv::token_factory_feature());
+            scenario.env.activate_feature_tx(BerylTestEnv::b20_factory_feature());
         let activate_b20 = scenario.env.activate_feature_tx(BerylTestEnv::b20_token_feature());
         let activate_registry =
             scenario.env.activate_feature_tx(BerylTestEnv::policy_registry_feature());
@@ -308,7 +308,7 @@ impl PolicyTransferScenario {
         scenario.push_block(beryl_boundary);
 
         let activate_factory =
-            scenario.env.activate_feature_tx(BerylTestEnv::token_factory_feature());
+            scenario.env.activate_feature_tx(BerylTestEnv::b20_factory_feature());
         let activate_b20 = scenario.env.activate_feature_tx(BerylTestEnv::b20_token_feature());
         let activate_registry =
             scenario.env.activate_feature_tx(BerylTestEnv::policy_registry_feature());
@@ -345,7 +345,7 @@ impl PolicyTransferScenario {
         scenario.push_block(beryl_boundary);
 
         let activate_factory =
-            scenario.env.activate_feature_tx(BerylTestEnv::token_factory_feature());
+            scenario.env.activate_feature_tx(BerylTestEnv::b20_factory_feature());
         let activate_b20 = scenario.env.activate_feature_tx(BerylTestEnv::b20_token_feature());
         let block =
             scenario.build_block_with_transactions(vec![activate_factory, activate_b20]).await;
@@ -388,10 +388,10 @@ impl PolicyTransferScenario {
         ));
 
         self.env.create_tx(
-            TxKind::Call(TokenFactoryStorage::ADDRESS),
+            TxKind::Call(B20FactoryStorage::ADDRESS),
             Bytes::from(
-                ITokenFactory::createTokenCall {
-                    variant: ITokenFactory::TokenVariant::DEFAULT,
+                IB20Factory::createB20Call {
+                    variant: IB20Factory::B20Variant::DEFAULT,
                     salt: BerylTestEnv::b20_token_salt(),
                     params: Self::token_params().abi_encode().into(),
                     initCalls: init_calls,
@@ -435,9 +435,9 @@ impl PolicyTransferScenario {
         self.env.derive_blocks(self.blocks, expected_safe_head).await;
     }
 
-    fn token_params() -> ITokenFactory::B20CreateParams {
-        ITokenFactory::B20CreateParams {
-            version: TokenFactoryStorage::CREATE_TOKEN_VERSION,
+    fn token_params() -> IB20Factory::B20CreateParams {
+        IB20Factory::B20CreateParams {
+            version: B20FactoryStorage::CREATE_TOKEN_VERSION,
             name: "Policy B20".to_string(),
             symbol: "PB20".to_string(),
             initialAdmin: BerylTestEnv::alice(),

--- a/actions/harness/tests/beryl/policy_transfer.rs
+++ b/actions/harness/tests/beryl/policy_transfer.rs
@@ -5,7 +5,7 @@
 //! configured `TRANSFER_SENDER_POLICY`, and the result drives allow/block decisions end-to-end.
 
 use alloy_primitives::{Address, Bytes, TxKind, U256};
-use alloy_sol_types::{SolCall, SolValue};
+use alloy_sol_types::SolCall;
 use base_common_consensus::{BaseBlock, BaseTxEnvelope};
 use base_common_precompiles::{
     B20PolicyType, IB20, IPolicyRegistry, ITokenFactory, PolicyRegistryStorage, TokenFactoryStorage,

--- a/actions/harness/tests/beryl/policy_transfer.rs
+++ b/actions/harness/tests/beryl/policy_transfer.rs
@@ -5,7 +5,7 @@
 //! configured `TRANSFER_SENDER_POLICY`, and the result drives allow/block decisions end-to-end.
 
 use alloy_primitives::{Address, Bytes, TxKind, U256};
-use alloy_sol_types::SolCall;
+use alloy_sol_types::{SolCall, SolValue};
 use base_common_consensus::{BaseBlock, BaseTxEnvelope};
 use base_common_precompiles::{
     B20PolicyType, IB20, IPolicyRegistry, ITokenFactory, PolicyRegistryStorage, TokenFactoryStorage,

--- a/actions/harness/tests/beryl/policy_transfer.rs
+++ b/actions/harness/tests/beryl/policy_transfer.rs
@@ -1,15 +1,14 @@
 //! Policy-gated B-20 transfer action tests across the Base Beryl boundary.
 //!
 //! These tests verify the cross-precompile integration between the B-20 token precompile and
-//! the PolicyRegistry precompile: every transfer call checks the sender against the token's
-//! configured TRANSFER_SENDER_POLICY, and the result drives allow/block decisions end-to-end.
+//! the `PolicyRegistry` precompile: every transfer call checks the sender against the token's
+//! configured `TRANSFER_SENDER_POLICY`, and the result drives allow/block decisions end-to-end.
 
 use alloy_primitives::{Address, Bytes, TxKind, U256};
 use alloy_sol_types::{SolCall, SolValue};
 use base_common_consensus::{BaseBlock, BaseTxEnvelope};
 use base_common_precompiles::{
-    B20PolicyType, IB20, IPolicyRegistry, ITokenFactory, POLICY_ALWAYS_BLOCK,
-    PolicyRegistryStorage, TokenFactoryStorage,
+    B20PolicyType, IB20, IPolicyRegistry, ITokenFactory, PolicyRegistryStorage, TokenFactoryStorage,
 };
 
 use crate::env::BerylTestEnv;
@@ -21,8 +20,9 @@ const TRANSFER_AMOUNT: u64 = 1_000;
 
 /// Computes the expected policy ID for a custom policy.
 ///
-/// IDs are encoded as `(type_discriminant << 56) | counter` where the counter
-/// is a global monotonic sequence starting at 0.
+/// IDs are encoded as `(type_discriminant << 56) | counter` where the counter is a
+/// global monotonic sequence. Counters 0 and 1 are reserved for the built-in policies
+/// written by `write_builtins`, so the first custom policy always gets counter 2.
 const fn policy_id(policy_type: IPolicyRegistry::PolicyType, counter: u64) -> u64 {
     (policy_type as u64) << 56 | counter
 }
@@ -31,7 +31,7 @@ const fn policy_id(policy_type: IPolicyRegistry::PolicyType, counter: u64) -> u6
 
 #[tokio::test]
 async fn allowlist_policy_gates_b20_transfers() {
-    let allowlist_id = policy_id(IPolicyRegistry::PolicyType::ALLOWLIST, 0);
+    let allowlist_id = policy_id(IPolicyRegistry::PolicyType::ALLOWLIST, 2);
     let mut scenario = PolicyTransferScenario::new_with_custom_policy(
         IPolicyRegistry::PolicyType::ALLOWLIST,
         allowlist_id,
@@ -104,7 +104,7 @@ async fn allowlist_policy_gates_b20_transfers() {
 
 #[tokio::test]
 async fn blocklist_policy_gates_b20_transfers() {
-    let blocklist_id = policy_id(IPolicyRegistry::PolicyType::BLOCKLIST, 0);
+    let blocklist_id = policy_id(IPolicyRegistry::PolicyType::BLOCKLIST, 2);
     let mut scenario = PolicyTransferScenario::new_with_custom_policy(
         IPolicyRegistry::PolicyType::BLOCKLIST,
         blocklist_id,
@@ -206,7 +206,9 @@ async fn always_allow_policy_never_blocks_b20_transfers() {
 #[tokio::test]
 async fn always_block_policy_always_blocks_b20_transfers() {
     // ALWAYS_BLOCK_ID = 1; set via updatePolicy init call.
-    let mut scenario = PolicyTransferScenario::new_with_builtin_policy(POLICY_ALWAYS_BLOCK).await;
+    let mut scenario =
+        PolicyTransferScenario::new_with_builtin_policy(PolicyRegistryStorage::ALWAYS_BLOCK_ID)
+            .await;
 
     let blocked = scenario.env.transfer_b20_tx(
         scenario.token,
@@ -228,7 +230,7 @@ async fn always_block_policy_always_blocks_b20_transfers() {
 // Scenario helpers
 // ---------------------------------------------------------------------------
 
-/// Test fixture: a funded B-20 token whose TRANSFER_SENDER_POLICY is pre-configured.
+/// Test fixture: a funded B-20 token whose `TRANSFER_SENDER_POLICY` is pre-configured.
 struct PolicyTransferScenario {
     env: BerylTestEnv,
     token: Address,
@@ -236,9 +238,9 @@ struct PolicyTransferScenario {
 }
 
 impl PolicyTransferScenario {
-    /// Sets up with TOKEN_FACTORY, B20_TOKEN, and POLICY_REGISTRY active, creates a custom
+    /// Sets up with `TOKEN_FACTORY`, `B20_TOKEN`, and `POLICY_REGISTRY` active, creates a custom
     /// `policy_type` policy (Alice as admin), then deploys a B-20 token with the
-    /// TRANSFER_SENDER_POLICY wired to that policy via an `updatePolicy` init call.
+    /// `TRANSFER_SENDER_POLICY` wired to that policy via an `updatePolicy` init call.
     async fn new_with_custom_policy(
         policy_type: IPolicyRegistry::PolicyType,
         policy_id: u64,
@@ -296,7 +298,7 @@ impl PolicyTransferScenario {
     }
 
     /// Sets up with all three features active, then deploys a B-20 token with the
-    /// TRANSFER_SENDER_POLICY set to one of the built-in IDs via an `updatePolicy` init call.
+    /// `TRANSFER_SENDER_POLICY` set to one of the built-in IDs via an `updatePolicy` init call.
     async fn new_with_builtin_policy(builtin_policy_id: u64) -> Self {
         let env = BerylTestEnv::new();
         let token = env.b20_token_address();
@@ -331,8 +333,8 @@ impl PolicyTransferScenario {
         scenario
     }
 
-    /// Sets up with TOKEN_FACTORY and B20_TOKEN active, then deploys a B-20 token without
-    /// an `updatePolicy` init call. The TRANSFER_SENDER_POLICY slot defaults to ALWAYS_ALLOW (0),
+    /// Sets up with `TOKEN_FACTORY` and `B20_TOKEN` active, then deploys a B-20 token without
+    /// an `updatePolicy` init call. The `TRANSFER_SENDER_POLICY` slot defaults to `ALWAYS_ALLOW` (0),
     /// so all transfers are permitted.
     async fn new_with_default_policy() -> Self {
         let env = BerylTestEnv::new();
@@ -362,8 +364,8 @@ impl PolicyTransferScenario {
     /// Builds a `createToken` transaction.
     ///
     /// When `transfer_sender_policy_id` is `Some`, an `updatePolicy` init call wires the
-    /// TRANSFER_SENDER_POLICY to that ID before minting the initial supply to Alice.
-    /// When `None`, only the mint init call is included (default ALWAYS_ALLOW semantics).
+    /// `TRANSFER_SENDER_POLICY` to that ID before minting the initial supply to Alice.
+    /// When `None`, only the mint init call is included (default `ALWAYS_ALLOW` semantics).
     fn create_token_tx(&self, transfer_sender_policy_id: Option<u64>) -> BaseTxEnvelope {
         let mut init_calls: Vec<Bytes> = Vec::new();
 
@@ -400,7 +402,7 @@ impl PolicyTransferScenario {
         )
     }
 
-    /// Creates a transaction that calls the PolicyRegistry precompile, signed by Alice.
+    /// Creates a transaction that calls the `PolicyRegistry` precompile, signed by Alice.
     fn policy_tx(&self, call: impl SolCall) -> BaseTxEnvelope {
         self.env.create_tx(
             TxKind::Call(PolicyRegistryStorage::ADDRESS),

--- a/actions/harness/tests/beryl/policy_transfer.rs
+++ b/actions/harness/tests/beryl/policy_transfer.rs
@@ -372,7 +372,7 @@ impl PolicyTransferScenario {
         if let Some(policy_id) = transfer_sender_policy_id {
             init_calls.push(Bytes::from(
                 IB20::updatePolicyCall {
-                    policyType: B20PolicyType::TransferSender.id(),
+                    policyScope: B20PolicyType::TransferSender.id(),
                     newPolicyId: policy_id,
                 }
                 .abi_encode(),

--- a/actions/harness/tests/beryl/policy_transfer.rs
+++ b/actions/harness/tests/beryl/policy_transfer.rs
@@ -18,20 +18,11 @@ const GAS_LIMIT: u64 = 10_000_000;
 /// Transfer amount used across all policy gating tests.
 const TRANSFER_AMOUNT: u64 = 1_000;
 
-/// Computes the expected policy ID for a custom policy.
-///
-/// IDs are encoded as `(type_discriminant << 56) | counter` where the counter is a
-/// global monotonic sequence. Counters 0 and 1 are reserved for the built-in policies
-/// written by `write_builtins`, so the first custom policy always gets counter 2.
-const fn policy_id(policy_type: IPolicyRegistry::PolicyType, counter: u64) -> u64 {
-    (policy_type as u64) << 56 | counter
-}
-
 // --- ALLOWLIST ---
 
 #[tokio::test]
 async fn allowlist_policy_gates_b20_transfers() {
-    let allowlist_id = policy_id(IPolicyRegistry::PolicyType::ALLOWLIST, 2);
+    let allowlist_id = BerylTestEnv::policy_id(IPolicyRegistry::PolicyType::ALLOWLIST, 2);
     let mut scenario = PolicyTransferScenario::new_with_custom_policy(
         IPolicyRegistry::PolicyType::ALLOWLIST,
         allowlist_id,
@@ -104,7 +95,7 @@ async fn allowlist_policy_gates_b20_transfers() {
 
 #[tokio::test]
 async fn blocklist_policy_gates_b20_transfers() {
-    let blocklist_id = policy_id(IPolicyRegistry::PolicyType::BLOCKLIST, 2);
+    let blocklist_id = BerylTestEnv::policy_id(IPolicyRegistry::PolicyType::BLOCKLIST, 2);
     let mut scenario = PolicyTransferScenario::new_with_custom_policy(
         IPolicyRegistry::PolicyType::BLOCKLIST,
         blocklist_id,
@@ -145,6 +136,7 @@ async fn blocklist_policy_gates_b20_transfers() {
     assert!(!scenario.env.user_tx_succeeded(&block, 0), "transfer from blocked sender must revert");
     scenario
         .assert_balance(BerylTestEnv::alice(), BerylTestEnv::B20_INITIAL_SUPPLY - TRANSFER_AMOUNT);
+    scenario.assert_balance(BerylTestEnv::carol(), 0);
 
     // Unblock Alice.
     let unblock_alice = scenario.policy_tx(IPolicyRegistry::updateBlocklistCall {

--- a/actions/harness/tests/beryl/policy_transfer.rs
+++ b/actions/harness/tests/beryl/policy_transfer.rs
@@ -1,0 +1,444 @@
+//! Policy-gated B-20 transfer action tests across the Base Beryl boundary.
+//!
+//! These tests verify the cross-precompile integration between the B-20 token precompile and
+//! the PolicyRegistry precompile: every transfer call checks the sender against the token's
+//! configured TRANSFER_SENDER_POLICY, and the result drives allow/block decisions end-to-end.
+
+use alloy_primitives::{Address, Bytes, TxKind, U256};
+use alloy_sol_types::{SolCall, SolValue};
+use base_common_consensus::{BaseBlock, BaseTxEnvelope};
+use base_common_precompiles::{
+    B20PolicyType, IB20, IPolicyRegistry, ITokenFactory, POLICY_ALWAYS_BLOCK,
+    PolicyRegistryStorage, TokenFactoryStorage,
+};
+
+use crate::env::BerylTestEnv;
+
+const GAS_LIMIT: u64 = 10_000_000;
+
+/// Transfer amount used across all policy gating tests.
+const TRANSFER_AMOUNT: u64 = 1_000;
+
+/// Computes the expected policy ID for a custom policy.
+///
+/// IDs are encoded as `(type_discriminant << 56) | counter` where the counter
+/// is a global monotonic sequence starting at 0.
+const fn policy_id(policy_type: IPolicyRegistry::PolicyType, counter: u64) -> u64 {
+    (policy_type as u64) << 56 | counter
+}
+
+// --- ALLOWLIST ---
+
+#[tokio::test]
+async fn allowlist_policy_gates_b20_transfers() {
+    let allowlist_id = policy_id(IPolicyRegistry::PolicyType::ALLOWLIST, 0);
+    let mut scenario = PolicyTransferScenario::new_with_custom_policy(
+        IPolicyRegistry::PolicyType::ALLOWLIST,
+        allowlist_id,
+    )
+    .await;
+
+    // Non-member: transfer must revert because Alice is not yet in the allowlist.
+    let blocked = scenario.env.transfer_b20_tx(
+        scenario.token,
+        BerylTestEnv::bob(),
+        U256::from(TRANSFER_AMOUNT),
+    );
+    let block = scenario.build_block_with_transactions(vec![blocked]).await;
+    assert!(
+        !scenario.env.user_tx_succeeded(&block, 0),
+        "transfer from non-allowlist member must revert"
+    );
+    scenario.assert_balance(BerylTestEnv::alice(), BerylTestEnv::B20_INITIAL_SUPPLY);
+    scenario.assert_balance(BerylTestEnv::bob(), 0);
+
+    // Add Alice to the allowlist.
+    let add_alice = scenario.policy_tx(IPolicyRegistry::updateAllowlistCall {
+        policyId: allowlist_id,
+        allowed: true,
+        accounts: vec![BerylTestEnv::alice()],
+    });
+    let block = scenario.build_block_with_transactions(vec![add_alice]).await;
+    assert!(scenario.env.user_tx_succeeded(&block, 0), "updateAllowlist() must succeed");
+
+    // Allowlist member: transfer must succeed.
+    let allowed = scenario.env.transfer_b20_tx(
+        scenario.token,
+        BerylTestEnv::bob(),
+        U256::from(TRANSFER_AMOUNT),
+    );
+    let block = scenario.build_block_with_transactions(vec![allowed]).await;
+    assert!(
+        scenario.env.user_tx_succeeded(&block, 0),
+        "transfer from allowlist member must succeed"
+    );
+    scenario
+        .assert_balance(BerylTestEnv::alice(), BerylTestEnv::B20_INITIAL_SUPPLY - TRANSFER_AMOUNT);
+    scenario.assert_balance(BerylTestEnv::bob(), TRANSFER_AMOUNT);
+
+    // Remove Alice from the allowlist.
+    let remove_alice = scenario.policy_tx(IPolicyRegistry::updateAllowlistCall {
+        policyId: allowlist_id,
+        allowed: false,
+        accounts: vec![BerylTestEnv::alice()],
+    });
+    let block = scenario.build_block_with_transactions(vec![remove_alice]).await;
+    assert!(scenario.env.user_tx_succeeded(&block, 0), "updateAllowlist(remove) must succeed");
+
+    // Re-blocked: transfer must revert once Alice is removed from the allowlist.
+    let re_blocked = scenario.env.transfer_b20_tx(
+        scenario.token,
+        BerylTestEnv::bob(),
+        U256::from(TRANSFER_AMOUNT),
+    );
+    let block = scenario.build_block_with_transactions(vec![re_blocked]).await;
+    assert!(
+        !scenario.env.user_tx_succeeded(&block, 0),
+        "transfer from removed allowlist member must revert"
+    );
+
+    scenario.derive().await;
+}
+
+// --- BLOCKLIST ---
+
+#[tokio::test]
+async fn blocklist_policy_gates_b20_transfers() {
+    let blocklist_id = policy_id(IPolicyRegistry::PolicyType::BLOCKLIST, 0);
+    let mut scenario = PolicyTransferScenario::new_with_custom_policy(
+        IPolicyRegistry::PolicyType::BLOCKLIST,
+        blocklist_id,
+    )
+    .await;
+
+    // Non-blocked sender: transfer must succeed.
+    let allowed = scenario.env.transfer_b20_tx(
+        scenario.token,
+        BerylTestEnv::bob(),
+        U256::from(TRANSFER_AMOUNT),
+    );
+    let block = scenario.build_block_with_transactions(vec![allowed]).await;
+    assert!(
+        scenario.env.user_tx_succeeded(&block, 0),
+        "transfer from non-blocklisted sender must succeed"
+    );
+    scenario
+        .assert_balance(BerylTestEnv::alice(), BerylTestEnv::B20_INITIAL_SUPPLY - TRANSFER_AMOUNT);
+    scenario.assert_balance(BerylTestEnv::bob(), TRANSFER_AMOUNT);
+
+    // Block Alice.
+    let block_alice = scenario.policy_tx(IPolicyRegistry::updateBlocklistCall {
+        policyId: blocklist_id,
+        blocked: true,
+        accounts: vec![BerylTestEnv::alice()],
+    });
+    let block = scenario.build_block_with_transactions(vec![block_alice]).await;
+    assert!(scenario.env.user_tx_succeeded(&block, 0), "updateBlocklist() must succeed");
+
+    // Blocked sender: transfer must revert.
+    let blocked = scenario.env.transfer_b20_tx(
+        scenario.token,
+        BerylTestEnv::carol(),
+        U256::from(TRANSFER_AMOUNT),
+    );
+    let block = scenario.build_block_with_transactions(vec![blocked]).await;
+    assert!(!scenario.env.user_tx_succeeded(&block, 0), "transfer from blocked sender must revert");
+    scenario
+        .assert_balance(BerylTestEnv::alice(), BerylTestEnv::B20_INITIAL_SUPPLY - TRANSFER_AMOUNT);
+
+    // Unblock Alice.
+    let unblock_alice = scenario.policy_tx(IPolicyRegistry::updateBlocklistCall {
+        policyId: blocklist_id,
+        blocked: false,
+        accounts: vec![BerylTestEnv::alice()],
+    });
+    let block = scenario.build_block_with_transactions(vec![unblock_alice]).await;
+    assert!(scenario.env.user_tx_succeeded(&block, 0), "updateBlocklist(unblock) must succeed");
+
+    // Unblocked sender: transfer must succeed again.
+    let unblocked = scenario.env.transfer_b20_tx(
+        scenario.token,
+        BerylTestEnv::carol(),
+        U256::from(TRANSFER_AMOUNT),
+    );
+    let block = scenario.build_block_with_transactions(vec![unblocked]).await;
+    assert!(
+        scenario.env.user_tx_succeeded(&block, 0),
+        "transfer from unblocked sender must succeed"
+    );
+    scenario.assert_balance(
+        BerylTestEnv::alice(),
+        BerylTestEnv::B20_INITIAL_SUPPLY - TRANSFER_AMOUNT * 2,
+    );
+    scenario.assert_balance(BerylTestEnv::bob(), TRANSFER_AMOUNT);
+    scenario.assert_balance(BerylTestEnv::carol(), TRANSFER_AMOUNT);
+
+    scenario.derive().await;
+}
+
+// --- ALWAYS_ALLOW (built-in id = 0) ---
+
+#[tokio::test]
+async fn always_allow_policy_never_blocks_b20_transfers() {
+    // The TRANSFER_SENDER_POLICY slot defaults to ALWAYS_ALLOW (0) when never written.
+    // This test verifies that the zero-initialized default permits all senders.
+    let mut scenario = PolicyTransferScenario::new_with_default_policy().await;
+
+    let transfer = scenario.env.transfer_b20_tx(
+        scenario.token,
+        BerylTestEnv::bob(),
+        U256::from(TRANSFER_AMOUNT),
+    );
+    let block = scenario.build_block_with_transactions(vec![transfer]).await;
+    assert!(
+        scenario.env.user_tx_succeeded(&block, 0),
+        "transfer must always succeed under ALWAYS_ALLOW policy"
+    );
+    scenario
+        .assert_balance(BerylTestEnv::alice(), BerylTestEnv::B20_INITIAL_SUPPLY - TRANSFER_AMOUNT);
+    scenario.assert_balance(BerylTestEnv::bob(), TRANSFER_AMOUNT);
+
+    scenario.derive().await;
+}
+
+// --- ALWAYS_BLOCK (built-in id = 1) ---
+
+#[tokio::test]
+async fn always_block_policy_always_blocks_b20_transfers() {
+    // ALWAYS_BLOCK_ID = 1; set via updatePolicy init call.
+    let mut scenario = PolicyTransferScenario::new_with_builtin_policy(POLICY_ALWAYS_BLOCK).await;
+
+    let blocked = scenario.env.transfer_b20_tx(
+        scenario.token,
+        BerylTestEnv::bob(),
+        U256::from(TRANSFER_AMOUNT),
+    );
+    let block = scenario.build_block_with_transactions(vec![blocked]).await;
+    assert!(
+        !scenario.env.user_tx_succeeded(&block, 0),
+        "transfer must always fail under ALWAYS_BLOCK policy"
+    );
+    scenario.assert_balance(BerylTestEnv::alice(), BerylTestEnv::B20_INITIAL_SUPPLY);
+    scenario.assert_balance(BerylTestEnv::bob(), 0);
+
+    scenario.derive().await;
+}
+
+// ---------------------------------------------------------------------------
+// Scenario helpers
+// ---------------------------------------------------------------------------
+
+/// Test fixture: a funded B-20 token whose TRANSFER_SENDER_POLICY is pre-configured.
+struct PolicyTransferScenario {
+    env: BerylTestEnv,
+    token: Address,
+    blocks: Vec<(BaseBlock, u64)>,
+}
+
+impl PolicyTransferScenario {
+    /// Sets up with TOKEN_FACTORY, B20_TOKEN, and POLICY_REGISTRY active, creates a custom
+    /// `policy_type` policy (Alice as admin), then deploys a B-20 token with the
+    /// TRANSFER_SENDER_POLICY wired to that policy via an `updatePolicy` init call.
+    async fn new_with_custom_policy(
+        policy_type: IPolicyRegistry::PolicyType,
+        policy_id: u64,
+    ) -> Self {
+        let env = BerylTestEnv::new();
+        let token = env.b20_token_address();
+        let mut scenario = Self { env, token, blocks: Vec::new() };
+
+        // Empty block to cross the Beryl activation boundary.
+        let beryl_boundary = scenario.env.sequencer.build_empty_block().await;
+        scenario.push_block(beryl_boundary);
+
+        // Activate all three features in one block.
+        let activate_factory =
+            scenario.env.activate_feature_tx(BerylTestEnv::token_factory_feature());
+        let activate_b20 = scenario.env.activate_feature_tx(BerylTestEnv::b20_token_feature());
+        let activate_registry =
+            scenario.env.activate_feature_tx(BerylTestEnv::policy_registry_feature());
+        let block = scenario
+            .build_block_with_transactions(vec![activate_factory, activate_b20, activate_registry])
+            .await;
+        assert!(scenario.env.user_tx_succeeded(&block, 0), "TOKEN_FACTORY activation must succeed");
+        assert!(scenario.env.user_tx_succeeded(&block, 1), "B20_TOKEN activation must succeed");
+        assert!(
+            scenario.env.user_tx_succeeded(&block, 2),
+            "POLICY_REGISTRY activation must succeed"
+        );
+
+        // Create the custom policy with Alice as admin in its own block so that the policy ID
+        // exists in committed state when the token's init call checks it.
+        let create_policy = scenario.env.create_tx(
+            TxKind::Call(PolicyRegistryStorage::ADDRESS),
+            Bytes::from(
+                IPolicyRegistry::createPolicyCall {
+                    admin: BerylTestEnv::alice(),
+                    policyType: policy_type,
+                }
+                .abi_encode(),
+            ),
+            GAS_LIMIT,
+        );
+        let block = scenario.build_block_with_transactions(vec![create_policy]).await;
+        assert!(scenario.env.user_tx_succeeded(&block, 0), "createPolicy() must succeed");
+
+        // Deploy the B-20 token with the TRANSFER_SENDER_POLICY wired to the custom policy.
+        let create_token = scenario.create_token_tx(Some(policy_id));
+        let block = scenario.build_block_with_transactions(vec![create_token]).await;
+        assert!(
+            scenario.env.user_tx_succeeded(&block, 0),
+            "B-20 token creation with custom policy must succeed"
+        );
+        assert!(scenario.env.sequencer.has_code(token), "B-20 token must be deployed");
+
+        scenario
+    }
+
+    /// Sets up with all three features active, then deploys a B-20 token with the
+    /// TRANSFER_SENDER_POLICY set to one of the built-in IDs via an `updatePolicy` init call.
+    async fn new_with_builtin_policy(builtin_policy_id: u64) -> Self {
+        let env = BerylTestEnv::new();
+        let token = env.b20_token_address();
+        let mut scenario = Self { env, token, blocks: Vec::new() };
+
+        let beryl_boundary = scenario.env.sequencer.build_empty_block().await;
+        scenario.push_block(beryl_boundary);
+
+        let activate_factory =
+            scenario.env.activate_feature_tx(BerylTestEnv::token_factory_feature());
+        let activate_b20 = scenario.env.activate_feature_tx(BerylTestEnv::b20_token_feature());
+        let activate_registry =
+            scenario.env.activate_feature_tx(BerylTestEnv::policy_registry_feature());
+        let block = scenario
+            .build_block_with_transactions(vec![activate_factory, activate_b20, activate_registry])
+            .await;
+        assert!(scenario.env.user_tx_succeeded(&block, 0), "TOKEN_FACTORY activation must succeed");
+        assert!(scenario.env.user_tx_succeeded(&block, 1), "B20_TOKEN activation must succeed");
+        assert!(
+            scenario.env.user_tx_succeeded(&block, 2),
+            "POLICY_REGISTRY activation must succeed"
+        );
+
+        let create_token = scenario.create_token_tx(Some(builtin_policy_id));
+        let block = scenario.build_block_with_transactions(vec![create_token]).await;
+        assert!(
+            scenario.env.user_tx_succeeded(&block, 0),
+            "B-20 token creation with built-in policy must succeed"
+        );
+        assert!(scenario.env.sequencer.has_code(token), "B-20 token must be deployed");
+
+        scenario
+    }
+
+    /// Sets up with TOKEN_FACTORY and B20_TOKEN active, then deploys a B-20 token without
+    /// an `updatePolicy` init call. The TRANSFER_SENDER_POLICY slot defaults to ALWAYS_ALLOW (0),
+    /// so all transfers are permitted.
+    async fn new_with_default_policy() -> Self {
+        let env = BerylTestEnv::new();
+        let token = env.b20_token_address();
+        let mut scenario = Self { env, token, blocks: Vec::new() };
+
+        let beryl_boundary = scenario.env.sequencer.build_empty_block().await;
+        scenario.push_block(beryl_boundary);
+
+        let activate_factory =
+            scenario.env.activate_feature_tx(BerylTestEnv::token_factory_feature());
+        let activate_b20 = scenario.env.activate_feature_tx(BerylTestEnv::b20_token_feature());
+        let block =
+            scenario.build_block_with_transactions(vec![activate_factory, activate_b20]).await;
+        assert!(scenario.env.user_tx_succeeded(&block, 0), "TOKEN_FACTORY activation must succeed");
+        assert!(scenario.env.user_tx_succeeded(&block, 1), "B20_TOKEN activation must succeed");
+
+        // No updatePolicy init call: the TRANSFER_SENDER_POLICY slot reads zero (ALWAYS_ALLOW).
+        let create_token = scenario.create_token_tx(None);
+        let block = scenario.build_block_with_transactions(vec![create_token]).await;
+        assert!(scenario.env.user_tx_succeeded(&block, 0), "B-20 token creation must succeed");
+        assert!(scenario.env.sequencer.has_code(token), "B-20 token must be deployed");
+
+        scenario
+    }
+
+    /// Builds a `createToken` transaction.
+    ///
+    /// When `transfer_sender_policy_id` is `Some`, an `updatePolicy` init call wires the
+    /// TRANSFER_SENDER_POLICY to that ID before minting the initial supply to Alice.
+    /// When `None`, only the mint init call is included (default ALWAYS_ALLOW semantics).
+    fn create_token_tx(&self, transfer_sender_policy_id: Option<u64>) -> BaseTxEnvelope {
+        let mut init_calls: Vec<Bytes> = Vec::new();
+
+        if let Some(policy_id) = transfer_sender_policy_id {
+            init_calls.push(Bytes::from(
+                IB20::updatePolicyCall {
+                    policyType: B20PolicyType::TransferSender.id(),
+                    newPolicyId: policy_id,
+                }
+                .abi_encode(),
+            ));
+        }
+
+        init_calls.push(Bytes::from(
+            IB20::mintCall {
+                to: BerylTestEnv::alice(),
+                amount: U256::from(BerylTestEnv::B20_INITIAL_SUPPLY),
+            }
+            .abi_encode(),
+        ));
+
+        self.env.create_tx(
+            TxKind::Call(TokenFactoryStorage::ADDRESS),
+            Bytes::from(
+                ITokenFactory::createTokenCall {
+                    variant: ITokenFactory::TokenVariant::DEFAULT,
+                    salt: BerylTestEnv::b20_token_salt(),
+                    params: Self::token_params().abi_encode().into(),
+                    initCalls: init_calls,
+                }
+                .abi_encode(),
+            ),
+            GAS_LIMIT,
+        )
+    }
+
+    /// Creates a transaction that calls the PolicyRegistry precompile, signed by Alice.
+    fn policy_tx(&self, call: impl SolCall) -> BaseTxEnvelope {
+        self.env.create_tx(
+            TxKind::Call(PolicyRegistryStorage::ADDRESS),
+            Bytes::from(call.abi_encode()),
+            GAS_LIMIT,
+        )
+    }
+
+    async fn build_block_with_transactions(&mut self, txs: Vec<BaseTxEnvelope>) -> BaseBlock {
+        let block = self.env.sequencer.build_next_block_with_transactions(txs).await;
+        self.push_block(block.clone());
+        block
+    }
+
+    fn push_block(&mut self, block: BaseBlock) {
+        let block_number = self.blocks.len() as u64 + 1;
+        self.blocks.push((block, block_number));
+    }
+
+    fn assert_balance(&self, account: Address, expected: u64) {
+        assert_eq!(
+            self.env.b20_balance(self.token, account),
+            U256::from(expected),
+            "B-20 balance for {account} must match expected value"
+        );
+    }
+
+    async fn derive(mut self) {
+        let expected_safe_head = self.blocks.len() as u64;
+        self.env.derive_blocks(self.blocks, expected_safe_head).await;
+    }
+
+    fn token_params() -> ITokenFactory::B20CreateParams {
+        ITokenFactory::B20CreateParams {
+            version: TokenFactoryStorage::CREATE_TOKEN_VERSION,
+            name: "Policy B20".to_string(),
+            symbol: "PB20".to_string(),
+            initialAdmin: BerylTestEnv::alice(),
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds end-to-end action tests proving that B20 token transfers are gated by the PolicyRegistry across both dispatch and storage layers.

Covers two complementary test files:

**`policy_transfer.rs`** (BOP-110) — Tests the TRANSFER_SENDER_POLICY wired via `require_transfer_authorized` in `B20Token::dispatch`, using a full create-policy-then-create-token-with-policy scenario:
- ALLOWLIST: non-member reverts; add member; succeeds; remove member; reverts again
- BLOCKLIST: non-blocked succeeds; block sender; reverts; unblock; succeeds again
- ALWAYS_ALLOW (id=0): default zero-initialized slot permits all senders
- ALWAYS_BLOCK (id=1): unconditionally rejects all transfers

**`b20_policy.rs`** (BOP-129) — Tests policy gating as implemented in `Transferable::transfer()` and `Mintable::mint()`, covering both TransferSender and TransferReceiver slots:
- `b20_allowlist_sender_policy_blocks_non_members`
- `b20_blocklist_sender_policy_blocks_listed_accounts`
- `b20_always_block_sender_policy_blocks_all_transfers`
- `b20_allowlist_receiver_policy_blocks_non_members`

## What was tried / considered

Kept both test files rather than merging into one: `policy_transfer.rs` tests the dispatch-level sender check via a scenario that creates the token with a policy already wired; `b20_policy.rs` tests the storage-level guard via a lighter scenario that wires policy after token creation and also covers the receiver slot.

Linked: BOP-110, BOP-129