### PR TITLE
fix(docker): configure dev chain for base rpc

### DIFF
--- a/etc/docker/docker-compose.yml
+++ b/etc/docker/docker-compose.yml
@@ -626,6 +626,9 @@ services:
       - ../../.devnet/l2/configs:/genesis/l2:ro
     environment:
       - OTEL_SERVICE_NAME=base-rpc
+      - BASE_CHAIN_NAME=dev
+      - BASE_CHAIN_L1_CHAIN_ID=${L1_CHAIN_ID}
+      - BASE_CHAIN_L2_CHAIN_ID=${L2_CHAIN_ID}
     entrypoint: /app/base
     command:
       - rpc


### PR DESCRIPTION
`base rpc --chain dev` needs explicit chain metadata because `dev` is not a built-in chain name. 

We pass the devnet chain name and L1/L2 chain IDs into the `base-rpc` service so it can resolve its chain config and become healthy for services that depend on it.