### PR TITLE
test(devnet): Increase Beryl Devnet Coverage

### DIFF
--- a/etc/systems/src/b20.rs
+++ b/etc/systems/src/b20.rs
@@ -14,7 +14,7 @@ use alloy_sol_types::{SolCall, SolValue};
 use base_common_network::Base;
 use base_common_precompiles::{
     ActivationRegistryStorage, B20FactoryStorage, B20PausableFeature, B20Variant,
-    IActivationRegistry, IB20, IB20Factory,
+    IActivationRegistry, IB20, IB20Factory, IB20Stablecoin,
 };
 use base_common_rpc_types::{BaseTransactionReceipt, BaseTransactionRequest};
 use eyre::{ContextCompat, Result, WrapErr, ensure};
@@ -23,8 +23,8 @@ use tokio::time::{sleep, timeout};
 /// Creation settings used by the system test B-20 factory client.
 #[derive(Debug, Clone)]
 pub struct B20CreateConfig {
-    /// ABI-level creation params sent to `IB20Factory.createB20`.
-    pub create: IB20Factory::B20AssetCreateParams,
+    /// ABI-encoded creation params sent to `IB20Factory.createB20`.
+    pub encoded_params: Bytes,
     /// Initial supply to mint during the factory init-call window.
     pub initial_supply: U256,
     /// Account receiving the initial supply.
@@ -110,13 +110,41 @@ impl<'a> B20PrecompileClient<'a> {
         initial_supply_recipient: Address,
     ) -> B20CreateConfig {
         B20CreateConfig {
-            create: IB20Factory::B20AssetCreateParams {
+            encoded_params: IB20Factory::B20AssetCreateParams {
                 version: B20Variant::Asset.supported_version(),
                 name: name.to_string(),
                 symbol: symbol.to_string(),
                 initialAdmin: initial_admin,
                 decimals: 6,
-            },
+            }
+            .abi_encode()
+            .into(),
+            initial_supply,
+            initial_supply_recipient,
+            supply_cap: U256::MAX,
+            contract_uri: String::new(),
+        }
+    }
+
+    /// Builds the required B-20 stablecoin params for factory creation.
+    pub fn stablecoin_params(
+        name: &str,
+        symbol: &str,
+        initial_admin: Address,
+        initial_supply: U256,
+        initial_supply_recipient: Address,
+        currency: &str,
+    ) -> B20CreateConfig {
+        B20CreateConfig {
+            encoded_params: IB20Factory::B20StablecoinCreateParams {
+                version: B20Variant::Stablecoin.supported_version(),
+                name: name.to_string(),
+                symbol: symbol.to_string(),
+                initialAdmin: initial_admin,
+                currency: currency.to_string(),
+            }
+            .abi_encode()
+            .into(),
             initial_supply,
             initial_supply_recipient,
             supply_cap: U256::MAX,
@@ -131,6 +159,17 @@ impl<'a> B20PrecompileClient<'a> {
         params: B20CreateConfig,
         salt: B256,
     ) -> Result<Address> {
+        let (token, _) = self.create_token_with_receipt(variant, params, salt).await?;
+        Ok(token)
+    }
+
+    /// Creates a B-20 token through the factory and returns the token address plus receipt.
+    pub async fn create_token_with_receipt(
+        &self,
+        variant: B20Variant,
+        params: B20CreateConfig,
+        salt: B256,
+    ) -> Result<(Address, BaseTransactionReceipt)> {
         let token = self.predict_token_address(variant, salt);
         let mut init_calls = Vec::new();
         if params.initial_supply > U256::ZERO {
@@ -156,11 +195,12 @@ impl<'a> B20PrecompileClient<'a> {
         let call = IB20Factory::createB20Call {
             variant: variant.abi(),
             salt,
-            params: params.create.abi_encode().into(),
+            params: params.encoded_params,
             initCalls: init_calls,
         };
-        self.send_call(B20FactoryStorage::ADDRESS, call, "create B-20 token").await?;
-        Ok(token)
+        let receipt =
+            self.send_call_receipt(B20FactoryStorage::ADDRESS, call, "create B-20 token").await?;
+        Ok((token, receipt))
     }
 
     /// Activates an activation-registry feature.
@@ -366,6 +406,13 @@ impl<'a> B20PrecompileClient<'a> {
             .wrap_err("Failed to decode contractURI")
     }
 
+    /// Reads the stablecoin currency code.
+    pub async fn currency(&self, token: Address) -> Result<String> {
+        let output = self.call(token, IB20Stablecoin::currencyCall {}).await?;
+        IB20Stablecoin::currencyCall::abi_decode_returns(output.as_ref())
+            .wrap_err("Failed to decode currency")
+    }
+
     /// Updates the contract URI.
     pub async fn update_contract_uri(&self, token: Address, new_uri: &str) -> Result<()> {
         self.send_call(
@@ -409,6 +456,15 @@ impl<'a> B20PrecompileClient<'a> {
             .wrap_err("Failed to decode isB20")
     }
 
+    /// Returns true if `token` has been initialized by the B-20 factory.
+    pub async fn is_b20_initialized(&self, token: Address) -> Result<bool> {
+        let output = self
+            .call(B20FactoryStorage::ADDRESS, IB20Factory::isB20InitializedCall { token })
+            .await?;
+        IB20Factory::isB20InitializedCall::abi_decode_returns(output.as_ref())
+            .wrap_err("Failed to decode isB20Initialized")
+    }
+
     /// Calls `getB20Address` on the factory precompile via RPC.
     pub async fn predict_token_address_rpc(
         &self,
@@ -432,6 +488,19 @@ impl<'a> B20PrecompileClient<'a> {
         C: SolCall,
     {
         Ok(self.send_and_wait(to, Bytes::from(call.abi_encode()), label).await?.status())
+    }
+
+    /// Sends a transaction and returns the receipt without requiring success.
+    pub async fn send_call_unchecked_receipt<C>(
+        &self,
+        to: Address,
+        call: C,
+        label: &'static str,
+    ) -> Result<BaseTransactionReceipt>
+    where
+        C: SolCall,
+    {
+        self.send_and_wait(to, Bytes::from(call.abi_encode()), label).await
     }
 
     /// Executes an `eth_call` against `to`.

--- a/etc/systems/src/l2/in_process_consensus.rs
+++ b/etc/systems/src/l2/in_process_consensus.rs
@@ -26,9 +26,16 @@ use base_consensus_rpc::{AdminApiClient, BaseP2PApiClient, RollupNodeApiClient, 
 use base_consensus_sources::BlockSigner;
 use eyre::{Result, WrapErr};
 use jsonrpsee::http_client::HttpClientBuilder;
-use tokio::task::JoinHandle;
+use tempfile::TempDir;
+use tokio::{
+    task::JoinHandle,
+    time::{sleep, timeout},
+};
 use tracing::info;
 use url::Url;
+
+const SEQUENCER_UNSAFE_HEAD_TIMEOUT: Duration = Duration::from_secs(60);
+const SEQUENCER_UNSAFE_HEAD_POLL_INTERVAL: Duration = Duration::from_millis(250);
 
 /// Configuration for starting an in-process consensus node.
 #[derive(Debug)]
@@ -72,6 +79,7 @@ pub struct InProcessConsensus {
     rpc_addr: SocketAddr,
     p2p_tcp_port: u16,
     peer_id: String,
+    _checkpoint_dir: TempDir,
     _handle: JoinHandle<()>,
 }
 
@@ -167,6 +175,12 @@ impl InProcessConsensus {
             max_concurrent_requests: NonZeroUsize::new(1024).expect("nonzero"),
         };
 
+        let checkpoint_dir = tempfile::tempdir()
+            .wrap_err("Failed to create temporary checkpoint database directory")?;
+        let checkpoint_path = checkpoint_dir.path().join("checkpoint.redb");
+
+        // In-process devnets can run multiple consensus nodes with the same chain ID.
+        // Give each node isolated checkpoint storage so redb writer locks do not collide.
         let mut builder = RollupNodeBuilder::new(
             rollup_config,
             l1_config,
@@ -174,7 +188,8 @@ impl InProcessConsensus {
             engine_config,
             net_config,
             Some(rpc_config),
-        );
+        )
+        .with_checkpoint_path(checkpoint_path);
 
         if config.mode == NodeMode::Sequencer {
             builder = builder.with_sequencer_config(SequencerConfig {
@@ -207,7 +222,13 @@ impl InProcessConsensus {
             }
         }
 
-        Ok(Self { rpc_addr, p2p_tcp_port, peer_id, _handle: handle })
+        Ok(Self {
+            rpc_addr,
+            p2p_tcp_port,
+            peer_id,
+            _checkpoint_dir: checkpoint_dir,
+            _handle: handle,
+        })
     }
 
     /// Connects this node to a peer at the given libp2p multiaddr via the `opp2p_connectPeer` RPC.
@@ -228,7 +249,7 @@ impl InProcessConsensus {
                 }
                 Err(e) => {
                     last_err = Some(e);
-                    tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+                    sleep(Duration::from_millis(500)).await;
                 }
             }
         }
@@ -248,19 +269,28 @@ impl InProcessConsensus {
         // The consensus node validates that the provided hash matches the engine's actual unsafe
         // head before activating the sequencer. Poll sync status until the engine is initialized
         // (non-zero unsafe head hash), then pass the real value.
-        let mut unsafe_head = B256::ZERO;
-        for _ in 0..40 {
-            match client.sync_status().await {
-                Ok(status) if status.unsafe_l2.block_info.hash != B256::ZERO => {
-                    unsafe_head = status.unsafe_l2.block_info.hash;
-                    break;
+        let mut last_sync_error = None;
+        let unsafe_head = timeout(SEQUENCER_UNSAFE_HEAD_TIMEOUT, async {
+            loop {
+                match client.sync_status().await {
+                    Ok(status) if status.unsafe_l2.block_info.hash != B256::ZERO => {
+                        return status.unsafe_l2.block_info.hash;
+                    }
+                    Ok(_) => {}
+                    Err(e) => {
+                        last_sync_error = Some(e.to_string());
+                    }
                 }
-                _ => tokio::time::sleep(std::time::Duration::from_millis(250)).await,
+                sleep(SEQUENCER_UNSAFE_HEAD_POLL_INTERVAL).await;
             }
-        }
-        if unsafe_head == B256::ZERO {
-            return Err(eyre::eyre!("Engine unsafe head did not initialize within 10s"));
-        }
+        })
+        .await
+        .map_err(|_| {
+            let suffix = last_sync_error
+                .map(|e| format!("; last sync_status error: {e}"))
+                .unwrap_or_default();
+            eyre::eyre!("Engine unsafe head did not initialize within 60s{suffix}")
+        })?;
 
         client
             .admin_start_sequencer(unsafe_head)
@@ -333,7 +363,7 @@ async fn wait_for_rpc(addr: SocketAddr) -> Result<()> {
             }
             Err(e) => {
                 last_err = Some(e);
-                tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+                sleep(Duration::from_millis(500)).await;
             }
         }
     }

--- a/etc/systems/tests/activation_registry.rs
+++ b/etc/systems/tests/activation_registry.rs
@@ -2,9 +2,11 @@
 
 mod common;
 
+use alloy_primitives::{Address, B256, LogData};
 use alloy_signer_local::PrivateKeySigner;
-use alloy_sol_types::SolCall;
+use alloy_sol_types::{SolCall, SolEvent};
 use base_common_precompiles::{ActivationFeature, ActivationRegistryStorage, IActivationRegistry};
+use base_common_rpc_types::BaseTransactionReceipt;
 use base_system_tests::{ANVIL_ACCOUNT_5, ANVIL_ACCOUNT_6, B20PrecompileClient};
 use eyre::{Result, WrapErr};
 
@@ -54,6 +56,73 @@ async fn test_activation_registry_admin() -> Result<()> {
     Ok(())
 }
 
+/// Admin activate/deactivate transitions update state, emit events, and reject repeated calls.
+#[tokio::test]
+async fn test_activation_registry_admin_lifecycle() -> Result<()> {
+    let (_system, provider) = common::start_beryl_system().await?;
+    let admin = PrivateKeySigner::from_bytes(&ANVIL_ACCOUNT_5.private_key)
+        .wrap_err("Failed to parse system test private key")?;
+    common::wait_for_balance(&provider, admin.address()).await?;
+
+    let client = B20PrecompileClient::new(&provider, &admin, common::L2_CHAIN_ID)
+        .with_receipt_timeout(common::TX_RECEIPT_TIMEOUT);
+    let feature = ActivationFeature::B20Stablecoin.id();
+
+    assert!(!is_activated(&client, feature).await?, "feature should start inactive");
+
+    let activate_receipt = client
+        .send_call_receipt(
+            ActivationRegistryStorage::ADDRESS,
+            IActivationRegistry::activateCall { feature },
+            "activate feature",
+        )
+        .await?;
+    assert_activation_log(&activate_receipt, feature, admin.address(), true);
+    assert!(is_activated(&client, feature).await?, "feature should be active after activate");
+
+    let activate_again = client
+        .try_send_call(
+            ActivationRegistryStorage::ADDRESS,
+            IActivationRegistry::activateCall { feature },
+            "activate feature again",
+        )
+        .await?;
+    assert!(!activate_again, "repeated activate should revert");
+    assert!(is_activated(&client, feature).await?, "feature should remain active");
+
+    let deactivate_receipt = client
+        .send_call_receipt(
+            ActivationRegistryStorage::ADDRESS,
+            IActivationRegistry::deactivateCall { feature },
+            "deactivate feature",
+        )
+        .await?;
+    assert_activation_log(&deactivate_receipt, feature, admin.address(), false);
+    assert!(!is_activated(&client, feature).await?, "feature should be inactive after deactivate");
+
+    let deactivate_again = client
+        .try_send_call(
+            ActivationRegistryStorage::ADDRESS,
+            IActivationRegistry::deactivateCall { feature },
+            "deactivate feature again",
+        )
+        .await?;
+    assert!(!deactivate_again, "repeated deactivate should revert");
+    assert!(!is_activated(&client, feature).await?, "feature should remain inactive");
+
+    let reactivate_receipt = client
+        .send_call_receipt(
+            ActivationRegistryStorage::ADDRESS,
+            IActivationRegistry::activateCall { feature },
+            "reactivate feature",
+        )
+        .await?;
+    assert_activation_log(&reactivate_receipt, feature, admin.address(), true);
+    assert!(is_activated(&client, feature).await?, "feature should be active after reactivation");
+
+    Ok(())
+}
+
 /// Calling `activate` from a non-admin account reverts with `Unauthorized`.
 #[tokio::test]
 async fn test_activation_registry_unauthorized_activate_reverts() -> Result<()> {
@@ -87,4 +156,34 @@ async fn test_activation_registry_unauthorized_activate_reverts() -> Result<()> 
     assert!(!is_activated, "feature should still be inactive after unauthorized activate");
 
     Ok(())
+}
+
+async fn is_activated(client: &B20PrecompileClient<'_>, feature: B256) -> Result<bool> {
+    let output = client
+        .call(ActivationRegistryStorage::ADDRESS, IActivationRegistry::isActivatedCall { feature })
+        .await?;
+    IActivationRegistry::isActivatedCall::abi_decode_returns(output.as_ref())
+        .wrap_err("Failed to decode isActivated")
+}
+
+fn assert_activation_log(
+    receipt: &BaseTransactionReceipt,
+    feature: B256,
+    caller: Address,
+    active: bool,
+) {
+    let expected = if active {
+        IActivationRegistry::FeatureActivated { feature, caller }.encode_log_data()
+    } else {
+        IActivationRegistry::FeatureDeactivated { feature, caller }.encode_log_data()
+    };
+    assert_receipt_log(receipt, ActivationRegistryStorage::ADDRESS, expected);
+}
+
+fn assert_receipt_log(receipt: &BaseTransactionReceipt, address: Address, expected: LogData) {
+    assert!(
+        receipt.inner.logs().iter().any(|log| log.address() == address && log.data() == &expected),
+        "receipt must contain expected log at {address}; expected={expected:?}, logs={:?}",
+        receipt.inner.logs()
+    );
 }

--- a/etc/systems/tests/b20_precompile.rs
+++ b/etc/systems/tests/b20_precompile.rs
@@ -2,16 +2,20 @@
 
 mod common;
 
-use alloy_primitives::{Address, B256, U256};
-use alloy_provider::RootProvider;
+use alloy_primitives::{Address, B256, Bytes, LogData, U256};
+use alloy_provider::{Provider, RootProvider};
 use alloy_signer_local::PrivateKeySigner;
-use alloy_sol_types::SolValue;
+use alloy_sol_types::{SolEvent, SolValue};
 use base_common_network::Base;
 use base_common_precompiles::{
     ActivationFeature, B20FactoryStorage, B20TokenRole, B20Variant, IB20, IB20Factory,
 };
-use base_system_tests::{ANVIL_ACCOUNT_5, ANVIL_ACCOUNT_6, ANVIL_ACCOUNT_7, B20PrecompileClient};
-use eyre::{Result, WrapErr};
+use base_common_rpc_types::BaseTransactionReceipt;
+use base_system_tests::{
+    ANVIL_ACCOUNT_5, ANVIL_ACCOUNT_6, ANVIL_ACCOUNT_7, B20PrecompileClient, SystemTestStack,
+    SystemTestStackBuilder,
+};
+use eyre::{Result, WrapErr, ensure};
 
 const TOKEN_DECIMALS: u8 = 6;
 const INITIAL_SUPPLY: u64 = 1_000_000_000;
@@ -23,14 +27,43 @@ const SPENDER_TRANSFER_AMOUNT: u64 = 30_000_000;
 const MEMO_TRANSFER_AMOUNT: u64 = 111_000;
 const INITIAL_SUPPLY_CAP: u64 = 2_000_000_000;
 const PAUSE_TRANSFER_AMOUNT: u64 = 10_000;
+const STABLECOIN_CURRENCY: &str = "USD";
+const PRE_BERYL_TEST_ACTIVATION_BLOCK: u64 = 8;
+
+async fn start_beryl_system_before_activation() -> Result<(SystemTestStack, RootProvider<Base>)> {
+    let system = SystemTestStackBuilder::new()
+        .with_l1_chain_id(common::L1_CHAIN_ID)
+        .with_l2_chain_id(common::L2_CHAIN_ID)
+        .with_base_azul_activation_block(common::BASE_AZUL_ACTIVATION_BLOCK)
+        .with_base_beryl_activation_block(PRE_BERYL_TEST_ACTIVATION_BLOCK)
+        .build()
+        .await?;
+    let provider = system.l2_builder_provider()?;
+    let block = provider.get_block_number().await?;
+    ensure!(
+        block < PRE_BERYL_TEST_ACTIVATION_BLOCK,
+        "system test stack already reached Beryl activation block: {block}"
+    );
+    Ok((system, provider))
+}
 
 async fn activated_b20_client<'a>(
     provider: &'a RootProvider<Base>,
     admin: &'a PrivateKeySigner,
 ) -> Result<B20PrecompileClient<'a>> {
+    activated_feature_client(provider, admin, [ActivationFeature::B20Asset]).await
+}
+
+async fn activated_feature_client<'a>(
+    provider: &'a RootProvider<Base>,
+    admin: &'a PrivateKeySigner,
+    features: impl IntoIterator<Item = ActivationFeature>,
+) -> Result<B20PrecompileClient<'a>> {
     let b20 = B20PrecompileClient::new(provider, admin, common::L2_CHAIN_ID)
         .with_receipt_timeout(common::TX_RECEIPT_TIMEOUT);
-    b20.activate_feature(ActivationFeature::B20Asset.id()).await?;
+    for feature in features {
+        b20.activate_feature(feature.id()).await?;
+    }
     Ok(b20)
 }
 
@@ -45,16 +78,29 @@ async fn test_b20_factory_create_and_transfer_via_rpc() -> Result<()> {
 
     let b20 = activated_b20_client(&provider, &admin).await?;
     let salt = B256::repeat_byte(0x42);
+    let name = "System Test B20";
+    let symbol = "DB20";
     let params = B20PrecompileClient::token_params(
-        "System Test B20",
-        "DB20",
+        name,
+        symbol,
         admin.address(),
         U256::from(INITIAL_SUPPLY),
         admin.address(),
     );
 
-    let token = b20.create_token(B20Variant::Asset, params, salt).await?;
+    let (token, create_receipt) =
+        b20.create_token_with_receipt(B20Variant::Asset, params, salt).await?;
     b20.wait_for_token_code(token, common::TX_RECEIPT_TIMEOUT, common::BLOCK_POLL_INTERVAL).await?;
+    assert_b20_created_log(
+        &create_receipt,
+        token,
+        B20Variant::Asset,
+        name,
+        symbol,
+        TOKEN_DECIMALS,
+        Bytes::new(),
+    );
+    assert_transfer_log(&create_receipt, token, Address::ZERO, admin.address(), INITIAL_SUPPLY);
 
     assert_eq!(b20.variant_of(token).await?, B20Variant::Asset);
     assert_eq!(b20.decimals_of(token).await?, TOKEN_DECIMALS);
@@ -62,7 +108,14 @@ async fn test_b20_factory_create_and_transfer_via_rpc() -> Result<()> {
     let admin_balance_before = b20.balance_of(token, admin.address()).await?;
     assert_eq!(admin_balance_before, U256::from(INITIAL_SUPPLY));
 
-    b20.transfer(token, recipient, U256::from(TRANSFER_AMOUNT)).await?;
+    let transfer_receipt = b20
+        .send_call_receipt(
+            token,
+            IB20::transferCall { to: recipient, amount: U256::from(TRANSFER_AMOUNT) },
+            "transfer B-20 token",
+        )
+        .await?;
+    assert_transfer_log(&transfer_receipt, token, admin.address(), recipient, TRANSFER_AMOUNT);
 
     let admin_balance_after = b20.balance_of(token, admin.address()).await?;
     let recipient_balance = b20.balance_of(token, recipient).await?;
@@ -439,6 +492,111 @@ async fn test_b20_factory_predict_and_is_b20() -> Result<()> {
 }
 
 #[tokio::test]
+async fn test_b20_stablecoin_variant_create_via_rpc() -> Result<()> {
+    let (_system, provider) = common::start_beryl_system().await?;
+    let admin = PrivateKeySigner::from_bytes(&ANVIL_ACCOUNT_5.private_key)
+        .wrap_err("Failed to parse admin key")?;
+    common::wait_for_balance(&provider, admin.address()).await?;
+
+    let b20 =
+        activated_feature_client(&provider, &admin, [ActivationFeature::B20Stablecoin]).await?;
+    let salt = B256::repeat_byte(0x19);
+    let name = "System Test USD Stablecoin";
+    let symbol = "SUSD";
+    let params = B20PrecompileClient::stablecoin_params(
+        name,
+        symbol,
+        admin.address(),
+        U256::from(INITIAL_SUPPLY),
+        admin.address(),
+        STABLECOIN_CURRENCY,
+    );
+
+    let local_prediction = b20.predict_token_address(B20Variant::Stablecoin, salt);
+    let rpc_prediction =
+        b20.predict_token_address_rpc(admin.address(), B20Variant::Stablecoin, salt).await?;
+    assert_eq!(local_prediction, rpc_prediction, "stablecoin prediction should match RPC");
+
+    let (token, receipt) =
+        b20.create_token_with_receipt(B20Variant::Stablecoin, params, salt).await?;
+    b20.wait_for_token_code(token, common::TX_RECEIPT_TIMEOUT, common::BLOCK_POLL_INTERVAL).await?;
+
+    assert_eq!(token, rpc_prediction, "created stablecoin address should match prediction");
+    assert_b20_created_log(
+        &receipt,
+        token,
+        B20Variant::Stablecoin,
+        name,
+        symbol,
+        TOKEN_DECIMALS,
+        IB20Factory::B20StablecoinEventParams {
+            version: 1,
+            currency: STABLECOIN_CURRENCY.to_string(),
+        }
+        .abi_encode()
+        .into(),
+    );
+    assert_transfer_log(&receipt, token, Address::ZERO, admin.address(), INITIAL_SUPPLY);
+    assert!(b20.is_b20(token).await?, "created stablecoin should be recognised as B-20");
+    assert!(b20.is_b20_initialized(token).await?, "stablecoin should be initialized");
+    assert_eq!(b20.variant_of(token).await?, B20Variant::Stablecoin);
+    assert_eq!(b20.decimals_of(token).await?, TOKEN_DECIMALS);
+    assert_eq!(b20.currency(token).await?, STABLECOIN_CURRENCY);
+    assert_eq!(b20.name(token).await?, name);
+    assert_eq!(b20.symbol(token).await?, symbol);
+    assert_eq!(b20.total_supply(token).await?, U256::from(INITIAL_SUPPLY));
+    assert_eq!(b20.balance_of(token, admin.address()).await?, U256::from(INITIAL_SUPPLY));
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_beryl_precompiles_do_not_execute_before_activation_block() -> Result<()> {
+    let (_system, provider) = start_beryl_system_before_activation().await?;
+    let admin = PrivateKeySigner::from_bytes(&ANVIL_ACCOUNT_5.private_key)
+        .wrap_err("Failed to parse admin key")?;
+    common::wait_for_balance(&provider, admin.address()).await?;
+    let b20 = B20PrecompileClient::new(&provider, &admin, common::L2_CHAIN_ID)
+        .with_receipt_timeout(common::TX_RECEIPT_TIMEOUT);
+    let salt = B256::repeat_byte(0x1a);
+    let params = B20PrecompileClient::token_params(
+        "Pre-Beryl Token",
+        "PRE",
+        admin.address(),
+        U256::ZERO,
+        admin.address(),
+    );
+    let token = b20.predict_token_address(B20Variant::Asset, salt);
+
+    let receipt = b20
+        .send_call_unchecked_receipt(
+            B20FactoryStorage::ADDRESS,
+            IB20Factory::createB20Call {
+                variant: IB20Factory::B20Variant::ASSET,
+                salt,
+                params: params.encoded_params.clone(),
+                initCalls: Vec::new(),
+            },
+            "pre-Beryl createB20",
+        )
+        .await?;
+    assert!(receipt.inner.logs().is_empty(), "pre-Beryl createB20 must not emit logs");
+    assert!(
+        provider.get_code_at(token).await?.is_empty(),
+        "pre-Beryl createB20 must not deploy code"
+    );
+
+    common::wait_for_block(&provider, PRE_BERYL_TEST_ACTIVATION_BLOCK + 1).await?;
+    b20.activate_feature(ActivationFeature::B20Asset.id()).await?;
+
+    let token_after_beryl = b20.create_token(B20Variant::Asset, params, salt).await?;
+    assert_eq!(token_after_beryl, token, "post-Beryl creation should use the same address");
+    b20.wait_for_token_code(token, common::TX_RECEIPT_TIMEOUT, common::BLOCK_POLL_INTERVAL).await?;
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn test_b20_create_token_duplicate_reverts() -> Result<()> {
     let (_system, provider) = common::start_beryl_system().await?;
     let admin = PrivateKeySigner::from_bytes(&ANVIL_ACCOUNT_5.private_key)
@@ -464,7 +622,7 @@ async fn test_b20_create_token_duplicate_reverts() -> Result<()> {
             IB20Factory::createB20Call {
                 variant: IB20Factory::B20Variant::ASSET,
                 salt,
-                params: params.create.abi_encode().into(),
+                params: params.encoded_params,
                 initCalls: Vec::new(),
             },
             "createB20 (duplicate salt)",
@@ -473,4 +631,50 @@ async fn test_b20_create_token_duplicate_reverts() -> Result<()> {
     assert!(!succeeded, "creating a token with the same salt should revert on-chain");
 
     Ok(())
+}
+
+fn assert_b20_created_log(
+    receipt: &BaseTransactionReceipt,
+    token: Address,
+    variant: B20Variant,
+    name: &str,
+    symbol: &str,
+    decimals: u8,
+    variant_params: Bytes,
+) {
+    assert_receipt_log(
+        receipt,
+        B20FactoryStorage::ADDRESS,
+        IB20Factory::B20Created {
+            token,
+            variant: variant.abi(),
+            name: name.to_string(),
+            symbol: symbol.to_string(),
+            decimals,
+            variantParams: variant_params,
+        }
+        .encode_log_data(),
+    );
+}
+
+fn assert_transfer_log(
+    receipt: &BaseTransactionReceipt,
+    token: Address,
+    from: Address,
+    to: Address,
+    amount: u64,
+) {
+    assert_receipt_log(
+        receipt,
+        token,
+        IB20::Transfer { from, to, amount: U256::from(amount) }.encode_log_data(),
+    );
+}
+
+fn assert_receipt_log(receipt: &BaseTransactionReceipt, address: Address, expected: LogData) {
+    assert!(
+        receipt.inner.logs().iter().any(|log| log.address() == address && log.data() == &expected),
+        "receipt must contain expected log at {address}; expected={expected:?}, logs={:?}",
+        receipt.inner.logs()
+    );
 }

--- a/etc/systems/tests/policy_registry.rs
+++ b/etc/systems/tests/policy_registry.rs
@@ -2,11 +2,60 @@
 
 mod common;
 
+use alloy_primitives::{Address, LogData};
 use alloy_signer_local::PrivateKeySigner;
-use alloy_sol_types::SolCall;
+use alloy_sol_types::{SolCall, SolEvent};
 use base_common_precompiles::{ActivationFeature, IPolicyRegistry, PolicyRegistryStorage};
+use base_common_rpc_types::BaseTransactionReceipt;
 use base_system_tests::{ANVIL_ACCOUNT_5, B20PrecompileClient};
 use eyre::{Result, WrapErr};
+
+/// `createPolicy` emits the expected policy-registry events over RPC receipts.
+#[tokio::test]
+async fn test_policy_registry_create_policy_emits_events() -> Result<()> {
+    let (_system, provider) = common::start_beryl_system().await?;
+    let caller = PrivateKeySigner::from_bytes(&ANVIL_ACCOUNT_5.private_key)
+        .wrap_err("Failed to parse system test private key")?;
+    common::wait_for_balance(&provider, caller.address()).await?;
+
+    let client = B20PrecompileClient::new(&provider, &caller, common::L2_CHAIN_ID)
+        .with_receipt_timeout(common::TX_RECEIPT_TIMEOUT);
+    client.activate_feature(ActivationFeature::PolicyRegistry.id()).await?;
+
+    let call = IPolicyRegistry::createPolicyCall {
+        admin: caller.address(),
+        policyType: IPolicyRegistry::PolicyType::ALLOWLIST,
+    };
+    let output = client.call(PolicyRegistryStorage::ADDRESS, call.clone()).await?;
+    let policy_id = IPolicyRegistry::createPolicyCall::abi_decode_returns(output.as_ref())
+        .wrap_err("Failed to decode createPolicy")?;
+    let receipt = client
+        .send_call_receipt(PolicyRegistryStorage::ADDRESS, call, "createPolicy ALLOWLIST")
+        .await?;
+
+    assert_receipt_log(
+        &receipt,
+        PolicyRegistryStorage::ADDRESS,
+        IPolicyRegistry::PolicyCreated {
+            policyId: policy_id,
+            creator: caller.address(),
+            policyType: IPolicyRegistry::PolicyType::ALLOWLIST,
+        }
+        .encode_log_data(),
+    );
+    assert_receipt_log(
+        &receipt,
+        PolicyRegistryStorage::ADDRESS,
+        IPolicyRegistry::PolicyAdminUpdated {
+            policyId: policy_id,
+            previousAdmin: Address::ZERO,
+            newAdmin: caller.address(),
+        }
+        .encode_log_data(),
+    );
+
+    Ok(())
+}
 
 /// `policyExists(ALWAYS_ALLOW_ID)` returns `true` once the policy registry is active.
 #[tokio::test]
@@ -32,4 +81,12 @@ async fn test_policy_registry_policy_exists() -> Result<()> {
     assert!(result, "policyExists(0) should return true after Beryl activation");
 
     Ok(())
+}
+
+fn assert_receipt_log(receipt: &BaseTransactionReceipt, address: Address, expected: LogData) {
+    assert!(
+        receipt.inner.logs().iter().any(|log| log.address() == address && log.data() == &expected),
+        "receipt must contain expected log at {address}; expected={expected:?}, logs={:?}",
+        receipt.inner.logs()
+    );
 }

--- a/etc/systems/tests/policy_transfer.rs
+++ b/etc/systems/tests/policy_transfer.rs
@@ -22,7 +22,7 @@ use eyre::{Result, WrapErr};
 const INITIAL_SUPPLY: u64 = 1_000_000;
 const TRANSFER_AMOUNT: u64 = 100_000;
 
-// Salts must not overlap with those used in b20_precompile.rs (0x10–0x18, 0x42).
+// Salts must not overlap with those used in b20_precompile.rs (0x10-0x1a, 0x42).
 const SALT_ALLOWLIST: B256 = B256::repeat_byte(0x50);
 const SALT_BLOCKLIST: B256 = B256::repeat_byte(0x51);
 const SALT_ALWAYS_BLOCK: B256 = B256::repeat_byte(0x52);


### PR DESCRIPTION
## Summary

This expands devnet coverage for the Beryl precompile surfaces with receipt log assertions, stablecoin and security creation paths, and pre-activation non-execution checks. It also adds activation and policy registry lifecycle event coverage through the RPC harness. The in-process consensus devnet now uses isolated checkpoint database paths so multiple consensus nodes with the same chain ID do not share the default redb lock.