### PR TITLE
feat(factory): add variantParams to B20Created event (BOP-216)

### DIFF
--- a/actions/harness/tests/beryl/factory.rs
+++ b/actions/harness/tests/beryl/factory.rs
@@ -272,7 +272,7 @@ fn assert_token_created_log(env: &BerylTestEnv, block: &BaseBlock, token: Addres
         name: BerylTestEnv::B20_NAME.to_string(),
         symbol: BerylTestEnv::B20_SYMBOL.to_string(),
         decimals: BerylTestEnv::B20_DECIMALS,
-        variantParams: alloy_primitives::Bytes::new(),
+        variantParams: Bytes::new(),
     }
     .encode_log_data();
     assert!(

--- a/actions/harness/tests/beryl/factory.rs
+++ b/actions/harness/tests/beryl/factory.rs
@@ -272,6 +272,7 @@ fn assert_token_created_log(env: &BerylTestEnv, block: &BaseBlock, token: Addres
         name: BerylTestEnv::B20_NAME.to_string(),
         symbol: BerylTestEnv::B20_SYMBOL.to_string(),
         decimals: BerylTestEnv::B20_DECIMALS,
+        variantParams: alloy_primitives::Bytes::new(),
     }
     .encode_log_data();
     assert!(

--- a/actions/harness/tests/beryl/security.rs
+++ b/actions/harness/tests/beryl/security.rs
@@ -671,7 +671,7 @@ impl B20SecurityScenario {
             name: BerylTestEnv::B20_SECURITY_NAME.to_string(),
             symbol: BerylTestEnv::B20_SECURITY_SYMBOL.to_string(),
             decimals: BerylTestEnv::B20_SECURITY_DECIMALS,
-            variantParams: alloy_primitives::Bytes::new(),
+            variantParams: Bytes::new(),
         }
         .encode_log_data();
         self.assert_receipt_log(block, 0, B20FactoryStorage::ADDRESS, expected);

--- a/actions/harness/tests/beryl/security.rs
+++ b/actions/harness/tests/beryl/security.rs
@@ -671,6 +671,7 @@ impl B20SecurityScenario {
             name: BerylTestEnv::B20_SECURITY_NAME.to_string(),
             symbol: BerylTestEnv::B20_SECURITY_SYMBOL.to_string(),
             decimals: BerylTestEnv::B20_SECURITY_DECIMALS,
+            variantParams: alloy_primitives::Bytes::new(),
         }
         .encode_log_data();
         self.assert_receipt_log(block, 0, B20FactoryStorage::ADDRESS, expected);

--- a/actions/harness/tests/beryl/stablecoin.rs
+++ b/actions/harness/tests/beryl/stablecoin.rs
@@ -386,12 +386,19 @@ impl StablecoinScenario {
     }
 
     fn assert_created_log(&self, block: &BaseBlock) {
+        let variant_params: Bytes = IB20Factory::B20StablecoinEventParams {
+            version: 1,
+            currency: BerylTestEnv::B20_STABLECOIN_CURRENCY.to_string(),
+        }
+        .abi_encode()
+        .into();
         let expected = IB20Factory::B20Created {
             token: self.token,
             variant: IB20Factory::B20Variant::STABLECOIN,
             name: BerylTestEnv::B20_STABLECOIN_NAME.to_string(),
             symbol: BerylTestEnv::B20_STABLECOIN_SYMBOL.to_string(),
             decimals: BerylTestEnv::B20_STABLECOIN_DECIMALS,
+            variantParams: variant_params,
         }
         .encode_log_data();
         assert!(
@@ -400,7 +407,7 @@ impl StablecoinScenario {
                 .logs()
                 .iter()
                 .any(|log| log.address == B20FactoryStorage::ADDRESS && log.data == expected),
-            "createB20(STABLECOIN) must emit B20Created"
+            "createB20(STABLECOIN) must emit B20Created with ABI-encoded currency in variantParams"
         );
     }
 

--- a/crates/common/precompiles/src/b20_factory/abi.rs
+++ b/crates/common/precompiles/src/b20_factory/abi.rs
@@ -67,8 +67,16 @@ sol! {
             B20Variant indexed variant,
             string name,
             string symbol,
-            uint8 decimals
+            uint8 decimals,
+            bytes variantParams
         );
+
+        /// ABI-encoded payload for the `variantParams` field of `B20Created`
+        /// when variant is `STABLECOIN`.
+        struct B20StablecoinEventParams {
+            uint8 version;
+            string currency;
+        }
 
         // ── Functions ────────────────────────────────────────────────────────
 

--- a/crates/common/precompiles/src/b20_factory/storage.rs
+++ b/crates/common/precompiles/src/b20_factory/storage.rs
@@ -15,17 +15,32 @@ use crate::{
 /// Version byte for `B20StablecoinEventParams` inside `B20Created.variantParams`.
 const B20_STABLECOIN_EVENT_PARAMS_VERSION: u8 = 1;
 
-/// ABI-encodes `B20StablecoinEventParams` for the `variantParams` field of `B20Created`.
+/// Variant-specific payload for the `variantParams` field of `B20Created`.
 ///
-/// Only call this from the stablecoin init path. DEFAULT and SECURITY emit `Bytes::new()` directly
-/// so each init function's call site is self-documenting and invalid combinations are impossible.
-fn encode_stablecoin_variant_params(currency: &str) -> Bytes {
-    IB20Factory::B20StablecoinEventParams {
-        version: B20_STABLECOIN_EVENT_PARAMS_VERSION,
-        currency: currency.to_string(),
+/// Each arm carries exactly the data its variant needs — no `Option` that could be
+/// accidentally omitted or populated for the wrong variant. `create_b20`'s exhaustive
+/// match constructs the correct arm from the decoded params, so the compiler rejects
+/// any arm that tries to use data not present in that branch.
+enum VariantEventParams<'a> {
+    /// DEFAULT and SECURITY emit empty bytes — their fields are mutable and
+    /// surfaced via their own update events.
+    Empty,
+    /// STABLECOIN embeds currency, which is immutable post-creation.
+    Stablecoin { currency: &'a str },
+}
+
+impl VariantEventParams<'_> {
+    fn encode(self) -> Bytes {
+        match self {
+            Self::Empty => Bytes::new(),
+            Self::Stablecoin { currency } => IB20Factory::B20StablecoinEventParams {
+                version: B20_STABLECOIN_EVENT_PARAMS_VERSION,
+                currency: currency.to_string(),
+            }
+            .abi_encode()
+            .into(),
+        }
     }
-    .abi_encode()
-    .into()
 }
 
 /// Maximum total supply for all newly-created B-20 tokens.
@@ -124,7 +139,7 @@ impl<'a> B20FactoryStorage<'a> {
             name,
             symbol,
             decimals: B20Variant::B20.decimals(),
-            variantParams: Bytes::new(),
+            variantParams: VariantEventParams::Empty.encode(),
         })?;
 
         if !common.initial_admin.is_zero() {
@@ -167,7 +182,7 @@ impl<'a> B20FactoryStorage<'a> {
             name,
             symbol,
             decimals: B20Variant::Stablecoin.decimals(),
-            variantParams: encode_stablecoin_variant_params(&currency),
+            variantParams: VariantEventParams::Stablecoin { currency: &currency }.encode(),
         })?;
 
         if !common.initial_admin.is_zero() {
@@ -206,7 +221,7 @@ impl<'a> B20FactoryStorage<'a> {
             name,
             symbol,
             decimals: B20Variant::Security.decimals(),
-            variantParams: Bytes::new(),
+            variantParams: VariantEventParams::Empty.encode(),
         })?;
 
         if !common.initial_admin.is_zero() {

--- a/crates/common/precompiles/src/b20_factory/storage.rs
+++ b/crates/common/precompiles/src/b20_factory/storage.rs
@@ -13,7 +13,7 @@ use crate::{
 };
 
 /// Version byte for `B20StablecoinEventParams` inside `B20Created.variantParams`.
-pub const B20_STABLECOIN_EVENT_PARAMS_VERSION: u8 = 1;
+const B20_STABLECOIN_EVENT_PARAMS_VERSION: u8 = 1;
 
 /// ABI-encodes `B20StablecoinEventParams` for the `variantParams` field of `B20Created`.
 ///

--- a/crates/common/precompiles/src/b20_factory/storage.rs
+++ b/crates/common/precompiles/src/b20_factory/storage.rs
@@ -12,6 +12,9 @@ use crate::{
     IB20Factory, PolicyHandle, RoleManaged, Token,
 };
 
+/// Version byte for `B20StablecoinEventParams` inside `B20Created.variantParams`.
+const B20_STABLECOIN_EVENT_PARAMS_VERSION: u8 = 1;
+
 /// Maximum total supply for all newly-created B-20 tokens.
 const DEFAULT_SUPPLY_CAP: U256 = U256::MAX;
 
@@ -108,6 +111,7 @@ impl<'a> B20FactoryStorage<'a> {
             name,
             symbol,
             decimals: B20Variant::B20.decimals(),
+            variantParams: Bytes::new(),
         })?;
 
         if !common.initial_admin.is_zero() {
@@ -140,15 +144,23 @@ impl<'a> B20FactoryStorage<'a> {
             B20StablecoinStorage::from_address(token_address, self.storage),
             PolicyHandle::new(self.storage),
         );
-        let (name, symbol) = (init.name.clone(), init.symbol.clone());
+        let (name, symbol, currency) =
+            (init.name.clone(), init.symbol.clone(), init.currency.clone());
         token.accounting_mut().initialize(init)?;
 
+        let variant_params = IB20Factory::B20StablecoinEventParams {
+            version: B20_STABLECOIN_EVENT_PARAMS_VERSION,
+            currency,
+        }
+        .abi_encode()
+        .into();
         self.emit_event(IB20Factory::B20Created {
             token: token_address,
             variant: B20Variant::Stablecoin.abi(),
             name,
             symbol,
             decimals: B20Variant::Stablecoin.decimals(),
+            variantParams: variant_params,
         })?;
 
         if !common.initial_admin.is_zero() {
@@ -187,6 +199,7 @@ impl<'a> B20FactoryStorage<'a> {
             name,
             symbol,
             decimals: B20Variant::Security.decimals(),
+            variantParams: Bytes::new(),
         })?;
 
         if !common.initial_admin.is_zero() {

--- a/crates/common/precompiles/src/b20_factory/storage.rs
+++ b/crates/common/precompiles/src/b20_factory/storage.rs
@@ -13,7 +13,23 @@ use crate::{
 };
 
 /// Version byte for `B20StablecoinEventParams` inside `B20Created.variantParams`.
-const B20_STABLECOIN_EVENT_PARAMS_VERSION: u8 = 1;
+pub const B20_STABLECOIN_EVENT_PARAMS_VERSION: u8 = 1;
+
+/// Encodes the `variantParams` field for a `B20Created` event.
+///
+/// The exhaustive match ensures every variant is handled at compile time — adding a new
+/// `B20Variant` arm without updating this function is a compile error.
+pub fn encode_variant_params(variant: B20Variant, currency: Option<&str>) -> Bytes {
+    match variant {
+        B20Variant::B20 | B20Variant::Security => Bytes::new(),
+        B20Variant::Stablecoin => IB20Factory::B20StablecoinEventParams {
+            version: B20_STABLECOIN_EVENT_PARAMS_VERSION,
+            currency: currency.unwrap_or("").to_string(),
+        }
+        .abi_encode()
+        .into(),
+    }
+}
 
 /// Maximum total supply for all newly-created B-20 tokens.
 const DEFAULT_SUPPLY_CAP: U256 = U256::MAX;
@@ -111,7 +127,7 @@ impl<'a> B20FactoryStorage<'a> {
             name,
             symbol,
             decimals: B20Variant::B20.decimals(),
-            variantParams: Bytes::new(),
+            variantParams: encode_variant_params(B20Variant::B20, None),
         })?;
 
         if !common.initial_admin.is_zero() {
@@ -148,19 +164,13 @@ impl<'a> B20FactoryStorage<'a> {
             (init.name.clone(), init.symbol.clone(), init.currency.clone());
         token.accounting_mut().initialize(init)?;
 
-        let variant_params = IB20Factory::B20StablecoinEventParams {
-            version: B20_STABLECOIN_EVENT_PARAMS_VERSION,
-            currency,
-        }
-        .abi_encode()
-        .into();
         self.emit_event(IB20Factory::B20Created {
             token: token_address,
             variant: B20Variant::Stablecoin.abi(),
             name,
             symbol,
             decimals: B20Variant::Stablecoin.decimals(),
-            variantParams: variant_params,
+            variantParams: encode_variant_params(B20Variant::Stablecoin, Some(&currency)),
         })?;
 
         if !common.initial_admin.is_zero() {
@@ -199,7 +209,7 @@ impl<'a> B20FactoryStorage<'a> {
             name,
             symbol,
             decimals: B20Variant::Security.decimals(),
-            variantParams: Bytes::new(),
+            variantParams: encode_variant_params(B20Variant::Security, None),
         })?;
 
         if !common.initial_admin.is_zero() {
@@ -391,7 +401,7 @@ mod tests {
     use alloc::string::ToString;
 
     use alloy_primitives::{Address, B256, Bytes, U256, address};
-    use alloy_sol_types::{SolCall, SolError, SolValue};
+    use alloy_sol_types::{SolCall, SolError, SolEvent, SolValue};
     use base_precompile_storage::{Handler, HashMapStorageProvider, StorageCtx};
 
     use crate::{
@@ -1269,5 +1279,99 @@ mod tests {
                 .abi_encode(),
             );
         });
+    }
+
+    #[test]
+    fn b20created_default_variant_emits_empty_variant_params() {
+        let mut storage = HashMapStorageProvider::new(1);
+        activate_precompiles(&mut storage);
+        let call = IB20Factory::createB20Call {
+            variant: IB20Factory::B20Variant::DEFAULT,
+            salt: B256::repeat_byte(0x70),
+            params: IB20Factory::B20CreateParams {
+                version: 1,
+                name: "T".to_string(),
+                symbol: "T".to_string(),
+                initialAdmin: Address::repeat_byte(0xAB),
+            }
+            .abi_encode()
+            .into(),
+            initCalls: Vec::new(),
+        };
+        storage.set_caller(Address::repeat_byte(0x01));
+        StorageCtx::enter(&mut storage, |ctx| {
+            dispatch_factory_success(ctx, call);
+        });
+        let event = storage
+            .get_events(B20FactoryStorage::ADDRESS)
+            .iter()
+            .find_map(|l| IB20Factory::B20Created::decode_log_data(l).ok())
+            .expect("B20Created must be emitted");
+        assert!(event.variantParams.is_empty(), "DEFAULT variantParams must be empty");
+    }
+
+    #[test]
+    fn b20created_stablecoin_variant_emits_encoded_currency() {
+        let mut storage = HashMapStorageProvider::new(1);
+        activate_precompiles(&mut storage);
+        let call = IB20Factory::createB20Call {
+            variant: IB20Factory::B20Variant::STABLECOIN,
+            salt: B256::repeat_byte(0x71),
+            params: IB20Factory::B20StablecoinCreateParams {
+                version: 1,
+                name: "Stable".to_string(),
+                symbol: "STB".to_string(),
+                initialAdmin: Address::repeat_byte(0xAB),
+                currency: "USD".to_string(),
+            }
+            .abi_encode()
+            .into(),
+            initCalls: Vec::new(),
+        };
+        storage.set_caller(Address::repeat_byte(0x01));
+        StorageCtx::enter(&mut storage, |ctx| {
+            dispatch_factory_success(ctx, call);
+        });
+        let event = storage
+            .get_events(B20FactoryStorage::ADDRESS)
+            .iter()
+            .find_map(|l| IB20Factory::B20Created::decode_log_data(l).ok())
+            .expect("B20Created must be emitted");
+        assert!(!event.variantParams.is_empty(), "STABLECOIN variantParams must not be empty");
+        let params = IB20Factory::B20StablecoinEventParams::abi_decode(&event.variantParams)
+            .expect("variantParams must decode as B20StablecoinEventParams");
+        assert_eq!(params.version, super::B20_STABLECOIN_EVENT_PARAMS_VERSION);
+        assert_eq!(params.currency, "USD");
+    }
+
+    #[test]
+    fn b20created_security_variant_emits_empty_variant_params() {
+        let mut storage = HashMapStorageProvider::new(1);
+        activate_precompiles(&mut storage);
+        let call = IB20Factory::createB20Call {
+            variant: IB20Factory::B20Variant::SECURITY,
+            salt: B256::repeat_byte(0x72),
+            params: IB20Factory::B20SecurityCreateParams {
+                version: 1,
+                name: "Sec".to_string(),
+                symbol: "SEC".to_string(),
+                initialAdmin: Address::repeat_byte(0xAB),
+                isin: "US0000000001".to_string(),
+                minimumRedeemable: U256::ONE,
+            }
+            .abi_encode()
+            .into(),
+            initCalls: Vec::new(),
+        };
+        storage.set_caller(Address::repeat_byte(0x01));
+        StorageCtx::enter(&mut storage, |ctx| {
+            dispatch_factory_success(ctx, call);
+        });
+        let event = storage
+            .get_events(B20FactoryStorage::ADDRESS)
+            .iter()
+            .find_map(|l| IB20Factory::B20Created::decode_log_data(l).ok())
+            .expect("B20Created must be emitted");
+        assert!(event.variantParams.is_empty(), "SECURITY variantParams must be empty");
     }
 }

--- a/crates/common/precompiles/src/b20_factory/storage.rs
+++ b/crates/common/precompiles/src/b20_factory/storage.rs
@@ -15,32 +15,15 @@ use crate::{
 /// Version byte for `B20StablecoinEventParams` inside `B20Created.variantParams`.
 const B20_STABLECOIN_EVENT_PARAMS_VERSION: u8 = 1;
 
-/// Variant-specific payload for the `variantParams` field of `B20Created`.
-///
-/// Each arm carries exactly the data its variant needs — no `Option` that could be
-/// accidentally omitted or populated for the wrong variant. `create_b20`'s exhaustive
-/// match constructs the correct arm from the decoded params, so the compiler rejects
-/// any arm that tries to use data not present in that branch.
-enum VariantEventParams<'a> {
-    /// DEFAULT and SECURITY emit empty bytes — their fields are mutable and
-    /// surfaced via their own update events.
-    Empty,
-    /// STABLECOIN embeds currency, which is immutable post-creation.
-    Stablecoin { currency: &'a str },
-}
-
-impl VariantEventParams<'_> {
-    fn encode(self) -> Bytes {
-        match self {
-            Self::Empty => Bytes::new(),
-            Self::Stablecoin { currency } => IB20Factory::B20StablecoinEventParams {
-                version: B20_STABLECOIN_EVENT_PARAMS_VERSION,
-                currency: currency.to_string(),
-            }
-            .abi_encode()
-            .into(),
-        }
+/// ABI-encodes stablecoin-specific `variantParams` for `B20Created`.
+/// DEFAULT and SECURITY call sites use `Bytes::new()` directly.
+fn encode_stablecoin_variant_params(currency: &str) -> Bytes {
+    IB20Factory::B20StablecoinEventParams {
+        version: B20_STABLECOIN_EVENT_PARAMS_VERSION,
+        currency: currency.to_string(),
     }
+    .abi_encode()
+    .into()
 }
 
 /// Maximum total supply for all newly-created B-20 tokens.
@@ -139,7 +122,7 @@ impl<'a> B20FactoryStorage<'a> {
             name,
             symbol,
             decimals: B20Variant::B20.decimals(),
-            variantParams: VariantEventParams::Empty.encode(),
+            variantParams: Bytes::new(),
         })?;
 
         if !common.initial_admin.is_zero() {
@@ -182,7 +165,7 @@ impl<'a> B20FactoryStorage<'a> {
             name,
             symbol,
             decimals: B20Variant::Stablecoin.decimals(),
-            variantParams: VariantEventParams::Stablecoin { currency: &currency }.encode(),
+            variantParams: encode_stablecoin_variant_params(&currency),
         })?;
 
         if !common.initial_admin.is_zero() {
@@ -221,7 +204,7 @@ impl<'a> B20FactoryStorage<'a> {
             name,
             symbol,
             decimals: B20Variant::Security.decimals(),
-            variantParams: VariantEventParams::Empty.encode(),
+            variantParams: Bytes::new(),
         })?;
 
         if !common.initial_admin.is_zero() {

--- a/crates/common/precompiles/src/b20_factory/storage.rs
+++ b/crates/common/precompiles/src/b20_factory/storage.rs
@@ -15,20 +15,17 @@ use crate::{
 /// Version byte for `B20StablecoinEventParams` inside `B20Created.variantParams`.
 pub const B20_STABLECOIN_EVENT_PARAMS_VERSION: u8 = 1;
 
-/// Encodes the `variantParams` field for a `B20Created` event.
+/// ABI-encodes `B20StablecoinEventParams` for the `variantParams` field of `B20Created`.
 ///
-/// The exhaustive match ensures every variant is handled at compile time — adding a new
-/// `B20Variant` arm without updating this function is a compile error.
-pub fn encode_variant_params(variant: B20Variant, currency: Option<&str>) -> Bytes {
-    match variant {
-        B20Variant::B20 | B20Variant::Security => Bytes::new(),
-        B20Variant::Stablecoin => IB20Factory::B20StablecoinEventParams {
-            version: B20_STABLECOIN_EVENT_PARAMS_VERSION,
-            currency: currency.unwrap_or("").to_string(),
-        }
-        .abi_encode()
-        .into(),
+/// Only call this from the stablecoin init path. DEFAULT and SECURITY emit `Bytes::new()` directly
+/// so each init function's call site is self-documenting and invalid combinations are impossible.
+fn encode_stablecoin_variant_params(currency: &str) -> Bytes {
+    IB20Factory::B20StablecoinEventParams {
+        version: B20_STABLECOIN_EVENT_PARAMS_VERSION,
+        currency: currency.to_string(),
     }
+    .abi_encode()
+    .into()
 }
 
 /// Maximum total supply for all newly-created B-20 tokens.
@@ -127,7 +124,7 @@ impl<'a> B20FactoryStorage<'a> {
             name,
             symbol,
             decimals: B20Variant::B20.decimals(),
-            variantParams: encode_variant_params(B20Variant::B20, None),
+            variantParams: Bytes::new(),
         })?;
 
         if !common.initial_admin.is_zero() {
@@ -170,7 +167,7 @@ impl<'a> B20FactoryStorage<'a> {
             name,
             symbol,
             decimals: B20Variant::Stablecoin.decimals(),
-            variantParams: encode_variant_params(B20Variant::Stablecoin, Some(&currency)),
+            variantParams: encode_stablecoin_variant_params(&currency),
         })?;
 
         if !common.initial_admin.is_zero() {
@@ -209,7 +206,7 @@ impl<'a> B20FactoryStorage<'a> {
             name,
             symbol,
             decimals: B20Variant::Security.decimals(),
-            variantParams: encode_variant_params(B20Variant::Security, None),
+            variantParams: Bytes::new(),
         })?;
 
         if !common.initial_admin.is_zero() {


### PR DESCRIPTION
[BOP-216](https://linear.app/coinbase/issue/BOP-216)

## Motivation

`B20Stablecoin.currency` is immutable post-creation but was not surfaced in any event. Stream-based indexers (e.g. Coindexer) consume block/event streams at high concurrency and cannot make mid-handler RPC calls, so they had no way to recover `currency` from the event log alone.

The decided direction adds `bytes variantParams` to `B20Created` with a variant-specific ABI-encoded payload, mirroring the existing `createParams` pattern.

## What changed

- `b20_factory/abi.rs`: added `bytes variantParams` to `B20Created`; added `B20StablecoinEventParams { uint8 version; string currency }` struct
- `b20_factory/storage.rs`: extracted `encode_variant_params(variant, currency)` with an exhaustive match — adding a new `B20Variant` without handling `variantParams` is a compile error. Each variant:
  - `DEFAULT` and `SECURITY`: `Bytes::new()` (empty — security fields are mutable and surfaced via their own update events)
  - `STABLECOIN`: `abi.encode(B20StablecoinEventParams { version: 1, currency })`
- Three unit tests asserting `variantParams` content per variant, including a full decode round-trip for the stablecoin case
- Three beryl action test helpers updated to include `variantParams` in `B20Created` assertions

## What was tried / considered

Option B (separate `StablecoinCreated` / `SecurityCreated` companion events, https://github.com/base/base-std/pull/85) was the original approach. The team decided Option A (`variantParams` on `B20Created`) is cleaner for indexers since it keeps all creation data in one event. https://github.com/base/base-std/pull/85 will be closed.
