### PR TITLE
fix(ci): Fail Fast ELF Manifest

### DIFF
--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -107,10 +107,138 @@ jobs:
           rust-cache-save: ${{ inputs.save_rust_cache }}
       - run: just check::format
 
+  succinct-elf-manifest:
+    name: SP1 ELF Manifest
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+    env:
+      BASE_REF: ${{ inputs.base_ref }}
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@a90bcbc6539c36a85cdfeb73f7e2f433735f215b # v2.15.0
+        with:
+          egress-policy: audit
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: ${{ inputs.base_ref != '' && 0 || 2 }}
+      - name: Fetch base branch
+        if: inputs.base_ref != ''
+        run: git fetch origin "$BASE_REF":refs/remotes/origin/"$BASE_REF"
+      - name: Detect SP1 ELF input changes
+        id: elf-inputs
+        run: python3 etc/scripts/ci/check-succinct-elf-inputs.py "$BASE_REF"
+      - uses: ./.github/actions/setup
+        if: steps.elf-inputs.outputs.needs_rebuild == 'true'
+        with:
+          free-disk: "true"
+          sp1: "true"
+          elf-cache: "true"
+      - name: Rebuild and verify SP1 ELF manifest
+        id: elf-manifest-check
+        if: steps.elf-inputs.outputs.needs_rebuild == 'true'
+        continue-on-error: true
+        shell: bash
+        run: |
+          set -euo pipefail
+          report_dir="${RUNNER_TEMP:-/tmp}/sp1-elf-manifest"
+          mkdir -p "$report_dir"
+          hash_file="$report_dir/hashes.txt"
+          diff_file="$report_dir/manifest.diff"
+          suggestion_file="$report_dir/suggestion.txt"
+
+          just succinct build-elfs
+          just succinct write-manifest
+          python3 etc/scripts/local/check-elf-manifest.py \
+            --print-hashes crates/proof/succinct/elf/manifest.toml crates/proof/succinct/elf \
+            | tee "$hash_file"
+          git diff -- crates/proof/succinct/elf/manifest.toml | tee "$diff_file"
+          grep '^+sha256 = ' "$diff_file" | sed 's/^+//' > "$suggestion_file" || true
+          if [ -s "$diff_file" ]; then
+            echo "::error file=crates/proof/succinct/elf/manifest.toml::SP1 ELF manifest is stale. The expected hashes are printed above. Run 'just succinct build-elfs && just succinct write-manifest' and commit the manifest."
+            exit 1
+          fi
+      - name: Comment on stale SP1 ELF manifest
+        if: >-
+          steps.elf-manifest-check.outcome == 'failure' &&
+          github.event_name == 'pull_request' &&
+          github.event.pull_request.head.repo.fork == false
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          report_dir="${RUNNER_TEMP:-/tmp}/sp1-elf-manifest"
+          hash_file="$report_dir/hashes.txt"
+          diff_file="$report_dir/manifest.diff"
+          suggestion_file="$report_dir/suggestion.txt"
+          body_file="$report_dir/comment.md"
+          body_json="$report_dir/comment.json"
+
+          if [ ! -s "$hash_file" ] || [ ! -s "$diff_file" ]; then
+            echo "No SP1 ELF hash diff was produced; skipping PR comment."
+            exit 0
+          fi
+
+          {
+            echo "<!-- sp1-elf-manifest-hash-diff -->"
+            echo "The SP1 ELF manifest is stale. Run \`just succinct build-elfs && just succinct write-manifest\` and commit \`crates/proof/succinct/elf/manifest.toml\`."
+            echo
+            if [ -s "$suggestion_file" ]; then
+              echo "Suggested replacement line(s):"
+              echo
+              echo '```suggestion'
+              cat "$suggestion_file"
+              echo '```'
+              echo
+            fi
+            echo "Expected and actual hashes from CI:"
+            echo
+            echo '```text'
+            cat "$hash_file"
+            echo '```'
+            echo
+            echo "Manifest diff:"
+            echo
+            echo '```diff'
+            cat "$diff_file"
+            echo '```'
+          } > "$body_file"
+
+          python3 - "$body_file" "$body_json" <<'PY'
+          import json
+          import sys
+
+          with open(sys.argv[1], encoding="utf-8") as body_file:
+              body = body_file.read()
+          with open(sys.argv[2], "w", encoding="utf-8") as json_file:
+              json.dump({"body": body}, json_file)
+          PY
+
+          comment_id="$(
+            gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" --paginate \
+              --jq '.[] | select(.body | contains("<!-- sp1-elf-manifest-hash-diff -->")) | .id' \
+              | tail -n 1
+          )"
+
+          if [ -n "$comment_id" ]; then
+            gh api -X PATCH "repos/${GITHUB_REPOSITORY}/issues/comments/${comment_id}" \
+              --input "$body_json" >/dev/null
+          else
+            gh pr comment "$PR_NUMBER" --body-file "$body_file"
+          fi
+      - name: Fail on stale SP1 ELF manifest
+        if: steps.elf-manifest-check.outcome == 'failure'
+        run: exit 1
+
   build:
     name: Build
     runs-on:
       group: BasePerfRunnerGroup
+    needs: succinct-elf-manifest
     env:
       BASE_REF: ${{ inputs.base_ref }}
     steps:
@@ -170,6 +298,7 @@ jobs:
     name: Test
     runs-on:
       group: BasePerfRunnerGroup
+    needs: succinct-elf-manifest
     env:
       BASE_REF: ${{ inputs.base_ref }}
     steps:
@@ -287,6 +416,7 @@ jobs:
     if: inputs.run_devnet
     runs-on:
       group: BasePerfRunnerGroup
+    needs: succinct-elf-manifest
     timeout-minutes: 60
     steps:
       - name: Harden the runner (Audit all outbound calls)

--- a/.github/workflows/ci-merge-queue.yml
+++ b/.github/workflows/ci-merge-queue.yml
@@ -10,8 +10,9 @@ concurrency:
 permissions:
   checks: write
   contents: read
+  issues: write
   packages: read
-  pull-requests: read
+  pull-requests: write
 
 jobs:
   ci:

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -10,8 +10,9 @@ concurrency:
 permissions:
   checks: write
   contents: read
+  issues: write
   packages: read
-  pull-requests: read
+  pull-requests: write
 
 jobs:
   ci:

--- a/crates/proof/succinct/elf/manifest.toml
+++ b/crates/proof/succinct/elf/manifest.toml
@@ -5,16 +5,19 @@
 #
 #     just succinct build-elfs
 #
-# That target writes the freshly built ELFs into this directory and rewrites
-# the `sha256` fields below. Commit the resulting manifest change together with
-# the code change that caused the ELF to change.
+# Then update this manifest with:
+#
+#     just succinct write-manifest
+#
+# Commit the resulting manifest change together with the code change that caused
+# the ELF to change.
 #
 # The `base-proof-succinct-elfs` crate's build.rs verifies the local cache against
 # these hashes; builds fail fast if they drift.
 
 [[elfs]]
 name = "range-elf-embedded"
-sha256 = "540b3edf3a85a5172e865b36fb43b0f3f44bd2fbd6af4fa23539921650e0503a"
+sha256 = "d7385895083ad46ff89629a3e6c6dc7d8553de42e01dac1d68f1199626806473"
 
 [[elfs]]
 name = "aggregation-elf"

--- a/crates/proof/succinct/utils/elfs/build.rs
+++ b/crates/proof/succinct/utils/elfs/build.rs
@@ -131,8 +131,7 @@ fn try_resolve_elf(cache_dir: &Path, entry: &ElfEntry) -> Result<PathBuf, String
     if actual != entry.sha256 {
         return Err(format!(
             "ELF `{name}` sha256 mismatch at {path} (expected {expected}, actual {actual}). \
-             Rebuild with: just succinct build-elfs (that target refreshes both the \
-             ELF and its hash in manifest.toml.)",
+             Rebuild with: just succinct build-elfs && just succinct write-manifest.",
             name = entry.name,
             path = path.display(),
             expected = entry.sha256,

--- a/etc/just/succinct.just
+++ b/etc/just/succinct.just
@@ -27,6 +27,7 @@ ensure-elfs:
             result=$(python3 "$script" "$manifest" "$cache_dir")
             if [ "$result" != "match" ]; then
                 echo "error: freshly built ELFs do not match manifest.toml ($result)." >&2
+                python3 "$script" --print-hashes "$manifest" "$cache_dir" >&2
                 echo "       If this is a legitimate change, run 'just succinct write-manifest' and commit." >&2
                 exit 1
             fi

--- a/etc/scripts/ci/check-succinct-elf-inputs.py
+++ b/etc/scripts/ci/check-succinct-elf-inputs.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Detect whether a change can affect the checked-in SP1 ELF manifest.
+
+The actual ELF binaries are ignored by git. CI uses this script as a cheap
+preflight before deciding whether to run the expensive Docker-backed SP1 build
+that verifies ``crates/proof/succinct/elf/manifest.toml``.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+MANIFEST = "crates/proof/succinct/elf/manifest.toml"
+
+INPUT_FILES = {
+    "Cargo.lock",
+    "Cargo.toml",
+    "rust-toolchain.toml",
+    "etc/just/succinct.just",
+}
+
+INPUT_PREFIXES = (
+    ".cargo/",
+    "crates/common/chains/",
+    "crates/common/consensus/",
+    "crates/common/evm/",
+    "crates/common/flz/",
+    "crates/common/genesis/",
+    "crates/common/precompile-macros/",
+    "crates/common/precompile-storage/",
+    "crates/common/precompiles/",
+    "crates/common/rpc-types-engine/",
+    "crates/consensus/derive/",
+    "crates/consensus/protocol/",
+    "crates/consensus/upgrades/",
+    "crates/proof/driver/",
+    "crates/proof/executor/",
+    "crates/proof/mpt/",
+    "crates/proof/preimage/",
+    "crates/proof/primitives/",
+    "crates/proof/proof/",
+    "crates/proof/succinct/programs/",
+    "crates/proof/succinct/utils/build/",
+    "crates/proof/succinct/utils/client/",
+    "crates/proof/succinct/utils/ethereum/client/",
+    "crates/utilities/metrics/",
+)
+
+
+def run_git_diff(args: list[str]) -> list[str] | None:
+    """Return changed files for a git diff invocation, or None on failure."""
+    result = subprocess.run(
+        ["git", "diff", "--name-only", *args],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        return None
+    return [line for line in result.stdout.splitlines() if line]
+
+
+def changed_files(base_ref: str | None) -> list[str]:
+    """Return files changed between base_ref and HEAD."""
+    if base_ref:
+        base_refs = [base_ref]
+        if not base_ref.startswith(("origin/", "refs/")):
+            base_refs.append(f"origin/{base_ref}")
+        for candidate in dict.fromkeys(base_refs):
+            for args in ([f"{candidate}...HEAD"], [candidate, "HEAD"]):
+                files = run_git_diff(args)
+                if files is not None:
+                    return files
+        raise RuntimeError(f"could not diff against base ref {base_ref}")
+
+    for args in (["HEAD^1...HEAD"], ["HEAD^", "HEAD"]):
+        files = run_git_diff(args)
+        if files is not None:
+            return files
+    raise RuntimeError("could not diff HEAD against a parent commit")
+
+
+def is_elf_input(path: str) -> bool:
+    """Return true if path can affect a generated SP1 ELF."""
+    return path in INPUT_FILES or any(path.startswith(prefix) for prefix in INPUT_PREFIXES)
+
+
+def write_output(name: str, value: bool) -> None:
+    """Write a GitHub Actions boolean output when running in CI."""
+    output_path = os.environ.get("GITHUB_OUTPUT")
+    if not output_path:
+        return
+    with Path(output_path).open("a", encoding="utf-8") as output:
+        output.write(f"{name}={str(value).lower()}\n")
+
+
+def main(argv: list[str]) -> None:
+    base_ref = argv[1] if len(argv) > 1 and argv[1] else None
+    files = changed_files(base_ref)
+    input_changes = [path for path in files if is_elf_input(path)]
+    manifest_changed = MANIFEST in files
+    needs_rebuild = bool(input_changes or manifest_changed)
+
+    write_output("input_changed", bool(input_changes))
+    write_output("manifest_changed", manifest_changed)
+    write_output("needs_rebuild", needs_rebuild)
+
+    if not needs_rebuild:
+        print("No SP1 ELF inputs changed.")
+        return
+
+    if input_changes:
+        print("SP1 ELF input changes:")
+        for path in input_changes:
+            print(f"  {path}")
+    if manifest_changed:
+        print(f"SP1 ELF manifest changed: {MANIFEST}")
+
+
+if __name__ == "__main__":
+    main(sys.argv)

--- a/etc/scripts/local/check-elf-manifest.py
+++ b/etc/scripts/local/check-elf-manifest.py
@@ -3,8 +3,9 @@
 
 Usage::
 
-    check_manifest.py <manifest.toml> <cache_dir>          # verify, print status
-    check_manifest.py --write <manifest.toml> <cache_dir>   # rewrite sha256 fields
+    check_manifest.py <manifest.toml> <cache_dir>                 # verify, print status
+    check_manifest.py --write <manifest.toml> <cache_dir>          # rewrite sha256 fields
+    check_manifest.py --print-hashes <manifest.toml> <cache_dir>   # print expected/actual hashes
 
 Verify mode exit code is always 0; the resulting status is printed to stdout as
 one of ``match``, ``missing:<name>``, or ``mismatch:<name>`` so the just recipe
@@ -84,19 +85,47 @@ def write(manifest_path: Path, cache_dir: Path) -> None:
     manifest_path.write_text(text)
 
 
+def print_hashes(manifest_path: Path, cache_dir: Path) -> None:
+    """Print the manifest hash and current cache hash for each ELF."""
+    entries = parse_manifest(manifest_path.read_text())
+    if not entries:
+        print("empty-manifest")
+        return
+    for name, expected in entries:
+        target = cache_dir / name
+        actual = sha256_of(target) if target.exists() else "<missing>"
+        print(f'{name}: expected="{expected}" actual="{actual}"')
+
+
 def main(argv: list[str]) -> None:
     args = argv[1:]
     write_mode = False
-    if args and args[0] == "--write":
-        write_mode = True
+    print_hashes_mode = False
+    while args and args[0].startswith("--"):
+        flag = args[0]
+        if flag == "--write":
+            write_mode = True
+        elif flag == "--print-hashes":
+            print_hashes_mode = True
+        else:
+            print(f"unknown option: {flag}", file=sys.stderr)
+            sys.exit(2)
         args = args[1:]
     if len(args) != 2:
-        print("usage: check_manifest.py [--write] <manifest.toml> <cache_dir>", file=sys.stderr)
+        print(
+            "usage: check_manifest.py [--write] [--print-hashes] <manifest.toml> <cache_dir>",
+            file=sys.stderr,
+        )
         sys.exit(2)
     manifest_path = Path(args[0])
     cache_dir = Path(args[1])
     if write_mode:
         write(manifest_path, cache_dir)
+        if print_hashes_mode:
+            print_hashes(manifest_path, cache_dir)
+        return
+    if print_hashes_mode:
+        print_hashes(manifest_path, cache_dir)
     else:
         print(verify(manifest_path, cache_dir))
 


### PR DESCRIPTION
## Summary

This adds a dedicated SP1 ELF manifest CI gate that checks whether proof ELF inputs changed before the expensive build and test jobs run. When verification is needed, the job rebuilds the ELFs, rewrites the manifest in the CI workspace, prints the expected and actual hashes, and fails with a direct instruction if the committed manifest is stale. The existing local manifest checker now supports hash printing so stale cache failures show the exact values that need to be committed.