### PR TITLE
fix(devnet): repair B20 zk proving bench

### DIFF
--- a/crates/common/precompiles/src/observer.rs
+++ b/crates/common/precompiles/src/observer.rs
@@ -96,7 +96,6 @@ mod tests {
         let result = catch_unwind(AssertUnwindSafe(|| {
             observer.observe("precompile-b20-transfer", || panic!("observed panic"));
         }));
-
         assert!(result.is_err());
         assert_eq!(
             observer.events(),

--- a/crates/proof/succinct/elf/manifest.toml
+++ b/crates/proof/succinct/elf/manifest.toml
@@ -17,7 +17,7 @@
 
 [[elfs]]
 name = "range-elf-embedded"
-sha256 = "fc20d749763f788b9c54cac58399d09eae1396d3e187cc0c22240b941f4ad0ed"
+sha256 = "b678508eb6d75befac282b9af9cb873d112a424f6a5fbdc4213b31628c0c2f8a"
 
 [[elfs]]
 name = "aggregation-elf"

--- a/crates/proof/succinct/programs/Cargo.lock
+++ b/crates/proof/succinct/programs/Cargo.lock
@@ -939,6 +939,7 @@ dependencies = [
  "base-common-consensus",
  "base-common-evm",
  "base-common-genesis",
+ "base-common-precompiles",
  "base-consensus-derive",
  "base-proof",
  "base-proof-driver",

--- a/devnet/benches/b20_zk_proving.rs
+++ b/devnet/benches/b20_zk_proving.rs
@@ -13,7 +13,10 @@ use std::time::Duration;
 use alloy_primitives::{Address, B256, U256};
 use alloy_signer_local::PrivateKeySigner;
 use alloy_sol_types::{SolCall, SolInterface};
-use base_common_precompiles::{ActivationFeature, B20TokenRole, B20Variant, IB20};
+use base_common_precompiles::{
+    ActivationFeature, ActivationRegistryStorage, B20TokenRole, B20Variant, IActivationRegistry,
+    IB20,
+};
 use clap::Parser;
 use devnet::{
     B20PrecompileClient,
@@ -53,6 +56,9 @@ fn main() -> Result<()> {
 /// CLI configuration for the local B-20 ZK proving benchmark.
 #[derive(Clone, Debug, Parser)]
 pub struct B20ZkProvingConfig {
+    /// Cargo passes this flag to custom benchmark binaries.
+    #[arg(long = "bench", hide = true)]
+    pub cargo_bench: bool,
     /// L2 execution RPC URL.
     #[arg(long, default_value = "http://localhost:8645")]
     pub l2_rpc_url: Url,
@@ -137,8 +143,8 @@ impl B20ZkProvingBench {
         let b20_spender = B20PrecompileClient::new(&l2_provider, &spender, config.l2_chain_id)
             .with_receipt_timeout(config.tx_receipt_timeout);
         display.setup_message("setup ensuring B-20 features are active");
-        b20.activate_feature(ActivationFeature::B20Factory.id()).await?;
-        b20.activate_feature(ActivationFeature::B20Token.id()).await?;
+        Self::ensure_feature_active(&b20, ActivationFeature::B20Factory.id()).await?;
+        Self::ensure_feature_active(&b20, ActivationFeature::B20Token.id()).await?;
 
         display.setup_message("setup creating benchmark B-20 token");
         let token = Self::create_b20_token(&b20, admin.address()).await?;
@@ -199,6 +205,25 @@ impl B20ZkProvingBench {
         );
 
         client.create_token(B20Variant::B20, params, salt).await
+    }
+
+    /// Activates `feature` if it is not already active.
+    pub async fn ensure_feature_active(
+        client: &B20PrecompileClient<'_>,
+        feature: B256,
+    ) -> Result<()> {
+        let output = client
+            .call(
+                ActivationRegistryStorage::ADDRESS,
+                IActivationRegistry::isActivatedCall { feature },
+            )
+            .await?;
+        let is_active = IActivationRegistry::isActivatedCall::abi_decode_returns(output.as_ref())
+            .wrap_err("failed to decode activation registry state")?;
+        if !is_active {
+            client.activate_feature(feature).await?;
+        }
+        Ok(())
     }
 }
 
@@ -274,16 +299,16 @@ impl B20CallSender<'_> {
         reports.push(
             self.send_call(
                 self.admin_client,
-                "updateContractURI",
-                IB20::updateContractURICall { newURI: HEAVY_CONTRACT_URI.to_string() },
+                "grantRole(metadata)",
+                IB20::grantRoleCall { role: B20TokenRole::Metadata.id(), account: self.admin },
             )
             .await?,
         );
         reports.push(
             self.send_call(
                 self.admin_client,
-                "grantRole(metadata)",
-                IB20::grantRoleCall { role: B20TokenRole::Metadata.id(), account: self.admin },
+                "updateContractURI",
+                IB20::updateContractURICall { newURI: HEAVY_CONTRACT_URI.to_string() },
             )
             .await?,
         );


### PR DESCRIPTION
## Summary
- Accept Cargo's hidden `--bench` argument for the custom B20 zk proving benchmark.
- Make B20 feature activation idempotent so benchmark reruns work against an already-initialized devnet.
- Grant `METADATA_ROLE` before metadata update calls and refresh the Succinct range ELF manifest hash.

## Test plan
- `cargo bench -p devnet --bench b20_zk_proving -- --help`
- Started `just devnet bench b20-zk-proving` locally and fixed the runtime setup failures it exposed.


Made with [Cursor](https://cursor.com)