### PR TITLE
test(precompile-storage): add trybuild compile-fail tests for #[namespace] (BOP-119)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5103,6 +5103,7 @@ dependencies = [
  "proptest",
  "revm",
  "thiserror 2.0.18",
+ "trybuild",
 ]
 
 [[package]]
@@ -22447,6 +22448,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "terminfo"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -22992,10 +23002,12 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
+ "indexmap 2.14.0",
  "serde_core",
  "serde_spanned 1.1.1",
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
+ "toml_writer",
  "winnow 1.0.3",
 ]
 
@@ -23632,6 +23644,21 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "trybuild"
+version = "1.0.116"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47c635f0191bd3a2941013e5062667100969f8c4e9cd787c14f977265d73616e"
+dependencies = [
+ "glob",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "target-triple",
+ "termcolor",
+ "toml 1.1.2+spec-1.1.0",
+]
 
 [[package]]
 name = "tungstenite"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -495,6 +495,7 @@ serde_json = { version = "1.0.145", default-features = false }
 # testing
 arbtest = "0.3"
 test-case = "3"
+trybuild = "1"
 mockall = "0.14"
 tempfile = "3.20"
 rstest = "0.26.1"

--- a/crates/common/precompile-storage/Cargo.toml
+++ b/crates/common/precompile-storage/Cargo.toml
@@ -30,11 +30,15 @@ derive_more = { workspace = true, features = ["from", "try_into"] }
 
 [dev-dependencies]
 proptest.workspace = true
+trybuild.workspace = true
 alloy-primitives = { workspace = true, features = ["rand"] }
 
 [[test]]
 name = "contract"
 required-features = ["test-utils"]
+
+[[test]]
+name = "ui"
 
 [features]
 default = [ "std" ]

--- a/crates/common/precompile-storage/tests/ui.rs
+++ b/crates/common/precompile-storage/tests/ui.rs
@@ -1,0 +1,9 @@
+//! Compile-fail (trybuild) tests for the `#[namespace]` macro error paths.
+//!
+//! Each fixture in `tests/ui/` exercises a validation that the macro enforces at compile time.
+//! The corresponding `.stderr` files capture the exact diagnostic the compiler must emit.
+#[test]
+fn namespace_compile_fail() {
+    let t = trybuild::TestCases::new();
+    t.compile_fail("tests/ui/*.rs");
+}

--- a/crates/common/precompile-storage/tests/ui/01_namespace_without_contract.rs
+++ b/crates/common/precompile-storage/tests/ui/01_namespace_without_contract.rs
@@ -1,0 +1,10 @@
+//! `#[namespace]` applied to a plain struct with neither `#[contract]` nor `#[derive(Storable)]`
+//! must be a compile error.
+use base_precompile_macros::namespace;
+
+#[namespace("my.contract")]
+struct Foo {
+    value: u64,
+}
+
+fn main() {}

--- a/crates/common/precompile-storage/tests/ui/01_namespace_without_contract.stderr
+++ b/crates/common/precompile-storage/tests/ui/01_namespace_without_contract.stderr
@@ -1,0 +1,5 @@
+error: `#[namespace]` must be paired with `#[contract]` or `#[derive(Storable)]`
+ --> tests/ui/01_namespace_without_contract.rs:6:8
+  |
+6 | struct Foo {
+  |        ^^^

--- a/crates/common/precompile-storage/tests/ui/02_duplicate_namespace_on_field.rs
+++ b/crates/common/precompile-storage/tests/ui/02_duplicate_namespace_on_field.rs
@@ -1,0 +1,13 @@
+//! Two `#[namespace]` attributes on the same field inside a `#[contract]` struct must be a
+//! compile error.
+use alloy_primitives::U256;
+use base_precompile_macros::contract;
+
+#[contract]
+struct Foo {
+    #[namespace("ns.a")]
+    #[namespace("ns.b")]
+    value: U256,
+}
+
+fn main() {}

--- a/crates/common/precompile-storage/tests/ui/02_duplicate_namespace_on_field.rs
+++ b/crates/common/precompile-storage/tests/ui/02_duplicate_namespace_on_field.rs
@@ -1,13 +1,13 @@
 //! Two `#[namespace]` attributes on the same field inside a `#[contract]` struct must be a
 //! compile error.
-use alloy_primitives::U256;
+
 use base_precompile_macros::contract;
 
 #[contract]
 struct Foo {
     #[namespace("ns.a")]
     #[namespace("ns.b")]
-    value: U256,
+    value: u64,
 }
 
 fn main() {}

--- a/crates/common/precompile-storage/tests/ui/02_duplicate_namespace_on_field.stderr
+++ b/crates/common/precompile-storage/tests/ui/02_duplicate_namespace_on_field.stderr
@@ -3,11 +3,3 @@ error: duplicate `namespace` attribute
   |
 9 |     #[namespace("ns.b")]
   |     ^^^^^^^^^^^^^^^^^^^^
-
-warning: unused import: `alloy_primitives::U256`
- --> tests/ui/02_duplicate_namespace_on_field.rs:3:5
-  |
-3 | use alloy_primitives::U256;
-  |     ^^^^^^^^^^^^^^^^^^^^^^
-  |
-  = note: `#[warn(unused_imports)]` (part of `#[warn(unused)]`) on by default

--- a/crates/common/precompile-storage/tests/ui/02_duplicate_namespace_on_field.stderr
+++ b/crates/common/precompile-storage/tests/ui/02_duplicate_namespace_on_field.stderr
@@ -1,0 +1,13 @@
+error: duplicate `namespace` attribute
+ --> tests/ui/02_duplicate_namespace_on_field.rs:9:5
+  |
+9 |     #[namespace("ns.b")]
+  |     ^^^^^^^^^^^^^^^^^^^^
+
+warning: unused import: `alloy_primitives::U256`
+ --> tests/ui/02_duplicate_namespace_on_field.rs:3:5
+  |
+3 | use alloy_primitives::U256;
+  |     ^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: `#[warn(unused_imports)]` (part of `#[warn(unused)]`) on by default

--- a/crates/common/precompile-storage/tests/ui/03_empty_namespace_id.rs
+++ b/crates/common/precompile-storage/tests/ui/03_empty_namespace_id.rs
@@ -1,11 +1,11 @@
 //! An empty string passed to `#[namespace]` must be a compile error.
-use alloy_primitives::U256;
+
 use base_precompile_macros::contract;
 
 #[contract]
 struct Foo {
     #[namespace("")]
-    value: U256,
+    value: u64,
 }
 
 fn main() {}

--- a/crates/common/precompile-storage/tests/ui/03_empty_namespace_id.rs
+++ b/crates/common/precompile-storage/tests/ui/03_empty_namespace_id.rs
@@ -1,0 +1,11 @@
+//! An empty string passed to `#[namespace]` must be a compile error.
+use alloy_primitives::U256;
+use base_precompile_macros::contract;
+
+#[contract]
+struct Foo {
+    #[namespace("")]
+    value: U256,
+}
+
+fn main() {}

--- a/crates/common/precompile-storage/tests/ui/03_empty_namespace_id.stderr
+++ b/crates/common/precompile-storage/tests/ui/03_empty_namespace_id.stderr
@@ -1,0 +1,13 @@
+error: namespace id cannot be empty
+ --> tests/ui/03_empty_namespace_id.rs:7:17
+  |
+7 |     #[namespace("")]
+  |                 ^^
+
+warning: unused import: `alloy_primitives::U256`
+ --> tests/ui/03_empty_namespace_id.rs:2:5
+  |
+2 | use alloy_primitives::U256;
+  |     ^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: `#[warn(unused_imports)]` (part of `#[warn(unused)]`) on by default

--- a/crates/common/precompile-storage/tests/ui/03_empty_namespace_id.stderr
+++ b/crates/common/precompile-storage/tests/ui/03_empty_namespace_id.stderr
@@ -3,11 +3,3 @@ error: namespace id cannot be empty
   |
 7 |     #[namespace("")]
   |                 ^^
-
-warning: unused import: `alloy_primitives::U256`
- --> tests/ui/03_empty_namespace_id.rs:2:5
-  |
-2 | use alloy_primitives::U256;
-  |     ^^^^^^^^^^^^^^^^^^^^^^
-  |
-  = note: `#[warn(unused_imports)]` (part of `#[warn(unused)]`) on by default

--- a/crates/common/precompile-storage/tests/ui/04_namespace_id_with_whitespace.rs
+++ b/crates/common/precompile-storage/tests/ui/04_namespace_id_with_whitespace.rs
@@ -1,11 +1,11 @@
 //! A namespace id containing whitespace must be a compile error.
-use alloy_primitives::U256;
+
 use base_precompile_macros::contract;
 
 #[contract]
 struct Foo {
     #[namespace("foo bar")]
-    value: U256,
+    value: u64,
 }
 
 fn main() {}

--- a/crates/common/precompile-storage/tests/ui/04_namespace_id_with_whitespace.rs
+++ b/crates/common/precompile-storage/tests/ui/04_namespace_id_with_whitespace.rs
@@ -1,0 +1,11 @@
+//! A namespace id containing whitespace must be a compile error.
+use alloy_primitives::U256;
+use base_precompile_macros::contract;
+
+#[contract]
+struct Foo {
+    #[namespace("foo bar")]
+    value: U256,
+}
+
+fn main() {}

--- a/crates/common/precompile-storage/tests/ui/04_namespace_id_with_whitespace.stderr
+++ b/crates/common/precompile-storage/tests/ui/04_namespace_id_with_whitespace.stderr
@@ -1,0 +1,13 @@
+error: namespace id must not contain whitespace
+ --> tests/ui/04_namespace_id_with_whitespace.rs:7:17
+  |
+7 |     #[namespace("foo bar")]
+  |                 ^^^^^^^^^
+
+warning: unused import: `alloy_primitives::U256`
+ --> tests/ui/04_namespace_id_with_whitespace.rs:2:5
+  |
+2 | use alloy_primitives::U256;
+  |     ^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: `#[warn(unused_imports)]` (part of `#[warn(unused)]`) on by default

--- a/crates/common/precompile-storage/tests/ui/04_namespace_id_with_whitespace.stderr
+++ b/crates/common/precompile-storage/tests/ui/04_namespace_id_with_whitespace.stderr
@@ -3,11 +3,3 @@ error: namespace id must not contain whitespace
   |
 7 |     #[namespace("foo bar")]
   |                 ^^^^^^^^^
-
-warning: unused import: `alloy_primitives::U256`
- --> tests/ui/04_namespace_id_with_whitespace.rs:2:5
-  |
-2 | use alloy_primitives::U256;
-  |     ^^^^^^^^^^^^^^^^^^^^^^
-  |
-  = note: `#[warn(unused_imports)]` (part of `#[warn(unused)]`) on by default

--- a/crates/common/precompile-storage/tests/ui/05_namespace_with_slot.rs
+++ b/crates/common/precompile-storage/tests/ui/05_namespace_with_slot.rs
@@ -1,0 +1,12 @@
+//! Combining `#[namespace]` and `#[slot]` on the same field must be a compile error.
+use alloy_primitives::U256;
+use base_precompile_macros::contract;
+
+#[contract]
+struct Foo {
+    #[slot(0)]
+    #[namespace("ns.field")]
+    value: U256,
+}
+
+fn main() {}

--- a/crates/common/precompile-storage/tests/ui/05_namespace_with_slot.rs
+++ b/crates/common/precompile-storage/tests/ui/05_namespace_with_slot.rs
@@ -1,12 +1,12 @@
 //! Combining `#[namespace]` and `#[slot]` on the same field must be a compile error.
-use alloy_primitives::U256;
+
 use base_precompile_macros::contract;
 
 #[contract]
 struct Foo {
     #[slot(0)]
     #[namespace("ns.field")]
-    value: U256,
+    value: u64,
 }
 
 fn main() {}

--- a/crates/common/precompile-storage/tests/ui/05_namespace_with_slot.stderr
+++ b/crates/common/precompile-storage/tests/ui/05_namespace_with_slot.stderr
@@ -3,11 +3,3 @@ error: cannot combine `slot`, `base_slot`, and `namespace` attributes on the sam
   |
 8 |     #[namespace("ns.field")]
   |     ^^^^^^^^^^^^^^^^^^^^^^^^
-
-warning: unused import: `alloy_primitives::U256`
- --> tests/ui/05_namespace_with_slot.rs:2:5
-  |
-2 | use alloy_primitives::U256;
-  |     ^^^^^^^^^^^^^^^^^^^^^^
-  |
-  = note: `#[warn(unused_imports)]` (part of `#[warn(unused)]`) on by default

--- a/crates/common/precompile-storage/tests/ui/05_namespace_with_slot.stderr
+++ b/crates/common/precompile-storage/tests/ui/05_namespace_with_slot.stderr
@@ -1,0 +1,13 @@
+error: cannot combine `slot`, `base_slot`, and `namespace` attributes on the same field
+ --> tests/ui/05_namespace_with_slot.rs:8:5
+  |
+8 |     #[namespace("ns.field")]
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^
+
+warning: unused import: `alloy_primitives::U256`
+ --> tests/ui/05_namespace_with_slot.rs:2:5
+  |
+2 | use alloy_primitives::U256;
+  |     ^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: `#[warn(unused_imports)]` (part of `#[warn(unused)]`) on by default

--- a/crates/common/precompile-storage/tests/ui/06_namespace_with_base_slot.rs
+++ b/crates/common/precompile-storage/tests/ui/06_namespace_with_base_slot.rs
@@ -1,0 +1,12 @@
+//! Combining `#[namespace]` and `#[base_slot]` on the same field must be a compile error.
+use alloy_primitives::U256;
+use base_precompile_macros::contract;
+
+#[contract]
+struct Foo {
+    #[base_slot(0)]
+    #[namespace("ns.field")]
+    value: U256,
+}
+
+fn main() {}

--- a/crates/common/precompile-storage/tests/ui/06_namespace_with_base_slot.rs
+++ b/crates/common/precompile-storage/tests/ui/06_namespace_with_base_slot.rs
@@ -1,12 +1,12 @@
 //! Combining `#[namespace]` and `#[base_slot]` on the same field must be a compile error.
-use alloy_primitives::U256;
+
 use base_precompile_macros::contract;
 
 #[contract]
 struct Foo {
     #[base_slot(0)]
     #[namespace("ns.field")]
-    value: U256,
+    value: u64,
 }
 
 fn main() {}

--- a/crates/common/precompile-storage/tests/ui/06_namespace_with_base_slot.stderr
+++ b/crates/common/precompile-storage/tests/ui/06_namespace_with_base_slot.stderr
@@ -3,11 +3,3 @@ error: cannot combine `slot`, `base_slot`, and `namespace` attributes on the sam
   |
 8 |     #[namespace("ns.field")]
   |     ^^^^^^^^^^^^^^^^^^^^^^^^
-
-warning: unused import: `alloy_primitives::U256`
- --> tests/ui/06_namespace_with_base_slot.rs:2:5
-  |
-2 | use alloy_primitives::U256;
-  |     ^^^^^^^^^^^^^^^^^^^^^^
-  |
-  = note: `#[warn(unused_imports)]` (part of `#[warn(unused)]`) on by default

--- a/crates/common/precompile-storage/tests/ui/06_namespace_with_base_slot.stderr
+++ b/crates/common/precompile-storage/tests/ui/06_namespace_with_base_slot.stderr
@@ -1,0 +1,13 @@
+error: cannot combine `slot`, `base_slot`, and `namespace` attributes on the same field
+ --> tests/ui/06_namespace_with_base_slot.rs:8:5
+  |
+8 |     #[namespace("ns.field")]
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^
+
+warning: unused import: `alloy_primitives::U256`
+ --> tests/ui/06_namespace_with_base_slot.rs:2:5
+  |
+2 | use alloy_primitives::U256;
+  |     ^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: `#[warn(unused_imports)]` (part of `#[warn(unused)]`) on by default

--- a/crates/common/precompile-storage/tests/ui/07_contract_namespace_with_field_slot.rs
+++ b/crates/common/precompile-storage/tests/ui/07_contract_namespace_with_field_slot.rs
@@ -1,0 +1,12 @@
+//! Field-level `#[slot]` cannot be used when a contract-level `#[namespace]` is active.
+use alloy_primitives::U256;
+use base_precompile_macros::{contract, namespace};
+
+#[namespace("ns.contract")]
+#[contract]
+struct Foo {
+    #[slot(0)]
+    value: U256,
+}
+
+fn main() {}

--- a/crates/common/precompile-storage/tests/ui/07_contract_namespace_with_field_slot.rs
+++ b/crates/common/precompile-storage/tests/ui/07_contract_namespace_with_field_slot.rs
@@ -1,12 +1,12 @@
 //! Field-level `#[slot]` cannot be used when a contract-level `#[namespace]` is active.
-use alloy_primitives::U256;
+
 use base_precompile_macros::{contract, namespace};
 
 #[namespace("ns.contract")]
 #[contract]
 struct Foo {
     #[slot(0)]
-    value: U256,
+    value: u64,
 }
 
 fn main() {}

--- a/crates/common/precompile-storage/tests/ui/07_contract_namespace_with_field_slot.stderr
+++ b/crates/common/precompile-storage/tests/ui/07_contract_namespace_with_field_slot.stderr
@@ -1,13 +1,5 @@
 error: field-level `slot`, `base_slot`, and `namespace` attributes cannot be used with contract-level `namespace`
  --> tests/ui/07_contract_namespace_with_field_slot.rs:9:5
   |
-9 |     value: U256,
+9 |     value: u64,
   |     ^^^^^
-
-warning: unused import: `alloy_primitives::U256`
- --> tests/ui/07_contract_namespace_with_field_slot.rs:2:5
-  |
-2 | use alloy_primitives::U256;
-  |     ^^^^^^^^^^^^^^^^^^^^^^
-  |
-  = note: `#[warn(unused_imports)]` (part of `#[warn(unused)]`) on by default

--- a/crates/common/precompile-storage/tests/ui/07_contract_namespace_with_field_slot.stderr
+++ b/crates/common/precompile-storage/tests/ui/07_contract_namespace_with_field_slot.stderr
@@ -1,0 +1,13 @@
+error: field-level `slot`, `base_slot`, and `namespace` attributes cannot be used with contract-level `namespace`
+ --> tests/ui/07_contract_namespace_with_field_slot.rs:9:5
+  |
+9 |     value: U256,
+  |     ^^^^^
+
+warning: unused import: `alloy_primitives::U256`
+ --> tests/ui/07_contract_namespace_with_field_slot.rs:2:5
+  |
+2 | use alloy_primitives::U256;
+  |     ^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: `#[warn(unused_imports)]` (part of `#[warn(unused)]`) on by default


### PR DESCRIPTION
[BOP-119](https://linear.app/coinbase/issue/BOP-119)

## Motivation

The `#[namespace]` macro enforces several invariants at compile time (missing `#[contract]`, duplicate attributes, empty or whitespace ids, conflicting attribute combinations), but none of these error paths had test coverage. A regression in the macro could silently start accepting invalid inputs with no automated signal.

## What changed

Added a `trybuild` test suite in `crates/common/precompile-storage/tests/ui/` with seven compile-fail fixtures, each covering one validation path:

- `01_namespace_without_contract.rs`: `#[namespace]` on a plain struct with neither `#[contract]` nor `#[derive(Storable)]`
- `02_duplicate_namespace_on_field.rs`: two `#[namespace]` attributes on the same field inside `#[contract]`
- `03_empty_namespace_id.rs`: empty string passed to `#[namespace("")]`
- `04_namespace_id_with_whitespace.rs`: namespace id containing a space (`"foo bar"`)
- `05_namespace_with_slot.rs`: `#[namespace]` and `#[slot]` on the same field
- `06_namespace_with_base_slot.rs`: `#[namespace]` and `#[base_slot]` on the same field
- `07_contract_namespace_with_field_slot.rs`: contract-level `#[namespace]` (via outer macro) combined with a field-level `#[slot]` attribute

Each fixture has a committed `.stderr` snapshot so `cargo test --test ui` will catch any deviation in error message or span.

## What was tried / considered

The tests could have lived in `base-precompile-macros` directly (the proc-macro crate). However, proc-macro crates cannot have integration tests that import themselves, and trybuild needs a crate that can be depended on by the fixtures. Placing the test suite in `base-precompile-storage` (which already depends on `base-precompile-macros`) follows the same pattern as the existing `contract` integration test and keeps the fixtures next to the runtime behavior they guard.

The `[[test]]` entry for `ui` intentionally omits `required-features = ["test-utils"]` because the fixtures do not exercise any runtime storage helpers and should compile (and fail) under the default feature set.