### PR TITLE
fix(builder): share runtime DA and gas configs

### DIFF
--- a/bin/builder/src/main.rs
+++ b/bin/builder/src/main.rs
@@ -33,8 +33,12 @@ fn main() {
         let builder_config = builder_args
             .into_builder_config(Arc::clone(&metering_provider))
             .expect("Failed to convert rollup args to builder config");
+        let da_config = builder_config.da_config.clone();
+        let gas_limit_config = builder_config.gas_limit_config.clone();
 
         let mut runner = BaseNodeRunner::new(rollup_args)
+            .with_da_config(da_config)
+            .with_gas_limit_config(gas_limit_config)
             .with_service_builder(FlashblocksServiceBuilder(builder_config));
         runner.install_ext::<MeteringStoreExtension>(metering_provider);
         runner.install_ext::<TxPoolRpcExtension>(TxPoolRpcConfig::default());

--- a/crates/execution/runner/src/runner.rs
+++ b/crates/execution/runner/src/runner.rs
@@ -2,7 +2,7 @@
 
 use std::fmt;
 
-use base_execution_payload_builder::config::BaseDAConfig;
+use base_execution_payload_builder::config::{BaseDAConfig, GasLimitConfig};
 use base_node_core::args::RollupArgs;
 use eyre::Result;
 use reth_node_builder::{Node, NodeHandle, NodeHandleFor};
@@ -32,8 +32,10 @@ pub struct BaseNodeRunner<SB: PayloadServiceBuilder = DefaultPayloadServiceBuild
     extensions: Vec<Box<dyn BaseNodeExtension>>,
     /// Payload service builder.
     service_builder: SB,
-    /// Shared DA configuration for the node and metering extension.
+    /// Shared DA configuration for the node and payload builder.
     da_config: Option<BaseDAConfig>,
+    /// Shared gas-limit configuration for the node and payload builder.
+    gas_limit_config: Option<GasLimitConfig>,
     /// Binary-owned callbacks to run after the node has started.
     started_callbacks: Vec<StartedCallback>,
 }
@@ -46,6 +48,7 @@ impl BaseNodeRunner<DefaultPayloadServiceBuilder> {
             extensions: Vec::new(),
             service_builder: DefaultPayloadServiceBuilder,
             da_config: None,
+            gas_limit_config: None,
             started_callbacks: Vec::new(),
         }
     }
@@ -57,6 +60,7 @@ impl<SB: PayloadServiceBuilder> fmt::Debug for BaseNodeRunner<SB> {
             .field("rollup_args", &self.rollup_args)
             .field("extensions", &self.extensions.len())
             .field("da_config", &self.da_config)
+            .field("gas_limit_config", &self.gas_limit_config)
             .field("started_callbacks", &self.started_callbacks.len())
             .finish()
     }
@@ -69,6 +73,12 @@ impl<SB: PayloadServiceBuilder> BaseNodeRunner<SB> {
         self
     }
 
+    /// Sets the shared gas-limit configuration.
+    pub fn with_gas_limit_config(mut self, gas_limit_config: GasLimitConfig) -> Self {
+        self.gas_limit_config = Some(gas_limit_config);
+        self
+    }
+
     /// Swap the payload service builder.
     pub fn with_service_builder<SB2: PayloadServiceBuilder>(self, sb: SB2) -> BaseNodeRunner<SB2> {
         BaseNodeRunner {
@@ -76,6 +86,7 @@ impl<SB: PayloadServiceBuilder> BaseNodeRunner<SB> {
             extensions: self.extensions,
             service_builder: sb,
             da_config: self.da_config,
+            gas_limit_config: self.gas_limit_config,
             started_callbacks: self.started_callbacks,
         }
     }
@@ -105,12 +116,20 @@ impl<SB: PayloadServiceBuilder> BaseNodeRunner<SB> {
     /// Applies all Base-specific wiring to the supplied builder and returns a launched node
     /// handle without waiting for shutdown.
     pub async fn launch(self, builder: BaseNodeBuilder) -> Result<LaunchedBaseNode> {
-        let Self { rollup_args, extensions, service_builder, da_config, started_callbacks } = self;
+        let Self {
+            rollup_args,
+            extensions,
+            service_builder,
+            da_config,
+            gas_limit_config,
+            started_callbacks,
+        } = self;
         let handle = Self::launch_node(
             rollup_args,
             extensions,
             service_builder,
             da_config,
+            gas_limit_config,
             started_callbacks,
             builder,
         )
@@ -123,6 +142,7 @@ impl<SB: PayloadServiceBuilder> BaseNodeRunner<SB> {
         extensions: Vec<Box<dyn BaseNodeExtension>>,
         service_builder: SB,
         da_config: Option<BaseDAConfig>,
+        gas_limit_config: Option<GasLimitConfig>,
         started_callbacks: Vec<StartedCallback>,
         builder: BaseNodeBuilder,
     ) -> Result<NodeHandleFor<BaseNode>> {
@@ -131,6 +151,9 @@ impl<SB: PayloadServiceBuilder> BaseNodeRunner<SB> {
         let mut base_node = BaseNode::new(rollup_args);
         if let Some(da_config) = da_config {
             base_node = base_node.with_da_config(da_config);
+        }
+        if let Some(gas_limit_config) = gas_limit_config {
+            base_node = base_node.with_gas_limit_config(gas_limit_config);
         }
         let components = service_builder.build_components(&base_node);
 
@@ -146,5 +169,46 @@ impl<SB: PayloadServiceBuilder> BaseNodeRunner<SB> {
             .fold(hooks, |hooks, callback| hooks.add_node_started_hook(move |_| callback()));
 
         hooks.apply_to(builder).launch().await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Debug)]
+    struct TestPayloadServiceBuilder;
+
+    impl crate::service::PayloadServiceBuilder for TestPayloadServiceBuilder {
+        type ComponentsBuilder = crate::types::BaseComponentsBuilder;
+
+        fn build_components(self, base_node: &BaseNode) -> Self::ComponentsBuilder {
+            base_node.components()
+        }
+    }
+
+    #[test]
+    fn service_builder_swap_preserves_shared_runtime_configs() {
+        let da_config = BaseDAConfig::new(100, 200);
+        let gas_limit_config = GasLimitConfig::new(30_000_000);
+
+        let runner = BaseNodeRunner::new(RollupArgs::default())
+            .with_da_config(da_config.clone())
+            .with_gas_limit_config(gas_limit_config.clone())
+            .with_service_builder(TestPayloadServiceBuilder);
+
+        let configured_da = runner.da_config.expect("DA config should be preserved");
+        let configured_gas = runner.gas_limit_config.expect("gas-limit config should be preserved");
+
+        assert_eq!(configured_da.max_da_tx_size(), Some(100));
+        assert_eq!(configured_da.max_da_block_size(), Some(200));
+        assert_eq!(configured_gas.gas_limit(), Some(30_000_000));
+
+        da_config.set_max_da_size(300, 400);
+        gas_limit_config.set_gas_limit(40_000_000);
+
+        assert_eq!(configured_da.max_da_tx_size(), Some(300));
+        assert_eq!(configured_da.max_da_block_size(), Some(400));
+        assert_eq!(configured_gas.gas_limit(), Some(40_000_000));
     }
 }


### PR DESCRIPTION
## Summary

Fix the combined Flashblocks builder wiring so runtime miner RPC updates reach the config objects used by block building.

The production builder was constructing `BuilderConfig` with its own `BaseDAConfig` and `GasLimitConfig`, then launching `BaseNodeRunner` without passing those shared objects into the node/add-ons path. That meant:

- `miner_setMaxDASize` updated the RPC/add-ons copy, while Flashblocks read `BuilderConfig.da_config`
- `miner_setGasLimit` updated the RPC/add-ons copy, while Flashblocks read `BuilderConfig.gas_limit_config`

This PR makes `bin/builder` clone the shared DA and gas-limit config objects out of `BuilderConfig` and install those same objects into `BaseNodeRunner`. It also adds `BaseNodeRunner::with_gas_limit_config` and preserves both runtime configs across service-builder swaps.

## Notes

The split was introduced by #682 (`0d8c9af5489839da76f4c9631e12b11e393b6550`), when builder startup moved to `BaseNodeRunner::new(...).with_service_builder(FlashblocksServiceBuilder(builder_config))` and stopped explicitly wiring the shared DA/gas config into the add-ons path.

This is the same bug class as #1115, which fixed the duplicated `MeteringStore` wiring after #682. This PR fixes the remaining runtime configs in that class.

## Testing

- `cargo check -p base-node-runner --lib`
- `cargo check -p base-builder-bin --bin base-builder`
- `cargo test -p base-node-runner --lib service_builder_swap_preserves_shared_runtime_configs` currently fails before compiling this test because this checkout is missing generated Foundry artifacts required by `base-test-utils` (`crates/utilities/test-utils/contracts/out/.../*.json`).
