### PR TITLE
test(b20-token): transferFrom zero-address regression test (BOP-226)

### DIFF
--- a/crates/common/precompiles/src/common/ops/transferable.rs
+++ b/crates/common/precompiles/src/common/ops/transferable.rs
@@ -232,6 +232,22 @@ mod tests {
         );
     }
 
+    /// Regression for G-01: transferFrom with from=address(0) must revert with InvalidSender.
+    ///
+    /// Commit 3937941a removed a duplicate outer zero-sender pre-check from
+    /// transfer_from that was redundant with the guard already inside transfer.
+    /// This test ensures the zero-sender guard is always enforced on the
+    /// transfer_from code path and cannot be silently dropped.
+    #[test]
+    fn transfer_from_with_zero_from_address_reverts() {
+        let mut token = make_token();
+
+        assert_eq!(
+            token.transfer_from(SPENDER, Address::ZERO, BOB, U256::ONE, false).unwrap_err(),
+            BasePrecompileError::revert(IB20::InvalidSender { sender: Address::ZERO })
+        );
+    }
+
     #[test]
     fn transfer_to_zero_receiver_reverts() {
         let mut token = token_with_balance(U256::from(100u64));

--- a/crates/common/precompiles/src/common/ops/transferable.rs
+++ b/crates/common/precompiles/src/common/ops/transferable.rs
@@ -232,12 +232,6 @@ mod tests {
         );
     }
 
-    /// Regression for G-01: transferFrom with from=address(0) must revert with InvalidSender.
-    ///
-    /// Commit 3937941a removed a duplicate outer zero-sender pre-check from
-    /// transfer_from that was redundant with the guard already inside transfer.
-    /// This test ensures the zero-sender guard is always enforced on the
-    /// transfer_from code path and cannot be silently dropped.
     #[test]
     fn transfer_from_with_zero_from_address_reverts() {
         let mut token = make_token();


### PR DESCRIPTION
[BOP-226](https://linear.app/coinbase/issue/BOP-226)

## Motivation

Fix commit 3937941a removed the redundant zero-address check on `from` in `transferFrom` (the check was already present inside `transfer`). This adds a dedicated regression test to prevent the double-check from being re-introduced.

## Changes

Added `transfer_from_with_zero_from_address_reverts` test in `b20_token` that calls `transferFrom` with `from = address(0)` and asserts the canonical zero-address revert from `transfer`.

type=routine
risk=low
impact=sev4