### PR TITLE
test(action-harness): Speed Up Sequence Window Test

### DIFF
--- a/actions/harness/tests/derivation/main.rs
+++ b/actions/harness/tests/derivation/main.rs
@@ -2525,7 +2525,7 @@ async fn large_l1_gaps_within_sequence_window() {
 /// Configuration:
 /// - `seq_window_size = 4` (small window so epochs expire quickly)
 /// - Zero batches submitted
-/// - 20 empty L1 blocks mined
+/// - More than two sequence windows of empty L1 blocks mined
 ///
 /// Expected result: the safe head advances well past genesis as the pipeline
 /// synthesises deposit-only blocks for each expired epoch.
@@ -2533,6 +2533,7 @@ async fn large_l1_gaps_within_sequence_window() {
 #[tokio::test]
 async fn extended_sequence_window_exhaustion_fills_with_deposit_only_blocks() {
     const SEQ_WINDOW: u64 = 4;
+    const EMPTY_L1_BLOCKS: u64 = SEQ_WINDOW * 2 + 2;
     let batcher_cfg = BatcherConfig::default();
     let rollup_cfg = TestRollupConfigBuilder::base_mainnet(&batcher_cfg)
         .with_seq_window_size(SEQ_WINDOW)
@@ -2546,17 +2547,15 @@ async fn extended_sequence_window_exhaustion_fills_with_deposit_only_blocks() {
         SharedL1Chain::from_blocks(h.l1.chain().to_vec()),
     );
 
-    // Mine 20 empty L1 blocks — no batches submitted anywhere.
-    for _ in 0..20 {
+    // Mine empty L1 blocks across multiple sequence windows with no batches
+    // submitted anywhere.
+    for _ in 0..EMPTY_L1_BLOCKS {
         h.mine_and_push(&chain);
     }
 
     node.initialize().await;
 
-    let mut total_derived = 0;
-    for _ in 1..=20u64 {
-        total_derived += node.run_until_idle().await;
-    }
+    let total_derived = node.run_until_idle().await;
 
     // With no batches, the pipeline generates deposit-only blocks for each
     // expired sequence window. The safe head must advance past genesis.
@@ -2571,4 +2570,10 @@ async fn extended_sequence_window_exhaustion_fills_with_deposit_only_blocks() {
         "pipeline must have generated deposit-only blocks for expired epochs; \
          total_derived = {total_derived}"
     );
+    for block_number in 1..=node.l2_safe_number() {
+        let block = node
+            .derived_block(block_number)
+            .expect("every derived block should be recorded by the node");
+        assert!(block.is_deposit_only(), "derived block {block_number} must be deposit-only");
+    }
 }


### PR DESCRIPTION
## Summary

This speeds up the slow action-harness derivation test by shrinking the empty-L1-block workload to the minimum multi-window case and draining the node once instead of repeating run_until_idle after it is already idle. The full base-action-harness CI-profile suite moved from 173.013s to 138.876s, a 34.137s improvement and 19.7% reduction. The original full-suite outlier for this test dropped from 97.241s to 37.494s, so it no longer trips the 90s action-test slow threshold. Validation passed with the focused test, full base-action-harness CI-profile nextest run, clippy, fmt, and git diff checks.