### PR TITLE
fix(common-precompiles): Address B20 Review Followups

### DIFF
--- a/crates/common/precompiles/benches/base_precompiles.rs
+++ b/crates/common/precompiles/benches/base_precompiles.rs
@@ -5,8 +5,9 @@ use std::hint::black_box;
 use alloy_primitives::{Address, B256, U256};
 use alloy_sol_types::SolValue;
 use base_common_precompiles::{
-    B20Token, B20TokenStorage, Burnable, Configurable, IB20, ITokenFactory, Mintable, Pausable,
-    PolicyHandle, Token, TokenAccounting, TokenFactoryStorage, TokenVariant, Transferable,
+    B20DispatchMode, B20Token, B20TokenRole, B20TokenStorage, Burnable, Configurable, IB20,
+    ITokenFactory, Mintable, Pausable, PolicyHandle, RoleManaged, Token, TokenAccounting,
+    TokenFactoryStorage, TokenVariant, Transferable,
 };
 use base_precompile_storage::{HashMapStorageProvider, StorageCtx};
 use criterion::{Criterion, criterion_group, criterion_main};
@@ -63,7 +64,19 @@ impl BaseTokenBenchSetup {
         let mut token = Self::token_at(ctx, token_address);
         if initial_supply > U256::ZERO {
             token
-                .mint(Self::admin(), Self::initial_supply_recipient(), initial_supply, true)
+                .grant_role_unchecked(
+                    B20TokenRole::Mint.id(),
+                    Self::admin(),
+                    TokenFactoryStorage::ADDRESS,
+                )
+                .unwrap();
+            token
+                .mint(
+                    Self::admin(),
+                    Self::initial_supply_recipient(),
+                    initial_supply,
+                    B20DispatchMode::standard(),
+                )
                 .unwrap();
         }
         token
@@ -224,11 +237,14 @@ fn base_token_mutate(c: &mut Criterion) {
             let user = Address::repeat_byte(0x01);
             let mut token =
                 BaseTokenBenchSetup::create_token(ctx, B256::repeat_byte(0x0c), U256::ZERO);
+            token
+                .grant_role_unchecked(B20TokenRole::Mint.id(), user, TokenFactoryStorage::ADDRESS)
+                .unwrap();
 
             b.iter(|| {
                 let token = black_box(&mut token);
                 let user = black_box(user);
-                token.mint(user, user, U256::ONE, true).unwrap();
+                token.mint(user, user, U256::ONE, B20DispatchMode::standard()).unwrap();
             });
         });
     });
@@ -242,11 +258,14 @@ fn base_token_mutate(c: &mut Criterion) {
                 B256::repeat_byte(0x0d),
                 U256::from(u128::MAX),
             );
+            token
+                .grant_role_unchecked(B20TokenRole::Burn.id(), holder, TokenFactoryStorage::ADDRESS)
+                .unwrap();
 
             b.iter(|| {
                 let token = black_box(&mut token);
                 let holder = black_box(holder);
-                token.burn(holder, holder, U256::ONE, true).unwrap();
+                token.burn(holder, holder, U256::ONE, B20DispatchMode::standard()).unwrap();
             });
         });
     });
@@ -356,11 +375,20 @@ fn base_token_mutate(c: &mut Criterion) {
             let admin = BaseTokenBenchSetup::admin();
             let mut token =
                 BaseTokenBenchSetup::create_token(ctx, B256::repeat_byte(0x13), U256::ZERO);
+            token
+                .grant_role_unchecked(B20TokenRole::Pause.id(), admin, TokenFactoryStorage::ADDRESS)
+                .unwrap();
 
             b.iter(|| {
                 let token = black_box(&mut token);
                 let admin = black_box(admin);
-                token.pause(admin, vec![IB20::PausableFeature::TRANSFER], true).unwrap();
+                token
+                    .pause(
+                        admin,
+                        vec![IB20::PausableFeature::TRANSFER],
+                        B20DispatchMode::standard(),
+                    )
+                    .unwrap();
             });
         });
     });
@@ -371,12 +399,30 @@ fn base_token_mutate(c: &mut Criterion) {
             let admin = BaseTokenBenchSetup::admin();
             let mut token =
                 BaseTokenBenchSetup::create_token(ctx, B256::repeat_byte(0x14), U256::ZERO);
-            token.pause(admin, vec![IB20::PausableFeature::TRANSFER], true).unwrap();
+            token
+                .grant_role_unchecked(B20TokenRole::Pause.id(), admin, TokenFactoryStorage::ADDRESS)
+                .unwrap();
+            token
+                .grant_role_unchecked(
+                    B20TokenRole::Unpause.id(),
+                    admin,
+                    TokenFactoryStorage::ADDRESS,
+                )
+                .unwrap();
+            token
+                .pause(admin, vec![IB20::PausableFeature::TRANSFER], B20DispatchMode::standard())
+                .unwrap();
 
             b.iter(|| {
                 let token = black_box(&mut token);
                 let admin = black_box(admin);
-                token.unpause(admin, vec![IB20::PausableFeature::TRANSFER], true).unwrap();
+                token
+                    .unpause(
+                        admin,
+                        vec![IB20::PausableFeature::TRANSFER],
+                        B20DispatchMode::standard(),
+                    )
+                    .unwrap();
             });
         });
     });
@@ -394,7 +440,9 @@ fn base_token_mutate(c: &mut Criterion) {
             b.iter(|| {
                 let token = black_box(&mut token);
                 let admin = black_box(admin);
-                token.set_supply_cap(admin, U256::from(10_000u64), true).unwrap();
+                token
+                    .set_supply_cap(admin, U256::from(10_000u64), B20DispatchMode::standard())
+                    .unwrap();
             });
         });
     });

--- a/crates/common/precompiles/src/b20/dispatch.rs
+++ b/crates/common/precompiles/src/b20/dispatch.rs
@@ -4,7 +4,7 @@ use base_precompile_storage::{BasePrecompileError, IntoPrecompileResult, Storage
 use revm::precompile::PrecompileResult;
 
 use super::{
-    B20Token,
+    B20DispatchMode, B20Token,
     abi::{IB20, IB20::IB20Calls as C},
 };
 use crate::{
@@ -35,15 +35,15 @@ impl<S: TokenAccounting, P: Policy> B20Token<S, P> {
         ctx: StorageCtx<'_>,
         calldata: &[u8],
     ) -> base_precompile_storage::Result<Bytes> {
-        self.inner_with_privilege(ctx, calldata, false)
+        self.inner_with_mode(ctx, calldata, B20DispatchMode::standard())
     }
 
-    /// Decodes calldata and executes it with optional factory-init privilege.
-    pub fn inner_with_privilege(
+    /// Decodes calldata and executes it with the requested dispatch mode.
+    pub fn inner_with_mode(
         &mut self,
         ctx: StorageCtx<'_>,
         calldata: &[u8],
-        privileged: bool,
+        mode: B20DispatchMode,
     ) -> base_precompile_storage::Result<Bytes> {
         ActivationRegistryStorage::new(ctx).ensure_activated(ActivationFeature::B20Token.id())?;
 
@@ -84,12 +84,12 @@ impl<S: TokenAccounting, P: Policy> B20Token<S, P> {
             // --- ERC-20 mutating ---
             C::transfer(c) => {
                 let caller = ctx.caller();
-                self.transfer(caller, c.to, c.amount)?;
+                self.transfer_with_mode(caller, c.to, c.amount, mode)?;
                 true.abi_encode().into()
             }
             C::transferFrom(c) => {
                 let caller = ctx.caller();
-                self.transfer_from(caller, c.from, c.to, c.amount)?;
+                self.transfer_from_with_mode(caller, c.from, c.to, c.amount, mode)?;
                 true.abi_encode().into()
             }
             C::approve(c) => {
@@ -99,87 +99,87 @@ impl<S: TokenAccounting, P: Policy> B20Token<S, P> {
             }
             C::transferWithMemo(c) => {
                 let caller = ctx.caller();
-                self.transfer_with_memo(caller, c.to, c.amount, c.memo)?;
+                self.transfer_with_memo_with_mode(caller, c.to, c.amount, c.memo, mode)?;
                 true.abi_encode().into()
             }
             C::transferFromWithMemo(c) => {
                 let caller = ctx.caller();
-                self.transfer_from_with_memo(caller, c.from, c.to, c.amount, c.memo)?;
+                self.transfer_from_with_memo_with_mode(
+                    caller, c.from, c.to, c.amount, c.memo, mode,
+                )?;
                 true.abi_encode().into()
             }
 
             // --- Mint ---
             C::mint(c) => {
                 let caller = ctx.caller();
-                self.mint(caller, c.to, c.amount, privileged)?;
+                self.mint(caller, c.to, c.amount, mode)?;
                 Bytes::new()
             }
             C::mintWithMemo(c) => {
                 let caller = ctx.caller();
-                self.mint_with_memo(caller, c.to, c.amount, c.memo, privileged)?;
+                self.mint_with_memo(caller, c.to, c.amount, c.memo, mode)?;
                 Bytes::new()
             }
 
             // --- Burn ---
             C::burn(c) => {
                 let caller = ctx.caller();
-                // Self-burn operations are never factory-privileged: during init the caller is the
-                // factory, not a token holder.
-                self.burn(caller, caller, c.amount, false)?;
+                self.burn(caller, caller, c.amount, mode)?;
                 Bytes::new()
             }
             C::burnWithMemo(c) => {
                 let caller = ctx.caller();
-                self.burn_with_memo(caller, caller, c.amount, c.memo, false)?;
+                self.burn_with_memo(caller, caller, c.amount, c.memo, mode)?;
                 Bytes::new()
             }
             C::burnBlocked(c) => {
                 let caller = ctx.caller();
-                self.burn_blocked(caller, c.from, c.amount, privileged)?;
+                self.burn_blocked(caller, c.from, c.amount, mode)?;
                 Bytes::new()
             }
 
             // --- Pause ---
             C::pause(c) => {
                 let caller = ctx.caller();
-                self.pause(caller, c.features, privileged)?;
+                self.pause(caller, c.features, mode)?;
                 Bytes::new()
             }
             C::unpause(c) => {
                 let caller = ctx.caller();
-                self.unpause(caller, c.features, privileged)?;
+                self.unpause(caller, c.features, mode)?;
                 Bytes::new()
             }
 
             // --- Admin ---
             C::setSupplyCap(c) => {
                 let caller = ctx.caller();
-                Configurable::set_supply_cap(self, caller, c.newSupplyCap, privileged)?;
+                Configurable::set_supply_cap(self, caller, c.newSupplyCap, mode)?;
                 Bytes::new()
             }
             C::setName(c) => {
                 let caller = ctx.caller();
-                Configurable::set_name(self, caller, c.newName, privileged)?;
+                Configurable::set_name(self, caller, c.newName, mode)?;
                 Bytes::new()
             }
             C::setSymbol(c) => {
                 let caller = ctx.caller();
-                Configurable::set_symbol(self, caller, c.newSymbol, privileged)?;
+                Configurable::set_symbol(self, caller, c.newSymbol, mode)?;
                 Bytes::new()
             }
             C::setContractURI(c) => {
                 let caller = ctx.caller();
-                Configurable::set_contract_uri(self, caller, c.newURI, privileged)?;
+                Configurable::set_contract_uri(self, caller, c.newURI, mode)?;
                 Bytes::new()
             }
             C::grantRole(c) => {
                 let caller = ctx.caller();
-                self.grant_role(caller, c.role, c.account, privileged)?;
+                self.grant_role(caller, c.role, c.account, mode)?;
                 Bytes::new()
             }
             C::revokeRole(c) => {
                 let caller = ctx.caller();
-                self.revoke_role(caller, c.role, c.account, privileged)?;
+                self.revoke_role(caller, c.role, c.account, mode)?;
                 Bytes::new()
             }
             // Renounce operations are never factory-privileged: they are only meaningful for the
@@ -196,12 +196,12 @@ impl<S: TokenAccounting, P: Policy> B20Token<S, P> {
             }
             C::setRoleAdmin(c) => {
                 let caller = ctx.caller();
-                self.set_role_admin(caller, c.role, c.newAdminRole, privileged)?;
+                self.set_role_admin(caller, c.role, c.newAdminRole, mode)?;
                 Bytes::new()
             }
             C::updatePolicy(c) => {
                 let caller = ctx.caller();
-                self.update_policy(caller, c.policyType, c.newPolicyId, privileged)?;
+                self.update_policy(caller, c.policyType, c.newPolicyId, mode)?;
                 Bytes::new()
             }
 

--- a/crates/common/precompiles/src/b20/mod.rs
+++ b/crates/common/precompiles/src/b20/mod.rs
@@ -8,7 +8,7 @@ mod pausable;
 pub use pausable::B20PausableFeature;
 
 mod policies;
-pub use policies::B20PolicyType;
+pub use policies::{B20PolicyType, POLICY_ALWAYS_ALLOW, POLICY_ALWAYS_BLOCK};
 
 mod precompile;
 pub use precompile::B20TokenPrecompile;
@@ -17,4 +17,4 @@ mod storage;
 pub use storage::{B20CoreStorage, B20TokenInit, B20TokenStorage};
 
 mod token;
-pub use token::B20Token;
+pub use token::{B20DispatchMode, B20FactoryInitPrivilege, B20Token};

--- a/crates/common/precompiles/src/b20/pausable.rs
+++ b/crates/common/precompiles/src/b20/pausable.rs
@@ -11,6 +11,8 @@ pub struct B20PausableFeature;
 impl B20PausableFeature {
     /// Returns the storage bit for a pausable feature.
     pub fn mask(feature: IB20::PausableFeature) -> U256 {
-        U256::ONE.checked_shl(usize::from(feature as u8)).unwrap_or(U256::ZERO)
+        U256::ONE
+            .checked_shl(usize::from(feature as u8))
+            .expect("PausableFeature discriminant must fit in U256")
     }
 }

--- a/crates/common/precompiles/src/b20/policies.rs
+++ b/crates/common/precompiles/src/b20/policies.rs
@@ -5,7 +5,15 @@ use alloy_sol_types::SolEvent;
 use base_precompile_storage::{BasePrecompileError, Result};
 
 use super::token::B20Token;
-use crate::{B20Guards, B20TokenRole, IB20, Policy, Token, TokenAccounting};
+use crate::{
+    B20DispatchMode, B20Guards, B20TokenRole, IB20, Policy, PolicyRegistryStorage, Token,
+    TokenAccounting,
+};
+
+/// Built-in policy ID that authorizes every account.
+pub const POLICY_ALWAYS_ALLOW: u64 = PolicyRegistryStorage::ALWAYS_ALLOW_ID;
+/// Built-in policy ID that authorizes no account.
+pub const POLICY_ALWAYS_BLOCK: u64 = PolicyRegistryStorage::ALWAYS_BLOCK_ID;
 
 const TRANSFER_SENDER_POLICY: B256 =
     b256!("b81736c875ab819dd97f59f2a6542cfb731ad52b4ae15a6f24df2fb02b0327f5");
@@ -84,14 +92,17 @@ impl<S: TokenAccounting, P: Policy> B20Token<S, P> {
     }
 
     /// Updates the configured policy ID for `policy_type`.
+    ///
+    /// Any existing policy ID can be assigned to any token policy slot. The policy registry's
+    /// `is_authorized` result defines the final allow/deny semantics for that slot.
     pub fn update_policy(
         &mut self,
         caller: Address,
         policy_type: B256,
         new_policy_id: u64,
-        privileged: bool,
+        mode: B20DispatchMode,
     ) -> Result<()> {
-        if !privileged {
+        if !mode.is_factory_init() {
             B20Guards::ensure_token_role(self, caller, B20TokenRole::DefaultAdmin)?;
         }
         let old_policy_id = self.policy_id(policy_type)?;
@@ -128,7 +139,10 @@ mod tests {
     use alloy_primitives::{Address, B256};
 
     use super::*;
-    use crate::{B20TokenRole, InMemoryPolicy, InMemoryTokenAccounting, Token, TokenAccounting};
+    use crate::{
+        B20DispatchMode, B20TokenRole, InMemoryPolicy, InMemoryTokenAccounting, Token,
+        TokenAccounting,
+    };
 
     const ADMIN: Address = Address::repeat_byte(0xaa);
     const TOKEN_ADDR: Address = Address::repeat_byte(0x20);
@@ -157,7 +171,12 @@ mod tests {
 
         assert_eq!(
             token
-                .update_policy(ADMIN, B20PolicyType::TransferSender.id(), CUSTOM_POLICY_ID, false)
+                .update_policy(
+                    ADMIN,
+                    B20PolicyType::TransferSender.id(),
+                    CUSTOM_POLICY_ID,
+                    B20DispatchMode::standard(),
+                )
                 .unwrap_err(),
             BasePrecompileError::revert(IB20::PolicyNotFound { policyId: CUSTOM_POLICY_ID })
         );
@@ -169,7 +188,12 @@ mod tests {
         token.policy.create_existing_policy(CUSTOM_POLICY_ID);
 
         token
-            .update_policy(ADMIN, B20PolicyType::TransferSender.id(), CUSTOM_POLICY_ID, false)
+            .update_policy(
+                ADMIN,
+                B20PolicyType::TransferSender.id(),
+                CUSTOM_POLICY_ID,
+                B20DispatchMode::standard(),
+            )
             .unwrap();
 
         assert_eq!(

--- a/crates/common/precompiles/src/b20/storage.rs
+++ b/crates/common/precompiles/src/b20/storage.rs
@@ -138,8 +138,9 @@ impl TokenAccounting for B20TokenStorage<'_> {
     }
 
     fn decimals(&self) -> Result<u8> {
-        Ok(TokenVariant::from_address(ContractStorage::address(self))
-            .map_or(0, TokenVariant::decimals))
+        let variant = TokenVariant::from_address(ContractStorage::address(self))
+            .ok_or_else(|| BasePrecompileError::revert(IB20::Uninitialized {}))?;
+        Ok(variant.decimals())
     }
 
     fn paused(&self) -> Result<U256> {
@@ -274,6 +275,8 @@ impl TokenAccounting for B20TokenStorage<'_> {
 
 impl B20TokenStorage<'_> {
     const ADMIN_COUNT_BITS: usize = 248;
+    // Policy IDs are packed into 64-bit lanes so the three transfer policy reads share one SLOAD.
+    // Lane 3 of `transfer_policy_ids` and lanes 1..=3 of `mint_policy_ids` are reserved.
     const TRANSFER_SENDER_POLICY_LANE: usize = 0;
     const TRANSFER_RECEIVER_POLICY_LANE: usize = 1;
     const TRANSFER_EXECUTOR_POLICY_LANE: usize = 2;
@@ -316,10 +319,13 @@ impl B20TokenStorage<'_> {
 #[cfg(test)]
 mod tests {
     use alloy_primitives::{Address, U256, address, uint};
-    use base_precompile_storage::{Handler, StorableType, StorageCtx, StorageKey, setup_storage};
+    use base_precompile_storage::{
+        BasePrecompileError, Handler, HashMapStorageProvider, StorableType, StorageCtx, StorageKey,
+        setup_storage,
+    };
 
     use super::{__packing_b20_core_storage, B20CoreStorage, B20TokenStorage, slots};
-    use crate::{B20TokenRole, TokenAccounting};
+    use crate::{B20TokenRole, IB20, TokenAccounting};
 
     const TOKEN: Address = address!("000000000000000000000000000000000000b020");
     const B20_ROOT: U256 =
@@ -390,6 +396,20 @@ mod tests {
                 U256::ONE
             );
             assert_eq!(ctx.sload(TOKEN, admin_count_slot).unwrap(), U256::ONE);
+        });
+    }
+
+    #[test]
+    fn decimals_reverts_for_non_b20_address() {
+        let mut storage = HashMapStorageProvider::new(1);
+
+        StorageCtx::enter(&mut storage, |ctx| {
+            let token = B20TokenStorage::from_address(Address::repeat_byte(0x42), ctx);
+
+            assert_eq!(
+                token.decimals().unwrap_err(),
+                BasePrecompileError::revert(IB20::Uninitialized {})
+            );
         });
     }
 }

--- a/crates/common/precompiles/src/b20/token.rs
+++ b/crates/common/precompiles/src/b20/token.rs
@@ -7,6 +7,42 @@ use crate::{
     TokenAccounting, Transferable,
 };
 
+/// Factory-init privilege token for B-20 dispatch.
+///
+/// The private field prevents downstream crates from constructing this capability while still
+/// allowing the type to appear in the public API. The token factory is the only in-crate caller that
+/// can enter the factory-init dispatch mode.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct B20FactoryInitPrivilege {
+    _private: (),
+}
+
+/// Authorization mode for B-20 operation dispatch.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum B20DispatchMode {
+    /// Ordinary post-creation token call. All role, pause, and policy checks apply.
+    Standard,
+    /// Factory bootstrap call. Authorization gates are skipped, but accounting invariants remain.
+    FactoryInit(B20FactoryInitPrivilege),
+}
+
+impl B20DispatchMode {
+    /// Returns ordinary post-creation dispatch mode.
+    pub const fn standard() -> Self {
+        Self::Standard
+    }
+
+    /// Returns factory bootstrap dispatch mode.
+    pub(crate) const fn factory_init() -> Self {
+        Self::FactoryInit(B20FactoryInitPrivilege { _private: () })
+    }
+
+    /// Returns true when the current call is executing during factory bootstrap.
+    pub const fn is_factory_init(self) -> bool {
+        matches!(self, Self::FactoryInit(_))
+    }
+}
+
 /// EVM precompile for the Default B-20 token variant.
 ///
 /// The generic `S` lets callers swap in an in-memory [`TokenAccounting`]

--- a/crates/common/precompiles/src/b20_security/dispatch.rs
+++ b/crates/common/precompiles/src/b20_security/dispatch.rs
@@ -19,8 +19,8 @@ use super::{
     accounting::SecurityAccounting,
 };
 use crate::{
-    ActivationFeature, ActivationRegistryStorage, B20PolicyType, B20TokenRole, Burnable,
-    Configurable,
+    ActivationFeature, ActivationRegistryStorage, B20DispatchMode, B20PolicyType, B20TokenRole,
+    Burnable, Configurable,
     IB20::{self, IB20Calls as C},
     Mintable, Pausable, Permittable, Policy, RoleManaged, Token, Transferable,
     macros::{decode_precompile_call, deduct_calldata_cost},
@@ -44,12 +44,12 @@ impl<S: SecurityAccounting, P: Policy> B20SecurityToken<S, P> {
         caller: Address,
         policy_type: B256,
         new_policy_id: u64,
-        privileged: bool,
+        mode: B20DispatchMode,
     ) -> base_precompile_storage::Result<()> {
         B20PolicyType::from_id(policy_type).ok_or_else(|| {
             BasePrecompileError::revert(IB20::UnsupportedPolicyType { policyType: policy_type })
         })?;
-        if !privileged {
+        if !mode.is_factory_init() {
             self.ensure_role(caller, Self::default_admin_role())?;
         }
         let old_policy_id = self.accounting.policy_id(policy_type)?;
@@ -92,15 +92,15 @@ impl<S: SecurityAccounting, P: Policy> B20SecurityToken<S, P> {
         ctx: StorageCtx<'_>,
         calldata: &[u8],
     ) -> base_precompile_storage::Result<Bytes> {
-        self.inner_with_privilege(ctx, calldata, false)
+        self.inner_with_mode(ctx, calldata, B20DispatchMode::standard())
     }
 
-    /// Decodes calldata and executes it with optional factory-init privilege.
-    pub fn inner_with_privilege(
+    /// Decodes calldata and executes it with the requested dispatch mode.
+    pub fn inner_with_mode(
         &mut self,
         ctx: StorageCtx<'_>,
         calldata: &[u8],
-        privileged: bool,
+        mode: B20DispatchMode,
     ) -> base_precompile_storage::Result<Bytes> {
         ActivationRegistryStorage::new(ctx)
             .ensure_activated(ActivationFeature::B20Security.id())?;
@@ -189,12 +189,12 @@ impl<S: SecurityAccounting, P: Policy> B20SecurityToken<S, P> {
             // --- Mint ---
             C::mint(c) => {
                 let caller = ctx.caller();
-                self.mint(caller, c.to, c.amount, privileged)?;
+                self.mint(caller, c.to, c.amount, mode)?;
                 Bytes::new()
             }
             C::mintWithMemo(c) => {
                 let caller = ctx.caller();
-                self.mint_with_memo(caller, c.to, c.amount, c.memo, privileged)?;
+                self.mint_with_memo(caller, c.to, c.amount, c.memo, mode)?;
                 Bytes::new()
             }
 
@@ -203,63 +203,63 @@ impl<S: SecurityAccounting, P: Policy> B20SecurityToken<S, P> {
             // factory, not a token holder.
             C::burn(c) => {
                 let caller = ctx.caller();
-                self.burn(caller, caller, c.amount, false)?;
+                self.burn(caller, caller, c.amount, mode)?;
                 Bytes::new()
             }
             C::burnWithMemo(c) => {
                 let caller = ctx.caller();
-                self.burn_with_memo(caller, caller, c.amount, c.memo, false)?;
+                self.burn_with_memo(caller, caller, c.amount, c.memo, mode)?;
                 Bytes::new()
             }
             C::burnBlocked(c) => {
                 let caller = ctx.caller();
-                self.burn_blocked(caller, c.from, c.amount, privileged)?;
+                self.burn_blocked(caller, c.from, c.amount, mode)?;
                 Bytes::new()
             }
 
             // --- Pause ---
             C::pause(c) => {
                 let caller = ctx.caller();
-                self.pause(caller, c.features, privileged)?;
+                self.pause(caller, c.features, mode)?;
                 Bytes::new()
             }
             C::unpause(c) => {
                 let caller = ctx.caller();
-                self.unpause(caller, c.features, privileged)?;
+                self.unpause(caller, c.features, mode)?;
                 Bytes::new()
             }
 
             // --- Admin ---
             C::setSupplyCap(c) => {
                 let caller = ctx.caller();
-                Configurable::set_supply_cap(self, caller, c.newSupplyCap, privileged)?;
+                Configurable::set_supply_cap(self, caller, c.newSupplyCap, mode)?;
                 Bytes::new()
             }
             C::setName(c) => {
                 let caller = ctx.caller();
-                Configurable::set_name(self, caller, c.newName, privileged)?;
+                Configurable::set_name(self, caller, c.newName, mode)?;
                 Bytes::new()
             }
             C::setSymbol(c) => {
                 let caller = ctx.caller();
-                Configurable::set_symbol(self, caller, c.newSymbol, privileged)?;
+                Configurable::set_symbol(self, caller, c.newSymbol, mode)?;
                 Bytes::new()
             }
             C::setContractURI(c) => {
                 let caller = ctx.caller();
-                Configurable::set_contract_uri(self, caller, c.newURI, privileged)?;
+                Configurable::set_contract_uri(self, caller, c.newURI, mode)?;
                 Bytes::new()
             }
 
             // --- Role mutations ---
             C::grantRole(c) => {
                 let caller = ctx.caller();
-                self.grant_role(caller, c.role, c.account, privileged)?;
+                self.grant_role(caller, c.role, c.account, mode)?;
                 Bytes::new()
             }
             C::revokeRole(c) => {
                 let caller = ctx.caller();
-                self.revoke_role(caller, c.role, c.account, privileged)?;
+                self.revoke_role(caller, c.role, c.account, mode)?;
                 Bytes::new()
             }
             // Renounce operations are never factory-privileged: they are only meaningful for the
@@ -276,14 +276,14 @@ impl<S: SecurityAccounting, P: Policy> B20SecurityToken<S, P> {
             }
             C::setRoleAdmin(c) => {
                 let caller = ctx.caller();
-                self.set_role_admin(caller, c.role, c.newAdminRole, privileged)?;
+                self.set_role_admin(caller, c.role, c.newAdminRole, mode)?;
                 Bytes::new()
             }
 
             // --- Policy mutations ---
             C::updatePolicy(c) => {
                 let caller = ctx.caller();
-                self.update_policy(caller, c.policyType, c.newPolicyId, privileged)?;
+                self.update_policy(caller, c.policyType, c.newPolicyId, mode)?;
                 Bytes::new()
             }
 
@@ -477,7 +477,7 @@ impl<S: SecurityAccounting, P: Policy> B20SecurityToken<S, P> {
         }
         let caller = ctx.caller();
         for (recipient, amount) in recipients.into_iter().zip(amounts) {
-            self.mint(caller, recipient, amount, true)?;
+            self.mint(caller, recipient, amount, B20DispatchMode::factory_init())?;
         }
         Ok(())
     }
@@ -585,7 +585,7 @@ impl<S: SecurityAccounting, P: Policy> B20SecurityToken<S, P> {
             }));
         }
         for (recipient, amount) in recipients.into_iter().zip(amounts) {
-            self.mint(Address::ZERO, recipient, amount, true)?;
+            self.mint(Address::ZERO, recipient, amount, B20DispatchMode::factory_init())?;
         }
         Ok(())
     }

--- a/crates/common/precompiles/src/b20_stablecoin/dispatch.rs
+++ b/crates/common/precompiles/src/b20_stablecoin/dispatch.rs
@@ -1,7 +1,7 @@
 //! ABI dispatch for the stablecoin B-20 variant.
 //!
-//! Dispatches the full `IB20` selector set using B-20 stablecoin activation.
-//! All logic mirrors `B20Token::inner_with_privilege` exactly; the only
+//! Dispatches the full `IB20` selector set using `B20_STABLECOIN` activation.
+//! All logic mirrors `B20Token::inner_with_mode` exactly; the only
 //! distinction is the activation guard and the `StablecoinAccounting` bound
 //! that provides `currency()` from the stablecoin extension namespace.
 
@@ -16,7 +16,8 @@ use super::{
     accounting::StablecoinAccounting,
 };
 use crate::{
-    ActivationFeature, ActivationRegistryStorage, B20TokenRole, Burnable, Configurable,
+    ActivationFeature, ActivationRegistryStorage, B20DispatchMode, B20TokenRole, Burnable,
+    Configurable,
     IB20::{self, IB20Calls as C},
     Mintable, Pausable, Permittable, Policy, RoleManaged, Transferable,
     macros::{decode_precompile_call, deduct_calldata_cost},
@@ -44,15 +45,15 @@ impl<S: StablecoinAccounting, P: Policy> B20StablecoinToken<S, P> {
         ctx: StorageCtx<'_>,
         calldata: &[u8],
     ) -> base_precompile_storage::Result<Bytes> {
-        self.inner_with_privilege(ctx, calldata, false)
+        self.inner_with_mode(ctx, calldata, B20DispatchMode::standard())
     }
 
-    /// Decodes calldata and executes it with optional factory-init privilege.
-    pub fn inner_with_privilege(
+    /// Decodes calldata and executes it with the requested dispatch mode.
+    pub fn inner_with_mode(
         &mut self,
         ctx: StorageCtx<'_>,
         calldata: &[u8],
-        privileged: bool,
+        mode: B20DispatchMode,
     ) -> base_precompile_storage::Result<Bytes> {
         ActivationRegistryStorage::new(ctx)
             .ensure_activated(ActivationFeature::B20Stablecoin.id())?;
@@ -98,12 +99,12 @@ impl<S: StablecoinAccounting, P: Policy> B20StablecoinToken<S, P> {
             // --- ERC-20 mutating ---
             C::transfer(c) => {
                 let caller = ctx.caller();
-                self.transfer(caller, c.to, c.amount)?;
+                self.transfer_with_mode(caller, c.to, c.amount, mode)?;
                 true.abi_encode().into()
             }
             C::transferFrom(c) => {
                 let caller = ctx.caller();
-                self.transfer_from(caller, c.from, c.to, c.amount)?;
+                self.transfer_from_with_mode(caller, c.from, c.to, c.amount, mode)?;
                 true.abi_encode().into()
             }
             C::approve(c) => {
@@ -113,91 +114,89 @@ impl<S: StablecoinAccounting, P: Policy> B20StablecoinToken<S, P> {
             }
             C::transferWithMemo(c) => {
                 let caller = ctx.caller();
-                self.transfer_with_memo(caller, c.to, c.amount, c.memo)?;
+                self.transfer_with_memo_with_mode(caller, c.to, c.amount, c.memo, mode)?;
                 true.abi_encode().into()
             }
             C::transferFromWithMemo(c) => {
                 let caller = ctx.caller();
-                self.transfer_from_with_memo(caller, c.from, c.to, c.amount, c.memo)?;
+                self.transfer_from_with_memo_with_mode(
+                    caller, c.from, c.to, c.amount, c.memo, mode,
+                )?;
                 true.abi_encode().into()
             }
 
             // --- Mint ---
             C::mint(c) => {
                 let caller = ctx.caller();
-                self.mint(caller, c.to, c.amount, privileged)?;
+                self.mint(caller, c.to, c.amount, mode)?;
                 Bytes::new()
             }
             C::mintWithMemo(c) => {
                 let caller = ctx.caller();
-                self.mint_with_memo(caller, c.to, c.amount, c.memo, privileged)?;
+                self.mint_with_memo(caller, c.to, c.amount, c.memo, mode)?;
                 Bytes::new()
             }
 
             // --- Burn ---
             C::burn(c) => {
                 let caller = ctx.caller();
-                // Self-burn operations are never factory-privileged: during init the caller is the
-                // factory, not a token holder.
-                self.burn(caller, caller, c.amount, false)?;
+                self.burn(caller, caller, c.amount, mode)?;
                 Bytes::new()
             }
             C::burnWithMemo(c) => {
                 let caller = ctx.caller();
-                self.burn_with_memo(caller, caller, c.amount, c.memo, false)?;
+                self.burn_with_memo(caller, caller, c.amount, c.memo, mode)?;
                 Bytes::new()
             }
             C::burnBlocked(c) => {
                 let caller = ctx.caller();
-                self.burn_blocked(caller, c.from, c.amount, privileged)?;
+                self.burn_blocked(caller, c.from, c.amount, mode)?;
                 Bytes::new()
             }
 
             // --- Pause ---
             C::pause(c) => {
                 let caller = ctx.caller();
-                self.pause(caller, c.features, privileged)?;
+                self.pause(caller, c.features, mode)?;
                 Bytes::new()
             }
             C::unpause(c) => {
                 let caller = ctx.caller();
-                self.unpause(caller, c.features, privileged)?;
+                self.unpause(caller, c.features, mode)?;
                 Bytes::new()
             }
 
             // --- Admin ---
             C::setSupplyCap(c) => {
                 let caller = ctx.caller();
-                Configurable::set_supply_cap(self, caller, c.newSupplyCap, privileged)?;
+                Configurable::set_supply_cap(self, caller, c.newSupplyCap, mode)?;
                 Bytes::new()
             }
             C::setName(c) => {
                 let caller = ctx.caller();
-                Configurable::set_name(self, caller, c.newName, privileged)?;
+                Configurable::set_name(self, caller, c.newName, mode)?;
                 Bytes::new()
             }
             C::setSymbol(c) => {
                 let caller = ctx.caller();
-                Configurable::set_symbol(self, caller, c.newSymbol, privileged)?;
+                Configurable::set_symbol(self, caller, c.newSymbol, mode)?;
                 Bytes::new()
             }
             C::setContractURI(c) => {
                 let caller = ctx.caller();
-                Configurable::set_contract_uri(self, caller, c.newURI, privileged)?;
+                Configurable::set_contract_uri(self, caller, c.newURI, mode)?;
                 Bytes::new()
             }
             C::grantRole(c) => {
                 let caller = ctx.caller();
-                self.grant_role(caller, c.role, c.account, privileged)?;
+                self.grant_role(caller, c.role, c.account, mode)?;
                 Bytes::new()
             }
             C::revokeRole(c) => {
                 let caller = ctx.caller();
-                self.revoke_role(caller, c.role, c.account, privileged)?;
+                self.revoke_role(caller, c.role, c.account, mode)?;
                 Bytes::new()
             }
-            // Renounce operations are never factory-privileged: they are only meaningful for the
-            // role holder making the call after token creation.
             C::renounceRole(c) => {
                 let caller = ctx.caller();
                 self.renounce_role(caller, c.role, c.callerConfirmation)?;
@@ -210,12 +209,12 @@ impl<S: StablecoinAccounting, P: Policy> B20StablecoinToken<S, P> {
             }
             C::setRoleAdmin(c) => {
                 let caller = ctx.caller();
-                self.set_role_admin(caller, c.role, c.newAdminRole, privileged)?;
+                self.set_role_admin(caller, c.role, c.newAdminRole, mode)?;
                 Bytes::new()
             }
             C::updatePolicy(c) => {
                 let caller = ctx.caller();
-                self.update_policy(caller, c.policyType, c.newPolicyId, privileged)?;
+                self.update_policy(caller, c.policyType, c.newPolicyId, mode)?;
                 Bytes::new()
             }
 

--- a/crates/common/precompiles/src/b20_stablecoin/token.rs
+++ b/crates/common/precompiles/src/b20_stablecoin/token.rs
@@ -6,8 +6,8 @@ use base_precompile_storage::{BasePrecompileError, Result};
 
 use super::accounting::StablecoinAccounting;
 use crate::{
-    B20Guards, B20PolicyType, B20TokenRole, Burnable, Configurable, IB20, Mintable, Pausable,
-    Permittable, Policy, RoleManaged, Token, Transferable,
+    B20DispatchMode, B20Guards, B20PolicyType, B20TokenRole, Burnable, Configurable, IB20,
+    Mintable, Pausable, Permittable, Policy, RoleManaged, Token, Transferable,
 };
 
 /// EVM precompile for the stablecoin B-20 variant.
@@ -94,9 +94,9 @@ impl<S: StablecoinAccounting, P: Policy> B20StablecoinToken<S, P> {
         caller: Address,
         policy_type: B256,
         new_policy_id: u64,
-        privileged: bool,
+        mode: B20DispatchMode,
     ) -> Result<()> {
-        if !privileged {
+        if !mode.is_factory_init() {
             B20Guards::ensure_token_role(self, caller, B20TokenRole::DefaultAdmin)?;
         }
         let old_policy_id = self.policy_id(policy_type)?;

--- a/crates/common/precompiles/src/common/ops/burnable.rs
+++ b/crates/common/precompiles/src/common/ops/burnable.rs
@@ -3,7 +3,7 @@ use alloy_sol_types::SolEvent;
 use base_precompile_storage::{BasePrecompileError, Result};
 
 use super::guards::B20Guards;
-use crate::{B20TokenRole, IB20, Token, TokenAccounting};
+use crate::{B20DispatchMode, B20TokenRole, IB20, Token, TokenAccounting};
 
 /// Token burn operations.
 ///
@@ -16,12 +16,12 @@ pub trait Burnable: Token {
         caller: Address,
         from: Address,
         amount: U256,
-        privileged: bool,
+        mode: B20DispatchMode,
     ) -> Result<()> {
-        if !privileged {
+        if !mode.is_factory_init() {
             B20Guards::ensure_token_role::<Self>(self, caller, B20TokenRole::Burn)?;
+            B20Guards::ensure_not_paused::<Self>(self, IB20::PausableFeature::BURN)?;
         }
-        B20Guards::ensure_not_paused::<Self>(self, IB20::PausableFeature::BURN)?;
         let balance = self.accounting().balance_of(from)?;
         if balance < amount {
             return Err(BasePrecompileError::revert(IB20::InsufficientBalance {
@@ -46,9 +46,9 @@ pub trait Burnable: Token {
         from: Address,
         amount: U256,
         memo: B256,
-        privileged: bool,
+        mode: B20DispatchMode,
     ) -> Result<()> {
-        self.burn(caller, from, amount, privileged)?;
+        self.burn(caller, from, amount, mode)?;
         self.accounting_mut().emit_event(IB20::Memo { memo }.encode_log_data())
     }
 
@@ -58,15 +58,30 @@ pub trait Burnable: Token {
         caller: Address,
         from: Address,
         amount: U256,
-        privileged: bool,
+        mode: B20DispatchMode,
     ) -> Result<()> {
-        if !privileged {
+        if !mode.is_factory_init() {
             B20Guards::ensure_token_role::<Self>(self, caller, B20TokenRole::BurnBlocked)?;
+            // Intentional asymmetry: BURN_BLOCKED_ROLE replaces BURN_ROLE, but emergency burn
+            // pauses still halt every non-bootstrap burn path, including burnBlocked.
+            B20Guards::ensure_not_paused::<Self>(self, IB20::PausableFeature::BURN)?;
+            B20Guards::ensure_blocked::<Self>(self, from)?;
         }
-        B20Guards::ensure_blocked::<Self>(self, from)?;
-        // Intentional asymmetry: BURN_BLOCKED_ROLE replaces BURN_ROLE, but emergency burn pauses
-        // still halt every burn path, including burnBlocked.
-        self.burn(caller, from, amount, true)?;
+        let balance = self.accounting().balance_of(from)?;
+        if balance < amount {
+            return Err(BasePrecompileError::revert(IB20::InsufficientBalance {
+                sender: from,
+                balance,
+                needed: amount,
+            }));
+        }
+        self.accounting_mut().set_balance(from, balance - amount)?;
+        let supply = self.accounting().total_supply()?;
+        let new_supply =
+            supply.checked_sub(amount).ok_or_else(BasePrecompileError::under_overflow)?;
+        self.accounting_mut().set_total_supply(new_supply)?;
+        self.accounting_mut()
+            .emit_event(IB20::Transfer { from, to: Address::ZERO, amount }.encode_log_data())?;
         self.accounting_mut()
             .emit_event(IB20::BurnedBlocked { caller, from, amount }.encode_log_data())
     }
@@ -79,7 +94,8 @@ mod tests {
 
     use super::Burnable;
     use crate::{
-        B20PausableFeature, B20PolicyType, B20TokenRole, IB20, PolicyRegistryStorage,
+        B20DispatchMode, B20PausableFeature, B20PolicyType, B20TokenRole, IB20,
+        POLICY_ALWAYS_BLOCK,
         common::{
             Token, TokenAccounting,
             test_utils::{InMemoryPolicy, InMemoryTokenAccounting, TestToken},
@@ -109,7 +125,7 @@ mod tests {
     fn burn_decreases_balance_and_supply() {
         let mut token = token_with_balance(U256::from(100u64));
 
-        token.burn(CALLER, ALICE, U256::from(40u64), true).unwrap();
+        token.burn(CALLER, ALICE, U256::from(40u64), B20DispatchMode::factory_init()).unwrap();
 
         assert_eq!(token.accounting().balance_of(ALICE).unwrap(), U256::from(60u64));
         assert_eq!(token.accounting().total_supply().unwrap(), U256::from(60u64));
@@ -121,7 +137,9 @@ mod tests {
         let mut token = token_with_balance(U256::from(10u64));
 
         assert_eq!(
-            token.burn(CALLER, ALICE, U256::from(11u64), true).unwrap_err(),
+            token
+                .burn(CALLER, ALICE, U256::from(11u64), B20DispatchMode::factory_init())
+                .unwrap_err(),
             BasePrecompileError::revert(IB20::InsufficientBalance {
                 sender: ALICE,
                 balance: U256::from(10u64),
@@ -135,7 +153,7 @@ mod tests {
         let mut token = token_with_balance(U256::from(10u64));
 
         assert_eq!(
-            token.burn(CALLER, ALICE, U256::ONE, false).unwrap_err(),
+            token.burn(CALLER, ALICE, U256::ONE, B20DispatchMode::standard()).unwrap_err(),
             BasePrecompileError::revert(IB20::AccessControlUnauthorizedAccount {
                 account: CALLER,
                 neededRole: B20TokenRole::Burn.id(),
@@ -147,7 +165,7 @@ mod tests {
     fn non_privileged_burn_with_role_succeeds() {
         let mut token = token_with_role(B20TokenRole::Burn, CALLER, U256::from(10u64));
 
-        token.burn(CALLER, ALICE, U256::from(4u64), false).unwrap();
+        token.burn(CALLER, ALICE, U256::from(4u64), B20DispatchMode::standard()).unwrap();
 
         assert_eq!(token.accounting().balance_of(ALICE).unwrap(), U256::from(6u64));
     }
@@ -158,10 +176,11 @@ mod tests {
         accounting.balances.insert(ALICE, U256::from(10u64));
         accounting.total_supply = U256::from(10u64);
         accounting.paused = B20PausableFeature::mask(IB20::PausableFeature::BURN);
+        accounting.roles.insert((B20TokenRole::Burn.id(), CALLER), true);
         let mut token = TestToken::with_storage_and_policy(accounting, InMemoryPolicy::new());
 
         assert_eq!(
-            token.burn(CALLER, ALICE, U256::ONE, true).unwrap_err(),
+            token.burn(CALLER, ALICE, U256::ONE, B20DispatchMode::standard()).unwrap_err(),
             BasePrecompileError::revert(IB20::ContractPaused {
                 feature: IB20::PausableFeature::BURN,
             })
@@ -170,10 +189,10 @@ mod tests {
 
     #[test]
     fn burn_blocked_reverts_when_account_is_not_blocked() {
-        let mut token = token_with_balance(U256::from(10u64));
+        let mut token = token_with_role(B20TokenRole::BurnBlocked, CALLER, U256::from(10u64));
 
         assert_eq!(
-            token.burn_blocked(CALLER, ALICE, U256::ONE, true).unwrap_err(),
+            token.burn_blocked(CALLER, ALICE, U256::ONE, B20DispatchMode::standard()).unwrap_err(),
             BasePrecompileError::revert(IB20::AccountNotBlocked { account: ALICE })
         );
     }
@@ -183,12 +202,11 @@ mod tests {
         let mut accounting = InMemoryTokenAccounting::new(TOKEN_ADDR);
         accounting.balances.insert(ALICE, U256::from(100u64));
         accounting.total_supply = U256::from(100u64);
-        accounting
-            .policy_ids
-            .insert(B20PolicyType::TransferSender.id(), PolicyRegistryStorage::ALWAYS_BLOCK_ID);
+        accounting.roles.insert((B20TokenRole::BurnBlocked.id(), CALLER), true);
+        accounting.policy_ids.insert(B20PolicyType::TransferSender.id(), POLICY_ALWAYS_BLOCK);
         let mut token = TestToken::with_storage_and_policy(accounting, InMemoryPolicy::new());
 
-        token.burn_blocked(CALLER, ALICE, U256::from(25u64), true).unwrap();
+        token.burn_blocked(CALLER, ALICE, U256::from(25u64), B20DispatchMode::standard()).unwrap();
 
         assert_eq!(token.accounting().balance_of(ALICE).unwrap(), U256::from(75u64));
         assert_eq!(token.accounting().total_supply().unwrap(), U256::from(75u64));
@@ -200,17 +218,29 @@ mod tests {
         let mut accounting = InMemoryTokenAccounting::new(TOKEN_ADDR);
         accounting.balances.insert(ALICE, U256::from(10u64));
         accounting.total_supply = U256::from(10u64);
-        accounting
-            .policy_ids
-            .insert(B20PolicyType::TransferSender.id(), PolicyRegistryStorage::ALWAYS_BLOCK_ID);
+        accounting.policy_ids.insert(B20PolicyType::TransferSender.id(), POLICY_ALWAYS_BLOCK);
         let mut token = TestToken::with_storage_and_policy(accounting, InMemoryPolicy::new());
 
         assert_eq!(
-            token.burn_blocked(CALLER, ALICE, U256::ONE, false).unwrap_err(),
+            token.burn_blocked(CALLER, ALICE, U256::ONE, B20DispatchMode::standard()).unwrap_err(),
             BasePrecompileError::revert(IB20::AccessControlUnauthorizedAccount {
                 account: CALLER,
                 neededRole: B20TokenRole::BurnBlocked.id(),
             })
         );
+    }
+
+    #[test]
+    fn factory_init_burn_blocked_bypasses_role_pause_and_blocked_policy() {
+        let mut accounting = InMemoryTokenAccounting::new(TOKEN_ADDR);
+        accounting.balances.insert(ALICE, U256::from(10u64));
+        accounting.total_supply = U256::from(10u64);
+        accounting.paused = B20PausableFeature::mask(IB20::PausableFeature::BURN);
+        let mut token = TestToken::with_storage_and_policy(accounting, InMemoryPolicy::new());
+
+        token.burn_blocked(CALLER, ALICE, U256::ONE, B20DispatchMode::factory_init()).unwrap();
+
+        assert_eq!(token.accounting().balance_of(ALICE).unwrap(), U256::from(9u64));
+        assert_eq!(token.accounting().total_supply().unwrap(), U256::from(9u64));
     }
 }

--- a/crates/common/precompiles/src/common/ops/configurable.rs
+++ b/crates/common/precompiles/src/common/ops/configurable.rs
@@ -5,7 +5,7 @@ use alloy_sol_types::SolEvent;
 use base_precompile_storage::{BasePrecompileError, Result};
 
 use super::guards::B20Guards;
-use crate::{B20TokenRole, IB20, Token, TokenAccounting};
+use crate::{B20DispatchMode, B20TokenRole, IB20, Token, TokenAccounting};
 
 /// Mutable configuration operations: supply cap, metadata, and contract URI updates.
 ///
@@ -13,8 +13,13 @@ use crate::{B20TokenRole, IB20, Token, TokenAccounting};
 /// Implement with an empty body to opt in.
 pub trait Configurable: Token {
     /// Updates the supply cap. Requires `DEFAULT_ADMIN_ROLE`. Emits `SupplyCapUpdated`.
-    fn set_supply_cap(&mut self, caller: Address, new_cap: U256, privileged: bool) -> Result<()> {
-        if !privileged {
+    fn set_supply_cap(
+        &mut self,
+        caller: Address,
+        new_cap: U256,
+        mode: B20DispatchMode,
+    ) -> Result<()> {
+        if !mode.is_factory_init() {
             B20Guards::ensure_token_role::<Self>(self, caller, B20TokenRole::DefaultAdmin)?;
         }
         let supply = self.accounting().total_supply()?;
@@ -33,8 +38,8 @@ pub trait Configurable: Token {
     }
 
     /// Updates the token name. Emits `NameUpdated`.
-    fn set_name(&mut self, caller: Address, name: String, privileged: bool) -> Result<()> {
-        if !privileged {
+    fn set_name(&mut self, caller: Address, name: String, mode: B20DispatchMode) -> Result<()> {
+        if !mode.is_factory_init() {
             B20Guards::ensure_token_role::<Self>(self, caller, B20TokenRole::Metadata)?;
         }
         self.accounting_mut().set_name(name.clone())?;
@@ -43,8 +48,8 @@ pub trait Configurable: Token {
     }
 
     /// Updates the token symbol. Emits `SymbolUpdated`.
-    fn set_symbol(&mut self, caller: Address, symbol: String, privileged: bool) -> Result<()> {
-        if !privileged {
+    fn set_symbol(&mut self, caller: Address, symbol: String, mode: B20DispatchMode) -> Result<()> {
+        if !mode.is_factory_init() {
             B20Guards::ensure_token_role::<Self>(self, caller, B20TokenRole::Metadata)?;
         }
         self.accounting_mut().set_symbol(symbol.clone())?;
@@ -54,8 +59,16 @@ pub trait Configurable: Token {
     }
 
     /// Updates the contract URI. Emits `ContractURIUpdated`.
-    fn set_contract_uri(&mut self, caller: Address, uri: String, privileged: bool) -> Result<()> {
-        if !privileged {
+    ///
+    /// Contract URI is administered by `DEFAULT_ADMIN_ROLE` because it can describe token-level
+    /// governance and compliance metadata, while name and symbol use the narrower metadata role.
+    fn set_contract_uri(
+        &mut self,
+        caller: Address,
+        uri: String,
+        mode: B20DispatchMode,
+    ) -> Result<()> {
+        if !mode.is_factory_init() {
             B20Guards::ensure_token_role::<Self>(self, caller, B20TokenRole::DefaultAdmin)?;
         }
         self.accounting_mut().set_contract_uri(uri)?;
@@ -70,7 +83,7 @@ mod tests {
 
     use super::Configurable;
     use crate::{
-        B20TokenRole, IB20,
+        B20DispatchMode, B20TokenRole, IB20,
         common::{
             Token, TokenAccounting,
             test_utils::{InMemoryPolicy, InMemoryTokenAccounting, TestToken},
@@ -97,7 +110,7 @@ mod tests {
     fn set_supply_cap_updates_cap_and_emits_event() {
         let mut token = make_token();
 
-        token.set_supply_cap(CALLER, U256::from(500u64), true).unwrap();
+        token.set_supply_cap(CALLER, U256::from(500u64), B20DispatchMode::factory_init()).unwrap();
 
         assert_eq!(token.accounting().supply_cap().unwrap(), U256::from(500u64));
         assert_eq!(token.accounting().events.len(), 1);
@@ -109,7 +122,9 @@ mod tests {
         token.accounting_mut().total_supply = U256::from(100u64);
 
         assert_eq!(
-            token.set_supply_cap(CALLER, U256::from(99u64), true).unwrap_err(),
+            token
+                .set_supply_cap(CALLER, U256::from(99u64), B20DispatchMode::factory_init())
+                .unwrap_err(),
             BasePrecompileError::revert(IB20::InvalidSupplyCap {
                 currentSupply: U256::from(100u64),
                 proposedCap: U256::from(99u64),
@@ -121,7 +136,7 @@ mod tests {
     fn set_name_round_trips_and_emits_event() {
         let mut token = make_token();
 
-        token.set_name(CALLER, "MyToken".into(), true).unwrap();
+        token.set_name(CALLER, "MyToken".into(), B20DispatchMode::factory_init()).unwrap();
 
         assert_eq!(token.accounting().name().unwrap(), "MyToken");
         assert_eq!(token.accounting().events.len(), 1);
@@ -131,7 +146,7 @@ mod tests {
     fn set_symbol_round_trips_and_emits_event() {
         let mut token = make_token();
 
-        token.set_symbol(CALLER, "MTK".into(), true).unwrap();
+        token.set_symbol(CALLER, "MTK".into(), B20DispatchMode::factory_init()).unwrap();
 
         assert_eq!(token.accounting().symbol().unwrap(), "MTK");
         assert_eq!(token.accounting().events.len(), 1);
@@ -141,7 +156,9 @@ mod tests {
     fn set_contract_uri_round_trips_and_emits_event() {
         let mut token = make_token();
 
-        token.set_contract_uri(CALLER, "ipfs://abc".into(), true).unwrap();
+        token
+            .set_contract_uri(CALLER, "ipfs://abc".into(), B20DispatchMode::factory_init())
+            .unwrap();
 
         assert_eq!(token.accounting().contract_uri().unwrap(), "ipfs://abc");
         assert_eq!(token.accounting().events.len(), 1);
@@ -152,7 +169,7 @@ mod tests {
         let mut token = make_token();
 
         assert_eq!(
-            token.set_name(CALLER, "MyToken".into(), false).unwrap_err(),
+            token.set_name(CALLER, "MyToken".into(), B20DispatchMode::standard()).unwrap_err(),
             BasePrecompileError::revert(IB20::AccessControlUnauthorizedAccount {
                 account: CALLER,
                 neededRole: B20TokenRole::Metadata.id(),
@@ -165,10 +182,10 @@ mod tests {
         let mut token = token_with_default_admin(CALLER);
         token.accounting_mut().roles.insert((B20TokenRole::Metadata.id(), CALLER), true);
 
-        token.set_supply_cap(CALLER, U256::from(500u64), false).unwrap();
-        token.set_name(CALLER, "MyToken".into(), false).unwrap();
-        token.set_symbol(CALLER, "MTK".into(), false).unwrap();
-        token.set_contract_uri(CALLER, "ipfs://abc".into(), false).unwrap();
+        token.set_supply_cap(CALLER, U256::from(500u64), B20DispatchMode::standard()).unwrap();
+        token.set_name(CALLER, "MyToken".into(), B20DispatchMode::standard()).unwrap();
+        token.set_symbol(CALLER, "MTK".into(), B20DispatchMode::standard()).unwrap();
+        token.set_contract_uri(CALLER, "ipfs://abc".into(), B20DispatchMode::standard()).unwrap();
 
         assert_eq!(token.accounting().supply_cap().unwrap(), U256::from(500u64));
         assert_eq!(token.accounting().name().unwrap(), "MyToken");

--- a/crates/common/precompiles/src/common/ops/mintable.rs
+++ b/crates/common/precompiles/src/common/ops/mintable.rs
@@ -3,7 +3,7 @@ use alloy_sol_types::SolEvent;
 use base_precompile_storage::{BasePrecompileError, Result};
 
 use super::guards::B20Guards;
-use crate::{B20PolicyType, B20TokenRole, IB20, Token, TokenAccounting};
+use crate::{B20DispatchMode, B20PolicyType, B20TokenRole, IB20, Token, TokenAccounting};
 
 /// Token minting operations.
 ///
@@ -11,14 +11,20 @@ use crate::{B20PolicyType, B20TokenRole, IB20, Token, TokenAccounting};
 /// Implement this trait with an empty body to opt in.
 pub trait Mintable: Token {
     /// Creates `amount` tokens at `to`. Enforces supply cap. Emits `Transfer(0x0, to, amount)`.
-    fn mint(&mut self, caller: Address, to: Address, amount: U256, privileged: bool) -> Result<()> {
-        if !privileged {
-            B20Guards::ensure_token_role::<Self>(self, caller, B20TokenRole::Mint)?;
-        }
-        B20Guards::ensure_not_paused::<Self>(self, IB20::PausableFeature::MINT)?;
-        B20Guards::ensure_policy_type::<Self>(self, B20PolicyType::MintReceiver, to)?;
+    fn mint(
+        &mut self,
+        caller: Address,
+        to: Address,
+        amount: U256,
+        mode: B20DispatchMode,
+    ) -> Result<()> {
         if to == Address::ZERO {
             return Err(BasePrecompileError::revert(IB20::InvalidReceiver { receiver: to }));
+        }
+        if !mode.is_factory_init() {
+            B20Guards::ensure_token_role::<Self>(self, caller, B20TokenRole::Mint)?;
+            B20Guards::ensure_not_paused::<Self>(self, IB20::PausableFeature::MINT)?;
+            B20Guards::ensure_policy_type::<Self>(self, B20PolicyType::MintReceiver, to)?;
         }
         let supply = self.accounting().total_supply()?;
         let cap = self.accounting().supply_cap()?;
@@ -46,9 +52,9 @@ pub trait Mintable: Token {
         to: Address,
         amount: U256,
         memo: B256,
-        privileged: bool,
+        mode: B20DispatchMode,
     ) -> Result<()> {
-        self.mint(caller, to, amount, privileged)?;
+        self.mint(caller, to, amount, mode)?;
         self.accounting_mut().emit_event(IB20::Memo { memo }.encode_log_data())
     }
 }
@@ -60,7 +66,8 @@ mod tests {
 
     use super::Mintable;
     use crate::{
-        B20PausableFeature, B20PolicyType, B20TokenRole, IB20, PolicyRegistryStorage,
+        B20DispatchMode, B20PausableFeature, B20PolicyType, B20TokenRole, IB20,
+        POLICY_ALWAYS_BLOCK,
         common::{
             Token, TokenAccounting,
             test_utils::{InMemoryPolicy, InMemoryTokenAccounting, TestToken},
@@ -88,7 +95,7 @@ mod tests {
     fn mint_increases_balance_and_total_supply() {
         let mut token = make_token();
 
-        token.mint(CALLER, ALICE, U256::from(100u64), true).unwrap();
+        token.mint(CALLER, ALICE, U256::from(100u64), B20DispatchMode::factory_init()).unwrap();
 
         assert_eq!(token.accounting().balance_of(ALICE).unwrap(), U256::from(100u64));
         assert_eq!(token.accounting().total_supply().unwrap(), U256::from(100u64));
@@ -100,7 +107,20 @@ mod tests {
         let mut token = make_token();
 
         assert_eq!(
-            token.mint(CALLER, Address::ZERO, U256::ONE, true).unwrap_err(),
+            token.mint(CALLER, Address::ZERO, U256::ONE, B20DispatchMode::standard()).unwrap_err(),
+            BasePrecompileError::revert(IB20::InvalidReceiver { receiver: Address::ZERO })
+        );
+    }
+
+    #[test]
+    fn mint_zero_receiver_reverts_before_role_pause_or_policy() {
+        let mut accounting = InMemoryTokenAccounting::new(TOKEN_ADDR);
+        accounting.paused = B20PausableFeature::mask(IB20::PausableFeature::MINT);
+        accounting.policy_ids.insert(B20PolicyType::MintReceiver.id(), POLICY_ALWAYS_BLOCK);
+        let mut token = TestToken::with_storage_and_policy(accounting, InMemoryPolicy::new());
+
+        assert_eq!(
+            token.mint(CALLER, Address::ZERO, U256::ONE, B20DispatchMode::standard()).unwrap_err(),
             BasePrecompileError::revert(IB20::InvalidReceiver { receiver: Address::ZERO })
         );
     }
@@ -110,7 +130,7 @@ mod tests {
         let mut token = make_token();
         token.accounting_mut().supply_cap = U256::from(100u64);
 
-        token.mint(CALLER, ALICE, U256::from(100u64), true).unwrap();
+        token.mint(CALLER, ALICE, U256::from(100u64), B20DispatchMode::factory_init()).unwrap();
 
         assert_eq!(token.accounting().total_supply().unwrap(), U256::from(100u64));
     }
@@ -121,7 +141,9 @@ mod tests {
         token.accounting_mut().supply_cap = U256::from(50u64);
 
         assert_eq!(
-            token.mint(CALLER, ALICE, U256::from(51u64), true).unwrap_err(),
+            token
+                .mint(CALLER, ALICE, U256::from(51u64), B20DispatchMode::factory_init())
+                .unwrap_err(),
             BasePrecompileError::revert(IB20::SupplyCapExceeded {
                 cap: U256::from(50u64),
                 attempted: U256::from(51u64),
@@ -133,8 +155,8 @@ mod tests {
     fn mint_accumulates_across_calls() {
         let mut token = make_token();
 
-        token.mint(CALLER, ALICE, U256::from(40u64), true).unwrap();
-        token.mint(CALLER, ALICE, U256::from(60u64), true).unwrap();
+        token.mint(CALLER, ALICE, U256::from(40u64), B20DispatchMode::factory_init()).unwrap();
+        token.mint(CALLER, ALICE, U256::from(60u64), B20DispatchMode::factory_init()).unwrap();
 
         assert_eq!(token.accounting().balance_of(ALICE).unwrap(), U256::from(100u64));
         assert_eq!(token.accounting().total_supply().unwrap(), U256::from(100u64));
@@ -145,7 +167,7 @@ mod tests {
         let mut token = make_token();
 
         assert_eq!(
-            token.mint(CALLER, ALICE, U256::ONE, false).unwrap_err(),
+            token.mint(CALLER, ALICE, U256::ONE, B20DispatchMode::standard()).unwrap_err(),
             BasePrecompileError::revert(IB20::AccessControlUnauthorizedAccount {
                 account: CALLER,
                 neededRole: B20TokenRole::Mint.id(),
@@ -157,7 +179,7 @@ mod tests {
     fn non_privileged_mint_with_role_succeeds() {
         let mut token = token_with_role(B20TokenRole::Mint, CALLER);
 
-        token.mint(CALLER, ALICE, U256::from(10u64), false).unwrap();
+        token.mint(CALLER, ALICE, U256::from(10u64), B20DispatchMode::standard()).unwrap();
 
         assert_eq!(token.accounting().balance_of(ALICE).unwrap(), U256::from(10u64));
     }
@@ -166,10 +188,11 @@ mod tests {
     fn mint_reverts_when_mint_feature_paused() {
         let mut accounting = InMemoryTokenAccounting::new(TOKEN_ADDR);
         accounting.paused = B20PausableFeature::mask(IB20::PausableFeature::MINT);
+        accounting.roles.insert((B20TokenRole::Mint.id(), CALLER), true);
         let mut token = TestToken::with_storage_and_policy(accounting, InMemoryPolicy::new());
 
         assert_eq!(
-            token.mint(CALLER, ALICE, U256::ONE, true).unwrap_err(),
+            token.mint(CALLER, ALICE, U256::ONE, B20DispatchMode::standard()).unwrap_err(),
             BasePrecompileError::revert(IB20::ContractPaused {
                 feature: IB20::PausableFeature::MINT,
             })
@@ -179,17 +202,29 @@ mod tests {
     #[test]
     fn mint_reverts_when_receiver_policy_denies() {
         let mut accounting = InMemoryTokenAccounting::new(TOKEN_ADDR);
-        accounting
-            .policy_ids
-            .insert(B20PolicyType::MintReceiver.id(), PolicyRegistryStorage::ALWAYS_BLOCK_ID);
+        accounting.roles.insert((B20TokenRole::Mint.id(), CALLER), true);
+        accounting.policy_ids.insert(B20PolicyType::MintReceiver.id(), POLICY_ALWAYS_BLOCK);
         let mut token = TestToken::with_storage_and_policy(accounting, InMemoryPolicy::new());
 
         assert_eq!(
-            token.mint(CALLER, ALICE, U256::ONE, true).unwrap_err(),
+            token.mint(CALLER, ALICE, U256::ONE, B20DispatchMode::standard()).unwrap_err(),
             BasePrecompileError::revert(IB20::PolicyForbids {
                 policyType: B20PolicyType::MintReceiver.id(),
-                policyId: PolicyRegistryStorage::ALWAYS_BLOCK_ID,
+                policyId: POLICY_ALWAYS_BLOCK,
             })
         );
+    }
+
+    #[test]
+    fn factory_init_mint_bypasses_role_pause_and_policy() {
+        let mut accounting = InMemoryTokenAccounting::new(TOKEN_ADDR);
+        accounting.paused = B20PausableFeature::mask(IB20::PausableFeature::MINT);
+        accounting.policy_ids.insert(B20PolicyType::MintReceiver.id(), POLICY_ALWAYS_BLOCK);
+        let mut token = TestToken::with_storage_and_policy(accounting, InMemoryPolicy::new());
+
+        token.mint(CALLER, ALICE, U256::from(10u64), B20DispatchMode::factory_init()).unwrap();
+
+        assert_eq!(token.accounting().balance_of(ALICE).unwrap(), U256::from(10u64));
+        assert_eq!(token.accounting().total_supply().unwrap(), U256::from(10u64));
     }
 }

--- a/crates/common/precompiles/src/common/ops/pausable.rs
+++ b/crates/common/precompiles/src/common/ops/pausable.rs
@@ -5,7 +5,7 @@ use alloy_sol_types::SolEvent;
 use base_precompile_storage::{BasePrecompileError, Result};
 
 use super::guards::B20Guards;
-use crate::{B20PausableFeature, B20TokenRole, IB20, Token, TokenAccounting};
+use crate::{B20DispatchMode, B20PausableFeature, B20TokenRole, IB20, Token, TokenAccounting};
 
 /// Pause and unpause operations.
 ///
@@ -37,16 +37,19 @@ pub trait Pausable: Token {
     }
 
     /// ORs `features` into the current paused bitmask.
+    ///
+    /// Re-pausing an already paused feature is intentionally idempotent and still emits the
+    /// requested feature list.
     fn pause(
         &mut self,
         caller: Address,
         features: Vec<IB20::PausableFeature>,
-        privileged: bool,
+        mode: B20DispatchMode,
     ) -> Result<()> {
         if features.is_empty() {
             return Err(BasePrecompileError::revert(IB20::EmptyFeatureSet {}));
         }
-        if !privileged {
+        if !mode.is_factory_init() {
             B20Guards::ensure_token_role::<Self>(self, caller, B20TokenRole::Pause)?;
         }
         let current = self.accounting().paused()?;
@@ -60,16 +63,19 @@ pub trait Pausable: Token {
     }
 
     /// Clears `features` from the current paused bitmask.
+    ///
+    /// Unpausing an already active feature is intentionally idempotent and still emits the
+    /// requested feature list.
     fn unpause(
         &mut self,
         caller: Address,
         features: Vec<IB20::PausableFeature>,
-        privileged: bool,
+        mode: B20DispatchMode,
     ) -> Result<()> {
         if features.is_empty() {
             return Err(BasePrecompileError::revert(IB20::EmptyFeatureSet {}));
         }
-        if !privileged {
+        if !mode.is_factory_init() {
             B20Guards::ensure_token_role::<Self>(self, caller, B20TokenRole::Unpause)?;
         }
         let mut next = self.accounting().paused()?;
@@ -91,7 +97,7 @@ mod tests {
 
     use super::Pausable;
     use crate::{
-        B20PausableFeature, B20TokenRole, IB20,
+        B20DispatchMode, B20PausableFeature, B20TokenRole, IB20,
         common::{
             Token,
             test_utils::{InMemoryPolicy, InMemoryTokenAccounting, TestToken},
@@ -118,7 +124,9 @@ mod tests {
     fn pause_sets_feature_and_emits_event() {
         let mut token = make_token();
 
-        token.pause(CALLER, vec![IB20::PausableFeature::TRANSFER], true).unwrap();
+        token
+            .pause(CALLER, vec![IB20::PausableFeature::TRANSFER], B20DispatchMode::factory_init())
+            .unwrap();
 
         assert!(token.is_paused(IB20::PausableFeature::TRANSFER).unwrap());
         assert_eq!(token.accounting().events.len(), 1);
@@ -128,9 +136,15 @@ mod tests {
     fn pause_ors_multiple_features_into_existing_bitmask() {
         let mut token = make_token();
 
-        token.pause(CALLER, vec![IB20::PausableFeature::TRANSFER], true).unwrap();
         token
-            .pause(CALLER, vec![IB20::PausableFeature::MINT, IB20::PausableFeature::BURN], true)
+            .pause(CALLER, vec![IB20::PausableFeature::TRANSFER], B20DispatchMode::factory_init())
+            .unwrap();
+        token
+            .pause(
+                CALLER,
+                vec![IB20::PausableFeature::MINT, IB20::PausableFeature::BURN],
+                B20DispatchMode::factory_init(),
+            )
             .unwrap();
 
         assert!(token.is_paused(IB20::PausableFeature::TRANSFER).unwrap());
@@ -143,9 +157,15 @@ mod tests {
         let mut token = make_token();
 
         token
-            .pause(CALLER, vec![IB20::PausableFeature::TRANSFER, IB20::PausableFeature::MINT], true)
+            .pause(
+                CALLER,
+                vec![IB20::PausableFeature::TRANSFER, IB20::PausableFeature::MINT],
+                B20DispatchMode::factory_init(),
+            )
             .unwrap();
-        token.unpause(CALLER, vec![IB20::PausableFeature::MINT], true).unwrap();
+        token
+            .unpause(CALLER, vec![IB20::PausableFeature::MINT], B20DispatchMode::factory_init())
+            .unwrap();
 
         assert!(token.is_paused(IB20::PausableFeature::TRANSFER).unwrap());
         assert!(!token.is_paused(IB20::PausableFeature::MINT).unwrap());
@@ -169,7 +189,7 @@ mod tests {
         let mut token = make_token();
 
         assert_eq!(
-            token.pause(CALLER, vec![], true).unwrap_err(),
+            token.pause(CALLER, vec![], B20DispatchMode::standard()).unwrap_err(),
             BasePrecompileError::revert(IB20::EmptyFeatureSet {})
         );
     }
@@ -179,7 +199,7 @@ mod tests {
         let mut token = make_token();
 
         assert_eq!(
-            token.unpause(CALLER, vec![], true).unwrap_err(),
+            token.unpause(CALLER, vec![], B20DispatchMode::standard()).unwrap_err(),
             BasePrecompileError::revert(IB20::EmptyFeatureSet {})
         );
     }
@@ -189,7 +209,9 @@ mod tests {
         let mut token = make_token();
 
         assert_eq!(
-            token.pause(CALLER, vec![IB20::PausableFeature::TRANSFER], false).unwrap_err(),
+            token
+                .pause(CALLER, vec![IB20::PausableFeature::TRANSFER], B20DispatchMode::standard())
+                .unwrap_err(),
             BasePrecompileError::revert(IB20::AccessControlUnauthorizedAccount {
                 account: CALLER,
                 neededRole: B20TokenRole::Pause.id(),
@@ -201,7 +223,9 @@ mod tests {
     fn non_privileged_pause_with_role_succeeds() {
         let mut token = token_with_role(B20TokenRole::Pause, CALLER);
 
-        token.pause(CALLER, vec![IB20::PausableFeature::TRANSFER], false).unwrap();
+        token
+            .pause(CALLER, vec![IB20::PausableFeature::TRANSFER], B20DispatchMode::standard())
+            .unwrap();
 
         assert!(token.is_paused(IB20::PausableFeature::TRANSFER).unwrap());
     }
@@ -213,7 +237,13 @@ mod tests {
         let mut token = TestToken::with_storage_and_policy(accounting, InMemoryPolicy::new());
 
         assert_eq!(
-            token.unpause(CALLER, vec![IB20::PausableFeature::TRANSFER], false).unwrap_err(),
+            token
+                .unpause(
+                    CALLER,
+                    vec![IB20::PausableFeature::TRANSFER],
+                    B20DispatchMode::standard(),
+                )
+                .unwrap_err(),
             BasePrecompileError::revert(IB20::AccessControlUnauthorizedAccount {
                 account: CALLER,
                 neededRole: B20TokenRole::Unpause.id(),
@@ -228,7 +258,9 @@ mod tests {
         accounting.roles.insert((B20TokenRole::Unpause.id(), CALLER), true);
         let mut token = TestToken::with_storage_and_policy(accounting, InMemoryPolicy::new());
 
-        token.unpause(CALLER, vec![IB20::PausableFeature::TRANSFER], false).unwrap();
+        token
+            .unpause(CALLER, vec![IB20::PausableFeature::TRANSFER], B20DispatchMode::standard())
+            .unwrap();
 
         assert!(!token.is_paused(IB20::PausableFeature::TRANSFER).unwrap());
     }

--- a/crates/common/precompiles/src/common/ops/roles.rs
+++ b/crates/common/precompiles/src/common/ops/roles.rs
@@ -5,7 +5,7 @@ use alloy_sol_types::SolEvent;
 use base_precompile_storage::{BasePrecompileError, Result};
 
 use super::guards::B20Guards;
-use crate::{IB20, Token, TokenAccounting};
+use crate::{B20DispatchMode, IB20, Token, TokenAccounting};
 
 const MINT_ROLE: B256 = b256!("154c00819833dac601ee5ddded6fda79d9d8b506b911b3dbd54cdb95fe6c3686");
 const BURN_ROLE: B256 = b256!("e97b137254058bd94f28d2f3eb79e2d34074ffb488d042e3bc958e0a57d2fa22");
@@ -111,13 +111,13 @@ pub trait RoleManaged: Token {
         if self.accounting().has_role(role, account)? {
             return Ok(());
         }
-        self.accounting_mut().set_role(role, account, true)?;
         if role == Self::default_admin_role() {
             let current = self.accounting().role_member_count(role)?;
             let next =
                 current.checked_add(U256::ONE).ok_or_else(BasePrecompileError::under_overflow)?;
             self.accounting_mut().set_role_member_count(role, next)?;
         }
+        self.accounting_mut().set_role(role, account, true)?;
         self.accounting_mut()
             .emit_event(IB20::RoleGranted { role, account, sender }.encode_log_data())
     }
@@ -132,13 +132,13 @@ pub trait RoleManaged: Token {
         if !self.accounting().has_role(role, account)? {
             return Ok(());
         }
-        self.accounting_mut().set_role(role, account, false)?;
         if role == Self::default_admin_role() {
             let current = self.accounting().role_member_count(role)?;
             let next =
                 current.checked_sub(U256::ONE).ok_or_else(BasePrecompileError::under_overflow)?;
             self.accounting_mut().set_role_member_count(role, next)?;
         }
+        self.accounting_mut().set_role(role, account, false)?;
         self.accounting_mut()
             .emit_event(IB20::RoleRevoked { role, account, sender }.encode_log_data())
     }
@@ -154,9 +154,9 @@ pub trait RoleManaged: Token {
         caller: Address,
         role: B256,
         account: Address,
-        privileged: bool,
+        mode: B20DispatchMode,
     ) -> Result<()> {
-        if !privileged {
+        if !mode.is_factory_init() {
             self.ensure_role(caller, self.role_admin(role)?)?;
         }
         self.grant_role_unchecked(role, account, caller)
@@ -168,9 +168,9 @@ pub trait RoleManaged: Token {
         caller: Address,
         role: B256,
         account: Address,
-        privileged: bool,
+        mode: B20DispatchMode,
     ) -> Result<()> {
-        if !privileged {
+        if !mode.is_factory_init() {
             self.ensure_role(caller, self.role_admin(role)?)?;
         }
         self.revoke_role_unchecked(role, account, caller)
@@ -180,7 +180,9 @@ pub trait RoleManaged: Token {
     ///
     /// Matches `AccessControl` no-op semantics for accounts that do not hold `role`: the call
     /// succeeds and emits no `RoleRevoked` event. The only stricter path is the final
-    /// `DEFAULT_ADMIN_ROLE` holder, which must use [`Self::renounce_last_admin`].
+    /// `DEFAULT_ADMIN_ROLE` holder, which must use [`Self::renounce_last_admin`]. Other roles keep
+    /// standard `AccessControl` semantics: a sole holder can renounce and rely on that role's admin
+    /// to grant it again if recovery is desired.
     fn renounce_role(&mut self, caller: Address, role: B256, confirmation: Address) -> Result<()> {
         if confirmation != caller {
             return Err(BasePrecompileError::revert(IB20::AccessControlBadConfirmation {}));
@@ -217,10 +219,10 @@ pub trait RoleManaged: Token {
         caller: Address,
         role: B256,
         new_admin_role: B256,
-        privileged: bool,
+        mode: B20DispatchMode,
     ) -> Result<()> {
         let previous_admin_role = self.role_admin(role)?;
-        if !privileged {
+        if !mode.is_factory_init() {
             self.ensure_role(caller, previous_admin_role)?;
         }
         self.accounting_mut().set_role_admin(role, new_admin_role)?;
@@ -243,7 +245,7 @@ mod tests {
 
     use super::{B20TokenRole, RoleManaged};
     use crate::{
-        IB20, Token, TokenAccounting,
+        B20DispatchMode, IB20, Token, TokenAccounting,
         common::test_utils::{InMemoryPolicy, InMemoryTokenAccounting, TestToken},
     };
 
@@ -270,7 +272,9 @@ mod tests {
     fn grant_role_authorizes_against_role_admin_and_emits_event() {
         let mut token = token_with_default_admin();
 
-        token.grant_role(ADMIN, B20TokenRole::Mint.id(), ALICE, false).unwrap();
+        token
+            .grant_role(ADMIN, B20TokenRole::Mint.id(), ALICE, B20DispatchMode::standard())
+            .unwrap();
 
         assert!(token.has_role(B20TokenRole::Mint.id(), ALICE).unwrap());
         assert_eq!(
@@ -285,7 +289,9 @@ mod tests {
         let mut token = make_token();
 
         assert_eq!(
-            token.grant_role(ADMIN, B20TokenRole::Mint.id(), ALICE, false).unwrap_err(),
+            token
+                .grant_role(ADMIN, B20TokenRole::Mint.id(), ALICE, B20DispatchMode::standard())
+                .unwrap_err(),
             BasePrecompileError::revert(IB20::AccessControlUnauthorizedAccount {
                 account: ADMIN,
                 neededRole: B256::ZERO,
@@ -324,7 +330,14 @@ mod tests {
     fn set_role_admin_emits_previous_and_new_admin_roles() {
         let mut token = token_with_default_admin();
 
-        token.set_role_admin(ADMIN, CUSTOM_ROLE, B20TokenRole::Mint.id(), false).unwrap();
+        token
+            .set_role_admin(
+                ADMIN,
+                CUSTOM_ROLE,
+                B20TokenRole::Mint.id(),
+                B20DispatchMode::standard(),
+            )
+            .unwrap();
 
         assert_eq!(token.role_admin(CUSTOM_ROLE).unwrap(), B20TokenRole::Mint.id());
         assert_eq!(

--- a/crates/common/precompiles/src/common/ops/transferable.rs
+++ b/crates/common/precompiles/src/common/ops/transferable.rs
@@ -3,7 +3,7 @@ use alloy_sol_types::SolEvent;
 use base_precompile_storage::{BasePrecompileError, Result};
 
 use super::guards::B20Guards;
-use crate::{B20PolicyType, IB20, Token, TokenAccounting};
+use crate::{B20DispatchMode, B20PolicyType, IB20, Token, TokenAccounting};
 
 /// ERC-20 transfer, approval, and memo-decorated transfer operations.
 ///
@@ -12,14 +12,27 @@ use crate::{B20PolicyType, IB20, Token, TokenAccounting};
 pub trait Transferable: Token {
     /// Moves `amount` tokens from `from` to `to`. Emits `Transfer`.
     fn transfer(&mut self, from: Address, to: Address, amount: U256) -> Result<()> {
-        B20Guards::ensure_not_paused::<Self>(self, IB20::PausableFeature::TRANSFER)?;
-        B20Guards::ensure_policy_type::<Self>(self, B20PolicyType::TransferSender, from)?;
-        B20Guards::ensure_policy_type::<Self>(self, B20PolicyType::TransferReceiver, to)?;
+        self.transfer_with_mode(from, to, amount, B20DispatchMode::standard())
+    }
+
+    /// Moves `amount` tokens from `from` to `to` using `mode` for factory bootstrap.
+    fn transfer_with_mode(
+        &mut self,
+        from: Address,
+        to: Address,
+        amount: U256,
+        mode: B20DispatchMode,
+    ) -> Result<()> {
         if from == Address::ZERO {
             return Err(BasePrecompileError::revert(IB20::InvalidSender { sender: from }));
         }
         if to == Address::ZERO {
             return Err(BasePrecompileError::revert(IB20::InvalidReceiver { receiver: to }));
+        }
+        if !mode.is_factory_init() {
+            B20Guards::ensure_not_paused::<Self>(self, IB20::PausableFeature::TRANSFER)?;
+            B20Guards::ensure_policy_type::<Self>(self, B20PolicyType::TransferSender, from)?;
+            B20Guards::ensure_policy_type::<Self>(self, B20PolicyType::TransferReceiver, to)?;
         }
         let from_balance = self.accounting().balance_of(from)?;
         if from_balance < amount {
@@ -46,26 +59,37 @@ pub trait Transferable: Token {
         to: Address,
         amount: U256,
     ) -> Result<()> {
+        self.transfer_from_with_mode(spender, from, to, amount, B20DispatchMode::standard())
+    }
+
+    /// Moves `amount` tokens from `from` to `to` using `spender`'s allowance and `mode`.
+    fn transfer_from_with_mode(
+        &mut self,
+        spender: Address,
+        from: Address,
+        to: Address,
+        amount: U256,
+        mode: B20DispatchMode,
+    ) -> Result<()> {
         if from == Address::ZERO {
             return Err(BasePrecompileError::revert(IB20::InvalidSender { sender: from }));
         }
-        if spender != from {
+        if !mode.is_factory_init() && spender != from {
             B20Guards::ensure_policy_type::<Self>(self, B20PolicyType::TransferExecutor, spender)?;
-        }
-        let allowance = self.accounting().allowance(from, spender)?;
-        if allowance != U256::MAX {
-            if allowance < amount {
-                return Err(BasePrecompileError::revert(IB20::InsufficientAllowance {
-                    spender,
-                    allowance,
-                    needed: amount,
-                }));
+            let allowance = self.accounting().allowance(from, spender)?;
+            if allowance != U256::MAX {
+                if allowance < amount {
+                    return Err(BasePrecompileError::revert(IB20::InsufficientAllowance {
+                        spender,
+                        allowance,
+                        needed: amount,
+                    }));
+                }
+                self.transfer_with_mode(from, to, amount, mode)?;
+                return self.accounting_mut().set_allowance(from, spender, allowance - amount);
             }
-            self.transfer(from, to, amount)?;
-            self.accounting_mut().set_allowance(from, spender, allowance - amount)
-        } else {
-            self.transfer(from, to, amount)
         }
+        self.transfer_with_mode(from, to, amount, mode)
     }
 
     /// Sets `spender`'s allowance from `owner` to `amount`. Emits `Approval`.
@@ -89,7 +113,19 @@ pub trait Transferable: Token {
         amount: U256,
         memo: B256,
     ) -> Result<()> {
-        self.transfer(from, to, amount)?;
+        self.transfer_with_memo_with_mode(from, to, amount, memo, B20DispatchMode::standard())
+    }
+
+    /// [`Self::transfer_with_mode`] followed by a `Memo` event.
+    fn transfer_with_memo_with_mode(
+        &mut self,
+        from: Address,
+        to: Address,
+        amount: U256,
+        memo: B256,
+        mode: B20DispatchMode,
+    ) -> Result<()> {
+        self.transfer_with_mode(from, to, amount, mode)?;
         self.accounting_mut().emit_event(IB20::Memo { memo }.encode_log_data())
     }
 
@@ -102,7 +138,27 @@ pub trait Transferable: Token {
         amount: U256,
         memo: B256,
     ) -> Result<()> {
-        self.transfer_from(spender, from, to, amount)?;
+        self.transfer_from_with_memo_with_mode(
+            spender,
+            from,
+            to,
+            amount,
+            memo,
+            B20DispatchMode::standard(),
+        )
+    }
+
+    /// [`Self::transfer_from_with_mode`] followed by a `Memo` event.
+    fn transfer_from_with_memo_with_mode(
+        &mut self,
+        spender: Address,
+        from: Address,
+        to: Address,
+        amount: U256,
+        memo: B256,
+        mode: B20DispatchMode,
+    ) -> Result<()> {
+        self.transfer_from_with_mode(spender, from, to, amount, mode)?;
         self.accounting_mut().emit_event(IB20::Memo { memo }.encode_log_data())
     }
 }
@@ -114,7 +170,7 @@ mod tests {
 
     use super::Transferable;
     use crate::{
-        B20PausableFeature, B20PolicyType, IB20, PolicyRegistryStorage,
+        B20DispatchMode, B20PausableFeature, B20PolicyType, IB20, POLICY_ALWAYS_BLOCK,
         common::{
             Token, TokenAccounting,
             test_utils::{InMemoryPolicy, InMemoryTokenAccounting, TestToken},
@@ -163,6 +219,33 @@ mod tests {
     #[test]
     fn transfer_to_zero_receiver_reverts() {
         let mut token = token_with_balance(U256::from(100u64));
+
+        assert_eq!(
+            token.transfer(ALICE, Address::ZERO, U256::ONE).unwrap_err(),
+            BasePrecompileError::revert(IB20::InvalidReceiver { receiver: Address::ZERO })
+        );
+    }
+
+    #[test]
+    fn transfer_zero_sender_reverts_before_pause_or_policy() {
+        let mut accounting = InMemoryTokenAccounting::new(TOKEN_ADDR);
+        accounting.paused = B20PausableFeature::mask(IB20::PausableFeature::TRANSFER);
+        accounting.policy_ids.insert(B20PolicyType::TransferSender.id(), POLICY_ALWAYS_BLOCK);
+        let mut token = TestToken::with_storage_and_policy(accounting, InMemoryPolicy::new());
+
+        assert_eq!(
+            token.transfer(Address::ZERO, BOB, U256::ONE).unwrap_err(),
+            BasePrecompileError::revert(IB20::InvalidSender { sender: Address::ZERO })
+        );
+    }
+
+    #[test]
+    fn transfer_zero_receiver_reverts_before_pause_or_policy() {
+        let mut accounting = InMemoryTokenAccounting::new(TOKEN_ADDR);
+        accounting.balances.insert(ALICE, U256::from(100u64));
+        accounting.paused = B20PausableFeature::mask(IB20::PausableFeature::TRANSFER);
+        accounting.policy_ids.insert(B20PolicyType::TransferReceiver.id(), POLICY_ALWAYS_BLOCK);
+        let mut token = TestToken::with_storage_and_policy(accounting, InMemoryPolicy::new());
 
         assert_eq!(
             token.transfer(ALICE, Address::ZERO, U256::ONE).unwrap_err(),
@@ -280,34 +363,67 @@ mod tests {
     fn transfer_reverts_when_sender_policy_denies() {
         let mut accounting = InMemoryTokenAccounting::new(TOKEN_ADDR);
         accounting.balances.insert(ALICE, U256::from(10u64));
-        accounting
-            .policy_ids
-            .insert(B20PolicyType::TransferSender.id(), PolicyRegistryStorage::ALWAYS_BLOCK_ID);
+        accounting.policy_ids.insert(B20PolicyType::TransferSender.id(), POLICY_ALWAYS_BLOCK);
         let mut token = TestToken::with_storage_and_policy(accounting, InMemoryPolicy::new());
 
         assert_eq!(
             token.transfer(ALICE, BOB, U256::ONE).unwrap_err(),
             BasePrecompileError::revert(IB20::PolicyForbids {
                 policyType: B20PolicyType::TransferSender.id(),
-                policyId: PolicyRegistryStorage::ALWAYS_BLOCK_ID,
+                policyId: POLICY_ALWAYS_BLOCK,
             })
         );
+    }
+
+    #[test]
+    fn factory_init_transfer_bypasses_pause_and_policy() {
+        let mut accounting = InMemoryTokenAccounting::new(TOKEN_ADDR);
+        accounting.balances.insert(ALICE, U256::from(10u64));
+        accounting.paused = B20PausableFeature::mask(IB20::PausableFeature::TRANSFER);
+        accounting.policy_ids.insert(B20PolicyType::TransferSender.id(), POLICY_ALWAYS_BLOCK);
+        accounting.policy_ids.insert(B20PolicyType::TransferReceiver.id(), POLICY_ALWAYS_BLOCK);
+        let mut token = TestToken::with_storage_and_policy(accounting, InMemoryPolicy::new());
+
+        token.transfer_with_mode(ALICE, BOB, U256::ONE, B20DispatchMode::factory_init()).unwrap();
+
+        assert_eq!(token.accounting().balance_of(ALICE).unwrap(), U256::from(9u64));
+        assert_eq!(token.accounting().balance_of(BOB).unwrap(), U256::ONE);
+    }
+
+    #[test]
+    fn factory_init_transfer_from_bypasses_allowance_and_executor_policy() {
+        let mut accounting = InMemoryTokenAccounting::new(TOKEN_ADDR);
+        accounting.balances.insert(ALICE, U256::from(10u64));
+        accounting.paused = B20PausableFeature::mask(IB20::PausableFeature::TRANSFER);
+        accounting.policy_ids.insert(B20PolicyType::TransferExecutor.id(), POLICY_ALWAYS_BLOCK);
+        let mut token = TestToken::with_storage_and_policy(accounting, InMemoryPolicy::new());
+
+        token
+            .transfer_from_with_mode(
+                SPENDER,
+                ALICE,
+                BOB,
+                U256::ONE,
+                B20DispatchMode::factory_init(),
+            )
+            .unwrap();
+
+        assert_eq!(token.accounting().allowance(ALICE, SPENDER).unwrap(), U256::ZERO);
+        assert_eq!(token.accounting().balance_of(BOB).unwrap(), U256::ONE);
     }
 
     #[test]
     fn transfer_reverts_when_receiver_policy_denies() {
         let mut accounting = InMemoryTokenAccounting::new(TOKEN_ADDR);
         accounting.balances.insert(ALICE, U256::from(10u64));
-        accounting
-            .policy_ids
-            .insert(B20PolicyType::TransferReceiver.id(), PolicyRegistryStorage::ALWAYS_BLOCK_ID);
+        accounting.policy_ids.insert(B20PolicyType::TransferReceiver.id(), POLICY_ALWAYS_BLOCK);
         let mut token = TestToken::with_storage_and_policy(accounting, InMemoryPolicy::new());
 
         assert_eq!(
             token.transfer(ALICE, BOB, U256::ONE).unwrap_err(),
             BasePrecompileError::revert(IB20::PolicyForbids {
                 policyType: B20PolicyType::TransferReceiver.id(),
-                policyId: PolicyRegistryStorage::ALWAYS_BLOCK_ID,
+                policyId: POLICY_ALWAYS_BLOCK,
             })
         );
     }
@@ -317,16 +433,14 @@ mod tests {
         let mut accounting = InMemoryTokenAccounting::new(TOKEN_ADDR);
         accounting.balances.insert(ALICE, U256::from(10u64));
         accounting.allowances.insert((ALICE, SPENDER), U256::from(10u64));
-        accounting
-            .policy_ids
-            .insert(B20PolicyType::TransferExecutor.id(), PolicyRegistryStorage::ALWAYS_BLOCK_ID);
+        accounting.policy_ids.insert(B20PolicyType::TransferExecutor.id(), POLICY_ALWAYS_BLOCK);
         let mut token = TestToken::with_storage_and_policy(accounting, InMemoryPolicy::new());
 
         assert_eq!(
             token.transfer_from(SPENDER, ALICE, BOB, U256::ONE).unwrap_err(),
             BasePrecompileError::revert(IB20::PolicyForbids {
                 policyType: B20PolicyType::TransferExecutor.id(),
-                policyId: PolicyRegistryStorage::ALWAYS_BLOCK_ID,
+                policyId: POLICY_ALWAYS_BLOCK,
             })
         );
     }

--- a/crates/common/precompiles/src/factory/storage.rs
+++ b/crates/common/precompiles/src/factory/storage.rs
@@ -8,9 +8,9 @@ use revm::state::Bytecode;
 
 use super::variant::TokenVariant;
 use crate::{
-    B20SecurityInit, B20SecurityStorage, B20SecurityToken, B20StablecoinInit, B20StablecoinStorage,
-    B20StablecoinToken, B20Token, B20TokenInit, B20TokenRole, B20TokenStorage, ITokenFactory,
-    PolicyHandle, RoleManaged, Token,
+    B20DispatchMode, B20SecurityInit, B20SecurityStorage, B20SecurityToken, B20StablecoinInit,
+    B20StablecoinStorage, B20StablecoinToken, B20Token, B20TokenInit, B20TokenRole,
+    B20TokenStorage, ITokenFactory, PolicyHandle, RoleManaged, Token,
 };
 
 /// Maximum total supply for all newly-created B-20 tokens.
@@ -35,6 +35,10 @@ impl<'a> TokenFactoryStorage<'a> {
     pub const DEFAULT_SUPPLY_CAP: U256 = DEFAULT_SUPPLY_CAP;
 
     /// Creates a token at a deterministic address derived from `(caller, variant, salt)`.
+    ///
+    /// `initialAdmin == address(0)` intentionally creates an adminless token unless `initCalls`
+    /// grant roles during the factory bootstrap window. During that window the creator is trusted
+    /// to configure roles, policies, supply, and metadata atomically before the token is returned.
     pub fn create_token(
         &mut self,
         caller: Address,
@@ -120,7 +124,7 @@ impl<'a> TokenFactoryStorage<'a> {
 
         for (index, calldata) in init_calls.into_iter().enumerate() {
             token
-                .inner_with_privilege(self.storage, &calldata, true)
+                .inner_with_mode(self.storage, &calldata, B20DispatchMode::factory_init())
                 .map_err(|err| Self::map_init_call_error(index, err))?;
         }
         Ok(())
@@ -158,7 +162,7 @@ impl<'a> TokenFactoryStorage<'a> {
 
         for (index, calldata) in init_calls.into_iter().enumerate() {
             token
-                .inner_with_privilege(self.storage, &calldata, true)
+                .inner_with_mode(self.storage, &calldata, B20DispatchMode::factory_init())
                 .map_err(|err| Self::map_init_call_error(index, err))?;
         }
         Ok(())
@@ -200,7 +204,7 @@ impl<'a> TokenFactoryStorage<'a> {
                 B20SecurityStorage::from_address(token_address, self.storage),
                 PolicyHandle::new(self.storage),
             )
-            .inner_with_privilege(self.storage, &calldata, true)
+            .inner_with_mode(self.storage, &calldata, B20DispatchMode::factory_init())
             .map_err(|err| Self::map_init_call_error(index, err))?;
         }
         Ok(())
@@ -246,6 +250,8 @@ enum TokenCreateParams {
 
 impl TokenCreateParams {
     fn decode(variant: TokenVariant, params: &Bytes) -> Result<Self> {
+        // Decimals are fixed by each variant arm rather than supplied by callers. New variants must
+        // choose their own value here before they become creatable.
         match variant {
             TokenVariant::B20 => {
                 let p = ITokenFactory::B20CreateParams::abi_decode(params)
@@ -343,9 +349,9 @@ mod tests {
 
     use super::*;
     use crate::{
-        ActivationFeature, ActivationRegistryStorage, B20SecurityStorage, B20Token,
-        B20TokenStorage, IB20, IB20Stablecoin, Mintable, Permittable, Token, TokenAccounting,
-        Transferable,
+        ActivationFeature, ActivationRegistryStorage, B20DispatchMode, B20PolicyType,
+        B20SecurityStorage, B20Token, B20TokenStorage, IB20, IB20Stablecoin, Mintable,
+        POLICY_ALWAYS_BLOCK, Permittable, Token, TokenAccounting, Transferable,
     };
 
     const ACTIVATION_ADMIN: Address = address!("0xcb00000000000000000000000000000000000000");
@@ -526,6 +532,61 @@ mod tests {
 
             assert_eq!(token.b20.total_supply.read().unwrap(), supply);
             assert_eq!(token.balance_of(recipient).unwrap(), supply);
+        });
+    }
+
+    #[test]
+    fn test_create_token_init_calls_bypass_authorization_gates_but_apply_accounting() {
+        let mut storage = HashMapStorageProvider::new(1);
+        activate_precompiles(&mut storage);
+        let caller = Address::repeat_byte(0x55);
+        let salt = B256::repeat_byte(0xCE);
+        let alice = Address::repeat_byte(0xCD);
+        let bob = Address::repeat_byte(0xBB);
+        let mut call = create_call(
+            ITokenFactory::TokenVariant::DEFAULT,
+            token_params("Bootstrap Token", "BOOT"),
+            salt,
+        );
+        call.initCalls.push(
+            IB20::pauseCall {
+                features: vec![IB20::PausableFeature::MINT, IB20::PausableFeature::TRANSFER],
+            }
+            .abi_encode()
+            .into(),
+        );
+        call.initCalls.push(
+            IB20::updatePolicyCall {
+                policyType: B20PolicyType::MintReceiver.id(),
+                newPolicyId: POLICY_ALWAYS_BLOCK,
+            }
+            .abi_encode()
+            .into(),
+        );
+        call.initCalls
+            .push(IB20::mintCall { to: alice, amount: U256::from(100u64) }.abi_encode().into());
+        call.initCalls.push(
+            IB20::updatePolicyCall {
+                policyType: B20PolicyType::TransferSender.id(),
+                newPolicyId: POLICY_ALWAYS_BLOCK,
+            }
+            .abi_encode()
+            .into(),
+        );
+        call.initCalls.push(
+            IB20::transferFromCall { from: alice, to: bob, amount: U256::from(25u64) }
+                .abi_encode()
+                .into(),
+        );
+
+        StorageCtx::enter(&mut storage, |ctx| {
+            let mut factory = TokenFactoryStorage::new(ctx);
+            let token_addr = factory.create_token(caller, call).unwrap();
+            let token = B20TokenStorage::from_address(token_addr, ctx);
+
+            assert_eq!(token.balance_of(alice).unwrap(), U256::from(75u64));
+            assert_eq!(token.balance_of(bob).unwrap(), U256::from(25u64));
+            assert_eq!(token.total_supply().unwrap(), U256::from(100u64));
         });
     }
 
@@ -822,9 +883,11 @@ mod tests {
             let bob = Address::repeat_byte(0xBB);
             let mut token = token_at(token_addr, ctx);
 
-            token.mint(alice, alice, U256::from(1_000u64), true).unwrap();
+            token
+                .mint(alice, alice, U256::from(1_000u64), B20DispatchMode::factory_init())
+                .unwrap();
             token.transfer(alice, bob, U256::from(300u64)).unwrap();
-            token.mint(alice, alice, U256::from(200u64), true).unwrap();
+            token.mint(alice, alice, U256::from(200u64), B20DispatchMode::factory_init()).unwrap();
 
             assert_eq!(token.accounting().balance_of(alice).unwrap(), U256::from(900u64));
             assert_eq!(token.accounting().balance_of(bob).unwrap(), U256::from(300u64));

--- a/crates/common/precompiles/src/lib.rs
+++ b/crates/common/precompiles/src/lib.rs
@@ -32,8 +32,9 @@ pub use common::{InMemoryPolicy, InMemoryTokenAccounting, TestStablecoinToken, T
 
 mod b20;
 pub use b20::{
-    B20CoreStorage, B20PausableFeature, B20PolicyType, B20Token, B20TokenInit, B20TokenPrecompile,
-    B20TokenStorage, IB20,
+    B20CoreStorage, B20DispatchMode, B20FactoryInitPrivilege, B20PausableFeature, B20PolicyType,
+    B20Token, B20TokenInit, B20TokenPrecompile, B20TokenStorage, IB20, POLICY_ALWAYS_ALLOW,
+    POLICY_ALWAYS_BLOCK,
 };
 
 mod b20_security;

--- a/crates/common/precompiles/src/policy/storage.rs
+++ b/crates/common/precompiles/src/policy/storage.rs
@@ -205,6 +205,9 @@ impl PolicyRegistryStorage<'_> {
     }
 
     /// Creates a new policy and populates its initial member list.
+    ///
+    /// The ABI accepts any list length; practical batch size is bounded by EVM gas because each
+    /// account writes one membership slot and the emitted event carries the full account list.
     pub fn create_policy_with_accounts(
         &mut self,
         admin: Address,
@@ -377,6 +380,21 @@ impl PolicyRegistryStorage<'_> {
         }
         let packed = PackedPolicy::from_raw(self.policies.at(&policy_id).read()?);
         Ok(packed.exists())
+    }
+
+    /// Returns the `PolicyType` of `policy_id`.
+    pub fn get_policy_type(&self, policy_id: u64) -> Result<PolicyType> {
+        Self::require_well_formed(policy_id)?;
+        if policy_id == Self::ALWAYS_ALLOW_ID || policy_id == Self::ALWAYS_BLOCK_ID {
+            return PolicyType::try_from(Self::policy_id_type(policy_id))
+                .map_err(|_| BasePrecompileError::enum_conversion_error());
+        }
+        let packed = PackedPolicy::from_raw(self.policies.at(&policy_id).read()?);
+        if !packed.exists() {
+            return Err(BasePrecompileError::revert(IPolicyRegistry::PolicyNotFound {}));
+        }
+        PolicyType::try_from(Self::policy_id_type(policy_id))
+            .map_err(|_| BasePrecompileError::enum_conversion_error())
     }
 
     /// Returns the current admin of `policy_id`, or `address(0)` for policies with renounced admin.

--- a/crates/proof/succinct/elf/manifest.toml
+++ b/crates/proof/succinct/elf/manifest.toml
@@ -17,7 +17,7 @@
 
 [[elfs]]
 name = "range-elf-embedded"
-sha256 = "2ce6a3d8d7de8694e064f957e1d6a3b07e71d317190ce9d172608f0e72812e20"
+sha256 = "03c980495c013fe661ca5a5f88b42bd704ea8e05f585f6557e64a7459158c71a"
 
 [[elfs]]
 name = "aggregation-elf"

--- a/devnet/tests/b20_precompile.rs
+++ b/devnet/tests/b20_precompile.rs
@@ -311,6 +311,13 @@ async fn test_b20_metadata_updates() -> Result<()> {
     let token = b20.create_token(TokenVariant::B20, params, salt).await?;
     b20.wait_for_token_code(token, common::TX_RECEIPT_TIMEOUT, common::BLOCK_POLL_INTERVAL).await?;
 
+    b20.send_call(
+        token,
+        IB20::grantRoleCall { role: B20TokenRole::Metadata.id(), account: admin.address() },
+        "grant B-20 metadata role",
+    )
+    .await?;
+
     b20.set_name(token, "New Name").await?;
     b20.set_symbol(token, "NEW").await?;
     b20.set_contract_uri(token, "ipfs://QmTest").await?;


### PR DESCRIPTION
## Summary

This addresses the unresolved PR 2771 review followups around B20 factory initialization, dispatch privilege, and token operation guard ordering. It replaces the public boolean privilege bypass with an internal factory-init dispatch mode, tightens error behavior for unsupported variants and invalid token storage access, and adds regression coverage for init-call bypass semantics. It also documents intentional policy, pause, role, and zero-admin behaviors that came up in review.