### PR TITLE
ci: disable base-std fork tests workflow

### DIFF
--- a/.github/workflows/base-std-fork-tests.yml
+++ b/.github/workflows/base-std-fork-tests.yml
@@ -1,8 +1,8 @@
 name: Base Std Fork Tests
 
 on:
-  pull_request:
-  merge_group:
+  # pull_request:
+  # merge_group:
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
Repos this depend on were made private, so the unauthenticated `git clone` in the workflow's clone step fails on every PR. Drop the `pull_request:` and `merge_group:` auto-triggers, leave only `workflow_dispatch:` so it can still be run manually with a suitably-scoped token. Re-enable by uncommenting the triggers once the repos are public again.