### PR TITLE
fix(precompiles): Mark Install Result Must Use

### DIFF
--- a/crates/common/precompiles/src/provider.rs
+++ b/crates/common/precompiles/src/provider.rs
@@ -167,6 +167,7 @@ impl<S: BasePrecompileSpec> BasePrecompiles<S> {
     /// Builds a [`PrecompilesMap`] with all Base precompiles for this spec installed.
     ///
     /// For Beryl and later, this also installs the dynamic token and registry precompiles.
+    #[must_use = "install returns the PrecompilesMap containing all installed Base precompiles"]
     pub fn install(self) -> PrecompilesMap {
         let mut precompiles = PrecompilesMap::from_static(self.precompiles());
         if self.spec.upgrade() >= BaseUpgrade::Beryl {


### PR DESCRIPTION
## Summary

This marks BasePrecompiles::install as must_use so callers get a compiler warning if they discard the installed PrecompilesMap. The installed map is the canonical surface for Beryl and later dynamic precompiles, so this adds a lightweight guard against accidentally ignoring that path. Validation passed with cargo check -p base-common-precompiles.