### PR TITLE
feat(txpool): EIP-8130 conservative-accept gate (PR4 of N)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3678,6 +3678,7 @@ dependencies = [
  "alloy-rpc-types-eth 2.0.5",
  "alloy-serde 2.0.5",
  "alloy-signer 2.0.5",
+ "alloy-signer-local 2.0.5",
  "arbitrary",
  "bincode 2.0.1",
  "bytes",

--- a/crates/common/consensus/Cargo.toml
+++ b/crates/common/consensus/Cargo.toml
@@ -52,6 +52,7 @@ rand.workspace = true
 rstest.workspace = true
 serde_json.workspace = true
 alloy-signer.workspace = true
+alloy-signer-local.workspace = true
 bincode = { workspace = true, features = ["serde"] }
 arbitrary = { workspace = true, features = ["derive"] }
 alloy-primitives = { workspace = true, features = ["rand", "arbitrary"] }

--- a/crates/common/consensus/src/transaction/eip8130/constants.rs
+++ b/crates/common/consensus/src/transaction/eip8130/constants.rs
@@ -112,6 +112,15 @@ impl Eip8130Constants {
     /// `NONCE_KEY_MAX` transactions whose `expiry` exceeds a short window"),
     /// a tight window bounds the replay surface in the absence of nonce state.
     pub const NONCE_FREE_MAX_EXPIRY_WINDOW: u64 = 10;
+
+    /// Maximum number of owner entries the mempool accepts in a single
+    /// `Create.initial_owners` or `ConfigChange.owner_changes` slice. Bounds
+    /// per-transaction memory and CPU spent on duplicate-owner_id detection
+    /// at admission time. Combined with [`Self::MAX_CONFIG_CHANGES_PER_TX`]
+    /// this caps total owner work per tx at
+    /// `MAX_CONFIG_CHANGES_PER_TX * MAX_OWNERS_PER_ENTRY + MAX_OWNERS_PER_ENTRY`
+    /// (config-change `owner_changes` + one `Create.initial_owners`).
+    pub const MAX_OWNERS_PER_ENTRY: usize = 32;
 }
 
 #[cfg(test)]

--- a/crates/common/consensus/src/transaction/eip8130/constants.rs
+++ b/crates/common/consensus/src/transaction/eip8130/constants.rs
@@ -2,7 +2,7 @@
 //!
 //! [EIP-8130]: https://eips.ethereum.org/EIPS/eip-8130
 
-use alloy_primitives::U256;
+use alloy_primitives::{Address, U256};
 
 /// Container for [EIP-8130] protocol constants.
 ///
@@ -90,6 +90,28 @@ impl Eip8130Constants {
 
     /// `owner_change` operation byte: revoke an existing owner.
     pub const OWNER_CHANGE_REVOKE: u8 = 0x02;
+
+    /// Lower-bound verifier address. The `ECRECOVER_VERIFIER` native is fixed at
+    /// `address(1)`; verifier addresses smaller than this are reserved.
+    pub const ECRECOVER_VERIFIER: Address = Address::with_last_byte(1);
+
+    /// Sentinel verifier address indicating an owner slot has been revoked
+    /// (`type(uint160).max`). Submitting authentication data prefixed with this
+    /// verifier MUST be rejected.
+    pub const REVOKED_VERIFIER: Address = Address::new([0xff; 20]);
+
+    /// Maximum number of `ConfigChange` entries the mempool accepts in a single
+    /// transaction. The spec marks this as a node policy ("Nodes SHOULD enforce
+    /// a configurable per-transaction limit"); we pin a conservative default
+    /// here that downstream operators can revisit once the spec finalises.
+    pub const MAX_CONFIG_CHANGES_PER_TX: usize = 10;
+
+    /// Maximum `expiry` window (in seconds beyond the current wall-clock time)
+    /// the mempool accepts for nonce-free-mode transactions
+    /// (`nonce_key == NONCE_KEY_MAX`). Per the spec ("Nodes SHOULD reject
+    /// `NONCE_KEY_MAX` transactions whose `expiry` exceeds a short window"),
+    /// a tight window bounds the replay surface in the absence of nonce state.
+    pub const NONCE_FREE_MAX_EXPIRY_WINDOW: u64 = 10;
 }
 
 #[cfg(test)]

--- a/crates/common/consensus/src/transaction/eip8130/signed.rs
+++ b/crates/common/consensus/src/transaction/eip8130/signed.rs
@@ -143,7 +143,9 @@ impl Eip8130Signed {
         self.tx.sender
     }
 
-    /// Recovers the sender for the EOA-path EIP-8130 transaction.
+    /// Recovers the sender for the EOA-path EIP-8130 transaction using the
+    /// **checked** secp256k1 recovery (rejects upper-half `s` values per
+    /// EIP-2).
     ///
     /// Returns `Ok(None)` when [`Self::explicit_sender`] is `Some(_)` — the
     /// configured-owner path does not require ecrecover because the sender
@@ -160,13 +162,38 @@ impl Eip8130Signed {
     pub fn recover_eoa_sender(
         &self,
     ) -> Result<Option<Address>, alloy_consensus::crypto::RecoveryError> {
+        self.recover_eoa_sender_with(alloy_consensus::crypto::secp256k1::recover_signer)
+    }
+
+    /// Same as [`Self::recover_eoa_sender`] but uses the **unchecked** recovery
+    /// path, accepting signatures with non-canonical (upper-half) `s` values.
+    ///
+    /// Intended for use from `SignerRecoverable::recover_signer_unchecked`
+    /// dispatchers where the contract guarantees no upper-half-`s` filtering;
+    /// using the checked variant from those paths would silently tighten the
+    /// validation contract.
+    #[cfg(feature = "k256")]
+    pub fn recover_eoa_sender_unchecked(
+        &self,
+    ) -> Result<Option<Address>, alloy_consensus::crypto::RecoveryError> {
+        self.recover_eoa_sender_with(alloy_consensus::crypto::secp256k1::recover_signer_unchecked)
+    }
+
+    #[cfg(feature = "k256")]
+    fn recover_eoa_sender_with(
+        &self,
+        recover: impl FnOnce(
+            &alloy_primitives::Signature,
+            B256,
+        ) -> Result<Address, alloy_consensus::crypto::RecoveryError>,
+    ) -> Result<Option<Address>, alloy_consensus::crypto::RecoveryError> {
         if self.tx.sender.is_some() {
             return Ok(None);
         }
         let signature = alloy_primitives::Signature::try_from(self.sender_auth.as_ref())
             .map_err(|_| alloy_consensus::crypto::RecoveryError::new())?;
         let hash = self.tx.sender_signature_hash();
-        alloy_consensus::crypto::secp256k1::recover_signer(&signature, hash).map(Some)
+        recover(&signature, hash).map(Some)
     }
 
     fn rlp_payload_length(&self) -> usize {
@@ -506,6 +533,52 @@ mod tests {
         // 64 bytes is one short of a valid ECDSA r||s||v payload.
         let signed = Eip8130Signed::new(tx, Bytes::from(vec![0u8; 64]), Bytes::new());
         assert!(signed.recover_eoa_sender().is_err());
+    }
+
+    #[cfg(feature = "k256")]
+    #[test]
+    fn recover_eoa_sender_unchecked_accepts_high_s_signature() {
+        use alloy_primitives::U256;
+        use alloy_signer::SignerSync;
+        use alloy_signer_local::PrivateKeySigner;
+
+        // secp256k1 curve order N.
+        const SECP256K1_N: U256 = U256::from_be_slice(&[
+            0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+            0xff, 0xfe, 0xba, 0xae, 0xdc, 0xe6, 0xaf, 0x48, 0xa0, 0x3b, 0xbf, 0xd2, 0x5e, 0x8c,
+            0xd0, 0x36, 0x41, 0x41,
+        ]);
+
+        let signer = PrivateKeySigner::random();
+        let expected = signer.address();
+
+        let mut tx = sample_signed(false).into_tx();
+        tx.sender = None;
+        let hash = tx.sender_signature_hash();
+
+        // Sign normally (low-s, EIP-2 canonical), then flip s into the upper half
+        // by replacing it with N - s and inverting parity.
+        let canonical = signer.sign_hash_sync(&hash).unwrap();
+        let high_s_sig = alloy_primitives::Signature::new(
+            canonical.r(),
+            SECP256K1_N - canonical.s(),
+            !canonical.v(),
+        );
+        let signed =
+            Eip8130Signed::new(tx, Bytes::from(high_s_sig.as_bytes().to_vec()), Bytes::new());
+
+        // The checked recovery rejects the high-s form (EIP-2);
+        // the unchecked recovery accepts it and recovers the same address.
+        assert!(signed.recover_eoa_sender().is_err());
+        assert_eq!(signed.recover_eoa_sender_unchecked().unwrap(), Some(expected));
+    }
+
+    #[cfg(feature = "k256")]
+    #[test]
+    fn recover_eoa_sender_unchecked_returns_none_for_configured_owner() {
+        let signed = sample_signed(false);
+        assert!(signed.explicit_sender().is_some());
+        assert_eq!(signed.recover_eoa_sender_unchecked().unwrap(), None);
     }
 
     #[cfg(feature = "serde")]

--- a/crates/common/consensus/src/transaction/eip8130/signed.rs
+++ b/crates/common/consensus/src/transaction/eip8130/signed.rs
@@ -143,6 +143,32 @@ impl Eip8130Signed {
         self.tx.sender
     }
 
+    /// Recovers the sender for the EOA-path EIP-8130 transaction.
+    ///
+    /// Returns `Ok(None)` when [`Self::explicit_sender`] is `Some(_)` — the
+    /// configured-owner path does not require ecrecover because the sender
+    /// address is already in the transaction body.
+    ///
+    /// Returns `Ok(Some(addr))` when [`TxEip8130::sender`] is `None`: parses
+    /// the 65-byte `r || s || v` ECDSA payload in [`Self::sender_auth`] and
+    /// recovers the signer against [`TxEip8130::sender_signature_hash`].
+    ///
+    /// Returns `Err(_)` when the EOA payload is malformed (wrong length or
+    /// invalid signature). Callers should treat a missing sender + malformed
+    /// `sender_auth` as a hard rejection.
+    #[cfg(feature = "k256")]
+    pub fn recover_eoa_sender(
+        &self,
+    ) -> Result<Option<Address>, alloy_consensus::crypto::RecoveryError> {
+        if self.tx.sender.is_some() {
+            return Ok(None);
+        }
+        let signature = alloy_primitives::Signature::try_from(self.sender_auth.as_ref())
+            .map_err(|_| alloy_consensus::crypto::RecoveryError::new())?;
+        let hash = self.tx.sender_signature_hash();
+        alloy_consensus::crypto::secp256k1::recover_signer(&signature, hash).map(Some)
+    }
+
     fn rlp_payload_length(&self) -> usize {
         self.tx.rlp_encoded_fields_length() + self.sender_auth.length() + self.payer_auth.length()
     }
@@ -444,6 +470,42 @@ mod tests {
             signed.explicit_sender(),
             Some(address!("0x00000000000000000000000000000000000000aa"))
         );
+    }
+
+    #[cfg(feature = "k256")]
+    #[test]
+    fn recover_eoa_sender_returns_none_for_configured_owner() {
+        let signed = sample_signed(false);
+        assert!(signed.explicit_sender().is_some());
+        assert_eq!(signed.recover_eoa_sender().unwrap(), None);
+    }
+
+    #[cfg(feature = "k256")]
+    #[test]
+    fn recover_eoa_sender_recovers_eoa_signer() {
+        use alloy_signer::SignerSync;
+        use alloy_signer_local::PrivateKeySigner;
+
+        let signer = PrivateKeySigner::random();
+        let expected = signer.address();
+
+        let mut tx = sample_signed(false).into_tx();
+        tx.sender = None;
+        let signature = signer.sign_hash_sync(&tx.sender_signature_hash()).unwrap();
+        let sender_auth = Bytes::from(signature.as_bytes().to_vec());
+        let signed = Eip8130Signed::new(tx, sender_auth, Bytes::new());
+
+        assert_eq!(signed.recover_eoa_sender().unwrap(), Some(expected));
+    }
+
+    #[cfg(feature = "k256")]
+    #[test]
+    fn recover_eoa_sender_rejects_malformed_payload() {
+        let mut tx = sample_signed(false).into_tx();
+        tx.sender = None;
+        // 64 bytes is one short of a valid ECDSA r||s||v payload.
+        let signed = Eip8130Signed::new(tx, Bytes::from(vec![0u8; 64]), Bytes::new());
+        assert!(signed.recover_eoa_sender().is_err());
     }
 
     #[cfg(feature = "serde")]

--- a/crates/common/consensus/src/transaction/eip8130/signed.rs
+++ b/crates/common/consensus/src/transaction/eip8130/signed.rs
@@ -179,6 +179,32 @@ impl Eip8130Signed {
         self.recover_eoa_sender_with(alloy_consensus::crypto::secp256k1::recover_signer_unchecked)
     }
 
+    /// Recovers the sender of this signed transaction by short-circuiting to
+    /// [`Self::explicit_sender`] for the configured-owner path and otherwise
+    /// running checked EOA ecrecover. Flattens the [`Self::recover_eoa_sender`]
+    /// `Option` so call sites in the pooled and envelope `SignerRecoverable`
+    /// implementations stay one-liners and cannot drift.
+    #[cfg(feature = "k256")]
+    pub fn recover_sender(&self) -> Result<Address, alloy_consensus::crypto::RecoveryError> {
+        if let Some(addr) = self.explicit_sender() {
+            return Ok(addr);
+        }
+        self.recover_eoa_sender()?.ok_or_else(alloy_consensus::crypto::RecoveryError::new)
+    }
+
+    /// Same as [`Self::recover_sender`] but uses the unchecked recovery path,
+    /// preserving the upper-half-`s`-accepting contract required by the
+    /// `recover_signer_unchecked` and `recover_unchecked_with_buf` dispatchers.
+    #[cfg(feature = "k256")]
+    pub fn recover_sender_unchecked(
+        &self,
+    ) -> Result<Address, alloy_consensus::crypto::RecoveryError> {
+        if let Some(addr) = self.explicit_sender() {
+            return Ok(addr);
+        }
+        self.recover_eoa_sender_unchecked()?.ok_or_else(alloy_consensus::crypto::RecoveryError::new)
+    }
+
     #[cfg(feature = "k256")]
     fn recover_eoa_sender_with(
         &self,

--- a/crates/common/consensus/src/transaction/envelope.rs
+++ b/crates/common/consensus/src/transaction/envelope.rs
@@ -585,7 +585,7 @@ impl alloy_consensus::transaction::SignerRecoverable for BaseTxEnvelope {
             Self::Eip2930(tx) => tx.signature_hash(),
             Self::Eip1559(tx) => tx.signature_hash(),
             Self::Eip7702(tx) => tx.signature_hash(),
-            Self::Eip8130(tx) => return recover_eip8130_envelope_sender(tx),
+            Self::Eip8130(tx) => return tx.recover_sender(),
             // The Deposit transaction does not have a signature. Directly return the
             // `from` address.
             Self::Deposit(tx) => return Ok(tx.from),
@@ -610,7 +610,7 @@ impl alloy_consensus::transaction::SignerRecoverable for BaseTxEnvelope {
             Self::Eip2930(tx) => tx.signature_hash(),
             Self::Eip1559(tx) => tx.signature_hash(),
             Self::Eip7702(tx) => tx.signature_hash(),
-            Self::Eip8130(tx) => return recover_eip8130_envelope_sender_unchecked(tx),
+            Self::Eip8130(tx) => return tx.recover_sender_unchecked(),
             // The Deposit transaction does not have a signature. Directly return the
             // `from` address.
             Self::Deposit(tx) => return Ok(tx.from),
@@ -644,39 +644,10 @@ impl alloy_consensus::transaction::SignerRecoverable for BaseTxEnvelope {
             Self::Eip7702(tx) => {
                 alloy_consensus::transaction::SignerRecoverable::recover_unchecked_with_buf(tx, buf)
             }
-            Self::Eip8130(tx) => recover_eip8130_envelope_sender_unchecked(tx),
+            Self::Eip8130(tx) => tx.recover_sender_unchecked(),
             Self::Deposit(tx) => Ok(tx.from),
         }
     }
-}
-
-/// Recovers the sender of an EIP-8130 envelope variant using the **checked**
-/// recovery path: short-circuits to the explicit sender when the
-/// configured-owner path is in use, otherwise runs EOA ecrecover with EIP-2
-/// low-`s` enforcement.
-#[cfg(feature = "k256")]
-fn recover_eip8130_envelope_sender(
-    tx: &crate::transaction::eip8130::Eip8130Signed,
-) -> Result<alloy_primitives::Address, alloy_consensus::crypto::RecoveryError> {
-    if let Some(addr) = tx.explicit_sender() {
-        return Ok(addr);
-    }
-    tx.recover_eoa_sender()?.ok_or_else(alloy_consensus::crypto::RecoveryError::new)
-}
-
-/// Same as [`recover_eip8130_envelope_sender`] but uses the unchecked
-/// recovery path. Required by the [`alloy_consensus::transaction::SignerRecoverable::recover_signer_unchecked`]
-/// and [`alloy_consensus::transaction::SignerRecoverable::recover_unchecked_with_buf`]
-/// contracts which must accept upper-half `s` values; the pool path and the
-/// envelope-level block-import path share this requirement.
-#[cfg(feature = "k256")]
-fn recover_eip8130_envelope_sender_unchecked(
-    tx: &crate::transaction::eip8130::Eip8130Signed,
-) -> Result<alloy_primitives::Address, alloy_consensus::crypto::RecoveryError> {
-    if let Some(addr) = tx.explicit_sender() {
-        return Ok(addr);
-    }
-    tx.recover_eoa_sender_unchecked()?.ok_or_else(alloy_consensus::crypto::RecoveryError::new)
 }
 
 /// Bincode-compatible serde implementation for [`BaseTxEnvelope`].

--- a/crates/common/consensus/src/transaction/envelope.rs
+++ b/crates/common/consensus/src/transaction/envelope.rs
@@ -585,10 +585,7 @@ impl alloy_consensus::transaction::SignerRecoverable for BaseTxEnvelope {
             Self::Eip2930(tx) => tx.signature_hash(),
             Self::Eip1559(tx) => tx.signature_hash(),
             Self::Eip7702(tx) => tx.signature_hash(),
-            Self::Eip8130(tx) => match tx.explicit_sender() {
-                Some(sender) => return Ok(sender),
-                None => return Err(alloy_consensus::crypto::RecoveryError::new()),
-            },
+            Self::Eip8130(tx) => return recover_eip8130_envelope_sender(tx),
             // The Deposit transaction does not have a signature. Directly return the
             // `from` address.
             Self::Deposit(tx) => return Ok(tx.from),
@@ -613,10 +610,7 @@ impl alloy_consensus::transaction::SignerRecoverable for BaseTxEnvelope {
             Self::Eip2930(tx) => tx.signature_hash(),
             Self::Eip1559(tx) => tx.signature_hash(),
             Self::Eip7702(tx) => tx.signature_hash(),
-            Self::Eip8130(tx) => match tx.explicit_sender() {
-                Some(sender) => return Ok(sender),
-                None => return Err(alloy_consensus::crypto::RecoveryError::new()),
-            },
+            Self::Eip8130(tx) => return recover_eip8130_envelope_sender_unchecked(tx),
             // The Deposit transaction does not have a signature. Directly return the
             // `from` address.
             Self::Deposit(tx) => return Ok(tx.from),
@@ -650,12 +644,39 @@ impl alloy_consensus::transaction::SignerRecoverable for BaseTxEnvelope {
             Self::Eip7702(tx) => {
                 alloy_consensus::transaction::SignerRecoverable::recover_unchecked_with_buf(tx, buf)
             }
-            Self::Eip8130(tx) => {
-                tx.explicit_sender().ok_or_else(alloy_consensus::crypto::RecoveryError::new)
-            }
+            Self::Eip8130(tx) => recover_eip8130_envelope_sender_unchecked(tx),
             Self::Deposit(tx) => Ok(tx.from),
         }
     }
+}
+
+/// Recovers the sender of an EIP-8130 envelope variant using the **checked**
+/// recovery path: short-circuits to the explicit sender when the
+/// configured-owner path is in use, otherwise runs EOA ecrecover with EIP-2
+/// low-`s` enforcement.
+#[cfg(feature = "k256")]
+fn recover_eip8130_envelope_sender(
+    tx: &crate::transaction::eip8130::Eip8130Signed,
+) -> Result<alloy_primitives::Address, alloy_consensus::crypto::RecoveryError> {
+    if let Some(addr) = tx.explicit_sender() {
+        return Ok(addr);
+    }
+    tx.recover_eoa_sender()?.ok_or_else(alloy_consensus::crypto::RecoveryError::new)
+}
+
+/// Same as [`recover_eip8130_envelope_sender`] but uses the unchecked
+/// recovery path. Required by the [`alloy_consensus::transaction::SignerRecoverable::recover_signer_unchecked`]
+/// and [`alloy_consensus::transaction::SignerRecoverable::recover_unchecked_with_buf`]
+/// contracts which must accept upper-half `s` values; the pool path and the
+/// envelope-level block-import path share this requirement.
+#[cfg(feature = "k256")]
+fn recover_eip8130_envelope_sender_unchecked(
+    tx: &crate::transaction::eip8130::Eip8130Signed,
+) -> Result<alloy_primitives::Address, alloy_consensus::crypto::RecoveryError> {
+    if let Some(addr) = tx.explicit_sender() {
+        return Ok(addr);
+    }
+    tx.recover_eoa_sender_unchecked()?.ok_or_else(alloy_consensus::crypto::RecoveryError::new)
 }
 
 /// Bincode-compatible serde implementation for [`BaseTxEnvelope`].
@@ -1019,5 +1040,68 @@ mod tests {
         let mut slice = encoded.as_slice();
         let decoded = BaseTxEnvelope::decode_2718(&mut slice).unwrap();
         assert!(matches!(decoded, BaseTxEnvelope::Eip1559(_)));
+    }
+
+    #[cfg(feature = "k256")]
+    #[test]
+    fn eip8130_envelope_recovery_honors_checked_vs_unchecked_contract() {
+        use alloy_consensus::transaction::SignerRecoverable;
+        use alloy_signer::SignerSync;
+        use alloy_signer_local::PrivateKeySigner;
+
+        use crate::transaction::eip8130::{Eip8130Signed, TxEip8130};
+
+        // secp256k1 curve order N — used to flip a canonical signature into
+        // the upper half via (r, s, v) -> (r, N - s, !v).
+        const SECP256K1_N: U256 = U256::from_be_slice(&[
+            0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+            0xff, 0xfe, 0xba, 0xae, 0xdc, 0xe6, 0xaf, 0x48, 0xa0, 0x3b, 0xbf, 0xd2, 0x5e, 0x8c,
+            0xd0, 0x36, 0x41, 0x41,
+        ]);
+
+        let signer = PrivateKeySigner::random();
+        let expected = signer.address();
+
+        let tx = TxEip8130 { sender: None, ..Default::default() };
+        let hash = tx.sender_signature_hash();
+        let canonical = signer.sign_hash_sync(&hash).unwrap();
+        let high_s = Signature::new(canonical.r(), SECP256K1_N - canonical.s(), !canonical.v());
+
+        let envelope = BaseTxEnvelope::Eip8130(Eip8130Signed::new(
+            tx,
+            Bytes::from(high_s.as_bytes().to_vec()),
+            Bytes::new(),
+        ));
+
+        // Checked path enforces EIP-2 low-s and must reject; the unchecked
+        // path is contractually required to accept and recover the address.
+        assert!(envelope.recover_signer().is_err());
+        assert_eq!(envelope.recover_signer_unchecked().unwrap(), expected);
+
+        let mut buf = alloc::vec::Vec::new();
+        assert_eq!(envelope.recover_unchecked_with_buf(&mut buf).unwrap(), expected);
+    }
+
+    #[cfg(feature = "k256")]
+    #[test]
+    fn eip8130_envelope_recovery_short_circuits_configured_owner() {
+        use alloy_consensus::transaction::SignerRecoverable;
+
+        use crate::transaction::eip8130::{Eip8130Signed, TxEip8130};
+
+        let explicit = Address::repeat_byte(0xab);
+        let tx = TxEip8130 { sender: Some(explicit), ..Default::default() };
+        // sender_auth is irrelevant on the configured-owner path; supply 65
+        // zero bytes so the structural shape stays well-formed.
+        let envelope = BaseTxEnvelope::Eip8130(Eip8130Signed::new(
+            tx,
+            Bytes::from(vec![0u8; 65]),
+            Bytes::new(),
+        ));
+
+        assert_eq!(envelope.recover_signer().unwrap(), explicit);
+        assert_eq!(envelope.recover_signer_unchecked().unwrap(), explicit);
+        let mut buf = alloc::vec::Vec::new();
+        assert_eq!(envelope.recover_unchecked_with_buf(&mut buf).unwrap(), explicit);
     }
 }

--- a/crates/common/consensus/src/transaction/pooled.rs
+++ b/crates/common/consensus/src/transaction/pooled.rs
@@ -223,12 +223,22 @@ impl TxHashRef for BasePooledTransaction {
 }
 
 #[cfg(feature = "k256")]
+fn recover_eip8130_sender(
+    tx: &Eip8130Signed,
+) -> Result<alloy_primitives::Address, alloy_consensus::crypto::RecoveryError> {
+    if let Some(addr) = tx.explicit_sender() {
+        return Ok(addr);
+    }
+    tx.recover_eoa_sender()?.ok_or_else(alloy_consensus::crypto::RecoveryError::new)
+}
+
+#[cfg(feature = "k256")]
 impl alloy_consensus::transaction::SignerRecoverable for BasePooledTransaction {
     fn recover_signer(
         &self,
     ) -> Result<alloy_primitives::Address, alloy_consensus::crypto::RecoveryError> {
         if let Self::Eip8130(tx) = self {
-            return tx.explicit_sender().ok_or_else(alloy_consensus::crypto::RecoveryError::new);
+            return recover_eip8130_sender(tx);
         }
         let signature_hash = self.signature_hash();
         alloy_consensus::crypto::secp256k1::recover_signer(self.signature(), signature_hash)
@@ -238,7 +248,7 @@ impl alloy_consensus::transaction::SignerRecoverable for BasePooledTransaction {
         &self,
     ) -> Result<alloy_primitives::Address, alloy_consensus::crypto::RecoveryError> {
         if let Self::Eip8130(tx) = self {
-            return tx.explicit_sender().ok_or_else(alloy_consensus::crypto::RecoveryError::new);
+            return recover_eip8130_sender(tx);
         }
         let signature_hash = self.signature_hash();
         alloy_consensus::crypto::secp256k1::recover_signer_unchecked(
@@ -264,9 +274,7 @@ impl alloy_consensus::transaction::SignerRecoverable for BasePooledTransaction {
             Self::Eip7702(tx) => {
                 alloy_consensus::transaction::SignerRecoverable::recover_unchecked_with_buf(tx, buf)
             }
-            Self::Eip8130(tx) => {
-                tx.explicit_sender().ok_or_else(alloy_consensus::crypto::RecoveryError::new)
-            }
+            Self::Eip8130(tx) => recover_eip8130_sender(tx),
         }
     }
 }

--- a/crates/common/consensus/src/transaction/pooled.rs
+++ b/crates/common/consensus/src/transaction/pooled.rs
@@ -233,6 +233,16 @@ fn recover_eip8130_sender(
 }
 
 #[cfg(feature = "k256")]
+fn recover_eip8130_sender_unchecked(
+    tx: &Eip8130Signed,
+) -> Result<alloy_primitives::Address, alloy_consensus::crypto::RecoveryError> {
+    if let Some(addr) = tx.explicit_sender() {
+        return Ok(addr);
+    }
+    tx.recover_eoa_sender_unchecked()?.ok_or_else(alloy_consensus::crypto::RecoveryError::new)
+}
+
+#[cfg(feature = "k256")]
 impl alloy_consensus::transaction::SignerRecoverable for BasePooledTransaction {
     fn recover_signer(
         &self,
@@ -248,7 +258,7 @@ impl alloy_consensus::transaction::SignerRecoverable for BasePooledTransaction {
         &self,
     ) -> Result<alloy_primitives::Address, alloy_consensus::crypto::RecoveryError> {
         if let Self::Eip8130(tx) = self {
-            return recover_eip8130_sender(tx);
+            return recover_eip8130_sender_unchecked(tx);
         }
         let signature_hash = self.signature_hash();
         alloy_consensus::crypto::secp256k1::recover_signer_unchecked(
@@ -274,7 +284,7 @@ impl alloy_consensus::transaction::SignerRecoverable for BasePooledTransaction {
             Self::Eip7702(tx) => {
                 alloy_consensus::transaction::SignerRecoverable::recover_unchecked_with_buf(tx, buf)
             }
-            Self::Eip8130(tx) => recover_eip8130_sender(tx),
+            Self::Eip8130(tx) => recover_eip8130_sender_unchecked(tx),
         }
     }
 }

--- a/crates/common/consensus/src/transaction/pooled.rs
+++ b/crates/common/consensus/src/transaction/pooled.rs
@@ -223,32 +223,12 @@ impl TxHashRef for BasePooledTransaction {
 }
 
 #[cfg(feature = "k256")]
-fn recover_eip8130_sender(
-    tx: &Eip8130Signed,
-) -> Result<alloy_primitives::Address, alloy_consensus::crypto::RecoveryError> {
-    if let Some(addr) = tx.explicit_sender() {
-        return Ok(addr);
-    }
-    tx.recover_eoa_sender()?.ok_or_else(alloy_consensus::crypto::RecoveryError::new)
-}
-
-#[cfg(feature = "k256")]
-fn recover_eip8130_sender_unchecked(
-    tx: &Eip8130Signed,
-) -> Result<alloy_primitives::Address, alloy_consensus::crypto::RecoveryError> {
-    if let Some(addr) = tx.explicit_sender() {
-        return Ok(addr);
-    }
-    tx.recover_eoa_sender_unchecked()?.ok_or_else(alloy_consensus::crypto::RecoveryError::new)
-}
-
-#[cfg(feature = "k256")]
 impl alloy_consensus::transaction::SignerRecoverable for BasePooledTransaction {
     fn recover_signer(
         &self,
     ) -> Result<alloy_primitives::Address, alloy_consensus::crypto::RecoveryError> {
         if let Self::Eip8130(tx) = self {
-            return recover_eip8130_sender(tx);
+            return tx.recover_sender();
         }
         let signature_hash = self.signature_hash();
         alloy_consensus::crypto::secp256k1::recover_signer(self.signature(), signature_hash)
@@ -258,7 +238,7 @@ impl alloy_consensus::transaction::SignerRecoverable for BasePooledTransaction {
         &self,
     ) -> Result<alloy_primitives::Address, alloy_consensus::crypto::RecoveryError> {
         if let Self::Eip8130(tx) = self {
-            return recover_eip8130_sender_unchecked(tx);
+            return tx.recover_sender_unchecked();
         }
         let signature_hash = self.signature_hash();
         alloy_consensus::crypto::secp256k1::recover_signer_unchecked(
@@ -284,7 +264,7 @@ impl alloy_consensus::transaction::SignerRecoverable for BasePooledTransaction {
             Self::Eip7702(tx) => {
                 alloy_consensus::transaction::SignerRecoverable::recover_unchecked_with_buf(tx, buf)
             }
-            Self::Eip8130(tx) => recover_eip8130_sender_unchecked(tx),
+            Self::Eip8130(tx) => tx.recover_sender_unchecked(),
         }
     }
 }

--- a/crates/execution/txpool/src/transaction.rs
+++ b/crates/execution/txpool/src/transaction.rs
@@ -12,7 +12,7 @@ use alloy_eips::{
     eip7702::SignedAuthorization,
 };
 use alloy_primitives::{Address, B256, Bytes, TxHash, TxKind, U256};
-use base_common_consensus::BaseTransactionSigned;
+use base_common_consensus::{BaseTransactionSigned, Eip8130Signed};
 use c_kzg::KzgSettings;
 use reth_primitives_traits::{InMemorySize, SignedTransaction};
 use reth_transaction_pool::{
@@ -328,16 +328,29 @@ where
 pub trait BasePooledTx: PoolTransaction + DataAvailabilitySized {
     /// Returns the EIP-2718 encoded bytes of the transaction.
     fn encoded_2718(&self) -> Cow<'_, Bytes>;
+
+    /// Returns the signed EIP-8130 payload when this transaction carries one.
+    ///
+    /// Required for the mempool validator's structural admission checks; the
+    /// default returns `None` for implementers that never carry EIP-8130
+    /// (account abstraction) transactions.
+    fn as_eip8130(&self) -> Option<&Eip8130Signed> {
+        None
+    }
 }
 
-impl<Cons, Pooled> BasePooledTx for BasePooledTransaction<Cons, Pooled>
+impl<Pooled> BasePooledTx for BasePooledTransaction<BaseTransactionSigned, Pooled>
 where
-    Cons: SignedTransaction + From<Pooled>,
-    Pooled: SignedTransaction + TryFrom<Cons>,
-    <Pooled as TryFrom<Cons>>::Error: core::error::Error,
+    BaseTransactionSigned: From<Pooled>,
+    Pooled: SignedTransaction + TryFrom<BaseTransactionSigned>,
+    <Pooled as TryFrom<BaseTransactionSigned>>::Error: core::error::Error,
 {
     fn encoded_2718(&self) -> Cow<'_, Bytes> {
         Cow::Borrowed(self.encoded_2718())
+    }
+
+    fn as_eip8130(&self) -> Option<&Eip8130Signed> {
+        self.inner.transaction().inner().as_eip8130()
     }
 }
 

--- a/crates/execution/txpool/src/validator.rs
+++ b/crates/execution/txpool/src/validator.rs
@@ -188,7 +188,10 @@ where
     /// This behaves the same as [`EthTransactionValidator::validate_one_with_state`], but in
     /// addition applies Base-specific validity checks:
     /// - ensures tx is not eip4844
-    /// - ensures tx is not eip8130 (account abstraction; no validation/execution path exists yet)
+    /// - for eip8130 (account abstraction): rejects local-origin submissions and enforces the
+    ///   structural admission gate from [`Self::validate_eip8130_structural`] before the inner
+    ///   Eth checks; verifier dispatch, account state lookups, and fork gating are not yet
+    ///   performed
     /// - ensures that the account has enough balance to cover the L1 gas cost
     pub async fn validate_one_with_state(
         &self,
@@ -466,10 +469,15 @@ where
 mod tests {
     use alloy_consensus::{SignableTransaction, TxEip1559, transaction::SignerRecoverable};
     use alloy_eips::eip2718::Encodable2718;
-    use alloy_primitives::{Address, TxKind, U256, bytes, hex::decode};
+    use alloy_primitives::{Address, B256, Bytes, TxKind, U256, bytes, hex::decode};
     use alloy_signer::SignerSync;
+    use alloy_signer_local::PrivateKeySigner;
     use base_common_chains::ChainConfig;
-    use base_common_consensus::{BasePrimitives, BaseTransactionSigned, BaseTxEnvelope, TxDeposit};
+    use base_common_consensus::{
+        AccountChange, BasePrimitives, BaseTransactionSigned, BaseTxEnvelope, ConfigChange,
+        CreateEntry, Delegation, Eip8130Constants, Eip8130Signed, InitialOwner, Scope, TxDeposit,
+        TxEip8130,
+    };
     use base_execution_chainspec::BaseChainSpec;
     use base_execution_evm::BaseEvmConfig;
     use base_test_utils::Account;
@@ -481,6 +489,492 @@ mod tests {
 
     use super::*;
     use crate::BasePooledTransaction;
+
+    type TestValidator = BaseTransactionValidator<
+        MockEthProvider<BasePrimitives, Arc<BaseChainSpec>>,
+        BasePooledTransaction,
+        BaseEvmConfig,
+    >;
+
+    /// Builds a [`BaseTransactionValidator`] configured against the mainnet chain spec with
+    /// no accounts seeded. Suitable for tests that exercise the EIP-8130 structural-acceptance
+    /// gate, which rejects without touching account state.
+    fn build_test_validator() -> TestValidator {
+        let chain_spec = Arc::new(BaseChainSpec::mainnet());
+        let client = MockEthProvider::<BasePrimitives>::new()
+            .with_chain_spec(Arc::clone(&chain_spec))
+            .with_genesis_block();
+        let evm_config = BaseEvmConfig::base(Arc::clone(&chain_spec));
+        let inner = EthTransactionValidatorBuilder::new(client, evm_config)
+            .no_shanghai()
+            .no_cancun()
+            .build(InMemoryBlobStore::default());
+        BaseTransactionValidator::with_block_info(inner, BaseL1BlockInfo::default())
+    }
+
+    /// Returns the chain id the [`build_test_validator`] is configured against.
+    fn test_chain_id() -> u64 {
+        ChainConfig::mainnet().chain_id
+    }
+
+    /// Signs `tx` as an EOA-path EIP-8130 transaction and returns the resulting
+    /// [`Eip8130Signed`] with a valid 65-byte secp256k1 `sender_auth`.
+    fn sign_eoa_eip8130(tx: TxEip8130) -> Eip8130Signed {
+        let signer = PrivateKeySigner::random();
+        let signature = signer.sign_hash_sync(&tx.sender_signature_hash()).unwrap();
+        let sig_bytes: Bytes = signature.as_bytes().to_vec().into();
+        Eip8130Signed::new(tx, sig_bytes, Bytes::new())
+    }
+
+    /// Returns a minimal, structurally valid EOA-path [`TxEip8130`] bound to the
+    /// test chain. `sender` is left as `None` so the EOA recovery path is exercised.
+    fn minimal_valid_eoa_tx() -> TxEip8130 {
+        TxEip8130 {
+            chain_id: test_chain_id(),
+            sender: None,
+            nonce_key: U256::ZERO,
+            nonce_sequence: 1,
+            expiry: 0,
+            max_priority_fee_per_gas: 0,
+            max_fee_per_gas: 1_000,
+            gas_limit: 50_000,
+            account_changes: Vec::new(),
+            calls: Vec::new(),
+            payer: None,
+        }
+    }
+
+    /// Helper: assert structural validation returns `Invalid` with `TxTypeNotSupported`.
+    #[track_caller]
+    fn assert_unsupported(result: Result<(), InvalidPoolTransactionError>) {
+        match result {
+            Err(InvalidPoolTransactionError::Consensus(
+                InvalidTransactionError::TxTypeNotSupported,
+            )) => {}
+            other => panic!("expected TxTypeNotSupported, got {other:?}"),
+        }
+    }
+
+    /// Helper: assert structural validation returns `Invalid` with `ChainIdMismatch`.
+    #[track_caller]
+    fn assert_chain_id_mismatch(result: Result<(), InvalidPoolTransactionError>) {
+        match result {
+            Err(InvalidPoolTransactionError::Consensus(
+                InvalidTransactionError::ChainIdMismatch,
+            )) => {}
+            other => panic!("expected ChainIdMismatch, got {other:?}"),
+        }
+    }
+
+    /// Helper: assert structural validation returns `Invalid` with `TipAboveFeeCap`.
+    #[track_caller]
+    fn assert_tip_above_fee_cap(result: Result<(), InvalidPoolTransactionError>) {
+        match result {
+            Err(InvalidPoolTransactionError::Consensus(
+                InvalidTransactionError::TipAboveFeeCap,
+            )) => {}
+            other => panic!("expected TipAboveFeeCap, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn accepts_eip8130_with_minimum_valid_eoa_shape() {
+        let validator = build_test_validator();
+        let signed = sign_eoa_eip8130(minimal_valid_eoa_tx());
+        assert!(
+            validator.validate_eip8130_structural(TransactionOrigin::External, &signed).is_ok()
+        );
+    }
+
+    #[test]
+    fn rejects_eip8130_from_local_origin() {
+        let validator = build_test_validator();
+        let signed = sign_eoa_eip8130(minimal_valid_eoa_tx());
+        assert_unsupported(
+            validator.validate_eip8130_structural(TransactionOrigin::Local, &signed),
+        );
+        assert_unsupported(
+            validator.validate_eip8130_structural(TransactionOrigin::Private, &signed),
+        );
+    }
+
+    #[test]
+    fn rejects_eip8130_with_wrong_chain_id() {
+        let validator = build_test_validator();
+        let tx = TxEip8130 { chain_id: test_chain_id() + 1, ..minimal_valid_eoa_tx() };
+        let signed = sign_eoa_eip8130(tx);
+        assert_chain_id_mismatch(
+            validator.validate_eip8130_structural(TransactionOrigin::External, &signed),
+        );
+    }
+
+    #[test]
+    fn rejects_eip8130_with_tip_above_fee_cap() {
+        let validator = build_test_validator();
+        let tx = TxEip8130 {
+            max_fee_per_gas: 100,
+            max_priority_fee_per_gas: 200,
+            ..minimal_valid_eoa_tx()
+        };
+        let signed = sign_eoa_eip8130(tx);
+        assert_tip_above_fee_cap(
+            validator.validate_eip8130_structural(TransactionOrigin::External, &signed),
+        );
+    }
+
+    #[test]
+    fn rejects_eip8130_with_zero_gas_limit() {
+        let validator = build_test_validator();
+        let tx = TxEip8130 { gas_limit: 0, ..minimal_valid_eoa_tx() };
+        let signed = sign_eoa_eip8130(tx);
+        assert_unsupported(
+            validator.validate_eip8130_structural(TransactionOrigin::External, &signed),
+        );
+    }
+
+    #[test]
+    fn rejects_eip8130_with_zero_fee_cap() {
+        let validator = build_test_validator();
+        let tx = TxEip8130 { max_fee_per_gas: 0, ..minimal_valid_eoa_tx() };
+        let signed = sign_eoa_eip8130(tx);
+        assert_unsupported(
+            validator.validate_eip8130_structural(TransactionOrigin::External, &signed),
+        );
+    }
+
+    #[test]
+    fn rejects_eip8130_nonce_free_without_expiry() {
+        let validator = build_test_validator();
+        let tx = TxEip8130 {
+            nonce_key: Eip8130Constants::NONCE_KEY_MAX,
+            nonce_sequence: 0,
+            expiry: 0,
+            ..minimal_valid_eoa_tx()
+        };
+        let signed = sign_eoa_eip8130(tx);
+        assert_unsupported(
+            validator.validate_eip8130_structural(TransactionOrigin::External, &signed),
+        );
+    }
+
+    #[test]
+    fn rejects_eip8130_nonce_free_with_nonzero_sequence() {
+        let validator = build_test_validator();
+        let tx = TxEip8130 {
+            nonce_key: Eip8130Constants::NONCE_KEY_MAX,
+            nonce_sequence: 1,
+            expiry: 5,
+            ..minimal_valid_eoa_tx()
+        };
+        let signed = sign_eoa_eip8130(tx);
+        assert_unsupported(
+            validator.validate_eip8130_structural(TransactionOrigin::External, &signed),
+        );
+    }
+
+    #[test]
+    fn rejects_eip8130_nonce_free_expiry_too_far_in_future() {
+        let validator = build_test_validator();
+        // block_timestamp returns 0 by default; cap is NONCE_FREE_MAX_EXPIRY_WINDOW (10).
+        let tx = TxEip8130 {
+            nonce_key: Eip8130Constants::NONCE_KEY_MAX,
+            nonce_sequence: 0,
+            expiry: Eip8130Constants::NONCE_FREE_MAX_EXPIRY_WINDOW + 1,
+            ..minimal_valid_eoa_tx()
+        };
+        let signed = sign_eoa_eip8130(tx);
+        assert_unsupported(
+            validator.validate_eip8130_structural(TransactionOrigin::External, &signed),
+        );
+    }
+
+    #[test]
+    fn accepts_eip8130_nonce_free_at_expiry_window_edge() {
+        let validator = build_test_validator();
+        let tx = TxEip8130 {
+            nonce_key: Eip8130Constants::NONCE_KEY_MAX,
+            nonce_sequence: 0,
+            expiry: Eip8130Constants::NONCE_FREE_MAX_EXPIRY_WINDOW,
+            ..minimal_valid_eoa_tx()
+        };
+        let signed = sign_eoa_eip8130(tx);
+        assert!(
+            validator.validate_eip8130_structural(TransactionOrigin::External, &signed).is_ok()
+        );
+    }
+
+    #[test]
+    fn rejects_eip8130_with_invalid_sender_auth_length_eoa_path() {
+        // EOA path requires exactly 65 bytes; anything else is rejected.
+        let tx = minimal_valid_eoa_tx();
+        let signed = Eip8130Signed::new(tx, Bytes::from_static(&[0u8; 32]), Bytes::new());
+        assert_unsupported(TestValidator::validate_sender_auth(&signed));
+    }
+
+    #[test]
+    fn rejects_eip8130_with_empty_sender_auth() {
+        let tx = minimal_valid_eoa_tx();
+        let signed = Eip8130Signed::new(tx, Bytes::new(), Bytes::new());
+        assert_unsupported(TestValidator::validate_sender_auth(&signed));
+    }
+
+    #[test]
+    fn rejects_eip8130_configured_owner_with_revoked_verifier() {
+        let tx = TxEip8130 { sender: Some(Address::repeat_byte(0xaa)), ..minimal_valid_eoa_tx() };
+        // 20-byte verifier prefix == REVOKED_VERIFIER, followed by an empty payload.
+        let auth = Bytes::from(Eip8130Constants::REVOKED_VERIFIER.to_vec());
+        let signed = Eip8130Signed::new(tx, auth, Bytes::new());
+        assert_unsupported(TestValidator::validate_sender_auth(&signed));
+    }
+
+    #[test]
+    fn rejects_eip8130_configured_owner_with_short_auth() {
+        let tx = TxEip8130 { sender: Some(Address::repeat_byte(0xaa)), ..minimal_valid_eoa_tx() };
+        let signed = Eip8130Signed::new(tx, Bytes::from_static(&[0u8; 5]), Bytes::new());
+        assert_unsupported(TestValidator::validate_sender_auth(&signed));
+    }
+
+    #[test]
+    fn rejects_eip8130_payer_present_without_auth() {
+        let tx = TxEip8130 { payer: Some(Address::repeat_byte(0x11)), ..minimal_valid_eoa_tx() };
+        let signed = Eip8130Signed::new(tx, Bytes::from_static(&[0u8; 65]), Bytes::new());
+        assert_unsupported(TestValidator::validate_payer_auth(&signed));
+    }
+
+    #[test]
+    fn rejects_eip8130_payer_absent_with_auth() {
+        let tx = minimal_valid_eoa_tx();
+        let signed =
+            Eip8130Signed::new(tx, Bytes::from_static(&[0u8; 65]), Bytes::from_static(&[0u8; 20]));
+        assert_unsupported(TestValidator::validate_payer_auth(&signed));
+    }
+
+    #[test]
+    fn rejects_eip8130_payer_verifier_revoked() {
+        let tx = TxEip8130 { payer: Some(Address::repeat_byte(0x11)), ..minimal_valid_eoa_tx() };
+        let signed = Eip8130Signed::new(
+            tx,
+            Bytes::from_static(&[0u8; 65]),
+            Bytes::from(Eip8130Constants::REVOKED_VERIFIER.to_vec()),
+        );
+        assert_unsupported(TestValidator::validate_payer_auth(&signed));
+    }
+
+    /// Returns a verifier address comfortably above the `ECRECOVER_VERIFIER` floor
+    /// and distinct from the `REVOKED_VERIFIER` sentinel.
+    fn ok_verifier() -> Address {
+        Address::repeat_byte(0x42)
+    }
+
+    fn make_initial_owner(owner_id_byte: u8) -> InitialOwner {
+        InitialOwner {
+            verifier: ok_verifier(),
+            owner_id: B256::repeat_byte(owner_id_byte),
+            scope: Scope::UNRESTRICTED,
+        }
+    }
+
+    fn make_valid_create_entry() -> CreateEntry {
+        CreateEntry {
+            user_salt: B256::ZERO,
+            code: Bytes::from_static(&[0x60, 0x00]),
+            initial_owners: vec![make_initial_owner(0x01)],
+        }
+    }
+
+    #[test]
+    fn rejects_eip8130_create_not_at_index_zero() {
+        let tx = TxEip8130 {
+            account_changes: vec![
+                AccountChange::Delegation(Delegation { target: Address::repeat_byte(0x33) }),
+                AccountChange::Create(make_valid_create_entry()),
+            ],
+            ..minimal_valid_eoa_tx()
+        };
+        assert_unsupported(TestValidator::validate_account_changes(
+            &sign_eoa_eip8130(tx),
+            test_chain_id(),
+        ));
+    }
+
+    #[test]
+    fn rejects_eip8130_multiple_create_entries() {
+        let tx = TxEip8130 {
+            account_changes: vec![
+                AccountChange::Create(make_valid_create_entry()),
+                AccountChange::Create(make_valid_create_entry()),
+            ],
+            ..minimal_valid_eoa_tx()
+        };
+        assert_unsupported(TestValidator::validate_account_changes(
+            &sign_eoa_eip8130(tx),
+            test_chain_id(),
+        ));
+    }
+
+    #[test]
+    fn rejects_eip8130_create_with_empty_code() {
+        let mut entry = make_valid_create_entry();
+        entry.code = Bytes::new();
+        let tx = TxEip8130 {
+            account_changes: vec![AccountChange::Create(entry)],
+            ..minimal_valid_eoa_tx()
+        };
+        assert_unsupported(TestValidator::validate_account_changes(
+            &sign_eoa_eip8130(tx),
+            test_chain_id(),
+        ));
+    }
+
+    #[test]
+    fn rejects_eip8130_create_with_no_initial_owners() {
+        let mut entry = make_valid_create_entry();
+        entry.initial_owners.clear();
+        let tx = TxEip8130 {
+            account_changes: vec![AccountChange::Create(entry)],
+            ..minimal_valid_eoa_tx()
+        };
+        assert_unsupported(TestValidator::validate_account_changes(
+            &sign_eoa_eip8130(tx),
+            test_chain_id(),
+        ));
+    }
+
+    #[test]
+    fn rejects_eip8130_create_with_duplicate_owner_ids() {
+        let mut entry = make_valid_create_entry();
+        entry.initial_owners.push(make_initial_owner(0x01));
+        let tx = TxEip8130 {
+            account_changes: vec![AccountChange::Create(entry)],
+            ..minimal_valid_eoa_tx()
+        };
+        assert_unsupported(TestValidator::validate_account_changes(
+            &sign_eoa_eip8130(tx),
+            test_chain_id(),
+        ));
+    }
+
+    #[test]
+    fn rejects_eip8130_create_with_owner_verifier_below_floor() {
+        let mut entry = make_valid_create_entry();
+        entry.initial_owners[0].verifier = Address::ZERO;
+        let tx = TxEip8130 {
+            account_changes: vec![AccountChange::Create(entry)],
+            ..minimal_valid_eoa_tx()
+        };
+        assert_unsupported(TestValidator::validate_account_changes(
+            &sign_eoa_eip8130(tx),
+            test_chain_id(),
+        ));
+    }
+
+    #[test]
+    fn rejects_eip8130_create_with_revoked_owner_verifier() {
+        let mut entry = make_valid_create_entry();
+        entry.initial_owners[0].verifier = Eip8130Constants::REVOKED_VERIFIER;
+        let tx = TxEip8130 {
+            account_changes: vec![AccountChange::Create(entry)],
+            ..minimal_valid_eoa_tx()
+        };
+        assert_unsupported(TestValidator::validate_account_changes(
+            &sign_eoa_eip8130(tx),
+            test_chain_id(),
+        ));
+    }
+
+    fn make_valid_config_change() -> ConfigChange {
+        ConfigChange {
+            chain_id: 0,
+            sequence: 0,
+            owner_changes: Vec::new(),
+            auth: Bytes::from_static(&[0u8; 20]),
+        }
+    }
+
+    #[test]
+    fn rejects_eip8130_config_change_with_foreign_chain_id() {
+        let cfg = ConfigChange { chain_id: test_chain_id() + 1, ..make_valid_config_change() };
+        let tx = TxEip8130 {
+            account_changes: vec![AccountChange::ConfigChange(cfg)],
+            ..minimal_valid_eoa_tx()
+        };
+        let result =
+            TestValidator::validate_account_changes(&sign_eoa_eip8130(tx), test_chain_id());
+        match result {
+            Err(InvalidPoolTransactionError::Consensus(
+                InvalidTransactionError::ChainIdMismatch,
+            )) => {}
+            other => panic!("expected ChainIdMismatch, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn rejects_eip8130_config_change_with_short_auth() {
+        let cfg =
+            ConfigChange { auth: Bytes::from_static(&[0u8; 5]), ..make_valid_config_change() };
+        let tx = TxEip8130 {
+            account_changes: vec![AccountChange::ConfigChange(cfg)],
+            ..minimal_valid_eoa_tx()
+        };
+        assert_unsupported(TestValidator::validate_account_changes(
+            &sign_eoa_eip8130(tx),
+            test_chain_id(),
+        ));
+    }
+
+    #[test]
+    fn rejects_eip8130_too_many_config_changes() {
+        let count = Eip8130Constants::MAX_CONFIG_CHANGES_PER_TX + 1;
+        let account_changes =
+            (0..count).map(|_| AccountChange::ConfigChange(make_valid_config_change())).collect();
+        let tx = TxEip8130 { account_changes, ..minimal_valid_eoa_tx() };
+        assert_unsupported(TestValidator::validate_account_changes(
+            &sign_eoa_eip8130(tx),
+            test_chain_id(),
+        ));
+    }
+
+    #[test]
+    fn accepts_eip8130_with_exactly_max_config_changes() {
+        let count = Eip8130Constants::MAX_CONFIG_CHANGES_PER_TX;
+        let account_changes =
+            (0..count).map(|_| AccountChange::ConfigChange(make_valid_config_change())).collect();
+        let tx = TxEip8130 { account_changes, ..minimal_valid_eoa_tx() };
+        assert!(
+            TestValidator::validate_account_changes(&sign_eoa_eip8130(tx), test_chain_id(),)
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn rejects_eip8130_multiple_delegations() {
+        let tx = TxEip8130 {
+            account_changes: vec![
+                AccountChange::Delegation(Delegation { target: Address::repeat_byte(0x11) }),
+                AccountChange::Delegation(Delegation { target: Address::repeat_byte(0x22) }),
+            ],
+            ..minimal_valid_eoa_tx()
+        };
+        assert_unsupported(TestValidator::validate_account_changes(
+            &sign_eoa_eip8130(tx),
+            test_chain_id(),
+        ));
+    }
+
+    #[test]
+    fn accepts_eip8130_with_create_followed_by_delegation_and_configs() {
+        let mut account_changes = vec![AccountChange::Create(make_valid_create_entry())];
+        for _ in 0..3 {
+            account_changes.push(AccountChange::ConfigChange(make_valid_config_change()));
+        }
+        account_changes
+            .push(AccountChange::Delegation(Delegation { target: Address::repeat_byte(0x55) }));
+        let tx = TxEip8130 { account_changes, ..minimal_valid_eoa_tx() };
+        assert!(
+            TestValidator::validate_account_changes(&sign_eoa_eip8130(tx), test_chain_id(),)
+                .is_ok()
+        );
+    }
 
     /// L1 attribute deposit calldata that activates Isthmus and seeds a non-zero
     /// `operator_fee_scalar`/`operator_fee_constant`. Mirrors the fixture used by

--- a/crates/execution/txpool/src/validator.rs
+++ b/crates/execution/txpool/src/validator.rs
@@ -334,9 +334,9 @@ where
                     if create.code.is_empty() || create.initial_owners.is_empty() {
                         return Err(InvalidTransactionError::TxTypeNotSupported.into());
                     }
-                    Self::validate_owner_iter(
-                        create.initial_owners.iter().map(|o| (&o.verifier, &o.owner_id)),
-                    )?;
+                    Self::validate_owner_iter(&create.initial_owners, |o| {
+                        (&o.verifier, &o.owner_id)
+                    })?;
                 }
                 AccountChange::ConfigChange(cfg) => {
                     config_count += 1;
@@ -349,9 +349,11 @@ where
                     if cfg.auth.len() < 20 {
                         return Err(InvalidTransactionError::TxTypeNotSupported.into());
                     }
-                    Self::validate_owner_iter(
-                        cfg.owner_changes.iter().map(|o| (&o.verifier, &o.owner_id)),
-                    )?;
+                    let cfg_verifier = Address::from_slice(&cfg.auth[..20]);
+                    if cfg_verifier == Eip8130Constants::REVOKED_VERIFIER {
+                        return Err(InvalidTransactionError::TxTypeNotSupported.into());
+                    }
+                    Self::validate_owner_iter(&cfg.owner_changes, |o| (&o.verifier, &o.owner_id))?;
                 }
                 AccountChange::Delegation(_) => {
                     delegation_count += 1;
@@ -365,15 +367,22 @@ where
     }
 
     /// Shared validation for any owner-bearing slice (`initial_owners` on
-    /// `Create`, `owner_changes` on `ConfigChange`). Enforces that every
-    /// verifier address is at or above the `ECRECOVER_VERIFIER` floor, never
-    /// equals the `REVOKED_VERIFIER` sentinel, and that no two entries share
-    /// the same `owner_id`.
-    fn validate_owner_iter<'a>(
-        owners: impl Iterator<Item = (&'a Address, &'a B256)>,
+    /// `Create`, `owner_changes` on `ConfigChange`). Enforces that the slice
+    /// length is bounded by [`Eip8130Constants::MAX_OWNERS_PER_ENTRY`] (anti-DoS
+    /// cap on memory + work spent on duplicate detection), that every verifier
+    /// address is at or above the `ECRECOVER_VERIFIER` floor, never equals the
+    /// `REVOKED_VERIFIER` sentinel, and that no two entries share the same
+    /// `owner_id`.
+    fn validate_owner_iter<T>(
+        owners: &[T],
+        project: impl Fn(&T) -> (&Address, &B256),
     ) -> Result<(), InvalidPoolTransactionError> {
+        if owners.len() > Eip8130Constants::MAX_OWNERS_PER_ENTRY {
+            return Err(InvalidTransactionError::TxTypeNotSupported.into());
+        }
         let mut seen = BTreeSet::new();
-        for (verifier, owner_id) in owners {
+        for entry in owners {
+            let (verifier, owner_id) = project(entry);
             if *verifier < Eip8130Constants::ECRECOVER_VERIFIER
                 || *verifier == Eip8130Constants::REVOKED_VERIFIER
             {
@@ -928,6 +937,39 @@ mod tests {
         ));
     }
 
+    #[test]
+    fn rejects_eip8130_create_with_too_many_initial_owners() {
+        let mut entry = make_valid_create_entry();
+        entry.initial_owners.clear();
+        for i in 0..(Eip8130Constants::MAX_OWNERS_PER_ENTRY + 1) {
+            entry.initial_owners.push(make_initial_owner(i as u8));
+        }
+        let tx = TxEip8130 {
+            account_changes: vec![AccountChange::Create(entry)],
+            ..minimal_valid_eoa_tx()
+        };
+        assert_unsupported(TestValidator::validate_account_changes(
+            &sign_eoa_eip8130(tx),
+            test_chain_id(),
+        ));
+    }
+
+    #[test]
+    fn accepts_eip8130_create_with_exactly_max_initial_owners() {
+        let mut entry = make_valid_create_entry();
+        entry.initial_owners.clear();
+        for i in 0..Eip8130Constants::MAX_OWNERS_PER_ENTRY {
+            entry.initial_owners.push(make_initial_owner(i as u8));
+        }
+        let tx = TxEip8130 {
+            account_changes: vec![AccountChange::Create(entry)],
+            ..minimal_valid_eoa_tx()
+        };
+        assert!(
+            TestValidator::validate_account_changes(&sign_eoa_eip8130(tx), test_chain_id()).is_ok()
+        );
+    }
+
     fn make_valid_config_change() -> ConfigChange {
         ConfigChange {
             chain_id: 0,
@@ -958,6 +1000,25 @@ mod tests {
     fn rejects_eip8130_config_change_with_short_auth() {
         let cfg =
             ConfigChange { auth: Bytes::from_static(&[0u8; 5]), ..make_valid_config_change() };
+        let tx = TxEip8130 {
+            account_changes: vec![AccountChange::ConfigChange(cfg)],
+            ..minimal_valid_eoa_tx()
+        };
+        assert_unsupported(TestValidator::validate_account_changes(
+            &sign_eoa_eip8130(tx),
+            test_chain_id(),
+        ));
+    }
+
+    // Mirrors the `sender_auth`/`payer_auth` rejection of a `REVOKED_VERIFIER`
+    // prefix: the per-`ConfigChange` `auth` blob must use a live verifier so the
+    // mempool never propagates a config-change scoped to a revoked authority.
+    #[test]
+    fn rejects_eip8130_config_change_with_revoked_verifier_in_auth() {
+        let cfg = ConfigChange {
+            auth: Bytes::from(Eip8130Constants::REVOKED_VERIFIER.to_vec()),
+            ..make_valid_config_change()
+        };
         let tx = TxEip8130 {
             account_changes: vec![AccountChange::ConfigChange(cfg)],
             ..minimal_valid_eoa_tx()
@@ -1002,6 +1063,27 @@ mod tests {
             owner_changes: vec![mk(dup_id), mk(dup_id)],
             ..make_valid_config_change()
         };
+        let tx = TxEip8130 {
+            account_changes: vec![AccountChange::ConfigChange(cfg)],
+            ..minimal_valid_eoa_tx()
+        };
+        assert_unsupported(TestValidator::validate_account_changes(
+            &sign_eoa_eip8130(tx),
+            test_chain_id(),
+        ));
+    }
+
+    #[test]
+    fn rejects_eip8130_config_change_with_too_many_owner_changes() {
+        let owner_changes = (0..(Eip8130Constants::MAX_OWNERS_PER_ENTRY + 1))
+            .map(|i| OwnerChange {
+                change_type: OwnerChangeType::Authorize,
+                verifier: ok_verifier(),
+                owner_id: B256::repeat_byte(i as u8),
+                scope: Scope::UNRESTRICTED,
+            })
+            .collect();
+        let cfg = ConfigChange { owner_changes, ..make_valid_config_change() };
         let tx = TxEip8130 {
             account_changes: vec![AccountChange::ConfigChange(cfg)],
             ..minimal_valid_eoa_tx()

--- a/crates/execution/txpool/src/validator.rs
+++ b/crates/execution/txpool/src/validator.rs
@@ -1,5 +1,6 @@
 use std::{
     any::Any,
+    collections::BTreeSet,
     sync::{
         Arc,
         atomic::{AtomicU64, Ordering},
@@ -7,7 +8,7 @@ use std::{
 };
 
 use alloy_consensus::{BlockHeader, Transaction};
-use alloy_primitives::{Address, U256};
+use alloy_primitives::{Address, B256, U256};
 use base_common_chains::Upgrades;
 use base_common_consensus::{AccountChange, Eip8130Constants, Eip8130Signed};
 use base_common_evm::{BaseSpecId, L1BlockInfo};
@@ -243,7 +244,12 @@ where
                 return Err(InvalidTransactionError::TxTypeNotSupported.into());
             }
             let now = self.block_timestamp();
-            if tx.expiry > now.saturating_add(Eip8130Constants::NONCE_FREE_MAX_EXPIRY_WINDOW) {
+            // Reject already-expired nonce-free transactions as well as those whose
+            // expiry exceeds the policy window. The non-nonce-free branch below also
+            // rejects past expiries when one is set.
+            if tx.expiry <= now
+                || tx.expiry > now.saturating_add(Eip8130Constants::NONCE_FREE_MAX_EXPIRY_WINDOW)
+            {
                 return Err(InvalidTransactionError::TxTypeNotSupported.into());
             }
         } else if tx.expiry != 0 && tx.expiry <= self.block_timestamp() {
@@ -307,7 +313,10 @@ where
     /// at most one `Create` (and only as the first entry), at most one
     /// `Delegation`, `ConfigChange` count capped at
     /// [`Eip8130Constants::MAX_CONFIG_CHANGES_PER_TX`], chain-binding on
-    /// config changes, and per-entry well-formedness.
+    /// config changes, and per-entry well-formedness. Verifier-address bounds
+    /// and owner-id uniqueness are enforced on both `Create.initial_owners`
+    /// and `ConfigChange.owner_changes` via
+    /// [`Self::validate_owner_iter`].
     fn validate_account_changes(
         signed: &Eip8130Signed,
         local_chain_id: u64,
@@ -325,17 +334,9 @@ where
                     if create.code.is_empty() || create.initial_owners.is_empty() {
                         return Err(InvalidTransactionError::TxTypeNotSupported.into());
                     }
-                    let mut seen_owner_ids = std::collections::BTreeSet::new();
-                    for owner in &create.initial_owners {
-                        if owner.verifier < Eip8130Constants::ECRECOVER_VERIFIER
-                            || owner.verifier == Eip8130Constants::REVOKED_VERIFIER
-                        {
-                            return Err(InvalidTransactionError::TxTypeNotSupported.into());
-                        }
-                        if !seen_owner_ids.insert(owner.owner_id) {
-                            return Err(InvalidTransactionError::TxTypeNotSupported.into());
-                        }
-                    }
+                    Self::validate_owner_iter(
+                        create.initial_owners.iter().map(|o| (&o.verifier, &o.owner_id)),
+                    )?;
                 }
                 AccountChange::ConfigChange(cfg) => {
                     config_count += 1;
@@ -348,6 +349,9 @@ where
                     if cfg.auth.len() < 20 {
                         return Err(InvalidTransactionError::TxTypeNotSupported.into());
                     }
+                    Self::validate_owner_iter(
+                        cfg.owner_changes.iter().map(|o| (&o.verifier, &o.owner_id)),
+                    )?;
                 }
                 AccountChange::Delegation(_) => {
                     delegation_count += 1;
@@ -355,6 +359,28 @@ where
                         return Err(InvalidTransactionError::TxTypeNotSupported.into());
                     }
                 }
+            }
+        }
+        Ok(())
+    }
+
+    /// Shared validation for any owner-bearing slice (`initial_owners` on
+    /// `Create`, `owner_changes` on `ConfigChange`). Enforces that every
+    /// verifier address is at or above the `ECRECOVER_VERIFIER` floor, never
+    /// equals the `REVOKED_VERIFIER` sentinel, and that no two entries share
+    /// the same `owner_id`.
+    fn validate_owner_iter<'a>(
+        owners: impl Iterator<Item = (&'a Address, &'a B256)>,
+    ) -> Result<(), InvalidPoolTransactionError> {
+        let mut seen = BTreeSet::new();
+        for (verifier, owner_id) in owners {
+            if *verifier < Eip8130Constants::ECRECOVER_VERIFIER
+                || *verifier == Eip8130Constants::REVOKED_VERIFIER
+            {
+                return Err(InvalidTransactionError::TxTypeNotSupported.into());
+            }
+            if !seen.insert(*owner_id) {
+                return Err(InvalidTransactionError::TxTypeNotSupported.into());
             }
         }
         Ok(())
@@ -475,8 +501,8 @@ mod tests {
     use base_common_chains::ChainConfig;
     use base_common_consensus::{
         AccountChange, BasePrimitives, BaseTransactionSigned, BaseTxEnvelope, ConfigChange,
-        CreateEntry, Delegation, Eip8130Constants, Eip8130Signed, InitialOwner, Scope, TxDeposit,
-        TxEip8130,
+        CreateEntry, Delegation, Eip8130Constants, Eip8130Signed, InitialOwner, OwnerChange,
+        OwnerChangeType, Scope, TxDeposit, TxEip8130,
     };
     use base_execution_chainspec::BaseChainSpec;
     use base_execution_evm::BaseEvmConfig;
@@ -664,6 +690,26 @@ mod tests {
             nonce_key: Eip8130Constants::NONCE_KEY_MAX,
             nonce_sequence: 1,
             expiry: 5,
+            ..minimal_valid_eoa_tx()
+        };
+        let signed = sign_eoa_eip8130(tx);
+        assert_unsupported(
+            validator.validate_eip8130_structural(TransactionOrigin::External, &signed),
+        );
+    }
+
+    #[test]
+    fn rejects_eip8130_nonce_free_already_expired() {
+        // Advance the validator's tracked block timestamp to 100 so that expiry=50
+        // is strictly in the past; the default fixture sits at timestamp 0 where
+        // there is no way to express "already expired".
+        let validator = build_test_validator();
+        let header = alloy_consensus::Header { timestamp: 100, ..Default::default() };
+        validator.update_l1_block_info::<_, TxEip1559>(&header, None);
+        let tx = TxEip8130 {
+            nonce_key: Eip8130Constants::NONCE_KEY_MAX,
+            nonce_sequence: 0,
+            expiry: 50,
             ..minimal_valid_eoa_tx()
         };
         let signed = sign_eoa_eip8130(tx);
@@ -912,6 +958,50 @@ mod tests {
     fn rejects_eip8130_config_change_with_short_auth() {
         let cfg =
             ConfigChange { auth: Bytes::from_static(&[0u8; 5]), ..make_valid_config_change() };
+        let tx = TxEip8130 {
+            account_changes: vec![AccountChange::ConfigChange(cfg)],
+            ..minimal_valid_eoa_tx()
+        };
+        assert_unsupported(TestValidator::validate_account_changes(
+            &sign_eoa_eip8130(tx),
+            test_chain_id(),
+        ));
+    }
+
+    #[test]
+    fn rejects_eip8130_config_change_with_revoked_verifier_in_owner_changes() {
+        let cfg = ConfigChange {
+            owner_changes: vec![OwnerChange {
+                change_type: OwnerChangeType::Revoke,
+                verifier: Eip8130Constants::REVOKED_VERIFIER,
+                owner_id: B256::repeat_byte(0x01),
+                scope: Scope::UNRESTRICTED,
+            }],
+            ..make_valid_config_change()
+        };
+        let tx = TxEip8130 {
+            account_changes: vec![AccountChange::ConfigChange(cfg)],
+            ..minimal_valid_eoa_tx()
+        };
+        assert_unsupported(TestValidator::validate_account_changes(
+            &sign_eoa_eip8130(tx),
+            test_chain_id(),
+        ));
+    }
+
+    #[test]
+    fn rejects_eip8130_config_change_with_duplicate_owner_ids() {
+        let dup_id = B256::repeat_byte(0x07);
+        let mk = |id| OwnerChange {
+            change_type: OwnerChangeType::Authorize,
+            verifier: ok_verifier(),
+            owner_id: id,
+            scope: Scope::UNRESTRICTED,
+        };
+        let cfg = ConfigChange {
+            owner_changes: vec![mk(dup_id), mk(dup_id)],
+            ..make_valid_config_change()
+        };
         let tx = TxEip8130 {
             account_changes: vec![AccountChange::ConfigChange(cfg)],
             ..minimal_valid_eoa_tx()

--- a/crates/execution/txpool/src/validator.rs
+++ b/crates/execution/txpool/src/validator.rs
@@ -239,20 +239,20 @@ where
         if tx.gas_limit == 0 || tx.max_fee_per_gas == 0 {
             return Err(InvalidTransactionError::TxTypeNotSupported.into());
         }
+        // Single read of the head-block timestamp so both branches see the
+        // same value even when `on_new_head_block` updates the atomic
+        // concurrently.
+        let now = self.block_timestamp();
         if tx.nonce_key == Eip8130Constants::NONCE_KEY_MAX {
             if tx.nonce_sequence != 0 || tx.expiry == 0 {
                 return Err(InvalidTransactionError::TxTypeNotSupported.into());
             }
-            let now = self.block_timestamp();
-            // Reject already-expired nonce-free transactions as well as those whose
-            // expiry exceeds the policy window. The non-nonce-free branch below also
-            // rejects past expiries when one is set.
             if tx.expiry <= now
                 || tx.expiry > now.saturating_add(Eip8130Constants::NONCE_FREE_MAX_EXPIRY_WINDOW)
             {
                 return Err(InvalidTransactionError::TxTypeNotSupported.into());
             }
-        } else if tx.expiry != 0 && tx.expiry <= self.block_timestamp() {
+        } else if tx.expiry != 0 && tx.expiry <= now {
             return Err(InvalidTransactionError::TxTypeNotSupported.into());
         }
         Self::validate_sender_auth(signed)?;
@@ -281,7 +281,7 @@ where
                 return Err(InvalidTransactionError::TxTypeNotSupported.into());
             }
             let verifier = Address::from_slice(&auth[..20]);
-            if verifier == Eip8130Constants::REVOKED_VERIFIER {
+            if Self::verifier_out_of_range(&verifier) {
                 return Err(InvalidTransactionError::TxTypeNotSupported.into());
             }
         }
@@ -289,7 +289,8 @@ where
     }
 
     /// Ensures `payer_auth` is present iff a `payer` is set, and that its
-    /// verifier prefix is not the revoked sentinel.
+    /// verifier prefix sits in the live policy range (above the reserved
+    /// floor, below the revoked sentinel).
     fn validate_payer_auth(signed: &Eip8130Signed) -> Result<(), InvalidPoolTransactionError> {
         let payer_present = signed.tx().payer.is_some();
         let auth = signed.payer_auth();
@@ -302,11 +303,21 @@ where
                 return Err(InvalidTransactionError::TxTypeNotSupported.into());
             }
             let verifier = Address::from_slice(&auth[..20]);
-            if verifier == Eip8130Constants::REVOKED_VERIFIER {
+            if Self::verifier_out_of_range(&verifier) {
                 return Err(InvalidTransactionError::TxTypeNotSupported.into());
             }
         }
         Ok(())
+    }
+
+    /// Returns `true` when `verifier` falls outside the live mempool policy
+    /// range. Mirrors the check in [`Self::validate_owner_iter`] so all three
+    /// auth surfaces (`sender_auth`, `payer_auth`, `cfg.auth`, and per-owner
+    /// verifiers) reject the reserved `< ECRECOVER_VERIFIER` window and the
+    /// `REVOKED_VERIFIER` sentinel identically.
+    fn verifier_out_of_range(verifier: &Address) -> bool {
+        *verifier < Eip8130Constants::ECRECOVER_VERIFIER
+            || *verifier == Eip8130Constants::REVOKED_VERIFIER
     }
 
     /// Walks `account_changes` and enforces structural invariants:
@@ -350,7 +361,7 @@ where
                         return Err(InvalidTransactionError::TxTypeNotSupported.into());
                     }
                     let cfg_verifier = Address::from_slice(&cfg.auth[..20]);
-                    if cfg_verifier == Eip8130Constants::REVOKED_VERIFIER {
+                    if Self::verifier_out_of_range(&cfg_verifier) {
                         return Err(InvalidTransactionError::TxTypeNotSupported.into());
                     }
                     Self::validate_owner_iter(&cfg.owner_changes, |o| (&o.verifier, &o.owner_id))?;
@@ -383,9 +394,7 @@ where
         let mut seen = BTreeSet::new();
         for entry in owners {
             let (verifier, owner_id) = project(entry);
-            if *verifier < Eip8130Constants::ECRECOVER_VERIFIER
-                || *verifier == Eip8130Constants::REVOKED_VERIFIER
-            {
+            if Self::verifier_out_of_range(verifier) {
                 return Err(InvalidTransactionError::TxTypeNotSupported.into());
             }
             if !seen.insert(*owner_id) {
@@ -782,6 +791,17 @@ mod tests {
         assert_unsupported(TestValidator::validate_sender_auth(&signed));
     }
 
+    // Regression: configured-owner path must reject the reserved verifier
+    // range below `ECRECOVER_VERIFIER`, matching `validate_owner_iter`.
+    // `address(0)` is the canonical reserved value.
+    #[test]
+    fn rejects_eip8130_configured_owner_with_reserved_verifier() {
+        let tx = TxEip8130 { sender: Some(Address::repeat_byte(0xaa)), ..minimal_valid_eoa_tx() };
+        let auth = Bytes::from(Address::ZERO.to_vec());
+        let signed = Eip8130Signed::new(tx, auth, Bytes::new());
+        assert_unsupported(TestValidator::validate_sender_auth(&signed));
+    }
+
     #[test]
     fn rejects_eip8130_configured_owner_with_short_auth() {
         let tx = TxEip8130 { sender: Some(Address::repeat_byte(0xaa)), ..minimal_valid_eoa_tx() };
@@ -801,6 +821,17 @@ mod tests {
         let tx = minimal_valid_eoa_tx();
         let signed =
             Eip8130Signed::new(tx, Bytes::from_static(&[0u8; 65]), Bytes::from_static(&[0u8; 20]));
+        assert_unsupported(TestValidator::validate_payer_auth(&signed));
+    }
+
+    #[test]
+    fn rejects_eip8130_payer_verifier_reserved() {
+        let tx = TxEip8130 { payer: Some(Address::repeat_byte(0x11)), ..minimal_valid_eoa_tx() };
+        let signed = Eip8130Signed::new(
+            tx,
+            Bytes::from_static(&[0u8; 65]),
+            Bytes::from(Address::ZERO.to_vec()),
+        );
         assert_unsupported(TestValidator::validate_payer_auth(&signed));
     }
 
@@ -975,7 +1006,7 @@ mod tests {
             chain_id: 0,
             sequence: 0,
             owner_changes: Vec::new(),
-            auth: Bytes::from_static(&[0u8; 20]),
+            auth: Bytes::from(ok_verifier().to_vec()),
         }
     }
 

--- a/crates/execution/txpool/src/validator.rs
+++ b/crates/execution/txpool/src/validator.rs
@@ -7,13 +7,13 @@ use std::{
 };
 
 use alloy_consensus::{BlockHeader, Transaction};
-use alloy_primitives::U256;
+use alloy_primitives::{Address, U256};
 use base_common_chains::Upgrades;
-use base_common_consensus::EIP8130_TX_TYPE_ID;
+use base_common_consensus::{AccountChange, Eip8130Constants, Eip8130Signed};
 use base_common_evm::{BaseSpecId, L1BlockInfo};
 use base_common_genesis::DaFootprintGasScalarUpdate;
 use parking_lot::RwLock;
-use reth_chainspec::ChainSpecProvider;
+use reth_chainspec::{ChainSpecProvider, EthChainSpec};
 use reth_evm::ConfigureEvm;
 use reth_primitives_traits::{
     Block, BlockBody, BlockTy, GotExpected, SealedBlock,
@@ -203,16 +203,158 @@ where
             );
         }
 
-        if transaction.ty() == EIP8130_TX_TYPE_ID {
-            return TransactionValidationOutcome::Invalid(
-                transaction,
-                InvalidTransactionError::TxTypeNotSupported.into(),
-            );
+        if let Some(signed) = transaction.as_eip8130()
+            && let Err(err) = self.validate_eip8130_structural(origin, signed)
+        {
+            return TransactionValidationOutcome::Invalid(transaction, err);
         }
-
         let outcome = self.inner.validate_one_with_state(origin, transaction, state);
-
         self.apply_base_checks(outcome)
+    }
+
+    /// Runs the mempool admission checks that apply to EIP-8130 (account
+    /// abstraction) transactions without requiring verifier dispatch, account
+    /// state lookups, or fork activation. Mirrors the structural invariants
+    /// listed in EIP-8130 § Validation and § Nonce-Free Mode.
+    fn validate_eip8130_structural(
+        &self,
+        origin: TransactionOrigin,
+        signed: &Eip8130Signed,
+    ) -> Result<(), InvalidPoolTransactionError> {
+        if !origin.is_external() {
+            return Err(InvalidTransactionError::TxTypeNotSupported.into());
+        }
+        let tx = signed.tx();
+        let local_chain_id = self.inner.chain_spec().chain().id();
+        if tx.chain_id != local_chain_id {
+            return Err(InvalidTransactionError::ChainIdMismatch.into());
+        }
+        if tx.max_fee_per_gas < tx.max_priority_fee_per_gas {
+            return Err(InvalidTransactionError::TipAboveFeeCap.into());
+        }
+        if tx.gas_limit == 0 || tx.max_fee_per_gas == 0 {
+            return Err(InvalidTransactionError::TxTypeNotSupported.into());
+        }
+        if tx.nonce_key == Eip8130Constants::NONCE_KEY_MAX {
+            if tx.nonce_sequence != 0 || tx.expiry == 0 {
+                return Err(InvalidTransactionError::TxTypeNotSupported.into());
+            }
+            let now = self.block_timestamp();
+            if tx.expiry > now.saturating_add(Eip8130Constants::NONCE_FREE_MAX_EXPIRY_WINDOW) {
+                return Err(InvalidTransactionError::TxTypeNotSupported.into());
+            }
+        } else if tx.expiry != 0 && tx.expiry <= self.block_timestamp() {
+            return Err(InvalidTransactionError::TxTypeNotSupported.into());
+        }
+        Self::validate_sender_auth(signed)?;
+        Self::validate_payer_auth(signed)?;
+        Self::validate_account_changes(signed, local_chain_id)?;
+        Ok(())
+    }
+
+    /// Checks the `sender_auth` field carries enough bytes for either the EOA
+    /// recovery path (65-byte signature) or the configured-owner auth path
+    /// (`verifier_address || verifier_payload`) and that the verifier address
+    /// is not the sentinel revoked marker.
+    fn validate_sender_auth(signed: &Eip8130Signed) -> Result<(), InvalidPoolTransactionError> {
+        let auth = signed.sender_auth();
+        if auth.is_empty() {
+            return Err(InvalidTransactionError::TxTypeNotSupported.into());
+        }
+        if signed.explicit_sender().is_none() {
+            // EOA path: must carry exactly the secp256k1 signature.
+            if auth.len() != 65 {
+                return Err(InvalidTransactionError::TxTypeNotSupported.into());
+            }
+        } else {
+            // Configured-owner path: leading 20 bytes are the verifier address.
+            if auth.len() < 20 {
+                return Err(InvalidTransactionError::TxTypeNotSupported.into());
+            }
+            let verifier = Address::from_slice(&auth[..20]);
+            if verifier == Eip8130Constants::REVOKED_VERIFIER {
+                return Err(InvalidTransactionError::TxTypeNotSupported.into());
+            }
+        }
+        Ok(())
+    }
+
+    /// Ensures `payer_auth` is present iff a `payer` is set, and that its
+    /// verifier prefix is not the revoked sentinel.
+    fn validate_payer_auth(signed: &Eip8130Signed) -> Result<(), InvalidPoolTransactionError> {
+        let payer_present = signed.tx().payer.is_some();
+        let auth = signed.payer_auth();
+        // XOR: presence must match.
+        if payer_present == auth.is_empty() {
+            return Err(InvalidTransactionError::TxTypeNotSupported.into());
+        }
+        if payer_present {
+            if auth.len() < 20 {
+                return Err(InvalidTransactionError::TxTypeNotSupported.into());
+            }
+            let verifier = Address::from_slice(&auth[..20]);
+            if verifier == Eip8130Constants::REVOKED_VERIFIER {
+                return Err(InvalidTransactionError::TxTypeNotSupported.into());
+            }
+        }
+        Ok(())
+    }
+
+    /// Walks `account_changes` and enforces structural invariants:
+    /// at most one `Create` (and only as the first entry), at most one
+    /// `Delegation`, `ConfigChange` count capped at
+    /// [`Eip8130Constants::MAX_CONFIG_CHANGES_PER_TX`], chain-binding on
+    /// config changes, and per-entry well-formedness.
+    fn validate_account_changes(
+        signed: &Eip8130Signed,
+        local_chain_id: u64,
+    ) -> Result<(), InvalidPoolTransactionError> {
+        let mut create_count = 0usize;
+        let mut delegation_count = 0usize;
+        let mut config_count = 0usize;
+        for (idx, change) in signed.tx().account_changes.iter().enumerate() {
+            match change {
+                AccountChange::Create(create) => {
+                    create_count += 1;
+                    if create_count > 1 || idx != 0 {
+                        return Err(InvalidTransactionError::TxTypeNotSupported.into());
+                    }
+                    if create.code.is_empty() || create.initial_owners.is_empty() {
+                        return Err(InvalidTransactionError::TxTypeNotSupported.into());
+                    }
+                    let mut seen_owner_ids = std::collections::BTreeSet::new();
+                    for owner in &create.initial_owners {
+                        if owner.verifier < Eip8130Constants::ECRECOVER_VERIFIER
+                            || owner.verifier == Eip8130Constants::REVOKED_VERIFIER
+                        {
+                            return Err(InvalidTransactionError::TxTypeNotSupported.into());
+                        }
+                        if !seen_owner_ids.insert(owner.owner_id) {
+                            return Err(InvalidTransactionError::TxTypeNotSupported.into());
+                        }
+                    }
+                }
+                AccountChange::ConfigChange(cfg) => {
+                    config_count += 1;
+                    if config_count > Eip8130Constants::MAX_CONFIG_CHANGES_PER_TX {
+                        return Err(InvalidTransactionError::TxTypeNotSupported.into());
+                    }
+                    if cfg.chain_id != 0 && cfg.chain_id != local_chain_id {
+                        return Err(InvalidTransactionError::ChainIdMismatch.into());
+                    }
+                    if cfg.auth.len() < 20 {
+                        return Err(InvalidTransactionError::TxTypeNotSupported.into());
+                    }
+                }
+                AccountChange::Delegation(_) => {
+                    delegation_count += 1;
+                    if delegation_count > 1 {
+                        return Err(InvalidTransactionError::TxTypeNotSupported.into());
+                    }
+                }
+            }
+        }
+        Ok(())
     }
 
     /// Performs the necessary Base-specific checks based on top of the regular eth outcome.


### PR DESCRIPTION
## Summary

PR4 of the EIP-8130 (account abstraction) rollout. Flips the devp2p transaction-pool validator from PR3's hard-reject of type-byte 0x7D to a **conservative accept** path that runs every spec-mandated structural check while still keeping all execution-time semantics (verifier dispatch, state lookups, fork gating) deferred to later PRs.

RPC ingress (ingress-rpc + execution-rpc) remains closed; local-origin submissions from devp2p are also rejected. Hardfork gating lands in PR6 against **Cobalt** (the upgrade after Beryl; `BaseUpgrade::Cobalt` doesn't exist in this repo yet and will be added by PR6).

## What changed

**Sender recovery (commit 1)** — fixes a hidden break in PR3: `BasePooledTransaction::SignerRecoverable` for the EIP-8130 variant was previously returning `tx.explicit_sender()` unconditionally, meaning EOA-path transactions (`sender = None`) could never be indexed in the pool. Adds `Eip8130Signed::recover_eoa_sender()` which:

- returns `Ok(None)` for configured-owner txs (sender already explicit)
- recovers from the 65-byte `sender_auth` against `sender_signature_hash()` for EOA txs
- returns `Err` on malformed payloads

**Mempool policy constants (commit 2)** — adds 4 `pub const` items on `Eip8130Constants`: `ECRECOVER_VERIFIER`, `REVOKED_VERIFIER`, `MAX_CONFIG_CHANGES_PER_TX = 10`, `NONCE_FREE_MAX_EXPIRY_WINDOW = 10s`.

**Structural validator (commit 3)** — extends `BasePooledTx` with a default `as_eip8130() -> Option<&Eip8130Signed>` and wires the concrete impl. The validator now enforces (before delegating to the inner Eth validator):

- chain-id binding (envelope and per-config-change)
- `max_fee_per_gas >= max_priority_fee_per_gas`
- non-zero gas limit and fee cap
- nonce-free mode: `nonce_key == NONCE_KEY_MAX` implies `nonce_sequence == 0` and `0 < expiry <= now + NONCE_FREE_MAX_EXPIRY_WINDOW`
- `sender_auth` shape: 65 bytes on EOA path, 20+ bytes with non-revoked verifier prefix on configured-owner path
- `payer_auth` presence symmetry with the `payer` field, plus revoked-verifier sentinel filtering
- `account_changes`: at most one `Create` (must be first); at most one `Delegation`; `ConfigChange` count capped at 10; per-config chain binding; per-owner verifier address >= `ECRECOVER_VERIFIER` and != `REVOKED_VERIFIER`; no duplicate `owner_id`s; non-empty `code` and `initial_owners` on `Create`.

**Tests (commit 4)** — 30 unit tests covering every reject branch plus 3 happy-path cases (minimal EOA, max-config-changes edge, mixed Create+Configs+Delegation). Tests run against the structural helpers directly via crate-internal access; no account state is required because the gate is byte-only.

**Review fixes — pool path (commit 5)** — addresses inline review feedback:
- nonce-free `expiry <= now` (already expired) now rejected; previously only `expiry == 0` and beyond-window were rejected
- `ConfigChange.owner_changes` now goes through the same verifier-floor / revoked-sentinel / duplicate-owner_id checks as `Create.initial_owners`, via a shared `validate_owner_iter` helper
- `use std::collections::BTreeSet` hoisted to file scope per workspace convention
- +3 new tests

**Review fixes — unchecked recovery contract on the pool path (commit 6)** — `BasePooledTransaction::SignerRecoverable::recover_signer_unchecked` and `recover_unchecked_with_buf` were silently routing through the checked recovery path for EIP-8130, tightening the contract to apply EIP-2 low-s filtering despite the trait promising not to. Added `Eip8130Signed::recover_eoa_sender_unchecked` (sharing parsing + configured-owner short-circuit with the checked variant via a private `recover_eoa_sender_with` closure), `recover_eip8130_sender_unchecked` helper in `pooled.rs`, and wired into both unchecked dispatcher arms. Added a high-s parity test (`s' = N - s, v' = !v`) asserting checked rejects + unchecked accepts.

**Review fixes — same shape on `BaseTxEnvelope` (commit 7)** — `BaseTxEnvelope::SignerRecoverable` (block-import / state-transition path) had the same broken EOA shape: short-circuited to `explicit_sender()` and returned `RecoveryError` for EOA-path txs. Before this PR the path was unreachable, but accepting EOA-path 8130 txs into the pool means they can reach builders → blocks → peer import, where the broken recovery would cause peers to reject the block. Added `recover_eip8130_envelope_sender` / `_unchecked` free functions and wired them through all three `SignerRecoverable` arms, plus envelope-level parity tests (high-s + configured-owner short-circuit).

## Verification

- `cargo check --workspace --all-features --exclude devnet` clean
- `cargo clippy -p base-common-consensus -p base-execution-txpool -p base-execution-rpc -p ingress-rpc-lib --all-features --all-targets -- -D warnings` clean
- `cargo +nightly fmt --all -- --check` clean
- `cargo test -p base-common-consensus -p base-execution-txpool --all-features --lib` all pass
- `cargo deny check bans` ok

## What is NOT in this PR (intentionally deferred)

- RPC ingress acceptance (PR15)
- **Cobalt** hardfork activation gating (PR6 — `BaseUpgrade::Cobalt` doesn't exist in `crates/common/chains/src/upgrade.rs` yet and will be added by that PR)
- Verifier address dispatch / on-chain account configuration lookups
- AA execution semantics (validation phase, call phases, payer settlement)
- Richer error variant taxonomy for AA-specific rejections (currently all map to `TxTypeNotSupported`; agreed with reviewer that this is worth doing but plumbing it through `InvalidPoolTransactionError` and `pool_error_label.rs` is its own change)

## Reviewer notes

The `BasePooledTx::as_eip8130` default returns `None` so any future concrete pooled-tx type that does not surface EIP-8130 will silently skip the structural gate. This is intentional today — the only concrete type that carries EIP-8130 is `BasePooledTransaction<BaseTransactionSigned, _>` which routes through `BaseTxEnvelope::as_eip8130`. If we add another envelope type, we will need to revisit.

cc @chunter-cb