### PR TITLE
fix(precompiles): zero-receiver check precedes zero-sender in transfer

### DIFF
--- a/crates/common/precompiles/src/common/ops/transferable.rs
+++ b/crates/common/precompiles/src/common/ops/transferable.rs
@@ -20,11 +20,11 @@ pub trait Transferable: Token {
         amount: U256,
         privileged: bool,
     ) -> Result<()> {
-        if from == Address::ZERO {
-            return Err(BasePrecompileError::revert(IB20::InvalidSender { sender: from }));
-        }
         if to == Address::ZERO {
             return Err(BasePrecompileError::revert(IB20::InvalidReceiver { receiver: to }));
+        }
+        if from == Address::ZERO {
+            return Err(BasePrecompileError::revert(IB20::InvalidSender { sender: from }));
         }
         if !privileged {
             B20Guards::ensure_not_paused::<Self>(self, IB20::PausableFeature::TRANSFER)?;
@@ -208,6 +208,16 @@ mod tests {
         assert_eq!(
             token.transfer(Address::ZERO, BOB, U256::ONE, false).unwrap_err(),
             BasePrecompileError::revert(IB20::InvalidSender { sender: Address::ZERO })
+        );
+    }
+
+    #[test]
+    fn transfer_zero_receiver_beats_zero_sender() {
+        let mut token = make_token();
+
+        assert_eq!(
+            token.transfer(Address::ZERO, Address::ZERO, U256::ONE, false).unwrap_err(),
+            BasePrecompileError::revert(IB20::InvalidReceiver { receiver: Address::ZERO })
         );
     }
 

--- a/crates/common/precompiles/src/common/ops/transferable.rs
+++ b/crates/common/precompiles/src/common/ops/transferable.rs
@@ -212,7 +212,7 @@ mod tests {
     }
 
     #[test]
-    fn transfer_zero_receiver_beats_zero_sender() {
+    fn transfer_receiver_error_should_fire_before_sender_error() {
         let mut token = make_token();
 
         assert_eq!(


### PR DESCRIPTION
## Summary

- Swaps the two zero-address guards at the top of `transfer()` so `to == address(0)` is checked before `from == address(0)`
- Aligns Rust revert order with Solidity: when both sender and receiver are `address(0)`, `InvalidReceiver` is returned (not `InvalidSender`)
- Adds regression test `transfer_zero_receiver_beats_zero_sender` to lock in the ordering

## Why

Rust and Solidity were diverging on revert order when both `from` and `to` are `address(0)`. Solidity canonically returns `InvalidReceiver`; this fixes Rust to match.

This should flip `test_transfer_revertOrder_zeroReceiver_beats_zeroSender` in `base-std test/unit/B20/erc20/transfer_revertOrder.t.sol`.

## Test plan

- [ ] `transfer_zero_receiver_beats_zero_sender` — both addresses zero returns `InvalidReceiver`, not `InvalidSender`
- [ ] `transfer_from_zero_sender_reverts` — zero sender with valid receiver still returns `InvalidSender`
- [ ] `transfer_to_zero_receiver_reverts` — zero receiver with valid sender still returns `InvalidReceiver`
- [ ] All 327 existing tests pass

Fixes BOP-200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)