### PR TITLE
fix(precompiles): add explicit zero-address recovery guard in permit

### DIFF
--- a/crates/common/precompiles/src/common/ops/permittable.rs
+++ b/crates/common/precompiles/src/common/ops/permittable.rs
@@ -144,6 +144,17 @@ pub trait Permittable: Transferable {
         let signing_hash = args.signing_hash(domain_sep, nonce);
         let recovered = args.recover_signer(signing_hash)?;
 
+        // Alloy's ECDSA recovery returns Err rather than Address::ZERO for degenerate inputs,
+        // making this branch cryptographically infeasible. The check is kept to match Solidity's
+        // explicit guard and ensure InvalidSigner (not InvalidApprover) is always the revert when
+        // recovery produces a zero address.
+        if recovered.is_zero() {
+            return Err(BasePrecompileError::revert(IB20::InvalidSigner {
+                signer: Address::ZERO,
+                owner: args.owner,
+            }));
+        }
+
         if recovered != args.owner {
             return Err(BasePrecompileError::revert(IB20::InvalidSigner {
                 signer: recovered,
@@ -402,6 +413,34 @@ mod tests {
         args.owner = wrong_owner;
 
         assert!(token.permit(CHAIN_ID, now, args).is_err());
+    }
+
+    #[test]
+    fn permit_zero_owner_returns_invalid_signer_not_invalid_approver() {
+        // A unit test for the recovered == Address::ZERO branch is not feasible: alloy's ECDSA
+        // recovery returns Err (not zero) for degenerate inputs, and producing a signature that
+        // recovers to zero is cryptographically infeasible. This test instead confirms that when
+        // owner is Address::ZERO the function returns InvalidSigner (from the signature guard),
+        // not InvalidApprover (from approve()) — proving the guard fires before the approve() call.
+        let mut token = make_token();
+        let real_owner = owner_address();
+        let base_args = signed_permit_args(&token, real_owner, SPENDER, U256::ONE, U256::MAX);
+        let args = PermitArgs { owner: Address::ZERO, ..base_args };
+
+        // Swapping owner to zero changes the struct hash, so the recovered signer is some
+        // arbitrary address. Compute it from the same args permit() would use.
+        let domain_sep = token.domain_separator(CHAIN_ID).unwrap();
+        let nonce = token.accounting().nonce(Address::ZERO).unwrap();
+        let signing_hash = args.signing_hash(domain_sep, nonce);
+        let expected_signer = args.recover_signer(signing_hash).unwrap();
+
+        assert_eq!(
+            token.permit(CHAIN_ID, U256::ZERO, args).unwrap_err(),
+            BasePrecompileError::revert(IB20::InvalidSigner {
+                signer: expected_signer,
+                owner: Address::ZERO,
+            })
+        );
     }
 
     #[test]

--- a/crates/common/precompiles/src/common/ops/permittable.rs
+++ b/crates/common/precompiles/src/common/ops/permittable.rs
@@ -63,7 +63,7 @@ impl PermitArgs {
     ///
     /// Returns `Err(InvalidSigner)` when `recovered` is `Address::ZERO` (matching Solidity's
     /// explicit zero-address guard) or when `recovered != owner`.
-    pub fn validate_recovered(recovered: Address, owner: Address) -> Result<()> {
+    pub fn validate_recovered_address(recovered: Address, owner: Address) -> Result<()> {
         if recovered.is_zero() || recovered != owner {
             return Err(BasePrecompileError::revert(IB20::InvalidSigner {
                 signer: recovered,
@@ -157,7 +157,7 @@ pub trait Permittable: Transferable {
         let nonce = self.accounting().nonce(args.owner)?;
         let signing_hash = args.signing_hash(domain_sep, nonce);
         let recovered = args.recover_signer(signing_hash)?;
-        PermitArgs::validate_recovered(recovered, args.owner)?;
+        PermitArgs::validate_recovered_address(recovered, args.owner)?;
 
         self.accounting_mut().increment_nonce(args.owner)?;
         self.approve(args.owner, args.spender, args.value)
@@ -288,30 +288,30 @@ mod tests {
     }
 
     #[test]
-    fn validate_recovered_rejects_zero_address() {
+    fn validate_recovered_address_rejects_zero_address() {
         let owner = Address::repeat_byte(0xaa);
 
         assert_eq!(
-            PermitArgs::validate_recovered(Address::ZERO, owner).unwrap_err(),
+            PermitArgs::validate_recovered_address(Address::ZERO, owner).unwrap_err(),
             BasePrecompileError::revert(IB20::InvalidSigner { signer: Address::ZERO, owner })
         );
     }
 
     #[test]
-    fn validate_recovered_rejects_wrong_signer() {
+    fn validate_recovered_address_rejects_wrong_signer() {
         let owner = Address::repeat_byte(0xaa);
         let wrong = Address::repeat_byte(0xbb);
 
         assert_eq!(
-            PermitArgs::validate_recovered(wrong, owner).unwrap_err(),
+            PermitArgs::validate_recovered_address(wrong, owner).unwrap_err(),
             BasePrecompileError::revert(IB20::InvalidSigner { signer: wrong, owner })
         );
     }
 
     #[test]
-    fn validate_recovered_accepts_matching_signer() {
+    fn validate_recovered_address_accepts_matching_signer() {
         let owner = Address::repeat_byte(0xaa);
-        PermitArgs::validate_recovered(owner, owner).unwrap();
+        PermitArgs::validate_recovered_address(owner, owner).unwrap();
     }
 
     #[test]

--- a/crates/common/precompiles/src/common/ops/permittable.rs
+++ b/crates/common/precompiles/src/common/ops/permittable.rs
@@ -59,6 +59,20 @@ impl PermitArgs {
         keccak256(buf)
     }
 
+    /// Validates a recovered ECDSA address against the declared `owner`.
+    ///
+    /// Returns `Err(InvalidSigner)` when `recovered` is `Address::ZERO` (matching Solidity's
+    /// explicit zero-address guard) or when `recovered != owner`.
+    pub fn validate_recovered(recovered: Address, owner: Address) -> Result<()> {
+        if recovered.is_zero() || recovered != owner {
+            return Err(BasePrecompileError::revert(IB20::InvalidSigner {
+                signer: recovered,
+                owner,
+            }));
+        }
+        Ok(())
+    }
+
     /// Maps Ethereum `v` (27/28) to secp256k1 recovery parity, then recovers the signer.
     pub fn recover_signer(&self, signing_hash: B256) -> Result<Address> {
         let odd_y_parity = match self.v {
@@ -143,24 +157,7 @@ pub trait Permittable: Transferable {
         let nonce = self.accounting().nonce(args.owner)?;
         let signing_hash = args.signing_hash(domain_sep, nonce);
         let recovered = args.recover_signer(signing_hash)?;
-
-        // Alloy's ECDSA recovery returns Err rather than Address::ZERO for degenerate inputs,
-        // making this branch cryptographically infeasible. The check is kept to match Solidity's
-        // explicit guard and ensure InvalidSigner (not InvalidApprover) is always the revert when
-        // recovery produces a zero address.
-        if recovered.is_zero() {
-            return Err(BasePrecompileError::revert(IB20::InvalidSigner {
-                signer: Address::ZERO,
-                owner: args.owner,
-            }));
-        }
-
-        if recovered != args.owner {
-            return Err(BasePrecompileError::revert(IB20::InvalidSigner {
-                signer: recovered,
-                owner: args.owner,
-            }));
-        }
+        PermitArgs::validate_recovered(recovered, args.owner)?;
 
         self.accounting_mut().increment_nonce(args.owner)?;
         self.approve(args.owner, args.spender, args.value)
@@ -288,6 +285,33 @@ mod tests {
             args.signing_hash(domain_sep, U256::ZERO),
             args.signing_hash(domain_sep, U256::ONE)
         );
+    }
+
+    #[test]
+    fn validate_recovered_rejects_zero_address() {
+        let owner = Address::repeat_byte(0xaa);
+
+        assert_eq!(
+            PermitArgs::validate_recovered(Address::ZERO, owner).unwrap_err(),
+            BasePrecompileError::revert(IB20::InvalidSigner { signer: Address::ZERO, owner })
+        );
+    }
+
+    #[test]
+    fn validate_recovered_rejects_wrong_signer() {
+        let owner = Address::repeat_byte(0xaa);
+        let wrong = Address::repeat_byte(0xbb);
+
+        assert_eq!(
+            PermitArgs::validate_recovered(wrong, owner).unwrap_err(),
+            BasePrecompileError::revert(IB20::InvalidSigner { signer: wrong, owner })
+        );
+    }
+
+    #[test]
+    fn validate_recovered_accepts_matching_signer() {
+        let owner = Address::repeat_byte(0xaa);
+        PermitArgs::validate_recovered(owner, owner).unwrap();
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Solidity's `permit` explicitly checks `recovered == address(0)` after ECDSA recovery and reverts with `InvalidSigner`. The Rust precompile was missing this guard.

**Investigation findings (BOP-170):**
- Alloy's `recover_address_from_prehash` returns `Err` (not `Address::ZERO`) for degenerate inputs (zero `r`/`s`, invalid curve points), so the zero-recovery branch is cryptographically infeasible in practice
- Producing a real signature that recovers to `address(0)` would require a secp256k1 public key whose keccak256 last-20-bytes are all zero — computationally infeasible
- Roger confirmed he could not construct a test case that triggers the zero path

**Behavioral difference without the fix:**
If somehow `recovered == Address::ZERO` (e.g., future alloy behavior change), the existing `recovered != owner` check only catches it when `owner != address(0)`. If both are zero, the call would fall through to `approve()` which reverts with `InvalidApprover` — a semantically incorrect error. The fix ensures `InvalidSigner` is always returned.

## Test plan

- [ ] `permit_zero_owner_returns_invalid_signer_not_invalid_approver` — confirms the signature guard fires before `approve()`, returning `InvalidSigner` not `InvalidApprover`
- [ ] All 17 existing permittable tests pass
- [ ] Full suite: 336 tests pass
- [ ] Note: a unit test for the `recovered.is_zero()` branch specifically is not feasible (alloy returns `Err` for degenerate inputs, not zero)

Fixes BOP-170.

🤖 Generated with [Claude Code](https://claude.com/claude-code)