### PR TITLE
fix(precompiles): Fix B20 Factory Address

### DIFF
--- a/crates/common/precompiles/src/b20_factory/storage.rs
+++ b/crates/common/precompiles/src/b20_factory/storage.rs
@@ -26,7 +26,7 @@ pub struct B20FactoryStorage {}
 
 impl<'a> B20FactoryStorage<'a> {
     /// Singleton precompile address for the `B20Factory`.
-    pub const ADDRESS: Address = address!("b20f00000000000000000000000000000000000f");
+    pub const ADDRESS: Address = address!("B20F000000000000000000000000000000000000");
 
     /// Current token creation parameter version.
     pub const CREATE_TOKEN_VERSION: u8 = 1;
@@ -356,6 +356,14 @@ mod tests {
     };
 
     const ACTIVATION_ADMIN: Address = address!("0xcb00000000000000000000000000000000000000");
+
+    #[test]
+    fn factory_address_matches_canonical_precompile_address() {
+        assert_eq!(
+            B20FactoryStorage::ADDRESS,
+            address!("B20F000000000000000000000000000000000000")
+        );
+    }
 
     fn activate_precompiles(storage: &mut HashMapStorageProvider) {
         storage.set_caller(ACTIVATION_ADMIN);

--- a/etc/scripts/devnet/check-factory-live.sh
+++ b/etc/scripts/devnet/check-factory-live.sh
@@ -78,7 +78,7 @@ done
 [[ -n "$BOB_ADDR" ]] || BOB_ADDR="0x70997970C51812dc3A010C7d01b50e0d17dc79C8"
 
 # Factory precompile (singleton, fixed at chain genesis)
-FACTORY="0xb20f00000000000000000000000000000000000f"
+FACTORY="0xb20f000000000000000000000000000000000000"
 
 # Token creation parameters
 TOKEN_NAME="Base USD"


### PR DESCRIPTION
## Summary

This fixes the B20 factory singleton address constant to use the canonical B20F precompile address. The change keeps factory storage aligned with the intended precompile address and avoids encoding the factory marker byte in the wrong position.