### PR TITLE
fix(precompiles): align batchBurn + security_redeem zero-amount semantics to ERC-20

### DIFF
--- a/crates/common/precompiles/src/b20_security/dispatch.rs
+++ b/crates/common/precompiles/src/b20_security/dispatch.rs
@@ -564,8 +564,9 @@ impl<S: SecurityAccounting, P: Policy> B20SecurityToken<S, P> {
         B20Guards::ensure_policy::<Self>(self, Self::REDEEM_SENDER_POLICY, caller)?;
         let ratio = self.accounting().shares_to_tokens_ratio()?;
         if !amount.is_zero() {
-            let shares = amount.checked_mul(ratio).ok_or_else(BasePrecompileError::under_overflow)?
-                / B20SecurityStorage::WAD;
+            let shares =
+                amount.checked_mul(ratio).ok_or_else(BasePrecompileError::under_overflow)?
+                    / B20SecurityStorage::WAD;
             let minimum = self.accounting().minimum_redeemable()?;
             if shares == U256::ZERO || shares < minimum {
                 return Err(BasePrecompileError::revert(IB20Security::BelowMinimumRedeemable {

--- a/crates/common/precompiles/src/b20_security/dispatch.rs
+++ b/crates/common/precompiles/src/b20_security/dispatch.rs
@@ -1220,6 +1220,30 @@ mod tests {
     }
 
     #[test]
+    fn batch_burn_does_not_revert_on_zero_value_transfer() {
+        let mut token = make_token();
+        token.accounting_mut().roles.insert((BURN_FROM_ROLE, ALICE), true);
+        token.accounting_mut().balances.insert(ALICE, U256::from(100u64));
+        token.accounting_mut().balances.insert(BOB, U256::from(50u64));
+        token.accounting_mut().total_supply = U256::from(150u64);
+
+        call_security(
+            &mut token,
+            ALICE,
+            batch_burn_calldata(
+                alloc::vec![ALICE, BOB],
+                alloc::vec![U256::from(10u64), U256::ZERO],
+            ),
+        )
+        .unwrap();
+
+        assert_eq!(token.accounting().balance_of(ALICE).unwrap(), U256::from(90u64));
+        assert_eq!(token.accounting().balance_of(BOB).unwrap(), U256::from(50u64));
+        assert_eq!(token.accounting().total_supply().unwrap(), U256::from(140u64));
+        assert_eq!(token.accounting().events.len(), 2); // one Transfer per element
+    }
+
+    #[test]
     fn batch_burn_multiple_accounts_emits_one_transfer_each() {
         let mut token = make_token();
         token.accounting_mut().roles.insert((BURN_FROM_ROLE, ALICE), true);

--- a/crates/common/precompiles/src/b20_security/dispatch.rs
+++ b/crates/common/precompiles/src/b20_security/dispatch.rs
@@ -562,18 +562,17 @@ impl<S: SecurityAccounting, P: Policy> B20SecurityToken<S, P> {
     ) -> base_precompile_storage::Result<U256> {
         B20Guards::ensure_not_paused::<Self>(self, IB20::PausableFeature::REDEEM)?;
         B20Guards::ensure_policy::<Self>(self, Self::REDEEM_SENDER_POLICY, caller)?;
-        if amount.is_zero() {
-            return Err(BasePrecompileError::revert(IB20::InvalidAmount {}));
-        }
         let ratio = self.accounting().shares_to_tokens_ratio()?;
-        let shares = amount.checked_mul(ratio).ok_or_else(BasePrecompileError::under_overflow)?
-            / B20SecurityStorage::WAD;
-        let minimum = self.accounting().minimum_redeemable()?;
-        if shares == U256::ZERO || shares < minimum {
-            return Err(BasePrecompileError::revert(IB20Security::BelowMinimumRedeemable {
-                shares,
-                minimum,
-            }));
+        if amount > U256::ZERO {
+            let shares = amount.checked_mul(ratio).ok_or_else(BasePrecompileError::under_overflow)?
+                / B20SecurityStorage::WAD;
+            let minimum = self.accounting().minimum_redeemable()?;
+            if shares == U256::ZERO || shares < minimum {
+                return Err(BasePrecompileError::revert(IB20Security::BelowMinimumRedeemable {
+                    shares,
+                    minimum,
+                }));
+            }
         }
         let balance = self.accounting().balance_of(caller)?;
         if balance < amount {
@@ -653,9 +652,6 @@ impl<S: SecurityAccounting, P: Policy> B20SecurityToken<S, P> {
         }
         B20Guards::ensure_not_paused::<Self>(self, IB20::PausableFeature::BURN)?;
         for (account, amount) in accounts.into_iter().zip(amounts) {
-            if amount.is_zero() {
-                return Err(BasePrecompileError::revert(IB20::InvalidAmount {}));
-            }
             let balance = self.accounting().balance_of(account)?;
             if balance < amount {
                 return Err(BasePrecompileError::revert(IB20::InsufficientBalance {
@@ -988,6 +984,20 @@ mod tests {
     }
 
     #[test]
+    fn security_redeem_zero_amount_is_no_op() {
+        let mut token = make_token();
+        token.accounting_mut().balances.insert(ALICE, U256::from(100u64));
+        token.accounting_mut().total_supply = U256::from(100u64);
+        token.accounting_mut().minimum_redeemable = U256::from(1u64);
+
+        token.security_redeem(ALICE, U256::ZERO).unwrap();
+
+        assert_eq!(token.accounting().balance_of(ALICE).unwrap(), U256::from(100u64));
+        assert_eq!(token.accounting().total_supply().unwrap(), U256::from(100u64));
+        assert_eq!(token.accounting().events.len(), 2); // Transfer(ALICE, 0x0, 0) + Redeemed(ALICE, 0, ratio)
+    }
+
+    #[test]
     fn security_redeem_rejects_below_minimum_shares() {
         let mut token = make_token();
         token.accounting_mut().balances.insert(ALICE, U256::from(100u64));
@@ -1191,23 +1201,22 @@ mod tests {
     }
 
     #[test]
-    fn batch_burn_rejects_zero_amount() {
+    fn batch_burn_zero_amount_is_no_op() {
         let mut token = make_token();
         token.accounting_mut().roles.insert((BURN_FROM_ROLE, ALICE), true);
         token.accounting_mut().balances.insert(ALICE, U256::from(100u64));
         token.accounting_mut().total_supply = U256::from(100u64);
 
-        assert_eq!(
-            call_security(
-                &mut token,
-                ALICE,
-                batch_burn_calldata(alloc::vec![ALICE], alloc::vec![U256::ZERO]),
-            )
-            .unwrap_err(),
-            BasePrecompileError::revert(IB20::InvalidAmount {})
-        );
+        call_security(
+            &mut token,
+            ALICE,
+            batch_burn_calldata(alloc::vec![ALICE], alloc::vec![U256::ZERO]),
+        )
+        .unwrap();
+
         assert_eq!(token.accounting().balance_of(ALICE).unwrap(), U256::from(100u64));
-        assert_eq!(token.accounting().events.len(), 0);
+        assert_eq!(token.accounting().total_supply().unwrap(), U256::from(100u64));
+        assert_eq!(token.accounting().events.len(), 1); // Transfer(ALICE, 0x0, 0) emitted
     }
 
     #[test]

--- a/crates/common/precompiles/src/b20_security/dispatch.rs
+++ b/crates/common/precompiles/src/b20_security/dispatch.rs
@@ -563,7 +563,7 @@ impl<S: SecurityAccounting, P: Policy> B20SecurityToken<S, P> {
         B20Guards::ensure_not_paused::<Self>(self, IB20::PausableFeature::REDEEM)?;
         B20Guards::ensure_policy::<Self>(self, Self::REDEEM_SENDER_POLICY, caller)?;
         let ratio = self.accounting().shares_to_tokens_ratio()?;
-        if amount > U256::ZERO {
+        if !amount.is_zero() {
             let shares = amount.checked_mul(ratio).ok_or_else(BasePrecompileError::under_overflow)?
                 / B20SecurityStorage::WAD;
             let minimum = self.accounting().minimum_redeemable()?;


### PR DESCRIPTION
## Summary

Zero-amount calls to `batchBurn` and `security_redeem` were rejected with `InvalidAmount`. Solidity was updated to allow zero (ERC-20 semantics), Rust now mirrors that behavior.

**`security_redeem_burn`**
- Removes the `amount.is_zero() → InvalidAmount` guard
- Gates the dust-prevention (`BelowMinimumRedeemable`) check on `amount > 0` — explicit zero-amount redemptions skip it and fall through as a no-op, emitting `Transfer(holder, 0x0, 0)` and `Redeemed(holder, 0, ratio)`

**`batch_burn`**
- Removes the per-element `amount.is_zero() → InvalidAmount` guard
- Zero-amount elements are now no-ops that emit `Transfer(account, 0x0, 0)` with no balance or supply changes

## Test plan

- [ ] `security_redeem_zero_amount_is_no_op` — zero-amount redeem succeeds, balance/supply unchanged, 2 events emitted
- [ ] `batch_burn_zero_amount_is_no_op` — zero-amount batch element succeeds, balance/supply unchanged, 1 Transfer event emitted
- [ ] `security_redeem_rejects_below_minimum_shares` — non-zero amount below minimum still reverts
- [ ] `security_redeem_rejects_zero_shares` — non-zero amount that rounds to zero shares still reverts
- [ ] All 327 existing tests pass
- [ ] Should flip `test_batchBurn_success_zeroAmountElementsAreNoOps` and `test_redeem_success_zeroAmountIsNoOp` in `base-std` once PR #89 merges

Fixes BOP-203.

🤖 Generated with [Claude Code](https://claude.com/claude-code)