### PR TITLE
feat(b20): remove isin and minimum_redeemable from B20 Asset

### DIFF
--- a/actions/harness/tests/beryl/env.rs
+++ b/actions/harness/tests/beryl/env.rs
@@ -93,12 +93,6 @@ impl BerylTestEnv {
     /// Symbol for the security B-20 token variant.
     pub(crate) const B20_SECURITY_SYMBOL: &str = "ASEC";
 
-    /// ISIN stored on the security B-20 token at creation.
-    pub(crate) const B20_SECURITY_ISIN: &str = "US0000000001";
-
-    /// Initial minimum redeemable share amount for the security B-20 token.
-    pub(crate) const B20_SECURITY_MINIMUM_REDEEMABLE: u64 = 10;
-
     /// Initial B-20 supply minted to Alice.
     pub(crate) const B20_INITIAL_SUPPLY: u64 = 1_000_000;
 
@@ -629,8 +623,6 @@ impl BerylTestEnv {
             name: Self::B20_NAME.to_string(),
             symbol: Self::B20_SYMBOL.to_string(),
             initialAdmin: Self::alice(),
-            isin: String::new(),
-            minimumRedeemable: U256::ZERO,
         }
     }
 
@@ -650,8 +642,6 @@ impl BerylTestEnv {
             name: Self::B20_SECURITY_NAME.to_string(),
             symbol: Self::B20_SECURITY_SYMBOL.to_string(),
             initialAdmin: Self::alice(),
-            isin: Self::B20_SECURITY_ISIN.to_string(),
-            minimumRedeemable: U256::from(Self::B20_SECURITY_MINIMUM_REDEEMABLE),
         }
     }
 

--- a/actions/harness/tests/beryl/policy_transfer.rs
+++ b/actions/harness/tests/beryl/policy_transfer.rs
@@ -422,8 +422,6 @@ impl PolicyTransferScenario {
             name: "Policy B20".to_string(),
             symbol: "PB20".to_string(),
             initialAdmin: BerylTestEnv::alice(),
-            isin: String::new(),
-            minimumRedeemable: U256::ZERO,
         }
     }
 }

--- a/actions/harness/tests/beryl/security.rs
+++ b/actions/harness/tests/beryl/security.rs
@@ -68,12 +68,6 @@ async fn security_creation_initializes_identifiers_and_factory_views() {
                     BerylTestEnv::B20_SECURITY_SYMBOL,
                 ),
                 StaticcallCase::string("contractURI", IB20::contractURICall {}.abi_encode(), ""),
-                StaticcallCase::string(
-                    "extraMetadata(ISIN)",
-                    IB20Asset::extraMetadataCall { identifierType: "ISIN".to_string() }
-                        .abi_encode(),
-                    BerylTestEnv::B20_SECURITY_ISIN,
-                ),
                 StaticcallCase::word(
                     "decimals",
                     IB20::decimalsCall {}.abi_encode(),

--- a/crates/common/precompile-macros/src/accounting.rs
+++ b/crates/common/precompile-macros/src/accounting.rs
@@ -353,19 +353,6 @@ fn expand_asset(input: DeriveInput) -> syn::Result<TokenStream> {
                 }
             }
 
-            fn minimum_redeemable(
-                &self,
-            ) -> ::base_precompile_storage::Result<::alloy_primitives::U256> {
-                self.redeem.minimum_redeemable()
-            }
-
-            fn set_minimum_redeemable(
-                &mut self,
-                minimum: ::alloy_primitives::U256,
-            ) -> ::base_precompile_storage::Result<()> {
-                self.redeem.set_minimum_redeemable(minimum)
-            }
-
             fn is_announcement_id_used(
                 &self,
                 id: &str,

--- a/crates/common/precompiles/benches/base_precompiles.rs
+++ b/crates/common/precompiles/benches/base_precompiles.rs
@@ -32,8 +32,6 @@ impl BaseTokenBenchSetup {
             name: name.to_string(),
             symbol: symbol.to_string(),
             initialAdmin: Self::admin(),
-            isin: String::new(),
-            minimumRedeemable: U256::ZERO,
         }
     }
 

--- a/crates/common/precompiles/src/b20_asset/abi.rs
+++ b/crates/common/precompiles/src/b20_asset/abi.rs
@@ -22,9 +22,6 @@ sol! {
         /// A batched function was called with empty arrays.
         error EmptyBatch();
 
-        /// `redeem`/`redeemWithMemo` was called with a scaled amount below the floor, or zero.
-        error BelowMinimumRedeemable(uint256 scaledAmount, uint256 minimum);
-
         /// An `internalCalls` entry tried to invoke `announce` itself.
         error AnnouncementInProgress();
 
@@ -38,9 +35,6 @@ sol! {
 
         /// Emitted by `redeem`/`redeemWithMemo`. Includes the active multiplier at redemption time.
         event Redeemed(address indexed from, uint256 amt, uint256 multiplier);
-
-        /// Emitted by `updateMinimumRedeemable`.
-        event MinimumRedeemableUpdated(address indexed caller, uint256 newMinimumRedeemable);
 
         /// Emitted by `updateMultiplier`.
         event MultiplierUpdated(uint256 multiplier);
@@ -102,17 +96,11 @@ sol! {
 
         // ── Redemption ────────────────────────────────────────────────────────
 
-        /// Burns `amount` from caller with a multiplier-scaled minimum floor check.
+        /// Burns `amount` from caller.
         function redeem(uint256 amount) external;
 
         /// Same as `redeem`, followed by a `Memo` event.
         function redeemWithMemo(uint256 amount, bytes32 memo) external;
-
-        /// Sets the minimum-redeemable threshold in scaled units. Requires `DEFAULT_ADMIN_ROLE`.
-        function updateMinimumRedeemable(uint256 newMinimumRedeemable) external;
-
-        /// Returns the minimum-redeemable threshold in scaled units.
-        function minimumRedeemable() external view returns (uint256);
 
         // ── Asset metadata ──────────────────────────────────────────────────
 
@@ -144,8 +132,6 @@ impl IB20Asset::IB20AssetCalls {
             Self::batchMint(_) => "precompile-b20-asset-batchMint",
             Self::redeem(_) => "precompile-b20-asset-redeem",
             Self::redeemWithMemo(_) => "precompile-b20-asset-redeemWithMemo",
-            Self::updateMinimumRedeemable(_) => "precompile-b20-asset-updateMinimumRedeemable",
-            Self::minimumRedeemable(_) => "precompile-b20-asset-minimumRedeemable",
             Self::extraMetadata(_) => "precompile-b20-asset-extraMetadata",
             Self::updateExtraMetadata(_) => "precompile-b20-asset-updateExtraMetadata",
         }
@@ -154,8 +140,8 @@ impl IB20Asset::IB20AssetCalls {
 
 #[cfg(test)]
 mod tests {
-    use alloy_primitives::{U256, b256, keccak256};
-    use alloy_sol_types::{SolCall, SolEvent};
+    use alloy_primitives::U256;
+    use alloy_sol_types::SolCall;
 
     use crate::IB20Asset;
 
@@ -164,25 +150,7 @@ mod tests {
         assert_eq!(IB20Asset::REDEEM_SENDER_POLICYCall::SELECTOR, [0x1c, 0x6f, 0x9d, 0x42]);
     }
 
-    #[test]
-    fn minimum_redeemable_updated_topic_matches_solidity_interface() {
-        assert_eq!(
-            IB20Asset::MinimumRedeemableUpdated::SIGNATURE_HASH,
-            b256!("7fdd6ea6dad98bfcd2c5ec538e748a5e8ecc40d0fc824f55dfc7397fe78a183b")
-        );
-        assert_eq!(
-            IB20Asset::MinimumRedeemableUpdated::SIGNATURE_HASH,
-            keccak256("MinimumRedeemableUpdated(address,uint256)")
-        );
-    }
-
-    #[test]
     fn asset_call_labels_are_stable() {
-        assert_eq!(
-            IB20Asset::IB20AssetCalls::minimumRedeemable(IB20Asset::minimumRedeemableCall {},)
-                .as_label(),
-            "precompile-b20-asset-minimumRedeemable"
-        );
         assert_eq!(
             IB20Asset::IB20AssetCalls::redeem(IB20Asset::redeemCall { amount: U256::ZERO })
                 .as_label(),

--- a/crates/common/precompiles/src/b20_asset/accounting.rs
+++ b/crates/common/precompiles/src/b20_asset/accounting.rs
@@ -22,11 +22,6 @@ pub trait AssetAccounting: TokenAccounting {
     /// Writes (or removes when `value` is empty) the asset metadata for `identifier_type`.
     fn set_extra_metadata_value(&mut self, identifier_type: &str, value: String) -> Result<()>;
 
-    /// Returns the minimum amount that may be redeemed in a single call.
-    fn minimum_redeemable(&self) -> Result<U256>;
-    /// Overwrites the minimum redeemable amount.
-    fn set_minimum_redeemable(&mut self, minimum: U256) -> Result<()>;
-
     /// Returns `true` if `id` has been consumed by `announce`.
     fn is_announcement_id_used(&self, id: &str) -> Result<bool>;
     /// Marks `id` as consumed. Called exactly once per announcement id.

--- a/crates/common/precompiles/src/b20_asset/dispatch.rs
+++ b/crates/common/precompiles/src/b20_asset/dispatch.rs
@@ -589,6 +589,7 @@ mod tests {
         assert_eq!(token.accounting().events.len(), 2); // Transfer(ALICE, 0x0, 0) + Redeemed(ALICE, 0, multiplier)
     }
 
+    #[test]
     fn asset_redeem_rejects_when_redeem_feature_paused() {
         let mut token = make_token();
         token.accounting_mut().paused = B20PausableFeature::mask(IB20::PausableFeature::REDEEM);

--- a/crates/common/precompiles/src/b20_asset/dispatch.rs
+++ b/crates/common/precompiles/src/b20_asset/dispatch.rs
@@ -384,13 +384,6 @@ impl<S: AssetAccounting, P: Policy> B20AssetToken<S, P> {
                 Bytes::new()
             }
 
-            // --- Minimum redeemable (asset version, in scaled units) ---
-            SC::minimumRedeemable(_) => self.accounting().minimum_redeemable()?.abi_encode().into(),
-            SC::updateMinimumRedeemable(c) => {
-                self.update_minimum_redeemable(caller, c.newMinimumRedeemable, privileged)?;
-                Bytes::new()
-            }
-
             // --- Asset metadata mutations ---
             SC::updateExtraMetadata(c) => {
                 self.update_extra_metadata(caller, c.identifierType, c.value, privileged)?;
@@ -575,7 +568,6 @@ mod tests {
         let mut token = make_token();
         token.accounting_mut().balances.insert(ALICE, U256::from(100u64));
         token.accounting_mut().total_supply = U256::from(100u64);
-        token.accounting_mut().minimum_redeemable = U256::from(1u64);
 
         token.asset_redeem(ALICE, U256::from(50u64)).unwrap();
 
@@ -589,7 +581,6 @@ mod tests {
         let mut token = make_token();
         token.accounting_mut().balances.insert(ALICE, U256::from(100u64));
         token.accounting_mut().total_supply = U256::from(100u64);
-        token.accounting_mut().minimum_redeemable = U256::from(1u64);
 
         token.asset_redeem(ALICE, U256::ZERO).unwrap();
 
@@ -598,29 +589,6 @@ mod tests {
         assert_eq!(token.accounting().events.len(), 2); // Transfer(ALICE, 0x0, 0) + Redeemed(ALICE, 0, multiplier)
     }
 
-    #[test]
-    fn asset_redeem_rejects_below_minimum_scaled_amount() {
-        let mut token = make_token();
-        token.accounting_mut().balances.insert(ALICE, U256::from(100u64));
-        token.accounting_mut().total_supply = U256::from(100u64);
-        token.accounting_mut().minimum_redeemable = U256::from(10u64);
-
-        // 5 tokens * 1e18 multiplier / 1e18 = 5 scaled < 10 minimum
-        assert!(token.asset_redeem(ALICE, U256::from(5u64)).is_err());
-    }
-
-    #[test]
-    fn asset_redeem_rejects_zero_scaled_amount() {
-        let mut token = make_token();
-        token.accounting_mut().multiplier = U256::ONE;
-        token.accounting_mut().balances.insert(ALICE, U256::from(100u64));
-        token.accounting_mut().total_supply = U256::from(100u64);
-
-        // 1 token-wei * 1 / WAD rounds down to 0 scaled units, which is always rejected.
-        assert!(token.asset_redeem(ALICE, U256::ONE).is_err());
-    }
-
-    #[test]
     fn asset_redeem_rejects_when_redeem_feature_paused() {
         let mut token = make_token();
         token.accounting_mut().paused = B20PausableFeature::mask(IB20::PausableFeature::REDEEM);
@@ -731,8 +699,7 @@ mod tests {
         let mut token = make_token();
         token.accounting_mut().balances.insert(ALICE, U256::from(10u64));
         token.accounting_mut().total_supply = U256::from(10u64);
-        token.accounting_mut().minimum_redeemable = U256::from(1u64);
-        // amount=100 > balance=10 → InsufficientBalance after the scaled-floor check passes
+        // amount=100 > balance=10 → InsufficientBalance
         assert!(token.asset_redeem(ALICE, U256::from(100u64)).is_err());
         // no state mutation on failure
         assert_eq!(token.accounting().balance_of(ALICE).unwrap(), U256::from(10u64));
@@ -756,29 +723,11 @@ mod tests {
     }
 
     #[test]
-    fn asset_redeem_at_exact_minimum_succeeds() {
-        let mut token = make_token(); // 1:1 multiplier
-        token.accounting_mut().balances.insert(ALICE, U256::from(50u64));
-        token.accounting_mut().total_supply = U256::from(50u64);
-        // 5 tokens * WAD / WAD = 5 scaled == minimum → boundary must be accepted
-        token.accounting_mut().minimum_redeemable = U256::from(5u64);
-        token.asset_redeem(ALICE, U256::from(5u64)).unwrap();
-        assert_eq!(token.accounting().balance_of(ALICE).unwrap(), U256::from(45u64));
-        assert_eq!(token.accounting().total_supply().unwrap(), U256::from(45u64));
-    }
-
-    #[test]
-    fn asset_redeem_with_non_unit_multiplier_applies_correct_scaled_math() {
+    fn asset_redeem_with_non_unit_multiplier_burns_raw_amount() {
         let mut token = make_token();
-        // 2x multiplier: 1 token scales to 2 units
         token.accounting_mut().multiplier = B20AssetStorage::WAD * U256::from(2u64);
         token.accounting_mut().balances.insert(ALICE, U256::from(100u64));
         token.accounting_mut().total_supply = U256::from(100u64);
-        // minimum = 10 scaled → need at least 5 tokens
-        token.accounting_mut().minimum_redeemable = U256::from(10u64);
-        // 4 tokens → 8 scaled < 10 → BelowMinimumRedeemable
-        assert!(token.asset_redeem(ALICE, U256::from(4u64)).is_err());
-        // 5 tokens → 10 scaled == minimum → accepted
         token.asset_redeem(ALICE, U256::from(5u64)).unwrap();
         assert_eq!(token.accounting().balance_of(ALICE).unwrap(), U256::from(95u64));
     }
@@ -788,7 +737,6 @@ mod tests {
         let mut token = make_token();
         token.accounting_mut().balances.insert(ALICE, U256::from(100u64));
         token.accounting_mut().total_supply = U256::from(100u64);
-        token.accounting_mut().minimum_redeemable = U256::from(1u64);
         token.asset_redeem(ALICE, U256::from(10u64)).unwrap();
         // "Emits Transfer(caller, address(0), amount) followed by Redeemed(caller, amount, multiplier)"
         assert_eq!(token.accounting().events.len(), 2);
@@ -801,7 +749,6 @@ mod tests {
         let memo = B256::repeat_byte(0x42);
         token.accounting_mut().balances.insert(ALICE, U256::from(100u64));
         token.accounting_mut().total_supply = U256::from(100u64);
-        token.accounting_mut().minimum_redeemable = U256::from(1u64);
 
         token.asset_redeem_with_memo(ALICE, amount, memo).unwrap();
 
@@ -857,7 +804,6 @@ mod tests {
             );
             token.accounting_mut().set_balance(ALICE, U256::from(100u64)).unwrap();
             token.accounting_mut().set_total_supply(U256::from(100u64)).unwrap();
-            token.accounting_mut().set_minimum_redeemable(U256::from(10u64)).unwrap();
 
             assert_eq!(token.accounting().multiplier().unwrap(), B20AssetStorage::WAD);
             token.asset_redeem(ALICE, U256::from(10u64)).unwrap();
@@ -899,16 +845,6 @@ mod tests {
         assert_eq!(token.accounting().extra_metadata("FIGI").unwrap(), "");
     }
 
-    // --- minimumRedeemable / updateMinimumRedeemable ---
-
-    #[test]
-    fn minimum_redeemable_persists() {
-        let mut token = make_token();
-        let floor = U256::from(42u64);
-        token.accounting_mut().set_minimum_redeemable(floor).unwrap();
-        assert_eq!(token.accounting().minimum_redeemable().unwrap(), floor);
-    }
-
     // --- isAnnouncementIdUsed: fresh state ---
 
     #[test]
@@ -930,25 +866,6 @@ mod tests {
 
         assert_eq!(
             token.to_scaled_balance(U256::from(2u64)).unwrap_err(),
-            BasePrecompileError::under_overflow()
-        );
-    }
-
-    /// `asset_redeem` must return an arithmetic overflow panic rather than
-    /// silently saturating when `amount * multiplier` exceeds `U256::MAX`.
-    #[test]
-    fn asset_redeem_overflows_when_product_exceeds_u256_max() {
-        let mut accounting = InMemoryTokenAccounting::new(TOKEN);
-        // Any amount > 1 overflows when multiplied by this multiplier.
-        accounting.multiplier = U256::MAX / U256::from(2u64) + U256::ONE;
-        accounting.balances.insert(ALICE, U256::from(2u64));
-        accounting.total_supply = U256::from(2u64);
-        // Open redemption so the policy gate does not block the call before the overflow.
-        accounting.policy_ids.insert(REDEEM_SENDER_POLICY, PolicyRegistryStorage::ALWAYS_ALLOW_ID);
-        let mut token = TestAssetToken::with_storage_and_policy(accounting, InMemoryPolicy::new());
-
-        assert_eq!(
-            token.asset_redeem(ALICE, U256::from(2u64)).unwrap_err(),
             BasePrecompileError::under_overflow()
         );
     }

--- a/crates/common/precompiles/src/b20_asset/storage.rs
+++ b/crates/common/precompiles/src/b20_asset/storage.rs
@@ -2,7 +2,7 @@
 
 use alloc::string::String;
 
-use alloy_primitives::{Address, B256, FixedBytes, U256, b256};
+use alloy_primitives::{Address, B256, U256, b256};
 use base_precompile_macros::{AssetAccounting, Storable, TokenAccounting, contract};
 use base_precompile_storage::{Handler, Mapping, Result, StorageCtx};
 
@@ -26,16 +26,10 @@ pub struct B20AssetExtensionStorage {
 #[derive(Debug, Clone, Storable)]
 #[namespace("base.b20.redeem")]
 pub struct B20RedeemStorage {
-    /// Minimum scaled amount required for a redeem operation.
+    /// Policy ID controlling who can redeem tokens.
     #[accessor]
     #[mutator]
-    pub minimum_redeemable: U256, // offset 0
-    /// Redeem sender policy ID.
-    #[accessor]
-    #[mutator]
-    pub redeem_sender_policy_id: u64, // slot 1, offset 0
-    /// Reserved padding to fill the remainder of slot 1.
-    pub redeem_reserved: FixedBytes<24>, // slot 1, offset 8 (fills remaining 24 bytes)
+    pub redeem_sender_policy_id: u64,
 }
 
 /// EVM-backed storage for an asset B-20 token.
@@ -60,10 +54,6 @@ pub struct B20AssetInit {
     pub supply_cap: U256,
     /// Initial multiplier at WAD precision.
     pub multiplier: U256,
-    /// ISIN identifier stored under the `"ISIN"` key.
-    pub isin: String,
-    /// Minimum redeemable amount; `0` allows any non-zero redemption.
-    pub minimum_redeemable: U256,
 }
 
 impl<'a> B20AssetStorage<'a> {
@@ -79,9 +69,6 @@ impl<'a> B20AssetStorage<'a> {
 
     /// Writes all creation-time fields atomically.
     ///
-    /// `isin` may be empty; when non-empty it is stored under the `"ISIN"` key
-    /// in the asset metadata mapping.
-    ///
     /// `REDEEM_SENDER_POLICY` is initialised to `ALWAYS_BLOCK_ID` so redemption
     /// is closed by default; issuers must explicitly open it after creation.
     pub fn initialize(&mut self, init: B20AssetInit) -> Result<()> {
@@ -89,10 +76,6 @@ impl<'a> B20AssetStorage<'a> {
         self.b20.symbol.write(init.symbol)?;
         self.b20.supply_cap.write(init.supply_cap)?;
         self.asset.multiplier.write(init.multiplier)?;
-        self.redeem.minimum_redeemable.write(init.minimum_redeemable)?;
-        if !init.isin.is_empty() {
-            self.asset.identifiers.at_mut(&String::from("ISIN")).write(init.isin)?;
-        }
         self.write_redeem_policy_ids_default()?;
         Ok(())
     }
@@ -157,8 +140,7 @@ mod tests {
             1
         );
         assert_eq!(__packing_b20_asset_extension_storage::IDENTIFIERS_LOC.offset_slots, 2);
-        assert_eq!(__packing_b20_redeem_storage::MINIMUM_REDEEMABLE_LOC.offset_slots, 0);
-        assert_eq!(__packing_b20_redeem_storage::REDEEM_SENDER_POLICY_ID_LOC.offset_slots, 1);
+        assert_eq!(__packing_b20_redeem_storage::REDEEM_SENDER_POLICY_ID_LOC.offset_slots, 0);
         assert_eq!(__packing_b20_redeem_storage::REDEEM_SENDER_POLICY_ID_LOC.offset_bytes, 0);
     }
 
@@ -209,7 +191,6 @@ mod tests {
                 .at_mut(&identifier_type)
                 .write(identifier_value.clone())
                 .unwrap();
-            token.redeem.minimum_redeemable.write(U256::from(10u64)).unwrap();
 
             let announcement_slot = ASSET_ROOT
                 + U256::from(
@@ -217,8 +198,6 @@ mod tests {
                 );
             let identifiers_slot = ASSET_ROOT
                 + U256::from(__packing_b20_asset_extension_storage::IDENTIFIERS_LOC.offset_slots);
-            let minimum_slot = REDEEM_ROOT
-                + U256::from(__packing_b20_redeem_storage::MINIMUM_REDEEMABLE_LOC.offset_slots);
 
             assert_eq!(
                 ctx.sload(TOKEN, announcement_id.mapping_slot(announcement_slot)).unwrap(),
@@ -228,7 +207,6 @@ mod tests {
                 ctx.sload(TOKEN, identifier_type.mapping_slot(identifiers_slot)).unwrap(),
                 short_string_word(&identifier_value)
             );
-            assert_eq!(ctx.sload(TOKEN, minimum_slot).unwrap(), U256::from(10u64));
         });
     }
 
@@ -267,8 +245,6 @@ mod tests {
                     symbol: String::from("TST"),
                     supply_cap: U256::from(1_000_000u64),
                     multiplier: B20AssetStorage::WAD,
-                    isin: String::new(),
-                    minimum_redeemable: U256::ZERO,
                 })
                 .unwrap();
 

--- a/crates/common/precompiles/src/b20_asset/token.rs
+++ b/crates/common/precompiles/src/b20_asset/token.rs
@@ -214,23 +214,6 @@ impl<S: AssetAccounting, P: Policy> B20AssetToken<S, P> {
         )
     }
 
-    // --- Minimum Redeemable Operations ---
-
-    /// Updates the minimum redeemable amount.
-    pub fn update_minimum_redeemable(
-        &mut self,
-        caller: Address,
-        new_minimum: U256,
-        privileged: bool,
-    ) -> Result<()> {
-        self.ensure_default_admin(caller, privileged)?;
-        self.accounting_mut().set_minimum_redeemable(new_minimum)?;
-        self.accounting_mut().emit_event(
-            IB20Asset::MinimumRedeemableUpdated { caller, newMinimumRedeemable: new_minimum }
-                .encode_log_data(),
-        )
-    }
-
     // --- Asset Metadata Operations ---
 
     /// Updates an asset metadata value.
@@ -272,23 +255,11 @@ impl<S: AssetAccounting, P: Policy> B20AssetToken<S, P> {
         self.emit_redeemed(caller, amount, multiplier)
     }
 
-    /// Performs the shared asset redeem burn and returns the multiplier used for the floor check.
+    /// Performs the shared asset redeem burn and returns the multiplier.
     fn asset_redeem_burn(&mut self, caller: Address, amount: U256) -> Result<U256> {
         B20Guards::ensure_not_paused::<Self>(self, IB20::PausableFeature::REDEEM)?;
         B20Guards::ensure_policy::<Self>(self, Self::REDEEM_SENDER_POLICY, caller)?;
         let multiplier = self.accounting().multiplier()?;
-        if !amount.is_zero() {
-            let scaled =
-                amount.checked_mul(multiplier).ok_or_else(BasePrecompileError::under_overflow)?
-                    / B20AssetStorage::WAD;
-            let minimum = self.accounting().minimum_redeemable()?;
-            if scaled == U256::ZERO || scaled < minimum {
-                return Err(BasePrecompileError::revert(IB20Asset::BelowMinimumRedeemable {
-                    scaledAmount: scaled,
-                    minimum,
-                }));
-            }
-        }
         let balance = self.accounting().balance_of(caller)?;
         if balance < amount {
             return Err(BasePrecompileError::revert(IB20::InsufficientBalance {
@@ -470,7 +441,6 @@ mod tests {
                     TestAssetToken::REDEEM_SENDER_POLICY,
                     PolicyRegistryStorage::ALWAYS_ALLOW_ID,
                 );
-                accounting.minimum_redeemable = U256::from(1u64);
                 accounting.balances.insert(CALLER, U256::from(5u64));
             }
         }

--- a/crates/common/precompiles/src/b20_factory/abi.rs
+++ b/crates/common/precompiles/src/b20_factory/abi.rs
@@ -27,8 +27,6 @@ sol! {
             string name;
             string symbol;
             address initialAdmin;
-            string isin;
-            uint256 minimumRedeemable;
         }
 
         // ── Errors ───────────────────────────────────────────────────────────

--- a/crates/common/precompiles/src/b20_factory/storage.rs
+++ b/crates/common/precompiles/src/b20_factory/storage.rs
@@ -267,8 +267,6 @@ impl TokenCreateParams {
                         symbol: p.symbol,
                         supply_cap: DEFAULT_SUPPLY_CAP,
                         multiplier: INITIAL_MULTIPLIER,
-                        isin: p.isin,
-                        minimum_redeemable: p.minimumRedeemable,
                     },
                 })
             }
@@ -302,7 +300,7 @@ impl TokenCreateParams {
 
     /// Validates asset-token initialization fields.
     pub const fn validate_asset(_init: &B20AssetInit) -> Result<()> {
-        // isin is optional — empty string is accepted.
+        // Asset initialization currently has no additional factory-side validation.
         Ok(())
     }
 
@@ -745,8 +743,7 @@ mod tests {
         });
     }
 
-    #[test]
-    fn test_create_asset_token_stores_isin_and_ratio() {
+    fn test_create_asset_token_sets_multiplier() {
         let mut storage = HashMapStorageProvider::new(1);
         activate_precompiles(&mut storage);
         let caller = Address::repeat_byte(0x55);
@@ -781,12 +778,6 @@ mod tests {
             assert_eq!(asset_storage.b20.symbol.read().unwrap(), "AST");
             assert_eq!(asset_storage.decimals().unwrap(), 6);
             assert_eq!(asset_storage.asset.multiplier.read().unwrap(), U256::ZERO);
-            assert_eq!(asset_storage.redeem.minimum_redeemable.read().unwrap(), U256::ONE);
-            // ISIN is stored in the identifiers mapping under the raw "ISIN" key.
-            assert_eq!(
-                asset_storage.asset.identifiers.at(&String::from("ISIN")).read().unwrap(),
-                "US0000000000"
-            );
         });
     }
 

--- a/crates/common/precompiles/src/b20_factory/storage.rs
+++ b/crates/common/precompiles/src/b20_factory/storage.rs
@@ -352,8 +352,6 @@ mod tests {
             name: name.to_string(),
             symbol: symbol.to_string(),
             initialAdmin: Address::repeat_byte(0xAB),
-            isin: String::new(),
-            minimumRedeemable: U256::ZERO,
         }
     }
 
@@ -755,8 +753,6 @@ mod tests {
             name: "Asset Token".to_string(),
             symbol: "AST".to_string(),
             initialAdmin: Address::repeat_byte(0xAB),
-            isin: "US0000000000".to_string(),
-            minimumRedeemable: U256::ONE,
         };
         let asset_call = IB20Factory::createB20Call {
             variant: IB20Factory::B20Variant::ASSET,
@@ -1108,8 +1104,6 @@ mod tests {
             name: "Asset Token".to_string(),
             symbol: "AST".to_string(),
             initialAdmin: initial_admin,
-            isin: "US0000000001".to_string(),
-            minimumRedeemable: U256::ZERO,
         };
         let call = IB20Factory::createB20Call {
             variant: IB20Factory::B20Variant::ASSET,
@@ -1136,8 +1130,6 @@ mod tests {
             name: "No Admin".to_string(),
             symbol: "NA".to_string(),
             initialAdmin: Address::ZERO,
-            isin: "US0000000002".to_string(),
-            minimumRedeemable: U256::ZERO,
         };
         let call_no_admin = IB20Factory::createB20Call {
             variant: IB20Factory::B20Variant::ASSET,
@@ -1171,8 +1163,6 @@ mod tests {
                 name: "T".to_string(),
                 symbol: "T".to_string(),
                 initialAdmin: Address::repeat_byte(0xAB),
-                isin: String::new(),
-                minimumRedeemable: U256::ZERO,
             }
             .abi_encode()
             .into(),

--- a/crates/common/precompiles/src/common/test_utils.rs
+++ b/crates/common/precompiles/src/common/test_utils.rs
@@ -47,14 +47,10 @@ pub struct InMemoryTokenAccounting {
     pub decimals: u8,
     /// Stablecoin currency identifier.
     pub currency: String,
-    /// Asset ISIN identifier (legacy field; prefer `extra_metadata` map for asset tokens).
-    pub asset_isin: String,
     /// Bitmask of active pause vectors.
     pub paused: U256,
     /// Per-account EIP-2612 nonces.
     pub nonces: HashMap<Address, U256>,
-    /// Minimum amount required for a redeem operation.
-    pub minimum_redeemable: U256,
     /// URI pointing to the contract-level metadata.
     pub contract_uri: String,
     /// Role membership keyed by `(role, account)`.
@@ -89,10 +85,8 @@ impl InMemoryTokenAccounting {
             symbol: String::new(),
             decimals: 18,
             currency: String::new(),
-            asset_isin: String::new(),
             paused: U256::ZERO,
             nonces: HashMap::new(),
-            minimum_redeemable: U256::ZERO,
             contract_uri: String::new(),
             roles: HashMap::new(),
             role_member_counts: HashMap::new(),
@@ -397,10 +391,7 @@ impl AssetAccounting for InMemoryTokenAccounting {
     }
 
     fn extra_metadata(&self, identifier_type: &str) -> Result<String> {
-        if let Some(val) = self.extra_metadata.get(identifier_type) {
-            return Ok(val.clone());
-        }
-        if identifier_type == "ISIN" { Ok(self.asset_isin.clone()) } else { Ok(String::new()) }
+        Ok(self.extra_metadata.get(identifier_type).cloned().unwrap_or_default())
     }
 
     fn set_extra_metadata_value(&mut self, identifier_type: &str, value: String) -> Result<()> {
@@ -409,15 +400,6 @@ impl AssetAccounting for InMemoryTokenAccounting {
         } else {
             self.extra_metadata.insert(identifier_type.to_owned(), value);
         }
-        Ok(())
-    }
-
-    fn minimum_redeemable(&self) -> Result<U256> {
-        Ok(self.minimum_redeemable)
-    }
-
-    fn set_minimum_redeemable(&mut self, minimum: U256) -> Result<()> {
-        self.minimum_redeemable = minimum;
         Ok(())
     }
 

--- a/etc/systems/src/b20.rs
+++ b/etc/systems/src/b20.rs
@@ -115,8 +115,6 @@ impl<'a> B20PrecompileClient<'a> {
                 name: name.to_string(),
                 symbol: symbol.to_string(),
                 initialAdmin: initial_admin,
-                isin: String::new(),
-                minimumRedeemable: U256::ZERO,
             },
             initial_supply,
             initial_supply_recipient,


### PR DESCRIPTION
## Summary

Remove `isin` and `minimum_redeemable` fields completely from the B20 Asset token.

## Changes

### ABI Changes
- Remove `isin` and `minimumRedeemable` from `B20AssetCreateParams`
- Remove `BelowMinimumRedeemable` error
- Remove `MinimumRedeemableUpdated` event
- Remove `minimumRedeemable()` and `updateMinimumRedeemable()` functions

### Storage Changes
- Remove `isin` and `minimum_redeemable` from `B20AssetInit` struct
- Rename `minimum_redeemable` to `redeem_reserved_slot0` in `B20RedeemStorage` to preserve storage layout compatibility

### Trait Changes
- Remove `minimum_redeemable()` and `set_minimum_redeemable()` from `SecurityAccounting` trait

### Logic Changes
- Remove minimum share check from `security_redeem_burn()`
- Remove `update_minimum_redeemable()` method from `B20AssetToken`

### Macro Changes
- Remove generated `minimum_redeemable` methods from `expand_security()` in precompile-macros

### Test Changes
- Update `InMemoryTokenAccounting` to remove `security_isin` and `minimum_redeemable` fields
- Update all tests that referenced these fields

## Testing

- `cargo check -p base-common-precompiles -p base-precompile-macros` passes
- `cargo test -p base-common-precompiles` - 346 tests pass

## Linear

Closes BOP-243