### PR TITLE
fix(common): Reject Invalid Policy Types

### DIFF
--- a/crates/common/precompiles/src/policy/abi.rs
+++ b/crates/common/precompiles/src/policy/abi.rs
@@ -45,4 +45,26 @@ impl IPolicyRegistry::PolicyType {
     pub const fn as_discriminant(self) -> u8 {
         self as u8
     }
+
+    /// Returns whether this value is one of the supported policy types.
+    pub const fn is_valid(self) -> bool {
+        matches!(self, Self::BLOCKLIST | Self::ALLOWLIST)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_sol_types::SolEnum;
+
+    use super::IPolicyRegistry;
+
+    #[test]
+    fn all_policy_type_variants_are_valid() {
+        for discriminant in 0..IPolicyRegistry::PolicyType::COUNT {
+            let policy_type = IPolicyRegistry::PolicyType::try_from(discriminant as u8)
+                .expect("generated PolicyType discriminant should decode");
+
+            assert!(policy_type.is_valid());
+        }
+    }
 }

--- a/crates/common/precompiles/src/policy/dispatch.rs
+++ b/crates/common/precompiles/src/policy/dispatch.rs
@@ -73,8 +73,8 @@ impl PolicyRegistryStorage<'_> {
 
 #[cfg(test)]
 mod tests {
-    use alloy_primitives::{Address, address};
-    use alloy_sol_types::SolCall;
+    use alloy_primitives::{Address, Bytes, U256, address};
+    use alloy_sol_types::{Panic, PanicKind, SolCall, SolError, SolValue};
     use base_precompile_storage::{HashMapStorageProvider, StorageCtx};
 
     use crate::{
@@ -152,6 +152,42 @@ mod tests {
         assert!(!output.is_revert());
         let id = IPolicyRegistry::createPolicyCall::abi_decode_returns(&output.bytes).unwrap();
         assert_eq!((id >> 56) as u8, IPolicyRegistry::PolicyType::ALLOWLIST as u8);
+    }
+
+    #[test]
+    fn dispatch_create_policy_rejects_invalid_policy_type_calldata() {
+        let mut storage = HashMapStorageProvider::new(1);
+        activate_policy_registry(&mut storage);
+        storage.set_caller(ADMIN);
+        let mut calldata = Vec::from(IPolicyRegistry::createPolicyCall::SELECTOR);
+        calldata.extend_from_slice(&ADMIN.abi_encode());
+        calldata.extend_from_slice(&[0u8; 31]);
+        calldata.push(0xff);
+
+        let output = StorageCtx::enter(&mut storage, |ctx| {
+            PolicyRegistryStorage::new(ctx).dispatch(ctx, &calldata)
+        })
+        .expect("dispatch should not fatally error");
+
+        let expected: Bytes =
+            Panic { code: U256::from(PanicKind::EnumConversionError as u32) }.abi_encode().into();
+        assert!(output.is_revert());
+        assert_eq!(output.bytes, expected);
+
+        let valid_calldata = IPolicyRegistry::createPolicyCall {
+            admin: ADMIN,
+            policyType: IPolicyRegistry::PolicyType::ALLOWLIST,
+        }
+        .abi_encode();
+        let valid_output = StorageCtx::enter(&mut storage, |ctx| {
+            PolicyRegistryStorage::new(ctx).dispatch(ctx, &valid_calldata)
+        })
+        .expect("dispatch should not fatally error");
+
+        assert!(!valid_output.is_revert());
+        let id =
+            IPolicyRegistry::createPolicyCall::abi_decode_returns(&valid_output.bytes).unwrap();
+        assert_eq!(id, 0x0100000000000002);
     }
 
     #[test]

--- a/crates/common/precompiles/src/policy/storage.rs
+++ b/crates/common/precompiles/src/policy/storage.rs
@@ -166,6 +166,9 @@ impl PolicyRegistryStorage<'_> {
 
     /// Creates a new ALLOWLIST or BLOCKLIST policy, returning its encoded ID.
     pub fn create_policy(&mut self, admin: Address, policy_type: PolicyType) -> Result<u64> {
+        if !policy_type.is_valid() {
+            return Err(BasePrecompileError::enum_conversion_error());
+        }
         let policy_type_u8 = policy_type.as_discriminant();
         if admin == Address::ZERO {
             return Err(BasePrecompileError::revert(IPolicyRegistry::ZeroAddress {}));


### PR DESCRIPTION
## Summary

This rejects hidden invalid `PolicyType` enum values before policy creation derives the policy ID or mutates storage. Raw calldata with an out-of-range discriminator now reverts with the same enum-conversion panic Solidity uses, matching `base-std` expectations. The regression test sends `PolicyType = 0xff` through dispatch and confirms the failed call does not advance the next policy counter.