### PR TITLE
docs: add macOS x86_64 Intel to supported targets

### DIFF
--- a/baseup/README.md
+++ b/baseup/README.md
@@ -49,8 +49,8 @@ Use `--unsafe-skip-verify` only for local testing; checksum verification is stil
 
 `baseup` matches the release workflow in this repo:
 
-- Linux: `x86_64`, `arm64`
-- macOS: Apple Silicon (`arm64`)
+* Linux: `x86_64`, `arm64`
+* macOS: `x86_64` (Intel), `arm64` (Apple Silicon)
 
 ## Installation Directory
 


### PR DESCRIPTION
Added missing macOS x86_64 (Intel) entry to the Supported Targets 
section in baseup/README.md. Intel Mac users were not listed, which 
could cause confusion about whether baseup supports their machine.