### PR TITLE
feat(prover-service): store protocol-native proof request fields

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6014,6 +6014,7 @@ name = "base-prover-service-db"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "base-prover-service-protocol",
  "chrono",
  "futures",
  "serde",

--- a/crates/proof/prover-service/db/Cargo.toml
+++ b/crates/proof/prover-service/db/Cargo.toml
@@ -26,6 +26,7 @@ thiserror.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]
+base-prover-service-protocol.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 
 [lints]

--- a/crates/proof/prover-service/db/migrations/010_add_protocol_native_request_storage.sql
+++ b/crates/proof/prover-service/db/migrations/010_add_protocol_native_request_storage.sql
@@ -5,6 +5,9 @@ ALTER TABLE proof_requests ADD COLUMN IF NOT EXISTS api_proof_type VARCHAR(32);
 ALTER TABLE proof_requests ADD COLUMN IF NOT EXISTS zk_vm VARCHAR(32);
 ALTER TABLE proof_requests ADD COLUMN IF NOT EXISTS tee_kind VARCHAR(32);
 
+-- Preserve historical updated_at values while backfilling protocol fields.
+ALTER TABLE proof_requests DISABLE TRIGGER update_proof_requests_updated_at;
+
 UPDATE proof_requests
 SET
     api_proof_type = COALESCE(
@@ -54,6 +57,8 @@ SET
             )
         END
     );
+
+ALTER TABLE proof_requests ENABLE TRIGGER update_proof_requests_updated_at;
 
 -- Keep these columns nullable during the expand phase so old service binaries
 -- can continue inserting proof_requests during rolling deploys.

--- a/crates/proof/prover-service/db/migrations/010_add_protocol_native_request_storage.sql
+++ b/crates/proof/prover-service/db/migrations/010_add_protocol_native_request_storage.sql
@@ -1,0 +1,67 @@
+-- Migration 010: Store protocol-native requester fields on proof_requests.
+--
+ALTER TABLE proof_requests ADD COLUMN IF NOT EXISTS request_payload JSONB;
+ALTER TABLE proof_requests ADD COLUMN IF NOT EXISTS api_proof_type VARCHAR(32);
+ALTER TABLE proof_requests ADD COLUMN IF NOT EXISTS zk_vm VARCHAR(32);
+ALTER TABLE proof_requests ADD COLUMN IF NOT EXISTS tee_kind VARCHAR(32);
+
+UPDATE proof_requests
+SET
+    api_proof_type = COALESCE(
+        api_proof_type,
+        CASE proof_type
+            WHEN 'op_succinct_sp1_cluster_snark_groth16' THEN 'snark_groth16'
+            ELSE 'compressed'
+        END
+    ),
+    zk_vm = COALESCE(zk_vm, 'sp1'),
+    request_payload = COALESCE(
+        request_payload,
+        CASE proof_type
+            WHEN 'op_succinct_sp1_cluster_snark_groth16' THEN jsonb_build_object(
+                'session_id', id::text,
+                'request', jsonb_build_object(
+                    'proof_type', 'snark_groth16',
+                    'payload', jsonb_build_object(
+                        'proof', jsonb_strip_nulls(jsonb_build_object(
+                            'start_block_number', start_block_number,
+                            'number_of_blocks_to_prove', number_of_blocks_to_prove,
+                            'sequence_window', sequence_window,
+                            'l1_head', l1_head,
+                            'intermediate_root_interval', intermediate_root_interval,
+                            'zk_vm', 'sp1'
+                        )),
+                        'prover_address', COALESCE(
+                            prover_address,
+                            '0x0000000000000000000000000000000000000000'
+                        )
+                    )
+                )
+            )
+            ELSE jsonb_build_object(
+                'session_id', id::text,
+                'request', jsonb_build_object(
+                    'proof_type', 'compressed',
+                    'payload', jsonb_strip_nulls(jsonb_build_object(
+                        'start_block_number', start_block_number,
+                        'number_of_blocks_to_prove', number_of_blocks_to_prove,
+                        'sequence_window', sequence_window,
+                        'l1_head', l1_head,
+                        'intermediate_root_interval', intermediate_root_interval,
+                        'zk_vm', 'sp1'
+                    ))
+                )
+            )
+        END
+    );
+
+-- Keep these columns nullable during the expand phase so old service binaries
+-- can continue inserting proof_requests during rolling deploys.
+
+CREATE INDEX IF NOT EXISTS idx_proof_requests_api_proof_type
+ON proof_requests(api_proof_type);
+
+COMMENT ON COLUMN proof_requests.request_payload IS 'Original protocol ProofRequest payload serialized as JSONB.';
+COMMENT ON COLUMN proof_requests.api_proof_type IS 'Protocol proof type: compressed, snark_groth16, tee.';
+COMMENT ON COLUMN proof_requests.zk_vm IS 'Protocol ZK VM discriminator for ZK proofs.';
+COMMENT ON COLUMN proof_requests.tee_kind IS 'Protocol TEE implementation discriminator for TEE proofs.';

--- a/crates/proof/prover-service/db/src/lib.rs
+++ b/crates/proof/prover-service/db/src/lib.rs
@@ -5,10 +5,11 @@ pub use config::DatabaseConfig;
 
 mod models;
 pub use models::{
-    CreateOutboxEntry, CreateProofRequest, CreateProofRequestError, CreateProofRequestOutcome,
-    CreateProofSession, MarkOutboxError, MarkOutboxProcessed, OutboxEntry, ProofRequest,
-    ProofRequestListItem, ProofRequestPage, ProofSession, ProofStatus, ProofType, RetryOutcome,
-    SessionStatus, SessionType, UpdateProofSession, UpdateReceipt,
+    ApiProofType, CreateOutboxEntry, CreateProofRequest, CreateProofRequestError,
+    CreateProofRequestOutcome, CreateProofSession, MarkOutboxError, MarkOutboxProcessed,
+    OutboxEntry, ProofRequest, ProofRequestListItem, ProofRequestPage, ProofSession, ProofStatus,
+    ProofType, RetryOutcome, SessionStatus, SessionType, TeeKind, UpdateProofSession,
+    UpdateReceipt, ZkVmKind,
 };
 
 mod repo;

--- a/crates/proof/prover-service/db/src/models.rs
+++ b/crates/proof/prover-service/db/src/models.rs
@@ -270,11 +270,136 @@ impl TryFrom<i32> for ProofType {
     }
 }
 
+/// Protocol-level proof type requested by API callers.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, sqlx::Type)]
+#[sqlx(type_name = "VARCHAR")]
+pub enum ApiProofType {
+    /// Compressed ZK proof.
+    #[sqlx(rename = "compressed")]
+    Compressed,
+    /// Groth16 SNARK proof.
+    #[sqlx(rename = "snark_groth16")]
+    SnarkGroth16,
+    /// Trusted execution environment proof.
+    #[sqlx(rename = "tee")]
+    Tee,
+}
+
+impl ApiProofType {
+    /// Convert enum to static string representation.
+    pub const fn as_str(&self) -> &'static str {
+        match self {
+            Self::Compressed => "compressed",
+            Self::SnarkGroth16 => "snark_groth16",
+            Self::Tee => "tee",
+        }
+    }
+}
+
+impl std::fmt::Display for ApiProofType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.as_str())
+    }
+}
+
+impl TryFrom<&str> for ApiProofType {
+    type Error = String;
+
+    fn try_from(s: &str) -> Result<Self, Self::Error> {
+        match s {
+            "compressed" => Ok(Self::Compressed),
+            "snark_groth16" => Ok(Self::SnarkGroth16),
+            "tee" => Ok(Self::Tee),
+            other => Err(format!("Unknown API proof type: {other}")),
+        }
+    }
+}
+
+/// Protocol-level ZK virtual machine discriminator.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, sqlx::Type)]
+#[sqlx(type_name = "VARCHAR")]
+pub enum ZkVmKind {
+    /// Succinct SP1.
+    #[sqlx(rename = "sp1")]
+    Sp1,
+}
+
+impl ZkVmKind {
+    /// Convert enum to static string representation.
+    pub const fn as_str(&self) -> &'static str {
+        match self {
+            Self::Sp1 => "sp1",
+        }
+    }
+}
+
+impl std::fmt::Display for ZkVmKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.as_str())
+    }
+}
+
+impl TryFrom<&str> for ZkVmKind {
+    type Error = String;
+
+    fn try_from(s: &str) -> Result<Self, Self::Error> {
+        match s {
+            "sp1" => Ok(Self::Sp1),
+            other => Err(format!("Unknown ZK VM: {other}")),
+        }
+    }
+}
+
+/// Protocol-level TEE implementation discriminator.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, sqlx::Type)]
+#[sqlx(type_name = "VARCHAR")]
+pub enum TeeKind {
+    /// AWS Nitro Enclaves.
+    #[sqlx(rename = "aws_nitro")]
+    AwsNitro,
+}
+
+impl TeeKind {
+    /// Convert enum to static string representation.
+    pub const fn as_str(&self) -> &'static str {
+        match self {
+            Self::AwsNitro => "aws_nitro",
+        }
+    }
+}
+
+impl std::fmt::Display for TeeKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.as_str())
+    }
+}
+
+impl TryFrom<&str> for TeeKind {
+    type Error = String;
+
+    fn try_from(s: &str) -> Result<Self, Self::Error> {
+        match s {
+            "aws_nitro" => Ok(Self::AwsNitro),
+            other => Err(format!("Unknown TEE kind: {other}")),
+        }
+    }
+}
+
 /// A proof request record in the database
 #[derive(Debug, Clone, FromRow, Serialize, Deserialize)]
 pub struct ProofRequest {
     /// Unique identifier.
     pub id: Uuid,
+    /// Public protocol session identifier.
+    pub session_id: String,
+    /// Original protocol request payload serialized as JSON.
+    pub request_payload: serde_json::Value,
+    /// Protocol-level proof type requested by API callers.
+    pub api_proof_type: ApiProofType,
+    /// Protocol-level ZK VM discriminator for ZK proofs.
+    pub zk_vm: Option<ZkVmKind>,
+    /// Protocol-level TEE discriminator for TEE proofs.
+    pub tee_kind: Option<TeeKind>,
     /// Starting L2 block number.
     pub start_block_number: i64,
     /// Number of consecutive blocks to prove.
@@ -312,6 +437,14 @@ pub struct ProofRequest {
 pub struct ProofRequestListItem {
     /// Unique identifier.
     pub id: Uuid,
+    /// Public protocol session identifier.
+    pub session_id: String,
+    /// Protocol-level proof type requested by API callers.
+    pub api_proof_type: ApiProofType,
+    /// Protocol-level ZK VM discriminator for ZK proofs.
+    pub zk_vm: Option<ZkVmKind>,
+    /// Protocol-level TEE discriminator for TEE proofs.
+    pub tee_kind: Option<TeeKind>,
     /// Starting L2 block number.
     pub start_block_number: i64,
     /// Number of consecutive blocks to prove.
@@ -399,6 +532,8 @@ pub struct CreateProofRequest {
     pub proof_type: ProofType,
     /// Client-provided UUID for idempotent requests.
     pub session_id: Option<Uuid>,
+    /// Original protocol request payload serialized as JSON.
+    pub request_payload: Option<serde_json::Value>,
     /// Ethereum address of the on-chain prover (required for SNARK Groth16 proofs).
     pub prover_address: Option<String>,
     /// Explicit L1 head hash for witness generation.

--- a/crates/proof/prover-service/db/src/models.rs
+++ b/crates/proof/prover-service/db/src/models.rs
@@ -386,7 +386,7 @@ impl TryFrom<&str> for TeeKind {
 }
 
 /// A proof request record in the database
-#[derive(Debug, Clone, FromRow, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ProofRequest {
     /// Unique identifier.
     pub id: Uuid,

--- a/crates/proof/prover-service/db/src/repo.rs
+++ b/crates/proof/prover-service/db/src/repo.rs
@@ -2,10 +2,11 @@ use sqlx::{PgPool, Result, Row};
 use uuid::Uuid;
 
 use crate::{
-    CreateOutboxEntry, CreateProofRequest, CreateProofRequestError, CreateProofRequestOutcome,
-    CreateProofSession, MarkOutboxError, MarkOutboxProcessed, OutboxEntry, ProofRequest,
-    ProofRequestListItem, ProofRequestPage, ProofSession, ProofStatus, ProofType, RetryOutcome,
-    SessionStatus, SessionType, UpdateProofSession, UpdateReceipt,
+    ApiProofType, CreateOutboxEntry, CreateProofRequest, CreateProofRequestError,
+    CreateProofRequestOutcome, CreateProofSession, MarkOutboxError, MarkOutboxProcessed,
+    OutboxEntry, ProofRequest, ProofRequestListItem, ProofRequestPage, ProofSession, ProofStatus,
+    ProofType, RetryOutcome, SessionStatus, SessionType, TeeKind, UpdateProofSession,
+    UpdateReceipt, ZkVmKind,
 };
 
 /// Repository for proof request database operations
@@ -22,58 +23,40 @@ impl ProofRequestRepo {
 
     /// Create a new proof request and return its UUID
     pub async fn create(&self, req: CreateProofRequest) -> Result<Uuid> {
-        let id = req.session_id.unwrap_or_else(Uuid::new_v4);
+        let prepared = PreparedProofRequest::try_from(req)?;
 
         sqlx::query(
             r#"
             INSERT INTO proof_requests (
-                id, start_block_number, number_of_blocks_to_prove,
-                sequence_window, proof_type, status, prover_address, l1_head,
-                intermediate_root_interval
+                id, request_payload, api_proof_type, zk_vm, tee_kind, start_block_number,
+                number_of_blocks_to_prove, sequence_window, proof_type, status,
+                prover_address, l1_head, intermediate_root_interval
             )
-            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
             "#,
         )
-        .bind(id)
-        .bind(
-            i64::try_from(req.start_block_number)
-                .map_err(|_| sqlx::Error::Protocol("block number exceeds i64 range".into()))?,
-        )
-        .bind(
-            i64::try_from(req.number_of_blocks_to_prove)
-                .map_err(|_| sqlx::Error::Protocol("blocks to prove exceeds i64 range".into()))?,
-        )
-        .bind(
-            req.sequence_window
-                .map(|w| {
-                    i64::try_from(w).map_err(|_| {
-                        sqlx::Error::Protocol("sequence window exceeds i64 range".into())
-                    })
-                })
-                .transpose()?,
-        )
-        .bind(req.proof_type.as_str())
+        .bind(prepared.id)
+        .bind(&prepared.request_payload)
+        .bind(prepared.api_proof_type.as_str())
+        .bind(prepared.zk_vm.map(|zk_vm| zk_vm.as_str()))
+        .bind(prepared.tee_kind.map(|tee_kind| tee_kind.as_str()))
+        .bind(prepared.start_block_number)
+        .bind(prepared.number_of_blocks_to_prove)
+        .bind(prepared.sequence_window)
+        .bind(prepared.proof_type.as_str())
         .bind(ProofStatus::Created.as_str())
-        .bind(&req.prover_address)
-        .bind(&req.l1_head)
-        .bind(
-            req.intermediate_root_interval
-                .map(|v| {
-                    i64::try_from(v).map_err(|_| {
-                        sqlx::Error::Protocol("intermediate root interval exceeds i64 range".into())
-                    })
-                })
-                .transpose()?,
-        )
+        .bind(&prepared.prover_address)
+        .bind(&prepared.l1_head)
+        .bind(prepared.intermediate_root_interval)
         .execute(&self.pool)
         .await?;
 
-        Ok(id)
+        Ok(prepared.id)
     }
 
     /// Atomically create a proof request and outbox entry in a transaction.
     ///
-    /// On `session_id` conflict, lock the row `FOR UPDATE` and branch on state:
+    /// On `id` conflict, lock the row `FOR UPDATE` and branch on state:
     /// parameter mismatch → [`CreateProofRequestError::IdCollision`];
     /// `CREATED` / `PENDING` / `RUNNING` / `SUCCEEDED` → [`CreateProofRequestOutcome::Replayed`];
     /// `FAILED` with room under `max_retries` → reset, bump `retry_count`, new outbox row
@@ -85,36 +68,16 @@ impl ProofRequestRepo {
         req: CreateProofRequest,
         max_retries: i32,
     ) -> std::result::Result<CreateProofRequestOutcome, CreateProofRequestError> {
-        let id = req.session_id.unwrap_or_else(Uuid::new_v4);
-
-        let start_block_number = i64::try_from(req.start_block_number)
-            .map_err(|_| sqlx::Error::Protocol("block number exceeds i64 range".into()))?;
-        let number_of_blocks_to_prove = i64::try_from(req.number_of_blocks_to_prove)
-            .map_err(|_| sqlx::Error::Protocol("blocks to prove exceeds i64 range".into()))?;
-        let sequence_window = req
-            .sequence_window
-            .map(|w| {
-                i64::try_from(w)
-                    .map_err(|_| sqlx::Error::Protocol("sequence window exceeds i64 range".into()))
-            })
-            .transpose()?;
-        let intermediate_root_interval = req
-            .intermediate_root_interval
-            .map(|v| {
-                i64::try_from(v).map_err(|_| {
-                    sqlx::Error::Protocol("intermediate root interval exceeds i64 range".into())
-                })
-            })
-            .transpose()?;
+        let prepared = PreparedProofRequest::try_from(req)?;
 
         let request_params = build_outbox_params(
-            start_block_number,
-            number_of_blocks_to_prove,
-            sequence_window,
-            req.proof_type.as_str(),
-            req.prover_address.as_deref(),
-            req.l1_head.as_deref(),
-            intermediate_root_interval,
+            prepared.start_block_number,
+            prepared.number_of_blocks_to_prove,
+            prepared.sequence_window,
+            prepared.proof_type.as_str(),
+            prepared.prover_address.as_deref(),
+            prepared.l1_head.as_deref(),
+            prepared.intermediate_root_interval,
         );
 
         let mut tx = self.pool.begin().await?;
@@ -122,23 +85,27 @@ impl ProofRequestRepo {
         let insert_result = sqlx::query(
             r#"
             INSERT INTO proof_requests (
-                id, start_block_number, number_of_blocks_to_prove,
-                sequence_window, proof_type, status, prover_address, l1_head,
-                intermediate_root_interval
+                id, request_payload, api_proof_type, zk_vm, tee_kind, start_block_number,
+                number_of_blocks_to_prove, sequence_window, proof_type, status,
+                prover_address, l1_head, intermediate_root_interval
             )
-            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
             ON CONFLICT (id) DO NOTHING
             "#,
         )
-        .bind(id)
-        .bind(start_block_number)
-        .bind(number_of_blocks_to_prove)
-        .bind(sequence_window)
-        .bind(req.proof_type.as_str())
+        .bind(prepared.id)
+        .bind(&prepared.request_payload)
+        .bind(prepared.api_proof_type.as_str())
+        .bind(prepared.zk_vm.map(|zk_vm| zk_vm.as_str()))
+        .bind(prepared.tee_kind.map(|tee_kind| tee_kind.as_str()))
+        .bind(prepared.start_block_number)
+        .bind(prepared.number_of_blocks_to_prove)
+        .bind(prepared.sequence_window)
+        .bind(prepared.proof_type.as_str())
         .bind(ProofStatus::Created.as_str())
-        .bind(&req.prover_address)
-        .bind(&req.l1_head)
-        .bind(intermediate_root_interval)
+        .bind(&prepared.prover_address)
+        .bind(&prepared.l1_head)
+        .bind(prepared.intermediate_root_interval)
         .execute(&mut *tx)
         .await?;
 
@@ -149,19 +116,20 @@ impl ProofRequestRepo {
                 VALUES ($1, $2)
                 "#,
             )
-            .bind(id)
+            .bind(prepared.id)
             .bind(&request_params)
             .execute(&mut *tx)
             .await?;
 
             tx.commit().await?;
-            return Ok(CreateProofRequestOutcome::Created(id));
+            return Ok(CreateProofRequestOutcome::Created(prepared.id));
         }
 
         // Conflict path: `FOR UPDATE` serializes with stuck recovery and workers.
         let row = sqlx::query(
             r#"
-            SELECT start_block_number, number_of_blocks_to_prove, sequence_window,
+            SELECT id, id::text AS session_id, request_payload, api_proof_type, zk_vm, tee_kind,
+                   start_block_number, number_of_blocks_to_prove, sequence_window,
                    proof_type, status, prover_address, l1_head,
                    intermediate_root_interval, retry_count
             FROM proof_requests
@@ -169,27 +137,34 @@ impl ProofRequestRepo {
             FOR UPDATE
             "#,
         )
-        .bind(id)
+        .bind(prepared.id)
         .fetch_optional(&mut *tx)
         .await?;
 
         let Some(row) = row else {
             tx.rollback().await?;
-            return Err(CreateProofRequestError::SessionRowMissingAfterConflict { id });
+            return Err(CreateProofRequestError::SessionRowMissingAfterConflict {
+                id: prepared.id,
+            });
         };
 
+        let existing_id: Uuid = row.get("id");
         let params = CreateOutboxRequestParams {
-            start_block_number,
-            number_of_blocks_to_prove,
-            sequence_window,
-            proof_type: req.proof_type.as_str(),
-            prover_address: req.prover_address.as_deref(),
-            l1_head: req.l1_head.as_deref(),
-            intermediate_root_interval,
+            request_payload: &prepared.request_payload,
+            api_proof_type: prepared.api_proof_type.as_str(),
+            zk_vm: prepared.zk_vm.map(|zk_vm| zk_vm.as_str()),
+            tee_kind: prepared.tee_kind.map(|tee_kind| tee_kind.as_str()),
+            start_block_number: prepared.start_block_number,
+            number_of_blocks_to_prove: prepared.number_of_blocks_to_prove,
+            sequence_window: prepared.sequence_window,
+            proof_type: prepared.proof_type.as_str(),
+            prover_address: prepared.prover_address.as_deref(),
+            l1_head: prepared.l1_head.as_deref(),
+            intermediate_root_interval: prepared.intermediate_root_interval,
         };
         if let Some(field) = params.first_mismatch(&row) {
             tx.rollback().await?;
-            return Err(CreateProofRequestError::IdCollision { id, field });
+            return Err(CreateProofRequestError::IdCollision { id: existing_id, field });
         }
 
         let status_str: &str = row.get("status");
@@ -203,13 +178,13 @@ impl ProofRequestRepo {
             | ProofStatus::Running
             | ProofStatus::Succeeded => {
                 tx.rollback().await?;
-                Ok(CreateProofRequestOutcome::Replayed(id))
+                Ok(CreateProofRequestOutcome::Replayed(existing_id))
             }
             ProofStatus::Failed => {
                 let retry_count: i32 = row.get("retry_count");
                 if retry_count >= max_retries {
                     tx.rollback().await?;
-                    return Ok(CreateProofRequestOutcome::RetryExhausted(id));
+                    return Ok(CreateProofRequestOutcome::RetryExhausted(existing_id));
                 }
 
                 // Fail any active sessions before resetting so the requeued run cannot
@@ -226,7 +201,7 @@ impl ProofRequestRepo {
                 )
                 .bind(SessionStatus::Failed.as_str())
                 .bind("cleared during create_with_outbox requeue")
-                .bind(id)
+                .bind(existing_id)
                 .bind(SessionStatus::Submitting.as_str())
                 .bind(SessionStatus::Running.as_str())
                 .execute(&mut *tx)
@@ -245,7 +220,7 @@ impl ProofRequestRepo {
                     "#,
                 )
                 .bind(ProofStatus::Created.as_str())
-                .bind(id)
+                .bind(existing_id)
                 .execute(&mut *tx)
                 .await?;
 
@@ -255,13 +230,13 @@ impl ProofRequestRepo {
                     VALUES ($1, $2)
                     "#,
                 )
-                .bind(id)
+                .bind(existing_id)
                 .bind(&request_params)
                 .execute(&mut *tx)
                 .await?;
 
                 tx.commit().await?;
-                Ok(CreateProofRequestOutcome::Requeued(id))
+                Ok(CreateProofRequestOutcome::Requeued(existing_id))
             }
         }
     }
@@ -271,8 +246,8 @@ impl ProofRequestRepo {
         let row = sqlx::query(
             r#"
             SELECT
-                id, start_block_number, number_of_blocks_to_prove,
-                sequence_window, proof_type,
+                id, id::text AS session_id, request_payload, api_proof_type, zk_vm, tee_kind,
+                start_block_number, number_of_blocks_to_prove, sequence_window, proof_type,
                 stark_receipt, snark_receipt,
                 status, error_message,
                 prover_address, l1_head, intermediate_root_interval,
@@ -818,7 +793,8 @@ impl ProofRequestRepo {
     pub async fn get_running_proof_requests(&self) -> Result<Vec<ProofRequest>> {
         let rows = sqlx::query(
             r#"
-            SELECT id, start_block_number, number_of_blocks_to_prove,
+            SELECT id, id::text AS session_id, request_payload, api_proof_type, zk_vm, tee_kind,
+                   start_block_number, number_of_blocks_to_prove,
                    sequence_window, proof_type, stark_receipt, snark_receipt,
                    status, error_message, prover_address, l1_head,
                    intermediate_root_interval,
@@ -843,7 +819,8 @@ impl ProofRequestRepo {
         let rows = sqlx::query(
             r#"
             SELECT
-                pr.id, pr.start_block_number, pr.number_of_blocks_to_prove,
+                pr.id, pr.id::text AS session_id, pr.request_payload, pr.api_proof_type, pr.zk_vm,
+                pr.tee_kind, pr.start_block_number, pr.number_of_blocks_to_prove,
                 pr.sequence_window, pr.proof_type, pr.stark_receipt, pr.snark_receipt,
                 pr.status, pr.error_message, pr.prover_address, pr.l1_head,
                 pr.intermediate_root_interval,
@@ -1046,8 +1023,8 @@ impl ProofRequestRepo {
             sqlx::query(
                 r#"
                 SELECT
-                    id, start_block_number, number_of_blocks_to_prove,
-                    sequence_window, proof_type,
+                    id, id::text AS session_id, request_payload, api_proof_type, zk_vm, tee_kind,
+                    start_block_number, number_of_blocks_to_prove, sequence_window, proof_type,
                     stark_receipt, snark_receipt,
                     status, error_message,
                     prover_address, l1_head, intermediate_root_interval,
@@ -1066,8 +1043,8 @@ impl ProofRequestRepo {
             sqlx::query(
                 r#"
                 SELECT
-                    id, start_block_number, number_of_blocks_to_prove,
-                    sequence_window, proof_type,
+                    id, id::text AS session_id, request_payload, api_proof_type, zk_vm, tee_kind,
+                    start_block_number, number_of_blocks_to_prove, sequence_window, proof_type,
                     stark_receipt, snark_receipt,
                     status, error_message,
                     prover_address, l1_head, intermediate_root_interval,
@@ -1097,8 +1074,19 @@ impl ProofRequestRepo {
             let rows = sqlx::query_as::<_, ProofRequestListItem>(
                 r#"
                 SELECT
-                    id, start_block_number, number_of_blocks_to_prove,
-                    proof_type, status, error_message,
+                    id,
+                    id::text AS session_id,
+                    COALESCE(
+                        api_proof_type,
+                        CASE proof_type
+                            WHEN 'op_succinct_sp1_cluster_snark_groth16' THEN 'snark_groth16'
+                            ELSE 'compressed'
+                        END
+                    ) AS api_proof_type,
+                    COALESCE(zk_vm, 'sp1') AS zk_vm,
+                    tee_kind,
+                    start_block_number, number_of_blocks_to_prove, proof_type,
+                    status, error_message,
                     created_at, updated_at, completed_at
                 FROM proof_requests
                 ORDER BY created_at DESC
@@ -1118,8 +1106,19 @@ impl ProofRequestRepo {
             let rows = sqlx::query_as::<_, ProofRequestListItem>(
                 r#"
                 SELECT
-                    id, start_block_number, number_of_blocks_to_prove,
-                    proof_type, status, error_message,
+                    id,
+                    id::text AS session_id,
+                    COALESCE(
+                        api_proof_type,
+                        CASE proof_type
+                            WHEN 'op_succinct_sp1_cluster_snark_groth16' THEN 'snark_groth16'
+                            ELSE 'compressed'
+                        END
+                    ) AS api_proof_type,
+                    COALESCE(zk_vm, 'sp1') AS zk_vm,
+                    tee_kind,
+                    start_block_number, number_of_blocks_to_prove, proof_type,
+                    status, error_message,
                     created_at, updated_at, completed_at
                 FROM proof_requests
                 WHERE status::text = ANY($1::text[])
@@ -1248,8 +1247,148 @@ impl ProofRequestRepo {
     }
 }
 
+#[derive(Debug, Clone)]
+struct PreparedProofRequest {
+    id: Uuid,
+    request_payload: serde_json::Value,
+    api_proof_type: ApiProofType,
+    zk_vm: Option<ZkVmKind>,
+    tee_kind: Option<TeeKind>,
+    start_block_number: i64,
+    number_of_blocks_to_prove: i64,
+    sequence_window: Option<i64>,
+    proof_type: ProofType,
+    prover_address: Option<String>,
+    l1_head: Option<String>,
+    intermediate_root_interval: Option<i64>,
+}
+
+impl TryFrom<CreateProofRequest> for PreparedProofRequest {
+    type Error = sqlx::Error;
+
+    fn try_from(req: CreateProofRequest) -> Result<Self> {
+        let id = req.session_id.unwrap_or_else(Uuid::new_v4);
+        let session_id = id.to_string();
+        let start_block_number = i64::try_from(req.start_block_number)
+            .map_err(|_| sqlx::Error::Protocol("block number exceeds i64 range".into()))?;
+        let number_of_blocks_to_prove = i64::try_from(req.number_of_blocks_to_prove)
+            .map_err(|_| sqlx::Error::Protocol("blocks to prove exceeds i64 range".into()))?;
+        let sequence_window = req
+            .sequence_window
+            .map(|w| {
+                i64::try_from(w)
+                    .map_err(|_| sqlx::Error::Protocol("sequence window exceeds i64 range".into()))
+            })
+            .transpose()?;
+        let intermediate_root_interval = req
+            .intermediate_root_interval
+            .map(|v| {
+                i64::try_from(v).map_err(|_| {
+                    sqlx::Error::Protocol("intermediate root interval exceeds i64 range".into())
+                })
+            })
+            .transpose()?;
+        let api_proof_type = api_proof_type_for_backend(req.proof_type);
+        let zk_vm = Some(ZkVmKind::Sp1);
+        let tee_kind = None;
+        let request_payload = req.request_payload.unwrap_or_else(|| {
+            build_protocol_request_payload(
+                &session_id,
+                start_block_number,
+                number_of_blocks_to_prove,
+                sequence_window,
+                req.proof_type,
+                req.prover_address.as_deref(),
+                req.l1_head.as_deref(),
+                intermediate_root_interval,
+            )
+        });
+
+        Ok(Self {
+            id,
+            request_payload,
+            api_proof_type,
+            zk_vm,
+            tee_kind,
+            start_block_number,
+            number_of_blocks_to_prove,
+            sequence_window,
+            proof_type: req.proof_type,
+            prover_address: req.prover_address,
+            l1_head: req.l1_head,
+            intermediate_root_interval,
+        })
+    }
+}
+
+const ZERO_ADDRESS: &str = "0x0000000000000000000000000000000000000000";
+
+const fn api_proof_type_for_backend(proof_type: ProofType) -> ApiProofType {
+    match proof_type {
+        ProofType::OpSuccinctSp1ClusterCompressed => ApiProofType::Compressed,
+        ProofType::OpSuccinctSp1ClusterSnarkGroth16 => ApiProofType::SnarkGroth16,
+    }
+}
+
+const fn zk_vm_for_backend(proof_type: ProofType) -> Option<ZkVmKind> {
+    match proof_type {
+        ProofType::OpSuccinctSp1ClusterCompressed | ProofType::OpSuccinctSp1ClusterSnarkGroth16 => {
+            Some(ZkVmKind::Sp1)
+        }
+    }
+}
+
+fn build_protocol_request_payload(
+    session_id: &str,
+    start_block_number: i64,
+    number_of_blocks_to_prove: i64,
+    sequence_window: Option<i64>,
+    proof_type: ProofType,
+    prover_address: Option<&str>,
+    l1_head: Option<&str>,
+    intermediate_root_interval: Option<i64>,
+) -> serde_json::Value {
+    let zk_payload = serde_json::json!({
+        "start_block_number": start_block_number,
+        "number_of_blocks_to_prove": number_of_blocks_to_prove,
+        "sequence_window": sequence_window,
+        "l1_head": l1_head,
+        "intermediate_root_interval": intermediate_root_interval,
+        "zk_vm": ZkVmKind::Sp1.as_str(),
+    });
+
+    match proof_type {
+        ProofType::OpSuccinctSp1ClusterCompressed => serde_json::json!({
+            "session_id": session_id,
+            "request": {
+                "proof_type": ApiProofType::Compressed.as_str(),
+                "payload": zk_payload,
+            },
+        }),
+        ProofType::OpSuccinctSp1ClusterSnarkGroth16 => serde_json::json!({
+            "session_id": session_id,
+            "request": {
+                "proof_type": ApiProofType::SnarkGroth16.as_str(),
+                "payload": {
+                    "proof": zk_payload,
+                    "prover_address": prover_address.unwrap_or(ZERO_ADDRESS),
+                },
+            },
+        }),
+    }
+}
+
 /// Helper function to convert a database row to `ProofRequest`
 fn row_to_proof_request(row: &sqlx::postgres::PgRow) -> Result<ProofRequest> {
+    let id = row.get("id");
+    let session_id = row.get::<String, _>("session_id");
+    let start_block_number = row.get("start_block_number");
+    let number_of_blocks_to_prove = row.get("number_of_blocks_to_prove");
+    let sequence_window = row.get("sequence_window");
+    let prover_address = row.get::<Option<String>, _>("prover_address");
+    let l1_head = row.get::<Option<String>, _>("l1_head");
+    let intermediate_root_interval = row.get("intermediate_root_interval");
+
     let status_str: &str = row.get("status");
     let status = ProofStatus::try_from(status_str)
         .map_err(|e| sqlx::Error::Protocol(format!("Unknown proof status '{status_str}': {e}")))?;
@@ -1259,24 +1398,65 @@ fn row_to_proof_request(row: &sqlx::postgres::PgRow) -> Result<ProofRequest> {
         sqlx::Error::Protocol(format!("Unknown proof_type '{proof_type_str}': {e}"))
     })?;
 
+    let api_proof_type = match row.get::<Option<&str>, _>("api_proof_type") {
+        Some(value) => ApiProofType::try_from(value)
+            .map_err(|e| sqlx::Error::Protocol(format!("Unknown api_proof_type '{value}': {e}")))?,
+        None => api_proof_type_for_backend(proof_type),
+    };
+
+    let zk_vm = row
+        .get::<Option<&str>, _>("zk_vm")
+        .map(parse_zk_vm_kind)
+        .transpose()?
+        .or_else(|| zk_vm_for_backend(proof_type));
+    let tee_kind = row.get::<Option<&str>, _>("tee_kind").map(parse_tee_kind).transpose()?;
+    let request_payload =
+        row.get::<Option<serde_json::Value>, _>("request_payload").unwrap_or_else(|| {
+            build_protocol_request_payload(
+                &session_id,
+                start_block_number,
+                number_of_blocks_to_prove,
+                sequence_window,
+                proof_type,
+                prover_address.as_deref(),
+                l1_head.as_deref(),
+                intermediate_root_interval,
+            )
+        });
+
     Ok(ProofRequest {
-        id: row.get("id"),
-        start_block_number: row.get("start_block_number"),
-        number_of_blocks_to_prove: row.get("number_of_blocks_to_prove"),
-        sequence_window: row.get("sequence_window"),
+        id,
+        session_id,
+        request_payload,
+        api_proof_type,
+        zk_vm,
+        tee_kind,
+        start_block_number,
+        number_of_blocks_to_prove,
+        sequence_window,
         proof_type,
         stark_receipt: row.get("stark_receipt"),
         snark_receipt: row.get("snark_receipt"),
         status,
         error_message: row.get("error_message"),
-        prover_address: row.get("prover_address"),
-        l1_head: row.get("l1_head"),
-        intermediate_root_interval: row.get("intermediate_root_interval"),
+        prover_address,
+        l1_head,
+        intermediate_root_interval,
         created_at: row.get("created_at"),
         updated_at: row.get("updated_at"),
         completed_at: row.get("completed_at"),
         retry_count: row.get("retry_count"),
     })
+}
+
+fn parse_zk_vm_kind(value: &str) -> Result<ZkVmKind> {
+    ZkVmKind::try_from(value)
+        .map_err(|e| sqlx::Error::Protocol(format!("Unknown zk_vm '{value}': {e}")))
+}
+
+fn parse_tee_kind(value: &str) -> Result<TeeKind> {
+    TeeKind::try_from(value)
+        .map_err(|e| sqlx::Error::Protocol(format!("Unknown tee_kind '{value}': {e}")))
 }
 
 /// Helper function to convert a database row to `ProofSession`
@@ -1307,6 +1487,10 @@ fn row_to_proof_session(row: &sqlx::postgres::PgRow) -> Result<ProofSession> {
 /// Incoming fields compared to a locked `proof_requests` row for idempotency checks.
 #[derive(Debug, Clone)]
 struct CreateOutboxRequestParams<'a> {
+    request_payload: &'a serde_json::Value,
+    api_proof_type: &'a str,
+    zk_vm: Option<&'a str>,
+    tee_kind: Option<&'a str>,
     start_block_number: i64,
     number_of_blocks_to_prove: i64,
     sequence_window: Option<i64>,
@@ -1341,6 +1525,24 @@ impl CreateOutboxRequestParams<'_> {
             != self.intermediate_root_interval
         {
             return Some("intermediate_root_interval");
+        }
+        if let Some(api_proof_type) = row.get::<Option<&str>, _>("api_proof_type") {
+            if api_proof_type != self.api_proof_type {
+                return Some("api_proof_type");
+            }
+        }
+        if let Some(zk_vm) = row.get::<Option<&str>, _>("zk_vm") {
+            if Some(zk_vm) != self.zk_vm {
+                return Some("zk_vm");
+            }
+        }
+        if row.get::<Option<&str>, _>("tee_kind") != self.tee_kind {
+            return Some("tee_kind");
+        }
+        if let Some(request_payload) = row.get::<Option<serde_json::Value>, _>("request_payload") {
+            if request_payload != *self.request_payload {
+                return Some("request_payload");
+            }
         }
         None
     }
@@ -1382,5 +1584,49 @@ fn row_to_outbox_entry(row: &sqlx::postgres::PgRow) -> OutboxEntry {
         retry_count: row.get("retry_count"),
         last_error: row.get("last_error"),
         created_at: row.get("created_at"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use base_prover_service_protocol::{
+        ProofRequest as ProtocolProofRequest, ProofRequestKind, ZkVm,
+    };
+
+    use super::*;
+
+    #[test]
+    fn prepared_request_uses_uuid_session_id_and_builds_protocol_payload() {
+        let session_id = Uuid::new_v4();
+        let prepared = PreparedProofRequest::try_from(CreateProofRequest {
+            start_block_number: 100,
+            number_of_blocks_to_prove: 5,
+            sequence_window: Some(50),
+            proof_type: ProofType::OpSuccinctSp1ClusterCompressed,
+            session_id: Some(session_id),
+            request_payload: None,
+            prover_address: None,
+            l1_head: None,
+            intermediate_root_interval: Some(5),
+        })
+        .expect("request should prepare");
+
+        assert_eq!(prepared.id, session_id);
+        assert_eq!(prepared.api_proof_type, ApiProofType::Compressed);
+        assert_eq!(prepared.zk_vm, Some(ZkVmKind::Sp1));
+        assert!(prepared.tee_kind.is_none());
+
+        let protocol_request: ProtocolProofRequest =
+            serde_json::from_value(prepared.request_payload).expect("payload should deserialize");
+        let session_id = session_id.to_string();
+        assert_eq!(protocol_request.session_id.as_deref(), Some(session_id.as_str()));
+        let ProofRequestKind::Compressed(zk_request) = protocol_request.request else {
+            panic!("expected compressed protocol request");
+        };
+        assert_eq!(zk_request.start_block_number, 100);
+        assert_eq!(zk_request.number_of_blocks_to_prove, 5);
+        assert_eq!(zk_request.sequence_window, Some(50));
+        assert_eq!(zk_request.intermediate_root_interval, Some(5));
+        assert_eq!(zk_request.zk_vm, ZkVm::Sp1);
     }
 }

--- a/crates/proof/prover-service/db/src/repo.rs
+++ b/crates/proof/prover-service/db/src/repo.rs
@@ -1083,7 +1083,17 @@ impl ProofRequestRepo {
                             ELSE 'compressed'
                         END
                     ) AS api_proof_type,
-                    COALESCE(zk_vm, 'sp1') AS zk_vm,
+                    CASE
+                        WHEN zk_vm IS NOT NULL THEN zk_vm
+                        WHEN COALESCE(
+                            api_proof_type,
+                            CASE proof_type
+                                WHEN 'op_succinct_sp1_cluster_snark_groth16' THEN 'snark_groth16'
+                                ELSE 'compressed'
+                            END
+                        ) IN ('compressed', 'snark_groth16') THEN 'sp1'
+                        ELSE NULL
+                    END AS zk_vm,
                     tee_kind,
                     start_block_number, number_of_blocks_to_prove, proof_type,
                     status, error_message,
@@ -1115,7 +1125,17 @@ impl ProofRequestRepo {
                             ELSE 'compressed'
                         END
                     ) AS api_proof_type,
-                    COALESCE(zk_vm, 'sp1') AS zk_vm,
+                    CASE
+                        WHEN zk_vm IS NOT NULL THEN zk_vm
+                        WHEN COALESCE(
+                            api_proof_type,
+                            CASE proof_type
+                                WHEN 'op_succinct_sp1_cluster_snark_groth16' THEN 'snark_groth16'
+                                ELSE 'compressed'
+                            END
+                        ) IN ('compressed', 'snark_groth16') THEN 'sp1'
+                        ELSE NULL
+                    END AS zk_vm,
                     tee_kind,
                     start_block_number, number_of_blocks_to_prove, proof_type,
                     status, error_message,

--- a/crates/proof/prover-service/db/src/repo.rs
+++ b/crates/proof/prover-service/db/src/repo.rs
@@ -1308,9 +1308,7 @@ impl TryFrom<CreateProofRequest> for PreparedProofRequest {
                 })
             })
             .transpose()?;
-        let api_proof_type = api_proof_type_for_backend(req.proof_type);
-        let zk_vm = Some(ZkVmKind::Sp1);
-        let tee_kind = None;
+        let (api_proof_type, zk_vm, tee_kind) = protocol_fields_for_backend(req.proof_type);
         let request_payload = req.request_payload.unwrap_or_else(|| {
             build_protocol_request_payload(
                 &session_id,
@@ -1344,16 +1342,22 @@ impl TryFrom<CreateProofRequest> for PreparedProofRequest {
 const ZERO_ADDRESS: &str = "0x0000000000000000000000000000000000000000";
 
 const fn api_proof_type_for_backend(proof_type: ProofType) -> ApiProofType {
-    match proof_type {
-        ProofType::OpSuccinctSp1ClusterCompressed => ApiProofType::Compressed,
-        ProofType::OpSuccinctSp1ClusterSnarkGroth16 => ApiProofType::SnarkGroth16,
-    }
+    protocol_fields_for_backend(proof_type).0
 }
 
 const fn zk_vm_for_backend(proof_type: ProofType) -> Option<ZkVmKind> {
+    protocol_fields_for_backend(proof_type).1
+}
+
+const fn protocol_fields_for_backend(
+    proof_type: ProofType,
+) -> (ApiProofType, Option<ZkVmKind>, Option<TeeKind>) {
     match proof_type {
-        ProofType::OpSuccinctSp1ClusterCompressed | ProofType::OpSuccinctSp1ClusterSnarkGroth16 => {
-            Some(ZkVmKind::Sp1)
+        ProofType::OpSuccinctSp1ClusterCompressed => {
+            (ApiProofType::Compressed, Some(ZkVmKind::Sp1), None)
+        }
+        ProofType::OpSuccinctSp1ClusterSnarkGroth16 => {
+            (ApiProofType::SnarkGroth16, Some(ZkVmKind::Sp1), None)
         }
     }
 }

--- a/crates/proof/prover-service/db/src/repo.rs
+++ b/crates/proof/prover-service/db/src/repo.rs
@@ -1350,6 +1350,16 @@ const fn zk_vm_for_backend(proof_type: ProofType) -> Option<ZkVmKind> {
     protocol_fields_for_backend(proof_type).1
 }
 
+const fn fallback_zk_vm_for_request(
+    api_proof_type: ApiProofType,
+    proof_type: ProofType,
+) -> Option<ZkVmKind> {
+    match api_proof_type {
+        ApiProofType::Compressed | ApiProofType::SnarkGroth16 => zk_vm_for_backend(proof_type),
+        ApiProofType::Tee => None,
+    }
+}
+
 const fn protocol_fields_for_backend(
     proof_type: ProofType,
 ) -> (ApiProofType, Option<ZkVmKind>, Option<TeeKind>) {
@@ -1457,7 +1467,7 @@ fn row_to_proof_request(row: &sqlx::postgres::PgRow) -> Result<ProofRequest> {
         .get::<Option<&str>, _>("zk_vm")
         .map(parse_zk_vm_kind)
         .transpose()?
-        .or_else(|| zk_vm_for_backend(proof_type));
+        .or_else(|| fallback_zk_vm_for_request(api_proof_type, proof_type));
     let tee_kind = row.get::<Option<&str>, _>("tee_kind").map(parse_tee_kind).transpose()?;
     let request_payload =
         row.get::<Option<serde_json::Value>, _>("request_payload").unwrap_or_else(|| {
@@ -1706,5 +1716,15 @@ mod tests {
         assert!(!payload.contains_key("sequence_window"));
         assert!(!payload.contains_key("l1_head"));
         assert!(!payload.contains_key("intermediate_root_interval"));
+    }
+
+    #[test]
+    fn tee_request_does_not_fallback_to_zk_vm() {
+        let zk_vm = fallback_zk_vm_for_request(
+            ApiProofType::Tee,
+            ProofType::OpSuccinctSp1ClusterCompressed,
+        );
+
+        assert!(zk_vm.is_none());
     }
 }

--- a/crates/proof/prover-service/db/src/repo.rs
+++ b/crates/proof/prover-service/db/src/repo.rs
@@ -1310,16 +1310,17 @@ impl TryFrom<CreateProofRequest> for PreparedProofRequest {
             .transpose()?;
         let (api_proof_type, zk_vm, tee_kind) = protocol_fields_for_backend(req.proof_type);
         let request_payload = req.request_payload.unwrap_or_else(|| {
-            build_protocol_request_payload(
-                &session_id,
+            ProtocolRequestPayloadParams {
+                session_id: &session_id,
                 start_block_number,
                 number_of_blocks_to_prove,
                 sequence_window,
-                req.proof_type,
-                req.prover_address.as_deref(),
-                req.l1_head.as_deref(),
+                proof_type: req.proof_type,
+                prover_address: req.prover_address.as_deref(),
+                l1_head: req.l1_head.as_deref(),
                 intermediate_root_interval,
-            )
+            }
+            .build()
         });
 
         Ok(Self {
@@ -1362,44 +1363,50 @@ const fn protocol_fields_for_backend(
     }
 }
 
-fn build_protocol_request_payload(
-    session_id: &str,
+/// Fields needed to build the canonical protocol request payload.
+#[derive(Debug, Clone, Copy)]
+struct ProtocolRequestPayloadParams<'a> {
+    session_id: &'a str,
     start_block_number: i64,
     number_of_blocks_to_prove: i64,
     sequence_window: Option<i64>,
     proof_type: ProofType,
-    prover_address: Option<&str>,
-    l1_head: Option<&str>,
+    prover_address: Option<&'a str>,
+    l1_head: Option<&'a str>,
     intermediate_root_interval: Option<i64>,
-) -> serde_json::Value {
-    let mut zk_payload = serde_json::json!({
-        "start_block_number": start_block_number,
-        "number_of_blocks_to_prove": number_of_blocks_to_prove,
-        "sequence_window": sequence_window,
-        "l1_head": l1_head,
-        "intermediate_root_interval": intermediate_root_interval,
-        "zk_vm": ZkVmKind::Sp1.as_str(),
-    });
-    strip_null_object_fields(&mut zk_payload);
+}
 
-    match proof_type {
-        ProofType::OpSuccinctSp1ClusterCompressed => serde_json::json!({
-            "session_id": session_id,
-            "request": {
-                "proof_type": ApiProofType::Compressed.as_str(),
-                "payload": zk_payload,
-            },
-        }),
-        ProofType::OpSuccinctSp1ClusterSnarkGroth16 => serde_json::json!({
-            "session_id": session_id,
-            "request": {
-                "proof_type": ApiProofType::SnarkGroth16.as_str(),
-                "payload": {
-                    "proof": zk_payload,
-                    "prover_address": prover_address.unwrap_or(ZERO_ADDRESS),
+impl ProtocolRequestPayloadParams<'_> {
+    fn build(self) -> serde_json::Value {
+        let mut zk_payload = serde_json::json!({
+            "start_block_number": self.start_block_number,
+            "number_of_blocks_to_prove": self.number_of_blocks_to_prove,
+            "sequence_window": self.sequence_window,
+            "l1_head": self.l1_head,
+            "intermediate_root_interval": self.intermediate_root_interval,
+            "zk_vm": ZkVmKind::Sp1.as_str(),
+        });
+        strip_null_object_fields(&mut zk_payload);
+
+        match self.proof_type {
+            ProofType::OpSuccinctSp1ClusterCompressed => serde_json::json!({
+                "session_id": self.session_id,
+                "request": {
+                    "proof_type": ApiProofType::Compressed.as_str(),
+                    "payload": zk_payload,
                 },
-            },
-        }),
+            }),
+            ProofType::OpSuccinctSp1ClusterSnarkGroth16 => serde_json::json!({
+                "session_id": self.session_id,
+                "request": {
+                    "proof_type": ApiProofType::SnarkGroth16.as_str(),
+                    "payload": {
+                        "proof": zk_payload,
+                        "prover_address": self.prover_address.unwrap_or(ZERO_ADDRESS),
+                    },
+                },
+            }),
+        }
     }
 }
 
@@ -1454,16 +1461,17 @@ fn row_to_proof_request(row: &sqlx::postgres::PgRow) -> Result<ProofRequest> {
     let tee_kind = row.get::<Option<&str>, _>("tee_kind").map(parse_tee_kind).transpose()?;
     let request_payload =
         row.get::<Option<serde_json::Value>, _>("request_payload").unwrap_or_else(|| {
-            build_protocol_request_payload(
-                &session_id,
+            ProtocolRequestPayloadParams {
+                session_id: &session_id,
                 start_block_number,
                 number_of_blocks_to_prove,
                 sequence_window,
                 proof_type,
-                prover_address.as_deref(),
-                l1_head.as_deref(),
+                prover_address: prover_address.as_deref(),
+                l1_head: l1_head.as_deref(),
                 intermediate_root_interval,
-            )
+            }
+            .build()
         });
 
     Ok(ProofRequest {
@@ -1568,25 +1576,25 @@ impl CreateOutboxRequestParams<'_> {
         {
             return Some("intermediate_root_interval");
         }
-        if let Some(api_proof_type) = row.get::<Option<&str>, _>("api_proof_type") {
-            if api_proof_type != self.api_proof_type {
-                return Some("api_proof_type");
-            }
+        if let Some(api_proof_type) = row.get::<Option<&str>, _>("api_proof_type")
+            && api_proof_type != self.api_proof_type
+        {
+            return Some("api_proof_type");
         }
-        if let Some(zk_vm) = row.get::<Option<&str>, _>("zk_vm") {
-            if Some(zk_vm) != self.zk_vm {
-                return Some("zk_vm");
-            }
+        if let Some(zk_vm) = row.get::<Option<&str>, _>("zk_vm")
+            && Some(zk_vm) != self.zk_vm
+        {
+            return Some("zk_vm");
         }
-        if let Some(tee_kind) = row.get::<Option<&str>, _>("tee_kind") {
-            if Some(tee_kind) != self.tee_kind {
-                return Some("tee_kind");
-            }
+        if let Some(tee_kind) = row.get::<Option<&str>, _>("tee_kind")
+            && Some(tee_kind) != self.tee_kind
+        {
+            return Some("tee_kind");
         }
-        if let Some(request_payload) = row.get::<Option<serde_json::Value>, _>("request_payload") {
-            if request_payload != *self.request_payload {
-                return Some("request_payload");
-            }
+        if let Some(request_payload) = row.get::<Option<serde_json::Value>, _>("request_payload")
+            && request_payload != *self.request_payload
+        {
+            return Some("request_payload");
         }
         None
     }

--- a/crates/proof/prover-service/db/src/repo.rs
+++ b/crates/proof/prover-service/db/src/repo.rs
@@ -1348,7 +1348,7 @@ fn build_protocol_request_payload(
     l1_head: Option<&str>,
     intermediate_root_interval: Option<i64>,
 ) -> serde_json::Value {
-    let zk_payload = serde_json::json!({
+    let mut zk_payload = serde_json::json!({
         "start_block_number": start_block_number,
         "number_of_blocks_to_prove": number_of_blocks_to_prove,
         "sequence_window": sequence_window,
@@ -1356,6 +1356,7 @@ fn build_protocol_request_payload(
         "intermediate_root_interval": intermediate_root_interval,
         "zk_vm": ZkVmKind::Sp1.as_str(),
     });
+    strip_null_object_fields(&mut zk_payload);
 
     match proof_type {
         ProofType::OpSuccinctSp1ClusterCompressed => serde_json::json!({
@@ -1375,6 +1376,23 @@ fn build_protocol_request_payload(
                 },
             },
         }),
+    }
+}
+
+fn strip_null_object_fields(value: &mut serde_json::Value) {
+    match value {
+        serde_json::Value::Object(map) => {
+            map.retain(|_, value| {
+                strip_null_object_fields(value);
+                !value.is_null()
+            });
+        }
+        serde_json::Value::Array(values) => {
+            for value in values {
+                strip_null_object_fields(value);
+            }
+        }
+        _ => {}
     }
 }
 
@@ -1536,8 +1554,10 @@ impl CreateOutboxRequestParams<'_> {
                 return Some("zk_vm");
             }
         }
-        if row.get::<Option<&str>, _>("tee_kind") != self.tee_kind {
-            return Some("tee_kind");
+        if let Some(tee_kind) = row.get::<Option<&str>, _>("tee_kind") {
+            if Some(tee_kind) != self.tee_kind {
+                return Some("tee_kind");
+            }
         }
         if let Some(request_payload) = row.get::<Option<serde_json::Value>, _>("request_payload") {
             if request_payload != *self.request_payload {
@@ -1628,5 +1648,31 @@ mod tests {
         assert_eq!(zk_request.sequence_window, Some(50));
         assert_eq!(zk_request.intermediate_root_interval, Some(5));
         assert_eq!(zk_request.zk_vm, ZkVm::Sp1);
+    }
+
+    #[test]
+    fn prepared_request_omits_absent_optional_protocol_payload_fields() {
+        let prepared = PreparedProofRequest::try_from(CreateProofRequest {
+            start_block_number: 100,
+            number_of_blocks_to_prove: 5,
+            sequence_window: None,
+            proof_type: ProofType::OpSuccinctSp1ClusterCompressed,
+            session_id: Some(Uuid::new_v4()),
+            request_payload: None,
+            prover_address: None,
+            l1_head: None,
+            intermediate_root_interval: None,
+        })
+        .expect("request should prepare");
+
+        let payload = prepared
+            .request_payload
+            .pointer("/request/payload")
+            .and_then(serde_json::Value::as_object)
+            .expect("compressed payload should be an object");
+
+        assert!(!payload.contains_key("sequence_window"));
+        assert!(!payload.contains_key("l1_head"));
+        assert!(!payload.contains_key("intermediate_root_interval"));
     }
 }

--- a/crates/proof/prover-service/db/tests/postgres_integration.rs
+++ b/crates/proof/prover-service/db/tests/postgres_integration.rs
@@ -16,10 +16,12 @@
 use std::time::Duration;
 
 use base_prover_service_db::{
-    CreateProofRequest, CreateProofRequestError, CreateProofRequestOutcome, CreateProofSession,
-    MarkOutboxError, MarkOutboxProcessed, ProofRequestRepo, ProofStatus, ProofType, RetryOutcome,
-    SessionStatus, SessionType, UpdateProofSession, UpdateReceipt,
+    ApiProofType, CreateProofRequest, CreateProofRequestError, CreateProofRequestOutcome,
+    CreateProofSession, MarkOutboxError, MarkOutboxProcessed, ProofRequestPage, ProofRequestRepo,
+    ProofStatus, ProofType, RetryOutcome, SessionStatus, SessionType, UpdateProofSession,
+    UpdateReceipt, ZkVmKind,
 };
+use base_prover_service_protocol::ProofRequest as ProtocolProofRequest;
 use sqlx::{PgPool, postgres::PgPoolOptions};
 use uuid::Uuid;
 
@@ -53,6 +55,7 @@ const fn compressed_request() -> CreateProofRequest {
         sequence_window: Some(50),
         proof_type: ProofType::OpSuccinctSp1ClusterCompressed,
         session_id: None,
+        request_payload: None,
         prover_address: None,
         l1_head: None,
         intermediate_root_interval: None,
@@ -66,6 +69,7 @@ fn snark_request() -> CreateProofRequest {
         sequence_window: Some(100),
         proof_type: ProofType::OpSuccinctSp1ClusterSnarkGroth16,
         session_id: None,
+        request_payload: None,
         prover_address: Some("0x1234567890abcdef1234567890abcdef12345678".to_string()),
         l1_head: Some(
             "0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890".to_string(),
@@ -106,6 +110,12 @@ async fn test_create_and_get_compressed() {
     let req = repo.get(id).await.unwrap().expect("should find request");
 
     assert_eq!(req.id, id);
+    assert_eq!(req.session_id, id.to_string());
+    assert_eq!(req.api_proof_type, ApiProofType::Compressed);
+    assert_eq!(req.zk_vm, Some(ZkVmKind::Sp1));
+    assert!(req.tee_kind.is_none());
+    serde_json::from_value::<ProtocolProofRequest>(req.request_payload.clone())
+        .expect("stored protocol request payload should deserialize");
     assert_eq!(req.start_block_number, 100);
     assert_eq!(req.number_of_blocks_to_prove, 5);
     assert_eq!(req.sequence_window, Some(50));
@@ -154,6 +164,82 @@ async fn test_create_with_session_id() {
 
     let fetched = repo.get(id).await.unwrap().expect("should find request");
     assert_eq!(fetched.id, explicit_id);
+    assert_eq!(fetched.session_id, explicit_id.to_string());
+}
+
+#[tokio::test]
+#[ignore = "requires a running Postgres with the prover schema (set DATABASE_URL); run with `cargo nextest run --run-ignored all -p base-prover-service-db --test postgres_integration --test-threads=1`"]
+async fn test_create_with_uppercase_session_id_is_canonicalized() {
+    let pool = test_pool().await;
+    let repo = test_repo(pool);
+
+    let explicit_id = Uuid::new_v4();
+    let mut req = compressed_request();
+    req.session_id = Some(Uuid::parse_str(&explicit_id.to_string().to_uppercase()).unwrap());
+
+    let id = repo.create(req).await.unwrap();
+    assert_eq!(id, explicit_id);
+
+    let fetched = repo.get(id).await.unwrap().expect("should find request by UUID session ID");
+    assert_eq!(fetched.id, explicit_id);
+    assert_eq!(fetched.session_id, explicit_id.to_string());
+
+    let (proofs, _) =
+        repo.list_with_offset(&[], ProofRequestPage::try_new(100, 0).unwrap()).await.unwrap();
+    assert!(proofs.iter().any(|proof| proof.session_id == fetched.session_id));
+}
+
+#[tokio::test]
+#[ignore = "requires a running Postgres with the prover schema (set DATABASE_URL); run with `cargo nextest run --run-ignored all -p base-prover-service-db --test postgres_integration --test-threads=1`"]
+async fn test_legacy_rollout_request_without_protocol_storage_is_readable_and_replayable() {
+    let pool = test_pool().await;
+    let repo = test_repo(pool.clone());
+
+    let explicit_id = Uuid::new_v4();
+    let mut req = compressed_request();
+    req.session_id = Some(explicit_id);
+
+    sqlx::query(
+        r#"
+        INSERT INTO proof_requests (
+            id, start_block_number, number_of_blocks_to_prove, sequence_window, proof_type, status,
+            prover_address, l1_head, intermediate_root_interval
+        )
+        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+        "#,
+    )
+    .bind(explicit_id)
+    .bind(i64::try_from(req.start_block_number).unwrap())
+    .bind(i64::try_from(req.number_of_blocks_to_prove).unwrap())
+    .bind(req.sequence_window.map(|value| i64::try_from(value).unwrap()))
+    .bind(req.proof_type.as_str())
+    .bind(ProofStatus::Created.as_str())
+    .bind(&req.prover_address)
+    .bind(&req.l1_head)
+    .bind(req.intermediate_root_interval.map(|value| i64::try_from(value).unwrap()))
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    let fetched = repo.get(explicit_id).await.unwrap().expect("should synthesize protocol fields");
+    assert_eq!(fetched.api_proof_type, ApiProofType::Compressed);
+    assert_eq!(fetched.zk_vm, Some(ZkVmKind::Sp1));
+    serde_json::from_value::<ProtocolProofRequest>(fetched.request_payload)
+        .expect("synthesized protocol request payload should deserialize");
+
+    let (proofs, _) = repo
+        .list_with_offset(&[ProofStatus::Created], ProofRequestPage::try_new(10_000, 0).unwrap())
+        .await
+        .unwrap();
+    let listed = proofs
+        .iter()
+        .find(|proof| proof.id == explicit_id)
+        .expect("list should synthesize protocol fields");
+    assert_eq!(listed.api_proof_type, ApiProofType::Compressed);
+    assert_eq!(listed.zk_vm, Some(ZkVmKind::Sp1));
+
+    let outcome = repo.create_with_outbox(req, TEST_MAX_PROOF_RETRIES).await.unwrap();
+    assert_eq!(outcome, CreateProofRequestOutcome::Replayed(explicit_id));
 }
 
 #[tokio::test]

--- a/crates/proof/prover-service/src/server/get_proof.rs
+++ b/crates/proof/prover-service/src/server/get_proof.rs
@@ -45,7 +45,7 @@ fn proof_result_for_request(proof_req: &ProofRequest) -> RpcResult<ProofResult> 
 }
 
 impl ProverServiceServer {
-    /// Returns current proof status and proof bytes for `session_id=<uuid>`.
+    /// Returns current proof status and proof bytes for the public `session_id`.
     pub async fn get_proof_impl(&self, request: GetProofRequest) -> RpcResult<GetProofResponse> {
         let start = std::time::Instant::now();
         let result = self.get_proof_inner(request).await;
@@ -141,8 +141,9 @@ impl ProverServiceServer {
 mod tests {
     use std::collections::HashMap;
 
-    use base_prover_service_db::{ProofRequest, ProofType};
+    use base_prover_service_db::{ApiProofType, ProofRequest, ProofType, ZkVmKind};
     use chrono::Utc;
+    use uuid::Uuid;
 
     use super::*;
     use crate::OpSuccinctStoredExecutionStats;
@@ -161,8 +162,17 @@ mod tests {
         snark_receipt: Option<Vec<u8>>,
     ) -> ProofRequest {
         let now = Utc::now();
+        let id = Uuid::new_v4();
         ProofRequest {
-            id: Uuid::new_v4(),
+            id,
+            session_id: id.to_string(),
+            request_payload: serde_json::json!({}),
+            api_proof_type: match proof_type {
+                ProofType::OpSuccinctSp1ClusterCompressed => ApiProofType::Compressed,
+                ProofType::OpSuccinctSp1ClusterSnarkGroth16 => ApiProofType::SnarkGroth16,
+            },
+            zk_vm: Some(ZkVmKind::Sp1),
+            tee_kind: None,
             start_block_number: 1,
             number_of_blocks_to_prove: 1,
             sequence_window: None,

--- a/crates/proof/prover-service/src/server/list_proofs.rs
+++ b/crates/proof/prover-service/src/server/list_proofs.rs
@@ -1,10 +1,11 @@
 //! Implementation of the `ListProofs` JSON-RPC endpoint.
 
 use base_prover_service_db::{
-    ProofRequestPage, ProofStatus as DbProofStatus, ProofType as DbProofType,
+    ApiProofType as DbApiProofType, ProofRequestPage, ProofStatus as DbProofStatus,
+    TeeKind as DbTeeKind, ZkVmKind as DbZkVmKind,
 };
 use base_prover_service_protocol::{
-    ListProofsRequest, ListProofsResponse, ProofStatus, ProofSummary, ProofType, ZkVm,
+    ListProofsRequest, ListProofsResponse, ProofStatus, ProofSummary, ProofType, TeeKind, ZkVm,
 };
 use jsonrpsee::core::RpcResult;
 use tracing::debug;
@@ -48,15 +49,15 @@ impl ProverServiceServer {
         let summaries: Vec<ProofSummary> = proofs
             .into_iter()
             .map(|p| ProofSummary {
-                session_id: p.id.to_string(),
-                proof_type: api_proof_type(p.proof_type),
+                session_id: p.session_id,
+                proof_type: api_proof_type(p.api_proof_type),
                 status: api_status(p.status),
                 created_at: p.created_at,
                 updated_at: p.updated_at,
                 completed_at: p.completed_at,
                 error_message: p.error_message,
-                tee_kind: None,
-                zk_vm: Some(ZkVm::Sp1),
+                tee_kind: p.tee_kind.map(api_tee_kind),
+                zk_vm: p.zk_vm.map(api_zk_vm),
             })
             .collect();
 
@@ -85,10 +86,23 @@ fn parse_status_filter(status_filter: Option<ProofStatus>) -> Vec<DbProofStatus>
     }
 }
 
-const fn api_proof_type(proof_type: DbProofType) -> ProofType {
+const fn api_proof_type(proof_type: DbApiProofType) -> ProofType {
     match proof_type {
-        DbProofType::OpSuccinctSp1ClusterCompressed => ProofType::Compressed,
-        DbProofType::OpSuccinctSp1ClusterSnarkGroth16 => ProofType::SnarkGroth16,
+        DbApiProofType::Compressed => ProofType::Compressed,
+        DbApiProofType::SnarkGroth16 => ProofType::SnarkGroth16,
+        DbApiProofType::Tee => ProofType::Tee,
+    }
+}
+
+const fn api_zk_vm(zk_vm: DbZkVmKind) -> ZkVm {
+    match zk_vm {
+        DbZkVmKind::Sp1 => ZkVm::Sp1,
+    }
+}
+
+const fn api_tee_kind(tee_kind: DbTeeKind) -> TeeKind {
+    match tee_kind {
+        DbTeeKind::AwsNitro => TeeKind::AwsNitro,
     }
 }
 
@@ -116,14 +130,9 @@ mod tests {
 
     #[test]
     fn api_proof_type_maps_all_variants() {
-        assert_eq!(
-            api_proof_type(DbProofType::OpSuccinctSp1ClusterCompressed),
-            ProofType::Compressed
-        );
-        assert_eq!(
-            api_proof_type(DbProofType::OpSuccinctSp1ClusterSnarkGroth16),
-            ProofType::SnarkGroth16
-        );
+        assert_eq!(api_proof_type(DbApiProofType::Compressed), ProofType::Compressed);
+        assert_eq!(api_proof_type(DbApiProofType::SnarkGroth16), ProofType::SnarkGroth16);
+        assert_eq!(api_proof_type(DbApiProofType::Tee), ProofType::Tee);
     }
 
     #[test]

--- a/crates/proof/prover-service/src/server/prove_block_range.rs
+++ b/crates/proof/prover-service/src/server/prove_block_range.rs
@@ -32,8 +32,14 @@ impl ProverServiceServer {
         &self,
         request: ProveBlockRangeRequest,
     ) -> RpcResult<ProveBlockRangeResponse> {
-        let session_id = parse_session_id(request.proof.session_id.as_deref())?;
-        let (zk_request, proof_type, prover_address) = parse_zk_request(request.proof)?;
+        let mut proof_request = request.proof;
+        let proof_request_id = parse_session_id(proof_request.session_id.as_deref())?;
+        let session_id = proof_request_id.to_string();
+        proof_request.session_id = Some(session_id.clone());
+
+        let request_payload = serde_json::to_value(&proof_request)
+            .map_err(|e| internal(format!("Failed to serialize proof request: {e}")))?;
+        let (zk_request, proof_type, prover_address) = parse_zk_request(proof_request)?;
         let l1_head = zk_request.l1_head.map(format_hash);
 
         info!(
@@ -64,7 +70,8 @@ impl ProverServiceServer {
             number_of_blocks_to_prove: zk_request.number_of_blocks_to_prove,
             sequence_window: zk_request.sequence_window,
             proof_type,
-            session_id,
+            session_id: Some(proof_request_id),
+            request_payload: Some(request_payload),
             prover_address,
             l1_head,
             intermediate_root_interval: zk_request.intermediate_root_interval,
@@ -97,16 +104,16 @@ impl ProverServiceServer {
                 CreateProofRequestError::Sqlx(e) => internal(format!("Database error: {e}")),
             })?;
 
-        let proof_request_id = outcome.id();
         match outcome {
             CreateProofRequestOutcome::RetryExhausted(id) => {
                 warn!(
                     proof_request_id = %id,
+                    session_id = %session_id,
                     max_proof_retries = self.max_proof_retries,
                     "rejected ProveBlockRange: proof request retry budget exhausted for this session_id",
                 );
                 return Err(resource_exhausted(format!(
-                    "session_id {id}: proof request retry budget exhausted; use get_proof for the stored terminal failure",
+                    "session_id {session_id}: proof request retry budget exhausted; use get_proof for the stored terminal failure",
                 )));
             }
             CreateProofRequestOutcome::Created(id) => {
@@ -129,16 +136,17 @@ impl ProverServiceServer {
             }
         }
 
-        Ok(ProveBlockRangeResponse { session_id: proof_request_id.to_string() })
+        Ok(ProveBlockRangeResponse { session_id })
     }
 }
 
-fn parse_session_id(session_id: Option<&str>) -> RpcResult<Option<Uuid>> {
+fn parse_session_id(session_id: Option<&str>) -> RpcResult<Uuid> {
     session_id
         .map(|id| {
             Uuid::parse_str(id).map_err(|e| invalid_argument(format!("Invalid session_id: {e}")))
         })
         .transpose()
+        .map(|id| id.unwrap_or_else(Uuid::new_v4))
 }
 
 fn parse_zk_request(
@@ -173,7 +181,9 @@ fn format_hash(hash: B256) -> String {
 #[cfg(test)]
 mod tests {
     use base_prover_service_db::ProofType;
+    use uuid::Uuid;
 
+    use super::parse_session_id;
     use crate::metrics;
 
     #[test]
@@ -190,5 +200,13 @@ mod tests {
             metrics::proof_type_label(ProofType::OpSuccinctSp1ClusterSnarkGroth16),
             "snark_groth16"
         );
+    }
+
+    #[test]
+    fn parse_session_id_accepts_uppercase_uuid() {
+        let id = Uuid::new_v4();
+        let parsed = parse_session_id(Some(&id.to_string().to_uppercase())).unwrap();
+
+        assert_eq!(parsed, id);
     }
 }


### PR DESCRIPTION
### What changed? Why?

Store the original protocol ProofRequest payload and normalized protocol selectors (`api_proof_type`, `zk_vm`, `tee_kind`) on `proof_requests` so API callers can get protocol-native proof summaries and stable session IDs back from the service.

This also adds an expand-phase migration/backfill for existing rows and threads the stored protocol fields through create, replay, list, and get flows.

### Notes to reviewers

The new columns stay nullable during the expand phase so old service binaries can continue inserting `proof_requests` during rolling deploys. Legacy rows synthesize protocol fields at read/list time for compatibility.

The Postgres integration tests added here remain ignored unless run against a prover schema database.

### How has it been tested?

`cargo test -p base-prover-service-db -p base-prover-service --lib`