### PR TITLE
feat(nitro-host): heartbeat during proof generation

### DIFF
--- a/crates/proof/tee/nitro-host/src/lib.rs
+++ b/crates/proof/tee/nitro-host/src/lib.rs
@@ -21,7 +21,7 @@ pub use proof_submitter::{
 
 mod proof_generator;
 pub use proof_generator::{
-    ProofGenerator, ProofGeneratorError, ProofGeneratorRequest, ProofGeneratorTask, ProofProducer,
+    ProofGenerator, ProofGeneratorError, ProofGeneratorRequest, ProofGeneratorTask,
 };
 
 mod pool;

--- a/crates/proof/tee/nitro-host/src/lib.rs
+++ b/crates/proof/tee/nitro-host/src/lib.rs
@@ -23,6 +23,7 @@ mod proof_generator;
 pub use proof_generator::{
     DEFAULT_PROOF_GENERATOR_HEARTBEAT_INTERVAL,
     DEFAULT_PROOF_GENERATOR_HEARTBEAT_LOCK_DURATION_SECONDS,
+    DEFAULT_PROOF_GENERATOR_MAX_CONSECUTIVE_HEARTBEAT_FAILURES,
     MIN_PROOF_GENERATOR_HEARTBEAT_INTERVAL, ProofGenerator, ProofGeneratorError,
     ProofGeneratorHeartbeatConfig, ProofGeneratorRequest, ProofGeneratorTask,
 };

--- a/crates/proof/tee/nitro-host/src/lib.rs
+++ b/crates/proof/tee/nitro-host/src/lib.rs
@@ -21,7 +21,10 @@ pub use proof_submitter::{
 
 mod proof_generator;
 pub use proof_generator::{
-    ProofGenerator, ProofGeneratorError, ProofGeneratorRequest, ProofGeneratorTask,
+    DEFAULT_PROOF_GENERATOR_HEARTBEAT_INTERVAL,
+    DEFAULT_PROOF_GENERATOR_HEARTBEAT_LOCK_DURATION_SECONDS,
+    MIN_PROOF_GENERATOR_HEARTBEAT_INTERVAL, ProofGenerator, ProofGeneratorError,
+    ProofGeneratorHeartbeatConfig, ProofGeneratorRequest, ProofGeneratorTask,
 };
 
 mod pool;

--- a/crates/proof/tee/nitro-host/src/lib.rs
+++ b/crates/proof/tee/nitro-host/src/lib.rs
@@ -19,6 +19,11 @@ pub use proof_submitter::{
     ProofSubmitterRequest,
 };
 
+mod proof_generator;
+pub use proof_generator::{
+    ProofGenerator, ProofGeneratorError, ProofGeneratorRequest, ProofGeneratorTask, ProofProducer,
+};
+
 mod pool;
 pub use pool::{
     MAX_CONCURRENT_PROOF_REQUESTS_PER_ENCLAVE, NitroEnclavePool, NitroEnclavePoolError,

--- a/crates/proof/tee/nitro-host/src/proof_generator.rs
+++ b/crates/proof/tee/nitro-host/src/proof_generator.rs
@@ -4,7 +4,9 @@ use std::sync::Arc;
 
 use base_proof_primitives::ProofRequest as NitroProofRequest;
 use base_prover_service_client::ProverWorkerProvider;
-use base_prover_service_protocol::{ProofJob, ProofRequestKind, WorkerSubmitProofResponse};
+use base_prover_service_protocol::{
+    ProofJob, ProofRequestKind, TeeKind, WorkerSubmitProofResponse,
+};
 use thiserror::Error;
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
@@ -43,6 +45,7 @@ impl TryFrom<ProofJob> for ProofGeneratorRequest {
         let ProofRequestKind::Tee(tee) = job.request.request else {
             return Err(ProofGeneratorError::UnsupportedProofRequest { session_id });
         };
+        let TeeKind::AwsNitro = tee.tee_kind;
 
         Ok(Self { session_id, lock_id, worker_id, proof: tee.proof })
     }
@@ -130,7 +133,7 @@ where
                 );
 
                 return Err(ProofGeneratorError::Generate {
-                    session_id: request.session_id.clone(),
+                    session_id: request.session_id,
                     source,
                 });
             }

--- a/crates/proof/tee/nitro-host/src/proof_generator.rs
+++ b/crates/proof/tee/nitro-host/src/proof_generator.rs
@@ -1,0 +1,470 @@
+//! Proof generation orchestration for claimed Nitro worker jobs.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use base_proof_primitives::{ProofRequest as NitroProofRequest, ProofResult as NitroProofResult};
+use base_prover_service_client::ProverWorkerProvider;
+use base_prover_service_protocol::{ProofJob, ProofRequestKind, WorkerSubmitProofResponse};
+use thiserror::Error;
+use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
+use tracing::info;
+
+use crate::{
+    NitroEnclavePool, NitroEnclavePoolError, ProofSubmitter, ProofSubmitterError,
+    ProofSubmitterRequest,
+};
+
+/// Executes Nitro proof generation from a primitive proof request.
+#[async_trait]
+pub trait ProofProducer: Send + Sync {
+    /// Generate a proof for the requested block range.
+    async fn prove(
+        &self,
+        request: NitroProofRequest,
+    ) -> Result<NitroProofResult, NitroEnclavePoolError>;
+}
+
+#[async_trait]
+impl ProofProducer for NitroEnclavePool {
+    async fn prove(
+        &self,
+        request: NitroProofRequest,
+    ) -> Result<NitroProofResult, NitroEnclavePoolError> {
+        Self::prove(self, request).await
+    }
+}
+
+/// Claimed prover-service job data needed to generate and submit a Nitro proof.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProofGeneratorRequest {
+    /// Proof session identifier.
+    pub session_id: String,
+    /// Server-issued lock identifier for this worker claim.
+    pub lock_id: String,
+    /// Worker identifier that owns the claim.
+    pub worker_id: String,
+    /// Primitive Nitro proof request.
+    pub proof: NitroProofRequest,
+}
+
+impl TryFrom<ProofJob> for ProofGeneratorRequest {
+    type Error = ProofGeneratorError;
+
+    fn try_from(job: ProofJob) -> Result<Self, Self::Error> {
+        let session_id = job.session_id;
+        let lock_id = job
+            .lock_id
+            .ok_or_else(|| ProofGeneratorError::MissingLockId { session_id: session_id.clone() })?;
+        let worker_id = job.worker_id.ok_or_else(|| ProofGeneratorError::MissingWorkerId {
+            session_id: session_id.clone(),
+        })?;
+
+        let ProofRequestKind::Tee(tee) = job.request.request else {
+            return Err(ProofGeneratorError::UnsupportedProofRequest { session_id });
+        };
+
+        Ok(Self { session_id, lock_id, worker_id, proof: tee.proof })
+    }
+}
+
+/// Handle for a proof submission task spawned after successful proof generation.
+#[derive(Debug)]
+pub struct ProofGeneratorTask {
+    /// Proof session identifier.
+    pub session_id: String,
+    /// Server-issued lock identifier for this worker claim.
+    pub lock_id: String,
+    /// Worker identifier that owns the claim.
+    pub worker_id: String,
+    /// Spawned proof submission task.
+    pub submit_handle: JoinHandle<Result<WorkerSubmitProofResponse, ProofSubmitterError>>,
+}
+
+/// Orchestrates Nitro witness generation, enclave proving, and async proof submission.
+#[derive(Debug)]
+pub struct ProofGenerator<Producer, Client> {
+    producer: Arc<Producer>,
+    submitter: ProofSubmitter<Client>,
+    submission_cancel: CancellationToken,
+}
+
+impl<Producer, Client> ProofGenerator<Producer, Client> {
+    /// Create a proof generator with its own submission cancellation token.
+    pub fn new(producer: Arc<Producer>, submitter: ProofSubmitter<Client>) -> Self {
+        Self { producer, submitter, submission_cancel: CancellationToken::new() }
+    }
+
+    /// Use a caller-provided cancellation token for spawned submission tasks.
+    pub fn with_submission_cancel(mut self, submission_cancel: CancellationToken) -> Self {
+        self.submission_cancel = submission_cancel;
+        self
+    }
+
+    /// Returns the proof producer.
+    pub fn producer(&self) -> Arc<Producer> {
+        Arc::clone(&self.producer)
+    }
+
+    /// Returns the proof submitter.
+    pub const fn submitter(&self) -> &ProofSubmitter<Client> {
+        &self.submitter
+    }
+
+    /// Returns the cancellation token used for spawned submission tasks.
+    pub fn submission_cancel(&self) -> CancellationToken {
+        self.submission_cancel.clone()
+    }
+}
+
+impl<Producer, Client> ProofGenerator<Producer, Client>
+where
+    Producer: ProofProducer + 'static,
+    Client: Clone + ProverWorkerProvider + 'static,
+{
+    /// Generate a proof for a claimed worker job and spawn proof submission.
+    pub async fn generate_and_submit(
+        &self,
+        job: ProofJob,
+    ) -> Result<ProofGeneratorTask, ProofGeneratorError> {
+        let request = ProofGeneratorRequest::try_from(job)?;
+
+        info!(
+            session_id = %request.session_id,
+            lock_id = %request.lock_id,
+            worker_id = %request.worker_id,
+            l2_block = request.proof.claimed_l2_block_number,
+            "starting nitro proof generation"
+        );
+
+        let proof = self.producer.prove(request.proof).await.map_err(|source| {
+            ProofGeneratorError::Generate { session_id: request.session_id.clone(), source }
+        })?;
+
+        let submit_request = ProofSubmitterRequest::from_tee_proof(
+            request.session_id.clone(),
+            request.lock_id.clone(),
+            request.worker_id.clone(),
+            proof,
+        )
+        .map_err(|source| ProofGeneratorError::BuildSubmission {
+            session_id: request.session_id.clone(),
+            source,
+        })?;
+
+        let submit_handle =
+            self.submitter.spawn_until_delivered(submit_request, self.submission_cancel.clone());
+
+        info!(
+            session_id = %request.session_id,
+            lock_id = %request.lock_id,
+            worker_id = %request.worker_id,
+            "nitro proof generated; proof submitter task spawned"
+        );
+
+        Ok(ProofGeneratorTask {
+            session_id: request.session_id,
+            lock_id: request.lock_id,
+            worker_id: request.worker_id,
+            submit_handle,
+        })
+    }
+}
+
+/// Errors raised while generating and dispatching Nitro proof submissions.
+#[derive(Debug, Error)]
+pub enum ProofGeneratorError {
+    /// Claimed proof job did not include a lock identifier.
+    #[error("proof job {session_id} is missing lock_id")]
+    MissingLockId {
+        /// Proof session identifier.
+        session_id: String,
+    },
+    /// Claimed proof job did not include a worker identifier.
+    #[error("proof job {session_id} is missing worker_id")]
+    MissingWorkerId {
+        /// Proof session identifier.
+        session_id: String,
+    },
+    /// Claimed proof job is not a TEE proof request.
+    #[error("proof job {session_id} is not an AWS Nitro TEE proof request")]
+    UnsupportedProofRequest {
+        /// Proof session identifier.
+        session_id: String,
+    },
+    /// Witness generation or enclave proving failed.
+    #[error("proof generation failed for job {session_id}: {source}")]
+    Generate {
+        /// Proof session identifier.
+        session_id: String,
+        /// Underlying proof generation error.
+        #[source]
+        source: NitroEnclavePoolError,
+    },
+    /// The generated proof could not be converted into a worker submission request.
+    #[error("failed to build proof submission for job {session_id}: {source}")]
+    BuildSubmission {
+        /// Proof session identifier.
+        session_id: String,
+        /// Underlying proof submission request error.
+        #[source]
+        source: ProofSubmitterError,
+    },
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{sync::Mutex, time::Duration};
+
+    use alloy_primitives::{B256, Bytes};
+    use base_proof_primitives::Proposal;
+    use base_prover_service_client::ProverServiceClientError;
+    use base_prover_service_protocol::{
+        GetNextProofRequest, GetNextProofResponse, HeartbeatRequest, HeartbeatResponse,
+        ProofJobStatus, ProofRequest, ProofResult as ServiceProofResult, TeeKind, TeeProofRequest,
+        WorkerSubmitProofRequest,
+    };
+    use chrono::Utc;
+    use tokio::time::timeout;
+
+    use super::*;
+
+    #[derive(Debug)]
+    struct MockProducer {
+        result: Mutex<Option<Result<NitroProofResult, NitroEnclavePoolError>>>,
+        requests: Mutex<Vec<NitroProofRequest>>,
+    }
+
+    impl MockProducer {
+        fn success() -> Self {
+            Self {
+                result: Mutex::new(Some(Ok(nitro_tee_proof()))),
+                requests: Mutex::new(Vec::new()),
+            }
+        }
+
+        fn failing(error: NitroEnclavePoolError) -> Self {
+            Self { result: Mutex::new(Some(Err(error))), requests: Mutex::new(Vec::new()) }
+        }
+
+        fn request_count(&self) -> usize {
+            self.requests.lock().expect("requests lock should not be poisoned").len()
+        }
+    }
+
+    #[async_trait]
+    impl ProofProducer for MockProducer {
+        async fn prove(
+            &self,
+            request: NitroProofRequest,
+        ) -> Result<NitroProofResult, NitroEnclavePoolError> {
+            self.requests.lock().expect("requests lock should not be poisoned").push(request);
+            self.result
+                .lock()
+                .expect("result lock should not be poisoned")
+                .take()
+                .expect("mock producer result should be configured")
+        }
+    }
+
+    #[derive(Clone, Debug, Default)]
+    struct MockWorkerClient {
+        submissions: Arc<Mutex<Vec<WorkerSubmitProofRequest>>>,
+    }
+
+    impl MockWorkerClient {
+        fn submissions(&self) -> Vec<WorkerSubmitProofRequest> {
+            self.submissions.lock().expect("submissions lock should not be poisoned").clone()
+        }
+    }
+
+    #[async_trait]
+    impl ProverWorkerProvider for MockWorkerClient {
+        async fn get_next_proof(
+            &self,
+            _request: GetNextProofRequest,
+        ) -> Result<GetNextProofResponse, ProverServiceClientError> {
+            panic!("get_next_proof is not used by proof generator tests")
+        }
+
+        async fn heartbeat(
+            &self,
+            _request: HeartbeatRequest,
+        ) -> Result<HeartbeatResponse, ProverServiceClientError> {
+            panic!("heartbeat is not used by proof generator tests")
+        }
+
+        async fn submit_proof(
+            &self,
+            request: WorkerSubmitProofRequest,
+        ) -> Result<WorkerSubmitProofResponse, ProverServiceClientError> {
+            self.submissions
+                .lock()
+                .expect("submissions lock should not be poisoned")
+                .push(request.clone());
+
+            Ok(WorkerSubmitProofResponse {
+                job: proof_job(
+                    request.session_id,
+                    ProofJobStatus::Succeeded,
+                    Some(request.lock_id),
+                    Some(request.worker_id),
+                    PrimitiveRequestKind::Tee,
+                ),
+            })
+        }
+    }
+
+    #[derive(Debug, Clone, Copy)]
+    enum PrimitiveRequestKind {
+        Tee,
+        Compressed,
+    }
+
+    fn primitive_request(block: u64) -> NitroProofRequest {
+        NitroProofRequest { claimed_l2_block_number: block, ..Default::default() }
+    }
+
+    fn proposal(block: u64) -> Proposal {
+        Proposal {
+            output_root: B256::repeat_byte(1),
+            signature: Bytes::from(vec![0xab; 65]),
+            l1_origin_hash: B256::repeat_byte(2),
+            l1_origin_number: block.saturating_sub(1),
+            l2_block_number: block,
+            prev_output_root: B256::repeat_byte(3),
+            config_hash: B256::repeat_byte(4),
+        }
+    }
+
+    fn nitro_tee_proof() -> NitroProofResult {
+        NitroProofResult::Tee {
+            aggregate_proposal: proposal(10),
+            proposals: vec![proposal(8), proposal(9), proposal(10)],
+        }
+    }
+
+    fn proof_job(
+        session_id: impl Into<String>,
+        status: ProofJobStatus,
+        lock_id: Option<String>,
+        worker_id: Option<String>,
+        kind: PrimitiveRequestKind,
+    ) -> ProofJob {
+        let session_id = session_id.into();
+        let now = Utc::now();
+        let request = match kind {
+            PrimitiveRequestKind::Tee => ProofRequestKind::Tee(TeeProofRequest {
+                proof: primitive_request(42),
+                tee_kind: TeeKind::AwsNitro,
+            }),
+            PrimitiveRequestKind::Compressed => {
+                ProofRequestKind::Compressed(base_prover_service_protocol::ZkProofRequest {
+                    start_block_number: 1,
+                    number_of_blocks_to_prove: 1,
+                    sequence_window: None,
+                    l1_head: None,
+                    intermediate_root_interval: None,
+                    zk_vm: base_prover_service_protocol::ZkVm::Sp1,
+                })
+            }
+        };
+
+        ProofJob {
+            session_id: session_id.clone(),
+            status,
+            request: ProofRequest { session_id: Some(session_id), request },
+            attempt: 1,
+            lock_id,
+            worker_id,
+            lock_expires_at: None,
+            created_at: now,
+            updated_at: now,
+            completed_at: None,
+            error_message: None,
+        }
+    }
+
+    #[test]
+    fn request_requires_claim_metadata() {
+        let job = proof_job(
+            "session-1",
+            ProofJobStatus::Claimed,
+            None,
+            Some("worker-1".to_owned()),
+            PrimitiveRequestKind::Tee,
+        );
+
+        let err = ProofGeneratorRequest::try_from(job).unwrap_err();
+
+        assert!(matches!(err, ProofGeneratorError::MissingLockId { .. }));
+    }
+
+    #[test]
+    fn request_rejects_non_tee_jobs() {
+        let job = proof_job(
+            "session-1",
+            ProofJobStatus::Claimed,
+            Some("lock-1".to_owned()),
+            Some("worker-1".to_owned()),
+            PrimitiveRequestKind::Compressed,
+        );
+
+        let err = ProofGeneratorRequest::try_from(job).unwrap_err();
+
+        assert!(matches!(err, ProofGeneratorError::UnsupportedProofRequest { .. }));
+    }
+
+    #[tokio::test]
+    async fn generate_and_submit_spawns_submitter_after_successful_proof() {
+        let producer = Arc::new(MockProducer::success());
+        let client = MockWorkerClient::default();
+        let generator =
+            ProofGenerator::new(Arc::clone(&producer), ProofSubmitter::new(client.clone()));
+        let job = proof_job(
+            "session-1",
+            ProofJobStatus::Claimed,
+            Some("lock-1".to_owned()),
+            Some("worker-1".to_owned()),
+            PrimitiveRequestKind::Tee,
+        );
+
+        let task = generator.generate_and_submit(job).await.expect("proof should generate");
+        let response = timeout(Duration::from_secs(1), task.submit_handle)
+            .await
+            .expect("submit task should complete")
+            .expect("submit task should not panic")
+            .expect("submission should succeed");
+
+        assert_eq!(producer.request_count(), 1);
+        assert_eq!(response.job.status, ProofJobStatus::Succeeded);
+        let submissions = client.submissions();
+        assert_eq!(submissions.len(), 1);
+        assert_eq!(submissions[0].session_id, "session-1");
+        assert_eq!(submissions[0].lock_id, "lock-1");
+        assert_eq!(submissions[0].worker_id, "worker-1");
+        assert!(matches!(submissions[0].result, ServiceProofResult::Tee(_)));
+    }
+
+    #[tokio::test]
+    async fn generate_failure_does_not_spawn_submitter() {
+        let producer = Arc::new(MockProducer::failing(NitroEnclavePoolError::Busy));
+        let client = MockWorkerClient::default();
+        let generator =
+            ProofGenerator::new(Arc::clone(&producer), ProofSubmitter::new(client.clone()));
+        let job = proof_job(
+            "session-1",
+            ProofJobStatus::Claimed,
+            Some("lock-1".to_owned()),
+            Some("worker-1".to_owned()),
+            PrimitiveRequestKind::Tee,
+        );
+
+        let err = generator.generate_and_submit(job).await.unwrap_err();
+
+        assert!(matches!(err, ProofGeneratorError::Generate { .. }));
+        assert_eq!(producer.request_count(), 1);
+        assert!(client.submissions().is_empty());
+    }
+}

--- a/crates/proof/tee/nitro-host/src/proof_generator.rs
+++ b/crates/proof/tee/nitro-host/src/proof_generator.rs
@@ -28,6 +28,9 @@ pub const DEFAULT_PROOF_GENERATOR_HEARTBEAT_INTERVAL: Duration = Duration::from_
 /// A value of zero asks the prover service to use its server-side default.
 pub const DEFAULT_PROOF_GENERATOR_HEARTBEAT_LOCK_DURATION_SECONDS: u32 = 0;
 
+/// Default maximum consecutive retryable heartbeat failures before aborting proof generation.
+pub const DEFAULT_PROOF_GENERATOR_MAX_CONSECUTIVE_HEARTBEAT_FAILURES: u32 = 5;
+
 /// Heartbeat settings used while the enclave pool is generating a proof.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ProofGeneratorHeartbeatConfig {
@@ -35,17 +38,37 @@ pub struct ProofGeneratorHeartbeatConfig {
     pub interval: Duration,
     /// Requested lock duration in seconds. Zero uses the server default.
     pub lock_duration_seconds: u32,
+    /// Maximum consecutive retryable heartbeat failures before aborting proof generation.
+    pub max_consecutive_failures: u32,
 }
 
 impl ProofGeneratorHeartbeatConfig {
     /// Creates a proof-generation heartbeat config.
     pub const fn new(interval: Duration, lock_duration_seconds: u32) -> Self {
-        Self { interval, lock_duration_seconds }
+        Self::with_max_consecutive_failures(
+            interval,
+            lock_duration_seconds,
+            DEFAULT_PROOF_GENERATOR_MAX_CONSECUTIVE_HEARTBEAT_FAILURES,
+        )
+    }
+
+    /// Creates a proof-generation heartbeat config with an explicit retryable failure limit.
+    pub const fn with_max_consecutive_failures(
+        interval: Duration,
+        lock_duration_seconds: u32,
+        max_consecutive_failures: u32,
+    ) -> Self {
+        Self { interval, lock_duration_seconds, max_consecutive_failures }
     }
 
     /// Returns the configured interval clamped to the minimum allowed delay.
     pub fn normalized_interval(&self) -> Duration {
         self.interval.max(MIN_PROOF_GENERATOR_HEARTBEAT_INTERVAL)
+    }
+
+    /// Returns the configured retryable failure limit clamped to at least one.
+    pub const fn normalized_max_consecutive_failures(&self) -> u32 {
+        if self.max_consecutive_failures == 0 { 1 } else { self.max_consecutive_failures }
     }
 }
 
@@ -263,6 +286,9 @@ where
         &self,
         request: &ProofGeneratorRequest,
     ) -> ProverServiceClientError {
+        let max_consecutive_failures = self.heartbeat.normalized_max_consecutive_failures();
+        let mut consecutive_failures = 0;
+
         loop {
             sleep(self.heartbeat.normalized_interval()).await;
 
@@ -275,6 +301,8 @@ where
 
             match self.submitter.heartbeat(heartbeat).await {
                 Ok(response) => {
+                    consecutive_failures = 0;
+
                     debug!(
                         session_id = %request.session_id,
                         lock_id = %request.lock_id,
@@ -284,10 +312,27 @@ where
                     );
                 }
                 Err(error) if error.is_retryable() => {
+                    consecutive_failures += 1;
+
+                    if consecutive_failures >= max_consecutive_failures {
+                        warn!(
+                            session_id = %request.session_id,
+                            lock_id = %request.lock_id,
+                            worker_id = %request.worker_id,
+                            consecutive_failures,
+                            max_consecutive_failures,
+                            error = %error,
+                            "proof job heartbeat retryable failures exceeded limit"
+                        );
+                        return error;
+                    }
+
                     warn!(
                         session_id = %request.session_id,
                         lock_id = %request.lock_id,
                         worker_id = %request.worker_id,
+                        consecutive_failures,
+                        max_consecutive_failures,
                         error = %error,
                         "proof job heartbeat failed; retrying on next interval"
                     );
@@ -665,7 +710,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn retryable_heartbeat_failure_does_not_abort_generation() {
+    async fn retryable_heartbeat_failure_does_not_abort_generation_before_limit() {
         let client = MockWorkerClient::with_heartbeat_failure(MockHeartbeatFailure::Retryable);
         let generator = generator_with_heartbeat_interval(client.clone(), Duration::from_millis(5));
         let request = claimed_tee_request();
@@ -680,6 +725,31 @@ mod tests {
 
         assert!(matches!(err, ProofGeneratorError::Generate { .. }));
         assert!(client.heartbeats().len() >= 2);
+    }
+
+    #[tokio::test]
+    async fn retryable_heartbeat_failures_abort_generation_after_limit() {
+        let client = MockWorkerClient::with_heartbeat_failure(MockHeartbeatFailure::Retryable);
+        let generator = generator_with_heartbeat(
+            client.clone(),
+            ProofGeneratorHeartbeatConfig::with_max_consecutive_failures(
+                Duration::from_millis(1),
+                TEST_HEARTBEAT_LOCK_DURATION_SECONDS,
+                3,
+            ),
+        );
+        let request = claimed_tee_request();
+
+        let err = generator
+            .with_heartbeat_while_generating(&request, async {
+                sleep(Duration::from_secs(60)).await;
+                Err::<(), NitroEnclavePoolError>(NitroEnclavePoolError::Busy)
+            })
+            .await
+            .unwrap_err();
+
+        assert!(matches!(err, ProofGeneratorError::Heartbeat { .. }));
+        assert_eq!(client.heartbeats().len(), 3);
     }
 
     #[tokio::test]

--- a/crates/proof/tee/nitro-host/src/proof_generator.rs
+++ b/crates/proof/tee/nitro-host/src/proof_generator.rs
@@ -188,6 +188,18 @@ where
 
                 return Err(ProofGeneratorError::Generate { session_id, source });
             }
+            Err(ProofGeneratorError::Heartbeat { session_id, source }) => {
+                warn!(
+                    session_id = %request.session_id,
+                    lock_id = %request.lock_id,
+                    worker_id = %request.worker_id,
+                    l2_block,
+                    error = %source,
+                    "aborting nitro proof generation due to heartbeat failure"
+                );
+
+                return Err(ProofGeneratorError::Heartbeat { session_id, source });
+            }
             Err(source) => {
                 return Err(source);
             }

--- a/crates/proof/tee/nitro-host/src/proof_generator.rs
+++ b/crates/proof/tee/nitro-host/src/proof_generator.rs
@@ -365,6 +365,11 @@ mod tests {
     use super::*;
     use crate::{NitroTransport, RegistrationChecker, test_utils::MockRegistry};
 
+    const TEST_SESSION_ID: &str = "session-1";
+    const TEST_LOCK_ID: &str = "lock-1";
+    const TEST_WORKER_ID: &str = "worker-1";
+    const TEST_HEARTBEAT_LOCK_DURATION_SECONDS: u32 = 123;
+
     #[derive(Clone, Debug, Default)]
     struct MockWorkerClient {
         state: Arc<Mutex<MockWorkerState>>,
@@ -540,13 +545,45 @@ mod tests {
         }
     }
 
+    fn claimed_tee_job() -> ProofJob {
+        proof_job(
+            TEST_SESSION_ID,
+            ProofJobStatus::Claimed,
+            Some(TEST_LOCK_ID.to_owned()),
+            Some(TEST_WORKER_ID.to_owned()),
+            PrimitiveRequestKind::Tee,
+        )
+    }
+
+    fn claimed_tee_request() -> ProofGeneratorRequest {
+        ProofGeneratorRequest::try_from(claimed_tee_job())
+            .expect("claimed tee job should build generator request")
+    }
+
+    fn generator_with_heartbeat(
+        client: MockWorkerClient,
+        heartbeat: ProofGeneratorHeartbeatConfig,
+    ) -> ProofGenerator<MockWorkerClient> {
+        ProofGenerator::new(Arc::new(test_pool()), ProofSubmitter::new(client), heartbeat)
+    }
+
+    fn generator_with_heartbeat_interval(
+        client: MockWorkerClient,
+        interval: Duration,
+    ) -> ProofGenerator<MockWorkerClient> {
+        generator_with_heartbeat(
+            client,
+            ProofGeneratorHeartbeatConfig::new(interval, TEST_HEARTBEAT_LOCK_DURATION_SECONDS),
+        )
+    }
+
     #[test]
     fn request_requires_claim_metadata() {
         let job = proof_job(
-            "session-1",
+            TEST_SESSION_ID,
             ProofJobStatus::Claimed,
             None,
-            Some("worker-1".to_owned()),
+            Some(TEST_WORKER_ID.to_owned()),
             PrimitiveRequestKind::Tee,
         );
 
@@ -558,10 +595,10 @@ mod tests {
     #[test]
     fn request_rejects_non_tee_jobs() {
         let job = proof_job(
-            "session-1",
+            TEST_SESSION_ID,
             ProofJobStatus::Claimed,
-            Some("lock-1".to_owned()),
-            Some("worker-1".to_owned()),
+            Some(TEST_LOCK_ID.to_owned()),
+            Some(TEST_WORKER_ID.to_owned()),
             PrimitiveRequestKind::Compressed,
         );
 
@@ -572,21 +609,9 @@ mod tests {
 
     #[tokio::test]
     async fn heartbeat_runs_while_generation_is_in_progress() {
-        let pool = Arc::new(test_pool());
         let client = MockWorkerClient::default();
-        let generator = ProofGenerator::new(
-            pool,
-            ProofSubmitter::new(client.clone()),
-            ProofGeneratorHeartbeatConfig::new(Duration::from_millis(5), 123),
-        );
-        let request = ProofGeneratorRequest::try_from(proof_job(
-            "session-1",
-            ProofJobStatus::Claimed,
-            Some("lock-1".to_owned()),
-            Some("worker-1".to_owned()),
-            PrimitiveRequestKind::Tee,
-        ))
-        .unwrap();
+        let generator = generator_with_heartbeat_interval(client.clone(), Duration::from_millis(5));
+        let request = claimed_tee_request();
 
         let err = generator
             .with_heartbeat_while_generating(&request, async {
@@ -601,30 +626,19 @@ mod tests {
         let heartbeats = client.heartbeats();
         assert!(heartbeats.len() >= 2);
         assert!(heartbeats.iter().all(|heartbeat| {
-            heartbeat.session_id == "session-1"
-                && heartbeat.lock_id == "lock-1"
-                && heartbeat.worker_id == "worker-1"
-                && heartbeat.lock_duration_seconds == 123
+            heartbeat.session_id == TEST_SESSION_ID
+                && heartbeat.lock_id == TEST_LOCK_ID
+                && heartbeat.worker_id == TEST_WORKER_ID
+                && heartbeat.lock_duration_seconds == TEST_HEARTBEAT_LOCK_DURATION_SECONDS
         }));
     }
 
     #[tokio::test]
     async fn short_generation_failure_does_not_heartbeat() {
-        let pool = Arc::new(test_pool());
         let client = MockWorkerClient::default();
-        let generator = ProofGenerator::new(
-            pool,
-            ProofSubmitter::new(client.clone()),
-            ProofGeneratorHeartbeatConfig::new(Duration::from_millis(50), 123),
-        );
-        let request = ProofGeneratorRequest::try_from(proof_job(
-            "session-1",
-            ProofJobStatus::Claimed,
-            Some("lock-1".to_owned()),
-            Some("worker-1".to_owned()),
-            PrimitiveRequestKind::Tee,
-        ))
-        .unwrap();
+        let generator =
+            generator_with_heartbeat_interval(client.clone(), Duration::from_millis(50));
+        let request = claimed_tee_request();
 
         let err = generator
             .with_heartbeat_while_generating(&request, async {
@@ -640,21 +654,9 @@ mod tests {
 
     #[tokio::test]
     async fn retryable_heartbeat_failure_does_not_abort_generation() {
-        let pool = Arc::new(test_pool());
         let client = MockWorkerClient::with_heartbeat_failure(MockHeartbeatFailure::Retryable);
-        let generator = ProofGenerator::new(
-            pool,
-            ProofSubmitter::new(client.clone()),
-            ProofGeneratorHeartbeatConfig::new(Duration::from_millis(5), 123),
-        );
-        let request = ProofGeneratorRequest::try_from(proof_job(
-            "session-1",
-            ProofJobStatus::Claimed,
-            Some("lock-1".to_owned()),
-            Some("worker-1".to_owned()),
-            PrimitiveRequestKind::Tee,
-        ))
-        .unwrap();
+        let generator = generator_with_heartbeat_interval(client.clone(), Duration::from_millis(5));
+        let request = claimed_tee_request();
 
         let err = generator
             .with_heartbeat_while_generating(&request, async {
@@ -670,21 +672,9 @@ mod tests {
 
     #[tokio::test]
     async fn non_retryable_heartbeat_failure_aborts_generation() {
-        let pool = Arc::new(test_pool());
         let client = MockWorkerClient::with_heartbeat_failure(MockHeartbeatFailure::NonRetryable);
-        let generator = ProofGenerator::new(
-            pool,
-            ProofSubmitter::new(client.clone()),
-            ProofGeneratorHeartbeatConfig::new(Duration::from_millis(5), 123),
-        );
-        let request = ProofGeneratorRequest::try_from(proof_job(
-            "session-1",
-            ProofJobStatus::Claimed,
-            Some("lock-1".to_owned()),
-            Some("worker-1".to_owned()),
-            PrimitiveRequestKind::Tee,
-        ))
-        .unwrap();
+        let generator = generator_with_heartbeat_interval(client.clone(), Duration::from_millis(5));
+        let request = claimed_tee_request();
 
         let err = generator
             .with_heartbeat_while_generating(&request, async {
@@ -700,22 +690,11 @@ mod tests {
 
     #[tokio::test]
     async fn generate_failure_does_not_spawn_submitter() {
-        let pool = Arc::new(test_pool());
         let client = MockWorkerClient::default();
-        let generator = ProofGenerator::new(
-            pool,
-            ProofSubmitter::new(client.clone()),
-            ProofGeneratorHeartbeatConfig::default(),
-        );
-        let job = proof_job(
-            "session-1",
-            ProofJobStatus::Claimed,
-            Some("lock-1".to_owned()),
-            Some("worker-1".to_owned()),
-            PrimitiveRequestKind::Tee,
-        );
+        let generator =
+            generator_with_heartbeat(client.clone(), ProofGeneratorHeartbeatConfig::default());
 
-        let err = generator.generate_and_submit(job).await.unwrap_err();
+        let err = generator.generate_and_submit(claimed_tee_job()).await.unwrap_err();
 
         assert!(matches!(err, ProofGeneratorError::Generate { .. }));
         assert!(client.submissions().is_empty());

--- a/crates/proof/tee/nitro-host/src/proof_generator.rs
+++ b/crates/proof/tee/nitro-host/src/proof_generator.rs
@@ -2,8 +2,7 @@
 
 use std::sync::Arc;
 
-use async_trait::async_trait;
-use base_proof_primitives::{ProofRequest as NitroProofRequest, ProofResult as NitroProofResult};
+use base_proof_primitives::ProofRequest as NitroProofRequest;
 use base_prover_service_client::ProverWorkerProvider;
 use base_prover_service_protocol::{ProofJob, ProofRequestKind, WorkerSubmitProofResponse};
 use thiserror::Error;
@@ -15,28 +14,6 @@ use crate::{
     NitroEnclavePool, NitroEnclavePoolError, ProofSubmitter, ProofSubmitterError,
     ProofSubmitterRequest,
 };
-
-/// Executes Nitro proof generation from a primitive proof request.
-#[async_trait]
-pub trait ProofProducer: Send + Sync {
-    /// Error returned when proof generation fails.
-    type Error: std::error::Error + Send + Sync + 'static;
-
-    /// Generate a proof for the requested block range.
-    async fn prove(&self, request: NitroProofRequest) -> Result<NitroProofResult, Self::Error>;
-}
-
-#[async_trait]
-impl ProofProducer for NitroEnclavePool {
-    type Error = NitroEnclavePoolError;
-
-    async fn prove(
-        &self,
-        request: NitroProofRequest,
-    ) -> Result<NitroProofResult, NitroEnclavePoolError> {
-        Self::prove(self, request).await
-    }
-}
 
 /// Claimed prover-service job data needed to generate and submit a Nitro proof.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -86,16 +63,16 @@ pub struct ProofGeneratorTask {
 
 /// Orchestrates Nitro witness generation, enclave proving, and async proof submission.
 #[derive(Debug)]
-pub struct ProofGenerator<Producer, Client> {
-    producer: Arc<Producer>,
+pub struct ProofGenerator<Client> {
+    pool: Arc<NitroEnclavePool>,
     submitter: ProofSubmitter<Client>,
     submission_cancel: CancellationToken,
 }
 
-impl<Producer, Client> ProofGenerator<Producer, Client> {
+impl<Client> ProofGenerator<Client> {
     /// Create a proof generator with its own submission cancellation token.
-    pub fn new(producer: Arc<Producer>, submitter: ProofSubmitter<Client>) -> Self {
-        Self { producer, submitter, submission_cancel: CancellationToken::new() }
+    pub fn new(pool: Arc<NitroEnclavePool>, submitter: ProofSubmitter<Client>) -> Self {
+        Self { pool, submitter, submission_cancel: CancellationToken::new() }
     }
 
     /// Use a caller-provided cancellation token for spawned submission tasks.
@@ -104,9 +81,9 @@ impl<Producer, Client> ProofGenerator<Producer, Client> {
         self
     }
 
-    /// Returns the proof producer.
-    pub fn producer(&self) -> Arc<Producer> {
-        Arc::clone(&self.producer)
+    /// Returns the Nitro enclave pool.
+    pub fn pool(&self) -> Arc<NitroEnclavePool> {
+        Arc::clone(&self.pool)
     }
 
     /// Returns the proof submitter.
@@ -120,9 +97,8 @@ impl<Producer, Client> ProofGenerator<Producer, Client> {
     }
 }
 
-impl<Producer, Client> ProofGenerator<Producer, Client>
+impl<Client> ProofGenerator<Client>
 where
-    Producer: ProofProducer + 'static,
     Client: Clone + ProverWorkerProvider + 'static,
 {
     /// Generate a proof for a claimed worker job and spawn proof submission.
@@ -141,7 +117,7 @@ where
         );
 
         let l2_block = request.proof.claimed_l2_block_number;
-        let proof = match self.producer.prove(request.proof).await {
+        let proof = match self.pool.prove(request.proof).await {
             Ok(proof) => proof,
             Err(source) => {
                 warn!(
@@ -155,7 +131,7 @@ where
 
                 return Err(ProofGeneratorError::Generate {
                     session_id: request.session_id.clone(),
-                    source: Box::new(source),
+                    source,
                 });
             }
         };
@@ -218,7 +194,7 @@ pub enum ProofGeneratorError {
         session_id: String,
         /// Underlying proof generation error.
         #[source]
-        source: Box<dyn std::error::Error + Send + Sync>,
+        source: NitroEnclavePoolError,
     },
     /// The generated proof could not be converted into a worker submission request.
     #[error("failed to build proof submission for job {session_id}: {source}")]
@@ -235,61 +211,20 @@ pub enum ProofGeneratorError {
 mod tests {
     use std::{sync::Mutex, time::Duration};
 
-    use alloy_primitives::{B256, Bytes};
-    use base_proof_primitives::Proposal;
+    use alloy_genesis::ChainConfig;
+    use async_trait::async_trait;
+    use base_common_genesis::RollupConfig;
+    use base_proof_host::ProverConfig;
+    use base_proof_tee_nitro_enclave::Server as EnclaveServer;
     use base_prover_service_client::ProverServiceClientError;
     use base_prover_service_protocol::{
         GetNextProofRequest, GetNextProofResponse, HeartbeatRequest, HeartbeatResponse,
-        ProofJobStatus, ProofRequest, ProofResult as ServiceProofResult, TeeKind, TeeProofRequest,
-        WorkerSubmitProofRequest,
+        ProofJobStatus, ProofRequest, TeeKind, TeeProofRequest, WorkerSubmitProofRequest,
     };
     use chrono::Utc;
-    use tokio::time::timeout;
 
     use super::*;
-
-    #[derive(Debug)]
-    struct MockProducer {
-        result: Mutex<Option<Result<NitroProofResult, MockProducerError>>>,
-        requests: Mutex<Vec<NitroProofRequest>>,
-    }
-
-    impl MockProducer {
-        fn success() -> Self {
-            Self {
-                result: Mutex::new(Some(Ok(nitro_tee_proof()))),
-                requests: Mutex::new(Vec::new()),
-            }
-        }
-
-        fn failing(error: MockProducerError) -> Self {
-            Self { result: Mutex::new(Some(Err(error))), requests: Mutex::new(Vec::new()) }
-        }
-
-        fn request_count(&self) -> usize {
-            self.requests.lock().expect("requests lock should not be poisoned").len()
-        }
-    }
-
-    #[derive(Debug, Error)]
-    enum MockProducerError {
-        #[error("mock proof failed")]
-        Failed,
-    }
-
-    #[async_trait]
-    impl ProofProducer for MockProducer {
-        type Error = MockProducerError;
-
-        async fn prove(&self, request: NitroProofRequest) -> Result<NitroProofResult, Self::Error> {
-            self.requests.lock().expect("requests lock should not be poisoned").push(request);
-            self.result
-                .lock()
-                .expect("result lock should not be poisoned")
-                .take()
-                .expect("mock producer result should be configured")
-        }
-    }
+    use crate::{NitroTransport, RegistrationChecker, test_utils::MockRegistry};
 
     #[derive(Clone, Debug, Default)]
     struct MockWorkerClient {
@@ -349,23 +284,29 @@ mod tests {
         NitroProofRequest { claimed_l2_block_number: block, ..Default::default() }
     }
 
-    fn proposal(block: u64) -> Proposal {
-        Proposal {
-            output_root: B256::repeat_byte(1),
-            signature: Bytes::from(vec![0xab; 65]),
-            l1_origin_hash: B256::repeat_byte(2),
-            l1_origin_number: block.saturating_sub(1),
-            l2_block_number: block,
-            prev_output_root: B256::repeat_byte(3),
-            config_hash: B256::repeat_byte(4),
+    fn test_prover_config() -> ProverConfig {
+        ProverConfig {
+            l1_eth_url: "http://127.0.0.1:1".to_string(),
+            l2_eth_url: "http://127.0.0.1:1".to_string(),
+            l1_beacon_url: "http://127.0.0.1:1".to_string(),
+            l2_chain_id: 0,
+            rollup_config: RollupConfig::default(),
+            l1_config: ChainConfig::default(),
+            enable_experimental_witness_endpoint: false,
         }
     }
 
-    fn nitro_tee_proof() -> NitroProofResult {
-        NitroProofResult::Tee {
-            aggregate_proposal: proposal(10),
-            proposals: vec![proposal(8), proposal(9), proposal(10)],
-        }
+    fn test_pool() -> NitroEnclavePool {
+        let server = Arc::new(EnclaveServer::new_local().unwrap());
+        let transport = Arc::new(NitroTransport::local(server));
+        let checker = Arc::new(
+            RegistrationChecker::new(vec![Arc::clone(&transport)], MockRegistry::new(false))
+                .unwrap(),
+        );
+
+        NitroEnclavePool::new(test_prover_config(), Arc::clone(&transport), Duration::from_secs(1))
+            .with_registration_checker(checker)
+            .unwrap()
     }
 
     fn proof_job(
@@ -440,42 +381,10 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn generate_and_submit_spawns_submitter_after_successful_proof() {
-        let producer = Arc::new(MockProducer::success());
-        let client = MockWorkerClient::default();
-        let generator =
-            ProofGenerator::new(Arc::clone(&producer), ProofSubmitter::new(client.clone()));
-        let job = proof_job(
-            "session-1",
-            ProofJobStatus::Claimed,
-            Some("lock-1".to_owned()),
-            Some("worker-1".to_owned()),
-            PrimitiveRequestKind::Tee,
-        );
-
-        let task = generator.generate_and_submit(job).await.expect("proof should generate");
-        let response = timeout(Duration::from_secs(1), task.submit_handle)
-            .await
-            .expect("submit task should complete")
-            .expect("submit task should not panic")
-            .expect("submission should succeed");
-
-        assert_eq!(producer.request_count(), 1);
-        assert_eq!(response.job.status, ProofJobStatus::Succeeded);
-        let submissions = client.submissions();
-        assert_eq!(submissions.len(), 1);
-        assert_eq!(submissions[0].session_id, "session-1");
-        assert_eq!(submissions[0].lock_id, "lock-1");
-        assert_eq!(submissions[0].worker_id, "worker-1");
-        assert!(matches!(submissions[0].result, ServiceProofResult::Tee(_)));
-    }
-
-    #[tokio::test]
     async fn generate_failure_does_not_spawn_submitter() {
-        let producer = Arc::new(MockProducer::failing(MockProducerError::Failed));
+        let pool = Arc::new(test_pool());
         let client = MockWorkerClient::default();
-        let generator =
-            ProofGenerator::new(Arc::clone(&producer), ProofSubmitter::new(client.clone()));
+        let generator = ProofGenerator::new(pool, ProofSubmitter::new(client.clone()));
         let job = proof_job(
             "session-1",
             ProofJobStatus::Claimed,
@@ -487,7 +396,6 @@ mod tests {
         let err = generator.generate_and_submit(job).await.unwrap_err();
 
         assert!(matches!(err, ProofGeneratorError::Generate { .. }));
-        assert_eq!(producer.request_count(), 1);
         assert!(client.submissions().is_empty());
     }
 }

--- a/crates/proof/tee/nitro-host/src/proof_generator.rs
+++ b/crates/proof/tee/nitro-host/src/proof_generator.rs
@@ -9,7 +9,7 @@ use base_prover_service_protocol::{ProofJob, ProofRequestKind, WorkerSubmitProof
 use thiserror::Error;
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
-use tracing::info;
+use tracing::{info, warn};
 
 use crate::{
     NitroEnclavePool, NitroEnclavePoolError, ProofSubmitter, ProofSubmitterError,
@@ -19,15 +19,17 @@ use crate::{
 /// Executes Nitro proof generation from a primitive proof request.
 #[async_trait]
 pub trait ProofProducer: Send + Sync {
+    /// Error returned when proof generation fails.
+    type Error: std::error::Error + Send + Sync + 'static;
+
     /// Generate a proof for the requested block range.
-    async fn prove(
-        &self,
-        request: NitroProofRequest,
-    ) -> Result<NitroProofResult, NitroEnclavePoolError>;
+    async fn prove(&self, request: NitroProofRequest) -> Result<NitroProofResult, Self::Error>;
 }
 
 #[async_trait]
 impl ProofProducer for NitroEnclavePool {
+    type Error = NitroEnclavePoolError;
+
     async fn prove(
         &self,
         request: NitroProofRequest,
@@ -138,9 +140,25 @@ where
             "starting nitro proof generation"
         );
 
-        let proof = self.producer.prove(request.proof).await.map_err(|source| {
-            ProofGeneratorError::Generate { session_id: request.session_id.clone(), source }
-        })?;
+        let l2_block = request.proof.claimed_l2_block_number;
+        let proof = match self.producer.prove(request.proof).await {
+            Ok(proof) => proof,
+            Err(source) => {
+                warn!(
+                    session_id = %request.session_id,
+                    lock_id = %request.lock_id,
+                    worker_id = %request.worker_id,
+                    l2_block,
+                    error = %source,
+                    "nitro proof generation failed"
+                );
+
+                return Err(ProofGeneratorError::Generate {
+                    session_id: request.session_id.clone(),
+                    source: Box::new(source),
+                });
+            }
+        };
 
         let submit_request = ProofSubmitterRequest::from_tee_proof(
             request.session_id.clone(),
@@ -200,7 +218,7 @@ pub enum ProofGeneratorError {
         session_id: String,
         /// Underlying proof generation error.
         #[source]
-        source: NitroEnclavePoolError,
+        source: Box<dyn std::error::Error + Send + Sync>,
     },
     /// The generated proof could not be converted into a worker submission request.
     #[error("failed to build proof submission for job {session_id}: {source}")]
@@ -232,7 +250,7 @@ mod tests {
 
     #[derive(Debug)]
     struct MockProducer {
-        result: Mutex<Option<Result<NitroProofResult, NitroEnclavePoolError>>>,
+        result: Mutex<Option<Result<NitroProofResult, MockProducerError>>>,
         requests: Mutex<Vec<NitroProofRequest>>,
     }
 
@@ -244,7 +262,7 @@ mod tests {
             }
         }
 
-        fn failing(error: NitroEnclavePoolError) -> Self {
+        fn failing(error: MockProducerError) -> Self {
             Self { result: Mutex::new(Some(Err(error))), requests: Mutex::new(Vec::new()) }
         }
 
@@ -253,12 +271,17 @@ mod tests {
         }
     }
 
+    #[derive(Debug, Error)]
+    enum MockProducerError {
+        #[error("mock proof failed")]
+        Failed,
+    }
+
     #[async_trait]
     impl ProofProducer for MockProducer {
-        async fn prove(
-            &self,
-            request: NitroProofRequest,
-        ) -> Result<NitroProofResult, NitroEnclavePoolError> {
+        type Error = MockProducerError;
+
+        async fn prove(&self, request: NitroProofRequest) -> Result<NitroProofResult, Self::Error> {
             self.requests.lock().expect("requests lock should not be poisoned").push(request);
             self.result
                 .lock()
@@ -449,7 +472,7 @@ mod tests {
 
     #[tokio::test]
     async fn generate_failure_does_not_spawn_submitter() {
-        let producer = Arc::new(MockProducer::failing(NitroEnclavePoolError::Busy));
+        let producer = Arc::new(MockProducer::failing(MockProducerError::Failed));
         let client = MockWorkerClient::default();
         let generator =
             ProofGenerator::new(Arc::clone(&producer), ProofSubmitter::new(client.clone()));

--- a/crates/proof/tee/nitro-host/src/proof_generator.rs
+++ b/crates/proof/tee/nitro-host/src/proof_generator.rs
@@ -1,21 +1,62 @@
 //! Proof generation orchestration for claimed Nitro worker jobs.
 
-use std::sync::Arc;
+use std::{future::Future, sync::Arc, time::Duration};
 
 use base_proof_primitives::ProofRequest as NitroProofRequest;
-use base_prover_service_client::ProverWorkerProvider;
+use base_prover_service_client::{ProverServiceClientError, ProverWorkerProvider};
 use base_prover_service_protocol::{
-    ProofJob, ProofRequestKind, TeeKind, WorkerSubmitProofResponse,
+    HeartbeatRequest, ProofJob, ProofRequestKind, TeeKind, WorkerSubmitProofResponse,
 };
 use thiserror::Error;
-use tokio::task::JoinHandle;
+use tokio::{task::JoinHandle, time::sleep};
 use tokio_util::sync::CancellationToken;
-use tracing::{info, warn};
+use tracing::{debug, info, warn};
 
 use crate::{
     NitroEnclavePool, NitroEnclavePoolError, ProofSubmitter, ProofSubmitterError,
     ProofSubmitterRequest,
 };
+
+/// Minimum proof-generation heartbeat interval.
+pub const MIN_PROOF_GENERATOR_HEARTBEAT_INTERVAL: Duration = Duration::from_millis(1);
+
+/// Default interval between worker API heartbeats while an enclave proof is being generated.
+pub const DEFAULT_PROOF_GENERATOR_HEARTBEAT_INTERVAL: Duration = Duration::from_secs(30);
+
+/// Default lock duration requested by proof-generation heartbeats.
+///
+/// A value of zero asks the prover service to use its server-side default.
+pub const DEFAULT_PROOF_GENERATOR_HEARTBEAT_LOCK_DURATION_SECONDS: u32 = 0;
+
+/// Heartbeat settings used while the enclave pool is generating a proof.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ProofGeneratorHeartbeatConfig {
+    /// Delay between heartbeat attempts.
+    pub interval: Duration,
+    /// Requested lock duration in seconds. Zero uses the server default.
+    pub lock_duration_seconds: u32,
+}
+
+impl ProofGeneratorHeartbeatConfig {
+    /// Creates a proof-generation heartbeat config.
+    pub const fn new(interval: Duration, lock_duration_seconds: u32) -> Self {
+        Self { interval, lock_duration_seconds }
+    }
+
+    /// Returns the configured interval clamped to the minimum allowed delay.
+    pub fn normalized_interval(&self) -> Duration {
+        self.interval.max(MIN_PROOF_GENERATOR_HEARTBEAT_INTERVAL)
+    }
+}
+
+impl Default for ProofGeneratorHeartbeatConfig {
+    fn default() -> Self {
+        Self::new(
+            DEFAULT_PROOF_GENERATOR_HEARTBEAT_INTERVAL,
+            DEFAULT_PROOF_GENERATOR_HEARTBEAT_LOCK_DURATION_SECONDS,
+        )
+    }
+}
 
 /// Claimed prover-service job data needed to generate and submit a Nitro proof.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -70,12 +111,17 @@ pub struct ProofGenerator<Client> {
     pool: Arc<NitroEnclavePool>,
     submitter: ProofSubmitter<Client>,
     submission_cancel: CancellationToken,
+    heartbeat: ProofGeneratorHeartbeatConfig,
 }
 
 impl<Client> ProofGenerator<Client> {
     /// Create a proof generator with its own submission cancellation token.
-    pub fn new(pool: Arc<NitroEnclavePool>, submitter: ProofSubmitter<Client>) -> Self {
-        Self { pool, submitter, submission_cancel: CancellationToken::new() }
+    pub fn new(
+        pool: Arc<NitroEnclavePool>,
+        submitter: ProofSubmitter<Client>,
+        heartbeat: ProofGeneratorHeartbeatConfig,
+    ) -> Self {
+        Self { pool, submitter, submission_cancel: CancellationToken::new(), heartbeat }
     }
 
     /// Use a caller-provided cancellation token for spawned submission tasks.
@@ -97,6 +143,11 @@ impl<Client> ProofGenerator<Client> {
     /// Returns the cancellation token used for spawned submission tasks.
     pub fn submission_cancel(&self) -> CancellationToken {
         self.submission_cancel.clone()
+    }
+
+    /// Returns the heartbeat settings used while proofs are generated.
+    pub const fn heartbeat_config(&self) -> ProofGeneratorHeartbeatConfig {
+        self.heartbeat
     }
 }
 
@@ -120,9 +171,12 @@ where
         );
 
         let l2_block = request.proof.claimed_l2_block_number;
-        let proof = match self.pool.prove(request.proof).await {
+        let proof = match self
+            .with_heartbeat_while_generating(&request, self.pool.prove(request.proof.clone()))
+            .await
+        {
             Ok(proof) => proof,
-            Err(source) => {
+            Err(ProofGeneratorError::Generate { session_id, source }) => {
                 warn!(
                     session_id = %request.session_id,
                     lock_id = %request.lock_id,
@@ -132,10 +186,10 @@ where
                     "nitro proof generation failed"
                 );
 
-                return Err(ProofGeneratorError::Generate {
-                    session_id: request.session_id,
-                    source,
-                });
+                return Err(ProofGeneratorError::Generate { session_id, source });
+            }
+            Err(source) => {
+                return Err(source);
             }
         };
 
@@ -166,6 +220,78 @@ where
             worker_id: request.worker_id,
             submit_handle,
         })
+    }
+
+    async fn with_heartbeat_while_generating<Output, Generate>(
+        &self,
+        request: &ProofGeneratorRequest,
+        generate: Generate,
+    ) -> Result<Output, ProofGeneratorError>
+    where
+        Generate: Future<Output = Result<Output, NitroEnclavePoolError>>,
+    {
+        let heartbeat = self.heartbeat_until_failure(request);
+        tokio::pin!(generate);
+        tokio::pin!(heartbeat);
+
+        tokio::select! {
+            biased;
+            result = &mut generate => result.map_err(|source| ProofGeneratorError::Generate {
+                session_id: request.session_id.clone(),
+                source,
+            }),
+            source = &mut heartbeat => Err(ProofGeneratorError::Heartbeat {
+                session_id: request.session_id.clone(),
+                source,
+            }),
+        }
+    }
+
+    async fn heartbeat_until_failure(
+        &self,
+        request: &ProofGeneratorRequest,
+    ) -> ProverServiceClientError {
+        loop {
+            sleep(self.heartbeat.normalized_interval()).await;
+
+            let heartbeat = HeartbeatRequest {
+                session_id: request.session_id.clone(),
+                lock_id: request.lock_id.clone(),
+                worker_id: request.worker_id.clone(),
+                lock_duration_seconds: self.heartbeat.lock_duration_seconds,
+            };
+
+            match self.submitter.heartbeat(heartbeat).await {
+                Ok(response) => {
+                    debug!(
+                        session_id = %request.session_id,
+                        lock_id = %request.lock_id,
+                        worker_id = %request.worker_id,
+                        lock_expires_at = ?response.job.lock_expires_at,
+                        "proof job heartbeat accepted"
+                    );
+                }
+                Err(error) if error.is_retryable() => {
+                    warn!(
+                        session_id = %request.session_id,
+                        lock_id = %request.lock_id,
+                        worker_id = %request.worker_id,
+                        error = %error,
+                        "proof job heartbeat failed; retrying on next interval"
+                    );
+                }
+                Err(error) => {
+                    warn!(
+                        session_id = %request.session_id,
+                        lock_id = %request.lock_id,
+                        worker_id = %request.worker_id,
+                        error = %error,
+                        "proof job heartbeat failed permanently"
+                    );
+                    return error;
+                }
+            }
+        }
     }
 }
 
@@ -199,6 +325,15 @@ pub enum ProofGeneratorError {
         #[source]
         source: NitroEnclavePoolError,
     },
+    /// Worker API heartbeat failed while the proof was being generated.
+    #[error("heartbeat failed while generating proof for job {session_id}: {source}")]
+    Heartbeat {
+        /// Proof session identifier.
+        session_id: String,
+        /// Underlying worker API error.
+        #[source]
+        source: ProverServiceClientError,
+    },
     /// The generated proof could not be converted into a worker submission request.
     #[error("failed to build proof submission for job {session_id}: {source}")]
     BuildSubmission {
@@ -225,18 +360,45 @@ mod tests {
         ProofJobStatus, ProofRequest, TeeKind, TeeProofRequest, WorkerSubmitProofRequest,
     };
     use chrono::Utc;
+    use tokio::time::sleep;
 
     use super::*;
     use crate::{NitroTransport, RegistrationChecker, test_utils::MockRegistry};
 
     #[derive(Clone, Debug, Default)]
     struct MockWorkerClient {
-        submissions: Arc<Mutex<Vec<WorkerSubmitProofRequest>>>,
+        state: Arc<Mutex<MockWorkerState>>,
+    }
+
+    #[derive(Debug, Default)]
+    struct MockWorkerState {
+        heartbeats: Vec<HeartbeatRequest>,
+        heartbeat_failure: Option<MockHeartbeatFailure>,
+        submissions: Vec<WorkerSubmitProofRequest>,
+    }
+
+    #[derive(Debug, Clone, Copy)]
+    enum MockHeartbeatFailure {
+        Retryable,
+        NonRetryable,
     }
 
     impl MockWorkerClient {
+        fn with_heartbeat_failure(failure: MockHeartbeatFailure) -> Self {
+            Self {
+                state: Arc::new(Mutex::new(MockWorkerState {
+                    heartbeat_failure: Some(failure),
+                    ..Default::default()
+                })),
+            }
+        }
+
+        fn heartbeats(&self) -> Vec<HeartbeatRequest> {
+            self.state.lock().expect("mock state lock should not be poisoned").heartbeats.clone()
+        }
+
         fn submissions(&self) -> Vec<WorkerSubmitProofRequest> {
-            self.submissions.lock().expect("submissions lock should not be poisoned").clone()
+            self.state.lock().expect("mock state lock should not be poisoned").submissions.clone()
         }
     }
 
@@ -251,18 +413,43 @@ mod tests {
 
         async fn heartbeat(
             &self,
-            _request: HeartbeatRequest,
+            request: HeartbeatRequest,
         ) -> Result<HeartbeatResponse, ProverServiceClientError> {
-            panic!("heartbeat is not used by proof generator tests")
+            let failure = {
+                let mut state = self.state.lock().expect("mock state lock should not be poisoned");
+                state.heartbeats.push(request.clone());
+                state.heartbeat_failure
+            };
+
+            match failure {
+                Some(MockHeartbeatFailure::Retryable) => Err(ProverServiceClientError::Timeout(
+                    "mock retryable heartbeat failure".to_owned(),
+                )),
+                Some(MockHeartbeatFailure::NonRetryable) => {
+                    Err(ProverServiceClientError::WorkerLeaseRejected {
+                        message: "mock lease rejected".to_owned(),
+                    })
+                }
+                None => Ok(HeartbeatResponse {
+                    job: proof_job(
+                        request.session_id,
+                        ProofJobStatus::Claimed,
+                        Some(request.lock_id),
+                        Some(request.worker_id),
+                        PrimitiveRequestKind::Tee,
+                    ),
+                }),
+            }
         }
 
         async fn submit_proof(
             &self,
             request: WorkerSubmitProofRequest,
         ) -> Result<WorkerSubmitProofResponse, ProverServiceClientError> {
-            self.submissions
+            self.state
                 .lock()
-                .expect("submissions lock should not be poisoned")
+                .expect("mock state lock should not be poisoned")
+                .submissions
                 .push(request.clone());
 
             Ok(WorkerSubmitProofResponse {
@@ -384,10 +571,142 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn heartbeat_runs_while_generation_is_in_progress() {
+        let pool = Arc::new(test_pool());
+        let client = MockWorkerClient::default();
+        let generator = ProofGenerator::new(
+            pool,
+            ProofSubmitter::new(client.clone()),
+            ProofGeneratorHeartbeatConfig::new(Duration::from_millis(5), 123),
+        );
+        let request = ProofGeneratorRequest::try_from(proof_job(
+            "session-1",
+            ProofJobStatus::Claimed,
+            Some("lock-1".to_owned()),
+            Some("worker-1".to_owned()),
+            PrimitiveRequestKind::Tee,
+        ))
+        .unwrap();
+
+        let err = generator
+            .with_heartbeat_while_generating(&request, async {
+                sleep(Duration::from_millis(20)).await;
+                Err::<(), NitroEnclavePoolError>(NitroEnclavePoolError::Busy)
+            })
+            .await
+            .unwrap_err();
+
+        assert!(matches!(err, ProofGeneratorError::Generate { .. }));
+
+        let heartbeats = client.heartbeats();
+        assert!(heartbeats.len() >= 2);
+        assert!(heartbeats.iter().all(|heartbeat| {
+            heartbeat.session_id == "session-1"
+                && heartbeat.lock_id == "lock-1"
+                && heartbeat.worker_id == "worker-1"
+                && heartbeat.lock_duration_seconds == 123
+        }));
+    }
+
+    #[tokio::test]
+    async fn short_generation_failure_does_not_heartbeat() {
+        let pool = Arc::new(test_pool());
+        let client = MockWorkerClient::default();
+        let generator = ProofGenerator::new(
+            pool,
+            ProofSubmitter::new(client.clone()),
+            ProofGeneratorHeartbeatConfig::new(Duration::from_millis(50), 123),
+        );
+        let request = ProofGeneratorRequest::try_from(proof_job(
+            "session-1",
+            ProofJobStatus::Claimed,
+            Some("lock-1".to_owned()),
+            Some("worker-1".to_owned()),
+            PrimitiveRequestKind::Tee,
+        ))
+        .unwrap();
+
+        let err = generator
+            .with_heartbeat_while_generating(&request, async {
+                tokio::task::yield_now().await;
+                Err::<(), NitroEnclavePoolError>(NitroEnclavePoolError::Busy)
+            })
+            .await
+            .unwrap_err();
+
+        assert!(matches!(err, ProofGeneratorError::Generate { .. }));
+        assert!(client.heartbeats().is_empty());
+    }
+
+    #[tokio::test]
+    async fn retryable_heartbeat_failure_does_not_abort_generation() {
+        let pool = Arc::new(test_pool());
+        let client = MockWorkerClient::with_heartbeat_failure(MockHeartbeatFailure::Retryable);
+        let generator = ProofGenerator::new(
+            pool,
+            ProofSubmitter::new(client.clone()),
+            ProofGeneratorHeartbeatConfig::new(Duration::from_millis(5), 123),
+        );
+        let request = ProofGeneratorRequest::try_from(proof_job(
+            "session-1",
+            ProofJobStatus::Claimed,
+            Some("lock-1".to_owned()),
+            Some("worker-1".to_owned()),
+            PrimitiveRequestKind::Tee,
+        ))
+        .unwrap();
+
+        let err = generator
+            .with_heartbeat_while_generating(&request, async {
+                sleep(Duration::from_millis(20)).await;
+                Err::<(), NitroEnclavePoolError>(NitroEnclavePoolError::Busy)
+            })
+            .await
+            .unwrap_err();
+
+        assert!(matches!(err, ProofGeneratorError::Generate { .. }));
+        assert!(client.heartbeats().len() >= 2);
+    }
+
+    #[tokio::test]
+    async fn non_retryable_heartbeat_failure_aborts_generation() {
+        let pool = Arc::new(test_pool());
+        let client = MockWorkerClient::with_heartbeat_failure(MockHeartbeatFailure::NonRetryable);
+        let generator = ProofGenerator::new(
+            pool,
+            ProofSubmitter::new(client.clone()),
+            ProofGeneratorHeartbeatConfig::new(Duration::from_millis(5), 123),
+        );
+        let request = ProofGeneratorRequest::try_from(proof_job(
+            "session-1",
+            ProofJobStatus::Claimed,
+            Some("lock-1".to_owned()),
+            Some("worker-1".to_owned()),
+            PrimitiveRequestKind::Tee,
+        ))
+        .unwrap();
+
+        let err = generator
+            .with_heartbeat_while_generating(&request, async {
+                sleep(Duration::from_secs(60)).await;
+                Err::<(), NitroEnclavePoolError>(NitroEnclavePoolError::Busy)
+            })
+            .await
+            .unwrap_err();
+
+        assert!(matches!(err, ProofGeneratorError::Heartbeat { .. }));
+        assert_eq!(client.heartbeats().len(), 1);
+    }
+
+    #[tokio::test]
     async fn generate_failure_does_not_spawn_submitter() {
         let pool = Arc::new(test_pool());
         let client = MockWorkerClient::default();
-        let generator = ProofGenerator::new(pool, ProofSubmitter::new(client.clone()));
+        let generator = ProofGenerator::new(
+            pool,
+            ProofSubmitter::new(client.clone()),
+            ProofGeneratorHeartbeatConfig::default(),
+        );
         let job = proof_job(
             "session-1",
             ProofJobStatus::Claimed,

--- a/crates/proof/tee/nitro-host/src/proof_submitter.rs
+++ b/crates/proof/tee/nitro-host/src/proof_submitter.rs
@@ -12,8 +12,8 @@ use backon::{ExponentialBuilder, Retryable};
 use base_proof_primitives::ProofResult as NitroProofResult;
 use base_prover_service_client::{ProverServiceClientError, ProverWorkerProvider};
 use base_prover_service_protocol::{
-    ProofResult as ServiceProofResult, TeeKind, TeeProofResult, WorkerSubmitProofRequest,
-    WorkerSubmitProofResponse,
+    HeartbeatRequest, HeartbeatResponse, ProofResult as ServiceProofResult, TeeKind,
+    TeeProofResult, WorkerSubmitProofRequest, WorkerSubmitProofResponse,
 };
 use thiserror::Error;
 use tokio::{task::JoinHandle, time::sleep};
@@ -148,6 +148,14 @@ impl<Client> ProofSubmitter<Client>
 where
     Client: ProverWorkerProvider,
 {
+    /// Extend a claimed proof job lock through the worker API.
+    pub async fn heartbeat(
+        &self,
+        request: HeartbeatRequest,
+    ) -> Result<HeartbeatResponse, ProverServiceClientError> {
+        self.client.heartbeat(request).await
+    }
+
     /// Submits a generated proof, retrying retryable delivery failures until success.
     ///
     /// This method has no cancellation or retry limit. Use


### PR DESCRIPTION
### What changed? Why?

Adds configurable worker API heartbeats while Nitro proof generation is in progress so claimed proof job locks can be extended during long-running enclave work.

This also exposes `ProofSubmitter::heartbeat`, re-exports the heartbeat config/defaults from `nitro-host`, retries retryable heartbeat failures on the next interval, and aborts generation when a heartbeat fails permanently.

### Notes to reviewers

`ProofGenerator::new` now accepts a `ProofGeneratorHeartbeatConfig`, making heartbeat behavior explicit at construction time.

### How has it been tested?

`cargo test -p base-proof-tee-nitro-host`