### PR TITLE
feat(nitro-host): add worker config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5718,6 +5718,7 @@ dependencies = [
  "base-proof-preimage",
  "base-proof-primitives",
  "base-proof-tee-nitro-enclave",
+ "base-prover-service-client",
  "eyre",
  "jsonrpsee",
  "k256",

--- a/crates/proof/prover-service/client/src/config.rs
+++ b/crates/proof/prover-service/client/src/config.rs
@@ -2,11 +2,50 @@
 
 use std::time::Duration;
 
-use jsonrpsee::http_client::{HttpClient, HttpClientBuilder};
+use jsonrpsee::{
+    core::client::Error as JsonRpcClientError,
+    http_client::{HttpClient, HttpClientBuilder},
+};
+use thiserror::Error;
 use tracing::debug;
 use url::Url;
 
-use crate::ProverServiceClientError;
+/// Errors that can occur during prover-service client configuration validation.
+#[derive(Clone, Debug, Error, Eq, PartialEq)]
+pub enum ProverServiceClientConfigError {
+    /// The configured endpoint URL cannot be parsed.
+    #[error("endpoint URL is invalid: {0}")]
+    InvalidEndpointUrl(String),
+    /// The configured endpoint URL uses an unsupported scheme.
+    #[error("endpoint URL scheme must be http or https")]
+    InvalidEndpointScheme,
+    /// The configured endpoint URL does not include a host.
+    #[error("endpoint URL must include a host")]
+    MissingEndpointHost,
+    /// The configured request timeout is zero.
+    #[error("request timeout must be greater than zero")]
+    ZeroRequestTimeout,
+    /// The configured poll interval is zero.
+    #[error("poll interval must be greater than zero")]
+    ZeroPollInterval,
+    /// The configured maximum wait duration is zero.
+    #[error("max wait must be greater than zero")]
+    ZeroMaxWait,
+    /// The configured poll interval is greater than the maximum wait duration.
+    #[error("poll interval must be less than or equal to max wait")]
+    PollIntervalExceedsMaxWait,
+}
+
+/// Errors that can occur when building a prover-service client.
+#[derive(Debug, Error)]
+pub enum ProverServiceClientBuildError {
+    /// The client configuration is invalid.
+    #[error("invalid prover-service client config: {0}")]
+    InvalidConfig(#[from] ProverServiceClientConfigError),
+    /// A JSON-RPC client, server, or transport error occurred.
+    #[error("prover-service RPC/transport failure: {0}")]
+    RpcTransport(#[from] JsonRpcClientError),
+}
 
 /// Configuration shared by prover-service client roles.
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -76,58 +115,45 @@ impl ProverServiceClientConfig {
     }
 
     /// Validate the endpoint and duration fields.
-    pub fn validate(&self) -> Result<(), ProverServiceClientError> {
-        let endpoint = Url::parse(&self.endpoint).map_err(|err| {
-            ProverServiceClientError::InvalidConfig(format!("endpoint URL is invalid: {err}"))
-        })?;
+    pub fn validate(&self) -> Result<(), ProverServiceClientConfigError> {
+        let endpoint = Url::parse(&self.endpoint)
+            .map_err(|err| ProverServiceClientConfigError::InvalidEndpointUrl(err.to_string()))?;
 
         if !matches!(endpoint.scheme(), "http" | "https") {
-            return Err(ProverServiceClientError::InvalidConfig(
-                "endpoint URL scheme must be http or https".to_owned(),
-            ));
+            return Err(ProverServiceClientConfigError::InvalidEndpointScheme);
         }
 
         if endpoint.host().is_none() {
-            return Err(ProverServiceClientError::InvalidConfig(
-                "endpoint URL must include a host".to_owned(),
-            ));
+            return Err(ProverServiceClientConfigError::MissingEndpointHost);
         }
 
         if self.request_timeout.is_zero() {
-            return Err(ProverServiceClientError::InvalidConfig(
-                "request timeout must be greater than zero".to_owned(),
-            ));
+            return Err(ProverServiceClientConfigError::ZeroRequestTimeout);
         }
 
         if self.poll_interval.is_zero() {
-            return Err(ProverServiceClientError::InvalidConfig(
-                "poll interval must be greater than zero".to_owned(),
-            ));
+            return Err(ProverServiceClientConfigError::ZeroPollInterval);
         }
 
         if self.max_wait.is_zero() {
-            return Err(ProverServiceClientError::InvalidConfig(
-                "max wait must be greater than zero".to_owned(),
-            ));
+            return Err(ProverServiceClientConfigError::ZeroMaxWait);
         }
 
         if self.poll_interval > self.max_wait {
-            return Err(ProverServiceClientError::InvalidConfig(
-                "poll interval must be less than or equal to max wait".to_owned(),
-            ));
+            return Err(ProverServiceClientConfigError::PollIntervalExceedsMaxWait);
         }
 
         Ok(())
     }
 
     /// Build a JSON-RPC HTTP client from this configuration.
-    pub fn build_http_client(&self) -> Result<HttpClient, ProverServiceClientError> {
+    pub fn build_http_client(&self) -> Result<HttpClient, ProverServiceClientBuildError> {
         self.validate()?;
 
         let builder = HttpClientBuilder::default().request_timeout(self.request_timeout);
 
         debug!(endpoint = %self.endpoint, "building prover-service client");
-        builder.build(&self.endpoint).map_err(ProverServiceClientError::from)
+        builder.build(&self.endpoint).map_err(ProverServiceClientBuildError::from)
     }
 }
 
@@ -206,8 +232,6 @@ mod tests {
 
         let err = config.validate().expect_err("invalid config should fail validation");
 
-        assert!(
-            matches!(err, ProverServiceClientError::InvalidConfig(message) if message.contains(expected_message))
-        );
+        assert!(err.to_string().contains(expected_message));
     }
 }

--- a/crates/proof/prover-service/client/src/error.rs
+++ b/crates/proof/prover-service/client/src/error.rs
@@ -3,13 +3,9 @@
 use jsonrpsee::{core::client::Error as JsonRpcClientError, types::ErrorCode};
 use thiserror::Error;
 
-/// Errors that can occur when constructing or using prover-service clients.
+/// Errors that can occur when using prover-service clients.
 #[derive(Debug, Error)]
 pub enum ProverServiceClientError {
-    /// The client configuration is invalid.
-    #[error("invalid prover-service client config: {0}")]
-    InvalidConfig(String),
-
     /// A JSON-RPC client, server, or transport error occurred.
     #[error("prover-service RPC/transport failure: {0}")]
     RpcTransport(#[from] JsonRpcClientError),
@@ -57,8 +53,7 @@ impl ProverServiceClientError {
         match self {
             Self::RpcTransport(err) => Self::is_retryable_rpc_error(err),
             Self::Timeout(_) => true,
-            Self::InvalidConfig(_)
-            | Self::ProofFailure { .. }
+            Self::ProofFailure { .. }
             | Self::WorkerLeaseRejected { .. }
             | Self::MissingResult(_)
             | Self::UnexpectedResultPayload(_) => false,
@@ -116,10 +111,6 @@ mod tests {
         true
     )]
     #[case::timeout(ProverServiceClientError::Timeout("proof not ready".to_owned()), true)]
-    #[case::invalid_config(
-        ProverServiceClientError::InvalidConfig("endpoint URL must include a host".to_owned()),
-        false
-    )]
     #[case::proof_failure(
         ProverServiceClientError::ProofFailure { message: "proof failed".to_owned() },
         false

--- a/crates/proof/prover-service/client/src/lib.rs
+++ b/crates/proof/prover-service/client/src/lib.rs
@@ -1,7 +1,9 @@
 #![doc = include_str!("../README.md")]
 
 mod config;
-pub use config::ProverServiceClientConfig;
+pub use config::{
+    ProverServiceClientBuildError, ProverServiceClientConfig, ProverServiceClientConfigError,
+};
 
 mod error;
 pub use error::ProverServiceClientError;

--- a/crates/proof/prover-service/client/src/requester.rs
+++ b/crates/proof/prover-service/client/src/requester.rs
@@ -8,7 +8,7 @@ use base_prover_service_protocol::{
 use jsonrpsee::http_client::HttpClient;
 use tracing::debug;
 
-use crate::{ProverServiceClientConfig, ProverServiceClientError};
+use crate::{ProverServiceClientBuildError, ProverServiceClientConfig, ProverServiceClientError};
 
 /// Abstraction over proof requester JSON-RPC methods.
 ///
@@ -50,7 +50,9 @@ impl ProofRequesterClient {
     }
 
     /// Connect a requester client using the provided configuration.
-    pub fn connect(config: &ProverServiceClientConfig) -> Result<Self, ProverServiceClientError> {
+    pub fn connect(
+        config: &ProverServiceClientConfig,
+    ) -> Result<Self, ProverServiceClientBuildError> {
         Ok(Self::new(config.build_http_client()?))
     }
 

--- a/crates/proof/prover-service/client/src/worker.rs
+++ b/crates/proof/prover-service/client/src/worker.rs
@@ -8,7 +8,7 @@ use base_prover_service_protocol::{
 use jsonrpsee::http_client::HttpClient;
 use tracing::debug;
 
-use crate::{ProverServiceClientConfig, ProverServiceClientError};
+use crate::{ProverServiceClientBuildError, ProverServiceClientConfig, ProverServiceClientError};
 
 /// Abstraction over prover worker JSON-RPC methods.
 ///
@@ -49,7 +49,9 @@ impl ProverWorkerClient {
     }
 
     /// Connect a worker client using the provided configuration.
-    pub fn connect(config: &ProverServiceClientConfig) -> Result<Self, ProverServiceClientError> {
+    pub fn connect(
+        config: &ProverServiceClientConfig,
+    ) -> Result<Self, ProverServiceClientBuildError> {
         Ok(Self::new(config.build_http_client()?))
     }
 

--- a/crates/proof/tee/nitro-host/Cargo.toml
+++ b/crates/proof/tee/nitro-host/Cargo.toml
@@ -17,6 +17,7 @@ base-health.workspace = true
 base-proof-host.workspace = true
 base-proof-preimage.workspace = true
 base-proof-contracts.workspace = true
+base-prover-service-client.workspace = true
 base-proof-tee-nitro-enclave.workspace = true
 base-proof-primitives = { workspace = true, features = ["std", "serde", "rpc-server"] }
 

--- a/crates/proof/tee/nitro-host/src/config.rs
+++ b/crates/proof/tee/nitro-host/src/config.rs
@@ -1,6 +1,15 @@
 //! Worker configuration for the nitro prover host.
 
 use base_prover_service_client::{ProverServiceClientConfig, ProverServiceClientError};
+use thiserror::Error;
+
+/// Errors that can occur during nitro worker configuration validation.
+#[derive(Debug, Error, Eq, PartialEq)]
+pub enum ConfigError {
+    /// Invalid prover-service client configuration.
+    #[error("invalid prover-service client config: {0}")]
+    InvalidProverService(String),
+}
 
 /// Configuration for a nitro prover worker.
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -16,8 +25,13 @@ impl NitroWorkerConfig {
     }
 
     /// Validate the worker configuration.
-    pub fn validate(&self) -> Result<(), ProverServiceClientError> {
-        self.prover_service.validate()
+    pub fn validate(&self) -> Result<(), ConfigError> {
+        self.prover_service.validate().map_err(|err| match err {
+            ProverServiceClientError::InvalidConfig(message) => {
+                ConfigError::InvalidProverService(message)
+            }
+            err => ConfigError::InvalidProverService(err.to_string()),
+        })
     }
 }
 
@@ -42,7 +56,7 @@ mod tests {
         let err = config.validate().expect_err("invalid endpoint should fail validation");
 
         assert!(
-            matches!(err, ProverServiceClientError::InvalidConfig(message) if message.contains("scheme"))
+            matches!(err, ConfigError::InvalidProverService(message) if message.contains("scheme"))
         );
     }
 }

--- a/crates/proof/tee/nitro-host/src/config.rs
+++ b/crates/proof/tee/nitro-host/src/config.rs
@@ -1,0 +1,48 @@
+//! Worker configuration for the nitro prover host.
+
+use base_prover_service_client::{ProverServiceClientConfig, ProverServiceClientError};
+
+/// Configuration for a nitro prover worker.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct NitroWorkerConfig {
+    /// Prover-service client configuration.
+    pub prover_service: ProverServiceClientConfig,
+}
+
+impl NitroWorkerConfig {
+    /// Create a nitro worker configuration.
+    pub const fn new(prover_service: ProverServiceClientConfig) -> Self {
+        Self { prover_service }
+    }
+
+    /// Validate the worker configuration.
+    pub fn validate(&self) -> Result<(), ProverServiceClientError> {
+        self.prover_service.validate()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validation_accepts_valid_prover_service_endpoint() {
+        let config =
+            NitroWorkerConfig::new(ProverServiceClientConfig::new("http://localhost:8545"));
+
+        config.validate().expect("valid endpoint should pass validation");
+    }
+
+    #[test]
+    fn validation_rejects_invalid_prover_service_endpoint() {
+        let config = NitroWorkerConfig::new(ProverServiceClientConfig::new(
+            "file:///tmp/prover-service.sock",
+        ));
+
+        let err = config.validate().expect_err("invalid endpoint should fail validation");
+
+        assert!(
+            matches!(err, ProverServiceClientError::InvalidConfig(message) if message.contains("scheme"))
+        );
+    }
+}

--- a/crates/proof/tee/nitro-host/src/config.rs
+++ b/crates/proof/tee/nitro-host/src/config.rs
@@ -1,6 +1,6 @@
 //! Worker configuration for the nitro prover host.
 
-use base_prover_service_client::{ProverServiceClientConfig, ProverServiceClientError};
+use base_prover_service_client::{ProverServiceClientConfig, ProverServiceClientConfigError};
 use thiserror::Error;
 
 /// Errors that can occur during nitro worker configuration validation.
@@ -8,7 +8,7 @@ use thiserror::Error;
 pub enum ConfigError {
     /// Invalid prover-service client configuration.
     #[error("invalid prover-service client config: {0}")]
-    InvalidProverService(String),
+    InvalidProverService(#[from] ProverServiceClientConfigError),
 }
 
 /// Configuration for a nitro prover worker.
@@ -26,12 +26,7 @@ impl NitroWorkerConfig {
 
     /// Validate the worker configuration.
     pub fn validate(&self) -> Result<(), ConfigError> {
-        self.prover_service.validate().map_err(|err| match err {
-            ProverServiceClientError::InvalidConfig(message) => {
-                ConfigError::InvalidProverService(message)
-            }
-            err => ConfigError::InvalidProverService(err.to_string()),
-        })
+        self.prover_service.validate().map_err(ConfigError::from)
     }
 }
 
@@ -55,8 +50,11 @@ mod tests {
 
         let err = config.validate().expect_err("invalid endpoint should fail validation");
 
-        assert!(
-            matches!(err, ConfigError::InvalidProverService(message) if message.contains("scheme"))
-        );
+        assert!(matches!(
+            err,
+            ConfigError::InvalidProverService(
+                ProverServiceClientConfigError::InvalidEndpointScheme
+            )
+        ));
     }
 }

--- a/crates/proof/tee/nitro-host/src/lib.rs
+++ b/crates/proof/tee/nitro-host/src/lib.rs
@@ -4,7 +4,7 @@ mod error;
 pub use error::NitroHostError;
 
 mod config;
-pub use config::NitroWorkerConfig;
+pub use config::{ConfigError, NitroWorkerConfig};
 
 mod backend;
 pub use backend::NitroBackend;

--- a/crates/proof/tee/nitro-host/src/lib.rs
+++ b/crates/proof/tee/nitro-host/src/lib.rs
@@ -3,6 +3,9 @@
 mod error;
 pub use error::NitroHostError;
 
+mod config;
+pub use config::NitroWorkerConfig;
+
 mod backend;
 pub use backend::NitroBackend;
 


### PR DESCRIPTION
### What changed? Why?

- Add `NitroWorkerConfig` to the nitro host crate so worker configuration can carry prover-service client settings.
- Validate nitro worker config by delegating to `ProverServiceClientConfig`, keeping endpoint and duration checks centralized.
- Split prover-service client configuration/build failures into typed `ProverServiceClientConfigError` and `ProverServiceClientBuildError` variants, leaving `ProverServiceClientError` focused on runtime RPC/proof failures.
- Update requester and worker `connect` APIs to return the build error type, and re-export the new config/build error types from the prover-service client crate.

### Notes to reviewers

- `ProverServiceClientError::InvalidConfig` was removed in favor of typed configuration errors. Callers that handle client construction failures should switch to `ProverServiceClientBuildError`.
- `base-proof-tee-nitro-host` now depends on `base-prover-service-client` for the shared client config type.

### How has it been tested?

- `cargo test -p base-proof-tee-nitro-host -p base-prover-service-client`