### PR TITLE
feat(prover-service-db): generalize protocol proof requests

### DIFF
--- a/crates/proof/prover-service/db/Cargo.toml
+++ b/crates/proof/prover-service/db/Cargo.toml
@@ -8,6 +8,9 @@ homepage.workspace = true
 repository.workspace = true
 
 [dependencies]
+# protocol
+base-prover-service-protocol.workspace = true
+
 # database
 futures.workspace = true
 sqlx = { workspace = true, features = ["runtime-tokio", "postgres", "uuid", "chrono", "derive", "tls-native-tls"] }
@@ -26,7 +29,6 @@ thiserror.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]
-base-prover-service-protocol.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 
 [lints]

--- a/crates/proof/prover-service/db/migrations/011_generalize_protocol_create_requests.sql
+++ b/crates/proof/prover-service/db/migrations/011_generalize_protocol_create_requests.sql
@@ -1,0 +1,25 @@
+-- Migration 011: Generalize create-time protocol request storage.
+--
+-- The worker-facing protocol uses opaque string session ids and can represent
+-- proof kinds that do not have an OP Succinct backend proof_type.
+ALTER TABLE proof_requests ADD COLUMN IF NOT EXISTS session_id TEXT;
+
+-- Preserve historical updated_at values while backfilling public session ids.
+ALTER TABLE proof_requests DISABLE TRIGGER update_proof_requests_updated_at;
+
+UPDATE proof_requests
+SET session_id = id::text
+WHERE session_id IS NULL;
+
+ALTER TABLE proof_requests ENABLE TRIGGER update_proof_requests_updated_at;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_proof_requests_session_id
+ON proof_requests(session_id);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_proof_requests_effective_session_id
+ON proof_requests((COALESCE(session_id, id::text)));
+
+ALTER TABLE proof_requests ALTER COLUMN proof_type DROP NOT NULL;
+
+COMMENT ON COLUMN proof_requests.session_id IS 'Public protocol session identifier. Defaults to id::text for legacy rows.';
+COMMENT ON COLUMN proof_requests.proof_type IS 'Backend-specific OP Succinct proof type for ZK requests; NULL for protocol proof kinds without an internal ZK backend.';

--- a/crates/proof/prover-service/db/migrations/011_generalize_protocol_create_requests.sql
+++ b/crates/proof/prover-service/db/migrations/011_generalize_protocol_create_requests.sql
@@ -13,9 +13,9 @@ WHERE session_id IS NULL;
 
 ALTER TABLE proof_requests ENABLE TRIGGER update_proof_requests_updated_at;
 
-CREATE UNIQUE INDEX IF NOT EXISTS idx_proof_requests_session_id
-ON proof_requests(session_id);
-
+-- Keep session_id nullable during the expand phase so legacy writers can keep
+-- inserting proof_requests. The effective id still remains unique: new protocol
+-- rows use session_id, while legacy rows fall back to id::text.
 CREATE UNIQUE INDEX IF NOT EXISTS idx_proof_requests_effective_session_id
 ON proof_requests((COALESCE(session_id, id::text)));
 

--- a/crates/proof/prover-service/db/src/lib.rs
+++ b/crates/proof/prover-service/db/src/lib.rs
@@ -10,6 +10,7 @@ pub use models::{
     DerivedProofRequestFields, MarkOutboxError, MarkOutboxProcessed, OutboxEntry, ProofRequest,
     ProofRequestListItem, ProofRequestPage, ProofSession, ProofStatus, ProofType, RetryOutcome,
     SessionStatus, SessionType, TeeKind, UpdateProofSession, UpdateReceipt, ZkVmKind,
+    canonical_session_id,
 };
 
 mod repo;

--- a/crates/proof/prover-service/db/src/lib.rs
+++ b/crates/proof/prover-service/db/src/lib.rs
@@ -6,10 +6,10 @@ pub use config::DatabaseConfig;
 mod models;
 pub use models::{
     ApiProofType, CreateOutboxEntry, CreateProofRequest, CreateProofRequestError,
-    CreateProofRequestOutcome, CreateProofSession, MarkOutboxError, MarkOutboxProcessed,
-    OutboxEntry, ProofRequest, ProofRequestListItem, ProofRequestPage, ProofSession, ProofStatus,
-    ProofType, RetryOutcome, SessionStatus, SessionType, TeeKind, UpdateProofSession,
-    UpdateReceipt, ZkVmKind,
+    CreateProofRequestOutcome, CreateProofRequestValidationError, CreateProofSession,
+    DerivedProofRequestFields, MarkOutboxError, MarkOutboxProcessed, OutboxEntry, ProofRequest,
+    ProofRequestListItem, ProofRequestPage, ProofSession, ProofStatus, ProofType, RetryOutcome,
+    SessionStatus, SessionType, TeeKind, UpdateProofSession, UpdateReceipt, ZkVmKind,
 };
 
 mod repo;

--- a/crates/proof/prover-service/db/src/models.rs
+++ b/crates/proof/prover-service/db/src/models.rs
@@ -234,6 +234,15 @@ pub enum CreateProofRequestValidationError {
         /// Name of the mismatched field.
         field: &'static str,
     },
+    /// A numeric request field cannot fit in the database representation.
+    #[error("field {field} exceeds database range")]
+    ValueOutOfRange {
+        /// Name of the out-of-range field.
+        field: &'static str,
+    },
+    /// The protocol request payload could not be serialized for storage.
+    #[error("failed to serialize request_payload")]
+    RequestPayloadSerialization,
     /// A backend proof type is required for the requested protocol proof type.
     #[error("missing backend proof_type for {api_proof_type}")]
     MissingBackendProofType {

--- a/crates/proof/prover-service/db/src/models.rs
+++ b/crates/proof/prover-service/db/src/models.rs
@@ -1,5 +1,9 @@
 use std::convert::TryFrom;
 
+use base_prover_service_protocol::{
+    ProofRequest as ProtocolProofRequest, ProofRequestKind as ProtocolProofRequestKind,
+    TeeKind as ProtocolTeeKind, ZkVm as ProtocolZkVm,
+};
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use sqlx::FromRow;
@@ -182,6 +186,15 @@ impl CreateProofRequestOutcome {
 /// Errors returned by `create_with_outbox`.
 #[derive(Debug, thiserror::Error)]
 pub enum CreateProofRequestError {
+    /// Request fields are not a supported protocol/backend combination.
+    #[error(transparent)]
+    Validation(#[from] CreateProofRequestValidationError),
+    /// The outbox flow only supports backend-backed ZK proof requests.
+    #[error("proof type {api_proof_type} cannot be enqueued through the legacy outbox flow")]
+    UnsupportedOutboxProofType {
+        /// Protocol proof type that cannot be handled by the outbox worker.
+        api_proof_type: ApiProofType,
+    },
     /// Persisted row disagrees with the new request for this `session_id`.
     #[error(
         "session_id {id} already exists with a different {field} \
@@ -202,6 +215,43 @@ pub enum CreateProofRequestError {
     /// Underlying database error.
     #[error(transparent)]
     Sqlx(#[from] sqlx::Error),
+}
+
+/// Validation errors for protocol-facing proof request creation.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum CreateProofRequestValidationError {
+    /// A caller supplied an empty protocol session identifier.
+    #[error("session_id must not be empty")]
+    EmptySessionId,
+    /// The explicit session id and the session id embedded in the payload disagree.
+    #[error("session_id disagrees with request_payload.session_id")]
+    SessionIdMismatch,
+    /// A request field disagrees with the canonical value derived from `request_payload`.
+    #[error("field {field} disagrees with request_payload")]
+    FieldMismatch {
+        /// Name of the mismatched field.
+        field: &'static str,
+    },
+    /// A backend proof type is required for the requested protocol proof type.
+    #[error("missing backend proof_type for {api_proof_type}")]
+    MissingBackendProofType {
+        /// Protocol proof type that needs a backend proof type.
+        api_proof_type: ApiProofType,
+    },
+    /// A backend proof type was provided for a request that must not have one.
+    #[error("backend proof_type is not supported for {api_proof_type}")]
+    UnexpectedBackendProofType {
+        /// Protocol proof type that must not carry a backend proof type.
+        api_proof_type: ApiProofType,
+    },
+    /// The backend proof type does not match the protocol proof type.
+    #[error("backend proof_type {proof_type} is invalid for {api_proof_type}")]
+    BackendProofTypeMismatch {
+        /// Protocol proof type requested by the API.
+        api_proof_type: ApiProofType,
+        /// Backend proof type supplied for the request.
+        proof_type: ProofType,
+    },
 }
 
 /// Type of proof that determines success criteria
@@ -406,8 +456,8 @@ pub struct ProofRequest {
     pub number_of_blocks_to_prove: i64,
     /// Optional sequence window for the proof range.
     pub sequence_window: Option<i64>,
-    /// Type of proof to generate.
-    pub proof_type: ProofType,
+    /// Backend-specific proof type for ZK requests.
+    pub proof_type: Option<ProofType>,
     /// Raw STARK receipt bytes, if available.
     pub stark_receipt: Option<Vec<u8>>,
     /// Raw SNARK receipt bytes, if available.
@@ -449,8 +499,8 @@ pub struct ProofRequestListItem {
     pub start_block_number: i64,
     /// Number of consecutive blocks to prove.
     pub number_of_blocks_to_prove: i64,
-    /// Type of proof to generate.
-    pub proof_type: ProofType,
+    /// Backend-specific proof type for ZK requests.
+    pub proof_type: Option<ProofType>,
     /// Current proof status.
     pub status: ProofStatus,
     /// Error message if the proof failed.
@@ -519,27 +569,214 @@ pub struct ProofSession {
     pub completed_at: Option<DateTime<Utc>>,
 }
 
-/// Parameters for creating a new proof request
+/// Parameters for creating a new proof request.
 #[derive(Debug, Clone)]
 pub struct CreateProofRequest {
+    /// Public protocol session identifier.
+    pub session_id: Option<String>,
+    /// Original protocol request payload.
+    pub request_payload: ProtocolProofRequest,
+    /// Protocol-level proof type requested by API callers.
+    pub api_proof_type: ApiProofType,
+    /// Protocol-level ZK VM discriminator for ZK proofs.
+    pub zk_vm: Option<ZkVmKind>,
+    /// Protocol-level TEE discriminator for TEE proofs.
+    pub tee_kind: Option<TeeKind>,
+    /// Backend-specific proof type for current OP Succinct backends.
+    pub proof_type: Option<ProofType>,
     /// Starting L2 block number.
     pub start_block_number: u64,
     /// Number of consecutive blocks to prove.
     pub number_of_blocks_to_prove: u64,
     /// Optional sequence window.
     pub sequence_window: Option<u64>,
-    /// Type of proof to generate.
-    pub proof_type: ProofType,
-    /// Client-provided UUID for idempotent requests.
-    pub session_id: Option<Uuid>,
-    /// Original protocol request payload serialized as JSON.
-    pub request_payload: Option<serde_json::Value>,
     /// Ethereum address of the on-chain prover (required for SNARK Groth16 proofs).
     pub prover_address: Option<String>,
     /// Explicit L1 head hash for witness generation.
     pub l1_head: Option<String>,
     /// Intermediate root interval for ZK proof generation.
     pub intermediate_root_interval: Option<u64>,
+}
+
+impl CreateProofRequest {
+    /// Build a canonical create request from the protocol payload.
+    pub fn new(
+        request_payload: ProtocolProofRequest,
+    ) -> Result<Self, CreateProofRequestValidationError> {
+        let fields = DerivedProofRequestFields::from_protocol(&request_payload)?;
+
+        Ok(Self {
+            session_id: request_payload.session_id.clone(),
+            request_payload,
+            api_proof_type: fields.api_proof_type,
+            zk_vm: fields.zk_vm,
+            tee_kind: fields.tee_kind,
+            proof_type: fields.proof_type,
+            start_block_number: fields.start_block_number,
+            number_of_blocks_to_prove: fields.number_of_blocks_to_prove,
+            sequence_window: fields.sequence_window,
+            prover_address: fields.prover_address,
+            l1_head: fields.l1_head,
+            intermediate_root_interval: fields.intermediate_root_interval,
+        })
+    }
+
+    /// Validate that explicit DB fields match the protocol payload and supported backends.
+    pub fn validate(&self) -> Result<(), CreateProofRequestValidationError> {
+        let expected = Self::new(self.request_payload.clone())?;
+
+        if canonical_session_id_opt(self.session_id.as_deref())?
+            != canonical_session_id_opt(expected.session_id.as_deref())?
+            && self.session_id.is_some()
+            && expected.session_id.is_some()
+        {
+            return Err(CreateProofRequestValidationError::SessionIdMismatch);
+        }
+        if self.api_proof_type != expected.api_proof_type {
+            return Err(CreateProofRequestValidationError::FieldMismatch {
+                field: "api_proof_type",
+            });
+        }
+        if self.zk_vm != expected.zk_vm {
+            return Err(CreateProofRequestValidationError::FieldMismatch { field: "zk_vm" });
+        }
+        if self.tee_kind != expected.tee_kind {
+            return Err(CreateProofRequestValidationError::FieldMismatch { field: "tee_kind" });
+        }
+        if self.proof_type != expected.proof_type {
+            return Err(CreateProofRequestValidationError::FieldMismatch { field: "proof_type" });
+        }
+        if self.start_block_number != expected.start_block_number {
+            return Err(CreateProofRequestValidationError::FieldMismatch {
+                field: "start_block_number",
+            });
+        }
+        if self.number_of_blocks_to_prove != expected.number_of_blocks_to_prove {
+            return Err(CreateProofRequestValidationError::FieldMismatch {
+                field: "number_of_blocks_to_prove",
+            });
+        }
+        if self.sequence_window != expected.sequence_window {
+            return Err(CreateProofRequestValidationError::FieldMismatch {
+                field: "sequence_window",
+            });
+        }
+        if self.prover_address != expected.prover_address {
+            return Err(CreateProofRequestValidationError::FieldMismatch {
+                field: "prover_address",
+            });
+        }
+        if self.l1_head != expected.l1_head {
+            return Err(CreateProofRequestValidationError::FieldMismatch { field: "l1_head" });
+        }
+        if self.intermediate_root_interval != expected.intermediate_root_interval {
+            return Err(CreateProofRequestValidationError::FieldMismatch {
+                field: "intermediate_root_interval",
+            });
+        }
+
+        Ok(())
+    }
+}
+
+/// Protocol fields derived from a create request payload.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DerivedProofRequestFields {
+    /// Protocol-level proof type requested by API callers.
+    pub api_proof_type: ApiProofType,
+    /// Protocol-level ZK VM discriminator for ZK proofs.
+    pub zk_vm: Option<ZkVmKind>,
+    /// Protocol-level TEE discriminator for TEE proofs.
+    pub tee_kind: Option<TeeKind>,
+    /// Backend-specific proof type for current OP Succinct backends.
+    pub proof_type: Option<ProofType>,
+    /// Starting L2 block number.
+    pub start_block_number: u64,
+    /// Number of consecutive blocks to prove.
+    pub number_of_blocks_to_prove: u64,
+    /// Optional sequence window.
+    pub sequence_window: Option<u64>,
+    /// Ethereum address of the on-chain prover.
+    pub prover_address: Option<String>,
+    /// Explicit L1 head hash.
+    pub l1_head: Option<String>,
+    /// Intermediate root interval.
+    pub intermediate_root_interval: Option<u64>,
+}
+
+impl DerivedProofRequestFields {
+    /// Derive database fields from a protocol proof request.
+    pub fn from_protocol(
+        request: &ProtocolProofRequest,
+    ) -> Result<Self, CreateProofRequestValidationError> {
+        match &request.request {
+            ProtocolProofRequestKind::Compressed(proof) => Ok(Self {
+                api_proof_type: ApiProofType::Compressed,
+                zk_vm: Some(protocol_zk_vm(proof.zk_vm)),
+                tee_kind: None,
+                proof_type: Some(ProofType::OpSuccinctSp1ClusterCompressed),
+                start_block_number: proof.start_block_number,
+                number_of_blocks_to_prove: proof.number_of_blocks_to_prove,
+                sequence_window: proof.sequence_window,
+                prover_address: None,
+                l1_head: proof.l1_head.map(|hash| format!("{hash:#x}")),
+                intermediate_root_interval: proof.intermediate_root_interval,
+            }),
+            ProtocolProofRequestKind::SnarkGroth16(request) => Ok(Self {
+                api_proof_type: ApiProofType::SnarkGroth16,
+                zk_vm: Some(protocol_zk_vm(request.proof.zk_vm)),
+                tee_kind: None,
+                proof_type: Some(ProofType::OpSuccinctSp1ClusterSnarkGroth16),
+                start_block_number: request.proof.start_block_number,
+                number_of_blocks_to_prove: request.proof.number_of_blocks_to_prove,
+                sequence_window: request.proof.sequence_window,
+                prover_address: Some(format!("{:#x}", request.prover_address)),
+                l1_head: request.proof.l1_head.map(|hash| format!("{hash:#x}")),
+                intermediate_root_interval: request.proof.intermediate_root_interval,
+            }),
+            ProtocolProofRequestKind::Tee(request) => Ok(Self {
+                api_proof_type: ApiProofType::Tee,
+                zk_vm: None,
+                tee_kind: Some(protocol_tee_kind(request.tee_kind)),
+                proof_type: None,
+                start_block_number: request.proof.claimed_l2_block_number,
+                number_of_blocks_to_prove: 1,
+                sequence_window: None,
+                prover_address: None,
+                l1_head: Some(format!("{:#x}", request.proof.l1_head)),
+                intermediate_root_interval: (request.proof.intermediate_block_interval > 0)
+                    .then_some(request.proof.intermediate_block_interval),
+            }),
+        }
+    }
+}
+
+const fn protocol_zk_vm(zk_vm: ProtocolZkVm) -> ZkVmKind {
+    match zk_vm {
+        ProtocolZkVm::Sp1 => ZkVmKind::Sp1,
+    }
+}
+
+const fn protocol_tee_kind(tee_kind: ProtocolTeeKind) -> TeeKind {
+    match tee_kind {
+        ProtocolTeeKind::AwsNitro => TeeKind::AwsNitro,
+    }
+}
+
+fn canonical_session_id_opt(
+    session_id: Option<&str>,
+) -> Result<Option<String>, CreateProofRequestValidationError> {
+    session_id.map(canonical_session_id).transpose()
+}
+
+fn canonical_session_id(session_id: &str) -> Result<String, CreateProofRequestValidationError> {
+    if session_id.is_empty() {
+        return Err(CreateProofRequestValidationError::EmptySessionId);
+    }
+
+    Ok(Uuid::parse_str(session_id)
+        .map(|uuid| uuid.to_string())
+        .unwrap_or_else(|_| session_id.to_owned()))
 }
 
 /// Parameters for creating a new proof session

--- a/crates/proof/prover-service/db/src/models.rs
+++ b/crates/proof/prover-service/db/src/models.rs
@@ -152,6 +152,8 @@ pub enum RetryOutcome {
     Retried,
     /// Request was permanently marked FAILED (max retries exceeded).
     PermanentlyFailed,
+    /// Request cannot be retried by the legacy outbox flow.
+    Unsupported,
     /// Request was no longer in PENDING state (already claimed or transitioned).
     Skipped,
 }
@@ -628,10 +630,10 @@ impl CreateProofRequest {
         let payload_session_id =
             canonical_session_id_opt(self.request_payload.session_id.as_deref())?;
 
-        if let (Some(session_id), Some(payload_session_id)) = (&session_id, &payload_session_id) {
-            if session_id != payload_session_id {
-                return Err(CreateProofRequestValidationError::SessionIdMismatch);
-            }
+        if let (Some(session_id), Some(payload_session_id)) = (&session_id, &payload_session_id)
+            && session_id != payload_session_id
+        {
+            return Err(CreateProofRequestValidationError::SessionIdMismatch);
         }
         if self.api_proof_type != expected.api_proof_type {
             return Err(CreateProofRequestValidationError::FieldMismatch {

--- a/crates/proof/prover-service/db/src/models.rs
+++ b/crates/proof/prover-service/db/src/models.rs
@@ -623,12 +623,12 @@ impl CreateProofRequest {
 
     /// Validate that explicit DB fields match the protocol payload and supported backends.
     pub fn validate(&self) -> Result<(), CreateProofRequestValidationError> {
-        let expected = Self::new(self.request_payload.clone())?;
+        let expected = DerivedProofRequestFields::from_protocol(&self.request_payload)?;
 
         if canonical_session_id_opt(self.session_id.as_deref())?
-            != canonical_session_id_opt(expected.session_id.as_deref())?
+            != canonical_session_id_opt(self.request_payload.session_id.as_deref())?
             && self.session_id.is_some()
-            && expected.session_id.is_some()
+            && self.request_payload.session_id.is_some()
         {
             return Err(CreateProofRequestValidationError::SessionIdMismatch);
         }

--- a/crates/proof/prover-service/db/src/models.rs
+++ b/crates/proof/prover-service/db/src/models.rs
@@ -769,7 +769,8 @@ fn canonical_session_id_opt(
     session_id.map(canonical_session_id).transpose()
 }
 
-fn canonical_session_id(session_id: &str) -> Result<String, CreateProofRequestValidationError> {
+/// Canonicalize a public proof request session id.
+pub fn canonical_session_id(session_id: &str) -> Result<String, CreateProofRequestValidationError> {
     if session_id.is_empty() {
         return Err(CreateProofRequestValidationError::EmptySessionId);
     }

--- a/crates/proof/prover-service/db/src/models.rs
+++ b/crates/proof/prover-service/db/src/models.rs
@@ -624,13 +624,14 @@ impl CreateProofRequest {
     /// Validate that explicit DB fields match the protocol payload and supported backends.
     pub fn validate(&self) -> Result<(), CreateProofRequestValidationError> {
         let expected = DerivedProofRequestFields::from_protocol(&self.request_payload)?;
+        let session_id = canonical_session_id_opt(self.session_id.as_deref())?;
+        let payload_session_id =
+            canonical_session_id_opt(self.request_payload.session_id.as_deref())?;
 
-        if canonical_session_id_opt(self.session_id.as_deref())?
-            != canonical_session_id_opt(self.request_payload.session_id.as_deref())?
-            && self.session_id.is_some()
-            && self.request_payload.session_id.is_some()
-        {
-            return Err(CreateProofRequestValidationError::SessionIdMismatch);
+        if let (Some(session_id), Some(payload_session_id)) = (&session_id, &payload_session_id) {
+            if session_id != payload_session_id {
+                return Err(CreateProofRequestValidationError::SessionIdMismatch);
+            }
         }
         if self.api_proof_type != expected.api_proof_type {
             return Err(CreateProofRequestValidationError::FieldMismatch {
@@ -869,7 +870,23 @@ pub struct MarkOutboxError {
 
 #[cfg(test)]
 mod tests {
+    use base_prover_service_protocol::{ZkProofRequest, ZkVm};
+
     use super::*;
+
+    fn compressed_protocol_request(session_id: Option<String>) -> ProtocolProofRequest {
+        ProtocolProofRequest {
+            session_id,
+            request: ProtocolProofRequestKind::Compressed(ZkProofRequest {
+                start_block_number: 100,
+                number_of_blocks_to_prove: 5,
+                sequence_window: Some(50),
+                l1_head: None,
+                intermediate_root_interval: None,
+                zk_vm: ZkVm::Sp1,
+            }),
+        }
+    }
 
     #[test]
     fn test_proof_type_try_from_proto() {
@@ -880,5 +897,32 @@ mod tests {
         assert!(ProofType::try_from(1).is_err());
         assert!(ProofType::try_from(2).is_err());
         assert!(ProofType::try_from(5).is_err());
+    }
+
+    #[test]
+    fn validate_rejects_empty_session_ids() {
+        let mut req = CreateProofRequest::new(compressed_protocol_request(None)).unwrap();
+        req.session_id = Some(String::new());
+
+        assert_eq!(req.validate(), Err(CreateProofRequestValidationError::EmptySessionId));
+
+        let mut req = CreateProofRequest::new(compressed_protocol_request(None)).unwrap();
+        req.request_payload.session_id = Some(String::new());
+
+        assert_eq!(req.validate(), Err(CreateProofRequestValidationError::EmptySessionId));
+    }
+
+    #[test]
+    fn validate_compares_canonical_session_ids_when_both_are_present() {
+        let id = Uuid::new_v4();
+        let mut req =
+            CreateProofRequest::new(compressed_protocol_request(Some(id.to_string()))).unwrap();
+        req.session_id = Some(id.to_string().to_uppercase());
+
+        assert_eq!(req.validate(), Ok(()));
+
+        req.session_id = Some("other-session".to_owned());
+
+        assert_eq!(req.validate(), Err(CreateProofRequestValidationError::SessionIdMismatch));
     }
 }

--- a/crates/proof/prover-service/db/src/repo.rs
+++ b/crates/proof/prover-service/db/src/repo.rs
@@ -498,7 +498,8 @@ impl ProofRequestRepo {
     ///
     /// If `retry_count < max_retries`: atomically resets to CREATED, increments `retry_count`,
     /// and creates a new outbox entry for backend-backed requests so a worker picks it up again.
-    /// Requests without a backend `proof_type` are reset without using the legacy outbox.
+    /// Requests without a backend `proof_type` are left unchanged because the legacy outbox cannot
+    /// make progress on them.
     /// If `retry_count >= max_retries`: transitions to FAILED.
     pub async fn retry_or_fail_stuck_request(
         &self,
@@ -534,6 +535,11 @@ impl ProofRequestRepo {
         }
 
         let retry_count: i32 = row.get("retry_count");
+        let proof_type = row.get::<Option<&str>, _>("proof_type");
+        if proof_type.is_none() {
+            tx.rollback().await?;
+            return Ok(RetryOutcome::Unsupported);
+        }
 
         // Fail any active sessions before resetting so the retried run cannot collide with
         // `idx_proof_sessions_request_type_active_unique`. No-op on the normal reaper path,
@@ -588,12 +594,6 @@ impl ProofRequestRepo {
         .bind(id)
         .execute(&mut *tx)
         .await?;
-
-        let proof_type = row.get::<Option<&str>, _>("proof_type");
-        if proof_type.is_none() {
-            tx.commit().await?;
-            return Ok(RetryOutcome::Retried);
-        }
 
         // Copy the most recent outbox entry for this request. If the outbox was
         // already cleaned up (0 rows), reconstruct request_params from the
@@ -873,6 +873,7 @@ impl ProofRequestRepo {
                 pr.created_at, pr.updated_at, pr.completed_at, pr.retry_count
             FROM proof_requests pr
             WHERE pr.status = 'PENDING'
+              AND pr.proof_type IS NOT NULL
               AND pr.updated_at < NOW() - INTERVAL '1 minute' * $1
               AND NOT EXISTS (
                   SELECT 1 FROM proof_sessions ps
@@ -1430,6 +1431,8 @@ const fn validate_backend_proof_type(
 
 const ZERO_ADDRESS: &str = "0x0000000000000000000000000000000000000000";
 
+// Legacy rows predate `api_proof_type`; valid legacy ZK rows always have `proof_type`.
+// Treat `None` as compressed only to keep reads tolerant of inconsistent pre-migration data.
 const fn api_proof_type_for_backend(proof_type: Option<ProofType>) -> ApiProofType {
     match proof_type {
         Some(ProofType::OpSuccinctSp1ClusterCompressed) | None => ApiProofType::Compressed,

--- a/crates/proof/prover-service/db/src/repo.rs
+++ b/crates/proof/prover-service/db/src/repo.rs
@@ -1345,18 +1345,18 @@ impl TryFrom<CreateProofRequest> for PreparedProofRequest {
         req.request_payload.session_id = Some(session_id.clone());
 
         let start_block_number = i64::try_from(req.start_block_number).map_err(|_| {
-            CreateProofRequestValidationError::FieldMismatch { field: "start_block_number" }
+            CreateProofRequestValidationError::ValueOutOfRange { field: "start_block_number" }
         })?;
         let number_of_blocks_to_prove =
             i64::try_from(req.number_of_blocks_to_prove).map_err(|_| {
-                CreateProofRequestValidationError::FieldMismatch {
+                CreateProofRequestValidationError::ValueOutOfRange {
                     field: "number_of_blocks_to_prove",
                 }
             })?;
         let sequence_window = req
             .sequence_window
             .map(|w| {
-                i64::try_from(w).map_err(|_| CreateProofRequestValidationError::FieldMismatch {
+                i64::try_from(w).map_err(|_| CreateProofRequestValidationError::ValueOutOfRange {
                     field: "sequence_window",
                 })
             })
@@ -1364,15 +1364,14 @@ impl TryFrom<CreateProofRequest> for PreparedProofRequest {
         let intermediate_root_interval = req
             .intermediate_root_interval
             .map(|v| {
-                i64::try_from(v).map_err(|_| CreateProofRequestValidationError::FieldMismatch {
+                i64::try_from(v).map_err(|_| CreateProofRequestValidationError::ValueOutOfRange {
                     field: "intermediate_root_interval",
                 })
             })
             .transpose()?;
         validate_backend_proof_type(req.api_proof_type, req.proof_type)?;
-        let request_payload = serde_json::to_value(&req.request_payload).map_err(|_| {
-            CreateProofRequestValidationError::FieldMismatch { field: "request_payload" }
-        })?;
+        let request_payload = serde_json::to_value(&req.request_payload)
+            .map_err(|_| CreateProofRequestValidationError::RequestPayloadSerialization)?;
 
         Ok(Self {
             id,
@@ -1866,5 +1865,29 @@ mod tests {
             PreparedProofRequest::try_from(create).expect_err("invalid TEE request should fail");
 
         assert_eq!(err, CreateProofRequestValidationError::FieldMismatch { field: "zk_vm" });
+    }
+
+    #[test]
+    fn prepared_request_rejects_database_range_overflow() {
+        let create = CreateProofRequest::new(ProtocolProofRequest {
+            session_id: Some(Uuid::new_v4().to_string()),
+            request: ProofRequestKind::Compressed(ZkProofRequest {
+                start_block_number: (i64::MAX as u64) + 1,
+                number_of_blocks_to_prove: 5,
+                sequence_window: None,
+                l1_head: None,
+                intermediate_root_interval: None,
+                zk_vm: ZkVm::Sp1,
+            }),
+        })
+        .expect("request should validate");
+
+        let err = PreparedProofRequest::try_from(create)
+            .expect_err("out-of-range request should fail preparation");
+
+        assert_eq!(
+            err,
+            CreateProofRequestValidationError::ValueOutOfRange { field: "start_block_number" }
+        );
     }
 }

--- a/crates/proof/prover-service/db/src/repo.rs
+++ b/crates/proof/prover-service/db/src/repo.rs
@@ -6,7 +6,7 @@ use crate::{
     CreateProofRequestOutcome, CreateProofRequestValidationError, CreateProofSession,
     MarkOutboxError, MarkOutboxProcessed, OutboxEntry, ProofRequest, ProofRequestListItem,
     ProofRequestPage, ProofSession, ProofStatus, ProofType, RetryOutcome, SessionStatus,
-    SessionType, TeeKind, UpdateProofSession, UpdateReceipt, ZkVmKind,
+    SessionType, TeeKind, UpdateProofSession, UpdateReceipt, ZkVmKind, canonical_session_id,
 };
 
 /// Repository for proof request database operations
@@ -277,6 +277,8 @@ impl ProofRequestRepo {
 
     /// Get a proof request by public protocol session ID.
     pub async fn get_by_session_id(&self, session_id: &str) -> Result<Option<ProofRequest>> {
+        let session_id = canonical_session_id(session_id)
+            .map_err(|e| sqlx::Error::InvalidArgument(e.to_string()))?;
         let row = sqlx::query(
             r#"
             SELECT
@@ -291,7 +293,7 @@ impl ProofRequestRepo {
             WHERE COALESCE(session_id, id::text) = $1
             "#,
         )
-        .bind(session_id)
+        .bind(&session_id)
         .fetch_optional(&self.pool)
         .await?;
 

--- a/crates/proof/prover-service/db/src/repo.rs
+++ b/crates/proof/prover-service/db/src/repo.rs
@@ -1429,6 +1429,7 @@ const fn validate_backend_proof_type(
 }
 
 const ZERO_ADDRESS: &str = "0x0000000000000000000000000000000000000000";
+const ZERO_HASH: &str = "0x0000000000000000000000000000000000000000000000000000000000000000";
 
 // Legacy rows predate `api_proof_type`; valid legacy ZK rows always have `proof_type`.
 // Treat `None` as compressed only to keep reads tolerant of inconsistent pre-migration data.
@@ -1439,10 +1440,7 @@ const fn api_proof_type_for_backend(proof_type: Option<ProofType>) -> ApiProofTy
     }
 }
 
-const fn fallback_zk_vm_for_request(
-    api_proof_type: ApiProofType,
-    _proof_type: Option<ProofType>,
-) -> Option<ZkVmKind> {
+const fn fallback_zk_vm_for_request(api_proof_type: ApiProofType) -> Option<ZkVmKind> {
     match api_proof_type {
         ApiProofType::Compressed | ApiProofType::SnarkGroth16 => Some(ZkVmKind::Sp1),
         ApiProofType::Tee => None,
@@ -1456,7 +1454,8 @@ struct ProtocolRequestPayloadParams<'a> {
     start_block_number: i64,
     number_of_blocks_to_prove: i64,
     sequence_window: Option<i64>,
-    proof_type: ProofType,
+    api_proof_type: ApiProofType,
+    tee_kind: Option<TeeKind>,
     prover_address: Option<&'a str>,
     l1_head: Option<&'a str>,
     intermediate_root_interval: Option<i64>,
@@ -1474,21 +1473,43 @@ impl ProtocolRequestPayloadParams<'_> {
         });
         strip_null_object_fields(&mut zk_payload);
 
-        match self.proof_type {
-            ProofType::OpSuccinctSp1ClusterCompressed => serde_json::json!({
+        match self.api_proof_type {
+            ApiProofType::Compressed => serde_json::json!({
                 "session_id": self.session_id,
                 "request": {
                     "proof_type": ApiProofType::Compressed.as_str(),
                     "payload": zk_payload,
                 },
             }),
-            ProofType::OpSuccinctSp1ClusterSnarkGroth16 => serde_json::json!({
+            ApiProofType::SnarkGroth16 => serde_json::json!({
                 "session_id": self.session_id,
                 "request": {
                     "proof_type": ApiProofType::SnarkGroth16.as_str(),
                     "payload": {
                         "proof": zk_payload,
                         "prover_address": self.prover_address.unwrap_or(ZERO_ADDRESS),
+                    },
+                },
+            }),
+            ApiProofType::Tee => serde_json::json!({
+                "session_id": self.session_id,
+                "request": {
+                    "proof_type": ApiProofType::Tee.as_str(),
+                    "payload": {
+                        "proof": {
+                            "l1_head": self.l1_head.unwrap_or(ZERO_HASH),
+                            "agreed_l2_head_hash": ZERO_HASH,
+                            "agreed_l2_output_root": ZERO_HASH,
+                            "claimed_l2_output_root": ZERO_HASH,
+                            "claimed_l2_block_number": self.start_block_number,
+                            "proposer": ZERO_ADDRESS,
+                            "intermediate_block_interval": self
+                                .intermediate_root_interval
+                                .unwrap_or_default(),
+                            "l1_head_number": 0,
+                            "image_hash": ZERO_HASH,
+                        },
+                        "tee_kind": self.tee_kind.unwrap_or(TeeKind::AwsNitro).as_str(),
                     },
                 },
             }),
@@ -1547,34 +1568,22 @@ fn row_to_proof_request(row: &sqlx::postgres::PgRow) -> Result<ProofRequest> {
         .get::<Option<&str>, _>("zk_vm")
         .map(parse_zk_vm_kind)
         .transpose()?
-        .or_else(|| fallback_zk_vm_for_request(api_proof_type, proof_type));
+        .or_else(|| fallback_zk_vm_for_request(api_proof_type));
     let tee_kind = row.get::<Option<&str>, _>("tee_kind").map(parse_tee_kind).transpose()?;
     let request_payload =
         row.get::<Option<serde_json::Value>, _>("request_payload").unwrap_or_else(|| {
-            proof_type.map_or_else(
-                || {
-                    serde_json::json!({
-                        "session_id": &session_id,
-                        "request": {
-                            "proof_type": api_proof_type.as_str(),
-                            "payload": {},
-                        },
-                    })
-                },
-                |proof_type| {
-                    ProtocolRequestPayloadParams {
-                        session_id: &session_id,
-                        start_block_number,
-                        number_of_blocks_to_prove,
-                        sequence_window,
-                        proof_type,
-                        prover_address: prover_address.as_deref(),
-                        l1_head: l1_head.as_deref(),
-                        intermediate_root_interval,
-                    }
-                    .build()
-                },
-            )
+            ProtocolRequestPayloadParams {
+                session_id: &session_id,
+                start_block_number,
+                number_of_blocks_to_prove,
+                sequence_window,
+                api_proof_type,
+                tee_kind,
+                prover_address: prover_address.as_deref(),
+                l1_head: l1_head.as_deref(),
+                intermediate_root_interval,
+            }
+            .build()
         });
 
     Ok(ProofRequest {
@@ -1816,12 +1825,36 @@ mod tests {
 
     #[test]
     fn tee_request_does_not_fallback_to_zk_vm() {
-        let zk_vm = fallback_zk_vm_for_request(
-            ApiProofType::Tee,
-            Some(ProofType::OpSuccinctSp1ClusterCompressed),
-        );
+        let zk_vm = fallback_zk_vm_for_request(ApiProofType::Tee);
 
         assert!(zk_vm.is_none());
+    }
+
+    #[test]
+    fn fallback_tee_protocol_payload_deserializes() {
+        let payload = ProtocolRequestPayloadParams {
+            session_id: "tee-session",
+            start_block_number: 100,
+            number_of_blocks_to_prove: 1,
+            sequence_window: None,
+            api_proof_type: ApiProofType::Tee,
+            tee_kind: Some(TeeKind::AwsNitro),
+            prover_address: None,
+            l1_head: Some(ZERO_HASH),
+            intermediate_root_interval: Some(10),
+        }
+        .build();
+
+        let protocol_request: ProtocolProofRequest =
+            serde_json::from_value(payload).expect("fallback TEE payload should deserialize");
+
+        assert_eq!(protocol_request.session_id.as_deref(), Some("tee-session"));
+        let ProofRequestKind::Tee(request) = protocol_request.request else {
+            panic!("expected TEE protocol request");
+        };
+        assert_eq!(request.tee_kind, ProtocolTeeKind::AwsNitro);
+        assert_eq!(request.proof.claimed_l2_block_number, 100);
+        assert_eq!(request.proof.intermediate_block_interval, 10);
     }
 
     #[test]

--- a/crates/proof/prover-service/db/src/repo.rs
+++ b/crates/proof/prover-service/db/src/repo.rs
@@ -99,7 +99,7 @@ impl ProofRequestRepo {
                 prover_address, l1_head, intermediate_root_interval
             )
             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
-            ON CONFLICT DO NOTHING
+            ON CONFLICT ((COALESCE(session_id, id::text))) DO NOTHING
             "#,
         )
         .bind(prepared.id)

--- a/crates/proof/prover-service/db/src/repo.rs
+++ b/crates/proof/prover-service/db/src/repo.rs
@@ -3,10 +3,10 @@ use uuid::Uuid;
 
 use crate::{
     ApiProofType, CreateOutboxEntry, CreateProofRequest, CreateProofRequestError,
-    CreateProofRequestOutcome, CreateProofSession, MarkOutboxError, MarkOutboxProcessed,
-    OutboxEntry, ProofRequest, ProofRequestListItem, ProofRequestPage, ProofSession, ProofStatus,
-    ProofType, RetryOutcome, SessionStatus, SessionType, TeeKind, UpdateProofSession,
-    UpdateReceipt, ZkVmKind,
+    CreateProofRequestOutcome, CreateProofRequestValidationError, CreateProofSession,
+    MarkOutboxError, MarkOutboxProcessed, OutboxEntry, ProofRequest, ProofRequestListItem,
+    ProofRequestPage, ProofSession, ProofStatus, ProofType, RetryOutcome, SessionStatus,
+    SessionType, TeeKind, UpdateProofSession, UpdateReceipt, ZkVmKind,
 };
 
 /// Repository for proof request database operations
@@ -22,20 +22,24 @@ impl ProofRequestRepo {
     }
 
     /// Create a new proof request and return its UUID
-    pub async fn create(&self, req: CreateProofRequest) -> Result<Uuid> {
+    pub async fn create(
+        &self,
+        req: CreateProofRequest,
+    ) -> std::result::Result<Uuid, CreateProofRequestError> {
         let prepared = PreparedProofRequest::try_from(req)?;
 
         sqlx::query(
             r#"
             INSERT INTO proof_requests (
-                id, request_payload, api_proof_type, zk_vm, tee_kind, start_block_number,
+                id, session_id, request_payload, api_proof_type, zk_vm, tee_kind, start_block_number,
                 number_of_blocks_to_prove, sequence_window, proof_type, status,
                 prover_address, l1_head, intermediate_root_interval
             )
-            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
             "#,
         )
         .bind(prepared.id)
+        .bind(&prepared.session_id)
         .bind(&prepared.request_payload)
         .bind(prepared.api_proof_type.as_str())
         .bind(prepared.zk_vm.map(|zk_vm| zk_vm.as_str()))
@@ -43,7 +47,7 @@ impl ProofRequestRepo {
         .bind(prepared.start_block_number)
         .bind(prepared.number_of_blocks_to_prove)
         .bind(prepared.sequence_window)
-        .bind(prepared.proof_type.as_str())
+        .bind(prepared.proof_type.map(|proof_type| proof_type.as_str()))
         .bind(ProofStatus::Created.as_str())
         .bind(&prepared.prover_address)
         .bind(&prepared.l1_head)
@@ -69,12 +73,17 @@ impl ProofRequestRepo {
         max_retries: i32,
     ) -> std::result::Result<CreateProofRequestOutcome, CreateProofRequestError> {
         let prepared = PreparedProofRequest::try_from(req)?;
+        let Some(proof_type) = prepared.proof_type else {
+            return Err(CreateProofRequestError::UnsupportedOutboxProofType {
+                api_proof_type: prepared.api_proof_type,
+            });
+        };
 
         let request_params = build_outbox_params(
             prepared.start_block_number,
             prepared.number_of_blocks_to_prove,
             prepared.sequence_window,
-            prepared.proof_type.as_str(),
+            Some(proof_type.as_str()),
             prepared.prover_address.as_deref(),
             prepared.l1_head.as_deref(),
             prepared.intermediate_root_interval,
@@ -85,15 +94,16 @@ impl ProofRequestRepo {
         let insert_result = sqlx::query(
             r#"
             INSERT INTO proof_requests (
-                id, request_payload, api_proof_type, zk_vm, tee_kind, start_block_number,
+                id, session_id, request_payload, api_proof_type, zk_vm, tee_kind, start_block_number,
                 number_of_blocks_to_prove, sequence_window, proof_type, status,
                 prover_address, l1_head, intermediate_root_interval
             )
-            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
-            ON CONFLICT (id) DO NOTHING
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
+            ON CONFLICT DO NOTHING
             "#,
         )
         .bind(prepared.id)
+        .bind(&prepared.session_id)
         .bind(&prepared.request_payload)
         .bind(prepared.api_proof_type.as_str())
         .bind(prepared.zk_vm.map(|zk_vm| zk_vm.as_str()))
@@ -101,7 +111,7 @@ impl ProofRequestRepo {
         .bind(prepared.start_block_number)
         .bind(prepared.number_of_blocks_to_prove)
         .bind(prepared.sequence_window)
-        .bind(prepared.proof_type.as_str())
+        .bind(Some(proof_type.as_str()))
         .bind(ProofStatus::Created.as_str())
         .bind(&prepared.prover_address)
         .bind(&prepared.l1_head)
@@ -128,16 +138,17 @@ impl ProofRequestRepo {
         // Conflict path: `FOR UPDATE` serializes with stuck recovery and workers.
         let row = sqlx::query(
             r#"
-            SELECT id, id::text AS session_id, request_payload, api_proof_type, zk_vm, tee_kind,
+            SELECT id, COALESCE(session_id, id::text) AS session_id,
+                   request_payload, api_proof_type, zk_vm, tee_kind,
                    start_block_number, number_of_blocks_to_prove, sequence_window,
                    proof_type, status, prover_address, l1_head,
                    intermediate_root_interval, retry_count
             FROM proof_requests
-            WHERE id = $1
+            WHERE COALESCE(session_id, id::text) = $1
             FOR UPDATE
             "#,
         )
-        .bind(prepared.id)
+        .bind(&prepared.session_id)
         .fetch_optional(&mut *tx)
         .await?;
 
@@ -157,7 +168,7 @@ impl ProofRequestRepo {
             start_block_number: prepared.start_block_number,
             number_of_blocks_to_prove: prepared.number_of_blocks_to_prove,
             sequence_window: prepared.sequence_window,
-            proof_type: prepared.proof_type.as_str(),
+            proof_type: prepared.proof_type.map(|proof_type| proof_type.as_str()),
             prover_address: prepared.prover_address.as_deref(),
             l1_head: prepared.l1_head.as_deref(),
             intermediate_root_interval: prepared.intermediate_root_interval,
@@ -246,7 +257,8 @@ impl ProofRequestRepo {
         let row = sqlx::query(
             r#"
             SELECT
-                id, id::text AS session_id, request_payload, api_proof_type, zk_vm, tee_kind,
+                id, COALESCE(session_id, id::text) AS session_id,
+                request_payload, api_proof_type, zk_vm, tee_kind,
                 start_block_number, number_of_blocks_to_prove, sequence_window, proof_type,
                 stark_receipt, snark_receipt,
                 status, error_message,
@@ -257,6 +269,29 @@ impl ProofRequestRepo {
             "#,
         )
         .bind(id)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        row.map(|r| row_to_proof_request(&r)).transpose()
+    }
+
+    /// Get a proof request by public protocol session ID.
+    pub async fn get_by_session_id(&self, session_id: &str) -> Result<Option<ProofRequest>> {
+        let row = sqlx::query(
+            r#"
+            SELECT
+                id, COALESCE(session_id, id::text) AS session_id,
+                request_payload, api_proof_type, zk_vm, tee_kind,
+                start_block_number, number_of_blocks_to_prove, sequence_window, proof_type,
+                stark_receipt, snark_receipt,
+                status, error_message,
+                prover_address, l1_head, intermediate_root_interval,
+                created_at, updated_at, completed_at, retry_count
+            FROM proof_requests
+            WHERE COALESCE(session_id, id::text) = $1
+            "#,
+        )
+        .bind(session_id)
         .fetch_optional(&self.pool)
         .await?;
 
@@ -460,7 +495,8 @@ impl ProofRequestRepo {
     /// Retry a stuck PENDING request if under the retry limit, otherwise fail it permanently.
     ///
     /// If `retry_count < max_retries`: atomically resets to CREATED, increments `retry_count`,
-    /// and creates a new outbox entry so a worker picks it up again.
+    /// and creates a new outbox entry for backend-backed requests so a worker picks it up again.
+    /// Requests without a backend `proof_type` are reset without using the legacy outbox.
     /// If `retry_count >= max_retries`: transitions to FAILED.
     pub async fn retry_or_fail_stuck_request(
         &self,
@@ -551,6 +587,12 @@ impl ProofRequestRepo {
         .execute(&mut *tx)
         .await?;
 
+        let proof_type = row.get::<Option<&str>, _>("proof_type");
+        if proof_type.is_none() {
+            tx.commit().await?;
+            return Ok(RetryOutcome::Retried);
+        }
+
         // Copy the most recent outbox entry for this request. If the outbox was
         // already cleaned up (0 rows), reconstruct request_params from the
         // proof_request row we hold under FOR UPDATE.
@@ -573,7 +615,7 @@ impl ProofRequestRepo {
                 row.get::<i64, _>("start_block_number"),
                 row.get::<i64, _>("number_of_blocks_to_prove"),
                 row.get::<Option<i64>, _>("sequence_window"),
-                row.get::<&str, _>("proof_type"),
+                proof_type,
                 row.get::<Option<&str>, _>("prover_address"),
                 row.get::<Option<&str>, _>("l1_head"),
                 row.get::<Option<i64>, _>("intermediate_root_interval"),
@@ -793,7 +835,8 @@ impl ProofRequestRepo {
     pub async fn get_running_proof_requests(&self) -> Result<Vec<ProofRequest>> {
         let rows = sqlx::query(
             r#"
-            SELECT id, id::text AS session_id, request_payload, api_proof_type, zk_vm, tee_kind,
+            SELECT id, COALESCE(session_id, id::text) AS session_id,
+                   request_payload, api_proof_type, zk_vm, tee_kind,
                    start_block_number, number_of_blocks_to_prove,
                    sequence_window, proof_type, stark_receipt, snark_receipt,
                    status, error_message, prover_address, l1_head,
@@ -819,7 +862,8 @@ impl ProofRequestRepo {
         let rows = sqlx::query(
             r#"
             SELECT
-                pr.id, pr.id::text AS session_id, pr.request_payload, pr.api_proof_type, pr.zk_vm,
+                pr.id, COALESCE(pr.session_id, pr.id::text) AS session_id,
+                pr.request_payload, pr.api_proof_type, pr.zk_vm,
                 pr.tee_kind, pr.start_block_number, pr.number_of_blocks_to_prove,
                 pr.sequence_window, pr.proof_type, pr.stark_receipt, pr.snark_receipt,
                 pr.status, pr.error_message, pr.prover_address, pr.l1_head,
@@ -1023,7 +1067,8 @@ impl ProofRequestRepo {
             sqlx::query(
                 r#"
                 SELECT
-                    id, id::text AS session_id, request_payload, api_proof_type, zk_vm, tee_kind,
+                    id, COALESCE(session_id, id::text) AS session_id,
+                    request_payload, api_proof_type, zk_vm, tee_kind,
                     start_block_number, number_of_blocks_to_prove, sequence_window, proof_type,
                     stark_receipt, snark_receipt,
                     status, error_message,
@@ -1043,7 +1088,8 @@ impl ProofRequestRepo {
             sqlx::query(
                 r#"
                 SELECT
-                    id, id::text AS session_id, request_payload, api_proof_type, zk_vm, tee_kind,
+                    id, COALESCE(session_id, id::text) AS session_id,
+                    request_payload, api_proof_type, zk_vm, tee_kind,
                     start_block_number, number_of_blocks_to_prove, sequence_window, proof_type,
                     stark_receipt, snark_receipt,
                     status, error_message,
@@ -1075,7 +1121,7 @@ impl ProofRequestRepo {
                 r#"
                 SELECT
                     id,
-                    id::text AS session_id,
+                    COALESCE(session_id, id::text) AS session_id,
                     COALESCE(
                         api_proof_type,
                         CASE proof_type
@@ -1117,7 +1163,7 @@ impl ProofRequestRepo {
                 r#"
                 SELECT
                     id,
-                    id::text AS session_id,
+                    COALESCE(session_id, id::text) AS session_id,
                     COALESCE(
                         api_proof_type,
                         CASE proof_type
@@ -1270,6 +1316,7 @@ impl ProofRequestRepo {
 #[derive(Debug, Clone)]
 struct PreparedProofRequest {
     id: Uuid,
+    session_id: String,
     request_payload: serde_json::Value,
     api_proof_type: ApiProofType,
     zk_vm: Option<ZkVmKind>,
@@ -1277,58 +1324,60 @@ struct PreparedProofRequest {
     start_block_number: i64,
     number_of_blocks_to_prove: i64,
     sequence_window: Option<i64>,
-    proof_type: ProofType,
+    proof_type: Option<ProofType>,
     prover_address: Option<String>,
     l1_head: Option<String>,
     intermediate_root_interval: Option<i64>,
 }
 
 impl TryFrom<CreateProofRequest> for PreparedProofRequest {
-    type Error = sqlx::Error;
+    type Error = CreateProofRequestValidationError;
 
-    fn try_from(req: CreateProofRequest) -> Result<Self> {
-        let id = req.session_id.unwrap_or_else(Uuid::new_v4);
-        let session_id = id.to_string();
-        let start_block_number = i64::try_from(req.start_block_number)
-            .map_err(|_| sqlx::Error::Protocol("block number exceeds i64 range".into()))?;
-        let number_of_blocks_to_prove = i64::try_from(req.number_of_blocks_to_prove)
-            .map_err(|_| sqlx::Error::Protocol("blocks to prove exceeds i64 range".into()))?;
+    fn try_from(mut req: CreateProofRequest) -> std::result::Result<Self, Self::Error> {
+        req.validate()?;
+
+        let (id, session_id) = canonical_request_ids(
+            req.session_id.as_deref().or(req.request_payload.session_id.as_deref()),
+        )?;
+        req.request_payload.session_id = Some(session_id.clone());
+
+        let start_block_number = i64::try_from(req.start_block_number).map_err(|_| {
+            CreateProofRequestValidationError::FieldMismatch { field: "start_block_number" }
+        })?;
+        let number_of_blocks_to_prove =
+            i64::try_from(req.number_of_blocks_to_prove).map_err(|_| {
+                CreateProofRequestValidationError::FieldMismatch {
+                    field: "number_of_blocks_to_prove",
+                }
+            })?;
         let sequence_window = req
             .sequence_window
             .map(|w| {
-                i64::try_from(w)
-                    .map_err(|_| sqlx::Error::Protocol("sequence window exceeds i64 range".into()))
+                i64::try_from(w).map_err(|_| CreateProofRequestValidationError::FieldMismatch {
+                    field: "sequence_window",
+                })
             })
             .transpose()?;
         let intermediate_root_interval = req
             .intermediate_root_interval
             .map(|v| {
-                i64::try_from(v).map_err(|_| {
-                    sqlx::Error::Protocol("intermediate root interval exceeds i64 range".into())
+                i64::try_from(v).map_err(|_| CreateProofRequestValidationError::FieldMismatch {
+                    field: "intermediate_root_interval",
                 })
             })
             .transpose()?;
-        let (api_proof_type, zk_vm, tee_kind) = protocol_fields_for_backend(req.proof_type);
-        let request_payload = req.request_payload.unwrap_or_else(|| {
-            ProtocolRequestPayloadParams {
-                session_id: &session_id,
-                start_block_number,
-                number_of_blocks_to_prove,
-                sequence_window,
-                proof_type: req.proof_type,
-                prover_address: req.prover_address.as_deref(),
-                l1_head: req.l1_head.as_deref(),
-                intermediate_root_interval,
-            }
-            .build()
-        });
+        validate_backend_proof_type(req.api_proof_type, req.proof_type)?;
+        let request_payload = serde_json::to_value(&req.request_payload).map_err(|_| {
+            CreateProofRequestValidationError::FieldMismatch { field: "request_payload" }
+        })?;
 
         Ok(Self {
             id,
+            session_id,
             request_payload,
-            api_proof_type,
-            zk_vm,
-            tee_kind,
+            api_proof_type: req.api_proof_type,
+            zk_vm: req.zk_vm,
+            tee_kind: req.tee_kind,
             start_block_number,
             number_of_blocks_to_prove,
             sequence_window,
@@ -1340,36 +1389,59 @@ impl TryFrom<CreateProofRequest> for PreparedProofRequest {
     }
 }
 
-const ZERO_ADDRESS: &str = "0x0000000000000000000000000000000000000000";
-
-const fn api_proof_type_for_backend(proof_type: ProofType) -> ApiProofType {
-    protocol_fields_for_backend(proof_type).0
+fn canonical_request_ids(
+    session_id: Option<&str>,
+) -> std::result::Result<(Uuid, String), CreateProofRequestValidationError> {
+    match session_id {
+        Some("") => Err(CreateProofRequestValidationError::EmptySessionId),
+        Some(session_id) => Uuid::parse_str(session_id).map_or_else(
+            |_| Ok((Uuid::new_v4(), session_id.to_owned())),
+            |id| Ok((id, id.to_string())),
+        ),
+        None => {
+            let id = Uuid::new_v4();
+            Ok((id, id.to_string()))
+        }
+    }
 }
 
-const fn zk_vm_for_backend(proof_type: ProofType) -> Option<ZkVmKind> {
-    protocol_fields_for_backend(proof_type).1
+const fn validate_backend_proof_type(
+    api_proof_type: ApiProofType,
+    proof_type: Option<ProofType>,
+) -> std::result::Result<(), CreateProofRequestValidationError> {
+    match (api_proof_type, proof_type) {
+        (ApiProofType::Compressed, Some(ProofType::OpSuccinctSp1ClusterCompressed))
+        | (ApiProofType::SnarkGroth16, Some(ProofType::OpSuccinctSp1ClusterSnarkGroth16))
+        | (ApiProofType::Tee, None) => Ok(()),
+        (ApiProofType::Compressed | ApiProofType::SnarkGroth16, None) => {
+            Err(CreateProofRequestValidationError::MissingBackendProofType { api_proof_type })
+        }
+        (ApiProofType::Tee, Some(_)) => {
+            Err(CreateProofRequestValidationError::UnexpectedBackendProofType { api_proof_type })
+        }
+        (_, Some(proof_type)) => Err(CreateProofRequestValidationError::BackendProofTypeMismatch {
+            api_proof_type,
+            proof_type,
+        }),
+    }
+}
+
+const ZERO_ADDRESS: &str = "0x0000000000000000000000000000000000000000";
+
+const fn api_proof_type_for_backend(proof_type: Option<ProofType>) -> ApiProofType {
+    match proof_type {
+        Some(ProofType::OpSuccinctSp1ClusterCompressed) | None => ApiProofType::Compressed,
+        Some(ProofType::OpSuccinctSp1ClusterSnarkGroth16) => ApiProofType::SnarkGroth16,
+    }
 }
 
 const fn fallback_zk_vm_for_request(
     api_proof_type: ApiProofType,
-    proof_type: ProofType,
+    _proof_type: Option<ProofType>,
 ) -> Option<ZkVmKind> {
     match api_proof_type {
-        ApiProofType::Compressed | ApiProofType::SnarkGroth16 => zk_vm_for_backend(proof_type),
+        ApiProofType::Compressed | ApiProofType::SnarkGroth16 => Some(ZkVmKind::Sp1),
         ApiProofType::Tee => None,
-    }
-}
-
-const fn protocol_fields_for_backend(
-    proof_type: ProofType,
-) -> (ApiProofType, Option<ZkVmKind>, Option<TeeKind>) {
-    match proof_type {
-        ProofType::OpSuccinctSp1ClusterCompressed => {
-            (ApiProofType::Compressed, Some(ZkVmKind::Sp1), None)
-        }
-        ProofType::OpSuccinctSp1ClusterSnarkGroth16 => {
-            (ApiProofType::SnarkGroth16, Some(ZkVmKind::Sp1), None)
-        }
     }
 }
 
@@ -1452,10 +1524,14 @@ fn row_to_proof_request(row: &sqlx::postgres::PgRow) -> Result<ProofRequest> {
     let status = ProofStatus::try_from(status_str)
         .map_err(|e| sqlx::Error::Protocol(format!("Unknown proof status '{status_str}': {e}")))?;
 
-    let proof_type_str: &str = row.get("proof_type");
-    let proof_type = ProofType::try_from(proof_type_str).map_err(|e| {
-        sqlx::Error::Protocol(format!("Unknown proof_type '{proof_type_str}': {e}"))
-    })?;
+    let proof_type = row
+        .get::<Option<&str>, _>("proof_type")
+        .map(|proof_type_str| {
+            ProofType::try_from(proof_type_str).map_err(|e| {
+                sqlx::Error::Protocol(format!("Unknown proof_type '{proof_type_str}': {e}"))
+            })
+        })
+        .transpose()?;
 
     let api_proof_type = match row.get::<Option<&str>, _>("api_proof_type") {
         Some(value) => ApiProofType::try_from(value)
@@ -1471,17 +1547,30 @@ fn row_to_proof_request(row: &sqlx::postgres::PgRow) -> Result<ProofRequest> {
     let tee_kind = row.get::<Option<&str>, _>("tee_kind").map(parse_tee_kind).transpose()?;
     let request_payload =
         row.get::<Option<serde_json::Value>, _>("request_payload").unwrap_or_else(|| {
-            ProtocolRequestPayloadParams {
-                session_id: &session_id,
-                start_block_number,
-                number_of_blocks_to_prove,
-                sequence_window,
-                proof_type,
-                prover_address: prover_address.as_deref(),
-                l1_head: l1_head.as_deref(),
-                intermediate_root_interval,
-            }
-            .build()
+            proof_type.map_or_else(
+                || {
+                    serde_json::json!({
+                        "session_id": &session_id,
+                        "request": {
+                            "proof_type": api_proof_type.as_str(),
+                            "payload": {},
+                        },
+                    })
+                },
+                |proof_type| {
+                    ProtocolRequestPayloadParams {
+                        session_id: &session_id,
+                        start_block_number,
+                        number_of_blocks_to_prove,
+                        sequence_window,
+                        proof_type,
+                        prover_address: prover_address.as_deref(),
+                        l1_head: l1_head.as_deref(),
+                        intermediate_root_interval,
+                    }
+                    .build()
+                },
+            )
         });
 
     Ok(ProofRequest {
@@ -1554,7 +1643,7 @@ struct CreateOutboxRequestParams<'a> {
     start_block_number: i64,
     number_of_blocks_to_prove: i64,
     sequence_window: Option<i64>,
-    proof_type: &'a str,
+    proof_type: Option<&'a str>,
     prover_address: Option<&'a str>,
     l1_head: Option<&'a str>,
     intermediate_root_interval: Option<i64>,
@@ -1572,7 +1661,7 @@ impl CreateOutboxRequestParams<'_> {
         if row.get::<Option<i64>, _>("sequence_window") != self.sequence_window {
             return Some("sequence_window");
         }
-        if row.get::<&str, _>("proof_type") != self.proof_type {
+        if row.get::<Option<&str>, _>("proof_type") != self.proof_type {
             return Some("proof_type");
         }
         if row.get::<Option<&str>, _>("prover_address") != self.prover_address {
@@ -1619,7 +1708,7 @@ fn build_outbox_params(
     start_block_number: i64,
     number_of_blocks_to_prove: i64,
     sequence_window: Option<i64>,
-    proof_type: &str,
+    proof_type: Option<&str>,
     prover_address: Option<&str>,
     l1_head: Option<&str>,
     intermediate_root_interval: Option<i64>,
@@ -1652,7 +1741,8 @@ fn row_to_outbox_entry(row: &sqlx::postgres::PgRow) -> OutboxEntry {
 #[cfg(test)]
 mod tests {
     use base_prover_service_protocol::{
-        ProofRequest as ProtocolProofRequest, ProofRequestKind, ZkVm,
+        ProofRequest as ProtocolProofRequest, ProofRequestKind, TeeKind as ProtocolTeeKind,
+        TeeProofRequest, ZkProofRequest, ZkVm,
     };
 
     use super::*;
@@ -1660,18 +1750,19 @@ mod tests {
     #[test]
     fn prepared_request_uses_uuid_session_id_and_builds_protocol_payload() {
         let session_id = Uuid::new_v4();
-        let prepared = PreparedProofRequest::try_from(CreateProofRequest {
-            start_block_number: 100,
-            number_of_blocks_to_prove: 5,
-            sequence_window: Some(50),
-            proof_type: ProofType::OpSuccinctSp1ClusterCompressed,
-            session_id: Some(session_id),
-            request_payload: None,
-            prover_address: None,
-            l1_head: None,
-            intermediate_root_interval: Some(5),
+        let create = CreateProofRequest::new(ProtocolProofRequest {
+            session_id: Some(session_id.to_string()),
+            request: ProofRequestKind::Compressed(ZkProofRequest {
+                start_block_number: 100,
+                number_of_blocks_to_prove: 5,
+                sequence_window: Some(50),
+                l1_head: None,
+                intermediate_root_interval: Some(5),
+                zk_vm: ZkVm::Sp1,
+            }),
         })
-        .expect("request should prepare");
+        .expect("request should validate");
+        let prepared = PreparedProofRequest::try_from(create).expect("request should prepare");
 
         assert_eq!(prepared.id, session_id);
         assert_eq!(prepared.api_proof_type, ApiProofType::Compressed);
@@ -1694,18 +1785,19 @@ mod tests {
 
     #[test]
     fn prepared_request_omits_absent_optional_protocol_payload_fields() {
-        let prepared = PreparedProofRequest::try_from(CreateProofRequest {
-            start_block_number: 100,
-            number_of_blocks_to_prove: 5,
-            sequence_window: None,
-            proof_type: ProofType::OpSuccinctSp1ClusterCompressed,
-            session_id: Some(Uuid::new_v4()),
-            request_payload: None,
-            prover_address: None,
-            l1_head: None,
-            intermediate_root_interval: None,
+        let create = CreateProofRequest::new(ProtocolProofRequest {
+            session_id: Some(Uuid::new_v4().to_string()),
+            request: ProofRequestKind::Compressed(ZkProofRequest {
+                start_block_number: 100,
+                number_of_blocks_to_prove: 5,
+                sequence_window: None,
+                l1_head: None,
+                intermediate_root_interval: None,
+                zk_vm: ZkVm::Sp1,
+            }),
         })
-        .expect("request should prepare");
+        .expect("request should validate");
+        let prepared = PreparedProofRequest::try_from(create).expect("request should prepare");
 
         let payload = prepared
             .request_payload
@@ -1722,9 +1814,52 @@ mod tests {
     fn tee_request_does_not_fallback_to_zk_vm() {
         let zk_vm = fallback_zk_vm_for_request(
             ApiProofType::Tee,
-            ProofType::OpSuccinctSp1ClusterCompressed,
+            Some(ProofType::OpSuccinctSp1ClusterCompressed),
         );
 
         assert!(zk_vm.is_none());
+    }
+
+    #[test]
+    fn prepared_request_represents_tee_protocol_request() {
+        let create = CreateProofRequest::new(ProtocolProofRequest {
+            session_id: Some("tee-session".to_owned()),
+            request: ProofRequestKind::Tee(TeeProofRequest {
+                proof: Default::default(),
+                tee_kind: ProtocolTeeKind::AwsNitro,
+            }),
+        })
+        .expect("TEE request should validate");
+
+        let prepared = PreparedProofRequest::try_from(create).expect("TEE request should prepare");
+
+        assert_eq!(prepared.session_id, "tee-session");
+        assert_eq!(prepared.api_proof_type, ApiProofType::Tee);
+        assert!(prepared.zk_vm.is_none());
+        assert_eq!(prepared.tee_kind, Some(TeeKind::AwsNitro));
+        assert!(prepared.proof_type.is_none());
+
+        let protocol_request: ProtocolProofRequest =
+            serde_json::from_value(prepared.request_payload).expect("payload should deserialize");
+        assert_eq!(protocol_request.session_id.as_deref(), Some("tee-session"));
+        assert!(matches!(protocol_request.request, ProofRequestKind::Tee(_)));
+    }
+
+    #[test]
+    fn prepared_request_rejects_unsupported_protocol_combination() {
+        let mut create = CreateProofRequest::new(ProtocolProofRequest {
+            session_id: Some("bad-tee-session".to_owned()),
+            request: ProofRequestKind::Tee(TeeProofRequest {
+                proof: Default::default(),
+                tee_kind: ProtocolTeeKind::AwsNitro,
+            }),
+        })
+        .expect("TEE request should validate");
+        create.zk_vm = Some(ZkVmKind::Sp1);
+
+        let err =
+            PreparedProofRequest::try_from(create).expect_err("invalid TEE request should fail");
+
+        assert_eq!(err, CreateProofRequestValidationError::FieldMismatch { field: "zk_vm" });
     }
 }

--- a/crates/proof/prover-service/db/tests/postgres_integration.rs
+++ b/crates/proof/prover-service/db/tests/postgres_integration.rs
@@ -21,7 +21,10 @@ use base_prover_service_db::{
     ProofStatus, ProofType, RetryOutcome, SessionStatus, SessionType, UpdateProofSession,
     UpdateReceipt, ZkVmKind,
 };
-use base_prover_service_protocol::ProofRequest as ProtocolProofRequest;
+use base_prover_service_protocol::{
+    ProofRequest as ProtocolProofRequest, ProofRequestKind as ProtocolProofRequestKind,
+    SnarkGroth16ProofRequest, TeeKind as ProtocolTeeKind, TeeProofRequest, ZkProofRequest, ZkVm,
+};
 use sqlx::{PgPool, postgres::PgPoolOptions};
 use uuid::Uuid;
 
@@ -48,34 +51,54 @@ const fn test_repo(pool: PgPool) -> ProofRequestRepo {
     ProofRequestRepo::new(pool)
 }
 
-const fn compressed_request() -> CreateProofRequest {
-    CreateProofRequest {
-        start_block_number: 100,
-        number_of_blocks_to_prove: 5,
-        sequence_window: Some(50),
-        proof_type: ProofType::OpSuccinctSp1ClusterCompressed,
+fn compressed_request() -> CreateProofRequest {
+    CreateProofRequest::new(ProtocolProofRequest {
         session_id: None,
-        request_payload: None,
-        prover_address: None,
-        l1_head: None,
-        intermediate_root_interval: None,
-    }
+        request: ProtocolProofRequestKind::Compressed(ZkProofRequest {
+            start_block_number: 100,
+            number_of_blocks_to_prove: 5,
+            sequence_window: Some(50),
+            l1_head: None,
+            intermediate_root_interval: None,
+            zk_vm: ZkVm::Sp1,
+        }),
+    })
+    .expect("compressed request should validate")
 }
 
 fn snark_request() -> CreateProofRequest {
-    CreateProofRequest {
-        start_block_number: 200,
-        number_of_blocks_to_prove: 10,
-        sequence_window: Some(100),
-        proof_type: ProofType::OpSuccinctSp1ClusterSnarkGroth16,
+    CreateProofRequest::new(ProtocolProofRequest {
         session_id: None,
-        request_payload: None,
-        prover_address: Some("0x1234567890abcdef1234567890abcdef12345678".to_string()),
-        l1_head: Some(
-            "0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890".to_string(),
-        ),
-        intermediate_root_interval: None,
-    }
+        request: ProtocolProofRequestKind::SnarkGroth16(SnarkGroth16ProofRequest {
+            proof: ZkProofRequest {
+                start_block_number: 200,
+                number_of_blocks_to_prove: 10,
+                sequence_window: Some(100),
+                l1_head: Some(
+                    "0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"
+                        .parse()
+                        .expect("valid hash"),
+                ),
+                intermediate_root_interval: None,
+                zk_vm: ZkVm::Sp1,
+            },
+            prover_address: "0x1234567890abcdef1234567890abcdef12345678"
+                .parse()
+                .expect("valid address"),
+        }),
+    })
+    .expect("snark request should validate")
+}
+
+fn tee_request() -> CreateProofRequest {
+    CreateProofRequest::new(ProtocolProofRequest {
+        session_id: None,
+        request: ProtocolProofRequestKind::Tee(TeeProofRequest {
+            proof: Default::default(),
+            tee_kind: ProtocolTeeKind::AwsNitro,
+        }),
+    })
+    .expect("TEE request should validate")
 }
 
 /// Create a request in RUNNING state with an associated proof session.
@@ -119,7 +142,7 @@ async fn test_create_and_get_compressed() {
     assert_eq!(req.start_block_number, 100);
     assert_eq!(req.number_of_blocks_to_prove, 5);
     assert_eq!(req.sequence_window, Some(50));
-    assert_eq!(req.proof_type, ProofType::OpSuccinctSp1ClusterCompressed);
+    assert_eq!(req.proof_type, Some(ProofType::OpSuccinctSp1ClusterCompressed));
     assert_eq!(req.status, ProofStatus::Created);
     assert!(req.stark_receipt.is_none());
     assert!(req.snark_receipt.is_none());
@@ -141,7 +164,7 @@ async fn test_create_and_get_snark() {
 
     assert_eq!(req.start_block_number, 200);
     assert_eq!(req.number_of_blocks_to_prove, 10);
-    assert_eq!(req.proof_type, ProofType::OpSuccinctSp1ClusterSnarkGroth16);
+    assert_eq!(req.proof_type, Some(ProofType::OpSuccinctSp1ClusterSnarkGroth16));
     assert_eq!(req.prover_address.as_deref(), Some("0x1234567890abcdef1234567890abcdef12345678"));
     assert_eq!(
         req.l1_head.as_deref(),
@@ -157,7 +180,7 @@ async fn test_create_with_session_id() {
 
     let explicit_id = Uuid::new_v4();
     let mut req = compressed_request();
-    req.session_id = Some(explicit_id);
+    req.session_id = Some(explicit_id.to_string());
 
     let id = repo.create(req).await.unwrap();
     assert_eq!(id, explicit_id);
@@ -175,7 +198,7 @@ async fn test_create_with_uppercase_session_id_is_canonicalized() {
 
     let explicit_id = Uuid::new_v4();
     let mut req = compressed_request();
-    req.session_id = Some(Uuid::parse_str(&explicit_id.to_string().to_uppercase()).unwrap());
+    req.session_id = Some(explicit_id.to_string().to_uppercase());
 
     let id = repo.create(req).await.unwrap();
     assert_eq!(id, explicit_id);
@@ -197,7 +220,7 @@ async fn test_legacy_rollout_request_without_protocol_storage_is_readable_and_re
 
     let explicit_id = Uuid::new_v4();
     let mut req = compressed_request();
-    req.session_id = Some(explicit_id);
+    req.session_id = Some(explicit_id.to_string());
 
     sqlx::query(
         r#"
@@ -212,7 +235,7 @@ async fn test_legacy_rollout_request_without_protocol_storage_is_readable_and_re
     .bind(i64::try_from(req.start_block_number).unwrap())
     .bind(i64::try_from(req.number_of_blocks_to_prove).unwrap())
     .bind(req.sequence_window.map(|value| i64::try_from(value).unwrap()))
-    .bind(req.proof_type.as_str())
+    .bind(req.proof_type.expect("compressed request has proof_type").as_str())
     .bind(ProofStatus::Created.as_str())
     .bind(&req.prover_address)
     .bind(&req.l1_head)
@@ -782,6 +805,28 @@ async fn test_retry_or_fail_stuck_request_retries() {
 
 #[tokio::test]
 #[ignore = "requires a running Postgres with the prover schema (set DATABASE_URL); run with `cargo nextest run --run-ignored all -p base-prover-service-db --test postgres_integration --test-threads=1`"]
+async fn test_retry_or_fail_stuck_request_skips_outbox_for_null_proof_type() {
+    let pool = test_pool().await;
+    let repo = test_repo(pool);
+
+    let id = repo.create(tee_request()).await.unwrap();
+    repo.atomic_claim_task(id).await.unwrap();
+
+    let outcome = repo.retry_or_fail_stuck_request(id, 3, "stuck in PENDING").await.unwrap();
+    assert_eq!(outcome, RetryOutcome::Retried);
+
+    let req = repo.get(id).await.unwrap().unwrap();
+    assert_eq!(req.status, ProofStatus::Created);
+    assert_eq!(req.retry_count, 1);
+    assert!(req.proof_type.is_none());
+
+    let entries = repo.get_unprocessed_outbox_entries(100, 3).await.unwrap();
+    let outbox_count = entries.iter().filter(|entry| entry.proof_request_id == id).count();
+    assert_eq!(outbox_count, 0, "NULL proof_type requests must not enter the legacy outbox");
+}
+
+#[tokio::test]
+#[ignore = "requires a running Postgres with the prover schema (set DATABASE_URL); run with `cargo nextest run --run-ignored all -p base-prover-service-db --test postgres_integration --test-threads=1`"]
 async fn test_retry_or_fail_stuck_request_exhausted() {
     let pool = test_pool().await;
     let repo = test_repo(pool);
@@ -859,7 +904,7 @@ async fn test_create_with_outbox_idempotent() {
 
     let explicit_id = Uuid::new_v4();
     let mut req = compressed_request();
-    req.session_id = Some(explicit_id);
+    req.session_id = Some(explicit_id.to_string());
 
     let first = repo.create_with_outbox(req.clone(), TEST_MAX_PROOF_RETRIES).await.unwrap();
     let second = repo.create_with_outbox(req, TEST_MAX_PROOF_RETRIES).await.unwrap();
@@ -953,7 +998,7 @@ async fn test_create_with_outbox_requeues_failed_row() {
 
     let explicit_id = Uuid::new_v4();
     let mut req = compressed_request();
-    req.session_id = Some(explicit_id);
+    req.session_id = Some(explicit_id.to_string());
 
     // First attempt: create the row, then fail it via the same path the worker uses.
     let first = repo.create_with_outbox(req.clone(), TEST_MAX_PROOF_RETRIES).await.unwrap();
@@ -1001,12 +1046,18 @@ async fn test_create_with_outbox_rejects_param_mismatch() {
 
     let explicit_id = Uuid::new_v4();
     let mut req = compressed_request();
-    req.session_id = Some(explicit_id);
+    req.session_id = Some(explicit_id.to_string());
     let _ = repo.create_with_outbox(req.clone(), TEST_MAX_PROOF_RETRIES).await.unwrap();
 
     // Same id, different start_block_number — must be rejected, not silently masked.
-    let mut mismatched = req.clone();
-    mismatched.start_block_number = req.start_block_number + 1;
+    let mut mismatched_payload = req.request_payload.clone();
+    let ProtocolProofRequestKind::Compressed(proof) = &mut mismatched_payload.request else {
+        panic!("expected compressed request");
+    };
+    proof.start_block_number += 1;
+    let mut mismatched =
+        CreateProofRequest::new(mismatched_payload).expect("mismatched request should validate");
+    mismatched.session_id = Some(explicit_id.to_string());
 
     let err = repo
         .create_with_outbox(mismatched, TEST_MAX_PROOF_RETRIES)
@@ -1035,7 +1086,7 @@ async fn test_create_with_outbox_retry_cap() {
 
     let explicit_id = Uuid::new_v4();
     let mut req = compressed_request();
-    req.session_id = Some(explicit_id);
+    req.session_id = Some(explicit_id.to_string());
 
     let first = repo.create_with_outbox(req.clone(), TEST_MAX_PROOF_RETRIES).await.unwrap();
     assert!(matches!(first, CreateProofRequestOutcome::Created(_)));
@@ -1080,7 +1131,7 @@ async fn test_create_with_outbox_idempotent_in_flight() {
 
     let explicit_id = Uuid::new_v4();
     let mut req = compressed_request();
-    req.session_id = Some(explicit_id);
+    req.session_id = Some(explicit_id.to_string());
     let _ = repo.create_with_outbox(req.clone(), TEST_MAX_PROOF_RETRIES).await.unwrap();
 
     // CREATED: replay must not insert another outbox row.

--- a/crates/proof/prover-service/db/tests/postgres_integration.rs
+++ b/crates/proof/prover-service/db/tests/postgres_integration.rs
@@ -805,19 +805,25 @@ async fn test_retry_or_fail_stuck_request_retries() {
 
 #[tokio::test]
 #[ignore = "requires a running Postgres with the prover schema (set DATABASE_URL); run with `cargo nextest run --run-ignored all -p base-prover-service-db --test postgres_integration --test-threads=1`"]
-async fn test_retry_or_fail_stuck_request_skips_outbox_for_null_proof_type() {
+async fn test_retry_or_fail_stuck_request_skips_null_proof_type() {
     let pool = test_pool().await;
     let repo = test_repo(pool);
 
     let id = repo.create(tee_request()).await.unwrap();
     repo.atomic_claim_task(id).await.unwrap();
 
+    let stuck_requests = repo.get_stuck_requests(-1).await.unwrap();
+    assert!(
+        stuck_requests.iter().all(|request| request.id != id),
+        "NULL proof_type requests must not enter legacy stuck retry detection"
+    );
+
     let outcome = repo.retry_or_fail_stuck_request(id, 3, "stuck in PENDING").await.unwrap();
-    assert_eq!(outcome, RetryOutcome::Retried);
+    assert_eq!(outcome, RetryOutcome::Unsupported);
 
     let req = repo.get(id).await.unwrap().unwrap();
-    assert_eq!(req.status, ProofStatus::Created);
-    assert_eq!(req.retry_count, 1);
+    assert_eq!(req.status, ProofStatus::Pending);
+    assert_eq!(req.retry_count, 0);
     assert!(req.proof_type.is_none());
 
     let entries = repo.get_unprocessed_outbox_entries(100, 3).await.unwrap();

--- a/crates/proof/prover-service/src/backends/op_succinct/cluster.rs
+++ b/crates/proof/prover-service/src/backends/op_succinct/cluster.rs
@@ -191,6 +191,10 @@ impl ProvingBackend for ClusterBackend {
         proof_request: &ProofRequest,
         repo: &ProofRequestRepo,
     ) -> anyhow::Result<ProofProcessingResult> {
+        let proof_type = proof_request
+            .proof_type
+            .ok_or_else(|| anyhow::anyhow!("OP Succinct request has no backend proof_type"))?;
+
         // 1. Get all sessions for this proof request.
         let sessions = repo.get_sessions_for_request(proof_request.id).await?;
 
@@ -214,7 +218,7 @@ impl ProvingBackend for ClusterBackend {
 
         // 4. If SNARK requested, check if STARK completed and SNARK session needs
         //    to be triggered.
-        if proof_request.proof_type == ProofType::OpSuccinctSp1ClusterSnarkGroth16 {
+        if proof_type == ProofType::OpSuccinctSp1ClusterSnarkGroth16 {
             let has_stark_completed = updated_sessions.iter().any(|s| {
                 s.session_type == SessionType::Stark && s.status == DbSessionStatus::Completed
             });
@@ -241,12 +245,12 @@ impl ProvingBackend for ClusterBackend {
                     });
                 }
                 let updated_sessions = repo.get_sessions_for_request(proof_request.id).await?;
-                return Ok(Self::determine_status(proof_request.proof_type, &updated_sessions));
+                return Ok(Self::determine_status(proof_type, &updated_sessions));
             }
         }
 
         // 5. Determine final status.
-        Ok(Self::determine_status(proof_request.proof_type, &updated_sessions))
+        Ok(Self::determine_status(proof_type, &updated_sessions))
     }
 
     async fn get_session_status(&self, session: &ProofSession) -> anyhow::Result<SessionStatus> {

--- a/crates/proof/prover-service/src/backends/op_succinct/dry_run.rs
+++ b/crates/proof/prover-service/src/backends/op_succinct/dry_run.rs
@@ -231,7 +231,11 @@ impl ProvingBackend for DryRunBackend {
         proof_request: &ProofRequest,
         repo: &ProofRequestRepo,
     ) -> anyhow::Result<ProofProcessingResult> {
-        if proof_request.proof_type == ProofType::OpSuccinctSp1ClusterSnarkGroth16 {
+        let proof_type = proof_request
+            .proof_type
+            .ok_or_else(|| anyhow::anyhow!("dry-run request has no backend proof_type"))?;
+
+        if proof_type == ProofType::OpSuccinctSp1ClusterSnarkGroth16 {
             return Ok(ProofProcessingResult {
                 status: ProofStatus::Failed,
                 error_message: Some(

--- a/crates/proof/prover-service/src/backends/op_succinct/mock.rs
+++ b/crates/proof/prover-service/src/backends/op_succinct/mock.rs
@@ -135,6 +135,9 @@ impl ProvingBackend for MockBackend {
         proof_request: &ProofRequest,
         repo: &ProofRequestRepo,
     ) -> anyhow::Result<ProofProcessingResult> {
+        let proof_type = proof_request
+            .proof_type
+            .ok_or_else(|| anyhow::anyhow!("mock OP Succinct request has no backend proof_type"))?;
         let sessions = repo.get_sessions_for_request(proof_request.id).await?;
 
         if sessions.is_empty() {
@@ -161,7 +164,7 @@ impl ProvingBackend for MockBackend {
                             number_of_blocks_to_prove: proof_request.number_of_blocks_to_prove
                                 as u64,
                             sequence_window: proof_request.sequence_window.map(|w| w as u64),
-                            proof_type: match proof_request.proof_type {
+                            proof_type: match proof_type {
                                 ProofType::OpSuccinctSp1ClusterCompressed => 3,
                                 ProofType::OpSuccinctSp1ClusterSnarkGroth16 => 4,
                             },
@@ -213,7 +216,7 @@ impl ProvingBackend for MockBackend {
         let updated_sessions = repo.get_sessions_for_request(proof_request.id).await?;
 
         // For SNARK_GROTH16, check if STARK is done and SNARK session needs creation.
-        if proof_request.proof_type == ProofType::OpSuccinctSp1ClusterSnarkGroth16 {
+        if proof_type == ProofType::OpSuccinctSp1ClusterSnarkGroth16 {
             let has_stark_completed = updated_sessions.iter().any(|s| {
                 s.session_type == SessionType::Stark && s.status == DbSessionStatus::Completed
             });
@@ -244,11 +247,11 @@ impl ProvingBackend for MockBackend {
                 repo.create_proof_session(session).await?;
 
                 let final_sessions = repo.get_sessions_for_request(proof_request.id).await?;
-                return Ok(determine_mock_status(proof_request.proof_type, &final_sessions));
+                return Ok(determine_mock_status(proof_type, &final_sessions));
             }
         }
 
-        Ok(determine_mock_status(proof_request.proof_type, &updated_sessions))
+        Ok(determine_mock_status(proof_type, &updated_sessions))
     }
 
     async fn get_session_status(&self, _session: &ProofSession) -> anyhow::Result<SessionStatus> {

--- a/crates/proof/prover-service/src/backends/op_succinct/network.rs
+++ b/crates/proof/prover-service/src/backends/op_succinct/network.rs
@@ -194,6 +194,9 @@ impl ProvingBackend for NetworkBackend {
         proof_request: &ProofRequest,
         repo: &ProofRequestRepo,
     ) -> anyhow::Result<ProofProcessingResult> {
+        let proof_type = proof_request
+            .proof_type
+            .ok_or_else(|| anyhow::anyhow!("OP Succinct request has no backend proof_type"))?;
         let sessions = repo.get_sessions_for_request(proof_request.id).await?;
 
         // Sync all RUNNING sessions with the SP1 Network.
@@ -214,7 +217,7 @@ impl ProvingBackend for NetworkBackend {
         let updated_sessions = repo.get_sessions_for_request(proof_request.id).await?;
 
         // If SNARK requested, check if STARK completed and SNARK session needs triggering.
-        if proof_request.proof_type == ProofType::OpSuccinctSp1ClusterSnarkGroth16 {
+        if proof_type == ProofType::OpSuccinctSp1ClusterSnarkGroth16 {
             let has_stark_completed = updated_sessions.iter().any(|s| {
                 s.session_type == SessionType::Stark && s.status == DbSessionStatus::Completed
             });
@@ -241,11 +244,11 @@ impl ProvingBackend for NetworkBackend {
                     });
                 }
                 let updated_sessions = repo.get_sessions_for_request(proof_request.id).await?;
-                return Ok(Self::determine_status(proof_request.proof_type, &updated_sessions));
+                return Ok(Self::determine_status(proof_type, &updated_sessions));
             }
         }
 
-        Ok(Self::determine_status(proof_request.proof_type, &updated_sessions))
+        Ok(Self::determine_status(proof_type, &updated_sessions))
     }
 
     async fn get_session_status(&self, session: &ProofSession) -> anyhow::Result<SessionStatus> {

--- a/crates/proof/prover-service/src/proof_request_manager.rs
+++ b/crates/proof/prover-service/src/proof_request_manager.rs
@@ -4,7 +4,7 @@ use anyhow::Result;
 use base_prover_service_db::{
     ProofRequest, ProofRequestRepo, ProofStatus, ProofType, UpdateReceipt,
 };
-use tracing::warn;
+use tracing::{debug, warn};
 
 use crate::{
     backends::{BackendRegistry, BackendType, ProvingBackend},
@@ -36,9 +36,14 @@ impl ProofRequestManager {
     /// the same proof request.
     pub async fn sync_and_update_proof_status(&self, proof_request: &ProofRequest) -> Result<()> {
         let prev_status = proof_request.status;
-        let proof_type = proof_request
-            .proof_type
-            .ok_or_else(|| anyhow::anyhow!("Proof request has no backend proof_type"))?;
+        let Some(proof_type) = proof_request.proof_type else {
+            debug!(
+                proof_request_id = %proof_request.id,
+                api_proof_type = %proof_request.api_proof_type,
+                "Skipping proof request without backend proof_type"
+            );
+            return Ok(());
+        };
         let proof_type_label = metrics::proof_type_label(proof_type);
 
         // 1. Get backend for this proof type

--- a/crates/proof/prover-service/src/proof_request_manager.rs
+++ b/crates/proof/prover-service/src/proof_request_manager.rs
@@ -36,10 +36,13 @@ impl ProofRequestManager {
     /// the same proof request.
     pub async fn sync_and_update_proof_status(&self, proof_request: &ProofRequest) -> Result<()> {
         let prev_status = proof_request.status;
-        let proof_type_label = metrics::proof_type_label(proof_request.proof_type);
+        let proof_type = proof_request
+            .proof_type
+            .ok_or_else(|| anyhow::anyhow!("Proof request has no backend proof_type"))?;
+        let proof_type_label = metrics::proof_type_label(proof_type);
 
         // 1. Get backend for this proof type
-        let backend = self.get_backend_for_proof_type(proof_request.proof_type)?;
+        let backend = self.get_backend_for_proof_type(proof_type)?;
 
         // 2. Let backend drive the proof request (sync sessions, create new sessions, determine
         //    status)

--- a/crates/proof/prover-service/src/server/get_proof.rs
+++ b/crates/proof/prover-service/src/server/get_proof.rs
@@ -12,7 +12,7 @@ use uuid::Uuid;
 
 use crate::{
     backends::{OP_SUCCINCT_DRY_RUN_METADATA_KEY, OP_SUCCINCT_EXECUTION_STATS_METADATA_KEY},
-    server::{ProverServiceServer, internal, invalid_argument, not_found, record_rpc_result},
+    server::{ProverServiceServer, internal, not_found, record_rpc_result},
 };
 
 fn is_dry_run_metadata(metadata: &serde_json::Value) -> bool {
@@ -25,14 +25,14 @@ fn is_dry_run_metadata(metadata: &serde_json::Value) -> bool {
 
 fn proof_result_for_request(proof_req: &ProofRequest) -> RpcResult<ProofResult> {
     match proof_req.proof_type {
-        DbProofType::OpSuccinctSp1ClusterCompressed => {
+        Some(DbProofType::OpSuccinctSp1ClusterCompressed) => {
             let proof = proof_req
                 .stark_receipt
                 .clone()
                 .ok_or_else(|| not_found("compressed proof receipt not available"))?;
             Ok(ProofResult::Compressed(ZkProofResult { zk_vm: ZkVm::Sp1, proof: proof.into() }))
         }
-        DbProofType::OpSuccinctSp1ClusterSnarkGroth16 => {
+        Some(DbProofType::OpSuccinctSp1ClusterSnarkGroth16) => {
             let proof = proof_req
                 .snark_receipt
                 .clone()
@@ -41,7 +41,12 @@ fn proof_result_for_request(proof_req: &ProofRequest) -> RpcResult<ProofResult> 
                 proof: ZkProofResult { zk_vm: ZkVm::Sp1, proof: proof.into() },
             }))
         }
+        None => Err(not_found("proof result not available for request without backend proof_type")),
     }
+}
+
+fn canonical_session_id(session_id: &str) -> String {
+    Uuid::parse_str(session_id).map(|id| id.to_string()).unwrap_or_else(|_| session_id.to_owned())
 }
 
 impl ProverServiceServer {
@@ -83,17 +88,20 @@ impl ProverServiceServer {
     }
 
     async fn get_proof_inner(&self, request: GetProofRequest) -> RpcResult<GetProofResponse> {
-        let proof_request_id =
-            Uuid::parse_str(&request.session_id).map_err(|_| invalid_argument("Invalid UUID"))?;
-
-        info!(proof_request_id = %proof_request_id, "Getting proof status");
-
+        let session_id = canonical_session_id(&request.session_id);
         let proof_req = self
             .repo
-            .get(proof_request_id)
+            .get_by_session_id(&session_id)
             .await
             .map_err(|e| internal(format!("Database error: {e}")))?
             .ok_or_else(|| not_found("Proof request not found"))?;
+        let proof_request_id = proof_req.id;
+
+        info!(
+            proof_request_id = %proof_request_id,
+            session_id = %proof_req.session_id,
+            "Getting proof status"
+        );
 
         let (status, result, error_message) = match proof_req.status {
             DbProofStatus::Created | DbProofStatus::Pending => (ProofStatus::Queued, None, None),
@@ -176,7 +184,7 @@ mod tests {
             start_block_number: 1,
             number_of_blocks_to_prove: 1,
             sequence_window: None,
-            proof_type,
+            proof_type: Some(proof_type),
             stark_receipt,
             snark_receipt,
             status: DbProofStatus::Succeeded,
@@ -239,5 +247,19 @@ mod tests {
                 proof: ZkProofResult { zk_vm: ZkVm::Sp1, proof: snark_bytes.into() },
             })
         );
+    }
+
+    #[test]
+    fn canonical_session_id_lowercases_uuid_values() {
+        let id = Uuid::new_v4();
+
+        assert_eq!(canonical_session_id(&id.to_string().to_uppercase()), id.to_string());
+    }
+
+    #[test]
+    fn canonical_session_id_preserves_opaque_values() {
+        let session_id = "Mock-SESSION-ABC123";
+
+        assert_eq!(canonical_session_id(session_id), session_id);
     }
 }

--- a/crates/proof/prover-service/src/server/get_proof.rs
+++ b/crates/proof/prover-service/src/server/get_proof.rs
@@ -1,6 +1,6 @@
 use base_prover_service_db::{
     ProofRequest, ProofStatus as DbProofStatus, ProofType as DbProofType,
-    SessionStatus as DbSessionStatus,
+    SessionStatus as DbSessionStatus, canonical_session_id,
 };
 use base_prover_service_protocol::{
     GetProofRequest, GetProofResponse, ProofResult, ProofStatus, SnarkGroth16ProofResult,
@@ -12,7 +12,7 @@ use uuid::Uuid;
 
 use crate::{
     backends::{OP_SUCCINCT_DRY_RUN_METADATA_KEY, OP_SUCCINCT_EXECUTION_STATS_METADATA_KEY},
-    server::{ProverServiceServer, internal, not_found, record_rpc_result},
+    server::{ProverServiceServer, internal, invalid_argument, not_found, record_rpc_result},
 };
 
 fn is_dry_run_metadata(metadata: &serde_json::Value) -> bool {
@@ -43,10 +43,6 @@ fn proof_result_for_request(proof_req: &ProofRequest) -> RpcResult<ProofResult> 
         }
         None => Err(not_found("proof result not available for request without backend proof_type")),
     }
-}
-
-fn canonical_session_id(session_id: &str) -> String {
-    Uuid::parse_str(session_id).map(|id| id.to_string()).unwrap_or_else(|_| session_id.to_owned())
 }
 
 impl ProverServiceServer {
@@ -88,7 +84,8 @@ impl ProverServiceServer {
     }
 
     async fn get_proof_inner(&self, request: GetProofRequest) -> RpcResult<GetProofResponse> {
-        let session_id = canonical_session_id(&request.session_id);
+        let session_id = canonical_session_id(&request.session_id)
+            .map_err(|e| invalid_argument(format!("{e}")))?;
         let proof_req = self
             .repo
             .get_by_session_id(&session_id)
@@ -253,13 +250,13 @@ mod tests {
     fn canonical_session_id_lowercases_uuid_values() {
         let id = Uuid::new_v4();
 
-        assert_eq!(canonical_session_id(&id.to_string().to_uppercase()), id.to_string());
+        assert_eq!(canonical_session_id(&id.to_string().to_uppercase()).unwrap(), id.to_string());
     }
 
     #[test]
     fn canonical_session_id_preserves_opaque_values() {
         let session_id = "Mock-SESSION-ABC123";
 
-        assert_eq!(canonical_session_id(session_id), session_id);
+        assert_eq!(canonical_session_id(session_id).unwrap(), session_id);
     }
 }

--- a/crates/proof/prover-service/src/server/prove_block_range.rs
+++ b/crates/proof/prover-service/src/server/prove_block_range.rs
@@ -1,7 +1,6 @@
 use alloy_primitives::B256;
 use base_prover_service_db::{
-    ApiProofType, CreateProofRequest, CreateProofRequestError, CreateProofRequestOutcome,
-    ProofType, ZkVmKind,
+    CreateProofRequest, CreateProofRequestError, CreateProofRequestOutcome, ProofType,
 };
 use base_prover_service_protocol::{
     ProofRequest, ProofRequestKind, ProveBlockRangeRequest, ProveBlockRangeResponse,
@@ -64,20 +63,8 @@ impl ProverServiceServer {
             }
         }
 
-        let db_request = CreateProofRequest {
-            session_id: Some(session_id.clone()),
-            request_payload: proof_request,
-            api_proof_type: api_proof_type_for_backend(proof_type),
-            zk_vm: Some(ZkVmKind::Sp1),
-            tee_kind: None,
-            proof_type: Some(proof_type),
-            start_block_number: zk_request.start_block_number,
-            number_of_blocks_to_prove: zk_request.number_of_blocks_to_prove,
-            sequence_window: zk_request.sequence_window,
-            prover_address,
-            l1_head,
-            intermediate_root_interval: zk_request.intermediate_root_interval,
-        };
+        let db_request =
+            CreateProofRequest::new(proof_request).map_err(|e| invalid_argument(format!("{e}")))?;
 
         let outcome = self
             .repo
@@ -179,13 +166,6 @@ fn parse_zk_request(
 const fn validate_zk_vm(zk_vm: ZkVm) -> RpcResult<()> {
     match zk_vm {
         ZkVm::Sp1 => Ok(()),
-    }
-}
-
-const fn api_proof_type_for_backend(proof_type: ProofType) -> ApiProofType {
-    match proof_type {
-        ProofType::OpSuccinctSp1ClusterCompressed => ApiProofType::Compressed,
-        ProofType::OpSuccinctSp1ClusterSnarkGroth16 => ApiProofType::SnarkGroth16,
     }
 }
 

--- a/crates/proof/prover-service/src/server/prove_block_range.rs
+++ b/crates/proof/prover-service/src/server/prove_block_range.rs
@@ -1,5 +1,6 @@
 use base_prover_service_db::{
     ApiProofType, CreateProofRequest, CreateProofRequestError, CreateProofRequestOutcome,
+    canonical_session_id,
 };
 use base_prover_service_protocol::{ProveBlockRangeRequest, ProveBlockRangeResponse};
 use jsonrpsee::core::RpcResult;
@@ -12,7 +13,7 @@ use crate::server::{
 };
 
 impl ProverServiceServer {
-    /// Enqueues a new proof request and returns the generated `session_id=<uuid>`.
+    /// Enqueues a new proof request and returns the accepted session ID.
     pub async fn prove_block_range_impl(
         &self,
         request: ProveBlockRangeRequest,
@@ -29,8 +30,7 @@ impl ProverServiceServer {
         request: ProveBlockRangeRequest,
     ) -> RpcResult<ProveBlockRangeResponse> {
         let mut proof_request = request.proof;
-        let proof_request_id = parse_session_id(proof_request.session_id.as_deref())?;
-        let session_id = proof_request_id.to_string();
+        let session_id = parse_session_id(proof_request.session_id.as_deref())?;
         proof_request.session_id = Some(session_id.clone());
 
         let db_request =
@@ -131,13 +131,12 @@ impl ProverServiceServer {
     }
 }
 
-fn parse_session_id(session_id: Option<&str>) -> RpcResult<Uuid> {
+fn parse_session_id(session_id: Option<&str>) -> RpcResult<String> {
     session_id
-        .map(|id| {
-            Uuid::parse_str(id).map_err(|e| invalid_argument(format!("Invalid session_id: {e}")))
-        })
+        .map(canonical_session_id)
         .transpose()
-        .map(|id| id.unwrap_or_else(Uuid::new_v4))
+        .map_err(|e| invalid_argument(format!("{e}")))
+        .map(|id| id.unwrap_or_else(|| Uuid::new_v4().to_string()))
 }
 
 #[cfg(test)]
@@ -169,6 +168,14 @@ mod tests {
         let id = Uuid::new_v4();
         let parsed = parse_session_id(Some(&id.to_string().to_uppercase())).unwrap();
 
-        assert_eq!(parsed, id);
+        assert_eq!(parsed, id.to_string());
+    }
+
+    #[test]
+    fn parse_session_id_accepts_opaque_values() {
+        let session_id = "tee/aws_nitro/claimed-root";
+        let parsed = parse_session_id(Some(session_id)).unwrap();
+
+        assert_eq!(parsed, session_id);
     }
 }

--- a/crates/proof/prover-service/src/server/prove_block_range.rs
+++ b/crates/proof/prover-service/src/server/prove_block_range.rs
@@ -45,9 +45,7 @@ impl ProverServiceServer {
             "Attempting to prove base block(s)",
         );
 
-        if let (Some(_), Some(interval)) =
-            (db_request.proof_type, db_request.intermediate_root_interval)
-        {
+        if let Some(interval) = db_request.intermediate_root_interval {
             if interval == 0 {
                 return Err(invalid_argument(
                     "Invalid intermediate_root_interval: must be greater than 0",

--- a/crates/proof/prover-service/src/server/prove_block_range.rs
+++ b/crates/proof/prover-service/src/server/prove_block_range.rs
@@ -1,11 +1,7 @@
-use alloy_primitives::B256;
 use base_prover_service_db::{
-    CreateProofRequest, CreateProofRequestError, CreateProofRequestOutcome, ProofType,
+    ApiProofType, CreateProofRequest, CreateProofRequestError, CreateProofRequestOutcome,
 };
-use base_prover_service_protocol::{
-    ProofRequest, ProofRequestKind, ProveBlockRangeRequest, ProveBlockRangeResponse,
-    ZkProofRequest, ZkVm,
-};
+use base_prover_service_protocol::{ProveBlockRangeRequest, ProveBlockRangeResponse};
 use jsonrpsee::core::RpcResult;
 use tracing::{info, warn};
 use uuid::Uuid;
@@ -37,34 +33,33 @@ impl ProverServiceServer {
         let session_id = proof_request_id.to_string();
         proof_request.session_id = Some(session_id.clone());
 
-        let (zk_request, proof_type, prover_address) = parse_zk_request(proof_request.clone())?;
-        let l1_head = zk_request.l1_head.map(format_hash);
+        let db_request =
+            CreateProofRequest::new(proof_request).map_err(|e| invalid_argument(format!("{e}")))?;
 
         info!(
-            start_block_number = zk_request.start_block_number,
-            num_blocks_to_prove = zk_request.number_of_blocks_to_prove,
-            proof_type = %proof_type,
-            prover_address = ?prover_address,
-            l1_head = ?l1_head,
+            start_block_number = db_request.start_block_number,
+            num_blocks_to_prove = db_request.number_of_blocks_to_prove,
+            proof_type = ?db_request.proof_type,
+            prover_address = ?db_request.prover_address.as_deref(),
+            l1_head = ?db_request.l1_head.as_deref(),
             "Attempting to prove base block(s)",
         );
 
-        if let Some(interval) = zk_request.intermediate_root_interval {
+        if let (Some(_), Some(interval)) =
+            (db_request.proof_type, db_request.intermediate_root_interval)
+        {
             if interval == 0 {
                 return Err(invalid_argument(
                     "Invalid intermediate_root_interval: must be greater than 0",
                 ));
             }
-            if !zk_request.number_of_blocks_to_prove.is_multiple_of(interval) {
+            if !db_request.number_of_blocks_to_prove.is_multiple_of(interval) {
                 return Err(invalid_argument(format!(
                     "Invalid number_of_blocks_to_prove ({}): must be a multiple of intermediate_root_interval ({})",
-                    zk_request.number_of_blocks_to_prove, interval,
+                    db_request.number_of_blocks_to_prove, interval,
                 )));
             }
         }
-
-        let db_request =
-            CreateProofRequest::new(proof_request).map_err(|e| invalid_argument(format!("{e}")))?;
 
         let outcome = self
             .repo
@@ -91,6 +86,9 @@ impl ProverServiceServer {
                     ))
                 }
                 CreateProofRequestError::Validation(e) => invalid_argument(format!("{e}")),
+                CreateProofRequestError::UnsupportedOutboxProofType {
+                    api_proof_type: ApiProofType::Tee,
+                } => invalid_argument("TEE proof requests are not supported by this ZK service"),
                 CreateProofRequestError::UnsupportedOutboxProofType { api_proof_type } => {
                     invalid_argument(format!(
                         "{api_proof_type} proof requests are not supported by this outbox service"
@@ -142,35 +140,6 @@ fn parse_session_id(session_id: Option<&str>) -> RpcResult<Uuid> {
         })
         .transpose()
         .map(|id| id.unwrap_or_else(Uuid::new_v4))
-}
-
-fn parse_zk_request(
-    proof_request: ProofRequest,
-) -> RpcResult<(ZkProofRequest, ProofType, Option<String>)> {
-    match proof_request.request {
-        ProofRequestKind::Compressed(request) => {
-            validate_zk_vm(request.zk_vm)?;
-            Ok((request, ProofType::OpSuccinctSp1ClusterCompressed, None))
-        }
-        ProofRequestKind::SnarkGroth16(request) => {
-            validate_zk_vm(request.proof.zk_vm)?;
-            let prover_address = Some(format!("{:#x}", request.prover_address));
-            Ok((request.proof, ProofType::OpSuccinctSp1ClusterSnarkGroth16, prover_address))
-        }
-        ProofRequestKind::Tee(_) => {
-            Err(invalid_argument("TEE proof requests are not supported by this ZK service"))
-        }
-    }
-}
-
-const fn validate_zk_vm(zk_vm: ZkVm) -> RpcResult<()> {
-    match zk_vm {
-        ZkVm::Sp1 => Ok(()),
-    }
-}
-
-fn format_hash(hash: B256) -> String {
-    format!("{hash:#x}")
 }
 
 #[cfg(test)]

--- a/crates/proof/prover-service/src/server/prove_block_range.rs
+++ b/crates/proof/prover-service/src/server/prove_block_range.rs
@@ -1,6 +1,7 @@
 use alloy_primitives::B256;
 use base_prover_service_db::{
-    CreateProofRequest, CreateProofRequestError, CreateProofRequestOutcome, ProofType,
+    ApiProofType, CreateProofRequest, CreateProofRequestError, CreateProofRequestOutcome,
+    ProofType, ZkVmKind,
 };
 use base_prover_service_protocol::{
     ProofRequest, ProofRequestKind, ProveBlockRangeRequest, ProveBlockRangeResponse,
@@ -37,9 +38,7 @@ impl ProverServiceServer {
         let session_id = proof_request_id.to_string();
         proof_request.session_id = Some(session_id.clone());
 
-        let request_payload = serde_json::to_value(&proof_request)
-            .map_err(|e| internal(format!("Failed to serialize proof request: {e}")))?;
-        let (zk_request, proof_type, prover_address) = parse_zk_request(proof_request)?;
+        let (zk_request, proof_type, prover_address) = parse_zk_request(proof_request.clone())?;
         let l1_head = zk_request.l1_head.map(format_hash);
 
         info!(
@@ -66,12 +65,15 @@ impl ProverServiceServer {
         }
 
         let db_request = CreateProofRequest {
+            session_id: Some(session_id.clone()),
+            request_payload: proof_request,
+            api_proof_type: api_proof_type_for_backend(proof_type),
+            zk_vm: Some(ZkVmKind::Sp1),
+            tee_kind: None,
+            proof_type: Some(proof_type),
             start_block_number: zk_request.start_block_number,
             number_of_blocks_to_prove: zk_request.number_of_blocks_to_prove,
             sequence_window: zk_request.sequence_window,
-            proof_type,
-            session_id: Some(proof_request_id),
-            request_payload: Some(request_payload),
             prover_address,
             l1_head,
             intermediate_root_interval: zk_request.intermediate_root_interval,
@@ -99,6 +101,12 @@ impl ProverServiceServer {
                     );
                     unavailable(format!(
                         "session_id {id} is temporarily unavailable after conflict; retry prove_block_range"
+                    ))
+                }
+                CreateProofRequestError::Validation(e) => invalid_argument(format!("{e}")),
+                CreateProofRequestError::UnsupportedOutboxProofType { api_proof_type } => {
+                    invalid_argument(format!(
+                        "{api_proof_type} proof requests are not supported by this outbox service"
                     ))
                 }
                 CreateProofRequestError::Sqlx(e) => internal(format!("Database error: {e}")),
@@ -171,6 +179,13 @@ fn parse_zk_request(
 const fn validate_zk_vm(zk_vm: ZkVm) -> RpcResult<()> {
     match zk_vm {
         ZkVm::Sp1 => Ok(()),
+    }
+}
+
+const fn api_proof_type_for_backend(proof_type: ProofType) -> ApiProofType {
+    match proof_type {
+        ProofType::OpSuccinctSp1ClusterCompressed => ApiProofType::Compressed,
+        ProofType::OpSuccinctSp1ClusterSnarkGroth16 => ApiProofType::SnarkGroth16,
     }
 }
 

--- a/crates/proof/prover-service/src/worker/status_poller.rs
+++ b/crates/proof/prover-service/src/worker/status_poller.rs
@@ -124,6 +124,12 @@ impl StatusPoller {
                         metrics::inc_stuck_requests(proof_type_label);
                         metrics::inc_proof_requests_completed("failed", proof_type_label);
                     }
+                    Ok(RetryOutcome::Unsupported) => {
+                        warn!(
+                            proof_request_id = %request.id,
+                            "Stuck request cannot be retried by the legacy outbox flow"
+                        );
+                    }
                     Ok(RetryOutcome::Skipped) => {
                         warn!(
                             proof_request_id = %request.id,

--- a/crates/proof/prover-service/src/worker/status_poller.rs
+++ b/crates/proof/prover-service/src/worker/status_poller.rs
@@ -93,7 +93,8 @@ impl StatusPoller {
             );
 
             for request in stuck_requests {
-                let proof_type_label = metrics::proof_type_label(request.proof_type);
+                let proof_type_label =
+                    request.proof_type.map(metrics::proof_type_label).unwrap_or("unknown");
 
                 let error_msg = format!(
                     "Request stuck in {} state without active session for {}+ minutes",
@@ -110,7 +111,7 @@ impl StatusPoller {
                             proof_request_id = %request.id,
                             retry_count = request.retry_count + 1,
                             max_retries = self.max_proof_retries,
-                            "Retrying stuck request — reset to CREATED with new outbox entry"
+                            "Retrying stuck request"
                         );
                         metrics::inc_retried_requests(proof_type_label);
                     }


### PR DESCRIPTION
### What changed? Why?

Generalizes prover-service DB request creation around protocol-native proof requests. The DB create input now carries protocol payloads, opaque session ids, API proof kind fields, optional backend proof type, and derived compatibility fields for existing OP Succinct backends. TEE requests can now be represented without a backend proof_type, while compressed and SNARK requests continue to map to their existing backend proof types.

Adds a migration for public session_id storage and nullable backend proof_type, updates repository create/get paths, and adjusts prover-service call sites to handle optional backend proof types.

### Notes to reviewers

The legacy outbox flow still rejects request kinds without an OP Succinct backend proof_type.

### How has it been tested?

- cargo test -p base-prover-service-db
- cargo check -p base-prover-service

Postgres integration tests compile but remain ignored unless DATABASE_URL is set.