### PR TITLE
refactor(precompiles): Streamline Native Precompile Entrypoints

### DIFF
--- a/crates/common/precompile-macros/src/lib.rs
+++ b/crates/common/precompile-macros/src/lib.rs
@@ -6,6 +6,7 @@ pub(crate) use contract::{FieldInfo, FieldKind};
 mod layout;
 mod namespace;
 mod packing;
+mod precompile;
 mod storable;
 mod storable_primitives;
 mod storable_tests;
@@ -29,6 +30,12 @@ pub fn contract(attr: TokenStream, item: TokenStream) -> TokenStream {
 #[proc_macro_attribute]
 pub fn namespace(attr: TokenStream, item: TokenStream) -> TokenStream {
     namespace::expand(attr, item)
+}
+
+/// Generates EVM precompile constructor and optional singleton installation methods.
+#[proc_macro_attribute]
+pub fn precompile(attr: TokenStream, item: TokenStream) -> TokenStream {
+    precompile::expand(attr, item)
 }
 
 /// Derives the `Storable` trait for structs with named fields and `#[repr(u8)]` unit enums.

--- a/crates/common/precompile-macros/src/lib.rs
+++ b/crates/common/precompile-macros/src/lib.rs
@@ -33,6 +33,10 @@ pub fn namespace(attr: TokenStream, item: TokenStream) -> TokenStream {
 }
 
 /// Generates EVM precompile constructor and optional singleton installation methods.
+///
+/// By default this expands through `crate::macros::base_precompile!` in the invoking crate. Callers
+/// outside `base-common-precompiles` can pass `macro_path = path::to::wrapper_macro` to override the
+/// runtime wrapper macro.
 #[proc_macro_attribute]
 pub fn precompile(attr: TokenStream, item: TokenStream) -> TokenStream {
     precompile::expand(attr, item)

--- a/crates/common/precompile-macros/src/precompile.rs
+++ b/crates/common/precompile-macros/src/precompile.rs
@@ -1,0 +1,213 @@
+//! Implementation of the `#[precompile]` attribute macro.
+
+use proc_macro::TokenStream;
+use proc_macro2::TokenStream as TokenStream2;
+use quote::{format_ident, quote};
+use syn::{
+    Data, DeriveInput, Expr, Ident, LitStr, Token, Type, parenthesized,
+    parse::{Parse, ParseStream},
+};
+
+pub(crate) fn expand(attr: TokenStream, item: TokenStream) -> TokenStream {
+    match expand_impl(attr.into(), item.into()) {
+        Ok(tokens) => tokens.into(),
+        Err(err) => err.to_compile_error().into(),
+    }
+}
+
+fn expand_impl(attr: TokenStream2, item: TokenStream2) -> syn::Result<TokenStream2> {
+    let config: PrecompileConfig = syn::parse2(attr)?;
+    let input: DeriveInput = syn::parse2(item)?;
+    let Data::Struct(_) = &input.data else {
+        return Err(syn::Error::new_spanned(input.ident, "`#[precompile]` supports structs only"));
+    };
+
+    let ident = input.ident.clone();
+    let generics = input.generics.clone();
+    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
+    let base_name = precompile_name(&ident);
+    let id = config.id.unwrap_or_else(|| {
+        let id = LitStr::new(&base_name, ident.span());
+        syn::parse_quote!(#id)
+    });
+    let storage = config.storage.unwrap_or_else(|| {
+        let storage = format_ident!("{base_name}Storage", span = ident.span());
+        syn::parse_quote!(#storage<'_>)
+    });
+    let args = config.args;
+    let arg_defs = args.iter().map(PrecompileArg::definition);
+    let install_arg_defs = args.iter().map(PrecompileArg::definition);
+    let install_arg_names = args.iter().map(|arg| &arg.ident);
+    let install = config.install.map(|install| {
+        let address = install
+            .address
+            .map_or_else(|| quote! { <#storage>::ADDRESS }, |address| quote! { #address });
+        let doc = format!("Installs the `{ident}` precompile into `precompiles`.");
+
+        quote! {
+            #[doc = #doc]
+            pub fn install(
+                precompiles: &mut ::alloy_evm::precompiles::PrecompilesMap,
+                #(#install_arg_defs),*
+            ) {
+                precompiles.extend_precompiles(::core::iter::once((
+                    #address,
+                    Self::precompile(#(#install_arg_names),*),
+                )));
+            }
+        }
+    });
+    let precompile_doc = format!("Creates the EVM precompile wrapper for `{ident}`.");
+    let arg_names = args.iter().map(|arg| &arg.ident);
+
+    Ok(quote! {
+        #input
+
+        impl #impl_generics #ident #ty_generics #where_clause {
+            #install
+
+            #[doc = #precompile_doc]
+            pub fn precompile(#(#arg_defs),*) -> ::alloy_evm::precompiles::DynPrecompile {
+                crate::macros::base_precompile!(#id, |ctx, calldata| {
+                    <#storage>::new(ctx).dispatch(ctx, &calldata #(, #arg_names)*)
+                })
+            }
+        }
+    })
+}
+
+struct PrecompileConfig {
+    id: Option<Expr>,
+    storage: Option<Type>,
+    args: Vec<PrecompileArg>,
+    install: Option<InstallConfig>,
+}
+
+impl Parse for PrecompileConfig {
+    fn parse(input: ParseStream<'_>) -> syn::Result<Self> {
+        let mut id = None;
+        let mut storage = None;
+        let mut args = Vec::new();
+        let mut install = None;
+
+        while !input.is_empty() {
+            let fork = input.fork();
+            let Ok(key) = fork.parse::<Ident>() else {
+                reject_duplicate(&storage, &Ident::new("storage", input.span()))?;
+                storage = Some(input.parse()?);
+                if input.peek(Token![,]) {
+                    input.parse::<Token![,]>()?;
+                }
+                continue;
+            };
+            match key.to_string().as_str() {
+                "id" => {
+                    input.parse::<Ident>()?;
+                    reject_duplicate(&id, &key)?;
+                    input.parse::<Token![=]>()?;
+                    id = Some(input.parse()?);
+                }
+                "storage" => {
+                    input.parse::<Ident>()?;
+                    reject_duplicate(&storage, &key)?;
+                    input.parse::<Token![=]>()?;
+                    storage = Some(input.parse()?);
+                }
+                "args" => {
+                    input.parse::<Ident>()?;
+                    if !args.is_empty() {
+                        return Err(syn::Error::new_spanned(key, "duplicate `args` option"));
+                    }
+                    let content;
+                    parenthesized!(content in input);
+                    args = content
+                        .parse_terminated(PrecompileArg::parse, Token![,])?
+                        .into_iter()
+                        .collect();
+                }
+                "install" => {
+                    input.parse::<Ident>()?;
+                    reject_duplicate(&install, &key)?;
+                    install = if input.peek(syn::token::Paren) {
+                        let content;
+                        parenthesized!(content in input);
+                        Some(content.parse()?)
+                    } else {
+                        Some(InstallConfig { address: None })
+                    };
+                }
+                _ => {
+                    reject_duplicate(&storage, &key)?;
+                    storage = Some(input.parse()?);
+                }
+            }
+
+            if input.peek(Token![,]) {
+                input.parse::<Token![,]>()?;
+            }
+        }
+
+        Ok(Self { id, storage, args, install })
+    }
+}
+
+struct PrecompileArg {
+    ident: Ident,
+    ty: Type,
+}
+
+impl PrecompileArg {
+    fn definition(&self) -> TokenStream2 {
+        let ident = &self.ident;
+        let ty = &self.ty;
+
+        quote! { #ident: #ty }
+    }
+}
+
+impl Parse for PrecompileArg {
+    fn parse(input: ParseStream<'_>) -> syn::Result<Self> {
+        let ident = input.parse()?;
+        input.parse::<Token![:]>()?;
+        let ty = input.parse()?;
+
+        Ok(Self { ident, ty })
+    }
+}
+
+struct InstallConfig {
+    address: Option<Expr>,
+}
+
+impl Parse for InstallConfig {
+    fn parse(input: ParseStream<'_>) -> syn::Result<Self> {
+        let key: Ident = input.parse()?;
+        if key != "address" && key != "addr" {
+            return Err(syn::Error::new_spanned(key, "`install` supports only `address = ...`"));
+        }
+
+        input.parse::<Token![=]>()?;
+        let address = input.parse()?;
+
+        if !input.is_empty() {
+            input.parse::<Token![,]>()?;
+        }
+        if !input.is_empty() {
+            return Err(syn::Error::new(input.span(), "unexpected `install` option"));
+        }
+
+        Ok(Self { address: Some(address) })
+    }
+}
+
+fn reject_duplicate<T>(option: &Option<T>, ident: &Ident) -> syn::Result<()> {
+    if option.is_some() {
+        return Err(syn::Error::new_spanned(ident, format!("duplicate `{ident}` option")));
+    }
+
+    Ok(())
+}
+
+fn precompile_name(ident: &Ident) -> String {
+    ident.to_string().trim_end_matches("Precompile").to_owned()
+}

--- a/crates/common/precompile-macros/src/precompile.rs
+++ b/crates/common/precompile-macros/src/precompile.rs
@@ -4,7 +4,7 @@ use proc_macro::TokenStream;
 use proc_macro2::TokenStream as TokenStream2;
 use quote::{format_ident, quote};
 use syn::{
-    Data, DeriveInput, Expr, Ident, LitStr, Token, Type, parenthesized,
+    Data, DeriveInput, Expr, Ident, LitStr, Path, Token, Type, parenthesized,
     parse::{Parse, ParseStream},
 };
 
@@ -34,6 +34,8 @@ fn expand_impl(attr: TokenStream2, item: TokenStream2) -> syn::Result<TokenStrea
         let storage = format_ident!("{base_name}Storage", span = ident.span());
         syn::parse_quote!(#storage<'_>)
     });
+    let macro_path =
+        config.macro_path.unwrap_or_else(|| syn::parse_quote!(crate::macros::base_precompile));
     let args = config.args;
     let arg_defs = args.iter().map(PrecompileArg::definition);
     let install_arg_defs = args.iter().map(PrecompileArg::definition);
@@ -68,7 +70,7 @@ fn expand_impl(attr: TokenStream2, item: TokenStream2) -> syn::Result<TokenStrea
 
             #[doc = #precompile_doc]
             pub fn precompile(#(#arg_defs),*) -> ::alloy_evm::precompiles::DynPrecompile {
-                crate::macros::base_precompile!(#id, |ctx, calldata| {
+                #macro_path!(#id, |ctx, calldata| {
                     <#storage>::new(ctx).dispatch(ctx, &calldata #(, #arg_names)*)
                 })
             }
@@ -79,6 +81,7 @@ fn expand_impl(attr: TokenStream2, item: TokenStream2) -> syn::Result<TokenStrea
 struct PrecompileConfig {
     id: Option<Expr>,
     storage: Option<Type>,
+    macro_path: Option<Path>,
     args: Vec<PrecompileArg>,
     install: Option<InstallConfig>,
 }
@@ -87,34 +90,29 @@ impl Parse for PrecompileConfig {
     fn parse(input: ParseStream<'_>) -> syn::Result<Self> {
         let mut id = None;
         let mut storage = None;
+        let mut macro_path = None;
         let mut args = Vec::new();
         let mut install = None;
 
         while !input.is_empty() {
-            let fork = input.fork();
-            let Ok(key) = fork.parse::<Ident>() else {
-                reject_duplicate(&storage, &Ident::new("storage", input.span()))?;
-                storage = Some(input.parse()?);
-                if input.peek(Token![,]) {
-                    input.parse::<Token![,]>()?;
-                }
-                continue;
-            };
+            let key: Ident = input.parse()?;
             match key.to_string().as_str() {
                 "id" => {
-                    input.parse::<Ident>()?;
                     reject_duplicate(&id, &key)?;
                     input.parse::<Token![=]>()?;
                     id = Some(input.parse()?);
                 }
                 "storage" => {
-                    input.parse::<Ident>()?;
                     reject_duplicate(&storage, &key)?;
                     input.parse::<Token![=]>()?;
                     storage = Some(input.parse()?);
                 }
+                "macro_path" => {
+                    reject_duplicate(&macro_path, &key)?;
+                    input.parse::<Token![=]>()?;
+                    macro_path = Some(input.parse()?);
+                }
                 "args" => {
-                    input.parse::<Ident>()?;
                     if !args.is_empty() {
                         return Err(syn::Error::new_spanned(key, "duplicate `args` option"));
                     }
@@ -126,7 +124,6 @@ impl Parse for PrecompileConfig {
                         .collect();
                 }
                 "install" => {
-                    input.parse::<Ident>()?;
                     reject_duplicate(&install, &key)?;
                     install = if input.peek(syn::token::Paren) {
                         let content;
@@ -137,8 +134,10 @@ impl Parse for PrecompileConfig {
                     };
                 }
                 _ => {
-                    reject_duplicate(&storage, &key)?;
-                    storage = Some(input.parse()?);
+                    return Err(syn::Error::new_spanned(
+                        key,
+                        "expected `id`, `storage`, `macro_path`, `args`, or `install`",
+                    ));
                 }
             }
 
@@ -147,7 +146,7 @@ impl Parse for PrecompileConfig {
             }
         }
 
-        Ok(Self { id, storage, args, install })
+        Ok(Self { id, storage, macro_path, args, install })
     }
 }
 
@@ -210,4 +209,48 @@ fn reject_duplicate<T>(option: &Option<T>, ident: &Ident) -> syn::Result<()> {
 
 fn precompile_name(ident: &Ident) -> String {
     ident.to_string().trim_end_matches("Precompile").to_owned()
+}
+
+#[cfg(test)]
+mod tests {
+    use proc_macro2::TokenStream as TokenStream2;
+    use quote::quote;
+
+    use super::PrecompileConfig;
+
+    fn parse_config(tokens: TokenStream2) -> syn::Result<PrecompileConfig> {
+        syn::parse2(tokens)
+    }
+
+    #[test]
+    fn config_rejects_unknown_options() {
+        let err = parse_config(quote! { instal }).err().unwrap();
+
+        assert!(
+            err.to_string()
+                .contains("expected `id`, `storage`, `macro_path`, `args`, or `install`")
+        );
+    }
+
+    #[test]
+    fn config_rejects_positional_storage() {
+        let err = parse_config(quote! { CustomStorage<'_> }).err().unwrap();
+
+        assert!(
+            err.to_string()
+                .contains("expected `id`, `storage`, `macro_path`, `args`, or `install`")
+        );
+    }
+
+    #[test]
+    fn config_accepts_explicit_storage_and_macro_path() {
+        let config = parse_config(quote! {
+            storage = CustomStorage<'_>,
+            macro_path = crate::macros::custom_precompile,
+        })
+        .unwrap();
+
+        assert!(config.storage.is_some());
+        assert!(config.macro_path.is_some());
+    }
 }

--- a/crates/common/precompiles/src/activation/precompile.rs
+++ b/crates/common/precompiles/src/activation/precompile.rs
@@ -1,28 +1,11 @@
 //! Precompile entry point for the activation registry.
 
-use alloy_evm::precompiles::{DynPrecompile, PrecompilesMap};
 use alloy_primitives::Address;
+use base_precompile_macros::precompile;
 
 use super::ActivationRegistryStorage;
-use crate::macros::base_precompile;
 
 /// Entry point for the activation registry precompile.
+#[precompile(install, args(activation_admin_address: Option<Address>))]
 #[derive(Debug, Default, Clone, Copy)]
 pub struct ActivationRegistry;
-
-impl ActivationRegistry {
-    /// Installs the singleton activation registry precompile into `precompiles`.
-    pub fn install(precompiles: &mut PrecompilesMap, activation_admin_address: Option<Address>) {
-        precompiles.extend_precompiles(core::iter::once((
-            ActivationRegistryStorage::ADDRESS,
-            Self::precompile(activation_admin_address),
-        )));
-    }
-
-    /// Creates the EVM precompile wrapper for the activation registry.
-    pub fn precompile(activation_admin_address: Option<Address>) -> DynPrecompile {
-        base_precompile!("ActivationRegistry", |ctx, calldata| {
-            ActivationRegistryStorage::new(ctx).dispatch(ctx, &calldata, activation_admin_address)
-        })
-    }
-}

--- a/crates/common/precompiles/src/b20_factory/precompile.rs
+++ b/crates/common/precompiles/src/b20_factory/precompile.rs
@@ -1,24 +1,10 @@
 //! Precompile entry point for the `B20Factory`.
 
-use alloy_evm::precompiles::{DynPrecompile, PrecompilesMap};
+use base_precompile_macros::precompile;
 
-use crate::{B20FactoryStorage, macros::base_precompile};
+use crate::B20FactoryStorage;
 
 /// Entry point for the `B20Factory` precompile.
+#[precompile(install)]
 #[derive(Debug, Default, Clone, Copy)]
 pub struct B20Factory;
-
-impl B20Factory {
-    /// Installs the singleton `B20Factory` precompile into `precompiles`.
-    pub fn install(precompiles: &mut PrecompilesMap) {
-        precompiles
-            .extend_precompiles(core::iter::once((B20FactoryStorage::ADDRESS, Self::precompile())));
-    }
-
-    /// Returns a [`DynPrecompile`] registerable with a [`PrecompilesMap`].
-    pub fn precompile() -> DynPrecompile {
-        base_precompile!("B20Factory", |ctx, calldata| {
-            B20FactoryStorage::new(ctx).dispatch(ctx, &calldata)
-        })
-    }
-}

--- a/crates/common/precompiles/src/b20_stablecoin/precompile.rs
+++ b/crates/common/precompiles/src/b20_stablecoin/precompile.rs
@@ -1,32 +1,18 @@
 //! Precompile entry point for the stablecoin B-20 variant.
 
-use alloy_evm::precompiles::{DynPrecompile, PrecompilesMap};
+use alloy_evm::precompiles::DynPrecompile;
 use alloy_primitives::Address;
 
 use super::{B20StablecoinToken, storage::B20StablecoinStorage};
-use crate::{B20Variant, PolicyHandle, macros::base_precompile};
+use crate::{PolicyHandle, macros::base_precompile};
 
 /// Entry point for the stablecoin B-20 token precompile.
 ///
-/// Wraps [`B20StablecoinToken`] dispatch behind a [`DynPrecompile`] for
-/// registration in a [`PrecompilesMap`].
+/// Wraps [`B20StablecoinToken`] dispatch behind a [`DynPrecompile`].
 #[derive(Debug)]
 pub struct B20StablecoinPrecompile;
 
 impl B20StablecoinPrecompile {
-    /// Installs the stablecoin dynamic precompile lookup into `precompiles`.
-    pub fn install(precompiles: &mut PrecompilesMap) {
-        precompiles.set_precompile_lookup(Self::lookup);
-    }
-
-    /// Returns the stablecoin precompile for `address`, if it encodes a stablecoin token.
-    pub fn lookup(address: &Address) -> Option<DynPrecompile> {
-        match B20Variant::from_address(*address)? {
-            B20Variant::Stablecoin => Some(Self::create_precompile(*address)),
-            _ => None,
-        }
-    }
-
     /// Returns a [`DynPrecompile`] that dispatches to [`B20StablecoinToken`] logic at
     /// `token_address`.
     pub fn create_precompile(token_address: Address) -> DynPrecompile {

--- a/crates/common/precompiles/src/lib.rs
+++ b/crates/common/precompiles/src/lib.rs
@@ -10,6 +10,9 @@ mod macros;
 mod provider;
 pub use provider::BasePrecompiles;
 
+mod lookup;
+pub use lookup::BerylLookup;
+
 mod spec;
 pub use spec::BasePrecompileSpec;
 

--- a/crates/common/precompiles/src/lookup.rs
+++ b/crates/common/precompiles/src/lookup.rs
@@ -1,0 +1,26 @@
+//! Dynamic lookup for Beryl-native precompiles.
+
+use alloy_evm::precompiles::{DynPrecompile, PrecompilesMap};
+use alloy_primitives::Address;
+
+use crate::{B20SecurityPrecompile, B20StablecoinPrecompile, B20TokenPrecompile, B20Variant};
+
+/// Dynamic precompile lookup installed for Beryl and later forks.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct BerylLookup;
+
+impl BerylLookup {
+    /// Installs the Beryl dynamic precompile lookup into `precompiles`.
+    pub fn install(precompiles: &mut PrecompilesMap) {
+        precompiles.set_precompile_lookup(Self::lookup);
+    }
+
+    /// Returns the B-20 variant precompile for `address`, if it encodes one.
+    pub fn lookup(address: &Address) -> Option<DynPrecompile> {
+        match B20Variant::from_address(*address)? {
+            B20Variant::B20 => Some(B20TokenPrecompile::create_precompile(*address)),
+            B20Variant::Stablecoin => Some(B20StablecoinPrecompile::create_precompile(*address)),
+            B20Variant::Security => Some(B20SecurityPrecompile::create_precompile(*address)),
+        }
+    }
+}

--- a/crates/common/precompiles/src/policy/precompile.rs
+++ b/crates/common/precompiles/src/policy/precompile.rs
@@ -1,26 +1,10 @@
 //! Entry point for the `PolicyRegistry` precompile.
 
-use alloy_evm::precompiles::{DynPrecompile, PrecompilesMap};
+use base_precompile_macros::precompile;
 
-use crate::{PolicyRegistryStorage, macros::base_precompile};
+use crate::PolicyRegistryStorage;
 
 /// EVM entry point for the `PolicyRegistry` precompile.
+#[precompile(install)]
 #[derive(Debug, Default, Clone, Copy)]
 pub struct PolicyRegistryPrecompile;
-
-impl PolicyRegistryPrecompile {
-    /// Installs the singleton `PolicyRegistry` precompile into `precompiles`.
-    pub fn install(precompiles: &mut PrecompilesMap) {
-        precompiles.extend_precompiles(core::iter::once((
-            PolicyRegistryStorage::ADDRESS,
-            Self::precompile(),
-        )));
-    }
-
-    /// Returns a [`DynPrecompile`] registerable with a [`PrecompilesMap`].
-    pub fn precompile() -> DynPrecompile {
-        base_precompile!("PolicyRegistry", |ctx, calldata| {
-            PolicyRegistryStorage::new(ctx).dispatch(ctx, &calldata)
-        })
-    }
-}

--- a/crates/common/precompiles/src/provider.rs
+++ b/crates/common/precompiles/src/provider.rs
@@ -13,24 +13,9 @@ use revm::{
 };
 
 use crate::{
-    ActivationRegistry, B20Factory, B20SecurityPrecompile, B20StablecoinPrecompile,
-    B20TokenPrecompile, B20Variant, BasePrecompileSpec, PolicyRegistryPrecompile, bls12_381,
-    bn254_pair,
+    ActivationRegistry, B20Factory, BasePrecompileSpec, BerylLookup, PolicyRegistryPrecompile,
+    bls12_381, bn254_pair,
 };
-
-/// Combined lookup for all B-20 token variants.
-///
-/// A single named function is required because `set_precompile_lookup` accepts
-/// function pointers (which are lifetime-generic) but not closures with a specific
-/// lifetime, and because successive `set_precompile_lookup` calls replace rather
-/// than chain the previous lookup.
-fn b20_token_lookup(address: &Address) -> Option<alloy_evm::precompiles::DynPrecompile> {
-    match B20Variant::from_address(*address)? {
-        B20Variant::B20 => Some(B20TokenPrecompile::create_precompile(*address)),
-        B20Variant::Stablecoin => Some(B20StablecoinPrecompile::create_precompile(*address)),
-        B20Variant::Security => Some(B20SecurityPrecompile::create_precompile(*address)),
-    }
-}
 
 /// Base precompile provider.
 #[derive(Debug, Clone)]
@@ -186,9 +171,7 @@ impl<S: BasePrecompileSpec> BasePrecompiles<S> {
         let mut precompiles = PrecompilesMap::from_static(self.precompiles());
         if self.spec.upgrade() >= BaseUpgrade::Beryl {
             B20Factory::install(&mut precompiles);
-            // A single combined lookup covers all B-20 variants:
-            // set_precompile_lookup replaces, not chains, so we cannot call install twice.
-            precompiles.set_precompile_lookup(b20_token_lookup);
+            BerylLookup::install(&mut precompiles);
             PolicyRegistryPrecompile::install(&mut precompiles);
             ActivationRegistry::install(&mut precompiles, self.activation_admin_address);
         }


### PR DESCRIPTION
## Summary

This refactor adds a `#[precompile]` attribute macro for singleton native precompile entrypoints and converts the factory, policy, and activation wrappers to use it. It also moves the Beryl dynamic B-20 routing into a `BerylLookup` install type so the provider installs every Beryl surface through explicit install calls. The old stablecoin-specific dynamic lookup helper was removed because the combined Beryl lookup owns that routing.