### PR TITLE
fix(precompiles): Encode EIP712 Domain Returns

### DIFF
--- a/actions/harness/tests/beryl/b20.rs
+++ b/actions/harness/tests/beryl/b20.rs
@@ -804,7 +804,7 @@ fn domain_separator_word(chain_id: u64, token: Address) -> U256 {
     U256::from_be_slice(domain_separator(chain_id, token).as_slice())
 }
 
-fn eip712_domain_fields_word() -> U256 {
+const fn eip712_domain_fields_word() -> U256 {
     let mut word = [0u8; 32];
     word[0] = 0x0c;
     U256::from_be_bytes(word)

--- a/actions/harness/tests/beryl/b20.rs
+++ b/actions/harness/tests/beryl/b20.rs
@@ -314,7 +314,7 @@ async fn b20_staticcall_abi_covers_all_read_methods() {
             StaticcallCase::word(
                 "eip712Domain",
                 IB20::eip712DomainCall {}.abi_encode(),
-                U256::from(32),
+                eip712_domain_fields_word(),
             ),
             StaticcallCase::word(
                 "contractURI",
@@ -802,6 +802,12 @@ fn domain_separator(chain_id: u64, token: Address) -> B256 {
 
 fn domain_separator_word(chain_id: u64, token: Address) -> U256 {
     U256::from_be_slice(domain_separator(chain_id, token).as_slice())
+}
+
+fn eip712_domain_fields_word() -> U256 {
+    let mut word = [0u8; 32];
+    word[0] = 0x0c;
+    U256::from_be_bytes(word)
 }
 
 struct B20StaticcallProbes {

--- a/crates/common/precompiles/src/b20/dispatch.rs
+++ b/crates/common/precompiles/src/b20/dispatch.rs
@@ -1,5 +1,5 @@
 use alloy_primitives::{Bytes, U256};
-use alloy_sol_types::SolValue;
+use alloy_sol_types::{SolCall, SolValue};
 use base_precompile_storage::{BasePrecompileError, IntoPrecompileResult, StorageCtx};
 use revm::precompile::PrecompileResult;
 
@@ -79,7 +79,20 @@ impl<S: TokenAccounting, P: Policy> B20Token<S, P> {
             // --- Domain reads (light logic) ---
             C::isPaused(c) => self.is_paused(c.feature)?.abi_encode().into(),
             C::DOMAIN_SEPARATOR(_) => self.domain_separator(ctx.chain_id())?.abi_encode().into(),
-            C::eip712Domain(_) => self.eip712_domain(ctx.chain_id())?.abi_encode().into(),
+            C::eip712Domain(_) => {
+                let (fields, name, version, chain_id, verifying_contract, salt, extensions) =
+                    self.eip712_domain(ctx.chain_id())?;
+                IB20::eip712DomainCall::abi_encode_returns(&IB20::eip712DomainReturn {
+                    fields,
+                    name,
+                    version,
+                    chainId: chain_id,
+                    verifyingContract: verifying_contract,
+                    salt,
+                    extensions,
+                })
+                .into()
+            }
 
             // --- ERC-20 mutating ---
             C::transfer(c) => {

--- a/crates/common/precompiles/src/b20_security/dispatch.rs
+++ b/crates/common/precompiles/src/b20_security/dispatch.rs
@@ -9,7 +9,7 @@
 use alloc::{string::String, vec::Vec};
 
 use alloy_primitives::{Address, B256, Bytes, U256};
-use alloy_sol_types::{SolEvent, SolInterface, SolValue};
+use alloy_sol_types::{SolCall, SolEvent, SolInterface, SolValue};
 use base_precompile_storage::{BasePrecompileError, IntoPrecompileResult, StorageCtx};
 use revm::precompile::PrecompileResult;
 
@@ -166,7 +166,20 @@ impl<S: SecurityAccounting, P: Policy> B20SecurityToken<S, P> {
 
             // --- Domain reads ---
             C::DOMAIN_SEPARATOR(_) => self.domain_separator(ctx.chain_id())?.abi_encode().into(),
-            C::eip712Domain(_) => self.eip712_domain(ctx.chain_id())?.abi_encode().into(),
+            C::eip712Domain(_) => {
+                let (fields, name, version, chain_id, verifying_contract, salt, extensions) =
+                    self.eip712_domain(ctx.chain_id())?;
+                IB20::eip712DomainCall::abi_encode_returns(&IB20::eip712DomainReturn {
+                    fields,
+                    name,
+                    version,
+                    chainId: chain_id,
+                    verifyingContract: verifying_contract,
+                    salt,
+                    extensions,
+                })
+                .into()
+            }
 
             // --- ERC-20 mutating ---
             C::transfer(c) => {

--- a/crates/common/precompiles/src/b20_stablecoin/dispatch.rs
+++ b/crates/common/precompiles/src/b20_stablecoin/dispatch.rs
@@ -6,7 +6,7 @@
 //! that provides `currency()` from the stablecoin extension namespace.
 
 use alloy_primitives::{Bytes, U256};
-use alloy_sol_types::{SolInterface, SolValue};
+use alloy_sol_types::{SolCall, SolInterface, SolValue};
 use base_precompile_storage::{BasePrecompileError, IntoPrecompileResult, StorageCtx};
 use revm::precompile::PrecompileResult;
 
@@ -93,7 +93,20 @@ impl<S: StablecoinAccounting, P: Policy> B20StablecoinToken<S, P> {
             // --- Domain reads (light logic) ---
             C::isPaused(c) => self.is_paused(c.feature)?.abi_encode().into(),
             C::DOMAIN_SEPARATOR(_) => self.domain_separator(ctx.chain_id())?.abi_encode().into(),
-            C::eip712Domain(_) => self.eip712_domain(ctx.chain_id())?.abi_encode().into(),
+            C::eip712Domain(_) => {
+                let (fields, name, version, chain_id, verifying_contract, salt, extensions) =
+                    self.eip712_domain(ctx.chain_id())?;
+                IB20::eip712DomainCall::abi_encode_returns(&IB20::eip712DomainReturn {
+                    fields,
+                    name,
+                    version,
+                    chainId: chain_id,
+                    verifyingContract: verifying_contract,
+                    salt,
+                    extensions,
+                })
+                .into()
+            }
 
             // --- ERC-20 mutating ---
             C::transfer(c) => {


### PR DESCRIPTION
## Summary

This fixes the B20 eip712Domain dispatch paths to use generated function-return ABI encoding instead of generic tuple encoding. It keeps the split scoped to the default, stablecoin, and security B20 dispatchers and updates the Beryl staticcall coverage to assert the actual ERC-5267 fields word.