### PR TITLE
refactor(txpool): follow up EIP-8130 structural cleanups

### DIFF
--- a/crates/common/consensus/src/transaction/eip8130/constants.rs
+++ b/crates/common/consensus/src/transaction/eip8130/constants.rs
@@ -2,7 +2,7 @@
 //!
 //! [EIP-8130]: https://eips.ethereum.org/EIPS/eip-8130
 
-use alloy_primitives::{Address, U256};
+use alloy_primitives::{Address, U256, address};
 
 /// Container for [EIP-8130] protocol constants.
 ///
@@ -93,12 +93,12 @@ impl Eip8130Constants {
 
     /// Lower-bound verifier address. The `ECRECOVER_VERIFIER` native is fixed at
     /// `address(1)`; verifier addresses smaller than this are reserved.
-    pub const ECRECOVER_VERIFIER: Address = Address::with_last_byte(1);
+    pub const ECRECOVER_VERIFIER: Address = address!("0x0000000000000000000000000000000000000001");
 
     /// Sentinel verifier address indicating an owner slot has been revoked
     /// (`type(uint160).max`). Submitting authentication data prefixed with this
     /// verifier MUST be rejected.
-    pub const REVOKED_VERIFIER: Address = Address::new([0xff; 20]);
+    pub const REVOKED_VERIFIER: Address = address!("0xffffffffffffffffffffffffffffffffffffffff");
 
     /// Maximum number of `ConfigChange` entries the mempool accepts in a single
     /// transaction. The spec marks this as a node policy ("Nodes SHOULD enforce

--- a/crates/common/consensus/src/transaction/eip8130/signed.rs
+++ b/crates/common/consensus/src/transaction/eip8130/signed.rs
@@ -20,6 +20,8 @@ use alloy_eips::{
 };
 use alloy_primitives::{Address, B256, Bytes, ChainId, TxKind, U256, bytes::BufMut, keccak256};
 use alloy_rlp::{Decodable, Encodable, Header, length_of_length};
+#[cfg(feature = "reth")]
+use reth_primitives_traits::transaction::error::InvalidTransactionError;
 
 use crate::transaction::eip8130::{constants::Eip8130Constants, tx::TxEip8130};
 
@@ -129,6 +131,53 @@ impl Eip8130Signed {
     /// Returns the cached EIP-2718 transaction hash.
     pub const fn hash(&self) -> &B256 {
         &self.hash
+    }
+
+    /// Validates the static admission rules that depend only on the transaction
+    /// body and the local chain id.
+    ///
+    /// This keeps the chain-id, fee-cap ordering, and non-zero gas/fee-cap
+    /// checks colocated with [`TxEip8130`]'s signed wrapper so txpool callers
+    /// only need to orchestrate pool-specific concerns.
+    #[cfg(feature = "reth")]
+    pub const fn validate_static(
+        &self,
+        local_chain_id: u64,
+    ) -> Result<(), InvalidTransactionError> {
+        let tx = self.tx();
+        if tx.chain_id != local_chain_id {
+            return Err(InvalidTransactionError::ChainIdMismatch);
+        }
+        if tx.max_fee_per_gas < tx.max_priority_fee_per_gas {
+            return Err(InvalidTransactionError::TipAboveFeeCap);
+        }
+        if tx.gas_limit == 0 || tx.max_fee_per_gas == 0 {
+            return Err(InvalidTransactionError::TxTypeNotSupported);
+        }
+        Ok(())
+    }
+
+    /// Validates the timestamp-sensitive admission rules for nonce-bearing and
+    /// nonce-free transactions against a single caller-supplied `now` value.
+    ///
+    /// Txpool passes in one head-block timestamp snapshot so both branches see
+    /// the same wall-clock value even if the tip updates concurrently.
+    #[cfg(feature = "reth")]
+    pub fn validate_timestamp(&self, now: u64) -> Result<(), InvalidTransactionError> {
+        let tx = self.tx();
+        if tx.nonce_key == Eip8130Constants::NONCE_KEY_MAX {
+            if tx.nonce_sequence != 0 || tx.expiry == 0 {
+                return Err(InvalidTransactionError::TxTypeNotSupported);
+            }
+            if tx.expiry <= now
+                || tx.expiry > now.saturating_add(Eip8130Constants::NONCE_FREE_MAX_EXPIRY_WINDOW)
+            {
+                return Err(InvalidTransactionError::TxTypeNotSupported);
+            }
+        } else if tx.expiry != 0 && tx.expiry <= now {
+            return Err(InvalidTransactionError::TxTypeNotSupported);
+        }
+        Ok(())
     }
 
     fn recompute_hash(&self) -> B256 {

--- a/crates/execution/txpool/src/validator.rs
+++ b/crates/execution/txpool/src/validator.rs
@@ -228,33 +228,13 @@ where
         if !origin.is_external() {
             return Err(InvalidTransactionError::TxTypeNotSupported.into());
         }
-        let tx = signed.tx();
         let local_chain_id = self.inner.chain_spec().chain().id();
-        if tx.chain_id != local_chain_id {
-            return Err(InvalidTransactionError::ChainIdMismatch.into());
-        }
-        if tx.max_fee_per_gas < tx.max_priority_fee_per_gas {
-            return Err(InvalidTransactionError::TipAboveFeeCap.into());
-        }
-        if tx.gas_limit == 0 || tx.max_fee_per_gas == 0 {
-            return Err(InvalidTransactionError::TxTypeNotSupported.into());
-        }
+        signed.validate_static(local_chain_id).map_err(InvalidPoolTransactionError::from)?;
         // Single read of the head-block timestamp so both branches see the
         // same value even when `on_new_head_block` updates the atomic
         // concurrently.
         let now = self.block_timestamp();
-        if tx.nonce_key == Eip8130Constants::NONCE_KEY_MAX {
-            if tx.nonce_sequence != 0 || tx.expiry == 0 {
-                return Err(InvalidTransactionError::TxTypeNotSupported.into());
-            }
-            if tx.expiry <= now
-                || tx.expiry > now.saturating_add(Eip8130Constants::NONCE_FREE_MAX_EXPIRY_WINDOW)
-            {
-                return Err(InvalidTransactionError::TxTypeNotSupported.into());
-            }
-        } else if tx.expiry != 0 && tx.expiry <= now {
-            return Err(InvalidTransactionError::TxTypeNotSupported.into());
-        }
+        signed.validate_timestamp(now).map_err(InvalidPoolTransactionError::from)?;
         Self::validate_sender_auth(signed)?;
         Self::validate_payer_auth(signed)?;
         Self::validate_account_changes(signed, local_chain_id)?;


### PR DESCRIPTION
## Summary
- switch `ECRECOVER_VERIFIER` and `REVOKED_VERIFIER` to `address!` literals for readability
- move the EIP-8130 chain-id / fee-cap / gas-limit structural checks onto `Eip8130Signed::validate_static`
- move the EIP-8130 expiry / nonce-free timestamp checks onto `Eip8130Signed::validate_timestamp`, keeping txpool responsible only for origin gating and pool-specific auth/account-change checks

## Validation
- `cargo +nightly fmt --check`
- `cargo test -p base-execution-txpool eip8130`
- `cargo test -p base-common-consensus eip8130`
- `cargo clippy --workspace -- -D warnings`
- `cargo check --workspace --all-features --exclude devnet`