### PR TITLE
fix(policy): align update_membership check order to match Solidity canonical

### DIFF
--- a/crates/common/precompiles/src/policy/storage.rs
+++ b/crates/common/precompiles/src/policy/storage.rs
@@ -349,9 +349,14 @@ impl PolicyRegistryStorage<'_> {
         add: bool,
         accounts: &[Address],
     ) -> Result<Address> {
-        let (_, caller) = self.require_admin(policy_id)?;
+        // Check order matches Solidity canonical: existence → type → admin → batch size.
+        let packed = self.require_custom(policy_id)?;
         if Self::policy_id_type(policy_id) != expected_type {
             return Err(BasePrecompileError::revert(IPolicyRegistry::IncompatiblePolicyType {}));
+        }
+        let caller = self.storage.caller();
+        if packed.admin() != caller {
+            return Err(BasePrecompileError::revert(IPolicyRegistry::Unauthorized {}));
         }
         Self::require_account_batch_size(accounts)?;
         for account in accounts {
@@ -1014,6 +1019,30 @@ mod tests {
                 maxBatchSize: U256::from(PolicyRegistryStorage::MAX_ACCOUNTS_PER_BATCH),
             })
         );
+    }
+
+    #[test]
+    fn update_allowlist_on_blocklist_policy_by_non_admin_reverts_with_incompatible_type() {
+        let mut s = storage();
+        let id = create_blocklist(&mut s);
+        s.set_caller(ALICE);
+        let err = StorageCtx::enter(&mut s, |ctx| {
+            PolicyRegistryStorage::new(ctx).update_allowlist(id, true, vec![BOB])
+        })
+        .unwrap_err();
+        assert_eq!(err, BasePrecompileError::revert(IPolicyRegistry::IncompatiblePolicyType {}));
+    }
+
+    #[test]
+    fn update_blocklist_on_allowlist_policy_by_non_admin_reverts_with_incompatible_type() {
+        let mut s = storage();
+        let id = create_allowlist(&mut s);
+        s.set_caller(ALICE);
+        let err = StorageCtx::enter(&mut s, |ctx| {
+            PolicyRegistryStorage::new(ctx).update_blocklist(id, true, vec![BOB])
+        })
+        .unwrap_err();
+        assert_eq!(err, BasePrecompileError::revert(IPolicyRegistry::IncompatiblePolicyType {}));
     }
 
     // --- createPolicyWithAccounts ---


### PR DESCRIPTION
## Summary

Reorder checks in `update_membership` to match Solidity's canonical order:
**existence → type → admin → batch size**

Previously Rust used: existence → admin → type → batch size.

## Problem

For an existing wrong-type policy called by a non-admin:
- **Solidity** reverts `IncompatiblePolicyType`
- **Rust (before)** reverted `Unauthorized`

This inconsistency was flagged during the audit-response workstream.

## Solution

Move the type check before the admin check in `update_membership`.

## Tests

Added two tests that lock in the precedence:
- `update_allowlist_on_blocklist_policy_by_non_admin_reverts_with_incompatible_type`
- `update_blocklist_on_allowlist_policy_by_non_admin_reverts_with_incompatible_type`

These verify that a non-admin calling `update_allowlist` on a blocklist policy (and vice versa) reverts with `IncompatiblePolicyType`, not `Unauthorized`.

Closes BOP-213