### PR TITLE
feat(common): Align B20 Storage Namespaces

### DIFF
--- a/actions/harness/tests/beryl/b20.rs
+++ b/actions/harness/tests/beryl/b20.rs
@@ -291,11 +291,6 @@ async fn b20_staticcall_abi_covers_all_read_methods() {
                 U256::from(BerylTestEnv::B20_BOB_ALLOWANCE),
             ),
             StaticcallCase::word(
-                "minimumRedeemable",
-                IB20::minimumRedeemableCall {}.abi_encode(),
-                U256::ZERO,
-            ),
-            StaticcallCase::word(
                 "pausedFeatures",
                 IB20::pausedFeaturesCall {}.abi_encode(),
                 U256::from(32),
@@ -476,11 +471,6 @@ async fn b20_extended_mutations_update_state_and_emit_events() {
                 "supplyCap after update",
                 IB20::supplyCapCall {}.abi_encode(),
                 new_cap,
-            ),
-            StaticcallCase::word(
-                "minimumRedeemable",
-                IB20::minimumRedeemableCall {}.abi_encode(),
-                U256::ZERO,
             ),
         ])
         .await;

--- a/actions/harness/tests/beryl/env.rs
+++ b/actions/harness/tests/beryl/env.rs
@@ -1,7 +1,7 @@
 //! Shared test environment for Base Beryl action tests.
 
 use alloy_consensus::TxReceipt;
-use alloy_primitives::{Address, B256, Bytes, TxKind, U256, hex};
+use alloy_primitives::{Address, B256, Bytes, TxKind, U256, hex, uint};
 use alloy_sol_types::{SolCall, SolEvent, SolValue};
 use base_action_harness::{
     ActionL2Source, ActionTestHarness, Batcher, BatcherConfig, L1MinerConfig, L2Sequencer,
@@ -21,13 +21,16 @@ use base_test_utils::Account;
 pub(crate) const BERYL_ACTIVATION_TIMESTAMP: u64 = 4;
 
 /// B-20 token storage slot for `total_supply`.
-const B20_TOTAL_SUPPLY_SLOT: U256 = U256::ZERO;
+const B20_TOTAL_SUPPLY_SLOT: U256 =
+    uint!(0xc78b71fee795ddd74aff64ea9b2474194c938c3196430e10bb5f01ed48434003_U256);
 
 /// B-20 token storage slot for `balances`.
-const B20_BALANCES_SLOT: U256 = U256::from_limbs([2, 0, 0, 0]);
+const B20_BALANCES_SLOT: U256 =
+    uint!(0xc78b71fee795ddd74aff64ea9b2474194c938c3196430e10bb5f01ed48434004_U256);
 
 /// B-20 token storage slot for `allowances`.
-const B20_ALLOWANCES_SLOT: U256 = U256::from_limbs([3, 0, 0, 0]);
+const B20_ALLOWANCES_SLOT: U256 =
+    uint!(0xc78b71fee795ddd74aff64ea9b2474194c938c3196430e10bb5f01ed48434005_U256);
 
 /// Storage slot where staticcall probes store the call success flag.
 const PROBE_CALL_SUCCESS_SLOT: U256 = U256::ZERO;

--- a/crates/common/precompile-storage/README.md
+++ b/crates/common/precompile-storage/README.md
@@ -58,6 +58,8 @@ slot(key, base) = keccak256(lpad32(key) ‖ to_be32(base))
 
 This matches Solidity's `keccak256(abi.encode(key, slot))` for:
 - Unsigned integers, `Address`, `FixedBytes<32>` — identical encoding
+- `String` — uses `keccak256(bytes(key) ‖ to_be32(base))`, matching Solidity's string-keyed
+  mapping derivation
 - Signed integers — diverges (we zero-left-pad the two's complement bits; Solidity sign-extends)
 - `FixedBytes<N>` for N < 32 — diverges (we left-pad; Solidity right-pads)
 

--- a/crates/common/precompile-storage/src/types/bytes_like.rs
+++ b/crates/common/precompile-storage/src/types/bytes_like.rs
@@ -17,7 +17,10 @@ use alloy_primitives::{Address, Bytes, U256, keccak256};
 
 use crate::{
     error::{BasePrecompileError, Result},
-    provider::{Handler, Layout, LayoutCtx, Storable, StorableType, StorageOps},
+    provider::{
+        Handler, Layout, LayoutCtx, Storable, StorableType, StorageKey, StorageOps,
+        sealed::OnlyPrimitives,
+    },
     types::Slot,
 };
 
@@ -153,6 +156,23 @@ impl Storable for String {
     fn delete<S: StorageOps>(storage: &mut S, slot: U256, ctx: LayoutCtx) -> Result<()> {
         debug_assert_eq!(ctx, LayoutCtx::FULL, "String cannot be packed");
         delete_bytes_like(storage, slot)
+    }
+}
+
+impl OnlyPrimitives for String {}
+
+impl StorageKey for String {
+    #[inline]
+    fn as_storage_bytes(&self) -> impl AsRef<[u8]> {
+        self.as_bytes()
+    }
+
+    #[inline]
+    fn mapping_slot(&self, slot: U256) -> U256 {
+        let mut buf = Vec::with_capacity(self.len() + 32);
+        buf.extend_from_slice(self.as_bytes());
+        buf.extend_from_slice(&slot.to_be_bytes::<32>());
+        U256::from_be_bytes(keccak256(buf).0)
     }
 }
 

--- a/crates/common/precompile-storage/src/types/mapping.rs
+++ b/crates/common/precompile-storage/src/types/mapping.rs
@@ -152,6 +152,16 @@ mod tests {
     }
 
     #[test]
+    fn test_string_mapping_slot_matches_solidity_packed_encoding() {
+        let slot = U256::from(123u64);
+        let key = "ISIN".to_owned();
+        let mut buf = key.as_bytes().to_vec();
+        buf.extend_from_slice(&slot.to_be_bytes::<32>());
+
+        assert_eq!(key.mapping_slot(slot), U256::from_be_bytes(keccak256(buf).0));
+    }
+
+    #[test]
     fn test_mapping_basic_properties() {
         let address = Address::from([0x10; 20]);
         let base_slot = U256::from(1u64);

--- a/crates/common/precompiles/benches/base_precompiles.rs
+++ b/crates/common/precompiles/benches/base_precompiles.rs
@@ -215,19 +215,6 @@ fn base_token_view(c: &mut Criterion) {
             });
         });
     });
-
-    c.bench_function("base_token_minimum_redeemable", |b| {
-        let mut storage = HashMapStorageProvider::new(1);
-        StorageCtx::enter(&mut storage, |ctx| {
-            let token = BaseTokenBenchSetup::create_token(ctx, B256::repeat_byte(0x0b), U256::ZERO);
-
-            b.iter(|| {
-                let token = black_box(&token);
-                let result = token.accounting().minimum_redeemable().unwrap();
-                black_box(result);
-            });
-        });
-    });
 }
 
 fn base_token_mutate(c: &mut Criterion) {

--- a/crates/common/precompiles/src/b20/abi.rs
+++ b/crates/common/precompiles/src/b20/abi.rs
@@ -77,9 +77,6 @@ sol! {
         function symbol() external view returns (string);
         function decimals() external view returns (uint8);
         function totalSupply() external view returns (uint256);
-        function minimumRedeemable() external view returns (uint256);
-        function currency() external view returns (string);
-        function securityIdentifier(string calldata identifierType) external view returns (string);
         function balanceOf(address account) external view returns (uint256);
         function allowance(address owner, address spender) external view returns (uint256);
         function transfer(address to, uint256 amount) external returns (bool);

--- a/crates/common/precompiles/src/b20/dispatch.rs
+++ b/crates/common/precompiles/src/b20/dispatch.rs
@@ -55,11 +55,6 @@ impl<S: TokenAccounting, P: Policy> B20Token<S, P> {
             C::symbol(_) => self.accounting.symbol()?.abi_encode().into(),
             C::decimals(_) => U256::from(self.accounting.decimals()?).abi_encode().into(),
             C::totalSupply(_) => self.accounting.total_supply()?.abi_encode().into(),
-            C::minimumRedeemable(_) => self.accounting.minimum_redeemable()?.abi_encode().into(),
-            C::currency(_) => self.accounting.currency()?.abi_encode().into(),
-            C::securityIdentifier(c) => {
-                self.accounting.security_identifier(&c.identifierType)?.abi_encode().into()
-            }
             C::balanceOf(c) => self.accounting.balance_of(c.account)?.abi_encode().into(),
             C::allowance(c) => self.accounting.allowance(c.owner, c.spender)?.abi_encode().into(),
             C::supplyCap(_) => self.accounting.supply_cap()?.abi_encode().into(),

--- a/crates/common/precompiles/src/b20/mod.rs
+++ b/crates/common/precompiles/src/b20/mod.rs
@@ -14,7 +14,7 @@ mod precompile;
 pub use precompile::B20TokenPrecompile;
 
 mod storage;
-pub use storage::{B20CoreStorage, B20StablecoinStorage, B20TokenStorage};
+pub use storage::{B20CoreStorage, B20StablecoinExtensionStorage, B20TokenStorage};
 
 mod token;
 pub use token::B20Token;

--- a/crates/common/precompiles/src/b20/mod.rs
+++ b/crates/common/precompiles/src/b20/mod.rs
@@ -14,7 +14,7 @@ mod precompile;
 pub use precompile::B20TokenPrecompile;
 
 mod storage;
-pub use storage::{B20CoreStorage, B20StablecoinExtensionStorage, B20TokenStorage};
+pub use storage::{B20CoreStorage, B20TokenStorage};
 
 mod token;
 pub use token::B20Token;

--- a/crates/common/precompiles/src/b20/mod.rs
+++ b/crates/common/precompiles/src/b20/mod.rs
@@ -14,7 +14,7 @@ mod precompile;
 pub use precompile::B20TokenPrecompile;
 
 mod storage;
-pub use storage::B20TokenStorage;
+pub use storage::{B20CoreStorage, B20StablecoinStorage, B20TokenStorage};
 
 mod token;
 pub use token::B20Token;

--- a/crates/common/precompiles/src/b20/storage.rs
+++ b/crates/common/precompiles/src/b20/storage.rs
@@ -129,14 +129,6 @@ impl TokenAccounting for B20TokenStorage<'_> {
             .map_or(0, TokenVariant::decimals))
     }
 
-    fn currency(&self) -> Result<String> {
-        Ok(String::new())
-    }
-
-    fn security_identifier(&self, _identifier_type: &str) -> Result<String> {
-        Ok(String::new())
-    }
-
     fn paused(&self) -> Result<U256> {
         self.b20.paused.read()
     }
@@ -154,14 +146,6 @@ impl TokenAccounting for B20TokenStorage<'_> {
         let next =
             current.checked_add(U256::ONE).ok_or_else(BasePrecompileError::under_overflow)?;
         self.b20.nonces.at_mut(&owner).write(next)
-    }
-
-    fn minimum_redeemable(&self) -> Result<U256> {
-        Ok(U256::ZERO)
-    }
-
-    fn set_minimum_redeemable(&mut self, _minimum: U256) -> Result<()> {
-        Ok(())
     }
 
     fn contract_uri(&self) -> Result<String> {

--- a/crates/common/precompiles/src/b20/storage.rs
+++ b/crates/common/precompiles/src/b20/storage.rs
@@ -44,19 +44,10 @@ pub struct B20CoreStorage {
     pub nonces: Mapping<Address, U256>, // offset 13
 }
 
-/// Stablecoin B-20 extension storage rooted at the `base.b20.stablecoin` ERC-7201 namespace.
-#[derive(Debug, Clone, Storable)]
-#[namespace("base.b20.stablecoin")]
-pub struct B20StablecoinExtensionStorage {
-    /// Stablecoin currency identifier.
-    pub currency: String, // offset 0
-}
-
-/// EVM-backed storage for the default and stablecoin B-20 variants.
+/// EVM-backed storage for the default B-20 variant.
 #[contract]
 pub struct B20TokenStorage {
     pub b20: B20CoreStorage,
-    pub stablecoin: B20StablecoinExtensionStorage,
 }
 
 impl<'a> B20TokenStorage<'a> {
@@ -139,7 +130,7 @@ impl TokenAccounting for B20TokenStorage<'_> {
     }
 
     fn currency(&self) -> Result<String> {
-        self.stablecoin.currency.read()
+        Ok(String::new())
     }
 
     fn security_identifier(&self, _identifier_type: &str) -> Result<String> {
@@ -330,33 +321,19 @@ mod tests {
     use alloy_primitives::{Address, U256, address, uint};
     use base_precompile_storage::{Handler, StorableType, StorageCtx, StorageKey, setup_storage};
 
-    use super::{
-        __packing_b20_core_storage, __packing_b20_stablecoin_storage, B20CoreStorage,
-        B20StablecoinExtensionStorage, B20TokenStorage, slots,
-    };
+    use super::{__packing_b20_core_storage, B20CoreStorage, B20TokenStorage, slots};
     use crate::{B20TokenRole, TokenAccounting};
 
     const TOKEN: Address = address!("000000000000000000000000000000000000b020");
     const B20_ROOT: U256 =
         uint!(0xc78b71fee795ddd74aff64ea9b2474194c938c3196430e10bb5f01ed48434000_U256);
-    const STABLECOIN_ROOT: U256 =
-        uint!(0x35827975a06ca0e9367ea3129b19441d45d0ca58e30b7693f09e73d0943d6200_U256);
 
     #[test]
     fn b20_namespaces_match_base_std_roots() {
         assert_eq!(<B20CoreStorage as StorableType>::STORAGE_NAMESPACE_ID, "base.b20");
         assert_eq!(<B20CoreStorage as StorableType>::STORAGE_NAMESPACE_ROOT, B20_ROOT);
-        assert_eq!(
-            <B20StablecoinExtensionStorage as StorableType>::STORAGE_NAMESPACE_ID,
-            "base.b20.stablecoin"
-        );
-        assert_eq!(
-            <B20StablecoinExtensionStorage as StorableType>::STORAGE_NAMESPACE_ROOT,
-            STABLECOIN_ROOT
-        );
 
         assert_eq!(slots::B20, B20_ROOT);
-        assert_eq!(slots::STABLECOIN, STABLECOIN_ROOT);
     }
 
     #[test]
@@ -375,7 +352,6 @@ mod tests {
         assert_eq!(__packing_b20_core_storage::PAUSED_LOC.offset_slots, 11);
         assert_eq!(__packing_b20_core_storage::SUPPLY_CAP_LOC.offset_slots, 12);
         assert_eq!(__packing_b20_core_storage::NONCES_LOC.offset_slots, 13);
-        assert_eq!(__packing_b20_stablecoin_storage::CURRENCY_LOC.offset_slots, 0);
     }
 
     #[test]

--- a/crates/common/precompiles/src/b20/storage.rs
+++ b/crates/common/precompiles/src/b20/storage.rs
@@ -44,10 +44,10 @@ pub struct B20CoreStorage {
     pub nonces: Mapping<Address, U256>, // offset 13
 }
 
-/// Stablecoin B-20 storage rooted at the `base.b20.stablecoin` ERC-7201 namespace.
+/// Stablecoin B-20 extension storage rooted at the `base.b20.stablecoin` ERC-7201 namespace.
 #[derive(Debug, Clone, Storable)]
 #[namespace("base.b20.stablecoin")]
-pub struct B20StablecoinStorage {
+pub struct B20StablecoinExtensionStorage {
     /// Stablecoin currency identifier.
     pub currency: String, // offset 0
 }
@@ -56,7 +56,7 @@ pub struct B20StablecoinStorage {
 #[contract]
 pub struct B20TokenStorage {
     pub b20: B20CoreStorage,
-    pub stablecoin: B20StablecoinStorage,
+    pub stablecoin: B20StablecoinExtensionStorage,
 }
 
 impl<'a> B20TokenStorage<'a> {
@@ -69,9 +69,9 @@ impl<'a> B20TokenStorage<'a> {
 
     /// Writes all creation-time fields atomically.
     pub fn initialize(&mut self, name: String, symbol: String, supply_cap: U256) -> Result<()> {
-        self.name.write(name)?;
-        self.symbol.write(symbol)?;
-        self.supply_cap.write(supply_cap)?;
+        self.b20.name.write(name)?;
+        self.b20.symbol.write(symbol)?;
+        self.b20.supply_cap.write(supply_cap)?;
         Ok(())
     }
 }
@@ -332,7 +332,7 @@ mod tests {
 
     use super::{
         __packing_b20_core_storage, __packing_b20_stablecoin_storage, B20CoreStorage,
-        B20StablecoinStorage, B20TokenStorage, slots,
+        B20StablecoinExtensionStorage, B20TokenStorage, slots,
     };
     use crate::{B20TokenRole, TokenAccounting};
 
@@ -347,10 +347,13 @@ mod tests {
         assert_eq!(<B20CoreStorage as StorableType>::STORAGE_NAMESPACE_ID, "base.b20");
         assert_eq!(<B20CoreStorage as StorableType>::STORAGE_NAMESPACE_ROOT, B20_ROOT);
         assert_eq!(
-            <B20StablecoinStorage as StorableType>::STORAGE_NAMESPACE_ID,
+            <B20StablecoinExtensionStorage as StorableType>::STORAGE_NAMESPACE_ID,
             "base.b20.stablecoin"
         );
-        assert_eq!(<B20StablecoinStorage as StorableType>::STORAGE_NAMESPACE_ROOT, STABLECOIN_ROOT);
+        assert_eq!(
+            <B20StablecoinExtensionStorage as StorableType>::STORAGE_NAMESPACE_ROOT,
+            STABLECOIN_ROOT
+        );
 
         assert_eq!(slots::B20, B20_ROOT);
         assert_eq!(slots::STABLECOIN, STABLECOIN_ROOT);

--- a/crates/common/precompiles/src/b20/storage.rs
+++ b/crates/common/precompiles/src/b20/storage.rs
@@ -3,33 +3,60 @@
 use alloc::string::String;
 
 use alloy_primitives::{Address, B256, LogData, U256};
-use base_precompile_macros::contract;
+use base_precompile_macros::{Storable, contract};
 use base_precompile_storage::{
     BasePrecompileError, ContractStorage, Handler, Mapping, Result, StorageCtx,
 };
 
-use crate::{B20PolicyType, IB20, TokenAccounting, TokenVariant};
+use crate::{B20PolicyType, B20TokenRole, IB20, TokenAccounting, TokenVariant};
 
+/// Core B-20 storage rooted at the `base.b20` ERC-7201 namespace.
+#[derive(Debug, Clone, Storable)]
+#[namespace("base.b20")]
+pub struct B20CoreStorage {
+    /// Mutable token name.
+    pub name: String, // offset 0
+    /// Mutable token symbol.
+    pub symbol: String, // offset 1
+    /// ERC-7572 contract metadata URI.
+    pub contract_uri: String, // offset 2
+    /// Total token supply.
+    pub total_supply: U256, // offset 3
+    /// Token balances by account.
+    pub balances: Mapping<Address, U256>, // offset 4
+    /// Spending allowances by owner and spender.
+    pub allowances: Mapping<Address, Mapping<Address, U256>>, // offset 5
+    /// Role membership flags by role and account.
+    pub roles: Mapping<B256, Mapping<Address, bool>>, // offset 6
+    /// Admin role configured for each role.
+    pub role_admins: Mapping<B256, B256>, // offset 7
+    /// Packed default-admin count and initialization flag.
+    pub admin_count_and_initialized: U256, // offset 8
+    /// Packed transfer-side policy IDs.
+    pub transfer_policy_ids: U256, // offset 9: sender, receiver, executor, reserved
+    /// Packed mint-side policy IDs.
+    pub mint_policy_ids: U256, // offset 10: receiver, reserved, reserved, reserved
+    /// Paused feature bitmask.
+    pub paused: U256, // offset 11
+    /// Maximum total supply.
+    pub supply_cap: U256, // offset 12
+    /// EIP-2612 permit nonces by owner.
+    pub nonces: Mapping<Address, U256>, // offset 13
+}
+
+/// Stablecoin B-20 storage rooted at the `base.b20.stablecoin` ERC-7201 namespace.
+#[derive(Debug, Clone, Storable)]
+#[namespace("base.b20.stablecoin")]
+pub struct B20StablecoinStorage {
+    /// Stablecoin currency identifier.
+    pub currency: String, // offset 0
+}
+
+/// EVM-backed storage for the default and stablecoin B-20 variants.
 #[contract]
 pub struct B20TokenStorage {
-    pub total_supply: U256,                                   // slot 0
-    pub supply_cap: U256,                                     // slot 1
-    pub balances: Mapping<Address, U256>,                     // slot 2
-    pub allowances: Mapping<Address, Mapping<Address, U256>>, // slot 3
-    pub paused: U256,                                         // slot 4
-    pub nonces: Mapping<Address, U256>,                       // slot 5
-    pub name: String,                                         // slot 6
-    pub symbol: String,                                       // slot 7
-    pub minimum_redeemable: U256,                             // slot 8
-    pub contract_uri: String,                                 // slot 9
-    // slot 10 previously held pre-production capabilities; Beryl starts with fresh B-20 storage.
-    pub roles: Mapping<B256, Mapping<Address, bool>>, // slot 10
-    pub role_member_counts: Mapping<B256, U256>,      // slot 11
-    pub role_admins: Mapping<B256, B256>,             // slot 12
-    pub transfer_policy_ids: U256, // slot 13: sender, receiver, executor, reserved
-    pub mint_policy_ids: U256,     // slot 14: receiver, reserved, reserved, reserved
-    pub stablecoin_currency: String, // slot 15
-    pub security_isin: String,     // slot 16
+    pub b20: B20CoreStorage,
+    pub stablecoin: B20StablecoinStorage,
 }
 
 impl<'a> B20TokenStorage<'a> {
@@ -59,141 +86,156 @@ impl TokenAccounting for B20TokenStorage<'_> {
     }
 
     fn balance_of(&self, account: Address) -> Result<U256> {
-        self.balances.at(&account).read()
+        self.b20.balances.at(&account).read()
     }
 
     fn set_balance(&mut self, account: Address, balance: U256) -> Result<()> {
-        self.balances.at_mut(&account).write(balance)
+        self.b20.balances.at_mut(&account).write(balance)
     }
 
     fn allowance(&self, owner: Address, spender: Address) -> Result<U256> {
-        self.allowances.at(&owner).at(&spender).read()
+        self.b20.allowances.at(&owner).at(&spender).read()
     }
 
     fn set_allowance(&mut self, owner: Address, spender: Address, amount: U256) -> Result<()> {
-        self.allowances.at_mut(&owner).at_mut(&spender).write(amount)
+        self.b20.allowances.at_mut(&owner).at_mut(&spender).write(amount)
     }
 
     fn total_supply(&self) -> Result<U256> {
-        self.total_supply.read()
+        self.b20.total_supply.read()
     }
 
     fn set_total_supply(&mut self, supply: U256) -> Result<()> {
-        self.total_supply.write(supply)
+        self.b20.total_supply.write(supply)
     }
 
     fn supply_cap(&self) -> Result<U256> {
-        self.supply_cap.read()
+        self.b20.supply_cap.read()
     }
 
     fn set_supply_cap(&mut self, cap: U256) -> Result<()> {
-        self.supply_cap.write(cap)
+        self.b20.supply_cap.write(cap)
     }
 
     fn name(&self) -> Result<String> {
-        self.name.read()
+        self.b20.name.read()
     }
 
     fn set_name(&mut self, name: String) -> Result<()> {
-        self.name.write(name)
+        self.b20.name.write(name)
     }
 
     fn symbol(&self) -> Result<String> {
-        self.symbol.read()
+        self.b20.symbol.read()
     }
 
     fn set_symbol(&mut self, symbol: String) -> Result<()> {
-        self.symbol.write(symbol)
+        self.b20.symbol.write(symbol)
     }
 
     fn decimals(&self) -> Result<u8> {
-        Ok(TokenVariant::from_address(self.address).map_or(0, TokenVariant::decimals))
+        Ok(TokenVariant::from_address(ContractStorage::address(self))
+            .map_or(0, TokenVariant::decimals))
     }
 
     fn currency(&self) -> Result<String> {
-        self.stablecoin_currency.read()
+        self.stablecoin.currency.read()
     }
 
-    fn security_identifier(&self, identifier_type: &str) -> Result<String> {
-        if identifier_type == "ISIN" { self.security_isin.read() } else { Ok(String::new()) }
+    fn security_identifier(&self, _identifier_type: &str) -> Result<String> {
+        Ok(String::new())
     }
 
     fn paused(&self) -> Result<U256> {
-        self.paused.read()
+        self.b20.paused.read()
     }
 
     fn set_paused(&mut self, vectors: U256) -> Result<()> {
-        self.paused.write(vectors)
+        self.b20.paused.write(vectors)
     }
 
     fn nonce(&self, owner: Address) -> Result<U256> {
-        self.nonces.at(&owner).read()
+        self.b20.nonces.at(&owner).read()
     }
 
     fn increment_nonce(&mut self, owner: Address) -> Result<()> {
-        let current = self.nonces.at(&owner).read()?;
+        let current = self.b20.nonces.at(&owner).read()?;
         let next =
             current.checked_add(U256::ONE).ok_or_else(BasePrecompileError::under_overflow)?;
-        self.nonces.at_mut(&owner).write(next)
+        self.b20.nonces.at_mut(&owner).write(next)
     }
 
     fn minimum_redeemable(&self) -> Result<U256> {
-        self.minimum_redeemable.read()
+        Ok(U256::ZERO)
     }
 
-    fn set_minimum_redeemable(&mut self, minimum: U256) -> Result<()> {
-        self.minimum_redeemable.write(minimum)
+    fn set_minimum_redeemable(&mut self, _minimum: U256) -> Result<()> {
+        Ok(())
     }
 
     fn contract_uri(&self) -> Result<String> {
-        self.contract_uri.read()
+        self.b20.contract_uri.read()
     }
 
     fn set_contract_uri(&mut self, uri: String) -> Result<()> {
-        self.contract_uri.write(uri)
+        self.b20.contract_uri.write(uri)
     }
 
     fn has_role(&self, role: B256, account: Address) -> Result<bool> {
-        self.roles.at(&role).at(&account).read()
+        self.b20.roles.at(&role).at(&account).read()
     }
 
     fn set_role(&mut self, role: B256, account: Address, enabled: bool) -> Result<()> {
-        self.roles.at_mut(&role).at_mut(&account).write(enabled)
+        self.b20.roles.at_mut(&role).at_mut(&account).write(enabled)
     }
 
     fn role_member_count(&self, role: B256) -> Result<U256> {
-        self.role_member_counts.at(&role).read()
+        if role == B20TokenRole::DefaultAdmin.id() {
+            Ok(Self::read_admin_count(self.b20.admin_count_and_initialized.read()?))
+        } else {
+            Ok(U256::ZERO)
+        }
     }
 
     fn set_role_member_count(&mut self, role: B256, count: U256) -> Result<()> {
-        self.role_member_counts.at_mut(&role).write(count)
+        if role == B20TokenRole::DefaultAdmin.id() {
+            let packed = self.b20.admin_count_and_initialized.read()?;
+            self.b20.admin_count_and_initialized.write(Self::write_admin_count(packed, count)?)
+        } else {
+            Ok(())
+        }
     }
 
     fn role_admin(&self, role: B256) -> Result<B256> {
-        self.role_admins.at(&role).read()
+        let admin_role = self.b20.role_admins.at(&role).read()?;
+        if admin_role.is_zero() && role != B20TokenRole::DefaultAdmin.id() {
+            Ok(B20TokenRole::DefaultAdmin.id())
+        } else {
+            Ok(admin_role)
+        }
     }
 
     fn set_role_admin(&mut self, role: B256, admin_role: B256) -> Result<()> {
-        self.role_admins.at_mut(&role).write(admin_role)
+        self.b20.role_admins.at_mut(&role).write(admin_role)
     }
 
     fn policy_id(&self, policy_type: B256) -> Result<u64> {
         let policy_type = Self::require_policy_type(policy_type)?;
         match policy_type {
             B20PolicyType::TransferSender => Ok(Self::read_policy_lane(
-                self.transfer_policy_ids.read()?,
+                self.b20.transfer_policy_ids.read()?,
                 Self::TRANSFER_SENDER_POLICY_LANE,
             )),
             B20PolicyType::TransferReceiver => Ok(Self::read_policy_lane(
-                self.transfer_policy_ids.read()?,
+                self.b20.transfer_policy_ids.read()?,
                 Self::TRANSFER_RECEIVER_POLICY_LANE,
             )),
             B20PolicyType::TransferExecutor => Ok(Self::read_policy_lane(
-                self.transfer_policy_ids.read()?,
+                self.b20.transfer_policy_ids.read()?,
                 Self::TRANSFER_EXECUTOR_POLICY_LANE,
             )),
             B20PolicyType::MintReceiver => Ok(Self::read_policy_lane(
-                self.mint_policy_ids.read()?,
+                self.b20.mint_policy_ids.read()?,
                 Self::MINT_RECEIVER_POLICY_LANE,
             )),
         }
@@ -204,35 +246,35 @@ impl TokenAccounting for B20TokenStorage<'_> {
         match policy_type {
             B20PolicyType::TransferSender => {
                 let packed = Self::write_policy_lane(
-                    self.transfer_policy_ids.read()?,
+                    self.b20.transfer_policy_ids.read()?,
                     Self::TRANSFER_SENDER_POLICY_LANE,
                     policy_id,
                 );
-                self.transfer_policy_ids.write(packed)
+                self.b20.transfer_policy_ids.write(packed)
             }
             B20PolicyType::TransferReceiver => {
                 let packed = Self::write_policy_lane(
-                    self.transfer_policy_ids.read()?,
+                    self.b20.transfer_policy_ids.read()?,
                     Self::TRANSFER_RECEIVER_POLICY_LANE,
                     policy_id,
                 );
-                self.transfer_policy_ids.write(packed)
+                self.b20.transfer_policy_ids.write(packed)
             }
             B20PolicyType::TransferExecutor => {
                 let packed = Self::write_policy_lane(
-                    self.transfer_policy_ids.read()?,
+                    self.b20.transfer_policy_ids.read()?,
                     Self::TRANSFER_EXECUTOR_POLICY_LANE,
                     policy_id,
                 );
-                self.transfer_policy_ids.write(packed)
+                self.b20.transfer_policy_ids.write(packed)
             }
             B20PolicyType::MintReceiver => {
                 let packed = Self::write_policy_lane(
-                    self.mint_policy_ids.read()?,
+                    self.b20.mint_policy_ids.read()?,
                     Self::MINT_RECEIVER_POLICY_LANE,
                     policy_id,
                 );
-                self.mint_policy_ids.write(packed)
+                self.b20.mint_policy_ids.write(packed)
             }
         }
     }
@@ -243,11 +285,28 @@ impl TokenAccounting for B20TokenStorage<'_> {
 }
 
 impl B20TokenStorage<'_> {
+    const ADMIN_COUNT_BITS: usize = 248;
     const TRANSFER_SENDER_POLICY_LANE: usize = 0;
     const TRANSFER_RECEIVER_POLICY_LANE: usize = 1;
     const TRANSFER_EXECUTOR_POLICY_LANE: usize = 2;
     const MINT_RECEIVER_POLICY_LANE: usize = 0;
     const POLICY_LANE_BITS: usize = 64;
+
+    fn admin_count_mask() -> U256 {
+        (U256::ONE << Self::ADMIN_COUNT_BITS) - U256::ONE
+    }
+
+    fn read_admin_count(packed: U256) -> U256 {
+        packed & Self::admin_count_mask()
+    }
+
+    fn write_admin_count(packed: U256, count: U256) -> Result<U256> {
+        let mask = Self::admin_count_mask();
+        if count > mask {
+            return Err(BasePrecompileError::under_overflow());
+        }
+        Ok((packed & !mask) | count)
+    }
 
     fn require_policy_type(policy_type: B256) -> Result<B20PolicyType> {
         B20PolicyType::from_id(policy_type).ok_or_else(|| {
@@ -263,5 +322,98 @@ impl B20TokenStorage<'_> {
         let shift = lane * Self::POLICY_LANE_BITS;
         let mask = U256::from(u64::MAX) << shift;
         (packed & !mask) | (U256::from(policy_id) << shift)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_primitives::{Address, U256, address, uint};
+    use base_precompile_storage::{Handler, StorableType, StorageCtx, StorageKey, setup_storage};
+
+    use super::{
+        __packing_b20_core_storage, __packing_b20_stablecoin_storage, B20CoreStorage,
+        B20StablecoinStorage, B20TokenStorage, slots,
+    };
+    use crate::{B20TokenRole, TokenAccounting};
+
+    const TOKEN: Address = address!("000000000000000000000000000000000000b020");
+    const B20_ROOT: U256 =
+        uint!(0xc78b71fee795ddd74aff64ea9b2474194c938c3196430e10bb5f01ed48434000_U256);
+    const STABLECOIN_ROOT: U256 =
+        uint!(0x35827975a06ca0e9367ea3129b19441d45d0ca58e30b7693f09e73d0943d6200_U256);
+
+    #[test]
+    fn b20_namespaces_match_base_std_roots() {
+        assert_eq!(<B20CoreStorage as StorableType>::STORAGE_NAMESPACE_ID, "base.b20");
+        assert_eq!(<B20CoreStorage as StorableType>::STORAGE_NAMESPACE_ROOT, B20_ROOT);
+        assert_eq!(
+            <B20StablecoinStorage as StorableType>::STORAGE_NAMESPACE_ID,
+            "base.b20.stablecoin"
+        );
+        assert_eq!(<B20StablecoinStorage as StorableType>::STORAGE_NAMESPACE_ROOT, STABLECOIN_ROOT);
+
+        assert_eq!(slots::B20, B20_ROOT);
+        assert_eq!(slots::STABLECOIN, STABLECOIN_ROOT);
+    }
+
+    #[test]
+    fn b20_core_offsets_match_mock_b20_storage() {
+        assert_eq!(__packing_b20_core_storage::NAME_LOC.offset_slots, 0);
+        assert_eq!(__packing_b20_core_storage::SYMBOL_LOC.offset_slots, 1);
+        assert_eq!(__packing_b20_core_storage::CONTRACT_URI_LOC.offset_slots, 2);
+        assert_eq!(__packing_b20_core_storage::TOTAL_SUPPLY_LOC.offset_slots, 3);
+        assert_eq!(__packing_b20_core_storage::BALANCES_LOC.offset_slots, 4);
+        assert_eq!(__packing_b20_core_storage::ALLOWANCES_LOC.offset_slots, 5);
+        assert_eq!(__packing_b20_core_storage::ROLES_LOC.offset_slots, 6);
+        assert_eq!(__packing_b20_core_storage::ROLE_ADMINS_LOC.offset_slots, 7);
+        assert_eq!(__packing_b20_core_storage::ADMIN_COUNT_AND_INITIALIZED_LOC.offset_slots, 8);
+        assert_eq!(__packing_b20_core_storage::TRANSFER_POLICY_IDS_LOC.offset_slots, 9);
+        assert_eq!(__packing_b20_core_storage::MINT_POLICY_IDS_LOC.offset_slots, 10);
+        assert_eq!(__packing_b20_core_storage::PAUSED_LOC.offset_slots, 11);
+        assert_eq!(__packing_b20_core_storage::SUPPLY_CAP_LOC.offset_slots, 12);
+        assert_eq!(__packing_b20_core_storage::NONCES_LOC.offset_slots, 13);
+        assert_eq!(__packing_b20_stablecoin_storage::CURRENCY_LOC.offset_slots, 0);
+    }
+
+    #[test]
+    fn b20_core_mapping_slots_are_rooted_at_namespace_offsets() {
+        let (mut storage, _) = setup_storage();
+        let holder = Address::repeat_byte(0xaa);
+        let spender = Address::repeat_byte(0xbb);
+        let role = B20TokenRole::Mint.id();
+
+        StorageCtx::enter(&mut storage, |ctx| {
+            let mut token = B20TokenStorage::from_address(TOKEN, ctx);
+            token.b20.balances.at_mut(&holder).write(U256::from(100)).unwrap();
+            token.b20.allowances.at_mut(&holder).at_mut(&spender).write(U256::from(25)).unwrap();
+            token.b20.roles.at_mut(&role).at_mut(&holder).write(true).unwrap();
+            token.set_role_member_count(B20TokenRole::DefaultAdmin.id(), U256::ONE).unwrap();
+
+            let balances_slot =
+                B20_ROOT + U256::from(__packing_b20_core_storage::BALANCES_LOC.offset_slots);
+            let allowances_slot =
+                B20_ROOT + U256::from(__packing_b20_core_storage::ALLOWANCES_LOC.offset_slots);
+            let roles_slot =
+                B20_ROOT + U256::from(__packing_b20_core_storage::ROLES_LOC.offset_slots);
+            let admin_count_slot = B20_ROOT
+                + U256::from(
+                    __packing_b20_core_storage::ADMIN_COUNT_AND_INITIALIZED_LOC.offset_slots,
+                );
+
+            assert_eq!(
+                ctx.sload(TOKEN, holder.mapping_slot(balances_slot)).unwrap(),
+                U256::from(100)
+            );
+            assert_eq!(
+                ctx.sload(TOKEN, spender.mapping_slot(holder.mapping_slot(allowances_slot)))
+                    .unwrap(),
+                U256::from(25)
+            );
+            assert_eq!(
+                ctx.sload(TOKEN, holder.mapping_slot(role.mapping_slot(roles_slot))).unwrap(),
+                U256::ONE
+            );
+            assert_eq!(ctx.sload(TOKEN, admin_count_slot).unwrap(), U256::ONE);
+        });
     }
 }

--- a/crates/common/precompiles/src/b20_security/abi.rs
+++ b/crates/common/precompiles/src/b20_security/abi.rs
@@ -114,6 +114,9 @@ sol! {
         /// Sets the minimum-redeemable threshold in shares. Requires `DEFAULT_ADMIN_ROLE`.
         function updateMinimumRedeemable(uint256 newMinimumRedeemable) external;
 
+        /// Returns the minimum-redeemable threshold in shares.
+        function minimumRedeemable() external view returns (uint256);
+
         // ── Security identifiers ─────────────────────────────────────────────
 
         /// Returns the value of the named identifier (e.g. ISIN, CUSIP). Empty string if not set.

--- a/crates/common/precompiles/src/b20_security/accounting.rs
+++ b/crates/common/precompiles/src/b20_security/accounting.rs
@@ -2,7 +2,7 @@
 
 use alloc::string::String;
 
-use alloy_primitives::{B256, U256};
+use alloy_primitives::U256;
 use base_precompile_storage::Result;
 
 use crate::TokenAccounting;
@@ -22,8 +22,8 @@ pub trait SecurityAccounting: TokenAccounting {
     fn set_security_identifier_value(&mut self, identifier_type: &str, value: String)
     -> Result<()>;
 
-    /// Returns `true` if `id_hash` (= `keccak256(id)`) has been consumed by `announce`.
-    fn is_announcement_id_used(&self, id_hash: B256) -> Result<bool>;
-    /// Marks `id_hash` as consumed. Called exactly once per announcement id.
-    fn mark_announcement_id_used(&mut self, id_hash: B256) -> Result<()>;
+    /// Returns `true` if `id` has been consumed by `announce`.
+    fn is_announcement_id_used(&self, id: &str) -> Result<bool>;
+    /// Marks `id` as consumed. Called exactly once per announcement id.
+    fn mark_announcement_id_used(&mut self, id: &str) -> Result<()>;
 }

--- a/crates/common/precompiles/src/b20_security/accounting.rs
+++ b/crates/common/precompiles/src/b20_security/accounting.rs
@@ -9,18 +9,24 @@ use crate::TokenAccounting;
 
 /// Extends [`TokenAccounting`] with security-token-specific storage slots.
 ///
-/// Security identifiers (ISIN, CUSIP, etc.) are stored and retrieved via
-/// [`TokenAccounting::security_identifier`] and
-/// [`SecurityAccounting::set_security_identifier_value`].
+/// Security identifiers (ISIN, CUSIP, etc.) and redeem parameters are only
+/// exposed through the security-token surface, not the base B-20 surface.
 pub trait SecurityAccounting: TokenAccounting {
     /// Returns the current share-to-tokens ratio scaled to WAD (1e18).
     fn shares_to_tokens_ratio(&self) -> Result<U256>;
     /// Writes a new share-to-tokens ratio.
     fn set_shares_to_tokens_ratio(&mut self, ratio: U256) -> Result<()>;
 
+    /// Returns the security identifier value for `identifier_type`, or an empty string if unset.
+    fn security_identifier(&self, identifier_type: &str) -> Result<String>;
     /// Writes (or removes when `value` is empty) the security identifier for `identifier_type`.
     fn set_security_identifier_value(&mut self, identifier_type: &str, value: String)
     -> Result<()>;
+
+    /// Returns the minimum amount that may be redeemed in a single call.
+    fn minimum_redeemable(&self) -> Result<U256>;
+    /// Overwrites the minimum redeemable amount.
+    fn set_minimum_redeemable(&mut self, minimum: U256) -> Result<()>;
 
     /// Returns `true` if `id` has been consumed by `announce`.
     fn is_announcement_id_used(&self, id: &str) -> Result<bool>;

--- a/crates/common/precompiles/src/b20_security/dispatch.rs
+++ b/crates/common/precompiles/src/b20_security/dispatch.rs
@@ -109,12 +109,6 @@ impl<S: SecurityAccounting, P: Policy> B20SecurityToken<S, P> {
             C::symbol(_) => self.accounting.symbol()?.abi_encode().into(),
             C::decimals(_) => U256::from(self.accounting.decimals()?).abi_encode().into(),
             C::totalSupply(_) => self.accounting.total_supply()?.abi_encode().into(),
-            C::minimumRedeemable(_) => self.accounting.minimum_redeemable()?.abi_encode().into(),
-            C::currency(_) => self.accounting.currency()?.abi_encode().into(),
-            // securityIdentifier also caught by IB20Security above; repeated for exhaustiveness.
-            C::securityIdentifier(c) => {
-                self.accounting.security_identifier(&c.identifierType)?.abi_encode().into()
-            }
             C::balanceOf(c) => self.accounting.balance_of(c.account)?.abi_encode().into(),
             C::allowance(c) => self.accounting.allowance(c.owner, c.spender)?.abi_encode().into(),
             C::supplyCap(_) => self.accounting.supply_cap()?.abi_encode().into(),
@@ -376,6 +370,7 @@ impl<S: SecurityAccounting, P: Policy> B20SecurityToken<S, P> {
             }
 
             // --- Minimum redeemable (security version, in shares) ---
+            SC::minimumRedeemable(_) => self.accounting.minimum_redeemable()?.abi_encode().into(),
             SC::updateMinimumRedeemable(c) => {
                 self.accounting_mut().set_minimum_redeemable(c.newMinimumRedeemable)?;
                 self.accounting_mut().emit_event(

--- a/crates/common/precompiles/src/b20_security/dispatch.rs
+++ b/crates/common/precompiles/src/b20_security/dispatch.rs
@@ -326,8 +326,7 @@ impl<S: SecurityAccounting, P: Policy> B20SecurityToken<S, P> {
 
             // --- Announcement reads ---
             SC::isAnnouncementIdUsed(c) => {
-                let id_hash = keccak256(c.id.as_bytes());
-                self.accounting.is_announcement_id_used(id_hash)?.abi_encode().into()
+                self.accounting.is_announcement_id_used(c.id.as_str())?.abi_encode().into()
             }
 
             // --- Security identifier reads ---
@@ -527,13 +526,12 @@ impl<S: SecurityAccounting, P: Policy> B20SecurityToken<S, P> {
             return Err(BasePrecompileError::revert(IB20Security::AnnouncementInProgress {}));
         }
 
-        let id_hash: B256 = keccak256(id.as_bytes());
-        if self.accounting.is_announcement_id_used(id_hash)? {
+        if self.accounting.is_announcement_id_used(id.as_str())? {
             return Err(BasePrecompileError::revert(IB20Security::AnnouncementIdAlreadyUsed {
                 id,
             }));
         }
-        self.accounting_mut().mark_announcement_id_used(id_hash)?;
+        self.accounting_mut().mark_announcement_id_used(id.as_str())?;
 
         let caller = ctx.caller();
         self.accounting_mut().emit_event(
@@ -708,11 +706,11 @@ mod tests {
     #[test]
     fn announce_marks_id_used() {
         let mut token = make_token();
-        let id_hash = keccak256(b"2026-Q1-split");
+        let id = "2026-Q1-split";
 
-        assert!(!token.accounting().is_announcement_id_used(id_hash).unwrap());
-        token.accounting_mut().mark_announcement_id_used(id_hash).unwrap();
-        assert!(token.accounting().is_announcement_id_used(id_hash).unwrap());
+        assert!(!token.accounting().is_announcement_id_used(id).unwrap());
+        token.accounting_mut().mark_announcement_id_used(id).unwrap();
+        assert!(token.accounting().is_announcement_id_used(id).unwrap());
     }
 
     #[test]
@@ -903,8 +901,8 @@ mod tests {
     #[test]
     fn announcement_id_not_used_initially() {
         let token = make_token();
-        let id_hash = keccak256(b"2026-Q1-split");
+        let id = "2026-Q1-split";
         // "Returns true if id has previously been consumed by announce" → false for new id
-        assert!(!token.accounting().is_announcement_id_used(id_hash).unwrap());
+        assert!(!token.accounting().is_announcement_id_used(id).unwrap());
     }
 }

--- a/crates/common/precompiles/src/b20_security/dispatch.rs
+++ b/crates/common/precompiles/src/b20_security/dispatch.rs
@@ -584,7 +584,7 @@ impl<S: SecurityAccounting, P: Policy> B20SecurityToken<S, P> {
 
 #[cfg(test)]
 mod tests {
-    use alloy_primitives::{Address, U256, keccak256};
+    use alloy_primitives::{Address, U256};
 
     use crate::{
         Token, TokenAccounting,

--- a/crates/common/precompiles/src/b20_security/mod.rs
+++ b/crates/common/precompiles/src/b20_security/mod.rs
@@ -12,7 +12,7 @@ mod precompile;
 pub use precompile::B20SecurityPrecompile;
 
 mod storage;
-pub use storage::B20SecurityStorage;
+pub use storage::{B20RedeemStorage, B20SecurityExtensionStorage, B20SecurityStorage};
 
 mod token;
 pub use token::B20SecurityToken;

--- a/crates/common/precompiles/src/b20_security/storage.rs
+++ b/crates/common/precompiles/src/b20_security/storage.rs
@@ -3,41 +3,42 @@
 use alloc::string::String;
 
 use alloy_primitives::{Address, B256, LogData, U256};
-use base_precompile_macros::contract;
+use base_precompile_macros::{Storable, contract};
 use base_precompile_storage::{
     BasePrecompileError, ContractStorage, Handler, Mapping, Result, StorageCtx,
 };
 
 use super::accounting::SecurityAccounting;
-use crate::{B20PolicyType, IB20, TokenAccounting, TokenVariant};
+use crate::{B20CoreStorage, B20PolicyType, B20TokenRole, IB20, TokenAccounting, TokenVariant};
+
+/// Security-specific B-20 storage rooted at the `base.b20.security` ERC-7201 namespace.
+#[derive(Debug, Clone, Storable)]
+#[namespace("base.b20.security")]
+pub struct B20SecurityExtensionStorage {
+    /// Share-to-token conversion ratio scaled to WAD.
+    pub shares_to_tokens_ratio: U256, // offset 0
+    /// Announcement IDs that have already been consumed.
+    pub used_announcement_ids: Mapping<String, bool>, // offset 1
+    /// Security identifier values by identifier type.
+    pub identifiers: Mapping<String, String>, // offset 2
+}
+
+/// Redemption-specific B-20 storage rooted at the `base.b20.redeem` ERC-7201 namespace.
+#[derive(Debug, Clone, Storable)]
+#[namespace("base.b20.redeem")]
+pub struct B20RedeemStorage {
+    /// Minimum share amount required for a redeem operation.
+    pub minimum_redeemable: U256, // offset 0
+    /// Packed redeem-side policy IDs.
+    pub redeem_policy_ids: U256, // offset 1
+}
 
 /// EVM-backed storage for a security B-20 token.
-///
-/// Slots 0–16 mirror [`crate::B20TokenStorage`] exactly so that address layout
-/// and role/policy/pause storage is compatible. Slots 17–19 hold the
-/// security-specific fields: share ratio, identifier map, and announcement-id set.
 #[contract]
 pub struct B20SecurityStorage {
-    pub total_supply: U256,                                   // slot 0
-    pub supply_cap: U256,                                     // slot 1
-    pub balances: Mapping<Address, U256>,                     // slot 2
-    pub allowances: Mapping<Address, Mapping<Address, U256>>, // slot 3
-    pub paused: U256,                                         // slot 4
-    pub nonces: Mapping<Address, U256>,                       // slot 5
-    pub name: String,                                         // slot 6
-    pub symbol: String,                                       // slot 7
-    pub minimum_redeemable: U256,                             // slot 8
-    pub contract_uri: String,                                 // slot 9
-    pub roles: Mapping<B256, Mapping<Address, bool>>,         // slot 10
-    pub role_member_counts: Mapping<B256, U256>,              // slot 11
-    pub role_admins: Mapping<B256, B256>,                     // slot 12
-    pub transfer_policy_ids: U256, // slot 13: sender, receiver, executor, reserved
-    pub mint_policy_ids: U256,     // slot 14: receiver, reserved, reserved, reserved
-    pub stablecoin_currency: String, // slot 15 (unused for security tokens)
-    pub security_isin: String,     // slot 16 (unused; identifiers stored in slot 18 mapping)
-    pub shares_to_tokens_ratio: U256, // slot 17
-    pub security_identifiers: Mapping<B256, String>, // slot 18  (key = keccak256(type))
-    pub announcement_ids_used: Mapping<B256, bool>, // slot 19  (key = keccak256(id))
+    pub b20: B20CoreStorage,
+    pub security: B20SecurityExtensionStorage,
+    pub redeem: B20RedeemStorage,
 }
 
 impl<'a> B20SecurityStorage<'a> {
@@ -48,8 +49,8 @@ impl<'a> B20SecurityStorage<'a> {
 
     /// Writes all creation-time fields atomically.
     ///
-    /// `initial_isin` may be empty; when non-empty it is stored under the
-    /// `keccak256("ISIN")` key in the `security_identifiers` mapping.
+    /// `initial_isin` may be empty; when non-empty it is stored under the raw
+    /// `"ISIN"` key in the security identifiers mapping.
     pub fn initialize(
         &mut self,
         name: String,
@@ -59,14 +60,13 @@ impl<'a> B20SecurityStorage<'a> {
         initial_isin: String,
         minimum_redeemable: U256,
     ) -> Result<()> {
-        self.name.write(name)?;
-        self.symbol.write(symbol)?;
-        self.supply_cap.write(supply_cap)?;
-        self.shares_to_tokens_ratio.write(initial_shares_to_tokens_ratio)?;
-        self.minimum_redeemable.write(minimum_redeemable)?;
+        self.b20.name.write(name)?;
+        self.b20.symbol.write(symbol)?;
+        self.b20.supply_cap.write(supply_cap)?;
+        self.security.shares_to_tokens_ratio.write(initial_shares_to_tokens_ratio)?;
+        self.redeem.minimum_redeemable.write(minimum_redeemable)?;
         if !initial_isin.is_empty() {
-            let key = alloy_primitives::keccak256(b"ISIN");
-            self.security_identifiers.at_mut(&key).write(initial_isin)?;
+            self.security.identifiers.at_mut(&String::from("ISIN")).write(initial_isin)?;
         }
         Ok(())
     }
@@ -82,142 +82,156 @@ impl TokenAccounting for B20SecurityStorage<'_> {
     }
 
     fn balance_of(&self, account: Address) -> Result<U256> {
-        self.balances.at(&account).read()
+        self.b20.balances.at(&account).read()
     }
 
     fn set_balance(&mut self, account: Address, balance: U256) -> Result<()> {
-        self.balances.at_mut(&account).write(balance)
+        self.b20.balances.at_mut(&account).write(balance)
     }
 
     fn allowance(&self, owner: Address, spender: Address) -> Result<U256> {
-        self.allowances.at(&owner).at(&spender).read()
+        self.b20.allowances.at(&owner).at(&spender).read()
     }
 
     fn set_allowance(&mut self, owner: Address, spender: Address, amount: U256) -> Result<()> {
-        self.allowances.at_mut(&owner).at_mut(&spender).write(amount)
+        self.b20.allowances.at_mut(&owner).at_mut(&spender).write(amount)
     }
 
     fn total_supply(&self) -> Result<U256> {
-        self.total_supply.read()
+        self.b20.total_supply.read()
     }
 
     fn set_total_supply(&mut self, supply: U256) -> Result<()> {
-        self.total_supply.write(supply)
+        self.b20.total_supply.write(supply)
     }
 
     fn supply_cap(&self) -> Result<U256> {
-        self.supply_cap.read()
+        self.b20.supply_cap.read()
     }
 
     fn set_supply_cap(&mut self, cap: U256) -> Result<()> {
-        self.supply_cap.write(cap)
+        self.b20.supply_cap.write(cap)
     }
 
     fn name(&self) -> Result<String> {
-        self.name.read()
+        self.b20.name.read()
     }
 
     fn set_name(&mut self, name: String) -> Result<()> {
-        self.name.write(name)
+        self.b20.name.write(name)
     }
 
     fn symbol(&self) -> Result<String> {
-        self.symbol.read()
+        self.b20.symbol.read()
     }
 
     fn set_symbol(&mut self, symbol: String) -> Result<()> {
-        self.symbol.write(symbol)
+        self.b20.symbol.write(symbol)
     }
 
     fn decimals(&self) -> Result<u8> {
-        Ok(TokenVariant::from_address(self.address).map_or(0, TokenVariant::decimals))
+        Ok(TokenVariant::from_address(ContractStorage::address(self))
+            .map_or(0, TokenVariant::decimals))
     }
 
     fn currency(&self) -> Result<String> {
-        self.stablecoin_currency.read()
+        Ok(String::new())
     }
 
     fn security_identifier(&self, identifier_type: &str) -> Result<String> {
-        let key = alloy_primitives::keccak256(identifier_type.as_bytes());
-        self.security_identifiers.at(&key).read()
+        self.security.identifiers.at(&identifier_type.to_owned()).read()
     }
 
     fn paused(&self) -> Result<U256> {
-        self.paused.read()
+        self.b20.paused.read()
     }
 
     fn set_paused(&mut self, vectors: U256) -> Result<()> {
-        self.paused.write(vectors)
+        self.b20.paused.write(vectors)
     }
 
     fn nonce(&self, owner: Address) -> Result<U256> {
-        self.nonces.at(&owner).read()
+        self.b20.nonces.at(&owner).read()
     }
 
     fn increment_nonce(&mut self, owner: Address) -> Result<()> {
-        let current = self.nonces.at(&owner).read()?;
+        let current = self.b20.nonces.at(&owner).read()?;
         let next =
             current.checked_add(U256::ONE).ok_or_else(BasePrecompileError::under_overflow)?;
-        self.nonces.at_mut(&owner).write(next)
+        self.b20.nonces.at_mut(&owner).write(next)
     }
 
     fn minimum_redeemable(&self) -> Result<U256> {
-        self.minimum_redeemable.read()
+        self.redeem.minimum_redeemable.read()
     }
 
     fn set_minimum_redeemable(&mut self, minimum: U256) -> Result<()> {
-        self.minimum_redeemable.write(minimum)
+        self.redeem.minimum_redeemable.write(minimum)
     }
 
     fn contract_uri(&self) -> Result<String> {
-        self.contract_uri.read()
+        self.b20.contract_uri.read()
     }
 
     fn set_contract_uri(&mut self, uri: String) -> Result<()> {
-        self.contract_uri.write(uri)
+        self.b20.contract_uri.write(uri)
     }
 
     fn has_role(&self, role: B256, account: Address) -> Result<bool> {
-        self.roles.at(&role).at(&account).read()
+        self.b20.roles.at(&role).at(&account).read()
     }
 
     fn set_role(&mut self, role: B256, account: Address, enabled: bool) -> Result<()> {
-        self.roles.at_mut(&role).at_mut(&account).write(enabled)
+        self.b20.roles.at_mut(&role).at_mut(&account).write(enabled)
     }
 
     fn role_member_count(&self, role: B256) -> Result<U256> {
-        self.role_member_counts.at(&role).read()
+        if role == B20TokenRole::DefaultAdmin.id() {
+            Ok(Self::read_admin_count(self.b20.admin_count_and_initialized.read()?))
+        } else {
+            Ok(U256::ZERO)
+        }
     }
 
     fn set_role_member_count(&mut self, role: B256, count: U256) -> Result<()> {
-        self.role_member_counts.at_mut(&role).write(count)
+        if role == B20TokenRole::DefaultAdmin.id() {
+            let packed = self.b20.admin_count_and_initialized.read()?;
+            self.b20.admin_count_and_initialized.write(Self::write_admin_count(packed, count)?)
+        } else {
+            Ok(())
+        }
     }
 
     fn role_admin(&self, role: B256) -> Result<B256> {
-        self.role_admins.at(&role).read()
+        let admin_role = self.b20.role_admins.at(&role).read()?;
+        if admin_role.is_zero() && role != B20TokenRole::DefaultAdmin.id() {
+            Ok(B20TokenRole::DefaultAdmin.id())
+        } else {
+            Ok(admin_role)
+        }
     }
 
     fn set_role_admin(&mut self, role: B256, admin_role: B256) -> Result<()> {
-        self.role_admins.at_mut(&role).write(admin_role)
+        self.b20.role_admins.at_mut(&role).write(admin_role)
     }
 
     fn policy_id(&self, policy_type: B256) -> Result<u64> {
         let policy_type = Self::require_policy_type(policy_type)?;
         match policy_type {
             B20PolicyType::TransferSender => Ok(Self::read_policy_lane(
-                self.transfer_policy_ids.read()?,
+                self.b20.transfer_policy_ids.read()?,
                 Self::TRANSFER_SENDER_POLICY_LANE,
             )),
             B20PolicyType::TransferReceiver => Ok(Self::read_policy_lane(
-                self.transfer_policy_ids.read()?,
+                self.b20.transfer_policy_ids.read()?,
                 Self::TRANSFER_RECEIVER_POLICY_LANE,
             )),
             B20PolicyType::TransferExecutor => Ok(Self::read_policy_lane(
-                self.transfer_policy_ids.read()?,
+                self.b20.transfer_policy_ids.read()?,
                 Self::TRANSFER_EXECUTOR_POLICY_LANE,
             )),
             B20PolicyType::MintReceiver => Ok(Self::read_policy_lane(
-                self.mint_policy_ids.read()?,
+                self.b20.mint_policy_ids.read()?,
                 Self::MINT_RECEIVER_POLICY_LANE,
             )),
         }
@@ -228,35 +242,35 @@ impl TokenAccounting for B20SecurityStorage<'_> {
         match policy_type {
             B20PolicyType::TransferSender => {
                 let packed = Self::write_policy_lane(
-                    self.transfer_policy_ids.read()?,
+                    self.b20.transfer_policy_ids.read()?,
                     Self::TRANSFER_SENDER_POLICY_LANE,
                     policy_id,
                 );
-                self.transfer_policy_ids.write(packed)
+                self.b20.transfer_policy_ids.write(packed)
             }
             B20PolicyType::TransferReceiver => {
                 let packed = Self::write_policy_lane(
-                    self.transfer_policy_ids.read()?,
+                    self.b20.transfer_policy_ids.read()?,
                     Self::TRANSFER_RECEIVER_POLICY_LANE,
                     policy_id,
                 );
-                self.transfer_policy_ids.write(packed)
+                self.b20.transfer_policy_ids.write(packed)
             }
             B20PolicyType::TransferExecutor => {
                 let packed = Self::write_policy_lane(
-                    self.transfer_policy_ids.read()?,
+                    self.b20.transfer_policy_ids.read()?,
                     Self::TRANSFER_EXECUTOR_POLICY_LANE,
                     policy_id,
                 );
-                self.transfer_policy_ids.write(packed)
+                self.b20.transfer_policy_ids.write(packed)
             }
             B20PolicyType::MintReceiver => {
                 let packed = Self::write_policy_lane(
-                    self.mint_policy_ids.read()?,
+                    self.b20.mint_policy_ids.read()?,
                     Self::MINT_RECEIVER_POLICY_LANE,
                     policy_id,
                 );
-                self.mint_policy_ids.write(packed)
+                self.b20.mint_policy_ids.write(packed)
             }
         }
     }
@@ -267,11 +281,28 @@ impl TokenAccounting for B20SecurityStorage<'_> {
 }
 
 impl B20SecurityStorage<'_> {
+    const ADMIN_COUNT_BITS: usize = 248;
     const TRANSFER_SENDER_POLICY_LANE: usize = 0;
     const TRANSFER_RECEIVER_POLICY_LANE: usize = 1;
     const TRANSFER_EXECUTOR_POLICY_LANE: usize = 2;
     const MINT_RECEIVER_POLICY_LANE: usize = 0;
     const POLICY_LANE_BITS: usize = 64;
+
+    fn admin_count_mask() -> U256 {
+        (U256::ONE << Self::ADMIN_COUNT_BITS) - U256::ONE
+    }
+
+    fn read_admin_count(packed: U256) -> U256 {
+        packed & Self::admin_count_mask()
+    }
+
+    fn write_admin_count(packed: U256, count: U256) -> Result<U256> {
+        let mask = Self::admin_count_mask();
+        if count > mask {
+            return Err(BasePrecompileError::under_overflow());
+        }
+        Ok((packed & !mask) | count)
+    }
 
     fn require_policy_type(policy_type: B256) -> Result<B20PolicyType> {
         B20PolicyType::from_id(policy_type).ok_or_else(|| {
@@ -292,11 +323,11 @@ impl B20SecurityStorage<'_> {
 
 impl SecurityAccounting for B20SecurityStorage<'_> {
     fn shares_to_tokens_ratio(&self) -> Result<U256> {
-        self.shares_to_tokens_ratio.read()
+        self.security.shares_to_tokens_ratio.read()
     }
 
     fn set_shares_to_tokens_ratio(&mut self, ratio: U256) -> Result<()> {
-        self.shares_to_tokens_ratio.write(ratio)
+        self.security.shares_to_tokens_ratio.write(ratio)
     }
 
     fn set_security_identifier_value(
@@ -304,19 +335,122 @@ impl SecurityAccounting for B20SecurityStorage<'_> {
         identifier_type: &str,
         value: String,
     ) -> Result<()> {
-        let key = alloy_primitives::keccak256(identifier_type.as_bytes());
+        let key = identifier_type.to_owned();
         if value.is_empty() {
-            self.security_identifiers.at_mut(&key).delete()
+            self.security.identifiers.at_mut(&key).delete()
         } else {
-            self.security_identifiers.at_mut(&key).write(value)
+            self.security.identifiers.at_mut(&key).write(value)
         }
     }
 
-    fn is_announcement_id_used(&self, id_hash: B256) -> Result<bool> {
-        self.announcement_ids_used.at(&id_hash).read()
+    fn is_announcement_id_used(&self, id: &str) -> Result<bool> {
+        self.security.used_announcement_ids.at(&id.to_owned()).read()
     }
 
-    fn mark_announcement_id_used(&mut self, id_hash: B256) -> Result<()> {
-        self.announcement_ids_used.at_mut(&id_hash).write(true)
+    fn mark_announcement_id_used(&mut self, id: &str) -> Result<()> {
+        self.security.used_announcement_ids.at_mut(&id.to_owned()).write(true)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_primitives::{Address, U256, address, uint};
+    use base_precompile_storage::{Handler, StorableType, StorageCtx, StorageKey, setup_storage};
+
+    use super::{
+        __packing_b20_redeem_storage, __packing_b20_security_extension_storage, B20RedeemStorage,
+        B20SecurityExtensionStorage, B20SecurityStorage, slots,
+    };
+    use crate::B20CoreStorage;
+
+    const TOKEN: Address = address!("000000000000000000000000000000000000b021");
+    const B20_ROOT: U256 =
+        uint!(0xc78b71fee795ddd74aff64ea9b2474194c938c3196430e10bb5f01ed48434000_U256);
+    const SECURITY_ROOT: U256 =
+        uint!(0x4a21e1b7f963e21baf0daffe6bab858a1e5fecef1144f3aca3c0c4534c7ac600_U256);
+    const REDEEM_ROOT: U256 =
+        uint!(0xc95c24ab0255f9fb9fcdcd524f71c4fe0437265856b7e5e6d0801df0e6cf5100_U256);
+
+    #[test]
+    fn security_namespaces_match_base_std_roots() {
+        assert_eq!(<B20CoreStorage as StorableType>::STORAGE_NAMESPACE_ROOT, B20_ROOT);
+        assert_eq!(
+            <B20SecurityExtensionStorage as StorableType>::STORAGE_NAMESPACE_ID,
+            "base.b20.security"
+        );
+        assert_eq!(
+            <B20SecurityExtensionStorage as StorableType>::STORAGE_NAMESPACE_ROOT,
+            SECURITY_ROOT
+        );
+        assert_eq!(<B20RedeemStorage as StorableType>::STORAGE_NAMESPACE_ID, "base.b20.redeem");
+        assert_eq!(<B20RedeemStorage as StorableType>::STORAGE_NAMESPACE_ROOT, REDEEM_ROOT);
+
+        assert_eq!(slots::B20, B20_ROOT);
+        assert_eq!(slots::SECURITY, SECURITY_ROOT);
+        assert_eq!(slots::REDEEM, REDEEM_ROOT);
+    }
+
+    #[test]
+    fn security_extension_offsets_match_mock_storage() {
+        assert_eq!(
+            __packing_b20_security_extension_storage::SHARES_TO_TOKENS_RATIO_LOC.offset_slots,
+            0
+        );
+        assert_eq!(
+            __packing_b20_security_extension_storage::USED_ANNOUNCEMENT_IDS_LOC.offset_slots,
+            1
+        );
+        assert_eq!(__packing_b20_security_extension_storage::IDENTIFIERS_LOC.offset_slots, 2);
+        assert_eq!(__packing_b20_redeem_storage::MINIMUM_REDEEMABLE_LOC.offset_slots, 0);
+        assert_eq!(__packing_b20_redeem_storage::REDEEM_POLICY_IDS_LOC.offset_slots, 1);
+    }
+
+    #[test]
+    fn security_string_mapping_slots_use_solidity_string_key_derivation() {
+        let (mut storage, _) = setup_storage();
+        let announcement_id = String::from("2026-Q1-split");
+        let identifier_type = String::from("ISIN");
+        let identifier_value = String::from("US0000000000");
+
+        StorageCtx::enter(&mut storage, |ctx| {
+            let mut token = B20SecurityStorage::from_address(TOKEN, ctx);
+            token.security.used_announcement_ids.at_mut(&announcement_id).write(true).unwrap();
+            token
+                .security
+                .identifiers
+                .at_mut(&identifier_type)
+                .write(identifier_value.clone())
+                .unwrap();
+            token.redeem.minimum_redeemable.write(U256::from(10u64)).unwrap();
+
+            let announcement_slot = SECURITY_ROOT
+                + U256::from(
+                    __packing_b20_security_extension_storage::USED_ANNOUNCEMENT_IDS_LOC
+                        .offset_slots,
+                );
+            let identifiers_slot = SECURITY_ROOT
+                + U256::from(
+                    __packing_b20_security_extension_storage::IDENTIFIERS_LOC.offset_slots,
+                );
+            let minimum_slot = REDEEM_ROOT
+                + U256::from(__packing_b20_redeem_storage::MINIMUM_REDEEMABLE_LOC.offset_slots);
+
+            assert_eq!(
+                ctx.sload(TOKEN, announcement_id.mapping_slot(announcement_slot)).unwrap(),
+                U256::ONE
+            );
+            assert_eq!(
+                ctx.sload(TOKEN, identifier_type.mapping_slot(identifiers_slot)).unwrap(),
+                short_string_word(&identifier_value)
+            );
+            assert_eq!(ctx.sload(TOKEN, minimum_slot).unwrap(), U256::from(10u64));
+        });
+    }
+
+    fn short_string_word(value: &str) -> U256 {
+        let mut word = [0u8; 32];
+        word[..value.len()].copy_from_slice(value.as_bytes());
+        word[31] = (value.len() * 2) as u8;
+        U256::from_be_bytes(word)
     }
 }

--- a/crates/common/precompiles/src/b20_security/storage.rs
+++ b/crates/common/precompiles/src/b20_security/storage.rs
@@ -139,7 +139,7 @@ impl TokenAccounting for B20SecurityStorage<'_> {
     }
 
     fn security_identifier(&self, identifier_type: &str) -> Result<String> {
-        self.security.identifiers.at(&identifier_type.to_owned()).read()
+        self.security.identifiers.at(&String::from(identifier_type)).read()
     }
 
     fn paused(&self) -> Result<U256> {
@@ -335,7 +335,7 @@ impl SecurityAccounting for B20SecurityStorage<'_> {
         identifier_type: &str,
         value: String,
     ) -> Result<()> {
-        let key = identifier_type.to_owned();
+        let key = String::from(identifier_type);
         if value.is_empty() {
             self.security.identifiers.at_mut(&key).delete()
         } else {
@@ -344,11 +344,11 @@ impl SecurityAccounting for B20SecurityStorage<'_> {
     }
 
     fn is_announcement_id_used(&self, id: &str) -> Result<bool> {
-        self.security.used_announcement_ids.at(&id.to_owned()).read()
+        self.security.used_announcement_ids.at(&String::from(id)).read()
     }
 
     fn mark_announcement_id_used(&mut self, id: &str) -> Result<()> {
-        self.security.used_announcement_ids.at_mut(&id.to_owned()).write(true)
+        self.security.used_announcement_ids.at_mut(&String::from(id)).write(true)
     }
 }
 

--- a/crates/common/precompiles/src/b20_security/storage.rs
+++ b/crates/common/precompiles/src/b20_security/storage.rs
@@ -134,14 +134,6 @@ impl TokenAccounting for B20SecurityStorage<'_> {
             .map_or(0, TokenVariant::decimals))
     }
 
-    fn currency(&self) -> Result<String> {
-        Ok(String::new())
-    }
-
-    fn security_identifier(&self, identifier_type: &str) -> Result<String> {
-        self.security.identifiers.at(&String::from(identifier_type)).read()
-    }
-
     fn paused(&self) -> Result<U256> {
         self.b20.paused.read()
     }
@@ -159,14 +151,6 @@ impl TokenAccounting for B20SecurityStorage<'_> {
         let next =
             current.checked_add(U256::ONE).ok_or_else(BasePrecompileError::under_overflow)?;
         self.b20.nonces.at_mut(&owner).write(next)
-    }
-
-    fn minimum_redeemable(&self) -> Result<U256> {
-        self.redeem.minimum_redeemable.read()
-    }
-
-    fn set_minimum_redeemable(&mut self, minimum: U256) -> Result<()> {
-        self.redeem.minimum_redeemable.write(minimum)
     }
 
     fn contract_uri(&self) -> Result<String> {
@@ -330,6 +314,10 @@ impl SecurityAccounting for B20SecurityStorage<'_> {
         self.security.shares_to_tokens_ratio.write(ratio)
     }
 
+    fn security_identifier(&self, identifier_type: &str) -> Result<String> {
+        self.security.identifiers.at(&String::from(identifier_type)).read()
+    }
+
     fn set_security_identifier_value(
         &mut self,
         identifier_type: &str,
@@ -341,6 +329,14 @@ impl SecurityAccounting for B20SecurityStorage<'_> {
         } else {
             self.security.identifiers.at_mut(&key).write(value)
         }
+    }
+
+    fn minimum_redeemable(&self) -> Result<U256> {
+        self.redeem.minimum_redeemable.read()
+    }
+
+    fn set_minimum_redeemable(&mut self, minimum: U256) -> Result<()> {
+        self.redeem.minimum_redeemable.write(minimum)
     }
 
     fn is_announcement_id_used(&self, id: &str) -> Result<bool> {

--- a/crates/common/precompiles/src/b20_stablecoin/accounting.rs
+++ b/crates/common/precompiles/src/b20_stablecoin/accounting.rs
@@ -11,6 +11,9 @@ use crate::TokenAccounting;
 /// Only [`super::B20StablecoinToken`] requires this bound; default and security
 /// tokens use the base [`TokenAccounting`] port exclusively.
 pub trait StablecoinAccounting: TokenAccounting {
+    /// Returns the stablecoin currency identifier.
+    fn currency(&self) -> Result<String>;
+
     /// Writes the currency identifier. Called once by the factory at creation.
     fn set_currency(&mut self, currency: String) -> Result<()>;
 }

--- a/crates/common/precompiles/src/b20_stablecoin/dispatch.rs
+++ b/crates/common/precompiles/src/b20_stablecoin/dispatch.rs
@@ -3,14 +3,18 @@
 //! Dispatches the full `IB20` selector set using B-20 stablecoin activation.
 //! All logic mirrors `B20Token::inner_with_privilege` exactly; the only
 //! distinction is the activation guard and the `StablecoinAccounting` bound
-//! that provides `currency()` from EVM slot 11.
+//! that provides `currency()` from the stablecoin extension namespace.
 
 use alloy_primitives::{Bytes, U256};
-use alloy_sol_types::SolValue;
+use alloy_sol_types::{SolInterface, SolValue};
 use base_precompile_storage::{BasePrecompileError, IntoPrecompileResult, StorageCtx};
 use revm::precompile::PrecompileResult;
 
-use super::{B20StablecoinToken, accounting::StablecoinAccounting};
+use super::{
+    B20StablecoinToken,
+    abi::{IB20Stablecoin, IB20Stablecoin::IB20StablecoinCalls as SC},
+    accounting::StablecoinAccounting,
+};
 use crate::{
     ActivationFeature, ActivationRegistryStorage, B20TokenRole, Burnable, Configurable,
     IB20::{self, IB20Calls as C},
@@ -53,6 +57,10 @@ impl<S: StablecoinAccounting, P: Policy> B20StablecoinToken<S, P> {
         ActivationRegistryStorage::new(ctx)
             .ensure_activated(ActivationFeature::B20Stablecoin.id())?;
 
+        if let Ok(call) = IB20Stablecoin::IB20StablecoinCalls::abi_decode(calldata) {
+            return self.handle_stablecoin_call(call);
+        }
+
         let call = decode_precompile_call!(calldata, IB20::IB20Calls);
 
         let encoded: Bytes = match call {
@@ -61,11 +69,6 @@ impl<S: StablecoinAccounting, P: Policy> B20StablecoinToken<S, P> {
             C::symbol(_) => self.accounting.symbol()?.abi_encode().into(),
             C::decimals(_) => U256::from(self.accounting.decimals()?).abi_encode().into(),
             C::totalSupply(_) => self.accounting.total_supply()?.abi_encode().into(),
-            C::minimumRedeemable(_) => self.accounting.minimum_redeemable()?.abi_encode().into(),
-            C::currency(_) => self.accounting.currency()?.abi_encode().into(),
-            C::securityIdentifier(c) => {
-                self.accounting.security_identifier(&c.identifierType)?.abi_encode().into()
-            }
             C::balanceOf(c) => self.accounting.balance_of(c.account)?.abi_encode().into(),
             C::allowance(c) => self.accounting.allowance(c.owner, c.spender)?.abi_encode().into(),
             C::supplyCap(_) => self.accounting.supply_cap()?.abi_encode().into(),
@@ -231,6 +234,13 @@ impl<S: StablecoinAccounting, P: Policy> B20StablecoinToken<S, P> {
                 )?;
                 Bytes::new()
             }
+        };
+        Ok(encoded)
+    }
+
+    fn handle_stablecoin_call(&self, call: SC) -> base_precompile_storage::Result<Bytes> {
+        let encoded: Bytes = match call {
+            SC::currency(_) => self.accounting.currency()?.abi_encode().into(),
         };
         Ok(encoded)
     }

--- a/crates/common/precompiles/src/b20_stablecoin/dispatch.rs
+++ b/crates/common/precompiles/src/b20_stablecoin/dispatch.rs
@@ -1,6 +1,6 @@
 //! ABI dispatch for the stablecoin B-20 variant.
 //!
-//! Dispatches the full `IB20` selector set using `B20_STABLECOIN` activation.
+//! Dispatches the full `IB20` selector set using B-20 stablecoin activation.
 //! All logic mirrors `B20Token::inner_with_privilege` exactly; the only
 //! distinction is the activation guard and the `StablecoinAccounting` bound
 //! that provides `currency()` from EVM slot 11.
@@ -12,7 +12,7 @@ use revm::precompile::PrecompileResult;
 
 use super::{B20StablecoinToken, accounting::StablecoinAccounting};
 use crate::{
-    ActivationRegistryStorage, B20TokenRole, Burnable, Configurable,
+    ActivationFeature, ActivationRegistryStorage, B20TokenRole, Burnable, Configurable,
     IB20::{self, IB20Calls as C},
     Mintable, Pausable, Permittable, Policy, RoleManaged, Transferable,
     macros::{decode_precompile_call, deduct_calldata_cost},
@@ -51,7 +51,7 @@ impl<S: StablecoinAccounting, P: Policy> B20StablecoinToken<S, P> {
         privileged: bool,
     ) -> base_precompile_storage::Result<Bytes> {
         ActivationRegistryStorage::new(ctx)
-            .ensure_activated(ActivationRegistryStorage::B20_STABLECOIN)?;
+            .ensure_activated(ActivationFeature::B20Stablecoin.id())?;
 
         let call = decode_precompile_call!(calldata, IB20::IB20Calls);
 

--- a/crates/common/precompiles/src/b20_stablecoin/mod.rs
+++ b/crates/common/precompiles/src/b20_stablecoin/mod.rs
@@ -12,7 +12,7 @@ mod precompile;
 pub use precompile::B20StablecoinPrecompile;
 
 mod storage;
-pub use storage::B20StablecoinStorage;
+pub use storage::{B20StablecoinExtensionStorage, B20StablecoinStorage};
 
 mod token;
 pub use token::B20StablecoinToken;

--- a/crates/common/precompiles/src/b20_stablecoin/storage.rs
+++ b/crates/common/precompiles/src/b20_stablecoin/storage.rs
@@ -118,14 +118,6 @@ impl TokenAccounting for B20StablecoinStorage<'_> {
             .map_or(0, TokenVariant::decimals))
     }
 
-    fn currency(&self) -> Result<String> {
-        self.stablecoin.currency.read()
-    }
-
-    fn security_identifier(&self, _identifier_type: &str) -> Result<String> {
-        Ok(String::new())
-    }
-
     fn paused(&self) -> Result<U256> {
         self.b20.paused.read()
     }
@@ -143,14 +135,6 @@ impl TokenAccounting for B20StablecoinStorage<'_> {
         let next =
             current.checked_add(U256::ONE).ok_or_else(BasePrecompileError::under_overflow)?;
         self.b20.nonces.at_mut(&owner).write(next)
-    }
-
-    fn minimum_redeemable(&self) -> Result<U256> {
-        Ok(U256::ZERO)
-    }
-
-    fn set_minimum_redeemable(&mut self, _minimum: U256) -> Result<()> {
-        Ok(())
     }
 
     fn contract_uri(&self) -> Result<String> {
@@ -306,6 +290,10 @@ impl B20StablecoinStorage<'_> {
 }
 
 impl StablecoinAccounting for B20StablecoinStorage<'_> {
+    fn currency(&self) -> Result<String> {
+        self.stablecoin.currency.read()
+    }
+
     fn set_currency(&mut self, currency: String) -> Result<()> {
         self.stablecoin.currency.write(currency)
     }

--- a/crates/common/precompiles/src/b20_stablecoin/storage.rs
+++ b/crates/common/precompiles/src/b20_stablecoin/storage.rs
@@ -3,37 +3,29 @@
 use alloc::string::String;
 
 use alloy_primitives::{Address, B256, LogData, U256};
-use base_precompile_macros::contract;
-use base_precompile_storage::{
-    BasePrecompileError, ContractStorage, Handler, Mapping, Result, StorageCtx,
-};
+use base_precompile_macros::{Storable, contract};
+use base_precompile_storage::{BasePrecompileError, ContractStorage, Handler, Result, StorageCtx};
 #[cfg(feature = "std")]
 use iso_currency::Currency;
 
 #[cfg(feature = "std")]
 use super::IB20Stablecoin;
 use super::accounting::StablecoinAccounting;
-use crate::{TokenAccounting, TokenVariant};
+use crate::{B20CoreStorage, B20PolicyType, B20TokenRole, IB20, TokenAccounting, TokenVariant};
+
+/// Stablecoin-specific B-20 storage rooted at the `base.b20.stablecoin` ERC-7201 namespace.
+#[derive(Debug, Clone, Storable)]
+#[namespace("base.b20.stablecoin")]
+pub struct B20StablecoinExtensionStorage {
+    /// Stablecoin currency identifier.
+    pub currency: String, // offset 0
+}
 
 /// EVM-backed storage for a stablecoin B-20 token.
-///
-/// Slots 0–10 mirror [`crate::B20TokenStorage`] exactly so that the factory can
-/// initialize common fields through either storage type. Slot 11 holds the
-/// immutable `currency` identifier written once at creation.
 #[contract]
 pub struct B20StablecoinStorage {
-    pub total_supply: U256,                                   // slot 0
-    pub supply_cap: U256,                                     // slot 1
-    pub balances: Mapping<Address, U256>,                     // slot 2
-    pub allowances: Mapping<Address, Mapping<Address, U256>>, // slot 3
-    pub paused: U256,                                         // slot 4
-    pub nonces: Mapping<Address, U256>,                       // slot 5
-    pub name: String,                                         // slot 6
-    pub symbol: String,                                       // slot 7
-    pub minimum_redeemable: U256,                             // slot 8
-    pub contract_uri: String,                                 // slot 9
-    pub capabilities: U256,                                   // slot 10
-    pub currency: String,                                     // slot 11
+    pub b20: B20CoreStorage,
+    pub stablecoin: B20StablecoinExtensionStorage,
 }
 
 impl<'a> B20StablecoinStorage<'a> {
@@ -51,18 +43,16 @@ impl<'a> B20StablecoinStorage<'a> {
         name: String,
         symbol: String,
         supply_cap: U256,
-        capabilities: U256,
         currency: String,
     ) -> Result<()> {
         #[cfg(feature = "std")]
         if Currency::from_code(&currency).is_none() {
             return Err(BasePrecompileError::revert(IB20Stablecoin::InvalidCurrency {}));
         }
-        self.name.write(name)?;
-        self.symbol.write(symbol)?;
-        self.supply_cap.write(supply_cap)?;
-        self.capabilities.write(capabilities)?;
-        self.currency.write(currency)
+        self.b20.name.write(name)?;
+        self.b20.symbol.write(symbol)?;
+        self.b20.supply_cap.write(supply_cap)?;
+        self.stablecoin.currency.write(currency)
     }
 }
 
@@ -76,130 +66,197 @@ impl TokenAccounting for B20StablecoinStorage<'_> {
     }
 
     fn balance_of(&self, account: Address) -> Result<U256> {
-        self.balances.at(&account).read()
+        self.b20.balances.at(&account).read()
     }
 
     fn set_balance(&mut self, account: Address, balance: U256) -> Result<()> {
-        self.balances.at_mut(&account).write(balance)
+        self.b20.balances.at_mut(&account).write(balance)
     }
 
     fn allowance(&self, owner: Address, spender: Address) -> Result<U256> {
-        self.allowances.at(&owner).at(&spender).read()
+        self.b20.allowances.at(&owner).at(&spender).read()
     }
 
     fn set_allowance(&mut self, owner: Address, spender: Address, amount: U256) -> Result<()> {
-        self.allowances.at_mut(&owner).at_mut(&spender).write(amount)
+        self.b20.allowances.at_mut(&owner).at_mut(&spender).write(amount)
     }
 
     fn total_supply(&self) -> Result<U256> {
-        self.total_supply.read()
+        self.b20.total_supply.read()
     }
 
     fn set_total_supply(&mut self, supply: U256) -> Result<()> {
-        self.total_supply.write(supply)
+        self.b20.total_supply.write(supply)
     }
 
     fn supply_cap(&self) -> Result<U256> {
-        self.supply_cap.read()
+        self.b20.supply_cap.read()
     }
 
     fn set_supply_cap(&mut self, cap: U256) -> Result<()> {
-        self.supply_cap.write(cap)
+        self.b20.supply_cap.write(cap)
     }
 
     fn name(&self) -> Result<String> {
-        self.name.read()
+        self.b20.name.read()
     }
 
     fn set_name(&mut self, name: String) -> Result<()> {
-        self.name.write(name)
+        self.b20.name.write(name)
     }
 
     fn symbol(&self) -> Result<String> {
-        self.symbol.read()
+        self.b20.symbol.read()
     }
 
     fn set_symbol(&mut self, symbol: String) -> Result<()> {
-        self.symbol.write(symbol)
+        self.b20.symbol.write(symbol)
     }
 
     fn decimals(&self) -> Result<u8> {
-        Ok(TokenVariant::decimals_of(self.address).unwrap_or(0))
-    }
-
-    fn paused(&self) -> Result<U256> {
-        self.paused.read()
-    }
-
-    fn set_paused(&mut self, vectors: U256) -> Result<()> {
-        self.paused.write(vectors)
-    }
-
-    fn nonce(&self, owner: Address) -> Result<U256> {
-        self.nonces.at(&owner).read()
-    }
-
-    fn increment_nonce(&mut self, owner: Address) -> Result<()> {
-        let current = self.nonces.at(&owner).read()?;
-        let next =
-            current.checked_add(U256::ONE).ok_or_else(BasePrecompileError::under_overflow)?;
-        self.nonces.at_mut(&owner).write(next)
-    }
-
-    fn minimum_redeemable(&self) -> Result<U256> {
-        self.minimum_redeemable.read()
-    }
-
-    fn set_minimum_redeemable(&mut self, minimum: U256) -> Result<()> {
-        self.minimum_redeemable.write(minimum)
-    }
-
-    fn contract_uri(&self) -> Result<String> {
-        self.contract_uri.read()
-    }
-
-    fn set_contract_uri(&mut self, uri: String) -> Result<()> {
-        self.contract_uri.write(uri)
+        Ok(TokenVariant::from_address(ContractStorage::address(self))
+            .map_or(0, TokenVariant::decimals))
     }
 
     fn currency(&self) -> Result<String> {
-        self.currency.read()
+        self.stablecoin.currency.read()
     }
 
     fn security_identifier(&self, _identifier_type: &str) -> Result<String> {
         Ok(String::new())
     }
 
-    fn has_role(&self, _role: B256, _account: Address) -> Result<bool> {
-        Ok(false)
+    fn paused(&self) -> Result<U256> {
+        self.b20.paused.read()
     }
 
-    fn set_role(&mut self, _role: B256, _account: Address, _enabled: bool) -> Result<()> {
-        Ok(())
+    fn set_paused(&mut self, vectors: U256) -> Result<()> {
+        self.b20.paused.write(vectors)
     }
 
-    fn role_member_count(&self, _role: B256) -> Result<U256> {
+    fn nonce(&self, owner: Address) -> Result<U256> {
+        self.b20.nonces.at(&owner).read()
+    }
+
+    fn increment_nonce(&mut self, owner: Address) -> Result<()> {
+        let current = self.b20.nonces.at(&owner).read()?;
+        let next =
+            current.checked_add(U256::ONE).ok_or_else(BasePrecompileError::under_overflow)?;
+        self.b20.nonces.at_mut(&owner).write(next)
+    }
+
+    fn minimum_redeemable(&self) -> Result<U256> {
         Ok(U256::ZERO)
     }
 
-    fn set_role_member_count(&mut self, _role: B256, _count: U256) -> Result<()> {
+    fn set_minimum_redeemable(&mut self, _minimum: U256) -> Result<()> {
         Ok(())
     }
 
-    fn role_admin(&self, _role: B256) -> Result<B256> {
-        Ok(B256::ZERO)
+    fn contract_uri(&self) -> Result<String> {
+        self.b20.contract_uri.read()
     }
 
-    fn set_role_admin(&mut self, _role: B256, _admin_role: B256) -> Result<()> {
-        Ok(())
+    fn set_contract_uri(&mut self, uri: String) -> Result<()> {
+        self.b20.contract_uri.write(uri)
     }
 
-    fn policy_id(&self, _policy_type: B256) -> Result<u64> {
-        Ok(0)
+    fn has_role(&self, role: B256, account: Address) -> Result<bool> {
+        self.b20.roles.at(&role).at(&account).read()
     }
 
-    fn set_policy_id(&mut self, _policy_type: B256, _policy_id: u64) -> Result<()> {
-        Ok(())
+    fn set_role(&mut self, role: B256, account: Address, enabled: bool) -> Result<()> {
+        self.b20.roles.at_mut(&role).at_mut(&account).write(enabled)
+    }
+
+    fn role_member_count(&self, role: B256) -> Result<U256> {
+        if role == B20TokenRole::DefaultAdmin.id() {
+            Ok(Self::read_admin_count(self.b20.admin_count_and_initialized.read()?))
+        } else {
+            Ok(U256::ZERO)
+        }
+    }
+
+    fn set_role_member_count(&mut self, role: B256, count: U256) -> Result<()> {
+        if role == B20TokenRole::DefaultAdmin.id() {
+            let packed = self.b20.admin_count_and_initialized.read()?;
+            self.b20.admin_count_and_initialized.write(Self::write_admin_count(packed, count)?)
+        } else {
+            Ok(())
+        }
+    }
+
+    fn role_admin(&self, role: B256) -> Result<B256> {
+        let admin_role = self.b20.role_admins.at(&role).read()?;
+        if admin_role.is_zero() && role != B20TokenRole::DefaultAdmin.id() {
+            Ok(B20TokenRole::DefaultAdmin.id())
+        } else {
+            Ok(admin_role)
+        }
+    }
+
+    fn set_role_admin(&mut self, role: B256, admin_role: B256) -> Result<()> {
+        self.b20.role_admins.at_mut(&role).write(admin_role)
+    }
+
+    fn policy_id(&self, policy_type: B256) -> Result<u64> {
+        let policy_type = Self::require_policy_type(policy_type)?;
+        match policy_type {
+            B20PolicyType::TransferSender => Ok(Self::read_policy_lane(
+                self.b20.transfer_policy_ids.read()?,
+                Self::TRANSFER_SENDER_POLICY_LANE,
+            )),
+            B20PolicyType::TransferReceiver => Ok(Self::read_policy_lane(
+                self.b20.transfer_policy_ids.read()?,
+                Self::TRANSFER_RECEIVER_POLICY_LANE,
+            )),
+            B20PolicyType::TransferExecutor => Ok(Self::read_policy_lane(
+                self.b20.transfer_policy_ids.read()?,
+                Self::TRANSFER_EXECUTOR_POLICY_LANE,
+            )),
+            B20PolicyType::MintReceiver => Ok(Self::read_policy_lane(
+                self.b20.mint_policy_ids.read()?,
+                Self::MINT_RECEIVER_POLICY_LANE,
+            )),
+        }
+    }
+
+    fn set_policy_id(&mut self, policy_type: B256, policy_id: u64) -> Result<()> {
+        let policy_type = Self::require_policy_type(policy_type)?;
+        match policy_type {
+            B20PolicyType::TransferSender => {
+                let packed = Self::write_policy_lane(
+                    self.b20.transfer_policy_ids.read()?,
+                    Self::TRANSFER_SENDER_POLICY_LANE,
+                    policy_id,
+                );
+                self.b20.transfer_policy_ids.write(packed)
+            }
+            B20PolicyType::TransferReceiver => {
+                let packed = Self::write_policy_lane(
+                    self.b20.transfer_policy_ids.read()?,
+                    Self::TRANSFER_RECEIVER_POLICY_LANE,
+                    policy_id,
+                );
+                self.b20.transfer_policy_ids.write(packed)
+            }
+            B20PolicyType::TransferExecutor => {
+                let packed = Self::write_policy_lane(
+                    self.b20.transfer_policy_ids.read()?,
+                    Self::TRANSFER_EXECUTOR_POLICY_LANE,
+                    policy_id,
+                );
+                self.b20.transfer_policy_ids.write(packed)
+            }
+            B20PolicyType::MintReceiver => {
+                let packed = Self::write_policy_lane(
+                    self.b20.mint_policy_ids.read()?,
+                    Self::MINT_RECEIVER_POLICY_LANE,
+                    policy_id,
+                );
+                self.b20.mint_policy_ids.write(packed)
+            }
+        }
     }
 
     fn emit_event(&mut self, log: LogData) -> Result<()> {
@@ -207,8 +264,107 @@ impl TokenAccounting for B20StablecoinStorage<'_> {
     }
 }
 
+impl B20StablecoinStorage<'_> {
+    const ADMIN_COUNT_BITS: usize = 248;
+    const TRANSFER_SENDER_POLICY_LANE: usize = 0;
+    const TRANSFER_RECEIVER_POLICY_LANE: usize = 1;
+    const TRANSFER_EXECUTOR_POLICY_LANE: usize = 2;
+    const MINT_RECEIVER_POLICY_LANE: usize = 0;
+    const POLICY_LANE_BITS: usize = 64;
+
+    fn admin_count_mask() -> U256 {
+        (U256::ONE << Self::ADMIN_COUNT_BITS) - U256::ONE
+    }
+
+    fn read_admin_count(packed: U256) -> U256 {
+        packed & Self::admin_count_mask()
+    }
+
+    fn write_admin_count(packed: U256, count: U256) -> Result<U256> {
+        let mask = Self::admin_count_mask();
+        if count > mask {
+            return Err(BasePrecompileError::under_overflow());
+        }
+        Ok((packed & !mask) | count)
+    }
+
+    fn require_policy_type(policy_type: B256) -> Result<B20PolicyType> {
+        B20PolicyType::from_id(policy_type).ok_or_else(|| {
+            BasePrecompileError::revert(IB20::UnsupportedPolicyType { policyType: policy_type })
+        })
+    }
+
+    fn read_policy_lane(packed: U256, lane: usize) -> u64 {
+        ((packed >> (lane * Self::POLICY_LANE_BITS)) & U256::from(u64::MAX)).to::<u64>()
+    }
+
+    fn write_policy_lane(packed: U256, lane: usize, policy_id: u64) -> U256 {
+        let shift = lane * Self::POLICY_LANE_BITS;
+        let mask = U256::from(u64::MAX) << shift;
+        (packed & !mask) | (U256::from(policy_id) << shift)
+    }
+}
+
 impl StablecoinAccounting for B20StablecoinStorage<'_> {
     fn set_currency(&mut self, currency: String) -> Result<()> {
-        self.currency.write(currency)
+        self.stablecoin.currency.write(currency)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::string::String;
+
+    use alloy_primitives::{Address, U256, address, uint};
+    use base_precompile_storage::{Handler, StorableType, StorageCtx, setup_storage};
+
+    use super::{
+        __packing_b20_stablecoin_extension_storage, B20StablecoinExtensionStorage,
+        B20StablecoinStorage, slots,
+    };
+    use crate::B20CoreStorage;
+
+    const TOKEN: Address = address!("000000000000000000000000000000000000b022");
+    const B20_ROOT: U256 =
+        uint!(0xc78b71fee795ddd74aff64ea9b2474194c938c3196430e10bb5f01ed48434000_U256);
+    const STABLECOIN_ROOT: U256 =
+        uint!(0x35827975a06ca0e9367ea3129b19441d45d0ca58e30b7693f09e73d0943d6200_U256);
+
+    #[test]
+    fn stablecoin_namespaces_match_base_std_roots() {
+        assert_eq!(<B20CoreStorage as StorableType>::STORAGE_NAMESPACE_ROOT, B20_ROOT);
+        assert_eq!(
+            <B20StablecoinExtensionStorage as StorableType>::STORAGE_NAMESPACE_ID,
+            "base.b20.stablecoin"
+        );
+        assert_eq!(
+            <B20StablecoinExtensionStorage as StorableType>::STORAGE_NAMESPACE_ROOT,
+            STABLECOIN_ROOT
+        );
+
+        assert_eq!(slots::B20, B20_ROOT);
+        assert_eq!(slots::STABLECOIN, STABLECOIN_ROOT);
+        assert_eq!(__packing_b20_stablecoin_extension_storage::CURRENCY_LOC.offset_slots, 0);
+    }
+
+    #[test]
+    fn stablecoin_currency_is_rooted_at_extension_namespace() {
+        let (mut storage, _) = setup_storage();
+
+        StorageCtx::enter(&mut storage, |ctx| {
+            let mut token = B20StablecoinStorage::from_address(TOKEN, ctx);
+            token.b20.name.write(String::from("Stablecoin")).unwrap();
+            token.stablecoin.currency.write(String::from("USD")).unwrap();
+
+            assert_eq!(ctx.sload(TOKEN, B20_ROOT).unwrap(), short_string_word("Stablecoin"));
+            assert_eq!(ctx.sload(TOKEN, STABLECOIN_ROOT).unwrap(), short_string_word("USD"));
+        });
+    }
+
+    fn short_string_word(value: &str) -> U256 {
+        let mut word = [0u8; 32];
+        word[..value.len()].copy_from_slice(value.as_bytes());
+        word[31] = (value.len() * 2) as u8;
+        U256::from_be_bytes(word)
     }
 }

--- a/crates/common/precompiles/src/b20_stablecoin/token.rs
+++ b/crates/common/precompiles/src/b20_stablecoin/token.rs
@@ -13,7 +13,7 @@ use crate::{
 /// EVM precompile for the stablecoin B-20 variant.
 ///
 /// Mirrors the structure of [`crate::B20Token`] but requires `S: StablecoinAccounting`
-/// so the dispatch layer can read `currency()` from storage. All inherited
+/// so the dispatch layer can read `currency()` from stablecoin storage. All inherited
 /// `IB20` capability traits are wired in identically.
 #[derive(Debug, Clone)]
 pub struct B20StablecoinToken<S: StablecoinAccounting, P: Policy> {

--- a/crates/common/precompiles/src/common/ops/roles.rs
+++ b/crates/common/precompiles/src/common/ops/roles.rs
@@ -111,11 +111,13 @@ pub trait RoleManaged: Token {
         if self.accounting().has_role(role, account)? {
             return Ok(());
         }
-        let current = self.accounting().role_member_count(role)?;
-        let next =
-            current.checked_add(U256::ONE).ok_or_else(BasePrecompileError::under_overflow)?;
         self.accounting_mut().set_role(role, account, true)?;
-        self.accounting_mut().set_role_member_count(role, next)?;
+        if role == Self::default_admin_role() {
+            let current = self.accounting().role_member_count(role)?;
+            let next =
+                current.checked_add(U256::ONE).ok_or_else(BasePrecompileError::under_overflow)?;
+            self.accounting_mut().set_role_member_count(role, next)?;
+        }
         self.accounting_mut()
             .emit_event(IB20::RoleGranted { role, account, sender }.encode_log_data())
     }
@@ -130,11 +132,13 @@ pub trait RoleManaged: Token {
         if !self.accounting().has_role(role, account)? {
             return Ok(());
         }
-        let current = self.accounting().role_member_count(role)?;
-        let next =
-            current.checked_sub(U256::ONE).ok_or_else(BasePrecompileError::under_overflow)?;
         self.accounting_mut().set_role(role, account, false)?;
-        self.accounting_mut().set_role_member_count(role, next)?;
+        if role == Self::default_admin_role() {
+            let current = self.accounting().role_member_count(role)?;
+            let next =
+                current.checked_sub(U256::ONE).ok_or_else(BasePrecompileError::under_overflow)?;
+            self.accounting_mut().set_role_member_count(role, next)?;
+        }
         self.accounting_mut()
             .emit_event(IB20::RoleRevoked { role, account, sender }.encode_log_data())
     }
@@ -269,10 +273,6 @@ mod tests {
         token.grant_role(ADMIN, B20TokenRole::Mint.id(), ALICE, false).unwrap();
 
         assert!(token.has_role(B20TokenRole::Mint.id(), ALICE).unwrap());
-        assert_eq!(
-            token.accounting().role_member_count(B20TokenRole::Mint.id()).unwrap(),
-            U256::ONE
-        );
         assert_eq!(
             token.accounting().events[0],
             IB20::RoleGranted { role: B20TokenRole::Mint.id(), account: ALICE, sender: ADMIN }

--- a/crates/common/precompiles/src/common/test_utils.rs
+++ b/crates/common/precompiles/src/common/test_utils.rs
@@ -70,10 +70,10 @@ pub struct InMemoryTokenAccounting {
     pub policy_ids: HashMap<B256, u64>,
     /// Share-to-tokens ratio scaled to WAD (1e18). Security tokens only.
     pub shares_to_tokens_ratio: U256,
-    /// Security identifier values keyed by `keccak256(identifier_type)`. Security tokens only.
-    pub security_identifiers: HashMap<B256, String>,
-    /// Consumed announcement ids (stored as `keccak256(id)`). Security tokens only.
-    pub announcement_ids_used: HashSet<B256>,
+    /// Security identifier values keyed by raw `identifier_type`. Security tokens only.
+    pub security_identifiers: HashMap<String, String>,
+    /// Consumed announcement ids keyed by raw announcement id. Security tokens only.
+    pub announcement_ids_used: HashSet<String>,
     /// Events collected by `emit_event`; does not produce real EVM logs.
     pub events: Vec<LogData>,
 }
@@ -181,8 +181,7 @@ impl TokenAccounting for InMemoryTokenAccounting {
     }
 
     fn security_identifier(&self, identifier_type: &str) -> Result<String> {
-        let key = alloy_primitives::keccak256(identifier_type.as_bytes());
-        if let Some(val) = self.security_identifiers.get(&key) {
+        if let Some(val) = self.security_identifiers.get(identifier_type) {
             return Ok(val.clone());
         }
         if identifier_type == "ISIN" { Ok(self.security_isin.clone()) } else { Ok(String::new()) }
@@ -420,21 +419,20 @@ impl SecurityAccounting for InMemoryTokenAccounting {
         identifier_type: &str,
         value: String,
     ) -> Result<()> {
-        let key = alloy_primitives::keccak256(identifier_type.as_bytes());
         if value.is_empty() {
-            self.security_identifiers.remove(&key);
+            self.security_identifiers.remove(identifier_type);
         } else {
-            self.security_identifiers.insert(key, value);
+            self.security_identifiers.insert(identifier_type.to_owned(), value);
         }
         Ok(())
     }
 
-    fn is_announcement_id_used(&self, id_hash: B256) -> Result<bool> {
-        Ok(self.announcement_ids_used.contains(&id_hash))
+    fn is_announcement_id_used(&self, id: &str) -> Result<bool> {
+        Ok(self.announcement_ids_used.contains(id))
     }
 
-    fn mark_announcement_id_used(&mut self, id_hash: B256) -> Result<()> {
-        self.announcement_ids_used.insert(id_hash);
+    fn mark_announcement_id_used(&mut self, id: &str) -> Result<()> {
+        self.announcement_ids_used.insert(id.to_owned());
         Ok(())
     }
 }

--- a/crates/common/precompiles/src/common/test_utils.rs
+++ b/crates/common/precompiles/src/common/test_utils.rs
@@ -176,17 +176,6 @@ impl TokenAccounting for InMemoryTokenAccounting {
         Ok(self.decimals)
     }
 
-    fn currency(&self) -> Result<String> {
-        Ok(self.currency.clone())
-    }
-
-    fn security_identifier(&self, identifier_type: &str) -> Result<String> {
-        if let Some(val) = self.security_identifiers.get(identifier_type) {
-            return Ok(val.clone());
-        }
-        if identifier_type == "ISIN" { Ok(self.security_isin.clone()) } else { Ok(String::new()) }
-    }
-
     fn paused(&self) -> Result<U256> {
         Ok(self.paused)
     }
@@ -203,15 +192,6 @@ impl TokenAccounting for InMemoryTokenAccounting {
     fn increment_nonce(&mut self, owner: Address) -> Result<()> {
         let n = self.nonces.entry(owner).or_default();
         *n += U256::from(1u64);
-        Ok(())
-    }
-
-    fn minimum_redeemable(&self) -> Result<U256> {
-        Ok(self.minimum_redeemable)
-    }
-
-    fn set_minimum_redeemable(&mut self, minimum: U256) -> Result<()> {
-        self.minimum_redeemable = minimum;
         Ok(())
     }
 
@@ -267,6 +247,10 @@ impl TokenAccounting for InMemoryTokenAccounting {
 }
 
 impl StablecoinAccounting for InMemoryTokenAccounting {
+    fn currency(&self) -> Result<String> {
+        Ok(self.currency.clone())
+    }
+
     fn set_currency(&mut self, currency: String) -> Result<()> {
         self.currency = currency;
         Ok(())
@@ -414,6 +398,13 @@ impl SecurityAccounting for InMemoryTokenAccounting {
         Ok(())
     }
 
+    fn security_identifier(&self, identifier_type: &str) -> Result<String> {
+        if let Some(val) = self.security_identifiers.get(identifier_type) {
+            return Ok(val.clone());
+        }
+        if identifier_type == "ISIN" { Ok(self.security_isin.clone()) } else { Ok(String::new()) }
+    }
+
     fn set_security_identifier_value(
         &mut self,
         identifier_type: &str,
@@ -424,6 +415,15 @@ impl SecurityAccounting for InMemoryTokenAccounting {
         } else {
             self.security_identifiers.insert(identifier_type.to_owned(), value);
         }
+        Ok(())
+    }
+
+    fn minimum_redeemable(&self) -> Result<U256> {
+        Ok(self.minimum_redeemable)
+    }
+
+    fn set_minimum_redeemable(&mut self, minimum: U256) -> Result<()> {
+        self.minimum_redeemable = minimum;
         Ok(())
     }
 

--- a/crates/common/precompiles/src/common/token_accounting.rs
+++ b/crates/common/precompiles/src/common/token_accounting.rs
@@ -53,10 +53,6 @@ pub trait TokenAccounting {
     fn set_symbol(&mut self, symbol: String) -> Result<()>;
     /// Returns the number of decimal places.
     fn decimals(&self) -> Result<u8>;
-    /// Returns the stablecoin currency identifier, or an empty string for non-stablecoin variants.
-    fn currency(&self) -> Result<String>;
-    /// Returns the security identifier value for `identifier_type`, or an empty string if unset.
-    fn security_identifier(&self, identifier_type: &str) -> Result<String>;
 
     // --- Pause ---
 
@@ -71,13 +67,6 @@ pub trait TokenAccounting {
     fn nonce(&self, owner: Address) -> Result<U256>;
     /// Increments the EIP-2612 permit nonce for `owner` by one.
     fn increment_nonce(&mut self, owner: Address) -> Result<()>;
-
-    // --- Redeem ---
-
-    /// Returns the minimum amount that may be redeemed in a single call.
-    fn minimum_redeemable(&self) -> Result<U256>;
-    /// Overwrites the minimum redeemable amount.
-    fn set_minimum_redeemable(&mut self, minimum: U256) -> Result<()>;
 
     // --- Contract URI ---
 

--- a/crates/common/precompiles/src/factory/storage.rs
+++ b/crates/common/precompiles/src/factory/storage.rs
@@ -58,15 +58,14 @@ impl<'a> TokenFactoryStorage<'a> {
                     B20TokenStorage::from_address(token_address, self.storage),
                     PolicyHandle::new(self.storage),
                 );
-                token.accounting_mut().name.write(token_params.name.clone())?;
-                token.accounting_mut().symbol.write(token_params.symbol.clone())?;
-                token.accounting_mut().supply_cap.write(Self::DEFAULT_SUPPLY_CAP)?;
-                token.accounting_mut().minimum_redeemable.write(token_params.minimum_redeemable)?;
+                token.accounting_mut().b20.name.write(token_params.name.clone())?;
+                token.accounting_mut().b20.symbol.write(token_params.symbol.clone())?;
+                token.accounting_mut().b20.supply_cap.write(Self::DEFAULT_SUPPLY_CAP)?;
                 token
                     .accounting_mut()
-                    .stablecoin_currency
+                    .stablecoin
+                    .currency
                     .write(token_params.stablecoin_currency)?;
-                token.accounting_mut().security_isin.write(token_params.security_isin)?;
 
                 self.emit_event(ITokenFactory::TokenCreated {
                     token: token_address,
@@ -415,8 +414,8 @@ mod tests {
             let token_addr = factory.create_token(caller, call).unwrap();
             let token = B20TokenStorage::from_address(token_addr, ctx);
 
-            assert_eq!(token.name.read().unwrap(), "My Token");
-            assert_eq!(token.symbol.read().unwrap(), "MYT");
+            assert_eq!(token.b20.name.read().unwrap(), "My Token");
+            assert_eq!(token.b20.symbol.read().unwrap(), "MYT");
             assert_eq!(token.decimals().unwrap(), 18);
             assert_eq!(token.supply_cap().unwrap(), TokenFactoryStorage::DEFAULT_SUPPLY_CAP);
             assert_eq!(TokenVariant::decimals_of(token_addr), Some(18));
@@ -443,7 +442,7 @@ mod tests {
             let token_addr = factory.create_token(caller, call).unwrap();
             let token = B20TokenStorage::from_address(token_addr, ctx);
 
-            assert_eq!(token.total_supply.read().unwrap(), supply);
+            assert_eq!(token.b20.total_supply.read().unwrap(), supply);
             assert_eq!(token.balance_of(recipient).unwrap(), supply);
         });
     }
@@ -518,8 +517,8 @@ mod tests {
             let token_addr = factory.create_token(caller, call).unwrap();
             let token = B20TokenStorage::from_address(token_addr, ctx);
 
-            assert_eq!(token.name.read().unwrap(), "");
-            assert_eq!(token.symbol.read().unwrap(), "");
+            assert_eq!(token.b20.name.read().unwrap(), "");
+            assert_eq!(token.b20.symbol.read().unwrap(), "");
         });
     }
 
@@ -603,7 +602,7 @@ mod tests {
             )
             .unwrap();
             let stablecoin = B20TokenStorage::from_address(stablecoin_addr, ctx);
-            assert_eq!(stablecoin.stablecoin_currency.read().unwrap(), "USD");
+            assert_eq!(stablecoin.stablecoin.currency.read().unwrap(), "USD");
             assert_eq!(TokenVariant::from_address(stablecoin_addr), Some(TokenVariant::Stablecoin));
             assert_eq!(TokenVariant::decimals_of(stablecoin_addr), Some(6));
         });
@@ -641,18 +640,17 @@ mod tests {
             assert!(ctx.has_bytecode(expected_addr).unwrap());
 
             let sec_storage = B20SecurityStorage::from_address(expected_addr, ctx);
-            assert_eq!(sec_storage.name.read().unwrap(), "Security Token");
-            assert_eq!(sec_storage.symbol.read().unwrap(), "SEC");
+            assert_eq!(sec_storage.b20.name.read().unwrap(), "Security Token");
+            assert_eq!(sec_storage.b20.symbol.read().unwrap(), "SEC");
             assert_eq!(sec_storage.decimals().unwrap(), 6);
             assert_eq!(
-                sec_storage.shares_to_tokens_ratio.read().unwrap(),
+                sec_storage.security.shares_to_tokens_ratio.read().unwrap(),
                 U256::from(1_000_000_000_000_000_000u128)
             );
-            assert_eq!(sec_storage.minimum_redeemable.read().unwrap(), U256::ONE);
-            // ISIN is stored in the security_identifiers mapping under keccak256("ISIN").
-            let isin_key = alloy_primitives::keccak256(b"ISIN");
+            assert_eq!(sec_storage.redeem.minimum_redeemable.read().unwrap(), U256::ONE);
+            // ISIN is stored in the identifiers mapping under the raw "ISIN" key.
             assert_eq!(
-                sec_storage.security_identifiers.at(&isin_key).read().unwrap(),
+                sec_storage.security.identifiers.at(&String::from("ISIN")).read().unwrap(),
                 "US0000000000"
             );
         });
@@ -673,7 +671,7 @@ mod tests {
             let token_addr = factory.create_token(caller, call).unwrap();
             let token = B20TokenStorage::from_address(token_addr, ctx);
 
-            assert_eq!(token.name.read().unwrap(), "Configured");
+            assert_eq!(token.b20.name.read().unwrap(), "Configured");
         });
     }
 

--- a/crates/common/precompiles/src/factory/storage.rs
+++ b/crates/common/precompiles/src/factory/storage.rs
@@ -906,10 +906,6 @@ mod tests {
                 U256::from(1_000u64).abi_encode(),
             );
             assert_output(
-                dispatch_b20_success(ctx, expected_token, IB20::minimumRedeemableCall {}),
-                U256::ZERO.abi_encode(),
-            );
-            assert_output(
                 dispatch_b20_success(ctx, expected_token, IB20::contractURICall {}),
                 "ipfs://dispatch".to_string().abi_encode(),
             );

--- a/crates/common/precompiles/src/factory/storage.rs
+++ b/crates/common/precompiles/src/factory/storage.rs
@@ -8,8 +8,8 @@ use revm::state::Bytecode;
 
 use super::variant::TokenVariant;
 use crate::{
-    B20SecurityStorage, B20SecurityToken, B20Token, B20TokenRole, B20TokenStorage, ITokenFactory,
-    PolicyHandle, RoleManaged, Token,
+    B20SecurityStorage, B20SecurityToken, B20StablecoinStorage, B20StablecoinToken, B20Token,
+    B20TokenRole, B20TokenStorage, ITokenFactory, PolicyHandle, RoleManaged, Token,
 };
 
 /// The B-20 token factory precompile.
@@ -53,7 +53,7 @@ impl<'a> TokenFactoryStorage<'a> {
         self.storage.set_code(token_address, stub)?;
 
         match variant {
-            TokenVariant::B20 | TokenVariant::Stablecoin => {
+            TokenVariant::B20 => {
                 let mut token = B20Token::with_storage_and_policy(
                     B20TokenStorage::from_address(token_address, self.storage),
                     PolicyHandle::new(self.storage),
@@ -61,11 +61,40 @@ impl<'a> TokenFactoryStorage<'a> {
                 token.accounting_mut().b20.name.write(token_params.name.clone())?;
                 token.accounting_mut().b20.symbol.write(token_params.symbol.clone())?;
                 token.accounting_mut().b20.supply_cap.write(Self::DEFAULT_SUPPLY_CAP)?;
-                token
-                    .accounting_mut()
-                    .stablecoin
-                    .currency
-                    .write(token_params.stablecoin_currency)?;
+
+                self.emit_event(ITokenFactory::TokenCreated {
+                    token: token_address,
+                    variant: call.variant,
+                    name: token_params.name,
+                    symbol: token_params.symbol,
+                    decimals: token_params.decimals,
+                })?;
+
+                if !token_params.initial_admin.is_zero() {
+                    token.grant_role_unchecked(
+                        B20TokenRole::DefaultAdmin.id(),
+                        token_params.initial_admin,
+                        Self::ADDRESS,
+                    )?;
+                }
+
+                for (index, calldata) in call.initCalls.into_iter().enumerate() {
+                    token
+                        .inner_with_privilege(self.storage, &calldata, true)
+                        .map_err(|err| Self::map_init_call_error(index, err))?;
+                }
+            }
+            TokenVariant::Stablecoin => {
+                let mut token = B20StablecoinToken::with_storage_and_policy(
+                    B20StablecoinStorage::from_address(token_address, self.storage),
+                    PolicyHandle::new(self.storage),
+                );
+                token.accounting_mut().initialize(
+                    token_params.name.clone(),
+                    token_params.symbol.clone(),
+                    Self::DEFAULT_SUPPLY_CAP,
+                    token_params.stablecoin_currency,
+                )?;
 
                 self.emit_event(ITokenFactory::TokenCreated {
                     token: token_address,
@@ -274,6 +303,7 @@ mod tests {
         for key in [
             ActivationFeature::TokenFactory.id(),
             ActivationFeature::B20Token.id(),
+            ActivationFeature::B20Stablecoin.id(),
             ActivationFeature::B20Security.id(),
         ] {
             StorageCtx::enter(storage, |ctx| {
@@ -601,8 +631,9 @@ mod tests {
                 dispatch_factory_success(ctx, stablecoin_call).as_ref(),
             )
             .unwrap();
-            let stablecoin = B20TokenStorage::from_address(stablecoin_addr, ctx);
+            let stablecoin = B20StablecoinStorage::from_address(stablecoin_addr, ctx);
             assert_eq!(stablecoin.stablecoin.currency.read().unwrap(), "USD");
+            assert_eq!(stablecoin.b20.name.read().unwrap(), "Stablecoin Token");
             assert_eq!(TokenVariant::from_address(stablecoin_addr), Some(TokenVariant::Stablecoin));
             assert_eq!(TokenVariant::decimals_of(stablecoin_addr), Some(6));
         });

--- a/crates/common/precompiles/src/lib.rs
+++ b/crates/common/precompiles/src/lib.rs
@@ -33,7 +33,7 @@ pub use common::{InMemoryPolicy, InMemoryTokenAccounting, TestStablecoinToken, T
 mod b20;
 pub use b20::{
     B20CoreStorage, B20PausableFeature, B20PolicyType, B20Token, B20TokenPrecompile,
-    B20TokenStorage, IB20, POLICY_ALWAYS_ALLOW, POLICY_ALWAYS_BLOCK,
+    B20TokenStorage, IB20,
 };
 
 mod b20_security;

--- a/crates/common/precompiles/src/lib.rs
+++ b/crates/common/precompiles/src/lib.rs
@@ -32,12 +32,14 @@ pub use common::{InMemoryPolicy, InMemoryTokenAccounting, TestStablecoinToken, T
 
 mod b20;
 pub use b20::{
-    B20PausableFeature, B20PolicyType, B20Token, B20TokenPrecompile, B20TokenStorage, IB20,
+    B20CoreStorage, B20PausableFeature, B20PolicyType, B20Token,
+    B20TokenPrecompile, B20TokenStorage, IB20, POLICY_ALWAYS_ALLOW, POLICY_ALWAYS_BLOCK,
 };
 
 mod b20_security;
 pub use b20_security::{
-    B20SecurityPrecompile, B20SecurityStorage, B20SecurityToken, IB20Security, SecurityAccounting,
+    B20RedeemStorage, B20SecurityExtensionStorage, B20SecurityPrecompile, B20SecurityStorage,
+    B20SecurityToken, IB20Security, SecurityAccounting,
 };
 
 mod b20_stablecoin;

--- a/crates/common/precompiles/src/lib.rs
+++ b/crates/common/precompiles/src/lib.rs
@@ -32,8 +32,8 @@ pub use common::{InMemoryPolicy, InMemoryTokenAccounting, TestStablecoinToken, T
 
 mod b20;
 pub use b20::{
-    B20CoreStorage, B20PausableFeature, B20PolicyType, B20Token,
-    B20TokenPrecompile, B20TokenStorage, IB20, POLICY_ALWAYS_ALLOW, POLICY_ALWAYS_BLOCK,
+    B20CoreStorage, B20PausableFeature, B20PolicyType, B20Token, B20TokenPrecompile,
+    B20TokenStorage, IB20, POLICY_ALWAYS_ALLOW, POLICY_ALWAYS_BLOCK,
 };
 
 mod b20_security;
@@ -44,8 +44,8 @@ pub use b20_security::{
 
 mod b20_stablecoin;
 pub use b20_stablecoin::{
-    B20StablecoinPrecompile, B20StablecoinStorage, B20StablecoinToken, IB20Stablecoin,
-    StablecoinAccounting,
+    B20StablecoinExtensionStorage, B20StablecoinPrecompile, B20StablecoinStorage,
+    B20StablecoinToken, IB20Stablecoin, StablecoinAccounting,
 };
 
 mod factory;

--- a/crates/common/precompiles/src/policy/dispatch.rs
+++ b/crates/common/precompiles/src/policy/dispatch.rs
@@ -102,7 +102,7 @@ mod tests {
     /// Activates the policy registry and writes the built-in policies to storage.
     ///
     /// Call this instead of `activate_policy_registry` when the test needs to query
-    /// built-in policy IDs (ALWAYS_ALLOW_ID, ALWAYS_BLOCK_ID) directly.
+    /// built-in policy IDs (`ALWAYS_ALLOW_ID`, `ALWAYS_BLOCK_ID`) directly.
     fn activate_and_init(storage: &mut HashMapStorageProvider) {
         activate_policy_registry(storage);
         StorageCtx::enter(storage, |ctx| PolicyRegistryStorage::new(ctx).write_builtins()).unwrap();

--- a/crates/common/precompiles/src/policy/storage.rs
+++ b/crates/common/precompiles/src/policy/storage.rs
@@ -367,6 +367,9 @@ impl PolicyRegistryStorage<'_> {
     /// Returns `true` if `policy_id` refers to an existing policy.
     pub fn policy_exists(&self, policy_id: u64) -> Result<bool> {
         Self::require_well_formed(policy_id)?;
+        if policy_id == Self::ALWAYS_ALLOW_ID || policy_id == Self::ALWAYS_BLOCK_ID {
+            return Ok(true);
+        }
         let packed = PackedPolicy::from_raw(self.policies.at(&policy_id).read()?);
         Ok(packed.exists())
     }
@@ -969,7 +972,7 @@ mod tests {
 
     #[test]
     fn policy_exists_builtin_ids_always_return_true() {
-        let mut s = storage();
+        let mut s = HashMapStorageProvider::new(1);
         assert!(
             StorageCtx::enter(&mut s, |ctx| {
                 PolicyRegistryStorage::new(ctx)

--- a/crates/common/precompiles/src/provider.rs
+++ b/crates/common/precompiles/src/provider.rs
@@ -13,11 +13,12 @@ use revm::{
 };
 
 use crate::{
-    ActivationRegistry, B20SecurityPrecompile, B20TokenPrecompile, BasePrecompileSpec,
-    PolicyRegistryPrecompile, TokenFactory, TokenVariant, bls12_381, bn254_pair,
+    ActivationRegistry, B20SecurityPrecompile, B20StablecoinPrecompile, B20TokenPrecompile,
+    BasePrecompileSpec, PolicyRegistryPrecompile, TokenFactory, TokenVariant, bls12_381,
+    bn254_pair,
 };
 
-/// Combined lookup for all B-20 token variants (default and security).
+/// Combined lookup for all B-20 token variants.
 ///
 /// A single named function is required because `set_precompile_lookup` accepts
 /// function pointers (which are lifetime-generic) but not closures with a specific
@@ -26,8 +27,8 @@ use crate::{
 fn b20_token_lookup(address: &Address) -> Option<alloy_evm::precompiles::DynPrecompile> {
     match TokenVariant::from_address(*address)? {
         TokenVariant::B20 => Some(B20TokenPrecompile::create_precompile(*address)),
+        TokenVariant::Stablecoin => Some(B20StablecoinPrecompile::create_precompile(*address)),
         TokenVariant::Security => Some(B20SecurityPrecompile::create_precompile(*address)),
-        TokenVariant::Stablecoin => None,
     }
 }
 

--- a/crates/proof/succinct/elf/manifest.toml
+++ b/crates/proof/succinct/elf/manifest.toml
@@ -17,7 +17,7 @@
 
 [[elfs]]
 name = "range-elf-embedded"
-sha256 = "f56d0095cc4005b6f313e3087d7f51c1956723328498af6f5f95df933fea6d04"
+sha256 = "bc77946a017e1f8cbe7a31d1f51755c9d4aac1bddba5d2e9c18d26afbd06189b"
 
 [[elfs]]
 name = "aggregation-elf"


### PR DESCRIPTION
## Summary

This aligns the B20 precompile storage adapters with the ERC-7201 namespaces defined by base-std. It splits core, stablecoin, security, and redeem storage into typed namespaced structs, updates factory and security accounting paths, and adds slot-layout tests for roots, offsets, packed admin count, and string-keyed mappings. It also teaches precompile storage how to derive Solidity-compatible string mapping slots.