### PR TITLE
chore: backport revm-inspectors 0.39.1 bump to releases/v1.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18822,9 +18822,9 @@ dependencies = [
 
 [[package]]
 name = "revm-inspectors"
-version = "0.39.0"
+version = "0.39.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "731b682530a732ef9c189ef831589128e2ce34d4a306c956322ae2dffe009715"
+checksum = "5dea6997563b46432f9c1822275cab4c462aed8f4a189dc518478c31317afb99"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth 2.0.5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -286,7 +286,7 @@ base-runtime = { path = "crates/utilities/runtime", default-features = false }
 revm = { version = "38.0.0", default-features = false }
 revm-bytecode = { version = "10.0.0", default-features = false }
 revm-database = { version = "13.0.0", default-features = false }
-revm-inspectors = { version = "0.39.0", default-features = false }
+revm-inspectors = { version = "0.39.1", default-features = false }
 revm-precompile = { version = "34.0.0", default-features = false }
 revm-primitives = { version = "23.0.0", default-features = false }
 revm-context-interface = { version = "17.0.1", default-features = false }


### PR DESCRIPTION
## Summary
- backport the workspace `revm-inspectors` dependency bump from `0.39.0` to `0.39.1`
- refresh `Cargo.lock` on `releases/v1.0.0` to the crates.io `0.39.1` release

## Validation
- cargo check -p base-metering
