### PR TITLE
fix(ci): Disable SP1 ELF Checks

### DIFF
--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -109,6 +109,8 @@ jobs:
 
   succinct-elf-manifest:
     name: SP1 ELF Manifest
+    # Temporarily disabled while SP1 ELF manifest hashing is unstable.
+    if: ${{ false }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -238,7 +240,6 @@ jobs:
     name: Build
     runs-on:
       group: BasePerfRunnerGroup
-    needs: succinct-elf-manifest
     env:
       BASE_REF: ${{ inputs.base_ref }}
     steps:
@@ -298,7 +299,6 @@ jobs:
     name: Test
     runs-on:
       group: BasePerfRunnerGroup
-    needs: succinct-elf-manifest
     env:
       BASE_REF: ${{ inputs.base_ref }}
     steps:
@@ -416,7 +416,6 @@ jobs:
     if: inputs.run_devnet
     runs-on:
       group: BasePerfRunnerGroup
-    needs: succinct-elf-manifest
     timeout-minutes: 60
     steps:
       - name: Harden the runner (Audit all outbound calls)

--- a/Justfile
+++ b/Justfile
@@ -127,11 +127,11 @@ test-affected base="main": install-nextest build::contracts build::elfs
     cargo nextest run --all-features "${pkg_args[@]}"
 
 # Runs tests with ci profile for minimal disk usage
-test-ci: install-nextest build::contracts build::elfs
+test-ci: install-nextest build::contracts
     cargo nextest run -P ci --locked --workspace --all-features --exclude devnet --cargo-profile ci
 
 # Runs tests only for affected crates with ci profile (for PRs)
-test-affected-ci base="main": install-nextest build::contracts build::elfs
+test-affected-ci base="main": install-nextest build::contracts
     #!/usr/bin/env bash
     set -euo pipefail
     pkg_args_output="$(python3 etc/scripts/local/affected-crates.py {{ base }} --exclude devnet --cargo-args)"

--- a/etc/just/build.just
+++ b/etc/just/build.just
@@ -11,11 +11,11 @@ all-targets: contracts elfs
     cargo build --workspace --all-targets
 
 # Builds all targets with ci profile
-ci: contracts elfs
+ci: contracts
     cargo build --locked --workspace --all-targets --profile ci
 
 # Builds only affected packages with ci profile
-affected-ci base="main": contracts elfs
+affected-ci base="main": contracts
     #!/usr/bin/env bash
     set -euo pipefail
     pkg_args_output="$(python3 {{justfile_directory()}}/etc/scripts/local/affected-crates.py {{ base }} --cargo-args)"


### PR DESCRIPTION
## Summary

This temporarily disables the dedicated SP1 ELF manifest CI job while the hash check is unstable. It also removes the SP1 ELF preflight from the CI build and test Just recipes so PR and merge-queue jobs can continue running without the manifest gate.