### PR TITLE
fix: bump revm-inspectors to 0.34.4 for erc7562Tracer storage reads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18616,9 +18616,9 @@ dependencies = [
 
 [[package]]
 name = "revm-inspectors"
-version = "0.34.3"
+version = "0.34.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e341d9777b1903a8428bc6f8fe7a8f80671d2249837c9749566e61328ef14125"
+checksum = "699b3689517761b838844d715482dfa6059c20a0a5a68bc363e1604d29918555"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -284,7 +284,10 @@ base-runtime = { path = "crates/utilities/runtime", default-features = false }
 revm = { version = "34.0.0", default-features = false }
 revm-bytecode = { version = "8.0.0", default-features = false }
 revm-database = { version = "10.0.0", default-features = false }
-revm-inspectors = { version = "0.34.3", default-features = false }
+# NOTE: 0.34.4 includes fix for erc7562Tracer accessedSlots.reads (paradigmxyz/revm-inspectors#451).
+# The fix was only backported to 0.34.x. If upgrading to 0.35.x-0.39.x, request a cherry-pick
+# from the reth team: https://github.com/paradigmxyz/revm-inspectors/commits/v0.34.4/
+revm-inspectors = { version = "0.34.4", default-features = false }
 revm-precompile = { version = "32.0.0", default-features = false }
 revm-primitives = { version = "22.0.0", default-features = false }
 revm-context-interface = { version = "14.0.0", default-features = false }
@@ -602,3 +605,4 @@ toml = { version = "1.0", default-features = false }
 ark-ff = { version = "0.5.0", default-features = false }
 unsigned-varint = { version = "0.8", default-features = false }
 ark-bls12-381 = { version = "0.5.0", default-features = false }
+


### PR DESCRIPTION
Bumps `revm-inspectors` from 0.34.3 to 0.34.4 which fixes `accessedSlots.reads` being empty in the `erc7562Tracer`.

Upstream fix: https://github.com/paradigmxyz/revm-inspectors/pull/451
Release: https://github.com/paradigmxyz/revm-inspectors/commits/v0.34.4/
