### PR TITLE
fix(b20_security): rename policy_id_checked to policy_id (BOP-211)

### DIFF
--- a/crates/common/precompiles/src/b20_asset/dispatch.rs
+++ b/crates/common/precompiles/src/b20_asset/dispatch.rs
@@ -163,7 +163,7 @@ impl<S: SecurityAccounting, P: Policy> B20AssetToken<S, P> {
             C::isPaused(c) => self.is_paused(c.feature)?.abi_encode().into(),
 
             // --- Policy reads ---
-            C::policyId(c) => self.policy_id_checked(c.policyScope)?.abi_encode().into(),
+            C::policyId(c) => self.policy_id(c.policyScope)?.abi_encode().into(),
 
             // --- Domain reads ---
             C::DOMAIN_SEPARATOR(_) => self.domain_separator(ctx.chain_id())?.abi_encode().into(),

--- a/crates/common/precompiles/src/b20_asset/token.rs
+++ b/crates/common/precompiles/src/b20_asset/token.rs
@@ -129,7 +129,7 @@ impl<S: SecurityAccounting, P: Policy> B20AssetToken<S, P> {
     // --- Policy Operations ---
 
     /// Returns the configured policy ID for `policy_scope`.
-    pub fn policy_id_checked(&self, policy_scope: B256) -> Result<u64> {
+    pub fn policy_id(&self, policy_scope: B256) -> Result<u64> {
         Self::ensure_supported_policy_type(policy_scope)?;
         self.accounting().policy_id(policy_scope)
     }


### PR DESCRIPTION
## Summary

- `policy_id_checked` on `B20SecurityToken` does `ensure_supported_policy_type` then `self.accounting().policy_id()`, which is meaningful (it reverts with `UnsupportedPolicyType` for unsupported scopes rather than returning a silent default)
- The method is not a duplicate of the raw `self.accounting().policy_id()` call; the precheck adds real safety
- The name `policy_id_checked` was inconsistent: both `B20Token` (`b20/policies.rs`) and `B20StablecoinToken` (`b20_stablecoin/token.rs`) expose the identical validate-then-read pattern as `policy_id`. Rename to match.

Closes https://linear.app/coinbase/issue/BOP-211

## Test plan

- [ ] Existing tests in `dispatch.rs` (no new tests needed; behaviour is unchanged, only the private method name changes)
- [ ] `cargo check -p base-common-precompiles` passes