### PR TITLE
chore: bump MSRV from 1.93.1 to 1.94.1

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,7 +67,7 @@ If you want to work on something that doesn't have an issue yet, open an issue f
 
 ### Developer Setup
 
-- Rust `1.93` or newer
+- Rust `1.94` or newer
 - [`just`](https://github.com/casey/just)
 - Foundry (`forge`) for Solidity-based test fixtures
 - Bun and Node.js `22+` if you want to run the spec site locally

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [workspace.package]
 version = "0.0.0"
 edition = "2024"
-rust-version = "1.93"
+rust-version = "1.94"
 license = "MIT"
 homepage = "https://github.com/base/base"
 repository = "https://github.com/base/base"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -126,6 +126,7 @@ explicit-iter-loop = "warn"
 iter-with-drain = "warn"
 needless-pass-by-ref-mut = "warn"
 string-lit-as-bytes = "warn"
+result-large-err = "allow"
 
 [profile.dev]
 debug = "line-tables-only"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -126,7 +126,6 @@ explicit-iter-loop = "warn"
 iter-with-drain = "warn"
 needless-pass-by-ref-mut = "warn"
 string-lit-as-bytes = "warn"
-result-large-err = "allow"
 
 [profile.dev]
 debug = "line-tables-only"

--- a/bin/base/src/config.rs
+++ b/bin/base/src/config.rs
@@ -224,6 +224,7 @@ mod tests {
 
     use super::*;
 
+    #[allow(clippy::result_large_err)]
     fn with_cleared_env(test: impl FnOnce(&mut Jail) -> figment::Result<()>) {
         Jail::expect_with(|jail| {
             jail.clear_env();
@@ -232,6 +233,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::result_large_err)]
     fn resolves_mainnet_builtin() {
         with_cleared_env(|_| {
             let resolved =
@@ -247,6 +249,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::result_large_err)]
     fn resolves_sepolia_builtin() {
         with_cleared_env(|_| {
             let resolved =
@@ -261,6 +264,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::result_large_err)]
     fn resolves_zeronet_builtin() {
         with_cleared_env(|_| {
             let resolved =
@@ -275,6 +279,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::result_large_err)]
     fn resolves_custom_toml_file() {
         with_cleared_env(|jail| {
             let path = jail.directory().join("chain.toml");

--- a/crates/builder/publish/src/listener.rs
+++ b/crates/builder/publish/src/listener.rs
@@ -71,6 +71,7 @@ impl Listener {
 
                     tokio::spawn(async move {
                         let (pos_tx, pos_rx) = tokio::sync::oneshot::channel();
+                        #[allow(clippy::result_large_err)]
                         let handshake = accept_hdr_async(connection, move |req: &http::Request<()>, resp| {
                             let _ = pos_tx.send(parse_resume_position(req));
                             Ok(resp)

--- a/crates/builder/publish/src/listener.rs
+++ b/crates/builder/publish/src/listener.rs
@@ -46,6 +46,7 @@ impl Listener {
     }
 
     /// Runs the listener loop, accepting connections until cancelled.
+    #[allow(clippy::result_large_err)]
     pub async fn run(self) {
         let Self { listener, metrics, receiver, ring_buffer, cancel } = self;
 

--- a/crates/builder/publish/src/listener.rs
+++ b/crates/builder/publish/src/listener.rs
@@ -46,7 +46,6 @@ impl Listener {
     }
 
     /// Runs the listener loop, accepting connections until cancelled.
-    #[allow(clippy::result_large_err)]
     pub async fn run(self) {
         let Self { listener, metrics, receiver, ring_buffer, cancel } = self;
 

--- a/crates/consensus/engine/src/ws_connect.rs
+++ b/crates/consensus/engine/src/ws_connect.rs
@@ -102,6 +102,7 @@ mod tests {
 
     /// Like [`capture_auth_header`] but borrows the listener, allowing it to
     /// be reused for subsequent accepts.
+    #[allow(clippy::result_large_err)]
     async fn capture_auth_header_from_listener(listener: &TcpListener) -> String {
         let (stream, _) = listener.accept().await.unwrap();
         let (tx, rx) = oneshot::channel::<String>();

--- a/crates/proof/driver/src/core.rs
+++ b/crates/proof/driver/src/core.rs
@@ -96,7 +96,7 @@ where
                 }
                 Err(e) => {
                     error!(target: "client", error = ?e, "Failed to produce payload");
-                    return Err(DriverError::Pipeline(e));
+                    return Err(e.into());
                 }
             };
 

--- a/crates/proof/driver/src/errors.rs
+++ b/crates/proof/driver/src/errors.rs
@@ -1,5 +1,7 @@
 //! Contains driver-related error types.
 
+use alloc::boxed::Box;
+
 use base_consensus_derive::PipelineErrorKind;
 use base_protocol::FromBlockError;
 use thiserror::Error;
@@ -15,7 +17,7 @@ where
 {
     /// Pipeline error.
     #[error("Pipeline error: {0}")]
-    Pipeline(#[from] PipelineErrorKind),
+    Pipeline(#[source] Box<PipelineErrorKind>),
     /// An error returned by the executor.
     #[error("Executor error: {0}")]
     Executor(E),
@@ -25,4 +27,13 @@ where
     /// Error decoding or encoding RLP.
     #[error("RLP error: {0}")]
     Rlp(alloy_rlp::Error),
+}
+
+impl<E> From<PipelineErrorKind> for DriverError<E>
+where
+    E: core::error::Error,
+{
+    fn from(e: PipelineErrorKind) -> Self {
+        Self::Pipeline(Box::new(e))
+    }
 }

--- a/crates/proof/succinct/programs/Cargo.toml
+++ b/crates/proof/succinct/programs/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 [workspace.package]
 version = "0.0.0"
 edition = "2024"
-rust-version = "1.93"
+rust-version = "1.94"
 license = "MIT"
 homepage = "https://github.com/base/base"
 repository = "https://github.com/base/base"

--- a/crates/proof/succinct/utils/client/src/client.rs
+++ b/crates/proof/succinct/utils/client/src/client.rs
@@ -110,7 +110,7 @@ where
             }
             Err(e) => {
                 error!(target: "client", "Failed to produce payload: {:?}", e);
-                return Err(DriverError::Pipeline(e));
+                return Err(e.into());
             }
         };
         #[cfg(target_os = "zkvm")]

--- a/crates/proof/succinct/utils/client/src/client.rs
+++ b/crates/proof/succinct/utils/client/src/client.rs
@@ -109,7 +109,7 @@ where
                 continue;
             }
             Err(e) => {
-                error!(target: "client", "Failed to produce payload: {:?}", e);
+                error!(target: "client", error = ?e, "Failed to produce payload");
                 return Err(e.into());
             }
         };

--- a/crates/proof/tee/nitro-attestation-prover/guest/.cargo/config.toml
+++ b/crates/proof/tee/nitro-attestation-prover/guest/.cargo/config.toml
@@ -1,4 +1,4 @@
-# The risc0 toolchain ships an older rustc (1.91) than the workspace MSRV (1.93).
+# The risc0 toolchain ships an older rustc (1.91) than the workspace MSRV (1.94).
 # The --ignore-rust-version flag is required when invoking cargo build.
 #
 # IMPORTANT: Always use `just build` / `just bundle` for reproducible builds.

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.93.1"
+channel = "1.94.1"
 components = ["clippy", "rustfmt"]


### PR DESCRIPTION
## Summary

  - Bumps `rust-toolchain.toml` from `1.93.1` to `1.94.1`
  - Bumps `rust-version` in the workspace `Cargo.toml` from `1.93` to `1.94`
  - Bumps `rust-version` in `crates/proof/succinct/programs/Cargo.toml` for consistency (built via SP1 Docker
  toolchain, not affected functionally)
  - Updates the Rust version requirement in `CONTRIBUTING.md`

## Not affected

  - SP1 programs — built in a pinned Docker image, isolated from the workspace toolchain
  - Risc0 guest — already uses `--ignore-rust-version`
  - `no-std` and `format` CI jobs — both use nightly