### PR TITLE
fix(b20-token): enforce executor policy in transferFrom regardless of allowance (BOP-227)

### DIFF
--- a/crates/common/precompiles/src/common/ops/transferable.rs
+++ b/crates/common/precompiles/src/common/ops/transferable.rs
@@ -67,8 +67,10 @@ pub trait Transferable: Token {
     /// Moves `amount` tokens from `from` to `to` using `spender`'s allowance.
     /// Emits `Transfer`. Skips allowance decrement when allowance is `U256::MAX`.
     ///
-    /// The pause check is always enforced first. When `privileged` is true the
-    /// executor policy check is skipped; the inner transfer also receives
+    /// The pause check is always enforced first. The executor policy check runs
+    /// unconditionally (unless `privileged` is true or `spender == from`),
+    /// regardless of whether the allowance is `U256::MAX`. When `privileged` is
+    /// true the executor policy check is skipped; the inner transfer also receives
     /// `privileged`.
     fn transfer_from(
         &mut self,
@@ -86,10 +88,8 @@ pub trait Transferable: Token {
             return Err(BasePrecompileError::revert(IB20::InvalidSender { sender: from }));
         }
         let allowance = self.accounting().allowance(from, spender)?;
-        if allowance == U256::MAX {
-            return self.transfer_inner(from, to, amount, privileged);
-        }
-        if allowance < amount {
+        let is_infinite = allowance == U256::MAX;
+        if !is_infinite && allowance < amount {
             return Err(BasePrecompileError::revert(IB20::InsufficientAllowance {
                 spender,
                 allowance,
@@ -100,6 +100,9 @@ pub trait Transferable: Token {
             B20Guards::ensure_policy_type::<Self>(self, B20PolicyType::TransferExecutor, spender)?;
         }
         self.transfer_inner(from, to, amount, privileged)?;
+        if is_infinite {
+            return Ok(());
+        }
         self.accounting_mut().set_allowance(from, spender, allowance - amount)
     }
 
@@ -391,6 +394,25 @@ mod tests {
         let mut accounting = InMemoryTokenAccounting::new(TOKEN_ADDR);
         accounting.balances.insert(ALICE, U256::from(10u64));
         accounting.allowances.insert((ALICE, SPENDER), U256::from(10u64));
+        accounting
+            .policy_ids
+            .insert(B20PolicyType::TransferExecutor.id(), PolicyRegistryStorage::ALWAYS_BLOCK_ID);
+        let mut token = TestToken::with_storage_and_policy(accounting, InMemoryPolicy::new());
+
+        assert_eq!(
+            token.transfer_from(SPENDER, ALICE, BOB, U256::ONE, false).unwrap_err(),
+            BasePrecompileError::revert(IB20::PolicyForbids {
+                policyScope: B20PolicyType::TransferExecutor.id(),
+                policyId: PolicyRegistryStorage::ALWAYS_BLOCK_ID,
+            })
+        );
+    }
+
+    #[test]
+    fn transfer_from_with_max_allowance_reverts_when_executor_policy_denies() {
+        let mut accounting = InMemoryTokenAccounting::new(TOKEN_ADDR);
+        accounting.balances.insert(ALICE, U256::from(10u64));
+        accounting.allowances.insert((ALICE, SPENDER), U256::MAX);
         accounting
             .policy_ids
             .insert(B20PolicyType::TransferExecutor.id(), PolicyRegistryStorage::ALWAYS_BLOCK_ID);


### PR DESCRIPTION
[BOP-227](https://linear.app/coinbase/issue/BOP-227)

## Motivation

When `transferFrom` is called with `allowance == uint256::MAX`, the executor policy check was skipped. Any caller with a max allowance could bypass transfer restrictions.

## Changes

Updated `transferFrom` to run the executor policy check unconditionally, regardless of allowance value. Added a regression test that sets max allowance, configures a restrictive executor policy, and asserts the policy is enforced.

type=routine
risk=low
impact=sev2
