### PR TITLE
docs(access lists): remove dangling link to non existent spec file

### DIFF
--- a/crates/common/access-lists/README.md
+++ b/crates/common/access-lists/README.md
@@ -2,8 +2,6 @@
 
 A library to build and process Flashblock-level Access Lists (FBALs).
 
-See the [spec](../../../docs/specs/pages/protocol/access-lists.md) for more details.
-
 ## Overview
 
 This crate provides types and utilities for tracking account and storage changes during EVM transaction execution, producing access lists that can be used by downstream consumers to understand exactly what state was read or modified.


### PR DESCRIPTION
Closes #2828.

The README in `crates/common/access-lists/` linked to `docs/specs/pages/protocol/access-lists.md`, but that file does not exist in the repo (and the entire `docs/specs/` tree was removed when the specs site was migrated to `base/docs`). The link resolves to a 404 for anyone clicking it.

There's no FBAL spec under `base/docs` either as far as I can tell, so this PR just removes the dangling sentence. If/when a spec is written, the reference can be added back pointing at the new location.

One-line removal, no other changes.