### PR TITLE
chore(prover-service): copy zk prover outbox into shared prover-service crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5960,6 +5960,7 @@ dependencies = [
  "base-zk-db",
  "serde_json",
  "tokio",
+ "tokio-util",
  "tracing",
  "uuid",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5952,6 +5952,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "base-prover-service-outbox"
+version = "0.0.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "base-zk-db",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
 name = "base-prover-zk"
 version = "0.0.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5974,7 +5974,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "base-zk-db",
+ "base-prover-service-db",
  "serde_json",
  "tokio",
  "tokio-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ members = [
   "crates/proof/primitives",
   "crates/proof/host",
   "crates/proof/prover-service",
+  "crates/proof/prover-service/outbox",
   "crates/proof/tee/nitro-host",
   "crates/proof/tee/nitro-enclave",
   "crates/proof/tee/registrar",
@@ -239,6 +240,7 @@ base-proof = { path = "crates/proof/proof", default-features = false }
 base-proof-mpt = { path = "crates/proof/mpt", default-features = false }
 base-proof-tee-nitro-enclave = { path = "crates/proof/tee/nitro-enclave" }
 base-proof-host = { path = "crates/proof/host", default-features = false }
+base-prover-service-outbox = { path = "crates/proof/prover-service/outbox" }
 base-proof-tee-nitro-verifier = { path = "crates/proof/tee/nitro-verifier" }
 base-proof-client = { path = "crates/proof/client", default-features = false }
 base-proof-driver = { path = "crates/proof/driver", default-features = false }

--- a/crates/proof/prover-service/outbox/Cargo.toml
+++ b/crates/proof/prover-service/outbox/Cargo.toml
@@ -10,7 +10,7 @@ repository.workspace = true
 
 [dependencies]
 # database
-base-zk-db.workspace = true
+base-prover-service-db.workspace = true
 
 # async
 tokio-util.workspace = true

--- a/crates/proof/prover-service/outbox/Cargo.toml
+++ b/crates/proof/prover-service/outbox/Cargo.toml
@@ -13,8 +13,9 @@ repository.workspace = true
 base-zk-db.workspace = true
 
 # async
+tokio-util.workspace = true
 async-trait.workspace = true
-tokio = { workspace = true, features = ["time", "sync"] }
+tokio = { workspace = true, features = ["macros", "sync", "time"] }
 
 # serialization
 serde_json.workspace = true

--- a/crates/proof/prover-service/outbox/Cargo.toml
+++ b/crates/proof/prover-service/outbox/Cargo.toml
@@ -19,7 +19,7 @@ tokio = { workspace = true, features = ["macros", "time"] }
 
 # serialization
 serde_json.workspace = true
-uuid = { workspace = true, features = ["v4", "serde"] }
+uuid = { workspace = true, features = ["serde"] }
 
 # error handling
 anyhow.workspace = true

--- a/crates/proof/prover-service/outbox/Cargo.toml
+++ b/crates/proof/prover-service/outbox/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "base-prover-service-outbox"
+description = "Shared prover service outbox processing utilities"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+
+[dependencies]
+# database
+base-zk-db.workspace = true
+
+# async
+async-trait.workspace = true
+tokio = { workspace = true, features = ["time", "sync"] }
+
+# serialization
+serde_json.workspace = true
+uuid = { workspace = true, features = ["v4", "serde"] }
+
+# error handling
+anyhow.workspace = true
+
+# tracing
+tracing.workspace = true
+
+[lints]
+workspace = true

--- a/crates/proof/prover-service/outbox/Cargo.toml
+++ b/crates/proof/prover-service/outbox/Cargo.toml
@@ -15,7 +15,7 @@ base-prover-service-db.workspace = true
 # async
 tokio-util.workspace = true
 async-trait.workspace = true
-tokio = { workspace = true, features = ["macros", "sync", "time"] }
+tokio = { workspace = true, features = ["macros", "time"] }
 
 # serialization
 serde_json.workspace = true

--- a/crates/proof/prover-service/outbox/README.md
+++ b/crates/proof/prover-service/outbox/README.md
@@ -1,0 +1,4 @@
+# `base-prover-service-outbox`
+
+Shared prover service outbox pattern implementation for reliable async task
+processing.

--- a/crates/proof/prover-service/outbox/src/database.rs
+++ b/crates/proof/prover-service/outbox/src/database.rs
@@ -1,0 +1,53 @@
+use async_trait::async_trait;
+use base_zk_db::{MarkOutboxError, MarkOutboxProcessed, ProofRequestRepo};
+
+use crate::{OutboxReader, OutboxTask};
+
+/// Outbox reader backed by `PostgreSQL` via [`ProofRequestRepo`].
+#[derive(Clone)]
+pub struct DatabaseOutboxReader {
+    repo: ProofRequestRepo,
+    max_retries: i32,
+}
+
+impl std::fmt::Debug for DatabaseOutboxReader {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DatabaseOutboxReader").field("max_retries", &self.max_retries).finish()
+    }
+}
+
+impl DatabaseOutboxReader {
+    /// Create a new database-backed outbox reader.
+    pub const fn new(repo: ProofRequestRepo, max_retries: i32) -> Self {
+        Self { repo, max_retries }
+    }
+}
+
+#[async_trait]
+impl OutboxReader for DatabaseOutboxReader {
+    async fn poll_tasks(&self, batch_size: i64) -> anyhow::Result<Vec<OutboxTask>> {
+        let entries =
+            self.repo.get_unprocessed_outbox_entries(batch_size, self.max_retries).await?;
+
+        let tasks = entries
+            .into_iter()
+            .map(|entry| OutboxTask {
+                sequence_id: entry.sequence_id,
+                proof_request_id: entry.proof_request_id,
+                params: entry.request_params,
+            })
+            .collect();
+
+        Ok(tasks)
+    }
+
+    async fn mark_processed(&self, sequence_id: i64) -> anyhow::Result<()> {
+        self.repo.mark_outbox_processed(MarkOutboxProcessed { sequence_id }).await?;
+        Ok(())
+    }
+
+    async fn mark_error(&self, sequence_id: i64, error_message: String) -> anyhow::Result<()> {
+        self.repo.mark_outbox_error(MarkOutboxError { sequence_id, error_message }).await?;
+        Ok(())
+    }
+}

--- a/crates/proof/prover-service/outbox/src/database.rs
+++ b/crates/proof/prover-service/outbox/src/database.rs
@@ -1,3 +1,4 @@
+use anyhow::Context;
 use async_trait::async_trait;
 use base_zk_db::{MarkOutboxError, MarkOutboxProcessed, ProofRequestRepo};
 
@@ -25,28 +26,38 @@ impl DatabaseOutboxReader {
 
 #[async_trait]
 impl OutboxReader for DatabaseOutboxReader {
-    async fn poll_tasks(&self, batch_size: i64) -> anyhow::Result<Vec<OutboxTask>> {
+    async fn poll_tasks(&self, batch_size: u64) -> anyhow::Result<Vec<OutboxTask>> {
+        let batch_size =
+            i64::try_from(batch_size).context("outbox batch size exceeds i64 range")?;
         let entries =
             self.repo.get_unprocessed_outbox_entries(batch_size, self.max_retries).await?;
 
         let tasks = entries
             .into_iter()
-            .map(|entry| OutboxTask {
-                sequence_id: entry.sequence_id,
-                proof_request_id: entry.proof_request_id,
-                params: entry.request_params,
+            .map(|entry| {
+                let sequence_id =
+                    u64::try_from(entry.sequence_id).context("outbox sequence ID is negative")?;
+                Ok(OutboxTask {
+                    sequence_id,
+                    proof_request_id: entry.proof_request_id,
+                    params: entry.request_params,
+                })
             })
-            .collect();
+            .collect::<anyhow::Result<Vec<_>>>()?;
 
         Ok(tasks)
     }
 
-    async fn mark_processed(&self, sequence_id: i64) -> anyhow::Result<()> {
+    async fn mark_processed(&self, sequence_id: u64) -> anyhow::Result<()> {
+        let sequence_id =
+            i64::try_from(sequence_id).context("outbox sequence ID exceeds i64 range")?;
         self.repo.mark_outbox_processed(MarkOutboxProcessed { sequence_id }).await?;
         Ok(())
     }
 
-    async fn mark_error(&self, sequence_id: i64, error_message: String) -> anyhow::Result<()> {
+    async fn mark_error(&self, sequence_id: u64, error_message: String) -> anyhow::Result<()> {
+        let sequence_id =
+            i64::try_from(sequence_id).context("outbox sequence ID exceeds i64 range")?;
         self.repo.mark_outbox_error(MarkOutboxError { sequence_id, error_message }).await?;
         Ok(())
     }

--- a/crates/proof/prover-service/outbox/src/database.rs
+++ b/crates/proof/prover-service/outbox/src/database.rs
@@ -1,6 +1,6 @@
 use anyhow::Context;
 use async_trait::async_trait;
-use base_zk_db::{MarkOutboxError, MarkOutboxProcessed, ProofRequestRepo};
+use base_prover_service_db::{MarkOutboxError, MarkOutboxProcessed, ProofRequestRepo};
 
 use crate::{OutboxReader, OutboxTask};
 

--- a/crates/proof/prover-service/outbox/src/lib.rs
+++ b/crates/proof/prover-service/outbox/src/lib.rs
@@ -1,0 +1,13 @@
+#![doc = include_str!("../README.md")]
+
+mod reader;
+pub use reader::{OutboxReader, OutboxTask};
+
+mod task_queue;
+pub use task_queue::TaskQueue;
+
+mod processor;
+pub use processor::OutboxProcessor;
+
+mod database;
+pub use database::DatabaseOutboxReader;

--- a/crates/proof/prover-service/outbox/src/processor.rs
+++ b/crates/proof/prover-service/outbox/src/processor.rs
@@ -1,8 +1,8 @@
 use std::time::Duration;
 
-use tokio::time;
+use tokio::time::{self, MissedTickBehavior};
 use tokio_util::sync::CancellationToken;
-use tracing::{debug, error, info};
+use tracing::{debug, error, info, warn};
 
 use crate::{OutboxReader, OutboxTask, TaskQueue};
 
@@ -38,6 +38,7 @@ impl<R: OutboxReader, Q: TaskQueue> OutboxProcessor<R, Q> {
         );
 
         let mut interval = time::interval(Duration::from_secs(self.poll_interval_secs));
+        interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
 
         loop {
             tokio::select! {
@@ -86,10 +87,10 @@ impl<R: OutboxReader, Q: TaskQueue> OutboxProcessor<R, Q> {
             Ok(()) => {
                 // Task successfully submitted to queue; mark as processed in outbox.
                 if let Err(e) = self.reader.mark_processed(sequence_id).await {
-                    error!(
+                    warn!(
                         sequence_id = sequence_id,
                         error = %e,
-                        "failed to mark task as processed in outbox"
+                        "failed to mark task as processed in outbox; task may be resubmitted"
                     );
                 } else {
                     info!(

--- a/crates/proof/prover-service/outbox/src/processor.rs
+++ b/crates/proof/prover-service/outbox/src/processor.rs
@@ -1,0 +1,106 @@
+use std::time::Duration;
+
+use tokio::time;
+use tracing::{debug, error, info};
+
+use crate::{OutboxReader, OutboxTask, TaskQueue};
+
+/// Orchestrates the outbox pattern: polls for tasks and submits them for processing.
+pub struct OutboxProcessor<R: OutboxReader, Q: TaskQueue> {
+    reader: R,
+    queue: Q,
+    poll_interval_secs: u64,
+    batch_size: i64,
+}
+
+impl<R: OutboxReader, Q: TaskQueue> std::fmt::Debug for OutboxProcessor<R, Q> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("OutboxProcessor")
+            .field("poll_interval_secs", &self.poll_interval_secs)
+            .field("batch_size", &self.batch_size)
+            .finish()
+    }
+}
+
+impl<R: OutboxReader, Q: TaskQueue> OutboxProcessor<R, Q> {
+    /// Create a new processor.
+    pub const fn new(reader: R, queue: Q, poll_interval_secs: u64, batch_size: i64) -> Self {
+        Self { reader, queue, poll_interval_secs, batch_size }
+    }
+
+    /// Run the processor loop indefinitely.
+    pub async fn run(&self) {
+        info!(
+            poll_interval_secs = self.poll_interval_secs,
+            batch_size = self.batch_size,
+            "starting outbox processor"
+        );
+
+        let mut interval = time::interval(Duration::from_secs(self.poll_interval_secs));
+
+        loop {
+            interval.tick().await;
+
+            if let Err(e) = self.process_batch().await {
+                error!(error = %e, "failed to process outbox batch");
+            }
+        }
+    }
+
+    /// Poll and submit one batch of outbox tasks.
+    pub async fn process_batch(&self) -> anyhow::Result<()> {
+        let tasks = self.reader.poll_tasks(self.batch_size).await?;
+
+        if tasks.is_empty() {
+            return Ok(());
+        }
+
+        debug!(count = tasks.len(), "polled outbox tasks");
+
+        for task in tasks {
+            self.process_task(task).await;
+        }
+
+        Ok(())
+    }
+
+    /// Submit one outbox task and update its processing state.
+    pub async fn process_task(&self, task: OutboxTask) {
+        let sequence_id = task.sequence_id;
+        let proof_request_id = task.proof_request_id;
+
+        match self.queue.submit(task).await {
+            Ok(()) => {
+                // Task successfully submitted to queue; mark as processed in outbox.
+                if let Err(e) = self.reader.mark_processed(sequence_id).await {
+                    error!(
+                        sequence_id = sequence_id,
+                        error = %e,
+                        "failed to mark task as processed in outbox"
+                    );
+                } else {
+                    info!(
+                        sequence_id = sequence_id,
+                        proof_request_id = %proof_request_id,
+                        "marked outbox entry as processed"
+                    );
+                }
+            }
+            Err(e) => {
+                error!(
+                    sequence_id = sequence_id,
+                    proof_request_id = %proof_request_id,
+                    error = %e,
+                    "failed to submit task to queue"
+                );
+                if let Err(mark_err) = self.reader.mark_error(sequence_id, e.to_string()).await {
+                    error!(
+                        sequence_id = sequence_id,
+                        error = %mark_err,
+                        "failed to mark task as error"
+                    );
+                }
+            }
+        }
+    }
+}

--- a/crates/proof/prover-service/outbox/src/processor.rs
+++ b/crates/proof/prover-service/outbox/src/processor.rs
@@ -43,16 +43,21 @@ impl<R: OutboxReader, Q: TaskQueue> OutboxProcessor<R, Q> {
             tokio::select! {
                 biased;
                 _ = cancel.cancelled() => {
-                    info!("stopping outbox processor");
                     break;
                 }
-                _ = interval.tick() => {
-                    if let Err(e) = self.process_batch().await {
-                        error!(error = %e, "failed to process outbox batch");
-                    }
-                }
+                _ = interval.tick() => {}
+            }
+
+            if cancel.is_cancelled() {
+                break;
+            }
+
+            if let Err(e) = self.process_batch().await {
+                error!(error = %e, "failed to process outbox batch");
             }
         }
+
+        info!("stopping outbox processor");
     }
 
     /// Poll and submit one batch of outbox tasks.

--- a/crates/proof/prover-service/outbox/src/processor.rs
+++ b/crates/proof/prover-service/outbox/src/processor.rs
@@ -1,6 +1,7 @@
 use std::time::Duration;
 
 use tokio::time;
+use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info};
 
 use crate::{OutboxReader, OutboxTask, TaskQueue};
@@ -10,7 +11,7 @@ pub struct OutboxProcessor<R: OutboxReader, Q: TaskQueue> {
     reader: R,
     queue: Q,
     poll_interval_secs: u64,
-    batch_size: i64,
+    batch_size: u64,
 }
 
 impl<R: OutboxReader, Q: TaskQueue> std::fmt::Debug for OutboxProcessor<R, Q> {
@@ -24,12 +25,12 @@ impl<R: OutboxReader, Q: TaskQueue> std::fmt::Debug for OutboxProcessor<R, Q> {
 
 impl<R: OutboxReader, Q: TaskQueue> OutboxProcessor<R, Q> {
     /// Create a new processor.
-    pub const fn new(reader: R, queue: Q, poll_interval_secs: u64, batch_size: i64) -> Self {
+    pub const fn new(reader: R, queue: Q, poll_interval_secs: u64, batch_size: u64) -> Self {
         Self { reader, queue, poll_interval_secs, batch_size }
     }
 
-    /// Run the processor loop indefinitely.
-    pub async fn run(&self) {
+    /// Run the processor loop until `cancel` is cancelled.
+    pub async fn run(&self, cancel: CancellationToken) {
         info!(
             poll_interval_secs = self.poll_interval_secs,
             batch_size = self.batch_size,
@@ -39,10 +40,17 @@ impl<R: OutboxReader, Q: TaskQueue> OutboxProcessor<R, Q> {
         let mut interval = time::interval(Duration::from_secs(self.poll_interval_secs));
 
         loop {
-            interval.tick().await;
-
-            if let Err(e) = self.process_batch().await {
-                error!(error = %e, "failed to process outbox batch");
+            tokio::select! {
+                biased;
+                _ = cancel.cancelled() => {
+                    info!("stopping outbox processor");
+                    break;
+                }
+                _ = interval.tick() => {
+                    if let Err(e) = self.process_batch().await {
+                        error!(error = %e, "failed to process outbox batch");
+                    }
+                }
             }
         }
     }

--- a/crates/proof/prover-service/outbox/src/reader.rs
+++ b/crates/proof/prover-service/outbox/src/reader.rs
@@ -1,0 +1,27 @@
+use async_trait::async_trait;
+use serde_json::Value;
+use uuid::Uuid;
+
+/// A task read from the outbox.
+#[derive(Debug, Clone)]
+pub struct OutboxTask {
+    /// Sequence ID for ordering.
+    pub sequence_id: i64,
+    /// Associated proof request ID.
+    pub proof_request_id: Uuid,
+    /// Task parameters as JSON.
+    pub params: Value,
+}
+
+/// Abstraction for reading from outbox storage.
+#[async_trait]
+pub trait OutboxReader: Send + Sync + Clone {
+    /// Poll for unprocessed tasks up to `batch_size`.
+    async fn poll_tasks(&self, batch_size: i64) -> anyhow::Result<Vec<OutboxTask>>;
+
+    /// Mark a task as successfully processed.
+    async fn mark_processed(&self, sequence_id: i64) -> anyhow::Result<()>;
+
+    /// Mark a task as failed with an error message.
+    async fn mark_error(&self, sequence_id: i64, error_message: String) -> anyhow::Result<()>;
+}

--- a/crates/proof/prover-service/outbox/src/reader.rs
+++ b/crates/proof/prover-service/outbox/src/reader.rs
@@ -15,7 +15,7 @@ pub struct OutboxTask {
 
 /// Abstraction for reading from outbox storage.
 #[async_trait]
-pub trait OutboxReader: Send + Sync + Clone {
+pub trait OutboxReader: Send + Sync {
     /// Poll for unprocessed tasks up to `batch_size`.
     async fn poll_tasks(&self, batch_size: u64) -> anyhow::Result<Vec<OutboxTask>>;
 

--- a/crates/proof/prover-service/outbox/src/reader.rs
+++ b/crates/proof/prover-service/outbox/src/reader.rs
@@ -6,7 +6,7 @@ use uuid::Uuid;
 #[derive(Debug, Clone)]
 pub struct OutboxTask {
     /// Sequence ID for ordering.
-    pub sequence_id: i64,
+    pub sequence_id: u64,
     /// Associated proof request ID.
     pub proof_request_id: Uuid,
     /// Task parameters as JSON.
@@ -17,11 +17,11 @@ pub struct OutboxTask {
 #[async_trait]
 pub trait OutboxReader: Send + Sync + Clone {
     /// Poll for unprocessed tasks up to `batch_size`.
-    async fn poll_tasks(&self, batch_size: i64) -> anyhow::Result<Vec<OutboxTask>>;
+    async fn poll_tasks(&self, batch_size: u64) -> anyhow::Result<Vec<OutboxTask>>;
 
     /// Mark a task as successfully processed.
-    async fn mark_processed(&self, sequence_id: i64) -> anyhow::Result<()>;
+    async fn mark_processed(&self, sequence_id: u64) -> anyhow::Result<()>;
 
     /// Mark a task as failed with an error message.
-    async fn mark_error(&self, sequence_id: i64, error_message: String) -> anyhow::Result<()>;
+    async fn mark_error(&self, sequence_id: u64, error_message: String) -> anyhow::Result<()>;
 }

--- a/crates/proof/prover-service/outbox/src/task_queue.rs
+++ b/crates/proof/prover-service/outbox/src/task_queue.rs
@@ -1,0 +1,10 @@
+use async_trait::async_trait;
+
+use crate::OutboxTask;
+
+/// Abstraction for submitting tasks to a processing queue.
+#[async_trait]
+pub trait TaskQueue: Send + Sync + Clone {
+    /// Submit a task for processing.
+    async fn submit(&self, task: OutboxTask) -> anyhow::Result<()>;
+}

--- a/crates/proof/prover-service/outbox/src/task_queue.rs
+++ b/crates/proof/prover-service/outbox/src/task_queue.rs
@@ -3,6 +3,10 @@ use async_trait::async_trait;
 use crate::OutboxTask;
 
 /// Abstraction for submitting tasks to a processing queue.
+///
+/// Implementations should be idempotent for a given outbox task. If the
+/// processor successfully submits a task but cannot mark the outbox entry as
+/// processed, the same task may be submitted again on a later poll.
 #[async_trait]
 pub trait TaskQueue: Send + Sync {
     /// Submit a task for processing.

--- a/crates/proof/prover-service/outbox/src/task_queue.rs
+++ b/crates/proof/prover-service/outbox/src/task_queue.rs
@@ -4,7 +4,7 @@ use crate::OutboxTask;
 
 /// Abstraction for submitting tasks to a processing queue.
 #[async_trait]
-pub trait TaskQueue: Send + Sync + Clone {
+pub trait TaskQueue: Send + Sync {
     /// Submit a task for processing.
     async fn submit(&self, task: OutboxTask) -> anyhow::Result<()>;
 }


### PR DESCRIPTION
## Summary

Copies the zk prover outbox implementation into a new shared crate `base-prover-service-outbox` under `crates/proof/prover-service/outbox/`. This sets up a shared location for outbox processing utilities that can be reused across prover services.