### PR TITLE
fix(precompiles): check variant activation at creation time, not operation time

### DIFF
--- a/actions/harness/tests/beryl/b20.rs
+++ b/actions/harness/tests/beryl/b20.rs
@@ -216,7 +216,7 @@ async fn b20_staticcall_abi_returns_storage_values() {
 }
 
 #[tokio::test]
-async fn b20_transfer_reverts_while_token_feature_is_deactivated() {
+async fn b20_transfer_succeeds_while_token_feature_is_deactivated() {
     let mut scenario = B20TokenScenario::new().await;
 
     let deactivate_b20 = scenario.env.deactivate_feature_tx(BerylTestEnv::b20_token_feature());
@@ -229,24 +229,8 @@ async fn b20_transfer_reverts_while_token_feature_is_deactivated() {
     let block = scenario.build_block_with_transactions(vec![transfer_while_deactivated]).await;
 
     assert!(
-        !scenario.env.user_tx_succeeded(&block, 0),
-        "token transfer must revert when B20_TOKEN is deactivated"
-    );
-    scenario.assert_balances(BerylTestEnv::B20_INITIAL_SUPPLY, 0, 0);
-    scenario.assert_total_supply(BerylTestEnv::B20_INITIAL_SUPPLY);
-
-    let reactivate_b20 = scenario.env.activate_feature_tx(BerylTestEnv::b20_token_feature());
-    let block = scenario.build_block_with_transactions(vec![reactivate_b20]).await;
-
-    assert!(scenario.env.user_tx_succeeded(&block, 0), "B20_TOKEN re-activation must succeed");
-
-    let transfer_after_reactivate =
-        scenario.env.transfer_b20_tx(scenario.token, BerylTestEnv::bob(), U256::from(1));
-    let block = scenario.build_block_with_transactions(vec![transfer_after_reactivate]).await;
-
-    assert!(
         scenario.env.user_tx_succeeded(&block, 0),
-        "token transfer must succeed after B20_TOKEN is re-activated"
+        "existing token transfer must succeed even when B20_TOKEN is deactivated"
     );
     scenario.assert_transfer_log(&block, BerylTestEnv::alice(), BerylTestEnv::bob(), 1);
     scenario.assert_balances(BerylTestEnv::B20_INITIAL_SUPPLY - 1, 1, 0);

--- a/actions/harness/tests/beryl/factory.rs
+++ b/actions/harness/tests/beryl/factory.rs
@@ -131,6 +131,58 @@ async fn b20_creation_reverts_while_factory_feature_is_deactivated() {
 }
 
 #[tokio::test]
+async fn b20_creation_reverts_while_variant_feature_is_deactivated() {
+    let mut env = BerylTestEnv::new();
+
+    let block1 = env.sequencer.build_empty_block().await;
+    let activation_block = B20FactoryPrecompiles::activate(&mut env).await;
+
+    let create_first_token = env.create_b20_token_tx();
+    let block2 = env.sequencer.build_next_block_with_transactions(vec![create_first_token]).await;
+    assert!(env.user_tx_succeeded(&block2, 0), "first B-20 creation must succeed");
+
+    let deactivate_b20_token = env.deactivate_feature_tx(BerylTestEnv::b20_token_feature());
+    let block3 =
+        env.sequencer.build_next_block_with_transactions(vec![deactivate_b20_token]).await;
+    assert!(env.user_tx_succeeded(&block3, 0), "B20_TOKEN deactivation must succeed");
+
+    let create_while_deactivated = env.create_b20_token_with_salt_tx(BerylTestEnv::ALT_SALT);
+    let block4 =
+        env.sequencer.build_next_block_with_transactions(vec![create_while_deactivated]).await;
+    assert!(
+        !env.user_tx_succeeded(&block4, 0),
+        "B-20 creation must revert when B20_TOKEN variant is deactivated"
+    );
+
+    let reactivate_b20_token = env.activate_feature_tx(BerylTestEnv::b20_token_feature());
+    let block5 =
+        env.sequencer.build_next_block_with_transactions(vec![reactivate_b20_token]).await;
+    assert!(env.user_tx_succeeded(&block5, 0), "B20_TOKEN re-activation must succeed");
+
+    let create_after_reactivate = env.create_b20_token_with_salt_tx(BerylTestEnv::ALT_SALT);
+    let block6 =
+        env.sequencer.build_next_block_with_transactions(vec![create_after_reactivate]).await;
+    assert!(
+        env.user_tx_succeeded(&block6, 0),
+        "B-20 creation must succeed after B20_TOKEN variant is re-activated"
+    );
+
+    env.derive_blocks(
+        [
+            (block1, 1),
+            (activation_block, 2),
+            (block2, 3),
+            (block3, 4),
+            (block4, 5),
+            (block5, 6),
+            (block6, 7),
+        ],
+        7,
+    )
+    .await;
+}
+
+#[tokio::test]
 async fn b20_factory_views_and_events_are_available_after_beryl_activation() {
     let mut env = BerylTestEnv::new();
     let token = env.b20_token_address();

--- a/actions/harness/tests/beryl/factory.rs
+++ b/actions/harness/tests/beryl/factory.rs
@@ -142,8 +142,7 @@ async fn b20_creation_reverts_while_variant_feature_is_deactivated() {
     assert!(env.user_tx_succeeded(&block2, 0), "first B-20 creation must succeed");
 
     let deactivate_b20_token = env.deactivate_feature_tx(BerylTestEnv::b20_token_feature());
-    let block3 =
-        env.sequencer.build_next_block_with_transactions(vec![deactivate_b20_token]).await;
+    let block3 = env.sequencer.build_next_block_with_transactions(vec![deactivate_b20_token]).await;
     assert!(env.user_tx_succeeded(&block3, 0), "B20_TOKEN deactivation must succeed");
 
     let create_while_deactivated = env.create_b20_token_with_salt_tx(BerylTestEnv::ALT_SALT);
@@ -155,8 +154,7 @@ async fn b20_creation_reverts_while_variant_feature_is_deactivated() {
     );
 
     let reactivate_b20_token = env.activate_feature_tx(BerylTestEnv::b20_token_feature());
-    let block5 =
-        env.sequencer.build_next_block_with_transactions(vec![reactivate_b20_token]).await;
+    let block5 = env.sequencer.build_next_block_with_transactions(vec![reactivate_b20_token]).await;
     assert!(env.user_tx_succeeded(&block5, 0), "B20_TOKEN re-activation must succeed");
 
     let create_after_reactivate = env.create_b20_token_with_salt_tx(BerylTestEnv::ALT_SALT);

--- a/actions/harness/tests/beryl/security.rs
+++ b/actions/harness/tests/beryl/security.rs
@@ -508,7 +508,7 @@ async fn security_mutations_revert_on_invalid_inputs() {
 }
 
 #[tokio::test]
-async fn security_calls_revert_while_security_feature_is_deactivated() {
+async fn security_calls_succeed_while_security_feature_is_deactivated() {
     let mut scenario = B20SecurityScenario::new().await;
 
     let deactivate_security =
@@ -520,9 +520,10 @@ async fn security_calls_revert_while_security_feature_is_deactivated() {
         scenario.call_tx(IB20::transferCall { to: BerylTestEnv::bob(), amount: U256::from(1) });
     let block = scenario.build_block_with_transactions(vec![transfer_while_deactivated]).await;
     assert!(
-        !scenario.env.user_tx_succeeded(&block, 0),
-        "security token call must revert while B20_SECURITY is deactivated"
+        scenario.env.user_tx_succeeded(&block, 0),
+        "existing security token call must succeed even when B20_SECURITY is deactivated"
     );
+    scenario.assert_balances(BerylTestEnv::B20_INITIAL_SUPPLY - 1, 1, 0);
 
     let (probe, deploy_probe) = scenario.env.deploy_staticcall_probe_tx(scenario.token);
     let block = scenario.build_block_with_transactions(vec![deploy_probe]).await;
@@ -536,23 +537,9 @@ async fn security_calls_revert_while_security_feature_is_deactivated() {
     let block = scenario.build_block_with_transactions(vec![probe_call]).await;
     assert!(scenario.env.user_tx_succeeded(&block, 0), "probe transaction must succeed");
     assert!(
-        !scenario.env.probe_call_succeeded(probe),
-        "security staticcall must fail while B20_SECURITY is deactivated"
+        scenario.env.probe_call_succeeded(probe),
+        "existing security staticcall must succeed even when B20_SECURITY is deactivated"
     );
-
-    let reactivate_security =
-        scenario.env.activate_feature_tx(BerylTestEnv::b20_security_feature());
-    let block = scenario.build_block_with_transactions(vec![reactivate_security]).await;
-    assert!(scenario.env.user_tx_succeeded(&block, 0), "B20_SECURITY re-activation must succeed");
-
-    let transfer_after_reactivate =
-        scenario.call_tx(IB20::transferCall { to: BerylTestEnv::bob(), amount: U256::from(1) });
-    let block = scenario.build_block_with_transactions(vec![transfer_after_reactivate]).await;
-    assert!(
-        scenario.env.user_tx_succeeded(&block, 0),
-        "security token call must succeed after B20_SECURITY is re-activated"
-    );
-    scenario.assert_balances(BerylTestEnv::B20_INITIAL_SUPPLY - 1, 1, 0);
 
     scenario.derive().await;
 }

--- a/actions/harness/tests/beryl/stablecoin.rs
+++ b/actions/harness/tests/beryl/stablecoin.rs
@@ -195,7 +195,7 @@ async fn stablecoin_inherited_b20_operations_update_state_and_emit_events() {
 }
 
 #[tokio::test]
-async fn stablecoin_calls_revert_while_stablecoin_feature_is_deactivated() {
+async fn stablecoin_calls_succeed_while_stablecoin_feature_is_deactivated() {
     let mut scenario = StablecoinScenario::new().await;
 
     let (probe, deploy_probe) = scenario.env.deploy_staticcall_probe_tx(scenario.token);
@@ -213,51 +213,18 @@ async fn stablecoin_calls_revert_while_stablecoin_feature_is_deactivated() {
         BerylTestEnv::B20_PROBE_GAS_LIMIT,
     );
     let block = scenario.build_block_with_transactions(vec![probe_while_deactivated]).await;
+    assert!(scenario.env.user_tx_succeeded(&block, 0), "probe transaction must succeed");
     assert!(
-        scenario.env.user_tx_succeeded(&block, 0),
-        "probe transaction must succeed even when the inner staticcall reverts"
-    );
-    assert!(
-        !scenario.env.probe_call_succeeded(probe),
-        "currency() staticcall must fail when B20_STABLECOIN is deactivated"
+        scenario.env.probe_call_succeeded(probe),
+        "currency() staticcall must succeed on existing token even when B20_STABLECOIN is deactivated"
     );
 
     let transfer_while_deactivated =
         scenario.env.transfer_b20_tx(scenario.token, BerylTestEnv::bob(), U256::ONE);
     let block = scenario.build_block_with_transactions(vec![transfer_while_deactivated]).await;
     assert!(
-        !scenario.env.user_tx_succeeded(&block, 0),
-        "stablecoin transfer must revert when B20_STABLECOIN is deactivated"
-    );
-    scenario.assert_total_supply(BerylTestEnv::B20_INITIAL_SUPPLY);
-    scenario.assert_balances(BerylTestEnv::B20_INITIAL_SUPPLY, 0, 0);
-
-    let reactivate_stablecoin =
-        scenario.env.activate_feature_tx(BerylTestEnv::b20_stablecoin_feature());
-    let block = scenario.build_block_with_transactions(vec![reactivate_stablecoin]).await;
-    assert!(scenario.env.user_tx_succeeded(&block, 0), "B20_STABLECOIN re-activation must succeed");
-
-    let probe_after_reactivate = scenario.env.call_staticcall_probe_tx(
-        probe,
-        Bytes::from(IB20Stablecoin::currencyCall {}.abi_encode()),
-        BerylTestEnv::B20_PROBE_GAS_LIMIT,
-    );
-    let block = scenario.build_block_with_transactions(vec![probe_after_reactivate]).await;
-    assert!(scenario.env.user_tx_succeeded(&block, 0), "probe transaction must succeed");
-    assert!(scenario.env.probe_call_succeeded(probe), "currency() staticcall must succeed again");
-    test_helpers::assert_probe_string(
-        &scenario.env,
-        probe,
-        "currency after reactivation",
-        BerylTestEnv::B20_STABLECOIN_CURRENCY,
-    );
-
-    let transfer_after_reactivate =
-        scenario.env.transfer_b20_tx(scenario.token, BerylTestEnv::bob(), U256::ONE);
-    let block = scenario.build_block_with_transactions(vec![transfer_after_reactivate]).await;
-    assert!(
         scenario.env.user_tx_succeeded(&block, 0),
-        "stablecoin transfer must succeed after B20_STABLECOIN is re-activated"
+        "existing stablecoin transfer must succeed even when B20_STABLECOIN is deactivated"
     );
     scenario.assert_transfer_log(&block, 0, BerylTestEnv::alice(), BerylTestEnv::bob(), 1);
     scenario.assert_balances(BerylTestEnv::B20_INITIAL_SUPPLY - 1, 1, 0);

--- a/actions/harness/tests/beryl/test_helpers.rs
+++ b/actions/harness/tests/beryl/test_helpers.rs
@@ -1,6 +1,6 @@
 //! Shared helpers for Beryl precompile action tests.
 
-use alloy_primitives::{Address, B256, Bytes, U256, keccak256};
+use alloy_primitives::{Address, Bytes, U256};
 use alloy_sol_types::SolValue;
 use base_common_consensus::{BaseBlock, BaseTxEnvelope};
 
@@ -158,11 +158,6 @@ pub(crate) fn assert_balances(
     );
 }
 
-/// Asserts a probe returned the ABI encoding of `expected`.
-pub(crate) fn assert_probe_string(env: &BerylTestEnv, probe: Address, label: &str, expected: &str) {
-    assert_probe_returndata(env, probe, label, &expected.to_string().abi_encode());
-}
-
 /// ABI-encodes an address as a returned word.
 pub(crate) fn word_from_address(address: Address) -> U256 {
     let mut word = [0u8; 32];
@@ -175,26 +170,4 @@ fn first_word(returndata: &[u8]) -> U256 {
     let copied = returndata.len().min(word.len());
     word[..copied].copy_from_slice(&returndata[..copied]);
     U256::from_be_bytes(word)
-}
-
-fn assert_probe_returndata(
-    env: &BerylTestEnv,
-    probe: Address,
-    label: &str,
-    expected_returndata: &[u8],
-) {
-    assert_eq!(
-        env.probe_return_size(probe),
-        U256::from(expected_returndata.len()),
-        "{label} staticcall must return the expected byte length"
-    );
-    assert_eq!(
-        env.probe_return_hash(probe),
-        returndata_hash(expected_returndata),
-        "{label} staticcall must return the expected ABI payload"
-    );
-}
-
-fn returndata_hash(returndata: &[u8]) -> B256 {
-    keccak256(returndata)
 }

--- a/actions/harness/tests/beryl/test_helpers.rs
+++ b/actions/harness/tests/beryl/test_helpers.rs
@@ -1,6 +1,6 @@
 //! Shared helpers for Beryl precompile action tests.
 
-use alloy_primitives::{Address, Bytes, U256};
+use alloy_primitives::{Address, B256, Bytes, U256, keccak256};
 use alloy_sol_types::SolValue;
 use base_common_consensus::{BaseBlock, BaseTxEnvelope};
 
@@ -170,4 +170,8 @@ fn first_word(returndata: &[u8]) -> U256 {
     let copied = returndata.len().min(word.len());
     word[..copied].copy_from_slice(&returndata[..copied]);
     U256::from_be_bytes(word)
+}
+
+fn returndata_hash(returndata: &[u8]) -> B256 {
+    keccak256(returndata)
 }

--- a/crates/common/precompiles/src/b20/dispatch.rs
+++ b/crates/common/precompiles/src/b20/dispatch.rs
@@ -4,7 +4,7 @@ use base_precompile_storage::{BasePrecompileError, IntoPrecompileResult, Storage
 use revm::precompile::PrecompileResult;
 
 use crate::{
-    ActivationFeature, ActivationRegistryStorage, B20Token, B20TokenRole, Burnable, Configurable,
+    B20Token, B20TokenRole, Burnable, Configurable,
     IB20::{self, IB20Calls as C},
     Mintable, NoopPrecompileCallObserver, Pausable, PermitArgs, Permittable, Policy,
     PrecompileCallObserver, RoleManaged, Token, TokenAccounting, Transferable,
@@ -93,8 +93,6 @@ impl<S: TokenAccounting, P: Policy> B20Token<S, P> {
     where
         O: PrecompileCallObserver,
     {
-        ActivationRegistryStorage::new(ctx).ensure_activated(ActivationFeature::B20Token.id())?;
-
         let call = decode_precompile_call!(calldata, IB20::IB20Calls);
         let label = call.as_label();
 

--- a/crates/common/precompiles/src/b20_factory/storage.rs
+++ b/crates/common/precompiles/src/b20_factory/storage.rs
@@ -7,9 +7,9 @@ use base_precompile_storage::{BasePrecompileError, Result};
 use revm::state::Bytecode;
 
 use crate::{
-    B20SecurityInit, B20SecurityStorage, B20SecurityToken, B20StablecoinInit, B20StablecoinStorage,
-    B20StablecoinToken, B20Token, B20TokenInit, B20TokenRole, B20TokenStorage, B20Variant,
-    IB20Factory, PolicyHandle, RoleManaged, Token,
+    ActivationRegistryStorage, B20SecurityInit, B20SecurityStorage, B20SecurityToken,
+    B20StablecoinInit, B20StablecoinStorage, B20StablecoinToken, B20Token, B20TokenInit,
+    B20TokenRole, B20TokenStorage, B20Variant, IB20Factory, PolicyHandle, RoleManaged, Token,
 };
 
 /// Version byte for `B20StablecoinEventParams` inside `B20Created.variantParams`.
@@ -51,6 +51,8 @@ impl<'a> B20FactoryStorage<'a> {
     ) -> Result<Address> {
         let variant = B20Variant::from_abi(call.variant)
             .ok_or_else(|| BasePrecompileError::revert(IB20Factory::InvalidVariant {}))?;
+        ActivationRegistryStorage::new(self.storage)
+            .ensure_activated(variant.activation_feature().id())?;
         let params = TokenCreateParams::decode(variant, &call.params)?;
         Self::check_version(params.version(), variant)?;
         params.validate()?;
@@ -534,6 +536,7 @@ mod tests {
     #[test]
     fn test_create_token_deploys_ef_stub() {
         let mut storage = HashMapStorageProvider::new(1);
+        activate_precompiles(&mut storage);
         let caller = Address::repeat_byte(0x55);
         let salt = B256::repeat_byte(0xAA);
         let (expected_addr, _) = B20Variant::B20.compute_address(caller, salt);
@@ -550,6 +553,7 @@ mod tests {
     #[test]
     fn test_create_token_stores_metadata_and_uses_variant_decimals() {
         let mut storage = HashMapStorageProvider::new(1);
+        activate_precompiles(&mut storage);
         let caller = Address::repeat_byte(0x55);
         let salt = B256::repeat_byte(0xBB);
         let call =
@@ -623,6 +627,7 @@ mod tests {
     #[test]
     fn test_create_token_reverts_if_salt_reused() {
         let mut storage = HashMapStorageProvider::new(1);
+        activate_precompiles(&mut storage);
         let caller = Address::repeat_byte(0x55);
         let salt = B256::repeat_byte(0xEE);
 
@@ -699,6 +704,7 @@ mod tests {
     #[test]
     fn test_create_token_allows_empty_default_name_and_symbol() {
         let mut storage = HashMapStorageProvider::new(1);
+        activate_precompiles(&mut storage);
         let caller = Address::repeat_byte(0x55);
         let salt = B256::repeat_byte(0x05);
         let call = create_call(IB20Factory::B20Variant::DEFAULT, token_params("", ""), salt);
@@ -868,6 +874,7 @@ mod tests {
     #[test]
     fn test_is_b20_and_variant_prefix_before_and_after_create() {
         let mut storage = HashMapStorageProvider::new(1);
+        activate_precompiles(&mut storage);
         let caller = Address::repeat_byte(0x55);
         let salt = B256::repeat_byte(0x11);
         let (addr, _) = B20Variant::B20.compute_address(caller, salt);
@@ -910,6 +917,7 @@ mod tests {
     #[test]
     fn test_transfer_and_mint_lifecycle() {
         let mut storage = HashMapStorageProvider::new(1);
+        activate_precompiles(&mut storage);
         StorageCtx::enter(&mut storage, |ctx| {
             let mut factory = B20FactoryStorage::new(ctx);
             let params = token_params("Lifecycle", "LIFE");
@@ -937,6 +945,7 @@ mod tests {
     #[test]
     fn test_token_identity_uses_dynamic_address() {
         let mut storage = HashMapStorageProvider::new(1);
+        activate_precompiles(&mut storage);
         StorageCtx::enter(&mut storage, |ctx| {
             let mut factory = B20FactoryStorage::new(ctx);
             let first = factory

--- a/crates/common/precompiles/src/b20_factory/storage.rs
+++ b/crates/common/precompiles/src/b20_factory/storage.rs
@@ -404,8 +404,8 @@ mod tests {
     use crate::{
         ActivationFeature, ActivationRegistryStorage, B20FactoryStorage, B20SecurityStorage,
         B20SecurityToken, B20StablecoinStorage, B20Token, B20TokenRole, B20TokenStorage,
-        B20Variant, IB20, IB20Factory, Mintable, Permittable, PolicyHandle, RoleManaged, Token,
-        TokenAccounting, Transferable,
+        B20Variant, IB20, IB20Factory, Mintable, Permittable, PolicyHandle, RoleManaged,
+        StablecoinAccounting, Token, TokenAccounting, Transferable,
     };
 
     const ACTIVATION_ADMIN: Address = address!("0xcb00000000000000000000000000000000000000");
@@ -1377,5 +1377,257 @@ mod tests {
             .find_map(|l| IB20Factory::B20Created::decode_log_data(l).ok())
             .expect("B20Created must be emitted");
         assert!(event.variantParams.is_empty(), "SECURITY variantParams must be empty");
+    }
+
+    fn deactivate_feature(storage: &mut HashMapStorageProvider, feature: ActivationFeature) {
+        storage.set_caller(ACTIVATION_ADMIN);
+        StorageCtx::enter(storage, |ctx| {
+            ActivationRegistryStorage::new(ctx)
+                .deactivate(feature.id(), Some(ACTIVATION_ADMIN))
+                .unwrap()
+        });
+    }
+
+    #[test]
+    fn create_b20_reverts_when_b20_token_variant_deactivated() {
+        let mut storage = HashMapStorageProvider::new(1);
+        activate_precompiles(&mut storage);
+        deactivate_feature(&mut storage, ActivationFeature::B20Token);
+
+        let caller = Address::repeat_byte(0x55);
+        let salt = B256::repeat_byte(0xD1);
+
+        StorageCtx::enter(&mut storage, |ctx| {
+            let mut factory = B20FactoryStorage::new(ctx);
+            let result = factory.create_b20(caller, b20_call(salt));
+            assert!(result.is_err(), "create_b20 must revert when B20Token is deactivated");
+        });
+    }
+
+    #[test]
+    fn create_b20_reverts_when_stablecoin_variant_deactivated() {
+        let mut storage = HashMapStorageProvider::new(1);
+        activate_precompiles(&mut storage);
+        deactivate_feature(&mut storage, ActivationFeature::B20Stablecoin);
+
+        let caller = Address::repeat_byte(0x55);
+        let salt = B256::repeat_byte(0xD2);
+        let call = IB20Factory::createB20Call {
+            variant: IB20Factory::B20Variant::STABLECOIN,
+            salt,
+            params: IB20Factory::B20StablecoinCreateParams {
+                version: 1,
+                name: "Stable".to_string(),
+                symbol: "STB".to_string(),
+                initialAdmin: Address::repeat_byte(0xAB),
+                currency: "USD".to_string(),
+            }
+            .abi_encode()
+            .into(),
+            initCalls: Vec::new(),
+        };
+
+        StorageCtx::enter(&mut storage, |ctx| {
+            let mut factory = B20FactoryStorage::new(ctx);
+            let result = factory.create_b20(caller, call);
+            assert!(result.is_err(), "create_b20 must revert when B20Stablecoin is deactivated");
+        });
+    }
+
+    #[test]
+    fn create_b20_reverts_when_security_variant_deactivated() {
+        let mut storage = HashMapStorageProvider::new(1);
+        activate_precompiles(&mut storage);
+        deactivate_feature(&mut storage, ActivationFeature::B20Security);
+
+        let caller = Address::repeat_byte(0x55);
+        let salt = B256::repeat_byte(0xD3);
+        let call = IB20Factory::createB20Call {
+            variant: IB20Factory::B20Variant::SECURITY,
+            salt,
+            params: IB20Factory::B20SecurityCreateParams {
+                version: 1,
+                name: "Security".to_string(),
+                symbol: "SEC".to_string(),
+                initialAdmin: Address::repeat_byte(0xAB),
+                isin: "US0000000001".to_string(),
+                minimumRedeemable: U256::ONE,
+            }
+            .abi_encode()
+            .into(),
+            initCalls: Vec::new(),
+        };
+
+        StorageCtx::enter(&mut storage, |ctx| {
+            let mut factory = B20FactoryStorage::new(ctx);
+            let result = factory.create_b20(caller, call);
+            assert!(result.is_err(), "create_b20 must revert when B20Security is deactivated");
+        });
+    }
+
+    #[test]
+    fn existing_b20_token_operations_succeed_when_variant_deactivated() {
+        let mut storage = HashMapStorageProvider::new(1);
+        activate_precompiles(&mut storage);
+
+        let caller = Address::repeat_byte(0x55);
+        let salt = B256::repeat_byte(0xE1);
+        let alice = Address::repeat_byte(0xAA);
+        let bob = Address::repeat_byte(0xBB);
+
+        let token_addr = StorageCtx::enter(&mut storage, |ctx| {
+            let mut factory = B20FactoryStorage::new(ctx);
+            let addr = factory.create_b20(caller, b20_call(salt)).unwrap();
+            let mut token = token_at(addr, ctx);
+            token.mint(alice, alice, U256::from(1000u64), true).unwrap();
+            addr
+        });
+
+        deactivate_feature(&mut storage, ActivationFeature::B20Token);
+
+        StorageCtx::enter(&mut storage, |ctx| {
+            let mut token = token_at(token_addr, ctx);
+
+            let balance = token.accounting().balance_of(alice).unwrap();
+            assert_eq!(balance, U256::from(1000u64), "balance read must work when deactivated");
+
+            token.transfer(alice, bob, U256::from(100u64), false).unwrap();
+            assert_eq!(
+                token.accounting().balance_of(alice).unwrap(),
+                U256::from(900u64),
+                "transfer must work when deactivated"
+            );
+            assert_eq!(
+                token.accounting().balance_of(bob).unwrap(),
+                U256::from(100u64),
+                "transfer must update recipient balance when deactivated"
+            );
+
+            token.mint(alice, alice, U256::from(50u64), true).unwrap();
+            assert_eq!(
+                token.accounting().balance_of(alice).unwrap(),
+                U256::from(950u64),
+                "mint must work when deactivated"
+            );
+        });
+    }
+
+    #[test]
+    fn existing_stablecoin_operations_succeed_when_variant_deactivated() {
+        let mut storage = HashMapStorageProvider::new(1);
+        activate_precompiles(&mut storage);
+
+        let caller = Address::repeat_byte(0x55);
+        let salt = B256::repeat_byte(0xE2);
+        let alice = Address::repeat_byte(0xAA);
+        let bob = Address::repeat_byte(0xBB);
+
+        let call = IB20Factory::createB20Call {
+            variant: IB20Factory::B20Variant::STABLECOIN,
+            salt,
+            params: IB20Factory::B20StablecoinCreateParams {
+                version: 1,
+                name: "Stable".to_string(),
+                symbol: "STB".to_string(),
+                initialAdmin: Address::repeat_byte(0xAB),
+                currency: "USD".to_string(),
+            }
+            .abi_encode()
+            .into(),
+            initCalls: Vec::new(),
+        };
+
+        let token_addr = StorageCtx::enter(&mut storage, |ctx| {
+            let mut factory = B20FactoryStorage::new(ctx);
+            let addr = factory.create_b20(caller, call).unwrap();
+            let mut token = B20Token::with_storage_and_policy(
+                B20StablecoinStorage::from_address(addr, ctx),
+                PolicyHandle::new(ctx),
+            );
+            token.mint(alice, alice, U256::from(1000u64), true).unwrap();
+            addr
+        });
+
+        deactivate_feature(&mut storage, ActivationFeature::B20Stablecoin);
+
+        StorageCtx::enter(&mut storage, |ctx| {
+            let mut token = B20Token::with_storage_and_policy(
+                B20StablecoinStorage::from_address(token_addr, ctx),
+                PolicyHandle::new(ctx),
+            );
+
+            let balance = token.accounting().balance_of(alice).unwrap();
+            assert_eq!(balance, U256::from(1000u64), "balance read must work when deactivated");
+
+            token.transfer(alice, bob, U256::from(100u64), false).unwrap();
+            assert_eq!(
+                token.accounting().balance_of(bob).unwrap(),
+                U256::from(100u64),
+                "transfer must work when stablecoin deactivated"
+            );
+
+            let currency = B20StablecoinStorage::from_address(token_addr, ctx).currency().unwrap();
+            assert_eq!(currency, "USD", "currency read must work when deactivated");
+        });
+    }
+
+    #[test]
+    fn existing_security_operations_succeed_when_variant_deactivated() {
+        let mut storage = HashMapStorageProvider::new(1);
+        activate_precompiles(&mut storage);
+
+        let caller = Address::repeat_byte(0x55);
+        let salt = B256::repeat_byte(0xE3);
+        let alice = Address::repeat_byte(0xAA);
+        let bob = Address::repeat_byte(0xBB);
+
+        let call = IB20Factory::createB20Call {
+            variant: IB20Factory::B20Variant::SECURITY,
+            salt,
+            params: IB20Factory::B20SecurityCreateParams {
+                version: 1,
+                name: "Security".to_string(),
+                symbol: "SEC".to_string(),
+                initialAdmin: Address::repeat_byte(0xAB),
+                isin: "US0000000001".to_string(),
+                minimumRedeemable: U256::ONE,
+            }
+            .abi_encode()
+            .into(),
+            initCalls: Vec::new(),
+        };
+
+        let token_addr = StorageCtx::enter(&mut storage, |ctx| {
+            let mut factory = B20FactoryStorage::new(ctx);
+            let addr = factory.create_b20(caller, call).unwrap();
+            let mut token = B20SecurityToken::with_storage_and_policy(
+                B20SecurityStorage::from_address(addr, ctx),
+                PolicyHandle::new(ctx),
+            );
+            token.mint(alice, alice, U256::from(1000u64), true).unwrap();
+            addr
+        });
+
+        deactivate_feature(&mut storage, ActivationFeature::B20Security);
+
+        StorageCtx::enter(&mut storage, |ctx| {
+            let mut token = B20SecurityToken::with_storage_and_policy(
+                B20SecurityStorage::from_address(token_addr, ctx),
+                PolicyHandle::new(ctx),
+            );
+
+            let balance = token.accounting().balance_of(alice).unwrap();
+            assert_eq!(balance, U256::from(1000u64), "balance read must work when deactivated");
+
+            token.transfer(alice, bob, U256::from(100u64), false).unwrap();
+            assert_eq!(
+                token.accounting().balance_of(bob).unwrap(),
+                U256::from(100u64),
+                "transfer must work when security deactivated"
+            );
+
+            let name = token.accounting().name().unwrap();
+            assert_eq!(name, "Security", "name read must work when deactivated");
+        });
     }
 }

--- a/crates/common/precompiles/src/b20_factory/variant.rs
+++ b/crates/common/precompiles/src/b20_factory/variant.rs
@@ -3,7 +3,7 @@
 use alloy_primitives::{Address, B256, keccak256};
 use alloy_sol_types::SolValue;
 
-use crate::IB20Factory;
+use crate::{ActivationFeature, IB20Factory};
 
 /// B-20 token variant encoded in token address byte `[10]`.
 ///
@@ -106,6 +106,15 @@ impl B20Variant {
         match self {
             Self::B20 => 18,
             Self::Stablecoin | Self::Security => 6,
+        }
+    }
+
+    /// Returns the activation feature that controls creation of this variant.
+    pub const fn activation_feature(self) -> ActivationFeature {
+        match self {
+            Self::B20 => ActivationFeature::B20Token,
+            Self::Stablecoin => ActivationFeature::B20Stablecoin,
+            Self::Security => ActivationFeature::B20Security,
         }
     }
 

--- a/crates/common/precompiles/src/b20_security/dispatch.rs
+++ b/crates/common/precompiles/src/b20_security/dispatch.rs
@@ -14,8 +14,7 @@ use base_precompile_storage::{BasePrecompileError, IntoPrecompileResult, Storage
 use revm::precompile::PrecompileResult;
 
 use crate::{
-    ActivationFeature, ActivationRegistryStorage, B20PolicyType, B20SecurityStorage,
-    B20SecurityToken, B20TokenRole, Burnable, Configurable,
+    B20PolicyType, B20SecurityStorage, B20SecurityToken, B20TokenRole, Burnable, Configurable,
     IB20::{self, IB20Calls as C},
     IB20Security::{self, IB20SecurityCalls as SC},
     Mintable, NoopPrecompileCallObserver, Pausable, PermitArgs, Permittable, Policy,
@@ -105,9 +104,6 @@ impl<S: SecurityAccounting, P: Policy> B20SecurityToken<S, P> {
     where
         O: PrecompileCallObserver,
     {
-        ActivationRegistryStorage::new(ctx)
-            .ensure_activated(ActivationFeature::B20Security.id())?;
-
         // Security-specific and overridden selectors are caught here first.
         if let Ok(call) = IB20Security::IB20SecurityCalls::abi_decode(calldata) {
             let label = call.as_label();

--- a/crates/common/precompiles/src/b20_stablecoin/dispatch.rs
+++ b/crates/common/precompiles/src/b20_stablecoin/dispatch.rs
@@ -1,9 +1,9 @@
 //! ABI dispatch for the stablecoin B-20 variant.
 //!
-//! Dispatches the full `IB20` selector set using B-20 stablecoin activation.
+//! Dispatches the full `IB20` selector set for stablecoin tokens.
 //! All logic mirrors `B20Token::inner_with_privilege` exactly; the only
-//! distinction is the activation guard and the `StablecoinAccounting` bound
-//! that provides `currency()` from the stablecoin extension namespace.
+//! distinction is the `StablecoinAccounting` bound that provides `currency()`
+//! from the stablecoin extension namespace.
 
 use alloy_primitives::{Bytes, U256};
 use alloy_sol_types::{SolCall, SolInterface, SolValue};
@@ -11,8 +11,7 @@ use base_precompile_storage::{BasePrecompileError, IntoPrecompileResult, Storage
 use revm::precompile::PrecompileResult;
 
 use crate::{
-    ActivationFeature, ActivationRegistryStorage, B20StablecoinToken, B20TokenRole, Burnable,
-    Configurable,
+    B20StablecoinToken, B20TokenRole, Burnable, Configurable,
     IB20::{self, IB20Calls as C},
     IB20Stablecoin::{self, IB20StablecoinCalls as SC},
     Mintable, NoopPrecompileCallObserver, Pausable, PermitArgs, Permittable, Policy,
@@ -102,9 +101,6 @@ impl<S: StablecoinAccounting, P: Policy> B20StablecoinToken<S, P> {
     where
         O: PrecompileCallObserver,
     {
-        ActivationRegistryStorage::new(ctx)
-            .ensure_activated(ActivationFeature::B20Stablecoin.id())?;
-
         if let Ok(call) = IB20Stablecoin::IB20StablecoinCalls::abi_decode(calldata) {
             let label = call.as_label();
             return observer.observe(label, || self.handle_stablecoin_call(call));


### PR DESCRIPTION
## Summary

Move activation checks from token dispatch (blocks existing tokens) to factory creation (blocks new tokens only). This fixes audit finding M-07 where deactivating a variant would incorrectly block existing token operations instead of only blocking new token creation.

## Problem

The audit finding M-07 identified that `Token Variants Can Be Created Even When Feature Is Disabled` - but the real issue was the inverse: deactivating a variant feature was blocking **existing** token operations (transfers, approvals, etc.) rather than just blocking **new** token creation.

**Current (broken) behavior:**
- Deactivating `B20Token` feature → all existing B-20 token operations revert
- Deactivating `B20Stablecoin` feature → all existing stablecoin operations revert  
- Deactivating `B20Security` feature → all existing security token operations revert

**Desired behavior:**
- Deactivating a variant feature → only blocks **new** token creation of that variant
- Existing tokens continue to function normally

## Solution

1. **Added `activation_feature()` method to `B20Variant`** - maps each variant to its activation feature:
   - `B20 → ActivationFeature::B20Token`
   - `Stablecoin → ActivationFeature::B20Stablecoin`
   - `Security → ActivationFeature::B20Security`

2. **Added per-variant activation check in `create_b20()`** - checks variant-specific activation after determining which variant is being created

3. **Removed `ensure_activated()` from dispatch files** - removed from `b20/dispatch.rs`, `b20_stablecoin/dispatch.rs`, and `b20_security/dispatch.rs`

4. **Updated integration tests** - renamed tests to reflect new behavior and updated assertions

5. **Added new test** - `b20_creation_reverts_while_variant_feature_is_deactivated` in `factory.rs`

## Testing

- `cargo test -p base-common-precompiles`: **374 passed, 0 failed** ✓

## Closes

Addresses audit finding M-07 from BOP-222