### PR TITLE
fix(precompiles): Preserve Factory Init Caller

### DIFF
--- a/crates/common/precompile-storage/src/evm.rs
+++ b/crates/common/precompile-storage/src/evm.rs
@@ -254,6 +254,10 @@ impl PrecompileStorageProvider for EvmPrecompileStorageProvider<'_> {
         self.caller
     }
 
+    fn replace_caller(&mut self, caller: Address) -> Address {
+        core::mem::replace(&mut self.caller, caller)
+    }
+
     fn checkpoint(&mut self) -> JournalCheckpoint {
         self.internals.checkpoint()
     }

--- a/crates/common/precompile-storage/src/hashmap.rs
+++ b/crates/common/precompile-storage/src/hashmap.rs
@@ -197,6 +197,10 @@ impl PrecompileStorageProvider for HashMapStorageProvider {
         self.caller
     }
 
+    fn replace_caller(&mut self, caller: Address) -> Address {
+        core::mem::replace(&mut self.caller, caller)
+    }
+
     fn checkpoint(&mut self) -> JournalCheckpoint {
         let idx = self.snapshots.len();
         self.snapshots

--- a/crates/common/precompile-storage/src/provider.rs
+++ b/crates/common/precompile-storage/src/provider.rs
@@ -79,6 +79,8 @@ pub trait PrecompileStorageProvider {
 
     /// Returns the address that called this precompile.
     fn caller(&self) -> Address;
+    /// Replaces the current caller address and returns the previous caller.
+    fn replace_caller(&mut self, caller: Address) -> Address;
 
     /// Creates a new journal checkpoint for atomic state management.
     fn checkpoint(&mut self) -> JournalCheckpoint;

--- a/crates/common/precompile-storage/src/storage_ctx.rs
+++ b/crates/common/precompile-storage/src/storage_ctx.rs
@@ -171,6 +171,15 @@ impl<'a> StorageCtx<'a> {
         self.with_storage(|s| s.caller())
     }
 
+    /// Executes `f` with a temporary caller override, restoring the previous caller on exit.
+    pub fn with_caller<R>(&self, caller: Address, f: impl FnOnce() -> R) -> R {
+        let previous = self.with_storage(|s| s.replace_caller(caller));
+        let guard = CallerGuard { storage: *self, previous: Some(previous) };
+        let result = f();
+        drop(guard);
+        result
+    }
+
     /// Deducts gas from the remaining gas, returning `OutOfGas` if insufficient.
     pub fn deduct_gas(&self, gas: u64) -> Result<()> {
         self.try_with_storage(|s| s.deduct_gas(gas))
@@ -215,6 +224,23 @@ impl<'a> StorageCtx<'a> {
     /// Returns a [`PrecompileResult`] constructed from the given error.
     pub fn error_result(&self, error: impl Into<BasePrecompileError>) -> PrecompileResult {
         error.into().into_precompile_result(self.gas_used(), self.state_gas_used())
+    }
+}
+
+/// RAII guard for temporary caller overrides.
+#[derive(Debug)]
+struct CallerGuard<'a> {
+    storage: StorageCtx<'a>,
+    previous: Option<Address>,
+}
+
+impl Drop for CallerGuard<'_> {
+    fn drop(&mut self) {
+        if let Some(previous) = self.previous.take() {
+            self.storage.with_storage(|s| {
+                s.replace_caller(previous);
+            });
+        }
     }
 }
 
@@ -346,6 +372,29 @@ mod tests {
     fn test_reentrant_with_storage_panics() {
         let mut storage = crate::hashmap::HashMapStorageProvider::new(1);
         StorageCtx::enter(&mut storage, |ctx| ctx.with_storage(|_| ctx.with_storage(|_| ())));
+    }
+
+    #[test]
+    fn test_with_caller_restores_previous_caller() {
+        let mut storage = crate::hashmap::HashMapStorageProvider::new(1);
+        let original = Address::repeat_byte(0x11);
+        let outer = Address::repeat_byte(0x22);
+        let inner = Address::repeat_byte(0x33);
+        storage.set_caller(original);
+
+        StorageCtx::enter(&mut storage, |ctx| {
+            assert_eq!(ctx.caller(), original);
+            let value = ctx.with_caller(outer, || {
+                assert_eq!(ctx.caller(), outer);
+                ctx.with_caller(inner, || {
+                    assert_eq!(ctx.caller(), inner);
+                    7
+                })
+            });
+
+            assert_eq!(value, 7);
+            assert_eq!(ctx.caller(), original);
+        });
     }
 
     #[test]

--- a/crates/common/precompiles/src/b20_factory/storage.rs
+++ b/crates/common/precompiles/src/b20_factory/storage.rs
@@ -122,11 +122,14 @@ impl<'a> B20FactoryStorage<'a> {
             )?;
         }
 
-        for (index, calldata) in init_calls.into_iter().enumerate() {
-            token
-                .inner_with_privilege(self.storage, &calldata, true)
-                .map_err(|err| Self::map_init_call_error(index, err))?;
-        }
+        self.storage.with_caller(Self::ADDRESS, || {
+            for (index, calldata) in init_calls.into_iter().enumerate() {
+                token
+                    .inner_with_privilege(self.storage, &calldata, true)
+                    .map_err(|err| Self::map_init_call_error(index, err))?;
+            }
+            Ok::<(), BasePrecompileError>(())
+        })?;
         Ok(())
     }
 
@@ -160,11 +163,14 @@ impl<'a> B20FactoryStorage<'a> {
             )?;
         }
 
-        for (index, calldata) in init_calls.into_iter().enumerate() {
-            token
-                .inner_with_privilege(self.storage, &calldata, true)
-                .map_err(|err| Self::map_init_call_error(index, err))?;
-        }
+        self.storage.with_caller(Self::ADDRESS, || {
+            for (index, calldata) in init_calls.into_iter().enumerate() {
+                token
+                    .inner_with_privilege(self.storage, &calldata, true)
+                    .map_err(|err| Self::map_init_call_error(index, err))?;
+            }
+            Ok::<(), BasePrecompileError>(())
+        })?;
         Ok(())
     }
 
@@ -199,14 +205,17 @@ impl<'a> B20FactoryStorage<'a> {
             )?;
         }
 
-        for (index, calldata) in init_calls.into_iter().enumerate() {
-            B20SecurityToken::with_storage_and_policy(
-                B20SecurityStorage::from_address(token_address, self.storage),
-                PolicyHandle::new(self.storage),
-            )
-            .inner_with_privilege(self.storage, &calldata, true)
-            .map_err(|err| Self::map_init_call_error(index, err))?;
-        }
+        self.storage.with_caller(Self::ADDRESS, || {
+            for (index, calldata) in init_calls.into_iter().enumerate() {
+                B20SecurityToken::with_storage_and_policy(
+                    B20SecurityStorage::from_address(token_address, self.storage),
+                    PolicyHandle::new(self.storage),
+                )
+                .inner_with_privilege(self.storage, &calldata, true)
+                .map_err(|err| Self::map_init_call_error(index, err))?;
+            }
+            Ok::<(), BasePrecompileError>(())
+        })?;
         Ok(())
     }
 
@@ -537,6 +546,33 @@ mod tests {
 
             assert_eq!(token.b20.total_supply.read().unwrap(), supply);
             assert_eq!(token.balance_of(recipient).unwrap(), supply);
+        });
+    }
+
+    #[test]
+    fn test_create_token_init_calls_use_factory_caller_and_restore_creator() {
+        let mut storage = HashMapStorageProvider::new(1);
+        activate_precompiles(&mut storage);
+        let creator = Address::repeat_byte(0x55);
+        let spender = Address::repeat_byte(0x77);
+        let salt = B256::repeat_byte(0xCE);
+        let allowance = U256::from(123u64);
+        let mut call = create_call(
+            IB20Factory::B20Variant::DEFAULT,
+            token_params("Caller Token", "CALL"),
+            salt,
+        );
+        call.initCalls.push(IB20::approveCall { spender, amount: allowance }.abi_encode().into());
+        storage.set_caller(creator);
+
+        StorageCtx::enter(&mut storage, |ctx| {
+            let mut factory = B20FactoryStorage::new(ctx);
+            let token_addr = factory.create_b20(creator, call).unwrap();
+            let token = B20TokenStorage::from_address(token_addr, ctx);
+
+            assert_eq!(ctx.caller(), creator);
+            assert_eq!(token.allowance(B20FactoryStorage::ADDRESS, spender).unwrap(), allowance);
+            assert_eq!(token.allowance(creator, spender).unwrap(), U256::ZERO);
         });
     }
 


### PR DESCRIPTION
## Summary

B20 factory init calls are specified by base-std to run as calls from the factory into the newly created token, so the token must observe the factory as msg.sender during bootstrap. The Rust precompile path dispatches those init calls in-process instead of creating a nested EVM call frame, which otherwise leaves the external creator as ctx.caller and changes observable behavior such as approval owners, memo callers, and role-event senders. This adds a scoped storage caller override around only the factory init-call replay, restores the previous caller afterward, and wires all B20 variants through that scope. It also adds regression coverage for caller restoration and factory init-call caller identity.