### PR TITLE
test(beryl): add devnet E2E and factory action tests for security and stablecoin variants

### DIFF
--- a/actions/harness/tests/beryl/factory.rs
+++ b/actions/harness/tests/beryl/factory.rs
@@ -4,9 +4,14 @@ use alloy_consensus::TxReceipt;
 use alloy_primitives::{Address, Bytes, TxKind, U256};
 use alloy_sol_types::{SolCall, SolEvent};
 use base_common_consensus::BaseBlock;
-use base_common_precompiles::{B20FactoryStorage, IB20Factory};
+use base_common_precompiles::{B20FactoryStorage, IB20, IB20Factory, IB20Security, IB20Stablecoin};
 
-use crate::env::BerylTestEnv;
+use crate::{
+    env::BerylTestEnv,
+    test_helpers::{self, StaticcallCase},
+};
+
+const WAD: U256 = U256::from_limbs([1_000_000_000_000_000_000, 0, 0, 0]);
 
 #[tokio::test]
 async fn beryl_enables_b20_factory_precompile() {
@@ -287,4 +292,179 @@ fn word_from_address(address: Address) -> U256 {
     let mut word = [0u8; 32];
     word[12..].copy_from_slice(address.as_slice());
     U256::from_be_slice(&word)
+}
+
+#[tokio::test]
+async fn b20_factory_creates_security_variant_and_initializes_state() {
+    let mut env = BerylTestEnv::new();
+    let token = env.b20_security_address();
+    let mut blocks: Vec<(BaseBlock, u64)> = Vec::new();
+
+    test_helpers::build_block_with_transactions(&mut env, &mut blocks, Vec::new()).await;
+
+    let activate_factory = env.activate_feature_tx(BerylTestEnv::b20_factory_feature());
+    let activate_security = env.activate_feature_tx(BerylTestEnv::b20_security_feature());
+    let activate_policy = env.activate_feature_tx(BerylTestEnv::policy_registry_feature());
+    let block2 = test_helpers::build_block_with_transactions(
+        &mut env,
+        &mut blocks,
+        vec![activate_factory, activate_security, activate_policy],
+    )
+    .await;
+
+    assert!(env.user_tx_succeeded(&block2, 0), "TOKEN_FACTORY activation must succeed");
+    assert!(env.user_tx_succeeded(&block2, 1), "B20_SECURITY activation must succeed");
+    assert!(env.user_tx_succeeded(&block2, 2), "POLICY_REGISTRY activation must succeed");
+
+    let create = env.create_b20_security_tx();
+    let block3 =
+        test_helpers::build_block_with_transactions(&mut env, &mut blocks, vec![create]).await;
+
+    assert!(env.user_tx_succeeded(&block3, 0), "security B-20 creation must succeed");
+    assert!(env.sequencer.has_code(token), "security B-20 code must be deployed");
+    assert_eq!(
+        env.b20_total_supply(token),
+        U256::from(BerylTestEnv::B20_INITIAL_SUPPLY),
+        "security B-20 total supply must be initialized",
+    );
+
+    test_helpers::assert_staticcall_cases(
+        &mut env,
+        &mut blocks,
+        B20FactoryStorage::ADDRESS,
+        vec![
+            StaticcallCase::word(
+                "isB20(security)",
+                IB20Factory::isB20Call { token }.abi_encode(),
+                U256::ONE,
+            ),
+            StaticcallCase::word(
+                "isB20Initialized(security)",
+                IB20Factory::isB20InitializedCall { token }.abi_encode(),
+                U256::ONE,
+            ),
+        ],
+        "security factory",
+    )
+    .await;
+
+    test_helpers::assert_staticcall_cases(
+        &mut env,
+        &mut blocks,
+        token,
+        vec![
+            StaticcallCase::word(
+                "sharesToTokensRatio",
+                IB20Security::sharesToTokensRatioCall {}.abi_encode(),
+                WAD,
+            ),
+            StaticcallCase::word(
+                "minimumRedeemable",
+                IB20Security::minimumRedeemableCall {}.abi_encode(),
+                U256::from(BerylTestEnv::B20_SECURITY_MINIMUM_REDEEMABLE),
+            ),
+            StaticcallCase::string(
+                "securityIdentifier(ISIN)",
+                IB20Security::securityIdentifierCall { identifierType: "ISIN".to_string() }
+                    .abi_encode(),
+                BerylTestEnv::B20_SECURITY_ISIN,
+            ),
+            StaticcallCase::word(
+                "decimals",
+                IB20::decimalsCall {}.abi_encode(),
+                U256::from(BerylTestEnv::B20_SECURITY_DECIMALS),
+            ),
+        ],
+        "security token",
+    )
+    .await;
+
+    let expected_safe_head = blocks.len() as u64;
+    env.derive_blocks(blocks, expected_safe_head).await;
+}
+
+#[tokio::test]
+async fn b20_factory_creates_stablecoin_variant_and_initializes_state() {
+    let mut env = BerylTestEnv::new();
+    let token = env.b20_stablecoin_address();
+    let mut blocks: Vec<(BaseBlock, u64)> = Vec::new();
+
+    test_helpers::build_block_with_transactions(&mut env, &mut blocks, Vec::new()).await;
+
+    let activate_factory = env.activate_feature_tx(BerylTestEnv::b20_factory_feature());
+    let activate_stablecoin = env.activate_feature_tx(BerylTestEnv::b20_stablecoin_feature());
+    let block2 = test_helpers::build_block_with_transactions(
+        &mut env,
+        &mut blocks,
+        vec![activate_factory, activate_stablecoin],
+    )
+    .await;
+
+    assert!(env.user_tx_succeeded(&block2, 0), "TOKEN_FACTORY activation must succeed");
+    assert!(env.user_tx_succeeded(&block2, 1), "B20_STABLECOIN activation must succeed");
+
+    let create = env.create_b20_stablecoin_tx();
+    let block3 =
+        test_helpers::build_block_with_transactions(&mut env, &mut blocks, vec![create]).await;
+
+    assert!(env.user_tx_succeeded(&block3, 0), "stablecoin creation must succeed");
+    assert!(env.sequencer.has_code(token), "stablecoin code must be deployed");
+    assert_eq!(
+        env.b20_total_supply(token),
+        U256::from(BerylTestEnv::B20_INITIAL_SUPPLY),
+        "stablecoin total supply must be initialized",
+    );
+
+    test_helpers::assert_staticcall_cases(
+        &mut env,
+        &mut blocks,
+        B20FactoryStorage::ADDRESS,
+        vec![
+            StaticcallCase::word(
+                "isB20(stablecoin)",
+                IB20Factory::isB20Call { token }.abi_encode(),
+                U256::ONE,
+            ),
+            StaticcallCase::word(
+                "isB20Initialized(stablecoin)",
+                IB20Factory::isB20InitializedCall { token }.abi_encode(),
+                U256::ONE,
+            ),
+        ],
+        "stablecoin factory",
+    )
+    .await;
+
+    test_helpers::assert_staticcall_cases(
+        &mut env,
+        &mut blocks,
+        token,
+        vec![
+            StaticcallCase::string(
+                "currency",
+                IB20Stablecoin::currencyCall {}.abi_encode(),
+                BerylTestEnv::B20_STABLECOIN_CURRENCY,
+            ),
+            StaticcallCase::word(
+                "decimals",
+                IB20::decimalsCall {}.abi_encode(),
+                U256::from(BerylTestEnv::B20_STABLECOIN_DECIMALS),
+            ),
+            StaticcallCase::string(
+                "name",
+                IB20::nameCall {}.abi_encode(),
+                BerylTestEnv::B20_STABLECOIN_NAME,
+            ),
+            StaticcallCase::string(
+                "symbol",
+                IB20::symbolCall {}.abi_encode(),
+                BerylTestEnv::B20_STABLECOIN_SYMBOL,
+            ),
+        ],
+        "stablecoin token",
+    )
+    .await;
+
+    let expected_safe_head = blocks.len() as u64;
+    env.derive_blocks(blocks, expected_safe_head).await;
 }

--- a/devnet/src/b20.rs
+++ b/devnet/src/b20.rs
@@ -14,7 +14,7 @@ use alloy_sol_types::{SolCall, SolValue};
 use base_common_network::Base;
 use base_common_precompiles::{
     ActivationRegistryStorage, B20FactoryStorage, B20PausableFeature, B20Variant,
-    IActivationRegistry, IB20, IB20Factory,
+    IActivationRegistry, IB20, IB20Factory, IB20Security, IB20Stablecoin,
 };
 use base_common_rpc_types::{BaseTransactionReceipt, BaseTransactionRequest};
 use eyre::{ContextCompat, Result, WrapErr, ensure};
@@ -33,6 +33,32 @@ pub struct B20CreateConfig {
     pub supply_cap: U256,
     /// Initial ERC-7572 contract URI.
     pub contract_uri: String,
+}
+
+/// Creation settings used by the devnet security-variant factory client.
+#[derive(Debug, Clone)]
+pub struct B20SecurityCreateConfig {
+    /// ABI-level creation params sent to `IB20Factory.createB20` for the security variant.
+    pub create: IB20Factory::B20SecurityCreateParams,
+    /// Initial supply to mint during the factory init-call window.
+    pub initial_supply: U256,
+    /// Account receiving the initial supply.
+    pub initial_supply_recipient: Address,
+    /// Initial supply cap to configure during the factory init-call window.
+    pub supply_cap: U256,
+}
+
+/// Creation settings used by the devnet stablecoin-variant factory client.
+#[derive(Debug, Clone)]
+pub struct B20StablecoinCreateConfig {
+    /// ABI-level creation params sent to `IB20Factory.createB20` for the stablecoin variant.
+    pub create: IB20Factory::B20StablecoinCreateParams,
+    /// Initial supply to mint during the factory init-call window.
+    pub initial_supply: U256,
+    /// Account receiving the initial supply.
+    pub initial_supply_recipient: Address,
+    /// Initial supply cap to configure during the factory init-call window.
+    pub supply_cap: U256,
 }
 
 /// RPC client for the B-20 token factory and created token precompiles.
@@ -421,6 +447,236 @@ impl<'a> B20PrecompileClient<'a> {
             .await?;
         IB20Factory::getB20AddressCall::abi_decode_returns(output.as_ref())
             .wrap_err("Failed to decode getB20Address")
+    }
+
+    /// Builds the required security B-20 token params for factory creation.
+    pub fn security_token_params(
+        name: &str,
+        symbol: &str,
+        initial_admin: Address,
+        isin: &str,
+        minimum_redeemable: U256,
+        initial_supply: U256,
+        initial_supply_recipient: Address,
+    ) -> B20SecurityCreateConfig {
+        B20SecurityCreateConfig {
+            create: IB20Factory::B20SecurityCreateParams {
+                version: B20FactoryStorage::CREATE_TOKEN_VERSION,
+                name: name.to_string(),
+                symbol: symbol.to_string(),
+                initialAdmin: initial_admin,
+                isin: isin.to_string(),
+                minimumRedeemable: minimum_redeemable,
+            },
+            initial_supply,
+            initial_supply_recipient,
+            supply_cap: U256::MAX,
+        }
+    }
+
+    /// Builds the required stablecoin B-20 token params for factory creation.
+    pub fn stablecoin_token_params(
+        name: &str,
+        symbol: &str,
+        initial_admin: Address,
+        currency: &str,
+        initial_supply: U256,
+        initial_supply_recipient: Address,
+    ) -> B20StablecoinCreateConfig {
+        B20StablecoinCreateConfig {
+            create: IB20Factory::B20StablecoinCreateParams {
+                version: B20FactoryStorage::CREATE_TOKEN_VERSION,
+                name: name.to_string(),
+                symbol: symbol.to_string(),
+                initialAdmin: initial_admin,
+                currency: currency.to_string(),
+            },
+            initial_supply,
+            initial_supply_recipient,
+            supply_cap: U256::MAX,
+        }
+    }
+
+    /// Creates a security B-20 token through the factory and returns the deterministic address.
+    pub async fn create_security_token(
+        &self,
+        params: B20SecurityCreateConfig,
+        salt: B256,
+    ) -> Result<Address> {
+        let token = self.predict_token_address(B20Variant::Security, salt);
+        let mut init_calls = Vec::new();
+        if params.initial_supply > U256::ZERO {
+            init_calls.push(
+                IB20::mintCall {
+                    to: params.initial_supply_recipient,
+                    amount: params.initial_supply,
+                }
+                .abi_encode()
+                .into(),
+            );
+        }
+        if params.supply_cap != U256::MAX {
+            init_calls.push(
+                IB20::updateSupplyCapCall { newSupplyCap: params.supply_cap }.abi_encode().into(),
+            );
+        }
+        let call = IB20Factory::createB20Call {
+            variant: B20Variant::Security.abi(),
+            salt,
+            params: params.create.abi_encode().into(),
+            initCalls: init_calls,
+        };
+        self.send_call(B20FactoryStorage::ADDRESS, call, "create security B-20 token").await?;
+        Ok(token)
+    }
+
+    /// Creates a stablecoin B-20 token through the factory and returns the deterministic address.
+    pub async fn create_stablecoin_token(
+        &self,
+        params: B20StablecoinCreateConfig,
+        salt: B256,
+    ) -> Result<Address> {
+        let token = self.predict_token_address(B20Variant::Stablecoin, salt);
+        let mut init_calls = Vec::new();
+        if params.initial_supply > U256::ZERO {
+            init_calls.push(
+                IB20::mintCall {
+                    to: params.initial_supply_recipient,
+                    amount: params.initial_supply,
+                }
+                .abi_encode()
+                .into(),
+            );
+        }
+        if params.supply_cap != U256::MAX {
+            init_calls.push(
+                IB20::updateSupplyCapCall { newSupplyCap: params.supply_cap }.abi_encode().into(),
+            );
+        }
+        let call = IB20Factory::createB20Call {
+            variant: B20Variant::Stablecoin.abi(),
+            salt,
+            params: params.create.abi_encode().into(),
+            initCalls: init_calls,
+        };
+        self.send_call(B20FactoryStorage::ADDRESS, call, "create stablecoin B-20 token").await?;
+        Ok(token)
+    }
+
+    /// Returns true if `token` has been initialized by the factory.
+    pub async fn is_b20_initialized(&self, token: Address) -> Result<bool> {
+        let output = self
+            .call(B20FactoryStorage::ADDRESS, IB20Factory::isB20InitializedCall { token })
+            .await?;
+        IB20Factory::isB20InitializedCall::abi_decode_returns(output.as_ref())
+            .wrap_err("Failed to decode isB20Initialized")
+    }
+
+    /// Reads the current shares-to-tokens ratio for a security token.
+    pub async fn shares_to_tokens_ratio(&self, token: Address) -> Result<U256> {
+        let output = self.call(token, IB20Security::sharesToTokensRatioCall {}).await?;
+        IB20Security::sharesToTokensRatioCall::abi_decode_returns(output.as_ref())
+            .wrap_err("Failed to decode sharesToTokensRatio")
+    }
+
+    /// Reads the minimum redeemable threshold (in shares) for a security token.
+    pub async fn minimum_redeemable(&self, token: Address) -> Result<U256> {
+        let output = self.call(token, IB20Security::minimumRedeemableCall {}).await?;
+        IB20Security::minimumRedeemableCall::abi_decode_returns(output.as_ref())
+            .wrap_err("Failed to decode minimumRedeemable")
+    }
+
+    /// Reads a named security identifier (e.g. "ISIN", "CUSIP") from a security token.
+    pub async fn security_identifier(
+        &self,
+        token: Address,
+        identifier_type: &str,
+    ) -> Result<String> {
+        let output = self
+            .call(
+                token,
+                IB20Security::securityIdentifierCall {
+                    identifierType: identifier_type.to_string(),
+                },
+            )
+            .await?;
+        IB20Security::securityIdentifierCall::abi_decode_returns(output.as_ref())
+            .wrap_err("Failed to decode securityIdentifier")
+    }
+
+    /// Converts a token balance to shares using the current ratio.
+    pub async fn to_shares(&self, token: Address, balance: U256) -> Result<U256> {
+        let output = self.call(token, IB20Security::toSharesCall { balance }).await?;
+        IB20Security::toSharesCall::abi_decode_returns(output.as_ref())
+            .wrap_err("Failed to decode toShares")
+    }
+
+    /// Batch-mints to multiple recipients. Requires `MINT_ROLE`.
+    pub async fn batch_mint(
+        &self,
+        token: Address,
+        recipients: Vec<Address>,
+        amounts: Vec<U256>,
+    ) -> Result<()> {
+        self.send_call(
+            token,
+            IB20Security::batchMintCall { recipients, amounts },
+            "batchMint security B-20 token",
+        )
+        .await?;
+        Ok(())
+    }
+
+    /// Batch-burns from multiple accounts. Requires `BURN_FROM_ROLE`.
+    pub async fn batch_burn(
+        &self,
+        token: Address,
+        accounts: Vec<Address>,
+        amounts: Vec<U256>,
+    ) -> Result<()> {
+        self.send_call(
+            token,
+            IB20Security::batchBurnCall { accounts, amounts },
+            "batchBurn security B-20 token",
+        )
+        .await?;
+        Ok(())
+    }
+
+    /// Redeems (burns) `amount` from the signer with a share-based floor check.
+    pub async fn redeem(&self, token: Address, amount: U256) -> Result<()> {
+        self.send_call(token, IB20Security::redeemCall { amount }, "redeem security B-20 token")
+            .await?;
+        Ok(())
+    }
+
+    /// Updates the minimum redeemable threshold (in shares). Requires `DEFAULT_ADMIN_ROLE`.
+    pub async fn update_minimum_redeemable(&self, token: Address, new_minimum: U256) -> Result<()> {
+        self.send_call(
+            token,
+            IB20Security::updateMinimumRedeemableCall { newMinimumRedeemable: new_minimum },
+            "updateMinimumRedeemable security B-20 token",
+        )
+        .await?;
+        Ok(())
+    }
+
+    /// Updates the shares-to-tokens ratio. Requires `SECURITY_OPERATOR_ROLE`.
+    pub async fn update_share_ratio(&self, token: Address, new_ratio: U256) -> Result<()> {
+        self.send_call(
+            token,
+            IB20Security::updateShareRatioCall { newSharesToTokensRatio: new_ratio },
+            "updateShareRatio security B-20 token",
+        )
+        .await?;
+        Ok(())
+    }
+
+    /// Reads the ISO 4217 currency code from a stablecoin B-20 token.
+    pub async fn currency(&self, token: Address) -> Result<String> {
+        let output = self.call(token, IB20Stablecoin::currencyCall {}).await?;
+        IB20Stablecoin::currencyCall::abi_decode_returns(output.as_ref())
+            .wrap_err("Failed to decode currency")
     }
 
     /// Sends a transaction and returns `true` if it succeeded, `false` if it reverted.

--- a/devnet/src/lib.rs
+++ b/devnet/src/lib.rs
@@ -11,7 +11,9 @@ mod utils;
 pub use utils::unique_name;
 
 mod b20;
-pub use b20::{B20CreateConfig, B20PrecompileClient};
+pub use b20::{
+    B20CreateConfig, B20PrecompileClient, B20SecurityCreateConfig, B20StablecoinCreateConfig,
+};
 
 pub mod config;
 pub mod containers;

--- a/devnet/tests/security_token.rs
+++ b/devnet/tests/security_token.rs
@@ -1,0 +1,289 @@
+//! End-to-end tests for the security B-20 variant over Base node RPC.
+
+mod common;
+
+use alloy_primitives::{B256, U256};
+use alloy_provider::RootProvider;
+use alloy_signer_local::PrivateKeySigner;
+use base_common_network::Base;
+use base_common_precompiles::{
+    ActivationFeature, B20SecurityToken, B20TokenRole, B20Variant, IB20, IB20Security,
+    InMemoryPolicy, InMemoryTokenAccounting,
+};
+use devnet::{
+    B20PrecompileClient,
+    config::{ANVIL_ACCOUNT_5, ANVIL_ACCOUNT_6, ANVIL_ACCOUNT_7},
+};
+use eyre::{Result, WrapErr};
+
+/// Concrete instantiation used only to access compile-time role constants on the generic type.
+type B20SecurityConsts = B20SecurityToken<InMemoryTokenAccounting, InMemoryPolicy>;
+
+const INITIAL_SUPPLY: u64 = 1_000_000;
+const SECURITY_ISIN: &str = "US0231351067";
+const BATCH_MINT_BOB: u64 = 300;
+const BATCH_MINT_CAROL: u64 = 500;
+const BATCH_BURN_BOB: u64 = 100;
+const BATCH_BURN_CAROL: u64 = 200;
+const REDEEM_MINIMUM: u64 = 20;
+const REDEEM_BELOW: u64 = 19;
+const REDEEM_AT_MINIMUM: u64 = 20;
+
+/// WAD precision for share ratio arithmetic: 1e18.
+const WAD: U256 = U256::from_limbs([1_000_000_000_000_000_000, 0, 0, 0]);
+
+/// Two times WAD, used in share ratio update tests.
+const TWO_WAD: U256 = U256::from_limbs([2_000_000_000_000_000_000, 0, 0, 0]);
+
+async fn activated_security_client<'a>(
+    provider: &'a RootProvider<Base>,
+    admin: &'a PrivateKeySigner,
+) -> Result<B20PrecompileClient<'a>> {
+    let b20 = B20PrecompileClient::new(provider, admin, common::L2_CHAIN_ID)
+        .with_receipt_timeout(common::TX_RECEIPT_TIMEOUT);
+    b20.activate_feature(ActivationFeature::B20Factory.id()).await?;
+    b20.activate_feature(ActivationFeature::B20Security.id()).await?;
+    b20.activate_feature(ActivationFeature::PolicyRegistry.id()).await?;
+    Ok(b20)
+}
+
+#[tokio::test]
+async fn test_b20_security_factory_create_and_views() -> Result<()> {
+    let (_devnet, provider) = common::start_beryl_devnet().await?;
+    let admin = PrivateKeySigner::from_bytes(&ANVIL_ACCOUNT_5.private_key)
+        .wrap_err("Failed to parse admin key")?;
+
+    common::wait_for_balance(&provider, admin.address()).await?;
+
+    let b20 = activated_security_client(&provider, &admin).await?;
+    let salt = B256::repeat_byte(0x50);
+    let params = B20PrecompileClient::security_token_params(
+        "Security Token",
+        "STOK",
+        admin.address(),
+        SECURITY_ISIN,
+        U256::ZERO,
+        U256::from(INITIAL_SUPPLY),
+        admin.address(),
+    );
+
+    let token = b20.create_security_token(params, salt).await?;
+    b20.wait_for_token_code(token, common::TX_RECEIPT_TIMEOUT, common::BLOCK_POLL_INTERVAL).await?;
+
+    assert!(b20.is_b20(token).await?, "security token must be recognised as B-20");
+    assert!(b20.is_b20_initialized(token).await?, "security token must be initialized");
+    assert_eq!(
+        b20.shares_to_tokens_ratio(token).await?,
+        WAD,
+        "initial sharesToTokensRatio must be WAD",
+    );
+    assert_eq!(
+        b20.minimum_redeemable(token).await?,
+        U256::ZERO,
+        "initial minimumRedeemable must be zero",
+    );
+    assert_eq!(
+        b20.security_identifier(token, "ISIN").await?,
+        SECURITY_ISIN,
+        "ISIN must match creation params",
+    );
+    assert_eq!(
+        b20.balance_of(token, admin.address()).await?,
+        U256::from(INITIAL_SUPPLY),
+        "admin must hold the full initial supply",
+    );
+    assert_eq!(
+        b20.to_shares(token, U256::from(100u64)).await?,
+        U256::from(100u64),
+        "toShares at 1:1 ratio must equal the balance",
+    );
+    assert_eq!(
+        b20.variant_of(token).await?,
+        B20Variant::Security,
+        "token variant must be Security"
+    );
+    assert_eq!(b20.decimals_of(token).await?, 6, "security token decimals must be 6");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_b20_security_batch_mint_and_burn() -> Result<()> {
+    let (_devnet, provider) = common::start_beryl_devnet().await?;
+    let admin = PrivateKeySigner::from_bytes(&ANVIL_ACCOUNT_5.private_key)
+        .wrap_err("Failed to parse admin key")?;
+    let bob = ANVIL_ACCOUNT_6.address;
+    let carol = ANVIL_ACCOUNT_7.address;
+
+    common::wait_for_balance(&provider, admin.address()).await?;
+
+    let b20 = activated_security_client(&provider, &admin).await?;
+    let salt = B256::repeat_byte(0x51);
+    let params = B20PrecompileClient::security_token_params(
+        "Batch Token",
+        "BTCH",
+        admin.address(),
+        SECURITY_ISIN,
+        U256::ZERO,
+        U256::from(INITIAL_SUPPLY),
+        admin.address(),
+    );
+
+    let token = b20.create_security_token(params, salt).await?;
+    b20.wait_for_token_code(token, common::TX_RECEIPT_TIMEOUT, common::BLOCK_POLL_INTERVAL).await?;
+
+    let mint_role = B20TokenRole::Mint.id();
+    let burn_from_role = B20SecurityConsts::BURN_FROM_ROLE;
+
+    b20.send_call(
+        token,
+        IB20::grantRoleCall { role: mint_role, account: admin.address() },
+        "grant MINT_ROLE",
+    )
+    .await?;
+    b20.send_call(
+        token,
+        IB20::grantRoleCall { role: burn_from_role, account: admin.address() },
+        "grant BURN_FROM_ROLE",
+    )
+    .await?;
+
+    b20.batch_mint(
+        token,
+        vec![bob, carol],
+        vec![U256::from(BATCH_MINT_BOB), U256::from(BATCH_MINT_CAROL)],
+    )
+    .await?;
+
+    assert_eq!(
+        b20.balance_of(token, bob).await?,
+        U256::from(BATCH_MINT_BOB),
+        "Bob must receive the minted amount",
+    );
+    assert_eq!(
+        b20.balance_of(token, carol).await?,
+        U256::from(BATCH_MINT_CAROL),
+        "Carol must receive the minted amount",
+    );
+    assert_eq!(
+        b20.total_supply(token).await?,
+        U256::from(INITIAL_SUPPLY) + U256::from(BATCH_MINT_BOB) + U256::from(BATCH_MINT_CAROL),
+        "total supply must reflect batch mint",
+    );
+
+    b20.batch_burn(
+        token,
+        vec![bob, carol],
+        vec![U256::from(BATCH_BURN_BOB), U256::from(BATCH_BURN_CAROL)],
+    )
+    .await?;
+
+    assert_eq!(
+        b20.balance_of(token, bob).await?,
+        U256::from(BATCH_MINT_BOB - BATCH_BURN_BOB),
+        "Bob balance must decrease after batch burn",
+    );
+    assert_eq!(
+        b20.balance_of(token, carol).await?,
+        U256::from(BATCH_MINT_CAROL - BATCH_BURN_CAROL),
+        "Carol balance must decrease after batch burn",
+    );
+    assert_eq!(
+        b20.total_supply(token).await?,
+        U256::from(INITIAL_SUPPLY)
+            + U256::from(BATCH_MINT_BOB - BATCH_BURN_BOB)
+            + U256::from(BATCH_MINT_CAROL - BATCH_BURN_CAROL),
+        "total supply must reflect batch burn",
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_b20_security_redeem_and_share_ratio() -> Result<()> {
+    let (_devnet, provider) = common::start_beryl_devnet().await?;
+    let admin = PrivateKeySigner::from_bytes(&ANVIL_ACCOUNT_5.private_key)
+        .wrap_err("Failed to parse admin key")?;
+
+    common::wait_for_balance(&provider, admin.address()).await?;
+
+    let b20 = activated_security_client(&provider, &admin).await?;
+    let salt = B256::repeat_byte(0x52);
+    let params = B20PrecompileClient::security_token_params(
+        "Redeem Token",
+        "RDMT",
+        admin.address(),
+        SECURITY_ISIN,
+        U256::ZERO,
+        U256::from(INITIAL_SUPPLY),
+        admin.address(),
+    );
+
+    let token = b20.create_security_token(params, salt).await?;
+    b20.wait_for_token_code(token, common::TX_RECEIPT_TIMEOUT, common::BLOCK_POLL_INTERVAL).await?;
+
+    let supply_before = b20.total_supply(token).await?;
+    assert_eq!(supply_before, U256::from(INITIAL_SUPPLY));
+
+    // Admin has DEFAULT_ADMIN_ROLE and can set the minimum redeemable threshold.
+    b20.update_minimum_redeemable(token, U256::from(REDEEM_MINIMUM)).await?;
+    assert_eq!(
+        b20.minimum_redeemable(token).await?,
+        U256::from(REDEEM_MINIMUM),
+        "minimumRedeemable must update to the new value",
+    );
+
+    // Redeem below the minimum must revert (19 shares < 20).
+    let below_minimum_succeeded = b20
+        .try_send_call(
+            token,
+            IB20Security::redeemCall { amount: U256::from(REDEEM_BELOW) },
+            "redeem below minimum",
+        )
+        .await?;
+    assert!(!below_minimum_succeeded, "redeem below minimum must revert");
+    assert_eq!(
+        b20.total_supply(token).await?,
+        supply_before,
+        "supply must not change on failed redeem"
+    );
+
+    // Redeem at the minimum must succeed (20 shares == 20 at 1:1 ratio).
+    b20.redeem(token, U256::from(REDEEM_AT_MINIMUM)).await?;
+    assert_eq!(
+        b20.total_supply(token).await?,
+        supply_before - U256::from(REDEEM_AT_MINIMUM),
+        "total supply must decrease after successful redeem",
+    );
+    assert_eq!(
+        b20.balance_of(token, admin.address()).await?,
+        U256::from(INITIAL_SUPPLY) - U256::from(REDEEM_AT_MINIMUM),
+        "admin balance must decrease after redeem",
+    );
+
+    // Grant SECURITY_OPERATOR_ROLE so admin can update the share ratio.
+    let security_operator_role = B20SecurityConsts::SECURITY_OPERATOR_ROLE;
+    b20.send_call(
+        token,
+        IB20::grantRoleCall { role: security_operator_role, account: admin.address() },
+        "grant SECURITY_OPERATOR_ROLE",
+    )
+    .await?;
+
+    // Update to a 2:1 ratio (2 shares per token).
+    b20.update_share_ratio(token, TWO_WAD).await?;
+    assert_eq!(
+        b20.shares_to_tokens_ratio(token).await?,
+        TWO_WAD,
+        "sharesToTokensRatio must update to TWO_WAD",
+    );
+
+    // At 2:1 ratio, 50 tokens = 100 shares.
+    assert_eq!(
+        b20.to_shares(token, U256::from(50u64)).await?,
+        U256::from(100u64),
+        "toShares must reflect the new ratio",
+    );
+
+    Ok(())
+}

--- a/devnet/tests/stablecoin.rs
+++ b/devnet/tests/stablecoin.rs
@@ -1,0 +1,250 @@
+//! End-to-end tests for the stablecoin B-20 variant over Base node RPC.
+
+mod common;
+
+use alloy_primitives::{B256, U256};
+use alloy_provider::RootProvider;
+use alloy_signer_local::PrivateKeySigner;
+use base_common_network::Base;
+use base_common_precompiles::{ActivationFeature, B20TokenRole, B20Variant, IB20};
+use devnet::{
+    B20PrecompileClient,
+    config::{ANVIL_ACCOUNT_5, ANVIL_ACCOUNT_6},
+};
+use eyre::{Result, WrapErr};
+
+const INITIAL_SUPPLY: u64 = 1_000_000;
+const STABLECOIN_CURRENCY: &str = "USD";
+const SUPPLY_CAP: u64 = 1_000_000;
+const RAISED_SUPPLY_CAP: u64 = 2_000_000;
+const PAUSE_TRANSFER_AMOUNT: u64 = 10_000;
+
+async fn activated_stablecoin_client<'a>(
+    provider: &'a RootProvider<Base>,
+    admin: &'a PrivateKeySigner,
+) -> Result<B20PrecompileClient<'a>> {
+    let b20 = B20PrecompileClient::new(provider, admin, common::L2_CHAIN_ID)
+        .with_receipt_timeout(common::TX_RECEIPT_TIMEOUT);
+    b20.activate_feature(ActivationFeature::B20Factory.id()).await?;
+    b20.activate_feature(ActivationFeature::B20Stablecoin.id()).await?;
+    Ok(b20)
+}
+
+#[tokio::test]
+async fn test_b20_stablecoin_factory_create_and_views() -> Result<()> {
+    let (_devnet, provider) = common::start_beryl_devnet().await?;
+    let admin = PrivateKeySigner::from_bytes(&ANVIL_ACCOUNT_5.private_key)
+        .wrap_err("Failed to parse admin key")?;
+
+    common::wait_for_balance(&provider, admin.address()).await?;
+
+    let b20 = activated_stablecoin_client(&provider, &admin).await?;
+    let salt = B256::repeat_byte(0x60);
+    let params = B20PrecompileClient::stablecoin_token_params(
+        "USD Stablecoin",
+        "USDS",
+        admin.address(),
+        STABLECOIN_CURRENCY,
+        U256::from(INITIAL_SUPPLY),
+        admin.address(),
+    );
+
+    let token = b20.create_stablecoin_token(params, salt).await?;
+    b20.wait_for_token_code(token, common::TX_RECEIPT_TIMEOUT, common::BLOCK_POLL_INTERVAL).await?;
+
+    assert!(b20.is_b20(token).await?, "stablecoin must be recognised as B-20");
+    assert!(b20.is_b20_initialized(token).await?, "stablecoin must be initialized");
+    assert_eq!(
+        b20.currency(token).await?,
+        STABLECOIN_CURRENCY,
+        "currency must match creation params",
+    );
+    assert_eq!(b20.name(token).await?, "USD Stablecoin", "name must match creation params");
+    assert_eq!(b20.symbol(token).await?, "USDS", "symbol must match creation params");
+    assert_eq!(
+        b20.variant_of(token).await?,
+        B20Variant::Stablecoin,
+        "token variant must be Stablecoin",
+    );
+    assert_eq!(b20.decimals_of(token).await?, 6, "stablecoin decimals must be 6");
+    assert_eq!(
+        b20.total_supply(token).await?,
+        U256::from(INITIAL_SUPPLY),
+        "total supply must equal the initial mint",
+    );
+    assert_eq!(
+        b20.balance_of(token, admin.address()).await?,
+        U256::from(INITIAL_SUPPLY),
+        "admin must hold the full initial supply",
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_b20_stablecoin_supply_cap_enforcement() -> Result<()> {
+    let (_devnet, provider) = common::start_beryl_devnet().await?;
+    let admin = PrivateKeySigner::from_bytes(&ANVIL_ACCOUNT_5.private_key)
+        .wrap_err("Failed to parse admin key")?;
+
+    common::wait_for_balance(&provider, admin.address()).await?;
+
+    let b20 = activated_stablecoin_client(&provider, &admin).await?;
+    let salt = B256::repeat_byte(0x61);
+    let mut params = B20PrecompileClient::stablecoin_token_params(
+        "Capped USD",
+        "CUSD",
+        admin.address(),
+        STABLECOIN_CURRENCY,
+        U256::from(INITIAL_SUPPLY),
+        admin.address(),
+    );
+    // Set the supply cap equal to the initial mint so the token starts at capacity.
+    params.supply_cap = U256::from(SUPPLY_CAP);
+
+    let token = b20.create_stablecoin_token(params, salt).await?;
+    b20.wait_for_token_code(token, common::TX_RECEIPT_TIMEOUT, common::BLOCK_POLL_INTERVAL).await?;
+
+    assert_eq!(
+        b20.supply_cap(token).await?,
+        U256::from(SUPPLY_CAP),
+        "supply cap must match creation params",
+    );
+    assert_eq!(
+        b20.currency(token).await?,
+        STABLECOIN_CURRENCY,
+        "currency must remain accessible throughout the test",
+    );
+
+    // Grant MINT_ROLE so admin can attempt additional mints.
+    b20.send_call(
+        token,
+        IB20::grantRoleCall { role: B20TokenRole::Mint.id(), account: admin.address() },
+        "grant MINT_ROLE",
+    )
+    .await?;
+
+    // Minting past the cap must revert.
+    let mint_past_cap_succeeded = b20
+        .try_send_call(
+            token,
+            IB20::mintCall { to: admin.address(), amount: U256::from(1u64) },
+            "mint past supply cap",
+        )
+        .await?;
+    assert!(!mint_past_cap_succeeded, "mint past supply cap must revert");
+    assert_eq!(
+        b20.total_supply(token).await?,
+        U256::from(INITIAL_SUPPLY),
+        "total supply must not change after failed mint",
+    );
+
+    // Raise the supply cap and verify the mint now succeeds.
+    b20.update_supply_cap(token, U256::from(RAISED_SUPPLY_CAP)).await?;
+    assert_eq!(
+        b20.supply_cap(token).await?,
+        U256::from(RAISED_SUPPLY_CAP),
+        "supply cap must reflect the update",
+    );
+
+    b20.mint(token, admin.address(), U256::from(1u64)).await?;
+    assert_eq!(
+        b20.total_supply(token).await?,
+        U256::from(INITIAL_SUPPLY) + U256::ONE,
+        "total supply must increase after successful mint",
+    );
+    assert_eq!(
+        b20.currency(token).await?,
+        STABLECOIN_CURRENCY,
+        "currency must remain accessible after supply cap changes",
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_b20_stablecoin_pause_and_transfer() -> Result<()> {
+    let (_devnet, provider) = common::start_beryl_devnet().await?;
+    let admin = PrivateKeySigner::from_bytes(&ANVIL_ACCOUNT_5.private_key)
+        .wrap_err("Failed to parse admin key")?;
+    let recipient = ANVIL_ACCOUNT_6.address;
+
+    common::wait_for_balance(&provider, admin.address()).await?;
+
+    let b20 = activated_stablecoin_client(&provider, &admin).await?;
+    let salt = B256::repeat_byte(0x62);
+    let params = B20PrecompileClient::stablecoin_token_params(
+        "EUR Stablecoin",
+        "EURS",
+        admin.address(),
+        "EUR",
+        U256::from(INITIAL_SUPPLY),
+        admin.address(),
+    );
+
+    let token = b20.create_stablecoin_token(params, salt).await?;
+    b20.wait_for_token_code(token, common::TX_RECEIPT_TIMEOUT, common::BLOCK_POLL_INTERVAL).await?;
+
+    assert_eq!(b20.currency(token).await?, "EUR", "currency must be EUR before pause");
+
+    // Transfer succeeds before pause.
+    b20.transfer(token, recipient, U256::from(PAUSE_TRANSFER_AMOUNT)).await?;
+    assert_eq!(
+        b20.balance_of(token, recipient).await?,
+        U256::from(PAUSE_TRANSFER_AMOUNT),
+        "recipient balance must increase after transfer",
+    );
+
+    // Grant PAUSE_ROLE and UNPAUSE_ROLE so admin can toggle.
+    b20.send_call(
+        token,
+        IB20::grantRoleCall { role: B20TokenRole::Pause.id(), account: admin.address() },
+        "grant PAUSE_ROLE",
+    )
+    .await?;
+    b20.send_call(
+        token,
+        IB20::grantRoleCall { role: B20TokenRole::Unpause.id(), account: admin.address() },
+        "grant UNPAUSE_ROLE",
+    )
+    .await?;
+
+    // Pause the TRANSFER feature (vector bit 1).
+    b20.pause(token, U256::from(1u64)).await?;
+    assert_ne!(b20.paused(token).await?, U256::ZERO, "token must report paused");
+    assert_eq!(b20.currency(token).await?, "EUR", "currency must be readable while paused");
+
+    // Transfer reverts while paused.
+    let transfer_while_paused_succeeded = b20
+        .try_send_call(
+            token,
+            IB20::transferCall { to: recipient, amount: U256::from(PAUSE_TRANSFER_AMOUNT) },
+            "transfer while paused",
+        )
+        .await?;
+    assert!(!transfer_while_paused_succeeded, "transfer must revert while paused");
+    assert_eq!(
+        b20.balance_of(token, recipient).await?,
+        U256::from(PAUSE_TRANSFER_AMOUNT),
+        "recipient balance must be unchanged while paused",
+    );
+
+    // Unpause and verify transfer succeeds again.
+    b20.unpause(token).await?;
+    assert_eq!(b20.paused(token).await?, U256::ZERO, "token must report unpaused");
+
+    b20.transfer(token, recipient, U256::from(PAUSE_TRANSFER_AMOUNT)).await?;
+    assert_eq!(
+        b20.balance_of(token, recipient).await?,
+        U256::from(PAUSE_TRANSFER_AMOUNT * 2),
+        "recipient balance must increase after transfer following unpause",
+    );
+    assert_eq!(
+        b20.balance_of(token, admin.address()).await?,
+        U256::from(INITIAL_SUPPLY) - U256::from(PAUSE_TRANSFER_AMOUNT * 2),
+        "admin balance must reflect both transfers",
+    );
+    assert_eq!(b20.currency(token).await?, "EUR", "currency must be readable after unpause");
+
+    Ok(())
+}


### PR DESCRIPTION
## Motivation

The SECURITY and STABLECOIN factory creation success paths were untested at the action layer. Neither variant had any devnet RPC tests; `b20_precompile.rs` only covered the DEFAULT variant.

## Changes

**`actions/harness/tests/beryl/factory.rs`** - two new scenario tests:
- `b20_factory_creates_security_variant_and_initializes_state`: verifies deployed code, `isB20`/`isB20Initialized`, and initial security state (`sharesToTokensRatio` at WAD, ISIN stored, `minimumRedeemable`).
- `b20_factory_creates_stablecoin_variant_and_initializes_state`: verifies deployed code, factory views, `currency()`, and `decimals == 6`.

**`devnet/tests/security_token.rs`** (new) - three devnet RPC tests:
- `test_b20_security_factory_create_and_views`: factory creation + all view reads over RPC.
- `test_b20_security_batch_mint_and_burn`: `batchMint` to multiple recipients, `batchBurn`, balance/supply verification.
- `test_b20_security_redeem_and_share_ratio`: `updateMinimumRedeemable` enforcement, `redeem` below/above minimum, `updateShareRatio` with `toShares` math.

**`devnet/tests/stablecoin.rs`** (new) - three devnet RPC tests:
- `test_b20_stablecoin_factory_create_and_views`: factory creation + currency/decimals views.
- `test_b20_stablecoin_supply_cap_enforcement`: mint to cap reverts, `updateSupplyCap` unblocks.
- `test_b20_stablecoin_pause_and_transfer`: pause/unpause TRANSFER with `currency()` readable throughout.

`devnet/src/b20.rs` extended with security and stablecoin call helpers.