### PR TITLE
feat(prover-service): update prover service protocol TEE payloads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5955,6 +5955,7 @@ dependencies = [
  "async-trait",
  "axum 0.8.9",
  "base-common-network",
+ "base-proof-primitives",
  "base-proof-rpc",
  "base-proof-succinct-client-utils",
  "base-proof-succinct-elfs",
@@ -6036,6 +6037,7 @@ name = "base-prover-service-protocol"
 version = "0.0.0"
 dependencies = [
  "alloy-primitives",
+ "base-proof-primitives",
  "chrono",
  "jsonrpsee",
  "serde",

--- a/crates/proof/prover-service/Cargo.toml
+++ b/crates/proof/prover-service/Cargo.toml
@@ -64,6 +64,7 @@ metrics.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]
+base-proof-primitives = { workspace = true, features = ["serde"] }
 tracing-subscriber = { workspace = true, features = ["env-filter", "fmt"] }
 
 [lints]

--- a/crates/proof/prover-service/protocol/Cargo.toml
+++ b/crates/proof/prover-service/protocol/Cargo.toml
@@ -11,6 +11,7 @@ repository.workspace = true
 [dependencies]
 # Primitive value types
 alloy-primitives = { workspace = true, features = ["serde"] }
+base-proof-primitives = { workspace = true, features = ["serde"] }
 
 # Serialization
 serde = { workspace = true, features = ["derive"] }

--- a/crates/proof/prover-service/protocol/src/lib.rs
+++ b/crates/proof/prover-service/protocol/src/lib.rs
@@ -13,6 +13,6 @@ pub use types::{
     HeartbeatResponse, ListProofsRequest, ListProofsResponse, ProofJob, ProofJobStatus,
     ProofRequest, ProofRequestKind, ProofResult, ProofStatus, ProofSummary, ProofType,
     ProveBlockRangeRequest, ProveBlockRangeResponse, SnarkGroth16ProofRequest,
-    SnarkGroth16ProofResult, TeeKind, TeeProofRequest, TeeProofResult, TeeProposal,
-    WorkerSubmitProofRequest, WorkerSubmitProofResponse, ZkProofRequest, ZkProofResult, ZkVm,
+    SnarkGroth16ProofResult, TeeKind, TeeProofRequest, TeeProofResult, WorkerSubmitProofRequest,
+    WorkerSubmitProofResponse, ZkProofRequest, ZkProofResult, ZkVm,
 };

--- a/crates/proof/prover-service/protocol/src/types.rs
+++ b/crates/proof/prover-service/protocol/src/types.rs
@@ -1,6 +1,7 @@
 //! JSON-RPC request and response types for the shared prover service protocol.
 
 use alloy_primitives::{Address, B256, Bytes};
+use base_proof_primitives::{ProofRequest as PrimitiveProofRequest, Proposal};
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
@@ -62,7 +63,6 @@ pub enum ProofJobStatus {
 
 /// Request to prove a block range.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
 pub struct ProveBlockRangeRequest {
     /// Proof request payload.
     pub proof: ProofRequest,
@@ -70,7 +70,6 @@ pub struct ProveBlockRangeRequest {
 
 /// Response returned after a prove-block-range request is accepted.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
 pub struct ProveBlockRangeResponse {
     /// Server-assigned or client-supplied session identifier.
     pub session_id: String,
@@ -78,7 +77,6 @@ pub struct ProveBlockRangeResponse {
 
 /// Submitted proof request.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
 pub struct ProofRequest {
     /// Optional client-provided idempotency key.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -89,7 +87,7 @@ pub struct ProofRequest {
 
 /// Concrete proof request variant.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(tag = "proofType", content = "payload", rename_all = "snake_case")]
+#[serde(tag = "proof_type", content = "payload", rename_all = "snake_case")]
 pub enum ProofRequestKind {
     /// Request a compressed ZK proof.
     Compressed(ZkProofRequest),
@@ -101,7 +99,6 @@ pub enum ProofRequestKind {
 
 /// ZK proof request parameters.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
 pub struct ZkProofRequest {
     /// First L2 block number to prove.
     pub start_block_number: u64,
@@ -122,7 +119,6 @@ pub struct ZkProofRequest {
 
 /// Groth16 SNARK proof request parameters.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
 pub struct SnarkGroth16ProofRequest {
     /// Underlying ZK proof request.
     pub proof: ZkProofRequest,
@@ -132,33 +128,16 @@ pub struct SnarkGroth16ProofRequest {
 
 /// Trusted execution environment proof request parameters.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
 pub struct TeeProofRequest {
-    /// L1 head hash.
-    pub l1_head: B256,
-    /// Agreed L2 head block hash.
-    pub agreed_l2_head_hash: B256,
-    /// Agreed L2 output root.
-    pub agreed_l2_output_root: B256,
-    /// Claimed L2 output root.
-    pub claimed_l2_output_root: B256,
-    /// Claimed L2 block number.
-    pub claimed_l2_block_number: u64,
-    /// Proposal submitter address.
-    pub proposer: Address,
-    /// Intermediate block interval.
-    pub intermediate_block_interval: u64,
-    /// L1 head block number.
-    pub l1_head_number: u64,
-    /// TEE image hash.
-    pub image_hash: B256,
+    /// Underlying TEE proof request.
+    pub proof: PrimitiveProofRequest,
     /// Trusted execution environment implementation.
     pub tee_kind: TeeKind,
 }
 
 /// Proof result payload.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(tag = "proofType", content = "payload", rename_all = "snake_case")]
+#[serde(tag = "proof_type", content = "payload", rename_all = "snake_case")]
 pub enum ProofResult {
     /// Compressed ZK proof result.
     Compressed(ZkProofResult),
@@ -170,7 +149,6 @@ pub enum ProofResult {
 
 /// ZK proof result.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
 pub struct ZkProofResult {
     /// ZK virtual machine implementation that produced the proof.
     pub zk_vm: ZkVm,
@@ -180,7 +158,6 @@ pub struct ZkProofResult {
 
 /// Groth16 SNARK proof result.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
 pub struct SnarkGroth16ProofResult {
     /// Wrapped ZK proof result.
     pub proof: ZkProofResult,
@@ -188,40 +165,17 @@ pub struct SnarkGroth16ProofResult {
 
 /// TEE proof result.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
 pub struct TeeProofResult {
-    /// Aggregate proposal, if one was produced.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub aggregate_proposal: Option<TeeProposal>,
+    /// Aggregate proposal covering the entire proven block range.
+    pub aggregate_proposal: Proposal,
     /// Individual signed proposals.
-    pub proposals: Vec<TeeProposal>,
+    pub proposals: Vec<Proposal>,
     /// Trusted execution environment implementation that produced the proof.
     pub tee_kind: TeeKind,
 }
 
-/// Signed TEE proposal data.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct TeeProposal {
-    /// Output root.
-    pub output_root: B256,
-    /// Serialized signature bytes.
-    pub signature: Bytes,
-    /// L1 origin block hash.
-    pub l1_origin_hash: B256,
-    /// L1 origin block number.
-    pub l1_origin_number: u64,
-    /// L2 block number.
-    pub l2_block_number: u64,
-    /// Previous output root.
-    pub prev_output_root: B256,
-    /// Rollup config hash.
-    pub config_hash: B256,
-}
-
 /// Request to fetch proof status and result data.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
 pub struct GetProofRequest {
     /// Proof session identifier.
     pub session_id: String,
@@ -229,7 +183,6 @@ pub struct GetProofRequest {
 
 /// Proof status and result data.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
 pub struct GetProofResponse {
     /// Current proof status.
     pub status: ProofStatus,
@@ -243,7 +196,6 @@ pub struct GetProofResponse {
 
 /// Request to list submitted proofs.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
 pub struct ListProofsRequest {
     /// Number of rows to skip.
     pub offset: u64,
@@ -256,7 +208,6 @@ pub struct ListProofsRequest {
 
 /// Summary of a submitted proof request.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
 pub struct ProofSummary {
     /// Proof session identifier.
     pub session_id: String,
@@ -284,7 +235,6 @@ pub struct ProofSummary {
 
 /// Response containing proof summaries.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
 pub struct ListProofsResponse {
     /// Proof summaries.
     pub proofs: Vec<ProofSummary>,
@@ -294,7 +244,6 @@ pub struct ListProofsResponse {
 
 /// Worker-owned proof job.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
 pub struct ProofJob {
     /// Proof session identifier.
     pub session_id: String,
@@ -327,7 +276,6 @@ pub struct ProofJob {
 
 /// Request to claim the next available proof job.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
 pub struct GetNextProofRequest {
     /// Worker identifier.
     pub worker_id: String,
@@ -345,7 +293,6 @@ pub struct GetNextProofRequest {
 
 /// Response returned when a worker claims the next proof job.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
 pub struct GetNextProofResponse {
     /// Claimed proof job, if one was available.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -354,7 +301,6 @@ pub struct GetNextProofResponse {
 
 /// Request to extend a proof job lock.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
 pub struct HeartbeatRequest {
     /// Proof session identifier.
     pub session_id: String,
@@ -368,7 +314,6 @@ pub struct HeartbeatRequest {
 
 /// Response returned after a proof job heartbeat.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
 pub struct HeartbeatResponse {
     /// Updated proof job.
     pub job: ProofJob,
@@ -376,7 +321,6 @@ pub struct HeartbeatResponse {
 
 /// Request to submit a proof result for a proof job.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
 pub struct WorkerSubmitProofRequest {
     /// Proof session identifier.
     pub session_id: String,
@@ -390,7 +334,6 @@ pub struct WorkerSubmitProofRequest {
 
 /// Response returned after a worker proof submission.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
 pub struct WorkerSubmitProofResponse {
     /// Completed proof job.
     pub job: ProofJob,
@@ -398,7 +341,7 @@ pub struct WorkerSubmitProofResponse {
 
 #[cfg(test)]
 mod tests {
-    use alloy_primitives::address;
+    use alloy_primitives::{Bytes, address};
     use serde_json::json;
 
     use super::*;
@@ -425,15 +368,15 @@ mod tests {
             value,
             json!({
                 "proof": {
-                    "sessionId": "proof-session",
+                    "session_id": "proof-session",
                     "request": {
-                        "proofType": "compressed",
+                        "proof_type": "compressed",
                         "payload": {
-                            "startBlockNumber": 10,
-                            "numberOfBlocksToProve": 20,
-                            "l1Head": format!("{:#x}", B256::repeat_byte(0xab)),
-                            "intermediateRootInterval": 128,
-                            "zkVm": "sp1"
+                            "start_block_number": 10,
+                            "number_of_blocks_to_prove": 20,
+                            "l1_head": format!("{:#x}", B256::repeat_byte(0xab)),
+                            "intermediate_root_interval": 128,
+                            "zk_vm": "sp1"
                         }
                     }
                 }
@@ -444,6 +387,168 @@ mod tests {
     #[test]
     fn tee_request_uses_hex_encoded_fixed_values() {
         let request = TeeProofRequest {
+            proof: PrimitiveProofRequest {
+                l1_head: B256::repeat_byte(1),
+                agreed_l2_head_hash: B256::repeat_byte(2),
+                agreed_l2_output_root: B256::repeat_byte(3),
+                claimed_l2_output_root: B256::repeat_byte(4),
+                claimed_l2_block_number: 5,
+                proposer: address!("0000000000000000000000000000000000000006"),
+                intermediate_block_interval: 7,
+                l1_head_number: 8,
+                image_hash: B256::repeat_byte(9),
+            },
+            tee_kind: TeeKind::AwsNitro,
+        };
+
+        let value = serde_json::to_value(request).expect("tee request should serialize");
+
+        assert_eq!(
+            value,
+            json!({
+                "proof": {
+                    "l1_head": format!("{:#x}", B256::repeat_byte(1)),
+                    "agreed_l2_head_hash": format!("{:#x}", B256::repeat_byte(2)),
+                    "agreed_l2_output_root": format!("{:#x}", B256::repeat_byte(3)),
+                    "claimed_l2_output_root": format!("{:#x}", B256::repeat_byte(4)),
+                    "claimed_l2_block_number": 5,
+                    "proposer": "0x0000000000000000000000000000000000000006",
+                    "intermediate_block_interval": 7,
+                    "l1_head_number": 8,
+                    "image_hash": format!("{:#x}", B256::repeat_byte(9)),
+                },
+                "tee_kind": "aws_nitro",
+            })
+        );
+    }
+
+    #[test]
+    fn tee_request_requires_tee_kind() {
+        let result = serde_json::from_value::<TeeProofRequest>(json!({
+            "proof": {
+                "l1_head": format!("{:#x}", B256::repeat_byte(1)),
+                "agreed_l2_head_hash": format!("{:#x}", B256::repeat_byte(2)),
+                "agreed_l2_output_root": format!("{:#x}", B256::repeat_byte(3)),
+                "claimed_l2_output_root": format!("{:#x}", B256::repeat_byte(4)),
+                "claimed_l2_block_number": 5,
+                "proposer": "0x0000000000000000000000000000000000000006",
+                "intermediate_block_interval": 7,
+                "l1_head_number": 8,
+                "image_hash": format!("{:#x}", B256::repeat_byte(9)),
+            }
+        }));
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn tee_request_rejects_flat_shape() {
+        let result = serde_json::from_value::<TeeProofRequest>(json!({
+            "l1_head": format!("{:#x}", B256::repeat_byte(1)),
+            "agreed_l2_head_hash": format!("{:#x}", B256::repeat_byte(2)),
+            "agreed_l2_output_root": format!("{:#x}", B256::repeat_byte(3)),
+            "claimed_l2_output_root": format!("{:#x}", B256::repeat_byte(4)),
+            "claimed_l2_block_number": 5,
+            "proposer": "0x0000000000000000000000000000000000000006",
+            "intermediate_block_interval": 7,
+            "l1_head_number": 8,
+            "image_hash": format!("{:#x}", B256::repeat_byte(9)),
+            "tee_kind": "aws_nitro"
+        }));
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn tee_result_uses_flat_proposal_shape() {
+        let aggregate_proposal = tee_proposal(1, 20);
+        let proposal = tee_proposal(2, 19);
+        let result = ProofResult::Tee(TeeProofResult {
+            aggregate_proposal: aggregate_proposal.clone(),
+            proposals: vec![proposal.clone()],
+            tee_kind: TeeKind::AwsNitro,
+        });
+
+        let value = serde_json::to_value(result).expect("tee result should serialize");
+
+        assert_eq!(value["proof_type"], json!("tee"));
+        assert_eq!(value["payload"]["tee_kind"], json!("aws_nitro"));
+        assert_eq!(
+            value["payload"]["aggregate_proposal"],
+            json!({
+                "output_root": format!("{:#x}", aggregate_proposal.output_root),
+                "signature": "0x010101",
+                "l1_origin_hash": format!("{:#x}", aggregate_proposal.l1_origin_hash),
+                "l1_origin_number": aggregate_proposal.l1_origin_number,
+                "l2_block_number": aggregate_proposal.l2_block_number,
+                "prev_output_root": format!("{:#x}", aggregate_proposal.prev_output_root),
+                "config_hash": format!("{:#x}", aggregate_proposal.config_hash),
+            })
+        );
+        assert_eq!(
+            value["payload"]["proposals"][0],
+            json!({
+                "output_root": format!("{:#x}", proposal.output_root),
+                "signature": "0x020202",
+                "l1_origin_hash": format!("{:#x}", proposal.l1_origin_hash),
+                "l1_origin_number": proposal.l1_origin_number,
+                "l2_block_number": proposal.l2_block_number,
+                "prev_output_root": format!("{:#x}", proposal.prev_output_root),
+                "config_hash": format!("{:#x}", proposal.config_hash),
+            })
+        );
+    }
+
+    #[test]
+    fn tee_result_rejects_nested_proof_shape() {
+        let aggregate_proposal = tee_proposal(1, 20);
+        let result = serde_json::from_value::<ProofResult>(json!({
+            "proof_type": "tee",
+            "payload": {
+                "proof": {
+                    "aggregate_proposal": {
+                        "output_root": format!("{:#x}", aggregate_proposal.output_root),
+                        "signature": "0x010101",
+                        "l1_origin_hash": format!("{:#x}", aggregate_proposal.l1_origin_hash),
+                        "l1_origin_number": aggregate_proposal.l1_origin_number,
+                        "l2_block_number": aggregate_proposal.l2_block_number,
+                        "prev_output_root": format!("{:#x}", aggregate_proposal.prev_output_root),
+                        "config_hash": format!("{:#x}", aggregate_proposal.config_hash),
+                    },
+                    "proposals": []
+                },
+                "tee_kind": "aws_nitro"
+            }
+        }));
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn tee_result_requires_aggregate_proposal() {
+        let proposal = tee_proposal(2, 19);
+        let result = serde_json::from_value::<ProofResult>(json!({
+            "proof_type": "tee",
+            "payload": {
+                "proposals": [{
+                    "output_root": format!("{:#x}", proposal.output_root),
+                    "signature": "0x020202",
+                    "l1_origin_hash": format!("{:#x}", proposal.l1_origin_hash),
+                    "l1_origin_number": proposal.l1_origin_number,
+                    "l2_block_number": proposal.l2_block_number,
+                    "prev_output_root": format!("{:#x}", proposal.prev_output_root),
+                    "config_hash": format!("{:#x}", proposal.config_hash),
+                }],
+                "tee_kind": "aws_nitro"
+            }
+        }));
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn tee_proof_payload_uses_hex_encoded_fixed_values() {
+        let request = PrimitiveProofRequest {
             l1_head: B256::repeat_byte(1),
             agreed_l2_head_hash: B256::repeat_byte(2),
             agreed_l2_output_root: B256::repeat_byte(3),
@@ -453,22 +558,70 @@ mod tests {
             intermediate_block_interval: 7,
             l1_head_number: 8,
             image_hash: B256::repeat_byte(9),
+        };
+
+        let value = serde_json::to_value(request).expect("tee request payload should serialize");
+
+        assert_eq!(
+            value,
+            json!({
+                "l1_head": format!("{:#x}", B256::repeat_byte(1)),
+                "agreed_l2_head_hash": format!("{:#x}", B256::repeat_byte(2)),
+                "agreed_l2_output_root": format!("{:#x}", B256::repeat_byte(3)),
+                "claimed_l2_output_root": format!("{:#x}", B256::repeat_byte(4)),
+                "claimed_l2_block_number": 5,
+                "proposer": "0x0000000000000000000000000000000000000006",
+                "intermediate_block_interval": 7,
+                "l1_head_number": 8,
+                "image_hash": format!("{:#x}", B256::repeat_byte(9)),
+            })
+        );
+    }
+
+    #[test]
+    fn tee_proposal_uses_hex_encoded_fixed_values() {
+        let aggregate_proposal = tee_proposal(1, 20);
+        let proposal = tee_proposal(2, 19);
+        let result = TeeProofResult {
+            aggregate_proposal: aggregate_proposal.clone(),
+            proposals: vec![proposal.clone()],
             tee_kind: TeeKind::AwsNitro,
         };
 
-        let value = serde_json::to_value(request).expect("tee request should serialize");
+        let value = serde_json::to_value(result).expect("tee result payload should serialize");
 
-        assert_eq!(value["l1Head"], json!(format!("{:#x}", B256::repeat_byte(1))));
-        assert_eq!(value["proposer"], json!("0x0000000000000000000000000000000000000006"));
-        assert_eq!(value["teeKind"], json!("aws_nitro"));
+        assert_eq!(
+            value["aggregate_proposal"],
+            json!({
+                "output_root": format!("{:#x}", aggregate_proposal.output_root),
+                "signature": "0x010101",
+                "l1_origin_hash": format!("{:#x}", aggregate_proposal.l1_origin_hash),
+                "l1_origin_number": aggregate_proposal.l1_origin_number,
+                "l2_block_number": aggregate_proposal.l2_block_number,
+                "prev_output_root": format!("{:#x}", aggregate_proposal.prev_output_root),
+                "config_hash": format!("{:#x}", aggregate_proposal.config_hash),
+            })
+        );
+        assert_eq!(
+            value["proposals"][0],
+            json!({
+                "output_root": format!("{:#x}", proposal.output_root),
+                "signature": "0x020202",
+                "l1_origin_hash": format!("{:#x}", proposal.l1_origin_hash),
+                "l1_origin_number": proposal.l1_origin_number,
+                "l2_block_number": proposal.l2_block_number,
+                "prev_output_root": format!("{:#x}", proposal.prev_output_root),
+                "config_hash": format!("{:#x}", proposal.config_hash),
+            })
+        );
     }
 
     #[test]
     fn omitted_optional_fields_deserialize_to_none() {
         let request: ZkProofRequest = serde_json::from_value(json!({
-            "startBlockNumber": 10,
-            "numberOfBlocksToProve": 20,
-            "zkVm": "sp1"
+            "start_block_number": 10,
+            "number_of_blocks_to_prove": 20,
+            "zk_vm": "sp1"
         }))
         .expect("zk request should accept omitted optional fields");
 
@@ -488,10 +641,10 @@ mod tests {
     #[test]
     fn zk_l1_head_rejects_malformed_hash() {
         let result = serde_json::from_value::<ZkProofRequest>(json!({
-            "startBlockNumber": 10,
-            "numberOfBlocksToProve": 20,
-            "l1Head": "0xabc",
-            "zkVm": "sp1"
+            "start_block_number": 10,
+            "number_of_blocks_to_prove": 20,
+            "l1_head": "0xabc",
+            "zk_vm": "sp1"
         }));
 
         assert!(result.is_err());
@@ -512,11 +665,11 @@ mod tests {
         assert_eq!(
             value,
             json!({
-                "workerId": "worker-1",
-                "proofType": "compressed",
-                "teeKinds": [],
-                "zkVms": ["sp1"],
-                "lockDurationSeconds": 30
+                "worker_id": "worker-1",
+                "proof_type": "compressed",
+                "tee_kinds": [],
+                "zk_vms": ["sp1"],
+                "lock_duration_seconds": 30
             })
         );
     }
@@ -524,9 +677,9 @@ mod tests {
     #[test]
     fn get_next_proof_request_defaults_omitted_capability_lists() {
         let request: GetNextProofRequest = serde_json::from_value(json!({
-            "workerId": "worker-1",
-            "proofType": "compressed",
-            "lockDurationSeconds": 30
+            "worker_id": "worker-1",
+            "proof_type": "compressed",
+            "lock_duration_seconds": 30
         }))
         .expect("get next proof request should accept omitted capability lists");
 
@@ -544,12 +697,12 @@ mod tests {
         };
 
         let heartbeat_value = serde_json::to_value(heartbeat).expect("heartbeat should serialize");
-        assert_eq!(heartbeat_value["lockId"], json!("lock-1"));
+        assert_eq!(heartbeat_value["lock_id"], json!("lock-1"));
         assert!(
             serde_json::from_value::<HeartbeatRequest>(json!({
-                "sessionId": "session-1",
-                "workerId": "worker-1",
-                "lockDurationSeconds": 30,
+                "session_id": "session-1",
+                "worker_id": "worker-1",
+                "lock_duration_seconds": 30,
             }))
             .is_err()
         );
@@ -565,20 +718,32 @@ mod tests {
         };
 
         let submit_value = serde_json::to_value(submit).expect("submit should serialize");
-        assert_eq!(submit_value["lockId"], json!("lock-1"));
+        assert_eq!(submit_value["lock_id"], json!("lock-1"));
         assert!(
             serde_json::from_value::<WorkerSubmitProofRequest>(json!({
-                "sessionId": "session-1",
-                "workerId": "worker-1",
+                "session_id": "session-1",
+                "worker_id": "worker-1",
                 "result": {
-                    "proofType": "compressed",
+                    "proof_type": "compressed",
                     "payload": {
-                        "zkVm": "sp1",
+                        "zk_vm": "sp1",
                         "proof": "0x010203"
                     }
                 }
             }))
             .is_err()
         );
+    }
+
+    fn tee_proposal(byte: u8, l2_block_number: u64) -> Proposal {
+        Proposal {
+            output_root: B256::repeat_byte(byte),
+            signature: Bytes::from(vec![byte; 3]),
+            l1_origin_hash: B256::repeat_byte(byte + 1),
+            l1_origin_number: u64::from(byte) + 100,
+            l2_block_number,
+            prev_output_root: B256::repeat_byte(byte + 2),
+            config_hash: B256::repeat_byte(byte + 3),
+        }
     }
 }

--- a/crates/proof/prover-service/tests/common/mod.rs
+++ b/crates/proof/prover-service/tests/common/mod.rs
@@ -2,6 +2,7 @@
 
 use alloy_primitives::{Address, B256};
 use anyhow::{Context, Result, bail};
+use base_proof_primitives::ProofRequest as PrimitiveProofRequest;
 pub(crate) use base_prover_service::ProveBlockRequest;
 use base_prover_service_protocol::{
     ProofRequest, ProofRequestKind, ProveBlockRangeRequest, ProveBlockRangeResponse,
@@ -55,15 +56,17 @@ fn to_prove_block_range_request(request: ProveBlockRequest) -> Result<ProveBlock
             ProofRequestKind::SnarkGroth16(SnarkGroth16ProofRequest { proof, prover_address })
         }
         -1 => ProofRequestKind::Tee(TeeProofRequest {
-            l1_head: B256::ZERO,
-            agreed_l2_head_hash: B256::ZERO,
-            agreed_l2_output_root: B256::ZERO,
-            claimed_l2_output_root: B256::ZERO,
-            claimed_l2_block_number: 0,
-            proposer: Address::ZERO,
-            intermediate_block_interval: 0,
-            l1_head_number: 0,
-            image_hash: B256::ZERO,
+            proof: PrimitiveProofRequest {
+                l1_head: B256::ZERO,
+                agreed_l2_head_hash: B256::ZERO,
+                agreed_l2_output_root: B256::ZERO,
+                claimed_l2_output_root: B256::ZERO,
+                claimed_l2_block_number: 0,
+                proposer: Address::ZERO,
+                intermediate_block_interval: 0,
+                l1_head_number: 0,
+                image_hash: B256::ZERO,
+            },
             tee_kind: TeeKind::AwsNitro,
         }),
         proof_type => bail!("invalid proof_type {proof_type}"),


### PR DESCRIPTION
Summary:
- Switch prover-service protocol JSON fields to snake_case.
- Reuse base-proof-primitives proof request/proposal types for TEE payloads.
- Add protocol serialization/rejection coverage for the new TEE shapes.