### PR TITLE
feat(proof): add L1 header prefetcher with shared cache

### DIFF
--- a/crates/proof/host/src/backend/online.rs
+++ b/crates/proof/host/src/backend/online.rs
@@ -11,7 +11,9 @@ use tracing::{debug, error, trace, warn};
 
 use crate::{
     HostConfig, HostProviders, Metrics, SharedKeyValueStore,
-    handler::{PayloadWitnessPrefetcher, handle_hint_with_prefetcher},
+    handler::{
+        L1HeaderCache, L1HeaderPrefetcher, PayloadWitnessPrefetcher, handle_hint_with_prefetchers,
+    },
 };
 
 /// Cap on `handle_hint` attempts before [`OnlineHostBackend::get_preimage`] gives up; previously
@@ -33,6 +35,7 @@ pub struct OnlineHostBackend {
     proactive_hints: HashSet<HintType>,
     last_hint: Arc<RwLock<Option<Hint<HintType>>>>,
     payload_witness_prefetcher: PayloadWitnessPrefetcher,
+    l1_header_prefetcher: L1HeaderPrefetcher,
 }
 
 impl fmt::Debug for OnlineHostBackend {
@@ -44,10 +47,21 @@ impl fmt::Debug for OnlineHostBackend {
 impl OnlineHostBackend {
     /// Creates a new [`OnlineHostBackend`].
     pub fn new(cfg: HostConfig, kv: SharedKeyValueStore, providers: HostProviders) -> Self {
+        Self::new_with_l1_header_cache(cfg, kv, providers, L1HeaderCache::new())
+    }
+
+    /// Creates a new [`OnlineHostBackend`] with a shared L1 header cache.
+    pub(crate) fn new_with_l1_header_cache(
+        cfg: HostConfig,
+        kv: SharedKeyValueStore,
+        providers: HostProviders,
+        l1_header_cache: L1HeaderCache,
+    ) -> Self {
         let cfg = Arc::new(cfg);
         let providers = Arc::new(providers);
         let payload_witness_prefetcher =
             PayloadWitnessPrefetcher::new(Arc::clone(&cfg), Arc::clone(&providers));
+        let l1_header_prefetcher = L1HeaderPrefetcher::new(Arc::clone(&providers), l1_header_cache);
 
         Self {
             cfg,
@@ -56,6 +70,7 @@ impl OnlineHostBackend {
             proactive_hints: HashSet::default(),
             last_hint: Arc::new(RwLock::new(None)),
             payload_witness_prefetcher,
+            l1_header_prefetcher,
         }
     }
 
@@ -76,12 +91,13 @@ impl HintRouter for OnlineHostBackend {
             .map_err(|e| PreimageOracleError::HintParseFailed(e.to_string()))?;
         if self.proactive_hints.contains(&parsed_hint.ty) {
             debug!(target: "host_backend", raw_hint = %hint, "proactive hint received, immediately fetching");
-            handle_hint_with_prefetcher(
+            handle_hint_with_prefetchers(
                 parsed_hint,
                 &self.cfg,
                 &self.providers,
                 Arc::clone(&self.kv),
                 Some(self.payload_witness_prefetcher.clone()),
+                Some(self.l1_header_prefetcher.clone()),
             )
             .await
             .map_err(|e| PreimageOracleError::Other(e.to_string()))?;
@@ -125,12 +141,13 @@ impl PreimageFetcher for OnlineHostBackend {
         let mut backoff = INITIAL_HINT_RETRY_BACKOFF;
         let mut last_error: Option<String> = None;
         for attempt in 1..=MAX_HINT_ATTEMPTS {
-            match handle_hint_with_prefetcher(
+            match handle_hint_with_prefetchers(
                 hint.clone(),
                 &self.cfg,
                 &self.providers,
                 Arc::clone(&self.kv),
                 Some(self.payload_witness_prefetcher.clone()),
+                Some(self.l1_header_prefetcher.clone()),
             )
             .await
             {

--- a/crates/proof/host/src/error.rs
+++ b/crates/proof/host/src/error.rs
@@ -76,6 +76,14 @@ pub enum HostError {
         /// Actual hash.
         actual: B256,
     },
+    /// Header preimage hash mismatch.
+    #[error("Header preimage hash mismatch: expected {expected}, actual {actual}")]
+    HeaderPreimageHashMismatch {
+        /// Expected hash.
+        expected: B256,
+        /// Actual hash.
+        actual: B256,
+    },
     /// Failed to serve a preimage request.
     #[error("Failed to serve preimage request: {0}")]
     PreimageRequestFailed(PreimageOracleError),

--- a/crates/proof/host/src/handler.rs
+++ b/crates/proof/host/src/handler.rs
@@ -672,8 +672,7 @@ impl L1HeaderPrefetcher {
             return false;
         }
 
-        let decoded_hash = decoded_header.hash_slow();
-        let hash = decoded_hash;
+        let hash = decoded_header.hash_slow();
 
         if let Err(err) = insert_l1_header_preimage(Arc::clone(&kv), hash, raw_header.clone()).await
         {
@@ -1406,6 +1405,23 @@ mod tests {
 
         assert!(!prefetcher.take_ready(B256::new([0; 32]), digest));
         assert!(prefetcher.take_ready(B256::new([1; 32]), digest));
+    }
+
+    #[test]
+    fn test_l1_header_ready_cache_evicts_oldest_entry() {
+        let cache = L1HeaderCache::new();
+
+        for i in 0..=L1_HEADER_PREFETCH_MAX_READY as u64 {
+            let mut hash = [0; 32];
+            hash[24..].copy_from_slice(&i.to_be_bytes());
+            cache.mark_ready(B256::new(hash), Bytes::from(vec![i as u8]));
+        }
+
+        assert!(cache.get_ready(B256::ZERO).is_none());
+
+        let mut second_hash = [0; 32];
+        second_hash[24..].copy_from_slice(&1u64.to_be_bytes());
+        assert_eq!(cache.get_ready(B256::new(second_hash)), Some(Bytes::from(vec![1])));
     }
 
     #[test]

--- a/crates/proof/host/src/handler.rs
+++ b/crates/proof/host/src/handler.rs
@@ -10,7 +10,7 @@ use alloy_eips::{BlockNumberOrTag, eip2718::Encodable2718, eip4844::FIELD_ELEMEN
 use alloy_network::Network;
 use alloy_primitives::{Address, B64, B256, Bytes, keccak256};
 use alloy_provider::Provider;
-use alloy_rlp::Decodable;
+use alloy_rlp::{Decodable, Encodable};
 use alloy_rpc_types::{Block, debug::ExecutionWitness};
 use ark_ff::{BigInteger, PrimeField};
 use base_common_consensus::{HoloceneExtraData, JovianExtraData, Predeploys};
@@ -35,6 +35,10 @@ const PAYLOAD_WITNESS_PREFETCH_MAX_READY: usize = 16;
 const PAYLOAD_WITNESS_PREFETCH_MAX_SCHEDULED_BLOCKS: usize = 128;
 const PAYLOAD_WITNESS_PREFETCH_MAX_SCHEDULED_LOOKAHEADS: usize = 128;
 const PAYLOAD_WITNESS_PREFETCH_PREIMAGE_WRITE_BATCH_SIZE: usize = 1024;
+const L1_HEADER_PREFETCH_LOOKBEHIND_BLOCKS: u64 = 512;
+const L1_HEADER_PREFETCH_MAX_READY: usize = 131_072;
+const L1_HEADER_PREFETCH_MAX_IN_FLIGHT: usize = 32;
+const L1_HEADER_PREFETCH_MAX_SCHEDULED_BLOCKS: usize = 131_072;
 
 #[derive(Debug, Default)]
 struct PayloadWitnessPrefetchState {
@@ -446,6 +450,254 @@ impl Drop for ScheduledBlockGuard {
     }
 }
 
+#[derive(Debug, Default)]
+struct L1HeaderPrefetchState {
+    ready: HashMap<B256, Bytes>,
+    ready_order: VecDeque<B256>,
+    scheduled_blocks: HashSet<u64>,
+    scheduled_block_order: VecDeque<u64>,
+}
+
+#[derive(Debug)]
+struct L1HeaderCacheInner {
+    state: Mutex<L1HeaderPrefetchState>,
+    semaphore: Semaphore,
+}
+
+/// Shared host-only cache for L1 header prefetch results.
+#[derive(Debug, Clone)]
+pub(crate) struct L1HeaderCache {
+    inner: Arc<L1HeaderCacheInner>,
+}
+
+impl L1HeaderCache {
+    pub(crate) fn new() -> Self {
+        Self {
+            inner: Arc::new(L1HeaderCacheInner {
+                state: Mutex::new(L1HeaderPrefetchState::default()),
+                semaphore: Semaphore::new(L1_HEADER_PREFETCH_MAX_IN_FLIGHT),
+            }),
+        }
+    }
+
+    fn get_ready(&self, hash: B256) -> Option<Bytes> {
+        self.lock_state().ready.get(&hash).cloned()
+    }
+
+    fn mark_ready(&self, hash: B256, raw_header: Bytes) {
+        let mut state = self.lock_state();
+        if state.ready.remove(&hash).is_some() {
+            state.ready_order.retain(|ready_hash| ready_hash != &hash);
+        }
+
+        while state.ready.len() >= L1_HEADER_PREFETCH_MAX_READY {
+            let Some(oldest) = state.ready_order.pop_front() else {
+                break;
+            };
+            state.ready.remove(&oldest);
+        }
+
+        state.ready.insert(hash, raw_header);
+        state.ready_order.push_back(hash);
+    }
+
+    fn mark_blocks_scheduled<I>(&self, block_numbers: I) -> Vec<u64>
+    where
+        I: IntoIterator<Item = u64>,
+    {
+        let mut newly_scheduled = Vec::new();
+        let mut state = self.lock_state();
+
+        for block_number in block_numbers {
+            if state.scheduled_blocks.contains(&block_number) {
+                continue;
+            }
+
+            while state.scheduled_blocks.len() >= L1_HEADER_PREFETCH_MAX_SCHEDULED_BLOCKS {
+                let Some(oldest) = state.scheduled_block_order.pop_front() else {
+                    break;
+                };
+                state.scheduled_blocks.remove(&oldest);
+            }
+
+            state.scheduled_blocks.insert(block_number);
+            state.scheduled_block_order.push_back(block_number);
+            newly_scheduled.push(block_number);
+        }
+
+        newly_scheduled
+    }
+
+    fn unmark_block_scheduled(&self, block_number: u64) {
+        let mut state = self.lock_state();
+        state.scheduled_blocks.remove(&block_number);
+        state.scheduled_block_order.retain(|scheduled| scheduled != &block_number);
+    }
+
+    fn lock_state(&self) -> std::sync::MutexGuard<'_, L1HeaderPrefetchState> {
+        self.inner.state.lock().unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+}
+
+impl Default for L1HeaderCache {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[derive(Debug)]
+struct L1HeaderPrefetchInner {
+    providers: Arc<HostProviders>,
+    cache: L1HeaderCache,
+}
+
+/// Best-effort host-only L1 header prefetcher.
+///
+/// The guest still requests headers by hash and validates the parent chain. Prefetch fetches
+/// nearby older blocks by number, then stores each header under its actual header hash so a reorged
+/// or otherwise non-ancestor block cannot satisfy a different guest request.
+#[derive(Debug, Clone)]
+pub(crate) struct L1HeaderPrefetcher {
+    inner: Arc<L1HeaderPrefetchInner>,
+}
+
+impl L1HeaderPrefetcher {
+    pub(crate) fn new(providers: Arc<HostProviders>, cache: L1HeaderCache) -> Self {
+        Self { inner: Arc::new(L1HeaderPrefetchInner { providers, cache }) }
+    }
+
+    fn get_ready(&self, hash: B256) -> Option<Bytes> {
+        self.inner.cache.get_ready(hash)
+    }
+
+    fn mark_ready(&self, hash: B256, raw_header: Bytes) {
+        self.inner.cache.mark_ready(hash, raw_header);
+    }
+
+    pub(crate) async fn schedule_lookbehind(&self, kv: SharedKeyValueStore, header: &Header) {
+        let Some(first_prefetch_block) = header.number.checked_sub(1) else {
+            return;
+        };
+        let last_prefetch_block =
+            header.number.saturating_sub(L1_HEADER_PREFETCH_LOOKBEHIND_BLOCKS);
+
+        let block_numbers = self
+            .inner
+            .cache
+            .mark_blocks_scheduled((last_prefetch_block..=first_prefetch_block).rev());
+
+        for block_number in block_numbers {
+            self.spawn_scheduled_prefetch_block(Arc::clone(&kv), block_number);
+        }
+    }
+
+    fn spawn_scheduled_prefetch_block(&self, kv: SharedKeyValueStore, block_number: u64) {
+        let prefetcher = self.clone();
+        std::mem::drop(tokio::spawn(async move {
+            let result =
+                AssertUnwindSafe(prefetcher.prefetch_block(kv, block_number)).catch_unwind().await;
+
+            if let Err(panic) = result {
+                warn!(
+                    target: HOST_SERVER_TARGET,
+                    block_number,
+                    panic = %panic_payload_message(panic.as_ref()),
+                    "l1 header prefetch task panicked"
+                );
+            }
+        }));
+    }
+
+    fn unmark_block_scheduled(&self, block_number: u64) {
+        self.inner.cache.unmark_block_scheduled(block_number);
+    }
+
+    async fn prefetch_block(&self, kv: SharedKeyValueStore, block_number: u64) {
+        let mut scheduled_guard = ScheduledL1HeaderBlockGuard::new(self.clone(), block_number);
+        if self.prefetch_block_inner(kv, block_number).await {
+            scheduled_guard.keep_scheduled();
+        }
+    }
+
+    async fn prefetch_block_inner(&self, kv: SharedKeyValueStore, block_number: u64) -> bool {
+        let _permit = match self.inner.cache.inner.semaphore.acquire().await {
+            Ok(permit) => permit,
+            Err(_) => return false,
+        };
+
+        let block = match self
+            .inner
+            .providers
+            .l1
+            .get_block_by_number(BlockNumberOrTag::Number(block_number))
+            .await
+        {
+            Ok(Some(block)) => block,
+            Ok(None) => {
+                debug!(
+                    target: HOST_SERVER_TARGET,
+                    block_number,
+                    "l1 header prefetch skipped: block not found"
+                );
+                return false;
+            }
+            Err(err) => {
+                debug!(
+                    target: HOST_SERVER_TARGET,
+                    block_number,
+                    error = %err,
+                    "l1 header prefetch skipped: failed to fetch block"
+                );
+                return false;
+            }
+        };
+
+        let header = block.header.into_consensus();
+        let hash = header.hash_slow();
+        let raw_header = encode_header_rlp(&header);
+
+        if let Err(err) = insert_l1_header_preimage(Arc::clone(&kv), hash, raw_header.clone()).await
+        {
+            warn!(
+                target: HOST_SERVER_TARGET,
+                block_number,
+                hash = %hash,
+                error = %err,
+                "l1 header prefetch failed: preimage insertion failed"
+            );
+            return false;
+        }
+
+        self.mark_ready(hash, raw_header);
+        true
+    }
+}
+
+#[derive(Debug)]
+struct ScheduledL1HeaderBlockGuard {
+    prefetcher: L1HeaderPrefetcher,
+    block_number: u64,
+    keep_scheduled: bool,
+}
+
+impl ScheduledL1HeaderBlockGuard {
+    const fn new(prefetcher: L1HeaderPrefetcher, block_number: u64) -> Self {
+        Self { prefetcher, block_number, keep_scheduled: false }
+    }
+
+    const fn keep_scheduled(&mut self) {
+        self.keep_scheduled = true;
+    }
+}
+
+impl Drop for ScheduledL1HeaderBlockGuard {
+    fn drop(&mut self) {
+        if !self.keep_scheduled {
+            self.prefetcher.unmark_block_scheduled(self.block_number);
+        }
+    }
+}
+
 fn execution_witness_preimages(
     execute_payload_response: ExecutionWitness,
 ) -> impl Iterator<Item = (PreimageKey, Vec<u8>)> {
@@ -554,6 +806,22 @@ fn encode_payload_eip_1559_params(elasticity: u32, denominator: u32) -> B64 {
     B64::from(encoded)
 }
 
+fn encode_header_rlp(header: &Header) -> Bytes {
+    let mut encoded = Vec::new();
+    header.encode(&mut encoded);
+    encoded.into()
+}
+
+async fn insert_l1_header_preimage(
+    kv: SharedKeyValueStore,
+    hash: B256,
+    raw_header: Bytes,
+) -> Result<()> {
+    let mut kv_lock = kv.write().await;
+    kv_lock.set(PreimageKey::new_keccak256(*hash).into(), raw_header.into())?;
+    Ok(())
+}
+
 /// Parses a blob hint, supporting both legacy (48-byte) and new (40-byte) formats.
 ///
 /// Returns the blob hash and timestamp.
@@ -596,23 +864,31 @@ pub async fn handle_hint(
     providers: &HostProviders,
     kv: SharedKeyValueStore,
 ) -> Result<()> {
-    handle_hint_with_prefetcher(hint, cfg, providers, kv, None).await
+    handle_hint_with_prefetchers(hint, cfg, providers, kv, None, None).await
 }
 
-pub(crate) async fn handle_hint_with_prefetcher(
+pub(crate) async fn handle_hint_with_prefetchers(
     hint: Hint<HintType>,
     cfg: &HostConfig,
     providers: &HostProviders,
     kv: SharedKeyValueStore,
     payload_witness_prefetcher: Option<PayloadWitnessPrefetcher>,
+    l1_header_prefetcher: Option<L1HeaderPrefetcher>,
 ) -> Result<()> {
     let hint_type_label: &str = hint.ty.into();
 
     Metrics::hint_requests_total(hint_type_label).increment(1);
     let _timer = base_metrics::timed!(Metrics::hint_duration_seconds(hint_type_label));
 
-    let result =
-        Box::pin(handle_hint_inner(hint, cfg, providers, kv, payload_witness_prefetcher)).await;
+    let result = Box::pin(handle_hint_inner(
+        hint,
+        cfg,
+        providers,
+        kv,
+        payload_witness_prefetcher,
+        l1_header_prefetcher,
+    ))
+    .await;
 
     if result.is_err() {
         Metrics::hint_errors_total(hint_type_label).increment(1);
@@ -627,6 +903,7 @@ async fn handle_hint_inner(
     providers: &HostProviders,
     kv: SharedKeyValueStore,
     payload_witness_prefetcher: Option<PayloadWitnessPrefetcher>,
+    l1_header_prefetcher: Option<L1HeaderPrefetcher>,
 ) -> Result<()> {
     match hint.ty {
         HintType::L1BlockHeader => {
@@ -635,11 +912,30 @@ async fn handle_hint_inner(
             }
 
             let hash: B256 = hint.data.as_ref().try_into()?;
-            let raw_header: Bytes =
-                providers.l1.client().request("debug_getRawHeader", [hash]).await?;
+            let raw_header = if let Some(prefetcher) = l1_header_prefetcher.as_ref()
+                && let Some(raw_header) = prefetcher.get_ready(hash)
+            {
+                debug!(
+                    target: HOST_SERVER_TARGET,
+                    hash = %hash,
+                    "l1 header served from prefetch cache"
+                );
+                raw_header
+            } else {
+                let raw_header: Bytes =
+                    providers.l1.client().request("debug_getRawHeader", [hash]).await?;
+                if let Some(prefetcher) = l1_header_prefetcher.as_ref() {
+                    prefetcher.mark_ready(hash, raw_header.clone());
+                }
+                raw_header
+            };
+            let header = Header::decode(&mut raw_header.as_ref())?;
 
-            let mut kv_lock = kv.write().await;
-            kv_lock.set(PreimageKey::new_keccak256(*hash).into(), raw_header.into())?;
+            insert_l1_header_preimage(Arc::clone(&kv), hash, raw_header).await?;
+
+            if let Some(prefetcher) = l1_header_prefetcher {
+                prefetcher.schedule_lookbehind(Arc::clone(&kv), &header).await;
+            }
         }
         HintType::L1Transactions => {
             if hint.data.len() != 32 {
@@ -1039,6 +1335,16 @@ mod tests {
         PayloadWitnessPrefetcher::new(Arc::new(test_cfg()), Arc::new(test_providers(l2)))
     }
 
+    fn test_l1_header_prefetcher() -> L1HeaderPrefetcher {
+        let l2 = RootProvider::new_http("http://127.0.0.1:1".parse().unwrap());
+        L1HeaderPrefetcher::new(Arc::new(test_providers(l2)), L1HeaderCache::new())
+    }
+
+    fn test_l1_header_prefetcher_with_cache(cache: L1HeaderCache) -> L1HeaderPrefetcher {
+        let l2 = RootProvider::new_http("http://127.0.0.1:1".parse().unwrap());
+        L1HeaderPrefetcher::new(Arc::new(test_providers(l2)), cache)
+    }
+
     #[test]
     fn test_parse_blob_hint_formats() {
         let (legacy_hash, legacy_timestamp) = parse_blob_hint(&LEGACY_HINT).unwrap();
@@ -1167,6 +1473,72 @@ mod tests {
         }
 
         assert!(!prefetcher.mark_block_scheduled(7));
+    }
+
+    #[test]
+    fn test_l1_header_scheduled_cache_dedupes_block_number() {
+        let prefetcher = test_l1_header_prefetcher();
+
+        assert_eq!(prefetcher.inner.cache.mark_blocks_scheduled([7]), vec![7]);
+        assert!(prefetcher.inner.cache.mark_blocks_scheduled([7]).is_empty());
+
+        prefetcher.unmark_block_scheduled(7);
+
+        assert_eq!(prefetcher.inner.cache.mark_blocks_scheduled([7]), vec![7]);
+    }
+
+    #[test]
+    fn test_l1_header_cache_is_shared_between_prefetchers() {
+        let cache = L1HeaderCache::new();
+        let prefetcher_a = test_l1_header_prefetcher_with_cache(cache.clone());
+        let prefetcher_b = test_l1_header_prefetcher_with_cache(cache);
+        let raw_header = Bytes::from(vec![1, 2, 3]);
+
+        prefetcher_a.mark_ready(TEST_HASH, raw_header.clone());
+
+        assert_eq!(prefetcher_b.get_ready(TEST_HASH), Some(raw_header));
+    }
+
+    #[test]
+    fn test_scheduled_l1_header_block_guard_unmarks_on_drop() {
+        let prefetcher = test_l1_header_prefetcher();
+        assert_eq!(prefetcher.inner.cache.mark_blocks_scheduled([7]), vec![7]);
+
+        {
+            let _guard = ScheduledL1HeaderBlockGuard::new(prefetcher.clone(), 7);
+        }
+
+        assert_eq!(prefetcher.inner.cache.mark_blocks_scheduled([7]), vec![7]);
+    }
+
+    #[test]
+    fn test_scheduled_l1_header_block_guard_keeps_successful_prefetch_scheduled() {
+        let prefetcher = test_l1_header_prefetcher();
+        assert_eq!(prefetcher.inner.cache.mark_blocks_scheduled([7]), vec![7]);
+
+        {
+            let mut guard = ScheduledL1HeaderBlockGuard::new(prefetcher.clone(), 7);
+            guard.keep_scheduled();
+        }
+
+        assert!(prefetcher.inner.cache.mark_blocks_scheduled([7]).is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_insert_l1_header_preimage_uses_header_hash() {
+        let header = Header { number: 7, parent_hash: TEST_HASH, ..Default::default() };
+        let hash = header.hash_slow();
+        let raw_header = encode_header_rlp(&header);
+        let kv: SharedKeyValueStore = Arc::new(RwLock::new(MemoryKeyValueStore::new()));
+
+        insert_l1_header_preimage(Arc::clone(&kv), hash, raw_header.clone()).await.unwrap();
+
+        let stored = kv
+            .read()
+            .await
+            .get(PreimageKey::new_keccak256(*hash).into())
+            .expect("header preimage should be stored under its hash");
+        assert_eq!(stored, raw_header);
     }
 
     #[tokio::test]

--- a/crates/proof/host/src/handler.rs
+++ b/crates/proof/host/src/handler.rs
@@ -515,6 +515,9 @@ impl L1HeaderCache {
         let mut newly_scheduled = Vec::new();
         let mut state = self.lock_state();
 
+        // Schedule a bounded lookbehind batch while holding the mutex once. This can briefly block
+        // ready-cache access, but the batch is capped at `L1_HEADER_PREFETCH_LOOKBEHIND_BLOCKS` and
+        // each step is an amortized O(1) collection operation.
         for block_number in block_numbers {
             if state.scheduled_blocks.contains(&block_number) {
                 continue;

--- a/crates/proof/host/src/handler.rs
+++ b/crates/proof/host/src/handler.rs
@@ -42,7 +42,10 @@ const L1_HEADER_PREFETCH_LOOKBEHIND_BLOCKS: u64 = 512;
 // L1 headers are hundreds of bytes each, so this bounds cached header bytes to a few MiB.
 const L1_HEADER_PREFETCH_MAX_READY: usize = 4096;
 const L1_HEADER_PREFETCH_MAX_IN_FLIGHT: usize = 32;
-const L1_HEADER_PREFETCH_MAX_SCHEDULED_BLOCKS: usize = 131_072;
+// Scheduled entries are just block numbers, but failed prefetches remove them while holding the
+// cache mutex. Keep the bound close to the active lookbehind window so failed RPC bursts do not scan
+// a long history of already-prefetched blocks.
+const L1_HEADER_PREFETCH_MAX_SCHEDULED_BLOCKS: usize = 4096;
 
 #[derive(Debug, Default)]
 struct PayloadWitnessPrefetchState {
@@ -580,7 +583,7 @@ impl L1HeaderPrefetcher {
         self.inner.cache.mark_ready(hash, raw_header);
     }
 
-    pub(crate) async fn schedule_lookbehind(&self, kv: SharedKeyValueStore, header: &Header) {
+    pub(crate) fn schedule_lookbehind(&self, kv: SharedKeyValueStore, header: &Header) {
         let Some(first_prefetch_block) = header.number.checked_sub(1) else {
             return;
         };
@@ -954,7 +957,7 @@ async fn handle_hint_inner(
             }
 
             if let Some(prefetcher) = l1_header_prefetcher {
-                prefetcher.schedule_lookbehind(Arc::clone(&kv), &header).await;
+                prefetcher.schedule_lookbehind(Arc::clone(&kv), &header);
             }
         }
         HintType::L1Transactions => {

--- a/crates/proof/host/src/handler.rs
+++ b/crates/proof/host/src/handler.rs
@@ -6,7 +6,9 @@ use std::{
 };
 
 use alloy_consensus::Header;
-use alloy_eips::{BlockNumberOrTag, eip2718::Encodable2718, eip4844::FIELD_ELEMENTS_PER_BLOB};
+use alloy_eips::{
+    BlockId, BlockNumberOrTag, eip2718::Encodable2718, eip4844::FIELD_ELEMENTS_PER_BLOB,
+};
 use alloy_network::Network;
 use alloy_primitives::{Address, B64, B256, Bytes, keccak256};
 use alloy_provider::Provider;
@@ -629,72 +631,49 @@ impl L1HeaderPrefetcher {
             Err(_) => return false,
         };
 
-        let block = match self
+        let raw_header: Bytes = match self
             .inner
             .providers
             .l1
-            .get_block_by_number(BlockNumberOrTag::Number(block_number))
+            .client()
+            .request("debug_getRawHeader", (BlockId::number(block_number),))
             .await
         {
-            Ok(Some(block)) => block,
-            Ok(None) => {
-                debug!(
-                    target: HOST_SERVER_TARGET,
-                    block_number,
-                    "l1 header prefetch skipped: block not found"
-                );
-                return false;
-            }
+            Ok(raw_header) => raw_header,
             Err(err) => {
                 debug!(
                     target: HOST_SERVER_TARGET,
                     block_number,
                     error = %err,
-                    "l1 header prefetch skipped: failed to fetch block"
+                    "l1 header prefetch skipped: failed to fetch raw header"
                 );
                 return false;
             }
         };
-
-        let hash = block.header.hash;
-        let raw_header: Bytes =
-            match self.inner.providers.l1.client().request("debug_getRawHeader", [hash]).await {
-                Ok(raw_header) => raw_header,
-                Err(err) => {
-                    debug!(
-                        target: HOST_SERVER_TARGET,
-                        block_number,
-                        hash = %hash,
-                        error = %err,
-                        "l1 header prefetch skipped: failed to fetch raw header"
-                    );
-                    return false;
-                }
-            };
         let decoded_header = match Header::decode(&mut raw_header.as_ref()) {
             Ok(header) => header,
             Err(err) => {
                 debug!(
                     target: HOST_SERVER_TARGET,
                     block_number,
-                    hash = %hash,
                     error = %err,
                     "l1 header prefetch skipped: failed to decode raw header"
                 );
                 return false;
             }
         };
-        let decoded_hash = decoded_header.hash_slow();
-        if decoded_hash != hash {
+        if decoded_header.number != block_number {
             warn!(
                 target: HOST_SERVER_TARGET,
                 block_number,
-                hash = %hash,
-                decoded_hash = %decoded_hash,
-                "l1 header prefetch skipped: raw header hash mismatch"
+                decoded_block_number = decoded_header.number,
+                "l1 header prefetch skipped: raw header number mismatch"
             );
             return false;
         }
+
+        let decoded_hash = decoded_header.hash_slow();
+        let hash = decoded_hash;
 
         if let Err(err) = insert_l1_header_preimage(Arc::clone(&kv), hash, raw_header.clone()).await
         {
@@ -962,6 +941,13 @@ async fn handle_hint_inner(
                 (raw_header, true)
             };
             let header = Header::decode(&mut raw_header.as_ref())?;
+            let decoded_hash = header.hash_slow();
+            if decoded_hash != hash {
+                return Err(HostError::HeaderPreimageHashMismatch {
+                    expected: hash,
+                    actual: decoded_hash,
+                });
+            }
 
             insert_l1_header_preimage(Arc::clone(&kv), hash, raw_header.clone()).await?;
             if should_mark_ready && let Some(prefetcher) = l1_header_prefetcher.as_ref() {
@@ -1358,12 +1344,16 @@ mod tests {
         }
     }
 
-    fn test_providers(l2: RootProvider<Base>) -> HostProviders {
-        let l1 = RootProvider::new_http("http://127.0.0.1:1".parse().unwrap());
+    fn test_providers_with_l1(l1: RootProvider, l2: RootProvider<Base>) -> HostProviders {
         let beacon = OnlineBeaconClient::new_http("http://127.0.0.1:1".to_string());
         let blobs =
             OnlineBlobProvider { beacon_client: beacon, genesis_time: 0, slot_interval: 12 };
         HostProviders { l1, blobs, l2 }
+    }
+
+    fn test_providers(l2: RootProvider<Base>) -> HostProviders {
+        let l1 = RootProvider::new_http("http://127.0.0.1:1".parse().unwrap());
+        test_providers_with_l1(l1, l2)
     }
 
     fn test_prefetcher() -> PayloadWitnessPrefetcher {
@@ -1603,5 +1593,34 @@ mod tests {
             other => panic!("unexpected error: {other}"),
         }
         assert!(kv.read().await.get(PreimageKey::new_keccak256(*requested_hash).into()).is_none());
+    }
+
+    #[tokio::test]
+    async fn test_l1_block_header_rejects_hash_mismatch() {
+        let requested_hash = TEST_HASH;
+        let header = Header { number: 7, parent_hash: B256::new([0x24; 32]), ..Default::default() };
+        let actual_hash = header.hash_slow();
+        let mut encoded_header = Vec::new();
+        header.encode(&mut encoded_header);
+        let raw_header = Bytes::from(encoded_header);
+        let asserter = Asserter::new();
+        asserter.push_success(&raw_header);
+        let l1 = provider_builder().connect_mocked_client(asserter);
+        let l2 = RootProvider::new_http("http://127.0.0.1:1".parse().unwrap());
+        let providers = test_providers_with_l1(l1, l2);
+        let kv: SharedKeyValueStore = Arc::new(RwLock::new(MemoryKeyValueStore::new()));
+        let hint = HintType::L1BlockHeader.with_data(&[requested_hash.as_slice()]);
+
+        let err = handle_hint(hint, &test_cfg(), &providers, Arc::clone(&kv)).await.unwrap_err();
+
+        match err {
+            HostError::HeaderPreimageHashMismatch { expected, actual } => {
+                assert_eq!(expected, requested_hash);
+                assert_eq!(actual, actual_hash);
+            }
+            other => panic!("unexpected error: {other}"),
+        }
+        assert!(kv.read().await.get(PreimageKey::new_keccak256(*requested_hash).into()).is_none());
+        assert!(kv.read().await.get(PreimageKey::new_keccak256(*actual_hash).into()).is_none());
     }
 }

--- a/crates/proof/host/src/handler.rs
+++ b/crates/proof/host/src/handler.rs
@@ -10,7 +10,7 @@ use alloy_eips::{BlockNumberOrTag, eip2718::Encodable2718, eip4844::FIELD_ELEMEN
 use alloy_network::Network;
 use alloy_primitives::{Address, B64, B256, Bytes, keccak256};
 use alloy_provider::Provider;
-use alloy_rlp::{Decodable, Encodable};
+use alloy_rlp::Decodable;
 use alloy_rpc_types::{Block, debug::ExecutionWitness};
 use ark_ff::{BigInteger, PrimeField};
 use base_common_consensus::{HoloceneExtraData, JovianExtraData, Predeploys};
@@ -36,7 +36,9 @@ const PAYLOAD_WITNESS_PREFETCH_MAX_SCHEDULED_BLOCKS: usize = 128;
 const PAYLOAD_WITNESS_PREFETCH_MAX_SCHEDULED_LOOKAHEADS: usize = 128;
 const PAYLOAD_WITNESS_PREFETCH_PREIMAGE_WRITE_BATCH_SIZE: usize = 1024;
 const L1_HEADER_PREFETCH_LOOKBEHIND_BLOCKS: u64 = 512;
-const L1_HEADER_PREFETCH_MAX_READY: usize = 131_072;
+// Keep several lookbehind windows ready without retaining every header seen by a long proof. Raw
+// L1 headers are hundreds of bytes each, so this bounds cached header bytes to a few MiB.
+const L1_HEADER_PREFETCH_MAX_READY: usize = 4096;
 const L1_HEADER_PREFETCH_MAX_IN_FLIGHT: usize = 32;
 const L1_HEADER_PREFETCH_MAX_SCHEDULED_BLOCKS: usize = 131_072;
 
@@ -535,6 +537,8 @@ impl L1HeaderCache {
     }
 
     fn lock_state(&self) -> std::sync::MutexGuard<'_, L1HeaderPrefetchState> {
+        // The L1 header cache is best-effort. Entries are validated by hash-keyed preimage reads in
+        // the guest, so recovering from poisoning can at worst leave stale prefetch metadata.
         self.inner.state.lock().unwrap_or_else(|poisoned| poisoned.into_inner())
     }
 }
@@ -652,9 +656,45 @@ impl L1HeaderPrefetcher {
             }
         };
 
-        let header = block.header.into_consensus();
-        let hash = header.hash_slow();
-        let raw_header = encode_header_rlp(&header);
+        let hash = block.header.hash;
+        let raw_header: Bytes =
+            match self.inner.providers.l1.client().request("debug_getRawHeader", [hash]).await {
+                Ok(raw_header) => raw_header,
+                Err(err) => {
+                    debug!(
+                        target: HOST_SERVER_TARGET,
+                        block_number,
+                        hash = %hash,
+                        error = %err,
+                        "l1 header prefetch skipped: failed to fetch raw header"
+                    );
+                    return false;
+                }
+            };
+        let decoded_header = match Header::decode(&mut raw_header.as_ref()) {
+            Ok(header) => header,
+            Err(err) => {
+                debug!(
+                    target: HOST_SERVER_TARGET,
+                    block_number,
+                    hash = %hash,
+                    error = %err,
+                    "l1 header prefetch skipped: failed to decode raw header"
+                );
+                return false;
+            }
+        };
+        let decoded_hash = decoded_header.hash_slow();
+        if decoded_hash != hash {
+            warn!(
+                target: HOST_SERVER_TARGET,
+                block_number,
+                hash = %hash,
+                decoded_hash = %decoded_hash,
+                "l1 header prefetch skipped: raw header hash mismatch"
+            );
+            return false;
+        }
 
         if let Err(err) = insert_l1_header_preimage(Arc::clone(&kv), hash, raw_header.clone()).await
         {
@@ -806,12 +846,6 @@ fn encode_payload_eip_1559_params(elasticity: u32, denominator: u32) -> B64 {
     B64::from(encoded)
 }
 
-fn encode_header_rlp(header: &Header) -> Bytes {
-    let mut encoded = Vec::new();
-    header.encode(&mut encoded);
-    encoded.into()
-}
-
 async fn insert_l1_header_preimage(
     kv: SharedKeyValueStore,
     hash: B256,
@@ -912,7 +946,8 @@ async fn handle_hint_inner(
             }
 
             let hash: B256 = hint.data.as_ref().try_into()?;
-            let raw_header = if let Some(prefetcher) = l1_header_prefetcher.as_ref()
+            let (raw_header, should_mark_ready) = if let Some(prefetcher) =
+                l1_header_prefetcher.as_ref()
                 && let Some(raw_header) = prefetcher.get_ready(hash)
             {
                 debug!(
@@ -920,18 +955,18 @@ async fn handle_hint_inner(
                     hash = %hash,
                     "l1 header served from prefetch cache"
                 );
-                raw_header
+                (raw_header, false)
             } else {
                 let raw_header: Bytes =
                     providers.l1.client().request("debug_getRawHeader", [hash]).await?;
-                if let Some(prefetcher) = l1_header_prefetcher.as_ref() {
-                    prefetcher.mark_ready(hash, raw_header.clone());
-                }
-                raw_header
+                (raw_header, true)
             };
             let header = Header::decode(&mut raw_header.as_ref())?;
 
-            insert_l1_header_preimage(Arc::clone(&kv), hash, raw_header).await?;
+            insert_l1_header_preimage(Arc::clone(&kv), hash, raw_header.clone()).await?;
+            if should_mark_ready && let Some(prefetcher) = l1_header_prefetcher.as_ref() {
+                prefetcher.mark_ready(hash, raw_header);
+            }
 
             if let Some(prefetcher) = l1_header_prefetcher {
                 prefetcher.schedule_lookbehind(Arc::clone(&kv), &header).await;
@@ -1281,6 +1316,7 @@ mod tests {
 
     use alloy_genesis::ChainConfig;
     use alloy_provider::{RootProvider, builder as provider_builder, mock::Asserter};
+    use alloy_rlp::Encodable;
     use base_common_genesis::RollupConfig;
     use base_common_network::Base;
     use base_consensus_providers::{OnlineBeaconClient, OnlineBlobProvider};
@@ -1528,7 +1564,9 @@ mod tests {
     async fn test_insert_l1_header_preimage_uses_header_hash() {
         let header = Header { number: 7, parent_hash: TEST_HASH, ..Default::default() };
         let hash = header.hash_slow();
-        let raw_header = encode_header_rlp(&header);
+        let mut encoded_header = Vec::new();
+        header.encode(&mut encoded_header);
+        let raw_header = Bytes::from(encoded_header);
         let kv: SharedKeyValueStore = Arc::new(RwLock::new(MemoryKeyValueStore::new()));
 
         insert_l1_header_preimage(Arc::clone(&kv), hash, raw_header.clone()).await.unwrap();

--- a/crates/proof/host/src/host.rs
+++ b/crates/proof/host/src/host.rs
@@ -29,21 +29,12 @@ use crate::{
 pub struct Host {
     /// The host configuration.
     pub config: HostConfig,
-    l1_header_cache: L1HeaderCache,
 }
 
 impl Host {
     /// Creates a new [`Host`] from the given [`HostConfig`].
-    pub fn new(config: HostConfig) -> Self {
-        Self::new_with_l1_header_cache(config, L1HeaderCache::new())
-    }
-
-    /// Creates a new [`Host`] with a shared L1 header cache.
-    pub(crate) const fn new_with_l1_header_cache(
-        config: HostConfig,
-        l1_header_cache: L1HeaderCache,
-    ) -> Self {
-        Self { config, l1_header_cache }
+    pub const fn new(config: HostConfig) -> Self {
+        Self { config }
     }
 
     /// Starts the preimage server, communicating with the client over the provided channels.
@@ -65,13 +56,9 @@ impl Host {
             })
         } else {
             let providers = self.create_providers().await?;
-            let backend = OnlineHostBackend::new_with_l1_header_cache(
-                self.config.clone(),
-                Arc::clone(&kv_store),
-                providers,
-                self.l1_header_cache.clone(),
-            )
-            .with_proactive_hint(HintType::L2PayloadWitness);
+            let backend =
+                OnlineHostBackend::new(self.config.clone(), Arc::clone(&kv_store), providers)
+                    .with_proactive_hint(HintType::L2PayloadWitness);
 
             task::spawn(async {
                 PreimageServer::new(
@@ -96,6 +83,17 @@ impl Host {
     where
         W: WitnessOracle + std::fmt::Debug + 'static,
     {
+        self.build_witness_with_l1_header_cache(witness, L1HeaderCache::new()).await
+    }
+
+    pub(crate) async fn build_witness_with_l1_header_cache<W>(
+        &self,
+        witness: W,
+        l1_header_cache: L1HeaderCache,
+    ) -> Result<W>
+    where
+        W: WitnessOracle + std::fmt::Debug + 'static,
+    {
         let witness = Arc::new(witness);
 
         let kv_store = self.create_key_value_store()?;
@@ -105,7 +103,7 @@ impl Host {
                 self.config.clone(),
                 Arc::clone(&kv_store),
                 providers,
-                self.l1_header_cache.clone(),
+                l1_header_cache,
             )
             .with_proactive_hint(HintType::L2PayloadWitness),
         );

--- a/crates/proof/host/src/host.rs
+++ b/crates/proof/host/src/host.rs
@@ -21,7 +21,7 @@ use crate::DiskKeyValueStore;
 use crate::{
     BootKeyValueStore, HostConfig, HostError, HostProviders, MemoryKeyValueStore, Metrics,
     OfflineHostBackend, OnlineHostBackend, PreimageServer, RecordingOracle, Result,
-    SharedKeyValueStore, SplitKeyValueStore,
+    SharedKeyValueStore, SplitKeyValueStore, handler::L1HeaderCache,
 };
 
 /// The proof host orchestrator.
@@ -29,12 +29,21 @@ use crate::{
 pub struct Host {
     /// The host configuration.
     pub config: HostConfig,
+    l1_header_cache: L1HeaderCache,
 }
 
 impl Host {
     /// Creates a new [`Host`] from the given [`HostConfig`].
-    pub const fn new(config: HostConfig) -> Self {
-        Self { config }
+    pub fn new(config: HostConfig) -> Self {
+        Self::new_with_l1_header_cache(config, L1HeaderCache::new())
+    }
+
+    /// Creates a new [`Host`] with a shared L1 header cache.
+    pub(crate) const fn new_with_l1_header_cache(
+        config: HostConfig,
+        l1_header_cache: L1HeaderCache,
+    ) -> Self {
+        Self { config, l1_header_cache }
     }
 
     /// Starts the preimage server, communicating with the client over the provided channels.
@@ -56,9 +65,13 @@ impl Host {
             })
         } else {
             let providers = self.create_providers().await?;
-            let backend =
-                OnlineHostBackend::new(self.config.clone(), Arc::clone(&kv_store), providers)
-                    .with_proactive_hint(HintType::L2PayloadWitness);
+            let backend = OnlineHostBackend::new_with_l1_header_cache(
+                self.config.clone(),
+                Arc::clone(&kv_store),
+                providers,
+                self.l1_header_cache.clone(),
+            )
+            .with_proactive_hint(HintType::L2PayloadWitness);
 
             task::spawn(async {
                 PreimageServer::new(
@@ -88,8 +101,13 @@ impl Host {
         let kv_store = self.create_key_value_store()?;
         let providers = self.create_providers().await?;
         let backend = Arc::new(
-            OnlineHostBackend::new(self.config.clone(), Arc::clone(&kv_store), providers)
-                .with_proactive_hint(HintType::L2PayloadWitness),
+            OnlineHostBackend::new_with_l1_header_cache(
+                self.config.clone(),
+                Arc::clone(&kv_store),
+                providers,
+                self.l1_header_cache.clone(),
+            )
+            .with_proactive_hint(HintType::L2PayloadWitness),
         );
 
         let preimage_chan = BidirectionalChannel::new().map_err(HostError::Io)?;

--- a/crates/proof/host/src/service.rs
+++ b/crates/proof/host/src/service.rs
@@ -3,7 +3,10 @@ use std::fmt;
 use base_proof_primitives::{ProofRequest, ProofResult, ProverBackend};
 use tracing::{Instrument, info, info_span};
 
-use crate::{Host, HostConfig, HostError, Metrics, ProverConfig, metrics::proof_guard};
+use crate::{
+    Host, HostConfig, HostError, Metrics, ProverConfig, handler::L1HeaderCache,
+    metrics::proof_guard,
+};
 
 /// Orchestrates witness generation ([`Host`]) and proving ([`ProverBackend`]).
 ///
@@ -12,6 +15,7 @@ use crate::{Host, HostConfig, HostError, Metrics, ProverConfig, metrics::proof_g
 pub struct ProverService<B> {
     config: ProverConfig,
     backend: B,
+    l1_header_cache: L1HeaderCache,
 }
 
 impl<B: ProverBackend> fmt::Debug for ProverService<B> {
@@ -22,8 +26,8 @@ impl<B: ProverBackend> fmt::Debug for ProverService<B> {
 
 impl<B: ProverBackend> ProverService<B> {
     /// Creates a new prover service.
-    pub const fn new(config: ProverConfig, backend: B) -> Self {
-        Self { config, backend }
+    pub fn new(config: ProverConfig, backend: B) -> Self {
+        Self { config, backend, l1_header_cache: L1HeaderCache::new() }
     }
 
     /// Returns a reference to the prover configuration.
@@ -64,7 +68,10 @@ impl<B: ProverBackend> ProverService<B> {
     ) -> Result<ProofResult, ProverError<B>> {
         info!(l2_block = request.claimed_l2_block_number, "starting proof generation");
 
-        let host = Host::new(HostConfig { request, prover: self.config.clone(), data_dir: None });
+        let host = Host::new_with_l1_header_cache(
+            HostConfig { request, prover: self.config.clone(), data_dir: None },
+            self.l1_header_cache.clone(),
+        );
         let oracle = self.backend.create_oracle();
 
         let oracle = base_metrics::time!(Metrics::witness_build_duration_seconds(), {

--- a/crates/proof/host/src/service.rs
+++ b/crates/proof/host/src/service.rs
@@ -1,4 +1,4 @@
-use std::fmt;
+use std::{fmt, sync::OnceLock};
 
 use base_proof_primitives::{ProofRequest, ProofResult, ProverBackend};
 use tracing::{Instrument, info, info_span};
@@ -15,7 +15,7 @@ use crate::{
 pub struct ProverService<B> {
     config: ProverConfig,
     backend: B,
-    l1_header_cache: L1HeaderCache,
+    l1_header_cache: OnceLock<L1HeaderCache>,
 }
 
 impl<B: ProverBackend> fmt::Debug for ProverService<B> {
@@ -26,8 +26,8 @@ impl<B: ProverBackend> fmt::Debug for ProverService<B> {
 
 impl<B: ProverBackend> ProverService<B> {
     /// Creates a new prover service.
-    pub fn new(config: ProverConfig, backend: B) -> Self {
-        Self { config, backend, l1_header_cache: L1HeaderCache::new() }
+    pub const fn new(config: ProverConfig, backend: B) -> Self {
+        Self { config, backend, l1_header_cache: OnceLock::new() }
     }
 
     /// Returns a reference to the prover configuration.
@@ -40,7 +40,7 @@ impl<B: ProverBackend> ProverService<B> {
     /// 1. Assembles [`HostConfig`] from static config + per-proof request
     /// 2. Creates a fresh [`Host`] (connects RPCs internally)
     /// 3. Creates a backend-specific oracle via [`ProverBackend::create_oracle`]
-    /// 4. Runs witness generation via [`Host::build_witness`]
+    /// 4. Runs witness generation with a shared L1 header cache
     /// 5. Hands the populated oracle to [`ProverBackend::prove`]
     pub async fn prove_block(&self, request: ProofRequest) -> Result<ProofResult, ProverError<B>> {
         Metrics::requests_total(Metrics::MODE_ONLINE).increment(1);
@@ -68,14 +68,14 @@ impl<B: ProverBackend> ProverService<B> {
     ) -> Result<ProofResult, ProverError<B>> {
         info!(l2_block = request.claimed_l2_block_number, "starting proof generation");
 
-        let host = Host::new_with_l1_header_cache(
-            HostConfig { request, prover: self.config.clone(), data_dir: None },
-            self.l1_header_cache.clone(),
-        );
+        let host = Host::new(HostConfig { request, prover: self.config.clone(), data_dir: None });
+        let l1_header_cache = self.l1_header_cache.get_or_init(L1HeaderCache::new).clone();
         let oracle = self.backend.create_oracle();
 
         let oracle = base_metrics::time!(Metrics::witness_build_duration_seconds(), {
-            host.build_witness(oracle).await.map_err(ProverError::Host)?
+            host.build_witness_with_l1_header_cache(oracle, l1_header_cache)
+                .await
+                .map_err(ProverError::Host)?
         });
 
         let result = base_metrics::time!(Metrics::prover_duration_seconds(), {


### PR DESCRIPTION
## Summary

Introduces an `L1HeaderPrefetcher` and a shared `L1HeaderCache` that proactively fetches nearby L1 headers (lookbehind from the requested header) and stores each header under its actual header hash so reorged or otherwise non-ancestor blocks cannot satisfy a different guest request.

The cache is threaded through `ProverService` → `Host` → `OnlineHostBackend` so it is shared across proof requests within a single prover service instance.

## Changes

- `crates/proof/host/src/handler.rs`: Add `L1HeaderCache`, `L1HeaderPrefetcher`, `ScheduledL1HeaderBlockGuard`, and helpers (`encode_header_rlp`, `insert_l1_header_preimage`). Rename `handle_hint_with_prefetcher` → `handle_hint_with_prefetchers` and thread the new prefetcher through. On an `L1BlockHeader` hint, serve from cache when possible and schedule a lookbehind prefetch otherwise.
- `crates/proof/host/src/backend/online.rs`: Add `new_with_l1_header_cache` constructor and route the prefetcher through hint handling.
- `crates/proof/host/src/host.rs`: Add `new_with_l1_header_cache` constructor and thread the shared cache into both online backend code paths.
- `crates/proof/host/src/service.rs`: Own a single `L1HeaderCache` on `ProverService` and pass a clone into each `Host` it constructs.

## Tuning constants

- `L1_HEADER_PREFETCH_LOOKBEHIND_BLOCKS`: 512
- `L1_HEADER_PREFETCH_MAX_READY`: 131_072
- `L1_HEADER_PREFETCH_MAX_IN_FLIGHT`: 32
- `L1_HEADER_PREFETCH_MAX_SCHEDULED_BLOCKS`: 131_072

## Tests

New unit tests cover scheduled-block dedupe, cache sharing across prefetchers, guard drop/keep behavior, and that `insert_l1_header_preimage` keys on the header hash.