### PR TITLE
fix(precompiles): Align B20 Admin Count Storage

### DIFF
--- a/crates/common/precompiles/src/b20/storage.rs
+++ b/crates/common/precompiles/src/b20/storage.rs
@@ -43,8 +43,8 @@ pub struct B20CoreStorage {
     pub roles: Mapping<B256, Mapping<Address, bool>>, // offset 6
     /// Admin role configured for each role.
     pub role_admins: Mapping<B256, B256>, // offset 7
-    /// Packed default-admin count and initialization flag.
-    pub admin_count_and_initialized: U256, // offset 8
+    /// Default-admin holder count.
+    pub admin_count: U256, // offset 8
     /// Packed transfer-side policy IDs.
     pub transfer_policy_ids: U256, // offset 9: sender, receiver, executor, reserved
     /// Packed mint-side policy IDs.
@@ -179,7 +179,7 @@ impl TokenAccounting for B20TokenStorage<'_> {
 
     fn role_member_count(&self, role: B256) -> Result<U256> {
         if role == B20TokenRole::DefaultAdmin.id() {
-            Ok(Self::read_admin_count(self.b20.admin_count_and_initialized.read()?))
+            self.b20.admin_count.read()
         } else {
             Ok(U256::ZERO)
         }
@@ -187,8 +187,7 @@ impl TokenAccounting for B20TokenStorage<'_> {
 
     fn set_role_member_count(&mut self, role: B256, count: U256) -> Result<()> {
         if role == B20TokenRole::DefaultAdmin.id() {
-            let packed = self.b20.admin_count_and_initialized.read()?;
-            self.b20.admin_count_and_initialized.write(Self::write_admin_count(packed, count)?)
+            self.b20.admin_count.write(count)
         } else {
             Ok(())
         }
@@ -273,28 +272,11 @@ impl TokenAccounting for B20TokenStorage<'_> {
 }
 
 impl B20TokenStorage<'_> {
-    const ADMIN_COUNT_BITS: usize = 248;
     const TRANSFER_SENDER_POLICY_LANE: usize = 0;
     const TRANSFER_RECEIVER_POLICY_LANE: usize = 1;
     const TRANSFER_EXECUTOR_POLICY_LANE: usize = 2;
     const MINT_RECEIVER_POLICY_LANE: usize = 0;
     const POLICY_LANE_BITS: usize = 64;
-
-    fn admin_count_mask() -> U256 {
-        (U256::ONE << Self::ADMIN_COUNT_BITS) - U256::ONE
-    }
-
-    fn read_admin_count(packed: U256) -> U256 {
-        packed & Self::admin_count_mask()
-    }
-
-    fn write_admin_count(packed: U256, count: U256) -> Result<U256> {
-        let mask = Self::admin_count_mask();
-        if count > mask {
-            return Err(BasePrecompileError::under_overflow());
-        }
-        Ok((packed & !mask) | count)
-    }
 
     fn require_policy_type(policy_type: B256) -> Result<B20PolicyType> {
         B20PolicyType::from_id(policy_type).ok_or_else(|| {
@@ -343,7 +325,7 @@ mod tests {
         assert_eq!(__packing_b20_core_storage::ALLOWANCES_LOC.offset_slots, 5);
         assert_eq!(__packing_b20_core_storage::ROLES_LOC.offset_slots, 6);
         assert_eq!(__packing_b20_core_storage::ROLE_ADMINS_LOC.offset_slots, 7);
-        assert_eq!(__packing_b20_core_storage::ADMIN_COUNT_AND_INITIALIZED_LOC.offset_slots, 8);
+        assert_eq!(__packing_b20_core_storage::ADMIN_COUNT_LOC.offset_slots, 8);
         assert_eq!(__packing_b20_core_storage::TRANSFER_POLICY_IDS_LOC.offset_slots, 9);
         assert_eq!(__packing_b20_core_storage::MINT_POLICY_IDS_LOC.offset_slots, 10);
         assert_eq!(__packing_b20_core_storage::PAUSED_LOC.offset_slots, 11);
@@ -371,10 +353,8 @@ mod tests {
                 B20_ROOT + U256::from(__packing_b20_core_storage::ALLOWANCES_LOC.offset_slots);
             let roles_slot =
                 B20_ROOT + U256::from(__packing_b20_core_storage::ROLES_LOC.offset_slots);
-            let admin_count_slot = B20_ROOT
-                + U256::from(
-                    __packing_b20_core_storage::ADMIN_COUNT_AND_INITIALIZED_LOC.offset_slots,
-                );
+            let admin_count_slot =
+                B20_ROOT + U256::from(__packing_b20_core_storage::ADMIN_COUNT_LOC.offset_slots);
 
             assert_eq!(
                 ctx.sload(TOKEN, holder.mapping_slot(balances_slot)).unwrap(),

--- a/crates/common/precompiles/src/b20_security/storage.rs
+++ b/crates/common/precompiles/src/b20_security/storage.rs
@@ -182,7 +182,7 @@ impl TokenAccounting for B20SecurityStorage<'_> {
 
     fn role_member_count(&self, role: B256) -> Result<U256> {
         if role == B20TokenRole::DefaultAdmin.id() {
-            Ok(Self::read_admin_count(self.b20.admin_count_and_initialized.read()?))
+            self.b20.admin_count.read()
         } else {
             Ok(U256::ZERO)
         }
@@ -190,8 +190,7 @@ impl TokenAccounting for B20SecurityStorage<'_> {
 
     fn set_role_member_count(&mut self, role: B256, count: U256) -> Result<()> {
         if role == B20TokenRole::DefaultAdmin.id() {
-            let packed = self.b20.admin_count_and_initialized.read()?;
-            self.b20.admin_count_and_initialized.write(Self::write_admin_count(packed, count)?)
+            self.b20.admin_count.write(count)
         } else {
             Ok(())
         }
@@ -290,29 +289,12 @@ impl TokenAccounting for B20SecurityStorage<'_> {
 }
 
 impl B20SecurityStorage<'_> {
-    const ADMIN_COUNT_BITS: usize = 248;
     const TRANSFER_SENDER_POLICY_LANE: usize = 0;
     const TRANSFER_RECEIVER_POLICY_LANE: usize = 1;
     const TRANSFER_EXECUTOR_POLICY_LANE: usize = 2;
     const MINT_RECEIVER_POLICY_LANE: usize = 0;
     const REDEEM_SENDER_POLICY_LANE: usize = 0;
     const POLICY_LANE_BITS: usize = 64;
-
-    fn admin_count_mask() -> U256 {
-        (U256::ONE << Self::ADMIN_COUNT_BITS) - U256::ONE
-    }
-
-    fn read_admin_count(packed: U256) -> U256 {
-        packed & Self::admin_count_mask()
-    }
-
-    fn write_admin_count(packed: U256, count: U256) -> Result<U256> {
-        let mask = Self::admin_count_mask();
-        if count > mask {
-            return Err(BasePrecompileError::under_overflow());
-        }
-        Ok((packed & !mask) | count)
-    }
 
     fn require_b20_policy_type(policy_type: B256) -> Result<B20PolicyType> {
         B20PolicyType::from_id(policy_type).ok_or_else(|| {

--- a/crates/common/precompiles/src/b20_stablecoin/storage.rs
+++ b/crates/common/precompiles/src/b20_stablecoin/storage.rs
@@ -166,7 +166,7 @@ impl TokenAccounting for B20StablecoinStorage<'_> {
 
     fn role_member_count(&self, role: B256) -> Result<U256> {
         if role == B20TokenRole::DefaultAdmin.id() {
-            Ok(Self::read_admin_count(self.b20.admin_count_and_initialized.read()?))
+            self.b20.admin_count.read()
         } else {
             Ok(U256::ZERO)
         }
@@ -174,8 +174,7 @@ impl TokenAccounting for B20StablecoinStorage<'_> {
 
     fn set_role_member_count(&mut self, role: B256, count: U256) -> Result<()> {
         if role == B20TokenRole::DefaultAdmin.id() {
-            let packed = self.b20.admin_count_and_initialized.read()?;
-            self.b20.admin_count_and_initialized.write(Self::write_admin_count(packed, count)?)
+            self.b20.admin_count.write(count)
         } else {
             Ok(())
         }
@@ -260,28 +259,11 @@ impl TokenAccounting for B20StablecoinStorage<'_> {
 }
 
 impl B20StablecoinStorage<'_> {
-    const ADMIN_COUNT_BITS: usize = 248;
     const TRANSFER_SENDER_POLICY_LANE: usize = 0;
     const TRANSFER_RECEIVER_POLICY_LANE: usize = 1;
     const TRANSFER_EXECUTOR_POLICY_LANE: usize = 2;
     const MINT_RECEIVER_POLICY_LANE: usize = 0;
     const POLICY_LANE_BITS: usize = 64;
-
-    fn admin_count_mask() -> U256 {
-        (U256::ONE << Self::ADMIN_COUNT_BITS) - U256::ONE
-    }
-
-    fn read_admin_count(packed: U256) -> U256 {
-        packed & Self::admin_count_mask()
-    }
-
-    fn write_admin_count(packed: U256, count: U256) -> Result<U256> {
-        let mask = Self::admin_count_mask();
-        if count > mask {
-            return Err(BasePrecompileError::under_overflow());
-        }
-        Ok((packed & !mask) | count)
-    }
 
     fn require_policy_type(policy_type: B256) -> Result<B20PolicyType> {
         B20PolicyType::from_id(policy_type).ok_or_else(|| {


### PR DESCRIPTION
## Summary

This updates the Rust B20 storage layout so the default-admin count is stored directly in its own slot. It removes the obsolete admin-count and initialized bit-packing path from the default, stablecoin, and security token storage adapters. This keeps Rust aligned with the current base-std layout while continuing to leave the initialized flag out of Rust storage.