### PR TITLE
fix(batcher/comp): always flush shadow on write to catch cumulative fullness

### DIFF
--- a/crates/batcher/comp/src/shadow.rs
+++ b/crates/batcher/comp/src/shadow.rs
@@ -72,21 +72,31 @@ impl CompressorWriter for ShadowCompressor {
             return Err(CompressorError::Full);
         }
 
-        // Write to the shadow compressor.
+        // Write to the shadow compressor and always flush it to obtain an
+        // up-to-date compressed-size estimate.
+        //
+        // The previous implementation only flushed the shadow when a single
+        // write's *uncompressed* size exceeded `target_output_size`.  That
+        // missed the common case where many small writes collectively push the
+        // total compressed output past the target: `is_full` was never set,
+        // the compressor kept accepting data, and the resulting frame was
+        // silently larger than `target_output_size` on-chain.
+        //
+        // Flushing on every write matches the docstring ("the shadow buffer is
+        // flushed on every write") and ensures that `bound` always reflects
+        // the cumulative compressed-size upper bound.
         self.shadow.write(data)?;
+        self.shadow.flush()?;
+        let newbound = self.shadow.len() as u64 + CLOSE_OVERHEAD_ZLIB;
 
-        // The new bound increases by the length of the compressed data.
-        let mut newbound = data.len() as u64;
         if newbound > self.config.target_output_size {
-            // Don't flush the buffer if there's a chance we're over the size limit.
-            self.shadow.flush()?;
-            newbound = self.shadow.len() as u64 + CLOSE_OVERHEAD_ZLIB;
-            if newbound > self.config.target_output_size {
-                self.is_full = true;
-                // Only error if the buffer has been written to.
-                if self.compressor.len() > 0 {
-                    return Err(CompressorError::Full);
-                }
+            self.is_full = true;
+            // Only error if the main compressor already contains data.  The
+            // first write is always allowed through so that a single block
+            // larger than `target_output_size` can still be encoded (it will
+            // be split across multiple frames by the frame encoder).
+            if self.compressor.len() > 0 {
+                return Err(CompressorError::Full);
             }
         }
 
@@ -137,5 +147,81 @@ impl ChannelCompressor for ShadowCompressor {
 
     fn channel_version_byte(&self) -> Option<u8> {
         self.compressor.channel_version_byte()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{CompressionAlgo, CompressorType};
+
+    fn shadow_config(target: u64) -> Config {
+        Config {
+            target_output_size: target,
+            approx_compr_ratio: 0.6,
+            compression_algo: CompressionAlgo::Zlib,
+            kind: CompressorType::Shadow,
+        }
+    }
+
+    /// Regression: many small writes that collectively push compressed output
+    /// past `target_output_size` must eventually trigger `is_full`.
+    ///
+    /// Before the fix the shadow compressor only flushed and checked fullness
+    /// when a single write's *uncompressed* size exceeded the target. Small
+    /// writes slipped through unchecked and the resulting frame was silently
+    /// larger than intended.
+    #[test]
+    fn test_small_writes_eventually_trigger_full() {
+        let target: u64 = 64;
+        let config = shadow_config(target);
+        let mut sc = ShadowCompressor::from(config);
+
+        let chunk = b"hello_world__padding"; // 20 bytes — well below target
+        let mut iters = 0usize;
+        loop {
+            match sc.write(chunk) {
+                Ok(_) => {}
+                Err(CompressorError::Full) => break,
+                Err(e) => panic!("unexpected error: {e}"),
+            }
+            iters += 1;
+            assert!(iters < 10_000, "compressor never became full after cumulative small writes");
+        }
+        assert!(sc.is_full, "is_full must be set when cumulative compressed size exceeds target");
+    }
+
+    /// A single write larger than `target_output_size` must be allowed through
+    /// (first-write exception) but mark the compressor full so the next write
+    /// is rejected.
+    #[test]
+    fn test_large_first_write_allowed_second_rejected() {
+        let target: u64 = 16;
+        let config = shadow_config(target);
+        let mut sc = ShadowCompressor::from(config);
+
+        let big = vec![0u8; 200];
+        assert!(sc.write(&big).is_ok(), "first oversized write must succeed");
+        assert!(sc.is_full, "compressor must be full after oversized first write");
+        assert_eq!(sc.write(b"x"), Err(CompressorError::Full));
+    }
+
+    /// After reset() the compressor must accept writes again and fullness
+    /// detection must work correctly on the fresh instance.
+    #[test]
+    fn test_reset_clears_full_flag_and_bound() {
+        let target: u64 = 16;
+        let config = shadow_config(target);
+        let mut sc = ShadowCompressor::from(config);
+
+        sc.write(&vec![0u8; 200]).unwrap();
+        assert!(sc.is_full);
+
+        sc.reset();
+        assert!(!sc.is_full, "is_full must be cleared by reset");
+        assert_eq!(sc.bound, SAFE_COMPRESSION_OVERHEAD, "bound must be reset to initial overhead");
+
+        // After reset a new small write must go through cleanly.
+        assert!(sc.write(b"x").is_ok());
     }
 }


### PR DESCRIPTION
## Summary

Fixes a silent frame-overflow bug in `ShadowCompressor`.

## Root Cause

`ShadowCompressor::write()` is supposed to detect when the cumulative compressed output would exceed `target_output_size` and mark the compressor as full. The implementation only flushed the shadow compressor and ran the fullness check when a **single** write's uncompressed size exceeded the target:

```rust
let mut newbound = data.len() as u64;
if newbound > self.config.target_output_size {   // ← only for large writes
    self.shadow.flush()?;
    newbound = self.shadow.len() as u64 + CLOSE_OVERHEAD_ZLIB;
    if newbound > self.config.target_output_size {
        self.is_full = true;
        ...
    }
}
```

Writes whose individual uncompressed size was **below** `target_output_size` skipped the flush and the check entirely. Many small batches that collectively compressed to more than `target_output_size` bytes were never detected — the compressor kept accepting data, and the resulting L1 frame was silently larger than intended.

The struct's own docstring already says *"The first compression buffer is flushed on every write"*, but the code did not honour this.

## Fix

Flush the shadow compressor after **every** write and derive `newbound` from the shadow's actual compressed length unconditionally:

```rust
self.shadow.write(data)?;
self.shadow.flush()?;   // always
let newbound = self.shadow.len() as u64 + CLOSE_OVERHEAD_ZLIB;

if newbound > self.config.target_output_size {
    self.is_full = true;
    if self.compressor.len() > 0 {
        return Err(CompressorError::Full);
    }
}
```

The first-write exception (single block larger than target is still allowed through so the frame encoder can split it) is unchanged.

## Tests Added

- `test_small_writes_eventually_trigger_full` — repeated small writes below the target eventually trigger `is_full`; before the fix this looped forever.
- `test_large_first_write_allowed_second_rejected` — first-write exception still works.
- `test_reset_clears_full_flag_and_bound` — `reset()` restores initial state correctly.
