### PR TITLE
Use hash-pinned L2 reads during derivation reset

### DIFF
--- a/crates/consensus/derive/src/attributes/stateful.rs
+++ b/crates/consensus/derive/src/attributes/stateful.rs
@@ -75,7 +75,7 @@ where
 
         let mut sys_config = self
             .config_fetcher
-            .system_config_by_number(l2_parent.block_info.number, Arc::clone(&self.rollup_cfg))
+            .system_config_by_hash(l2_parent.block_info.hash, Arc::clone(&self.rollup_cfg))
             .await
             .map_err(Into::into)?;
 
@@ -376,7 +376,7 @@ mod tests {
         let l1_cfg = Arc::new(Sepolia::l1_config());
         let l2_number = 1;
         let mut fetcher = TestSystemConfigL2Fetcher::default();
-        fetcher.insert(l2_number, SystemConfig::default());
+        fetcher.insert_by_hash(B256::ZERO, SystemConfig::default());
         let mut provider = TestChainProvider::default();
         let header = Header::default();
         let hash = header.hash_slow();
@@ -402,7 +402,7 @@ mod tests {
         let l1_cfg = Arc::new(Sepolia::l1_config());
         let l2_number = 1;
         let mut fetcher = TestSystemConfigL2Fetcher::default();
-        fetcher.insert(l2_number, SystemConfig::default());
+        fetcher.insert_by_hash(B256::ZERO, SystemConfig::default());
         let mut provider = TestChainProvider::default();
         let header = Header::default();
         let hash = header.hash_slow();
@@ -429,7 +429,7 @@ mod tests {
         let l1_cfg = Arc::new(Sepolia::l1_config());
         let l2_number = 1;
         let mut fetcher = TestSystemConfigL2Fetcher::default();
-        fetcher.insert(l2_number, SystemConfig::default());
+        fetcher.insert_by_hash(B256::ZERO, SystemConfig::default());
         let mut provider = TestChainProvider::default();
         let header = Header { timestamp, ..Default::default() };
         let hash = header.hash_slow();
@@ -454,6 +454,41 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_prepare_payload_uses_parent_hash_for_system_config() {
+        let block_time = 10;
+        let timestamp = 100;
+        let l2_parent_hash = B256::with_last_byte(0x42);
+        let cfg = Arc::new(RollupConfig { block_time, ..Default::default() });
+        let l1_cfg = Arc::new(Sepolia::l1_config());
+        let l2_number = 1;
+        let mut fetcher = TestSystemConfigL2Fetcher::default();
+        fetcher.insert_by_hash(
+            l2_parent_hash,
+            SystemConfig { gas_limit: 12_345, ..Default::default() },
+        );
+        let mut provider = TestChainProvider::default();
+        let header = Header { timestamp, ..Default::default() };
+        let hash = header.hash_slow();
+        provider.insert_header(hash, header);
+        let mut builder = StatefulAttributesBuilder::new(cfg, l1_cfg, fetcher, provider);
+        let epoch = BlockNumHash { hash, number: l2_number };
+        let l2_parent = L2BlockInfo {
+            block_info: BlockInfo {
+                hash: l2_parent_hash,
+                number: l2_number,
+                timestamp,
+                parent_hash: hash,
+            },
+            l1_origin: BlockNumHash { hash, number: l2_number },
+            seq_num: 0,
+        };
+
+        let payload = builder.prepare_payload_attributes(l2_parent, epoch).await.unwrap();
+
+        assert_eq!(payload.gas_limit, Some(12_345));
+    }
+
+    #[tokio::test]
     async fn test_prepare_payload_without_forks() {
         let block_time = 10;
         let timestamp = 100;
@@ -461,7 +496,7 @@ mod tests {
         let l1_cfg = Arc::new(Sepolia::l1_config());
         let l2_number = 1;
         let mut fetcher = TestSystemConfigL2Fetcher::default();
-        fetcher.insert(l2_number, SystemConfig::default());
+        fetcher.insert_by_hash(B256::ZERO, SystemConfig::default());
         let mut provider = TestChainProvider::default();
         let header = Header { timestamp, ..Default::default() };
         let prev_randao = header.mix_hash;
@@ -514,7 +549,7 @@ mod tests {
         let l1_cfg = Arc::new(Sepolia::l1_config());
         let l2_number = 1;
         let mut fetcher = TestSystemConfigL2Fetcher::default();
-        fetcher.insert(l2_number, SystemConfig::default());
+        fetcher.insert_by_hash(B256::ZERO, SystemConfig::default());
         let mut provider = TestChainProvider::default();
         let header = Header { timestamp, ..Default::default() };
         let prev_randao = header.mix_hash;
@@ -567,7 +602,7 @@ mod tests {
         let l1_cfg = Arc::new(Sepolia::l1_config());
         let l2_number = 1;
         let mut fetcher = TestSystemConfigL2Fetcher::default();
-        fetcher.insert(l2_number, SystemConfig::default());
+        fetcher.insert_by_hash(B256::ZERO, SystemConfig::default());
         let mut provider = TestChainProvider::default();
         let header = Header { timestamp, ..Default::default() };
         let parent_beacon_block_root = Some(header.parent_beacon_block_root.unwrap_or_default());
@@ -621,7 +656,7 @@ mod tests {
         let l1_cfg = Arc::new(Sepolia::l1_config());
         let l2_number = 1;
         let mut fetcher = TestSystemConfigL2Fetcher::default();
-        fetcher.insert(l2_number, SystemConfig::default());
+        fetcher.insert_by_hash(B256::ZERO, SystemConfig::default());
         let mut provider = TestChainProvider::default();
         let header = Header { timestamp, ..Default::default() };
         let prev_randao = header.mix_hash;
@@ -674,7 +709,7 @@ mod tests {
         let l1_cfg = Arc::new(Sepolia::l1_config());
         let l2_number = 1;
         let mut fetcher = TestSystemConfigL2Fetcher::default();
-        fetcher.insert(l2_number, SystemConfig::default());
+        fetcher.insert_by_hash(B256::ZERO, SystemConfig::default());
         let mut provider = TestChainProvider::default();
 
         // The epoch header's parent_hash must match l2_parent.l1_origin.hash.

--- a/crates/consensus/derive/src/pipeline/core.rs
+++ b/crates/consensus/derive/src/pipeline/core.rs
@@ -85,14 +85,14 @@ where
             }
             current = self
                 .l2_chain_provider
-                .l2_block_info_by_number(current.block_info.number - 1)
+                .l2_block_info_by_hash(current.block_info.parent_hash)
                 .await
                 .map_err(Into::into)?;
         }
 
         let system_config = self
             .l2_chain_provider
-            .system_config_by_number(current.block_info.number, Arc::clone(&self.rollup_config))
+            .system_config_by_hash(current.block_info.hash, Arc::clone(&self.rollup_config))
             .await
             .map_err(Into::into)?;
 
@@ -446,6 +446,9 @@ mod tests {
         const CODE_STOP_L1_ORIGIN: u64 = L1_HEAD - RollupConfig::GRANITE_CHANNEL_TIMEOUT;
         const BATCHER_AT_SPEC_STOP: Address = address!("BB00000000000000000000000000000000000002");
         const BATCHER_AT_CODE_STOP: Address = address!("AA00000000000000000000000000000000000001");
+        fn test_hash(n: u64) -> B256 {
+            B256::left_padding_from(&n.to_be_bytes())
+        }
 
         let rollup_config = Arc::new(RollupConfig {
             block_time: 2,
@@ -466,14 +469,11 @@ mod tests {
             l2_chain_provider.blocks.push(L2BlockInfo {
                 block_info: BlockInfo {
                     number: n,
-                    hash: B256::with_last_byte((n & 0xff) as u8),
-                    parent_hash: B256::ZERO,
+                    hash: test_hash(n),
+                    parent_hash: test_hash(n - 1),
                     timestamp,
                 },
-                l1_origin: BlockNumHash {
-                    number: n,
-                    hash: B256::with_last_byte(((n ^ 0x80) & 0xff) as u8),
-                },
+                l1_origin: BlockNumHash { number: n, hash: test_hash(n ^ 0x80) },
                 seq_num: 0,
             });
         }
@@ -492,14 +492,11 @@ mod tests {
         let safe_head = L2BlockInfo {
             block_info: BlockInfo {
                 number: L1_HEAD,
-                hash: B256::with_last_byte((L1_HEAD & 0xff) as u8),
-                parent_hash: B256::ZERO,
+                hash: test_hash(L1_HEAD),
+                parent_hash: test_hash(L1_HEAD - 1),
                 timestamp: L2_SAFE_HEAD_TIMESTAMP,
             },
-            l1_origin: BlockNumHash {
-                number: L1_HEAD,
-                hash: B256::with_last_byte(((L1_HEAD ^ 0x80) & 0xff) as u8),
-            },
+            l1_origin: BlockNumHash { number: L1_HEAD, hash: test_hash(L1_HEAD ^ 0x80) },
             seq_num: 0,
         };
 

--- a/crates/consensus/derive/src/test_utils/chain_providers.rs
+++ b/crates/consensus/derive/src/test_utils/chain_providers.rs
@@ -96,6 +96,9 @@ pub enum TestProviderError {
     /// The system config was not found.
     #[error("System config not found")]
     SystemConfigNotFound(u64),
+    /// The system config was not found by hash.
+    #[error("System config not found")]
+    SystemConfigHashNotFound(B256),
 }
 
 impl From<TestProviderError> for PipelineErrorKind {
@@ -209,6 +212,38 @@ impl L2ChainProvider for TestL2ChainProvider {
         number: u64,
         _: Arc<RollupConfig>,
     ) -> Result<SystemConfig, <Self as L2ChainProvider>::Error> {
+        self.system_configs
+            .get(&number)
+            .ok_or_else(|| TestProviderError::SystemConfigNotFound(number))
+            .cloned()
+    }
+
+    async fn l2_block_info_by_hash(
+        &mut self,
+        hash: B256,
+    ) -> Result<L2BlockInfo, <Self as L2ChainProvider>::Error> {
+        if self.short_circuit {
+            return self.blocks.first().copied().ok_or_else(|| TestProviderError::BlockNotFound);
+        }
+        self.blocks
+            .iter()
+            .find(|b| b.block_info.hash == hash)
+            .copied()
+            .ok_or_else(|| TestProviderError::BlockNotFound)
+    }
+
+    async fn system_config_by_hash(
+        &mut self,
+        hash: B256,
+        _: Arc<RollupConfig>,
+    ) -> Result<SystemConfig, <Self as L2ChainProvider>::Error> {
+        let number = self
+            .blocks
+            .iter()
+            .find(|b| b.block_info.hash == hash)
+            .map(|b| b.block_info.number)
+            .or_else(|| (hash == B256::ZERO).then_some(0))
+            .ok_or_else(|| TestProviderError::SystemConfigHashNotFound(hash))?;
         self.system_configs
             .get(&number)
             .ok_or_else(|| TestProviderError::SystemConfigNotFound(number))

--- a/crates/consensus/derive/src/test_utils/sys_config_fetcher.rs
+++ b/crates/consensus/derive/src/test_utils/sys_config_fetcher.rs
@@ -2,7 +2,7 @@
 
 use alloc::{boxed::Box, string::ToString, sync::Arc};
 
-use alloy_primitives::map::HashMap;
+use alloy_primitives::{B256, map::HashMap};
 use async_trait::async_trait;
 use base_common_consensus::BaseBlock;
 use base_common_genesis::{RollupConfig, SystemConfig};
@@ -19,6 +19,8 @@ use crate::{
 pub struct TestSystemConfigL2Fetcher {
     /// A map from [u64] block number to a [`SystemConfig`].
     pub system_configs: HashMap<u64, SystemConfig>,
+    /// A map from L2 block hash to a [`SystemConfig`].
+    pub system_configs_by_hash: HashMap<B256, SystemConfig>,
 }
 
 impl TestSystemConfigL2Fetcher {
@@ -27,9 +29,15 @@ impl TestSystemConfigL2Fetcher {
         self.system_configs.insert(number, config);
     }
 
+    /// Inserts a new system config into the mock fetcher with the given L2 block hash.
+    pub fn insert_by_hash(&mut self, hash: B256, config: SystemConfig) {
+        self.system_configs_by_hash.insert(hash, config);
+    }
+
     /// Clears all system configs from the mock fetcher.
     pub fn clear(&mut self) {
         self.system_configs.clear();
+        self.system_configs_by_hash.clear();
     }
 }
 
@@ -39,6 +47,9 @@ pub enum TestSystemConfigL2FetcherError {
     /// The system config was not found.
     #[error("system config not found: {0}")]
     NotFound(u64),
+    /// The system config was not found by hash.
+    #[error("system config not found: {0}")]
+    HashNotFound(B256),
 }
 
 impl From<TestSystemConfigL2FetcherError> for PipelineErrorKind {
@@ -73,5 +84,23 @@ impl L2ChainProvider for TestSystemConfigL2Fetcher {
             .get(&number)
             .copied()
             .ok_or_else(|| TestSystemConfigL2FetcherError::NotFound(number))
+    }
+
+    async fn l2_block_info_by_hash(
+        &mut self,
+        _: B256,
+    ) -> Result<L2BlockInfo, <Self as L2ChainProvider>::Error> {
+        unimplemented!()
+    }
+
+    async fn system_config_by_hash(
+        &mut self,
+        hash: B256,
+        _: Arc<RollupConfig>,
+    ) -> Result<SystemConfig, <Self as L2ChainProvider>::Error> {
+        self.system_configs_by_hash
+            .get(&hash)
+            .copied()
+            .ok_or_else(|| TestSystemConfigL2FetcherError::HashNotFound(hash))
     }
 }

--- a/crates/consensus/derive/src/traits/providers.rs
+++ b/crates/consensus/derive/src/traits/providers.rs
@@ -7,7 +7,7 @@ use alloy_consensus::{Header, Receipt, TxEnvelope};
 use alloy_primitives::B256;
 use async_trait::async_trait;
 use base_common_genesis::{RollupConfig, SystemConfig};
-use base_protocol::{BatchValidationProvider, BlockInfo};
+use base_protocol::{BatchValidationProvider, BlockInfo, L2BlockInfo};
 
 use crate::PipelineErrorKind;
 
@@ -45,6 +45,19 @@ pub trait L2ChainProvider: BatchValidationProviderDerive {
     async fn system_config_by_number(
         &mut self,
         number: u64,
+        rollup_config: Arc<RollupConfig>,
+    ) -> Result<SystemConfig, <Self as L2ChainProvider>::Error>;
+
+    /// Returns the [`L2BlockInfo`] by L2 block hash.
+    async fn l2_block_info_by_hash(
+        &mut self,
+        hash: B256,
+    ) -> Result<L2BlockInfo, <Self as L2ChainProvider>::Error>;
+
+    /// Returns the [`SystemConfig`] by L2 block hash.
+    async fn system_config_by_hash(
+        &mut self,
+        hash: B256,
         rollup_config: Arc<RollupConfig>,
     ) -> Result<SystemConfig, <Self as L2ChainProvider>::Error>;
 }

--- a/crates/consensus/providers/src/l2_chain_provider.rs
+++ b/crates/consensus/providers/src/l2_chain_provider.rs
@@ -181,6 +181,23 @@ impl AlloyL2ChainProvider {
         let rpc = RootProvider::<Base>::new(rpc_client);
         Self::new(rpc, rollup_config, cache_size)
     }
+
+    async fn block_by_hash(&mut self, hash: B256) -> Result<BaseBlock, AlloyL2ChainProviderError> {
+        Metrics::l2_chain_requests("l2_block_ref_by_hash").increment(1);
+
+        let block = base_metrics::time!(Metrics::request_duration("l2_block_ref_by_hash"), {
+            self.inner.get_block_by_hash(hash).full().await
+        })
+        .map_err(|e| {
+            Metrics::l2_chain_errors("l2_block_ref_by_hash").increment(1);
+            AlloyL2ChainProviderError::Transport(e)
+        })?
+        .ok_or(AlloyL2ChainProviderError::BlockNotFound(hash.into()))?;
+
+        self.verify_block_hash(block.header.hash, hash)?;
+
+        Ok(block.into_consensus().map_transactions(|t| t.inner.inner.into_inner()))
+    }
 }
 
 /// An error for the [`AlloyL2ChainProvider`].
@@ -191,13 +208,13 @@ pub enum AlloyL2ChainProviderError {
     Transport(#[from] RpcError<TransportErrorKind>),
     /// Failed to find a block.
     #[error("Failed to fetch block {0}")]
-    BlockNotFound(u64),
+    BlockNotFound(BlockId),
     /// Failed to construct [`L2BlockInfo`] from the block and genesis.
     #[error("Failed to construct L2BlockInfo from block {0} and genesis")]
-    L2BlockInfoConstruction(u64),
+    L2BlockInfoConstruction(BlockId),
     /// Failed to convert the block into a [`SystemConfig`].
     #[error("Failed to convert block {0} into SystemConfig")]
-    SystemConfigConversion(u64),
+    SystemConfigConversion(BlockId),
 }
 
 impl From<AlloyL2ChainProviderError> for PipelineErrorKind {
@@ -206,9 +223,7 @@ impl From<AlloyL2ChainProviderError> for PipelineErrorKind {
             AlloyL2ChainProviderError::Transport(e) => {
                 Self::Temporary(PipelineError::Provider(format!("Transport error: {e}")))
             }
-            AlloyL2ChainProviderError::BlockNotFound(number) => {
-                ResetError::BlockNotFound(alloy_eips::BlockId::Number(number.into())).reset()
-            }
+            AlloyL2ChainProviderError::BlockNotFound(id) => ResetError::BlockNotFound(id).reset(),
             AlloyL2ChainProviderError::L2BlockInfoConstruction(_) => Self::Temporary(
                 PipelineError::Provider("L2 block info construction failed".to_string()),
             ),
@@ -227,9 +242,9 @@ impl BatchValidationProvider for AlloyL2ChainProvider {
         let block = self
             .block_by_number(number)
             .await
-            .map_err(|_| AlloyL2ChainProviderError::BlockNotFound(number))?;
+            .map_err(|_| AlloyL2ChainProviderError::BlockNotFound(number.into()))?;
         L2BlockInfo::from_block_and_genesis(&block, &self.rollup_config.genesis)
-            .map_err(|_| AlloyL2ChainProviderError::L2BlockInfoConstruction(number))
+            .map_err(|_| AlloyL2ChainProviderError::L2BlockInfoConstruction(number.into()))
     }
 
     async fn block_by_number(&mut self, number: u64) -> Result<BaseBlock, Self::Error> {
@@ -246,7 +261,7 @@ impl BatchValidationProvider for AlloyL2ChainProvider {
             Metrics::l2_chain_errors("l2_block_ref_by_number").increment(1);
             AlloyL2ChainProviderError::Transport(e)
         })?
-        .ok_or(AlloyL2ChainProviderError::BlockNotFound(number))?
+        .ok_or(AlloyL2ChainProviderError::BlockNotFound(number.into()))?
         .into_consensus()
         .map_transactions(|t| t.inner.inner.into_inner());
 
@@ -267,9 +282,28 @@ impl L2ChainProvider for AlloyL2ChainProvider {
         let block = self
             .block_by_number(number)
             .await
-            .map_err(|_| AlloyL2ChainProviderError::BlockNotFound(number))?;
+            .map_err(|_| AlloyL2ChainProviderError::BlockNotFound(number.into()))?;
         to_system_config(&block, &rollup_config)
-            .map_err(|_| AlloyL2ChainProviderError::SystemConfigConversion(number))
+            .map_err(|_| AlloyL2ChainProviderError::SystemConfigConversion(number.into()))
+    }
+
+    async fn l2_block_info_by_hash(
+        &mut self,
+        hash: B256,
+    ) -> Result<L2BlockInfo, <Self as L2ChainProvider>::Error> {
+        let block = self.block_by_hash(hash).await?;
+        L2BlockInfo::from_block_and_genesis(&block, &self.rollup_config.genesis)
+            .map_err(|_| AlloyL2ChainProviderError::L2BlockInfoConstruction(hash.into()))
+    }
+
+    async fn system_config_by_hash(
+        &mut self,
+        hash: B256,
+        rollup_config: Arc<RollupConfig>,
+    ) -> Result<SystemConfig, <Self as L2ChainProvider>::Error> {
+        let block = self.block_by_hash(hash).await?;
+        to_system_config(&block, &rollup_config)
+            .map_err(|_| AlloyL2ChainProviderError::SystemConfigConversion(hash.into()))
     }
 }
 
@@ -288,16 +322,18 @@ mod tests {
         assert!(matches!(kind, PipelineErrorKind::Temporary(_)));
 
         // L2BlockInfoConstruction is a decode failure — transient.
-        let kind: PipelineErrorKind = AlloyL2ChainProviderError::L2BlockInfoConstruction(0).into();
+        let kind: PipelineErrorKind =
+            AlloyL2ChainProviderError::L2BlockInfoConstruction(0u64.into()).into();
         assert!(matches!(kind, PipelineErrorKind::Temporary(_)));
 
         // SystemConfigConversion is a decode failure — transient.
-        let kind: PipelineErrorKind = AlloyL2ChainProviderError::SystemConfigConversion(0).into();
+        let kind: PipelineErrorKind =
+            AlloyL2ChainProviderError::SystemConfigConversion(0u64.into()).into();
         assert!(matches!(kind, PipelineErrorKind::Temporary(_)));
 
         // L2 BlockNotFound: the pipeline only requests blocks that should exist on the
         // canonical chain. A missing L2 block means a reorg occurred — must Reset.
-        let kind: PipelineErrorKind = AlloyL2ChainProviderError::BlockNotFound(42).into();
+        let kind: PipelineErrorKind = AlloyL2ChainProviderError::BlockNotFound(42u64.into()).into();
         assert!(
             matches!(kind, PipelineErrorKind::Reset(_)),
             "L2 BlockNotFound must map to Reset (block disappeared due to reorg)"


### PR DESCRIPTION
## Problem
During the duplicate-blob investigation, base-consensus was observed entering a reset loop where the safe head stayed unchanged while the derivation pipeline failed with L2 BlockNotFound errors for blocks that existed onchain. The vulnerable path was using L2 block numbers to recover parent state during derivation reset and payload-attribute preparation.

L2 block numbers are not a stable identifier across a reorg or transient provider/engine inconsistency. If the local execution provider has not exposed the expected number mapping yet, or the number briefly resolves against a different view of the chain, a number-based lookup can fail or return the wrong block even though the hash-pinned parent that base-consensus is trying to derive from is known. That keeps derivation from making progress, which can keep the batcher channel open longer and contribute to repeated blob submission behavior.

This PR narrows the fix to matching op-node behavior for the affected reads: once base-consensus has a parent block hash, it uses that hash as the source of truth for parent L2 block info and system config reads. This does not mask a deeper provider issue if the execution provider also cannot serve the block by hash, but it removes the avoidable number-aliasing failure mode from the reset and attributes paths.

## Summary
- Fetch parent system config by L2 parent hash when preparing payload attributes.
- Walk reset state backward by parent hash and load the reset system config by hash.
- Add provider and test support for hash-based L2 block/system config reads.

## Tests
- cargo test -p base-consensus-derive -p base-consensus-providers -p base-consensus-node

type=routine
risk=low
impact=sev5