### PR TITLE
fix(balance-monitor): use send_if_modified and biased select for cancellation

### DIFF
--- a/crates/utilities/balance-monitor/src/monitor.rs
+++ b/crates/utilities/balance-monitor/src/monitor.rs
@@ -110,12 +110,35 @@ where
             interval.tick().await;
             loop {
                 tokio::select! {
+                    // Prioritise cancellation: if both the cancel token and a
+                    // tick fire simultaneously, always exit rather than
+                    // performing one more RPC call.  Mirrors the `biased;`
+                    // pattern used in SafeHeadPoller.
+                    biased;
                     () = cancel.cancelled() => break,
                     _ = interval.tick() => {
                         match provider.get_balance(address).await {
                             Ok(bal) => {
-                                let _ = tx.send(bal);
-                                debug!(balance = %bal, address = %address, "recorded account balance");
+                                // Only wake receivers when the balance actually
+                                // changes.  Using `send` unconditionally woke
+                                // every downstream metric writer and watcher on
+                                // every poll tick even when nothing had changed,
+                                // causing spurious metric updates.
+                                // `send_if_modified` returns true only when the
+                                // value is new, matching the SafeHeadPoller pattern.
+                                let changed = tx.send_if_modified(|prev| {
+                                    if *prev != bal {
+                                        *prev = bal;
+                                        true
+                                    } else {
+                                        false
+                                    }
+                                });
+                                if changed {
+                                    debug!(balance = %bal, address = %address, "balance changed");
+                                } else {
+                                    debug!(address = %address, "balance unchanged");
+                                }
                             }
                             Err(e) => {
                                 warn!(error = %e, address = %address, "failed to fetch account balance");


### PR DESCRIPTION
## Summary

Fixes two bugs in `BalanceMonitorLayer`'s background polling task (`crates/utilities/balance-monitor/src/monitor.rs`).

---

### Bug 1 — Spurious receiver wakeups: `send` instead of `send_if_modified`

The poll loop called `tx.send(bal)` on every tick, unconditionally waking all receivers even when the balance had not changed:

```rust
// before
let _ = tx.send(bal);  // always wakes every downstream watcher
```

`watch::Sender::send` notifies all subscribers on every call regardless of whether the value changed. Every metric writer and status reporter subscribed to this channel was being woken every 12 seconds (one L1 block) even during periods of no balance movement.

The fix uses `send_if_modified`, which only marks the channel as changed and wakes receivers when the new value actually differs from the stored value — identical to the pattern used in `SafeHeadPoller`:

```rust
// after
let changed = tx.send_if_modified(|prev| {
    if *prev != bal { *prev = bal; true } else { false }
});
```

---

### Bug 2 — Cancellation not prioritised in `tokio::select!`

Without `biased;`, when both the cancellation token and an interval tick fire simultaneously `tokio::select!` chooses an arm pseudo-randomly. This can delay shutdown by one additional polling cycle — one unnecessary `get_balance` RPC call plus up to one `poll_interval` (12 s) before the task exits.

`SafeHeadPoller::run` already uses `biased;` to prioritise its cancellation arm. The balance monitor should match:

```rust
// after
tokio::select! {
    biased;
    () = cancel.cancelled() => break,
    _ = interval.tick() => { ... }
}
```
