### PR TITLE
feat(devnet): Add B20 ZK proving benchmark

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8461,6 +8461,7 @@ dependencies = [
  "base-txpool-rpc",
  "base-txpool-tracing",
  "base-zk-client",
+ "clap",
  "eyre",
  "hex",
  "indicatif 0.18.4",

--- a/crates/proof/succinct/elf/manifest.toml
+++ b/crates/proof/succinct/elf/manifest.toml
@@ -17,8 +17,8 @@
 
 [[elfs]]
 name = "range-elf-embedded"
-sha256 = "70a92c48baf813f04dc3e48a97e4881c2c41752991dc665b17ce68a9296f1889"
+sha256 = "fc20d749763f788b9c54cac58399d09eae1396d3e187cc0c22240b941f4ad0ed"
 
 [[elfs]]
 name = "aggregation-elf"
-sha256 = "8f3de7dc344cd8537ee19bb9f4cfb1e8e7a547ba0ddbcd4a2b496a052e9ea585"
+sha256 = "baf0a889a5c493d780235b14f21e4f6c94feb8d4d8e138224f0d7d8572c944b9"

--- a/crates/proof/succinct/programs/Cargo.lock
+++ b/crates/proof/succinct/programs/Cargo.lock
@@ -148,14 +148,15 @@ dependencies = [
 
 [[package]]
 name = "alloy-eip7928"
-version = "0.3.4"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "407510740da514b694fecb44d8b3cebdc60d448f70cc5d24743e8ba273448a6e"
+checksum = "6b827a6d7784fe3eb3489d40699407a4cdcce74271421a01bdffe60cf573bb16"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "once_cell",
  "serde",
+ "thiserror",
 ]
 
 [[package]]
@@ -271,7 +272,7 @@ dependencies = [
  "const-hex",
  "derive_more",
  "foldhash",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "indexmap",
  "itoa",
  "k256",
@@ -280,7 +281,7 @@ dependencies = [
  "ruint",
  "rustc-hash",
  "serde",
- "sha3 0.11.0",
+ "sha3",
 ]
 
 [[package]]
@@ -324,9 +325,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-eth"
-version = "2.0.4"
+version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56a282daf869eeb7383d3d5c2deb35b0b3fb45ecb329513af4090fc61245ee18"
+checksum = "175a2a5b6017d7f61b5e4b800d21215fe8e94fe729d00828e13bb6d93dcf3492"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -366,9 +367,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro"
-version = "1.5.7"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab81bab693da9bb79f7a95b64b394718259fdd7e41dceeced4cad57cb71c4f6a"
+checksum = "840128ed2b2971d6d4668a553fe403a82683d3acc646c73e75887e7157408033"
 dependencies = [
  "alloy-sol-macro-expander",
  "alloy-sol-macro-input",
@@ -380,9 +381,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro-expander"
-version = "1.5.7"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "489f1620bb7e2483fb5819ed01ab6edc1d2f93939dce35a5695085a1afd1d699"
+checksum = "63ec265e5d65d725175f6ca7711c970824c90ef9c0d1f1973711d4150ee612dd"
 dependencies = [
  "alloy-sol-macro-input",
  "const-hex",
@@ -391,16 +392,16 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "sha3 0.10.8",
+ "sha3",
  "syn 2.0.117",
  "syn-solidity",
 ]
 
 [[package]]
 name = "alloy-sol-macro-input"
-version = "1.5.7"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56cef806ad22d4392c5fc83cf8f2089f988eb99c7067b4e0c6f1971fc1cca318"
+checksum = "89bf01077f18650876cfa682eb1f949967b5cde03f1a51c955c469d2c9b4aa67"
 dependencies = [
  "const-hex",
  "dunce",
@@ -414,9 +415,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-types"
-version = "1.5.7"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64612d29379782a5dde6f4b6570d9c756d734d760c0c94c254d361e678a6591f"
+checksum = "384cf252de0db2dec52821eac037a7f57e2aa33fe5b900ce6fe39973402341f1"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-macro",
@@ -475,9 +476,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3df4dcc01ff89867cd86b0da835f23c3f02738353aaee7dde7495af71363b8d5"
 dependencies = [
  "ark-ec",
- "ark-ff 0.5.0",
- "ark-serialize 0.5.0",
- "ark-std 0.5.0",
+ "ark-ff",
+ "ark-serialize",
+ "ark-std",
 ]
 
 [[package]]
@@ -487,8 +488,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d69eab57e8d2663efa5c63135b2af4f396d66424f88954c21104125ab6b3e6bc"
 dependencies = [
  "ark-ec",
- "ark-ff 0.5.0",
- "ark-std 0.5.0",
+ "ark-ff",
+ "ark-std",
 ]
 
 [[package]]
@@ -498,10 +499,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43d68f2d516162846c1238e755a7c4d131b892b70cc70c471a8e3ca3ed818fce"
 dependencies = [
  "ahash",
- "ark-ff 0.5.0",
+ "ark-ff",
  "ark-poly",
- "ark-serialize 0.5.0",
- "ark-std 0.5.0",
+ "ark-serialize",
+ "ark-std",
  "educe",
  "fnv",
  "hashbrown 0.15.5",
@@ -514,34 +515,14 @@ dependencies = [
 
 [[package]]
 name = "ark-ff"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec847af850f44ad29048935519032c33da8aa03340876d351dfab5660d2966ba"
-dependencies = [
- "ark-ff-asm 0.4.2",
- "ark-ff-macros 0.4.2",
- "ark-serialize 0.4.2",
- "ark-std 0.4.0",
- "derivative",
- "digest 0.10.7",
- "itertools 0.10.5",
- "num-bigint 0.4.6",
- "num-traits",
- "paste",
- "rustc_version",
- "zeroize",
-]
-
-[[package]]
-name = "ark-ff"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a177aba0ed1e0fbb62aa9f6d0502e9b46dad8c2eab04c14258a1212d2557ea70"
 dependencies = [
- "ark-ff-asm 0.5.0",
- "ark-ff-macros 0.5.0",
- "ark-serialize 0.5.0",
- "ark-std 0.5.0",
+ "ark-ff-asm",
+ "ark-ff-macros",
+ "ark-serialize",
+ "ark-std",
  "arrayvec",
  "digest 0.10.7",
  "educe",
@@ -554,35 +535,12 @@ dependencies = [
 
 [[package]]
 name = "ark-ff-asm"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed4aa4fe255d0bc6d79373f7e31d2ea147bcf486cba1be5ba7ea85abdb92348"
-dependencies = [
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "ark-ff-asm"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62945a2f7e6de02a31fe400aa489f0e0f5b2502e69f95f853adb82a96c7a6b60"
 dependencies = [
  "quote",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "ark-ff-macros"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7abe79b0e4288889c4574159ab790824d0033b9fdcb2a112a3182fac2e514565"
-dependencies = [
- "num-bigint 0.4.6",
- "num-traits",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -605,23 +563,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "579305839da207f02b89cd1679e50e67b4331e2f9294a57693e5051b7703fe27"
 dependencies = [
  "ahash",
- "ark-ff 0.5.0",
- "ark-serialize 0.5.0",
- "ark-std 0.5.0",
+ "ark-ff",
+ "ark-serialize",
+ "ark-std",
  "educe",
  "fnv",
  "hashbrown 0.15.5",
-]
-
-[[package]]
-name = "ark-serialize"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adb7b85a02b83d2f22f89bd5cac66c9c89474240cb6207cb1efc16d098e822a5"
-dependencies = [
- "ark-std 0.4.0",
- "digest 0.10.7",
- "num-bigint 0.4.6",
 ]
 
 [[package]]
@@ -631,7 +578,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f4d068aaf107ebcd7dfb52bc748f8030e0fc930ac8e360146ca54c1203088f7"
 dependencies = [
  "ark-serialize-derive",
- "ark-std 0.5.0",
+ "ark-std",
  "arrayvec",
  "digest 0.10.7",
  "num-bigint 0.4.6",
@@ -646,16 +593,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "ark-std"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94893f1e0c6eeab764ade8dc4c0db24caf4fe7cbbaafc0eba0a9030f447b5185"
-dependencies = [
- "num-traits",
- "rand 0.8.6",
 ]
 
 [[package]]
@@ -714,9 +651,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "base-common-chains"
@@ -887,7 +824,7 @@ dependencies = [
  "alloy-rlp",
  "alloy-trie",
  "ark-bls12-381",
- "ark-ff 0.5.0",
+ "ark-ff",
  "async-trait",
  "base-common-chains",
  "base-common-consensus",
@@ -1142,30 +1079,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "blake2"
-version = "0.10.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
-dependencies = [
- "digest 0.10.7",
-]
-
-[[package]]
-name = "blake2b_simd"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b79834656f71332577234b50bfc009996f7449e0c056884e6a02492ded0ca2f3"
-dependencies = [
- "arrayref",
- "arrayvec",
- "constant_time_eq",
-]
-
-[[package]]
 name = "blake3"
-version = "1.8.4"
+version = "1.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d2d5991425dfd0785aed03aedcf0b321d61975c9b5b3689c774a2610ae0b51e"
+checksum = "0aa83c34e62843d924f905e0f5c866eb1dd6545fc4d719e803d9ba6030371fce"
 dependencies = [
  "arrayref",
  "arrayvec",
@@ -1191,19 +1108,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
 dependencies = [
  "hybrid-array",
-]
-
-[[package]]
-name = "bls12_381"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3c196a77437e7cc2fb515ce413a6401291578b5afc8ecb29a3c7ab957f05941"
-dependencies = [
- "ff 0.12.1",
- "group 0.12.1",
- "pairing 0.22.0",
- "rand_core 0.6.4",
- "subtle",
 ]
 
 [[package]]
@@ -1239,9 +1143,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.20.2"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytecheck"
@@ -1298,9 +1202,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.60"
+version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
+checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1322,9 +1226,9 @@ checksum = "0b396d1f76d455557e1218ec8066ae14bba60b4b36ecd55577ba979f5db7ecaa"
 
 [[package]]
 name = "const-hex"
-version = "1.18.1"
+version = "1.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "531185e432bb31db1ecda541e9e7ab21468d4d844ad7505e0546a49b4945d49b"
+checksum = "33e2a781ebdf4467d1428dc4593067825fb646f6871475098d8577421af73558"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
@@ -1382,34 +1286,15 @@ dependencies = [
 
 [[package]]
 name = "crc-catalog"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
+checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
 
 [[package]]
 name = "critical-section"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
-
-[[package]]
-name = "crossbeam-deque"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
-dependencies = [
- "crossbeam-epoch",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-epoch"
-version = "0.9.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
-dependencies = [
- "crossbeam-utils",
-]
 
 [[package]]
 name = "crossbeam-utils"
@@ -1485,9 +1370,9 @@ dependencies = [
 
 [[package]]
 name = "dashmap"
-version = "6.1.0"
+version = "6.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -1506,17 +1391,6 @@ checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
  "const-oid",
  "zeroize",
-]
-
-[[package]]
-name = "derivative"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -1627,9 +1501,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 dependencies = [
  "serde",
 ]
@@ -1649,9 +1523,9 @@ dependencies = [
  "base16ct",
  "crypto-bigint",
  "digest 0.10.7",
- "ff 0.13.1",
+ "ff",
  "generic-array",
- "group 0.13.0",
+ "group",
  "hkdf",
  "pkcs8",
  "rand_core 0.6.4",
@@ -1704,17 +1578,6 @@ name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
-
-[[package]]
-name = "ff"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d013fc25338cc558c5c2cfbad646908fb23591e2404481826742b651c9af7160"
-dependencies = [
- "bitvec",
- "rand_core 0.6.4",
- "subtle",
-]
 
 [[package]]
 name = "ff"
@@ -1904,23 +1767,11 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "group"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dfbfb3a6cfbd390d5c9564ab283a0349b9b9fcd46a706c1eb10e0db70bfbac7"
-dependencies = [
- "ff 0.12.1",
- "memuse",
- "rand_core 0.6.4",
- "subtle",
-]
-
-[[package]]
-name = "group"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
- "ff 0.13.1",
+ "ff",
  "rand_core 0.6.4",
  "subtle",
 ]
@@ -1930,29 +1781,6 @@ name = "half"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b43ede17f21864e81be2fa654110bf1e793774238d86ef8555c37e6519c0403"
-
-[[package]]
-name = "halo2"
-version = "0.1.0-beta.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a23c779b38253fe1538102da44ad5bd5378495a61d2c4ee18d64eaa61ae5995"
-dependencies = [
- "halo2_proofs",
-]
-
-[[package]]
-name = "halo2_proofs"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e925780549adee8364c7f2b685c753f6f3df23bde520c67416e93bf615933760"
-dependencies = [
- "blake2b_simd",
- "ff 0.12.1",
- "group 0.12.1",
- "pasta_curves 0.4.1",
- "rand_core 0.6.4",
- "rayon",
-]
 
 [[package]]
 name = "hashbrown"
@@ -1982,9 +1810,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
  "foldhash",
  "serde",
@@ -2058,7 +1886,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
@@ -2117,26 +1945,14 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.95"
+version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
+checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "jubjub"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a575df5f985fe1cd5b2b05664ff6accfc46559032b954529fd225a2168d27b0f"
-dependencies = [
- "bitvec",
- "bls12_381",
- "ff 0.12.1",
- "group 0.12.1",
- "rand_core 0.6.4",
- "subtle",
 ]
 
 [[package]]
@@ -2155,15 +1971,6 @@ dependencies = [
 
 [[package]]
 name = "keccak"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
-dependencies = [
- "cpufeatures 0.2.17",
-]
-
-[[package]]
-name = "keccak"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e24a010dd405bd7ed803e5253182815b41bf2e6a80cc3bfc066658e03a198aa"
@@ -2178,7 +1985,7 @@ version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee8b4f55c3dedcfaa8668de1dfc8469e7a32d441c28edf225ed1f566fb32977d"
 dependencies = [
- "ff 0.13.1",
+ "ff",
  "hex",
  "rkyv",
  "serde",
@@ -2193,15 +2000,12 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-dependencies = [
- "spin 0.9.8",
-]
 
 [[package]]
 name = "libc"
-version = "0.2.185"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libm"
@@ -2241,9 +2045,9 @@ dependencies = [
 
 [[package]]
 name = "macro-string"
-version = "0.1.4"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b27834086c65ec3f9387b096d66e99f221cf081c2b738042aa252bcd41204e3"
+checksum = "59a9dbbfc75d2688ed057456ce8a3ee3f48d12eec09229f560f3643b9f275653"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2255,12 +2059,6 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
-
-[[package]]
-name = "memuse"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d97bbf43eb4f088f8ca469930cde17fa036207c9a5e02ccc5107c4e8b17c964"
 
 [[package]]
 name = "miniz_oxide"
@@ -2474,11 +2272,11 @@ dependencies = [
 
 [[package]]
 name = "p3-bn254-fr"
-version = "0.3.2-succinct"
+version = "0.4.3-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9abf208fbfe540d6e2a6caaa2a9a345b1c8cb23ffdcdfcc6987244525d4fc821"
+checksum = "2077757c7cb514202ccb5368f521f23f5709c720599e6545c683c66e0a52d2d8"
 dependencies = [
- "ff 0.13.1",
+ "ff",
  "num-bigint 0.4.6",
  "p3-field",
  "p3-poseidon2",
@@ -2489,9 +2287,9 @@ dependencies = [
 
 [[package]]
 name = "p3-challenger"
-version = "0.3.2-succinct"
+version = "0.4.3-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42b725b453bbb35117a1abf0ddfd900b0676063d6e4231e0fa6bb0d76018d8ad"
+checksum = "b6a908924d43e4cfb93fb41c8346cac211b70314385a9037e9241f5b7f3eaf77"
 dependencies = [
  "p3-field",
  "p3-maybe-rayon",
@@ -2503,9 +2301,9 @@ dependencies = [
 
 [[package]]
 name = "p3-dft"
-version = "0.3.2-succinct"
+version = "0.4.3-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56a1f81101bff744b7ebba7f4497e917a2c6716d6e62736e4a56e555a2d98cb7"
+checksum = "be6408b10a2c27eb13a7d5580c546c2179a8dc7dbc10a990657311891f9b41c0"
 dependencies = [
  "p3-field",
  "p3-matrix",
@@ -2516,9 +2314,9 @@ dependencies = [
 
 [[package]]
 name = "p3-field"
-version = "0.3.2-succinct"
+version = "0.4.3-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36459d4acb03d08097d713f336c7393990bb489ab19920d4f68658c7a5c10968"
+checksum = "3dc75969ca3ac847f43e632ab979d59ff7a68f9eac8dbf8edcbba47fc2e1d3aa"
 dependencies = [
  "itertools 0.12.1",
  "num-bigint 0.4.6",
@@ -2530,24 +2328,26 @@ dependencies = [
 
 [[package]]
 name = "p3-koala-bear"
-version = "0.3.2-succinct"
+version = "0.4.3-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb1f52bcb6be38bdc8fa6b38b3434d4eedd511f361d4249fd798c6a5ef817b40"
+checksum = "3a9683cd0ef68100df7c62490533047bcf19c04c4a0fa1efc9d7c1e03e31f6b3"
 dependencies = [
+ "cfg-if",
  "num-bigint 0.4.6",
  "p3-field",
  "p3-mds",
  "p3-poseidon2",
  "p3-symmetric",
  "rand 0.8.6",
+ "rustc_version",
  "serde",
 ]
 
 [[package]]
 name = "p3-matrix"
-version = "0.3.2-succinct"
+version = "0.4.3-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5583e9cd136a4095a25c41a9edfdcce2dfae58ef01639317813bdbbd5b55c583"
+checksum = "75c3f150ceb90e09539413bf481e618d05ee19210b4e467d2902eb82d2e15281"
 dependencies = [
  "itertools 0.12.1",
  "p3-field",
@@ -2560,15 +2360,15 @@ dependencies = [
 
 [[package]]
 name = "p3-maybe-rayon"
-version = "0.3.2-succinct"
+version = "0.4.3-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e524d47a49fb4265611303339c4ef970d892817b006cc330dad18afb91e411b1"
+checksum = "e0641952b42da45e1dfa2d4a2a3163e330f944ad9740942f35026c0a71a605f1"
 
 [[package]]
 name = "p3-mds"
-version = "0.3.2-succinct"
+version = "0.4.3-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f6cb8edcb276033d43769a3725570c340d2ed6f35c3cca4cddeee07718fa376"
+checksum = "aa4a5f250e174dcfca5cbeac6ad75713924e7e7320e0a335e3c50b8b1f4fe8ec"
 dependencies = [
  "itertools 0.12.1",
  "p3-dft",
@@ -2581,9 +2381,9 @@ dependencies = [
 
 [[package]]
 name = "p3-poseidon2"
-version = "0.3.2-succinct"
+version = "0.4.3-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a26197df2097b98ab7038d59a01e1fe1a0f545e7e04aa9436b2454b1836654f"
+checksum = "522986377b2164c5f94f2dae88e0e0a3d169cc6239202ef4aeb4322d60feffd0"
 dependencies = [
  "gcd",
  "p3-field",
@@ -2595,9 +2395,9 @@ dependencies = [
 
 [[package]]
 name = "p3-symmetric"
-version = "0.3.2-succinct"
+version = "0.4.3-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a1d3b5202096bca57cde912fbbb9cbaedaf5ac7c42a924c7166b98709d64d21"
+checksum = "9047ce85c086a9b3f118e10078f10636f7bfeed5da871a04da0b61400af8793a"
 dependencies = [
  "itertools 0.12.1",
  "p3-field",
@@ -2606,20 +2406,11 @@ dependencies = [
 
 [[package]]
 name = "p3-util"
-version = "0.3.2-succinct"
+version = "0.4.3-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec5f0388aa6d935ca3a17444086120f393f0b2f0816010b5ff95998c1c4095e3"
+checksum = "cff962f8eaa5f36e0447cee7c241f6b4b475fadf3ee61f154327a26bb4e009ba"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "pairing"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "135590d8bdba2b31346f9cd1fb2a912329f5135e832a4f422942eb6ead8b6b3b"
-dependencies = [
- "group 0.12.1",
 ]
 
 [[package]]
@@ -2628,7 +2419,7 @@ version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81fec4625e73cf41ef4bb6846cafa6d44736525f442ba45e407c4a000a13996f"
 dependencies = [
- "group 0.13.0",
+ "group",
 ]
 
 [[package]]
@@ -2642,36 +2433,6 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "windows-link",
-]
-
-[[package]]
-name = "pasta_curves"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cc65faf8e7313b4b1fbaa9f7ca917a0eed499a9663be71477f87993604341d8"
-dependencies = [
- "blake2b_simd",
- "ff 0.12.1",
- "group 0.12.1",
- "lazy_static",
- "rand 0.8.6",
- "static_assertions",
- "subtle",
-]
-
-[[package]]
-name = "pasta_curves"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3e57598f73cc7e1b2ac63c79c517b31a0877cd7c402cdcaa311b5208de7a095"
-dependencies = [
- "blake2b_simd",
- "ff 0.13.1",
- "group 0.13.0",
- "lazy_static",
- "rand 0.8.6",
- "static_assertions",
- "subtle",
 ]
 
 [[package]]
@@ -2947,26 +2708,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rayon"
-version = "1.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
-dependencies = [
- "either",
- "rayon-core",
-]
-
-[[package]]
-name = "rayon-core"
-version = "1.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
-dependencies = [
- "crossbeam-deque",
- "crossbeam-utils",
-]
-
-[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3198,8 +2939,8 @@ dependencies = [
  "ark-bls12-381",
  "ark-bn254",
  "ark-ec",
- "ark-ff 0.5.0",
- "ark-serialize 0.5.0",
+ "ark-ff",
+ "ark-serialize",
  "arrayref",
  "aurora-engine-modexp",
  "cfg-if",
@@ -3272,7 +3013,7 @@ checksum = "73389e0c99e664f919275ab5b5b0471391fe9a8de61e1dff9b1eaf56a90f16e3"
 dependencies = [
  "bytecheck",
  "bytes",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "indexmap",
  "munge",
  "ptr_meta",
@@ -3449,9 +3190,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",
@@ -3462,9 +3203,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.18.0"
+version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd5414fad8e6907dbdd5bc441a50ae8d6e26151a03b1de04d89a5576de61d01f"
+checksum = "e72c1c2cb7b223fafb600a619537a871c2818583d619401b785e7c0b746ccde2"
 dependencies = [
  "serde_core",
  "serde_with_macros",
@@ -3472,9 +3213,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.18.0"
+version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3db8978e608f1fe7357e211969fd9abdcae80bac1ba7a3369bb7eb6b404eb65"
+checksum = "b90c488738ecb4fb0262f41f43bc40efc5868d9fb744319ddf5f5317f417bfac"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -3504,21 +3245,12 @@ dependencies = [
 
 [[package]]
 name = "sha3"
-version = "0.10.8"
-source = "git+https://github.com/sp1-patches/RustCrypto-hashes?tag=patch-sha3-0.10.8-sp1-6.0.0#0a16ae7acd5cd5fbb432d884bd4aae2764a18cf7"
-dependencies = [
- "digest 0.10.7",
- "keccak 0.1.6",
-]
-
-[[package]]
-name = "sha3"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be176f1a57ce4e3d31c1a166222d9768de5954f811601fb7ca06fc8203905ce1"
 dependencies = [
  "digest 0.11.3",
- "keccak 0.2.0",
+ "keccak",
 ]
 
 [[package]]
@@ -3554,9 +3286,9 @@ checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "siphasher"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "slab"
@@ -3566,9 +3298,9 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "slop-algebra"
-version = "6.1.0"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "733912d564a68ff209707e71fdc517d4ff82d4362b6a409f6a8241dfcb7a576a"
+checksum = "3e8abf7cfad18c0580576e8adc01f7fa27b1cb19432e451e82950c9a445a7cfc"
 dependencies = [
  "itertools 0.14.0",
  "p3-field",
@@ -3577,25 +3309,24 @@ dependencies = [
 
 [[package]]
 name = "slop-bn254"
-version = "6.1.0"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a71b23ede427299e139fb822c5d0ea8fb931dc297eba0c6e2f30f774c04ebc81"
+checksum = "c327e0927fabf9c0ae9a7b0333027dc04431e5981ab80d7bbe994d6c4ce35fc1"
 dependencies = [
- "ff 0.13.1",
+ "ff",
  "p3-bn254-fr",
  "serde",
  "slop-algebra",
  "slop-challenger",
  "slop-poseidon2",
  "slop-symmetric",
- "zkhash",
 ]
 
 [[package]]
 name = "slop-challenger"
-version = "6.1.0"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59e4993210936ab317c0d56ee8257e1cdfe6c2fae4df1e158737f034e21d45f9"
+checksum = "c263e731bb694d4465eedae7ecd6faf1f277198e751f3c209a1c4186d80d1b6b"
 dependencies = [
  "futures",
  "p3-challenger",
@@ -3606,9 +3337,9 @@ dependencies = [
 
 [[package]]
 name = "slop-koala-bear"
-version = "6.1.0"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8986e94b9a43d58fc8ce5bf111b0985479ab888ced923e3052fb19943f7859b4"
+checksum = "0a8cdc74f04d13e738b4628312b16dfec6a2e547bde697c8bdcf556884c6e91f"
 dependencies = [
  "lazy_static",
  "p3-koala-bear",
@@ -3621,27 +3352,27 @@ dependencies = [
 
 [[package]]
 name = "slop-poseidon2"
-version = "6.1.0"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b06e4a24cba104a0a39740eedd97e60e8896926cc38e6a58d5866cc9811affa"
+checksum = "3aedfc3bf87cf2694bd108c039d663c346c7bb807491a7db6701eb9dff5c6e5d"
 dependencies = [
  "p3-poseidon2",
 ]
 
 [[package]]
 name = "slop-primitives"
-version = "6.1.0"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b0b66701c82f6aab97f4990b5d9ed7463beb5b5042dbe5eda5f6c71a6207b35"
+checksum = "f30e6e332c3cb103541bed9f5f477b769df1b5fb6076b5e2386569c94b1475dc"
 dependencies = [
  "slop-algebra",
 ]
 
 [[package]]
 name = "slop-symmetric"
-version = "6.1.0"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6d159948b924fd00f280064d7a049e43dceb2f26067f32fb99570d3169969ee"
+checksum = "4cb1de854325a8c36a1bdfee5514e1d4c9f39290ae19eeaecb21ca6ee88d96d6"
 dependencies = [
  "p3-symmetric",
 ]
@@ -3669,9 +3400,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-primitives"
-version = "6.1.0"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6b77098dae9d62e080be3af253188c08e7e96e666423306654eede0110bf363"
+checksum = "13ad00052921b993af682403b378c8fe23c40382f9790f093c8fac0f30433c5e"
 dependencies = [
  "bincode",
  "blake3",
@@ -3718,9 +3449,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f23e41cd36168cc2e51e5d3e35ff0c34b204d945769a65591a76286d04b51e43"
 dependencies = [
  "cfg-if",
- "ff 0.13.1",
- "group 0.13.0",
- "pairing 0.23.0",
+ "ff",
+ "group",
+ "pairing",
  "rand_core 0.6.4",
  "sp1-lib",
  "subtle",
@@ -3827,9 +3558,9 @@ dependencies = [
 
 [[package]]
 name = "syn-solidity"
-version = "1.5.7"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53f425ae0b12e2f5ae65542e00898d500d4d318b4baf09f40fd0d410454e9947"
+checksum = "ec005042c7d952febc1a3ef5b0f6674e9054aa836877a31c90b20e25b3d31744"
 dependencies = [
  "paste",
  "proc-macro2",
@@ -4034,9 +3765,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.118"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
+checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -4047,9 +3778,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.118"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
+checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4057,9 +3788,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.118"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
+checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -4070,9 +3801,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.118"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
+checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
 dependencies = [
  "unicode-ident",
 ]
@@ -4148,33 +3879,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "zkhash"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4352d1081da6922701401cdd4cbf29a2723feb4cfabb5771f6fee8e9276da1c7"
-dependencies = [
- "ark-ff 0.4.2",
- "ark-std 0.4.0",
- "bitvec",
- "blake2",
- "bls12_381",
- "byteorder",
- "cfg-if",
- "group 0.12.1",
- "group 0.13.0",
- "halo2",
- "hex",
- "jubjub",
- "lazy_static",
- "pasta_curves 0.5.1",
- "rand 0.8.6",
- "serde",
- "sha2",
- "sha3 0.10.8",
- "subtle",
-]
-
-[[package]]
 name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4207,6 +3911,11 @@ dependencies = [
  "cc",
  "pkg-config",
 ]
+
+[[patch.unused]]
+name = "sha3"
+version = "0.10.8"
+source = "git+https://github.com/sp1-patches/RustCrypto-hashes?tag=patch-sha3-0.10.8-sp1-6.0.0#0a16ae7acd5cd5fbb432d884bd4aae2764a18cf7"
 
 [[patch.unused]]
 name = "substrate-bn"

--- a/devnet/Cargo.toml
+++ b/devnet/Cargo.toml
@@ -89,9 +89,16 @@ serde = { workspace = true, features = ["derive", "std"] }
 testcontainers = { workspace = true, features = ["blocking", "host-port-exposure"] }
 
 [dev-dependencies]
+# cli
+clap = { workspace = true, features = ["derive"] }
+
 # proof
 base-zk-client.workspace = true
 base-proof-rpc.workspace = true
 
 # misc
 indicatif.workspace = true
+
+[[bench]]
+name = "b20_zk_proving"
+harness = false

--- a/devnet/benches/b20_zk_proving.rs
+++ b/devnet/benches/b20_zk_proving.rs
@@ -1,0 +1,332 @@
+//! Local devnet benchmark for B-20 precompile ZK proving cycles.
+//!
+//! Run with:
+//!
+//! ```bash
+//! cargo bench -p devnet --bench b20_zk_proving
+//! ```
+//!
+//! Requires a full local devnet with `base-prover-zk` running in `SP1_PROVER=dry-run` mode.
+
+use std::time::Duration;
+
+use alloy_primitives::{Address, B256, U256};
+use alloy_signer_local::PrivateKeySigner;
+use alloy_sol_types::SolCall;
+use base_common_precompiles::{
+    ActivationFeature, B20TokenPrecompile, B20TokenRole, B20Variant, IB20,
+};
+use clap::Parser;
+use devnet::{
+    B20PrecompileClient,
+    config::{ANVIL_ACCOUNT_5, ANVIL_ACCOUNT_6, ANVIL_ACCOUNT_7},
+};
+use eyre::{Result, WrapErr};
+use tokio::runtime::Runtime;
+use url::Url;
+
+pub mod common;
+
+use common::{
+    BenchDisplay, BenchProvider, CycleReport, OperationReport, ZkProofBench, ZkProofBenchConfig,
+};
+
+const WORKLOAD_TXS: u64 = 10;
+const INITIAL_SUPPLY: u64 = 1_000_000;
+const TRANSFER_AMOUNT: u64 = 100;
+const TRANSFER_WITH_MEMO_AMOUNT: u64 = 101;
+const TRANSFER_FROM_AMOUNT: u64 = 102;
+const TRANSFER_FROM_WITH_MEMO_AMOUNT: u64 = 103;
+const ALLOWANCE_AMOUNT: u64 = 1_000;
+const UPDATED_SUPPLY_CAP: u64 = 2_000_000;
+const HEAVY_CONTRACT_URI: &str =
+    "ipfs://b20-zk-bench/metadata/heavy-interaction/with/a/longer/contract-uri/payload";
+
+/// Local B-20 ZK dry-run proving benchmark.
+#[derive(Debug)]
+pub struct B20ZkProvingBench;
+
+fn main() -> Result<()> {
+    Runtime::new()
+        .wrap_err("failed to start tokio runtime")?
+        .block_on(B20ZkProvingBench::run(B20ZkProvingConfig::parse()))
+}
+
+/// CLI configuration for the local B-20 ZK proving benchmark.
+#[derive(Clone, Debug, Parser)]
+pub struct B20ZkProvingConfig {
+    /// L2 execution RPC URL.
+    #[arg(long, default_value = "http://localhost:8645")]
+    pub l2_rpc_url: Url,
+    /// Rollup RPC URL.
+    #[arg(long, default_value = "http://localhost:8649")]
+    pub rollup_rpc_url: Url,
+    /// ZK prover RPC URL.
+    #[arg(long, default_value = "http://localhost:9000")]
+    pub zk_prover_url: Url,
+    /// Local devnet L2 chain ID.
+    #[arg(long, default_value_t = 84538453)]
+    pub l2_chain_id: u64,
+    /// Polling interval in milliseconds for block, receipt, and account funding waits.
+    #[arg(long = "block-poll-interval-ms", default_value = "500", value_parser = parse_duration_millis)]
+    pub block_poll_interval: Duration,
+    /// Transaction receipt timeout in seconds.
+    #[arg(long = "tx-receipt-timeout-secs", default_value = "60", value_parser = parse_duration_secs)]
+    pub tx_receipt_timeout: Duration,
+    /// Account funding timeout in seconds.
+    #[arg(long = "account-funding-timeout-secs", default_value = "15", value_parser = parse_duration_secs)]
+    pub account_funding_timeout: Duration,
+    /// Proof status polling interval in seconds.
+    #[arg(long = "proof-poll-interval-secs", default_value = "5", value_parser = parse_duration_secs)]
+    pub proof_poll_interval: Duration,
+    /// Proof job timeout in seconds.
+    #[arg(long = "proof-timeout-secs", default_value = "900", value_parser = parse_duration_secs)]
+    pub proof_timeout: Duration,
+    /// Timeout in seconds for waiting until workload blocks are safe.
+    #[arg(long = "safe-l2-timeout-secs", default_value = "300", value_parser = parse_duration_secs)]
+    pub safe_l2_timeout: Duration,
+}
+
+fn parse_duration_millis(value: &str) -> Result<Duration, std::num::ParseIntError> {
+    value.parse().map(Duration::from_millis)
+}
+
+fn parse_duration_secs(value: &str) -> Result<Duration, std::num::ParseIntError> {
+    value.parse().map(Duration::from_secs)
+}
+
+/// Sends the fixed B-20 call sequence used by the benchmark.
+#[derive(Debug)]
+pub struct B20CallSender<'a> {
+    /// B-20 client signed by the benchmark admin.
+    pub admin_client: &'a B20PrecompileClient<'a>,
+    /// B-20 client signed by the benchmark spender.
+    pub spender_client: &'a B20PrecompileClient<'a>,
+    /// Benchmark token admin address.
+    pub admin: Address,
+    /// Benchmark spender address.
+    pub spender: Address,
+    /// Benchmark B-20 token address.
+    pub token: Address,
+    /// Progress display updated as calls are sent.
+    pub display: &'a BenchDisplay,
+}
+
+impl B20ZkProvingBench {
+    /// Runs the B-20 ZK proving benchmark against a local devnet and dry-run prover.
+    pub async fn run(config: B20ZkProvingConfig) -> Result<()> {
+        let display = BenchDisplay::new("B-20 zk dry-run benchmark", WORKLOAD_TXS);
+
+        display.setup_message("setup connecting to devnet RPCs");
+        let l2_provider = BenchProvider::connect_base(config.l2_rpc_url.clone());
+        let rollup_provider = BenchProvider::connect_base(config.rollup_rpc_url.clone());
+
+        let admin = PrivateKeySigner::from_bytes(&ANVIL_ACCOUNT_5.private_key)
+            .wrap_err("failed to parse devnet admin private key")?;
+        let spender = PrivateKeySigner::from_bytes(&ANVIL_ACCOUNT_7.private_key)
+            .wrap_err("failed to parse devnet spender private key")?;
+        display.setup_message("setup waiting for funded devnet accounts");
+        BenchProvider::wait_for_balances(
+            &l2_provider,
+            [admin.address(), spender.address()],
+            config.block_poll_interval,
+            config.account_funding_timeout,
+        )
+        .await?;
+
+        let b20 = B20PrecompileClient::new(&l2_provider, &admin, config.l2_chain_id)
+            .with_receipt_timeout(config.tx_receipt_timeout);
+        let b20_spender = B20PrecompileClient::new(&l2_provider, &spender, config.l2_chain_id)
+            .with_receipt_timeout(config.tx_receipt_timeout);
+        display.setup_message("setup ensuring B-20 features are active");
+        b20.activate_feature(ActivationFeature::B20Factory.id()).await?;
+        b20.activate_feature(ActivationFeature::B20Token.id()).await?;
+
+        display.setup_message("setup creating benchmark B-20 token");
+        let token = Self::create_b20_token(&b20, admin.address()).await?;
+        display.setup_message("setup waiting for benchmark token bytecode");
+        b20.wait_for_token_code(token, config.tx_receipt_timeout, config.block_poll_interval)
+            .await?;
+        display.setup_done(token);
+
+        let reports = B20CallSender {
+            admin_client: &b20,
+            spender_client: &b20_spender,
+            admin: admin.address(),
+            spender: spender.address(),
+            token,
+            display: &display,
+        }
+        .send_sequence()
+        .await?;
+        display.txs_done();
+        let (first_block, last_block) = OperationReport::block_range(&reports)?;
+        let stats = ZkProofBench::prove_safe_block_range_with_dry_run_stats(
+            &rollup_provider,
+            config.zk_prover_url.clone(),
+            first_block,
+            last_block,
+            ZkProofBenchConfig {
+                safe_l2_timeout: config.safe_l2_timeout,
+                safe_l2_poll_interval: config.block_poll_interval,
+                proof_timeout: config.proof_timeout,
+                proof_poll_interval: config.proof_poll_interval,
+            },
+            &display,
+        )
+        .await?;
+        display.proof_done(&stats);
+
+        CycleReport::print_summary(
+            "B-20 zk dry-run proof benchmark",
+            first_block,
+            last_block,
+            &reports,
+            &stats,
+        )
+    }
+
+    /// Creates the benchmark B-20 token.
+    pub async fn create_b20_token(
+        client: &B20PrecompileClient<'_>,
+        admin: Address,
+    ) -> Result<Address> {
+        let salt = B256::from(rand::random::<[u8; 32]>());
+        let params = B20PrecompileClient::token_params(
+            "ZK Proof B20",
+            "ZKPB",
+            admin,
+            U256::from(INITIAL_SUPPLY),
+            admin,
+        );
+
+        client.create_token(B20Variant::B20, params, salt).await
+    }
+}
+
+impl B20CallSender<'_> {
+    /// Sends the fixed B-20 call sequence used by the proof benchmark.
+    pub async fn send_sequence(&self) -> Result<Vec<OperationReport>> {
+        let mut reports = Vec::new();
+
+        reports.push(
+            self.send_call(
+                self.admin_client,
+                "transfer",
+                IB20::transferCall {
+                    to: ANVIL_ACCOUNT_6.address,
+                    amount: U256::from(TRANSFER_AMOUNT),
+                },
+            )
+            .await?,
+        );
+        reports.push(
+            self.send_call(
+                self.admin_client,
+                "transferWithMemo",
+                IB20::transferWithMemoCall {
+                    to: ANVIL_ACCOUNT_6.address,
+                    amount: U256::from(TRANSFER_WITH_MEMO_AMOUNT),
+                    memo: B256::repeat_byte(0x20),
+                },
+            )
+            .await?,
+        );
+        reports.push(
+            self.send_call(
+                self.admin_client,
+                "approve",
+                IB20::approveCall { spender: self.spender, amount: U256::from(ALLOWANCE_AMOUNT) },
+            )
+            .await?,
+        );
+        reports.push(
+            self.send_call(
+                self.spender_client,
+                "transferFrom",
+                IB20::transferFromCall {
+                    from: self.admin,
+                    to: ANVIL_ACCOUNT_6.address,
+                    amount: U256::from(TRANSFER_FROM_AMOUNT),
+                },
+            )
+            .await?,
+        );
+        reports.push(
+            self.send_call(
+                self.spender_client,
+                "transferFromWithMemo",
+                IB20::transferFromWithMemoCall {
+                    from: self.admin,
+                    to: ANVIL_ACCOUNT_6.address,
+                    amount: U256::from(TRANSFER_FROM_WITH_MEMO_AMOUNT),
+                    memo: B256::repeat_byte(0x21),
+                },
+            )
+            .await?,
+        );
+        reports.push(
+            self.send_call(
+                self.admin_client,
+                "updateSupplyCap",
+                IB20::updateSupplyCapCall { newSupplyCap: U256::from(UPDATED_SUPPLY_CAP) },
+            )
+            .await?,
+        );
+        reports.push(
+            self.send_call(
+                self.admin_client,
+                "updateContractURI",
+                IB20::updateContractURICall { newURI: HEAVY_CONTRACT_URI.to_string() },
+            )
+            .await?,
+        );
+        reports.push(
+            self.send_call(
+                self.admin_client,
+                "grantRole(metadata)",
+                IB20::grantRoleCall { role: B20TokenRole::Metadata.id(), account: self.admin },
+            )
+            .await?,
+        );
+        reports.push(
+            self.send_call(
+                self.admin_client,
+                "updateName",
+                IB20::updateNameCall { newName: "ZK Proof B20 Heavy Metadata".to_string() },
+            )
+            .await?,
+        );
+        reports.push(
+            self.send_call(
+                self.admin_client,
+                "updateSymbol",
+                IB20::updateSymbolCall { newSymbol: "ZKPH".to_string() },
+            )
+            .await?,
+        );
+
+        Ok(reports)
+    }
+
+    /// Sends a signed B-20 call and records its gas, block, and tracker metadata.
+    pub async fn send_call<C>(
+        &self,
+        client: &B20PrecompileClient<'_>,
+        operation: &'static str,
+        call: C,
+    ) -> Result<OperationReport>
+    where
+        C: SolCall,
+    {
+        let input = call.abi_encode();
+        let tracker_key =
+            <B20TokenPrecompile as base_common_precompiles::CalldataCycleTracker>::key_for_calldata(&input)
+            .ok_or_else(|| eyre::eyre!("missing B-20 cycle tracker key for {operation}"))?;
+        self.display.tx_started(operation);
+        let receipt = client.send_call_receipt(self.token, call, operation).await?;
+        let report = OperationReport::from_receipt(operation, tracker_key, receipt)?;
+        self.display.tx_done(&report);
+        Ok(report)
+    }
+}

--- a/devnet/src/b20.rs
+++ b/devnet/src/b20.rs
@@ -169,7 +169,8 @@ impl<'a> B20PrecompileClient<'a> {
             IActivationRegistry::activateCall { feature },
             "activate feature",
         )
-        .await
+        .await?;
+        Ok(())
     }
 
     /// Deactivates an activation-registry feature.
@@ -179,7 +180,8 @@ impl<'a> B20PrecompileClient<'a> {
             IActivationRegistry::deactivateCall { feature },
             "deactivate feature",
         )
-        .await
+        .await?;
+        Ok(())
     }
 
     /// Computes the token address a factory creation call will use.
@@ -226,12 +228,14 @@ impl<'a> B20PrecompileClient<'a> {
 
     /// Mints B-20 tokens to an account.
     pub async fn mint(&self, token: Address, to: Address, amount: U256) -> Result<()> {
-        self.send_call(token, IB20::mintCall { to, amount }, "mint B-20 token").await
+        self.send_call(token, IB20::mintCall { to, amount }, "mint B-20 token").await?;
+        Ok(())
     }
 
     /// Transfers B-20 tokens.
     pub async fn transfer(&self, token: Address, to: Address, amount: U256) -> Result<()> {
-        self.send_call(token, IB20::transferCall { to, amount }, "transfer B-20 token").await
+        self.send_call(token, IB20::transferCall { to, amount }, "transfer B-20 token").await?;
+        Ok(())
     }
 
     /// Reads the token name.
@@ -267,7 +271,9 @@ impl<'a> B20PrecompileClient<'a> {
 
     /// Approves `spender` to transfer up to `amount` on behalf of the signer.
     pub async fn approve(&self, token: Address, spender: Address, amount: U256) -> Result<()> {
-        self.send_call(token, IB20::approveCall { spender, amount }, "approve B-20 spender").await
+        self.send_call(token, IB20::approveCall { spender, amount }, "approve B-20 spender")
+            .await?;
+        Ok(())
     }
 
     /// Transfers tokens from `from` to `to` using the signer's allowance.
@@ -283,12 +289,14 @@ impl<'a> B20PrecompileClient<'a> {
             IB20::transferFromCall { from, to, amount },
             "transferFrom B-20 token",
         )
-        .await
+        .await?;
+        Ok(())
     }
 
     /// Burns tokens from the signer's balance.
     pub async fn burn(&self, token: Address, amount: U256) -> Result<()> {
-        self.send_call(token, IB20::burnCall { amount }, "burn B-20 token").await
+        self.send_call(token, IB20::burnCall { amount }, "burn B-20 token").await?;
+        Ok(())
     }
 
     /// Transfers tokens with a memo tag.
@@ -304,7 +312,8 @@ impl<'a> B20PrecompileClient<'a> {
             IB20::transferWithMemoCall { to, amount, memo },
             "transferWithMemo B-20 token",
         )
-        .await
+        .await?;
+        Ok(())
     }
 
     /// Reads the supply cap.
@@ -321,7 +330,8 @@ impl<'a> B20PrecompileClient<'a> {
             IB20::updateSupplyCapCall { newSupplyCap: new_cap },
             "updateSupplyCap B-20 token",
         )
-        .await
+        .await?;
+        Ok(())
     }
 
     /// Updates the token name.
@@ -331,7 +341,8 @@ impl<'a> B20PrecompileClient<'a> {
             IB20::updateNameCall { newName: new_name.to_string() },
             "updateName B-20 token",
         )
-        .await
+        .await?;
+        Ok(())
     }
 
     /// Updates the token symbol.
@@ -341,7 +352,8 @@ impl<'a> B20PrecompileClient<'a> {
             IB20::updateSymbolCall { newSymbol: new_symbol.to_string() },
             "updateSymbol B-20 token",
         )
-        .await
+        .await?;
+        Ok(())
     }
 
     /// Reads the contract URI.
@@ -358,7 +370,8 @@ impl<'a> B20PrecompileClient<'a> {
             IB20::updateContractURICall { newURI: new_uri.to_string() },
             "updateContractURI B-20 token",
         )
-        .await
+        .await?;
+        Ok(())
     }
 
     /// Reads the pause vector flags.
@@ -374,13 +387,15 @@ impl<'a> B20PrecompileClient<'a> {
     /// Pauses the token for the given vector flags.
     pub async fn pause(&self, token: Address, vectors: U256) -> Result<()> {
         let features = pausable_features_from_mask(vectors);
-        self.send_call(token, IB20::pauseCall { features }, "pause B-20 token").await
+        self.send_call(token, IB20::pauseCall { features }, "pause B-20 token").await?;
+        Ok(())
     }
 
     /// Unpauses all pause vectors on the token.
     pub async fn unpause(&self, token: Address) -> Result<()> {
         let features = pausable_features_from_mask(U256::from(0x0f));
-        self.send_call(token, IB20::unpauseCall { features }, "unpause B-20 token").await
+        self.send_call(token, IB20::unpauseCall { features }, "unpause B-20 token").await?;
+        Ok(())
     }
 
     /// Returns true if `token` is a deployed B-20 via the factory.
@@ -434,10 +449,24 @@ impl<'a> B20PrecompileClient<'a> {
     where
         C: SolCall,
     {
+        self.send_call_receipt(to, call, label).await?;
+        Ok(())
+    }
+
+    /// Signs, sends, and waits for a successful transaction receipt against `to`.
+    pub async fn send_call_receipt<C>(
+        &self,
+        to: Address,
+        call: C,
+        label: &'static str,
+    ) -> Result<BaseTransactionReceipt>
+    where
+        C: SolCall,
+    {
         let receipt = self.send_and_wait(to, Bytes::from(call.abi_encode()), label).await?;
         ensure!(receipt.status(), "{label} transaction reverted");
         ensure!(receipt.inner.to == Some(to), "{label} receipt target mismatch");
-        Ok(())
+        Ok(receipt)
     }
 
     /// Signs, sends, and polls until a receipt is available.

--- a/etc/docker/Dockerfile.rust-services
+++ b/etc/docker/Dockerfile.rust-services
@@ -134,7 +134,7 @@ ARG PROFILE=release
 RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
     --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
     --mount=type=cache,target=/app/target,id=zk-prover-target,sharing=locked \
-    cargo build --profile $PROFILE --package base-prover-zk --bin base-prover-zk && \
+    BASE_SUCCINCT_ELF_REQUIRE=1 cargo build --profile $PROFILE --package base-prover-zk --bin base-prover-zk && \
     cp /app/target/$([ "$PROFILE" = "dev" ] && echo debug || echo "$PROFILE")/base-prover-zk /app/base-prover-zk
 
 FROM public.ecr.aws/docker/library/debian:trixie-slim AS runtime-base

--- a/etc/docker/Justfile
+++ b/etc/docker/Justfile
@@ -112,6 +112,15 @@ tests: _install-nextest _build-contracts
 tests-ci: _install-nextest _build-contracts
     cargo nextest run -P ci --locked -p devnet --cargo-profile ci
 
+# Runs devnet benchmarks
+bench name:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    case "{{ name }}" in
+      b20-zk-proving) cargo bench -p devnet --bench b20_zk_proving ;;
+      *) echo "unknown devnet bench: {{ name }}" >&2; exit 1 ;;
+    esac
+
 [private]
 _install-nextest:
     @command -v cargo-nextest >/dev/null 2>&1 || cargo install cargo-nextest


### PR DESCRIPTION
## Summary
- Add a clap-configured B-20 ZK dry-run proving benchmark that reports per-operation gas and cycle tracker output.
- Add the devnet bench entrypoint, Justfile helper, B-20 receipt reporting support, and Succinct ELF/Docker enforcement updates needed by the benchmark.

Made with [Cursor](https://cursor.com)