### PR TITLE
refactor(consensus/checkpoint): derive on-disk offsets from field sizes

### DIFF
--- a/crates/consensus/service/src/actors/checkpoint/db.rs
+++ b/crates/consensus/service/src/actors/checkpoint/db.rs
@@ -10,7 +10,42 @@ use tokio::task;
 
 use super::CheckpointError;
 
+/// On-disk size of a [`B256`] hash.
+const B256_LEN: usize = 32;
+/// On-disk size of a `u64`.
+const U64_LEN: usize = 8;
+
+/// Byte offsets of each [`L2BlockInfo`] field within the encoded payload, derived from the
+/// field order in [`CheckpointDB::encode`].
+///
+/// Centralising the offsets here means a field change is a single-point edit: extend or
+/// reorder the chain, and every reader and writer (and the layout-pinning test) is updated
+/// in lockstep instead of through a fan-out of hand-counted magic numbers.
+const HASH_OFFSET: usize = 0;
+const NUMBER_OFFSET: usize = HASH_OFFSET + B256_LEN;
+const PARENT_HASH_OFFSET: usize = NUMBER_OFFSET + U64_LEN;
+const TIMESTAMP_OFFSET: usize = PARENT_HASH_OFFSET + B256_LEN;
+const L1_ORIGIN_NUMBER_OFFSET: usize = TIMESTAMP_OFFSET + U64_LEN;
+const L1_ORIGIN_HASH_OFFSET: usize = L1_ORIGIN_NUMBER_OFFSET + U64_LEN;
+const SEQ_NUM_OFFSET: usize = L1_ORIGIN_HASH_OFFSET + B256_LEN;
+const PAYLOAD_END: usize = SEQ_NUM_OFFSET + U64_LEN;
+
+/// Encoded checkpoint value length. Fixed at 128 bytes so the on-disk schema is identical
+/// to the original layout shipped in #2698; any existing databases continue to round-trip
+/// without migration.
+///
+/// The current payload (`PAYLOAD_END`) fills this slot exactly — there is no spare capacity.
+/// Any new field appended to [`L2BlockInfo`] will require expanding this constant, which
+/// changes the redb table type (`&[u8; 128]`) and is an on-disk-breaking migration that
+/// must be handled deliberately.
 const CHECKPOINT_VALUE_LEN: usize = 128;
+
+const _: () = assert!(
+    PAYLOAD_END <= CHECKPOINT_VALUE_LEN,
+    "L2BlockInfo encoding overflows the redb value slot; expanding CHECKPOINT_VALUE_LEN \
+     is a breaking on-disk change"
+);
+
 const CHECKPOINTS: TableDefinition<'_, u8, &[u8; CHECKPOINT_VALUE_LEN]> =
     TableDefinition::new("checkpoints");
 
@@ -85,29 +120,29 @@ impl CheckpointDB {
 
     fn encode(block: L2BlockInfo) -> [u8; Self::VALUE_LEN] {
         let mut bytes = [0; Self::VALUE_LEN];
-        put_b256(&mut bytes, 0, block.block_info.hash);
-        put_u64(&mut bytes, 32, block.block_info.number);
-        put_b256(&mut bytes, 40, block.block_info.parent_hash);
-        put_u64(&mut bytes, 72, block.block_info.timestamp);
-        put_u64(&mut bytes, 80, block.l1_origin.number);
-        put_b256(&mut bytes, 88, block.l1_origin.hash);
-        put_u64(&mut bytes, 120, block.seq_num);
+        put_b256(&mut bytes, HASH_OFFSET, block.block_info.hash);
+        put_u64(&mut bytes, NUMBER_OFFSET, block.block_info.number);
+        put_b256(&mut bytes, PARENT_HASH_OFFSET, block.block_info.parent_hash);
+        put_u64(&mut bytes, TIMESTAMP_OFFSET, block.block_info.timestamp);
+        put_u64(&mut bytes, L1_ORIGIN_NUMBER_OFFSET, block.l1_origin.number);
+        put_b256(&mut bytes, L1_ORIGIN_HASH_OFFSET, block.l1_origin.hash);
+        put_u64(&mut bytes, SEQ_NUM_OFFSET, block.seq_num);
         bytes
     }
 
     fn decode(bytes: &[u8; Self::VALUE_LEN]) -> L2BlockInfo {
         L2BlockInfo {
             block_info: BlockInfo {
-                hash: get_b256(bytes, 0),
-                number: get_u64(bytes, 32),
-                parent_hash: get_b256(bytes, 40),
-                timestamp: get_u64(bytes, 72),
+                hash: get_b256(bytes, HASH_OFFSET),
+                number: get_u64(bytes, NUMBER_OFFSET),
+                parent_hash: get_b256(bytes, PARENT_HASH_OFFSET),
+                timestamp: get_u64(bytes, TIMESTAMP_OFFSET),
             },
             l1_origin: alloy_eips::BlockNumHash {
-                number: get_u64(bytes, 80),
-                hash: get_b256(bytes, 88),
+                number: get_u64(bytes, L1_ORIGIN_NUMBER_OFFSET),
+                hash: get_b256(bytes, L1_ORIGIN_HASH_OFFSET),
             },
-            seq_num: get_u64(bytes, 120),
+            seq_num: get_u64(bytes, SEQ_NUM_OFFSET),
         }
     }
 }
@@ -120,19 +155,19 @@ const fn label_key(label: ForkchoiceCheckpointLabel) -> u8 {
 }
 
 fn put_b256(bytes: &mut [u8; CheckpointDB::VALUE_LEN], offset: usize, value: B256) {
-    bytes[offset..offset + 32].copy_from_slice(value.as_slice());
+    bytes[offset..offset + B256_LEN].copy_from_slice(value.as_slice());
 }
 
 fn put_u64(bytes: &mut [u8; CheckpointDB::VALUE_LEN], offset: usize, value: u64) {
-    bytes[offset..offset + 8].copy_from_slice(&value.to_be_bytes());
+    bytes[offset..offset + U64_LEN].copy_from_slice(&value.to_be_bytes());
 }
 
 fn get_b256(bytes: &[u8; CheckpointDB::VALUE_LEN], offset: usize) -> B256 {
-    B256::from_slice(&bytes[offset..offset + 32])
+    B256::from_slice(&bytes[offset..offset + B256_LEN])
 }
 
 fn get_u64(bytes: &[u8; CheckpointDB::VALUE_LEN], offset: usize) -> u64 {
-    u64::from_be_bytes(bytes[offset..offset + 8].try_into().expect("slice length is 8"))
+    u64::from_be_bytes(bytes[offset..offset + U64_LEN].try_into().expect("slice length is 8"))
 }
 
 #[cfg(test)]
@@ -144,11 +179,8 @@ mod tests {
 
     use super::CheckpointDB;
 
-    #[tokio::test]
-    async fn checkpoint_survives_reopen() {
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("checkpoint.redb");
-        let checkpoint = L2BlockInfo {
+    fn sample_checkpoint() -> L2BlockInfo {
+        L2BlockInfo {
             block_info: BlockInfo {
                 hash: B256::with_last_byte(1),
                 number: 10,
@@ -157,7 +189,30 @@ mod tests {
             },
             l1_origin: BlockNumHash { number: 4, hash: B256::with_last_byte(5) },
             seq_num: 6,
-        };
+        }
+    }
+
+    /// Hand-constructed bytes of the v0.13 / #2698 layout. Any encoder change that perturbs
+    /// these bytes \u2014 or any decoder change that fails to reconstruct
+    /// [`sample_checkpoint`] from them \u2014 will fail the round-trip tests below and surface
+    /// loudly instead of silently producing wrong records on already-deployed databases.
+    fn legacy_encoded_bytes() -> [u8; CheckpointDB::VALUE_LEN] {
+        let mut bytes = [0u8; CheckpointDB::VALUE_LEN];
+        bytes[31] = 1;
+        bytes[32..40].copy_from_slice(&10u64.to_be_bytes());
+        bytes[71] = 2;
+        bytes[72..80].copy_from_slice(&30u64.to_be_bytes());
+        bytes[80..88].copy_from_slice(&4u64.to_be_bytes());
+        bytes[119] = 5;
+        bytes[120..128].copy_from_slice(&6u64.to_be_bytes());
+        bytes
+    }
+
+    #[tokio::test]
+    async fn checkpoint_survives_reopen() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("checkpoint.redb");
+        let checkpoint = sample_checkpoint();
 
         {
             let db = CheckpointDB::open(&path).unwrap();
@@ -167,5 +222,20 @@ mod tests {
         let db = CheckpointDB::open(&path).unwrap();
         let stored = db.checkpoint(ForkchoiceCheckpointLabel::Safe).await.unwrap();
         assert_eq!(stored, Some(checkpoint));
+    }
+
+    #[test]
+    fn encode_matches_pinned_layout() {
+        assert_eq!(
+            CheckpointDB::encode(sample_checkpoint()),
+            legacy_encoded_bytes(),
+            "L2BlockInfo on-disk encoding has changed; databases written by earlier builds \
+             will be mis-decoded"
+        );
+    }
+
+    #[test]
+    fn decode_round_trips_pinned_layout() {
+        assert_eq!(CheckpointDB::decode(&legacy_encoded_bytes()), sample_checkpoint());
     }
 }


### PR DESCRIPTION
## Summary
- Replace the hand-counted magic offsets in \`CheckpointDB::encode\` / \`decode\` with a chain of \`const\`s anchored to \`B256_LEN\` and \`U64_LEN\`. Adding or reordering an \`L2BlockInfo\` field is now a single-point edit instead of a fan-out of seven numeric literals.
- Pin the byte layout with a golden \`encode_matches_pinned_layout\` test and a paired \`decode_round_trips_pinned_layout\` test. The pinned bytes match the schema shipped in #2698 verbatim, so any accidental drift in the encoder, decoder, or offset chain trips the tests instead of silently corrupting deployed databases.
- Add a compile-time \`const\` assertion that \`PAYLOAD_END <= CHECKPOINT_VALUE_LEN\` so any future field expansion that would overflow the 128-byte redb value slot fails at build time, not at first read on a running node.

## Why
Pointed out in #2698 review: the original encoder used seven hand-counted byte offsets (\`0/32/40/72/80/88/120\`) that had to be kept in lockstep with the struct layout. Editing the struct meant updating literal numbers in two places, with nothing structural to catch a mistake.

A first iteration of this PR added a leading version byte, but that would have changed the redb table value type from \`&[u8; 128]\` to \`&[u8; 129]\` and broken on-disk compatibility for any node carrying an existing checkpoint database \u2014 defeating the whole point of #2698. This version keeps the 128-byte layout exactly as shipped, makes the offsets self-describing, and adds the golden test so future changes can't silently mis-decode existing records.

## Test plan
- \`cargo clippy -p base-consensus-node --all-targets -- -D warnings\`
- \`cargo test -p base-consensus-node --lib actors::checkpoint::db\` \u2014 3 tests pass (round-trip, encode pin, decode pin)