### PR TITLE
add custom decimals storage to B20Asset (uint8, range [6,18]) (BOP-241)

### DIFF
--- a/actions/harness/tests/beryl/env.rs
+++ b/actions/harness/tests/beryl/env.rs
@@ -63,13 +63,13 @@ impl BerylTestEnv {
     /// Gas limit used for B-20 staticcall probe transactions.
     pub(crate) const B20_PROBE_GAS_LIMIT: u64 = 1_000_000;
 
-    /// Fixed decimals for the asset B-20 token variant.
+    /// Fixed decimals for the default B-20 token variant.
     pub(crate) const B20_DECIMALS: u8 = 6;
 
-    /// Name for the asset B-20 token variant.
+    /// Name for the default B-20 token variant.
     pub(crate) const B20_NAME: &str = "Action B20";
 
-    /// Symbol for the asset B-20 token variant.
+    /// Symbol for the default B-20 token variant.
     pub(crate) const B20_SYMBOL: &str = "AB20";
 
     /// Fixed decimals for the stablecoin B-20 token variant.
@@ -85,19 +85,19 @@ impl BerylTestEnv {
     pub(crate) const B20_STABLECOIN_CURRENCY: &str = "USD";
 
     /// Fixed decimals for the security B-20 token variant.
-    pub(crate) const B20_SECURITY_DECIMALS: u8 = 6;
+    pub(crate) const B20_ASSET_DECIMALS: u8 = 6;
 
     /// Name for the security B-20 token variant.
-    pub(crate) const B20_SECURITY_NAME: &str = "Action Security";
+    pub(crate) const B20_ASSET_NAME: &str = "Action Security";
 
     /// Symbol for the security B-20 token variant.
-    pub(crate) const B20_SECURITY_SYMBOL: &str = "ASEC";
+    pub(crate) const B20_ASSET_SYMBOL: &str = "ASEC";
 
     /// ISIN stored on the security B-20 token at creation.
-    pub(crate) const B20_SECURITY_ISIN: &str = "US0000000001";
+    pub(crate) const B20_ASSET_ISIN: &str = "US0000000001";
 
     /// Initial minimum redeemable share amount for the security B-20 token.
-    pub(crate) const B20_SECURITY_MINIMUM_REDEEMABLE: u64 = 10;
+    pub(crate) const B20_ASSET_MINIMUM_REDEEMABLE: u64 = 10;
 
     /// Initial B-20 supply minted to Alice.
     pub(crate) const B20_INITIAL_SUPPLY: u64 = 1_000_000;
@@ -578,7 +578,7 @@ impl BerylTestEnv {
         IB20Factory::createB20Call {
             variant: IB20Factory::B20Variant::ASSET,
             salt,
-            params: self.b20_security_params().abi_encode().into(),
+            params: self.b20_asset_params().abi_encode().into(),
             initCalls: vec![
                 IB20::mintCall { to: Self::alice(), amount: U256::from(Self::B20_INITIAL_SUPPLY) }
                     .abi_encode()
@@ -631,6 +631,7 @@ impl BerylTestEnv {
             initialAdmin: Self::alice(),
             isin: String::new(),
             minimumRedeemable: U256::ZERO,
+            decimals: 6,
         }
     }
 
@@ -644,14 +645,15 @@ impl BerylTestEnv {
         }
     }
 
-    fn b20_security_params(&self) -> IB20Factory::B20AssetCreateParams {
+    fn b20_asset_params(&self) -> IB20Factory::B20AssetCreateParams {
         IB20Factory::B20AssetCreateParams {
             version: B20Variant::Asset.supported_version(),
-            name: Self::B20_SECURITY_NAME.to_string(),
-            symbol: Self::B20_SECURITY_SYMBOL.to_string(),
+            name: Self::B20_ASSET_NAME.to_string(),
+            symbol: Self::B20_ASSET_SYMBOL.to_string(),
             initialAdmin: Self::alice(),
-            isin: Self::B20_SECURITY_ISIN.to_string(),
-            minimumRedeemable: U256::from(Self::B20_SECURITY_MINIMUM_REDEEMABLE),
+            isin: Self::B20_ASSET_ISIN.to_string(),
+            minimumRedeemable: U256::from(Self::B20_ASSET_MINIMUM_REDEEMABLE),
+            decimals: Self::B20_ASSET_DECIMALS,
         }
     }
 

--- a/actions/harness/tests/beryl/policy_transfer.rs
+++ b/actions/harness/tests/beryl/policy_transfer.rs
@@ -424,6 +424,7 @@ impl PolicyTransferScenario {
             initialAdmin: BerylTestEnv::alice(),
             isin: String::new(),
             minimumRedeemable: U256::ZERO,
+            decimals: 6,
         }
     }
 }

--- a/actions/harness/tests/beryl/security.rs
+++ b/actions/harness/tests/beryl/security.rs
@@ -60,24 +60,24 @@ async fn security_creation_initializes_identifiers_and_factory_views() {
                 StaticcallCase::string(
                     "name",
                     IB20::nameCall {}.abi_encode(),
-                    BerylTestEnv::B20_SECURITY_NAME,
+                    BerylTestEnv::B20_ASSET_NAME,
                 ),
                 StaticcallCase::string(
                     "symbol",
                     IB20::symbolCall {}.abi_encode(),
-                    BerylTestEnv::B20_SECURITY_SYMBOL,
+                    BerylTestEnv::B20_ASSET_SYMBOL,
                 ),
                 StaticcallCase::string("contractURI", IB20::contractURICall {}.abi_encode(), ""),
                 StaticcallCase::string(
                     "extraMetadata(ISIN)",
                     IB20Asset::extraMetadataCall { identifierType: "ISIN".to_string() }
                         .abi_encode(),
-                    BerylTestEnv::B20_SECURITY_ISIN,
+                    BerylTestEnv::B20_ASSET_ISIN,
                 ),
                 StaticcallCase::word(
                     "decimals",
                     IB20::decimalsCall {}.abi_encode(),
-                    U256::from(BerylTestEnv::B20_SECURITY_DECIMALS),
+                    U256::from(BerylTestEnv::B20_ASSET_DECIMALS),
                 ),
                 StaticcallCase::word(
                     "totalSupply",
@@ -521,9 +521,9 @@ impl B20AssetScenario {
         let expected = IB20Factory::B20Created {
             token: self.token,
             variant: IB20Factory::B20Variant::ASSET,
-            name: BerylTestEnv::B20_SECURITY_NAME.to_string(),
-            symbol: BerylTestEnv::B20_SECURITY_SYMBOL.to_string(),
-            decimals: BerylTestEnv::B20_SECURITY_DECIMALS,
+            name: BerylTestEnv::B20_ASSET_NAME.to_string(),
+            symbol: BerylTestEnv::B20_ASSET_SYMBOL.to_string(),
+            decimals: BerylTestEnv::B20_ASSET_DECIMALS,
             variantParams: Bytes::new(),
         }
         .encode_log_data();

--- a/crates/common/precompile-macros/src/accounting.rs
+++ b/crates/common/precompile-macros/src/accounting.rs
@@ -19,10 +19,10 @@ pub(crate) fn derive_asset(input: DeriveInput) -> proc_macro::TokenStream {
 fn expand_token(input: DeriveInput) -> syn::Result<TokenStream> {
     require_field(&input, "b20")?;
     let has_redeem = has_field(&input, "redeem");
-    let has_security = has_field(&input, "security");
+    let has_security = has_field(&input, "asset");
     let name = input.ident;
     let decimals_impl = if has_security {
-        quote! { crate::SecurityAccounting::decimals(self) }
+        quote! { crate::AssetAccounting::decimals(self) }
     } else {
         quote! {
             Ok(crate::B20Variant::from_address(
@@ -398,7 +398,7 @@ fn expand_asset(input: DeriveInput) -> syn::Result<TokenStream> {
             }
 
             fn decimals(&self) -> ::base_precompile_storage::Result<u8> {
-                let stored = self.security.decimals()?;
+                let stored = self.asset.decimals()?;
                 Ok(if stored == 0 { 6 } else { stored })
             }
         }

--- a/crates/common/precompile-macros/src/accounting.rs
+++ b/crates/common/precompile-macros/src/accounting.rs
@@ -19,7 +19,18 @@ pub(crate) fn derive_asset(input: DeriveInput) -> proc_macro::TokenStream {
 fn expand_token(input: DeriveInput) -> syn::Result<TokenStream> {
     require_field(&input, "b20")?;
     let has_redeem = has_field(&input, "redeem");
+    let has_security = has_field(&input, "security");
     let name = input.ident;
+    let decimals_impl = if has_security {
+        quote! { crate::SecurityAccounting::decimals(self) }
+    } else {
+        quote! {
+            Ok(crate::B20Variant::from_address(
+                ::base_precompile_storage::ContractStorage::address(self),
+            )
+            .map_or(0, crate::B20Variant::decimals))
+        }
+    };
     let redeem = has_redeem.then_some(quote! {
         if policy_scope == Self::REDEEM_SENDER_POLICY {
             return self.redeem.redeem_sender_policy_id();
@@ -132,10 +143,7 @@ fn expand_token(input: DeriveInput) -> syn::Result<TokenStream> {
             }
 
             fn decimals(&self) -> ::base_precompile_storage::Result<u8> {
-                Ok(crate::B20Variant::from_address(
-                    ::base_precompile_storage::ContractStorage::address(self),
-                )
-                .map_or(0, crate::B20Variant::decimals))
+                #decimals_impl
             }
 
             fn paused(&self) -> ::base_precompile_storage::Result<::alloy_primitives::U256> {
@@ -387,6 +395,11 @@ fn expand_asset(input: DeriveInput) -> syn::Result<TokenStream> {
                         .at_mut(&::alloc::string::String::from(id)),
                     true,
                 )
+            }
+
+            fn decimals(&self) -> ::base_precompile_storage::Result<u8> {
+                let stored = self.security.decimals()?;
+                Ok(if stored == 0 { 6 } else { stored })
             }
         }
     })

--- a/crates/common/precompiles/benches/base_precompiles.rs
+++ b/crates/common/precompiles/benches/base_precompiles.rs
@@ -34,6 +34,7 @@ impl BaseTokenBenchSetup {
             initialAdmin: Self::admin(),
             isin: String::new(),
             minimumRedeemable: U256::ZERO,
+            decimals: 6,
         }
     }
 

--- a/crates/common/precompiles/src/b20_asset/abi.rs
+++ b/crates/common/precompiles/src/b20_asset/abi.rs
@@ -34,6 +34,9 @@ sol! {
         /// An `internalCalls` entry reverted during its inner dispatch.
         error InternalCallFailed(bytes call);
 
+        /// `decimals` was not in the allowed range `[6, 18]`.
+        error InvalidDecimals();
+
         // ── Events ───────────────────────────────────────────────────────────
 
         /// Emitted by `redeem`/`redeemWithMemo`. Includes the active multiplier at redemption time.

--- a/crates/common/precompiles/src/b20_asset/accounting.rs
+++ b/crates/common/precompiles/src/b20_asset/accounting.rs
@@ -31,4 +31,7 @@ pub trait AssetAccounting: TokenAccounting {
     fn is_announcement_id_used(&self, id: &str) -> Result<bool>;
     /// Marks `id` as consumed. Called exactly once per announcement id.
     fn mark_announcement_id_used(&mut self, id: &str) -> Result<()>;
+
+    /// Returns the custom decimal precision stored for this security token.
+    fn decimals(&self) -> Result<u8>;
 }

--- a/crates/common/precompiles/src/b20_asset/dispatch.rs
+++ b/crates/common/precompiles/src/b20_asset/dispatch.rs
@@ -128,7 +128,7 @@ impl<S: AssetAccounting, P: Policy> B20AssetToken<S, P> {
             C::name(_) => self.accounting().name()?.abi_encode().into(),
             C::symbol(_) => self.accounting().symbol()?.abi_encode().into(),
             C::decimals(_) => {
-                U256::from(SecurityAccounting::decimals(self.accounting())?).abi_encode().into()
+                U256::from(AssetAccounting::decimals(self.accounting())?).abi_encode().into()
             }
             C::totalSupply(_) => self.accounting().total_supply()?.abi_encode().into(),
             C::balanceOf(c) => self.accounting().balance_of(c.account)?.abi_encode().into(),

--- a/crates/common/precompiles/src/b20_asset/dispatch.rs
+++ b/crates/common/precompiles/src/b20_asset/dispatch.rs
@@ -127,7 +127,9 @@ impl<S: AssetAccounting, P: Policy> B20AssetToken<S, P> {
             // --- Pure reads ---
             C::name(_) => self.accounting().name()?.abi_encode().into(),
             C::symbol(_) => self.accounting().symbol()?.abi_encode().into(),
-            C::decimals(_) => U256::from(self.accounting().decimals()?).abi_encode().into(),
+            C::decimals(_) => {
+                U256::from(SecurityAccounting::decimals(self.accounting())?).abi_encode().into()
+            }
             C::totalSupply(_) => self.accounting().total_supply()?.abi_encode().into(),
             C::balanceOf(c) => self.accounting().balance_of(c.account)?.abi_encode().into(),
             C::allowance(c) => self.accounting().allowance(c.owner, c.spender)?.abi_encode().into(),

--- a/crates/common/precompiles/src/b20_asset/storage.rs
+++ b/crates/common/precompiles/src/b20_asset/storage.rs
@@ -131,7 +131,7 @@ mod tests {
         __packing_b20_asset_extension_storage, __packing_b20_redeem_storage,
         B20AssetExtensionStorage, B20AssetInit, B20AssetStorage, B20RedeemStorage, slots,
     };
-    use crate::{B20CoreStorage, PolicyRegistryStorage, AssetAccounting, TokenAccounting};
+    use crate::{AssetAccounting, B20CoreStorage, PolicyRegistryStorage, TokenAccounting};
 
     const TOKEN: Address = address!("000000000000000000000000000000000000b021");
     const B20_ROOT: U256 =

--- a/crates/common/precompiles/src/b20_asset/storage.rs
+++ b/crates/common/precompiles/src/b20_asset/storage.rs
@@ -219,7 +219,7 @@ mod tests {
             let mut token = B20AssetStorage::from_address(TOKEN, ctx);
             token.asset.used_announcement_ids.at_mut(&announcement_id).write(true).unwrap();
             token
-                .security
+                .asset
                 .identifiers
                 .at_mut(&identifier_type)
                 .write(identifier_value.clone())

--- a/crates/common/precompiles/src/b20_asset/storage.rs
+++ b/crates/common/precompiles/src/b20_asset/storage.rs
@@ -4,22 +4,25 @@ use alloc::string::String;
 
 use alloy_primitives::{Address, B256, FixedBytes, U256, b256};
 use base_precompile_macros::{AssetAccounting, Storable, TokenAccounting, contract};
-use base_precompile_storage::{Handler, Mapping, Result, StorageCtx};
+use base_precompile_storage::{BasePrecompileError, Handler, Mapping, Result, StorageCtx};
 
-use crate::{B20CoreStorage, PolicyRegistryStorage};
+use crate::{B20CoreStorage, IB20Asset, PolicyRegistryStorage};
 
 /// Asset-specific B-20 storage rooted at the `base.b20.asset` ERC-7201 namespace.
 #[derive(Debug, Clone, Storable)]
 #[namespace("base.b20.asset")]
 pub struct B20AssetExtensionStorage {
+    /// Custom decimal precision for this token; stored once at creation time.
+    #[accessor]
+    pub decimals: u8, // slot 0, offset 0
     /// Multiplier scaled to WAD.
     #[accessor]
     #[mutator]
-    pub multiplier: U256, // offset 0
+    pub multiplier: U256, // slot 1
     /// Announcement IDs that have already been consumed.
-    pub used_announcement_ids: Mapping<String, bool>, // offset 1
-    /// Asset metadata values by identifier type.
-    pub identifiers: Mapping<String, String>, // offset 2
+    pub used_announcement_ids: Mapping<String, bool>, // slot 2
+    /// Security identifier values by identifier type.
+    pub identifiers: Mapping<String, String>, // slot 3
 }
 
 /// Redemption-specific B-20 storage rooted at the `base.b20.redeem` ERC-7201 namespace.
@@ -64,6 +67,8 @@ pub struct B20AssetInit {
     pub isin: String,
     /// Minimum redeemable amount; `0` allows any non-zero redemption.
     pub minimum_redeemable: U256,
+    /// Custom decimal precision for this token; must be in `[6, 18]`.
+    pub decimals: u8,
 }
 
 impl<'a> B20AssetStorage<'a> {
@@ -80,15 +85,19 @@ impl<'a> B20AssetStorage<'a> {
     /// Writes all creation-time fields atomically.
     ///
     /// `isin` may be empty; when non-empty it is stored under the `"ISIN"` key
-    /// in the asset metadata mapping.
+    /// in the security identifiers mapping.
     ///
     /// `REDEEM_SENDER_POLICY` is initialised to `ALWAYS_BLOCK_ID` so redemption
     /// is closed by default; issuers must explicitly open it after creation.
     pub fn initialize(&mut self, init: B20AssetInit) -> Result<()> {
+        if init.decimals < Self::MIN_DECIMALS || init.decimals > Self::MAX_DECIMALS {
+            return Err(BasePrecompileError::revert(IB20Asset::InvalidDecimals {}));
+        }
         self.b20.name.write(init.name)?;
         self.b20.symbol.write(init.symbol)?;
         self.b20.supply_cap.write(init.supply_cap)?;
         self.asset.multiplier.write(init.multiplier)?;
+        self.asset.decimals.write(init.decimals)?;
         self.redeem.minimum_redeemable.write(init.minimum_redeemable)?;
         if !init.isin.is_empty() {
             self.asset.identifiers.at_mut(&String::from("ISIN")).write(init.isin)?;
@@ -99,6 +108,10 @@ impl<'a> B20AssetStorage<'a> {
 }
 
 impl B20AssetStorage<'_> {
+    /// Minimum allowed decimals for a B-20 asset token.
+    pub const MIN_DECIMALS: u8 = 6;
+    /// Maximum allowed decimals for a B-20 asset token.
+    pub const MAX_DECIMALS: u8 = 18;
     /// WAD precision for multiplier arithmetic: 1e18.
     pub const WAD: U256 = U256::from_limbs([1_000_000_000_000_000_000, 0, 0, 0]);
 
@@ -118,7 +131,7 @@ mod tests {
         __packing_b20_asset_extension_storage, __packing_b20_redeem_storage,
         B20AssetExtensionStorage, B20AssetInit, B20AssetStorage, B20RedeemStorage, slots,
     };
-    use crate::{AssetAccounting, B20CoreStorage, PolicyRegistryStorage, TokenAccounting};
+    use crate::{B20CoreStorage, PolicyRegistryStorage, AssetAccounting, TokenAccounting};
 
     const TOKEN: Address = address!("000000000000000000000000000000000000b021");
     const B20_ROOT: U256 =
@@ -134,7 +147,7 @@ mod tests {
     }
 
     #[test]
-    fn asset_namespaces_match_base_std_roots() {
+    fn security_namespaces_match_base_std_roots() {
         assert_eq!(<B20CoreStorage as StorableType>::STORAGE_NAMESPACE_ROOT, B20_ROOT);
         assert_eq!(
             <B20AssetExtensionStorage as StorableType>::STORAGE_NAMESPACE_ID,
@@ -151,12 +164,14 @@ mod tests {
 
     #[test]
     fn asset_extension_offsets_match_mock_storage() {
-        assert_eq!(__packing_b20_asset_extension_storage::MULTIPLIER_LOC.offset_slots, 0);
+        assert_eq!(__packing_b20_asset_extension_storage::DECIMALS_LOC.offset_slots, 0);
+        assert_eq!(__packing_b20_asset_extension_storage::DECIMALS_LOC.offset_bytes, 0);
+        assert_eq!(__packing_b20_asset_extension_storage::MULTIPLIER_LOC.offset_slots, 1);
         assert_eq!(
             __packing_b20_asset_extension_storage::USED_ANNOUNCEMENT_IDS_LOC.offset_slots,
-            1
+            2
         );
-        assert_eq!(__packing_b20_asset_extension_storage::IDENTIFIERS_LOC.offset_slots, 2);
+        assert_eq!(__packing_b20_asset_extension_storage::IDENTIFIERS_LOC.offset_slots, 3);
         assert_eq!(__packing_b20_redeem_storage::MINIMUM_REDEEMABLE_LOC.offset_slots, 0);
         assert_eq!(__packing_b20_redeem_storage::REDEEM_SENDER_POLICY_ID_LOC.offset_slots, 1);
         assert_eq!(__packing_b20_redeem_storage::REDEEM_SENDER_POLICY_ID_LOC.offset_bytes, 0);
@@ -194,7 +209,7 @@ mod tests {
     }
 
     #[test]
-    fn asset_string_mapping_slots_use_solidity_string_key_derivation() {
+    fn security_string_mapping_slots_use_solidity_string_key_derivation() {
         let (mut storage, _) = setup_storage();
         let announcement_id = String::from("2026-Q1-split");
         let identifier_type = String::from("ISIN");
@@ -204,7 +219,7 @@ mod tests {
             let mut token = B20AssetStorage::from_address(TOKEN, ctx);
             token.asset.used_announcement_ids.at_mut(&announcement_id).write(true).unwrap();
             token
-                .asset
+                .security
                 .identifiers
                 .at_mut(&identifier_type)
                 .write(identifier_value.clone())
@@ -269,6 +284,7 @@ mod tests {
                     multiplier: B20AssetStorage::WAD,
                     isin: String::new(),
                     minimum_redeemable: U256::ZERO,
+                    decimals: 6,
                 })
                 .unwrap();
 
@@ -285,5 +301,87 @@ mod tests {
         word[..value.len()].copy_from_slice(value.as_bytes());
         word[31] = (value.len() * 2) as u8;
         U256::from_be_bytes(word)
+    }
+
+    fn make_init(decimals: u8) -> B20AssetInit {
+        B20AssetInit {
+            name: String::from("Test"),
+            symbol: String::from("TST"),
+            supply_cap: U256::from(1_000_000u64),
+            multiplier: B20AssetStorage::WAD,
+            isin: String::new(),
+            minimum_redeemable: U256::ZERO,
+            decimals,
+        }
+    }
+
+    #[test]
+    fn decimals_6_stores_and_reads_back() {
+        let (mut storage, _) = setup_storage();
+
+        StorageCtx::enter(&mut storage, |ctx| {
+            let mut token = B20AssetStorage::from_address(TOKEN, ctx);
+            token.initialize(make_init(6)).unwrap();
+            assert_eq!(token.asset.decimals.read().unwrap(), 6);
+        });
+    }
+
+    #[test]
+    fn decimals_18_stores_and_reads_back() {
+        let (mut storage, _) = setup_storage();
+
+        StorageCtx::enter(&mut storage, |ctx| {
+            let mut token = B20AssetStorage::from_address(TOKEN, ctx);
+            token.initialize(make_init(18)).unwrap();
+            assert_eq!(token.asset.decimals.read().unwrap(), 18);
+        });
+    }
+
+    #[test]
+    fn decimals_5_reverts_with_invalid_decimals() {
+        let (mut storage, _) = setup_storage();
+
+        StorageCtx::enter(&mut storage, |ctx| {
+            let mut token = B20AssetStorage::from_address(TOKEN, ctx);
+            let err = token.initialize(make_init(5)).unwrap_err();
+            assert_eq!(
+                err,
+                base_precompile_storage::BasePrecompileError::revert(
+                    crate::IB20Asset::InvalidDecimals {}
+                )
+            );
+        });
+    }
+
+    #[test]
+    fn decimals_19_reverts_with_invalid_decimals() {
+        let (mut storage, _) = setup_storage();
+
+        StorageCtx::enter(&mut storage, |ctx| {
+            let mut token = B20AssetStorage::from_address(TOKEN, ctx);
+            let err = token.initialize(make_init(19)).unwrap_err();
+            assert_eq!(
+                err,
+                base_precompile_storage::BasePrecompileError::revert(
+                    crate::IB20Asset::InvalidDecimals {}
+                )
+            );
+        });
+    }
+
+    #[test]
+    fn decimals_uninitialized_slot_falls_back_to_six() {
+        let (mut storage, _) = setup_storage();
+
+        StorageCtx::enter(&mut storage, |ctx| {
+            // Token address exists but initialize() was never called — storage slot is 0.
+            let token = B20AssetStorage::from_address(TOKEN, ctx);
+            assert_eq!(token.asset.decimals.read().unwrap(), 0, "raw slot should be 0");
+            assert_eq!(
+                crate::AssetAccounting::decimals(&token).unwrap(),
+                6,
+                "fallback must return 6 for uninitialized tokens"
+            );
+        });
     }
 }

--- a/crates/common/precompiles/src/b20_factory/abi.rs
+++ b/crates/common/precompiles/src/b20_factory/abi.rs
@@ -29,6 +29,7 @@ sol! {
             address initialAdmin;
             string isin;
             uint256 minimumRedeemable;
+            uint8 decimals;
         }
 
         // ── Errors ───────────────────────────────────────────────────────────

--- a/crates/common/precompiles/src/b20_factory/storage.rs
+++ b/crates/common/precompiles/src/b20_factory/storage.rs
@@ -1187,7 +1187,7 @@ mod tests {
                 initialAdmin: Address::repeat_byte(0xAB),
                 isin: String::new(),
                 minimumRedeemable: U256::ZERO,
-            decimals: 6,
+                decimals: 6,
             }
             .abi_encode()
             .into(),

--- a/crates/common/precompiles/src/b20_factory/storage.rs
+++ b/crates/common/precompiles/src/b20_factory/storage.rs
@@ -268,6 +268,7 @@ impl TokenCreateParams {
                         supply_cap: DEFAULT_SUPPLY_CAP,
                         multiplier: INITIAL_MULTIPLIER,
                         isin: p.isin,
+                        decimals: p.decimals,
                         minimum_redeemable: p.minimumRedeemable,
                     },
                 })
@@ -356,6 +357,7 @@ mod tests {
             initialAdmin: Address::repeat_byte(0xAB),
             isin: String::new(),
             minimumRedeemable: U256::ZERO,
+            decimals: 6,
         }
     }
 
@@ -760,6 +762,7 @@ mod tests {
             initialAdmin: Address::repeat_byte(0xAB),
             isin: "US0000000000".to_string(),
             minimumRedeemable: U256::ONE,
+            decimals: 6,
         };
         let asset_call = IB20Factory::createB20Call {
             variant: IB20Factory::B20Variant::ASSET,
@@ -1119,6 +1122,7 @@ mod tests {
             initialAdmin: initial_admin,
             isin: "US0000000001".to_string(),
             minimumRedeemable: U256::ZERO,
+            decimals: 6,
         };
         let call = IB20Factory::createB20Call {
             variant: IB20Factory::B20Variant::ASSET,
@@ -1147,6 +1151,7 @@ mod tests {
             initialAdmin: Address::ZERO,
             isin: "US0000000002".to_string(),
             minimumRedeemable: U256::ZERO,
+            decimals: 6,
         };
         let call_no_admin = IB20Factory::createB20Call {
             variant: IB20Factory::B20Variant::ASSET,
@@ -1182,6 +1187,7 @@ mod tests {
                 initialAdmin: Address::repeat_byte(0xAB),
                 isin: String::new(),
                 minimumRedeemable: U256::ZERO,
+            decimals: 6,
             }
             .abi_encode()
             .into(),

--- a/crates/common/precompiles/src/common/test_utils.rs
+++ b/crates/common/precompiles/src/common/test_utils.rs
@@ -429,4 +429,8 @@ impl AssetAccounting for InMemoryTokenAccounting {
         self.announcement_ids_used.insert(id.to_owned());
         Ok(())
     }
+
+    fn decimals(&self) -> Result<u8> {
+        Ok(if self.decimals == 0 { 6 } else { self.decimals })
+    }
 }

--- a/etc/systems/benches/b20_zk_proving.rs
+++ b/etc/systems/benches/b20_zk_proving.rs
@@ -14,7 +14,8 @@ use alloy_primitives::{Address, B256, U256};
 use alloy_signer_local::PrivateKeySigner;
 use alloy_sol_types::{SolCall, SolInterface};
 use base_common_precompiles::{
-    ActivationFeature, ActivationRegistryStorage, B20TokenRole, IActivationRegistry, IB20,
+    ActivationFeature, ActivationRegistryStorage, B20TokenRole, B20Variant, IActivationRegistry,
+    IB20,
 };
 use base_system_tests::{ANVIL_ACCOUNT_5, ANVIL_ACCOUNT_6, ANVIL_ACCOUNT_7, B20PrecompileClient};
 use clap::Parser;
@@ -199,7 +200,7 @@ impl B20ZkProvingBench {
             admin,
         );
 
-        client.create_token(params, salt).await
+        client.create_token(B20Variant::Asset, params, salt).await
     }
 
     /// Activates `feature` if it is not already active.

--- a/etc/systems/src/b20.rs
+++ b/etc/systems/src/b20.rs
@@ -117,6 +117,7 @@ impl<'a> B20PrecompileClient<'a> {
                 initialAdmin: initial_admin,
                 isin: String::new(),
                 minimumRedeemable: U256::ZERO,
+                decimals: 6,
             },
             initial_supply,
             initial_supply_recipient,
@@ -125,9 +126,14 @@ impl<'a> B20PrecompileClient<'a> {
         }
     }
 
-    /// Creates a B-20 asset token through the factory and returns the deterministic token address.
-    pub async fn create_token(&self, params: B20CreateConfig, salt: B256) -> Result<Address> {
-        let token = self.predict_token_address(B20Variant::Asset, salt);
+    /// Creates a B-20 token through the factory and returns the deterministic token address.
+    pub async fn create_token(
+        &self,
+        variant: B20Variant,
+        params: B20CreateConfig,
+        salt: B256,
+    ) -> Result<Address> {
+        let token = self.predict_token_address(variant, salt);
         let mut init_calls = Vec::new();
         if params.initial_supply > U256::ZERO {
             init_calls.push(
@@ -150,7 +156,7 @@ impl<'a> B20PrecompileClient<'a> {
             );
         }
         let call = IB20Factory::createB20Call {
-            variant: B20Variant::Asset.abi(),
+            variant: variant.abi(),
             salt,
             params: params.create.abi_encode().into(),
             initCalls: init_calls,

--- a/etc/systems/tests/b20_precompile.rs
+++ b/etc/systems/tests/b20_precompile.rs
@@ -53,7 +53,7 @@ async fn test_b20_factory_create_and_transfer_via_rpc() -> Result<()> {
         admin.address(),
     );
 
-    let token = b20.create_token(params, salt).await?;
+    let token = b20.create_token(B20Variant::Asset, params, salt).await?;
     b20.wait_for_token_code(token, common::TX_RECEIPT_TIMEOUT, common::BLOCK_POLL_INTERVAL).await?;
 
     assert_eq!(b20.variant_of(token).await?, B20Variant::Asset);
@@ -90,7 +90,7 @@ async fn test_b20_token_metadata() -> Result<()> {
         admin.address(),
     );
 
-    let token = b20.create_token(params, salt).await?;
+    let token = b20.create_token(B20Variant::Asset, params, salt).await?;
     b20.wait_for_token_code(token, common::TX_RECEIPT_TIMEOUT, common::BLOCK_POLL_INTERVAL).await?;
 
     assert_eq!(b20.name(token).await?, "Metadata Token");
@@ -123,7 +123,7 @@ async fn test_b20_approve_and_transfer_from() -> Result<()> {
         U256::from(INITIAL_SUPPLY),
         admin.address(),
     );
-    let token = b20_admin.create_token(params, salt).await?;
+    let token = b20_admin.create_token(B20Variant::Asset, params, salt).await?;
     b20_admin
         .wait_for_token_code(token, common::TX_RECEIPT_TIMEOUT, common::BLOCK_POLL_INTERVAL)
         .await?;
@@ -168,7 +168,7 @@ async fn test_b20_mint_and_burn() -> Result<()> {
         U256::from(INITIAL_SUPPLY),
         admin.address(),
     );
-    let token = b20.create_token(params, salt).await?;
+    let token = b20.create_token(B20Variant::Asset, params, salt).await?;
     b20.wait_for_token_code(token, common::TX_RECEIPT_TIMEOUT, common::BLOCK_POLL_INTERVAL).await?;
 
     let supply_before = b20.total_supply(token).await?;
@@ -238,7 +238,7 @@ async fn test_b20_transfer_with_memo() -> Result<()> {
         U256::from(INITIAL_SUPPLY),
         admin.address(),
     );
-    let token = b20.create_token(params, salt).await?;
+    let token = b20.create_token(B20Variant::Asset, params, salt).await?;
     b20.wait_for_token_code(token, common::TX_RECEIPT_TIMEOUT, common::BLOCK_POLL_INTERVAL).await?;
 
     let memo = B256::repeat_byte(0xde);
@@ -269,7 +269,7 @@ async fn test_b20_supply_cap() -> Result<()> {
     );
     params.supply_cap = U256::from(INITIAL_SUPPLY_CAP);
 
-    let token = b20.create_token(params, salt).await?;
+    let token = b20.create_token(B20Variant::Asset, params, salt).await?;
     b20.wait_for_token_code(token, common::TX_RECEIPT_TIMEOUT, common::BLOCK_POLL_INTERVAL).await?;
 
     assert_eq!(b20.supply_cap(token).await?, U256::from(INITIAL_SUPPLY_CAP));
@@ -319,7 +319,7 @@ async fn test_b20_metadata_updates() -> Result<()> {
         U256::from(INITIAL_SUPPLY),
         admin.address(),
     );
-    let token = b20.create_token(params, salt).await?;
+    let token = b20.create_token(B20Variant::Asset, params, salt).await?;
     b20.wait_for_token_code(token, common::TX_RECEIPT_TIMEOUT, common::BLOCK_POLL_INTERVAL).await?;
 
     b20.send_call(
@@ -357,7 +357,7 @@ async fn test_b20_pause_and_unpause() -> Result<()> {
         U256::from(INITIAL_SUPPLY),
         admin.address(),
     );
-    let token = b20.create_token(params, salt).await?;
+    let token = b20.create_token(B20Variant::Asset, params, salt).await?;
     b20.wait_for_token_code(token, common::TX_RECEIPT_TIMEOUT, common::BLOCK_POLL_INTERVAL).await?;
 
     // Transfer succeeds before pause.
@@ -423,7 +423,7 @@ async fn test_b20_factory_predict_and_is_b20() -> Result<()> {
         b20.predict_token_address_rpc(admin.address(), B20Variant::Asset, salt).await?;
     assert_eq!(local_prediction, rpc_prediction, "local and RPC predictions should match");
 
-    let token = b20.create_token(params, salt).await?;
+    let token = b20.create_token(B20Variant::Asset, params, salt).await?;
     b20.wait_for_token_code(token, common::TX_RECEIPT_TIMEOUT, common::BLOCK_POLL_INTERVAL).await?;
 
     assert_eq!(token, rpc_prediction, "created token address should match prediction");
@@ -455,7 +455,7 @@ async fn test_b20_create_token_duplicate_reverts() -> Result<()> {
         admin.address(),
     );
 
-    let token = b20.create_token(params.clone(), salt).await?;
+    let token = b20.create_token(B20Variant::Asset, params.clone(), salt).await?;
     b20.wait_for_token_code(token, common::TX_RECEIPT_TIMEOUT, common::BLOCK_POLL_INTERVAL).await?;
 
     let succeeded = b20

--- a/etc/systems/tests/policy_transfer.rs
+++ b/etc/systems/tests/policy_transfer.rs
@@ -14,7 +14,7 @@ use alloy_signer_local::PrivateKeySigner;
 use alloy_sol_types::SolCall;
 use base_common_network::Base;
 use base_common_precompiles::{
-    ActivationFeature, B20PolicyType, IB20, IPolicyRegistry, PolicyRegistryStorage,
+    ActivationFeature, B20PolicyType, B20Variant, IB20, IPolicyRegistry, PolicyRegistryStorage,
 };
 use base_system_tests::{ANVIL_ACCOUNT_5, ANVIL_ACCOUNT_6, ANVIL_ACCOUNT_7, B20PrecompileClient};
 use eyre::{Result, WrapErr};
@@ -86,7 +86,7 @@ async fn create_token(
 ) -> Result<Address> {
     let params =
         B20PrecompileClient::token_params(name, symbol, admin, U256::from(INITIAL_SUPPLY), admin);
-    let token = client.create_token(params, salt).await?;
+    let token = client.create_token(B20Variant::Asset, params, salt).await?;
     client
         .wait_for_token_code(token, common::TX_RECEIPT_TIMEOUT, common::BLOCK_POLL_INTERVAL)
         .await?;


### PR DESCRIPTION
[BOP-241](https://linear.app/coinbase/issue/BOP-241/basebase-add-custom-decimals-storage-to-b20asset)

## Motivation

B20Asset tokens previously had a fixed decimal precision derived from the token address (always 6 for asset tokens). Tokens that need to represent assets with different decimal precision (e.g. USDC at 6, a bond at 8, a custom instrument at 18) had no way to express this. This PR stores the decimal value on-chain at creation time and validates it is in the allowed range.

## What changed

- `b20_asset/abi.rs`: added `error InvalidDecimals()` and `uint8 decimals` to `B20AssetCreateParams`
- `b20_asset/storage.rs`: added `decimals: u8` field to `B20AssetExtensionStorage` (slot 3) and `B20AssetInit`; `initialize()` validates `decimals` is in `[6, 18]` and reverts `InvalidDecimals` otherwise
- `b20_asset/accounting.rs`: added `fn decimals(&self) -> Result<u8>` to `SecurityAccounting` trait
- `precompile-macros/src/accounting.rs`: `expand_security` now generates a storage-backed `SecurityAccounting::decimals()` impl that falls back to `6` for pre-existing tokens with uninitialized storage
- `b20_asset/dispatch.rs`: `decimals()` reads from storage via `SecurityAccounting::decimals()` instead of returning the address-derived default
- `b20_factory/storage.rs`: passes `decimals` from create params into `B20AssetInit` and emits it in the `B20Created` event

## What was considered

Keeping decimals address-derived (always 6) was the status quo, but it prevents representing assets with different precision. A storage field allows per-token configuration while the `[6, 18]` range constraint keeps it compatible with the broader ERC-20 ecosystem. The fallback of `0 -> 6` for uninitialized slots provides backwards compatibility for any tokens created before this change.