### PR TITLE
test(action-harness): Add B20 Security Tests

### DIFF
--- a/actions/harness/tests/beryl/env.rs
+++ b/actions/harness/tests/beryl/env.rs
@@ -12,7 +12,8 @@ use base_batcher_encoder::{DaType, EncoderConfig};
 use base_common_consensus::{BaseBlock, BaseReceipt, BaseTxEnvelope};
 use base_common_precompiles::{
     ActivationFeature, ActivationRegistryStorage, B20FactoryStorage, B20Variant,
-    IActivationRegistry, IB20, IB20Factory, IPolicyRegistry,
+    IActivationRegistry, IB20, IB20Factory, IPolicyRegistry, PolicyRegistryStorage,
+    REDEEM_SENDER_POLICY,
 };
 use base_precompile_storage::StorageKey;
 use base_test_utils::Account;
@@ -83,6 +84,21 @@ impl BerylTestEnv {
 
     /// ISO 4217 currency code for the stablecoin B-20 token variant.
     pub(crate) const B20_STABLECOIN_CURRENCY: &str = "USD";
+
+    /// Fixed decimals for the security B-20 token variant.
+    pub(crate) const B20_SECURITY_DECIMALS: u8 = 6;
+
+    /// Name for the security B-20 token variant.
+    pub(crate) const B20_SECURITY_NAME: &str = "Action Security";
+
+    /// Symbol for the security B-20 token variant.
+    pub(crate) const B20_SECURITY_SYMBOL: &str = "ASEC";
+
+    /// ISIN stored on the security B-20 token at creation.
+    pub(crate) const B20_SECURITY_ISIN: &str = "US0000000001";
+
+    /// Initial minimum redeemable share amount for the security B-20 token.
+    pub(crate) const B20_SECURITY_MINIMUM_REDEEMABLE: u64 = 10;
 
     /// Initial B-20 supply minted to Alice.
     pub(crate) const B20_INITIAL_SUPPLY: u64 = 1_000_000;
@@ -186,6 +202,11 @@ impl BerylTestEnv {
         ActivationFeature::B20Stablecoin.id()
     }
 
+    /// Activation registry feature ID for the B-20 security precompile.
+    pub(crate) const fn b20_security_feature() -> B256 {
+        ActivationFeature::B20Security.id()
+    }
+
     /// Activation registry feature ID for the policy registry precompile.
     pub(crate) const fn policy_registry_feature() -> B256 {
         ActivationFeature::PolicyRegistry.id()
@@ -213,6 +234,11 @@ impl BerylTestEnv {
         B256::repeat_byte(0x45)
     }
 
+    /// Returns the deterministic salt used to create the B-20 security token.
+    pub(crate) const fn b20_security_salt() -> B256 {
+        B256::repeat_byte(0x46)
+    }
+
     /// Returns the deterministic B-20 token address created by Alice.
     pub(crate) fn b20_token_address(&self) -> Address {
         B20Variant::B20.compute_address(Self::alice(), Self::b20_token_salt()).0
@@ -221,6 +247,11 @@ impl BerylTestEnv {
     /// Returns the deterministic B-20 stablecoin address created by Alice.
     pub(crate) fn b20_stablecoin_address(&self) -> Address {
         B20Variant::Stablecoin.compute_address(Self::alice(), Self::b20_stablecoin_salt()).0
+    }
+
+    /// Returns the deterministic B-20 security token address created by Alice.
+    pub(crate) fn b20_security_address(&self) -> Address {
+        B20Variant::Security.compute_address(Self::alice(), Self::b20_security_salt()).0
     }
 
     /// Creates a transaction that calls the B-20 token factory with the default salt.
@@ -247,6 +278,20 @@ impl BerylTestEnv {
         self.create_tx(
             TxKind::Call(B20FactoryStorage::ADDRESS),
             Bytes::from(self.create_b20_stablecoin_call_with_salt(salt).abi_encode()),
+            Self::B20_GAS_LIMIT,
+        )
+    }
+
+    /// Creates a transaction that calls the B-20 token factory for a security token.
+    pub(crate) fn create_b20_security_tx(&self) -> BaseTxEnvelope {
+        self.create_b20_security_with_salt_tx(Self::b20_security_salt())
+    }
+
+    /// Creates a security-token factory transaction with the given `salt`.
+    pub(crate) fn create_b20_security_with_salt_tx(&self, salt: B256) -> BaseTxEnvelope {
+        self.create_tx(
+            TxKind::Call(B20FactoryStorage::ADDRESS),
+            Bytes::from(self.create_b20_security_call_with_salt(salt).abi_encode()),
             Self::B20_GAS_LIMIT,
         )
     }
@@ -540,6 +585,25 @@ impl BerylTestEnv {
         }
     }
 
+    fn create_b20_security_call_with_salt(&self, salt: B256) -> IB20Factory::createB20Call {
+        IB20Factory::createB20Call {
+            variant: IB20Factory::B20Variant::SECURITY,
+            salt,
+            params: self.b20_security_params().abi_encode().into(),
+            initCalls: vec![
+                IB20::mintCall { to: Self::alice(), amount: U256::from(Self::B20_INITIAL_SUPPLY) }
+                    .abi_encode()
+                    .into(),
+                IB20::updatePolicyCall {
+                    policyScope: REDEEM_SENDER_POLICY,
+                    newPolicyId: PolicyRegistryStorage::ALWAYS_ALLOW_ID,
+                }
+                .abi_encode()
+                .into(),
+            ],
+        }
+    }
+
     fn create_account_tx(
         chain_id: u64,
         account: &mut TestAccount,
@@ -580,6 +644,17 @@ impl BerylTestEnv {
             symbol: Self::B20_STABLECOIN_SYMBOL.to_string(),
             initialAdmin: Self::alice(),
             currency: Self::B20_STABLECOIN_CURRENCY.to_string(),
+        }
+    }
+
+    fn b20_security_params(&self) -> IB20Factory::B20SecurityCreateParams {
+        IB20Factory::B20SecurityCreateParams {
+            version: B20FactoryStorage::CREATE_TOKEN_VERSION,
+            name: Self::B20_SECURITY_NAME.to_string(),
+            symbol: Self::B20_SECURITY_SYMBOL.to_string(),
+            initialAdmin: Self::alice(),
+            isin: Self::B20_SECURITY_ISIN.to_string(),
+            minimumRedeemable: U256::from(Self::B20_SECURITY_MINIMUM_REDEEMABLE),
         }
     }
 

--- a/actions/harness/tests/beryl/main.rs
+++ b/actions/harness/tests/beryl/main.rs
@@ -7,4 +7,5 @@ mod env;
 mod factory;
 mod policy_registry;
 mod policy_transfer;
+mod security;
 mod stablecoin;

--- a/actions/harness/tests/beryl/main.rs
+++ b/actions/harness/tests/beryl/main.rs
@@ -9,3 +9,4 @@ mod policy_registry;
 mod policy_transfer;
 mod security;
 mod stablecoin;
+mod test_helpers;

--- a/actions/harness/tests/beryl/security.rs
+++ b/actions/harness/tests/beryl/security.rs
@@ -9,7 +9,10 @@ use base_common_precompiles::{
     REDEEM_SENDER_POLICY,
 };
 
-use crate::env::BerylTestEnv;
+use crate::{
+    env::BerylTestEnv,
+    test_helpers::{self, StaticcallCase, word_from_address},
+};
 
 const WAD: U256 = U256::from_limbs([1_000_000_000_000_000_000, 0, 0, 0]);
 const UPDATED_RATIO: U256 = U256::from_limbs([2_000_000_000_000_000_000, 0, 0, 0]);
@@ -617,10 +620,8 @@ impl B20SecurityScenario {
         &mut self,
         transactions: Vec<BaseTxEnvelope>,
     ) -> BaseBlock {
-        let block = self.env.sequencer.build_next_block_with_transactions(transactions).await;
-        let block_number = self.blocks.len() as u64 + 1;
-        self.blocks.push((block.clone(), block_number));
-        block
+        test_helpers::build_block_with_transactions(&mut self.env, &mut self.blocks, transactions)
+            .await
     }
 
     async fn grant_roles(&mut self, roles: impl IntoIterator<Item = B256>) {
@@ -644,91 +645,22 @@ impl B20SecurityScenario {
     }
 
     async fn assert_staticcall_cases(&mut self, target: Address, cases: Vec<StaticcallCase>) {
-        let mut probes = Vec::with_capacity(cases.len());
-        let mut deployments = Vec::with_capacity(cases.len());
-        for _ in &cases {
-            let (probe, deploy) = self.env.deploy_staticcall_probe_tx(target);
-            probes.push(probe);
-            deployments.push(deploy);
-        }
-
-        let deploy_block = self.build_block_with_transactions(deployments).await;
-        for index in 0..cases.len() {
-            assert!(
-                self.env.user_tx_succeeded(&deploy_block, index),
-                "security staticcall probe deployment {index} must succeed"
-            );
-        }
-
-        let calls = probes
-            .iter()
-            .zip(cases.iter())
-            .map(|(probe, case)| {
-                self.env.call_staticcall_probe_tx(
-                    *probe,
-                    Bytes::from(case.input.clone()),
-                    BerylTestEnv::B20_PROBE_GAS_LIMIT,
-                )
-            })
-            .collect();
-        let call_block = self.build_block_with_transactions(calls).await;
-
-        for (index, (probe, case)) in probes.iter().zip(cases.iter()).enumerate() {
-            assert!(
-                self.env.user_tx_succeeded(&call_block, index),
-                "{} probe transaction must succeed",
-                case.label
-            );
-            assert!(
-                self.env.probe_call_succeeded(*probe),
-                "{} staticcall must succeed",
-                case.label
-            );
-            assert_eq!(
-                self.env.probe_return_word(*probe),
-                case.expected_word,
-                "{} staticcall must return the expected first word",
-                case.label
-            );
-            assert_eq!(
-                self.env.probe_return_length(*probe),
-                U256::from(case.expected_returndata.len()),
-                "{} staticcall must return the expected byte length",
-                case.label
-            );
-            assert_eq!(
-                self.env.probe_return_hash(*probe),
-                returndata_hash_word(&case.expected_returndata),
-                "{} staticcall must return the expected ABI payload",
-                case.label
-            );
-        }
+        test_helpers::assert_staticcall_cases(
+            &mut self.env,
+            &mut self.blocks,
+            target,
+            cases,
+            "security",
+        )
+        .await;
     }
 
     fn assert_total_supply(&self, total_supply: u64) {
-        assert_eq!(
-            self.env.b20_total_supply(self.token),
-            U256::from(total_supply),
-            "security B-20 total supply must match expected value"
-        );
+        test_helpers::assert_total_supply(&self.env, self.token, "security B-20", total_supply);
     }
 
     fn assert_balances(&self, alice: u64, bob: u64, carol: u64) {
-        assert_eq!(
-            self.env.b20_balance(self.token, BerylTestEnv::alice()),
-            U256::from(alice),
-            "Alice security B-20 balance must match expected value"
-        );
-        assert_eq!(
-            self.env.b20_balance(self.token, BerylTestEnv::bob()),
-            U256::from(bob),
-            "Bob security B-20 balance must match expected value"
-        );
-        assert_eq!(
-            self.env.b20_balance(self.token, BerylTestEnv::carol()),
-            U256::from(carol),
-            "Carol security B-20 balance must match expected value"
-        );
+        test_helpers::assert_balances(&self.env, self.token, "security B-20", alice, bob, carol);
     }
 
     fn assert_token_created_log(&self, block: &BaseBlock) {
@@ -770,53 +702,10 @@ impl B20SecurityScenario {
     }
 }
 
-struct StaticcallCase {
-    label: &'static str,
-    input: Vec<u8>,
-    expected_word: U256,
-    expected_returndata: Vec<u8>,
-}
-
-impl StaticcallCase {
-    fn returndata(label: &'static str, input: Vec<u8>, expected_returndata: Vec<u8>) -> Self {
-        let expected_word = first_word(&expected_returndata);
-        Self { label, input, expected_word, expected_returndata }
-    }
-
-    fn word(label: &'static str, input: Vec<u8>, expected_word: U256) -> Self {
-        Self::returndata(label, input, expected_word.abi_encode())
-    }
-
-    fn bytes32(label: &'static str, input: Vec<u8>, expected: B256) -> Self {
-        Self::returndata(label, input, expected.abi_encode())
-    }
-
-    fn string(label: &'static str, input: Vec<u8>, expected: &str) -> Self {
-        Self::returndata(label, input, expected.to_string().abi_encode())
-    }
-}
-
 fn security_operator_role() -> B256 {
     keccak256("SECURITY_OPERATOR_ROLE")
 }
 
 fn burn_from_role() -> B256 {
     keccak256("BURN_FROM_ROLE")
-}
-
-fn word_from_address(address: Address) -> U256 {
-    let mut word = [0u8; 32];
-    word[12..].copy_from_slice(address.as_slice());
-    U256::from_be_slice(&word)
-}
-
-fn first_word(bytes: &[u8]) -> U256 {
-    let mut word = [0u8; 32];
-    let copied = bytes.len().min(32);
-    word[..copied].copy_from_slice(&bytes[..copied]);
-    U256::from_be_bytes(word)
-}
-
-fn returndata_hash_word(bytes: &[u8]) -> U256 {
-    U256::from_be_slice(keccak256(bytes).as_slice())
 }

--- a/actions/harness/tests/beryl/security.rs
+++ b/actions/harness/tests/beryl/security.rs
@@ -1,0 +1,822 @@
+//! Security B-20 precompile action tests across the Base Beryl boundary.
+
+use alloy_consensus::TxReceipt;
+use alloy_primitives::{Address, B256, Bytes, LogData, TxKind, U256, keccak256};
+use alloy_sol_types::{SolCall, SolEvent, SolValue};
+use base_common_consensus::{BaseBlock, BaseTxEnvelope};
+use base_common_precompiles::{
+    B20FactoryStorage, B20TokenRole, IB20, IB20Factory, IB20Security, PolicyRegistryStorage,
+    REDEEM_SENDER_POLICY,
+};
+
+use crate::env::BerylTestEnv;
+
+const WAD: U256 = U256::from_limbs([1_000_000_000_000_000_000, 0, 0, 0]);
+const UPDATED_RATIO: U256 = U256::from_limbs([2_000_000_000_000_000_000, 0, 0, 0]);
+const UPDATED_MINIMUM_REDEEMABLE: U256 = U256::from_limbs([20, 0, 0, 0]);
+const BOB_MINT_AMOUNT: u64 = 100;
+const CAROL_MINT_AMOUNT: u64 = 200;
+const BOB_BURN_AMOUNT: u64 = 10;
+const CAROL_BURN_AMOUNT: u64 = 20;
+const REDEEM_AMOUNT: u64 = 20;
+const REDEEM_WITH_MEMO_AMOUNT: u64 = 30;
+const REDEEM_MEMO: B256 = B256::repeat_byte(0x61);
+const CUSIP: &str = "123456789";
+const FIGI: &str = "BBG000000001";
+const ANNOUNCEMENT_ID: &str = "security-action-1";
+const ANNOUNCEMENT_DESCRIPTION: &str = "update FIGI";
+const ANNOUNCEMENT_URI: &str = "ipfs://security-action";
+
+#[tokio::test]
+async fn security_creation_initializes_identifiers_and_factory_views() {
+    let mut scenario = B20SecurityScenario::new().await;
+
+    scenario
+        .assert_staticcall_cases(
+            B20FactoryStorage::ADDRESS,
+            vec![
+                StaticcallCase::word(
+                    "factory getB20Address(SECURITY)",
+                    IB20Factory::getB20AddressCall {
+                        variant: IB20Factory::B20Variant::SECURITY,
+                        sender: BerylTestEnv::alice(),
+                        salt: BerylTestEnv::b20_security_salt(),
+                    }
+                    .abi_encode(),
+                    word_from_address(scenario.token),
+                ),
+                StaticcallCase::word(
+                    "factory isB20(security)",
+                    IB20Factory::isB20Call { token: scenario.token }.abi_encode(),
+                    U256::ONE,
+                ),
+                StaticcallCase::word(
+                    "factory isB20Initialized(security)",
+                    IB20Factory::isB20InitializedCall { token: scenario.token }.abi_encode(),
+                    U256::ONE,
+                ),
+            ],
+        )
+        .await;
+
+    scenario
+        .assert_staticcall_cases(
+            scenario.token,
+            vec![
+                StaticcallCase::string(
+                    "name",
+                    IB20::nameCall {}.abi_encode(),
+                    BerylTestEnv::B20_SECURITY_NAME,
+                ),
+                StaticcallCase::string(
+                    "symbol",
+                    IB20::symbolCall {}.abi_encode(),
+                    BerylTestEnv::B20_SECURITY_SYMBOL,
+                ),
+                StaticcallCase::string("contractURI", IB20::contractURICall {}.abi_encode(), ""),
+                StaticcallCase::string(
+                    "securityIdentifier(ISIN)",
+                    IB20Security::securityIdentifierCall { identifierType: "ISIN".to_string() }
+                        .abi_encode(),
+                    BerylTestEnv::B20_SECURITY_ISIN,
+                ),
+                StaticcallCase::word(
+                    "decimals",
+                    IB20::decimalsCall {}.abi_encode(),
+                    U256::from(BerylTestEnv::B20_SECURITY_DECIMALS),
+                ),
+                StaticcallCase::word(
+                    "totalSupply",
+                    IB20::totalSupplyCall {}.abi_encode(),
+                    U256::from(BerylTestEnv::B20_INITIAL_SUPPLY),
+                ),
+                StaticcallCase::word(
+                    "balanceOf(alice)",
+                    IB20::balanceOfCall { account: BerylTestEnv::alice() }.abi_encode(),
+                    U256::from(BerylTestEnv::B20_INITIAL_SUPPLY),
+                ),
+                StaticcallCase::word(
+                    "sharesToTokensRatio",
+                    IB20Security::sharesToTokensRatioCall {}.abi_encode(),
+                    WAD,
+                ),
+                StaticcallCase::word(
+                    "WAD_PRECISION",
+                    IB20Security::WAD_PRECISIONCall {}.abi_encode(),
+                    WAD,
+                ),
+                StaticcallCase::word(
+                    "toShares",
+                    IB20Security::toSharesCall { balance: U256::from(100) }.abi_encode(),
+                    U256::from(100),
+                ),
+                StaticcallCase::word(
+                    "sharesOf(alice)",
+                    IB20Security::sharesOfCall { account: BerylTestEnv::alice() }.abi_encode(),
+                    U256::from(BerylTestEnv::B20_INITIAL_SUPPLY),
+                ),
+                StaticcallCase::word(
+                    "minimumRedeemable",
+                    IB20Security::minimumRedeemableCall {}.abi_encode(),
+                    U256::from(BerylTestEnv::B20_SECURITY_MINIMUM_REDEEMABLE),
+                ),
+                StaticcallCase::word(
+                    "isAnnouncementIdUsed(fresh)",
+                    IB20Security::isAnnouncementIdUsedCall { id: ANNOUNCEMENT_ID.to_string() }
+                        .abi_encode(),
+                    U256::ZERO,
+                ),
+                StaticcallCase::bytes32(
+                    "SECURITY_OPERATOR_ROLE",
+                    IB20Security::SECURITY_OPERATOR_ROLECall {}.abi_encode(),
+                    security_operator_role(),
+                ),
+                StaticcallCase::bytes32(
+                    "BURN_FROM_ROLE",
+                    IB20Security::BURN_FROM_ROLECall {}.abi_encode(),
+                    burn_from_role(),
+                ),
+                StaticcallCase::bytes32(
+                    "REDEEM_SENDER_POLICY",
+                    IB20Security::REDEEM_SENDER_POLICYCall {}.abi_encode(),
+                    REDEEM_SENDER_POLICY,
+                ),
+                StaticcallCase::word(
+                    "policyId(REDEEM_SENDER_POLICY)",
+                    IB20::policyIdCall { policyScope: REDEEM_SENDER_POLICY }.abi_encode(),
+                    U256::from(PolicyRegistryStorage::ALWAYS_ALLOW_ID),
+                ),
+                StaticcallCase::returndata(
+                    "pausedFeatures",
+                    IB20::pausedFeaturesCall {}.abi_encode(),
+                    Vec::<IB20::PausableFeature>::new().abi_encode(),
+                ),
+            ],
+        )
+        .await;
+
+    scenario.derive().await;
+}
+
+#[tokio::test]
+async fn security_mutations_update_state_and_emit_events() {
+    let mut scenario = B20SecurityScenario::new().await;
+    scenario
+        .grant_roles([security_operator_role(), burn_from_role(), B20TokenRole::Mint.id()])
+        .await;
+
+    let update_ratio = scenario
+        .call_tx(IB20Security::updateShareRatioCall { newSharesToTokensRatio: UPDATED_RATIO });
+    let update_minimum = scenario.call_tx(IB20Security::updateMinimumRedeemableCall {
+        newMinimumRedeemable: UPDATED_MINIMUM_REDEEMABLE,
+    });
+    let update_cusip = scenario.call_tx(IB20Security::updateSecurityIdentifierCall {
+        identifierType: "CUSIP".to_string(),
+        value: CUSIP.to_string(),
+    });
+    let batch_mint = scenario.call_tx(IB20Security::batchMintCall {
+        recipients: vec![BerylTestEnv::bob(), BerylTestEnv::carol()],
+        amounts: vec![U256::from(BOB_MINT_AMOUNT), U256::from(CAROL_MINT_AMOUNT)],
+    });
+    let batch_burn = scenario.call_tx(IB20Security::batchBurnCall {
+        accounts: vec![BerylTestEnv::bob(), BerylTestEnv::carol()],
+        amounts: vec![U256::from(BOB_BURN_AMOUNT), U256::from(CAROL_BURN_AMOUNT)],
+    });
+    let redeem = scenario.call_tx(IB20Security::redeemCall { amount: U256::from(REDEEM_AMOUNT) });
+    let redeem_with_memo = scenario.call_tx(IB20Security::redeemWithMemoCall {
+        amount: U256::from(REDEEM_WITH_MEMO_AMOUNT),
+        memo: REDEEM_MEMO,
+    });
+    let announced_identifier = IB20Security::updateSecurityIdentifierCall {
+        identifierType: "FIGI".to_string(),
+        value: FIGI.to_string(),
+    };
+    let announce = scenario.call_tx(IB20Security::announceCall {
+        internalCalls: vec![Bytes::from(announced_identifier.abi_encode())],
+        id: ANNOUNCEMENT_ID.to_string(),
+        description: ANNOUNCEMENT_DESCRIPTION.to_string(),
+        uri: ANNOUNCEMENT_URI.to_string(),
+    });
+    let block = scenario
+        .build_block_with_transactions(vec![
+            update_ratio,
+            update_minimum,
+            update_cusip,
+            batch_mint,
+            batch_burn,
+            redeem,
+            redeem_with_memo,
+            announce,
+        ])
+        .await;
+
+    for index in 0..8 {
+        assert!(
+            scenario.env.user_tx_succeeded(&block, index),
+            "security mutation {index} must succeed"
+        );
+    }
+
+    scenario.assert_log(
+        &block,
+        0,
+        IB20Security::ShareRatioUpdated { sharesToTokensRatio: UPDATED_RATIO }.encode_log_data(),
+    );
+    scenario.assert_log(
+        &block,
+        1,
+        IB20Security::MinimumRedeemableUpdated {
+            caller: BerylTestEnv::alice(),
+            newMinimumRedeemable: UPDATED_MINIMUM_REDEEMABLE,
+        }
+        .encode_log_data(),
+    );
+    scenario.assert_log(
+        &block,
+        2,
+        IB20Security::SecurityIdentifierUpdated {
+            identifierType: "CUSIP".to_string(),
+            value: CUSIP.to_string(),
+        }
+        .encode_log_data(),
+    );
+    scenario.assert_log(
+        &block,
+        3,
+        IB20::Transfer {
+            from: Address::ZERO,
+            to: BerylTestEnv::bob(),
+            amount: U256::from(BOB_MINT_AMOUNT),
+        }
+        .encode_log_data(),
+    );
+    scenario.assert_log(
+        &block,
+        3,
+        IB20::Transfer {
+            from: Address::ZERO,
+            to: BerylTestEnv::carol(),
+            amount: U256::from(CAROL_MINT_AMOUNT),
+        }
+        .encode_log_data(),
+    );
+    scenario.assert_log(
+        &block,
+        4,
+        IB20::Transfer {
+            from: BerylTestEnv::bob(),
+            to: Address::ZERO,
+            amount: U256::from(BOB_BURN_AMOUNT),
+        }
+        .encode_log_data(),
+    );
+    scenario.assert_log(
+        &block,
+        4,
+        IB20::Transfer {
+            from: BerylTestEnv::carol(),
+            to: Address::ZERO,
+            amount: U256::from(CAROL_BURN_AMOUNT),
+        }
+        .encode_log_data(),
+    );
+    scenario.assert_log(
+        &block,
+        5,
+        IB20Security::Redeemed {
+            from: BerylTestEnv::alice(),
+            amt: U256::from(REDEEM_AMOUNT),
+            sharesToTokensRatio: UPDATED_RATIO,
+        }
+        .encode_log_data(),
+    );
+    scenario.assert_log(
+        &block,
+        6,
+        IB20::Memo { caller: BerylTestEnv::alice(), memo: REDEEM_MEMO }.encode_log_data(),
+    );
+    scenario.assert_log(
+        &block,
+        6,
+        IB20Security::Redeemed {
+            from: BerylTestEnv::alice(),
+            amt: U256::from(REDEEM_WITH_MEMO_AMOUNT),
+            sharesToTokensRatio: UPDATED_RATIO,
+        }
+        .encode_log_data(),
+    );
+    scenario.assert_log(
+        &block,
+        7,
+        IB20Security::Announcement {
+            caller: BerylTestEnv::alice(),
+            id: ANNOUNCEMENT_ID.to_string(),
+            description: ANNOUNCEMENT_DESCRIPTION.to_string(),
+            uri: ANNOUNCEMENT_URI.to_string(),
+        }
+        .encode_log_data(),
+    );
+    scenario.assert_log(
+        &block,
+        7,
+        IB20Security::SecurityIdentifierUpdated {
+            identifierType: "FIGI".to_string(),
+            value: FIGI.to_string(),
+        }
+        .encode_log_data(),
+    );
+    scenario.assert_log(
+        &block,
+        7,
+        IB20Security::EndAnnouncement { id: ANNOUNCEMENT_ID.to_string() }.encode_log_data(),
+    );
+
+    scenario.assert_total_supply(
+        BerylTestEnv::B20_INITIAL_SUPPLY + BOB_MINT_AMOUNT + CAROL_MINT_AMOUNT
+            - BOB_BURN_AMOUNT
+            - CAROL_BURN_AMOUNT
+            - REDEEM_AMOUNT
+            - REDEEM_WITH_MEMO_AMOUNT,
+    );
+    scenario.assert_balances(
+        BerylTestEnv::B20_INITIAL_SUPPLY - REDEEM_AMOUNT - REDEEM_WITH_MEMO_AMOUNT,
+        BOB_MINT_AMOUNT - BOB_BURN_AMOUNT,
+        CAROL_MINT_AMOUNT - CAROL_BURN_AMOUNT,
+    );
+
+    scenario
+        .assert_staticcall_cases(
+            scenario.token,
+            vec![
+                StaticcallCase::word(
+                    "sharesToTokensRatio after update",
+                    IB20Security::sharesToTokensRatioCall {}.abi_encode(),
+                    UPDATED_RATIO,
+                ),
+                StaticcallCase::word(
+                    "toShares after update",
+                    IB20Security::toSharesCall { balance: U256::from(50) }.abi_encode(),
+                    U256::from(100),
+                ),
+                StaticcallCase::word(
+                    "sharesOf(alice) after redeem",
+                    IB20Security::sharesOfCall { account: BerylTestEnv::alice() }.abi_encode(),
+                    U256::from(BerylTestEnv::B20_INITIAL_SUPPLY - 50) * U256::from(2),
+                ),
+                StaticcallCase::word(
+                    "minimumRedeemable after update",
+                    IB20Security::minimumRedeemableCall {}.abi_encode(),
+                    UPDATED_MINIMUM_REDEEMABLE,
+                ),
+                StaticcallCase::string(
+                    "securityIdentifier(CUSIP)",
+                    IB20Security::securityIdentifierCall { identifierType: "CUSIP".to_string() }
+                        .abi_encode(),
+                    CUSIP,
+                ),
+                StaticcallCase::string(
+                    "securityIdentifier(FIGI)",
+                    IB20Security::securityIdentifierCall { identifierType: "FIGI".to_string() }
+                        .abi_encode(),
+                    FIGI,
+                ),
+                StaticcallCase::word(
+                    "isAnnouncementIdUsed",
+                    IB20Security::isAnnouncementIdUsedCall { id: ANNOUNCEMENT_ID.to_string() }
+                        .abi_encode(),
+                    U256::ONE,
+                ),
+                StaticcallCase::word(
+                    "totalSupply after security mutations",
+                    IB20::totalSupplyCall {}.abi_encode(),
+                    U256::from(1_000_220),
+                ),
+            ],
+        )
+        .await;
+
+    scenario.derive().await;
+}
+
+#[tokio::test]
+async fn security_mutations_revert_on_invalid_inputs() {
+    let mut scenario = B20SecurityScenario::new().await;
+    scenario
+        .grant_roles([security_operator_role(), burn_from_role(), B20TokenRole::Mint.id()])
+        .await;
+
+    let first_announcement = scenario.call_tx(IB20Security::announceCall {
+        internalCalls: Vec::new(),
+        id: "duplicate-id".to_string(),
+        description: "initial".to_string(),
+        uri: "ipfs://initial".to_string(),
+    });
+    let empty_batch_mint = scenario
+        .call_tx(IB20Security::batchMintCall { recipients: Vec::new(), amounts: Vec::new() });
+    let mismatched_batch_mint = scenario.call_tx(IB20Security::batchMintCall {
+        recipients: vec![BerylTestEnv::bob()],
+        amounts: vec![U256::from(1), U256::from(2)],
+    });
+    let mismatched_batch_burn = scenario.call_tx(IB20Security::batchBurnCall {
+        accounts: vec![BerylTestEnv::bob()],
+        amounts: vec![U256::from(1), U256::from(2)],
+    });
+    let below_minimum_redeem = scenario.call_tx(IB20Security::redeemCall { amount: U256::from(1) });
+    let empty_identifier_type = scenario.call_tx(IB20Security::updateSecurityIdentifierCall {
+        identifierType: String::new(),
+        value: "x".to_string(),
+    });
+    let duplicate_announcement = scenario.call_tx(IB20Security::announceCall {
+        internalCalls: Vec::new(),
+        id: "duplicate-id".to_string(),
+        description: "again".to_string(),
+        uri: "ipfs://again".to_string(),
+    });
+    let malformed_internal_call = scenario.call_tx(IB20Security::announceCall {
+        internalCalls: vec![Bytes::from(vec![1, 2, 3])],
+        id: "malformed-id".to_string(),
+        description: "malformed".to_string(),
+        uri: "ipfs://malformed".to_string(),
+    });
+    let recursive_call = IB20Security::announceCall {
+        internalCalls: Vec::new(),
+        id: "inner".to_string(),
+        description: "inner".to_string(),
+        uri: "ipfs://inner".to_string(),
+    };
+    let recursive_announcement = scenario.call_tx(IB20Security::announceCall {
+        internalCalls: vec![Bytes::from(recursive_call.abi_encode())],
+        id: "recursive-id".to_string(),
+        description: "recursive".to_string(),
+        uri: "ipfs://recursive".to_string(),
+    });
+    let block = scenario
+        .build_block_with_transactions(vec![
+            first_announcement,
+            empty_batch_mint,
+            mismatched_batch_mint,
+            mismatched_batch_burn,
+            below_minimum_redeem,
+            empty_identifier_type,
+            duplicate_announcement,
+            malformed_internal_call,
+            recursive_announcement,
+        ])
+        .await;
+
+    assert!(scenario.env.user_tx_succeeded(&block, 0), "first announce() must succeed");
+    for index in 1..9 {
+        assert!(
+            !scenario.env.user_tx_succeeded(&block, index),
+            "invalid security mutation {index} must revert"
+        );
+    }
+    scenario.assert_total_supply(BerylTestEnv::B20_INITIAL_SUPPLY);
+    scenario.assert_balances(BerylTestEnv::B20_INITIAL_SUPPLY, 0, 0);
+
+    scenario
+        .assert_staticcall_cases(
+            scenario.token,
+            vec![
+                StaticcallCase::word(
+                    "duplicate announcement id remains used",
+                    IB20Security::isAnnouncementIdUsedCall { id: "duplicate-id".to_string() }
+                        .abi_encode(),
+                    U256::ONE,
+                ),
+                StaticcallCase::word(
+                    "failed malformed announcement id is rolled back",
+                    IB20Security::isAnnouncementIdUsedCall { id: "malformed-id".to_string() }
+                        .abi_encode(),
+                    U256::ZERO,
+                ),
+                StaticcallCase::word(
+                    "failed recursive announcement id is rolled back",
+                    IB20Security::isAnnouncementIdUsedCall { id: "recursive-id".to_string() }
+                        .abi_encode(),
+                    U256::ZERO,
+                ),
+            ],
+        )
+        .await;
+
+    scenario.derive().await;
+}
+
+#[tokio::test]
+async fn security_calls_revert_while_security_feature_is_deactivated() {
+    let mut scenario = B20SecurityScenario::new().await;
+
+    let deactivate_security =
+        scenario.env.deactivate_feature_tx(BerylTestEnv::b20_security_feature());
+    let block = scenario.build_block_with_transactions(vec![deactivate_security]).await;
+    assert!(scenario.env.user_tx_succeeded(&block, 0), "B20_SECURITY deactivation must succeed");
+
+    let transfer_while_deactivated =
+        scenario.call_tx(IB20::transferCall { to: BerylTestEnv::bob(), amount: U256::from(1) });
+    let block = scenario.build_block_with_transactions(vec![transfer_while_deactivated]).await;
+    assert!(
+        !scenario.env.user_tx_succeeded(&block, 0),
+        "security token call must revert while B20_SECURITY is deactivated"
+    );
+
+    let (probe, deploy_probe) = scenario.env.deploy_staticcall_probe_tx(scenario.token);
+    let block = scenario.build_block_with_transactions(vec![deploy_probe]).await;
+    assert!(scenario.env.user_tx_succeeded(&block, 0), "staticcall probe must deploy");
+
+    let probe_call = scenario.env.call_staticcall_probe_tx(
+        probe,
+        Bytes::from(IB20Security::sharesToTokensRatioCall {}.abi_encode()),
+        BerylTestEnv::B20_PROBE_GAS_LIMIT,
+    );
+    let block = scenario.build_block_with_transactions(vec![probe_call]).await;
+    assert!(scenario.env.user_tx_succeeded(&block, 0), "probe transaction must succeed");
+    assert!(
+        !scenario.env.probe_call_succeeded(probe),
+        "security staticcall must fail while B20_SECURITY is deactivated"
+    );
+
+    let reactivate_security =
+        scenario.env.activate_feature_tx(BerylTestEnv::b20_security_feature());
+    let block = scenario.build_block_with_transactions(vec![reactivate_security]).await;
+    assert!(scenario.env.user_tx_succeeded(&block, 0), "B20_SECURITY re-activation must succeed");
+
+    let transfer_after_reactivate =
+        scenario.call_tx(IB20::transferCall { to: BerylTestEnv::bob(), amount: U256::from(1) });
+    let block = scenario.build_block_with_transactions(vec![transfer_after_reactivate]).await;
+    assert!(
+        scenario.env.user_tx_succeeded(&block, 0),
+        "security token call must succeed after B20_SECURITY is re-activated"
+    );
+    scenario.assert_balances(BerylTestEnv::B20_INITIAL_SUPPLY - 1, 1, 0);
+
+    scenario.derive().await;
+}
+
+struct B20SecurityScenario {
+    env: BerylTestEnv,
+    token: Address,
+    blocks: Vec<(BaseBlock, u64)>,
+}
+
+impl B20SecurityScenario {
+    async fn new() -> Self {
+        let env = BerylTestEnv::new();
+        let token = env.b20_security_address();
+        let mut scenario = Self { env, token, blocks: Vec::new() };
+
+        scenario.build_block_with_transactions(Vec::new()).await;
+
+        let activate_factory =
+            scenario.env.activate_feature_tx(BerylTestEnv::b20_factory_feature());
+        let activate_security =
+            scenario.env.activate_feature_tx(BerylTestEnv::b20_security_feature());
+        let activate_policy =
+            scenario.env.activate_feature_tx(BerylTestEnv::policy_registry_feature());
+        let block = scenario
+            .build_block_with_transactions(vec![
+                activate_factory,
+                activate_security,
+                activate_policy,
+            ])
+            .await;
+
+        assert!(scenario.env.user_tx_succeeded(&block, 0), "TOKEN_FACTORY activation must succeed");
+        assert!(scenario.env.user_tx_succeeded(&block, 1), "B20_SECURITY activation must succeed");
+        assert!(
+            scenario.env.user_tx_succeeded(&block, 2),
+            "POLICY_REGISTRY activation must succeed"
+        );
+
+        let create = scenario.env.create_b20_security_tx();
+        let block = scenario.build_block_with_transactions(vec![create]).await;
+
+        assert!(
+            scenario.env.user_tx_succeeded(&block, 0),
+            "security B-20 creation transaction must succeed"
+        );
+        assert!(scenario.env.sequencer.has_code(token), "security B-20 code must be deployed");
+        scenario.assert_token_created_log(&block);
+        scenario.assert_log(
+            &block,
+            0,
+            IB20::Transfer {
+                from: Address::ZERO,
+                to: BerylTestEnv::alice(),
+                amount: U256::from(BerylTestEnv::B20_INITIAL_SUPPLY),
+            }
+            .encode_log_data(),
+        );
+        scenario.assert_total_supply(BerylTestEnv::B20_INITIAL_SUPPLY);
+        scenario.assert_balances(BerylTestEnv::B20_INITIAL_SUPPLY, 0, 0);
+
+        scenario
+    }
+
+    async fn build_block_with_transactions(
+        &mut self,
+        transactions: Vec<BaseTxEnvelope>,
+    ) -> BaseBlock {
+        let block = self.env.sequencer.build_next_block_with_transactions(transactions).await;
+        let block_number = self.blocks.len() as u64 + 1;
+        self.blocks.push((block.clone(), block_number));
+        block
+    }
+
+    async fn grant_roles(&mut self, roles: impl IntoIterator<Item = B256>) {
+        let grants = roles
+            .into_iter()
+            .map(|role| self.call_tx(IB20::grantRoleCall { role, account: BerylTestEnv::alice() }))
+            .collect::<Vec<_>>();
+        let grant_count = grants.len();
+        let block = self.build_block_with_transactions(grants).await;
+        for index in 0..grant_count {
+            assert!(self.env.user_tx_succeeded(&block, index), "role grant {index} must succeed");
+        }
+    }
+
+    fn call_tx(&self, call: impl SolCall) -> BaseTxEnvelope {
+        self.env.create_tx(
+            TxKind::Call(self.token),
+            Bytes::from(call.abi_encode()),
+            BerylTestEnv::B20_GAS_LIMIT,
+        )
+    }
+
+    async fn assert_staticcall_cases(&mut self, target: Address, cases: Vec<StaticcallCase>) {
+        let mut probes = Vec::with_capacity(cases.len());
+        let mut deployments = Vec::with_capacity(cases.len());
+        for _ in &cases {
+            let (probe, deploy) = self.env.deploy_staticcall_probe_tx(target);
+            probes.push(probe);
+            deployments.push(deploy);
+        }
+
+        let deploy_block = self.build_block_with_transactions(deployments).await;
+        for index in 0..cases.len() {
+            assert!(
+                self.env.user_tx_succeeded(&deploy_block, index),
+                "security staticcall probe deployment {index} must succeed"
+            );
+        }
+
+        let calls = probes
+            .iter()
+            .zip(cases.iter())
+            .map(|(probe, case)| {
+                self.env.call_staticcall_probe_tx(
+                    *probe,
+                    Bytes::from(case.input.clone()),
+                    BerylTestEnv::B20_PROBE_GAS_LIMIT,
+                )
+            })
+            .collect();
+        let call_block = self.build_block_with_transactions(calls).await;
+
+        for (index, (probe, case)) in probes.iter().zip(cases.iter()).enumerate() {
+            assert!(
+                self.env.user_tx_succeeded(&call_block, index),
+                "{} probe transaction must succeed",
+                case.label
+            );
+            assert!(
+                self.env.probe_call_succeeded(*probe),
+                "{} staticcall must succeed",
+                case.label
+            );
+            assert_eq!(
+                self.env.probe_return_word(*probe),
+                case.expected_word,
+                "{} staticcall must return the expected first word",
+                case.label
+            );
+            assert_eq!(
+                self.env.probe_return_length(*probe),
+                U256::from(case.expected_returndata.len()),
+                "{} staticcall must return the expected byte length",
+                case.label
+            );
+            assert_eq!(
+                self.env.probe_return_hash(*probe),
+                returndata_hash_word(&case.expected_returndata),
+                "{} staticcall must return the expected ABI payload",
+                case.label
+            );
+        }
+    }
+
+    fn assert_total_supply(&self, total_supply: u64) {
+        assert_eq!(
+            self.env.b20_total_supply(self.token),
+            U256::from(total_supply),
+            "security B-20 total supply must match expected value"
+        );
+    }
+
+    fn assert_balances(&self, alice: u64, bob: u64, carol: u64) {
+        assert_eq!(
+            self.env.b20_balance(self.token, BerylTestEnv::alice()),
+            U256::from(alice),
+            "Alice security B-20 balance must match expected value"
+        );
+        assert_eq!(
+            self.env.b20_balance(self.token, BerylTestEnv::bob()),
+            U256::from(bob),
+            "Bob security B-20 balance must match expected value"
+        );
+        assert_eq!(
+            self.env.b20_balance(self.token, BerylTestEnv::carol()),
+            U256::from(carol),
+            "Carol security B-20 balance must match expected value"
+        );
+    }
+
+    fn assert_token_created_log(&self, block: &BaseBlock) {
+        let expected = IB20Factory::B20Created {
+            token: self.token,
+            variant: IB20Factory::B20Variant::SECURITY,
+            name: BerylTestEnv::B20_SECURITY_NAME.to_string(),
+            symbol: BerylTestEnv::B20_SECURITY_SYMBOL.to_string(),
+            decimals: BerylTestEnv::B20_SECURITY_DECIMALS,
+        }
+        .encode_log_data();
+        self.assert_receipt_log(block, 0, B20FactoryStorage::ADDRESS, expected);
+    }
+
+    fn assert_log(&self, block: &BaseBlock, user_tx_index: usize, expected: LogData) {
+        self.assert_receipt_log(block, user_tx_index, self.token, expected);
+    }
+
+    fn assert_receipt_log(
+        &self,
+        block: &BaseBlock,
+        user_tx_index: usize,
+        address: Address,
+        expected: LogData,
+    ) {
+        assert!(
+            self.env
+                .user_tx_receipt(block, user_tx_index)
+                .logs()
+                .iter()
+                .any(|log| log.address == address && log.data == expected),
+            "security B-20 transaction {user_tx_index} must emit the expected event"
+        );
+    }
+
+    async fn derive(mut self) {
+        let expected_safe_head = self.blocks.len() as u64;
+        self.env.derive_blocks(self.blocks, expected_safe_head).await;
+    }
+}
+
+struct StaticcallCase {
+    label: &'static str,
+    input: Vec<u8>,
+    expected_word: U256,
+    expected_returndata: Vec<u8>,
+}
+
+impl StaticcallCase {
+    fn returndata(label: &'static str, input: Vec<u8>, expected_returndata: Vec<u8>) -> Self {
+        let expected_word = first_word(&expected_returndata);
+        Self { label, input, expected_word, expected_returndata }
+    }
+
+    fn word(label: &'static str, input: Vec<u8>, expected_word: U256) -> Self {
+        Self::returndata(label, input, expected_word.abi_encode())
+    }
+
+    fn bytes32(label: &'static str, input: Vec<u8>, expected: B256) -> Self {
+        Self::returndata(label, input, expected.abi_encode())
+    }
+
+    fn string(label: &'static str, input: Vec<u8>, expected: &str) -> Self {
+        Self::returndata(label, input, expected.to_string().abi_encode())
+    }
+}
+
+fn security_operator_role() -> B256 {
+    keccak256("SECURITY_OPERATOR_ROLE")
+}
+
+fn burn_from_role() -> B256 {
+    keccak256("BURN_FROM_ROLE")
+}
+
+fn word_from_address(address: Address) -> U256 {
+    let mut word = [0u8; 32];
+    word[12..].copy_from_slice(address.as_slice());
+    U256::from_be_slice(&word)
+}
+
+fn first_word(bytes: &[u8]) -> U256 {
+    let mut word = [0u8; 32];
+    let copied = bytes.len().min(32);
+    word[..copied].copy_from_slice(&bytes[..copied]);
+    U256::from_be_bytes(word)
+}
+
+fn returndata_hash_word(bytes: &[u8]) -> U256 {
+    U256::from_be_slice(keccak256(bytes).as_slice())
+}

--- a/actions/harness/tests/beryl/stablecoin.rs
+++ b/actions/harness/tests/beryl/stablecoin.rs
@@ -473,38 +473,3 @@ fn create_stablecoin_with_currency_tx(env: &BerylTestEnv, currency: &str) -> Bas
         BerylTestEnv::B20_GAS_LIMIT,
     )
 }
-
-fn assert_probe_returndata(
-    env: &BerylTestEnv,
-    probe: Address,
-    label: &str,
-    expected_returndata: &[u8],
-) {
-    assert_eq!(
-        env.probe_return_size(probe),
-        U256::from(expected_returndata.len()),
-        "{label} staticcall must return the expected byte length"
-    );
-    assert_eq!(
-        env.probe_return_hash(probe),
-        keccak256(expected_returndata),
-        "{label} staticcall must return the expected ABI payload"
-    );
-}
-
-fn string_ret(value: &str) -> Vec<u8> {
-    value.to_string().abi_encode()
-}
-
-fn first_word(returndata: &[u8]) -> U256 {
-    let mut word = [0u8; 32];
-    let copied = returndata.len().min(word.len());
-    word[..copied].copy_from_slice(&returndata[..copied]);
-    U256::from_be_bytes(word)
-}
-
-fn word_from_address(address: Address) -> U256 {
-    let mut word = [0u8; 32];
-    word[12..].copy_from_slice(address.as_slice());
-    U256::from_be_slice(&word)
-}

--- a/actions/harness/tests/beryl/stablecoin.rs
+++ b/actions/harness/tests/beryl/stablecoin.rs
@@ -1,12 +1,15 @@
 //! Stablecoin B-20 precompile action tests across the Base Beryl boundary.
 
 use alloy_consensus::TxReceipt;
-use alloy_primitives::{Address, Bytes, TxKind, U256, keccak256};
+use alloy_primitives::{Address, Bytes, TxKind, U256};
 use alloy_sol_types::{SolCall, SolEvent, SolValue};
 use base_common_consensus::{BaseBlock, BaseTxEnvelope};
 use base_common_precompiles::{B20FactoryStorage, B20TokenRole, IB20, IB20Factory, IB20Stablecoin};
 
-use crate::env::BerylTestEnv;
+use crate::{
+    env::BerylTestEnv,
+    test_helpers::{self, StaticcallCase, word_from_address},
+};
 
 #[tokio::test]
 async fn stablecoin_creation_initializes_currency_and_factory_views() {
@@ -44,20 +47,20 @@ async fn stablecoin_creation_initializes_currency_and_factory_views() {
         .assert_staticcall_cases(
             scenario.token,
             vec![
-                StaticcallCase::returndata(
+                StaticcallCase::string(
                     "currency",
                     IB20Stablecoin::currencyCall {}.abi_encode(),
-                    string_ret(BerylTestEnv::B20_STABLECOIN_CURRENCY),
+                    BerylTestEnv::B20_STABLECOIN_CURRENCY,
                 ),
-                StaticcallCase::returndata(
+                StaticcallCase::string(
                     "name",
                     IB20::nameCall {}.abi_encode(),
-                    string_ret(BerylTestEnv::B20_STABLECOIN_NAME),
+                    BerylTestEnv::B20_STABLECOIN_NAME,
                 ),
-                StaticcallCase::returndata(
+                StaticcallCase::string(
                     "symbol",
                     IB20::symbolCall {}.abi_encode(),
-                    string_ret(BerylTestEnv::B20_STABLECOIN_SYMBOL),
+                    BerylTestEnv::B20_STABLECOIN_SYMBOL,
                 ),
                 StaticcallCase::word(
                     "decimals",
@@ -84,11 +87,7 @@ async fn stablecoin_creation_initializes_currency_and_factory_views() {
                     U256::ZERO,
                 ),
                 StaticcallCase::word("supplyCap", IB20::supplyCapCall {}.abi_encode(), U256::MAX),
-                StaticcallCase::returndata(
-                    "contractURI",
-                    IB20::contractURICall {}.abi_encode(),
-                    string_ret(""),
-                ),
+                StaticcallCase::string("contractURI", IB20::contractURICall {}.abi_encode(), ""),
                 StaticcallCase::word(
                     "nonces(alice)",
                     IB20::noncesCall { owner: BerylTestEnv::alice() }.abi_encode(),
@@ -244,11 +243,11 @@ async fn stablecoin_calls_revert_while_stablecoin_feature_is_deactivated() {
     let block = scenario.build_block_with_transactions(vec![probe_after_reactivate]).await;
     assert!(scenario.env.user_tx_succeeded(&block, 0), "probe transaction must succeed");
     assert!(scenario.env.probe_call_succeeded(probe), "currency() staticcall must succeed again");
-    assert_probe_returndata(
+    test_helpers::assert_probe_string(
         &scenario.env,
         probe,
         "currency after reactivation",
-        &string_ret(BerylTestEnv::B20_STABLECOIN_CURRENCY),
+        BerylTestEnv::B20_STABLECOIN_CURRENCY,
     );
 
     let transfer_after_reactivate =
@@ -345,10 +344,8 @@ impl StablecoinScenario {
         &mut self,
         transactions: Vec<BaseTxEnvelope>,
     ) -> BaseBlock {
-        let block = self.env.sequencer.build_next_block_with_transactions(transactions).await;
-        let block_number = self.blocks.len() as u64 + 1;
-        self.blocks.push((block.clone(), block_number));
-        block
+        test_helpers::build_block_with_transactions(&mut self.env, &mut self.blocks, transactions)
+            .await
     }
 
     fn call_tx(&self, call: impl SolCall) -> BaseTxEnvelope {
@@ -360,79 +357,22 @@ impl StablecoinScenario {
     }
 
     async fn assert_staticcall_cases(&mut self, target: Address, cases: Vec<StaticcallCase>) {
-        let mut probes = Vec::with_capacity(cases.len());
-        let mut deployments = Vec::with_capacity(cases.len());
-        for _ in &cases {
-            let (probe, deploy) = self.env.deploy_staticcall_probe_tx(target);
-            probes.push(probe);
-            deployments.push(deploy);
-        }
-
-        let deploy_block = self.build_block_with_transactions(deployments).await;
-        for index in 0..cases.len() {
-            assert!(
-                self.env.user_tx_succeeded(&deploy_block, index),
-                "stablecoin staticcall probe deployment {index} must succeed"
-            );
-        }
-
-        let calls = probes
-            .iter()
-            .zip(cases.iter())
-            .map(|(probe, case)| {
-                self.env.call_staticcall_probe_tx(
-                    *probe,
-                    Bytes::from(case.input.clone()),
-                    BerylTestEnv::B20_PROBE_GAS_LIMIT,
-                )
-            })
-            .collect();
-        let call_block = self.build_block_with_transactions(calls).await;
-        for (index, (probe, case)) in probes.iter().zip(cases.iter()).enumerate() {
-            assert!(
-                self.env.user_tx_succeeded(&call_block, index),
-                "{} probe transaction must succeed",
-                case.label
-            );
-            assert!(
-                self.env.probe_call_succeeded(*probe),
-                "{} staticcall must succeed",
-                case.label
-            );
-            assert_eq!(
-                self.env.probe_return_word(*probe),
-                case.expected_word,
-                "{} staticcall must return the expected first word",
-                case.label
-            );
-            assert_probe_returndata(&self.env, *probe, case.label, &case.expected_returndata);
-        }
+        test_helpers::assert_staticcall_cases(
+            &mut self.env,
+            &mut self.blocks,
+            target,
+            cases,
+            "stablecoin",
+        )
+        .await;
     }
 
     fn assert_total_supply(&self, total_supply: u64) {
-        assert_eq!(
-            self.env.b20_total_supply(self.token),
-            U256::from(total_supply),
-            "stablecoin total supply must match expected value"
-        );
+        test_helpers::assert_total_supply(&self.env, self.token, "stablecoin", total_supply);
     }
 
     fn assert_balances(&self, alice: u64, bob: u64, carol: u64) {
-        assert_eq!(
-            self.env.b20_balance(self.token, BerylTestEnv::alice()),
-            U256::from(alice),
-            "Alice stablecoin balance must match expected value"
-        );
-        assert_eq!(
-            self.env.b20_balance(self.token, BerylTestEnv::bob()),
-            U256::from(bob),
-            "Bob stablecoin balance must match expected value"
-        );
-        assert_eq!(
-            self.env.b20_balance(self.token, BerylTestEnv::carol()),
-            U256::from(carol),
-            "Carol stablecoin balance must match expected value"
-        );
+        test_helpers::assert_balances(&self.env, self.token, "stablecoin", alice, bob, carol);
     }
 
     fn assert_allowance(&self, owner: Address, spender: Address, amount: u64) {
@@ -510,24 +450,6 @@ impl StablecoinScenario {
     }
 }
 
-struct StaticcallCase {
-    label: &'static str,
-    input: Vec<u8>,
-    expected_word: U256,
-    expected_returndata: Vec<u8>,
-}
-
-impl StaticcallCase {
-    fn word(label: &'static str, input: Vec<u8>, expected_word: U256) -> Self {
-        Self::returndata(label, input, expected_word.abi_encode())
-    }
-
-    fn returndata(label: &'static str, input: Vec<u8>, expected_returndata: Vec<u8>) -> Self {
-        let expected_word = first_word(&expected_returndata);
-        Self { label, input, expected_word, expected_returndata }
-    }
-}
-
 fn create_stablecoin_with_currency_tx(env: &BerylTestEnv, currency: &str) -> BaseTxEnvelope {
     let params = IB20Factory::B20StablecoinCreateParams {
         version: B20FactoryStorage::CREATE_TOKEN_VERSION,
@@ -550,43 +472,4 @@ fn create_stablecoin_with_currency_tx(env: &BerylTestEnv, currency: &str) -> Bas
         ),
         BerylTestEnv::B20_GAS_LIMIT,
     )
-}
-
-fn assert_probe_returndata(
-    env: &BerylTestEnv,
-    probe: Address,
-    label: &str,
-    expected_returndata: &[u8],
-) {
-    assert_eq!(
-        env.probe_return_length(probe),
-        U256::from(expected_returndata.len()),
-        "{label} staticcall must return the expected byte length"
-    );
-    assert_eq!(
-        env.probe_return_hash(probe),
-        returndata_hash_word(expected_returndata),
-        "{label} staticcall must return the expected ABI payload"
-    );
-}
-
-fn string_ret(value: &str) -> Vec<u8> {
-    value.to_string().abi_encode()
-}
-
-fn first_word(returndata: &[u8]) -> U256 {
-    let mut word = [0u8; 32];
-    let copied = returndata.len().min(word.len());
-    word[..copied].copy_from_slice(&returndata[..copied]);
-    U256::from_be_bytes(word)
-}
-
-fn returndata_hash_word(returndata: &[u8]) -> U256 {
-    U256::from_be_slice(keccak256(returndata).as_slice())
-}
-
-fn word_from_address(address: Address) -> U256 {
-    let mut word = [0u8; 32];
-    word[12..].copy_from_slice(address.as_slice());
-    U256::from_be_slice(&word)
 }

--- a/actions/harness/tests/beryl/test_helpers.rs
+++ b/actions/harness/tests/beryl/test_helpers.rs
@@ -104,14 +104,14 @@ pub(crate) async fn assert_staticcall_cases(
             case.label
         );
         assert_eq!(
-            env.probe_return_length(*probe),
+            env.probe_return_size(*probe),
             U256::from(case.expected_returndata.len()),
             "{} staticcall must return the expected byte length",
             case.label
         );
         assert_eq!(
             env.probe_return_hash(*probe),
-            returndata_hash_word(&case.expected_returndata),
+            returndata_hash(&case.expected_returndata),
             "{} staticcall must return the expected ABI payload",
             case.label
         );
@@ -184,17 +184,17 @@ fn assert_probe_returndata(
     expected_returndata: &[u8],
 ) {
     assert_eq!(
-        env.probe_return_length(probe),
+        env.probe_return_size(probe),
         U256::from(expected_returndata.len()),
         "{label} staticcall must return the expected byte length"
     );
     assert_eq!(
         env.probe_return_hash(probe),
-        returndata_hash_word(expected_returndata),
+        returndata_hash(expected_returndata),
         "{label} staticcall must return the expected ABI payload"
     );
 }
 
-fn returndata_hash_word(returndata: &[u8]) -> U256 {
-    U256::from_be_slice(keccak256(returndata).as_slice())
+fn returndata_hash(returndata: &[u8]) -> B256 {
+    keccak256(returndata)
 }

--- a/actions/harness/tests/beryl/test_helpers.rs
+++ b/actions/harness/tests/beryl/test_helpers.rs
@@ -1,0 +1,200 @@
+//! Shared helpers for Beryl precompile action tests.
+
+use alloy_primitives::{Address, B256, Bytes, U256, keccak256};
+use alloy_sol_types::SolValue;
+use base_common_consensus::{BaseBlock, BaseTxEnvelope};
+
+use crate::env::BerylTestEnv;
+
+/// Expected output for a staticcall probe invocation.
+pub(crate) struct StaticcallCase {
+    label: &'static str,
+    input: Vec<u8>,
+    expected_word: U256,
+    expected_returndata: Vec<u8>,
+}
+
+impl StaticcallCase {
+    /// Creates a staticcall case from full expected ABI returndata.
+    pub(crate) fn returndata(
+        label: &'static str,
+        input: Vec<u8>,
+        expected_returndata: Vec<u8>,
+    ) -> Self {
+        let expected_word = first_word(&expected_returndata);
+        Self { label, input, expected_word, expected_returndata }
+    }
+
+    /// Creates a staticcall case for a single-word ABI value.
+    pub(crate) fn word(label: &'static str, input: Vec<u8>, expected_word: U256) -> Self {
+        Self::returndata(label, input, expected_word.abi_encode())
+    }
+
+    /// Creates a staticcall case for a `bytes32` ABI value.
+    pub(crate) fn bytes32(label: &'static str, input: Vec<u8>, expected: B256) -> Self {
+        Self::returndata(label, input, expected.abi_encode())
+    }
+
+    /// Creates a staticcall case for a dynamic string ABI value.
+    pub(crate) fn string(label: &'static str, input: Vec<u8>, expected: &str) -> Self {
+        Self::returndata(label, input, expected.to_string().abi_encode())
+    }
+}
+
+/// Builds an L2 block and records it for derivation replay.
+pub(crate) async fn build_block_with_transactions(
+    env: &mut BerylTestEnv,
+    blocks: &mut Vec<(BaseBlock, u64)>,
+    transactions: Vec<BaseTxEnvelope>,
+) -> BaseBlock {
+    let block = env.sequencer.build_next_block_with_transactions(transactions).await;
+    let block_number = blocks.len() as u64 + 1;
+    blocks.push((block.clone(), block_number));
+    block
+}
+
+/// Deploys staticcall probes, executes all cases, and asserts the full returndata payload.
+pub(crate) async fn assert_staticcall_cases(
+    env: &mut BerylTestEnv,
+    blocks: &mut Vec<(BaseBlock, u64)>,
+    target: Address,
+    cases: Vec<StaticcallCase>,
+    probe_label: &str,
+) {
+    let mut probes = Vec::with_capacity(cases.len());
+    let mut deployments = Vec::with_capacity(cases.len());
+    for _ in &cases {
+        let (probe, deploy) = env.deploy_staticcall_probe_tx(target);
+        probes.push(probe);
+        deployments.push(deploy);
+    }
+
+    let deploy_block = build_block_with_transactions(env, blocks, deployments).await;
+    for index in 0..cases.len() {
+        assert!(
+            env.user_tx_succeeded(&deploy_block, index),
+            "{probe_label} staticcall probe deployment {index} must succeed"
+        );
+    }
+
+    let calls = probes
+        .iter()
+        .zip(cases.iter())
+        .map(|(probe, case)| {
+            env.call_staticcall_probe_tx(
+                *probe,
+                Bytes::from(case.input.clone()),
+                BerylTestEnv::B20_PROBE_GAS_LIMIT,
+            )
+        })
+        .collect();
+    let call_block = build_block_with_transactions(env, blocks, calls).await;
+
+    for (index, (probe, case)) in probes.iter().zip(cases.iter()).enumerate() {
+        assert!(
+            env.user_tx_succeeded(&call_block, index),
+            "{} probe transaction must succeed",
+            case.label
+        );
+        assert!(env.probe_call_succeeded(*probe), "{} staticcall must succeed", case.label);
+        assert_eq!(
+            env.probe_return_word(*probe),
+            case.expected_word,
+            "{} staticcall must return the expected first word",
+            case.label
+        );
+        assert_eq!(
+            env.probe_return_length(*probe),
+            U256::from(case.expected_returndata.len()),
+            "{} staticcall must return the expected byte length",
+            case.label
+        );
+        assert_eq!(
+            env.probe_return_hash(*probe),
+            returndata_hash_word(&case.expected_returndata),
+            "{} staticcall must return the expected ABI payload",
+            case.label
+        );
+    }
+}
+
+/// Asserts a token's total supply from storage.
+pub(crate) fn assert_total_supply(
+    env: &BerylTestEnv,
+    token: Address,
+    token_label: &str,
+    total_supply: u64,
+) {
+    assert_eq!(
+        env.b20_total_supply(token),
+        U256::from(total_supply),
+        "{token_label} total supply must match expected value"
+    );
+}
+
+/// Asserts the Alice, Bob, and Carol token balances from storage.
+pub(crate) fn assert_balances(
+    env: &BerylTestEnv,
+    token: Address,
+    token_label: &str,
+    alice: u64,
+    bob: u64,
+    carol: u64,
+) {
+    assert_eq!(
+        env.b20_balance(token, BerylTestEnv::alice()),
+        U256::from(alice),
+        "Alice {token_label} balance must match expected value"
+    );
+    assert_eq!(
+        env.b20_balance(token, BerylTestEnv::bob()),
+        U256::from(bob),
+        "Bob {token_label} balance must match expected value"
+    );
+    assert_eq!(
+        env.b20_balance(token, BerylTestEnv::carol()),
+        U256::from(carol),
+        "Carol {token_label} balance must match expected value"
+    );
+}
+
+/// Asserts a probe returned the ABI encoding of `expected`.
+pub(crate) fn assert_probe_string(env: &BerylTestEnv, probe: Address, label: &str, expected: &str) {
+    assert_probe_returndata(env, probe, label, &expected.to_string().abi_encode());
+}
+
+/// ABI-encodes an address as a returned word.
+pub(crate) fn word_from_address(address: Address) -> U256 {
+    let mut word = [0u8; 32];
+    word[12..].copy_from_slice(address.as_slice());
+    U256::from_be_slice(&word)
+}
+
+fn first_word(returndata: &[u8]) -> U256 {
+    let mut word = [0u8; 32];
+    let copied = returndata.len().min(word.len());
+    word[..copied].copy_from_slice(&returndata[..copied]);
+    U256::from_be_bytes(word)
+}
+
+fn assert_probe_returndata(
+    env: &BerylTestEnv,
+    probe: Address,
+    label: &str,
+    expected_returndata: &[u8],
+) {
+    assert_eq!(
+        env.probe_return_length(probe),
+        U256::from(expected_returndata.len()),
+        "{label} staticcall must return the expected byte length"
+    );
+    assert_eq!(
+        env.probe_return_hash(probe),
+        returndata_hash_word(expected_returndata),
+        "{label} staticcall must return the expected ABI payload"
+    );
+}
+
+fn returndata_hash_word(returndata: &[u8]) -> U256 {
+    U256::from_be_slice(keccak256(returndata).as_slice())
+}


### PR DESCRIPTION
## Summary

This adds Beryl action-harness coverage for the B-20 security token variant. The tests cover factory creation, dynamic ABI readbacks, security-specific mutations and events, invalid input reverts, and activation gating across derivation. The coverage uses the returndata hash staticcall probe so string and array payloads are asserted directly.