### PR TITLE
chore(prover-service-client): add requester provider trait

### DIFF
--- a/crates/proof/prover-service/client/src/lib.rs
+++ b/crates/proof/prover-service/client/src/lib.rs
@@ -7,7 +7,7 @@ mod error;
 pub use error::ProverServiceClientError;
 
 mod requester;
-pub use requester::ProverRequesterClient;
+pub use requester::{ProofRequesterClient, ProofRequesterProvider};
 
 mod worker;
 pub use worker::{ProverWorkerClient, ProverWorkerProvider};

--- a/crates/proof/prover-service/client/src/requester.rs
+++ b/crates/proof/prover-service/client/src/requester.rs
@@ -1,21 +1,49 @@
 //! Client for proof requester JSON-RPC methods.
 
+use async_trait::async_trait;
 use base_prover_service_protocol::{
     GetProofRequest, GetProofResponse, ListProofsRequest, ListProofsResponse,
-    ProverRequesterApiClient, SubmitProofRequest, SubmitProofResponse,
+    ProveBlockRangeRequest, ProveBlockRangeResponse, ProverRequesterApiClient,
 };
 use jsonrpsee::http_client::HttpClient;
 use tracing::debug;
 
 use crate::{ProverServiceClientConfig, ProverServiceClientError};
 
+/// Abstraction over proof requester JSON-RPC methods.
+///
+/// The canonical implementation is [`ProofRequesterClient`]. The trait lets
+/// proposer, challenger, and CLI components depend on a mockable interface
+/// that exposes only the requester surface — worker-only methods such as
+/// `claim`, `heartbeat`, `complete`, and `fail` are intentionally absent.
+#[async_trait]
+pub trait ProofRequesterProvider: Send + Sync {
+    /// Submit a request to prove a block range.
+    async fn prove_block_range(
+        &self,
+        request: ProveBlockRangeRequest,
+    ) -> Result<ProveBlockRangeResponse, ProverServiceClientError>;
+
+    /// Return proof status and result data for a submitted proof request.
+    async fn get_proof(
+        &self,
+        request: GetProofRequest,
+    ) -> Result<GetProofResponse, ProverServiceClientError>;
+
+    /// List submitted proof requests.
+    async fn list_proofs(
+        &self,
+        request: ListProofsRequest,
+    ) -> Result<ListProofsResponse, ProverServiceClientError>;
+}
+
 /// JSON-RPC client for proof requester methods.
 #[derive(Clone, Debug)]
-pub struct ProverRequesterClient {
+pub struct ProofRequesterClient {
     inner: HttpClient,
 }
 
-impl ProverRequesterClient {
+impl ProofRequesterClient {
     /// Create a requester client from an existing JSON-RPC HTTP client.
     pub const fn new(inner: HttpClient) -> Self {
         Self { inner }
@@ -31,16 +59,16 @@ impl ProverRequesterClient {
         &self.inner
     }
 
-    /// Submit a proof request.
-    pub async fn submit_proof(
+    /// Submit a prove-block-range proof request.
+    pub async fn prove_block_range(
         &self,
-        request: SubmitProofRequest,
-    ) -> Result<SubmitProofResponse, ProverServiceClientError> {
+        request: ProveBlockRangeRequest,
+    ) -> Result<ProveBlockRangeResponse, ProverServiceClientError> {
         debug!(
             session_id = ?request.proof.session_id,
-            "submitting proof request"
+            "proving block range"
         );
-        Ok(self.inner.submit_proof(request).await?)
+        Ok(self.inner.prove_block_range(request).await?)
     }
 
     /// Return proof status and result data for a submitted proof request.
@@ -48,7 +76,7 @@ impl ProverRequesterClient {
         &self,
         request: GetProofRequest,
     ) -> Result<GetProofResponse, ProverServiceClientError> {
-        debug!(session_id = %request.session_id, "fetching proof request");
+        debug!(session_id = %request.session_id, "fetching proof");
         Ok(self.inner.get_proof(request).await?)
     }
 
@@ -61,8 +89,255 @@ impl ProverRequesterClient {
             offset = request.offset,
             limit = request.limit,
             status_filter = ?request.status_filter,
-            "listing proof requests"
+            "listing proofs"
         );
         Ok(self.inner.list_proofs(request).await?)
+    }
+}
+
+#[async_trait]
+impl ProofRequesterProvider for ProofRequesterClient {
+    async fn prove_block_range(
+        &self,
+        request: ProveBlockRangeRequest,
+    ) -> Result<ProveBlockRangeResponse, ProverServiceClientError> {
+        Self::prove_block_range(self, request).await
+    }
+
+    async fn get_proof(
+        &self,
+        request: GetProofRequest,
+    ) -> Result<GetProofResponse, ProverServiceClientError> {
+        Self::get_proof(self, request).await
+    }
+
+    async fn list_proofs(
+        &self,
+        request: ListProofsRequest,
+    ) -> Result<ListProofsResponse, ProverServiceClientError> {
+        Self::list_proofs(self, request).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        net::SocketAddr,
+        sync::{Arc, Mutex},
+    };
+
+    use async_trait::async_trait;
+    use base_prover_service_protocol::{
+        GetProofRequest, GetProofResponse, ListProofsRequest, ListProofsResponse, ProofRequest,
+        ProofRequestKind, ProofResult, ProofStatus, ProofSummary, ProofType,
+        ProveBlockRangeRequest, ProveBlockRangeResponse, ProverRequesterApiServer, ZkProofRequest,
+        ZkProofResult, ZkVm,
+    };
+    use chrono::Utc;
+    use jsonrpsee::{
+        core::{RpcResult, client::Error as JsonRpcClientError},
+        http_client::HttpClientBuilder,
+        server::{Server, ServerHandle},
+        types::ErrorObjectOwned,
+    };
+
+    use super::{ProofRequesterClient, ProofRequesterProvider};
+    use crate::ProverServiceClientError;
+
+    #[derive(Clone, Debug)]
+    struct MockRequesterApi {
+        state: Arc<Mutex<MockRequesterState>>,
+        reject_get_proof: bool,
+    }
+
+    #[derive(Debug, Default)]
+    struct MockRequesterState {
+        prove_request: Option<ProveBlockRangeRequest>,
+        get_request: Option<GetProofRequest>,
+        list_request: Option<ListProofsRequest>,
+    }
+
+    #[derive(Debug)]
+    struct RunningRequesterServer {
+        client: ProofRequesterClient,
+        handle: ServerHandle,
+    }
+
+    impl MockRequesterApi {
+        fn new() -> Self {
+            Self {
+                state: Arc::new(Mutex::new(MockRequesterState::default())),
+                reject_get_proof: false,
+            }
+        }
+
+        fn rejecting_get_proof() -> Self {
+            Self {
+                state: Arc::new(Mutex::new(MockRequesterState::default())),
+                reject_get_proof: true,
+            }
+        }
+    }
+
+    impl RunningRequesterServer {
+        async fn spawn(api: MockRequesterApi) -> Self {
+            let addr: SocketAddr = "127.0.0.1:0".parse().expect("test address should parse");
+            let server = Server::builder().build(addr).await.expect("server should bind");
+            let local_addr = server.local_addr().expect("server should have local address");
+            let handle = server.start(api.into_rpc());
+            let endpoint = format!("http://{local_addr}");
+            let inner = HttpClientBuilder::default().build(endpoint).expect("client should build");
+
+            Self { client: ProofRequesterClient::new(inner), handle }
+        }
+
+        async fn shutdown(self) {
+            self.handle.stop().expect("server should stop");
+            self.handle.stopped().await;
+        }
+    }
+
+    #[async_trait]
+    impl ProverRequesterApiServer for MockRequesterApi {
+        async fn prove_block_range(
+            &self,
+            request: ProveBlockRangeRequest,
+        ) -> RpcResult<ProveBlockRangeResponse> {
+            self.state.lock().expect("state lock should not be poisoned").prove_request =
+                Some(request.clone());
+
+            let session_id =
+                request.proof.session_id.clone().expect("test request should set session_id");
+            Ok(ProveBlockRangeResponse { session_id })
+        }
+
+        async fn get_proof(&self, request: GetProofRequest) -> RpcResult<GetProofResponse> {
+            self.state.lock().expect("state lock should not be poisoned").get_request =
+                Some(request.clone());
+
+            if self.reject_get_proof {
+                return Err(ErrorObjectOwned::owned(
+                    ProverServiceClientError::ERROR_UNAVAILABLE,
+                    format!("session_id {} is temporarily unavailable", request.session_id),
+                    None::<()>,
+                ));
+            }
+
+            Ok(GetProofResponse {
+                status: ProofStatus::Succeeded,
+                error_message: None,
+                result: Some(ProofResult::Compressed(ZkProofResult {
+                    zk_vm: ZkVm::Sp1,
+                    proof: vec![0xab, 0xcd].into(),
+                })),
+            })
+        }
+
+        async fn list_proofs(
+            &self,
+            request: ListProofsRequest,
+        ) -> RpcResult<ListProofsResponse> {
+            self.state.lock().expect("state lock should not be poisoned").list_request =
+                Some(request);
+
+            let summary = ProofSummary {
+                session_id: "session-list-1".to_owned(),
+                proof_type: ProofType::Compressed,
+                status: ProofStatus::Succeeded,
+                created_at: Utc::now(),
+                updated_at: Utc::now(),
+                completed_at: Some(Utc::now()),
+                error_message: None,
+                tee_kind: None,
+                zk_vm: Some(ZkVm::Sp1),
+            };
+            Ok(ListProofsResponse { proofs: vec![summary], total_count: 1 })
+        }
+    }
+
+    fn sample_prove_request(session_id: &str) -> ProveBlockRangeRequest {
+        ProveBlockRangeRequest {
+            proof: ProofRequest {
+                session_id: Some(session_id.to_owned()),
+                request: ProofRequestKind::Compressed(ZkProofRequest {
+                    start_block_number: 100,
+                    number_of_blocks_to_prove: 5,
+                    sequence_window: None,
+                    l1_head: None,
+                    intermediate_root_interval: None,
+                    zk_vm: ZkVm::Sp1,
+                }),
+            },
+        }
+    }
+
+    #[tokio::test]
+    async fn requester_methods_round_trip_requests_and_responses() {
+        let api = MockRequesterApi::new();
+        let server = RunningRequesterServer::spawn(api.clone()).await;
+        let provider: &dyn ProofRequesterProvider = &server.client;
+
+        let prove_request = sample_prove_request("session-prove");
+        let prove_response = provider
+            .prove_block_range(prove_request.clone())
+            .await
+            .expect("prove_block_range should succeed");
+        assert_eq!(prove_response.session_id, "session-prove");
+
+        let get_request = GetProofRequest { session_id: "session-get".to_owned() };
+        let get_response =
+            provider.get_proof(get_request.clone()).await.expect("get_proof should succeed");
+        assert_eq!(get_response.status, ProofStatus::Succeeded);
+        match get_response.result.expect("get response should include a result") {
+            ProofResult::Compressed(zk) => {
+                assert_eq!(zk.zk_vm, ZkVm::Sp1);
+                assert_eq!(zk.proof.as_ref(), &[0xab, 0xcd]);
+            }
+            other => panic!("unexpected proof result variant: {other:?}"),
+        }
+
+        let list_request = ListProofsRequest {
+            offset: 7,
+            limit: 25,
+            status_filter: Some(ProofStatus::Succeeded),
+        };
+        let list_response =
+            provider.list_proofs(list_request).await.expect("list_proofs should succeed");
+        assert_eq!(list_response.total_count, 1);
+        assert_eq!(list_response.proofs.len(), 1);
+        assert_eq!(list_response.proofs[0].session_id, "session-list-1");
+
+        {
+            let state = api.state.lock().expect("state lock should not be poisoned");
+            assert_eq!(state.prove_request.as_ref(), Some(&prove_request));
+            assert_eq!(state.get_request.as_ref(), Some(&get_request));
+            assert_eq!(state.list_request, Some(list_request));
+        }
+
+        server.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn requester_rpc_errors_preserve_call_context_and_retryability() {
+        let api = MockRequesterApi::rejecting_get_proof();
+        let server = RunningRequesterServer::spawn(api).await;
+        let provider: &dyn ProofRequesterProvider = &server.client;
+
+        let err = provider
+            .get_proof(GetProofRequest { session_id: "session-error".to_owned() })
+            .await
+            .expect_err("get_proof should be rejected");
+
+        assert!(err.is_retryable());
+
+        match err {
+            ProverServiceClientError::RpcTransport(JsonRpcClientError::Call(call)) => {
+                assert_eq!(call.code(), ProverServiceClientError::ERROR_UNAVAILABLE);
+                assert!(call.message().contains("session-error"));
+            }
+            other => panic!("unexpected error variant: {other:?}"),
+        }
+
+        server.shutdown().await;
     }
 }

--- a/crates/proof/prover-service/client/src/requester.rs
+++ b/crates/proof/prover-service/client/src/requester.rs
@@ -206,8 +206,7 @@ mod tests {
             self.state.lock().expect("state lock should not be poisoned").prove_request =
                 Some(request.clone());
 
-            let session_id =
-                request.proof.session_id.clone().expect("test request should set session_id");
+            let session_id = request.proof.session_id.expect("test request should set session_id");
             Ok(ProveBlockRangeResponse { session_id })
         }
 
@@ -233,10 +232,7 @@ mod tests {
             })
         }
 
-        async fn list_proofs(
-            &self,
-            request: ListProofsRequest,
-        ) -> RpcResult<ListProofsResponse> {
+        async fn list_proofs(&self, request: ListProofsRequest) -> RpcResult<ListProofsResponse> {
             self.state.lock().expect("state lock should not be poisoned").list_request =
                 Some(request);
 
@@ -296,11 +292,8 @@ mod tests {
             other => panic!("unexpected proof result variant: {other:?}"),
         }
 
-        let list_request = ListProofsRequest {
-            offset: 7,
-            limit: 25,
-            status_filter: Some(ProofStatus::Succeeded),
-        };
+        let list_request =
+            ListProofsRequest { offset: 7, limit: 25, status_filter: Some(ProofStatus::Succeeded) };
         let list_response =
             provider.list_proofs(list_request).await.expect("list_proofs should succeed");
         assert_eq!(list_response.total_count, 1);

--- a/crates/proof/prover-service/protocol/src/api.rs
+++ b/crates/proof/prover-service/protocol/src/api.rs
@@ -6,7 +6,7 @@ use crate::{
     ClaimProofJobRequest, ClaimProofJobResponse, CompleteProofJobRequest, CompleteProofJobResponse,
     FailProofJobRequest, FailProofJobResponse, GetProofJobRequest, GetProofJobResponse,
     GetProofRequest, GetProofResponse, HeartbeatProofJobRequest, HeartbeatProofJobResponse,
-    ListProofsRequest, ListProofsResponse, SubmitProofRequest, SubmitProofResponse,
+    ListProofsRequest, ListProofsResponse, ProveBlockRangeRequest, ProveBlockRangeResponse,
 };
 
 #[cfg_attr(
@@ -23,12 +23,12 @@ use crate::{
 )]
 /// JSON-RPC interface for proof requesters.
 pub trait ProverRequesterApi {
-    /// Submit a proof request.
-    #[method(name = "submitProof")]
-    async fn submit_proof(
+    /// Submit a prove-block-range proof request.
+    #[method(name = "proveBlockRange")]
+    async fn prove_block_range(
         &self,
-        request: SubmitProofRequest,
-    ) -> jsonrpsee::core::RpcResult<SubmitProofResponse>;
+        request: ProveBlockRangeRequest,
+    ) -> jsonrpsee::core::RpcResult<ProveBlockRangeResponse>;
 
     /// Return proof status and result data for a submitted proof request.
     #[method(name = "getProof")]

--- a/crates/proof/prover-service/protocol/src/lib.rs
+++ b/crates/proof/prover-service/protocol/src/lib.rs
@@ -13,7 +13,7 @@ pub use types::{
     FailProofJobRequest, FailProofJobResponse, GetProofJobRequest, GetProofJobResponse,
     GetProofRequest, GetProofResponse, HeartbeatProofJobRequest, HeartbeatProofJobResponse,
     ListProofsRequest, ListProofsResponse, ProofJob, ProofJobStatus, ProofRequest,
-    ProofRequestKind, ProofResult, ProofStatus, ProofSummary, ProofType, SnarkGroth16ProofRequest,
-    SnarkGroth16ProofResult, SubmitProofRequest, SubmitProofResponse, TeeKind, TeeProofRequest,
-    TeeProofResult, TeeProposal, ZkProofRequest, ZkProofResult, ZkVm,
+    ProofRequestKind, ProofResult, ProofStatus, ProofSummary, ProofType, ProveBlockRangeRequest,
+    ProveBlockRangeResponse, SnarkGroth16ProofRequest, SnarkGroth16ProofResult, TeeKind,
+    TeeProofRequest, TeeProofResult, TeeProposal, ZkProofRequest, ZkProofResult, ZkVm,
 };

--- a/crates/proof/prover-service/protocol/src/types.rs
+++ b/crates/proof/prover-service/protocol/src/types.rs
@@ -62,18 +62,18 @@ pub enum ProofJobStatus {
     Failed,
 }
 
-/// Request to submit a proof.
+/// Request to prove a block range.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct SubmitProofRequest {
+pub struct ProveBlockRangeRequest {
     /// Proof request payload.
     pub proof: ProofRequest,
 }
 
-/// Response returned after a proof request is accepted.
+/// Response returned after a prove-block-range request is accepted.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct SubmitProofResponse {
+pub struct ProveBlockRangeResponse {
     /// Server-assigned or client-supplied session identifier.
     pub session_id: String,
 }
@@ -455,7 +455,7 @@ mod tests {
 
     #[test]
     fn proof_request_serializes_as_json_rpc_payload() {
-        let request = SubmitProofRequest {
+        let request = ProveBlockRangeRequest {
             proof: ProofRequest {
                 session_id: Some("proof-session".to_owned()),
                 request: ProofRequestKind::Compressed(ZkProofRequest {

--- a/crates/proof/prover-service/src/server/mod.rs
+++ b/crates/proof/prover-service/src/server/mod.rs
@@ -5,7 +5,7 @@ use std::fmt;
 use base_prover_service_db::ProofRequestRepo;
 use base_prover_service_protocol::{
     GetProofRequest, GetProofResponse, ListProofsRequest, ListProofsResponse,
-    ProverRequesterApiServer, SubmitProofRequest, SubmitProofResponse,
+    ProveBlockRangeRequest, ProveBlockRangeResponse, ProverRequesterApiServer,
 };
 use jsonrpsee::{
     core::{RpcResult, async_trait},
@@ -16,7 +16,7 @@ use crate::ProofRequestManager;
 
 mod get_proof;
 mod list_proofs;
-mod submit_proof;
+mod prove_block_range;
 
 const ERROR_NOT_FOUND: i32 = -32004;
 const ERROR_UNAVAILABLE: i32 = -32014;
@@ -53,8 +53,11 @@ impl ProverServiceServer {
 
 #[async_trait]
 impl ProverRequesterApiServer for ProverServiceServer {
-    async fn submit_proof(&self, request: SubmitProofRequest) -> RpcResult<SubmitProofResponse> {
-        self.submit_proof_impl(request).await
+    async fn prove_block_range(
+        &self,
+        request: ProveBlockRangeRequest,
+    ) -> RpcResult<ProveBlockRangeResponse> {
+        self.prove_block_range_impl(request).await
     }
 
     async fn get_proof(&self, request: GetProofRequest) -> RpcResult<GetProofResponse> {

--- a/crates/proof/prover-service/src/server/prove_block_range.rs
+++ b/crates/proof/prover-service/src/server/prove_block_range.rs
@@ -3,7 +3,8 @@ use base_prover_service_db::{
     CreateProofRequest, CreateProofRequestError, CreateProofRequestOutcome, ProofType,
 };
 use base_prover_service_protocol::{
-    ProofRequest, ProofRequestKind, SubmitProofRequest, SubmitProofResponse, ZkProofRequest, ZkVm,
+    ProofRequest, ProofRequestKind, ProveBlockRangeRequest, ProveBlockRangeResponse,
+    ZkProofRequest, ZkVm,
 };
 use jsonrpsee::core::RpcResult;
 use tracing::{info, warn};
@@ -16,23 +17,23 @@ use crate::server::{
 
 impl ProverServiceServer {
     /// Enqueues a new proof request and returns the generated `session_id=<uuid>`.
-    pub async fn submit_proof_impl(
+    pub async fn prove_block_range_impl(
         &self,
-        request: SubmitProofRequest,
-    ) -> RpcResult<SubmitProofResponse> {
+        request: ProveBlockRangeRequest,
+    ) -> RpcResult<ProveBlockRangeResponse> {
         let start = std::time::Instant::now();
-        let result = self.submit_proof_inner(request).await;
-        record_rpc_result("SubmitProof", start, &result);
+        let result = self.prove_block_range_inner(request).await;
+        record_rpc_result("ProveBlockRange", start, &result);
 
         result
     }
 
-    async fn submit_proof_inner(
+    async fn prove_block_range_inner(
         &self,
-        submit_request: SubmitProofRequest,
-    ) -> RpcResult<SubmitProofResponse> {
-        let session_id = parse_session_id(submit_request.proof.session_id.as_deref())?;
-        let (zk_request, proof_type, prover_address) = parse_zk_request(submit_request.proof)?;
+        request: ProveBlockRangeRequest,
+    ) -> RpcResult<ProveBlockRangeResponse> {
+        let session_id = parse_session_id(request.proof.session_id.as_deref())?;
+        let (zk_request, proof_type, prover_address) = parse_zk_request(request.proof)?;
         let l1_head = zk_request.l1_head.map(format_hash);
 
         info!(
@@ -78,7 +79,7 @@ impl ProverServiceServer {
                     warn!(
                         proof_request_id = %id,
                         mismatched_field = field,
-                        "rejected SubmitProof: session_id already bound to a different request"
+                        "rejected ProveBlockRange: session_id already bound to a different request"
                     );
                     failed_precondition(format!(
                         "session_id {id} already exists with a different {field}"
@@ -87,10 +88,10 @@ impl ProverServiceServer {
                 CreateProofRequestError::SessionRowMissingAfterConflict { id } => {
                     warn!(
                         proof_request_id = %id,
-                        "rejected SubmitProof: session_id row missing after insert conflict"
+                        "rejected ProveBlockRange: session_id row missing after insert conflict"
                     );
                     unavailable(format!(
-                        "session_id {id} is temporarily unavailable after conflict; retry submit_proof"
+                        "session_id {id} is temporarily unavailable after conflict; retry prove_block_range"
                     ))
                 }
                 CreateProofRequestError::Sqlx(e) => internal(format!("Database error: {e}")),
@@ -102,7 +103,7 @@ impl ProverServiceServer {
                 warn!(
                     proof_request_id = %id,
                     max_proof_retries = self.max_proof_retries,
-                    "rejected SubmitProof: proof request retry budget exhausted for this session_id",
+                    "rejected ProveBlockRange: proof request retry budget exhausted for this session_id",
                 );
                 return Err(resource_exhausted(format!(
                     "session_id {id}: proof request retry budget exhausted; use get_proof for the stored terminal failure",
@@ -128,7 +129,7 @@ impl ProverServiceServer {
             }
         }
 
-        Ok(SubmitProofResponse { session_id: proof_request_id.to_string() })
+        Ok(ProveBlockRangeResponse { session_id: proof_request_id.to_string() })
     }
 }
 

--- a/crates/proof/prover-service/src/snark_e2e.rs
+++ b/crates/proof/prover-service/src/snark_e2e.rs
@@ -11,7 +11,8 @@ use anyhow::{Context, Result, bail};
 use base_common_network::Base;
 use base_prover_service_protocol::{
     GetProofRequest, ProofRequest, ProofRequestKind, ProofResult, ProofStatus,
-    ProverRequesterApiClient, SnarkGroth16ProofRequest, SubmitProofRequest, ZkProofRequest, ZkVm,
+    ProveBlockRangeRequest, ProverRequesterApiClient, SnarkGroth16ProofRequest, ZkProofRequest,
+    ZkVm,
 };
 use jsonrpsee::http_client::{HttpClient, HttpClientBuilder};
 use sp1_sdk::{
@@ -207,7 +208,7 @@ impl SnarkE2e {
         // heuristic.
         let client = Self::connect().await?;
         let prove_resp = client
-            .submit_proof(SubmitProofRequest {
+            .prove_block_range(ProveBlockRangeRequest {
                 proof: ProofRequest {
                     session_id: None,
                     request: ProofRequestKind::SnarkGroth16(SnarkGroth16ProofRequest {

--- a/crates/proof/prover-service/tests/common/mod.rs
+++ b/crates/proof/prover-service/tests/common/mod.rs
@@ -4,8 +4,9 @@ use alloy_primitives::{Address, B256};
 use anyhow::{Context, Result, bail};
 pub(crate) use base_prover_service::ProveBlockRequest;
 use base_prover_service_protocol::{
-    ProofRequest, ProofRequestKind, ProverRequesterApiClient, SnarkGroth16ProofRequest,
-    SubmitProofRequest, SubmitProofResponse, TeeKind, TeeProofRequest, ZkProofRequest, ZkVm,
+    ProofRequest, ProofRequestKind, ProveBlockRangeRequest, ProveBlockRangeResponse,
+    ProverRequesterApiClient, SnarkGroth16ProofRequest, TeeKind, TeeProofRequest, ZkProofRequest,
+    ZkVm,
 };
 use jsonrpsee::http_client::{HttpClient, HttpClientBuilder};
 
@@ -22,12 +23,12 @@ pub(crate) fn connect() -> HttpClient {
 pub(crate) async fn prove_block(
     client: &HttpClient,
     request: ProveBlockRequest,
-) -> Result<SubmitProofResponse> {
-    let request = to_submit_proof_request(request)?;
-    client.submit_proof(request).await.context("submit_proof failed")
+) -> Result<ProveBlockRangeResponse> {
+    let request = to_prove_block_range_request(request)?;
+    client.prove_block_range(request).await.context("prove_block_range failed")
 }
 
-fn to_submit_proof_request(request: ProveBlockRequest) -> Result<SubmitProofRequest> {
+fn to_prove_block_range_request(request: ProveBlockRequest) -> Result<ProveBlockRangeRequest> {
     let l1_head = request
         .l1_head
         .as_deref()
@@ -68,5 +69,7 @@ fn to_submit_proof_request(request: ProveBlockRequest) -> Result<SubmitProofRequ
         proof_type => bail!("invalid proof_type {proof_type}"),
     };
 
-    Ok(SubmitProofRequest { proof: ProofRequest { session_id: request.session_id, request: body } })
+    Ok(ProveBlockRangeRequest {
+        proof: ProofRequest { session_id: request.session_id, request: body },
+    })
 }


### PR DESCRIPTION
Mirrors the worker provider trait added in #3040.

## What

- Adds `ProofRequesterClient` and `ProofRequesterProvider` in `base-prover-service-client` so proposer, challenger, and CLI components can depend on a mockable requester surface that exposes only `prove_block_range`, `get_proof`, and `list_proofs`. Worker-only methods (`claim`, `heartbeat`, `complete`, `fail`, `get_proof_job`) are intentionally absent from this trait.
- Renames `submit_proof` -> `prove_block_range` end to end to match the naming used elsewhere for the requester surface:
  - Protocol: `SubmitProofRequest`/`SubmitProofResponse` -> `ProveBlockRangeRequest`/`ProveBlockRangeResponse`, wire method `submitProof` -> `proveBlockRange`.
  - Server: `submit_proof.rs` -> `prove_block_range.rs` (impl + metric label + log fields updated).
  - Client + callers: `client.submit_proof(...)` -> `client.prove_block_range(...)` in `snark_e2e.rs` and integration test helpers.

## Test plan

- `cargo test -p base-prover-service-protocol -p base-prover-service-client` — 5 + 22 unit tests pass, including 2 new requester tests covering all 3 methods and an error path via a jsonrpsee mock server (same harness pattern as the worker tests).
- `cargo test -p base-prover-service --lib` — 49 unit tests pass.
- `cargo check` clean across the workspace.