### PR TITLE
feat(chains): Schedule Zeronet Beryl Activation

### DIFF
--- a/crates/common/chains/res/genesis/zeronet_base.json
+++ b/crates/common/chains/res/genesis/zeronet_base.json
@@ -27,6 +27,10 @@
     "holoceneTime": 0,
     "isthmusTime": 0,
     "jovianTime": 0,
+    "base": {
+      "azul": 1775152800,
+      "beryl": 1780333200
+    },
     "terminalTotalDifficulty": 0,
     "depositContractAddress": "0x0000000000000000000000000000000000000000",
     "optimism": {
@@ -15354,4 +15358,3 @@
   "excessBlobGas": "0x0",
   "blobGasUsed": "0x0"
 }
-

--- a/crates/common/chains/src/chain.rs
+++ b/crates/common/chains/src/chain.rs
@@ -297,15 +297,15 @@ mod tests {
 
     #[test]
     fn is_beryl_active_at_timestamp() {
-        for forks in [
-            ChainUpgrades::mainnet(),
-            ChainUpgrades::sepolia(),
-            ChainUpgrades::devnet(),
-            ChainUpgrades::zeronet(),
-        ] {
+        for forks in [ChainUpgrades::mainnet(), ChainUpgrades::sepolia(), ChainUpgrades::devnet()] {
             assert!(!forks.is_beryl_active_at_timestamp(0));
             assert!(!forks.is_beryl_active_at_timestamp(u64::MAX));
         }
+
+        let zeronet_forks = ChainUpgrades::zeronet();
+        assert!(!zeronet_forks.is_beryl_active_at_timestamp(1_780_333_199));
+        assert!(zeronet_forks.is_beryl_active_at_timestamp(1_780_333_200));
+        assert!(zeronet_forks.is_beryl_active_at_timestamp(u64::MAX));
     }
 
     #[test]

--- a/crates/common/chains/src/config.rs
+++ b/crates/common/chains/src/config.rs
@@ -530,7 +530,7 @@ const ZERONET: ChainConfig = ChainConfig {
     isthmus_timestamp: 0,
     jovian_timestamp: 0,
     azul_timestamp: Some(1_775_152_800),
-    beryl_timestamp: None,
+    beryl_timestamp: Some(1_780_333_200),
 
     genesis_l1_hash: b256!("b7d4b69971ff31d5179be5e1b83f5a4f438f4cd1db886a6630623b7047f32cfd"),
     genesis_l1_number: 2_450_277,
@@ -603,5 +603,11 @@ mod tests {
         assert_eq!(ChainConfig::SEPOLIA, ChainConfig::sepolia());
         assert_eq!(ChainConfig::DEVNET, ChainConfig::devnet());
         assert_eq!(ChainConfig::ZERONET, ChainConfig::zeronet());
+    }
+
+    #[test]
+    fn zeronet_beryl_is_scheduled() {
+        assert_eq!(ChainConfig::zeronet().beryl_timestamp, Some(1_780_333_200));
+        assert_eq!(ChainConfig::zeronet().hardfork_config().base.beryl, Some(1_780_333_200));
     }
 }


### PR DESCRIPTION
## Summary

This schedules the Zeronet Beryl activation for June 1, 2026 at 1:00pm EDT. It updates the built-in chain config, keeps the embedded Zeronet genesis Base fork stanza aligned, and adjusts the focused activation assertions for the new timestamp.

Timestamp verified with https://www.unixtimestamp.com/


<img width="732" height="447" alt="Screenshot 2026-05-26 at 10 21 29 AM" src="https://github.com/user-attachments/assets/475aa2f5-1f6f-4710-ae42-a4bf1a947c1e" />