### PR TITLE
feat(chains): Add Activation Admin Keys

### DIFF
--- a/crates/common/chains/src/config.rs
+++ b/crates/common/chains/src/config.rs
@@ -362,7 +362,7 @@ const MAINNET: ChainConfig = ChainConfig {
     protocol_versions_address: address!("8062abc286f5e7d9428a0ccb9abd71e50d93b935"),
 
     unsafe_block_signer: Some(address!("Af6E19BE0F9cE7f8afd49a1824851023A8249e8a")),
-    activation_admin_address: None,
+    activation_admin_address: Some(address!("331C9d37BbcebBC9dfAf98FBE3C5B8A39Dd6E771")),
 
     max_gas_limit: 105_000_000,
     prune_delete_limit: 20_000,
@@ -435,7 +435,7 @@ const SEPOLIA: ChainConfig = ChainConfig {
     protocol_versions_address: address!("79add5713b383daa0a138d3c4780c7a1804a8090"),
 
     unsafe_block_signer: Some(address!("b830b99c95Ea32300039624Cb567d324D4b1D83C")),
-    activation_admin_address: None,
+    activation_admin_address: Some(address!("5Be7Dd3678e999D5F7bC508c413db239F7D4Ac59")),
 
     max_gas_limit: 45_000_000,
     prune_delete_limit: 10_000,

--- a/crates/execution/chainspec/src/spec.rs
+++ b/crates/execution/chainspec/src/spec.rs
@@ -595,8 +595,19 @@ mod tests {
     }
 
     #[test]
-    fn activation_admin_is_unset_by_default() {
-        assert_eq!(BaseChainSpec::mainnet().activation_admin_address(), None);
+    fn activation_admin_matches_chain_config() {
+        assert_eq!(
+            BaseChainSpec::mainnet().activation_admin_address(),
+            Some(address!("331C9d37BbcebBC9dfAf98FBE3C5B8A39Dd6E771"))
+        );
+        assert_eq!(
+            BaseChainSpec::sepolia().activation_admin_address(),
+            Some(address!("5Be7Dd3678e999D5F7bC508c413db239F7D4Ac59"))
+        );
+    }
+
+    #[test]
+    fn activation_admin_is_unset_for_default_genesis() {
         assert_eq!(
             BaseChainSpec::from_genesis(Genesis::default()).activation_admin_address(),
             None

--- a/crates/proof/succinct/elf/manifest.toml
+++ b/crates/proof/succinct/elf/manifest.toml
@@ -14,7 +14,7 @@
 
 [[elfs]]
 name = "range-elf-embedded"
-sha256 = "540b3edf3a85a5172e865b36fb43b0f3f44bd2fbd6af4fa23539921650e0503a"
+sha256 = "f56d0095cc4005b6f313e3087d7f51c1956723328498af6f5f95df933fea6d04"
 
 [[elfs]]
 name = "aggregation-elf"


### PR DESCRIPTION
## Summary

This sets the activation admin addresses for Base mainnet and Base Sepolia in the chain config. The change wires the configured admin keys into the existing activation admin field so activation-gated flows can read the network-specific owner instead of `None`.