### PR TITLE
feat: heartbeat during proof generation

### DIFF
--- a/crates/proof/tee/nitro-host/src/lib.rs
+++ b/crates/proof/tee/nitro-host/src/lib.rs
@@ -23,6 +23,7 @@ mod proof_generator;
 pub use proof_generator::{
     DEFAULT_PROOF_GENERATOR_HEARTBEAT_INTERVAL,
     DEFAULT_PROOF_GENERATOR_HEARTBEAT_LOCK_DURATION_SECONDS,
+    DEFAULT_PROOF_GENERATOR_MAX_CONSECUTIVE_HEARTBEAT_FAILURES,
     MIN_PROOF_GENERATOR_HEARTBEAT_INTERVAL, ProofGenerator, ProofGeneratorError,
     ProofGeneratorHeartbeatConfig, ProofGeneratorRequest, ProofGeneratorTask,
 };

--- a/crates/proof/tee/nitro-host/src/lib.rs
+++ b/crates/proof/tee/nitro-host/src/lib.rs
@@ -21,7 +21,10 @@ pub use proof_submitter::{
 
 mod proof_generator;
 pub use proof_generator::{
-    ProofGenerator, ProofGeneratorError, ProofGeneratorRequest, ProofGeneratorTask,
+    DEFAULT_PROOF_GENERATOR_HEARTBEAT_INTERVAL,
+    DEFAULT_PROOF_GENERATOR_HEARTBEAT_LOCK_DURATION_SECONDS,
+    MIN_PROOF_GENERATOR_HEARTBEAT_INTERVAL, ProofGenerator, ProofGeneratorError,
+    ProofGeneratorHeartbeatConfig, ProofGeneratorRequest, ProofGeneratorTask,
 };
 
 mod pool;

--- a/crates/proof/tee/nitro-host/src/proof_generator.rs
+++ b/crates/proof/tee/nitro-host/src/proof_generator.rs
@@ -223,8 +223,15 @@ where
 
                 return Err(ProofGeneratorError::Heartbeat { session_id, source });
             }
-            Err(source) => {
-                return Err(source);
+            Err(
+                source @ (ProofGeneratorError::MissingLockId { .. }
+                | ProofGeneratorError::MissingWorkerId { .. }
+                | ProofGeneratorError::UnsupportedProofRequest { .. }
+                | ProofGeneratorError::BuildSubmission { .. }),
+            ) => {
+                unreachable!(
+                    "with_heartbeat_while_generating returned an impossible error: {source}"
+                );
             }
         };
 

--- a/crates/proof/tee/nitro-host/src/proof_generator.rs
+++ b/crates/proof/tee/nitro-host/src/proof_generator.rs
@@ -275,10 +275,22 @@ where
                 session_id: request.session_id.clone(),
                 source,
             }),
-            source = &mut heartbeat => Err(ProofGeneratorError::Heartbeat {
-                session_id: request.session_id.clone(),
-                source,
-            }),
+            source = &mut heartbeat => {
+                if let Err(error) = generate.await {
+                    warn!(
+                        session_id = %request.session_id,
+                        lock_id = %request.lock_id,
+                        worker_id = %request.worker_id,
+                        error = %error,
+                        "nitro proof generation finished with error after heartbeat failure"
+                    );
+                }
+
+                Err(ProofGeneratorError::Heartbeat {
+                    session_id: request.session_id.clone(),
+                    source,
+                })
+            },
         }
     }
 
@@ -742,7 +754,7 @@ mod tests {
 
         let err = generator
             .with_heartbeat_while_generating(&request, async {
-                sleep(Duration::from_secs(60)).await;
+                sleep(Duration::from_millis(50)).await;
                 Err::<(), NitroEnclavePoolError>(NitroEnclavePoolError::Busy)
             })
             .await
@@ -760,7 +772,7 @@ mod tests {
 
         let err = generator
             .with_heartbeat_while_generating(&request, async {
-                sleep(Duration::from_secs(60)).await;
+                sleep(Duration::from_millis(25)).await;
                 Err::<(), NitroEnclavePoolError>(NitroEnclavePoolError::Busy)
             })
             .await
@@ -768,6 +780,32 @@ mod tests {
 
         assert!(matches!(err, ProofGeneratorError::Heartbeat { .. }));
         assert_eq!(client.heartbeats().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn heartbeat_failure_waits_for_in_flight_generation() {
+        let client = MockWorkerClient::with_heartbeat_failure(MockHeartbeatFailure::NonRetryable);
+        let generator = generator_with_heartbeat_interval(client, Duration::from_millis(5));
+        let request = claimed_tee_request();
+        let generation_finished = Arc::new(Mutex::new(false));
+        let generation_finished_for_task = Arc::clone(&generation_finished);
+
+        let err = generator
+            .with_heartbeat_while_generating(&request, async move {
+                sleep(Duration::from_millis(25)).await;
+                *generation_finished_for_task
+                    .lock()
+                    .expect("generation completion flag should not be poisoned") = true;
+                Ok::<(), NitroEnclavePoolError>(())
+            })
+            .await
+            .unwrap_err();
+
+        assert!(matches!(err, ProofGeneratorError::Heartbeat { .. }));
+        assert!(
+            *generation_finished.lock().expect("generation completion flag should not be poisoned"),
+            "heartbeat failure must not return until in-flight generation finishes"
+        );
     }
 
     #[tokio::test]

--- a/crates/proof/tee/nitro-host/src/proof_generator.rs
+++ b/crates/proof/tee/nitro-host/src/proof_generator.rs
@@ -28,6 +28,9 @@ pub const DEFAULT_PROOF_GENERATOR_HEARTBEAT_INTERVAL: Duration = Duration::from_
 /// A value of zero asks the prover service to use its server-side default.
 pub const DEFAULT_PROOF_GENERATOR_HEARTBEAT_LOCK_DURATION_SECONDS: u32 = 0;
 
+/// Default maximum consecutive retryable heartbeat failures before aborting proof generation.
+pub const DEFAULT_PROOF_GENERATOR_MAX_CONSECUTIVE_HEARTBEAT_FAILURES: u32 = 5;
+
 /// Heartbeat settings used while the enclave pool is generating a proof.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ProofGeneratorHeartbeatConfig {
@@ -35,17 +38,37 @@ pub struct ProofGeneratorHeartbeatConfig {
     pub interval: Duration,
     /// Requested lock duration in seconds. Zero uses the server default.
     pub lock_duration_seconds: u32,
+    /// Maximum consecutive retryable heartbeat failures before aborting proof generation.
+    pub max_consecutive_failures: u32,
 }
 
 impl ProofGeneratorHeartbeatConfig {
     /// Creates a proof-generation heartbeat config.
     pub const fn new(interval: Duration, lock_duration_seconds: u32) -> Self {
-        Self { interval, lock_duration_seconds }
+        Self::with_max_consecutive_failures(
+            interval,
+            lock_duration_seconds,
+            DEFAULT_PROOF_GENERATOR_MAX_CONSECUTIVE_HEARTBEAT_FAILURES,
+        )
+    }
+
+    /// Creates a proof-generation heartbeat config with an explicit retryable failure limit.
+    pub const fn with_max_consecutive_failures(
+        interval: Duration,
+        lock_duration_seconds: u32,
+        max_consecutive_failures: u32,
+    ) -> Self {
+        Self { interval, lock_duration_seconds, max_consecutive_failures }
     }
 
     /// Returns the configured interval clamped to the minimum allowed delay.
     pub fn normalized_interval(&self) -> Duration {
         self.interval.max(MIN_PROOF_GENERATOR_HEARTBEAT_INTERVAL)
+    }
+
+    /// Returns the configured retryable failure limit clamped to at least one.
+    pub const fn normalized_max_consecutive_failures(&self) -> u32 {
+        if self.max_consecutive_failures == 0 { 1 } else { self.max_consecutive_failures }
     }
 }
 
@@ -263,6 +286,9 @@ where
         &self,
         request: &ProofGeneratorRequest,
     ) -> ProverServiceClientError {
+        let max_consecutive_failures = self.heartbeat.normalized_max_consecutive_failures();
+        let mut consecutive_failures = 0;
+
         loop {
             sleep(self.heartbeat.normalized_interval()).await;
 
@@ -275,6 +301,8 @@ where
 
             match self.submitter.heartbeat(heartbeat).await {
                 Ok(response) => {
+                    consecutive_failures = 0;
+
                     debug!(
                         session_id = %request.session_id,
                         lock_id = %request.lock_id,
@@ -284,10 +312,27 @@ where
                     );
                 }
                 Err(error) if error.is_retryable() => {
+                    consecutive_failures += 1;
+
+                    if consecutive_failures >= max_consecutive_failures {
+                        warn!(
+                            session_id = %request.session_id,
+                            lock_id = %request.lock_id,
+                            worker_id = %request.worker_id,
+                            consecutive_failures,
+                            max_consecutive_failures,
+                            error = %error,
+                            "proof job heartbeat retryable failures exceeded limit"
+                        );
+                        return error;
+                    }
+
                     warn!(
                         session_id = %request.session_id,
                         lock_id = %request.lock_id,
                         worker_id = %request.worker_id,
+                        consecutive_failures,
+                        max_consecutive_failures,
                         error = %error,
                         "proof job heartbeat failed; retrying on next interval"
                     );
@@ -665,7 +710,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn retryable_heartbeat_failure_does_not_abort_generation() {
+    async fn retryable_heartbeat_failure_does_not_abort_generation_before_limit() {
         let client = MockWorkerClient::with_heartbeat_failure(MockHeartbeatFailure::Retryable);
         let generator = generator_with_heartbeat_interval(client.clone(), Duration::from_millis(5));
         let request = claimed_tee_request();
@@ -680,6 +725,31 @@ mod tests {
 
         assert!(matches!(err, ProofGeneratorError::Generate { .. }));
         assert!(client.heartbeats().len() >= 2);
+    }
+
+    #[tokio::test]
+    async fn retryable_heartbeat_failures_abort_generation_after_limit() {
+        let client = MockWorkerClient::with_heartbeat_failure(MockHeartbeatFailure::Retryable);
+        let generator = generator_with_heartbeat(
+            client.clone(),
+            ProofGeneratorHeartbeatConfig::with_max_consecutive_failures(
+                Duration::from_millis(1),
+                TEST_HEARTBEAT_LOCK_DURATION_SECONDS,
+                3,
+            ),
+        );
+        let request = claimed_tee_request();
+
+        let err = generator
+            .with_heartbeat_while_generating(&request, async {
+                sleep(Duration::from_secs(60)).await;
+                Err::<(), NitroEnclavePoolError>(NitroEnclavePoolError::Busy)
+            })
+            .await
+            .unwrap_err();
+
+        assert!(matches!(err, ProofGeneratorError::Heartbeat { .. }));
+        assert_eq!(client.heartbeats().len(), 3);
     }
 
     #[tokio::test]

--- a/crates/proof/tee/nitro-host/src/proof_generator.rs
+++ b/crates/proof/tee/nitro-host/src/proof_generator.rs
@@ -188,6 +188,18 @@ where
 
                 return Err(ProofGeneratorError::Generate { session_id, source });
             }
+            Err(ProofGeneratorError::Heartbeat { session_id, source }) => {
+                warn!(
+                    session_id = %request.session_id,
+                    lock_id = %request.lock_id,
+                    worker_id = %request.worker_id,
+                    l2_block,
+                    error = %source,
+                    "aborting nitro proof generation due to heartbeat failure"
+                );
+
+                return Err(ProofGeneratorError::Heartbeat { session_id, source });
+            }
             Err(source) => {
                 return Err(source);
             }

--- a/crates/proof/tee/nitro-host/src/proof_generator.rs
+++ b/crates/proof/tee/nitro-host/src/proof_generator.rs
@@ -365,6 +365,11 @@ mod tests {
     use super::*;
     use crate::{NitroTransport, RegistrationChecker, test_utils::MockRegistry};
 
+    const TEST_SESSION_ID: &str = "session-1";
+    const TEST_LOCK_ID: &str = "lock-1";
+    const TEST_WORKER_ID: &str = "worker-1";
+    const TEST_HEARTBEAT_LOCK_DURATION_SECONDS: u32 = 123;
+
     #[derive(Clone, Debug, Default)]
     struct MockWorkerClient {
         state: Arc<Mutex<MockWorkerState>>,
@@ -540,13 +545,45 @@ mod tests {
         }
     }
 
+    fn claimed_tee_job() -> ProofJob {
+        proof_job(
+            TEST_SESSION_ID,
+            ProofJobStatus::Claimed,
+            Some(TEST_LOCK_ID.to_owned()),
+            Some(TEST_WORKER_ID.to_owned()),
+            PrimitiveRequestKind::Tee,
+        )
+    }
+
+    fn claimed_tee_request() -> ProofGeneratorRequest {
+        ProofGeneratorRequest::try_from(claimed_tee_job())
+            .expect("claimed tee job should build generator request")
+    }
+
+    fn generator_with_heartbeat(
+        client: MockWorkerClient,
+        heartbeat: ProofGeneratorHeartbeatConfig,
+    ) -> ProofGenerator<MockWorkerClient> {
+        ProofGenerator::new(Arc::new(test_pool()), ProofSubmitter::new(client), heartbeat)
+    }
+
+    fn generator_with_heartbeat_interval(
+        client: MockWorkerClient,
+        interval: Duration,
+    ) -> ProofGenerator<MockWorkerClient> {
+        generator_with_heartbeat(
+            client,
+            ProofGeneratorHeartbeatConfig::new(interval, TEST_HEARTBEAT_LOCK_DURATION_SECONDS),
+        )
+    }
+
     #[test]
     fn request_requires_claim_metadata() {
         let job = proof_job(
-            "session-1",
+            TEST_SESSION_ID,
             ProofJobStatus::Claimed,
             None,
-            Some("worker-1".to_owned()),
+            Some(TEST_WORKER_ID.to_owned()),
             PrimitiveRequestKind::Tee,
         );
 
@@ -558,10 +595,10 @@ mod tests {
     #[test]
     fn request_rejects_non_tee_jobs() {
         let job = proof_job(
-            "session-1",
+            TEST_SESSION_ID,
             ProofJobStatus::Claimed,
-            Some("lock-1".to_owned()),
-            Some("worker-1".to_owned()),
+            Some(TEST_LOCK_ID.to_owned()),
+            Some(TEST_WORKER_ID.to_owned()),
             PrimitiveRequestKind::Compressed,
         );
 
@@ -572,21 +609,9 @@ mod tests {
 
     #[tokio::test]
     async fn heartbeat_runs_while_generation_is_in_progress() {
-        let pool = Arc::new(test_pool());
         let client = MockWorkerClient::default();
-        let generator = ProofGenerator::new(
-            pool,
-            ProofSubmitter::new(client.clone()),
-            ProofGeneratorHeartbeatConfig::new(Duration::from_millis(5), 123),
-        );
-        let request = ProofGeneratorRequest::try_from(proof_job(
-            "session-1",
-            ProofJobStatus::Claimed,
-            Some("lock-1".to_owned()),
-            Some("worker-1".to_owned()),
-            PrimitiveRequestKind::Tee,
-        ))
-        .unwrap();
+        let generator = generator_with_heartbeat_interval(client.clone(), Duration::from_millis(5));
+        let request = claimed_tee_request();
 
         let err = generator
             .with_heartbeat_while_generating(&request, async {
@@ -601,30 +626,19 @@ mod tests {
         let heartbeats = client.heartbeats();
         assert!(heartbeats.len() >= 2);
         assert!(heartbeats.iter().all(|heartbeat| {
-            heartbeat.session_id == "session-1"
-                && heartbeat.lock_id == "lock-1"
-                && heartbeat.worker_id == "worker-1"
-                && heartbeat.lock_duration_seconds == 123
+            heartbeat.session_id == TEST_SESSION_ID
+                && heartbeat.lock_id == TEST_LOCK_ID
+                && heartbeat.worker_id == TEST_WORKER_ID
+                && heartbeat.lock_duration_seconds == TEST_HEARTBEAT_LOCK_DURATION_SECONDS
         }));
     }
 
     #[tokio::test]
     async fn short_generation_failure_does_not_heartbeat() {
-        let pool = Arc::new(test_pool());
         let client = MockWorkerClient::default();
-        let generator = ProofGenerator::new(
-            pool,
-            ProofSubmitter::new(client.clone()),
-            ProofGeneratorHeartbeatConfig::new(Duration::from_millis(50), 123),
-        );
-        let request = ProofGeneratorRequest::try_from(proof_job(
-            "session-1",
-            ProofJobStatus::Claimed,
-            Some("lock-1".to_owned()),
-            Some("worker-1".to_owned()),
-            PrimitiveRequestKind::Tee,
-        ))
-        .unwrap();
+        let generator =
+            generator_with_heartbeat_interval(client.clone(), Duration::from_millis(50));
+        let request = claimed_tee_request();
 
         let err = generator
             .with_heartbeat_while_generating(&request, async {
@@ -640,21 +654,9 @@ mod tests {
 
     #[tokio::test]
     async fn retryable_heartbeat_failure_does_not_abort_generation() {
-        let pool = Arc::new(test_pool());
         let client = MockWorkerClient::with_heartbeat_failure(MockHeartbeatFailure::Retryable);
-        let generator = ProofGenerator::new(
-            pool,
-            ProofSubmitter::new(client.clone()),
-            ProofGeneratorHeartbeatConfig::new(Duration::from_millis(5), 123),
-        );
-        let request = ProofGeneratorRequest::try_from(proof_job(
-            "session-1",
-            ProofJobStatus::Claimed,
-            Some("lock-1".to_owned()),
-            Some("worker-1".to_owned()),
-            PrimitiveRequestKind::Tee,
-        ))
-        .unwrap();
+        let generator = generator_with_heartbeat_interval(client.clone(), Duration::from_millis(5));
+        let request = claimed_tee_request();
 
         let err = generator
             .with_heartbeat_while_generating(&request, async {
@@ -670,21 +672,9 @@ mod tests {
 
     #[tokio::test]
     async fn non_retryable_heartbeat_failure_aborts_generation() {
-        let pool = Arc::new(test_pool());
         let client = MockWorkerClient::with_heartbeat_failure(MockHeartbeatFailure::NonRetryable);
-        let generator = ProofGenerator::new(
-            pool,
-            ProofSubmitter::new(client.clone()),
-            ProofGeneratorHeartbeatConfig::new(Duration::from_millis(5), 123),
-        );
-        let request = ProofGeneratorRequest::try_from(proof_job(
-            "session-1",
-            ProofJobStatus::Claimed,
-            Some("lock-1".to_owned()),
-            Some("worker-1".to_owned()),
-            PrimitiveRequestKind::Tee,
-        ))
-        .unwrap();
+        let generator = generator_with_heartbeat_interval(client.clone(), Duration::from_millis(5));
+        let request = claimed_tee_request();
 
         let err = generator
             .with_heartbeat_while_generating(&request, async {
@@ -700,22 +690,11 @@ mod tests {
 
     #[tokio::test]
     async fn generate_failure_does_not_spawn_submitter() {
-        let pool = Arc::new(test_pool());
         let client = MockWorkerClient::default();
-        let generator = ProofGenerator::new(
-            pool,
-            ProofSubmitter::new(client.clone()),
-            ProofGeneratorHeartbeatConfig::default(),
-        );
-        let job = proof_job(
-            "session-1",
-            ProofJobStatus::Claimed,
-            Some("lock-1".to_owned()),
-            Some("worker-1".to_owned()),
-            PrimitiveRequestKind::Tee,
-        );
+        let generator =
+            generator_with_heartbeat(client.clone(), ProofGeneratorHeartbeatConfig::default());
 
-        let err = generator.generate_and_submit(job).await.unwrap_err();
+        let err = generator.generate_and_submit(claimed_tee_job()).await.unwrap_err();
 
         assert!(matches!(err, ProofGeneratorError::Generate { .. }));
         assert!(client.submissions().is_empty());

--- a/crates/proof/tee/nitro-host/src/proof_generator.rs
+++ b/crates/proof/tee/nitro-host/src/proof_generator.rs
@@ -276,14 +276,25 @@ where
                 source,
             }),
             source = &mut heartbeat => {
-                if let Err(error) = generate.await {
-                    warn!(
-                        session_id = %request.session_id,
-                        lock_id = %request.lock_id,
-                        worker_id = %request.worker_id,
-                        error = %error,
-                        "nitro proof generation finished with error after heartbeat failure"
-                    );
+                match generate.await {
+                    Ok(_) => {
+                        info!(
+                            session_id = %request.session_id,
+                            lock_id = %request.lock_id,
+                            worker_id = %request.worker_id,
+                            l2_block = request.proof.claimed_l2_block_number,
+                            "discarding nitro proof generated after heartbeat failure"
+                        );
+                    }
+                    Err(error) => {
+                        warn!(
+                            session_id = %request.session_id,
+                            lock_id = %request.lock_id,
+                            worker_id = %request.worker_id,
+                            error = %error,
+                            "nitro proof generation finished with error after heartbeat failure"
+                        );
+                    }
                 }
 
                 Err(ProofGeneratorError::Heartbeat {

--- a/crates/proof/tee/nitro-host/src/proof_generator.rs
+++ b/crates/proof/tee/nitro-host/src/proof_generator.rs
@@ -1,21 +1,62 @@
 //! Proof generation orchestration for claimed Nitro worker jobs.
 
-use std::sync::Arc;
+use std::{future::Future, sync::Arc, time::Duration};
 
 use base_proof_primitives::ProofRequest as NitroProofRequest;
-use base_prover_service_client::ProverWorkerProvider;
+use base_prover_service_client::{ProverServiceClientError, ProverWorkerProvider};
 use base_prover_service_protocol::{
-    ProofJob, ProofRequestKind, TeeKind, WorkerSubmitProofResponse,
+    HeartbeatRequest, ProofJob, ProofRequestKind, TeeKind, WorkerSubmitProofResponse,
 };
 use thiserror::Error;
-use tokio::task::JoinHandle;
+use tokio::{task::JoinHandle, time::sleep};
 use tokio_util::sync::CancellationToken;
-use tracing::{info, warn};
+use tracing::{debug, info, warn};
 
 use crate::{
     NitroEnclavePool, NitroEnclavePoolError, ProofSubmitter, ProofSubmitterError,
     ProofSubmitterRequest,
 };
+
+/// Minimum proof-generation heartbeat interval.
+pub const MIN_PROOF_GENERATOR_HEARTBEAT_INTERVAL: Duration = Duration::from_millis(1);
+
+/// Default interval between worker API heartbeats while an enclave proof is being generated.
+pub const DEFAULT_PROOF_GENERATOR_HEARTBEAT_INTERVAL: Duration = Duration::from_secs(30);
+
+/// Default lock duration requested by proof-generation heartbeats.
+///
+/// A value of zero asks the prover service to use its server-side default.
+pub const DEFAULT_PROOF_GENERATOR_HEARTBEAT_LOCK_DURATION_SECONDS: u32 = 0;
+
+/// Heartbeat settings used while the enclave pool is generating a proof.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ProofGeneratorHeartbeatConfig {
+    /// Delay between heartbeat attempts.
+    pub interval: Duration,
+    /// Requested lock duration in seconds. Zero uses the server default.
+    pub lock_duration_seconds: u32,
+}
+
+impl ProofGeneratorHeartbeatConfig {
+    /// Creates a proof-generation heartbeat config.
+    pub const fn new(interval: Duration, lock_duration_seconds: u32) -> Self {
+        Self { interval, lock_duration_seconds }
+    }
+
+    /// Returns the configured interval clamped to the minimum allowed delay.
+    pub fn normalized_interval(&self) -> Duration {
+        self.interval.max(MIN_PROOF_GENERATOR_HEARTBEAT_INTERVAL)
+    }
+}
+
+impl Default for ProofGeneratorHeartbeatConfig {
+    fn default() -> Self {
+        Self::new(
+            DEFAULT_PROOF_GENERATOR_HEARTBEAT_INTERVAL,
+            DEFAULT_PROOF_GENERATOR_HEARTBEAT_LOCK_DURATION_SECONDS,
+        )
+    }
+}
 
 /// Claimed prover-service job data needed to generate and submit a Nitro proof.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -70,12 +111,17 @@ pub struct ProofGenerator<Client> {
     pool: Arc<NitroEnclavePool>,
     submitter: ProofSubmitter<Client>,
     submission_cancel: CancellationToken,
+    heartbeat: ProofGeneratorHeartbeatConfig,
 }
 
 impl<Client> ProofGenerator<Client> {
     /// Create a proof generator with its own submission cancellation token.
-    pub fn new(pool: Arc<NitroEnclavePool>, submitter: ProofSubmitter<Client>) -> Self {
-        Self { pool, submitter, submission_cancel: CancellationToken::new() }
+    pub fn new(
+        pool: Arc<NitroEnclavePool>,
+        submitter: ProofSubmitter<Client>,
+        heartbeat: ProofGeneratorHeartbeatConfig,
+    ) -> Self {
+        Self { pool, submitter, submission_cancel: CancellationToken::new(), heartbeat }
     }
 
     /// Use a caller-provided cancellation token for spawned submission tasks.
@@ -97,6 +143,11 @@ impl<Client> ProofGenerator<Client> {
     /// Returns the cancellation token used for spawned submission tasks.
     pub fn submission_cancel(&self) -> CancellationToken {
         self.submission_cancel.clone()
+    }
+
+    /// Returns the heartbeat settings used while proofs are generated.
+    pub const fn heartbeat_config(&self) -> ProofGeneratorHeartbeatConfig {
+        self.heartbeat
     }
 }
 
@@ -120,9 +171,12 @@ where
         );
 
         let l2_block = request.proof.claimed_l2_block_number;
-        let proof = match self.pool.prove(request.proof).await {
+        let proof = match self
+            .with_heartbeat_while_generating(&request, self.pool.prove(request.proof.clone()))
+            .await
+        {
             Ok(proof) => proof,
-            Err(source) => {
+            Err(ProofGeneratorError::Generate { session_id, source }) => {
                 warn!(
                     session_id = %request.session_id,
                     lock_id = %request.lock_id,
@@ -132,10 +186,10 @@ where
                     "nitro proof generation failed"
                 );
 
-                return Err(ProofGeneratorError::Generate {
-                    session_id: request.session_id,
-                    source,
-                });
+                return Err(ProofGeneratorError::Generate { session_id, source });
+            }
+            Err(source) => {
+                return Err(source);
             }
         };
 
@@ -166,6 +220,78 @@ where
             worker_id: request.worker_id,
             submit_handle,
         })
+    }
+
+    async fn with_heartbeat_while_generating<Output, Generate>(
+        &self,
+        request: &ProofGeneratorRequest,
+        generate: Generate,
+    ) -> Result<Output, ProofGeneratorError>
+    where
+        Generate: Future<Output = Result<Output, NitroEnclavePoolError>>,
+    {
+        let heartbeat = self.heartbeat_until_failure(request);
+        tokio::pin!(generate);
+        tokio::pin!(heartbeat);
+
+        tokio::select! {
+            biased;
+            result = &mut generate => result.map_err(|source| ProofGeneratorError::Generate {
+                session_id: request.session_id.clone(),
+                source,
+            }),
+            source = &mut heartbeat => Err(ProofGeneratorError::Heartbeat {
+                session_id: request.session_id.clone(),
+                source,
+            }),
+        }
+    }
+
+    async fn heartbeat_until_failure(
+        &self,
+        request: &ProofGeneratorRequest,
+    ) -> ProverServiceClientError {
+        loop {
+            sleep(self.heartbeat.normalized_interval()).await;
+
+            let heartbeat = HeartbeatRequest {
+                session_id: request.session_id.clone(),
+                lock_id: request.lock_id.clone(),
+                worker_id: request.worker_id.clone(),
+                lock_duration_seconds: self.heartbeat.lock_duration_seconds,
+            };
+
+            match self.submitter.heartbeat(heartbeat).await {
+                Ok(response) => {
+                    debug!(
+                        session_id = %request.session_id,
+                        lock_id = %request.lock_id,
+                        worker_id = %request.worker_id,
+                        lock_expires_at = ?response.job.lock_expires_at,
+                        "proof job heartbeat accepted"
+                    );
+                }
+                Err(error) if error.is_retryable() => {
+                    warn!(
+                        session_id = %request.session_id,
+                        lock_id = %request.lock_id,
+                        worker_id = %request.worker_id,
+                        error = %error,
+                        "proof job heartbeat failed; retrying on next interval"
+                    );
+                }
+                Err(error) => {
+                    warn!(
+                        session_id = %request.session_id,
+                        lock_id = %request.lock_id,
+                        worker_id = %request.worker_id,
+                        error = %error,
+                        "proof job heartbeat failed permanently"
+                    );
+                    return error;
+                }
+            }
+        }
     }
 }
 
@@ -199,6 +325,15 @@ pub enum ProofGeneratorError {
         #[source]
         source: NitroEnclavePoolError,
     },
+    /// Worker API heartbeat failed while the proof was being generated.
+    #[error("heartbeat failed while generating proof for job {session_id}: {source}")]
+    Heartbeat {
+        /// Proof session identifier.
+        session_id: String,
+        /// Underlying worker API error.
+        #[source]
+        source: ProverServiceClientError,
+    },
     /// The generated proof could not be converted into a worker submission request.
     #[error("failed to build proof submission for job {session_id}: {source}")]
     BuildSubmission {
@@ -225,18 +360,45 @@ mod tests {
         ProofJobStatus, ProofRequest, TeeKind, TeeProofRequest, WorkerSubmitProofRequest,
     };
     use chrono::Utc;
+    use tokio::time::sleep;
 
     use super::*;
     use crate::{NitroTransport, RegistrationChecker, test_utils::MockRegistry};
 
     #[derive(Clone, Debug, Default)]
     struct MockWorkerClient {
-        submissions: Arc<Mutex<Vec<WorkerSubmitProofRequest>>>,
+        state: Arc<Mutex<MockWorkerState>>,
+    }
+
+    #[derive(Debug, Default)]
+    struct MockWorkerState {
+        heartbeats: Vec<HeartbeatRequest>,
+        heartbeat_failure: Option<MockHeartbeatFailure>,
+        submissions: Vec<WorkerSubmitProofRequest>,
+    }
+
+    #[derive(Debug, Clone, Copy)]
+    enum MockHeartbeatFailure {
+        Retryable,
+        NonRetryable,
     }
 
     impl MockWorkerClient {
+        fn with_heartbeat_failure(failure: MockHeartbeatFailure) -> Self {
+            Self {
+                state: Arc::new(Mutex::new(MockWorkerState {
+                    heartbeat_failure: Some(failure),
+                    ..Default::default()
+                })),
+            }
+        }
+
+        fn heartbeats(&self) -> Vec<HeartbeatRequest> {
+            self.state.lock().expect("mock state lock should not be poisoned").heartbeats.clone()
+        }
+
         fn submissions(&self) -> Vec<WorkerSubmitProofRequest> {
-            self.submissions.lock().expect("submissions lock should not be poisoned").clone()
+            self.state.lock().expect("mock state lock should not be poisoned").submissions.clone()
         }
     }
 
@@ -251,18 +413,43 @@ mod tests {
 
         async fn heartbeat(
             &self,
-            _request: HeartbeatRequest,
+            request: HeartbeatRequest,
         ) -> Result<HeartbeatResponse, ProverServiceClientError> {
-            panic!("heartbeat is not used by proof generator tests")
+            let failure = {
+                let mut state = self.state.lock().expect("mock state lock should not be poisoned");
+                state.heartbeats.push(request.clone());
+                state.heartbeat_failure
+            };
+
+            match failure {
+                Some(MockHeartbeatFailure::Retryable) => Err(ProverServiceClientError::Timeout(
+                    "mock retryable heartbeat failure".to_owned(),
+                )),
+                Some(MockHeartbeatFailure::NonRetryable) => {
+                    Err(ProverServiceClientError::WorkerLeaseRejected {
+                        message: "mock lease rejected".to_owned(),
+                    })
+                }
+                None => Ok(HeartbeatResponse {
+                    job: proof_job(
+                        request.session_id,
+                        ProofJobStatus::Claimed,
+                        Some(request.lock_id),
+                        Some(request.worker_id),
+                        PrimitiveRequestKind::Tee,
+                    ),
+                }),
+            }
         }
 
         async fn submit_proof(
             &self,
             request: WorkerSubmitProofRequest,
         ) -> Result<WorkerSubmitProofResponse, ProverServiceClientError> {
-            self.submissions
+            self.state
                 .lock()
-                .expect("submissions lock should not be poisoned")
+                .expect("mock state lock should not be poisoned")
+                .submissions
                 .push(request.clone());
 
             Ok(WorkerSubmitProofResponse {
@@ -384,10 +571,142 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn heartbeat_runs_while_generation_is_in_progress() {
+        let pool = Arc::new(test_pool());
+        let client = MockWorkerClient::default();
+        let generator = ProofGenerator::new(
+            pool,
+            ProofSubmitter::new(client.clone()),
+            ProofGeneratorHeartbeatConfig::new(Duration::from_millis(5), 123),
+        );
+        let request = ProofGeneratorRequest::try_from(proof_job(
+            "session-1",
+            ProofJobStatus::Claimed,
+            Some("lock-1".to_owned()),
+            Some("worker-1".to_owned()),
+            PrimitiveRequestKind::Tee,
+        ))
+        .unwrap();
+
+        let err = generator
+            .with_heartbeat_while_generating(&request, async {
+                sleep(Duration::from_millis(20)).await;
+                Err::<(), NitroEnclavePoolError>(NitroEnclavePoolError::Busy)
+            })
+            .await
+            .unwrap_err();
+
+        assert!(matches!(err, ProofGeneratorError::Generate { .. }));
+
+        let heartbeats = client.heartbeats();
+        assert!(heartbeats.len() >= 2);
+        assert!(heartbeats.iter().all(|heartbeat| {
+            heartbeat.session_id == "session-1"
+                && heartbeat.lock_id == "lock-1"
+                && heartbeat.worker_id == "worker-1"
+                && heartbeat.lock_duration_seconds == 123
+        }));
+    }
+
+    #[tokio::test]
+    async fn short_generation_failure_does_not_heartbeat() {
+        let pool = Arc::new(test_pool());
+        let client = MockWorkerClient::default();
+        let generator = ProofGenerator::new(
+            pool,
+            ProofSubmitter::new(client.clone()),
+            ProofGeneratorHeartbeatConfig::new(Duration::from_millis(50), 123),
+        );
+        let request = ProofGeneratorRequest::try_from(proof_job(
+            "session-1",
+            ProofJobStatus::Claimed,
+            Some("lock-1".to_owned()),
+            Some("worker-1".to_owned()),
+            PrimitiveRequestKind::Tee,
+        ))
+        .unwrap();
+
+        let err = generator
+            .with_heartbeat_while_generating(&request, async {
+                tokio::task::yield_now().await;
+                Err::<(), NitroEnclavePoolError>(NitroEnclavePoolError::Busy)
+            })
+            .await
+            .unwrap_err();
+
+        assert!(matches!(err, ProofGeneratorError::Generate { .. }));
+        assert!(client.heartbeats().is_empty());
+    }
+
+    #[tokio::test]
+    async fn retryable_heartbeat_failure_does_not_abort_generation() {
+        let pool = Arc::new(test_pool());
+        let client = MockWorkerClient::with_heartbeat_failure(MockHeartbeatFailure::Retryable);
+        let generator = ProofGenerator::new(
+            pool,
+            ProofSubmitter::new(client.clone()),
+            ProofGeneratorHeartbeatConfig::new(Duration::from_millis(5), 123),
+        );
+        let request = ProofGeneratorRequest::try_from(proof_job(
+            "session-1",
+            ProofJobStatus::Claimed,
+            Some("lock-1".to_owned()),
+            Some("worker-1".to_owned()),
+            PrimitiveRequestKind::Tee,
+        ))
+        .unwrap();
+
+        let err = generator
+            .with_heartbeat_while_generating(&request, async {
+                sleep(Duration::from_millis(20)).await;
+                Err::<(), NitroEnclavePoolError>(NitroEnclavePoolError::Busy)
+            })
+            .await
+            .unwrap_err();
+
+        assert!(matches!(err, ProofGeneratorError::Generate { .. }));
+        assert!(client.heartbeats().len() >= 2);
+    }
+
+    #[tokio::test]
+    async fn non_retryable_heartbeat_failure_aborts_generation() {
+        let pool = Arc::new(test_pool());
+        let client = MockWorkerClient::with_heartbeat_failure(MockHeartbeatFailure::NonRetryable);
+        let generator = ProofGenerator::new(
+            pool,
+            ProofSubmitter::new(client.clone()),
+            ProofGeneratorHeartbeatConfig::new(Duration::from_millis(5), 123),
+        );
+        let request = ProofGeneratorRequest::try_from(proof_job(
+            "session-1",
+            ProofJobStatus::Claimed,
+            Some("lock-1".to_owned()),
+            Some("worker-1".to_owned()),
+            PrimitiveRequestKind::Tee,
+        ))
+        .unwrap();
+
+        let err = generator
+            .with_heartbeat_while_generating(&request, async {
+                sleep(Duration::from_secs(60)).await;
+                Err::<(), NitroEnclavePoolError>(NitroEnclavePoolError::Busy)
+            })
+            .await
+            .unwrap_err();
+
+        assert!(matches!(err, ProofGeneratorError::Heartbeat { .. }));
+        assert_eq!(client.heartbeats().len(), 1);
+    }
+
+    #[tokio::test]
     async fn generate_failure_does_not_spawn_submitter() {
         let pool = Arc::new(test_pool());
         let client = MockWorkerClient::default();
-        let generator = ProofGenerator::new(pool, ProofSubmitter::new(client.clone()));
+        let generator = ProofGenerator::new(
+            pool,
+            ProofSubmitter::new(client.clone()),
+            ProofGeneratorHeartbeatConfig::default(),
+        );
         let job = proof_job(
             "session-1",
             ProofJobStatus::Claimed,

--- a/crates/proof/tee/nitro-host/src/proof_submitter.rs
+++ b/crates/proof/tee/nitro-host/src/proof_submitter.rs
@@ -12,8 +12,8 @@ use backon::{ExponentialBuilder, Retryable};
 use base_proof_primitives::ProofResult as NitroProofResult;
 use base_prover_service_client::{ProverServiceClientError, ProverWorkerProvider};
 use base_prover_service_protocol::{
-    ProofResult as ServiceProofResult, TeeKind, TeeProofResult, WorkerSubmitProofRequest,
-    WorkerSubmitProofResponse,
+    HeartbeatRequest, HeartbeatResponse, ProofResult as ServiceProofResult, TeeKind,
+    TeeProofResult, WorkerSubmitProofRequest, WorkerSubmitProofResponse,
 };
 use thiserror::Error;
 use tokio::{task::JoinHandle, time::sleep};
@@ -148,6 +148,14 @@ impl<Client> ProofSubmitter<Client>
 where
     Client: ProverWorkerProvider,
 {
+    /// Extend a claimed proof job lock through the worker API.
+    pub async fn heartbeat(
+        &self,
+        request: HeartbeatRequest,
+    ) -> Result<HeartbeatResponse, ProverServiceClientError> {
+        self.client.heartbeat(request).await
+    }
+
     /// Submits a generated proof, retrying retryable delivery failures until success.
     ///
     /// This method has no cancellation or retry limit. Use


### PR DESCRIPTION
### What changed? Why?

Adds heartbeat updates while Nitro proof generation is in progress so long-running proof jobs stay visible as active. Also logs proof aborts caused by heartbeat failures and caps retryable heartbeat failures so generation eventually aborts instead of running indefinitely with stale status.

### How has it been tested?

cargo test -p base-proof-tee-nitro-host