### PR TITLE
fix(snapshotter): guard against non-aligned start in chunk_hashes_for_file

### DIFF
--- a/crates/infra/snapshotter/src/snapshot.rs
+++ b/crates/infra/snapshotter/src/snapshot.rs
@@ -83,6 +83,9 @@ impl SnapshotManifest {
         if meta.blocks_per_file == 0 {
             return None;
         }
+        if start % meta.blocks_per_file != 0 {
+            return None;
+        }
         let chunk_index = usize::try_from(start / meta.blocks_per_file).ok()?;
         let entries = meta.chunk_output_files.get(chunk_index)?;
         if entries.is_empty() {


### PR DESCRIPTION
Fixes #3126.

Follow-up to #3114. `chunk_hashes_for_file` uses integer division to compute the chunk index (`start / blocks_per_file`), but never checks that `start` is actually aligned to `blocks_per_file`. A non-aligned `start` silently truncates to the wrong index, returning hashes for a different chunk and potentially producing a false-positive match in the upload diff loop.

The fix adds a one-liner guard immediately after the existing `blocks_per_file == 0` check:

```rust
if start % meta.blocks_per_file != 0 {
    return None;
}
```

This returns `None` for any filename whose `start` isn't a clean multiple of `blocks_per_file`, causing the upload loop to fall through to a re-upload rather than skipping on a wrong hash match. It matches the spirit of the existing structural validation in `ChunkFilename::parse` and makes the alignment assumption explicit.

Current production filenames are always generated with aligned values, so this has no effect on the happy path. It only fires on malformed filenames that today would silently produce wrong results.

Three-line addition, no other changes.