### PR TITLE
fix(precompile-storage): charge EIP-8037 state gas in set_code for new accounts (BOP-127)

### DIFF
--- a/crates/common/precompile-storage/src/error.rs
+++ b/crates/common/precompile-storage/src/error.rs
@@ -103,7 +103,7 @@ impl BasePrecompileError {
     ///
     /// Internal dispatch diagnostics use compact, non-ABI revert data: unknown selectors return the
     /// raw selector bytes, and decode failures return `selector || utf8_error_string`.
-    pub fn into_precompile_result(self, gas: u64) -> PrecompileResult {
+    pub fn into_precompile_result(self, gas: u64, state_gas: u64) -> PrecompileResult {
         let bytes: Bytes = match self {
             Self::Revert(bytes) => bytes,
             Self::Panic(kind) => Panic { code: U256::from(kind as u32) }.abi_encode().into(),
@@ -124,7 +124,7 @@ impl BasePrecompileError {
                 bytes.into()
             }
         };
-        Ok(PrecompileOutput::revert(gas, bytes, 0))
+        Ok(PrecompileOutput::revert(gas, bytes, state_gas))
     }
 }
 
@@ -134,6 +134,7 @@ pub trait IntoPrecompileResult<T> {
     fn into_precompile_result(
         self,
         gas: u64,
+        state_gas: u64,
         encode_ok: impl FnOnce(T) -> Bytes,
     ) -> PrecompileResult;
 }
@@ -142,11 +143,12 @@ impl<T> IntoPrecompileResult<T> for Result<T> {
     fn into_precompile_result(
         self,
         gas: u64,
+        state_gas: u64,
         encode_ok: impl FnOnce(T) -> Bytes,
     ) -> PrecompileResult {
         match self {
-            Ok(res) => Ok(PrecompileOutput::new(gas, encode_ok(res), 0)),
-            Err(err) => err.into_precompile_result(gas),
+            Ok(res) => Ok(PrecompileOutput::new(gas, encode_ok(res), state_gas)),
+            Err(err) => err.into_precompile_result(gas, state_gas),
         }
     }
 }
@@ -161,7 +163,7 @@ mod tests {
     fn delegate_call_not_allowed_encodes_to_typed_revert() {
         let expected: Bytes = DelegateCallNotAllowed {}.abi_encode().into();
         let result =
-            BasePrecompileError::revert(DelegateCallNotAllowed {}).into_precompile_result(0);
+            BasePrecompileError::revert(DelegateCallNotAllowed {}).into_precompile_result(0, 0);
         let output = result.unwrap();
         assert!(output.is_revert());
         assert_eq!(output.bytes, expected);

--- a/crates/common/precompile-storage/src/evm.rs
+++ b/crates/common/precompile-storage/src/evm.rs
@@ -107,7 +107,13 @@ impl PrecompileStorageProvider for EvmPrecompileStorageProvider<'_> {
             // Yellow Paper G_sha3 + G_sha3word: cost of computing the stored code hash.
             let num_words = code_len.div_ceil(32) as u64;
             self.deduct_gas(KECCAK256.saturating_add(KECCAK256WORD.saturating_mul(num_words)))?;
-            // EIP-8037: state gas for account creation and code deposit.
+            // EIP-8037: both state gas charges are gated on is_new_account.
+            // create_state_gas covers the new account entry in the state trie.
+            // code_deposit_state_gas covers the new code object. Replacing code on an
+            // existing account is not a state-creating operation in the EIP-8037 model —
+            // the code slot already occupies a trie node — so it is intentionally excluded.
+            // In practice, precompile set_code is only called during factory token creation,
+            // where the target address is always a fresh account.
             self.deduct_state_gas(self.gas_params.create_state_gas())?;
             self.deduct_state_gas(self.gas_params.code_deposit_state_gas(code_len))?;
         }

--- a/crates/common/precompile-storage/src/evm.rs
+++ b/crates/common/precompile-storage/src/evm.rs
@@ -38,6 +38,7 @@ pub struct EvmPrecompileStorageProvider<'a> {
     timestamp: U256,
     chain_id: u64,
     beneficiary: Address,
+    state_gas_used: u64,
 }
 
 impl<'a> EvmPrecompileStorageProvider<'a> {
@@ -63,6 +64,7 @@ impl<'a> EvmPrecompileStorageProvider<'a> {
             timestamp,
             chain_id,
             beneficiary,
+            state_gas_used: 0,
         }
     }
 }
@@ -105,8 +107,9 @@ impl PrecompileStorageProvider for EvmPrecompileStorageProvider<'_> {
             // Yellow Paper G_sha3 + G_sha3word: cost of computing the stored code hash.
             let num_words = code_len.div_ceil(32) as u64;
             self.deduct_gas(KECCAK256.saturating_add(KECCAK256WORD.saturating_mul(num_words)))?;
-            // TODO: also charge create_state_gas + code_deposit_state_gas (Amsterdam EIP-8037)
-            // once GasParams upgrades to context-interface v17.
+            // EIP-8037: state gas for account creation and code deposit.
+            self.deduct_state_gas(self.gas_params.create_state_gas())?;
+            self.deduct_state_gas(self.gas_params.code_deposit_state_gas(code_len))?;
         }
 
         self.internals
@@ -206,6 +209,13 @@ impl PrecompileStorageProvider for EvmPrecompileStorageProvider<'_> {
         Ok(())
     }
 
+    fn deduct_state_gas(&mut self, gas: u64) -> Result<()> {
+        // No separate reservoir in the precompile context; state gas is drawn from regular gas.
+        self.deduct_gas(gas)?;
+        self.state_gas_used = self.state_gas_used.saturating_add(gas);
+        Ok(())
+    }
+
     fn refund_gas(&mut self, gas: i64) {
         self.gas.record_refund(gas);
     }
@@ -219,7 +229,7 @@ impl PrecompileStorageProvider for EvmPrecompileStorageProvider<'_> {
     }
 
     fn state_gas_used(&self) -> u64 {
-        0
+        self.state_gas_used
     }
 
     fn gas_refunded(&self) -> i64 {
@@ -266,5 +276,58 @@ impl PrecompileStorageProvider for EvmPrecompileStorageProvider<'_> {
 impl From<alloy_evm::EvmInternalsError> for BasePrecompileError {
     fn from(e: alloy_evm::EvmInternalsError) -> Self {
         Self::Fatal(e.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_primitives::Address;
+    use revm::{context_interface::cfg::GasParams, primitives::hardfork::SpecId, state::Bytecode};
+
+    use crate::{hashmap::HashMapStorageProvider, provider::PrecompileStorageProvider};
+
+    fn amsterdam_provider() -> HashMapStorageProvider {
+        let mut provider = HashMapStorageProvider::new(1);
+        provider.set_gas_params(GasParams::new_spec(SpecId::AMSTERDAM));
+        provider
+    }
+
+    /// `set_code` on a brand-new account must charge both `create_state_gas` and
+    /// `code_deposit_state_gas` against the state-gas counter.
+    #[test]
+    fn set_code_new_account_charges_create_and_deposit_state_gas() {
+        let mut provider = amsterdam_provider();
+        let addr = Address::from([0x42u8; 20]);
+        let code = Bytecode::new_raw([0x60u8, 0x00].as_ref().into());
+        let code_len = code.len();
+        let gas_params = GasParams::new_spec(SpecId::AMSTERDAM);
+
+        provider.set_code(addr, code).unwrap();
+
+        let expected = gas_params.create_state_gas() + gas_params.code_deposit_state_gas(code_len);
+        assert!(expected > 0, "AMSTERDAM state gas must be non-zero");
+        assert_eq!(provider.state_gas_used(), expected);
+    }
+
+    /// `set_code` on an already-initialised account must NOT charge any additional
+    /// state gas (the account and its metadata already exist in the trie).
+    #[test]
+    fn set_code_existing_account_skips_state_gas() {
+        let mut provider = amsterdam_provider();
+        let addr = Address::from([0x42u8; 20]);
+        let code = Bytecode::new_raw([0x60u8, 0x00].as_ref().into());
+
+        // First call creates the account and charges state gas.
+        provider.set_code(addr, code.clone()).unwrap();
+        let after_first = provider.state_gas_used();
+        assert!(after_first > 0);
+
+        // Second call updates an existing account; state gas must not increase.
+        provider.set_code(addr, code).unwrap();
+        assert_eq!(
+            provider.state_gas_used(),
+            after_first,
+            "state_gas_used must not increase for an existing account"
+        );
     }
 }

--- a/crates/common/precompile-storage/src/hashmap.rs
+++ b/crates/common/precompile-storage/src/hashmap.rs
@@ -89,7 +89,7 @@ impl PrecompileStorageProvider for HashMapStorageProvider {
     fn set_code(&mut self, address: Address, code: Bytecode) -> Result<(), BasePrecompileError> {
         let code_len = code.len();
         // Mirror the production is_new_account check so state gas tracking is faithful.
-        let is_new_account = self.accounts.get(&address).map_or(true, AccountInfo::is_empty);
+        let is_new_account = self.accounts.get(&address).is_none_or(AccountInfo::is_empty);
         if is_new_account {
             self.deduct_state_gas(self.gas_params.create_state_gas())?;
             self.deduct_state_gas(self.gas_params.code_deposit_state_gas(code_len))?;

--- a/crates/common/precompile-storage/src/hashmap.rs
+++ b/crates/common/precompile-storage/src/hashmap.rs
@@ -315,16 +315,6 @@ impl HashMapStorageProvider {
     pub fn set_gas_params(&mut self, gas_params: GasParams) {
         self.gas_params = gas_params;
     }
-
-    /// Returns the cumulative state gas charged so far (test-utils only).
-    pub fn get_state_gas_used(&self) -> u64 {
-        self.state_gas_used
-    }
-
-    /// Resets the state gas used counter (test-utils only).
-    pub fn reset_state_gas_used(&mut self) {
-        self.state_gas_used = 0;
-    }
 }
 
 /// Test helper: returns a fresh `(HashMapStorageProvider, precompile_address)` pair.

--- a/crates/common/precompile-storage/src/hashmap.rs
+++ b/crates/common/precompile-storage/src/hashmap.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 use alloy_primitives::{Address, LogData, U256};
 use revm::{
     context::journaled_state::JournalCheckpoint,
+    context_interface::cfg::GasParams,
     state::{AccountInfo, Bytecode},
 };
 
@@ -26,6 +27,8 @@ pub struct HashMapStorageProvider {
     counter_sload: u64,
     counter_sstore: u64,
     snapshots: Vec<Snapshot>,
+    gas_params: GasParams,
+    state_gas_used: u64,
     /// Emitted events keyed by contract address.
     pub events: HashMap<Address, Vec<LogData>>,
 }
@@ -60,6 +63,8 @@ impl HashMapStorageProvider {
             is_static: false,
             counter_sload: 0,
             counter_sstore: 0,
+            gas_params: GasParams::default(),
+            state_gas_used: 0,
         }
     }
 }
@@ -82,6 +87,13 @@ impl PrecompileStorageProvider for HashMapStorageProvider {
     }
 
     fn set_code(&mut self, address: Address, code: Bytecode) -> Result<(), BasePrecompileError> {
+        let code_len = code.len();
+        // Mirror the production is_new_account check so state gas tracking is faithful.
+        let is_new_account = self.accounts.get(&address).map_or(true, AccountInfo::is_empty);
+        if is_new_account {
+            self.deduct_state_gas(self.gas_params.create_state_gas())?;
+            self.deduct_state_gas(self.gas_params.code_deposit_state_gas(code_len))?;
+        }
         let account = self.accounts.entry(address).or_default();
         account.code_hash = code.hash_slow();
         account.code = Some(code);
@@ -149,6 +161,12 @@ impl PrecompileStorageProvider for HashMapStorageProvider {
         Ok(())
     }
 
+    fn deduct_state_gas(&mut self, gas: u64) -> Result<(), BasePrecompileError> {
+        // No gas limit in the test provider; just track the cumulative amount.
+        self.state_gas_used = self.state_gas_used.saturating_add(gas);
+        Ok(())
+    }
+
     fn refund_gas(&mut self, _gas: i64) {}
 
     fn gas_limit(&self) -> u64 {
@@ -160,7 +178,7 @@ impl PrecompileStorageProvider for HashMapStorageProvider {
     }
 
     fn state_gas_used(&self) -> u64 {
-        0
+        self.state_gas_used
     }
 
     fn gas_refunded(&self) -> i64 {
@@ -291,6 +309,21 @@ impl HashMapStorageProvider {
     /// Reads a storage slot directly without journal overhead (test-utils only).
     pub fn sload_direct(&self, address: Address, key: U256) -> U256 {
         self.internals.get(&(address, key)).copied().unwrap_or(U256::ZERO)
+    }
+
+    /// Overrides the gas parameters used for state gas accounting (test-utils only).
+    pub fn set_gas_params(&mut self, gas_params: GasParams) {
+        self.gas_params = gas_params;
+    }
+
+    /// Returns the cumulative state gas charged so far (test-utils only).
+    pub fn get_state_gas_used(&self) -> u64 {
+        self.state_gas_used
+    }
+
+    /// Resets the state gas used counter (test-utils only).
+    pub fn reset_state_gas_used(&mut self) {
+        self.state_gas_used = 0;
     }
 }
 

--- a/crates/common/precompile-storage/src/provider.rs
+++ b/crates/common/precompile-storage/src/provider.rs
@@ -62,10 +62,9 @@ pub trait PrecompileStorageProvider {
     fn gas_limit(&self) -> u64;
     /// Returns the gas used so far.
     fn gas_used(&self) -> u64;
-    /// Returns the state-creating gas spent so far (EIP-8037 reservoir model).
+    /// Returns the state-creating gas spent so far (EIP-8037).
     ///
-    /// Counts only state-creation operations: zero→nonzero SSTORE and code deposit.
-    /// Returns zero unless an EIP-8037 reservoir was provided at construction time.
+    /// Counts only new account creation and code deposit operations.
     fn state_gas_used(&self) -> u64;
     /// Returns the gas refunded so far.
     fn gas_refunded(&self) -> i64;

--- a/crates/common/precompile-storage/src/provider.rs
+++ b/crates/common/precompile-storage/src/provider.rs
@@ -50,6 +50,12 @@ pub trait PrecompileStorageProvider {
 
     /// Deducts gas from the remaining gas and returns an error if insufficient.
     fn deduct_gas(&mut self, gas: u64) -> Result<()>;
+    /// Deducts state-creating gas (EIP-8037 reservoir model).
+    ///
+    /// Counts only state-creation operations: new account creation and code deposit.
+    /// State gas is tracked separately from regular gas and also deducted from the
+    /// regular gas counter when no reservoir is available.
+    fn deduct_state_gas(&mut self, gas: u64) -> Result<()>;
     /// Adds a gas refund to the refund counter.
     fn refund_gas(&mut self, gas: i64);
     /// Returns the gas limit for this precompile call.

--- a/crates/common/precompile-storage/src/storage_ctx.rs
+++ b/crates/common/precompile-storage/src/storage_ctx.rs
@@ -192,7 +192,7 @@ impl<'a> StorageCtx<'a> {
     /// The `gas_refunded` field is populated so revm's frame handler can propagate it to the
     /// transaction-level refund counter, where the EIP-3529 cap (`gas_used / 5`) is applied.
     pub fn success_output(&self, output: Bytes) -> PrecompileOutput {
-        let mut out = PrecompileOutput::new(self.gas_used(), output, 0);
+        let mut out = PrecompileOutput::new(self.gas_used(), output, self.state_gas_used());
         out.gas_refunded = self.gas_refunded();
         out
     }
@@ -204,7 +204,7 @@ impl<'a> StorageCtx<'a> {
 
     /// Returns a revert [`PrecompileOutput`] with the current gas used.
     pub fn revert_output(&self, output: Bytes) -> PrecompileOutput {
-        PrecompileOutput::revert(self.gas_used(), output, 0)
+        PrecompileOutput::revert(self.gas_used(), output, self.state_gas_used())
     }
 
     /// Reverts with an ABI-encoded error.
@@ -214,7 +214,7 @@ impl<'a> StorageCtx<'a> {
 
     /// Returns a [`PrecompileResult`] constructed from the given error.
     pub fn error_result(&self, error: impl Into<BasePrecompileError>) -> PrecompileResult {
-        error.into().into_precompile_result(self.gas_used())
+        error.into().into_precompile_result(self.gas_used(), self.state_gas_used())
     }
 }
 

--- a/crates/common/precompiles/src/activation/dispatch.rs
+++ b/crates/common/precompiles/src/activation/dispatch.rs
@@ -20,8 +20,11 @@ impl ActivationRegistryStorage<'_> {
         activation_admin_address: Option<Address>,
     ) -> PrecompileResult {
         deduct_calldata_cost!(ctx, calldata);
-        self.inner(calldata, activation_admin_address)
-            .into_precompile_result(ctx.gas_used(), |output| output)
+        self.inner(calldata, activation_admin_address).into_precompile_result(
+            ctx.gas_used(),
+            ctx.state_gas_used(),
+            |output| output,
+        )
     }
 
     fn inner(

--- a/crates/common/precompiles/src/activation/storage.rs
+++ b/crates/common/precompiles/src/activation/storage.rs
@@ -87,8 +87,11 @@ impl ActivationRegistryStorage<'_> {
     /// [`revm::precompile::PrecompileOutput::reverted`] to distinguish an activated feature from an
     /// ABI revert.
     pub fn assert_activated(&self, feature: B256) -> PrecompileResult {
-        self.ensure_activated(feature)
-            .into_precompile_result(self.storage.gas_used(), |()| Bytes::new())
+        self.ensure_activated(feature).into_precompile_result(
+            self.storage.gas_used(),
+            self.storage.state_gas_used(),
+            |()| Bytes::new(),
+        )
     }
 
     /// Returns `Ok(())` when the feature is activated.

--- a/crates/common/precompiles/src/b20/dispatch.rs
+++ b/crates/common/precompiles/src/b20/dispatch.rs
@@ -22,11 +22,15 @@ impl<S: TokenAccounting, P: Policy> B20Token<S, P> {
             Ok(true) => {}
             Ok(false) => {
                 return BasePrecompileError::Revert(Bytes::new())
-                    .into_precompile_result(ctx.gas_used());
+                    .into_precompile_result(ctx.gas_used(), ctx.state_gas_used());
             }
-            Err(e) => return e.into_precompile_result(ctx.gas_used()),
+            Err(e) => return e.into_precompile_result(ctx.gas_used(), ctx.state_gas_used()),
         }
-        self.inner(ctx, calldata).into_precompile_result(ctx.gas_used(), |b| b)
+        self.inner(ctx, calldata).into_precompile_result(
+            ctx.gas_used(),
+            ctx.state_gas_used(),
+            |b| b,
+        )
     }
 
     /// Decodes calldata and executes the matching `IB20` operation.

--- a/crates/common/precompiles/src/b20_factory/dispatch.rs
+++ b/crates/common/precompiles/src/b20_factory/dispatch.rs
@@ -16,7 +16,7 @@ impl<'a> B20FactoryStorage<'a> {
         deduct_calldata_cost!(ctx, calldata);
         let result = self.inner(ctx, calldata);
         let gas = ctx.gas_used();
-        result.into_precompile_result(gas, |b| b)
+        result.into_precompile_result(gas, ctx.state_gas_used(), |b| b)
     }
 
     fn inner(

--- a/crates/common/precompiles/src/b20_security/dispatch.rs
+++ b/crates/common/precompiles/src/b20_security/dispatch.rs
@@ -88,11 +88,15 @@ impl<S: SecurityAccounting, P: Policy> B20SecurityToken<S, P> {
             Ok(true) => {}
             Ok(false) => {
                 return BasePrecompileError::Revert(Bytes::new())
-                    .into_precompile_result(ctx.gas_used());
+                    .into_precompile_result(ctx.gas_used(), ctx.state_gas_used());
             }
-            Err(e) => return e.into_precompile_result(ctx.gas_used()),
+            Err(e) => return e.into_precompile_result(ctx.gas_used(), ctx.state_gas_used()),
         }
-        self.inner(ctx, calldata).into_precompile_result(ctx.gas_used(), |b| b)
+        self.inner(ctx, calldata).into_precompile_result(
+            ctx.gas_used(),
+            ctx.state_gas_used(),
+            |b| b,
+        )
     }
 
     /// Decodes calldata and executes the matching `IB20Security` or inherited `IB20` operation.

--- a/crates/common/precompiles/src/b20_stablecoin/dispatch.rs
+++ b/crates/common/precompiles/src/b20_stablecoin/dispatch.rs
@@ -31,11 +31,15 @@ impl<S: StablecoinAccounting, P: Policy> B20StablecoinToken<S, P> {
             Ok(true) => {}
             Ok(false) => {
                 return BasePrecompileError::Revert(Bytes::new())
-                    .into_precompile_result(ctx.gas_used());
+                    .into_precompile_result(ctx.gas_used(), ctx.state_gas_used());
             }
-            Err(e) => return e.into_precompile_result(ctx.gas_used()),
+            Err(e) => return e.into_precompile_result(ctx.gas_used(), ctx.state_gas_used()),
         }
-        self.inner(ctx, calldata).into_precompile_result(ctx.gas_used(), |b| b)
+        self.inner(ctx, calldata).into_precompile_result(
+            ctx.gas_used(),
+            ctx.state_gas_used(),
+            |b| b,
+        )
     }
 
     /// Decodes calldata and executes the matching `IB20` operation.

--- a/crates/common/precompiles/src/macros.rs
+++ b/crates/common/precompiles/src/macros.rs
@@ -9,7 +9,7 @@ macro_rules! base_precompile {
                     return ::base_precompile_storage::BasePrecompileError::revert(
                         ::base_precompile_storage::DelegateCallNotAllowed {},
                     )
-                    .into_precompile_result(0);
+                    .into_precompile_result(0, 0);
                 }
 
                 let $calldata: ::alloy_primitives::Bytes = input.data.to_vec().into();
@@ -30,7 +30,7 @@ macro_rules! base_precompile {
                     return ::base_precompile_storage::BasePrecompileError::revert(
                         ::base_precompile_storage::DelegateCallNotAllowed {},
                     )
-                    .into_precompile_result(0);
+                    .into_precompile_result(0, 0);
                 }
 
                 let $calldata: ::alloy_primitives::Bytes = $input.data.to_vec().into();
@@ -52,7 +52,7 @@ macro_rules! deduct_calldata_cost {
         let calldata_len = $calldata.len();
         let calldata_cost = calldata_len.div_ceil(32).saturating_mul(G_SHA3WORD as usize) as u64;
         if let Err(e) = $ctx.deduct_gas(calldata_cost) {
-            return e.into_precompile_result($ctx.gas_used());
+            return e.into_precompile_result($ctx.gas_used(), $ctx.state_gas_used());
         }
     }};
 }

--- a/crates/common/precompiles/src/policy/dispatch.rs
+++ b/crates/common/precompiles/src/policy/dispatch.rs
@@ -18,7 +18,7 @@ impl PolicyRegistryStorage<'_> {
         ActivationRegistryStorage::new(ctx)
             .ensure_activated(ActivationFeature::PolicyRegistry.id())
             .and_then(|()| self.inner(calldata))
-            .into_precompile_result(ctx.gas_used(), |b| b)
+            .into_precompile_result(ctx.gas_used(), ctx.state_gas_used(), |b| b)
     }
 
     fn inner(&mut self, calldata: &[u8]) -> base_precompile_storage::Result<Bytes> {


### PR DESCRIPTION
[BOP-127](https://linear.app/coinbase/issue/BOP-127)

## Motivation

`EvmPrecompileStorageProvider::set_code` had a TODO to charge the two EIP-8037 state gas costs (`create_state_gas` and `code_deposit_state_gas`) when deploying bytecode to a new account. The TODO was blocked on `revm-context-interface` reaching v17, which exposes those methods on `GasParams`. The workspace is already pinned to v17.0.1, so the blocker is gone.

Without this fix, native precompiles that deploy contracts (e.g. via `set_code` on a fresh address) undercharge gas under the Amsterdam fork rules, skipping the account-creation and code-deposit state gas costs that the EVM itself would charge.

## What changed

- `PrecompileStorageProvider` (trait): added a required `deduct_state_gas(gas: u64) -> Result<()>` method, distinct from `deduct_gas`, so callers can charge state gas separately from regular execution gas.
- `EvmPrecompileStorageProvider`: added a `state_gas_used: u64` tracking field; `deduct_state_gas` deducts from the regular gas counter (no separate reservoir exists in the precompile call frame) and increments the tracker; `state_gas_used()` now returns the tracked value instead of a hardcoded zero; `set_code` now calls `deduct_state_gas(create_state_gas())` and `deduct_state_gas(code_deposit_state_gas(code_len))` for new accounts, replacing the TODO.
- `HashMapStorageProvider`: added `gas_params: GasParams` and `state_gas_used: u64` fields; `set_code` now mirrors the production new-account check and charges state gas so the test mock is faithful; `deduct_state_gas` tracks cumulative state gas without enforcing a limit (unlimited gas is the existing contract for test providers); new helpers `set_gas_params`, `get_state_gas_used`, and `reset_state_gas_used` exposed under `#[cfg(any(test, feature = "test-utils"))]`.
- Two unit tests added in `evm.rs`: one verifies that `set_code` on a brand-new account charges the sum of `create_state_gas` and `code_deposit_state_gas` under the AMSTERDAM spec, and one verifies that a second `set_code` on the same address (already initialised) charges no additional state gas.

## What was tried / considered

The state gas could alternatively have been routed through a dedicated reservoir field on `EvmPrecompileStorageProvider` (mirroring the transaction-level reservoir used by the EVM proper). That path was deferred: precompile call frames currently receive no reservoir budget from the transaction context, so any reservoir would immediately be exhausted and all state gas would still spill to regular gas. Keeping the routing simple (state gas comes from regular gas) matches the existing `reservoir() -> 0` contract and avoids plumbing a reservoir through `PrecompileInput` before there is a concrete need.