### PR TITLE
feat(tee): limit nitro-host prove to 1 concurrent request per enclave (backport #2988)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5274,9 +5274,11 @@ dependencies = [
 name = "base-proof-tee-nitro-host"
 version = "0.9.1"
 dependencies = [
+ "alloy-genesis 2.0.5",
  "alloy-primitives",
  "alloy-signer",
  "async-trait",
+ "base-common-genesis",
  "base-health",
  "base-proof-contracts",
  "base-proof-host",

--- a/crates/proof/tee/nitro-host/Cargo.toml
+++ b/crates/proof/tee/nitro-host/Cargo.toml
@@ -42,6 +42,8 @@ tokio-vsock.workspace = true
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt"] }
+alloy-genesis.workspace = true
+base-common-genesis = { workspace = true, features = ["serde", "std"] }
 
 [features]
 metrics = [ "base-proof-host/metrics" ]

--- a/crates/proof/tee/nitro-host/src/registration.rs
+++ b/crates/proof/tee/nitro-host/src/registration.rs
@@ -207,6 +207,43 @@ impl RegistrationChecker {
 
         Err(RegistrationError::NoValidSigner { signers: discovered })
     }
+
+    /// Returns every enclave whose signer is currently valid on-chain, in
+    /// config order.
+    ///
+    /// Same fail-closed semantics as [`select_valid_enclave`](Self::select_valid_enclave):
+    /// an RPC error short-circuits the whole call. Returns
+    /// [`RegistrationError::NoValidSigner`] if no enclave is valid.
+    pub async fn select_all_valid_enclaves(&self) -> Result<Vec<ValidSigner>, RegistrationError> {
+        let mut valid = Vec::new();
+        let mut discovered = Vec::new();
+
+        for (index, transport) in self.transports.iter().enumerate() {
+            let signer = match Self::signer_address(transport).await {
+                Ok(s) => s,
+                Err(e) => {
+                    warn!(error = %e, index, "skipping transport: key fetch failed");
+                    continue;
+                }
+            };
+
+            discovered.push(signer);
+
+            match self.is_valid_signer(signer).await {
+                Ok(true) => valid.push(ValidSigner { index, signer }),
+                Ok(false) => {
+                    warn!(signer = %signer, index, "signer not valid in TEEProverRegistry");
+                }
+                Err(e) => return Err(e),
+            }
+        }
+
+        if valid.is_empty() {
+            Err(RegistrationError::NoValidSigner { signers: discovered })
+        } else {
+            Ok(valid)
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/proof/tee/nitro-host/src/registration.rs
+++ b/crates/proof/tee/nitro-host/src/registration.rs
@@ -179,35 +179,6 @@ impl RegistrationChecker {
         }
     }
 
-    /// Selects the first enclave whose signer is currently valid on-chain.
-    ///
-    /// Returns as soon as a valid signer is found (config order).
-    pub async fn select_valid_enclave(&self) -> Result<ValidSigner, RegistrationError> {
-        let mut discovered = Vec::new();
-
-        for (index, transport) in self.transports.iter().enumerate() {
-            let signer = match Self::signer_address(transport).await {
-                Ok(s) => s,
-                Err(e) => {
-                    warn!(error = %e, index, "skipping transport: key fetch failed");
-                    continue;
-                }
-            };
-
-            discovered.push(signer);
-
-            match self.is_valid_signer(signer).await {
-                Ok(true) => return Ok(ValidSigner { index, signer }),
-                Ok(false) => {
-                    warn!(signer = %signer, index, "signer not valid in TEEProverRegistry");
-                }
-                Err(e) => return Err(e),
-            }
-        }
-
-        Err(RegistrationError::NoValidSigner { signers: discovered })
-    }
-
     /// Returns every enclave whose signer is currently valid on-chain, in
     /// config order.
     ///
@@ -394,7 +365,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn select_first_invalid_second_valid_returns_index_1() {
+    async fn select_all_skips_invalid_returns_only_valid() {
         let registry = AddressBasedMockRegistry::new(HashMap::new());
         let checker = two_transport_checker(registry.clone());
         let (addr0, addr1) = two_transport_signers(&checker).await;
@@ -402,13 +373,14 @@ mod tests {
         registry.validity_map.lock().unwrap().insert(addr0, false);
         registry.validity_map.lock().unwrap().insert(addr1, true);
 
-        let valid = checker.select_valid_enclave().await.unwrap();
-        assert_eq!(valid.index, 1);
-        assert_eq!(valid.signer, addr1);
+        let valid = checker.select_all_valid_enclaves().await.unwrap();
+        assert_eq!(valid.len(), 1);
+        assert_eq!(valid[0].index, 1);
+        assert_eq!(valid[0].signer, addr1);
     }
 
     #[tokio::test]
-    async fn select_both_valid_returns_first() {
+    async fn select_all_both_valid_returns_in_config_order() {
         let registry = AddressBasedMockRegistry::new(HashMap::new());
         let checker = two_transport_checker(registry.clone());
         let (addr0, addr1) = two_transport_signers(&checker).await;
@@ -416,17 +388,20 @@ mod tests {
         registry.validity_map.lock().unwrap().insert(addr0, true);
         registry.validity_map.lock().unwrap().insert(addr1, true);
 
-        let valid = checker.select_valid_enclave().await.unwrap();
-        assert_eq!(valid.index, 0);
-        assert_eq!(valid.signer, addr0);
+        let valid = checker.select_all_valid_enclaves().await.unwrap();
+        assert_eq!(valid.len(), 2);
+        assert_eq!(valid[0].index, 0);
+        assert_eq!(valid[0].signer, addr0);
+        assert_eq!(valid[1].index, 1);
+        assert_eq!(valid[1].signer, addr1);
     }
 
     #[tokio::test]
-    async fn select_none_valid_returns_no_valid_signer() {
+    async fn select_all_none_valid_returns_no_valid_signer() {
         let registry = AddressBasedMockRegistry::new(HashMap::new());
         let checker = two_transport_checker(registry);
 
-        let err = checker.select_valid_enclave().await.unwrap_err();
+        let err = checker.select_all_valid_enclaves().await.unwrap_err();
         match err {
             RegistrationError::NoValidSigner { signers } => {
                 assert_eq!(signers.len(), 2);

--- a/crates/proof/tee/nitro-host/src/registration.rs
+++ b/crates/proof/tee/nitro-host/src/registration.rs
@@ -211,12 +211,16 @@ impl RegistrationChecker {
     /// Returns every enclave whose signer is currently valid on-chain, in
     /// config order.
     ///
-    /// Same fail-closed semantics as [`select_valid_enclave`](Self::select_valid_enclave):
-    /// an RPC error short-circuits the whole call. Returns
-    /// [`RegistrationError::NoValidSigner`] if no enclave is valid.
+    /// Best-effort across enclaves: RPC errors for individual signers are
+    /// logged and skipped rather than failing the whole call. If no valid
+    /// signer was found, returns the first RPC error encountered (so the
+    /// caller surfaces L1 reachability problems) or
+    /// [`RegistrationError::NoValidSigner`] if every signer was reachable
+    /// but invalid.
     pub async fn select_all_valid_enclaves(&self) -> Result<Vec<ValidSigner>, RegistrationError> {
         let mut valid = Vec::new();
         let mut discovered = Vec::new();
+        let mut first_rpc_error = None;
 
         for (index, transport) in self.transports.iter().enumerate() {
             let signer = match Self::signer_address(transport).await {
@@ -234,14 +238,24 @@ impl RegistrationChecker {
                 Ok(false) => {
                     warn!(signer = %signer, index, "signer not valid in TEEProverRegistry");
                 }
-                Err(e) => return Err(e),
+                Err(e) => {
+                    warn!(
+                        error = %e,
+                        signer = %signer,
+                        index,
+                        "L1 RPC failed during validity check, skipping enclave"
+                    );
+                    first_rpc_error.get_or_insert(e);
+                }
             }
         }
 
-        if valid.is_empty() {
-            Err(RegistrationError::NoValidSigner { signers: discovered })
-        } else {
+        if !valid.is_empty() {
             Ok(valid)
+        } else if let Some(e) = first_rpc_error {
+            Err(e)
+        } else {
+            Err(RegistrationError::NoValidSigner { signers: discovered })
         }
     }
 }
@@ -448,6 +462,39 @@ mod tests {
         registry.should_fail.store(true, Ordering::Relaxed);
 
         assert!(checker.check_health().await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn select_all_valid_returns_valid_when_other_rpc_fails() {
+        let registry = AddressBasedMockRegistry::new(HashMap::new());
+        let checker = two_transport_checker(registry.clone());
+        let (addr0, addr1) = two_transport_signers(&checker).await;
+
+        registry.validity_map.lock().unwrap().insert(addr0, true);
+        registry.validity_map.lock().unwrap().insert(addr1, true);
+        // Enclave 1's validity check will fail at the RPC layer; enclave 0
+        // is still valid and must be returned.
+        registry.fail_signers.lock().unwrap().insert(addr1);
+
+        let valid = checker.select_all_valid_enclaves().await.unwrap();
+        assert_eq!(valid.len(), 1);
+        assert_eq!(valid[0].index, 0);
+        assert_eq!(valid[0].signer, addr0);
+    }
+
+    #[tokio::test]
+    async fn select_all_valid_propagates_rpc_error_when_none_valid() {
+        let registry = AddressBasedMockRegistry::new(HashMap::new());
+        let checker = two_transport_checker(registry.clone());
+        let (addr0, addr1) = two_transport_signers(&checker).await;
+
+        // Enclave 0 RPC fails, enclave 1 reports not-valid. No valid signer,
+        // so the RPC error should surface so the operator sees L1 trouble.
+        registry.fail_signers.lock().unwrap().insert(addr0);
+        registry.validity_map.lock().unwrap().insert(addr1, false);
+
+        let err = checker.select_all_valid_enclaves().await.unwrap_err();
+        assert!(matches!(err, RegistrationError::Rpc { .. }), "got {err:?}");
     }
 
     #[tokio::test]

--- a/crates/proof/tee/nitro-host/src/server.rs
+++ b/crates/proof/tee/nitro-host/src/server.rs
@@ -9,6 +9,7 @@ use jsonrpsee::{
     core::{RpcResult, async_trait},
     server::{Server, ServerHandle, middleware::http::ProxyGetRequestLayer},
 };
+use tokio::sync::Semaphore;
 use tracing::{info, warn};
 
 use super::{
@@ -24,9 +25,17 @@ const MAX_USER_DATA_BYTES: usize = 512;
 /// Maximum allowed size for the `nonce` attestation field (NSM limit).
 const MAX_NONCE_BYTES: usize = 512;
 
+/// Maximum number of concurrent `prover_prove` requests per enclave.
+///
+/// Proving is CPU- and memory-intensive and the enclave processes one request at a time, so any
+/// excess concurrency only adds queueing latency and resource pressure. Additional concurrent
+/// requests are rejected with `-32002` so callers can back off and retry instead of piling up.
+const MAX_CONCURRENT_PROOF_REQUESTS_PER_ENCLAVE: usize = 1;
+
 struct EnclaveService {
     transport: Arc<NitroTransport>,
     service: ProverService<NitroBackend>,
+    prove_permit: Arc<Semaphore>,
 }
 
 /// Host-side TEE prover server exposing a JSON-RPC interface.
@@ -75,7 +84,13 @@ impl NitroProverServer {
             .into_iter()
             .map(|transport| {
                 let backend = NitroBackend::new(Arc::clone(&transport));
-                EnclaveService { transport, service: ProverService::new(config.clone(), backend) }
+                EnclaveService {
+                    transport,
+                    service: ProverService::new(config.clone(), backend),
+                    prove_permit: Arc::new(Semaphore::new(
+                        MAX_CONCURRENT_PROOF_REQUESTS_PER_ENCLAVE,
+                    )),
+                }
             })
             .collect();
         Self { enclaves, proof_request_timeout, registration_health: None }
@@ -166,6 +181,16 @@ impl ProverApiServer for NitroProverRpc {
         let l2_block = request.claimed_l2_block_number;
         let timeout = self.proof_request_timeout;
 
+        let _permit = enclave.prove_permit.clone().try_acquire_owned().map_err(|_| {
+            warn!(l2_block, "rejecting proof request: enclave already proving");
+            NitroProverServer::rpc_err(
+                -32002,
+                format!(
+                    "enclave busy: another proof request is already in flight for L2 block {l2_block}"
+                ),
+            )
+        })?;
+
         match tokio::time::timeout(timeout, enclave.service.prove_block(request)).await {
             Ok(result) => result.map_err(|e| NitroProverServer::rpc_err(-32000, e)),
             Err(_elapsed) => {
@@ -243,10 +268,41 @@ impl EnclaveApiServer for NitroSignerRpc {
 
 #[cfg(test)]
 mod tests {
+    use alloy_genesis::ChainConfig;
+    use base_common_genesis::RollupConfig;
     use base_proof_primitives::EnclaveApiServer;
     use base_proof_tee_nitro_enclave::Server as EnclaveServer;
 
     use super::*;
+
+    fn test_prover_config() -> ProverConfig {
+        ProverConfig {
+            l1_eth_url: "http://127.0.0.1:1".to_string(),
+            l2_eth_url: "http://127.0.0.1:1".to_string(),
+            l1_beacon_url: "http://127.0.0.1:1".to_string(),
+            l2_chain_id: 0,
+            rollup_config: RollupConfig::default(),
+            l1_config: ChainConfig::default(),
+            enable_experimental_witness_endpoint: false,
+        }
+    }
+
+    fn test_prover_rpc() -> NitroProverRpc {
+        let server = Arc::new(EnclaveServer::new_local().unwrap());
+        let transport = Arc::new(NitroTransport::local(server));
+        let backend = NitroBackend::new(Arc::clone(&transport));
+        let service = ProverService::new(test_prover_config(), backend);
+        let enclave = EnclaveService {
+            transport,
+            service,
+            prove_permit: Arc::new(Semaphore::new(MAX_CONCURRENT_PROOF_REQUESTS_PER_ENCLAVE)),
+        };
+        NitroProverRpc {
+            enclaves: vec![enclave],
+            proof_request_timeout: Duration::from_secs(60),
+            checker: None,
+        }
+    }
 
     #[tokio::test]
     async fn signer_public_key_routed_to_transport() {
@@ -305,5 +361,52 @@ mod tests {
         let err = result.unwrap_err();
         assert_eq!(err.code(), -32602);
         assert!(err.message().contains("nonce"));
+    }
+
+    #[tokio::test]
+    async fn prove_rejects_concurrent_request_when_permit_held() {
+        let rpc = test_prover_rpc();
+
+        let permit = Arc::clone(&rpc.enclaves[0].prove_permit)
+            .try_acquire_owned()
+            .expect("permit should be available before first acquire");
+
+        let err = rpc.prove(ProofRequest::default()).await.unwrap_err();
+        assert_eq!(err.code(), -32002);
+        assert!(err.message().contains("enclave busy"));
+
+        drop(permit);
+        assert_eq!(rpc.enclaves[0].prove_permit.available_permits(), 1);
+    }
+
+    #[tokio::test]
+    async fn prove_permit_is_released_after_request_completes() {
+        let rpc = test_prover_rpc();
+
+        let _ = rpc.prove(ProofRequest::default()).await;
+
+        assert_eq!(
+            rpc.enclaves[0].prove_permit.available_permits(),
+            MAX_CONCURRENT_PROOF_REQUESTS_PER_ENCLAVE,
+            "permit must be released after the proof request returns"
+        );
+    }
+
+    #[tokio::test]
+    async fn prove_permit_is_per_enclave_in_multi_enclave_setup() {
+        let mut rpc = test_prover_rpc();
+        let second = Arc::new(EnclaveServer::new_local().unwrap());
+        let second_transport = Arc::new(NitroTransport::local(second));
+        let second_backend = NitroBackend::new(Arc::clone(&second_transport));
+        let second_service = ProverService::new(test_prover_config(), second_backend);
+        rpc.enclaves.push(EnclaveService {
+            transport: second_transport,
+            service: second_service,
+            prove_permit: Arc::new(Semaphore::new(MAX_CONCURRENT_PROOF_REQUESTS_PER_ENCLAVE)),
+        });
+
+        let _held = Arc::clone(&rpc.enclaves[0].prove_permit).try_acquire_owned().unwrap();
+
+        assert_eq!(rpc.enclaves[1].prove_permit.available_permits(), 1);
     }
 }

--- a/crates/proof/tee/nitro-host/src/server.rs
+++ b/crates/proof/tee/nitro-host/src/server.rs
@@ -27,9 +27,10 @@ const MAX_NONCE_BYTES: usize = 512;
 
 /// Maximum number of concurrent `prover_prove` requests per enclave.
 ///
-/// Proving is CPU- and memory-intensive and the enclave processes one request at a time, so any
-/// excess concurrency only adds queueing latency and resource pressure. Additional concurrent
-/// requests are rejected with `-32002` so callers can back off and retry instead of piling up.
+/// Proving is CPU- and memory-intensive. The enclave does not reject concurrent requests itself;
+/// it would serialize them under load, adding queueing latency and resource pressure. We enforce
+/// the limit host-side and reject excess requests with `-32002` so callers can back off and retry
+/// instead of piling up.
 const MAX_CONCURRENT_PROOF_REQUESTS_PER_ENCLAVE: usize = 1;
 
 struct EnclaveService {
@@ -163,15 +164,14 @@ struct NitroProverRpc {
     checker: Option<Arc<RegistrationChecker>>,
 }
 
-#[async_trait]
-impl ProverApiServer for NitroProverRpc {
-    async fn prove(&self, request: ProofRequest) -> RpcResult<ProofResult> {
-        let l2_block = request.claimed_l2_block_number;
-        let timeout = self.proof_request_timeout;
-
-        // Pick the first valid enclave with an available permit. Falling through busy enclaves
-        // matters in dual-enclave deployments: without fall-through a single in-flight request
-        // would make idle enclaves unreachable even though they are valid and available.
+impl NitroProverRpc {
+    /// Pick the first valid enclave with an available permit. Falling through busy enclaves
+    /// matters in dual-enclave deployments: without fall-through a single in-flight request
+    /// would make idle enclaves unreachable even though they are valid and available.
+    async fn acquire_enclave(
+        &self,
+        l2_block: u64,
+    ) -> RpcResult<(&EnclaveService, tokio::sync::OwnedSemaphorePermit)> {
         let candidate_indices: Vec<usize> = match &self.checker {
             Some(checker) => checker
                 .select_all_valid_enclaves()
@@ -187,7 +187,7 @@ impl ProverApiServer for NitroProverRpc {
             None => vec![0],
         };
 
-        let (enclave, _permit) = candidate_indices
+        candidate_indices
             .iter()
             .find_map(|&i| {
                 Arc::clone(&self.enclaves[i].prove_permit)
@@ -201,7 +201,17 @@ impl ProverApiServer for NitroProverRpc {
                     -32002,
                     "enclave busy: another proof request is already in flight",
                 )
-            })?;
+            })
+    }
+}
+
+#[async_trait]
+impl ProverApiServer for NitroProverRpc {
+    async fn prove(&self, request: ProofRequest) -> RpcResult<ProofResult> {
+        let l2_block = request.claimed_l2_block_number;
+        let timeout = self.proof_request_timeout;
+
+        let (enclave, _permit) = self.acquire_enclave(l2_block).await?;
 
         match tokio::time::timeout(timeout, enclave.service.prove_block(request)).await {
             Ok(result) => result.map_err(|e| NitroProverServer::rpc_err(-32000, e)),
@@ -397,15 +407,17 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn prove_permit_is_released_after_request_completes() {
+    async fn prove_permit_is_released_when_handle_dropped() {
         let rpc = test_prover_rpc();
 
-        let _ = rpc.prove(ProofRequest::default()).await;
+        let (_enclave, permit) = rpc.acquire_enclave(0).await.unwrap();
+        assert_eq!(rpc.enclaves[0].prove_permit.available_permits(), 0);
 
+        drop(permit);
         assert_eq!(
             rpc.enclaves[0].prove_permit.available_permits(),
             MAX_CONCURRENT_PROOF_REQUESTS_PER_ENCLAVE,
-            "permit must be released after the proof request returns"
+            "permit must be released when the RAII handle is dropped"
         );
     }
 
@@ -471,9 +483,13 @@ mod tests {
         // Saturate the first enclave; the second is still free.
         let _held = Arc::clone(&rpc.enclaves[0].prove_permit).try_acquire_owned().unwrap();
 
-        // prove() must not return -32002 (busy) because enclave[1] is available; the request will
-        // route there and only fail later because RPCs are bogus (-32000).
-        let err = rpc.prove(ProofRequest::default()).await.unwrap_err();
-        assert_ne!(err.code(), -32002, "expected fall-through to second enclave, got busy");
+        // acquire_enclave must select enclave[1] since enclave[0] has no permits. We test the
+        // selection helper directly because prove_block requires a live beacon endpoint.
+        let (enclave, _permit) = rpc.acquire_enclave(0).await.expect("fall-through to enclave[1]");
+        assert!(
+            Arc::ptr_eq(&enclave.transport, &rpc.enclaves[1].transport),
+            "expected enclave[1] selected via fall-through"
+        );
+        assert_eq!(rpc.enclaves[1].prove_permit.available_permits(), 0);
     }
 }

--- a/crates/proof/tee/nitro-host/src/server.rs
+++ b/crates/proof/tee/nitro-host/src/server.rs
@@ -166,30 +166,45 @@ struct NitroProverRpc {
 #[async_trait]
 impl ProverApiServer for NitroProverRpc {
     async fn prove(&self, request: ProofRequest) -> RpcResult<ProofResult> {
-        let enclave = match &self.checker {
-            Some(checker) => {
-                let valid = checker.select_valid_enclave().await.map_err(|e| {
-                    warn!(error = %e, "rejecting proof request: signer validation failed");
-                    NitroProverServer::rpc_err(-32001, e)
-                })?;
-                &self.enclaves[valid.index]
-            }
-            // Constructor guarantees at least one enclave.
-            None => &self.enclaves[0],
-        };
-
         let l2_block = request.claimed_l2_block_number;
         let timeout = self.proof_request_timeout;
 
-        let _permit = enclave.prove_permit.clone().try_acquire_owned().map_err(|_| {
-            warn!(l2_block, "rejecting proof request: enclave already proving");
-            NitroProverServer::rpc_err(
-                -32002,
-                format!(
-                    "enclave busy: another proof request is already in flight for L2 block {l2_block}"
-                ),
-            )
-        })?;
+        // Pick the first valid enclave with an available permit. Falling through busy enclaves
+        // matters in dual-enclave deployments with a checker: `select_valid_enclave` always
+        // returns the first valid enclave, so without fall-through a single in-flight request
+        // would make the second enclave unreachable even while it is idle.
+        let candidate_indices: Vec<usize> = match &self.checker {
+            Some(checker) => checker
+                .select_all_valid_enclaves()
+                .await
+                .map_err(|e| {
+                    warn!(error = %e, "rejecting proof request: signer validation failed");
+                    NitroProverServer::rpc_err(-32001, e)
+                })?
+                .into_iter()
+                .map(|v| v.index)
+                .collect(),
+            // Constructor guarantees at least one enclave.
+            None => vec![0],
+        };
+
+        let (enclave, _permit) = candidate_indices
+            .iter()
+            .find_map(|&i| {
+                self.enclaves[i]
+                    .prove_permit
+                    .clone()
+                    .try_acquire_owned()
+                    .ok()
+                    .map(|permit| (&self.enclaves[i], permit))
+            })
+            .ok_or_else(|| {
+                warn!(l2_block, "rejecting proof request: all valid enclaves already proving");
+                NitroProverServer::rpc_err(
+                    -32002,
+                    "enclave busy: another proof request is already in flight",
+                )
+            })?;
 
         match tokio::time::timeout(timeout, enclave.service.prove_block(request)).await {
             Ok(result) => result.map_err(|e| NitroProverServer::rpc_err(-32000, e)),
@@ -408,5 +423,62 @@ mod tests {
         let _held = Arc::clone(&rpc.enclaves[0].prove_permit).try_acquire_owned().unwrap();
 
         assert_eq!(rpc.enclaves[1].prove_permit.available_permits(), 1);
+    }
+
+    #[tokio::test]
+    async fn prove_falls_through_to_second_enclave_when_first_is_busy() {
+        use std::collections::HashMap;
+
+        use alloy_signer::utils::public_key_to_address;
+        use k256::ecdsa::VerifyingKey;
+
+        use crate::test_utils::AddressBasedMockRegistry;
+
+        async fn signer_for(transport: &NitroTransport) -> alloy_primitives::Address {
+            let pk = transport.signer_public_key().await.unwrap();
+            let vk = VerifyingKey::from_sec1_bytes(&pk).unwrap();
+            public_key_to_address(&vk)
+        }
+
+        let s1 = Arc::new(EnclaveServer::new_local().unwrap());
+        let s2 = Arc::new(EnclaveServer::new_local().unwrap());
+        let t1 = Arc::new(NitroTransport::local(s1));
+        let t2 = Arc::new(NitroTransport::local(s2));
+
+        let addr1 = signer_for(&t1).await;
+        let addr2 = signer_for(&t2).await;
+
+        let mut map = HashMap::new();
+        map.insert(addr1, true);
+        map.insert(addr2, true);
+        let registry = AddressBasedMockRegistry::new(map);
+
+        let checker = Arc::new(
+            RegistrationChecker::new(vec![Arc::clone(&t1), Arc::clone(&t2)], registry).unwrap(),
+        );
+
+        let enclave0 = EnclaveService {
+            transport: Arc::clone(&t1),
+            service: ProverService::new(test_prover_config(), NitroBackend::new(Arc::clone(&t1))),
+            prove_permit: Arc::new(Semaphore::new(MAX_CONCURRENT_PROOF_REQUESTS_PER_ENCLAVE)),
+        };
+        let enclave1 = EnclaveService {
+            transport: Arc::clone(&t2),
+            service: ProverService::new(test_prover_config(), NitroBackend::new(Arc::clone(&t2))),
+            prove_permit: Arc::new(Semaphore::new(MAX_CONCURRENT_PROOF_REQUESTS_PER_ENCLAVE)),
+        };
+        let rpc = NitroProverRpc {
+            enclaves: vec![enclave0, enclave1],
+            proof_request_timeout: Duration::from_secs(60),
+            checker: Some(checker),
+        };
+
+        // Saturate the first enclave; the second is still free.
+        let _held = Arc::clone(&rpc.enclaves[0].prove_permit).try_acquire_owned().unwrap();
+
+        // prove() must not return -32002 (busy) because enclave[1] is available; the request will
+        // route there and only fail later because RPCs are bogus (-32000).
+        let err = rpc.prove(ProofRequest::default()).await.unwrap_err();
+        assert_ne!(err.code(), -32002, "expected fall-through to second enclave, got busy");
     }
 }

--- a/crates/proof/tee/nitro-host/src/server.rs
+++ b/crates/proof/tee/nitro-host/src/server.rs
@@ -280,12 +280,17 @@ impl EnclaveApiServer for NitroSignerRpc {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
+
     use alloy_genesis::ChainConfig;
+    use alloy_signer::utils::public_key_to_address;
     use base_common_genesis::RollupConfig;
     use base_proof_primitives::EnclaveApiServer;
     use base_proof_tee_nitro_enclave::Server as EnclaveServer;
+    use k256::ecdsa::VerifyingKey;
 
     use super::*;
+    use crate::test_utils::AddressBasedMockRegistry;
 
     fn test_prover_config() -> ProverConfig {
         ProverConfig {
@@ -424,13 +429,6 @@ mod tests {
 
     #[tokio::test]
     async fn prove_falls_through_to_second_enclave_when_first_is_busy() {
-        use std::collections::HashMap;
-
-        use alloy_signer::utils::public_key_to_address;
-        use k256::ecdsa::VerifyingKey;
-
-        use crate::test_utils::AddressBasedMockRegistry;
-
         async fn signer_for(transport: &NitroTransport) -> alloy_primitives::Address {
             let pk = transport.signer_public_key().await.unwrap();
             let vk = VerifyingKey::from_sec1_bytes(&pk).unwrap();

--- a/crates/proof/tee/nitro-host/src/server.rs
+++ b/crates/proof/tee/nitro-host/src/server.rs
@@ -191,9 +191,7 @@ impl ProverApiServer for NitroProverRpc {
         let (enclave, _permit) = candidate_indices
             .iter()
             .find_map(|&i| {
-                self.enclaves[i]
-                    .prove_permit
-                    .clone()
+                Arc::clone(&self.enclaves[i].prove_permit)
                     .try_acquire_owned()
                     .ok()
                     .map(|permit| (&self.enclaves[i], permit))

--- a/crates/proof/tee/nitro-host/src/server.rs
+++ b/crates/proof/tee/nitro-host/src/server.rs
@@ -170,9 +170,8 @@ impl ProverApiServer for NitroProverRpc {
         let timeout = self.proof_request_timeout;
 
         // Pick the first valid enclave with an available permit. Falling through busy enclaves
-        // matters in dual-enclave deployments with a checker: `select_valid_enclave` always
-        // returns the first valid enclave, so without fall-through a single in-flight request
-        // would make the second enclave unreachable even while it is idle.
+        // matters in dual-enclave deployments: without fall-through a single in-flight request
+        // would make idle enclaves unreachable even though they are valid and available.
         let candidate_indices: Vec<usize> = match &self.checker {
             Some(checker) => checker
                 .select_all_valid_enclaves()

--- a/crates/proof/tee/nitro-host/src/test_utils.rs
+++ b/crates/proof/tee/nitro-host/src/test_utils.rs
@@ -1,7 +1,7 @@
 //! Shared test utilities for the `base-proof-tee-nitro-host` crate.
 
 use std::{
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     sync::{
         Arc, Mutex,
         atomic::{AtomicBool, AtomicUsize, Ordering},
@@ -72,6 +72,8 @@ pub struct AddressBasedMockRegistry {
     pub call_count: Arc<AtomicUsize>,
     /// When `true`, all calls return an error.
     pub should_fail: Arc<AtomicBool>,
+    /// Per-address override; calls for any signer in this set return an error.
+    pub fail_signers: Arc<Mutex<HashSet<Address>>>,
 }
 
 impl AddressBasedMockRegistry {
@@ -81,6 +83,7 @@ impl AddressBasedMockRegistry {
             validity_map: Arc::new(Mutex::new(validity_map)),
             call_count: Arc::new(AtomicUsize::new(0)),
             should_fail: Arc::new(AtomicBool::new(false)),
+            fail_signers: Arc::new(Mutex::new(HashSet::new())),
         }
     }
 }
@@ -93,6 +96,9 @@ impl TEEProverRegistryClient for AddressBasedMockRegistry {
     ) -> Result<bool, base_proof_contracts::ContractError> {
         self.call_count.fetch_add(1, Ordering::Relaxed);
         if self.should_fail.load(Ordering::Relaxed) {
+            return Err(base_proof_contracts::ContractError::Validation("mock RPC failure".into()));
+        }
+        if self.fail_signers.lock().expect("fail_signers poisoned").contains(&signer) {
             return Err(base_proof_contracts::ContractError::Validation("mock RPC failure".into()));
         }
         let map = self.validity_map.lock().expect("validity map poisoned");


### PR DESCRIPTION
## Summary

Backport of #2988 for `releases/v0.9.2`.

Gate `prover_prove` with a per-enclave `Semaphore::new(1)`. Concurrent calls to the same enclave are rejected immediately with JSON-RPC `-32002` ("enclave busy"). In dual-enclave deployments each enclave keeps its own budget.

## Validation

- `git diff --check origin/releases/v0.9.2...HEAD`
- Cherry-picked all 7 commits from #2988 cleanly (one auto-merge in Cargo.lock)