### PR TITLE
fix(devnet): allow zk prover builds without Succinct ELFs

### DIFF
--- a/etc/docker/Dockerfile.rust-services
+++ b/etc/docker/Dockerfile.rust-services
@@ -131,10 +131,11 @@ COPY . .
 
 FROM zk-source AS zk-prover-builder
 ARG PROFILE=release
+ARG BASE_SUCCINCT_ELF_REQUIRE=1
 RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
     --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
     --mount=type=cache,target=/app/target,id=zk-prover-target,sharing=locked \
-    BASE_SUCCINCT_ELF_REQUIRE=1 cargo build --profile $PROFILE --package base-prover-zk --bin base-prover-zk && \
+    cargo build --profile $PROFILE --package base-prover-zk --bin base-prover-zk && \
     cp /app/target/$([ "$PROFILE" = "dev" ] && echo debug || echo "$PROFILE")/base-prover-zk /app/base-prover-zk
 
 FROM public.ecr.aws/docker/library/debian:trixie-slim AS runtime-base

--- a/etc/docker/Justfile
+++ b/etc/docker/Justfile
@@ -106,7 +106,11 @@ build-image target='client' profile='dev':
       arm64|aarch64) platform_pair="linux-arm64" ;;
       *) echo "unsupported architecture: $(uname -m)" >&2; exit 1 ;;
     esac
-    PROFILE="{{ profile }}" PLATFORM_PAIR="${platform_pair}" docker buildx bake -f etc/docker/docker-bake.hcl "{{ target }}" --load
+    elf_require=1
+    case "{{ target }}" in
+      zk-prover|devnet) elf_require=0 ;;
+    esac
+    PROFILE="{{ profile }}" BASE_SUCCINCT_ELF_REQUIRE="${elf_require}" PLATFORM_PAIR="${platform_pair}" docker buildx bake -f etc/docker/docker-bake.hcl "{{ target }}" --load
 
 # Prepares Docker images needed for devnet tests
 pull-images:
@@ -148,7 +152,11 @@ _build-rust-images group profile='dev':
       arm64|aarch64) platform_pair="linux-arm64" ;;
       *) echo "unsupported architecture: $(uname -m)" >&2; exit 1 ;;
     esac
-    PROFILE="{{ profile }}" PLATFORM_PAIR="${platform_pair}" docker buildx bake -f etc/docker/docker-bake.hcl "{{ group }}" --load
+    elf_require=1
+    case "{{ group }}" in
+      devnet) elf_require=0 ;;
+    esac
+    PROFILE="{{ profile }}" BASE_SUCCINCT_ELF_REQUIRE="${elf_require}" PLATFORM_PAIR="${platform_pair}" docker buildx bake -f etc/docker/docker-bake.hcl "{{ group }}" --load
 
 [private]
 _up-devnet compose_profile zk:

--- a/etc/docker/Justfile
+++ b/etc/docker/Justfile
@@ -107,8 +107,12 @@ build-image target='client' profile='dev':
       *) echo "unsupported architecture: $(uname -m)" >&2; exit 1 ;;
     esac
     elf_require=1
-    case "{{ target }}" in
-      zk-prover|devnet) elf_require=0 ;;
+    case "{{ profile }}" in
+      dev|profiling)
+        case "{{ target }}" in
+          zk-prover|devnet) elf_require=0 ;;
+        esac
+        ;;
     esac
     PROFILE="{{ profile }}" BASE_SUCCINCT_ELF_REQUIRE="${elf_require}" PLATFORM_PAIR="${platform_pair}" docker buildx bake -f etc/docker/docker-bake.hcl "{{ target }}" --load
 
@@ -153,8 +157,12 @@ _build-rust-images group profile='dev':
       *) echo "unsupported architecture: $(uname -m)" >&2; exit 1 ;;
     esac
     elf_require=1
-    case "{{ group }}" in
-      devnet) elf_require=0 ;;
+    case "{{ profile }}" in
+      dev|profiling)
+        case "{{ group }}" in
+          devnet) elf_require=0 ;;
+        esac
+        ;;
     esac
     PROFILE="{{ profile }}" BASE_SUCCINCT_ELF_REQUIRE="${elf_require}" PLATFORM_PAIR="${platform_pair}" docker buildx bake -f etc/docker/docker-bake.hcl "{{ group }}" --load
 

--- a/etc/docker/docker-bake.hcl
+++ b/etc/docker/docker-bake.hcl
@@ -10,6 +10,10 @@ variable "RUST_VERSION" {
   default = "1.93"
 }
 
+variable "BASE_SUCCINCT_ELF_REQUIRE" {
+  default = "1"
+}
+
 variable "REGISTRY_IMAGE" {
   default = "ghcr.io/base/node-reth-dev"
 }
@@ -133,7 +137,8 @@ target "zk-prover" {
   inherits = ["_rust-service-common"]
   target = "zk-prover"
   args = {
-    PROFILE = "${ZK_PROVER_PROFILE}"
+    PROFILE                   = "${ZK_PROVER_PROFILE}"
+    BASE_SUCCINCT_ELF_REQUIRE = "${BASE_SUCCINCT_ELF_REQUIRE}"
   }
   tags = ["base-prover-zk:local"]
   cache-from = [

--- a/etc/docker/docker-compose.yml
+++ b/etc/docker/docker-compose.yml
@@ -3,6 +3,7 @@ x-rust-service-build: &rust-service-build
   dockerfile: etc/docker/Dockerfile.rust-services
   args:
     PROFILE: "${CARGO_PROFILE:-dev}"
+    BASE_SUCCINCT_ELF_REQUIRE: "${BASE_SUCCINCT_ELF_REQUIRE:-0}"
 
 services:
   setup-l1:


### PR DESCRIPTION
Let devnet image builds fall back to stub Succinct ELFs so local networks can start without requiring the SP1 toolchain or prebuilt artifacts.