### PR TITLE
docs(consensus/engine): fix stray doc comment on unsafe_head_tx field

### DIFF
--- a/crates/consensus/service/src/actors/engine/engine_request_processor.rs
+++ b/crates/consensus/service/src/actors/engine/engine_request_processor.rs
@@ -107,8 +107,8 @@ where
     last_safe_head_checkpointed: L2BlockInfo,
     /// The last finalized head checkpoint written.
     last_finalized_head_checkpointed: L2BlockInfo,
-    /// The [`RollupConfig`] .
     /// A channel to use to relay the current unsafe head.
+    ///
     /// ## Note
     /// This is `Some` when the node is in sequencer mode, and `None` when the node is in validator
     /// mode.


### PR DESCRIPTION
## Summary
- Remove the stray \`/// The [\`RollupConfig\`] .\` line that #2698's field reordering left attached to \`EngineProcessor::unsafe_head_tx\`.
- Add a blank doc line above \`## Note\` so rustdoc renders the heading on its own line.

## Why
Pointed out in #2698 review (\`engine_request_processor.rs\` line 111): the leftover docstring fragment associates the unsafe-head channel with the rollup config, which is misleading for anyone reading the actor's field layout.

## Test plan
- \`cargo clippy -p base-consensus-node --all-targets -- -D warnings\`