### PR TITLE
fix(precompiles): Namespace Policy Registry Storage

### DIFF
--- a/actions/harness/tests/beryl/factory.rs
+++ b/actions/harness/tests/beryl/factory.rs
@@ -206,8 +206,7 @@ async fn token_factory_views_and_events_are_available_after_beryl_activation() {
         ),
         BerylTestEnv::B20_PROBE_GAS_LIMIT,
     );
-    let block8 =
-        env.sequencer.build_next_block_with_transactions(vec![is_not_initialized]).await;
+    let block8 = env.sequencer.build_next_block_with_transactions(vec![is_not_initialized]).await;
 
     assert!(env.probe_call_succeeded(probe), "isInitialized(non-token) staticcall must succeed");
     assert_eq!(env.probe_return_word(probe), U256::ZERO, "non-token must not be initialized");

--- a/actions/harness/tests/beryl/factory.rs
+++ b/actions/harness/tests/beryl/factory.rs
@@ -189,35 +189,28 @@ async fn token_factory_views_and_events_are_available_after_beryl_activation() {
     assert!(env.probe_call_succeeded(probe), "isB20(non-token) staticcall must succeed");
     assert_eq!(env.probe_return_word(probe), U256::ZERO, "factory singleton must not be B-20");
 
-    let get_variant = env.call_staticcall_probe_tx(
+    let is_initialized = env.call_staticcall_probe_tx(
         probe,
-        Bytes::from(ITokenFactory::getTokenVariantCall { token }.abi_encode()),
+        Bytes::from(ITokenFactory::isInitializedCall { token }.abi_encode()),
         BerylTestEnv::B20_PROBE_GAS_LIMIT,
     );
-    let block7 = env.sequencer.build_next_block_with_transactions(vec![get_variant]).await;
+    let block7 = env.sequencer.build_next_block_with_transactions(vec![is_initialized]).await;
 
-    assert!(env.probe_call_succeeded(probe), "getTokenVariant() staticcall must succeed");
-    assert_eq!(
-        env.probe_return_word(probe),
-        U256::from(ITokenFactory::TokenVariant::DEFAULT as u8),
-        "created token variant must be DEFAULT"
-    );
+    assert!(env.probe_call_succeeded(probe), "isInitialized() staticcall must succeed");
+    assert_eq!(env.probe_return_word(probe), U256::ONE, "created token must be initialized");
 
-    let get_none_variant = env.call_staticcall_probe_tx(
+    let is_not_initialized = env.call_staticcall_probe_tx(
         probe,
         Bytes::from(
-            ITokenFactory::getTokenVariantCall { token: Address::repeat_byte(0xab) }.abi_encode(),
+            ITokenFactory::isInitializedCall { token: Address::repeat_byte(0xab) }.abi_encode(),
         ),
         BerylTestEnv::B20_PROBE_GAS_LIMIT,
     );
-    let block8 = env.sequencer.build_next_block_with_transactions(vec![get_none_variant]).await;
+    let block8 =
+        env.sequencer.build_next_block_with_transactions(vec![is_not_initialized]).await;
 
-    assert!(env.probe_call_succeeded(probe), "getTokenVariant(non-token) staticcall must succeed");
-    assert_eq!(
-        env.probe_return_word(probe),
-        U256::from(ITokenFactory::TokenVariant::NONE as u8),
-        "non-token variant must be NONE"
-    );
+    assert!(env.probe_call_succeeded(probe), "isInitialized(non-token) staticcall must succeed");
+    assert_eq!(env.probe_return_word(probe), U256::ZERO, "non-token must not be initialized");
 
     let invalid_variant_create = env.create_tx(
         TxKind::Call(TokenFactoryStorage::ADDRESS),

--- a/crates/common/precompiles/src/policy/storage.rs
+++ b/crates/common/precompiles/src/policy/storage.rs
@@ -54,6 +54,7 @@ impl PackedPolicy {
 ///
 /// Slots are append-only — never reorder across hardforks.
 #[contract(addr = Self::ADDRESS)]
+#[namespace("base.policy_registry")]
 pub struct PolicyRegistryStorage {
     pub policies: Mapping<u64, U256>,                  // slot 0
     pub members: Mapping<u64, Mapping<Address, bool>>, // slot 1
@@ -472,9 +473,9 @@ impl crate::PolicyRegistry for PolicyRegistryStorage<'_> {
 
 #[cfg(test)]
 mod tests {
-    use alloy_primitives::{Address, U256, address};
+    use alloy_primitives::{Address, U256, address, uint};
     use alloy_sol_types::SolEvent;
-    use base_precompile_storage::{HashMapStorageProvider, StorageCtx};
+    use base_precompile_storage::{HashMapStorageProvider, StorageCtx, StorageKey};
 
     use super::*;
     use crate::IPolicyRegistry;
@@ -520,6 +521,8 @@ mod tests {
     const ALICE: Address = address!("0xA000000000000000000000000000000000000001");
     const BOB: Address = address!("0xB000000000000000000000000000000000000001");
     const NEW_ADMIN: Address = address!("0x2000000000000000000000000000000000000002");
+    const POLICY_REGISTRY_ROOT: U256 =
+        uint!(0x00503aeb06982fa1fe3151dc68f90b3946c55c449dfd447e49dcaece71ba4a00_U256);
 
     /// Returns a storage provider with both built-in policies pre-written.
     fn storage() -> HashMapStorageProvider {
@@ -548,6 +551,36 @@ mod tests {
             PolicyRegistryStorage::new(ctx).is_authorized(policy_id, account)
         })
         .unwrap()
+    }
+
+    #[test]
+    fn policy_registry_namespace_matches_base_std_root() {
+        assert_eq!(slots::POLICIES, POLICY_REGISTRY_ROOT);
+        assert_eq!(slots::MEMBERS, POLICY_REGISTRY_ROOT + U256::from(1));
+        assert_eq!(slots::PENDING_ADMINS, POLICY_REGISTRY_ROOT + U256::from(2));
+        assert_eq!(slots::NEXT_COUNTER, POLICY_REGISTRY_ROOT + U256::from(3));
+    }
+
+    #[test]
+    fn policy_registry_writes_use_base_std_namespace_slots() {
+        let mut s = storage();
+        let id = create_allowlist(&mut s);
+
+        StorageCtx::enter(&mut s, |ctx| {
+            assert_ne!(
+                ctx.sload(PolicyRegistryStorage::ADDRESS, id.mapping_slot(slots::POLICIES))
+                    .unwrap(),
+                U256::ZERO
+            );
+            assert_eq!(
+                ctx.sload(PolicyRegistryStorage::ADDRESS, slots::NEXT_COUNTER).unwrap(),
+                U256::from(3)
+            );
+            assert_eq!(
+                ctx.sload(PolicyRegistryStorage::ADDRESS, id.mapping_slot(U256::ZERO)).unwrap(),
+                U256::ZERO
+            );
+        });
     }
 
     // --- built-in IDs ---

--- a/crates/proof/succinct/elf/manifest.toml
+++ b/crates/proof/succinct/elf/manifest.toml
@@ -17,7 +17,7 @@
 
 [[elfs]]
 name = "range-elf-embedded"
-sha256 = "2ce6a3d8d7de8694e064f957e1d6a3b07e71d317190ce9d172608f0e72812e20"
+sha256 = "06ce15cd69ac8dbf7cd4ca8fd4309715ff877a19868ba5233878a94b446babee"
 
 [[elfs]]
 name = "aggregation-elf"

--- a/devnet/src/b20.rs
+++ b/devnet/src/b20.rs
@@ -213,14 +213,9 @@ impl<'a> B20PrecompileClient<'a> {
             .wrap_err("Failed to decode balanceOf")
     }
 
-    /// Reads the variant encoded in a token address via the factory.
+    /// Reads the variant encoded in a token address.
     pub async fn variant_of(&self, token: Address) -> Result<TokenVariant> {
-        let output = self
-            .call(TokenFactoryStorage::ADDRESS, ITokenFactory::getTokenVariantCall { token })
-            .await?;
-        let variant = ITokenFactory::getTokenVariantCall::abi_decode_returns(output.as_ref())
-            .wrap_err("Failed to decode getTokenVariant")?;
-        TokenVariant::from_abi(variant).map_err(|_| eyre::eyre!("invalid B-20 variant"))
+        TokenVariant::from_address(token).wrap_err("Token address is not a supported B-20 token")
     }
 
     /// Reads the fixed decimals for the token variant encoded in an address.


### PR DESCRIPTION
## Summary

This fixes the policy registry precompile storage layout by rooting it at the base.policy_registry ERC-7201 namespace used by the base-std mock. The change keeps the field order unchanged while moving the absolute slots for policies, members, pending admins, and the counter to the canonical namespace root. It also adds coverage for generated slots and real writes landing under the namespaced mapping slots.