### PR TITLE
refactor(common): Derive Precompile Storage Accounting

### DIFF
--- a/crates/common/precompile-macros/src/accounting.rs
+++ b/crates/common/precompile-macros/src/accounting.rs
@@ -1,0 +1,464 @@
+//! Derives for Base B-20 storage accounting ports.
+
+use proc_macro2::TokenStream;
+use quote::quote;
+use syn::{Data, DeriveInput, Fields};
+
+pub(crate) fn derive_token(input: DeriveInput) -> proc_macro::TokenStream {
+    expand_token(input).unwrap_or_else(syn::Error::into_compile_error).into()
+}
+
+pub(crate) fn derive_stablecoin(input: DeriveInput) -> proc_macro::TokenStream {
+    expand_stablecoin(input).unwrap_or_else(syn::Error::into_compile_error).into()
+}
+
+pub(crate) fn derive_security(input: DeriveInput) -> proc_macro::TokenStream {
+    expand_security(input).unwrap_or_else(syn::Error::into_compile_error).into()
+}
+
+fn expand_token(input: DeriveInput) -> syn::Result<TokenStream> {
+    require_field(&input, "b20")?;
+    let has_redeem = has_field(&input, "redeem");
+    let name = input.ident;
+    let redeem = has_redeem.then_some(quote! {
+        if policy_scope == Self::REDEEM_SENDER_POLICY {
+            return Ok(Self::__read_policy_lane(
+                self.redeem.redeem_policy_ids()?,
+                Self::__REDEEM_SENDER_POLICY_LANE,
+            ));
+        }
+    });
+    let set_redeem = has_redeem.then_some(quote! {
+        if policy_scope == Self::REDEEM_SENDER_POLICY {
+            let packed = Self::__write_policy_lane(
+                self.redeem.redeem_policy_ids()?,
+                Self::__REDEEM_SENDER_POLICY_LANE,
+                policy_id,
+            );
+            return self.redeem.set_redeem_policy_ids(packed);
+        }
+    });
+
+    Ok(quote! {
+        impl #name<'_> {
+            const __TRANSFER_SENDER_POLICY_LANE: usize = 0;
+            const __TRANSFER_RECEIVER_POLICY_LANE: usize = 1;
+            const __TRANSFER_EXECUTOR_POLICY_LANE: usize = 2;
+            const __MINT_RECEIVER_POLICY_LANE: usize = 0;
+            const __REDEEM_SENDER_POLICY_LANE: usize = 0;
+            const __POLICY_LANE_BITS: usize = 64;
+
+            fn __require_policy_type(
+                policy_scope: ::alloy_primitives::B256,
+            ) -> ::base_precompile_storage::Result<crate::B20PolicyType> {
+                crate::B20PolicyType::from_id(policy_scope).ok_or_else(|| {
+                    ::base_precompile_storage::BasePrecompileError::revert(
+                        crate::IB20::UnsupportedPolicyType { policyScope: policy_scope },
+                    )
+                })
+            }
+
+            fn __read_policy_lane(packed: ::alloy_primitives::U256, lane: usize) -> u64 {
+                ((packed >> (lane * Self::__POLICY_LANE_BITS))
+                    & ::alloy_primitives::U256::from(u64::MAX))
+                    .to::<u64>()
+            }
+
+            fn __write_policy_lane(
+                packed: ::alloy_primitives::U256,
+                lane: usize,
+                policy_id: u64,
+            ) -> ::alloy_primitives::U256 {
+                let shift = lane * Self::__POLICY_LANE_BITS;
+                let mask = ::alloy_primitives::U256::from(u64::MAX) << shift;
+                (packed & !mask) | (::alloy_primitives::U256::from(policy_id) << shift)
+            }
+        }
+
+        impl crate::TokenAccounting for #name<'_> {
+            fn token_address(&self) -> ::alloy_primitives::Address {
+                ::base_precompile_storage::ContractStorage::address(self)
+            }
+
+            fn is_initialized(&self) -> ::base_precompile_storage::Result<bool> {
+                ::base_precompile_storage::ContractStorage::is_initialized(self)
+            }
+
+            fn balance_of(
+                &self,
+                account: ::alloy_primitives::Address,
+            ) -> ::base_precompile_storage::Result<::alloy_primitives::U256> {
+                self.b20.balance_of(account)
+            }
+
+            fn set_balance(
+                &mut self,
+                account: ::alloy_primitives::Address,
+                balance: ::alloy_primitives::U256,
+            ) -> ::base_precompile_storage::Result<()> {
+                self.b20.set_balance(account, balance)
+            }
+
+            fn allowance(
+                &self,
+                owner: ::alloy_primitives::Address,
+                spender: ::alloy_primitives::Address,
+            ) -> ::base_precompile_storage::Result<::alloy_primitives::U256> {
+                self.b20.allowance(owner, spender)
+            }
+
+            fn set_allowance(
+                &mut self,
+                owner: ::alloy_primitives::Address,
+                spender: ::alloy_primitives::Address,
+                amount: ::alloy_primitives::U256,
+            ) -> ::base_precompile_storage::Result<()> {
+                self.b20.set_allowance(owner, spender, amount)
+            }
+
+            fn total_supply(
+                &self,
+            ) -> ::base_precompile_storage::Result<::alloy_primitives::U256> {
+                self.b20.total_supply()
+            }
+
+            fn set_total_supply(
+                &mut self,
+                supply: ::alloy_primitives::U256,
+            ) -> ::base_precompile_storage::Result<()> {
+                self.b20.set_total_supply(supply)
+            }
+
+            fn supply_cap(&self) -> ::base_precompile_storage::Result<::alloy_primitives::U256> {
+                self.b20.supply_cap()
+            }
+
+            fn set_supply_cap(
+                &mut self,
+                cap: ::alloy_primitives::U256,
+            ) -> ::base_precompile_storage::Result<()> {
+                self.b20.set_supply_cap(cap)
+            }
+
+            fn name(&self) -> ::base_precompile_storage::Result<::alloc::string::String> {
+                self.b20.name()
+            }
+
+            fn set_name(
+                &mut self,
+                name: ::alloc::string::String,
+            ) -> ::base_precompile_storage::Result<()> {
+                self.b20.set_name(name)
+            }
+
+            fn symbol(&self) -> ::base_precompile_storage::Result<::alloc::string::String> {
+                self.b20.symbol()
+            }
+
+            fn set_symbol(
+                &mut self,
+                symbol: ::alloc::string::String,
+            ) -> ::base_precompile_storage::Result<()> {
+                self.b20.set_symbol(symbol)
+            }
+
+            fn decimals(&self) -> ::base_precompile_storage::Result<u8> {
+                Ok(crate::B20Variant::from_address(
+                    ::base_precompile_storage::ContractStorage::address(self),
+                )
+                .map_or(0, crate::B20Variant::decimals))
+            }
+
+            fn paused(&self) -> ::base_precompile_storage::Result<::alloy_primitives::U256> {
+                self.b20.paused()
+            }
+
+            fn set_paused(
+                &mut self,
+                vectors: ::alloy_primitives::U256,
+            ) -> ::base_precompile_storage::Result<()> {
+                self.b20.set_paused(vectors)
+            }
+
+            fn nonce(
+                &self,
+                owner: ::alloy_primitives::Address,
+            ) -> ::base_precompile_storage::Result<::alloy_primitives::U256> {
+                self.b20.nonce(owner)
+            }
+
+            fn increment_nonce(
+                &mut self,
+                owner: ::alloy_primitives::Address,
+            ) -> ::base_precompile_storage::Result<()> {
+                let current = self.b20.nonce(owner)?;
+                let next = current
+                    .checked_add(::alloy_primitives::U256::ONE)
+                    .ok_or_else(::base_precompile_storage::BasePrecompileError::under_overflow)?;
+                self.b20.set_nonce(owner, next)
+            }
+
+            fn contract_uri(&self) -> ::base_precompile_storage::Result<::alloc::string::String> {
+                self.b20.contract_uri()
+            }
+
+            fn set_contract_uri(
+                &mut self,
+                uri: ::alloc::string::String,
+            ) -> ::base_precompile_storage::Result<()> {
+                self.b20.set_contract_uri(uri)
+            }
+
+            fn has_role(
+                &self,
+                role: ::alloy_primitives::B256,
+                account: ::alloy_primitives::Address,
+            ) -> ::base_precompile_storage::Result<bool> {
+                self.b20.has_role(role, account)
+            }
+
+            fn set_role(
+                &mut self,
+                role: ::alloy_primitives::B256,
+                account: ::alloy_primitives::Address,
+                enabled: bool,
+            ) -> ::base_precompile_storage::Result<()> {
+                self.b20.set_role(role, account, enabled)
+            }
+
+            fn role_member_count(
+                &self,
+                role: ::alloy_primitives::B256,
+            ) -> ::base_precompile_storage::Result<::alloy_primitives::U256> {
+                if role == crate::B20TokenRole::DefaultAdmin.id() {
+                    self.b20.admin_count()
+                } else {
+                    Ok(::alloy_primitives::U256::ZERO)
+                }
+            }
+
+            fn set_role_member_count(
+                &mut self,
+                role: ::alloy_primitives::B256,
+                count: ::alloy_primitives::U256,
+            ) -> ::base_precompile_storage::Result<()> {
+                if role == crate::B20TokenRole::DefaultAdmin.id() {
+                    self.b20.set_admin_count(count)
+                } else {
+                    Ok(())
+                }
+            }
+
+            fn role_admin(
+                &self,
+                role: ::alloy_primitives::B256,
+            ) -> ::base_precompile_storage::Result<::alloy_primitives::B256> {
+                let admin_role = self.b20.role_admin(role)?;
+                if admin_role.is_zero() && role != crate::B20TokenRole::DefaultAdmin.id() {
+                    Ok(crate::B20TokenRole::DefaultAdmin.id())
+                } else {
+                    Ok(admin_role)
+                }
+            }
+
+            fn set_role_admin(
+                &mut self,
+                role: ::alloy_primitives::B256,
+                admin_role: ::alloy_primitives::B256,
+            ) -> ::base_precompile_storage::Result<()> {
+                self.b20.set_role_admin(role, admin_role)
+            }
+
+            fn policy_id(
+                &self,
+                policy_scope: ::alloy_primitives::B256,
+            ) -> ::base_precompile_storage::Result<u64> {
+                #redeem
+                match Self::__require_policy_type(policy_scope)? {
+                    crate::B20PolicyType::TransferSender => Ok(Self::__read_policy_lane(
+                        self.b20.transfer_policy_ids()?,
+                        Self::__TRANSFER_SENDER_POLICY_LANE,
+                    )),
+                    crate::B20PolicyType::TransferReceiver => Ok(Self::__read_policy_lane(
+                        self.b20.transfer_policy_ids()?,
+                        Self::__TRANSFER_RECEIVER_POLICY_LANE,
+                    )),
+                    crate::B20PolicyType::TransferExecutor => Ok(Self::__read_policy_lane(
+                        self.b20.transfer_policy_ids()?,
+                        Self::__TRANSFER_EXECUTOR_POLICY_LANE,
+                    )),
+                    crate::B20PolicyType::MintReceiver => Ok(Self::__read_policy_lane(
+                        self.b20.mint_policy_ids()?,
+                        Self::__MINT_RECEIVER_POLICY_LANE,
+                    )),
+                }
+            }
+
+            fn set_policy_id(
+                &mut self,
+                policy_scope: ::alloy_primitives::B256,
+                policy_id: u64,
+            ) -> ::base_precompile_storage::Result<()> {
+                #set_redeem
+                let (packed, lane, mint) = match Self::__require_policy_type(policy_scope)? {
+                    crate::B20PolicyType::TransferSender => (
+                        self.b20.transfer_policy_ids()?,
+                        Self::__TRANSFER_SENDER_POLICY_LANE,
+                        false,
+                    ),
+                    crate::B20PolicyType::TransferReceiver => (
+                        self.b20.transfer_policy_ids()?,
+                        Self::__TRANSFER_RECEIVER_POLICY_LANE,
+                        false,
+                    ),
+                    crate::B20PolicyType::TransferExecutor => (
+                        self.b20.transfer_policy_ids()?,
+                        Self::__TRANSFER_EXECUTOR_POLICY_LANE,
+                        false,
+                    ),
+                    crate::B20PolicyType::MintReceiver => (
+                        self.b20.mint_policy_ids()?,
+                        Self::__MINT_RECEIVER_POLICY_LANE,
+                        true,
+                    ),
+                };
+                let packed = Self::__write_policy_lane(packed, lane, policy_id);
+                if mint {
+                    self.b20.set_mint_policy_ids(packed)
+                } else {
+                    self.b20.set_transfer_policy_ids(packed)
+                }
+            }
+
+            fn emit_event(
+                &mut self,
+                log: ::alloy_primitives::LogData,
+            ) -> ::base_precompile_storage::Result<()> {
+                self.emit_event(log)
+            }
+        }
+    })
+}
+
+fn expand_stablecoin(input: DeriveInput) -> syn::Result<TokenStream> {
+    require_field(&input, "stablecoin")?;
+    let name = input.ident;
+    Ok(quote! {
+        impl crate::StablecoinAccounting for #name<'_> {
+            fn currency(&self) -> ::base_precompile_storage::Result<::alloc::string::String> {
+                self.stablecoin.currency()
+            }
+
+            fn set_currency(
+                &mut self,
+                currency: ::alloc::string::String,
+            ) -> ::base_precompile_storage::Result<()> {
+                self.stablecoin.set_currency(currency)
+            }
+        }
+    })
+}
+
+fn expand_security(input: DeriveInput) -> syn::Result<TokenStream> {
+    require_field(&input, "security")?;
+    require_field(&input, "redeem")?;
+    let name = input.ident;
+    Ok(quote! {
+        impl crate::SecurityAccounting for #name<'_> {
+            fn shares_to_tokens_ratio(
+                &self,
+            ) -> ::base_precompile_storage::Result<::alloy_primitives::U256> {
+                let ratio = self.security.shares_to_tokens_ratio()?;
+                Ok(if ratio.is_zero() { Self::WAD } else { ratio })
+            }
+
+            fn set_shares_to_tokens_ratio(
+                &mut self,
+                ratio: ::alloy_primitives::U256,
+            ) -> ::base_precompile_storage::Result<()> {
+                self.security.set_shares_to_tokens_ratio(ratio)
+            }
+
+            fn security_identifier(
+                &self,
+                identifier_type: &str,
+            ) -> ::base_precompile_storage::Result<::alloc::string::String> {
+                ::base_precompile_storage::Handler::read(
+                    self.security
+                        .identifiers
+                        .at(&::alloc::string::String::from(identifier_type)),
+                )
+            }
+
+            fn set_security_identifier_value(
+                &mut self,
+                identifier_type: &str,
+                value: ::alloc::string::String,
+            ) -> ::base_precompile_storage::Result<()> {
+                let key = ::alloc::string::String::from(identifier_type);
+                if value.is_empty() {
+                    ::base_precompile_storage::Handler::delete(self.security.identifiers.at_mut(&key))
+                } else {
+                    ::base_precompile_storage::Handler::write(
+                        self.security.identifiers.at_mut(&key),
+                        value,
+                    )
+                }
+            }
+
+            fn minimum_redeemable(
+                &self,
+            ) -> ::base_precompile_storage::Result<::alloy_primitives::U256> {
+                self.redeem.minimum_redeemable()
+            }
+
+            fn set_minimum_redeemable(
+                &mut self,
+                minimum: ::alloy_primitives::U256,
+            ) -> ::base_precompile_storage::Result<()> {
+                self.redeem.set_minimum_redeemable(minimum)
+            }
+
+            fn is_announcement_id_used(
+                &self,
+                id: &str,
+            ) -> ::base_precompile_storage::Result<bool> {
+                ::base_precompile_storage::Handler::read(
+                    self.security
+                        .used_announcement_ids
+                        .at(&::alloc::string::String::from(id)),
+                )
+            }
+
+            fn mark_announcement_id_used(
+                &mut self,
+                id: &str,
+            ) -> ::base_precompile_storage::Result<()> {
+                ::base_precompile_storage::Handler::write(
+                    self.security
+                        .used_announcement_ids
+                        .at_mut(&::alloc::string::String::from(id)),
+                    true,
+                )
+            }
+        }
+    })
+}
+
+fn require_field(input: &DeriveInput, name: &str) -> syn::Result<()> {
+    if has_field(input, name) {
+        Ok(())
+    } else {
+        Err(syn::Error::new_spanned(&input.ident, format!("missing `{name}` field")))
+    }
+}
+
+fn has_field(input: &DeriveInput, name: &str) -> bool {
+    let Data::Struct(data) = &input.data else {
+        return false;
+    };
+    let Fields::Named(fields) = &data.fields else {
+        return false;
+    };
+    fields.named.iter().any(|field| field.ident.as_ref().is_some_and(|ident| ident == name))
+}

--- a/crates/common/precompile-macros/src/contract.rs
+++ b/crates/common/precompile-macros/src/contract.rs
@@ -3,7 +3,9 @@
 use alloy_primitives::U256;
 use proc_macro2::TokenStream;
 use quote::quote;
-use syn::{Data, DeriveInput, Expr, Fields, Ident, Token, Type, Visibility, parse::ParseStream};
+use syn::{
+    Attribute, Data, DeriveInput, Expr, Fields, Ident, Token, Type, Visibility, parse::ParseStream,
+};
 
 use crate::{
     layout, packing,
@@ -59,9 +61,15 @@ pub(crate) fn generate(input: DeriveInput, address: Option<&Expr>) -> proc_macro
 fn gen_output(input: DeriveInput, address: Option<&Expr>) -> syn::Result<TokenStream> {
     let (ident, vis) = (input.ident.clone(), input.vis.clone());
     let namespace = extract_namespace(&input.attrs)?;
+    let derives = input
+        .attrs
+        .iter()
+        .filter(|attr| attr.path().is_ident("derive"))
+        .cloned()
+        .collect::<Vec<_>>();
     let fields = parse_fields(input, namespace.is_some())?;
 
-    let storage_output = gen_storage(&ident, &vis, &fields, address, namespace.as_ref())?;
+    let storage_output = gen_storage(&ident, &vis, &derives, &fields, address, namespace.as_ref())?;
     Ok(quote! { #storage_output })
 }
 
@@ -117,6 +125,7 @@ pub(crate) fn parse_fields(
 fn gen_storage(
     ident: &Ident,
     vis: &Visibility,
+    attrs: &[Attribute],
     fields: &[FieldInfo],
     address: Option<&Expr>,
     namespace: Option<&NamespaceInfo>,
@@ -126,7 +135,7 @@ fn gen_storage(
         namespace.map_or(U256::ZERO, |namespace| namespace.root),
         namespace.is_none(),
     )?;
-    let transformed_struct = layout::gen_struct(ident, vis, &allocated_fields);
+    let transformed_struct = layout::gen_struct(ident, vis, attrs, &allocated_fields);
     let storage_trait = layout::gen_contract_storage_impl(ident);
     let constructor = layout::gen_constructor(ident, &allocated_fields, address);
     let slots_module = layout::gen_slots_module(&allocated_fields, namespace);

--- a/crates/common/precompile-macros/src/layout.rs
+++ b/crates/common/precompile-macros/src/layout.rs
@@ -1,5 +1,5 @@
 use quote::{format_ident, quote};
-use syn::{Expr, Ident, Visibility};
+use syn::{Attribute, Expr, Ident, Visibility};
 
 use crate::{
     FieldKind,
@@ -120,12 +120,14 @@ fn gen_shares_slot_check(
 pub(crate) fn gen_struct(
     name: &Ident,
     vis: &Visibility,
+    attrs: &[Attribute],
     allocated_fields: &[LayoutField<'_>],
 ) -> proc_macro2::TokenStream {
     let handler_fields = allocated_fields.iter().map(gen_handler_field_decl);
     let doc_str = format!("Storage layout for the [`{name}`] precompile.");
 
     quote! {
+        #(#attrs)*
         #[doc = #doc_str]
         #vis struct #name<'a> {
             #(#handler_fields,)*

--- a/crates/common/precompile-macros/src/lib.rs
+++ b/crates/common/precompile-macros/src/lib.rs
@@ -3,6 +3,7 @@
 mod contract;
 pub(crate) use contract::{FieldInfo, FieldKind};
 
+mod accounting;
 mod layout;
 mod namespace;
 mod packing;
@@ -43,9 +44,30 @@ pub fn precompile(attr: TokenStream, item: TokenStream) -> TokenStream {
 }
 
 /// Derives the `Storable` trait for structs with named fields and `#[repr(u8)]` unit enums.
-#[proc_macro_derive(Storable, attributes(storable_arrays, namespace, storage_namespace))]
+#[proc_macro_derive(
+    Storable,
+    attributes(accessor, mutator, storable_arrays, namespace, storage_namespace)
+)]
 pub fn derive_storage_block(input: TokenStream) -> TokenStream {
     storable::derive(parse_macro_input!(input as DeriveInput))
+}
+
+/// Derives the B-20 `TokenAccounting` storage port for contract storage structs.
+#[proc_macro_derive(TokenAccounting)]
+pub fn derive_token_accounting(input: TokenStream) -> TokenStream {
+    accounting::derive_token(parse_macro_input!(input as DeriveInput))
+}
+
+/// Derives the stablecoin storage port for contract storage structs.
+#[proc_macro_derive(StablecoinAccounting)]
+pub fn derive_stablecoin_accounting(input: TokenStream) -> TokenStream {
+    accounting::derive_stablecoin(parse_macro_input!(input as DeriveInput))
+}
+
+/// Derives the security-token storage port for contract storage structs.
+#[proc_macro_derive(SecurityAccounting)]
+pub fn derive_security_accounting(input: TokenStream) -> TokenStream {
+    accounting::derive_security(parse_macro_input!(input as DeriveInput))
 }
 
 /// Generate `StorableType` and `Storable` implementations for all standard integer types.

--- a/crates/common/precompile-macros/src/storable.rs
+++ b/crates/common/precompile-macros/src/storable.rs
@@ -2,7 +2,10 @@
 
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
-use syn::{Attribute, Data, DataEnum, DataStruct, DeriveInput, Fields, Ident, Type};
+use syn::{
+    Attribute, Data, DataEnum, DataStruct, DeriveInput, Fields, Ident, Token, Type, parenthesized,
+    parse::Parse,
+};
 
 use crate::{
     FieldInfo,
@@ -14,6 +17,19 @@ use crate::{
         extract_storage_namespace, to_snake_case,
     },
 };
+
+struct AccessField {
+    name: Ident,
+    ty: Type,
+    accessor: Option<AccessSpec>,
+    mutator: Option<AccessSpec>,
+}
+
+struct AccessSpec {
+    name: Ident,
+    keys: Vec<Ident>,
+    value: Ident,
+}
 
 /// Entry point called from `lib.rs` — parses input and converts errors to compile errors.
 pub(crate) fn derive(input: DeriveInput) -> proc_macro::TokenStream {
@@ -56,16 +72,24 @@ fn derive_struct_impl(input: &DeriveInput, data_struct: &DataStruct) -> syn::Res
         ));
     }
 
-    let field_infos: Vec<_> = fields
-        .iter()
-        .map(|f| FieldInfo {
-            name: f.ident.as_ref().unwrap().clone(),
-            ty: f.ty.clone(),
+    let mut field_infos = Vec::with_capacity(fields.len());
+    let mut access_fields = Vec::with_capacity(fields.len());
+    for field in fields {
+        let name = field.ident.as_ref().unwrap().clone();
+        field_infos.push(FieldInfo {
+            name: name.clone(),
+            ty: field.ty.clone(),
             slot: None,
             base_slot: None,
             namespace: None,
-        })
-        .collect();
+        });
+        access_fields.push(AccessField {
+            accessor: parse_access_attr(&field.attrs, &name, "accessor", false)?,
+            mutator: parse_access_attr(&field.attrs, &name, "mutator", true)?,
+            name,
+            ty: field.ty.clone(),
+        });
+    }
 
     let layout_fields = packing::allocate_slots(&field_infos)?;
 
@@ -92,7 +116,7 @@ fn derive_struct_impl(input: &DeriveInput, data_struct: &DataStruct) -> syn::Res
     let store_impl = gen_store_impl(&direct_fields, &mod_ident);
     let delete_impl = gen_delete_impl(&direct_fields, &mod_ident);
 
-    let handler_struct = gen_handler_struct(strukt, &layout_fields, &mod_ident);
+    let handler_struct = gen_handler_struct(strukt, &layout_fields, &mod_ident, &access_fields)?;
     let handler_name = format_ident!("{}Handler", strukt);
     let namespace_consts = gen_storage_namespace_consts(namespace.as_ref());
 
@@ -326,15 +350,17 @@ fn gen_handler_struct(
     struct_name: &Ident,
     fields: &[LayoutField<'_>],
     mod_ident: &Ident,
-) -> TokenStream {
+    access_fields: &[AccessField],
+) -> syn::Result<TokenStream> {
     let handler_name = format_ident!("{}Handler", struct_name);
     let handler_fields = fields.iter().map(gen_handler_field_decl);
     let field_inits = fields
         .iter()
         .enumerate()
         .map(|(idx, field)| gen_handler_field_init(field, idx, fields, Some(mod_ident)));
+    let access_methods = gen_access_methods(access_fields)?;
 
-    quote! {
+    Ok(quote! {
         /// Type-safe handler for accessing `#struct_name` in storage.
         #[derive(Debug, Clone)]
         pub struct #handler_name<'a> {
@@ -372,6 +398,8 @@ fn gen_handler_struct(
                     self.storage,
                 )
             }
+
+            #access_methods
         }
 
         impl ::base_precompile_storage::Handler<#struct_name> for #handler_name<'_> {
@@ -400,7 +428,140 @@ fn gen_handler_struct(
                 self.as_slot().t_delete()
             }
         }
+    })
+}
+
+fn parse_access_attr(
+    attrs: &[Attribute],
+    field_name: &Ident,
+    attr_name: &str,
+    mutator: bool,
+) -> syn::Result<Option<AccessSpec>> {
+    let mut parsed = None;
+    for attr in attrs {
+        if !attr.path().is_ident(attr_name) {
+            continue;
+        }
+        if parsed.is_some() {
+            return Err(syn::Error::new_spanned(
+                attr,
+                format!("duplicate `{attr_name}` attribute"),
+            ));
+        }
+        let mut spec = AccessSpec {
+            name: if mutator { format_ident!("set_{}", field_name) } else { field_name.clone() },
+            keys: Vec::new(),
+            value: field_name.clone(),
+        };
+        if !matches!(attr.meta, syn::Meta::Path(_)) {
+            attr.parse_nested_meta(|meta| {
+                if meta.path.is_ident("name") {
+                    spec.name = meta.value()?.parse()?;
+                } else if meta.path.is_ident("value") {
+                    spec.value = meta.value()?.parse()?;
+                } else if meta.path.is_ident("keys") {
+                    let content;
+                    parenthesized!(content in meta.input);
+                    spec.keys =
+                        content.parse_terminated(Ident::parse, Token![,])?.into_iter().collect();
+                } else {
+                    return Err(meta.error("supported keys are `name`, `keys`, and `value`"));
+                }
+                Ok(())
+            })?;
+        }
+        parsed = Some(spec);
     }
+    Ok(parsed)
+}
+
+fn gen_access_methods(fields: &[AccessField]) -> syn::Result<TokenStream> {
+    let mut out = TokenStream::new();
+    for field in fields {
+        if let Some(accessor) = &field.accessor {
+            out.extend(gen_access_method(field, accessor)?);
+        }
+        if let Some(mutator) = &field.mutator {
+            out.extend(gen_mutate_method(field, mutator)?);
+        }
+    }
+    Ok(out)
+}
+
+fn gen_access_method(field: &AccessField, spec: &AccessSpec) -> syn::Result<TokenStream> {
+    let (key_tys, value_ty) = access_types(field, spec)?;
+    let (name, args) = (&spec.name, method_args(&spec.keys, &key_tys));
+    let target = access_target(&field.name, &spec.keys, false);
+    let doc = format!("Reads the `{}` storage field.", field.name);
+    Ok(quote! {
+        #[doc = #doc]
+        pub fn #name(&self, #(#args),*) -> ::base_precompile_storage::Result<#value_ty> {
+            ::base_precompile_storage::Handler::read(#target)
+        }
+    })
+}
+
+fn gen_mutate_method(field: &AccessField, spec: &AccessSpec) -> syn::Result<TokenStream> {
+    let (key_tys, value_ty) = access_types(field, spec)?;
+    let (name, value, args) = (&spec.name, &spec.value, method_args(&spec.keys, &key_tys));
+    let target = access_target(&field.name, &spec.keys, true);
+    let doc = format!("Writes the `{}` storage field.", field.name);
+    Ok(quote! {
+        #[doc = #doc]
+        pub fn #name(
+            &mut self,
+            #(#args,)*
+            #value: #value_ty,
+        ) -> ::base_precompile_storage::Result<()> {
+            ::base_precompile_storage::Handler::write(#target, #value)
+        }
+    })
+}
+
+fn access_types<'a>(
+    field: &'a AccessField,
+    spec: &AccessSpec,
+) -> syn::Result<(Vec<&'a Type>, &'a Type)> {
+    let mut key_tys = Vec::new();
+    let mut value_ty = &field.ty;
+    while let Some((key_ty, nested_value_ty)) = extract_mapping_types(value_ty) {
+        key_tys.push(key_ty);
+        value_ty = nested_value_ty;
+    }
+    if key_tys.len() != spec.keys.len() {
+        return Err(syn::Error::new_spanned(
+            &field.name,
+            format!("expected {} `keys(...)` entries", key_tys.len()),
+        ));
+    }
+    Ok((key_tys, value_ty))
+}
+
+fn method_args<'a>(
+    keys: &'a [Ident],
+    key_tys: &'a [&'a Type],
+) -> impl Iterator<Item = TokenStream> + 'a {
+    keys.iter().zip(key_tys).map(|(key, ty)| quote! { #key: #ty })
+}
+
+fn access_target(field_name: &Ident, keys: &[Ident], mutator: bool) -> TokenStream {
+    if keys.is_empty() {
+        return if mutator {
+            quote! { &mut self.#field_name }
+        } else {
+            quote! { &self.#field_name }
+        };
+    }
+
+    let mut target = quote! { self.#field_name };
+    for key in keys {
+        target = if mutator {
+            quote! { #target.at_mut(&#key) }
+        } else {
+            quote! { #target.at(&#key) }
+        };
+    }
+    target
 }
 
 fn gen_storage_namespace_consts(namespace: Option<&NamespaceInfo>) -> TokenStream {

--- a/crates/common/precompiles/src/b20/storage.rs
+++ b/crates/common/precompiles/src/b20/storage.rs
@@ -2,13 +2,9 @@
 
 use alloc::string::String;
 
-use alloy_primitives::{Address, B256, LogData, U256};
-use base_precompile_macros::{Storable, contract};
-use base_precompile_storage::{
-    BasePrecompileError, ContractStorage, Handler, Mapping, Result, StorageCtx,
-};
-
-use crate::{B20PolicyType, B20TokenRole, B20Variant, IB20, TokenAccounting};
+use alloy_primitives::{Address, B256, U256};
+use base_precompile_macros::{Storable, TokenAccounting, contract};
+use base_precompile_storage::{Handler, Mapping, Result, StorageCtx};
 
 /// Creation-time parameters for a B-20 token.
 ///
@@ -28,37 +24,66 @@ pub struct B20TokenInit {
 #[namespace("base.b20")]
 pub struct B20CoreStorage {
     /// Mutable token name.
+    #[accessor]
+    #[mutator]
     pub name: String, // offset 0
     /// Mutable token symbol.
+    #[accessor]
+    #[mutator]
     pub symbol: String, // offset 1
     /// ERC-7572 contract metadata URI.
+    #[accessor]
+    #[mutator]
     pub contract_uri: String, // offset 2
     /// Total token supply.
+    #[accessor]
+    #[mutator]
     pub total_supply: U256, // offset 3
     /// Token balances by account.
+    #[accessor(name = balance_of, keys(account))]
+    #[mutator(name = set_balance, keys(account), value = balance)]
     pub balances: Mapping<Address, U256>, // offset 4
     /// Spending allowances by owner and spender.
+    #[accessor(name = allowance, keys(owner, spender))]
+    #[mutator(name = set_allowance, keys(owner, spender), value = amount)]
     pub allowances: Mapping<Address, Mapping<Address, U256>>, // offset 5
     /// Role membership flags by role and account.
+    #[accessor(name = has_role, keys(role, account))]
+    #[mutator(name = set_role, keys(role, account), value = enabled)]
     pub roles: Mapping<B256, Mapping<Address, bool>>, // offset 6
     /// Admin role configured for each role.
+    #[accessor(name = role_admin, keys(role))]
+    #[mutator(name = set_role_admin, keys(role), value = admin_role)]
     pub role_admins: Mapping<B256, B256>, // offset 7
     /// Default-admin holder count.
+    #[accessor]
+    #[mutator]
     pub admin_count: U256, // offset 8
     /// Packed transfer-side policy IDs.
+    #[accessor]
+    #[mutator]
     pub transfer_policy_ids: U256, // offset 9: sender, receiver, executor, reserved
     /// Packed mint-side policy IDs.
+    #[accessor]
+    #[mutator]
     pub mint_policy_ids: U256, // offset 10: receiver, reserved, reserved, reserved
     /// Paused feature bitmask.
+    #[accessor]
+    #[mutator]
     pub paused: U256, // offset 11
     /// Maximum total supply.
+    #[accessor]
+    #[mutator]
     pub supply_cap: U256, // offset 12
     /// EIP-2612 permit nonces by owner.
+    #[accessor(name = nonce, keys(owner))]
+    #[mutator(name = set_nonce, keys(owner), value = nonce)]
     pub nonces: Mapping<Address, U256>, // offset 13
 }
 
 /// EVM-backed storage for the default B-20 variant.
 #[contract]
+#[derive(TokenAccounting)]
 pub struct B20TokenStorage {
     pub b20: B20CoreStorage,
 }
@@ -77,220 +102,6 @@ impl<'a> B20TokenStorage<'a> {
         self.b20.symbol.write(init.symbol)?;
         self.b20.supply_cap.write(init.supply_cap)?;
         Ok(())
-    }
-}
-
-impl TokenAccounting for B20TokenStorage<'_> {
-    fn token_address(&self) -> Address {
-        ContractStorage::address(self)
-    }
-
-    fn is_initialized(&self) -> Result<bool> {
-        ContractStorage::is_initialized(self)
-    }
-
-    fn balance_of(&self, account: Address) -> Result<U256> {
-        self.b20.balances.at(&account).read()
-    }
-
-    fn set_balance(&mut self, account: Address, balance: U256) -> Result<()> {
-        self.b20.balances.at_mut(&account).write(balance)
-    }
-
-    fn allowance(&self, owner: Address, spender: Address) -> Result<U256> {
-        self.b20.allowances.at(&owner).at(&spender).read()
-    }
-
-    fn set_allowance(&mut self, owner: Address, spender: Address, amount: U256) -> Result<()> {
-        self.b20.allowances.at_mut(&owner).at_mut(&spender).write(amount)
-    }
-
-    fn total_supply(&self) -> Result<U256> {
-        self.b20.total_supply.read()
-    }
-
-    fn set_total_supply(&mut self, supply: U256) -> Result<()> {
-        self.b20.total_supply.write(supply)
-    }
-
-    fn supply_cap(&self) -> Result<U256> {
-        self.b20.supply_cap.read()
-    }
-
-    fn set_supply_cap(&mut self, cap: U256) -> Result<()> {
-        self.b20.supply_cap.write(cap)
-    }
-
-    fn name(&self) -> Result<String> {
-        self.b20.name.read()
-    }
-
-    fn set_name(&mut self, name: String) -> Result<()> {
-        self.b20.name.write(name)
-    }
-
-    fn symbol(&self) -> Result<String> {
-        self.b20.symbol.read()
-    }
-
-    fn set_symbol(&mut self, symbol: String) -> Result<()> {
-        self.b20.symbol.write(symbol)
-    }
-
-    fn decimals(&self) -> Result<u8> {
-        Ok(B20Variant::from_address(ContractStorage::address(self)).map_or(0, B20Variant::decimals))
-    }
-
-    fn paused(&self) -> Result<U256> {
-        self.b20.paused.read()
-    }
-
-    fn set_paused(&mut self, vectors: U256) -> Result<()> {
-        self.b20.paused.write(vectors)
-    }
-
-    fn nonce(&self, owner: Address) -> Result<U256> {
-        self.b20.nonces.at(&owner).read()
-    }
-
-    fn increment_nonce(&mut self, owner: Address) -> Result<()> {
-        let current = self.b20.nonces.at(&owner).read()?;
-        let next =
-            current.checked_add(U256::ONE).ok_or_else(BasePrecompileError::under_overflow)?;
-        self.b20.nonces.at_mut(&owner).write(next)
-    }
-
-    fn contract_uri(&self) -> Result<String> {
-        self.b20.contract_uri.read()
-    }
-
-    fn set_contract_uri(&mut self, uri: String) -> Result<()> {
-        self.b20.contract_uri.write(uri)
-    }
-
-    fn has_role(&self, role: B256, account: Address) -> Result<bool> {
-        self.b20.roles.at(&role).at(&account).read()
-    }
-
-    fn set_role(&mut self, role: B256, account: Address, enabled: bool) -> Result<()> {
-        self.b20.roles.at_mut(&role).at_mut(&account).write(enabled)
-    }
-
-    fn role_member_count(&self, role: B256) -> Result<U256> {
-        if role == B20TokenRole::DefaultAdmin.id() {
-            self.b20.admin_count.read()
-        } else {
-            Ok(U256::ZERO)
-        }
-    }
-
-    fn set_role_member_count(&mut self, role: B256, count: U256) -> Result<()> {
-        if role == B20TokenRole::DefaultAdmin.id() {
-            self.b20.admin_count.write(count)
-        } else {
-            Ok(())
-        }
-    }
-
-    fn role_admin(&self, role: B256) -> Result<B256> {
-        let admin_role = self.b20.role_admins.at(&role).read()?;
-        if admin_role.is_zero() && role != B20TokenRole::DefaultAdmin.id() {
-            Ok(B20TokenRole::DefaultAdmin.id())
-        } else {
-            Ok(admin_role)
-        }
-    }
-
-    fn set_role_admin(&mut self, role: B256, admin_role: B256) -> Result<()> {
-        self.b20.role_admins.at_mut(&role).write(admin_role)
-    }
-
-    fn policy_id(&self, policy_scope: B256) -> Result<u64> {
-        let policy_type = Self::require_policy_type(policy_scope)?;
-        match policy_type {
-            B20PolicyType::TransferSender => Ok(Self::read_policy_lane(
-                self.b20.transfer_policy_ids.read()?,
-                Self::TRANSFER_SENDER_POLICY_LANE,
-            )),
-            B20PolicyType::TransferReceiver => Ok(Self::read_policy_lane(
-                self.b20.transfer_policy_ids.read()?,
-                Self::TRANSFER_RECEIVER_POLICY_LANE,
-            )),
-            B20PolicyType::TransferExecutor => Ok(Self::read_policy_lane(
-                self.b20.transfer_policy_ids.read()?,
-                Self::TRANSFER_EXECUTOR_POLICY_LANE,
-            )),
-            B20PolicyType::MintReceiver => Ok(Self::read_policy_lane(
-                self.b20.mint_policy_ids.read()?,
-                Self::MINT_RECEIVER_POLICY_LANE,
-            )),
-        }
-    }
-
-    fn set_policy_id(&mut self, policy_scope: B256, policy_id: u64) -> Result<()> {
-        let policy_type = Self::require_policy_type(policy_scope)?;
-        match policy_type {
-            B20PolicyType::TransferSender => {
-                let packed = Self::write_policy_lane(
-                    self.b20.transfer_policy_ids.read()?,
-                    Self::TRANSFER_SENDER_POLICY_LANE,
-                    policy_id,
-                );
-                self.b20.transfer_policy_ids.write(packed)
-            }
-            B20PolicyType::TransferReceiver => {
-                let packed = Self::write_policy_lane(
-                    self.b20.transfer_policy_ids.read()?,
-                    Self::TRANSFER_RECEIVER_POLICY_LANE,
-                    policy_id,
-                );
-                self.b20.transfer_policy_ids.write(packed)
-            }
-            B20PolicyType::TransferExecutor => {
-                let packed = Self::write_policy_lane(
-                    self.b20.transfer_policy_ids.read()?,
-                    Self::TRANSFER_EXECUTOR_POLICY_LANE,
-                    policy_id,
-                );
-                self.b20.transfer_policy_ids.write(packed)
-            }
-            B20PolicyType::MintReceiver => {
-                let packed = Self::write_policy_lane(
-                    self.b20.mint_policy_ids.read()?,
-                    Self::MINT_RECEIVER_POLICY_LANE,
-                    policy_id,
-                );
-                self.b20.mint_policy_ids.write(packed)
-            }
-        }
-    }
-
-    fn emit_event(&mut self, log: LogData) -> Result<()> {
-        self.emit_event(log)
-    }
-}
-
-impl B20TokenStorage<'_> {
-    const TRANSFER_SENDER_POLICY_LANE: usize = 0;
-    const TRANSFER_RECEIVER_POLICY_LANE: usize = 1;
-    const TRANSFER_EXECUTOR_POLICY_LANE: usize = 2;
-    const MINT_RECEIVER_POLICY_LANE: usize = 0;
-    const POLICY_LANE_BITS: usize = 64;
-
-    fn require_policy_type(policy_scope: B256) -> Result<B20PolicyType> {
-        B20PolicyType::from_id(policy_scope).ok_or_else(|| {
-            BasePrecompileError::revert(IB20::UnsupportedPolicyType { policyScope: policy_scope })
-        })
-    }
-
-    fn read_policy_lane(packed: U256, lane: usize) -> u64 {
-        ((packed >> (lane * Self::POLICY_LANE_BITS)) & U256::from(u64::MAX)).to::<u64>()
-    }
-
-    fn write_policy_lane(packed: U256, lane: usize, policy_id: u64) -> U256 {
-        let shift = lane * Self::POLICY_LANE_BITS;
-        let mask = U256::from(u64::MAX) << shift;
-        (packed & !mask) | (U256::from(policy_id) << shift)
     }
 }
 

--- a/crates/common/precompiles/src/b20_security/dispatch.rs
+++ b/crates/common/precompiles/src/b20_security/dispatch.rs
@@ -14,17 +14,14 @@ use base_precompile_storage::{BasePrecompileError, IntoPrecompileResult, Storage
 use revm::precompile::PrecompileResult;
 
 use crate::{
-    ActivationFeature, ActivationRegistryStorage, B20Guards, B20PolicyType, B20SecurityToken,
-    B20TokenRole, Burnable, Configurable,
+    ActivationFeature, ActivationRegistryStorage, B20Guards, B20PolicyType, B20SecurityStorage,
+    B20SecurityToken, B20TokenRole, Burnable, Configurable,
     IB20::{self, IB20Calls as C},
     IB20Security::{self, IB20SecurityCalls as SC},
     Mintable, NoopPrecompileCallObserver, Pausable, PermitArgs, Permittable, Policy,
     PrecompileCallObserver, RoleManaged, SecurityAccounting, Token, Transferable,
     macros::{decode_precompile_call, deduct_calldata_cost},
 };
-
-/// WAD precision for share ratio arithmetic: 1e18.
-const WAD: U256 = U256::from_limbs([1_000_000_000_000_000_000, 0, 0, 0]);
 
 impl<S: SecurityAccounting, P: Policy> B20SecurityToken<S, P> {
     /// Ensures `policy_scope` names either an inherited B-20 policy slot or the
@@ -421,7 +418,7 @@ impl<S: SecurityAccounting, P: Policy> B20SecurityToken<S, P> {
             // --- Role / precision constants ---
             SC::SECURITY_OPERATOR_ROLE(_) => Self::SECURITY_OPERATOR_ROLE.abi_encode().into(),
             SC::BURN_FROM_ROLE(_) => Self::BURN_FROM_ROLE.abi_encode().into(),
-            SC::WAD_PRECISION(_) => WAD.abi_encode().into(),
+            SC::WAD_PRECISION(_) => B20SecurityStorage::WAD.abi_encode().into(),
             SC::REDEEM_SENDER_POLICY(_) => Self::REDEEM_SENDER_POLICY.abi_encode().into(),
 
             // --- Share ratio reads ---
@@ -531,7 +528,7 @@ impl<S: SecurityAccounting, P: Policy> B20SecurityToken<S, P> {
     /// Converts a token balance to shares: `balance * sharesToTokensRatio / WAD`.
     fn to_shares(&self, balance: U256) -> base_precompile_storage::Result<U256> {
         let ratio = self.accounting().shares_to_tokens_ratio()?;
-        Ok(balance.saturating_mul(ratio) / WAD)
+        Ok(balance.saturating_mul(ratio) / B20SecurityStorage::WAD)
     }
 
     /// Performs a security-specific redeem: share-based floor check, burn, security `Redeemed` event.
@@ -568,7 +565,7 @@ impl<S: SecurityAccounting, P: Policy> B20SecurityToken<S, P> {
             return Err(BasePrecompileError::revert(IB20::InvalidAmount {}));
         }
         let ratio = self.accounting().shares_to_tokens_ratio()?;
-        let shares = amount.saturating_mul(ratio) / WAD;
+        let shares = amount.saturating_mul(ratio) / B20SecurityStorage::WAD;
         let minimum = self.accounting().minimum_redeemable()?;
         if shares == U256::ZERO || shares < minimum {
             return Err(BasePrecompileError::revert(IB20Security::BelowMinimumRedeemable {
@@ -750,11 +747,9 @@ mod tests {
     const BOB: Address = Address::repeat_byte(0xbb);
     const TOKEN: Address = Address::repeat_byte(0x01);
     const ACTIVATION_ADMIN: Address = Address::repeat_byte(0xcb);
-    const WAD: U256 = U256::from_limbs([1_000_000_000_000_000_000, 0, 0, 0]);
-
     fn make_token() -> TestSecurityToken {
         let mut accounting = InMemoryTokenAccounting::new(TOKEN);
-        accounting.shares_to_tokens_ratio = WAD; // 1:1 ratio
+        accounting.shares_to_tokens_ratio = B20SecurityStorage::WAD; // 1:1 ratio
         // Explicitly open redemption so non-policy tests are not blocked by the ALWAYS_BLOCK default.
         accounting.policy_ids.insert(REDEEM_SENDER_POLICY, PolicyRegistryStorage::ALWAYS_ALLOW_ID);
         TestSecurityToken::with_storage_and_policy(accounting, InMemoryPolicy::new())
@@ -802,7 +797,7 @@ mod tests {
     #[test]
     fn to_shares_two_to_one_ratio() {
         let mut accounting = InMemoryTokenAccounting::new(TOKEN);
-        accounting.shares_to_tokens_ratio = WAD * U256::from(2u64);
+        accounting.shares_to_tokens_ratio = B20SecurityStorage::WAD * U256::from(2u64);
         let token = TestSecurityToken::with_storage_and_policy(accounting, InMemoryPolicy::new());
         assert_eq!(token.to_shares(U256::from(50u64)).unwrap(), U256::from(100u64));
     }
@@ -1027,7 +1022,7 @@ mod tests {
     fn security_redeem_rejects_when_sender_policy_denies() {
         let policy_id = 7;
         let mut accounting = InMemoryTokenAccounting::new(TOKEN);
-        accounting.shares_to_tokens_ratio = WAD;
+        accounting.shares_to_tokens_ratio = B20SecurityStorage::WAD;
         accounting.balances.insert(ALICE, U256::from(100u64));
         accounting.total_supply = U256::from(100u64);
         accounting.policy_ids.insert(REDEEM_SENDER_POLICY, policy_id);
@@ -1257,7 +1252,7 @@ mod tests {
     fn security_redeem_with_non_unit_ratio_applies_correct_share_math() {
         let mut token = make_token();
         // 2:1 ratio: 1 token = 2 shares
-        token.accounting_mut().shares_to_tokens_ratio = WAD * U256::from(2u64);
+        token.accounting_mut().shares_to_tokens_ratio = B20SecurityStorage::WAD * U256::from(2u64);
         token.accounting_mut().balances.insert(ALICE, U256::from(100u64));
         token.accounting_mut().total_supply = U256::from(100u64);
         // minimum = 10 shares → need at least 5 tokens
@@ -1301,8 +1296,12 @@ mod tests {
         );
         assert_eq!(
             token.accounting().events[2],
-            IB20Security::Redeemed { from: ALICE, amt: amount, sharesToTokensRatio: WAD }
-                .encode_log_data()
+            IB20Security::Redeemed {
+                from: ALICE,
+                amt: amount,
+                sharesToTokensRatio: B20SecurityStorage::WAD,
+            }
+            .encode_log_data()
         );
     }
 
@@ -1318,7 +1317,7 @@ mod tests {
     fn to_shares_sub_wad_ratio_truncates_to_zero() {
         let mut accounting = InMemoryTokenAccounting::new(TOKEN);
         // 0.5 WAD: 1 token → 0.5 shares → truncates to 0 via integer division
-        accounting.shares_to_tokens_ratio = WAD / U256::from(2u64);
+        accounting.shares_to_tokens_ratio = B20SecurityStorage::WAD / U256::from(2u64);
         let token = TestSecurityToken::with_storage_and_policy(accounting, InMemoryPolicy::new());
         assert_eq!(token.to_shares(U256::from(1u64)).unwrap(), U256::ZERO);
     }
@@ -1345,7 +1344,10 @@ mod tests {
             token.accounting_mut().set_total_supply(U256::from(100u64)).unwrap();
             token.accounting_mut().set_minimum_redeemable(U256::from(10u64)).unwrap();
 
-            assert_eq!(token.accounting().shares_to_tokens_ratio().unwrap(), WAD);
+            assert_eq!(
+                token.accounting().shares_to_tokens_ratio().unwrap(),
+                B20SecurityStorage::WAD
+            );
             token.security_redeem(ALICE, U256::from(10u64)).unwrap();
 
             assert_eq!(token.accounting().balance_of(ALICE).unwrap(), U256::from(90u64));
@@ -1358,7 +1360,7 @@ mod tests {
     #[test]
     fn shares_to_tokens_ratio_update_persists() {
         let mut token = make_token();
-        let new_ratio = WAD * U256::from(3u64);
+        let new_ratio = B20SecurityStorage::WAD * U256::from(3u64);
         token.accounting_mut().set_shares_to_tokens_ratio(new_ratio).unwrap();
         assert_eq!(token.accounting().shares_to_tokens_ratio().unwrap(), new_ratio);
     }

--- a/crates/common/precompiles/src/b20_security/storage.rs
+++ b/crates/common/precompiles/src/b20_security/storage.rs
@@ -2,25 +2,19 @@
 
 use alloc::string::String;
 
-use alloy_primitives::{Address, B256, LogData, U256, b256};
-use base_precompile_macros::{Storable, contract};
-use base_precompile_storage::{
-    BasePrecompileError, ContractStorage, Handler, Mapping, Result, StorageCtx,
-};
+use alloy_primitives::{Address, B256, U256, b256};
+use base_precompile_macros::{SecurityAccounting, Storable, TokenAccounting, contract};
+use base_precompile_storage::{Handler, Mapping, Result, StorageCtx};
 
-use crate::{
-    B20CoreStorage, B20PolicyType, B20TokenRole, B20Variant, IB20, PolicyRegistryStorage,
-    SecurityAccounting, TokenAccounting,
-};
-
-/// WAD precision for share ratio arithmetic: 1e18.
-const WAD: U256 = U256::from_limbs([1_000_000_000_000_000_000, 0, 0, 0]);
+use crate::{B20CoreStorage, PolicyRegistryStorage};
 
 /// Security-specific B-20 storage rooted at the `base.b20.security` ERC-7201 namespace.
 #[derive(Debug, Clone, Storable)]
 #[namespace("base.b20.security")]
 pub struct B20SecurityExtensionStorage {
     /// Share-to-token conversion ratio scaled to WAD.
+    #[accessor]
+    #[mutator]
     pub shares_to_tokens_ratio: U256, // offset 0
     /// Announcement IDs that have already been consumed.
     pub used_announcement_ids: Mapping<String, bool>, // offset 1
@@ -33,13 +27,18 @@ pub struct B20SecurityExtensionStorage {
 #[namespace("base.b20.redeem")]
 pub struct B20RedeemStorage {
     /// Minimum share amount required for a redeem operation.
+    #[accessor]
+    #[mutator]
     pub minimum_redeemable: U256, // offset 0
     /// Packed redeem-side policy IDs.
+    #[accessor]
+    #[mutator]
     pub redeem_policy_ids: U256, // offset 1
 }
 
 /// EVM-backed storage for a security B-20 token.
 #[contract]
+#[derive(TokenAccounting, SecurityAccounting)]
 pub struct B20SecurityStorage {
     pub b20: B20CoreStorage,
     pub security: B20SecurityExtensionStorage,
@@ -97,287 +96,19 @@ impl<'a> B20SecurityStorage<'a> {
     }
 }
 
-impl TokenAccounting for B20SecurityStorage<'_> {
-    fn token_address(&self) -> Address {
-        ContractStorage::address(self)
-    }
-
-    fn is_initialized(&self) -> Result<bool> {
-        ContractStorage::is_initialized(self)
-    }
-
-    fn balance_of(&self, account: Address) -> Result<U256> {
-        self.b20.balances.at(&account).read()
-    }
-
-    fn set_balance(&mut self, account: Address, balance: U256) -> Result<()> {
-        self.b20.balances.at_mut(&account).write(balance)
-    }
-
-    fn allowance(&self, owner: Address, spender: Address) -> Result<U256> {
-        self.b20.allowances.at(&owner).at(&spender).read()
-    }
-
-    fn set_allowance(&mut self, owner: Address, spender: Address, amount: U256) -> Result<()> {
-        self.b20.allowances.at_mut(&owner).at_mut(&spender).write(amount)
-    }
-
-    fn total_supply(&self) -> Result<U256> {
-        self.b20.total_supply.read()
-    }
-
-    fn set_total_supply(&mut self, supply: U256) -> Result<()> {
-        self.b20.total_supply.write(supply)
-    }
-
-    fn supply_cap(&self) -> Result<U256> {
-        self.b20.supply_cap.read()
-    }
-
-    fn set_supply_cap(&mut self, cap: U256) -> Result<()> {
-        self.b20.supply_cap.write(cap)
-    }
-
-    fn name(&self) -> Result<String> {
-        self.b20.name.read()
-    }
-
-    fn set_name(&mut self, name: String) -> Result<()> {
-        self.b20.name.write(name)
-    }
-
-    fn symbol(&self) -> Result<String> {
-        self.b20.symbol.read()
-    }
-
-    fn set_symbol(&mut self, symbol: String) -> Result<()> {
-        self.b20.symbol.write(symbol)
-    }
-
-    fn decimals(&self) -> Result<u8> {
-        Ok(B20Variant::from_address(ContractStorage::address(self)).map_or(0, B20Variant::decimals))
-    }
-
-    fn paused(&self) -> Result<U256> {
-        self.b20.paused.read()
-    }
-
-    fn set_paused(&mut self, vectors: U256) -> Result<()> {
-        self.b20.paused.write(vectors)
-    }
-
-    fn nonce(&self, owner: Address) -> Result<U256> {
-        self.b20.nonces.at(&owner).read()
-    }
-
-    fn increment_nonce(&mut self, owner: Address) -> Result<()> {
-        let current = self.b20.nonces.at(&owner).read()?;
-        let next =
-            current.checked_add(U256::ONE).ok_or_else(BasePrecompileError::under_overflow)?;
-        self.b20.nonces.at_mut(&owner).write(next)
-    }
-
-    fn contract_uri(&self) -> Result<String> {
-        self.b20.contract_uri.read()
-    }
-
-    fn set_contract_uri(&mut self, uri: String) -> Result<()> {
-        self.b20.contract_uri.write(uri)
-    }
-
-    fn has_role(&self, role: B256, account: Address) -> Result<bool> {
-        self.b20.roles.at(&role).at(&account).read()
-    }
-
-    fn set_role(&mut self, role: B256, account: Address, enabled: bool) -> Result<()> {
-        self.b20.roles.at_mut(&role).at_mut(&account).write(enabled)
-    }
-
-    fn role_member_count(&self, role: B256) -> Result<U256> {
-        if role == B20TokenRole::DefaultAdmin.id() {
-            self.b20.admin_count.read()
-        } else {
-            Ok(U256::ZERO)
-        }
-    }
-
-    fn set_role_member_count(&mut self, role: B256, count: U256) -> Result<()> {
-        if role == B20TokenRole::DefaultAdmin.id() {
-            self.b20.admin_count.write(count)
-        } else {
-            Ok(())
-        }
-    }
-
-    fn role_admin(&self, role: B256) -> Result<B256> {
-        let admin_role = self.b20.role_admins.at(&role).read()?;
-        if admin_role.is_zero() && role != B20TokenRole::DefaultAdmin.id() {
-            Ok(B20TokenRole::DefaultAdmin.id())
-        } else {
-            Ok(admin_role)
-        }
-    }
-
-    fn set_role_admin(&mut self, role: B256, admin_role: B256) -> Result<()> {
-        self.b20.role_admins.at_mut(&role).write(admin_role)
-    }
-
-    fn policy_id(&self, policy_scope: B256) -> Result<u64> {
-        if policy_scope == Self::REDEEM_SENDER_POLICY {
-            return Ok(Self::read_policy_lane(
-                self.redeem.redeem_policy_ids.read()?,
-                Self::REDEEM_SENDER_POLICY_LANE,
-            ));
-        }
-        let policy_type = Self::require_b20_policy_type(policy_scope)?;
-        match policy_type {
-            B20PolicyType::TransferSender => Ok(Self::read_policy_lane(
-                self.b20.transfer_policy_ids.read()?,
-                Self::TRANSFER_SENDER_POLICY_LANE,
-            )),
-            B20PolicyType::TransferReceiver => Ok(Self::read_policy_lane(
-                self.b20.transfer_policy_ids.read()?,
-                Self::TRANSFER_RECEIVER_POLICY_LANE,
-            )),
-            B20PolicyType::TransferExecutor => Ok(Self::read_policy_lane(
-                self.b20.transfer_policy_ids.read()?,
-                Self::TRANSFER_EXECUTOR_POLICY_LANE,
-            )),
-            B20PolicyType::MintReceiver => Ok(Self::read_policy_lane(
-                self.b20.mint_policy_ids.read()?,
-                Self::MINT_RECEIVER_POLICY_LANE,
-            )),
-        }
-    }
-
-    fn set_policy_id(&mut self, policy_scope: B256, policy_id: u64) -> Result<()> {
-        if policy_scope == Self::REDEEM_SENDER_POLICY {
-            let packed = Self::write_policy_lane(
-                self.redeem.redeem_policy_ids.read()?,
-                Self::REDEEM_SENDER_POLICY_LANE,
-                policy_id,
-            );
-            return self.redeem.redeem_policy_ids.write(packed);
-        }
-        let policy_type = Self::require_b20_policy_type(policy_scope)?;
-        match policy_type {
-            B20PolicyType::TransferSender => {
-                let packed = Self::write_policy_lane(
-                    self.b20.transfer_policy_ids.read()?,
-                    Self::TRANSFER_SENDER_POLICY_LANE,
-                    policy_id,
-                );
-                self.b20.transfer_policy_ids.write(packed)
-            }
-            B20PolicyType::TransferReceiver => {
-                let packed = Self::write_policy_lane(
-                    self.b20.transfer_policy_ids.read()?,
-                    Self::TRANSFER_RECEIVER_POLICY_LANE,
-                    policy_id,
-                );
-                self.b20.transfer_policy_ids.write(packed)
-            }
-            B20PolicyType::TransferExecutor => {
-                let packed = Self::write_policy_lane(
-                    self.b20.transfer_policy_ids.read()?,
-                    Self::TRANSFER_EXECUTOR_POLICY_LANE,
-                    policy_id,
-                );
-                self.b20.transfer_policy_ids.write(packed)
-            }
-            B20PolicyType::MintReceiver => {
-                let packed = Self::write_policy_lane(
-                    self.b20.mint_policy_ids.read()?,
-                    Self::MINT_RECEIVER_POLICY_LANE,
-                    policy_id,
-                );
-                self.b20.mint_policy_ids.write(packed)
-            }
-        }
-    }
-
-    fn emit_event(&mut self, log: LogData) -> Result<()> {
-        self.emit_event(log)
-    }
-}
-
 impl B20SecurityStorage<'_> {
-    const TRANSFER_SENDER_POLICY_LANE: usize = 0;
-    const TRANSFER_RECEIVER_POLICY_LANE: usize = 1;
-    const TRANSFER_EXECUTOR_POLICY_LANE: usize = 2;
-    const MINT_RECEIVER_POLICY_LANE: usize = 0;
-    const REDEEM_SENDER_POLICY_LANE: usize = 0;
-    const POLICY_LANE_BITS: usize = 64;
+    /// WAD precision for share ratio arithmetic: 1e18.
+    pub const WAD: U256 = U256::from_limbs([1_000_000_000_000_000_000, 0, 0, 0]);
 
     /// Writes the initial packed `redeem_policy_ids` word with `REDEEM_SENDER_POLICY`
     /// set to `ALWAYS_BLOCK_ID`. Called once from [`initialize`].
     fn write_redeem_policy_ids_default(&mut self) -> Result<()> {
-        let packed = Self::write_policy_lane(
+        let packed = Self::__write_policy_lane(
             U256::ZERO,
-            Self::REDEEM_SENDER_POLICY_LANE,
+            Self::__REDEEM_SENDER_POLICY_LANE,
             PolicyRegistryStorage::ALWAYS_BLOCK_ID,
         );
-        self.redeem.redeem_policy_ids.write(packed)
-    }
-
-    fn require_b20_policy_type(policy_scope: B256) -> Result<B20PolicyType> {
-        B20PolicyType::from_id(policy_scope).ok_or_else(|| {
-            BasePrecompileError::revert(IB20::UnsupportedPolicyType { policyScope: policy_scope })
-        })
-    }
-
-    fn read_policy_lane(packed: U256, lane: usize) -> u64 {
-        ((packed >> (lane * Self::POLICY_LANE_BITS)) & U256::from(u64::MAX)).to::<u64>()
-    }
-
-    fn write_policy_lane(packed: U256, lane: usize, policy_id: u64) -> U256 {
-        let shift = lane * Self::POLICY_LANE_BITS;
-        let mask = U256::from(u64::MAX) << shift;
-        (packed & !mask) | (U256::from(policy_id) << shift)
-    }
-}
-
-impl SecurityAccounting for B20SecurityStorage<'_> {
-    fn shares_to_tokens_ratio(&self) -> Result<U256> {
-        let ratio = self.security.shares_to_tokens_ratio.read()?;
-        Ok(if ratio.is_zero() { WAD } else { ratio })
-    }
-
-    fn set_shares_to_tokens_ratio(&mut self, ratio: U256) -> Result<()> {
-        self.security.shares_to_tokens_ratio.write(ratio)
-    }
-
-    fn security_identifier(&self, identifier_type: &str) -> Result<String> {
-        self.security.identifiers.at(&String::from(identifier_type)).read()
-    }
-
-    fn set_security_identifier_value(
-        &mut self,
-        identifier_type: &str,
-        value: String,
-    ) -> Result<()> {
-        let key = String::from(identifier_type);
-        if value.is_empty() {
-            self.security.identifiers.at_mut(&key).delete()
-        } else {
-            self.security.identifiers.at_mut(&key).write(value)
-        }
-    }
-
-    fn minimum_redeemable(&self) -> Result<U256> {
-        self.redeem.minimum_redeemable.read()
-    }
-
-    fn set_minimum_redeemable(&mut self, minimum: U256) -> Result<()> {
-        self.redeem.minimum_redeemable.write(minimum)
-    }
-
-    fn is_announcement_id_used(&self, id: &str) -> Result<bool> {
-        self.security.used_announcement_ids.at(&String::from(id)).read()
-    }
-
-    fn mark_announcement_id_used(&mut self, id: &str) -> Result<()> {
-        self.security.used_announcement_ids.at_mut(&String::from(id)).write(true)
+        self.redeem.set_redeem_policy_ids(packed)
     }
 }
 
@@ -386,13 +117,11 @@ mod tests {
     use alloy_primitives::{Address, U256, address, uint};
     use base_precompile_storage::{Handler, StorableType, StorageCtx, StorageKey, setup_storage};
 
-    use crate::{
-        B20CoreStorage, B20RedeemStorage, B20SecurityExtensionStorage, B20SecurityInit,
-        B20SecurityStorage, PolicyRegistryStorage, SecurityAccounting, TokenAccounting,
-        b20_security::storage::{
-            __packing_b20_redeem_storage, __packing_b20_security_extension_storage, WAD, slots,
-        },
+    use super::{
+        __packing_b20_redeem_storage, __packing_b20_security_extension_storage, B20RedeemStorage,
+        B20SecurityExtensionStorage, B20SecurityInit, B20SecurityStorage, slots,
     };
+    use crate::{B20CoreStorage, PolicyRegistryStorage, SecurityAccounting, TokenAccounting};
 
     const TOKEN: Address = address!("000000000000000000000000000000000000b021");
     const B20_ROOT: U256 =
@@ -401,6 +130,11 @@ mod tests {
         uint!(0x4a21e1b7f963e21baf0daffe6bab858a1e5fecef1144f3aca3c0c4534c7ac600_U256);
     const REDEEM_ROOT: U256 =
         uint!(0xc95c24ab0255f9fb9fcdcd524f71c4fe0437265856b7e5e6d0801df0e6cf5100_U256);
+
+    #[test]
+    fn wad_constant_is_ten_to_the_eighteenth() {
+        assert_eq!(B20SecurityStorage::WAD, U256::from(10u64).pow(U256::from(18u64)));
+    }
 
     #[test]
     fn security_namespaces_match_base_std_roots() {
@@ -449,14 +183,14 @@ mod tests {
                 );
 
             assert_eq!(ctx.sload(TOKEN, ratio_slot).unwrap(), U256::ZERO);
-            assert_eq!(token.shares_to_tokens_ratio().unwrap(), WAD);
+            assert_eq!(token.shares_to_tokens_ratio().unwrap(), B20SecurityStorage::WAD);
         });
     }
 
     #[test]
     fn shares_to_tokens_ratio_preserves_configured_value() {
         let (mut storage, _) = setup_storage();
-        let configured_ratio = WAD * U256::from(3u64);
+        let configured_ratio = B20SecurityStorage::WAD * U256::from(3u64);
 
         StorageCtx::enter(&mut storage, |ctx| {
             let mut token = B20SecurityStorage::from_address(TOKEN, ctx);
@@ -547,7 +281,7 @@ mod tests {
                     name: String::from("Test"),
                     symbol: String::from("TST"),
                     supply_cap: U256::from(1_000_000u64),
-                    shares_to_tokens_ratio: WAD,
+                    shares_to_tokens_ratio: B20SecurityStorage::WAD,
                     isin: String::new(),
                     minimum_redeemable: U256::ZERO,
                 })

--- a/crates/common/precompiles/src/b20_stablecoin/storage.rs
+++ b/crates/common/precompiles/src/b20_stablecoin/storage.rs
@@ -2,25 +2,25 @@
 
 use alloc::string::String;
 
-use alloy_primitives::{Address, B256, LogData, U256};
-use base_precompile_macros::{Storable, contract};
-use base_precompile_storage::{BasePrecompileError, ContractStorage, Handler, Result, StorageCtx};
+use alloy_primitives::{Address, U256};
+use base_precompile_macros::{StablecoinAccounting, Storable, TokenAccounting, contract};
+use base_precompile_storage::{BasePrecompileError, Handler, Result, StorageCtx};
 
-use crate::{
-    B20CoreStorage, B20PolicyType, B20TokenRole, B20Variant, IB20, IB20Factory,
-    StablecoinAccounting, TokenAccounting,
-};
+use crate::{B20CoreStorage, IB20Factory};
 
 /// Stablecoin-specific B-20 storage rooted at the `base.b20.stablecoin` ERC-7201 namespace.
 #[derive(Debug, Clone, Storable)]
 #[namespace("base.b20.stablecoin")]
 pub struct B20StablecoinExtensionStorage {
     /// Stablecoin currency identifier.
+    #[accessor]
+    #[mutator]
     pub currency: String, // offset 0
 }
 
 /// EVM-backed storage for a stablecoin B-20 token.
 #[contract]
+#[derive(TokenAccounting, StablecoinAccounting)]
 pub struct B20StablecoinStorage {
     pub b20: B20CoreStorage,
     pub stablecoin: B20StablecoinExtensionStorage,
@@ -61,230 +61,6 @@ impl<'a> B20StablecoinStorage<'a> {
         self.b20.symbol.write(init.symbol)?;
         self.b20.supply_cap.write(init.supply_cap)?;
         self.stablecoin.currency.write(init.currency)
-    }
-}
-
-impl TokenAccounting for B20StablecoinStorage<'_> {
-    fn token_address(&self) -> Address {
-        ContractStorage::address(self)
-    }
-
-    fn is_initialized(&self) -> Result<bool> {
-        ContractStorage::is_initialized(self)
-    }
-
-    fn balance_of(&self, account: Address) -> Result<U256> {
-        self.b20.balances.at(&account).read()
-    }
-
-    fn set_balance(&mut self, account: Address, balance: U256) -> Result<()> {
-        self.b20.balances.at_mut(&account).write(balance)
-    }
-
-    fn allowance(&self, owner: Address, spender: Address) -> Result<U256> {
-        self.b20.allowances.at(&owner).at(&spender).read()
-    }
-
-    fn set_allowance(&mut self, owner: Address, spender: Address, amount: U256) -> Result<()> {
-        self.b20.allowances.at_mut(&owner).at_mut(&spender).write(amount)
-    }
-
-    fn total_supply(&self) -> Result<U256> {
-        self.b20.total_supply.read()
-    }
-
-    fn set_total_supply(&mut self, supply: U256) -> Result<()> {
-        self.b20.total_supply.write(supply)
-    }
-
-    fn supply_cap(&self) -> Result<U256> {
-        self.b20.supply_cap.read()
-    }
-
-    fn set_supply_cap(&mut self, cap: U256) -> Result<()> {
-        self.b20.supply_cap.write(cap)
-    }
-
-    fn name(&self) -> Result<String> {
-        self.b20.name.read()
-    }
-
-    fn set_name(&mut self, name: String) -> Result<()> {
-        self.b20.name.write(name)
-    }
-
-    fn symbol(&self) -> Result<String> {
-        self.b20.symbol.read()
-    }
-
-    fn set_symbol(&mut self, symbol: String) -> Result<()> {
-        self.b20.symbol.write(symbol)
-    }
-
-    fn decimals(&self) -> Result<u8> {
-        Ok(B20Variant::from_address(ContractStorage::address(self)).map_or(0, B20Variant::decimals))
-    }
-
-    fn paused(&self) -> Result<U256> {
-        self.b20.paused.read()
-    }
-
-    fn set_paused(&mut self, vectors: U256) -> Result<()> {
-        self.b20.paused.write(vectors)
-    }
-
-    fn nonce(&self, owner: Address) -> Result<U256> {
-        self.b20.nonces.at(&owner).read()
-    }
-
-    fn increment_nonce(&mut self, owner: Address) -> Result<()> {
-        let current = self.b20.nonces.at(&owner).read()?;
-        let next =
-            current.checked_add(U256::ONE).ok_or_else(BasePrecompileError::under_overflow)?;
-        self.b20.nonces.at_mut(&owner).write(next)
-    }
-
-    fn contract_uri(&self) -> Result<String> {
-        self.b20.contract_uri.read()
-    }
-
-    fn set_contract_uri(&mut self, uri: String) -> Result<()> {
-        self.b20.contract_uri.write(uri)
-    }
-
-    fn has_role(&self, role: B256, account: Address) -> Result<bool> {
-        self.b20.roles.at(&role).at(&account).read()
-    }
-
-    fn set_role(&mut self, role: B256, account: Address, enabled: bool) -> Result<()> {
-        self.b20.roles.at_mut(&role).at_mut(&account).write(enabled)
-    }
-
-    fn role_member_count(&self, role: B256) -> Result<U256> {
-        if role == B20TokenRole::DefaultAdmin.id() {
-            self.b20.admin_count.read()
-        } else {
-            Ok(U256::ZERO)
-        }
-    }
-
-    fn set_role_member_count(&mut self, role: B256, count: U256) -> Result<()> {
-        if role == B20TokenRole::DefaultAdmin.id() {
-            self.b20.admin_count.write(count)
-        } else {
-            Ok(())
-        }
-    }
-
-    fn role_admin(&self, role: B256) -> Result<B256> {
-        let admin_role = self.b20.role_admins.at(&role).read()?;
-        if admin_role.is_zero() && role != B20TokenRole::DefaultAdmin.id() {
-            Ok(B20TokenRole::DefaultAdmin.id())
-        } else {
-            Ok(admin_role)
-        }
-    }
-
-    fn set_role_admin(&mut self, role: B256, admin_role: B256) -> Result<()> {
-        self.b20.role_admins.at_mut(&role).write(admin_role)
-    }
-
-    fn policy_id(&self, policy_scope: B256) -> Result<u64> {
-        let policy_type = Self::require_policy_type(policy_scope)?;
-        match policy_type {
-            B20PolicyType::TransferSender => Ok(Self::read_policy_lane(
-                self.b20.transfer_policy_ids.read()?,
-                Self::TRANSFER_SENDER_POLICY_LANE,
-            )),
-            B20PolicyType::TransferReceiver => Ok(Self::read_policy_lane(
-                self.b20.transfer_policy_ids.read()?,
-                Self::TRANSFER_RECEIVER_POLICY_LANE,
-            )),
-            B20PolicyType::TransferExecutor => Ok(Self::read_policy_lane(
-                self.b20.transfer_policy_ids.read()?,
-                Self::TRANSFER_EXECUTOR_POLICY_LANE,
-            )),
-            B20PolicyType::MintReceiver => Ok(Self::read_policy_lane(
-                self.b20.mint_policy_ids.read()?,
-                Self::MINT_RECEIVER_POLICY_LANE,
-            )),
-        }
-    }
-
-    fn set_policy_id(&mut self, policy_scope: B256, policy_id: u64) -> Result<()> {
-        let policy_type = Self::require_policy_type(policy_scope)?;
-        match policy_type {
-            B20PolicyType::TransferSender => {
-                let packed = Self::write_policy_lane(
-                    self.b20.transfer_policy_ids.read()?,
-                    Self::TRANSFER_SENDER_POLICY_LANE,
-                    policy_id,
-                );
-                self.b20.transfer_policy_ids.write(packed)
-            }
-            B20PolicyType::TransferReceiver => {
-                let packed = Self::write_policy_lane(
-                    self.b20.transfer_policy_ids.read()?,
-                    Self::TRANSFER_RECEIVER_POLICY_LANE,
-                    policy_id,
-                );
-                self.b20.transfer_policy_ids.write(packed)
-            }
-            B20PolicyType::TransferExecutor => {
-                let packed = Self::write_policy_lane(
-                    self.b20.transfer_policy_ids.read()?,
-                    Self::TRANSFER_EXECUTOR_POLICY_LANE,
-                    policy_id,
-                );
-                self.b20.transfer_policy_ids.write(packed)
-            }
-            B20PolicyType::MintReceiver => {
-                let packed = Self::write_policy_lane(
-                    self.b20.mint_policy_ids.read()?,
-                    Self::MINT_RECEIVER_POLICY_LANE,
-                    policy_id,
-                );
-                self.b20.mint_policy_ids.write(packed)
-            }
-        }
-    }
-
-    fn emit_event(&mut self, log: LogData) -> Result<()> {
-        self.emit_event(log)
-    }
-}
-
-impl B20StablecoinStorage<'_> {
-    const TRANSFER_SENDER_POLICY_LANE: usize = 0;
-    const TRANSFER_RECEIVER_POLICY_LANE: usize = 1;
-    const TRANSFER_EXECUTOR_POLICY_LANE: usize = 2;
-    const MINT_RECEIVER_POLICY_LANE: usize = 0;
-    const POLICY_LANE_BITS: usize = 64;
-
-    fn require_policy_type(policy_scope: B256) -> Result<B20PolicyType> {
-        B20PolicyType::from_id(policy_scope).ok_or_else(|| {
-            BasePrecompileError::revert(IB20::UnsupportedPolicyType { policyScope: policy_scope })
-        })
-    }
-
-    fn read_policy_lane(packed: U256, lane: usize) -> u64 {
-        ((packed >> (lane * Self::POLICY_LANE_BITS)) & U256::from(u64::MAX)).to::<u64>()
-    }
-
-    fn write_policy_lane(packed: U256, lane: usize, policy_id: u64) -> U256 {
-        let shift = lane * Self::POLICY_LANE_BITS;
-        let mask = U256::from(u64::MAX) << shift;
-        (packed & !mask) | (U256::from(policy_id) << shift)
-    }
-}
-
-impl StablecoinAccounting for B20StablecoinStorage<'_> {
-    fn currency(&self) -> Result<String> {
-        self.stablecoin.currency.read()
-    }
-
-    fn set_currency(&mut self, currency: String) -> Result<()> {
-        self.stablecoin.currency.write(currency)
     }
 }
 


### PR DESCRIPTION
## Summary

This refactors the common precompile storage layer so simple storage accessors and mutators are generated from field attributes instead of repeated by hand. The B-20 token storage adapters now derive their accounting implementations, while security WAD precision is centralized on the security storage type. The generated code preserves the existing behavior and keeps the resulting diff net-negative.