### PR TITLE
docs(snapshotter): note size only skip ignores manifest BLAKE3 hashes

### DIFF
--- a/crates/infra/snapshotter/src/upload.rs
+++ b/crates/infra/snapshotter/src/upload.rs
@@ -40,6 +40,10 @@ pub enum UploadStrategy {
     /// Always upload to the per-run date directory (mdbx, rocksdb, manifest).
     AlwaysUpload,
     /// Upload to `static_files/`, skipping if the remote object has the same size.
+    ///
+    /// Skip is size-based only — the BLAKE3 hashes computed in `snapshot.rs`
+    /// and recorded in `manifest.json` are not consulted here. See #2960 for
+    /// context on the asymmetry.
     DiffBySize,
 }
 


### PR DESCRIPTION
Documentation-only follow up to #2960.

Adds a short note to the `DiffBySize` doc comment in `crates/infra/snapshotter/src/upload.rs` pointing out that skip decisions only compare file size, even though `snapshot.rs` already produces per-file BLAKE3 hashes that land in `manifest.json`.

No behavior change. If #2960 ends up being resolved by actually consulting those hashes (or by deciding the asymmetry is intentional), this note can be updated or removed.