### PR TITLE
feat(common): Type Level Storage Namespaces

### DIFF
--- a/crates/common/precompile-macros/README.md
+++ b/crates/common/precompile-macros/README.md
@@ -5,11 +5,27 @@ Procedural macros for type-safe EVM storage abstractions for Base native precomp
 ## Macros
 
 - `#[contract]` — transforms a storage layout struct into a full contract
-- `#[namespace("id")]` — starts a `#[contract]` field or layout at an ERC-7201 namespace root
+- `#[namespace("id")]` — starts a `#[contract]` field/layout or a `Storable` layout type at
+  an ERC-7201 namespace root
 - `#[derive(Storable)]` — generates storage I/O for structs and `#[repr(u8)]` enums
 - `storable_rust_ints!()`, `storable_alloy_ints!()`, `storable_alloy_bytes!()` — primitive impls
 - `storable_arrays!()`, `storable_nested_arrays!()` — fixed-size array impls
 - `gen_storable_tests!()` — proptest round-trip tests for all storage types
+
+For `Storable` layouts, place the derive before the namespace helper:
+
+```rust,ignore
+#[derive(Debug, Clone, Storable)]
+#[namespace("b20")]
+pub struct B20Storage {
+    pub total_supply: U256,
+}
+
+#[contract]
+pub struct B20Security {
+    pub b20: B20Storage,
+}
+```
 
 ## Attribution
 

--- a/crates/common/precompile-macros/src/contract.rs
+++ b/crates/common/precompile-macros/src/contract.rs
@@ -124,6 +124,7 @@ fn gen_storage(
     let allocated_fields = packing::allocate_slots_from(
         fields,
         namespace.map_or(U256::ZERO, |namespace| namespace.root),
+        namespace.is_none(),
     )?;
     let transformed_struct = layout::gen_struct(ident, vis, &allocated_fields);
     let storage_trait = layout::gen_contract_storage_impl(ident);

--- a/crates/common/precompile-macros/src/layout.rs
+++ b/crates/common/precompile-macros/src/layout.rs
@@ -45,31 +45,24 @@ pub(crate) fn gen_handler_field_init(
         quote! { base_slot.saturating_add(::alloy_primitives::U256::from_limbs([#const_mod::#loc_const.offset_slots as u64, 0, 0, 0])) }
     };
 
+    let shares_slot_check =
+        gen_shares_slot_check(field, field_idx, all_fields, const_mod, is_contract);
+
     match &field.kind {
         FieldKind::Direct(ty) => {
-            let (prev_slot_const_ref, next_slot_const_ref) = if is_contract {
-                packing::get_same_root_neighbor_slot_refs(field_idx, all_fields, const_mod)
-            } else {
-                packing::get_neighbor_slot_refs(field_idx, all_fields, const_mod, |f| f.name, false)
-            };
-
             let layout_ctx = if is_contract {
                 packing::gen_layout_ctx_expr(
                     ty,
                     matches!(field.assigned_slot, SlotAssignment::Manual(_)),
-                    quote! { #const_mod::#slot_const },
                     quote! { #const_mod::#offset_const },
-                    prev_slot_const_ref,
-                    next_slot_const_ref,
+                    shares_slot_check,
                 )
             } else {
                 packing::gen_layout_ctx_expr(
                     ty,
                     false,
-                    quote! { #const_mod::#loc_const.offset_slots },
                     quote! { #const_mod::#loc_const.offset_bytes },
-                    prev_slot_const_ref,
-                    next_slot_const_ref,
+                    shares_slot_check,
                 )
             };
 
@@ -87,6 +80,41 @@ pub(crate) fn gen_handler_field_init(
             }
         }
     }
+}
+
+fn gen_shares_slot_check(
+    field: &LayoutField<'_>,
+    field_idx: usize,
+    all_fields: &[LayoutField<'_>],
+    const_mod: &Ident,
+    is_contract: bool,
+) -> Option<proc_macro2::TokenStream> {
+    let current_consts = PackingConstants::new(field.name);
+    let current_slot = if is_contract {
+        let current_slot = current_consts.slot();
+        quote! { #const_mod::#current_slot }
+    } else {
+        let current_loc = current_consts.location();
+        quote! { #const_mod::#current_loc.offset_slots }
+    };
+
+    let checks: Vec<_> = all_fields
+        .iter()
+        .enumerate()
+        .filter(|(idx, _)| *idx != field_idx)
+        .map(|(_, other)| {
+            let other_consts = PackingConstants::new(other.name);
+            if is_contract {
+                let other_slot = other_consts.slot();
+                quote! { #current_slot == #const_mod::#other_slot }
+            } else {
+                let other_loc = other_consts.location();
+                quote! { #current_slot == #const_mod::#other_loc.offset_slots }
+            }
+        })
+        .collect();
+
+    if checks.is_empty() { None } else { Some(quote! { false #(|| #checks)* }) }
 }
 
 pub(crate) fn gen_struct(

--- a/crates/common/precompile-macros/src/lib.rs
+++ b/crates/common/precompile-macros/src/lib.rs
@@ -25,14 +25,14 @@ pub fn contract(attr: TokenStream, item: TokenStream) -> TokenStream {
     contract::generate(input, config.address.as_ref())
 }
 
-/// Namespaces a `#[contract]` storage struct using an ERC-7201 storage root.
+/// Namespaces a `#[contract]` storage struct or `Storable` layout using an ERC-7201 storage root.
 #[proc_macro_attribute]
 pub fn namespace(attr: TokenStream, item: TokenStream) -> TokenStream {
     namespace::expand(attr, item)
 }
 
 /// Derives the `Storable` trait for structs with named fields and `#[repr(u8)]` unit enums.
-#[proc_macro_derive(Storable, attributes(storable_arrays))]
+#[proc_macro_derive(Storable, attributes(storable_arrays, namespace, storage_namespace))]
 pub fn derive_storage_block(input: TokenStream) -> TokenStream {
     storable::derive(parse_macro_input!(input as DeriveInput))
 }

--- a/crates/common/precompile-macros/src/namespace.rs
+++ b/crates/common/precompile-macros/src/namespace.rs
@@ -22,21 +22,44 @@ fn expand_impl(
 
     parse_namespace_id(namespace_id.clone())?;
 
-    if input.attrs.iter().any(|attr| attr_path_is(attr.path(), "namespace")) {
+    if input.attrs.iter().any(|attr| {
+        attr_path_is(attr.path(), "namespace") || attr_path_is(attr.path(), "storage_namespace")
+    }) {
         return Err(syn::Error::new_spanned(&input.ident, "duplicate `namespace` attribute"));
     }
 
-    let contract_index =
-        input.attrs.iter().position(|attr| attr_path_is(attr.path(), "contract")).ok_or_else(
-            || {
-                syn::Error::new_spanned(
-                    &input.ident,
-                    "`#[namespace]` must be paired with `#[contract]`",
-                )
-            },
-        )?;
+    if let Some(contract_index) =
+        input.attrs.iter().position(|attr| attr_path_is(attr.path(), "contract"))
+    {
+        input.attrs.insert(contract_index + 1, syn::parse_quote!(#[namespace(#namespace_id)]));
+        return Ok(quote! { #input });
+    }
 
-    input.attrs.insert(contract_index + 1, syn::parse_quote!(#[namespace(#namespace_id)]));
+    if has_storable_derive(&input)? {
+        input.attrs.push(syn::parse_quote!(#[storage_namespace(#namespace_id)]));
+        return Ok(quote! { #input });
+    }
 
-    Ok(quote! { #input })
+    Err(syn::Error::new_spanned(
+        &input.ident,
+        "`#[namespace]` must be paired with `#[contract]` or `#[derive(Storable)]`",
+    ))
+}
+
+fn has_storable_derive(input: &DeriveInput) -> syn::Result<bool> {
+    let mut found = false;
+    for attr in &input.attrs {
+        if !attr.path().is_ident("derive") {
+            continue;
+        }
+
+        attr.parse_nested_meta(|meta| {
+            if attr_path_is(&meta.path, "Storable") {
+                found = true;
+            }
+            Ok(())
+        })?;
+    }
+
+    Ok(found)
 }

--- a/crates/common/precompile-macros/src/packing.rs
+++ b/crates/common/precompile-macros/src/packing.rs
@@ -44,14 +44,21 @@ pub(crate) fn const_name(name: &Ident) -> String {
 #[derive(Debug, Clone)]
 pub(crate) enum SlotAssignment {
     Manual(U256),
-    Auto { base_slot: U256 },
+    Auto { base_slot: U256, allow_type_namespace: bool },
 }
 
 impl SlotAssignment {
     pub(crate) const fn ref_slot(&self) -> &U256 {
         match self {
             Self::Manual(slot) => slot,
-            Self::Auto { base_slot } => base_slot,
+            Self::Auto { base_slot, .. } => base_slot,
+        }
+    }
+
+    pub(crate) const fn allows_type_namespace(&self) -> bool {
+        match self {
+            Self::Manual(_) => false,
+            Self::Auto { allow_type_namespace, .. } => *allow_type_namespace,
         }
     }
 }
@@ -66,13 +73,14 @@ pub(crate) struct LayoutField<'a> {
 
 /// Build layout IR from field information.
 pub(crate) fn allocate_slots(fields: &[FieldInfo]) -> syn::Result<Vec<LayoutField<'_>>> {
-    allocate_slots_from(fields, U256::ZERO)
+    allocate_slots_from(fields, U256::ZERO, false)
 }
 
 /// Build layout IR from field information, starting auto-allocation at `initial_base_slot`.
 pub(crate) fn allocate_slots_from(
     fields: &[FieldInfo],
     initial_base_slot: U256,
+    allow_type_namespaces: bool,
 ) -> syn::Result<Vec<LayoutField<'_>>> {
     let mut result = Vec::with_capacity(fields.len());
     let mut current_base_slot = initial_base_slot;
@@ -84,10 +92,15 @@ pub(crate) fn allocate_slots_from(
             (Some(explicit), _, _) => SlotAssignment::Manual(explicit),
             (None, Some(new_base), _) => {
                 current_base_slot = new_base;
-                SlotAssignment::Auto { base_slot: new_base }
+                SlotAssignment::Auto { base_slot: new_base, allow_type_namespace: false }
             }
-            (None, None, Some(namespace)) => SlotAssignment::Auto { base_slot: namespace.root },
-            (None, None, None) => SlotAssignment::Auto { base_slot: current_base_slot },
+            (None, None, Some(namespace)) => {
+                SlotAssignment::Auto { base_slot: namespace.root, allow_type_namespace: false }
+            }
+            (None, None, None) => SlotAssignment::Auto {
+                base_slot: current_base_slot,
+                allow_type_namespace: allow_type_namespaces,
+            },
         };
 
         result.push(LayoutField { name: &field.name, ty: &field.ty, kind, assigned_slot });
@@ -124,31 +137,7 @@ pub(crate) fn gen_constants_from_ir(fields: &[LayoutField<'_>], gen_location: bo
                 (slot_expr, quote! { 0 })
             }
             SlotAssignment::Auto { base_slot, .. } => {
-                let output = last_auto_fields
-                    .iter()
-                    .rev()
-                    .find(|candidate| candidate.assigned_slot.ref_slot() == base_slot)
-                    .map_or_else(
-                        || {
-                            let limbs = *base_slot.as_limbs();
-                            let slot_expr = quote! {
-                                ::alloy_primitives::U256::from_limbs([#(#limbs),*])
-                                    .checked_add(#slots_to_end).expect("slot overflow")
-                                    .saturating_sub(#slots_to_end)
-                            };
-                            (slot_expr, quote! { 0 })
-                        },
-                        |current_base| {
-                            let (prev_slot, prev_offset) =
-                                PackingConstants::new(current_base.name).into_tuple();
-                            gen_slot_packing_logic(
-                                current_base.ty,
-                                field.ty,
-                                quote! { #prev_slot },
-                                quote! { #prev_offset },
-                            )
-                        },
-                    );
+                let output = gen_auto_slot_expr(field, base_slot, &last_auto_fields, slots_to_end);
                 last_auto_fields.push(field);
                 output
             }
@@ -184,6 +173,83 @@ pub(crate) fn gen_constants_from_ir(fields: &[LayoutField<'_>], gen_location: bo
     }
 
     constants
+}
+
+fn gen_auto_slot_expr(
+    field: &LayoutField<'_>,
+    base_slot: &U256,
+    previous_auto_fields: &[&LayoutField<'_>],
+    slots_to_end: TokenStream,
+) -> (TokenStream, TokenStream) {
+    let limbs = *base_slot.as_limbs();
+    let initial_slot_expr = quote! {
+        ::alloy_primitives::U256::from_limbs([#(#limbs),*])
+            .checked_add(#slots_to_end).expect("slot overflow")
+            .saturating_sub(#slots_to_end)
+    };
+    let mut output = (initial_slot_expr, quote! { 0 });
+
+    for candidate in previous_auto_fields.iter().filter(|candidate| {
+        matches!(candidate.assigned_slot, SlotAssignment::Auto { .. })
+            && candidate.assigned_slot.ref_slot() == base_slot
+    }) {
+        let (prev_slot, prev_offset) = PackingConstants::new(candidate.name).into_tuple();
+        let candidate_output = gen_slot_packing_logic(
+            candidate.ty,
+            field.ty,
+            quote! { #prev_slot },
+            quote! { #prev_offset },
+        );
+
+        if candidate.assigned_slot.allows_type_namespace() {
+            let candidate_ty = candidate.ty;
+            let (fallback_slot, fallback_offset) = output;
+            let (candidate_slot, candidate_offset) = candidate_output;
+            output = (
+                quote! {
+                    if <#candidate_ty as ::base_precompile_storage::StorableType>::HAS_STORAGE_NAMESPACE {
+                        #fallback_slot
+                    } else {
+                        #candidate_slot
+                    }
+                },
+                quote! {
+                    if <#candidate_ty as ::base_precompile_storage::StorableType>::HAS_STORAGE_NAMESPACE {
+                        #fallback_offset
+                    } else {
+                        #candidate_offset
+                    }
+                },
+            );
+        } else {
+            output = candidate_output;
+        }
+    }
+
+    if field.assigned_slot.allows_type_namespace() {
+        let field_ty = field.ty;
+        let (normal_slot, normal_offset) = output;
+        (
+            quote! {
+                if <#field_ty as ::base_precompile_storage::StorableType>::HAS_STORAGE_NAMESPACE {
+                    <#field_ty as ::base_precompile_storage::StorableType>::STORAGE_NAMESPACE_ROOT
+                        .checked_add(#slots_to_end).expect("slot overflow")
+                        .saturating_sub(#slots_to_end)
+                } else {
+                    #normal_slot
+                }
+            },
+            quote! {
+                if <#field_ty as ::base_precompile_storage::StorableType>::HAS_STORAGE_NAMESPACE {
+                    0
+                } else {
+                    #normal_offset
+                }
+            },
+        )
+    } else {
+        output
+    }
 }
 
 /// Classify a field based on its type.
@@ -237,43 +303,6 @@ where
     (prev_slot_ref, next_slot_ref)
 }
 
-/// Returns previous and next slot constants for fields that share the same auto-allocation root.
-pub(crate) fn get_same_root_neighbor_slot_refs(
-    idx: usize,
-    fields: &[LayoutField<'_>],
-    packing: &Ident,
-) -> (Option<TokenStream>, Option<TokenStream>) {
-    if !matches!(fields[idx].assigned_slot, SlotAssignment::Auto { .. }) {
-        return (None, None);
-    }
-
-    let root = fields[idx].assigned_slot.ref_slot();
-    let prev_slot_ref = fields[..idx]
-        .iter()
-        .rev()
-        .find(|field| {
-            matches!(field.assigned_slot, SlotAssignment::Auto { .. })
-                && field.assigned_slot.ref_slot() == root
-        })
-        .map(|field| {
-            let prev_slot = PackingConstants::new(field.name).slot();
-            quote! { #packing::#prev_slot }
-        });
-
-    let next_slot_ref = fields[idx + 1..]
-        .iter()
-        .find(|field| {
-            matches!(field.assigned_slot, SlotAssignment::Auto { .. })
-                && field.assigned_slot.ref_slot() == root
-        })
-        .map(|field| {
-            let next_slot = PackingConstants::new(field.name).slot();
-            quote! { #packing::#next_slot }
-        });
-
-    (prev_slot_ref, next_slot_ref)
-}
-
 /// Generate slot packing decision logic.
 pub(crate) fn gen_slot_packing_logic(
     prev_ty: &Type,
@@ -317,22 +346,10 @@ pub(crate) fn gen_slot_packing_logic(
 pub(crate) fn gen_layout_ctx_expr(
     ty: &Type,
     is_manual_slot: bool,
-    slot_const_ref: TokenStream,
     offset_const_ref: TokenStream,
-    prev_slot_const_ref: Option<TokenStream>,
-    next_slot_const_ref: Option<TokenStream>,
+    shares_slot_check: Option<TokenStream>,
 ) -> TokenStream {
-    if !is_manual_slot && (prev_slot_const_ref.is_some() || next_slot_const_ref.is_some()) {
-        let prev_check = prev_slot_const_ref.map(|prev| quote! { #slot_const_ref == #prev });
-        let next_check = next_slot_const_ref.map(|next| quote! { #slot_const_ref == #next });
-
-        let shares_slot_check = match (prev_check, next_check) {
-            (Some(prev), Some(next)) => quote! { (#prev || #next) },
-            (Some(prev), None) => prev,
-            (None, Some(next)) => next,
-            (None, None) => unreachable!(),
-        };
-
+    if !is_manual_slot && let Some(shares_slot_check) = shares_slot_check {
         quote! {
             {
                 if #shares_slot_check && <#ty as ::base_precompile_storage::StorableType>::IS_PACKABLE {

--- a/crates/common/precompile-macros/src/storable.rs
+++ b/crates/common/precompile-macros/src/storable.rs
@@ -9,7 +9,10 @@ use crate::{
     layout::{gen_handler_field_decl, gen_handler_field_init},
     packing::{self, LayoutField, PackingConstants},
     storable_primitives::gen_struct_arrays,
-    utils::{extract_mapping_types, extract_storable_array_sizes, to_snake_case},
+    utils::{
+        NamespaceInfo, extract_mapping_types, extract_storable_array_sizes,
+        extract_storage_namespace, to_snake_case,
+    },
 };
 
 /// Entry point called from `lib.rs` — parses input and converts errors to compile errors.
@@ -34,6 +37,7 @@ pub(crate) fn derive_impl(input: DeriveInput) -> syn::Result<TokenStream> {
 fn derive_struct_impl(input: &DeriveInput, data_struct: &DataStruct) -> syn::Result<TokenStream> {
     let strukt = &input.ident;
     let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
+    let namespace = extract_storage_namespace(&input.attrs)?;
 
     let fields = match &data_struct.fields {
         Fields::Named(fields_named) => &fields_named.named,
@@ -90,6 +94,7 @@ fn derive_struct_impl(input: &DeriveInput, data_struct: &DataStruct) -> syn::Res
 
     let handler_struct = gen_handler_struct(strukt, &layout_fields, &mod_ident);
     let handler_name = format_ident!("{}Handler", strukt);
+    let namespace_consts = gen_storage_namespace_consts(namespace.as_ref());
 
     let expanded = quote! {
         #packing_module
@@ -97,6 +102,7 @@ fn derive_struct_impl(input: &DeriveInput, data_struct: &DataStruct) -> syn::Res
 
         impl #impl_generics ::base_precompile_storage::StorableType for #strukt #ty_generics #where_clause {
             const LAYOUT: ::base_precompile_storage::Layout = ::base_precompile_storage::Layout::Slots(#mod_ident::SLOT_COUNT);
+            #namespace_consts
 
             const IS_DYNAMIC: bool = #(
                 <#direct_tys as ::base_precompile_storage::StorableType>::IS_DYNAMIC
@@ -175,6 +181,13 @@ fn derive_struct_impl(input: &DeriveInput, data_struct: &DataStruct) -> syn::Res
 }
 
 fn derive_unit_enum_impl(input: &DeriveInput, data_enum: &DataEnum) -> syn::Result<TokenStream> {
+    if extract_storage_namespace(&input.attrs)?.is_some() {
+        return Err(syn::Error::new_spanned(
+            &input.ident,
+            "`namespace` is only supported for `Storable` structs",
+        ));
+    }
+
     if extract_storable_array_sizes(&input.attrs)?.is_some() {
         return Err(syn::Error::new_spanned(
             &input.ident,
@@ -388,6 +401,22 @@ fn gen_handler_struct(
             }
         }
     }
+}
+
+fn gen_storage_namespace_consts(namespace: Option<&NamespaceInfo>) -> TokenStream {
+    namespace.map_or_else(
+        || quote! {},
+        |namespace| {
+            let id = &namespace.id;
+            let limbs = *namespace.root.as_limbs();
+            quote! {
+                const HAS_STORAGE_NAMESPACE: bool = true;
+                const STORAGE_NAMESPACE_ID: &'static str = #id;
+                const STORAGE_NAMESPACE_ROOT: ::alloy_primitives::U256 =
+                    ::alloy_primitives::U256::from_limbs([#(#limbs),*]);
+            }
+        },
+    )
 }
 
 fn gen_load_impl(fields: &[(&Ident, &Type)], packing: &Ident) -> TokenStream {

--- a/crates/common/precompile-macros/src/utils.rs
+++ b/crates/common/precompile-macros/src/utils.rs
@@ -186,6 +186,26 @@ pub(crate) fn extract_namespace(attrs: &[Attribute]) -> syn::Result<Option<Names
     Ok(namespace)
 }
 
+/// Extracts a type-level `#[namespace("...")]` attribute from a `Storable` layout.
+pub(crate) fn extract_storage_namespace(attrs: &[Attribute]) -> syn::Result<Option<NamespaceInfo>> {
+    let mut namespace = None;
+
+    for attr in attrs {
+        let is_namespace = attr_path_is(attr.path(), "namespace")
+            || attr_path_is(attr.path(), "storage_namespace");
+        if !is_namespace {
+            continue;
+        }
+        if namespace.is_some() {
+            return Err(syn::Error::new_spanned(attr, "duplicate `namespace` attribute"));
+        }
+
+        namespace = Some(parse_namespace_id(attr.parse_args()?)?);
+    }
+
+    Ok(namespace)
+}
+
 /// Extracts array sizes from the `#[storable_arrays(...)]` attribute.
 pub(crate) fn extract_storable_array_sizes(attrs: &[Attribute]) -> syn::Result<Option<Vec<usize>>> {
     for attr in attrs {

--- a/crates/common/precompile-storage/README.md
+++ b/crates/common/precompile-storage/README.md
@@ -34,6 +34,22 @@ Multiple fields with the same namespace use normal Solidity offsets from that ro
 the surrounding contract layout. `#[slot]` and `#[base_slot]` overrides cannot be combined with
 `#[namespace]` on the same field.
 
+The namespace can also be declared once on a reusable `Storable` layout type. A `#[contract]`
+field with that type is automatically mounted at the type's namespace root:
+
+```rust,ignore
+#[derive(Debug, Clone, Storable)]
+#[namespace("b20.security")]
+pub struct B20SecurityStorage {
+    pub shares_to_tokens_ratio: U256,
+}
+
+#[contract]
+pub struct B20Security {
+    pub security: B20SecurityStorage,
+}
+```
+
 ### Mapping slot derivation
 
 ```text

--- a/crates/common/precompile-storage/src/provider.rs
+++ b/crates/common/precompile-storage/src/provider.rs
@@ -188,6 +188,12 @@ impl LayoutCtx {
 pub trait StorableType {
     /// Storage layout descriptor.
     const LAYOUT: Layout;
+    /// Whether this type declares its own ERC-7201 storage namespace.
+    const HAS_STORAGE_NAMESPACE: bool = false;
+    /// ERC-7201 namespace identifier for this type.
+    const STORAGE_NAMESPACE_ID: &'static str = "";
+    /// ERC-7201 namespace root slot for this type.
+    const STORAGE_NAMESPACE_ROOT: U256 = U256::ZERO;
     /// Number of storage slots this type occupies.
     const SLOTS: usize = Self::LAYOUT.slots();
     /// Number of bytes this type occupies.

--- a/crates/common/precompile-storage/tests/contract.rs
+++ b/crates/common/precompile-storage/tests/contract.rs
@@ -346,7 +346,6 @@ mod type_namespaced_layouts {
         let security_root = erc7201_root("b20.security");
         let redeem_root = erc7201_root("b20.redeem");
 
-        assert!(<B20Storage as StorableType>::HAS_STORAGE_NAMESPACE);
         assert_eq!(<B20Storage as StorableType>::STORAGE_NAMESPACE_ID, "b20");
         assert_eq!(<B20Storage as StorableType>::STORAGE_NAMESPACE_ROOT, b20_root);
         assert_eq!(<B20SecurityStorage as StorableType>::STORAGE_NAMESPACE_ROOT, security_root);

--- a/crates/common/precompile-storage/tests/contract.rs
+++ b/crates/common/precompile-storage/tests/contract.rs
@@ -12,6 +12,13 @@ fn data_slot(slot: U256) -> U256 {
     U256::from_be_bytes(keccak256(slot.to_be_bytes::<32>()).0)
 }
 
+fn erc7201_root(id: &str) -> U256 {
+    let id_hash = U256::from_be_bytes(keccak256(id.as_bytes()).0);
+    let shifted = id_hash.checked_sub(U256::ONE).unwrap();
+    let root = U256::from_be_bytes(keccak256(shifted.to_be_bytes::<32>()).0);
+    root & (U256::MAX - U256::from(0xffu64))
+}
+
 fn word_from_chunk(data: &[u8], chunk_index: usize) -> U256 {
     let mut word = [0u8; 32];
     let start = chunk_index * 32;
@@ -265,6 +272,162 @@ mod namespaced_layout {
                 ctx.sload(NAMESPACED_ADDR, amounts_data_slot + U256::from(2)).unwrap(),
                 U256::from(33)
             );
+        });
+    }
+}
+
+mod type_namespaced_layouts {
+    use alloy_primitives::{Address, U256, address};
+    use base_precompile_macros::{Storable, contract};
+    use base_precompile_storage::{
+        Handler, Mapping, StorableType, StorageCtx, StorageKey, setup_storage,
+    };
+
+    use super::erc7201_root;
+
+    const TYPE_NAMESPACE_ADDR: Address = address!("0000000000000000000000000000000000002468");
+
+    /// Core B-20 storage rooted at the canonical B-20 namespace.
+    #[derive(Debug, Clone, Storable)]
+    #[namespace("b20")]
+    struct B20Storage {
+        total_supply: U256,
+        balances: Mapping<Address, U256>,
+    }
+
+    /// Security-specific B-20 extension storage.
+    #[derive(Debug, Clone, Storable)]
+    #[namespace("b20.security")]
+    struct B20SecurityStorage {
+        shares_to_tokens_ratio: U256,
+        used_announcement_ids: Mapping<String, bool>,
+        security_identifiers: Mapping<String, bool>,
+    }
+
+    /// Redeem-specific B-20 extension storage.
+    #[derive(Debug, Clone, Storable)]
+    #[namespace("b20.redeem")]
+    struct B20RedeemStorage {
+        minimum_redeemable: U256,
+        redeem_policy_ids: U256,
+    }
+
+    /// Security token layout that composes canonical namespaced storage sections.
+    #[contract(addr = TYPE_NAMESPACE_ADDR)]
+    pub struct B20SecurityLayout {
+        pub local_head: u8,
+        pub b20: B20Storage,
+        pub security: B20SecurityStorage,
+        pub redeem: B20RedeemStorage,
+        pub local_tail: u16,
+    }
+
+    #[test]
+    fn type_level_namespaces_mount_layouts_without_repeating_strings() {
+        let b20_value = B20Storage { total_supply: U256::ZERO, balances: Mapping::default() };
+        let security_value = B20SecurityStorage {
+            shares_to_tokens_ratio: U256::ZERO,
+            used_announcement_ids: Mapping::default(),
+            security_identifiers: Mapping::default(),
+        };
+        let redeem_value =
+            B20RedeemStorage { minimum_redeemable: U256::ZERO, redeem_policy_ids: U256::ZERO };
+        let _ = (
+            &b20_value.total_supply,
+            &b20_value.balances,
+            &security_value.shares_to_tokens_ratio,
+            &security_value.used_announcement_ids,
+            &security_value.security_identifiers,
+            &redeem_value.minimum_redeemable,
+            &redeem_value.redeem_policy_ids,
+        );
+
+        let b20_root = erc7201_root("b20");
+        let security_root = erc7201_root("b20.security");
+        let redeem_root = erc7201_root("b20.redeem");
+
+        assert!(<B20Storage as StorableType>::HAS_STORAGE_NAMESPACE);
+        assert_eq!(<B20Storage as StorableType>::STORAGE_NAMESPACE_ID, "b20");
+        assert_eq!(<B20Storage as StorableType>::STORAGE_NAMESPACE_ROOT, b20_root);
+        assert_eq!(<B20SecurityStorage as StorableType>::STORAGE_NAMESPACE_ROOT, security_root);
+        assert_eq!(<B20RedeemStorage as StorableType>::STORAGE_NAMESPACE_ROOT, redeem_root);
+
+        assert_eq!(slots::LOCAL_HEAD, U256::ZERO);
+        assert_eq!(slots::LOCAL_HEAD_OFFSET, 0);
+        assert_eq!(slots::B20, b20_root);
+        assert_eq!(slots::SECURITY, security_root);
+        assert_eq!(slots::REDEEM, redeem_root);
+        assert_eq!(slots::LOCAL_TAIL, U256::ZERO);
+        assert_eq!(slots::LOCAL_TAIL_OFFSET, 1);
+    }
+
+    #[test]
+    fn type_level_namespaced_layouts_round_trip_through_handlers() {
+        let (mut storage, _) = setup_storage();
+        let holder = Address::from([0xaa; 20]);
+
+        StorageCtx::enter(&mut storage, |ctx| {
+            let mut layout = B20SecurityLayout::new(ctx);
+
+            layout.local_head.write(0x11).unwrap();
+            layout.b20.total_supply.write(U256::from(100)).unwrap();
+            layout.b20.balances.at_mut(&holder).write(U256::from(25)).unwrap();
+            layout.security.shares_to_tokens_ratio.write(U256::from(2)).unwrap();
+            layout.redeem.minimum_redeemable.write(U256::from(10)).unwrap();
+            layout.redeem.redeem_policy_ids.write(U256::from(3)).unwrap();
+            layout.local_tail.write(0x2233).unwrap();
+
+            assert_eq!(layout.local_head.read().unwrap(), 0x11);
+            assert_eq!(layout.b20.total_supply.read().unwrap(), U256::from(100));
+            assert_eq!(layout.b20.balances.at(&holder).read().unwrap(), U256::from(25));
+            assert_eq!(layout.security.shares_to_tokens_ratio.read().unwrap(), U256::from(2));
+            assert_eq!(layout.redeem.minimum_redeemable.read().unwrap(), U256::from(10));
+            assert_eq!(layout.redeem.redeem_policy_ids.read().unwrap(), U256::from(3));
+            assert_eq!(layout.local_tail.read().unwrap(), 0x2233);
+
+            assert_eq!(
+                ctx.sload(
+                    TYPE_NAMESPACE_ADDR,
+                    slots::B20 + U256::from(__packing_b20_storage::TOTAL_SUPPLY_LOC.offset_slots),
+                )
+                .unwrap(),
+                U256::from(100)
+            );
+            assert_eq!(
+                ctx.sload(
+                    TYPE_NAMESPACE_ADDR,
+                    holder.mapping_slot(
+                        slots::B20 + U256::from(__packing_b20_storage::BALANCES_LOC.offset_slots),
+                    ),
+                )
+                .unwrap(),
+                U256::from(25)
+            );
+            assert_eq!(
+                ctx.sload(
+                    TYPE_NAMESPACE_ADDR,
+                    slots::SECURITY
+                        + U256::from(
+                            __packing_b20_security_storage::SHARES_TO_TOKENS_RATIO_LOC.offset_slots,
+                        ),
+                )
+                .unwrap(),
+                U256::from(2)
+            );
+            assert_eq!(
+                ctx.sload(
+                    TYPE_NAMESPACE_ADDR,
+                    slots::REDEEM
+                        + U256::from(
+                            __packing_b20_redeem_storage::MINIMUM_REDEEMABLE_LOC.offset_slots
+                        ),
+                )
+                .unwrap(),
+                U256::from(10)
+            );
+            let local_slot = ctx.sload(TYPE_NAMESPACE_ADDR, slots::LOCAL_HEAD).unwrap();
+            assert_eq!(local_slot & U256::from(0xff), U256::from(0x11));
+            assert_eq!((local_slot >> 8) & U256::from(0xffff), U256::from(0x2233));
         });
     }
 }

--- a/crates/proof/succinct/elf/manifest.toml
+++ b/crates/proof/succinct/elf/manifest.toml
@@ -14,7 +14,7 @@
 
 [[elfs]]
 name = "range-elf-embedded"
-sha256 = "960222495f7ec3f7d9999d50d427191c2e56e1cd038e7ad4cc159d661f6d2c71"
+sha256 = "95ec382d2fee4ad878f5f11be5714b466dceadbec0e69633d392745e802a2762"
 
 [[elfs]]
 name = "aggregation-elf"

--- a/crates/proof/succinct/elf/manifest.toml
+++ b/crates/proof/succinct/elf/manifest.toml
@@ -14,7 +14,7 @@
 
 [[elfs]]
 name = "range-elf-embedded"
-sha256 = "95ec382d2fee4ad878f5f11be5714b466dceadbec0e69633d392745e802a2762"
+sha256 = "49334574477cd9c2911ab7457d428e0f7284e620c85bc855ce1c5a2f10e49b99"
 
 [[elfs]]
 name = "aggregation-elf"

--- a/crates/proof/succinct/programs/Cargo.lock
+++ b/crates/proof/succinct/programs/Cargo.lock
@@ -868,7 +868,11 @@ name = "base-common-precompiles"
 version = "0.0.0"
 dependencies = [
  "alloy-evm",
+ "alloy-primitives",
+ "alloy-sol-types",
  "base-common-chains",
+ "base-precompile-macros",
+ "base-precompile-storage",
  "revm",
 ]
 
@@ -921,6 +925,29 @@ dependencies = [
 [[package]]
 name = "base-metrics"
 version = "0.0.0"
+
+[[package]]
+name = "base-precompile-macros"
+version = "0.0.0"
+dependencies = [
+ "alloy-primitives",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "base-precompile-storage"
+version = "0.0.0"
+dependencies = [
+ "alloy-evm",
+ "alloy-primitives",
+ "alloy-sol-types",
+ "base-precompile-macros",
+ "derive_more",
+ "revm",
+ "thiserror",
+]
 
 [[package]]
 name = "base-proof"


### PR DESCRIPTION
## Summary

Adds support for declaring ERC-7201 storage namespaces directly on reusable Storable layout structs. Contract layouts can now compose typed storage sections without repeating namespace strings at each field, while preserving existing field-level namespace overrides. This reduces typo risk for canonical layouts like B20 core, security, and redeem storage.

Before, each consuming contract field repeated the namespace string:

```rust
#[derive(Debug, Clone, Storable)]
pub struct B20Storage {
    pub total_supply: U256,
}

#[contract]
pub struct B20Security {
    #[namespace("b20")]
    pub b20: B20Storage,

    #[namespace("b20.security")]
    pub security: B20SecurityStorage,
}
```

After, the namespace is declared once on the reusable layout type:

```rust
#[derive(Debug, Clone, Storable)]
#[namespace("b20")]
pub struct B20Storage {
    pub total_supply: U256,
}

#[derive(Debug, Clone, Storable)]
#[namespace("b20.security")]
pub struct B20SecurityStorage {
    pub shares_to_tokens_ratio: U256,
}

#[contract]
pub struct B20Security {
    pub b20: B20Storage,
    pub security: B20SecurityStorage,
}
```