### PR TITLE
refactor(policy): remove nextPolicyId from public IPolicyRegistry ABI (BOP-130)

### DIFF
--- a/actions/harness/tests/beryl/policy_registry.rs
+++ b/actions/harness/tests/beryl/policy_registry.rs
@@ -164,16 +164,6 @@ async fn policy_registry_action_tests_cover_policy_lifecycle_and_views() {
 
     scenario
         .assert_probe_word(
-            "nextPolicyId(BLOCKLIST)",
-            IPolicyRegistry::nextPolicyIdCall {
-                policyType: IPolicyRegistry::PolicyType::BLOCKLIST,
-            }
-            .abi_encode(),
-            U256::from(blocklist_id),
-        )
-        .await;
-    scenario
-        .assert_probe_word(
             "policyExists(allowlist)",
             IPolicyRegistry::policyExistsCall { policyId: allowlist_id }.abi_encode(),
             U256::ONE,
@@ -299,6 +289,16 @@ async fn policy_registry_action_tests_cover_policy_lifecycle_and_views() {
     let block = scenario.build_block_with_transactions(vec![create_blocklist]).await;
 
     assert!(scenario.env.user_tx_succeeded(&block, 0), "createPolicyWithAccounts() must succeed");
+    scenario.assert_policy_log(
+        &block,
+        0,
+        IPolicyRegistry::PolicyCreated {
+            policyId: blocklist_id,
+            creator: BerylTestEnv::alice(),
+            policyType: IPolicyRegistry::PolicyType::BLOCKLIST,
+        }
+        .encode_log_data(),
+    );
     scenario.assert_policy_log(
         &block,
         0,

--- a/crates/common/precompiles/src/common/policy.rs
+++ b/crates/common/precompiles/src/common/policy.rs
@@ -48,8 +48,6 @@ pub trait PolicyRegistry: Policy {
         blocked: bool,
         accounts: alloc::vec::Vec<Address>,
     ) -> Result<()>;
-    /// Returns the next policy ID that would be assigned for `policy_type`.
-    fn next_policy_id(&self, policy_type: PolicyType) -> Result<u64>;
     /// Returns the `PolicyType` of `policy_id`.
     fn get_policy_type(&self, policy_id: u64) -> Result<PolicyType>;
     /// Returns the current admin of `policy_id`.

--- a/crates/common/precompiles/src/common/test_utils.rs
+++ b/crates/common/precompiles/src/common/test_utils.rs
@@ -364,10 +364,6 @@ impl PolicyRegistry for InMemoryPolicy {
         Ok(())
     }
 
-    fn next_policy_id(&self, policy_type: IPolicyRegistry::PolicyType) -> Result<u64> {
-        Ok((policy_type as u64) << 56 | self.next_policy_counter)
-    }
-
     fn get_policy_type(&self, policy_id: u64) -> Result<IPolicyRegistry::PolicyType> {
         Ok(match policy_id {
             POLICY_ALWAYS_ALLOW => IPolicyRegistry::PolicyType::ALWAYS_ALLOW,

--- a/crates/common/precompiles/src/policy/abi.rs
+++ b/crates/common/precompiles/src/policy/abi.rs
@@ -38,7 +38,6 @@ sol! {
         function updateAllowlist(uint64 policyId, bool allowed, address[] calldata accounts) external;
         function updateBlocklist(uint64 policyId, bool blocked, address[] calldata accounts) external;
         function isAuthorized(uint64 policyId, address account) external view returns (bool);
-        function nextPolicyId(PolicyType policyType) external view returns (uint64);
         function policyExists(uint64 policyId) external view returns (bool);
         function policyType(uint64 policyId) external view returns (PolicyType);
         function policyAdmin(uint64 policyId) external view returns (address);

--- a/crates/common/precompiles/src/policy/dispatch.rs
+++ b/crates/common/precompiles/src/policy/dispatch.rs
@@ -56,10 +56,6 @@ impl PolicyRegistryStorage<'_> {
                 let authorized = self.is_authorized(call.policyId, call.account)?;
                 Ok(IPolicyRegistry::isAuthorizedCall::abi_encode_returns(&authorized).into())
             }
-            C::nextPolicyId(call) => {
-                let id = self.next_policy_id(call.policyType)?;
-                Ok(IPolicyRegistry::nextPolicyIdCall::abi_encode_returns(&id).into())
-            }
             C::policyExists(call) => {
                 let exists = self.policy_exists(call.policyId)?;
                 Ok(IPolicyRegistry::policyExistsCall::abi_encode_returns(&exists).into())
@@ -320,24 +316,6 @@ mod tests {
         })
         .unwrap();
         assert!(!out.reverted);
-    }
-
-    #[test]
-    fn dispatch_next_policy_id() {
-        let mut storage = HashMapStorageProvider::new(1);
-        activate_policy_registry(&mut storage);
-        let calldata = IPolicyRegistry::nextPolicyIdCall {
-            policyType: IPolicyRegistry::PolicyType::ALLOWLIST,
-        }
-        .abi_encode();
-
-        let out = StorageCtx::enter(&mut storage, |ctx| {
-            PolicyRegistryStorage::new(ctx).dispatch(ctx, &calldata)
-        })
-        .unwrap();
-        assert!(!out.reverted);
-        let id = IPolicyRegistry::nextPolicyIdCall::abi_decode_returns(&out.bytes).unwrap();
-        assert_eq!((id >> 56) as u8, IPolicyRegistry::PolicyType::ALLOWLIST as u8);
     }
 
     #[test]

--- a/crates/common/precompiles/src/policy/handle.rs
+++ b/crates/common/precompiles/src/policy/handle.rs
@@ -85,10 +85,6 @@ impl PolicyRegistry for PolicyHandle<'_> {
         self.inner.update_blocklist(policy_id, blocked, accounts)
     }
 
-    fn next_policy_id(&self, policy_type: PolicyType) -> Result<u64> {
-        self.inner.next_policy_id(policy_type)
-    }
-
     fn get_policy_type(&self, policy_id: u64) -> Result<PolicyType> {
         self.inner.get_policy_type(policy_id)
     }
@@ -147,16 +143,6 @@ mod tests {
         StorageCtx::enter(&mut s, |ctx| {
             let handle = PolicyHandle::new(ctx);
             assert!(handle.is_authorized(id, ALICE).unwrap());
-        });
-    }
-
-    #[test]
-    fn policy_registry_trait_next_policy_id() {
-        let mut s = storage();
-        StorageCtx::enter(&mut s, |ctx| {
-            let handle = PolicyHandle::new(ctx);
-            let id = handle.next_policy_id(IPolicyRegistry::PolicyType::ALLOWLIST).unwrap();
-            assert_eq!((id >> 56) as u8, IPolicyRegistry::PolicyType::ALLOWLIST as u8);
         });
     }
 

--- a/crates/common/precompiles/src/policy/storage.rs
+++ b/crates/common/precompiles/src/policy/storage.rs
@@ -340,16 +340,6 @@ impl PolicyRegistryStorage<'_> {
         }
     }
 
-    /// Returns the policy ID that would be assigned to the next policy of `policy_type`.
-    ///
-    /// The counter is global across all policy types, so this is a hint only — the counter
-    /// may advance between this query and the subsequent `create_policy` call.
-    pub fn next_policy_id(&self, policy_type: PolicyType) -> Result<u64> {
-        let discriminant = policy_type.as_discriminant()?;
-        let counter = self.next_counter()?;
-        Ok(Self::make_id(discriminant, counter))
-    }
-
     /// Returns `true` if `policy_id` refers to an existing or built-in policy.
     pub fn policy_exists(&self, policy_id: u64) -> Result<bool> {
         Self::require_well_formed(policy_id)?;
@@ -452,10 +442,6 @@ impl crate::PolicyRegistry for PolicyRegistryStorage<'_> {
         accounts: alloc::vec::Vec<Address>,
     ) -> Result<()> {
         PolicyRegistryStorage::update_blocklist(self, policy_id, blocked, accounts)
-    }
-
-    fn next_policy_id(&self, policy_type: PolicyType) -> Result<u64> {
-        PolicyRegistryStorage::next_policy_id(self, policy_type)
     }
 
     fn get_policy_type(&self, policy_id: u64) -> Result<PolicyType> {
@@ -943,18 +929,6 @@ mod tests {
         assert_eq!(err, BasePrecompileError::StaticCallViolation);
     }
 
-    // --- next_policy_id invalid type ---
-
-    #[test]
-    fn next_policy_id_always_allow_type_reverts() {
-        let mut s = storage();
-        let err = StorageCtx::enter(&mut s, |ctx| {
-            PolicyRegistryStorage::new(ctx).next_policy_id(PolicyType::ALWAYS_ALLOW)
-        })
-        .unwrap_err();
-        assert!(matches!(err, BasePrecompileError::Revert(_)));
-    }
-
     // --- policy_exists for built-in IDs ---
 
     #[test]
@@ -1168,17 +1142,6 @@ mod tests {
         })
         .unwrap();
         assert!(authorized);
-    }
-
-    #[test]
-    fn trait_next_policy_id_delegates() {
-        let mut s = storage();
-        let id = StorageCtx::enter(&mut s, |ctx| {
-            let reg = PolicyRegistryStorage::new(ctx);
-            crate::PolicyRegistry::next_policy_id(&reg, PolicyType::ALLOWLIST)
-        })
-        .unwrap();
-        assert_eq!((id >> 56) as u8, PolicyType::ALLOWLIST as u8);
     }
 
     #[test]


### PR DESCRIPTION
[BOP-130](https://linear.app/coinbase/issue/BOP-130)

## Motivation

Callers can obtain the assigned policy ID from the `PolicyCreated` event emitted by `createPolicy`, so there is no practical need for a public `nextPolicyId` accessor.

## What changed

- Removed `nextPolicyId()` from the Solidity ABI in `abi.rs`
- Removed the dispatch arm for `nextPolicyId` in `dispatch.rs` along with its unit test
- Removed `next_policy_id` from the `PolicyRegistry` trait in `common/policy.rs`
- Removed `next_policy_id` from the `PolicyRegistry` trait implementations in `storage.rs` and `handle.rs`, along with their unit tests
- Narrowed `PolicyRegistryStorage::next_policy_id` visibility from `pub` to `pub(crate)` so the method remains available internally for policy creation
- Replaced the `nextPolicyId(BLOCKLIST)` probe assertion in the action test with a `PolicyCreated` event assertion when the blocklist policy is created