### PR TITLE
refactor(b20_security): deduplicate burn code paths using burn_inner (BOP-212)

### DIFF
--- a/crates/common/precompiles/src/b20_security/token.rs
+++ b/crates/common/precompiles/src/b20_security/token.rs
@@ -268,22 +268,7 @@ impl<S: SecurityAccounting, P: Policy> B20SecurityToken<S, P> {
                 }));
             }
         }
-        let balance = self.accounting().balance_of(caller)?;
-        if balance < amount {
-            return Err(BasePrecompileError::revert(IB20::InsufficientBalance {
-                sender: caller,
-                balance,
-                needed: amount,
-            }));
-        }
-        self.accounting_mut().set_balance(caller, balance - amount)?;
-        let supply = self.accounting().total_supply()?;
-        let new_supply =
-            supply.checked_sub(amount).ok_or_else(BasePrecompileError::under_overflow)?;
-        self.accounting_mut().set_total_supply(new_supply)?;
-        self.accounting_mut().emit_event(
-            IB20::Transfer { from: caller, to: Address::ZERO, amount }.encode_log_data(),
-        )?;
+        self.burn_inner(caller, amount)?;
         Ok(ratio)
     }
 
@@ -357,22 +342,7 @@ impl<S: SecurityAccounting, P: Policy> B20SecurityToken<S, P> {
         }
         // 4. BUSINESS LOGIC (no allowance/policy for batch_burn)
         for (account, amount) in accounts.into_iter().zip(amounts) {
-            let balance = self.accounting().balance_of(account)?;
-            if balance < amount {
-                return Err(BasePrecompileError::revert(IB20::InsufficientBalance {
-                    sender: account,
-                    balance,
-                    needed: amount,
-                }));
-            }
-            self.accounting_mut().set_balance(account, balance - amount)?;
-            let supply = self.accounting().total_supply()?;
-            let new_supply =
-                supply.checked_sub(amount).ok_or_else(BasePrecompileError::under_overflow)?;
-            self.accounting_mut().set_total_supply(new_supply)?;
-            self.accounting_mut().emit_event(
-                IB20::Transfer { from: account, to: Address::ZERO, amount }.encode_log_data(),
-            )?;
+            self.burn_inner(account, amount)?;
         }
         Ok(())
     }


### PR DESCRIPTION
[BOP-212](https://linear.app/coinbase/issue/BOP-212/b20security-rust-deduplicate-burn-code-paths)

## Motivation

`B20SecurityToken` had two burn code paths (`security_redeem_burn` and the per-element loop body in `batch_burn`) that each manually inlined the same 7-line sequence that `Burnable::burn_inner` already implements:

1. Read balance
2. Check `InsufficientBalance`
3. `set_balance`
4. Read `total_supply`
5. `checked_sub` with overflow panic
6. `set_total_supply`
7. Emit `Transfer(from, 0x0, amount)` event

This duplication was flagged by the security audit (G-02) and raised the risk that future fixes (like the L-01 `saturating_sub` fix) would need to be applied in multiple places.

## Changes

`crates/common/precompiles/src/b20_security/token.rs`
- `security_redeem_burn`: replaced 7-line manual block with `self.burn_inner(caller, amount)?`
- `batch_burn` loop body: replaced 7-line manual block with `self.burn_inner(account, amount)?`
- Net: -32 lines, +2 lines

## Test plan
- [ ] `cargo test -p base-common-precompiles b20_security` passes (69 tests)
- [ ] `cargo build -p base-common-precompiles` passes
