### PR TITLE
feat(precompiles): add EIP-8130 transaction context and nonce manager precompiles

### DIFF
--- a/crates/common/precompile-storage/src/error.rs
+++ b/crates/common/precompile-storage/src/error.rs
@@ -99,6 +99,15 @@ impl BasePrecompileError {
         Self::Panic(PanicKind::ArrayOutOfBounds)
     }
 
+    /// Creates an assertion-failure panic error (Solidity `Panic(0x01)`).
+    ///
+    /// Use for internal invariants that must always hold. It is classified as a
+    /// system error (see [`Self::is_system_error`]) so it propagates and fails
+    /// the transaction rather than surfacing as a catchable revert.
+    pub const fn assert_failed() -> Self {
+        Self::Panic(PanicKind::Assert)
+    }
+
     /// ABI-encodes this error and wraps it as a [`PrecompileResult`] (revert or fatal error).
     ///
     /// Internal dispatch diagnostics use compact, non-ABI revert data: unknown selectors return the

--- a/crates/common/precompile-storage/src/evm.rs
+++ b/crates/common/precompile-storage/src/evm.rs
@@ -39,6 +39,7 @@ pub struct EvmPrecompileStorageProvider<'a> {
     timestamp: U256,
     chain_id: u64,
     beneficiary: Address,
+    origin: Address,
     state_gas_used: u64,
 }
 
@@ -54,6 +55,7 @@ impl<'a> EvmPrecompileStorageProvider<'a> {
         let timestamp = internals.block_env().timestamp();
         let chain_id = internals.chain_id();
         let beneficiary = internals.block_env().beneficiary();
+        let origin = internals.tx_origin();
 
         Self {
             internals,
@@ -66,6 +68,7 @@ impl<'a> EvmPrecompileStorageProvider<'a> {
             timestamp,
             chain_id,
             beneficiary,
+            origin,
             state_gas_used: 0,
         }
     }
@@ -86,6 +89,10 @@ impl PrecompileStorageProvider for EvmPrecompileStorageProvider<'_> {
 
     fn block_number(&self) -> u64 {
         self.block_number
+    }
+
+    fn origin(&self) -> Address {
+        self.origin
     }
 
     fn set_code(&mut self, address: Address, code: Bytecode) -> Result<()> {

--- a/crates/common/precompile-storage/src/hashmap.rs
+++ b/crates/common/precompile-storage/src/hashmap.rs
@@ -23,6 +23,7 @@ pub struct HashMapStorageProvider {
     timestamp: U256,
     beneficiary: Address,
     block_number: u64,
+    origin: Address,
     caller: Address,
     call_value: U256,
     is_static: bool,
@@ -68,6 +69,7 @@ impl HashMapStorageProvider {
             ),
             beneficiary: Address::ZERO,
             block_number: 0,
+            origin: Address::ZERO,
             caller: Address::ZERO,
             call_value: U256::ZERO,
             is_static: false,
@@ -97,6 +99,10 @@ impl PrecompileStorageProvider for HashMapStorageProvider {
 
     fn block_number(&self) -> u64 {
         self.block_number
+    }
+
+    fn origin(&self) -> Address {
+        self.origin
     }
 
     fn set_code(&mut self, address: Address, code: Bytecode) -> Result<(), BasePrecompileError> {
@@ -335,6 +341,11 @@ impl HashMapStorageProvider {
     /// Sets the native call value in wei (test-utils only).
     pub const fn set_call_value(&mut self, value: U256) {
         self.call_value = value;
+    }
+
+    /// Overrides the transaction origin (`tx.origin`) (test-utils only).
+    pub const fn set_origin(&mut self, origin: Address) {
+        self.origin = origin;
     }
 
     /// Sets whether the current call is static (test-utils only).

--- a/crates/common/precompile-storage/src/provider.rs
+++ b/crates/common/precompile-storage/src/provider.rs
@@ -25,6 +25,8 @@ pub trait PrecompileStorageProvider {
     fn beneficiary(&self) -> Address;
     /// Returns the current block number.
     fn block_number(&self) -> u64;
+    /// Returns the transaction origin (`tx.origin`).
+    fn origin(&self) -> Address;
 
     /// Sets the bytecode at the given address.
     fn set_code(&mut self, address: Address, code: Bytecode) -> Result<()>;

--- a/crates/common/precompile-storage/src/storage_ctx.rs
+++ b/crates/common/precompile-storage/src/storage_ctx.rs
@@ -107,6 +107,10 @@ impl<'a> StorageCtx<'a> {
     pub fn block_number(&self) -> u64 {
         self.with_storage(|s| s.block_number())
     }
+    /// Returns the transaction origin (`tx.origin`).
+    pub fn origin(&self) -> Address {
+        self.with_storage(|s| s.origin())
+    }
 
     /// Sets the bytecode at the given address.
     pub fn set_code(&self, address: Address, code: Bytecode) -> Result<()> {

--- a/crates/common/precompiles/src/lib.rs
+++ b/crates/common/precompiles/src/lib.rs
@@ -79,3 +79,6 @@ pub use policy::{
 
 mod tx_context;
 pub use tx_context::{ITxContext, TxContext, TxContextStorage};
+
+mod nonce;
+pub use nonce::{INonce, NonceManager, NonceManagerStorage};

--- a/crates/common/precompiles/src/lib.rs
+++ b/crates/common/precompiles/src/lib.rs
@@ -78,7 +78,7 @@ pub use policy::{
 };
 
 mod tx_context;
-pub use tx_context::{ITxContext, TxContext, TxContextStorage};
+pub use tx_context::{ITransactionContext, TxContext, TxContextStorage};
 
 mod nonce;
-pub use nonce::{INonce, NonceManager, NonceManagerStorage};
+pub use nonce::{INonceManager, NonceManager, NonceManagerStorage};

--- a/crates/common/precompiles/src/lib.rs
+++ b/crates/common/precompiles/src/lib.rs
@@ -76,3 +76,6 @@ mod policy;
 pub use policy::{
     IPolicyRegistry, PackedPolicy, PolicyHandle, PolicyRegistryPrecompile, PolicyRegistryStorage,
 };
+
+mod tx_context;
+pub use tx_context::{ITxContext, TxContext, TxContextStorage};

--- a/crates/common/precompiles/src/nonce/abi.rs
+++ b/crates/common/precompiles/src/nonce/abi.rs
@@ -1,0 +1,42 @@
+//! ABI definitions for the EIP-8130 2D nonce manager precompile.
+
+use alloy_sol_types::sol;
+
+sol! {
+    /// EIP-8130 2D nonce manager ABI.
+    ///
+    /// Exposes the per-`(account, nonceKey)` sequence nonces that enable
+    /// concurrent EIP-8130 transaction execution. Nonce key `0` is reserved for
+    /// the protocol nonce and is stored in account state rather than here, so it
+    /// is not readable through this precompile.
+    interface INonce {
+        /// Precompile cannot be executed via delegatecall or callcode.
+        error DelegateCallNotAllowed();
+
+        /// Nonce key `0` is the protocol nonce and is not served by this precompile.
+        error ProtocolNonceNotSupported();
+
+        /// Nonce key `0` is reserved for the protocol nonce and cannot be incremented here.
+        error InvalidNonceKey();
+
+        /// The 2D nonce for the `(account, nonceKey)` channel is already at its maximum.
+        error NonceOverflow();
+
+        /// Expiring-nonce `validBefore` is outside the allowed `(now, now + maxExpiry]` window.
+        error InvalidExpiringNonceExpiry();
+
+        /// An expiring-nonce replay hash has already been recorded and has not yet expired.
+        error ExpiringNonceReplay();
+
+        /// The expiring-nonce ring buffer is full of unexpired entries and cannot accept more.
+        error ExpiringNonceSetFull();
+
+        /// Emitted when the 2D nonce for `(account, nonceKey)` is incremented to `newNonce`.
+        event NonceIncremented(address indexed account, uint256 indexed nonceKey, uint64 newNonce);
+
+        /// Returns the current 2D nonce for `account` at `nonceKey`.
+        ///
+        /// Reverts with `ProtocolNonceNotSupported` for nonce key `0`.
+        function getNonce(address account, uint256 nonceKey) external view returns (uint64);
+    }
+}

--- a/crates/common/precompiles/src/nonce/abi.rs
+++ b/crates/common/precompiles/src/nonce/abi.rs
@@ -9,7 +9,7 @@ sol! {
     /// concurrent EIP-8130 transaction execution. Nonce key `0` is reserved for
     /// the protocol nonce and is stored in account state rather than here, so it
     /// is not readable through this precompile.
-    interface INonce {
+    interface INonceManager {
         /// Precompile cannot be executed via delegatecall or callcode.
         error DelegateCallNotAllowed();
 

--- a/crates/common/precompiles/src/nonce/dispatch.rs
+++ b/crates/common/precompiles/src/nonce/dispatch.rs
@@ -1,0 +1,90 @@
+//! ABI dispatch for the EIP-8130 2D nonce manager precompile.
+
+use alloy_primitives::Bytes;
+use alloy_sol_types::SolCall;
+use base_precompile_storage::{IntoPrecompileResult, StorageCtx};
+use revm::precompile::PrecompileResult;
+
+use crate::{
+    INonce::{self, INonceCalls as C},
+    macros::{decode_precompile_call, deduct_calldata_cost},
+    nonce::storage::NonceManagerStorage,
+};
+
+impl NonceManagerStorage<'_> {
+    /// ABI-dispatches nonce manager calldata.
+    ///
+    /// Only the read-only `getNonce` getter is reachable through the ABI; the
+    /// nonce-mutating entry points (`increment_nonce`, `check_and_mark_expiring_nonce`)
+    /// are driven by the EIP-8130 execution layer, not by EVM calls.
+    pub fn dispatch(&self, ctx: StorageCtx<'_>, calldata: &[u8]) -> PrecompileResult {
+        deduct_calldata_cost!(ctx, calldata);
+        self.inner(calldata).into_precompile_result(
+            ctx.gas_used(),
+            ctx.state_gas_used(),
+            |output| output,
+        )
+    }
+
+    fn inner(&self, calldata: &[u8]) -> base_precompile_storage::Result<Bytes> {
+        match decode_precompile_call!(calldata, INonce::INonceCalls) {
+            C::getNonce(call) => Ok(INonce::getNonceCall::abi_encode_returns(
+                &self.get_nonce(call.account, call.nonceKey)?,
+            )
+            .into()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_primitives::{Address, U256, address};
+    use alloy_sol_types::SolCall;
+    use base_precompile_storage::{HashMapStorageProvider, StorageCtx};
+
+    use crate::{INonce, NonceManagerStorage};
+
+    const ACCOUNT: Address = address!("0x1111111111111111111111111111111111111111");
+
+    fn dispatch(
+        storage: &mut HashMapStorageProvider,
+        calldata: &[u8],
+    ) -> revm::precompile::PrecompileOutput {
+        StorageCtx::enter(storage, |ctx| NonceManagerStorage::new(ctx).dispatch(ctx, calldata))
+            .expect("dispatch should not fail fatally")
+    }
+
+    #[test]
+    fn dispatch_get_nonce_returns_current_value() {
+        let mut storage = HashMapStorageProvider::new(1);
+        let nonce_key = U256::from(9);
+        StorageCtx::enter(&mut storage, |ctx| {
+            let mut mgr = NonceManagerStorage::new(ctx);
+            mgr.increment_nonce(ACCOUNT, nonce_key).unwrap();
+            mgr.increment_nonce(ACCOUNT, nonce_key).unwrap();
+        });
+
+        let calldata = INonce::getNonceCall { account: ACCOUNT, nonceKey: nonce_key }.abi_encode();
+        let output = dispatch(&mut storage, &calldata);
+
+        assert!(!output.is_revert());
+        assert_eq!(INonce::getNonceCall::abi_decode_returns(&output.bytes).unwrap(), 2);
+    }
+
+    #[test]
+    fn dispatch_get_nonce_reverts_for_protocol_nonce() {
+        let mut storage = HashMapStorageProvider::new(1);
+        let calldata = INonce::getNonceCall { account: ACCOUNT, nonceKey: U256::ZERO }.abi_encode();
+        let output = dispatch(&mut storage, &calldata);
+
+        assert!(output.is_revert());
+    }
+
+    #[test]
+    fn dispatch_reverts_on_unknown_selector() {
+        let mut storage = HashMapStorageProvider::new(1);
+        let output = dispatch(&mut storage, &[0xde, 0xad, 0xbe, 0xef]);
+
+        assert!(output.is_revert());
+    }
+}

--- a/crates/common/precompiles/src/nonce/dispatch.rs
+++ b/crates/common/precompiles/src/nonce/dispatch.rs
@@ -7,9 +7,12 @@ use revm::precompile::PrecompileResult;
 
 use crate::{
     INonceManager::{self, INonceManagerCalls as C},
-    macros::{decode_precompile_call, deduct_calldata_cost},
+    macros::decode_precompile_call,
     nonce::storage::NonceManagerStorage,
 };
+
+/// Per-word calldata gas charge (`G_SHA3WORD`), matching common Base precompile dispatch.
+const CALLDATA_WORD_GAS: u64 = 6;
 
 impl NonceManagerStorage<'_> {
     /// ABI-dispatches nonce manager calldata.
@@ -18,10 +21,15 @@ impl NonceManagerStorage<'_> {
     /// nonce-mutating entry points (`increment_nonce`, `check_and_mark_expiring_nonce`)
     /// are driven by the EIP-8130 execution layer, not by EVM calls.
     pub fn dispatch(&self, ctx: StorageCtx<'_>, calldata: &[u8]) -> PrecompileResult {
-        deduct_calldata_cost!(ctx, calldata);
+        let calldata_cost = (calldata.len() as u64).div_ceil(32).saturating_mul(CALLDATA_WORD_GAS);
+        if let Err(error) = ctx.deduct_gas(calldata_cost) {
+            return error.into_precompile_result(ctx.gas_used(), ctx.state_gas_used());
+        }
+        // `getNonce` is a read-only getter and never produces a gas refund.
         self.inner(calldata).into_precompile_result(
             ctx.gas_used(),
             ctx.state_gas_used(),
+            0,
             |output| output,
         )
     }

--- a/crates/common/precompiles/src/nonce/dispatch.rs
+++ b/crates/common/precompiles/src/nonce/dispatch.rs
@@ -6,7 +6,7 @@ use base_precompile_storage::{IntoPrecompileResult, StorageCtx};
 use revm::precompile::PrecompileResult;
 
 use crate::{
-    INonce::{self, INonceCalls as C},
+    INonceManager::{self, INonceManagerCalls as C},
     macros::{decode_precompile_call, deduct_calldata_cost},
     nonce::storage::NonceManagerStorage,
 };
@@ -27,8 +27,8 @@ impl NonceManagerStorage<'_> {
     }
 
     fn inner(&self, calldata: &[u8]) -> base_precompile_storage::Result<Bytes> {
-        match decode_precompile_call!(calldata, INonce::INonceCalls) {
-            C::getNonce(call) => Ok(INonce::getNonceCall::abi_encode_returns(
+        match decode_precompile_call!(calldata, INonceManager::INonceManagerCalls) {
+            C::getNonce(call) => Ok(INonceManager::getNonceCall::abi_encode_returns(
                 &self.get_nonce(call.account, call.nonceKey)?,
             )
             .into()),
@@ -42,7 +42,7 @@ mod tests {
     use alloy_sol_types::SolCall;
     use base_precompile_storage::{HashMapStorageProvider, StorageCtx};
 
-    use crate::{INonce, NonceManagerStorage};
+    use crate::{INonceManager, NonceManagerStorage};
 
     const ACCOUNT: Address = address!("0x1111111111111111111111111111111111111111");
 
@@ -64,17 +64,19 @@ mod tests {
             mgr.increment_nonce(ACCOUNT, nonce_key).unwrap();
         });
 
-        let calldata = INonce::getNonceCall { account: ACCOUNT, nonceKey: nonce_key }.abi_encode();
+        let calldata =
+            INonceManager::getNonceCall { account: ACCOUNT, nonceKey: nonce_key }.abi_encode();
         let output = dispatch(&mut storage, &calldata);
 
         assert!(!output.is_revert());
-        assert_eq!(INonce::getNonceCall::abi_decode_returns(&output.bytes).unwrap(), 2);
+        assert_eq!(INonceManager::getNonceCall::abi_decode_returns(&output.bytes).unwrap(), 2);
     }
 
     #[test]
     fn dispatch_get_nonce_reverts_for_protocol_nonce() {
         let mut storage = HashMapStorageProvider::new(1);
-        let calldata = INonce::getNonceCall { account: ACCOUNT, nonceKey: U256::ZERO }.abi_encode();
+        let calldata =
+            INonceManager::getNonceCall { account: ACCOUNT, nonceKey: U256::ZERO }.abi_encode();
         let output = dispatch(&mut storage, &calldata);
 
         assert!(output.is_revert());

--- a/crates/common/precompiles/src/nonce/mod.rs
+++ b/crates/common/precompiles/src/nonce/mod.rs
@@ -1,0 +1,12 @@
+//! EIP-8130 2D nonce manager native precompile.
+
+mod abi;
+pub use abi::INonce;
+
+mod storage;
+pub use storage::NonceManagerStorage;
+
+mod dispatch;
+
+mod precompile;
+pub use precompile::NonceManager;

--- a/crates/common/precompiles/src/nonce/mod.rs
+++ b/crates/common/precompiles/src/nonce/mod.rs
@@ -1,7 +1,7 @@
 //! EIP-8130 2D nonce manager native precompile.
 
 mod abi;
-pub use abi::INonce;
+pub use abi::INonceManager;
 
 mod storage;
 pub use storage::NonceManagerStorage;

--- a/crates/common/precompiles/src/nonce/precompile.rs
+++ b/crates/common/precompiles/src/nonce/precompile.rs
@@ -1,0 +1,10 @@
+//! Precompile entry point for the EIP-8130 2D nonce manager.
+
+use base_precompile_macros::precompile;
+
+use crate::NonceManagerStorage;
+
+/// Entry point for the EIP-8130 2D nonce manager precompile.
+#[precompile(install)]
+#[derive(Debug, Default, Clone, Copy)]
+pub struct NonceManager;

--- a/crates/common/precompiles/src/nonce/storage.rs
+++ b/crates/common/precompiles/src/nonce/storage.rs
@@ -90,6 +90,13 @@ impl NonceManagerStorage<'_> {
         if nonce_key == Self::PROTOCOL_NONCE_KEY {
             return Err(BasePrecompileError::revert(INonceManager::InvalidNonceKey {}));
         }
+
+        // The nonce write and its NonceIncremented event must commit together;
+        // guard them with a checkpoint so a failure after the write (e.g. during
+        // event emission) reverts the advanced nonce rather than leaving it
+        // advanced without a log. The guard reverts on drop unless committed.
+        let checkpoint = self.storage.checkpoint();
+
         self.__initialize()?;
         let current = self.nonces.at(&account).at(&nonce_key).read()?;
         let new_nonce = current
@@ -101,6 +108,8 @@ impl NonceManagerStorage<'_> {
             nonceKey: nonce_key,
             newNonce: new_nonce,
         })?;
+
+        checkpoint.commit();
         Ok(new_nonce)
     }
 

--- a/crates/common/precompiles/src/nonce/storage.rs
+++ b/crates/common/precompiles/src/nonce/storage.rs
@@ -105,7 +105,14 @@ impl NonceManagerStorage<'_> {
     }
 
     /// Returns whether `hash` has been recorded and has not yet expired relative
-    /// to `now` (Unix seconds). Intended for transaction-pool replay checks.
+    /// to `now` (Unix seconds).
+    ///
+    /// Intended for transaction-pool replay checks. `now` is a caller-supplied
+    /// timestamp because the mempool has no block context and uses wall-clock
+    /// time, whereas [`Self::check_and_mark_expiring_nonce`] reads the block
+    /// timestamp internally at inclusion. The two clocks can disagree near an
+    /// entry's expiry boundary; this getter is an advisory pre-filter and the
+    /// block-timestamp check at inclusion is authoritative.
     pub fn is_expiring_nonce_seen(&self, hash: B256, now: u64) -> Result<bool> {
         let expiry = self.expiring_nonce_seen.at(&hash).read()?;
         Ok(expiry != 0 && expiry > now)
@@ -115,10 +122,14 @@ impl NonceManagerStorage<'_> {
     /// protection for nonce-free EIP-8130 transactions.
     ///
     /// `expiring_nonce_hash` is the signature-invariant replay hash
-    /// (`keccak256(encode_for_signing || sender)`), so re-signed fee-payer
-    /// variants of one logical transaction collapse to a single entry. The hash
-    /// is recorded in a circular buffer that reclaims expired slots as the write
-    /// pointer advances.
+    /// (`keccak256(resolved_sender || sender_signature_hash)`), so re-signed
+    /// fee-payer variants of one logical transaction collapse to a single entry.
+    /// The hash is recorded in a circular buffer that reclaims expired slots as
+    /// the write pointer advances.
+    ///
+    /// `now` is read from the block timestamp, so this is the authoritative
+    /// inclusion-time replay check (cf. the advisory, wall-clock-based
+    /// [`Self::is_expiring_nonce_seen`] used by the mempool).
     ///
     /// Intended for the EIP-8130 execution layer; not reachable through ABI
     /// dispatch.
@@ -149,6 +160,15 @@ impl NonceManagerStorage<'_> {
             return Err(BasePrecompileError::revert(INonceManager::ExpiringNonceReplay {}));
         }
 
+        // Steps 3–6 mutate four correlated persistent slots (the reclaimed old
+        // entry, the ring slot, the new seen entry, and the write pointer). Guard
+        // them with a checkpoint so a mid-sequence failure reverts the whole group
+        // atomically — otherwise a partial write could record an entry in
+        // `expiring_nonce_seen` whose ring slot is never reclaimable because the
+        // pointer never advanced. The guard reverts on drop unless committed, so
+        // any early `?` return below rolls back every write in the group.
+        let checkpoint = self.storage.checkpoint();
+
         self.__initialize()?;
 
         // 3. Inspect the entry the write pointer currently references.
@@ -174,6 +194,7 @@ impl NonceManagerStorage<'_> {
         let next = if ptr + 1 >= Self::EXPIRING_NONCE_SET_CAPACITY { 0 } else { ptr + 1 };
         self.expiring_nonce_ring_ptr.write(next)?;
 
+        checkpoint.commit();
         Ok(())
     }
 }

--- a/crates/common/precompiles/src/nonce/storage.rs
+++ b/crates/common/precompiles/src/nonce/storage.rs
@@ -200,7 +200,10 @@ impl NonceManagerStorage<'_> {
         self.expiring_nonce_seen.at_mut(&expiring_nonce_hash).write(valid_before)?;
 
         // 6. Advance the write pointer, wrapping at capacity (not u32::MAX).
-        let next = if ptr + 1 >= Self::EXPIRING_NONCE_SET_CAPACITY { 0 } else { ptr + 1 };
+        // `wrapping_add` is defensive: a corrupted ptr at u32::MAX wraps to 0
+        // (still < capacity) rather than panicking in debug builds.
+        let incremented = ptr.wrapping_add(1);
+        let next = if incremented >= Self::EXPIRING_NONCE_SET_CAPACITY { 0 } else { incremented };
         self.expiring_nonce_ring_ptr.write(next)?;
 
         checkpoint.commit();
@@ -263,6 +266,39 @@ mod tests {
             let err =
                 NonceManagerStorage::new(ctx).increment_nonce(ACCOUNT_A, U256::ZERO).unwrap_err();
             assert_eq!(err, BasePrecompileError::revert(INonceManager::InvalidNonceKey {}));
+        });
+    }
+
+    #[test]
+    fn increment_nonce_rejects_overflow() {
+        let mut storage = HashMapStorageProvider::new(1);
+        let nonce_key = U256::from(9);
+        StorageCtx::enter(&mut storage, |ctx| {
+            let mut mgr = NonceManagerStorage::new(ctx);
+            // Seed the channel at the maximum so the next increment overflows.
+            mgr.nonces.at_mut(&ACCOUNT_A).at_mut(&nonce_key).write(u64::MAX).unwrap();
+            let err = mgr.increment_nonce(ACCOUNT_A, nonce_key).unwrap_err();
+            assert_eq!(err, BasePrecompileError::revert(INonceManager::NonceOverflow {}));
+        });
+    }
+
+    #[test]
+    fn expiring_nonce_rejects_when_ring_slot_is_live() {
+        let mut storage = HashMapStorageProvider::new(1);
+        let now = 1_000u64;
+        storage.set_timestamp(U256::from(now));
+        StorageCtx::enter(&mut storage, |ctx| {
+            let mut mgr = NonceManagerStorage::new(ctx);
+            // Occupy the slot the write pointer references with an unexpired entry
+            // (simulating a full ring) so the slot cannot be reclaimed.
+            let occupant = B256::repeat_byte(0xAB);
+            let ptr = mgr.expiring_nonce_ring_ptr.read().unwrap();
+            mgr.expiring_nonce_ring.at_mut(&ptr).write(occupant).unwrap();
+            mgr.expiring_nonce_seen.at_mut(&occupant).write(now + 20).unwrap();
+
+            let err =
+                mgr.check_and_mark_expiring_nonce(B256::repeat_byte(0xCD), now + 20).unwrap_err();
+            assert_eq!(err, BasePrecompileError::revert(INonceManager::ExpiringNonceSetFull {}));
         });
     }
 

--- a/crates/common/precompiles/src/nonce/storage.rs
+++ b/crates/common/precompiles/src/nonce/storage.rs
@@ -45,10 +45,10 @@ pub struct NonceManagerStorage {
 impl NonceManagerStorage<'_> {
     /// 2D nonce manager precompile address.
     ///
-    /// Provisional: the EIP-8130 nonce-manager address is not finalized upstream.
-    /// Uses the `0x8130…` namespace (the EIP number) reserved for EIP-8130 system
-    /// precompiles and can be renumbered when the spec pins a concrete value.
-    pub const ADDRESS: Address = address!("813000000000000000000000000000000000aa02");
+    /// Pinned to `NONCE_MANAGER_ADDRESS` from the EIP-8130 constant table
+    /// (`0x8130…aa01`, in the `0x8130…` / EIP-number namespace for EIP-8130
+    /// system precompiles).
+    pub const ADDRESS: Address = address!("813000000000000000000000000000000000aa01");
 
     /// Capacity of the expiring-nonce ring buffer.
     ///

--- a/crates/common/precompiles/src/nonce/storage.rs
+++ b/crates/common/precompiles/src/nonce/storage.rs
@@ -1,0 +1,336 @@
+//! Storage layout and constants for the EIP-8130 2D nonce manager precompile.
+
+use alloy_primitives::{Address, B256, U256, address};
+use base_precompile_macros::contract;
+use base_precompile_storage::{BasePrecompileError, Handler, Mapping, Result};
+
+use crate::INonce;
+
+/// Persistent 2D nonce manager for EIP-8130 account-abstraction transactions.
+///
+/// Mirrors a Solidity contract with the layout:
+///
+/// ```solidity
+/// contract NonceManager {
+///     mapping(address => mapping(uint256 => uint64)) nonces;  // slot 0
+///     mapping(bytes32 => uint64) expiringNonceSeen;           // slot 1: replay hash => expiry
+///     mapping(uint32 => bytes32) expiringNonceRing;           // slot 2: circular buffer
+///     uint32 expiringNonceRingPtr;                            // slot 3: ring write position
+/// }
+/// ```
+///
+/// The 2D nonce (`nonces`) provides sequence-nonce channels keyed by an
+/// arbitrary `nonce_key`, allowing a sender to have many independently-ordered
+/// in-flight transactions. Nonce key `0` is the protocol nonce and lives in
+/// account state, not here.
+///
+/// The expiring-nonce structures provide replay protection for nonce-free
+/// (`NONCE_KEY_MAX`) transactions: a signature-invariant replay hash is recorded
+/// with its expiry in a fixed-capacity circular buffer that reclaims expired
+/// slots as the write pointer advances.
+#[contract(addr = Self::ADDRESS)]
+#[namespace("base.nonce_manager")]
+pub struct NonceManagerStorage {
+    /// 2D sequence nonces keyed by `(account, nonce_key)`.
+    pub nonces: Mapping<Address, Mapping<U256, u64>>,
+    /// Expiring-nonce seen set: replay hash => `valid_before` expiry timestamp.
+    pub expiring_nonce_seen: Mapping<B256, u64>,
+    /// Circular buffer of recorded replay hashes, indexed by ring position.
+    pub expiring_nonce_ring: Mapping<u32, B256>,
+    /// Current circular-buffer write position; wraps at
+    /// [`Self::EXPIRING_NONCE_SET_CAPACITY`].
+    pub expiring_nonce_ring_ptr: u32,
+}
+
+impl NonceManagerStorage<'_> {
+    /// 2D nonce manager precompile address.
+    ///
+    /// Provisional: the EIP-8130 nonce-manager address is not finalized upstream.
+    /// Uses the `0x8130…` namespace (the EIP number) reserved for EIP-8130 system
+    /// precompiles and can be renumbered when the spec pins a concrete value.
+    pub const ADDRESS: Address = address!("813000000000000000000000000000000000aa02");
+
+    /// Capacity of the expiring-nonce ring buffer.
+    ///
+    /// Sized to absorb a sustained burst (~10k TPS for ~30s) so that, by the time
+    /// the write pointer wraps back to a slot, the entry it holds has expired and
+    /// can be reclaimed.
+    pub const EXPIRING_NONCE_SET_CAPACITY: u32 = 300_000;
+
+    /// Maximum lifetime of an expiring-nonce transaction, in seconds.
+    ///
+    /// A transaction's `valid_before` must fall in `(now, now + this]`.
+    pub const EXPIRING_NONCE_MAX_EXPIRY_SECS: u64 = 30;
+
+    /// Nonce key reserved for the protocol nonce, which is held in account state.
+    const PROTOCOL_NONCE_KEY: U256 = U256::ZERO;
+
+    /// Returns the current 2D nonce for `account` at `nonce_key`.
+    ///
+    /// # Errors
+    /// - [`INonce::ProtocolNonceNotSupported`] — `nonce_key` is `0`, the protocol
+    ///   nonce, which is stored in account state and must be read from there.
+    pub fn get_nonce(&self, account: Address, nonce_key: U256) -> Result<u64> {
+        if nonce_key == Self::PROTOCOL_NONCE_KEY {
+            return Err(BasePrecompileError::revert(INonce::ProtocolNonceNotSupported {}));
+        }
+        self.nonces.at(&account).at(&nonce_key).read()
+    }
+
+    /// Increments the 2D nonce for `account` at `nonce_key`, returning the new
+    /// value and emitting [`INonce::NonceIncremented`].
+    ///
+    /// Intended for the EIP-8130 execution layer; not reachable through ABI
+    /// dispatch.
+    ///
+    /// # Errors
+    /// - [`INonce::InvalidNonceKey`] — `nonce_key` is `0` (the protocol nonce).
+    /// - [`INonce::NonceOverflow`] — the channel nonce is already `u64::MAX`.
+    pub fn increment_nonce(&mut self, account: Address, nonce_key: U256) -> Result<u64> {
+        if nonce_key == Self::PROTOCOL_NONCE_KEY {
+            return Err(BasePrecompileError::revert(INonce::InvalidNonceKey {}));
+        }
+        self.__initialize()?;
+        let current = self.nonces.at(&account).at(&nonce_key).read()?;
+        let new_nonce = current
+            .checked_add(1)
+            .ok_or_else(|| BasePrecompileError::revert(INonce::NonceOverflow {}))?;
+        self.nonces.at_mut(&account).at_mut(&nonce_key).write(new_nonce)?;
+        self.emit_event(INonce::NonceIncremented {
+            account,
+            nonceKey: nonce_key,
+            newNonce: new_nonce,
+        })?;
+        Ok(new_nonce)
+    }
+
+    /// Returns whether `hash` has been recorded and has not yet expired relative
+    /// to `now` (Unix seconds). Intended for transaction-pool replay checks.
+    pub fn is_expiring_nonce_seen(&self, hash: B256, now: u64) -> Result<bool> {
+        let expiry = self.expiring_nonce_seen.at(&hash).read()?;
+        Ok(expiry != 0 && expiry > now)
+    }
+
+    /// Validates and records an expiring-nonce transaction, providing replay
+    /// protection for nonce-free EIP-8130 transactions.
+    ///
+    /// `expiring_nonce_hash` is the signature-invariant replay hash
+    /// (`keccak256(encode_for_signing || sender)`), so re-signed fee-payer
+    /// variants of one logical transaction collapse to a single entry. The hash
+    /// is recorded in a circular buffer that reclaims expired slots as the write
+    /// pointer advances.
+    ///
+    /// Intended for the EIP-8130 execution layer; not reachable through ABI
+    /// dispatch.
+    ///
+    /// # Errors
+    /// - [`INonce::InvalidExpiringNonceExpiry`] — `valid_before` is not in
+    ///   `(now, now + EXPIRING_NONCE_MAX_EXPIRY_SECS]`.
+    /// - [`INonce::ExpiringNonceReplay`] — the hash is already recorded and unexpired.
+    /// - [`INonce::ExpiringNonceSetFull`] — the ring slot holds an unexpired entry
+    ///   that cannot be reclaimed.
+    pub fn check_and_mark_expiring_nonce(
+        &mut self,
+        expiring_nonce_hash: B256,
+        valid_before: u64,
+    ) -> Result<()> {
+        let now: u64 = self.storage.timestamp().saturating_to();
+
+        // 1. Validate the expiry window: must be in (now, now + MAX_EXPIRY_SECS].
+        if valid_before <= now
+            || valid_before > now.saturating_add(Self::EXPIRING_NONCE_MAX_EXPIRY_SECS)
+        {
+            return Err(BasePrecompileError::revert(INonce::InvalidExpiringNonceExpiry {}));
+        }
+
+        // 2. Replay check: reject if the hash is already seen and not yet expired.
+        let seen_expiry = self.expiring_nonce_seen.at(&expiring_nonce_hash).read()?;
+        if seen_expiry != 0 && seen_expiry > now {
+            return Err(BasePrecompileError::revert(INonce::ExpiringNonceReplay {}));
+        }
+
+        self.__initialize()?;
+
+        // 3. Inspect the entry the write pointer currently references.
+        let ptr = self.expiring_nonce_ring_ptr.read()?;
+        let old_hash = self.expiring_nonce_ring.at(&ptr).read()?;
+
+        // 4. Reclaim the slot only if its occupant has expired (or is empty).
+        // The buffer is sized so entries should always be expired by the time the
+        // pointer wraps, but verify in case throughput exceeds expectations.
+        if old_hash != B256::ZERO {
+            let old_expiry = self.expiring_nonce_seen.at(&old_hash).read()?;
+            if old_expiry != 0 && old_expiry > now {
+                return Err(BasePrecompileError::revert(INonce::ExpiringNonceSetFull {}));
+            }
+            self.expiring_nonce_seen.at_mut(&old_hash).write(0)?;
+        }
+
+        // 5. Record the new entry.
+        self.expiring_nonce_ring.at_mut(&ptr).write(expiring_nonce_hash)?;
+        self.expiring_nonce_seen.at_mut(&expiring_nonce_hash).write(valid_before)?;
+
+        // 6. Advance the write pointer, wrapping at capacity (not u32::MAX).
+        let next = if ptr + 1 >= Self::EXPIRING_NONCE_SET_CAPACITY { 0 } else { ptr + 1 };
+        self.expiring_nonce_ring_ptr.write(next)?;
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_primitives::{Address, B256, U256, address};
+    use base_precompile_storage::{
+        BasePrecompileError, Handler, HashMapStorageProvider, StorageCtx,
+    };
+
+    use crate::{INonce, nonce::storage::NonceManagerStorage};
+
+    const ACCOUNT_A: Address = address!("0x1111111111111111111111111111111111111111");
+    const ACCOUNT_B: Address = address!("0x2222222222222222222222222222222222222222");
+
+    #[test]
+    fn get_nonce_returns_zero_for_new_key() {
+        let mut storage = HashMapStorageProvider::new(1);
+        StorageCtx::enter(&mut storage, |ctx| {
+            let nonce = NonceManagerStorage::new(ctx).get_nonce(ACCOUNT_A, U256::from(5)).unwrap();
+            assert_eq!(nonce, 0);
+        });
+    }
+
+    #[test]
+    fn get_nonce_rejects_protocol_nonce() {
+        let mut storage = HashMapStorageProvider::new(1);
+        StorageCtx::enter(&mut storage, |ctx| {
+            let err = NonceManagerStorage::new(ctx).get_nonce(ACCOUNT_A, U256::ZERO).unwrap_err();
+            assert_eq!(err, BasePrecompileError::revert(INonce::ProtocolNonceNotSupported {}));
+        });
+    }
+
+    #[test]
+    fn increment_nonce_advances_and_emits_event() {
+        let mut storage = HashMapStorageProvider::new(1);
+        let nonce_key = U256::from(5);
+        StorageCtx::enter(&mut storage, |ctx| {
+            let mut mgr = NonceManagerStorage::new(ctx);
+            assert_eq!(mgr.increment_nonce(ACCOUNT_A, nonce_key).unwrap(), 1);
+            assert_eq!(mgr.increment_nonce(ACCOUNT_A, nonce_key).unwrap(), 2);
+        });
+        assert_eq!(storage.get_events(NonceManagerStorage::ADDRESS).len(), 2);
+        StorageCtx::enter(&mut storage, |ctx| {
+            assert_eq!(NonceManagerStorage::new(ctx).get_nonce(ACCOUNT_A, nonce_key).unwrap(), 2);
+        });
+    }
+
+    #[test]
+    fn increment_nonce_rejects_protocol_nonce() {
+        let mut storage = HashMapStorageProvider::new(1);
+        StorageCtx::enter(&mut storage, |ctx| {
+            let err =
+                NonceManagerStorage::new(ctx).increment_nonce(ACCOUNT_A, U256::ZERO).unwrap_err();
+            assert_eq!(err, BasePrecompileError::revert(INonce::InvalidNonceKey {}));
+        });
+    }
+
+    #[test]
+    fn nonces_are_independent_per_account() {
+        let mut storage = HashMapStorageProvider::new(1);
+        let nonce_key = U256::from(7);
+        StorageCtx::enter(&mut storage, |ctx| {
+            let mut mgr = NonceManagerStorage::new(ctx);
+            for _ in 0..10 {
+                mgr.increment_nonce(ACCOUNT_A, nonce_key).unwrap();
+            }
+            for _ in 0..20 {
+                mgr.increment_nonce(ACCOUNT_B, nonce_key).unwrap();
+            }
+        });
+        StorageCtx::enter(&mut storage, |ctx| {
+            let mgr = NonceManagerStorage::new(ctx);
+            assert_eq!(mgr.get_nonce(ACCOUNT_A, nonce_key).unwrap(), 10);
+            assert_eq!(mgr.get_nonce(ACCOUNT_B, nonce_key).unwrap(), 20);
+        });
+    }
+
+    #[test]
+    fn expiring_nonce_rejects_replay_within_window() {
+        let mut storage = HashMapStorageProvider::new(1);
+        let now = 1_000u64;
+        storage.set_timestamp(U256::from(now));
+        StorageCtx::enter(&mut storage, |ctx| {
+            let mut mgr = NonceManagerStorage::new(ctx);
+            let hash = B256::repeat_byte(0x11);
+            mgr.check_and_mark_expiring_nonce(hash, now + 20).unwrap();
+            let err = mgr.check_and_mark_expiring_nonce(hash, now + 20).unwrap_err();
+            assert_eq!(err, BasePrecompileError::revert(INonce::ExpiringNonceReplay {}));
+        });
+    }
+
+    #[test]
+    fn expiring_nonce_validates_expiry_window() {
+        let mut storage = HashMapStorageProvider::new(1);
+        let now = 1_000u64;
+        storage.set_timestamp(U256::from(now));
+        StorageCtx::enter(&mut storage, |ctx| {
+            let mut mgr = NonceManagerStorage::new(ctx);
+            let hash = B256::repeat_byte(0x22);
+            let invalid = BasePrecompileError::revert(INonce::InvalidExpiringNonceExpiry {});
+
+            // In the past, exactly now, and beyond the max window all fail.
+            assert_eq!(mgr.check_and_mark_expiring_nonce(hash, now - 1).unwrap_err(), invalid);
+            assert_eq!(mgr.check_and_mark_expiring_nonce(hash, now).unwrap_err(), invalid);
+            assert_eq!(
+                mgr.check_and_mark_expiring_nonce(
+                    hash,
+                    now + NonceManagerStorage::EXPIRING_NONCE_MAX_EXPIRY_SECS + 1
+                )
+                .unwrap_err(),
+                invalid
+            );
+
+            // Exactly at the max window succeeds.
+            mgr.check_and_mark_expiring_nonce(
+                hash,
+                now + NonceManagerStorage::EXPIRING_NONCE_MAX_EXPIRY_SECS,
+            )
+            .unwrap();
+        });
+    }
+
+    #[test]
+    fn expiring_nonce_seen_clears_after_expiry() {
+        let mut storage = HashMapStorageProvider::new(1);
+        let now = 1_000u64;
+        let valid_before = now + 20;
+        storage.set_timestamp(U256::from(now));
+        StorageCtx::enter(&mut storage, |ctx| {
+            let mut mgr = NonceManagerStorage::new(ctx);
+            let hash = B256::repeat_byte(0x33);
+            mgr.check_and_mark_expiring_nonce(hash, valid_before).unwrap();
+            assert!(mgr.is_expiring_nonce_seen(hash, now).unwrap());
+            assert!(!mgr.is_expiring_nonce_seen(hash, valid_before + 1).unwrap());
+        });
+    }
+
+    #[test]
+    fn expiring_nonce_ring_pointer_wraps_at_capacity() {
+        let mut storage = HashMapStorageProvider::new(1);
+        let now = 1_000u64;
+        let valid_before = now + 20;
+        storage.set_timestamp(U256::from(now));
+        StorageCtx::enter(&mut storage, |ctx| {
+            let mut mgr = NonceManagerStorage::new(ctx);
+            // Seed the pointer just below capacity so the next write wraps it.
+            mgr.expiring_nonce_ring_ptr
+                .write(NonceManagerStorage::EXPIRING_NONCE_SET_CAPACITY - 1)
+                .unwrap();
+
+            mgr.check_and_mark_expiring_nonce(B256::repeat_byte(0x77), valid_before).unwrap();
+            assert_eq!(mgr.expiring_nonce_ring_ptr.read().unwrap(), 0);
+
+            mgr.check_and_mark_expiring_nonce(B256::repeat_byte(0x88), valid_before).unwrap();
+            assert_eq!(mgr.expiring_nonce_ring_ptr.read().unwrap(), 1);
+        });
+    }
+}

--- a/crates/common/precompiles/src/nonce/storage.rs
+++ b/crates/common/precompiles/src/nonce/storage.rs
@@ -4,7 +4,7 @@ use alloy_primitives::{Address, B256, U256, address};
 use base_precompile_macros::contract;
 use base_precompile_storage::{BasePrecompileError, Handler, Mapping, Result};
 
-use crate::INonce;
+use crate::INonceManager;
 
 /// Persistent 2D nonce manager for EIP-8130 account-abstraction transactions.
 ///
@@ -68,35 +68,35 @@ impl NonceManagerStorage<'_> {
     /// Returns the current 2D nonce for `account` at `nonce_key`.
     ///
     /// # Errors
-    /// - [`INonce::ProtocolNonceNotSupported`] — `nonce_key` is `0`, the protocol
-    ///   nonce, which is stored in account state and must be read from there.
+    /// - [`INonceManager::ProtocolNonceNotSupported`] — `nonce_key` is `0`, the
+    ///   protocol nonce, which is stored in account state and must be read from there.
     pub fn get_nonce(&self, account: Address, nonce_key: U256) -> Result<u64> {
         if nonce_key == Self::PROTOCOL_NONCE_KEY {
-            return Err(BasePrecompileError::revert(INonce::ProtocolNonceNotSupported {}));
+            return Err(BasePrecompileError::revert(INonceManager::ProtocolNonceNotSupported {}));
         }
         self.nonces.at(&account).at(&nonce_key).read()
     }
 
     /// Increments the 2D nonce for `account` at `nonce_key`, returning the new
-    /// value and emitting [`INonce::NonceIncremented`].
+    /// value and emitting [`INonceManager::NonceIncremented`].
     ///
     /// Intended for the EIP-8130 execution layer; not reachable through ABI
     /// dispatch.
     ///
     /// # Errors
-    /// - [`INonce::InvalidNonceKey`] — `nonce_key` is `0` (the protocol nonce).
-    /// - [`INonce::NonceOverflow`] — the channel nonce is already `u64::MAX`.
+    /// - [`INonceManager::InvalidNonceKey`] — `nonce_key` is `0` (the protocol nonce).
+    /// - [`INonceManager::NonceOverflow`] — the channel nonce is already `u64::MAX`.
     pub fn increment_nonce(&mut self, account: Address, nonce_key: U256) -> Result<u64> {
         if nonce_key == Self::PROTOCOL_NONCE_KEY {
-            return Err(BasePrecompileError::revert(INonce::InvalidNonceKey {}));
+            return Err(BasePrecompileError::revert(INonceManager::InvalidNonceKey {}));
         }
         self.__initialize()?;
         let current = self.nonces.at(&account).at(&nonce_key).read()?;
         let new_nonce = current
             .checked_add(1)
-            .ok_or_else(|| BasePrecompileError::revert(INonce::NonceOverflow {}))?;
+            .ok_or_else(|| BasePrecompileError::revert(INonceManager::NonceOverflow {}))?;
         self.nonces.at_mut(&account).at_mut(&nonce_key).write(new_nonce)?;
-        self.emit_event(INonce::NonceIncremented {
+        self.emit_event(INonceManager::NonceIncremented {
             account,
             nonceKey: nonce_key,
             newNonce: new_nonce,
@@ -124,10 +124,10 @@ impl NonceManagerStorage<'_> {
     /// dispatch.
     ///
     /// # Errors
-    /// - [`INonce::InvalidExpiringNonceExpiry`] — `valid_before` is not in
+    /// - [`INonceManager::InvalidExpiringNonceExpiry`] — `valid_before` is not in
     ///   `(now, now + EXPIRING_NONCE_MAX_EXPIRY_SECS]`.
-    /// - [`INonce::ExpiringNonceReplay`] — the hash is already recorded and unexpired.
-    /// - [`INonce::ExpiringNonceSetFull`] — the ring slot holds an unexpired entry
+    /// - [`INonceManager::ExpiringNonceReplay`] — the hash is already recorded and unexpired.
+    /// - [`INonceManager::ExpiringNonceSetFull`] — the ring slot holds an unexpired entry
     ///   that cannot be reclaimed.
     pub fn check_and_mark_expiring_nonce(
         &mut self,
@@ -140,13 +140,13 @@ impl NonceManagerStorage<'_> {
         if valid_before <= now
             || valid_before > now.saturating_add(Self::EXPIRING_NONCE_MAX_EXPIRY_SECS)
         {
-            return Err(BasePrecompileError::revert(INonce::InvalidExpiringNonceExpiry {}));
+            return Err(BasePrecompileError::revert(INonceManager::InvalidExpiringNonceExpiry {}));
         }
 
         // 2. Replay check: reject if the hash is already seen and not yet expired.
         let seen_expiry = self.expiring_nonce_seen.at(&expiring_nonce_hash).read()?;
         if seen_expiry != 0 && seen_expiry > now {
-            return Err(BasePrecompileError::revert(INonce::ExpiringNonceReplay {}));
+            return Err(BasePrecompileError::revert(INonceManager::ExpiringNonceReplay {}));
         }
 
         self.__initialize()?;
@@ -161,7 +161,7 @@ impl NonceManagerStorage<'_> {
         if old_hash != B256::ZERO {
             let old_expiry = self.expiring_nonce_seen.at(&old_hash).read()?;
             if old_expiry != 0 && old_expiry > now {
-                return Err(BasePrecompileError::revert(INonce::ExpiringNonceSetFull {}));
+                return Err(BasePrecompileError::revert(INonceManager::ExpiringNonceSetFull {}));
             }
             self.expiring_nonce_seen.at_mut(&old_hash).write(0)?;
         }
@@ -185,7 +185,7 @@ mod tests {
         BasePrecompileError, Handler, HashMapStorageProvider, StorageCtx,
     };
 
-    use crate::{INonce, nonce::storage::NonceManagerStorage};
+    use crate::{INonceManager, nonce::storage::NonceManagerStorage};
 
     const ACCOUNT_A: Address = address!("0x1111111111111111111111111111111111111111");
     const ACCOUNT_B: Address = address!("0x2222222222222222222222222222222222222222");
@@ -204,7 +204,10 @@ mod tests {
         let mut storage = HashMapStorageProvider::new(1);
         StorageCtx::enter(&mut storage, |ctx| {
             let err = NonceManagerStorage::new(ctx).get_nonce(ACCOUNT_A, U256::ZERO).unwrap_err();
-            assert_eq!(err, BasePrecompileError::revert(INonce::ProtocolNonceNotSupported {}));
+            assert_eq!(
+                err,
+                BasePrecompileError::revert(INonceManager::ProtocolNonceNotSupported {})
+            );
         });
     }
 
@@ -229,7 +232,7 @@ mod tests {
         StorageCtx::enter(&mut storage, |ctx| {
             let err =
                 NonceManagerStorage::new(ctx).increment_nonce(ACCOUNT_A, U256::ZERO).unwrap_err();
-            assert_eq!(err, BasePrecompileError::revert(INonce::InvalidNonceKey {}));
+            assert_eq!(err, BasePrecompileError::revert(INonceManager::InvalidNonceKey {}));
         });
     }
 
@@ -263,7 +266,7 @@ mod tests {
             let hash = B256::repeat_byte(0x11);
             mgr.check_and_mark_expiring_nonce(hash, now + 20).unwrap();
             let err = mgr.check_and_mark_expiring_nonce(hash, now + 20).unwrap_err();
-            assert_eq!(err, BasePrecompileError::revert(INonce::ExpiringNonceReplay {}));
+            assert_eq!(err, BasePrecompileError::revert(INonceManager::ExpiringNonceReplay {}));
         });
     }
 
@@ -275,7 +278,7 @@ mod tests {
         StorageCtx::enter(&mut storage, |ctx| {
             let mut mgr = NonceManagerStorage::new(ctx);
             let hash = B256::repeat_byte(0x22);
-            let invalid = BasePrecompileError::revert(INonce::InvalidExpiringNonceExpiry {});
+            let invalid = BasePrecompileError::revert(INonceManager::InvalidExpiringNonceExpiry {});
 
             // In the past, exactly now, and beyond the max window all fail.
             assert_eq!(mgr.check_and_mark_expiring_nonce(hash, now - 1).unwrap_err(), invalid);

--- a/crates/common/precompiles/src/provider.rs
+++ b/crates/common/precompiles/src/provider.rs
@@ -13,8 +13,9 @@ use revm::{
 };
 
 use crate::{
-    ActivationRegistry, B20Factory, BasePrecompileSpec, BerylLookup, NoopPrecompileCallObserver,
-    PolicyRegistryPrecompile, PrecompileCallObserver, TxContext, bls12_381, bn254_pair,
+    ActivationRegistry, B20Factory, BasePrecompileSpec, BerylLookup, NonceManager,
+    NoopPrecompileCallObserver, PolicyRegistryPrecompile, PrecompileCallObserver, TxContext,
+    bls12_381, bn254_pair,
 };
 
 /// Base precompile provider.
@@ -203,6 +204,7 @@ impl<S: BasePrecompileSpec> BasePrecompiles<S> {
         }
         if self.spec.upgrade() >= BaseUpgrade::Cobalt {
             TxContext::install(&mut precompiles);
+            NonceManager::install(&mut precompiles);
         }
         precompiles
     }
@@ -265,7 +267,7 @@ mod tests {
 
     use crate::{
         ActivationRegistryStorage, B20FactoryStorage, B20Variant, BasePrecompiles,
-        TxContextStorage, bls12_381, bn254_pair,
+        NonceManagerStorage, TxContextStorage, bls12_381, bn254_pair,
     };
 
     type TestPrecompiles = BasePrecompiles<BaseUpgrade>;
@@ -563,5 +565,15 @@ mod tests {
         let precompiles = BasePrecompiles::new_with_spec(spec).install();
 
         assert_eq!(precompiles.get(&TxContextStorage::ADDRESS).is_some(), expected);
+    }
+
+    #[rstest]
+    #[case::azul(BaseUpgrade::Azul, false)]
+    #[case::beryl(BaseUpgrade::Beryl, false)]
+    #[case::cobalt(BaseUpgrade::Cobalt, true)]
+    fn nonce_manager_is_installed_at_cobalt(#[case] spec: BaseUpgrade, #[case] expected: bool) {
+        let precompiles = BasePrecompiles::new_with_spec(spec).install();
+
+        assert_eq!(precompiles.get(&NonceManagerStorage::ADDRESS).is_some(), expected);
     }
 }

--- a/crates/common/precompiles/src/provider.rs
+++ b/crates/common/precompiles/src/provider.rs
@@ -192,6 +192,11 @@ impl<S: BasePrecompileSpec> BasePrecompiles<S> {
         O: PrecompileCallObserver,
     {
         let mut precompiles = PrecompilesMap::from_static(self.precompiles());
+        // The `observer` only applies to the dynamic, address-derived B-20 token
+        // precompiles resolved at call time via `BerylLookup`. Every directly
+        // installed precompile below — Beryl's factory/registries and Cobalt's
+        // EIP-8130 precompiles alike — uses plain `install`; none is observed, by
+        // design, since metrics are scoped to the B-20 token call path.
         if self.spec.upgrade() >= BaseUpgrade::Beryl {
             B20Factory::install_with_observer(&mut precompiles, observer.clone());
             BerylLookup::install_with_observer(&mut precompiles, observer.clone());

--- a/crates/common/precompiles/src/provider.rs
+++ b/crates/common/precompiles/src/provider.rs
@@ -14,7 +14,7 @@ use revm::{
 
 use crate::{
     ActivationRegistry, B20Factory, BasePrecompileSpec, BerylLookup, NoopPrecompileCallObserver,
-    PolicyRegistryPrecompile, PrecompileCallObserver, bls12_381, bn254_pair,
+    PolicyRegistryPrecompile, PrecompileCallObserver, TxContext, bls12_381, bn254_pair,
 };
 
 /// Base precompile provider.
@@ -201,6 +201,9 @@ impl<S: BasePrecompileSpec> BasePrecompiles<S> {
                 observer,
             );
         }
+        if self.spec.upgrade() >= BaseUpgrade::Cobalt {
+            TxContext::install(&mut precompiles);
+        }
         precompiles
     }
 }
@@ -261,8 +264,8 @@ mod tests {
     use rstest::rstest;
 
     use crate::{
-        ActivationRegistryStorage, B20FactoryStorage, B20Variant, BasePrecompiles, bls12_381,
-        bn254_pair,
+        ActivationRegistryStorage, B20FactoryStorage, B20Variant, BasePrecompiles,
+        TxContextStorage, bls12_381, bn254_pair,
     };
 
     type TestPrecompiles = BasePrecompiles<BaseUpgrade>;
@@ -550,5 +553,15 @@ mod tests {
         let precompiles = BasePrecompiles::new_with_spec(BaseUpgrade::Beryl).install();
 
         assert!(precompiles.get(&ActivationRegistryStorage::ADDRESS).is_some());
+    }
+
+    #[rstest]
+    #[case::azul(BaseUpgrade::Azul, false)]
+    #[case::beryl(BaseUpgrade::Beryl, false)]
+    #[case::cobalt(BaseUpgrade::Cobalt, true)]
+    fn tx_context_is_installed_at_cobalt(#[case] spec: BaseUpgrade, #[case] expected: bool) {
+        let precompiles = BasePrecompiles::new_with_spec(spec).install();
+
+        assert_eq!(precompiles.get(&TxContextStorage::ADDRESS).is_some(), expected);
     }
 }

--- a/crates/common/precompiles/src/tx_context/abi.rs
+++ b/crates/common/precompiles/src/tx_context/abi.rs
@@ -1,0 +1,27 @@
+//! ABI definitions for the EIP-8130 transaction context precompile.
+
+use alloy_sol_types::sol;
+
+sol! {
+    /// Read-only EIP-8130 transaction context ABI.
+    ///
+    /// Exposes the resolved sender, payer, and sender owner id for the
+    /// in-flight EIP-8130 transaction. On non-EIP-8130 transactions the
+    /// backing transient slots are unset and the getters return the zero
+    /// address / zero word.
+    interface ITxContext {
+        /// Precompile cannot be executed via delegatecall or callcode.
+        error DelegateCallNotAllowed();
+
+        /// Returns the resolved sender of the in-flight transaction.
+        function getSender() external view returns (address);
+
+        /// Returns the resolved payer of the in-flight transaction.
+        ///
+        /// Equal to the sender when the transaction is self-paying.
+        function getPayer() external view returns (address);
+
+        /// Returns the owner id resolved while authenticating the sender.
+        function getSenderOwnerId() external view returns (bytes32);
+    }
+}

--- a/crates/common/precompiles/src/tx_context/abi.rs
+++ b/crates/common/precompiles/src/tx_context/abi.rs
@@ -5,23 +5,23 @@ use alloy_sol_types::sol;
 sol! {
     /// Read-only EIP-8130 transaction context ABI.
     ///
-    /// Exposes the resolved sender, payer, and sender owner id for the
+    /// Exposes the resolved sender, payer, and sender actor id for the
     /// in-flight EIP-8130 transaction. On non-EIP-8130 transactions the
     /// backing transient slots are unset and the getters return the zero
     /// address / zero word.
-    interface ITxContext {
+    interface ITransactionContext {
         /// Precompile cannot be executed via delegatecall or callcode.
         error DelegateCallNotAllowed();
 
         /// Returns the resolved sender of the in-flight transaction.
-        function getSender() external view returns (address);
+        function getTransactionSender() external view returns (address);
 
         /// Returns the resolved payer of the in-flight transaction.
         ///
         /// Equal to the sender when the transaction is self-paying.
-        function getPayer() external view returns (address);
+        function getTransactionPayer() external view returns (address);
 
-        /// Returns the owner id resolved while authenticating the sender.
-        function getSenderOwnerId() external view returns (bytes32);
+        /// Returns the actor id resolved while authenticating the sender.
+        function getTransactionSenderActorId() external view returns (bytes32);
     }
 }

--- a/crates/common/precompiles/src/tx_context/abi.rs
+++ b/crates/common/precompiles/src/tx_context/abi.rs
@@ -7,8 +7,11 @@ sol! {
     ///
     /// Exposes the resolved sender, payer, and sender actor id for the
     /// in-flight EIP-8130 transaction. On non-EIP-8130 transactions the
-    /// backing transient slots are unset and the getters return the zero
-    /// address / zero word.
+    /// backing transient slots are unset and the getters fall back to the
+    /// ambient origin: `getTransactionSender` and `getTransactionPayer`
+    /// return `tx.origin`, and `getTransactionSenderActorId` returns
+    /// `bytes32(bytes20(tx.origin))` (the address left-aligned in the high
+    /// 20 bytes).
     interface ITransactionContext {
         /// Precompile cannot be executed via delegatecall or callcode.
         error DelegateCallNotAllowed();

--- a/crates/common/precompiles/src/tx_context/dispatch.rs
+++ b/crates/common/precompiles/src/tx_context/dispatch.rs
@@ -1,0 +1,102 @@
+//! ABI dispatch for the EIP-8130 transaction context precompile.
+
+use alloy_primitives::Bytes;
+use alloy_sol_types::SolCall;
+use base_precompile_storage::{IntoPrecompileResult, StorageCtx};
+use revm::precompile::PrecompileResult;
+
+use crate::{
+    ITxContext::{self, ITxContextCalls as C},
+    macros::{decode_precompile_call, deduct_calldata_cost},
+    tx_context::storage::TxContextStorage,
+};
+
+impl TxContextStorage<'_> {
+    /// ABI-dispatches transaction context calldata.
+    pub fn dispatch(&self, ctx: StorageCtx<'_>, calldata: &[u8]) -> PrecompileResult {
+        deduct_calldata_cost!(ctx, calldata);
+        self.inner(calldata).into_precompile_result(
+            ctx.gas_used(),
+            ctx.state_gas_used(),
+            |output| output,
+        )
+    }
+
+    fn inner(&self, calldata: &[u8]) -> base_precompile_storage::Result<Bytes> {
+        match decode_precompile_call!(calldata, ITxContext::ITxContextCalls) {
+            C::getSender(_) => {
+                Ok(ITxContext::getSenderCall::abi_encode_returns(&self.sender()?).into())
+            }
+            C::getPayer(_) => {
+                Ok(ITxContext::getPayerCall::abi_encode_returns(&self.payer()?).into())
+            }
+            C::getSenderOwnerId(_) => {
+                Ok(ITxContext::getSenderOwnerIdCall::abi_encode_returns(&self.sender_owner_id()?)
+                    .into())
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_primitives::{Address, B256, address, b256};
+    use alloy_sol_types::SolCall;
+    use base_precompile_storage::{HashMapStorageProvider, StorageCtx};
+
+    use crate::{ITxContext, TxContextStorage};
+
+    const SENDER: Address = address!("0x1111111111111111111111111111111111111111");
+    const PAYER: Address = address!("0x2222222222222222222222222222222222222222");
+    const SENDER_OWNER_ID: B256 =
+        b256!("0x3333333333333333333333333333333333333333333333333333333333333333");
+
+    fn dispatch(storage: &mut HashMapStorageProvider, calldata: &[u8]) -> Vec<u8> {
+        StorageCtx::enter(storage, |ctx| {
+            TxContextStorage::new(ctx)
+                .dispatch(ctx, calldata)
+                .expect("dispatch should not fail fatally")
+                .bytes
+                .to_vec()
+        })
+    }
+
+    #[test]
+    fn dispatch_returns_resolved_context() {
+        let mut storage = HashMapStorageProvider::new(1);
+        StorageCtx::enter(&mut storage, |ctx| {
+            TxContextStorage::new(ctx).set_context(SENDER, PAYER, SENDER_OWNER_ID).unwrap();
+        });
+
+        let sender = dispatch(&mut storage, &ITxContext::getSenderCall {}.abi_encode());
+        assert_eq!(ITxContext::getSenderCall::abi_decode_returns(&sender).unwrap(), SENDER);
+
+        let payer = dispatch(&mut storage, &ITxContext::getPayerCall {}.abi_encode());
+        assert_eq!(ITxContext::getPayerCall::abi_decode_returns(&payer).unwrap(), PAYER);
+
+        let owner_id = dispatch(&mut storage, &ITxContext::getSenderOwnerIdCall {}.abi_encode());
+        assert_eq!(
+            ITxContext::getSenderOwnerIdCall::abi_decode_returns(&owner_id).unwrap(),
+            SENDER_OWNER_ID
+        );
+    }
+
+    #[test]
+    fn dispatch_returns_zero_when_unset() {
+        let mut storage = HashMapStorageProvider::new(1);
+
+        let sender = dispatch(&mut storage, &ITxContext::getSenderCall {}.abi_encode());
+        assert_eq!(ITxContext::getSenderCall::abi_decode_returns(&sender).unwrap(), Address::ZERO);
+    }
+
+    #[test]
+    fn dispatch_reverts_on_unknown_selector() {
+        let mut storage = HashMapStorageProvider::new(1);
+        let output = StorageCtx::enter(&mut storage, |ctx| {
+            TxContextStorage::new(ctx).dispatch(ctx, &[0xde, 0xad, 0xbe, 0xef])
+        })
+        .expect("unknown selector should revert, not fail fatally");
+
+        assert!(output.is_revert());
+    }
+}

--- a/crates/common/precompiles/src/tx_context/dispatch.rs
+++ b/crates/common/precompiles/src/tx_context/dispatch.rs
@@ -7,17 +7,25 @@ use revm::precompile::PrecompileResult;
 
 use crate::{
     ITransactionContext::{self, ITransactionContextCalls as C},
-    macros::{decode_precompile_call, deduct_calldata_cost},
+    macros::decode_precompile_call,
     tx_context::storage::TxContextStorage,
 };
+
+/// Per-word calldata gas charge (`G_SHA3WORD`), matching common Base precompile dispatch.
+const CALLDATA_WORD_GAS: u64 = 6;
 
 impl TxContextStorage<'_> {
     /// ABI-dispatches transaction context calldata.
     pub fn dispatch(&self, ctx: StorageCtx<'_>, calldata: &[u8]) -> PrecompileResult {
-        deduct_calldata_cost!(ctx, calldata);
+        let calldata_cost = (calldata.len() as u64).div_ceil(32).saturating_mul(CALLDATA_WORD_GAS);
+        if let Err(error) = ctx.deduct_gas(calldata_cost) {
+            return error.into_precompile_result(ctx.gas_used(), ctx.state_gas_used());
+        }
+        // These getters never produce a gas refund, so the refund arg is 0.
         self.inner(calldata).into_precompile_result(
             ctx.gas_used(),
             ctx.state_gas_used(),
+            0,
             |output| output,
         )
     }

--- a/crates/common/precompiles/src/tx_context/dispatch.rs
+++ b/crates/common/precompiles/src/tx_context/dispatch.rs
@@ -6,7 +6,7 @@ use base_precompile_storage::{IntoPrecompileResult, StorageCtx};
 use revm::precompile::PrecompileResult;
 
 use crate::{
-    ITxContext::{self, ITxContextCalls as C},
+    ITransactionContext::{self, ITransactionContextCalls as C},
     macros::{decode_precompile_call, deduct_calldata_cost},
     tx_context::storage::TxContextStorage,
 };
@@ -23,16 +23,20 @@ impl TxContextStorage<'_> {
     }
 
     fn inner(&self, calldata: &[u8]) -> base_precompile_storage::Result<Bytes> {
-        match decode_precompile_call!(calldata, ITxContext::ITxContextCalls) {
-            C::getSender(_) => {
-                Ok(ITxContext::getSenderCall::abi_encode_returns(&self.sender()?).into())
-            }
-            C::getPayer(_) => {
-                Ok(ITxContext::getPayerCall::abi_encode_returns(&self.payer()?).into())
-            }
-            C::getSenderOwnerId(_) => {
-                Ok(ITxContext::getSenderOwnerIdCall::abi_encode_returns(&self.sender_owner_id()?)
+        match decode_precompile_call!(calldata, ITransactionContext::ITransactionContextCalls) {
+            C::getTransactionSender(_) => Ok(
+                ITransactionContext::getTransactionSenderCall::abi_encode_returns(&self.sender()?)
+                    .into(),
+            ),
+            C::getTransactionPayer(_) => {
+                Ok(ITransactionContext::getTransactionPayerCall::abi_encode_returns(&self.payer()?)
                     .into())
+            }
+            C::getTransactionSenderActorId(_) => {
+                Ok(ITransactionContext::getTransactionSenderActorIdCall::abi_encode_returns(
+                    &self.sender_actor_id()?,
+                )
+                .into())
             }
         }
     }
@@ -44,11 +48,11 @@ mod tests {
     use alloy_sol_types::SolCall;
     use base_precompile_storage::{HashMapStorageProvider, StorageCtx};
 
-    use crate::{ITxContext, TxContextStorage};
+    use crate::{ITransactionContext, TxContextStorage};
 
     const SENDER: Address = address!("0x1111111111111111111111111111111111111111");
     const PAYER: Address = address!("0x2222222222222222222222222222222222222222");
-    const SENDER_OWNER_ID: B256 =
+    const SENDER_ACTOR_ID: B256 =
         b256!("0x3333333333333333333333333333333333333333333333333333333333333333");
 
     fn dispatch(storage: &mut HashMapStorageProvider, calldata: &[u8]) -> Vec<u8> {
@@ -65,19 +69,31 @@ mod tests {
     fn dispatch_returns_resolved_context() {
         let mut storage = HashMapStorageProvider::new(1);
         StorageCtx::enter(&mut storage, |ctx| {
-            TxContextStorage::new(ctx).set_context(SENDER, PAYER, SENDER_OWNER_ID).unwrap();
+            TxContextStorage::new(ctx).set_context(SENDER, PAYER, SENDER_ACTOR_ID).unwrap();
         });
 
-        let sender = dispatch(&mut storage, &ITxContext::getSenderCall {}.abi_encode());
-        assert_eq!(ITxContext::getSenderCall::abi_decode_returns(&sender).unwrap(), SENDER);
-
-        let payer = dispatch(&mut storage, &ITxContext::getPayerCall {}.abi_encode());
-        assert_eq!(ITxContext::getPayerCall::abi_decode_returns(&payer).unwrap(), PAYER);
-
-        let owner_id = dispatch(&mut storage, &ITxContext::getSenderOwnerIdCall {}.abi_encode());
+        let sender =
+            dispatch(&mut storage, &ITransactionContext::getTransactionSenderCall {}.abi_encode());
         assert_eq!(
-            ITxContext::getSenderOwnerIdCall::abi_decode_returns(&owner_id).unwrap(),
-            SENDER_OWNER_ID
+            ITransactionContext::getTransactionSenderCall::abi_decode_returns(&sender).unwrap(),
+            SENDER
+        );
+
+        let payer =
+            dispatch(&mut storage, &ITransactionContext::getTransactionPayerCall {}.abi_encode());
+        assert_eq!(
+            ITransactionContext::getTransactionPayerCall::abi_decode_returns(&payer).unwrap(),
+            PAYER
+        );
+
+        let actor_id = dispatch(
+            &mut storage,
+            &ITransactionContext::getTransactionSenderActorIdCall {}.abi_encode(),
+        );
+        assert_eq!(
+            ITransactionContext::getTransactionSenderActorIdCall::abi_decode_returns(&actor_id)
+                .unwrap(),
+            SENDER_ACTOR_ID
         );
     }
 
@@ -85,8 +101,12 @@ mod tests {
     fn dispatch_returns_zero_when_unset() {
         let mut storage = HashMapStorageProvider::new(1);
 
-        let sender = dispatch(&mut storage, &ITxContext::getSenderCall {}.abi_encode());
-        assert_eq!(ITxContext::getSenderCall::abi_decode_returns(&sender).unwrap(), Address::ZERO);
+        let sender =
+            dispatch(&mut storage, &ITransactionContext::getTransactionSenderCall {}.abi_encode());
+        assert_eq!(
+            ITransactionContext::getTransactionSenderCall::abi_decode_returns(&sender).unwrap(),
+            Address::ZERO
+        );
     }
 
     #[test]

--- a/crates/common/precompiles/src/tx_context/dispatch.rs
+++ b/crates/common/precompiles/src/tx_context/dispatch.rs
@@ -54,6 +54,7 @@ mod tests {
     const PAYER: Address = address!("0x2222222222222222222222222222222222222222");
     const SENDER_ACTOR_ID: B256 =
         b256!("0x3333333333333333333333333333333333333333333333333333333333333333");
+    const ORIGIN: Address = address!("0x9999999999999999999999999999999999999999");
 
     fn dispatch(storage: &mut HashMapStorageProvider, calldata: &[u8]) -> Vec<u8> {
         StorageCtx::enter(storage, |ctx| {
@@ -98,14 +99,22 @@ mod tests {
     }
 
     #[test]
-    fn dispatch_returns_zero_when_unset() {
+    fn dispatch_falls_back_to_origin_when_unset() {
         let mut storage = HashMapStorageProvider::new(1);
+        storage.set_origin(ORIGIN);
 
         let sender =
             dispatch(&mut storage, &ITransactionContext::getTransactionSenderCall {}.abi_encode());
         assert_eq!(
             ITransactionContext::getTransactionSenderCall::abi_decode_returns(&sender).unwrap(),
-            Address::ZERO
+            ORIGIN
+        );
+
+        let payer =
+            dispatch(&mut storage, &ITransactionContext::getTransactionPayerCall {}.abi_encode());
+        assert_eq!(
+            ITransactionContext::getTransactionPayerCall::abi_decode_returns(&payer).unwrap(),
+            ORIGIN
         );
     }
 

--- a/crates/common/precompiles/src/tx_context/mod.rs
+++ b/crates/common/precompiles/src/tx_context/mod.rs
@@ -1,0 +1,12 @@
+//! EIP-8130 transaction context native precompile.
+
+mod abi;
+pub use abi::ITxContext;
+
+mod storage;
+pub use storage::TxContextStorage;
+
+mod dispatch;
+
+mod precompile;
+pub use precompile::TxContext;

--- a/crates/common/precompiles/src/tx_context/mod.rs
+++ b/crates/common/precompiles/src/tx_context/mod.rs
@@ -1,7 +1,7 @@
 //! EIP-8130 transaction context native precompile.
 
 mod abi;
-pub use abi::ITxContext;
+pub use abi::ITransactionContext;
 
 mod storage;
 pub use storage::TxContextStorage;

--- a/crates/common/precompiles/src/tx_context/precompile.rs
+++ b/crates/common/precompiles/src/tx_context/precompile.rs
@@ -1,0 +1,10 @@
+//! Precompile entry point for the EIP-8130 transaction context.
+
+use base_precompile_macros::precompile;
+
+use crate::TxContextStorage;
+
+/// Entry point for the EIP-8130 transaction context precompile.
+#[precompile(install)]
+#[derive(Debug, Default, Clone, Copy)]
+pub struct TxContext;

--- a/crates/common/precompiles/src/tx_context/storage.rs
+++ b/crates/common/precompiles/src/tx_context/storage.rs
@@ -1,0 +1,138 @@
+//! Storage layout and constants for the EIP-8130 transaction context precompile.
+
+use alloy_primitives::{Address, B256, U256, address};
+use base_precompile_storage::{Result, StorageCtx};
+
+/// Transient-storage-backed view of the in-flight EIP-8130 transaction context.
+///
+/// The resolved sender, payer, and sender owner id are written to transient
+/// storage at [`Self::ADDRESS`] by the EIP-8130 execution layer at the start of
+/// transaction processing and cleared automatically at transaction end. The
+/// precompile only reads them back, so for any non-EIP-8130 transaction (where
+/// nothing is written) every getter returns the zero value.
+#[derive(Debug)]
+pub struct TxContextStorage<'a> {
+    storage: StorageCtx<'a>,
+}
+
+impl<'a> TxContextStorage<'a> {
+    /// Transaction context precompile address.
+    ///
+    /// Provisional: the EIP-8130 `TX_CONTEXT_ADDRESS` is not finalized upstream.
+    /// This follows the Base singleton convention (`0x8453…`) and can be
+    /// renumbered when the spec pins a concrete value.
+    pub const ADDRESS: Address = address!("8453000000000000000000000000000000000003");
+
+    /// Transient slot holding the resolved sender address.
+    const SENDER_SLOT: U256 = U256::ZERO;
+    /// Transient slot holding the resolved payer address.
+    const PAYER_SLOT: U256 = U256::from_limbs([1, 0, 0, 0]);
+    /// Transient slot holding the sender owner id.
+    const SENDER_OWNER_ID_SLOT: U256 = U256::from_limbs([2, 0, 0, 0]);
+
+    /// Creates a transaction context view over the active storage scope.
+    pub const fn new(storage: StorageCtx<'a>) -> Self {
+        Self { storage }
+    }
+
+    /// Returns the resolved sender, or [`Address::ZERO`] when unset.
+    pub fn sender(&self) -> Result<Address> {
+        let raw = self.storage.tload(Self::ADDRESS, Self::SENDER_SLOT)?;
+        Ok(Address::from_word(B256::from(raw.to_be_bytes::<32>())))
+    }
+
+    /// Returns the resolved payer, or [`Address::ZERO`] when unset.
+    pub fn payer(&self) -> Result<Address> {
+        let raw = self.storage.tload(Self::ADDRESS, Self::PAYER_SLOT)?;
+        Ok(Address::from_word(B256::from(raw.to_be_bytes::<32>())))
+    }
+
+    /// Returns the sender owner id, or [`B256::ZERO`] when unset.
+    pub fn sender_owner_id(&self) -> Result<B256> {
+        let raw = self.storage.tload(Self::ADDRESS, Self::SENDER_OWNER_ID_SLOT)?;
+        Ok(B256::from(raw.to_be_bytes::<32>()))
+    }
+
+    /// Writes the resolved transaction context into transient storage.
+    ///
+    /// Intended for the EIP-8130 execution layer to call once at the start of
+    /// transaction processing. The values are cleared automatically when the
+    /// transaction's transient storage is reset.
+    pub fn set_context(
+        &mut self,
+        sender: Address,
+        payer: Address,
+        sender_owner_id: B256,
+    ) -> Result<()> {
+        self.storage.tstore(
+            Self::ADDRESS,
+            Self::SENDER_SLOT,
+            U256::from_be_bytes(sender.into_word().0),
+        )?;
+        self.storage.tstore(
+            Self::ADDRESS,
+            Self::PAYER_SLOT,
+            U256::from_be_bytes(payer.into_word().0),
+        )?;
+        self.storage.tstore(
+            Self::ADDRESS,
+            Self::SENDER_OWNER_ID_SLOT,
+            U256::from_be_bytes(sender_owner_id.0),
+        )?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_primitives::{Address, B256, address, b256};
+    use base_precompile_storage::{HashMapStorageProvider, StorageCtx};
+
+    use crate::tx_context::storage::TxContextStorage;
+
+    const SENDER: Address = address!("0x1111111111111111111111111111111111111111");
+    const PAYER: Address = address!("0x2222222222222222222222222222222222222222");
+    const SENDER_OWNER_ID: B256 =
+        b256!("0x3333333333333333333333333333333333333333333333333333333333333333");
+
+    #[test]
+    fn context_is_zero_by_default() {
+        let mut storage = HashMapStorageProvider::new(1);
+
+        StorageCtx::enter(&mut storage, |ctx| {
+            let view = TxContextStorage::new(ctx);
+            assert_eq!(view.sender().unwrap(), Address::ZERO);
+            assert_eq!(view.payer().unwrap(), Address::ZERO);
+            assert_eq!(view.sender_owner_id().unwrap(), B256::ZERO);
+        });
+    }
+
+    #[test]
+    fn set_context_round_trips_each_field() {
+        let mut storage = HashMapStorageProvider::new(1);
+
+        StorageCtx::enter(&mut storage, |ctx| {
+            let mut view = TxContextStorage::new(ctx);
+            view.set_context(SENDER, PAYER, SENDER_OWNER_ID).unwrap();
+
+            assert_eq!(view.sender().unwrap(), SENDER);
+            assert_eq!(view.payer().unwrap(), PAYER);
+            assert_eq!(view.sender_owner_id().unwrap(), SENDER_OWNER_ID);
+        });
+    }
+
+    #[test]
+    fn context_clears_with_transient_storage() {
+        let mut storage = HashMapStorageProvider::new(1);
+
+        StorageCtx::enter(&mut storage, |ctx| {
+            TxContextStorage::new(ctx).set_context(SENDER, PAYER, SENDER_OWNER_ID).unwrap();
+            ctx.clear_transient();
+
+            let view = TxContextStorage::new(ctx);
+            assert_eq!(view.sender().unwrap(), Address::ZERO);
+            assert_eq!(view.payer().unwrap(), Address::ZERO);
+            assert_eq!(view.sender_owner_id().unwrap(), B256::ZERO);
+        });
+    }
+}

--- a/crates/common/precompiles/src/tx_context/storage.rs
+++ b/crates/common/precompiles/src/tx_context/storage.rs
@@ -8,8 +8,12 @@ use base_precompile_storage::{Result, StorageCtx};
 /// The resolved sender, payer, and sender actor id are written to transient
 /// storage at [`Self::ADDRESS`] by the EIP-8130 execution layer at the start of
 /// transaction processing and cleared automatically at transaction end. The
-/// precompile only reads them back, so for any non-EIP-8130 transaction (where
-/// nothing is written) every getter returns the zero value.
+/// precompile only reads them back.
+///
+/// For any non-EIP-8130 transaction (where nothing is written) each getter falls
+/// back to `tx.origin`: [`Self::sender`] and [`Self::payer`] return the origin
+/// address and [`Self::sender_actor_id`] returns `bytes32(bytes20(tx.origin))`,
+/// so callers observe the actual transaction originator uniformly across tx types.
 #[derive(Debug)]
 pub struct TxContextStorage<'a> {
     storage: StorageCtx<'a>,
@@ -35,22 +39,44 @@ impl<'a> TxContextStorage<'a> {
         Self { storage }
     }
 
-    /// Returns the resolved sender, or [`Address::ZERO`] when unset.
+    /// Returns the resolved sender, falling back to `tx.origin` when unset
+    /// (i.e. outside an EIP-8130 transaction).
     pub fn sender(&self) -> Result<Address> {
         let raw = self.storage.tload(Self::ADDRESS, Self::SENDER_SLOT)?;
+        if raw.is_zero() {
+            return Ok(self.storage.origin());
+        }
         Ok(Address::from_word(B256::from(raw.to_be_bytes::<32>())))
     }
 
-    /// Returns the resolved payer, or [`Address::ZERO`] when unset.
+    /// Returns the resolved payer, falling back to `tx.origin` when unset
+    /// (i.e. outside an EIP-8130 transaction).
     pub fn payer(&self) -> Result<Address> {
         let raw = self.storage.tload(Self::ADDRESS, Self::PAYER_SLOT)?;
+        if raw.is_zero() {
+            return Ok(self.storage.origin());
+        }
         Ok(Address::from_word(B256::from(raw.to_be_bytes::<32>())))
     }
 
-    /// Returns the sender actor id, or [`B256::ZERO`] when unset.
+    /// Returns the sender actor id, falling back to `bytes32(bytes20(tx.origin))`
+    /// when unset (i.e. outside an EIP-8130 transaction).
     pub fn sender_actor_id(&self) -> Result<B256> {
         let raw = self.storage.tload(Self::ADDRESS, Self::SENDER_ACTOR_ID_SLOT)?;
+        if raw.is_zero() {
+            return Ok(Self::address_to_actor_id(self.storage.origin()));
+        }
         Ok(B256::from(raw.to_be_bytes::<32>()))
+    }
+
+    /// Derives the EOA actor id for `addr` as `bytes32(bytes20(addr))`: the 20
+    /// address bytes occupy the high-order bytes of the word, low 12 bytes zero
+    /// (left-aligned, matching the EIP-8130 Solidity cast — distinct from the
+    /// right-aligned EVM address word produced by [`Address::into_word`]).
+    fn address_to_actor_id(addr: Address) -> B256 {
+        let mut word = [0u8; 32];
+        word[..20].copy_from_slice(addr.as_slice());
+        B256::from(word)
     }
 
     /// Writes the resolved transaction context into transient storage.
@@ -94,9 +120,13 @@ mod tests {
     const PAYER: Address = address!("0x2222222222222222222222222222222222222222");
     const SENDER_ACTOR_ID: B256 =
         b256!("0x3333333333333333333333333333333333333333333333333333333333333333");
+    const ORIGIN: Address = address!("0x9999999999999999999999999999999999999999");
+    /// `bytes32(bytes20(ORIGIN))`: address left-aligned in the high 20 bytes.
+    const ORIGIN_ACTOR_ID: B256 =
+        b256!("0x9999999999999999999999999999999999999999000000000000000000000000");
 
     #[test]
-    fn context_is_zero_by_default() {
+    fn context_is_zero_when_origin_is_zero() {
         let mut storage = HashMapStorageProvider::new(1);
 
         StorageCtx::enter(&mut storage, |ctx| {
@@ -108,8 +138,22 @@ mod tests {
     }
 
     #[test]
-    fn set_context_round_trips_each_field() {
+    fn context_falls_back_to_origin_when_unset() {
         let mut storage = HashMapStorageProvider::new(1);
+        storage.set_origin(ORIGIN);
+
+        StorageCtx::enter(&mut storage, |ctx| {
+            let view = TxContextStorage::new(ctx);
+            assert_eq!(view.sender().unwrap(), ORIGIN);
+            assert_eq!(view.payer().unwrap(), ORIGIN);
+            assert_eq!(view.sender_actor_id().unwrap(), ORIGIN_ACTOR_ID);
+        });
+    }
+
+    #[test]
+    fn set_context_overrides_origin_fallback() {
+        let mut storage = HashMapStorageProvider::new(1);
+        storage.set_origin(ORIGIN);
 
         StorageCtx::enter(&mut storage, |ctx| {
             let mut view = TxContextStorage::new(ctx);
@@ -122,17 +166,18 @@ mod tests {
     }
 
     #[test]
-    fn context_clears_with_transient_storage() {
+    fn context_clears_to_origin_with_transient_storage() {
         let mut storage = HashMapStorageProvider::new(1);
+        storage.set_origin(ORIGIN);
 
         StorageCtx::enter(&mut storage, |ctx| {
             TxContextStorage::new(ctx).set_context(SENDER, PAYER, SENDER_ACTOR_ID).unwrap();
             ctx.clear_transient();
 
             let view = TxContextStorage::new(ctx);
-            assert_eq!(view.sender().unwrap(), Address::ZERO);
-            assert_eq!(view.payer().unwrap(), Address::ZERO);
-            assert_eq!(view.sender_actor_id().unwrap(), B256::ZERO);
+            assert_eq!(view.sender().unwrap(), ORIGIN);
+            assert_eq!(view.payer().unwrap(), ORIGIN);
+            assert_eq!(view.sender_actor_id().unwrap(), ORIGIN_ACTOR_ID);
         });
     }
 }

--- a/crates/common/precompiles/src/tx_context/storage.rs
+++ b/crates/common/precompiles/src/tx_context/storage.rs
@@ -99,11 +99,12 @@ impl<'a> TxContextStorage<'a> {
     /// `sender_actor_id` is zero, failing the transaction rather than corrupting
     /// sender/payer attribution.
     ///
-    /// # Gas
-    /// The three `tstore` writes are intentionally not checkpointed: transient
-    /// storage resets at transaction end, so a partial write cannot persist
-    /// across transactions. The caller is responsible for ensuring enough gas is
-    /// available to complete all three writes.
+    /// # Atomicity
+    /// The three `tstore` writes are grouped under a storage checkpoint, so a
+    /// mid-write failure (e.g. out-of-gas between writes) reverts the whole group
+    /// rather than leaving a half-set context (e.g. a real sender alongside an
+    /// unset payer that then falls back to `tx.origin`). Transient storage also
+    /// resets at transaction end, so nothing persists across transactions.
     pub fn set_context(
         &mut self,
         sender: Address,
@@ -118,6 +119,10 @@ impl<'a> TxContextStorage<'a> {
         if sender.is_zero() || payer.is_zero() || sender_actor_id.is_zero() {
             return Err(BasePrecompileError::assert_failed());
         }
+        // Write the three correlated context slots atomically: the guard reverts
+        // on drop unless committed, so a failure between writes leaves no
+        // half-set context.
+        let checkpoint = self.storage.checkpoint();
         self.storage.tstore(
             Self::ADDRESS,
             Self::SENDER_SLOT,
@@ -133,6 +138,7 @@ impl<'a> TxContextStorage<'a> {
             Self::SENDER_ACTOR_ID_SLOT,
             U256::from_be_bytes(sender_actor_id.0),
         )?;
+        checkpoint.commit();
         Ok(())
     }
 }

--- a/crates/common/precompiles/src/tx_context/storage.rs
+++ b/crates/common/precompiles/src/tx_context/storage.rs
@@ -84,12 +84,29 @@ impl<'a> TxContextStorage<'a> {
     /// Intended for the EIP-8130 execution layer to call once at the start of
     /// transaction processing. The values are cleared automatically when the
     /// transaction's transient storage is reset.
+    ///
+    /// # Invariant
+    /// In the EIP-8130 domain the resolved sender, payer, and actor id are always
+    /// non-zero (sender/payer are recovered addresses; the actor id derives from
+    /// the sender). The getters depend on this: a zero slot unambiguously means
+    /// "unset" and selects the `tx.origin` fallback, so writing a zero field here
+    /// would make it indistinguishable from an unset one. The debug assertions
+    /// below pin the invariant; callers must uphold it.
+    ///
+    /// # Gas
+    /// The three `tstore` writes are intentionally not checkpointed: transient
+    /// storage resets at transaction end, so a partial write cannot persist
+    /// across transactions. The caller is responsible for ensuring enough gas is
+    /// available to complete all three writes.
     pub fn set_context(
         &mut self,
         sender: Address,
         payer: Address,
         sender_actor_id: B256,
     ) -> Result<()> {
+        debug_assert!(!sender.is_zero(), "EIP-8130 resolved sender must be non-zero");
+        debug_assert!(!payer.is_zero(), "EIP-8130 resolved payer must be non-zero");
+        debug_assert!(!sender_actor_id.is_zero(), "EIP-8130 sender actor id must be non-zero");
         self.storage.tstore(
             Self::ADDRESS,
             Self::SENDER_SLOT,

--- a/crates/common/precompiles/src/tx_context/storage.rs
+++ b/crates/common/precompiles/src/tx_context/storage.rs
@@ -1,7 +1,7 @@
 //! Storage layout and constants for the EIP-8130 transaction context precompile.
 
 use alloy_primitives::{Address, B256, U256, address};
-use base_precompile_storage::{Result, StorageCtx};
+use base_precompile_storage::{BasePrecompileError, Result, StorageCtx};
 
 /// Transient-storage-backed view of the in-flight EIP-8130 transaction context.
 ///
@@ -90,8 +90,14 @@ impl<'a> TxContextStorage<'a> {
     /// non-zero (sender/payer are recovered addresses; the actor id derives from
     /// the sender). The getters depend on this: a zero slot unambiguously means
     /// "unset" and selects the `tx.origin` fallback, so writing a zero field here
-    /// would make it indistinguishable from an unset one. The debug assertions
-    /// below pin the invariant; callers must uphold it.
+    /// would make it indistinguishable from an unset one and silently
+    /// misattribute the transaction. This identity boundary is enforced at
+    /// runtime in all builds (see Errors), not just via debug assertions.
+    ///
+    /// # Errors
+    /// Returns [`BasePrecompileError::assert_failed`] if `sender`, `payer`, or
+    /// `sender_actor_id` is zero, failing the transaction rather than corrupting
+    /// sender/payer attribution.
     ///
     /// # Gas
     /// The three `tstore` writes are intentionally not checkpointed: transient
@@ -104,9 +110,14 @@ impl<'a> TxContextStorage<'a> {
         payer: Address,
         sender_actor_id: B256,
     ) -> Result<()> {
-        debug_assert!(!sender.is_zero(), "EIP-8130 resolved sender must be non-zero");
-        debug_assert!(!payer.is_zero(), "EIP-8130 resolved payer must be non-zero");
-        debug_assert!(!sender_actor_id.is_zero(), "EIP-8130 sender actor id must be non-zero");
+        // Identity boundary: a zero field is indistinguishable from an unset
+        // transient slot and would silently misattribute the transaction to
+        // tx.origin via the getter fallback. Reject it at runtime (in all builds)
+        // so a buggy caller fails the transaction rather than corrupting
+        // sender/payer attribution.
+        if sender.is_zero() || payer.is_zero() || sender_actor_id.is_zero() {
+            return Err(BasePrecompileError::assert_failed());
+        }
         self.storage.tstore(
             Self::ADDRESS,
             Self::SENDER_SLOT,
@@ -179,6 +190,18 @@ mod tests {
             assert_eq!(view.sender().unwrap(), SENDER);
             assert_eq!(view.payer().unwrap(), PAYER);
             assert_eq!(view.sender_actor_id().unwrap(), SENDER_ACTOR_ID);
+        });
+    }
+
+    #[test]
+    fn set_context_rejects_zero_fields() {
+        let mut storage = HashMapStorageProvider::new(1);
+
+        StorageCtx::enter(&mut storage, |ctx| {
+            let mut view = TxContextStorage::new(ctx);
+            assert!(view.set_context(Address::ZERO, PAYER, SENDER_ACTOR_ID).is_err());
+            assert!(view.set_context(SENDER, Address::ZERO, SENDER_ACTOR_ID).is_err());
+            assert!(view.set_context(SENDER, PAYER, B256::ZERO).is_err());
         });
     }
 

--- a/crates/common/precompiles/src/tx_context/storage.rs
+++ b/crates/common/precompiles/src/tx_context/storage.rs
@@ -18,10 +18,10 @@ pub struct TxContextStorage<'a> {
 impl<'a> TxContextStorage<'a> {
     /// Transaction context precompile address.
     ///
-    /// Provisional: the EIP-8130 `TX_CONTEXT_ADDRESS` is not finalized upstream.
-    /// Uses the `0x8130…` namespace (the EIP number) reserved for EIP-8130 system
-    /// precompiles and can be renumbered when the spec pins a concrete value.
-    pub const ADDRESS: Address = address!("813000000000000000000000000000000000aa01");
+    /// Pinned to `TX_CONTEXT_ADDRESS` from the EIP-8130 constant table
+    /// (`0x8130…aa02`, in the `0x8130…` / EIP-number namespace for EIP-8130
+    /// system precompiles).
+    pub const ADDRESS: Address = address!("813000000000000000000000000000000000aa02");
 
     /// Transient slot holding the resolved sender address.
     const SENDER_SLOT: U256 = U256::ZERO;

--- a/crates/common/precompiles/src/tx_context/storage.rs
+++ b/crates/common/precompiles/src/tx_context/storage.rs
@@ -5,7 +5,7 @@ use base_precompile_storage::{Result, StorageCtx};
 
 /// Transient-storage-backed view of the in-flight EIP-8130 transaction context.
 ///
-/// The resolved sender, payer, and sender owner id are written to transient
+/// The resolved sender, payer, and sender actor id are written to transient
 /// storage at [`Self::ADDRESS`] by the EIP-8130 execution layer at the start of
 /// transaction processing and cleared automatically at transaction end. The
 /// precompile only reads them back, so for any non-EIP-8130 transaction (where
@@ -27,8 +27,8 @@ impl<'a> TxContextStorage<'a> {
     const SENDER_SLOT: U256 = U256::ZERO;
     /// Transient slot holding the resolved payer address.
     const PAYER_SLOT: U256 = U256::from_limbs([1, 0, 0, 0]);
-    /// Transient slot holding the sender owner id.
-    const SENDER_OWNER_ID_SLOT: U256 = U256::from_limbs([2, 0, 0, 0]);
+    /// Transient slot holding the sender actor id.
+    const SENDER_ACTOR_ID_SLOT: U256 = U256::from_limbs([2, 0, 0, 0]);
 
     /// Creates a transaction context view over the active storage scope.
     pub const fn new(storage: StorageCtx<'a>) -> Self {
@@ -47,9 +47,9 @@ impl<'a> TxContextStorage<'a> {
         Ok(Address::from_word(B256::from(raw.to_be_bytes::<32>())))
     }
 
-    /// Returns the sender owner id, or [`B256::ZERO`] when unset.
-    pub fn sender_owner_id(&self) -> Result<B256> {
-        let raw = self.storage.tload(Self::ADDRESS, Self::SENDER_OWNER_ID_SLOT)?;
+    /// Returns the sender actor id, or [`B256::ZERO`] when unset.
+    pub fn sender_actor_id(&self) -> Result<B256> {
+        let raw = self.storage.tload(Self::ADDRESS, Self::SENDER_ACTOR_ID_SLOT)?;
         Ok(B256::from(raw.to_be_bytes::<32>()))
     }
 
@@ -62,7 +62,7 @@ impl<'a> TxContextStorage<'a> {
         &mut self,
         sender: Address,
         payer: Address,
-        sender_owner_id: B256,
+        sender_actor_id: B256,
     ) -> Result<()> {
         self.storage.tstore(
             Self::ADDRESS,
@@ -76,8 +76,8 @@ impl<'a> TxContextStorage<'a> {
         )?;
         self.storage.tstore(
             Self::ADDRESS,
-            Self::SENDER_OWNER_ID_SLOT,
-            U256::from_be_bytes(sender_owner_id.0),
+            Self::SENDER_ACTOR_ID_SLOT,
+            U256::from_be_bytes(sender_actor_id.0),
         )?;
         Ok(())
     }
@@ -92,7 +92,7 @@ mod tests {
 
     const SENDER: Address = address!("0x1111111111111111111111111111111111111111");
     const PAYER: Address = address!("0x2222222222222222222222222222222222222222");
-    const SENDER_OWNER_ID: B256 =
+    const SENDER_ACTOR_ID: B256 =
         b256!("0x3333333333333333333333333333333333333333333333333333333333333333");
 
     #[test]
@@ -103,7 +103,7 @@ mod tests {
             let view = TxContextStorage::new(ctx);
             assert_eq!(view.sender().unwrap(), Address::ZERO);
             assert_eq!(view.payer().unwrap(), Address::ZERO);
-            assert_eq!(view.sender_owner_id().unwrap(), B256::ZERO);
+            assert_eq!(view.sender_actor_id().unwrap(), B256::ZERO);
         });
     }
 
@@ -113,11 +113,11 @@ mod tests {
 
         StorageCtx::enter(&mut storage, |ctx| {
             let mut view = TxContextStorage::new(ctx);
-            view.set_context(SENDER, PAYER, SENDER_OWNER_ID).unwrap();
+            view.set_context(SENDER, PAYER, SENDER_ACTOR_ID).unwrap();
 
             assert_eq!(view.sender().unwrap(), SENDER);
             assert_eq!(view.payer().unwrap(), PAYER);
-            assert_eq!(view.sender_owner_id().unwrap(), SENDER_OWNER_ID);
+            assert_eq!(view.sender_actor_id().unwrap(), SENDER_ACTOR_ID);
         });
     }
 
@@ -126,13 +126,13 @@ mod tests {
         let mut storage = HashMapStorageProvider::new(1);
 
         StorageCtx::enter(&mut storage, |ctx| {
-            TxContextStorage::new(ctx).set_context(SENDER, PAYER, SENDER_OWNER_ID).unwrap();
+            TxContextStorage::new(ctx).set_context(SENDER, PAYER, SENDER_ACTOR_ID).unwrap();
             ctx.clear_transient();
 
             let view = TxContextStorage::new(ctx);
             assert_eq!(view.sender().unwrap(), Address::ZERO);
             assert_eq!(view.payer().unwrap(), Address::ZERO);
-            assert_eq!(view.sender_owner_id().unwrap(), B256::ZERO);
+            assert_eq!(view.sender_actor_id().unwrap(), B256::ZERO);
         });
     }
 }

--- a/crates/common/precompiles/src/tx_context/storage.rs
+++ b/crates/common/precompiles/src/tx_context/storage.rs
@@ -19,9 +19,9 @@ impl<'a> TxContextStorage<'a> {
     /// Transaction context precompile address.
     ///
     /// Provisional: the EIP-8130 `TX_CONTEXT_ADDRESS` is not finalized upstream.
-    /// Uses the `0xaa00…` namespace reserved for EIP-8130 system precompiles and
-    /// can be renumbered when the spec pins a concrete value.
-    pub const ADDRESS: Address = address!("aa0000000000000000000000000000000000aa01");
+    /// Uses the `0x8130…` namespace (the EIP number) reserved for EIP-8130 system
+    /// precompiles and can be renumbered when the spec pins a concrete value.
+    pub const ADDRESS: Address = address!("813000000000000000000000000000000000aa01");
 
     /// Transient slot holding the resolved sender address.
     const SENDER_SLOT: U256 = U256::ZERO;

--- a/crates/common/precompiles/src/tx_context/storage.rs
+++ b/crates/common/precompiles/src/tx_context/storage.rs
@@ -19,9 +19,9 @@ impl<'a> TxContextStorage<'a> {
     /// Transaction context precompile address.
     ///
     /// Provisional: the EIP-8130 `TX_CONTEXT_ADDRESS` is not finalized upstream.
-    /// This follows the Base singleton convention (`0x8453…`) and can be
-    /// renumbered when the spec pins a concrete value.
-    pub const ADDRESS: Address = address!("8453000000000000000000000000000000000003");
+    /// Uses the `0xaa00…` namespace reserved for EIP-8130 system precompiles and
+    /// can be renumbered when the spec pins a concrete value.
+    pub const ADDRESS: Address = address!("aa0000000000000000000000000000000000aa01");
 
     /// Transient slot holding the resolved sender address.
     const SENDER_SLOT: U256 = U256::ZERO;


### PR DESCRIPTION
## Summary

Adds the two EIP-8130 system precompiles, gated behind the **Cobalt** hardfork (stacked on the Cobalt plumbing from #3119):

- **Transaction context** — `TX_CONTEXT_ADDRESS` = `0x8130…aa02`
- **Nonce manager** — `NONCE_MANAGER_ADDRESS` = `0x8130…aa01`

Addresses are pinned to the EIP-8130 constant table (the `0x8130…` / EIP-number namespace). See [EIPs#11757](https://github.com/ethereum/EIPs/pull/11757).

### Transaction context precompile (`ITransactionContext`)

Read-only getters scoped to the three requested for this PR:

- `getTransactionSender()` → resolved sender of the in-flight EIP-8130 transaction
- `getTransactionPayer()` → resolved payer (equal to sender when self-paying)
- `getTransactionSenderActorId()` → actor id resolved while authenticating the sender

Backed by **transient storage** at the precompile address. The EIP-8130 execution layer calls `TxContextStorage::set_context(...)` once at the start of transaction processing (EVM execution for EIP-8130 lands in a later PR); the slots clear automatically at transaction end.

**Fallback to `tx.origin`:** outside an EIP-8130 transaction nothing is written, so the getters fall back to the ambient origin rather than returning zero — `getTransactionSender()` / `getTransactionPayer()` return `tx.origin`, and `getTransactionSenderActorId()` returns `bytes32(bytes20(tx.origin))` (address left-aligned in the high 20 bytes). This is plumbed via a new `origin()` accessor on `PrecompileStorageProvider` / `StorageCtx`.

`TxContextStorage` intentionally skips the `#[contract]` macro since it uses transient storage exclusively via raw `tload`/`tstore`.

### Nonce manager precompile (`INonceManager`)

Ported from Tempo and adapted to the Base precompile framework (`#[contract]` macro, persistent `Mapping` storage). Provides:

- `getNonce(account, nonceKey)` (ABI-callable) → current 2D sequence nonce for a channel
- `increment_nonce(...)` (internal) → advances the sequence nonce and emits `NonceIncremented`
- `check_and_mark_expiring_nonce(...)` (internal) → replay protection for nonce-free EIP-8130 transactions via a circular buffer of `(replay_id, expiry)` entries

Nonce key `0` is reserved (rejected) — that channel is served by the account-level protocol nonce, matching Tempo.

The expiring-nonce ring update wraps its correlated persistent writes in a storage **checkpoint** so a mid-sequence failure reverts the whole group atomically. The advisory mempool pre-filter (`is_expiring_nonce_seen`) takes a caller-supplied wall-clock timestamp, while the authoritative inclusion-time check reads the block timestamp; this asymmetry is documented.

### Gating

Both precompiles install at `>= BaseUpgrade::Cobalt` inside `install_with_observer`. The zkvm precompile provider reuses that same install path, so base/zkvm consistency tests stay green with no proof-crate changes.

## Test plan

- [x] `cargo test -p base-common-precompiles` — incl. transient round-trip, `tx.origin` fallback, dispatch, nonce 2D/expiring-nonce, and Cobalt-gating install tests
- [x] `cargo clippy -p base-common-precompiles --all-targets` (clean)
- [x] `cargo +nightly fmt -p base-common-precompiles --check` (clean)