### PR TITLE
fix(builder/execution): use saturating_add for gas limit check in is_tx_over_limits

### DIFF
--- a/crates/builder/core/src/execution.rs
+++ b/crates/builder/core/src/execution.rs
@@ -328,7 +328,7 @@ impl ExecutionInfo {
         }
 
         // Check gas limit
-        if self.cumulative_gas_used + tx.gas_limit > limits.block_gas_limit {
+        if self.cumulative_gas_used.saturating_add(tx.gas_limit) > limits.block_gas_limit {
             return Err(TxnExecutionError::TransactionGasLimitExceeded {
                 cumulative_gas_used: self.cumulative_gas_used,
                 tx_gas_limit: tx.gas_limit,
@@ -774,6 +774,43 @@ mod tests {
         let result = info.is_tx_over_limits(&tx, &limits);
         // u128::MAX - 100 + 200 saturates to u128::MAX, which equals the limit
         assert!(result.is_ok());
+    }
+
+    /// Gas limit check must use saturating_add so that a crafted
+    /// (cumulative_gas_used, tx.gas_limit) pair that overflows u64 cannot
+    /// silently bypass the block-gas-limit guard in a release build.
+    /// Plain addition would wrap to a small value and pass the check.
+    #[test]
+    fn test_gas_limit_check_uses_saturating_add() {
+        let mut info = ExecutionInfo::with_capacity(1);
+        info.cumulative_gas_used = u64::MAX - 100;
+
+        let limits = ResourceLimits {
+            block_gas_limit: u64::MAX,
+            ..Default::default()
+        };
+        let tx = TxResources {
+            gas_limit: 200, // cumulative + gas_limit overflows without saturating_add
+            ..Default::default()
+        };
+
+        // saturating_add(u64::MAX - 100, 200) = u64::MAX == block_gas_limit → Ok
+        // plain add: (u64::MAX - 100).wrapping_add(200) = 99 <= u64::MAX → also Ok here,
+        // but the point is the arithmetic is defined and capped.
+        let result = info.is_tx_over_limits(&tx, &limits);
+        assert!(result.is_ok(), "should be ok when saturated sum equals the limit");
+
+        // Now set limit just below the saturated sum.
+        let limits_tight = ResourceLimits {
+            block_gas_limit: u64::MAX - 1,
+            ..Default::default()
+        };
+        let result = info.is_tx_over_limits(&tx, &limits_tight);
+        assert!(
+            result.is_err(),
+            "should be rejected when saturated sum exceeds limit; \
+             with plain addition this would have wrapped and passed"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## The bug

I was reading through `is_tx_over_limits` and noticed that every resource check uses `saturating_add` — except the gas limit check, which uses plain `+`:

```rust
// every other check:
let total_da_bytes_used = self.cumulative_da_bytes_used.saturating_add(tx.da_size);
let total_time = self.flashblock_execution_time_us.saturating_add(tx_time);
let total = self.cumulative_state_root_gas.saturating_add(tx_sr_gas);
let total = self.cumulative_uncompressed_bytes.saturating_add(tx.uncompressed_size);

// gas limit check — plain + still here:
if self.cumulative_gas_used + tx.gas_limit > limits.block_gas_limit {
```

In a release build, if `cumulative_gas_used + tx.gas_limit` overflows `u64`, the wrapped result is a small number. The comparison `small_value > block_gas_limit` is then **false**, so the transaction passes the gas limit check when it shouldn't. In a debug build the same overflow panics, crashing the builder task.

## The fix

One-word change: `+` → `saturating_add`.

```rust
// after
if self.cumulative_gas_used.saturating_add(tx.gas_limit) > limits.block_gas_limit {
```

Saturating addition caps the sum at `u64::MAX`, so an overflow-inducing pair correctly triggers the `>` check instead of bypassing it.

## Test added

`test_gas_limit_check_uses_saturating_add` constructs a `(cumulative_gas_used, tx.gas_limit)` pair that would overflow with plain addition and verifies it is correctly rejected rather than passing through.
