### PR TITLE
rename SECURITY_OPERATOR_ROLE -> OPERATOR_ROLE and Security Identifiers -> Extra Metadata (BOP-237)

### DIFF
--- a/actions/harness/tests/beryl/security.rs
+++ b/actions/harness/tests/beryl/security.rs
@@ -69,8 +69,8 @@ async fn security_creation_initializes_identifiers_and_factory_views() {
                 ),
                 StaticcallCase::string("contractURI", IB20::contractURICall {}.abi_encode(), ""),
                 StaticcallCase::string(
-                    "securityIdentifier(ISIN)",
-                    IB20Asset::securityIdentifierCall { identifierType: "ISIN".to_string() }
+                    "extraMetadata(ISIN)",
+                    IB20Asset::extraMetadataCall { identifierType: "ISIN".to_string() }
                         .abi_encode(),
                     BerylTestEnv::B20_SECURITY_ISIN,
                 ),
@@ -116,8 +116,8 @@ async fn security_creation_initializes_identifiers_and_factory_views() {
                     U256::ZERO,
                 ),
                 StaticcallCase::bytes32(
-                    "SECURITY_OPERATOR_ROLE",
-                    IB20Asset::SECURITY_OPERATOR_ROLECall {}.abi_encode(),
+                    "OPERATOR_ROLE",
+                    IB20Asset::OPERATOR_ROLECall {}.abi_encode(),
                     security_operator_role(),
                 ),
                 StaticcallCase::returndata(
@@ -139,7 +139,7 @@ async fn security_mutations_update_state_and_emit_events() {
 
     let update_ratio =
         scenario.call_tx(IB20Asset::updateShareRatioCall { newSharesToTokensRatio: UPDATED_RATIO });
-    let update_cusip = scenario.call_tx(IB20Asset::updateSecurityIdentifierCall {
+    let update_cusip = scenario.call_tx(IB20Asset::updateExtraMetadataCall {
         identifierType: "CUSIP".to_string(),
         value: CUSIP.to_string(),
     });
@@ -147,7 +147,7 @@ async fn security_mutations_update_state_and_emit_events() {
         recipients: vec![BerylTestEnv::bob(), BerylTestEnv::carol()],
         amounts: vec![U256::from(BOB_MINT_AMOUNT), U256::from(CAROL_MINT_AMOUNT)],
     });
-    let announced_identifier = IB20Asset::updateSecurityIdentifierCall {
+    let announced_identifier = IB20Asset::updateExtraMetadataCall {
         identifierType: "FIGI".to_string(),
         value: FIGI.to_string(),
     };
@@ -176,7 +176,7 @@ async fn security_mutations_update_state_and_emit_events() {
     scenario.assert_log(
         &block,
         1,
-        IB20Asset::SecurityIdentifierUpdated {
+        IB20Asset::ExtraMetadataUpdated {
             identifierType: "CUSIP".to_string(),
             value: CUSIP.to_string(),
         }
@@ -216,7 +216,7 @@ async fn security_mutations_update_state_and_emit_events() {
     scenario.assert_log(
         &block,
         3,
-        IB20Asset::SecurityIdentifierUpdated {
+        IB20Asset::ExtraMetadataUpdated {
             identifierType: "FIGI".to_string(),
             value: FIGI.to_string(),
         }
@@ -253,14 +253,14 @@ async fn security_mutations_update_state_and_emit_events() {
                     U256::from(BerylTestEnv::B20_INITIAL_SUPPLY) * U256::from(2),
                 ),
                 StaticcallCase::string(
-                    "securityIdentifier(CUSIP)",
-                    IB20Asset::securityIdentifierCall { identifierType: "CUSIP".to_string() }
+                    "extraMetadata(CUSIP)",
+                    IB20Asset::extraMetadataCall { identifierType: "CUSIP".to_string() }
                         .abi_encode(),
                     CUSIP,
                 ),
                 StaticcallCase::string(
-                    "securityIdentifier(FIGI)",
-                    IB20Asset::securityIdentifierCall { identifierType: "FIGI".to_string() }
+                    "extraMetadata(FIGI)",
+                    IB20Asset::extraMetadataCall { identifierType: "FIGI".to_string() }
                         .abi_encode(),
                     FIGI,
                 ),
@@ -299,7 +299,7 @@ async fn security_mutations_revert_on_invalid_inputs() {
         recipients: vec![BerylTestEnv::bob()],
         amounts: vec![U256::from(1), U256::from(2)],
     });
-    let empty_identifier_type = scenario.call_tx(IB20Asset::updateSecurityIdentifierCall {
+    let empty_identifier_type = scenario.call_tx(IB20Asset::updateExtraMetadataCall {
         identifierType: String::new(),
         value: "x".to_string(),
     });
@@ -561,5 +561,5 @@ impl B20SecurityScenario {
 }
 
 fn security_operator_role() -> B256 {
-    keccak256("SECURITY_OPERATOR_ROLE")
+    keccak256("OPERATOR_ROLE")
 }

--- a/crates/common/precompile-macros/src/accounting.rs
+++ b/crates/common/precompile-macros/src/accounting.rs
@@ -326,7 +326,7 @@ fn expand_security(input: DeriveInput) -> syn::Result<TokenStream> {
                 self.security.set_shares_to_tokens_ratio(ratio)
             }
 
-            fn security_identifier(
+            fn extra_metadata(
                 &self,
                 identifier_type: &str,
             ) -> ::base_precompile_storage::Result<::alloc::string::String> {
@@ -337,7 +337,7 @@ fn expand_security(input: DeriveInput) -> syn::Result<TokenStream> {
                 )
             }
 
-            fn set_security_identifier_value(
+            fn set_extra_metadata_value(
                 &mut self,
                 identifier_type: &str,
                 value: ::alloc::string::String,

--- a/crates/common/precompiles/src/b20_asset/abi.rs
+++ b/crates/common/precompiles/src/b20_asset/abi.rs
@@ -13,7 +13,7 @@ sol! {
         /// `id` has previously been consumed by `announce`. Each id may be used at most once.
         error AnnouncementIdAlreadyUsed(string id);
 
-        /// `updateSecurityIdentifier` was called with an empty `identifierType`.
+        /// `updateExtraMetadata` was called with an empty `identifierType`.
         error InvalidIdentifierType();
 
         /// A batched function was called with parallel arrays of differing lengths.
@@ -45,8 +45,8 @@ sol! {
         /// Emitted by `updateShareRatio`.
         event ShareRatioUpdated(uint256 sharesToTokensRatio);
 
-        /// Emitted by `updateSecurityIdentifier`. Empty `value` indicates removal.
-        event SecurityIdentifierUpdated(string identifierType, string value);
+        /// Emitted by `updateExtraMetadata`. Empty `value` indicates removal.
+        event ExtraMetadataUpdated(string identifierType, string value);
 
         /// Emitted at the start of `announce`. Indexers join with `EndAnnouncement` via `id`.
         event Announcement(address indexed caller, string id, string description, string uri);
@@ -56,8 +56,8 @@ sol! {
 
         // ── Role / precision identifiers ─────────────────────────────────────
 
-        /// `keccak256("SECURITY_OPERATOR_ROLE")` — required for `announce`, `updateShareRatio`, `updateSecurityIdentifier`.
-        function SECURITY_OPERATOR_ROLE() external view returns (bytes32);
+        /// `keccak256("OPERATOR_ROLE")` — required for `announce`, `updateShareRatio`, `updateExtraMetadata`.
+        function OPERATOR_ROLE() external view returns (bytes32);
 
         /// Fixed-point precision for `sharesToTokensRatio`: `1e18` (one WAD).
         function WAD_PRECISION() external view returns (uint256);
@@ -114,10 +114,10 @@ sol! {
         // ── Security identifiers ─────────────────────────────────────────────
 
         /// Returns the value of the named identifier (e.g. ISIN, CUSIP). Empty string if not set.
-        function securityIdentifier(string calldata identifierType) external view returns (string);
+        function extraMetadata(string calldata identifierType) external view returns (string);
 
         /// Sets, updates, or removes a security identifier. Empty `value` removes the entry.
-        function updateSecurityIdentifier(
+        function updateExtraMetadata(
             string calldata identifierType,
             string calldata value
         ) external;
@@ -128,7 +128,7 @@ impl IB20Asset::IB20AssetCalls {
     /// Returns the stable label for this decoded asset B-20 call.
     pub const fn as_label(&self) -> &'static str {
         match self {
-            Self::SECURITY_OPERATOR_ROLE(_) => "precompile-b20-asset-SECURITY_OPERATOR_ROLE",
+            Self::OPERATOR_ROLE(_) => "precompile-b20-asset-OPERATOR_ROLE",
             Self::WAD_PRECISION(_) => "precompile-b20-asset-WAD_PRECISION",
             Self::REDEEM_SENDER_POLICY(_) => "precompile-b20-asset-REDEEM_SENDER_POLICY",
             Self::announce(_) => "precompile-b20-asset-announce",
@@ -142,8 +142,8 @@ impl IB20Asset::IB20AssetCalls {
             Self::redeemWithMemo(_) => "precompile-b20-asset-redeemWithMemo",
             Self::updateMinimumRedeemable(_) => "precompile-b20-asset-updateMinimumRedeemable",
             Self::minimumRedeemable(_) => "precompile-b20-asset-minimumRedeemable",
-            Self::securityIdentifier(_) => "precompile-b20-asset-securityIdentifier",
-            Self::updateSecurityIdentifier(_) => "precompile-b20-asset-updateSecurityIdentifier",
+            Self::extraMetadata(_) => "precompile-b20-asset-extraMetadata",
+            Self::updateExtraMetadata(_) => "precompile-b20-asset-updateExtraMetadata",
         }
     }
 }

--- a/crates/common/precompiles/src/b20_asset/accounting.rs
+++ b/crates/common/precompiles/src/b20_asset/accounting.rs
@@ -18,10 +18,9 @@ pub trait SecurityAccounting: TokenAccounting {
     fn set_shares_to_tokens_ratio(&mut self, ratio: U256) -> Result<()>;
 
     /// Returns the security identifier value for `identifier_type`, or an empty string if unset.
-    fn security_identifier(&self, identifier_type: &str) -> Result<String>;
+    fn extra_metadata(&self, identifier_type: &str) -> Result<String>;
     /// Writes (or removes when `value` is empty) the security identifier for `identifier_type`.
-    fn set_security_identifier_value(&mut self, identifier_type: &str, value: String)
-    -> Result<()>;
+    fn set_extra_metadata_value(&mut self, identifier_type: &str, value: String) -> Result<()>;
 
     /// Returns the minimum amount that may be redeemed in a single call.
     fn minimum_redeemable(&self) -> Result<U256>;

--- a/crates/common/precompiles/src/b20_asset/dispatch.rs
+++ b/crates/common/precompiles/src/b20_asset/dispatch.rs
@@ -340,7 +340,7 @@ impl<S: SecurityAccounting, P: Policy> B20AssetToken<S, P> {
         let caller = ctx.caller();
         let encoded: Bytes = match call {
             // --- Role / precision constants ---
-            SC::SECURITY_OPERATOR_ROLE(_) => Self::SECURITY_OPERATOR_ROLE.abi_encode().into(),
+            SC::OPERATOR_ROLE(_) => Self::OPERATOR_ROLE.abi_encode().into(),
             SC::WAD_PRECISION(_) => B20AssetStorage::WAD.abi_encode().into(),
             SC::REDEEM_SENDER_POLICY(_) => Self::REDEEM_SENDER_POLICY.abi_encode().into(),
 
@@ -357,11 +357,9 @@ impl<S: SecurityAccounting, P: Policy> B20AssetToken<S, P> {
             }
 
             // --- Security identifier reads ---
-            SC::securityIdentifier(c) => self
-                .accounting()
-                .security_identifier(c.identifierType.as_str())?
-                .abi_encode()
-                .into(),
+            SC::extraMetadata(c) => {
+                self.accounting().extra_metadata(c.identifierType.as_str())?.abi_encode().into()
+            }
 
             // --- Share ratio mutations ---
             SC::updateShareRatio(c) => {
@@ -399,8 +397,8 @@ impl<S: SecurityAccounting, P: Policy> B20AssetToken<S, P> {
             }
 
             // --- Security identifier mutations ---
-            SC::updateSecurityIdentifier(c) => {
-                self.update_security_identifier(caller, c.identifierType, c.value, privileged)?;
+            SC::updateExtraMetadata(c) => {
+                self.update_extra_metadata(caller, c.identifierType, c.value, privileged)?;
                 Bytes::new()
             }
         };
@@ -420,7 +418,7 @@ impl<S: SecurityAccounting, P: Policy> B20AssetToken<S, P> {
         privileged: bool,
     ) -> base_precompile_storage::Result<()> {
         let caller = ctx.caller();
-        self.ensure_security_operator(caller, privileged)?;
+        self.ensure_operator_role(caller, privileged)?;
         if self.is_announcement_active() {
             return Err(BasePrecompileError::revert(IB20Asset::AnnouncementInProgress {}));
         }
@@ -678,18 +676,15 @@ mod tests {
     }
 
     #[test]
-    fn security_identifier_roundtrip() {
+    fn extra_metadata_roundtrip() {
         let mut token = make_token();
 
-        assert_eq!(token.accounting().security_identifier("ISIN").unwrap(), "");
+        assert_eq!(token.accounting().extra_metadata("ISIN").unwrap(), "");
         token
             .accounting_mut()
-            .set_security_identifier_value("ISIN", "US0000000000".to_string())
+            .set_extra_metadata_value("ISIN", "US0000000000".to_string())
             .unwrap();
-        assert_eq!(
-            token.accounting().security_identifier("ISIN").unwrap(),
-            "US0000000000".to_string()
-        );
+        assert_eq!(token.accounting().extra_metadata("ISIN").unwrap(), "US0000000000".to_string());
     }
 
     // --- batchMint: EmptyBatch / LengthMismatch ---
@@ -895,26 +890,26 @@ mod tests {
         assert_eq!(token.accounting().shares_to_tokens_ratio().unwrap(), new_ratio);
     }
 
-    // --- securityIdentifier / updateSecurityIdentifier ---
+    // --- extraMetadata / updateExtraMetadata ---
 
     #[test]
-    fn security_identifier_missing_key_returns_empty() {
+    fn extra_metadata_missing_key_returns_empty() {
         let token = make_token();
         // "Returns the empty string if not set"
-        assert_eq!(token.accounting().security_identifier("CUSIP").unwrap(), "");
+        assert_eq!(token.accounting().extra_metadata("CUSIP").unwrap(), "");
     }
 
     #[test]
-    fn security_identifier_empty_value_clears_entry() {
+    fn extra_metadata_empty_value_clears_entry() {
         let mut token = make_token();
         token
             .accounting_mut()
-            .set_security_identifier_value("FIGI", "BBG000B9XRY4".to_string())
+            .set_extra_metadata_value("FIGI", "BBG000B9XRY4".to_string())
             .unwrap();
-        assert_eq!(token.accounting().security_identifier("FIGI").unwrap(), "BBG000B9XRY4");
+        assert_eq!(token.accounting().extra_metadata("FIGI").unwrap(), "BBG000B9XRY4");
         // "passing an empty value removes the entry"
-        token.accounting_mut().set_security_identifier_value("FIGI", String::new()).unwrap();
-        assert_eq!(token.accounting().security_identifier("FIGI").unwrap(), "");
+        token.accounting_mut().set_extra_metadata_value("FIGI", String::new()).unwrap();
+        assert_eq!(token.accounting().extra_metadata("FIGI").unwrap(), "");
     }
 
     // --- minimumRedeemable / updateMinimumRedeemable ---

--- a/crates/common/precompiles/src/b20_asset/token.rs
+++ b/crates/common/precompiles/src/b20_asset/token.rs
@@ -29,7 +29,7 @@ pub struct B20AssetToken<S: SecurityAccounting, P: Policy> {
 impl<S: SecurityAccounting, P: Policy> B20AssetToken<S, P> {
     /// Role identifier for security operators: `keccak256("OPERATOR_ROLE")`.
     pub const OPERATOR_ROLE: B256 =
-        b256!("e63901dfe7775ace99fa3654743976eb0ab2009f5d19c4fc1ecd40aed27d59af");
+        b256!("97667070c54ef182b0f5858b034beac1b6f3089aa2d3188bb1e8929f4fa9b929");
 
     /// Policy scope identifier for redeem senders: `keccak256("REDEEM_SENDER_POLICY")`.
     pub const REDEEM_SENDER_POLICY: B256 = B20AssetStorage::REDEEM_SENDER_POLICY;

--- a/crates/common/precompiles/src/b20_asset/token.rs
+++ b/crates/common/precompiles/src/b20_asset/token.rs
@@ -27,8 +27,8 @@ pub struct B20AssetToken<S: SecurityAccounting, P: Policy> {
 }
 
 impl<S: SecurityAccounting, P: Policy> B20AssetToken<S, P> {
-    /// Role identifier for security operators: `keccak256("SECURITY_OPERATOR_ROLE")`.
-    pub const SECURITY_OPERATOR_ROLE: B256 =
+    /// Role identifier for security operators: `keccak256("OPERATOR_ROLE")`.
+    pub const OPERATOR_ROLE: B256 =
         b256!("e63901dfe7775ace99fa3654743976eb0ab2009f5d19c4fc1ecd40aed27d59af");
 
     /// Policy scope identifier for redeem senders: `keccak256("REDEEM_SENDER_POLICY")`.
@@ -108,8 +108,8 @@ impl<S: SecurityAccounting, P: Policy> B20AssetToken<S, P> {
     // --- Authorization Helpers ---
 
     /// Ensures the caller has the security operator role.
-    pub fn ensure_security_operator(&self, caller: Address, privileged: bool) -> Result<()> {
-        if privileged { Ok(()) } else { self.ensure_role(caller, Self::SECURITY_OPERATOR_ROLE) }
+    pub fn ensure_operator_role(&self, caller: Address, privileged: bool) -> Result<()> {
+        if privileged { Ok(()) } else { self.ensure_role(caller, Self::OPERATOR_ROLE) }
     }
 
     /// Ensures the caller has the default admin role.
@@ -176,7 +176,7 @@ impl<S: SecurityAccounting, P: Policy> B20AssetToken<S, P> {
         new_ratio: U256,
         privileged: bool,
     ) -> Result<()> {
-        self.ensure_security_operator(caller, privileged)?;
+        self.ensure_operator_role(caller, privileged)?;
         self.accounting_mut().set_shares_to_tokens_ratio(new_ratio)?;
         self.accounting_mut().emit_event(
             IB20Asset::ShareRatioUpdated { sharesToTokensRatio: new_ratio }.encode_log_data(),
@@ -203,21 +203,20 @@ impl<S: SecurityAccounting, P: Policy> B20AssetToken<S, P> {
     // --- Security Identifier Operations ---
 
     /// Updates a security identifier value.
-    pub fn update_security_identifier(
+    pub fn update_extra_metadata(
         &mut self,
         caller: Address,
         identifier_type: String,
         value: String,
         privileged: bool,
     ) -> Result<()> {
-        self.ensure_security_operator(caller, privileged)?;
+        self.ensure_operator_role(caller, privileged)?;
         if identifier_type.is_empty() {
             return Err(BasePrecompileError::revert(IB20Asset::InvalidIdentifierType {}));
         }
-        self.accounting_mut()
-            .set_security_identifier_value(identifier_type.as_str(), value.clone())?;
+        self.accounting_mut().set_extra_metadata_value(identifier_type.as_str(), value.clone())?;
         self.accounting_mut().emit_event(
-            IB20Asset::SecurityIdentifierUpdated { identifierType: identifier_type, value }
+            IB20Asset::ExtraMetadataUpdated { identifierType: identifier_type, value }
                 .encode_log_data(),
         )
     }
@@ -504,7 +503,7 @@ mod tests {
 
     #[test]
     fn role_and_policy_ids_match_solidity_hashes() {
-        assert_eq!(TestSecurityToken::SECURITY_OPERATOR_ROLE, keccak256("SECURITY_OPERATOR_ROLE"));
+        assert_eq!(TestSecurityToken::OPERATOR_ROLE, keccak256("OPERATOR_ROLE"));
         assert_eq!(TestSecurityToken::REDEEM_SENDER_POLICY, keccak256("REDEEM_SENDER_POLICY"));
     }
 

--- a/crates/common/precompiles/src/common/test_utils.rs
+++ b/crates/common/precompiles/src/common/test_utils.rs
@@ -71,7 +71,7 @@ pub struct InMemoryTokenAccounting {
     /// Share-to-tokens ratio scaled to WAD (1e18). Security tokens only.
     pub shares_to_tokens_ratio: U256,
     /// Security identifier values keyed by raw `identifier_type`. Security tokens only.
-    pub security_identifiers: HashMap<String, String>,
+    pub extra_metadata: HashMap<String, String>,
     /// Consumed announcement ids keyed by raw announcement id. Security tokens only.
     pub announcement_ids_used: HashSet<String>,
     /// Events collected by `emit_event`; does not produce real EVM logs.
@@ -102,7 +102,7 @@ impl InMemoryTokenAccounting {
             role_admins: HashMap::new(),
             policy_ids: HashMap::new(),
             shares_to_tokens_ratio: U256::ZERO,
-            security_identifiers: HashMap::new(),
+            extra_metadata: HashMap::new(),
             announcement_ids_used: HashSet::new(),
             events: Vec::new(),
         }
@@ -399,22 +399,18 @@ impl SecurityAccounting for InMemoryTokenAccounting {
         Ok(())
     }
 
-    fn security_identifier(&self, identifier_type: &str) -> Result<String> {
-        if let Some(val) = self.security_identifiers.get(identifier_type) {
+    fn extra_metadata(&self, identifier_type: &str) -> Result<String> {
+        if let Some(val) = self.extra_metadata.get(identifier_type) {
             return Ok(val.clone());
         }
         if identifier_type == "ISIN" { Ok(self.security_isin.clone()) } else { Ok(String::new()) }
     }
 
-    fn set_security_identifier_value(
-        &mut self,
-        identifier_type: &str,
-        value: String,
-    ) -> Result<()> {
+    fn set_extra_metadata_value(&mut self, identifier_type: &str, value: String) -> Result<()> {
         if value.is_empty() {
-            self.security_identifiers.remove(identifier_type);
+            self.extra_metadata.remove(identifier_type);
         } else {
-            self.security_identifiers.insert(identifier_type.to_owned(), value);
+            self.extra_metadata.insert(identifier_type.to_owned(), value);
         }
         Ok(())
     }


### PR DESCRIPTION
[BOP-237](https://linear.app/coinbase/issue/BOP-237/basebase-rename-security-operator-role-operator-role-security)

## Motivation

Three cleanup items from the B20Asset rename/simplification work:

1. `SECURITY_OPERATOR_ROLE` is renamed to `OPERATOR_ROLE` now that the token type is "Asset" not "Security". The keccak ID changes from `keccak256("SECURITY_OPERATOR_ROLE")` to `keccak256("OPERATOR_ROLE")`.
2. "Security Identifiers" (the key-value metadata system) is renamed to "Extra Metadata" to better reflect its purpose as an open-ended extension point.
3. `updateExtraMetadata` is gated by `OPERATOR_ROLE` (unchanged behavior, role constant renamed).

## Changes

`b20_security/abi.rs`
- `SECURITY_OPERATOR_ROLE()` -> `OPERATOR_ROLE()`
- `SecurityIdentifierUpdated` -> `ExtraMetadataUpdated`
- `securityIdentifier()` -> `extraMetadata()`
- `updateSecurityIdentifier()` -> `updateExtraMetadata()`

`b20_security/token.rs`
- `SECURITY_OPERATOR_ROLE` constant renamed to `OPERATOR_ROLE` with updated keccak hash
- `ensure_security_operator()` -> `ensure_operator_role()`
- `update_security_identifier()` -> `update_extra_metadata()`

`b20_security/dispatch.rs`
- All dispatch arms updated to new names

`actions/harness/tests/beryl/security.rs`
- All call and event references updated to new names

## What was considered

Internal trait methods (`SecurityAccounting::security_identifier()`, `set_security_identifier_value()`, `security_identifiers` storage field) retain the old "security identifier" naming since they are internal implementation details. These can be cleaned up in a follow-up.

## Test plan
- [ ] `cargo test -p base-common-precompiles b20_security` passes
- [ ] `cargo build -p base-common-precompiles` passes

type=routine
risk=low
impact=sev4