### PR TITLE
chore: remove beryl activation

### DIFF
--- a/crates/common/chains/res/genesis/zeronet_base.json
+++ b/crates/common/chains/res/genesis/zeronet_base.json
@@ -28,8 +28,7 @@
     "isthmusTime": 0,
     "jovianTime": 0,
     "base": {
-      "azul": 1775152800,
-      "beryl": 1780333200
+      "azul": 1775152800
     },
     "terminalTotalDifficulty": 0,
     "depositContractAddress": "0x0000000000000000000000000000000000000000",

--- a/crates/common/chains/src/chain.rs
+++ b/crates/common/chains/src/chain.rs
@@ -297,15 +297,15 @@ mod tests {
 
     #[test]
     fn is_beryl_active_at_timestamp() {
-        for forks in [ChainUpgrades::mainnet(), ChainUpgrades::sepolia(), ChainUpgrades::devnet()] {
+        for forks in [
+            ChainUpgrades::mainnet(),
+            ChainUpgrades::sepolia(),
+            ChainUpgrades::devnet(),
+            ChainUpgrades::zeronet(),
+        ] {
             assert!(!forks.is_beryl_active_at_timestamp(0));
             assert!(!forks.is_beryl_active_at_timestamp(u64::MAX));
         }
-
-        let zeronet_forks = ChainUpgrades::zeronet();
-        assert!(!zeronet_forks.is_beryl_active_at_timestamp(1_780_333_199));
-        assert!(zeronet_forks.is_beryl_active_at_timestamp(1_780_333_200));
-        assert!(zeronet_forks.is_beryl_active_at_timestamp(u64::MAX));
     }
 
     #[test]

--- a/crates/common/chains/src/config.rs
+++ b/crates/common/chains/src/config.rs
@@ -530,7 +530,7 @@ const ZERONET: ChainConfig = ChainConfig {
     isthmus_timestamp: 0,
     jovian_timestamp: 0,
     azul_timestamp: Some(1_775_152_800),
-    beryl_timestamp: Some(1_780_333_200),
+    beryl_timestamp: None,
 
     genesis_l1_hash: b256!("b7d4b69971ff31d5179be5e1b83f5a4f438f4cd1db886a6630623b7047f32cfd"),
     genesis_l1_number: 2_450_277,
@@ -606,8 +606,8 @@ mod tests {
     }
 
     #[test]
-    fn zeronet_beryl_is_scheduled() {
-        assert_eq!(ChainConfig::zeronet().beryl_timestamp, Some(1_780_333_200));
-        assert_eq!(ChainConfig::zeronet().hardfork_config().base.beryl, Some(1_780_333_200));
+    fn zeronet_beryl_is_unscheduled() {
+        assert_eq!(ChainConfig::zeronet().beryl_timestamp, None);
+        assert_eq!(ChainConfig::zeronet().hardfork_config().base.beryl, None);
     }
 }


### PR DESCRIPTION
## Summary
- backport #2985 to releases/v1.0.0
- remove the scheduled Beryl activation timestamp from zeronet
- remove base.beryl from the embedded zeronet genesis JSON

## Tests
- just build::contracts
- just actions::lint-ci
- just actions::test-ci
- cargo test --locked -p base-common-chains