### PR TITLE
fix(evm): relax BaseEvm database bounds

### DIFF
--- a/crates/common/evm/src/api/builder.rs
+++ b/crates/common/evm/src/api/builder.rs
@@ -1,7 +1,8 @@
 //! [`Builder`] trait for constructing a [`BaseEvm`] directly from a [`BaseContext`].
-use alloy_evm::{Database, precompiles::PrecompilesMap};
+use alloy_evm::precompiles::PrecompilesMap;
 use alloy_primitives::Address;
 use revm::{
+    Database,
     context::FrameStack,
     handler::{EthFrame, instructions::EthInstructions},
     interpreter::interpreter::EthInterpreter,
@@ -128,6 +129,8 @@ impl<DB: Database> Builder for BaseContext<DB> {
 
 #[cfg(test)]
 mod tests {
+    use core::convert::Infallible;
+
     use alloy_primitives::{Address, B256};
     use alloy_sol_types::SolCall;
     use base_common_precompiles::{
@@ -135,11 +138,13 @@ mod tests {
         PolicyRegistryStorage,
     };
     use revm::{
-        Context, ExecuteEvm,
+        Context, DatabaseRef, ExecuteEvm,
+        bytecode::Bytecode,
         context::{CfgEnv, TxEnv},
         handler::EvmTr,
         inspector::NoOpInspector,
-        primitives::{Bytes, TxKind},
+        primitives::{Bytes, StorageKey, StorageValue, TxKind},
+        state::AccountInfo,
     };
 
     use super::*;
@@ -207,5 +212,36 @@ mod tests {
         let actual = IActivationRegistry::adminCall::abi_decode_returns(output).unwrap();
 
         assert_eq!(actual, admin);
+    }
+
+    struct NonDebugDatabaseRef;
+
+    impl DatabaseRef for NonDebugDatabaseRef {
+        type Error = Infallible;
+
+        fn basic_ref(&self, _address: Address) -> Result<Option<AccountInfo>, Self::Error> {
+            Ok(None)
+        }
+
+        fn code_by_hash_ref(&self, _code_hash: B256) -> Result<Bytecode, Self::Error> {
+            Ok(Bytecode::new())
+        }
+
+        fn storage_ref(
+            &self,
+            _address: Address,
+            _index: StorageKey,
+        ) -> Result<StorageValue, Self::Error> {
+            Ok(StorageValue::ZERO)
+        }
+
+        fn block_hash_ref(&self, _number: u64) -> Result<B256, Self::Error> {
+            Ok(B256::ZERO)
+        }
+    }
+
+    #[test]
+    fn build_base_accepts_non_debug_database_ref() {
+        let _evm = BaseContext::base().with_ref_db(NonDebugDatabaseRef).build_base();
     }
 }

--- a/crates/common/evm/src/evm.rs
+++ b/crates/common/evm/src/evm.rs
@@ -1,10 +1,10 @@
 use core::ops::{Deref, DerefMut};
 
-use alloy_evm::{Database, Evm, EvmEnv};
+use alloy_evm::{Database as AlloyDatabase, Evm, EvmEnv};
 use alloy_primitives::{Address, Bytes};
 use revm::{
-    DatabaseCommit, ExecuteCommitEvm, ExecuteEvm, InspectCommitEvm, InspectEvm,
-    InspectSystemCallEvm, Inspector, SystemCallEvm,
+    Database as RevmDatabase, DatabaseCommit, ExecuteCommitEvm, ExecuteEvm, InspectCommitEvm,
+    InspectEvm, InspectSystemCallEvm, Inspector, SystemCallEvm,
     context::{
         BlockEnv, CfgEnv, ContextError, ContextSetters, Evm as RevmEvm, FrameStack, TxEnv,
         result::ExecResultAndState,
@@ -47,7 +47,7 @@ type InnerEvm<DB, I, P> = RevmEvm<
 /// [`Evm::transact`]. When `false`, the inspector is present in the type but silent,
 /// enabling zero-cost tracing toggling at runtime without type changes.
 #[allow(missing_debug_implementations)] // revm::Context does not implement Debug
-pub struct BaseEvm<DB: Database, I, P = BasePrecompiles> {
+pub struct BaseEvm<DB: RevmDatabase, I, P = BasePrecompiles> {
     /// Inner revm EVM with Base-specific context, fixed [`EthInstructions`] and
     /// [`EthFrame`], and generic precompile set [`P`].
     pub(crate) inner: InnerEvm<DB, I, P>,
@@ -55,7 +55,7 @@ pub struct BaseEvm<DB: Database, I, P = BasePrecompiles> {
     pub(crate) inspect: bool,
 }
 
-impl<DB: Database, I, P> BaseEvm<DB, I, P> {
+impl<DB: RevmDatabase, I, P> BaseEvm<DB, I, P> {
     /// Constructs a [`BaseEvm`] from a pre-built [`RevmEvm`] and an inspect flag.
     ///
     /// Prefer [`crate::Builder::build_base`] or [`crate::Builder::build_with_inspector`]
@@ -98,7 +98,7 @@ impl<DB: Database, I, P> BaseEvm<DB, I, P> {
     }
 }
 
-impl<DB: Database, I, P> Deref for BaseEvm<DB, I, P> {
+impl<DB: RevmDatabase, I, P> Deref for BaseEvm<DB, I, P> {
     type Target = BaseContext<DB>;
 
     #[inline]
@@ -107,7 +107,7 @@ impl<DB: Database, I, P> Deref for BaseEvm<DB, I, P> {
     }
 }
 
-impl<DB: Database, I, P> DerefMut for BaseEvm<DB, I, P> {
+impl<DB: RevmDatabase, I, P> DerefMut for BaseEvm<DB, I, P> {
     #[inline]
     fn deref_mut(&mut self) -> &mut Self::Target {
         self.ctx_mut()
@@ -116,7 +116,7 @@ impl<DB: Database, I, P> DerefMut for BaseEvm<DB, I, P> {
 
 impl<DB, I, P> EvmTr for BaseEvm<DB, I, P>
 where
-    DB: Database,
+    DB: RevmDatabase,
     P: PrecompileProvider<BaseContext<DB>, Output = InterpreterResult>,
 {
     type Context = BaseContext<DB>;
@@ -167,7 +167,7 @@ where
 
 impl<DB, I, P> InspectorEvmTr for BaseEvm<DB, I, P>
 where
-    DB: Database,
+    DB: RevmDatabase,
     BaseContext<DB>: ContextTr<Journal: JournalExt> + ContextSetters,
     I: Inspector<BaseContext<DB>>,
     P: PrecompileProvider<BaseContext<DB>, Output = InterpreterResult>,
@@ -203,7 +203,7 @@ where
 
 impl<DB, I, P> ExecuteEvm for BaseEvm<DB, I, P>
 where
-    DB: Database,
+    DB: RevmDatabase,
     BaseContext<DB>: crate::BaseContextTr
         + ContextSetters
         + ContextTr<Db = DB, Tx = BaseTransaction<TxEnv>, Block = BlockEnv>,
@@ -242,7 +242,7 @@ where
 
 impl<DB, I, P> ExecuteCommitEvm for BaseEvm<DB, I, P>
 where
-    DB: Database + DatabaseCommit,
+    DB: RevmDatabase + DatabaseCommit,
     BaseContext<DB>: crate::BaseContextTr
         + ContextSetters
         + ContextTr<Db = DB, Tx = BaseTransaction<TxEnv>, Block = BlockEnv>,
@@ -255,7 +255,7 @@ where
 
 impl<DB, I, P> InspectEvm for BaseEvm<DB, I, P>
 where
-    DB: Database,
+    DB: RevmDatabase,
     BaseContext<DB>: crate::BaseContextTr<Journal: JournalExt>
         + ContextSetters
         + ContextTr<Db = DB, Tx = BaseTransaction<TxEnv>, Block = BlockEnv>,
@@ -277,7 +277,7 @@ where
 
 impl<DB, I, P> InspectCommitEvm for BaseEvm<DB, I, P>
 where
-    DB: Database + DatabaseCommit,
+    DB: RevmDatabase + DatabaseCommit,
     BaseContext<DB>: crate::BaseContextTr<Journal: JournalExt>
         + ContextSetters
         + ContextTr<Db = DB, Tx = BaseTransaction<TxEnv>, Block = BlockEnv>,
@@ -288,7 +288,7 @@ where
 
 impl<DB, I, P> SystemCallEvm for BaseEvm<DB, I, P>
 where
-    DB: Database,
+    DB: RevmDatabase,
     BaseContext<DB>: crate::BaseContextTr<Tx: SystemCallTx>
         + ContextSetters
         + ContextTr<Db = DB, Tx = BaseTransaction<TxEnv>, Block = BlockEnv>,
@@ -317,7 +317,7 @@ where
 
 impl<DB, I, P> InspectSystemCallEvm for BaseEvm<DB, I, P>
 where
-    DB: Database,
+    DB: RevmDatabase,
     BaseContext<DB>: crate::BaseContextTr<Journal: JournalExt, Tx: SystemCallTx>
         + ContextSetters
         + ContextTr<Db = DB, Tx = BaseTransaction<TxEnv>, Block = BlockEnv>,
@@ -347,7 +347,7 @@ where
 
 impl<DB, I, P> Evm for BaseEvm<DB, I, P>
 where
-    DB: Database,
+    DB: AlloyDatabase,
     I: Inspector<BaseContext<DB>>,
     P: PrecompileProvider<BaseContext<DB>, Output = InterpreterResult>,
     BaseContext<DB>: crate::BaseContextTr


### PR DESCRIPTION
  ## Summary

  This relaxes `BaseEvm` and the `Builder` path to use `revm::Database` where possible, instead of `alloy_evm::Database`.

  The stricter `alloy_evm::Database` bound is still kept where upstream alloy requires it, namely the `alloy_evm::Evm` integration boundary.

  A regression test is added for a non-`Debug` `DatabaseRef` used through:

  ```rust
  BaseContext::base()
      .with_ref_db(non_debug_db)
      .build_base();
  ```

  ## Why

  In v0.8, the direct builder path returned the revm-facing OpEvm<OpContext<DB>, ...> layer. That path only required DB: revm::Database, so DatabaseRef adapters worked without requiring the underlying adapter type to implement
  Debug.

  After OpEvm was merged into BaseEvm, the normal builder path started exposing BaseEvm<DB, ...> directly. Since BaseEvm used alloy_evm::Database, this unintentionally leaked alloy's stricter Debug bound into revm-style
  construction.

  That breaks generic read-only database adapters, especially DatabaseRef adapters wrapped by WrapDatabaseRef<T>, where Debug is not required for execution.

  ## Longer-Term Note

  This patch keeps the current simplified BaseEvm design and only relaxes bounds where alloy does not force them.

  A broader alternative would be to restore the old layering with Base naming, effectively keeping a lower-level revm-facing EVM/context layer and reserving alloy-specific bounds for the alloy wrapper/factory boundary. I strongly believe that more control and flexibility with a prod-tested design is a way to go.
  
  Closes #2916 