### PR TITLE
feat(devnet): Add Network-Aware Activation Scripts

### DIFF
--- a/etc/scripts/devnet/activate-features.sh
+++ b/etc/scripts/devnet/activate-features.sh
@@ -1,0 +1,227 @@
+#!/usr/bin/env bash
+# activate-features.sh — activate every Base-native feature in the activation
+# registry precompile.
+#
+# Prerequisites:
+#   • cast (foundry) in PATH
+#
+# Usage:
+#   ./activate-features.sh [network] [rpc-url]
+#   ./activate-features.sh --network <network> [--rpc-url <url>] [--admin-key <private-key>]
+#
+# Examples:
+#   ./activate-features.sh
+#   ./activate-features.sh vibes
+#   ./activate-features.sh devnet http://localhost:8545
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/activation-networks.sh"
+NETWORK="${ACTIVATION_NETWORK:-vibes}"
+
+# ── Colours ───────────────────────────────────────────────────────────────────
+RED='\033[0;31m'; GREEN='\033[0;32m'; CYAN='\033[0;36m'; YELLOW='\033[0;33m'; BOLD='\033[1m'; NC='\033[0m'
+
+# ── Config ────────────────────────────────────────────────────────────────────
+REGISTRY="0x8453000000000000000000000000000000000001"
+
+# Feature id ↔ canonical name pairs (kept in sync with
+# crates/common/precompiles/src/activation/storage.rs::ActivationFeature).
+FEATURES=(
+    "base.b20_token:0x47a1afe8d3d691b87e090ee972d223a11f4da971ff5416c04985bb2393aca752"
+    "base.b20_factory:0x78751e29c8bcc0d609ab18e9fbc4158e73f7db25ae2ee095dad42e2578b1e800"
+    "base.policy_registry:0xb582ebae03f16fee49a6763f78df482fb11ae73f103ed0d330bbe556aa90a43f"
+    "base.b20_stablecoin:0xecfa0def2c10020caaf65e6155aa69c84b24892aaef76eeac52e0e2b3a0b8601"
+    "base.b20_security:0x83d32fab502ae0e8bc4352a117767262cb5e47cc8d67a744008ed4ff03fcf5e6"
+)
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+trim() { echo "$1" | tr -d '"' | sed 's/ \[.*\]$//' | xargs; }
+
+usage() {
+    cat <<EOF
+Usage:
+  $0 [network] [rpc-url]
+  $0 --network <network> [--rpc-url <url>] [--admin-addr <address>] [--admin-key <private-key>]
+
+Networks: $(activation_supported_networks)
+
+Examples:
+  $0
+  $0 vibes
+  $0 devnet http://localhost:8545
+  $0 --network base-sepolia --rpc-url <url> --admin-key <private-key>
+EOF
+}
+
+NETWORK_SET=false
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -h | --help)
+            usage
+            exit 0
+            ;;
+        -n | --network)
+            shift
+            [[ $# -gt 0 ]] || { echo "--network requires a value" >&2; exit 1; }
+            NETWORK="$1"
+            NETWORK_SET=true
+            ;;
+        --network=*)
+            NETWORK="${1#*=}"
+            NETWORK_SET=true
+            ;;
+        -r | --rpc-url)
+            shift
+            [[ $# -gt 0 ]] || { echo "--rpc-url requires a value" >&2; exit 1; }
+            RPC_URL="$1"
+            ;;
+        --rpc-url=*)
+            RPC_URL="${1#*=}"
+            ;;
+        --admin-addr)
+            shift
+            [[ $# -gt 0 ]] || { echo "--admin-addr requires a value" >&2; exit 1; }
+            ADMIN_ADDR="$1"
+            ;;
+        --admin-addr=*)
+            ADMIN_ADDR="${1#*=}"
+            ;;
+        --admin-key)
+            shift
+            [[ $# -gt 0 ]] || { echo "--admin-key requires a value" >&2; exit 1; }
+            ADMIN_KEY="$1"
+            ;;
+        --admin-key=*)
+            ADMIN_KEY="${1#*=}"
+            ;;
+        *)
+            if activation_arg_is_url "$1"; then
+                [[ -z "${RPC_URL:-}" ]] || { echo "RPC URL specified more than once" >&2; exit 1; }
+                RPC_URL="$1"
+            elif [[ "$NETWORK_SET" == false ]]; then
+                NETWORK="$1"
+                NETWORK_SET=true
+            else
+                echo "Unexpected argument: $1" >&2
+                usage >&2
+                exit 1
+            fi
+            ;;
+    esac
+    shift
+done
+
+resolve_activation_network_defaults
+require_activation_rpc_url
+
+command -v cast >/dev/null 2>&1 || {
+    echo -e "${RED}cast not found — install foundry: https://getfoundry.sh${NC}" >&2
+    exit 1
+}
+
+# ── Pre-flight ────────────────────────────────────────────────────────────────
+echo -e "${CYAN}${BOLD}Activate Features${NC} on ${REGISTRY}"
+echo -e "${YELLOW}  → Network: ${NETWORK}${NC}"
+echo -e "${YELLOW}  → RPC:     ${RPC_URL}${NC}"
+
+CHAIN_ID=$(cast chain-id --rpc-url "$RPC_URL" 2>&1) || {
+    echo -e "${RED}Node not reachable at ${RPC_URL}${NC}" >&2
+    exit 1
+}
+echo -e "${YELLOW}  → Chain:   ${CHAIN_ID}${NC}"
+
+ON_CHAIN_ADMIN_RAW=$(cast call --rpc-url "$RPC_URL" "$REGISTRY" "admin()(address)" 2>&1) || {
+    echo -e "${RED}admin() call failed:${NC} $ON_CHAIN_ADMIN_RAW" >&2
+    exit 1
+}
+ON_CHAIN_ADMIN=$(trim "$ON_CHAIN_ADMIN_RAW")
+ADMIN_ADDR="${ADMIN_ADDR:-$ON_CHAIN_ADMIN}"
+echo -e "${YELLOW}  → Admin:   ${ADMIN_ADDR} (on-chain: ${ON_CHAIN_ADMIN})${NC}"
+
+if [[ "$(echo "$ON_CHAIN_ADMIN" | tr '[:upper:]' '[:lower:]')" != "$(echo "$ADMIN_ADDR" | tr '[:upper:]' '[:lower:]')" ]]; then
+    echo -e "${RED}Configured admin for ${NETWORK} (${ADMIN_ADDR}) does not match on-chain admin (${ON_CHAIN_ADMIN}).${NC}" >&2
+    exit 1
+fi
+
+if [[ -z "${ADMIN_KEY:-}" ]]; then
+    echo -e "${RED}No activation admin private key configured for network '${NETWORK}'.${NC}" >&2
+    echo -e "${RED}Pass --admin-key or set ACTIVATION_ADMIN_KEY / a network-specific admin key env var.${NC}" >&2
+    exit 1
+fi
+
+KEY_ADDR_RAW=$(cast wallet address --private-key "$ADMIN_KEY" 2>&1) || {
+    echo -e "${RED}Could not derive address from activation admin private key:${NC} $KEY_ADDR_RAW" >&2
+    exit 1
+}
+KEY_ADDR=$(trim "$KEY_ADDR_RAW")
+
+if [[ "$(echo "$KEY_ADDR" | tr '[:upper:]' '[:lower:]')" != "$(echo "$ON_CHAIN_ADMIN" | tr '[:upper:]' '[:lower:]')" ]]; then
+    echo -e "${RED}Activation admin key resolves to ${KEY_ADDR}, but on-chain admin is ${ON_CHAIN_ADMIN}.${NC}" >&2
+    exit 1
+fi
+
+BAL=$(cast balance --rpc-url "$RPC_URL" "$ADMIN_ADDR" 2>&1)
+[[ -n "$BAL" && "$BAL" != "0" ]] || {
+    echo -e "${RED}Admin (${ADMIN_ADDR}) has no ETH on ${RPC_URL}${NC}" >&2
+    exit 1
+}
+echo -e "${YELLOW}  → Admin balance: $(cast from-wei "$BAL") ETH${NC}"
+echo ""
+
+# ── Activate each feature ─────────────────────────────────────────────────────
+activated=0
+skipped=0
+failed=0
+
+for entry in "${FEATURES[@]}"; do
+    name="${entry%%:*}"
+    id="${entry##*:}"
+
+    current_raw=$(cast call --rpc-url "$RPC_URL" "$REGISTRY" \
+        "isActivated(bytes32)(bool)" "$id" 2>&1) || {
+        echo -e "  ${RED}✗ fail${NC}  ${name}: isActivated call failed: ${current_raw}"
+        failed=$((failed + 1))
+        continue
+    }
+    current=$(trim "$current_raw")
+
+    if [[ "$current" == "true" ]]; then
+        echo -e "  ${YELLOW}↷ skip${NC}  ${BOLD}${name}${NC} — already active"
+        skipped=$((skipped + 1))
+        continue
+    fi
+
+    echo -e "  ${CYAN}→ send${NC}  activate(${name}) …"
+    out=$(cast send \
+        --rpc-url "$RPC_URL" \
+        --private-key "$ADMIN_KEY" \
+        --json \
+        --confirmations 1 \
+        "$REGISTRY" \
+        "activate(bytes32)" "$id" 2>&1) || {
+        echo -e "  ${RED}✗ fail${NC}  ${name}: ${out}"
+        failed=$((failed + 1))
+        continue
+    }
+
+    tx_hash=$(echo "$out" | grep -o '"transactionHash":"[^"]*"' | cut -d'"' -f4)
+    status=$(echo "$out" | grep -o '"status":"[^"]*"' | cut -d'"' -f4)
+
+    if [[ "$status" == "0x1" ]]; then
+        echo -e "  ${GREEN}✓ ok${NC}    ${BOLD}${name}${NC}  tx=${tx_hash}"
+        activated=$((activated + 1))
+    else
+        echo -e "  ${RED}✗ fail${NC}  ${name} reverted (status=${status})  tx=${tx_hash}"
+        failed=$((failed + 1))
+    fi
+done
+
+# ── Summary ───────────────────────────────────────────────────────────────────
+echo ""
+echo -e "${BOLD}Summary:${NC} ${GREEN}${activated} activated${NC}, ${YELLOW}${skipped} skipped${NC}, ${RED}${failed} failed${NC}"
+
+if [[ "$failed" -gt 0 ]]; then
+    exit 1
+fi

--- a/etc/scripts/devnet/activate-features.sh
+++ b/etc/scripts/devnet/activate-features.sh
@@ -7,7 +7,7 @@
 #
 # Usage:
 #   ./activate-features.sh [network] [rpc-url]
-#   ./activate-features.sh --network <network> [--rpc-url <url>] [--admin-key <private-key>]
+#   ./activate-features.sh --network <network> [--rpc-url <url>]
 #
 # Examples:
 #   ./activate-features.sh
@@ -26,24 +26,11 @@ RED='\033[0;31m'; GREEN='\033[0;32m'; CYAN='\033[0;36m'; YELLOW='\033[0;33m'; BO
 # ── Config ────────────────────────────────────────────────────────────────────
 REGISTRY="0x8453000000000000000000000000000000000001"
 
-# Feature id ↔ canonical name pairs (kept in sync with
-# crates/common/precompiles/src/activation/storage.rs::ActivationFeature).
-FEATURES=(
-    "base.b20_token:0x47a1afe8d3d691b87e090ee972d223a11f4da971ff5416c04985bb2393aca752"
-    "base.b20_factory:0x78751e29c8bcc0d609ab18e9fbc4158e73f7db25ae2ee095dad42e2578b1e800"
-    "base.policy_registry:0xb582ebae03f16fee49a6763f78df482fb11ae73f103ed0d330bbe556aa90a43f"
-    "base.b20_stablecoin:0xecfa0def2c10020caaf65e6155aa69c84b24892aaef76eeac52e0e2b3a0b8601"
-    "base.b20_security:0x83d32fab502ae0e8bc4352a117767262cb5e47cc8d67a744008ed4ff03fcf5e6"
-)
-
-# ── Helpers ───────────────────────────────────────────────────────────────────
-trim() { echo "$1" | tr -d '"' | sed 's/ \[.*\]$//' | xargs; }
-
 usage() {
     cat <<EOF
 Usage:
   $0 [network] [rpc-url]
-  $0 --network <network> [--rpc-url <url>] [--admin-addr <address>] [--admin-key <private-key>]
+  $0 --network <network> [--rpc-url <url>] [--admin-addr <address>]
 
 Networks: $(activation_supported_networks)
 
@@ -51,7 +38,7 @@ Examples:
   $0
   $0 vibes
   $0 devnet http://localhost:8545
-  $0 --network base-sepolia --rpc-url <url> --admin-key <private-key>
+  ACTIVATION_ADMIN_KEY=<private-key> $0 --network base-sepolia --rpc-url <url>
 EOF
 }
 
@@ -87,14 +74,6 @@ while [[ $# -gt 0 ]]; do
             ;;
         --admin-addr=*)
             ADMIN_ADDR="${1#*=}"
-            ;;
-        --admin-key)
-            shift
-            [[ $# -gt 0 ]] || { echo "--admin-key requires a value" >&2; exit 1; }
-            ADMIN_KEY="$1"
-            ;;
-        --admin-key=*)
-            ADMIN_KEY="${1#*=}"
             ;;
         *)
             if activation_arg_is_url "$1"; then
@@ -136,7 +115,7 @@ ON_CHAIN_ADMIN_RAW=$(cast call --rpc-url "$RPC_URL" "$REGISTRY" "admin()(address
     echo -e "${RED}admin() call failed:${NC} $ON_CHAIN_ADMIN_RAW" >&2
     exit 1
 }
-ON_CHAIN_ADMIN=$(trim "$ON_CHAIN_ADMIN_RAW")
+ON_CHAIN_ADMIN=$(activation_trim "$ON_CHAIN_ADMIN_RAW")
 ADMIN_ADDR="${ADMIN_ADDR:-$ON_CHAIN_ADMIN}"
 echo -e "${YELLOW}  → Admin:   ${ADMIN_ADDR} (on-chain: ${ON_CHAIN_ADMIN})${NC}"
 
@@ -147,22 +126,14 @@ fi
 
 if [[ -z "${ADMIN_KEY:-}" ]]; then
     echo -e "${RED}No activation admin private key configured for network '${NETWORK}'.${NC}" >&2
-    echo -e "${RED}Pass --admin-key or set ACTIVATION_ADMIN_KEY / a network-specific admin key env var.${NC}" >&2
+    echo -e "${RED}Set ACTIVATION_ADMIN_KEY or a network-specific admin key env var.${NC}" >&2
     exit 1
 fi
 
-KEY_ADDR_RAW=$(cast wallet address --private-key "$ADMIN_KEY" 2>&1) || {
-    echo -e "${RED}Could not derive address from activation admin private key:${NC} $KEY_ADDR_RAW" >&2
+BAL=$(cast balance --rpc-url "$RPC_URL" "$ADMIN_ADDR" 2>&1) || {
+    echo -e "${RED}Failed to query admin balance on ${RPC_URL}: ${BAL}${NC}" >&2
     exit 1
 }
-KEY_ADDR=$(trim "$KEY_ADDR_RAW")
-
-if [[ "$(echo "$KEY_ADDR" | tr '[:upper:]' '[:lower:]')" != "$(echo "$ON_CHAIN_ADMIN" | tr '[:upper:]' '[:lower:]')" ]]; then
-    echo -e "${RED}Activation admin key resolves to ${KEY_ADDR}, but on-chain admin is ${ON_CHAIN_ADMIN}.${NC}" >&2
-    exit 1
-fi
-
-BAL=$(cast balance --rpc-url "$RPC_URL" "$ADMIN_ADDR" 2>&1)
 [[ -n "$BAL" && "$BAL" != "0" ]] || {
     echo -e "${RED}Admin (${ADMIN_ADDR}) has no ETH on ${RPC_URL}${NC}" >&2
     exit 1
@@ -175,7 +146,7 @@ activated=0
 skipped=0
 failed=0
 
-for entry in "${FEATURES[@]}"; do
+for entry in "${ACTIVATION_FEATURES[@]}"; do
     name="${entry%%:*}"
     id="${entry##*:}"
 
@@ -185,7 +156,7 @@ for entry in "${FEATURES[@]}"; do
         failed=$((failed + 1))
         continue
     }
-    current=$(trim "$current_raw")
+    current=$(activation_trim "$current_raw")
 
     if [[ "$current" == "true" ]]; then
         echo -e "  ${YELLOW}↷ skip${NC}  ${BOLD}${name}${NC} — already active"
@@ -194,9 +165,8 @@ for entry in "${FEATURES[@]}"; do
     fi
 
     echo -e "  ${CYAN}→ send${NC}  activate(${name}) …"
-    out=$(cast send \
+    out=$(ETH_PRIVATE_KEY="$ADMIN_KEY" cast send \
         --rpc-url "$RPC_URL" \
-        --private-key "$ADMIN_KEY" \
         --json \
         --confirmations 1 \
         "$REGISTRY" \

--- a/etc/scripts/devnet/activation-networks.sh
+++ b/etc/scripts/devnet/activation-networks.sh
@@ -11,6 +11,16 @@ if [[ -f "$ACTIVATION_ENV_FILE" ]]; then
     set +a
 fi
 
+# Feature id ↔ canonical name pairs (kept in sync with
+# crates/common/precompiles/src/activation/storage.rs::ActivationFeature).
+ACTIVATION_FEATURES=(
+    "base.b20_token:0x47a1afe8d3d691b87e090ee972d223a11f4da971ff5416c04985bb2393aca752"
+    "base.b20_factory:0x78751e29c8bcc0d609ab18e9fbc4158e73f7db25ae2ee095dad42e2578b1e800"
+    "base.policy_registry:0xb582ebae03f16fee49a6763f78df482fb11ae73f103ed0d330bbe556aa90a43f"
+    "base.b20_stablecoin:0xecfa0def2c10020caaf65e6155aa69c84b24892aaef76eeac52e0e2b3a0b8601"
+    "base.b20_security:0x83d32fab502ae0e8bc4352a117767262cb5e47cc8d67a744008ed4ff03fcf5e6"
+)
+
 activation_supported_networks() {
     echo "vibes, devnet, base, base-sepolia, base-zeronet, custom"
 }
@@ -49,6 +59,17 @@ activation_arg_is_url() {
     [[ "$1" == http://* || "$1" == https://* ]]
 }
 
+activation_trim() {
+    local value="$1"
+    value="${value//\"/}"
+    value="${value#"${value%%[![:space:]]*}"}"
+    value="${value%"${value##*[![:space:]]}"}"
+    value="${value% \[*\]}"
+    value="${value#"${value%%[![:space:]]*}"}"
+    value="${value%"${value##*[![:space:]]}"}"
+    printf '%s\n' "$value"
+}
+
 resolve_activation_network_defaults() {
     local hardhat_account_5_addr="${ANVIL_ACCOUNT_5_ADDR:-0x9965507D1a55bcC2695C58ba16FB37d819B0A4dc}"
     local hardhat_account_5_key="${ANVIL_ACCOUNT_5_KEY:-0x8b3a350cf5c34c9194ca85829a2df0ec3153be0318b5e2d3348e872092edffba}"
@@ -62,7 +83,7 @@ resolve_activation_network_defaults() {
         vibes)
             RPC_URL="${RPC_URL:-${VIBES_RPC_URL:-https://rpc.vibes.base.org}}"
             ADMIN_ADDR="${ADMIN_ADDR:-${VIBES_ACTIVATION_ADMIN_ADDR:-$hardhat_account_5_addr}}"
-            ADMIN_KEY="${ADMIN_KEY:-${VIBES_ACTIVATION_ADMIN_KEY:-$hardhat_account_5_key}}"
+            ADMIN_KEY="${ADMIN_KEY:-${VIBES_ACTIVATION_ADMIN_KEY:-}}"
             ;;
         devnet)
             RPC_URL="${RPC_URL:-${DEVNET_RPC_URL:-${L2_CLIENT_RPC_URL:-http://localhost:8545}}}"

--- a/etc/scripts/devnet/activation-networks.sh
+++ b/etc/scripts/devnet/activation-networks.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+
+# Shared network defaults for activation registry scripts.
+
+ACTIVATION_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ACTIVATION_ENV_FILE="$ACTIVATION_SCRIPT_DIR/../../docker/devnet-env"
+
+if [[ -f "$ACTIVATION_ENV_FILE" ]]; then
+    set -a
+    source "$ACTIVATION_ENV_FILE"
+    set +a
+fi
+
+activation_supported_networks() {
+    echo "vibes, devnet, base, base-sepolia, base-zeronet, custom"
+}
+
+activation_normalize_network() {
+    local network="$1"
+    network="$(echo "$network" | tr '[:upper:]_' '[:lower:]-')"
+
+    case "$network" in
+        "" | vibes | vibenet)
+            echo "vibes"
+            ;;
+        dev | devnet | local)
+            echo "devnet"
+            ;;
+        base | mainnet | base-mainnet)
+            echo "base"
+            ;;
+        sepolia | base-sepolia)
+            echo "base-sepolia"
+            ;;
+        zeronet | base-zeronet)
+            echo "base-zeronet"
+            ;;
+        custom)
+            echo "custom"
+            ;;
+        *)
+            echo "Unknown network '$1'. Supported networks: $(activation_supported_networks)" >&2
+            return 1
+            ;;
+    esac
+}
+
+activation_arg_is_url() {
+    [[ "$1" == http://* || "$1" == https://* ]]
+}
+
+resolve_activation_network_defaults() {
+    local hardhat_account_5_addr="${ANVIL_ACCOUNT_5_ADDR:-0x9965507D1a55bcC2695C58ba16FB37d819B0A4dc}"
+    local hardhat_account_5_key="${ANVIL_ACCOUNT_5_KEY:-0x8b3a350cf5c34c9194ca85829a2df0ec3153be0318b5e2d3348e872092edffba}"
+
+    NETWORK="$(activation_normalize_network "${NETWORK:-${ACTIVATION_NETWORK:-vibes}}")" || return 1
+    RPC_URL="${RPC_URL:-${ACTIVATION_RPC_URL:-}}"
+    ADMIN_ADDR="${ADMIN_ADDR:-${ACTIVATION_ADMIN_ADDR:-}}"
+    ADMIN_KEY="${ADMIN_KEY:-${ACTIVATION_ADMIN_KEY:-}}"
+
+    case "$NETWORK" in
+        vibes)
+            RPC_URL="${RPC_URL:-${VIBES_RPC_URL:-https://rpc.vibes.base.org}}"
+            ADMIN_ADDR="${ADMIN_ADDR:-${VIBES_ACTIVATION_ADMIN_ADDR:-$hardhat_account_5_addr}}"
+            ADMIN_KEY="${ADMIN_KEY:-${VIBES_ACTIVATION_ADMIN_KEY:-$hardhat_account_5_key}}"
+            ;;
+        devnet)
+            RPC_URL="${RPC_URL:-${DEVNET_RPC_URL:-${L2_CLIENT_RPC_URL:-http://localhost:8545}}}"
+            ADMIN_ADDR="${ADMIN_ADDR:-${DEVNET_ACTIVATION_ADMIN_ADDR:-${L2_ACTIVATION_ADMIN_ADDR:-$hardhat_account_5_addr}}}"
+            ADMIN_KEY="${ADMIN_KEY:-${DEVNET_ACTIVATION_ADMIN_KEY:-${L2_ACTIVATION_ADMIN_KEY:-$hardhat_account_5_key}}}"
+            ;;
+        base)
+            RPC_URL="${RPC_URL:-${BASE_MAINNET_RPC_URL:-${BASE_RPC_URL:-}}}"
+            ADMIN_ADDR="${ADMIN_ADDR:-${BASE_MAINNET_ACTIVATION_ADMIN_ADDR:-0x331C9d37BbcebBC9dfAf98FBE3C5B8A39Dd6E771}}"
+            ADMIN_KEY="${ADMIN_KEY:-${BASE_MAINNET_ACTIVATION_ADMIN_KEY:-}}"
+            ;;
+        base-sepolia)
+            RPC_URL="${RPC_URL:-${BASE_SEPOLIA_RPC_URL:-}}"
+            ADMIN_ADDR="${ADMIN_ADDR:-${BASE_SEPOLIA_ACTIVATION_ADMIN_ADDR:-0x5Be7Dd3678e999D5F7bC508c413db239F7D4Ac59}}"
+            ADMIN_KEY="${ADMIN_KEY:-${BASE_SEPOLIA_ACTIVATION_ADMIN_KEY:-}}"
+            ;;
+        base-zeronet)
+            RPC_URL="${RPC_URL:-${BASE_ZERONET_RPC_URL:-}}"
+            ADMIN_ADDR="${ADMIN_ADDR:-${BASE_ZERONET_ACTIVATION_ADMIN_ADDR:-0xF5969A85a555671EeD766C4ff0C61426AA626b11}}"
+            ADMIN_KEY="${ADMIN_KEY:-${BASE_ZERONET_ACTIVATION_ADMIN_KEY:-}}"
+            ;;
+        custom)
+            RPC_URL="${RPC_URL:-${CUSTOM_RPC_URL:-}}"
+            ADMIN_ADDR="${ADMIN_ADDR:-${CUSTOM_ACTIVATION_ADMIN_ADDR:-}}"
+            ADMIN_KEY="${ADMIN_KEY:-${CUSTOM_ACTIVATION_ADMIN_KEY:-}}"
+            ;;
+    esac
+}
+
+require_activation_rpc_url() {
+    if [[ -n "${RPC_URL:-}" ]]; then
+        return 0
+    fi
+
+    echo "No RPC URL configured for network '$NETWORK'." >&2
+    echo "Pass --rpc-url <url> or set ACTIVATION_RPC_URL / a network-specific RPC env var." >&2
+    return 1
+}

--- a/etc/scripts/devnet/check-activations.sh
+++ b/etc/scripts/devnet/check-activations.sh
@@ -26,19 +26,6 @@ RED='\033[0;31m'; GREEN='\033[0;32m'; CYAN='\033[0;36m'; YELLOW='\033[0;33m'; BO
 # ── Config ────────────────────────────────────────────────────────────────────
 REGISTRY="0x8453000000000000000000000000000000000001"
 
-# Feature id ↔ canonical name pairs (kept in sync with
-# crates/common/precompiles/src/activation/storage.rs::ActivationFeature).
-FEATURES=(
-    "base.b20_token:0x47a1afe8d3d691b87e090ee972d223a11f4da971ff5416c04985bb2393aca752"
-    "base.b20_factory:0x78751e29c8bcc0d609ab18e9fbc4158e73f7db25ae2ee095dad42e2578b1e800"
-    "base.policy_registry:0xb582ebae03f16fee49a6763f78df482fb11ae73f103ed0d330bbe556aa90a43f"
-    "base.b20_stablecoin:0xecfa0def2c10020caaf65e6155aa69c84b24892aaef76eeac52e0e2b3a0b8601"
-    "base.b20_security:0x83d32fab502ae0e8bc4352a117767262cb5e47cc8d67a744008ed4ff03fcf5e6"
-)
-
-# ── Helpers ───────────────────────────────────────────────────────────────────
-trim() { echo "$1" | tr -d '"' | sed 's/ \[.*\]$//' | xargs; }
-
 usage() {
     cat <<EOF
 Usage:
@@ -119,7 +106,7 @@ echo -e "${YELLOW}  → Chain ID: ${CHAIN_ID}${NC}"
 # admin() — surfaces who can activate/deactivate features on this chain.
 ADMIN_RAW=$(cast call --rpc-url "$RPC_URL" "$REGISTRY" "admin()(address)" 2>&1) \
     || { echo -e "${RED}admin() call failed:${NC} $ADMIN_RAW" >&2; exit 1; }
-ADMIN=$(trim "$ADMIN_RAW")
+ADMIN=$(activation_trim "$ADMIN_RAW")
 echo -e "${YELLOW}  → Admin: ${ADMIN}${NC}"
 echo ""
 
@@ -131,18 +118,20 @@ printf "  %-24s  %-66s  %s\n" "------------------------" \
 
 active_count=0
 inactive_count=0
-total=${#FEATURES[@]}
+error_count=0
+total=${#ACTIVATION_FEATURES[@]}
 
-for entry in "${FEATURES[@]}"; do
+for entry in "${ACTIVATION_FEATURES[@]}"; do
     name="${entry%%:*}"
     id="${entry##*:}"
 
     result=$(cast call --rpc-url "$RPC_URL" "$REGISTRY" \
         "isActivated(bytes32)(bool)" "$id" 2>&1) || {
         printf "  %-24s  %-66s  ${RED}ERROR${NC}  %s\n" "$name" "$id" "$result"
+        error_count=$((error_count + 1))
         continue
     }
-    result=$(trim "$result")
+    result=$(activation_trim "$result")
 
     if [[ "$result" == "true" ]]; then
         printf "  %-24s  %-66s  ${GREEN}✓ ACTIVE${NC}\n" "$name" "$id"
@@ -160,6 +149,6 @@ if [[ "$active_count" -eq "$total" ]]; then
     exit 0
 else
     echo -e "${YELLOW}${BOLD}${active_count}/${total} features activated${NC}" \
-        "(${inactive_count} inactive)"
+        "(${inactive_count} inactive, ${error_count} errors)"
     exit 1
 fi

--- a/etc/scripts/devnet/check-activations.sh
+++ b/etc/scripts/devnet/check-activations.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+# check-activations.sh — query the activation registry precompile and print the
+# activation state of every known Base-native feature.
+#
+# Prerequisites:
+#   • cast (foundry) in PATH
+#
+# Usage:
+#   ./check-activations.sh [network] [rpc-url]
+#   ./check-activations.sh --network <network> [--rpc-url <url>]
+#
+# Examples:
+#   ./check-activations.sh
+#   ./check-activations.sh vibes
+#   ./check-activations.sh devnet http://localhost:8545
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/activation-networks.sh"
+NETWORK="${ACTIVATION_NETWORK:-vibes}"
+
+# ── Colours ───────────────────────────────────────────────────────────────────
+RED='\033[0;31m'; GREEN='\033[0;32m'; CYAN='\033[0;36m'; YELLOW='\033[0;33m'; BOLD='\033[1m'; NC='\033[0m'
+
+# ── Config ────────────────────────────────────────────────────────────────────
+REGISTRY="0x8453000000000000000000000000000000000001"
+
+# Feature id ↔ canonical name pairs (kept in sync with
+# crates/common/precompiles/src/activation/storage.rs::ActivationFeature).
+FEATURES=(
+    "base.b20_token:0x47a1afe8d3d691b87e090ee972d223a11f4da971ff5416c04985bb2393aca752"
+    "base.b20_factory:0x78751e29c8bcc0d609ab18e9fbc4158e73f7db25ae2ee095dad42e2578b1e800"
+    "base.policy_registry:0xb582ebae03f16fee49a6763f78df482fb11ae73f103ed0d330bbe556aa90a43f"
+    "base.b20_stablecoin:0xecfa0def2c10020caaf65e6155aa69c84b24892aaef76eeac52e0e2b3a0b8601"
+    "base.b20_security:0x83d32fab502ae0e8bc4352a117767262cb5e47cc8d67a744008ed4ff03fcf5e6"
+)
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+trim() { echo "$1" | tr -d '"' | sed 's/ \[.*\]$//' | xargs; }
+
+usage() {
+    cat <<EOF
+Usage:
+  $0 [network] [rpc-url]
+  $0 --network <network> [--rpc-url <url>]
+
+Networks: $(activation_supported_networks)
+
+Examples:
+  $0
+  $0 vibes
+  $0 devnet http://localhost:8545
+  $0 --network custom --rpc-url https://example.invalid
+EOF
+}
+
+NETWORK_SET=false
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -h | --help)
+            usage
+            exit 0
+            ;;
+        -n | --network)
+            shift
+            [[ $# -gt 0 ]] || { echo "--network requires a value" >&2; exit 1; }
+            NETWORK="$1"
+            NETWORK_SET=true
+            ;;
+        --network=*)
+            NETWORK="${1#*=}"
+            NETWORK_SET=true
+            ;;
+        -r | --rpc-url)
+            shift
+            [[ $# -gt 0 ]] || { echo "--rpc-url requires a value" >&2; exit 1; }
+            RPC_URL="$1"
+            ;;
+        --rpc-url=*)
+            RPC_URL="${1#*=}"
+            ;;
+        *)
+            if activation_arg_is_url "$1"; then
+                [[ -z "${RPC_URL:-}" ]] || { echo "RPC URL specified more than once" >&2; exit 1; }
+                RPC_URL="$1"
+            elif [[ "$NETWORK_SET" == false ]]; then
+                NETWORK="$1"
+                NETWORK_SET=true
+            else
+                echo "Unexpected argument: $1" >&2
+                usage >&2
+                exit 1
+            fi
+            ;;
+    esac
+    shift
+done
+
+resolve_activation_network_defaults
+require_activation_rpc_url
+
+command -v cast >/dev/null 2>&1 || {
+    echo -e "${RED}cast not found — install foundry: https://getfoundry.sh${NC}" >&2
+    exit 1
+}
+
+# ── Pre-flight ────────────────────────────────────────────────────────────────
+echo -e "${CYAN}${BOLD}Activation Registry${NC} @ ${REGISTRY}"
+echo -e "${YELLOW}  → Network: ${NETWORK}${NC}"
+echo -e "${YELLOW}  → RPC:     ${RPC_URL}${NC}"
+
+CHAIN_ID=$(cast chain-id --rpc-url "$RPC_URL" 2>&1) || {
+    echo -e "${RED}Node not reachable at ${RPC_URL}${NC}" >&2
+    exit 1
+}
+echo -e "${YELLOW}  → Chain ID: ${CHAIN_ID}${NC}"
+
+# admin() — surfaces who can activate/deactivate features on this chain.
+ADMIN_RAW=$(cast call --rpc-url "$RPC_URL" "$REGISTRY" "admin()(address)" 2>&1) \
+    || { echo -e "${RED}admin() call failed:${NC} $ADMIN_RAW" >&2; exit 1; }
+ADMIN=$(trim "$ADMIN_RAW")
+echo -e "${YELLOW}  → Admin: ${ADMIN}${NC}"
+echo ""
+
+# ── Query each feature ────────────────────────────────────────────────────────
+printf "${BOLD}  %-24s  %-66s  %s${NC}\n" "FEATURE" "ID" "STATUS"
+printf "  %-24s  %-66s  %s\n" "------------------------" \
+    "------------------------------------------------------------------" \
+    "----------"
+
+active_count=0
+inactive_count=0
+total=${#FEATURES[@]}
+
+for entry in "${FEATURES[@]}"; do
+    name="${entry%%:*}"
+    id="${entry##*:}"
+
+    result=$(cast call --rpc-url "$RPC_URL" "$REGISTRY" \
+        "isActivated(bytes32)(bool)" "$id" 2>&1) || {
+        printf "  %-24s  %-66s  ${RED}ERROR${NC}  %s\n" "$name" "$id" "$result"
+        continue
+    }
+    result=$(trim "$result")
+
+    if [[ "$result" == "true" ]]; then
+        printf "  %-24s  %-66s  ${GREEN}✓ ACTIVE${NC}\n" "$name" "$id"
+        active_count=$((active_count + 1))
+    else
+        printf "  %-24s  %-66s  ${RED}✗ INACTIVE${NC}\n" "$name" "$id"
+        inactive_count=$((inactive_count + 1))
+    fi
+done
+
+# ── Summary ───────────────────────────────────────────────────────────────────
+echo ""
+if [[ "$active_count" -eq "$total" ]]; then
+    echo -e "${GREEN}${BOLD}All ${total} features are activated.${NC}"
+    exit 0
+else
+    echo -e "${YELLOW}${BOLD}${active_count}/${total} features activated${NC}" \
+        "(${inactive_count} inactive)"
+    exit 1
+fi


### PR DESCRIPTION
## Summary

This PR adds network-aware activation registry tooling for checking and activating Base-native features across vibes, local devnet, Base mainnet, Base Sepolia, Base Zeronet, and custom RPCs. It introduces shared network/default resolution plus a single canonical feature list so the check and activation scripts stay in sync. The activator keeps the local devnet Hardhat key default, but remote networks require an explicit admin key and pass it to cast via scoped ETH_PRIVATE_KEY instead of argv. The scripts also report RPC/check errors separately, handle balance-query failures explicitly, and use a safer bash trim helper.