### PR TITLE
test(engine/versions): add missing unit tests for EngineForkchoiceVersion and EngineNewPayloadVersion

### DIFF
--- a/crates/consensus/engine/src/versions.rs
+++ b/crates/consensus/engine/src/versions.rs
@@ -157,4 +157,76 @@ mod tests {
             EngineGetPayloadVersion::V5
         );
     }
+
+    // ── EngineForkchoiceVersion ──────────────────────────────────────────────
+
+    #[test]
+    fn forkchoice_version_uses_v2_before_ecotone() {
+        assert_eq!(
+            EngineForkchoiceVersion::from_cfg(&test_rollup_config(), 10),
+            EngineForkchoiceVersion::V2
+        );
+    }
+
+    #[test]
+    fn forkchoice_version_uses_v3_at_ecotone() {
+        assert_eq!(
+            EngineForkchoiceVersion::from_cfg(&test_rollup_config(), 20),
+            EngineForkchoiceVersion::V3
+        );
+    }
+
+    #[test]
+    fn forkchoice_version_uses_v3_for_jovian() {
+        // All forks from Ecotone onwards (Jovian, Base Azul, …) keep using FCU V3.
+        assert_eq!(
+            EngineForkchoiceVersion::from_cfg(&test_rollup_config(), 35),
+            EngineForkchoiceVersion::V3
+        );
+    }
+
+    #[test]
+    fn forkchoice_version_uses_v3_for_base_azul() {
+        assert_eq!(
+            EngineForkchoiceVersion::from_cfg(&test_rollup_config(), 45),
+            EngineForkchoiceVersion::V3
+        );
+    }
+
+    // ── EngineNewPayloadVersion ──────────────────────────────────────────────
+
+    #[test]
+    fn new_payload_version_uses_v2_before_ecotone() {
+        assert_eq!(
+            EngineNewPayloadVersion::from_cfg(&test_rollup_config(), 10),
+            EngineNewPayloadVersion::V2
+        );
+    }
+
+    #[test]
+    fn new_payload_version_uses_v3_at_ecotone() {
+        assert_eq!(
+            EngineNewPayloadVersion::from_cfg(&test_rollup_config(), 20),
+            EngineNewPayloadVersion::V3
+        );
+    }
+
+    #[test]
+    fn new_payload_version_uses_v4_at_jovian() {
+        // Jovian activates via `implies is_isthmus_active`, so V4 kicks in even when
+        // `isthmus_time` is not explicitly set in the config.
+        assert_eq!(
+            EngineNewPayloadVersion::from_cfg(&test_rollup_config(), 35),
+            EngineNewPayloadVersion::V4
+        );
+    }
+
+    #[test]
+    fn new_payload_version_uses_v4_for_base_azul() {
+        // engine_newPayloadV4 is reused for Base Azul; only engine_getPayload upgrades to V5.
+        assert_eq!(
+            EngineNewPayloadVersion::from_cfg(&test_rollup_config(), 45),
+            EngineNewPayloadVersion::V4
+        );
+    }
 }


### PR DESCRIPTION
## Summary

`versions.rs` contains three Engine API version selectors but only `EngineGetPayloadVersion` had unit tests. `EngineForkchoiceVersion` and `EngineNewPayloadVersion` had **zero** coverage.

## Why this matters

Each selector contains hardfork-conditional logic and relies on the `implies` chain in `rollup_fork_methods!` (e.g. `is_isthmus_active` returns `true` when Jovian is active, even when `isthmus_time` is not set explicitly). Without tests, a wrong branch or broken `implies` chain would silently produce the wrong Engine API version, causing consensus failures.

## Changes

Adds 4 tests for `EngineForkchoiceVersion` and 4 for `EngineNewPayloadVersion`, matching the hardfork boundary structure of the existing suite:

| Timestamp | FCU | newPayload | getPayload |
|-----------|-----|-----------|------------|
| 10 pre-Ecotone | V2 | V2 | V2 |
| 20 Ecotone | V3 | V3 | V3 |
| 35 Jovian | V3 | V4 | V4 |
| 45 Base Azul | V3 | V4 | V5 |

Key notes:
- All post-Ecotone forks keep FCU V3 — no new forkchoice version after Cancun.
- `engine_newPayloadV4` is reused at Base Azul; only `engine_getPayload` upgrades to V5.
- Jovian activates `is_isthmus_active` via `implies` even without explicit `isthmus_time`.