### PR TITLE
docs(consensus): fix grammar in block_validity.rs comment

### DIFF
--- a/crates/consensus/gossip/src/block_validity.rs
+++ b/crates/consensus/gossip/src/block_validity.rs
@@ -287,7 +287,7 @@ impl BlockHandler {
         }
 
         // Same as v3, except:
-        // 1. The block should have an non-empty withdrawals root (checked by type-safety)
+        // 1. The block should have a non-empty withdrawals root (checked by type-safety)
         fn validate_v4(
             rollup_config: &RollupConfig,
             block: &BaseExecutionPayloadV4,


### PR DESCRIPTION
Closes #2827

See the commit message for the full rationale. 1-file change, no test impact.