### PR TITLE
refactor(policy): simplify PolicyType enum and fix built-in policy IDs

### DIFF
--- a/crates/common/precompiles/src/b20/mod.rs
+++ b/crates/common/precompiles/src/b20/mod.rs
@@ -8,7 +8,7 @@ mod pausable;
 pub use pausable::B20PausableFeature;
 
 mod policies;
-pub use policies::{B20PolicyType, POLICY_ALWAYS_ALLOW, POLICY_ALWAYS_BLOCK};
+pub use policies::B20PolicyType;
 
 mod precompile;
 pub use precompile::B20TokenPrecompile;

--- a/crates/common/precompiles/src/b20/policies.rs
+++ b/crates/common/precompiles/src/b20/policies.rs
@@ -111,12 +111,6 @@ impl<S: TokenAccounting, P: Policy> B20Token<S, P> {
         )
     }
 
-    /// Returns whether `policy_id` is one of the built-in global policies.
-    pub const fn is_builtin_policy(policy_id: u64) -> bool {
-        policy_id == PolicyRegistryStorage::ALWAYS_ALLOW_ID
-            || policy_id == PolicyRegistryStorage::ALWAYS_BLOCK_ID
-    }
-
     /// Ensures `policy_type` names a B-20 policy slot.
     pub fn ensure_supported_policy_type(policy_type: B256) -> Result<()> {
         if B20PolicyType::from_id(policy_type).is_some() {

--- a/crates/common/precompiles/src/b20/policies.rs
+++ b/crates/common/precompiles/src/b20/policies.rs
@@ -5,14 +5,7 @@ use alloy_sol_types::SolEvent;
 use base_precompile_storage::{BasePrecompileError, Result};
 
 use super::token::B20Token;
-use crate::{B20Guards, B20TokenRole, IB20, Policy, Token, TokenAccounting};
-
-/// Built-in policy ID that authorizes every account.
-/// BLOCKLIST semantics (empty blocklist), counter 0; fast-pathed in all query methods.
-pub const POLICY_ALWAYS_ALLOW: u64 = 0;
-/// Built-in policy ID that authorizes no account.
-/// ALLOWLIST type (discriminant 0), counter 1, empty member set.
-pub const POLICY_ALWAYS_BLOCK: u64 = 1;
+use crate::{B20Guards, B20TokenRole, IB20, Policy, PolicyRegistryStorage, Token, TokenAccounting};
 
 const TRANSFER_SENDER_POLICY: B256 =
     b256!("b81736c875ab819dd97f59f2a6542cfb731ad52b4ae15a6f24df2fb02b0327f5");
@@ -120,7 +113,8 @@ impl<S: TokenAccounting, P: Policy> B20Token<S, P> {
 
     /// Returns whether `policy_id` is one of the built-in global policies.
     pub const fn is_builtin_policy(policy_id: u64) -> bool {
-        policy_id == POLICY_ALWAYS_ALLOW || policy_id == POLICY_ALWAYS_BLOCK
+        policy_id == PolicyRegistryStorage::ALWAYS_ALLOW_ID
+            || policy_id == PolicyRegistryStorage::ALWAYS_BLOCK_ID
     }
 
     /// Ensures `policy_type` names a B-20 policy slot.

--- a/crates/common/precompiles/src/b20/policies.rs
+++ b/crates/common/precompiles/src/b20/policies.rs
@@ -8,8 +8,10 @@ use super::token::B20Token;
 use crate::{B20Guards, B20TokenRole, IB20, Policy, Token, TokenAccounting};
 
 /// Built-in policy ID that authorizes every account.
+/// BLOCKLIST semantics (empty blocklist), counter 0; fast-pathed in all query methods.
 pub const POLICY_ALWAYS_ALLOW: u64 = 0;
 /// Built-in policy ID that authorizes no account.
+/// ALLOWLIST type (discriminant 0), counter 1, empty member set.
 pub const POLICY_ALWAYS_BLOCK: u64 = 1;
 
 const TRANSFER_SENDER_POLICY: B256 =

--- a/crates/common/precompiles/src/b20/policies.rs
+++ b/crates/common/precompiles/src/b20/policies.rs
@@ -5,7 +5,7 @@ use alloy_sol_types::SolEvent;
 use base_precompile_storage::{BasePrecompileError, Result};
 
 use super::token::B20Token;
-use crate::{B20Guards, B20TokenRole, IB20, Policy, PolicyRegistryStorage, Token, TokenAccounting};
+use crate::{B20Guards, B20TokenRole, IB20, Policy, Token, TokenAccounting};
 
 const TRANSFER_SENDER_POLICY: B256 =
     b256!("b81736c875ab819dd97f59f2a6542cfb731ad52b4ae15a6f24df2fb02b0327f5");

--- a/crates/common/precompiles/src/common/ops/burnable.rs
+++ b/crates/common/precompiles/src/common/ops/burnable.rs
@@ -79,7 +79,7 @@ mod tests {
 
     use super::Burnable;
     use crate::{
-        B20PausableFeature, B20PolicyType, B20TokenRole, IB20, POLICY_ALWAYS_BLOCK,
+        B20PausableFeature, B20PolicyType, B20TokenRole, IB20, PolicyRegistryStorage,
         common::{
             Token, TokenAccounting,
             test_utils::{InMemoryPolicy, InMemoryTokenAccounting, TestToken},
@@ -183,7 +183,7 @@ mod tests {
         let mut accounting = InMemoryTokenAccounting::new(TOKEN_ADDR);
         accounting.balances.insert(ALICE, U256::from(100u64));
         accounting.total_supply = U256::from(100u64);
-        accounting.policy_ids.insert(B20PolicyType::TransferSender.id(), POLICY_ALWAYS_BLOCK);
+        accounting.policy_ids.insert(B20PolicyType::TransferSender.id(), PolicyRegistryStorage::ALWAYS_BLOCK_ID);
         let mut token = TestToken::with_storage_and_policy(accounting, InMemoryPolicy::new());
 
         token.burn_blocked(CALLER, ALICE, U256::from(25u64), true).unwrap();
@@ -198,7 +198,7 @@ mod tests {
         let mut accounting = InMemoryTokenAccounting::new(TOKEN_ADDR);
         accounting.balances.insert(ALICE, U256::from(10u64));
         accounting.total_supply = U256::from(10u64);
-        accounting.policy_ids.insert(B20PolicyType::TransferSender.id(), POLICY_ALWAYS_BLOCK);
+        accounting.policy_ids.insert(B20PolicyType::TransferSender.id(), PolicyRegistryStorage::ALWAYS_BLOCK_ID);
         let mut token = TestToken::with_storage_and_policy(accounting, InMemoryPolicy::new());
 
         assert_eq!(

--- a/crates/common/precompiles/src/common/ops/burnable.rs
+++ b/crates/common/precompiles/src/common/ops/burnable.rs
@@ -183,7 +183,9 @@ mod tests {
         let mut accounting = InMemoryTokenAccounting::new(TOKEN_ADDR);
         accounting.balances.insert(ALICE, U256::from(100u64));
         accounting.total_supply = U256::from(100u64);
-        accounting.policy_ids.insert(B20PolicyType::TransferSender.id(), PolicyRegistryStorage::ALWAYS_BLOCK_ID);
+        accounting
+            .policy_ids
+            .insert(B20PolicyType::TransferSender.id(), PolicyRegistryStorage::ALWAYS_BLOCK_ID);
         let mut token = TestToken::with_storage_and_policy(accounting, InMemoryPolicy::new());
 
         token.burn_blocked(CALLER, ALICE, U256::from(25u64), true).unwrap();
@@ -198,7 +200,9 @@ mod tests {
         let mut accounting = InMemoryTokenAccounting::new(TOKEN_ADDR);
         accounting.balances.insert(ALICE, U256::from(10u64));
         accounting.total_supply = U256::from(10u64);
-        accounting.policy_ids.insert(B20PolicyType::TransferSender.id(), PolicyRegistryStorage::ALWAYS_BLOCK_ID);
+        accounting
+            .policy_ids
+            .insert(B20PolicyType::TransferSender.id(), PolicyRegistryStorage::ALWAYS_BLOCK_ID);
         let mut token = TestToken::with_storage_and_policy(accounting, InMemoryPolicy::new());
 
         assert_eq!(

--- a/crates/common/precompiles/src/common/ops/guards.rs
+++ b/crates/common/precompiles/src/common/ops/guards.rs
@@ -141,13 +141,17 @@ mod tests {
     fn test_ensure_blocked_preserves_global_block_semantics() {
         let account = Address::repeat_byte(0xaa);
         let mut accounting = InMemoryTokenAccounting::new(Address::repeat_byte(0x20));
-        accounting.policy_ids.insert(B20PolicyType::TransferSender.id(), PolicyRegistryStorage::ALWAYS_BLOCK_ID);
+        accounting
+            .policy_ids
+            .insert(B20PolicyType::TransferSender.id(), PolicyRegistryStorage::ALWAYS_BLOCK_ID);
         let token = TestToken::with_storage_and_policy(accounting, InMemoryPolicy::new());
 
         B20Guards::ensure_blocked(&token, account).unwrap();
 
         let mut accounting = InMemoryTokenAccounting::new(Address::repeat_byte(0x20));
-        accounting.policy_ids.insert(B20PolicyType::TransferSender.id(), PolicyRegistryStorage::ALWAYS_ALLOW_ID);
+        accounting
+            .policy_ids
+            .insert(B20PolicyType::TransferSender.id(), PolicyRegistryStorage::ALWAYS_ALLOW_ID);
         let token = TestToken::with_storage_and_policy(accounting, InMemoryPolicy::new());
 
         assert_eq!(

--- a/crates/common/precompiles/src/common/ops/guards.rs
+++ b/crates/common/precompiles/src/common/ops/guards.rs
@@ -92,10 +92,7 @@ mod tests {
     use alloy_primitives::Address;
 
     use super::*;
-    use crate::{
-        InMemoryPolicy, InMemoryTokenAccounting, POLICY_ALWAYS_ALLOW, POLICY_ALWAYS_BLOCK,
-        TestToken,
-    };
+    use crate::{InMemoryPolicy, InMemoryTokenAccounting, PolicyRegistryStorage, TestToken};
 
     const EXTERNAL_POLICY_ID: u64 = 7;
 
@@ -144,13 +141,13 @@ mod tests {
     fn test_ensure_blocked_preserves_global_block_semantics() {
         let account = Address::repeat_byte(0xaa);
         let mut accounting = InMemoryTokenAccounting::new(Address::repeat_byte(0x20));
-        accounting.policy_ids.insert(B20PolicyType::TransferSender.id(), POLICY_ALWAYS_BLOCK);
+        accounting.policy_ids.insert(B20PolicyType::TransferSender.id(), PolicyRegistryStorage::ALWAYS_BLOCK_ID);
         let token = TestToken::with_storage_and_policy(accounting, InMemoryPolicy::new());
 
         B20Guards::ensure_blocked(&token, account).unwrap();
 
         let mut accounting = InMemoryTokenAccounting::new(Address::repeat_byte(0x20));
-        accounting.policy_ids.insert(B20PolicyType::TransferSender.id(), POLICY_ALWAYS_ALLOW);
+        accounting.policy_ids.insert(B20PolicyType::TransferSender.id(), PolicyRegistryStorage::ALWAYS_ALLOW_ID);
         let token = TestToken::with_storage_and_policy(accounting, InMemoryPolicy::new());
 
         assert_eq!(

--- a/crates/common/precompiles/src/common/ops/mintable.rs
+++ b/crates/common/precompiles/src/common/ops/mintable.rs
@@ -179,7 +179,9 @@ mod tests {
     #[test]
     fn mint_reverts_when_receiver_policy_denies() {
         let mut accounting = InMemoryTokenAccounting::new(TOKEN_ADDR);
-        accounting.policy_ids.insert(B20PolicyType::MintReceiver.id(), PolicyRegistryStorage::ALWAYS_BLOCK_ID);
+        accounting
+            .policy_ids
+            .insert(B20PolicyType::MintReceiver.id(), PolicyRegistryStorage::ALWAYS_BLOCK_ID);
         let mut token = TestToken::with_storage_and_policy(accounting, InMemoryPolicy::new());
 
         assert_eq!(

--- a/crates/common/precompiles/src/common/ops/mintable.rs
+++ b/crates/common/precompiles/src/common/ops/mintable.rs
@@ -60,7 +60,7 @@ mod tests {
 
     use super::Mintable;
     use crate::{
-        B20PausableFeature, B20PolicyType, B20TokenRole, IB20, POLICY_ALWAYS_BLOCK,
+        B20PausableFeature, B20PolicyType, B20TokenRole, IB20, PolicyRegistryStorage,
         common::{
             Token, TokenAccounting,
             test_utils::{InMemoryPolicy, InMemoryTokenAccounting, TestToken},
@@ -179,14 +179,14 @@ mod tests {
     #[test]
     fn mint_reverts_when_receiver_policy_denies() {
         let mut accounting = InMemoryTokenAccounting::new(TOKEN_ADDR);
-        accounting.policy_ids.insert(B20PolicyType::MintReceiver.id(), POLICY_ALWAYS_BLOCK);
+        accounting.policy_ids.insert(B20PolicyType::MintReceiver.id(), PolicyRegistryStorage::ALWAYS_BLOCK_ID);
         let mut token = TestToken::with_storage_and_policy(accounting, InMemoryPolicy::new());
 
         assert_eq!(
             token.mint(CALLER, ALICE, U256::ONE, true).unwrap_err(),
             BasePrecompileError::revert(IB20::PolicyForbids {
                 policyType: B20PolicyType::MintReceiver.id(),
-                policyId: POLICY_ALWAYS_BLOCK,
+                policyId: PolicyRegistryStorage::ALWAYS_BLOCK_ID,
             })
         );
     }

--- a/crates/common/precompiles/src/common/ops/transferable.rs
+++ b/crates/common/precompiles/src/common/ops/transferable.rs
@@ -280,7 +280,9 @@ mod tests {
     fn transfer_reverts_when_sender_policy_denies() {
         let mut accounting = InMemoryTokenAccounting::new(TOKEN_ADDR);
         accounting.balances.insert(ALICE, U256::from(10u64));
-        accounting.policy_ids.insert(B20PolicyType::TransferSender.id(), PolicyRegistryStorage::ALWAYS_BLOCK_ID);
+        accounting
+            .policy_ids
+            .insert(B20PolicyType::TransferSender.id(), PolicyRegistryStorage::ALWAYS_BLOCK_ID);
         let mut token = TestToken::with_storage_and_policy(accounting, InMemoryPolicy::new());
 
         assert_eq!(
@@ -296,7 +298,9 @@ mod tests {
     fn transfer_reverts_when_receiver_policy_denies() {
         let mut accounting = InMemoryTokenAccounting::new(TOKEN_ADDR);
         accounting.balances.insert(ALICE, U256::from(10u64));
-        accounting.policy_ids.insert(B20PolicyType::TransferReceiver.id(), PolicyRegistryStorage::ALWAYS_BLOCK_ID);
+        accounting
+            .policy_ids
+            .insert(B20PolicyType::TransferReceiver.id(), PolicyRegistryStorage::ALWAYS_BLOCK_ID);
         let mut token = TestToken::with_storage_and_policy(accounting, InMemoryPolicy::new());
 
         assert_eq!(
@@ -313,7 +317,9 @@ mod tests {
         let mut accounting = InMemoryTokenAccounting::new(TOKEN_ADDR);
         accounting.balances.insert(ALICE, U256::from(10u64));
         accounting.allowances.insert((ALICE, SPENDER), U256::from(10u64));
-        accounting.policy_ids.insert(B20PolicyType::TransferExecutor.id(), PolicyRegistryStorage::ALWAYS_BLOCK_ID);
+        accounting
+            .policy_ids
+            .insert(B20PolicyType::TransferExecutor.id(), PolicyRegistryStorage::ALWAYS_BLOCK_ID);
         let mut token = TestToken::with_storage_and_policy(accounting, InMemoryPolicy::new());
 
         assert_eq!(

--- a/crates/common/precompiles/src/common/ops/transferable.rs
+++ b/crates/common/precompiles/src/common/ops/transferable.rs
@@ -114,7 +114,7 @@ mod tests {
 
     use super::Transferable;
     use crate::{
-        B20PausableFeature, B20PolicyType, IB20, POLICY_ALWAYS_BLOCK,
+        B20PausableFeature, B20PolicyType, IB20, PolicyRegistryStorage,
         common::{
             Token, TokenAccounting,
             test_utils::{InMemoryPolicy, InMemoryTokenAccounting, TestToken},
@@ -280,14 +280,14 @@ mod tests {
     fn transfer_reverts_when_sender_policy_denies() {
         let mut accounting = InMemoryTokenAccounting::new(TOKEN_ADDR);
         accounting.balances.insert(ALICE, U256::from(10u64));
-        accounting.policy_ids.insert(B20PolicyType::TransferSender.id(), POLICY_ALWAYS_BLOCK);
+        accounting.policy_ids.insert(B20PolicyType::TransferSender.id(), PolicyRegistryStorage::ALWAYS_BLOCK_ID);
         let mut token = TestToken::with_storage_and_policy(accounting, InMemoryPolicy::new());
 
         assert_eq!(
             token.transfer(ALICE, BOB, U256::ONE).unwrap_err(),
             BasePrecompileError::revert(IB20::PolicyForbids {
                 policyType: B20PolicyType::TransferSender.id(),
-                policyId: POLICY_ALWAYS_BLOCK,
+                policyId: PolicyRegistryStorage::ALWAYS_BLOCK_ID,
             })
         );
     }
@@ -296,14 +296,14 @@ mod tests {
     fn transfer_reverts_when_receiver_policy_denies() {
         let mut accounting = InMemoryTokenAccounting::new(TOKEN_ADDR);
         accounting.balances.insert(ALICE, U256::from(10u64));
-        accounting.policy_ids.insert(B20PolicyType::TransferReceiver.id(), POLICY_ALWAYS_BLOCK);
+        accounting.policy_ids.insert(B20PolicyType::TransferReceiver.id(), PolicyRegistryStorage::ALWAYS_BLOCK_ID);
         let mut token = TestToken::with_storage_and_policy(accounting, InMemoryPolicy::new());
 
         assert_eq!(
             token.transfer(ALICE, BOB, U256::ONE).unwrap_err(),
             BasePrecompileError::revert(IB20::PolicyForbids {
                 policyType: B20PolicyType::TransferReceiver.id(),
-                policyId: POLICY_ALWAYS_BLOCK,
+                policyId: PolicyRegistryStorage::ALWAYS_BLOCK_ID,
             })
         );
     }
@@ -313,14 +313,14 @@ mod tests {
         let mut accounting = InMemoryTokenAccounting::new(TOKEN_ADDR);
         accounting.balances.insert(ALICE, U256::from(10u64));
         accounting.allowances.insert((ALICE, SPENDER), U256::from(10u64));
-        accounting.policy_ids.insert(B20PolicyType::TransferExecutor.id(), POLICY_ALWAYS_BLOCK);
+        accounting.policy_ids.insert(B20PolicyType::TransferExecutor.id(), PolicyRegistryStorage::ALWAYS_BLOCK_ID);
         let mut token = TestToken::with_storage_and_policy(accounting, InMemoryPolicy::new());
 
         assert_eq!(
             token.transfer_from(SPENDER, ALICE, BOB, U256::ONE).unwrap_err(),
             BasePrecompileError::revert(IB20::PolicyForbids {
                 policyType: B20PolicyType::TransferExecutor.id(),
-                policyId: POLICY_ALWAYS_BLOCK,
+                policyId: PolicyRegistryStorage::ALWAYS_BLOCK_ID,
             })
         );
     }

--- a/crates/common/precompiles/src/common/test_utils.rs
+++ b/crates/common/precompiles/src/common/test_utils.rs
@@ -365,12 +365,14 @@ impl PolicyRegistry for InMemoryPolicy {
     }
 
     fn get_policy_type(&self, policy_id: u64) -> Result<IPolicyRegistry::PolicyType> {
-        Ok(match policy_id {
-            POLICY_ALWAYS_ALLOW => IPolicyRegistry::PolicyType::ALWAYS_ALLOW,
-            POLICY_ALWAYS_BLOCK => IPolicyRegistry::PolicyType::ALWAYS_BLOCK,
-            _ => IPolicyRegistry::PolicyType::try_from((policy_id >> 56) as u8).map_err(|_| {
-                base_precompile_storage::BasePrecompileError::enum_conversion_error()
-            })?,
+        // POLICY_ALWAYS_ALLOW=0 has BLOCKLIST semantics but its high byte encodes
+        // ALLOWLIST (the zero value), so we must hardcode the return.
+        if policy_id == POLICY_ALWAYS_ALLOW {
+            return Ok(IPolicyRegistry::PolicyType::BLOCKLIST);
+        }
+        // All other IDs (including POLICY_ALWAYS_BLOCK=1) encode the type in the high byte.
+        IPolicyRegistry::PolicyType::try_from((policy_id >> 56) as u8).map_err(|_| {
+            base_precompile_storage::BasePrecompileError::enum_conversion_error()
         })
     }
 

--- a/crates/common/precompiles/src/common/test_utils.rs
+++ b/crates/common/precompiles/src/common/test_utils.rs
@@ -9,7 +9,7 @@ use alloy_primitives::{Address, B256, LogData, U256};
 use base_precompile_storage::Result;
 
 use crate::{
-    IPolicyRegistry, POLICY_ALWAYS_ALLOW, POLICY_ALWAYS_BLOCK, PolicyRegistry,
+    IPolicyRegistry, PolicyRegistry, PolicyRegistryStorage,
     b20::B20Token,
     common::{Policy, TokenAccounting},
 };
@@ -233,7 +233,7 @@ impl TokenAccounting for InMemoryTokenAccounting {
     }
 
     fn policy_id(&self, policy_type: B256) -> Result<u64> {
-        Ok(*self.policy_ids.get(&policy_type).unwrap_or(&POLICY_ALWAYS_ALLOW))
+        Ok(*self.policy_ids.get(&policy_type).unwrap_or(&PolicyRegistryStorage::ALWAYS_ALLOW_ID))
     }
 
     fn set_policy_id(&mut self, policy_type: B256, policy_id: u64) -> Result<()> {
@@ -288,15 +288,15 @@ impl InMemoryPolicy {
 impl Policy for InMemoryPolicy {
     fn is_authorized(&self, policy_id: u64, account: Address) -> Result<bool> {
         match policy_id {
-            POLICY_ALWAYS_ALLOW => Ok(true),
-            POLICY_ALWAYS_BLOCK => Ok(false),
+            PolicyRegistryStorage::ALWAYS_ALLOW_ID => Ok(true),
+            PolicyRegistryStorage::ALWAYS_BLOCK_ID => Ok(false),
             _ => Ok(*self.authorizations.get(&(policy_id, account)).unwrap_or(&false)),
         }
     }
 
     fn policy_exists(&self, policy_id: u64) -> Result<bool> {
-        Ok(policy_id == POLICY_ALWAYS_ALLOW
-            || policy_id == POLICY_ALWAYS_BLOCK
+        Ok(policy_id == PolicyRegistryStorage::ALWAYS_ALLOW_ID
+            || policy_id == PolicyRegistryStorage::ALWAYS_BLOCK_ID
             || self.policies.contains(&policy_id))
     }
 }
@@ -365,12 +365,12 @@ impl PolicyRegistry for InMemoryPolicy {
     }
 
     fn get_policy_type(&self, policy_id: u64) -> Result<IPolicyRegistry::PolicyType> {
-        // POLICY_ALWAYS_ALLOW=0 has BLOCKLIST semantics but its high byte encodes
+        // PolicyRegistryStorage::ALWAYS_ALLOW_ID=0 has BLOCKLIST semantics but its high byte encodes
         // ALLOWLIST (the zero value), so we must hardcode the return.
-        if policy_id == POLICY_ALWAYS_ALLOW {
+        if policy_id == PolicyRegistryStorage::ALWAYS_ALLOW_ID {
             return Ok(IPolicyRegistry::PolicyType::BLOCKLIST);
         }
-        // All other IDs (including POLICY_ALWAYS_BLOCK=1) encode the type in the high byte.
+        // All other IDs (including PolicyRegistryStorage::ALWAYS_BLOCK_ID=1) encode the type in the high byte.
         IPolicyRegistry::PolicyType::try_from((policy_id >> 56) as u8).map_err(|_| {
             base_precompile_storage::BasePrecompileError::enum_conversion_error()
         })

--- a/crates/common/precompiles/src/common/test_utils.rs
+++ b/crates/common/precompiles/src/common/test_utils.rs
@@ -365,9 +365,8 @@ impl PolicyRegistry for InMemoryPolicy {
     }
 
     fn get_policy_type(&self, policy_id: u64) -> Result<IPolicyRegistry::PolicyType> {
-        IPolicyRegistry::PolicyType::try_from((policy_id >> 56) as u8).map_err(|_| {
-            base_precompile_storage::BasePrecompileError::enum_conversion_error()
-        })
+        IPolicyRegistry::PolicyType::try_from((policy_id >> 56) as u8)
+            .map_err(|_| base_precompile_storage::BasePrecompileError::enum_conversion_error())
     }
 
     fn get_policy_admin(&self, _policy_id: u64) -> Result<Address> {

--- a/crates/common/precompiles/src/common/test_utils.rs
+++ b/crates/common/precompiles/src/common/test_utils.rs
@@ -365,12 +365,6 @@ impl PolicyRegistry for InMemoryPolicy {
     }
 
     fn get_policy_type(&self, policy_id: u64) -> Result<IPolicyRegistry::PolicyType> {
-        // PolicyRegistryStorage::ALWAYS_ALLOW_ID=0 has BLOCKLIST semantics but its high byte encodes
-        // ALLOWLIST (the zero value), so we must hardcode the return.
-        if policy_id == PolicyRegistryStorage::ALWAYS_ALLOW_ID {
-            return Ok(IPolicyRegistry::PolicyType::BLOCKLIST);
-        }
-        // All other IDs (including PolicyRegistryStorage::ALWAYS_BLOCK_ID=1) encode the type in the high byte.
         IPolicyRegistry::PolicyType::try_from((policy_id >> 56) as u8).map_err(|_| {
             base_precompile_storage::BasePrecompileError::enum_conversion_error()
         })

--- a/crates/common/precompiles/src/lib.rs
+++ b/crates/common/precompiles/src/lib.rs
@@ -29,10 +29,7 @@ pub use common::{
 pub use common::{InMemoryPolicy, InMemoryTokenAccounting, TestToken};
 
 mod b20;
-pub use b20::{
-    B20PausableFeature, B20PolicyType, B20Token, B20TokenPrecompile, B20TokenStorage, IB20,
-    POLICY_ALWAYS_ALLOW, POLICY_ALWAYS_BLOCK,
-};
+pub use b20::{B20PausableFeature, B20PolicyType, B20Token, B20TokenPrecompile, B20TokenStorage, IB20};
 
 mod factory;
 pub use factory::{ITokenFactory, TokenFactory, TokenFactoryStorage, TokenVariant};

--- a/crates/common/precompiles/src/lib.rs
+++ b/crates/common/precompiles/src/lib.rs
@@ -29,7 +29,9 @@ pub use common::{
 pub use common::{InMemoryPolicy, InMemoryTokenAccounting, TestToken};
 
 mod b20;
-pub use b20::{B20PausableFeature, B20PolicyType, B20Token, B20TokenPrecompile, B20TokenStorage, IB20};
+pub use b20::{
+    B20PausableFeature, B20PolicyType, B20Token, B20TokenPrecompile, B20TokenStorage, IB20,
+};
 
 mod factory;
 pub use factory::{ITokenFactory, TokenFactory, TokenFactoryStorage, TokenVariant};

--- a/crates/common/precompiles/src/policy/abi.rs
+++ b/crates/common/precompiles/src/policy/abi.rs
@@ -1,5 +1,4 @@
 use alloy_sol_types::sol;
-use base_precompile_storage::Result;
 
 sol! {
     #[derive(Debug, PartialEq, Eq)]
@@ -45,7 +44,7 @@ sol! {
 
 impl IPolicyRegistry::PolicyType {
     /// Returns the raw `u8` discriminant for this policy type.
-    pub fn as_discriminant(self) -> Result<u8> {
-        Ok(self as u8)
+    pub fn as_discriminant(self) -> u8 {
+        self as u8
     }
 }

--- a/crates/common/precompiles/src/policy/abi.rs
+++ b/crates/common/precompiles/src/policy/abi.rs
@@ -4,12 +4,12 @@ sol! {
     #[derive(Debug, PartialEq, Eq)]
     interface IPolicyRegistry {
         enum PolicyType {
-            /// Authorizes only accounts explicitly added to the allowlist.
-            /// An empty allowlist rejects everyone.
-            ALLOWLIST,
             /// Rejects only accounts explicitly added to the blocklist.
             /// An empty blocklist authorizes everyone.
-            BLOCKLIST
+            BLOCKLIST,
+            /// Authorizes only accounts explicitly added to the allowlist.
+            /// An empty allowlist rejects everyone.
+            ALLOWLIST
         }
 
         error Unauthorized();

--- a/crates/common/precompiles/src/policy/abi.rs
+++ b/crates/common/precompiles/src/policy/abi.rs
@@ -1,17 +1,15 @@
 use alloy_sol_types::sol;
-use base_precompile_storage::{BasePrecompileError, Result};
+use base_precompile_storage::Result;
 
 sol! {
     #[derive(Debug, PartialEq, Eq)]
     interface IPolicyRegistry {
         enum PolicyType {
-            /// Authorizes all accounts unconditionally.
-            ALWAYS_ALLOW,
-            /// Rejects all accounts unconditionally.
-            ALWAYS_BLOCK,
             /// Authorizes only accounts explicitly added to the allowlist.
+            /// An empty allowlist rejects everyone.
             ALLOWLIST,
             /// Rejects only accounts explicitly added to the blocklist.
+            /// An empty blocklist authorizes everyone.
             BLOCKLIST
         }
 
@@ -46,12 +44,8 @@ sol! {
 }
 
 impl IPolicyRegistry::PolicyType {
-    /// Returns the raw `u8` discriminant for ALLOWLIST or BLOCKLIST.
-    /// Reverts with `InvalidPolicyType` for built-in sentinels (`ALWAYS_ALLOW`, `ALWAYS_BLOCK`).
+    /// Returns the raw `u8` discriminant for this policy type.
     pub fn as_discriminant(self) -> Result<u8> {
-        match self {
-            Self::ALLOWLIST | Self::BLOCKLIST => Ok(self as u8),
-            _ => Err(BasePrecompileError::revert(IPolicyRegistry::InvalidPolicyType {})),
-        }
+        Ok(self as u8)
     }
 }

--- a/crates/common/precompiles/src/policy/abi.rs
+++ b/crates/common/precompiles/src/policy/abi.rs
@@ -44,7 +44,7 @@ sol! {
 
 impl IPolicyRegistry::PolicyType {
     /// Returns the raw `u8` discriminant for this policy type.
-    pub fn as_discriminant(self) -> u8 {
+    pub const fn as_discriminant(self) -> u8 {
         self as u8
     }
 }

--- a/crates/common/precompiles/src/policy/dispatch.rs
+++ b/crates/common/precompiles/src/policy/dispatch.rs
@@ -103,10 +103,7 @@ mod tests {
     /// built-in policy IDs (ALWAYS_ALLOW_ID, ALWAYS_BLOCK_ID) directly.
     fn activate_and_init(storage: &mut HashMapStorageProvider) {
         activate_policy_registry(storage);
-        StorageCtx::enter(storage, |ctx| {
-            PolicyRegistryStorage::new(ctx).write_builtins()
-        })
-        .unwrap();
+        StorageCtx::enter(storage, |ctx| PolicyRegistryStorage::new(ctx).write_builtins()).unwrap();
     }
 
     #[test]

--- a/crates/common/precompiles/src/policy/dispatch.rs
+++ b/crates/common/precompiles/src/policy/dispatch.rs
@@ -97,6 +97,18 @@ mod tests {
         });
     }
 
+    /// Activates the policy registry and writes the built-in policies to storage.
+    ///
+    /// Call this instead of `activate_policy_registry` when the test needs to query
+    /// built-in policy IDs (ALWAYS_ALLOW_ID, ALWAYS_BLOCK_ID) directly.
+    fn activate_and_init(storage: &mut HashMapStorageProvider) {
+        activate_policy_registry(storage);
+        StorageCtx::enter(storage, |ctx| {
+            PolicyRegistryStorage::new(ctx).write_builtins()
+        })
+        .unwrap();
+    }
+
     #[test]
     fn dispatch_reverts_when_policy_registry_is_inactive() {
         let mut storage = HashMapStorageProvider::new(1);
@@ -113,8 +125,10 @@ mod tests {
     #[test]
     fn dispatch_succeeds_when_policy_registry_is_active() {
         let mut storage = HashMapStorageProvider::new(1);
-        activate_policy_registry(&mut storage);
-        let calldata = IPolicyRegistry::policyExistsCall { policyId: 0 }.abi_encode();
+        activate_and_init(&mut storage);
+        let calldata =
+            IPolicyRegistry::policyExistsCall { policyId: PolicyRegistryStorage::ALWAYS_ALLOW_ID }
+                .abi_encode();
 
         let output = StorageCtx::enter(&mut storage, |ctx| {
             PolicyRegistryStorage::new(ctx).dispatch(ctx, &calldata)
@@ -149,7 +163,7 @@ mod tests {
     #[test]
     fn dispatch_is_authorized_always_allow_returns_true() {
         let mut storage = HashMapStorageProvider::new(1);
-        activate_policy_registry(&mut storage);
+        activate_and_init(&mut storage);
         let calldata = IPolicyRegistry::isAuthorizedCall {
             policyId: PolicyRegistryStorage::ALWAYS_ALLOW_ID,
             account: ALICE,
@@ -321,7 +335,7 @@ mod tests {
     #[test]
     fn dispatch_policy_type() {
         let mut storage = HashMapStorageProvider::new(1);
-        activate_policy_registry(&mut storage);
+        activate_and_init(&mut storage);
 
         let calldata =
             IPolicyRegistry::policyTypeCall { policyId: PolicyRegistryStorage::ALWAYS_ALLOW_ID }
@@ -332,7 +346,7 @@ mod tests {
         .unwrap();
         assert!(!out.reverted);
         let pt = IPolicyRegistry::policyTypeCall::abi_decode_returns(&out.bytes).unwrap();
-        assert_eq!(pt, IPolicyRegistry::PolicyType::ALWAYS_ALLOW);
+        assert_eq!(pt, IPolicyRegistry::PolicyType::BLOCKLIST);
     }
 
     #[test]

--- a/crates/common/precompiles/src/policy/handle.rs
+++ b/crates/common/precompiles/src/policy/handle.rs
@@ -113,10 +113,7 @@ mod tests {
     fn storage() -> HashMapStorageProvider {
         let mut s = HashMapStorageProvider::new(1);
         s.set_caller(ADMIN);
-        StorageCtx::enter(&mut s, |ctx| {
-            PolicyRegistryStorage::new(ctx).write_builtins()
-        })
-        .unwrap();
+        StorageCtx::enter(&mut s, |ctx| PolicyRegistryStorage::new(ctx).write_builtins()).unwrap();
         s
     }
 

--- a/crates/common/precompiles/src/policy/handle.rs
+++ b/crates/common/precompiles/src/policy/handle.rs
@@ -113,6 +113,10 @@ mod tests {
     fn storage() -> HashMapStorageProvider {
         let mut s = HashMapStorageProvider::new(1);
         s.set_caller(ADMIN);
+        StorageCtx::enter(&mut s, |ctx| {
+            PolicyRegistryStorage::new(ctx).write_builtins()
+        })
+        .unwrap();
         s
     }
 
@@ -183,11 +187,11 @@ mod tests {
             let handle = PolicyHandle::new(ctx);
             assert_eq!(
                 handle.get_policy_type(PolicyRegistryStorage::ALWAYS_ALLOW_ID).unwrap(),
-                IPolicyRegistry::PolicyType::ALWAYS_ALLOW
+                IPolicyRegistry::PolicyType::BLOCKLIST
             );
             assert_eq!(
                 handle.get_policy_type(PolicyRegistryStorage::ALWAYS_BLOCK_ID).unwrap(),
-                IPolicyRegistry::PolicyType::ALWAYS_BLOCK
+                IPolicyRegistry::PolicyType::ALLOWLIST
             );
         });
     }

--- a/crates/common/precompiles/src/policy/storage.rs
+++ b/crates/common/precompiles/src/policy/storage.rs
@@ -373,15 +373,6 @@ impl PolicyRegistryStorage<'_> {
     /// Returns the `PolicyType` of `policy_id`.
     pub fn get_policy_type(&self, policy_id: u64) -> Result<PolicyType> {
         Self::require_well_formed(policy_id)?;
-        // Fast-path for built-in IDs: both encode the correct type in their high byte
-        // (ALWAYS_ALLOW_ID=0 → BLOCKLIST=0, ALWAYS_BLOCK_ID=(1<<56)|1 → ALLOWLIST=1),
-        // but the storage slot may be zero before write_builtins() has been called,
-        // but the storage slot may not have the exists flag set before write_builtins() is called,
-        // so we skip the exists check for them.
-        if policy_id == Self::ALWAYS_ALLOW_ID || policy_id == Self::ALWAYS_BLOCK_ID {
-            return PolicyType::try_from(Self::policy_id_type(policy_id))
-                .map_err(|_| BasePrecompileError::enum_conversion_error());
-        }
         let packed = PackedPolicy::from_raw(self.policies.at(&policy_id).read()?);
         if !packed.exists() {
             return Err(BasePrecompileError::revert(IPolicyRegistry::PolicyNotFound {}));

--- a/crates/common/precompiles/src/policy/storage.rs
+++ b/crates/common/precompiles/src/policy/storage.rs
@@ -369,16 +369,6 @@ impl PolicyRegistryStorage<'_> {
         }
     }
 
-    /// Returns the policy ID that would be assigned to the next policy of `policy_type`.
-    ///
-    /// The counter is global across all policy types, so this is a hint only — the counter
-    /// may advance between this query and the subsequent `create_policy` call.
-    pub fn next_policy_id(&self, policy_type: PolicyType) -> Result<u64> {
-        let discriminant = policy_type.as_discriminant()?;
-        let counter = self.next_counter()?;
-        Ok(Self::make_id(discriminant, counter))
-    }
-
     /// Returns `true` if `policy_id` refers to an existing or built-in policy.
     pub fn policy_exists(&self, policy_id: u64) -> Result<bool> {
         Self::require_well_formed(policy_id)?;

--- a/crates/common/precompiles/src/policy/storage.rs
+++ b/crates/common/precompiles/src/policy/storage.rs
@@ -363,12 +363,9 @@ impl PolicyRegistryStorage<'_> {
         }
     }
 
-    /// Returns `true` if `policy_id` refers to an existing or built-in policy.
+    /// Returns `true` if `policy_id` refers to an existing policy.
     pub fn policy_exists(&self, policy_id: u64) -> Result<bool> {
         Self::require_well_formed(policy_id)?;
-        if policy_id == Self::ALWAYS_ALLOW_ID || policy_id == Self::ALWAYS_BLOCK_ID {
-            return Ok(true);
-        }
         let packed = PackedPolicy::from_raw(self.policies.at(&policy_id).read()?);
         Ok(packed.exists())
     }
@@ -396,11 +393,6 @@ impl PolicyRegistryStorage<'_> {
     /// Returns the current admin of `policy_id`, or `address(0)` for policies with renounced admin.
     pub fn get_policy_admin(&self, policy_id: u64) -> Result<Address> {
         Self::require_well_formed(policy_id)?;
-        // Built-ins have a permanently renounced (zero) admin; fast-path so this works
-        // even before write_builtins() has been called.
-        if policy_id == Self::ALWAYS_ALLOW_ID || policy_id == Self::ALWAYS_BLOCK_ID {
-            return Ok(Address::ZERO);
-        }
         let packed = PackedPolicy::from_raw(self.policies.at(&policy_id).read()?);
         if !packed.exists() {
             return Err(BasePrecompileError::revert(IPolicyRegistry::PolicyNotFound {}));
@@ -411,11 +403,6 @@ impl PolicyRegistryStorage<'_> {
     /// Returns the pending admin staged for `policy_id`, or `address(0)` if none.
     pub fn pending_policy_admin(&self, policy_id: u64) -> Result<Address> {
         Self::require_well_formed(policy_id)?;
-        // Built-ins can never have a pending admin; fast-path so this works
-        // even before write_builtins() has been called.
-        if policy_id == Self::ALWAYS_ALLOW_ID || policy_id == Self::ALWAYS_BLOCK_ID {
-            return Ok(Address::ZERO);
-        }
         self.pending_admins.at(&policy_id).read()
     }
 }

--- a/crates/common/precompiles/src/policy/storage.rs
+++ b/crates/common/precompiles/src/policy/storage.rs
@@ -38,8 +38,8 @@ impl PackedPolicy {
         Address::from_slice(&bytes[12..])
     }
 
-    fn is_zero(self) -> bool {
-        self.0.is_zero()
+    fn exists(self) -> bool {
+        !(self.0 & Self::EXISTS_BIT).is_zero()
     }
 
     const fn into_u256(self) -> U256 {
@@ -84,6 +84,8 @@ impl PolicyRegistryStorage<'_> {
     const BLOCKLIST_TYPE: u8 = PolicyType::BLOCKLIST as u8;
     const COUNTER_MASK: u64 = (1u64 << 56) - 1;
     const POLICY_ID_TYPE_SHIFT: usize = 56;
+    /// Number of built-in policies; the counter is set to this value after write_builtins().
+    const BUILTIN_POLICY_COUNT: u64 = 2;
 
     fn require_write(&self) -> Result<()> {
         if self.storage.is_static() {
@@ -108,7 +110,7 @@ impl PolicyRegistryStorage<'_> {
     fn require_custom(&self, policy_id: u64) -> Result<PackedPolicy> {
         Self::require_well_formed(policy_id)?;
         let packed = PackedPolicy::from_raw(self.policies.at(&policy_id).read()?);
-        if packed.is_zero() {
+        if !packed.exists() {
             return Err(BasePrecompileError::revert(IPolicyRegistry::PolicyNotFound {}));
         }
         Ok(packed)
@@ -142,15 +144,23 @@ impl PolicyRegistryStorage<'_> {
     /// - `ALWAYS_ALLOW_ID` (counter=0, BLOCKLIST): no members blocked — everyone is authorized.
     /// - `ALWAYS_BLOCK_ID` (counter=1, ALLOWLIST): no members allowed — nobody is authorized.
     pub fn write_builtins(&mut self) -> Result<()> {
-        if self.next_counter.read()? > 0 {
+        if self.next_counter.read()? >= Self::BUILTIN_POLICY_COUNT {
             return Ok(());
         }
+        // Assert that the ID constants match the enum discriminants and counter slots,
+        // catching any future drift from enum reordering or constant changes.
+        debug_assert_eq!(
+            Self::make_id(PolicyType::BLOCKLIST.as_discriminant(), 0),
+            Self::ALWAYS_ALLOW_ID
+        );
+        debug_assert_eq!(
+            Self::make_id(PolicyType::ALLOWLIST.as_discriminant(), 1),
+            Self::ALWAYS_BLOCK_ID
+        );
         let builtin = PackedPolicy::new(Address::ZERO).into_u256();
-        // counter=0 → BLOCKLIST → ALWAYS_ALLOW_ID=0
         self.policies.at_mut(&Self::ALWAYS_ALLOW_ID).write(builtin)?;
-        // counter=1 → ALLOWLIST → ALWAYS_BLOCK_ID=(1<<56)|1
         self.policies.at_mut(&Self::ALWAYS_BLOCK_ID).write(builtin)?;
-        self.next_counter.write(2)?;
+        self.next_counter.write(Self::BUILTIN_POLICY_COUNT)?;
         Ok(())
     }
 
@@ -342,7 +352,7 @@ impl PolicyRegistryStorage<'_> {
             return Ok(false);
         }
         let packed = PackedPolicy::from_raw(self.policies.at(&policy_id).read()?);
-        if packed.is_zero() {
+        if !packed.exists() {
             return Err(BasePrecompileError::revert(IPolicyRegistry::PolicyNotFound {}));
         }
         let member = self.members.at(&policy_id).at(&account).read()?;
@@ -360,7 +370,7 @@ impl PolicyRegistryStorage<'_> {
             return Ok(true);
         }
         let packed = PackedPolicy::from_raw(self.policies.at(&policy_id).read()?);
-        Ok(!packed.is_zero())
+        Ok(packed.exists())
     }
 
     /// Returns the `PolicyType` of `policy_id`.
@@ -369,13 +379,14 @@ impl PolicyRegistryStorage<'_> {
         // Fast-path for built-in IDs: both encode the correct type in their high byte
         // (ALWAYS_ALLOW_ID=0 → BLOCKLIST=0, ALWAYS_BLOCK_ID=(1<<56)|1 → ALLOWLIST=1),
         // but the storage slot may be zero before write_builtins() has been called,
-        // so we skip the is_zero check for them.
+        // but the storage slot may not have the exists flag set before write_builtins() is called,
+        // so we skip the exists check for them.
         if policy_id == Self::ALWAYS_ALLOW_ID || policy_id == Self::ALWAYS_BLOCK_ID {
             return PolicyType::try_from(Self::policy_id_type(policy_id))
                 .map_err(|_| BasePrecompileError::enum_conversion_error());
         }
         let packed = PackedPolicy::from_raw(self.policies.at(&policy_id).read()?);
-        if packed.is_zero() {
+        if !packed.exists() {
             return Err(BasePrecompileError::revert(IPolicyRegistry::PolicyNotFound {}));
         }
         PolicyType::try_from(Self::policy_id_type(policy_id))
@@ -385,8 +396,13 @@ impl PolicyRegistryStorage<'_> {
     /// Returns the current admin of `policy_id`, or `address(0)` for policies with renounced admin.
     pub fn get_policy_admin(&self, policy_id: u64) -> Result<Address> {
         Self::require_well_formed(policy_id)?;
+        // Built-ins have a permanently renounced (zero) admin; fast-path so this works
+        // even before write_builtins() has been called.
+        if policy_id == Self::ALWAYS_ALLOW_ID || policy_id == Self::ALWAYS_BLOCK_ID {
+            return Ok(Address::ZERO);
+        }
         let packed = PackedPolicy::from_raw(self.policies.at(&policy_id).read()?);
-        if packed.is_zero() {
+        if !packed.exists() {
             return Err(BasePrecompileError::revert(IPolicyRegistry::PolicyNotFound {}));
         }
         Ok(packed.admin())
@@ -395,6 +411,11 @@ impl PolicyRegistryStorage<'_> {
     /// Returns the pending admin staged for `policy_id`, or `address(0)` if none.
     pub fn pending_policy_admin(&self, policy_id: u64) -> Result<Address> {
         Self::require_well_formed(policy_id)?;
+        // Built-ins can never have a pending admin; fast-path so this works
+        // even before write_builtins() has been called.
+        if policy_id == Self::ALWAYS_ALLOW_ID || policy_id == Self::ALWAYS_BLOCK_ID {
+            return Ok(Address::ZERO);
+        }
         self.pending_admins.at(&policy_id).read()
     }
 }
@@ -481,20 +502,20 @@ mod tests {
     fn packed_policy_new_roundtrips_admin() {
         let p = PackedPolicy::new(ADMIN);
         assert_eq!(p.admin(), ADMIN);
-        assert!(!p.is_zero());
+        assert!(p.exists());
     }
 
     #[test]
     fn packed_policy_zero_signals_never_created() {
         let p = PackedPolicy::from_raw(U256::ZERO);
-        assert!(p.is_zero());
+        assert!(!p.exists());
     }
 
     #[test]
     fn packed_policy_zero_admin_is_non_zero() {
-        // Created flag at bit 0 keeps the word non-zero even with zero admin.
+        // Exists flag at bit 160 keeps the word non-zero even with zero admin.
         let p = PackedPolicy::new(Address::ZERO);
-        assert!(!p.is_zero());
+        assert!(p.exists());
         assert_eq!(p.admin(), Address::ZERO);
     }
 

--- a/crates/common/precompiles/src/policy/storage.rs
+++ b/crates/common/precompiles/src/policy/storage.rs
@@ -171,7 +171,7 @@ impl PolicyRegistryStorage<'_> {
     /// Creates a new ALLOWLIST or BLOCKLIST policy, returning its encoded ID.
     pub fn create_policy(&mut self, admin: Address, policy_type: PolicyType) -> Result<u64> {
         self.require_write()?;
-        let policy_type_u8 = policy_type.as_discriminant()?;
+        let policy_type_u8 = policy_type.as_discriminant();
         if admin == Address::ZERO {
             return Err(BasePrecompileError::revert(IPolicyRegistry::ZeroAddress {}));
         }
@@ -215,7 +215,7 @@ impl PolicyRegistryStorage<'_> {
         accounts: Vec<Address>,
     ) -> Result<u64> {
         let policy_id = self.create_policy(admin, policy_type)?;
-        let policy_type_u8 = policy_type.as_discriminant()?;
+        let policy_type_u8 = policy_type.as_discriminant();
         let caller = self.storage.caller();
         for account in &accounts {
             self.members.at_mut(&policy_id).at_mut(account).write(true)?;

--- a/crates/common/precompiles/src/policy/storage.rs
+++ b/crates/common/precompiles/src/policy/storage.rs
@@ -130,17 +130,6 @@ impl PolicyRegistryStorage<'_> {
         Ok((packed, caller))
     }
 
-    /// Assigns the next counter slot to a built-in policy with zero (renounced) admin.
-    fn create_builtin_policy(&mut self, policy_type: PolicyType) -> Result<u64> {
-        let policy_type_u8 = policy_type.as_discriminant();
-        let counter = self.next_counter.read()?;
-        let next = counter.checked_add(1).ok_or_else(BasePrecompileError::under_overflow)?;
-        self.next_counter.write(next)?;
-        let policy_id = Self::make_id(policy_type_u8, counter);
-        self.policies.at_mut(&policy_id).write(PackedPolicy::new(Address::ZERO).into_u256())?;
-        Ok(policy_id)
-    }
-
     /// Writes the two built-in policies into the `policies` mapping.
     ///
     /// Consumes counters 0 and 1, leaving the counter at 2 so custom policies
@@ -152,8 +141,12 @@ impl PolicyRegistryStorage<'_> {
         if self.next_counter.read()? > 0 {
             return Ok(());
         }
-        self.create_builtin_policy(PolicyType::BLOCKLIST)?;
-        self.create_builtin_policy(PolicyType::ALLOWLIST)?;
+        let builtin = PackedPolicy::new(Address::ZERO).into_u256();
+        // counter=0 → BLOCKLIST → ALWAYS_ALLOW_ID=0
+        self.policies.at_mut(&Self::ALWAYS_ALLOW_ID).write(builtin)?;
+        // counter=1 → ALLOWLIST → ALWAYS_BLOCK_ID=(1<<56)|1
+        self.policies.at_mut(&Self::ALWAYS_BLOCK_ID).write(builtin)?;
+        self.next_counter.write(2)?;
         Ok(())
     }
 
@@ -220,7 +213,7 @@ impl PolicyRegistryStorage<'_> {
                 blocked: true,
                 accounts,
             })?,
-            _ => unreachable!("policy_type validated by create_policy"),
+            _ => return Err(BasePrecompileError::revert(IPolicyRegistry::InvalidPolicyType {})),
         }
         Ok(policy_id)
     }
@@ -524,8 +517,7 @@ mod tests {
     fn storage() -> HashMapStorageProvider {
         let mut s = HashMapStorageProvider::new(1);
         s.set_caller(ADMIN);
-        StorageCtx::enter(&mut s, |ctx| PolicyRegistryStorage::new(ctx).write_builtins())
-            .unwrap();
+        StorageCtx::enter(&mut s, |ctx| PolicyRegistryStorage::new(ctx).write_builtins()).unwrap();
         s
     }
 
@@ -1035,7 +1027,9 @@ mod tests {
     fn builtin_policies_reject_admin_mutations() {
         let mut s = storage();
         // Both built-in policies have zero admin, so any caller gets Unauthorized.
-        for policy_id in [PolicyRegistryStorage::ALWAYS_ALLOW_ID, PolicyRegistryStorage::ALWAYS_BLOCK_ID] {
+        for policy_id in
+            [PolicyRegistryStorage::ALWAYS_ALLOW_ID, PolicyRegistryStorage::ALWAYS_BLOCK_ID]
+        {
             let err = StorageCtx::enter(&mut s, |ctx| {
                 PolicyRegistryStorage::new(ctx).stage_update_admin(policy_id, ALICE)
             })

--- a/crates/common/precompiles/src/policy/storage.rs
+++ b/crates/common/precompiles/src/policy/storage.rs
@@ -390,6 +390,9 @@ impl PolicyRegistryStorage<'_> {
     /// Returns the pending admin staged for `policy_id`, or `address(0)` if none.
     pub fn pending_policy_admin(&self, policy_id: u64) -> Result<Address> {
         Self::require_well_formed(policy_id)?;
+        if policy_id == Self::ALWAYS_ALLOW_ID || policy_id == Self::ALWAYS_BLOCK_ID {
+            return Ok(Address::ZERO);
+        }
         self.pending_admins.at(&policy_id).read()
     }
 }

--- a/crates/common/precompiles/src/policy/storage.rs
+++ b/crates/common/precompiles/src/policy/storage.rs
@@ -8,18 +8,17 @@ use super::{IPolicyRegistry, IPolicyRegistry::PolicyType};
 
 /// A packed policy storage word.
 ///
-/// Layout: `[255:161]` reserved (zero) | `[160]` exists flag | `[159:0]` admin (160 bits).
+/// Layout: `[255]` exists flag | `[254:160]` reserved (zero) | `[159:0]` admin (160 bits).
 ///
 /// The policy type is not stored here — it is encoded in the high byte of the policy ID
-/// and derived from there. Bit 160 is always set for any written slot, making the zero word
+/// and derived from there. Bit 255 is always set for any written slot, making the zero word
 /// a reliable "never written" sentinel even when admin is `Address::ZERO`.
-/// The high bytes are always zero, matching the EVM's left-padded address encoding.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct PackedPolicy(U256);
 
 impl PackedPolicy {
-    /// Bit 160: the limb-2 bit at position 32 (160 - 128 = 32).
-    const EXISTS_BIT: U256 = U256::from_limbs([0, 0, 1u64 << 32, 0]);
+    /// Bit 255: the highest bit of limb 3.
+    const EXISTS_BIT: U256 = U256::from_limbs([0, 0, 0, 1u64 << 63]);
     /// Mask covering the low 160 bits where the admin address lives.
     const ADMIN_MASK: U256 = U256::from_limbs([u64::MAX, u64::MAX, 0xFFFF_FFFF, 0]);
 

--- a/crates/common/precompiles/src/policy/storage.rs
+++ b/crates/common/precompiles/src/policy/storage.rs
@@ -84,7 +84,7 @@ impl PolicyRegistryStorage<'_> {
     const BLOCKLIST_TYPE: u8 = PolicyType::BLOCKLIST as u8;
     const COUNTER_MASK: u64 = (1u64 << 56) - 1;
     const POLICY_ID_TYPE_SHIFT: usize = 56;
-    /// Number of built-in policies; the counter is set to this value after write_builtins().
+    /// Number of built-in policies; the counter is set to this value after `write_builtins`.
     const BUILTIN_POLICY_COUNT: u64 = 2;
 
     fn require_write(&self) -> Result<()> {
@@ -168,6 +168,9 @@ impl PolicyRegistryStorage<'_> {
     pub fn create_policy(&mut self, admin: Address, policy_type: PolicyType) -> Result<u64> {
         self.require_write()?;
         let policy_type_u8 = policy_type.as_discriminant();
+        if policy_type_u8 > Self::ALLOWLIST_TYPE {
+            return Err(BasePrecompileError::revert(IPolicyRegistry::InvalidPolicyType {}));
+        }
         if admin == Address::ZERO {
             return Err(BasePrecompileError::revert(IPolicyRegistry::ZeroAddress {}));
         }
@@ -569,6 +572,46 @@ mod tests {
         })
         .unwrap_err();
         assert!(matches!(err, BasePrecompileError::Revert(_)));
+    }
+
+    // --- write_builtins initialization ---
+
+    #[test]
+    fn first_create_policy_initializes_builtins_and_starts_counter_at_two() {
+        // Start from bare storage — write_builtins has NOT been called yet.
+        let mut s = HashMapStorageProvider::new(1);
+        s.set_caller(ADMIN);
+        let id = StorageCtx::enter(&mut s, |ctx| {
+            PolicyRegistryStorage::new(ctx).create_policy(ADMIN, PolicyType::ALLOWLIST)
+        })
+        .unwrap();
+        // Builtins claimed counters 0 and 1; first custom policy gets 2.
+        assert_eq!(id & PolicyRegistryStorage::COUNTER_MASK, 2);
+        // Builtins are now in storage.
+        assert!(
+            StorageCtx::enter(&mut s, |ctx| PolicyRegistryStorage::new(ctx)
+                .policy_exists(PolicyRegistryStorage::ALWAYS_ALLOW_ID))
+            .unwrap()
+        );
+        assert!(
+            StorageCtx::enter(&mut s, |ctx| PolicyRegistryStorage::new(ctx)
+                .policy_exists(PolicyRegistryStorage::ALWAYS_BLOCK_ID))
+            .unwrap()
+        );
+    }
+
+    #[test]
+    fn write_builtins_is_idempotent() {
+        let mut s = HashMapStorageProvider::new(1);
+        for _ in 0..3 {
+            StorageCtx::enter(&mut s, |ctx| PolicyRegistryStorage::new(ctx).write_builtins())
+                .unwrap();
+        }
+        // Counter must be exactly BUILTIN_POLICY_COUNT regardless of how many times called.
+        let counter =
+            StorageCtx::enter(&mut s, |ctx| PolicyRegistryStorage::new(ctx).next_counter.read())
+                .unwrap();
+        assert_eq!(counter, PolicyRegistryStorage::BUILTIN_POLICY_COUNT);
     }
 
     // --- createPolicy ---

--- a/crates/common/precompiles/src/policy/storage.rs
+++ b/crates/common/precompiles/src/policy/storage.rs
@@ -14,7 +14,7 @@ use super::{IPolicyRegistry, IPolicyRegistry::PolicyType};
 /// `is_zero()` reliable as a "never written" sentinel even for BLOCKLIST (discriminant 0)
 /// policies whose admin has been renounced to `Address::ZERO`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) struct PackedPolicy(U256);
+struct PackedPolicy(U256);
 
 impl PackedPolicy {
     /// Bit position of the "exists" flag. Always set for any initialized policy slot.
@@ -22,40 +22,40 @@ impl PackedPolicy {
 
     /// Packs `admin` and `policy_type` into a storage word.
     /// Accepts `PolicyType` to prevent invalid discriminants at construction time.
-    pub(crate) fn new(admin: Address, policy_type: PolicyType) -> Self {
+    fn new(admin: Address, policy_type: PolicyType) -> Self {
         Self::from_parts(admin, policy_type as u8)
     }
 
     /// Returns a new word with the same type byte but a different admin.
     /// Used when transferring or renouncing admin without changing the policy type.
-    pub(crate) fn with_admin(self, new_admin: Address) -> Self {
+    fn with_admin(self, new_admin: Address) -> Self {
         Self::from_parts(new_admin, self.policy_type_u8())
     }
 
     /// Returns the admin address stored in `[167:8]`.
-    pub(crate) fn admin(self) -> Address {
+    fn admin(self) -> Address {
         let bytes = (self.0 >> 8usize).to_be_bytes::<32>();
         Address::from_slice(&bytes[12..])
     }
 
     /// Returns the raw `PolicyType` discriminant stored in `[7:0]`.
-    pub(crate) const fn policy_type_u8(self) -> u8 {
+    const fn policy_type_u8(self) -> u8 {
         self.0.to_be_bytes::<32>()[31]
     }
 
     /// Returns `true` if the word is zero (policy slot was never written).
-    pub(crate) fn is_zero(self) -> bool {
+    fn is_zero(self) -> bool {
         self.0.is_zero()
     }
 
     /// Returns the raw `U256` value for writing to storage.
-    pub(crate) const fn into_u256(self) -> U256 {
+    const fn into_u256(self) -> U256 {
         self.0
     }
 
     /// Wraps a raw storage word without validating the type discriminant.
     /// Intended only for reading words back from storage.
-    pub(crate) const fn from_raw(v: U256) -> Self {
+    const fn from_raw(v: U256) -> Self {
         Self(v)
     }
 
@@ -101,7 +101,7 @@ impl PolicyRegistryStorage<'_> {
 
     const ALLOWLIST_TYPE: u8 = PolicyType::ALLOWLIST as u8;
     const BLOCKLIST_TYPE: u8 = PolicyType::BLOCKLIST as u8;
-    pub(crate) const COUNTER_MASK: u64 = (1u64 << 56) - 1;
+    const COUNTER_MASK: u64 = (1u64 << 56) - 1;
     const INITIAL_CUSTOM_COUNTER: u64 = 2;
     const POLICY_ID_TYPE_SHIFT: usize = 56;
 
@@ -160,7 +160,7 @@ impl PolicyRegistryStorage<'_> {
     /// Both have a renounced (zero) admin so they are permanently immutable.
     /// - `ALWAYS_ALLOW_ID`: BLOCKLIST with no members — everyone is authorized.
     /// - `ALWAYS_BLOCK_ID`: ALLOWLIST with no members — nobody is authorized.
-    pub(crate) fn write_builtins(&mut self) -> Result<()> {
+    pub fn write_builtins(&mut self) -> Result<()> {
         let allow_packed = PackedPolicy::new(Address::ZERO, PolicyType::BLOCKLIST).into_u256();
         self.policies.at_mut(&Self::ALWAYS_ALLOW_ID).write(allow_packed)?;
         let block_packed = PackedPolicy::new(Address::ZERO, PolicyType::ALLOWLIST).into_u256();

--- a/crates/common/precompiles/src/policy/storage.rs
+++ b/crates/common/precompiles/src/policy/storage.rs
@@ -344,9 +344,8 @@ impl PolicyRegistryStorage<'_> {
     /// Returns `true` if `account` is authorized under `policy_id`.
     pub fn is_authorized(&self, policy_id: u64, account: Address) -> Result<bool> {
         Self::require_well_formed(policy_id)?;
-        // Fast-paths for built-in IDs: these are semantically defined without storage
-        // and must work even before write_builtins() has been called (e.g. a token
-        // whose policy was set to ALWAYS_BLOCK_ID before any custom policy was created).
+        // Fast-paths for built-in IDs: ALWAYS_ALLOW_ID = 0 is the EVM default for any
+        // uninitialized policy field, so this must work before write_builtins() has run.
         if policy_id == Self::ALWAYS_ALLOW_ID {
             return Ok(true);
         }

--- a/crates/common/precompiles/src/policy/storage.rs
+++ b/crates/common/precompiles/src/policy/storage.rs
@@ -8,64 +8,42 @@ use super::{IPolicyRegistry, IPolicyRegistry::PolicyType};
 
 /// A packed policy storage word.
 ///
-/// Layout: `[255:169]` reserved (zero) | `[168]` exists flag | `[167:8]` admin (160 bits) | `[7:0]` `PolicyType`.
+/// Layout: `[255:96]` admin (160 bits) | `[95:1]` reserved (zero) | `[0]` created flag.
 ///
-/// Bit 168 is always set for any created (or initialized built-in) policy. This keeps
-/// `is_zero()` reliable as a "never written" sentinel even for BLOCKLIST (discriminant 0)
-/// policies whose admin has been renounced to `Address::ZERO`.
+/// The policy type is not stored here — it is encoded in the high byte of the policy ID
+/// and derived from there. Bit 0 is always set for any written slot, making the zero word
+/// a reliable "never written" sentinel even when admin is `Address::ZERO`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct PackedPolicy(U256);
 
 impl PackedPolicy {
-    /// Bit position of the "exists" flag. Always set for any initialized policy slot.
-    const EXISTS_BIT: usize = 168;
+    const ADMIN_SHIFT: usize = 96;
 
-    /// Packs `admin` and `policy_type` into a storage word.
-    /// Accepts `PolicyType` to prevent invalid discriminants at construction time.
-    fn new(admin: Address, policy_type: PolicyType) -> Self {
-        Self::from_parts(admin, policy_type as u8)
+    fn new(admin: Address) -> Self {
+        let mut word = [0u8; 32];
+        word[12..32].copy_from_slice(admin.as_slice());
+        Self((U256::from_be_slice(&word) << Self::ADMIN_SHIFT) | U256::from(1u8))
     }
 
-    /// Returns a new word with the same type byte but a different admin.
-    /// Used when transferring or renouncing admin without changing the policy type.
     fn with_admin(self, new_admin: Address) -> Self {
-        Self::from_parts(new_admin, self.policy_type_u8())
+        Self::new(new_admin)
     }
 
-    /// Returns the admin address stored in `[167:8]`.
     fn admin(self) -> Address {
-        let bytes = (self.0 >> 8usize).to_be_bytes::<32>();
+        let bytes = (self.0 >> Self::ADMIN_SHIFT).to_be_bytes::<32>();
         Address::from_slice(&bytes[12..])
     }
 
-    /// Returns the raw `PolicyType` discriminant stored in `[7:0]`.
-    const fn policy_type_u8(self) -> u8 {
-        self.0.to_be_bytes::<32>()[31]
-    }
-
-    /// Returns `true` if the word is zero (policy slot was never written).
     fn is_zero(self) -> bool {
         self.0.is_zero()
     }
 
-    /// Returns the raw `U256` value for writing to storage.
     const fn into_u256(self) -> U256 {
         self.0
     }
 
-    /// Wraps a raw storage word without validating the type discriminant.
-    /// Intended only for reading words back from storage.
     const fn from_raw(v: U256) -> Self {
         Self(v)
-    }
-
-    fn from_parts(admin: Address, policy_type_u8: u8) -> Self {
-        let mut word = [0u8; 32];
-        word[12..32].copy_from_slice(admin.as_slice());
-        let packed = (U256::from_be_slice(&word) << 8) | U256::from(policy_type_u8);
-        // Set the exists bit so that (zero admin, BLOCKLIST type=0) is non-zero and distinguishable
-        // from a slot that was never written (raw zero word).
-        Self(packed | (U256::from(1u64) << Self::EXISTS_BIT))
     }
 }
 
@@ -161,10 +139,9 @@ impl PolicyRegistryStorage<'_> {
     /// - `ALWAYS_ALLOW_ID`: BLOCKLIST with no members — everyone is authorized.
     /// - `ALWAYS_BLOCK_ID`: ALLOWLIST with no members — nobody is authorized.
     pub fn write_builtins(&mut self) -> Result<()> {
-        let allow_packed = PackedPolicy::new(Address::ZERO, PolicyType::BLOCKLIST).into_u256();
-        self.policies.at_mut(&Self::ALWAYS_ALLOW_ID).write(allow_packed)?;
-        let block_packed = PackedPolicy::new(Address::ZERO, PolicyType::ALLOWLIST).into_u256();
-        self.policies.at_mut(&Self::ALWAYS_BLOCK_ID).write(block_packed)?;
+        let builtin = PackedPolicy::new(Address::ZERO).into_u256();
+        self.policies.at_mut(&Self::ALWAYS_ALLOW_ID).write(builtin)?;
+        self.policies.at_mut(&Self::ALWAYS_BLOCK_ID).write(builtin)?;
         Ok(())
     }
 
@@ -189,8 +166,7 @@ impl PolicyRegistryStorage<'_> {
         let next = counter.checked_add(1).ok_or_else(BasePrecompileError::under_overflow)?;
         self.next_counter.write(next)?;
         let policy_id = Self::make_id(policy_type_u8, counter);
-        let packed = PackedPolicy::new(admin, policy_type).into_u256();
-        self.policies.at_mut(&policy_id).write(packed)?;
+        self.policies.at_mut(&policy_id).write(PackedPolicy::new(admin).into_u256())?;
 
         let caller = self.storage.caller();
         self.emit_event(IPolicyRegistry::PolicyCreated {
@@ -215,19 +191,18 @@ impl PolicyRegistryStorage<'_> {
         accounts: Vec<Address>,
     ) -> Result<u64> {
         let policy_id = self.create_policy(admin, policy_type)?;
-        let policy_type_u8 = policy_type.as_discriminant();
         let caller = self.storage.caller();
         for account in &accounts {
             self.members.at_mut(&policy_id).at_mut(account).write(true)?;
         }
-        match policy_type_u8 {
-            Self::ALLOWLIST_TYPE => self.emit_event(IPolicyRegistry::AllowlistUpdated {
+        match policy_type {
+            PolicyType::ALLOWLIST => self.emit_event(IPolicyRegistry::AllowlistUpdated {
                 policyId: policy_id,
                 updater: caller,
                 allowed: true,
                 accounts,
             })?,
-            Self::BLOCKLIST_TYPE => self.emit_event(IPolicyRegistry::BlocklistUpdated {
+            PolicyType::BLOCKLIST => self.emit_event(IPolicyRegistry::BlocklistUpdated {
                 policyId: policy_id,
                 updater: caller,
                 blocked: true,
@@ -331,8 +306,8 @@ impl PolicyRegistryStorage<'_> {
         add: bool,
         accounts: &[Address],
     ) -> Result<Address> {
-        let (packed, caller) = self.require_admin(policy_id)?;
-        if packed.policy_type_u8() != expected_type {
+        let (_, caller) = self.require_admin(policy_id)?;
+        if Self::policy_id_type(policy_id) != expected_type {
             return Err(BasePrecompileError::revert(IPolicyRegistry::IncompatiblePolicyType {}));
         }
         for account in accounts {
@@ -362,7 +337,7 @@ impl PolicyRegistryStorage<'_> {
             return Err(BasePrecompileError::revert(IPolicyRegistry::PolicyNotFound {}));
         }
         let member = self.members.at(&policy_id).at(&account).read()?;
-        match packed.policy_type_u8() {
+        match Self::policy_id_type(policy_id) {
             Self::ALLOWLIST_TYPE => Ok(member),
             Self::BLOCKLIST_TYPE => Ok(!member),
             _ => Err(BasePrecompileError::enum_conversion_error()),
@@ -395,7 +370,7 @@ impl PolicyRegistryStorage<'_> {
         if packed.is_zero() {
             return Err(BasePrecompileError::revert(IPolicyRegistry::PolicyNotFound {}));
         }
-        PolicyType::try_from(packed.policy_type_u8())
+        PolicyType::try_from(Self::policy_id_type(policy_id))
             .map_err(|_| BasePrecompileError::enum_conversion_error())
     }
 
@@ -498,10 +473,9 @@ mod tests {
     // --- PackedPolicy unit tests ---
 
     #[test]
-    fn packed_policy_new_roundtrips_admin_and_type() {
-        let p = PackedPolicy::new(ADMIN, PolicyType::ALLOWLIST);
+    fn packed_policy_new_roundtrips_admin() {
+        let p = PackedPolicy::new(ADMIN);
         assert_eq!(p.admin(), ADMIN);
-        assert_eq!(p.policy_type_u8(), PolicyType::ALLOWLIST as u8);
         assert!(!p.is_zero());
     }
 
@@ -512,39 +486,25 @@ mod tests {
     }
 
     #[test]
-    fn packed_policy_renounced_admin_is_non_zero() {
-        // ALLOWLIST (discriminant 1) with zero admin: exists bit keeps the word non-zero.
-        let p = PackedPolicy::new(Address::ZERO, PolicyType::ALLOWLIST);
+    fn packed_policy_zero_admin_is_non_zero() {
+        // Created flag at bit 0 keeps the word non-zero even with zero admin.
+        let p = PackedPolicy::new(Address::ZERO);
         assert!(!p.is_zero());
         assert_eq!(p.admin(), Address::ZERO);
-        assert_eq!(p.policy_type_u8(), PolicyType::ALLOWLIST as u8);
-    }
-
-    #[test]
-    fn packed_policy_blocklist_zero_admin_is_non_zero() {
-        // BLOCKLIST (discriminant 0) with zero admin: exists bit prevents false "never created" signal.
-        let p = PackedPolicy::new(Address::ZERO, PolicyType::BLOCKLIST);
-        assert!(!p.is_zero(), "BLOCKLIST with zero admin must be non-zero due to exists bit");
-        assert_eq!(p.admin(), Address::ZERO);
-        assert_eq!(p.policy_type_u8(), PolicyType::BLOCKLIST as u8);
     }
 
     #[test]
     fn packed_policy_into_u256_from_raw_roundtrip() {
-        let p = PackedPolicy::new(ADMIN, PolicyType::BLOCKLIST);
+        let p = PackedPolicy::new(ADMIN);
         let p2 = PackedPolicy::from_raw(p.into_u256());
         assert_eq!(p, p2);
         assert_eq!(p2.admin(), ADMIN);
-        assert_eq!(p2.policy_type_u8(), PolicyType::BLOCKLIST as u8);
     }
 
     #[test]
     fn packed_policy_different_admins_produce_different_words() {
         let other = address!("0x2000000000000000000000000000000000000002");
-        assert_ne!(
-            PackedPolicy::new(ADMIN, PolicyType::ALLOWLIST),
-            PackedPolicy::new(other, PolicyType::ALLOWLIST)
-        );
+        assert_ne!(PackedPolicy::new(ADMIN), PackedPolicy::new(other));
     }
 
     const ADMIN: Address = address!("0x1000000000000000000000000000000000000001");

--- a/crates/common/precompiles/src/policy/storage.rs
+++ b/crates/common/precompiles/src/policy/storage.rs
@@ -67,20 +67,18 @@ impl PolicyRegistryStorage<'_> {
     pub const ADDRESS: Address = address!("b030000000000000000000000000000000000000");
 
     /// Built-in policy ID that always authorizes every account.
-    /// Semantically a BLOCKLIST with no blocked members; handled via a fast-path
-    /// in all query methods so it works without registry initialization.
+    /// Encoded as BLOCKLIST (type=0) with counter=0 — an empty blocklist authorizes everyone.
     /// Also the EVM zero default: zero-initialized policy ID fields map here.
     pub const ALWAYS_ALLOW_ID: u64 = 0;
 
     /// Built-in policy ID that always rejects every account.
-    /// Encoded as ALLOWLIST (type=0) with counter=1 and an empty member set,
+    /// Encoded as ALLOWLIST (type=1) with counter=1 and an empty member set,
     /// so no account is on the allowlist and nobody passes.
-    pub const ALWAYS_BLOCK_ID: u64 = 1;
+    pub const ALWAYS_BLOCK_ID: u64 = (1u64 << Self::POLICY_ID_TYPE_SHIFT) | 1;
 
     const ALLOWLIST_TYPE: u8 = PolicyType::ALLOWLIST as u8;
     const BLOCKLIST_TYPE: u8 = PolicyType::BLOCKLIST as u8;
     const COUNTER_MASK: u64 = (1u64 << 56) - 1;
-    const INITIAL_CUSTOM_COUNTER: u64 = 2;
     const POLICY_ID_TYPE_SHIFT: usize = 56;
 
     fn require_write(&self) -> Result<()> {
@@ -95,7 +93,7 @@ impl PolicyRegistryStorage<'_> {
     }
 
     fn require_well_formed(policy_id: u64) -> Result<()> {
-        if Self::policy_id_type(policy_id) > PolicyType::BLOCKLIST as u8 {
+        if Self::policy_id_type(policy_id) > PolicyType::ALLOWLIST as u8 {
             return Err(BasePrecompileError::revert(IPolicyRegistry::MalformedPolicyId {
                 policyId: policy_id,
             }));
@@ -113,8 +111,7 @@ impl PolicyRegistryStorage<'_> {
     }
 
     fn next_counter(&self) -> Result<u64> {
-        let counter = self.next_counter.read()?;
-        Ok(counter.max(Self::INITIAL_CUSTOM_COUNTER))
+        self.next_counter.read()
     }
 
     const fn make_id(policy_type: u8, counter: u64) -> u64 {
@@ -133,15 +130,30 @@ impl PolicyRegistryStorage<'_> {
         Ok((packed, caller))
     }
 
+    /// Assigns the next counter slot to a built-in policy with zero (renounced) admin.
+    fn create_builtin_policy(&mut self, policy_type: PolicyType) -> Result<u64> {
+        let policy_type_u8 = policy_type.as_discriminant();
+        let counter = self.next_counter.read()?;
+        let next = counter.checked_add(1).ok_or_else(BasePrecompileError::under_overflow)?;
+        self.next_counter.write(next)?;
+        let policy_id = Self::make_id(policy_type_u8, counter);
+        self.policies.at_mut(&policy_id).write(PackedPolicy::new(Address::ZERO).into_u256())?;
+        Ok(policy_id)
+    }
+
     /// Writes the two built-in policies into the `policies` mapping.
     ///
-    /// Both have a renounced (zero) admin so they are permanently immutable.
-    /// - `ALWAYS_ALLOW_ID`: BLOCKLIST with no members — everyone is authorized.
-    /// - `ALWAYS_BLOCK_ID`: ALLOWLIST with no members — nobody is authorized.
+    /// Consumes counters 0 and 1, leaving the counter at 2 so custom policies
+    /// start there. Both built-ins have a renounced (zero) admin. Idempotent:
+    /// if the counter is already past 0 the builtins were already written.
+    /// - `ALWAYS_ALLOW_ID` (counter=0, BLOCKLIST): no members blocked — everyone is authorized.
+    /// - `ALWAYS_BLOCK_ID` (counter=1, ALLOWLIST): no members allowed — nobody is authorized.
     pub fn write_builtins(&mut self) -> Result<()> {
-        let builtin = PackedPolicy::new(Address::ZERO).into_u256();
-        self.policies.at_mut(&Self::ALWAYS_ALLOW_ID).write(builtin)?;
-        self.policies.at_mut(&Self::ALWAYS_BLOCK_ID).write(builtin)?;
+        if self.next_counter.read()? > 0 {
+            return Ok(());
+        }
+        self.create_builtin_policy(PolicyType::BLOCKLIST)?;
+        self.create_builtin_policy(PolicyType::ALLOWLIST)?;
         Ok(())
     }
 
@@ -357,14 +369,13 @@ impl PolicyRegistryStorage<'_> {
     /// Returns the `PolicyType` of `policy_id`.
     pub fn get_policy_type(&self, policy_id: u64) -> Result<PolicyType> {
         Self::require_well_formed(policy_id)?;
-        // Built-in IDs: return the semantic type directly. ALWAYS_ALLOW_ID=0 has no
-        // meaningful type encoding in its high byte (it's the EVM zero-default), so
-        // we cannot derive the type from the ID; we hardcode it instead.
-        if policy_id == Self::ALWAYS_ALLOW_ID {
-            return Ok(PolicyType::BLOCKLIST);
-        }
-        if policy_id == Self::ALWAYS_BLOCK_ID {
-            return Ok(PolicyType::ALLOWLIST);
+        // Fast-path for built-in IDs: both encode the correct type in their high byte
+        // (ALWAYS_ALLOW_ID=0 → BLOCKLIST=0, ALWAYS_BLOCK_ID=(1<<56)|1 → ALLOWLIST=1),
+        // but the storage slot may be zero before write_builtins() has been called,
+        // so we skip the is_zero check for them.
+        if policy_id == Self::ALWAYS_ALLOW_ID || policy_id == Self::ALWAYS_BLOCK_ID {
+            return PolicyType::try_from(Self::policy_id_type(policy_id))
+                .map_err(|_| BasePrecompileError::enum_conversion_error());
         }
         let packed = PackedPolicy::from_raw(self.policies.at(&policy_id).read()?);
         if packed.is_zero() {
@@ -377,9 +388,6 @@ impl PolicyRegistryStorage<'_> {
     /// Returns the current admin of `policy_id`, or `address(0)` for policies with renounced admin.
     pub fn get_policy_admin(&self, policy_id: u64) -> Result<Address> {
         Self::require_well_formed(policy_id)?;
-        if policy_id == Self::ALWAYS_ALLOW_ID || policy_id == Self::ALWAYS_BLOCK_ID {
-            return Ok(Address::ZERO);
-        }
         let packed = PackedPolicy::from_raw(self.policies.at(&policy_id).read()?);
         if packed.is_zero() {
             return Err(BasePrecompileError::revert(IPolicyRegistry::PolicyNotFound {}));
@@ -390,9 +398,6 @@ impl PolicyRegistryStorage<'_> {
     /// Returns the pending admin staged for `policy_id`, or `address(0)` if none.
     pub fn pending_policy_admin(&self, policy_id: u64) -> Result<Address> {
         Self::require_well_formed(policy_id)?;
-        if policy_id == Self::ALWAYS_ALLOW_ID || policy_id == Self::ALWAYS_BLOCK_ID {
-            return Ok(Address::ZERO);
-        }
         self.pending_admins.at(&policy_id).read()
     }
 }

--- a/crates/common/precompiles/src/policy/storage.rs
+++ b/crates/common/precompiles/src/policy/storage.rs
@@ -8,22 +8,25 @@ use super::{IPolicyRegistry, IPolicyRegistry::PolicyType};
 
 /// A packed policy storage word.
 ///
-/// Layout: `[255:96]` admin (160 bits) | `[95]` exists flag | `[94:0]` reserved (zero).
+/// Layout: `[255:161]` reserved (zero) | `[160]` exists flag | `[159:0]` admin (160 bits).
 ///
 /// The policy type is not stored here — it is encoded in the high byte of the policy ID
-/// and derived from there. Bit 95 is always set for any written slot, making the zero word
+/// and derived from there. Bit 160 is always set for any written slot, making the zero word
 /// a reliable "never written" sentinel even when admin is `Address::ZERO`.
+/// The high bytes are always zero, matching the EVM's left-padded address encoding.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct PackedPolicy(U256);
 
 impl PackedPolicy {
-    const ADMIN_SHIFT: usize = 96;
-    const EXISTS_BIT: U256 = U256::from_limbs([0, 1u64 << 31, 0, 0]); // bit 95
+    /// Bit 160: the limb-2 bit at position 32 (160 - 128 = 32).
+    const EXISTS_BIT: U256 = U256::from_limbs([0, 0, 1u64 << 32, 0]);
+    /// Mask covering the low 160 bits where the admin address lives.
+    const ADMIN_MASK: U256 = U256::from_limbs([u64::MAX, u64::MAX, 0xFFFF_FFFF, 0]);
 
     fn new(admin: Address) -> Self {
         let mut word = [0u8; 32];
         word[12..32].copy_from_slice(admin.as_slice());
-        Self((U256::from_be_slice(&word) << Self::ADMIN_SHIFT) | Self::EXISTS_BIT)
+        Self(U256::from_be_slice(&word) | Self::EXISTS_BIT)
     }
 
     fn with_admin(self, new_admin: Address) -> Self {
@@ -31,7 +34,7 @@ impl PackedPolicy {
     }
 
     fn admin(self) -> Address {
-        let bytes = (self.0 >> Self::ADMIN_SHIFT).to_be_bytes::<32>();
+        let bytes = (self.0 & Self::ADMIN_MASK).to_be_bytes::<32>();
         Address::from_slice(&bytes[12..])
     }
 

--- a/crates/common/precompiles/src/policy/storage.rs
+++ b/crates/common/precompiles/src/policy/storage.rs
@@ -8,21 +8,22 @@ use super::{IPolicyRegistry, IPolicyRegistry::PolicyType};
 
 /// A packed policy storage word.
 ///
-/// Layout: `[255:96]` admin (160 bits) | `[95:1]` reserved (zero) | `[0]` created flag.
+/// Layout: `[255:96]` admin (160 bits) | `[95]` exists flag | `[94:0]` reserved (zero).
 ///
 /// The policy type is not stored here — it is encoded in the high byte of the policy ID
-/// and derived from there. Bit 0 is always set for any written slot, making the zero word
+/// and derived from there. Bit 95 is always set for any written slot, making the zero word
 /// a reliable "never written" sentinel even when admin is `Address::ZERO`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct PackedPolicy(U256);
 
 impl PackedPolicy {
     const ADMIN_SHIFT: usize = 96;
+    const EXISTS_BIT: U256 = U256::from_limbs([0, 1u64 << 31, 0, 0]); // bit 95
 
     fn new(admin: Address) -> Self {
         let mut word = [0u8; 32];
         word[12..32].copy_from_slice(admin.as_slice());
-        Self((U256::from_be_slice(&word) << Self::ADMIN_SHIFT) | U256::from(1u8))
+        Self((U256::from_be_slice(&word) << Self::ADMIN_SHIFT) | Self::EXISTS_BIT)
     }
 
     fn with_admin(self, new_admin: Address) -> Self {

--- a/crates/common/precompiles/src/policy/storage.rs
+++ b/crates/common/precompiles/src/policy/storage.rs
@@ -8,15 +8,18 @@ use super::{IPolicyRegistry, IPolicyRegistry::PolicyType};
 
 /// A packed policy storage word.
 ///
-/// Layout: `[255:168]` reserved (zero) | `[167:8]` admin (160 bits) | `[7:0]` `PolicyType`.
+/// Layout: `[255:169]` reserved (zero) | `[168]` exists flag | `[167:8]` admin (160 bits) | `[7:0]` `PolicyType`.
 ///
-/// The inner value is always non-zero for valid custom policies because ALLOWLIST = 2 and
-/// BLOCKLIST = 3 are both non-zero. This means the zero value reliably signals "never created",
-/// even after `renounce_admin` sets admin to `Address::ZERO` (the type byte is preserved).
+/// Bit 168 is always set for any created (or initialized built-in) policy. This keeps
+/// `is_zero()` reliable as a "never written" sentinel even for BLOCKLIST (discriminant 0)
+/// policies whose admin has been renounced to `Address::ZERO`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct PackedPolicy(U256);
 
 impl PackedPolicy {
+    /// Bit position of the "exists" flag. Always set for any initialized policy slot.
+    const EXISTS_BIT: usize = 168;
+
     /// Packs `admin` and `policy_type` into a storage word.
     /// Accepts `PolicyType` to prevent invalid discriminants at construction time.
     pub(crate) fn new(admin: Address, policy_type: PolicyType) -> Self {
@@ -40,7 +43,7 @@ impl PackedPolicy {
         self.0.to_be_bytes::<32>()[31]
     }
 
-    /// Returns `true` if the word is zero (policy was never created).
+    /// Returns `true` if the word is zero (policy slot was never written).
     pub(crate) fn is_zero(self) -> bool {
         self.0.is_zero()
     }
@@ -59,7 +62,10 @@ impl PackedPolicy {
     fn from_parts(admin: Address, policy_type_u8: u8) -> Self {
         let mut word = [0u8; 32];
         word[12..32].copy_from_slice(admin.as_slice());
-        Self((U256::from_be_slice(&word) << 8) | U256::from(policy_type_u8))
+        let packed = (U256::from_be_slice(&word) << 8) | U256::from(policy_type_u8);
+        // Set the exists bit so that (zero admin, BLOCKLIST type=0) is non-zero and distinguishable
+        // from a slot that was never written (raw zero word).
+        Self(packed | (U256::from(1u64) << Self::EXISTS_BIT))
     }
 }
 
@@ -83,13 +89,19 @@ impl PolicyRegistryStorage<'_> {
     pub const ADDRESS: Address = address!("b030000000000000000000000000000000000000");
 
     /// Built-in policy ID that always authorizes every account.
+    /// Semantically a BLOCKLIST with no blocked members; handled via a fast-path
+    /// in all query methods so it works without registry initialization.
+    /// Also the EVM zero default: zero-initialized policy ID fields map here.
     pub const ALWAYS_ALLOW_ID: u64 = 0;
+
     /// Built-in policy ID that always rejects every account.
+    /// Encoded as ALLOWLIST (type=0) with counter=1 and an empty member set,
+    /// so no account is on the allowlist and nobody passes.
     pub const ALWAYS_BLOCK_ID: u64 = 1;
 
     const ALLOWLIST_TYPE: u8 = PolicyType::ALLOWLIST as u8;
     const BLOCKLIST_TYPE: u8 = PolicyType::BLOCKLIST as u8;
-    const COUNTER_MASK: u64 = (1u64 << 56) - 1;
+    pub(crate) const COUNTER_MASK: u64 = (1u64 << 56) - 1;
     const INITIAL_CUSTOM_COUNTER: u64 = 2;
     const POLICY_ID_TYPE_SHIFT: usize = 56;
 
@@ -143,6 +155,19 @@ impl PolicyRegistryStorage<'_> {
         Ok((packed, caller))
     }
 
+    /// Writes the two built-in policies into the `policies` mapping.
+    ///
+    /// Both have a renounced (zero) admin so they are permanently immutable.
+    /// - `ALWAYS_ALLOW_ID`: BLOCKLIST with no members — everyone is authorized.
+    /// - `ALWAYS_BLOCK_ID`: ALLOWLIST with no members — nobody is authorized.
+    pub(crate) fn write_builtins(&mut self) -> Result<()> {
+        let allow_packed = PackedPolicy::new(Address::ZERO, PolicyType::BLOCKLIST).into_u256();
+        self.policies.at_mut(&Self::ALWAYS_ALLOW_ID).write(allow_packed)?;
+        let block_packed = PackedPolicy::new(Address::ZERO, PolicyType::ALLOWLIST).into_u256();
+        self.policies.at_mut(&Self::ALWAYS_BLOCK_ID).write(block_packed)?;
+        Ok(())
+    }
+
     /// Creates a new ALLOWLIST or BLOCKLIST policy, returning its encoded ID.
     pub fn create_policy(&mut self, admin: Address, policy_type: PolicyType) -> Result<u64> {
         self.require_write()?;
@@ -157,6 +182,7 @@ impl PolicyRegistryStorage<'_> {
         // charges warm/cold account-read gas before skipping repeated `set_code`.
         if !self.is_initialized()? {
             self.__initialize()?;
+            self.write_builtins()?;
         }
 
         let counter = self.next_counter()?;
@@ -322,6 +348,9 @@ impl PolicyRegistryStorage<'_> {
     /// Returns `true` if `account` is authorized under `policy_id`.
     pub fn is_authorized(&self, policy_id: u64, account: Address) -> Result<bool> {
         Self::require_well_formed(policy_id)?;
+        // Fast-paths for built-in IDs: these are semantically defined without storage
+        // and must work even before write_builtins() has been called (e.g. a token
+        // whose policy was set to ALWAYS_BLOCK_ID before any custom policy was created).
         if policy_id == Self::ALWAYS_ALLOW_ID {
             return Ok(true);
         }
@@ -340,6 +369,16 @@ impl PolicyRegistryStorage<'_> {
         }
     }
 
+    /// Returns the policy ID that would be assigned to the next policy of `policy_type`.
+    ///
+    /// The counter is global across all policy types, so this is a hint only — the counter
+    /// may advance between this query and the subsequent `create_policy` call.
+    pub fn next_policy_id(&self, policy_type: PolicyType) -> Result<u64> {
+        let discriminant = policy_type.as_discriminant()?;
+        let counter = self.next_counter()?;
+        Ok(Self::make_id(discriminant, counter))
+    }
+
     /// Returns `true` if `policy_id` refers to an existing or built-in policy.
     pub fn policy_exists(&self, policy_id: u64) -> Result<bool> {
         Self::require_well_formed(policy_id)?;
@@ -350,14 +389,17 @@ impl PolicyRegistryStorage<'_> {
         Ok(!packed.is_zero())
     }
 
-    /// Returns the `PolicyType` of `policy_id`, including built-in IDs.
+    /// Returns the `PolicyType` of `policy_id`.
     pub fn get_policy_type(&self, policy_id: u64) -> Result<PolicyType> {
         Self::require_well_formed(policy_id)?;
+        // Built-in IDs: return the semantic type directly. ALWAYS_ALLOW_ID=0 has no
+        // meaningful type encoding in its high byte (it's the EVM zero-default), so
+        // we cannot derive the type from the ID; we hardcode it instead.
         if policy_id == Self::ALWAYS_ALLOW_ID {
-            return Ok(PolicyType::ALWAYS_ALLOW);
+            return Ok(PolicyType::BLOCKLIST);
         }
         if policy_id == Self::ALWAYS_BLOCK_ID {
-            return Ok(PolicyType::ALWAYS_BLOCK);
+            return Ok(PolicyType::ALLOWLIST);
         }
         let packed = PackedPolicy::from_raw(self.policies.at(&policy_id).read()?);
         if packed.is_zero() {
@@ -367,7 +409,7 @@ impl PolicyRegistryStorage<'_> {
             .map_err(|_| BasePrecompileError::enum_conversion_error())
     }
 
-    /// Returns the current admin of `policy_id`, or `address(0)` for built-in policies.
+    /// Returns the current admin of `policy_id`, or `address(0)` for policies with renounced admin.
     pub fn get_policy_admin(&self, policy_id: u64) -> Result<Address> {
         Self::require_well_formed(policy_id)?;
         if policy_id == Self::ALWAYS_ALLOW_ID || policy_id == Self::ALWAYS_BLOCK_ID {
@@ -383,9 +425,6 @@ impl PolicyRegistryStorage<'_> {
     /// Returns the pending admin staged for `policy_id`, or `address(0)` if none.
     pub fn pending_policy_admin(&self, policy_id: u64) -> Result<Address> {
         Self::require_well_formed(policy_id)?;
-        if policy_id == Self::ALWAYS_ALLOW_ID || policy_id == Self::ALWAYS_BLOCK_ID {
-            return Ok(Address::ZERO);
-        }
         self.pending_admins.at(&policy_id).read()
     }
 }
@@ -484,10 +523,20 @@ mod tests {
 
     #[test]
     fn packed_policy_renounced_admin_is_non_zero() {
+        // ALLOWLIST (discriminant 1) with zero admin: exists bit keeps the word non-zero.
         let p = PackedPolicy::new(Address::ZERO, PolicyType::ALLOWLIST);
         assert!(!p.is_zero());
         assert_eq!(p.admin(), Address::ZERO);
         assert_eq!(p.policy_type_u8(), PolicyType::ALLOWLIST as u8);
+    }
+
+    #[test]
+    fn packed_policy_blocklist_zero_admin_is_non_zero() {
+        // BLOCKLIST (discriminant 0) with zero admin: exists bit prevents false "never created" signal.
+        let p = PackedPolicy::new(Address::ZERO, PolicyType::BLOCKLIST);
+        assert!(!p.is_zero(), "BLOCKLIST with zero admin must be non-zero due to exists bit");
+        assert_eq!(p.admin(), Address::ZERO);
+        assert_eq!(p.policy_type_u8(), PolicyType::BLOCKLIST as u8);
     }
 
     #[test]
@@ -513,9 +562,12 @@ mod tests {
     const BOB: Address = address!("0xB000000000000000000000000000000000000001");
     const NEW_ADMIN: Address = address!("0x2000000000000000000000000000000000000002");
 
+    /// Returns a storage provider with both built-in policies pre-written.
     fn storage() -> HashMapStorageProvider {
         let mut s = HashMapStorageProvider::new(1);
         s.set_caller(ADMIN);
+        StorageCtx::enter(&mut s, |ctx| PolicyRegistryStorage::new(ctx).write_builtins())
+            .unwrap();
         s
     }
 
@@ -573,16 +625,6 @@ mod tests {
         let mut s = storage();
         let err = StorageCtx::enter(&mut s, |ctx| {
             PolicyRegistryStorage::new(ctx).create_policy(Address::ZERO, PolicyType::ALLOWLIST)
-        })
-        .unwrap_err();
-        assert!(matches!(err, BasePrecompileError::Revert(_)));
-    }
-
-    #[test]
-    fn create_policy_invalid_type_reverts() {
-        let mut s = storage();
-        let err = StorageCtx::enter(&mut s, |ctx| {
-            PolicyRegistryStorage::new(ctx).create_policy(ADMIN, PolicyType::ALWAYS_ALLOW)
         })
         .unwrap_err();
         assert!(matches!(err, BasePrecompileError::Revert(_)));
@@ -961,7 +1003,7 @@ mod tests {
                     .get_policy_type(PolicyRegistryStorage::ALWAYS_ALLOW_ID)
             })
             .unwrap(),
-            PolicyType::ALWAYS_ALLOW
+            PolicyType::BLOCKLIST
         );
         assert_eq!(
             StorageCtx::enter(&mut s, |ctx| {
@@ -969,7 +1011,7 @@ mod tests {
                     .get_policy_type(PolicyRegistryStorage::ALWAYS_BLOCK_ID)
             })
             .unwrap(),
-            PolicyType::ALWAYS_BLOCK
+            PolicyType::ALLOWLIST
         );
     }
 
@@ -1027,6 +1069,21 @@ mod tests {
         })
         .unwrap();
         assert_eq!(pending, Address::ZERO);
+    }
+
+    // --- builtin policies block mutations via Unauthorized ---
+
+    #[test]
+    fn builtin_policies_reject_admin_mutations() {
+        let mut s = storage();
+        // Both built-in policies have zero admin, so any caller gets Unauthorized.
+        for policy_id in [PolicyRegistryStorage::ALWAYS_ALLOW_ID, PolicyRegistryStorage::ALWAYS_BLOCK_ID] {
+            let err = StorageCtx::enter(&mut s, |ctx| {
+                PolicyRegistryStorage::new(ctx).stage_update_admin(policy_id, ALICE)
+            })
+            .unwrap_err();
+            assert!(matches!(err, BasePrecompileError::Revert(_)));
+        }
     }
 
     // --- PolicyRegistryTrait delegation ---
@@ -1163,7 +1220,7 @@ mod tests {
             crate::PolicyRegistry::get_policy_type(&reg, PolicyRegistryStorage::ALWAYS_ALLOW_ID)
         })
         .unwrap();
-        assert_eq!(pt, PolicyType::ALWAYS_ALLOW);
+        assert_eq!(pt, PolicyType::BLOCKLIST);
     }
 
     #[test]


### PR DESCRIPTION
[BOP-133](https://linear.app/coinbase/issue/BOP-133)

## Motivation

`PolicyType` had four variants: `ALWAYS_ALLOW`, `ALWAYS_BLOCK`, `ALLOWLIST`, `BLOCKLIST`. The first two were not real types; they were degenerate cases of the latter two with empty member sets. Nobody could create them via `createPolicy`. This made `as_discriminant()` fallible for no reason and required special-casing throughout the storage layer. `PackedPolicy` also stored the type redundantly, since it is already encoded in the high byte of every policy ID.

## What changed

- `PolicyType` reduced to `BLOCKLIST = 0`, `ALLOWLIST = 1`. `as_discriminant()` is now `const fn` and infallible.
- `PackedPolicy` layout: `[255]` exists flag | `[254:160]` reserved | `[159:0]` admin. Type is no longer stored; all callers derive it from `policy_id >> 56`.
- `ALWAYS_ALLOW_ID = 0` (BLOCKLIST, counter 0) and `ALWAYS_BLOCK_ID = (1<<56)|1` (ALLOWLIST, counter 1) now encode their semantic types correctly in their high bytes with no hardcoded special cases.
- Counter starts at 0. `write_builtins` claims counters 0 and 1, sets `next_counter = BUILTIN_POLICY_COUNT (2)`, and is idempotent. `debug_assert_eq!` guards catch future drift between ID constants and enum discriminants.
- `create_policy` now validates the `PolicyType` discriminant is in range, closing a gap where crafted calldata with an out-of-range `uint8` could store a permanently broken policy.
- All five query methods go through storage uniformly. Only `is_authorized` retains builtin fast-paths for the pre-init case where a token policy field defaults to `ALWAYS_ALLOW_ID` before any policy is created.
- Removed dead code: `POLICY_ALWAYS_ALLOW`, `POLICY_ALWAYS_BLOCK`, `is_builtin_policy`.

## What was tried / considered

- **Keeping `ALWAYS_ALLOW`/`ALWAYS_BLOCK` as enum variants**: implies callers can create them, which was never true, and made `as_discriminant()` return `Result` with an unreachable error path.
- **Keeping the type in `PackedPolicy`**: redundant with the ID encoding, and caused a zero-collision between `{type=0, admin=0}` and an unwritten slot.
- **Old `ALLOWLIST = 0` ordering**: required a hardcoded special-case in `get_policy_type` because `ALWAYS_ALLOW_ID = 0` had high byte 0 = ALLOWLIST but semantics of BLOCKLIST. Flipping to `BLOCKLIST = 0` makes both builtin IDs self-describing.