### PR TITLE
chore(challenger): add prover-service proof adapters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5876,7 +5876,6 @@ dependencies = [
  "tokio-util",
  "tracing",
  "url",
- "uuid",
 ]
 
 [[package]]
@@ -6050,6 +6049,7 @@ dependencies = [
  "jsonrpsee",
  "serde",
  "serde_json",
+ "uuid",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3594,6 +3594,7 @@ dependencies = [
  "base-proof-primitives",
  "base-proof-rpc",
  "base-protocol",
+ "base-prover-service-protocol",
  "base-runtime",
  "base-tx-manager",
  "base-zk-client",

--- a/crates/proof/challenge/Cargo.toml
+++ b/crates/proof/challenge/Cargo.toml
@@ -31,6 +31,7 @@ base-balance-monitor.workspace = true
 base-proof-rpc.workspace = true
 base-zk-client.workspace = true
 base-proof-contracts.workspace = true
+base-prover-service-protocol.workspace = true
 base-proof-primitives = { workspace = true, features = ["rpc-client"] }
 
 # Protocol

--- a/crates/proof/challenge/src/lib.rs
+++ b/crates/proof/challenge/src/lib.rs
@@ -18,6 +18,9 @@ pub use driver::{Driver, DriverComponents, DriverConfig, TeeConfig};
 mod pending;
 pub use pending::{DisputeIntent, PendingProof, PendingProofs, ProofKind, ProofPhase, ProofUpdate};
 
+mod proof_adapter;
+pub use proof_adapter::ChallengerProofAdapter;
+
 mod error;
 pub use error::ChallengeSubmitError;
 

--- a/crates/proof/challenge/src/proof_adapter.rs
+++ b/crates/proof/challenge/src/proof_adapter.rs
@@ -1,14 +1,12 @@
 //! Adapters between challenger proof types and the shared prover-service protocol.
 
-use alloy_primitives::{Address, B256, Bytes};
+use alloy_primitives::{B256, Bytes};
 use base_proof_primitives::{PROOF_TYPE_ZK, ProofEncoder, ProofRequest as PrimitiveProofRequest};
 use base_prover_service_protocol::{
-    ProofRequest, ProofRequestKind, ProofResult, ProveBlockRangeRequest, SnarkGroth16ProofRequest,
-    TeeKind, TeeProofRequest, ZkProofRequest, ZkVm,
+    ProofRequest, ProofRequestKind, ProofResult, ProofSessionId, ProveBlockRangeRequest,
+    SnarkGroth16ProofRequest, TeeKind, TeeProofRequest,
 };
-use base_zk_client::{ProofType as ZkServiceProofType, ProveBlockRequest};
-use eyre::{Result, WrapErr, bail, eyre};
-use uuid::Uuid;
+use eyre::{Result, WrapErr, bail};
 
 /// Conversion helpers for challenger proof requests and dispute proof bytes.
 #[derive(Debug)]
@@ -17,9 +15,6 @@ pub struct ChallengerProofAdapter;
 impl ChallengerProofAdapter {
     /// Namespace used to derive challenger proof session IDs.
     pub const SESSION_NAMESPACE: &'static [u8] = b"base/challenger/proof-session/v1";
-
-    /// Separator used between session ID components before `UUIDv5` hashing.
-    pub const SESSION_COMPONENT_SEPARATOR: &'static [u8] = b":";
 
     /// Returns the session-ID proof subtype label for challenger SNARK proofs.
     pub const fn snark_groth16_session_label() -> &'static str {
@@ -33,78 +28,36 @@ impl ChallengerProofAdapter {
         }
     }
 
-    /// Derives an idempotent proof session ID from proof subtype and disputed root.
-    pub fn session_id(proof_subtype: &str, disputed_root: B256) -> String {
-        let root = disputed_root.as_slice();
-        let mut name = Vec::with_capacity(
-            Self::SESSION_NAMESPACE.len()
-                + Self::SESSION_COMPONENT_SEPARATOR.len()
-                + proof_subtype.len()
-                + Self::SESSION_COMPONENT_SEPARATOR.len()
-                + root.len(),
-        );
-        name.extend_from_slice(Self::SESSION_NAMESPACE);
-        name.extend_from_slice(Self::SESSION_COMPONENT_SEPARATOR);
-        name.extend_from_slice(proof_subtype.as_bytes());
-        name.extend_from_slice(Self::SESSION_COMPONENT_SEPARATOR);
-        name.extend_from_slice(root);
-
-        Uuid::new_v5(&Uuid::NAMESPACE_OID, &name).to_string()
-    }
-
     /// Derives an idempotent challenger SNARK proof session ID.
     pub fn snark_groth16_session_id(disputed_root: B256) -> String {
-        Self::session_id(Self::snark_groth16_session_label(), disputed_root)
+        ProofSessionId::derive(
+            Self::SESSION_NAMESPACE,
+            Self::snark_groth16_session_label(),
+            disputed_root,
+        )
     }
 
     /// Derives an idempotent challenger TEE proof session ID.
     pub fn tee_session_id(disputed_root: B256, tee_kind: TeeKind) -> String {
-        Self::session_id(Self::tee_session_label(tee_kind), disputed_root)
+        ProofSessionId::derive(
+            Self::SESSION_NAMESPACE,
+            Self::tee_session_label(tee_kind),
+            disputed_root,
+        )
     }
 
     /// Builds a prover-service request for a challenger SNARK proof.
     pub fn snark_groth16_prove_block_range_request(
-        request: ProveBlockRequest,
-    ) -> Result<ProveBlockRangeRequest> {
-        let expected_proof_type: i32 = ZkServiceProofType::SnarkGroth16.into();
-        if request.proof_type != expected_proof_type {
-            bail!(
-                "expected SNARK_GROTH16 proof_type {}, got {}",
-                expected_proof_type,
-                request.proof_type
-            );
-        }
-
-        let l1_head = request
-            .l1_head
-            .as_deref()
-            .map(str::parse::<B256>)
-            .transpose()
-            .wrap_err("l1_head must be a 0x-prefixed 32-byte hash")?;
-        let prover_address = request
-            .prover_address
-            .as_deref()
-            .ok_or_else(|| eyre!("prover_address is required for SNARK_GROTH16 proofs"))?
-            .parse::<Address>()
-            .wrap_err("prover_address must be a valid Ethereum address")?;
-        let proof = ZkProofRequest {
-            start_block_number: request.start_block_number,
-            number_of_blocks_to_prove: request.number_of_blocks_to_prove,
-            sequence_window: request.sequence_window,
-            l1_head,
-            intermediate_root_interval: request.intermediate_root_interval,
-            zk_vm: ZkVm::Sp1,
-        };
-
-        Ok(ProveBlockRangeRequest {
+        disputed_root: B256,
+        request: SnarkGroth16ProofRequest,
+    ) -> ProveBlockRangeRequest {
+        let session_id = Self::snark_groth16_session_id(disputed_root);
+        ProveBlockRangeRequest {
             proof: ProofRequest {
-                session_id: request.session_id,
-                request: ProofRequestKind::SnarkGroth16(SnarkGroth16ProofRequest {
-                    proof,
-                    prover_address,
-                }),
+                session_id: Some(session_id),
+                request: ProofRequestKind::SnarkGroth16(request),
             },
-        })
+        }
     }
 
     /// Builds a prover-service request for a challenger TEE proof.
@@ -168,10 +121,9 @@ mod tests {
     use alloy_primitives::{Address, B256, Bytes};
     use base_proof_primitives::{PROOF_TYPE_TEE, Proposal};
     use base_prover_service_protocol::{
-        ProofRequestKind, ProofResult, SnarkGroth16ProofResult, TeeKind, TeeProofResult,
-        ZkProofResult, ZkVm,
+        ProofRequestKind, ProofResult, SnarkGroth16ProofRequest, SnarkGroth16ProofResult, TeeKind,
+        TeeProofResult, ZkProofRequest, ZkProofResult, ZkVm,
     };
-    use base_zk_client::{ProofType as ZkServiceProofType, ProveBlockRequest};
 
     use super::ChallengerProofAdapter;
 
@@ -219,22 +171,22 @@ mod tests {
 
     #[test]
     fn snark_groth16_prove_block_range_request_converts_zk_request() {
-        let session_id = "session-zk".to_owned();
+        let root = B256::repeat_byte(0xaa);
+        let session_id = ChallengerProofAdapter::snark_groth16_session_id(root);
         let prover_address = Address::repeat_byte(0x11);
         let l1_head = B256::repeat_byte(0x22);
-        let request = ProveBlockRequest {
+        let proof = ZkProofRequest {
             start_block_number: 100,
             number_of_blocks_to_prove: 300,
             sequence_window: Some(10),
-            proof_type: ZkServiceProofType::SnarkGroth16.into(),
-            session_id: Some(session_id.clone()),
-            prover_address: Some(format!("{prover_address:#x}")),
-            l1_head: Some(format!("{l1_head:#x}")),
+            l1_head: Some(l1_head),
             intermediate_root_interval: Some(150),
+            zk_vm: ZkVm::Sp1,
         };
+        let request = SnarkGroth16ProofRequest { proof, prover_address };
 
         let wrapped =
-            ChallengerProofAdapter::snark_groth16_prove_block_range_request(request).unwrap();
+            ChallengerProofAdapter::snark_groth16_prove_block_range_request(root, request);
 
         assert_eq!(wrapped.proof.session_id.as_deref(), Some(session_id.as_str()));
         match wrapped.proof.request {
@@ -249,20 +201,6 @@ mod tests {
             }
             other => panic!("unexpected proof request kind: {other:?}"),
         }
-    }
-
-    #[test]
-    fn snark_groth16_prove_block_range_request_rejects_non_snark_type() {
-        let request = ProveBlockRequest {
-            proof_type: ZkServiceProofType::Compressed.into(),
-            prover_address: Some(format!("{:#x}", Address::repeat_byte(0x11))),
-            ..Default::default()
-        };
-
-        let err = ChallengerProofAdapter::snark_groth16_prove_block_range_request(request)
-            .expect_err("compressed proof type should be rejected");
-
-        assert!(err.to_string().contains("SNARK_GROTH16"));
     }
 
     #[test]

--- a/crates/proof/challenge/src/proof_adapter.rs
+++ b/crates/proof/challenge/src/proof_adapter.rs
@@ -1,0 +1,310 @@
+//! Adapters between challenger proof types and the shared prover-service protocol.
+
+use alloy_primitives::{Address, B256, Bytes};
+use base_proof_primitives::{PROOF_TYPE_ZK, ProofEncoder, ProofRequest as PrimitiveProofRequest};
+use base_prover_service_protocol::{
+    ProofRequest, ProofRequestKind, ProofResult, ProveBlockRangeRequest, SnarkGroth16ProofRequest,
+    TeeKind, TeeProofRequest, ZkProofRequest, ZkVm,
+};
+use base_zk_client::{ProofType as ZkServiceProofType, ProveBlockRequest};
+use eyre::{Result, WrapErr, bail, eyre};
+use uuid::Uuid;
+
+/// Conversion helpers for challenger proof requests and dispute proof bytes.
+#[derive(Debug)]
+pub struct ChallengerProofAdapter;
+
+impl ChallengerProofAdapter {
+    /// Namespace used to derive challenger proof session IDs.
+    pub const SESSION_NAMESPACE: &'static [u8] = b"base/challenger/proof-session/v1";
+
+    /// Returns the session-ID proof subtype label for challenger SNARK proofs.
+    pub const fn snark_groth16_session_label() -> &'static str {
+        "zk/sp1/snark_groth16"
+    }
+
+    /// Returns the session-ID proof subtype label for a TEE implementation.
+    pub const fn tee_session_label(tee_kind: TeeKind) -> &'static str {
+        match tee_kind {
+            TeeKind::AwsNitro => "tee/aws_nitro",
+        }
+    }
+
+    /// Derives an idempotent proof session ID from proof subtype and disputed root.
+    pub fn session_id(proof_subtype: &str, disputed_root: B256) -> String {
+        let mut name = Vec::with_capacity(
+            Self::SESSION_NAMESPACE.len() + proof_subtype.len() + disputed_root.len(),
+        );
+        name.extend_from_slice(Self::SESSION_NAMESPACE);
+        name.extend_from_slice(proof_subtype.as_bytes());
+        name.extend_from_slice(disputed_root.as_slice());
+
+        Uuid::new_v5(&Uuid::NAMESPACE_OID, &name).to_string()
+    }
+
+    /// Derives an idempotent challenger SNARK proof session ID.
+    pub fn snark_groth16_session_id(disputed_root: B256) -> String {
+        Self::session_id(Self::snark_groth16_session_label(), disputed_root)
+    }
+
+    /// Derives an idempotent challenger TEE proof session ID.
+    pub fn tee_session_id(disputed_root: B256, tee_kind: TeeKind) -> String {
+        Self::session_id(Self::tee_session_label(tee_kind), disputed_root)
+    }
+
+    /// Builds a prover-service request for a challenger SNARK proof.
+    pub fn snark_groth16_prove_block_range_request(
+        request: ProveBlockRequest,
+    ) -> Result<ProveBlockRangeRequest> {
+        let expected_proof_type: i32 = ZkServiceProofType::SnarkGroth16.into();
+        if request.proof_type != expected_proof_type {
+            bail!(
+                "expected SNARK_GROTH16 proof_type {}, got {}",
+                expected_proof_type,
+                request.proof_type
+            );
+        }
+
+        let l1_head = request
+            .l1_head
+            .as_deref()
+            .map(str::parse::<B256>)
+            .transpose()
+            .wrap_err("l1_head must be a 0x-prefixed 32-byte hash")?;
+        let prover_address = request
+            .prover_address
+            .as_deref()
+            .ok_or_else(|| eyre!("prover_address is required for SNARK_GROTH16 proofs"))?
+            .parse::<Address>()
+            .wrap_err("prover_address must be a valid Ethereum address")?;
+        let proof = ZkProofRequest {
+            start_block_number: request.start_block_number,
+            number_of_blocks_to_prove: request.number_of_blocks_to_prove,
+            sequence_window: request.sequence_window,
+            l1_head,
+            intermediate_root_interval: request.intermediate_root_interval,
+            zk_vm: ZkVm::Sp1,
+        };
+
+        Ok(ProveBlockRangeRequest {
+            proof: ProofRequest {
+                session_id: request.session_id,
+                request: ProofRequestKind::SnarkGroth16(SnarkGroth16ProofRequest {
+                    proof,
+                    prover_address,
+                }),
+            },
+        })
+    }
+
+    /// Builds a prover-service request for a challenger TEE proof.
+    pub const fn tee_prove_block_range_request(
+        session_id: String,
+        request: PrimitiveProofRequest,
+        tee_kind: TeeKind,
+    ) -> ProveBlockRangeRequest {
+        ProveBlockRangeRequest {
+            proof: ProofRequest {
+                session_id: Some(session_id),
+                request: ProofRequestKind::Tee(TeeProofRequest { proof: request, tee_kind }),
+            },
+        }
+    }
+
+    /// Converts a prover-service SNARK result into bytes accepted by `submit_dispute`.
+    pub fn snark_groth16_dispute_proof_bytes(result: ProofResult) -> Result<Bytes> {
+        let proof = match result {
+            ProofResult::SnarkGroth16(result) => result.proof.proof,
+            other => bail!("expected SNARK_GROTH16 proof result, got {other:?}"),
+        };
+
+        let mut raw = Vec::with_capacity(1 + proof.len());
+        raw.push(PROOF_TYPE_ZK);
+        raw.extend_from_slice(proof.as_ref());
+        Ok(Bytes::from(raw))
+    }
+
+    /// Converts a prover-service TEE result into bytes accepted by `submit_dispute`.
+    pub fn tee_dispute_proof_bytes(result: ProofResult, expected_root: B256) -> Result<Bytes> {
+        let aggregate_proposal = match result {
+            ProofResult::Tee(result) => result.aggregate_proposal,
+            other => bail!("expected TEE proof result, got {other:?}"),
+        };
+
+        if aggregate_proposal.output_root != expected_root {
+            bail!(
+                "TEE computed unexpected output root: expected {expected_root}, got {}",
+                aggregate_proposal.output_root
+            );
+        }
+
+        ProofEncoder::encode_dispute_proof_bytes(&aggregate_proposal.signature)
+            .wrap_err("TEE proof encoding failed")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_primitives::{Address, B256, Bytes};
+    use base_proof_primitives::{PROOF_TYPE_TEE, Proposal};
+    use base_prover_service_protocol::{
+        ProofRequestKind, ProofResult, SnarkGroth16ProofResult, TeeKind, TeeProofResult,
+        ZkProofResult, ZkVm,
+    };
+    use base_zk_client::{ProofType as ZkServiceProofType, ProveBlockRequest};
+
+    use super::ChallengerProofAdapter;
+
+    fn test_primitive_request(root: B256) -> base_proof_primitives::ProofRequest {
+        base_proof_primitives::ProofRequest {
+            l1_head: B256::repeat_byte(0x01),
+            agreed_l2_head_hash: B256::repeat_byte(0x02),
+            agreed_l2_output_root: B256::repeat_byte(0x03),
+            claimed_l2_output_root: root,
+            claimed_l2_block_number: 600,
+            proposer: Address::repeat_byte(0x04),
+            intermediate_block_interval: 300,
+            l1_head_number: 1200,
+            image_hash: B256::repeat_byte(0x05),
+        }
+    }
+
+    fn test_proposal(root: B256) -> Proposal {
+        let mut signature = vec![0xab; 65];
+        signature[64] = 0;
+        Proposal {
+            output_root: root,
+            signature: Bytes::from(signature),
+            l1_origin_hash: B256::repeat_byte(0x06),
+            l1_origin_number: 1200,
+            l2_block_number: 600,
+            prev_output_root: B256::repeat_byte(0x07),
+            config_hash: B256::repeat_byte(0x08),
+        }
+    }
+
+    #[test]
+    fn challenger_session_ids_are_stable_and_type_separated() {
+        let root = B256::repeat_byte(0xaa);
+
+        assert_eq!(
+            ChallengerProofAdapter::snark_groth16_session_id(root),
+            ChallengerProofAdapter::snark_groth16_session_id(root)
+        );
+        assert_ne!(
+            ChallengerProofAdapter::snark_groth16_session_id(root),
+            ChallengerProofAdapter::tee_session_id(root, TeeKind::AwsNitro)
+        );
+    }
+
+    #[test]
+    fn snark_groth16_prove_block_range_request_converts_zk_request() {
+        let session_id = "session-zk".to_owned();
+        let prover_address = Address::repeat_byte(0x11);
+        let l1_head = B256::repeat_byte(0x22);
+        let request = ProveBlockRequest {
+            start_block_number: 100,
+            number_of_blocks_to_prove: 300,
+            sequence_window: Some(10),
+            proof_type: ZkServiceProofType::SnarkGroth16.into(),
+            session_id: Some(session_id.clone()),
+            prover_address: Some(format!("{prover_address:#x}")),
+            l1_head: Some(format!("{l1_head:#x}")),
+            intermediate_root_interval: Some(150),
+        };
+
+        let wrapped =
+            ChallengerProofAdapter::snark_groth16_prove_block_range_request(request).unwrap();
+
+        assert_eq!(wrapped.proof.session_id.as_deref(), Some(session_id.as_str()));
+        match wrapped.proof.request {
+            ProofRequestKind::SnarkGroth16(snark) => {
+                assert_eq!(snark.prover_address, prover_address);
+                assert_eq!(snark.proof.start_block_number, 100);
+                assert_eq!(snark.proof.number_of_blocks_to_prove, 300);
+                assert_eq!(snark.proof.sequence_window, Some(10));
+                assert_eq!(snark.proof.l1_head, Some(l1_head));
+                assert_eq!(snark.proof.intermediate_root_interval, Some(150));
+                assert_eq!(snark.proof.zk_vm, ZkVm::Sp1);
+            }
+            other => panic!("unexpected proof request kind: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn snark_groth16_prove_block_range_request_rejects_non_snark_type() {
+        let request = ProveBlockRequest {
+            proof_type: ZkServiceProofType::Compressed.into(),
+            prover_address: Some(format!("{:#x}", Address::repeat_byte(0x11))),
+            ..Default::default()
+        };
+
+        let err = ChallengerProofAdapter::snark_groth16_prove_block_range_request(request)
+            .expect_err("compressed proof type should be rejected");
+
+        assert!(err.to_string().contains("SNARK_GROTH16"));
+    }
+
+    #[test]
+    fn tee_prove_block_range_request_wraps_primitive_request() {
+        let root = B256::repeat_byte(0xaa);
+        let request = test_primitive_request(root);
+        let session_id = ChallengerProofAdapter::tee_session_id(root, TeeKind::AwsNitro);
+
+        let wrapped = ChallengerProofAdapter::tee_prove_block_range_request(
+            session_id.clone(),
+            request.clone(),
+            TeeKind::AwsNitro,
+        );
+
+        assert_eq!(wrapped.proof.session_id.as_deref(), Some(session_id.as_str()));
+        match wrapped.proof.request {
+            ProofRequestKind::Tee(tee) => {
+                assert_eq!(tee.proof, request);
+                assert_eq!(tee.tee_kind, TeeKind::AwsNitro);
+            }
+            other => panic!("unexpected proof request kind: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn snark_groth16_dispute_proof_bytes_prefixes_zk_type() {
+        let result = ProofResult::SnarkGroth16(SnarkGroth16ProofResult {
+            proof: ZkProofResult { zk_vm: ZkVm::Sp1, proof: Bytes::from_static(&[0xab, 0xcd]) },
+        });
+
+        let proof_bytes =
+            ChallengerProofAdapter::snark_groth16_dispute_proof_bytes(result).unwrap();
+
+        assert_eq!(proof_bytes.as_ref(), &[1, 0xab, 0xcd]);
+    }
+
+    #[test]
+    fn tee_dispute_proof_bytes_encodes_signature() {
+        let root = B256::repeat_byte(0xaa);
+        let result = ProofResult::Tee(TeeProofResult {
+            aggregate_proposal: test_proposal(root),
+            proposals: Vec::new(),
+            tee_kind: TeeKind::AwsNitro,
+        });
+
+        let proof_bytes = ChallengerProofAdapter::tee_dispute_proof_bytes(result, root).unwrap();
+
+        assert_eq!(proof_bytes[0], PROOF_TYPE_TEE);
+        assert_eq!(proof_bytes.len(), 66);
+    }
+
+    #[test]
+    fn tee_dispute_proof_bytes_rejects_unexpected_root() {
+        let result = ProofResult::Tee(TeeProofResult {
+            aggregate_proposal: test_proposal(B256::repeat_byte(0xaa)),
+            proposals: Vec::new(),
+            tee_kind: TeeKind::AwsNitro,
+        });
+
+        let err = ChallengerProofAdapter::tee_dispute_proof_bytes(result, B256::repeat_byte(0xbb))
+            .expect_err("root mismatch should be rejected");
+
+        assert!(err.to_string().contains("unexpected output root"));
+    }
+}

--- a/crates/proof/challenge/src/proof_adapter.rs
+++ b/crates/proof/challenge/src/proof_adapter.rs
@@ -125,11 +125,11 @@ impl ChallengerProofAdapter {
     pub fn snark_groth16_dispute_proof_bytes(result: ProofResult) -> Result<Bytes> {
         let proof = match result {
             ProofResult::SnarkGroth16(result) => result.proof.proof,
-            ProofResult::Compressed(result) => {
-                bail!("expected SNARK_GROTH16 proof result, got {result:?}")
+            ProofResult::Compressed(_) => {
+                bail!("expected SNARK_GROTH16 proof result, got Compressed")
             }
-            ProofResult::Tee(result) => {
-                bail!("expected SNARK_GROTH16 proof result, got {result:?}")
+            ProofResult::Tee(_) => {
+                bail!("expected SNARK_GROTH16 proof result, got Tee")
             }
         };
 
@@ -143,11 +143,11 @@ impl ChallengerProofAdapter {
     pub fn tee_dispute_proof_bytes(result: ProofResult, expected_root: B256) -> Result<Bytes> {
         let aggregate_proposal = match result {
             ProofResult::Tee(result) => result.aggregate_proposal,
-            ProofResult::Compressed(result) => {
-                bail!("expected TEE proof result, got {result:?}")
+            ProofResult::Compressed(_) => {
+                bail!("expected TEE proof result, got Compressed")
             }
-            ProofResult::SnarkGroth16(result) => {
-                bail!("expected TEE proof result, got {result:?}")
+            ProofResult::SnarkGroth16(_) => {
+                bail!("expected TEE proof result, got SnarkGroth16")
             }
         };
 

--- a/crates/proof/challenge/src/proof_adapter.rs
+++ b/crates/proof/challenge/src/proof_adapter.rs
@@ -18,6 +18,9 @@ impl ChallengerProofAdapter {
     /// Namespace used to derive challenger proof session IDs.
     pub const SESSION_NAMESPACE: &'static [u8] = b"base/challenger/proof-session/v1";
 
+    /// Separator used between session ID components before `UUIDv5` hashing.
+    pub const SESSION_COMPONENT_SEPARATOR: &'static [u8] = b":";
+
     /// Returns the session-ID proof subtype label for challenger SNARK proofs.
     pub const fn snark_groth16_session_label() -> &'static str {
         "zk/sp1/snark_groth16"
@@ -32,12 +35,19 @@ impl ChallengerProofAdapter {
 
     /// Derives an idempotent proof session ID from proof subtype and disputed root.
     pub fn session_id(proof_subtype: &str, disputed_root: B256) -> String {
+        let root = disputed_root.as_slice();
         let mut name = Vec::with_capacity(
-            Self::SESSION_NAMESPACE.len() + proof_subtype.len() + disputed_root.len(),
+            Self::SESSION_NAMESPACE.len()
+                + Self::SESSION_COMPONENT_SEPARATOR.len()
+                + proof_subtype.len()
+                + Self::SESSION_COMPONENT_SEPARATOR.len()
+                + root.len(),
         );
         name.extend_from_slice(Self::SESSION_NAMESPACE);
+        name.extend_from_slice(Self::SESSION_COMPONENT_SEPARATOR);
         name.extend_from_slice(proof_subtype.as_bytes());
-        name.extend_from_slice(disputed_root.as_slice());
+        name.extend_from_slice(Self::SESSION_COMPONENT_SEPARATOR);
+        name.extend_from_slice(root);
 
         Uuid::new_v5(&Uuid::NAMESPACE_OID, &name).to_string()
     }
@@ -98,11 +108,11 @@ impl ChallengerProofAdapter {
     }
 
     /// Builds a prover-service request for a challenger TEE proof.
-    pub const fn tee_prove_block_range_request(
-        session_id: String,
+    pub fn tee_prove_block_range_request(
         request: PrimitiveProofRequest,
         tee_kind: TeeKind,
     ) -> ProveBlockRangeRequest {
+        let session_id = Self::tee_session_id(request.claimed_l2_output_root, tee_kind);
         ProveBlockRangeRequest {
             proof: ProofRequest {
                 session_id: Some(session_id),
@@ -115,7 +125,12 @@ impl ChallengerProofAdapter {
     pub fn snark_groth16_dispute_proof_bytes(result: ProofResult) -> Result<Bytes> {
         let proof = match result {
             ProofResult::SnarkGroth16(result) => result.proof.proof,
-            other => bail!("expected SNARK_GROTH16 proof result, got {other:?}"),
+            ProofResult::Compressed(result) => {
+                bail!("expected SNARK_GROTH16 proof result, got {result:?}")
+            }
+            ProofResult::Tee(result) => {
+                bail!("expected SNARK_GROTH16 proof result, got {result:?}")
+            }
         };
 
         let mut raw = Vec::with_capacity(1 + proof.len());
@@ -128,7 +143,12 @@ impl ChallengerProofAdapter {
     pub fn tee_dispute_proof_bytes(result: ProofResult, expected_root: B256) -> Result<Bytes> {
         let aggregate_proposal = match result {
             ProofResult::Tee(result) => result.aggregate_proposal,
-            other => bail!("expected TEE proof result, got {other:?}"),
+            ProofResult::Compressed(result) => {
+                bail!("expected TEE proof result, got {result:?}")
+            }
+            ProofResult::SnarkGroth16(result) => {
+                bail!("expected TEE proof result, got {result:?}")
+            }
         };
 
         if aggregate_proposal.output_root != expected_root {
@@ -252,7 +272,6 @@ mod tests {
         let session_id = ChallengerProofAdapter::tee_session_id(root, TeeKind::AwsNitro);
 
         let wrapped = ChallengerProofAdapter::tee_prove_block_range_request(
-            session_id.clone(),
             request.clone(),
             TeeKind::AwsNitro,
         );

--- a/crates/proof/proposer/Cargo.toml
+++ b/crates/proof/proposer/Cargo.toml
@@ -66,7 +66,6 @@ base-health = { workspace = true, features = ["axum-server"] }
 # Misc
 url.workspace = true
 humantime.workspace = true
-uuid = { workspace = true, features = ["v5"] }
 
 [dev-dependencies]
 rstest.workspace = true

--- a/crates/proof/proposer/src/proof_adapter.rs
+++ b/crates/proof/proposer/src/proof_adapter.rs
@@ -4,9 +4,9 @@ use base_proof_primitives::{
     ProofRequest as PrimitiveProofRequest, ProofResult as PrimitiveProofResult,
 };
 use base_prover_service_protocol::{
-    ProofRequest, ProofRequestKind, ProofResult, ProveBlockRangeRequest, TeeKind, TeeProofRequest,
+    ProofRequest, ProofRequestKind, ProofResult, ProofSessionId, ProveBlockRangeRequest, TeeKind,
+    TeeProofRequest,
 };
-use uuid::Uuid;
 
 use crate::ProposerError;
 
@@ -17,9 +17,6 @@ pub struct ProposerProofAdapter;
 impl ProposerProofAdapter {
     /// Namespace used to derive proposer proof session IDs.
     pub const SESSION_NAMESPACE: &'static [u8] = b"base/proposer/proof-session/v1";
-
-    /// Separator used between session ID components before `UUIDv5` hashing.
-    pub const SESSION_COMPONENT_SEPARATOR: &'static [u8] = b":";
 
     /// Returns the session-ID proof subtype label for a TEE implementation.
     pub const fn tee_session_label(tee_kind: TeeKind) -> &'static str {
@@ -34,22 +31,11 @@ impl ProposerProofAdapter {
     /// `proof type + root`. Other request fields are excluded so redeploys or
     /// retries for the same proof identity re-use the same prover-service session.
     pub fn tee_session_id(request: &PrimitiveProofRequest, tee_kind: TeeKind) -> String {
-        let label = Self::tee_session_label(tee_kind).as_bytes();
-        let root = request.claimed_l2_output_root.as_slice();
-        let mut name = Vec::with_capacity(
-            Self::SESSION_NAMESPACE.len()
-                + Self::SESSION_COMPONENT_SEPARATOR.len()
-                + label.len()
-                + Self::SESSION_COMPONENT_SEPARATOR.len()
-                + root.len(),
-        );
-        name.extend_from_slice(Self::SESSION_NAMESPACE);
-        name.extend_from_slice(Self::SESSION_COMPONENT_SEPARATOR);
-        name.extend_from_slice(label);
-        name.extend_from_slice(Self::SESSION_COMPONENT_SEPARATOR);
-        name.extend_from_slice(root);
-
-        Uuid::new_v5(&Uuid::NAMESPACE_OID, &name).to_string()
+        ProofSessionId::derive(
+            Self::SESSION_NAMESPACE,
+            Self::tee_session_label(tee_kind),
+            request.claimed_l2_output_root,
+        )
     }
 
     /// Builds a prover-service request for a TEE proposal proof.

--- a/crates/proof/prover-service/protocol/Cargo.toml
+++ b/crates/proof/prover-service/protocol/Cargo.toml
@@ -22,6 +22,9 @@ chrono = { workspace = true, features = ["serde"] }
 # RPC
 jsonrpsee = { workspace = true, optional = true }
 
+# Misc
+uuid = { workspace = true, features = ["v5"] }
+
 [dev-dependencies]
 serde_json = { workspace = true, features = ["std"] }
 

--- a/crates/proof/prover-service/protocol/src/lib.rs
+++ b/crates/proof/prover-service/protocol/src/lib.rs
@@ -7,6 +7,9 @@ pub use api::{ProverRequesterApiClient, ProverWorkerApiClient};
 #[cfg(feature = "rpc-server")]
 pub use api::{ProverRequesterApiServer, ProverWorkerApiServer};
 
+mod session;
+pub use session::ProofSessionId;
+
 mod types;
 pub use types::{
     GetNextProofRequest, GetNextProofResponse, GetProofRequest, GetProofResponse, HeartbeatRequest,

--- a/crates/proof/prover-service/protocol/src/session.rs
+++ b/crates/proof/prover-service/protocol/src/session.rs
@@ -1,0 +1,65 @@
+//! Session ID derivation helpers for prover-service proof requests.
+
+use alloy_primitives::B256;
+use uuid::Uuid;
+
+/// Shared prover-service proof session ID derivation.
+#[derive(Debug)]
+pub struct ProofSessionId;
+
+impl ProofSessionId {
+    /// Separator used between session ID components before `UUIDv5` hashing.
+    pub const COMPONENT_SEPARATOR: &'static [u8] = b":";
+
+    /// Derives an idempotent proof session ID from namespace, proof subtype, and root.
+    pub fn derive(namespace: &[u8], proof_subtype: &str, root: B256) -> String {
+        let root = root.as_slice();
+        let mut name = Vec::with_capacity(
+            namespace.len()
+                + Self::COMPONENT_SEPARATOR.len()
+                + proof_subtype.len()
+                + Self::COMPONENT_SEPARATOR.len()
+                + root.len(),
+        );
+        name.extend_from_slice(namespace);
+        name.extend_from_slice(Self::COMPONENT_SEPARATOR);
+        name.extend_from_slice(proof_subtype.as_bytes());
+        name.extend_from_slice(Self::COMPONENT_SEPARATOR);
+        name.extend_from_slice(root);
+
+        Uuid::new_v5(&Uuid::NAMESPACE_OID, &name).to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_primitives::B256;
+
+    use super::ProofSessionId;
+
+    #[test]
+    fn derive_is_stable_for_same_inputs() {
+        assert_eq!(
+            ProofSessionId::derive(b"namespace", "tee/aws_nitro", B256::repeat_byte(0xaa)),
+            ProofSessionId::derive(b"namespace", "tee/aws_nitro", B256::repeat_byte(0xaa)),
+        );
+    }
+
+    #[test]
+    fn derive_separates_namespace_subtype_and_root() {
+        let root = B256::repeat_byte(0xaa);
+
+        assert_ne!(
+            ProofSessionId::derive(b"namespace", "tee/aws_nitro", root),
+            ProofSessionId::derive(b"other-namespace", "tee/aws_nitro", root),
+        );
+        assert_ne!(
+            ProofSessionId::derive(b"namespace", "tee/aws_nitro", root),
+            ProofSessionId::derive(b"namespace", "zk/sp1/snark_groth16", root),
+        );
+        assert_ne!(
+            ProofSessionId::derive(b"namespace", "tee/aws_nitro", root),
+            ProofSessionId::derive(b"namespace", "tee/aws_nitro", B256::repeat_byte(0xbb)),
+        );
+    }
+}


### PR DESCRIPTION
## What

Adds adapter-only groundwork for migrating challenger proof sourcing to the consolidated prover service requester API.

- Adds `ChallengerProofAdapter`.
- Derives deterministic UUIDv5 proof session IDs from proof subtype + disputed root for:
  - `zk/sp1/snark_groth16`
  - `tee/aws_nitro`
- Converts existing challenger `base_zk_client::ProveBlockRequest` values into prover-service `ProveBlockRangeRequest` with `ProofRequestKind::SnarkGroth16`.
- Wraps primitive TEE proof requests into prover-service `ProveBlockRangeRequest` with `ProofRequestKind::Tee`.
- Converts prover-service SNARK results into `PROOF_TYPE_ZK || proof` bytes for `submit_dispute`.
- Converts prover-service TEE results into compact dispute proof bytes with expected-root validation.

No runtime wiring changes in this PR.

## Test plan

- `cargo +nightly fmt --all --check`
- `cargo test -p base-challenger proof_adapter`
- `cargo clippy -p base-challenger --all-targets -- -D warnings`