### PR TITLE
fix(precompiles): pause check precedes policy check in mint

### DIFF
--- a/crates/common/precompiles/src/common/ops/mintable.rs
+++ b/crates/common/precompiles/src/common/ops/mintable.rs
@@ -17,8 +17,8 @@ pub trait Mintable: Token {
         if !privileged {
             B20Guards::ensure_token_role::<Self>(self, caller, B20TokenRole::Mint)?;
         }
-        B20Guards::ensure_policy_type::<Self>(self, B20PolicyType::MintReceiver, to)?;
         B20Guards::ensure_not_paused::<Self>(self, IB20::PausableFeature::MINT)?;
+        B20Guards::ensure_policy_type::<Self>(self, B20PolicyType::MintReceiver, to)?;
         let supply = self.accounting().total_supply()?;
         let cap = self.accounting().supply_cap()?;
         let new_supply =
@@ -162,6 +162,23 @@ mod tests {
     fn mint_reverts_when_mint_feature_paused() {
         let mut accounting = InMemoryTokenAccounting::new(TOKEN_ADDR);
         accounting.paused = B20PausableFeature::mask(IB20::PausableFeature::MINT);
+        let mut token = TestToken::with_storage_and_policy(accounting, InMemoryPolicy::new());
+
+        assert_eq!(
+            token.mint(CALLER, ALICE, U256::ONE, true).unwrap_err(),
+            BasePrecompileError::revert(IB20::ContractPaused {
+                feature: IB20::PausableFeature::MINT,
+            })
+        );
+    }
+
+    #[test]
+    fn mint_paused_gets_pause_error_not_policy_error() {
+        let mut accounting = InMemoryTokenAccounting::new(TOKEN_ADDR);
+        accounting.paused = B20PausableFeature::mask(IB20::PausableFeature::MINT);
+        accounting
+            .policy_ids
+            .insert(B20PolicyType::MintReceiver.id(), PolicyRegistryStorage::ALWAYS_BLOCK_ID);
         let mut token = TestToken::with_storage_and_policy(accounting, InMemoryPolicy::new());
 
         assert_eq!(


### PR DESCRIPTION
## Summary

- Swaps `ensure_not_paused` and `ensure_policy_type` in `mint()` so pause is checked before the per-account policy lookup
- `transfer()` already had this ordering — `mint()` is now consistent
- Adds a regression test: a paused mint with a policy-denied receiver returns `ContractPaused`, not `PolicyForbids`

## Why pause beats policy

Pause is a contract-level halt set by an admin to stop all activity. Policy is a per-account check backed by an external registry call. The coarser gate should always fire first — there's no reason to do a per-account registry lookup if the entire operation is halted.

## Test plan

- [ ] `mint_paused_gets_pause_error_not_policy_error` — paused mint with ALWAYS_BLOCK receiver policy returns `ContractPaused`
- [ ] All 327 existing tests continue to pass

Fixes BOP-199.

🤖 Generated with [Claude Code](https://claude.com/claude-code)