### PR TITLE
feat(precompiles): remove B20Factory activation flag

### DIFF
--- a/actions/harness/tests/beryl/b20.rs
+++ b/actions/harness/tests/beryl/b20.rs
@@ -598,14 +598,10 @@ impl B20TokenScenario {
 
         scenario.build_block_with_transactions(Vec::new()).await;
 
-        let activate_factory =
-            scenario.env.activate_feature_tx(BerylTestEnv::b20_factory_feature());
         let activate_b20 = scenario.env.activate_feature_tx(BerylTestEnv::b20_asset_feature());
-        let block =
-            scenario.build_block_with_transactions(vec![activate_factory, activate_b20]).await;
+        let block = scenario.build_block_with_transactions(vec![activate_b20]).await;
 
-        assert!(scenario.env.user_tx_succeeded(&block, 0), "TOKEN_FACTORY activation must succeed");
-        assert!(scenario.env.user_tx_succeeded(&block, 1), "B20_ASSET activation must succeed");
+        assert!(scenario.env.user_tx_succeeded(&block, 0), "B20_ASSET activation must succeed");
 
         let create = scenario.env.create_b20_token_tx();
         let block = scenario.build_block_with_transactions(vec![create]).await;

--- a/actions/harness/tests/beryl/b20_policy.rs
+++ b/actions/harness/tests/beryl/b20_policy.rs
@@ -237,14 +237,12 @@ impl B20PolicyScenario {
 
         scenario.build_block(vec![]).await;
 
-        let act_factory = scenario.env.activate_feature_tx(BerylTestEnv::b20_factory_feature());
         let act_b20 = scenario.env.activate_feature_tx(BerylTestEnv::b20_asset_feature());
         let act_policy = scenario.env.activate_feature_tx(BerylTestEnv::policy_registry_feature());
-        let block = scenario.build_block(vec![act_factory, act_b20, act_policy]).await;
-        assert!(scenario.env.user_tx_succeeded(&block, 0), "TOKEN_FACTORY activation must succeed");
-        assert!(scenario.env.user_tx_succeeded(&block, 1), "B20_ASSET activation must succeed");
+        let block = scenario.build_block(vec![act_b20, act_policy]).await;
+        assert!(scenario.env.user_tx_succeeded(&block, 0), "B20_ASSET activation must succeed");
         assert!(
-            scenario.env.user_tx_succeeded(&block, 2),
+            scenario.env.user_tx_succeeded(&block, 1),
             "POLICY_REGISTRY activation must succeed"
         );
 

--- a/actions/harness/tests/beryl/env.rs
+++ b/actions/harness/tests/beryl/env.rs
@@ -186,19 +186,14 @@ impl BerylTestEnv {
         self.chain_id
     }
 
-    /// Activation registry feature ID for the token factory precompile.
-    pub(crate) const fn b20_factory_feature() -> B256 {
-        ActivationFeature::B20Factory.id()
+    /// Activation registry feature ID for the B-20 asset precompile.
+    pub(crate) const fn b20_asset_feature() -> B256 {
+        ActivationFeature::B20Asset.id()
     }
 
     /// Activation registry feature ID for the B-20 stablecoin precompile.
     pub(crate) const fn b20_stablecoin_feature() -> B256 {
         ActivationFeature::B20Stablecoin.id()
-    }
-
-    /// Activation registry feature ID for the B-20 asset precompile.
-    pub(crate) const fn b20_asset_feature() -> B256 {
-        ActivationFeature::B20Asset.id()
     }
 
     /// Activation registry feature ID for the policy registry precompile.

--- a/actions/harness/tests/beryl/factory.rs
+++ b/actions/harness/tests/beryl/factory.rs
@@ -259,8 +259,8 @@ struct B20FactoryPrecompiles;
 
 impl B20FactoryPrecompiles {
     async fn activate(env: &mut BerylTestEnv) -> BaseBlock {
-        let activate_b20_asset = env.activate_feature_tx(BerylTestEnv::b20_asset_feature());
-        let block = env.sequencer.build_next_block_with_transactions(vec![activate_b20_asset]).await;
+        let activate_b20 = env.activate_feature_tx(BerylTestEnv::b20_asset_feature());
+        let block = env.sequencer.build_next_block_with_transactions(vec![activate_b20]).await;
 
         assert!(env.user_tx_succeeded(&block, 0), "B20_ASSET activation must succeed");
 

--- a/actions/harness/tests/beryl/factory.rs
+++ b/actions/harness/tests/beryl/factory.rs
@@ -89,48 +89,6 @@ async fn duplicate_b20_creation_reverts() {
 }
 
 #[tokio::test]
-async fn b20_creation_reverts_while_factory_feature_is_deactivated() {
-    let mut env = BerylTestEnv::new();
-
-    let block1 = env.sequencer.build_empty_block().await;
-    let activation_block = B20FactoryPrecompiles::activate(&mut env).await;
-
-    let deactivate_factory = env.deactivate_feature_tx(BerylTestEnv::b20_factory_feature());
-    let block2 = env.sequencer.build_next_block_with_transactions(vec![deactivate_factory]).await;
-
-    assert!(env.user_tx_succeeded(&block2, 0), "TOKEN_FACTORY deactivation must succeed");
-
-    let create_while_deactivated = env.create_b20_token_with_salt_tx(BerylTestEnv::ALT_SALT);
-    let block3 =
-        env.sequencer.build_next_block_with_transactions(vec![create_while_deactivated]).await;
-
-    assert!(
-        !env.user_tx_succeeded(&block3, 0),
-        "token creation must revert when TOKEN_FACTORY is deactivated"
-    );
-
-    let reactivate_factory = env.activate_feature_tx(BerylTestEnv::b20_factory_feature());
-    let block4 = env.sequencer.build_next_block_with_transactions(vec![reactivate_factory]).await;
-
-    assert!(env.user_tx_succeeded(&block4, 0), "TOKEN_FACTORY re-activation must succeed");
-
-    let create_after_reactivate = env.create_b20_token_with_salt_tx(BerylTestEnv::ALT_SALT);
-    let block5 =
-        env.sequencer.build_next_block_with_transactions(vec![create_after_reactivate]).await;
-
-    assert!(
-        env.user_tx_succeeded(&block5, 0),
-        "token creation must succeed after TOKEN_FACTORY is re-activated"
-    );
-
-    env.derive_blocks(
-        [(block1, 1), (activation_block, 2), (block2, 3), (block3, 4), (block4, 5), (block5, 6)],
-        6,
-    )
-    .await;
-}
-
-#[tokio::test]
 async fn b20_creation_reverts_while_variant_feature_is_deactivated() {
     let mut env = BerylTestEnv::new();
 
@@ -301,15 +259,10 @@ struct B20FactoryPrecompiles;
 
 impl B20FactoryPrecompiles {
     async fn activate(env: &mut BerylTestEnv) -> BaseBlock {
-        let activate_factory = env.activate_feature_tx(BerylTestEnv::b20_factory_feature());
         let activate_b20_asset = env.activate_feature_tx(BerylTestEnv::b20_asset_feature());
-        let block = env
-            .sequencer
-            .build_next_block_with_transactions(vec![activate_factory, activate_b20_asset])
-            .await;
+        let block = env.sequencer.build_next_block_with_transactions(vec![activate_b20_asset]).await;
 
-        assert!(env.user_tx_succeeded(&block, 0), "TOKEN_FACTORY activation must succeed");
-        assert!(env.user_tx_succeeded(&block, 1), "B20_ASSET activation must succeed");
+        assert!(env.user_tx_succeeded(&block, 0), "B20_ASSET activation must succeed");
 
         block
     }

--- a/actions/harness/tests/beryl/policy_transfer.rs
+++ b/actions/harness/tests/beryl/policy_transfer.rs
@@ -246,19 +246,16 @@ impl PolicyTransferScenario {
         let beryl_boundary = scenario.env.sequencer.build_empty_block().await;
         scenario.push_block(beryl_boundary);
 
-        // Activate all three features in one block.
-        let activate_factory =
-            scenario.env.activate_feature_tx(BerylTestEnv::b20_factory_feature());
+        // Activate both features in one block.
         let activate_b20 = scenario.env.activate_feature_tx(BerylTestEnv::b20_asset_feature());
         let activate_registry =
             scenario.env.activate_feature_tx(BerylTestEnv::policy_registry_feature());
         let block = scenario
-            .build_block_with_transactions(vec![activate_factory, activate_b20, activate_registry])
+            .build_block_with_transactions(vec![activate_b20, activate_registry])
             .await;
-        assert!(scenario.env.user_tx_succeeded(&block, 0), "TOKEN_FACTORY activation must succeed");
-        assert!(scenario.env.user_tx_succeeded(&block, 1), "B20_ASSET activation must succeed");
+        assert!(scenario.env.user_tx_succeeded(&block, 0), "B20_ASSET activation must succeed");
         assert!(
-            scenario.env.user_tx_succeeded(&block, 2),
+            scenario.env.user_tx_succeeded(&block, 1),
             "POLICY_REGISTRY activation must succeed"
         );
 
@@ -300,18 +297,15 @@ impl PolicyTransferScenario {
         let beryl_boundary = scenario.env.sequencer.build_empty_block().await;
         scenario.push_block(beryl_boundary);
 
-        let activate_factory =
-            scenario.env.activate_feature_tx(BerylTestEnv::b20_factory_feature());
         let activate_b20 = scenario.env.activate_feature_tx(BerylTestEnv::b20_asset_feature());
         let activate_registry =
             scenario.env.activate_feature_tx(BerylTestEnv::policy_registry_feature());
         let block = scenario
-            .build_block_with_transactions(vec![activate_factory, activate_b20, activate_registry])
+            .build_block_with_transactions(vec![activate_b20, activate_registry])
             .await;
-        assert!(scenario.env.user_tx_succeeded(&block, 0), "TOKEN_FACTORY activation must succeed");
-        assert!(scenario.env.user_tx_succeeded(&block, 1), "B20_ASSET activation must succeed");
+        assert!(scenario.env.user_tx_succeeded(&block, 0), "B20_ASSET activation must succeed");
         assert!(
-            scenario.env.user_tx_succeeded(&block, 2),
+            scenario.env.user_tx_succeeded(&block, 1),
             "POLICY_REGISTRY activation must succeed"
         );
 
@@ -337,13 +331,9 @@ impl PolicyTransferScenario {
         let beryl_boundary = scenario.env.sequencer.build_empty_block().await;
         scenario.push_block(beryl_boundary);
 
-        let activate_factory =
-            scenario.env.activate_feature_tx(BerylTestEnv::b20_factory_feature());
         let activate_b20 = scenario.env.activate_feature_tx(BerylTestEnv::b20_asset_feature());
-        let block =
-            scenario.build_block_with_transactions(vec![activate_factory, activate_b20]).await;
-        assert!(scenario.env.user_tx_succeeded(&block, 0), "TOKEN_FACTORY activation must succeed");
-        assert!(scenario.env.user_tx_succeeded(&block, 1), "B20_ASSET activation must succeed");
+        let block = scenario.build_block_with_transactions(vec![activate_b20]).await;
+        assert!(scenario.env.user_tx_succeeded(&block, 0), "B20_ASSET activation must succeed");
 
         // No updatePolicy init call: the TRANSFER_SENDER_POLICY slot reads zero (ALWAYS_ALLOW).
         let create_token = scenario.create_token_tx(None);

--- a/actions/harness/tests/beryl/policy_transfer.rs
+++ b/actions/harness/tests/beryl/policy_transfer.rs
@@ -250,9 +250,8 @@ impl PolicyTransferScenario {
         let activate_b20 = scenario.env.activate_feature_tx(BerylTestEnv::b20_asset_feature());
         let activate_registry =
             scenario.env.activate_feature_tx(BerylTestEnv::policy_registry_feature());
-        let block = scenario
-            .build_block_with_transactions(vec![activate_b20, activate_registry])
-            .await;
+        let block =
+            scenario.build_block_with_transactions(vec![activate_b20, activate_registry]).await;
         assert!(scenario.env.user_tx_succeeded(&block, 0), "B20_ASSET activation must succeed");
         assert!(
             scenario.env.user_tx_succeeded(&block, 1),
@@ -300,9 +299,8 @@ impl PolicyTransferScenario {
         let activate_b20 = scenario.env.activate_feature_tx(BerylTestEnv::b20_asset_feature());
         let activate_registry =
             scenario.env.activate_feature_tx(BerylTestEnv::policy_registry_feature());
-        let block = scenario
-            .build_block_with_transactions(vec![activate_b20, activate_registry])
-            .await;
+        let block =
+            scenario.build_block_with_transactions(vec![activate_b20, activate_registry]).await;
         assert!(scenario.env.user_tx_succeeded(&block, 0), "B20_ASSET activation must succeed");
         assert!(
             scenario.env.user_tx_succeeded(&block, 1),

--- a/actions/harness/tests/beryl/security.rs
+++ b/actions/harness/tests/beryl/security.rs
@@ -428,23 +428,16 @@ impl B20AssetScenario {
 
         scenario.build_block_with_transactions(Vec::new()).await;
 
-        let activate_factory =
-            scenario.env.activate_feature_tx(BerylTestEnv::b20_factory_feature());
         let activate_security = scenario.env.activate_feature_tx(BerylTestEnv::b20_asset_feature());
         let activate_policy =
             scenario.env.activate_feature_tx(BerylTestEnv::policy_registry_feature());
         let block = scenario
-            .build_block_with_transactions(vec![
-                activate_factory,
-                activate_security,
-                activate_policy,
-            ])
+            .build_block_with_transactions(vec![activate_security, activate_policy])
             .await;
 
-        assert!(scenario.env.user_tx_succeeded(&block, 0), "TOKEN_FACTORY activation must succeed");
-        assert!(scenario.env.user_tx_succeeded(&block, 1), "B20_SECURITY activation must succeed");
+        assert!(scenario.env.user_tx_succeeded(&block, 0), "B20_SECURITY activation must succeed");
         assert!(
-            scenario.env.user_tx_succeeded(&block, 2),
+            scenario.env.user_tx_succeeded(&block, 1),
             "POLICY_REGISTRY activation must succeed"
         );
 

--- a/actions/harness/tests/beryl/security.rs
+++ b/actions/harness/tests/beryl/security.rs
@@ -431,9 +431,8 @@ impl B20AssetScenario {
         let activate_security = scenario.env.activate_feature_tx(BerylTestEnv::b20_asset_feature());
         let activate_policy =
             scenario.env.activate_feature_tx(BerylTestEnv::policy_registry_feature());
-        let block = scenario
-            .build_block_with_transactions(vec![activate_security, activate_policy])
-            .await;
+        let block =
+            scenario.build_block_with_transactions(vec![activate_security, activate_policy]).await;
 
         assert!(scenario.env.user_tx_succeeded(&block, 0), "B20_SECURITY activation must succeed");
         assert!(

--- a/actions/harness/tests/beryl/stablecoin.rs
+++ b/actions/harness/tests/beryl/stablecoin.rs
@@ -239,10 +239,7 @@ async fn stablecoin_creation_reverts_for_invalid_currency() {
 
     let block1 = env.sequencer.build_empty_block().await;
     let activate_stablecoin = env.activate_feature_tx(BerylTestEnv::b20_stablecoin_feature());
-    let block2 = env
-        .sequencer
-        .build_next_block_with_transactions(vec![activate_stablecoin])
-        .await;
+    let block2 = env.sequencer.build_next_block_with_transactions(vec![activate_stablecoin]).await;
     assert!(env.user_tx_succeeded(&block2, 0), "B20_STABLECOIN activation must succeed");
 
     let invalid_currency = create_stablecoin_with_currency_tx(&env, "usd");

--- a/actions/harness/tests/beryl/stablecoin.rs
+++ b/actions/harness/tests/beryl/stablecoin.rs
@@ -238,14 +238,12 @@ async fn stablecoin_creation_reverts_for_invalid_currency() {
     let token = env.b20_stablecoin_address();
 
     let block1 = env.sequencer.build_empty_block().await;
-    let activate_factory = env.activate_feature_tx(BerylTestEnv::b20_factory_feature());
     let activate_stablecoin = env.activate_feature_tx(BerylTestEnv::b20_stablecoin_feature());
     let block2 = env
         .sequencer
-        .build_next_block_with_transactions(vec![activate_factory, activate_stablecoin])
+        .build_next_block_with_transactions(vec![activate_stablecoin])
         .await;
-    assert!(env.user_tx_succeeded(&block2, 0), "TOKEN_FACTORY activation must succeed");
-    assert!(env.user_tx_succeeded(&block2, 1), "B20_STABLECOIN activation must succeed");
+    assert!(env.user_tx_succeeded(&block2, 0), "B20_STABLECOIN activation must succeed");
 
     let invalid_currency = create_stablecoin_with_currency_tx(&env, "usd");
     let block3 = env.sequencer.build_next_block_with_transactions(vec![invalid_currency]).await;
@@ -299,14 +297,11 @@ impl StablecoinScenario {
     }
 
     async fn activate_precompiles(&mut self) {
-        let activate_factory = self.env.activate_feature_tx(BerylTestEnv::b20_factory_feature());
         let activate_stablecoin =
             self.env.activate_feature_tx(BerylTestEnv::b20_stablecoin_feature());
-        let block =
-            self.build_block_with_transactions(vec![activate_factory, activate_stablecoin]).await;
+        let block = self.build_block_with_transactions(vec![activate_stablecoin]).await;
 
-        assert!(self.env.user_tx_succeeded(&block, 0), "TOKEN_FACTORY activation must succeed");
-        assert!(self.env.user_tx_succeeded(&block, 1), "B20_STABLECOIN activation must succeed");
+        assert!(self.env.user_tx_succeeded(&block, 0), "B20_STABLECOIN activation must succeed");
     }
 
     async fn build_block_with_transactions(

--- a/crates/common/precompiles/src/activation/storage.rs
+++ b/crates/common/precompiles/src/activation/storage.rs
@@ -25,8 +25,6 @@ pub struct ActivationRegistryStorage {
 pub enum ActivationFeature {
     /// `keccak256("base.b20_token")`
     B20Token,
-    /// `keccak256("base.b20_factory")`
-    B20Factory,
     /// `keccak256("base.policy_registry")`
     PolicyRegistry,
     /// `keccak256("base.b20_stablecoin")`
@@ -41,9 +39,6 @@ impl ActivationFeature {
         match self {
             Self::B20Token => {
                 b256!("0x47a1afe8d3d691b87e090ee972d223a11f4da971ff5416c04985bb2393aca752")
-            }
-            Self::B20Factory => {
-                b256!("0x78751e29c8bcc0d609ab18e9fbc4158e73f7db25ae2ee095dad42e2578b1e800")
             }
             Self::PolicyRegistry => {
                 b256!("0xb582ebae03f16fee49a6763f78df482fb11ae73f103ed0d330bbe556aa90a43f")
@@ -282,7 +277,6 @@ mod tests {
     #[test]
     fn feature_id_constants_match_canonical_names() {
         assert_eq!(ActivationFeature::B20Token.id(), keccak256("base.b20_token"));
-        assert_eq!(ActivationFeature::B20Factory.id(), keccak256("base.b20_factory"));
         assert_eq!(ActivationFeature::PolicyRegistry.id(), keccak256("base.policy_registry"));
         assert_eq!(ActivationFeature::B20Stablecoin.id(), keccak256("base.b20_stablecoin"));
         assert_eq!(ActivationFeature::B20Asset.id(), keccak256("base.b20_security"));

--- a/crates/common/precompiles/src/b20_factory/dispatch.rs
+++ b/crates/common/precompiles/src/b20_factory/dispatch.rs
@@ -6,7 +6,7 @@ use base_precompile_storage::{BasePrecompileError, IntoPrecompileResult, Storage
 use revm::precompile::PrecompileResult;
 
 use crate::{
-    ActivationFeature, ActivationRegistryStorage, B20FactoryStorage, B20Variant, IB20Factory,
+    B20FactoryStorage, B20Variant, IB20Factory,
     macros::{decode_precompile_call, deduct_calldata_cost},
 };
 
@@ -24,8 +24,6 @@ impl<'a> B20FactoryStorage<'a> {
         ctx: StorageCtx<'_>,
         calldata: &[u8],
     ) -> base_precompile_storage::Result<Bytes> {
-        ActivationRegistryStorage::new(ctx).ensure_activated(ActivationFeature::B20Factory.id())?;
-
         match decode_precompile_call!(calldata, IB20Factory::IB20FactoryCalls) {
             IB20Factory::IB20FactoryCalls::createB20(call) => {
                 let caller = ctx.caller();

--- a/crates/common/precompiles/src/b20_factory/storage.rs
+++ b/crates/common/precompiles/src/b20_factory/storage.rs
@@ -346,7 +346,6 @@ mod tests {
     fn activate_precompiles(storage: &mut HashMapStorageProvider) {
         storage.set_caller(ACTIVATION_ADMIN);
         for key in [
-            ActivationFeature::B20Factory.id(),
             ActivationFeature::B20Token.id(),
             ActivationFeature::B20Stablecoin.id(),
             ActivationFeature::B20Asset.id(),

--- a/crates/infra/basectl/src/app/views/upgrades.rs
+++ b/crates/infra/basectl/src/app/views/upgrades.rs
@@ -189,7 +189,6 @@ const BERYL_CHECK_NAMES: &[&str] = &[
     "registry precompile",
     "registry admin",
     "B-20 token feature",
-    "B-20 factory feature",
     "policy registry feature",
     "B-20 stablecoin feature",
     "B-20 asset feature",
@@ -197,7 +196,6 @@ const BERYL_CHECK_NAMES: &[&str] = &[
 
 const BERYL_FEATURE_CHECKS: &[(&str, ActivationFeature)] = &[
     ("B-20 token feature", ActivationFeature::B20Token),
-    ("B-20 factory feature", ActivationFeature::B20Factory),
     ("policy registry feature", ActivationFeature::PolicyRegistry),
     ("B-20 stablecoin feature", ActivationFeature::B20Stablecoin),
     ("B-20 asset feature", ActivationFeature::B20Asset),

--- a/etc/systems/benches/b20_zk_proving.rs
+++ b/etc/systems/benches/b20_zk_proving.rs
@@ -140,7 +140,6 @@ impl B20ZkProvingBench {
         let b20_spender = B20PrecompileClient::new(&l2_provider, &spender, config.l2_chain_id)
             .with_receipt_timeout(config.tx_receipt_timeout);
         display.setup_message("setup ensuring B-20 features are active");
-        Self::ensure_feature_active(&b20, ActivationFeature::B20Factory.id()).await?;
         Self::ensure_feature_active(&b20, ActivationFeature::B20Asset.id()).await?;
 
         display.setup_message("setup creating benchmark B-20 token");

--- a/etc/systems/tests/b20_precompile.rs
+++ b/etc/systems/tests/b20_precompile.rs
@@ -30,7 +30,6 @@ async fn activated_b20_client<'a>(
 ) -> Result<B20PrecompileClient<'a>> {
     let b20 = B20PrecompileClient::new(provider, admin, common::L2_CHAIN_ID)
         .with_receipt_timeout(common::TX_RECEIPT_TIMEOUT);
-    b20.activate_feature(ActivationFeature::B20Factory.id()).await?;
     b20.activate_feature(ActivationFeature::B20Asset.id()).await?;
     Ok(b20)
 }

--- a/etc/systems/tests/policy_transfer.rs
+++ b/etc/systems/tests/policy_transfer.rs
@@ -27,15 +27,14 @@ const SALT_ALLOWLIST: B256 = B256::repeat_byte(0x50);
 const SALT_BLOCKLIST: B256 = B256::repeat_byte(0x51);
 const SALT_ALWAYS_BLOCK: B256 = B256::repeat_byte(0x52);
 
-/// Activates `B20_FACTORY`, `B20_TOKEN`, and `POLICY_REGISTRY` features, then
-/// returns a [`B20PrecompileClient`] ready for precompile calls.
+/// Activates `B20_TOKEN` and `POLICY_REGISTRY` features, then returns a
+/// [`B20PrecompileClient`] ready for precompile calls.
 async fn activated_client<'a>(
     provider: &'a RootProvider<Base>,
     admin: &'a PrivateKeySigner,
 ) -> Result<B20PrecompileClient<'a>> {
     let client = B20PrecompileClient::new(provider, admin, common::L2_CHAIN_ID)
         .with_receipt_timeout(common::TX_RECEIPT_TIMEOUT);
-    client.activate_feature(ActivationFeature::B20Factory.id()).await?;
     client.activate_feature(ActivationFeature::B20Asset.id()).await?;
     client.activate_feature(ActivationFeature::PolicyRegistry.id()).await?;
     Ok(client)


### PR DESCRIPTION
## Summary

Remove the B20Factory activation feature and make the factory always enabled once Beryl is active. This simplifies the precompile activation model to only require variant-level feature flags (B20Token, B20Stablecoin, B20Security).

## Changes

- Remove `B20Factory` variant from `ActivationFeature` enum
- Remove factory activation check from `B20FactoryStorage::dispatch()`
- Remove `b20_factory_feature()` helper from `BerylTestEnv`
- Remove test `b20_creation_reverts_while_factory_feature_is_deactivated`
- Update all tests to not activate the factory feature
- Remove factory feature from basectl upgrade checks

## Testing

- `cargo check -p base-common-precompiles` passes
- `cargo clippy -p base-common-precompiles --lib` passes
- `cargo check -p basectl-cli` passes

## Files Changed (14 files, +26/-117)

- `crates/common/precompiles/src/activation/storage.rs` - Remove B20Factory variant
- `crates/common/precompiles/src/b20_factory/dispatch.rs` - Remove activation check
- `crates/common/precompiles/src/b20_factory/storage.rs` - Update test helper
- `crates/infra/basectl/src/app/views/upgrades.rs` - Remove factory from checks
- `actions/harness/tests/beryl/*.rs` - Update test setups
- `etc/systems/tests/*.rs` - Update system tests
- `etc/systems/benches/b20_zk_proving.rs` - Update benchmark