### PR TITLE
fix(factory): MissingRequiredField includes field name; isin no longer required

### DIFF
--- a/crates/common/precompiles/src/b20_factory/abi.rs
+++ b/crates/common/precompiles/src/b20_factory/abi.rs
@@ -52,7 +52,7 @@ sol! {
         error UnsupportedVersion(uint8 version, B20Variant variant);
 
         /// A required string argument was empty.
-        /// @param field  Name of the missing field (e.g. `"isin"`, `"currency"`).
+        /// @param field  Name of the missing field (e.g. `"currency"`).
         error MissingRequiredField(string field);
 
         /// The stablecoin `currency` field was not on the ISO 4217 fiat allowlist.

--- a/crates/common/precompiles/src/b20_factory/abi.rs
+++ b/crates/common/precompiles/src/b20_factory/abi.rs
@@ -52,7 +52,8 @@ sol! {
         error UnsupportedVersion(uint8 version, B20Variant variant);
 
         /// A required string argument was empty.
-        error MissingRequiredField();
+        /// @param field  Name of the missing field (e.g. `"isin"`, `"currency"`).
+        error MissingRequiredField(string field);
 
         /// The stablecoin `currency` field was not on the ISO 4217 fiat allowlist.
         error InvalidCurrency(string code);

--- a/crates/common/precompiles/src/b20_factory/storage.rs
+++ b/crates/common/precompiles/src/b20_factory/storage.rs
@@ -354,7 +354,7 @@ impl TokenCreateParams {
     ///
     /// Each arm owns its own rules. Version is checked first by the caller (`check_version`)
     /// so that version errors always take precedence over field-level errors.
-    pub fn validate(&self) -> Result<()> {
+    pub const fn validate(&self) -> Result<()> {
         match self {
             Self::B20 { init, .. } => Self::validate_b20(init),
             Self::Stablecoin { init, .. } => Self::validate_stablecoin(init),

--- a/crates/common/precompiles/src/b20_factory/storage.rs
+++ b/crates/common/precompiles/src/b20_factory/storage.rs
@@ -375,12 +375,8 @@ impl TokenCreateParams {
     }
 
     /// Validates security-token initialization fields.
-    pub fn validate_security(init: &B20SecurityInit) -> Result<()> {
-        if init.isin.is_empty() {
-            return Err(BasePrecompileError::revert(IB20Factory::MissingRequiredField {
-                field: "isin".to_string(),
-            }));
-        }
+    pub const fn validate_security(_init: &B20SecurityInit) -> Result<()> {
+        // isin is optional — empty string is accepted.
         Ok(())
     }
 
@@ -1248,22 +1244,6 @@ mod tests {
             assert!(!token.has_role(B20TokenRole::DefaultAdmin.id(), Address::ZERO).unwrap());
         });
     }
-
-    #[test]
-    fn test_create_security_token_reverts_for_empty_isin() {
-        let mut storage = HashMapStorageProvider::new(1);
-        activate_precompiles(&mut storage);
-
-        let params = IB20Factory::B20SecurityCreateParams {
-            version: B20Variant::Security.supported_version(),
-            name: "Security Token".to_string(),
-            symbol: "SEC".to_string(),
-            initialAdmin: Address::repeat_byte(0xAB),
-            isin: String::new(),
-            minimumRedeemable: U256::ZERO,
-        };
-        let call = IB20Factory::createB20Call {
-            variant: IB20Factory::B20Variant::SECURITY,
             salt: B256::repeat_byte(0x52),
             params: params.abi_encode().into(),
             initCalls: Vec::new(),

--- a/crates/common/precompiles/src/b20_factory/storage.rs
+++ b/crates/common/precompiles/src/b20_factory/storage.rs
@@ -370,7 +370,7 @@ impl TokenCreateParams {
     /// Validates stablecoin initialization fields.
     pub const fn validate_stablecoin(_init: &B20StablecoinInit) -> Result<()> {
         // Currency validation is delegated to `B20StablecoinStorage::initialize`, which rejects
-        // all invalid values (including empty) with `InvalidCurrency`.
+        // empty values with `MissingRequiredField` and non-A-Z values with `InvalidCurrency`.
         Ok(())
     }
 
@@ -736,7 +736,7 @@ mod tests {
         StorageCtx::enter(&mut storage, |ctx| {
             assert_output(
                 dispatch_factory_revert(ctx, call),
-                IB20Factory::InvalidCurrency { code: String::new() }.abi_encode(),
+                IB20Factory::MissingRequiredField { field: "currency".to_string() }.abi_encode(),
             );
         });
     }

--- a/crates/common/precompiles/src/b20_factory/storage.rs
+++ b/crates/common/precompiles/src/b20_factory/storage.rs
@@ -742,6 +742,32 @@ mod tests {
     }
 
     #[test]
+    fn test_create_token_reverts_for_invalid_stablecoin_currency_format() {
+        let mut storage = HashMapStorageProvider::new(1);
+        activate_precompiles(&mut storage);
+        let params = IB20Factory::B20StablecoinCreateParams {
+            version: B20FactoryStorage::CREATE_TOKEN_VERSION,
+            name: "Stablecoin Token".to_string(),
+            symbol: "STB".to_string(),
+            initialAdmin: Address::repeat_byte(0xAB),
+            currency: "usd".to_string(), // lowercase — invalid format
+        };
+        let call = IB20Factory::createB20Call {
+            variant: IB20Factory::B20Variant::STABLECOIN,
+            salt: B256::repeat_byte(0x08),
+            params: params.abi_encode().into(),
+            initCalls: Vec::new(),
+        };
+
+        StorageCtx::enter(&mut storage, |ctx| {
+            assert_output(
+                dispatch_factory_revert(ctx, call),
+                IB20Factory::InvalidCurrency { code: "usd".to_string() }.abi_encode(),
+            );
+        });
+    }
+
+    #[test]
     fn test_create_token_checks_stablecoin_version_before_currency() {
         let mut storage = HashMapStorageProvider::new(1);
         activate_precompiles(&mut storage);

--- a/crates/common/precompiles/src/b20_factory/storage.rs
+++ b/crates/common/precompiles/src/b20_factory/storage.rs
@@ -377,7 +377,9 @@ impl TokenCreateParams {
     /// Validates security-token initialization fields.
     pub fn validate_security(init: &B20SecurityInit) -> Result<()> {
         if init.isin.is_empty() {
-            return Err(BasePrecompileError::revert(IB20Factory::MissingRequiredField {}));
+            return Err(BasePrecompileError::revert(IB20Factory::MissingRequiredField {
+                field: "isin".to_string(),
+            }));
         }
         Ok(())
     }
@@ -1244,7 +1246,7 @@ mod tests {
         StorageCtx::enter(&mut storage, |ctx| {
             assert_output(
                 dispatch_factory_revert(ctx, call),
-                IB20Factory::MissingRequiredField {}.abi_encode(),
+                IB20Factory::MissingRequiredField { field: "isin".to_string() }.abi_encode(),
             );
         });
 

--- a/crates/common/precompiles/src/b20_factory/storage.rs
+++ b/crates/common/precompiles/src/b20_factory/storage.rs
@@ -742,7 +742,7 @@ mod tests {
         let mut storage = HashMapStorageProvider::new(1);
         activate_precompiles(&mut storage);
         let params = IB20Factory::B20StablecoinCreateParams {
-            version: B20FactoryStorage::CREATE_TOKEN_VERSION,
+            version: B20Variant::Stablecoin.supported_version(),
             name: "Stablecoin Token".to_string(),
             symbol: "STB".to_string(),
             initialAdmin: Address::repeat_byte(0xAB),
@@ -1242,45 +1242,6 @@ mod tests {
             );
             assert!(!token.has_role(B20TokenRole::DefaultAdmin.id(), initial_admin).unwrap());
             assert!(!token.has_role(B20TokenRole::DefaultAdmin.id(), Address::ZERO).unwrap());
-        });
-    }
-            salt: B256::repeat_byte(0x52),
-            params: params.abi_encode().into(),
-            initCalls: Vec::new(),
-        };
-
-        StorageCtx::enter(&mut storage, |ctx| {
-            assert_output(
-                dispatch_factory_revert(ctx, call),
-                IB20Factory::MissingRequiredField { field: "isin".to_string() }.abi_encode(),
-            );
-        });
-
-        // Bad version with empty ISIN reverts with UnsupportedVersion, not MissingRequiredField.
-        let params_bad_version = IB20Factory::B20SecurityCreateParams {
-            version: B20Variant::Security.supported_version() + 1,
-            name: "Security Token".to_string(),
-            symbol: "SEC".to_string(),
-            initialAdmin: Address::repeat_byte(0xAB),
-            isin: String::new(),
-            minimumRedeemable: U256::ZERO,
-        };
-        let call_bad_version = IB20Factory::createB20Call {
-            variant: IB20Factory::B20Variant::SECURITY,
-            salt: B256::repeat_byte(0x53),
-            params: params_bad_version.abi_encode().into(),
-            initCalls: Vec::new(),
-        };
-
-        StorageCtx::enter(&mut storage, |ctx| {
-            assert_output(
-                dispatch_factory_revert(ctx, call_bad_version),
-                IB20Factory::UnsupportedVersion {
-                    version: B20Variant::Security.supported_version() + 1,
-                    variant: IB20Factory::B20Variant::SECURITY,
-                }
-                .abi_encode(),
-            );
         });
     }
 

--- a/crates/common/precompiles/src/b20_stablecoin/storage.rs
+++ b/crates/common/precompiles/src/b20_stablecoin/storage.rs
@@ -49,10 +49,16 @@ impl<'a> B20StablecoinStorage<'a> {
 
     /// Writes all creation-time fields atomically.
     ///
-    /// Validates that `currency` contains only `A-Z` characters before writing
-    /// anything; reverts `ITokenFactory::InvalidCurrency` otherwise.
+    /// Validates that `currency` is non-empty and contains only `A-Z` characters
+    /// before writing anything; reverts `MissingRequiredField` for empty and
+    /// `InvalidCurrency` for non-A-Z values.
     pub fn initialize(&mut self, init: B20StablecoinInit) -> Result<()> {
-        if init.currency.is_empty() || !init.currency.bytes().all(|b| b.is_ascii_uppercase()) {
+        if init.currency.is_empty() {
+            return Err(BasePrecompileError::revert(IB20Factory::MissingRequiredField {
+                field: "currency".to_string(),
+            }));
+        }
+        if !init.currency.bytes().all(|b| b.is_ascii_uppercase()) {
             return Err(BasePrecompileError::revert(IB20Factory::InvalidCurrency {
                 code: init.currency,
             }));

--- a/crates/common/precompiles/src/b20_stablecoin/storage.rs
+++ b/crates/common/precompiles/src/b20_stablecoin/storage.rs
@@ -55,7 +55,7 @@ impl<'a> B20StablecoinStorage<'a> {
     pub fn initialize(&mut self, init: B20StablecoinInit) -> Result<()> {
         if init.currency.is_empty() {
             return Err(BasePrecompileError::revert(IB20Factory::MissingRequiredField {
-                field: "currency".to_string(),
+                field: String::from("currency"),
             }));
         }
         if !init.currency.bytes().all(|b| b.is_ascii_uppercase()) {


### PR DESCRIPTION
[BOP-155](https://linear.app/coinbase/issue/BOP-155) · [BOP-223](https://linear.app/coinbase/issue/BOP-223)

## Motivation

Two related factory alignment changes:

**BOP-155:** `MissingRequiredField` carried no information about which field was absent. This aligns the Rust precompile with the updated Solidity interface so both sides emit the same ABI-encoded error with the field name included. Empty `currency` on stablecoin creation was also previously collapsed into `InvalidCurrency` — this separates the two cases.

**BOP-223:** New requirement: `isin` is no longer required when creating a security token. Empty isin is now accepted.

## What changed

- `b20_factory/abi.rs`: `error MissingRequiredField(string field)`
- `b20_factory/storage.rs`: removed empty-isin guard from `validate_security` (isin is now optional); updated stablecoin empty-currency check to revert `MissingRequiredField("currency")`; added `InvalidCurrency` format test for non-empty invalid currency
- `b20_stablecoin/storage.rs`: splits the combined empty+invalid check so empty currency reverts `MissingRequiredField("currency")` and non-A-Z currency reverts `InvalidCurrency`
