### PR TITLE
fix(nitro host): skip job discovery when no valid enclave signers are registered

### DIFF
--- a/crates/proof/tee/nitro-host/src/job_discovery.rs
+++ b/crates/proof/tee/nitro-host/src/job_discovery.rs
@@ -248,6 +248,13 @@ where
         };
 
         match checker.select_all_valid_enclaves().await {
+            Ok(valid) if valid.is_empty() => {
+                warn!(
+                    worker_id = %self.config.worker_id,
+                    "no valid enclave signers registered; skipping nitro job discovery poll"
+                );
+                false
+            }
             Ok(valid) => {
                 debug!(
                     worker_id = %self.config.worker_id,


### PR DESCRIPTION
Fixes #3124.

`has_valid_registered_signer` was returning `true` whenever `select_all_valid_enclaves` succeeded, even if the returned list was empty. This caused `poll_once` to claim a proof job that would immediately fail inside `acquire_enclave` (empty `candidate_indices` → `find_map` returns `None`), holding the job lock for the duration of the failed attempt and delaying other capable workers.

The fix adds an `Ok(valid) if valid.is_empty()` guard arm that returns `false` and logs a `warn` matching the existing pattern used for RPC errors and making the empty-signer case visible in operator logs.

One line behavior change in `has_valid_registered_signer`, no other changes.