### PR TITLE
rename(b20): policyType -> policyScope in IB20 ABI (BOP-147)

### DIFF
--- a/crates/common/precompiles/src/b20/abi.rs
+++ b/crates/common/precompiles/src/b20/abi.rs
@@ -30,9 +30,9 @@ sol! {
         error EmptyFeatureSet();
         error InvalidSupplyCap(uint256 currentSupply, uint256 proposedCap);
         error SupplyCapExceeded(uint256 cap, uint256 attempted);
-        error PolicyForbids(bytes32 policyType, uint64 policyId);
+        error PolicyForbids(bytes32 policyScope, uint64 policyId);
         error PolicyNotFound(uint64 policyId);
-        error UnsupportedPolicyType(bytes32 policyType);
+        error UnsupportedPolicyType(bytes32 policyScope);
         error AccountNotBlocked(address account);
         error ExpiredSignature(uint256 deadline);
         error InvalidSigner(address signer, address owner);
@@ -51,7 +51,7 @@ sol! {
         event LastAdminRenounced(address indexed previousAdmin);
         event Paused(address indexed updater, PausableFeature[] features);
         event Unpaused(address indexed updater, PausableFeature[] features);
-        event PolicyUpdated(bytes32 indexed policyType, uint64 oldPolicyId, uint64 newPolicyId);
+        event PolicyUpdated(bytes32 indexed policyScope, uint64 oldPolicyId, uint64 newPolicyId);
         event SupplyCapUpdated(address indexed updater, uint256 oldSupplyCap, uint256 newSupplyCap);
         event ContractURIUpdated();
         event NameUpdated(address indexed updater, string newName);
@@ -114,8 +114,8 @@ sol! {
         function unpause(PausableFeature[] calldata features) external;
 
         // Policy
-        function policyId(bytes32 policyType) external view returns (uint64);
-        function updatePolicy(bytes32 policyType, uint64 newPolicyId) external;
+        function policyId(bytes32 policyScope) external view returns (uint64);
+        function updatePolicy(bytes32 policyScope, uint64 newPolicyId) external;
 
         // Supply cap
         function supplyCap() external view returns (uint256);

--- a/crates/common/precompiles/src/b20/dispatch.rs
+++ b/crates/common/precompiles/src/b20/dispatch.rs
@@ -74,7 +74,7 @@ impl<S: TokenAccounting, P: Policy> B20Token<S, P> {
             C::hasRole(c) => self.has_role(c.role, c.account)?.abi_encode().into(),
             C::getRoleAdmin(c) => self.role_admin(c.role)?.abi_encode().into(),
             C::pausedFeatures(_) => self.paused_features()?.abi_encode().into(),
-            C::policyId(c) => self.policy_id(c.policyType)?.abi_encode().into(),
+            C::policyId(c) => self.policy_id(c.policyScope)?.abi_encode().into(),
 
             // --- Domain reads (light logic) ---
             C::isPaused(c) => self.is_paused(c.feature)?.abi_encode().into(),
@@ -201,7 +201,7 @@ impl<S: TokenAccounting, P: Policy> B20Token<S, P> {
             }
             C::updatePolicy(c) => {
                 let caller = ctx.caller();
-                self.update_policy(caller, c.policyType, c.newPolicyId, privileged)?;
+                self.update_policy(caller, c.policyScope, c.newPolicyId, privileged)?;
                 Bytes::new()
             }
 

--- a/crates/common/precompiles/src/b20/policies.rs
+++ b/crates/common/precompiles/src/b20/policies.rs
@@ -77,33 +77,33 @@ impl<S: TokenAccounting, P: Policy> B20Token<S, P> {
         B20PolicyType::MintReceiver.id()
     }
 
-    /// Returns the configured policy ID for `policy_type`.
-    pub fn policy_id(&self, policy_type: B256) -> Result<u64> {
-        Self::ensure_supported_policy_type(policy_type)?;
-        self.accounting.policy_id(policy_type)
+    /// Returns the configured policy ID for `policy_scope`.
+    pub fn policy_id(&self, policy_scope: B256) -> Result<u64> {
+        Self::ensure_supported_policy_type(policy_scope)?;
+        self.accounting.policy_id(policy_scope)
     }
 
-    /// Updates the configured policy ID for `policy_type`.
+    /// Updates the configured policy ID for `policy_scope`.
     pub fn update_policy(
         &mut self,
         caller: Address,
-        policy_type: B256,
+        policy_scope: B256,
         new_policy_id: u64,
         privileged: bool,
     ) -> Result<()> {
         if !privileged {
             B20Guards::ensure_token_role(self, caller, B20TokenRole::DefaultAdmin)?;
         }
-        let old_policy_id = self.policy_id(policy_type)?;
+        let old_policy_id = self.policy_id(policy_scope)?;
         if !self.policy.policy_exists(new_policy_id)? {
             return Err(BasePrecompileError::revert(IB20::PolicyNotFound {
                 policyId: new_policy_id,
             }));
         }
-        self.accounting_mut().set_policy_id(policy_type, new_policy_id)?;
+        self.accounting_mut().set_policy_id(policy_scope, new_policy_id)?;
         self.accounting_mut().emit_event(
             IB20::PolicyUpdated {
-                policyScope: policy_type,
+                policyScope: policy_scope,
                 oldPolicyId: old_policy_id,
                 newPolicyId: new_policy_id,
             }
@@ -111,13 +111,13 @@ impl<S: TokenAccounting, P: Policy> B20Token<S, P> {
         )
     }
 
-    /// Ensures `policy_type` names a B-20 policy slot.
-    pub fn ensure_supported_policy_type(policy_type: B256) -> Result<()> {
-        if B20PolicyType::from_id(policy_type).is_some() {
+    /// Ensures `policy_scope` names a B-20 policy slot.
+    pub fn ensure_supported_policy_type(policy_scope: B256) -> Result<()> {
+        if B20PolicyType::from_id(policy_scope).is_some() {
             Ok(())
         } else {
             Err(BasePrecompileError::revert(IB20::UnsupportedPolicyType {
-                policyScope: policy_type,
+                policyScope: policy_scope,
             }))
         }
     }
@@ -143,11 +143,11 @@ mod tests {
     #[test]
     fn policy_id_reverts_for_unsupported_policy_type() {
         let token = token();
-        let policy_type = B256::repeat_byte(0x99);
+        let policy_scope = B256::repeat_byte(0x99);
 
         assert_eq!(
-            token.policy_id(policy_type).unwrap_err(),
-            BasePrecompileError::revert(IB20::UnsupportedPolicyType { policyScope: policy_type })
+            token.policy_id(policy_scope).unwrap_err(),
+            BasePrecompileError::revert(IB20::UnsupportedPolicyType { policyScope: policy_scope })
         );
     }
 

--- a/crates/common/precompiles/src/b20/policies.rs
+++ b/crates/common/precompiles/src/b20/policies.rs
@@ -103,7 +103,7 @@ impl<S: TokenAccounting, P: Policy> B20Token<S, P> {
         self.accounting_mut().set_policy_id(policy_type, new_policy_id)?;
         self.accounting_mut().emit_event(
             IB20::PolicyUpdated {
-                policyType: policy_type,
+                policyScope: policy_type,
                 oldPolicyId: old_policy_id,
                 newPolicyId: new_policy_id,
             }
@@ -117,7 +117,7 @@ impl<S: TokenAccounting, P: Policy> B20Token<S, P> {
             Ok(())
         } else {
             Err(BasePrecompileError::revert(IB20::UnsupportedPolicyType {
-                policyType: policy_type,
+                policyScope: policy_type,
             }))
         }
     }
@@ -147,7 +147,7 @@ mod tests {
 
         assert_eq!(
             token.policy_id(policy_type).unwrap_err(),
-            BasePrecompileError::revert(IB20::UnsupportedPolicyType { policyType: policy_type })
+            BasePrecompileError::revert(IB20::UnsupportedPolicyType { policyScope: policy_type })
         );
     }
 

--- a/crates/common/precompiles/src/b20/storage.rs
+++ b/crates/common/precompiles/src/b20/storage.rs
@@ -280,7 +280,7 @@ impl B20TokenStorage<'_> {
 
     fn require_policy_type(policy_type: B256) -> Result<B20PolicyType> {
         B20PolicyType::from_id(policy_type).ok_or_else(|| {
-            BasePrecompileError::revert(IB20::UnsupportedPolicyType { policyType: policy_type })
+            BasePrecompileError::revert(IB20::UnsupportedPolicyType { policyScope: policy_type })
         })
     }
 

--- a/crates/common/precompiles/src/b20/storage.rs
+++ b/crates/common/precompiles/src/b20/storage.rs
@@ -206,8 +206,8 @@ impl TokenAccounting for B20TokenStorage<'_> {
         self.b20.role_admins.at_mut(&role).write(admin_role)
     }
 
-    fn policy_id(&self, policy_type: B256) -> Result<u64> {
-        let policy_type = Self::require_policy_type(policy_type)?;
+    fn policy_id(&self, policy_scope: B256) -> Result<u64> {
+        let policy_type = Self::require_policy_type(policy_scope)?;
         match policy_type {
             B20PolicyType::TransferSender => Ok(Self::read_policy_lane(
                 self.b20.transfer_policy_ids.read()?,
@@ -228,8 +228,8 @@ impl TokenAccounting for B20TokenStorage<'_> {
         }
     }
 
-    fn set_policy_id(&mut self, policy_type: B256, policy_id: u64) -> Result<()> {
-        let policy_type = Self::require_policy_type(policy_type)?;
+    fn set_policy_id(&mut self, policy_scope: B256, policy_id: u64) -> Result<()> {
+        let policy_type = Self::require_policy_type(policy_scope)?;
         match policy_type {
             B20PolicyType::TransferSender => {
                 let packed = Self::write_policy_lane(
@@ -278,9 +278,9 @@ impl B20TokenStorage<'_> {
     const MINT_RECEIVER_POLICY_LANE: usize = 0;
     const POLICY_LANE_BITS: usize = 64;
 
-    fn require_policy_type(policy_type: B256) -> Result<B20PolicyType> {
-        B20PolicyType::from_id(policy_type).ok_or_else(|| {
-            BasePrecompileError::revert(IB20::UnsupportedPolicyType { policyScope: policy_type })
+    fn require_policy_type(policy_scope: B256) -> Result<B20PolicyType> {
+        B20PolicyType::from_id(policy_scope).ok_or_else(|| {
+            BasePrecompileError::revert(IB20::UnsupportedPolicyType { policyScope: policy_scope })
         })
     }
 

--- a/crates/common/precompiles/src/b20_security/dispatch.rs
+++ b/crates/common/precompiles/src/b20_security/dispatch.rs
@@ -38,7 +38,7 @@ impl<S: SecurityAccounting, P: Policy> B20SecurityToken<S, P> {
             Ok(())
         } else {
             Err(BasePrecompileError::revert(IB20::UnsupportedPolicyType {
-                policyType: policy_type,
+                policyScope: policy_type,
             }))
         }
     }
@@ -70,7 +70,7 @@ impl<S: SecurityAccounting, P: Policy> B20SecurityToken<S, P> {
         self.accounting_mut().set_policy_id(policy_type, new_policy_id)?;
         self.accounting_mut().emit_event(
             IB20::PolicyUpdated {
-                policyType: policy_type,
+                policyScope: policy_type,
                 oldPolicyId: old_policy_id,
                 newPolicyId: new_policy_id,
             }
@@ -162,7 +162,7 @@ impl<S: SecurityAccounting, P: Policy> B20SecurityToken<S, P> {
             C::isPaused(c) => self.is_paused(c.feature)?.abi_encode().into(),
 
             // --- Policy reads ---
-            C::policyId(c) => self.policy_id_checked(c.policyType)?.abi_encode().into(),
+            C::policyId(c) => self.policy_id_checked(c.policyScope)?.abi_encode().into(),
 
             // --- Domain reads ---
             C::DOMAIN_SEPARATOR(_) => self.domain_separator(ctx.chain_id())?.abi_encode().into(),
@@ -292,7 +292,7 @@ impl<S: SecurityAccounting, P: Policy> B20SecurityToken<S, P> {
             // --- Policy mutations ---
             C::updatePolicy(c) => {
                 let caller = ctx.caller();
-                self.update_policy(caller, c.policyType, c.newPolicyId, privileged)?;
+                self.update_policy(caller, c.policyScope, c.newPolicyId, privileged)?;
                 Bytes::new()
             }
 
@@ -797,7 +797,7 @@ mod tests {
         assert_eq!(
             token.security_redeem(ALICE, U256::from(1u64)).unwrap_err(),
             BasePrecompileError::revert(IB20::PolicyForbids {
-                policyType: REDEEM_SENDER_POLICY,
+                policyScope: REDEEM_SENDER_POLICY,
                 policyId: policy_id,
             })
         );

--- a/crates/common/precompiles/src/b20_security/dispatch.rs
+++ b/crates/common/precompiles/src/b20_security/dispatch.rs
@@ -31,46 +31,46 @@ use crate::{
 const WAD: U256 = U256::from_limbs([1_000_000_000_000_000_000, 0, 0, 0]);
 
 impl<S: SecurityAccounting, P: Policy> B20SecurityToken<S, P> {
-    /// Ensures `policy_type` names either an inherited B-20 policy slot or the
+    /// Ensures `policy_scope` names either an inherited B-20 policy slot or the
     /// security redeem slot.
-    fn ensure_supported_policy_type(policy_type: B256) -> base_precompile_storage::Result<()> {
-        if B20PolicyType::from_id(policy_type).is_some() || policy_type == REDEEM_SENDER_POLICY {
+    fn ensure_supported_policy_type(policy_scope: B256) -> base_precompile_storage::Result<()> {
+        if B20PolicyType::from_id(policy_scope).is_some() || policy_scope == REDEEM_SENDER_POLICY {
             Ok(())
         } else {
             Err(BasePrecompileError::revert(IB20::UnsupportedPolicyType {
-                policyScope: policy_type,
+                policyScope: policy_scope,
             }))
         }
     }
 
-    /// Returns the configured policy ID for `policy_type`.
-    fn policy_id_checked(&self, policy_type: B256) -> base_precompile_storage::Result<u64> {
-        Self::ensure_supported_policy_type(policy_type)?;
-        self.accounting.policy_id(policy_type)
+    /// Returns the configured policy ID for `policy_scope`.
+    fn policy_id_checked(&self, policy_scope: B256) -> base_precompile_storage::Result<u64> {
+        Self::ensure_supported_policy_type(policy_scope)?;
+        self.accounting.policy_id(policy_scope)
     }
 
-    /// Updates the configured policy ID for `policy_type`.
+    /// Updates the configured policy ID for `policy_scope`.
     fn update_policy(
         &mut self,
         caller: Address,
-        policy_type: B256,
+        policy_scope: B256,
         new_policy_id: u64,
         privileged: bool,
     ) -> base_precompile_storage::Result<()> {
-        Self::ensure_supported_policy_type(policy_type)?;
+        Self::ensure_supported_policy_type(policy_scope)?;
         if !privileged {
             self.ensure_role(caller, Self::default_admin_role())?;
         }
-        let old_policy_id = self.accounting.policy_id(policy_type)?;
+        let old_policy_id = self.accounting.policy_id(policy_scope)?;
         if !self.policy().policy_exists(new_policy_id)? {
             return Err(BasePrecompileError::revert(IB20::PolicyNotFound {
                 policyId: new_policy_id,
             }));
         }
-        self.accounting_mut().set_policy_id(policy_type, new_policy_id)?;
+        self.accounting_mut().set_policy_id(policy_scope, new_policy_id)?;
         self.accounting_mut().emit_event(
             IB20::PolicyUpdated {
-                policyScope: policy_type,
+                policyScope: policy_scope,
                 oldPolicyId: old_policy_id,
                 newPolicyId: new_policy_id,
             }

--- a/crates/common/precompiles/src/b20_security/storage.rs
+++ b/crates/common/precompiles/src/b20_security/storage.rs
@@ -212,14 +212,14 @@ impl TokenAccounting for B20SecurityStorage<'_> {
         self.b20.role_admins.at_mut(&role).write(admin_role)
     }
 
-    fn policy_id(&self, policy_type: B256) -> Result<u64> {
-        if policy_type == REDEEM_SENDER_POLICY {
+    fn policy_id(&self, policy_scope: B256) -> Result<u64> {
+        if policy_scope == REDEEM_SENDER_POLICY {
             return Ok(Self::read_policy_lane(
                 self.redeem.redeem_policy_ids.read()?,
                 Self::REDEEM_SENDER_POLICY_LANE,
             ));
         }
-        let policy_type = Self::require_b20_policy_type(policy_type)?;
+        let policy_type = Self::require_b20_policy_type(policy_scope)?;
         match policy_type {
             B20PolicyType::TransferSender => Ok(Self::read_policy_lane(
                 self.b20.transfer_policy_ids.read()?,
@@ -240,8 +240,8 @@ impl TokenAccounting for B20SecurityStorage<'_> {
         }
     }
 
-    fn set_policy_id(&mut self, policy_type: B256, policy_id: u64) -> Result<()> {
-        if policy_type == REDEEM_SENDER_POLICY {
+    fn set_policy_id(&mut self, policy_scope: B256, policy_id: u64) -> Result<()> {
+        if policy_scope == REDEEM_SENDER_POLICY {
             let packed = Self::write_policy_lane(
                 self.redeem.redeem_policy_ids.read()?,
                 Self::REDEEM_SENDER_POLICY_LANE,
@@ -249,7 +249,7 @@ impl TokenAccounting for B20SecurityStorage<'_> {
             );
             return self.redeem.redeem_policy_ids.write(packed);
         }
-        let policy_type = Self::require_b20_policy_type(policy_type)?;
+        let policy_type = Self::require_b20_policy_type(policy_scope)?;
         match policy_type {
             B20PolicyType::TransferSender => {
                 let packed = Self::write_policy_lane(
@@ -299,9 +299,9 @@ impl B20SecurityStorage<'_> {
     const REDEEM_SENDER_POLICY_LANE: usize = 0;
     const POLICY_LANE_BITS: usize = 64;
 
-    fn require_b20_policy_type(policy_type: B256) -> Result<B20PolicyType> {
-        B20PolicyType::from_id(policy_type).ok_or_else(|| {
-            BasePrecompileError::revert(IB20::UnsupportedPolicyType { policyScope: policy_type })
+    fn require_b20_policy_type(policy_scope: B256) -> Result<B20PolicyType> {
+        B20PolicyType::from_id(policy_scope).ok_or_else(|| {
+            BasePrecompileError::revert(IB20::UnsupportedPolicyType { policyScope: policy_scope })
         })
     }
 

--- a/crates/common/precompiles/src/b20_security/storage.rs
+++ b/crates/common/precompiles/src/b20_security/storage.rs
@@ -301,7 +301,7 @@ impl B20SecurityStorage<'_> {
 
     fn require_b20_policy_type(policy_type: B256) -> Result<B20PolicyType> {
         B20PolicyType::from_id(policy_type).ok_or_else(|| {
-            BasePrecompileError::revert(IB20::UnsupportedPolicyType { policyType: policy_type })
+            BasePrecompileError::revert(IB20::UnsupportedPolicyType { policyScope: policy_type })
         })
     }
 

--- a/crates/common/precompiles/src/b20_stablecoin/dispatch.rs
+++ b/crates/common/precompiles/src/b20_stablecoin/dispatch.rs
@@ -88,7 +88,7 @@ impl<S: StablecoinAccounting, P: Policy> B20StablecoinToken<S, P> {
             C::hasRole(c) => self.has_role(c.role, c.account)?.abi_encode().into(),
             C::getRoleAdmin(c) => self.role_admin(c.role)?.abi_encode().into(),
             C::pausedFeatures(_) => self.paused_features()?.abi_encode().into(),
-            C::policyId(c) => self.policy_id(c.policyType)?.abi_encode().into(),
+            C::policyId(c) => self.policy_id(c.policyScope)?.abi_encode().into(),
 
             // --- Domain reads (light logic) ---
             C::isPaused(c) => self.is_paused(c.feature)?.abi_encode().into(),
@@ -215,7 +215,7 @@ impl<S: StablecoinAccounting, P: Policy> B20StablecoinToken<S, P> {
             }
             C::updatePolicy(c) => {
                 let caller = ctx.caller();
-                self.update_policy(caller, c.policyType, c.newPolicyId, privileged)?;
+                self.update_policy(caller, c.policyScope, c.newPolicyId, privileged)?;
                 Bytes::new()
             }
 

--- a/crates/common/precompiles/src/b20_stablecoin/storage.rs
+++ b/crates/common/precompiles/src/b20_stablecoin/storage.rs
@@ -267,7 +267,7 @@ impl B20StablecoinStorage<'_> {
 
     fn require_policy_type(policy_type: B256) -> Result<B20PolicyType> {
         B20PolicyType::from_id(policy_type).ok_or_else(|| {
-            BasePrecompileError::revert(IB20::UnsupportedPolicyType { policyType: policy_type })
+            BasePrecompileError::revert(IB20::UnsupportedPolicyType { policyScope: policy_type })
         })
     }
 

--- a/crates/common/precompiles/src/b20_stablecoin/storage.rs
+++ b/crates/common/precompiles/src/b20_stablecoin/storage.rs
@@ -193,8 +193,8 @@ impl TokenAccounting for B20StablecoinStorage<'_> {
         self.b20.role_admins.at_mut(&role).write(admin_role)
     }
 
-    fn policy_id(&self, policy_type: B256) -> Result<u64> {
-        let policy_type = Self::require_policy_type(policy_type)?;
+    fn policy_id(&self, policy_scope: B256) -> Result<u64> {
+        let policy_type = Self::require_policy_type(policy_scope)?;
         match policy_type {
             B20PolicyType::TransferSender => Ok(Self::read_policy_lane(
                 self.b20.transfer_policy_ids.read()?,
@@ -215,8 +215,8 @@ impl TokenAccounting for B20StablecoinStorage<'_> {
         }
     }
 
-    fn set_policy_id(&mut self, policy_type: B256, policy_id: u64) -> Result<()> {
-        let policy_type = Self::require_policy_type(policy_type)?;
+    fn set_policy_id(&mut self, policy_scope: B256, policy_id: u64) -> Result<()> {
+        let policy_type = Self::require_policy_type(policy_scope)?;
         match policy_type {
             B20PolicyType::TransferSender => {
                 let packed = Self::write_policy_lane(
@@ -265,9 +265,9 @@ impl B20StablecoinStorage<'_> {
     const MINT_RECEIVER_POLICY_LANE: usize = 0;
     const POLICY_LANE_BITS: usize = 64;
 
-    fn require_policy_type(policy_type: B256) -> Result<B20PolicyType> {
-        B20PolicyType::from_id(policy_type).ok_or_else(|| {
-            BasePrecompileError::revert(IB20::UnsupportedPolicyType { policyScope: policy_type })
+    fn require_policy_type(policy_scope: B256) -> Result<B20PolicyType> {
+        B20PolicyType::from_id(policy_scope).ok_or_else(|| {
+            BasePrecompileError::revert(IB20::UnsupportedPolicyType { policyScope: policy_scope })
         })
     }
 

--- a/crates/common/precompiles/src/b20_stablecoin/token.rs
+++ b/crates/common/precompiles/src/b20_stablecoin/token.rs
@@ -82,33 +82,33 @@ impl<S: StablecoinAccounting, P: Policy> B20StablecoinToken<S, P> {
         B20PolicyType::MintReceiver.id()
     }
 
-    /// Returns the configured policy ID for `policy_type`.
-    pub fn policy_id(&self, policy_type: B256) -> Result<u64> {
-        Self::ensure_supported_policy_type(policy_type)?;
-        self.accounting.policy_id(policy_type)
+    /// Returns the configured policy ID for `policy_scope`.
+    pub fn policy_id(&self, policy_scope: B256) -> Result<u64> {
+        Self::ensure_supported_policy_type(policy_scope)?;
+        self.accounting.policy_id(policy_scope)
     }
 
-    /// Updates the configured policy ID for `policy_type`.
+    /// Updates the configured policy ID for `policy_scope`.
     pub fn update_policy(
         &mut self,
         caller: Address,
-        policy_type: B256,
+        policy_scope: B256,
         new_policy_id: u64,
         privileged: bool,
     ) -> Result<()> {
         if !privileged {
             B20Guards::ensure_token_role(self, caller, B20TokenRole::DefaultAdmin)?;
         }
-        let old_policy_id = self.policy_id(policy_type)?;
+        let old_policy_id = self.policy_id(policy_scope)?;
         if !self.policy.policy_exists(new_policy_id)? {
             return Err(BasePrecompileError::revert(IB20::PolicyNotFound {
                 policyId: new_policy_id,
             }));
         }
-        self.accounting_mut().set_policy_id(policy_type, new_policy_id)?;
+        self.accounting_mut().set_policy_id(policy_scope, new_policy_id)?;
         self.accounting_mut().emit_event(
             IB20::PolicyUpdated {
-                policyScope: policy_type,
+                policyScope: policy_scope,
                 oldPolicyId: old_policy_id,
                 newPolicyId: new_policy_id,
             }
@@ -116,13 +116,13 @@ impl<S: StablecoinAccounting, P: Policy> B20StablecoinToken<S, P> {
         )
     }
 
-    /// Ensures `policy_type` names a B-20 policy slot.
-    pub fn ensure_supported_policy_type(policy_type: B256) -> Result<()> {
-        if B20PolicyType::from_id(policy_type).is_some() {
+    /// Ensures `policy_scope` names a B-20 policy slot.
+    pub fn ensure_supported_policy_type(policy_scope: B256) -> Result<()> {
+        if B20PolicyType::from_id(policy_scope).is_some() {
             Ok(())
         } else {
             Err(BasePrecompileError::revert(IB20::UnsupportedPolicyType {
-                policyScope: policy_type,
+                policyScope: policy_scope,
             }))
         }
     }

--- a/crates/common/precompiles/src/b20_stablecoin/token.rs
+++ b/crates/common/precompiles/src/b20_stablecoin/token.rs
@@ -108,7 +108,7 @@ impl<S: StablecoinAccounting, P: Policy> B20StablecoinToken<S, P> {
         self.accounting_mut().set_policy_id(policy_type, new_policy_id)?;
         self.accounting_mut().emit_event(
             IB20::PolicyUpdated {
-                policyType: policy_type,
+                policyScope: policy_type,
                 oldPolicyId: old_policy_id,
                 newPolicyId: new_policy_id,
             }
@@ -122,7 +122,7 @@ impl<S: StablecoinAccounting, P: Policy> B20StablecoinToken<S, P> {
             Ok(())
         } else {
             Err(BasePrecompileError::revert(IB20::UnsupportedPolicyType {
-                policyType: policy_type,
+                policyScope: policy_type,
             }))
         }
     }

--- a/crates/common/precompiles/src/common/ops/guards.rs
+++ b/crates/common/precompiles/src/common/ops/guards.rs
@@ -54,7 +54,7 @@ impl B20Guards {
         Self::ensure_policy(token, policy_type.id(), account)
     }
 
-    /// Ensures `account` is allowed by the raw `policy_type`.
+    /// Ensures `account` is allowed by the raw `policy_scope`.
     ///
     /// All policy IDs, including built-ins, are delegated to the configured policy registry.
     pub fn ensure_policy<T: Token + ?Sized>(

--- a/crates/common/precompiles/src/common/ops/guards.rs
+++ b/crates/common/precompiles/src/common/ops/guards.rs
@@ -67,7 +67,7 @@ impl B20Guards {
             Ok(())
         } else {
             Err(BasePrecompileError::revert(IB20::PolicyForbids {
-                policyType: policy_type,
+                policyScope: policy_type,
                 policyId: policy_id,
             }))
         }
@@ -118,7 +118,7 @@ mod tests {
             B20Guards::ensure_policy_type(&token, B20PolicyType::TransferSender, denied)
                 .unwrap_err(),
             BasePrecompileError::revert(IB20::PolicyForbids {
-                policyType: B20PolicyType::TransferSender.id(),
+                policyScope: B20PolicyType::TransferSender.id(),
                 policyId: EXTERNAL_POLICY_ID,
             })
         );

--- a/crates/common/precompiles/src/common/ops/guards.rs
+++ b/crates/common/precompiles/src/common/ops/guards.rs
@@ -59,15 +59,15 @@ impl B20Guards {
     /// All policy IDs, including built-ins, are delegated to the configured policy registry.
     pub fn ensure_policy<T: Token + ?Sized>(
         token: &T,
-        policy_type: B256,
+        policy_scope: B256,
         account: Address,
     ) -> Result<()> {
-        let policy_id = token.accounting().policy_id(policy_type)?;
+        let policy_id = token.accounting().policy_id(policy_scope)?;
         if token.policy().is_authorized(policy_id, account)? {
             Ok(())
         } else {
             Err(BasePrecompileError::revert(IB20::PolicyForbids {
-                policyScope: policy_type,
+                policyScope: policy_scope,
                 policyId: policy_id,
             }))
         }
@@ -77,8 +77,8 @@ impl B20Guards {
     ///
     /// Accounts are blocked when the configured registry policy does not authorize them.
     pub fn ensure_blocked<T: Token + ?Sized>(token: &T, account: Address) -> Result<()> {
-        let policy_type = B20PolicyType::TransferSender.id();
-        let policy_id = token.accounting().policy_id(policy_type)?;
+        let policy_scope = B20PolicyType::TransferSender.id();
+        let policy_id = token.accounting().policy_id(policy_scope)?;
         if token.policy().is_authorized(policy_id, account)? {
             Err(BasePrecompileError::revert(IB20::AccountNotBlocked { account }))
         } else {

--- a/crates/common/precompiles/src/common/ops/mintable.rs
+++ b/crates/common/precompiles/src/common/ops/mintable.rs
@@ -200,7 +200,7 @@ mod tests {
         assert_eq!(
             token.mint(CALLER, ALICE, U256::ONE, true).unwrap_err(),
             BasePrecompileError::revert(IB20::PolicyForbids {
-                policyType: B20PolicyType::MintReceiver.id(),
+                policyScope: B20PolicyType::MintReceiver.id(),
                 policyId: PolicyRegistryStorage::ALWAYS_BLOCK_ID,
             })
         );

--- a/crates/common/precompiles/src/common/ops/transferable.rs
+++ b/crates/common/precompiles/src/common/ops/transferable.rs
@@ -346,7 +346,7 @@ mod tests {
         assert_eq!(
             token.transfer(ALICE, BOB, U256::ONE, false).unwrap_err(),
             BasePrecompileError::revert(IB20::PolicyForbids {
-                policyType: B20PolicyType::TransferSender.id(),
+                policyScope: B20PolicyType::TransferSender.id(),
                 policyId: PolicyRegistryStorage::ALWAYS_BLOCK_ID,
             })
         );
@@ -364,7 +364,7 @@ mod tests {
         assert_eq!(
             token.transfer(ALICE, BOB, U256::ONE, false).unwrap_err(),
             BasePrecompileError::revert(IB20::PolicyForbids {
-                policyType: B20PolicyType::TransferReceiver.id(),
+                policyScope: B20PolicyType::TransferReceiver.id(),
                 policyId: PolicyRegistryStorage::ALWAYS_BLOCK_ID,
             })
         );
@@ -383,7 +383,7 @@ mod tests {
         assert_eq!(
             token.transfer_from(SPENDER, ALICE, BOB, U256::ONE, false).unwrap_err(),
             BasePrecompileError::revert(IB20::PolicyForbids {
-                policyType: B20PolicyType::TransferExecutor.id(),
+                policyScope: B20PolicyType::TransferExecutor.id(),
                 policyId: PolicyRegistryStorage::ALWAYS_BLOCK_ID,
             })
         );
@@ -513,7 +513,7 @@ mod tests {
         assert_eq!(
             token.transfer(ALICE, BOB, U256::ONE, false).unwrap_err(),
             BasePrecompileError::revert(IB20::PolicyForbids {
-                policyType: B20PolicyType::TransferSender.id(),
+                policyScope: B20PolicyType::TransferSender.id(),
                 policyId: POLICY_ID,
             })
         );

--- a/crates/common/precompiles/src/common/test_utils.rs
+++ b/crates/common/precompiles/src/common/test_utils.rs
@@ -231,12 +231,12 @@ impl TokenAccounting for InMemoryTokenAccounting {
         Ok(())
     }
 
-    fn policy_id(&self, policy_type: B256) -> Result<u64> {
-        Ok(*self.policy_ids.get(&policy_type).unwrap_or(&PolicyRegistryStorage::ALWAYS_ALLOW_ID))
+    fn policy_id(&self, policy_scope: B256) -> Result<u64> {
+        Ok(*self.policy_ids.get(&policy_scope).unwrap_or(&PolicyRegistryStorage::ALWAYS_ALLOW_ID))
     }
 
-    fn set_policy_id(&mut self, policy_type: B256, policy_id: u64) -> Result<()> {
-        self.policy_ids.insert(policy_type, policy_id);
+    fn set_policy_id(&mut self, policy_scope: B256, policy_id: u64) -> Result<()> {
+        self.policy_ids.insert(policy_scope, policy_id);
         Ok(())
     }
 

--- a/crates/common/precompiles/src/common/token_accounting.rs
+++ b/crates/common/precompiles/src/common/token_accounting.rs
@@ -92,10 +92,10 @@ pub trait TokenAccounting {
 
     // --- Policies ---
 
-    /// Returns the policy ID assigned to `policy_type`.
-    fn policy_id(&self, policy_type: B256) -> Result<u64>;
-    /// Overwrites the policy ID assigned to `policy_type`.
-    fn set_policy_id(&mut self, policy_type: B256, policy_id: u64) -> Result<()>;
+    /// Returns the policy ID assigned to `policy_scope`.
+    fn policy_id(&self, policy_scope: B256) -> Result<u64>;
+    /// Overwrites the policy ID assigned to `policy_scope`.
+    fn set_policy_id(&mut self, policy_scope: B256, policy_id: u64) -> Result<()>;
 
     // --- Event emission ---
 


### PR DESCRIPTION
## Summary

Renames the `policyType` identifier (a `bytes32` slot key) to `policyScope` across the IB20 ABI and all Rust call sites. This eliminates the name collision with `PolicyType` (the ALLOWLIST/BLOCKLIST enum in `IPolicyRegistry`).

## What changed

**IB20 ABI** (`b20/abi.rs`) — renamed `bytes32 policyType` parameter to `bytes32 policyScope` in:
- `error PolicyForbids`
- `error UnsupportedPolicyType` (error name kept, only parameter renamed)
- `event PolicyUpdated`
- `function policyId`
- `function updatePolicy`

**Rust call sites** — renamed `policy_type: B256` parameters and local variables to `policy_scope`:
- `b20/policies.rs`, `b20/storage.rs`
- `b20_stablecoin/token.rs`, `b20_stablecoin/storage.rs`
- `b20_security/dispatch.rs`, `b20_security/storage.rs`
- `common/ops/guards.rs`
- `common/token_accounting.rs` (trait)

Not changed: `policy/` files and the `B20PolicyType` enum parameter in `ensure_policy_type` (those use the ALLOWLIST/BLOCKLIST concept, not the slot key).

## What was tried / considered

Shadowed locals that hold the converted `B20PolicyType` enum (produced by `require_policy_type`) are intentionally kept as `policy_type` to reflect their actual type.

Linked: BOP-147