### PR TITLE
fix(devnet): Stabilize Devnet Test Runs

### DIFF
--- a/devnet/src/setup/container.rs
+++ b/devnet/src/setup/container.rs
@@ -1,4 +1,11 @@
-use std::{path::PathBuf, process::Command, time::Duration};
+use std::{
+    fs,
+    io::ErrorKind,
+    path::PathBuf,
+    process::Command,
+    thread,
+    time::{Duration, Instant},
+};
 
 use eyre::{Result, WrapErr, ensure};
 use testcontainers::{
@@ -13,6 +20,9 @@ use crate::{
 };
 
 const SETUP_IMAGE_TAG: &str = "devnet-setup:local";
+const SETUP_IMAGE_BUILD_LOCK_DIR: &str = "base-devnet-setup-image-build.lock";
+const SETUP_IMAGE_BUILD_LOCK_TIMEOUT: Duration = Duration::from_secs(600);
+const SETUP_IMAGE_BUILD_LOCK_POLL_INTERVAL: Duration = Duration::from_millis(500);
 const DEPLOY_TIMEOUT_SECS: u64 = 300;
 
 /// Builder enode ID
@@ -276,30 +286,71 @@ impl SetupContainer {
     }
 
     fn ensure_setup_image_built(&self) -> Result<()> {
-        let image_exists = Command::new("docker")
-            .args(["image", "inspect", SETUP_IMAGE_TAG])
-            .output()
-            .map(|o| o.status.success())
-            .unwrap_or(false);
+        let setup_image_exists = || {
+            Command::new("docker")
+                .args(["image", "inspect", SETUP_IMAGE_TAG])
+                .output()
+                .map(|o| o.status.success())
+                .unwrap_or(false)
+        };
 
-        if image_exists {
+        if setup_image_exists() {
             return Ok(());
         }
 
-        let repo_root = self.find_repo_root()?;
-        let dockerfile_path = repo_root.join("etc/docker/Dockerfile.devnet");
+        let lock_dir = std::env::temp_dir().join(SETUP_IMAGE_BUILD_LOCK_DIR);
+        let lock_started = Instant::now();
+        loop {
+            match fs::create_dir(&lock_dir) {
+                Ok(()) => break,
+                Err(error) if error.kind() == ErrorKind::AlreadyExists => {
+                    if setup_image_exists() {
+                        return Ok(());
+                    }
+                    ensure!(
+                        lock_started.elapsed() < SETUP_IMAGE_BUILD_LOCK_TIMEOUT,
+                        "timed out waiting for devnet setup image build lock at {}",
+                        lock_dir.display(),
+                    );
+                    thread::sleep(SETUP_IMAGE_BUILD_LOCK_POLL_INTERVAL);
+                }
+                Err(error) => {
+                    return Err(error).wrap_err("Failed to acquire devnet setup image build lock");
+                }
+            }
+        }
 
-        ensure!(dockerfile_path.exists(), "etc/docker/Dockerfile.devnet not found");
+        let build_result = (|| {
+            if setup_image_exists() {
+                return Ok(());
+            }
 
-        let status = Command::new("docker")
-            .args(["build", "-t", SETUP_IMAGE_TAG, "-f", "etc/docker/Dockerfile.devnet", "."])
-            .current_dir(&repo_root)
-            .status()
-            .wrap_err("Failed to run docker build")?;
+            let repo_root = self.find_repo_root()?;
+            let dockerfile_path = repo_root.join("etc/docker/Dockerfile.devnet");
 
-        ensure!(status.success(), "docker build failed");
+            ensure!(dockerfile_path.exists(), "etc/docker/Dockerfile.devnet not found");
 
-        Ok(())
+            let status = Command::new("docker")
+                .args(["build", "-t", SETUP_IMAGE_TAG, "-f", "etc/docker/Dockerfile.devnet", "."])
+                .current_dir(&repo_root)
+                .status()
+                .wrap_err("Failed to run docker build")?;
+
+            ensure!(status.success(), "docker build failed");
+
+            Ok(())
+        })();
+
+        let cleanup_result =
+            fs::remove_dir(&lock_dir).wrap_err("Failed to release devnet setup image build lock");
+
+        match build_result {
+            Ok(()) => cleanup_result,
+            Err(error) => {
+                let _ = cleanup_result;
+                Err(error)
+            }
+        }
     }
 
     fn find_repo_root(&self) -> Result<PathBuf> {

--- a/devnet/tests/b20_precompile.rs
+++ b/devnet/tests/b20_precompile.rs
@@ -326,6 +326,13 @@ async fn test_b20_metadata_updates() -> Result<()> {
     let token = b20.create_token(TokenVariant::B20, params, salt).await?;
     b20.wait_for_token_code(token, common::TX_RECEIPT_TIMEOUT, common::BLOCK_POLL_INTERVAL).await?;
 
+    b20.send_call(
+        token,
+        IB20::grantRoleCall { role: B20TokenRole::Metadata.id(), account: admin.address() },
+        "grant B-20 metadata role",
+    )
+    .await?;
+
     b20.update_name(token, "New Name").await?;
     b20.update_symbol(token, "NEW").await?;
     b20.update_contract_uri(token, "ipfs://QmTest").await?;

--- a/devnet/tests/policy_registry.rs
+++ b/devnet/tests/policy_registry.rs
@@ -4,11 +4,11 @@ mod common;
 
 use alloy_signer_local::PrivateKeySigner;
 use alloy_sol_types::SolCall;
-use base_common_precompiles::{IPolicyRegistry, PolicyRegistryStorage};
+use base_common_precompiles::{ActivationFeature, IPolicyRegistry, PolicyRegistryStorage};
 use devnet::{B20PrecompileClient, config::ANVIL_ACCOUNT_5};
 use eyre::{Result, WrapErr};
 
-/// `policyExists(0)` returns `true` once the Beryl fork is active.
+/// `policyExists(ALWAYS_ALLOW_ID)` returns `true` once the policy registry is active.
 #[tokio::test]
 async fn test_policy_registry_policy_exists() -> Result<()> {
     let (_devnet, provider) = common::start_beryl_devnet().await?;
@@ -18,9 +18,13 @@ async fn test_policy_registry_policy_exists() -> Result<()> {
 
     let client = B20PrecompileClient::new(&provider, &caller, common::L2_CHAIN_ID)
         .with_receipt_timeout(common::TX_RECEIPT_TIMEOUT);
+    client.activate_feature(ActivationFeature::PolicyRegistry.id()).await?;
 
     let output = client
-        .call(PolicyRegistryStorage::ADDRESS, IPolicyRegistry::policyExistsCall { policyId: 0 })
+        .call(
+            PolicyRegistryStorage::ADDRESS,
+            IPolicyRegistry::policyExistsCall { policyId: PolicyRegistryStorage::ALWAYS_ALLOW_ID },
+        )
         .await?;
     let result = IPolicyRegistry::policyExistsCall::abi_decode_returns(output.as_ref())
         .wrap_err("Failed to decode policyExists")?;

--- a/devnet/tests/smoke.rs
+++ b/devnet/tests/smoke.rs
@@ -21,8 +21,11 @@ const BLOCK_PRODUCTION_TIMEOUT: Duration = Duration::from_secs(30);
 const BLOCK_POLL_INTERVAL: Duration = Duration::from_millis(500);
 const TX_RECEIPT_TIMEOUT: Duration = Duration::from_secs(60);
 
+static SMOKE_TEST_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
 #[tokio::test]
 async fn smoke_test_devnet_block_production_and_transactions() -> Result<()> {
+    let _guard = SMOKE_TEST_LOCK.lock().await;
     let devnet = DevnetBuilder::new()
         .with_l1_chain_id(L1_CHAIN_ID)
         .with_l2_chain_id(L2_CHAIN_ID)
@@ -150,6 +153,7 @@ async fn send_l2_transaction_via_client(
 
 #[tokio::test]
 async fn smoke_test_builder_and_client_block_sync() -> Result<()> {
+    let _guard = SMOKE_TEST_LOCK.lock().await;
     base_node_runner::test_utils::init_silenced_tracing();
     let devnet = DevnetBuilder::new()
         .with_l1_chain_id(L1_CHAIN_ID)
@@ -191,6 +195,7 @@ async fn smoke_test_builder_and_client_block_sync() -> Result<()> {
 
 #[tokio::test]
 async fn smoke_test_client_pending_state_via_flashblocks() -> Result<()> {
+    let _guard = SMOKE_TEST_LOCK.lock().await;
     let devnet = DevnetBuilder::new()
         .with_l1_chain_id(L1_CHAIN_ID)
         .with_l2_chain_id(L2_CHAIN_ID)


### PR DESCRIPTION
## Summary

This stabilizes devnet test runs by serializing shared Docker setup paths and aligning tests with the current activation and role requirements. The setup image build now uses a lock so parallel tests do not race on the local tag. The B20 and policy registry tests explicitly perform the role and feature setup required by the current precompile behavior.