### PR TITLE
chore(prover-service): copy zk prover service db crate into new prover-service crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5952,6 +5952,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "base-prover-service-db"
+version = "0.0.0"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "futures",
+ "serde",
+ "serde_json",
+ "sqlx",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
 name = "base-prover-zk"
 version = "0.0.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ members = [
   "crates/proof/primitives",
   "crates/proof/host",
   "crates/proof/prover-service",
+  "crates/proof/prover-service/db",
   "crates/proof/tee/nitro-host",
   "crates/proof/tee/nitro-enclave",
   "crates/proof/tee/registrar",
@@ -231,9 +232,10 @@ base-zk-db = { path = "crates/proof/zk/db" }
 base-zk-outbox = { path = "crates/proof/zk/outbox" }
 base-zk-service = { path = "crates/proof/zk/service" }
 base-challenger = { path = "crates/proof/challenge" }
-base-prover-service = { path = "crates/proof/prover-service" }
 base-proof-contracts = { path = "crates/proof/contracts" }
+base-prover-service = { path = "crates/proof/prover-service" }
 base-proof-tee-registrar = { path = "crates/proof/tee/registrar" }
+base-prover-service-db = { path = "crates/proof/prover-service/db" }
 base-proof-tee-nitro-host = { path = "crates/proof/tee/nitro-host" }
 base-proof = { path = "crates/proof/proof", default-features = false }
 base-proof-mpt = { path = "crates/proof/mpt", default-features = false }

--- a/crates/proof/prover-service/db/Cargo.toml
+++ b/crates/proof/prover-service/db/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+name = "base-prover-service-db"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+
+[dependencies]
+# database
+futures.workspace = true
+sqlx = { workspace = true, features = ["runtime-tokio", "postgres", "uuid", "chrono", "derive", "tls-native-tls"] }
+
+# serialization
+serde_json.workspace = true
+serde = { workspace = true, features = ["derive"] }
+chrono = { workspace = true, features = ["serde"] }
+uuid = { workspace = true, features = ["v4", "serde"] }
+
+# error handling
+anyhow.workspace = true
+thiserror.workspace = true
+
+# tracing
+tracing.workspace = true
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+
+[lints]
+workspace = true

--- a/crates/proof/prover-service/db/README.md
+++ b/crates/proof/prover-service/db/README.md
@@ -1,0 +1,3 @@
+# `base-prover-service-db`
+
+`PostgreSQL` persistence layer for prover-service proof requests and sessions.

--- a/crates/proof/prover-service/db/migrations/001_init_schema.sql
+++ b/crates/proof/prover-service/db/migrations/001_init_schema.sql
@@ -1,0 +1,79 @@
+-- Create proof_requests table
+CREATE TABLE IF NOT EXISTS proof_requests (
+    -- Primary identifier (our UUID, returned to caller immediately)
+    id UUID PRIMARY KEY,
+
+    -- Request parameters
+    start_block_number BIGINT NOT NULL,
+    number_of_blocks_to_prove BIGINT NOT NULL,
+    sequence_window BIGINT,
+
+    -- Proving backend tracking
+    proving_backend_id VARCHAR(50),  -- Backend identifier (e.g., 'generic_zkvm')
+    proving_backend_session_id VARCHAR(255),  -- Backend-specific session ID
+
+    -- Receipts (binary data)
+    stark_receipt BYTEA,
+    snark_receipt BYTEA,
+
+    -- Status tracking: CREATED -> PENDING -> RUNNING -> SUCCEEDED/FAILED
+    status VARCHAR(20) NOT NULL DEFAULT 'CREATED',
+    error_message TEXT,
+
+    -- Timestamps
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    completed_at TIMESTAMP WITH TIME ZONE
+);
+
+-- Indexes for common queries
+CREATE INDEX IF NOT EXISTS idx_proof_requests_status ON proof_requests(status);
+CREATE INDEX IF NOT EXISTS idx_proof_requests_backend_session ON proof_requests(proving_backend_session_id);
+CREATE INDEX IF NOT EXISTS idx_proof_requests_created_at ON proof_requests(created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_proof_requests_backend_id ON proof_requests(proving_backend_id);
+
+-- Function to automatically update updated_at timestamp
+CREATE OR REPLACE FUNCTION update_updated_at_column()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = NOW();
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Trigger to call the function on every update
+DROP TRIGGER IF EXISTS update_proof_requests_updated_at ON proof_requests;
+CREATE TRIGGER update_proof_requests_updated_at
+    BEFORE UPDATE ON proof_requests
+    FOR EACH ROW
+    EXECUTE FUNCTION update_updated_at_column();
+
+-- Create proof_request_outbox table for reliable task processing
+CREATE TABLE IF NOT EXISTS proof_request_outbox (
+    -- Auto-incrementing sequence for ordering
+    sequence_id BIGSERIAL PRIMARY KEY,
+
+    -- Reference to the proof request
+    proof_request_id UUID NOT NULL REFERENCES proof_requests(id),
+
+    -- Request parameters (JSON)
+    request_params JSONB NOT NULL,
+
+    -- Processing status
+    processed BOOLEAN NOT NULL DEFAULT FALSE,
+    processed_at TIMESTAMP WITH TIME ZONE,
+
+    -- Retry tracking
+    retry_count INTEGER NOT NULL DEFAULT 0,
+    last_error TEXT,
+
+    -- Timestamps
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+);
+
+-- Indexes for outbox queries
+CREATE INDEX IF NOT EXISTS idx_outbox_processed ON proof_request_outbox(processed, created_at);
+CREATE INDEX IF NOT EXISTS idx_outbox_proof_request_id ON proof_request_outbox(proof_request_id);
+
+-- Comment on status column
+COMMENT ON COLUMN proof_requests.status IS 'Status: CREATED, PENDING, RUNNING, SUCCEEDED, FAILED';

--- a/crates/proof/prover-service/db/migrations/002_add_proof_sessions.sql
+++ b/crates/proof/prover-service/db/migrations/002_add_proof_sessions.sql
@@ -1,0 +1,93 @@
+-- Migration 002: Add proof_sessions table and proof_type column
+-- This migration adds support for multi-stage proving workflow (STARK -> SNARK conversion)
+-- and allows proof_type to determine success criteria
+
+-- Part 1: Create proof_sessions table for tracking multi-stage proving workflow
+-- Each proof request can have multiple sessions (e.g., STARK generation, STARK->SNARK conversion)
+CREATE TABLE IF NOT EXISTS proof_sessions (
+    id BIGSERIAL PRIMARY KEY,
+
+    -- Reference to the proof request
+    proof_request_id UUID NOT NULL REFERENCES proof_requests(id) ON DELETE CASCADE,
+
+    -- Session metadata
+    session_type VARCHAR(20) NOT NULL, -- 'STARK', 'SNARK', etc.
+    backend_session_id VARCHAR(255) NOT NULL, -- Backend-specific session ID
+
+    -- Status: RUNNING, COMPLETED, FAILED
+    status VARCHAR(20) NOT NULL DEFAULT 'RUNNING',
+    error_message TEXT,
+
+    -- Timestamps
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    completed_at TIMESTAMP WITH TIME ZONE
+);
+
+-- Indexes for common queries
+CREATE INDEX IF NOT EXISTS idx_proof_sessions_request ON proof_sessions(proof_request_id);
+CREATE INDEX IF NOT EXISTS idx_proof_sessions_backend ON proof_sessions(backend_session_id);
+CREATE INDEX IF NOT EXISTS idx_proof_sessions_status ON proof_sessions(status, created_at);
+CREATE INDEX IF NOT EXISTS idx_proof_sessions_type ON proof_sessions(session_type);
+
+-- Comment on columns
+COMMENT ON COLUMN proof_sessions.session_type IS 'Type of proving session: STARK (initial proof generation), SNARK (STARK to SNARK conversion), etc.';
+COMMENT ON COLUMN proof_sessions.status IS 'Session status: RUNNING, COMPLETED, FAILED';
+
+-- Part 2: Add proof_type column to proof_requests
+-- Determines what constitutes a successful proof (e.g., STARK only vs STARK+SNARK)
+ALTER TABLE proof_requests
+ADD COLUMN proof_type VARCHAR(50) NOT NULL DEFAULT 'generic_zkvm_cluster_compressed';
+
+-- Create index for querying by proof type
+CREATE INDEX IF NOT EXISTS idx_proof_requests_proof_type ON proof_requests(proof_type);
+
+-- Comment on proof_type column
+COMMENT ON COLUMN proof_requests.proof_type IS 'Type of proof: generic_zkvm_cluster_compressed';
+
+-- Part 3: Backfill existing data from proof_requests into proof_sessions
+-- All existing proofs are STARK proofs
+-- Only run if the old column still exists (idempotent migration)
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM information_schema.columns
+        WHERE table_name = 'proof_requests'
+        AND column_name = 'proving_backend_session_id'
+    ) THEN
+        INSERT INTO proof_sessions (
+            proof_request_id,
+            session_type,
+            backend_session_id,
+            status,
+            created_at,
+            completed_at
+        )
+        SELECT
+            id as proof_request_id,
+            'STARK' as session_type,
+            proving_backend_session_id as backend_session_id,
+            CASE
+                WHEN status = 'RUNNING' THEN 'RUNNING'
+                WHEN status = 'SUCCEEDED' THEN 'COMPLETED'
+                WHEN status = 'FAILED' THEN 'FAILED'
+                ELSE 'RUNNING'
+            END as status,
+            created_at,
+            completed_at
+        FROM proof_requests
+        WHERE proving_backend_session_id IS NOT NULL;
+    END IF;
+END $$;
+
+-- Part 4: Remove old single-session columns from proof_requests
+-- Drop indexes first (these are safe to drop if they don't exist)
+DROP INDEX IF EXISTS idx_proof_requests_backend_session;
+DROP INDEX IF EXISTS idx_proof_requests_backend_id;
+
+-- Drop columns (IF EXISTS clause makes this idempotent)
+ALTER TABLE proof_requests DROP COLUMN IF EXISTS proving_backend_id;
+ALTER TABLE proof_requests DROP COLUMN IF EXISTS proving_backend_session_id;
+
+-- Update status comment to reflect simplified workflow
+COMMENT ON COLUMN proof_requests.status IS 'Overall request status: CREATED, PENDING, RUNNING, SUCCEEDED, FAILED';

--- a/crates/proof/prover-service/db/migrations/003_add_session_metadata.sql
+++ b/crates/proof/prover-service/db/migrations/003_add_session_metadata.sql
@@ -1,0 +1,10 @@
+-- Migration 003: Add metadata field to proof_sessions
+-- This allows backends to store backend-specific data (e.g., artifact IDs, deadlines)
+
+ALTER TABLE proof_sessions
+ADD COLUMN metadata JSONB;
+
+COMMENT ON COLUMN proof_sessions.metadata IS 'Backend-specific metadata (JSONB): proof_output_id, deadlines, etc.';
+
+-- Create GIN index for JSONB queries if needed
+CREATE INDEX IF NOT EXISTS idx_proof_sessions_metadata ON proof_sessions USING GIN (metadata);

--- a/crates/proof/prover-service/db/migrations/004_add_prover_address.sql
+++ b/crates/proof/prover-service/db/migrations/004_add_prover_address.sql
@@ -1,0 +1,1 @@
+ALTER TABLE proof_requests ADD COLUMN prover_address VARCHAR(42);

--- a/crates/proof/prover-service/db/migrations/005_add_l1_head.sql
+++ b/crates/proof/prover-service/db/migrations/005_add_l1_head.sql
@@ -1,0 +1,1 @@
+ALTER TABLE proof_requests ADD COLUMN l1_head VARCHAR(66);

--- a/crates/proof/prover-service/db/migrations/006_rename_proof_types.sql
+++ b/crates/proof/prover-service/db/migrations/006_rename_proof_types.sql
@@ -1,0 +1,12 @@
+-- Rename proof_type values from generic_zkvm_cluster_* to op_succinct_sp1_cluster_*
+UPDATE proof_requests
+SET proof_type = 'op_succinct_sp1_cluster_compressed'
+WHERE proof_type = 'generic_zkvm_cluster_compressed';
+
+UPDATE proof_requests
+SET proof_type = 'op_succinct_sp1_cluster_snark_groth16'
+WHERE proof_type = 'generic_zkvm_cluster_snark_groth16';
+
+-- Update the column default to the new naming
+ALTER TABLE proof_requests
+ALTER COLUMN proof_type SET DEFAULT 'op_succinct_sp1_cluster_compressed';

--- a/crates/proof/prover-service/db/migrations/007_add_retry_count.sql
+++ b/crates/proof/prover-service/db/migrations/007_add_retry_count.sql
@@ -1,0 +1,4 @@
+-- Add retry_count to proof_requests for auto-retry of stuck PENDING requests.
+-- The stuck detector resets requests to CREATED up to MAX_PROOF_RETRIES times
+-- before permanently failing them.
+ALTER TABLE proof_requests ADD COLUMN retry_count INTEGER NOT NULL DEFAULT 0;

--- a/crates/proof/prover-service/db/migrations/008_add_intermediate_root_interval.sql
+++ b/crates/proof/prover-service/db/migrations/008_add_intermediate_root_interval.sql
@@ -1,0 +1,5 @@
+-- Persist the requested intermediate-root interval on the proof request itself
+-- so retries can recover the original value when the outbox row has been
+-- pruned. NULL preserves the existing semantics (worker falls back to
+-- DEFAULT_INTERMEDIATE_ROOT_INTERVAL).
+ALTER TABLE proof_requests ADD COLUMN intermediate_root_interval BIGINT;

--- a/crates/proof/prover-service/db/migrations/009_add_unique_active_session.sql
+++ b/crates/proof/prover-service/db/migrations/009_add_unique_active_session.sql
@@ -1,0 +1,34 @@
+-- Migration 009: Enforce at most one active session per (proof_request, session_type)
+-- to prevent concurrent pollers from creating duplicate SNARK Groth16 jobs on the
+-- SP1 cluster. See CHAIN-4254 (Immunefi 75630).
+--
+-- The index is partial on (SUBMITTING, RUNNING); terminal sessions remain as audit
+-- history. Pre-existing duplicates are failed (not deleted) to preserve the audit
+-- trail, keeping the newest row active.
+
+BEGIN;
+
+-- Fail duplicate active sessions, keeping the newest per (proof_request_id, session_type).
+WITH ranked AS (
+    SELECT
+        id,
+        ROW_NUMBER() OVER (
+            PARTITION BY proof_request_id, session_type
+            ORDER BY created_at DESC, id DESC
+        ) AS row_num
+    FROM proof_sessions
+    WHERE status IN ('SUBMITTING', 'RUNNING')
+)
+UPDATE proof_sessions
+SET status = 'FAILED',
+    error_message = 'duplicate session cleared by migration 009',
+    completed_at = NOW()
+FROM ranked
+WHERE proof_sessions.id = ranked.id
+  AND ranked.row_num > 1;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_proof_sessions_request_type_active_unique
+ON proof_sessions(proof_request_id, session_type)
+WHERE status IN ('SUBMITTING', 'RUNNING');
+
+COMMIT;

--- a/crates/proof/prover-service/db/src/config.rs
+++ b/crates/proof/prover-service/db/src/config.rs
@@ -1,0 +1,101 @@
+use std::{fmt, time::Duration};
+
+use anyhow::{Context, Result};
+use sqlx::{PgPool, postgres::PgPoolOptions};
+use tracing::info;
+
+/// Database configuration.
+#[derive(Clone)]
+pub struct DatabaseConfig {
+    /// Connection URL.
+    pub url: String,
+    /// Maximum number of connections in the pool.
+    pub max_connections: u32,
+    /// Timeout for acquiring a connection.
+    pub connection_timeout: Duration,
+}
+
+impl fmt::Debug for DatabaseConfig {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("DatabaseConfig")
+            .field("url", &mask_password(&self.url))
+            .field("max_connections", &self.max_connections)
+            .field("connection_timeout", &self.connection_timeout)
+            .finish()
+    }
+}
+
+impl DatabaseConfig {
+    /// Create database configuration from environment variables.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if any required environment variable is missing.
+    pub fn from_env() -> Result<Self> {
+        let host = std::env::var("POSTGRES_HOST")
+            .context("POSTGRES_HOST environment variable is required")?;
+        let port = std::env::var("POSTGRES_PORT")
+            .context("POSTGRES_PORT environment variable is required")?;
+        let db =
+            std::env::var("POSTGRES_DB").context("POSTGRES_DB environment variable is required")?;
+        let user = std::env::var("POSTGRES_USER")
+            .context("POSTGRES_USER environment variable is required")?;
+        let password = std::env::var("POSTGRES_PASSWORD")
+            .context("POSTGRES_PASSWORD environment variable is required")?;
+
+        let sslmode = std::env::var("POSTGRES_SSLMODE").unwrap_or_else(|_| "require".to_string());
+        let url = format!("postgres://{user}:{password}@{host}:{port}/{db}?sslmode={sslmode}");
+
+        Ok(Self { url, max_connections: 10, connection_timeout: Duration::from_secs(30) })
+    }
+
+    /// Initialize database connection pool.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the connection cannot be established.
+    pub async fn init_pool(&self) -> Result<PgPool> {
+        info!(url = %mask_password(&self.url), "connecting to database");
+
+        let pool = PgPoolOptions::new()
+            .max_connections(self.max_connections)
+            .acquire_timeout(self.connection_timeout)
+            .connect(&self.url)
+            .await
+            .context("failed to connect to database")?;
+
+        info!("database connection pool initialized");
+        Ok(pool)
+    }
+}
+
+/// Mask password in database URL for logging.
+fn mask_password(url: &str) -> String {
+    if let Some(at_pos) = url.rfind('@')
+        && let Some(colon_pos) = url[..at_pos].rfind(':')
+    {
+        let mut masked = url.to_string();
+        masked.replace_range(colon_pos + 1..at_pos, "****");
+        return masked;
+    }
+    url.to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mask_password_standard_url() {
+        let url = "postgres://user:secret@localhost:5432/db";
+        let masked = mask_password(url);
+        assert_eq!(masked, "postgres://user:****@localhost:5432/db");
+    }
+
+    #[test]
+    fn mask_password_no_password() {
+        let url = "postgres://localhost:5432/db";
+        let masked = mask_password(url);
+        assert_eq!(masked, url);
+    }
+}

--- a/crates/proof/prover-service/db/src/lib.rs
+++ b/crates/proof/prover-service/db/src/lib.rs
@@ -1,0 +1,15 @@
+#![doc = include_str!("../README.md")]
+
+mod config;
+pub use config::DatabaseConfig;
+
+mod models;
+pub use models::{
+    CreateOutboxEntry, CreateProofRequest, CreateProofRequestError, CreateProofRequestOutcome,
+    CreateProofSession, MarkOutboxError, MarkOutboxProcessed, OutboxEntry, ProofRequest,
+    ProofRequestListItem, ProofRequestPage, ProofSession, ProofStatus, ProofType, RetryOutcome,
+    SessionStatus, SessionType, UpdateProofSession, UpdateReceipt,
+};
+
+mod repo;
+pub use repo::ProofRequestRepo;

--- a/crates/proof/prover-service/db/src/models.rs
+++ b/crates/proof/prover-service/db/src/models.rs
@@ -1,0 +1,511 @@
+use std::convert::TryFrom;
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use sqlx::FromRow;
+use uuid::Uuid;
+
+/// Status of a proof request
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, sqlx::Type)]
+#[sqlx(type_name = "VARCHAR", rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum ProofStatus {
+    /// Proof request has been created but not yet queued.
+    Created,
+    /// Proof request is queued and awaiting processing.
+    Pending,
+    /// Proof is actively being generated.
+    Running,
+    /// Proof generation completed successfully.
+    Succeeded,
+    /// Proof generation failed.
+    Failed,
+}
+
+impl ProofStatus {
+    /// Convert enum to static string representation
+    pub const fn as_str(&self) -> &'static str {
+        match self {
+            Self::Created => "CREATED",
+            Self::Pending => "PENDING",
+            Self::Running => "RUNNING",
+            Self::Succeeded => "SUCCEEDED",
+            Self::Failed => "FAILED",
+        }
+    }
+}
+
+impl std::fmt::Display for ProofStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.as_str())
+    }
+}
+
+impl TryFrom<&str> for ProofStatus {
+    type Error = String;
+
+    fn try_from(s: &str) -> Result<Self, Self::Error> {
+        match s {
+            "CREATED" => Ok(Self::Created),
+            "PENDING" => Ok(Self::Pending),
+            "RUNNING" => Ok(Self::Running),
+            "SUCCEEDED" => Ok(Self::Succeeded),
+            "FAILED" => Ok(Self::Failed),
+            other => Err(format!("Unknown proof status: {other}")),
+        }
+    }
+}
+
+/// Status of an individual proof session (STARK or SNARK)
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, sqlx::Type)]
+#[sqlx(type_name = "VARCHAR", rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum SessionStatus {
+    /// Reservation placeholder before the backend job has been submitted. The row holds a
+    /// synthetic `backend_session_id` so the partial unique index serializes concurrent
+    /// reservations; sync loops skip it because they only poll RUNNING rows.
+    Submitting,
+    /// Backend session is actively running.
+    Running,
+    /// Backend session completed successfully.
+    Completed,
+    /// Backend session failed.
+    Failed,
+}
+
+impl SessionStatus {
+    /// Convert enum to static string representation
+    pub const fn as_str(&self) -> &'static str {
+        match self {
+            Self::Submitting => "SUBMITTING",
+            Self::Running => "RUNNING",
+            Self::Completed => "COMPLETED",
+            Self::Failed => "FAILED",
+        }
+    }
+}
+
+impl std::fmt::Display for SessionStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.as_str())
+    }
+}
+
+impl TryFrom<&str> for SessionStatus {
+    type Error = String;
+
+    fn try_from(s: &str) -> Result<Self, Self::Error> {
+        match s {
+            "SUBMITTING" => Ok(Self::Submitting),
+            "RUNNING" => Ok(Self::Running),
+            "COMPLETED" => Ok(Self::Completed),
+            "FAILED" => Ok(Self::Failed),
+            other => Err(format!("Unknown session status: {other}")),
+        }
+    }
+}
+
+/// Type of proof session
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, sqlx::Type)]
+#[sqlx(type_name = "VARCHAR", rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum SessionType {
+    /// STARK proof session.
+    Stark,
+    /// SNARK proof session.
+    Snark,
+}
+
+impl SessionType {
+    /// Convert enum to static string representation
+    pub const fn as_str(&self) -> &'static str {
+        match self {
+            Self::Stark => "STARK",
+            Self::Snark => "SNARK",
+        }
+    }
+}
+
+impl std::fmt::Display for SessionType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.as_str())
+    }
+}
+
+impl TryFrom<&str> for SessionType {
+    type Error = String;
+
+    fn try_from(s: &str) -> Result<Self, Self::Error> {
+        match s {
+            "STARK" => Ok(Self::Stark),
+            "SNARK" => Ok(Self::Snark),
+            other => Err(format!("Unknown session type: {other}")),
+        }
+    }
+}
+
+/// Outcome of attempting to retry or fail a stuck proof request.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RetryOutcome {
+    /// Request was reset to CREATED with incremented `retry_count`.
+    Retried,
+    /// Request was permanently marked FAILED (max retries exceeded).
+    PermanentlyFailed,
+    /// Request was no longer in PENDING state (already claimed or transitioned).
+    Skipped,
+}
+
+/// Outcome of a `create_with_outbox` call.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CreateProofRequestOutcome {
+    /// A new proof request row and outbox entry were inserted.
+    Created(Uuid),
+    /// An existing terminal `FAILED` row was reset to `CREATED` and a fresh
+    /// outbox entry was inserted; the worker will pick it up again.
+    Requeued(Uuid),
+    /// An existing non-terminal or `SUCCEEDED` row was returned unchanged for
+    /// idempotent replay; no new outbox entry was inserted.
+    Replayed(Uuid),
+    /// An existing terminal `FAILED` row is at the retry cap; no requeue.
+    RetryExhausted(Uuid),
+}
+
+impl CreateProofRequestOutcome {
+    /// Returns the proof request UUID regardless of outcome variant.
+    pub const fn id(&self) -> Uuid {
+        match self {
+            Self::Created(id)
+            | Self::Requeued(id)
+            | Self::Replayed(id)
+            | Self::RetryExhausted(id) => *id,
+        }
+    }
+}
+
+/// Errors returned by `create_with_outbox`.
+#[derive(Debug, thiserror::Error)]
+pub enum CreateProofRequestError {
+    /// Persisted row disagrees with the new request for this `session_id`.
+    #[error(
+        "session_id {id} already exists with a different {field} \
+         (existing request parameters do not match the new request)"
+    )]
+    IdCollision {
+        /// Conflicting proof request UUID.
+        id: Uuid,
+        /// Name of the first mismatched field. Stable across runs.
+        field: &'static str,
+    },
+    /// Conflicting row disappeared after insert conflict; safe to retry.
+    #[error("session_id {id}: proof request row missing after insert conflict; retry prove_block")]
+    SessionRowMissingAfterConflict {
+        /// Proof request UUID that was expected to exist.
+        id: Uuid,
+    },
+    /// Underlying database error.
+    #[error(transparent)]
+    Sqlx(#[from] sqlx::Error),
+}
+
+/// Type of proof that determines success criteria
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, sqlx::Type)]
+#[sqlx(type_name = "VARCHAR")]
+pub enum ProofType {
+    /// Compressed proof generated via the Succinct SP1 cluster.
+    #[sqlx(rename = "op_succinct_sp1_cluster_compressed")]
+    OpSuccinctSp1ClusterCompressed,
+    /// SNARK Groth16 proof generated via the Succinct SP1 cluster.
+    #[sqlx(rename = "op_succinct_sp1_cluster_snark_groth16")]
+    OpSuccinctSp1ClusterSnarkGroth16,
+}
+
+impl ProofType {
+    /// Proto discriminant for `PROOF_TYPE_COMPRESSED`.
+    pub const PROTO_COMPRESSED: i32 = 3;
+    /// Proto discriminant for `PROOF_TYPE_SNARK_GROTH16`.
+    pub const PROTO_SNARK_GROTH16: i32 = 4;
+
+    /// Returns the proto wire value for this proof type.
+    pub const fn proto_i32(&self) -> i32 {
+        match self {
+            Self::OpSuccinctSp1ClusterCompressed => Self::PROTO_COMPRESSED,
+            Self::OpSuccinctSp1ClusterSnarkGroth16 => Self::PROTO_SNARK_GROTH16,
+        }
+    }
+
+    /// Convert enum to static string representation
+    pub const fn as_str(&self) -> &'static str {
+        match self {
+            Self::OpSuccinctSp1ClusterCompressed => "op_succinct_sp1_cluster_compressed",
+            Self::OpSuccinctSp1ClusterSnarkGroth16 => "op_succinct_sp1_cluster_snark_groth16",
+        }
+    }
+}
+
+impl std::fmt::Display for ProofType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.as_str())
+    }
+}
+
+impl TryFrom<&str> for ProofType {
+    type Error = String;
+
+    fn try_from(s: &str) -> Result<Self, Self::Error> {
+        match s {
+            "op_succinct_sp1_cluster_compressed" => Ok(Self::OpSuccinctSp1ClusterCompressed),
+            "op_succinct_sp1_cluster_snark_groth16" => Ok(Self::OpSuccinctSp1ClusterSnarkGroth16),
+            other => Err(format!("Unknown proof type: {other}")),
+        }
+    }
+}
+
+/// Convert from proto proof type integer to `ProofType`
+impl TryFrom<i32> for ProofType {
+    type Error = String;
+
+    fn try_from(value: i32) -> Result<Self, Self::Error> {
+        match value {
+            Self::PROTO_COMPRESSED => Ok(Self::OpSuccinctSp1ClusterCompressed),
+            Self::PROTO_SNARK_GROTH16 => Ok(Self::OpSuccinctSp1ClusterSnarkGroth16),
+            _ => Err(format!("Unknown proof type: {value}")),
+        }
+    }
+}
+
+/// A proof request record in the database
+#[derive(Debug, Clone, FromRow, Serialize, Deserialize)]
+pub struct ProofRequest {
+    /// Unique identifier.
+    pub id: Uuid,
+    /// Starting L2 block number.
+    pub start_block_number: i64,
+    /// Number of consecutive blocks to prove.
+    pub number_of_blocks_to_prove: i64,
+    /// Optional sequence window for the proof range.
+    pub sequence_window: Option<i64>,
+    /// Type of proof to generate.
+    pub proof_type: ProofType,
+    /// Raw STARK receipt bytes, if available.
+    pub stark_receipt: Option<Vec<u8>>,
+    /// Raw SNARK receipt bytes, if available.
+    pub snark_receipt: Option<Vec<u8>>,
+    /// Current proof status.
+    pub status: ProofStatus,
+    /// Error message if the proof failed.
+    pub error_message: Option<String>,
+    /// Ethereum address of the on-chain prover.
+    pub prover_address: Option<String>,
+    /// Explicit L1 head hash used for witness generation.
+    pub l1_head: Option<String>,
+    /// Intermediate root interval requested for ZK proof generation.
+    pub intermediate_root_interval: Option<i64>,
+    /// Timestamp when the request was created.
+    pub created_at: DateTime<Utc>,
+    /// Timestamp of the last status update.
+    pub updated_at: DateTime<Utc>,
+    /// Timestamp when the proof completed (success or failure).
+    pub completed_at: Option<DateTime<Utc>>,
+    /// Number of times this request has been retried after getting stuck.
+    pub retry_count: i32,
+}
+
+/// Receipt-free proof request row used by list endpoints.
+#[derive(Debug, Clone, FromRow, Serialize, Deserialize)]
+pub struct ProofRequestListItem {
+    /// Unique identifier.
+    pub id: Uuid,
+    /// Starting L2 block number.
+    pub start_block_number: i64,
+    /// Number of consecutive blocks to prove.
+    pub number_of_blocks_to_prove: i64,
+    /// Type of proof to generate.
+    pub proof_type: ProofType,
+    /// Current proof status.
+    pub status: ProofStatus,
+    /// Error message if the proof failed.
+    pub error_message: Option<String>,
+    /// Timestamp when the request was created.
+    pub created_at: DateTime<Utc>,
+    /// Timestamp of the last status update.
+    pub updated_at: DateTime<Utc>,
+    /// Timestamp when the proof completed (success or failure).
+    pub completed_at: Option<DateTime<Utc>>,
+}
+
+/// Offset pagination parameters.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ProofRequestPage {
+    limit: i64,
+    offset: i64,
+}
+
+impl ProofRequestPage {
+    /// Create pagination parameters from API-level unsigned values.
+    pub fn try_new(limit: u64, offset: u64) -> Result<Self, String> {
+        if limit == 0 {
+            return Err("limit must be greater than zero".to_owned());
+        }
+
+        let limit =
+            i64::try_from(limit).map_err(|_| "limit exceeds maximum supported value".to_owned())?;
+        let offset = i64::try_from(offset)
+            .map_err(|_| "offset exceeds maximum supported value".to_owned())?;
+
+        Ok(Self { limit, offset })
+    }
+
+    /// Maximum number of rows to return.
+    pub const fn limit(&self) -> i64 {
+        self.limit
+    }
+
+    /// Number of rows to skip.
+    pub const fn offset(&self) -> i64 {
+        self.offset
+    }
+}
+
+/// A proof session record tracking a specific backend job (STARK or SNARK)
+#[derive(Debug, Clone, FromRow, Serialize, Deserialize)]
+pub struct ProofSession {
+    /// Auto-incrementing session identifier.
+    pub id: i64,
+    /// Parent proof request identifier.
+    pub proof_request_id: Uuid,
+    /// Whether this session produces a STARK or SNARK proof.
+    pub session_type: SessionType,
+    /// Backend-assigned session identifier.
+    pub backend_session_id: String,
+    /// Current session status.
+    pub status: SessionStatus,
+    /// Error message if the session failed.
+    pub error_message: Option<String>,
+    /// Backend-specific metadata (JSON).
+    pub metadata: Option<serde_json::Value>,
+    /// Timestamp when the session was created.
+    pub created_at: DateTime<Utc>,
+    /// Timestamp when the session completed.
+    pub completed_at: Option<DateTime<Utc>>,
+}
+
+/// Parameters for creating a new proof request
+#[derive(Debug, Clone)]
+pub struct CreateProofRequest {
+    /// Starting L2 block number.
+    pub start_block_number: u64,
+    /// Number of consecutive blocks to prove.
+    pub number_of_blocks_to_prove: u64,
+    /// Optional sequence window.
+    pub sequence_window: Option<u64>,
+    /// Type of proof to generate.
+    pub proof_type: ProofType,
+    /// Client-provided UUID for idempotent requests.
+    pub session_id: Option<Uuid>,
+    /// Ethereum address of the on-chain prover (required for SNARK Groth16 proofs).
+    pub prover_address: Option<String>,
+    /// Explicit L1 head hash for witness generation.
+    pub l1_head: Option<String>,
+    /// Intermediate root interval for ZK proof generation.
+    pub intermediate_root_interval: Option<u64>,
+}
+
+/// Parameters for creating a new proof session
+#[derive(Debug, Clone)]
+pub struct CreateProofSession {
+    /// Parent proof request identifier.
+    pub proof_request_id: Uuid,
+    /// Whether this is a STARK or SNARK session.
+    pub session_type: SessionType,
+    /// Backend-assigned session identifier.
+    pub backend_session_id: String,
+    /// Backend-specific metadata (JSON).
+    pub metadata: Option<serde_json::Value>,
+}
+
+/// Parameters for updating a proof session status
+#[derive(Debug, Clone)]
+pub struct UpdateProofSession {
+    /// Backend-assigned session identifier to look up.
+    pub backend_session_id: String,
+    /// New session status.
+    pub status: SessionStatus,
+    /// Error message, if the session failed.
+    pub error_message: Option<String>,
+    /// Updated backend metadata (JSON).
+    pub metadata: Option<serde_json::Value>,
+}
+
+/// Parameters for updating a proof request with receipt
+#[derive(Debug, Clone)]
+pub struct UpdateReceipt {
+    /// Proof request identifier.
+    pub id: Uuid,
+    /// Raw STARK receipt bytes.
+    pub stark_receipt: Option<Vec<u8>>,
+    /// Raw SNARK receipt bytes.
+    pub snark_receipt: Option<Vec<u8>>,
+    /// New proof status.
+    pub status: ProofStatus,
+    /// Error message, if the proof failed.
+    pub error_message: Option<String>,
+}
+
+/// Outbox entry for reliable task processing
+#[derive(Debug, Clone, FromRow, Serialize, Deserialize)]
+pub struct OutboxEntry {
+    /// Auto-incrementing sequence identifier (FIFO ordering).
+    pub sequence_id: i64,
+    /// Associated proof request identifier.
+    pub proof_request_id: Uuid,
+    /// Serialized proof request parameters (JSON).
+    pub request_params: serde_json::Value,
+    /// Whether this entry has been processed.
+    pub processed: bool,
+    /// Timestamp when the entry was processed.
+    pub processed_at: Option<DateTime<Utc>>,
+    /// Number of times processing has been retried.
+    pub retry_count: i32,
+    /// Error from the most recent processing attempt.
+    pub last_error: Option<String>,
+    /// Timestamp when the entry was created.
+    pub created_at: DateTime<Utc>,
+}
+
+/// Parameters for creating an outbox entry
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CreateOutboxEntry {
+    /// Associated proof request identifier.
+    pub proof_request_id: Uuid,
+    /// Serialized proof request parameters (JSON).
+    pub request_params: serde_json::Value,
+}
+
+/// Parameters for marking an outbox entry as processed
+#[derive(Debug, Clone)]
+pub struct MarkOutboxProcessed {
+    /// Sequence identifier of the outbox entry to mark.
+    pub sequence_id: i64,
+}
+
+/// Parameters for recording a processing error
+#[derive(Debug, Clone)]
+pub struct MarkOutboxError {
+    /// Sequence identifier of the outbox entry.
+    pub sequence_id: i64,
+    /// Error message from the failed processing attempt.
+    pub error_message: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_proof_type_try_from_proto() {
+        assert_eq!(ProofType::try_from(3).unwrap(), ProofType::OpSuccinctSp1ClusterCompressed);
+        assert_eq!(ProofType::try_from(4).unwrap(), ProofType::OpSuccinctSp1ClusterSnarkGroth16);
+
+        assert!(ProofType::try_from(0).is_err());
+        assert!(ProofType::try_from(1).is_err());
+        assert!(ProofType::try_from(2).is_err());
+        assert!(ProofType::try_from(5).is_err());
+    }
+}

--- a/crates/proof/prover-service/db/src/repo.rs
+++ b/crates/proof/prover-service/db/src/repo.rs
@@ -1,0 +1,1383 @@
+use sqlx::{PgPool, Result, Row};
+use uuid::Uuid;
+
+use crate::{
+    CreateOutboxEntry, CreateProofRequest, CreateProofRequestError, CreateProofRequestOutcome,
+    CreateProofSession, MarkOutboxError, MarkOutboxProcessed, OutboxEntry, ProofRequest,
+    ProofRequestListItem, ProofRequestPage, ProofSession, ProofStatus, ProofType, RetryOutcome,
+    SessionStatus, SessionType, UpdateProofSession, UpdateReceipt,
+};
+
+/// Repository for proof request database operations
+#[derive(Clone, Debug)]
+pub struct ProofRequestRepo {
+    pool: PgPool,
+}
+
+impl ProofRequestRepo {
+    /// Create a new repository instance with the given database pool
+    pub const fn new(pool: PgPool) -> Self {
+        Self { pool }
+    }
+
+    /// Create a new proof request and return its UUID
+    pub async fn create(&self, req: CreateProofRequest) -> Result<Uuid> {
+        let id = req.session_id.unwrap_or_else(Uuid::new_v4);
+
+        sqlx::query(
+            r#"
+            INSERT INTO proof_requests (
+                id, start_block_number, number_of_blocks_to_prove,
+                sequence_window, proof_type, status, prover_address, l1_head,
+                intermediate_root_interval
+            )
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+            "#,
+        )
+        .bind(id)
+        .bind(
+            i64::try_from(req.start_block_number)
+                .map_err(|_| sqlx::Error::Protocol("block number exceeds i64 range".into()))?,
+        )
+        .bind(
+            i64::try_from(req.number_of_blocks_to_prove)
+                .map_err(|_| sqlx::Error::Protocol("blocks to prove exceeds i64 range".into()))?,
+        )
+        .bind(
+            req.sequence_window
+                .map(|w| {
+                    i64::try_from(w).map_err(|_| {
+                        sqlx::Error::Protocol("sequence window exceeds i64 range".into())
+                    })
+                })
+                .transpose()?,
+        )
+        .bind(req.proof_type.as_str())
+        .bind(ProofStatus::Created.as_str())
+        .bind(&req.prover_address)
+        .bind(&req.l1_head)
+        .bind(
+            req.intermediate_root_interval
+                .map(|v| {
+                    i64::try_from(v).map_err(|_| {
+                        sqlx::Error::Protocol("intermediate root interval exceeds i64 range".into())
+                    })
+                })
+                .transpose()?,
+        )
+        .execute(&self.pool)
+        .await?;
+
+        Ok(id)
+    }
+
+    /// Atomically create a proof request and outbox entry in a transaction.
+    ///
+    /// On `session_id` conflict, lock the row `FOR UPDATE` and branch on state:
+    /// parameter mismatch → [`CreateProofRequestError::IdCollision`];
+    /// `CREATED` / `PENDING` / `RUNNING` / `SUCCEEDED` → [`CreateProofRequestOutcome::Replayed`];
+    /// `FAILED` with room under `max_retries` → reset, bump `retry_count`, new outbox row
+    /// ([`CreateProofRequestOutcome::Requeued`]); `FAILED` at cap → [`CreateProofRequestOutcome::RetryExhausted`].
+    ///
+    /// Use the same `max_retries` as [`Self::retry_or_fail_stuck_request`] (shared `retry_count` cap).
+    pub async fn create_with_outbox(
+        &self,
+        req: CreateProofRequest,
+        max_retries: i32,
+    ) -> std::result::Result<CreateProofRequestOutcome, CreateProofRequestError> {
+        let id = req.session_id.unwrap_or_else(Uuid::new_v4);
+
+        let start_block_number = i64::try_from(req.start_block_number)
+            .map_err(|_| sqlx::Error::Protocol("block number exceeds i64 range".into()))?;
+        let number_of_blocks_to_prove = i64::try_from(req.number_of_blocks_to_prove)
+            .map_err(|_| sqlx::Error::Protocol("blocks to prove exceeds i64 range".into()))?;
+        let sequence_window = req
+            .sequence_window
+            .map(|w| {
+                i64::try_from(w)
+                    .map_err(|_| sqlx::Error::Protocol("sequence window exceeds i64 range".into()))
+            })
+            .transpose()?;
+        let intermediate_root_interval = req
+            .intermediate_root_interval
+            .map(|v| {
+                i64::try_from(v).map_err(|_| {
+                    sqlx::Error::Protocol("intermediate root interval exceeds i64 range".into())
+                })
+            })
+            .transpose()?;
+
+        let request_params = build_outbox_params(
+            start_block_number,
+            number_of_blocks_to_prove,
+            sequence_window,
+            req.proof_type.as_str(),
+            req.prover_address.as_deref(),
+            req.l1_head.as_deref(),
+            intermediate_root_interval,
+        );
+
+        let mut tx = self.pool.begin().await?;
+
+        let insert_result = sqlx::query(
+            r#"
+            INSERT INTO proof_requests (
+                id, start_block_number, number_of_blocks_to_prove,
+                sequence_window, proof_type, status, prover_address, l1_head,
+                intermediate_root_interval
+            )
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+            ON CONFLICT (id) DO NOTHING
+            "#,
+        )
+        .bind(id)
+        .bind(start_block_number)
+        .bind(number_of_blocks_to_prove)
+        .bind(sequence_window)
+        .bind(req.proof_type.as_str())
+        .bind(ProofStatus::Created.as_str())
+        .bind(&req.prover_address)
+        .bind(&req.l1_head)
+        .bind(intermediate_root_interval)
+        .execute(&mut *tx)
+        .await?;
+
+        if insert_result.rows_affected() > 0 {
+            sqlx::query(
+                r#"
+                INSERT INTO proof_request_outbox (proof_request_id, request_params)
+                VALUES ($1, $2)
+                "#,
+            )
+            .bind(id)
+            .bind(&request_params)
+            .execute(&mut *tx)
+            .await?;
+
+            tx.commit().await?;
+            return Ok(CreateProofRequestOutcome::Created(id));
+        }
+
+        // Conflict path: `FOR UPDATE` serializes with stuck recovery and workers.
+        let row = sqlx::query(
+            r#"
+            SELECT start_block_number, number_of_blocks_to_prove, sequence_window,
+                   proof_type, status, prover_address, l1_head,
+                   intermediate_root_interval, retry_count
+            FROM proof_requests
+            WHERE id = $1
+            FOR UPDATE
+            "#,
+        )
+        .bind(id)
+        .fetch_optional(&mut *tx)
+        .await?;
+
+        let Some(row) = row else {
+            tx.rollback().await?;
+            return Err(CreateProofRequestError::SessionRowMissingAfterConflict { id });
+        };
+
+        let params = CreateOutboxRequestParams {
+            start_block_number,
+            number_of_blocks_to_prove,
+            sequence_window,
+            proof_type: req.proof_type.as_str(),
+            prover_address: req.prover_address.as_deref(),
+            l1_head: req.l1_head.as_deref(),
+            intermediate_root_interval,
+        };
+        if let Some(field) = params.first_mismatch(&row) {
+            tx.rollback().await?;
+            return Err(CreateProofRequestError::IdCollision { id, field });
+        }
+
+        let status_str: &str = row.get("status");
+        let status = ProofStatus::try_from(status_str).map_err(|e| {
+            sqlx::Error::Protocol(format!("Unknown proof status '{status_str}': {e}"))
+        })?;
+
+        match status {
+            ProofStatus::Created
+            | ProofStatus::Pending
+            | ProofStatus::Running
+            | ProofStatus::Succeeded => {
+                tx.rollback().await?;
+                Ok(CreateProofRequestOutcome::Replayed(id))
+            }
+            ProofStatus::Failed => {
+                let retry_count: i32 = row.get("retry_count");
+                if retry_count >= max_retries {
+                    tx.rollback().await?;
+                    return Ok(CreateProofRequestOutcome::RetryExhausted(id));
+                }
+
+                // Fail any active sessions before resetting so the requeued run cannot
+                // collide with `idx_proof_sessions_request_type_active_unique`. Mirrors
+                // the cleanup in `retry_or_fail_stuck_request`.
+                sqlx::query(
+                    r#"
+                    UPDATE proof_sessions
+                    SET status = $1,
+                        error_message = COALESCE(error_message, $2),
+                        completed_at = NOW()
+                    WHERE proof_request_id = $3 AND status IN ($4, $5)
+                    "#,
+                )
+                .bind(SessionStatus::Failed.as_str())
+                .bind("cleared during create_with_outbox requeue")
+                .bind(id)
+                .bind(SessionStatus::Submitting.as_str())
+                .bind(SessionStatus::Running.as_str())
+                .execute(&mut *tx)
+                .await?;
+
+                sqlx::query(
+                    r#"
+                    UPDATE proof_requests
+                    SET status = $1,
+                        retry_count = retry_count + 1,
+                        error_message = NULL,
+                        stark_receipt = NULL,
+                        snark_receipt = NULL,
+                        completed_at = NULL
+                    WHERE id = $2
+                    "#,
+                )
+                .bind(ProofStatus::Created.as_str())
+                .bind(id)
+                .execute(&mut *tx)
+                .await?;
+
+                sqlx::query(
+                    r#"
+                    INSERT INTO proof_request_outbox (proof_request_id, request_params)
+                    VALUES ($1, $2)
+                    "#,
+                )
+                .bind(id)
+                .bind(&request_params)
+                .execute(&mut *tx)
+                .await?;
+
+                tx.commit().await?;
+                Ok(CreateProofRequestOutcome::Requeued(id))
+            }
+        }
+    }
+
+    /// Get a proof request by ID
+    pub async fn get(&self, id: Uuid) -> Result<Option<ProofRequest>> {
+        let row = sqlx::query(
+            r#"
+            SELECT
+                id, start_block_number, number_of_blocks_to_prove,
+                sequence_window, proof_type,
+                stark_receipt, snark_receipt,
+                status, error_message,
+                prover_address, l1_head, intermediate_root_interval,
+                created_at, updated_at, completed_at, retry_count
+            FROM proof_requests
+            WHERE id = $1
+            "#,
+        )
+        .bind(id)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        row.map(|r| row_to_proof_request(&r)).transpose()
+    }
+
+    /// Update receipt fields while the request is still RUNNING.
+    /// Status is kept as RUNNING — this method cannot be used for state transitions.
+    /// Returns true if update succeeded, false otherwise.
+    pub async fn update_receipt_if_running(&self, update: UpdateReceipt) -> Result<bool> {
+        debug_assert_eq!(
+            update.status,
+            ProofStatus::Running,
+            "update_receipt_if_running is for intermediate receipt updates only; \
+             use transition_running_to_succeeded or fail_session_and_request for state transitions",
+        );
+
+        let result = sqlx::query(
+            r#"
+            UPDATE proof_requests
+            SET
+                stark_receipt = COALESCE($1, stark_receipt),
+                snark_receipt = COALESCE($2, snark_receipt),
+                status = 'RUNNING',
+                error_message = $3,
+                completed_at = NULL
+            WHERE id = $4
+              AND status = 'RUNNING'
+            "#,
+        )
+        .bind(&update.stark_receipt)
+        .bind(&update.snark_receipt)
+        .bind(&update.error_message)
+        .bind(update.id)
+        .execute(&self.pool)
+        .await?;
+
+        let updated = result.rows_affected() > 0;
+
+        Ok(updated)
+    }
+
+    /// Atomically claim a task by transitioning it from CREATED to PENDING.
+    /// Returns true if the task was successfully claimed (was in CREATED state).
+    /// Returns false if the task was already claimed or doesn't exist.
+    pub async fn atomic_claim_task(&self, id: Uuid) -> Result<bool> {
+        let result = sqlx::query(
+            r#"
+            UPDATE proof_requests
+            SET status = $1
+            WHERE id = $2 AND status = $3
+            "#,
+        )
+        .bind(ProofStatus::Pending.as_str())
+        .bind(id)
+        .bind(ProofStatus::Created.as_str())
+        .execute(&self.pool)
+        .await?;
+
+        let claimed = result.rows_affected() > 0;
+
+        Ok(claimed)
+    }
+
+    /// Atomically create a proof session and transition proof request PENDING → RUNNING.
+    /// Returns `Ok(Some(session_id))` if the request was in PENDING state.
+    /// Returns `Ok(None)` if the request was NOT in PENDING state (race lost).
+    pub async fn transition_pending_to_running(
+        &self,
+        session: CreateProofSession,
+    ) -> Result<Option<i64>> {
+        let mut tx = self.pool.begin().await?;
+
+        let result = sqlx::query(
+            r#"
+            UPDATE proof_requests
+            SET status = $1
+            WHERE id = $2 AND status = $3
+            "#,
+        )
+        .bind(ProofStatus::Running.as_str())
+        .bind(session.proof_request_id)
+        .bind(ProofStatus::Pending.as_str())
+        .execute(&mut *tx)
+        .await?;
+
+        if result.rows_affected() == 0 {
+            tx.rollback().await?;
+            return Ok(None);
+        }
+
+        let row = sqlx::query(
+            r#"
+            INSERT INTO proof_sessions (
+                proof_request_id, session_type, backend_session_id, status, metadata
+            )
+            VALUES ($1, $2, $3, $4, $5)
+            RETURNING id
+            "#,
+        )
+        .bind(session.proof_request_id)
+        .bind(session.session_type.as_str())
+        .bind(&session.backend_session_id)
+        .bind(SessionStatus::Running.as_str())
+        .bind(&session.metadata)
+        .fetch_one(&mut *tx)
+        .await?;
+
+        let session_id: i64 = row.get("id");
+        tx.commit().await?;
+
+        Ok(Some(session_id))
+    }
+
+    /// Transition proof request PENDING → FAILED with error message.
+    /// Returns true if the transition succeeded (was PENDING).
+    pub async fn transition_pending_to_failed(
+        &self,
+        id: Uuid,
+        error_message: String,
+    ) -> Result<bool> {
+        let result = sqlx::query(
+            r#"
+            UPDATE proof_requests
+            SET status = $1,
+                error_message = $2,
+                completed_at = NOW()
+            WHERE id = $3 AND status = $4
+            "#,
+        )
+        .bind(ProofStatus::Failed.as_str())
+        .bind(&error_message)
+        .bind(id)
+        .bind(ProofStatus::Pending.as_str())
+        .execute(&self.pool)
+        .await?;
+
+        Ok(result.rows_affected() > 0)
+    }
+
+    /// Transition proof request RUNNING → FAILED with optional error message.
+    /// Returns true if the transition succeeded (was RUNNING).
+    pub async fn transition_running_to_failed(
+        &self,
+        id: Uuid,
+        error_message: Option<String>,
+    ) -> Result<bool> {
+        let result = sqlx::query(
+            r#"
+            UPDATE proof_requests
+            SET status = $1,
+                error_message = $2,
+                completed_at = NOW()
+            WHERE id = $3 AND status = $4
+            "#,
+        )
+        .bind(ProofStatus::Failed.as_str())
+        .bind(&error_message)
+        .bind(id)
+        .bind(ProofStatus::Running.as_str())
+        .execute(&self.pool)
+        .await?;
+
+        Ok(result.rows_affected() > 0)
+    }
+
+    /// Transition proof request RUNNING → SUCCEEDED with receipt data.
+    /// Returns true if the transition succeeded (was RUNNING).
+    pub async fn transition_running_to_succeeded(&self, update: UpdateReceipt) -> Result<bool> {
+        debug_assert_eq!(
+            update.status,
+            ProofStatus::Succeeded,
+            "transition_running_to_succeeded called with status {:?}; the status field is ignored \
+             — this method always writes SUCCEEDED",
+            update.status,
+        );
+
+        let result = sqlx::query(
+            r#"
+            UPDATE proof_requests
+            SET stark_receipt = COALESCE($1, stark_receipt),
+                snark_receipt = COALESCE($2, snark_receipt),
+                status = $3,
+                error_message = $4,
+                completed_at = NOW()
+            WHERE id = $5 AND status = $6
+            "#,
+        )
+        .bind(&update.stark_receipt)
+        .bind(&update.snark_receipt)
+        .bind(ProofStatus::Succeeded.as_str())
+        .bind(&update.error_message)
+        .bind(update.id)
+        .bind(ProofStatus::Running.as_str())
+        .execute(&self.pool)
+        .await?;
+
+        Ok(result.rows_affected() > 0)
+    }
+
+    /// Retry a stuck PENDING request if under the retry limit, otherwise fail it permanently.
+    ///
+    /// If `retry_count < max_retries`: atomically resets to CREATED, increments `retry_count`,
+    /// and creates a new outbox entry so a worker picks it up again.
+    /// If `retry_count >= max_retries`: transitions to FAILED.
+    pub async fn retry_or_fail_stuck_request(
+        &self,
+        id: Uuid,
+        max_retries: i32,
+        error_message: &str,
+    ) -> Result<RetryOutcome> {
+        let mut tx = self.pool.begin().await?;
+
+        let maybe_row = sqlx::query(
+            r#"
+            SELECT retry_count, status, start_block_number, number_of_blocks_to_prove,
+                   sequence_window, proof_type, prover_address, l1_head,
+                   intermediate_root_interval
+            FROM proof_requests
+            WHERE id = $1
+            FOR UPDATE
+            "#,
+        )
+        .bind(id)
+        .fetch_optional(&mut *tx)
+        .await?;
+
+        let Some(row) = maybe_row else {
+            tx.rollback().await?;
+            return Ok(RetryOutcome::Skipped);
+        };
+
+        let status_str: &str = row.get("status");
+        if status_str != ProofStatus::Pending.as_str() {
+            tx.rollback().await?;
+            return Ok(RetryOutcome::Skipped);
+        }
+
+        let retry_count: i32 = row.get("retry_count");
+
+        // Fail any active sessions before resetting so the retried run cannot collide with
+        // `idx_proof_sessions_request_type_active_unique`. No-op on the normal reaper path,
+        // since `get_stuck_requests` already excludes requests that have an active session.
+        sqlx::query(
+            r#"
+            UPDATE proof_sessions
+            SET status = $1,
+                error_message = COALESCE(error_message, $2),
+                completed_at = NOW()
+            WHERE proof_request_id = $3 AND status IN ($4, $5)
+            "#,
+        )
+        .bind(SessionStatus::Failed.as_str())
+        .bind("cleared during stuck-request retry")
+        .bind(id)
+        .bind(SessionStatus::Submitting.as_str())
+        .bind(SessionStatus::Running.as_str())
+        .execute(&mut *tx)
+        .await?;
+
+        if retry_count >= max_retries {
+            sqlx::query(
+                r#"
+                UPDATE proof_requests
+                SET status = $1,
+                    error_message = $2,
+                    completed_at = NOW()
+                WHERE id = $3
+                "#,
+            )
+            .bind(ProofStatus::Failed.as_str())
+            .bind(format!("{error_message} (max retries exceeded after {retry_count} attempts)"))
+            .bind(id)
+            .execute(&mut *tx)
+            .await?;
+
+            tx.commit().await?;
+            return Ok(RetryOutcome::PermanentlyFailed);
+        }
+
+        sqlx::query(
+            r#"
+            UPDATE proof_requests
+            SET status = $1,
+                retry_count = retry_count + 1,
+                error_message = NULL
+            WHERE id = $2
+            "#,
+        )
+        .bind(ProofStatus::Created.as_str())
+        .bind(id)
+        .execute(&mut *tx)
+        .await?;
+
+        // Copy the most recent outbox entry for this request. If the outbox was
+        // already cleaned up (0 rows), reconstruct request_params from the
+        // proof_request row we hold under FOR UPDATE.
+        let outbox_copy = sqlx::query(
+            r#"
+            INSERT INTO proof_request_outbox (proof_request_id, request_params)
+            SELECT proof_request_id, request_params
+            FROM proof_request_outbox
+            WHERE proof_request_id = $1
+            ORDER BY sequence_id DESC
+            LIMIT 1
+            "#,
+        )
+        .bind(id)
+        .execute(&mut *tx)
+        .await?;
+
+        if outbox_copy.rows_affected() == 0 {
+            let request_params = build_outbox_params(
+                row.get::<i64, _>("start_block_number"),
+                row.get::<i64, _>("number_of_blocks_to_prove"),
+                row.get::<Option<i64>, _>("sequence_window"),
+                row.get::<&str, _>("proof_type"),
+                row.get::<Option<&str>, _>("prover_address"),
+                row.get::<Option<&str>, _>("l1_head"),
+                row.get::<Option<i64>, _>("intermediate_root_interval"),
+            );
+
+            sqlx::query(
+                r#"
+                INSERT INTO proof_request_outbox (proof_request_id, request_params)
+                VALUES ($1, $2)
+                "#,
+            )
+            .bind(id)
+            .bind(&request_params)
+            .execute(&mut *tx)
+            .await?;
+        }
+
+        tx.commit().await?;
+        Ok(RetryOutcome::Retried)
+    }
+
+    // ========== Proof Session Methods ==========
+
+    /// Create a new proof session
+    pub async fn create_proof_session(&self, session: CreateProofSession) -> Result<i64> {
+        let row = sqlx::query(
+            r#"
+            INSERT INTO proof_sessions (
+                proof_request_id, session_type, backend_session_id, status, metadata
+            )
+            VALUES ($1, $2, $3, $4, $5)
+            RETURNING id
+            "#,
+        )
+        .bind(session.proof_request_id)
+        .bind(session.session_type.as_str())
+        .bind(&session.backend_session_id)
+        .bind(SessionStatus::Running.as_str())
+        .bind(&session.metadata)
+        .fetch_one(&self.pool)
+        .await?;
+
+        let id: i64 = row.get("id");
+        Ok(id)
+    }
+
+    /// Reserve a `(proof_request_id, session_type)` slot for a future backend submission.
+    /// Returns `Some(reservation_id)` for the single race winner; `None` if another
+    /// caller already holds an active (`SUBMITTING` or `RUNNING`) row.
+    ///
+    /// The row is inserted as `SUBMITTING` so sync loops (which only poll `RUNNING`
+    /// rows) skip it until activation. Callers must follow up with
+    /// [`Self::activate_reserved_proof_session`] on success or
+    /// [`Self::fail_reserved_proof_session`] on failure.
+    pub async fn reserve_proof_session(
+        &self,
+        proof_request_id: Uuid,
+        session_type: SessionType,
+    ) -> Result<Option<String>> {
+        let reservation_id = format!(
+            "reservation-{}-{}",
+            session_type.as_str().to_ascii_lowercase(),
+            Uuid::new_v4()
+        );
+
+        // ON CONFLICT predicate mirrors the partial unique index predicate.
+        let row = sqlx::query(
+            r#"
+            INSERT INTO proof_sessions (
+                proof_request_id, session_type, backend_session_id, status, metadata
+            )
+            VALUES ($1, $2, $3, $4, NULL)
+            ON CONFLICT (proof_request_id, session_type)
+                WHERE status IN ('SUBMITTING', 'RUNNING')
+                DO NOTHING
+            RETURNING backend_session_id
+            "#,
+        )
+        .bind(proof_request_id)
+        .bind(session_type.as_str())
+        .bind(&reservation_id)
+        .bind(SessionStatus::Submitting.as_str())
+        .fetch_optional(&self.pool)
+        .await?;
+
+        Ok(row.map(|r| r.get("backend_session_id")))
+    }
+
+    /// Promote a `SUBMITTING` reservation row to `RUNNING` with the real backend session
+    /// id. Returns `false` if the row was no longer eligible (failed or activated
+    /// out-of-band); the caller should then treat the backend job as orphaned.
+    pub async fn activate_reserved_proof_session(
+        &self,
+        reservation_id: &str,
+        session: CreateProofSession,
+    ) -> Result<bool> {
+        let result = sqlx::query(
+            r#"
+            UPDATE proof_sessions
+            SET backend_session_id = $1,
+                metadata = $2,
+                status = $3,
+                error_message = NULL
+            WHERE backend_session_id = $4
+              AND proof_request_id = $5
+              AND session_type = $6
+              AND status = $7
+            "#,
+        )
+        .bind(&session.backend_session_id)
+        .bind(&session.metadata)
+        .bind(SessionStatus::Running.as_str())
+        .bind(reservation_id)
+        .bind(session.proof_request_id)
+        .bind(session.session_type.as_str())
+        .bind(SessionStatus::Submitting.as_str())
+        .execute(&self.pool)
+        .await?;
+
+        Ok(result.rows_affected() > 0)
+    }
+
+    /// Mark a `SUBMITTING` reservation row as `FAILED` so the partial unique index
+    /// releases the slot and a future poll can retry. Used when the backend submit step
+    /// itself fails after a successful reservation.
+    pub async fn fail_reserved_proof_session(
+        &self,
+        proof_request_id: Uuid,
+        session_type: SessionType,
+        reservation_id: &str,
+        error_message: &str,
+    ) -> Result<bool> {
+        let result = sqlx::query(
+            r#"
+            UPDATE proof_sessions
+            SET status = $1,
+                error_message = $2,
+                completed_at = NOW()
+            WHERE backend_session_id = $3
+              AND proof_request_id = $4
+              AND session_type = $5
+              AND status = $6
+            "#,
+        )
+        .bind(SessionStatus::Failed.as_str())
+        .bind(error_message)
+        .bind(reservation_id)
+        .bind(proof_request_id)
+        .bind(session_type.as_str())
+        .bind(SessionStatus::Submitting.as_str())
+        .execute(&self.pool)
+        .await?;
+
+        Ok(result.rows_affected() > 0)
+    }
+
+    /// Get a proof session by backend session ID
+    pub async fn get_session_by_backend_id(
+        &self,
+        backend_session_id: &str,
+    ) -> Result<Option<ProofSession>> {
+        let row = sqlx::query(
+            r#"
+            SELECT id, proof_request_id, session_type, backend_session_id,
+                   status, error_message, metadata, created_at, completed_at
+            FROM proof_sessions
+            WHERE backend_session_id = $1
+            "#,
+        )
+        .bind(backend_session_id)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        row.map(|r| row_to_proof_session(&r)).transpose()
+    }
+
+    /// Get all sessions for a proof request
+    pub async fn get_sessions_for_request(
+        &self,
+        proof_request_id: Uuid,
+    ) -> Result<Vec<ProofSession>> {
+        let rows = sqlx::query(
+            r#"
+            SELECT id, proof_request_id, session_type, backend_session_id,
+                   status, error_message, metadata, created_at, completed_at
+            FROM proof_sessions
+            WHERE proof_request_id = $1
+            ORDER BY created_at ASC
+            "#,
+        )
+        .bind(proof_request_id)
+        .fetch_all(&self.pool)
+        .await?;
+
+        rows.iter().map(row_to_proof_session).collect()
+    }
+
+    /// Get all running sessions (for polling)
+    pub async fn get_running_sessions(&self) -> Result<Vec<ProofSession>> {
+        let rows = sqlx::query(
+            r#"
+            SELECT id, proof_request_id, session_type, backend_session_id,
+                   status, error_message, metadata, created_at, completed_at
+            FROM proof_sessions
+            WHERE status = $1
+            ORDER BY created_at ASC
+            "#,
+        )
+        .bind(SessionStatus::Running.as_str())
+        .fetch_all(&self.pool)
+        .await?;
+
+        rows.iter().map(row_to_proof_session).collect()
+    }
+
+    /// Get all running proof requests (for polling)
+    pub async fn get_running_proof_requests(&self) -> Result<Vec<ProofRequest>> {
+        let rows = sqlx::query(
+            r#"
+            SELECT id, start_block_number, number_of_blocks_to_prove,
+                   sequence_window, proof_type, stark_receipt, snark_receipt,
+                   status, error_message, prover_address, l1_head,
+                   intermediate_root_interval,
+                   created_at, updated_at, completed_at, retry_count
+            FROM proof_requests
+            WHERE status = $1
+            ORDER BY created_at ASC
+            "#,
+        )
+        .bind(ProofStatus::Running.as_str())
+        .fetch_all(&self.pool)
+        .await?;
+
+        rows.iter().map(row_to_proof_request).collect()
+    }
+
+    /// Get proof requests that are stuck in PENDING without a running session.
+    /// These are likely orphaned due to crashes before session creation.
+    /// Only checks for active (RUNNING) sessions so that retried requests
+    /// with old COMPLETED/FAILED sessions are still detected as stuck.
+    pub async fn get_stuck_requests(&self, stuck_timeout_mins: i32) -> Result<Vec<ProofRequest>> {
+        let rows = sqlx::query(
+            r#"
+            SELECT
+                pr.id, pr.start_block_number, pr.number_of_blocks_to_prove,
+                pr.sequence_window, pr.proof_type, pr.stark_receipt, pr.snark_receipt,
+                pr.status, pr.error_message, pr.prover_address, pr.l1_head,
+                pr.intermediate_root_interval,
+                pr.created_at, pr.updated_at, pr.completed_at, pr.retry_count
+            FROM proof_requests pr
+            WHERE pr.status = 'PENDING'
+              AND pr.updated_at < NOW() - INTERVAL '1 minute' * $1
+              AND NOT EXISTS (
+                  SELECT 1 FROM proof_sessions ps
+                  WHERE ps.proof_request_id = pr.id
+                    AND ps.status IN ('SUBMITTING', 'RUNNING')
+              )
+            ORDER BY pr.created_at ASC
+            "#,
+        )
+        .bind(stuck_timeout_mins)
+        .fetch_all(&self.pool)
+        .await?;
+
+        rows.iter().map(row_to_proof_request).collect()
+    }
+
+    /// Update a proof session status
+    pub async fn update_proof_session(&self, update: UpdateProofSession) -> Result<()> {
+        sqlx::query(
+            r#"
+            UPDATE proof_sessions
+            SET status = $1,
+                error_message = $2,
+                metadata = COALESCE($3, metadata),
+                completed_at = CASE WHEN $1 IN ('COMPLETED', 'FAILED') THEN NOW() ELSE completed_at END
+            WHERE backend_session_id = $4
+            "#,
+        )
+        .bind(update.status.as_str())
+        .bind(&update.error_message)
+        .bind(&update.metadata)
+        .bind(&update.backend_session_id)
+        .execute(&self.pool)
+        .await?;
+
+        Ok(())
+    }
+
+    /// Update a proof session only if it's still in RUNNING state (non-terminal).
+    /// Returns true if the session was updated, false if already terminal.
+    pub async fn update_proof_session_if_non_terminal(
+        &self,
+        update: UpdateProofSession,
+    ) -> Result<bool> {
+        let result = sqlx::query(
+            r#"
+            UPDATE proof_sessions
+            SET status = $1,
+                error_message = $2,
+                metadata = COALESCE($3, metadata),
+                completed_at = CASE WHEN $1 IN ('COMPLETED', 'FAILED') THEN NOW() ELSE completed_at END
+            WHERE backend_session_id = $4
+              AND status = 'RUNNING'
+            "#,
+        )
+        .bind(update.status.as_str())
+        .bind(&update.error_message)
+        .bind(&update.metadata)
+        .bind(&update.backend_session_id)
+        .execute(&self.pool)
+        .await?;
+
+        let updated = result.rows_affected() > 0;
+        Ok(updated)
+    }
+
+    /// Atomically update proof session to FAILED and proof request RUNNING → FAILED.
+    ///
+    /// The request update is guarded on `status = 'RUNNING'` so that a
+    /// concurrent stuck-detector marking PENDING → FAILED cannot be
+    /// overwritten. If the guard fails the entire transaction is rolled back
+    /// so the session is not left in an inconsistent `FAILED` state while the
+    /// request remains unchanged.
+    ///
+    /// Returns `true` if both updates were applied, `false` if the request was
+    /// not in RUNNING state (transaction rolled back, no changes persisted).
+    pub async fn fail_session_and_request(
+        &self,
+        backend_session_id: &str,
+        proof_request_id: Uuid,
+        error_message: Option<String>,
+    ) -> Result<bool> {
+        let mut tx = self.pool.begin().await?;
+
+        let result = sqlx::query(
+            r#"
+            UPDATE proof_requests
+            SET status = $1,
+                error_message = $2,
+                completed_at = NOW()
+            WHERE id = $3
+              AND status = 'RUNNING'
+            "#,
+        )
+        .bind(ProofStatus::Failed.as_str())
+        .bind(&error_message)
+        .bind(proof_request_id)
+        .execute(&mut *tx)
+        .await?;
+
+        if result.rows_affected() == 0 {
+            tx.rollback().await?;
+            return Ok(false);
+        }
+
+        sqlx::query(
+            r#"
+            UPDATE proof_sessions
+            SET status = $1,
+                error_message = $2,
+                completed_at = NOW()
+            WHERE backend_session_id = $3
+            "#,
+        )
+        .bind(SessionStatus::Failed.as_str())
+        .bind(&error_message)
+        .bind(backend_session_id)
+        .execute(&mut *tx)
+        .await?;
+
+        tx.commit().await?;
+
+        Ok(true)
+    }
+
+    /// Atomically update proof session to COMPLETED and update proof request
+    /// with the receipt.
+    ///
+    /// The request update is guarded on `status = 'RUNNING'`. If the guard
+    /// fails the entire transaction is rolled back so the session is not left
+    /// in an inconsistent `COMPLETED` state while the request remains
+    /// unchanged.
+    ///
+    /// Returns `true` if both updates were applied, `false` if the request was
+    /// not in RUNNING state (transaction rolled back, no changes persisted).
+    pub async fn complete_session_and_update_receipt(
+        &self,
+        backend_session_id: &str,
+        update_receipt: UpdateReceipt,
+    ) -> Result<bool> {
+        let mut tx = self.pool.begin().await?;
+
+        let result = sqlx::query(
+            r#"
+            UPDATE proof_requests
+            SET
+                stark_receipt = COALESCE($1, stark_receipt),
+                snark_receipt = COALESCE($2, snark_receipt),
+                status = $3,
+                error_message = $4,
+                completed_at = CASE WHEN $3 IN ('SUCCEEDED', 'FAILED') THEN NOW() ELSE completed_at END
+            WHERE id = $5
+              AND status = 'RUNNING'
+            "#,
+        )
+        .bind(&update_receipt.stark_receipt)
+        .bind(&update_receipt.snark_receipt)
+        .bind(update_receipt.status.as_str())
+        .bind(&update_receipt.error_message)
+        .bind(update_receipt.id)
+        .execute(&mut *tx)
+        .await?;
+
+        if result.rows_affected() == 0 {
+            tx.rollback().await?;
+            return Ok(false);
+        }
+
+        sqlx::query(
+            r#"
+            UPDATE proof_sessions
+            SET status = $1,
+                completed_at = NOW()
+            WHERE backend_session_id = $2
+            "#,
+        )
+        .bind(SessionStatus::Completed.as_str())
+        .bind(backend_session_id)
+        .execute(&mut *tx)
+        .await?;
+
+        tx.commit().await?;
+
+        Ok(true)
+    }
+
+    /// List all proof requests with optional status filter
+    pub async fn list(
+        &self,
+        status_filter: Option<ProofStatus>,
+        limit: i64,
+    ) -> Result<Vec<ProofRequest>> {
+        let rows = if let Some(status) = status_filter {
+            sqlx::query(
+                r#"
+                SELECT
+                    id, start_block_number, number_of_blocks_to_prove,
+                    sequence_window, proof_type,
+                    stark_receipt, snark_receipt,
+                    status, error_message,
+                    prover_address, l1_head, intermediate_root_interval,
+                    created_at, updated_at, completed_at, retry_count
+                FROM proof_requests
+                WHERE status = $1
+                ORDER BY created_at DESC
+                LIMIT $2
+                "#,
+            )
+            .bind(status.as_str())
+            .bind(limit)
+            .fetch_all(&self.pool)
+            .await?
+        } else {
+            sqlx::query(
+                r#"
+                SELECT
+                    id, start_block_number, number_of_blocks_to_prove,
+                    sequence_window, proof_type,
+                    stark_receipt, snark_receipt,
+                    status, error_message,
+                    prover_address, l1_head, intermediate_root_interval,
+                    created_at, updated_at, completed_at, retry_count
+                FROM proof_requests
+                ORDER BY created_at DESC
+                LIMIT $1
+                "#,
+            )
+            .bind(limit)
+            .fetch_all(&self.pool)
+            .await?
+        };
+
+        rows.iter().map(row_to_proof_request).collect()
+    }
+
+    /// List proof requests with offset-based pagination and return total count.
+    pub async fn list_with_offset(
+        &self,
+        status_filter: Option<ProofStatus>,
+        page: ProofRequestPage,
+    ) -> Result<(Vec<ProofRequestListItem>, u64)> {
+        let (rows, count) = if let Some(status) = status_filter {
+            let rows = sqlx::query_as::<_, ProofRequestListItem>(
+                r#"
+                SELECT
+                    id, start_block_number, number_of_blocks_to_prove,
+                    proof_type, status, error_message,
+                    created_at, updated_at, completed_at
+                FROM proof_requests
+                WHERE status = $1
+                ORDER BY created_at DESC
+                LIMIT $2 OFFSET $3
+                "#,
+            )
+            .bind(status.as_str())
+            .bind(page.limit())
+            .bind(page.offset())
+            .fetch_all(&self.pool);
+
+            let count = sqlx::query_as::<_, (i64,)>(
+                "SELECT COUNT(*) FROM proof_requests WHERE status = $1",
+            )
+            .bind(status.as_str())
+            .fetch_one(&self.pool);
+
+            futures::try_join!(rows, count)?
+        } else {
+            let rows = sqlx::query_as::<_, ProofRequestListItem>(
+                r#"
+                SELECT
+                    id, start_block_number, number_of_blocks_to_prove,
+                    proof_type, status, error_message,
+                    created_at, updated_at, completed_at
+                FROM proof_requests
+                ORDER BY created_at DESC
+                LIMIT $1 OFFSET $2
+                "#,
+            )
+            .bind(page.limit())
+            .bind(page.offset())
+            .fetch_all(&self.pool);
+
+            let count = sqlx::query_as::<_, (i64,)>("SELECT COUNT(*) FROM proof_requests")
+                .fetch_one(&self.pool);
+
+            futures::try_join!(rows, count)?
+        };
+
+        Ok((rows, count.0.max(0) as u64))
+    }
+
+    // ========== Outbox Methods ==========
+
+    /// Create an outbox entry for background task processing.
+    /// This should be called in the same transaction as creating the proof request.
+    pub async fn create_outbox_entry(&self, entry: CreateOutboxEntry) -> Result<i64> {
+        let row = sqlx::query(
+            r#"
+            INSERT INTO proof_request_outbox (proof_request_id, request_params)
+            VALUES ($1, $2)
+            RETURNING sequence_id
+            "#,
+        )
+        .bind(entry.proof_request_id)
+        .bind(&entry.request_params)
+        .fetch_one(&self.pool)
+        .await?;
+
+        let sequence_id: i64 = row.get("sequence_id");
+
+        Ok(sequence_id)
+    }
+
+    /// Get the next batch of unprocessed outbox entries.
+    ///
+    /// Returns entries in order by `sequence_id` (FIFO), excluding entries that
+    /// have exceeded `max_retries` attempts.
+    pub async fn get_unprocessed_outbox_entries(
+        &self,
+        limit: i64,
+        max_retries: i32,
+    ) -> Result<Vec<OutboxEntry>> {
+        let rows = sqlx::query(
+            r#"
+            SELECT sequence_id, proof_request_id, request_params,
+                   processed, processed_at, retry_count, last_error, created_at
+            FROM proof_request_outbox
+            WHERE processed = FALSE
+              AND retry_count < $2
+            ORDER BY sequence_id ASC
+            LIMIT $1
+            "#,
+        )
+        .bind(limit)
+        .bind(max_retries)
+        .fetch_all(&self.pool)
+        .await?;
+
+        Ok(rows.iter().map(row_to_outbox_entry).collect())
+    }
+
+    /// Mark an outbox entry as processed
+    pub async fn mark_outbox_processed(&self, mark: MarkOutboxProcessed) -> Result<()> {
+        sqlx::query(
+            r#"
+            UPDATE proof_request_outbox
+            SET processed = TRUE,
+                processed_at = NOW()
+            WHERE sequence_id = $1
+            "#,
+        )
+        .bind(mark.sequence_id)
+        .execute(&self.pool)
+        .await?;
+
+        Ok(())
+    }
+
+    /// Record an error for an outbox entry and increment retry count
+    pub async fn mark_outbox_error(&self, mark: MarkOutboxError) -> Result<()> {
+        sqlx::query(
+            r#"
+            UPDATE proof_request_outbox
+            SET retry_count = retry_count + 1,
+                last_error = $1
+            WHERE sequence_id = $2
+            "#,
+        )
+        .bind(&mark.error_message)
+        .bind(mark.sequence_id)
+        .execute(&self.pool)
+        .await?;
+
+        Ok(())
+    }
+
+    /// Delete old processed outbox entries (for cleanup)
+    pub async fn delete_old_processed_outbox_entries(&self, older_than_days: i32) -> Result<u64> {
+        let result = sqlx::query(
+            r#"
+            DELETE FROM proof_request_outbox
+            WHERE processed = TRUE
+              AND processed_at < NOW() - INTERVAL '1 day' * $1
+            "#,
+        )
+        .bind(older_than_days)
+        .execute(&self.pool)
+        .await?;
+
+        let rows_deleted = result.rows_affected();
+
+        Ok(rows_deleted)
+    }
+}
+
+/// Helper function to convert a database row to `ProofRequest`
+fn row_to_proof_request(row: &sqlx::postgres::PgRow) -> Result<ProofRequest> {
+    let status_str: &str = row.get("status");
+    let status = ProofStatus::try_from(status_str)
+        .map_err(|e| sqlx::Error::Protocol(format!("Unknown proof status '{status_str}': {e}")))?;
+
+    let proof_type_str: &str = row.get("proof_type");
+    let proof_type = ProofType::try_from(proof_type_str).map_err(|e| {
+        sqlx::Error::Protocol(format!("Unknown proof_type '{proof_type_str}': {e}"))
+    })?;
+
+    Ok(ProofRequest {
+        id: row.get("id"),
+        start_block_number: row.get("start_block_number"),
+        number_of_blocks_to_prove: row.get("number_of_blocks_to_prove"),
+        sequence_window: row.get("sequence_window"),
+        proof_type,
+        stark_receipt: row.get("stark_receipt"),
+        snark_receipt: row.get("snark_receipt"),
+        status,
+        error_message: row.get("error_message"),
+        prover_address: row.get("prover_address"),
+        l1_head: row.get("l1_head"),
+        intermediate_root_interval: row.get("intermediate_root_interval"),
+        created_at: row.get("created_at"),
+        updated_at: row.get("updated_at"),
+        completed_at: row.get("completed_at"),
+        retry_count: row.get("retry_count"),
+    })
+}
+
+/// Helper function to convert a database row to `ProofSession`
+fn row_to_proof_session(row: &sqlx::postgres::PgRow) -> Result<ProofSession> {
+    let status_str: &str = row.get("status");
+    let status = SessionStatus::try_from(status_str).map_err(|e| {
+        sqlx::Error::Protocol(format!("Unknown session status '{status_str}': {e}"))
+    })?;
+
+    let session_type_str: &str = row.get("session_type");
+    let session_type = SessionType::try_from(session_type_str).map_err(|e| {
+        sqlx::Error::Protocol(format!("Unknown session type '{session_type_str}': {e}"))
+    })?;
+
+    Ok(ProofSession {
+        id: row.get("id"),
+        proof_request_id: row.get("proof_request_id"),
+        session_type,
+        backend_session_id: row.get("backend_session_id"),
+        status,
+        error_message: row.get("error_message"),
+        metadata: row.get("metadata"),
+        created_at: row.get("created_at"),
+        completed_at: row.get("completed_at"),
+    })
+}
+
+/// Incoming fields compared to a locked `proof_requests` row for idempotency checks.
+#[derive(Debug, Clone)]
+struct CreateOutboxRequestParams<'a> {
+    start_block_number: i64,
+    number_of_blocks_to_prove: i64,
+    sequence_window: Option<i64>,
+    proof_type: &'a str,
+    prover_address: Option<&'a str>,
+    l1_head: Option<&'a str>,
+    intermediate_root_interval: Option<i64>,
+}
+
+impl CreateOutboxRequestParams<'_> {
+    /// First field name that disagrees with `row`, or `None`. Stable for [`CreateProofRequestError::IdCollision`].
+    fn first_mismatch(&self, row: &sqlx::postgres::PgRow) -> Option<&'static str> {
+        if row.get::<i64, _>("start_block_number") != self.start_block_number {
+            return Some("start_block_number");
+        }
+        if row.get::<i64, _>("number_of_blocks_to_prove") != self.number_of_blocks_to_prove {
+            return Some("number_of_blocks_to_prove");
+        }
+        if row.get::<Option<i64>, _>("sequence_window") != self.sequence_window {
+            return Some("sequence_window");
+        }
+        if row.get::<&str, _>("proof_type") != self.proof_type {
+            return Some("proof_type");
+        }
+        if row.get::<Option<&str>, _>("prover_address") != self.prover_address {
+            return Some("prover_address");
+        }
+        if row.get::<Option<&str>, _>("l1_head") != self.l1_head {
+            return Some("l1_head");
+        }
+        if row.get::<Option<i64>, _>("intermediate_root_interval")
+            != self.intermediate_root_interval
+        {
+            return Some("intermediate_root_interval");
+        }
+        None
+    }
+}
+
+/// Build the canonical JSON payload for outbox entries.
+///
+/// Both [`ProofRequestRepo::create_with_outbox`] and
+/// [`ProofRequestRepo::retry_or_fail_stuck_request`] must produce the same
+/// shape so the downstream worker can parse either identically.
+fn build_outbox_params(
+    start_block_number: i64,
+    number_of_blocks_to_prove: i64,
+    sequence_window: Option<i64>,
+    proof_type: &str,
+    prover_address: Option<&str>,
+    l1_head: Option<&str>,
+    intermediate_root_interval: Option<i64>,
+) -> serde_json::Value {
+    serde_json::json!({
+        "start_block_number": start_block_number,
+        "number_of_blocks_to_prove": number_of_blocks_to_prove,
+        "sequence_window": sequence_window,
+        "proof_type": proof_type,
+        "prover_address": prover_address,
+        "l1_head": l1_head,
+        "intermediate_root_interval": intermediate_root_interval,
+    })
+}
+
+/// Helper function to convert a database row to `OutboxEntry`
+fn row_to_outbox_entry(row: &sqlx::postgres::PgRow) -> OutboxEntry {
+    OutboxEntry {
+        sequence_id: row.get("sequence_id"),
+        proof_request_id: row.get("proof_request_id"),
+        request_params: row.get("request_params"),
+        processed: row.get("processed"),
+        processed_at: row.get("processed_at"),
+        retry_count: row.get("retry_count"),
+        last_error: row.get("last_error"),
+        created_at: row.get("created_at"),
+    }
+}

--- a/crates/proof/prover-service/db/tests/postgres_integration.rs
+++ b/crates/proof/prover-service/db/tests/postgres_integration.rs
@@ -1,0 +1,1201 @@
+//! Integration tests for [`ProofRequestRepo`] against a real `PostgreSQL` database.
+//!
+//! These tests require a running Postgres instance with the prover schema applied.
+//!
+//! Run with:
+//!   ```sh
+//!   DATABASE_URL=postgres://prover:prover@localhost:5433/prover \
+//!     cargo nextest run --run-ignored all -p base-prover-service-db --test postgres_integration --test-threads=1
+//!   ```
+//!
+//! Tests are marked `#[ignore]` so they're skipped by default (no Postgres in CI)
+//! and must be opted into explicitly via `--run-ignored all`.
+//! They run sequentially (`--test-threads=1`) because they share the same database;
+//! each test creates unique UUIDs so they don't collide.
+
+use std::time::Duration;
+
+use base_prover_service_db::{
+    CreateProofRequest, CreateProofRequestError, CreateProofRequestOutcome, CreateProofSession,
+    MarkOutboxError, MarkOutboxProcessed, ProofRequestRepo, ProofStatus, ProofType, RetryOutcome,
+    SessionStatus, SessionType, UpdateProofSession, UpdateReceipt,
+};
+use sqlx::{PgPool, postgres::PgPoolOptions};
+use uuid::Uuid;
+
+/// `create_with_outbox` retry cap; must match prover `MAX_PROOF_RETRIES` default (`3`).
+const TEST_MAX_PROOF_RETRIES: i32 = 3;
+
+/// Outbox reader attempt cap (not proof `retry_count`).
+const TEST_OUTBOX_MAX_ATTEMPTS: i32 = 3;
+
+/// Connect to the test database using `DATABASE_URL` env var.
+async fn test_pool() -> PgPool {
+    let url = std::env::var("DATABASE_URL")
+        .unwrap_or_else(|_| "postgres://prover:prover@localhost:5433/prover".to_string());
+
+    PgPoolOptions::new()
+        .max_connections(5)
+        .acquire_timeout(Duration::from_secs(5))
+        .connect(&url)
+        .await
+        .expect("Failed to connect to test database — is Postgres running?")
+}
+
+const fn test_repo(pool: PgPool) -> ProofRequestRepo {
+    ProofRequestRepo::new(pool)
+}
+
+const fn compressed_request() -> CreateProofRequest {
+    CreateProofRequest {
+        start_block_number: 100,
+        number_of_blocks_to_prove: 5,
+        sequence_window: Some(50),
+        proof_type: ProofType::OpSuccinctSp1ClusterCompressed,
+        session_id: None,
+        prover_address: None,
+        l1_head: None,
+        intermediate_root_interval: None,
+    }
+}
+
+fn snark_request() -> CreateProofRequest {
+    CreateProofRequest {
+        start_block_number: 200,
+        number_of_blocks_to_prove: 10,
+        sequence_window: Some(100),
+        proof_type: ProofType::OpSuccinctSp1ClusterSnarkGroth16,
+        session_id: None,
+        prover_address: Some("0x1234567890abcdef1234567890abcdef12345678".to_string()),
+        l1_head: Some(
+            "0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890".to_string(),
+        ),
+        intermediate_root_interval: None,
+    }
+}
+
+/// Create a request in RUNNING state with an associated proof session.
+/// Returns `(request_id, backend_session_id)`.
+async fn setup_running_request(repo: &ProofRequestRepo) -> (Uuid, String) {
+    let id = repo.create(compressed_request()).await.unwrap();
+    repo.atomic_claim_task(id).await.unwrap();
+    let backend_id = format!("session-{}", Uuid::new_v4());
+    repo.transition_pending_to_running(CreateProofSession {
+        proof_request_id: id,
+        session_type: SessionType::Stark,
+        backend_session_id: backend_id.clone(),
+        metadata: None,
+    })
+    .await
+    .unwrap()
+    .expect("transition should succeed");
+    (id, backend_id)
+}
+
+// ============================================================
+// Basic CRUD tests
+// ============================================================
+
+#[tokio::test]
+#[ignore = "requires a running Postgres with the prover schema (set DATABASE_URL); run with `cargo nextest run --run-ignored all -p base-prover-service-db --test postgres_integration --test-threads=1`"]
+async fn test_create_and_get_compressed() {
+    let pool = test_pool().await;
+    let repo = test_repo(pool);
+
+    let id = repo.create(compressed_request()).await.unwrap();
+    let req = repo.get(id).await.unwrap().expect("should find request");
+
+    assert_eq!(req.id, id);
+    assert_eq!(req.start_block_number, 100);
+    assert_eq!(req.number_of_blocks_to_prove, 5);
+    assert_eq!(req.sequence_window, Some(50));
+    assert_eq!(req.proof_type, ProofType::OpSuccinctSp1ClusterCompressed);
+    assert_eq!(req.status, ProofStatus::Created);
+    assert!(req.stark_receipt.is_none());
+    assert!(req.snark_receipt.is_none());
+    assert!(req.error_message.is_none());
+    assert!(req.prover_address.is_none());
+    assert!(req.l1_head.is_none());
+    assert!(req.completed_at.is_none());
+    assert_eq!(req.retry_count, 0);
+}
+
+#[tokio::test]
+#[ignore = "requires a running Postgres with the prover schema (set DATABASE_URL); run with `cargo nextest run --run-ignored all -p base-prover-service-db --test postgres_integration --test-threads=1`"]
+async fn test_create_and_get_snark() {
+    let pool = test_pool().await;
+    let repo = test_repo(pool);
+
+    let id = repo.create(snark_request()).await.unwrap();
+    let req = repo.get(id).await.unwrap().expect("should find request");
+
+    assert_eq!(req.start_block_number, 200);
+    assert_eq!(req.number_of_blocks_to_prove, 10);
+    assert_eq!(req.proof_type, ProofType::OpSuccinctSp1ClusterSnarkGroth16);
+    assert_eq!(req.prover_address.as_deref(), Some("0x1234567890abcdef1234567890abcdef12345678"));
+    assert_eq!(
+        req.l1_head.as_deref(),
+        Some("0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890")
+    );
+}
+
+#[tokio::test]
+#[ignore = "requires a running Postgres with the prover schema (set DATABASE_URL); run with `cargo nextest run --run-ignored all -p base-prover-service-db --test postgres_integration --test-threads=1`"]
+async fn test_create_with_session_id() {
+    let pool = test_pool().await;
+    let repo = test_repo(pool);
+
+    let explicit_id = Uuid::new_v4();
+    let mut req = compressed_request();
+    req.session_id = Some(explicit_id);
+
+    let id = repo.create(req).await.unwrap();
+    assert_eq!(id, explicit_id);
+
+    let fetched = repo.get(id).await.unwrap().expect("should find request");
+    assert_eq!(fetched.id, explicit_id);
+}
+
+#[tokio::test]
+#[ignore = "requires a running Postgres with the prover schema (set DATABASE_URL); run with `cargo nextest run --run-ignored all -p base-prover-service-db --test postgres_integration --test-threads=1`"]
+async fn test_get_nonexistent_returns_none() {
+    let pool = test_pool().await;
+    let repo = test_repo(pool);
+
+    let result = repo.get(Uuid::new_v4()).await.unwrap();
+    assert!(result.is_none());
+}
+
+// ============================================================
+// Guarded state transition tests
+// ============================================================
+
+#[tokio::test]
+#[ignore = "requires a running Postgres with the prover schema (set DATABASE_URL); run with `cargo nextest run --run-ignored all -p base-prover-service-db --test postgres_integration --test-threads=1`"]
+async fn test_transition_pending_to_running() {
+    let pool = test_pool().await;
+    let repo = test_repo(pool);
+
+    let id = repo.create(compressed_request()).await.unwrap();
+    repo.atomic_claim_task(id).await.unwrap();
+
+    let backend_id = format!("ptr-{}", Uuid::new_v4());
+    let session_id = repo
+        .transition_pending_to_running(CreateProofSession {
+            proof_request_id: id,
+            session_type: SessionType::Stark,
+            backend_session_id: backend_id.clone(),
+            metadata: None,
+        })
+        .await
+        .unwrap();
+    assert!(session_id.is_some());
+
+    let req = repo.get(id).await.unwrap().unwrap();
+    assert_eq!(req.status, ProofStatus::Running);
+
+    let session =
+        repo.get_session_by_backend_id(&backend_id).await.unwrap().expect("should find session");
+    assert_eq!(session.status, SessionStatus::Running);
+}
+
+#[tokio::test]
+#[ignore = "requires a running Postgres with the prover schema (set DATABASE_URL); run with `cargo nextest run --run-ignored all -p base-prover-service-db --test postgres_integration --test-threads=1`"]
+async fn test_transition_pending_to_running_race() {
+    let pool = test_pool().await;
+    let repo = test_repo(pool);
+
+    let id = repo.create(compressed_request()).await.unwrap();
+    repo.atomic_claim_task(id).await.unwrap();
+
+    let first = repo
+        .transition_pending_to_running(CreateProofSession {
+            proof_request_id: id,
+            session_type: SessionType::Stark,
+            backend_session_id: format!("first-{}", Uuid::new_v4()),
+            metadata: None,
+        })
+        .await
+        .unwrap();
+    assert!(first.is_some());
+
+    let second = repo
+        .transition_pending_to_running(CreateProofSession {
+            proof_request_id: id,
+            session_type: SessionType::Stark,
+            backend_session_id: format!("second-{}", Uuid::new_v4()),
+            metadata: None,
+        })
+        .await
+        .unwrap();
+    assert!(second.is_none(), "second transition should lose the race");
+}
+
+#[tokio::test]
+#[ignore = "requires a running Postgres with the prover schema (set DATABASE_URL); run with `cargo nextest run --run-ignored all -p base-prover-service-db --test postgres_integration --test-threads=1`"]
+async fn test_transition_pending_to_failed() {
+    let pool = test_pool().await;
+    let repo = test_repo(pool);
+
+    let id = repo.create(compressed_request()).await.unwrap();
+    repo.atomic_claim_task(id).await.unwrap();
+
+    let updated = repo.transition_pending_to_failed(id, "submission timeout".into()).await.unwrap();
+    assert!(updated);
+
+    let req = repo.get(id).await.unwrap().unwrap();
+    assert_eq!(req.status, ProofStatus::Failed);
+    assert_eq!(req.error_message.as_deref(), Some("submission timeout"));
+    assert!(req.completed_at.is_some());
+}
+
+#[tokio::test]
+#[ignore = "requires a running Postgres with the prover schema (set DATABASE_URL); run with `cargo nextest run --run-ignored all -p base-prover-service-db --test postgres_integration --test-threads=1`"]
+async fn test_transition_pending_to_failed_wrong_state() {
+    let pool = test_pool().await;
+    let repo = test_repo(pool);
+
+    let id = repo.create(compressed_request()).await.unwrap();
+    // Still CREATED, not PENDING
+    let updated = repo.transition_pending_to_failed(id, "should not work".into()).await.unwrap();
+    assert!(!updated);
+
+    let req = repo.get(id).await.unwrap().unwrap();
+    assert_eq!(req.status, ProofStatus::Created);
+}
+
+#[tokio::test]
+#[ignore = "requires a running Postgres with the prover schema (set DATABASE_URL); run with `cargo nextest run --run-ignored all -p base-prover-service-db --test postgres_integration --test-threads=1`"]
+async fn test_transition_running_to_failed() {
+    let pool = test_pool().await;
+    let repo = test_repo(pool);
+
+    let (id, _backend_id) = setup_running_request(&repo).await;
+
+    let updated =
+        repo.transition_running_to_failed(id, Some("cluster timeout".into())).await.unwrap();
+    assert!(updated);
+
+    let req = repo.get(id).await.unwrap().unwrap();
+    assert_eq!(req.status, ProofStatus::Failed);
+    assert_eq!(req.error_message.as_deref(), Some("cluster timeout"));
+    assert!(req.completed_at.is_some());
+}
+
+#[tokio::test]
+#[ignore = "requires a running Postgres with the prover schema (set DATABASE_URL); run with `cargo nextest run --run-ignored all -p base-prover-service-db --test postgres_integration --test-threads=1`"]
+async fn test_transition_running_to_failed_wrong_state() {
+    let pool = test_pool().await;
+    let repo = test_repo(pool);
+
+    let id = repo.create(compressed_request()).await.unwrap();
+    repo.atomic_claim_task(id).await.unwrap();
+    // PENDING, not RUNNING
+    let updated =
+        repo.transition_running_to_failed(id, Some("should not work".into())).await.unwrap();
+    assert!(!updated);
+
+    let req = repo.get(id).await.unwrap().unwrap();
+    assert_eq!(req.status, ProofStatus::Pending);
+}
+
+// ============================================================
+// Receipt update tests
+// ============================================================
+
+#[tokio::test]
+#[ignore = "requires a running Postgres with the prover schema (set DATABASE_URL); run with `cargo nextest run --run-ignored all -p base-prover-service-db --test postgres_integration --test-threads=1`"]
+async fn test_update_receipt_if_running() {
+    let pool = test_pool().await;
+    let repo = test_repo(pool);
+
+    let (id, _backend_id) = setup_running_request(&repo).await;
+
+    let updated = repo
+        .update_receipt_if_running(UpdateReceipt {
+            id,
+            stark_receipt: Some(vec![1, 2, 3]),
+            snark_receipt: None,
+            status: ProofStatus::Succeeded,
+            error_message: None,
+        })
+        .await
+        .unwrap();
+    assert!(updated);
+
+    // Now that it's SUCCEEDED, a second update should be skipped
+    let updated = repo
+        .update_receipt_if_running(UpdateReceipt {
+            id,
+            stark_receipt: Some(vec![4, 5, 6]),
+            snark_receipt: None,
+            status: ProofStatus::Succeeded,
+            error_message: None,
+        })
+        .await
+        .unwrap();
+    assert!(!updated);
+
+    let req = repo.get(id).await.unwrap().unwrap();
+    assert_eq!(req.stark_receipt.as_deref(), Some(&[1u8, 2, 3][..])); // first write won
+}
+
+// ============================================================
+// Atomic claim tests
+// ============================================================
+
+#[tokio::test]
+#[ignore = "requires a running Postgres with the prover schema (set DATABASE_URL); run with `cargo nextest run --run-ignored all -p base-prover-service-db --test postgres_integration --test-threads=1`"]
+async fn test_atomic_claim_task() {
+    let pool = test_pool().await;
+    let repo = test_repo(pool);
+
+    let id = repo.create(compressed_request()).await.unwrap();
+
+    // First claim should succeed (CREATED -> PENDING)
+    let claimed = repo.atomic_claim_task(id).await.unwrap();
+    assert!(claimed);
+
+    let req = repo.get(id).await.unwrap().unwrap();
+    assert_eq!(req.status, ProofStatus::Pending);
+
+    // Second claim should fail (already PENDING)
+    let claimed = repo.atomic_claim_task(id).await.unwrap();
+    assert!(!claimed);
+}
+
+#[tokio::test]
+#[ignore = "requires a running Postgres with the prover schema (set DATABASE_URL); run with `cargo nextest run --run-ignored all -p base-prover-service-db --test postgres_integration --test-threads=1`"]
+async fn test_atomic_claim_nonexistent() {
+    let pool = test_pool().await;
+    let repo = test_repo(pool);
+
+    let claimed = repo.atomic_claim_task(Uuid::new_v4()).await.unwrap();
+    assert!(!claimed);
+}
+
+// ============================================================
+// Proof session tests
+// ============================================================
+
+#[tokio::test]
+#[ignore = "requires a running Postgres with the prover schema (set DATABASE_URL); run with `cargo nextest run --run-ignored all -p base-prover-service-db --test postgres_integration --test-threads=1`"]
+async fn test_create_proof_session() {
+    let pool = test_pool().await;
+    let repo = test_repo(pool);
+
+    let req_id = repo.create(compressed_request()).await.unwrap();
+    let session_id = repo
+        .create_proof_session(CreateProofSession {
+            proof_request_id: req_id,
+            session_type: SessionType::Stark,
+            backend_session_id: format!("test-session-{}", Uuid::new_v4()),
+            metadata: Some(serde_json::json!({"key": "value"})),
+        })
+        .await
+        .unwrap();
+
+    assert!(session_id > 0);
+}
+
+#[tokio::test]
+#[ignore = "requires a running Postgres with the prover schema (set DATABASE_URL); run with `cargo nextest run --run-ignored all -p base-prover-service-db --test postgres_integration --test-threads=1`"]
+async fn test_get_session_by_backend_id() {
+    let pool = test_pool().await;
+    let repo = test_repo(pool);
+
+    let req_id = repo.create(compressed_request()).await.unwrap();
+    let backend_id = format!("backend-{}", Uuid::new_v4());
+
+    repo.create_proof_session(CreateProofSession {
+        proof_request_id: req_id,
+        session_type: SessionType::Stark,
+        backend_session_id: backend_id.clone(),
+        metadata: None,
+    })
+    .await
+    .unwrap();
+
+    let session =
+        repo.get_session_by_backend_id(&backend_id).await.unwrap().expect("should find session");
+    assert_eq!(session.proof_request_id, req_id);
+    assert_eq!(session.session_type, SessionType::Stark);
+    assert_eq!(session.status, SessionStatus::Running);
+    assert_eq!(session.backend_session_id, backend_id);
+}
+
+#[tokio::test]
+#[ignore = "requires a running Postgres with the prover schema (set DATABASE_URL); run with `cargo nextest run --run-ignored all -p base-prover-service-db --test postgres_integration --test-threads=1`"]
+async fn test_get_sessions_for_request() {
+    let pool = test_pool().await;
+    let repo = test_repo(pool);
+
+    let req_id = repo.create(snark_request()).await.unwrap();
+
+    // Create STARK session
+    repo.create_proof_session(CreateProofSession {
+        proof_request_id: req_id,
+        session_type: SessionType::Stark,
+        backend_session_id: format!("stark-{}", Uuid::new_v4()),
+        metadata: None,
+    })
+    .await
+    .unwrap();
+
+    // Create SNARK session
+    repo.create_proof_session(CreateProofSession {
+        proof_request_id: req_id,
+        session_type: SessionType::Snark,
+        backend_session_id: format!("snark-{}", Uuid::new_v4()),
+        metadata: None,
+    })
+    .await
+    .unwrap();
+
+    let sessions = repo.get_sessions_for_request(req_id).await.unwrap();
+    assert_eq!(sessions.len(), 2);
+    assert_eq!(sessions[0].session_type, SessionType::Stark);
+    assert_eq!(sessions[1].session_type, SessionType::Snark);
+}
+
+#[tokio::test]
+#[ignore = "requires a running Postgres with the prover schema (set DATABASE_URL); run with `cargo nextest run --run-ignored all -p base-prover-service-db --test postgres_integration --test-threads=1`"]
+async fn test_update_proof_session() {
+    let pool = test_pool().await;
+    let repo = test_repo(pool);
+
+    let req_id = repo.create(compressed_request()).await.unwrap();
+    let backend_id = format!("session-update-{}", Uuid::new_v4());
+
+    repo.create_proof_session(CreateProofSession {
+        proof_request_id: req_id,
+        session_type: SessionType::Stark,
+        backend_session_id: backend_id.clone(),
+        metadata: None,
+    })
+    .await
+    .unwrap();
+
+    repo.update_proof_session(UpdateProofSession {
+        backend_session_id: backend_id.clone(),
+        status: SessionStatus::Completed,
+        error_message: None,
+        metadata: Some(serde_json::json!({"output_id": "abc123"})),
+    })
+    .await
+    .unwrap();
+
+    let session = repo.get_session_by_backend_id(&backend_id).await.unwrap().unwrap();
+    assert_eq!(session.status, SessionStatus::Completed);
+    assert!(session.completed_at.is_some());
+    assert_eq!(session.metadata.unwrap()["output_id"].as_str(), Some("abc123"));
+}
+
+#[tokio::test]
+#[ignore = "requires a running Postgres with the prover schema (set DATABASE_URL); run with `cargo nextest run --run-ignored all -p base-prover-service-db --test postgres_integration --test-threads=1`"]
+async fn test_update_proof_session_if_non_terminal() {
+    let pool = test_pool().await;
+    let repo = test_repo(pool);
+
+    let req_id = repo.create(compressed_request()).await.unwrap();
+    let backend_id = format!("session-nonterminal-{}", Uuid::new_v4());
+
+    repo.create_proof_session(CreateProofSession {
+        proof_request_id: req_id,
+        session_type: SessionType::Stark,
+        backend_session_id: backend_id.clone(),
+        metadata: None,
+    })
+    .await
+    .unwrap();
+
+    // First update: RUNNING -> COMPLETED (should succeed)
+    let updated = repo
+        .update_proof_session_if_non_terminal(UpdateProofSession {
+            backend_session_id: backend_id.clone(),
+            status: SessionStatus::Completed,
+            error_message: None,
+            metadata: None,
+        })
+        .await
+        .unwrap();
+    assert!(updated);
+
+    // Second update: COMPLETED -> FAILED (should be skipped since COMPLETED is terminal)
+    let updated = repo
+        .update_proof_session_if_non_terminal(UpdateProofSession {
+            backend_session_id: backend_id.clone(),
+            status: SessionStatus::Failed,
+            error_message: Some("late failure".into()),
+            metadata: None,
+        })
+        .await
+        .unwrap();
+    assert!(!updated);
+
+    let session = repo.get_session_by_backend_id(&backend_id).await.unwrap().unwrap();
+    assert_eq!(session.status, SessionStatus::Completed); // unchanged
+}
+
+// ============================================================
+// Atomic transaction tests
+// ============================================================
+
+#[tokio::test]
+#[ignore = "requires a running Postgres with the prover schema (set DATABASE_URL); run with `cargo nextest run --run-ignored all -p base-prover-service-db --test postgres_integration --test-threads=1`"]
+async fn test_fail_session_and_request() {
+    let pool = test_pool().await;
+    let repo = test_repo(pool);
+
+    let (req_id, backend_id) = setup_running_request(&repo).await;
+
+    let updated = repo
+        .fail_session_and_request(&backend_id, req_id, Some("cluster timeout".into()))
+        .await
+        .unwrap();
+    assert!(updated);
+
+    let req = repo.get(req_id).await.unwrap().unwrap();
+    assert_eq!(req.status, ProofStatus::Failed);
+    assert_eq!(req.error_message.as_deref(), Some("cluster timeout"));
+    assert!(req.completed_at.is_some());
+
+    let session = repo.get_session_by_backend_id(&backend_id).await.unwrap().unwrap();
+    assert_eq!(session.status, SessionStatus::Failed);
+    assert!(session.completed_at.is_some());
+}
+
+#[tokio::test]
+#[ignore = "requires a running Postgres with the prover schema (set DATABASE_URL); run with `cargo nextest run --run-ignored all -p base-prover-service-db --test postgres_integration --test-threads=1`"]
+async fn test_fail_session_and_request_skips_terminal() {
+    let pool = test_pool().await;
+    let repo = test_repo(pool);
+
+    let (req_id, backend_id) = setup_running_request(&repo).await;
+
+    repo.complete_session_and_update_receipt(
+        &backend_id,
+        UpdateReceipt {
+            id: req_id,
+            stark_receipt: Some(vec![0xDE, 0xAD]),
+            snark_receipt: None,
+            status: ProofStatus::Succeeded,
+            error_message: None,
+        },
+    )
+    .await
+    .unwrap();
+
+    // Now try to fail — request should NOT be updated (already SUCCEEDED, not RUNNING)
+    let updated = repo
+        .fail_session_and_request(&backend_id, req_id, Some("late error".into()))
+        .await
+        .unwrap();
+    assert!(!updated);
+
+    let req = repo.get(req_id).await.unwrap().unwrap();
+    assert_eq!(req.status, ProofStatus::Succeeded);
+
+    let session = repo.get_session_by_backend_id(&backend_id).await.unwrap().unwrap();
+    assert_eq!(session.status, SessionStatus::Completed);
+}
+
+#[tokio::test]
+#[ignore = "requires a running Postgres with the prover schema (set DATABASE_URL); run with `cargo nextest run --run-ignored all -p base-prover-service-db --test postgres_integration --test-threads=1`"]
+async fn test_complete_session_and_update_receipt() {
+    let pool = test_pool().await;
+    let repo = test_repo(pool);
+
+    let (req_id, backend_id) = setup_running_request(&repo).await;
+
+    let stark_data = vec![0xCA, 0xFE, 0xBA, 0xBE];
+    let updated = repo
+        .complete_session_and_update_receipt(
+            &backend_id,
+            UpdateReceipt {
+                id: req_id,
+                stark_receipt: Some(stark_data.clone()),
+                snark_receipt: None,
+                status: ProofStatus::Succeeded,
+                error_message: None,
+            },
+        )
+        .await
+        .unwrap();
+    assert!(updated);
+
+    let req = repo.get(req_id).await.unwrap().unwrap();
+    assert_eq!(req.status, ProofStatus::Succeeded);
+    assert_eq!(req.stark_receipt.as_deref(), Some(stark_data.as_slice()));
+    assert!(req.completed_at.is_some());
+
+    let session = repo.get_session_by_backend_id(&backend_id).await.unwrap().unwrap();
+    assert_eq!(session.status, SessionStatus::Completed);
+    assert!(session.completed_at.is_some());
+}
+
+#[tokio::test]
+#[ignore = "requires a running Postgres with the prover schema (set DATABASE_URL); run with `cargo nextest run --run-ignored all -p base-prover-service-db --test postgres_integration --test-threads=1`"]
+async fn test_complete_session_and_update_receipt_skips_non_running() {
+    let pool = test_pool().await;
+    let repo = test_repo(pool);
+
+    let id = repo.create(compressed_request()).await.unwrap();
+    repo.atomic_claim_task(id).await.unwrap();
+    // Request is PENDING, not RUNNING
+    let backend_id = format!("complete-pending-{}", Uuid::new_v4());
+    repo.create_proof_session(CreateProofSession {
+        proof_request_id: id,
+        session_type: SessionType::Stark,
+        backend_session_id: backend_id.clone(),
+        metadata: None,
+    })
+    .await
+    .unwrap();
+
+    let updated = repo
+        .complete_session_and_update_receipt(
+            &backend_id,
+            UpdateReceipt {
+                id,
+                stark_receipt: Some(vec![1, 2, 3]),
+                snark_receipt: None,
+                status: ProofStatus::Succeeded,
+                error_message: None,
+            },
+        )
+        .await
+        .unwrap();
+    assert!(!updated, "should not update a PENDING request");
+
+    let req = repo.get(id).await.unwrap().unwrap();
+    assert_eq!(req.status, ProofStatus::Pending); // unchanged
+}
+
+// ============================================================
+// Retry logic tests
+// ============================================================
+
+#[tokio::test]
+#[ignore = "requires a running Postgres with the prover schema (set DATABASE_URL); run with `cargo nextest run --run-ignored all -p base-prover-service-db --test postgres_integration --test-threads=1`"]
+async fn test_retry_or_fail_stuck_request_retries() {
+    let pool = test_pool().await;
+    let repo = test_repo(pool);
+
+    let id = repo.create(compressed_request()).await.unwrap();
+    repo.atomic_claim_task(id).await.unwrap();
+
+    let outcome = repo.retry_or_fail_stuck_request(id, 3, "stuck in PENDING").await.unwrap();
+    assert_eq!(outcome, RetryOutcome::Retried);
+
+    let req = repo.get(id).await.unwrap().unwrap();
+    assert_eq!(req.status, ProofStatus::Created);
+    assert_eq!(req.retry_count, 1);
+    assert!(req.error_message.is_none());
+}
+
+#[tokio::test]
+#[ignore = "requires a running Postgres with the prover schema (set DATABASE_URL); run with `cargo nextest run --run-ignored all -p base-prover-service-db --test postgres_integration --test-threads=1`"]
+async fn test_retry_or_fail_stuck_request_exhausted() {
+    let pool = test_pool().await;
+    let repo = test_repo(pool);
+
+    let id = repo.create(compressed_request()).await.unwrap();
+
+    // Retry 3 times: each cycle is claim → retry (resets to CREATED) → claim again
+    for i in 0..3 {
+        repo.atomic_claim_task(id).await.unwrap();
+        let outcome = repo.retry_or_fail_stuck_request(id, 3, "stuck").await.unwrap();
+        assert_eq!(outcome, RetryOutcome::Retried, "retry {i} should succeed");
+    }
+
+    // retry_count is now 3, claim once more
+    repo.atomic_claim_task(id).await.unwrap();
+
+    // This time should permanently fail (retry_count >= max_retries)
+    let outcome = repo.retry_or_fail_stuck_request(id, 3, "stuck").await.unwrap();
+    assert_eq!(outcome, RetryOutcome::PermanentlyFailed);
+
+    let req = repo.get(id).await.unwrap().unwrap();
+    assert_eq!(req.status, ProofStatus::Failed);
+    assert!(req.error_message.as_deref().unwrap().contains("max retries exceeded"));
+    assert!(req.completed_at.is_some());
+}
+
+#[tokio::test]
+#[ignore = "requires a running Postgres with the prover schema (set DATABASE_URL); run with `cargo nextest run --run-ignored all -p base-prover-service-db --test postgres_integration --test-threads=1`"]
+async fn test_retry_or_fail_stuck_request_wrong_state() {
+    let pool = test_pool().await;
+    let repo = test_repo(pool);
+
+    let (id, _backend_id) = setup_running_request(&repo).await;
+
+    // Request is RUNNING, not PENDING — should be skipped
+    let outcome = repo.retry_or_fail_stuck_request(id, 3, "stuck").await.unwrap();
+    assert_eq!(outcome, RetryOutcome::Skipped);
+
+    let req = repo.get(id).await.unwrap().unwrap();
+    assert_eq!(req.status, ProofStatus::Running); // unchanged
+}
+
+// ============================================================
+// Outbox tests
+// ============================================================
+
+#[tokio::test]
+#[ignore = "requires a running Postgres with the prover schema (set DATABASE_URL); run with `cargo nextest run --run-ignored all -p base-prover-service-db --test postgres_integration --test-threads=1`"]
+async fn test_create_with_outbox() {
+    let pool = test_pool().await;
+    let repo = test_repo(pool);
+
+    let outcome =
+        repo.create_with_outbox(compressed_request(), TEST_MAX_PROOF_RETRIES).await.unwrap();
+    let id = match outcome {
+        CreateProofRequestOutcome::Created(id) => id,
+        other => panic!("expected Created outcome, got {other:?}"),
+    };
+
+    // Verify proof request exists
+    let req = repo.get(id).await.unwrap().expect("should find request");
+    assert_eq!(req.status, ProofStatus::Created);
+
+    // Verify outbox entry was created
+    let entries = repo.get_unprocessed_outbox_entries(100, 3).await.unwrap();
+    let found = entries.iter().any(|e| e.proof_request_id == id);
+    assert!(found, "outbox entry should exist for this request");
+}
+
+#[tokio::test]
+#[ignore = "requires a running Postgres with the prover schema (set DATABASE_URL); run with `cargo nextest run --run-ignored all -p base-prover-service-db --test postgres_integration --test-threads=1`"]
+async fn test_create_with_outbox_idempotent() {
+    let pool = test_pool().await;
+    let repo = test_repo(pool);
+
+    let explicit_id = Uuid::new_v4();
+    let mut req = compressed_request();
+    req.session_id = Some(explicit_id);
+
+    let first = repo.create_with_outbox(req.clone(), TEST_MAX_PROOF_RETRIES).await.unwrap();
+    let second = repo.create_with_outbox(req, TEST_MAX_PROOF_RETRIES).await.unwrap();
+
+    assert!(matches!(first, CreateProofRequestOutcome::Created(id) if id == explicit_id));
+    assert!(matches!(second, CreateProofRequestOutcome::Replayed(id) if id == explicit_id));
+
+    // The second call must NOT enqueue a fresh outbox entry while the row is
+    // still in a non-terminal state.
+    let entries = repo.get_unprocessed_outbox_entries(100, 3).await.unwrap();
+    let outbox_count = entries.iter().filter(|e| e.proof_request_id == explicit_id).count();
+    assert_eq!(outbox_count, 1, "in-flight replay must not create another outbox row");
+}
+
+#[tokio::test]
+#[ignore = "requires a running Postgres with the prover schema (set DATABASE_URL); run with `cargo nextest run --run-ignored all -p base-prover-service-db --test postgres_integration --test-threads=1`"]
+async fn test_outbox_process_and_cleanup() {
+    let pool = test_pool().await;
+    let repo = test_repo(pool);
+
+    let id =
+        repo.create_with_outbox(compressed_request(), TEST_MAX_PROOF_RETRIES).await.unwrap().id();
+
+    // Get unprocessed entries
+    let entries = repo.get_unprocessed_outbox_entries(10, 3).await.unwrap();
+    let entry = entries.iter().find(|e| e.proof_request_id == id).expect("should find our entry");
+    assert!(!entry.processed);
+    let seq = entry.sequence_id;
+
+    // Mark processed
+    repo.mark_outbox_processed(MarkOutboxProcessed { sequence_id: seq }).await.unwrap();
+
+    // Should no longer appear in unprocessed
+    let entries = repo.get_unprocessed_outbox_entries(100, 3).await.unwrap();
+    let found = entries.iter().any(|e| e.proof_request_id == id);
+    assert!(!found, "processed entry should not appear in unprocessed");
+}
+
+#[tokio::test]
+#[ignore = "requires a running Postgres with the prover schema (set DATABASE_URL); run with `cargo nextest run --run-ignored all -p base-prover-service-db --test postgres_integration --test-threads=1`"]
+async fn test_outbox_error_tracking() {
+    let pool = test_pool().await;
+    let repo = test_repo(pool);
+
+    let id =
+        repo.create_with_outbox(compressed_request(), TEST_MAX_PROOF_RETRIES).await.unwrap().id();
+
+    let entries = repo.get_unprocessed_outbox_entries(100, 3).await.unwrap();
+    let entry = entries.iter().find(|e| e.proof_request_id == id).expect("should find our entry");
+    let seq = entry.sequence_id;
+    assert_eq!(entry.retry_count, 0);
+
+    // Record errors
+    repo.mark_outbox_error(MarkOutboxError {
+        sequence_id: seq,
+        error_message: "first error".into(),
+    })
+    .await
+    .unwrap();
+
+    repo.mark_outbox_error(MarkOutboxError {
+        sequence_id: seq,
+        error_message: "second error".into(),
+    })
+    .await
+    .unwrap();
+
+    // Verify retry count incremented
+    let entries = repo.get_unprocessed_outbox_entries(100, 3).await.unwrap();
+    let entry = entries.iter().find(|e| e.sequence_id == seq).expect("should still find entry");
+    assert_eq!(entry.retry_count, 2);
+    assert_eq!(entry.last_error.as_deref(), Some("second error"));
+}
+
+// create_with_outbox FAILED retry (CHAIN-4297 / Immunefi #75829)
+
+/// `CREATED` → `PENDING` → `FAILED` (same transitions as the worker on backend failure).
+async fn drive_to_failed(repo: &ProofRequestRepo, id: Uuid, error_message: &str) {
+    assert!(repo.atomic_claim_task(id).await.unwrap(), "claim CREATED -> PENDING");
+    assert!(
+        repo.transition_pending_to_failed(id, error_message.into()).await.unwrap(),
+        "transition PENDING -> FAILED",
+    );
+}
+
+#[tokio::test]
+#[ignore = "requires a running Postgres with the prover schema (set DATABASE_URL); run with `cargo nextest run --run-ignored all -p base-prover-service-db --test postgres_integration --test-threads=1`"]
+async fn test_create_with_outbox_requeues_failed_row() {
+    let pool = test_pool().await;
+    let repo = test_repo(pool);
+
+    let explicit_id = Uuid::new_v4();
+    let mut req = compressed_request();
+    req.session_id = Some(explicit_id);
+
+    // First attempt: create the row, then fail it via the same path the worker uses.
+    let first = repo.create_with_outbox(req.clone(), TEST_MAX_PROOF_RETRIES).await.unwrap();
+    assert!(matches!(first, CreateProofRequestOutcome::Created(id) if id == explicit_id));
+    drive_to_failed(&repo, explicit_id, "transient backend error").await;
+
+    // Sanity: the row is FAILED and the original outbox row exists.
+    let before = repo.get(explicit_id).await.unwrap().unwrap();
+    assert_eq!(before.status, ProofStatus::Failed);
+    assert_eq!(before.retry_count, 0);
+    let original_outbox =
+        repo.get_unprocessed_outbox_entries(100, TEST_OUTBOX_MAX_ATTEMPTS).await.unwrap();
+    let original_outbox_count =
+        original_outbox.iter().filter(|e| e.proof_request_id == explicit_id).count();
+
+    // Retry: same request, same id. The DB must reset the row and enqueue a new outbox entry.
+    let second = repo.create_with_outbox(req, TEST_MAX_PROOF_RETRIES).await.unwrap();
+    assert!(matches!(second, CreateProofRequestOutcome::Requeued(id) if id == explicit_id));
+
+    let after = repo.get(explicit_id).await.unwrap().unwrap();
+    assert_eq!(after.status, ProofStatus::Created, "row must be reset to CREATED for re-claim");
+    assert_eq!(after.retry_count, 1, "retry_count must increment");
+    assert!(after.error_message.is_none(), "stale error_message must be cleared");
+    assert!(after.completed_at.is_none(), "stale completed_at must be cleared");
+    assert!(after.stark_receipt.is_none(), "stale stark_receipt must be cleared");
+    assert!(after.snark_receipt.is_none(), "stale snark_receipt must be cleared");
+
+    // A new outbox entry must be present so the worker can claim the task again.
+    let after_outbox =
+        repo.get_unprocessed_outbox_entries(100, TEST_OUTBOX_MAX_ATTEMPTS).await.unwrap();
+    let after_outbox_count =
+        after_outbox.iter().filter(|e| e.proof_request_id == explicit_id).count();
+    assert_eq!(
+        after_outbox_count,
+        original_outbox_count + 1,
+        "requeue must insert exactly one new outbox row",
+    );
+}
+
+#[tokio::test]
+#[ignore = "requires a running Postgres with the prover schema (set DATABASE_URL); run with `cargo nextest run --run-ignored all -p base-prover-service-db --test postgres_integration --test-threads=1`"]
+async fn test_create_with_outbox_rejects_param_mismatch() {
+    let pool = test_pool().await;
+    let repo = test_repo(pool);
+
+    let explicit_id = Uuid::new_v4();
+    let mut req = compressed_request();
+    req.session_id = Some(explicit_id);
+    let _ = repo.create_with_outbox(req.clone(), TEST_MAX_PROOF_RETRIES).await.unwrap();
+
+    // Same id, different start_block_number — must be rejected, not silently masked.
+    let mut mismatched = req.clone();
+    mismatched.start_block_number = req.start_block_number + 1;
+
+    let err = repo
+        .create_with_outbox(mismatched, TEST_MAX_PROOF_RETRIES)
+        .await
+        .expect_err("param mismatch must produce IdCollision");
+
+    match err {
+        CreateProofRequestError::IdCollision { id, field } => {
+            assert_eq!(id, explicit_id);
+            assert_eq!(field, "start_block_number");
+        }
+        other => panic!("expected IdCollision, got {other:?}"),
+    }
+
+    // The original row must be untouched (no spurious requeue / state change).
+    let row = repo.get(explicit_id).await.unwrap().unwrap();
+    assert_eq!(row.status, ProofStatus::Created);
+    assert_eq!(row.retry_count, 0);
+}
+
+#[tokio::test]
+#[ignore = "requires a running Postgres with the prover schema (set DATABASE_URL); run with `cargo nextest run --run-ignored all -p base-prover-service-db --test postgres_integration --test-threads=1`"]
+async fn test_create_with_outbox_retry_cap() {
+    let pool = test_pool().await;
+    let repo = test_repo(pool);
+
+    let explicit_id = Uuid::new_v4();
+    let mut req = compressed_request();
+    req.session_id = Some(explicit_id);
+
+    let first = repo.create_with_outbox(req.clone(), TEST_MAX_PROOF_RETRIES).await.unwrap();
+    assert!(matches!(first, CreateProofRequestOutcome::Created(_)));
+
+    for expected in 1..=TEST_MAX_PROOF_RETRIES {
+        drive_to_failed(&repo, explicit_id, "transient backend error").await;
+        let outcome = repo.create_with_outbox(req.clone(), TEST_MAX_PROOF_RETRIES).await.unwrap();
+        assert!(matches!(outcome, CreateProofRequestOutcome::Requeued(_)));
+        let row = repo.get(explicit_id).await.unwrap().unwrap();
+        assert_eq!(row.retry_count, expected, "retry {expected} should reset and bump count");
+    }
+
+    // At cap: next create must not enqueue outbox.
+    drive_to_failed(&repo, explicit_id, "final backend error").await;
+    let outbox_before =
+        repo.get_unprocessed_outbox_entries(100, TEST_OUTBOX_MAX_ATTEMPTS).await.unwrap();
+    let outbox_count_before =
+        outbox_before.iter().filter(|e| e.proof_request_id == explicit_id).count();
+
+    let outcome = repo.create_with_outbox(req, TEST_MAX_PROOF_RETRIES).await.unwrap();
+    assert!(matches!(outcome, CreateProofRequestOutcome::RetryExhausted(id) if id == explicit_id));
+
+    let row = repo.get(explicit_id).await.unwrap().unwrap();
+    assert_eq!(row.status, ProofStatus::Failed, "row must stay FAILED at retry cap");
+    assert_eq!(row.retry_count, TEST_MAX_PROOF_RETRIES, "retry_count must not exceed cap");
+
+    let outbox_after =
+        repo.get_unprocessed_outbox_entries(100, TEST_OUTBOX_MAX_ATTEMPTS).await.unwrap();
+    let outbox_count_after =
+        outbox_after.iter().filter(|e| e.proof_request_id == explicit_id).count();
+    assert_eq!(
+        outbox_count_after, outbox_count_before,
+        "RetryExhausted must not enqueue a new outbox row",
+    );
+}
+
+#[tokio::test]
+#[ignore = "requires a running Postgres with the prover schema (set DATABASE_URL); run with `cargo nextest run --run-ignored all -p base-prover-service-db --test postgres_integration --test-threads=1`"]
+async fn test_create_with_outbox_idempotent_in_flight() {
+    let pool = test_pool().await;
+    let repo = test_repo(pool);
+
+    let explicit_id = Uuid::new_v4();
+    let mut req = compressed_request();
+    req.session_id = Some(explicit_id);
+    let _ = repo.create_with_outbox(req.clone(), TEST_MAX_PROOF_RETRIES).await.unwrap();
+
+    // CREATED: replay must not insert another outbox row.
+    let replayed = repo.create_with_outbox(req.clone(), TEST_MAX_PROOF_RETRIES).await.unwrap();
+    assert!(matches!(replayed, CreateProofRequestOutcome::Replayed(id) if id == explicit_id));
+
+    // PENDING: claim, then replay.
+    assert!(repo.atomic_claim_task(explicit_id).await.unwrap());
+    let replayed = repo.create_with_outbox(req.clone(), TEST_MAX_PROOF_RETRIES).await.unwrap();
+    assert!(matches!(replayed, CreateProofRequestOutcome::Replayed(id) if id == explicit_id));
+
+    // RUNNING: bring the row up via a STARK session, then replay.
+    let backend_id = format!("inflight-{}", Uuid::new_v4());
+    repo.transition_pending_to_running(CreateProofSession {
+        proof_request_id: explicit_id,
+        session_type: SessionType::Stark,
+        backend_session_id: backend_id,
+        metadata: None,
+    })
+    .await
+    .unwrap()
+    .expect("transition PENDING -> RUNNING");
+    let replayed = repo.create_with_outbox(req, TEST_MAX_PROOF_RETRIES).await.unwrap();
+    assert!(matches!(replayed, CreateProofRequestOutcome::Replayed(id) if id == explicit_id));
+
+    // Exactly one outbox row should exist for this id across all three replays.
+    let entries = repo.get_unprocessed_outbox_entries(100, TEST_OUTBOX_MAX_ATTEMPTS).await.unwrap();
+    let outbox_count = entries.iter().filter(|e| e.proof_request_id == explicit_id).count();
+    assert_eq!(outbox_count, 1, "in-flight replays must not enqueue new outbox rows");
+}
+
+// ============================================================
+// Query tests
+// ============================================================
+
+#[tokio::test]
+#[ignore = "requires a running Postgres with the prover schema (set DATABASE_URL); run with `cargo nextest run --run-ignored all -p base-prover-service-db --test postgres_integration --test-threads=1`"]
+async fn test_get_running_sessions() {
+    let pool = test_pool().await;
+    let repo = test_repo(pool);
+
+    let req_id = repo.create(compressed_request()).await.unwrap();
+    let running_id = format!("running-session-{}", Uuid::new_v4());
+    let completed_id = format!("completed-session-{}", Uuid::new_v4());
+
+    // Create a running session
+    repo.create_proof_session(CreateProofSession {
+        proof_request_id: req_id,
+        session_type: SessionType::Stark,
+        backend_session_id: running_id.clone(),
+        metadata: None,
+    })
+    .await
+    .unwrap();
+
+    // Create and complete another session
+    repo.create_proof_session(CreateProofSession {
+        proof_request_id: req_id,
+        session_type: SessionType::Snark,
+        backend_session_id: completed_id.clone(),
+        metadata: None,
+    })
+    .await
+    .unwrap();
+    repo.update_proof_session(UpdateProofSession {
+        backend_session_id: completed_id.clone(),
+        status: SessionStatus::Completed,
+        error_message: None,
+        metadata: None,
+    })
+    .await
+    .unwrap();
+
+    let running = repo.get_running_sessions().await.unwrap();
+    let has_running = running.iter().any(|s| s.backend_session_id == running_id);
+    let has_completed = running.iter().any(|s| s.backend_session_id == completed_id);
+    assert!(has_running, "should include running session");
+    assert!(!has_completed, "should not include completed session");
+}
+
+#[tokio::test]
+#[ignore = "requires a running Postgres with the prover schema (set DATABASE_URL); run with `cargo nextest run --run-ignored all -p base-prover-service-db --test postgres_integration --test-threads=1`"]
+async fn test_get_running_proof_requests() {
+    let pool = test_pool().await;
+    let repo = test_repo(pool);
+
+    let (id, _backend_id) = setup_running_request(&repo).await;
+
+    let running = repo.get_running_proof_requests().await.unwrap();
+    let found = running.iter().any(|r| r.id == id);
+    assert!(found, "should include our running request");
+}
+
+#[tokio::test]
+#[ignore = "requires a running Postgres with the prover schema (set DATABASE_URL); run with `cargo nextest run --run-ignored all -p base-prover-service-db --test postgres_integration --test-threads=1`"]
+async fn test_list_with_filter() {
+    let pool = test_pool().await;
+    let repo = test_repo(pool);
+
+    let id1 = repo.create(compressed_request()).await.unwrap();
+    let (id2, _backend_id) = setup_running_request(&repo).await;
+
+    // List only CREATED
+    let created_list = repo.list(Some(ProofStatus::Created), 100).await.unwrap();
+    let has_id1 = created_list.iter().any(|r| r.id == id1);
+    let has_id2 = created_list.iter().any(|r| r.id == id2);
+    assert!(has_id1, "CREATED request should be in list");
+    assert!(!has_id2, "RUNNING request should not be in CREATED list");
+
+    // List all
+    let all_list = repo.list(None, 100).await.unwrap();
+    assert!(all_list.iter().any(|r| r.id == id1));
+    assert!(all_list.iter().any(|r| r.id == id2));
+}
+
+// ============================================================
+// Two-stage SNARK pipeline test
+// ============================================================
+
+#[tokio::test]
+#[ignore = "requires a running Postgres with the prover schema (set DATABASE_URL); run with `cargo nextest run --run-ignored all -p base-prover-service-db --test postgres_integration --test-threads=1`"]
+async fn test_full_snark_pipeline() {
+    let pool = test_pool().await;
+    let repo = test_repo(pool);
+
+    // 1. Create SNARK request
+    let req_id = repo.create(snark_request()).await.unwrap();
+
+    // 2. Claim task (CREATED -> PENDING)
+    assert!(repo.atomic_claim_task(req_id).await.unwrap());
+
+    // 3. Submit STARK session (PENDING -> RUNNING)
+    let stark_backend_id = format!("stark-pipeline-{}", Uuid::new_v4());
+    let session_id = repo
+        .transition_pending_to_running(CreateProofSession {
+            proof_request_id: req_id,
+            session_type: SessionType::Stark,
+            backend_session_id: stark_backend_id.clone(),
+            metadata: None,
+        })
+        .await
+        .unwrap();
+    assert!(session_id.is_some());
+
+    // 4. STARK completes — store receipt but keep RUNNING (awaiting SNARK)
+    let stark_receipt = vec![0x01, 0x02, 0x03];
+    repo.complete_session_and_update_receipt(
+        &stark_backend_id,
+        UpdateReceipt {
+            id: req_id,
+            stark_receipt: Some(stark_receipt.clone()),
+            snark_receipt: None,
+            status: ProofStatus::Running, // still running — SNARK stage not done
+            error_message: None,
+        },
+    )
+    .await
+    .unwrap();
+
+    let req = repo.get(req_id).await.unwrap().unwrap();
+    assert_eq!(req.status, ProofStatus::Running);
+    assert_eq!(req.stark_receipt.as_deref(), Some(stark_receipt.as_slice()));
+    assert!(req.snark_receipt.is_none());
+
+    // 5. Submit SNARK session
+    let snark_backend_id = format!("snark-pipeline-{}", Uuid::new_v4());
+    repo.create_proof_session(CreateProofSession {
+        proof_request_id: req_id,
+        session_type: SessionType::Snark,
+        backend_session_id: snark_backend_id.clone(),
+        metadata: None,
+    })
+    .await
+    .unwrap();
+
+    // 6. SNARK completes — store receipt, mark SUCCEEDED
+    let snark_receipt = vec![0xAA, 0xBB, 0xCC];
+    repo.complete_session_and_update_receipt(
+        &snark_backend_id,
+        UpdateReceipt {
+            id: req_id,
+            stark_receipt: None, // don't overwrite
+            snark_receipt: Some(snark_receipt.clone()),
+            status: ProofStatus::Succeeded,
+            error_message: None,
+        },
+    )
+    .await
+    .unwrap();
+
+    // 7. Verify final state
+    let req = repo.get(req_id).await.unwrap().unwrap();
+    assert_eq!(req.status, ProofStatus::Succeeded);
+    assert_eq!(req.stark_receipt.as_deref(), Some(stark_receipt.as_slice())); // preserved
+    assert_eq!(req.snark_receipt.as_deref(), Some(snark_receipt.as_slice()));
+    assert!(req.completed_at.is_some());
+
+    let sessions = repo.get_sessions_for_request(req_id).await.unwrap();
+    assert_eq!(sessions.len(), 2);
+    assert_eq!(sessions[0].session_type, SessionType::Stark);
+    assert_eq!(sessions[0].status, SessionStatus::Completed);
+    assert_eq!(sessions[1].session_type, SessionType::Snark);
+    assert_eq!(sessions[1].status, SessionStatus::Completed);
+}


### PR DESCRIPTION
## Summary

Copies the existing zk prover service `db` crate into a new `prover-service` crate location at `crates/proof/prover-service/db`.

This is a preparatory move to establish the new `prover-service` crate structure. No logic changes — files are copied as-is.