### PR TITLE
derive/frame_queue: fix usize underflow in prune() when queue is empty

### DIFF
--- a/crates/consensus/derive/src/stages/frame_queue.rs
+++ b/crates/consensus/derive/src/stages/frame_queue.rs
@@ -65,7 +65,7 @@ where
         }
 
         let mut i = 0;
-        while i < self.queue.len() - 1 {
+        while i + 1 < self.queue.len() {
             let prev_frame = &self.queue[i];
             let next_frame = &self.queue[i + 1];
             let extends_channel = prev_frame.id == next_frame.id;
@@ -534,6 +534,33 @@ pub(super) mod tests {
             .build();
         assert.holocene_active(true);
         assert.next_frames().await;
+    }
+
+    /// When Holocene is active and no frames are parsed from the transaction data
+    /// (e.g. the payload contained only the derivation version byte and no frame bodies),
+    /// `prune()` must not panic.
+    ///
+    /// Regression test: before the fix `while i < self.queue.len() - 1` would wrap
+    /// `0usize - 1` to `usize::MAX` in release mode (or panic in debug mode) when the
+    /// frame queue happened to be empty after extending with an empty frame list.
+    #[test]
+    fn test_prune_empty_queue_no_panic() {
+        let cfg = RollupConfig {
+            hardforks: HardForkConfig { holocene_time: Some(0), ..Default::default() },
+            ..Default::default()
+        };
+        let mock = TestFrameQueueProvider::new(vec![]);
+        let mut fq = FrameQueue::new(mock, Arc::new(cfg));
+
+        // Queue is empty; Holocene is active.
+        let origin = BlockInfo::default(); // timestamp = 0 → holocene active
+        assert!(fq.is_holocene_active(origin));
+        assert!(fq.queue.is_empty());
+
+        // Must not panic.
+        fq.prune(origin);
+
+        assert!(fq.queue.is_empty());
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Problem

The Holocene-era `prune()` method in `FrameQueue` iterates with:

```rust
while i < self.queue.len() - 1 { ... }
```

When `self.queue` is empty, `self.queue.len()` is `0`, and the subtraction wraps:

- **Debug builds**: Rust panics immediately with an arithmetic-overflow check.
- **Release builds**: `0usize - 1` evaluates to `usize::MAX`, so the `while` condition is trivially true (`0 < usize::MAX`). The loop body then indexes `self.queue[0]`, which panics with an out-of-bounds access.

## How is the empty-queue path reached?

`prune()` is called from `load_frames()` after extending the queue with newly parsed frames:

```rust
self.queue.extend(frames);
self.prune(origin);
```

If `Frame::parse_frames` returns zero frames — e.g. a batch transaction whose payload contains only the `0x00` derivation version prefix and no actual frame bodies — `frames` is empty, the queue remains empty, and `prune()` is called.

## Fix

Rewrite the loop condition to avoid the subtraction entirely:

```rust
// Before (underflows when len == 0)
while i < self.queue.len() - 1 { ... }

// After (safe: trivially false when len == 0 or 1)
while i + 1 < self.queue.len() { ... }
```

The semantics are identical for non-empty queues; the only change is that `i + 1 < 0` is never evaluated as unsigned arithmetic.

## Test

Added `test_prune_empty_queue_no_panic`: activates Holocene, leaves the frame queue empty, and asserts that `prune()` completes without panicking.