### PR TITLE
fix(precompiles): Align Share Ratio Sentinel

### DIFF
--- a/crates/common/precompiles/src/b20_factory/storage.rs
+++ b/crates/common/precompiles/src/b20_factory/storage.rs
@@ -16,9 +16,8 @@ use crate::{
 /// Maximum total supply for all newly-created B-20 tokens.
 const DEFAULT_SUPPLY_CAP: U256 = U256::MAX;
 
-/// Initial share-to-token ratio at WAD precision (1:1).
-const INITIAL_SHARES_TO_TOKENS_RATIO: U256 =
-    U256::from_limbs([1_000_000_000_000_000_000u64, 0, 0, 0]);
+/// Initial share-to-token ratio storage value. Reads treat zero as WAD precision (1:1).
+const INITIAL_SHARES_TO_TOKENS_RATIO: U256 = U256::ZERO;
 
 /// The B-20 token factory precompile.
 #[contract(addr = Self::ADDRESS)]
@@ -728,10 +727,7 @@ mod tests {
             assert_eq!(sec_storage.b20.name.read().unwrap(), "Security Token");
             assert_eq!(sec_storage.b20.symbol.read().unwrap(), "SEC");
             assert_eq!(sec_storage.decimals().unwrap(), 6);
-            assert_eq!(
-                sec_storage.security.shares_to_tokens_ratio.read().unwrap(),
-                U256::from(1_000_000_000_000_000_000u128)
-            );
+            assert_eq!(sec_storage.security.shares_to_tokens_ratio.read().unwrap(), U256::ZERO);
             assert_eq!(sec_storage.redeem.minimum_redeemable.read().unwrap(), U256::ONE);
             // ISIN is stored in the identifiers mapping under the raw "ISIN" key.
             assert_eq!(


### PR DESCRIPTION
## Summary

This aligns B20 security-token factory bootstrap with base-std by storing the share-to-token ratio as the zero sentinel instead of writing WAD into the raw slot. The public getter still reports WAD for a fresh token because the storage layer maps zero to WAD, matching base-std read semantics. This matters because base-std asserts both parts of the invariant: raw storage remains zero until updateShareRatio writes an explicit value, while users still see the 1:1 default.