### PR TITLE
feat(metering): split opcode gas by contract

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4943,7 +4943,6 @@ dependencies = [
  "revm",
  "revm-bytecode",
  "revm-database",
- "revm-inspectors",
  "serde",
  "serde_json",
  "thiserror 2.0.18",

--- a/crates/common/bundles/src/meter.rs
+++ b/crates/common/bundles/src/meter.rs
@@ -7,6 +7,9 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct OpcodeGas {
+    /// Address of the contract/precompile whose execution consumed this gas.
+    #[serde(default)]
+    pub contract_address: Address,
     /// Opcode or precompile name (e.g., "SSTORE", "BLAKE2F").
     pub opcode: String,
     /// Number of times this opcode/precompile was executed in the transaction.
@@ -114,16 +117,39 @@ mod tests {
             tx_hash: B256::default(),
             value: U256::from(1_000_000_000_000_000_000u64),
             execution_time_us: 500,
-            opcode_gas: vec![],
+            opcode_gas: vec![OpcodeGas {
+                contract_address: address!("0x3333333333333333333333333333333333333333"),
+                opcode: "SSTORE".to_string(),
+                count: 1,
+                gas_used: 20_000,
+            }],
         };
 
         let json = serde_json::to_string(&result).unwrap();
         assert!(json.contains("\"fromAddress\":\"0x1111111111111111111111111111111111111111\""));
         assert!(json.contains("\"toAddress\":\"0x2222222222222222222222222222222222222222\""));
         assert!(json.contains("\"gasUsed\":21000"));
+        assert!(
+            json.contains("\"contractAddress\":\"0x3333333333333333333333333333333333333333\"")
+        );
 
         let deserialized: TransactionResult = serde_json::from_str(&json).unwrap();
         assert_eq!(deserialized, result);
+    }
+
+    #[test]
+    fn test_opcode_gas_deserialization_without_contract_address() {
+        let json = r#"{
+            "opcode": "SSTORE",
+            "count": 1,
+            "gasUsed": 20000
+        }"#;
+
+        let deserialized: OpcodeGas = serde_json::from_str(json).unwrap();
+        assert_eq!(deserialized.contract_address, Address::ZERO);
+        assert_eq!(deserialized.opcode, "SSTORE");
+        assert_eq!(deserialized.count, 1);
+        assert_eq!(deserialized.gas_used, 20_000);
     }
 
     #[test]

--- a/crates/execution/metering/Cargo.toml
+++ b/crates/execution/metering/Cargo.toml
@@ -30,7 +30,6 @@ base-execution-chainspec.workspace = true
 # revm
 revm.workspace = true
 revm-database.workspace = true
-revm-inspectors.workspace = true
 revm-bytecode.workspace = true
 
 # alloy

--- a/crates/execution/metering/src/inspector.rs
+++ b/crates/execution/metering/src/inspector.rs
@@ -90,30 +90,24 @@ impl MeteringInspector {
         std::mem::take(&mut self.precompile_gas)
     }
 
-    /// Records nested call/create gas so the parent opcode is charged only its own overhead.
+    /// Subtracts forwarded call/create gas so the parent opcode is charged only its own overhead.
     ///
-    /// The parent opcode's `step_end` sees overhead plus callee execution gas. Nested opcode
-    /// execution is already metered in the callee frame, so subtract it from the parent opcode
-    /// when CALL/CREATE-family opcodes are explicitly metered.
-    fn record_nested_gas_used(
+    /// The parent opcode's `step_end` runs before revm refunds unused child-frame gas, so it sees
+    /// overhead plus the full forwarded frame gas limit. By `call_end`/`create_end`, the parent
+    /// opcode frame has already been popped, so subtract from the accumulated opcode entry.
+    fn subtract_forwarded_gas(
         &mut self,
         contract_address: Address,
         opcode_value: u8,
-        gas_used: u64,
+        gas_limit: u64,
     ) {
         let Some(opcode) = OpCode::new(opcode_value) else { return };
         if !self.metered_opcodes.contains(&opcode) {
             return;
         }
 
-        if let Some(frame) = self
-            .opcode_frames
-            .iter_mut()
-            .rev()
-            .find(|frame| frame.contract_address == contract_address && frame.opcode == opcode)
-        {
-            frame.nested_gas_used = frame.nested_gas_used.saturating_add(gas_used);
-        }
+        let entry = self.opcode_gas.entry((contract_address, opcode)).or_default();
+        entry.gas_used = entry.gas_used.saturating_sub(gas_limit);
     }
 }
 
@@ -177,7 +171,7 @@ where
             CallScheme::Call | CallScheme::StaticCall => inputs.caller,
             CallScheme::CallCode | CallScheme::DelegateCall => inputs.target_address,
         };
-        self.record_nested_gas_used(contract_address, opcode, outcome.result.gas.total_gas_spent());
+        self.subtract_forwarded_gas(contract_address, opcode, inputs.gas_limit);
 
         let target = inputs.bytecode_address;
         if self.metered_precompiles.contains(&target) {
@@ -197,7 +191,7 @@ where
         &mut self,
         context: &mut CTX,
         inputs: &CreateInputs,
-        outcome: &mut CreateOutcome,
+        _outcome: &mut CreateOutcome,
     ) {
         let _ = context;
 
@@ -206,6 +200,6 @@ where
             CreateScheme::Create2 { .. } => opcode::CREATE2,
             CreateScheme::Custom { .. } => return,
         };
-        self.record_nested_gas_used(inputs.caller(), opcode, outcome.result.gas.total_gas_spent());
+        self.subtract_forwarded_gas(inputs.caller(), opcode, inputs.gas_limit());
     }
 }

--- a/crates/execution/metering/src/inspector.rs
+++ b/crates/execution/metering/src/inspector.rs
@@ -1,4 +1,4 @@
-//! Custom EVM inspector for metering per-opcode and precompile gas usage.
+//! Custom EVM inspector for metering per-contract opcode and precompile gas usage.
 
 use alloy_primitives::{
     Address,
@@ -7,10 +7,22 @@ use alloy_primitives::{
 use revm::{
     Inspector,
     context::ContextTr,
-    interpreter::{CallInputs, CallOutcome, CreateInputs, CreateOutcome, Interpreter},
+    interpreter::{
+        CallInputs, CallOutcome, CallScheme, CreateInputs, CreateOutcome, CreateScheme,
+        Interpreter,
+        interpreter_types::{InputsTr, Jumps},
+    },
 };
-use revm_bytecode::opcode::OpCode;
-use revm_inspectors::opcode::OpcodeGasInspector;
+use revm_bytecode::opcode::{self, OpCode};
+
+/// Accumulated gas data for a single opcode executed by one contract.
+#[derive(Debug, Default, Clone, Copy)]
+pub(crate) struct OpcodeGasUsage {
+    /// Number of times this opcode was executed.
+    pub(crate) count: u64,
+    /// Total gas consumed across all executions.
+    pub(crate) gas_used: u64,
+}
 
 /// Accumulated gas data for a single precompile address.
 #[derive(Debug, Default, Clone, Copy)]
@@ -21,21 +33,31 @@ pub(crate) struct PrecompileGasUsage {
     pub(crate) gas_used: u64,
 }
 
-/// EVM inspector that tracks per-opcode gas usage and precompile call costs.
+/// Pending opcode frame used to attribute gas after `step_end`.
+#[derive(Debug, Clone, Copy)]
+struct OpcodeFrame {
+    contract_address: Address,
+    opcode: OpCode,
+    metered: bool,
+    gas_remaining: u64,
+    nested_gas_used: u64,
+}
+
+/// EVM inspector that tracks per-contract opcode gas usage and precompile call costs.
 ///
-/// Wraps [`OpcodeGasInspector`] for opcode-level tracking and adds gas
-/// attribution for calls to precompile addresses. Precompile execution
-/// bypasses the interpreter (no `step`/`step_end` callbacks), so their
-/// gas cost is invisible to the opcode inspector alone.
+/// Opcode gas is keyed by the current EVM target address (`interp.input.target_address()`), which
+/// is also the address used by storage opcodes. This keeps storage-related opcode costs separated
+/// by the contract whose storage context is being executed.
 ///
 /// When `metered_opcodes` is empty, `step`/`step_end` are no-ops to avoid
 /// per-opcode overhead when only precompile tracking is needed.
 #[derive(Debug)]
 pub(crate) struct MeteringInspector {
-    inner: OpcodeGasInspector,
+    opcode_gas: HashMap<(Address, OpCode), OpcodeGasUsage>,
     precompile_gas: HashMap<Address, PrecompileGasUsage>,
     metered_precompiles: HashSet<Address>,
     metered_opcodes: HashSet<OpCode>,
+    opcode_frames: Vec<OpcodeFrame>,
 }
 
 impl MeteringInspector {
@@ -45,18 +67,20 @@ impl MeteringInspector {
         metered_opcodes: HashSet<OpCode>,
     ) -> Self {
         Self {
-            inner: OpcodeGasInspector::new(),
+            opcode_gas: HashMap::default(),
             precompile_gas: HashMap::default(),
             metered_precompiles,
             metered_opcodes,
+            opcode_frames: Vec::new(),
         }
     }
 
-    /// Extracts the accumulated opcode gas data and resets the inner inspector.
+    /// Extracts the accumulated opcode gas data and resets the map.
     ///
     /// Call this after each transaction to get per-transaction opcode data.
-    pub(crate) fn take_opcode_inspector(&mut self) -> OpcodeGasInspector {
-        std::mem::take(&mut self.inner)
+    pub(crate) fn take_opcode_gas(&mut self) -> HashMap<(Address, OpCode), OpcodeGasUsage> {
+        self.opcode_frames.clear();
+        std::mem::take(&mut self.opcode_gas)
     }
 
     /// Extracts the accumulated precompile gas data and resets the map.
@@ -65,6 +89,32 @@ impl MeteringInspector {
     pub(crate) fn take_precompile_gas(&mut self) -> HashMap<Address, PrecompileGasUsage> {
         std::mem::take(&mut self.precompile_gas)
     }
+
+    /// Records nested call/create gas so the parent opcode is charged only its own overhead.
+    ///
+    /// The parent opcode's `step_end` sees overhead plus callee execution gas. Nested opcode
+    /// execution is already metered in the callee frame, so subtract it from the parent opcode
+    /// when CALL/CREATE-family opcodes are explicitly metered.
+    fn record_nested_gas_used(
+        &mut self,
+        contract_address: Address,
+        opcode_value: u8,
+        gas_used: u64,
+    ) {
+        let Some(opcode) = OpCode::new(opcode_value) else { return };
+        if !self.metered_opcodes.contains(&opcode) {
+            return;
+        }
+
+        if let Some(frame) = self
+            .opcode_frames
+            .iter_mut()
+            .rev()
+            .find(|frame| frame.contract_address == contract_address && frame.opcode == opcode)
+        {
+            frame.nested_gas_used = frame.nested_gas_used.saturating_add(gas_used);
+        }
+    }
 }
 
 impl<CTX> Inspector<CTX> for MeteringInspector
@@ -72,34 +122,75 @@ where
     CTX: ContextTr,
 {
     fn step(&mut self, interp: &mut Interpreter, context: &mut CTX) {
-        if !self.metered_opcodes.is_empty() {
-            self.inner.step(interp, context);
+        let _ = context;
+
+        if self.metered_opcodes.is_empty() {
+            return;
         }
+
+        let Some(opcode) = OpCode::new(interp.bytecode.opcode()) else { return };
+        let contract_address = interp.input.target_address();
+        let metered = self.metered_opcodes.contains(&opcode);
+        if metered {
+            let entry = self.opcode_gas.entry((contract_address, opcode)).or_default();
+            entry.count = entry.count.saturating_add(1);
+        }
+        self.opcode_frames.push(OpcodeFrame {
+            contract_address,
+            opcode,
+            metered,
+            gas_remaining: interp.gas.remaining(),
+            nested_gas_used: 0,
+        });
     }
 
     fn step_end(&mut self, interp: &mut Interpreter, context: &mut CTX) {
-        if !self.metered_opcodes.is_empty() {
-            self.inner.step_end(interp, context);
+        let _ = context;
+
+        if let Some(frame) = self.opcode_frames.pop()
+            && frame.metered
+        {
+            let gas_cost = frame
+                .gas_remaining
+                .saturating_sub(interp.gas.remaining())
+                .saturating_sub(frame.nested_gas_used);
+            let entry = self.opcode_gas.entry((frame.contract_address, frame.opcode)).or_default();
+            entry.gas_used = entry.gas_used.saturating_add(gas_cost);
         }
     }
 
     fn call(&mut self, context: &mut CTX, inputs: &mut CallInputs) -> Option<CallOutcome> {
-        self.inner.call(context, inputs)
+        let _ = (context, inputs);
+        None
     }
 
     fn call_end(&mut self, context: &mut CTX, inputs: &CallInputs, outcome: &mut CallOutcome) {
-        self.inner.call_end(context, inputs, outcome);
+        let _ = context;
+
+        let opcode = match inputs.scheme {
+            CallScheme::Call => opcode::CALL,
+            CallScheme::CallCode => opcode::CALLCODE,
+            CallScheme::DelegateCall => opcode::DELEGATECALL,
+            CallScheme::StaticCall => opcode::STATICCALL,
+        };
+        let contract_address = match inputs.scheme {
+            CallScheme::Call | CallScheme::StaticCall => inputs.caller,
+            CallScheme::CallCode | CallScheme::DelegateCall => inputs.target_address,
+        };
+        self.record_nested_gas_used(contract_address, opcode, outcome.result.gas.total_gas_spent());
+
         let target = inputs.bytecode_address;
         if self.metered_precompiles.contains(&target) {
             let gas_used = outcome.result.gas.total_gas_spent();
             let entry = self.precompile_gas.entry(target).or_default();
-            entry.count += 1;
-            entry.gas_used += gas_used;
+            entry.count = entry.count.saturating_add(1);
+            entry.gas_used = entry.gas_used.saturating_add(gas_used);
         }
     }
 
     fn create(&mut self, context: &mut CTX, inputs: &mut CreateInputs) -> Option<CreateOutcome> {
-        self.inner.create(context, inputs)
+        let _ = (context, inputs);
+        None
     }
 
     fn create_end(
@@ -108,6 +199,13 @@ where
         inputs: &CreateInputs,
         outcome: &mut CreateOutcome,
     ) {
-        self.inner.create_end(context, inputs, outcome);
+        let _ = context;
+
+        let opcode = match inputs.scheme() {
+            CreateScheme::Create => opcode::CREATE,
+            CreateScheme::Create2 { .. } => opcode::CREATE2,
+            CreateScheme::Custom { .. } => return,
+        };
+        self.record_nested_gas_used(inputs.caller(), opcode, outcome.result.gas.total_gas_spent());
     }
 }

--- a/crates/execution/metering/src/inspector.rs
+++ b/crates/execution/metering/src/inspector.rs
@@ -38,9 +38,7 @@ pub(crate) struct PrecompileGasUsage {
 struct OpcodeFrame {
     contract_address: Address,
     opcode: OpCode,
-    metered: bool,
     gas_remaining: u64,
-    nested_gas_used: u64,
 }
 
 /// EVM inspector that tracks per-contract opcode gas usage and precompile call costs.
@@ -57,7 +55,7 @@ pub(crate) struct MeteringInspector {
     precompile_gas: HashMap<Address, PrecompileGasUsage>,
     metered_precompiles: HashSet<Address>,
     metered_opcodes: HashSet<OpCode>,
-    opcode_frames: Vec<OpcodeFrame>,
+    opcode_frame: Option<OpcodeFrame>,
 }
 
 impl MeteringInspector {
@@ -71,7 +69,7 @@ impl MeteringInspector {
             precompile_gas: HashMap::default(),
             metered_precompiles,
             metered_opcodes,
-            opcode_frames: Vec::new(),
+            opcode_frame: None,
         }
     }
 
@@ -79,7 +77,7 @@ impl MeteringInspector {
     ///
     /// Call this after each transaction to get per-transaction opcode data.
     pub(crate) fn take_opcode_gas(&mut self) -> HashMap<(Address, OpCode), OpcodeGasUsage> {
-        self.opcode_frames.clear();
+        self.opcode_frame = None;
         std::mem::take(&mut self.opcode_gas)
     }
 
@@ -124,30 +122,21 @@ where
 
         let Some(opcode) = OpCode::new(interp.bytecode.opcode()) else { return };
         let contract_address = interp.input.target_address();
-        let metered = self.metered_opcodes.contains(&opcode);
-        if metered {
-            let entry = self.opcode_gas.entry((contract_address, opcode)).or_default();
-            entry.count = entry.count.saturating_add(1);
+        if !self.metered_opcodes.contains(&opcode) {
+            return;
         }
-        self.opcode_frames.push(OpcodeFrame {
-            contract_address,
-            opcode,
-            metered,
-            gas_remaining: interp.gas.remaining(),
-            nested_gas_used: 0,
-        });
+
+        let entry = self.opcode_gas.entry((contract_address, opcode)).or_default();
+        entry.count = entry.count.saturating_add(1);
+        self.opcode_frame =
+            Some(OpcodeFrame { contract_address, opcode, gas_remaining: interp.gas.remaining() });
     }
 
     fn step_end(&mut self, interp: &mut Interpreter, context: &mut CTX) {
         let _ = context;
 
-        if let Some(frame) = self.opcode_frames.pop()
-            && frame.metered
-        {
-            let gas_cost = frame
-                .gas_remaining
-                .saturating_sub(interp.gas.remaining())
-                .saturating_sub(frame.nested_gas_used);
+        if let Some(frame) = self.opcode_frame.take() {
+            let gas_cost = frame.gas_remaining.saturating_sub(interp.gas.remaining());
             let entry = self.opcode_gas.entry((frame.contract_address, frame.opcode)).or_default();
             entry.gas_used = entry.gas_used.saturating_add(gas_cost);
         }

--- a/crates/execution/metering/src/meter.rs
+++ b/crates/execution/metering/src/meter.rs
@@ -973,6 +973,82 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn meter_bundle_opcode_gas_subtracts_nested_call_gas() -> eyre::Result<()> {
+        let harness = TestHarness::new().await?;
+
+        let (factory_deployment_tx, factory_address, _) =
+            Account::Deployer.create_deployment_tx(ContractFactory::BYTECODE.clone(), 0)?;
+        harness.build_block_from_transactions(vec![factory_deployment_tx]).await?;
+
+        let latest = harness.latest_block();
+        let header = latest.sealed_header().clone();
+
+        let signed_tx = TransactionBuilder::default()
+            .signer(Account::Alice.signer_b256())
+            .chain_id(harness.chain_id())
+            .nonce(0)
+            .to(factory_address)
+            .gas_limit(1_000_000)
+            .max_fee_per_gas(MIN_BASEFEE as u128)
+            .max_priority_fee_per_gas(0)
+            .input(
+                ContractFactory::deployAndCallCall {
+                    bytecode: SimpleStorage::BYTECODE.clone(),
+                    callData: SimpleStorage::setValueCall { v: U256::from(42) }.abi_encode().into(),
+                }
+                .abi_encode(),
+            )
+            .into_eip1559();
+
+        let tx = BaseTransactionSigned::Eip1559(
+            signed_tx.as_eip1559().expect("eip1559 transaction").clone(),
+        );
+
+        let state_provider = harness
+            .blockchain_provider()
+            .state_by_block_hash(latest.hash())
+            .context("getting state provider")?;
+
+        let parsed_bundle = create_parsed_bundle(vec![tx])?;
+        let metered = MeteredOpcodes::parse(&["CALL".to_string(), "SSTORE".to_string()]).unwrap();
+
+        let output = meter_bundle(MeterBundleInput {
+            state_provider,
+            chain_spec: harness.chain_spec(),
+            bundle: parsed_bundle,
+            header: header.clone(),
+            parent_beacon_block_root: header.parent_beacon_block_root(),
+            pending_state: None,
+            l1_block_info: L1BlockInfo::default(),
+            metered_opcodes: Arc::new(metered),
+        })?;
+
+        assert_eq!(output.results.len(), 1);
+        let tx_opcodes = &output.results[0].opcode_gas;
+        let call = tx_opcodes
+            .iter()
+            .find(|entry| entry.opcode == "CALL" && entry.contract_address == factory_address)
+            .expect("factory should report CALL gas");
+        let sstore = tx_opcodes
+            .iter()
+            .find(|entry| entry.opcode == "SSTORE" && entry.contract_address != factory_address)
+            .expect("callee should report SSTORE gas");
+
+        assert_eq!(call.count, 1, "factory should execute one CALL into SimpleStorage");
+        assert_eq!(sstore.count, 1, "callee should execute one SSTORE");
+        assert!(call.gas_used > 0, "CALL gas_used should be non-zero");
+        assert!(sstore.gas_used > 0, "SSTORE gas_used should be non-zero");
+        assert!(
+            call.gas_used < sstore.gas_used,
+            "CALL gas should exclude nested callee gas: CALL={} SSTORE={}",
+            call.gas_used,
+            sstore.gas_used
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn meter_bundle_opcode_gas_empty_when_disabled() -> eyre::Result<()> {
         let harness = TestHarness::new().await?;
         let latest = harness.latest_block();

--- a/crates/execution/metering/src/meter.rs
+++ b/crates/execution/metering/src/meter.rs
@@ -450,20 +450,17 @@ where
 
             // Extract per-transaction opcode and precompile gas, then reset for next tx.
             let inspector = builder.evm_mut().inspector_mut();
-            let opcode_data = inspector.take_opcode_inspector();
+            let opcode_data = inspector.take_opcode_gas();
             let precompile_data = inspector.take_precompile_gas();
 
-            let mut opcode_gas: Vec<OpcodeGas> = metered_opcodes
-                .opcodes
+            let mut opcode_gas: Vec<OpcodeGas> = opcode_data
                 .iter()
-                .filter_map(|&opcode| {
-                    let count = opcode_data.opcode_counts().get(&opcode).copied().unwrap_or(0);
-                    if count > 0 {
-                        let gas_used = opcode_data.opcode_gas().get(&opcode).copied().unwrap_or(0);
-                        Some(OpcodeGas { opcode: opcode.as_str().to_string(), count, gas_used })
-                    } else {
-                        None
-                    }
+                .filter(|(_, usage)| usage.count > 0)
+                .map(|(&(contract_address, opcode), usage)| OpcodeGas {
+                    contract_address,
+                    opcode: opcode.as_str().to_string(),
+                    count: usage.count,
+                    gas_used: usage.gas_used,
                 })
                 .collect();
 
@@ -472,12 +469,16 @@ where
                     && usage.count > 0
                 {
                     opcode_gas.push(OpcodeGas {
+                        contract_address: *addr,
                         opcode: name.clone(),
                         count: usage.count,
                         gas_used: usage.gas_used,
                     });
                 }
             }
+            opcode_gas.sort_by(|a, b| {
+                a.contract_address.cmp(&b.contract_address).then_with(|| a.opcode.cmp(&b.opcode))
+            });
 
             results.push(TransactionResult {
                 coinbase_diff: gas_fees,
@@ -826,8 +827,86 @@ mod tests {
         let sstore = tx_opcodes.iter().find(|o| o.opcode == "SSTORE");
         assert!(sstore.is_some(), "SSTORE should appear in opcode gas results");
         let sstore = sstore.unwrap();
+        assert_eq!(sstore.contract_address, contract_address);
         assert!(sstore.count > 0, "SSTORE count should be non-zero");
         assert!(sstore.gas_used > 0, "SSTORE gas_used should be non-zero");
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn meter_bundle_opcode_gas_splits_by_contract() -> eyre::Result<()> {
+        let harness = TestHarness::new().await?;
+
+        let (deployment_tx_1, contract_address_1, _) =
+            Account::Deployer.create_deployment_tx(SimpleStorage::BYTECODE.clone(), 0)?;
+        let (deployment_tx_2, contract_address_2, _) =
+            Account::Deployer.create_deployment_tx(SimpleStorage::BYTECODE.clone(), 1)?;
+        harness.build_block_from_transactions(vec![deployment_tx_1, deployment_tx_2]).await?;
+
+        let latest = harness.latest_block();
+        let header = latest.sealed_header().clone();
+
+        let tx_1 = TransactionBuilder::default()
+            .signer(Account::Alice.signer_b256())
+            .chain_id(harness.chain_id())
+            .nonce(0)
+            .to(contract_address_1)
+            .gas_limit(100_000)
+            .max_fee_per_gas(MIN_BASEFEE as u128)
+            .max_priority_fee_per_gas(0)
+            .input(SimpleStorage::setValueCall { v: U256::from(1) }.abi_encode())
+            .into_eip1559();
+        let tx_1 =
+            BaseTransactionSigned::Eip1559(tx_1.as_eip1559().expect("eip1559 transaction").clone());
+
+        let tx_2 = TransactionBuilder::default()
+            .signer(Account::Alice.signer_b256())
+            .chain_id(harness.chain_id())
+            .nonce(1)
+            .to(contract_address_2)
+            .gas_limit(100_000)
+            .max_fee_per_gas(MIN_BASEFEE as u128)
+            .max_priority_fee_per_gas(0)
+            .input(SimpleStorage::setValueCall { v: U256::from(2) }.abi_encode())
+            .into_eip1559();
+        let tx_2 =
+            BaseTransactionSigned::Eip1559(tx_2.as_eip1559().expect("eip1559 transaction").clone());
+
+        let state_provider = harness
+            .blockchain_provider()
+            .state_by_block_hash(latest.hash())
+            .context("getting state provider")?;
+
+        let parsed_bundle = create_parsed_bundle(vec![tx_1, tx_2])?;
+        let metered = MeteredOpcodes::parse(&["SSTORE".to_string()]).unwrap();
+
+        let output = meter_bundle(MeterBundleInput {
+            state_provider,
+            chain_spec: harness.chain_spec(),
+            bundle: parsed_bundle,
+            header: header.clone(),
+            parent_beacon_block_root: header.parent_beacon_block_root(),
+            pending_state: None,
+            l1_block_info: L1BlockInfo::default(),
+            metered_opcodes: Arc::new(metered),
+        })?;
+
+        assert_eq!(output.results.len(), 2);
+        let sstore_1 = output.results[0]
+            .opcode_gas
+            .iter()
+            .find(|entry| entry.opcode == "SSTORE")
+            .expect("first contract should report SSTORE gas");
+        let sstore_2 = output.results[1]
+            .opcode_gas
+            .iter()
+            .find(|entry| entry.opcode == "SSTORE")
+            .expect("second contract should report SSTORE gas");
+
+        assert_eq!(sstore_1.contract_address, contract_address_1);
+        assert_eq!(sstore_2.contract_address, contract_address_2);
+        assert_ne!(sstore_1.contract_address, sstore_2.contract_address);
 
         Ok(())
     }


### PR DESCRIPTION
## Summary
- key meterBundle opcode gas usage by executed contract address
- include `contractAddress` on each opcode/precompile gas response entry
- add coverage that two contracts executing SSTORE report separate opcode gas rows
- remove the now-unused `revm-inspectors` dependency from `base-metering`

## Why
Tracking opcode calls and gas costs gives us a lever to compute synthetic metering gas with adjusted pricing that reflects actual load. Splitting storage opcode usage by executed contract makes it possible to price storage-heavy behavior against contract-local state size, rather than only using transaction gas or bundle-level state-root timing.

This synthetic gas is not charged to users. It is intended for metering and throttling so Base can keep chain performance healthy. If the per-contract opcode signal is precise enough, it may also let us reduce or remove state-root calculation from `meterBundle`, lowering the latency required to enforce resource throttling.

## Testing
- `cargo test -p base-metering --lib`
- `cargo test -p base-bundles --lib`
- `cargo check -p base-metering`
- `cargo +nightly fmt --check`
- `cargo clippy -p base-metering --lib -- -D warnings`
- `cargo clippy -p base-bundles --lib -- -D warnings`
- `git diff --check`

type=routine
risk=low
impact=sev5