### PR TITLE
test(b20): action tests for policy-gated transfers (BOP-129)

### DIFF
--- a/actions/harness/tests/beryl/b20_policy.rs
+++ b/actions/harness/tests/beryl/b20_policy.rs
@@ -1,0 +1,277 @@
+//! Action tests proving that B20 token transfers are gated by the policy registry.
+//!
+//! Each test activates TOKEN_FACTORY, B20_TOKEN, and POLICY_REGISTRY together,
+//! creates a token, wires a policy via `updatePolicy`, and asserts that transfers
+//! revert or succeed based on policy membership.
+
+use alloy_primitives::{Address, Bytes, TxKind, U256};
+use alloy_sol_types::SolCall;
+use base_common_consensus::{BaseBlock, BaseTxEnvelope};
+use base_common_precompiles::{B20PolicyType, IB20, IPolicyRegistry, PolicyRegistryStorage};
+
+use crate::env::BerylTestEnv;
+
+/// Transfer amount used in setup (seeding bob with tokens).
+const SEED_AMOUNT: U256 = U256::from_limbs([100_000, 0, 0, 0]);
+
+/// First custom policy has counter=2 (IDs 0 and 1 are reserved built-ins).
+const fn policy_id(policy_type: IPolicyRegistry::PolicyType, counter: u64) -> u64 {
+    (policy_type as u64) << 56 | counter
+}
+
+/// ALLOWLIST policy wired to TransferSender blocks non-members from sending.
+///
+/// 1. Alice seeds bob with tokens (default ALWAYS_ALLOW policy, succeeds).
+/// 2. Create ALLOWLIST policy; wire it to TransferSender.
+/// 3. Bob tries to transfer; reverts (not in allowlist).
+/// 4. Admin adds bob to the allowlist.
+/// 5. Bob transfers again; succeeds.
+#[tokio::test]
+async fn b20_allowlist_sender_policy_blocks_non_members() {
+    let mut scenario = B20PolicyScenario::new().await;
+
+    let seed_bob =
+        scenario.token_tx(IB20::transferCall { to: BerylTestEnv::bob(), amount: SEED_AMOUNT });
+    let block = scenario.build_block(vec![seed_bob]).await;
+    assert!(scenario.env.user_tx_succeeded(&block, 0), "seeding bob must succeed");
+
+    let allowlist_id = policy_id(IPolicyRegistry::PolicyType::ALLOWLIST, 2);
+    let create_policy = scenario.policy_tx(IPolicyRegistry::createPolicyCall {
+        admin: BerylTestEnv::alice(),
+        policyType: IPolicyRegistry::PolicyType::ALLOWLIST,
+    });
+    let block = scenario.build_block(vec![create_policy]).await;
+    assert!(scenario.env.user_tx_succeeded(&block, 0), "createPolicy(ALLOWLIST) must succeed");
+
+    let wire = scenario.token_tx(IB20::updatePolicyCall {
+        policyType: B20PolicyType::TransferSender.id(),
+        newPolicyId: allowlist_id,
+    });
+    let block = scenario.build_block(vec![wire]).await;
+    assert!(scenario.env.user_tx_succeeded(&block, 0), "updatePolicy must succeed");
+
+    let blocked = scenario
+        .bob_token_tx(IB20::transferCall { to: BerylTestEnv::carol(), amount: U256::from(1u64) });
+    let block = scenario.build_block(vec![blocked]).await;
+    assert!(
+        !scenario.env.user_tx_succeeded(&block, 0),
+        "transfer from non-member must revert when ALLOWLIST sender policy is set"
+    );
+
+    let add_bob = scenario.policy_tx(IPolicyRegistry::updateAllowlistCall {
+        policyId: allowlist_id,
+        allowed: true,
+        accounts: vec![BerylTestEnv::bob()],
+    });
+    let block = scenario.build_block(vec![add_bob]).await;
+    assert!(scenario.env.user_tx_succeeded(&block, 0), "updateAllowlist must succeed");
+
+    let allowed = scenario
+        .bob_token_tx(IB20::transferCall { to: BerylTestEnv::carol(), amount: U256::from(1u64) });
+    let block = scenario.build_block(vec![allowed]).await;
+    assert!(
+        scenario.env.user_tx_succeeded(&block, 0),
+        "transfer from allowlisted member must succeed"
+    );
+
+    scenario.derive().await;
+}
+
+/// BLOCKLIST policy wired to TransferSender blocks listed accounts from sending.
+///
+/// 1. Alice seeds bob with tokens (default ALWAYS_ALLOW policy, succeeds).
+/// 2. Create BLOCKLIST policy; wire it to TransferSender.
+/// 3. Bob transfers; succeeds (not in blocklist).
+/// 4. Admin adds bob to the blocklist.
+/// 5. Bob tries to transfer; reverts.
+#[tokio::test]
+async fn b20_blocklist_sender_policy_blocks_listed_accounts() {
+    let mut scenario = B20PolicyScenario::new().await;
+
+    let seed_bob =
+        scenario.token_tx(IB20::transferCall { to: BerylTestEnv::bob(), amount: SEED_AMOUNT });
+    let block = scenario.build_block(vec![seed_bob]).await;
+    assert!(scenario.env.user_tx_succeeded(&block, 0), "seeding bob must succeed");
+
+    let blocklist_id = policy_id(IPolicyRegistry::PolicyType::BLOCKLIST, 2);
+    let create_policy = scenario.policy_tx(IPolicyRegistry::createPolicyCall {
+        admin: BerylTestEnv::alice(),
+        policyType: IPolicyRegistry::PolicyType::BLOCKLIST,
+    });
+    let block = scenario.build_block(vec![create_policy]).await;
+    assert!(scenario.env.user_tx_succeeded(&block, 0), "createPolicy(BLOCKLIST) must succeed");
+
+    let wire = scenario.token_tx(IB20::updatePolicyCall {
+        policyType: B20PolicyType::TransferSender.id(),
+        newPolicyId: blocklist_id,
+    });
+    let block = scenario.build_block(vec![wire]).await;
+    assert!(scenario.env.user_tx_succeeded(&block, 0), "updatePolicy must succeed");
+
+    let first_transfer = scenario
+        .bob_token_tx(IB20::transferCall { to: BerylTestEnv::carol(), amount: U256::from(1u64) });
+    let block = scenario.build_block(vec![first_transfer]).await;
+    assert!(
+        scenario.env.user_tx_succeeded(&block, 0),
+        "transfer from non-blocked account must succeed"
+    );
+
+    let block_bob = scenario.policy_tx(IPolicyRegistry::updateBlocklistCall {
+        policyId: blocklist_id,
+        blocked: true,
+        accounts: vec![BerylTestEnv::bob()],
+    });
+    let block = scenario.build_block(vec![block_bob]).await;
+    assert!(scenario.env.user_tx_succeeded(&block, 0), "updateBlocklist must succeed");
+
+    let blocked = scenario
+        .bob_token_tx(IB20::transferCall { to: BerylTestEnv::carol(), amount: U256::from(1u64) });
+    let block = scenario.build_block(vec![blocked]).await;
+    assert!(
+        !scenario.env.user_tx_succeeded(&block, 0),
+        "transfer from blocked account must revert"
+    );
+
+    scenario.derive().await;
+}
+
+/// Wiring the built-in ALWAYS_BLOCK policy to TransferSender blocks every sender immediately.
+///
+/// No allowlist entries are needed: ALWAYS_BLOCK_ID denies all accounts unconditionally.
+#[tokio::test]
+async fn b20_always_block_sender_policy_blocks_all_transfers() {
+    let mut scenario = B20PolicyScenario::new().await;
+
+    let wire = scenario.token_tx(IB20::updatePolicyCall {
+        policyType: B20PolicyType::TransferSender.id(),
+        newPolicyId: PolicyRegistryStorage::ALWAYS_BLOCK_ID,
+    });
+    let block = scenario.build_block(vec![wire]).await;
+    assert!(scenario.env.user_tx_succeeded(&block, 0), "updatePolicy must succeed");
+
+    let blocked =
+        scenario.token_tx(IB20::transferCall { to: BerylTestEnv::bob(), amount: U256::from(1u64) });
+    let block = scenario.build_block(vec![blocked]).await;
+    assert!(
+        !scenario.env.user_tx_succeeded(&block, 0),
+        "transfer must revert when ALWAYS_BLOCK sender policy is set"
+    );
+
+    scenario.derive().await;
+}
+
+/// ALLOWLIST policy wired to TransferReceiver blocks non-members from receiving.
+#[tokio::test]
+async fn b20_allowlist_receiver_policy_blocks_non_members() {
+    let mut scenario = B20PolicyScenario::new().await;
+
+    let allowlist_id = policy_id(IPolicyRegistry::PolicyType::ALLOWLIST, 2);
+    let create_policy = scenario.policy_tx(IPolicyRegistry::createPolicyCall {
+        admin: BerylTestEnv::alice(),
+        policyType: IPolicyRegistry::PolicyType::ALLOWLIST,
+    });
+    let block = scenario.build_block(vec![create_policy]).await;
+    assert!(scenario.env.user_tx_succeeded(&block, 0), "createPolicy(ALLOWLIST) must succeed");
+
+    let wire = scenario.token_tx(IB20::updatePolicyCall {
+        policyType: B20PolicyType::TransferReceiver.id(),
+        newPolicyId: allowlist_id,
+    });
+    let block = scenario.build_block(vec![wire]).await;
+    assert!(scenario.env.user_tx_succeeded(&block, 0), "updatePolicy must succeed");
+
+    let blocked =
+        scenario.token_tx(IB20::transferCall { to: BerylTestEnv::bob(), amount: U256::from(1u64) });
+    let block = scenario.build_block(vec![blocked]).await;
+    assert!(
+        !scenario.env.user_tx_succeeded(&block, 0),
+        "transfer to non-member must revert when ALLOWLIST receiver policy is set"
+    );
+
+    let add_bob = scenario.policy_tx(IPolicyRegistry::updateAllowlistCall {
+        policyId: allowlist_id,
+        allowed: true,
+        accounts: vec![BerylTestEnv::bob()],
+    });
+    let block = scenario.build_block(vec![add_bob]).await;
+    assert!(scenario.env.user_tx_succeeded(&block, 0), "updateAllowlist must succeed");
+
+    let allowed =
+        scenario.token_tx(IB20::transferCall { to: BerylTestEnv::bob(), amount: U256::from(1u64) });
+    let block = scenario.build_block(vec![allowed]).await;
+    assert!(
+        scenario.env.user_tx_succeeded(&block, 0),
+        "transfer to allowlisted receiver must succeed"
+    );
+
+    scenario.derive().await;
+}
+
+struct B20PolicyScenario {
+    env: BerylTestEnv,
+    token: Address,
+    blocks: Vec<(BaseBlock, u64)>,
+}
+
+impl B20PolicyScenario {
+    async fn new() -> Self {
+        let env = BerylTestEnv::new();
+        let token = env.b20_token_address();
+        let mut scenario = Self { env, token, blocks: Vec::new() };
+
+        scenario.build_block(vec![]).await;
+
+        let act_factory = scenario.env.activate_feature_tx(BerylTestEnv::token_factory_feature());
+        let act_b20 = scenario.env.activate_feature_tx(BerylTestEnv::b20_token_feature());
+        let act_policy = scenario.env.activate_feature_tx(BerylTestEnv::policy_registry_feature());
+        let block = scenario.build_block(vec![act_factory, act_b20, act_policy]).await;
+        assert!(scenario.env.user_tx_succeeded(&block, 0), "TOKEN_FACTORY activation must succeed");
+        assert!(scenario.env.user_tx_succeeded(&block, 1), "B20_TOKEN activation must succeed");
+        assert!(
+            scenario.env.user_tx_succeeded(&block, 2),
+            "POLICY_REGISTRY activation must succeed"
+        );
+
+        let create = scenario.env.create_b20_token_tx();
+        let block = scenario.build_block(vec![create]).await;
+        assert!(scenario.env.user_tx_succeeded(&block, 0), "B20 token creation must succeed");
+
+        scenario
+    }
+
+    async fn build_block(&mut self, txs: Vec<BaseTxEnvelope>) -> BaseBlock {
+        let block = self.env.sequencer.build_next_block_with_transactions(txs).await;
+        let block_number = self.blocks.len() as u64 + 1;
+        self.blocks.push((block.clone(), block_number));
+        block
+    }
+
+    fn token_tx(&self, call: impl SolCall) -> BaseTxEnvelope {
+        self.env.create_tx(
+            TxKind::Call(self.token),
+            Bytes::from(call.abi_encode()),
+            BerylTestEnv::B20_GAS_LIMIT,
+        )
+    }
+
+    fn bob_token_tx(&mut self, call: impl SolCall) -> BaseTxEnvelope {
+        self.env.create_bob_tx(
+            TxKind::Call(self.token),
+            Bytes::from(call.abi_encode()),
+            BerylTestEnv::B20_GAS_LIMIT,
+        )
+    }
+
+    fn policy_tx(&self, call: impl SolCall) -> BaseTxEnvelope {
+        self.env.create_tx(
+            TxKind::Call(PolicyRegistryStorage::ADDRESS),
+            Bytes::from(call.abi_encode()),
+            BerylTestEnv::B20_GAS_LIMIT,
+        )
+    }
+
+    async fn derive(mut self) {
+        let expected_safe_head = self.blocks.len() as u64;
+        self.env.derive_blocks(self.blocks, expected_safe_head).await;
+    }
+}

--- a/actions/harness/tests/beryl/main.rs
+++ b/actions/harness/tests/beryl/main.rs
@@ -2,6 +2,7 @@
 
 mod activation;
 mod b20;
+mod b20_policy;
 mod env;
 mod factory;
 mod policy_registry;


### PR DESCRIPTION
[BOP-129](https://linear.app/coinbase/issue/BOP-129/implement-policy-gating-in-transferabletransfer)

## Motivation

BOP-129 tracked the requirement to wire `policy.is_authorized()` into B20 token transfers. That implementation landed in PRs #2771 and #2856 (policy checks in `Transferable::transfer()` and `Mintable::mint()`, plus the `updatePolicy`/`policyId` ABI surface). What was missing were action-level tests that prove the full stack works end-to-end across a live Beryl node boundary.

## What changed

Added `actions/harness/tests/beryl/b20_policy.rs` with four action harness tests:

- `b20_allowlist_sender_policy_blocks_non_members`: creates an ALLOWLIST policy, wires it to the token's `TransferSender` slot via `updatePolicy`, asserts that a non-member sender is rejected, then adds the sender to the allowlist and asserts the transfer succeeds.
- `b20_blocklist_sender_policy_blocks_listed_accounts`: creates a BLOCKLIST policy wired to `TransferSender`, asserts a non-blocked sender succeeds, blocks the sender, and asserts the subsequent transfer reverts.
- `b20_always_block_sender_policy_blocks_all_transfers`: wires the built-in `ALWAYS_BLOCK_ID` to `TransferSender` and asserts that all transfers revert unconditionally.
- `b20_allowlist_receiver_policy_blocks_non_members`: creates an ALLOWLIST policy wired to `TransferReceiver`, asserts that transfers to unlisted receivers revert, then allowlists the receiver and asserts success.

Each test activates `TOKEN_FACTORY`, `B20_TOKEN`, and `POLICY_REGISTRY` together and drives the full create-policy, wire-policy, transfer flow through the action harness.

## What was tried / considered

**Using the existing `B20TokenScenario` struct**: the existing scenario only activates token features, not `POLICY_REGISTRY`. A new `B20PolicyScenario` is simpler than extending the existing one with optional policy activation.

**Reusing `PolicyRegistryScenario`**: that struct deploys a probe contract and is oriented around registry-level view queries. The token-centric flow needed its own lightweight scenario.

**Covering `TransferExecutor` policy**: `transferFrom` executor gating follows the same code path as sender gating and is already covered by unit tests in `transferable.rs`. The action tests focus on the two slots that are exercised by every direct transfer: sender and receiver.