### PR TITLE
fix(flashblocks): handle empty pending state input

### DIFF
--- a/crates/execution/flashblocks/src/processor.rs
+++ b/crates/execution/flashblocks/src/processor.rs
@@ -357,7 +357,9 @@ where
                 .push(flashblock.clone());
         }
 
-        let earliest_block_number = flashblocks_per_block.keys().min().unwrap();
+        let Some(earliest_block_number) = flashblocks_per_block.keys().min() else {
+            return Ok(None);
+        };
         let canonical_block = earliest_block_number - 1;
         let mut last_block_header = self
             .client


### PR DESCRIPTION
## Summary

Fixes a panic in `StateProcessor::build_pending_state` when called with empty flashblock input.

The previous code called `.unwrap()` on the minimum key of an empty `BTreeMap`, which could panic. This now returns `Ok(None)` when there is no pending state to build.

Fixes #2785

## Testing

- `cargo +nightly fmt`

I attempted `cargo check -p base-flashblocks` locally on Windows, but the build is blocked by a native `librocksdb-sys`/MSVC toolchain error unrelated to this change.