### PR TITLE
feat(load tests): add B20 workload

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4877,6 +4877,7 @@ dependencies = [
  "base-common-consensus",
  "base-common-flashblocks",
  "base-common-network",
+ "base-common-precompiles",
  "base-tx-manager",
  "eyre",
  "futures",

--- a/bin/load-tester/src/cli.rs
+++ b/bin/load-tester/src/cli.rs
@@ -270,6 +270,14 @@ async fn run_load_test(args: LoadArgs) -> Result<()> {
     // mempool state settles before we query balances for the drain.
     tokio::time::sleep(Duration::from_secs(2)).await;
 
+    if runner.needs_b20_setup() {
+        println!("Burning remaining B-20 tokens...");
+        match runner.teardown_b20_tokens().await {
+            Ok(()) => println!("B-20 teardown complete."),
+            Err(e) => eprintln!("Warning: B-20 teardown failed: {e}"),
+        }
+    }
+
     println!();
     println!("Draining accounts back to funder...");
     match runner.drain_accounts(funding_key).await {
@@ -307,6 +315,12 @@ async fn run_test_phases(
         println!("Distributing swap tokens...");
         runner.setup_swap_tokens(funding_key.clone(), swap_token_amount).await?;
         println!("Swap tokens distributed.");
+    }
+
+    if runner.needs_b20_setup() {
+        println!("Setting up B-20 tokens...");
+        runner.setup_b20_tokens(funding_key.clone(), swap_token_amount).await?;
+        println!("B-20 tokens ready.");
     }
     println!();
 

--- a/bin/load-tester/src/cli.rs
+++ b/bin/load-tester/src/cli.rs
@@ -161,6 +161,7 @@ async fn run_load_test(args: LoadArgs) -> Result<()> {
 
     let funding_amount = test_config.parse_funding_amount()?;
     let swap_token_amount = test_config.parse_swap_token_amount()?;
+    let b20_mint_amount = test_config.parse_b20_mint_amount()?;
 
     let config_summary = test_config.to_summary();
     let mut runner = LoadRunner::new(load_config.clone())?;
@@ -176,6 +177,7 @@ async fn run_load_test(args: LoadArgs) -> Result<()> {
         &funding_key,
         funding_amount,
         swap_token_amount,
+        b20_mint_amount,
         &mp,
         load_config.duration,
     )
@@ -298,6 +300,7 @@ async fn run_test_phases(
     funding_key: &PrivateKeySigner,
     funding_amount: U256,
     swap_token_amount: U256,
+    b20_mint_amount: U256,
     mp: &indicatif::MultiProgress,
     duration: Option<Duration>,
 ) -> LoadResult<MetricsSummary> {
@@ -319,7 +322,7 @@ async fn run_test_phases(
 
     if runner.needs_b20_setup() {
         println!("Setting up B-20 tokens...");
-        runner.setup_b20_tokens(funding_key.clone(), swap_token_amount).await?;
+        runner.setup_b20_tokens(funding_key.clone(), b20_mint_amount).await?;
         println!("B-20 tokens ready.");
     }
     println!();

--- a/crates/infra/load-tests/Cargo.toml
+++ b/crates/infra/load-tests/Cargo.toml
@@ -28,6 +28,7 @@ base-tx-manager.workspace = true
 base-common-network.workspace = true
 base-common-consensus.workspace = true
 base-common-flashblocks.workspace = true
+base-common-precompiles = { workspace = true, default-features = false }
 
 # display
 indicatif.workspace = true

--- a/crates/infra/load-tests/README.md
+++ b/crates/infra/load-tests/README.md
@@ -144,3 +144,24 @@ looper_contract: "0x..."  # Deployed PrecompileLooper contract
 ```
 
 The `PrecompileLooper` contract enables batch testing by calling a precompile multiple times in a single transaction, useful for scenarios like multi-signature verification or repeated hash operations.
+
+#### B-20 Token Testing
+
+B-20 precompile tokens can be load-tested to benchmark the precompile's `transfer` performance.
+The load tester handles the full lifecycle: token creation via the B-20 factory, role grants
+(`MINT_ROLE` / `BURN_ROLE` to every sender), minting during setup, and burning during teardown.
+
+Requires Beryl activation (B-20 factory and token features must be active on the target chain).
+
+```yaml
+# Auto-create a new B-20 token per run (devnet/zeronet)
+transactions:
+  - weight: 100
+    type: b20
+
+# Use a pre-deployed B-20 token
+transactions:
+  - weight: 100
+    type: b20
+    contract: "0x..."
+```

--- a/crates/infra/load-tests/examples/devnet.yaml
+++ b/crates/infra/load-tests/examples/devnet.yaml
@@ -55,7 +55,6 @@ transactions:
   - weight: 20
     type: calldata
     max_size: 256
-    repeat_count: 1
   - weight: 10
     type: precompile
     target: sha256

--- a/crates/infra/load-tests/examples/devnet.yaml
+++ b/crates/infra/load-tests/examples/devnet.yaml
@@ -46,14 +46,18 @@ funding_amount: "10000000000000000"
 
 # Transaction mix
 transactions:
-  - weight: 70
-    type: transfer
-  - weight: 20
-    type: calldata
-    max_size: 256
-  - weight: 10
-    type: precompile
-    target: sha256
+  #- weight: 70
+  #  type: transfer
+  #- weight: 20
+  #  type: calldata
+  #  max_size: 256
+  #- weight: 10
+  #  type: precompile
+  #  target: sha256
+  # B-20 precompile token transfer (requires Beryl activation):
+  - weight: 100
+    type: b20
+  #   # contract: "0x..."  # Optional: omit to auto-create via factory
   # Swap transaction types (require deployed contracts):
   # - weight: 5
   #   type: uniswap_v3

--- a/crates/infra/load-tests/examples/devnet.yaml
+++ b/crates/infra/load-tests/examples/devnet.yaml
@@ -44,19 +44,24 @@ funding_amount: "10000000000000000"
 # Only used when swap transaction types are configured.
 # swap_token_amount: "1000000000000000000000"
 
+# Amount of B-20 tokens to mint per sender during setup (1000 tokens).
+# Only used when B-20 transaction types are configured.
+# b20_mint_amount: "1000000000000000000000"
+
 # Transaction mix
 transactions:
-  #- weight: 70
-  #  type: transfer
-  #- weight: 20
-  #  type: calldata
-  #  max_size: 256
-  #- weight: 10
-  #  type: precompile
-  #  target: sha256
+  - weight: 70
+    type: transfer
+  - weight: 20
+    type: calldata
+    max_size: 256
+    repeat_count: 1
+  - weight: 10
+    type: precompile
+    target: sha256
   # B-20 precompile token transfer (requires Beryl activation):
-  - weight: 100
-    type: b20
+  # - weight: 100
+  #   type: b20
   #   # contract: "0x..."  # Optional: omit to auto-create via factory
   # Swap transaction types (require deployed contracts):
   # - weight: 5

--- a/crates/infra/load-tests/src/config/test_config.rs
+++ b/crates/infra/load-tests/src/config/test_config.rs
@@ -276,6 +276,14 @@ pub enum TxTypeConfig {
         #[serde(default = "default_swap_max_amount")]
         max_amount: String,
     },
+    /// B-20 precompile token transfer.
+    B20 {
+        /// B-20 token precompile address. When omitted, a new token is created via the factory
+        /// during setup.
+        #[serde(default)]
+        contract: Option<String>,
+    },
+
     /// Aerodrome Slipstream (concentrated liquidity) swap.
     AerodromeCl {
         /// CL Router contract address.
@@ -584,6 +592,19 @@ impl TestConfig {
                     iterations: *iterations,
                     looper_contract,
                 }
+            }
+            TxTypeConfig::B20 { contract } => {
+                let contract = contract
+                    .as_ref()
+                    .map(|c| {
+                        c.parse::<Address>().map_err(|e| {
+                            BaselineError::Config(format!(
+                                "invalid b20 contract address '{c}': {e}"
+                            ))
+                        })
+                    })
+                    .transpose()?;
+                TxType::B20 { contract }
             }
             TxTypeConfig::Osaka { target } => TxType::Osaka { target: target.clone() },
             TxTypeConfig::UniswapV3 {

--- a/crates/infra/load-tests/src/config/test_config.rs
+++ b/crates/infra/load-tests/src/config/test_config.rs
@@ -144,6 +144,11 @@ pub struct TestConfig {
     /// Only used when swap transaction types are configured.
     #[serde(default = "default_swap_token_amount")]
     pub swap_token_amount: String,
+
+    /// Amount of B-20 tokens to mint per sender during setup (in wei, as string).
+    /// Only used when B-20 transaction types are configured.
+    #[serde(default = "default_b20_mint_amount")]
+    pub b20_mint_amount: String,
 }
 
 impl Default for TestConfig {
@@ -169,6 +174,7 @@ impl Default for TestConfig {
             transactions: vec![WeightedTxType { weight: 100, tx_type: TxTypeConfig::Transfer }],
             looper_contract: None,
             swap_token_amount: default_swap_token_amount(),
+            b20_mint_amount: default_b20_mint_amount(),
         }
     }
 }
@@ -192,6 +198,7 @@ impl fmt::Debug for TestConfig {
             .field("transactions", &self.transactions)
             .field("looper_contract", &self.looper_contract)
             .field("swap_token_amount", &self.swap_token_amount)
+            .field("b20_mint_amount", &self.b20_mint_amount)
             .finish()
     }
 }
@@ -336,6 +343,10 @@ fn default_swap_token_amount() -> String {
     "1000000000000000000000".to_string() // 1000 tokens (1000e18)
 }
 
+fn default_b20_mint_amount() -> String {
+    "1000000000000000000000".to_string() // 1000 tokens (1000e18)
+}
+
 impl TestConfig {
     /// Loads configuration from a YAML file.
     pub fn load<P: AsRef<Path>>(path: P) -> Result<Self> {
@@ -476,6 +487,16 @@ impl TestConfig {
         })
     }
 
+    /// Parses the B-20 mint amount string into a U256.
+    pub fn parse_b20_mint_amount(&self) -> Result<alloy_primitives::U256> {
+        self.b20_mint_amount.parse().map_err(|e| {
+            BaselineError::Config(format!(
+                "invalid b20_mint_amount '{}': {e}",
+                self.b20_mint_amount
+            ))
+        })
+    }
+
     /// Returns a summary of the config for JSON output (excludes URLs and secrets).
     pub fn to_summary(&self) -> ConfigSummary {
         ConfigSummary {
@@ -499,6 +520,7 @@ impl TestConfig {
                 .unwrap_or_default(),
             looper_contract: self.looper_contract.clone(),
             swap_token_amount: self.swap_token_amount.clone(),
+            b20_mint_amount: self.b20_mint_amount.clone(),
         }
     }
 

--- a/crates/infra/load-tests/src/lib.rs
+++ b/crates/infra/load-tests/src/lib.rs
@@ -25,9 +25,9 @@ pub use metrics::{
 
 mod workload;
 pub use workload::{
-    AccountPool, AerodromeClPayload, CalldataPayload, Erc20Payload, FundedAccount, OsakaPayload,
-    Payload, PrecompileLooper, PrecompilePayload, SeededRng, StoragePayload, TransferPayload,
-    UniswapV3Payload, WorkloadGenerator, parse_precompile_id,
+    AccountPool, AerodromeClPayload, B20TransferPayload, CalldataPayload, Erc20Payload,
+    FundedAccount, OsakaPayload, Payload, PrecompileLooper, PrecompilePayload, SeededRng,
+    StoragePayload, TransferPayload, UniswapV3Payload, WorkloadGenerator, parse_precompile_id,
 };
 
 mod runner;

--- a/crates/infra/load-tests/src/metrics/types.rs
+++ b/crates/infra/load-tests/src/metrics/types.rs
@@ -211,4 +211,6 @@ pub struct ConfigSummary {
     pub looper_contract: Option<String>,
     /// Amount of each swap token per sender (in wei, as string).
     pub swap_token_amount: String,
+    /// Amount of B-20 tokens to mint per sender (in wei, as string).
+    pub b20_mint_amount: String,
 }

--- a/crates/infra/load-tests/src/runner/config.rs
+++ b/crates/infra/load-tests/src/runner/config.rs
@@ -48,6 +48,11 @@ pub enum TxType {
         /// Looper contract address (required when iterations > 1).
         looper_contract: Option<Address>,
     },
+    /// B-20 precompile token transfer.
+    B20 {
+        /// Pre-deployed token address, or `None` to create a new token during setup.
+        contract: Option<Address>,
+    },
     /// Osaka (Base Azul) opcode or precompile transaction.
     Osaka {
         /// Target Osaka feature.

--- a/crates/infra/load-tests/src/runner/load_runner.rs
+++ b/crates/infra/load-tests/src/runner/load_runner.rs
@@ -26,10 +26,10 @@ use tracing::{debug, error, info, instrument, warn};
 /// Maximum number of concurrent RPC requests during funding/draining operations.
 const FUNDING_CONCURRENCY: usize = 32;
 
-/// Maximum number of funding TXs to send before waiting for confirmation.
+/// Maximum number of TXs to send before waiting for confirmation.
 /// Kept below typical per-sender txpool limits (e.g. reth default is 16) to
 /// avoid "txpool is full" rejections when all TXs originate from one funder.
-const FUNDING_BATCH_SIZE: usize = 16;
+const BATCH_SIZE: usize = 16;
 
 use super::{
     BlockWatcher, DisplaySnapshot, FlashblockWatcher, LoadConfig, LoadTestDisplay, PreparedBatch,
@@ -214,7 +214,13 @@ impl LoadRunner {
                     generator = generator.with_payload(payload, weight_pct);
                 }
                 TxType::B20 { contract } => {
-                    let token = contract.expect("b20 contract must be resolved before run");
+                    let token = contract.ok_or_else(|| {
+                        BaselineError::Config(
+                            "b20 contract must be resolved before run; \
+                             call setup_b20_tokens first"
+                                .into(),
+                        )
+                    })?;
                     generator = generator.with_payload(
                         B20TransferPayload::new(token, U256::from(1000), U256::from(10000)),
                         weight_pct,
@@ -450,7 +456,7 @@ impl LoadRunner {
         let pb_fund = self.progress_bar(total_txs, "Funding accounts");
         let mut txs_remaining = txs.into_iter().peekable();
         while txs_remaining.peek().is_some() {
-            let batch: Vec<_> = txs_remaining.by_ref().take(FUNDING_BATCH_SIZE).collect();
+            let batch: Vec<_> = txs_remaining.by_ref().take(BATCH_SIZE).collect();
             let mut batch_pending: Vec<Address> = Vec::with_capacity(batch.len());
             let mut retries: Vec<(Address, U256, u64)> = Vec::new();
             let mut fatal_errors: Vec<String> = Vec::new();
@@ -463,7 +469,7 @@ impl LoadRunner {
                 }
             });
 
-            let mut send_stream = stream::iter(send_futs).buffer_unordered(FUNDING_BATCH_SIZE);
+            let mut send_stream = stream::iter(send_futs).buffer_unordered(BATCH_SIZE);
 
             let mut nonce_refresh_needed: Vec<(Address, U256)> = Vec::new();
 
@@ -516,7 +522,7 @@ impl LoadRunner {
                 });
 
                 let mut retry_stream =
-                    stream::iter(retry_futs).buffer_unordered(FUNDING_BATCH_SIZE);
+                    stream::iter(retry_futs).buffer_unordered(BATCH_SIZE);
 
                 while let Some((result, address, nonce)) = retry_stream.next().await {
                     match result {
@@ -565,7 +571,7 @@ impl LoadRunner {
                     });
 
                 let mut nonce_retry_stream =
-                    stream::iter(nonce_retry_futs).buffered(FUNDING_BATCH_SIZE);
+                    stream::iter(nonce_retry_futs).buffered(BATCH_SIZE);
 
                 let mut nonce_retry_pending: Vec<Address> = Vec::new();
                 while let Some((result, address, retry_nonce)) = nonce_retry_stream.next().await {
@@ -879,7 +885,7 @@ impl LoadRunner {
         let total_txs = txs.len();
         let mut txs_remaining = txs.into_iter().peekable();
         while txs_remaining.peek().is_some() {
-            let batch: Vec<_> = txs_remaining.by_ref().take(FUNDING_BATCH_SIZE).collect();
+            let batch: Vec<_> = txs_remaining.by_ref().take(BATCH_SIZE).collect();
             let mut pending_txs: Vec<(Address, Address)> = Vec::new();
 
             let send_futs = batch.into_iter().map(|(tx, token, sender)| {
@@ -890,7 +896,7 @@ impl LoadRunner {
                 }
             });
 
-            let mut send_stream = stream::iter(send_futs).buffer_unordered(FUNDING_BATCH_SIZE);
+            let mut send_stream = stream::iter(send_futs).buffer_unordered(BATCH_SIZE);
 
             while let Some((result, token, sender)) = send_stream.next().await {
                 match result {
@@ -1034,7 +1040,9 @@ impl LoadRunner {
             token_address = Some(predicted);
         }
 
-        let token = token_address.expect("token address must be resolved");
+        let token = token_address.ok_or_else(|| {
+            BaselineError::Config("b20 token address was not resolved during setup".into())
+        })?;
 
         for tx_config in &mut self.config.transactions {
             if let TxType::B20 { contract } = &mut tx_config.tx_type {
@@ -1087,7 +1095,7 @@ impl LoadRunner {
         let mut grant_failed = 0usize;
         let mut txs_remaining = grant_txs.into_iter().peekable();
         while txs_remaining.peek().is_some() {
-            let batch: Vec<_> = txs_remaining.by_ref().take(FUNDING_BATCH_SIZE).collect();
+            let batch: Vec<_> = txs_remaining.by_ref().take(BATCH_SIZE).collect();
             let send_futs = batch.into_iter().map(|tx| {
                 let provider = Arc::clone(&funder_provider);
                 async move {
@@ -1096,7 +1104,7 @@ impl LoadRunner {
                 }
             });
 
-            let mut send_stream = stream::iter(send_futs).buffer_unordered(FUNDING_BATCH_SIZE);
+            let mut send_stream = stream::iter(send_futs).buffer_unordered(BATCH_SIZE);
             while let Some(result) = send_stream.next().await {
                 match result {
                     Ok(receipt) if receipt.status() => pb.inc(1),
@@ -1148,7 +1156,7 @@ impl LoadRunner {
         let mut txs_remaining = mint_txs.into_iter().peekable();
 
         while txs_remaining.peek().is_some() {
-            let batch: Vec<_> = txs_remaining.by_ref().take(FUNDING_BATCH_SIZE).collect();
+            let batch: Vec<_> = txs_remaining.by_ref().take(BATCH_SIZE).collect();
             let send_futs = batch.into_iter().map(|(tx, sender)| {
                 let provider = Arc::clone(&funder_provider);
                 async move {
@@ -1165,7 +1173,7 @@ impl LoadRunner {
                 }
             });
 
-            let mut send_stream = stream::iter(send_futs).buffer_unordered(FUNDING_BATCH_SIZE);
+            let mut send_stream = stream::iter(send_futs).buffer_unordered(BATCH_SIZE);
             while let Some(result) = send_stream.next().await {
                 match result {
                     Ok((receipt, sender)) if receipt.status() => {
@@ -1226,60 +1234,92 @@ impl LoadRunner {
 
         let sender_addresses: Vec<Address> =
             self.accounts.accounts().iter().map(|a| a.address).collect();
-        let pb = self.progress_bar(sender_addresses.len() as u64, "Burning B-20 tokens");
 
         let signers = Self::build_signers(&self.accounts);
+        let client = &self.client;
+        let rpc_url = self.config.primary_submission_rpc().clone();
+
+        // Phase 1: Query all balances in parallel.
+        let balance_futs: Vec<_> = sender_addresses
+            .iter()
+            .map(|&sender| {
+                let client = client.clone();
+                let call_data = Self::encode_erc20_balance_of(sender);
+                async move {
+                    let balance = client
+                        .call(
+                            TransactionRequest::default()
+                                .with_to(token)
+                                .with_input(call_data)
+                                .into(),
+                        )
+                        .await
+                        .rpc("eth_call")
+                        .map(|bytes| U256::from_be_slice(bytes.as_ref()))
+                        .unwrap_or(U256::ZERO);
+                    (sender, balance)
+                }
+            })
+            .collect();
+
+        let balances: Vec<_> = stream::iter(balance_futs)
+            .buffer_unordered(FUNDING_CONCURRENCY)
+            .collect()
+            .await;
+
+        let senders_with_balance: Vec<_> = balances
+            .into_iter()
+            .filter(|(_, balance)| !balance.is_zero())
+            .collect();
+
+        if senders_with_balance.is_empty() {
+            info!("all B-20 balances are zero, skipping teardown");
+            return Ok(());
+        }
+
+        // Phase 2: Build burn txs — each sender burns their own balance.
+        let pb = self.progress_bar(senders_with_balance.len() as u64, "Burning B-20 tokens");
         let mut burn_failed = 0usize;
         let mut burn_count = 0usize;
 
-        for &sender in &sender_addresses {
-            let call_data = Self::encode_erc20_balance_of(sender);
-            let balance = self
-                .client
-                .call(TransactionRequest::default().with_to(token).with_input(call_data).into())
-                .await
-                .rpc("eth_call")
-                .map(|bytes| U256::from_be_slice(bytes.as_ref()))
-                .unwrap_or(U256::ZERO);
+        let burn_futs: Vec<_> = senders_with_balance
+            .into_iter()
+            .filter_map(|(sender, balance)| {
+                let signer = signers.get(&sender)?.clone();
+                let wallet = EthereumWallet::from(signer);
+                let provider = create_wallet_provider(rpc_url.clone(), wallet);
+                let burn_call = IB20::burnCall { amount: balance };
+                let tx = TransactionRequest::default()
+                    .with_to(token)
+                    .with_input(Bytes::from(burn_call.abi_encode()))
+                    .with_chain_id(chain_id)
+                    .with_gas_limit(burn_gas_limit)
+                    .with_max_fee_per_gas(max_fee)
+                    .with_max_priority_fee_per_gas(max_priority_fee);
+                Some(async move {
+                    match provider.send_transaction(tx).await {
+                        Ok(pending) => match pending.get_receipt().await {
+                            Ok(receipt) => Ok((sender, balance, receipt)),
+                            Err(e) => Err((sender, eyre::eyre!("receipt failed: {e}"))),
+                        },
+                        Err(e) => Err((sender, eyre::eyre!("send failed: {e}"))),
+                    }
+                })
+            })
+            .collect();
 
-            if balance.is_zero() {
-                pb.inc(1);
-                continue;
-            }
-
-            let Some(signer) = signers.get(&sender) else {
-                warn!(sender = %sender, "no signer for B-20 burn");
-                pb.inc(1);
-                continue;
-            };
-
-            let wallet = EthereumWallet::from(signer.clone());
-            let sender_provider =
-                create_wallet_provider(self.config.primary_submission_rpc().clone(), wallet);
-
-            let sender_nonce = sender_provider
-                .get_transaction_count(sender)
-                .pending()
-                .await
-                .rpc("get pending transaction count")?;
-
-            let burn_call = IB20::burnCall { amount: balance };
-            let tx = TransactionRequest::default()
-                .with_to(token)
-                .with_input(Bytes::from(burn_call.abi_encode()))
-                .with_nonce(sender_nonce)
-                .with_chain_id(chain_id)
-                .with_gas_limit(burn_gas_limit)
-                .with_max_fee_per_gas(max_fee)
-                .with_max_priority_fee_per_gas(max_priority_fee);
-
-            match sender_provider.send_transaction(tx).await {
-                Ok(pending) => {
-                    let tx_hash = *pending.tx_hash();
-                    debug!(sender = %sender, amount = %balance, tx_hash = %tx_hash, "B-20 burn sent");
+        let mut burn_stream = stream::iter(burn_futs).buffer_unordered(BATCH_SIZE);
+        while let Some(result) = burn_stream.next().await {
+            match result {
+                Ok((sender, balance, receipt)) if receipt.status() => {
+                    debug!(sender = %sender, amount = %balance, tx_hash = %receipt.transaction_hash, "B-20 burn confirmed");
                     burn_count += 1;
                 }
-                Err(e) => {
+                Ok((sender, _, receipt)) => {
+                    warn!(sender = %sender, tx_hash = %receipt.transaction_hash, "B-20 burn reverted");
+                    burn_failed += 1;
+                }
+                Err((sender, e)) => {
                     warn!(sender = %sender, error = %e, "B-20 burn failed");
                     burn_failed += 1;
                 }

--- a/crates/infra/load-tests/src/runner/load_runner.rs
+++ b/crates/infra/load-tests/src/runner/load_runner.rs
@@ -14,7 +14,10 @@ use alloy_rpc_types::{BlockNumberOrTag, TransactionRequest};
 use alloy_signer_local::PrivateKeySigner;
 use alloy_sol_types::{SolCall, SolValue, sol};
 use base_common_network::Base;
-use base_common_precompiles::{B20FactoryStorage, B20TokenRole, B20Variant, IB20, IB20Factory};
+use base_common_precompiles::{
+    ActivationFeature, ActivationRegistryStorage, B20FactoryStorage, B20TokenRole, B20Variant,
+    IActivationRegistry, IB20, IB20Factory,
+};
 use base_tx_manager::NonceManager;
 use futures::{StreamExt, stream};
 use indicatif::{ProgressBar, ProgressStyle};
@@ -214,17 +217,12 @@ impl LoadRunner {
                     generator = generator.with_payload(payload, weight_pct);
                 }
                 TxType::B20 { contract } => {
-                    let token = contract.ok_or_else(|| {
-                        BaselineError::Config(
-                            "b20 contract must be resolved before run; \
-                             call setup_b20_tokens first"
-                                .into(),
-                        )
-                    })?;
-                    generator = generator.with_payload(
-                        B20TransferPayload::new(token, U256::from(1000), U256::from(10000)),
-                        weight_pct,
-                    );
+                    if let Some(token) = contract {
+                        generator = generator.with_payload(
+                            B20TransferPayload::new(*token, U256::from(1000), U256::from(10000)),
+                            weight_pct,
+                        );
+                    }
                 }
                 TxType::Osaka { target } => {
                     generator =
@@ -521,8 +519,7 @@ impl LoadRunner {
                     }
                 });
 
-                let mut retry_stream =
-                    stream::iter(retry_futs).buffer_unordered(BATCH_SIZE);
+                let mut retry_stream = stream::iter(retry_futs).buffer_unordered(BATCH_SIZE);
 
                 while let Some((result, address, nonce)) = retry_stream.next().await {
                     match result {
@@ -570,8 +567,7 @@ impl LoadRunner {
                         }
                     });
 
-                let mut nonce_retry_stream =
-                    stream::iter(nonce_retry_futs).buffered(BATCH_SIZE);
+                let mut nonce_retry_stream = stream::iter(nonce_retry_futs).buffered(BATCH_SIZE);
 
                 let mut nonce_retry_pending: Vec<Address> = Vec::new();
                 while let Some((result, address, retry_nonce)) = nonce_retry_stream.next().await {
@@ -990,13 +986,71 @@ impl LoadRunner {
         }
 
         if token_address.is_none() {
+            // Activate B-20 features if not already active. Activation is idempotent on
+            // already-active features but reverts if the funder is not the activation admin.
+            let features = [ActivationFeature::B20Factory.id(), ActivationFeature::B20Token.id()];
+            for feature in &features {
+                let is_activated_call = IActivationRegistry::isActivatedCall { feature: *feature };
+                let check_result = self
+                    .client
+                    .call(
+                        TransactionRequest::default()
+                            .with_to(ActivationRegistryStorage::ADDRESS)
+                            .with_input(Bytes::from(is_activated_call.abi_encode()))
+                            .into(),
+                    )
+                    .await;
+
+                let already_active = check_result
+                    .ok()
+                    .and_then(|bytes| {
+                        IActivationRegistry::isActivatedCall::abi_decode_returns(bytes.as_ref())
+                            .ok()
+                    })
+                    .unwrap_or(false);
+
+                if !already_active {
+                    info!(feature = %feature, "activating B-20 feature");
+                    let activate_call = IActivationRegistry::activateCall { feature: *feature };
+                    let tx = TransactionRequest::default()
+                        .with_to(ActivationRegistryStorage::ADDRESS)
+                        .with_input(Bytes::from(activate_call.abi_encode()))
+                        .with_nonce(nonce)
+                        .with_chain_id(chain_id)
+                        .with_gas_limit(b20_gas_limit)
+                        .with_max_fee_per_gas(max_fee)
+                        .with_max_priority_fee_per_gas(max_priority_fee);
+                    nonce += 1;
+
+                    let pending = funder_provider.send_transaction(tx).await.map_err(|e| {
+                        BaselineError::Transaction(format!(
+                            "failed to activate B-20 feature {feature}: {e}. \
+                             The funder must be the activation admin (sequencer key on devnet)"
+                        ))
+                    })?;
+
+                    let receipt = pending.get_receipt().await.map_err(|e| {
+                        BaselineError::Transaction(format!(
+                            "B-20 feature activation receipt failed: {e}"
+                        ))
+                    })?;
+
+                    if !receipt.status() {
+                        return Err(BaselineError::Transaction(format!(
+                            "B-20 feature {feature} activation reverted. \
+                             The funder must be the activation admin (sequencer key on devnet)"
+                        )));
+                    }
+                }
+            }
+
             info!("creating new B-20 token via factory");
 
             let salt = B256::from(rand::random::<[u8; 32]>());
             let predicted = B20Variant::B20.compute_address(funder_address, salt).0;
 
             let params = IB20Factory::B20CreateParams {
-                version: B20FactoryStorage::CREATE_TOKEN_VERSION,
+                version: 1,
                 name: "Load Test B20".to_string(),
                 symbol: "LTB20".to_string(),
                 initialAdmin: funder_address,
@@ -1201,6 +1255,10 @@ impl LoadRunner {
             )));
         }
 
+        // Rebuild the workload generator now that the B-20 contract address is resolved.
+        let workload_config = WorkloadConfig::new("load-test").with_seed(self.config.seed);
+        self.generator = Self::create_generator(workload_config, &self.config)?;
+
         info!(
             token = %token,
             senders = total_mints,
@@ -1262,15 +1320,11 @@ impl LoadRunner {
             })
             .collect();
 
-        let balances: Vec<_> = stream::iter(balance_futs)
-            .buffer_unordered(FUNDING_CONCURRENCY)
-            .collect()
-            .await;
+        let balances: Vec<_> =
+            stream::iter(balance_futs).buffer_unordered(FUNDING_CONCURRENCY).collect().await;
 
-        let senders_with_balance: Vec<_> = balances
-            .into_iter()
-            .filter(|(_, balance)| !balance.is_zero())
-            .collect();
+        let senders_with_balance: Vec<_> =
+            balances.into_iter().filter(|(_, balance)| !balance.is_zero()).collect();
 
         if senders_with_balance.is_empty() {
             info!("all B-20 balances are zero, skipping teardown");
@@ -1288,15 +1342,25 @@ impl LoadRunner {
                 let signer = signers.get(&sender)?.clone();
                 let wallet = EthereumWallet::from(signer);
                 let provider = create_wallet_provider(rpc_url.clone(), wallet);
-                let burn_call = IB20::burnCall { amount: balance };
-                let tx = TransactionRequest::default()
-                    .with_to(token)
-                    .with_input(Bytes::from(burn_call.abi_encode()))
-                    .with_chain_id(chain_id)
-                    .with_gas_limit(burn_gas_limit)
-                    .with_max_fee_per_gas(max_fee)
-                    .with_max_priority_fee_per_gas(max_priority_fee);
                 Some(async move {
+                    let sender_nonce = match provider.get_transaction_count(sender).pending().await
+                    {
+                        Ok(n) => n,
+                        Err(e) => {
+                            return Err((sender, eyre::eyre!("nonce fetch failed: {e}")));
+                        }
+                    };
+
+                    let burn_call = IB20::burnCall { amount: balance };
+                    let tx = TransactionRequest::default()
+                        .with_to(token)
+                        .with_input(Bytes::from(burn_call.abi_encode()))
+                        .with_nonce(sender_nonce)
+                        .with_chain_id(chain_id)
+                        .with_gas_limit(burn_gas_limit)
+                        .with_max_fee_per_gas(max_fee)
+                        .with_max_priority_fee_per_gas(max_priority_fee);
+
                     match provider.send_transaction(tx).await {
                         Ok(pending) => match pending.get_receipt().await {
                             Ok(receipt) => Ok((sender, balance, receipt)),
@@ -1340,6 +1404,14 @@ impl LoadRunner {
     /// Runs the load test and returns metrics summary.
     #[instrument(skip(self), fields(target_gps = self.config.target_gps, continuous = self.config.duration.is_none(), duration = ?self.config.duration))]
     pub async fn run(&mut self) -> Result<MetricsSummary> {
+        for tx_config in &self.config.transactions {
+            if let TxType::B20 { contract: None } = &tx_config.tx_type {
+                return Err(BaselineError::Config(
+                    "b20 contract address not resolved; call setup_b20_tokens first".into(),
+                ));
+            }
+        }
+
         self.collector.reset();
         self.stop_flag.store(false, Ordering::SeqCst);
         self.cancel_token = CancellationToken::new();

--- a/crates/infra/load-tests/src/runner/load_runner.rs
+++ b/crates/infra/load-tests/src/runner/load_runner.rs
@@ -14,9 +14,7 @@ use alloy_rpc_types::{BlockNumberOrTag, TransactionRequest};
 use alloy_signer_local::PrivateKeySigner;
 use alloy_sol_types::{SolCall, SolValue, sol};
 use base_common_network::Base;
-use base_common_precompiles::{
-    B20FactoryStorage, B20TokenRole, B20Variant, IB20, IB20Factory,
-};
+use base_common_precompiles::{B20FactoryStorage, B20TokenRole, B20Variant, IB20, IB20Factory};
 use base_tx_manager::NonceManager;
 use futures::{StreamExt, stream};
 use indicatif::{ProgressBar, ProgressStyle};
@@ -1044,32 +1042,47 @@ impl LoadRunner {
             }
         }
 
-        // Phase 2: Grant MINT_ROLE and BURN_ROLE to all senders.
+        // Phase 2: Grant MINT_ROLE to funder + MINT_ROLE and BURN_ROLE to all senders.
         let sender_addresses: Vec<Address> =
             self.accounts.accounts().iter().map(|a| a.address).collect();
         let roles = [B20TokenRole::Mint.id(), B20TokenRole::Burn.id()];
 
-        let total_grants = sender_addresses.len() * roles.len();
+        let total_grants = 1 + sender_addresses.len() * roles.len();
         let pb = self.progress_bar(total_grants as u64, "Granting B-20 roles");
 
-        let grant_txs: Vec<TransactionRequest> = sender_addresses
-            .iter()
-            .flat_map(|&sender| {
-                roles.iter().map(move |&role| {
-                    let call = IB20::grantRoleCall { role, account: sender };
-                    let tx = TransactionRequest::default()
+        let mut grant_txs: Vec<TransactionRequest> = Vec::with_capacity(total_grants);
+
+        // Funder needs MINT_ROLE to execute Phase 3 mints.
+        let funder_mint_grant =
+            IB20::grantRoleCall { role: B20TokenRole::Mint.id(), account: funder_address };
+        grant_txs.push(
+            TransactionRequest::default()
+                .with_to(token)
+                .with_input(Bytes::from(funder_mint_grant.abi_encode()))
+                .with_nonce(nonce)
+                .with_chain_id(chain_id)
+                .with_gas_limit(b20_gas_limit)
+                .with_max_fee_per_gas(max_fee)
+                .with_max_priority_fee_per_gas(max_priority_fee),
+        );
+        nonce += 1;
+
+        for &sender in &sender_addresses {
+            for &role in &roles {
+                let call = IB20::grantRoleCall { role, account: sender };
+                grant_txs.push(
+                    TransactionRequest::default()
                         .with_to(token)
                         .with_input(Bytes::from(call.abi_encode()))
                         .with_nonce(nonce)
                         .with_chain_id(chain_id)
                         .with_gas_limit(b20_gas_limit)
                         .with_max_fee_per_gas(max_fee)
-                        .with_max_priority_fee_per_gas(max_priority_fee);
-                    nonce += 1;
-                    tx
-                })
-            })
-            .collect();
+                        .with_max_priority_fee_per_gas(max_priority_fee),
+                );
+                nonce += 1;
+            }
+        }
 
         let mut grant_failed = 0usize;
         let mut txs_remaining = grant_txs.into_iter().peekable();
@@ -1077,13 +1090,21 @@ impl LoadRunner {
             let batch: Vec<_> = txs_remaining.by_ref().take(FUNDING_BATCH_SIZE).collect();
             let send_futs = batch.into_iter().map(|tx| {
                 let provider = Arc::clone(&funder_provider);
-                async move { provider.send_transaction(tx).await }
+                async move {
+                    let pending = provider.send_transaction(tx).await?;
+                    pending.get_receipt().await
+                }
             });
 
             let mut send_stream = stream::iter(send_futs).buffer_unordered(FUNDING_BATCH_SIZE);
             while let Some(result) = send_stream.next().await {
                 match result {
-                    Ok(_) => pb.inc(1),
+                    Ok(receipt) if receipt.status() => pb.inc(1),
+                    Ok(receipt) => {
+                        warn!(tx_hash = %receipt.transaction_hash, "B-20 role grant reverted");
+                        grant_failed += 1;
+                        pb.inc(1);
+                    }
                     Err(e) => {
                         warn!(error = %e, "B-20 role grant failed");
                         grant_failed += 1;
@@ -1124,7 +1145,6 @@ impl LoadRunner {
             .collect();
 
         let mut mint_failed = 0usize;
-        let mut pending_balances: Vec<(Address, Address)> = Vec::new();
         let mut txs_remaining = mint_txs.into_iter().peekable();
 
         while txs_remaining.peek().is_some() {
@@ -1132,33 +1152,38 @@ impl LoadRunner {
             let send_futs = batch.into_iter().map(|(tx, sender)| {
                 let provider = Arc::clone(&funder_provider);
                 async move {
-                    let result = provider.send_transaction(tx).await;
-                    (result, sender)
+                    match provider.send_transaction(tx).await {
+                        Ok(pending) => {
+                            let receipt = pending
+                                .get_receipt()
+                                .await
+                                .map_err(|e| eyre::eyre!("mint receipt failed: {e}"))?;
+                            Ok::<_, eyre::Report>((receipt, sender))
+                        }
+                        Err(e) => Err(eyre::eyre!("mint send failed: {e}")),
+                    }
                 }
             });
 
             let mut send_stream = stream::iter(send_futs).buffer_unordered(FUNDING_BATCH_SIZE);
-            while let Some((result, sender)) = send_stream.next().await {
+            while let Some(result) = send_stream.next().await {
                 match result {
-                    Ok(pending) => {
-                        let tx_hash = *pending.tx_hash();
-                        debug!(to = %sender, tx_hash = %tx_hash, "B-20 mint sent");
-                        pending_balances.push((token, sender));
+                    Ok((receipt, sender)) if receipt.status() => {
+                        debug!(to = %sender, tx_hash = %receipt.transaction_hash, "B-20 mint confirmed");
+                        pb_mint.inc(1);
+                    }
+                    Ok((receipt, sender)) => {
+                        warn!(to = %sender, tx_hash = %receipt.transaction_hash, "B-20 mint reverted");
+                        mint_failed += 1;
+                        pb_mint.inc(1);
                     }
                     Err(e) => {
-                        warn!(to = %sender, error = %e, "B-20 mint failed");
+                        warn!(error = %e, "B-20 mint failed");
                         mint_failed += 1;
+                        pb_mint.inc(1);
                     }
                 }
             }
-
-            Self::await_token_balances(
-                &self.client,
-                &mut pending_balances,
-                amount_per_sender,
-                &pb_mint,
-            )
-            .await?;
         }
 
         pb_mint.finish_and_clear();
@@ -1197,7 +1222,7 @@ impl LoadRunner {
         let gas_price = self.client.get_gas_price().await.rpc("get gas price")?;
         let max_priority_fee = (gas_price / 10).max(1);
         let max_fee = gas_price.saturating_mul(2).max(max_priority_fee).min(max_gas_price);
-        let b20_gas_limit = 10_000_000u64;
+        let burn_gas_limit = 200_000u64;
 
         let sender_addresses: Vec<Address> =
             self.accounts.accounts().iter().map(|a| a.address).collect();
@@ -1244,7 +1269,7 @@ impl LoadRunner {
                 .with_input(Bytes::from(burn_call.abi_encode()))
                 .with_nonce(sender_nonce)
                 .with_chain_id(chain_id)
-                .with_gas_limit(b20_gas_limit)
+                .with_gas_limit(burn_gas_limit)
                 .with_max_fee_per_gas(max_fee)
                 .with_max_priority_fee_per_gas(max_priority_fee);
 

--- a/crates/infra/load-tests/src/runner/load_runner.rs
+++ b/crates/infra/load-tests/src/runner/load_runner.rs
@@ -8,12 +8,15 @@ use std::{
 };
 
 use alloy_network::{Ethereum, EthereumWallet, TransactionBuilder};
-use alloy_primitives::{Address, Bytes, TxHash, U256, utils::format_ether};
+use alloy_primitives::{Address, B256, Bytes, TxHash, U256, utils::format_ether};
 use alloy_provider::{Provider, RootProvider};
 use alloy_rpc_types::{BlockNumberOrTag, TransactionRequest};
 use alloy_signer_local::PrivateKeySigner;
-use alloy_sol_types::{SolCall, sol};
+use alloy_sol_types::{SolCall, SolValue, sol};
 use base_common_network::Base;
+use base_common_precompiles::{
+    B20FactoryStorage, B20TokenRole, B20Variant, IB20, IB20Factory,
+};
 use base_tx_manager::NonceManager;
 use futures::{StreamExt, stream};
 use indicatif::{ProgressBar, ProgressStyle};
@@ -44,8 +47,8 @@ use crate::{
         create_wallet_provider,
     },
     workload::{
-        AccountPool, AerodromeClPayload, CalldataPayload, Erc20Payload, OsakaPayload,
-        PrecompilePayload, TransferPayload, UniswapV3Payload, WorkloadGenerator,
+        AccountPool, AerodromeClPayload, B20TransferPayload, CalldataPayload, Erc20Payload,
+        OsakaPayload, PrecompilePayload, TransferPayload, UniswapV3Payload, WorkloadGenerator,
     },
 };
 
@@ -212,6 +215,13 @@ impl LoadRunner {
                     );
                     generator = generator.with_payload(payload, weight_pct);
                 }
+                TxType::B20 { contract } => {
+                    let token = contract.expect("b20 contract must be resolved before run");
+                    generator = generator.with_payload(
+                        B20TransferPayload::new(token, U256::from(1000), U256::from(10000)),
+                        weight_pct,
+                    );
+                }
                 TxType::Osaka { target } => {
                     generator =
                         generator.with_payload(OsakaPayload::new(target.clone()), weight_pct);
@@ -271,6 +281,7 @@ impl LoadRunner {
                 TxType::Transfer => 21_000,
                 TxType::Calldata { max_size, .. } => 21_000 + (*max_size as u64 * 16),
                 TxType::Erc20 { .. } => 65_000,
+                TxType::B20 { .. } => 100_000,
                 TxType::Precompile { target, iterations, blake2f_rounds, .. } => {
                     let per_call = match target {
                         PrecompileId::Identity | PrecompileId::Bn254Add => 22_000,
@@ -643,6 +654,7 @@ impl LoadRunner {
                 TxType::Transfer
                 | TxType::Calldata { .. }
                 | TxType::Erc20 { .. }
+                | TxType::B20 { .. }
                 | TxType::Precompile { .. }
                 | TxType::Osaka { .. } => {}
             }
@@ -929,6 +941,335 @@ impl LoadRunner {
             function balanceOf(address account) external view returns (uint256);
         }
         Bytes::from(balanceOfCall { account }.abi_encode())
+    }
+
+    /// Returns `true` if any configured transaction type is [`TxType::B20`].
+    pub fn needs_b20_setup(&self) -> bool {
+        self.config.transactions.iter().any(|t| matches!(t.tx_type, TxType::B20 { .. }))
+    }
+
+    /// Creates a B-20 token via the factory, grants `MINT_ROLE` and `BURN_ROLE` to all senders,
+    /// then mints tokens to every sender account.
+    ///
+    /// If all B-20 transaction configs already have a resolved `contract` address, this is a
+    /// no-op for creation but still handles role grants and minting.
+    #[instrument(skip(self, funding_key), fields(accounts = self.accounts.len()))]
+    pub async fn setup_b20_tokens(
+        &mut self,
+        funding_key: PrivateKeySigner,
+        amount_per_sender: U256,
+    ) -> Result<()> {
+        let funder_address = funding_key.address();
+        let wallet = EthereumWallet::from(funding_key);
+        let funder_provider =
+            Arc::new(create_wallet_provider(self.config.primary_submission_rpc().clone(), wallet));
+        let chain_id = self.config.chain_id;
+        let max_gas_price = self.config.max_gas_price;
+        let gas_price = self.client.get_gas_price().await.rpc("get gas price")?;
+        let max_priority_fee = (gas_price / 10).max(1);
+        let max_fee = gas_price.saturating_mul(2).max(max_priority_fee).min(max_gas_price);
+        let b20_gas_limit = 10_000_000u64;
+
+        let mut nonce = funder_provider
+            .get_transaction_count(funder_address)
+            .pending()
+            .await
+            .rpc("get pending transaction count")?;
+
+        // Phase 1: Create B-20 token if no contract address is configured.
+        let mut token_address: Option<Address> = None;
+        for tx_config in &self.config.transactions {
+            if let TxType::B20 { contract: Some(addr) } = &tx_config.tx_type {
+                token_address = Some(*addr);
+                break;
+            }
+        }
+
+        if token_address.is_none() {
+            info!("creating new B-20 token via factory");
+
+            let salt = B256::from(rand::random::<[u8; 32]>());
+            let predicted = B20Variant::B20.compute_address(funder_address, salt).0;
+
+            let params = IB20Factory::B20CreateParams {
+                version: B20FactoryStorage::CREATE_TOKEN_VERSION,
+                name: "Load Test B20".to_string(),
+                symbol: "LTB20".to_string(),
+                initialAdmin: funder_address,
+            };
+
+            let init_calls: Vec<Bytes> =
+                vec![IB20::updateSupplyCapCall { newSupplyCap: U256::MAX }.abi_encode().into()];
+
+            let create_call = IB20Factory::createB20Call {
+                variant: IB20Factory::B20Variant::DEFAULT,
+                salt,
+                params: params.abi_encode().into(),
+                initCalls: init_calls,
+            };
+
+            let tx = TransactionRequest::default()
+                .with_to(B20FactoryStorage::ADDRESS)
+                .with_input(Bytes::from(create_call.abi_encode()))
+                .with_nonce(nonce)
+                .with_chain_id(chain_id)
+                .with_gas_limit(b20_gas_limit)
+                .with_max_fee_per_gas(max_fee)
+                .with_max_priority_fee_per_gas(max_priority_fee);
+            nonce += 1;
+
+            let pending = funder_provider.send_transaction(tx).await.map_err(|e| {
+                BaselineError::Transaction(format!("failed to create B-20 token: {e}"))
+            })?;
+
+            let receipt = pending.get_receipt().await.map_err(|e| {
+                BaselineError::Transaction(format!("B-20 creation receipt failed: {e}"))
+            })?;
+
+            if !receipt.status() {
+                return Err(BaselineError::Transaction(
+                    "B-20 token creation transaction reverted".into(),
+                ));
+            }
+
+            info!(token = %predicted, "B-20 token created");
+            token_address = Some(predicted);
+        }
+
+        let token = token_address.expect("token address must be resolved");
+
+        for tx_config in &mut self.config.transactions {
+            if let TxType::B20 { contract } = &mut tx_config.tx_type {
+                *contract = Some(token);
+            }
+        }
+
+        // Phase 2: Grant MINT_ROLE and BURN_ROLE to all senders.
+        let sender_addresses: Vec<Address> =
+            self.accounts.accounts().iter().map(|a| a.address).collect();
+        let roles = [B20TokenRole::Mint.id(), B20TokenRole::Burn.id()];
+
+        let total_grants = sender_addresses.len() * roles.len();
+        let pb = self.progress_bar(total_grants as u64, "Granting B-20 roles");
+
+        let grant_txs: Vec<TransactionRequest> = sender_addresses
+            .iter()
+            .flat_map(|&sender| {
+                roles.iter().map(move |&role| {
+                    let call = IB20::grantRoleCall { role, account: sender };
+                    let tx = TransactionRequest::default()
+                        .with_to(token)
+                        .with_input(Bytes::from(call.abi_encode()))
+                        .with_nonce(nonce)
+                        .with_chain_id(chain_id)
+                        .with_gas_limit(b20_gas_limit)
+                        .with_max_fee_per_gas(max_fee)
+                        .with_max_priority_fee_per_gas(max_priority_fee);
+                    nonce += 1;
+                    tx
+                })
+            })
+            .collect();
+
+        let mut grant_failed = 0usize;
+        let mut txs_remaining = grant_txs.into_iter().peekable();
+        while txs_remaining.peek().is_some() {
+            let batch: Vec<_> = txs_remaining.by_ref().take(FUNDING_BATCH_SIZE).collect();
+            let send_futs = batch.into_iter().map(|tx| {
+                let provider = Arc::clone(&funder_provider);
+                async move { provider.send_transaction(tx).await }
+            });
+
+            let mut send_stream = stream::iter(send_futs).buffer_unordered(FUNDING_BATCH_SIZE);
+            while let Some(result) = send_stream.next().await {
+                match result {
+                    Ok(_) => pb.inc(1),
+                    Err(e) => {
+                        warn!(error = %e, "B-20 role grant failed");
+                        grant_failed += 1;
+                        pb.inc(1);
+                    }
+                }
+            }
+        }
+
+        pb.finish_and_clear();
+        if grant_failed > 0 {
+            return Err(BaselineError::Transaction(format!(
+                "{grant_failed}/{total_grants} B-20 role grants failed"
+            )));
+        }
+
+        info!(roles = total_grants, "B-20 roles granted");
+
+        // Phase 3: Mint tokens to all senders.
+        let total_mints = sender_addresses.len();
+        let pb_mint = self.progress_bar(total_mints as u64, "Minting B-20 tokens");
+
+        let mint_txs: Vec<(TransactionRequest, Address)> = sender_addresses
+            .iter()
+            .map(|&sender| {
+                let call = IB20::mintCall { to: sender, amount: amount_per_sender };
+                let tx = TransactionRequest::default()
+                    .with_to(token)
+                    .with_input(Bytes::from(call.abi_encode()))
+                    .with_nonce(nonce)
+                    .with_chain_id(chain_id)
+                    .with_gas_limit(b20_gas_limit)
+                    .with_max_fee_per_gas(max_fee)
+                    .with_max_priority_fee_per_gas(max_priority_fee);
+                nonce += 1;
+                (tx, sender)
+            })
+            .collect();
+
+        let mut mint_failed = 0usize;
+        let mut pending_balances: Vec<(Address, Address)> = Vec::new();
+        let mut txs_remaining = mint_txs.into_iter().peekable();
+
+        while txs_remaining.peek().is_some() {
+            let batch: Vec<_> = txs_remaining.by_ref().take(FUNDING_BATCH_SIZE).collect();
+            let send_futs = batch.into_iter().map(|(tx, sender)| {
+                let provider = Arc::clone(&funder_provider);
+                async move {
+                    let result = provider.send_transaction(tx).await;
+                    (result, sender)
+                }
+            });
+
+            let mut send_stream = stream::iter(send_futs).buffer_unordered(FUNDING_BATCH_SIZE);
+            while let Some((result, sender)) = send_stream.next().await {
+                match result {
+                    Ok(pending) => {
+                        let tx_hash = *pending.tx_hash();
+                        debug!(to = %sender, tx_hash = %tx_hash, "B-20 mint sent");
+                        pending_balances.push((token, sender));
+                    }
+                    Err(e) => {
+                        warn!(to = %sender, error = %e, "B-20 mint failed");
+                        mint_failed += 1;
+                    }
+                }
+            }
+
+            Self::await_token_balances(
+                &self.client,
+                &mut pending_balances,
+                amount_per_sender,
+                &pb_mint,
+            )
+            .await?;
+        }
+
+        pb_mint.finish_and_clear();
+        if mint_failed > 0 {
+            return Err(BaselineError::Transaction(format!(
+                "{mint_failed}/{total_mints} B-20 mints failed"
+            )));
+        }
+
+        info!(
+            token = %token,
+            senders = total_mints,
+            amount = %amount_per_sender,
+            "B-20 token setup complete"
+        );
+        Ok(())
+    }
+
+    /// Burns remaining B-20 token balances from all sender accounts.
+    ///
+    /// Each sender calls `burn(uint256)` with their full balance. Requires senders to hold
+    /// `BURN_ROLE`, which is granted during [`Self::setup_b20_tokens`].
+    #[instrument(skip(self), fields(accounts = self.accounts.len()))]
+    pub async fn teardown_b20_tokens(&self) -> Result<()> {
+        let token = self.config.transactions.iter().find_map(|t| match &t.tx_type {
+            TxType::B20 { contract: Some(addr) } => Some(*addr),
+            _ => None,
+        });
+
+        let Some(token) = token else {
+            return Ok(());
+        };
+
+        let chain_id = self.config.chain_id;
+        let max_gas_price = self.config.max_gas_price;
+        let gas_price = self.client.get_gas_price().await.rpc("get gas price")?;
+        let max_priority_fee = (gas_price / 10).max(1);
+        let max_fee = gas_price.saturating_mul(2).max(max_priority_fee).min(max_gas_price);
+        let b20_gas_limit = 10_000_000u64;
+
+        let sender_addresses: Vec<Address> =
+            self.accounts.accounts().iter().map(|a| a.address).collect();
+        let pb = self.progress_bar(sender_addresses.len() as u64, "Burning B-20 tokens");
+
+        let signers = Self::build_signers(&self.accounts);
+        let mut burn_failed = 0usize;
+        let mut burn_count = 0usize;
+
+        for &sender in &sender_addresses {
+            let call_data = Self::encode_erc20_balance_of(sender);
+            let balance = self
+                .client
+                .call(TransactionRequest::default().with_to(token).with_input(call_data).into())
+                .await
+                .rpc("eth_call")
+                .map(|bytes| U256::from_be_slice(bytes.as_ref()))
+                .unwrap_or(U256::ZERO);
+
+            if balance.is_zero() {
+                pb.inc(1);
+                continue;
+            }
+
+            let Some(signer) = signers.get(&sender) else {
+                warn!(sender = %sender, "no signer for B-20 burn");
+                pb.inc(1);
+                continue;
+            };
+
+            let wallet = EthereumWallet::from(signer.clone());
+            let sender_provider =
+                create_wallet_provider(self.config.primary_submission_rpc().clone(), wallet);
+
+            let sender_nonce = sender_provider
+                .get_transaction_count(sender)
+                .pending()
+                .await
+                .rpc("get pending transaction count")?;
+
+            let burn_call = IB20::burnCall { amount: balance };
+            let tx = TransactionRequest::default()
+                .with_to(token)
+                .with_input(Bytes::from(burn_call.abi_encode()))
+                .with_nonce(sender_nonce)
+                .with_chain_id(chain_id)
+                .with_gas_limit(b20_gas_limit)
+                .with_max_fee_per_gas(max_fee)
+                .with_max_priority_fee_per_gas(max_priority_fee);
+
+            match sender_provider.send_transaction(tx).await {
+                Ok(pending) => {
+                    let tx_hash = *pending.tx_hash();
+                    debug!(sender = %sender, amount = %balance, tx_hash = %tx_hash, "B-20 burn sent");
+                    burn_count += 1;
+                }
+                Err(e) => {
+                    warn!(sender = %sender, error = %e, "B-20 burn failed");
+                    burn_failed += 1;
+                }
+            }
+            pb.inc(1);
+        }
+
+        pb.finish_and_clear();
+
+        if burn_failed > 0 {
+            warn!(failed = burn_failed, succeeded = burn_count, "some B-20 burns failed");
+        }
+
+        info!(burned = burn_count, failed = burn_failed, "B-20 teardown complete");
+        Ok(())
     }
 
     /// Runs the load test and returns metrics summary.

--- a/crates/infra/load-tests/src/workload/mod.rs
+++ b/crates/infra/load-tests/src/workload/mod.rs
@@ -8,8 +8,9 @@ pub use seeded::SeededRng;
 
 mod payloads;
 pub use payloads::{
-    AerodromeClPayload, CalldataPayload, Erc20Payload, OsakaPayload, Payload, PrecompileLooper,
-    PrecompilePayload, StoragePayload, TransferPayload, UniswapV3Payload, parse_precompile_id,
+    AerodromeClPayload, B20TransferPayload, CalldataPayload, Erc20Payload, OsakaPayload, Payload,
+    PrecompileLooper, PrecompilePayload, StoragePayload, TransferPayload, UniswapV3Payload,
+    parse_precompile_id,
 };
 
 mod generator;

--- a/crates/infra/load-tests/src/workload/payloads/b20.rs
+++ b/crates/infra/load-tests/src/workload/payloads/b20.rs
@@ -1,0 +1,56 @@
+//! B-20 precompile token transfer payload for load testing.
+
+use alloy_network::TransactionBuilder;
+use alloy_primitives::{Address, Bytes, U256};
+use alloy_rpc_types::TransactionRequest;
+use alloy_sol_types::SolCall;
+use base_common_precompiles::IB20;
+
+use super::Payload;
+use crate::workload::SeededRng;
+
+/// Generates B-20 precompile token transfer transactions.
+///
+/// During the load phase, each generated transaction calls `transfer(address,uint256)` on the
+/// configured B-20 token precompile. The B-20 `transfer` selector is ERC-20 compatible, so this
+/// exercises the precompile's state-mutation code path (balance updates, event emission) under
+/// sustained load.
+#[derive(Debug, Clone)]
+pub struct B20TransferPayload {
+    /// B-20 token precompile address.
+    pub token_address: Address,
+    /// Minimum transfer amount.
+    pub min_amount: U256,
+    /// Maximum transfer amount.
+    pub max_amount: U256,
+}
+
+impl B20TransferPayload {
+    /// Creates a new B-20 transfer payload.
+    pub const fn new(token_address: Address, min_amount: U256, max_amount: U256) -> Self {
+        Self { token_address, min_amount, max_amount }
+    }
+}
+
+impl Payload for B20TransferPayload {
+    fn name(&self) -> &'static str {
+        "b20"
+    }
+
+    fn generate(&self, rng: &mut SeededRng, _from: Address, to: Address) -> TransactionRequest {
+        let amount = if self.min_amount == self.max_amount {
+            self.min_amount
+        } else {
+            let min: u128 = self.min_amount.try_into().expect("b20 min_amount must fit in u128");
+            let max: u128 = self.max_amount.try_into().expect("b20 max_amount must fit in u128");
+            U256::from(rng.gen_range(min..=max))
+        };
+
+        let call = IB20::transferCall { to, amount };
+
+        TransactionRequest::default()
+            .with_to(self.token_address)
+            .with_input(Bytes::from(call.abi_encode()))
+            .with_gas_limit(100_000)
+    }
+}

--- a/crates/infra/load-tests/src/workload/payloads/mod.rs
+++ b/crates/infra/load-tests/src/workload/payloads/mod.rs
@@ -29,6 +29,9 @@ pub use uniswap::UniswapV3Payload;
 mod aerodrome;
 pub use aerodrome::AerodromeClPayload;
 
+mod b20;
+pub use b20::B20TransferPayload;
+
 mod osaka;
 pub use osaka::OsakaPayload;
 


### PR DESCRIPTION
- Adds B20 workload to test precompile performance on commonly used functions (i.e., mint, transfer, approve, burn)
- The load test phase is broken down to the following:
   - All senders have the MINT_ROLE and will call mint
   - The actual load test will do approve/transfer
   - At the end of the load test all senders will burn their amount with the BURN_ROLE
- Follows a similar pattern to how the swap workload is performed (i.e., minting/distributing swap tokens before doing the actual load test of only swaps)

Pending:
- Zeronet activation of Beryl to test get the B20 precompile address

Test Plan:
- Ran on local devnet:
```
FUNDER_KEY=0x...  cargo run -p base-load-tester-bin --release --bin base-load-tester -- crates/infra/load-tests/examples/devnet.yaml
```

Devnet file:
- Uncomment the b20 type in the devnet.yaml
