### PR TITLE
test(action-harness): Assert Beryl Returndata Payloads

### DIFF
--- a/.github/workflows/zepter.yml
+++ b/.github/workflows/zepter.yml
@@ -23,9 +23,9 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 1
-      - uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4
+      - uses: taiki-e/install-action@3575e532701a5fc614b0c842e4119af4cc5fd16d # v2.62.60
         with:
-          just-version: "1.43.1"
+          tool: just@1.43.1
       - uses: taiki-e/install-action@3575e532701a5fc614b0c842e4119af4cc5fd16d # v2.62.60
         with:
           tool: zepter

--- a/actions/harness/tests/beryl/b20.rs
+++ b/actions/harness/tests/beryl/b20.rs
@@ -1,7 +1,7 @@
 //! B-20 precompile action tests across the Base Beryl boundary.
 
 use alloy_consensus::TxReceipt;
-use alloy_primitives::{Address, B256, Bytes, TxKind, U256, keccak256};
+use alloy_primitives::{Address, B256, Bytes, FixedBytes, TxKind, U256, keccak256};
 use alloy_signer::SignerSync;
 use alloy_signer_local::PrivateKeySigner;
 use alloy_sol_types::{SolCall, SolEvent, SolValue};
@@ -269,8 +269,16 @@ async fn b20_staticcall_abi_covers_all_read_methods() {
 
     scenario
         .assert_staticcall_cases(vec![
-            StaticcallCase::word("name", IB20::nameCall {}.abi_encode(), U256::from(32)),
-            StaticcallCase::word("symbol", IB20::symbolCall {}.abi_encode(), U256::from(32)),
+            StaticcallCase::output(
+                "name",
+                IB20::nameCall {}.abi_encode(),
+                IB20::nameCall::abi_encode_returns(&BerylTestEnv::B20_NAME.to_string()),
+            ),
+            StaticcallCase::output(
+                "symbol",
+                IB20::symbolCall {}.abi_encode(),
+                IB20::symbolCall::abi_encode_returns(&BerylTestEnv::B20_SYMBOL.to_string()),
+            ),
             StaticcallCase::word(
                 "decimals",
                 IB20::decimalsCall {}.abi_encode(),
@@ -296,7 +304,10 @@ async fn b20_staticcall_abi_covers_all_read_methods() {
                 "pausedFeatures",
                 IB20::pausedFeaturesCall {}.abi_encode(),
                 U256::from(32),
-            ),
+            )
+            .with_output(IB20::pausedFeaturesCall::abi_encode_returns(
+                &Vec::<IB20::PausableFeature>::new(),
+            )),
             StaticcallCase::word(
                 "isPaused",
                 IB20::isPausedCall { feature: IB20::PausableFeature::TRANSFER }.abi_encode(),
@@ -321,11 +332,18 @@ async fn b20_staticcall_abi_covers_all_read_methods() {
                 "eip712Domain",
                 IB20::eip712DomainCall {}.abi_encode(),
                 eip712_domain_fields_word(),
-            ),
-            StaticcallCase::word(
+            )
+            .with_output(IB20::eip712DomainCall::abi_encode_returns(
+                &eip712_domain_return(
+                    scenario.env.chain_id(),
+                    scenario.token,
+                    BerylTestEnv::B20_NAME,
+                ),
+            )),
+            StaticcallCase::output(
                 "contractURI",
                 IB20::contractURICall {}.abi_encode(),
-                U256::from(32),
+                IB20::contractURICall::abi_encode_returns(&String::new()),
             ),
         ])
         .await;
@@ -502,11 +520,29 @@ async fn b20_extended_mutations_update_state_and_emit_events() {
                 "pausedFeatures after unpause",
                 IB20::pausedFeaturesCall {}.abi_encode(),
                 U256::from(32),
-            ),
+            )
+            .with_output(IB20::pausedFeaturesCall::abi_encode_returns(
+                &Vec::<IB20::PausableFeature>::new(),
+            )),
             StaticcallCase::word(
                 "supplyCap after update",
                 IB20::supplyCapCall {}.abi_encode(),
                 new_cap,
+            ),
+            StaticcallCase::output(
+                "name after update",
+                IB20::nameCall {}.abi_encode(),
+                IB20::nameCall::abi_encode_returns(&"Action B20 Updated".to_string()),
+            ),
+            StaticcallCase::output(
+                "symbol after update",
+                IB20::symbolCall {}.abi_encode(),
+                IB20::symbolCall::abi_encode_returns(&"AB20U".to_string()),
+            ),
+            StaticcallCase::output(
+                "contractURI after update",
+                IB20::contractURICall {}.abi_encode(),
+                IB20::contractURICall::abi_encode_returns(&"ipfs://action".to_string()),
             ),
         ])
         .await;
@@ -675,6 +711,18 @@ impl B20TokenScenario {
                     case.label
                 );
             }
+            assert_eq!(
+                self.env.probe_return_size(*probe),
+                U256::from(case.expected_output.len()),
+                "{} staticcall must return the expected byte length",
+                case.label
+            );
+            assert_eq!(
+                self.env.probe_return_hash(*probe),
+                keccak256(&case.expected_output),
+                "{} staticcall must return the expected ABI payload hash",
+                case.label
+            );
         }
     }
 
@@ -765,11 +813,28 @@ struct StaticcallCase {
     label: &'static str,
     input: Vec<u8>,
     expected_word: Option<U256>,
+    expected_output: Vec<u8>,
 }
 
 impl StaticcallCase {
-    const fn word(label: &'static str, input: Vec<u8>, expected_word: U256) -> Self {
-        Self { label, input, expected_word: Some(expected_word) }
+    fn word(label: &'static str, input: Vec<u8>, expected_word: U256) -> Self {
+        Self {
+            label,
+            input,
+            expected_word: Some(expected_word),
+            expected_output: expected_word.abi_encode(),
+        }
+    }
+
+    fn output(label: &'static str, input: Vec<u8>, expected_output: Vec<u8>) -> Self {
+        let expected_word = expected_output.get(..32).map(U256::from_be_slice);
+        Self { label, input, expected_word, expected_output }
+    }
+
+    fn with_output(mut self, expected_output: Vec<u8>) -> Self {
+        self.expected_word = expected_output.get(..32).map(U256::from_be_slice);
+        self.expected_output = expected_output;
+        self
     }
 }
 
@@ -815,6 +880,18 @@ const fn eip712_domain_fields_word() -> U256 {
     let mut word = [0u8; 32];
     word[0] = 0x0f; // bits 0+1+2+3: name + version + chainId + verifyingContract
     U256::from_be_bytes(word)
+}
+
+fn eip712_domain_return(chain_id: u64, token: Address, name: &str) -> IB20::eip712DomainReturn {
+    IB20::eip712DomainReturn {
+        fields: FixedBytes::<1>::from([0x0f]),
+        name: name.to_string(),
+        version: "1".to_string(),
+        chainId: U256::from(chain_id),
+        verifyingContract: token,
+        salt: B256::ZERO,
+        extensions: Vec::new(),
+    }
 }
 
 struct B20StaticcallProbes {
@@ -884,11 +961,22 @@ impl B20StaticcallProbes {
     }
 
     fn assert_probe_return(scenario: &B20TokenScenario, probe: Address, expected: u64) {
+        let expected_output = U256::from(expected).abi_encode();
         assert!(scenario.env.probe_call_succeeded(probe), "B-20 staticcall probe must succeed");
         assert_eq!(
             scenario.env.probe_return_word(probe),
             U256::from(expected),
             "B-20 staticcall probe must return the expected word"
+        );
+        assert_eq!(
+            scenario.env.probe_return_size(probe),
+            U256::from(expected_output.len()),
+            "B-20 staticcall probe must return one ABI word"
+        );
+        assert_eq!(
+            scenario.env.probe_return_hash(probe),
+            keccak256(&expected_output),
+            "B-20 staticcall probe must return the expected ABI payload hash"
         );
     }
 }

--- a/actions/harness/tests/beryl/env.rs
+++ b/actions/harness/tests/beryl/env.rs
@@ -38,6 +38,12 @@ const PROBE_CALL_SUCCESS_SLOT: U256 = U256::ZERO;
 /// Storage slot where staticcall probes store the first returned word.
 const PROBE_RETURN_WORD_SLOT: U256 = U256::from_limbs([1, 0, 0, 0]);
 
+/// Storage slot where staticcall probes store the returned byte length.
+const PROBE_RETURN_SIZE_SLOT: U256 = U256::from_limbs([2, 0, 0, 0]);
+
+/// Storage slot where staticcall probes store `keccak256(returndata)`.
+const PROBE_RETURN_HASH_SLOT: U256 = U256::from_limbs([3, 0, 0, 0]);
+
 /// Test environment preconfigured to cross Base Beryl at L2 block 2.
 pub(crate) struct BerylTestEnv {
     /// Sequencer used to build Beryl precompile blocks.
@@ -372,6 +378,16 @@ impl BerylTestEnv {
         self.sequencer.storage_at(probe, PROBE_RETURN_WORD_SLOT)
     }
 
+    /// Reads the returned byte length from a staticcall probe's most recent call.
+    pub(crate) fn probe_return_size(&self, probe: Address) -> U256 {
+        self.sequencer.storage_at(probe, PROBE_RETURN_SIZE_SLOT)
+    }
+
+    /// Reads `keccak256(returndata)` from a staticcall probe's most recent call.
+    pub(crate) fn probe_return_hash(&self, probe: Address) -> B256 {
+        B256::from(self.sequencer.storage_at(probe, PROBE_RETURN_HASH_SLOT).to_be_bytes::<32>())
+    }
+
     /// Returns whether a user transaction in `block` succeeded.
     pub(crate) fn user_tx_succeeded(&self, block: &BaseBlock, user_tx_index: usize) -> bool {
         self.user_tx_receipt(block, user_tx_index).status()
@@ -481,13 +497,21 @@ impl BerylTestEnv {
     }
 
     fn staticcall_probe_init_code(target: Address) -> Bytes {
-        let mut runtime = Vec::with_capacity(47);
-        runtime.extend_from_slice(&hex!("3660006000376020600036600073"));
+        let mut runtime = Vec::with_capacity(65);
+        runtime.extend_from_slice(&hex!("3660006000376000600036600073"));
         runtime.extend_from_slice(target.as_slice());
-        runtime.extend_from_slice(&hex!("5afa8060005560005160015500"));
+        runtime.extend_from_slice(&hex!(
+            "5afa" // staticcall(gas(), target, 0, calldatasize(), 0, 0)
+            "8060005550" // store success in slot 0
+            "3d80600255" // store returndatasize in slot 2
+            "80600060003e" // copy returndata to memory
+            "600051600155" // store first returned word in slot 1
+            "600020600355" // store keccak256(returndata) in slot 3
+            "00"
+        ));
 
         let mut init_code = Vec::with_capacity(12 + runtime.len());
-        init_code.extend_from_slice(&hex!("602f600c600039602f6000f3"));
+        init_code.extend_from_slice(&hex!("6041600c60003960416000f3"));
         init_code.extend_from_slice(&runtime);
         Bytes::from(init_code)
     }

--- a/actions/harness/tests/beryl/stablecoin.rs
+++ b/actions/harness/tests/beryl/stablecoin.rs
@@ -559,13 +559,13 @@ fn assert_probe_returndata(
     expected_returndata: &[u8],
 ) {
     assert_eq!(
-        env.probe_return_length(probe),
+        env.probe_return_size(probe),
         U256::from(expected_returndata.len()),
         "{label} staticcall must return the expected byte length"
     );
     assert_eq!(
         env.probe_return_hash(probe),
-        returndata_hash_word(expected_returndata),
+        keccak256(expected_returndata),
         "{label} staticcall must return the expected ABI payload"
     );
 }
@@ -579,10 +579,6 @@ fn first_word(returndata: &[u8]) -> U256 {
     let copied = returndata.len().min(word.len());
     word[..copied].copy_from_slice(&returndata[..copied]);
     U256::from_be_bytes(word)
-}
-
-fn returndata_hash_word(returndata: &[u8]) -> U256 {
-    U256::from_be_slice(keccak256(returndata).as_slice())
 }
 
 fn word_from_address(address: Address) -> U256 {


### PR DESCRIPTION
## Summary

This strengthens the Beryl action-test staticcall probe so it records both the returned byte length and the keccak hash of full returndata while preserving the existing first-word checks. The B20 staticcall cases now assert exact ABI payloads for dynamic returns such as token metadata, paused features, contract URI, and EIP-712 domain output.