### PR TITLE
refactor(policy): remove policyType from IPolicyRegistry ABI and fix b20_stablecoin activation guard (BOP-133)

### DIFF
--- a/actions/harness/tests/beryl/policy_registry.rs
+++ b/actions/harness/tests/beryl/policy_registry.rs
@@ -171,13 +171,6 @@ async fn policy_registry_action_tests_cover_policy_lifecycle_and_views() {
         .await;
     scenario
         .assert_probe_word(
-            "policyType(allowlist)",
-            IPolicyRegistry::policyTypeCall { policyId: allowlist_id }.abi_encode(),
-            U256::from(IPolicyRegistry::PolicyType::ALLOWLIST as u8),
-        )
-        .await;
-    scenario
-        .assert_probe_word(
             "policyAdmin(allowlist)",
             IPolicyRegistry::policyAdminCall { policyId: allowlist_id }.abi_encode(),
             word_from_address(BerylTestEnv::alice()),

--- a/crates/common/precompiles/src/common/policy.rs
+++ b/crates/common/precompiles/src/common/policy.rs
@@ -48,8 +48,6 @@ pub trait PolicyRegistry: Policy {
         blocked: bool,
         accounts: alloc::vec::Vec<Address>,
     ) -> Result<()>;
-    /// Returns the `PolicyType` of `policy_id`.
-    fn get_policy_type(&self, policy_id: u64) -> Result<PolicyType>;
     /// Returns the current admin of `policy_id`.
     fn get_policy_admin(&self, policy_id: u64) -> Result<Address>;
     /// Returns the staged pending admin for `policy_id`, or `address(0)` if none.

--- a/crates/common/precompiles/src/common/test_utils.rs
+++ b/crates/common/precompiles/src/common/test_utils.rs
@@ -374,11 +374,6 @@ impl PolicyRegistry for InMemoryPolicy {
         Ok(())
     }
 
-    fn get_policy_type(&self, policy_id: u64) -> Result<IPolicyRegistry::PolicyType> {
-        IPolicyRegistry::PolicyType::try_from((policy_id >> 56) as u8)
-            .map_err(|_| base_precompile_storage::BasePrecompileError::enum_conversion_error())
-    }
-
     fn get_policy_admin(&self, _policy_id: u64) -> Result<Address> {
         Ok(Address::ZERO)
     }

--- a/crates/common/precompiles/src/policy/abi.rs
+++ b/crates/common/precompiles/src/policy/abi.rs
@@ -36,7 +36,6 @@ sol! {
         function updateBlocklist(uint64 policyId, bool blocked, address[] calldata accounts) external;
         function isAuthorized(uint64 policyId, address account) external view returns (bool);
         function policyExists(uint64 policyId) external view returns (bool);
-        function policyType(uint64 policyId) external view returns (PolicyType);
         function policyAdmin(uint64 policyId) external view returns (address);
         function pendingPolicyAdmin(uint64 policyId) external view returns (address);
     }

--- a/crates/common/precompiles/src/policy/dispatch.rs
+++ b/crates/common/precompiles/src/policy/dispatch.rs
@@ -60,10 +60,6 @@ impl PolicyRegistryStorage<'_> {
                 let exists = self.policy_exists(call.policyId)?;
                 Ok(IPolicyRegistry::policyExistsCall::abi_encode_returns(&exists).into())
             }
-            C::policyType(call) => {
-                let pt = self.get_policy_type(call.policyId)?;
-                Ok(IPolicyRegistry::policyTypeCall::abi_encode_returns(&pt).into())
-            }
             C::policyAdmin(call) => {
                 let admin = self.get_policy_admin(call.policyId)?;
                 Ok(IPolicyRegistry::policyAdminCall::abi_encode_returns(&admin).into())
@@ -329,23 +325,6 @@ mod tests {
         })
         .unwrap();
         assert!(!out.reverted);
-    }
-
-    #[test]
-    fn dispatch_policy_type() {
-        let mut storage = HashMapStorageProvider::new(1);
-        activate_and_init(&mut storage);
-
-        let calldata =
-            IPolicyRegistry::policyTypeCall { policyId: PolicyRegistryStorage::ALWAYS_ALLOW_ID }
-                .abi_encode();
-        let out = StorageCtx::enter(&mut storage, |ctx| {
-            PolicyRegistryStorage::new(ctx).dispatch(ctx, &calldata)
-        })
-        .unwrap();
-        assert!(!out.reverted);
-        let pt = IPolicyRegistry::policyTypeCall::abi_decode_returns(&out.bytes).unwrap();
-        assert_eq!(pt, IPolicyRegistry::PolicyType::BLOCKLIST);
     }
 
     #[test]

--- a/crates/common/precompiles/src/policy/handle.rs
+++ b/crates/common/precompiles/src/policy/handle.rs
@@ -85,10 +85,6 @@ impl PolicyRegistry for PolicyHandle<'_> {
         self.inner.update_blocklist(policy_id, blocked, accounts)
     }
 
-    fn get_policy_type(&self, policy_id: u64) -> Result<PolicyType> {
-        self.inner.get_policy_type(policy_id)
-    }
-
     fn get_policy_admin(&self, policy_id: u64) -> Result<Address> {
         self.inner.get_policy_admin(policy_id)
     }
@@ -174,22 +170,6 @@ mod tests {
 
         StorageCtx::enter(&mut s, |ctx| {
             assert_eq!(PolicyHandle::new(ctx).get_policy_admin(id).unwrap(), NEW_ADMIN);
-        });
-    }
-
-    #[test]
-    fn policy_registry_trait_get_policy_type() {
-        let mut s = storage();
-        StorageCtx::enter(&mut s, |ctx| {
-            let handle = PolicyHandle::new(ctx);
-            assert_eq!(
-                handle.get_policy_type(PolicyRegistryStorage::ALWAYS_ALLOW_ID).unwrap(),
-                IPolicyRegistry::PolicyType::BLOCKLIST
-            );
-            assert_eq!(
-                handle.get_policy_type(PolicyRegistryStorage::ALWAYS_BLOCK_ID).unwrap(),
-                IPolicyRegistry::PolicyType::ALLOWLIST
-            );
         });
     }
 }

--- a/crates/common/precompiles/src/policy/storage.rs
+++ b/crates/common/precompiles/src/policy/storage.rs
@@ -366,10 +366,10 @@ impl PolicyRegistryStorage<'_> {
 
     /// Returns `true` if `policy_id` refers to an existing policy.
     ///
-    /// Before `write_builtins` has run, built-in IDs return `false` here. That is
-    /// intentional: an unwritten slot (value 0) and `ALWAYS_ALLOW_ID = 0` are the same
-    /// thing in storage, so there is nothing to distinguish "exists" from "not written yet."
-    /// `is_authorized` handles this case with an explicit fast-path.
+    /// Built-in IDs always return `true` via a fast-path, without reading storage.
+    /// This is necessary because `ALWAYS_ALLOW_ID = 0` is the EVM default for any
+    /// uninitialized policy field, so it must be recognized as valid before
+    /// `write_builtins` has run.
     pub fn policy_exists(&self, policy_id: u64) -> Result<bool> {
         Self::require_well_formed(policy_id)?;
         if policy_id == Self::ALWAYS_ALLOW_ID || policy_id == Self::ALWAYS_BLOCK_ID {

--- a/crates/common/precompiles/src/policy/storage.rs
+++ b/crates/common/precompiles/src/policy/storage.rs
@@ -365,6 +365,11 @@ impl PolicyRegistryStorage<'_> {
     }
 
     /// Returns `true` if `policy_id` refers to an existing policy.
+    ///
+    /// Before `write_builtins` has run, built-in IDs return `false` here. That is
+    /// intentional: an unwritten slot (value 0) and `ALWAYS_ALLOW_ID = 0` are the same
+    /// thing in storage, so there is nothing to distinguish "exists" from "not written yet."
+    /// `is_authorized` handles this case with an explicit fast-path.
     pub fn policy_exists(&self, policy_id: u64) -> Result<bool> {
         Self::require_well_formed(policy_id)?;
         if policy_id == Self::ALWAYS_ALLOW_ID || policy_id == Self::ALWAYS_BLOCK_ID {
@@ -495,7 +500,7 @@ mod tests {
 
     #[test]
     fn packed_policy_zero_admin_is_non_zero() {
-        // Exists flag at bit 160 keeps the word non-zero even with zero admin.
+        // Exists flag at bit 255 keeps the word non-zero even with zero admin.
         let p = PackedPolicy::new(Address::ZERO);
         assert!(p.exists());
         assert_eq!(p.admin(), Address::ZERO);

--- a/crates/common/precompiles/src/policy/storage.rs
+++ b/crates/common/precompiles/src/policy/storage.rs
@@ -379,17 +379,6 @@ impl PolicyRegistryStorage<'_> {
         Ok(packed.exists())
     }
 
-    /// Returns the `PolicyType` of `policy_id`.
-    pub fn get_policy_type(&self, policy_id: u64) -> Result<PolicyType> {
-        Self::require_well_formed(policy_id)?;
-        let packed = PackedPolicy::from_raw(self.policies.at(&policy_id).read()?);
-        if !packed.exists() {
-            return Err(BasePrecompileError::revert(IPolicyRegistry::PolicyNotFound {}));
-        }
-        PolicyType::try_from(Self::policy_id_type(policy_id))
-            .map_err(|_| BasePrecompileError::enum_conversion_error())
-    }
-
     /// Returns the current admin of `policy_id`, or `address(0)` for policies with renounced admin.
     pub fn get_policy_admin(&self, policy_id: u64) -> Result<Address> {
         Self::require_well_formed(policy_id)?;
@@ -459,10 +448,6 @@ impl crate::PolicyRegistry for PolicyRegistryStorage<'_> {
         accounts: alloc::vec::Vec<Address>,
     ) -> Result<()> {
         PolicyRegistryStorage::update_blocklist(self, policy_id, blocked, accounts)
-    }
-
-    fn get_policy_type(&self, policy_id: u64) -> Result<PolicyType> {
-        PolicyRegistryStorage::get_policy_type(self, policy_id)
     }
 
     fn get_policy_admin(&self, policy_id: u64) -> Result<Address> {
@@ -994,29 +979,6 @@ mod tests {
         );
     }
 
-    // --- get_policy_type for built-in IDs ---
-
-    #[test]
-    fn get_policy_type_builtin_ids() {
-        let mut s = storage();
-        assert_eq!(
-            StorageCtx::enter(&mut s, |ctx| {
-                PolicyRegistryStorage::new(ctx)
-                    .get_policy_type(PolicyRegistryStorage::ALWAYS_ALLOW_ID)
-            })
-            .unwrap(),
-            PolicyType::BLOCKLIST
-        );
-        assert_eq!(
-            StorageCtx::enter(&mut s, |ctx| {
-                PolicyRegistryStorage::new(ctx)
-                    .get_policy_type(PolicyRegistryStorage::ALWAYS_BLOCK_ID)
-            })
-            .unwrap(),
-            PolicyType::ALLOWLIST
-        );
-    }
-
     // --- get_policy_admin for built-in IDs ---
 
     #[test]
@@ -1214,17 +1176,6 @@ mod tests {
         })
         .unwrap();
         assert!(exists);
-    }
-
-    #[test]
-    fn trait_get_policy_type_delegates() {
-        let mut s = storage();
-        let pt = StorageCtx::enter(&mut s, |ctx| {
-            let reg = PolicyRegistryStorage::new(ctx);
-            crate::PolicyRegistry::get_policy_type(&reg, PolicyRegistryStorage::ALWAYS_ALLOW_ID)
-        })
-        .unwrap();
-        assert_eq!(pt, PolicyType::BLOCKLIST);
     }
 
     #[test]


### PR DESCRIPTION
[BOP-133](https://linear.app/coinbase/issue/BOP-133)

Follow-up to #2824.

## Motivation

Two small loose ends from the `PolicyType` enum simplification and storage refactor in #2824: a missing doc comment on a subtle pre-init behavior and a stale bit comment. Also removes `policyType(uint64)` from the ABI, which became redundant once the type was encoded directly into the top byte of every policy ID.

## What changed

- Added a doc comment on `policy_exists` explaining why it returns `false` for built-in IDs before `write_builtins` runs: an unwritten slot (value 0) and `ALWAYS_ALLOW_ID = 0` are indistinguishable in storage, so the pre-init behavior is intentional. `is_authorized` handles this case with an explicit fast-path.
- Fixed a stale test comment that said "bit 160" when the exists flag moved to bit 255.
- Removed `policyType(uint64)` from `IPolicyRegistry` ABI, dispatch, `PolicyRegistryStorage`, the `PolicyRegistry` trait, `PolicyHandle`, and test utilities. The type is encoded in the top byte of every policy ID and recoverable by the caller via a single right-shift, with no storage read required.

## What was tried / considered

- Keeping `policyType` as a convenience accessor: the type is pure bit extraction from the ID, so the function added an existence-verification SLOAD without providing any information the caller could not derive locally. On the known call paths (B20 tokens querying `isAuthorized`), the policy ID was already validated at write time via `updatePolicy`, so the extra SLOAD is wasted work.