### PR TITLE
feat(b20-security): default REDEEM_SENDER_POLICY to ALWAYS_BLOCK_ID at creation (BOP-152)

### DIFF
--- a/crates/common/precompiles/src/b20_security/dispatch.rs
+++ b/crates/common/precompiles/src/b20_security/dispatch.rs
@@ -643,7 +643,7 @@ mod tests {
 
     use super::{BURN_FROM_ROLE, REDEEM_SENDER_POLICY, SECURITY_OPERATOR_ROLE};
     use crate::{
-        B20PausableFeature, IB20, PolicyHandle, Token, TokenAccounting,
+        B20PausableFeature, IB20, PolicyHandle, PolicyRegistryStorage, Token, TokenAccounting,
         b20_security::{B20SecurityStorage, B20SecurityToken, IB20Security, SecurityAccounting},
         common::test_utils::{InMemoryPolicy, InMemoryTokenAccounting},
     };
@@ -660,6 +660,8 @@ mod tests {
         accounting.shares_to_tokens_ratio = WAD; // 1:1 ratio
         accounting.roles.insert((BURN_FROM_ROLE, ALICE), true);
         accounting.roles.insert((SECURITY_OPERATOR_ROLE, ALICE), true);
+        // Explicitly open redemption so non-policy tests are not blocked by the ALWAYS_BLOCK default.
+        accounting.policy_ids.insert(REDEEM_SENDER_POLICY, PolicyRegistryStorage::ALWAYS_ALLOW_ID);
         TestSecurityToken::with_storage_and_policy(accounting, InMemoryPolicy::new())
     }
 

--- a/crates/common/precompiles/src/b20_security/ids.rs
+++ b/crates/common/precompiles/src/b20_security/ids.rs
@@ -6,7 +6,8 @@ pub(super) const SECURITY_OPERATOR_ROLE: B256 =
     b256!("e63901dfe7775ace99fa3654743976eb0ab2009f5d19c4fc1ecd40aed27d59af");
 pub(super) const BURN_FROM_ROLE: B256 =
     b256!("25400dba76bf0d00acf274c2b61ff56aa4ed19826e21e0186e3fecd6a6671875");
-pub(super) const REDEEM_SENDER_POLICY: B256 =
+/// Policy scope identifier for the sender of a redeem operation: `keccak256("REDEEM_SENDER_POLICY")`.
+pub const REDEEM_SENDER_POLICY: B256 =
     b256!("0ff53b08b65363a609bb561211128f4044adc0e351f0b92b6aa23f8d85462f59");
 
 #[cfg(test)]

--- a/crates/common/precompiles/src/b20_security/mod.rs
+++ b/crates/common/precompiles/src/b20_security/mod.rs
@@ -14,6 +14,7 @@ mod precompile;
 pub use precompile::B20SecurityPrecompile;
 
 mod storage;
+pub use ids::REDEEM_SENDER_POLICY;
 pub use storage::{
     B20RedeemStorage, B20SecurityExtensionStorage, B20SecurityInit, B20SecurityStorage,
 };

--- a/crates/common/precompiles/src/b20_security/mod.rs
+++ b/crates/common/precompiles/src/b20_security/mod.rs
@@ -9,12 +9,12 @@ pub use accounting::SecurityAccounting;
 mod dispatch;
 
 mod ids;
+pub use ids::REDEEM_SENDER_POLICY;
 
 mod precompile;
 pub use precompile::B20SecurityPrecompile;
 
 mod storage;
-pub use ids::REDEEM_SENDER_POLICY;
 pub use storage::{
     B20RedeemStorage, B20SecurityExtensionStorage, B20SecurityInit, B20SecurityStorage,
 };

--- a/crates/common/precompiles/src/b20_security/storage.rs
+++ b/crates/common/precompiles/src/b20_security/storage.rs
@@ -9,7 +9,10 @@ use base_precompile_storage::{
 };
 
 use super::{accounting::SecurityAccounting, ids::REDEEM_SENDER_POLICY};
-use crate::{B20CoreStorage, B20PolicyType, B20TokenRole, B20Variant, IB20, TokenAccounting};
+use crate::{
+    B20CoreStorage, B20PolicyType, B20TokenRole, B20Variant, IB20, PolicyRegistryStorage,
+    TokenAccounting,
+};
 
 /// WAD precision for share ratio arithmetic: 1e18.
 const WAD: U256 = U256::from_limbs([1_000_000_000_000_000_000, 0, 0, 0]);
@@ -73,6 +76,9 @@ impl<'a> B20SecurityStorage<'a> {
     ///
     /// `isin` may be empty; when non-empty it is stored under the `"ISIN"` key
     /// in the security identifiers mapping.
+    ///
+    /// `REDEEM_SENDER_POLICY` is initialised to `ALWAYS_BLOCK_ID` so redemption
+    /// is closed by default; issuers must explicitly open it after creation.
     pub fn initialize(&mut self, init: B20SecurityInit) -> Result<()> {
         self.b20.name.write(init.name)?;
         self.b20.symbol.write(init.symbol)?;
@@ -82,6 +88,7 @@ impl<'a> B20SecurityStorage<'a> {
         if !init.isin.is_empty() {
             self.security.identifiers.at_mut(&String::from("ISIN")).write(init.isin)?;
         }
+        self.write_redeem_default_policy_ids()?;
         Ok(())
     }
 }
@@ -298,6 +305,17 @@ impl B20SecurityStorage<'_> {
     const REDEEM_SENDER_POLICY_LANE: usize = 0;
     const POLICY_LANE_BITS: usize = 64;
 
+    /// Writes the initial packed `redeem_policy_ids` word with `REDEEM_SENDER_POLICY`
+    /// set to `ALWAYS_BLOCK_ID`. Called once from [`initialize`].
+    fn write_redeem_default_policy_ids(&mut self) -> Result<()> {
+        let packed = Self::write_policy_lane(
+            U256::ZERO,
+            Self::REDEEM_SENDER_POLICY_LANE,
+            PolicyRegistryStorage::ALWAYS_BLOCK_ID,
+        );
+        self.redeem.redeem_policy_ids.write(packed)
+    }
+
     fn require_b20_policy_type(policy_scope: B256) -> Result<B20PolicyType> {
         B20PolicyType::from_id(policy_scope).ok_or_else(|| {
             BasePrecompileError::revert(IB20::UnsupportedPolicyType { policyScope: policy_scope })
@@ -366,9 +384,10 @@ mod tests {
 
     use super::{
         __packing_b20_redeem_storage, __packing_b20_security_extension_storage, B20RedeemStorage,
-        B20SecurityExtensionStorage, B20SecurityStorage, REDEEM_SENDER_POLICY, WAD, slots,
+        B20SecurityExtensionStorage, B20SecurityInit, B20SecurityStorage, REDEEM_SENDER_POLICY,
+        WAD, slots,
     };
-    use crate::{B20CoreStorage, SecurityAccounting, TokenAccounting};
+    use crate::{B20CoreStorage, PolicyRegistryStorage, SecurityAccounting, TokenAccounting};
 
     const TOKEN: Address = address!("000000000000000000000000000000000000b021");
     const B20_ROOT: U256 =
@@ -506,6 +525,31 @@ mod tests {
             let redeem_policy_slot = REDEEM_ROOT
                 + U256::from(__packing_b20_redeem_storage::REDEEM_POLICY_IDS_LOC.offset_slots);
             assert_eq!(ctx.sload(TOKEN, redeem_policy_slot).unwrap(), U256::from(policy_id));
+        });
+    }
+
+    #[test]
+    fn initialize_sets_redeem_sender_policy_to_always_block() {
+        let (mut storage, _) = setup_storage();
+
+        StorageCtx::enter(&mut storage, |ctx| {
+            let mut token = B20SecurityStorage::from_address(TOKEN, ctx);
+            token
+                .initialize(B20SecurityInit {
+                    name: String::from("Test"),
+                    symbol: String::from("TST"),
+                    supply_cap: U256::from(1_000_000u64),
+                    shares_to_tokens_ratio: WAD,
+                    isin: String::new(),
+                    minimum_redeemable: U256::ZERO,
+                })
+                .unwrap();
+
+            assert_eq!(
+                token.policy_id(REDEEM_SENDER_POLICY).unwrap(),
+                PolicyRegistryStorage::ALWAYS_BLOCK_ID,
+                "REDEEM_SENDER_POLICY must default to ALWAYS_BLOCK_ID at creation"
+            );
         });
     }
 

--- a/crates/common/precompiles/src/b20_security/storage.rs
+++ b/crates/common/precompiles/src/b20_security/storage.rs
@@ -88,7 +88,7 @@ impl<'a> B20SecurityStorage<'a> {
         if !init.isin.is_empty() {
             self.security.identifiers.at_mut(&String::from("ISIN")).write(init.isin)?;
         }
-        self.write_redeem_default_policy_ids()?;
+        self.write_redeem_policy_ids_default()?;
         Ok(())
     }
 }
@@ -307,7 +307,7 @@ impl B20SecurityStorage<'_> {
 
     /// Writes the initial packed `redeem_policy_ids` word with `REDEEM_SENDER_POLICY`
     /// set to `ALWAYS_BLOCK_ID`. Called once from [`initialize`].
-    fn write_redeem_default_policy_ids(&mut self) -> Result<()> {
+    fn write_redeem_policy_ids_default(&mut self) -> Result<()> {
         let packed = Self::write_policy_lane(
             U256::ZERO,
             Self::REDEEM_SENDER_POLICY_LANE,

--- a/crates/common/precompiles/src/common/test_utils.rs
+++ b/crates/common/precompiles/src/common/test_utils.rs
@@ -9,7 +9,7 @@ use alloy_primitives::{Address, B256, LogData, U256};
 use base_precompile_storage::Result;
 
 use crate::{
-    IPolicyRegistry, PolicyRegistry, PolicyRegistryStorage,
+    IPolicyRegistry, PolicyRegistry, PolicyRegistryStorage, REDEEM_SENDER_POLICY,
     b20::B20Token,
     b20_security::SecurityAccounting,
     b20_stablecoin::{B20StablecoinToken, StablecoinAccounting},
@@ -232,7 +232,12 @@ impl TokenAccounting for InMemoryTokenAccounting {
     }
 
     fn policy_id(&self, policy_scope: B256) -> Result<u64> {
-        Ok(*self.policy_ids.get(&policy_scope).unwrap_or(&PolicyRegistryStorage::ALWAYS_ALLOW_ID))
+        let default = if policy_scope == REDEEM_SENDER_POLICY {
+            PolicyRegistryStorage::ALWAYS_BLOCK_ID
+        } else {
+            PolicyRegistryStorage::ALWAYS_ALLOW_ID
+        };
+        Ok(*self.policy_ids.get(&policy_scope).unwrap_or(&default))
     }
 
     fn set_policy_id(&mut self, policy_scope: B256, policy_id: u64) -> Result<()> {

--- a/crates/common/precompiles/src/lib.rs
+++ b/crates/common/precompiles/src/lib.rs
@@ -44,7 +44,7 @@ pub use b20::{
 mod b20_security;
 pub use b20_security::{
     B20RedeemStorage, B20SecurityExtensionStorage, B20SecurityInit, B20SecurityPrecompile,
-    B20SecurityStorage, B20SecurityToken, IB20Security, SecurityAccounting,
+    B20SecurityStorage, B20SecurityToken, IB20Security, REDEEM_SENDER_POLICY, SecurityAccounting,
 };
 
 mod b20_stablecoin;


### PR DESCRIPTION
[BOP-152](https://linear.app/coinbase/issue/BOP-152)

## Motivation

`initialize()` never wrote to `redeem_policy_ids`, leaving `REDEEM_SENDER_POLICY` at zero (`ALWAYS_ALLOW`). The spec requires redemption to be closed by default; issuers must explicitly open it.

## What changed

- `initialize()` calls new `write_redeem_default_policy_ids()` helper, which packs `ALWAYS_BLOCK_ID` into the `REDEEM_SENDER_POLICY` lane.
- `REDEEM_SENDER_POLICY` promoted to `pub` and re-exported so the mock can reference it.
- `InMemoryTokenAccounting::policy_id()` returns `ALWAYS_BLOCK_ID` for `REDEEM_SENDER_POLICY` when not explicitly set.
- Existing redeem dispatch tests updated to opt in to `ALWAYS_ALLOW` so they still pass.
- New unit test verifies the storage write on `initialize`.

## What was tried / considered

Writing the default in `B20FactoryStorage` instead of `initialize()` — rejected since `initialize()` is the canonical place for creation-time defaults.