### PR TITLE
feat(consensus): add EIP-8130 Account Abstraction transaction types

### DIFF
--- a/crates/common/consensus/src/lib.rs
+++ b/crates/common/consensus/src/lib.rs
@@ -24,8 +24,10 @@ mod transaction;
 #[cfg(feature = "serde")]
 pub use transaction::serde_deposit_tx_rpc;
 pub use transaction::{
-    BasePooledTransaction, BaseTransaction, BaseTransactionInfo, BaseTxEnvelope,
-    BaseTypedTransaction, DEPOSIT_TX_TYPE_ID, DepositInfo, DepositTransaction, OpTxType, TxDeposit,
+    Aa8130Constants, AaSigned, AccountChange, BasePooledTransaction, BaseTransaction,
+    BaseTransactionInfo, BaseTxEnvelope, BaseTypedTransaction, Call, ConfigChange, CreateEntry,
+    DEPOSIT_TX_TYPE_ID, Delegation, DepositInfo, DepositTransaction, InitialOwner, OpTxType,
+    OwnerChange, OwnerChangeType, Scope, TxAa8130, TxDeposit,
 };
 
 mod extra;

--- a/crates/common/consensus/src/lib.rs
+++ b/crates/common/consensus/src/lib.rs
@@ -26,8 +26,8 @@ pub use transaction::serde_deposit_tx_rpc;
 pub use transaction::{
     Aa8130Constants, AaSigned, AccountChange, BasePooledTransaction, BaseTransaction,
     BaseTransactionInfo, BaseTxEnvelope, BaseTypedTransaction, Call, ConfigChange, CreateEntry,
-    DEPOSIT_TX_TYPE_ID, Delegation, DepositInfo, DepositTransaction, InitialOwner, OpTxType,
-    OwnerChange, OwnerChangeType, Scope, TxAa8130, TxDeposit,
+    DEPOSIT_TX_TYPE_ID, Delegation, DepositInfo, DepositTransaction, EIP8130_TX_TYPE_ID,
+    InitialOwner, OpTxType, OwnerChange, OwnerChangeType, Scope, TxAa8130, TxDeposit,
 };
 
 mod extra;

--- a/crates/common/consensus/src/receipts/envelope.rs
+++ b/crates/common/consensus/src/receipts/envelope.rs
@@ -49,6 +49,12 @@ pub enum BaseReceiptEnvelope {
     /// [deposit]: https://specs.base.org/protocol/bridging/deposits
     #[cfg_attr(feature = "serde", serde(rename = "0x7e", alias = "0x7E"))]
     Deposit(ReceiptWithBloom<DepositReceipt>),
+    /// Receipt envelope with type flag 125, containing an [EIP-8130] Account
+    /// Abstraction receipt.
+    ///
+    /// [EIP-8130]: https://eips.ethereum.org/EIPS/eip-8130
+    #[cfg_attr(feature = "serde", serde(rename = "0x7d", alias = "0x7D"))]
+    Aa8130(ReceiptWithBloom<Receipt<Log>>),
 }
 
 impl BaseReceiptEnvelope {
@@ -89,6 +95,9 @@ impl BaseReceiptEnvelope {
                 };
                 Self::Deposit(inner)
             }
+            OpTxType::Aa8130 => {
+                Self::Aa8130(ReceiptWithBloom { receipt: inner_receipt, logs_bloom })
+            }
         }
     }
 }
@@ -102,6 +111,7 @@ impl BaseReceiptEnvelope {
             Self::Eip1559(_) => OpTxType::Eip1559,
             Self::Eip7702(_) => OpTxType::Eip7702,
             Self::Deposit(_) => OpTxType::Deposit,
+            Self::Aa8130(_) => OpTxType::Aa8130,
         }
     }
 
@@ -133,9 +143,11 @@ impl BaseReceiptEnvelope {
     /// Return the receipt's bloom.
     pub const fn logs_bloom(&self) -> &Bloom {
         match self {
-            Self::Legacy(t) | Self::Eip2930(t) | Self::Eip1559(t) | Self::Eip7702(t) => {
-                &t.logs_bloom
-            }
+            Self::Legacy(t)
+            | Self::Eip2930(t)
+            | Self::Eip1559(t)
+            | Self::Eip7702(t)
+            | Self::Aa8130(t) => &t.logs_bloom,
             Self::Deposit(t) => &t.logs_bloom,
         }
     }
@@ -169,7 +181,11 @@ impl BaseReceiptEnvelope {
     /// Consumes the type and returns the underlying [`Receipt`].
     pub fn into_receipt(self) -> Receipt<Log> {
         match self {
-            Self::Legacy(t) | Self::Eip2930(t) | Self::Eip1559(t) | Self::Eip7702(t) => t.receipt,
+            Self::Legacy(t)
+            | Self::Eip2930(t)
+            | Self::Eip1559(t)
+            | Self::Eip7702(t)
+            | Self::Aa8130(t) => t.receipt,
             Self::Deposit(t) => t.receipt.into_inner(),
         }
     }
@@ -178,9 +194,11 @@ impl BaseReceiptEnvelope {
     /// receipt types may be added.
     pub const fn as_receipt(&self) -> Option<&Receipt<Log>> {
         match self {
-            Self::Legacy(t) | Self::Eip2930(t) | Self::Eip1559(t) | Self::Eip7702(t) => {
-                Some(&t.receipt)
-            }
+            Self::Legacy(t)
+            | Self::Eip2930(t)
+            | Self::Eip1559(t)
+            | Self::Eip7702(t)
+            | Self::Aa8130(t) => Some(&t.receipt),
             Self::Deposit(t) => Some(&t.receipt.inner),
         }
     }
@@ -190,7 +208,11 @@ impl BaseReceiptEnvelope {
     /// Get the length of the inner receipt in the 2718 encoding.
     pub fn inner_length(&self) -> usize {
         match self {
-            Self::Legacy(t) | Self::Eip2930(t) | Self::Eip1559(t) | Self::Eip7702(t) => t.length(),
+            Self::Legacy(t)
+            | Self::Eip2930(t)
+            | Self::Eip1559(t)
+            | Self::Eip7702(t)
+            | Self::Aa8130(t) => t.length(),
             Self::Deposit(t) => t.length(),
         }
     }
@@ -265,6 +287,7 @@ impl Typed2718 for BaseReceiptEnvelope {
             Self::Eip1559(_) => OpTxType::Eip1559,
             Self::Eip7702(_) => OpTxType::Eip7702,
             Self::Deposit(_) => OpTxType::Deposit,
+            Self::Aa8130(_) => OpTxType::Aa8130,
         };
         ty as u8
     }
@@ -288,9 +311,11 @@ impl Encodable2718 for BaseReceiptEnvelope {
         }
         match self {
             Self::Deposit(t) => t.encode(out),
-            Self::Legacy(t) | Self::Eip2930(t) | Self::Eip1559(t) | Self::Eip7702(t) => {
-                t.encode(out)
-            }
+            Self::Legacy(t)
+            | Self::Eip2930(t)
+            | Self::Eip1559(t)
+            | Self::Eip7702(t)
+            | Self::Aa8130(t) => t.encode(out),
         }
     }
 }
@@ -306,6 +331,7 @@ impl Decodable2718 for BaseReceiptEnvelope {
             OpTxType::Eip7702 => Ok(Self::Eip7702(Decodable::decode(buf)?)),
             OpTxType::Eip2930 => Ok(Self::Eip2930(Decodable::decode(buf)?)),
             OpTxType::Deposit => Ok(Self::Deposit(Decodable::decode(buf)?)),
+            OpTxType::Aa8130 => Ok(Self::Aa8130(Decodable::decode(buf)?)),
         }
     }
 
@@ -329,12 +355,13 @@ impl From<BaseReceiptEnvelope> for Receipt<Log> {
 #[cfg(all(test, feature = "arbitrary"))]
 impl<'a> arbitrary::Arbitrary<'a> for BaseReceiptEnvelope {
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
-        match u.int_in_range(0..=4)? {
+        match u.int_in_range(0..=5)? {
             0 => Ok(Self::Legacy(ReceiptWithBloom::arbitrary(u)?)),
             1 => Ok(Self::Eip2930(ReceiptWithBloom::arbitrary(u)?)),
             2 => Ok(Self::Eip1559(ReceiptWithBloom::arbitrary(u)?)),
             3 => Ok(Self::Eip7702(ReceiptWithBloom::arbitrary(u)?)),
-            _ => Ok(Self::Deposit(DepositReceiptWithBloom::arbitrary(u)?)),
+            4 => Ok(Self::Deposit(DepositReceiptWithBloom::arbitrary(u)?)),
+            _ => Ok(Self::Aa8130(ReceiptWithBloom::arbitrary(u)?)),
         }
     }
 }

--- a/crates/common/consensus/src/receipts/receipt.rs
+++ b/crates/common/consensus/src/receipts/receipt.rs
@@ -37,6 +37,9 @@ pub enum BaseReceipt<T = Log> {
     /// Deposit receipt
     #[cfg_attr(feature = "serde", serde(rename = "0x7e", alias = "0x7E"))]
     Deposit(DepositReceipt<T>),
+    /// EIP-8130 Account Abstraction receipt
+    #[cfg_attr(feature = "serde", serde(rename = "0x7d", alias = "0x7D"))]
+    Aa8130(Receipt<T>),
 }
 
 impl<T> BaseReceipt<T> {
@@ -48,6 +51,7 @@ impl<T> BaseReceipt<T> {
             Self::Eip1559(_) => OpTxType::Eip1559,
             Self::Eip7702(_) => OpTxType::Eip7702,
             Self::Deposit(_) => OpTxType::Deposit,
+            Self::Aa8130(_) => OpTxType::Aa8130,
         }
     }
 
@@ -57,7 +61,8 @@ impl<T> BaseReceipt<T> {
             Self::Legacy(receipt)
             | Self::Eip2930(receipt)
             | Self::Eip1559(receipt)
-            | Self::Eip7702(receipt) => receipt,
+            | Self::Eip7702(receipt)
+            | Self::Aa8130(receipt) => receipt,
             Self::Deposit(receipt) => &receipt.inner,
         }
     }
@@ -68,7 +73,8 @@ impl<T> BaseReceipt<T> {
             Self::Legacy(receipt)
             | Self::Eip2930(receipt)
             | Self::Eip1559(receipt)
-            | Self::Eip7702(receipt) => receipt,
+            | Self::Eip7702(receipt)
+            | Self::Aa8130(receipt) => receipt,
             Self::Deposit(receipt) => &mut receipt.inner,
         }
     }
@@ -79,7 +85,8 @@ impl<T> BaseReceipt<T> {
             Self::Legacy(receipt)
             | Self::Eip2930(receipt)
             | Self::Eip1559(receipt)
-            | Self::Eip7702(receipt) => receipt,
+            | Self::Eip7702(receipt)
+            | Self::Aa8130(receipt) => receipt,
             Self::Deposit(receipt) => receipt.inner,
         }
     }
@@ -94,6 +101,7 @@ impl<T> BaseReceipt<T> {
             Self::Eip1559(receipt) => BaseReceipt::Eip1559(receipt.map_logs(f)),
             Self::Eip7702(receipt) => BaseReceipt::Eip7702(receipt.map_logs(f)),
             Self::Deposit(receipt) => BaseReceipt::Deposit(receipt.map_logs(f)),
+            Self::Aa8130(receipt) => BaseReceipt::Aa8130(receipt.map_logs(f)),
         }
     }
 
@@ -106,7 +114,8 @@ impl<T> BaseReceipt<T> {
             Self::Legacy(receipt)
             | Self::Eip2930(receipt)
             | Self::Eip1559(receipt)
-            | Self::Eip7702(receipt) => receipt.rlp_encoded_fields_length_with_bloom(bloom),
+            | Self::Eip7702(receipt)
+            | Self::Aa8130(receipt) => receipt.rlp_encoded_fields_length_with_bloom(bloom),
             Self::Deposit(receipt) => receipt.rlp_encoded_fields_length_with_bloom(bloom),
         }
     }
@@ -120,7 +129,8 @@ impl<T> BaseReceipt<T> {
             Self::Legacy(receipt)
             | Self::Eip2930(receipt)
             | Self::Eip1559(receipt)
-            | Self::Eip7702(receipt) => receipt.rlp_encode_fields_with_bloom(bloom, out),
+            | Self::Eip7702(receipt)
+            | Self::Aa8130(receipt) => receipt.rlp_encode_fields_with_bloom(bloom, out),
             Self::Deposit(receipt) => receipt.rlp_encode_fields_with_bloom(bloom, out),
         }
     }
@@ -176,6 +186,11 @@ impl<T> BaseReceipt<T> {
                     RlpDecodableReceipt::rlp_decode_with_bloom(buf)?;
                 Ok(ReceiptWithBloom { receipt: Self::Deposit(receipt), logs_bloom })
             }
+            OpTxType::Aa8130 => {
+                let ReceiptWithBloom { receipt, logs_bloom } =
+                    RlpDecodableReceipt::rlp_decode_with_bloom(buf)?;
+                Ok(ReceiptWithBloom { receipt: Self::Aa8130(receipt), logs_bloom })
+            }
         }
     }
 
@@ -189,7 +204,8 @@ impl<T> BaseReceipt<T> {
             Self::Legacy(receipt)
             | Self::Eip2930(receipt)
             | Self::Eip1559(receipt)
-            | Self::Eip7702(receipt) => {
+            | Self::Eip7702(receipt)
+            | Self::Aa8130(receipt) => {
                 receipt.status.encode(out);
                 receipt.cumulative_gas_used.encode(out);
                 receipt.logs.encode(out);
@@ -218,7 +234,8 @@ impl<T> BaseReceipt<T> {
                 Self::Legacy(receipt)
                 | Self::Eip2930(receipt)
                 | Self::Eip1559(receipt)
-                | Self::Eip7702(receipt) => {
+                | Self::Eip7702(receipt)
+                | Self::Aa8130(receipt) => {
                     receipt.status.length()
                         + receipt.cumulative_gas_used.length()
                         + receipt.logs.length()
@@ -246,7 +263,6 @@ impl<T> BaseReceipt<T> {
         let mut deposit_nonce = None;
         let mut deposit_receipt_version = None;
 
-        // For deposit receipts, try to decode nonce and version if they exist
         if tx_type == OpTxType::Deposit && !buf.is_empty() {
             deposit_nonce = Some(Decodable::decode(buf)?);
             if !buf.is_empty() {
@@ -264,6 +280,7 @@ impl<T> BaseReceipt<T> {
                 deposit_nonce,
                 deposit_receipt_version,
             })),
+            OpTxType::Aa8130 => Ok(Self::Aa8130(Receipt { status, cumulative_gas_used, logs })),
         }
     }
 }
@@ -403,7 +420,8 @@ impl<T: Send + Sync + Clone + Debug + Eq + AsRef<Log>> TxReceipt for BaseReceipt
             Self::Legacy(receipt)
             | Self::Eip2930(receipt)
             | Self::Eip1559(receipt)
-            | Self::Eip7702(receipt) => receipt.logs,
+            | Self::Eip7702(receipt)
+            | Self::Aa8130(receipt) => receipt.logs,
             Self::Deposit(receipt) => receipt.inner.logs,
         }
     }
@@ -449,6 +467,7 @@ impl From<super::BaseReceiptEnvelope> for BaseReceipt {
                 deposit_receipt_version: receipt.receipt.deposit_receipt_version,
                 inner: receipt.receipt.inner,
             }),
+            super::BaseReceiptEnvelope::Aa8130(receipt) => Self::Aa8130(receipt.receipt),
         }
     }
 }
@@ -470,6 +489,7 @@ impl From<ReceiptWithBloom<BaseReceipt>> for BaseReceiptEnvelope {
             BaseReceipt::Deposit(receipt) => {
                 Self::Deposit(ReceiptWithBloom { receipt, logs_bloom })
             }
+            BaseReceipt::Aa8130(receipt) => Self::Aa8130(ReceiptWithBloom { receipt, logs_bloom }),
         }
     }
 }
@@ -507,6 +527,8 @@ pub(super) mod serde_bincode_compat {
         Eip7702(alloy_consensus::serde_bincode_compat::Receipt<'a, alloy_primitives::Log>),
         /// Deposit receipt
         Deposit(crate::serde_bincode_compat::DepositReceipt<'a, alloy_primitives::Log>),
+        /// EIP-8130 Account Abstraction receipt
+        Aa8130(alloy_consensus::serde_bincode_compat::Receipt<'a, alloy_primitives::Log>),
     }
 
     impl<'a> From<&'a super::BaseReceipt> for BaseReceipt<'a> {
@@ -517,6 +539,7 @@ pub(super) mod serde_bincode_compat {
                 super::BaseReceipt::Eip1559(receipt) => Self::Eip1559(receipt.into()),
                 super::BaseReceipt::Eip7702(receipt) => Self::Eip7702(receipt.into()),
                 super::BaseReceipt::Deposit(receipt) => Self::Deposit(receipt.into()),
+                super::BaseReceipt::Aa8130(receipt) => Self::Aa8130(receipt.into()),
             }
         }
     }
@@ -529,6 +552,7 @@ pub(super) mod serde_bincode_compat {
                 BaseReceipt::Eip1559(receipt) => Self::Eip1559(receipt.into()),
                 BaseReceipt::Eip7702(receipt) => Self::Eip7702(receipt.into()),
                 BaseReceipt::Deposit(receipt) => Self::Deposit(receipt.into()),
+                BaseReceipt::Aa8130(receipt) => Self::Aa8130(receipt.into()),
             }
         }
     }
@@ -597,7 +621,8 @@ where
             Self::Legacy(receipt)
             | Self::Eip2930(receipt)
             | Self::Eip1559(receipt)
-            | Self::Eip7702(receipt) => receipt.size(),
+            | Self::Eip7702(receipt)
+            | Self::Aa8130(receipt) => receipt.size(),
             Self::Deposit(receipt) => receipt.size(),
         }
     }

--- a/crates/common/consensus/src/reth_compat.rs
+++ b/crates/common/consensus/src/reth_compat.rs
@@ -24,7 +24,8 @@ use reth_ethereum_primitives as _;
 
 use crate::{
     BaseBlock, BasePooledTransaction, BaseReceipt, BaseTxEnvelope, BaseTypedTransaction,
-    DEPOSIT_TX_TYPE_ID, DepositReceipt, OpTxType, TxDeposit,
+    DEPOSIT_TX_TYPE_ID, DepositReceipt, EIP8130_TX_TYPE_ID, OpTxType, TxAa8130, TxDeposit,
+    transaction::AaSigned,
 };
 
 // ---------------------------------------------------------------------------
@@ -45,6 +46,20 @@ impl reth_primitives_traits::InMemorySize for TxDeposit {
     }
 }
 
+impl reth_primitives_traits::InMemorySize for TxAa8130 {
+    #[inline]
+    fn size(&self) -> usize {
+        Self::size(self)
+    }
+}
+
+impl reth_primitives_traits::InMemorySize for AaSigned {
+    #[inline]
+    fn size(&self) -> usize {
+        alloy_consensus::InMemorySize::size(self)
+    }
+}
+
 impl reth_primitives_traits::InMemorySize for DepositReceipt {
     fn size(&self) -> usize {
         self.inner.size()
@@ -59,7 +74,8 @@ impl reth_primitives_traits::InMemorySize for BaseReceipt {
             Self::Legacy(receipt)
             | Self::Eip2930(receipt)
             | Self::Eip1559(receipt)
-            | Self::Eip7702(receipt) => receipt.size(),
+            | Self::Eip7702(receipt)
+            | Self::Aa8130(receipt) => receipt.size(),
             Self::Deposit(receipt) => receipt.size(),
         }
     }
@@ -73,6 +89,7 @@ impl reth_primitives_traits::InMemorySize for BaseTypedTransaction {
             Self::Eip1559(tx) => tx.size(),
             Self::Eip7702(tx) => tx.size(),
             Self::Deposit(tx) => tx.size(),
+            Self::Aa8130(tx) => tx.size(),
         }
     }
 }
@@ -84,6 +101,7 @@ impl reth_primitives_traits::InMemorySize for BasePooledTransaction {
             Self::Eip2930(tx) => tx.size(),
             Self::Eip1559(tx) => tx.size(),
             Self::Eip7702(tx) => tx.size(),
+            Self::Aa8130(tx) => tx.size(),
         }
     }
 }
@@ -96,6 +114,7 @@ impl reth_primitives_traits::InMemorySize for BaseTxEnvelope {
             Self::Eip1559(tx) => tx.size(),
             Self::Eip7702(tx) => tx.size(),
             Self::Deposit(tx) => tx.size(),
+            Self::Aa8130(tx) => tx.size(),
         }
     }
 }
@@ -227,6 +246,10 @@ impl Compact for OpTxType {
                 buf.put_u8(DEPOSIT_TX_TYPE_ID);
                 COMPACT_EXTENDED_IDENTIFIER_FLAG
             }
+            Self::Aa8130 => {
+                buf.put_u8(EIP8130_TX_TYPE_ID);
+                COMPACT_EXTENDED_IDENTIFIER_FLAG
+            }
         }
     }
 
@@ -241,6 +264,7 @@ impl Compact for OpTxType {
                     match extended_identifier {
                         EIP7702_TX_TYPE_ID => Self::Eip7702,
                         DEPOSIT_TX_TYPE_ID => Self::Deposit,
+                        EIP8130_TX_TYPE_ID => Self::Aa8130,
                         _ => panic!("Unsupported OpTxType identifier: {extended_identifier}"),
                     }
                 }
@@ -267,6 +291,9 @@ impl Compact for BaseTypedTransaction {
             Self::Eip1559(tx) => tx.to_compact(out),
             Self::Eip7702(tx) => tx.to_compact(out),
             Self::Deposit(tx) => tx.to_compact(out),
+            Self::Aa8130(_) => unimplemented!(
+                "Compact encoding for EIP-8130 BaseTypedTransaction is not yet implemented"
+            ),
         };
         identifier
     }
@@ -294,6 +321,9 @@ impl Compact for BaseTypedTransaction {
                 let (tx, buf) = Compact::from_compact(buf, buf.len());
                 (Self::Deposit(tx), buf)
             }
+            OpTxType::Aa8130 => unimplemented!(
+                "Compact decoding for EIP-8130 BaseTypedTransaction is not yet implemented"
+            ),
         }
     }
 }
@@ -310,6 +340,9 @@ impl reth_codecs::alloy::transaction::ToTxCompact for BaseTxEnvelope {
             Self::Eip1559(tx) => tx.tx().to_compact(buf),
             Self::Eip7702(tx) => tx.tx().to_compact(buf),
             Self::Deposit(tx) => tx.to_compact(buf),
+            Self::Aa8130(_) => unimplemented!(
+                "Compact encoding for EIP-8130 BaseTxEnvelope is not yet implemented"
+            ),
         };
     }
 }
@@ -344,6 +377,9 @@ impl reth_codecs::alloy::transaction::FromTxCompact for BaseTxEnvelope {
                 let tx = Sealed::new(tx);
                 (Self::Deposit(tx), buf)
             }
+            OpTxType::Aa8130 => unimplemented!(
+                "Compact decoding for EIP-8130 BaseTxEnvelope is not yet implemented"
+            ),
         }
     }
 }
@@ -362,7 +398,7 @@ impl reth_codecs::alloy::transaction::Envelope for BaseTxEnvelope {
             Self::Eip2930(tx) => tx.signature(),
             Self::Eip1559(tx) => tx.signature(),
             Self::Eip7702(tx) => tx.signature(),
-            Self::Deposit(_) => &DEPOSIT_SIGNATURE,
+            Self::Deposit(_) | Self::Aa8130(_) => &DEPOSIT_SIGNATURE,
         }
     }
 
@@ -450,6 +486,9 @@ impl From<CompactBaseReceipt<'_>> for BaseReceipt {
             OpTxType::Eip7702 => Self::Eip7702(inner),
             OpTxType::Deposit => {
                 Self::Deposit(DepositReceipt { inner, deposit_nonce, deposit_receipt_version })
+            }
+            OpTxType::Aa8130 => {
+                unimplemented!("Compact decoding for EIP-8130 BaseReceipt is not yet implemented")
             }
         }
     }

--- a/crates/common/consensus/src/reth_compat.rs
+++ b/crates/common/consensus/src/reth_compat.rs
@@ -398,6 +398,11 @@ impl reth_codecs::alloy::transaction::Envelope for BaseTxEnvelope {
             Self::Eip2930(tx) => tx.signature(),
             Self::Eip1559(tx) => tx.signature(),
             Self::Eip7702(tx) => tx.signature(),
+            // The `Envelope` trait forces a `&Signature` return, so neither variant can
+            // signal absence the way `BaseTxEnvelope::signature` (which returns `Option`)
+            // does. Both Deposit and EIP-8130 AA transactions carry their own auth model
+            // and have no meaningful ECDSA signature: callers MUST NOT feed this value
+            // into ECDSA recovery — it is an all-zero placeholder.
             Self::Deposit(_) | Self::Aa8130(_) => &DEPOSIT_SIGNATURE,
         }
     }

--- a/crates/common/consensus/src/transaction/aa8130/account_changes.rs
+++ b/crates/common/consensus/src/transaction/aa8130/account_changes.rs
@@ -14,12 +14,31 @@ use crate::transaction::aa8130::constants::Aa8130Constants;
 
 /// Bitmask describing the contexts in which an owner is valid.
 ///
-/// See `SCOPE_*` constants on [`Aa8130Constants`].
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash, RlpEncodable, RlpDecodable)]
+/// On the wire, `Scope` is encoded as a single RLP-encoded byte (matching the
+/// EIP-8130 `uint8` spec), not as a one-element list. The derived RLP impls
+/// from `alloy_rlp` would wrap the inner byte in a list header, so the
+/// `Encodable`/`Decodable` impls are written by hand.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(transparent))]
 pub struct Scope(pub u8);
+
+impl Encodable for Scope {
+    fn encode(&self, out: &mut dyn BufMut) {
+        self.0.encode(out);
+    }
+
+    fn length(&self) -> usize {
+        self.0.length()
+    }
+}
+
+impl Decodable for Scope {
+    fn decode(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
+        u8::decode(buf).map(Self)
+    }
+}
 
 impl Scope {
     /// Unrestricted scope (owner valid in all contexts).
@@ -393,5 +412,25 @@ mod tests {
         let mut slice = &buf[..];
         let res = AccountChange::decode(&mut slice);
         assert!(res.is_err());
+    }
+
+    #[test]
+    fn scope_encodes_as_bare_uint8() {
+        let mut buf = Vec::new();
+        Scope(0x05).encode(&mut buf);
+        assert_eq!(buf, vec![0x05], "Scope must serialize as a single RLP byte, not a list");
+
+        let mut zero = Vec::new();
+        Scope(0x00).encode(&mut zero);
+        assert_eq!(zero, vec![0x80], "Zero byte RLP encodes as 0x80");
+
+        let mut high = Vec::new();
+        Scope(0x80).encode(&mut high);
+        assert_eq!(high, vec![0x81, 0x80], "High-bit byte RLP encodes as 0x81 0x80");
+
+        let mut slice = buf.as_slice();
+        let decoded = Scope::decode(&mut slice).unwrap();
+        assert_eq!(decoded, Scope(0x05));
+        assert!(slice.is_empty());
     }
 }

--- a/crates/common/consensus/src/transaction/aa8130/account_changes.rs
+++ b/crates/common/consensus/src/transaction/aa8130/account_changes.rs
@@ -1,0 +1,397 @@
+//! [EIP-8130] `account_changes` entry types.
+//!
+//! An [`AccountChange`] is a tagged-union entry inside `TxAa8130::account_changes`.
+//! On the wire, each entry is encoded as `type_byte || rlp([entry_fields...])`.
+//!
+//! [EIP-8130]: https://eips.ethereum.org/EIPS/eip-8130
+
+use alloy_primitives::{Address, B256, Bytes};
+use alloy_rlp::{
+    Buf, BufMut, Decodable, Encodable, Header, RlpDecodable, RlpEncodable, length_of_length,
+};
+
+use crate::transaction::aa8130::constants::Aa8130Constants;
+
+/// Bitmask describing the contexts in which an owner is valid.
+///
+/// See `SCOPE_*` constants on [`Aa8130Constants`].
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash, RlpEncodable, RlpDecodable)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(transparent))]
+pub struct Scope(pub u8);
+
+impl Scope {
+    /// Unrestricted scope (owner valid in all contexts).
+    pub const UNRESTRICTED: Self = Self(Aa8130Constants::SCOPE_UNRESTRICTED);
+
+    /// Returns the raw bitmask.
+    pub const fn bits(&self) -> u8 {
+        self.0
+    }
+
+    /// Returns true if the scope grants the `SCOPE_SIGNATURE` context.
+    pub const fn has_signature(&self) -> bool {
+        self.0 & Aa8130Constants::SCOPE_SIGNATURE != 0
+    }
+
+    /// Returns true if the scope grants the `SCOPE_SENDER` context.
+    pub const fn has_sender(&self) -> bool {
+        self.0 & Aa8130Constants::SCOPE_SENDER != 0
+    }
+
+    /// Returns true if the scope grants the `SCOPE_PAYER` context.
+    pub const fn has_payer(&self) -> bool {
+        self.0 & Aa8130Constants::SCOPE_PAYER != 0
+    }
+
+    /// Returns true if the scope grants the `SCOPE_CONFIG` context.
+    pub const fn has_config(&self) -> bool {
+        self.0 & Aa8130Constants::SCOPE_CONFIG != 0
+    }
+}
+
+/// Initial owner installed on a newly-created account.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, RlpEncodable, RlpDecodable)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+pub struct InitialOwner {
+    /// Address of the verifier contract (e.g. an ERC-1271 verifier).
+    pub verifier: Address,
+    /// Owner identifier passed to the verifier.
+    pub owner_id: B256,
+    /// Scope bitmask granted to this owner.
+    pub scope: Scope,
+}
+
+/// Operation performed by an [`OwnerChange`] inside a [`ConfigChange`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub enum OwnerChangeType {
+    /// Authorize a new owner (op byte `0x01`).
+    Authorize,
+    /// Revoke an existing owner (op byte `0x02`).
+    Revoke,
+}
+
+impl OwnerChangeType {
+    /// Returns the on-wire op byte.
+    pub const fn op_byte(&self) -> u8 {
+        match self {
+            Self::Authorize => Aa8130Constants::OWNER_CHANGE_AUTHORIZE,
+            Self::Revoke => Aa8130Constants::OWNER_CHANGE_REVOKE,
+        }
+    }
+
+    /// Parses a wire op byte.
+    pub const fn from_op_byte(byte: u8) -> Option<Self> {
+        match byte {
+            Aa8130Constants::OWNER_CHANGE_AUTHORIZE => Some(Self::Authorize),
+            Aa8130Constants::OWNER_CHANGE_REVOKE => Some(Self::Revoke),
+            _ => None,
+        }
+    }
+}
+
+/// A single owner authorization or revocation inside a [`ConfigChange`].
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+pub struct OwnerChange {
+    /// Operation (authorize / revoke).
+    pub change_type: OwnerChangeType,
+    /// Verifier contract address.
+    pub verifier: Address,
+    /// Owner identifier.
+    pub owner_id: B256,
+    /// Scope bitmask (relevant for `Authorize`; ignored on `Revoke`).
+    pub scope: Scope,
+}
+
+impl OwnerChange {
+    fn rlp_fields_len(&self) -> usize {
+        self.change_type.op_byte().length()
+            + self.verifier.length()
+            + self.owner_id.length()
+            + self.scope.length()
+    }
+}
+
+impl Encodable for OwnerChange {
+    fn encode(&self, out: &mut dyn BufMut) {
+        let fields_len = self.rlp_fields_len();
+        let header = Header { list: true, payload_length: fields_len };
+        header.encode(out);
+        self.change_type.op_byte().encode(out);
+        self.verifier.encode(out);
+        self.owner_id.encode(out);
+        self.scope.encode(out);
+    }
+
+    fn length(&self) -> usize {
+        let fields_len = self.rlp_fields_len();
+        length_of_length(fields_len) + fields_len
+    }
+}
+
+impl Decodable for OwnerChange {
+    fn decode(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
+        let header = Header::decode(buf)?;
+        if !header.list {
+            return Err(alloy_rlp::Error::UnexpectedString);
+        }
+        let started_len = buf.len();
+        let op = u8::decode(buf)?;
+        let change_type = OwnerChangeType::from_op_byte(op)
+            .ok_or(alloy_rlp::Error::Custom("invalid OwnerChange op byte"))?;
+        let verifier = Address::decode(buf)?;
+        let owner_id = B256::decode(buf)?;
+        let scope = Scope::decode(buf)?;
+        let consumed = started_len - buf.len();
+        if consumed != header.payload_length {
+            return Err(alloy_rlp::Error::ListLengthMismatch {
+                expected: header.payload_length,
+                got: consumed,
+            });
+        }
+        Ok(Self { change_type, verifier, owner_id, scope })
+    }
+}
+
+/// Body of an [`AccountChange::Create`] entry.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, RlpEncodable, RlpDecodable)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+pub struct CreateEntry {
+    /// User-chosen salt used in the deterministic deploy address derivation.
+    pub user_salt: B256,
+    /// Account bytecode to install.
+    pub code: Bytes,
+    /// Initial owners authorized on the new account.
+    pub initial_owners: Vec<InitialOwner>,
+}
+
+/// Body of an [`AccountChange::ConfigChange`] entry.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, RlpEncodable, RlpDecodable)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+pub struct ConfigChange {
+    /// Chain ID this config change is bound to (replay protection).
+    pub chain_id: u64,
+    /// Per-account config-change sequence number.
+    pub sequence: u64,
+    /// Owner authorize/revoke operations applied in order.
+    pub owner_changes: Vec<OwnerChange>,
+    /// Authorization payload validated against an existing owner with `SCOPE_CONFIG`.
+    pub auth: Bytes,
+}
+
+/// Body of an [`AccountChange::Delegation`] entry.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, RlpEncodable, RlpDecodable)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+pub struct Delegation {
+    /// Delegation target address. Zero means clear the existing delegation.
+    pub target: Address,
+}
+
+/// A tagged-union entry inside `TxAa8130::account_changes`.
+///
+/// On the wire each entry is `type_byte || rlp([body_fields...])`:
+/// - `0x00` -> [`AccountChange::Create`]
+/// - `0x01` -> [`AccountChange::ConfigChange`]
+/// - `0x02` -> [`AccountChange::Delegation`]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(tag = "type", rename_all = "camelCase"))]
+pub enum AccountChange {
+    /// Create a new account.
+    Create(CreateEntry),
+    /// Change an existing account's owner set.
+    ConfigChange(ConfigChange),
+    /// Set or clear an [EIP-7702]-style delegation.
+    ///
+    /// [EIP-7702]: https://eips.ethereum.org/EIPS/eip-7702
+    Delegation(Delegation),
+}
+
+impl AccountChange {
+    /// Returns the on-wire type byte for this entry.
+    pub const fn type_byte(&self) -> u8 {
+        match self {
+            Self::Create(_) => Aa8130Constants::ACCOUNT_CHANGE_TYPE_CREATE,
+            Self::ConfigChange(_) => Aa8130Constants::ACCOUNT_CHANGE_TYPE_CONFIG,
+            Self::Delegation(_) => Aa8130Constants::ACCOUNT_CHANGE_TYPE_DELEGATION,
+        }
+    }
+
+    fn body_len(&self) -> usize {
+        match self {
+            Self::Create(b) => b.length(),
+            Self::ConfigChange(b) => b.length(),
+            Self::Delegation(b) => b.length(),
+        }
+    }
+}
+
+impl Encodable for AccountChange {
+    fn encode(&self, out: &mut dyn BufMut) {
+        out.put_u8(self.type_byte());
+        match self {
+            Self::Create(b) => b.encode(out),
+            Self::ConfigChange(b) => b.encode(out),
+            Self::Delegation(b) => b.encode(out),
+        }
+    }
+
+    fn length(&self) -> usize {
+        1 + self.body_len()
+    }
+}
+
+impl Decodable for AccountChange {
+    fn decode(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
+        if buf.is_empty() {
+            return Err(alloy_rlp::Error::InputTooShort);
+        }
+        let type_byte = buf[0];
+        buf.advance(1);
+        match type_byte {
+            Aa8130Constants::ACCOUNT_CHANGE_TYPE_CREATE => {
+                CreateEntry::decode(buf).map(Self::Create)
+            }
+            Aa8130Constants::ACCOUNT_CHANGE_TYPE_CONFIG => {
+                ConfigChange::decode(buf).map(Self::ConfigChange)
+            }
+            Aa8130Constants::ACCOUNT_CHANGE_TYPE_DELEGATION => {
+                Delegation::decode(buf).map(Self::Delegation)
+            }
+            _ => Err(alloy_rlp::Error::Custom("invalid AccountChange type byte")),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_primitives::{address, b256, bytes};
+
+    use super::*;
+
+    #[test]
+    fn scope_bit_helpers() {
+        let s = Scope(
+            Aa8130Constants::SCOPE_SIGNATURE
+                | Aa8130Constants::SCOPE_SENDER
+                | Aa8130Constants::SCOPE_PAYER
+                | Aa8130Constants::SCOPE_CONFIG,
+        );
+        assert!(s.has_signature());
+        assert!(s.has_sender());
+        assert!(s.has_payer());
+        assert!(s.has_config());
+        assert!(!Scope::UNRESTRICTED.has_signature());
+    }
+
+    #[test]
+    fn owner_change_type_roundtrip() {
+        for ct in [OwnerChangeType::Authorize, OwnerChangeType::Revoke] {
+            assert_eq!(OwnerChangeType::from_op_byte(ct.op_byte()), Some(ct));
+        }
+        assert_eq!(OwnerChangeType::from_op_byte(0x00), None);
+        assert_eq!(OwnerChangeType::from_op_byte(0xff), None);
+    }
+
+    #[test]
+    fn owner_change_rlp_roundtrip() {
+        let oc = OwnerChange {
+            change_type: OwnerChangeType::Authorize,
+            verifier: address!("0x00000000000000000000000000000000000000aa"),
+            owner_id: b256!("0x1111111111111111111111111111111111111111111111111111111111111111"),
+            scope: Scope(Aa8130Constants::SCOPE_SIGNATURE | Aa8130Constants::SCOPE_SENDER),
+        };
+        let mut buf = Vec::new();
+        oc.encode(&mut buf);
+        assert_eq!(buf.len(), oc.length());
+        let decoded = OwnerChange::decode(&mut buf.as_slice()).unwrap();
+        assert_eq!(oc, decoded);
+    }
+
+    #[test]
+    fn account_change_create_roundtrip() {
+        let ac = AccountChange::Create(CreateEntry {
+            user_salt: b256!("0x2222222222222222222222222222222222222222222222222222222222222222"),
+            code: bytes!("6080604052"),
+            initial_owners: vec![InitialOwner {
+                verifier: address!("0x00000000000000000000000000000000000000bb"),
+                owner_id: b256!(
+                    "0x3333333333333333333333333333333333333333333333333333333333333333"
+                ),
+                scope: Scope(Aa8130Constants::SCOPE_SIGNATURE),
+            }],
+        });
+        let mut buf = Vec::new();
+        ac.encode(&mut buf);
+        assert_eq!(buf[0], Aa8130Constants::ACCOUNT_CHANGE_TYPE_CREATE);
+        assert_eq!(buf.len(), ac.length());
+        let decoded = AccountChange::decode(&mut buf.as_slice()).unwrap();
+        assert_eq!(ac, decoded);
+    }
+
+    #[test]
+    fn account_change_config_roundtrip() {
+        let ac = AccountChange::ConfigChange(ConfigChange {
+            chain_id: 8453,
+            sequence: 7,
+            owner_changes: vec![OwnerChange {
+                change_type: OwnerChangeType::Revoke,
+                verifier: address!("0x00000000000000000000000000000000000000cc"),
+                owner_id: b256!(
+                    "0x4444444444444444444444444444444444444444444444444444444444444444"
+                ),
+                scope: Scope::UNRESTRICTED,
+            }],
+            auth: bytes!("aabbcc"),
+        });
+        let mut buf = Vec::new();
+        ac.encode(&mut buf);
+        assert_eq!(buf[0], Aa8130Constants::ACCOUNT_CHANGE_TYPE_CONFIG);
+        let decoded = AccountChange::decode(&mut buf.as_slice()).unwrap();
+        assert_eq!(ac, decoded);
+    }
+
+    #[test]
+    fn account_change_delegation_roundtrip() {
+        let ac = AccountChange::Delegation(Delegation {
+            target: address!("0x00000000000000000000000000000000000000dd"),
+        });
+        let mut buf = Vec::new();
+        ac.encode(&mut buf);
+        assert_eq!(buf[0], Aa8130Constants::ACCOUNT_CHANGE_TYPE_DELEGATION);
+        let decoded = AccountChange::decode(&mut buf.as_slice()).unwrap();
+        assert_eq!(ac, decoded);
+    }
+
+    #[test]
+    fn account_change_clear_delegation() {
+        let ac = AccountChange::Delegation(Delegation { target: Address::ZERO });
+        let mut buf = Vec::new();
+        ac.encode(&mut buf);
+        let decoded = AccountChange::decode(&mut buf.as_slice()).unwrap();
+        assert_eq!(ac, decoded);
+    }
+
+    #[test]
+    fn account_change_invalid_type_byte() {
+        let buf = [0xffu8, 0xc0];
+        let mut slice = &buf[..];
+        let res = AccountChange::decode(&mut slice);
+        assert!(res.is_err());
+    }
+}

--- a/crates/common/consensus/src/transaction/aa8130/account_changes.rs
+++ b/crates/common/consensus/src/transaction/aa8130/account_changes.rs
@@ -5,6 +5,8 @@
 //!
 //! [EIP-8130]: https://eips.ethereum.org/EIPS/eip-8130
 
+use alloc::vec::Vec;
+
 use alloy_primitives::{Address, B256, Bytes};
 use alloy_rlp::{
     Buf, BufMut, Decodable, Encodable, Header, RlpDecodable, RlpEncodable, length_of_length,

--- a/crates/common/consensus/src/transaction/aa8130/call.rs
+++ b/crates/common/consensus/src/transaction/aa8130/call.rs
@@ -1,0 +1,54 @@
+//! Per-call payload used inside the [EIP-8130] `calls` field.
+//!
+//! [EIP-8130]: https://eips.ethereum.org/EIPS/eip-8130
+
+use alloy_primitives::{Address, Bytes};
+use alloy_rlp::{RlpDecodable, RlpEncodable};
+
+/// A single call dispatched by the protocol during AA transaction execution.
+///
+/// Spec wire form: `rlp([to, data])` where `to` is a 20-byte address and `data`
+/// is the calldata. The dispatched call carries no value (`msg.value == 0`);
+/// ETH transfers must be performed by the wallet bytecode via the `CALL` opcode.
+///
+/// AA transactions group calls into phases (`Vec<Vec<Call>>`); see
+/// [`super::tx::TxAa8130::calls`].
+#[derive(Debug, Clone, PartialEq, Eq, Hash, RlpEncodable, RlpDecodable)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+pub struct Call {
+    /// Recipient address of the call.
+    pub to: Address,
+    /// Calldata passed to the recipient.
+    pub data: Bytes,
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_primitives::{address, bytes};
+    use alloy_rlp::{Decodable, Encodable};
+
+    use super::*;
+
+    #[test]
+    fn rlp_roundtrip() {
+        let call = Call {
+            to: address!("0x00000000000000000000000000000000000000aa"),
+            data: bytes!("deadbeef"),
+        };
+        let mut buf = Vec::new();
+        call.encode(&mut buf);
+        let decoded = Call::decode(&mut buf.as_slice()).unwrap();
+        assert_eq!(call, decoded);
+    }
+
+    #[test]
+    fn rlp_roundtrip_empty_data() {
+        let call = Call { to: Address::ZERO, data: Bytes::new() };
+        let mut buf = Vec::new();
+        call.encode(&mut buf);
+        let decoded = Call::decode(&mut buf.as_slice()).unwrap();
+        assert_eq!(call, decoded);
+    }
+}

--- a/crates/common/consensus/src/transaction/aa8130/constants.rs
+++ b/crates/common/consensus/src/transaction/aa8130/constants.rs
@@ -1,0 +1,139 @@
+//! Constants for the [EIP-8130] Account Abstraction transaction type.
+//!
+//! [EIP-8130]: https://eips.ethereum.org/EIPS/eip-8130
+
+use alloy_primitives::U256;
+
+/// Container for [EIP-8130] protocol constants.
+///
+/// All constants are exposed as associated `pub const` items so the public API
+/// is type-anchored (per repo convention: "the public API exports types, not loose
+/// functions").
+///
+/// Spec status (as of writing): EIP-8130 is in Draft. Several numeric constants
+/// are marked TBD in the spec; concrete values used here are project choices
+/// that can be renumbered when the spec finalizes.
+/// for rationale.
+///
+/// [EIP-8130]: https://eips.ethereum.org/EIPS/eip-8130
+#[derive(Debug)]
+pub struct Aa8130Constants;
+
+impl Aa8130Constants {
+    /// [EIP-2718] transaction type byte for AA transactions (`AA_TX_TYPE`).
+    ///
+    /// Spec value: TBD. We use `0x7D`, picked to live in the high "OP-style"
+    /// type-byte range adjacent to (but distinct from) the deposit type `0x7E`,
+    /// and to be easy to renumber once the EIP finalizes.
+    ///
+    /// [EIP-2718]: https://eips.ethereum.org/EIPS/eip-2718
+    pub const AA_TX_TYPE: u8 = 0x7D;
+
+    /// Magic prefix byte for payer signature domain separation (`AA_PAYER_TYPE`).
+    ///
+    /// Used in the payer signature preimage:
+    /// `keccak256(AA_PAYER_TYPE || rlp([...fields through calls...]))`.
+    ///
+    /// Spec value: TBD. We use `0xFA`, distinct from any registered EIP-2718
+    /// transaction type byte to prevent cross-domain reuse.
+    pub const AA_PAYER_TYPE: u8 = 0xFA;
+
+    /// Base intrinsic gas cost for any AA transaction (`AA_BASE_COST`).
+    pub const AA_BASE_COST: u64 = 15_000;
+
+    /// Sentinel `nonce_key` value selecting nonce-free mode (`NONCE_KEY_MAX`).
+    ///
+    /// When `nonce_key == NONCE_KEY_MAX`, no nonce state is read or written
+    /// and replay protection relies on `expiry` (which must be non-zero).
+    pub const NONCE_KEY_MAX: U256 = U256::MAX;
+
+    /// Owner scope bit: ERC-1271 `verifySignature()` context.
+    pub const SCOPE_SIGNATURE: u8 = 0x01;
+
+    /// Owner scope bit: `sender_auth` validation context.
+    pub const SCOPE_SENDER: u8 = 0x02;
+
+    /// Owner scope bit: `payer_auth` validation context.
+    pub const SCOPE_PAYER: u8 = 0x04;
+
+    /// Owner scope bit: config change `auth` context.
+    pub const SCOPE_CONFIG: u8 = 0x08;
+
+    /// Unrestricted scope value (owner is valid in all contexts).
+    pub const SCOPE_UNRESTRICTED: u8 = 0x00;
+
+    /// [EIP-7702]-style delegation indicator code prefix.
+    ///
+    /// A delegated account's code is exactly `DELEGATION_INDICATOR_PREFIX || target`
+    /// where `target` is a 20-byte address.
+    ///
+    /// [EIP-7702]: https://eips.ethereum.org/EIPS/eip-7702
+    pub const DELEGATION_INDICATOR_PREFIX: [u8; 3] = [0xef, 0x01, 0x00];
+
+    /// Total length in bytes of an [EIP-7702] delegation indicator
+    /// (`DELEGATION_INDICATOR_PREFIX || target`).
+    ///
+    /// [EIP-7702]: https://eips.ethereum.org/EIPS/eip-7702
+    pub const DELEGATION_INDICATOR_SIZE: usize = 23;
+
+    /// `account_changes` entry type byte: account creation.
+    pub const ACCOUNT_CHANGE_TYPE_CREATE: u8 = 0x00;
+
+    /// `account_changes` entry type byte: owner config change.
+    pub const ACCOUNT_CHANGE_TYPE_CONFIG: u8 = 0x01;
+
+    /// `account_changes` entry type byte: code delegation.
+    pub const ACCOUNT_CHANGE_TYPE_DELEGATION: u8 = 0x02;
+
+    /// `owner_change` operation byte: authorize a new owner.
+    pub const OWNER_CHANGE_AUTHORIZE: u8 = 0x01;
+
+    /// `owner_change` operation byte: revoke an existing owner.
+    pub const OWNER_CHANGE_REVOKE: u8 = 0x02;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const LEGACY_TX_TYPE: u8 = 0x00;
+    const EIP2930_TX_TYPE: u8 = 0x01;
+    const EIP1559_TX_TYPE: u8 = 0x02;
+    const EIP7702_TX_TYPE: u8 = 0x04;
+    const DEPOSIT_TX_TYPE: u8 = 0x7E;
+
+    #[test]
+    fn type_bytes_are_distinct() {
+        assert_ne!(Aa8130Constants::AA_TX_TYPE, Aa8130Constants::AA_PAYER_TYPE);
+        assert_ne!(Aa8130Constants::AA_TX_TYPE, LEGACY_TX_TYPE);
+        assert_ne!(Aa8130Constants::AA_TX_TYPE, EIP2930_TX_TYPE);
+        assert_ne!(Aa8130Constants::AA_TX_TYPE, EIP1559_TX_TYPE);
+        assert_ne!(Aa8130Constants::AA_TX_TYPE, EIP7702_TX_TYPE);
+        assert_ne!(Aa8130Constants::AA_TX_TYPE, DEPOSIT_TX_TYPE);
+    }
+
+    #[test]
+    fn scope_bits_are_orthogonal() {
+        let bits = [
+            Aa8130Constants::SCOPE_SIGNATURE,
+            Aa8130Constants::SCOPE_SENDER,
+            Aa8130Constants::SCOPE_PAYER,
+            Aa8130Constants::SCOPE_CONFIG,
+        ];
+        let mut acc: u8 = 0;
+        for b in bits {
+            assert_eq!(b.count_ones(), 1, "scope bit must be a single bit");
+            assert_eq!(acc & b, 0, "scope bits must be orthogonal");
+            acc |= b;
+        }
+        assert_eq!(Aa8130Constants::SCOPE_UNRESTRICTED, 0);
+    }
+
+    #[test]
+    fn delegation_indicator_size_matches_prefix_plus_address() {
+        assert_eq!(
+            Aa8130Constants::DELEGATION_INDICATOR_SIZE,
+            Aa8130Constants::DELEGATION_INDICATOR_PREFIX.len() + 20
+        );
+    }
+}

--- a/crates/common/consensus/src/transaction/aa8130/mod.rs
+++ b/crates/common/consensus/src/transaction/aa8130/mod.rs
@@ -1,0 +1,25 @@
+//! [EIP-8130] Account Abstraction by Account Configuration transaction type.
+//!
+//! Provides type-only plumbing for the new transaction kind:
+//! [`TxAa8130`] (unsigned), [`AaSigned`] (signed envelope), [`AccountChange`]
+//! (tagged-union account-mutation entries), and [`Call`] (per-call payload).
+//!
+//! [EIP-8130]: https://eips.ethereum.org/EIPS/eip-8130
+
+mod constants;
+pub use constants::Aa8130Constants;
+
+mod call;
+pub use call::Call;
+
+mod account_changes;
+pub use account_changes::{
+    AccountChange, ConfigChange, CreateEntry, Delegation, InitialOwner, OwnerChange,
+    OwnerChangeType, Scope,
+};
+
+mod tx;
+pub use tx::TxAa8130;
+
+mod signed;
+pub use signed::AaSigned;

--- a/crates/common/consensus/src/transaction/aa8130/signed.rs
+++ b/crates/common/consensus/src/transaction/aa8130/signed.rs
@@ -30,9 +30,6 @@ use crate::transaction::aa8130::{constants::Aa8130Constants, tx::TxAa8130};
 ///
 /// [EIP-8130]: https://eips.ethereum.org/EIPS/eip-8130
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 pub struct AaSigned {
     /// Unsigned transaction body.
     tx: TxAa8130,
@@ -52,6 +49,51 @@ pub struct AaSigned {
     payer_auth: Bytes,
     /// Cached EIP-2718 transaction hash (`keccak256(encode_2718(self))`).
     hash: B256,
+}
+
+#[cfg(feature = "serde")]
+mod serde_impl {
+    use super::{AaSigned, Bytes, TxAa8130};
+    use serde::{Deserialize, Deserializer, Serialize, Serializer, de};
+
+    #[derive(Serialize, Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    struct AaSignedRepr {
+        tx: TxAa8130,
+        sender_auth: Bytes,
+        payer_auth: Bytes,
+    }
+
+    impl Serialize for AaSigned {
+        fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: Serializer,
+        {
+            AaSignedRepr {
+                tx: self.tx.clone(),
+                sender_auth: self.sender_auth.clone(),
+                payer_auth: self.payer_auth.clone(),
+            }
+            .serialize(serializer)
+        }
+    }
+
+    impl<'de> Deserialize<'de> for AaSigned {
+        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where
+            D: Deserializer<'de>,
+        {
+            let repr = AaSignedRepr::deserialize(deserializer).map_err(de::Error::custom)?;
+            Ok(Self::new(repr.tx, repr.sender_auth, repr.payer_auth))
+        }
+    }
+}
+
+#[cfg(feature = "arbitrary")]
+impl<'a> arbitrary::Arbitrary<'a> for AaSigned {
+    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+        Ok(Self::new(TxAa8130::arbitrary(u)?, Bytes::arbitrary(u)?, Bytes::arbitrary(u)?))
+    }
 }
 
 impl AaSigned {
@@ -401,5 +443,33 @@ mod tests {
             signed.explicit_sender(),
             Some(address!("0x00000000000000000000000000000000000000aa"))
         );
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn serde_roundtrip_recomputes_hash() {
+        let signed = sample_signed(true);
+        let json = serde_json::to_string(&signed).unwrap();
+
+        assert!(!json.contains("\"hash\""));
+
+        let decoded: AaSigned = serde_json::from_str(&json).unwrap();
+        assert_eq!(decoded, signed);
+        assert_eq!(decoded.hash(), signed.hash());
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn serde_deserialize_computes_hash_from_payload() {
+        let signed = sample_signed(false);
+        let mut value = serde_json::to_value(&signed).unwrap();
+        value
+            .as_object_mut()
+            .unwrap()
+            .insert("hash".to_string(), serde_json::Value::String(format!("{:?}", B256::ZERO)));
+
+        let decoded: AaSigned = serde_json::from_value(value).unwrap();
+        assert_eq!(*decoded.hash(), *signed.hash());
+        assert_ne!(*decoded.hash(), B256::ZERO);
     }
 }

--- a/crates/common/consensus/src/transaction/aa8130/signed.rs
+++ b/crates/common/consensus/src/transaction/aa8130/signed.rs
@@ -53,8 +53,9 @@ pub struct AaSigned {
 
 #[cfg(feature = "serde")]
 mod serde_impl {
-    use super::{AaSigned, Bytes, TxAa8130};
     use serde::{Deserialize, Deserializer, Serialize, Serializer, de};
+
+    use super::{AaSigned, Bytes, TxAa8130};
 
     #[derive(Serialize, Deserialize)]
     #[serde(rename_all = "camelCase")]

--- a/crates/common/consensus/src/transaction/aa8130/signed.rs
+++ b/crates/common/consensus/src/transaction/aa8130/signed.rs
@@ -26,8 +26,7 @@ use crate::transaction::aa8130::{constants::Aa8130Constants, tx::TxAa8130};
 /// Signed [EIP-8130] Account Abstraction transaction envelope.
 ///
 /// Holds the unsigned [`TxAa8130`] body plus the two authentication byte
-/// strings. The transaction hash is recomputed on each [`Self::hash`] call;
-/// callers that need caching should wrap in an outer cache.
+/// strings. The transaction hash is computed at construction and cached.
 ///
 /// [EIP-8130]: https://eips.ethereum.org/EIPS/eip-8130
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -51,12 +50,17 @@ pub struct AaSigned {
     /// [`TxAa8130::payer_signature_hash`] (with the resolved sender substituted).
     /// When `tx.payer.is_none()` this is empty.
     payer_auth: Bytes,
+    /// Cached EIP-2718 transaction hash (`keccak256(encode_2718(self))`).
+    hash: B256,
 }
 
 impl AaSigned {
-    /// Constructs a new [`AaSigned`] from its parts.
-    pub const fn new(tx: TxAa8130, sender_auth: Bytes, payer_auth: Bytes) -> Self {
-        Self { tx, sender_auth, payer_auth }
+    /// Constructs a new [`AaSigned`] from its parts, computing and caching
+    /// the EIP-2718 transaction hash.
+    pub fn new(tx: TxAa8130, sender_auth: Bytes, payer_auth: Bytes) -> Self {
+        let mut this = Self { tx, sender_auth, payer_auth, hash: B256::ZERO };
+        this.hash = this.recompute_hash();
+        this
     }
 
     /// Returns the unsigned transaction body.
@@ -79,9 +83,12 @@ impl AaSigned {
         &self.payer_auth
     }
 
-    /// Returns the EIP-2718 transaction hash, computed as
-    /// `keccak256(encode_2718(self))`. Not cached.
-    pub fn hash(&self) -> B256 {
+    /// Returns the cached EIP-2718 transaction hash.
+    pub const fn hash(&self) -> &B256 {
+        &self.hash
+    }
+
+    fn recompute_hash(&self) -> B256 {
         let mut buf = Vec::with_capacity(self.encode_2718_len());
         self.encode_2718(&mut buf);
         keccak256(&buf)
@@ -196,7 +203,7 @@ impl Encodable2718 for AaSigned {
     }
 
     fn trie_hash(&self) -> B256 {
-        self.hash()
+        self.hash
     }
 }
 
@@ -362,7 +369,7 @@ mod tests {
         let signed = sample_signed(false);
         let mut buf = Vec::new();
         signed.encode_2718(&mut buf);
-        assert_eq!(signed.hash(), keccak256(&buf));
+        assert_eq!(*signed.hash(), keccak256(&buf));
     }
 
     #[test]

--- a/crates/common/consensus/src/transaction/aa8130/signed.rs
+++ b/crates/common/consensus/src/transaction/aa8130/signed.rs
@@ -1,0 +1,398 @@
+//! Signed [EIP-8130] Account Abstraction transaction envelope ([`AaSigned`]).
+//!
+//! [`AaSigned`] wraps a [`TxAa8130`] together with the two opaque byte strings
+//! `sender_auth` and `payer_auth` that authenticate the sender and (optional)
+//! payer respectively. The wire format is:
+//!
+//! ```text
+//! AA_TX_TYPE || rlp([...TxAa8130 fields..., sender_auth, payer_auth])
+//! ```
+//!
+//! [EIP-8130]: https://eips.ethereum.org/EIPS/eip-8130
+
+use alloc::vec::Vec;
+
+use alloy_consensus::{InMemorySize, Transaction, Typed2718};
+use alloy_eips::{
+    eip2718::{Decodable2718, Eip2718Error, Eip2718Result, Encodable2718, IsTyped2718},
+    eip2930::AccessList,
+    eip7702::SignedAuthorization,
+};
+use alloy_primitives::{Address, B256, Bytes, ChainId, TxKind, U256, bytes::BufMut, keccak256};
+use alloy_rlp::{Decodable, Encodable, Header, length_of_length};
+
+use crate::transaction::aa8130::{constants::Aa8130Constants, tx::TxAa8130};
+
+/// Signed [EIP-8130] Account Abstraction transaction envelope.
+///
+/// Holds the unsigned [`TxAa8130`] body plus the two authentication byte
+/// strings. The transaction hash is recomputed on each [`Self::hash`] call;
+/// callers that need caching should wrap in an outer cache.
+///
+/// [EIP-8130]: https://eips.ethereum.org/EIPS/eip-8130
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+pub struct AaSigned {
+    /// Unsigned transaction body.
+    tx: TxAa8130,
+    /// Sender authentication payload.
+    ///
+    /// On the EOA path (`tx.sender == None`) this is a 65-byte ECDSA signature
+    /// (`r || s || v`) over [`TxAa8130::sender_signature_hash`].
+    /// On the configured-owner path (`tx.sender == Some(_)`) this is
+    /// `verifier(20) || verifier_data`.
+    sender_auth: Bytes,
+    /// Payer authentication payload, or empty for self-pay.
+    ///
+    /// When `tx.payer.is_some()` this carries the payer's authorization,
+    /// formatted as `verifier(20) || verifier_data` and validated against
+    /// [`TxAa8130::payer_signature_hash`] (with the resolved sender substituted).
+    /// When `tx.payer.is_none()` this is empty.
+    payer_auth: Bytes,
+}
+
+impl AaSigned {
+    /// Constructs a new [`AaSigned`] from its parts.
+    pub const fn new(tx: TxAa8130, sender_auth: Bytes, payer_auth: Bytes) -> Self {
+        Self { tx, sender_auth, payer_auth }
+    }
+
+    /// Returns the unsigned transaction body.
+    pub const fn tx(&self) -> &TxAa8130 {
+        &self.tx
+    }
+
+    /// Consumes the envelope and returns the unsigned transaction body.
+    pub fn into_tx(self) -> TxAa8130 {
+        self.tx
+    }
+
+    /// Returns the sender authentication payload.
+    pub const fn sender_auth(&self) -> &Bytes {
+        &self.sender_auth
+    }
+
+    /// Returns the payer authentication payload.
+    pub const fn payer_auth(&self) -> &Bytes {
+        &self.payer_auth
+    }
+
+    /// Returns the EIP-2718 transaction hash, computed as
+    /// `keccak256(encode_2718(self))`. Not cached.
+    pub fn hash(&self) -> B256 {
+        let mut buf = Vec::with_capacity(self.encode_2718_len());
+        self.encode_2718(&mut buf);
+        keccak256(&buf)
+    }
+
+    /// Returns the sender address if it is explicitly provided by the
+    /// transaction body (configured-owner path).
+    pub const fn explicit_sender(&self) -> Option<Address> {
+        self.tx.sender
+    }
+
+    fn rlp_payload_length(&self) -> usize {
+        self.tx.rlp_encoded_fields_length() + self.sender_auth.length() + self.payer_auth.length()
+    }
+
+    fn rlp_header(&self) -> Header {
+        Header { list: true, payload_length: self.rlp_payload_length() }
+    }
+
+    /// RLP-encodes the signed body (with list header) as
+    /// `rlp([...tx fields..., sender_auth, payer_auth])`.
+    pub fn rlp_encode_signed(&self, out: &mut dyn BufMut) {
+        self.rlp_header().encode(out);
+        self.tx.rlp_encode_fields(out);
+        self.sender_auth.encode(out);
+        self.payer_auth.encode(out);
+    }
+
+    fn rlp_encoded_signed_length(&self) -> usize {
+        let payload = self.rlp_payload_length();
+        length_of_length(payload) + payload
+    }
+
+    /// RLP-decodes the signed body produced by [`Self::rlp_encode_signed`].
+    pub fn rlp_decode_signed(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
+        let header = Header::decode(buf)?;
+        if !header.list {
+            return Err(alloy_rlp::Error::UnexpectedString);
+        }
+        let started = buf.len();
+        let tx = TxAa8130::rlp_decode_fields(buf)?;
+        let sender_auth = Bytes::decode(buf)?;
+        let payer_auth = Bytes::decode(buf)?;
+        let consumed = started - buf.len();
+        if consumed != header.payload_length {
+            return Err(alloy_rlp::Error::ListLengthMismatch {
+                expected: header.payload_length,
+                got: consumed,
+            });
+        }
+        Ok(Self::new(tx, sender_auth, payer_auth))
+    }
+}
+
+impl Encodable for AaSigned {
+    fn encode(&self, out: &mut dyn BufMut) {
+        let len = self.encode_2718_len();
+        Header { list: false, payload_length: len }.encode(out);
+        self.encode_2718(out);
+    }
+
+    fn length(&self) -> usize {
+        let inner = self.encode_2718_len();
+        length_of_length(inner) + inner
+    }
+}
+
+impl Decodable for AaSigned {
+    fn decode(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
+        let header = Header::decode(buf)?;
+        if header.list {
+            return Err(alloy_rlp::Error::Custom("expected EIP-2718 envelope, got list"));
+        }
+        if buf.len() < header.payload_length {
+            return Err(alloy_rlp::Error::InputTooShort);
+        }
+        let (mut payload, rest) = buf.split_at(header.payload_length);
+        *buf = rest;
+        let decoded = Self::decode_2718(&mut payload)
+            .map_err(|_| alloy_rlp::Error::Custom("invalid EIP-8130 envelope"))?;
+        if !payload.is_empty() {
+            return Err(alloy_rlp::Error::Custom("trailing bytes in EIP-8130 envelope"));
+        }
+        Ok(decoded)
+    }
+}
+
+impl Typed2718 for AaSigned {
+    fn ty(&self) -> u8 {
+        Aa8130Constants::AA_TX_TYPE
+    }
+}
+
+impl IsTyped2718 for AaSigned {
+    fn is_type(ty: u8) -> bool {
+        ty == Aa8130Constants::AA_TX_TYPE
+    }
+}
+
+impl Encodable2718 for AaSigned {
+    fn type_flag(&self) -> Option<u8> {
+        Some(Aa8130Constants::AA_TX_TYPE)
+    }
+
+    fn encode_2718_len(&self) -> usize {
+        1 + self.rlp_encoded_signed_length()
+    }
+
+    fn encode_2718(&self, out: &mut dyn BufMut) {
+        out.put_u8(Aa8130Constants::AA_TX_TYPE);
+        self.rlp_encode_signed(out);
+    }
+
+    fn trie_hash(&self) -> B256 {
+        self.hash()
+    }
+}
+
+impl Decodable2718 for AaSigned {
+    fn typed_decode(ty: u8, buf: &mut &[u8]) -> Eip2718Result<Self> {
+        if ty != Aa8130Constants::AA_TX_TYPE {
+            return Err(Eip2718Error::UnexpectedType(ty));
+        }
+        Self::rlp_decode_signed(buf).map_err(Into::into)
+    }
+
+    fn fallback_decode(_buf: &mut &[u8]) -> Eip2718Result<Self> {
+        Err(Eip2718Error::UnexpectedType(0))
+    }
+}
+
+impl InMemorySize for AaSigned {
+    fn size(&self) -> usize {
+        InMemorySize::size(&self.tx) + self.sender_auth.len() + self.payer_auth.len()
+    }
+}
+
+impl Transaction for AaSigned {
+    fn chain_id(&self) -> Option<ChainId> {
+        self.tx.chain_id()
+    }
+
+    fn nonce(&self) -> u64 {
+        self.tx.nonce()
+    }
+
+    fn gas_limit(&self) -> u64 {
+        self.tx.gas_limit()
+    }
+
+    fn gas_price(&self) -> Option<u128> {
+        self.tx.gas_price()
+    }
+
+    fn max_fee_per_gas(&self) -> u128 {
+        self.tx.max_fee_per_gas()
+    }
+
+    fn max_priority_fee_per_gas(&self) -> Option<u128> {
+        self.tx.max_priority_fee_per_gas()
+    }
+
+    fn max_fee_per_blob_gas(&self) -> Option<u128> {
+        self.tx.max_fee_per_blob_gas()
+    }
+
+    fn priority_fee_or_price(&self) -> u128 {
+        self.tx.priority_fee_or_price()
+    }
+
+    fn effective_gas_price(&self, base_fee: Option<u64>) -> u128 {
+        self.tx.effective_gas_price(base_fee)
+    }
+
+    fn is_dynamic_fee(&self) -> bool {
+        self.tx.is_dynamic_fee()
+    }
+
+    fn kind(&self) -> TxKind {
+        self.tx.kind()
+    }
+
+    fn is_create(&self) -> bool {
+        self.tx.is_create()
+    }
+
+    fn value(&self) -> U256 {
+        self.tx.value()
+    }
+
+    fn input(&self) -> &Bytes {
+        self.tx.input()
+    }
+
+    fn access_list(&self) -> Option<&AccessList> {
+        self.tx.access_list()
+    }
+
+    fn blob_versioned_hashes(&self) -> Option<&[B256]> {
+        self.tx.blob_versioned_hashes()
+    }
+
+    fn authorization_list(&self) -> Option<&[SignedAuthorization]> {
+        self.tx.authorization_list()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_primitives::{address, bytes};
+
+    use super::*;
+    use crate::transaction::aa8130::{
+        account_changes::{AccountChange, Delegation},
+        call::Call,
+    };
+
+    fn sample_signed(payer_present: bool) -> AaSigned {
+        let tx = TxAa8130 {
+            chain_id: 8453,
+            sender: Some(address!("0x00000000000000000000000000000000000000aa")),
+            nonce_key: U256::from(7u64),
+            nonce_sequence: 3,
+            expiry: 0,
+            max_priority_fee_per_gas: 1_000_000_000,
+            max_fee_per_gas: 5_000_000_000,
+            gas_limit: 250_000,
+            account_changes: vec![AccountChange::Delegation(Delegation { target: Address::ZERO })],
+            calls: vec![vec![Call {
+                to: address!("0x00000000000000000000000000000000000000bb"),
+                data: bytes!("01020304"),
+            }]],
+            payer: if payer_present {
+                Some(address!("0x00000000000000000000000000000000000000cc"))
+            } else {
+                None
+            },
+        };
+        AaSigned::new(
+            tx,
+            bytes!("deadbeef"),
+            if payer_present { bytes!("cafebabe") } else { Bytes::new() },
+        )
+    }
+
+    #[test]
+    fn eip2718_roundtrip_self_pay() {
+        let signed = sample_signed(false);
+        let mut buf = Vec::new();
+        signed.encode_2718(&mut buf);
+        assert_eq!(buf[0], Aa8130Constants::AA_TX_TYPE);
+        assert_eq!(buf.len(), signed.encode_2718_len());
+
+        let decoded = AaSigned::decode_2718(&mut buf.as_slice()).unwrap();
+        assert_eq!(signed, decoded);
+    }
+
+    #[test]
+    fn eip2718_roundtrip_sponsored() {
+        let signed = sample_signed(true);
+        let mut buf = Vec::new();
+        signed.encode_2718(&mut buf);
+        let decoded = AaSigned::decode_2718(&mut buf.as_slice()).unwrap();
+        assert_eq!(signed, decoded);
+    }
+
+    #[test]
+    fn rlp_envelope_roundtrip() {
+        let signed = sample_signed(true);
+        let mut buf = Vec::new();
+        signed.encode(&mut buf);
+        let decoded = AaSigned::decode(&mut buf.as_slice()).unwrap();
+        assert_eq!(signed, decoded);
+    }
+
+    #[test]
+    fn hash_is_keccak_of_eip2718_payload() {
+        let signed = sample_signed(false);
+        let mut buf = Vec::new();
+        signed.encode_2718(&mut buf);
+        assert_eq!(signed.hash(), keccak256(&buf));
+    }
+
+    #[test]
+    fn hash_is_deterministic() {
+        let signed = sample_signed(false);
+        assert_eq!(signed.hash(), signed.hash());
+    }
+
+    #[test]
+    fn ty_byte() {
+        let signed = sample_signed(false);
+        assert_eq!(signed.ty(), Aa8130Constants::AA_TX_TYPE);
+        assert_eq!(signed.type_flag(), Some(Aa8130Constants::AA_TX_TYPE));
+    }
+
+    #[test]
+    fn typed_decode_rejects_wrong_type() {
+        let signed = sample_signed(false);
+        let mut buf = Vec::new();
+        signed.rlp_encode_signed(&mut buf);
+        let res = AaSigned::typed_decode(0x00, &mut buf.as_slice());
+        assert!(res.is_err());
+    }
+
+    #[test]
+    fn explicit_sender_returns_field() {
+        let signed = sample_signed(false);
+        assert_eq!(
+            signed.explicit_sender(),
+            Some(address!("0x00000000000000000000000000000000000000aa"))
+        );
+    }
+}

--- a/crates/common/consensus/src/transaction/aa8130/tx.rs
+++ b/crates/common/consensus/src/transaction/aa8130/tx.rs
@@ -79,7 +79,7 @@ impl TxAa8130 {
     }
 
     /// Length contribution of an `Option<Address>` under [`Self::encode_address_opt`].
-    fn address_opt_encoded_length(addr: &Option<Address>) -> usize {
+    const fn address_opt_encoded_length(addr: &Option<Address>) -> usize {
         match addr {
             None => 1,
             Some(_) => 21,
@@ -213,8 +213,8 @@ impl TxAa8130 {
 
     /// Signing-hash preimage for the payer, per [EIP-8130].
     ///
-    /// `keccak256(AA_PAYER_TYPE || rlp([...unsigned body fields with sender
-    /// substituted by `resolved_sender`...]))`.
+    /// `keccak256(AA_PAYER_TYPE || rlp(unsigned body fields with the
+    /// `sender` slot replaced by the recovered sender address))`.
     ///
     /// [EIP-8130]: https://eips.ethereum.org/EIPS/eip-8130
     pub fn payer_signature_hash(&self, resolved_sender: Address) -> B256 {
@@ -322,13 +322,9 @@ impl Transaction for TxAa8130 {
     }
 
     fn effective_gas_price(&self, base_fee: Option<u64>) -> u128 {
-        match base_fee {
-            Some(bf) => {
-                let bf = bf as u128;
-                bf.saturating_add(self.max_priority_fee_per_gas).min(self.max_fee_per_gas)
-            }
-            None => self.max_fee_per_gas,
-        }
+        base_fee.map_or(self.max_fee_per_gas, |bf| {
+            (bf as u128).saturating_add(self.max_priority_fee_per_gas).min(self.max_fee_per_gas)
+        })
     }
 
     fn is_dynamic_fee(&self) -> bool {

--- a/crates/common/consensus/src/transaction/aa8130/tx.rs
+++ b/crates/common/consensus/src/transaction/aa8130/tx.rs
@@ -1,0 +1,545 @@
+//! Unsigned [EIP-8130] Account Abstraction transaction body ([`TxAa8130`]).
+//!
+//! This module defines the unsigned payload of an EIP-8130 transaction. The
+//! signed envelope (which wraps this type alongside the `sender_auth` and
+//! `payer_auth` byte strings) lives in [`super::signed`].
+//!
+//! [EIP-8130]: https://eips.ethereum.org/EIPS/eip-8130
+
+use alloc::vec::Vec;
+use core::mem;
+
+use alloy_consensus::{InMemorySize, SignableTransaction, Transaction, Typed2718};
+use alloy_eips::{eip2718::IsTyped2718, eip2930::AccessList, eip7702::SignedAuthorization};
+use alloy_primitives::{
+    Address, B256, Bytes, ChainId, Signature, TxKind, U256, bytes::BufMut, keccak256,
+};
+use alloy_rlp::{Decodable, Encodable, Header, length_of_length};
+
+use crate::transaction::aa8130::{
+    account_changes::AccountChange, call::Call, constants::Aa8130Constants,
+};
+
+/// Unsigned body of an [EIP-8130] Account Abstraction transaction.
+///
+/// On the wire, the signed form (an [`super::AaSigned`]) is
+/// `AA_TX_TYPE || rlp([...all fields..., sender_auth, payer_auth])`. The
+/// unsigned struct here carries only the consensus fields; signature material
+/// is held by [`super::AaSigned`].
+///
+/// Field semantics follow the [EIP-8130] draft. Two fields are nullable on the
+/// wire (encoded as a zero-length byte string when absent):
+///
+/// - [`Self::sender`]: `None` selects the EOA path (recovered from
+///   `sender_auth` as a 65-byte ECDSA signature); `Some` selects the
+///   configured-owner path with an explicit account address.
+/// - [`Self::payer`]: `None` selects self-pay (the resolved sender pays);
+///   `Some` selects sponsored pay (the payer address pays).
+///
+/// [EIP-8130]: https://eips.ethereum.org/EIPS/eip-8130
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Default)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+pub struct TxAa8130 {
+    /// EIP-155 chain ID this transaction is bound to.
+    pub chain_id: ChainId,
+    /// Explicit sender account address, or `None` for the EOA path.
+    pub sender: Option<Address>,
+    /// High 192 bits of the compound nonce; with `nonce_sequence` forms the
+    /// per-account replay protection key.
+    pub nonce_key: U256,
+    /// Sequence number within the nonce key.
+    pub nonce_sequence: u64,
+    /// Unix-seconds expiry timestamp; `0` means no expiry.
+    pub expiry: u64,
+    /// Max priority fee per gas (tip) the sender is willing to pay.
+    pub max_priority_fee_per_gas: u128,
+    /// Max total fee per gas (base + tip cap) the sender is willing to pay.
+    pub max_fee_per_gas: u128,
+    /// Gas limit for the entire AA transaction execution.
+    pub gas_limit: u64,
+    /// Account-mutation entries applied before calls execute.
+    pub account_changes: Vec<AccountChange>,
+    /// Calls dispatched by the protocol after account changes apply, grouped
+    /// into phases (`Vec<Vec<Call>>`).
+    pub calls: Vec<Vec<Call>>,
+    /// Optional explicit payer; `None` means the resolved sender pays gas.
+    pub payer: Option<Address>,
+}
+
+impl TxAa8130 {
+    /// Encodes an `Option<Address>` as the AA wire format: zero-length byte
+    /// string when `None`, 20-byte string when `Some`.
+    fn encode_address_opt(addr: &Option<Address>, out: &mut dyn BufMut) {
+        match addr {
+            None => Bytes::new().encode(out),
+            Some(a) => Bytes::copy_from_slice(a.as_slice()).encode(out),
+        }
+    }
+
+    /// Length contribution of an `Option<Address>` under [`Self::encode_address_opt`].
+    fn address_opt_encoded_length(addr: &Option<Address>) -> usize {
+        match addr {
+            None => 1,
+            Some(_) => 21,
+        }
+    }
+
+    /// Decodes the [`Self::encode_address_opt`] wire format.
+    fn decode_address_opt(buf: &mut &[u8]) -> alloy_rlp::Result<Option<Address>> {
+        let raw = Bytes::decode(buf)?;
+        match raw.len() {
+            0 => Ok(None),
+            20 => Ok(Some(Address::from_slice(&raw))),
+            _ => Err(alloy_rlp::Error::Custom("invalid Option<Address> length")),
+        }
+    }
+
+    /// Encodes the inner phase list of `calls` as `rlp([rlp([Call, ...]), ...])`.
+    fn encode_calls(calls: &[Vec<Call>], out: &mut dyn BufMut) {
+        let mut payload_len = 0usize;
+        for phase in calls {
+            payload_len += phase.length();
+        }
+        Header { list: true, payload_length: payload_len }.encode(out);
+        for phase in calls {
+            phase.encode(out);
+        }
+    }
+
+    /// Total RLP length of the `calls` field as encoded by [`Self::encode_calls`].
+    fn calls_encoded_length(calls: &[Vec<Call>]) -> usize {
+        let mut payload_len = 0usize;
+        for phase in calls {
+            payload_len += phase.length();
+        }
+        length_of_length(payload_len) + payload_len
+    }
+
+    fn decode_calls(buf: &mut &[u8]) -> alloy_rlp::Result<Vec<Vec<Call>>> {
+        let header = Header::decode(buf)?;
+        if !header.list {
+            return Err(alloy_rlp::Error::UnexpectedString);
+        }
+        let started = buf.len();
+        let mut phases = Vec::new();
+        while started - buf.len() < header.payload_length {
+            phases.push(Vec::<Call>::decode(buf)?);
+        }
+        let consumed = started - buf.len();
+        if consumed != header.payload_length {
+            return Err(alloy_rlp::Error::ListLengthMismatch {
+                expected: header.payload_length,
+                got: consumed,
+            });
+        }
+        Ok(phases)
+    }
+
+    /// Length of all RLP fields (no list header).
+    pub fn rlp_encoded_fields_length(&self) -> usize {
+        self.chain_id.length()
+            + Self::address_opt_encoded_length(&self.sender)
+            + self.nonce_key.length()
+            + self.nonce_sequence.length()
+            + self.expiry.length()
+            + self.max_priority_fee_per_gas.length()
+            + self.max_fee_per_gas.length()
+            + self.gas_limit.length()
+            + self.account_changes.length()
+            + Self::calls_encoded_length(&self.calls)
+            + Self::address_opt_encoded_length(&self.payer)
+    }
+
+    /// Encodes the RLP fields (no list header) in canonical order.
+    pub fn rlp_encode_fields(&self, out: &mut dyn BufMut) {
+        self.chain_id.encode(out);
+        Self::encode_address_opt(&self.sender, out);
+        self.nonce_key.encode(out);
+        self.nonce_sequence.encode(out);
+        self.expiry.encode(out);
+        self.max_priority_fee_per_gas.encode(out);
+        self.max_fee_per_gas.encode(out);
+        self.gas_limit.encode(out);
+        self.account_changes.encode(out);
+        Self::encode_calls(&self.calls, out);
+        Self::encode_address_opt(&self.payer, out);
+    }
+
+    /// Decodes the RLP fields (no list header) in canonical order.
+    pub fn rlp_decode_fields(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
+        Ok(Self {
+            chain_id: Decodable::decode(buf)?,
+            sender: Self::decode_address_opt(buf)?,
+            nonce_key: Decodable::decode(buf)?,
+            nonce_sequence: Decodable::decode(buf)?,
+            expiry: Decodable::decode(buf)?,
+            max_priority_fee_per_gas: Decodable::decode(buf)?,
+            max_fee_per_gas: Decodable::decode(buf)?,
+            gas_limit: Decodable::decode(buf)?,
+            account_changes: Decodable::decode(buf)?,
+            calls: Self::decode_calls(buf)?,
+            payer: Self::decode_address_opt(buf)?,
+        })
+    }
+
+    fn rlp_header(&self) -> Header {
+        Header { list: true, payload_length: self.rlp_encoded_fields_length() }
+    }
+
+    /// RLP-encodes the unsigned transaction body (with list header).
+    pub fn rlp_encode(&self, out: &mut dyn BufMut) {
+        self.rlp_header().encode(out);
+        self.rlp_encode_fields(out);
+    }
+
+    /// Returns the RLP-encoded length of the unsigned transaction body.
+    pub fn rlp_encoded_length(&self) -> usize {
+        self.rlp_header().length_with_payload()
+    }
+
+    /// Signing-hash preimage for the sender, per [EIP-8130].
+    ///
+    /// `keccak256(AA_TX_TYPE || rlp([...unsigned body fields...]))`.
+    ///
+    /// [EIP-8130]: https://eips.ethereum.org/EIPS/eip-8130
+    pub fn sender_signature_hash(&self) -> B256 {
+        let mut buf = Vec::with_capacity(self.rlp_encoded_length() + 1);
+        buf.put_u8(Aa8130Constants::AA_TX_TYPE);
+        self.rlp_encode(&mut buf);
+        keccak256(&buf)
+    }
+
+    /// Signing-hash preimage for the payer, per [EIP-8130].
+    ///
+    /// `keccak256(AA_PAYER_TYPE || rlp([...unsigned body fields with sender
+    /// substituted by `resolved_sender`...]))`.
+    ///
+    /// [EIP-8130]: https://eips.ethereum.org/EIPS/eip-8130
+    pub fn payer_signature_hash(&self, resolved_sender: Address) -> B256 {
+        let with_resolved = Self { sender: Some(resolved_sender), ..self.clone() };
+        let mut buf = Vec::with_capacity(with_resolved.rlp_encoded_length() + 1);
+        buf.put_u8(Aa8130Constants::AA_PAYER_TYPE);
+        with_resolved.rlp_encode(&mut buf);
+        keccak256(&buf)
+    }
+
+    /// In-memory size heuristic.
+    pub fn size(&self) -> usize {
+        mem::size_of::<ChainId>()
+            + mem::size_of::<Option<Address>>()
+            + mem::size_of::<U256>()
+            + mem::size_of::<u64>()
+            + mem::size_of::<u64>()
+            + mem::size_of::<u128>()
+            + mem::size_of::<u128>()
+            + mem::size_of::<u64>()
+            + self.account_changes.capacity() * mem::size_of::<AccountChange>()
+            + self.calls.iter().map(|p| p.capacity() * mem::size_of::<Call>()).sum::<usize>()
+            + mem::size_of::<Option<Address>>()
+    }
+}
+
+impl Encodable for TxAa8130 {
+    fn encode(&self, out: &mut dyn BufMut) {
+        self.rlp_encode(out);
+    }
+
+    fn length(&self) -> usize {
+        self.rlp_encoded_length()
+    }
+}
+
+impl Decodable for TxAa8130 {
+    fn decode(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
+        let header = Header::decode(buf)?;
+        if !header.list {
+            return Err(alloy_rlp::Error::UnexpectedString);
+        }
+        let started = buf.len();
+        let this = Self::rlp_decode_fields(buf)?;
+        let consumed = started - buf.len();
+        if consumed != header.payload_length {
+            return Err(alloy_rlp::Error::ListLengthMismatch {
+                expected: header.payload_length,
+                got: consumed,
+            });
+        }
+        Ok(this)
+    }
+}
+
+impl Typed2718 for TxAa8130 {
+    fn ty(&self) -> u8 {
+        Aa8130Constants::AA_TX_TYPE
+    }
+}
+
+impl IsTyped2718 for TxAa8130 {
+    fn is_type(ty: u8) -> bool {
+        ty == Aa8130Constants::AA_TX_TYPE
+    }
+}
+
+impl InMemorySize for TxAa8130 {
+    fn size(&self) -> usize {
+        Self::size(self)
+    }
+}
+
+impl Transaction for TxAa8130 {
+    fn chain_id(&self) -> Option<ChainId> {
+        Some(self.chain_id)
+    }
+
+    fn nonce(&self) -> u64 {
+        self.nonce_sequence
+    }
+
+    fn gas_limit(&self) -> u64 {
+        self.gas_limit
+    }
+
+    fn gas_price(&self) -> Option<u128> {
+        None
+    }
+
+    fn max_fee_per_gas(&self) -> u128 {
+        self.max_fee_per_gas
+    }
+
+    fn max_priority_fee_per_gas(&self) -> Option<u128> {
+        Some(self.max_priority_fee_per_gas)
+    }
+
+    fn max_fee_per_blob_gas(&self) -> Option<u128> {
+        None
+    }
+
+    fn priority_fee_or_price(&self) -> u128 {
+        self.max_priority_fee_per_gas
+    }
+
+    fn effective_gas_price(&self, base_fee: Option<u64>) -> u128 {
+        match base_fee {
+            Some(bf) => {
+                let bf = bf as u128;
+                bf.saturating_add(self.max_priority_fee_per_gas).min(self.max_fee_per_gas)
+            }
+            None => self.max_fee_per_gas,
+        }
+    }
+
+    fn is_dynamic_fee(&self) -> bool {
+        true
+    }
+
+    fn kind(&self) -> TxKind {
+        TxKind::Call(Address::ZERO)
+    }
+
+    fn is_create(&self) -> bool {
+        false
+    }
+
+    fn value(&self) -> U256 {
+        U256::ZERO
+    }
+
+    fn input(&self) -> &Bytes {
+        static EMPTY: Bytes = Bytes::new();
+        &EMPTY
+    }
+
+    fn access_list(&self) -> Option<&AccessList> {
+        None
+    }
+
+    fn blob_versioned_hashes(&self) -> Option<&[B256]> {
+        None
+    }
+
+    fn authorization_list(&self) -> Option<&[SignedAuthorization]> {
+        None
+    }
+}
+
+impl SignableTransaction<Signature> for TxAa8130 {
+    fn set_chain_id(&mut self, chain_id: ChainId) {
+        self.chain_id = chain_id;
+    }
+
+    fn encode_for_signing(&self, out: &mut dyn BufMut) {
+        out.put_u8(Aa8130Constants::AA_TX_TYPE);
+        self.rlp_encode(out);
+    }
+
+    fn payload_len_for_signature(&self) -> usize {
+        1 + self.rlp_encoded_length()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_primitives::{address, b256, bytes};
+
+    use super::*;
+    use crate::transaction::aa8130::account_changes::Delegation;
+
+    fn sample_tx() -> TxAa8130 {
+        TxAa8130 {
+            chain_id: 8453,
+            sender: Some(address!("0x00000000000000000000000000000000000000aa")),
+            nonce_key: U256::from(0x1234u64),
+            nonce_sequence: 7,
+            expiry: 0,
+            max_priority_fee_per_gas: 1_000_000_000,
+            max_fee_per_gas: 5_000_000_000,
+            gas_limit: 200_000,
+            account_changes: vec![AccountChange::Delegation(Delegation {
+                target: address!("0x00000000000000000000000000000000000000bb"),
+            })],
+            calls: vec![vec![Call {
+                to: address!("0x00000000000000000000000000000000000000cc"),
+                data: bytes!("deadbeef"),
+            }]],
+            payer: None,
+        }
+    }
+
+    #[test]
+    fn rlp_roundtrip_full() {
+        let tx = sample_tx();
+        let mut buf = Vec::new();
+        tx.rlp_encode(&mut buf);
+        assert_eq!(buf.len(), tx.rlp_encoded_length());
+        let decoded = TxAa8130::rlp_decode_fields(&mut {
+            let header = Header::decode(&mut &buf[..]).unwrap();
+            assert!(header.list);
+            &buf[buf.len() - header.payload_length..]
+        })
+        .unwrap();
+        assert_eq!(tx, decoded);
+    }
+
+    #[test]
+    fn rlp_roundtrip_via_decodable() {
+        let tx = sample_tx();
+        let mut buf = Vec::new();
+        tx.encode(&mut buf);
+        let decoded = TxAa8130::decode(&mut buf.as_slice()).unwrap();
+        assert_eq!(tx, decoded);
+    }
+
+    #[test]
+    fn rlp_roundtrip_minimal_empty() {
+        let tx = TxAa8130::default();
+        let mut buf = Vec::new();
+        tx.encode(&mut buf);
+        let decoded = TxAa8130::decode(&mut buf.as_slice()).unwrap();
+        assert_eq!(tx, decoded);
+    }
+
+    #[test]
+    fn address_opt_roundtrip_none() {
+        let mut buf = Vec::new();
+        TxAa8130::encode_address_opt(&None, &mut buf);
+        assert_eq!(buf, vec![0x80]);
+        let decoded = TxAa8130::decode_address_opt(&mut buf.as_slice()).unwrap();
+        assert_eq!(decoded, None);
+    }
+
+    #[test]
+    fn address_opt_roundtrip_some() {
+        let addr = address!("0x00000000000000000000000000000000000000ff");
+        let mut buf = Vec::new();
+        TxAa8130::encode_address_opt(&Some(addr), &mut buf);
+        let decoded = TxAa8130::decode_address_opt(&mut buf.as_slice()).unwrap();
+        assert_eq!(decoded, Some(addr));
+    }
+
+    #[test]
+    fn address_opt_rejects_wrong_length() {
+        let mut buf = Vec::new();
+        Bytes::copy_from_slice(&[0u8; 19]).encode(&mut buf);
+        let res = TxAa8130::decode_address_opt(&mut buf.as_slice());
+        assert!(res.is_err());
+    }
+
+    #[test]
+    fn signing_hashes_are_distinct() {
+        let tx = sample_tx();
+        let sender_hash = tx.sender_signature_hash();
+        let payer_hash =
+            tx.payer_signature_hash(address!("0x00000000000000000000000000000000000000dd"));
+        assert_ne!(sender_hash, payer_hash);
+    }
+
+    #[test]
+    fn signing_hashes_use_prefix_bytes() {
+        let tx = sample_tx();
+        let h = tx.sender_signature_hash();
+        assert_ne!(h, B256::ZERO);
+    }
+
+    #[test]
+    fn ty_byte_matches_constant() {
+        assert_eq!(sample_tx().ty(), Aa8130Constants::AA_TX_TYPE);
+        assert!(<TxAa8130 as IsTyped2718>::is_type(Aa8130Constants::AA_TX_TYPE));
+        assert!(!<TxAa8130 as IsTyped2718>::is_type(0x00));
+    }
+
+    #[test]
+    fn nested_calls_roundtrip() {
+        let tx = TxAa8130 {
+            chain_id: 1,
+            calls: vec![
+                vec![Call { to: Address::ZERO, data: bytes!("01") }],
+                vec![],
+                vec![
+                    Call { to: Address::ZERO, data: bytes!("02") },
+                    Call { to: Address::ZERO, data: bytes!("03") },
+                ],
+            ],
+            ..Default::default()
+        };
+        let mut buf = Vec::new();
+        tx.encode(&mut buf);
+        let decoded = TxAa8130::decode(&mut buf.as_slice()).unwrap();
+        assert_eq!(tx, decoded);
+    }
+
+    #[test]
+    fn account_change_roundtrip_in_tx() {
+        let tx = TxAa8130 {
+            chain_id: 1,
+            account_changes: vec![
+                AccountChange::Delegation(Delegation { target: Address::ZERO }),
+                AccountChange::Delegation(Delegation {
+                    target: address!("0x00000000000000000000000000000000000000ee"),
+                }),
+            ],
+            ..Default::default()
+        };
+        let mut buf = Vec::new();
+        tx.encode(&mut buf);
+        let decoded = TxAa8130::decode(&mut buf.as_slice()).unwrap();
+        assert_eq!(tx.account_changes, decoded.account_changes);
+    }
+
+    #[test]
+    fn payer_signature_hash_uses_substituted_sender() {
+        let mut tx = sample_tx();
+        tx.sender = None;
+        let resolved = address!("0x00000000000000000000000000000000000000dd");
+        let payer_hash_v1 = tx.payer_signature_hash(resolved);
+
+        let tx2 = TxAa8130 { sender: Some(resolved), ..tx.clone() };
+        let mut buf = Vec::with_capacity(tx2.rlp_encoded_length() + 1);
+        buf.put_u8(Aa8130Constants::AA_PAYER_TYPE);
+        tx2.rlp_encode(&mut buf);
+        let payer_hash_v2 = keccak256(&buf);
+        assert_eq!(payer_hash_v1, payer_hash_v2);
+    }
+}

--- a/crates/common/consensus/src/transaction/aa8130/tx.rs
+++ b/crates/common/consensus/src/transaction/aa8130/tx.rs
@@ -378,7 +378,7 @@ impl SignableTransaction<Signature> for TxAa8130 {
 
 #[cfg(test)]
 mod tests {
-    use alloy_primitives::{address, b256, bytes};
+    use alloy_primitives::{address, bytes};
 
     use super::*;
     use crate::transaction::aa8130::account_changes::Delegation;
@@ -531,7 +531,7 @@ mod tests {
         let resolved = address!("0x00000000000000000000000000000000000000dd");
         let payer_hash_v1 = tx.payer_signature_hash(resolved);
 
-        let tx2 = TxAa8130 { sender: Some(resolved), ..tx.clone() };
+        let tx2 = TxAa8130 { sender: Some(resolved), ..tx };
         let mut buf = Vec::with_capacity(tx2.rlp_encoded_length() + 1);
         buf.put_u8(Aa8130Constants::AA_PAYER_TYPE);
         tx2.rlp_encode(&mut buf);

--- a/crates/common/consensus/src/transaction/envelope.rs
+++ b/crates/common/consensus/src/transaction/envelope.rs
@@ -162,6 +162,10 @@ impl From<Signed<BaseTypedTransaction>> for BaseTxEnvelope {
                     tx.sender.is_none(),
                     "configured-owner EIP-8130 transactions must not be wrapped through the ECDSA Signed<BaseTypedTransaction> path; route them via BaseTxEnvelope::Aa8130 directly with the appropriate sender_auth",
                 );
+                debug_assert!(
+                    tx.payer.is_none(),
+                    "sponsored EIP-8130 transactions must not be wrapped through the ECDSA Signed<BaseTypedTransaction> path; the payer_auth would be silently dropped",
+                );
                 Self::Aa8130(AaSigned::new(tx, sig.as_bytes().into(), Bytes::new()))
             }
         }

--- a/crates/common/consensus/src/transaction/envelope.rs
+++ b/crates/common/consensus/src/transaction/envelope.rs
@@ -158,6 +158,10 @@ impl From<Signed<BaseTypedTransaction>> for BaseTxEnvelope {
             }
             BaseTypedTransaction::Deposit(tx) => Self::Deposit(Sealed::new_unchecked(tx, hash)),
             BaseTypedTransaction::Aa8130(tx) => {
+                debug_assert!(
+                    tx.sender.is_none(),
+                    "configured-owner EIP-8130 transactions must not be wrapped through the ECDSA Signed<BaseTypedTransaction> path; route them via BaseTxEnvelope::Aa8130 directly with the appropriate sender_auth",
+                );
                 Self::Aa8130(AaSigned::new(tx, sig.as_bytes().into(), Bytes::new()))
             }
         }

--- a/crates/common/consensus/src/transaction/envelope.rs
+++ b/crates/common/consensus/src/transaction/envelope.rs
@@ -242,7 +242,9 @@ impl From<BaseTxEnvelope> for alloy_rpc_types_eth::TransactionRequest {
             BaseTxEnvelope::Eip7702(tx) => tx.into_parts().0.into(),
             BaseTxEnvelope::Deposit(tx) => tx.into_inner().into(),
             BaseTxEnvelope::Legacy(tx) => tx.into_parts().0.into(),
-            BaseTxEnvelope::Aa8130(_) => Self::default(),
+            BaseTxEnvelope::Aa8130(_) => unimplemented!(
+                "BaseTxEnvelope::Aa8130 cannot be converted to an alloy TransactionRequest; AA transactions have no single sender/recipient/value to project into the legacy request shape"
+            ),
         }
     }
 }

--- a/crates/common/consensus/src/transaction/envelope.rs
+++ b/crates/common/consensus/src/transaction/envelope.rs
@@ -569,9 +569,10 @@ impl alloy_consensus::transaction::SignerRecoverable for BaseTxEnvelope {
             // The Deposit transaction does not have a signature. Directly return the
             // `from` address.
             Self::Deposit(tx) => return Ok(tx.from),
-            Self::Aa8130(tx) => {
-                return Ok(tx.explicit_sender().unwrap_or(alloy_primitives::Address::ZERO));
-            }
+            Self::Aa8130(tx) => match tx.explicit_sender() {
+                Some(sender) => return Ok(sender),
+                None => return Err(alloy_consensus::crypto::RecoveryError::new()),
+            },
         };
         let signature = match self {
             Self::Legacy(tx) => tx.signature(),
@@ -596,9 +597,10 @@ impl alloy_consensus::transaction::SignerRecoverable for BaseTxEnvelope {
             // The Deposit transaction does not have a signature. Directly return the
             // `from` address.
             Self::Deposit(tx) => return Ok(tx.from),
-            Self::Aa8130(tx) => {
-                return Ok(tx.explicit_sender().unwrap_or(alloy_primitives::Address::ZERO));
-            }
+            Self::Aa8130(tx) => match tx.explicit_sender() {
+                Some(sender) => return Ok(sender),
+                None => return Err(alloy_consensus::crypto::RecoveryError::new()),
+            },
         };
         let signature = match self {
             Self::Legacy(tx) => tx.signature(),
@@ -630,7 +632,9 @@ impl alloy_consensus::transaction::SignerRecoverable for BaseTxEnvelope {
                 alloy_consensus::transaction::SignerRecoverable::recover_unchecked_with_buf(tx, buf)
             }
             Self::Deposit(tx) => Ok(tx.from),
-            Self::Aa8130(tx) => Ok(tx.explicit_sender().unwrap_or(alloy_primitives::Address::ZERO)),
+            Self::Aa8130(tx) => {
+                tx.explicit_sender().ok_or_else(alloy_consensus::crypto::RecoveryError::new)
+            }
         }
     }
 }

--- a/crates/common/consensus/src/transaction/envelope.rs
+++ b/crates/common/consensus/src/transaction/envelope.rs
@@ -19,7 +19,7 @@ use revm::context::TxEnv;
 
 use crate::{
     BasePooledTransaction, TxDeposit,
-    transaction::{BaseTransactionInfo, DepositInfo},
+    transaction::{AaSigned, BaseTransactionInfo, DepositInfo, TxAa8130},
 };
 
 /// The Ethereum [EIP-2718] Transaction Envelope, modified for Base.
@@ -52,6 +52,11 @@ pub enum BaseTxEnvelope {
     #[envelope(ty = 126)]
     #[serde(serialize_with = "crate::serde_deposit_tx_rpc")]
     Deposit(Sealed<TxDeposit>),
+    /// An [EIP-8130] Account Abstraction transaction tagged with type 0x7D.
+    ///
+    /// [EIP-8130]: https://eips.ethereum.org/EIPS/eip-8130
+    #[envelope(ty = 125, typed = TxAa8130)]
+    Aa8130(AaSigned),
 }
 
 /// Represents a transaction envelope for Base chains.
@@ -152,6 +157,9 @@ impl From<Signed<BaseTypedTransaction>> for BaseTxEnvelope {
                 Self::Eip7702(tx)
             }
             BaseTypedTransaction::Deposit(tx) => Self::Deposit(Sealed::new_unchecked(tx, hash)),
+            BaseTypedTransaction::Aa8130(tx) => {
+                Self::Aa8130(AaSigned::new(tx, sig.as_bytes().into(), Bytes::new()))
+            }
         }
     }
 }
@@ -199,6 +207,9 @@ impl FromRecoveredTx<BaseTxEnvelope> for TxEnv {
             BaseTxEnvelope::Eip2930(tx) => Self::from_recovered_tx(tx.tx(), caller),
             BaseTxEnvelope::Eip7702(tx) => Self::from_recovered_tx(tx.tx(), caller),
             BaseTxEnvelope::Deposit(tx) => Self::from_recovered_tx(tx.inner(), caller),
+            BaseTxEnvelope::Aa8130(_) => {
+                unimplemented!("EIP-8130 AA transactions cannot be converted to TxEnv yet")
+            }
         }
     }
 }
@@ -223,6 +234,7 @@ impl From<BaseTxEnvelope> for alloy_rpc_types_eth::TransactionRequest {
             BaseTxEnvelope::Eip7702(tx) => tx.into_parts().0.into(),
             BaseTxEnvelope::Deposit(tx) => tx.into_inner().into(),
             BaseTxEnvelope::Legacy(tx) => tx.into_parts().0.into(),
+            BaseTxEnvelope::Aa8130(_) => Self::default(),
         }
     }
 }
@@ -321,6 +333,7 @@ impl BaseTxEnvelope {
             Self::Deposit(tx) => {
                 Err(ValueError::new(tx.into(), "Deposit transactions cannot be pooled"))
             }
+            Self::Aa8130(tx) => Ok(tx.into()),
         }
     }
 
@@ -346,6 +359,10 @@ impl BaseTxEnvelope {
             tx @ Self::Deposit(_) => Err(ValueError::new(
                 tx,
                 "Deposit transactions cannot be converted to ethereum transaction",
+            )),
+            tx @ Self::Aa8130(_) => Err(ValueError::new(
+                tx,
+                "EIP-8130 transactions cannot be converted to ethereum transaction",
             )),
         }
     }
@@ -384,14 +401,20 @@ impl BaseTxEnvelope {
     /// Returns mutable access to the input bytes.
     ///
     /// Caution: modifying this will cause side-effects on the hash.
+    ///
+    /// Panics for [`Self::Aa8130`] since EIP-8130 transactions have no single
+    /// input field; their payload is a list of calls.
     #[doc(hidden)]
-    pub const fn input_mut(&mut self) -> &mut Bytes {
+    pub fn input_mut(&mut self) -> &mut Bytes {
         match self {
             Self::Eip1559(tx) => &mut tx.tx_mut().input,
             Self::Eip2930(tx) => &mut tx.tx_mut().input,
             Self::Legacy(tx) => &mut tx.tx_mut().input,
             Self::Eip7702(tx) => &mut tx.tx_mut().input,
             Self::Deposit(tx) => &mut tx.inner_mut().input,
+            Self::Aa8130(_) => {
+                unimplemented!("EIP-8130 transactions have no single input field")
+            }
         }
     }
 
@@ -426,6 +449,12 @@ impl BaseTxEnvelope {
         matches!(self, Self::Deposit(_))
     }
 
+    /// Returns true if the transaction is an EIP-8130 AA transaction.
+    #[inline]
+    pub const fn is_aa8130(&self) -> bool {
+        matches!(self, Self::Aa8130(_))
+    }
+
     /// Returns the [`TxLegacy`] variant if the transaction is a legacy transaction.
     pub const fn as_legacy(&self) -> Option<&Signed<TxLegacy>> {
         match self {
@@ -458,16 +487,24 @@ impl BaseTxEnvelope {
         }
     }
 
+    /// Returns the [`AaSigned`] variant if the transaction is an EIP-8130 AA transaction.
+    pub const fn as_aa8130(&self) -> Option<&AaSigned> {
+        match self {
+            Self::Aa8130(tx) => Some(tx),
+            _ => None,
+        }
+    }
+
     /// Return the reference to signature.
     ///
-    /// Returns `None` if this is a deposit variant.
+    /// Returns `None` if this is a deposit or EIP-8130 variant.
     pub const fn signature(&self) -> Option<&Signature> {
         match self {
             Self::Legacy(tx) => Some(tx.signature()),
             Self::Eip2930(tx) => Some(tx.signature()),
             Self::Eip1559(tx) => Some(tx.signature()),
             Self::Eip7702(tx) => Some(tx.signature()),
-            Self::Deposit(_) => None,
+            Self::Deposit(_) | Self::Aa8130(_) => None,
         }
     }
 
@@ -479,6 +516,7 @@ impl BaseTxEnvelope {
             Self::Eip1559(_) => OpTxType::Eip1559,
             Self::Eip7702(_) => OpTxType::Eip7702,
             Self::Deposit(_) => OpTxType::Deposit,
+            Self::Aa8130(_) => OpTxType::Aa8130,
         }
     }
 
@@ -490,6 +528,7 @@ impl BaseTxEnvelope {
             Self::Eip2930(tx) => tx.hash(),
             Self::Eip7702(tx) => tx.hash(),
             Self::Deposit(tx) => tx.hash_ref(),
+            Self::Aa8130(tx) => tx.hash(),
         }
     }
 
@@ -506,6 +545,7 @@ impl BaseTxEnvelope {
             Self::Eip1559(t) => t.eip2718_encoded_length(),
             Self::Eip7702(t) => t.eip2718_encoded_length(),
             Self::Deposit(t) => t.eip2718_encoded_length(),
+            Self::Aa8130(t) => t.encode_2718_len(),
         }
     }
 }
@@ -529,13 +569,18 @@ impl alloy_consensus::transaction::SignerRecoverable for BaseTxEnvelope {
             // The Deposit transaction does not have a signature. Directly return the
             // `from` address.
             Self::Deposit(tx) => return Ok(tx.from),
+            Self::Aa8130(tx) => {
+                return Ok(tx.explicit_sender().unwrap_or(alloy_primitives::Address::ZERO));
+            }
         };
         let signature = match self {
             Self::Legacy(tx) => tx.signature(),
             Self::Eip2930(tx) => tx.signature(),
             Self::Eip1559(tx) => tx.signature(),
             Self::Eip7702(tx) => tx.signature(),
-            Self::Deposit(_) => unreachable!("Deposit transactions should not be handled here"),
+            Self::Deposit(_) | Self::Aa8130(_) => {
+                unreachable!("non-ECDSA variants short-circuit above")
+            }
         };
         alloy_consensus::crypto::secp256k1::recover_signer(signature, signature_hash)
     }
@@ -551,13 +596,18 @@ impl alloy_consensus::transaction::SignerRecoverable for BaseTxEnvelope {
             // The Deposit transaction does not have a signature. Directly return the
             // `from` address.
             Self::Deposit(tx) => return Ok(tx.from),
+            Self::Aa8130(tx) => {
+                return Ok(tx.explicit_sender().unwrap_or(alloy_primitives::Address::ZERO));
+            }
         };
         let signature = match self {
             Self::Legacy(tx) => tx.signature(),
             Self::Eip2930(tx) => tx.signature(),
             Self::Eip1559(tx) => tx.signature(),
             Self::Eip7702(tx) => tx.signature(),
-            Self::Deposit(_) => unreachable!("Deposit transactions should not be handled here"),
+            Self::Deposit(_) | Self::Aa8130(_) => {
+                unreachable!("non-ECDSA variants short-circuit above")
+            }
         };
         alloy_consensus::crypto::secp256k1::recover_signer_unchecked(signature, signature_hash)
     }
@@ -580,6 +630,7 @@ impl alloy_consensus::transaction::SignerRecoverable for BaseTxEnvelope {
                 alloy_consensus::transaction::SignerRecoverable::recover_unchecked_with_buf(tx, buf)
             }
             Self::Deposit(tx) => Ok(tx.from),
+            Self::Aa8130(tx) => Ok(tx.explicit_sender().unwrap_or(alloy_primitives::Address::ZERO)),
         }
     }
 }
@@ -595,7 +646,7 @@ pub(super) mod serde_bincode_compat {
     use serde::{Deserialize, Deserializer, Serialize, Serializer};
     use serde_with::{DeserializeAs, SerializeAs};
 
-    use crate::serde_bincode_compat::TxDeposit;
+    use crate::{serde_bincode_compat::TxDeposit, transaction::AaSigned};
 
     /// Bincode-compatible representation of an [`BaseTxEnvelope`].
     #[derive(Debug, Serialize, Deserialize)]
@@ -635,6 +686,16 @@ pub(super) mod serde_bincode_compat {
             /// Borrowed deposit transaction data.
             transaction: TxDeposit<'a>,
         },
+        /// EIP-8130 Account Abstraction variant.
+        Aa8130 {
+            /// Owned [`AaSigned`] envelope.
+            ///
+            /// The [`AaSigned`] payload includes variable-length `calls`,
+            /// `account_changes`, and authentication buffers, so we serialize
+            /// it directly instead of borrowing a flattened bincode-friendly
+            /// projection.
+            transaction: AaSigned,
+        },
     }
 
     impl<'a> From<&'a super::BaseTxEnvelope> for BaseTxEnvelope<'a> {
@@ -660,6 +721,9 @@ pub(super) mod serde_bincode_compat {
                     hash: sealed_deposit.seal(),
                     transaction: sealed_deposit.inner().into(),
                 },
+                super::BaseTxEnvelope::Aa8130(aa_signed) => {
+                    Self::Aa8130 { transaction: aa_signed.clone() }
+                }
             }
         }
     }
@@ -682,6 +746,7 @@ pub(super) mod serde_bincode_compat {
                 BaseTxEnvelope::Deposit { hash, transaction } => {
                     Self::Deposit(Sealed::new_unchecked(transaction.into(), hash))
                 }
+                BaseTxEnvelope::Aa8130 { transaction } => Self::Aa8130(transaction),
             }
         }
     }
@@ -752,6 +817,7 @@ impl InMemorySize for BaseTxEnvelope {
             Self::Eip1559(tx) => tx.size(),
             Self::Eip7702(tx) => tx.size(),
             Self::Deposit(tx) => tx.size(),
+            Self::Aa8130(tx) => tx.size(),
         }
     }
 }

--- a/crates/common/consensus/src/transaction/envelope.rs
+++ b/crates/common/consensus/src/transaction/envelope.rs
@@ -349,12 +349,21 @@ impl BaseTxEnvelope {
 
     /// Attempts to convert the envelope into the ethereum pooled variant.
     ///
-    /// Returns an error if the envelope's variant is incompatible with the pooled format:
-    /// [`TxDeposit`].
+    /// Returns an error if the envelope's variant is incompatible with the ethereum pooled
+    /// format: [`TxDeposit`] (not pooled at all) or [`AaSigned`] (pooled, but has no
+    /// ethereum-format representation since the alloy `PooledTransaction` enum has no
+    /// EIP-8130 variant). Rejecting [`AaSigned`] here prevents
+    /// `From<BasePooledTransaction> for alloy_consensus::PooledTransaction` from panicking.
     pub fn try_into_eth_pooled(
         self,
     ) -> Result<alloy_consensus::transaction::PooledTransaction, ValueError<Self>> {
-        self.try_into_pooled().map(Into::into)
+        match self {
+            tx @ Self::Aa8130(_) => Err(ValueError::new(
+                tx,
+                "EIP-8130 transactions cannot be converted to ethereum PooledTransaction",
+            )),
+            other => other.try_into_pooled().map(Into::into),
+        }
     }
 
     /// Attempts to convert the L2 variant into an ethereum [`TxEnvelope`].

--- a/crates/common/consensus/src/transaction/mod.rs
+++ b/crates/common/consensus/src/transaction/mod.rs
@@ -3,6 +3,12 @@
 mod deposit;
 pub use deposit::{DepositTransaction, TxDeposit};
 
+mod aa8130;
+pub use aa8130::{
+    Aa8130Constants, AaSigned, AccountChange, Call, ConfigChange, CreateEntry, Delegation,
+    InitialOwner, OwnerChange, OwnerChangeType, Scope, TxAa8130,
+};
+
 mod tx_type;
 pub use tx_type::DEPOSIT_TX_TYPE_ID;
 

--- a/crates/common/consensus/src/transaction/mod.rs
+++ b/crates/common/consensus/src/transaction/mod.rs
@@ -10,7 +10,7 @@ pub use aa8130::{
 };
 
 mod tx_type;
-pub use tx_type::DEPOSIT_TX_TYPE_ID;
+pub use tx_type::{DEPOSIT_TX_TYPE_ID, EIP8130_TX_TYPE_ID};
 
 mod envelope;
 pub use envelope::{BaseTransaction, BaseTxEnvelope, OpTxType};

--- a/crates/common/consensus/src/transaction/pooled.rs
+++ b/crates/common/consensus/src/transaction/pooled.rs
@@ -222,6 +222,9 @@ impl alloy_consensus::transaction::SignerRecoverable for BasePooledTransaction {
     fn recover_signer(
         &self,
     ) -> Result<alloy_primitives::Address, alloy_consensus::crypto::RecoveryError> {
+        if let Self::Aa8130(tx) = self {
+            return tx.explicit_sender().ok_or_else(alloy_consensus::crypto::RecoveryError::new);
+        }
         let signature_hash = self.signature_hash();
         alloy_consensus::crypto::secp256k1::recover_signer(self.signature(), signature_hash)
     }
@@ -229,6 +232,9 @@ impl alloy_consensus::transaction::SignerRecoverable for BasePooledTransaction {
     fn recover_signer_unchecked(
         &self,
     ) -> Result<alloy_primitives::Address, alloy_consensus::crypto::RecoveryError> {
+        if let Self::Aa8130(tx) = self {
+            return tx.explicit_sender().ok_or_else(alloy_consensus::crypto::RecoveryError::new);
+        }
         let signature_hash = self.signature_hash();
         alloy_consensus::crypto::secp256k1::recover_signer_unchecked(
             self.signature(),

--- a/crates/common/consensus/src/transaction/pooled.rs
+++ b/crates/common/consensus/src/transaction/pooled.rs
@@ -12,10 +12,7 @@ use alloy_consensus::{
 use alloy_eips::eip2718::Encodable2718;
 use alloy_primitives::{B256, Signature, TxHash, bytes};
 
-use crate::{
-    BaseTxEnvelope,
-    transaction::{AaSigned, TxAa8130},
-};
+use crate::{BaseTxEnvelope, transaction::AaSigned};
 
 /// All possible transactions that can be included in a response to `GetPooledTransactions`.
 /// A response to `GetPooledTransactions`. This can include a typed signed transaction, but cannot

--- a/crates/common/consensus/src/transaction/pooled.rs
+++ b/crates/common/consensus/src/transaction/pooled.rs
@@ -55,7 +55,7 @@ impl BasePooledTransaction {
             Self::Eip1559(tx) => tx.signature_hash(),
             Self::Eip7702(tx) => tx.signature_hash(),
             Self::Aa8130(_) => {
-                unreachable!("BasePooledTransaction::signature_hash invoked on EIP-8130 variant")
+                unimplemented!("BasePooledTransaction::signature_hash invoked on EIP-8130 variant")
             }
         }
     }
@@ -82,7 +82,7 @@ impl BasePooledTransaction {
             Self::Eip1559(tx) => tx.signature(),
             Self::Eip7702(tx) => tx.signature(),
             Self::Aa8130(_) => {
-                unreachable!("BasePooledTransaction::signature invoked on EIP-8130 variant")
+                unimplemented!("BasePooledTransaction::signature invoked on EIP-8130 variant")
             }
         }
     }
@@ -110,7 +110,7 @@ impl BasePooledTransaction {
             Self::Eip1559(tx) => tx.into(),
             Self::Eip7702(tx) => tx.into(),
             Self::Aa8130(_) => {
-                unreachable!("BasePooledTransaction::into_envelope invoked on EIP-8130 variant")
+                unimplemented!("BasePooledTransaction::into_envelope invoked on EIP-8130 variant")
             }
         }
     }
@@ -204,7 +204,7 @@ impl From<BasePooledTransaction> for alloy_consensus::transaction::PooledTransac
             BasePooledTransaction::Eip2930(tx) => tx.into(),
             BasePooledTransaction::Eip1559(tx) => tx.into(),
             BasePooledTransaction::Eip7702(tx) => tx.into(),
-            BasePooledTransaction::Aa8130(_) => unreachable!(
+            BasePooledTransaction::Aa8130(_) => unimplemented!(
                 "EIP-8130 transactions cannot be converted to ethereum PooledTransaction"
             ),
         }

--- a/crates/common/consensus/src/transaction/pooled.rs
+++ b/crates/common/consensus/src/transaction/pooled.rs
@@ -12,7 +12,10 @@ use alloy_consensus::{
 use alloy_eips::eip2718::Encodable2718;
 use alloy_primitives::{B256, Signature, TxHash, bytes};
 
-use crate::BaseTxEnvelope;
+use crate::{
+    BaseTxEnvelope,
+    transaction::{AaSigned, TxAa8130},
+};
 
 /// All possible transactions that can be included in a response to `GetPooledTransactions`.
 /// A response to `GetPooledTransactions`. This can include a typed signed transaction, but cannot
@@ -35,17 +38,28 @@ pub enum BasePooledTransaction {
     /// A [`TxEip7702`] transaction tagged with type 4.
     #[envelope(ty = 4)]
     Eip7702(Signed<TxEip7702>),
+    /// An [EIP-8130] Account Abstraction transaction tagged with type 0x7D.
+    ///
+    /// [EIP-8130]: https://eips.ethereum.org/EIPS/eip-8130
+    #[envelope(ty = 125, typed = TxAa8130)]
+    Aa8130(AaSigned),
 }
 
 impl BasePooledTransaction {
     /// Heavy operation that returns the signature hash over rlp encoded transaction. It is only
     /// for signature signing or signer recovery.
+    ///
+    /// Panics on the [`Self::Aa8130`] variant: EIP-8130 transactions do not
+    /// have a single ECDSA signature.
     pub fn signature_hash(&self) -> B256 {
         match self {
             Self::Legacy(tx) => tx.signature_hash(),
             Self::Eip2930(tx) => tx.signature_hash(),
             Self::Eip1559(tx) => tx.signature_hash(),
             Self::Eip7702(tx) => tx.signature_hash(),
+            Self::Aa8130(_) => {
+                unreachable!("BasePooledTransaction::signature_hash invoked on EIP-8130 variant")
+            }
         }
     }
 
@@ -56,16 +70,23 @@ impl BasePooledTransaction {
             Self::Eip2930(tx) => tx.hash(),
             Self::Eip1559(tx) => tx.hash(),
             Self::Eip7702(tx) => tx.hash(),
+            Self::Aa8130(tx) => tx.hash(),
         }
     }
 
     /// Returns the signature of the transaction.
-    pub const fn signature(&self) -> &Signature {
+    ///
+    /// Panics on the [`Self::Aa8130`] variant: EIP-8130 transactions do not
+    /// have a single ECDSA signature.
+    pub fn signature(&self) -> &Signature {
         match self {
             Self::Legacy(tx) => tx.signature(),
             Self::Eip2930(tx) => tx.signature(),
             Self::Eip1559(tx) => tx.signature(),
             Self::Eip7702(tx) => tx.signature(),
+            Self::Aa8130(_) => {
+                unreachable!("BasePooledTransaction::signature invoked on EIP-8130 variant")
+            }
         }
     }
 
@@ -77,16 +98,23 @@ impl BasePooledTransaction {
             Self::Eip2930(tx) => tx.tx().encode_for_signing(out),
             Self::Eip1559(tx) => tx.tx().encode_for_signing(out),
             Self::Eip7702(tx) => tx.tx().encode_for_signing(out),
+            Self::Aa8130(tx) => tx.tx().encode_for_signing(out),
         }
     }
 
     /// Converts the transaction into the ethereum [`TxEnvelope`].
+    ///
+    /// Panics on the [`Self::Aa8130`] variant: EIP-8130 is Base-specific and
+    /// has no corresponding ethereum envelope variant.
     pub fn into_envelope(self) -> TxEnvelope {
         match self {
             Self::Legacy(tx) => tx.into(),
             Self::Eip2930(tx) => tx.into(),
             Self::Eip1559(tx) => tx.into(),
             Self::Eip7702(tx) => tx.into(),
+            Self::Aa8130(_) => {
+                unreachable!("BasePooledTransaction::into_envelope invoked on EIP-8130 variant")
+            }
         }
     }
 
@@ -97,6 +125,15 @@ impl BasePooledTransaction {
             Self::Eip2930(tx) => tx.into(),
             Self::Eip1559(tx) => tx.into(),
             Self::Eip7702(tx) => tx.into(),
+            Self::Aa8130(tx) => BaseTxEnvelope::Aa8130(tx),
+        }
+    }
+
+    /// Returns the [`AaSigned`] variant if the transaction is an EIP-8130 transaction.
+    pub const fn as_aa8130(&self) -> Option<&AaSigned> {
+        match self {
+            Self::Aa8130(tx) => Some(tx),
+            _ => None,
         }
     }
 
@@ -157,6 +194,12 @@ impl From<Signed<TxEip7702>> for BasePooledTransaction {
     }
 }
 
+impl From<AaSigned> for BasePooledTransaction {
+    fn from(v: AaSigned) -> Self {
+        Self::Aa8130(v)
+    }
+}
+
 impl From<BasePooledTransaction> for alloy_consensus::transaction::PooledTransaction {
     fn from(value: BasePooledTransaction) -> Self {
         match value {
@@ -164,6 +207,9 @@ impl From<BasePooledTransaction> for alloy_consensus::transaction::PooledTransac
             BasePooledTransaction::Eip2930(tx) => tx.into(),
             BasePooledTransaction::Eip1559(tx) => tx.into(),
             BasePooledTransaction::Eip7702(tx) => tx.into(),
+            BasePooledTransaction::Aa8130(_) => unreachable!(
+                "EIP-8130 transactions cannot be converted to ethereum PooledTransaction"
+            ),
         }
     }
 }
@@ -210,6 +256,7 @@ impl alloy_consensus::transaction::SignerRecoverable for BasePooledTransaction {
             Self::Eip7702(tx) => {
                 alloy_consensus::transaction::SignerRecoverable::recover_unchecked_with_buf(tx, buf)
             }
+            Self::Aa8130(tx) => Ok(tx.explicit_sender().unwrap_or(alloy_primitives::Address::ZERO)),
         }
     }
 }
@@ -258,6 +305,7 @@ impl InMemorySize for BasePooledTransaction {
             Self::Eip2930(tx) => tx.size(),
             Self::Eip1559(tx) => tx.size(),
             Self::Eip7702(tx) => tx.size(),
+            Self::Aa8130(tx) => tx.size(),
         }
     }
 }

--- a/crates/common/consensus/src/transaction/pooled.rs
+++ b/crates/common/consensus/src/transaction/pooled.rs
@@ -253,7 +253,9 @@ impl alloy_consensus::transaction::SignerRecoverable for BasePooledTransaction {
             Self::Eip7702(tx) => {
                 alloy_consensus::transaction::SignerRecoverable::recover_unchecked_with_buf(tx, buf)
             }
-            Self::Aa8130(tx) => Ok(tx.explicit_sender().unwrap_or(alloy_primitives::Address::ZERO)),
+            Self::Aa8130(tx) => {
+                tx.explicit_sender().ok_or_else(alloy_consensus::crypto::RecoveryError::new)
+            }
         }
     }
 }

--- a/crates/common/consensus/src/transaction/tx_type.rs
+++ b/crates/common/consensus/src/transaction/tx_type.rs
@@ -9,6 +9,11 @@ use crate::transaction::envelope::OpTxType;
 /// Identifier for a deposit transaction
 pub const DEPOSIT_TX_TYPE_ID: u8 = 126; // 0x7E
 
+/// Identifier for an [EIP-8130] Account Abstraction transaction.
+///
+/// [EIP-8130]: https://eips.ethereum.org/EIPS/eip-8130
+pub const EIP8130_TX_TYPE_ID: u8 = 125; // 0x7D
+
 #[allow(clippy::derivable_impls)]
 impl Default for OpTxType {
     fn default() -> Self {
@@ -24,18 +29,24 @@ impl Display for OpTxType {
             Self::Eip1559 => write!(f, "eip1559"),
             Self::Eip7702 => write!(f, "eip7702"),
             Self::Deposit => write!(f, "deposit"),
+            Self::Aa8130 => write!(f, "aa8130"),
         }
     }
 }
 
 impl OpTxType {
     /// List of all variants.
-    pub const ALL: [Self; 5] =
-        [Self::Legacy, Self::Eip2930, Self::Eip1559, Self::Eip7702, Self::Deposit];
+    pub const ALL: [Self; 6] =
+        [Self::Legacy, Self::Eip2930, Self::Eip1559, Self::Eip7702, Self::Deposit, Self::Aa8130];
 
     /// Returns `true` if the type is [`OpTxType::Deposit`].
     pub const fn is_deposit(&self) -> bool {
         matches!(self, Self::Deposit)
+    }
+
+    /// Returns `true` if the type is [`OpTxType::Aa8130`].
+    pub const fn is_aa8130(&self) -> bool {
+        matches!(self, Self::Aa8130)
     }
 }
 
@@ -56,13 +67,14 @@ mod tests {
 
     #[test]
     fn test_all_tx_types() {
-        assert_eq!(OpTxType::ALL.len(), 5);
+        assert_eq!(OpTxType::ALL.len(), 6);
         let all = vec![
             OpTxType::Legacy,
             OpTxType::Eip2930,
             OpTxType::Eip1559,
             OpTxType::Eip7702,
             OpTxType::Deposit,
+            OpTxType::Aa8130,
         ];
         assert_eq!(OpTxType::ALL.to_vec(), all);
     }

--- a/crates/common/consensus/src/transaction/typed.rs
+++ b/crates/common/consensus/src/transaction/typed.rs
@@ -6,7 +6,7 @@ use alloy_eips::Encodable2718;
 use alloy_primitives::{B256, ChainId, Signature, TxHash, bytes::BufMut};
 
 pub use crate::transaction::envelope::BaseTypedTransaction;
-use crate::{BaseTxEnvelope, OpTxType, TxDeposit};
+use crate::{BaseTxEnvelope, OpTxType, TxAa8130, TxDeposit, transaction::AaSigned};
 
 impl From<TxLegacy> for BaseTypedTransaction {
     fn from(tx: TxLegacy) -> Self {
@@ -38,6 +38,12 @@ impl From<TxDeposit> for BaseTypedTransaction {
     }
 }
 
+impl From<TxAa8130> for BaseTypedTransaction {
+    fn from(tx: TxAa8130) -> Self {
+        Self::Aa8130(tx)
+    }
+}
+
 impl From<BaseTxEnvelope> for BaseTypedTransaction {
     fn from(envelope: BaseTxEnvelope) -> Self {
         match envelope {
@@ -46,6 +52,7 @@ impl From<BaseTxEnvelope> for BaseTypedTransaction {
             BaseTxEnvelope::Eip1559(tx) => Self::Eip1559(tx.strip_signature()),
             BaseTxEnvelope::Eip7702(tx) => Self::Eip7702(tx.strip_signature()),
             BaseTxEnvelope::Deposit(tx) => Self::Deposit(tx.into_inner()),
+            BaseTxEnvelope::Aa8130(tx) => Self::Aa8130(tx.into_tx()),
         }
     }
 }
@@ -59,6 +66,7 @@ impl From<BaseTypedTransaction> for alloy_rpc_types_eth::TransactionRequest {
             BaseTypedTransaction::Eip1559(tx) => tx.into(),
             BaseTypedTransaction::Eip7702(tx) => tx.into(),
             BaseTypedTransaction::Deposit(tx) => tx.into(),
+            BaseTypedTransaction::Aa8130(_) => Self::default(),
         }
     }
 }
@@ -72,12 +80,14 @@ impl BaseTypedTransaction {
             Self::Eip1559(_) => OpTxType::Eip1559,
             Self::Eip7702(_) => OpTxType::Eip7702,
             Self::Deposit(_) => OpTxType::Deposit,
+            Self::Aa8130(_) => OpTxType::Aa8130,
         }
     }
 
     /// Calculates the signing hash for the transaction.
     ///
-    /// Returns `None` if the tx is a deposit transaction.
+    /// Returns `None` if the tx is a deposit or EIP-8130 transaction (those
+    /// do not use a standard ECDSA single-signature path).
     pub fn checked_signature_hash(&self) -> Option<B256> {
         match self {
             Self::Legacy(tx) => Some(tx.signature_hash()),
@@ -85,6 +95,7 @@ impl BaseTypedTransaction {
             Self::Eip1559(tx) => Some(tx.signature_hash()),
             Self::Eip7702(tx) => Some(tx.signature_hash()),
             Self::Deposit(_) => None,
+            Self::Aa8130(_) => None,
         }
     }
 
@@ -125,9 +136,24 @@ impl BaseTypedTransaction {
         matches!(self, Self::Deposit(_))
     }
 
+    /// Return the inner EIP-8130 transaction if it exists.
+    pub const fn aa8130(&self) -> Option<&TxAa8130> {
+        match self {
+            Self::Aa8130(tx) => Some(tx),
+            _ => None,
+        }
+    }
+
+    /// Returns `true` if transaction is an EIP-8130 transaction.
+    pub const fn is_aa8130(&self) -> bool {
+        matches!(self, Self::Aa8130(_))
+    }
+
     /// Calculate the transaction hash for the given signature.
     ///
-    /// Note: Returns the regular tx hash if this is a deposit variant
+    /// For a deposit variant the regular tx hash is returned (signature ignored).
+    /// Panics on an EIP-8130 variant: that variant has no ECDSA signature and
+    /// callers must hash through the [`BaseTxEnvelope`] path instead.
     pub fn tx_hash(&self, signature: &Signature) -> TxHash {
         match self {
             Self::Legacy(tx) => tx.tx_hash(signature),
@@ -135,6 +161,9 @@ impl BaseTypedTransaction {
             Self::Eip1559(tx) => tx.tx_hash(signature),
             Self::Eip7702(tx) => tx.tx_hash(signature),
             Self::Deposit(tx) => tx.tx_hash(),
+            Self::Aa8130(_) => unreachable!(
+                "BaseTypedTransaction::tx_hash invoked on an EIP-8130 variant; use AaSigned::hash via the envelope path"
+            ),
         }
     }
 
@@ -159,6 +188,10 @@ impl BaseTypedTransaction {
                 tx,
                 "Deposit transactions cannot be converted to ethereum transaction",
             )),
+            tx @ Self::Aa8130(_) => Err(ValueError::new(
+                tx,
+                "EIP-8130 transactions cannot be converted to ethereum transaction",
+            )),
         }
     }
 }
@@ -171,6 +204,7 @@ impl RlpEcdsaEncodableTx for BaseTypedTransaction {
             Self::Eip1559(tx) => tx.rlp_encoded_fields_length(),
             Self::Eip7702(tx) => tx.rlp_encoded_fields_length(),
             Self::Deposit(tx) => tx.rlp_encoded_fields_length(),
+            Self::Aa8130(tx) => tx.rlp_encoded_fields_length(),
         }
     }
 
@@ -181,6 +215,7 @@ impl RlpEcdsaEncodableTx for BaseTypedTransaction {
             Self::Eip1559(tx) => tx.rlp_encode_fields(out),
             Self::Eip7702(tx) => tx.rlp_encode_fields(out),
             Self::Deposit(tx) => tx.rlp_encode_fields(out),
+            Self::Aa8130(tx) => tx.rlp_encode_fields(out),
         }
     }
 
@@ -191,6 +226,9 @@ impl RlpEcdsaEncodableTx for BaseTypedTransaction {
             Self::Eip1559(tx) => tx.eip2718_encode_with_type(signature, tx.ty(), out),
             Self::Eip7702(tx) => tx.eip2718_encode_with_type(signature, tx.ty(), out),
             Self::Deposit(tx) => tx.encode_2718(out),
+            Self::Aa8130(_) => unreachable!(
+                "BaseTypedTransaction::eip2718_encode_with_type invoked on EIP-8130 variant; use AaSigned::encode_2718"
+            ),
         }
     }
 
@@ -201,6 +239,9 @@ impl RlpEcdsaEncodableTx for BaseTypedTransaction {
             Self::Eip1559(tx) => tx.eip2718_encode(signature, out),
             Self::Eip7702(tx) => tx.eip2718_encode(signature, out),
             Self::Deposit(tx) => tx.encode_2718(out),
+            Self::Aa8130(_) => unreachable!(
+                "BaseTypedTransaction::eip2718_encode invoked on EIP-8130 variant; use AaSigned::encode_2718"
+            ),
         }
     }
 
@@ -211,6 +252,9 @@ impl RlpEcdsaEncodableTx for BaseTypedTransaction {
             Self::Eip1559(tx) => tx.network_encode_with_type(signature, tx.ty(), out),
             Self::Eip7702(tx) => tx.network_encode_with_type(signature, tx.ty(), out),
             Self::Deposit(tx) => tx.network_encode(out),
+            Self::Aa8130(_) => unreachable!(
+                "BaseTypedTransaction::network_encode_with_type invoked on EIP-8130 variant"
+            ),
         }
     }
 
@@ -221,6 +265,9 @@ impl RlpEcdsaEncodableTx for BaseTypedTransaction {
             Self::Eip1559(tx) => tx.network_encode(signature, out),
             Self::Eip7702(tx) => tx.network_encode(signature, out),
             Self::Deposit(tx) => tx.network_encode(out),
+            Self::Aa8130(_) => {
+                unreachable!("BaseTypedTransaction::network_encode invoked on EIP-8130 variant")
+            }
         }
     }
 
@@ -231,6 +278,9 @@ impl RlpEcdsaEncodableTx for BaseTypedTransaction {
             Self::Eip1559(tx) => tx.tx_hash_with_type(signature, tx.ty()),
             Self::Eip7702(tx) => tx.tx_hash_with_type(signature, tx.ty()),
             Self::Deposit(tx) => tx.tx_hash(),
+            Self::Aa8130(_) => {
+                unreachable!("BaseTypedTransaction::tx_hash_with_type invoked on EIP-8130 variant")
+            }
         }
     }
 
@@ -241,6 +291,9 @@ impl RlpEcdsaEncodableTx for BaseTypedTransaction {
             Self::Eip1559(tx) => tx.tx_hash(signature),
             Self::Eip7702(tx) => tx.tx_hash(signature),
             Self::Deposit(tx) => tx.tx_hash(),
+            Self::Aa8130(_) => {
+                unreachable!("BaseTypedTransaction::tx_hash invoked on EIP-8130 variant")
+            }
         }
     }
 }
@@ -253,6 +306,7 @@ impl SignableTransaction<Signature> for BaseTypedTransaction {
             Self::Eip1559(tx) => tx.set_chain_id(chain_id),
             Self::Eip7702(tx) => tx.set_chain_id(chain_id),
             Self::Deposit(_) => {}
+            Self::Aa8130(tx) => tx.set_chain_id(chain_id),
         }
     }
 
@@ -263,6 +317,7 @@ impl SignableTransaction<Signature> for BaseTypedTransaction {
             Self::Eip1559(tx) => tx.encode_for_signing(out),
             Self::Eip7702(tx) => tx.encode_for_signing(out),
             Self::Deposit(_) => {}
+            Self::Aa8130(tx) => tx.encode_for_signing(out),
         }
     }
 
@@ -273,6 +328,7 @@ impl SignableTransaction<Signature> for BaseTypedTransaction {
             Self::Eip1559(tx) => tx.payload_len_for_signature(),
             Self::Eip7702(tx) => tx.payload_len_for_signature(),
             Self::Deposit(_) => 0,
+            Self::Aa8130(tx) => tx.payload_len_for_signature(),
         }
     }
 
@@ -293,6 +349,13 @@ impl InMemorySize for BaseTypedTransaction {
             Self::Eip1559(tx) => tx.size(),
             Self::Eip7702(tx) => tx.size(),
             Self::Deposit(tx) => tx.size(),
+            Self::Aa8130(tx) => tx.size(),
         }
+    }
+}
+
+impl From<AaSigned> for BaseTxEnvelope {
+    fn from(signed: AaSigned) -> Self {
+        Self::Aa8130(signed)
     }
 }

--- a/crates/common/consensus/src/transaction/typed.rs
+++ b/crates/common/consensus/src/transaction/typed.rs
@@ -160,7 +160,7 @@ impl BaseTypedTransaction {
             Self::Eip1559(tx) => tx.tx_hash(signature),
             Self::Eip7702(tx) => tx.tx_hash(signature),
             Self::Deposit(tx) => tx.tx_hash(),
-            Self::Aa8130(_) => unreachable!(
+            Self::Aa8130(_) => unimplemented!(
                 "BaseTypedTransaction::tx_hash invoked on an EIP-8130 variant; use AaSigned::hash via the envelope path"
             ),
         }
@@ -225,7 +225,7 @@ impl RlpEcdsaEncodableTx for BaseTypedTransaction {
             Self::Eip1559(tx) => tx.eip2718_encode_with_type(signature, tx.ty(), out),
             Self::Eip7702(tx) => tx.eip2718_encode_with_type(signature, tx.ty(), out),
             Self::Deposit(tx) => tx.encode_2718(out),
-            Self::Aa8130(_) => unreachable!(
+            Self::Aa8130(_) => unimplemented!(
                 "BaseTypedTransaction::eip2718_encode_with_type invoked on EIP-8130 variant; use AaSigned::encode_2718"
             ),
         }
@@ -238,7 +238,7 @@ impl RlpEcdsaEncodableTx for BaseTypedTransaction {
             Self::Eip1559(tx) => tx.eip2718_encode(signature, out),
             Self::Eip7702(tx) => tx.eip2718_encode(signature, out),
             Self::Deposit(tx) => tx.encode_2718(out),
-            Self::Aa8130(_) => unreachable!(
+            Self::Aa8130(_) => unimplemented!(
                 "BaseTypedTransaction::eip2718_encode invoked on EIP-8130 variant; use AaSigned::encode_2718"
             ),
         }
@@ -251,7 +251,7 @@ impl RlpEcdsaEncodableTx for BaseTypedTransaction {
             Self::Eip1559(tx) => tx.network_encode_with_type(signature, tx.ty(), out),
             Self::Eip7702(tx) => tx.network_encode_with_type(signature, tx.ty(), out),
             Self::Deposit(tx) => tx.network_encode(out),
-            Self::Aa8130(_) => unreachable!(
+            Self::Aa8130(_) => unimplemented!(
                 "BaseTypedTransaction::network_encode_with_type invoked on EIP-8130 variant"
             ),
         }
@@ -265,7 +265,7 @@ impl RlpEcdsaEncodableTx for BaseTypedTransaction {
             Self::Eip7702(tx) => tx.network_encode(signature, out),
             Self::Deposit(tx) => tx.network_encode(out),
             Self::Aa8130(_) => {
-                unreachable!("BaseTypedTransaction::network_encode invoked on EIP-8130 variant")
+                unimplemented!("BaseTypedTransaction::network_encode invoked on EIP-8130 variant")
             }
         }
     }
@@ -278,7 +278,9 @@ impl RlpEcdsaEncodableTx for BaseTypedTransaction {
             Self::Eip7702(tx) => tx.tx_hash_with_type(signature, tx.ty()),
             Self::Deposit(tx) => tx.tx_hash(),
             Self::Aa8130(_) => {
-                unreachable!("BaseTypedTransaction::tx_hash_with_type invoked on EIP-8130 variant")
+                unimplemented!(
+                    "BaseTypedTransaction::tx_hash_with_type invoked on EIP-8130 variant"
+                )
             }
         }
     }
@@ -291,7 +293,7 @@ impl RlpEcdsaEncodableTx for BaseTypedTransaction {
             Self::Eip7702(tx) => tx.tx_hash(signature),
             Self::Deposit(tx) => tx.tx_hash(),
             Self::Aa8130(_) => {
-                unreachable!("BaseTypedTransaction::tx_hash invoked on EIP-8130 variant")
+                unimplemented!("BaseTypedTransaction::tx_hash invoked on EIP-8130 variant")
             }
         }
     }

--- a/crates/common/consensus/src/transaction/typed.rs
+++ b/crates/common/consensus/src/transaction/typed.rs
@@ -94,8 +94,7 @@ impl BaseTypedTransaction {
             Self::Eip2930(tx) => Some(tx.signature_hash()),
             Self::Eip1559(tx) => Some(tx.signature_hash()),
             Self::Eip7702(tx) => Some(tx.signature_hash()),
-            Self::Deposit(_) => None,
-            Self::Aa8130(_) => None,
+            Self::Deposit(_) | Self::Aa8130(_) => None,
         }
     }
 

--- a/crates/common/consensus/src/transaction/typed.rs
+++ b/crates/common/consensus/src/transaction/typed.rs
@@ -66,7 +66,9 @@ impl From<BaseTypedTransaction> for alloy_rpc_types_eth::TransactionRequest {
             BaseTypedTransaction::Eip1559(tx) => tx.into(),
             BaseTypedTransaction::Eip7702(tx) => tx.into(),
             BaseTypedTransaction::Deposit(tx) => tx.into(),
-            BaseTypedTransaction::Aa8130(_) => Self::default(),
+            BaseTypedTransaction::Aa8130(_) => unimplemented!(
+                "BaseTypedTransaction::Aa8130 cannot be converted to an alloy TransactionRequest; AA transactions have no single sender/recipient/value to project into the legacy request shape"
+            ),
         }
     }
 }

--- a/crates/common/evm/src/receipt_builder.rs
+++ b/crates/common/evm/src/receipt_builder.rs
@@ -60,6 +60,7 @@ impl BaseReceiptBuilder for AlloyReceiptBuilder {
                     OpTxType::Eip1559 => BaseReceiptEnvelope::Eip1559(receipt),
                     OpTxType::Eip7702 => BaseReceiptEnvelope::Eip7702(receipt),
                     OpTxType::Deposit => unreachable!(),
+                    OpTxType::Aa8130 => BaseReceiptEnvelope::Aa8130(receipt),
                 })
             }
         }

--- a/crates/common/evm/src/transaction/core.rs
+++ b/crates/common/evm/src/transaction/core.rs
@@ -243,6 +243,9 @@ impl FromTxWithEncoded<BaseTxEnvelope> for BaseTransaction<TxEnv> {
                 deposit: Default::default(),
             },
             BaseTxEnvelope::Deposit(tx) => Self::from_encoded_tx(tx.inner(), caller, encoded),
+            BaseTxEnvelope::Aa8130(_) => {
+                unimplemented!("EVM execution for EIP-8130 BaseTxEnvelope is not yet implemented")
+            }
         }
     }
 }

--- a/crates/common/rpc-types/src/receipt.rs
+++ b/crates/common/rpc-types/src/receipt.rs
@@ -253,6 +253,9 @@ impl From<BaseTransactionReceipt> for BaseReceiptEnvelope {
                 };
                 Self::Deposit(consensus_receipt)
             }
+            BaseReceipt::Aa8130(receipt) => {
+                Self::Aa8130(convert_standard_receipt(receipt, logs_bloom))
+            }
         }
     }
 }

--- a/crates/common/rpc-types/src/transaction/request.rs
+++ b/crates/common/rpc-types/src/transaction/request.rs
@@ -196,6 +196,7 @@ impl From<BaseTypedTransaction> for BaseTransactionRequest {
             BaseTypedTransaction::Eip1559(tx) => Self(tx.into()),
             BaseTypedTransaction::Eip7702(tx) => Self(tx.into()),
             BaseTypedTransaction::Deposit(tx) => tx.into(),
+            BaseTypedTransaction::Aa8130(_) => Self::default(),
         }
     }
 }
@@ -208,6 +209,7 @@ impl From<BaseTxEnvelope> for BaseTransactionRequest {
             BaseTxEnvelope::Eip1559(tx) => tx.into(),
             BaseTxEnvelope::Eip7702(tx) => tx.into(),
             BaseTxEnvelope::Deposit(tx) => tx.into(),
+            BaseTxEnvelope::Aa8130(_) => Self::default(),
         }
     }
 }

--- a/crates/common/rpc-types/src/transaction/request.rs
+++ b/crates/common/rpc-types/src/transaction/request.rs
@@ -196,7 +196,9 @@ impl From<BaseTypedTransaction> for BaseTransactionRequest {
             BaseTypedTransaction::Eip1559(tx) => Self(tx.into()),
             BaseTypedTransaction::Eip7702(tx) => Self(tx.into()),
             BaseTypedTransaction::Deposit(tx) => tx.into(),
-            BaseTypedTransaction::Aa8130(_) => Self::default(),
+            BaseTypedTransaction::Aa8130(_) => unimplemented!(
+                "BaseTypedTransaction::Aa8130 cannot be projected onto BaseTransactionRequest; AA transactions have no single sender/recipient/value"
+            ),
         }
     }
 }
@@ -209,7 +211,9 @@ impl From<BaseTxEnvelope> for BaseTransactionRequest {
             BaseTxEnvelope::Eip1559(tx) => tx.into(),
             BaseTxEnvelope::Eip7702(tx) => tx.into(),
             BaseTxEnvelope::Deposit(tx) => tx.into(),
-            BaseTxEnvelope::Aa8130(_) => Self::default(),
+            BaseTxEnvelope::Aa8130(_) => unimplemented!(
+                "BaseTxEnvelope::Aa8130 cannot be projected onto BaseTransactionRequest; AA transactions have no single sender/recipient/value"
+            ),
         }
     }
 }

--- a/crates/execution/evm/src/receipts.rs
+++ b/crates/execution/evm/src/receipts.rs
@@ -35,6 +35,7 @@ impl BaseReceiptBuilder for BaseRethReceiptBuilder {
                     OpTxType::Eip2930 => BaseReceipt::Eip2930(receipt),
                     OpTxType::Eip7702 => BaseReceipt::Eip7702(receipt),
                     OpTxType::Deposit => unreachable!(),
+                    OpTxType::Aa8130 => BaseReceipt::Aa8130(receipt),
                 })
             }
         }

--- a/crates/execution/flashblocks/src/receipt_builder.rs
+++ b/crates/execution/flashblocks/src/receipt_builder.rs
@@ -118,6 +118,7 @@ impl<C: Upgrades> UnifiedReceiptBuilder<C> {
                 OpTxType::Eip1559 => BaseReceipt::Eip1559(receipt),
                 OpTxType::Eip7702 => BaseReceipt::Eip7702(receipt),
                 OpTxType::Deposit => unreachable!(),
+                OpTxType::Aa8130 => BaseReceipt::Aa8130(receipt),
             })
         }
     }

--- a/crates/execution/rpc/src/eth/receipt.rs
+++ b/crates/execution/rpc/src/eth/receipt.rs
@@ -303,6 +303,7 @@ impl BaseReceiptBuilder {
                 BaseReceipt::Eip1559(receipt) => BaseReceipt::Eip1559(map_logs(receipt)),
                 BaseReceipt::Eip7702(receipt) => BaseReceipt::Eip7702(map_logs(receipt)),
                 BaseReceipt::Deposit(receipt) => BaseReceipt::Deposit(receipt.map_inner(map_logs)),
+                BaseReceipt::Aa8130(receipt) => BaseReceipt::Aa8130(map_logs(receipt)),
             };
             mapped_receipt.into_with_bloom()
         });


### PR DESCRIPTION
## Summary

First PR in a planned series introducing [EIP-8130 Account Abstraction by Account Configuration](https://eips.ethereum.org/EIPS/eip-8130) support. This PR is **type-only plumbing** — it adds the AA transaction shape and wires the new variant through the envelope, typed-transaction, pooled-transaction, and receipt enums so the type byte `0x7D` is recognized end-to-end. Execution, signature verification, sender resolution, mempool ingestion, and RPC encoding are intentionally out of scope and will follow in later PRs.

The goal is to land the seam now so subsequent PRs can be focused and small.

## What's included

- New module `crates/common/consensus/src/transaction/aa8130/` with:
  - `TxAa8130` — unsigned AA transaction body (chain id, gas, fees, sender/payer, account changes, calls)
  - `AaSigned` — wrapper carrying `sender_auth` and `payer_auth` bytes plus a cached EIP-2718 hash
  - `AccountChange` enum (`CreateOwned`, `CreateContract`, `ConfigChange`) with hand-rolled RLP that mirrors the EIP-8130 byte layout
  - `Call { to, data }` and `Vec<Vec<Call>>` parallel-call shape
  - `Scope` bitmask encoded as a bare RLP `uint8`
  - `Aa8130Constants` (type byte `0x7D`, payer-signature type `0xFA`, base cost `15_000`)
- New variants:
  - `BaseTxEnvelope::Aa8130(AaSigned)`
  - `BaseTypedTransaction::Aa8130(TxAa8130)`
  - `BasePooledTransaction::Aa8130(AaSigned)`
  - `BaseReceipt::Aa8130(Receipt<Log>)` and `BaseReceiptEnvelope::Aa8130(ReceiptWithBloom<Receipt<Log>>)`
  - `OpTxType::Aa8130` and the corresponding RPC / EVM dispatch arms
- All trait stubs that have no meaningful behavior yet use `unimplemented!("...")` with a descriptive message, so any unexpected hit panics loudly instead of corrupting state

## Out of scope (intentional)

- Executing AA transactions in the EVM
- Sender / payer signature verification logic
- Mempool admission and gossiping for type `0x7D`
- Full JSON-RPC encoding of AA transactions / receipts
- Hardfork activation and gas accounting

## Testing

- 90 unit tests in `base-common-consensus` (35 new for the `aa8130` module)
- Tests cover: bare-byte vs list RLP encoding of `Scope`, EIP-2718 round-trip, hash recomputation on `Deserialize` and `Arbitrary`, `AccountChange` discriminant byte validation, trailing-data rejection, address-option `None` (0-byte) vs `Some` (20-byte) wire form
- `cargo check --workspace --all-features`: clean
- `cargo clippy -D warnings` clean on `base-common-consensus`, `base-common-evm`, `base-common-rpc-types`, `base-execution-evm`, `base-execution-rpc`, `base-flashblocks`

## Commits

Eleven small, atomic commits — feature work followed by a round of review fixes (recover_signer correctness, hash recomputation on deserialize/arbitrary, `unimplemented!` over `unreachable!`, debug-asserts on the configured-owner / sponsored paths, `Scope` wire format, `TransactionRequest` conversions). See `git log`.

## Follow-up PRs (planned)

- Pool size accounting fix for `TxAa8130` heap data
- AA execution / state transition
- Sender + payer signature verification
- RPC encoding / decoding
- Hardfork activation gating
