### PR TITLE
fix(derive): rename BlobSource::batcher_address to batch_inbox_address

### DIFF
--- a/crates/consensus/derive/src/sources/blobs.rs
+++ b/crates/consensus/derive/src/sources/blobs.rs
@@ -26,7 +26,7 @@ where
     /// Fetches blobs.
     pub blob_fetcher: B,
     /// The address of the batcher contract.
-    pub batcher_address: Address,
+    pub batch_inbox_address: Address,
     /// Data.
     pub data: Vec<BlobData>,
     /// Whether the source is open.
@@ -39,8 +39,8 @@ where
     B: BlobProvider + Send,
 {
     /// Creates a new blob source.
-    pub const fn new(chain_provider: F, blob_fetcher: B, batcher_address: Address) -> Self {
-        Self { chain_provider, blob_fetcher, batcher_address, data: Vec::new(), open: false }
+    pub const fn new(chain_provider: F, blob_fetcher: B, batch_inbox_address: Address) -> Self {
+        Self { chain_provider, blob_fetcher, batch_inbox_address, data: Vec::new(), open: false }
     }
 
     fn extract_blob_data(
@@ -68,7 +68,7 @@ where
             };
             let Some(to) = tx_kind else { continue };
 
-            if to != self.batcher_address {
+            if to != self.batch_inbox_address {
                 continue;
             }
             if tx.recover_signer().unwrap_or_default() != batcher_address {
@@ -318,7 +318,7 @@ pub(super) mod tests {
         let block_info = BlockInfo::default();
         let batcher_address = valid_blob_batcher_address();
         let batch_inbox_address = ChainConfig::MAINNET.batch_inbox_address;
-        source.batcher_address = batch_inbox_address;
+        source.batch_inbox_address = batch_inbox_address;
         let txs = valid_blob_txs();
         source.blob_fetcher.should_error = true;
         source.chain_provider.insert_block_with_transactions(1, block_info, txs);
@@ -334,7 +334,7 @@ pub(super) mod tests {
         let block_info = BlockInfo::default();
         let batcher_address = valid_blob_batcher_address();
         let batch_inbox_address = ChainConfig::MAINNET.batch_inbox_address;
-        source.batcher_address = batch_inbox_address;
+        source.batch_inbox_address = batch_inbox_address;
         let txs = valid_blob_txs();
         source.chain_provider.insert_block_with_transactions(1, block_info, txs);
         let hashes = [
@@ -404,7 +404,7 @@ pub(super) mod tests {
         let block_info = BlockInfo::default();
         let batcher_address = valid_blob_batcher_address();
         let batch_inbox_address = ChainConfig::MAINNET.batch_inbox_address;
-        source.batcher_address = batch_inbox_address;
+        source.batch_inbox_address = batch_inbox_address;
         let txs = valid_blob_txs();
         source.blob_fetcher.should_return_extra_blob = true;
         source.chain_provider.insert_block_with_transactions(1, block_info, txs);
@@ -491,7 +491,7 @@ pub(super) mod tests {
         let block_info = BlockInfo::default();
         let batcher_address = valid_blob_batcher_address();
         let batch_inbox_address = ChainConfig::MAINNET.batch_inbox_address;
-        source.batcher_address = batch_inbox_address;
+        source.batch_inbox_address = batch_inbox_address;
         source.chain_provider.insert_block_with_transactions(1, block_info, valid_blob_txs());
         source.blob_fetcher.should_return_not_found = true;
         let err = source.load_blobs(&BlockInfo::default(), batcher_address).await.unwrap_err();
@@ -510,7 +510,7 @@ pub(super) mod tests {
         let block_info = BlockInfo::default();
         let batcher_address = valid_blob_batcher_address();
         let batch_inbox_address = ChainConfig::MAINNET.batch_inbox_address;
-        source.batcher_address = batch_inbox_address;
+        source.batch_inbox_address = batch_inbox_address;
         source.chain_provider.insert_block_with_transactions(1, block_info, valid_blob_txs());
         source.blob_fetcher.should_return_not_found = true;
         let err = source.next(&BlockInfo::default(), batcher_address).await.unwrap_err();
@@ -540,7 +540,7 @@ pub(super) mod tests {
 
     /// Verifies that EIP-4844 blobs from non-batcher transactions are excluded from the pipeline.
     ///
-    /// When the configured batch inbox address (`source.batcher_address`) does not match the
+    /// When the configured batch inbox address (`source.batch_inbox_address`) does not match the
     /// transaction's `to` field, the entire transaction is skipped — no blob hashes are collected
     /// and `data` remains empty. This tests the exclusion path that previously incremented an
     /// index counter regardless of the sender.
@@ -550,7 +550,7 @@ pub(super) mod tests {
     /// 2. Correct batch inbox address → all 5 blobs from the batcher transaction are captured.
     #[test]
     fn test_extract_blob_data_non_batcher_blobs_excluded() {
-        // Case 1: source.batcher_address = Address::ZERO does not match the tx's batch inbox
+        // Case 1: source.batch_inbox_address = Address::ZERO does not match the tx's batch inbox
         // address from `ChainConfig::MAINNET`, so the transaction is skipped and no
         // blobs are captured.
         let source = default_test_blob_source(); // batch_inbox_address = Address::ZERO
@@ -562,7 +562,7 @@ pub(super) mod tests {
         // Case 2: correct batch inbox address → all 5 blobs from the batcher transaction captured.
         let mut source2 = default_test_blob_source();
         let batch_inbox_address = ChainConfig::MAINNET.batch_inbox_address;
-        source2.batcher_address = batch_inbox_address;
+        source2.batch_inbox_address = batch_inbox_address;
         let batcher_address = valid_blob_batcher_address();
         let (data, hashes) = source2.extract_blob_data(valid_blob_txs(), batcher_address);
         assert_eq!(data.len(), 5, "all 5 batcher blobs must be captured");

--- a/crates/consensus/derive/src/sources/ethereum.rs
+++ b/crates/consensus/derive/src/sources/ethereum.rs
@@ -99,8 +99,8 @@ mod tests {
     fn default_test_blob_source() -> BlobSource<TestChainProvider, TestBlobProvider> {
         let chain_provider = TestChainProvider::default();
         let blob_fetcher = TestBlobProvider::default();
-        let batcher_address = Address::default();
-        BlobSource::new(chain_provider, blob_fetcher, batcher_address)
+        let batch_inbox_address = Address::default();
+        BlobSource::new(chain_provider, blob_fetcher, batch_inbox_address)
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

`BlobSource` had a public struct field named `batcher_address` that actually stored the **batch inbox address** — the `to` address that batcher transactions are sent to on L1. Conventionally, `batcher_address` refers to the *signer* / sender key used by the batcher, which is a completely different address.

`CalldataSource` — the sibling data-availability source — already uses the correct name `batch_inbox_address` for the same concept. The inconsistency between the two structs made it easy to misread the field's role, and several test comments explicitly worked around the confusion (e.g. *"When the configured batch inbox address (`source.batcher_address`) does not match…"*).

## Changes

- Rename `BlobSource::batcher_address` → `BlobSource::batch_inbox_address` in `blobs.rs`
- Update the `new()` constructor parameter to match
- Update the `self.batcher_address` usage in `extract_blob_data` to `self.batch_inbox_address`
- Update all test sites that set `source.batcher_address = …` to `source.batch_inbox_address = …`
- Fix the related doc-comment in the same test
- Update the local variable in the `default_test_blob_source` helper in `ethereum.rs`

No behaviour change — pure rename.

## Why this matters

The two addresses serve opposite roles in the filtering logic:

```rust
// destination check — is the tx sent to the batch inbox?
if to != self.batch_inbox_address { continue; }

// sender check — did the batcher sign this tx?
if tx.recover_signer().unwrap_or_default() != batcher_address { continue; }
```

Having both called `batcher_address` in the old code obscured which check was which. The rename brings `BlobSource` in line with `CalldataSource` and makes the two roles unambiguous.