### PR TITLE
fix(precompiles): guard PolicyRegistry counter at COUNTER_MASK [BOP-206]

### DIFF
--- a/crates/common/precompiles/src/policy/storage.rs
+++ b/crates/common/precompiles/src/policy/storage.rs
@@ -202,9 +202,8 @@ impl PolicyRegistryStorage<'_> {
         self.write_builtins()?;
 
         let counter = self.next_counter()?;
-        // Guard at COUNTER_MASK rather than u64::MAX: make_id masks the counter to 56 bits,
-        // so values above COUNTER_MASK would alias back to existing policy IDs.
-        if counter >= Self::COUNTER_MASK {
+        let is_counter_overflowed = counter >= Self::COUNTER_MASK;
+        if is_counter_overflowed {
             return Err(BasePrecompileError::under_overflow());
         }
         self.next_counter.write(counter + 1)?;

--- a/crates/common/precompiles/src/policy/storage.rs
+++ b/crates/common/precompiles/src/policy/storage.rs
@@ -202,8 +202,12 @@ impl PolicyRegistryStorage<'_> {
         self.write_builtins()?;
 
         let counter = self.next_counter()?;
-        let next = counter.checked_add(1).ok_or_else(BasePrecompileError::under_overflow)?;
-        self.next_counter.write(next)?;
+        // Guard at COUNTER_MASK rather than u64::MAX: make_id masks the counter to 56 bits,
+        // so values above COUNTER_MASK would alias back to existing policy IDs.
+        if counter >= Self::COUNTER_MASK {
+            return Err(BasePrecompileError::under_overflow());
+        }
+        self.next_counter.write(counter + 1)?;
         let policy_id = Self::make_id(policy_type_u8, counter);
         self.policies.at_mut(&policy_id).write(PackedPolicy::new(admin).into_u256())?;
 
@@ -773,6 +777,49 @@ mod tests {
         assert_eq!((id2 >> 56) as u8, PolicyType::BLOCKLIST as u8);
         assert_eq!(id1 & PolicyRegistryStorage::COUNTER_MASK, 2);
         assert_eq!(id2 & PolicyRegistryStorage::COUNTER_MASK, 3);
+    }
+
+    #[test]
+    fn create_policy_at_counter_mask_reverts_with_under_overflow() {
+        // Seed next_counter at COUNTER_MASK. Any further create would produce a
+        // policy_id whose low 56 bits alias an existing ID, so the guard must fire.
+        let mut s = storage();
+        StorageCtx::enter(&mut s, |ctx| {
+            PolicyRegistryStorage::new(ctx).next_counter.write(PolicyRegistryStorage::COUNTER_MASK)
+        })
+        .unwrap();
+        let err = StorageCtx::enter(&mut s, |ctx| {
+            PolicyRegistryStorage::new(ctx).create_policy(ADMIN, PolicyType::ALLOWLIST)
+        })
+        .unwrap_err();
+        assert_eq!(err, BasePrecompileError::under_overflow());
+    }
+
+    #[test]
+    fn create_policy_at_counter_mask_minus_one_consumes_last_slot_then_reverts() {
+        // The last valid counter value is COUNTER_MASK - 1: it produces a policy_id
+        // whose low 56 bits equal COUNTER_MASK - 1 (no aliasing), and bumps next_counter
+        // to COUNTER_MASK. The very next create must then revert.
+        let mut s = storage();
+        StorageCtx::enter(&mut s, |ctx| {
+            PolicyRegistryStorage::new(ctx)
+                .next_counter
+                .write(PolicyRegistryStorage::COUNTER_MASK - 1)
+        })
+        .unwrap();
+        let id = StorageCtx::enter(&mut s, |ctx| {
+            PolicyRegistryStorage::new(ctx).create_policy(ADMIN, PolicyType::ALLOWLIST)
+        })
+        .unwrap();
+        assert_eq!(
+            id & PolicyRegistryStorage::COUNTER_MASK,
+            PolicyRegistryStorage::COUNTER_MASK - 1
+        );
+        let err = StorageCtx::enter(&mut s, |ctx| {
+            PolicyRegistryStorage::new(ctx).create_policy(ADMIN, PolicyType::ALLOWLIST)
+        })
+        .unwrap_err();
+        assert_eq!(err, BasePrecompileError::under_overflow());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- `create_policy_inner` used `counter.checked_add(1)`, which only reverts at `u64::MAX` (2^64). But `make_id` masks the counter to 56 bits, so any counter value ≥ 2^56 aliases back to existing policy IDs (including `ALWAYS_ALLOW_ID`). The existing guard was therefore unreachable in practice.
- Move the threshold to `COUNTER_MASK = (1u64 << 56) - 1` so the guard fires at the real aliasing boundary. Continues to revert with `BasePrecompileError::under_overflow()` to match the convention used by the other arithmetic guards in this crate (`common/ops/transferable.rs`, `mintable.rs`, `roles.rs`, `b20_security/dispatch.rs`).
- Added two tests pinning the boundary: one asserts `next_counter == COUNTER_MASK` reverts the next create; the other consumes the last valid slot at `COUNTER_MASK - 1` successfully and then asserts the very next create reverts.

Risk is theoretical (~4.6B years at current block rate), but the guard exists and was mis-placed; cheaper to fix correctly than to document the gap. Audit finding from BOP-206.

Solidity companion guard is tracked separately.

Based on `rayyanalam/refactor-policy-id-storage-packing` since that PR is also in the policy area; merging order should be refactor → this.

## Test plan

- [x] `cargo test -p base-common-precompiles --lib policy::storage::tests` — 72 passed (70 prior + 2 new).
- [x] `cargo clippy -p base-common-precompiles --all-targets -- -D warnings` — clean.
- [x] `cargo fmt` applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)