### PR TITLE
Pluggable subscriber for FlashblocksExtension

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4799,6 +4799,7 @@ dependencies = [
  "tokio-tungstenite 0.28.0",
  "tracing",
  "tracing-subscriber 0.3.23",
+ "url",
 ]
 
 [[package]]

--- a/crates/execution/cli/src/standard_node.rs
+++ b/crates/execution/cli/src/standard_node.rs
@@ -1,8 +1,10 @@
 //! Standard Base execution-node arguments and runner wiring.
 
+use std::fmt;
+
 use base_bundle_extension::BundleExtension;
 use base_flashblocks::FlashblocksConfig;
-use base_flashblocks_node::FlashblocksExtension;
+use base_flashblocks_node::{FlashblocksExtension, SubscriberFactory};
 use base_metering::{MeteredOpcodes, MeteringConfig, MeteringExtension, MeteringResourceLimits};
 use base_node_core::args::RollupArgs;
 use base_node_runner::{BaseNodeBuilder, BaseNodeRunner, LaunchedBaseNode};
@@ -14,6 +16,32 @@ use base_tx_forwarding::{
 use base_txpool_rpc::{TxPoolRpcConfig, TxPoolRpcExtension};
 use base_txpool_tracing::{TxPoolExtension, TxpoolConfig};
 use url::Url;
+
+/// Customization knobs for [`StandardBaseRethNode::runner_with_options`].
+#[derive(Default)]
+pub struct StandardRunnerOptions {
+    /// Optional override for the flashblocks subscriber. When `None`, the default subscriber is used.
+    pub flashblocks_subscriber_factory: Option<SubscriberFactory>,
+}
+
+impl fmt::Debug for StandardRunnerOptions {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("StandardRunnerOptions")
+            .field(
+                "flashblocks_subscriber_factory",
+                &self.flashblocks_subscriber_factory.as_ref().map(|_| "<factory>"),
+            )
+            .finish()
+    }
+}
+
+impl StandardRunnerOptions {
+    /// Sets the flashblocks subscriber factory override.
+    pub fn with_flashblocks_subscriber_factory(mut self, factory: SubscriberFactory) -> Self {
+        self.flashblocks_subscriber_factory = Some(factory);
+        self
+    }
+}
 
 /// CLI arguments for a standard Base execution node.
 #[derive(Debug, Clone, PartialEq, Eq, clap::Args)]
@@ -198,6 +226,15 @@ pub struct StandardBaseRethNode;
 impl StandardBaseRethNode {
     /// Builds a runner with the standard Base execution-node extensions installed.
     pub fn runner(args: StandardNodeArgs) -> eyre::Result<BaseNodeRunner> {
+        Self::runner_with_options(args, StandardRunnerOptions::default())
+    }
+
+    /// Builds a runner with the standard Base execution-node extensions installed, applying the
+    /// supplied [`StandardRunnerOptions`] to customize specific extensions.
+    pub fn runner_with_options(
+        args: StandardNodeArgs,
+        options: StandardRunnerOptions,
+    ) -> eyre::Result<BaseNodeRunner> {
         let mut runner = BaseNodeRunner::new(args.rpc.rollup_args.clone());
 
         // Create flashblocks config first so we can share its state with metering.
@@ -242,7 +279,13 @@ impl StandardBaseRethNode {
         runner.install_ext::<MeteringExtension>(metering_config);
         runner.install_ext::<BundleExtension>(());
         runner.install_ext::<TxForwardingExtension>((&args).into());
-        runner.install_ext::<FlashblocksExtension>(flashblocks_config);
+
+        let mut flashblocks_ext = FlashblocksExtension::new(flashblocks_config);
+        if let Some(factory) = options.flashblocks_subscriber_factory {
+            flashblocks_ext = flashblocks_ext.with_subscriber_factory(factory);
+        }
+        runner.add_extension(flashblocks_ext);
+
         runner.install_ext::<ProofsHistoryExtension>(args.rpc.rollup_args);
 
         Ok(runner)

--- a/crates/execution/flashblocks-node/Cargo.toml
+++ b/crates/execution/flashblocks-node/Cargo.toml
@@ -42,6 +42,9 @@ tokio-stream.workspace = true
 # tracing
 tracing = { workspace = true, features = ["std"] }
 
+# misc
+url.workspace = true
+
 # test-utils (optional)
 eyre = { workspace = true, optional = true }
 base-test-utils = { workspace = true, optional = true }

--- a/crates/execution/flashblocks-node/src/extension.rs
+++ b/crates/execution/flashblocks-node/src/extension.rs
@@ -1,30 +1,58 @@
 //! Contains the [`FlashblocksExtension`] which wires up the flashblocks feature
 //! (canonical block subscription and RPC surface) on the Base node builder.
 
-use std::sync::Arc;
+use std::{fmt, sync::Arc};
 
 use base_engine_tree::BaseEngineValidatorBuilder;
 use base_flashblocks::{
     EthApiExt, EthApiOverrideServer, EthPubSub, EthPubSubApiServer, FlashblocksConfig,
-    FlashblocksSubscriber,
+    FlashblocksState, FlashblocksSubscriber, FlashblocksSubscriberRunner,
 };
 use base_node_core::BasePayloadValidatorBuilder;
 use base_node_runner::{BaseNodeExtension, FromExtensionConfig, NodeHooks};
 use reth_chain_state::CanonStateSubscriptions;
 use tokio_stream::{StreamExt, wrappers::BroadcastStream};
 use tracing::info;
+use url::Url;
+
+/// Factory that produces a flashblocks subscriber given the shared state and the WebSocket URL.
+/// Used with [`FlashblocksExtension::with_subscriber_factory`] to substitute the default
+/// [`FlashblocksSubscriber`] for a custom implementation.
+pub type SubscriberFactory = Box<
+    dyn FnOnce(Arc<FlashblocksState>, Url) -> Box<dyn FlashblocksSubscriberRunner + Send>
+        + Send
+        + Sync
+        + 'static,
+>;
 
 /// Helper struct that wires the Flashblocks feature (canonical subscription and RPC) into the node builder.
-#[derive(Debug)]
 pub struct FlashblocksExtension {
     /// Optional Flashblocks configuration (includes state).
     config: Option<FlashblocksConfig>,
+    /// Optional override for the subscriber. When `None`, the default [`FlashblocksSubscriber`] is used.
+    subscriber_factory: Option<SubscriberFactory>,
+}
+
+impl fmt::Debug for FlashblocksExtension {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("FlashblocksExtension")
+            .field("config", &self.config)
+            .field("subscriber_factory", &self.subscriber_factory.as_ref().map(|_| "<factory>"))
+            .finish()
+    }
 }
 
 impl FlashblocksExtension {
     /// Create a new Flashblocks extension helper.
     pub const fn new(config: Option<FlashblocksConfig>) -> Self {
-        Self { config }
+        Self { config, subscriber_factory: None }
+    }
+
+    /// Overrides the subscriber used when the extension is enabled. If unset, the default
+    /// [`FlashblocksSubscriber`] is used.
+    pub fn with_subscriber_factory(mut self, factory: SubscriberFactory) -> Self {
+        self.subscriber_factory = Some(factory);
+        self
     }
 }
 
@@ -37,7 +65,11 @@ impl BaseNodeExtension for FlashblocksExtension {
         };
 
         let state = cfg.state;
-        let mut subscriber = FlashblocksSubscriber::new(Arc::clone(&state), cfg.websocket_url);
+        let mut subscriber: Box<dyn FlashblocksSubscriberRunner + Send> =
+            match self.subscriber_factory {
+                Some(factory) => factory(Arc::clone(&state), cfg.websocket_url),
+                None => Box::new(FlashblocksSubscriber::new(Arc::clone(&state), cfg.websocket_url)),
+            };
 
         let state_for_canonical = Arc::clone(&state);
         let state_for_rpc = Arc::clone(&state);

--- a/crates/execution/flashblocks-node/src/lib.rs
+++ b/crates/execution/flashblocks-node/src/lib.rs
@@ -8,7 +8,7 @@
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 
 mod extension;
-pub use extension::FlashblocksExtension;
+pub use extension::{FlashblocksExtension, SubscriberFactory};
 
 #[cfg(any(test, feature = "test-utils"))]
 pub mod test_harness;

--- a/crates/execution/flashblocks/src/lib.rs
+++ b/crates/execution/flashblocks/src/lib.rs
@@ -34,7 +34,7 @@ mod state;
 pub use state::FlashblocksState;
 
 mod subscription;
-pub use subscription::FlashblocksSubscriber;
+pub use subscription::{FlashblocksSubscriber, FlashblocksSubscriberRunner};
 
 mod traits;
 pub use traits::{FlashblocksAPI, FlashblocksReceiver, PendingBlocksAPI};

--- a/crates/execution/flashblocks/src/subscription.rs
+++ b/crates/execution/flashblocks/src/subscription.rs
@@ -173,3 +173,20 @@ where
         std::cmp::min(backoff * 2, Self::MAX_BACKOFF)
     }
 }
+
+/// Decouples the flashblocks extension from a concrete subscriber so callers can substitute
+/// custom implementations without forking the extension.
+pub trait FlashblocksSubscriberRunner: Send + 'static {
+    /// Starts the subscriber. Called from inside the flashblocks extension's node-started hook
+    /// after the state processor has been started.
+    fn start(&mut self);
+}
+
+impl<Receiver> FlashblocksSubscriberRunner for FlashblocksSubscriber<Receiver>
+where
+    Receiver: FlashblocksReceiver + Send + Sync + 'static,
+{
+    fn start(&mut self) {
+        Self::start(self);
+    }
+}

--- a/crates/execution/runner/src/runner.rs
+++ b/crates/execution/runner/src/runner.rs
@@ -96,6 +96,13 @@ impl<SB: PayloadServiceBuilder> BaseNodeRunner<SB> {
         self.extensions.push(Box::new(T::from_config(config)));
     }
 
+    /// Registers a pre-built extension. Use this when an extension needs to be customized via
+    /// builder methods before installing; otherwise prefer [`install_ext`](Self::install_ext)
+    /// which constructs the extension from a config.
+    pub fn add_extension<E: BaseNodeExtension + 'static>(&mut self, ext: E) {
+        self.extensions.push(Box::new(ext));
+    }
+
     /// Registers a callback to run after the node has started.
     pub fn add_started_callback<F>(&mut self, callback: F)
     where


### PR DESCRIPTION
Lets downstream binaries swap the flashblocks subscriber without forking `FlashblocksExtension`. Motivation: external builds currently have to patch `flashblocks-node/extension.rs` in-tree because the subscriber is constructed inside the extension with no override point.

API additions:
- `base-flashblocks`: new `FlashblocksSubscriberRunner` trait (impl'd for the upstream `FlashblocksSubscriber`).
- `base-flashblocks-node`: `FlashblocksExtension::with_subscriber_factory` builder method + `SubscriberFactory` type alias.
- `base-node-runner`: `BaseNodeRunner::add_extension` for installing pre-built extensions (needed because `install_ext` constructs via `FromExtensionConfig::from_config` and can't thread a factory).
- `base-execution-cli`: `StandardOptions` struct + `runner_with_options` variant of `StandardBaseRethNode::runner`. The single-arg `runner` delegates with `StandardOptions::default()`.

No behavior change for existing callers: when no factory is supplied, `FlashblocksExtension` constructs the upstream `FlashblocksSubscriber` exactly as before.