### PR TITLE
fix(common): Align Activation Deactivate Revert

### DIFF
--- a/crates/common/precompiles/src/activation/storage.rs
+++ b/crates/common/precompiles/src/activation/storage.rs
@@ -150,7 +150,7 @@ impl ActivationRegistryStorage<'_> {
                 }));
             }
 
-            return Err(BasePrecompileError::revert(IActivationRegistry::AlreadyDeactivated {
+            return Err(BasePrecompileError::revert(IActivationRegistry::FeatureNotActivated {
                 feature,
             }));
         }
@@ -378,7 +378,21 @@ mod tests {
 
         let result = apply_transition(&mut storage, transition);
 
-        assert!(result.is_err());
+        assert_eq!(
+            result.unwrap_err(),
+            match transition {
+                Transition::Activate => {
+                    BasePrecompileError::revert(IActivationRegistry::AlreadyActivated {
+                        feature: FEATURE,
+                    })
+                }
+                Transition::Deactivate => {
+                    BasePrecompileError::revert(IActivationRegistry::FeatureNotActivated {
+                        feature: FEATURE,
+                    })
+                }
+            }
+        );
         assert_activated(&mut storage, initially_active);
         // A failed transition must not emit any events — guard against emit-then-revert bugs.
         assert_eq!(storage.get_events(ActivationRegistryStorage::ADDRESS).len(), events_before);


### PR DESCRIPTION
## Summary

`base-std` MockActivationRegistry treats `deactivate` on any inactive feature as the same not-currently-activated case and reverts with `FeatureNotActivated(feature)`:

```solidity
if (!$.features[feature]) revert FeatureNotActivated(feature);
```

The Rust precompile previously used a different ABI selector for the same state transition:

```rust
return Err(BasePrecompileError::revert(IActivationRegistry::AlreadyDeactivated {
    feature,
}));
```

That made consumers and tests using the `base-std` mock observe different revert data than the live precompile. This changes the Rust precompile to return `FeatureNotActivated(feature)` for inactive `deactivate` calls and pins both repeated transitions with exact selector assertions:

```rust
Transition::Deactivate => BasePrecompileError::revert(
    IActivationRegistry::FeatureNotActivated { feature: FEATURE },
)
```