### PR TITLE
fix(trie/in-memory): reset position to -1 in InMemoryAccountCursor::reset

### DIFF
--- a/crates/execution/trie/src/in_memory.rs
+++ b/crates/execution/trie/src/in_memory.rs
@@ -533,7 +533,7 @@ impl HashedCursor for InMemoryAccountCursor {
     }
 
     fn reset(&mut self) {
-        // no reset needed
+        self.position = -1;
     }
 }
 


### PR DESCRIPTION
## Bug

`InMemoryAccountCursor::reset` was implemented as a no-op (`// no reset needed`), while every other cursor in the same file correctly resets the iteration position:

```rust
// InMemoryStorageCursor
fn reset(&mut self) {
    self.position = -1;   // ✓
}

// InMemoryTrieCursor
fn reset(&mut self) {
    self.position = -1;   // ✓
}

// InMemoryAccountCursor — BUG
fn reset(&mut self) {
    // no reset needed    // ✗
}
```

After a `seek()` call the `position` field is set to a non-negative index. Calling `reset()` on the account cursor left that value in place. Any subsequent iteration via `next()` would then increment from the stale index rather than from `-1`, returning entries starting at the wrong offset and missing everything before the previous seek position.

## Fix

Set `self.position = -1` in `InMemoryAccountCursor::reset`, matching the behaviour of the two sibling cursors:

```rust
fn reset(&mut self) {
    self.position = -1;
}
```

No logic changes anywhere else — this is purely restoring the expected reset semantics.
