### PR TITLE
fix(policy): policyExists and isAuthorized default instead of revert for invalid IDs

### DIFF
--- a/crates/common/precompiles/src/common/policy.rs
+++ b/crates/common/precompiles/src/common/policy.rs
@@ -6,6 +6,13 @@ use base_precompile_storage::Result;
 use crate::IPolicyRegistry::PolicyType;
 
 /// Minimal read-only policy interface consulted by B-20 tokens on every transfer, mint, and redeem.
+///
+/// # `is_authorized` vs `policy_exists`
+///
+/// These two methods can diverge for never-created BLOCKLIST IDs: `policy_exists` returns `false`
+/// (the slot was never written) while `is_authorized` returns `true` (empty blocklist allows
+/// everyone). Do not gate `is_authorized` calls on a prior `policy_exists` check — call
+/// `is_authorized` directly; it handles all cases correctly on its own.
 pub trait Policy {
     /// Returns `true` if `account` is authorized under the given `policy_id`.
     fn is_authorized(&self, policy_id: u64, account: Address) -> Result<bool>;

--- a/crates/common/precompiles/src/policy/storage.rs
+++ b/crates/common/precompiles/src/policy/storage.rs
@@ -343,8 +343,17 @@ impl PolicyRegistryStorage<'_> {
     }
 
     /// Returns `true` if `account` is authorized under `policy_id`.
+    ///
+    /// Malformed policy IDs (type byte > 1) return `Ok(false)` rather than reverting.
+    ///
+    /// If the policy slot has never been written, the function falls back to default
+    /// semantics for that type: an ALLOWLIST with no members authorizes nobody (`false`),
+    /// a BLOCKLIST with no members blocks nobody (`true`). `PolicyNotFound` is never returned.
     pub fn is_authorized(&self, policy_id: u64, account: Address) -> Result<bool> {
-        Self::require_well_formed(policy_id)?;
+        // Malformed IDs (type byte > 1) are treated as unauthorized rather than reverting.
+        if Self::policy_id_type(policy_id) > PolicyType::ALLOWLIST as u8 {
+            return Ok(false);
+        }
         // Fast-paths for built-in IDs: ALWAYS_ALLOW_ID = 0 is the EVM default for any
         // uninitialized policy field, so this must work before write_builtins() has run.
         if policy_id == Self::ALWAYS_ALLOW_ID {
@@ -353,10 +362,10 @@ impl PolicyRegistryStorage<'_> {
         if policy_id == Self::ALWAYS_BLOCK_ID {
             return Ok(false);
         }
-        let packed = PackedPolicy::from_raw(self.policies.at(&policy_id).read()?);
-        if !packed.exists() {
-            return Err(BasePrecompileError::revert(IPolicyRegistry::PolicyNotFound {}));
-        }
+        // Read membership directly without requiring the policy slot to be written first.
+        // If the slot is unwritten the mapping returns false, which naturally gives:
+        //   ALLOWLIST  => false  (no members => not authorized)
+        //   BLOCKLIST  => !false (no members blocked => authorized)
         let member = self.members.at(&policy_id).at(&account).read()?;
         match Self::policy_id_type(policy_id) {
             Self::ALLOWLIST_TYPE => Ok(member),
@@ -367,12 +376,16 @@ impl PolicyRegistryStorage<'_> {
 
     /// Returns `true` if `policy_id` refers to an existing policy.
     ///
+    /// Malformed policy IDs (type byte > 1) return `Ok(false)` rather than reverting.
     /// Built-in IDs always return `true` via a fast-path, without reading storage.
     /// This is necessary because `ALWAYS_ALLOW_ID = 0` is the EVM default for any
     /// uninitialized policy field, so it must be recognized as valid before
     /// `write_builtins` has run.
     pub fn policy_exists(&self, policy_id: u64) -> Result<bool> {
-        Self::require_well_formed(policy_id)?;
+        // Malformed IDs (type byte > 1) are not well-formed, so they do not exist.
+        if Self::policy_id_type(policy_id) > PolicyType::ALLOWLIST as u8 {
+            return Ok(false);
+        }
         if policy_id == Self::ALWAYS_ALLOW_ID || policy_id == Self::ALWAYS_BLOCK_ID {
             return Ok(true);
         }
@@ -600,13 +613,43 @@ mod tests {
     }
 
     #[test]
-    fn unknown_policy_id_returns_policy_not_found() {
+    fn unknown_blocklist_policy_id_authorizes_account() {
+        // 0xdeadbeef has type byte 0 (BLOCKLIST); no members blocked => authorized.
         let mut s = storage();
-        let err = StorageCtx::enter(&mut s, |ctx| {
-            PolicyRegistryStorage::new(ctx).is_authorized(0xdeadbeef, ALICE)
+        assert!(is_authorized(&mut s, 0xdeadbeef, ALICE));
+    }
+
+    #[test]
+    fn unknown_allowlist_policy_id_does_not_authorize_account() {
+        // A well-formed ALLOWLIST ID that was never written to storage.
+        // No members exist => not authorized.
+        let unknown_allowlist = PolicyRegistryStorage::make_id(PolicyType::ALLOWLIST as u8, 9999);
+        let mut s = storage();
+        assert!(!is_authorized(&mut s, unknown_allowlist, ALICE));
+    }
+
+    #[test]
+    fn malformed_policy_id_is_authorized_returns_false() {
+        // Type byte > 1 => malformed; is_authorized must return false, not revert.
+        let malformed: u64 = (2u64 << 56) | 42;
+        let mut s = storage();
+        let result = StorageCtx::enter(&mut s, |ctx| {
+            PolicyRegistryStorage::new(ctx).is_authorized(malformed, ALICE)
         })
-        .unwrap_err();
-        assert!(matches!(err, BasePrecompileError::Revert(_)));
+        .unwrap();
+        assert!(!result);
+    }
+
+    #[test]
+    fn malformed_policy_id_policy_exists_returns_false() {
+        // Type byte > 1 => malformed; policy_exists must return false, not revert.
+        let malformed: u64 = (5u64 << 56) | 100;
+        let mut s = storage();
+        let result = StorageCtx::enter(&mut s, |ctx| {
+            PolicyRegistryStorage::new(ctx).policy_exists(malformed)
+        })
+        .unwrap();
+        assert!(!result);
     }
 
     // --- write_builtins initialization ---

--- a/crates/common/precompiles/src/policy/storage.rs
+++ b/crates/common/precompiles/src/policy/storage.rs
@@ -370,7 +370,7 @@ impl PolicyRegistryStorage<'_> {
         match Self::policy_id_type(policy_id) {
             Self::ALLOWLIST_TYPE => Ok(member),
             Self::BLOCKLIST_TYPE => Ok(!member),
-            _ => Err(BasePrecompileError::enum_conversion_error()),
+            _ => unreachable!("type byte > 1 was rejected by the malformed-ID guard above"),
         }
     }
 


### PR DESCRIPTION
## Motivation

`policy_exists` and `is_authorized` currently revert for malformed policy IDs (type byte out of range) and for non-existent policies. Reverting makes these methods difficult to use safely as view calls without prior existence validation. The cleaner behavior is to return a meaningful default.

## What changed

- `policy_exists`: malformed policy ID (type byte > 1) now returns `false` instead of reverting with `MalformedPolicyId`.
- `is_authorized`: two changes:
  - Malformed policy ID returns `false` instead of reverting.
  - Existence check removed. An unwritten policy slot now behaves as an empty policy: ALLOWLIST with no members denies everyone, BLOCKLIST with no members allows everyone. `PolicyNotFound` is no longer returned. The `ALWAYS_ALLOW_ID` and `ALWAYS_BLOCK_ID` fast-paths are preserved.

## What was tried / considered

- Keeping the reverts: forces every caller to pre-check existence, which is awkward for view calls and redundant given B20 already enforces policy existence at the token layer when updating.
- Returning a sentinel error code instead of a default: adds complexity with no benefit over a clean boolean default.