### PR TITLE
fix(metering/estimator): limit_at_block_end truncates when total_limit not divisible by flashblock count

### DIFF
--- a/crates/execution/metering/src/estimator.rs
+++ b/crates/execution/metering/src/estimator.rs
@@ -704,11 +704,25 @@ const fn cumulative_limit_for_flashblock(
 }
 
 const fn limit_at_block_end(total_limit: u128, total_flashblock_count: usize) -> u128 {
-    cumulative_limit_for_flashblock(
-        total_limit,
-        total_flashblock_count as u64,
-        total_flashblock_count,
-    )
+    // Return the full block budget directly instead of routing through
+    // cumulative_limit_for_flashblock(total_limit, N, N).
+    //
+    // The cumulative helper computes (total_limit / N) * N, which truncates
+    // whenever total_limit is not evenly divisible by total_flashblock_count.
+    // The discarded remainder (up to N-1 units) caused two downstream problems:
+    //
+    // 1. ensure_capacity rejected bundles whose demand fell in the gap
+    //    ((total_limit / N) * N, total_limit], even though the full block
+    //    budget was sufficient — an incorrect DemandExceedsCapacity error.
+    //
+    // 2. estimate_accumulating_resource used the under-reported limit as the
+    //    capacity for the whole-block fee estimate, producing fee suggestions
+    //    that were slightly too high.
+    //
+    // At the end of a block all of total_limit is available, so the correct
+    // return value is total_limit itself, not the truncated product.
+    let _ = total_flashblock_count; // kept for API symmetry with cumulative_limit_for_flashblock
+    total_limit
 }
 
 const fn estimate_competitiveness_key(


### PR DESCRIPTION
## What's the bug

`limit_at_block_end` delegates to `cumulative_limit_for_flashblock` passing `flashblock_index = N` and `total_flashblock_count = N`, which computes:

```
(total_limit / N) * N
```

Integer division truncates the remainder, so whenever `total_limit` is not evenly divisible by `N` the returned limit is **smaller than `total_limit` by up to `N - 1` units**.

## Impact

**1. False `DemandExceedsCapacity` errors.** `estimate_accumulating_resource` calls:
```rust
self.ensure_capacity(resource, demand, block_end_limit)?;
```
where `block_end_limit` is the truncated value. Any bundle whose demand lands in the gap `((total_limit / N) * N, total_limit]` gets rejected with `DemandExceedsCapacity` even though the full block budget would accommodate it.

**2. Slightly inflated whole-block fee estimates.** The same truncated limit is passed to `estimate_resource` for the whole-block estimate. With a lower ceiling, the estimator sees the block as tighter than it actually is, nudging the suggested fee upward for bundles near the block-end capacity.

## Fix

Return `total_limit` directly. At the end of a block all of `total_limit` is available — there is no per-flashblock proration to apply:

```rust
// before
const fn limit_at_block_end(total_limit: u128, total_flashblock_count: usize) -> u128 {
    cumulative_limit_for_flashblock(total_limit, total_flashblock_count as u64, total_flashblock_count)
}

// after
const fn limit_at_block_end(total_limit: u128, _total_flashblock_count: usize) -> u128 {
    total_limit
}
```

### Minimal reproduction

```rust
assert_eq!(limit_at_block_end(1_000, 3), 1_000); // was 999
assert_eq!(limit_at_block_end(30_000_001, 10), 30_000_001); // was 30_000_000
```
