### PR TITLE
fix(ci): use BASE_STD_TOKEN to access private base-std in base-anvil-package

### DIFF
--- a/.github/workflows/base-anvil-package.yml
+++ b/.github/workflows/base-anvil-package.yml
@@ -116,17 +116,19 @@ jobs:
       - name: Resolve base-std ref
         id: base-std
         shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.BASE_STD_TOKEN }}
         run: |
           set -euo pipefail
 
-          if base_std_sha="$(git ls-remote https://github.com/base/base-std.git "refs/heads/$BASE_STD_REF" | awk '{print $1}' | head -1)" \
+          if base_std_sha="$(gh api repos/base/base-std/git/ref/heads/"$BASE_STD_REF" --jq '.object.sha' 2>/dev/null)" \
             && [[ -n "$base_std_sha" ]]; then
             :
-          elif base_std_sha="$(git ls-remote https://github.com/base/base-std.git "refs/tags/$BASE_STD_REF" | awk '{print $1}' | head -1)" \
+          elif base_std_sha="$(gh api repos/base/base-std/git/ref/tags/"$BASE_STD_REF" --jq '.object.sha' 2>/dev/null)" \
             && [[ -n "$base_std_sha" ]]; then
             :
           else
-            base_std_sha="$(git ls-remote https://github.com/base/base-std.git "$BASE_STD_REF" | awk '{print $1}' | head -1)"
+            base_std_sha="$(gh api "repos/base/base-std/git/ref/$BASE_STD_REF" --jq '.object.sha')"
           fi
 
           if [[ -z "$base_std_sha" ]]; then
@@ -157,6 +159,7 @@ jobs:
         if: matrix.settings.smoke_test
         shell: bash
         env:
+          GH_TOKEN: ${{ secrets.BASE_STD_TOKEN }}
           BASE_STD_SHA: ${{ steps.base-std.outputs.sha }}
         run: |
           set -euo pipefail
@@ -165,10 +168,8 @@ jobs:
           base_std_dir="$workdir/base-std"
           mkdir -p "$workdir"
 
-          git init "$base_std_dir"
-          git -C "$base_std_dir" remote add origin https://github.com/base/base-std.git
-          git -C "$base_std_dir" fetch --depth 1 origin "$BASE_STD_SHA"
-          git -C "$base_std_dir" checkout --detach FETCH_HEAD
+          gh repo clone base/base-std "$base_std_dir" -- --depth 1 --single-branch
+          git -C "$base_std_dir" checkout --detach "$BASE_STD_SHA"
           git -C "$base_std_dir" submodule update --init --recursive --depth 1
 
           echo "BASE_STD_DIR=$base_std_dir" >> "$GITHUB_ENV"

--- a/.github/workflows/base-anvil-package.yml
+++ b/.github/workflows/base-anvil-package.yml
@@ -168,8 +168,10 @@ jobs:
           base_std_dir="$workdir/base-std"
           mkdir -p "$workdir"
 
-          gh repo clone base/base-std "$base_std_dir" -- --depth 1 --single-branch
-          git -C "$base_std_dir" checkout --detach "$BASE_STD_SHA"
+          gh auth setup-git
+          gh repo clone base/base-std "$base_std_dir" -- --depth 1 --single-branch --no-checkout
+          git -C "$base_std_dir" fetch --depth 1 origin "$BASE_STD_SHA"
+          git -C "$base_std_dir" checkout --detach FETCH_HEAD
           git -C "$base_std_dir" submodule update --init --recursive --depth 1
 
           echo "BASE_STD_DIR=$base_std_dir" >> "$GITHUB_ENV"

--- a/.github/workflows/base-anvil-package.yml
+++ b/.github/workflows/base-anvil-package.yml
@@ -169,7 +169,7 @@ jobs:
           mkdir -p "$workdir"
 
           gh auth setup-git
-          gh repo clone base/base-std "$base_std_dir" -- --depth 1 --single-branch --no-checkout
+          gh repo clone base/base-std "$base_std_dir" -- --filter=blob:none --no-checkout
           git -C "$base_std_dir" fetch --depth 1 origin "$BASE_STD_SHA"
           git -C "$base_std_dir" checkout --detach FETCH_HEAD
           git -C "$base_std_dir" submodule update --init --recursive --depth 1


### PR DESCRIPTION
[BOP-219](https://linear.app/coinbase/issue/BOP-219)

## Motivation

`base-anvil-package.yml` used unauthenticated `git ls-remote` and `git fetch` calls against `https://github.com/base/base-std.git`. Since base-std is now private/internal, these return 404 and the workflow failed at "Resolve base-std ref" before any build could happen.

## What changed

- "Resolve base-std ref": replaced `git ls-remote` with `gh api repos/base/base-std/git/ref/...` calls using `GH_TOKEN: ${{ secrets.BASE_STD_TOKEN }}`
- "Clone base-std": added `gh auth setup-git` to configure git credentials, then uses a blobless clone (`--filter=blob:none`) followed by `git fetch --depth 1 origin "$BASE_STD_SHA"` + `git checkout --detach FETCH_HEAD` — preserving correct behavior for non-tip SHAs (tags, non-default branches)

`BASE_STD_TOKEN` already exists as a repo secret (also used in `base-std-fork-tests.yml`) — no new secret provisioning needed.

## Verified

Manually triggered on this branch: https://github.com/base/base/actions/runs/26767230143

"Resolve base-std ref" and "Clone base-std" both passed on both matrix jobs. The only failure is fork test divergences (known, pre-existing) unrelated to this fix.
