### PR TITLE
refactor(consensus): rename Aa8130 -> Eip8130 and reorder match arms

### DIFF
--- a/crates/common/consensus/src/lib.rs
+++ b/crates/common/consensus/src/lib.rs
@@ -24,10 +24,10 @@ mod transaction;
 #[cfg(feature = "serde")]
 pub use transaction::serde_deposit_tx_rpc;
 pub use transaction::{
-    Aa8130Constants, AaSigned, AccountChange, BasePooledTransaction, BaseTransaction,
-    BaseTransactionInfo, BaseTxEnvelope, BaseTypedTransaction, Call, ConfigChange, CreateEntry,
-    DEPOSIT_TX_TYPE_ID, Delegation, DepositInfo, DepositTransaction, EIP8130_TX_TYPE_ID,
-    InitialOwner, OpTxType, OwnerChange, OwnerChangeType, Scope, TxAa8130, TxDeposit,
+    AccountChange, BasePooledTransaction, BaseTransaction, BaseTransactionInfo, BaseTxEnvelope,
+    BaseTypedTransaction, Call, ConfigChange, CreateEntry, DEPOSIT_TX_TYPE_ID, Delegation,
+    DepositInfo, DepositTransaction, EIP8130_TX_TYPE_ID, Eip8130Constants, Eip8130Signed,
+    InitialOwner, OpTxType, OwnerChange, OwnerChangeType, Scope, TxDeposit, TxEip8130,
 };
 
 mod extra;

--- a/crates/common/consensus/src/receipts/envelope.rs
+++ b/crates/common/consensus/src/receipts/envelope.rs
@@ -84,6 +84,9 @@ impl BaseReceiptEnvelope {
             OpTxType::Eip7702 => {
                 Self::Eip7702(ReceiptWithBloom { receipt: inner_receipt, logs_bloom })
             }
+            OpTxType::Eip8130 => {
+                Self::Eip8130(ReceiptWithBloom { receipt: inner_receipt, logs_bloom })
+            }
             OpTxType::Deposit => {
                 let inner = DepositReceiptWithBloom {
                     receipt: DepositReceipt {
@@ -94,9 +97,6 @@ impl BaseReceiptEnvelope {
                     logs_bloom,
                 };
                 Self::Deposit(inner)
-            }
-            OpTxType::Eip8130 => {
-                Self::Eip8130(ReceiptWithBloom { receipt: inner_receipt, logs_bloom })
             }
         }
     }
@@ -110,8 +110,8 @@ impl BaseReceiptEnvelope {
             Self::Eip2930(_) => OpTxType::Eip2930,
             Self::Eip1559(_) => OpTxType::Eip1559,
             Self::Eip7702(_) => OpTxType::Eip7702,
-            Self::Deposit(_) => OpTxType::Deposit,
             Self::Eip8130(_) => OpTxType::Eip8130,
+            Self::Deposit(_) => OpTxType::Deposit,
         }
     }
 
@@ -286,8 +286,8 @@ impl Typed2718 for BaseReceiptEnvelope {
             Self::Eip2930(_) => OpTxType::Eip2930,
             Self::Eip1559(_) => OpTxType::Eip1559,
             Self::Eip7702(_) => OpTxType::Eip7702,
-            Self::Deposit(_) => OpTxType::Deposit,
             Self::Eip8130(_) => OpTxType::Eip8130,
+            Self::Deposit(_) => OpTxType::Deposit,
         };
         ty as u8
     }
@@ -310,12 +310,12 @@ impl Encodable2718 for BaseReceiptEnvelope {
             Some(ty) => out.put_u8(ty),
         }
         match self {
-            Self::Deposit(t) => t.encode(out),
             Self::Legacy(t)
             | Self::Eip2930(t)
             | Self::Eip1559(t)
             | Self::Eip7702(t)
             | Self::Eip8130(t) => t.encode(out),
+            Self::Deposit(t) => t.encode(out),
         }
     }
 }
@@ -330,8 +330,8 @@ impl Decodable2718 for BaseReceiptEnvelope {
             OpTxType::Eip1559 => Ok(Self::Eip1559(Decodable::decode(buf)?)),
             OpTxType::Eip7702 => Ok(Self::Eip7702(Decodable::decode(buf)?)),
             OpTxType::Eip2930 => Ok(Self::Eip2930(Decodable::decode(buf)?)),
-            OpTxType::Deposit => Ok(Self::Deposit(Decodable::decode(buf)?)),
             OpTxType::Eip8130 => Ok(Self::Eip8130(Decodable::decode(buf)?)),
+            OpTxType::Deposit => Ok(Self::Deposit(Decodable::decode(buf)?)),
         }
     }
 

--- a/crates/common/consensus/src/receipts/envelope.rs
+++ b/crates/common/consensus/src/receipts/envelope.rs
@@ -54,7 +54,7 @@ pub enum BaseReceiptEnvelope {
     ///
     /// [EIP-8130]: https://eips.ethereum.org/EIPS/eip-8130
     #[cfg_attr(feature = "serde", serde(rename = "0x7d", alias = "0x7D"))]
-    Aa8130(ReceiptWithBloom<Receipt<Log>>),
+    Eip8130(ReceiptWithBloom<Receipt<Log>>),
 }
 
 impl BaseReceiptEnvelope {
@@ -95,8 +95,8 @@ impl BaseReceiptEnvelope {
                 };
                 Self::Deposit(inner)
             }
-            OpTxType::Aa8130 => {
-                Self::Aa8130(ReceiptWithBloom { receipt: inner_receipt, logs_bloom })
+            OpTxType::Eip8130 => {
+                Self::Eip8130(ReceiptWithBloom { receipt: inner_receipt, logs_bloom })
             }
         }
     }
@@ -111,7 +111,7 @@ impl BaseReceiptEnvelope {
             Self::Eip1559(_) => OpTxType::Eip1559,
             Self::Eip7702(_) => OpTxType::Eip7702,
             Self::Deposit(_) => OpTxType::Deposit,
-            Self::Aa8130(_) => OpTxType::Aa8130,
+            Self::Eip8130(_) => OpTxType::Eip8130,
         }
     }
 
@@ -147,7 +147,7 @@ impl BaseReceiptEnvelope {
             | Self::Eip2930(t)
             | Self::Eip1559(t)
             | Self::Eip7702(t)
-            | Self::Aa8130(t) => &t.logs_bloom,
+            | Self::Eip8130(t) => &t.logs_bloom,
             Self::Deposit(t) => &t.logs_bloom,
         }
     }
@@ -185,7 +185,7 @@ impl BaseReceiptEnvelope {
             | Self::Eip2930(t)
             | Self::Eip1559(t)
             | Self::Eip7702(t)
-            | Self::Aa8130(t) => t.receipt,
+            | Self::Eip8130(t) => t.receipt,
             Self::Deposit(t) => t.receipt.into_inner(),
         }
     }
@@ -198,7 +198,7 @@ impl BaseReceiptEnvelope {
             | Self::Eip2930(t)
             | Self::Eip1559(t)
             | Self::Eip7702(t)
-            | Self::Aa8130(t) => Some(&t.receipt),
+            | Self::Eip8130(t) => Some(&t.receipt),
             Self::Deposit(t) => Some(&t.receipt.inner),
         }
     }
@@ -212,7 +212,7 @@ impl BaseReceiptEnvelope {
             | Self::Eip2930(t)
             | Self::Eip1559(t)
             | Self::Eip7702(t)
-            | Self::Aa8130(t) => t.length(),
+            | Self::Eip8130(t) => t.length(),
             Self::Deposit(t) => t.length(),
         }
     }
@@ -287,7 +287,7 @@ impl Typed2718 for BaseReceiptEnvelope {
             Self::Eip1559(_) => OpTxType::Eip1559,
             Self::Eip7702(_) => OpTxType::Eip7702,
             Self::Deposit(_) => OpTxType::Deposit,
-            Self::Aa8130(_) => OpTxType::Aa8130,
+            Self::Eip8130(_) => OpTxType::Eip8130,
         };
         ty as u8
     }
@@ -315,7 +315,7 @@ impl Encodable2718 for BaseReceiptEnvelope {
             | Self::Eip2930(t)
             | Self::Eip1559(t)
             | Self::Eip7702(t)
-            | Self::Aa8130(t) => t.encode(out),
+            | Self::Eip8130(t) => t.encode(out),
         }
     }
 }
@@ -331,7 +331,7 @@ impl Decodable2718 for BaseReceiptEnvelope {
             OpTxType::Eip7702 => Ok(Self::Eip7702(Decodable::decode(buf)?)),
             OpTxType::Eip2930 => Ok(Self::Eip2930(Decodable::decode(buf)?)),
             OpTxType::Deposit => Ok(Self::Deposit(Decodable::decode(buf)?)),
-            OpTxType::Aa8130 => Ok(Self::Aa8130(Decodable::decode(buf)?)),
+            OpTxType::Eip8130 => Ok(Self::Eip8130(Decodable::decode(buf)?)),
         }
     }
 
@@ -361,7 +361,7 @@ impl<'a> arbitrary::Arbitrary<'a> for BaseReceiptEnvelope {
             2 => Ok(Self::Eip1559(ReceiptWithBloom::arbitrary(u)?)),
             3 => Ok(Self::Eip7702(ReceiptWithBloom::arbitrary(u)?)),
             4 => Ok(Self::Deposit(DepositReceiptWithBloom::arbitrary(u)?)),
-            _ => Ok(Self::Aa8130(ReceiptWithBloom::arbitrary(u)?)),
+            _ => Ok(Self::Eip8130(ReceiptWithBloom::arbitrary(u)?)),
         }
     }
 }

--- a/crates/common/consensus/src/receipts/receipt.rs
+++ b/crates/common/consensus/src/receipts/receipt.rs
@@ -39,7 +39,7 @@ pub enum BaseReceipt<T = Log> {
     Deposit(DepositReceipt<T>),
     /// EIP-8130 Account Abstraction receipt
     #[cfg_attr(feature = "serde", serde(rename = "0x7d", alias = "0x7D"))]
-    Aa8130(Receipt<T>),
+    Eip8130(Receipt<T>),
 }
 
 impl<T> BaseReceipt<T> {
@@ -51,7 +51,7 @@ impl<T> BaseReceipt<T> {
             Self::Eip1559(_) => OpTxType::Eip1559,
             Self::Eip7702(_) => OpTxType::Eip7702,
             Self::Deposit(_) => OpTxType::Deposit,
-            Self::Aa8130(_) => OpTxType::Aa8130,
+            Self::Eip8130(_) => OpTxType::Eip8130,
         }
     }
 
@@ -62,7 +62,7 @@ impl<T> BaseReceipt<T> {
             | Self::Eip2930(receipt)
             | Self::Eip1559(receipt)
             | Self::Eip7702(receipt)
-            | Self::Aa8130(receipt) => receipt,
+            | Self::Eip8130(receipt) => receipt,
             Self::Deposit(receipt) => &receipt.inner,
         }
     }
@@ -74,7 +74,7 @@ impl<T> BaseReceipt<T> {
             | Self::Eip2930(receipt)
             | Self::Eip1559(receipt)
             | Self::Eip7702(receipt)
-            | Self::Aa8130(receipt) => receipt,
+            | Self::Eip8130(receipt) => receipt,
             Self::Deposit(receipt) => &mut receipt.inner,
         }
     }
@@ -86,7 +86,7 @@ impl<T> BaseReceipt<T> {
             | Self::Eip2930(receipt)
             | Self::Eip1559(receipt)
             | Self::Eip7702(receipt)
-            | Self::Aa8130(receipt) => receipt,
+            | Self::Eip8130(receipt) => receipt,
             Self::Deposit(receipt) => receipt.inner,
         }
     }
@@ -101,7 +101,7 @@ impl<T> BaseReceipt<T> {
             Self::Eip1559(receipt) => BaseReceipt::Eip1559(receipt.map_logs(f)),
             Self::Eip7702(receipt) => BaseReceipt::Eip7702(receipt.map_logs(f)),
             Self::Deposit(receipt) => BaseReceipt::Deposit(receipt.map_logs(f)),
-            Self::Aa8130(receipt) => BaseReceipt::Aa8130(receipt.map_logs(f)),
+            Self::Eip8130(receipt) => BaseReceipt::Eip8130(receipt.map_logs(f)),
         }
     }
 
@@ -115,7 +115,7 @@ impl<T> BaseReceipt<T> {
             | Self::Eip2930(receipt)
             | Self::Eip1559(receipt)
             | Self::Eip7702(receipt)
-            | Self::Aa8130(receipt) => receipt.rlp_encoded_fields_length_with_bloom(bloom),
+            | Self::Eip8130(receipt) => receipt.rlp_encoded_fields_length_with_bloom(bloom),
             Self::Deposit(receipt) => receipt.rlp_encoded_fields_length_with_bloom(bloom),
         }
     }
@@ -130,7 +130,7 @@ impl<T> BaseReceipt<T> {
             | Self::Eip2930(receipt)
             | Self::Eip1559(receipt)
             | Self::Eip7702(receipt)
-            | Self::Aa8130(receipt) => receipt.rlp_encode_fields_with_bloom(bloom, out),
+            | Self::Eip8130(receipt) => receipt.rlp_encode_fields_with_bloom(bloom, out),
             Self::Deposit(receipt) => receipt.rlp_encode_fields_with_bloom(bloom, out),
         }
     }
@@ -186,10 +186,10 @@ impl<T> BaseReceipt<T> {
                     RlpDecodableReceipt::rlp_decode_with_bloom(buf)?;
                 Ok(ReceiptWithBloom { receipt: Self::Deposit(receipt), logs_bloom })
             }
-            OpTxType::Aa8130 => {
+            OpTxType::Eip8130 => {
                 let ReceiptWithBloom { receipt, logs_bloom } =
                     RlpDecodableReceipt::rlp_decode_with_bloom(buf)?;
-                Ok(ReceiptWithBloom { receipt: Self::Aa8130(receipt), logs_bloom })
+                Ok(ReceiptWithBloom { receipt: Self::Eip8130(receipt), logs_bloom })
             }
         }
     }
@@ -205,7 +205,7 @@ impl<T> BaseReceipt<T> {
             | Self::Eip2930(receipt)
             | Self::Eip1559(receipt)
             | Self::Eip7702(receipt)
-            | Self::Aa8130(receipt) => {
+            | Self::Eip8130(receipt) => {
                 receipt.status.encode(out);
                 receipt.cumulative_gas_used.encode(out);
                 receipt.logs.encode(out);
@@ -235,7 +235,7 @@ impl<T> BaseReceipt<T> {
                 | Self::Eip2930(receipt)
                 | Self::Eip1559(receipt)
                 | Self::Eip7702(receipt)
-                | Self::Aa8130(receipt) => {
+                | Self::Eip8130(receipt) => {
                     receipt.status.length()
                         + receipt.cumulative_gas_used.length()
                         + receipt.logs.length()
@@ -280,7 +280,7 @@ impl<T> BaseReceipt<T> {
                 deposit_nonce,
                 deposit_receipt_version,
             })),
-            OpTxType::Aa8130 => Ok(Self::Aa8130(Receipt { status, cumulative_gas_used, logs })),
+            OpTxType::Eip8130 => Ok(Self::Eip8130(Receipt { status, cumulative_gas_used, logs })),
         }
     }
 }
@@ -421,7 +421,7 @@ impl<T: Send + Sync + Clone + Debug + Eq + AsRef<Log>> TxReceipt for BaseReceipt
             | Self::Eip2930(receipt)
             | Self::Eip1559(receipt)
             | Self::Eip7702(receipt)
-            | Self::Aa8130(receipt) => receipt.logs,
+            | Self::Eip8130(receipt) => receipt.logs,
             Self::Deposit(receipt) => receipt.inner.logs,
         }
     }
@@ -467,7 +467,7 @@ impl From<super::BaseReceiptEnvelope> for BaseReceipt {
                 deposit_receipt_version: receipt.receipt.deposit_receipt_version,
                 inner: receipt.receipt.inner,
             }),
-            super::BaseReceiptEnvelope::Aa8130(receipt) => Self::Aa8130(receipt.receipt),
+            super::BaseReceiptEnvelope::Eip8130(receipt) => Self::Eip8130(receipt.receipt),
         }
     }
 }
@@ -489,7 +489,7 @@ impl From<ReceiptWithBloom<BaseReceipt>> for BaseReceiptEnvelope {
             BaseReceipt::Deposit(receipt) => {
                 Self::Deposit(ReceiptWithBloom { receipt, logs_bloom })
             }
-            BaseReceipt::Aa8130(receipt) => Self::Aa8130(ReceiptWithBloom { receipt, logs_bloom }),
+            BaseReceipt::Eip8130(receipt) => Self::Eip8130(ReceiptWithBloom { receipt, logs_bloom }),
         }
     }
 }
@@ -528,7 +528,7 @@ pub(super) mod serde_bincode_compat {
         /// Deposit receipt
         Deposit(crate::serde_bincode_compat::DepositReceipt<'a, alloy_primitives::Log>),
         /// EIP-8130 Account Abstraction receipt
-        Aa8130(alloy_consensus::serde_bincode_compat::Receipt<'a, alloy_primitives::Log>),
+        Eip8130(alloy_consensus::serde_bincode_compat::Receipt<'a, alloy_primitives::Log>),
     }
 
     impl<'a> From<&'a super::BaseReceipt> for BaseReceipt<'a> {
@@ -539,7 +539,7 @@ pub(super) mod serde_bincode_compat {
                 super::BaseReceipt::Eip1559(receipt) => Self::Eip1559(receipt.into()),
                 super::BaseReceipt::Eip7702(receipt) => Self::Eip7702(receipt.into()),
                 super::BaseReceipt::Deposit(receipt) => Self::Deposit(receipt.into()),
-                super::BaseReceipt::Aa8130(receipt) => Self::Aa8130(receipt.into()),
+                super::BaseReceipt::Eip8130(receipt) => Self::Eip8130(receipt.into()),
             }
         }
     }
@@ -552,7 +552,7 @@ pub(super) mod serde_bincode_compat {
                 BaseReceipt::Eip1559(receipt) => Self::Eip1559(receipt.into()),
                 BaseReceipt::Eip7702(receipt) => Self::Eip7702(receipt.into()),
                 BaseReceipt::Deposit(receipt) => Self::Deposit(receipt.into()),
-                BaseReceipt::Aa8130(receipt) => Self::Aa8130(receipt.into()),
+                BaseReceipt::Eip8130(receipt) => Self::Eip8130(receipt.into()),
             }
         }
     }
@@ -622,7 +622,7 @@ where
             | Self::Eip2930(receipt)
             | Self::Eip1559(receipt)
             | Self::Eip7702(receipt)
-            | Self::Aa8130(receipt) => receipt.size(),
+            | Self::Eip8130(receipt) => receipt.size(),
             Self::Deposit(receipt) => receipt.size(),
         }
     }

--- a/crates/common/consensus/src/receipts/receipt.rs
+++ b/crates/common/consensus/src/receipts/receipt.rs
@@ -50,8 +50,8 @@ impl<T> BaseReceipt<T> {
             Self::Eip2930(_) => OpTxType::Eip2930,
             Self::Eip1559(_) => OpTxType::Eip1559,
             Self::Eip7702(_) => OpTxType::Eip7702,
-            Self::Deposit(_) => OpTxType::Deposit,
             Self::Eip8130(_) => OpTxType::Eip8130,
+            Self::Deposit(_) => OpTxType::Deposit,
         }
     }
 
@@ -100,8 +100,8 @@ impl<T> BaseReceipt<T> {
             Self::Eip2930(receipt) => BaseReceipt::Eip2930(receipt.map_logs(f)),
             Self::Eip1559(receipt) => BaseReceipt::Eip1559(receipt.map_logs(f)),
             Self::Eip7702(receipt) => BaseReceipt::Eip7702(receipt.map_logs(f)),
-            Self::Deposit(receipt) => BaseReceipt::Deposit(receipt.map_logs(f)),
             Self::Eip8130(receipt) => BaseReceipt::Eip8130(receipt.map_logs(f)),
+            Self::Deposit(receipt) => BaseReceipt::Deposit(receipt.map_logs(f)),
         }
     }
 
@@ -181,15 +181,15 @@ impl<T> BaseReceipt<T> {
                     RlpDecodableReceipt::rlp_decode_with_bloom(buf)?;
                 Ok(ReceiptWithBloom { receipt: Self::Eip7702(receipt), logs_bloom })
             }
-            OpTxType::Deposit => {
-                let ReceiptWithBloom { receipt, logs_bloom } =
-                    RlpDecodableReceipt::rlp_decode_with_bloom(buf)?;
-                Ok(ReceiptWithBloom { receipt: Self::Deposit(receipt), logs_bloom })
-            }
             OpTxType::Eip8130 => {
                 let ReceiptWithBloom { receipt, logs_bloom } =
                     RlpDecodableReceipt::rlp_decode_with_bloom(buf)?;
                 Ok(ReceiptWithBloom { receipt: Self::Eip8130(receipt), logs_bloom })
+            }
+            OpTxType::Deposit => {
+                let ReceiptWithBloom { receipt, logs_bloom } =
+                    RlpDecodableReceipt::rlp_decode_with_bloom(buf)?;
+                Ok(ReceiptWithBloom { receipt: Self::Deposit(receipt), logs_bloom })
             }
         }
     }
@@ -275,12 +275,12 @@ impl<T> BaseReceipt<T> {
             OpTxType::Eip2930 => Ok(Self::Eip2930(Receipt { status, cumulative_gas_used, logs })),
             OpTxType::Eip1559 => Ok(Self::Eip1559(Receipt { status, cumulative_gas_used, logs })),
             OpTxType::Eip7702 => Ok(Self::Eip7702(Receipt { status, cumulative_gas_used, logs })),
+            OpTxType::Eip8130 => Ok(Self::Eip8130(Receipt { status, cumulative_gas_used, logs })),
             OpTxType::Deposit => Ok(Self::Deposit(DepositReceipt {
                 inner: Receipt { status, cumulative_gas_used, logs },
                 deposit_nonce,
                 deposit_receipt_version,
             })),
-            OpTxType::Eip8130 => Ok(Self::Eip8130(Receipt { status, cumulative_gas_used, logs })),
         }
     }
 }
@@ -462,12 +462,12 @@ impl From<super::BaseReceiptEnvelope> for BaseReceipt {
             super::BaseReceiptEnvelope::Eip2930(receipt) => Self::Eip2930(receipt.receipt),
             super::BaseReceiptEnvelope::Eip1559(receipt) => Self::Eip1559(receipt.receipt),
             super::BaseReceiptEnvelope::Eip7702(receipt) => Self::Eip7702(receipt.receipt),
+            super::BaseReceiptEnvelope::Eip8130(receipt) => Self::Eip8130(receipt.receipt),
             super::BaseReceiptEnvelope::Deposit(receipt) => Self::Deposit(DepositReceipt {
                 deposit_nonce: receipt.receipt.deposit_nonce,
                 deposit_receipt_version: receipt.receipt.deposit_receipt_version,
                 inner: receipt.receipt.inner,
             }),
-            super::BaseReceiptEnvelope::Eip8130(receipt) => Self::Eip8130(receipt.receipt),
         }
     }
 }
@@ -486,10 +486,12 @@ impl From<ReceiptWithBloom<BaseReceipt>> for BaseReceiptEnvelope {
             BaseReceipt::Eip7702(receipt) => {
                 Self::Eip7702(ReceiptWithBloom { receipt, logs_bloom })
             }
+            BaseReceipt::Eip8130(receipt) => {
+                Self::Eip8130(ReceiptWithBloom { receipt, logs_bloom })
+            }
             BaseReceipt::Deposit(receipt) => {
                 Self::Deposit(ReceiptWithBloom { receipt, logs_bloom })
             }
-            BaseReceipt::Eip8130(receipt) => Self::Eip8130(ReceiptWithBloom { receipt, logs_bloom }),
         }
     }
 }
@@ -538,8 +540,8 @@ pub(super) mod serde_bincode_compat {
                 super::BaseReceipt::Eip2930(receipt) => Self::Eip2930(receipt.into()),
                 super::BaseReceipt::Eip1559(receipt) => Self::Eip1559(receipt.into()),
                 super::BaseReceipt::Eip7702(receipt) => Self::Eip7702(receipt.into()),
-                super::BaseReceipt::Deposit(receipt) => Self::Deposit(receipt.into()),
                 super::BaseReceipt::Eip8130(receipt) => Self::Eip8130(receipt.into()),
+                super::BaseReceipt::Deposit(receipt) => Self::Deposit(receipt.into()),
             }
         }
     }
@@ -551,8 +553,8 @@ pub(super) mod serde_bincode_compat {
                 BaseReceipt::Eip2930(receipt) => Self::Eip2930(receipt.into()),
                 BaseReceipt::Eip1559(receipt) => Self::Eip1559(receipt.into()),
                 BaseReceipt::Eip7702(receipt) => Self::Eip7702(receipt.into()),
-                BaseReceipt::Deposit(receipt) => Self::Deposit(receipt.into()),
                 BaseReceipt::Eip8130(receipt) => Self::Eip8130(receipt.into()),
+                BaseReceipt::Deposit(receipt) => Self::Deposit(receipt.into()),
             }
         }
     }

--- a/crates/common/consensus/src/reth_compat.rs
+++ b/crates/common/consensus/src/reth_compat.rs
@@ -24,8 +24,8 @@ use reth_ethereum_primitives as _;
 
 use crate::{
     BaseBlock, BasePooledTransaction, BaseReceipt, BaseTxEnvelope, BaseTypedTransaction,
-    DEPOSIT_TX_TYPE_ID, DepositReceipt, EIP8130_TX_TYPE_ID, OpTxType, TxAa8130, TxDeposit,
-    transaction::AaSigned,
+    DEPOSIT_TX_TYPE_ID, DepositReceipt, EIP8130_TX_TYPE_ID, OpTxType, TxEip8130, TxDeposit,
+    transaction::Eip8130Signed,
 };
 
 // ---------------------------------------------------------------------------
@@ -46,14 +46,14 @@ impl reth_primitives_traits::InMemorySize for TxDeposit {
     }
 }
 
-impl reth_primitives_traits::InMemorySize for TxAa8130 {
+impl reth_primitives_traits::InMemorySize for TxEip8130 {
     #[inline]
     fn size(&self) -> usize {
         Self::size(self)
     }
 }
 
-impl reth_primitives_traits::InMemorySize for AaSigned {
+impl reth_primitives_traits::InMemorySize for Eip8130Signed {
     #[inline]
     fn size(&self) -> usize {
         alloy_consensus::InMemorySize::size(self)
@@ -75,7 +75,7 @@ impl reth_primitives_traits::InMemorySize for BaseReceipt {
             | Self::Eip2930(receipt)
             | Self::Eip1559(receipt)
             | Self::Eip7702(receipt)
-            | Self::Aa8130(receipt) => receipt.size(),
+            | Self::Eip8130(receipt) => receipt.size(),
             Self::Deposit(receipt) => receipt.size(),
         }
     }
@@ -89,7 +89,7 @@ impl reth_primitives_traits::InMemorySize for BaseTypedTransaction {
             Self::Eip1559(tx) => tx.size(),
             Self::Eip7702(tx) => tx.size(),
             Self::Deposit(tx) => tx.size(),
-            Self::Aa8130(tx) => tx.size(),
+            Self::Eip8130(tx) => tx.size(),
         }
     }
 }
@@ -101,7 +101,7 @@ impl reth_primitives_traits::InMemorySize for BasePooledTransaction {
             Self::Eip2930(tx) => tx.size(),
             Self::Eip1559(tx) => tx.size(),
             Self::Eip7702(tx) => tx.size(),
-            Self::Aa8130(tx) => tx.size(),
+            Self::Eip8130(tx) => tx.size(),
         }
     }
 }
@@ -114,7 +114,7 @@ impl reth_primitives_traits::InMemorySize for BaseTxEnvelope {
             Self::Eip1559(tx) => tx.size(),
             Self::Eip7702(tx) => tx.size(),
             Self::Deposit(tx) => tx.size(),
-            Self::Aa8130(tx) => tx.size(),
+            Self::Eip8130(tx) => tx.size(),
         }
     }
 }
@@ -246,7 +246,7 @@ impl Compact for OpTxType {
                 buf.put_u8(DEPOSIT_TX_TYPE_ID);
                 COMPACT_EXTENDED_IDENTIFIER_FLAG
             }
-            Self::Aa8130 => {
+            Self::Eip8130 => {
                 buf.put_u8(EIP8130_TX_TYPE_ID);
                 COMPACT_EXTENDED_IDENTIFIER_FLAG
             }
@@ -264,7 +264,7 @@ impl Compact for OpTxType {
                     match extended_identifier {
                         EIP7702_TX_TYPE_ID => Self::Eip7702,
                         DEPOSIT_TX_TYPE_ID => Self::Deposit,
-                        EIP8130_TX_TYPE_ID => Self::Aa8130,
+                        EIP8130_TX_TYPE_ID => Self::Eip8130,
                         _ => panic!("Unsupported OpTxType identifier: {extended_identifier}"),
                     }
                 }
@@ -291,7 +291,7 @@ impl Compact for BaseTypedTransaction {
             Self::Eip1559(tx) => tx.to_compact(out),
             Self::Eip7702(tx) => tx.to_compact(out),
             Self::Deposit(tx) => tx.to_compact(out),
-            Self::Aa8130(_) => unimplemented!(
+            Self::Eip8130(_) => unimplemented!(
                 "Compact encoding for EIP-8130 BaseTypedTransaction is not yet implemented"
             ),
         };
@@ -321,7 +321,7 @@ impl Compact for BaseTypedTransaction {
                 let (tx, buf) = Compact::from_compact(buf, buf.len());
                 (Self::Deposit(tx), buf)
             }
-            OpTxType::Aa8130 => unimplemented!(
+            OpTxType::Eip8130 => unimplemented!(
                 "Compact decoding for EIP-8130 BaseTypedTransaction is not yet implemented"
             ),
         }
@@ -340,7 +340,7 @@ impl reth_codecs::alloy::transaction::ToTxCompact for BaseTxEnvelope {
             Self::Eip1559(tx) => tx.tx().to_compact(buf),
             Self::Eip7702(tx) => tx.tx().to_compact(buf),
             Self::Deposit(tx) => tx.to_compact(buf),
-            Self::Aa8130(_) => unimplemented!(
+            Self::Eip8130(_) => unimplemented!(
                 "Compact encoding for EIP-8130 BaseTxEnvelope is not yet implemented"
             ),
         };
@@ -377,7 +377,7 @@ impl reth_codecs::alloy::transaction::FromTxCompact for BaseTxEnvelope {
                 let tx = Sealed::new(tx);
                 (Self::Deposit(tx), buf)
             }
-            OpTxType::Aa8130 => unimplemented!(
+            OpTxType::Eip8130 => unimplemented!(
                 "Compact decoding for EIP-8130 BaseTxEnvelope is not yet implemented"
             ),
         }
@@ -403,7 +403,7 @@ impl reth_codecs::alloy::transaction::Envelope for BaseTxEnvelope {
             // does. Both Deposit and EIP-8130 AA transactions carry their own auth model
             // and have no meaningful ECDSA signature: callers MUST NOT feed this value
             // into ECDSA recovery — it is an all-zero placeholder.
-            Self::Deposit(_) | Self::Aa8130(_) => &DEPOSIT_SIGNATURE,
+            Self::Deposit(_) | Self::Eip8130(_) => &DEPOSIT_SIGNATURE,
         }
     }
 
@@ -492,7 +492,7 @@ impl From<CompactBaseReceipt<'_>> for BaseReceipt {
             OpTxType::Deposit => {
                 Self::Deposit(DepositReceipt { inner, deposit_nonce, deposit_receipt_version })
             }
-            OpTxType::Aa8130 => {
+            OpTxType::Eip8130 => {
                 unimplemented!("Compact decoding for EIP-8130 BaseReceipt is not yet implemented")
             }
         }

--- a/crates/common/consensus/src/reth_compat.rs
+++ b/crates/common/consensus/src/reth_compat.rs
@@ -24,7 +24,7 @@ use reth_ethereum_primitives as _;
 
 use crate::{
     BaseBlock, BasePooledTransaction, BaseReceipt, BaseTxEnvelope, BaseTypedTransaction,
-    DEPOSIT_TX_TYPE_ID, DepositReceipt, EIP8130_TX_TYPE_ID, OpTxType, TxEip8130, TxDeposit,
+    DEPOSIT_TX_TYPE_ID, DepositReceipt, EIP8130_TX_TYPE_ID, OpTxType, TxDeposit, TxEip8130,
     transaction::Eip8130Signed,
 };
 
@@ -88,8 +88,8 @@ impl reth_primitives_traits::InMemorySize for BaseTypedTransaction {
             Self::Eip2930(tx) => tx.size(),
             Self::Eip1559(tx) => tx.size(),
             Self::Eip7702(tx) => tx.size(),
-            Self::Deposit(tx) => tx.size(),
             Self::Eip8130(tx) => tx.size(),
+            Self::Deposit(tx) => tx.size(),
         }
     }
 }
@@ -113,8 +113,8 @@ impl reth_primitives_traits::InMemorySize for BaseTxEnvelope {
             Self::Eip2930(tx) => tx.size(),
             Self::Eip1559(tx) => tx.size(),
             Self::Eip7702(tx) => tx.size(),
-            Self::Deposit(tx) => tx.size(),
             Self::Eip8130(tx) => tx.size(),
+            Self::Deposit(tx) => tx.size(),
         }
     }
 }

--- a/crates/common/consensus/src/transaction/eip8130/account_changes.rs
+++ b/crates/common/consensus/src/transaction/eip8130/account_changes.rs
@@ -1,6 +1,6 @@
 //! [EIP-8130] `account_changes` entry types.
 //!
-//! An [`AccountChange`] is a tagged-union entry inside `TxAa8130::account_changes`.
+//! An [`AccountChange`] is a tagged-union entry inside `TxEip8130::account_changes`.
 //! On the wire, each entry is encoded as `type_byte || rlp([entry_fields...])`.
 //!
 //! [EIP-8130]: https://eips.ethereum.org/EIPS/eip-8130
@@ -12,7 +12,7 @@ use alloy_rlp::{
     Buf, BufMut, Decodable, Encodable, Header, RlpDecodable, RlpEncodable, length_of_length,
 };
 
-use crate::transaction::aa8130::constants::Aa8130Constants;
+use crate::transaction::eip8130::constants::Eip8130Constants;
 
 /// Bitmask describing the contexts in which an owner is valid.
 ///
@@ -44,7 +44,7 @@ impl Decodable for Scope {
 
 impl Scope {
     /// Unrestricted scope (owner valid in all contexts).
-    pub const UNRESTRICTED: Self = Self(Aa8130Constants::SCOPE_UNRESTRICTED);
+    pub const UNRESTRICTED: Self = Self(Eip8130Constants::SCOPE_UNRESTRICTED);
 
     /// Returns the raw bitmask.
     pub const fn bits(&self) -> u8 {
@@ -53,22 +53,22 @@ impl Scope {
 
     /// Returns true if the scope grants the `SCOPE_SIGNATURE` context.
     pub const fn has_signature(&self) -> bool {
-        self.0 & Aa8130Constants::SCOPE_SIGNATURE != 0
+        self.0 & Eip8130Constants::SCOPE_SIGNATURE != 0
     }
 
     /// Returns true if the scope grants the `SCOPE_SENDER` context.
     pub const fn has_sender(&self) -> bool {
-        self.0 & Aa8130Constants::SCOPE_SENDER != 0
+        self.0 & Eip8130Constants::SCOPE_SENDER != 0
     }
 
     /// Returns true if the scope grants the `SCOPE_PAYER` context.
     pub const fn has_payer(&self) -> bool {
-        self.0 & Aa8130Constants::SCOPE_PAYER != 0
+        self.0 & Eip8130Constants::SCOPE_PAYER != 0
     }
 
     /// Returns true if the scope grants the `SCOPE_CONFIG` context.
     pub const fn has_config(&self) -> bool {
-        self.0 & Aa8130Constants::SCOPE_CONFIG != 0
+        self.0 & Eip8130Constants::SCOPE_CONFIG != 0
     }
 }
 
@@ -101,16 +101,16 @@ impl OwnerChangeType {
     /// Returns the on-wire op byte.
     pub const fn op_byte(&self) -> u8 {
         match self {
-            Self::Authorize => Aa8130Constants::OWNER_CHANGE_AUTHORIZE,
-            Self::Revoke => Aa8130Constants::OWNER_CHANGE_REVOKE,
+            Self::Authorize => Eip8130Constants::OWNER_CHANGE_AUTHORIZE,
+            Self::Revoke => Eip8130Constants::OWNER_CHANGE_REVOKE,
         }
     }
 
     /// Parses a wire op byte.
     pub const fn from_op_byte(byte: u8) -> Option<Self> {
         match byte {
-            Aa8130Constants::OWNER_CHANGE_AUTHORIZE => Some(Self::Authorize),
-            Aa8130Constants::OWNER_CHANGE_REVOKE => Some(Self::Revoke),
+            Eip8130Constants::OWNER_CHANGE_AUTHORIZE => Some(Self::Authorize),
+            Eip8130Constants::OWNER_CHANGE_REVOKE => Some(Self::Revoke),
             _ => None,
         }
     }
@@ -222,7 +222,7 @@ pub struct Delegation {
     pub target: Address,
 }
 
-/// A tagged-union entry inside `TxAa8130::account_changes`.
+/// A tagged-union entry inside `TxEip8130::account_changes`.
 ///
 /// On the wire each entry is `type_byte || rlp([body_fields...])`:
 /// - `0x00` -> [`AccountChange::Create`]
@@ -247,9 +247,9 @@ impl AccountChange {
     /// Returns the on-wire type byte for this entry.
     pub const fn type_byte(&self) -> u8 {
         match self {
-            Self::Create(_) => Aa8130Constants::ACCOUNT_CHANGE_TYPE_CREATE,
-            Self::ConfigChange(_) => Aa8130Constants::ACCOUNT_CHANGE_TYPE_CONFIG,
-            Self::Delegation(_) => Aa8130Constants::ACCOUNT_CHANGE_TYPE_DELEGATION,
+            Self::Create(_) => Eip8130Constants::ACCOUNT_CHANGE_TYPE_CREATE,
+            Self::ConfigChange(_) => Eip8130Constants::ACCOUNT_CHANGE_TYPE_CONFIG,
+            Self::Delegation(_) => Eip8130Constants::ACCOUNT_CHANGE_TYPE_DELEGATION,
         }
     }
 
@@ -285,13 +285,13 @@ impl Decodable for AccountChange {
         let type_byte = buf[0];
         buf.advance(1);
         match type_byte {
-            Aa8130Constants::ACCOUNT_CHANGE_TYPE_CREATE => {
+            Eip8130Constants::ACCOUNT_CHANGE_TYPE_CREATE => {
                 CreateEntry::decode(buf).map(Self::Create)
             }
-            Aa8130Constants::ACCOUNT_CHANGE_TYPE_CONFIG => {
+            Eip8130Constants::ACCOUNT_CHANGE_TYPE_CONFIG => {
                 ConfigChange::decode(buf).map(Self::ConfigChange)
             }
-            Aa8130Constants::ACCOUNT_CHANGE_TYPE_DELEGATION => {
+            Eip8130Constants::ACCOUNT_CHANGE_TYPE_DELEGATION => {
                 Delegation::decode(buf).map(Self::Delegation)
             }
             _ => Err(alloy_rlp::Error::Custom("invalid AccountChange type byte")),
@@ -308,10 +308,10 @@ mod tests {
     #[test]
     fn scope_bit_helpers() {
         let s = Scope(
-            Aa8130Constants::SCOPE_SIGNATURE
-                | Aa8130Constants::SCOPE_SENDER
-                | Aa8130Constants::SCOPE_PAYER
-                | Aa8130Constants::SCOPE_CONFIG,
+            Eip8130Constants::SCOPE_SIGNATURE
+                | Eip8130Constants::SCOPE_SENDER
+                | Eip8130Constants::SCOPE_PAYER
+                | Eip8130Constants::SCOPE_CONFIG,
         );
         assert!(s.has_signature());
         assert!(s.has_sender());
@@ -335,7 +335,7 @@ mod tests {
             change_type: OwnerChangeType::Authorize,
             verifier: address!("0x00000000000000000000000000000000000000aa"),
             owner_id: b256!("0x1111111111111111111111111111111111111111111111111111111111111111"),
-            scope: Scope(Aa8130Constants::SCOPE_SIGNATURE | Aa8130Constants::SCOPE_SENDER),
+            scope: Scope(Eip8130Constants::SCOPE_SIGNATURE | Eip8130Constants::SCOPE_SENDER),
         };
         let mut buf = Vec::new();
         oc.encode(&mut buf);
@@ -354,12 +354,12 @@ mod tests {
                 owner_id: b256!(
                     "0x3333333333333333333333333333333333333333333333333333333333333333"
                 ),
-                scope: Scope(Aa8130Constants::SCOPE_SIGNATURE),
+                scope: Scope(Eip8130Constants::SCOPE_SIGNATURE),
             }],
         });
         let mut buf = Vec::new();
         ac.encode(&mut buf);
-        assert_eq!(buf[0], Aa8130Constants::ACCOUNT_CHANGE_TYPE_CREATE);
+        assert_eq!(buf[0], Eip8130Constants::ACCOUNT_CHANGE_TYPE_CREATE);
         assert_eq!(buf.len(), ac.length());
         let decoded = AccountChange::decode(&mut buf.as_slice()).unwrap();
         assert_eq!(ac, decoded);
@@ -382,7 +382,7 @@ mod tests {
         });
         let mut buf = Vec::new();
         ac.encode(&mut buf);
-        assert_eq!(buf[0], Aa8130Constants::ACCOUNT_CHANGE_TYPE_CONFIG);
+        assert_eq!(buf[0], Eip8130Constants::ACCOUNT_CHANGE_TYPE_CONFIG);
         let decoded = AccountChange::decode(&mut buf.as_slice()).unwrap();
         assert_eq!(ac, decoded);
     }
@@ -394,7 +394,7 @@ mod tests {
         });
         let mut buf = Vec::new();
         ac.encode(&mut buf);
-        assert_eq!(buf[0], Aa8130Constants::ACCOUNT_CHANGE_TYPE_DELEGATION);
+        assert_eq!(buf[0], Eip8130Constants::ACCOUNT_CHANGE_TYPE_DELEGATION);
         let decoded = AccountChange::decode(&mut buf.as_slice()).unwrap();
         assert_eq!(ac, decoded);
     }

--- a/crates/common/consensus/src/transaction/eip8130/call.rs
+++ b/crates/common/consensus/src/transaction/eip8130/call.rs
@@ -12,7 +12,7 @@ use alloy_rlp::{RlpDecodable, RlpEncodable};
 /// ETH transfers must be performed by the wallet bytecode via the `CALL` opcode.
 ///
 /// AA transactions group calls into phases (`Vec<Vec<Call>>`); see
-/// [`super::tx::TxAa8130::calls`].
+/// [`super::tx::TxEip8130::calls`].
 #[derive(Debug, Clone, PartialEq, Eq, Hash, RlpEncodable, RlpDecodable)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]

--- a/crates/common/consensus/src/transaction/eip8130/constants.rs
+++ b/crates/common/consensus/src/transaction/eip8130/constants.rs
@@ -17,29 +17,29 @@ use alloy_primitives::U256;
 ///
 /// [EIP-8130]: https://eips.ethereum.org/EIPS/eip-8130
 #[derive(Debug)]
-pub struct Aa8130Constants;
+pub struct Eip8130Constants;
 
-impl Aa8130Constants {
-    /// [EIP-2718] transaction type byte for AA transactions (`AA_TX_TYPE`).
+impl Eip8130Constants {
+    /// [EIP-2718] transaction type byte for AA transactions (`EIP8130_TX_TYPE`).
     ///
     /// Spec value: TBD. We use `0x7D`, picked to live in the high "OP-style"
     /// type-byte range adjacent to (but distinct from) the deposit type `0x7E`,
     /// and to be easy to renumber once the EIP finalizes.
     ///
     /// [EIP-2718]: https://eips.ethereum.org/EIPS/eip-2718
-    pub const AA_TX_TYPE: u8 = 0x7D;
+    pub const EIP8130_TX_TYPE: u8 = 0x7D;
 
-    /// Magic prefix byte for payer signature domain separation (`AA_PAYER_TYPE`).
+    /// Magic prefix byte for payer signature domain separation (`EIP8130_PAYER_TYPE`).
     ///
     /// Used in the payer signature preimage:
-    /// `keccak256(AA_PAYER_TYPE || rlp([...fields through calls...]))`.
+    /// `keccak256(EIP8130_PAYER_TYPE || rlp([...fields through calls...]))`.
     ///
     /// Spec value: TBD. We use `0xFA`, distinct from any registered EIP-2718
     /// transaction type byte to prevent cross-domain reuse.
-    pub const AA_PAYER_TYPE: u8 = 0xFA;
+    pub const EIP8130_PAYER_TYPE: u8 = 0xFA;
 
-    /// Base intrinsic gas cost for any AA transaction (`AA_BASE_COST`).
-    pub const AA_BASE_COST: u64 = 15_000;
+    /// Base intrinsic gas cost for any AA transaction (`EIP8130_BASE_COST`).
+    pub const EIP8130_BASE_COST: u64 = 15_000;
 
     /// Sentinel `nonce_key` value selecting nonce-free mode (`NONCE_KEY_MAX`).
     ///
@@ -104,21 +104,21 @@ mod tests {
 
     #[test]
     fn type_bytes_are_distinct() {
-        assert_ne!(Aa8130Constants::AA_TX_TYPE, Aa8130Constants::AA_PAYER_TYPE);
-        assert_ne!(Aa8130Constants::AA_TX_TYPE, LEGACY_TX_TYPE);
-        assert_ne!(Aa8130Constants::AA_TX_TYPE, EIP2930_TX_TYPE);
-        assert_ne!(Aa8130Constants::AA_TX_TYPE, EIP1559_TX_TYPE);
-        assert_ne!(Aa8130Constants::AA_TX_TYPE, EIP7702_TX_TYPE);
-        assert_ne!(Aa8130Constants::AA_TX_TYPE, DEPOSIT_TX_TYPE);
+        assert_ne!(Eip8130Constants::EIP8130_TX_TYPE, Eip8130Constants::EIP8130_PAYER_TYPE);
+        assert_ne!(Eip8130Constants::EIP8130_TX_TYPE, LEGACY_TX_TYPE);
+        assert_ne!(Eip8130Constants::EIP8130_TX_TYPE, EIP2930_TX_TYPE);
+        assert_ne!(Eip8130Constants::EIP8130_TX_TYPE, EIP1559_TX_TYPE);
+        assert_ne!(Eip8130Constants::EIP8130_TX_TYPE, EIP7702_TX_TYPE);
+        assert_ne!(Eip8130Constants::EIP8130_TX_TYPE, DEPOSIT_TX_TYPE);
     }
 
     #[test]
     fn scope_bits_are_orthogonal() {
         let bits = [
-            Aa8130Constants::SCOPE_SIGNATURE,
-            Aa8130Constants::SCOPE_SENDER,
-            Aa8130Constants::SCOPE_PAYER,
-            Aa8130Constants::SCOPE_CONFIG,
+            Eip8130Constants::SCOPE_SIGNATURE,
+            Eip8130Constants::SCOPE_SENDER,
+            Eip8130Constants::SCOPE_PAYER,
+            Eip8130Constants::SCOPE_CONFIG,
         ];
         let mut acc: u8 = 0;
         for b in bits {
@@ -126,14 +126,14 @@ mod tests {
             assert_eq!(acc & b, 0, "scope bits must be orthogonal");
             acc |= b;
         }
-        assert_eq!(Aa8130Constants::SCOPE_UNRESTRICTED, 0);
+        assert_eq!(Eip8130Constants::SCOPE_UNRESTRICTED, 0);
     }
 
     #[test]
     fn delegation_indicator_size_matches_prefix_plus_address() {
         assert_eq!(
-            Aa8130Constants::DELEGATION_INDICATOR_SIZE,
-            Aa8130Constants::DELEGATION_INDICATOR_PREFIX.len() + 20
+            Eip8130Constants::DELEGATION_INDICATOR_SIZE,
+            Eip8130Constants::DELEGATION_INDICATOR_PREFIX.len() + 20
         );
     }
 }

--- a/crates/common/consensus/src/transaction/eip8130/mod.rs
+++ b/crates/common/consensus/src/transaction/eip8130/mod.rs
@@ -1,13 +1,13 @@
 //! [EIP-8130] Account Abstraction by Account Configuration transaction type.
 //!
 //! Provides type-only plumbing for the new transaction kind:
-//! [`TxAa8130`] (unsigned), [`AaSigned`] (signed envelope), [`AccountChange`]
+//! [`TxEip8130`] (unsigned), [`Eip8130Signed`] (signed envelope), [`AccountChange`]
 //! (tagged-union account-mutation entries), and [`Call`] (per-call payload).
 //!
 //! [EIP-8130]: https://eips.ethereum.org/EIPS/eip-8130
 
 mod constants;
-pub use constants::Aa8130Constants;
+pub use constants::Eip8130Constants;
 
 mod call;
 pub use call::Call;
@@ -19,7 +19,7 @@ pub use account_changes::{
 };
 
 mod tx;
-pub use tx::TxAa8130;
+pub use tx::TxEip8130;
 
 mod signed;
-pub use signed::AaSigned;
+pub use signed::Eip8130Signed;

--- a/crates/common/consensus/src/transaction/eip8130/signed.rs
+++ b/crates/common/consensus/src/transaction/eip8130/signed.rs
@@ -1,11 +1,11 @@
-//! Signed [EIP-8130] Account Abstraction transaction envelope ([`AaSigned`]).
+//! Signed [EIP-8130] Account Abstraction transaction envelope ([`Eip8130Signed`]).
 //!
-//! [`AaSigned`] wraps a [`TxAa8130`] together with the two opaque byte strings
+//! [`Eip8130Signed`] wraps a [`TxEip8130`] together with the two opaque byte strings
 //! `sender_auth` and `payer_auth` that authenticate the sender and (optional)
 //! payer respectively. The wire format is:
 //!
 //! ```text
-//! AA_TX_TYPE || rlp([...TxAa8130 fields..., sender_auth, payer_auth])
+//! EIP8130_TX_TYPE || rlp([...TxEip8130 fields..., sender_auth, payer_auth])
 //! ```
 //!
 //! [EIP-8130]: https://eips.ethereum.org/EIPS/eip-8130
@@ -21,22 +21,22 @@ use alloy_eips::{
 use alloy_primitives::{Address, B256, Bytes, ChainId, TxKind, U256, bytes::BufMut, keccak256};
 use alloy_rlp::{Decodable, Encodable, Header, length_of_length};
 
-use crate::transaction::aa8130::{constants::Aa8130Constants, tx::TxAa8130};
+use crate::transaction::eip8130::{constants::Eip8130Constants, tx::TxEip8130};
 
 /// Signed [EIP-8130] Account Abstraction transaction envelope.
 ///
-/// Holds the unsigned [`TxAa8130`] body plus the two authentication byte
+/// Holds the unsigned [`TxEip8130`] body plus the two authentication byte
 /// strings. The transaction hash is computed at construction and cached.
 ///
 /// [EIP-8130]: https://eips.ethereum.org/EIPS/eip-8130
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct AaSigned {
+pub struct Eip8130Signed {
     /// Unsigned transaction body.
-    tx: TxAa8130,
+    tx: TxEip8130,
     /// Sender authentication payload.
     ///
     /// On the EOA path (`tx.sender == None`) this is a 65-byte ECDSA signature
-    /// (`r || s || v`) over [`TxAa8130::sender_signature_hash`].
+    /// (`r || s || v`) over [`TxEip8130::sender_signature_hash`].
     /// On the configured-owner path (`tx.sender == Some(_)`) this is
     /// `verifier(20) || verifier_data`.
     sender_auth: Bytes,
@@ -44,7 +44,7 @@ pub struct AaSigned {
     ///
     /// When `tx.payer.is_some()` this carries the payer's authorization,
     /// formatted as `verifier(20) || verifier_data` and validated against
-    /// [`TxAa8130::payer_signature_hash`] (with the resolved sender substituted).
+    /// [`TxEip8130::payer_signature_hash`] (with the resolved sender substituted).
     /// When `tx.payer.is_none()` this is empty.
     payer_auth: Bytes,
     /// Cached EIP-2718 transaction hash (`keccak256(encode_2718(self))`).
@@ -55,22 +55,22 @@ pub struct AaSigned {
 mod serde_impl {
     use serde::{Deserialize, Deserializer, Serialize, Serializer, de};
 
-    use super::{AaSigned, Bytes, TxAa8130};
+    use super::{Bytes, Eip8130Signed, TxEip8130};
 
     #[derive(Serialize, Deserialize)]
     #[serde(rename_all = "camelCase")]
-    struct AaSignedRepr {
-        tx: TxAa8130,
+    struct Eip8130SignedRepr {
+        tx: TxEip8130,
         sender_auth: Bytes,
         payer_auth: Bytes,
     }
 
-    impl Serialize for AaSigned {
+    impl Serialize for Eip8130Signed {
         fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
         where
             S: Serializer,
         {
-            AaSignedRepr {
+            Eip8130SignedRepr {
                 tx: self.tx.clone(),
                 sender_auth: self.sender_auth.clone(),
                 payer_auth: self.payer_auth.clone(),
@@ -79,40 +79,40 @@ mod serde_impl {
         }
     }
 
-    impl<'de> Deserialize<'de> for AaSigned {
+    impl<'de> Deserialize<'de> for Eip8130Signed {
         fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
         where
             D: Deserializer<'de>,
         {
-            let repr = AaSignedRepr::deserialize(deserializer).map_err(de::Error::custom)?;
+            let repr = Eip8130SignedRepr::deserialize(deserializer).map_err(de::Error::custom)?;
             Ok(Self::new(repr.tx, repr.sender_auth, repr.payer_auth))
         }
     }
 }
 
 #[cfg(feature = "arbitrary")]
-impl<'a> arbitrary::Arbitrary<'a> for AaSigned {
+impl<'a> arbitrary::Arbitrary<'a> for Eip8130Signed {
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
-        Ok(Self::new(TxAa8130::arbitrary(u)?, Bytes::arbitrary(u)?, Bytes::arbitrary(u)?))
+        Ok(Self::new(TxEip8130::arbitrary(u)?, Bytes::arbitrary(u)?, Bytes::arbitrary(u)?))
     }
 }
 
-impl AaSigned {
-    /// Constructs a new [`AaSigned`] from its parts, computing and caching
+impl Eip8130Signed {
+    /// Constructs a new [`Eip8130Signed`] from its parts, computing and caching
     /// the EIP-2718 transaction hash.
-    pub fn new(tx: TxAa8130, sender_auth: Bytes, payer_auth: Bytes) -> Self {
+    pub fn new(tx: TxEip8130, sender_auth: Bytes, payer_auth: Bytes) -> Self {
         let mut this = Self { tx, sender_auth, payer_auth, hash: B256::ZERO };
         this.hash = this.recompute_hash();
         this
     }
 
     /// Returns the unsigned transaction body.
-    pub const fn tx(&self) -> &TxAa8130 {
+    pub const fn tx(&self) -> &TxEip8130 {
         &self.tx
     }
 
     /// Consumes the envelope and returns the unsigned transaction body.
-    pub fn into_tx(self) -> TxAa8130 {
+    pub fn into_tx(self) -> TxEip8130 {
         self.tx
     }
 
@@ -172,7 +172,7 @@ impl AaSigned {
             return Err(alloy_rlp::Error::UnexpectedString);
         }
         let started = buf.len();
-        let tx = TxAa8130::rlp_decode_fields(buf)?;
+        let tx = TxEip8130::rlp_decode_fields(buf)?;
         let sender_auth = Bytes::decode(buf)?;
         let payer_auth = Bytes::decode(buf)?;
         let consumed = started - buf.len();
@@ -186,7 +186,7 @@ impl AaSigned {
     }
 }
 
-impl Encodable for AaSigned {
+impl Encodable for Eip8130Signed {
     fn encode(&self, out: &mut dyn BufMut) {
         let len = self.encode_2718_len();
         Header { list: false, payload_length: len }.encode(out);
@@ -199,7 +199,7 @@ impl Encodable for AaSigned {
     }
 }
 
-impl Decodable for AaSigned {
+impl Decodable for Eip8130Signed {
     fn decode(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
         let header = Header::decode(buf)?;
         if header.list {
@@ -219,21 +219,21 @@ impl Decodable for AaSigned {
     }
 }
 
-impl Typed2718 for AaSigned {
+impl Typed2718 for Eip8130Signed {
     fn ty(&self) -> u8 {
-        Aa8130Constants::AA_TX_TYPE
+        Eip8130Constants::EIP8130_TX_TYPE
     }
 }
 
-impl IsTyped2718 for AaSigned {
+impl IsTyped2718 for Eip8130Signed {
     fn is_type(ty: u8) -> bool {
-        ty == Aa8130Constants::AA_TX_TYPE
+        ty == Eip8130Constants::EIP8130_TX_TYPE
     }
 }
 
-impl Encodable2718 for AaSigned {
+impl Encodable2718 for Eip8130Signed {
     fn type_flag(&self) -> Option<u8> {
-        Some(Aa8130Constants::AA_TX_TYPE)
+        Some(Eip8130Constants::EIP8130_TX_TYPE)
     }
 
     fn encode_2718_len(&self) -> usize {
@@ -241,7 +241,7 @@ impl Encodable2718 for AaSigned {
     }
 
     fn encode_2718(&self, out: &mut dyn BufMut) {
-        out.put_u8(Aa8130Constants::AA_TX_TYPE);
+        out.put_u8(Eip8130Constants::EIP8130_TX_TYPE);
         self.rlp_encode_signed(out);
     }
 
@@ -250,9 +250,9 @@ impl Encodable2718 for AaSigned {
     }
 }
 
-impl Decodable2718 for AaSigned {
+impl Decodable2718 for Eip8130Signed {
     fn typed_decode(ty: u8, buf: &mut &[u8]) -> Eip2718Result<Self> {
-        if ty != Aa8130Constants::AA_TX_TYPE {
+        if ty != Eip8130Constants::EIP8130_TX_TYPE {
             return Err(Eip2718Error::UnexpectedType(ty));
         }
         Self::rlp_decode_signed(buf).map_err(Into::into)
@@ -263,13 +263,13 @@ impl Decodable2718 for AaSigned {
     }
 }
 
-impl InMemorySize for AaSigned {
+impl InMemorySize for Eip8130Signed {
     fn size(&self) -> usize {
         InMemorySize::size(&self.tx) + self.sender_auth.len() + self.payer_auth.len()
     }
 }
 
-impl Transaction for AaSigned {
+impl Transaction for Eip8130Signed {
     fn chain_id(&self) -> Option<ChainId> {
         self.tx.chain_id()
     }
@@ -344,13 +344,13 @@ mod tests {
     use alloy_primitives::{address, bytes};
 
     use super::*;
-    use crate::transaction::aa8130::{
+    use crate::transaction::eip8130::{
         account_changes::{AccountChange, Delegation},
         call::Call,
     };
 
-    fn sample_signed(payer_present: bool) -> AaSigned {
-        let tx = TxAa8130 {
+    fn sample_signed(payer_present: bool) -> Eip8130Signed {
+        let tx = TxEip8130 {
             chain_id: 8453,
             sender: Some(address!("0x00000000000000000000000000000000000000aa")),
             nonce_key: U256::from(7u64),
@@ -370,7 +370,7 @@ mod tests {
                 None
             },
         };
-        AaSigned::new(
+        Eip8130Signed::new(
             tx,
             bytes!("deadbeef"),
             if payer_present { bytes!("cafebabe") } else { Bytes::new() },
@@ -382,10 +382,10 @@ mod tests {
         let signed = sample_signed(false);
         let mut buf = Vec::new();
         signed.encode_2718(&mut buf);
-        assert_eq!(buf[0], Aa8130Constants::AA_TX_TYPE);
+        assert_eq!(buf[0], Eip8130Constants::EIP8130_TX_TYPE);
         assert_eq!(buf.len(), signed.encode_2718_len());
 
-        let decoded = AaSigned::decode_2718(&mut buf.as_slice()).unwrap();
+        let decoded = Eip8130Signed::decode_2718(&mut buf.as_slice()).unwrap();
         assert_eq!(signed, decoded);
     }
 
@@ -394,7 +394,7 @@ mod tests {
         let signed = sample_signed(true);
         let mut buf = Vec::new();
         signed.encode_2718(&mut buf);
-        let decoded = AaSigned::decode_2718(&mut buf.as_slice()).unwrap();
+        let decoded = Eip8130Signed::decode_2718(&mut buf.as_slice()).unwrap();
         assert_eq!(signed, decoded);
     }
 
@@ -403,7 +403,7 @@ mod tests {
         let signed = sample_signed(true);
         let mut buf = Vec::new();
         signed.encode(&mut buf);
-        let decoded = AaSigned::decode(&mut buf.as_slice()).unwrap();
+        let decoded = Eip8130Signed::decode(&mut buf.as_slice()).unwrap();
         assert_eq!(signed, decoded);
     }
 
@@ -424,8 +424,8 @@ mod tests {
     #[test]
     fn ty_byte() {
         let signed = sample_signed(false);
-        assert_eq!(signed.ty(), Aa8130Constants::AA_TX_TYPE);
-        assert_eq!(signed.type_flag(), Some(Aa8130Constants::AA_TX_TYPE));
+        assert_eq!(signed.ty(), Eip8130Constants::EIP8130_TX_TYPE);
+        assert_eq!(signed.type_flag(), Some(Eip8130Constants::EIP8130_TX_TYPE));
     }
 
     #[test]
@@ -433,7 +433,7 @@ mod tests {
         let signed = sample_signed(false);
         let mut buf = Vec::new();
         signed.rlp_encode_signed(&mut buf);
-        let res = AaSigned::typed_decode(0x00, &mut buf.as_slice());
+        let res = Eip8130Signed::typed_decode(0x00, &mut buf.as_slice());
         assert!(res.is_err());
     }
 
@@ -454,7 +454,7 @@ mod tests {
 
         assert!(!json.contains("\"hash\""));
 
-        let decoded: AaSigned = serde_json::from_str(&json).unwrap();
+        let decoded: Eip8130Signed = serde_json::from_str(&json).unwrap();
         assert_eq!(decoded, signed);
         assert_eq!(decoded.hash(), signed.hash());
     }
@@ -469,7 +469,7 @@ mod tests {
             .unwrap()
             .insert("hash".to_string(), serde_json::Value::String(format!("{:?}", B256::ZERO)));
 
-        let decoded: AaSigned = serde_json::from_value(value).unwrap();
+        let decoded: Eip8130Signed = serde_json::from_value(value).unwrap();
         assert_eq!(*decoded.hash(), *signed.hash());
         assert_ne!(*decoded.hash(), B256::ZERO);
     }

--- a/crates/common/consensus/src/transaction/eip8130/tx.rs
+++ b/crates/common/consensus/src/transaction/eip8130/tx.rs
@@ -1,4 +1,4 @@
-//! Unsigned [EIP-8130] Account Abstraction transaction body ([`TxAa8130`]).
+//! Unsigned [EIP-8130] Account Abstraction transaction body ([`TxEip8130`]).
 //!
 //! This module defines the unsigned payload of an EIP-8130 transaction. The
 //! signed envelope (which wraps this type alongside the `sender_auth` and
@@ -16,16 +16,16 @@ use alloy_primitives::{
 };
 use alloy_rlp::{Decodable, Encodable, Header, length_of_length};
 
-use crate::transaction::aa8130::{
-    account_changes::AccountChange, call::Call, constants::Aa8130Constants,
+use crate::transaction::eip8130::{
+    account_changes::AccountChange, call::Call, constants::Eip8130Constants,
 };
 
 /// Unsigned body of an [EIP-8130] Account Abstraction transaction.
 ///
-/// On the wire, the signed form (an [`super::AaSigned`]) is
-/// `AA_TX_TYPE || rlp([...all fields..., sender_auth, payer_auth])`. The
+/// On the wire, the signed form (an [`super::Eip8130Signed`]) is
+/// `EIP8130_TX_TYPE || rlp([...all fields..., sender_auth, payer_auth])`. The
 /// unsigned struct here carries only the consensus fields; signature material
-/// is held by [`super::AaSigned`].
+/// is held by [`super::Eip8130Signed`].
 ///
 /// Field semantics follow the [EIP-8130] draft. Two fields are nullable on the
 /// wire (encoded as a zero-length byte string when absent):
@@ -41,7 +41,7 @@ use crate::transaction::aa8130::{
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
-pub struct TxAa8130 {
+pub struct TxEip8130 {
     /// EIP-155 chain ID this transaction is bound to.
     pub chain_id: ChainId,
     /// Explicit sender account address, or `None` for the EOA path.
@@ -68,7 +68,7 @@ pub struct TxAa8130 {
     pub payer: Option<Address>,
 }
 
-impl TxAa8130 {
+impl TxEip8130 {
     /// Encodes an `Option<Address>` as the AA wire format: zero-length byte
     /// string when `None`, 20-byte string when `Some`.
     fn encode_address_opt(addr: &Option<Address>, out: &mut dyn BufMut) {
@@ -201,26 +201,26 @@ impl TxAa8130 {
 
     /// Signing-hash preimage for the sender, per [EIP-8130].
     ///
-    /// `keccak256(AA_TX_TYPE || rlp([...unsigned body fields...]))`.
+    /// `keccak256(EIP8130_TX_TYPE || rlp([...unsigned body fields...]))`.
     ///
     /// [EIP-8130]: https://eips.ethereum.org/EIPS/eip-8130
     pub fn sender_signature_hash(&self) -> B256 {
         let mut buf = Vec::with_capacity(self.rlp_encoded_length() + 1);
-        buf.put_u8(Aa8130Constants::AA_TX_TYPE);
+        buf.put_u8(Eip8130Constants::EIP8130_TX_TYPE);
         self.rlp_encode(&mut buf);
         keccak256(&buf)
     }
 
     /// Signing-hash preimage for the payer, per [EIP-8130].
     ///
-    /// `keccak256(AA_PAYER_TYPE || rlp(unsigned body fields with the
+    /// `keccak256(EIP8130_PAYER_TYPE || rlp(unsigned body fields with the
     /// `sender` slot replaced by the recovered sender address))`.
     ///
     /// [EIP-8130]: https://eips.ethereum.org/EIPS/eip-8130
     pub fn payer_signature_hash(&self, resolved_sender: Address) -> B256 {
         let with_resolved = Self { sender: Some(resolved_sender), ..self.clone() };
         let mut buf = Vec::with_capacity(with_resolved.rlp_encoded_length() + 1);
-        buf.put_u8(Aa8130Constants::AA_PAYER_TYPE);
+        buf.put_u8(Eip8130Constants::EIP8130_PAYER_TYPE);
         with_resolved.rlp_encode(&mut buf);
         keccak256(&buf)
     }
@@ -241,7 +241,7 @@ impl TxAa8130 {
     }
 }
 
-impl Encodable for TxAa8130 {
+impl Encodable for TxEip8130 {
     fn encode(&self, out: &mut dyn BufMut) {
         self.rlp_encode(out);
     }
@@ -251,7 +251,7 @@ impl Encodable for TxAa8130 {
     }
 }
 
-impl Decodable for TxAa8130 {
+impl Decodable for TxEip8130 {
     fn decode(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
         let header = Header::decode(buf)?;
         if !header.list {
@@ -270,25 +270,25 @@ impl Decodable for TxAa8130 {
     }
 }
 
-impl Typed2718 for TxAa8130 {
+impl Typed2718 for TxEip8130 {
     fn ty(&self) -> u8 {
-        Aa8130Constants::AA_TX_TYPE
+        Eip8130Constants::EIP8130_TX_TYPE
     }
 }
 
-impl IsTyped2718 for TxAa8130 {
+impl IsTyped2718 for TxEip8130 {
     fn is_type(ty: u8) -> bool {
-        ty == Aa8130Constants::AA_TX_TYPE
+        ty == Eip8130Constants::EIP8130_TX_TYPE
     }
 }
 
-impl InMemorySize for TxAa8130 {
+impl InMemorySize for TxEip8130 {
     fn size(&self) -> usize {
         Self::size(self)
     }
 }
 
-impl Transaction for TxAa8130 {
+impl Transaction for TxEip8130 {
     fn chain_id(&self) -> Option<ChainId> {
         Some(self.chain_id)
     }
@@ -361,13 +361,13 @@ impl Transaction for TxAa8130 {
     }
 }
 
-impl SignableTransaction<Signature> for TxAa8130 {
+impl SignableTransaction<Signature> for TxEip8130 {
     fn set_chain_id(&mut self, chain_id: ChainId) {
         self.chain_id = chain_id;
     }
 
     fn encode_for_signing(&self, out: &mut dyn BufMut) {
-        out.put_u8(Aa8130Constants::AA_TX_TYPE);
+        out.put_u8(Eip8130Constants::EIP8130_TX_TYPE);
         self.rlp_encode(out);
     }
 
@@ -381,10 +381,10 @@ mod tests {
     use alloy_primitives::{address, bytes};
 
     use super::*;
-    use crate::transaction::aa8130::account_changes::Delegation;
+    use crate::transaction::eip8130::account_changes::Delegation;
 
-    fn sample_tx() -> TxAa8130 {
-        TxAa8130 {
+    fn sample_tx() -> TxEip8130 {
+        TxEip8130 {
             chain_id: 8453,
             sender: Some(address!("0x00000000000000000000000000000000000000aa")),
             nonce_key: U256::from(0x1234u64),
@@ -410,7 +410,7 @@ mod tests {
         let mut buf = Vec::new();
         tx.rlp_encode(&mut buf);
         assert_eq!(buf.len(), tx.rlp_encoded_length());
-        let decoded = TxAa8130::rlp_decode_fields(&mut {
+        let decoded = TxEip8130::rlp_decode_fields(&mut {
             let header = Header::decode(&mut &buf[..]).unwrap();
             assert!(header.list);
             &buf[buf.len() - header.payload_length..]
@@ -424,25 +424,25 @@ mod tests {
         let tx = sample_tx();
         let mut buf = Vec::new();
         tx.encode(&mut buf);
-        let decoded = TxAa8130::decode(&mut buf.as_slice()).unwrap();
+        let decoded = TxEip8130::decode(&mut buf.as_slice()).unwrap();
         assert_eq!(tx, decoded);
     }
 
     #[test]
     fn rlp_roundtrip_minimal_empty() {
-        let tx = TxAa8130::default();
+        let tx = TxEip8130::default();
         let mut buf = Vec::new();
         tx.encode(&mut buf);
-        let decoded = TxAa8130::decode(&mut buf.as_slice()).unwrap();
+        let decoded = TxEip8130::decode(&mut buf.as_slice()).unwrap();
         assert_eq!(tx, decoded);
     }
 
     #[test]
     fn address_opt_roundtrip_none() {
         let mut buf = Vec::new();
-        TxAa8130::encode_address_opt(&None, &mut buf);
+        TxEip8130::encode_address_opt(&None, &mut buf);
         assert_eq!(buf, vec![0x80]);
-        let decoded = TxAa8130::decode_address_opt(&mut buf.as_slice()).unwrap();
+        let decoded = TxEip8130::decode_address_opt(&mut buf.as_slice()).unwrap();
         assert_eq!(decoded, None);
     }
 
@@ -450,8 +450,8 @@ mod tests {
     fn address_opt_roundtrip_some() {
         let addr = address!("0x00000000000000000000000000000000000000ff");
         let mut buf = Vec::new();
-        TxAa8130::encode_address_opt(&Some(addr), &mut buf);
-        let decoded = TxAa8130::decode_address_opt(&mut buf.as_slice()).unwrap();
+        TxEip8130::encode_address_opt(&Some(addr), &mut buf);
+        let decoded = TxEip8130::decode_address_opt(&mut buf.as_slice()).unwrap();
         assert_eq!(decoded, Some(addr));
     }
 
@@ -459,7 +459,7 @@ mod tests {
     fn address_opt_rejects_wrong_length() {
         let mut buf = Vec::new();
         Bytes::copy_from_slice(&[0u8; 19]).encode(&mut buf);
-        let res = TxAa8130::decode_address_opt(&mut buf.as_slice());
+        let res = TxEip8130::decode_address_opt(&mut buf.as_slice());
         assert!(res.is_err());
     }
 
@@ -481,14 +481,14 @@ mod tests {
 
     #[test]
     fn ty_byte_matches_constant() {
-        assert_eq!(sample_tx().ty(), Aa8130Constants::AA_TX_TYPE);
-        assert!(<TxAa8130 as IsTyped2718>::is_type(Aa8130Constants::AA_TX_TYPE));
-        assert!(!<TxAa8130 as IsTyped2718>::is_type(0x00));
+        assert_eq!(sample_tx().ty(), Eip8130Constants::EIP8130_TX_TYPE);
+        assert!(<TxEip8130 as IsTyped2718>::is_type(Eip8130Constants::EIP8130_TX_TYPE));
+        assert!(!<TxEip8130 as IsTyped2718>::is_type(0x00));
     }
 
     #[test]
     fn nested_calls_roundtrip() {
-        let tx = TxAa8130 {
+        let tx = TxEip8130 {
             chain_id: 1,
             calls: vec![
                 vec![Call { to: Address::ZERO, data: bytes!("01") }],
@@ -502,13 +502,13 @@ mod tests {
         };
         let mut buf = Vec::new();
         tx.encode(&mut buf);
-        let decoded = TxAa8130::decode(&mut buf.as_slice()).unwrap();
+        let decoded = TxEip8130::decode(&mut buf.as_slice()).unwrap();
         assert_eq!(tx, decoded);
     }
 
     #[test]
     fn account_change_roundtrip_in_tx() {
-        let tx = TxAa8130 {
+        let tx = TxEip8130 {
             chain_id: 1,
             account_changes: vec![
                 AccountChange::Delegation(Delegation { target: Address::ZERO }),
@@ -520,7 +520,7 @@ mod tests {
         };
         let mut buf = Vec::new();
         tx.encode(&mut buf);
-        let decoded = TxAa8130::decode(&mut buf.as_slice()).unwrap();
+        let decoded = TxEip8130::decode(&mut buf.as_slice()).unwrap();
         assert_eq!(tx.account_changes, decoded.account_changes);
     }
 
@@ -531,9 +531,9 @@ mod tests {
         let resolved = address!("0x00000000000000000000000000000000000000dd");
         let payer_hash_v1 = tx.payer_signature_hash(resolved);
 
-        let tx2 = TxAa8130 { sender: Some(resolved), ..tx };
+        let tx2 = TxEip8130 { sender: Some(resolved), ..tx };
         let mut buf = Vec::with_capacity(tx2.rlp_encoded_length() + 1);
-        buf.put_u8(Aa8130Constants::AA_PAYER_TYPE);
+        buf.put_u8(Eip8130Constants::EIP8130_PAYER_TYPE);
         tx2.rlp_encode(&mut buf);
         let payer_hash_v2 = keccak256(&buf);
         assert_eq!(payer_hash_v1, payer_hash_v2);

--- a/crates/common/consensus/src/transaction/envelope.rs
+++ b/crates/common/consensus/src/transaction/envelope.rs
@@ -19,7 +19,7 @@ use revm::context::TxEnv;
 
 use crate::{
     BasePooledTransaction, TxDeposit,
-    transaction::{Eip8130Signed, BaseTransactionInfo, DepositInfo, TxEip8130},
+    transaction::{BaseTransactionInfo, DepositInfo, Eip8130Signed, TxEip8130},
 };
 
 /// The Ethereum [EIP-2718] Transaction Envelope, modified for Base.
@@ -156,7 +156,6 @@ impl From<Signed<BaseTypedTransaction>> for BaseTxEnvelope {
                 let tx = Signed::new_unchecked(tx_eip7702, sig, hash);
                 Self::Eip7702(tx)
             }
-            BaseTypedTransaction::Deposit(tx) => Self::Deposit(Sealed::new_unchecked(tx, hash)),
             BaseTypedTransaction::Eip8130(tx) => {
                 debug_assert!(
                     tx.sender.is_none(),
@@ -168,6 +167,7 @@ impl From<Signed<BaseTypedTransaction>> for BaseTxEnvelope {
                 );
                 Self::Eip8130(Eip8130Signed::new(tx, sig.as_bytes().into(), Bytes::new()))
             }
+            BaseTypedTransaction::Deposit(tx) => Self::Deposit(Sealed::new_unchecked(tx, hash)),
         }
     }
 }
@@ -214,10 +214,10 @@ impl FromRecoveredTx<BaseTxEnvelope> for TxEnv {
             BaseTxEnvelope::Eip1559(tx) => Self::from_recovered_tx(tx.tx(), caller),
             BaseTxEnvelope::Eip2930(tx) => Self::from_recovered_tx(tx.tx(), caller),
             BaseTxEnvelope::Eip7702(tx) => Self::from_recovered_tx(tx.tx(), caller),
-            BaseTxEnvelope::Deposit(tx) => Self::from_recovered_tx(tx.inner(), caller),
             BaseTxEnvelope::Eip8130(_) => {
                 unimplemented!("EIP-8130 AA transactions cannot be converted to TxEnv yet")
             }
+            BaseTxEnvelope::Deposit(tx) => Self::from_recovered_tx(tx.inner(), caller),
         }
     }
 }
@@ -240,11 +240,11 @@ impl From<BaseTxEnvelope> for alloy_rpc_types_eth::TransactionRequest {
             BaseTxEnvelope::Eip2930(tx) => tx.into_parts().0.into(),
             BaseTxEnvelope::Eip1559(tx) => tx.into_parts().0.into(),
             BaseTxEnvelope::Eip7702(tx) => tx.into_parts().0.into(),
-            BaseTxEnvelope::Deposit(tx) => tx.into_inner().into(),
             BaseTxEnvelope::Legacy(tx) => tx.into_parts().0.into(),
             BaseTxEnvelope::Eip8130(_) => unimplemented!(
                 "BaseTxEnvelope::Eip8130 cannot be converted to an alloy TransactionRequest; AA transactions have no single sender/recipient/value to project into the legacy request shape"
             ),
+            BaseTxEnvelope::Deposit(tx) => tx.into_inner().into(),
         }
     }
 }
@@ -340,10 +340,10 @@ impl BaseTxEnvelope {
             Self::Eip2930(tx) => Ok(tx.into()),
             Self::Eip1559(tx) => Ok(tx.into()),
             Self::Eip7702(tx) => Ok(tx.into()),
+            Self::Eip8130(tx) => Ok(tx.into()),
             Self::Deposit(tx) => {
                 Err(ValueError::new(tx.into(), "Deposit transactions cannot be pooled"))
             }
-            Self::Eip8130(tx) => Ok(tx.into()),
         }
     }
 
@@ -375,13 +375,13 @@ impl BaseTxEnvelope {
             Self::Eip2930(tx) => Ok(tx.into()),
             Self::Eip1559(tx) => Ok(tx.into()),
             Self::Eip7702(tx) => Ok(tx.into()),
-            tx @ Self::Deposit(_) => Err(ValueError::new(
-                tx,
-                "Deposit transactions cannot be converted to ethereum transaction",
-            )),
             tx @ Self::Eip8130(_) => Err(ValueError::new(
                 tx,
                 "EIP-8130 transactions cannot be converted to ethereum transaction",
+            )),
+            tx @ Self::Deposit(_) => Err(ValueError::new(
+                tx,
+                "Deposit transactions cannot be converted to ethereum transaction",
             )),
         }
     }
@@ -430,10 +430,10 @@ impl BaseTxEnvelope {
             Self::Eip2930(tx) => &mut tx.tx_mut().input,
             Self::Legacy(tx) => &mut tx.tx_mut().input,
             Self::Eip7702(tx) => &mut tx.tx_mut().input,
-            Self::Deposit(tx) => &mut tx.inner_mut().input,
             Self::Eip8130(_) => {
                 unimplemented!("EIP-8130 transactions have no single input field")
             }
+            Self::Deposit(tx) => &mut tx.inner_mut().input,
         }
     }
 
@@ -523,7 +523,7 @@ impl BaseTxEnvelope {
             Self::Eip2930(tx) => Some(tx.signature()),
             Self::Eip1559(tx) => Some(tx.signature()),
             Self::Eip7702(tx) => Some(tx.signature()),
-            Self::Deposit(_) | Self::Eip8130(_) => None,
+            Self::Eip8130(_) | Self::Deposit(_) => None,
         }
     }
 
@@ -534,8 +534,8 @@ impl BaseTxEnvelope {
             Self::Eip2930(_) => OpTxType::Eip2930,
             Self::Eip1559(_) => OpTxType::Eip1559,
             Self::Eip7702(_) => OpTxType::Eip7702,
-            Self::Deposit(_) => OpTxType::Deposit,
             Self::Eip8130(_) => OpTxType::Eip8130,
+            Self::Deposit(_) => OpTxType::Deposit,
         }
     }
 
@@ -546,8 +546,8 @@ impl BaseTxEnvelope {
             Self::Eip1559(tx) => tx.hash(),
             Self::Eip2930(tx) => tx.hash(),
             Self::Eip7702(tx) => tx.hash(),
-            Self::Deposit(tx) => tx.hash_ref(),
             Self::Eip8130(tx) => tx.hash(),
+            Self::Deposit(tx) => tx.hash_ref(),
         }
     }
 
@@ -563,8 +563,8 @@ impl BaseTxEnvelope {
             Self::Eip2930(t) => t.eip2718_encoded_length(),
             Self::Eip1559(t) => t.eip2718_encoded_length(),
             Self::Eip7702(t) => t.eip2718_encoded_length(),
-            Self::Deposit(t) => t.eip2718_encoded_length(),
             Self::Eip8130(t) => t.encode_2718_len(),
+            Self::Deposit(t) => t.eip2718_encoded_length(),
         }
     }
 }
@@ -585,20 +585,20 @@ impl alloy_consensus::transaction::SignerRecoverable for BaseTxEnvelope {
             Self::Eip2930(tx) => tx.signature_hash(),
             Self::Eip1559(tx) => tx.signature_hash(),
             Self::Eip7702(tx) => tx.signature_hash(),
-            // The Deposit transaction does not have a signature. Directly return the
-            // `from` address.
-            Self::Deposit(tx) => return Ok(tx.from),
             Self::Eip8130(tx) => match tx.explicit_sender() {
                 Some(sender) => return Ok(sender),
                 None => return Err(alloy_consensus::crypto::RecoveryError::new()),
             },
+            // The Deposit transaction does not have a signature. Directly return the
+            // `from` address.
+            Self::Deposit(tx) => return Ok(tx.from),
         };
         let signature = match self {
             Self::Legacy(tx) => tx.signature(),
             Self::Eip2930(tx) => tx.signature(),
             Self::Eip1559(tx) => tx.signature(),
             Self::Eip7702(tx) => tx.signature(),
-            Self::Deposit(_) | Self::Eip8130(_) => {
+            Self::Eip8130(_) | Self::Deposit(_) => {
                 unreachable!("non-ECDSA variants short-circuit above")
             }
         };
@@ -613,20 +613,20 @@ impl alloy_consensus::transaction::SignerRecoverable for BaseTxEnvelope {
             Self::Eip2930(tx) => tx.signature_hash(),
             Self::Eip1559(tx) => tx.signature_hash(),
             Self::Eip7702(tx) => tx.signature_hash(),
-            // The Deposit transaction does not have a signature. Directly return the
-            // `from` address.
-            Self::Deposit(tx) => return Ok(tx.from),
             Self::Eip8130(tx) => match tx.explicit_sender() {
                 Some(sender) => return Ok(sender),
                 None => return Err(alloy_consensus::crypto::RecoveryError::new()),
             },
+            // The Deposit transaction does not have a signature. Directly return the
+            // `from` address.
+            Self::Deposit(tx) => return Ok(tx.from),
         };
         let signature = match self {
             Self::Legacy(tx) => tx.signature(),
             Self::Eip2930(tx) => tx.signature(),
             Self::Eip1559(tx) => tx.signature(),
             Self::Eip7702(tx) => tx.signature(),
-            Self::Deposit(_) | Self::Eip8130(_) => {
+            Self::Eip8130(_) | Self::Deposit(_) => {
                 unreachable!("non-ECDSA variants short-circuit above")
             }
         };
@@ -650,10 +650,10 @@ impl alloy_consensus::transaction::SignerRecoverable for BaseTxEnvelope {
             Self::Eip7702(tx) => {
                 alloy_consensus::transaction::SignerRecoverable::recover_unchecked_with_buf(tx, buf)
             }
-            Self::Deposit(tx) => Ok(tx.from),
             Self::Eip8130(tx) => {
                 tx.explicit_sender().ok_or_else(alloy_consensus::crypto::RecoveryError::new)
             }
+            Self::Deposit(tx) => Ok(tx.from),
         }
     }
 }
@@ -740,13 +740,13 @@ pub(super) mod serde_bincode_compat {
                     signature: *signed_7702.signature(),
                     transaction: signed_7702.tx().into(),
                 },
+                super::BaseTxEnvelope::Eip8130(eip8130_signed) => {
+                    Self::Eip8130 { transaction: eip8130_signed.clone() }
+                }
                 super::BaseTxEnvelope::Deposit(sealed_deposit) => Self::Deposit {
                     hash: sealed_deposit.seal(),
                     transaction: sealed_deposit.inner().into(),
                 },
-                super::BaseTxEnvelope::Eip8130(eip8130_signed) => {
-                    Self::Eip8130 { transaction: eip8130_signed.clone() }
-                }
             }
         }
     }
@@ -766,10 +766,10 @@ pub(super) mod serde_bincode_compat {
                 BaseTxEnvelope::Eip7702 { signature, transaction } => {
                     Self::Eip7702(Signed::new_unhashed(transaction.into(), signature))
                 }
+                BaseTxEnvelope::Eip8130 { transaction } => Self::Eip8130(transaction),
                 BaseTxEnvelope::Deposit { hash, transaction } => {
                     Self::Deposit(Sealed::new_unchecked(transaction.into(), hash))
                 }
-                BaseTxEnvelope::Eip8130 { transaction } => Self::Eip8130(transaction),
             }
         }
     }
@@ -839,8 +839,8 @@ impl InMemorySize for BaseTxEnvelope {
             Self::Eip2930(tx) => tx.size(),
             Self::Eip1559(tx) => tx.size(),
             Self::Eip7702(tx) => tx.size(),
-            Self::Deposit(tx) => tx.size(),
             Self::Eip8130(tx) => tx.size(),
+            Self::Deposit(tx) => tx.size(),
         }
     }
 }

--- a/crates/common/consensus/src/transaction/envelope.rs
+++ b/crates/common/consensus/src/transaction/envelope.rs
@@ -19,7 +19,7 @@ use revm::context::TxEnv;
 
 use crate::{
     BasePooledTransaction, TxDeposit,
-    transaction::{AaSigned, BaseTransactionInfo, DepositInfo, TxAa8130},
+    transaction::{Eip8130Signed, BaseTransactionInfo, DepositInfo, TxEip8130},
 };
 
 /// The Ethereum [EIP-2718] Transaction Envelope, modified for Base.
@@ -55,8 +55,8 @@ pub enum BaseTxEnvelope {
     /// An [EIP-8130] Account Abstraction transaction tagged with type 0x7D.
     ///
     /// [EIP-8130]: https://eips.ethereum.org/EIPS/eip-8130
-    #[envelope(ty = 125, typed = TxAa8130)]
-    Aa8130(AaSigned),
+    #[envelope(ty = 125, typed = TxEip8130)]
+    Eip8130(Eip8130Signed),
 }
 
 /// Represents a transaction envelope for Base chains.
@@ -157,16 +157,16 @@ impl From<Signed<BaseTypedTransaction>> for BaseTxEnvelope {
                 Self::Eip7702(tx)
             }
             BaseTypedTransaction::Deposit(tx) => Self::Deposit(Sealed::new_unchecked(tx, hash)),
-            BaseTypedTransaction::Aa8130(tx) => {
+            BaseTypedTransaction::Eip8130(tx) => {
                 debug_assert!(
                     tx.sender.is_none(),
-                    "configured-owner EIP-8130 transactions must not be wrapped through the ECDSA Signed<BaseTypedTransaction> path; route them via BaseTxEnvelope::Aa8130 directly with the appropriate sender_auth",
+                    "configured-owner EIP-8130 transactions must not be wrapped through the ECDSA Signed<BaseTypedTransaction> path; route them via BaseTxEnvelope::Eip8130 directly with the appropriate sender_auth",
                 );
                 debug_assert!(
                     tx.payer.is_none(),
                     "sponsored EIP-8130 transactions must not be wrapped through the ECDSA Signed<BaseTypedTransaction> path; the payer_auth would be silently dropped",
                 );
-                Self::Aa8130(AaSigned::new(tx, sig.as_bytes().into(), Bytes::new()))
+                Self::Eip8130(Eip8130Signed::new(tx, sig.as_bytes().into(), Bytes::new()))
             }
         }
     }
@@ -215,7 +215,7 @@ impl FromRecoveredTx<BaseTxEnvelope> for TxEnv {
             BaseTxEnvelope::Eip2930(tx) => Self::from_recovered_tx(tx.tx(), caller),
             BaseTxEnvelope::Eip7702(tx) => Self::from_recovered_tx(tx.tx(), caller),
             BaseTxEnvelope::Deposit(tx) => Self::from_recovered_tx(tx.inner(), caller),
-            BaseTxEnvelope::Aa8130(_) => {
+            BaseTxEnvelope::Eip8130(_) => {
                 unimplemented!("EIP-8130 AA transactions cannot be converted to TxEnv yet")
             }
         }
@@ -242,8 +242,8 @@ impl From<BaseTxEnvelope> for alloy_rpc_types_eth::TransactionRequest {
             BaseTxEnvelope::Eip7702(tx) => tx.into_parts().0.into(),
             BaseTxEnvelope::Deposit(tx) => tx.into_inner().into(),
             BaseTxEnvelope::Legacy(tx) => tx.into_parts().0.into(),
-            BaseTxEnvelope::Aa8130(_) => unimplemented!(
-                "BaseTxEnvelope::Aa8130 cannot be converted to an alloy TransactionRequest; AA transactions have no single sender/recipient/value to project into the legacy request shape"
+            BaseTxEnvelope::Eip8130(_) => unimplemented!(
+                "BaseTxEnvelope::Eip8130 cannot be converted to an alloy TransactionRequest; AA transactions have no single sender/recipient/value to project into the legacy request shape"
             ),
         }
     }
@@ -343,22 +343,22 @@ impl BaseTxEnvelope {
             Self::Deposit(tx) => {
                 Err(ValueError::new(tx.into(), "Deposit transactions cannot be pooled"))
             }
-            Self::Aa8130(tx) => Ok(tx.into()),
+            Self::Eip8130(tx) => Ok(tx.into()),
         }
     }
 
     /// Attempts to convert the envelope into the ethereum pooled variant.
     ///
     /// Returns an error if the envelope's variant is incompatible with the ethereum pooled
-    /// format: [`TxDeposit`] (not pooled at all) or [`AaSigned`] (pooled, but has no
+    /// format: [`TxDeposit`] (not pooled at all) or [`Eip8130Signed`] (pooled, but has no
     /// ethereum-format representation since the alloy `PooledTransaction` enum has no
-    /// EIP-8130 variant). Rejecting [`AaSigned`] here prevents
+    /// EIP-8130 variant). Rejecting [`Eip8130Signed`] here prevents
     /// `From<BasePooledTransaction> for alloy_consensus::PooledTransaction` from panicking.
     pub fn try_into_eth_pooled(
         self,
     ) -> Result<alloy_consensus::transaction::PooledTransaction, ValueError<Self>> {
         match self {
-            tx @ Self::Aa8130(_) => Err(ValueError::new(
+            tx @ Self::Eip8130(_) => Err(ValueError::new(
                 tx,
                 "EIP-8130 transactions cannot be converted to ethereum PooledTransaction",
             )),
@@ -379,7 +379,7 @@ impl BaseTxEnvelope {
                 tx,
                 "Deposit transactions cannot be converted to ethereum transaction",
             )),
-            tx @ Self::Aa8130(_) => Err(ValueError::new(
+            tx @ Self::Eip8130(_) => Err(ValueError::new(
                 tx,
                 "EIP-8130 transactions cannot be converted to ethereum transaction",
             )),
@@ -421,7 +421,7 @@ impl BaseTxEnvelope {
     ///
     /// Caution: modifying this will cause side-effects on the hash.
     ///
-    /// Panics for [`Self::Aa8130`] since EIP-8130 transactions have no single
+    /// Panics for [`Self::Eip8130`] since EIP-8130 transactions have no single
     /// input field; their payload is a list of calls.
     #[doc(hidden)]
     pub fn input_mut(&mut self) -> &mut Bytes {
@@ -431,7 +431,7 @@ impl BaseTxEnvelope {
             Self::Legacy(tx) => &mut tx.tx_mut().input,
             Self::Eip7702(tx) => &mut tx.tx_mut().input,
             Self::Deposit(tx) => &mut tx.inner_mut().input,
-            Self::Aa8130(_) => {
+            Self::Eip8130(_) => {
                 unimplemented!("EIP-8130 transactions have no single input field")
             }
         }
@@ -470,8 +470,8 @@ impl BaseTxEnvelope {
 
     /// Returns true if the transaction is an EIP-8130 AA transaction.
     #[inline]
-    pub const fn is_aa8130(&self) -> bool {
-        matches!(self, Self::Aa8130(_))
+    pub const fn is_eip8130(&self) -> bool {
+        matches!(self, Self::Eip8130(_))
     }
 
     /// Returns the [`TxLegacy`] variant if the transaction is a legacy transaction.
@@ -506,10 +506,10 @@ impl BaseTxEnvelope {
         }
     }
 
-    /// Returns the [`AaSigned`] variant if the transaction is an EIP-8130 AA transaction.
-    pub const fn as_aa8130(&self) -> Option<&AaSigned> {
+    /// Returns the [`Eip8130Signed`] variant if the transaction is an EIP-8130 AA transaction.
+    pub const fn as_eip8130(&self) -> Option<&Eip8130Signed> {
         match self {
-            Self::Aa8130(tx) => Some(tx),
+            Self::Eip8130(tx) => Some(tx),
             _ => None,
         }
     }
@@ -523,7 +523,7 @@ impl BaseTxEnvelope {
             Self::Eip2930(tx) => Some(tx.signature()),
             Self::Eip1559(tx) => Some(tx.signature()),
             Self::Eip7702(tx) => Some(tx.signature()),
-            Self::Deposit(_) | Self::Aa8130(_) => None,
+            Self::Deposit(_) | Self::Eip8130(_) => None,
         }
     }
 
@@ -535,7 +535,7 @@ impl BaseTxEnvelope {
             Self::Eip1559(_) => OpTxType::Eip1559,
             Self::Eip7702(_) => OpTxType::Eip7702,
             Self::Deposit(_) => OpTxType::Deposit,
-            Self::Aa8130(_) => OpTxType::Aa8130,
+            Self::Eip8130(_) => OpTxType::Eip8130,
         }
     }
 
@@ -547,7 +547,7 @@ impl BaseTxEnvelope {
             Self::Eip2930(tx) => tx.hash(),
             Self::Eip7702(tx) => tx.hash(),
             Self::Deposit(tx) => tx.hash_ref(),
-            Self::Aa8130(tx) => tx.hash(),
+            Self::Eip8130(tx) => tx.hash(),
         }
     }
 
@@ -564,7 +564,7 @@ impl BaseTxEnvelope {
             Self::Eip1559(t) => t.eip2718_encoded_length(),
             Self::Eip7702(t) => t.eip2718_encoded_length(),
             Self::Deposit(t) => t.eip2718_encoded_length(),
-            Self::Aa8130(t) => t.encode_2718_len(),
+            Self::Eip8130(t) => t.encode_2718_len(),
         }
     }
 }
@@ -588,7 +588,7 @@ impl alloy_consensus::transaction::SignerRecoverable for BaseTxEnvelope {
             // The Deposit transaction does not have a signature. Directly return the
             // `from` address.
             Self::Deposit(tx) => return Ok(tx.from),
-            Self::Aa8130(tx) => match tx.explicit_sender() {
+            Self::Eip8130(tx) => match tx.explicit_sender() {
                 Some(sender) => return Ok(sender),
                 None => return Err(alloy_consensus::crypto::RecoveryError::new()),
             },
@@ -598,7 +598,7 @@ impl alloy_consensus::transaction::SignerRecoverable for BaseTxEnvelope {
             Self::Eip2930(tx) => tx.signature(),
             Self::Eip1559(tx) => tx.signature(),
             Self::Eip7702(tx) => tx.signature(),
-            Self::Deposit(_) | Self::Aa8130(_) => {
+            Self::Deposit(_) | Self::Eip8130(_) => {
                 unreachable!("non-ECDSA variants short-circuit above")
             }
         };
@@ -616,7 +616,7 @@ impl alloy_consensus::transaction::SignerRecoverable for BaseTxEnvelope {
             // The Deposit transaction does not have a signature. Directly return the
             // `from` address.
             Self::Deposit(tx) => return Ok(tx.from),
-            Self::Aa8130(tx) => match tx.explicit_sender() {
+            Self::Eip8130(tx) => match tx.explicit_sender() {
                 Some(sender) => return Ok(sender),
                 None => return Err(alloy_consensus::crypto::RecoveryError::new()),
             },
@@ -626,7 +626,7 @@ impl alloy_consensus::transaction::SignerRecoverable for BaseTxEnvelope {
             Self::Eip2930(tx) => tx.signature(),
             Self::Eip1559(tx) => tx.signature(),
             Self::Eip7702(tx) => tx.signature(),
-            Self::Deposit(_) | Self::Aa8130(_) => {
+            Self::Deposit(_) | Self::Eip8130(_) => {
                 unreachable!("non-ECDSA variants short-circuit above")
             }
         };
@@ -651,7 +651,7 @@ impl alloy_consensus::transaction::SignerRecoverable for BaseTxEnvelope {
                 alloy_consensus::transaction::SignerRecoverable::recover_unchecked_with_buf(tx, buf)
             }
             Self::Deposit(tx) => Ok(tx.from),
-            Self::Aa8130(tx) => {
+            Self::Eip8130(tx) => {
                 tx.explicit_sender().ok_or_else(alloy_consensus::crypto::RecoveryError::new)
             }
         }
@@ -669,7 +669,7 @@ pub(super) mod serde_bincode_compat {
     use serde::{Deserialize, Deserializer, Serialize, Serializer};
     use serde_with::{DeserializeAs, SerializeAs};
 
-    use crate::{serde_bincode_compat::TxDeposit, transaction::AaSigned};
+    use crate::{serde_bincode_compat::TxDeposit, transaction::Eip8130Signed};
 
     /// Bincode-compatible representation of an [`BaseTxEnvelope`].
     #[derive(Debug, Serialize, Deserialize)]
@@ -710,14 +710,14 @@ pub(super) mod serde_bincode_compat {
             transaction: TxDeposit<'a>,
         },
         /// EIP-8130 Account Abstraction variant.
-        Aa8130 {
-            /// Owned [`AaSigned`] envelope.
+        Eip8130 {
+            /// Owned [`Eip8130Signed`] envelope.
             ///
-            /// The [`AaSigned`] payload includes variable-length `calls`,
+            /// The [`Eip8130Signed`] payload includes variable-length `calls`,
             /// `account_changes`, and authentication buffers, so we serialize
             /// it directly instead of borrowing a flattened bincode-friendly
             /// projection.
-            transaction: AaSigned,
+            transaction: Eip8130Signed,
         },
     }
 
@@ -744,8 +744,8 @@ pub(super) mod serde_bincode_compat {
                     hash: sealed_deposit.seal(),
                     transaction: sealed_deposit.inner().into(),
                 },
-                super::BaseTxEnvelope::Aa8130(aa_signed) => {
-                    Self::Aa8130 { transaction: aa_signed.clone() }
+                super::BaseTxEnvelope::Eip8130(eip8130_signed) => {
+                    Self::Eip8130 { transaction: eip8130_signed.clone() }
                 }
             }
         }
@@ -769,7 +769,7 @@ pub(super) mod serde_bincode_compat {
                 BaseTxEnvelope::Deposit { hash, transaction } => {
                     Self::Deposit(Sealed::new_unchecked(transaction.into(), hash))
                 }
-                BaseTxEnvelope::Aa8130 { transaction } => Self::Aa8130(transaction),
+                BaseTxEnvelope::Eip8130 { transaction } => Self::Eip8130(transaction),
             }
         }
     }
@@ -840,7 +840,7 @@ impl InMemorySize for BaseTxEnvelope {
             Self::Eip1559(tx) => tx.size(),
             Self::Eip7702(tx) => tx.size(),
             Self::Deposit(tx) => tx.size(),
-            Self::Aa8130(tx) => tx.size(),
+            Self::Eip8130(tx) => tx.size(),
         }
     }
 }

--- a/crates/common/consensus/src/transaction/mod.rs
+++ b/crates/common/consensus/src/transaction/mod.rs
@@ -3,10 +3,10 @@
 mod deposit;
 pub use deposit::{DepositTransaction, TxDeposit};
 
-mod aa8130;
-pub use aa8130::{
-    Aa8130Constants, AaSigned, AccountChange, Call, ConfigChange, CreateEntry, Delegation,
-    InitialOwner, OwnerChange, OwnerChangeType, Scope, TxAa8130,
+mod eip8130;
+pub use eip8130::{
+    AccountChange, Call, ConfigChange, CreateEntry, Delegation, Eip8130Constants, Eip8130Signed,
+    InitialOwner, OwnerChange, OwnerChangeType, Scope, TxEip8130,
 };
 
 mod tx_type;

--- a/crates/common/consensus/src/transaction/pooled.rs
+++ b/crates/common/consensus/src/transaction/pooled.rs
@@ -12,7 +12,7 @@ use alloy_consensus::{
 use alloy_eips::eip2718::Encodable2718;
 use alloy_primitives::{B256, Signature, TxHash, bytes};
 
-use crate::{BaseTxEnvelope, transaction::AaSigned};
+use crate::{BaseTxEnvelope, transaction::Eip8130Signed};
 
 /// All possible transactions that can be included in a response to `GetPooledTransactions`.
 /// A response to `GetPooledTransactions`. This can include a typed signed transaction, but cannot
@@ -38,15 +38,15 @@ pub enum BasePooledTransaction {
     /// An [EIP-8130] Account Abstraction transaction tagged with type 0x7D.
     ///
     /// [EIP-8130]: https://eips.ethereum.org/EIPS/eip-8130
-    #[envelope(ty = 125, typed = TxAa8130)]
-    Aa8130(AaSigned),
+    #[envelope(ty = 125, typed = TxEip8130)]
+    Eip8130(Eip8130Signed),
 }
 
 impl BasePooledTransaction {
     /// Heavy operation that returns the signature hash over rlp encoded transaction. It is only
     /// for signature signing or signer recovery.
     ///
-    /// Panics on the [`Self::Aa8130`] variant: EIP-8130 transactions do not
+    /// Panics on the [`Self::Eip8130`] variant: EIP-8130 transactions do not
     /// have a single ECDSA signature.
     pub fn signature_hash(&self) -> B256 {
         match self {
@@ -54,7 +54,7 @@ impl BasePooledTransaction {
             Self::Eip2930(tx) => tx.signature_hash(),
             Self::Eip1559(tx) => tx.signature_hash(),
             Self::Eip7702(tx) => tx.signature_hash(),
-            Self::Aa8130(_) => {
+            Self::Eip8130(_) => {
                 unimplemented!("BasePooledTransaction::signature_hash invoked on EIP-8130 variant")
             }
         }
@@ -67,13 +67,13 @@ impl BasePooledTransaction {
             Self::Eip2930(tx) => tx.hash(),
             Self::Eip1559(tx) => tx.hash(),
             Self::Eip7702(tx) => tx.hash(),
-            Self::Aa8130(tx) => tx.hash(),
+            Self::Eip8130(tx) => tx.hash(),
         }
     }
 
     /// Returns the signature of the transaction.
     ///
-    /// Panics on the [`Self::Aa8130`] variant: EIP-8130 transactions do not
+    /// Panics on the [`Self::Eip8130`] variant: EIP-8130 transactions do not
     /// have a single ECDSA signature.
     pub fn signature(&self) -> &Signature {
         match self {
@@ -81,7 +81,7 @@ impl BasePooledTransaction {
             Self::Eip2930(tx) => tx.signature(),
             Self::Eip1559(tx) => tx.signature(),
             Self::Eip7702(tx) => tx.signature(),
-            Self::Aa8130(_) => {
+            Self::Eip8130(_) => {
                 unimplemented!("BasePooledTransaction::signature invoked on EIP-8130 variant")
             }
         }
@@ -95,13 +95,13 @@ impl BasePooledTransaction {
             Self::Eip2930(tx) => tx.tx().encode_for_signing(out),
             Self::Eip1559(tx) => tx.tx().encode_for_signing(out),
             Self::Eip7702(tx) => tx.tx().encode_for_signing(out),
-            Self::Aa8130(tx) => tx.tx().encode_for_signing(out),
+            Self::Eip8130(tx) => tx.tx().encode_for_signing(out),
         }
     }
 
     /// Converts the transaction into the ethereum [`TxEnvelope`].
     ///
-    /// Panics on the [`Self::Aa8130`] variant: EIP-8130 is Base-specific and
+    /// Panics on the [`Self::Eip8130`] variant: EIP-8130 is Base-specific and
     /// has no corresponding ethereum envelope variant.
     pub fn into_envelope(self) -> TxEnvelope {
         match self {
@@ -109,7 +109,7 @@ impl BasePooledTransaction {
             Self::Eip2930(tx) => tx.into(),
             Self::Eip1559(tx) => tx.into(),
             Self::Eip7702(tx) => tx.into(),
-            Self::Aa8130(_) => {
+            Self::Eip8130(_) => {
                 unimplemented!("BasePooledTransaction::into_envelope invoked on EIP-8130 variant")
             }
         }
@@ -122,14 +122,14 @@ impl BasePooledTransaction {
             Self::Eip2930(tx) => tx.into(),
             Self::Eip1559(tx) => tx.into(),
             Self::Eip7702(tx) => tx.into(),
-            Self::Aa8130(tx) => BaseTxEnvelope::Aa8130(tx),
+            Self::Eip8130(tx) => BaseTxEnvelope::Eip8130(tx),
         }
     }
 
-    /// Returns the [`AaSigned`] variant if the transaction is an EIP-8130 transaction.
-    pub const fn as_aa8130(&self) -> Option<&AaSigned> {
+    /// Returns the [`Eip8130Signed`] variant if the transaction is an EIP-8130 transaction.
+    pub const fn as_eip8130(&self) -> Option<&Eip8130Signed> {
         match self {
-            Self::Aa8130(tx) => Some(tx),
+            Self::Eip8130(tx) => Some(tx),
             _ => None,
         }
     }
@@ -191,9 +191,9 @@ impl From<Signed<TxEip7702>> for BasePooledTransaction {
     }
 }
 
-impl From<AaSigned> for BasePooledTransaction {
-    fn from(v: AaSigned) -> Self {
-        Self::Aa8130(v)
+impl From<Eip8130Signed> for BasePooledTransaction {
+    fn from(v: Eip8130Signed) -> Self {
+        Self::Eip8130(v)
     }
 }
 
@@ -204,7 +204,7 @@ impl From<BasePooledTransaction> for alloy_consensus::transaction::PooledTransac
             BasePooledTransaction::Eip2930(tx) => tx.into(),
             BasePooledTransaction::Eip1559(tx) => tx.into(),
             BasePooledTransaction::Eip7702(tx) => tx.into(),
-            BasePooledTransaction::Aa8130(_) => unimplemented!(
+            BasePooledTransaction::Eip8130(_) => unimplemented!(
                 "EIP-8130 transactions cannot be converted to ethereum PooledTransaction"
             ),
         }
@@ -222,7 +222,7 @@ impl alloy_consensus::transaction::SignerRecoverable for BasePooledTransaction {
     fn recover_signer(
         &self,
     ) -> Result<alloy_primitives::Address, alloy_consensus::crypto::RecoveryError> {
-        if let Self::Aa8130(tx) = self {
+        if let Self::Eip8130(tx) = self {
             return tx.explicit_sender().ok_or_else(alloy_consensus::crypto::RecoveryError::new);
         }
         let signature_hash = self.signature_hash();
@@ -232,7 +232,7 @@ impl alloy_consensus::transaction::SignerRecoverable for BasePooledTransaction {
     fn recover_signer_unchecked(
         &self,
     ) -> Result<alloy_primitives::Address, alloy_consensus::crypto::RecoveryError> {
-        if let Self::Aa8130(tx) = self {
+        if let Self::Eip8130(tx) = self {
             return tx.explicit_sender().ok_or_else(alloy_consensus::crypto::RecoveryError::new);
         }
         let signature_hash = self.signature_hash();
@@ -259,7 +259,7 @@ impl alloy_consensus::transaction::SignerRecoverable for BasePooledTransaction {
             Self::Eip7702(tx) => {
                 alloy_consensus::transaction::SignerRecoverable::recover_unchecked_with_buf(tx, buf)
             }
-            Self::Aa8130(tx) => {
+            Self::Eip8130(tx) => {
                 tx.explicit_sender().ok_or_else(alloy_consensus::crypto::RecoveryError::new)
             }
         }
@@ -310,7 +310,7 @@ impl InMemorySize for BasePooledTransaction {
             Self::Eip2930(tx) => tx.size(),
             Self::Eip1559(tx) => tx.size(),
             Self::Eip7702(tx) => tx.size(),
-            Self::Aa8130(tx) => tx.size(),
+            Self::Eip8130(tx) => tx.size(),
         }
     }
 }

--- a/crates/common/consensus/src/transaction/tx_type.rs
+++ b/crates/common/consensus/src/transaction/tx_type.rs
@@ -37,7 +37,7 @@ impl Display for OpTxType {
 impl OpTxType {
     /// List of all variants.
     pub const ALL: [Self; 6] =
-        [Self::Legacy, Self::Eip2930, Self::Eip1559, Self::Eip7702, Self::Deposit, Self::Eip8130];
+        [Self::Legacy, Self::Eip2930, Self::Eip1559, Self::Eip7702, Self::Eip8130, Self::Deposit];
 
     /// Returns `true` if the type is [`OpTxType::Deposit`].
     pub const fn is_deposit(&self) -> bool {
@@ -73,8 +73,8 @@ mod tests {
             OpTxType::Eip2930,
             OpTxType::Eip1559,
             OpTxType::Eip7702,
-            OpTxType::Deposit,
             OpTxType::Eip8130,
+            OpTxType::Deposit,
         ];
         assert_eq!(OpTxType::ALL.to_vec(), all);
     }

--- a/crates/common/consensus/src/transaction/tx_type.rs
+++ b/crates/common/consensus/src/transaction/tx_type.rs
@@ -29,7 +29,7 @@ impl Display for OpTxType {
             Self::Eip1559 => write!(f, "eip1559"),
             Self::Eip7702 => write!(f, "eip7702"),
             Self::Deposit => write!(f, "deposit"),
-            Self::Aa8130 => write!(f, "aa8130"),
+            Self::Eip8130 => write!(f, "eip8130"),
         }
     }
 }
@@ -37,16 +37,16 @@ impl Display for OpTxType {
 impl OpTxType {
     /// List of all variants.
     pub const ALL: [Self; 6] =
-        [Self::Legacy, Self::Eip2930, Self::Eip1559, Self::Eip7702, Self::Deposit, Self::Aa8130];
+        [Self::Legacy, Self::Eip2930, Self::Eip1559, Self::Eip7702, Self::Deposit, Self::Eip8130];
 
     /// Returns `true` if the type is [`OpTxType::Deposit`].
     pub const fn is_deposit(&self) -> bool {
         matches!(self, Self::Deposit)
     }
 
-    /// Returns `true` if the type is [`OpTxType::Aa8130`].
-    pub const fn is_aa8130(&self) -> bool {
-        matches!(self, Self::Aa8130)
+    /// Returns `true` if the type is [`OpTxType::Eip8130`].
+    pub const fn is_eip8130(&self) -> bool {
+        matches!(self, Self::Eip8130)
     }
 }
 
@@ -74,7 +74,7 @@ mod tests {
             OpTxType::Eip1559,
             OpTxType::Eip7702,
             OpTxType::Deposit,
-            OpTxType::Aa8130,
+            OpTxType::Eip8130,
         ];
         assert_eq!(OpTxType::ALL.to_vec(), all);
     }

--- a/crates/common/consensus/src/transaction/typed.rs
+++ b/crates/common/consensus/src/transaction/typed.rs
@@ -6,7 +6,7 @@ use alloy_eips::Encodable2718;
 use alloy_primitives::{B256, ChainId, Signature, TxHash, bytes::BufMut};
 
 pub use crate::transaction::envelope::BaseTypedTransaction;
-use crate::{BaseTxEnvelope, OpTxType, TxEip8130, TxDeposit, transaction::Eip8130Signed};
+use crate::{BaseTxEnvelope, OpTxType, TxDeposit, TxEip8130, transaction::Eip8130Signed};
 
 impl From<TxLegacy> for BaseTypedTransaction {
     fn from(tx: TxLegacy) -> Self {
@@ -51,8 +51,8 @@ impl From<BaseTxEnvelope> for BaseTypedTransaction {
             BaseTxEnvelope::Eip2930(tx) => Self::Eip2930(tx.strip_signature()),
             BaseTxEnvelope::Eip1559(tx) => Self::Eip1559(tx.strip_signature()),
             BaseTxEnvelope::Eip7702(tx) => Self::Eip7702(tx.strip_signature()),
-            BaseTxEnvelope::Deposit(tx) => Self::Deposit(tx.into_inner()),
             BaseTxEnvelope::Eip8130(tx) => Self::Eip8130(tx.into_tx()),
+            BaseTxEnvelope::Deposit(tx) => Self::Deposit(tx.into_inner()),
         }
     }
 }
@@ -65,10 +65,10 @@ impl From<BaseTypedTransaction> for alloy_rpc_types_eth::TransactionRequest {
             BaseTypedTransaction::Eip2930(tx) => tx.into(),
             BaseTypedTransaction::Eip1559(tx) => tx.into(),
             BaseTypedTransaction::Eip7702(tx) => tx.into(),
-            BaseTypedTransaction::Deposit(tx) => tx.into(),
             BaseTypedTransaction::Eip8130(_) => unimplemented!(
                 "BaseTypedTransaction::Eip8130 cannot be converted to an alloy TransactionRequest; AA transactions have no single sender/recipient/value to project into the legacy request shape"
             ),
+            BaseTypedTransaction::Deposit(tx) => tx.into(),
         }
     }
 }
@@ -81,8 +81,8 @@ impl BaseTypedTransaction {
             Self::Eip2930(_) => OpTxType::Eip2930,
             Self::Eip1559(_) => OpTxType::Eip1559,
             Self::Eip7702(_) => OpTxType::Eip7702,
-            Self::Deposit(_) => OpTxType::Deposit,
             Self::Eip8130(_) => OpTxType::Eip8130,
+            Self::Deposit(_) => OpTxType::Deposit,
         }
     }
 
@@ -96,7 +96,7 @@ impl BaseTypedTransaction {
             Self::Eip2930(tx) => Some(tx.signature_hash()),
             Self::Eip1559(tx) => Some(tx.signature_hash()),
             Self::Eip7702(tx) => Some(tx.signature_hash()),
-            Self::Deposit(_) | Self::Eip8130(_) => None,
+            Self::Eip8130(_) | Self::Deposit(_) => None,
         }
     }
 
@@ -161,10 +161,10 @@ impl BaseTypedTransaction {
             Self::Eip2930(tx) => tx.tx_hash(signature),
             Self::Eip1559(tx) => tx.tx_hash(signature),
             Self::Eip7702(tx) => tx.tx_hash(signature),
-            Self::Deposit(tx) => tx.tx_hash(),
             Self::Eip8130(_) => unimplemented!(
                 "BaseTypedTransaction::tx_hash invoked on an EIP-8130 variant; use Eip8130Signed::hash via the envelope path"
             ),
+            Self::Deposit(tx) => tx.tx_hash(),
         }
     }
 
@@ -185,13 +185,13 @@ impl BaseTypedTransaction {
             Self::Eip2930(tx) => Ok(tx.into()),
             Self::Eip1559(tx) => Ok(tx.into()),
             Self::Eip7702(tx) => Ok(tx.into()),
-            tx @ Self::Deposit(_) => Err(ValueError::new(
-                tx,
-                "Deposit transactions cannot be converted to ethereum transaction",
-            )),
             tx @ Self::Eip8130(_) => Err(ValueError::new(
                 tx,
                 "EIP-8130 transactions cannot be converted to ethereum transaction",
+            )),
+            tx @ Self::Deposit(_) => Err(ValueError::new(
+                tx,
+                "Deposit transactions cannot be converted to ethereum transaction",
             )),
         }
     }
@@ -204,8 +204,8 @@ impl RlpEcdsaEncodableTx for BaseTypedTransaction {
             Self::Eip2930(tx) => tx.rlp_encoded_fields_length(),
             Self::Eip1559(tx) => tx.rlp_encoded_fields_length(),
             Self::Eip7702(tx) => tx.rlp_encoded_fields_length(),
-            Self::Deposit(tx) => tx.rlp_encoded_fields_length(),
             Self::Eip8130(tx) => tx.rlp_encoded_fields_length(),
+            Self::Deposit(tx) => tx.rlp_encoded_fields_length(),
         }
     }
 
@@ -215,8 +215,8 @@ impl RlpEcdsaEncodableTx for BaseTypedTransaction {
             Self::Eip2930(tx) => tx.rlp_encode_fields(out),
             Self::Eip1559(tx) => tx.rlp_encode_fields(out),
             Self::Eip7702(tx) => tx.rlp_encode_fields(out),
-            Self::Deposit(tx) => tx.rlp_encode_fields(out),
             Self::Eip8130(tx) => tx.rlp_encode_fields(out),
+            Self::Deposit(tx) => tx.rlp_encode_fields(out),
         }
     }
 
@@ -226,10 +226,10 @@ impl RlpEcdsaEncodableTx for BaseTypedTransaction {
             Self::Eip2930(tx) => tx.eip2718_encode_with_type(signature, tx.ty(), out),
             Self::Eip1559(tx) => tx.eip2718_encode_with_type(signature, tx.ty(), out),
             Self::Eip7702(tx) => tx.eip2718_encode_with_type(signature, tx.ty(), out),
-            Self::Deposit(tx) => tx.encode_2718(out),
             Self::Eip8130(_) => unimplemented!(
                 "BaseTypedTransaction::eip2718_encode_with_type invoked on EIP-8130 variant; use Eip8130Signed::encode_2718"
             ),
+            Self::Deposit(tx) => tx.encode_2718(out),
         }
     }
 
@@ -239,10 +239,10 @@ impl RlpEcdsaEncodableTx for BaseTypedTransaction {
             Self::Eip2930(tx) => tx.eip2718_encode(signature, out),
             Self::Eip1559(tx) => tx.eip2718_encode(signature, out),
             Self::Eip7702(tx) => tx.eip2718_encode(signature, out),
-            Self::Deposit(tx) => tx.encode_2718(out),
             Self::Eip8130(_) => unimplemented!(
                 "BaseTypedTransaction::eip2718_encode invoked on EIP-8130 variant; use Eip8130Signed::encode_2718"
             ),
+            Self::Deposit(tx) => tx.encode_2718(out),
         }
     }
 
@@ -252,10 +252,10 @@ impl RlpEcdsaEncodableTx for BaseTypedTransaction {
             Self::Eip2930(tx) => tx.network_encode_with_type(signature, tx.ty(), out),
             Self::Eip1559(tx) => tx.network_encode_with_type(signature, tx.ty(), out),
             Self::Eip7702(tx) => tx.network_encode_with_type(signature, tx.ty(), out),
-            Self::Deposit(tx) => tx.network_encode(out),
             Self::Eip8130(_) => unimplemented!(
                 "BaseTypedTransaction::network_encode_with_type invoked on EIP-8130 variant"
             ),
+            Self::Deposit(tx) => tx.network_encode(out),
         }
     }
 
@@ -265,10 +265,10 @@ impl RlpEcdsaEncodableTx for BaseTypedTransaction {
             Self::Eip2930(tx) => tx.network_encode(signature, out),
             Self::Eip1559(tx) => tx.network_encode(signature, out),
             Self::Eip7702(tx) => tx.network_encode(signature, out),
-            Self::Deposit(tx) => tx.network_encode(out),
             Self::Eip8130(_) => {
                 unimplemented!("BaseTypedTransaction::network_encode invoked on EIP-8130 variant")
             }
+            Self::Deposit(tx) => tx.network_encode(out),
         }
     }
 
@@ -278,12 +278,12 @@ impl RlpEcdsaEncodableTx for BaseTypedTransaction {
             Self::Eip2930(tx) => tx.tx_hash_with_type(signature, tx.ty()),
             Self::Eip1559(tx) => tx.tx_hash_with_type(signature, tx.ty()),
             Self::Eip7702(tx) => tx.tx_hash_with_type(signature, tx.ty()),
-            Self::Deposit(tx) => tx.tx_hash(),
             Self::Eip8130(_) => {
                 unimplemented!(
                     "BaseTypedTransaction::tx_hash_with_type invoked on EIP-8130 variant"
                 )
             }
+            Self::Deposit(tx) => tx.tx_hash(),
         }
     }
 
@@ -293,10 +293,10 @@ impl RlpEcdsaEncodableTx for BaseTypedTransaction {
             Self::Eip2930(tx) => tx.tx_hash(signature),
             Self::Eip1559(tx) => tx.tx_hash(signature),
             Self::Eip7702(tx) => tx.tx_hash(signature),
-            Self::Deposit(tx) => tx.tx_hash(),
             Self::Eip8130(_) => {
                 unimplemented!("BaseTypedTransaction::tx_hash invoked on EIP-8130 variant")
             }
+            Self::Deposit(tx) => tx.tx_hash(),
         }
     }
 }
@@ -308,8 +308,8 @@ impl SignableTransaction<Signature> for BaseTypedTransaction {
             Self::Eip2930(tx) => tx.set_chain_id(chain_id),
             Self::Eip1559(tx) => tx.set_chain_id(chain_id),
             Self::Eip7702(tx) => tx.set_chain_id(chain_id),
-            Self::Deposit(_) => {}
             Self::Eip8130(tx) => tx.set_chain_id(chain_id),
+            Self::Deposit(_) => {}
         }
     }
 
@@ -319,8 +319,8 @@ impl SignableTransaction<Signature> for BaseTypedTransaction {
             Self::Eip2930(tx) => tx.encode_for_signing(out),
             Self::Eip1559(tx) => tx.encode_for_signing(out),
             Self::Eip7702(tx) => tx.encode_for_signing(out),
-            Self::Deposit(_) => {}
             Self::Eip8130(tx) => tx.encode_for_signing(out),
+            Self::Deposit(_) => {}
         }
     }
 
@@ -330,8 +330,8 @@ impl SignableTransaction<Signature> for BaseTypedTransaction {
             Self::Eip2930(tx) => tx.payload_len_for_signature(),
             Self::Eip1559(tx) => tx.payload_len_for_signature(),
             Self::Eip7702(tx) => tx.payload_len_for_signature(),
-            Self::Deposit(_) => 0,
             Self::Eip8130(tx) => tx.payload_len_for_signature(),
+            Self::Deposit(_) => 0,
         }
     }
 
@@ -351,8 +351,8 @@ impl InMemorySize for BaseTypedTransaction {
             Self::Eip2930(tx) => tx.size(),
             Self::Eip1559(tx) => tx.size(),
             Self::Eip7702(tx) => tx.size(),
-            Self::Deposit(tx) => tx.size(),
             Self::Eip8130(tx) => tx.size(),
+            Self::Deposit(tx) => tx.size(),
         }
     }
 }

--- a/crates/common/consensus/src/transaction/typed.rs
+++ b/crates/common/consensus/src/transaction/typed.rs
@@ -6,7 +6,7 @@ use alloy_eips::Encodable2718;
 use alloy_primitives::{B256, ChainId, Signature, TxHash, bytes::BufMut};
 
 pub use crate::transaction::envelope::BaseTypedTransaction;
-use crate::{BaseTxEnvelope, OpTxType, TxAa8130, TxDeposit, transaction::AaSigned};
+use crate::{BaseTxEnvelope, OpTxType, TxEip8130, TxDeposit, transaction::Eip8130Signed};
 
 impl From<TxLegacy> for BaseTypedTransaction {
     fn from(tx: TxLegacy) -> Self {
@@ -38,9 +38,9 @@ impl From<TxDeposit> for BaseTypedTransaction {
     }
 }
 
-impl From<TxAa8130> for BaseTypedTransaction {
-    fn from(tx: TxAa8130) -> Self {
-        Self::Aa8130(tx)
+impl From<TxEip8130> for BaseTypedTransaction {
+    fn from(tx: TxEip8130) -> Self {
+        Self::Eip8130(tx)
     }
 }
 
@@ -52,7 +52,7 @@ impl From<BaseTxEnvelope> for BaseTypedTransaction {
             BaseTxEnvelope::Eip1559(tx) => Self::Eip1559(tx.strip_signature()),
             BaseTxEnvelope::Eip7702(tx) => Self::Eip7702(tx.strip_signature()),
             BaseTxEnvelope::Deposit(tx) => Self::Deposit(tx.into_inner()),
-            BaseTxEnvelope::Aa8130(tx) => Self::Aa8130(tx.into_tx()),
+            BaseTxEnvelope::Eip8130(tx) => Self::Eip8130(tx.into_tx()),
         }
     }
 }
@@ -66,8 +66,8 @@ impl From<BaseTypedTransaction> for alloy_rpc_types_eth::TransactionRequest {
             BaseTypedTransaction::Eip1559(tx) => tx.into(),
             BaseTypedTransaction::Eip7702(tx) => tx.into(),
             BaseTypedTransaction::Deposit(tx) => tx.into(),
-            BaseTypedTransaction::Aa8130(_) => unimplemented!(
-                "BaseTypedTransaction::Aa8130 cannot be converted to an alloy TransactionRequest; AA transactions have no single sender/recipient/value to project into the legacy request shape"
+            BaseTypedTransaction::Eip8130(_) => unimplemented!(
+                "BaseTypedTransaction::Eip8130 cannot be converted to an alloy TransactionRequest; AA transactions have no single sender/recipient/value to project into the legacy request shape"
             ),
         }
     }
@@ -82,7 +82,7 @@ impl BaseTypedTransaction {
             Self::Eip1559(_) => OpTxType::Eip1559,
             Self::Eip7702(_) => OpTxType::Eip7702,
             Self::Deposit(_) => OpTxType::Deposit,
-            Self::Aa8130(_) => OpTxType::Aa8130,
+            Self::Eip8130(_) => OpTxType::Eip8130,
         }
     }
 
@@ -96,7 +96,7 @@ impl BaseTypedTransaction {
             Self::Eip2930(tx) => Some(tx.signature_hash()),
             Self::Eip1559(tx) => Some(tx.signature_hash()),
             Self::Eip7702(tx) => Some(tx.signature_hash()),
-            Self::Deposit(_) | Self::Aa8130(_) => None,
+            Self::Deposit(_) | Self::Eip8130(_) => None,
         }
     }
 
@@ -138,16 +138,16 @@ impl BaseTypedTransaction {
     }
 
     /// Return the inner EIP-8130 transaction if it exists.
-    pub const fn aa8130(&self) -> Option<&TxAa8130> {
+    pub const fn eip8130(&self) -> Option<&TxEip8130> {
         match self {
-            Self::Aa8130(tx) => Some(tx),
+            Self::Eip8130(tx) => Some(tx),
             _ => None,
         }
     }
 
     /// Returns `true` if transaction is an EIP-8130 transaction.
-    pub const fn is_aa8130(&self) -> bool {
-        matches!(self, Self::Aa8130(_))
+    pub const fn is_eip8130(&self) -> bool {
+        matches!(self, Self::Eip8130(_))
     }
 
     /// Calculate the transaction hash for the given signature.
@@ -162,8 +162,8 @@ impl BaseTypedTransaction {
             Self::Eip1559(tx) => tx.tx_hash(signature),
             Self::Eip7702(tx) => tx.tx_hash(signature),
             Self::Deposit(tx) => tx.tx_hash(),
-            Self::Aa8130(_) => unimplemented!(
-                "BaseTypedTransaction::tx_hash invoked on an EIP-8130 variant; use AaSigned::hash via the envelope path"
+            Self::Eip8130(_) => unimplemented!(
+                "BaseTypedTransaction::tx_hash invoked on an EIP-8130 variant; use Eip8130Signed::hash via the envelope path"
             ),
         }
     }
@@ -189,7 +189,7 @@ impl BaseTypedTransaction {
                 tx,
                 "Deposit transactions cannot be converted to ethereum transaction",
             )),
-            tx @ Self::Aa8130(_) => Err(ValueError::new(
+            tx @ Self::Eip8130(_) => Err(ValueError::new(
                 tx,
                 "EIP-8130 transactions cannot be converted to ethereum transaction",
             )),
@@ -205,7 +205,7 @@ impl RlpEcdsaEncodableTx for BaseTypedTransaction {
             Self::Eip1559(tx) => tx.rlp_encoded_fields_length(),
             Self::Eip7702(tx) => tx.rlp_encoded_fields_length(),
             Self::Deposit(tx) => tx.rlp_encoded_fields_length(),
-            Self::Aa8130(tx) => tx.rlp_encoded_fields_length(),
+            Self::Eip8130(tx) => tx.rlp_encoded_fields_length(),
         }
     }
 
@@ -216,7 +216,7 @@ impl RlpEcdsaEncodableTx for BaseTypedTransaction {
             Self::Eip1559(tx) => tx.rlp_encode_fields(out),
             Self::Eip7702(tx) => tx.rlp_encode_fields(out),
             Self::Deposit(tx) => tx.rlp_encode_fields(out),
-            Self::Aa8130(tx) => tx.rlp_encode_fields(out),
+            Self::Eip8130(tx) => tx.rlp_encode_fields(out),
         }
     }
 
@@ -227,8 +227,8 @@ impl RlpEcdsaEncodableTx for BaseTypedTransaction {
             Self::Eip1559(tx) => tx.eip2718_encode_with_type(signature, tx.ty(), out),
             Self::Eip7702(tx) => tx.eip2718_encode_with_type(signature, tx.ty(), out),
             Self::Deposit(tx) => tx.encode_2718(out),
-            Self::Aa8130(_) => unimplemented!(
-                "BaseTypedTransaction::eip2718_encode_with_type invoked on EIP-8130 variant; use AaSigned::encode_2718"
+            Self::Eip8130(_) => unimplemented!(
+                "BaseTypedTransaction::eip2718_encode_with_type invoked on EIP-8130 variant; use Eip8130Signed::encode_2718"
             ),
         }
     }
@@ -240,8 +240,8 @@ impl RlpEcdsaEncodableTx for BaseTypedTransaction {
             Self::Eip1559(tx) => tx.eip2718_encode(signature, out),
             Self::Eip7702(tx) => tx.eip2718_encode(signature, out),
             Self::Deposit(tx) => tx.encode_2718(out),
-            Self::Aa8130(_) => unimplemented!(
-                "BaseTypedTransaction::eip2718_encode invoked on EIP-8130 variant; use AaSigned::encode_2718"
+            Self::Eip8130(_) => unimplemented!(
+                "BaseTypedTransaction::eip2718_encode invoked on EIP-8130 variant; use Eip8130Signed::encode_2718"
             ),
         }
     }
@@ -253,7 +253,7 @@ impl RlpEcdsaEncodableTx for BaseTypedTransaction {
             Self::Eip1559(tx) => tx.network_encode_with_type(signature, tx.ty(), out),
             Self::Eip7702(tx) => tx.network_encode_with_type(signature, tx.ty(), out),
             Self::Deposit(tx) => tx.network_encode(out),
-            Self::Aa8130(_) => unimplemented!(
+            Self::Eip8130(_) => unimplemented!(
                 "BaseTypedTransaction::network_encode_with_type invoked on EIP-8130 variant"
             ),
         }
@@ -266,7 +266,7 @@ impl RlpEcdsaEncodableTx for BaseTypedTransaction {
             Self::Eip1559(tx) => tx.network_encode(signature, out),
             Self::Eip7702(tx) => tx.network_encode(signature, out),
             Self::Deposit(tx) => tx.network_encode(out),
-            Self::Aa8130(_) => {
+            Self::Eip8130(_) => {
                 unimplemented!("BaseTypedTransaction::network_encode invoked on EIP-8130 variant")
             }
         }
@@ -279,7 +279,7 @@ impl RlpEcdsaEncodableTx for BaseTypedTransaction {
             Self::Eip1559(tx) => tx.tx_hash_with_type(signature, tx.ty()),
             Self::Eip7702(tx) => tx.tx_hash_with_type(signature, tx.ty()),
             Self::Deposit(tx) => tx.tx_hash(),
-            Self::Aa8130(_) => {
+            Self::Eip8130(_) => {
                 unimplemented!(
                     "BaseTypedTransaction::tx_hash_with_type invoked on EIP-8130 variant"
                 )
@@ -294,7 +294,7 @@ impl RlpEcdsaEncodableTx for BaseTypedTransaction {
             Self::Eip1559(tx) => tx.tx_hash(signature),
             Self::Eip7702(tx) => tx.tx_hash(signature),
             Self::Deposit(tx) => tx.tx_hash(),
-            Self::Aa8130(_) => {
+            Self::Eip8130(_) => {
                 unimplemented!("BaseTypedTransaction::tx_hash invoked on EIP-8130 variant")
             }
         }
@@ -309,7 +309,7 @@ impl SignableTransaction<Signature> for BaseTypedTransaction {
             Self::Eip1559(tx) => tx.set_chain_id(chain_id),
             Self::Eip7702(tx) => tx.set_chain_id(chain_id),
             Self::Deposit(_) => {}
-            Self::Aa8130(tx) => tx.set_chain_id(chain_id),
+            Self::Eip8130(tx) => tx.set_chain_id(chain_id),
         }
     }
 
@@ -320,7 +320,7 @@ impl SignableTransaction<Signature> for BaseTypedTransaction {
             Self::Eip1559(tx) => tx.encode_for_signing(out),
             Self::Eip7702(tx) => tx.encode_for_signing(out),
             Self::Deposit(_) => {}
-            Self::Aa8130(tx) => tx.encode_for_signing(out),
+            Self::Eip8130(tx) => tx.encode_for_signing(out),
         }
     }
 
@@ -331,7 +331,7 @@ impl SignableTransaction<Signature> for BaseTypedTransaction {
             Self::Eip1559(tx) => tx.payload_len_for_signature(),
             Self::Eip7702(tx) => tx.payload_len_for_signature(),
             Self::Deposit(_) => 0,
-            Self::Aa8130(tx) => tx.payload_len_for_signature(),
+            Self::Eip8130(tx) => tx.payload_len_for_signature(),
         }
     }
 
@@ -352,13 +352,13 @@ impl InMemorySize for BaseTypedTransaction {
             Self::Eip1559(tx) => tx.size(),
             Self::Eip7702(tx) => tx.size(),
             Self::Deposit(tx) => tx.size(),
-            Self::Aa8130(tx) => tx.size(),
+            Self::Eip8130(tx) => tx.size(),
         }
     }
 }
 
-impl From<AaSigned> for BaseTxEnvelope {
-    fn from(signed: AaSigned) -> Self {
-        Self::Aa8130(signed)
+impl From<Eip8130Signed> for BaseTxEnvelope {
+    fn from(signed: Eip8130Signed) -> Self {
+        Self::Eip8130(signed)
     }
 }

--- a/crates/common/evm/src/receipt_builder.rs
+++ b/crates/common/evm/src/receipt_builder.rs
@@ -60,7 +60,7 @@ impl BaseReceiptBuilder for AlloyReceiptBuilder {
                     OpTxType::Eip1559 => BaseReceiptEnvelope::Eip1559(receipt),
                     OpTxType::Eip7702 => BaseReceiptEnvelope::Eip7702(receipt),
                     OpTxType::Deposit => unreachable!(),
-                    OpTxType::Aa8130 => BaseReceiptEnvelope::Aa8130(receipt),
+                    OpTxType::Eip8130 => BaseReceiptEnvelope::Eip8130(receipt),
                 })
             }
         }

--- a/crates/common/evm/src/transaction/core.rs
+++ b/crates/common/evm/src/transaction/core.rs
@@ -242,10 +242,10 @@ impl FromTxWithEncoded<BaseTxEnvelope> for BaseTransaction<TxEnv> {
                 enveloped_tx: Some(encoded),
                 deposit: Default::default(),
             },
-            BaseTxEnvelope::Deposit(tx) => Self::from_encoded_tx(tx.inner(), caller, encoded),
             BaseTxEnvelope::Eip8130(_) => {
                 unimplemented!("EVM execution for EIP-8130 BaseTxEnvelope is not yet implemented")
             }
+            BaseTxEnvelope::Deposit(tx) => Self::from_encoded_tx(tx.inner(), caller, encoded),
         }
     }
 }

--- a/crates/common/evm/src/transaction/core.rs
+++ b/crates/common/evm/src/transaction/core.rs
@@ -243,7 +243,7 @@ impl FromTxWithEncoded<BaseTxEnvelope> for BaseTransaction<TxEnv> {
                 deposit: Default::default(),
             },
             BaseTxEnvelope::Deposit(tx) => Self::from_encoded_tx(tx.inner(), caller, encoded),
-            BaseTxEnvelope::Aa8130(_) => {
+            BaseTxEnvelope::Eip8130(_) => {
                 unimplemented!("EVM execution for EIP-8130 BaseTxEnvelope is not yet implemented")
             }
         }

--- a/crates/common/rpc-types/src/receipt.rs
+++ b/crates/common/rpc-types/src/receipt.rs
@@ -253,8 +253,8 @@ impl From<BaseTransactionReceipt> for BaseReceiptEnvelope {
                 };
                 Self::Deposit(consensus_receipt)
             }
-            BaseReceipt::Aa8130(receipt) => {
-                Self::Aa8130(convert_standard_receipt(receipt, logs_bloom))
+            BaseReceipt::Eip8130(receipt) => {
+                Self::Eip8130(convert_standard_receipt(receipt, logs_bloom))
             }
         }
     }

--- a/crates/common/rpc-types/src/receipt.rs
+++ b/crates/common/rpc-types/src/receipt.rs
@@ -237,6 +237,9 @@ impl From<BaseTransactionReceipt> for BaseReceiptEnvelope {
             BaseReceipt::Eip7702(receipt) => {
                 Self::Eip7702(convert_standard_receipt(receipt, logs_bloom))
             }
+            BaseReceipt::Eip8130(receipt) => {
+                Self::Eip8130(convert_standard_receipt(receipt, logs_bloom))
+            }
             BaseReceipt::Deposit(receipt) => {
                 let consensus_logs = receipt.inner.logs.into_iter().map(|log| log.inner).collect();
                 let consensus_receipt = DepositReceiptWithBloom {
@@ -252,9 +255,6 @@ impl From<BaseTransactionReceipt> for BaseReceiptEnvelope {
                     logs_bloom,
                 };
                 Self::Deposit(consensus_receipt)
-            }
-            BaseReceipt::Eip8130(receipt) => {
-                Self::Eip8130(convert_standard_receipt(receipt, logs_bloom))
             }
         }
     }

--- a/crates/common/rpc-types/src/transaction/request.rs
+++ b/crates/common/rpc-types/src/transaction/request.rs
@@ -195,10 +195,10 @@ impl From<BaseTypedTransaction> for BaseTransactionRequest {
             BaseTypedTransaction::Eip2930(tx) => Self(tx.into()),
             BaseTypedTransaction::Eip1559(tx) => Self(tx.into()),
             BaseTypedTransaction::Eip7702(tx) => Self(tx.into()),
-            BaseTypedTransaction::Deposit(tx) => tx.into(),
             BaseTypedTransaction::Eip8130(_) => unimplemented!(
                 "BaseTypedTransaction::Eip8130 cannot be projected onto BaseTransactionRequest; AA transactions have no single sender/recipient/value"
             ),
+            BaseTypedTransaction::Deposit(tx) => tx.into(),
         }
     }
 }
@@ -210,10 +210,10 @@ impl From<BaseTxEnvelope> for BaseTransactionRequest {
             BaseTxEnvelope::Eip2930(tx) => tx.into(),
             BaseTxEnvelope::Eip1559(tx) => tx.into(),
             BaseTxEnvelope::Eip7702(tx) => tx.into(),
-            BaseTxEnvelope::Deposit(tx) => tx.into(),
             BaseTxEnvelope::Eip8130(_) => unimplemented!(
                 "BaseTxEnvelope::Eip8130 cannot be projected onto BaseTransactionRequest; AA transactions have no single sender/recipient/value"
             ),
+            BaseTxEnvelope::Deposit(tx) => tx.into(),
         }
     }
 }

--- a/crates/common/rpc-types/src/transaction/request.rs
+++ b/crates/common/rpc-types/src/transaction/request.rs
@@ -196,8 +196,8 @@ impl From<BaseTypedTransaction> for BaseTransactionRequest {
             BaseTypedTransaction::Eip1559(tx) => Self(tx.into()),
             BaseTypedTransaction::Eip7702(tx) => Self(tx.into()),
             BaseTypedTransaction::Deposit(tx) => tx.into(),
-            BaseTypedTransaction::Aa8130(_) => unimplemented!(
-                "BaseTypedTransaction::Aa8130 cannot be projected onto BaseTransactionRequest; AA transactions have no single sender/recipient/value"
+            BaseTypedTransaction::Eip8130(_) => unimplemented!(
+                "BaseTypedTransaction::Eip8130 cannot be projected onto BaseTransactionRequest; AA transactions have no single sender/recipient/value"
             ),
         }
     }
@@ -211,8 +211,8 @@ impl From<BaseTxEnvelope> for BaseTransactionRequest {
             BaseTxEnvelope::Eip1559(tx) => tx.into(),
             BaseTxEnvelope::Eip7702(tx) => tx.into(),
             BaseTxEnvelope::Deposit(tx) => tx.into(),
-            BaseTxEnvelope::Aa8130(_) => unimplemented!(
-                "BaseTxEnvelope::Aa8130 cannot be projected onto BaseTransactionRequest; AA transactions have no single sender/recipient/value"
+            BaseTxEnvelope::Eip8130(_) => unimplemented!(
+                "BaseTxEnvelope::Eip8130 cannot be projected onto BaseTransactionRequest; AA transactions have no single sender/recipient/value"
             ),
         }
     }

--- a/crates/execution/evm/src/receipts.rs
+++ b/crates/execution/evm/src/receipts.rs
@@ -35,7 +35,7 @@ impl BaseReceiptBuilder for BaseRethReceiptBuilder {
                     OpTxType::Eip2930 => BaseReceipt::Eip2930(receipt),
                     OpTxType::Eip7702 => BaseReceipt::Eip7702(receipt),
                     OpTxType::Deposit => unreachable!(),
-                    OpTxType::Aa8130 => BaseReceipt::Aa8130(receipt),
+                    OpTxType::Eip8130 => BaseReceipt::Eip8130(receipt),
                 })
             }
         }

--- a/crates/execution/flashblocks/src/receipt_builder.rs
+++ b/crates/execution/flashblocks/src/receipt_builder.rs
@@ -118,7 +118,7 @@ impl<C: Upgrades> UnifiedReceiptBuilder<C> {
                 OpTxType::Eip1559 => BaseReceipt::Eip1559(receipt),
                 OpTxType::Eip7702 => BaseReceipt::Eip7702(receipt),
                 OpTxType::Deposit => unreachable!(),
-                OpTxType::Aa8130 => BaseReceipt::Aa8130(receipt),
+                OpTxType::Eip8130 => BaseReceipt::Eip8130(receipt),
             })
         }
     }

--- a/crates/execution/rpc/src/eth/receipt.rs
+++ b/crates/execution/rpc/src/eth/receipt.rs
@@ -303,7 +303,7 @@ impl BaseReceiptBuilder {
                 BaseReceipt::Eip1559(receipt) => BaseReceipt::Eip1559(map_logs(receipt)),
                 BaseReceipt::Eip7702(receipt) => BaseReceipt::Eip7702(map_logs(receipt)),
                 BaseReceipt::Deposit(receipt) => BaseReceipt::Deposit(receipt.map_inner(map_logs)),
-                BaseReceipt::Aa8130(receipt) => BaseReceipt::Aa8130(map_logs(receipt)),
+                BaseReceipt::Eip8130(receipt) => BaseReceipt::Eip8130(map_logs(receipt)),
             };
             mapped_receipt.into_with_bloom()
         });


### PR DESCRIPTION
## Summary

Pure refactor on top of #2863 (now merged on `main`). Two coordinated changes, no behavior change.

### 1. Rename `Aa8130` → `Eip8130`

Align EIP-8130 transaction types with the workspace's existing `Eip7702` / `Eip1559` / `Eip2930` naming convention. The `Aa` prefix was a transitional shorthand; using the EIP number matches every other typed transaction and the upstream alloy convention.

| Before | After |
|---|---|
| `Aa8130` (envelope/typed/receipt variants) | `Eip8130` |
| `AaSigned` | `Eip8130Signed` |
| `TxAa8130` | `TxEip8130` |
| `Aa8130Constants` | `Eip8130Constants` |
| `AA_TX_TYPE` | `EIP8130_TX_TYPE` |
| `AA_PAYER_TYPE` | `EIP8130_PAYER_TYPE` |
| `AA_BASE_COST` | `EIP8130_BASE_COST` |
| `is_aa8130()` | `is_eip8130()` |
| `as_aa8130()` | `as_eip8130()` |
| `aa8130/` (module directory) | `eip8130/` |

### 2. Reorder match arms so `Deposit` comes last

Across every match expression that fans out over `BaseTxEnvelope` / `BaseTypedTransaction` variants, the arm order is now:

```
Legacy / Eip2930 / Eip1559 / Eip7702 / Eip8130  // normal ECDSA path
Deposit                                         // always last
```

The Deposit transaction is the special, unsigned, L2-only variant that requires distinct handling (no signature recovery, no pool admission, explicit `from` field). Keeping it as the final arm in every match makes the ECDSA path read top-to-bottom as a single cohesive block and makes the special-case handling visually obvious. `Eip8130` is an ECDSA-class L2 transaction, so it sits with the other typed variants rather than next to `Deposit`. Pipe-chain arms (e.g. `Self::Eip8130(_) | Self::Deposit(_)`) follow the same ordering rule.

## Verification

- `cargo check --workspace --all-features --exclude devnet` ✅
- `cargo test -p base-common-consensus --all-features --lib` ✅ (90 passed)
- `cargo +nightly fmt --all -- --check` ✅

## Stacking

This was originally drafted as a stacked PR on top of #2863. Since #2863 has now merged via the merge queue, this PR targets `main` directly.