### PR TITLE
fix(common): Align Stablecoin Interface Errors

### DIFF
--- a/crates/common/precompiles/src/b20_stablecoin/abi.rs
+++ b/crates/common/precompiles/src/b20_stablecoin/abi.rs
@@ -8,9 +8,6 @@ use alloy_sol_types::sol;
 sol! {
     #[derive(Debug, PartialEq, Eq)]
     interface IB20Stablecoin {
-        /// `currency` is not a recognised ISO 4217 currency code.
-        error InvalidCurrency();
-
         function currency() external view returns (string);
     }
 }

--- a/crates/common/precompiles/src/b20_stablecoin/storage.rs
+++ b/crates/common/precompiles/src/b20_stablecoin/storage.rs
@@ -8,10 +8,10 @@ use base_precompile_storage::{BasePrecompileError, ContractStorage, Handler, Res
 #[cfg(feature = "std")]
 use iso_currency::Currency;
 
-#[cfg(feature = "std")]
-use super::IB20Stablecoin;
 use super::accounting::StablecoinAccounting;
-use crate::{B20CoreStorage, B20PolicyType, B20TokenRole, IB20, TokenAccounting, TokenVariant};
+use crate::{
+    B20CoreStorage, B20PolicyType, B20TokenRole, IB20, ITokenFactory, TokenAccounting, TokenVariant,
+};
 
 /// Stablecoin-specific B-20 storage rooted at the `base.b20.stablecoin` ERC-7201 namespace.
 #[derive(Debug, Clone, Storable)]
@@ -52,11 +52,13 @@ impl<'a> B20StablecoinStorage<'a> {
     /// Writes all creation-time fields atomically.
     ///
     /// Validates that `currency` is a recognised ISO 4217 code before writing
-    /// anything; reverts `IB20Stablecoin::InvalidCurrency` otherwise.
+    /// anything; reverts `ITokenFactory::InvalidCurrency` otherwise.
     pub fn initialize(&mut self, init: B20StablecoinInit) -> Result<()> {
         #[cfg(feature = "std")]
         if Currency::from_code(&init.currency).is_none() {
-            return Err(BasePrecompileError::revert(IB20Stablecoin::InvalidCurrency {}));
+            return Err(BasePrecompileError::revert(ITokenFactory::InvalidCurrency {
+                code: init.currency,
+            }));
         }
         self.b20.name.write(init.name)?;
         self.b20.symbol.write(init.symbol)?;

--- a/crates/common/precompiles/src/factory/abi.rs
+++ b/crates/common/precompiles/src/factory/abi.rs
@@ -54,6 +54,9 @@ sol! {
         /// A required string argument was empty.
         error MissingRequiredField();
 
+        /// The stablecoin `currency` field was not on the ISO 4217 fiat allowlist.
+        error InvalidCurrency(string code);
+
         /// One of the post-creation init calls failed.
         error InitCallFailed(uint256 index);
 

--- a/crates/common/precompiles/src/factory/storage.rs
+++ b/crates/common/precompiles/src/factory/storage.rs
@@ -344,8 +344,7 @@ mod tests {
     use super::*;
     use crate::{
         ActivationFeature, ActivationRegistryStorage, B20SecurityStorage, B20Token,
-        B20TokenStorage, IB20, IB20Stablecoin, Mintable, Permittable, Token, TokenAccounting,
-        Transferable,
+        B20TokenStorage, IB20, Mintable, Permittable, Token, TokenAccounting, Transferable,
     };
 
     const ACTIVATION_ADMIN: Address = address!("0xcb00000000000000000000000000000000000000");
@@ -625,7 +624,7 @@ mod tests {
         StorageCtx::enter(&mut storage, |ctx| {
             assert_output(
                 dispatch_factory_revert(ctx, call),
-                IB20Stablecoin::InvalidCurrency {}.abi_encode(),
+                ITokenFactory::InvalidCurrency { code: String::new() }.abi_encode(),
             );
         });
     }


### PR DESCRIPTION
## Summary

This aligns the Rust B20 stablecoin ABI with the canonical interface by leaving `IB20Stablecoin` with only the stablecoin-specific `currency()` selector. Currency validation now reverts through the factory ABI with `InvalidCurrency(string)`, matching creation-time validation ownership. The focused stablecoin precompile tests and package formatting check pass locally.