### PR TITLE
test(devnet): add activation and policy registry RPC round-trip tests

### DIFF
--- a/devnet/tests/activation_registry.rs
+++ b/devnet/tests/activation_registry.rs
@@ -57,6 +57,59 @@ async fn test_activation_registry_admin() -> Result<()> {
     Ok(())
 }
 
+/// Activating, deactivating, and re-activating a feature all apply the expected state transitions.
+#[tokio::test]
+async fn test_activation_registry_activate_and_deactivate_round_trip() -> Result<()> {
+    let (_devnet, provider) = common::start_beryl_devnet().await?;
+    let admin = PrivateKeySigner::from_bytes(&ANVIL_ACCOUNT_5.private_key)
+        .wrap_err("Failed to parse devnet private key")?;
+    common::wait_for_balance(&provider, admin.address()).await?;
+
+    let client = B20PrecompileClient::new(&provider, &admin, common::L2_CHAIN_ID)
+        .with_receipt_timeout(common::TX_RECEIPT_TIMEOUT);
+
+    // Activate the feature.
+    client.activate_feature(ActivationFeature::B20Security.id()).await?;
+
+    let output = client
+        .call(
+            ActivationRegistryStorage::ADDRESS,
+            IActivationRegistry::isActivatedCall { feature: ActivationFeature::B20Security.id() },
+        )
+        .await?;
+    let is_activated = IActivationRegistry::isActivatedCall::abi_decode_returns(output.as_ref())
+        .wrap_err("Failed to decode isActivated")?;
+    assert!(is_activated, "feature should be active after activate()");
+
+    // Deactivate the feature.
+    client.deactivate_feature(ActivationFeature::B20Security.id()).await?;
+
+    let output = client
+        .call(
+            ActivationRegistryStorage::ADDRESS,
+            IActivationRegistry::isActivatedCall { feature: ActivationFeature::B20Security.id() },
+        )
+        .await?;
+    let is_activated = IActivationRegistry::isActivatedCall::abi_decode_returns(output.as_ref())
+        .wrap_err("Failed to decode isActivated")?;
+    assert!(!is_activated, "feature should be inactive after deactivate()");
+
+    // Activate again: deactivate followed by activate must work (reactivation).
+    client.activate_feature(ActivationFeature::B20Security.id()).await?;
+
+    let output = client
+        .call(
+            ActivationRegistryStorage::ADDRESS,
+            IActivationRegistry::isActivatedCall { feature: ActivationFeature::B20Security.id() },
+        )
+        .await?;
+    let is_activated = IActivationRegistry::isActivatedCall::abi_decode_returns(output.as_ref())
+        .wrap_err("Failed to decode isActivated")?;
+    assert!(is_activated, "feature should be active again after second activate()");
+
+    Ok(())
+}
+
 /// Calling `activate` from a non-admin account reverts with `Unauthorized`.
 #[tokio::test]
 async fn test_activation_registry_unauthorized_activate_reverts() -> Result<()> {

--- a/devnet/tests/policy_registry.rs
+++ b/devnet/tests/policy_registry.rs
@@ -59,19 +59,19 @@ async fn test_policy_registry_admin_handoff_and_frozen_policy() -> Result<()> {
     // Activate the PolicyRegistry feature.
     admin_client.activate_feature(ActivationFeature::PolicyRegistry.id()).await?;
 
-    // Create a new ALLOWLIST policy. In a fresh devnet write_builtins() claims counters 0
-    // (ALWAYS_ALLOW_ID) and 1 (ALWAYS_BLOCK_ID), so the first user-created policy always gets
-    // counter 2. The type discriminant for ALLOWLIST is 1.
-    let policy_id: u64 = (IPolicyRegistry::PolicyType::ALLOWLIST as u64) << 56 | 2;
+    // Simulate createPolicy to get the ID the registry will assign, then dispatch the real
+    // transaction. Using call() avoids relying on internal counter state or enum discriminant
+    // ordering.
+    let create_call = IPolicyRegistry::createPolicyCall {
+        admin: admin.address(),
+        policyType: IPolicyRegistry::PolicyType::ALLOWLIST,
+    };
+    let output =
+        admin_client.call(PolicyRegistryStorage::ADDRESS, create_call.clone()).await?;
+    let policy_id = IPolicyRegistry::createPolicyCall::abi_decode_returns(output.as_ref())
+        .wrap_err("Failed to decode createPolicy return")?;
     admin_client
-        .send_call(
-            PolicyRegistryStorage::ADDRESS,
-            IPolicyRegistry::createPolicyCall {
-                admin: admin.address(),
-                policyType: IPolicyRegistry::PolicyType::ALLOWLIST,
-            },
-            "createPolicy",
-        )
+        .send_call(PolicyRegistryStorage::ADDRESS, create_call, "createPolicy")
         .await?;
 
     // Stage the admin transfer to new_admin.

--- a/devnet/tests/policy_registry.rs
+++ b/devnet/tests/policy_registry.rs
@@ -66,13 +66,10 @@ async fn test_policy_registry_admin_handoff_and_frozen_policy() -> Result<()> {
         admin: admin.address(),
         policyType: IPolicyRegistry::PolicyType::ALLOWLIST,
     };
-    let output =
-        admin_client.call(PolicyRegistryStorage::ADDRESS, create_call.clone()).await?;
+    let output = admin_client.call(PolicyRegistryStorage::ADDRESS, create_call.clone()).await?;
     let policy_id = IPolicyRegistry::createPolicyCall::abi_decode_returns(output.as_ref())
         .wrap_err("Failed to decode createPolicy return")?;
-    admin_client
-        .send_call(PolicyRegistryStorage::ADDRESS, create_call, "createPolicy")
-        .await?;
+    admin_client.send_call(PolicyRegistryStorage::ADDRESS, create_call, "createPolicy").await?;
 
     // Stage the admin transfer to new_admin.
     admin_client

--- a/devnet/tests/policy_registry.rs
+++ b/devnet/tests/policy_registry.rs
@@ -2,10 +2,14 @@
 
 mod common;
 
+use alloy_primitives::Address;
 use alloy_signer_local::PrivateKeySigner;
 use alloy_sol_types::SolCall;
 use base_common_precompiles::{ActivationFeature, IPolicyRegistry, PolicyRegistryStorage};
-use devnet::{B20PrecompileClient, config::ANVIL_ACCOUNT_5};
+use devnet::{
+    B20PrecompileClient,
+    config::{ANVIL_ACCOUNT_5, ANVIL_ACCOUNT_6},
+};
 use eyre::{Result, WrapErr};
 
 /// `policyExists(ALWAYS_ALLOW_ID)` returns `true` once the policy registry is active.
@@ -30,6 +34,152 @@ async fn test_policy_registry_policy_exists() -> Result<()> {
         .wrap_err("Failed to decode policyExists")?;
 
     assert!(result, "policyExists(0) should return true after Beryl activation");
+
+    Ok(())
+}
+
+/// Full admin lifecycle over RPC: create policy, stage and finalize admin handoff, verify new
+/// admin can mutate and old admin cannot, renounce admin, verify the policy is frozen, and
+/// verify read-only views still work after renounce.
+#[tokio::test]
+async fn test_policy_registry_admin_handoff_and_frozen_policy() -> Result<()> {
+    let (_devnet, provider) = common::start_beryl_devnet().await?;
+    let admin = PrivateKeySigner::from_bytes(&ANVIL_ACCOUNT_5.private_key)
+        .wrap_err("Failed to parse devnet private key")?;
+    let new_admin = PrivateKeySigner::from_bytes(&ANVIL_ACCOUNT_6.private_key)
+        .wrap_err("Failed to parse new admin private key")?;
+    common::wait_for_balance(&provider, admin.address()).await?;
+    common::wait_for_balance(&provider, new_admin.address()).await?;
+
+    let admin_client = B20PrecompileClient::new(&provider, &admin, common::L2_CHAIN_ID)
+        .with_receipt_timeout(common::TX_RECEIPT_TIMEOUT);
+    let new_admin_client = B20PrecompileClient::new(&provider, &new_admin, common::L2_CHAIN_ID)
+        .with_receipt_timeout(common::TX_RECEIPT_TIMEOUT);
+
+    // Activate the PolicyRegistry feature.
+    admin_client.activate_feature(ActivationFeature::PolicyRegistry.id()).await?;
+
+    // Create a new ALLOWLIST policy. In a fresh devnet write_builtins() claims counters 0
+    // (ALWAYS_ALLOW_ID) and 1 (ALWAYS_BLOCK_ID), so the first user-created policy always gets
+    // counter 2. The type discriminant for ALLOWLIST is 1.
+    let policy_id: u64 = (IPolicyRegistry::PolicyType::ALLOWLIST as u64) << 56 | 2;
+    admin_client
+        .send_call(
+            PolicyRegistryStorage::ADDRESS,
+            IPolicyRegistry::createPolicyCall {
+                admin: admin.address(),
+                policyType: IPolicyRegistry::PolicyType::ALLOWLIST,
+            },
+            "createPolicy",
+        )
+        .await?;
+
+    // Stage the admin transfer to new_admin.
+    admin_client
+        .send_call(
+            PolicyRegistryStorage::ADDRESS,
+            IPolicyRegistry::stageUpdateAdminCall {
+                policyId: policy_id,
+                newAdmin: new_admin.address(),
+            },
+            "stageUpdateAdmin",
+        )
+        .await?;
+
+    // Finalize the admin transfer from new_admin.
+    new_admin_client
+        .send_call(
+            PolicyRegistryStorage::ADDRESS,
+            IPolicyRegistry::finalizeUpdateAdminCall { policyId: policy_id },
+            "finalizeUpdateAdmin",
+        )
+        .await?;
+
+    // Verify policyAdmin now returns new_admin.
+    let output = admin_client
+        .call(
+            PolicyRegistryStorage::ADDRESS,
+            IPolicyRegistry::policyAdminCall { policyId: policy_id },
+        )
+        .await?;
+    let current_admin = IPolicyRegistry::policyAdminCall::abi_decode_returns(output.as_ref())
+        .wrap_err("Failed to decode policyAdmin")?;
+    assert_eq!(current_admin, new_admin.address(), "policyAdmin should be new_admin after handoff");
+
+    // Verify new admin can mutate: add an address to the allowlist.
+    let allowlisted = Address::repeat_byte(0xaa);
+    new_admin_client
+        .send_call(
+            PolicyRegistryStorage::ADDRESS,
+            IPolicyRegistry::updateAllowlistCall {
+                policyId: policy_id,
+                allowed: true,
+                accounts: vec![allowlisted],
+            },
+            "updateAllowlist (new admin)",
+        )
+        .await?;
+
+    // Verify old admin can no longer mutate after the handoff.
+    let succeeded = admin_client
+        .try_send_call(
+            PolicyRegistryStorage::ADDRESS,
+            IPolicyRegistry::updateAllowlistCall {
+                policyId: policy_id,
+                allowed: true,
+                accounts: vec![Address::repeat_byte(0xbb)],
+            },
+            "updateAllowlist from old admin (should revert)",
+        )
+        .await?;
+    assert!(!succeeded, "updateAllowlist from old admin should revert after handoff");
+
+    // Renounce admin: new_admin gives up control permanently.
+    new_admin_client
+        .send_call(
+            PolicyRegistryStorage::ADDRESS,
+            IPolicyRegistry::renounceAdminCall { policyId: policy_id },
+            "renounceAdmin",
+        )
+        .await?;
+
+    // Policy is now frozen: updateAllowlist from anyone reverts.
+    let succeeded = new_admin_client
+        .try_send_call(
+            PolicyRegistryStorage::ADDRESS,
+            IPolicyRegistry::updateAllowlistCall {
+                policyId: policy_id,
+                allowed: false,
+                accounts: vec![allowlisted],
+            },
+            "updateAllowlist after renounce (should revert)",
+        )
+        .await?;
+    assert!(!succeeded, "updateAllowlist should revert after renounceAdmin");
+
+    // Read-only views must still work correctly after renounce.
+    let output = admin_client
+        .call(
+            PolicyRegistryStorage::ADDRESS,
+            IPolicyRegistry::isAuthorizedCall { policyId: policy_id, account: allowlisted },
+        )
+        .await?;
+    let is_auth = IPolicyRegistry::isAuthorizedCall::abi_decode_returns(output.as_ref())
+        .wrap_err("Failed to decode isAuthorized")?;
+    assert!(
+        is_auth,
+        "isAuthorized should still return true for allowlisted address after renounce",
+    );
+
+    let output = admin_client
+        .call(
+            PolicyRegistryStorage::ADDRESS,
+            IPolicyRegistry::policyExistsCall { policyId: policy_id },
+        )
+        .await?;
+    let exists = IPolicyRegistry::policyExistsCall::abi_decode_returns(output.as_ref())
+        .wrap_err("Failed to decode policyExists")?;
+    assert!(exists, "policyExists should still return true after renounceAdmin");
 
     Ok(())
 }


### PR DESCRIPTION
## Motivation

The activation registry devnet tests only covered static state and unauthorized reverts, never a successful state change. The policy registry devnet had one test (`policyExists`), with no lifecycle coverage despite comprehensive action-layer tests existing.

## Changes

**`devnet/tests/activation_registry.rs`**:
- `test_activation_registry_activate_and_deactivate_round_trip`: admin activates a feature, verifies `isActivated` true, deactivates, verifies false, reactivates, verifies true again.

**`devnet/tests/policy_registry.rs`**:
- `test_policy_registry_admin_handoff_and_frozen_policy`: creates an ALLOWLIST policy, stages and finalizes admin handoff to a second account, verifies new admin can mutate and old admin cannot, renounces admin, confirms policy is frozen (mutations revert) while read-only views (`isAuthorized`, `policyExists`) remain correct.