### PR TITLE
fix(precompiles): remove duplicate from-zero check in transfer_from

### DIFF
--- a/crates/common/precompiles/src/common/ops/transferable.rs
+++ b/crates/common/precompiles/src/common/ops/transferable.rs
@@ -62,9 +62,6 @@ pub trait Transferable: Token {
         amount: U256,
         privileged: bool,
     ) -> Result<()> {
-        if from == Address::ZERO {
-            return Err(BasePrecompileError::revert(IB20::InvalidSender { sender: from }));
-        }
         let allowance = self.accounting().allowance(from, spender)?;
         if allowance == U256::MAX {
             return self.transfer(from, to, amount, privileged);


### PR DESCRIPTION
## Summary

- Removes the redundant `from == Address::ZERO` guard at the top of `transfer_from` — `transfer` already performs this check and returns `InvalidSender`, so the outer check was dead code.

Closes [BOP-209](https://linear.app/coinbase/issue/BOP-209/b20-rust-remove-duplicate-from-zero-check-in-transfer-from)

## Test plan

- [ ] Existing test suite passes (`cargo test -p base-common-precompiles` — 340 tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)