### PR TITLE
fix(infra): Grant Release Attestation Permissions

### DIFF
--- a/.github/workflows/create-rc.yml
+++ b/.github/workflows/create-rc.yml
@@ -8,6 +8,8 @@ on:
 permissions:
   contents: write
   packages: write
+  id-token: write
+  attestations: write
 
 concurrency:
   group: release-${{ github.ref_name }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -11,6 +11,8 @@ on:
 permissions:
   contents: write
   packages: write
+  id-token: write
+  attestations: write
 
 concurrency:
   group: publish-release-${{ inputs.version }}


### PR DESCRIPTION
## Summary

This regressed when #2740 added `actions/attest` to `build-release.yml` without updating the release workflows that call it: https://github.com/base/base/commit/ca882515e17e97ed517809fe18b3617c78133c59. The last successful v0.9.0 RC branch and the current v0.9.1 branch do not contain that commit; the failing v0.10.0 branch does, so GitHub rejects the reusable workflow graph before creating any jobs. GitHub's current artifact attestation docs require `id-token: write` and `attestations: write`, and the reusable workflow docs say token permissions can be reduced but not elevated through the call chain: https://docs.github.com/en/actions/how-tos/secure-your-work/use-artifact-attestations/use-artifact-attestations and https://docs.github.com/actions/how-tos/sharing-automations/reusing-workflows.