### PR TITLE
feat(infra): Add Beryl Upgrade Checks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6393,6 +6393,7 @@ dependencies = [
  "base-common-flashblocks",
  "base-common-genesis",
  "base-common-network",
+ "base-common-precompiles",
  "base-consensus-gossip",
  "base-consensus-rpc",
  "base-protocol",

--- a/crates/infra/basectl/Cargo.toml
+++ b/crates/infra/basectl/Cargo.toml
@@ -20,6 +20,7 @@ alloy-contract = { workspace = true }
 base-common-chains = { workspace = true }
 base-common-network = { workspace = true }
 base-consensus-gossip = { workspace = true }
+base-common-precompiles = { workspace = true }
 base-common-flashblocks = { workspace = true }
 url = { workspace = true, features = ["serde"] }
 serde = { workspace = true, features = ["std"] }

--- a/crates/infra/basectl/src/app/views/upgrades.rs
+++ b/crates/infra/basectl/src/app/views/upgrades.rs
@@ -125,11 +125,15 @@ fn user_config_rpc(name: &str) -> Option<String> {
     Some(parsed.rpc.to_string())
 }
 
+fn devnet_rpc() -> String {
+    "http://localhost:7545/".to_string()
+}
+
 fn all_chains() -> [ChainUpgrades; 4] {
     [
         ChainUpgrades {
             display_name: "Devnet",
-            rpc: user_config_rpc("devnet"),
+            rpc: user_config_rpc("devnet").or_else(|| Some(devnet_rpc())),
             specs: specs_from_config(ChainConfig::devnet()),
         },
         ChainUpgrades {
@@ -204,10 +208,17 @@ fn check_names_for(hardfork: &str) -> &'static [&'static str] {
     }
 }
 
+fn has_checks(hardfork: &str) -> bool {
+    !check_names_for(hardfork).is_empty()
+}
+
+fn checkable_specs_display(chain: &ChainUpgrades) -> Vec<&UpgradeSpec> {
+    chain.specs.iter().filter(|spec| has_checks(spec.name)).rev().collect()
+}
+
 /// Returns the hardfork whose checks should be shown for this chain.
 fn target_hardfork(chain: &ChainUpgrades, now: u64) -> Option<&'static str> {
-    let check_specs: Vec<_> =
-        chain.specs.iter().filter(|spec| !check_names_for(spec.name).is_empty()).collect();
+    let check_specs: Vec<_> = chain.specs.iter().filter(|spec| has_checks(spec.name)).collect();
 
     if let Some(upcoming) =
         check_specs.iter().find(|spec| spec.timestamp.is_some_and(|timestamp| timestamp > now))
@@ -282,6 +293,7 @@ impl ChecksPanel {
         let (tx, rx) = mpsc::channel(64);
         let chain_changed = self.chain_idx != Some(chain_idx);
         let hardfork_changed = self.hardfork != Some(hardfork);
+        let mode_changed = self.mode != Some(mode);
         self.chain_idx = Some(chain_idx);
         self.hardfork = Some(hardfork);
         self.mode = Some(mode);
@@ -290,7 +302,7 @@ impl ChecksPanel {
         // Preserve previous results across auto-refreshes so the table updates
         // in-place rather than blanking on every tick. Only clear when the
         // target context actually changed.
-        if chain_changed || hardfork_changed {
+        if chain_changed || hardfork_changed || mode_changed {
             self.results.clear();
         }
         self.running = true;
@@ -414,6 +426,7 @@ fn fmt_elapsed(elapsed_secs: u64) -> String {
 
 const KEYBINDINGS: &[Keybinding] = &[
     Keybinding { key: "←/→", description: "Switch chain" },
+    Keybinding { key: "↑/↓", description: "Select checks upgrade" },
     Keybinding { key: "1-4", description: "Jump to chain" },
     Keybinding { key: "r", description: "Run checks now" },
     Keybinding { key: "a", description: "Toggle auto-refresh" },
@@ -429,6 +442,7 @@ const AUTO_REFRESH_INTERVAL: Duration = Duration::from_secs(2);
 pub struct UpgradesView {
     chains: [ChainUpgrades; 4],
     selected_chain: usize,
+    selected_check_hardforks: [Option<&'static str>; 4],
     tick_count: u64,
     checks: ChecksPanel,
     /// When true, re-run the activation checks on the configured cadence
@@ -448,6 +462,7 @@ impl UpgradesView {
         Self {
             chains: all_chains(),
             selected_chain: 0,
+            selected_check_hardforks: [None; 4],
             tick_count: 0,
             checks: ChecksPanel {
                 chain_idx: None,
@@ -470,9 +485,10 @@ impl UpgradesView {
     fn start_checks(&mut self, resources: &Resources) {
         self.apply_live_hardforks(resources);
         let now = now_unix();
+        let selected_hardfork = self.selected_check_hardfork(now);
         let chain = &self.chains[self.selected_chain];
-        let Some(spec) = target_hardfork(chain, now)
-            .and_then(|name| chain.specs.iter().find(|s| s.name == name))
+        let Some(spec) =
+            selected_hardfork.and_then(|name| chain.specs.iter().find(|s| s.name == name))
         else {
             return;
         };
@@ -481,6 +497,38 @@ impl UpgradesView {
             if ts > now { CheckMode::Before } else { CheckMode::After }
         });
         self.checks.start(self.selected_chain, rpc, spec.name, mode);
+    }
+
+    fn selected_check_hardfork(&self, now: u64) -> Option<&'static str> {
+        let chain = &self.chains[self.selected_chain];
+        self.selected_check_hardforks[self.selected_chain]
+            .filter(|name| chain.specs.iter().any(|spec| spec.name == *name && has_checks(name)))
+            .or_else(|| target_hardfork(chain, now))
+    }
+
+    fn move_selected_check_hardfork(&mut self, resources: &Resources, direction: i8) {
+        self.apply_live_hardforks(resources);
+        let now = now_unix();
+        let current = self.selected_check_hardfork(now);
+        let checkable: Vec<_> = checkable_specs_display(&self.chains[self.selected_chain])
+            .into_iter()
+            .map(|spec| spec.name)
+            .collect();
+        let Some(last_index) = checkable.len().checked_sub(1) else { return };
+
+        let current_index =
+            current.and_then(|name| checkable.iter().position(|candidate| *candidate == name));
+        let current_index = current_index.unwrap_or(0);
+        let next_index = match direction {
+            -1 => current_index.saturating_sub(1),
+            1 => (current_index + 1).min(last_index),
+            _ => current_index,
+        };
+        let next = checkable[next_index];
+        if self.selected_check_hardforks[self.selected_chain] != Some(next) {
+            self.selected_check_hardforks[self.selected_chain] = Some(next);
+            self.checks.reset();
+        }
     }
 
     fn apply_live_hardforks(&mut self, resources: &Resources) {
@@ -520,6 +568,12 @@ impl View for UpgradesView {
                     self.selected_chain += 1;
                     self.checks.reset();
                 }
+            }
+            KeyCode::Up | KeyCode::Char('k') => {
+                self.move_selected_check_hardfork(resources, -1);
+            }
+            KeyCode::Down | KeyCode::Char('j') => {
+                self.move_selected_check_hardfork(resources, 1);
             }
             KeyCode::Char(c @ '1'..='4') => {
                 let idx = (c as usize) - ('1' as usize);
@@ -601,6 +655,7 @@ impl View for UpgradesView {
         };
 
         render_chain_tabs(frame, outer[0], &self.chains, self.selected_chain);
+        let selected_hardfork = self.selected_check_hardfork(now);
 
         match upcoming {
             Some((name, ts)) => {
@@ -628,14 +683,13 @@ impl View for UpgradesView {
             .constraints([Constraint::Percentage(38), Constraint::Percentage(62)])
             .split(outer[2]);
 
-        render_history(frame, bottom[0], chain, now);
-        let active_hf = target_hardfork(chain, now);
+        render_history(frame, bottom[0], chain, now, selected_hardfork);
         render_checks_panel(
             frame,
             bottom[1],
             &self.checks,
             self.tick_count,
-            active_hf,
+            selected_hardfork,
             self.auto_refresh,
         );
         render_footer(frame, outer[3], self.checks.running, self.auto_refresh);
@@ -811,7 +865,13 @@ fn render_tbd(frame: &mut Frame<'_>, area: Rect) {
     frame.render_widget(Paragraph::new(lines).block(block).alignment(Alignment::Center), area);
 }
 
-fn render_history(frame: &mut Frame<'_>, area: Rect, chain: &ChainUpgrades, now: u64) {
+fn render_history(
+    frame: &mut Frame<'_>,
+    area: Rect,
+    chain: &ChainUpgrades,
+    now: u64,
+    selected_hardfork: Option<&'static str>,
+) {
     let block = Block::default()
         .title(" Upgrade History ")
         .borders(Borders::ALL)
@@ -822,6 +882,9 @@ fn render_history(frame: &mut Frame<'_>, area: Rect, chain: &ChainUpgrades, now:
         .iter()
         .rev()
         .map(|spec| {
+            let selected = selected_hardfork == Some(spec.name);
+            let upgrade_name =
+                if selected { format!("▶ {}", spec.name) } else { format!("  {}", spec.name) };
             let (date_str, status_str, status_color) = match spec.timestamp {
                 None => ("-".to_string(), "− TBD".to_string(), Color::DarkGray),
                 Some(ts) if ts <= now => {
@@ -830,11 +893,16 @@ fn render_history(frame: &mut Frame<'_>, area: Rect, chain: &ChainUpgrades, now:
                 Some(ts) => (fmt_timestamp(ts), "⏳ Upcoming".to_string(), Color::Yellow),
             };
             Row::new([
-                Cell::from(spec.name).style(Style::default().fg(Color::White)),
+                Cell::from(upgrade_name).style(Style::default().fg(Color::White)),
                 Cell::from(date_str).style(Style::default().fg(Color::Gray)),
                 Cell::from(status_str)
                     .style(Style::default().fg(status_color).add_modifier(Modifier::BOLD)),
             ])
+            .style(if selected {
+                Style::default().bg(Color::Rgb(20, 35, 60))
+            } else {
+                Style::default()
+            })
         })
         .collect();
 
@@ -857,12 +925,26 @@ fn render_checks_panel(
 
     // Panel is idle and has never been run.
     if panel.chain_idx.is_none() {
-        let hf_name = active_hardfork.unwrap_or("?");
+        let Some(hf_name) = active_hardfork else {
+            let block = Block::default()
+                .title(" Checks ")
+                .borders(Borders::ALL)
+                .border_style(Style::default().fg(Color::DarkGray));
+            frame.render_widget(
+                Paragraph::new("No activation checks are defined for this network.")
+                    .block(block)
+                    .alignment(Alignment::Center),
+                area,
+            );
+            return;
+        };
         let check_list = check_names_for(hf_name).join(" · ");
         let hint = if auto_refresh {
-            format!("Auto-refreshing {hf_name} checks every 2s — [a] to disable")
+            format!("Auto-refreshing {hf_name} checks every 2s · ↑/↓ to change · [a] to disable")
         } else {
-            format!("Press [r] to run {hf_name} post-upgrade checks · [a] to enable auto-refresh")
+            format!(
+                "Press [r] to run {hf_name} checks · ↑/↓ to change · [a] to enable auto-refresh"
+            )
         };
         let lines: Vec<Line<'static>> = vec![
             Line::from(""),
@@ -989,6 +1071,10 @@ fn render_footer(frame: &mut Frame<'_>, area: Rect, checks_running: bool, auto_r
         Span::styled("[←/→]", key_style),
         Span::raw(" "),
         Span::styled("switch chain", desc_style),
+        sep.clone(),
+        Span::styled("[↑/↓]", key_style),
+        Span::raw(" "),
+        Span::styled("select checks", desc_style),
         sep.clone(),
         Span::styled("[1-4]", key_style),
         Span::raw(" "),
@@ -1668,8 +1754,10 @@ async fn run_azul_checks_streaming(rpc_url: String, tx: mpsc::Sender<CheckUpdate
 #[cfg(test)]
 mod tests {
     use base_common_genesis::HardforkConfig;
+    use crossterm::event::KeyModifiers;
 
     use super::*;
+    use crate::config::MonitoringConfig;
 
     #[test]
     fn unscheduled_beryl_follows_active_azul_checks() {
@@ -1712,5 +1800,32 @@ mod tests {
         assert!(chain_name_matches_loaded("Devnet", "devnet"));
         assert!(chain_name_matches_loaded("Devnet", "local-vibenet"));
         assert!(!chain_name_matches_loaded("Mainnet", "devnet"));
+    }
+
+    #[test]
+    fn checkable_specs_are_display_ordered() {
+        let chain = ChainUpgrades {
+            display_name: "Devnet",
+            rpc: None,
+            specs: specs_from_config(ChainConfig::devnet()),
+        };
+        let names: Vec<_> =
+            checkable_specs_display(&chain).into_iter().map(|spec| spec.name).collect();
+
+        assert_eq!(names, vec!["Beryl", "Azul", "Jovian"]);
+    }
+
+    #[test]
+    fn arrow_keys_select_check_hardfork() {
+        let mut view = UpgradesView::new();
+        let mut resources = Resources::new(MonitoringConfig::mainnet());
+
+        assert_eq!(view.selected_check_hardfork(100), Some("Beryl"));
+
+        view.handle_key(KeyEvent::new(KeyCode::Down, KeyModifiers::NONE), &mut resources);
+        assert_eq!(view.selected_check_hardfork(100), Some("Azul"));
+
+        view.handle_key(KeyEvent::new(KeyCode::Up, KeyModifiers::NONE), &mut resources);
+        assert_eq!(view.selected_check_hardfork(100), Some("Beryl"));
     }
 }

--- a/crates/infra/basectl/src/app/views/upgrades.rs
+++ b/crates/infra/basectl/src/app/views/upgrades.rs
@@ -76,8 +76,9 @@ struct ChainUpgrades {
 
 impl ChainUpgrades {
     fn set_timestamp(&mut self, name: &'static str, timestamp: Option<u64>) {
+        let Some(timestamp) = timestamp else { return };
         if let Some(spec) = self.specs.iter_mut().find(|spec| spec.name == name) {
-            spec.timestamp = timestamp;
+            spec.timestamp = Some(timestamp);
         }
     }
 
@@ -157,10 +158,13 @@ fn all_chains() -> [ChainUpgrades; 4] {
 }
 
 fn chain_name_matches_loaded(display_name: &str, loaded_name: &str) -> bool {
-    let loaded = loaded_name.to_lowercase();
-    let selected = display_name.to_lowercase();
-    loaded == selected
-        || (selected == "devnet" && (loaded.contains("devnet") || loaded.contains("vibenet")))
+    loaded_name.eq_ignore_ascii_case(display_name)
+        || (display_name.eq_ignore_ascii_case("devnet") && loaded_name_is_devnet_alias(loaded_name))
+}
+
+fn loaded_name_is_devnet_alias(loaded_name: &str) -> bool {
+    const DEVNET_ALIASES: &[&str] = &["devnet", "vibenet", "local-devnet", "local-vibenet"];
+    DEVNET_ALIASES.iter().any(|alias| loaded_name.eq_ignore_ascii_case(alias))
 }
 
 // ── Check types ───────────────────────────────────────────────────────────────
@@ -231,8 +235,12 @@ fn target_hardfork(chain: &ChainUpgrades, now: u64) -> Option<&'static str> {
         .rposition(|spec| spec.timestamp.is_some_and(|timestamp| timestamp <= now));
 
     latest_active.map_or_else(
-        || check_specs.iter().find(|spec| spec.timestamp.is_some()).map(|spec| spec.name),
-        |index| check_specs.get(index + 1).or_else(|| check_specs.get(index)).map(|spec| spec.name),
+        || check_specs.last().map(|spec| spec.name),
+        |index| {
+            // Prefer the next checkable hardfork when it exists, even before it
+            // is scheduled. At the frontier, keep showing the active hardfork.
+            check_specs.get(index + 1).or_else(|| check_specs.get(index)).map(|spec| spec.name)
+        },
     )
 }
 
@@ -485,25 +493,30 @@ impl UpgradesView {
     fn start_checks(&mut self, resources: &Resources) {
         self.apply_live_hardforks(resources);
         let now = now_unix();
-        let selected_hardfork = self.selected_check_hardfork(now);
-        let chain = &self.chains[self.selected_chain];
-        let Some(spec) =
-            selected_hardfork.and_then(|name| chain.specs.iter().find(|s| s.name == name))
+        let Some((hardfork, timestamp)) =
+            self.selected_check_spec(now).map(|spec| (spec.name, spec.timestamp))
         else {
             return;
         };
+        let Some(ts) = timestamp else {
+            self.checks.reset();
+            return;
+        };
         let Some(rpc) = self.rpc_for_selected(resources) else { return };
-        let mode = spec.timestamp.map_or(CheckMode::After, |ts| {
-            if ts > now { CheckMode::Before } else { CheckMode::After }
-        });
-        self.checks.start(self.selected_chain, rpc, spec.name, mode);
+        let mode = if ts > now { CheckMode::Before } else { CheckMode::After };
+        self.checks.start(self.selected_chain, rpc, hardfork, mode);
     }
 
-    fn selected_check_hardfork(&self, now: u64) -> Option<&'static str> {
+    fn selected_check_spec(&self, now: u64) -> Option<&UpgradeSpec> {
         let chain = &self.chains[self.selected_chain];
         self.selected_check_hardforks[self.selected_chain]
             .filter(|name| chain.specs.iter().any(|spec| spec.name == *name && has_checks(name)))
             .or_else(|| target_hardfork(chain, now))
+            .and_then(|name| chain.specs.iter().find(|spec| spec.name == name))
+    }
+
+    fn selected_check_hardfork(&self, now: u64) -> Option<&'static str> {
+        self.selected_check_spec(now).map(|spec| spec.name)
     }
 
     fn move_selected_check_hardfork(&mut self, resources: &Resources, direction: i8) {
@@ -596,10 +609,13 @@ impl View for UpgradesView {
     fn tick(&mut self, resources: &mut Resources) -> Action {
         self.tick_count = self.tick_count.wrapping_add(1);
         self.checks.poll();
+        self.apply_live_hardforks(resources);
 
         if self.auto_refresh && !self.checks.running {
             let due = self.checks.last_run_at.is_none_or(|t| t.elapsed() >= AUTO_REFRESH_INTERVAL);
-            if due {
+            let scheduled =
+                self.selected_check_spec(now_unix()).is_some_and(|spec| spec.timestamp.is_some());
+            if due && scheduled {
                 self.start_checks(resources);
             }
         }
@@ -607,8 +623,7 @@ impl View for UpgradesView {
         Action::None
     }
 
-    fn render(&mut self, frame: &mut Frame<'_>, area: Rect, resources: &Resources) {
-        self.apply_live_hardforks(resources);
+    fn render(&mut self, frame: &mut Frame<'_>, area: Rect, _resources: &Resources) {
         let now = now_unix();
         let chain = &self.chains[self.selected_chain];
 
@@ -655,7 +670,8 @@ impl View for UpgradesView {
         };
 
         render_chain_tabs(frame, outer[0], &self.chains, self.selected_chain);
-        let selected_hardfork = self.selected_check_hardfork(now);
+        let selected_check_spec = self.selected_check_spec(now);
+        let selected_hardfork = selected_check_spec.map(|spec| spec.name);
 
         match upcoming {
             Some((name, ts)) => {
@@ -689,7 +705,7 @@ impl View for UpgradesView {
             bottom[1],
             &self.checks,
             self.tick_count,
-            selected_hardfork,
+            selected_check_spec,
             self.auto_refresh,
         );
         render_footer(frame, outer[3], self.checks.running, self.auto_refresh);
@@ -918,14 +934,14 @@ fn render_checks_panel(
     area: Rect,
     panel: &ChecksPanel,
     tick: u64,
-    active_hardfork: Option<&'static str>,
+    selected_spec: Option<&UpgradeSpec>,
     auto_refresh: bool,
 ) {
     let spinner = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
 
     // Panel is idle and has never been run.
     if panel.chain_idx.is_none() {
-        let Some(hf_name) = active_hardfork else {
+        let Some(spec) = selected_spec else {
             let block = Block::default()
                 .title(" Checks ")
                 .borders(Borders::ALL)
@@ -938,6 +954,30 @@ fn render_checks_panel(
             );
             return;
         };
+        let hf_name = spec.name;
+        if spec.timestamp.is_none() {
+            let lines: Vec<Line<'static>> = vec![
+                Line::from(""),
+                Line::from(Span::styled(
+                    format!("{hf_name} is not scheduled for this network."),
+                    Style::default().fg(Color::DarkGray),
+                )),
+                Line::from(""),
+                Line::from(Span::styled(
+                    "Checks are skipped until an activation timestamp is configured.",
+                    Style::default().fg(Color::DarkGray),
+                )),
+            ];
+            let block = Block::default()
+                .title(format!(" {hf_name} Checks "))
+                .borders(Borders::ALL)
+                .border_style(Style::default().fg(Color::DarkGray));
+            frame.render_widget(
+                Paragraph::new(lines).block(block).alignment(Alignment::Center),
+                area,
+            );
+            return;
+        }
         let check_list = check_names_for(hf_name).join(" · ");
         let hint = if auto_refresh {
             format!("Auto-refreshing {hf_name} checks every 2s · ↑/↓ to change · [a] to disable")
@@ -1796,9 +1836,32 @@ mod tests {
     }
 
     #[test]
+    fn live_hardforks_do_not_clear_known_static_timestamps() {
+        let mut chain = ChainUpgrades {
+            display_name: "Mainnet",
+            rpc: None,
+            specs: specs_from_config(ChainConfig::mainnet()),
+        };
+        let delta = chain.specs.iter().find(|spec| spec.name == "Delta").unwrap().timestamp;
+
+        chain.apply_hardforks(&HardForkConfig {
+            base: HardforkConfig { azul: Some(20), beryl: None },
+            ..HardForkConfig::default()
+        });
+
+        assert_eq!(chain.specs.iter().find(|spec| spec.name == "Delta").unwrap().timestamp, delta);
+        assert_eq!(
+            chain.specs.iter().find(|spec| spec.name == "Azul").unwrap().timestamp,
+            Some(20)
+        );
+    }
+
+    #[test]
     fn devnet_selection_accepts_vibenet_configs() {
         assert!(chain_name_matches_loaded("Devnet", "devnet"));
+        assert!(chain_name_matches_loaded("Devnet", "LOCAL-VIBENET"));
         assert!(chain_name_matches_loaded("Devnet", "local-vibenet"));
+        assert!(!chain_name_matches_loaded("Devnet", "not-vibenet-really"));
         assert!(!chain_name_matches_loaded("Mainnet", "devnet"));
     }
 
@@ -1827,5 +1890,18 @@ mod tests {
 
         view.handle_key(KeyEvent::new(KeyCode::Up, KeyModifiers::NONE), &mut resources);
         assert_eq!(view.selected_check_hardfork(100), Some("Beryl"));
+    }
+
+    #[test]
+    fn unscheduled_selected_checks_do_not_start() {
+        let mut view = UpgradesView::new();
+        view.selected_chain = 3;
+        let resources = Resources::new(MonitoringConfig::mainnet());
+
+        assert_eq!(view.selected_check_hardfork(now_unix()), Some("Beryl"));
+        view.start_checks(&resources);
+
+        assert!(!view.checks.running);
+        assert!(view.checks.chain_idx.is_none());
     }
 }

--- a/crates/infra/basectl/src/app/views/upgrades.rs
+++ b/crates/infra/basectl/src/app/views/upgrades.rs
@@ -491,7 +491,6 @@ impl UpgradesView {
     /// Kick off an activation-check run for the currently selected chain, if
     /// the chain has a hardfork with defined checks and a usable RPC URL.
     fn start_checks(&mut self, resources: &Resources) {
-        self.apply_live_hardforks(resources);
         let now = now_unix();
         let Some((hardfork, timestamp)) =
             self.selected_check_spec(now).map(|spec| (spec.name, spec.timestamp))
@@ -519,8 +518,7 @@ impl UpgradesView {
         self.selected_check_spec(now).map(|spec| spec.name)
     }
 
-    fn move_selected_check_hardfork(&mut self, resources: &Resources, direction: i8) {
-        self.apply_live_hardforks(resources);
+    fn move_selected_check_hardfork(&mut self, direction: i8) {
         let now = now_unix();
         let current = self.selected_check_hardfork(now);
         let checkable: Vec<_> = checkable_specs_display(&self.chains[self.selected_chain])
@@ -583,10 +581,10 @@ impl View for UpgradesView {
                 }
             }
             KeyCode::Up | KeyCode::Char('k') => {
-                self.move_selected_check_hardfork(resources, -1);
+                self.move_selected_check_hardfork(-1);
             }
             KeyCode::Down | KeyCode::Char('j') => {
-                self.move_selected_check_hardfork(resources, 1);
+                self.move_selected_check_hardfork(1);
             }
             KeyCode::Char(c @ '1'..='4') => {
                 let idx = (c as usize) - ('1' as usize);

--- a/crates/infra/basectl/src/app/views/upgrades.rs
+++ b/crates/infra/basectl/src/app/views/upgrades.rs
@@ -204,14 +204,25 @@ fn check_names_for(hardfork: &str) -> &'static [&'static str] {
     }
 }
 
-/// Returns the last hardfork spec for a chain that has defined checks, or `None`.
-fn target_hardfork(chain: &ChainUpgrades) -> Option<&'static str> {
-    chain
-        .specs
+/// Returns the hardfork whose checks should be shown for this chain.
+fn target_hardfork(chain: &ChainUpgrades, now: u64) -> Option<&'static str> {
+    let check_specs: Vec<_> =
+        chain.specs.iter().filter(|spec| !check_names_for(spec.name).is_empty()).collect();
+
+    if let Some(upcoming) =
+        check_specs.iter().find(|spec| spec.timestamp.is_some_and(|timestamp| timestamp > now))
+    {
+        return Some(upcoming.name);
+    }
+
+    let latest_active = check_specs
         .iter()
-        .rev()
-        .find(|s| s.timestamp.is_some() && !check_names_for(s.name).is_empty())
-        .map(|s| s.name)
+        .rposition(|spec| spec.timestamp.is_some_and(|timestamp| timestamp <= now));
+
+    latest_active.map_or_else(
+        || check_specs.iter().find(|spec| spec.timestamp.is_some()).map(|spec| spec.name),
+        |index| check_specs.get(index + 1).or_else(|| check_specs.get(index)).map(|spec| spec.name),
+    )
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -460,14 +471,15 @@ impl UpgradesView {
         self.apply_live_hardforks(resources);
         let now = now_unix();
         let chain = &self.chains[self.selected_chain];
-        let Some(spec) =
-            target_hardfork(chain).and_then(|name| chain.specs.iter().find(|s| s.name == name))
+        let Some(spec) = target_hardfork(chain, now)
+            .and_then(|name| chain.specs.iter().find(|s| s.name == name))
         else {
             return;
         };
-        let ts = spec.timestamp.unwrap();
         let Some(rpc) = self.rpc_for_selected(resources) else { return };
-        let mode = if ts > now { CheckMode::Before } else { CheckMode::After };
+        let mode = spec.timestamp.map_or(CheckMode::After, |ts| {
+            if ts > now { CheckMode::Before } else { CheckMode::After }
+        });
         self.checks.start(self.selected_chain, rpc, spec.name, mode);
     }
 
@@ -617,7 +629,7 @@ impl View for UpgradesView {
             .split(outer[2]);
 
         render_history(frame, bottom[0], chain, now);
-        let active_hf = target_hardfork(chain);
+        let active_hf = target_hardfork(chain, now);
         render_checks_panel(
             frame,
             bottom[1],
@@ -1660,22 +1672,39 @@ mod tests {
     use super::*;
 
     #[test]
-    fn live_hardforks_make_beryl_the_devnet_check_target() {
+    fn unscheduled_beryl_follows_active_azul_checks() {
         let mut chain = ChainUpgrades {
             display_name: "Devnet",
             rpc: None,
             specs: specs_from_config(ChainConfig::devnet()),
         };
-        assert_eq!(target_hardfork(&chain), Some("Azul"));
+        assert_eq!(target_hardfork(&chain, 100), Some("Beryl"));
 
         chain.apply_hardforks(&HardForkConfig {
             base: HardforkConfig { azul: Some(10), beryl: Some(12) },
             ..HardForkConfig::default()
         });
 
-        assert_eq!(target_hardfork(&chain), Some("Beryl"));
+        assert_eq!(target_hardfork(&chain, 11), Some("Beryl"));
         let beryl = chain.specs.iter().find(|spec| spec.name == "Beryl").unwrap();
         assert_eq!(beryl.timestamp, Some(12));
+    }
+
+    #[test]
+    fn upcoming_azul_remains_target_before_beryl() {
+        let mut chain = ChainUpgrades {
+            display_name: "Mainnet",
+            rpc: None,
+            specs: specs_from_config(ChainConfig::mainnet()),
+        };
+        chain.apply_hardforks(&HardForkConfig {
+            jovian_time: Some(10),
+            base: HardforkConfig { azul: Some(20), beryl: None },
+            ..HardForkConfig::default()
+        });
+
+        assert_eq!(target_hardfork(&chain, 15), Some("Azul"));
+        assert_eq!(target_hardfork(&chain, 21), Some("Beryl"));
     }
 
     #[test]

--- a/crates/infra/basectl/src/app/views/upgrades.rs
+++ b/crates/infra/basectl/src/app/views/upgrades.rs
@@ -5,7 +5,11 @@ use std::{
     time::{Duration, Instant, SystemTime, UNIX_EPOCH},
 };
 
+use alloy_primitives::{Address, B256, hex};
+use alloy_sol_types::SolCall;
 use base_common_chains::ChainConfig;
+use base_common_genesis::HardForkConfig;
+use base_common_precompiles::{ActivationFeature, ActivationRegistryStorage, IActivationRegistry};
 use chrono::{DateTime, Utc};
 use crossterm::event::{KeyCode, KeyEvent};
 use jsonrpsee::{
@@ -70,6 +74,27 @@ struct ChainUpgrades {
     specs: Vec<UpgradeSpec>,
 }
 
+impl ChainUpgrades {
+    fn set_timestamp(&mut self, name: &'static str, timestamp: Option<u64>) {
+        if let Some(spec) = self.specs.iter_mut().find(|spec| spec.name == name) {
+            spec.timestamp = timestamp;
+        }
+    }
+
+    fn apply_hardforks(&mut self, hardforks: &HardForkConfig) {
+        self.set_timestamp("Delta", hardforks.delta_time);
+        self.set_timestamp("Canyon", hardforks.canyon_time);
+        self.set_timestamp("Ecotone", hardforks.ecotone_time);
+        self.set_timestamp("Fjord", hardforks.fjord_time);
+        self.set_timestamp("Granite", hardforks.granite_time);
+        self.set_timestamp("Holocene", hardforks.holocene_time);
+        self.set_timestamp("Isthmus", hardforks.isthmus_time);
+        self.set_timestamp("Jovian", hardforks.jovian_time);
+        self.set_timestamp("Azul", hardforks.base.azul);
+        self.set_timestamp("Beryl", hardforks.base.beryl);
+    }
+}
+
 fn specs_from_config(cfg: &ChainConfig) -> Vec<UpgradeSpec> {
     vec![
         UpgradeSpec { name: "Delta", timestamp: Some(cfg.delta_timestamp) },
@@ -127,6 +152,13 @@ fn all_chains() -> [ChainUpgrades; 4] {
     ]
 }
 
+fn chain_name_matches_loaded(display_name: &str, loaded_name: &str) -> bool {
+    let loaded = loaded_name.to_lowercase();
+    let selected = display_name.to_lowercase();
+    loaded == selected
+        || (selected == "devnet" && (loaded.contains("devnet") || loaded.contains("vibenet")))
+}
+
 // ── Check types ───────────────────────────────────────────────────────────────
 
 /// Expected check names for Azul, in execution order.
@@ -144,8 +176,28 @@ const AZUL_CHECK_NAMES: &[&str] = &[
 /// Expected check names for Jovian, in execution order.
 const JOVIAN_CHECK_NAMES: &[&str] = &["bn256Pairing limit", "extra data v1", "GPO implementation"];
 
+/// Expected check names for Beryl, in execution order.
+const BERYL_CHECK_NAMES: &[&str] = &[
+    "registry precompile",
+    "registry admin",
+    "B-20 token feature",
+    "B-20 factory feature",
+    "policy registry feature",
+    "B-20 stablecoin feature",
+    "B-20 security feature",
+];
+
+const BERYL_FEATURE_CHECKS: &[(&str, ActivationFeature)] = &[
+    ("B-20 token feature", ActivationFeature::B20Token),
+    ("B-20 factory feature", ActivationFeature::B20Factory),
+    ("policy registry feature", ActivationFeature::PolicyRegistry),
+    ("B-20 stablecoin feature", ActivationFeature::B20Stablecoin),
+    ("B-20 security feature", ActivationFeature::B20Security),
+];
+
 fn check_names_for(hardfork: &str) -> &'static [&'static str] {
     match hardfork {
+        "Beryl" => BERYL_CHECK_NAMES,
         "Azul" => AZUL_CHECK_NAMES,
         "Jovian" => JOVIAN_CHECK_NAMES,
         _ => &[],
@@ -405,6 +457,7 @@ impl UpgradesView {
     /// Kick off an activation-check run for the currently selected chain, if
     /// the chain has a hardfork with defined checks and a usable RPC URL.
     fn start_checks(&mut self, resources: &Resources) {
+        self.apply_live_hardforks(resources);
         let now = now_unix();
         let chain = &self.chains[self.selected_chain];
         let Some(spec) =
@@ -418,11 +471,17 @@ impl UpgradesView {
         self.checks.start(self.selected_chain, rpc, spec.name, mode);
     }
 
+    fn apply_live_hardforks(&mut self, resources: &Resources) {
+        let Some(hardforks) = resources.config.hardforks.as_ref() else { return };
+        let chain = &mut self.chains[self.selected_chain];
+        if chain_name_matches_loaded(chain.display_name, &resources.config.name) {
+            chain.apply_hardforks(hardforks);
+        }
+    }
+
     fn rpc_for_selected(&self, resources: &Resources) -> Option<String> {
         let chain = &self.chains[self.selected_chain];
-        let loaded = resources.config.name.to_lowercase();
-        let selected = chain.display_name.to_lowercase();
-        if loaded == selected || (selected == "devnet" && loaded.contains("devnet")) {
+        if chain_name_matches_loaded(chain.display_name, &resources.config.name) {
             Some(resources.config.rpc.to_string())
         } else {
             chain.rpc.clone()
@@ -482,7 +541,8 @@ impl View for UpgradesView {
         Action::None
     }
 
-    fn render(&mut self, frame: &mut Frame<'_>, area: Rect, _resources: &Resources) {
+    fn render(&mut self, frame: &mut Frame<'_>, area: Rect, resources: &Resources) {
+        self.apply_live_hardforks(resources);
         let now = now_unix();
         let chain = &self.chains[self.selected_chain];
 
@@ -873,7 +933,7 @@ fn render_checks_panel(
     let header = Row::new(["CHECK", "", "DETAIL"])
         .style(Style::default().fg(Color::DarkGray).add_modifier(Modifier::BOLD));
 
-    let widths = [Constraint::Length(20), Constraint::Length(5), Constraint::Min(8)];
+    let widths = [Constraint::Length(24), Constraint::Length(5), Constraint::Min(8)];
 
     let block = Block::default()
         .title(title)
@@ -1011,9 +1071,181 @@ async fn run_checks_streaming(
     tx: mpsc::Sender<CheckUpdate>,
 ) {
     match hardfork {
+        "Beryl" => run_beryl_checks_streaming(rpc_url, mode, tx).await,
         "Azul" => run_azul_checks_streaming(rpc_url, tx).await,
         "Jovian" => run_jovian_checks_streaming(rpc_url, mode, tx).await,
         _ => {}
+    }
+}
+
+// ── Beryl activation checks ───────────────────────────────────────────────────
+
+fn activation_registry_address() -> String {
+    ActivationRegistryStorage::ADDRESS.to_string()
+}
+
+fn calldata_hex(calldata: impl AsRef<[u8]>) -> String {
+    format!("0x{}", hex::encode(calldata.as_ref()))
+}
+
+fn decode_rpc_bytes(value: &str) -> Result<Vec<u8>, String> {
+    hex::decode(value.trim_start_matches("0x")).map_err(|e| format!("invalid hex response: {e}"))
+}
+
+fn short_address(address: Address) -> String {
+    let value = address.to_string();
+    if value.len() <= 14 {
+        value
+    } else {
+        format!("{}..{}", &value[..10], &value[value.len() - 4..])
+    }
+}
+
+async fn activation_admin(client: &HttpClient) -> Result<Address, String> {
+    let data = calldata_hex(IActivationRegistry::adminCall {}.abi_encode());
+    let to = activation_registry_address();
+    let output = eth_call(client, &to, &data).await?;
+    let bytes = decode_rpc_bytes(&output)?;
+    IActivationRegistry::adminCall::abi_decode_returns(bytes.as_ref()).map_err(|e| e.to_string())
+}
+
+async fn activation_feature_state(client: &HttpClient, feature: B256) -> Result<bool, String> {
+    let data = calldata_hex(IActivationRegistry::isActivatedCall { feature }.abi_encode());
+    let to = activation_registry_address();
+    let output = eth_call(client, &to, &data).await?;
+    let bytes = decode_rpc_bytes(&output)?;
+    IActivationRegistry::isActivatedCall::abi_decode_returns(bytes.as_ref())
+        .map_err(|e| e.to_string())
+}
+
+fn evaluate_beryl_precompile(mode: CheckMode, result: &Result<Address, String>) -> CheckResult {
+    match (mode, result) {
+        (CheckMode::Before, Ok(admin)) => CheckResult {
+            passed: Some(false),
+            detail: format!("responded before Beryl; admin {}", short_address(*admin)),
+        },
+        (CheckMode::Before, Err(_)) => {
+            CheckResult { passed: Some(true), detail: "unavailable before Beryl".to_string() }
+        }
+        (CheckMode::After, Ok(_)) => CheckResult {
+            passed: Some(true),
+            detail: format!("responds at {}", activation_registry_address()),
+        },
+        (CheckMode::After, Err(e)) => {
+            CheckResult { passed: Some(false), detail: format!("unavailable after Beryl: {e}") }
+        }
+    }
+}
+
+fn evaluate_beryl_admin(mode: CheckMode, result: Result<Address, String>) -> CheckResult {
+    match (mode, result) {
+        (CheckMode::Before, Ok(admin)) => CheckResult {
+            passed: Some(false),
+            detail: format!("admin {} available before Beryl", short_address(admin)),
+        },
+        (CheckMode::Before, Err(_)) => {
+            CheckResult { passed: None, detail: "skipped before Beryl".to_string() }
+        }
+        (CheckMode::After, Ok(admin)) => {
+            CheckResult { passed: Some(true), detail: format!("admin {}", short_address(admin)) }
+        }
+        (CheckMode::After, Err(e)) => {
+            CheckResult { passed: Some(false), detail: format!("admin query failed: {e}") }
+        }
+    }
+}
+
+fn evaluate_beryl_feature(mode: CheckMode, result: Result<bool, String>) -> CheckResult {
+    match (mode, result) {
+        (CheckMode::Before, Ok(active)) => CheckResult {
+            passed: Some(false),
+            detail: format!("responded before Beryl: {}", feature_state(active)),
+        },
+        (CheckMode::Before, Err(_)) => {
+            CheckResult { passed: Some(true), detail: "unavailable before Beryl".to_string() }
+        }
+        (CheckMode::After, Ok(active)) => {
+            CheckResult { passed: Some(true), detail: feature_state(active).to_string() }
+        }
+        (CheckMode::After, Err(e)) => {
+            CheckResult { passed: Some(false), detail: format!("query failed: {e}") }
+        }
+    }
+}
+
+const fn feature_state(active: bool) -> &'static str {
+    if active { "active" } else { "inactive" }
+}
+
+async fn run_beryl_checks_streaming(
+    rpc_url: String,
+    mode: CheckMode,
+    tx: mpsc::Sender<CheckUpdate>,
+) {
+    macro_rules! send_start {
+        ($name:expr) => {
+            if tx.send(CheckUpdate::Starting($name.to_string())).await.is_err() {
+                return;
+            }
+        };
+    }
+    macro_rules! send_result {
+        ($name:expr, $result:expr) => {
+            if tx
+                .send(CheckUpdate::Completed { name: $name.to_string(), result: $result })
+                .await
+                .is_err()
+            {
+                return;
+            }
+        };
+    }
+
+    let client = match make_rpc_client(&rpc_url) {
+        Ok(c) => c,
+        Err(e) => {
+            let conn_result = CheckResult {
+                passed: Some(false),
+                detail: format!("cannot build client for {rpc_url}: {e}"),
+            };
+            send_result!("registry precompile", conn_result);
+            for &name in &BERYL_CHECK_NAMES[1..] {
+                send_result!(
+                    name,
+                    CheckResult { passed: None, detail: "skipped (no connection)".into() }
+                );
+            }
+            return;
+        }
+    };
+
+    match ClientT::request::<String, _>(&client, "eth_blockNumber", rpc_params![]).await {
+        Ok(_) => {}
+        Err(e) => {
+            let conn_result =
+                CheckResult { passed: Some(false), detail: format!("cannot reach {rpc_url}: {e}") };
+            send_result!("registry precompile", conn_result);
+            for &name in &BERYL_CHECK_NAMES[1..] {
+                send_result!(
+                    name,
+                    CheckResult { passed: None, detail: "skipped (no connection)".into() }
+                );
+            }
+            return;
+        }
+    }
+
+    send_start!("registry precompile");
+    let admin = activation_admin(&client).await;
+    send_result!("registry precompile", evaluate_beryl_precompile(mode, &admin));
+
+    send_start!("registry admin");
+    send_result!("registry admin", evaluate_beryl_admin(mode, admin));
+
+    for &(name, feature) in BERYL_FEATURE_CHECKS {
+        send_start!(name);
+        let result = activation_feature_state(&client, feature.id()).await;
+        send_result!(name, evaluate_beryl_feature(mode, result));
     }
 }
 
@@ -1419,4 +1651,37 @@ async fn run_azul_checks_streaming(rpc_url: String, tx: mpsc::Sender<CheckUpdate
         }
     };
     send_result!("eth_config", eth_config_check);
+}
+
+#[cfg(test)]
+mod tests {
+    use base_common_genesis::HardforkConfig;
+
+    use super::*;
+
+    #[test]
+    fn live_hardforks_make_beryl_the_devnet_check_target() {
+        let mut chain = ChainUpgrades {
+            display_name: "Devnet",
+            rpc: None,
+            specs: specs_from_config(ChainConfig::devnet()),
+        };
+        assert_eq!(target_hardfork(&chain), Some("Azul"));
+
+        chain.apply_hardforks(&HardForkConfig {
+            base: HardforkConfig { azul: Some(10), beryl: Some(12) },
+            ..HardForkConfig::default()
+        });
+
+        assert_eq!(target_hardfork(&chain), Some("Beryl"));
+        let beryl = chain.specs.iter().find(|spec| spec.name == "Beryl").unwrap();
+        assert_eq!(beryl.timestamp, Some(12));
+    }
+
+    #[test]
+    fn devnet_selection_accepts_vibenet_configs() {
+        assert!(chain_name_matches_loaded("Devnet", "devnet"));
+        assert!(chain_name_matches_loaded("Devnet", "local-vibenet"));
+        assert!(!chain_name_matches_loaded("Mainnet", "devnet"));
+    }
 }

--- a/crates/infra/basectl/src/config.rs
+++ b/crates/infra/basectl/src/config.rs
@@ -4,7 +4,7 @@ use alloy_primitives::Address;
 use alloy_provider::{Provider, ProviderBuilder};
 use anyhow::{Context, Result};
 use base_common_chains::{ChainConfig, rollup_config};
-use base_common_genesis::RollupConfig;
+use base_common_genesis::{HardForkConfig, RollupConfig};
 use serde::{Deserialize, Serialize};
 use tracing::warn;
 use url::Url;
@@ -264,6 +264,9 @@ pub struct MonitoringConfig {
     /// Optional Base consensus node JSON-RPC endpoint URL.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub consensus_node_rpc: Option<Url>,
+    /// Live rollup hardfork configuration fetched from the consensus node when available.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub hardforks: Option<HardForkConfig>,
     /// L1 `SystemConfig` contract address.
     pub system_config: Address,
     /// L1 batcher address for blob attribution.
@@ -364,6 +367,7 @@ struct MonitoringConfigOverride {
     flashblocks_ws: Option<Url>,
     l1_rpc: Option<Url>,
     consensus_node_rpc: Option<Url>,
+    hardforks: Option<HardForkConfig>,
     #[serde(default)]
     system_config: Option<Address>,
     #[serde(default)]
@@ -409,6 +413,7 @@ impl MonitoringConfig {
             flashblocks_ws: Url::parse("wss://mainnet.flashblocks.base.org/ws").unwrap(),
             l1_rpc: Url::parse("https://ethereum-rpc.publicnode.com").unwrap(),
             consensus_node_rpc: None,
+            hardforks: Some(rollup.hardforks),
             system_config: rollup.l1_system_config_address,
             batcher_address: Some("0x5050F69a9786F081509234F1a7F4684b5E5b76C9".parse().unwrap()),
             l1_blob_target: 14,
@@ -431,6 +436,7 @@ impl MonitoringConfig {
             flashblocks_ws: Url::parse("wss://sepolia.flashblocks.base.org/ws").unwrap(),
             l1_rpc: Url::parse("https://ethereum-sepolia-rpc.publicnode.com").unwrap(),
             consensus_node_rpc: None,
+            hardforks: Some(rollup.hardforks),
             system_config: rollup.l1_system_config_address,
             batcher_address: Some("0xfc56E7272EEBBBA5bC6c544e159483C4a38f8bA3".parse().unwrap()),
             l1_blob_target: 14,
@@ -459,6 +465,7 @@ impl MonitoringConfig {
             flashblocks_ws: Url::parse("ws://localhost:7111").unwrap(),
             l1_rpc: Url::parse("http://localhost:4545").unwrap(),
             consensus_node_rpc: Some(Url::parse("http://localhost:7549").unwrap()),
+            hardforks: None,
             // These will be populated by fetch_rollup_config
             system_config: Address::ZERO,
             batcher_address: None,
@@ -603,6 +610,7 @@ impl MonitoringConfig {
 
         config.system_config = rollup_config.l1_system_config_address;
         config.batcher_address = rollup_config.genesis.system_config.map(|sc| sc.batcher_address);
+        config.hardforks = Some(rollup_config.hardforks);
 
         Ok(config)
     }
@@ -630,6 +638,7 @@ impl MonitoringConfig {
             flashblocks_ws: overrides.flashblocks_ws.unwrap_or(base.flashblocks_ws),
             l1_rpc: overrides.l1_rpc.unwrap_or(base.l1_rpc),
             consensus_node_rpc: overrides.consensus_node_rpc.or(base.consensus_node_rpc),
+            hardforks: overrides.hardforks.or(base.hardforks),
             system_config: overrides.system_config.unwrap_or(base.system_config),
             batcher_address: overrides.batcher_address.or(base.batcher_address),
             l1_blob_target: overrides.l1_blob_target.unwrap_or(base.l1_blob_target),

--- a/crates/proof/prover-service/Cargo.toml
+++ b/crates/proof/prover-service/Cargo.toml
@@ -27,13 +27,5 @@ workspace = true
 
 [features]
 default = []
-rpc-client = [
-	"dep:jsonrpsee",
-	"jsonrpsee/http-client",
-	"jsonrpsee/macros",
-]
-rpc-server = [
-	"dep:jsonrpsee",
-	"jsonrpsee/macros",
-	"jsonrpsee/server",
-]
+rpc-client = [ "dep:jsonrpsee", "jsonrpsee/http-client", "jsonrpsee/macros" ]
+rpc-server = [ "dep:jsonrpsee", "jsonrpsee/macros", "jsonrpsee/server" ]


### PR DESCRIPTION
## Summary

This updates basectl upgrades to apply live hardfork timestamps from the loaded rollup config, so running devnet and vibenet instances can show their generated Beryl activation time. It adds Beryl activation checks backed by the activation registry precompile and displays the active/inactive state for each registry feature. It also unschedules Beryl in the static Zeronet chain config and bundled Zeronet genesis so Zeronet no longer reports a compiled-in Beryl activation.
<img width="1182" height="908" alt="Screenshot 2026-05-28 at 4 19 47 PM" src="https://github.com/user-attachments/assets/f13f85fb-4181-4197-a6ec-6fdbb18937eb" />
<img width="1182" height="908" alt="Screenshot 2026-05-28 at 4 19 40 PM" src="https://github.com/user-attachments/assets/6e5777ae-283c-469d-999b-6b688816c7d7" />

