### PR TITLE
feat(consensus/engine): surface checkpoint mismatches as a dedicated error

### DIFF
--- a/crates/consensus/engine/src/sync/checkpoint.rs
+++ b/crates/consensus/engine/src/sync/checkpoint.rs
@@ -1,5 +1,7 @@
 //! Forkchoice checkpoint interfaces for sync start recovery.
 
+use std::fmt;
+
 use async_trait::async_trait;
 use base_protocol::L2BlockInfo;
 use thiserror::Error;
@@ -20,6 +22,12 @@ impl ForkchoiceCheckpointLabel {
             Self::Safe => "safe",
             Self::Finalized => "finalized",
         }
+    }
+}
+
+impl fmt::Display for ForkchoiceCheckpointLabel {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
     }
 }
 

--- a/crates/consensus/engine/src/sync/error.rs
+++ b/crates/consensus/engine/src/sync/error.rs
@@ -6,7 +6,7 @@ use alloy_transport::{RpcError, TransportErrorKind};
 use base_protocol::FromBlockError;
 use thiserror::Error;
 
-use super::checkpoint::ForkchoiceCheckpointError;
+use super::{ForkchoiceCheckpointLabel, checkpoint::ForkchoiceCheckpointError};
 
 /// An error that can occur during the sync start process.
 #[derive(Error, Debug)]
@@ -43,4 +43,25 @@ pub enum SyncStartError {
     /// Inconsistent sequence number.
     #[error("Inconsistent sequence number; Must monotonically increase.")]
     InconsistentSequenceNumber,
+    /// The on-disk forkchoice checkpoint did not match the reth-labeled head block.
+    ///
+    /// Surfaced instead of [`SyncStartError::FromBlock`] when the underlying
+    /// [`FromBlockError::MissingL1InfoDeposit`] was caused by a stale or otherwise
+    /// inconsistent checkpoint, so operators see "checkpoint mismatch" in logs rather
+    /// than the misleading "missing L1 info deposit".
+    #[error(
+        "forkchoice checkpoint mismatch for {label}: reth labeled block {reth_number} ({reth_hash}), checkpoint {checkpoint_number} ({checkpoint_hash})"
+    )]
+    CheckpointMismatch {
+        /// Which labeled head (safe / finalized) the mismatch was observed on.
+        label: ForkchoiceCheckpointLabel,
+        /// Block number reth returned for the label.
+        reth_number: u64,
+        /// Block hash reth returned for the label.
+        reth_hash: B256,
+        /// Block number recorded in the on-disk checkpoint.
+        checkpoint_number: u64,
+        /// Block hash recorded in the on-disk checkpoint.
+        checkpoint_hash: B256,
+    },
 }

--- a/crates/consensus/engine/src/sync/forkchoice.rs
+++ b/crates/consensus/engine/src/sync/forkchoice.rs
@@ -174,7 +174,13 @@ async fn block_info_from_reth_or_checkpoint<
                     checkpoint_timestamp = checkpoint.block_info.timestamp,
                     "forkchoice checkpoint does not match reth labeled block header"
                 );
-                return Err(err.into());
+                return Err(SyncStartError::CheckpointMismatch {
+                    label,
+                    reth_number: header.number,
+                    reth_hash: header.hash,
+                    checkpoint_number: checkpoint.block_info.number,
+                    checkpoint_hash: checkpoint.block_info.hash,
+                });
             }
             warn!(
                 target: "sync_start",


### PR DESCRIPTION
## Summary
- Add \`SyncStartError::CheckpointMismatch { label, reth_number, reth_hash, checkpoint_number, checkpoint_hash }\` and return it from \`block_info_from_reth_or_checkpoint\` when the loaded checkpoint disagrees with the reth-labeled header.
- Keep the existing structured \`warn!\` log; the new error variant carries the same operator-facing context in its Display message.

## Why
Pointed out in #2698 review (\`forkchoice.rs\` line 177): when the checkpoint and reth disagree, the function was re-throwing the original \`FromBlockError::MissingL1InfoDeposit\` that triggered the checkpoint lookup in the first place. Operators saw \"missing L1 info deposit\" in the failure path and had to cross-reference the warn log to discover the actual cause was a stale checkpoint.

A dedicated variant makes the failure mode unambiguous in error chains, panics, and any future telemetry that distinguishes between sync-start error kinds.

## Test plan
- \`cargo clippy -p base-consensus-engine --all-targets -- -D warnings\`