### PR TITLE
fix(policy): policyAdmin and pendingPolicyAdmin return address(0) for invalid IDs

### DIFF
--- a/crates/common/precompiles/src/common/policy.rs
+++ b/crates/common/precompiles/src/common/policy.rs
@@ -48,8 +48,6 @@ pub trait PolicyRegistry: Policy {
         blocked: bool,
         accounts: alloc::vec::Vec<Address>,
     ) -> Result<()>;
-    /// Returns the `PolicyType` of `policy_id`.
-    fn get_policy_type(&self, policy_id: u64) -> Result<PolicyType>;
     /// Returns the current admin of `policy_id`, or `address(0)` if the policy does not exist
     /// or the policy ID is malformed. Never reverts.
     fn get_policy_admin(&self, policy_id: u64) -> Result<Address>;

--- a/crates/common/precompiles/src/common/policy.rs
+++ b/crates/common/precompiles/src/common/policy.rs
@@ -48,8 +48,12 @@ pub trait PolicyRegistry: Policy {
         blocked: bool,
         accounts: alloc::vec::Vec<Address>,
     ) -> Result<()>;
-    /// Returns the current admin of `policy_id`.
+    /// Returns the `PolicyType` of `policy_id`.
+    fn get_policy_type(&self, policy_id: u64) -> Result<PolicyType>;
+    /// Returns the current admin of `policy_id`, or `address(0)` if the policy does not exist
+    /// or the policy ID is malformed. Never reverts.
     fn get_policy_admin(&self, policy_id: u64) -> Result<Address>;
-    /// Returns the staged pending admin for `policy_id`, or `address(0)` if none.
+    /// Returns the staged pending admin for `policy_id`, or `address(0)` if none, the policy
+    /// does not exist, or the policy ID is malformed. Never reverts.
     fn pending_policy_admin(&self, policy_id: u64) -> Result<Address>;
 }

--- a/crates/common/precompiles/src/policy/storage.rs
+++ b/crates/common/precompiles/src/policy/storage.rs
@@ -1080,6 +1080,19 @@ mod tests {
         assert_eq!(pending, Address::ZERO);
     }
 
+    #[test]
+    fn pending_policy_admin_nonexistent_well_formed_policy_returns_zero_address() {
+        // A well-formed ID (type byte in range) that was never created: storage
+        // slot is unwritten, so the read returns Address::ZERO without reverting.
+        let mut s = storage();
+        let nonexistent = PolicyRegistryStorage::make_id(0, 999);
+        let pending = StorageCtx::enter(&mut s, |ctx| {
+            PolicyRegistryStorage::new(ctx).pending_policy_admin(nonexistent)
+        })
+        .unwrap();
+        assert_eq!(pending, Address::ZERO);
+    }
+
     // --- builtin policies block mutations via Unauthorized ---
 
     #[test]

--- a/crates/common/precompiles/src/policy/storage.rs
+++ b/crates/common/precompiles/src/policy/storage.rs
@@ -380,18 +380,29 @@ impl PolicyRegistryStorage<'_> {
     }
 
     /// Returns the current admin of `policy_id`, or `address(0)` for policies with renounced admin.
+    ///
+    /// Returns `address(0)` without reverting for malformed policy IDs (type byte > 1) and for
+    /// policy IDs that have never been written to storage.
     pub fn get_policy_admin(&self, policy_id: u64) -> Result<Address> {
-        Self::require_well_formed(policy_id)?;
+        if Self::policy_id_type(policy_id) > PolicyType::ALLOWLIST as u8 {
+            return Ok(Address::ZERO);
+        }
         let packed = PackedPolicy::from_raw(self.policies.at(&policy_id).read()?);
         if !packed.exists() {
-            return Err(BasePrecompileError::revert(IPolicyRegistry::PolicyNotFound {}));
+            return Ok(Address::ZERO);
         }
         Ok(packed.admin())
     }
 
     /// Returns the pending admin staged for `policy_id`, or `address(0)` if none.
+    ///
+    /// Returns `address(0)` without reverting for malformed policy IDs (type byte > 1). For
+    /// policy IDs that exist but have no pending transfer, the storage slot returns `address(0)`
+    /// naturally.
     pub fn pending_policy_admin(&self, policy_id: u64) -> Result<Address> {
-        Self::require_well_formed(policy_id)?;
+        if Self::policy_id_type(policy_id) > PolicyType::ALLOWLIST as u8 {
+            return Ok(Address::ZERO);
+        }
         self.pending_admins.at(&policy_id).read()
     }
 }
@@ -1030,6 +1041,40 @@ mod tests {
         let mut s = storage();
         let pending = StorageCtx::enter(&mut s, |ctx| {
             PolicyRegistryStorage::new(ctx).pending_policy_admin(0xdeadbeef)
+        })
+        .unwrap();
+        assert_eq!(pending, Address::ZERO);
+    }
+
+    // A policy ID whose type byte is 2 (> ALLOWLIST=1) is malformed.
+    const MALFORMED_POLICY_ID: u64 = (2u64 << 56) | 42;
+
+    #[test]
+    fn get_policy_admin_malformed_policy_id_returns_zero_address() {
+        let mut s = storage();
+        let admin = StorageCtx::enter(&mut s, |ctx| {
+            PolicyRegistryStorage::new(ctx).get_policy_admin(MALFORMED_POLICY_ID)
+        })
+        .unwrap();
+        assert_eq!(admin, Address::ZERO);
+    }
+
+    #[test]
+    fn get_policy_admin_nonexistent_policy_returns_zero_address() {
+        let mut s = storage();
+        // 0xdeadbeef has type byte 0, so it is well-formed but was never created.
+        let admin = StorageCtx::enter(&mut s, |ctx| {
+            PolicyRegistryStorage::new(ctx).get_policy_admin(0xdeadbeef)
+        })
+        .unwrap();
+        assert_eq!(admin, Address::ZERO);
+    }
+
+    #[test]
+    fn pending_policy_admin_malformed_policy_id_returns_zero_address() {
+        let mut s = storage();
+        let pending = StorageCtx::enter(&mut s, |ctx| {
+            PolicyRegistryStorage::new(ctx).pending_policy_admin(MALFORMED_POLICY_ID)
         })
         .unwrap();
         assert_eq!(pending, Address::ZERO);

--- a/crates/proof/succinct/elf/manifest.toml
+++ b/crates/proof/succinct/elf/manifest.toml
@@ -17,7 +17,7 @@
 
 [[elfs]]
 name = "range-elf-embedded"
-sha256 = "015c968f88a1a39e41e81b3a4e68867000c5ade1527b596abf338a90cc0b2e63"
+sha256 = "2ce6a3d8d7de8694e064f957e1d6a3b07e71d317190ce9d172608f0e72812e20"
 
 [[elfs]]
 name = "aggregation-elf"


### PR DESCRIPTION
## Motivation

`get_policy_admin` and `pending_policy_admin` currently revert for malformed policy IDs and non-existent policies. Returning `address(0)` is a cleaner default: it accurately represents a renounced or absent admin without forcing callers to guard with existence checks first.

## What changed

- `get_policy_admin`: malformed ID (type byte > 1) and non-existent policy both return `address(0)` instead of reverting.
- `pending_policy_admin`: malformed ID returns `address(0)` instead of reverting. Non-existent policies already returned `address(0)` naturally via unwritten storage slots.

## What was tried / considered

- Keeping the reverts: forces callers to pre-validate existence before querying admin, which is awkward for view-only contexts.
- Returning a distinct sentinel: no benefit over `address(0)`, which already means "no admin" throughout the policy system.