### PR TITLE
fix(precompiles): Align B20 Interface

### DIFF
--- a/actions/harness/tests/beryl/b20.rs
+++ b/actions/harness/tests/beryl/b20.rs
@@ -363,12 +363,12 @@ async fn b20_extended_mutations_update_state_and_emit_events() {
         amount: U256::from(5),
         memo: MEMO_TRANSFER_FROM,
     });
-    let set_supply_cap = scenario.call_tx(IB20::setSupplyCapCall { newSupplyCap: new_cap });
-    let set_name =
-        scenario.call_tx(IB20::setNameCall { newName: "Action B20 Updated".to_string() });
-    let set_symbol = scenario.call_tx(IB20::setSymbolCall { newSymbol: "AB20U".to_string() });
-    let set_contract_uri =
-        scenario.call_tx(IB20::setContractURICall { newURI: "ipfs://action".to_string() });
+    let update_supply_cap = scenario.call_tx(IB20::updateSupplyCapCall { newSupplyCap: new_cap });
+    let update_name =
+        scenario.call_tx(IB20::updateNameCall { newName: "Action B20 Updated".to_string() });
+    let update_symbol = scenario.call_tx(IB20::updateSymbolCall { newSymbol: "AB20U".to_string() });
+    let update_contract_uri =
+        scenario.call_tx(IB20::updateContractURICall { newURI: "ipfs://action".to_string() });
     let mint =
         scenario.call_tx(IB20::mintCall { to: BerylTestEnv::alice(), amount: U256::from(20) });
     let mint_with_memo = scenario.call_tx(IB20::mintWithMemoCall {
@@ -389,10 +389,10 @@ async fn b20_extended_mutations_update_state_and_emit_events() {
             transfer_with_memo,
             approve_bob,
             transfer_from_with_memo,
-            set_supply_cap,
-            set_name,
-            set_symbol,
-            set_contract_uri,
+            update_supply_cap,
+            update_name,
+            update_symbol,
+            update_contract_uri,
             mint,
             mint_with_memo,
             burn,
@@ -409,8 +409,16 @@ async fn b20_extended_mutations_update_state_and_emit_events() {
         );
     }
 
-    scenario.assert_log(&block, 0, IB20::Memo { memo: MEMO_TRANSFER }.encode_log_data());
-    scenario.assert_log(&block, 2, IB20::Memo { memo: MEMO_TRANSFER_FROM }.encode_log_data());
+    scenario.assert_log(
+        &block,
+        0,
+        IB20::Memo { caller: BerylTestEnv::alice(), memo: MEMO_TRANSFER }.encode_log_data(),
+    );
+    scenario.assert_log(
+        &block,
+        2,
+        IB20::Memo { caller: BerylTestEnv::bob(), memo: MEMO_TRANSFER_FROM }.encode_log_data(),
+    );
     scenario.assert_log(
         &block,
         3,
@@ -437,8 +445,16 @@ async fn b20_extended_mutations_update_state_and_emit_events() {
             .encode_log_data(),
     );
     scenario.assert_log(&block, 6, IB20::ContractURIUpdated {}.encode_log_data());
-    scenario.assert_log(&block, 8, IB20::Memo { memo: MEMO_MINT }.encode_log_data());
-    scenario.assert_log(&block, 10, IB20::Memo { memo: MEMO_BURN }.encode_log_data());
+    scenario.assert_log(
+        &block,
+        8,
+        IB20::Memo { caller: BerylTestEnv::alice(), memo: MEMO_MINT }.encode_log_data(),
+    );
+    scenario.assert_log(
+        &block,
+        10,
+        IB20::Memo { caller: BerylTestEnv::alice(), memo: MEMO_BURN }.encode_log_data(),
+    );
     scenario.assert_log(
         &block,
         11,
@@ -460,6 +476,20 @@ async fn b20_extended_mutations_update_state_and_emit_events() {
 
     scenario.assert_total_supply(initial + 20 + 30 - 2 - 3);
     scenario.assert_allowance(BerylTestEnv::alice(), BerylTestEnv::bob(), 45);
+
+    let zero_mint =
+        scenario.call_tx(IB20::mintCall { to: BerylTestEnv::alice(), amount: U256::ZERO });
+    let zero_burn = scenario.call_tx(IB20::burnCall { amount: U256::ZERO });
+    let block = scenario.build_block_with_transactions(vec![zero_mint, zero_burn]).await;
+
+    for index in 0..2 {
+        assert!(
+            !scenario.env.user_tx_succeeded(&block, index),
+            "zero-amount B-20 mutation {index} must revert"
+        );
+    }
+    scenario.assert_total_supply(initial + 20 + 30 - 2 - 3);
+
     scenario
         .assert_staticcall_cases(vec![
             StaticcallCase::word(

--- a/crates/common/precompiles/benches/base_precompiles.rs
+++ b/crates/common/precompiles/benches/base_precompiles.rs
@@ -381,7 +381,7 @@ fn base_token_mutate(c: &mut Criterion) {
         });
     });
 
-    c.bench_function("base_token_set_supply_cap", |b| {
+    c.bench_function("base_token_update_supply_cap", |b| {
         let mut storage = HashMapStorageProvider::new(1);
         StorageCtx::enter(&mut storage, |ctx| {
             let admin = BaseTokenBenchSetup::admin();
@@ -394,7 +394,7 @@ fn base_token_mutate(c: &mut Criterion) {
             b.iter(|| {
                 let token = black_box(&mut token);
                 let admin = black_box(admin);
-                token.set_supply_cap(admin, U256::from(10_000u64), true).unwrap();
+                token.update_supply_cap(admin, U256::from(10_000u64), true).unwrap();
             });
         });
     });

--- a/crates/common/precompiles/src/b20/abi.rs
+++ b/crates/common/precompiles/src/b20/abi.rs
@@ -26,6 +26,7 @@ sol! {
         error InvalidReceiver(address receiver);
         error InvalidApprover(address approver);
         error InvalidSpender(address spender);
+        error InvalidAmount();
         error EmptyFeatureSet();
         error InvalidSupplyCap(uint256 currentSupply, uint256 proposedCap);
         error SupplyCapExceeded(uint256 cap, uint256 attempted);
@@ -35,7 +36,6 @@ sol! {
         error AccountNotBlocked(address account);
         error ExpiredSignature(uint256 deadline);
         error InvalidSigner(address signer, address owner);
-        error Uninitialized();
         error LastAdminCannotRenounce();
         error NotSoleAdmin();
         error AccessControlBadConfirmation();
@@ -43,7 +43,7 @@ sol! {
         // Events
         event Transfer(address indexed from, address indexed to, uint256 amount);
         event Approval(address indexed owner, address indexed spender, uint256 amount);
-        event Memo(bytes32 indexed memo);
+        event Memo(address indexed caller, bytes32 indexed memo);
         event BurnedBlocked(address indexed caller, address indexed from, uint256 amount);
         event RoleGranted(bytes32 indexed role, address indexed account, address indexed sender);
         event RoleRevoked(bytes32 indexed role, address indexed account, address indexed sender);
@@ -84,8 +84,8 @@ sol! {
         function approve(address spender, uint256 amount) external returns (bool);
 
         // Metadata updates
-        function setName(string calldata newName) external;
-        function setSymbol(string calldata newSymbol) external;
+        function updateName(string calldata newName) external;
+        function updateSymbol(string calldata newSymbol) external;
 
         // Memo transfer variants
         function transferWithMemo(address to, uint256 amount, bytes32 memo) external returns (bool);
@@ -119,7 +119,7 @@ sol! {
 
         // Supply cap
         function supplyCap() external view returns (uint256);
-        function setSupplyCap(uint256 newSupplyCap) external;
+        function updateSupplyCap(uint256 newSupplyCap) external;
 
         // Permit (EIP-2612 + ERC-5267)
         function DOMAIN_SEPARATOR() external view returns (bytes32);
@@ -129,6 +129,6 @@ sol! {
 
         // Contract URI (ERC-7572)
         function contractURI() external view returns (string);
-        function setContractURI(string calldata newURI) external;
+        function updateContractURI(string calldata newURI) external;
     }
 }

--- a/crates/common/precompiles/src/b20/dispatch.rs
+++ b/crates/common/precompiles/src/b20/dispatch.rs
@@ -21,7 +21,7 @@ impl<S: TokenAccounting, P: Policy> B20Token<S, P> {
         match self.accounting.is_initialized() {
             Ok(true) => {}
             Ok(false) => {
-                return BasePrecompileError::revert(IB20::Uninitialized {})
+                return BasePrecompileError::Revert(Bytes::new())
                     .into_precompile_result(ctx.gas_used());
             }
             Err(e) => return e.into_precompile_result(ctx.gas_used()),
@@ -152,24 +152,24 @@ impl<S: TokenAccounting, P: Policy> B20Token<S, P> {
             }
 
             // --- Admin ---
-            C::setSupplyCap(c) => {
+            C::updateSupplyCap(c) => {
                 let caller = ctx.caller();
-                Configurable::set_supply_cap(self, caller, c.newSupplyCap, privileged)?;
+                Configurable::update_supply_cap(self, caller, c.newSupplyCap, privileged)?;
                 Bytes::new()
             }
-            C::setName(c) => {
+            C::updateName(c) => {
                 let caller = ctx.caller();
-                Configurable::set_name(self, caller, c.newName, privileged)?;
+                Configurable::update_name(self, caller, c.newName, privileged)?;
                 Bytes::new()
             }
-            C::setSymbol(c) => {
+            C::updateSymbol(c) => {
                 let caller = ctx.caller();
-                Configurable::set_symbol(self, caller, c.newSymbol, privileged)?;
+                Configurable::update_symbol(self, caller, c.newSymbol, privileged)?;
                 Bytes::new()
             }
-            C::setContractURI(c) => {
+            C::updateContractURI(c) => {
                 let caller = ctx.caller();
-                Configurable::set_contract_uri(self, caller, c.newURI, privileged)?;
+                Configurable::update_contract_uri(self, caller, c.newURI, privileged)?;
                 Bytes::new()
             }
             C::grantRole(c) => {

--- a/crates/common/precompiles/src/b20_security/dispatch.rs
+++ b/crates/common/precompiles/src/b20_security/dispatch.rs
@@ -78,7 +78,7 @@ impl<S: SecurityAccounting, P: Policy> B20SecurityToken<S, P> {
         match self.accounting.is_initialized() {
             Ok(true) => {}
             Ok(false) => {
-                return BasePrecompileError::revert(IB20::Uninitialized {})
+                return BasePrecompileError::Revert(Bytes::new())
                     .into_precompile_result(ctx.gas_used());
             }
             Err(e) => return e.into_precompile_result(ctx.gas_used()),
@@ -230,24 +230,24 @@ impl<S: SecurityAccounting, P: Policy> B20SecurityToken<S, P> {
             }
 
             // --- Admin ---
-            C::setSupplyCap(c) => {
+            C::updateSupplyCap(c) => {
                 let caller = ctx.caller();
-                Configurable::set_supply_cap(self, caller, c.newSupplyCap, privileged)?;
+                Configurable::update_supply_cap(self, caller, c.newSupplyCap, privileged)?;
                 Bytes::new()
             }
-            C::setName(c) => {
+            C::updateName(c) => {
                 let caller = ctx.caller();
-                Configurable::set_name(self, caller, c.newName, privileged)?;
+                Configurable::update_name(self, caller, c.newName, privileged)?;
                 Bytes::new()
             }
-            C::setSymbol(c) => {
+            C::updateSymbol(c) => {
                 let caller = ctx.caller();
-                Configurable::set_symbol(self, caller, c.newSymbol, privileged)?;
+                Configurable::update_symbol(self, caller, c.newSymbol, privileged)?;
                 Bytes::new()
             }
-            C::setContractURI(c) => {
+            C::updateContractURI(c) => {
                 let caller = ctx.caller();
-                Configurable::set_contract_uri(self, caller, c.newURI, privileged)?;
+                Configurable::update_contract_uri(self, caller, c.newURI, privileged)?;
                 Bytes::new()
             }
 
@@ -379,7 +379,8 @@ impl<S: SecurityAccounting, P: Policy> B20SecurityToken<S, P> {
             SC::redeemWithMemo(c) => {
                 let caller = ctx.caller();
                 self.security_redeem(caller, c.amount)?;
-                self.accounting_mut().emit_event(IB20::Memo { memo: c.memo }.encode_log_data())?;
+                self.accounting_mut()
+                    .emit_event(IB20::Memo { caller, memo: c.memo }.encode_log_data())?;
                 Bytes::new()
             }
 
@@ -430,6 +431,9 @@ impl<S: SecurityAccounting, P: Policy> B20SecurityToken<S, P> {
         caller: Address,
         amount: U256,
     ) -> base_precompile_storage::Result<()> {
+        if amount.is_zero() {
+            return Err(BasePrecompileError::revert(IB20::InvalidAmount {}));
+        }
         let ratio = self.accounting.shares_to_tokens_ratio()?;
         let shares = amount.saturating_mul(ratio) / WAD;
         let minimum = self.accounting.minimum_redeemable()?;
@@ -502,6 +506,9 @@ impl<S: SecurityAccounting, P: Policy> B20SecurityToken<S, P> {
             }));
         }
         for (account, amount) in accounts.into_iter().zip(amounts) {
+            if amount.is_zero() {
+                return Err(BasePrecompileError::revert(IB20::InvalidAmount {}));
+            }
             let balance = self.accounting.balance_of(account)?;
             if balance < amount {
                 return Err(BasePrecompileError::revert(IB20::InsufficientBalance {
@@ -594,9 +601,10 @@ impl<S: SecurityAccounting, P: Policy> B20SecurityToken<S, P> {
 #[cfg(test)]
 mod tests {
     use alloy_primitives::{Address, U256};
+    use base_precompile_storage::BasePrecompileError;
 
     use crate::{
-        Token, TokenAccounting,
+        IB20, Token, TokenAccounting,
         b20_security::{B20SecurityToken, SecurityAccounting},
         common::test_utils::{InMemoryPolicy, InMemoryTokenAccounting},
     };
@@ -753,6 +761,16 @@ mod tests {
         );
     }
 
+    #[test]
+    fn batch_mint_test_rejects_zero_amount() {
+        let mut token = make_token();
+
+        assert_eq!(
+            token.batch_mint_test(alloc::vec![ALICE], alloc::vec![U256::ZERO]).unwrap_err(),
+            BasePrecompileError::revert(IB20::InvalidAmount {})
+        );
+    }
+
     // --- batchBurn: EmptyBatch / LengthMismatch / multi-account Transfer events ---
 
     #[test]
@@ -765,6 +783,20 @@ mod tests {
     fn batch_burn_rejects_length_mismatch() {
         let mut token = make_token();
         assert!(token.batch_burn(alloc::vec![ALICE], alloc::vec![U256::ONE, U256::ONE]).is_err());
+    }
+
+    #[test]
+    fn batch_burn_rejects_zero_amount() {
+        let mut token = make_token();
+        token.accounting_mut().balances.insert(ALICE, U256::from(100u64));
+        token.accounting_mut().total_supply = U256::from(100u64);
+
+        assert_eq!(
+            token.batch_burn(alloc::vec![ALICE], alloc::vec![U256::ZERO]).unwrap_err(),
+            BasePrecompileError::revert(IB20::InvalidAmount {})
+        );
+        assert_eq!(token.accounting().balance_of(ALICE).unwrap(), U256::from(100u64));
+        assert_eq!(token.accounting().events.len(), 0);
     }
 
     #[test]
@@ -796,6 +828,18 @@ mod tests {
         assert!(token.security_redeem(ALICE, U256::from(100u64)).is_err());
         // no state mutation on failure
         assert_eq!(token.accounting().balance_of(ALICE).unwrap(), U256::from(10u64));
+    }
+
+    #[test]
+    fn security_redeem_rejects_zero_amount() {
+        let mut token = make_token();
+        token.accounting_mut().balances.insert(ALICE, U256::from(10u64));
+        token.accounting_mut().total_supply = U256::from(10u64);
+
+        assert_eq!(
+            token.security_redeem(ALICE, U256::ZERO).unwrap_err(),
+            BasePrecompileError::revert(IB20::InvalidAmount {})
+        );
     }
 
     #[test]

--- a/crates/common/precompiles/src/b20_stablecoin/dispatch.rs
+++ b/crates/common/precompiles/src/b20_stablecoin/dispatch.rs
@@ -30,7 +30,7 @@ impl<S: StablecoinAccounting, P: Policy> B20StablecoinToken<S, P> {
         match self.accounting.is_initialized() {
             Ok(true) => {}
             Ok(false) => {
-                return BasePrecompileError::revert(IB20::Uninitialized {})
+                return BasePrecompileError::Revert(Bytes::new())
                     .into_precompile_result(ctx.gas_used());
             }
             Err(e) => return e.into_precompile_result(ctx.gas_used()),
@@ -166,24 +166,24 @@ impl<S: StablecoinAccounting, P: Policy> B20StablecoinToken<S, P> {
             }
 
             // --- Admin ---
-            C::setSupplyCap(c) => {
+            C::updateSupplyCap(c) => {
                 let caller = ctx.caller();
-                Configurable::set_supply_cap(self, caller, c.newSupplyCap, privileged)?;
+                Configurable::update_supply_cap(self, caller, c.newSupplyCap, privileged)?;
                 Bytes::new()
             }
-            C::setName(c) => {
+            C::updateName(c) => {
                 let caller = ctx.caller();
-                Configurable::set_name(self, caller, c.newName, privileged)?;
+                Configurable::update_name(self, caller, c.newName, privileged)?;
                 Bytes::new()
             }
-            C::setSymbol(c) => {
+            C::updateSymbol(c) => {
                 let caller = ctx.caller();
-                Configurable::set_symbol(self, caller, c.newSymbol, privileged)?;
+                Configurable::update_symbol(self, caller, c.newSymbol, privileged)?;
                 Bytes::new()
             }
-            C::setContractURI(c) => {
+            C::updateContractURI(c) => {
                 let caller = ctx.caller();
-                Configurable::set_contract_uri(self, caller, c.newURI, privileged)?;
+                Configurable::update_contract_uri(self, caller, c.newURI, privileged)?;
                 Bytes::new()
             }
             C::grantRole(c) => {

--- a/crates/common/precompiles/src/common/ops/burnable.rs
+++ b/crates/common/precompiles/src/common/ops/burnable.rs
@@ -22,6 +22,9 @@ pub trait Burnable: Token {
             B20Guards::ensure_token_role::<Self>(self, caller, B20TokenRole::Burn)?;
         }
         B20Guards::ensure_not_paused::<Self>(self, IB20::PausableFeature::BURN)?;
+        if amount.is_zero() {
+            return Err(BasePrecompileError::revert(IB20::InvalidAmount {}));
+        }
         let balance = self.accounting().balance_of(from)?;
         if balance < amount {
             return Err(BasePrecompileError::revert(IB20::InsufficientBalance {
@@ -49,7 +52,7 @@ pub trait Burnable: Token {
         privileged: bool,
     ) -> Result<()> {
         self.burn(caller, from, amount, privileged)?;
-        self.accounting_mut().emit_event(IB20::Memo { memo }.encode_log_data())
+        self.accounting_mut().emit_event(IB20::Memo { caller, memo }.encode_log_data())
     }
 
     /// Destroys `amount` from a policy-blocked account. Emits `Transfer` and `BurnedBlocked`.
@@ -117,6 +120,16 @@ mod tests {
     }
 
     #[test]
+    fn burn_zero_amount_reverts() {
+        let mut token = token_with_balance(U256::from(100u64));
+
+        assert_eq!(
+            token.burn(CALLER, ALICE, U256::ZERO, true).unwrap_err(),
+            BasePrecompileError::revert(IB20::InvalidAmount {})
+        );
+    }
+
+    #[test]
     fn burn_insufficient_balance_reverts() {
         let mut token = token_with_balance(U256::from(10u64));
 
@@ -175,6 +188,22 @@ mod tests {
         assert_eq!(
             token.burn_blocked(CALLER, ALICE, U256::ONE, true).unwrap_err(),
             BasePrecompileError::revert(IB20::AccountNotBlocked { account: ALICE })
+        );
+    }
+
+    #[test]
+    fn burn_blocked_zero_amount_reverts() {
+        let mut accounting = InMemoryTokenAccounting::new(TOKEN_ADDR);
+        accounting.balances.insert(ALICE, U256::from(10u64));
+        accounting.total_supply = U256::from(10u64);
+        accounting
+            .policy_ids
+            .insert(B20PolicyType::TransferSender.id(), PolicyRegistryStorage::ALWAYS_BLOCK_ID);
+        let mut token = TestToken::with_storage_and_policy(accounting, InMemoryPolicy::new());
+
+        assert_eq!(
+            token.burn_blocked(CALLER, ALICE, U256::ZERO, true).unwrap_err(),
+            BasePrecompileError::revert(IB20::InvalidAmount {})
         );
     }
 

--- a/crates/common/precompiles/src/common/ops/configurable.rs
+++ b/crates/common/precompiles/src/common/ops/configurable.rs
@@ -13,7 +13,12 @@ use crate::{B20TokenRole, IB20, Token, TokenAccounting};
 /// Implement with an empty body to opt in.
 pub trait Configurable: Token {
     /// Updates the supply cap. Requires `DEFAULT_ADMIN_ROLE`. Emits `SupplyCapUpdated`.
-    fn set_supply_cap(&mut self, caller: Address, new_cap: U256, privileged: bool) -> Result<()> {
+    fn update_supply_cap(
+        &mut self,
+        caller: Address,
+        new_cap: U256,
+        privileged: bool,
+    ) -> Result<()> {
         if !privileged {
             B20Guards::ensure_token_role::<Self>(self, caller, B20TokenRole::DefaultAdmin)?;
         }
@@ -33,7 +38,7 @@ pub trait Configurable: Token {
     }
 
     /// Updates the token name. Emits `NameUpdated`.
-    fn set_name(&mut self, caller: Address, name: String, privileged: bool) -> Result<()> {
+    fn update_name(&mut self, caller: Address, name: String, privileged: bool) -> Result<()> {
         if !privileged {
             B20Guards::ensure_token_role::<Self>(self, caller, B20TokenRole::Metadata)?;
         }
@@ -43,7 +48,7 @@ pub trait Configurable: Token {
     }
 
     /// Updates the token symbol. Emits `SymbolUpdated`.
-    fn set_symbol(&mut self, caller: Address, symbol: String, privileged: bool) -> Result<()> {
+    fn update_symbol(&mut self, caller: Address, symbol: String, privileged: bool) -> Result<()> {
         if !privileged {
             B20Guards::ensure_token_role::<Self>(self, caller, B20TokenRole::Metadata)?;
         }
@@ -54,7 +59,12 @@ pub trait Configurable: Token {
     }
 
     /// Updates the contract URI. Emits `ContractURIUpdated`.
-    fn set_contract_uri(&mut self, caller: Address, uri: String, privileged: bool) -> Result<()> {
+    fn update_contract_uri(
+        &mut self,
+        caller: Address,
+        uri: String,
+        privileged: bool,
+    ) -> Result<()> {
         if !privileged {
             B20Guards::ensure_token_role::<Self>(self, caller, B20TokenRole::DefaultAdmin)?;
         }
@@ -94,22 +104,22 @@ mod tests {
     }
 
     #[test]
-    fn set_supply_cap_updates_cap_and_emits_event() {
+    fn update_supply_cap_updates_cap_and_emits_event() {
         let mut token = make_token();
 
-        token.set_supply_cap(CALLER, U256::from(500u64), true).unwrap();
+        token.update_supply_cap(CALLER, U256::from(500u64), true).unwrap();
 
         assert_eq!(token.accounting().supply_cap().unwrap(), U256::from(500u64));
         assert_eq!(token.accounting().events.len(), 1);
     }
 
     #[test]
-    fn set_supply_cap_below_current_supply_reverts() {
+    fn update_supply_cap_below_current_supply_reverts() {
         let mut token = make_token();
         token.accounting_mut().total_supply = U256::from(100u64);
 
         assert_eq!(
-            token.set_supply_cap(CALLER, U256::from(99u64), true).unwrap_err(),
+            token.update_supply_cap(CALLER, U256::from(99u64), true).unwrap_err(),
             BasePrecompileError::revert(IB20::InvalidSupplyCap {
                 currentSupply: U256::from(100u64),
                 proposedCap: U256::from(99u64),
@@ -118,30 +128,30 @@ mod tests {
     }
 
     #[test]
-    fn set_name_round_trips_and_emits_event() {
+    fn update_name_round_trips_and_emits_event() {
         let mut token = make_token();
 
-        token.set_name(CALLER, "MyToken".into(), true).unwrap();
+        token.update_name(CALLER, "MyToken".into(), true).unwrap();
 
         assert_eq!(token.accounting().name().unwrap(), "MyToken");
         assert_eq!(token.accounting().events.len(), 1);
     }
 
     #[test]
-    fn set_symbol_round_trips_and_emits_event() {
+    fn update_symbol_round_trips_and_emits_event() {
         let mut token = make_token();
 
-        token.set_symbol(CALLER, "MTK".into(), true).unwrap();
+        token.update_symbol(CALLER, "MTK".into(), true).unwrap();
 
         assert_eq!(token.accounting().symbol().unwrap(), "MTK");
         assert_eq!(token.accounting().events.len(), 1);
     }
 
     #[test]
-    fn set_contract_uri_round_trips_and_emits_event() {
+    fn update_contract_uri_round_trips_and_emits_event() {
         let mut token = make_token();
 
-        token.set_contract_uri(CALLER, "ipfs://abc".into(), true).unwrap();
+        token.update_contract_uri(CALLER, "ipfs://abc".into(), true).unwrap();
 
         assert_eq!(token.accounting().contract_uri().unwrap(), "ipfs://abc");
         assert_eq!(token.accounting().events.len(), 1);
@@ -152,7 +162,7 @@ mod tests {
         let mut token = make_token();
 
         assert_eq!(
-            token.set_name(CALLER, "MyToken".into(), false).unwrap_err(),
+            token.update_name(CALLER, "MyToken".into(), false).unwrap_err(),
             BasePrecompileError::revert(IB20::AccessControlUnauthorizedAccount {
                 account: CALLER,
                 neededRole: B20TokenRole::Metadata.id(),
@@ -165,10 +175,10 @@ mod tests {
         let mut token = token_with_default_admin(CALLER);
         token.accounting_mut().roles.insert((B20TokenRole::Metadata.id(), CALLER), true);
 
-        token.set_supply_cap(CALLER, U256::from(500u64), false).unwrap();
-        token.set_name(CALLER, "MyToken".into(), false).unwrap();
-        token.set_symbol(CALLER, "MTK".into(), false).unwrap();
-        token.set_contract_uri(CALLER, "ipfs://abc".into(), false).unwrap();
+        token.update_supply_cap(CALLER, U256::from(500u64), false).unwrap();
+        token.update_name(CALLER, "MyToken".into(), false).unwrap();
+        token.update_symbol(CALLER, "MTK".into(), false).unwrap();
+        token.update_contract_uri(CALLER, "ipfs://abc".into(), false).unwrap();
 
         assert_eq!(token.accounting().supply_cap().unwrap(), U256::from(500u64));
         assert_eq!(token.accounting().name().unwrap(), "MyToken");

--- a/crates/common/precompiles/src/common/ops/mintable.rs
+++ b/crates/common/precompiles/src/common/ops/mintable.rs
@@ -20,6 +20,9 @@ pub trait Mintable: Token {
         if to == Address::ZERO {
             return Err(BasePrecompileError::revert(IB20::InvalidReceiver { receiver: to }));
         }
+        if amount.is_zero() {
+            return Err(BasePrecompileError::revert(IB20::InvalidAmount {}));
+        }
         let supply = self.accounting().total_supply()?;
         let cap = self.accounting().supply_cap()?;
         let new_supply =
@@ -49,7 +52,7 @@ pub trait Mintable: Token {
         privileged: bool,
     ) -> Result<()> {
         self.mint(caller, to, amount, privileged)?;
-        self.accounting_mut().emit_event(IB20::Memo { memo }.encode_log_data())
+        self.accounting_mut().emit_event(IB20::Memo { caller, memo }.encode_log_data())
     }
 }
 
@@ -102,6 +105,16 @@ mod tests {
         assert_eq!(
             token.mint(CALLER, Address::ZERO, U256::ONE, true).unwrap_err(),
             BasePrecompileError::revert(IB20::InvalidReceiver { receiver: Address::ZERO })
+        );
+    }
+
+    #[test]
+    fn mint_zero_amount_reverts() {
+        let mut token = make_token();
+
+        assert_eq!(
+            token.mint(CALLER, ALICE, U256::ZERO, true).unwrap_err(),
+            BasePrecompileError::revert(IB20::InvalidAmount {})
         );
     }
 

--- a/crates/common/precompiles/src/common/ops/roles.rs
+++ b/crates/common/precompiles/src/common/ops/roles.rs
@@ -32,7 +32,7 @@ pub enum B20TokenRole {
     Pause,
     /// Role required for `unpause`.
     Unpause,
-    /// Role required for `setName` and `setSymbol`.
+    /// Role required for `updateName` and `updateSymbol`.
     Metadata,
 }
 
@@ -86,7 +86,7 @@ pub trait RoleManaged: Token {
         B20TokenRole::Unpause.id()
     }
 
-    /// Role required for `setName` and `setSymbol`.
+    /// Role required for `updateName` and `updateSymbol`.
     fn metadata_role() -> B256 {
         B20TokenRole::Metadata.id()
     }

--- a/crates/common/precompiles/src/common/ops/transferable.rs
+++ b/crates/common/precompiles/src/common/ops/transferable.rs
@@ -90,7 +90,7 @@ pub trait Transferable: Token {
         memo: B256,
     ) -> Result<()> {
         self.transfer(from, to, amount)?;
-        self.accounting_mut().emit_event(IB20::Memo { memo }.encode_log_data())
+        self.accounting_mut().emit_event(IB20::Memo { caller: from, memo }.encode_log_data())
     }
 
     /// [`Self::transfer_from`] followed by a `Memo` event.
@@ -103,7 +103,7 @@ pub trait Transferable: Token {
         memo: B256,
     ) -> Result<()> {
         self.transfer_from(spender, from, to, amount)?;
-        self.accounting_mut().emit_event(IB20::Memo { memo }.encode_log_data())
+        self.accounting_mut().emit_event(IB20::Memo { caller: spender, memo }.encode_log_data())
     }
 }
 

--- a/crates/common/precompiles/src/factory/storage.rs
+++ b/crates/common/precompiles/src/factory/storage.rs
@@ -747,7 +747,7 @@ mod tests {
         let salt = B256::repeat_byte(0xDD);
         let mut call = b20_call(salt);
         call.initCalls
-            .push(IB20::setNameCall { newName: "Configured".to_string() }.abi_encode().into());
+            .push(IB20::updateNameCall { newName: "Configured".to_string() }.abi_encode().into());
 
         StorageCtx::enter(&mut storage, |ctx| {
             let mut factory = TokenFactoryStorage::new(ctx);
@@ -882,7 +882,9 @@ mod tests {
                 .into(),
         );
         call.initCalls.push(
-            IB20::setContractURICall { newURI: "ipfs://dispatch".to_string() }.abi_encode().into(),
+            IB20::updateContractURICall { newURI: "ipfs://dispatch".to_string() }
+                .abi_encode()
+                .into(),
         );
 
         let mut storage = HashMapStorageProvider::new(1);
@@ -970,7 +972,7 @@ mod tests {
             let result = token.dispatch(ctx, &IB20::nameCall {}.abi_encode()).unwrap();
 
             assert!(result.reverted);
-            assert_eq!(result.bytes.as_ref(), IB20::Uninitialized {}.abi_encode());
+            assert!(result.bytes.is_empty());
         });
     }
 

--- a/crates/proof/succinct/elf/manifest.toml
+++ b/crates/proof/succinct/elf/manifest.toml
@@ -17,7 +17,7 @@
 
 [[elfs]]
 name = "range-elf-embedded"
-sha256 = "06ce15cd69ac8dbf7cd4ca8fd4309715ff877a19868ba5233878a94b446babee"
+sha256 = "615a5ff8716f4de2bd1b6f1e3b74454bd10f93e38edc5e781ca0b228d334a2a4"
 
 [[elfs]]
 name = "aggregation-elf"

--- a/devnet/src/b20.rs
+++ b/devnet/src/b20.rs
@@ -144,12 +144,13 @@ impl<'a> B20PrecompileClient<'a> {
         }
         if params.supply_cap != U256::MAX {
             init_calls.push(
-                IB20::setSupplyCapCall { newSupplyCap: params.supply_cap }.abi_encode().into(),
+                IB20::updateSupplyCapCall { newSupplyCap: params.supply_cap }.abi_encode().into(),
             );
         }
         if !params.contract_uri.is_empty() {
-            init_calls
-                .push(IB20::setContractURICall { newURI: params.contract_uri }.abi_encode().into());
+            init_calls.push(
+                IB20::updateContractURICall { newURI: params.contract_uri }.abi_encode().into(),
+            );
         }
         let call = ITokenFactory::createTokenCall {
             variant: variant.abi(),
@@ -313,32 +314,32 @@ impl<'a> B20PrecompileClient<'a> {
             .wrap_err("Failed to decode supplyCap")
     }
 
-    /// Sets the supply cap.
-    pub async fn set_supply_cap(&self, token: Address, new_cap: U256) -> Result<()> {
+    /// Updates the supply cap.
+    pub async fn update_supply_cap(&self, token: Address, new_cap: U256) -> Result<()> {
         self.send_call(
             token,
-            IB20::setSupplyCapCall { newSupplyCap: new_cap },
-            "setSupplyCap B-20 token",
+            IB20::updateSupplyCapCall { newSupplyCap: new_cap },
+            "updateSupplyCap B-20 token",
         )
         .await
     }
 
-    /// Sets the token name.
-    pub async fn set_name(&self, token: Address, new_name: &str) -> Result<()> {
+    /// Updates the token name.
+    pub async fn update_name(&self, token: Address, new_name: &str) -> Result<()> {
         self.send_call(
             token,
-            IB20::setNameCall { newName: new_name.to_string() },
-            "setName B-20 token",
+            IB20::updateNameCall { newName: new_name.to_string() },
+            "updateName B-20 token",
         )
         .await
     }
 
-    /// Sets the token symbol.
-    pub async fn set_symbol(&self, token: Address, new_symbol: &str) -> Result<()> {
+    /// Updates the token symbol.
+    pub async fn update_symbol(&self, token: Address, new_symbol: &str) -> Result<()> {
         self.send_call(
             token,
-            IB20::setSymbolCall { newSymbol: new_symbol.to_string() },
-            "setSymbol B-20 token",
+            IB20::updateSymbolCall { newSymbol: new_symbol.to_string() },
+            "updateSymbol B-20 token",
         )
         .await
     }
@@ -350,12 +351,12 @@ impl<'a> B20PrecompileClient<'a> {
             .wrap_err("Failed to decode contractURI")
     }
 
-    /// Sets the contract URI.
-    pub async fn set_contract_uri(&self, token: Address, new_uri: &str) -> Result<()> {
+    /// Updates the contract URI.
+    pub async fn update_contract_uri(&self, token: Address, new_uri: &str) -> Result<()> {
         self.send_call(
             token,
-            IB20::setContractURICall { newURI: new_uri.to_string() },
-            "setContractURI B-20 token",
+            IB20::updateContractURICall { newURI: new_uri.to_string() },
+            "updateContractURI B-20 token",
         )
         .await
     }

--- a/devnet/tests/b20_precompile.rs
+++ b/devnet/tests/b20_precompile.rs
@@ -190,6 +190,21 @@ async fn test_b20_mint_and_burn() -> Result<()> {
     )
     .await?;
 
+    let zero_mint_succeeded = b20
+        .try_send_call(
+            token,
+            IB20::mintCall { to: admin.address(), amount: U256::ZERO },
+            "zero amount B-20 mint",
+        )
+        .await?;
+    assert!(!zero_mint_succeeded, "zero amount B-20 mint should revert");
+
+    let zero_burn_succeeded = b20
+        .try_send_call(token, IB20::burnCall { amount: U256::ZERO }, "zero amount B-20 burn")
+        .await?;
+    assert!(!zero_burn_succeeded, "zero amount B-20 burn should revert");
+    assert_eq!(b20.total_supply(token).await?, supply_before);
+
     b20.mint(token, admin.address(), U256::from(MINT_AMOUNT)).await?;
     assert_eq!(b20.total_supply(token).await?, supply_before + U256::from(MINT_AMOUNT));
     assert_eq!(
@@ -267,15 +282,15 @@ async fn test_b20_supply_cap() -> Result<()> {
     assert!(
         !b20.try_send_call(
             token,
-            IB20::setSupplyCapCall { newSupplyCap: U256::from(INITIAL_SUPPLY - 1) },
-            "setSupplyCap below current supply",
+            IB20::updateSupplyCapCall { newSupplyCap: U256::from(INITIAL_SUPPLY - 1) },
+            "updateSupplyCap below current supply",
         )
         .await?,
-        "setSupplyCap below total supply should revert",
+        "updateSupplyCap below total supply should revert",
     );
 
     // Tighten cap to exactly the current supply.
-    b20.set_supply_cap(token, U256::from(INITIAL_SUPPLY)).await?;
+    b20.update_supply_cap(token, U256::from(INITIAL_SUPPLY)).await?;
     assert_eq!(b20.supply_cap(token).await?, U256::from(INITIAL_SUPPLY));
 
     // Minting past the cap reverts.
@@ -311,9 +326,9 @@ async fn test_b20_metadata_updates() -> Result<()> {
     let token = b20.create_token(TokenVariant::B20, params, salt).await?;
     b20.wait_for_token_code(token, common::TX_RECEIPT_TIMEOUT, common::BLOCK_POLL_INTERVAL).await?;
 
-    b20.set_name(token, "New Name").await?;
-    b20.set_symbol(token, "NEW").await?;
-    b20.set_contract_uri(token, "ipfs://QmTest").await?;
+    b20.update_name(token, "New Name").await?;
+    b20.update_symbol(token, "NEW").await?;
+    b20.update_contract_uri(token, "ipfs://QmTest").await?;
 
     assert_eq!(b20.name(token).await?, "New Name");
     assert_eq!(b20.symbol(token).await?, "NEW");

--- a/etc/scripts/devnet/check-factory-live.sh
+++ b/etc/scripts/devnet/check-factory-live.sh
@@ -164,8 +164,8 @@ CREATE_PARAMS=$(cast abi-encode \
     1 "$TOKEN_NAME" "$TOKEN_SYMBOL" "$ALICE_ADDR")
 
 MINT_CALL=$(cast calldata "mint(address,uint256)" "$ALICE_ADDR" "$INITIAL_SUPPLY")
-SUPPLY_CAP_CALL=$(cast calldata "setSupplyCap(uint256)" "$SUPPLY_CAP")
-CONTRACT_URI_CALL=$(cast calldata "setContractURI(string)" "ipfs://check-factory-live")
+SUPPLY_CAP_CALL=$(cast calldata "updateSupplyCap(uint256)" "$SUPPLY_CAP")
+CONTRACT_URI_CALL=$(cast calldata "updateContractURI(string)" "ipfs://check-factory-live")
 INIT_CALLS="[$MINT_CALL,$SUPPLY_CAP_CALL,$CONTRACT_URI_CALL]"
 
 info "Sending createToken transaction …"


### PR DESCRIPTION
## Summary

This aligns the Rust B20 ABI and precompile dispatch with the canonical Solidity interface. It switches metadata, supply-cap, and contract-URI mutators to the update-prefixed selectors, updates memo events to include the caller, and refreshes precompile, action-harness, devnet, and live-check coverage accordingly.