### PR TITLE
refactor(policy): remove redundant require_write; fix HashMapStorageProvider static enforcement

### DIFF
--- a/crates/common/precompile-storage/src/hashmap.rs
+++ b/crates/common/precompile-storage/src/hashmap.rs
@@ -104,6 +104,9 @@ impl PrecompileStorageProvider for HashMapStorageProvider {
         key: U256,
         value: U256,
     ) -> Result<(), BasePrecompileError> {
+        if self.is_static {
+            return Err(BasePrecompileError::StaticCallViolation);
+        }
         self.counter_sstore += 1;
         self.internals.insert((address, key), value);
         Ok(())
@@ -115,11 +118,17 @@ impl PrecompileStorageProvider for HashMapStorageProvider {
         key: U256,
         value: U256,
     ) -> Result<(), BasePrecompileError> {
+        if self.is_static {
+            return Err(BasePrecompileError::StaticCallViolation);
+        }
         self.transient.insert((address, key), value);
         Ok(())
     }
 
     fn emit_event(&mut self, address: Address, event: LogData) -> Result<(), BasePrecompileError> {
+        if self.is_static {
+            return Err(BasePrecompileError::StaticCallViolation);
+        }
         self.events.entry(address).or_default().push(event);
         Ok(())
     }

--- a/crates/common/precompiles/src/policy/storage.rs
+++ b/crates/common/precompiles/src/policy/storage.rs
@@ -87,13 +87,6 @@ impl PolicyRegistryStorage<'_> {
     /// Number of built-in policies; the counter is set to this value after `write_builtins`.
     const BUILTIN_POLICY_COUNT: u64 = 2;
 
-    fn require_write(&self) -> Result<()> {
-        if self.storage.is_static() {
-            return Err(BasePrecompileError::StaticCallViolation);
-        }
-        Ok(())
-    }
-
     const fn policy_id_type(policy_id: u64) -> u8 {
         (policy_id >> Self::POLICY_ID_TYPE_SHIFT) as u8
     }
@@ -117,7 +110,6 @@ impl PolicyRegistryStorage<'_> {
     /// Validates the policy exists and the caller is its current admin.
     /// Returns `(packed, caller)` on success.
     fn require_admin(&self, policy_id: u64) -> Result<(PackedPolicy, Address)> {
-        self.require_write()?;
         let packed = self.require_custom(policy_id)?;
         let caller = self.storage.caller();
         if packed.admin() != caller {
@@ -156,7 +148,6 @@ impl PolicyRegistryStorage<'_> {
 
     /// Creates a new ALLOWLIST or BLOCKLIST policy, returning its encoded ID.
     pub fn create_policy(&mut self, admin: Address, policy_type: PolicyType) -> Result<u64> {
-        self.require_write()?;
         let policy_type_u8 = policy_type.as_discriminant();
         if admin == Address::ZERO {
             return Err(BasePrecompileError::revert(IPolicyRegistry::ZeroAddress {}));
@@ -242,7 +233,6 @@ impl PolicyRegistryStorage<'_> {
 
     /// Completes a pending admin transfer; caller must be the staged pending admin.
     pub fn finalize_update_admin(&mut self, policy_id: u64) -> Result<()> {
-        self.require_write()?;
         let packed = self.require_custom(policy_id)?;
         let pending = self.pending_admins.at(&policy_id).read()?;
         if pending == Address::ZERO {


### PR DESCRIPTION
## Motivation

`PolicyRegistryStorage` had a `require_write` helper that checked `is_static` and returned `StaticCallViolation` before any mutating operation. The real EVM storage provider already enforces this at the `sstore`, `tstore`, and `emit_event` level, making the precompile-level check redundant in production.

The reason `require_write` existed was that `HashMapStorageProvider` (used in unit tests) did not enforce the static flag on writes, so without the explicit check the static-context tests would pass when they should have failed. This was a gap in the test provider, not a feature of the precompile.

## What changed

- `HashMapStorageProvider`: `sstore`, `tstore`, and `emit_event` now return `StaticCallViolation` when `is_static` is set, matching the behavior of `EvmPrecompileStorageProvider`.
- `PolicyRegistryStorage`: removed `require_write` and its three call sites (`require_admin`, `create_policy`, `finalize_update_admin`). The storage layer now enforces the invariant without help from the precompile.

## What was tried / considered

- Keeping `require_write` as a defense-in-depth early exit: the only concrete benefit would be saving a few storage reads on static calls, which is not a meaningful optimization for a policy registry that is not on the per-transfer hot path for these mutating operations. Redundant enforcement at two layers is harder to reason about and maintain.