### PR TITLE
fix(batcher/encoder): reject NaN approx_compr_ratio in EncoderConfig::validate

### DIFF
--- a/crates/batcher/encoder/src/config.rs
+++ b/crates/batcher/encoder/src/config.rs
@@ -154,7 +154,11 @@ impl EncoderConfig {
                 max_blob_frame_size: Self::MAX_BLOB_FRAME_SIZE,
             });
         }
-        if self.approx_compr_ratio <= 0.0 || self.approx_compr_ratio > 1.0 {
+        // Use the positive-range idiom (!(in_range)) so that NaN — which
+        // compares false with both operands — is correctly rejected. The
+        // `<= 0.0 || > 1.0` form returns false for NaN on both branches,
+        // silently treating it as valid and later producing NaN estimates.
+        if !(self.approx_compr_ratio > 0.0 && self.approx_compr_ratio <= 1.0) {
             return Err(EncoderConfigError::InvalidApproxComprRatio {
                 approx_compr_ratio: self.approx_compr_ratio,
             });
@@ -389,6 +393,7 @@ mod tests {
     #[case(-1.0)] // negative: nonsensical ratio
     #[case(1.1)] // above 1: overestimates compressed size
     #[case(f64::INFINITY)]
+    #[case(f64::NAN)]  // NaN: silently passes old `<= || >` check but must be rejected
     fn validate_approx_compr_ratio_err(#[case] approx_compr_ratio: f64) {
         let cfg = EncoderConfig { approx_compr_ratio, ..EncoderConfig::default() };
         let err = cfg.validate().unwrap_err();


### PR DESCRIPTION
## The bug

The `approx_compr_ratio` guard in `EncoderConfig::validate` is:

```rust
if self.approx_compr_ratio <= 0.0 || self.approx_compr_ratio > 1.0 {
    return Err(EncoderConfigError::InvalidApproxComprRatio { .. });
}
```

In IEEE 754, every comparison that involves NaN returns **false**:

```
NaN <= 0.0  →  false
NaN  > 1.0  →  false
```

So the condition is never taken and `validate()` returns `Ok(())` for `f64::NAN`.

The test suite even checks `f64::INFINITY` (which is correctly caught by the `> 1.0` branch), but `NaN` slips through silently.

## Impact

With `approx_compr_ratio = NaN`, every call to `raw_bytes as f64 * self.approx_compr_ratio` produces NaN. Downstream comparisons like `da_backlog_bytes > span_threshold` always evaluate to `false` for NaN, so the span accumulator's size-based channel close never fires — channels accumulate blocks in memory until the duration timeout, producing unexpectedly large batches.

## Fix

Swap to the positive-range idiom, which returns `true` for NaN because `NaN > 0.0 && NaN <= 1.0` evaluates to `false`:

```rust
// before
if self.approx_compr_ratio <= 0.0 || self.approx_compr_ratio > 1.0 {

// after
if !(self.approx_compr_ratio > 0.0 && self.approx_compr_ratio <= 1.0) {
```

Also adds `f64::NAN` to the existing `rstest` parameterisation so the case is explicitly covered going forward.
