### PR TITLE
remove batch_burn and BURN_FROM_ROLE from B20Asset precompile

### DIFF
--- a/actions/harness/tests/beryl/security.rs
+++ b/actions/harness/tests/beryl/security.rs
@@ -19,8 +19,6 @@ const UPDATED_RATIO: U256 = U256::from_limbs([2_000_000_000_000_000_000, 0, 0, 0
 const UPDATED_MINIMUM_REDEEMABLE: U256 = U256::from_limbs([20, 0, 0, 0]);
 const BOB_MINT_AMOUNT: u64 = 100;
 const CAROL_MINT_AMOUNT: u64 = 200;
-const BOB_BURN_AMOUNT: u64 = 10;
-const CAROL_BURN_AMOUNT: u64 = 20;
 const REDEEM_AMOUNT: u64 = 20;
 const REDEEM_WITH_MEMO_AMOUNT: u64 = 30;
 const REDEEM_MEMO: B256 = B256::repeat_byte(0x61);
@@ -135,11 +133,6 @@ async fn security_creation_initializes_identifiers_and_factory_views() {
                     security_operator_role(),
                 ),
                 StaticcallCase::bytes32(
-                    "BURN_FROM_ROLE",
-                    IB20Security::BURN_FROM_ROLECall {}.abi_encode(),
-                    burn_from_role(),
-                ),
-                StaticcallCase::bytes32(
                     "REDEEM_SENDER_POLICY",
                     IB20Security::REDEEM_SENDER_POLICYCall {}.abi_encode(),
                     B20SecurityStorage::REDEEM_SENDER_POLICY,
@@ -165,9 +158,7 @@ async fn security_creation_initializes_identifiers_and_factory_views() {
 #[tokio::test]
 async fn security_mutations_update_state_and_emit_events() {
     let mut scenario = B20SecurityScenario::new().await;
-    scenario
-        .grant_roles([security_operator_role(), burn_from_role(), B20TokenRole::Mint.id()])
-        .await;
+    scenario.grant_roles([security_operator_role(), B20TokenRole::Mint.id()]).await;
 
     let update_ratio = scenario
         .call_tx(IB20Security::updateShareRatioCall { newSharesToTokensRatio: UPDATED_RATIO });
@@ -181,10 +172,6 @@ async fn security_mutations_update_state_and_emit_events() {
     let batch_mint = scenario.call_tx(IB20Security::batchMintCall {
         recipients: vec![BerylTestEnv::bob(), BerylTestEnv::carol()],
         amounts: vec![U256::from(BOB_MINT_AMOUNT), U256::from(CAROL_MINT_AMOUNT)],
-    });
-    let batch_burn = scenario.call_tx(IB20Security::batchBurnCall {
-        accounts: vec![BerylTestEnv::bob(), BerylTestEnv::carol()],
-        amounts: vec![U256::from(BOB_BURN_AMOUNT), U256::from(CAROL_BURN_AMOUNT)],
     });
     let redeem = scenario.call_tx(IB20Security::redeemCall { amount: U256::from(REDEEM_AMOUNT) });
     let redeem_with_memo = scenario.call_tx(IB20Security::redeemWithMemoCall {
@@ -207,14 +194,13 @@ async fn security_mutations_update_state_and_emit_events() {
             update_minimum,
             update_cusip,
             batch_mint,
-            batch_burn,
             redeem,
             redeem_with_memo,
             announce,
         ])
         .await;
 
-    for index in 0..8 {
+    for index in 0..7 {
         assert!(
             scenario.env.user_tx_succeeded(&block, index),
             "security mutation {index} must succeed"
@@ -267,26 +253,6 @@ async fn security_mutations_update_state_and_emit_events() {
     scenario.assert_log(
         &block,
         4,
-        IB20::Transfer {
-            from: BerylTestEnv::bob(),
-            to: Address::ZERO,
-            amount: U256::from(BOB_BURN_AMOUNT),
-        }
-        .encode_log_data(),
-    );
-    scenario.assert_log(
-        &block,
-        4,
-        IB20::Transfer {
-            from: BerylTestEnv::carol(),
-            to: Address::ZERO,
-            amount: U256::from(CAROL_BURN_AMOUNT),
-        }
-        .encode_log_data(),
-    );
-    scenario.assert_log(
-        &block,
-        5,
         IB20Security::Redeemed {
             from: BerylTestEnv::alice(),
             amt: U256::from(REDEEM_AMOUNT),
@@ -296,12 +262,12 @@ async fn security_mutations_update_state_and_emit_events() {
     );
     scenario.assert_log(
         &block,
-        6,
+        5,
         IB20::Memo { caller: BerylTestEnv::alice(), memo: REDEEM_MEMO }.encode_log_data(),
     );
     scenario.assert_log(
         &block,
-        6,
+        5,
         IB20Security::Redeemed {
             from: BerylTestEnv::alice(),
             amt: U256::from(REDEEM_WITH_MEMO_AMOUNT),
@@ -311,7 +277,7 @@ async fn security_mutations_update_state_and_emit_events() {
     );
     scenario.assert_log(
         &block,
-        7,
+        6,
         IB20Security::Announcement {
             caller: BerylTestEnv::alice(),
             id: ANNOUNCEMENT_ID.to_string(),
@@ -322,7 +288,7 @@ async fn security_mutations_update_state_and_emit_events() {
     );
     scenario.assert_log(
         &block,
-        7,
+        6,
         IB20Security::SecurityIdentifierUpdated {
             identifierType: "FIGI".to_string(),
             value: FIGI.to_string(),
@@ -331,21 +297,19 @@ async fn security_mutations_update_state_and_emit_events() {
     );
     scenario.assert_log(
         &block,
-        7,
+        6,
         IB20Security::EndAnnouncement { id: ANNOUNCEMENT_ID.to_string() }.encode_log_data(),
     );
 
     scenario.assert_total_supply(
         BerylTestEnv::B20_INITIAL_SUPPLY + BOB_MINT_AMOUNT + CAROL_MINT_AMOUNT
-            - BOB_BURN_AMOUNT
-            - CAROL_BURN_AMOUNT
             - REDEEM_AMOUNT
             - REDEEM_WITH_MEMO_AMOUNT,
     );
     scenario.assert_balances(
         BerylTestEnv::B20_INITIAL_SUPPLY - REDEEM_AMOUNT - REDEEM_WITH_MEMO_AMOUNT,
-        BOB_MINT_AMOUNT - BOB_BURN_AMOUNT,
-        CAROL_MINT_AMOUNT - CAROL_BURN_AMOUNT,
+        BOB_MINT_AMOUNT,
+        CAROL_MINT_AMOUNT,
     );
 
     scenario
@@ -393,7 +357,7 @@ async fn security_mutations_update_state_and_emit_events() {
                 StaticcallCase::word(
                     "totalSupply after security mutations",
                     IB20::totalSupplyCall {}.abi_encode(),
-                    U256::from(1_000_220),
+                    U256::from(1_000_250),
                 ),
             ],
         )
@@ -405,9 +369,7 @@ async fn security_mutations_update_state_and_emit_events() {
 #[tokio::test]
 async fn security_mutations_revert_on_invalid_inputs() {
     let mut scenario = B20SecurityScenario::new().await;
-    scenario
-        .grant_roles([security_operator_role(), burn_from_role(), B20TokenRole::Mint.id()])
-        .await;
+    scenario.grant_roles([security_operator_role(), B20TokenRole::Mint.id()]).await;
 
     let first_announcement = scenario.call_tx(IB20Security::announceCall {
         internalCalls: Vec::new(),
@@ -419,10 +381,6 @@ async fn security_mutations_revert_on_invalid_inputs() {
         .call_tx(IB20Security::batchMintCall { recipients: Vec::new(), amounts: Vec::new() });
     let mismatched_batch_mint = scenario.call_tx(IB20Security::batchMintCall {
         recipients: vec![BerylTestEnv::bob()],
-        amounts: vec![U256::from(1), U256::from(2)],
-    });
-    let mismatched_batch_burn = scenario.call_tx(IB20Security::batchBurnCall {
-        accounts: vec![BerylTestEnv::bob()],
         amounts: vec![U256::from(1), U256::from(2)],
     });
     let below_minimum_redeem = scenario.call_tx(IB20Security::redeemCall { amount: U256::from(1) });
@@ -459,7 +417,6 @@ async fn security_mutations_revert_on_invalid_inputs() {
             first_announcement,
             empty_batch_mint,
             mismatched_batch_mint,
-            mismatched_batch_burn,
             below_minimum_redeem,
             empty_identifier_type,
             duplicate_announcement,
@@ -469,7 +426,7 @@ async fn security_mutations_revert_on_invalid_inputs() {
         .await;
 
     assert!(scenario.env.user_tx_succeeded(&block, 0), "first announce() must succeed");
-    for index in 1..9 {
+    for index in 1..8 {
         assert!(
             !scenario.env.user_tx_succeeded(&block, index),
             "invalid security mutation {index} must revert"
@@ -706,8 +663,4 @@ impl B20SecurityScenario {
 
 fn security_operator_role() -> B256 {
     keccak256("SECURITY_OPERATOR_ROLE")
-}
-
-fn burn_from_role() -> B256 {
-    keccak256("BURN_FROM_ROLE")
 }

--- a/crates/common/precompiles/src/b20_security/abi.rs
+++ b/crates/common/precompiles/src/b20_security/abi.rs
@@ -59,9 +59,6 @@ sol! {
         /// `keccak256("SECURITY_OPERATOR_ROLE")` — required for `announce`, `updateShareRatio`, `updateSecurityIdentifier`.
         function SECURITY_OPERATOR_ROLE() external view returns (bytes32);
 
-        /// `keccak256("BURN_FROM_ROLE")` — required for `batchBurn`.
-        function BURN_FROM_ROLE() external view returns (bytes32);
-
         /// Fixed-point precision for `sharesToTokensRatio`: `1e18` (one WAD).
         function WAD_PRECISION() external view returns (uint256);
 
@@ -100,9 +97,6 @@ sol! {
         /// Mints `amounts[i]` to `recipients[i]`. Requires `MINT_ROLE`. All-or-nothing.
         function batchMint(address[] calldata recipients, uint256[] calldata amounts) external;
 
-        /// Burns `amounts[i]` from `accounts[i]`. Requires `BURN_FROM_ROLE`. All-or-nothing.
-        function batchBurn(address[] calldata accounts, uint256[] calldata amounts) external;
-
         // ── Redemption ────────────────────────────────────────────────────────
 
         /// Burns `amount` from caller with a share-based minimum floor check.
@@ -135,7 +129,6 @@ impl IB20Security::IB20SecurityCalls {
     pub const fn as_label(&self) -> &'static str {
         match self {
             Self::SECURITY_OPERATOR_ROLE(_) => "precompile-b20-security-SECURITY_OPERATOR_ROLE",
-            Self::BURN_FROM_ROLE(_) => "precompile-b20-security-BURN_FROM_ROLE",
             Self::WAD_PRECISION(_) => "precompile-b20-security-WAD_PRECISION",
             Self::REDEEM_SENDER_POLICY(_) => "precompile-b20-security-REDEEM_SENDER_POLICY",
             Self::announce(_) => "precompile-b20-security-announce",
@@ -145,7 +138,6 @@ impl IB20Security::IB20SecurityCalls {
             Self::sharesOf(_) => "precompile-b20-security-sharesOf",
             Self::updateShareRatio(_) => "precompile-b20-security-updateShareRatio",
             Self::batchMint(_) => "precompile-b20-security-batchMint",
-            Self::batchBurn(_) => "precompile-b20-security-batchBurn",
             Self::redeem(_) => "precompile-b20-security-redeem",
             Self::redeemWithMemo(_) => "precompile-b20-security-redeemWithMemo",
             Self::updateMinimumRedeemable(_) => "precompile-b20-security-updateMinimumRedeemable",

--- a/crates/common/precompiles/src/b20_security/dispatch.rs
+++ b/crates/common/precompiles/src/b20_security/dispatch.rs
@@ -379,7 +379,7 @@ impl<S: SecurityAccounting, P: Policy> B20SecurityToken<S, P> {
                 Bytes::new()
             }
 
-            // --- Batched mint / burn ---
+            // --- Batched mint ---
             SC::batchMint(c) => {
                 self.batch_mint(caller, c.recipients, c.amounts, privileged)?;
                 Bytes::new()

--- a/crates/common/precompiles/src/b20_security/dispatch.rs
+++ b/crates/common/precompiles/src/b20_security/dispatch.rs
@@ -345,7 +345,6 @@ impl<S: SecurityAccounting, P: Policy> B20SecurityToken<S, P> {
         let encoded: Bytes = match call {
             // --- Role / precision constants ---
             SC::SECURITY_OPERATOR_ROLE(_) => Self::SECURITY_OPERATOR_ROLE.abi_encode().into(),
-            SC::BURN_FROM_ROLE(_) => Self::BURN_FROM_ROLE.abi_encode().into(),
             SC::WAD_PRECISION(_) => B20SecurityStorage::WAD.abi_encode().into(),
             SC::REDEEM_SENDER_POLICY(_) => Self::REDEEM_SENDER_POLICY.abi_encode().into(),
 
@@ -383,10 +382,6 @@ impl<S: SecurityAccounting, P: Policy> B20SecurityToken<S, P> {
             // --- Batched mint / burn ---
             SC::batchMint(c) => {
                 self.batch_mint(caller, c.recipients, c.amounts, privileged)?;
-                Bytes::new()
-            }
-            SC::batchBurn(c) => {
-                self.batch_burn(caller, c.accounts, c.amounts)?;
                 Bytes::new()
             }
 
@@ -486,7 +481,6 @@ mod tests {
 
     type TestSecurityToken = B20SecurityToken<InMemoryTokenAccounting, InMemoryPolicy>;
 
-    const BURN_FROM_ROLE: B256 = TestSecurityToken::BURN_FROM_ROLE;
     const REDEEM_SENDER_POLICY: B256 = TestSecurityToken::REDEEM_SENDER_POLICY;
 
     const ALICE: Address = Address::repeat_byte(0xaa);
@@ -528,10 +522,6 @@ mod tests {
 
     fn batch_mint_calldata(recipients: Vec<Address>, amounts: Vec<U256>) -> Vec<u8> {
         IB20Security::batchMintCall { recipients, amounts }.abi_encode()
-    }
-
-    fn batch_burn_calldata(accounts: Vec<Address>, amounts: Vec<U256>) -> Vec<u8> {
-        IB20Security::batchBurnCall { accounts, amounts }.abi_encode()
     }
 
     #[test]
@@ -597,120 +587,6 @@ mod tests {
         );
         assert_eq!(token.accounting().balance_of(BOB).unwrap(), U256::ZERO);
         assert_eq!(token.accounting().total_supply().unwrap(), U256::ZERO);
-    }
-
-    #[test]
-    fn batch_burn_decrements_balances() {
-        let mut token = make_token();
-        token.accounting_mut().roles.insert((BURN_FROM_ROLE, ALICE), true);
-        token.accounting_mut().balances.insert(ALICE, U256::from(500u64));
-        token.accounting_mut().total_supply = U256::from(500u64);
-
-        call_security(
-            &mut token,
-            ALICE,
-            batch_burn_calldata(alloc::vec![ALICE], alloc::vec![U256::from(200u64)]),
-        )
-        .unwrap();
-
-        assert_eq!(token.accounting().balance_of(ALICE).unwrap(), U256::from(300u64));
-        assert_eq!(token.accounting().total_supply().unwrap(), U256::from(300u64));
-        assert_eq!(
-            token.accounting().events,
-            alloc::vec![
-                IB20::Transfer { from: ALICE, to: Address::ZERO, amount: U256::from(200u64) }
-                    .encode_log_data()
-            ]
-        );
-    }
-
-    #[test]
-    fn batch_burn_rejects_insufficient_balance() {
-        let mut token = make_token();
-        token.accounting_mut().roles.insert((BURN_FROM_ROLE, ALICE), true);
-        token.accounting_mut().balances.insert(ALICE, U256::from(10u64));
-
-        assert_eq!(
-            call_security(
-                &mut token,
-                ALICE,
-                batch_burn_calldata(alloc::vec![ALICE], alloc::vec![U256::from(100u64)]),
-            )
-            .unwrap_err(),
-            BasePrecompileError::revert(IB20::InsufficientBalance {
-                sender: ALICE,
-                balance: U256::from(10u64),
-                needed: U256::from(100u64),
-            })
-        );
-    }
-
-    #[test]
-    fn batch_burn_requires_burn_from_role() {
-        let mut token = make_token();
-        token.accounting_mut().balances.insert(BOB, U256::from(50u64));
-        token.accounting_mut().total_supply = U256::from(50u64);
-
-        let err = call_security(
-            &mut token,
-            ALICE,
-            batch_burn_calldata(alloc::vec![BOB], alloc::vec![U256::from(10u64)]),
-        )
-        .unwrap_err();
-
-        assert_eq!(
-            err,
-            BasePrecompileError::revert(IB20::AccessControlUnauthorizedAccount {
-                account: ALICE,
-                neededRole: BURN_FROM_ROLE,
-            })
-        );
-        assert_eq!(token.accounting().balance_of(BOB).unwrap(), U256::from(50u64));
-        assert_eq!(token.accounting().total_supply().unwrap(), U256::from(50u64));
-    }
-
-    #[test]
-    fn batch_burn_with_role_decrements_balances() {
-        let mut token = make_token();
-        token.accounting_mut().roles.insert((BURN_FROM_ROLE, ALICE), true);
-        token.accounting_mut().balances.insert(BOB, U256::from(50u64));
-        token.accounting_mut().total_supply = U256::from(50u64);
-
-        call_security(
-            &mut token,
-            ALICE,
-            batch_burn_calldata(alloc::vec![BOB], alloc::vec![U256::from(10u64)]),
-        )
-        .unwrap();
-
-        assert_eq!(token.accounting().balance_of(BOB).unwrap(), U256::from(40u64));
-        assert_eq!(token.accounting().total_supply().unwrap(), U256::from(40u64));
-        assert_eq!(token.accounting().events.len(), 1);
-    }
-
-    #[test]
-    fn batch_burn_respects_burn_pause() {
-        let mut token = make_token();
-        token.accounting_mut().roles.insert((BURN_FROM_ROLE, ALICE), true);
-        token.accounting_mut().paused = B20PausableFeature::mask(IB20::PausableFeature::BURN);
-        token.accounting_mut().balances.insert(BOB, U256::from(50u64));
-        token.accounting_mut().total_supply = U256::from(50u64);
-
-        let err = call_security(
-            &mut token,
-            ALICE,
-            batch_burn_calldata(alloc::vec![BOB], alloc::vec![U256::from(10u64)]),
-        )
-        .unwrap_err();
-
-        assert_eq!(
-            err,
-            BasePrecompileError::revert(IB20::ContractPaused {
-                feature: IB20::PausableFeature::BURN,
-            })
-        );
-        assert_eq!(token.accounting().balance_of(BOB).unwrap(), U256::from(50u64));
-        assert_eq!(token.accounting().total_supply().unwrap(), U256::from(50u64));
     }
 
     #[test]
@@ -867,181 +743,6 @@ mod tests {
                 leftLen: U256::ZERO,
                 rightLen: U256::ONE,
             })
-        );
-    }
-
-    // --- batchBurn: EmptyBatch / LengthMismatch / multi-account Transfer events ---
-
-    #[test]
-    fn batch_burn_rejects_empty() {
-        let mut token = make_token();
-        token.accounting_mut().roles.insert((BURN_FROM_ROLE, ALICE), true);
-
-        let err =
-            call_security(&mut token, ALICE, batch_burn_calldata(alloc::vec![], alloc::vec![]))
-                .unwrap_err();
-
-        assert_eq!(err, BasePrecompileError::revert(IB20Security::EmptyBatch {}));
-    }
-
-    #[test]
-    fn batch_burn_rejects_length_mismatch() {
-        let mut token = make_token();
-        token.accounting_mut().roles.insert((BURN_FROM_ROLE, ALICE), true);
-
-        let err = call_security(
-            &mut token,
-            ALICE,
-            batch_burn_calldata(alloc::vec![ALICE], alloc::vec![U256::ONE, U256::ONE]),
-        )
-        .unwrap_err();
-        assert_eq!(
-            err,
-            BasePrecompileError::revert(IB20Security::LengthMismatch {
-                leftLen: U256::ONE,
-                rightLen: U256::from(2u64),
-            })
-        );
-
-        let err = call_security(
-            &mut token,
-            ALICE,
-            batch_burn_calldata(alloc::vec![], alloc::vec![U256::ONE]),
-        )
-        .unwrap_err();
-        assert_eq!(
-            err,
-            BasePrecompileError::revert(IB20Security::LengthMismatch {
-                leftLen: U256::ZERO,
-                rightLen: U256::ONE,
-            })
-        );
-    }
-
-    #[test]
-    fn batch_burn_pause_error_takes_precedence_over_input_validation() {
-        let mut token = make_token();
-        token.accounting_mut().roles.insert((BURN_FROM_ROLE, ALICE), true);
-        token.accounting_mut().paused = B20PausableFeature::mask(IB20::PausableFeature::BURN);
-
-        let err = call_security(
-            &mut token,
-            ALICE,
-            batch_burn_calldata(alloc::vec![ALICE], alloc::vec![U256::ONE, U256::ONE]),
-        )
-        .unwrap_err();
-        assert_eq!(
-            err,
-            BasePrecompileError::revert(IB20::ContractPaused {
-                feature: IB20::PausableFeature::BURN,
-            })
-        );
-
-        let err =
-            call_security(&mut token, ALICE, batch_burn_calldata(alloc::vec![], alloc::vec![]))
-                .unwrap_err();
-        assert_eq!(
-            err,
-            BasePrecompileError::revert(IB20::ContractPaused {
-                feature: IB20::PausableFeature::BURN,
-            })
-        );
-    }
-
-    #[test]
-    fn batch_burn_zero_amount_is_no_op() {
-        let mut token = make_token();
-        token.accounting_mut().roles.insert((BURN_FROM_ROLE, ALICE), true);
-        token.accounting_mut().balances.insert(ALICE, U256::from(100u64));
-        token.accounting_mut().total_supply = U256::from(100u64);
-
-        call_security(
-            &mut token,
-            ALICE,
-            batch_burn_calldata(alloc::vec![ALICE], alloc::vec![U256::ZERO]),
-        )
-        .unwrap();
-
-        assert_eq!(token.accounting().balance_of(ALICE).unwrap(), U256::from(100u64));
-        assert_eq!(token.accounting().total_supply().unwrap(), U256::from(100u64));
-        assert_eq!(token.accounting().events.len(), 1); // Transfer(ALICE, 0x0, 0) emitted
-    }
-
-    #[test]
-    fn batch_burn_does_not_revert_on_zero_value_transfer() {
-        let mut token = make_token();
-        token.accounting_mut().roles.insert((BURN_FROM_ROLE, ALICE), true);
-        token.accounting_mut().balances.insert(ALICE, U256::from(100u64));
-        token.accounting_mut().balances.insert(BOB, U256::from(50u64));
-        token.accounting_mut().total_supply = U256::from(150u64);
-
-        call_security(
-            &mut token,
-            ALICE,
-            batch_burn_calldata(
-                alloc::vec![ALICE, BOB],
-                alloc::vec![U256::from(10u64), U256::ZERO],
-            ),
-        )
-        .unwrap();
-
-        assert_eq!(token.accounting().balance_of(ALICE).unwrap(), U256::from(90u64));
-        assert_eq!(token.accounting().balance_of(BOB).unwrap(), U256::from(50u64));
-        assert_eq!(token.accounting().total_supply().unwrap(), U256::from(140u64));
-        assert_eq!(token.accounting().events.len(), 2); // one Transfer per element
-    }
-
-    #[test]
-    fn batch_burn_multiple_accounts_emits_one_transfer_each() {
-        let mut token = make_token();
-        token.accounting_mut().roles.insert((BURN_FROM_ROLE, ALICE), true);
-        token.accounting_mut().balances.insert(ALICE, U256::from(100u64));
-        token.accounting_mut().balances.insert(BOB, U256::from(200u64));
-        token.accounting_mut().total_supply = U256::from(300u64);
-
-        call_security(
-            &mut token,
-            ALICE,
-            batch_burn_calldata(
-                alloc::vec![ALICE, BOB],
-                alloc::vec![U256::from(100u64), U256::from(200u64)],
-            ),
-        )
-        .unwrap();
-
-        // IB20Security: "Emits Transfer(accounts[i], address(0), amounts[i]) per element"
-        assert_eq!(
-            token.accounting().events,
-            alloc::vec![
-                IB20::Transfer { from: ALICE, to: Address::ZERO, amount: U256::from(100u64) }
-                    .encode_log_data(),
-                IB20::Transfer { from: BOB, to: Address::ZERO, amount: U256::from(200u64) }
-                    .encode_log_data()
-            ]
-        );
-        assert_eq!(token.accounting().total_supply().unwrap(), U256::ZERO);
-    }
-
-    #[test]
-    fn batch_burn_supply_underflow_is_under_overflow_panic() {
-        // Regression: before BOP-160, saturating_sub silently clamped supply to zero.
-        // If an accounting bug left total_supply < balance, the correct behavior is to
-        // revert with an arithmetic under/overflow panic rather than zeroing the supply.
-        let mut token = make_token();
-        token.accounting_mut().roles.insert((BURN_FROM_ROLE, ALICE), true);
-        // Supply invariant violated: balance exceeds total supply.
-        token.accounting_mut().balances.insert(ALICE, U256::from(100u64));
-        token.accounting_mut().total_supply = U256::from(50u64);
-
-        // amount=75 passes the balance check (100 >= 75) but underflows total_supply (50 - 75).
-        assert_eq!(
-            call_security(
-                &mut token,
-                ALICE,
-                batch_burn_calldata(alloc::vec![ALICE], alloc::vec![U256::from(75u64)]),
-            )
-            .unwrap_err(),
-            BasePrecompileError::under_overflow()
         );
     }
 

--- a/crates/common/precompiles/src/b20_security/token.rs
+++ b/crates/common/precompiles/src/b20_security/token.rs
@@ -31,10 +31,6 @@ impl<S: SecurityAccounting, P: Policy> B20SecurityToken<S, P> {
     pub const SECURITY_OPERATOR_ROLE: B256 =
         b256!("e63901dfe7775ace99fa3654743976eb0ab2009f5d19c4fc1ecd40aed27d59af");
 
-    /// Role identifier for delegated burns: `keccak256("BURN_FROM_ROLE")`.
-    pub const BURN_FROM_ROLE: B256 =
-        b256!("25400dba76bf0d00acf274c2b61ff56aa4ed19826e21e0186e3fecd6a6671875");
-
     /// Policy scope identifier for redeem senders: `keccak256("REDEEM_SENDER_POLICY")`.
     pub const REDEEM_SENDER_POLICY: B256 = B20SecurityStorage::REDEEM_SENDER_POLICY;
 
@@ -119,11 +115,6 @@ impl<S: SecurityAccounting, P: Policy> B20SecurityToken<S, P> {
     /// Ensures the caller has the default admin role.
     pub fn ensure_default_admin(&self, caller: Address, privileged: bool) -> Result<()> {
         if privileged { Ok(()) } else { self.ensure_role(caller, Self::default_admin_role()) }
-    }
-
-    /// Ensures the caller has the burn-from role.
-    pub fn ensure_burn_from_role(&self, caller: Address) -> Result<()> {
-        self.ensure_role(caller, Self::BURN_FROM_ROLE)
     }
 
     // --- Policy Operations ---
@@ -328,54 +319,6 @@ impl<S: SecurityAccounting, P: Policy> B20SecurityToken<S, P> {
         }
         Ok(())
     }
-
-    /// Burns tokens from multiple accounts unconditionally. All-or-nothing.
-    ///
-    /// Unlike `burnBlocked`, this path has no policy precondition. The
-    /// `BURN_FROM_ROLE` authorization and burn pause check are the only gates.
-    ///
-    /// Check order: PAUSE → ROLE → INPUT → BUSINESS
-    pub fn batch_burn(
-        &mut self,
-        caller: Address,
-        accounts: Vec<Address>,
-        amounts: Vec<U256>,
-    ) -> Result<()> {
-        // 1. PAUSE (kill switch)
-        B20Guards::ensure_not_paused::<Self>(self, IB20::PausableFeature::BURN)?;
-        // 2. ROLE
-        self.ensure_burn_from_role(caller)?;
-        // 3. INPUT VALIDATION
-        if accounts.len() != amounts.len() {
-            return Err(BasePrecompileError::revert(IB20Security::LengthMismatch {
-                leftLen: U256::from(accounts.len()),
-                rightLen: U256::from(amounts.len()),
-            }));
-        }
-        if accounts.is_empty() {
-            return Err(BasePrecompileError::revert(IB20Security::EmptyBatch {}));
-        }
-        // 4. BUSINESS LOGIC (no allowance/policy for batch_burn)
-        for (account, amount) in accounts.into_iter().zip(amounts) {
-            let balance = self.accounting().balance_of(account)?;
-            if balance < amount {
-                return Err(BasePrecompileError::revert(IB20::InsufficientBalance {
-                    sender: account,
-                    balance,
-                    needed: amount,
-                }));
-            }
-            self.accounting_mut().set_balance(account, balance - amount)?;
-            let supply = self.accounting().total_supply()?;
-            let new_supply =
-                supply.checked_sub(amount).ok_or_else(BasePrecompileError::under_overflow)?;
-            self.accounting_mut().set_total_supply(new_supply)?;
-            self.accounting_mut().emit_event(
-                IB20::Transfer { from: account, to: Address::ZERO, amount }.encode_log_data(),
-            )?;
-        }
-        Ok(())
-    }
 }
 
 #[cfg(test)]
@@ -464,81 +407,6 @@ mod tests {
                 BasePrecompileError::revert(IB20Security::LengthMismatch {
                     leftLen: U256::from(2u64),
                     rightLen: U256::from(1u64),
-                })
-            }
-        }
-    }
-
-    #[derive(Debug, Clone, Copy)]
-    enum BatchBurnSetup {
-        Paused,
-        NoRole,
-        EmptyBatch,
-        LengthMismatch,
-        InsufficientBalance,
-    }
-
-    fn setup_batch_burn(setup: BatchBurnSetup) -> (TestSecurityToken, Vec<Address>, Vec<U256>) {
-        let mut accounting = InMemoryTokenAccounting::new(TOKEN);
-        accounting.shares_to_tokens_ratio = B20SecurityStorage::WAD;
-        let accounts;
-        let amounts;
-
-        match setup {
-            BatchBurnSetup::Paused => {
-                accounting.paused = B20PausableFeature::mask(IB20::PausableFeature::BURN);
-                accounts = vec![ALICE];
-                amounts = vec![U256::from(10u64)];
-            }
-            BatchBurnSetup::NoRole => {
-                accounts = vec![];
-                amounts = vec![];
-            }
-            BatchBurnSetup::EmptyBatch => {
-                accounting.roles.insert((TestSecurityToken::BURN_FROM_ROLE, CALLER), true);
-                accounts = vec![];
-                amounts = vec![];
-            }
-            BatchBurnSetup::LengthMismatch => {
-                accounting.roles.insert((TestSecurityToken::BURN_FROM_ROLE, CALLER), true);
-                accounts = vec![ALICE, BOB];
-                amounts = vec![U256::from(10u64)];
-            }
-            BatchBurnSetup::InsufficientBalance => {
-                accounting.roles.insert((TestSecurityToken::BURN_FROM_ROLE, CALLER), true);
-                accounting.balances.insert(ALICE, U256::from(5u64));
-                accounts = vec![ALICE];
-                amounts = vec![U256::from(10u64)];
-            }
-        }
-
-        let token = TestSecurityToken::with_storage_and_policy(accounting, InMemoryPolicy::new());
-        (token, accounts, amounts)
-    }
-
-    fn expected_batch_burn_error(setup: BatchBurnSetup) -> BasePrecompileError {
-        match setup {
-            BatchBurnSetup::Paused => BasePrecompileError::revert(IB20::ContractPaused {
-                feature: IB20::PausableFeature::BURN,
-            }),
-            BatchBurnSetup::NoRole => {
-                BasePrecompileError::revert(IB20::AccessControlUnauthorizedAccount {
-                    account: CALLER,
-                    neededRole: TestSecurityToken::BURN_FROM_ROLE,
-                })
-            }
-            BatchBurnSetup::EmptyBatch => BasePrecompileError::revert(IB20Security::EmptyBatch {}),
-            BatchBurnSetup::LengthMismatch => {
-                BasePrecompileError::revert(IB20Security::LengthMismatch {
-                    leftLen: U256::from(2u64),
-                    rightLen: U256::from(1u64),
-                })
-            }
-            BatchBurnSetup::InsufficientBalance => {
-                BasePrecompileError::revert(IB20::InsufficientBalance {
-                    sender: ALICE,
-                    balance: U256::from(5u64),
-                    needed: U256::from(10u64),
                 })
             }
         }
@@ -637,7 +505,6 @@ mod tests {
     #[test]
     fn role_and_policy_ids_match_solidity_hashes() {
         assert_eq!(TestSecurityToken::SECURITY_OPERATOR_ROLE, keccak256("SECURITY_OPERATOR_ROLE"));
-        assert_eq!(TestSecurityToken::BURN_FROM_ROLE, keccak256("BURN_FROM_ROLE"));
         assert_eq!(TestSecurityToken::REDEEM_SENDER_POLICY, keccak256("REDEEM_SENDER_POLICY"));
     }
 
@@ -652,20 +519,6 @@ mod tests {
         let err = token.batch_mint(CALLER, recipients, amounts, false).unwrap_err();
 
         assert_eq!(err, expected_batch_mint_error(setup));
-    }
-
-    #[rstest]
-    #[case::paused_gets_pause_error(BatchBurnSetup::Paused)]
-    #[case::no_role_gets_role_error(BatchBurnSetup::NoRole)]
-    #[case::empty_batch_gets_input_error(BatchBurnSetup::EmptyBatch)]
-    #[case::length_mismatch_gets_input_error(BatchBurnSetup::LengthMismatch)]
-    #[case::insufficient_balance_gets_business_error(BatchBurnSetup::InsufficientBalance)]
-    fn batch_burn_check_order(#[case] setup: BatchBurnSetup) {
-        let (mut token, accounts, amounts) = setup_batch_burn(setup);
-
-        let err = token.batch_burn(CALLER, accounts, amounts).unwrap_err();
-
-        assert_eq!(err, expected_batch_burn_error(setup));
     }
 
     #[rstest]


### PR DESCRIPTION
## Motivation

BOP-239: removes `batch_burn` and `BURN_FROM_ROLE` from the B20Asset precompile as part of the B20 asset simplification effort.

## Changes

**`abi.rs`**
- Removed `BURN_FROM_ROLE()` function declaration
- Removed `batchBurn(address[], uint256[])` function declaration
- Removed corresponding `as_label()` arms

**`token.rs`**
- Removed `BURN_FROM_ROLE` constant
- Removed `ensure_burn_from_role` guard
- Removed `batch_burn` implementation
- Removed `BatchBurnSetup` test helpers and 13 `batch_burn_*` tests

**`dispatch.rs`**
- Removed `SC::BURN_FROM_ROLE` and `SC::batchBurn` dispatch arms
- Removed `batch_burn_calldata` test helper

`security_redeem_burn` is not touched by this PR.

## Test plan
- [ ] `cargo test -p base-common-precompiles b20_security` passes (52 tests)
- [ ] `cargo build -p base-common-precompiles` passes