### PR TITLE
docs(precompiles): clarify `privileged` semantics for mint/burn/pause/configurable ops

### DIFF
--- a/crates/common/precompiles/src/common/ops/burnable.rs
+++ b/crates/common/precompiles/src/common/ops/burnable.rs
@@ -11,6 +11,10 @@ use crate::{B20TokenRole, IB20, Token, TokenAccounting};
 /// Implement this trait with an empty body to opt in.
 pub trait Burnable: Token {
     /// Destroys `amount` tokens from `from`. Emits `Transfer(from, 0x0, amount)`.
+    ///
+    /// When `privileged` is true the [`B20TokenRole::Burn`] role check is skipped.
+    /// Unlike [`Transferable::transfer`], the pause check still applies under
+    /// `privileged`; see issue #2914 for context.
     fn burn(
         &mut self,
         caller: Address,

--- a/crates/common/precompiles/src/common/ops/configurable.rs
+++ b/crates/common/precompiles/src/common/ops/configurable.rs
@@ -13,6 +13,10 @@ use crate::{B20TokenRole, IB20, Token, TokenAccounting};
 /// Implement with an empty body to opt in.
 pub trait Configurable: Token {
     /// Updates the supply cap. Requires `DEFAULT_ADMIN_ROLE`. Emits `SupplyCapUpdated`.
+    ///
+    /// When `privileged` is true the role check is skipped. Unlike
+    /// [`Transferable::transfer`], no other guards are bypassed; see issue
+    /// #2914 for context.
     fn update_supply_cap(
         &mut self,
         caller: Address,
@@ -38,6 +42,10 @@ pub trait Configurable: Token {
     }
 
     /// Updates the token name. Emits `NameUpdated` and `EIP712DomainChanged` (ERC-5267).
+    ///
+    /// When `privileged` is true the [`B20TokenRole::Metadata`] role check is
+    /// skipped. Unlike [`Transferable::transfer`], no other guards are
+    /// bypassed; see issue #2914 for context.
     fn update_name(&mut self, caller: Address, name: String, privileged: bool) -> Result<()> {
         if !privileged {
             B20Guards::ensure_token_role::<Self>(self, caller, B20TokenRole::Metadata)?;
@@ -49,6 +57,10 @@ pub trait Configurable: Token {
     }
 
     /// Updates the token symbol. Emits `SymbolUpdated`.
+    ///
+    /// When `privileged` is true the [`B20TokenRole::Metadata`] role check is
+    /// skipped. Unlike [`Transferable::transfer`], no other guards are
+    /// bypassed; see issue #2914 for context.
     fn update_symbol(&mut self, caller: Address, symbol: String, privileged: bool) -> Result<()> {
         if !privileged {
             B20Guards::ensure_token_role::<Self>(self, caller, B20TokenRole::Metadata)?;
@@ -60,6 +72,10 @@ pub trait Configurable: Token {
     }
 
     /// Updates the contract URI. Emits `ContractURIUpdated`.
+    ///
+    /// When `privileged` is true the [`B20TokenRole::Metadata`] role check is
+    /// skipped. Unlike [`Transferable::transfer`], no other guards are
+    /// bypassed; see issue #2914 for context.
     fn update_contract_uri(
         &mut self,
         caller: Address,

--- a/crates/common/precompiles/src/common/ops/mintable.rs
+++ b/crates/common/precompiles/src/common/ops/mintable.rs
@@ -11,6 +11,10 @@ use crate::{B20PolicyType, B20TokenRole, IB20, Token, TokenAccounting};
 /// Implement this trait with an empty body to opt in.
 pub trait Mintable: Token {
     /// Creates `amount` tokens at `to`. Enforces supply cap. Emits `Transfer(0x0, to, amount)`.
+    ///
+    /// When `privileged` is true the [`B20TokenRole::Mint`] role check is skipped.
+    /// Unlike [`Transferable::transfer`], the pause and `MintReceiver` policy
+    /// checks still apply under `privileged`; see issue #2914 for context.
     fn mint(&mut self, caller: Address, to: Address, amount: U256, privileged: bool) -> Result<()> {
         if to == Address::ZERO {
             return Err(BasePrecompileError::revert(IB20::InvalidReceiver { receiver: to }));

--- a/crates/common/precompiles/src/common/ops/pausable.rs
+++ b/crates/common/precompiles/src/common/ops/pausable.rs
@@ -35,6 +35,10 @@ pub trait Pausable: Token {
     }
 
     /// ORs `features` into the current paused bitmask.
+    ///
+    /// When `privileged` is true the [`B20TokenRole::Pause`] role check is skipped.
+    /// Unlike [`Transferable::transfer`], no other guards are bypassed; see
+    /// issue #2914 for context.
     fn pause(
         &mut self,
         caller: Address,
@@ -58,6 +62,10 @@ pub trait Pausable: Token {
     }
 
     /// Clears `features` from the current paused bitmask.
+    ///
+    /// When `privileged` is true the [`B20TokenRole::Unpause`] role check is skipped.
+    /// Unlike [`Transferable::transfer`], no other guards are bypassed; see
+    /// issue #2914 for context.
     fn unpause(
         &mut self,
         caller: Address,


### PR DESCRIPTION
Documentation only follow up to #2914.

While reading the B20 token ops I noticed that `privileged: bool` has different semantics across the ops that take it, and only `Transferable::transfer` documents what `privileged` actually does. The other four traits (`Mintable`, `Burnable`, `Pausable`, `Configurable`) take the same parameter but only skip the role check under it pause and policy guards still apply.

This PR doesn't change any behavior. It just adds short doc comments on `mint`, `burn`, `pause`, `unpause`, `update_supply_cap`, `update_name`, `update_symbol`, and `update_contract_uri` calling out:
1. Which role check is skipped when `privileged = true`.
2. The fact that, unlike `Transferable::transfer`, no other guards are bypassed.
3. A reference to issue #2914 so the asymmetry can be tracked in one place.

If #2914 ends up being resolved by changing the behavior of one side, these docs should be updated to match. For now this just makes the current asymmetry discoverable from the trait definitions.

No test or code changes `git diff --stat`: