### PR TITLE
docs(access-lists): remove broken link to unpublished spec file

### DIFF
--- a/crates/common/access-lists/README.md
+++ b/crates/common/access-lists/README.md
@@ -2,7 +2,7 @@
 
 A library to build and process Flashblock-level Access Lists (FBALs).
 
-See the [spec](../../../docs/specs/pages/protocol/access-lists.md) for more details.
+<!-- TODO: spec link pending — access-lists.md has not yet been published -->
 
 ## Overview
 


### PR DESCRIPTION
## Summary

Fixes the broken spec link in `crates/common/access-lists/README.md` reported in #2828.

The README referenced `../../../docs/specs/pages/protocol/access-lists.md` which does not exist anywhere in the repository. Any contributor clicking this link gets a file-not-found error.

## Change

Replaced the dangling link with a TODO comment until the spec is published.

**Before:**
```
See the [spec](../../../docs/specs/pages/protocol/access-lists.md) for more details.
```

**After:**
```
<!-- TODO: spec link pending — access-lists.md has not yet been published -->
```

## Why

- The linked file does not exist in `docs/specs/pages/protocol/`
- Leaving a broken link misleads contributors looking for FBAL documentation
- A TODO comment clearly signals the spec is pending without breaking the README

Closes #2828