### PR TITLE
fix(precompiles): Validate No Std Currency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3409,7 +3409,7 @@ dependencies = [
  "base-precompile-macros",
  "base-precompile-storage",
  "criterion",
- "iso_currency",
+ "iso4217-static",
  "k256",
  "revm",
  "rstest",
@@ -10980,23 +10980,74 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
-name = "iso_country"
-version = "0.1.4"
+name = "iso3166-macros"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20633e788d3948ea7336861fdb09ec247f5dae4267e8f0743fa97de26c28624d"
+checksum = "731b1db633b63cb5e90312b6ae8ad4821d54709285de1bbc6ec32fab64438525"
 dependencies = [
- "lazy_static",
+ "heck",
+ "iso3166-parsers",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "syn 2.0.117",
 ]
 
 [[package]]
-name = "iso_currency"
-version = "0.5.3"
+name = "iso3166-parsers"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed4b3f0921193400b1df556228bfd917c57c7fa38bda904d552653c5c3b641b"
+checksum = "754672b76089b19c687be1d743c32277d059566f469a8f549f28b8f900b64240"
 dependencies = [
- "iso_country",
+ "serde",
+]
+
+[[package]]
+name = "iso3166-static"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e2db16976004b25b80b54acefcb121b40bcdcd8eff142d74ea746d7620ebb23"
+dependencies = [
+ "iso3166-macros",
+]
+
+[[package]]
+name = "iso4217-macros"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "136a1ef24bd5f95a4b74598722bb83265fd52e3f1655b35d26c5d0e2d3c7a340"
+dependencies = [
+ "chrono",
+ "heck",
+ "iso4217-parser",
  "proc-macro2",
+ "quick-xml",
  "quote",
+ "serde",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "iso4217-parser"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "500ca119265ca61f9838fda0be789c8b9bfae4e7d56f75afa6ddb2fb29165ebd"
+dependencies = [
+ "chrono",
+ "serde",
+]
+
+[[package]]
+name = "iso4217-static"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dacfb059186f5aa948a900742cd5f30cac3bfd9c2a85c16a2fd8fcc02f0d2c52"
+dependencies = [
+ "cfg-if",
+ "chrono",
+ "iso3166-static",
+ "iso4217-macros",
 ]
 
 [[package]]
@@ -15147,6 +15198,16 @@ dependencies = [
  "quick-protobuf",
  "thiserror 1.0.69",
  "unsigned-varint 0.8.0",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.39.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
+dependencies = [
+ "memchr",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -545,7 +545,7 @@ hostname = "0.4.0"
 ratatui = "0.30.0"
 crossterm = "0.29"
 indicatif = "0.18"
-iso_currency = { version = "0.5.3", default-features = false }
+iso4217-static = { version = "0.2.3", default-features = false }
 arc-swap = "1.7.1"
 tokio-vsock = "0.7"
 hex-literal = "1.1"

--- a/crates/common/evm/Cargo.toml
+++ b/crates/common/evm/Cargo.toml
@@ -54,7 +54,6 @@ std = [
 	"base-common-chains/std",
 	"base-common-consensus/std",
 	"base-common-flz/std",
-	"base-common-precompiles/std",
 	"revm/std",
 	"serde?/std",
 	"thiserror/std",

--- a/crates/common/precompile-macros/src/layout.rs
+++ b/crates/common/precompile-macros/src/layout.rs
@@ -191,7 +191,7 @@ pub(crate) fn gen_constructor(
 
             #[cfg(feature = "test-utils")]
             /// Returns all events emitted by this contract (test-utils only).
-            pub fn emitted_events(&self) -> ::std::vec::Vec<::alloy_primitives::LogData> {
+            pub fn emitted_events(&self) -> ::alloc::vec::Vec<::alloy_primitives::LogData> {
                 self.storage.get_events(self.address)
             }
 
@@ -203,7 +203,7 @@ pub(crate) fn gen_constructor(
 
             #[cfg(feature = "test-utils")]
             /// Asserts that emitted events match the expected list (test-utils only).
-            pub fn assert_emitted_events(&self, expected: ::std::vec::Vec<impl ::alloy_primitives::IntoLogData>) {
+            pub fn assert_emitted_events(&self, expected: ::alloc::vec::Vec<impl ::alloy_primitives::IntoLogData>) {
                 let emitted = self.storage.get_events(self.address);
                 assert_eq!(emitted.len(), expected.len());
                 for (i, event) in expected.into_iter().enumerate() {

--- a/crates/common/precompile-storage/tests/contract.rs
+++ b/crates/common/precompile-storage/tests/contract.rs
@@ -2,6 +2,8 @@
 //!
 //! Validates that the macro generates correct storage layout,
 //! typed getter/setter fields work round-trip, and collision detection fires.
+extern crate alloc;
+
 use alloy_primitives::{Address, U256, address, keccak256};
 use base_precompile_macros::contract;
 use base_precompile_storage::{Handler, Mapping, StorageCtx, StorageKey, setup_storage};

--- a/crates/common/precompiles/Cargo.toml
+++ b/crates/common/precompiles/Cargo.toml
@@ -27,7 +27,7 @@ base-precompile-storage.workspace = true
 revm.workspace = true
 
 # misc
-iso_currency = { workspace = true, optional = true }
+iso4217-static.workspace = true
 
 [dev-dependencies]
 rstest.workspace = true
@@ -41,16 +41,7 @@ harness = false
 required-features = ["test-utils"]
 
 [features]
-default = [ "blst", "c-kzg", "portable", "secp256k1", "std" ]
-std = [
-	"alloy-evm/std",
-	"alloy-primitives/std",
-	"alloy-sol-types/std",
-	"base-common-chains/std",
-	"base-precompile-storage/std",
-	"dep:iso_currency",
-	"revm/std",
-]
+default = [ "blst", "c-kzg", "portable", "secp256k1" ]
 bn = [ "revm/bn" ]
 blst = [ "revm/blst" ]
 c-kzg = [ "revm/c-kzg" ]
@@ -63,4 +54,7 @@ optional_eip3607 = [ "revm/optional_eip3607" ]
 optional_fee_charge = [ "revm/optional_fee_charge" ]
 optional_balance_check = [ "revm/optional_balance_check" ]
 optional_block_gas_limit = [ "revm/optional_block_gas_limit" ]
-test-utils = [ "base-precompile-storage/test-utils" ]
+test-utils = [
+	"base-common-chains/test-utils",
+	"base-precompile-storage/test-utils",
+]

--- a/crates/common/precompiles/src/b20_security/dispatch.rs
+++ b/crates/common/precompiles/src/b20_security/dispatch.rs
@@ -637,6 +637,8 @@ impl<S: SecurityAccounting, P: Policy> B20SecurityToken<S, P> {
 
 #[cfg(test)]
 mod tests {
+    use alloc::string::{String, ToString};
+
     use alloy_primitives::{Address, B256, U256};
     use alloy_sol_types::SolEvent;
     use base_precompile_storage::BasePrecompileError;

--- a/crates/common/precompiles/src/b20_security/storage.rs
+++ b/crates/common/precompiles/src/b20_security/storage.rs
@@ -376,6 +376,8 @@ impl SecurityAccounting for B20SecurityStorage<'_> {
 
 #[cfg(test)]
 mod tests {
+    use alloc::string::String;
+
     use alloy_primitives::{Address, U256, address, uint};
     use base_precompile_storage::{Handler, StorableType, StorageCtx, StorageKey, setup_storage};
 

--- a/crates/common/precompiles/src/b20_stablecoin/storage.rs
+++ b/crates/common/precompiles/src/b20_stablecoin/storage.rs
@@ -5,13 +5,9 @@ use alloc::string::String;
 use alloy_primitives::{Address, B256, LogData, U256};
 use base_precompile_macros::{Storable, contract};
 use base_precompile_storage::{BasePrecompileError, ContractStorage, Handler, Result, StorageCtx};
-#[cfg(feature = "std")]
-use iso_currency::Currency;
 
 use super::accounting::StablecoinAccounting;
-use crate::{
-    B20CoreStorage, B20PolicyType, B20TokenRole, IB20, ITokenFactory, TokenAccounting, TokenVariant,
-};
+use crate::{B20CoreStorage, B20PolicyType, B20TokenRole, IB20, TokenAccounting, TokenVariant};
 
 /// Stablecoin-specific B-20 storage rooted at the `base.b20.stablecoin` ERC-7201 namespace.
 #[derive(Debug, Clone, Storable)]
@@ -51,15 +47,8 @@ impl<'a> B20StablecoinStorage<'a> {
 
     /// Writes all creation-time fields atomically.
     ///
-    /// Validates that `currency` is a recognised ISO 4217 code before writing
-    /// anything; reverts `ITokenFactory::InvalidCurrency` otherwise.
+    /// The factory validates `currency` before calling this initializer.
     pub fn initialize(&mut self, init: B20StablecoinInit) -> Result<()> {
-        #[cfg(feature = "std")]
-        if Currency::from_code(&init.currency).is_none() {
-            return Err(BasePrecompileError::revert(ITokenFactory::InvalidCurrency {
-                code: init.currency,
-            }));
-        }
         self.b20.name.write(init.name)?;
         self.b20.symbol.write(init.symbol)?;
         self.b20.supply_cap.write(init.supply_cap)?;

--- a/crates/common/precompiles/src/bls12_381.rs
+++ b/crates/common/precompiles/src/bls12_381.rs
@@ -98,6 +98,8 @@ pub(crate) const JOVIAN_PAIRING: Precompile = Precompile::new(
 
 #[cfg(test)]
 mod tests {
+    use alloc::vec;
+
     use revm::{precompile::PrecompileError, primitives::Bytes};
     use rstest::rstest;
 

--- a/crates/common/precompiles/src/bn254_pair.rs
+++ b/crates/common/precompiles/src/bn254_pair.rs
@@ -34,6 +34,8 @@ pub(crate) const JOVIAN: Precompile =
 
 #[cfg(test)]
 mod tests {
+    use alloc::vec;
+
     use revm::{
         precompile::{PrecompileError, bn254},
         primitives::hex,

--- a/crates/common/precompiles/src/common/test_utils.rs
+++ b/crates/common/precompiles/src/common/test_utils.rs
@@ -3,7 +3,12 @@
 //! Use these for capability/ops logic tests (Transferable, Mintable, …).
 //! For factory, dispatch, and storage-layout tests keep the EVM harness.
 
-use std::collections::{HashMap, HashSet};
+use alloc::{
+    borrow::ToOwned,
+    collections::{BTreeMap, BTreeSet},
+    string::String,
+    vec::Vec,
+};
 
 use alloy_primitives::{Address, B256, LogData, U256};
 use base_precompile_storage::Result;
@@ -26,7 +31,7 @@ pub type TestToken = B20Token<InMemoryTokenAccounting, InMemoryPolicy>;
 /// Use this in unit tests instead of spelling out the full generic each time.
 pub type TestStablecoinToken = B20StablecoinToken<InMemoryTokenAccounting, InMemoryPolicy>;
 
-/// HashMap-backed [`TokenAccounting`] for unit tests.
+/// BTreeMap-backed [`TokenAccounting`] for unit tests.
 ///
 /// Collect emitted events via the public `events` field after calling token ops.
 #[derive(Debug)]
@@ -35,9 +40,9 @@ pub struct InMemoryTokenAccounting {
     /// Whether `is_initialized` returns `true`.
     pub initialized: bool,
     /// Per-account token balances.
-    pub balances: HashMap<Address, U256>,
+    pub balances: BTreeMap<Address, U256>,
     /// Approved spending allowances keyed by `(owner, spender)`.
-    pub allowances: HashMap<(Address, Address), U256>,
+    pub allowances: BTreeMap<(Address, Address), U256>,
     /// Current total token supply.
     pub total_supply: U256,
     /// Defaults to `U256::MAX` so mint tests don't need to set a cap explicitly.
@@ -55,37 +60,37 @@ pub struct InMemoryTokenAccounting {
     /// Bitmask of active pause vectors.
     pub paused: U256,
     /// Per-account EIP-2612 nonces.
-    pub nonces: HashMap<Address, U256>,
+    pub nonces: BTreeMap<Address, U256>,
     /// Minimum amount required for a redeem operation.
     pub minimum_redeemable: U256,
     /// URI pointing to the contract-level metadata.
     pub contract_uri: String,
     /// Role membership keyed by `(role, account)`.
-    pub roles: HashMap<(B256, Address), bool>,
+    pub roles: BTreeMap<(B256, Address), bool>,
     /// Number of accounts assigned to each role.
-    pub role_member_counts: HashMap<B256, U256>,
+    pub role_member_counts: BTreeMap<B256, U256>,
     /// Admin role for each role.
-    pub role_admins: HashMap<B256, B256>,
+    pub role_admins: BTreeMap<B256, B256>,
     /// Policy IDs keyed by policy type.
-    pub policy_ids: HashMap<B256, u64>,
+    pub policy_ids: BTreeMap<B256, u64>,
     /// Share-to-tokens ratio scaled to WAD (1e18). Security tokens only.
     pub shares_to_tokens_ratio: U256,
     /// Security identifier values keyed by raw `identifier_type`. Security tokens only.
-    pub security_identifiers: HashMap<String, String>,
+    pub security_identifiers: BTreeMap<String, String>,
     /// Consumed announcement ids keyed by raw announcement id. Security tokens only.
-    pub announcement_ids_used: HashSet<String>,
+    pub announcement_ids_used: BTreeSet<String>,
     /// Events collected by `emit_event`; does not produce real EVM logs.
     pub events: Vec<LogData>,
 }
 
 impl InMemoryTokenAccounting {
     /// Creates an initialized accounting instance at `address` with sensible defaults.
-    pub fn new(address: Address) -> Self {
+    pub const fn new(address: Address) -> Self {
         Self {
             address,
             initialized: true,
-            balances: HashMap::new(),
-            allowances: HashMap::new(),
+            balances: BTreeMap::new(),
+            allowances: BTreeMap::new(),
             total_supply: U256::ZERO,
             supply_cap: U256::MAX,
             name: String::new(),
@@ -94,16 +99,16 @@ impl InMemoryTokenAccounting {
             currency: String::new(),
             security_isin: String::new(),
             paused: U256::ZERO,
-            nonces: HashMap::new(),
+            nonces: BTreeMap::new(),
             minimum_redeemable: U256::ZERO,
             contract_uri: String::new(),
-            roles: HashMap::new(),
-            role_member_counts: HashMap::new(),
-            role_admins: HashMap::new(),
-            policy_ids: HashMap::new(),
+            roles: BTreeMap::new(),
+            role_member_counts: BTreeMap::new(),
+            role_admins: BTreeMap::new(),
+            policy_ids: BTreeMap::new(),
             shares_to_tokens_ratio: U256::ZERO,
-            security_identifiers: HashMap::new(),
-            announcement_ids_used: HashSet::new(),
+            security_identifiers: BTreeMap::new(),
+            announcement_ids_used: BTreeSet::new(),
             events: Vec::new(),
         }
     }
@@ -264,16 +269,16 @@ impl StablecoinAccounting for InMemoryTokenAccounting {
 #[derive(Debug)]
 pub struct InMemoryPolicy {
     /// Authorization grants keyed by `(policy_id, account)`.
-    pub authorizations: HashMap<(u64, Address), bool>,
+    pub authorizations: BTreeMap<(u64, Address), bool>,
     /// Policy IDs that should be treated as existing.
-    pub policies: HashSet<u64>,
+    pub policies: BTreeSet<u64>,
     /// Next custom policy counter for tests that exercise registry creation.
     pub next_policy_counter: u64,
 }
 
 impl Default for InMemoryPolicy {
     fn default() -> Self {
-        Self { authorizations: HashMap::new(), policies: HashSet::new(), next_policy_counter: 2 }
+        Self { authorizations: BTreeMap::new(), policies: BTreeSet::new(), next_policy_counter: 2 }
     }
 }
 

--- a/crates/common/precompiles/src/factory/storage.rs
+++ b/crates/common/precompiles/src/factory/storage.rs
@@ -10,7 +10,7 @@ use super::variant::TokenVariant;
 use crate::{
     B20SecurityInit, B20SecurityStorage, B20SecurityToken, B20StablecoinInit, B20StablecoinStorage,
     B20StablecoinToken, B20Token, B20TokenInit, B20TokenRole, B20TokenStorage, ITokenFactory,
-    PolicyHandle, RoleManaged, Token,
+    Iso4217, PolicyHandle, RoleManaged, Token,
 };
 
 /// Maximum total supply for all newly-created B-20 tokens.
@@ -314,9 +314,12 @@ impl TokenCreateParams {
         Ok(())
     }
 
-    const fn validate_stablecoin(_init: &B20StablecoinInit) -> Result<()> {
-        // Currency validation is delegated to `B20StablecoinStorage::initialize`, which rejects
-        // all invalid values (including empty) with `InvalidCurrency`.
+    fn validate_stablecoin(init: &B20StablecoinInit) -> Result<()> {
+        if !Iso4217::is_valid_fiat_code(&init.currency) {
+            return Err(BasePrecompileError::revert(ITokenFactory::InvalidCurrency {
+                code: init.currency.clone(),
+            }));
+        }
         Ok(())
     }
 
@@ -337,6 +340,8 @@ impl TokenCreateParams {
 
 #[cfg(test)]
 mod tests {
+    use alloc::string::{String, ToString};
+
     use alloy_primitives::{B256, address};
     use alloy_sol_types::{SolCall, SolError, SolValue};
     use base_precompile_storage::{Handler, HashMapStorageProvider, StorageCtx};
@@ -387,6 +392,22 @@ mod tests {
 
     fn b20_call(salt: B256) -> ITokenFactory::createTokenCall {
         create_call(ITokenFactory::TokenVariant::DEFAULT, token_params("Test", "TST"), salt)
+    }
+
+    fn stablecoin_call(currency: &str, salt: B256) -> ITokenFactory::createTokenCall {
+        let params = ITokenFactory::B20StablecoinCreateParams {
+            version: TokenFactoryStorage::CREATE_TOKEN_VERSION,
+            name: "Stablecoin Token".to_string(),
+            symbol: "USD".to_string(),
+            initialAdmin: Address::repeat_byte(0xAB),
+            currency: currency.to_string(),
+        };
+        ITokenFactory::createTokenCall {
+            variant: ITokenFactory::TokenVariant::STABLECOIN,
+            salt,
+            params: params.abi_encode().into(),
+            initCalls: Vec::new(),
+        }
     }
 
     fn token_at<'a>(
@@ -607,19 +628,7 @@ mod tests {
     fn test_create_token_reverts_for_missing_stablecoin_currency() {
         let mut storage = HashMapStorageProvider::new(1);
         activate_precompiles(&mut storage);
-        let params = ITokenFactory::B20StablecoinCreateParams {
-            version: TokenFactoryStorage::CREATE_TOKEN_VERSION,
-            name: "Stablecoin Token".to_string(),
-            symbol: "USD".to_string(),
-            initialAdmin: Address::repeat_byte(0xAB),
-            currency: String::new(),
-        };
-        let call = ITokenFactory::createTokenCall {
-            variant: ITokenFactory::TokenVariant::STABLECOIN,
-            salt: B256::repeat_byte(0x06),
-            params: params.abi_encode().into(),
-            initCalls: Vec::new(),
-        };
+        let call = stablecoin_call("", B256::repeat_byte(0x06));
 
         StorageCtx::enter(&mut storage, |ctx| {
             assert_output(
@@ -627,6 +636,24 @@ mod tests {
                 ITokenFactory::InvalidCurrency { code: String::new() }.abi_encode(),
             );
         });
+    }
+
+    #[test]
+    fn test_create_token_rejects_non_allowlist_stablecoin_currencies() {
+        for (index, currency) in
+            ["usd", "USDC", "BTC", "XAU", "XDR", "XXX", "BOV", "ZZZ"].into_iter().enumerate()
+        {
+            let mut storage = HashMapStorageProvider::new(1);
+            activate_precompiles(&mut storage);
+            let call = stablecoin_call(currency, B256::repeat_byte(index as u8 + 1));
+
+            StorageCtx::enter(&mut storage, |ctx| {
+                assert_output(
+                    dispatch_factory_revert(ctx, call),
+                    ITokenFactory::InvalidCurrency { code: currency.to_string() }.abi_encode(),
+                );
+            });
+        }
     }
 
     #[test]
@@ -663,19 +690,7 @@ mod tests {
         let mut storage = HashMapStorageProvider::new(1);
         activate_precompiles(&mut storage);
 
-        let stablecoin_params = ITokenFactory::B20StablecoinCreateParams {
-            version: TokenFactoryStorage::CREATE_TOKEN_VERSION,
-            name: "Stablecoin Token".to_string(),
-            symbol: "USD".to_string(),
-            initialAdmin: Address::repeat_byte(0xAB),
-            currency: "USD".to_string(),
-        };
-        let stablecoin_call = ITokenFactory::createTokenCall {
-            variant: ITokenFactory::TokenVariant::STABLECOIN,
-            salt: B256::repeat_byte(0x08),
-            params: stablecoin_params.abi_encode().into(),
-            initCalls: Vec::new(),
-        };
+        let stablecoin_call = stablecoin_call("USD", B256::repeat_byte(0x08));
 
         StorageCtx::enter(&mut storage, |ctx| {
             let stablecoin_addr = ITokenFactory::createTokenCall::abi_decode_returns(

--- a/crates/common/precompiles/src/iso4217.rs
+++ b/crates/common/precompiles/src/iso4217.rs
@@ -1,0 +1,220 @@
+//! ISO 4217 fiat-code validation for B-20 stablecoin creation.
+
+use iso4217_static::Currency;
+
+/// ISO 4217 helpers mirrored from `base-std`'s `ISO4217.sol`.
+#[derive(Debug, Clone, Copy)]
+pub struct Iso4217;
+
+impl Iso4217 {
+    /// ISO 4217 codes deliberately excluded from the stablecoin fiat allowlist.
+    pub const EXCLUDED_CODES: &'static [&'static str] = &[
+        "XAU", "XAG", "XPT", "XPD", "XBA", "XBB", "XBC", "XBD", "XDR", "XSU", "XUA", "XXX", "XTS",
+        "BOV", "CHE", "CHW", "CLF", "COU", "MXV", "USN", "UYI", "UYW",
+    ];
+
+    /// Returns true iff `code` is a supported active ISO 4217 circulating fiat code.
+    pub fn is_valid_fiat_code(code: &str) -> bool {
+        Currency::try_from(code).is_ok() && Self::is_allowed_fiat_code(code)
+    }
+
+    /// Returns the number of deliberately excluded ISO 4217 codes.
+    pub const fn excluded_count() -> usize {
+        Self::EXCLUDED_CODES.len()
+    }
+
+    /// Returns a deliberately excluded ISO 4217 code by index.
+    pub fn excluded_at(index: usize) -> Option<&'static str> {
+        Self::EXCLUDED_CODES.get(index).copied()
+    }
+
+    /// Returns true iff `code` is in Base's stablecoin fiat allowlist.
+    pub fn is_allowed_fiat_code(code: &str) -> bool {
+        matches!(
+            code.as_bytes(),
+            b"USD"
+                | b"UAH"
+                | b"UGX"
+                | b"UYU"
+                | b"UZS"
+                | b"EUR"
+                | b"EGP"
+                | b"ETB"
+                | b"ERN"
+                | b"JPY"
+                | b"JMD"
+                | b"JOD"
+                | b"GBP"
+                | b"GHS"
+                | b"GEL"
+                | b"GTQ"
+                | b"GIP"
+                | b"GMD"
+                | b"GNF"
+                | b"GYD"
+                | b"CHF"
+                | b"CNY"
+                | b"CAD"
+                | b"CZK"
+                | b"COP"
+                | b"CRC"
+                | b"CUP"
+                | b"CVE"
+                | b"CDF"
+                | b"AUD"
+                | b"AED"
+                | b"ARS"
+                | b"AMD"
+                | b"ANG"
+                | b"AOA"
+                | b"AFN"
+                | b"ALL"
+                | b"AWG"
+                | b"AZN"
+                | b"NOK"
+                | b"NZD"
+                | b"NGN"
+                | b"NPR"
+                | b"NIO"
+                | b"NAD"
+                | b"SEK"
+                | b"SGD"
+                | b"SAR"
+                | b"SHP"
+                | b"SCR"
+                | b"SBD"
+                | b"SDG"
+                | b"SLE"
+                | b"SOS"
+                | b"SRD"
+                | b"SSP"
+                | b"STN"
+                | b"SVC"
+                | b"SYP"
+                | b"SZL"
+                | b"INR"
+                | b"IDR"
+                | b"ILS"
+                | b"ISK"
+                | b"IQD"
+                | b"IRR"
+                | b"MXN"
+                | b"MYR"
+                | b"MAD"
+                | b"MNT"
+                | b"MMK"
+                | b"MUR"
+                | b"MOP"
+                | b"MVR"
+                | b"MWK"
+                | b"MGA"
+                | b"MDL"
+                | b"MZN"
+                | b"MKD"
+                | b"MRU"
+                | b"TRY"
+                | b"THB"
+                | b"TWD"
+                | b"TZS"
+                | b"TND"
+                | b"TOP"
+                | b"TTD"
+                | b"TJS"
+                | b"TMT"
+                | b"PLN"
+                | b"PHP"
+                | b"PKR"
+                | b"PEN"
+                | b"PGK"
+                | b"PYG"
+                | b"PAB"
+                | b"KRW"
+                | b"KZT"
+                | b"KES"
+                | b"KWD"
+                | b"KGS"
+                | b"KHR"
+                | b"KMF"
+                | b"KPW"
+                | b"KYD"
+                | b"BRL"
+                | b"BHD"
+                | b"BDT"
+                | b"BGN"
+                | b"BAM"
+                | b"BBD"
+                | b"BIF"
+                | b"BMD"
+                | b"BND"
+                | b"BOB"
+                | b"BSD"
+                | b"BTN"
+                | b"BWP"
+                | b"BYN"
+                | b"BZD"
+                | b"HKD"
+                | b"HUF"
+                | b"HNL"
+                | b"HTG"
+                | b"RUB"
+                | b"RON"
+                | b"RSD"
+                | b"RWF"
+                | b"DKK"
+                | b"DOP"
+                | b"DZD"
+                | b"DJF"
+                | b"XOF"
+                | b"XAF"
+                | b"XCD"
+                | b"XPF"
+                | b"ZAR"
+                | b"ZMW"
+                | b"ZWG"
+                | b"VND"
+                | b"VES"
+                | b"VED"
+                | b"VUV"
+                | b"LKR"
+                | b"LBP"
+                | b"LAK"
+                | b"LRD"
+                | b"LSL"
+                | b"LYD"
+                | b"FJD"
+                | b"FKP"
+                | b"OMR"
+                | b"QAR"
+                | b"WST"
+                | b"YER"
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Iso4217;
+
+    #[test]
+    fn accepts_base_std_fiat_codes() {
+        for code in ["USD", "EUR", "JPY", "GBP", "AUD", "SGD", "XOF", "XAF", "XCD", "XPF", "ZWG"] {
+            assert!(Iso4217::is_valid_fiat_code(code), "{code} should be accepted");
+        }
+    }
+
+    #[test]
+    fn rejects_non_allowlist_codes() {
+        for code in ["", "US", "USDC", "usd", "BTC", "ETH", "ZZZ"] {
+            assert!(!Iso4217::is_valid_fiat_code(code), "{code} should be rejected");
+        }
+    }
+
+    #[test]
+    fn rejects_base_std_excluded_codes() {
+        assert_eq!(Iso4217::excluded_count(), 22);
+        for index in 0..Iso4217::excluded_count() {
+            let code = Iso4217::excluded_at(index).unwrap();
+            assert!(!Iso4217::is_valid_fiat_code(code), "{code} should be rejected");
+        }
+    }
+}

--- a/crates/common/precompiles/src/lib.rs
+++ b/crates/common/precompiles/src/lib.rs
@@ -1,7 +1,7 @@
 #![doc = include_str!("../README.md")]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(docsrs, feature(doc_cfg))]
-#![cfg_attr(not(feature = "std"), no_std)]
+#![no_std]
 
 extern crate alloc;
 
@@ -29,6 +29,9 @@ pub use common::{
 };
 #[cfg(any(test, feature = "test-utils"))]
 pub use common::{InMemoryPolicy, InMemoryTokenAccounting, TestStablecoinToken, TestToken};
+
+mod iso4217;
+pub use iso4217::Iso4217;
 
 mod b20;
 pub use b20::{

--- a/crates/common/precompiles/src/policy/storage.rs
+++ b/crates/common/precompiles/src/policy/storage.rs
@@ -473,6 +473,8 @@ impl crate::PolicyRegistry for PolicyRegistryStorage<'_> {
 
 #[cfg(test)]
 mod tests {
+    use alloc::vec;
+
     use alloy_primitives::{Address, U256, address, uint};
     use alloy_sol_types::SolEvent;
     use base_precompile_storage::{HashMapStorageProvider, StorageCtx, StorageKey};

--- a/crates/common/precompiles/src/provider.rs
+++ b/crates/common/precompiles/src/provider.rs
@@ -242,7 +242,7 @@ impl<S: BasePrecompileSpec> Default for BasePrecompiles<S> {
 
 #[cfg(test)]
 mod tests {
-    use std::vec;
+    use alloc::{vec, vec::Vec};
 
     use alloy_primitives::{Address, B256};
     use revm::{

--- a/etc/scripts/ci/check-no-std.sh
+++ b/etc/scripts/ci/check-no-std.sh
@@ -11,6 +11,8 @@ no_std_packages=(
   base-common-chains
   base-common-rpc-types
   base-common-rpc-types-engine
+  base-precompile-storage
+  base-common-precompiles
 
   # consensus protocol crates
   base-metrics


### PR DESCRIPTION
## Summary

This replaces the std-only ISO currency validation path with a no_std `iso4217-static` dependency and a Base-specific fiat allowlist. Stablecoin currency validation now runs at the token factory boundary in no_std builds, matching proofs requirements and rejecting non-allowlist codes consistently. The no_std CI package list now covers the precompile crates so this path stays checked.