### PR TITLE
fix(precompiles): Default Security Share Ratio

### DIFF
--- a/crates/common/precompiles/src/b20_security/dispatch.rs
+++ b/crates/common/precompiles/src/b20_security/dispatch.rs
@@ -639,12 +639,12 @@ impl<S: SecurityAccounting, P: Policy> B20SecurityToken<S, P> {
 mod tests {
     use alloy_primitives::{Address, B256, U256};
     use alloy_sol_types::SolEvent;
-    use base_precompile_storage::BasePrecompileError;
+    use base_precompile_storage::{BasePrecompileError, StorageCtx, setup_storage};
 
     use super::{BURN_FROM_ROLE, REDEEM_SENDER_POLICY, SECURITY_OPERATOR_ROLE};
     use crate::{
-        B20PausableFeature, IB20, Token, TokenAccounting,
-        b20_security::{B20SecurityToken, IB20Security, SecurityAccounting},
+        B20PausableFeature, IB20, PolicyHandle, Token, TokenAccounting,
+        b20_security::{B20SecurityStorage, B20SecurityToken, IB20Security, SecurityAccounting},
         common::test_utils::{InMemoryPolicy, InMemoryTokenAccounting},
     };
 
@@ -759,12 +759,12 @@ mod tests {
     #[test]
     fn security_redeem_rejects_zero_shares() {
         let mut token = make_token();
-        token.accounting_mut().shares_to_tokens_ratio = U256::ZERO;
+        token.accounting_mut().shares_to_tokens_ratio = WAD / U256::from(2u64);
         token.accounting_mut().balances.insert(ALICE, U256::from(100u64));
         token.accounting_mut().total_supply = U256::from(100u64);
 
-        // 0 ratio → 0 shares → always rejected
-        assert!(token.security_redeem(ALICE, U256::from(50u64)).is_err());
+        // 1 token * 0.5 WAD / WAD truncates to 0 shares, which is always rejected.
+        assert!(token.security_redeem(ALICE, U256::ONE).is_err());
     }
 
     #[test]
@@ -1017,6 +1017,27 @@ mod tests {
         // sharesOf(account) = toShares(balanceOf(account))
         let balance = token.accounting().balance_of(ALICE).unwrap();
         assert_eq!(token.to_shares(balance).unwrap(), U256::from(75u64));
+    }
+
+    #[test]
+    fn storage_backed_redeem_uses_wad_when_share_ratio_slot_is_unset() {
+        let (mut storage, _) = setup_storage();
+
+        StorageCtx::enter(&mut storage, |ctx| {
+            let mut token = B20SecurityToken::with_storage_and_policy(
+                B20SecurityStorage::from_address(TOKEN, ctx),
+                PolicyHandle::new(ctx),
+            );
+            token.accounting_mut().set_balance(ALICE, U256::from(100u64)).unwrap();
+            token.accounting_mut().set_total_supply(U256::from(100u64)).unwrap();
+            token.accounting_mut().set_minimum_redeemable(U256::from(10u64)).unwrap();
+
+            assert_eq!(token.accounting().shares_to_tokens_ratio().unwrap(), WAD);
+            token.security_redeem(ALICE, U256::from(10u64)).unwrap();
+
+            assert_eq!(token.accounting().balance_of(ALICE).unwrap(), U256::from(90u64));
+            assert_eq!(token.accounting().total_supply().unwrap(), U256::from(90u64));
+        });
     }
 
     // --- updateShareRatio: persistence ---

--- a/crates/common/precompiles/src/b20_security/storage.rs
+++ b/crates/common/precompiles/src/b20_security/storage.rs
@@ -11,6 +11,9 @@ use base_precompile_storage::{
 use super::{accounting::SecurityAccounting, ids::REDEEM_SENDER_POLICY};
 use crate::{B20CoreStorage, B20PolicyType, B20TokenRole, IB20, TokenAccounting, TokenVariant};
 
+/// WAD precision for share ratio arithmetic: 1e18.
+const WAD: U256 = U256::from_limbs([1_000_000_000_000_000_000, 0, 0, 0]);
+
 /// Security-specific B-20 storage rooted at the `base.b20.security` ERC-7201 namespace.
 #[derive(Debug, Clone, Storable)]
 #[namespace("base.b20.security")]
@@ -333,7 +336,8 @@ impl B20SecurityStorage<'_> {
 
 impl SecurityAccounting for B20SecurityStorage<'_> {
     fn shares_to_tokens_ratio(&self) -> Result<U256> {
-        self.security.shares_to_tokens_ratio.read()
+        let ratio = self.security.shares_to_tokens_ratio.read()?;
+        Ok(if ratio.is_zero() { WAD } else { ratio })
     }
 
     fn set_shares_to_tokens_ratio(&mut self, ratio: U256) -> Result<()> {
@@ -381,9 +385,9 @@ mod tests {
 
     use super::{
         __packing_b20_redeem_storage, __packing_b20_security_extension_storage, B20RedeemStorage,
-        B20SecurityExtensionStorage, B20SecurityStorage, REDEEM_SENDER_POLICY, slots,
+        B20SecurityExtensionStorage, B20SecurityStorage, REDEEM_SENDER_POLICY, WAD, slots,
     };
-    use crate::{B20CoreStorage, TokenAccounting};
+    use crate::{B20CoreStorage, SecurityAccounting, TokenAccounting};
 
     const TOKEN: Address = address!("000000000000000000000000000000000000b021");
     const B20_ROOT: U256 =
@@ -425,6 +429,43 @@ mod tests {
         assert_eq!(__packing_b20_security_extension_storage::IDENTIFIERS_LOC.offset_slots, 2);
         assert_eq!(__packing_b20_redeem_storage::MINIMUM_REDEEMABLE_LOC.offset_slots, 0);
         assert_eq!(__packing_b20_redeem_storage::REDEEM_POLICY_IDS_LOC.offset_slots, 1);
+    }
+
+    #[test]
+    fn shares_to_tokens_ratio_defaults_unset_slot_to_wad() {
+        let (mut storage, _) = setup_storage();
+
+        StorageCtx::enter(&mut storage, |ctx| {
+            let token = B20SecurityStorage::from_address(TOKEN, ctx);
+            let ratio_slot = SECURITY_ROOT
+                + U256::from(
+                    __packing_b20_security_extension_storage::SHARES_TO_TOKENS_RATIO_LOC
+                        .offset_slots,
+                );
+
+            assert_eq!(ctx.sload(TOKEN, ratio_slot).unwrap(), U256::ZERO);
+            assert_eq!(token.shares_to_tokens_ratio().unwrap(), WAD);
+        });
+    }
+
+    #[test]
+    fn shares_to_tokens_ratio_preserves_configured_value() {
+        let (mut storage, _) = setup_storage();
+        let configured_ratio = WAD * U256::from(3u64);
+
+        StorageCtx::enter(&mut storage, |ctx| {
+            let mut token = B20SecurityStorage::from_address(TOKEN, ctx);
+            token.set_shares_to_tokens_ratio(configured_ratio).unwrap();
+
+            let ratio_slot = SECURITY_ROOT
+                + U256::from(
+                    __packing_b20_security_extension_storage::SHARES_TO_TOKENS_RATIO_LOC
+                        .offset_slots,
+                );
+
+            assert_eq!(ctx.sload(TOKEN, ratio_slot).unwrap(), configured_ratio);
+            assert_eq!(token.shares_to_tokens_ratio().unwrap(), configured_ratio);
+        });
     }
 
     #[test]

--- a/crates/common/precompiles/src/common/test_utils.rs
+++ b/crates/common/precompiles/src/common/test_utils.rs
@@ -385,7 +385,8 @@ impl PolicyRegistry for InMemoryPolicy {
 
 impl SecurityAccounting for InMemoryTokenAccounting {
     fn shares_to_tokens_ratio(&self) -> Result<U256> {
-        Ok(self.shares_to_tokens_ratio)
+        const WAD: U256 = U256::from_limbs([1_000_000_000_000_000_000, 0, 0, 0]);
+        Ok(if self.shares_to_tokens_ratio.is_zero() { WAD } else { self.shares_to_tokens_ratio })
     }
 
     fn set_shares_to_tokens_ratio(&mut self, ratio: U256) -> Result<()> {


### PR DESCRIPTION
## Summary

This defaults an unset security B-20 share ratio storage slot to WAD so zero-filled storage behaves as the intended 1:1 ratio. It also adds storage and dispatch regression tests that cover both the default read path and storage-backed redeem accounting.