### PR TITLE
feat(prover-service): store protocol proof result payloads

### DIFF
--- a/crates/proof/prover-service/db/migrations/012_add_generic_proof_results.sql
+++ b/crates/proof/prover-service/db/migrations/012_add_generic_proof_results.sql
@@ -1,0 +1,52 @@
+-- Migration 012: Store protocol-native proof results.
+--
+-- `result_payload` is the canonical requester/worker API result shape. The
+-- legacy STARK/SNARK receipt columns remain populated during the compatibility
+-- period for existing ZK service paths.
+ALTER TABLE proof_requests ADD COLUMN IF NOT EXISTS result_payload JSONB;
+ALTER TABLE proof_requests ADD COLUMN IF NOT EXISTS submitted_by_worker_id TEXT;
+ALTER TABLE proof_requests ADD COLUMN IF NOT EXISTS submitted_lock_id TEXT;
+
+-- Preserve historical updated_at values while backfilling protocol results.
+ALTER TABLE proof_requests DISABLE TRIGGER update_proof_requests_updated_at;
+
+UPDATE proof_requests
+SET result_payload = CASE
+    WHEN COALESCE(
+        api_proof_type,
+        CASE proof_type
+            WHEN 'op_succinct_sp1_cluster_snark_groth16' THEN 'snark_groth16'
+            ELSE 'compressed'
+        END
+    ) = 'snark_groth16' AND snark_receipt IS NOT NULL THEN jsonb_build_object(
+        'proof_type', 'snark_groth16',
+        'payload', jsonb_build_object(
+            'proof', jsonb_build_object(
+                'zk_vm', COALESCE(zk_vm, 'sp1'),
+                'proof', concat('0x', encode(snark_receipt, 'hex'))
+            )
+        )
+    )
+    WHEN COALESCE(
+        api_proof_type,
+        CASE proof_type
+            WHEN 'op_succinct_sp1_cluster_snark_groth16' THEN 'snark_groth16'
+            ELSE 'compressed'
+        END
+    ) = 'compressed' AND stark_receipt IS NOT NULL THEN jsonb_build_object(
+        'proof_type', 'compressed',
+        'payload', jsonb_build_object(
+            'zk_vm', COALESCE(zk_vm, 'sp1'),
+            'proof', concat('0x', encode(stark_receipt, 'hex'))
+        )
+    )
+    ELSE result_payload
+END
+WHERE result_payload IS NULL
+  AND (stark_receipt IS NOT NULL OR snark_receipt IS NOT NULL);
+
+ALTER TABLE proof_requests ENABLE TRIGGER update_proof_requests_updated_at;
+
+COMMENT ON COLUMN proof_requests.result_payload IS 'Protocol ProofResult payload serialized as JSONB.';
+COMMENT ON COLUMN proof_requests.submitted_by_worker_id IS 'Worker id that submitted result_payload, when completed through the worker API.';
+COMMENT ON COLUMN proof_requests.submitted_lock_id IS 'Worker lock token that submitted result_payload, when completed through the worker API.';

--- a/crates/proof/prover-service/db/migrations/012_add_generic_proof_results.sql
+++ b/crates/proof/prover-service/db/migrations/012_add_generic_proof_results.sql
@@ -8,6 +8,8 @@ ALTER TABLE proof_requests ADD COLUMN IF NOT EXISTS submitted_by_worker_id TEXT;
 ALTER TABLE proof_requests ADD COLUMN IF NOT EXISTS submitted_lock_id TEXT;
 
 -- Preserve historical updated_at values while backfilling protocol results.
+BEGIN;
+
 ALTER TABLE proof_requests DISABLE TRIGGER update_proof_requests_updated_at;
 
 UPDATE proof_requests
@@ -46,6 +48,8 @@ WHERE result_payload IS NULL
   AND (stark_receipt IS NOT NULL OR snark_receipt IS NOT NULL);
 
 ALTER TABLE proof_requests ENABLE TRIGGER update_proof_requests_updated_at;
+
+COMMIT;
 
 COMMENT ON COLUMN proof_requests.result_payload IS 'Protocol ProofResult payload serialized as JSONB.';
 COMMENT ON COLUMN proof_requests.submitted_by_worker_id IS 'Worker id that submitted result_payload, when completed through the worker API.';

--- a/crates/proof/prover-service/db/src/lib.rs
+++ b/crates/proof/prover-service/db/src/lib.rs
@@ -5,12 +5,12 @@ pub use config::DatabaseConfig;
 
 mod models;
 pub use models::{
-    ApiProofType, CreateOutboxEntry, CreateProofRequest, CreateProofRequestError,
-    CreateProofRequestOutcome, CreateProofRequestValidationError, CreateProofSession,
-    DerivedProofRequestFields, MarkOutboxError, MarkOutboxProcessed, OutboxEntry, ProofRequest,
-    ProofRequestListItem, ProofRequestPage, ProofSession, ProofStatus, ProofType, RetryOutcome,
-    SessionStatus, SessionType, TeeKind, UpdateProofSession, UpdateReceipt, ZkVmKind,
-    canonical_session_id,
+    ApiProofType, CompleteProofResult, CreateOutboxEntry, CreateProofRequest,
+    CreateProofRequestError, CreateProofRequestOutcome, CreateProofRequestValidationError,
+    CreateProofSession, DerivedProofRequestFields, MarkOutboxError, MarkOutboxProcessed,
+    OutboxEntry, ProofRequest, ProofRequestListItem, ProofRequestPage, ProofSession, ProofStatus,
+    ProofType, RetryOutcome, SessionStatus, SessionType, TeeKind, UpdateProofSession,
+    UpdateReceipt, ZkVmKind, canonical_session_id,
 };
 
 mod repo;

--- a/crates/proof/prover-service/db/src/models.rs
+++ b/crates/proof/prover-service/db/src/models.rs
@@ -2,7 +2,7 @@ use std::convert::TryFrom;
 
 use base_prover_service_protocol::{
     ProofRequest as ProtocolProofRequest, ProofRequestKind as ProtocolProofRequestKind,
-    TeeKind as ProtocolTeeKind, ZkVm as ProtocolZkVm,
+    ProofResult as ProtocolProofResult, TeeKind as ProtocolTeeKind, ZkVm as ProtocolZkVm,
 };
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
@@ -473,6 +473,12 @@ pub struct ProofRequest {
     pub stark_receipt: Option<Vec<u8>>,
     /// Raw SNARK receipt bytes, if available.
     pub snark_receipt: Option<Vec<u8>>,
+    /// Protocol-level proof result payload, if available.
+    pub result_payload: Option<serde_json::Value>,
+    /// Worker id that submitted the result, if completed through the worker API.
+    pub submitted_by_worker_id: Option<String>,
+    /// Worker lock token that submitted the result, if completed through the worker API.
+    pub submitted_lock_id: Option<String>,
     /// Current proof status.
     pub status: ProofStatus,
     /// Error message if the proof failed.
@@ -830,6 +836,21 @@ pub struct UpdateReceipt {
     /// New proof status.
     pub status: ProofStatus,
     /// Error message, if the proof failed.
+    pub error_message: Option<String>,
+}
+
+/// Parameters for completing a proof request with a protocol-native result payload.
+#[derive(Debug, Clone)]
+pub struct CompleteProofResult {
+    /// Proof request identifier.
+    pub id: Uuid,
+    /// Protocol result to store in `result_payload`.
+    pub result: ProtocolProofResult,
+    /// Worker id that submitted the proof, if completed through the worker API.
+    pub submitted_by_worker_id: Option<String>,
+    /// Worker lock token that submitted the proof, if completed through the worker API.
+    pub submitted_lock_id: Option<String>,
+    /// Error message to store with the completion. Usually `None`.
     pub error_message: Option<String>,
 }
 

--- a/crates/proof/prover-service/db/src/repo.rs
+++ b/crates/proof/prover-service/db/src/repo.rs
@@ -638,9 +638,12 @@ impl ProofRequestRepo {
             SET status = $1,
                 retry_count = retry_count + 1,
                 error_message = NULL,
+                stark_receipt = NULL,
+                snark_receipt = NULL,
                 result_payload = NULL,
                 submitted_by_worker_id = NULL,
-                submitted_lock_id = NULL
+                submitted_lock_id = NULL,
+                completed_at = NULL
             WHERE id = $2
             "#,
         )

--- a/crates/proof/prover-service/db/src/repo.rs
+++ b/crates/proof/prover-service/db/src/repo.rs
@@ -1,12 +1,16 @@
+use base_prover_service_protocol::{
+    ProofResult as ProtocolProofResult, SnarkGroth16ProofResult, ZkProofResult, ZkVm,
+};
 use sqlx::{PgPool, Result, Row};
 use uuid::Uuid;
 
 use crate::{
-    ApiProofType, CreateOutboxEntry, CreateProofRequest, CreateProofRequestError,
-    CreateProofRequestOutcome, CreateProofRequestValidationError, CreateProofSession,
-    MarkOutboxError, MarkOutboxProcessed, OutboxEntry, ProofRequest, ProofRequestListItem,
-    ProofRequestPage, ProofSession, ProofStatus, ProofType, RetryOutcome, SessionStatus,
-    SessionType, TeeKind, UpdateProofSession, UpdateReceipt, ZkVmKind, canonical_session_id,
+    ApiProofType, CompleteProofResult, CreateOutboxEntry, CreateProofRequest,
+    CreateProofRequestError, CreateProofRequestOutcome, CreateProofRequestValidationError,
+    CreateProofSession, MarkOutboxError, MarkOutboxProcessed, OutboxEntry, ProofRequest,
+    ProofRequestListItem, ProofRequestPage, ProofSession, ProofStatus, ProofType, RetryOutcome,
+    SessionStatus, SessionType, TeeKind, UpdateProofSession, UpdateReceipt, ZkVmKind,
+    canonical_session_id,
 };
 
 /// Repository for proof request database operations
@@ -226,6 +230,9 @@ impl ProofRequestRepo {
                         error_message = NULL,
                         stark_receipt = NULL,
                         snark_receipt = NULL,
+                        result_payload = NULL,
+                        submitted_by_worker_id = NULL,
+                        submitted_lock_id = NULL,
                         completed_at = NULL
                     WHERE id = $2
                     "#,
@@ -260,7 +267,8 @@ impl ProofRequestRepo {
                 id, COALESCE(session_id, id::text) AS session_id,
                 request_payload, api_proof_type, zk_vm, tee_kind,
                 start_block_number, number_of_blocks_to_prove, sequence_window, proof_type,
-                stark_receipt, snark_receipt,
+                stark_receipt, snark_receipt, result_payload,
+                submitted_by_worker_id, submitted_lock_id,
                 status, error_message,
                 prover_address, l1_head, intermediate_root_interval,
                 created_at, updated_at, completed_at, retry_count
@@ -285,7 +293,8 @@ impl ProofRequestRepo {
                 id, COALESCE(session_id, id::text) AS session_id,
                 request_payload, api_proof_type, zk_vm, tee_kind,
                 start_block_number, number_of_blocks_to_prove, sequence_window, proof_type,
-                stark_receipt, snark_receipt,
+                stark_receipt, snark_receipt, result_payload,
+                submitted_by_worker_id, submitted_lock_id,
                 status, error_message,
                 prover_address, l1_head, intermediate_root_interval,
                 created_at, updated_at, completed_at, retry_count
@@ -471,19 +480,61 @@ impl ProofRequestRepo {
             update.status,
         );
 
+        let result_payload = result_payload_from_receipt_update(&update)?;
+
         let result = sqlx::query(
             r#"
             UPDATE proof_requests
             SET stark_receipt = COALESCE($1, stark_receipt),
                 snark_receipt = COALESCE($2, snark_receipt),
-                status = $3,
-                error_message = $4,
+                result_payload = COALESCE($3, result_payload),
+                status = $4,
+                error_message = $5,
                 completed_at = NOW()
-            WHERE id = $5 AND status = $6
+            WHERE id = $6 AND status = $7
             "#,
         )
         .bind(&update.stark_receipt)
         .bind(&update.snark_receipt)
+        .bind(&result_payload)
+        .bind(ProofStatus::Succeeded.as_str())
+        .bind(&update.error_message)
+        .bind(update.id)
+        .bind(ProofStatus::Running.as_str())
+        .execute(&self.pool)
+        .await?;
+
+        Ok(result.rows_affected() > 0)
+    }
+
+    /// Transition proof request RUNNING → SUCCEEDED with a protocol-native result payload.
+    ///
+    /// ZK results are also mirrored into `stark_receipt` or `snark_receipt` for legacy
+    /// compatibility. TEE results are stored only in `result_payload`.
+    pub async fn complete_running_proof_result(&self, update: CompleteProofResult) -> Result<bool> {
+        let result_payload =
+            serde_json::to_value(&update.result).map_err(|e| sqlx::Error::Encode(Box::new(e)))?;
+        let (stark_receipt, snark_receipt) = compatibility_receipts_for_result(&update.result);
+
+        let result = sqlx::query(
+            r#"
+            UPDATE proof_requests
+            SET result_payload = $1,
+                submitted_by_worker_id = $2,
+                submitted_lock_id = $3,
+                stark_receipt = COALESCE($4, stark_receipt),
+                snark_receipt = COALESCE($5, snark_receipt),
+                status = $6,
+                error_message = $7,
+                completed_at = NOW()
+            WHERE id = $8 AND status = $9
+            "#,
+        )
+        .bind(&result_payload)
+        .bind(&update.submitted_by_worker_id)
+        .bind(&update.submitted_lock_id)
+        .bind(&stark_receipt)
+        .bind(&snark_receipt)
         .bind(ProofStatus::Succeeded.as_str())
         .bind(&update.error_message)
         .bind(update.id)
@@ -586,7 +637,10 @@ impl ProofRequestRepo {
             UPDATE proof_requests
             SET status = $1,
                 retry_count = retry_count + 1,
-                error_message = NULL
+                error_message = NULL,
+                result_payload = NULL,
+                submitted_by_worker_id = NULL,
+                submitted_lock_id = NULL
             WHERE id = $2
             "#,
         )
@@ -841,6 +895,7 @@ impl ProofRequestRepo {
                    request_payload, api_proof_type, zk_vm, tee_kind,
                    start_block_number, number_of_blocks_to_prove,
                    sequence_window, proof_type, stark_receipt, snark_receipt,
+                   result_payload, submitted_by_worker_id, submitted_lock_id,
                    status, error_message, prover_address, l1_head,
                    intermediate_root_interval,
                    created_at, updated_at, completed_at, retry_count
@@ -868,6 +923,7 @@ impl ProofRequestRepo {
                 pr.request_payload, pr.api_proof_type, pr.zk_vm,
                 pr.tee_kind, pr.start_block_number, pr.number_of_blocks_to_prove,
                 pr.sequence_window, pr.proof_type, pr.stark_receipt, pr.snark_receipt,
+                pr.result_payload, pr.submitted_by_worker_id, pr.submitted_lock_id,
                 pr.status, pr.error_message, pr.prover_address, pr.l1_head,
                 pr.intermediate_root_interval,
                 pr.created_at, pr.updated_at, pr.completed_at, pr.retry_count
@@ -1015,6 +1071,7 @@ impl ProofRequestRepo {
         update_receipt: UpdateReceipt,
     ) -> Result<bool> {
         let mut tx = self.pool.begin().await?;
+        let result_payload = result_payload_from_receipt_update(&update_receipt)?;
 
         let result = sqlx::query(
             r#"
@@ -1022,15 +1079,17 @@ impl ProofRequestRepo {
             SET
                 stark_receipt = COALESCE($1, stark_receipt),
                 snark_receipt = COALESCE($2, snark_receipt),
-                status = $3,
-                error_message = $4,
-                completed_at = CASE WHEN $3 IN ('SUCCEEDED', 'FAILED') THEN NOW() ELSE completed_at END
-            WHERE id = $5
+                result_payload = COALESCE($3, result_payload),
+                status = $4,
+                error_message = $5,
+                completed_at = CASE WHEN $4 IN ('SUCCEEDED', 'FAILED') THEN NOW() ELSE completed_at END
+            WHERE id = $6
               AND status = 'RUNNING'
             "#,
         )
         .bind(&update_receipt.stark_receipt)
         .bind(&update_receipt.snark_receipt)
+        .bind(&result_payload)
         .bind(update_receipt.status.as_str())
         .bind(&update_receipt.error_message)
         .bind(update_receipt.id)
@@ -1073,7 +1132,8 @@ impl ProofRequestRepo {
                     id, COALESCE(session_id, id::text) AS session_id,
                     request_payload, api_proof_type, zk_vm, tee_kind,
                     start_block_number, number_of_blocks_to_prove, sequence_window, proof_type,
-                    stark_receipt, snark_receipt,
+                    stark_receipt, snark_receipt, result_payload,
+                    submitted_by_worker_id, submitted_lock_id,
                     status, error_message,
                     prover_address, l1_head, intermediate_root_interval,
                     created_at, updated_at, completed_at, retry_count
@@ -1094,7 +1154,8 @@ impl ProofRequestRepo {
                     id, COALESCE(session_id, id::text) AS session_id,
                     request_payload, api_proof_type, zk_vm, tee_kind,
                     start_block_number, number_of_blocks_to_prove, sequence_window, proof_type,
-                    stark_receipt, snark_receipt,
+                    stark_receipt, snark_receipt, result_payload,
+                    submitted_by_worker_id, submitted_lock_id,
                     status, error_message,
                     prover_address, l1_head, intermediate_root_interval,
                     created_at, updated_at, completed_at, retry_count
@@ -1428,6 +1489,43 @@ const fn validate_backend_proof_type(
     }
 }
 
+fn result_payload_from_receipt_update(update: &UpdateReceipt) -> Result<Option<serde_json::Value>> {
+    if update.status != ProofStatus::Succeeded {
+        return Ok(None);
+    }
+
+    let Some(result) = proof_result_from_receipt_update(update) else {
+        return Ok(None);
+    };
+
+    serde_json::to_value(result).map(Some).map_err(|e| sqlx::Error::Encode(Box::new(e)))
+}
+
+fn proof_result_from_receipt_update(update: &UpdateReceipt) -> Option<ProtocolProofResult> {
+    if let Some(snark_receipt) = &update.snark_receipt {
+        return Some(ProtocolProofResult::SnarkGroth16(SnarkGroth16ProofResult {
+            proof: ZkProofResult { zk_vm: ZkVm::Sp1, proof: snark_receipt.clone().into() },
+        }));
+    }
+
+    update.stark_receipt.as_ref().map(|stark_receipt| {
+        ProtocolProofResult::Compressed(ZkProofResult {
+            zk_vm: ZkVm::Sp1,
+            proof: stark_receipt.clone().into(),
+        })
+    })
+}
+
+fn compatibility_receipts_for_result(
+    result: &ProtocolProofResult,
+) -> (Option<Vec<u8>>, Option<Vec<u8>>) {
+    match result {
+        ProtocolProofResult::Compressed(proof) => (Some(proof.proof.to_vec()), None),
+        ProtocolProofResult::SnarkGroth16(proof) => (None, Some(proof.proof.proof.to_vec())),
+        ProtocolProofResult::Tee(_) => (None, None),
+    }
+}
+
 const ZERO_ADDRESS: &str = "0x0000000000000000000000000000000000000000";
 const ZERO_HASH: &str = "0x0000000000000000000000000000000000000000000000000000000000000000";
 
@@ -1599,6 +1697,9 @@ fn row_to_proof_request(row: &sqlx::postgres::PgRow) -> Result<ProofRequest> {
         proof_type,
         stark_receipt: row.get("stark_receipt"),
         snark_receipt: row.get("snark_receipt"),
+        result_payload: row.get("result_payload"),
+        submitted_by_worker_id: row.get("submitted_by_worker_id"),
+        submitted_lock_id: row.get("submitted_lock_id"),
         status,
         error_message: row.get("error_message"),
         prover_address,
@@ -1921,6 +2022,72 @@ mod tests {
         assert_eq!(
             err,
             CreateProofRequestValidationError::ValueOutOfRange { field: "start_block_number" }
+        );
+    }
+
+    #[test]
+    fn receipt_update_builds_compressed_result_payload() {
+        let update = UpdateReceipt {
+            id: Uuid::new_v4(),
+            stark_receipt: Some(vec![1, 2, 3]),
+            snark_receipt: None,
+            status: ProofStatus::Succeeded,
+            error_message: None,
+        };
+
+        let payload = result_payload_from_receipt_update(&update)
+            .expect("payload should serialize")
+            .expect("stark receipt should produce payload");
+        let result: ProtocolProofResult =
+            serde_json::from_value(payload).expect("payload should deserialize");
+
+        assert_eq!(
+            result,
+            ProtocolProofResult::Compressed(ZkProofResult {
+                zk_vm: ZkVm::Sp1,
+                proof: vec![1, 2, 3].into()
+            })
+        );
+    }
+
+    #[test]
+    fn receipt_update_skips_non_terminal_result_payload() {
+        let update = UpdateReceipt {
+            id: Uuid::new_v4(),
+            stark_receipt: Some(vec![1, 2, 3]),
+            snark_receipt: None,
+            status: ProofStatus::Running,
+            error_message: None,
+        };
+
+        assert!(
+            result_payload_from_receipt_update(&update)
+                .expect("payload check should not fail")
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn receipt_update_prefers_snark_result_payload() {
+        let update = UpdateReceipt {
+            id: Uuid::new_v4(),
+            stark_receipt: Some(vec![1, 2, 3]),
+            snark_receipt: Some(vec![4, 5, 6]),
+            status: ProofStatus::Succeeded,
+            error_message: None,
+        };
+
+        let payload = result_payload_from_receipt_update(&update)
+            .expect("payload should serialize")
+            .expect("snark receipt should produce payload");
+        let result: ProtocolProofResult =
+            serde_json::from_value(payload).expect("payload should deserialize");
+
+        assert_eq!(
+            result,
+            ProtocolProofResult::SnarkGroth16(SnarkGroth16ProofResult {
+                proof: ZkProofResult { zk_vm: ZkVm::Sp1, proof: vec![4, 5, 6].into() }
+            })
         );
     }
 }

--- a/crates/proof/prover-service/db/src/repo.rs
+++ b/crates/proof/prover-service/db/src/repo.rs
@@ -1502,6 +1502,8 @@ fn result_payload_from_receipt_update(update: &UpdateReceipt) -> Result<Option<s
 }
 
 fn proof_result_from_receipt_update(update: &UpdateReceipt) -> Option<ProtocolProofResult> {
+    // `UpdateReceipt` is the legacy OP Succinct receipt path, which currently only
+    // stores SP1 receipts. Protocol-native completions carry their own ZK VM.
     if let Some(snark_receipt) = &update.snark_receipt {
         return Some(ProtocolProofResult::SnarkGroth16(SnarkGroth16ProofResult {
             proof: ZkProofResult { zk_vm: ZkVm::Sp1, proof: snark_receipt.clone().into() },

--- a/crates/proof/prover-service/db/tests/postgres_integration.rs
+++ b/crates/proof/prover-service/db/tests/postgres_integration.rs
@@ -790,10 +790,31 @@ async fn test_complete_session_and_update_receipt_skips_non_running() {
 #[ignore = "requires a running Postgres with the prover schema (set DATABASE_URL); run with `cargo nextest run --run-ignored all -p base-prover-service-db --test postgres_integration --test-threads=1`"]
 async fn test_retry_or_fail_stuck_request_retries() {
     let pool = test_pool().await;
-    let repo = test_repo(pool);
+    let repo = test_repo(pool.clone());
 
     let id = repo.create(compressed_request()).await.unwrap();
     repo.atomic_claim_task(id).await.unwrap();
+    sqlx::query(
+        r#"
+        UPDATE proof_requests
+        SET stark_receipt = $1,
+            snark_receipt = $2,
+            result_payload = $3,
+            submitted_by_worker_id = $4,
+            submitted_lock_id = $5,
+            completed_at = NOW()
+        WHERE id = $6
+        "#,
+    )
+    .bind(vec![0x01, 0x02])
+    .bind(vec![0x03, 0x04])
+    .bind(serde_json::json!({"proof_type": "compressed"}))
+    .bind("stale-worker")
+    .bind("stale-lock")
+    .bind(id)
+    .execute(&pool)
+    .await
+    .unwrap();
 
     let outcome = repo.retry_or_fail_stuck_request(id, 3, "stuck in PENDING").await.unwrap();
     assert_eq!(outcome, RetryOutcome::Retried);
@@ -802,6 +823,12 @@ async fn test_retry_or_fail_stuck_request_retries() {
     assert_eq!(req.status, ProofStatus::Created);
     assert_eq!(req.retry_count, 1);
     assert!(req.error_message.is_none());
+    assert!(req.stark_receipt.is_none());
+    assert!(req.snark_receipt.is_none());
+    assert!(req.result_payload.is_none());
+    assert!(req.submitted_by_worker_id.is_none());
+    assert!(req.submitted_lock_id.is_none());
+    assert!(req.completed_at.is_none());
 }
 
 #[tokio::test]

--- a/crates/proof/prover-service/db/tests/postgres_integration.rs
+++ b/crates/proof/prover-service/db/tests/postgres_integration.rs
@@ -23,7 +23,8 @@ use base_prover_service_db::{
 };
 use base_prover_service_protocol::{
     ProofRequest as ProtocolProofRequest, ProofRequestKind as ProtocolProofRequestKind,
-    SnarkGroth16ProofRequest, TeeKind as ProtocolTeeKind, TeeProofRequest, ZkProofRequest, ZkVm,
+    ProofResult as ProtocolProofResult, SnarkGroth16ProofRequest, SnarkGroth16ProofResult,
+    TeeKind as ProtocolTeeKind, TeeProofRequest, ZkProofRequest, ZkProofResult, ZkVm,
 };
 use sqlx::{PgPool, postgres::PgPoolOptions};
 use uuid::Uuid;
@@ -1301,6 +1302,7 @@ async fn test_full_snark_pipeline() {
     assert_eq!(req.status, ProofStatus::Running);
     assert_eq!(req.stark_receipt.as_deref(), Some(stark_receipt.as_slice()));
     assert!(req.snark_receipt.is_none());
+    assert!(req.result_payload.is_none());
 
     // 5. Submit SNARK session
     let snark_backend_id = format!("snark-pipeline-{}", Uuid::new_v4());
@@ -1333,6 +1335,15 @@ async fn test_full_snark_pipeline() {
     assert_eq!(req.status, ProofStatus::Succeeded);
     assert_eq!(req.stark_receipt.as_deref(), Some(stark_receipt.as_slice())); // preserved
     assert_eq!(req.snark_receipt.as_deref(), Some(snark_receipt.as_slice()));
+    let result_payload = req.result_payload.expect("SNARK result payload should be stored");
+    let result: ProtocolProofResult =
+        serde_json::from_value(result_payload).expect("SNARK result payload should deserialize");
+    assert_eq!(
+        result,
+        ProtocolProofResult::SnarkGroth16(SnarkGroth16ProofResult {
+            proof: ZkProofResult { zk_vm: ZkVm::Sp1, proof: snark_receipt.into() }
+        })
+    );
     assert!(req.completed_at.is_some());
 
     let sessions = repo.get_sessions_for_request(req_id).await.unwrap();

--- a/crates/proof/prover-service/src/server/get_proof.rs
+++ b/crates/proof/prover-service/src/server/get_proof.rs
@@ -54,6 +54,12 @@ fn proof_result_for_request(proof_req: &ProofRequest) -> RpcResult<ProofResult> 
     }
 }
 
+fn should_use_dry_run_result(proof_req: &ProofRequest) -> bool {
+    proof_req.result_payload.is_none()
+        && proof_req.stark_receipt.is_none()
+        && proof_req.snark_receipt.is_none()
+}
+
 impl ProverServiceServer {
     /// Returns current proof status and proof bytes for the public `session_id`.
     pub async fn get_proof_impl(&self, request: GetProofRequest) -> RpcResult<GetProofResponse> {
@@ -79,10 +85,7 @@ impl ProverServiceServer {
     }
 
     async fn succeeded_result(&self, proof_req: &ProofRequest) -> RpcResult<Option<ProofResult>> {
-        if proof_req.stark_receipt.is_none()
-            && proof_req.snark_receipt.is_none()
-            && self.request_is_dry_run(proof_req.id).await?
-        {
+        if should_use_dry_run_result(proof_req) && self.request_is_dry_run(proof_req.id).await? {
             return Ok(Some(ProofResult::Compressed(ZkProofResult {
                 zk_vm: ZkVm::Sp1,
                 proof: Vec::new().into(),
@@ -300,6 +303,19 @@ mod tests {
 
         let result = proof_result_for_request(&req).unwrap();
         assert!(matches!(result, ProofResult::Tee(_)));
+    }
+
+    #[test]
+    fn dry_run_result_is_not_used_when_result_payload_exists() {
+        let stored_result = ProofResult::Compressed(ZkProofResult {
+            zk_vm: ZkVm::Sp1,
+            proof: vec![0xAA, 0xBB].into(),
+        });
+        let mut req = make_proof_request(ProofType::OpSuccinctSp1ClusterCompressed, None, None);
+        req.result_payload =
+            Some(serde_json::to_value(&stored_result).expect("proof result should serialize"));
+
+        assert!(!should_use_dry_run_result(&req));
     }
 
     #[test]

--- a/crates/proof/prover-service/src/server/get_proof.rs
+++ b/crates/proof/prover-service/src/server/get_proof.rs
@@ -24,6 +24,15 @@ fn is_dry_run_metadata(metadata: &serde_json::Value) -> bool {
 }
 
 fn proof_result_for_request(proof_req: &ProofRequest) -> RpcResult<ProofResult> {
+    if let Some(result_payload) = &proof_req.result_payload {
+        return serde_json::from_value(result_payload.clone()).map_err(|e| {
+            internal(format!(
+                "stored proof result payload for session_id {} is invalid: {e}",
+                proof_req.session_id
+            ))
+        });
+    }
+
     match proof_req.proof_type {
         Some(DbProofType::OpSuccinctSp1ClusterCompressed) => {
             let proof = proof_req
@@ -184,6 +193,9 @@ mod tests {
             proof_type: Some(proof_type),
             stark_receipt,
             snark_receipt,
+            result_payload: None,
+            submitted_by_worker_id: None,
+            submitted_lock_id: None,
             status: DbProofStatus::Succeeded,
             error_message: None,
             prover_address: None,
@@ -244,6 +256,50 @@ mod tests {
                 proof: ZkProofResult { zk_vm: ZkVm::Sp1, proof: snark_bytes.into() },
             })
         );
+    }
+
+    #[test]
+    fn proof_result_prefers_stored_result_payload() {
+        let stored_result = ProofResult::Compressed(ZkProofResult {
+            zk_vm: ZkVm::Sp1,
+            proof: vec![0xAA, 0xBB].into(),
+        });
+        let mut req = make_proof_request(
+            ProofType::OpSuccinctSp1ClusterCompressed,
+            Some(vec![0xDE, 0xAD]),
+            None,
+        );
+        req.result_payload =
+            Some(serde_json::to_value(&stored_result).expect("proof result should serialize"));
+
+        let result = proof_result_for_request(&req).unwrap();
+        assert_eq!(result, stored_result);
+    }
+
+    #[test]
+    fn proof_result_for_tee_returns_stored_result_payload() {
+        let stored_result = serde_json::json!({
+            "proof_type": "tee",
+            "payload": {
+                "aggregate_proposal": {
+                    "output_root": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                    "signature": "0x",
+                    "l1_origin_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                    "l1_origin_number": 0,
+                    "l2_block_number": 0,
+                    "prev_output_root": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                    "config_hash": "0x0000000000000000000000000000000000000000000000000000000000000000"
+                },
+                "proposals": [],
+                "tee_kind": "aws_nitro"
+            }
+        });
+        let mut req = make_proof_request(ProofType::OpSuccinctSp1ClusterCompressed, None, None);
+        req.proof_type = None;
+        req.result_payload = Some(stored_result);
+
+        let result = proof_result_for_request(&req).unwrap();
+        assert!(matches!(result, ProofResult::Tee(_)));
     }
 
     #[test]

--- a/crates/proof/prover-service/src/server/get_proof.rs
+++ b/crates/proof/prover-service/src/server/get_proof.rs
@@ -54,7 +54,7 @@ fn proof_result_for_request(proof_req: &ProofRequest) -> RpcResult<ProofResult> 
     }
 }
 
-fn should_use_dry_run_result(proof_req: &ProofRequest) -> bool {
+const fn should_use_dry_run_result(proof_req: &ProofRequest) -> bool {
     proof_req.result_payload.is_none()
         && proof_req.stark_receipt.is_none()
         && proof_req.snark_receipt.is_none()


### PR DESCRIPTION
### What changed? Why?

- Add a protocol-native `result_payload` JSONB column for proof requests, plus worker submission metadata columns.
- Backfill stored ZK receipts into `ProofResult` payload JSON while preserving legacy STARK/SNARK receipt columns for compatibility.
- Store and return protocol-native proof results from the prover-service DB/server path, including TEE results that do not map to legacy receipt columns.

### Notes to reviewers

- Legacy receipt columns remain populated for ZK compatibility; `result_payload` is preferred when present.
- The migration disables the proof request `updated_at` trigger during backfill so historical rows do not receive artificial update times.

### How has it been tested?

- `cargo fmt --check`
- `cargo test -p base-prover-service-db receipt_update --lib`
- `cargo test -p base-prover-service proof_result --lib`