### PR TITLE
feat(proof): configure boundless offer lock timeout

### DIFF
--- a/bin/prover-registrar/src/cli.rs
+++ b/bin/prover-registrar/src/cli.rs
@@ -192,8 +192,22 @@ struct BoundlessArgs {
     #[arg(long, env = cli_env!("BOUNDLESS_POLL_INTERVAL_SECS"), default_value_t = 5)]
     boundless_poll_interval_secs: u64,
 
-    /// Proof generation timeout in seconds.
-    #[arg(long, env = cli_env!("BOUNDLESS_TIMEOUT_SECS"), default_value_t = 600)]
+    /// Client-side fulfillment poll budget, in seconds.
+    ///
+    /// Maximum wall-clock time the registrar will wait for a Boundless
+    /// proof to be fulfilled before giving up. Purely a client-side cap
+    /// on `wait_for_request_fulfillment` — not submitted on-chain. The
+    /// on-chain request lifetime is controlled by
+    /// `--boundless-offer-lock-timeout-secs` (and the SDK-derived
+    /// `Offer.timeout = 2 * lockTimeout` default).
+    ///
+    /// Should be set greater than the on-chain `Offer.timeout` plus
+    /// headroom for clock skew, RPC latency, and the indexer catching
+    /// up after the on-chain `Fulfilled` event. The default of 1260 s
+    /// covers a `lockTimeout = 600 s` (10 min) deployment, in which
+    /// the SDK derives `Offer.timeout = 1200 s` (20 min total request
+    /// lifetime) and 1260 s gives ~60 s of headroom over that expiry.
+    #[arg(long, env = cli_env!("BOUNDLESS_TIMEOUT_SECS"), default_value_t = 1260)]
     boundless_timeout_secs: u64,
 
     /// Minimum Boundless offer price in ETH for each submitted proof request.
@@ -215,6 +229,23 @@ struct BoundlessArgs {
     /// Optional duration for the Boundless offer price to ramp from min to max.
     #[arg(long, env = cli_env!("BOUNDLESS_OFFER_RAMP_UP_PERIOD_SECS"))]
     boundless_offer_ramp_up_period_secs: Option<u32>,
+
+    /// Maximum time, in seconds, that a prover that locks a request has to
+    /// deliver the proof before forfeiting its stake bond and the request
+    /// opening up to permissionless secondary fulfillment.
+    ///
+    /// This is also the window during which any prover may lock the
+    /// request in the first place — locking and delivery share a single
+    /// deadline at `rampUpStart + lockTimeout`. Lowering this number
+    /// shortens the time the accepting prover has to prove. With
+    /// `Offer.timeout` left unset, the Boundless SDK derives
+    /// `Offer.timeout = 2 * lockTimeout`, so the secondary fallback
+    /// window equals the primary window.
+    ///
+    /// Defaults to SDK behaviour (cycle-count-derived recommendation)
+    /// when unset.
+    #[arg(long, env = cli_env!("BOUNDLESS_OFFER_LOCK_TIMEOUT_SECS"))]
+    boundless_offer_lock_timeout_secs: Option<u32>,
 
     /// Maximum number of deterministic request-ID slots to probe when
     /// recovering in-flight proofs after an instance rotation.
@@ -394,6 +425,7 @@ impl Cli {
                     offer_min_price,
                     offer_max_price,
                     offer_ramp_up_period_secs: self.boundless.boundless_offer_ramp_up_period_secs,
+                    offer_lock_timeout_secs: self.boundless.boundless_offer_lock_timeout_secs,
                 }))
             }
             ProvingMode::Direct => {
@@ -594,6 +626,7 @@ impl Cli {
                 offer_min_price: boundless.offer_min_price.clone(),
                 offer_max_price: boundless.offer_max_price.clone(),
                 offer_ramp_up_period_secs: boundless.offer_ramp_up_period_secs,
+                offer_lock_timeout_secs: boundless.offer_lock_timeout_secs,
                 submit_lock: Arc::new(tokio::sync::Mutex::new(())),
                 recovery_blocked: Arc::new(std::sync::Mutex::new(std::collections::HashSet::new())),
             }),
@@ -700,6 +733,8 @@ mod tests {
     const TEST_BOUNDLESS_MIN_PRICE_ETH: &str = "0.01";
     const TEST_BOUNDLESS_MAX_PRICE_ETH: &str = "0.03";
     const TEST_BOUNDLESS_RAMP_UP_PERIOD_SECS: u32 = 30;
+    const TEST_BOUNDLESS_OFFER_LOCK_TIMEOUT_SECS: u32 = 600;
+    const TEST_BOUNDLESS_OFFER_LOCK_TIMEOUT_SECS_STR: &str = "600";
     const TEST_ELF_PATH: &str = "/tmp/guest.elf";
     const TEST_SIGNER_ENDPOINT: &str = "http://localhost:8546";
     const TEST_SIGNER_ADDR: &str = "0x0000000000000000000000000000000000000002";
@@ -911,6 +946,36 @@ mod tests {
         assert!(b.offer_min_price.is_none());
         assert!(b.offer_max_price.is_none());
         assert!(b.offer_ramp_up_period_secs.is_none());
+        assert!(b.offer_lock_timeout_secs.is_none());
+    }
+
+    #[rstest]
+    fn boundless_offer_lock_timeout_parses() {
+        let mut args = boundless_args();
+        args.extend([
+            "--boundless-offer-lock-timeout-secs",
+            TEST_BOUNDLESS_OFFER_LOCK_TIMEOUT_SECS_STR,
+        ]);
+
+        let config = Cli::parse_from(args).into_config().unwrap();
+        let ProvingConfig::Boundless(b) = &config.proving else {
+            panic!("expected Boundless proving config");
+        };
+
+        assert_eq!(b.offer_lock_timeout_secs, Some(TEST_BOUNDLESS_OFFER_LOCK_TIMEOUT_SECS));
+    }
+
+    /// `--boundless-timeout-secs` default should cover a 10-minute
+    /// lock timeout with the SDK-derived `Offer.timeout = 1200 s`
+    /// plus headroom.
+    #[rstest]
+    fn boundless_timeout_default_covers_default_lock_timeout() {
+        let config = Cli::parse_from(boundless_args()).into_config().unwrap();
+        let ProvingConfig::Boundless(b) = &config.proving else {
+            panic!("expected Boundless proving config");
+        };
+
+        assert_eq!(b.timeout, Duration::from_secs(1260));
     }
 
     #[rstest]

--- a/crates/proof/tee/nitro-attestation-prover/src/boundless.rs
+++ b/crates/proof/tee/nitro-attestation-prover/src/boundless.rs
@@ -90,6 +90,15 @@ pub struct BoundlessProver {
     pub offer_max_price: Option<Amount>,
     /// Optional duration in seconds for Boundless price to ramp from min to max.
     pub offer_ramp_up_period_secs: Option<u32>,
+    /// Optional maximum time, in seconds, that a prover that locks a
+    /// request has to deliver the proof before forfeiting its stake bond
+    /// and the request opening up to permissionless secondary
+    /// fulfillment. Also the deadline for any prover to lock the request
+    /// in the first place — locking and delivery share a single
+    /// deadline at `rampUpStart + lockTimeout`. When unset, the
+    /// Boundless SDK derives a recommended value from the program's
+    /// cycle count.
+    pub offer_lock_timeout_secs: Option<u32>,
     /// Serialises the `submit_onchain` call so that concurrent proof
     /// requests do not race on the Boundless wallet nonce. The lock is
     /// released immediately after submission, allowing the long-running
@@ -120,6 +129,7 @@ impl fmt::Debug for BoundlessProver {
             .field("offer_min_price", &self.offer_min_price)
             .field("offer_max_price", &self.offer_max_price)
             .field("offer_ramp_up_period_secs", &self.offer_ramp_up_period_secs)
+            .field("offer_lock_timeout_secs", &self.offer_lock_timeout_secs)
             .finish()
     }
 }
@@ -168,6 +178,7 @@ impl BoundlessProver {
         if self.offer_min_price.is_none()
             && self.offer_max_price.is_none()
             && self.offer_ramp_up_period_secs.is_none()
+            && self.offer_lock_timeout_secs.is_none()
         {
             return params;
         }
@@ -181,6 +192,9 @@ impl BoundlessProver {
         }
         if let Some(ramp_up_period) = self.offer_ramp_up_period_secs {
             offer.ramp_up_period(ramp_up_period);
+        }
+        if let Some(lock_timeout) = self.offer_lock_timeout_secs {
+            offer.lock_timeout(lock_timeout);
         }
 
         params.with_offer(offer)
@@ -756,6 +770,7 @@ mod tests {
     const TEST_MIN_PRICE_ETH: &str = "0.01";
     const TEST_MAX_PRICE_ETH: &str = "0.03";
     const TEST_RAMP_UP_PERIOD_SECS: u32 = 30;
+    const TEST_LOCK_TIMEOUT_SECS: u32 = 600;
 
     const TEST_MAX_ATTESTATION_AGE: Duration = Duration::from_secs(3300);
 
@@ -778,6 +793,7 @@ mod tests {
             offer_min_price: None,
             offer_max_price: None,
             offer_ramp_up_period_secs: None,
+            offer_lock_timeout_secs: None,
             submit_lock: Arc::new(Mutex::new(())),
             recovery_blocked: Arc::new(std::sync::Mutex::new(HashSet::new())),
         }
@@ -809,6 +825,7 @@ mod tests {
         assert!(prover.offer_min_price.is_none());
         assert!(prover.offer_max_price.is_none());
         assert!(prover.offer_ramp_up_period_secs.is_none());
+        assert!(prover.offer_lock_timeout_secs.is_none());
     }
 
     #[rstest]
@@ -818,6 +835,7 @@ mod tests {
         assert!(params.offer.min_price.is_none());
         assert!(params.offer.max_price.is_none());
         assert!(params.offer.ramp_up_period.is_none());
+        assert!(params.offer.lock_timeout.is_none());
     }
 
     #[rstest]
@@ -827,12 +845,29 @@ mod tests {
         prover.offer_min_price = Some(min_price.clone());
         prover.offer_max_price = Some(max_price.clone());
         prover.offer_ramp_up_period_secs = Some(TEST_RAMP_UP_PERIOD_SECS);
+        prover.offer_lock_timeout_secs = Some(TEST_LOCK_TIMEOUT_SECS);
 
         let params = prover.apply_offer_config(RequestParams::new());
 
         assert_eq!(params.offer.min_price, Some(min_price));
         assert_eq!(params.offer.max_price, Some(max_price));
         assert_eq!(params.offer.ramp_up_period, Some(TEST_RAMP_UP_PERIOD_SECS));
+        assert_eq!(params.offer.lock_timeout, Some(TEST_LOCK_TIMEOUT_SECS));
+    }
+
+    /// `lock_timeout` can be set independently of price/ramp fields,
+    /// in which case `apply_offer_config` must still emit an offer
+    /// override (not return params unchanged).
+    #[rstest]
+    fn apply_offer_config_sets_lock_timeout_alone(mut prover: BoundlessProver) {
+        prover.offer_lock_timeout_secs = Some(TEST_LOCK_TIMEOUT_SECS);
+
+        let params = prover.apply_offer_config(RequestParams::new());
+
+        assert_eq!(params.offer.lock_timeout, Some(TEST_LOCK_TIMEOUT_SECS));
+        assert!(params.offer.min_price.is_none());
+        assert!(params.offer.max_price.is_none());
+        assert!(params.offer.ramp_up_period.is_none());
     }
 
     // ── Clone ───────────────────────────────────────────────────────────

--- a/crates/proof/tee/registrar/src/config.rs
+++ b/crates/proof/tee/registrar/src/config.rs
@@ -61,6 +61,13 @@ pub struct BoundlessConfig {
     pub offer_max_price: Option<Amount>,
     /// Optional duration in seconds for Boundless price to ramp from min to max.
     pub offer_ramp_up_period_secs: Option<u32>,
+    /// Optional maximum time, in seconds, that a prover that locks a
+    /// request has to deliver the proof before forfeiting its stake bond
+    /// and the request opening up to permissionless secondary
+    /// fulfillment. Also the deadline for any prover to lock the request
+    /// in the first place. When unset, the Boundless SDK derives a
+    /// recommended value from the program's cycle count.
+    pub offer_lock_timeout_secs: Option<u32>,
 }
 
 impl std::fmt::Debug for BoundlessConfig {
@@ -77,6 +84,7 @@ impl std::fmt::Debug for BoundlessConfig {
             .field("offer_min_price", &self.offer_min_price)
             .field("offer_max_price", &self.offer_max_price)
             .field("offer_ramp_up_period_secs", &self.offer_ramp_up_period_secs)
+            .field("offer_lock_timeout_secs", &self.offer_lock_timeout_secs)
             .finish()
     }
 }


### PR DESCRIPTION
Adds `--boundless-offer-lock-timeout-secs` to the prover-registrar CLI, threading the value through `BoundlessConfig` and `BoundlessProver` into `OfferParams::lock_timeout`. Mirrors the wiring introduced in #2949 for offer pricing fields.

## Why

`lockTimeout` bounds both:

1. the window in which any prover may **lock** the request (acquiring exclusive fulfillment rights against the stake bond), and
2. the **delivery deadline** by which the locking prover must produce the proof before forfeiting that bond and the request opening to permissionless secondary fulfillment.

Both events fire at the same on-chain instant: `rampUpStart + lockTimeout`.

With `Offer.timeout` left unset, the Boundless SDK derives `Offer.timeout = 2 * lockTimeout` (`boundless-market` `request_builder/offer_layer.rs`), so a `lockTimeout = 600 s` deployment yields a `1200 s` total on-chain request lifetime with a symmetric secondary fallback window.

## Client-side timeout bump

This PR also bumps `--boundless-timeout-secs` default `600 → 1260`.

That flag is a **purely client-side** poll budget on `BoundlessProver::wait_for_request_fulfillment` — it is **not** submitted on-chain. It must exceed the on-chain `Offer.timeout` plus headroom for clock skew, RPC latency, and indexer lag past the on-chain `Fulfilled` event; otherwise the registrar gives up before the secondary fallback window even opens.

`1260 s` covers a `600 s` `lockTimeout` deployment (`1200 s` SDK-derived on-chain timeout) with `~60 s` of headroom.

The docstring on `--boundless-timeout-secs` is also reworded to make the client-side vs. on-chain distinction explicit, since the previous text ("Proof generation timeout in seconds") was ambiguous.

## Deployment

Operators that want the 10-minute lock-timeout behaviour should set:

```
BASE_REGISTRAR_BOUNDLESS_OFFER_LOCK_TIMEOUT_SECS=600
```

When unset, the Boundless SDK falls back to its cycle-count-derived recommendation, matching the behaviour of the other optional flags introduced in #2949.

## Tests

- `boundless_offer_lock_timeout_parses` — CLI flag round-trips into `BoundlessConfig`.
- `boundless_timeout_default_covers_default_lock_timeout` — asserts the `1260 s` default.
- `apply_offer_config_sets_lock_timeout_alone` — confirms `lock_timeout` is enough on its own to emit an offer override (early-return guard updated).
- Existing `apply_offer_config_preserves_default_when_unset` / `apply_offer_config_sets_explicit_prices` extended to cover the new field.

cc #2949