### PR TITLE
fix(common-evm): Install Beryl Builder Precompiles

### DIFF
--- a/crates/common/evm/src/api/builder.rs
+++ b/crates/common/evm/src/api/builder.rs
@@ -1,5 +1,5 @@
 //! [`Builder`] trait for constructing a [`BaseEvm`] directly from a [`BaseContext`].
-use alloy_evm::Database;
+use alloy_evm::{Database, precompiles::PrecompilesMap};
 use revm::{
     context::FrameStack,
     handler::{EthFrame, instructions::EthInstructions},
@@ -11,7 +11,7 @@ use crate::{BaseContext, BaseEvm, BasePrecompiles, BaseSpecId};
 /// Trait that allows constructing a [`BaseEvm`] from a [`BaseContext`].
 ///
 /// Implemented for [`BaseContext<DB>`] of any database. The resulting [`BaseEvm`]
-/// uses [`BasePrecompiles`] for the active [`BaseSpecId`]; call
+/// installs the full [`BasePrecompiles`] map for the active [`BaseSpecId`]; call
 /// [`BaseEvm::with_precompiles`] afterwards to substitute a custom precompile set.
 pub trait Builder: Sized {
     /// The database type of the context.
@@ -20,42 +20,96 @@ pub trait Builder: Sized {
     /// Builds a [`BaseEvm`] with a `()` inspector. The inspect flag is `false`,
     /// so [`Inspector`][revm::Inspector] callbacks are never invoked via
     /// [`alloy_evm::Evm::transact`].
-    fn build_base(self) -> BaseEvm<Self::Db, ()>;
+    fn build_base(self) -> BaseEvm<Self::Db, (), PrecompilesMap>;
 
     /// Builds a [`BaseEvm`] with the given inspector. The inspect flag is `true`,
     /// so [`Inspector`][revm::Inspector] callbacks are invoked on every
     /// [`alloy_evm::Evm::transact`] call.
-    fn build_with_inspector<INSP>(self, inspector: INSP) -> BaseEvm<Self::Db, INSP>;
+    fn build_with_inspector<INSP>(self, inspector: INSP)
+    -> BaseEvm<Self::Db, INSP, PrecompilesMap>;
 }
 
 impl<DB: Database> Builder for BaseContext<DB> {
     type Db = DB;
 
-    fn build_base(self) -> BaseEvm<DB, ()> {
+    fn build_base(self) -> BaseEvm<DB, (), PrecompilesMap> {
         let spec: BaseSpecId = self.cfg.spec;
         BaseEvm::new(
             revm::context::Evm {
                 ctx: self,
                 inspector: (),
                 instruction: EthInstructions::new_mainnet_with_spec(spec.into()),
-                precompiles: BasePrecompiles::new_with_spec(spec),
+                precompiles: BasePrecompiles::new_with_spec(spec).install(),
                 frame_stack: FrameStack::<EthFrame<EthInterpreter>>::new_prealloc(8),
             },
             false,
         )
     }
 
-    fn build_with_inspector<INSP>(self, inspector: INSP) -> BaseEvm<DB, INSP> {
+    fn build_with_inspector<INSP>(self, inspector: INSP) -> BaseEvm<DB, INSP, PrecompilesMap> {
         let spec: BaseSpecId = self.cfg.spec;
         BaseEvm::new(
             revm::context::Evm {
                 ctx: self,
                 inspector,
                 instruction: EthInstructions::new_mainnet_with_spec(spec.into()),
-                precompiles: BasePrecompiles::new_with_spec(spec),
+                precompiles: BasePrecompiles::new_with_spec(spec).install(),
                 frame_stack: FrameStack::<EthFrame<EthInterpreter>>::new_prealloc(8),
             },
             true,
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_primitives::{Address, B256};
+    use base_common_precompiles::{
+        ActivationRegistryStorage, B20FactoryStorage, B20Variant, PolicyRegistryStorage,
+    };
+    use revm::{Context, context::CfgEnv, handler::EvmTr, inspector::NoOpInspector};
+
+    use super::*;
+    use crate::{BaseUpgrade, DefaultBase};
+
+    fn b20_token_address() -> Address {
+        B20Variant::B20.compute_address(Address::repeat_byte(0x11), B256::repeat_byte(0x22)).0
+    }
+
+    #[test]
+    fn build_base_installs_dynamic_beryl_precompiles() {
+        let ctx =
+            Context::base().with_cfg(CfgEnv::new_with_spec(BaseSpecId::new(BaseUpgrade::Beryl)));
+        let evm = ctx.build_base();
+        let (_, _, precompiles, _) = evm.all();
+
+        assert!(precompiles.get(&B20FactoryStorage::ADDRESS).is_some());
+        assert!(precompiles.get(&b20_token_address()).is_some());
+        assert!(precompiles.get(&PolicyRegistryStorage::ADDRESS).is_some());
+        assert!(precompiles.get(&ActivationRegistryStorage::ADDRESS).is_some());
+    }
+
+    #[test]
+    fn build_base_does_not_install_beryl_precompiles_before_beryl() {
+        let ctx =
+            Context::base().with_cfg(CfgEnv::new_with_spec(BaseSpecId::new(BaseUpgrade::Azul)));
+        let evm = ctx.build_base();
+        let (_, _, precompiles, _) = evm.all();
+
+        assert!(precompiles.get(&B20FactoryStorage::ADDRESS).is_none());
+        assert!(precompiles.get(&b20_token_address()).is_none());
+        assert!(precompiles.get(&PolicyRegistryStorage::ADDRESS).is_none());
+        assert!(precompiles.get(&ActivationRegistryStorage::ADDRESS).is_none());
+    }
+
+    #[test]
+    fn build_with_inspector_installs_dynamic_beryl_precompiles() {
+        let ctx =
+            Context::base().with_cfg(CfgEnv::new_with_spec(BaseSpecId::new(BaseUpgrade::Beryl)));
+        let evm = ctx.build_with_inspector(NoOpInspector {});
+        let (_, _, precompiles, _) = evm.all();
+
+        assert!(precompiles.get(&B20FactoryStorage::ADDRESS).is_some());
+        assert!(precompiles.get(&b20_token_address()).is_some());
     }
 }

--- a/crates/common/evm/src/api/builder.rs
+++ b/crates/common/evm/src/api/builder.rs
@@ -1,5 +1,6 @@
 //! [`Builder`] trait for constructing a [`BaseEvm`] directly from a [`BaseContext`].
 use alloy_evm::{Database, precompiles::PrecompilesMap};
+use alloy_primitives::Address;
 use revm::{
     context::FrameStack,
     handler::{EthFrame, instructions::EthInstructions},
@@ -22,24 +23,74 @@ pub trait Builder: Sized {
     /// [`alloy_evm::Evm::transact`].
     fn build_base(self) -> BaseEvm<Self::Db, (), PrecompilesMap>;
 
+    /// Builds a [`BaseEvm`] with a `()` inspector and an activation registry admin address.
+    ///
+    /// The inspect flag is `false`, so [`Inspector`][revm::Inspector] callbacks are never invoked
+    /// via [`alloy_evm::Evm::transact`].
+    fn build_base_with_activation_admin_address(
+        self,
+        activation_admin_address: Option<Address>,
+    ) -> BaseEvm<Self::Db, (), PrecompilesMap>;
+
+    /// Builds a [`BaseEvm`] with a `()` inspector and caller-supplied precompiles.
+    ///
+    /// The inspect flag is `false`, so [`Inspector`][revm::Inspector] callbacks are never invoked
+    /// via [`alloy_evm::Evm::transact`].
+    fn build_base_with_precompiles<P>(self, precompiles: P) -> BaseEvm<Self::Db, (), P>;
+
     /// Builds a [`BaseEvm`] with the given inspector. The inspect flag is `true`,
     /// so [`Inspector`][revm::Inspector] callbacks are invoked on every
     /// [`alloy_evm::Evm::transact`] call.
     fn build_with_inspector<INSP>(self, inspector: INSP)
     -> BaseEvm<Self::Db, INSP, PrecompilesMap>;
+
+    /// Builds a [`BaseEvm`] with the given inspector and activation registry admin address.
+    ///
+    /// The inspect flag is `true`, so [`Inspector`][revm::Inspector] callbacks are invoked on every
+    /// [`alloy_evm::Evm::transact`] call.
+    fn build_with_inspector_and_activation_admin_address<INSP>(
+        self,
+        inspector: INSP,
+        activation_admin_address: Option<Address>,
+    ) -> BaseEvm<Self::Db, INSP, PrecompilesMap>;
+
+    /// Builds a [`BaseEvm`] with the given inspector and caller-supplied precompiles.
+    ///
+    /// The inspect flag is `true`, so [`Inspector`][revm::Inspector] callbacks are invoked on every
+    /// [`alloy_evm::Evm::transact`] call.
+    fn build_with_inspector_and_precompiles<INSP, P>(
+        self,
+        inspector: INSP,
+        precompiles: P,
+    ) -> BaseEvm<Self::Db, INSP, P>;
 }
 
 impl<DB: Database> Builder for BaseContext<DB> {
     type Db = DB;
 
     fn build_base(self) -> BaseEvm<DB, (), PrecompilesMap> {
+        self.build_base_with_activation_admin_address(None)
+    }
+
+    fn build_base_with_activation_admin_address(
+        self,
+        activation_admin_address: Option<Address>,
+    ) -> BaseEvm<DB, (), PrecompilesMap> {
+        let spec: BaseSpecId = self.cfg.spec;
+        let precompiles = BasePrecompiles::new_with_spec(spec)
+            .with_activation_admin_address(activation_admin_address)
+            .install();
+        self.build_base_with_precompiles(precompiles)
+    }
+
+    fn build_base_with_precompiles<P>(self, precompiles: P) -> BaseEvm<DB, (), P> {
         let spec: BaseSpecId = self.cfg.spec;
         BaseEvm::new(
             revm::context::Evm {
                 ctx: self,
                 inspector: (),
                 instruction: EthInstructions::new_mainnet_with_spec(spec.into()),
-                precompiles: BasePrecompiles::new_with_spec(spec).install(),
+                precompiles,
                 frame_stack: FrameStack::<EthFrame<EthInterpreter>>::new_prealloc(8),
             },
             false,
@@ -47,13 +98,33 @@ impl<DB: Database> Builder for BaseContext<DB> {
     }
 
     fn build_with_inspector<INSP>(self, inspector: INSP) -> BaseEvm<DB, INSP, PrecompilesMap> {
+        self.build_with_inspector_and_activation_admin_address(inspector, None)
+    }
+
+    fn build_with_inspector_and_activation_admin_address<INSP>(
+        self,
+        inspector: INSP,
+        activation_admin_address: Option<Address>,
+    ) -> BaseEvm<DB, INSP, PrecompilesMap> {
+        let spec: BaseSpecId = self.cfg.spec;
+        let precompiles = BasePrecompiles::new_with_spec(spec)
+            .with_activation_admin_address(activation_admin_address)
+            .install();
+        self.build_with_inspector_and_precompiles(inspector, precompiles)
+    }
+
+    fn build_with_inspector_and_precompiles<INSP, P>(
+        self,
+        inspector: INSP,
+        precompiles: P,
+    ) -> BaseEvm<DB, INSP, P> {
         let spec: BaseSpecId = self.cfg.spec;
         BaseEvm::new(
             revm::context::Evm {
                 ctx: self,
                 inspector,
                 instruction: EthInstructions::new_mainnet_with_spec(spec.into()),
-                precompiles: BasePrecompiles::new_with_spec(spec).install(),
+                precompiles,
                 frame_stack: FrameStack::<EthFrame<EthInterpreter>>::new_prealloc(8),
             },
             true,
@@ -64,13 +135,21 @@ impl<DB: Database> Builder for BaseContext<DB> {
 #[cfg(test)]
 mod tests {
     use alloy_primitives::{Address, B256};
+    use alloy_sol_types::SolCall;
     use base_common_precompiles::{
-        ActivationRegistryStorage, B20FactoryStorage, B20Variant, PolicyRegistryStorage,
+        ActivationRegistryStorage, B20FactoryStorage, B20Variant, IActivationRegistry,
+        PolicyRegistryStorage,
     };
-    use revm::{Context, context::CfgEnv, handler::EvmTr, inspector::NoOpInspector};
+    use revm::{
+        Context, ExecuteEvm,
+        context::{CfgEnv, TxEnv},
+        handler::EvmTr,
+        inspector::NoOpInspector,
+        primitives::{Bytes, TxKind},
+    };
 
     use super::*;
-    use crate::{BaseUpgrade, DefaultBase};
+    use crate::{BaseTransaction, BaseUpgrade, DefaultBase};
 
     fn b20_token_address() -> Address {
         B20Variant::B20.compute_address(Address::repeat_byte(0x11), B256::repeat_byte(0x22)).0
@@ -111,5 +190,28 @@ mod tests {
 
         assert!(precompiles.get(&B20FactoryStorage::ADDRESS).is_some());
         assert!(precompiles.get(&b20_token_address()).is_some());
+    }
+
+    #[test]
+    fn build_base_with_activation_admin_address_configures_activation_registry() {
+        let admin = Address::repeat_byte(0xaa);
+        let ctx =
+            Context::base().with_cfg(CfgEnv::new_with_spec(BaseSpecId::new(BaseUpgrade::Beryl)));
+        let mut evm = ctx.build_base_with_activation_admin_address(Some(admin));
+
+        let tx = BaseTransaction::builder()
+            .base(
+                TxEnv::builder()
+                    .kind(TxKind::Call(ActivationRegistryStorage::ADDRESS))
+                    .data(Bytes::from(IActivationRegistry::adminCall {}.abi_encode()))
+                    .gas_limit(100_000),
+            )
+            .build_fill();
+
+        let result = evm.transact_one(tx).unwrap();
+        let output = result.output().unwrap();
+        let actual = IActivationRegistry::adminCall::abi_decode_returns(output).unwrap();
+
+        assert_eq!(actual, admin);
     }
 }

--- a/crates/common/evm/src/api/builder.rs
+++ b/crates/common/evm/src/api/builder.rs
@@ -18,10 +18,15 @@ pub trait Builder: Sized {
     /// The database type of the context.
     type Db: Database;
 
+    /// Returns the active [`BaseSpecId`] for this builder.
+    fn spec(&self) -> BaseSpecId;
+
     /// Builds a [`BaseEvm`] with a `()` inspector. The inspect flag is `false`,
     /// so [`Inspector`][revm::Inspector] callbacks are never invoked via
     /// [`alloy_evm::Evm::transact`].
-    fn build_base(self) -> BaseEvm<Self::Db, (), PrecompilesMap>;
+    fn build_base(self) -> BaseEvm<Self::Db, (), PrecompilesMap> {
+        self.build_base_with_activation_admin_address(None)
+    }
 
     /// Builds a [`BaseEvm`] with a `()` inspector and an activation registry admin address.
     ///
@@ -30,7 +35,13 @@ pub trait Builder: Sized {
     fn build_base_with_activation_admin_address(
         self,
         activation_admin_address: Option<Address>,
-    ) -> BaseEvm<Self::Db, (), PrecompilesMap>;
+    ) -> BaseEvm<Self::Db, (), PrecompilesMap> {
+        let spec = self.spec();
+        let precompiles = BasePrecompiles::new_with_spec(spec)
+            .with_activation_admin_address(activation_admin_address)
+            .install();
+        self.build_base_with_precompiles(precompiles)
+    }
 
     /// Builds a [`BaseEvm`] with a `()` inspector and caller-supplied precompiles.
     ///
@@ -41,8 +52,12 @@ pub trait Builder: Sized {
     /// Builds a [`BaseEvm`] with the given inspector. The inspect flag is `true`,
     /// so [`Inspector`][revm::Inspector] callbacks are invoked on every
     /// [`alloy_evm::Evm::transact`] call.
-    fn build_with_inspector<INSP>(self, inspector: INSP)
-    -> BaseEvm<Self::Db, INSP, PrecompilesMap>;
+    fn build_with_inspector<INSP>(
+        self,
+        inspector: INSP,
+    ) -> BaseEvm<Self::Db, INSP, PrecompilesMap> {
+        self.build_with_inspector_and_activation_admin_address(inspector, None)
+    }
 
     /// Builds a [`BaseEvm`] with the given inspector and activation registry admin address.
     ///
@@ -52,7 +67,13 @@ pub trait Builder: Sized {
         self,
         inspector: INSP,
         activation_admin_address: Option<Address>,
-    ) -> BaseEvm<Self::Db, INSP, PrecompilesMap>;
+    ) -> BaseEvm<Self::Db, INSP, PrecompilesMap> {
+        let spec = self.spec();
+        let precompiles = BasePrecompiles::new_with_spec(spec)
+            .with_activation_admin_address(activation_admin_address)
+            .install();
+        self.build_with_inspector_and_precompiles(inspector, precompiles)
+    }
 
     /// Builds a [`BaseEvm`] with the given inspector and caller-supplied precompiles.
     ///
@@ -68,19 +89,8 @@ pub trait Builder: Sized {
 impl<DB: Database> Builder for BaseContext<DB> {
     type Db = DB;
 
-    fn build_base(self) -> BaseEvm<DB, (), PrecompilesMap> {
-        self.build_base_with_activation_admin_address(None)
-    }
-
-    fn build_base_with_activation_admin_address(
-        self,
-        activation_admin_address: Option<Address>,
-    ) -> BaseEvm<DB, (), PrecompilesMap> {
-        let spec: BaseSpecId = self.cfg.spec;
-        let precompiles = BasePrecompiles::new_with_spec(spec)
-            .with_activation_admin_address(activation_admin_address)
-            .install();
-        self.build_base_with_precompiles(precompiles)
+    fn spec(&self) -> BaseSpecId {
+        self.cfg.spec
     }
 
     fn build_base_with_precompiles<P>(self, precompiles: P) -> BaseEvm<DB, (), P> {
@@ -95,22 +105,6 @@ impl<DB: Database> Builder for BaseContext<DB> {
             },
             false,
         )
-    }
-
-    fn build_with_inspector<INSP>(self, inspector: INSP) -> BaseEvm<DB, INSP, PrecompilesMap> {
-        self.build_with_inspector_and_activation_admin_address(inspector, None)
-    }
-
-    fn build_with_inspector_and_activation_admin_address<INSP>(
-        self,
-        inspector: INSP,
-        activation_admin_address: Option<Address>,
-    ) -> BaseEvm<DB, INSP, PrecompilesMap> {
-        let spec: BaseSpecId = self.cfg.spec;
-        let precompiles = BasePrecompiles::new_with_spec(spec)
-            .with_activation_admin_address(activation_admin_address)
-            .install();
-        self.build_with_inspector_and_precompiles(inspector, precompiles)
     }
 
     fn build_with_inspector_and_precompiles<INSP, P>(

--- a/crates/common/evm/src/executor/block_executor.rs
+++ b/crates/common/evm/src/executor/block_executor.rs
@@ -327,7 +327,9 @@ mod tests {
 
     use alloy_consensus::{SignableTransaction, TxLegacy, transaction::Recovered};
     use alloy_eips::eip2718::WithEncoded;
-    use alloy_evm::{EvmEnv, EvmFactory, ToTxEnv, block::BlockExecutorFactory};
+    use alloy_evm::{
+        EvmEnv, EvmFactory, ToTxEnv, block::BlockExecutorFactory, precompiles::PrecompilesMap,
+    };
     use alloy_hardforks::ForkCondition;
     use alloy_primitives::{Address, Signature, U256, uint};
     use base_common_chains::{BaseUpgrade, ChainUpgrades};
@@ -423,7 +425,7 @@ mod tests {
         gas_limit: u64,
         jovian_timestamp: u64,
     ) -> BaseBlockExecutor<
-        BaseEvm<&'a mut revm::database::State<InMemoryDB>, NoOpInspector>,
+        BaseEvm<&'a mut revm::database::State<InMemoryDB>, NoOpInspector, PrecompilesMap>,
         &'a AlloyReceiptBuilder,
         &'a ChainUpgrades,
     > {

--- a/crates/common/evm/src/factory.rs
+++ b/crates/common/evm/src/factory.rs
@@ -8,8 +8,8 @@ use revm::{
 };
 
 use crate::{
-    BaseContext, BaseEvm, BaseHaltReason, BasePrecompiles, BaseSpecId, BaseTransaction,
-    BaseTransactionError, Builder, DefaultBase,
+    BaseContext, BaseEvm, BaseHaltReason, BaseSpecId, BaseTransaction, BaseTransactionError,
+    Builder, DefaultBase,
 };
 
 /// Factory that produces [`BaseEvm`] instances backed by a [`PrecompilesMap`].
@@ -75,17 +75,13 @@ impl EvmFactory for BaseEvmFactory {
         db: DB,
         input: EvmEnv<BaseSpecId>,
     ) -> Self::Evm<DB, NoOpInspector> {
-        let spec_id = input.cfg_env.spec;
         Context::base()
             .with_db(db)
             .with_block(input.block_env)
             .with_cfg(input.cfg_env)
-            .build_base()
-            .with_inspector(NoOpInspector {})
-            .with_precompiles(
-                BasePrecompiles::new_with_spec(spec_id)
-                    .with_activation_admin_address(self.activation_admin_address)
-                    .install(),
+            .build_with_inspector_and_activation_admin_address(
+                NoOpInspector {},
+                self.activation_admin_address,
             )
     }
 
@@ -95,16 +91,13 @@ impl EvmFactory for BaseEvmFactory {
         input: EvmEnv<BaseSpecId>,
         inspector: I,
     ) -> Self::Evm<DB, I> {
-        let spec_id = input.cfg_env.spec;
         Context::base()
             .with_db(db)
             .with_block(input.block_env)
             .with_cfg(input.cfg_env)
-            .build_with_inspector(inspector)
-            .with_precompiles(
-                BasePrecompiles::new_with_spec(spec_id)
-                    .with_activation_admin_address(self.activation_admin_address)
-                    .install(),
+            .build_with_inspector_and_activation_admin_address(
+                inspector,
+                self.activation_admin_address,
             )
     }
 }

--- a/crates/common/precompiles/src/provider.rs
+++ b/crates/common/precompiles/src/provider.rs
@@ -53,6 +53,7 @@ impl<S: BasePrecompileSpec> BasePrecompiles<S> {
     }
 
     /// Sets the activation registry admin address.
+    #[must_use = "with_activation_admin_address returns a new BasePrecompiles value"]
     pub const fn with_activation_admin_address(
         mut self,
         activation_admin_address: Option<Address>,

--- a/crates/proof/succinct/utils/client/src/precompiles/factory.rs
+++ b/crates/proof/succinct/utils/client/src/precompiles/factory.rs
@@ -64,16 +64,15 @@ impl EvmFactory for ZkvmBaseEvmFactory {
         input: EvmEnv<BaseSpecId>,
     ) -> Self::Evm<DB, NoOpInspector> {
         let spec_id = input.cfg_env.spec;
+        let precompiles = BaseZkvmPrecompiles::new_with_spec_and_activation_admin_address(
+            spec_id,
+            self.activation_admin_address,
+        );
         Context::base()
             .with_db(db)
             .with_block(input.block_env)
             .with_cfg(input.cfg_env)
-            .build_base()
-            .with_inspector(NoOpInspector {})
-            .with_precompiles(BaseZkvmPrecompiles::new_with_spec_and_activation_admin_address(
-                spec_id,
-                self.activation_admin_address,
-            ))
+            .build_with_inspector_and_precompiles(NoOpInspector {}, precompiles)
     }
 
     fn create_evm_with_inspector<DB: Database, I: Inspector<Self::Context<DB>>>(
@@ -83,14 +82,14 @@ impl EvmFactory for ZkvmBaseEvmFactory {
         inspector: I,
     ) -> Self::Evm<DB, I> {
         let spec_id = input.cfg_env.spec;
+        let precompiles = BaseZkvmPrecompiles::new_with_spec_and_activation_admin_address(
+            spec_id,
+            self.activation_admin_address,
+        );
         Context::base()
             .with_db(db)
             .with_block(input.block_env)
             .with_cfg(input.cfg_env)
-            .build_with_inspector(inspector)
-            .with_precompiles(BaseZkvmPrecompiles::new_with_spec_and_activation_admin_address(
-                spec_id,
-                self.activation_admin_address,
-            ))
+            .build_with_inspector_and_precompiles(inspector, precompiles)
     }
 }


### PR DESCRIPTION
## Summary

This updates the direct BaseContext builder API to install the full Base precompile map for the active spec, so Beryl builders include the dynamic B20 and registry surface by default. It adds regression coverage for Beryl and pre-Beryl builder behavior, and marks activation-admin builder configuration as must-use. The factory and custom precompile replacement paths remain available through with_precompiles.