### PR TITLE
fix(b20_security): use checked_sub for total supply in burn paths (BOP-160)

### DIFF
--- a/crates/common/precompiles/src/b20_security/dispatch.rs
+++ b/crates/common/precompiles/src/b20_security/dispatch.rs
@@ -1231,6 +1231,29 @@ mod tests {
         assert_eq!(token.accounting().total_supply().unwrap(), U256::ZERO);
     }
 
+    #[test]
+    fn batch_burn_supply_underflow_is_under_overflow_panic() {
+        // Regression: before BOP-160, saturating_sub silently clamped supply to zero.
+        // If an accounting bug left total_supply < balance, the correct behavior is to
+        // revert with an arithmetic under/overflow panic rather than zeroing the supply.
+        let mut token = make_token();
+        token.accounting_mut().roles.insert((BURN_FROM_ROLE, ALICE), true);
+        // Supply invariant violated: balance exceeds total supply.
+        token.accounting_mut().balances.insert(ALICE, U256::from(100u64));
+        token.accounting_mut().total_supply = U256::from(50u64);
+
+        // amount=75 passes the balance check (100 >= 75) but underflows total_supply (50 - 75).
+        assert_eq!(
+            call_security(
+                &mut token,
+                ALICE,
+                batch_burn_calldata(alloc::vec![ALICE], alloc::vec![U256::from(75u64)]),
+            )
+            .unwrap_err(),
+            BasePrecompileError::under_overflow()
+        );
+    }
+
     // --- redeem: InsufficientBalance / boundary / ratio math / event pair ---
 
     #[test]
@@ -1243,6 +1266,23 @@ mod tests {
         assert!(token.security_redeem(ALICE, U256::from(100u64)).is_err());
         // no state mutation on failure
         assert_eq!(token.accounting().balance_of(ALICE).unwrap(), U256::from(10u64));
+    }
+
+    #[test]
+    fn security_redeem_supply_underflow_is_under_overflow_panic() {
+        // Regression: before BOP-160, saturating_sub silently clamped supply to zero.
+        // If an accounting bug left total_supply < balance, the correct behavior is to
+        // revert with an arithmetic under/overflow panic rather than zeroing the supply.
+        let mut token = make_token();
+        // Supply invariant violated: balance exceeds total supply.
+        token.accounting_mut().balances.insert(ALICE, U256::from(100u64));
+        token.accounting_mut().total_supply = U256::from(50u64);
+
+        // amount=75 passes the balance check (100 >= 75) but underflows total_supply (50 - 75).
+        assert_eq!(
+            token.security_redeem(ALICE, U256::from(75u64)).unwrap_err(),
+            BasePrecompileError::under_overflow()
+        );
     }
 
     #[test]

--- a/crates/common/precompiles/src/b20_security/dispatch.rs
+++ b/crates/common/precompiles/src/b20_security/dispatch.rs
@@ -586,7 +586,9 @@ impl<S: SecurityAccounting, P: Policy> B20SecurityToken<S, P> {
         }
         self.accounting_mut().set_balance(caller, balance - amount)?;
         let supply = self.accounting().total_supply()?;
-        self.accounting_mut().set_total_supply(supply.saturating_sub(amount))?;
+        let new_supply =
+            supply.checked_sub(amount).ok_or_else(BasePrecompileError::under_overflow)?;
+        self.accounting_mut().set_total_supply(new_supply)?;
         self.accounting_mut().emit_event(
             IB20::Transfer { from: caller, to: Address::ZERO, amount }.encode_log_data(),
         )?;
@@ -665,7 +667,9 @@ impl<S: SecurityAccounting, P: Policy> B20SecurityToken<S, P> {
             }
             self.accounting_mut().set_balance(account, balance - amount)?;
             let supply = self.accounting().total_supply()?;
-            self.accounting_mut().set_total_supply(supply.saturating_sub(amount))?;
+            let new_supply =
+                supply.checked_sub(amount).ok_or_else(BasePrecompileError::under_overflow)?;
+            self.accounting_mut().set_total_supply(new_supply)?;
             self.accounting_mut().emit_event(
                 IB20::Transfer { from: account, to: Address::ZERO, amount }.encode_log_data(),
             )?;


### PR DESCRIPTION
[BOP-160](https://linear.app/coinbase/issue/BOP-160)

## Motivation

`security_redeem_inner` and `batch_burn` in `B20SecurityToken` were decrementing total supply with `saturating_sub`, which silently clamps to zero on underflow instead of reverting. If total supply ever underflowed (e.g. due to an accounting bug elsewhere), the supply would be silently zeroed rather than the transaction reverting. The base B20 `Burnable` implementation already uses `checked_sub` with an arithmetic panic, and the security variant should match.

## What changed

- `security_redeem_inner` (dispatch.rs:491): replaced `supply.saturating_sub(amount)` with `supply.checked_sub(amount).ok_or_else(BasePrecompileError::under_overflow)?`
- `batch_burn` (dispatch.rs:561): same replacement

## What was tried / considered

`saturating_sub` was likely chosen defensively to avoid panics, but the correct behavior here is to revert on underflow. Both call sites already guard `balance < amount` before touching the holder balance, so underflow of total supply should be impossible in correct operation — the `checked_sub` is a defense-in-depth revert, matching the Solidity version's behavior and the base B20 implementation.

> **Note:** This branch includes 4 BOP-125 devnet test commits in addition to the security fix because the B20 code does not yet exist on `main`. This PR is intended to be merged after the B20 base branch lands.