### PR TITLE
fix(consensus/engine): log-and-continue on checkpoint write failure

### DIFF
--- a/crates/consensus/service/src/actors/engine/engine_request_processor.rs
+++ b/crates/consensus/service/src/actors/engine/engine_request_processor.rs
@@ -198,7 +198,7 @@ where
             )
             .await?;
 
-        self.checkpoint_forkchoice_state_if_updated().await?;
+        self.checkpoint_forkchoice_state_if_updated().await;
 
         // Signal the derivation actor to reset.
         let signal = ResetSignal { l2_safe_head };
@@ -215,26 +215,44 @@ where
         Ok(())
     }
 
-    async fn checkpoint_forkchoice_state_if_updated(&mut self) -> Result<(), EngineError> {
+    async fn checkpoint_forkchoice_state_if_updated(&mut self) {
         let safe_head = self.engine.state().sync_state.safe_head();
         if safe_head != L2BlockInfo::default() && safe_head != self.last_safe_head_checkpointed {
-            self.checkpoint_writer
+            match self
+                .checkpoint_writer
                 .update_checkpoint(ForkchoiceCheckpointLabel::Safe, safe_head)
-                .await?;
-            self.last_safe_head_checkpointed = safe_head;
+                .await
+            {
+                Ok(()) => self.last_safe_head_checkpointed = safe_head,
+                Err(err) => warn!(
+                    target: "engine",
+                    error = %err,
+                    block_number = safe_head.block_info.number,
+                    block_hash = %safe_head.block_info.hash,
+                    "failed to persist safe head checkpoint; continuing without it"
+                ),
+            }
         }
 
         let finalized_head = self.engine.state().sync_state.finalized_head();
         if finalized_head != L2BlockInfo::default()
             && finalized_head != self.last_finalized_head_checkpointed
         {
-            self.checkpoint_writer
+            match self
+                .checkpoint_writer
                 .update_checkpoint(ForkchoiceCheckpointLabel::Finalized, finalized_head)
-                .await?;
-            self.last_finalized_head_checkpointed = finalized_head;
+                .await
+            {
+                Ok(()) => self.last_finalized_head_checkpointed = finalized_head,
+                Err(err) => warn!(
+                    target: "engine",
+                    error = %err,
+                    block_number = finalized_head.block_info.number,
+                    block_hash = %finalized_head.block_info.hash,
+                    "failed to persist finalized head checkpoint; continuing without it"
+                ),
+            }
         }
-
-        Ok(())
     }
 
     /// Handles an [`EngineTaskErrors`] according to its severity.
@@ -297,7 +315,7 @@ where
             }
         }
 
-        self.checkpoint_forkchoice_state_if_updated().await?;
+        self.checkpoint_forkchoice_state_if_updated().await;
         self.send_derivation_actor_safe_head_if_updated().await?;
 
         if !self.el_sync_complete && self.engine.state().el_sync_finished {

--- a/crates/consensus/service/src/actors/engine/error.rs
+++ b/crates/consensus/service/src/actors/engine/error.rs
@@ -4,8 +4,6 @@
 
 use base_consensus_engine::{EngineResetError, EngineTaskErrors};
 
-use crate::CheckpointError;
-
 /// An error from the [`EngineActor`].
 ///
 /// [`EngineActor`]: super::EngineActor
@@ -23,7 +21,4 @@ pub enum EngineError {
     /// A critical engine task error was already forwarded to the request caller.
     #[error("critical engine task error: {0}")]
     CriticalEngineTask(String),
-    /// Checkpoint error.
-    #[error(transparent)]
-    Checkpoint(#[from] CheckpointError),
 }


### PR DESCRIPTION
## Summary
- Switch \`checkpoint_forkchoice_state_if_updated\` to log redb write failures at \`warn\` instead of propagating them out of the engine actor. The tracker fields (\`last_safe_head_checkpointed\` / \`last_finalized_head_checkpointed\`) advance only on success so the next drain naturally re-attempts the same write.
- Drop the now-unused \`EngineError::Checkpoint\` variant and its \`CheckpointError\` import.

## Why
The checkpoint is a startup recovery aid, not authoritative state. Pre-#2698 the engine actor never touched the on-disk checkpoint at all; this change restores that liveness property while keeping the new persistence behaviour. Maintainer agreed in #2698 review: *\"we should just log and proceed otherwise we'll crash the node\"*.

Concretely, a transient \`io::ErrorKind::OutOfStorage\` or a brief filesystem hiccup would propagate out of \`drain\` / \`reset\` via \`?\` and \`spawn_and_wait!\` would terminate the engine actor on the very next forkchoice update, crashing the node. After this change the node logs the failure (with the block context) and keeps going; the next forkchoice update re-attempts the write.

## Test plan
- \`cargo clippy -p base-consensus-node --all-targets -- -D warnings\`