### PR TITLE
feat(nitro-host): add worker mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5944,11 +5944,14 @@ dependencies = [
  "base-proof-host",
  "base-proof-tee-nitro-enclave",
  "base-proof-tee-nitro-host",
+ "base-prover-service-client",
  "clap",
  "eyre",
  "serde",
  "tokio",
+ "tokio-util",
  "tracing",
+ "uuid",
 ]
 
 [[package]]

--- a/bin/prover/nitro-host/Cargo.toml
+++ b/bin/prover/nitro-host/Cargo.toml
@@ -23,9 +23,12 @@ alloy-primitives.workspace = true
 base-common-chains.workspace = true
 base-proof-tee-nitro-host.workspace = true
 tokio = { workspace = true, features = ["full"] }
+tokio-util = { workspace = true, optional = true }
 clap = { workspace = true, features = ["derive", "env"] }
 serde = { workspace = true, features = ["derive", "std"] }
 base-proof-host = { workspace = true, features = ["metrics"] }
+uuid = { workspace = true, features = ["v4"], optional = true }
+base-prover-service-client = { workspace = true, optional = true }
 base-proof-tee-nitro-enclave = { workspace = true, optional = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
@@ -33,3 +36,4 @@ base-proof-tee-nitro-enclave.workspace = true
 
 [features]
 local = [ "dep:base-proof-tee-nitro-enclave" ]
+worker = [ "dep:base-prover-service-client", "dep:tokio-util", "dep:uuid" ]

--- a/bin/prover/nitro-host/README.md
+++ b/bin/prover/nitro-host/README.md
@@ -5,7 +5,35 @@ TEE prover host server for AWS Nitro Enclaves.
 ## Subcommands
 
 - **`server`** — Runs the JSON-RPC server on the EC2 host, forwarding proving requests to the enclave over vsock.
+- **`server`** with `--features worker` — Runs as a prover-service worker instead of binding JSON-RPC, claiming Nitro TEE jobs from `PROVER_SERVICE_ENDPOINT`.
 - **`local`** *(feature-gated)* — Runs server and enclave in a single process for local development.
+- **`local`** with `--features local,worker` — Runs as a prover-service worker backed by in-process local enclave instances.
+
+## Worker Mode
+
+Worker mode is selected at build time:
+
+```bash
+cargo build --package base-prover-nitro-host --features worker
+```
+
+The worker build keeps the `server` subcommand name, but it does not accept
+`LISTEN_ADDR` and does not expose the prover or enclave JSON-RPC APIs. It
+requires `PROVER_SERVICE_ENDPOINT` and claims AWS Nitro TEE jobs through the
+prover-service worker API.
+
+For local worker development, enable both feature flags and use `local`:
+
+```bash
+cargo run --package base-prover-nitro-host --features local,worker -- local \
+  --prover-service-endpoint "$PROVER_SERVICE_ENDPOINT" \
+  --l1-eth-url "$L1_ETH_URL" \
+  --l2-eth-url "$L2_ETH_URL" \
+  --l1-beacon-url "$L1_BEACON_URL" \
+  --l2-chain-id "$L2_CHAIN_ID"
+```
+
+The `just tee nitro-local-worker` recipe wraps the same command.
 
 ## Inspecting the enclave
 

--- a/bin/prover/nitro-host/src/cli.rs
+++ b/bin/prover/nitro-host/src/cli.rs
@@ -30,8 +30,8 @@ use base_proof_tee_nitro_host::{
     DEFAULT_JOB_DISCOVERY_LOCK_DURATION_SECONDS, DEFAULT_JOB_DISCOVERY_MAX_CONCURRENT_JOBS,
     DEFAULT_PROOF_GENERATOR_HEARTBEAT_LOCK_DURATION_SECONDS,
     DEFAULT_PROOF_GENERATOR_MAX_CONSECUTIVE_HEARTBEAT_FAILURES, JobDiscovery, JobDiscoveryConfig,
-    NitroEnclavePool, NitroWorkerConfig, ProofGenerator, ProofGeneratorHeartbeatConfig,
-    ProofSubmitter, RegistrationChecker,
+    NitroEnclavePool, ProofGenerator, ProofGeneratorHeartbeatConfig, ProofSubmitter,
+    RegistrationChecker,
 };
 #[cfg(any(target_os = "linux", feature = "local"))]
 use base_proof_tee_nitro_host::{NitroTransport, RegistrationHealthConfig};
@@ -241,14 +241,34 @@ impl Cli {
         base_cli_utils::MetricsConfig::from(metrics).init_with(|| {
             base_cli_utils::register_version_metrics!();
         })?;
-        RuntimeManager::new().with_thread_stack_size(8 * 1024 * 1024).run_until_ctrl_c(async move {
-            match command {
-                #[cfg(target_os = "linux")]
-                Command::Server(args) => args.run().await,
-                #[cfg(feature = "local")]
-                Command::Local(args) => args.run().await,
-            }
-        })
+        let runtime = RuntimeManager::new().with_thread_stack_size(8 * 1024 * 1024);
+
+        #[cfg(feature = "worker")]
+        {
+            runtime.run_until_shutdown(|cancel| async move {
+                #[cfg(not(any(target_os = "linux", feature = "local")))]
+                let _ = cancel;
+
+                match command {
+                    #[cfg(target_os = "linux")]
+                    Command::Server(args) => args.run(cancel).await,
+                    #[cfg(feature = "local")]
+                    Command::Local(args) => args.run(cancel).await,
+                }
+            })
+        }
+
+        #[cfg(not(feature = "worker"))]
+        {
+            runtime.run_until_ctrl_c(async move {
+                match command {
+                    #[cfg(target_os = "linux")]
+                    Command::Server(args) => args.run().await,
+                    #[cfg(feature = "local")]
+                    Command::Local(args) => args.run().await,
+                }
+            })
+        }
     }
 }
 
@@ -283,14 +303,14 @@ impl ServerArgs {
 
 #[cfg(all(target_os = "linux", feature = "worker"))]
 impl ServerArgs {
-    async fn run(self) -> eyre::Result<()> {
+    async fn run(self, cancel: CancellationToken) -> eyre::Result<()> {
         if self.vsock_cid.is_empty() {
             return Err(eyre!("at least one --vsock-cid is required"));
         }
         let transports = vsock_transports(&self.vsock_cid);
 
         info!(cids = ?self.vsock_cid, "configured vsock CIDs");
-        run_worker(self.runtime, self.worker, transports, WorkerTransportMode::Vsock).await
+        run_worker(self.runtime, self.worker, transports, WorkerTransportMode::Vsock, cancel).await
     }
 }
 
@@ -356,13 +376,13 @@ struct LocalArgs {
 
 #[cfg(all(feature = "local", feature = "worker"))]
 impl LocalArgs {
-    async fn run(self) -> eyre::Result<()> {
+    async fn run(self, cancel: CancellationToken) -> eyre::Result<()> {
         if self.local_enclave_count == 0 {
             return Err(eyre!("--local-enclave-count must be at least 1"));
         }
 
         let transports = local_transports(self.local_enclave_count)?;
-        run_worker(self.runtime, self.worker, transports, WorkerTransportMode::Local).await
+        run_worker(self.runtime, self.worker, transports, WorkerTransportMode::Local, cancel).await
     }
 }
 
@@ -387,6 +407,7 @@ async fn run_worker(
     worker: WorkerArgs,
     transports: Vec<Arc<NitroTransport>>,
     transport_mode: WorkerTransportMode,
+    cancel: CancellationToken,
 ) -> eyre::Result<()> {
     let registration_health = runtime.registration_health_config();
     let registry_configured = registration_health.is_some();
@@ -422,8 +443,7 @@ async fn run_worker(
 
     let prover_service = ProverServiceClientConfig::new(worker.prover_service_endpoint.clone())
         .with_request_timeout(Duration::from_secs(worker.prover_service_request_timeout_secs));
-    let worker_config = NitroWorkerConfig::new(prover_service.clone());
-    worker_config.validate()?;
+    prover_service.validate()?;
 
     let client = ProverWorkerClient::connect(&prover_service)?;
     let submitter = ProofSubmitter::new(client.clone());
@@ -459,7 +479,7 @@ async fn run_worker(
             );
         }
     }
-    discovery.run_until_cancelled(CancellationToken::new()).await;
+    discovery.run_until_cancelled(cancel).await;
     Ok(())
 }
 

--- a/bin/prover/nitro-host/src/cli.rs
+++ b/bin/prover/nitro-host/src/cli.rs
@@ -443,7 +443,6 @@ async fn run_worker(
 
     let prover_service = ProverServiceClientConfig::new(worker.prover_service_endpoint.clone())
         .with_request_timeout(Duration::from_secs(worker.prover_service_request_timeout_secs));
-    prover_service.validate()?;
 
     let client = ProverWorkerClient::connect(&prover_service)?;
     let submitter = ProofSubmitter::new(client.clone());

--- a/bin/prover/nitro-host/src/cli.rs
+++ b/bin/prover/nitro-host/src/cli.rs
@@ -430,10 +430,10 @@ async fn run_worker(
         );
     }
 
-    let mut pool = NitroEnclavePool::new_multi(config, transports.clone());
+    let mut pool = NitroEnclavePool::new_multi(config, transports);
     if let Some(registration_health) = registration_health {
         let checker = Arc::new(
-            RegistrationChecker::from_health_config(transports, &registration_health)
+            RegistrationChecker::from_health_config(pool.transports(), &registration_health)
                 .map_err(|e| eyre!("registration checker init failed: {e}"))?,
         );
         pool = pool

--- a/bin/prover/nitro-host/src/cli.rs
+++ b/bin/prover/nitro-host/src/cli.rs
@@ -1,8 +1,14 @@
 //! CLI definition for the Nitro TEE prover host binary.
 
+#[cfg(any(
+    all(target_os = "linux", not(feature = "worker")),
+    all(feature = "local", not(feature = "worker"))
+))]
 use std::net::SocketAddr;
 #[cfg(any(target_os = "linux", feature = "local"))]
 use std::sync::Arc;
+#[cfg(all(feature = "worker", any(target_os = "linux", feature = "local")))]
+use std::time::Duration;
 
 use alloy_primitives::Address;
 use base_cli_utils::{LogConfig, RuntimeManager};
@@ -14,17 +20,34 @@ use base_proof_host::ProverConfig;
 use base_proof_tee_nitro_enclave::Server as EnclaveServer;
 #[cfg(target_os = "linux")]
 use base_proof_tee_nitro_enclave::VSOCK_PORT;
+#[cfg(any(
+    all(target_os = "linux", not(feature = "worker")),
+    all(feature = "local", not(feature = "worker"))
+))]
+use base_proof_tee_nitro_host::NitroProverServer;
+#[cfg(all(feature = "worker", any(target_os = "linux", feature = "local")))]
+use base_proof_tee_nitro_host::{
+    DEFAULT_JOB_DISCOVERY_LOCK_DURATION_SECONDS, DEFAULT_JOB_DISCOVERY_MAX_CONCURRENT_JOBS,
+    DEFAULT_PROOF_GENERATOR_HEARTBEAT_LOCK_DURATION_SECONDS,
+    DEFAULT_PROOF_GENERATOR_MAX_CONSECUTIVE_HEARTBEAT_FAILURES, JobDiscovery, JobDiscoveryConfig,
+    NitroEnclavePool, NitroWorkerConfig, ProofGenerator, ProofGeneratorHeartbeatConfig,
+    ProofSubmitter, RegistrationChecker,
+};
 #[cfg(any(target_os = "linux", feature = "local"))]
-use base_proof_tee_nitro_host::RegistrationHealthConfig;
-#[cfg(any(target_os = "linux", feature = "local"))]
-use base_proof_tee_nitro_host::{NitroProverServer, NitroTransport};
+use base_proof_tee_nitro_host::{NitroTransport, RegistrationHealthConfig};
+#[cfg(all(feature = "worker", any(target_os = "linux", feature = "local")))]
+use base_prover_service_client::{ProverServiceClientConfig, ProverWorkerClient};
 use clap::{Parser, Subcommand};
 #[cfg(any(target_os = "linux", feature = "local"))]
 use eyre::eyre;
+#[cfg(all(feature = "worker", any(target_os = "linux", feature = "local")))]
+use tokio_util::sync::CancellationToken;
 #[cfg(any(target_os = "linux", feature = "local"))]
 use tracing::info;
-#[cfg(feature = "local")]
+#[cfg(any(feature = "local", all(target_os = "linux", feature = "worker")))]
 use tracing::warn;
+#[cfg(all(feature = "worker", any(target_os = "linux", feature = "local")))]
+use uuid::Uuid;
 
 base_cli_utils::define_log_args!("BASE_PROVER_NITRO_HOST");
 base_cli_utils::define_metrics_args!("BASE_PROVER_NITRO_HOST", 7300);
@@ -52,17 +75,24 @@ enum Command {
     ///
     /// Accepts proving requests over JSON-RPC and forwards them to the Nitro
     /// Enclave over vsock.
-    #[cfg(target_os = "linux")]
+    #[cfg(all(target_os = "linux", not(feature = "worker")))]
     Server(ServerArgs),
 
-    /// Run server and enclave in a single process for local development.
+    /// Run as a prover-service worker on the EC2 host.
+    ///
+    /// Claims Nitro proof jobs from prover-service and forwards them to the
+    /// Nitro Enclave over vsock.
+    #[cfg(all(target_os = "linux", feature = "worker"))]
+    Server(ServerArgs),
+
+    /// Run with in-process local enclave instances for local development.
     #[cfg(feature = "local")]
     Local(LocalArgs),
 }
 
-/// Shared arguments for subcommands that run the JSON-RPC prover server.
+/// Shared arguments for subcommands that run Nitro proving.
 #[derive(Parser)]
-struct ProverServerArgs {
+struct ProverRuntimeArgs {
     /// L1 execution layer RPC URL.
     #[arg(long, env = "L1_ETH_URL")]
     l1_eth_url: String,
@@ -79,40 +109,128 @@ struct ProverServerArgs {
     #[arg(long, env = "L2_CHAIN_ID")]
     l2_chain_id: u64,
 
-    /// Socket address to listen on for JSON-RPC.
-    #[arg(long, env = "LISTEN_ADDR")]
-    listen_addr: SocketAddr,
-
     /// Enable experimental `debug_executePayload` witness endpoint.
     #[arg(long, env = "ENABLE_EXPERIMENTAL_WITNESS_ENDPOINT")]
     enable_experimental_witness_endpoint: bool,
 
-    /// `TEEProverRegistry` contract address on L1. When set, `/healthz` returns
-    /// healthy only if the enclave signer is registered on-chain.
+    /// `TEEProverRegistry` contract address on L1. When set, proving is guarded
+    /// by on-chain signer validity and server `/healthz` is registration-gated.
     #[arg(long, env = "TEE_PROVER_REGISTRY_ADDRESS")]
     tee_prover_registry_address: Option<Address>,
 }
 
 #[cfg(any(target_os = "linux", feature = "local"))]
-impl ProverServerArgs {
+impl ProverRuntimeArgs {
     fn registration_health_config(&self) -> Option<RegistrationHealthConfig> {
         self.tee_prover_registry_address.map(|address| RegistrationHealthConfig {
             registry_address: address,
             l1_rpc_url: self.l1_eth_url.clone(),
         })
     }
+
+    fn prover_config(self) -> eyre::Result<ProverConfig> {
+        let rollup_config = rollup_config!(self.l2_chain_id)
+            .ok_or_else(|| eyre!("unknown L2 chain ID: {}", self.l2_chain_id))?;
+
+        let l1_config = base_common_chains::L1_CONFIGS
+            .get(&rollup_config.l1_chain_id)
+            .ok_or_else(|| eyre!("unknown L1 chain ID: {}", rollup_config.l1_chain_id))?
+            .clone();
+
+        Ok(ProverConfig {
+            l1_eth_url: self.l1_eth_url,
+            l2_eth_url: self.l2_eth_url,
+            l1_beacon_url: self.l1_beacon_url,
+            l2_chain_id: self.l2_chain_id,
+            rollup_config,
+            l1_config,
+            enable_experimental_witness_endpoint: self.enable_experimental_witness_endpoint,
+        })
+    }
 }
 
 /// Arguments for the `server` subcommand.
-#[cfg(target_os = "linux")]
+#[cfg(all(target_os = "linux", not(feature = "worker")))]
 #[derive(Parser)]
 struct ServerArgs {
     #[command(flatten)]
-    server: ProverServerArgs,
+    runtime: ProverRuntimeArgs,
+
+    /// Socket address to listen on for JSON-RPC.
+    #[arg(long, env = "LISTEN_ADDR")]
+    listen_addr: SocketAddr,
 
     /// Vsock CID(s) of the enclave(s), comma-separated for multi-enclave mode.
     #[arg(long, env = "VSOCK_CID", value_delimiter = ',')]
     vsock_cid: Vec<u32>,
+}
+
+/// Arguments for the `server` subcommand when the `worker` feature is enabled.
+#[cfg(all(target_os = "linux", feature = "worker"))]
+#[derive(Parser)]
+struct ServerArgs {
+    #[command(flatten)]
+    runtime: ProverRuntimeArgs,
+
+    #[command(flatten)]
+    worker: WorkerArgs,
+
+    /// Vsock CID(s) of the enclave(s), comma-separated for multi-enclave mode.
+    #[arg(long, env = "VSOCK_CID", value_delimiter = ',')]
+    vsock_cid: Vec<u32>,
+}
+
+/// Worker-mode arguments for claiming and generating Nitro proof jobs.
+#[cfg(all(feature = "worker", any(target_os = "linux", feature = "local")))]
+#[derive(Parser)]
+struct WorkerArgs {
+    /// Prover-service JSON-RPC endpoint.
+    #[arg(long, env = "PROVER_SERVICE_ENDPOINT")]
+    prover_service_endpoint: String,
+
+    /// Prover-service JSON-RPC request timeout in seconds.
+    #[arg(long, env = "PROVER_SERVICE_REQUEST_TIMEOUT_SECS", default_value_t = 60)]
+    prover_service_request_timeout_secs: u64,
+
+    /// Delay after an empty or failed discovery attempt, in milliseconds.
+    #[arg(long, env = "JOB_DISCOVERY_POLL_INTERVAL_MS", default_value_t = 5_000)]
+    job_discovery_poll_interval_ms: u64,
+
+    /// Requested claim lock duration in seconds. Zero uses the server default.
+    #[arg(
+        long,
+        env = "JOB_DISCOVERY_LOCK_DURATION_SECONDS",
+        default_value_t = DEFAULT_JOB_DISCOVERY_LOCK_DURATION_SECONDS
+    )]
+    job_discovery_lock_duration_seconds: u32,
+
+    /// Maximum number of claimed proof jobs generated concurrently.
+    #[arg(
+        long,
+        env = "JOB_DISCOVERY_MAX_CONCURRENT_JOBS",
+        default_value_t = DEFAULT_JOB_DISCOVERY_MAX_CONCURRENT_JOBS
+    )]
+    job_discovery_max_concurrent_jobs: usize,
+
+    /// Delay between worker API heartbeats while an enclave proof is being generated.
+    #[arg(long, env = "PROOF_GENERATOR_HEARTBEAT_INTERVAL_SECS", default_value_t = 30)]
+    proof_generator_heartbeat_interval_secs: u64,
+
+    /// Requested heartbeat lock duration in seconds. Zero uses the server default.
+    #[arg(
+        long,
+        env = "PROOF_GENERATOR_HEARTBEAT_LOCK_DURATION_SECONDS",
+        default_value_t = DEFAULT_PROOF_GENERATOR_HEARTBEAT_LOCK_DURATION_SECONDS
+    )]
+    proof_generator_heartbeat_lock_duration_seconds: u32,
+
+    /// Maximum consecutive retryable heartbeat failures before aborting generation.
+    #[arg(
+        long,
+        env = "PROOF_GENERATOR_MAX_CONSECUTIVE_HEARTBEAT_FAILURES",
+        default_value_t = DEFAULT_PROOF_GENERATOR_MAX_CONSECUTIVE_HEARTBEAT_FAILURES
+    )]
+    proof_generator_max_consecutive_heartbeat_failures: u32,
 }
 
 impl Cli {
@@ -134,113 +252,232 @@ impl Cli {
     }
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(all(target_os = "linux", not(feature = "worker")))]
 impl ServerArgs {
     async fn run(self) -> eyre::Result<()> {
-        let rollup_config = rollup_config!(self.server.l2_chain_id)
-            .ok_or_else(|| eyre!("unknown L2 chain ID: {}", self.server.l2_chain_id))?;
-
-        let l1_config = base_common_chains::L1_CONFIGS
-            .get(&rollup_config.l1_chain_id)
-            .ok_or_else(|| eyre!("unknown L1 chain ID: {}", rollup_config.l1_chain_id))?
-            .clone();
-
-        let registration_health = self.server.registration_health_config();
-
-        let config = ProverConfig {
-            l1_eth_url: self.server.l1_eth_url,
-            l2_eth_url: self.server.l2_eth_url,
-            l1_beacon_url: self.server.l1_beacon_url,
-            l2_chain_id: self.server.l2_chain_id,
-            rollup_config,
-            l1_config,
-            enable_experimental_witness_endpoint: self.server.enable_experimental_witness_endpoint,
-        };
+        let registration_health = self.runtime.registration_health_config();
+        let registry_configured = registration_health.is_some();
+        let config = self.runtime.prover_config()?;
 
         if self.vsock_cid.is_empty() {
             return Err(eyre!("at least one --vsock-cid is required"));
         }
-        if self.vsock_cid.len() > 1 && self.server.tee_prover_registry_address.is_none() {
+        if self.vsock_cid.len() > 1 && !registry_configured {
             return Err(eyre!(
                 "multi-CID requires --tee-prover-registry-address for on-chain routing"
             ));
         }
-        let transports: Vec<Arc<NitroTransport>> = self
-            .vsock_cid
-            .iter()
-            .map(|&cid| Arc::new(NitroTransport::vsock(cid, VSOCK_PORT)))
-            .collect();
+        let transports = vsock_transports(&self.vsock_cid);
         let mut server = NitroProverServer::new_multi(config, transports);
         if let Some(reg) = registration_health {
             server = server.with_registration_health(reg);
         }
 
         info!(cids = ?self.vsock_cid, "configured vsock CIDs");
-        info!(addr = %self.server.listen_addr, "starting nitro prover host server");
-        let handle = server.run(self.server.listen_addr).await?;
+        info!(addr = %self.listen_addr, "starting nitro prover host server");
+        let handle = server.run(self.listen_addr).await?;
         handle.stopped().await;
         Ok(())
     }
 }
 
+#[cfg(all(target_os = "linux", feature = "worker"))]
+impl ServerArgs {
+    async fn run(self) -> eyre::Result<()> {
+        if self.vsock_cid.is_empty() {
+            return Err(eyre!("at least one --vsock-cid is required"));
+        }
+        let transports = vsock_transports(&self.vsock_cid);
+
+        info!(cids = ?self.vsock_cid, "configured vsock CIDs");
+        run_worker(self.runtime, self.worker, transports, WorkerTransportMode::Vsock).await
+    }
+}
+
 /// Arguments for the `local` subcommand.
-#[cfg(feature = "local")]
+#[cfg(all(feature = "local", not(feature = "worker")))]
 #[derive(Parser)]
 struct LocalArgs {
     #[command(flatten)]
-    server: ProverServerArgs,
+    runtime: ProverRuntimeArgs,
+
+    /// Socket address to listen on for JSON-RPC.
+    #[arg(long, env = "LISTEN_ADDR")]
+    listen_addr: SocketAddr,
 
     /// Number of local enclave instances to run (minimum 1).
     #[arg(long, env = "LOCAL_ENCLAVE_COUNT", default_value = "1")]
     local_enclave_count: usize,
 }
 
-#[cfg(feature = "local")]
+#[cfg(all(feature = "local", not(feature = "worker")))]
 impl LocalArgs {
     async fn run(self) -> eyre::Result<()> {
-        let rollup_config = rollup_config!(self.server.l2_chain_id)
-            .ok_or_else(|| eyre!("unknown L2 chain ID: {}", self.server.l2_chain_id))?;
-
-        let l1_config = base_common_chains::L1_CONFIGS
-            .get(&rollup_config.l1_chain_id)
-            .ok_or_else(|| eyre!("unknown L1 chain ID: {}", rollup_config.l1_chain_id))?
-            .clone();
-
-        let registration_health = self.server.registration_health_config();
-
-        let prover_config = ProverConfig {
-            l1_eth_url: self.server.l1_eth_url,
-            l2_eth_url: self.server.l2_eth_url,
-            l1_beacon_url: self.server.l1_beacon_url,
-            l2_chain_id: self.server.l2_chain_id,
-            rollup_config,
-            l1_config,
-            enable_experimental_witness_endpoint: self.server.enable_experimental_witness_endpoint,
-        };
+        let registration_health = self.runtime.registration_health_config();
+        let registry_configured = registration_health.is_some();
+        let prover_config = self.runtime.prover_config()?;
 
         if self.local_enclave_count == 0 {
             return Err(eyre!("--local-enclave-count must be at least 1"));
         }
-        if self.local_enclave_count > 1 && self.server.tee_prover_registry_address.is_none() {
+        if self.local_enclave_count > 1 && !registry_configured {
             warn!(
                 count = self.local_enclave_count,
                 "multiple local enclaves without registry; defaulting to index 0 for routing"
             );
         }
-        let transports: Vec<Arc<NitroTransport>> = (0..self.local_enclave_count)
-            .map(|_| {
-                let server = Arc::new(EnclaveServer::new_local()?);
-                Ok(Arc::new(NitroTransport::local(server)))
-            })
-            .collect::<eyre::Result<Vec<_>>>()?;
+        let transports = local_transports(self.local_enclave_count)?;
         let mut server = NitroProverServer::new_multi(prover_config, transports);
         if let Some(reg) = registration_health {
             server = server.with_registration_health(reg);
         }
 
-        info!(addr = %self.server.listen_addr, "starting nitro prover server (local mode)");
-        let handle = server.run(self.server.listen_addr).await?;
+        info!(addr = %self.listen_addr, "starting nitro prover server (local mode)");
+        let handle = server.run(self.listen_addr).await?;
         handle.stopped().await;
         Ok(())
+    }
+}
+
+/// Arguments for the worker `local` subcommand.
+#[cfg(all(feature = "local", feature = "worker"))]
+#[derive(Parser)]
+struct LocalArgs {
+    #[command(flatten)]
+    runtime: ProverRuntimeArgs,
+
+    #[command(flatten)]
+    worker: WorkerArgs,
+
+    /// Number of local enclave instances to run (minimum 1).
+    #[arg(long, env = "LOCAL_ENCLAVE_COUNT", default_value = "1")]
+    local_enclave_count: usize,
+}
+
+#[cfg(all(feature = "local", feature = "worker"))]
+impl LocalArgs {
+    async fn run(self) -> eyre::Result<()> {
+        if self.local_enclave_count == 0 {
+            return Err(eyre!("--local-enclave-count must be at least 1"));
+        }
+
+        let transports = local_transports(self.local_enclave_count)?;
+        run_worker(self.runtime, self.worker, transports, WorkerTransportMode::Local).await
+    }
+}
+
+#[cfg(feature = "local")]
+fn local_transports(count: usize) -> eyre::Result<Vec<Arc<NitroTransport>>> {
+    (0..count)
+        .map(|_| {
+            let server = Arc::new(EnclaveServer::new_local()?);
+            Ok(Arc::new(NitroTransport::local(server)))
+        })
+        .collect::<eyre::Result<Vec<_>>>()
+}
+
+#[cfg(target_os = "linux")]
+fn vsock_transports(cids: &[u32]) -> Vec<Arc<NitroTransport>> {
+    cids.iter().map(|&cid| Arc::new(NitroTransport::vsock(cid, VSOCK_PORT))).collect()
+}
+
+#[cfg(all(feature = "worker", any(target_os = "linux", feature = "local")))]
+async fn run_worker(
+    runtime: ProverRuntimeArgs,
+    worker: WorkerArgs,
+    transports: Vec<Arc<NitroTransport>>,
+    transport_mode: WorkerTransportMode,
+) -> eyre::Result<()> {
+    let registration_health = runtime.registration_health_config();
+    let registry_configured = registration_health.is_some();
+    let config = runtime.prover_config()?;
+
+    if transports.is_empty() {
+        return Err(eyre!("at least one enclave transport is required"));
+    }
+    let enclave_count = transports.len();
+    if enclave_count > 1 && !registry_configured {
+        if transport_mode.requires_registry_for_multi_transport() {
+            return Err(eyre!(
+                "multi-CID requires --tee-prover-registry-address for on-chain routing"
+            ));
+        }
+
+        warn!(
+            count = enclave_count,
+            "multiple local enclaves without registry; all signers are eligible for routing"
+        );
+    }
+
+    let mut pool = NitroEnclavePool::new_multi(config, transports.clone());
+    if let Some(registration_health) = registration_health {
+        let checker = Arc::new(
+            RegistrationChecker::from_health_config(transports, &registration_health)
+                .map_err(|e| eyre!("registration checker init failed: {e}"))?,
+        );
+        pool = pool
+            .with_registration_checker(checker)
+            .map_err(|e| eyre!("registration checker init failed: {e}"))?;
+    }
+
+    let prover_service = ProverServiceClientConfig::new(worker.prover_service_endpoint.clone())
+        .with_request_timeout(Duration::from_secs(worker.prover_service_request_timeout_secs));
+    let worker_config = NitroWorkerConfig::new(prover_service.clone());
+    worker_config.validate()?;
+
+    let client = ProverWorkerClient::connect(&prover_service)?;
+    let submitter = ProofSubmitter::new(client.clone());
+    let heartbeat = ProofGeneratorHeartbeatConfig::with_max_consecutive_failures(
+        Duration::from_secs(worker.proof_generator_heartbeat_interval_secs),
+        worker.proof_generator_heartbeat_lock_duration_seconds,
+        worker.proof_generator_max_consecutive_heartbeat_failures,
+    );
+    let proof_generator = Arc::new(ProofGenerator::new(Arc::new(pool), submitter, heartbeat));
+    let worker_id = format!("nitro-host-{}", Uuid::new_v4());
+    let discovery_config = JobDiscoveryConfig::new(worker_id.clone())
+        .with_poll_interval(Duration::from_millis(worker.job_discovery_poll_interval_ms))
+        .with_lock_duration_seconds(worker.job_discovery_lock_duration_seconds)
+        .with_max_concurrent_jobs(worker.job_discovery_max_concurrent_jobs);
+    let discovery = JobDiscovery::new(client, proof_generator, discovery_config);
+
+    match transport_mode {
+        #[cfg(target_os = "linux")]
+        WorkerTransportMode::Vsock => {
+            info!(
+                worker_id = %worker_id,
+                prover_service_endpoint = %worker.prover_service_endpoint,
+                enclave_count,
+                "starting nitro prover host worker"
+            );
+        }
+        WorkerTransportMode::Local => {
+            info!(
+                worker_id = %worker_id,
+                prover_service_endpoint = %worker.prover_service_endpoint,
+                enclave_count,
+                "starting nitro prover host worker (local mode)"
+            );
+        }
+    }
+    discovery.run_until_cancelled(CancellationToken::new()).await;
+    Ok(())
+}
+
+#[cfg(all(feature = "worker", any(target_os = "linux", feature = "local")))]
+#[derive(Clone, Copy)]
+enum WorkerTransportMode {
+    #[cfg(target_os = "linux")]
+    Vsock,
+    Local,
+}
+
+#[cfg(all(feature = "worker", any(target_os = "linux", feature = "local")))]
+impl WorkerTransportMode {
+    const fn requires_registry_for_multi_transport(self) -> bool {
+        match self {
+            #[cfg(target_os = "linux")]
+            Self::Vsock => true,
+            Self::Local => false,
+        }
     }
 }

--- a/bin/prover/nitro-host/src/main.rs
+++ b/bin/prover/nitro-host/src/main.rs
@@ -5,17 +5,9 @@
 
 #[cfg(not(any(target_os = "linux", feature = "local")))]
 use base_common_chains as _;
-#[cfg(all(feature = "local", feature = "worker", not(target_os = "linux")))]
-use base_common_chains as _;
 #[cfg(not(any(target_os = "linux", feature = "local")))]
 use base_proof_host as _;
-#[cfg(all(feature = "local", feature = "worker", not(target_os = "linux")))]
-use base_proof_host as _;
-#[cfg(all(feature = "local", feature = "worker", not(target_os = "linux")))]
-use base_proof_tee_nitro_enclave as _;
 #[cfg(not(any(target_os = "linux", feature = "local")))]
-use base_proof_tee_nitro_host as _;
-#[cfg(all(feature = "local", feature = "worker", not(target_os = "linux")))]
 use base_proof_tee_nitro_host as _;
 #[cfg(all(feature = "worker", not(target_os = "linux")))]
 use base_prover_service_client as _;
@@ -24,8 +16,6 @@ use tokio as _;
 #[cfg(all(feature = "worker", not(target_os = "linux")))]
 use tokio_util as _;
 #[cfg(not(any(target_os = "linux", feature = "local")))]
-use tracing as _;
-#[cfg(all(feature = "local", feature = "worker", not(target_os = "linux")))]
 use tracing as _;
 #[cfg(all(feature = "worker", not(target_os = "linux")))]
 use uuid as _;

--- a/bin/prover/nitro-host/src/main.rs
+++ b/bin/prover/nitro-host/src/main.rs
@@ -5,14 +5,30 @@
 
 #[cfg(not(any(target_os = "linux", feature = "local")))]
 use base_common_chains as _;
+#[cfg(all(feature = "local", feature = "worker", not(target_os = "linux")))]
+use base_common_chains as _;
 #[cfg(not(any(target_os = "linux", feature = "local")))]
 use base_proof_host as _;
+#[cfg(all(feature = "local", feature = "worker", not(target_os = "linux")))]
+use base_proof_host as _;
+#[cfg(all(feature = "local", feature = "worker", not(target_os = "linux")))]
+use base_proof_tee_nitro_enclave as _;
 #[cfg(not(any(target_os = "linux", feature = "local")))]
 use base_proof_tee_nitro_host as _;
+#[cfg(all(feature = "local", feature = "worker", not(target_os = "linux")))]
+use base_proof_tee_nitro_host as _;
+#[cfg(all(feature = "worker", not(target_os = "linux")))]
+use base_prover_service_client as _;
 use serde as _;
 use tokio as _;
+#[cfg(all(feature = "worker", not(target_os = "linux")))]
+use tokio_util as _;
 #[cfg(not(any(target_os = "linux", feature = "local")))]
 use tracing as _;
+#[cfg(all(feature = "local", feature = "worker", not(target_os = "linux")))]
+use tracing as _;
+#[cfg(all(feature = "worker", not(target_os = "linux")))]
+use uuid as _;
 
 mod cli;
 

--- a/crates/proof/tee/Justfile
+++ b/crates/proof/tee/Justfile
@@ -42,6 +42,20 @@ nitro-local *args:
         --logs.stdout.format json \
         {{ args }}
 
+# Run worker and enclave in a single process for local development
+nitro-local-worker *args:
+    RUST_LOG=info RUST_BACKTRACE=1 \
+        cargo run --package base-prover-nitro-host --bin base-prover-nitro-host --features local,worker -- local \
+        --l1-eth-url "${L1_ETH_URL:-http://localhost:8545}" \
+        --l2-eth-url "${L2_ETH_URL:-http://localhost:9545}" \
+        --l1-beacon-url "${L1_BEACON_URL:-http://localhost:5052}" \
+        --l2-chain-id "${L2_CHAIN_ID:-8453}" \
+        --prover-service-endpoint "${PROVER_SERVICE_ENDPOINT:?PROVER_SERVICE_ENDPOINT is required}" \
+        --enable-experimental-witness-endpoint \
+        --metrics.enabled \
+        --logs.stdout.format json \
+        {{ args }}
+
 # Build the nitro host Docker image (full runtime image)
 build-host *args="":
     #!/usr/bin/env bash

--- a/crates/proof/tee/nitro-host/src/job_discovery.rs
+++ b/crates/proof/tee/nitro-host/src/job_discovery.rs
@@ -223,6 +223,12 @@ where
             .acquire_owned()
             .await
             .expect("semaphore is not closed");
+
+        if !self.has_valid_registered_signer().await {
+            drop(permit);
+            return Ok(JobDiscoveryPollOutcome::Empty);
+        }
+
         let request = self.config.get_next_proof_request();
         let response = self.client.get_next_proof(request).await?;
 
@@ -234,6 +240,31 @@ where
 
         let task = self.proof_generator_task(job, permit);
         Ok(JobDiscoveryPollOutcome::Claimed { task })
+    }
+
+    async fn has_valid_registered_signer(&self) -> bool {
+        let Some(checker) = self.proof_generator.pool().registration_checker() else {
+            return true;
+        };
+
+        match checker.select_all_valid_enclaves().await {
+            Ok(valid) => {
+                debug!(
+                    worker_id = %self.config.worker_id,
+                    valid_signer_count = valid.len(),
+                    "registration gate passed for nitro job discovery"
+                );
+                true
+            }
+            Err(error) => {
+                warn!(
+                    worker_id = %self.config.worker_id,
+                    error = %error,
+                    "registration gate not ready; skipping nitro job discovery poll"
+                );
+                false
+            }
+        }
     }
 
     /// Builds a proof generator task for a claimed prover-service job.
@@ -292,7 +323,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use std::sync::{Arc, Mutex};
+    use std::sync::{Arc, Mutex, atomic::Ordering};
 
     use alloy_genesis::ChainConfig;
     use async_trait::async_trait;
@@ -308,7 +339,10 @@ mod tests {
     use tokio::time::timeout;
 
     use super::*;
-    use crate::{NitroEnclavePool, NitroTransport, ProofGeneratorHeartbeatConfig, ProofSubmitter};
+    use crate::{
+        NitroEnclavePool, NitroTransport, ProofGeneratorHeartbeatConfig, ProofSubmitter,
+        RegistrationChecker, test_utils::MockRegistry,
+    };
 
     #[derive(Clone, Debug)]
     struct MockWorkerClient {
@@ -384,6 +418,26 @@ mod tests {
         let server = Arc::new(EnclaveServer::new_local().unwrap());
         let transport = Arc::new(NitroTransport::local(server));
         let pool = NitroEnclavePool::new(test_prover_config(), transport);
+        let submitter = ProofSubmitter::new(client);
+
+        Arc::new(ProofGenerator::new(
+            Arc::new(pool),
+            submitter,
+            ProofGeneratorHeartbeatConfig::default(),
+        ))
+    }
+
+    fn test_generator_with_registry(
+        client: MockWorkerClient,
+        registry: MockRegistry,
+    ) -> Arc<ProofGenerator<MockWorkerClient>> {
+        let server = Arc::new(EnclaveServer::new_local().unwrap());
+        let transport = Arc::new(NitroTransport::local(server));
+        let checker =
+            Arc::new(RegistrationChecker::new(vec![Arc::clone(&transport)], registry).unwrap());
+        let pool = NitroEnclavePool::new(test_prover_config(), transport)
+            .with_registration_checker(checker)
+            .unwrap();
         let submitter = ProofSubmitter::new(client);
 
         Arc::new(ProofGenerator::new(
@@ -476,6 +530,26 @@ mod tests {
         };
         timeout(Duration::from_secs(1), task).await.expect("proof generator task should finish");
         assert_eq!(client.get_next_requests().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn poll_once_skips_claim_when_registration_checker_has_no_valid_signer() {
+        let client = MockWorkerClient::new(Some(compressed_job()));
+        let registry = MockRegistry::new(false);
+        let discovery = JobDiscovery::new(
+            client.clone(),
+            test_generator_with_registry(client.clone(), registry.clone()),
+            JobDiscoveryConfig::new("worker-a"),
+        );
+
+        let outcome = discovery.poll_once().await.expect("poll should succeed");
+
+        assert!(matches!(outcome, JobDiscoveryPollOutcome::Empty));
+        assert!(
+            client.get_next_requests().is_empty(),
+            "discovery must not claim jobs until registration has a valid signer"
+        );
+        assert_eq!(registry.call_count.load(Ordering::Relaxed), 1);
     }
 
     #[tokio::test]

--- a/crates/proof/tee/nitro-host/src/registration.rs
+++ b/crates/proof/tee/nitro-host/src/registration.rs
@@ -21,19 +21,27 @@ use std::{sync::Arc, time::Duration};
 
 use alloy_primitives::Address;
 use alloy_signer::utils::public_key_to_address;
-use base_proof_contracts::TEEProverRegistryClient;
+use base_proof_contracts::{TEEProverRegistryClient, TEEProverRegistryContractClient};
 use k256::ecdsa::VerifyingKey;
 use thiserror::Error;
 use tokio::sync::OnceCell;
 use tracing::warn;
 
-use super::transport::NitroTransport;
+use super::{health::RegistrationHealthConfig, transport::NitroTransport};
 
 const CHECK_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// Errors from signer-validity checks.
 #[derive(Debug, Error)]
 pub enum RegistrationError {
+    /// L1 RPC URL could not be parsed.
+    #[error("invalid L1 RPC URL {url}: {reason}")]
+    InvalidRpcUrl {
+        /// Invalid L1 RPC URL.
+        url: String,
+        /// Parse failure details.
+        reason: String,
+    },
     /// Enclave signer key could not be retrieved or parsed.
     #[error("signer setup failed: {0}")]
     Setup(String),
@@ -99,6 +107,22 @@ impl RegistrationChecker {
             return Err(RegistrationError::Setup("at least one transport is required".into()));
         }
         Ok(Self { transports, registry: Box::new(registry), healthy: OnceCell::new() })
+    }
+
+    /// Creates a checker from a deployed `TEEProverRegistry` configuration.
+    pub fn from_health_config(
+        transports: Vec<Arc<NitroTransport>>,
+        config: &RegistrationHealthConfig,
+    ) -> Result<Self, RegistrationError> {
+        let l1_url = url::Url::parse(&config.l1_rpc_url).map_err(|err| {
+            RegistrationError::InvalidRpcUrl {
+                url: config.l1_rpc_url.clone(),
+                reason: err.to_string(),
+            }
+        })?;
+        let registry = TEEProverRegistryContractClient::new(config.registry_address, l1_url);
+
+        Self::new(transports, registry)
     }
 
     /// Returns the configured enclave transports in checker index order.

--- a/crates/proof/tee/nitro-host/src/server.rs
+++ b/crates/proof/tee/nitro-host/src/server.rs
@@ -2,7 +2,6 @@ use std::{fmt, net::SocketAddr, sync::Arc};
 
 use alloy_signer::utils::public_key_to_address;
 use base_health::{HealthzApiServer, HealthzRpc};
-use base_proof_contracts::TEEProverRegistryContractClient;
 use base_proof_host::ProverConfig;
 use base_proof_primitives::{EnclaveApiServer, ProofRequest, ProofResult, ProverApiServer};
 use jsonrpsee::{
@@ -99,12 +98,8 @@ impl NitroProverServer {
                     registry = %config.registry_address,
                     "registration-gated health and proving guard enabled"
                 );
-                let l1_url = url::Url::parse(&config.l1_rpc_url)
-                    .map_err(|e| eyre::eyre!("invalid L1 RPC URL: {e}"))?;
-                let registry =
-                    TEEProverRegistryContractClient::new(config.registry_address, l1_url);
                 let checker = Arc::new(
-                    RegistrationChecker::new(transports.clone(), registry)
+                    RegistrationChecker::from_health_config(transports.clone(), &config)
                         .map_err(|e| eyre::eyre!("registration checker init failed: {e}"))?,
                 );
                 module.merge(

--- a/crates/utilities/cli/src/runtime.rs
+++ b/crates/utilities/cli/src/runtime.rs
@@ -96,4 +96,22 @@ impl RuntimeManager {
             }
         })
     }
+
+    /// Run a fallible future with a cancellation token wired to shutdown signals.
+    pub fn run_until_shutdown<F, Fut>(&self, make_fut: F) -> eyre::Result<()>
+    where
+        F: FnOnce(CancellationToken) -> Fut,
+        Fut: Future<Output = eyre::Result<()>>,
+    {
+        let rt = self.tokio_runtime().map_err(|e| eyre::eyre!(e))?;
+        rt.block_on(async move {
+            let cancel = CancellationToken::new();
+            let signal_handle = Self::install_signal_handler(cancel.clone());
+            let result = make_fut(cancel.clone()).await;
+
+            cancel.cancel();
+            signal_handle.abort();
+            result
+        })
+    }
 }


### PR DESCRIPTION
### What changed? Why?

Adds a worker-mode build path for base-prover-nitro-host that claims Nitro proof jobs from prover-service instead of exposing JSON-RPC, with local worker mode support for development.

Refactors shared Nitro runtime config and registration checking so server and worker paths can reuse the same registration-gated transport setup.

### Notes to reviewers

Worker mode is feature-gated with `worker`; the worker build keeps the `server` subcommand name but does not bind a JSON-RPC listener. Local worker development is available with `--features local,worker` and the new `just tee nitro-local-worker` recipe.

### How has it been tested?

- `git diff --check`
- `cargo fmt --check` (passes; stable rustfmt prints existing nightly-only config warnings)
- `cargo check -p base-prover-nitro-host --features local,worker`