### PR TITLE
fix(proof): Thread Activation Admin

### DIFF
--- a/crates/common/evm/src/factory.rs
+++ b/crates/common/evm/src/factory.rs
@@ -34,6 +34,15 @@ impl BaseEvmFactory {
         self.activation_admin_address
     }
 
+    /// Returns this factory with the activation registry admin address set.
+    pub const fn with_activation_admin_address(
+        mut self,
+        activation_admin_address: Option<Address>,
+    ) -> Self {
+        self.set_activation_admin_address(activation_admin_address);
+        self
+    }
+
     /// Sets the activation registry admin address.
     pub const fn set_activation_admin_address(
         &mut self,

--- a/crates/common/evm/src/factory.rs
+++ b/crates/common/evm/src/factory.rs
@@ -33,6 +33,14 @@ impl BaseEvmFactory {
     pub const fn activation_admin_address(&self) -> Option<Address> {
         self.activation_admin_address
     }
+
+    /// Sets the activation registry admin address.
+    pub const fn set_activation_admin_address(
+        &mut self,
+        activation_admin_address: Option<Address>,
+    ) {
+        self.activation_admin_address = activation_admin_address;
+    }
 }
 
 impl Default for BaseEvmFactory {

--- a/crates/common/evm/src/factory.rs
+++ b/crates/common/evm/src/factory.rs
@@ -35,6 +35,7 @@ impl BaseEvmFactory {
     }
 
     /// Returns this factory with the activation registry admin address set.
+    #[must_use]
     pub const fn with_activation_admin_address(
         mut self,
         activation_admin_address: Option<Address>,

--- a/crates/proof/client/src/lib.rs
+++ b/crates/proof/client/src/lib.rs
@@ -13,7 +13,7 @@ mod epilogue;
 pub use epilogue::Epilogue;
 
 mod prologue;
-pub use prologue::Prologue;
+pub use prologue::{ActivationAdminEvmFactory, Prologue};
 
 mod driver;
 pub use driver::FaultProofDriver;

--- a/crates/proof/client/src/lib.rs
+++ b/crates/proof/client/src/lib.rs
@@ -13,7 +13,7 @@ mod epilogue;
 pub use epilogue::Epilogue;
 
 mod prologue;
-pub use prologue::{ActivationAdminEvmFactory, Prologue};
+pub use prologue::Prologue;
 
 mod driver;
 pub use driver::FaultProofDriver;

--- a/crates/proof/client/src/prologue.rs
+++ b/crates/proof/client/src/prologue.rs
@@ -2,9 +2,9 @@ use alloc::sync::Arc;
 use core::fmt::Debug;
 
 use alloy_consensus::Sealed;
-use alloy_evm::{EvmFactory, FromRecoveredTx, FromTxWithEncoded, revm::context::BlockEnv};
-use alloy_primitives::{Address, B256};
-use base_common_evm::{BaseEvmFactory, BaseSpecId, BaseTxEnv};
+use alloy_evm::{EvmFactory, FromRecoveredTx, FromTxWithEncoded};
+use alloy_primitives::B256;
+use base_common_evm::{BaseEvmFactory, BaseTxEnv};
 use base_consensus_derive::EthereumDataSource;
 use base_proof::{
     BootInfo, CachingOracle, HintType, OracleBlobProvider, OracleL1ChainProvider,
@@ -15,39 +15,24 @@ use base_proof_preimage::{CommsClient, HintWriterClient, PreimageKey, PreimageOr
 
 use crate::{FaultProofDriver, FaultProofProgramError};
 
-/// Configures a proof EVM factory with boot-derived activation registry parameters.
-pub trait ActivationAdminEvmFactory {
-    /// Returns this factory configured with `activation_admin_address`.
-    fn with_activation_admin_address(self, activation_admin_address: Option<Address>) -> Self;
-}
-
-impl ActivationAdminEvmFactory for BaseEvmFactory {
-    fn with_activation_admin_address(mut self, activation_admin_address: Option<Address>) -> Self {
-        self.set_activation_admin_address(activation_admin_address);
-        self
-    }
-}
-
 /// The prologue phase — loads boot information and initializes the derivation pipeline.
 #[derive(Debug)]
-pub struct Prologue<P, H, F> {
+pub struct Prologue<P, H> {
     oracle_client: P,
     hint_writer: H,
-    evm_factory: F,
+    evm_factory: BaseEvmFactory,
 }
 
-impl<P, H, F> Prologue<P, H, F>
+impl<P, H> Prologue<P, H>
 where
     P: PreimageOracleClient + Send + Sync + Clone + Debug + 'static,
     H: HintWriterClient + Send + Sync + Clone + Debug + 'static,
-    F: EvmFactory<Spec = BaseSpecId, BlockEnv = BlockEnv> + Send + Sync + Clone + Debug + 'static,
-    F: ActivationAdminEvmFactory,
-    F::Tx: FromTxWithEncoded<base_common_consensus::BaseTxEnvelope>
+    <BaseEvmFactory as EvmFactory>::Tx: FromTxWithEncoded<base_common_consensus::BaseTxEnvelope>
         + FromRecoveredTx<base_common_consensus::BaseTxEnvelope>
         + BaseTxEnv,
 {
     /// Creates a new prologue.
-    pub const fn new(oracle_client: P, hint_writer: H, evm_factory: F) -> Self {
+    pub const fn new(oracle_client: P, hint_writer: H, evm_factory: BaseEvmFactory) -> Self {
         Self { oracle_client, hint_writer, evm_factory }
     }
 
@@ -56,7 +41,9 @@ where
     /// # Errors
     ///
     /// Returns an error if boot information cannot be loaded or pipeline initialization fails.
-    pub async fn load(self) -> Result<FaultProofDriver<P, H, F>, FaultProofProgramError> {
+    pub async fn load(
+        self,
+    ) -> Result<FaultProofDriver<P, H, BaseEvmFactory>, FaultProofProgramError> {
         const ORACLE_LRU_SIZE: usize = 1024;
 
         let oracle = Arc::new(CachingOracle::new(
@@ -179,7 +166,7 @@ where
 mod tests {
     use alloy_primitives::address;
 
-    use super::{ActivationAdminEvmFactory, BaseEvmFactory};
+    use super::BaseEvmFactory;
 
     #[test]
     fn base_evm_factory_records_activation_admin_address() {

--- a/crates/proof/client/src/prologue.rs
+++ b/crates/proof/client/src/prologue.rs
@@ -22,8 +22,9 @@ pub trait ActivationAdminEvmFactory {
 }
 
 impl ActivationAdminEvmFactory for BaseEvmFactory {
-    fn with_activation_admin_address(self, activation_admin_address: Option<Address>) -> Self {
-        Self::new(activation_admin_address)
+    fn with_activation_admin_address(mut self, activation_admin_address: Option<Address>) -> Self {
+        self.set_activation_admin_address(activation_admin_address);
+        self
     }
 }
 

--- a/crates/proof/client/src/prologue.rs
+++ b/crates/proof/client/src/prologue.rs
@@ -3,8 +3,8 @@ use core::fmt::Debug;
 
 use alloy_consensus::Sealed;
 use alloy_evm::{EvmFactory, FromRecoveredTx, FromTxWithEncoded, revm::context::BlockEnv};
-use alloy_primitives::B256;
-use base_common_evm::{BaseSpecId, BaseTxEnv};
+use alloy_primitives::{Address, B256};
+use base_common_evm::{BaseEvmFactory, BaseSpecId, BaseTxEnv};
 use base_consensus_derive::EthereumDataSource;
 use base_proof::{
     BootInfo, CachingOracle, HintType, OracleBlobProvider, OracleL1ChainProvider,
@@ -14,6 +14,18 @@ use base_proof_executor::TrieDBProvider;
 use base_proof_preimage::{CommsClient, HintWriterClient, PreimageKey, PreimageOracleClient};
 
 use crate::{FaultProofDriver, FaultProofProgramError};
+
+/// Configures a proof EVM factory with boot-derived activation registry parameters.
+pub trait ActivationAdminEvmFactory {
+    /// Returns this factory configured with `activation_admin_address`.
+    fn with_activation_admin_address(self, activation_admin_address: Option<Address>) -> Self;
+}
+
+impl ActivationAdminEvmFactory for BaseEvmFactory {
+    fn with_activation_admin_address(self, activation_admin_address: Option<Address>) -> Self {
+        Self::new(activation_admin_address)
+    }
+}
 
 /// The prologue phase — loads boot information and initializes the derivation pipeline.
 #[derive(Debug)]
@@ -28,6 +40,7 @@ where
     P: PreimageOracleClient + Send + Sync + Clone + Debug + 'static,
     H: HintWriterClient + Send + Sync + Clone + Debug + 'static,
     F: EvmFactory<Spec = BaseSpecId, BlockEnv = BlockEnv> + Send + Sync + Clone + Debug + 'static,
+    F: ActivationAdminEvmFactory,
     F::Tx: FromTxWithEncoded<base_common_consensus::BaseTxEnvelope>
         + FromRecoveredTx<base_common_consensus::BaseTxEnvelope>
         + BaseTxEnv,
@@ -51,6 +64,8 @@ where
             self.hint_writer.clone(),
         ));
         let boot = BootInfo::load(oracle.as_ref()).await?;
+        let evm_factory =
+            self.evm_factory.with_activation_admin_address(boot.activation_admin_address);
         let l1_config = boot.l1_config;
         let rollup_config = Arc::new(boot.rollup_config);
 
@@ -136,7 +151,7 @@ where
             cursor,
             pipeline,
             l2_provider,
-            self.evm_factory,
+            evm_factory,
         ))
     }
 }
@@ -157,4 +172,20 @@ where
         .get_exact(PreimageKey::new_keccak256(*agreed_l2_output_root), output_preimage.as_mut())
         .await?;
     Ok(B256::from_slice(&output_preimage[96..128]))
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_primitives::address;
+
+    use super::{ActivationAdminEvmFactory, BaseEvmFactory};
+
+    #[test]
+    fn base_evm_factory_records_activation_admin_address() {
+        let admin = address!("331C9d37BbcebBC9dfAf98FBE3C5B8A39Dd6E771");
+
+        let factory = BaseEvmFactory::default().with_activation_admin_address(Some(admin));
+
+        assert_eq!(factory.activation_admin_address(), Some(admin));
+    }
 }


### PR DESCRIPTION
## Summary

This threads the activation registry admin from BootInfo into the EVM factory used by generic proof execution. Host replay and Nitro TEE proof paths now inherit the configured admin instead of running with a default factory that reports no activation admin. The proof-client regression covers configuring BaseEvmFactory with the boot-derived activation admin.