### PR TITLE
fix(sync): initialize safe_cursor from safe FC instead of unsafe

### DIFF
--- a/crates/consensus/engine/src/sync/mod.rs
+++ b/crates/consensus/engine/src/sync/mod.rs
@@ -76,7 +76,7 @@ pub async fn find_starting_forkchoice<EngineClient_: EngineClient>(
 
     // Search for the highest `safe` block that's L1 origin is at least older than the sequencing
     // window, relative to the L1 origin of the `unsafe` block.
-    let mut safe_cursor = current_fc.un_safe;
+    let mut safe_cursor = current_fc.safe;
     loop {
         info!(
             target: "sync_start",


### PR DESCRIPTION
## Bug

In `find_starting_forkchoice()`, the safe block search cursor was initialized with `current_fc.un_safe` (the unsafe/unconfirmed head) instead of `current_fc.safe` (the known-safe head).

```rust
// Before (buggy)
let mut safe_cursor = current_fc.un_safe;

// After (fixed)
let mut safe_cursor = current_fc.safe;
```

## Impact

On every node restart, the algorithm unnecessarily traverses every block between the unsafe head and the actual safe head before finding the correct safe block. In practice, the unsafe head can be hundreds or thousands of blocks ahead of the safe head (the sequencing window on Base mainnet is 3600 L1 blocks), making sync start significantly slower than it needs to be.

## Why the fix is safe

The loop already handles the general case correctly: it checks `is_behind_sequence_window || is_finalized || is_genesis` and walks backwards if needed. Starting from `current_fc.safe` means:
- If the existing safe block already satisfies the sequencing window condition (the common case), the loop exits immediately.
- If for some reason the safe block needs to be pushed further back, the loop continues walking backwards exactly as before.

Correctness is unchanged; only the number of unnecessary iterations is eliminated.

Fixes the issue reported in https://github.com/base/base/issues/1173.