### PR TITLE
feat(snapshotter): use BLAKE3 to diff static file chunks

### DIFF
--- a/crates/infra/snapshotter/src/lib.rs
+++ b/crates/infra/snapshotter/src/lib.rs
@@ -14,7 +14,7 @@ mod container;
 pub use container::{ContainerManager, DockerContainerManager};
 
 mod snapshot;
-pub use snapshot::{OutputFileChecksum, SnapshotGenerator, SnapshotManifest};
+pub use snapshot::{ChunkFilename, OutputFileChecksum, SnapshotGenerator, SnapshotManifest};
 
 mod upload;
 pub use upload::{SnapshotUploader, UploadStrategy};

--- a/crates/infra/snapshotter/src/orchestrator.rs
+++ b/crates/infra/snapshotter/src/orchestrator.rs
@@ -9,7 +9,9 @@ use anyhow::{Context, Result, bail};
 use tracing::{error, info};
 
 use crate::{
-    SnapshotterConfig, container::ContainerManager, snapshot::SnapshotGenerator,
+    SnapshotterConfig,
+    container::ContainerManager,
+    snapshot::{SnapshotGenerator, SnapshotManifest},
     upload::SnapshotUploader,
 };
 
@@ -98,12 +100,18 @@ impl<C: ContainerManager> Snapshotter<C> {
 
         info!(remote_files = remote_static_files.len(), "fetched remote static file listing");
 
+        let remote_manifest = self.uploader.fetch_previous_manifest().await?;
+        info!(
+            has_remote_manifest = remote_manifest.is_some(),
+            "fetched previous manifest for blake3 diff"
+        );
+
         let source_datadir = self.config.source_datadir.clone();
         let output_dir_for_gen = run_output_dir.clone();
         let chain_id = self.config.chain_id;
         let block = self.config.block;
         let blocks_per_file = self.config.blocks_per_file;
-        let remote_for_gen = remote_static_files.clone();
+        let remote_for_gen = remote_static_files;
 
         let files = tokio::task::spawn_blocking(move || {
             SnapshotGenerator::generate_manifest(
@@ -123,8 +131,20 @@ impl<C: ContainerManager> Snapshotter<C> {
             bail!("snapshot generation produced no files");
         }
 
+        let manifest_bytes = tokio::fs::read(run_output_dir.join("manifest.json"))
+            .await
+            .context("failed to read freshly generated manifest.json")?;
+        let local_manifest: SnapshotManifest = serde_json::from_slice(&manifest_bytes)
+            .context("failed to parse freshly generated manifest.json")?;
+
         self.uploader
-            .upload(&run_output_dir, &files, run_timestamp, &remote_static_files)
+            .upload(
+                &run_output_dir,
+                &files,
+                run_timestamp,
+                &local_manifest,
+                remote_manifest.as_ref(),
+            )
             .await
             .context("snapshot upload failed")?;
 

--- a/crates/infra/snapshotter/src/snapshot.rs
+++ b/crates/infra/snapshotter/src/snapshot.rs
@@ -56,6 +56,44 @@ pub struct SnapshotManifest {
     pub components: BTreeMap<String, serde_json::Value>,
 }
 
+/// Minimal projection of a chunked component's manifest entry for hash lookup.
+#[derive(Deserialize)]
+struct ChunkedComponentMeta {
+    blocks_per_file: u64,
+    chunk_output_files: Vec<Vec<OutputFileChecksum>>,
+}
+
+impl SnapshotManifest {
+    /// Returns the per-file BLAKE3 hashes for a static-file chunk archive,
+    /// sorted by file path, or `None` if the chunk has no recorded hashes.
+    ///
+    /// Returns `None` when:
+    /// - `filename` does not match the `{component}-{start}-{end}.tar.zst` pattern,
+    /// - the component is not present in the manifest or is not a chunked component,
+    /// - the chunk index is out of range, or
+    /// - the chunk's hash list is empty (which happens for chunks that were skipped
+    ///   at generation time — see the tip+buffer invariant in `compute_skip_ranges`).
+    ///
+    /// Callers should treat `None` as "no comparable hash available" and fall
+    /// through to re-upload.
+    pub fn chunk_hashes_for_file(&self, filename: &str) -> Option<Vec<String>> {
+        let (component, start, _end) = ChunkFilename::parse(filename)?;
+        let value = self.components.get(&component)?;
+        let meta: ChunkedComponentMeta = serde_json::from_value(value.clone()).ok()?;
+        if meta.blocks_per_file == 0 {
+            return None;
+        }
+        let chunk_index = usize::try_from(start / meta.blocks_per_file).ok()?;
+        let entries = meta.chunk_output_files.get(chunk_index)?;
+        if entries.is_empty() {
+            return None;
+        }
+        let mut sorted = entries.clone();
+        sorted.sort_unstable_by(|a, b| a.path.cmp(&b.path));
+        Some(sorted.into_iter().map(|e| e.blake3).collect())
+    }
+}
+
 /// Checksum metadata for an extracted file within an archive.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct OutputFileChecksum {
@@ -154,7 +192,7 @@ impl SnapshotGenerator {
 
                 planned.push(PlannedChunk {
                     chunk_idx: i,
-                    archive_path: output_dir.join(chunk_filename(key, start, end)),
+                    archive_path: output_dir.join(ChunkFilename::format(key, start, end)),
                     source_files,
                 });
             }
@@ -271,7 +309,7 @@ impl SnapshotGenerator {
                 .context("block range overflow in skip computation")?;
 
             let dominated_by_remote = CHUNKED_COMPONENTS.iter().all(|&(key, _)| {
-                let filename = chunk_filename(key, start, end);
+                let filename = ChunkFilename::format(key, start, end);
                 remote_filenames.contains(filename.as_str())
             });
 
@@ -284,8 +322,29 @@ impl SnapshotGenerator {
     }
 }
 
-fn chunk_filename(component_key: &str, start: u64, end: u64) -> String {
-    format!("{component_key}-{start}-{end}.tar.zst")
+/// Parser/formatter for chunked static-file archive names of the form
+/// `{component}-{start}-{end}.tar.zst` (e.g. `headers-0-499999.tar.zst`).
+#[derive(Debug)]
+pub struct ChunkFilename;
+
+impl ChunkFilename {
+    /// Formats a chunk archive filename.
+    pub fn format(component: &str, start: u64, end: u64) -> String {
+        format!("{component}-{start}-{end}.tar.zst")
+    }
+
+    /// Parses a chunk archive filename into `(component, start, end)`.
+    /// Returns `None` if the filename does not match the expected pattern.
+    pub fn parse(filename: &str) -> Option<(String, u64, u64)> {
+        let stem = filename.strip_suffix(".tar.zst")?;
+        let parts: Vec<&str> = stem.rsplitn(3, '-').collect();
+        if parts.len() < 3 {
+            return None;
+        }
+        let end = parts[0].parse::<u64>().ok()?;
+        let start = parts[1].parse::<u64>().ok()?;
+        Some((parts[2].to_string(), start, end))
+    }
 }
 
 /// Infers the snapshot block from the highest header static file range.
@@ -605,10 +664,10 @@ mod tests {
     fn compute_skip_ranges_skips_finalized_chunks() {
         let mut remote = HashSet::new();
         for &(key, _) in CHUNKED_COMPONENTS {
-            remote.insert(chunk_filename(key, 0, 499_999));
-            remote.insert(chunk_filename(key, 500_000, 999_999));
-            remote.insert(chunk_filename(key, 1_000_000, 1_499_999));
-            remote.insert(chunk_filename(key, 1_500_000, 1_999_999));
+            remote.insert(ChunkFilename::format(key, 0, 499_999));
+            remote.insert(ChunkFilename::format(key, 500_000, 999_999));
+            remote.insert(ChunkFilename::format(key, 1_000_000, 1_499_999));
+            remote.insert(ChunkFilename::format(key, 1_500_000, 1_999_999));
         }
 
         // block=2_000_000, blocks_per_file=500_000 → 4 chunks (indices 0-3)
@@ -629,8 +688,8 @@ mod tests {
     fn compute_skip_ranges_keeps_all_when_few_chunks() {
         let mut remote = HashSet::new();
         for &(key, _) in CHUNKED_COMPONENTS {
-            remote.insert(chunk_filename(key, 0, 499_999));
-            remote.insert(chunk_filename(key, 500_000, 999_999));
+            remote.insert(ChunkFilename::format(key, 0, 499_999));
+            remote.insert(ChunkFilename::format(key, 500_000, 999_999));
         }
 
         // block=1_000_000 → 2 chunks, tip + buffer(2) = 3 → keep all
@@ -651,7 +710,7 @@ mod tests {
     fn compute_skip_ranges_requires_all_components_present() {
         let mut remote = HashSet::new();
         // Only add headers, not other components
-        remote.insert(chunk_filename("headers", 0, 499_999));
+        remote.insert(ChunkFilename::format("headers", 0, 499_999));
 
         let refs: HashSet<&str> = remote.iter().map(String::as_str).collect();
         let skip = SnapshotGenerator::compute_skip_ranges(&refs, 5_000_000, 500_000).unwrap();
@@ -712,7 +771,7 @@ mod tests {
         // Simulate all chunked components existing remotely for range 0-499999
         let mut remote = HashMap::new();
         for &(key, _) in CHUNKED_COMPONENTS {
-            remote.insert(chunk_filename(key, 0, 499_999), 0u64);
+            remote.insert(ChunkFilename::format(key, 0, 499_999), 0u64);
         }
 
         let files = SnapshotGenerator::generate_manifest(
@@ -764,7 +823,7 @@ mod tests {
 
         let mut remote = HashMap::new();
         for &(key, _) in CHUNKED_COMPONENTS {
-            remote.insert(chunk_filename(key, 0, 499_999), 0u64);
+            remote.insert(ChunkFilename::format(key, 0, 499_999), 0u64);
         }
 
         SnapshotGenerator::generate_manifest(

--- a/crates/infra/snapshotter/src/upload.rs
+++ b/crates/infra/snapshotter/src/upload.rs
@@ -4,7 +4,9 @@
 //!
 //! - `{prefix}/static_files/` — static file chunks that are immutable for finalized
 //!   block ranges. Only the tip chunk changes between snapshots. The uploader
-//!   compares local sizes against existing remote objects and skips unchanged chunks.
+//!   compares the per-file BLAKE3 hashes recorded in the previous run's
+//!   `manifest.json` against the freshly generated manifest, and skips chunks
+//!   whose hashes match.
 //!
 //! - `{prefix}/{date}/` — per-run directory for mdbx state, rocksdb, and the manifest.
 //!   These are always re-uploaded since they change every snapshot.
@@ -21,7 +23,9 @@ use aws_sdk_s3::{
     types::{CompletedMultipartUpload, CompletedPart},
 };
 use futures::stream::{self, StreamExt, TryStreamExt};
-use tracing::{debug, info};
+use tracing::{debug, info, warn};
+
+use crate::snapshot::{ChunkFilename, SnapshotManifest};
 
 /// Maximum number of concurrent file uploads.
 const MAX_CONCURRENT_UPLOADS: usize = 10;
@@ -39,8 +43,9 @@ const MULTIPART_PART_SIZE: u64 = 100 * 1024 * 1024;
 pub enum UploadStrategy {
     /// Always upload to the per-run date directory (mdbx, rocksdb, manifest).
     AlwaysUpload,
-    /// Upload to `static_files/`, skipping if the remote object has the same size.
-    DiffBySize,
+    /// Upload to `static_files/`, skipping if the per-file BLAKE3 hashes
+    /// recorded in the previous run's manifest match the freshly generated ones.
+    DiffByHash,
 }
 
 impl UploadStrategy {
@@ -52,25 +57,12 @@ impl UploadStrategy {
     ///
     /// Everything else (state, rocksdb, manifest) is always uploaded.
     pub fn classify(filename: &str) -> Self {
-        if is_static_file_chunk(filename) { Self::DiffBySize } else { Self::AlwaysUpload }
+        if ChunkFilename::parse(filename).is_some() {
+            Self::DiffByHash
+        } else {
+            Self::AlwaysUpload
+        }
     }
-}
-
-/// Returns `true` if the filename matches the static file chunk pattern:
-/// `{component}-{start}-{end}.tar.zst`.
-fn is_static_file_chunk(filename: &str) -> bool {
-    let Some(stem) = filename.strip_suffix(".tar.zst") else {
-        return false;
-    };
-
-    let parts: Vec<&str> = stem.rsplitn(3, '-').collect();
-    if parts.len() < 3 {
-        return false;
-    }
-
-    let end_ok = parts[0].parse::<u64>().is_ok();
-    let start_ok = parts[1].parse::<u64>().is_ok();
-    end_ok && start_ok
 }
 
 /// Uploads snapshot artifacts to an S3-compatible store (R2, `MinIO`, etc.).
@@ -88,24 +80,105 @@ impl SnapshotUploader {
     }
 
     /// Lists remote static files with their sizes. Call once and pass the result
-    /// to both `generate_manifest` (for skip ranges) and `upload` (for diff).
+    /// to `generate_manifest` for skip-range computation.
     pub async fn list_remote_static_files(&self) -> Result<HashMap<String, u64>> {
         self.list_remote_objects(&self.static_files_prefix()).await
     }
 
+    /// Fetches the most recent `manifest.json` from a prior run, if one exists.
+    ///
+    /// Looks for keys matching `{prefix}/{digits}/manifest.json` (where `{digits}`
+    /// is the run's unix-timestamp directory) and downloads the one with the
+    /// largest timestamp. Returns `None` on a fresh bucket. A parse error on the
+    /// found manifest is logged and treated as no-previous (so we fall back to
+    /// re-uploading everything rather than failing the run).
+    pub async fn fetch_previous_manifest(&self) -> Result<Option<SnapshotManifest>> {
+        let manifest_suffix = "/manifest.json";
+        let list_prefix =
+            if self.prefix.is_empty() { String::new() } else { format!("{}/", self.prefix) };
+
+        let mut best: Option<(u64, String)> = None;
+        let mut continuation_token = None;
+
+        loop {
+            let mut req = self.client.list_objects_v2().bucket(&self.bucket);
+            if !list_prefix.is_empty() {
+                req = req.prefix(&list_prefix);
+            }
+            if let Some(token) = continuation_token.take() {
+                req = req.continuation_token(token);
+            }
+
+            let resp = req
+                .send()
+                .await
+                .with_context(|| format!("failed to list objects under {list_prefix}"))?;
+
+            for obj in resp.contents() {
+                let Some(key) = obj.key() else { continue };
+                let Some(rest) = key.strip_prefix(list_prefix.as_str()) else { continue };
+                let Some(timestamp_str) = rest.strip_suffix(manifest_suffix) else { continue };
+                if timestamp_str.contains('/') {
+                    continue;
+                }
+                let Ok(timestamp) = timestamp_str.parse::<u64>() else { continue };
+                if best.as_ref().is_none_or(|(prev, _)| timestamp > *prev) {
+                    best = Some((timestamp, key.to_string()));
+                }
+            }
+
+            if resp.is_truncated() == Some(true) {
+                continuation_token = resp.next_continuation_token().map(String::from);
+            } else {
+                break;
+            }
+        }
+
+        let Some((timestamp, key)) = best else {
+            debug!("no previous manifest found");
+            return Ok(None);
+        };
+
+        debug!(timestamp, key = %key, "fetching previous manifest");
+        let resp = self
+            .client
+            .get_object()
+            .bucket(&self.bucket)
+            .key(&key)
+            .send()
+            .await
+            .with_context(|| format!("failed to fetch previous manifest {key}"))?;
+
+        let bytes = resp
+            .body
+            .collect()
+            .await
+            .with_context(|| format!("failed to read previous manifest body {key}"))?
+            .into_bytes();
+
+        match serde_json::from_slice::<SnapshotManifest>(&bytes) {
+            Ok(manifest) => Ok(Some(manifest)),
+            Err(e) => {
+                warn!(error = %e, key = %key, "failed to parse previous manifest, treating as missing");
+                Ok(None)
+            }
+        }
+    }
+
     /// Uploads snapshot artifacts with diff-based optimization.
     ///
-    /// `remote_static_files` is the pre-fetched listing from `list_remote_static_files`.
-    /// Static file chunks go to `{prefix}/static_files/` and are skipped if the
-    /// remote object already exists with the same size. State, rocksdb, and
-    /// manifest go to `{prefix}/{date}/` and are always re-uploaded.
-    /// `manifest.json` is uploaded last as the "snapshot complete" signal.
+    /// Static file chunks go to `{prefix}/static_files/` and are skipped when
+    /// their per-file BLAKE3 hashes (recorded in `local_manifest`) match those
+    /// from `remote_manifest`. State, rocksdb, and manifest go to
+    /// `{prefix}/{timestamp}/` and are always re-uploaded. `manifest.json` is
+    /// uploaded last as the "snapshot complete" signal.
     pub async fn upload(
         &self,
         output_dir: &Path,
         files: &[PathBuf],
         timestamp: u64,
-        remote_static_files: &HashMap<String, u64>,
+        local_manifest: &SnapshotManifest,
+        remote_manifest: Option<&SnapshotManifest>,
     ) -> Result<String> {
         let static_prefix = self.static_files_prefix();
         let run_prefix = self.run_prefix(timestamp);
@@ -134,18 +207,25 @@ impl SnapshotUploader {
                 .to_string_lossy()
                 .to_string();
 
-            let local_size = tokio::fs::metadata(file).await?.len();
             let strategy = UploadStrategy::classify(&file_name);
 
             match strategy {
-                UploadStrategy::DiffBySize => {
-                    if let Some(&remote_size) = remote_static_files.get(&file_name) {
-                        if remote_size == local_size {
-                            debug!(file = %file_name, size = local_size, "skipping static file (size matches)");
+                UploadStrategy::DiffByHash => {
+                    let local_hashes = local_manifest.chunk_hashes_for_file(&file_name);
+                    let remote_hashes =
+                        remote_manifest.and_then(|m| m.chunk_hashes_for_file(&file_name));
+                    match (&local_hashes, &remote_hashes) {
+                        (Some(local), Some(remote)) if local == remote => {
+                            debug!(file = %file_name, "skipping static file (blake3 matches)");
                             skipped += 1;
                             continue;
                         }
-                        debug!(file = %file_name, local_size, remote_size, "re-uploading static file (size mismatch)");
+                        (Some(_), Some(_)) => {
+                            debug!(file = %file_name, "re-uploading static file (blake3 mismatch)");
+                        }
+                        _ => {
+                            debug!(file = %file_name, "re-uploading static file (no prior hash available)");
+                        }
                     }
                     static_uploads.push(file.clone());
                 }
@@ -406,27 +486,27 @@ mod tests {
     fn static_file_chunks_are_diff_eligible() {
         assert_eq!(
             UploadStrategy::classify("headers-0-499999.tar.zst"),
-            UploadStrategy::DiffBySize
+            UploadStrategy::DiffByHash
         );
         assert_eq!(
             UploadStrategy::classify("transactions-500000-999999.tar.zst"),
-            UploadStrategy::DiffBySize
+            UploadStrategy::DiffByHash
         );
         assert_eq!(
             UploadStrategy::classify("receipts-9500000-9999999.tar.zst"),
-            UploadStrategy::DiffBySize
+            UploadStrategy::DiffByHash
         );
         assert_eq!(
             UploadStrategy::classify("account_changesets-0-499999.tar.zst"),
-            UploadStrategy::DiffBySize
+            UploadStrategy::DiffByHash
         );
         assert_eq!(
             UploadStrategy::classify("storage_changesets-1000000-1499999.tar.zst"),
-            UploadStrategy::DiffBySize
+            UploadStrategy::DiffByHash
         );
         assert_eq!(
             UploadStrategy::classify("transaction_senders-0-499999.tar.zst"),
-            UploadStrategy::DiffBySize
+            UploadStrategy::DiffByHash
         );
     }
 
@@ -442,13 +522,25 @@ mod tests {
     }
 
     #[test]
-    fn is_static_file_chunk_edge_cases() {
-        assert!(!is_static_file_chunk("state.tar.zst"));
-        assert!(!is_static_file_chunk("headers.tar.zst"));
-        assert!(!is_static_file_chunk("headers-abc-def.tar.zst"));
-        assert!(!is_static_file_chunk("headers-0-499999.tar.gz"));
-        assert!(!is_static_file_chunk("headers-0-499999"));
-        assert!(is_static_file_chunk("headers-0-499999.tar.zst"));
-        assert!(is_static_file_chunk("custom_component-100-200.tar.zst"));
+    fn classify_chunk_filename_edge_cases() {
+        assert_eq!(UploadStrategy::classify("state.tar.zst"), UploadStrategy::AlwaysUpload);
+        assert_eq!(UploadStrategy::classify("headers.tar.zst"), UploadStrategy::AlwaysUpload);
+        assert_eq!(
+            UploadStrategy::classify("headers-abc-def.tar.zst"),
+            UploadStrategy::AlwaysUpload
+        );
+        assert_eq!(
+            UploadStrategy::classify("headers-0-499999.tar.gz"),
+            UploadStrategy::AlwaysUpload
+        );
+        assert_eq!(UploadStrategy::classify("headers-0-499999"), UploadStrategy::AlwaysUpload);
+        assert_eq!(
+            UploadStrategy::classify("headers-0-499999.tar.zst"),
+            UploadStrategy::DiffByHash
+        );
+        assert_eq!(
+            UploadStrategy::classify("custom_component-100-200.tar.zst"),
+            UploadStrategy::DiffByHash
+        );
     }
 }

--- a/crates/infra/snapshotter/src/upload.rs
+++ b/crates/infra/snapshotter/src/upload.rs
@@ -57,11 +57,7 @@ impl UploadStrategy {
     ///
     /// Everything else (state, rocksdb, manifest) is always uploaded.
     pub fn classify(filename: &str) -> Self {
-        if ChunkFilename::parse(filename).is_some() {
-            Self::DiffByHash
-        } else {
-            Self::AlwaysUpload
-        }
+        if ChunkFilename::parse(filename).is_some() { Self::DiffByHash } else { Self::AlwaysUpload }
     }
 }
 

--- a/crates/infra/snapshotter/tests/e2e_test.rs
+++ b/crates/infra/snapshotter/tests/e2e_test.rs
@@ -1,7 +1,7 @@
 //! E2E tests for the snapshotter upload flow using `MinIO`.
 
 use std::{
-    collections::HashMap,
+    collections::{BTreeMap, HashMap},
     path::{Path, PathBuf},
     sync::atomic::{AtomicBool, Ordering},
 };
@@ -9,7 +9,8 @@ use std::{
 use anyhow::Result;
 use async_trait::async_trait;
 use base_snapshotter::{
-    ContainerManager, DockerContainerManager, SnapshotGenerator, SnapshotUploader,
+    ContainerManager, DockerContainerManager, SnapshotGenerator, SnapshotManifest,
+    SnapshotUploader,
 };
 use bollard::{
     Docker,
@@ -168,6 +169,71 @@ fn create_fake_snapshot(dir: &Path, block: u64) -> Result<Vec<PathBuf>> {
     Ok(files)
 }
 
+/// Parses a `manifest.json` written into `output_dir` by `create_fake_snapshot`
+/// or `SnapshotGenerator::generate_manifest`.
+fn parse_local_manifest(output_dir: &Path) -> Result<SnapshotManifest> {
+    let bytes = std::fs::read(output_dir.join("manifest.json"))?;
+    Ok(serde_json::from_slice(&bytes)?)
+}
+
+/// Minimal `SnapshotManifest` with no components — for tests that don't
+/// upload any `DiffByHash` chunks and therefore don't need real hashes.
+const fn empty_manifest(block: u64) -> SnapshotManifest {
+    SnapshotManifest {
+        block,
+        chain_id: 8453,
+        storage_version: 2,
+        timestamp: 0,
+        components: BTreeMap::new(),
+    }
+}
+
+/// Builds a `SnapshotManifest` whose chunked components carry per-chunk
+/// `OutputFileChecksum` entries derived from `hash_seed`. Two manifests built
+/// with the same seed will produce identical BLAKE3s for every chunk (→ skip).
+/// Different seeds → mismatch (→ re-upload).
+fn manifest_with_seeded_hashes(
+    block: u64,
+    blocks_per_file: u64,
+    components: &[&str],
+    hash_seed: &str,
+) -> SnapshotManifest {
+    let num_chunks = block.div_ceil(blocks_per_file);
+    let mut comps: BTreeMap<String, serde_json::Value> = BTreeMap::new();
+    for &component in components {
+        let chunk_output_files: Vec<serde_json::Value> = (0..num_chunks)
+            .map(|i| {
+                let start = i * blocks_per_file;
+                let end = start + blocks_per_file - 1;
+                serde_json::json!([
+                    {
+                        "path": format!("static_files/static_file_{component}_{start}_{end}"),
+                        "size": 100,
+                        "blake3": format!("{hash_seed}-{component}-{i}-main")
+                    },
+                    {
+                        "path": format!("static_files/static_file_{component}_{start}_{end}.off"),
+                        "size": 100,
+                        "blake3": format!("{hash_seed}-{component}-{i}-off")
+                    }
+                ])
+            })
+            .collect();
+        comps.insert(
+            component.to_string(),
+            serde_json::json!({
+                "blocks_per_file": blocks_per_file,
+                "total_blocks": block,
+                "chunk_sizes": vec![100u64; num_chunks as usize],
+                "chunk_decompressed_sizes": vec![200u64; num_chunks as usize],
+                "chunk_output_files": chunk_output_files,
+                "chunk_skipped": vec![false; num_chunks as usize],
+            }),
+        );
+    }
+    SnapshotManifest { block, chain_id: 8453, storage_version: 2, timestamp: 0, components: comps }
+}
+
 #[tokio::test]
 #[serial]
 async fn upload_artifacts_to_minio() -> Result<()> {
@@ -181,10 +247,10 @@ async fn upload_artifacts_to_minio() -> Result<()> {
     let tmp = tempfile::tempdir()?;
     let output_dir = tmp.path().join("output");
     let files = create_fake_snapshot(&output_dir, 1_000_000)?;
+    let local_manifest = parse_local_manifest(&output_dir)?;
 
-    let upload_prefix = uploader
-        .upload(&output_dir, &files, 1_700_000_000, &std::collections::HashMap::new())
-        .await?;
+    let upload_prefix =
+        uploader.upload(&output_dir, &files, 1_700_000_000, &local_manifest, None).await?;
     assert_eq!(upload_prefix, "mainnet/1700000000", "run prefix should be date-based");
 
     let s3 = &harness.storage_client;
@@ -238,10 +304,10 @@ async fn upload_with_empty_prefix() -> Result<()> {
     let tmp = tempfile::tempdir()?;
     let output_dir = tmp.path().join("output");
     let files = create_fake_snapshot(&output_dir, 100)?;
+    let local_manifest = parse_local_manifest(&output_dir)?;
 
-    let upload_prefix = uploader
-        .upload(&output_dir, &files, 1_700_000_000, &std::collections::HashMap::new())
-        .await?;
+    let upload_prefix =
+        uploader.upload(&output_dir, &files, 1_700_000_000, &local_manifest, None).await?;
     assert_eq!(upload_prefix, "1700000000", "empty prefix should produce bare date");
 
     let s3 = &harness.storage_client;
@@ -264,9 +330,53 @@ async fn upload_with_empty_prefix() -> Result<()> {
     Ok(())
 }
 
+/// Helper: writes a `manifest.json` and a complete set of fake artifacts to
+/// `output_dir`. The chunked-component sections of the manifest carry BLAKE3
+/// hashes derived from `hash_seed`, so two runs sharing a seed will produce
+/// matching hashes and trigger the `DiffByHash` skip path.
+fn seeded_snapshot(
+    output_dir: &Path,
+    block: u64,
+    blocks_per_file: u64,
+    components: &[&str],
+    hash_seed: &str,
+    chunk_content: &[u8],
+) -> Result<Vec<PathBuf>> {
+    std::fs::create_dir_all(output_dir)?;
+    let manifest = manifest_with_seeded_hashes(block, blocks_per_file, components, hash_seed);
+    std::fs::write(output_dir.join("manifest.json"), serde_json::to_string_pretty(&manifest)?)?;
+    std::fs::write(output_dir.join("state.tar.zst"), b"state-data")?;
+    std::fs::write(output_dir.join("rocksdb_indices.tar.zst"), b"rocksdb-data")?;
+
+    let num_chunks = block.div_ceil(blocks_per_file);
+    for &component in components {
+        for i in 0..num_chunks {
+            let start = i * blocks_per_file;
+            let end = start + blocks_per_file - 1;
+            std::fs::write(output_dir.join(format!("{component}-{start}-{end}.tar.zst")), chunk_content)?;
+        }
+    }
+
+    let mut files: Vec<PathBuf> = std::fs::read_dir(output_dir)?
+        .filter_map(|e| e.ok().map(|e| e.path()))
+        .filter(|p| p.is_file())
+        .collect();
+    files.sort_unstable();
+    Ok(files)
+}
+
+const DIFF_TEST_COMPONENTS: &[&str] = &[
+    "headers",
+    "transactions",
+    "receipts",
+    "account_changesets",
+    "storage_changesets",
+    "transaction_senders",
+];
+
 #[tokio::test]
 #[serial]
-async fn diff_upload_skips_unchanged_static_file_chunks() -> Result<()> {
+async fn diff_upload_skips_chunks_when_blake3_matches() -> Result<()> {
     let harness = TestHarness::new().await?;
     let s3 = &harness.storage_client;
     let bucket = &harness.bucket_name;
@@ -274,99 +384,177 @@ async fn diff_upload_skips_unchanged_static_file_chunks() -> Result<()> {
     let uploader = SnapshotUploader::new(
         harness.storage_client.clone(),
         harness.bucket_name.clone(),
-        "diff-test".to_string(),
+        "diff-match".to_string(),
     );
 
-    // Pre-seed static_files/ with finalized chunks from a previous run
-    let preexisting: &[(&str, &[u8])] = &[
-        ("headers-0-499999.tar.zst", b"finalized-headers-0"),
-        ("headers-500000-999999.tar.zst", b"finalized-headers-1"),
-        ("transactions-0-499999.tar.zst", b"finalized-txs-0"),
-        ("transactions-500000-999999.tar.zst", b"finalized-txs-1"),
-        ("receipts-0-499999.tar.zst", b"finalized-receipts-0"),
-        ("receipts-500000-999999.tar.zst", b"finalized-receipts-1"),
-        ("account_changesets-0-499999.tar.zst", b"finalized-acc-cs-0"),
-        ("storage_changesets-0-499999.tar.zst", b"finalized-stor-cs-0"),
-    ];
+    // Pre-seed static_files/ with the prior run's chunks and a previous manifest.json
+    // at {prefix}/1699000000/manifest.json. Both use the same hash seed.
+    let prev_manifest = manifest_with_seeded_hashes(1_000_000, 500_000, DIFF_TEST_COMPONENTS, "v1");
+    s3.put_object()
+        .bucket(bucket)
+        .key("diff-match/1699000000/manifest.json")
+        .body(serde_json::to_vec(&prev_manifest)?.into())
+        .send()
+        .await?;
 
-    for (name, data) in preexisting {
-        let key = format!("diff-test/static_files/{name}");
-        s3.put_object()
-            .bucket(bucket)
-            .key(&key)
-            .body(aws_sdk_s3::primitives::ByteStream::from(data.to_vec()))
-            .send()
-            .await?;
+    for &component in DIFF_TEST_COMPONENTS {
+        for chunk_idx in 0..2u64 {
+            let start = chunk_idx * 500_000;
+            let end = start + 499_999;
+            let key = format!("diff-match/static_files/{component}-{start}-{end}.tar.zst");
+            s3.put_object()
+                .bucket(bucket)
+                .key(&key)
+                .body(aws_sdk_s3::primitives::ByteStream::from(b"old-bytes".to_vec()))
+                .send()
+                .await?;
+        }
     }
+
+    // Generate a new run that produces the SAME hashes (same seed) but with
+    // different on-disk byte content — proves the comparison is hash-based,
+    // not byte-based.
+    let tmp = tempfile::tempdir()?;
+    let output_dir = tmp.path().join("output");
+    let files =
+        seeded_snapshot(&output_dir, 1_000_000, 500_000, DIFF_TEST_COMPONENTS, "v1", b"new-bytes")?;
+    let local_manifest = parse_local_manifest(&output_dir)?;
+    let remote_manifest = uploader.fetch_previous_manifest().await?;
+    assert!(remote_manifest.is_some(), "should find the pre-seeded previous manifest");
+
+    uploader
+        .upload(&output_dir, &files, 1_700_000_000, &local_manifest, remote_manifest.as_ref())
+        .await?;
+
+    // Verify: pre-seeded chunks were NOT overwritten (skipped due to blake3 match).
+    for &component in DIFF_TEST_COMPONENTS {
+        for chunk_idx in 0..2u64 {
+            let start = chunk_idx * 500_000;
+            let end = start + 499_999;
+            let key = format!("diff-match/static_files/{component}-{start}-{end}.tar.zst");
+            let body = get_object_bytes(s3, bucket, &key).await?;
+            assert_eq!(
+                body.as_slice(),
+                b"old-bytes",
+                "chunk {component} {chunk_idx} should have been skipped (blake3 match)"
+            );
+        }
+    }
+
+    Ok(())
+}
+
+#[tokio::test]
+#[serial]
+async fn diff_upload_reuploads_on_blake3_mismatch_even_when_size_matches() -> Result<()> {
+    // This is the core correctness case the PR exists to fix: a chunk whose
+    // contents changed in a way that preserves its archive size. Size-based
+    // diff would skip; hash-based diff must re-upload.
+    let harness = TestHarness::new().await?;
+    let s3 = &harness.storage_client;
+    let bucket = &harness.bucket_name;
+
+    let uploader = SnapshotUploader::new(
+        harness.storage_client.clone(),
+        harness.bucket_name.clone(),
+        "diff-mismatch".to_string(),
+    );
+
+    // Previous run published hashes with seed "v1".
+    let prev_manifest = manifest_with_seeded_hashes(1_000_000, 500_000, DIFF_TEST_COMPONENTS, "v1");
+    s3.put_object()
+        .bucket(bucket)
+        .key("diff-mismatch/1699000000/manifest.json")
+        .body(serde_json::to_vec(&prev_manifest)?.into())
+        .send()
+        .await?;
+
+    for &component in DIFF_TEST_COMPONENTS {
+        for chunk_idx in 0..2u64 {
+            let start = chunk_idx * 500_000;
+            let end = start + 499_999;
+            let key = format!("diff-mismatch/static_files/{component}-{start}-{end}.tar.zst");
+            s3.put_object()
+                .bucket(bucket)
+                .key(&key)
+                .body(aws_sdk_s3::primitives::ByteStream::from(
+                    b"corrupted-bytes-x".to_vec(),
+                ))
+                .send()
+                .await?;
+        }
+    }
+
+    // New run reports DIFFERENT hashes (seed "v2") for the same chunk filenames.
+    // Local chunk bytes are the same length as remote, so size comparison would
+    // have skipped — but blake3 comparison should force a re-upload.
+    let tmp = tempfile::tempdir()?;
+    let output_dir = tmp.path().join("output");
+    let files = seeded_snapshot(
+        &output_dir,
+        1_000_000,
+        500_000,
+        DIFF_TEST_COMPONENTS,
+        "v2",
+        b"healthy-bytes-yy",
+    )?;
+    assert_eq!(
+        b"healthy-bytes-yy".len(),
+        b"corrupted-bytes-x".len(),
+        "test fixture must hold size constant"
+    );
+    let local_manifest = parse_local_manifest(&output_dir)?;
+    let remote_manifest = uploader.fetch_previous_manifest().await?;
+
+    uploader
+        .upload(&output_dir, &files, 1_700_000_000, &local_manifest, remote_manifest.as_ref())
+        .await?;
+
+    // Verify every chunk was re-uploaded with the fresh bytes.
+    for &component in DIFF_TEST_COMPONENTS {
+        for chunk_idx in 0..2u64 {
+            let start = chunk_idx * 500_000;
+            let end = start + 499_999;
+            let key = format!("diff-mismatch/static_files/{component}-{start}-{end}.tar.zst");
+            let body = get_object_bytes(s3, bucket, &key).await?;
+            assert_eq!(
+                body.as_slice(),
+                b"healthy-bytes-yy",
+                "chunk {component} {chunk_idx} should have been re-uploaded despite size match"
+            );
+        }
+    }
+
+    Ok(())
+}
+
+#[tokio::test]
+#[serial]
+async fn diff_upload_uploads_everything_on_first_run() -> Result<()> {
+    let harness = TestHarness::new().await?;
+    let s3 = &harness.storage_client;
+    let bucket = &harness.bucket_name;
+
+    let uploader = SnapshotUploader::new(
+        harness.storage_client.clone(),
+        harness.bucket_name.clone(),
+        "first-run".to_string(),
+    );
 
     let tmp = tempfile::tempdir()?;
     let output_dir = tmp.path().join("output");
-    std::fs::create_dir_all(&output_dir)?;
+    let files =
+        seeded_snapshot(&output_dir, 500_000, 500_000, &["headers"], "v1", b"fresh-chunk")?;
+    let local_manifest = parse_local_manifest(&output_dir)?;
+    let remote_manifest = uploader.fetch_previous_manifest().await?;
+    assert!(remote_manifest.is_none(), "fresh bucket should have no previous manifest");
 
-    let manifest = serde_json::json!({"block": 1_000_000, "chain_id": 8453, "storage_version": 2});
-    std::fs::write(output_dir.join("manifest.json"), serde_json::to_string(&manifest)?)?;
+    uploader
+        .upload(&output_dir, &files, 1_700_000_000, &local_manifest, remote_manifest.as_ref())
+        .await?;
 
-    // AlwaysUpload: mdbx + rocksdb
-    std::fs::write(output_dir.join("state.tar.zst"), b"new-mdbx-state-data")?;
-    std::fs::write(output_dir.join("rocksdb_indices.tar.zst"), b"new-rocksdb-data")?;
-
-    // DiffBySize: finalized chunks with SAME size → should be SKIPPED
-    for &(name, data) in preexisting {
-        std::fs::write(output_dir.join(name), data)?;
-    }
-
-    // DiffBySize: new tip chunks → should be UPLOADED
-    std::fs::write(output_dir.join("headers-1000000-1499999.tar.zst"), b"new-tip-headers")?;
-    std::fs::write(output_dir.join("transactions-1000000-1499999.tar.zst"), b"new-tip-txs")?;
-    std::fs::write(output_dir.join("receipts-1000000-1499999.tar.zst"), b"new-tip-receipts")?;
-    std::fs::write(output_dir.join("account_changesets-500000-999999.tar.zst"), b"new-tip-acc-cs")?;
-    std::fs::write(
-        output_dir.join("storage_changesets-500000-999999.tar.zst"),
-        b"new-tip-stor-cs",
-    )?;
-
-    let mut files: Vec<PathBuf> = std::fs::read_dir(&output_dir)?
-        .filter_map(|e| e.ok().map(|e| e.path()))
-        .filter(|p| p.is_file())
-        .collect();
-    files.sort_unstable();
-
-    let remote_listing = uploader.list_remote_static_files().await?;
-    let upload_prefix =
-        uploader.upload(&output_dir, &files, 1_700_000_000, &remote_listing).await?;
-    assert_eq!(upload_prefix, "diff-test/1700000000");
-
-    // Verify AlwaysUpload: mdbx + rocksdb in date dir
-    let state_body = get_object_bytes(s3, bucket, "diff-test/1700000000/state.tar.zst").await?;
-    assert_eq!(state_body, b"new-mdbx-state-data", "mdbx should be in date dir");
-
-    let rocksdb_body =
-        get_object_bytes(s3, bucket, "diff-test/1700000000/rocksdb_indices.tar.zst").await?;
-    assert_eq!(rocksdb_body, b"new-rocksdb-data", "rocksdb should be in date dir");
-
-    // Verify DiffBySize SKIPPED: finalized chunks retain original content in static_files/
-    for (name, original_data) in preexisting {
-        let body = get_object_bytes(s3, bucket, &format!("diff-test/static_files/{name}")).await?;
-        assert_eq!(body.as_slice(), *original_data, "finalized chunk {name} should be unchanged");
-    }
-
-    // Verify DiffBySize UPLOADED: new tip chunks in static_files/
-    let tip_checks: &[(&str, &[u8])] = &[
-        ("headers-1000000-1499999.tar.zst", b"new-tip-headers"),
-        ("transactions-1000000-1499999.tar.zst", b"new-tip-txs"),
-        ("receipts-1000000-1499999.tar.zst", b"new-tip-receipts"),
-        ("account_changesets-500000-999999.tar.zst", b"new-tip-acc-cs"),
-        ("storage_changesets-500000-999999.tar.zst", b"new-tip-stor-cs"),
-    ];
-    for (name, expected) in tip_checks {
-        let body = get_object_bytes(s3, bucket, &format!("diff-test/static_files/{name}")).await?;
-        assert_eq!(body.as_slice(), *expected, "tip chunk {name} should be in static_files/");
-    }
-
-    // Verify manifest in date dir
-    let manifest_body = get_object_bytes(s3, bucket, "diff-test/1700000000/manifest.json").await?;
-    let parsed: serde_json::Value = serde_json::from_slice(&manifest_body)?;
-    assert_eq!(parsed["block"], 1_000_000, "manifest should be in date dir");
+    let body = get_object_bytes(s3, bucket, "first-run/static_files/headers-0-499999.tar.zst").await?;
+    assert_eq!(body.as_slice(), b"fresh-chunk", "static file should be uploaded on first run");
 
     Ok(())
 }
@@ -502,7 +690,7 @@ async fn always_upload_overwrites_existing_state_and_rocksdb() -> Result<()> {
     ];
 
     let upload_prefix = uploader
-        .upload(&output_dir, &files, 1_700_000_000, &std::collections::HashMap::new())
+        .upload(&output_dir, &files, 1_700_000_000, &empty_manifest(2_000_000), None)
         .await?;
     assert_eq!(upload_prefix, "overwrite-test/1700000000");
 
@@ -625,15 +813,15 @@ async fn e2e_stop_upload_restart_real_container() -> Result<()> {
     let tmp = tempfile::tempdir()?;
     let output_dir = tmp.path().join("output");
     let files = create_fake_snapshot(&output_dir, 1_000_000)?;
+    let local_manifest = parse_local_manifest(&output_dir)?;
 
     let uploader = SnapshotUploader::new(
         harness.storage_client.clone(),
         harness.bucket_name.clone(),
         "e2e-test".to_string(),
     );
-    let upload_prefix = uploader
-        .upload(&output_dir, &files, 1_700_000_000, &std::collections::HashMap::new())
-        .await?;
+    let upload_prefix =
+        uploader.upload(&output_dir, &files, 1_700_000_000, &local_manifest, None).await?;
 
     let manifest_body = get_object_bytes(
         &harness.storage_client,

--- a/crates/infra/snapshotter/tests/e2e_test.rs
+++ b/crates/infra/snapshotter/tests/e2e_test.rs
@@ -496,10 +496,10 @@ async fn diff_upload_reuploads_on_blake3_mismatch_even_when_size_matches() -> Re
         500_000,
         DIFF_TEST_COMPONENTS,
         "v2",
-        b"healthy-bytes-yy",
+        b"healthy-bytes-yyy",
     )?;
     assert_eq!(
-        b"healthy-bytes-yy".len(),
+        b"healthy-bytes-yyy".len(),
         b"corrupted-bytes-x".len(),
         "test fixture must hold size constant"
     );
@@ -519,7 +519,7 @@ async fn diff_upload_reuploads_on_blake3_mismatch_even_when_size_matches() -> Re
             let body = get_object_bytes(s3, bucket, &key).await?;
             assert_eq!(
                 body.as_slice(),
-                b"healthy-bytes-yy",
+                b"healthy-bytes-yyy",
                 "chunk {component} {chunk_idx} should have been re-uploaded despite size match"
             );
         }

--- a/crates/infra/snapshotter/tests/e2e_test.rs
+++ b/crates/infra/snapshotter/tests/e2e_test.rs
@@ -9,8 +9,7 @@ use std::{
 use anyhow::Result;
 use async_trait::async_trait;
 use base_snapshotter::{
-    ContainerManager, DockerContainerManager, SnapshotGenerator, SnapshotManifest,
-    SnapshotUploader,
+    ContainerManager, DockerContainerManager, SnapshotGenerator, SnapshotManifest, SnapshotUploader,
 };
 use bollard::{
     Docker,
@@ -353,7 +352,10 @@ fn seeded_snapshot(
         for i in 0..num_chunks {
             let start = i * blocks_per_file;
             let end = start + blocks_per_file - 1;
-            std::fs::write(output_dir.join(format!("{component}-{start}-{end}.tar.zst")), chunk_content)?;
+            std::fs::write(
+                output_dir.join(format!("{component}-{start}-{end}.tar.zst")),
+                chunk_content,
+            )?;
         }
     }
 
@@ -477,9 +479,7 @@ async fn diff_upload_reuploads_on_blake3_mismatch_even_when_size_matches() -> Re
             s3.put_object()
                 .bucket(bucket)
                 .key(&key)
-                .body(aws_sdk_s3::primitives::ByteStream::from(
-                    b"corrupted-bytes-x".to_vec(),
-                ))
+                .body(aws_sdk_s3::primitives::ByteStream::from(b"corrupted-bytes-x".to_vec()))
                 .send()
                 .await?;
         }
@@ -543,8 +543,7 @@ async fn diff_upload_uploads_everything_on_first_run() -> Result<()> {
 
     let tmp = tempfile::tempdir()?;
     let output_dir = tmp.path().join("output");
-    let files =
-        seeded_snapshot(&output_dir, 500_000, 500_000, &["headers"], "v1", b"fresh-chunk")?;
+    let files = seeded_snapshot(&output_dir, 500_000, 500_000, &["headers"], "v1", b"fresh-chunk")?;
     let local_manifest = parse_local_manifest(&output_dir)?;
     let remote_manifest = uploader.fetch_previous_manifest().await?;
     assert!(remote_manifest.is_none(), "fresh bucket should have no previous manifest");
@@ -553,7 +552,8 @@ async fn diff_upload_uploads_everything_on_first_run() -> Result<()> {
         .upload(&output_dir, &files, 1_700_000_000, &local_manifest, remote_manifest.as_ref())
         .await?;
 
-    let body = get_object_bytes(s3, bucket, "first-run/static_files/headers-0-499999.tar.zst").await?;
+    let body =
+        get_object_bytes(s3, bucket, "first-run/static_files/headers-0-499999.tar.zst").await?;
     assert_eq!(body.as_slice(), b"fresh-chunk", "static file should be uploaded on first run");
 
     Ok(())


### PR DESCRIPTION
## Summary

  Replaces `UploadStrategy::DiffBySize` with `DiffByHash`, comparing per-file BLAKE3 hashes (already computed
  during chunk generation and stored in `manifest.json`) instead of file sizes when deciding whether to skip
  re-uploading a static-file chunk archive. Size-only comparison could silently skip a chunk whose contents
  changed without changing size; BLAKE3 closes that hole and reuses work that was already being done.

  ## Changes

  - `crates/infra/snapshotter/src/snapshot.rs`: add `ChunkFilename` helper (parse/format
  `{component}-{start}-{end}.tar.zst`) and `SnapshotManifest::chunk_hashes_for_file()` to extract sorted per-file
   BLAKE3s for a given chunk archive.
  - `crates/infra/snapshotter/src/upload.rs`: rename `DiffBySize` → `DiffByHash`; add
  `fetch_previous_manifest()`; change `upload()` to take `&local_manifest` + `Option<&remote_manifest>` instead
  of a remote-size map. Falls through to re-upload on first run or any missing entry.
  - `crates/infra/snapshotter/src/orchestrator.rs`: fetch previous manifest from S3, parse the freshly written
  local manifest from disk, pass both into `upload()`.
  - `crates/infra/snapshotter/src/lib.rs`: re-export `ChunkFilename`.
  - `crates/infra/snapshotter/tests/e2e_test.rs`: update existing `upload()` callsites for new signature; add
  coverage for skip-on-blake3-match, re-upload-on-mismatch-even-when-size-matches, and
  first-run-uploads-everything.

  No manifest schema change. No behavior change for `AlwaysUpload`. `compute_skip_ranges` still uses the existing
   remote static-file listing.

  Closes #2960

  ## Test plan

  - [ ] `cargo build -p base-snapshotter` clean
  - [ ] `cargo clippy -p base-snapshotter -- -D warnings` clean
  - [ ] `cargo test -p base-snapshotter` (15 lib unit + 10 e2e tests) passes