### PR TITLE
fix(infra): Grant Release Attestation Permissions

### DIFF
--- a/.github/workflows/create-rc.yml
+++ b/.github/workflows/create-rc.yml
@@ -8,6 +8,8 @@ on:
 permissions:
   contents: write
   packages: write
+  id-token: write
+  attestations: write
 
 concurrency:
   group: release-${{ github.ref_name }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -11,6 +11,8 @@ on:
 permissions:
   contents: write
   packages: write
+  id-token: write
+  attestations: write
 
 concurrency:
   group: publish-release-${{ inputs.version }}


### PR DESCRIPTION
## Summary

Backports #2933 to `releases/v0.10.0`. This release branch contains #2740's `actions/attest` change in `build-release.yml`, but the RC and final release callers still do not grant the token scopes that reusable workflow needs. Granting `id-token: write` and `attestations: write` in both callers fixes the RC startup failure before any jobs are created.