### PR TITLE
fix(nitro-host): remove proof request timeout

### DIFF
--- a/bin/prover/nitro-host/src/cli.rs
+++ b/bin/prover/nitro-host/src/cli.rs
@@ -3,8 +3,6 @@
 use std::net::SocketAddr;
 #[cfg(any(target_os = "linux", feature = "local"))]
 use std::sync::Arc;
-#[cfg(any(target_os = "linux", feature = "local"))]
-use std::time::Duration;
 
 use alloy_primitives::Address;
 use base_cli_utils::{LogConfig, RuntimeManager};
@@ -89,10 +87,6 @@ struct ProverServerArgs {
     #[arg(long, env = "ENABLE_EXPERIMENTAL_WITNESS_ENDPOINT")]
     enable_experimental_witness_endpoint: bool,
 
-    /// Maximum seconds for a single proof request before it is aborted.
-    #[arg(long, env = "PROOF_REQUEST_TIMEOUT_SECS", default_value = "1740", value_parser = clap::value_parser!(u64).range(1..))]
-    proof_request_timeout_secs: u64,
-
     /// `TEEProverRegistry` contract address on L1. When set, `/healthz` returns
     /// healthy only if the enclave signer is registered on-chain.
     #[arg(long, env = "TEE_PROVER_REGISTRY_ADDRESS")]
@@ -176,8 +170,7 @@ impl ServerArgs {
             .iter()
             .map(|&cid| Arc::new(NitroTransport::vsock(cid, VSOCK_PORT)))
             .collect();
-        let timeout = Duration::from_secs(self.server.proof_request_timeout_secs);
-        let mut server = NitroProverServer::new_multi(config, transports, timeout);
+        let mut server = NitroProverServer::new_multi(config, transports);
         if let Some(reg) = registration_health {
             server = server.with_registration_health(reg);
         }
@@ -240,8 +233,7 @@ impl LocalArgs {
                 Ok(Arc::new(NitroTransport::local(server)))
             })
             .collect::<eyre::Result<Vec<_>>>()?;
-        let timeout = Duration::from_secs(self.server.proof_request_timeout_secs);
-        let mut server = NitroProverServer::new_multi(prover_config, transports, timeout);
+        let mut server = NitroProverServer::new_multi(prover_config, transports);
         if let Some(reg) = registration_health {
             server = server.with_registration_health(reg);
         }

--- a/crates/proof/tee/nitro-host/README.md
+++ b/crates/proof/tee/nitro-host/README.md
@@ -15,7 +15,7 @@ development mode the enclave server runs in-process without vsock or NSM hardwar
 | Module | Description |
 |---|---|
 | `server` | `NitroProverServer` — JSON-RPC server (`prover_*`, `enclave_*`) |
-| `pool` | `NitroEnclavePool` — reusable enclave selection, concurrency, timeout, and registration guard |
+| `pool` | `NitroEnclavePool` — reusable enclave selection, concurrency, and registration guard |
 | `job_discovery` | `JobDiscovery` — prover-service polling loop that claims Nitro jobs and spawns proof generation |
 | `backend` | `NitroBackend` — `ProverBackend` impl dispatching to enclave via transport |
 | `transport` | `NitroTransport` — vsock (production) or in-process (local dev) |

--- a/crates/proof/tee/nitro-host/src/job_discovery.rs
+++ b/crates/proof/tee/nitro-host/src/job_discovery.rs
@@ -383,7 +383,7 @@ mod tests {
     fn test_generator(client: MockWorkerClient) -> Arc<ProofGenerator<MockWorkerClient>> {
         let server = Arc::new(EnclaveServer::new_local().unwrap());
         let transport = Arc::new(NitroTransport::local(server));
-        let pool = NitroEnclavePool::new(test_prover_config(), transport, Duration::from_secs(1));
+        let pool = NitroEnclavePool::new(test_prover_config(), transport);
         let submitter = ProofSubmitter::new(client);
 
         Arc::new(ProofGenerator::new(

--- a/crates/proof/tee/nitro-host/src/pool.rs
+++ b/crates/proof/tee/nitro-host/src/pool.rs
@@ -1,11 +1,11 @@
 //! Reusable Nitro enclave proof pool.
 
-use std::{fmt, sync::Arc, time::Duration};
+use std::{fmt, sync::Arc};
 
 use base_proof_host::{ProverConfig, ProverError, ProverService};
 use base_proof_primitives::{ProofRequest, ProofResult};
 use thiserror::Error;
-use tokio::sync::Semaphore;
+use tokio::sync::{OwnedSemaphorePermit, Semaphore};
 use tracing::warn;
 
 use super::{
@@ -35,7 +35,6 @@ struct EnclaveService {
 /// selection.
 pub struct NitroEnclavePool {
     enclaves: Vec<EnclaveService>,
-    proof_request_timeout: Duration,
     checker: Option<Arc<RegistrationChecker>>,
 }
 
@@ -43,7 +42,6 @@ impl fmt::Debug for NitroEnclavePool {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("NitroEnclavePool")
             .field("enclave_count", &self.enclaves.len())
-            .field("proof_request_timeout", &self.proof_request_timeout)
             .field("has_registration_checker", &self.checker.is_some())
             .finish()
     }
@@ -51,12 +49,8 @@ impl fmt::Debug for NitroEnclavePool {
 
 impl NitroEnclavePool {
     /// Create a pool with one enclave transport.
-    pub fn new(
-        config: ProverConfig,
-        transport: Arc<NitroTransport>,
-        proof_request_timeout: Duration,
-    ) -> Self {
-        Self::new_multi(config, vec![transport], proof_request_timeout)
+    pub fn new(config: ProverConfig, transport: Arc<NitroTransport>) -> Self {
+        Self::new_multi(config, vec![transport])
     }
 
     /// Create a pool with multiple enclave transports.
@@ -64,11 +58,7 @@ impl NitroEnclavePool {
     /// # Panics
     ///
     /// Panics if `transports` is empty.
-    pub fn new_multi(
-        config: ProverConfig,
-        transports: Vec<Arc<NitroTransport>>,
-        proof_request_timeout: Duration,
-    ) -> Self {
+    pub fn new_multi(config: ProverConfig, transports: Vec<Arc<NitroTransport>>) -> Self {
         assert!(!transports.is_empty(), "at least one transport is required");
         let enclaves = transports
             .into_iter()
@@ -84,7 +74,7 @@ impl NitroEnclavePool {
             })
             .collect();
 
-        Self { enclaves, proof_request_timeout, checker: None }
+        Self { enclaves, checker: None }
     }
 
     /// Attach a registration checker used to select valid enclave signers.
@@ -112,25 +102,18 @@ impl NitroEnclavePool {
         self.checker.as_ref().map(Arc::clone)
     }
 
-    /// Proves one request using the configured timeout and busy-enclave policy.
+    /// Proves one request using the busy-enclave policy.
     pub async fn prove(&self, request: ProofRequest) -> Result<ProofResult, NitroEnclavePoolError> {
         let l2_block = request.claimed_l2_block_number;
-        let timeout = self.proof_request_timeout;
         let (enclave, _permit) = self.acquire_enclave(l2_block).await?;
 
-        match tokio::time::timeout(timeout, enclave.service.prove_block(request)).await {
-            Ok(result) => result.map_err(NitroEnclavePoolError::Prover),
-            Err(_elapsed) => {
-                warn!(l2_block, timeout_secs = timeout.as_secs(), "proof request timed out");
-                Err(NitroEnclavePoolError::Timeout { l2_block, timeout_secs: timeout.as_secs() })
-            }
-        }
+        enclave.service.prove_block(request).await.map_err(NitroEnclavePoolError::Prover)
     }
 
     async fn acquire_enclave(
         &self,
         l2_block: u64,
-    ) -> Result<(&EnclaveService, tokio::sync::OwnedSemaphorePermit), NitroEnclavePoolError> {
+    ) -> Result<(&EnclaveService, OwnedSemaphorePermit), NitroEnclavePoolError> {
         let candidate_indices: Vec<usize> = match &self.checker {
             Some(checker) => checker
                 .select_all_valid_enclaves()
@@ -207,14 +190,6 @@ pub enum NitroEnclavePoolError {
     /// Every valid enclave is already proving.
     #[error("enclave busy: another proof request is already in flight")]
     Busy,
-    /// The proof request exceeded its configured timeout.
-    #[error("proof request timed out after {timeout_secs}s for L2 block {l2_block}")]
-    Timeout {
-        /// L2 block number from the proof request.
-        l2_block: u64,
-        /// Configured timeout in seconds.
-        timeout_secs: u64,
-    },
     /// Witness generation or enclave proving failed.
     #[error(transparent)]
     Prover(#[from] ProverError<NitroBackend>),
@@ -255,7 +230,7 @@ mod tests {
     fn test_pool() -> NitroEnclavePool {
         let server = Arc::new(EnclaveServer::new_local().unwrap());
         let transport = Arc::new(NitroTransport::local(server));
-        NitroEnclavePool::new(test_prover_config(), transport, Duration::from_secs(60))
+        NitroEnclavePool::new(test_prover_config(), transport)
     }
 
     async fn signer_for(transport: &NitroTransport) -> alloy_primitives::Address {
@@ -304,7 +279,6 @@ mod tests {
         let pool = NitroEnclavePool::new_multi(
             test_prover_config(),
             vec![first_transport, second_transport],
-            Duration::from_secs(60),
         );
 
         let _held = Arc::clone(&pool.enclaves[0].prove_permit).try_acquire_owned().unwrap();
@@ -334,7 +308,6 @@ mod tests {
         let pool = NitroEnclavePool::new_multi(
             test_prover_config(),
             vec![Arc::clone(&t1), Arc::clone(&t2)],
-            Duration::from_secs(60),
         )
         .with_registration_checker(checker)
         .unwrap();
@@ -358,7 +331,6 @@ mod tests {
         let pool = NitroEnclavePool::new_multi(
             test_prover_config(),
             vec![Arc::clone(&t1), Arc::clone(&t2)],
-            Duration::from_secs(60),
         );
 
         let _held = Arc::clone(&pool.enclaves[0].prove_permit).try_acquire_owned().unwrap();
@@ -381,8 +353,7 @@ mod tests {
         let checker = Arc::new(
             RegistrationChecker::new(vec![Arc::clone(&t1), Arc::clone(&t2)], registry).unwrap(),
         );
-        let pool =
-            NitroEnclavePool::new(test_prover_config(), Arc::clone(&t1), Duration::from_secs(60));
+        let pool = NitroEnclavePool::new(test_prover_config(), Arc::clone(&t1));
 
         let err = pool.with_registration_checker(checker).unwrap_err();
         assert!(matches!(
@@ -408,7 +379,6 @@ mod tests {
         let pool = NitroEnclavePool::new_multi(
             test_prover_config(),
             vec![Arc::clone(&t1), Arc::clone(&t2)],
-            Duration::from_secs(60),
         );
 
         let err = pool.with_registration_checker(checker).unwrap_err();

--- a/crates/proof/tee/nitro-host/src/proof_generator.rs
+++ b/crates/proof/tee/nitro-host/src/proof_generator.rs
@@ -586,7 +586,7 @@ mod tests {
                 .unwrap(),
         );
 
-        NitroEnclavePool::new(test_prover_config(), Arc::clone(&transport), Duration::from_secs(1))
+        NitroEnclavePool::new(test_prover_config(), Arc::clone(&transport))
             .with_registration_checker(checker)
             .unwrap()
     }

--- a/crates/proof/tee/nitro-host/src/server.rs
+++ b/crates/proof/tee/nitro-host/src/server.rs
@@ -1,4 +1,4 @@
-use std::{fmt, net::SocketAddr, sync::Arc, time::Duration};
+use std::{fmt, net::SocketAddr, sync::Arc};
 
 use alloy_signer::utils::public_key_to_address;
 use base_health::{HealthzApiServer, HealthzRpc};
@@ -55,18 +55,13 @@ impl NitroProverServer {
             }
             NitroEnclavePoolError::Busy => Self::rpc_err(-32002, err),
             NitroEnclavePoolError::RegistrationCheckerMismatch { .. }
-            | NitroEnclavePoolError::Timeout { .. }
             | NitroEnclavePoolError::Prover(_) => Self::rpc_err(-32000, err),
         }
     }
 
-    /// Create a server with the given prover config, enclave transport, and proof request timeout.
-    pub fn new(
-        config: ProverConfig,
-        transport: Arc<NitroTransport>,
-        proof_request_timeout: Duration,
-    ) -> Self {
-        Self::new_multi(config, vec![transport], proof_request_timeout)
+    /// Create a server with the given prover config and enclave transport.
+    pub fn new(config: ProverConfig, transport: Arc<NitroTransport>) -> Self {
+        Self::new_multi(config, vec![transport])
     }
 
     /// Create a server with multiple enclave transports for dual-enclave deployments.
@@ -74,12 +69,8 @@ impl NitroProverServer {
     /// # Panics
     ///
     /// Panics if `transports` is empty.
-    pub fn new_multi(
-        config: ProverConfig,
-        transports: Vec<Arc<NitroTransport>>,
-        proof_request_timeout: Duration,
-    ) -> Self {
-        let pool = NitroEnclavePool::new_multi(config, transports, proof_request_timeout);
+    pub fn new_multi(config: ProverConfig, transports: Vec<Arc<NitroTransport>>) -> Self {
+        let pool = NitroEnclavePool::new_multi(config, transports);
         Self { pool, registration_health: None }
     }
 

--- a/etc/docker/nitro-host/entrypoint.sh
+++ b/etc/docker/nitro-host/entrypoint.sh
@@ -7,7 +7,6 @@ set -eux
 : "${L1_BEACON_URL:?required}"
 : "${L2_ETH_URL:?required}"
 : "${L2_CHAIN_ID:?required}"
-: "${PROOF_REQUEST_TIMEOUT_SECS:=3600}"
 
 ADDITIONAL_ARGS=()
 if [ -n "${TEE_PROVER_REGISTRY_ADDRESS:-}" ]; then
@@ -22,6 +21,5 @@ exec ./base-prover-nitro-host \
     --l2-chain-id "$L2_CHAIN_ID" \
     --listen-addr "$LISTEN_ADDR" \
     --vsock-cid "$VSOCK_CID" \
-    --proof-request-timeout-secs "$PROOF_REQUEST_TIMEOUT_SECS" \
     --enable-experimental-witness-endpoint \
     "${ADDITIONAL_ARGS[@]}"


### PR DESCRIPTION
### What changed? Why?

Removes the Nitro host fixed proof request timeout (`PROOF_REQUEST_TIMEOUT_SECS` / `--proof-request-timeout-secs`) from the JSON-RPC server and enclave pool.

The previous timeout only cancelled the host-side request future. It did not stop the enclave from continuing the proof work that had already been sent over vsock. When a proof exceeded the timeout, the caller saw a failure, but the enclave could keep working in the background. Repeated timeouts could leave detached proof work piling up and consuming enclave capacity.

This lets a proof request run until the prover succeeds or the underlying proving/transport path returns an error, so host request lifetime stays aligned with enclave proof execution.

The existing per-enclave concurrency guard is still in place: each enclave accepts one in-flight proof, and additional requests fail fast with the existing busy error instead of queueing behind a long proof.

### Notes to reviewers

- `NitroProverServer::{new,new_multi}` and `NitroEnclavePool::{new,new_multi}` no longer take a timeout argument.
- The Docker entrypoint no longer defaults or passes `PROOF_REQUEST_TIMEOUT_SECS`.
- This only removes the proof-generation wall-clock timeout. Existing vsock connect/response timeouts for enclave metadata calls remain unchanged.
- Deployment/config references to `PROOF_REQUEST_TIMEOUT_SECS` can be removed because the Nitro host no longer reads it.

### How has it been tested?

`cargo test -p base-proof-tee-nitro-host -p base-prover-nitro-host`