### PR TITLE
feat(proof): configure boundless offer bidding-start delay

### DIFF
--- a/bin/prover-registrar/src/cli.rs
+++ b/bin/prover-registrar/src/cli.rs
@@ -226,9 +226,18 @@ struct BoundlessArgs {
     #[arg(long, env = cli_env!("BOUNDLESS_MAX_PRICE_ETH"))]
     boundless_max_price_eth: Option<String>,
 
-    /// Optional duration for the Boundless offer price to ramp from min to max.
-    #[arg(long, env = cli_env!("BOUNDLESS_OFFER_RAMP_UP_PERIOD_SECS"))]
-    boundless_offer_ramp_up_period_secs: Option<u32>,
+    /// Duration in seconds for the Boundless offer price to ramp from
+    /// `--boundless-min-price-eth` to `--boundless-max-price-eth`.
+    ///
+    /// Defaults to `0` so that the max price is offered immediately,
+    /// eliminating the auction "discount window" that the SDK would
+    /// otherwise insert. With `0`, a prover that locks the request
+    /// receives the full max price, which minimises time-to-lock at
+    /// the cost of paying the max price every time. Set to a non-zero
+    /// value to reintroduce a price ramp (typically for cost
+    /// optimisation when latency is less critical).
+    #[arg(long, env = cli_env!("BOUNDLESS_OFFER_RAMP_UP_PERIOD_SECS"), default_value_t = 0)]
+    boundless_offer_ramp_up_period_secs: u32,
 
     /// Maximum time, in seconds, that a prover that locks a request has to
     /// deliver the proof before forfeiting its stake bond and the request
@@ -250,24 +259,21 @@ struct BoundlessArgs {
     /// Delay, in seconds, between request submission and the moment
     /// bidding is allowed to begin (`Offer.rampUpStart`).
     ///
-    /// The Boundless SDK's default for this value is roughly the
-    /// guest program's executor time (`cycles / 1 MHz`, capped at
-    /// 1 hour), giving provers a "discovery window" to see the
-    /// request and run the executor before bidding opens. That
-    /// window appears on the Boundless explorer as the "flat
-    /// period" preceding the price ramp and accounts for several
-    /// minutes of submission-to-fulfillment latency.
-    ///
-    /// Setting this to `0` eliminates the discovery window entirely:
-    /// bidding opens immediately at submission and the fastest prover
-    /// can lock as soon as it has executed the program. This minimises
-    /// end-to-end latency at the cost of higher prices (no time spent
-    /// on the ramp-up) and a smaller set of provers seeing the
-    /// request before it is locked.
-    ///
-    /// Defaults to SDK behaviour when unset.
-    #[arg(long, env = cli_env!("BOUNDLESS_OFFER_BIDDING_START_DELAY_SECS"))]
-    boundless_offer_bidding_start_delay_secs: Option<u64>,
+    /// Defaults to `0` so that bidding opens immediately at submission
+    /// and the fastest prover can lock as soon as it has executed the
+    /// guest program. This eliminates the SDK's default "discovery
+    /// window" (roughly `cycles / 1 MHz`, capped at 1 hour) — visible
+    /// on the Boundless explorer as the "flat period" preceding the
+    /// price ramp — which accounts for several minutes of
+    /// submission-to-fulfillment latency on large workloads. Set to a
+    /// non-zero value to reintroduce a discovery window so more provers
+    /// can see the request before it is locked.
+    #[arg(
+        long,
+        env = cli_env!("BOUNDLESS_OFFER_BIDDING_START_DELAY_SECS"),
+        default_value_t = 0
+    )]
+    boundless_offer_bidding_start_delay_secs: u64,
 
     /// Maximum number of deterministic request-ID slots to probe when
     /// recovering in-flight proofs after an instance rotation.
@@ -761,8 +767,8 @@ mod tests {
     const TEST_BOUNDLESS_RAMP_UP_PERIOD_SECS: u32 = 30;
     const TEST_BOUNDLESS_OFFER_LOCK_TIMEOUT_SECS: u32 = 600;
     const TEST_BOUNDLESS_OFFER_LOCK_TIMEOUT_SECS_STR: &str = "600";
-    const TEST_BOUNDLESS_OFFER_BIDDING_START_DELAY_SECS: u64 = 0;
-    const TEST_BOUNDLESS_OFFER_BIDDING_START_DELAY_SECS_STR: &str = "0";
+    const TEST_BOUNDLESS_OFFER_BIDDING_START_DELAY_SECS: u64 = 90;
+    const TEST_BOUNDLESS_OFFER_BIDDING_START_DELAY_SECS_STR: &str = "90";
     const TEST_ELF_PATH: &str = "/tmp/guest.elf";
     const TEST_SIGNER_ENDPOINT: &str = "http://localhost:8546";
     const TEST_SIGNER_ADDR: &str = "0x0000000000000000000000000000000000000002";
@@ -964,6 +970,11 @@ mod tests {
         assert_eq!(b.image_id, [1, 2, 3, 4, 5, 6, 7, 8]);
     }
 
+    /// Price and lock-timeout fields remain `Option`-typed and default
+    /// to `None` so the Boundless SDK derives sensible values from the
+    /// workload's cycle count. Ramp-up period and bidding-start delay
+    /// default to `0` ("fast lane") so the binary is latency-optimised
+    /// out of the box.
     #[rstest]
     fn boundless_offer_pricing_defaults_to_sdk() {
         let config = Cli::parse_from(boundless_args()).into_config().unwrap();
@@ -973,9 +984,9 @@ mod tests {
 
         assert!(b.offer_min_price.is_none());
         assert!(b.offer_max_price.is_none());
-        assert!(b.offer_ramp_up_period_secs.is_none());
         assert!(b.offer_lock_timeout_secs.is_none());
-        assert!(b.offer_bidding_start_delay_secs.is_none());
+        assert_eq!(b.offer_ramp_up_period_secs, 0);
+        assert_eq!(b.offer_bidding_start_delay_secs, 0);
     }
 
     #[rstest]
@@ -991,10 +1002,7 @@ mod tests {
             panic!("expected Boundless proving config");
         };
 
-        assert_eq!(
-            b.offer_bidding_start_delay_secs,
-            Some(TEST_BOUNDLESS_OFFER_BIDDING_START_DELAY_SECS)
-        );
+        assert_eq!(b.offer_bidding_start_delay_secs, TEST_BOUNDLESS_OFFER_BIDDING_START_DELAY_SECS);
     }
 
     #[rstest]
@@ -1063,7 +1071,7 @@ mod tests {
                 .unwrap(),
             ),
         );
-        assert_eq!(b.offer_ramp_up_period_secs, Some(TEST_BOUNDLESS_RAMP_UP_PERIOD_SECS));
+        assert_eq!(b.offer_ramp_up_period_secs, TEST_BOUNDLESS_RAMP_UP_PERIOD_SECS);
     }
 
     #[rstest]

--- a/bin/prover-registrar/src/cli.rs
+++ b/bin/prover-registrar/src/cli.rs
@@ -247,6 +247,28 @@ struct BoundlessArgs {
     #[arg(long, env = cli_env!("BOUNDLESS_OFFER_LOCK_TIMEOUT_SECS"))]
     boundless_offer_lock_timeout_secs: Option<u32>,
 
+    /// Delay, in seconds, between request submission and the moment
+    /// bidding is allowed to begin (`Offer.rampUpStart`).
+    ///
+    /// The Boundless SDK's default for this value is roughly the
+    /// guest program's executor time (`cycles / 1 MHz`, capped at
+    /// 1 hour), giving provers a "discovery window" to see the
+    /// request and run the executor before bidding opens. That
+    /// window appears on the Boundless explorer as the "flat
+    /// period" preceding the price ramp and accounts for several
+    /// minutes of submission-to-fulfillment latency.
+    ///
+    /// Setting this to `0` eliminates the discovery window entirely:
+    /// bidding opens immediately at submission and the fastest prover
+    /// can lock as soon as it has executed the program. This minimises
+    /// end-to-end latency at the cost of higher prices (no time spent
+    /// on the ramp-up) and a smaller set of provers seeing the
+    /// request before it is locked.
+    ///
+    /// Defaults to SDK behaviour when unset.
+    #[arg(long, env = cli_env!("BOUNDLESS_OFFER_BIDDING_START_DELAY_SECS"))]
+    boundless_offer_bidding_start_delay_secs: Option<u64>,
+
     /// Maximum number of deterministic request-ID slots to probe when
     /// recovering in-flight proofs after an instance rotation.
     #[arg(
@@ -426,6 +448,9 @@ impl Cli {
                     offer_max_price,
                     offer_ramp_up_period_secs: self.boundless.boundless_offer_ramp_up_period_secs,
                     offer_lock_timeout_secs: self.boundless.boundless_offer_lock_timeout_secs,
+                    offer_bidding_start_delay_secs: self
+                        .boundless
+                        .boundless_offer_bidding_start_delay_secs,
                 }))
             }
             ProvingMode::Direct => {
@@ -627,6 +652,7 @@ impl Cli {
                 offer_max_price: boundless.offer_max_price.clone(),
                 offer_ramp_up_period_secs: boundless.offer_ramp_up_period_secs,
                 offer_lock_timeout_secs: boundless.offer_lock_timeout_secs,
+                offer_bidding_start_delay_secs: boundless.offer_bidding_start_delay_secs,
                 submit_lock: Arc::new(tokio::sync::Mutex::new(())),
                 recovery_blocked: Arc::new(std::sync::Mutex::new(std::collections::HashSet::new())),
             }),
@@ -735,6 +761,8 @@ mod tests {
     const TEST_BOUNDLESS_RAMP_UP_PERIOD_SECS: u32 = 30;
     const TEST_BOUNDLESS_OFFER_LOCK_TIMEOUT_SECS: u32 = 600;
     const TEST_BOUNDLESS_OFFER_LOCK_TIMEOUT_SECS_STR: &str = "600";
+    const TEST_BOUNDLESS_OFFER_BIDDING_START_DELAY_SECS: u64 = 0;
+    const TEST_BOUNDLESS_OFFER_BIDDING_START_DELAY_SECS_STR: &str = "0";
     const TEST_ELF_PATH: &str = "/tmp/guest.elf";
     const TEST_SIGNER_ENDPOINT: &str = "http://localhost:8546";
     const TEST_SIGNER_ADDR: &str = "0x0000000000000000000000000000000000000002";
@@ -947,6 +975,26 @@ mod tests {
         assert!(b.offer_max_price.is_none());
         assert!(b.offer_ramp_up_period_secs.is_none());
         assert!(b.offer_lock_timeout_secs.is_none());
+        assert!(b.offer_bidding_start_delay_secs.is_none());
+    }
+
+    #[rstest]
+    fn boundless_offer_bidding_start_delay_parses() {
+        let mut args = boundless_args();
+        args.extend([
+            "--boundless-offer-bidding-start-delay-secs",
+            TEST_BOUNDLESS_OFFER_BIDDING_START_DELAY_SECS_STR,
+        ]);
+
+        let config = Cli::parse_from(args).into_config().unwrap();
+        let ProvingConfig::Boundless(b) = &config.proving else {
+            panic!("expected Boundless proving config");
+        };
+
+        assert_eq!(
+            b.offer_bidding_start_delay_secs,
+            Some(TEST_BOUNDLESS_OFFER_BIDDING_START_DELAY_SECS)
+        );
     }
 
     #[rstest]

--- a/bin/prover-registrar/src/cli.rs
+++ b/bin/prover-registrar/src/cli.rs
@@ -226,18 +226,18 @@ struct BoundlessArgs {
     #[arg(long, env = cli_env!("BOUNDLESS_MAX_PRICE_ETH"))]
     boundless_max_price_eth: Option<String>,
 
-    /// Duration in seconds for the Boundless offer price to ramp from
-    /// `--boundless-min-price-eth` to `--boundless-max-price-eth`.
+    /// Optional duration in seconds for the Boundless offer price to
+    /// ramp from `--boundless-min-price-eth` to
+    /// `--boundless-max-price-eth`.
     ///
-    /// Defaults to `0` so that the max price is offered immediately,
-    /// eliminating the auction "discount window" that the SDK would
-    /// otherwise insert. With `0`, a prover that locks the request
-    /// receives the full max price, which minimises time-to-lock at
-    /// the cost of paying the max price every time. Set to a non-zero
-    /// value to reintroduce a price ramp (typically for cost
-    /// optimisation when latency is less critical).
-    #[arg(long, env = cli_env!("BOUNDLESS_OFFER_RAMP_UP_PERIOD_SECS"), default_value_t = 0)]
-    boundless_offer_ramp_up_period_secs: u32,
+    /// Defaults to the Boundless SDK's cycle-count-derived value when
+    /// unset (preserving the standard Dutch-auction price ramp). Set
+    /// to `0` to eliminate the ramp entirely so that the max price is
+    /// offered immediately — useful in "fast lane" deployments that
+    /// minimise time-to-lock at the cost of paying the max price every
+    /// time.
+    #[arg(long, env = cli_env!("BOUNDLESS_OFFER_RAMP_UP_PERIOD_SECS"))]
+    boundless_offer_ramp_up_period_secs: Option<u32>,
 
     /// Maximum time, in seconds, that a prover that locks a request has to
     /// deliver the proof before forfeiting its stake bond and the request
@@ -970,11 +970,11 @@ mod tests {
         assert_eq!(b.image_id, [1, 2, 3, 4, 5, 6, 7, 8]);
     }
 
-    /// Price and lock-timeout fields remain `Option`-typed and default
-    /// to `None` so the Boundless SDK derives sensible values from the
-    /// workload's cycle count. Ramp-up period and bidding-start delay
-    /// default to `0` ("fast lane") so the binary is latency-optimised
-    /// out of the box.
+    /// Price, ramp-up period, and lock-timeout fields remain
+    /// `Option`-typed and default to `None` so the Boundless SDK
+    /// derives sensible values from the workload's cycle count. Only
+    /// `bidding-start-delay` defaults to `0` ("fast lane") to minimise
+    /// time-to-lock out of the box.
     #[rstest]
     fn boundless_offer_pricing_defaults_to_sdk() {
         let config = Cli::parse_from(boundless_args()).into_config().unwrap();
@@ -984,8 +984,8 @@ mod tests {
 
         assert!(b.offer_min_price.is_none());
         assert!(b.offer_max_price.is_none());
+        assert!(b.offer_ramp_up_period_secs.is_none());
         assert!(b.offer_lock_timeout_secs.is_none());
-        assert_eq!(b.offer_ramp_up_period_secs, 0);
         assert_eq!(b.offer_bidding_start_delay_secs, 0);
     }
 
@@ -1071,7 +1071,7 @@ mod tests {
                 .unwrap(),
             ),
         );
-        assert_eq!(b.offer_ramp_up_period_secs, TEST_BOUNDLESS_RAMP_UP_PERIOD_SECS);
+        assert_eq!(b.offer_ramp_up_period_secs, Some(TEST_BOUNDLESS_RAMP_UP_PERIOD_SECS));
     }
 
     #[rstest]

--- a/crates/proof/tee/nitro-attestation-prover/src/boundless.rs
+++ b/crates/proof/tee/nitro-attestation-prover/src/boundless.rs
@@ -189,8 +189,10 @@ impl BoundlessProver {
     }
 
     /// Returns the current Unix timestamp in seconds, used to compute
-    /// `Offer.rampUpStart` when `offer_bidding_start_delay_secs` is
-    /// configured. Factored out so tests can substitute a fixed clock.
+    /// `Offer.rampUpStart` as `now + offer_bidding_start_delay_secs`.
+    /// Factored out so tests can bracket calls between `before`/`after`
+    /// snapshots to assert the resulting timestamp falls in the
+    /// expected window.
     fn now_unix_secs() -> u64 {
         std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)

--- a/crates/proof/tee/nitro-attestation-prover/src/boundless.rs
+++ b/crates/proof/tee/nitro-attestation-prover/src/boundless.rs
@@ -89,10 +89,11 @@ pub struct BoundlessProver {
     pub offer_min_price: Option<Amount>,
     /// Optional maximum Boundless offer price for each submitted proof request.
     pub offer_max_price: Option<Amount>,
-    /// Duration in seconds for the Boundless offer price to ramp from
-    /// `offer_min_price` to `offer_max_price`. Defaults to `0` so that
-    /// the maximum price is offered immediately, minimising time-to-lock.
-    pub offer_ramp_up_period_secs: u32,
+    /// Optional duration in seconds for the Boundless offer price to
+    /// ramp from `offer_min_price` to `offer_max_price`. When unset
+    /// the Boundless SDK derives a cycle-count-based ramp; set to `0`
+    /// to eliminate the ramp entirely (max price offered immediately).
+    pub offer_ramp_up_period_secs: Option<u32>,
     /// Optional maximum time, in seconds, that a prover that locks a
     /// request has to deliver the proof before forfeiting its stake bond
     /// and the request opening up to permissionless secondary
@@ -203,11 +204,10 @@ impl BoundlessProver {
     /// Applies the time-independent Boundless offer overrides to
     /// request params.
     ///
-    /// `ramp_up_period` is always set from the prover's configuration
-    /// (defaults to `0` to minimise auction latency); `min_price`,
-    /// `max_price`, and `lock_timeout` are only passed through when
-    /// explicitly configured, otherwise the Boundless SDK derives
-    /// sensible values.
+    /// `min_price`, `max_price`, `ramp_up_period`, and `lock_timeout`
+    /// are only passed through when explicitly configured; when unset,
+    /// the Boundless SDK derives sensible values from the workload's
+    /// cycle count.
     ///
     /// `bidding_start` is intentionally **not** set here: it is a
     /// wall-clock-relative deadline anchor (the SDK computes
@@ -227,7 +227,9 @@ impl BoundlessProver {
         if let Some(max_price) = &self.offer_max_price {
             offer.max_price(max_price.clone());
         }
-        offer.ramp_up_period(self.offer_ramp_up_period_secs);
+        if let Some(ramp_up_period) = self.offer_ramp_up_period_secs {
+            offer.ramp_up_period(ramp_up_period);
+        }
         if let Some(lock_timeout) = self.offer_lock_timeout_secs {
             offer.lock_timeout(lock_timeout);
         }
@@ -886,7 +888,7 @@ mod tests {
             max_attestation_age: TEST_MAX_ATTESTATION_AGE,
             offer_min_price: None,
             offer_max_price: None,
-            offer_ramp_up_period_secs: 0,
+            offer_ramp_up_period_secs: None,
             offer_lock_timeout_secs: None,
             offer_bidding_start_delay_secs: 0,
             submit_lock: Arc::new(Mutex::new(())),
@@ -919,22 +921,21 @@ mod tests {
         assert_eq!(prover.max_recovery_attempts, TEST_MAX_RECOVERY_ATTEMPTS);
         assert!(prover.offer_min_price.is_none());
         assert!(prover.offer_max_price.is_none());
-        assert_eq!(prover.offer_ramp_up_period_secs, 0);
+        assert!(prover.offer_ramp_up_period_secs.is_none());
         assert!(prover.offer_lock_timeout_secs.is_none());
         assert_eq!(prover.offer_bidding_start_delay_secs, 0);
     }
 
-    /// With defaults (ramp = 0), `apply_offer_config` always emits an
-    /// offer override that sets `ramp_up_period = 0`. The other
-    /// (still-Option) price/timeout fields remain unset so the
-    /// Boundless SDK derives them from cycle count. `bidding_start`
-    /// is intentionally **not** set here — it is anchored later by
-    /// `apply_bidding_start` immediately before on-chain submission.
+    /// With every Option-typed offer override unset, `apply_offer_config`
+    /// leaves the corresponding offer fields unset so the Boundless SDK
+    /// derives them from cycle count. `bidding_start` is intentionally
+    /// **not** set here — it is anchored later by `apply_bidding_start`
+    /// immediately before on-chain submission.
     #[rstest]
-    fn apply_offer_config_defaults_enable_fast_lane(prover: BoundlessProver) {
+    fn apply_offer_config_defaults_to_sdk(prover: BoundlessProver) {
         let params = prover.apply_offer_config(RequestParams::new());
 
-        assert_eq!(params.offer.ramp_up_period, Some(0));
+        assert!(params.offer.ramp_up_period.is_none());
         assert!(params.offer.min_price.is_none());
         assert!(params.offer.max_price.is_none());
         assert!(params.offer.lock_timeout.is_none());
@@ -951,7 +952,7 @@ mod tests {
         let max_price = eth_amount(TEST_MAX_PRICE_ETH);
         prover.offer_min_price = Some(min_price.clone());
         prover.offer_max_price = Some(max_price.clone());
-        prover.offer_ramp_up_period_secs = TEST_RAMP_UP_PERIOD_SECS;
+        prover.offer_ramp_up_period_secs = Some(TEST_RAMP_UP_PERIOD_SECS);
         prover.offer_lock_timeout_secs = Some(TEST_LOCK_TIMEOUT_SECS);
         prover.offer_bidding_start_delay_secs = TEST_NON_ZERO_BIDDING_START_DELAY_SECS;
 
@@ -967,8 +968,7 @@ mod tests {
         );
     }
 
-    /// `lock_timeout` can be set independently of price fields; the
-    /// always-set ramp default still flows through.
+    /// `lock_timeout` can be set independently of price/ramp fields.
     #[rstest]
     fn apply_offer_config_sets_lock_timeout_alone(mut prover: BoundlessProver) {
         prover.offer_lock_timeout_secs = Some(TEST_LOCK_TIMEOUT_SECS);
@@ -976,7 +976,7 @@ mod tests {
         let params = prover.apply_offer_config(RequestParams::new());
 
         assert_eq!(params.offer.lock_timeout, Some(TEST_LOCK_TIMEOUT_SECS));
-        assert_eq!(params.offer.ramp_up_period, Some(0));
+        assert!(params.offer.ramp_up_period.is_none());
         assert!(params.offer.min_price.is_none());
         assert!(params.offer.max_price.is_none());
         assert!(params.offer.bidding_start.is_none());
@@ -1026,7 +1026,7 @@ mod tests {
         let max_price = eth_amount(TEST_MAX_PRICE_ETH);
         prover.offer_min_price = Some(min_price.clone());
         prover.offer_max_price = Some(max_price.clone());
-        prover.offer_ramp_up_period_secs = TEST_RAMP_UP_PERIOD_SECS;
+        prover.offer_ramp_up_period_secs = Some(TEST_RAMP_UP_PERIOD_SECS);
         prover.offer_lock_timeout_secs = Some(TEST_LOCK_TIMEOUT_SECS);
 
         let params = prover.apply_offer_config(RequestParams::new());

--- a/crates/proof/tee/nitro-attestation-prover/src/boundless.rs
+++ b/crates/proof/tee/nitro-attestation-prover/src/boundless.rs
@@ -195,9 +195,15 @@ impl BoundlessProver {
     /// tests can bracket calls between `before`/`after` snapshots to
     /// assert the resulting timestamp falls in the expected window.
     fn now_unix_secs() -> u64 {
+        // Matches the fail-soft pattern used elsewhere in this file
+        // (`effective_expiry`, `is_journal_fresh`): a pre-epoch system
+        // clock is unrealistic, and on a long-running registrar
+        // returning 0 here is preferable to panicking — the resulting
+        // bidding_start would be rejected downstream rather than
+        // crashing the process.
         std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
-            .expect("system clock before UNIX epoch")
+            .unwrap_or_default()
             .as_secs()
     }
 

--- a/crates/proof/tee/nitro-attestation-prover/src/boundless.rs
+++ b/crates/proof/tee/nitro-attestation-prover/src/boundless.rs
@@ -89,8 +89,10 @@ pub struct BoundlessProver {
     pub offer_min_price: Option<Amount>,
     /// Optional maximum Boundless offer price for each submitted proof request.
     pub offer_max_price: Option<Amount>,
-    /// Optional duration in seconds for Boundless price to ramp from min to max.
-    pub offer_ramp_up_period_secs: Option<u32>,
+    /// Duration in seconds for the Boundless offer price to ramp from
+    /// `offer_min_price` to `offer_max_price`. Defaults to `0` so that
+    /// the maximum price is offered immediately, minimising time-to-lock.
+    pub offer_ramp_up_period_secs: u32,
     /// Optional maximum time, in seconds, that a prover that locks a
     /// request has to deliver the proof before forfeiting its stake bond
     /// and the request opening up to permissionless secondary
@@ -100,23 +102,17 @@ pub struct BoundlessProver {
     /// Boundless SDK derives a recommended value from the program's
     /// cycle count.
     pub offer_lock_timeout_secs: Option<u32>,
-    /// Optional delay, in seconds, between request submission and the
-    /// moment bidding is allowed to begin (`Offer.rampUpStart`).
+    /// Delay, in seconds, between request submission and the moment
+    /// bidding is allowed to begin (`Offer.rampUpStart`).
     ///
-    /// Setting this to `0` eliminates the SDK's default "pre-bid flat
-    /// period" (visible on the Boundless explorer as the gap before the
-    /// price-ramp begins), which the SDK normally sets to roughly the
-    /// guest program's executor time so provers have time to discover
-    /// the request and run the executor before bidding. With this set
-    /// to `0`, the fastest prover can lock as soon as it finishes
-    /// executing — at the cost of higher prices (no auction headroom)
-    /// and fewer provers seeing the request before lock.
-    ///
-    /// When unset, the Boundless SDK derives the delay from
-    /// `cycle_count / 1 MHz` (capped at 1 hour). When set, the value is
-    /// added to the current wall-clock time per request to produce
-    /// `Offer.rampUpStart`.
-    pub offer_bidding_start_delay_secs: Option<u64>,
+    /// Defaults to `0` so that bidding opens immediately at submission,
+    /// eliminating the SDK's default "pre-bid flat period" (visible on
+    /// the Boundless explorer as the gap before the price-ramp begins).
+    /// With `0`, the fastest prover can lock as soon as it finishes
+    /// executing — at the cost of fewer provers seeing the request
+    /// before lock. The value is added to the current wall-clock time
+    /// per request to produce `Offer.rampUpStart`.
+    pub offer_bidding_start_delay_secs: u64,
     /// Serialises the `submit_onchain` call so that concurrent proof
     /// requests do not race on the Boundless wallet nonce. The lock is
     /// released immediately after submission, allowing the long-running
@@ -202,22 +198,18 @@ impl BoundlessProver {
             .as_secs()
     }
 
-    /// Applies optional explicit Boundless offer pricing to request params.
+    /// Applies explicit Boundless offer overrides to request params.
     ///
-    /// When `offer_bidding_start_delay_secs` is set, `Offer.rampUpStart`
-    /// is computed as `now_unix_secs() + delay` per request rather than
-    /// being captured at registrar startup, so the value is always
-    /// fresh relative to the request submission time.
+    /// `ramp_up_period` and `bidding_start` are always set from the
+    /// prover's configuration (both default to `0` to minimise auction
+    /// latency); `min_price`, `max_price`, and `lock_timeout` are only
+    /// passed through when explicitly configured, otherwise the
+    /// Boundless SDK derives sensible values.
+    ///
+    /// `Offer.rampUpStart` is computed as `now_unix_secs() + delay` per
+    /// request rather than being captured at registrar startup, so the
+    /// value is always fresh relative to the request submission time.
     fn apply_offer_config(&self, params: RequestParams) -> RequestParams {
-        if self.offer_min_price.is_none()
-            && self.offer_max_price.is_none()
-            && self.offer_ramp_up_period_secs.is_none()
-            && self.offer_lock_timeout_secs.is_none()
-            && self.offer_bidding_start_delay_secs.is_none()
-        {
-            return params;
-        }
-
         let mut offer = OfferParams::builder();
         if let Some(min_price) = &self.offer_min_price {
             offer.min_price(min_price.clone());
@@ -225,15 +217,13 @@ impl BoundlessProver {
         if let Some(max_price) = &self.offer_max_price {
             offer.max_price(max_price.clone());
         }
-        if let Some(ramp_up_period) = self.offer_ramp_up_period_secs {
-            offer.ramp_up_period(ramp_up_period);
-        }
+        offer.ramp_up_period(self.offer_ramp_up_period_secs);
         if let Some(lock_timeout) = self.offer_lock_timeout_secs {
             offer.lock_timeout(lock_timeout);
         }
-        if let Some(delay) = self.offer_bidding_start_delay_secs {
-            offer.bidding_start(Self::now_unix_secs().saturating_add(delay));
-        }
+        offer.bidding_start(
+            Self::now_unix_secs().saturating_add(self.offer_bidding_start_delay_secs),
+        );
 
         params.with_offer(offer)
     }
@@ -842,7 +832,7 @@ mod tests {
     const TEST_MAX_PRICE_ETH: &str = "0.03";
     const TEST_RAMP_UP_PERIOD_SECS: u32 = 30;
     const TEST_LOCK_TIMEOUT_SECS: u32 = 600;
-    const TEST_BIDDING_START_DELAY_SECS: u64 = 0;
+    const TEST_NON_ZERO_BIDDING_START_DELAY_SECS: u64 = 120;
 
     const TEST_MAX_ATTESTATION_AGE: Duration = Duration::from_secs(3300);
 
@@ -864,9 +854,9 @@ mod tests {
             max_attestation_age: TEST_MAX_ATTESTATION_AGE,
             offer_min_price: None,
             offer_max_price: None,
-            offer_ramp_up_period_secs: None,
+            offer_ramp_up_period_secs: 0,
             offer_lock_timeout_secs: None,
-            offer_bidding_start_delay_secs: None,
+            offer_bidding_start_delay_secs: 0,
             submit_lock: Arc::new(Mutex::new(())),
             recovery_blocked: Arc::new(std::sync::Mutex::new(HashSet::new())),
         }
@@ -897,20 +887,31 @@ mod tests {
         assert_eq!(prover.max_recovery_attempts, TEST_MAX_RECOVERY_ATTEMPTS);
         assert!(prover.offer_min_price.is_none());
         assert!(prover.offer_max_price.is_none());
-        assert!(prover.offer_ramp_up_period_secs.is_none());
+        assert_eq!(prover.offer_ramp_up_period_secs, 0);
         assert!(prover.offer_lock_timeout_secs.is_none());
-        assert!(prover.offer_bidding_start_delay_secs.is_none());
+        assert_eq!(prover.offer_bidding_start_delay_secs, 0);
     }
 
+    /// With defaults (ramp = 0, bidding delay = 0), `apply_offer_config`
+    /// always emits an offer override that sets `ramp_up_period = 0`
+    /// and `bidding_start` to the current wall-clock time. The other
+    /// (still-Option) fields remain unset so the Boundless SDK derives
+    /// them from cycle count.
     #[rstest]
-    fn apply_offer_config_preserves_default_when_unset(prover: BoundlessProver) {
+    fn apply_offer_config_defaults_enable_fast_lane(prover: BoundlessProver) {
+        let before = BoundlessProver::now_unix_secs();
         let params = prover.apply_offer_config(RequestParams::new());
+        let after = BoundlessProver::now_unix_secs();
 
+        assert_eq!(params.offer.ramp_up_period, Some(0));
+        let bidding_start = params.offer.bidding_start.expect("bidding_start always set");
+        assert!(
+            (before..=after).contains(&bidding_start),
+            "bidding_start {bidding_start} outside [{before}, {after}]"
+        );
         assert!(params.offer.min_price.is_none());
         assert!(params.offer.max_price.is_none());
-        assert!(params.offer.ramp_up_period.is_none());
         assert!(params.offer.lock_timeout.is_none());
-        assert!(params.offer.bidding_start.is_none());
     }
 
     #[rstest]
@@ -919,9 +920,9 @@ mod tests {
         let max_price = eth_amount(TEST_MAX_PRICE_ETH);
         prover.offer_min_price = Some(min_price.clone());
         prover.offer_max_price = Some(max_price.clone());
-        prover.offer_ramp_up_period_secs = Some(TEST_RAMP_UP_PERIOD_SECS);
+        prover.offer_ramp_up_period_secs = TEST_RAMP_UP_PERIOD_SECS;
         prover.offer_lock_timeout_secs = Some(TEST_LOCK_TIMEOUT_SECS);
-        prover.offer_bidding_start_delay_secs = Some(TEST_BIDDING_START_DELAY_SECS);
+        prover.offer_bidding_start_delay_secs = TEST_NON_ZERO_BIDDING_START_DELAY_SECS;
 
         let before = BoundlessProver::now_unix_secs();
         let params = prover.apply_offer_config(RequestParams::new());
@@ -933,16 +934,15 @@ mod tests {
         assert_eq!(params.offer.lock_timeout, Some(TEST_LOCK_TIMEOUT_SECS));
         let bidding_start = params.offer.bidding_start.expect("bidding_start set");
         assert!(
-            (before.saturating_add(TEST_BIDDING_START_DELAY_SECS)
-                ..=after.saturating_add(TEST_BIDDING_START_DELAY_SECS))
+            (before.saturating_add(TEST_NON_ZERO_BIDDING_START_DELAY_SECS)
+                ..=after.saturating_add(TEST_NON_ZERO_BIDDING_START_DELAY_SECS))
                 .contains(&bidding_start),
             "bidding_start {bidding_start} outside expected window"
         );
     }
 
-    /// `lock_timeout` can be set independently of price/ramp fields,
-    /// in which case `apply_offer_config` must still emit an offer
-    /// override (not return params unchanged).
+    /// `lock_timeout` can be set independently of price fields; the
+    /// always-set ramp/bidding-start defaults still flow through.
     #[rstest]
     fn apply_offer_config_sets_lock_timeout_alone(mut prover: BoundlessProver) {
         prover.offer_lock_timeout_secs = Some(TEST_LOCK_TIMEOUT_SECS);
@@ -950,36 +950,10 @@ mod tests {
         let params = prover.apply_offer_config(RequestParams::new());
 
         assert_eq!(params.offer.lock_timeout, Some(TEST_LOCK_TIMEOUT_SECS));
+        assert_eq!(params.offer.ramp_up_period, Some(0));
+        assert!(params.offer.bidding_start.is_some());
         assert!(params.offer.min_price.is_none());
         assert!(params.offer.max_price.is_none());
-        assert!(params.offer.ramp_up_period.is_none());
-        assert!(params.offer.bidding_start.is_none());
-    }
-
-    /// `bidding_start_delay` can be set independently of price/ramp/lock
-    /// fields, and `apply_offer_config` must emit an offer override with
-    /// `bidding_start = now + delay` (per-request, not captured at
-    /// startup).
-    #[rstest]
-    fn apply_offer_config_sets_bidding_start_alone(mut prover: BoundlessProver) {
-        prover.offer_bidding_start_delay_secs = Some(TEST_BIDDING_START_DELAY_SECS);
-
-        let before = BoundlessProver::now_unix_secs();
-        let params = prover.apply_offer_config(RequestParams::new());
-        let after = BoundlessProver::now_unix_secs();
-
-        let bidding_start = params.offer.bidding_start.expect("bidding_start set");
-        let lower = before.saturating_add(TEST_BIDDING_START_DELAY_SECS);
-        let upper = after.saturating_add(TEST_BIDDING_START_DELAY_SECS);
-        assert!(
-            (lower..=upper).contains(&bidding_start),
-            "bidding_start {bidding_start} outside [{lower}, {upper}]"
-        );
-
-        assert!(params.offer.min_price.is_none());
-        assert!(params.offer.max_price.is_none());
-        assert!(params.offer.ramp_up_period.is_none());
-        assert!(params.offer.lock_timeout.is_none());
     }
 
     /// Non-zero `bidding_start_delay` is offset from the current clock,
@@ -987,17 +961,16 @@ mod tests {
     /// in the future at call time.
     #[rstest]
     fn apply_offer_config_bidding_start_uses_current_clock(mut prover: BoundlessProver) {
-        const DELAY: u64 = 120;
-        prover.offer_bidding_start_delay_secs = Some(DELAY);
+        prover.offer_bidding_start_delay_secs = TEST_NON_ZERO_BIDDING_START_DELAY_SECS;
 
         let before = BoundlessProver::now_unix_secs();
         let params = prover.apply_offer_config(RequestParams::new());
 
         let bidding_start = params.offer.bidding_start.expect("bidding_start set");
         assert!(
-            bidding_start >= before.saturating_add(DELAY),
+            bidding_start >= before.saturating_add(TEST_NON_ZERO_BIDDING_START_DELAY_SECS),
             "bidding_start {bidding_start} should be >= {} (before + delay)",
-            before.saturating_add(DELAY)
+            before.saturating_add(TEST_NON_ZERO_BIDDING_START_DELAY_SECS)
         );
     }
 

--- a/crates/proof/tee/nitro-attestation-prover/src/boundless.rs
+++ b/crates/proof/tee/nitro-attestation-prover/src/boundless.rs
@@ -100,6 +100,23 @@ pub struct BoundlessProver {
     /// Boundless SDK derives a recommended value from the program's
     /// cycle count.
     pub offer_lock_timeout_secs: Option<u32>,
+    /// Optional delay, in seconds, between request submission and the
+    /// moment bidding is allowed to begin (`Offer.rampUpStart`).
+    ///
+    /// Setting this to `0` eliminates the SDK's default "pre-bid flat
+    /// period" (visible on the Boundless explorer as the gap before the
+    /// price-ramp begins), which the SDK normally sets to roughly the
+    /// guest program's executor time so provers have time to discover
+    /// the request and run the executor before bidding. With this set
+    /// to `0`, the fastest prover can lock as soon as it finishes
+    /// executing — at the cost of higher prices (no auction headroom)
+    /// and fewer provers seeing the request before lock.
+    ///
+    /// When unset, the Boundless SDK derives the delay from
+    /// `cycle_count / 1 MHz` (capped at 1 hour). When set, the value is
+    /// added to the current wall-clock time per request to produce
+    /// `Offer.rampUpStart`.
+    pub offer_bidding_start_delay_secs: Option<u64>,
     /// Serialises the `submit_onchain` call so that concurrent proof
     /// requests do not race on the Boundless wallet nonce. The lock is
     /// released immediately after submission, allowing the long-running
@@ -131,6 +148,7 @@ impl fmt::Debug for BoundlessProver {
             .field("offer_max_price", &self.offer_max_price)
             .field("offer_ramp_up_period_secs", &self.offer_ramp_up_period_secs)
             .field("offer_lock_timeout_secs", &self.offer_lock_timeout_secs)
+            .field("offer_bidding_start_delay_secs", &self.offer_bidding_start_delay_secs)
             .finish()
     }
 }
@@ -174,12 +192,28 @@ impl BoundlessProver {
         debug.to_ascii_lowercase().contains(NEEDLE)
     }
 
+    /// Returns the current Unix timestamp in seconds, used to compute
+    /// `Offer.rampUpStart` when `offer_bidding_start_delay_secs` is
+    /// configured. Factored out so tests can substitute a fixed clock.
+    fn now_unix_secs() -> u64 {
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("system clock before UNIX epoch")
+            .as_secs()
+    }
+
     /// Applies optional explicit Boundless offer pricing to request params.
+    ///
+    /// When `offer_bidding_start_delay_secs` is set, `Offer.rampUpStart`
+    /// is computed as `now_unix_secs() + delay` per request rather than
+    /// being captured at registrar startup, so the value is always
+    /// fresh relative to the request submission time.
     fn apply_offer_config(&self, params: RequestParams) -> RequestParams {
         if self.offer_min_price.is_none()
             && self.offer_max_price.is_none()
             && self.offer_ramp_up_period_secs.is_none()
             && self.offer_lock_timeout_secs.is_none()
+            && self.offer_bidding_start_delay_secs.is_none()
         {
             return params;
         }
@@ -196,6 +230,9 @@ impl BoundlessProver {
         }
         if let Some(lock_timeout) = self.offer_lock_timeout_secs {
             offer.lock_timeout(lock_timeout);
+        }
+        if let Some(delay) = self.offer_bidding_start_delay_secs {
+            offer.bidding_start(Self::now_unix_secs().saturating_add(delay));
         }
 
         params.with_offer(offer)
@@ -805,6 +842,7 @@ mod tests {
     const TEST_MAX_PRICE_ETH: &str = "0.03";
     const TEST_RAMP_UP_PERIOD_SECS: u32 = 30;
     const TEST_LOCK_TIMEOUT_SECS: u32 = 600;
+    const TEST_BIDDING_START_DELAY_SECS: u64 = 0;
 
     const TEST_MAX_ATTESTATION_AGE: Duration = Duration::from_secs(3300);
 
@@ -828,6 +866,7 @@ mod tests {
             offer_max_price: None,
             offer_ramp_up_period_secs: None,
             offer_lock_timeout_secs: None,
+            offer_bidding_start_delay_secs: None,
             submit_lock: Arc::new(Mutex::new(())),
             recovery_blocked: Arc::new(std::sync::Mutex::new(HashSet::new())),
         }
@@ -860,6 +899,7 @@ mod tests {
         assert!(prover.offer_max_price.is_none());
         assert!(prover.offer_ramp_up_period_secs.is_none());
         assert!(prover.offer_lock_timeout_secs.is_none());
+        assert!(prover.offer_bidding_start_delay_secs.is_none());
     }
 
     #[rstest]
@@ -870,6 +910,7 @@ mod tests {
         assert!(params.offer.max_price.is_none());
         assert!(params.offer.ramp_up_period.is_none());
         assert!(params.offer.lock_timeout.is_none());
+        assert!(params.offer.bidding_start.is_none());
     }
 
     #[rstest]
@@ -880,13 +921,23 @@ mod tests {
         prover.offer_max_price = Some(max_price.clone());
         prover.offer_ramp_up_period_secs = Some(TEST_RAMP_UP_PERIOD_SECS);
         prover.offer_lock_timeout_secs = Some(TEST_LOCK_TIMEOUT_SECS);
+        prover.offer_bidding_start_delay_secs = Some(TEST_BIDDING_START_DELAY_SECS);
 
+        let before = BoundlessProver::now_unix_secs();
         let params = prover.apply_offer_config(RequestParams::new());
+        let after = BoundlessProver::now_unix_secs();
 
         assert_eq!(params.offer.min_price, Some(min_price));
         assert_eq!(params.offer.max_price, Some(max_price));
         assert_eq!(params.offer.ramp_up_period, Some(TEST_RAMP_UP_PERIOD_SECS));
         assert_eq!(params.offer.lock_timeout, Some(TEST_LOCK_TIMEOUT_SECS));
+        let bidding_start = params.offer.bidding_start.expect("bidding_start set");
+        assert!(
+            (before.saturating_add(TEST_BIDDING_START_DELAY_SECS)
+                ..=after.saturating_add(TEST_BIDDING_START_DELAY_SECS))
+                .contains(&bidding_start),
+            "bidding_start {bidding_start} outside expected window"
+        );
     }
 
     /// `lock_timeout` can be set independently of price/ramp fields,
@@ -902,6 +953,52 @@ mod tests {
         assert!(params.offer.min_price.is_none());
         assert!(params.offer.max_price.is_none());
         assert!(params.offer.ramp_up_period.is_none());
+        assert!(params.offer.bidding_start.is_none());
+    }
+
+    /// `bidding_start_delay` can be set independently of price/ramp/lock
+    /// fields, and `apply_offer_config` must emit an offer override with
+    /// `bidding_start = now + delay` (per-request, not captured at
+    /// startup).
+    #[rstest]
+    fn apply_offer_config_sets_bidding_start_alone(mut prover: BoundlessProver) {
+        prover.offer_bidding_start_delay_secs = Some(TEST_BIDDING_START_DELAY_SECS);
+
+        let before = BoundlessProver::now_unix_secs();
+        let params = prover.apply_offer_config(RequestParams::new());
+        let after = BoundlessProver::now_unix_secs();
+
+        let bidding_start = params.offer.bidding_start.expect("bidding_start set");
+        let lower = before.saturating_add(TEST_BIDDING_START_DELAY_SECS);
+        let upper = after.saturating_add(TEST_BIDDING_START_DELAY_SECS);
+        assert!(
+            (lower..=upper).contains(&bidding_start),
+            "bidding_start {bidding_start} outside [{lower}, {upper}]"
+        );
+
+        assert!(params.offer.min_price.is_none());
+        assert!(params.offer.max_price.is_none());
+        assert!(params.offer.ramp_up_period.is_none());
+        assert!(params.offer.lock_timeout.is_none());
+    }
+
+    /// Non-zero `bidding_start_delay` is offset from the current clock,
+    /// not captured at startup, so the resulting timestamp is always
+    /// in the future at call time.
+    #[rstest]
+    fn apply_offer_config_bidding_start_uses_current_clock(mut prover: BoundlessProver) {
+        const DELAY: u64 = 120;
+        prover.offer_bidding_start_delay_secs = Some(DELAY);
+
+        let before = BoundlessProver::now_unix_secs();
+        let params = prover.apply_offer_config(RequestParams::new());
+
+        let bidding_start = params.offer.bidding_start.expect("bidding_start set");
+        assert!(
+            bidding_start >= before.saturating_add(DELAY),
+            "bidding_start {bidding_start} should be >= {} (before + delay)",
+            before.saturating_add(DELAY)
+        );
     }
 
     // ── Clone ───────────────────────────────────────────────────────────

--- a/crates/proof/tee/nitro-attestation-prover/src/boundless.rs
+++ b/crates/proof/tee/nitro-attestation-prover/src/boundless.rs
@@ -189,10 +189,10 @@ impl BoundlessProver {
     }
 
     /// Returns the current Unix timestamp in seconds, used to compute
-    /// `Offer.rampUpStart` as `now + offer_bidding_start_delay_secs`.
-    /// Factored out so tests can bracket calls between `before`/`after`
-    /// snapshots to assert the resulting timestamp falls in the
-    /// expected window.
+    /// `Offer.rampUpStart` as `now + offer_bidding_start_delay_secs`
+    /// immediately before each on-chain submission. Factored out so
+    /// tests can bracket calls between `before`/`after` snapshots to
+    /// assert the resulting timestamp falls in the expected window.
     fn now_unix_secs() -> u64 {
         std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
@@ -200,17 +200,25 @@ impl BoundlessProver {
             .as_secs()
     }
 
-    /// Applies explicit Boundless offer overrides to request params.
+    /// Applies the time-independent Boundless offer overrides to
+    /// request params.
     ///
-    /// `ramp_up_period` and `bidding_start` are always set from the
-    /// prover's configuration (both default to `0` to minimise auction
-    /// latency); `min_price`, `max_price`, and `lock_timeout` are only
-    /// passed through when explicitly configured, otherwise the
-    /// Boundless SDK derives sensible values.
+    /// `ramp_up_period` is always set from the prover's configuration
+    /// (defaults to `0` to minimise auction latency); `min_price`,
+    /// `max_price`, and `lock_timeout` are only passed through when
+    /// explicitly configured, otherwise the Boundless SDK derives
+    /// sensible values.
     ///
-    /// `Offer.rampUpStart` is computed as `now_unix_secs() + delay` per
-    /// request rather than being captured at registrar startup, so the
-    /// value is always fresh relative to the request submission time.
+    /// `bidding_start` is intentionally **not** set here: it is a
+    /// wall-clock-relative deadline anchor (the SDK computes
+    /// `Offer.lockTimeout = bidding_start + lock_timeout_secs` and
+    /// `Offer.timeout = bidding_start + timeout_secs`), so capturing
+    /// it at params-build time would let the recovery scan,
+    /// `submit_lock` contention, and preflight execution consume the
+    /// lock/expiry window before the request is even submitted. It is
+    /// instead set by [`apply_bidding_start`](Self::apply_bidding_start)
+    /// immediately before `client.submit_onchain` inside the
+    /// `submit_lock` guard.
     fn apply_offer_config(&self, params: RequestParams) -> RequestParams {
         let mut offer = OfferParams::builder();
         if let Some(min_price) = &self.offer_min_price {
@@ -223,11 +231,27 @@ impl BoundlessProver {
         if let Some(lock_timeout) = self.offer_lock_timeout_secs {
             offer.lock_timeout(lock_timeout);
         }
-        offer.bidding_start(
-            Self::now_unix_secs().saturating_add(self.offer_bidding_start_delay_secs),
-        );
 
         params.with_offer(offer)
+    }
+
+    /// Sets `Offer.rampUpStart` to `now_unix_secs() + offer_bidding_start_delay_secs`
+    /// on the given params, mutating the existing offer in place rather
+    /// than replacing it (so prior `apply_offer_config` settings are
+    /// preserved).
+    ///
+    /// Must be called as late as possible — ideally inside the
+    /// `submit_lock` guard, immediately before `client.submit_onchain`
+    /// — so that the deadline anchor is fresh at the moment the
+    /// request actually hits the chain. Calling it earlier (e.g. when
+    /// the params are first built) lets recovery RPC latency and lock
+    /// contention silently consume the lock/expiry window before the
+    /// request exists, which can result in requests submitted with
+    /// little or no remaining lock window.
+    fn apply_bidding_start(&self, mut params: RequestParams) -> RequestParams {
+        params.offer.bidding_start =
+            Some(Self::now_unix_secs().saturating_add(self.offer_bidding_start_delay_secs));
+        params
     }
 
     /// Fetches and ABI-encodes the set inclusion receipt for a fulfilled
@@ -467,6 +491,12 @@ impl BoundlessProver {
     ) -> Result<AttestationProof> {
         let (request_id, expires_at) = {
             let _guard = self.submit_lock.lock().await;
+            // Anchor `Offer.rampUpStart` to the current wall-clock as
+            // late as possible — after any recovery scan, preflight,
+            // and `submit_lock` contention — so the full configured
+            // lock/timeout window is available to provers once the
+            // request hits the chain. See `apply_bidding_start`.
+            let params = self.apply_bidding_start(params);
             client.submit_onchain(params).await.map_err(|e| {
                 warn!(
                     error = %e,
@@ -894,26 +924,25 @@ mod tests {
         assert_eq!(prover.offer_bidding_start_delay_secs, 0);
     }
 
-    /// With defaults (ramp = 0, bidding delay = 0), `apply_offer_config`
-    /// always emits an offer override that sets `ramp_up_period = 0`
-    /// and `bidding_start` to the current wall-clock time. The other
-    /// (still-Option) fields remain unset so the Boundless SDK derives
-    /// them from cycle count.
+    /// With defaults (ramp = 0), `apply_offer_config` always emits an
+    /// offer override that sets `ramp_up_period = 0`. The other
+    /// (still-Option) price/timeout fields remain unset so the
+    /// Boundless SDK derives them from cycle count. `bidding_start`
+    /// is intentionally **not** set here — it is anchored later by
+    /// `apply_bidding_start` immediately before on-chain submission.
     #[rstest]
     fn apply_offer_config_defaults_enable_fast_lane(prover: BoundlessProver) {
-        let before = BoundlessProver::now_unix_secs();
         let params = prover.apply_offer_config(RequestParams::new());
-        let after = BoundlessProver::now_unix_secs();
 
         assert_eq!(params.offer.ramp_up_period, Some(0));
-        let bidding_start = params.offer.bidding_start.expect("bidding_start always set");
-        assert!(
-            (before..=after).contains(&bidding_start),
-            "bidding_start {bidding_start} outside [{before}, {after}]"
-        );
         assert!(params.offer.min_price.is_none());
         assert!(params.offer.max_price.is_none());
         assert!(params.offer.lock_timeout.is_none());
+        assert!(
+            params.offer.bidding_start.is_none(),
+            "bidding_start must be left unset by apply_offer_config and only \
+             populated by apply_bidding_start at submission time"
+        );
     }
 
     #[rstest]
@@ -926,14 +955,59 @@ mod tests {
         prover.offer_lock_timeout_secs = Some(TEST_LOCK_TIMEOUT_SECS);
         prover.offer_bidding_start_delay_secs = TEST_NON_ZERO_BIDDING_START_DELAY_SECS;
 
-        let before = BoundlessProver::now_unix_secs();
         let params = prover.apply_offer_config(RequestParams::new());
-        let after = BoundlessProver::now_unix_secs();
 
         assert_eq!(params.offer.min_price, Some(min_price));
         assert_eq!(params.offer.max_price, Some(max_price));
         assert_eq!(params.offer.ramp_up_period, Some(TEST_RAMP_UP_PERIOD_SECS));
         assert_eq!(params.offer.lock_timeout, Some(TEST_LOCK_TIMEOUT_SECS));
+        assert!(
+            params.offer.bidding_start.is_none(),
+            "bidding_start is set by apply_bidding_start, not apply_offer_config"
+        );
+    }
+
+    /// `lock_timeout` can be set independently of price fields; the
+    /// always-set ramp default still flows through.
+    #[rstest]
+    fn apply_offer_config_sets_lock_timeout_alone(mut prover: BoundlessProver) {
+        prover.offer_lock_timeout_secs = Some(TEST_LOCK_TIMEOUT_SECS);
+
+        let params = prover.apply_offer_config(RequestParams::new());
+
+        assert_eq!(params.offer.lock_timeout, Some(TEST_LOCK_TIMEOUT_SECS));
+        assert_eq!(params.offer.ramp_up_period, Some(0));
+        assert!(params.offer.min_price.is_none());
+        assert!(params.offer.max_price.is_none());
+        assert!(params.offer.bidding_start.is_none());
+    }
+
+    /// `apply_bidding_start` with the default (`0`) delay sets
+    /// `bidding_start` to the current wall-clock at call time.
+    #[rstest]
+    fn apply_bidding_start_defaults_to_now(prover: BoundlessProver) {
+        let before = BoundlessProver::now_unix_secs();
+        let params = prover.apply_bidding_start(RequestParams::new());
+        let after = BoundlessProver::now_unix_secs();
+
+        let bidding_start = params.offer.bidding_start.expect("bidding_start set");
+        assert!(
+            (before..=after).contains(&bidding_start),
+            "bidding_start {bidding_start} outside [{before}, {after}]"
+        );
+    }
+
+    /// Non-zero `bidding_start_delay` is offset from the current clock
+    /// at call time (per-request, not captured at startup), so the
+    /// resulting timestamp is always in the configured window.
+    #[rstest]
+    fn apply_bidding_start_uses_current_clock(mut prover: BoundlessProver) {
+        prover.offer_bidding_start_delay_secs = TEST_NON_ZERO_BIDDING_START_DELAY_SECS;
+
+        let before = BoundlessProver::now_unix_secs();
+        let params = prover.apply_bidding_start(RequestParams::new());
+        let after = BoundlessProver::now_unix_secs();
+
         let bidding_start = params.offer.bidding_start.expect("bidding_start set");
         assert!(
             (before.saturating_add(TEST_NON_ZERO_BIDDING_START_DELAY_SECS)
@@ -943,37 +1017,26 @@ mod tests {
         );
     }
 
-    /// `lock_timeout` can be set independently of price fields; the
-    /// always-set ramp/bidding-start defaults still flow through.
+    /// `apply_bidding_start` preserves all other offer fields set by
+    /// `apply_offer_config` — it mutates `bidding_start` in place
+    /// rather than replacing the offer.
     #[rstest]
-    fn apply_offer_config_sets_lock_timeout_alone(mut prover: BoundlessProver) {
+    fn apply_bidding_start_preserves_other_offer_fields(mut prover: BoundlessProver) {
+        let min_price = eth_amount(TEST_MIN_PRICE_ETH);
+        let max_price = eth_amount(TEST_MAX_PRICE_ETH);
+        prover.offer_min_price = Some(min_price.clone());
+        prover.offer_max_price = Some(max_price.clone());
+        prover.offer_ramp_up_period_secs = TEST_RAMP_UP_PERIOD_SECS;
         prover.offer_lock_timeout_secs = Some(TEST_LOCK_TIMEOUT_SECS);
 
         let params = prover.apply_offer_config(RequestParams::new());
+        let params = prover.apply_bidding_start(params);
 
+        assert_eq!(params.offer.min_price, Some(min_price));
+        assert_eq!(params.offer.max_price, Some(max_price));
+        assert_eq!(params.offer.ramp_up_period, Some(TEST_RAMP_UP_PERIOD_SECS));
         assert_eq!(params.offer.lock_timeout, Some(TEST_LOCK_TIMEOUT_SECS));
-        assert_eq!(params.offer.ramp_up_period, Some(0));
         assert!(params.offer.bidding_start.is_some());
-        assert!(params.offer.min_price.is_none());
-        assert!(params.offer.max_price.is_none());
-    }
-
-    /// Non-zero `bidding_start_delay` is offset from the current clock,
-    /// not captured at startup, so the resulting timestamp is always
-    /// in the future at call time.
-    #[rstest]
-    fn apply_offer_config_bidding_start_uses_current_clock(mut prover: BoundlessProver) {
-        prover.offer_bidding_start_delay_secs = TEST_NON_ZERO_BIDDING_START_DELAY_SECS;
-
-        let before = BoundlessProver::now_unix_secs();
-        let params = prover.apply_offer_config(RequestParams::new());
-
-        let bidding_start = params.offer.bidding_start.expect("bidding_start set");
-        assert!(
-            bidding_start >= before.saturating_add(TEST_NON_ZERO_BIDDING_START_DELAY_SECS),
-            "bidding_start {bidding_start} should be >= {} (before + delay)",
-            before.saturating_add(TEST_NON_ZERO_BIDDING_START_DELAY_SECS)
-        );
     }
 
     // ── Clone ───────────────────────────────────────────────────────────

--- a/crates/proof/tee/registrar/src/config.rs
+++ b/crates/proof/tee/registrar/src/config.rs
@@ -68,6 +68,15 @@ pub struct BoundlessConfig {
     /// in the first place. When unset, the Boundless SDK derives a
     /// recommended value from the program's cycle count.
     pub offer_lock_timeout_secs: Option<u32>,
+    /// Optional delay, in seconds, between request submission and the
+    /// moment bidding is allowed to begin (`Offer.rampUpStart`). With
+    /// this set to `0`, bidding opens immediately at submission, which
+    /// eliminates the SDK's default cycle-count-derived "discovery
+    /// window" (`bidding_start_delay`) and lets the fastest prover lock
+    /// as soon as they finish executing the guest program. When unset,
+    /// the Boundless SDK derives a delay roughly equal to the program's
+    /// executor time (`cycles / 1 MHz`, capped at 1 hour).
+    pub offer_bidding_start_delay_secs: Option<u64>,
 }
 
 impl std::fmt::Debug for BoundlessConfig {
@@ -85,6 +94,7 @@ impl std::fmt::Debug for BoundlessConfig {
             .field("offer_max_price", &self.offer_max_price)
             .field("offer_ramp_up_period_secs", &self.offer_ramp_up_period_secs)
             .field("offer_lock_timeout_secs", &self.offer_lock_timeout_secs)
+            .field("offer_bidding_start_delay_secs", &self.offer_bidding_start_delay_secs)
             .finish()
     }
 }

--- a/crates/proof/tee/registrar/src/config.rs
+++ b/crates/proof/tee/registrar/src/config.rs
@@ -59,13 +59,13 @@ pub struct BoundlessConfig {
     pub offer_min_price: Option<Amount>,
     /// Optional maximum Boundless offer price for each submitted proof request.
     pub offer_max_price: Option<Amount>,
-    /// Duration in seconds for the Boundless offer price to ramp from
-    /// `offer_min_price` to `offer_max_price`. Defaults to `0` so that
-    /// the maximum price is offered immediately, eliminating the
-    /// "discount window" at the start of the auction and minimising
-    /// time-to-lock. Set to a non-zero value to introduce a price ramp
-    /// (e.g. for cost optimisation when latency is less critical).
-    pub offer_ramp_up_period_secs: u32,
+    /// Optional duration in seconds for the Boundless offer price to
+    /// ramp from `offer_min_price` to `offer_max_price`. When unset
+    /// the Boundless SDK derives a cycle-count-based ramp; set to `0`
+    /// to eliminate the ramp entirely so that the max price is offered
+    /// immediately (a "fast lane" tradeoff that minimises time-to-lock
+    /// at the cost of paying the max price every time).
+    pub offer_ramp_up_period_secs: Option<u32>,
     /// Optional maximum time, in seconds, that a prover that locks a
     /// request has to deliver the proof before forfeiting its stake bond
     /// and the request opening up to permissionless secondary

--- a/crates/proof/tee/registrar/src/config.rs
+++ b/crates/proof/tee/registrar/src/config.rs
@@ -59,8 +59,13 @@ pub struct BoundlessConfig {
     pub offer_min_price: Option<Amount>,
     /// Optional maximum Boundless offer price for each submitted proof request.
     pub offer_max_price: Option<Amount>,
-    /// Optional duration in seconds for Boundless price to ramp from min to max.
-    pub offer_ramp_up_period_secs: Option<u32>,
+    /// Duration in seconds for the Boundless offer price to ramp from
+    /// `offer_min_price` to `offer_max_price`. Defaults to `0` so that
+    /// the maximum price is offered immediately, eliminating the
+    /// "discount window" at the start of the auction and minimising
+    /// time-to-lock. Set to a non-zero value to introduce a price ramp
+    /// (e.g. for cost optimisation when latency is less critical).
+    pub offer_ramp_up_period_secs: u32,
     /// Optional maximum time, in seconds, that a prover that locks a
     /// request has to deliver the proof before forfeiting its stake bond
     /// and the request opening up to permissionless secondary
@@ -68,15 +73,15 @@ pub struct BoundlessConfig {
     /// in the first place. When unset, the Boundless SDK derives a
     /// recommended value from the program's cycle count.
     pub offer_lock_timeout_secs: Option<u32>,
-    /// Optional delay, in seconds, between request submission and the
-    /// moment bidding is allowed to begin (`Offer.rampUpStart`). With
-    /// this set to `0`, bidding opens immediately at submission, which
-    /// eliminates the SDK's default cycle-count-derived "discovery
-    /// window" (`bidding_start_delay`) and lets the fastest prover lock
-    /// as soon as they finish executing the guest program. When unset,
-    /// the Boundless SDK derives a delay roughly equal to the program's
-    /// executor time (`cycles / 1 MHz`, capped at 1 hour).
-    pub offer_bidding_start_delay_secs: Option<u64>,
+    /// Delay, in seconds, between request submission and the moment
+    /// bidding is allowed to begin (`Offer.rampUpStart`). Defaults to
+    /// `0` so that bidding opens immediately at submission, eliminating
+    /// the SDK's default cycle-count-derived "discovery window" and
+    /// letting the fastest prover lock as soon as it finishes executing
+    /// the guest program. Set to a non-zero value to introduce a
+    /// discovery delay (typically to give more provers time to see the
+    /// request, at the cost of latency).
+    pub offer_bidding_start_delay_secs: u64,
 }
 
 impl std::fmt::Debug for BoundlessConfig {


### PR DESCRIPTION
Adds `--boundless-offer-bidding-start-delay-secs` to the prover-registrar CLI, threading the value through `BoundlessConfig` and `BoundlessProver` into `OfferParams::bidding_start`. Mirrors the wiring introduced in #2949 (offer pricing) and #2996 (lock timeout) for the other offer fields.

## What this controls

`bidding_start` (`Offer.rampUpStart` on-chain) is the moment a request becomes biddable. Before this instant the request is published on-chain but no prover can lock it.

The Boundless SDK auto-derives this value as roughly the guest program's executor time (`cycle_count / 1 MHz`, capped at 1 hour), creating a 'discovery window' that ensures provers have time to find the request and run the executor before bidding opens. This window is visible on the Boundless explorer as the flat period preceding the price ramp.

For our 314M-cycle workload that derived window is ~5 min 15 sec — a substantial chunk of the observed ~21 min total turn-around.

## Why expose it as an explicit flag

Setting `--boundless-offer-bidding-start-delay-secs=0` eliminates the discovery window entirely:

- Bidding opens immediately at request submission.
- The fastest prover can lock as soon as it has executed the program.
- End-to-end submission→fulfillment latency drops to roughly `executor_time + proving_time` (~15 min for our workload, down from ~21 min).

Trade-offs:

- **Higher effective price**: with no flat period, provers don't get a chance to compete on price during a ramp; you'll typically pay closer to `max_price`. (Mitigated by setting `min_price == max_price` anyway in a 'fast lane' configuration.)
- **Smaller prover set**: only provers fast enough to discover, execute, and lock immediately will win these requests. With a longer flat period more provers can compete.
- **Possible no-lock fallthrough**: if no prover wins in time, the request waits through the rest of `lockTimeout` before opening to secondary fulfillment, which is slower than the discovery-window default.

## Implementation note: per-request `now()`

`OfferParams::bidding_start` is an **absolute** Unix timestamp, not a delay. The new field is exposed as a *delay* and converted to an absolute timestamp per request inside `apply_offer_config` (`now_unix_secs() + delay`). This avoids the failure mode where a value captured at registrar startup ends up far in the past after hours of uptime.

The helper `BoundlessProver::now_unix_secs()` is factored out so tests can assert the computed timestamp falls within a `(before, after)` window bracketing the call.

## Combined recipe for fastest turn-around

Together with the offer pricing knobs from #2949 and the lock-timeout knob from #2996, operators can now run a 'fast lane' configuration that skips the auction entirely:

```
BASE_REGISTRAR_BOUNDLESS_OFFER_BIDDING_START_DELAY_SECS=0     # no discovery window
BASE_REGISTRAR_BOUNDLESS_OFFER_RAMP_UP_PERIOD_SECS=0          # no price ramp
BASE_REGISTRAR_BOUNDLESS_MIN_PRICE_ETH=<X>                    # same as max
BASE_REGISTRAR_BOUNDLESS_MAX_PRICE_ETH=<X>                    # high enough to attract fast provers
BASE_REGISTRAR_BOUNDLESS_OFFER_LOCK_TIMEOUT_SECS=<proving_time + buffer>
```

## Tests

- `boundless_offer_bidding_start_delay_parses` — CLI flag round-trips into `BoundlessConfig`.
- `apply_offer_config_sets_bidding_start_alone` — `bidding_start_delay` is enough on its own to emit an offer override (early-return guard updated); resulting `bidding_start` falls within `[before+delay, after+delay]`.
- `apply_offer_config_bidding_start_uses_current_clock` — non-zero delay is offset from the current clock at call time, not captured at startup.
- Existing `apply_offer_config_preserves_default_when_unset` / `apply_offer_config_sets_explicit_prices` extended to cover the new field.

cc #2949 #2996