### PR TITLE
fix(load-test): record TPS on first to last block

### DIFF
--- a/crates/infra/load-tests/src/metrics/aggregator.rs
+++ b/crates/infra/load-tests/src/metrics/aggregator.rs
@@ -20,9 +20,13 @@ impl<'a> MetricsAggregator<'a> {
     }
 
     /// Computes summary statistics from the collected metrics.
+    ///
+    /// `wall_clock_duration` is used as a fallback for TPS when block timestamps
+    /// are unavailable. When block timestamps are present, TPS is derived from
+    /// the first-to-last block time span instead.
     pub fn summarize(
         &self,
-        duration: Duration,
+        wall_clock_duration: Duration,
         submitted: u64,
         failed: u64,
         failure_reasons: &HashMap<String, u64>,
@@ -37,17 +41,20 @@ impl<'a> MetricsAggregator<'a> {
         let tps_values: Vec<f64> = throughput_samples.iter().map(|s| s.tps).collect();
         let gps_values: Vec<f64> = throughput_samples.iter().map(|s| s.gps).collect();
 
+        let block_range = self.compute_block_range();
+        let throughput_duration = block_range.block_time_duration().unwrap_or(wall_clock_duration);
+
         MetricsSummary {
             config,
             error: None,
             block_latency: self.compute_block_latency(),
             block_receipt_delay: self.compute_block_receipt_delay(),
             flashblocks_latency: self.compute_flashblocks_latency(),
-            throughput: self.compute_throughput(duration, submitted, failed),
+            throughput: self.compute_throughput(throughput_duration, submitted, failed),
             throughput_percentiles: Self::compute_throughput_percentiles(&tps_values, &gps_values),
             throughput_timeseries: throughput_samples.to_vec(),
             gas: self.compute_gas(),
-            block_range: self.compute_block_range(),
+            block_range,
             top_failure_reasons,
         }
     }

--- a/crates/infra/load-tests/src/metrics/collector.rs
+++ b/crates/infra/load-tests/src/metrics/collector.rs
@@ -106,12 +106,16 @@ impl MetricsCollector {
 
     /// Generates a summary of collected metrics.
     ///
-    /// `duration` should span from first submission to last confirmation
-    /// so that the reported TPS reflects end-to-end throughput.
-    pub fn summarize(&self, duration: Duration, config: Option<ConfigSummary>) -> MetricsSummary {
+    /// `wall_clock_duration` is used as a fallback when block timestamps are
+    /// unavailable. TPS is normally derived from block time span.
+    pub fn summarize(
+        &self,
+        wall_clock_duration: Duration,
+        config: Option<ConfigSummary>,
+    ) -> MetricsSummary {
         let aggregator = MetricsAggregator::new(&self.transactions);
         aggregator.summarize(
-            duration,
+            wall_clock_duration,
             self.submitted_count,
             self.failed_count,
             &self.failure_reasons,

--- a/crates/infra/load-tests/src/metrics/types.rs
+++ b/crates/infra/load-tests/src/metrics/types.rs
@@ -147,6 +147,9 @@ pub struct ThroughputSample {
     pub gps: f64,
 }
 
+/// L2 block interval (2 seconds per block).
+const BLOCK_INTERVAL: Duration = Duration::from_secs(2);
+
 /// Range of block numbers in which test transactions were included.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct BlockRange {
@@ -159,6 +162,17 @@ pub struct BlockRange {
     /// Inclusive number of blocks spanned (`last_block - first_block + 1`),
     /// or `0` when no test transactions were confirmed.
     pub block_count: u64,
+}
+
+impl BlockRange {
+    /// Returns the duration spanned by this block range using the fixed L2 block interval,
+    /// or `None` when the range spans fewer than 2 blocks.
+    pub fn block_time_duration(&self) -> Option<Duration> {
+        if self.block_count < 2 {
+            return None;
+        }
+        Some(BLOCK_INTERVAL * (self.block_count - 1) as u32)
+    }
 }
 
 /// Aggregated flashblocks latency percentiles.


### PR DESCRIPTION
currently TPS is based on start.elapsed and not the first block timestamp of when the load test happens. we should record TPS from the [first, last] block time range and not account setup time as part of TPS