### PR TITLE
fix: enable storage read tracking in erc7562Tracer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18616,9 +18616,9 @@ dependencies = [
 
 [[package]]
 name = "revm-inspectors"
-version = "0.34.3"
+version = "0.34.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e341d9777b1903a8428bc6f8fe7a8f80671d2249837c9749566e61328ef14125"
+checksum = "699b3689517761b838844d715482dfa6059c20a0a5a68bc363e1604d29918555"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -284,7 +284,10 @@ base-runtime = { path = "crates/utilities/runtime", default-features = false }
 revm = { version = "34.0.0", default-features = false }
 revm-bytecode = { version = "8.0.0", default-features = false }
 revm-database = { version = "10.0.0", default-features = false }
-revm-inspectors = { version = "0.34.3", default-features = false }
+# NOTE: 0.34.4 includes fix for erc7562Tracer accessedSlots.reads (paradigmxyz/revm-inspectors#451).
+# The fix was only backported to 0.34.x. If upgrading to 0.35.x-0.39.x, request a cherry-pick
+# from the reth team: https://github.com/paradigmxyz/revm-inspectors/commits/v0.34.4/
+revm-inspectors = { version = "0.34.4", default-features = false }
 revm-precompile = { version = "32.0.0", default-features = false }
 revm-primitives = { version = "22.0.0", default-features = false }
 revm-context-interface = { version = "14.0.0", default-features = false }
@@ -602,3 +605,4 @@ toml = { version = "1.0", default-features = false }
 ark-ff = { version = "0.5.0", default-features = false }
 unsigned-varint = { version = "0.8", default-features = false }
 ark-bls12-381 = { version = "0.5.0", default-features = false }
+


### PR DESCRIPTION
One-line fix to enable storage read tracking in the native `erc7562Tracer`.

## Problem

`accessedSlots.reads` is always empty for SLOAD operations because `from_geth_erc7562_config()` in revm-inspectors starts from `Self::none()` which sets `record_state_diff: false`. The SLOAD handler depends on `step.storage_change`, which is only populated when `record_state_diff` is enabled.

## Fix

Cargo patch on `revm-inspectors` v0.34.3 adding `.set_state_diffs(true)`:
https://github.com/stephancill/revm-inspectors/commit/c8643d7

## Why

ERC-4337 bundlers need `(slot, initial_value)` pairs from SLOAD to enforce ERC-7562 storage access rules. Without this fix, the native `erc7562Tracer` cannot replace custom JS tracers (which are 4-100x slower due to per-opcode JS interpretation). geth's implementation already tracks reads correctly.
