### PR TITLE
fix(chains): update BaseUpgrade::LATEST and #[default] to Beryl

### DIFF
--- a/crates/common/chains/src/upgrade.rs
+++ b/crates/common/chains/src/upgrade.rs
@@ -30,16 +30,16 @@ hardfork!(
         /// Jovian: Base network upgrade.
         Jovian,
         /// Azul: First Base-specific network upgrade.
-        #[default]
         Azul,
         /// Beryl: Second Base-specific network upgrade.
+        #[default]
         Beryl,
     }
 );
 
 impl BaseUpgrade {
     /// Latest Base upgrade used by default.
-    pub const LATEST: Self = Self::Azul;
+    pub const LATEST: Self = Self::Beryl;
 
     /// Converts the Base upgrade into its matching Ethereum execution spec.
     pub const fn into_eth_spec(self) -> SpecId {
@@ -178,7 +178,7 @@ mod tests {
     #[test]
     fn latest_base_upgrade_matches_default() {
         assert_eq!(BaseUpgrade::default(), BaseUpgrade::LATEST);
-        assert_eq!(BaseUpgrade::LATEST, BaseUpgrade::Azul);
+        assert_eq!(BaseUpgrade::LATEST, BaseUpgrade::Beryl);
     }
 
     #[test]


### PR DESCRIPTION
## What I found

While reading through the upgrade chain I noticed that `Beryl` was added to the `BaseUpgrade` enum after `Azul`, but two things were not updated to keep up:

**1. `LATEST` const still points to `Azul`**
```rust
// before
pub const LATEST: Self = Self::Azul;

// after
pub const LATEST: Self = Self::Beryl;
```

**2. `#[default]` attribute is still on `Azul`**
```rust
// before
#[default]
Azul,
Beryl,

// after
Azul,
#[default]
Beryl,
```

## Why it matters

Code that reaches for `BaseUpgrade::LATEST` or `BaseUpgrade::default()` to pick the current active fork silently ends up one fork behind — missing any Beryl-specific rule changes. This can affect default devnet/chain-spec builders, fee estimation defaults, and anything else that keys off "the most recent known upgrade".

## Changes

- Move `#[default]` from `Azul` to `Beryl`
- Change `LATEST` from `Azul` to `Beryl`
- Update the unit test that hard-codes `LATEST == Azul`
