### PR TITLE
ci(release): Limit ARM Binary Build Parallelism

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -86,12 +86,15 @@ jobs:
 
       - name: Build binaries
         run: |
-          cargo_args=()
+          cargo_args=(--locked --profile maxperf)
+          if [[ "${{ matrix.target.triple }}" == "aarch64-unknown-linux-gnu" ]]; then
+            cargo_args+=(--jobs 2)
+          fi
           while IFS= read -r bin; do
             [[ -n "$bin" ]] || continue
             cargo_args+=(--bin "$bin")
           done <<< "${RELEASE_BINS}"
-          cargo build --locked --profile maxperf "${cargo_args[@]}"
+          cargo build "${cargo_args[@]}"
 
       - name: Package binaries
         run: |


### PR DESCRIPTION
## Summary

The Create RC run for `releases/v1.0.0` lost communication with the hosted `ubuntu-24.04-arm` runner during the maxperf binary build. The x86_64 binary build completed signing and attestation successfully, so this is scoped to ARM release build stability rather than GPG signing.

This caps cargo parallelism to `--jobs 2` only for the `aarch64-unknown-linux-gnu` release binary build. Other release targets keep the existing default cargo parallelism.

## Validation

- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 .github/workflows/create-rc.yml .github/workflows/publish-release.yml .github/workflows/build-release.yml`
- `git diff --check`