### PR TITLE
feat(b20-asset): add METADATA_ROLE to gate updateExtraMetadata (BOP-237)

### DIFF
--- a/actions/harness/tests/beryl/security.rs
+++ b/actions/harness/tests/beryl/security.rs
@@ -116,6 +116,11 @@ async fn security_creation_initializes_identifiers_and_factory_views() {
                     IB20Asset::OPERATOR_ROLECall {}.abi_encode(),
                     security_operator_role(),
                 ),
+                StaticcallCase::bytes32(
+                    "METADATA_ROLE",
+                    IB20Asset::METADATA_ROLECall {}.abi_encode(),
+                    metadata_role(),
+                ),
                 StaticcallCase::returndata(
                     "pausedFeatures",
                     IB20::pausedFeaturesCall {}.abi_encode(),
@@ -131,7 +136,9 @@ async fn security_creation_initializes_identifiers_and_factory_views() {
 #[tokio::test]
 async fn security_mutations_update_state_and_emit_events() {
     let mut scenario = B20AssetScenario::new().await;
-    scenario.grant_roles([security_operator_role(), B20TokenRole::Mint.id()]).await;
+    scenario
+        .grant_roles([security_operator_role(), metadata_role(), B20TokenRole::Mint.id()])
+        .await;
 
     let update_ratio =
         scenario.call_tx(IB20Asset::updateMultiplierCall { newMultiplier: UPDATED_RATIO });
@@ -281,7 +288,9 @@ async fn security_mutations_update_state_and_emit_events() {
 #[tokio::test]
 async fn security_mutations_revert_on_invalid_inputs() {
     let mut scenario = B20AssetScenario::new().await;
-    scenario.grant_roles([security_operator_role(), B20TokenRole::Mint.id()]).await;
+    scenario
+        .grant_roles([security_operator_role(), metadata_role(), B20TokenRole::Mint.id()])
+        .await;
 
     let first_announcement = scenario.call_tx(IB20Asset::announceCall {
         internalCalls: Vec::new(),
@@ -550,4 +559,8 @@ impl B20AssetScenario {
 
 fn security_operator_role() -> B256 {
     keccak256("OPERATOR_ROLE")
+}
+
+fn metadata_role() -> B256 {
+    keccak256("METADATA_ROLE")
 }

--- a/crates/common/precompiles/src/b20_asset/abi.rs
+++ b/crates/common/precompiles/src/b20_asset/abi.rs
@@ -56,8 +56,11 @@ sol! {
 
         // ── Role / precision identifiers ─────────────────────────────────────
 
-        /// `keccak256("OPERATOR_ROLE")` — required for `announce`, `updateMultiplier`, `updateExtraMetadata`.
+        /// `keccak256("OPERATOR_ROLE")` — required for `announce` and `updateMultiplier`.
         function OPERATOR_ROLE() external view returns (bytes32);
+
+        /// `keccak256("METADATA_ROLE")` — required for `updateExtraMetadata`.
+        function METADATA_ROLE() external view returns (bytes32);
 
         /// Fixed-point precision for `multiplier`: `1e18` (one WAD).
         function WAD_PRECISION() external view returns (uint256);
@@ -116,7 +119,7 @@ sol! {
         /// Returns the value of the named identifier (e.g. ISIN, CUSIP). Empty string if not set.
         function extraMetadata(string calldata identifierType) external view returns (string);
 
-        /// Sets, updates, or removes a security identifier. Empty `value` removes the entry.
+        /// Sets, updates, or removes a security identifier. Empty `value` removes the entry. Requires `METADATA_ROLE`.
         function updateExtraMetadata(
             string calldata identifierType,
             string calldata value
@@ -129,6 +132,7 @@ impl IB20Asset::IB20AssetCalls {
     pub const fn as_label(&self) -> &'static str {
         match self {
             Self::OPERATOR_ROLE(_) => "precompile-b20-asset-OPERATOR_ROLE",
+            Self::METADATA_ROLE(_) => "precompile-b20-asset-METADATA_ROLE",
             Self::WAD_PRECISION(_) => "precompile-b20-asset-WAD_PRECISION",
             Self::REDEEM_SENDER_POLICY(_) => "precompile-b20-asset-REDEEM_SENDER_POLICY",
             Self::announce(_) => "precompile-b20-asset-announce",

--- a/crates/common/precompiles/src/b20_asset/dispatch.rs
+++ b/crates/common/precompiles/src/b20_asset/dispatch.rs
@@ -341,6 +341,7 @@ impl<S: SecurityAccounting, P: Policy> B20AssetToken<S, P> {
         let encoded: Bytes = match call {
             // --- Role / precision constants ---
             SC::OPERATOR_ROLE(_) => Self::OPERATOR_ROLE.abi_encode().into(),
+            SC::METADATA_ROLE(_) => Self::METADATA_ROLE.abi_encode().into(),
             SC::WAD_PRECISION(_) => B20AssetStorage::WAD.abi_encode().into(),
             SC::REDEEM_SENDER_POLICY(_) => Self::REDEEM_SENDER_POLICY.abi_encode().into(),
 

--- a/crates/common/precompiles/src/b20_asset/token.rs
+++ b/crates/common/precompiles/src/b20_asset/token.rs
@@ -551,4 +551,26 @@ mod tests {
 
         assert_eq!(err, expected_update_policy_error(setup, invalid_scope));
     }
+
+    /// Caller holding only `OPERATOR_ROLE` must be denied `updateExtraMetadata`.
+    ///
+    /// This guards against regressions where `ensure_metadata_role` is accidentally
+    /// reverted to `ensure_operator_role`, collapsing the two distinct capabilities.
+    #[test]
+    fn update_extra_metadata_requires_metadata_role_not_operator_role() {
+        let mut token = make_token();
+        token.accounting_mut().roles.insert((TestSecurityToken::OPERATOR_ROLE, CALLER), true);
+
+        let err = token
+            .update_extra_metadata(CALLER, "ISIN".to_string(), "US0000000000".to_string(), false)
+            .unwrap_err();
+
+        assert_eq!(
+            err,
+            BasePrecompileError::revert(IB20::AccessControlUnauthorizedAccount {
+                account: CALLER,
+                neededRole: TestSecurityToken::METADATA_ROLE,
+            })
+        );
+    }
 }

--- a/crates/common/precompiles/src/b20_asset/token.rs
+++ b/crates/common/precompiles/src/b20_asset/token.rs
@@ -31,6 +31,10 @@ impl<S: SecurityAccounting, P: Policy> B20AssetToken<S, P> {
     pub const OPERATOR_ROLE: B256 =
         b256!("97667070c54ef182b0f5858b034beac1b6f3089aa2d3188bb1e8929f4fa9b929");
 
+    /// Role identifier for metadata updaters: `keccak256("METADATA_ROLE")`.
+    pub const METADATA_ROLE: B256 =
+        b256!("6bd6b5318a46e5fff572d5e4258a20774aab40cc35ac7680654b9081fcc82f80");
+
     /// Policy scope identifier for redeem senders: `keccak256("REDEEM_SENDER_POLICY")`.
     pub const REDEEM_SENDER_POLICY: B256 = B20AssetStorage::REDEEM_SENDER_POLICY;
 
@@ -110,6 +114,11 @@ impl<S: SecurityAccounting, P: Policy> B20AssetToken<S, P> {
     /// Ensures the caller has the security operator role.
     pub fn ensure_operator_role(&self, caller: Address, privileged: bool) -> Result<()> {
         if privileged { Ok(()) } else { self.ensure_role(caller, Self::OPERATOR_ROLE) }
+    }
+
+    /// Ensures the caller has the metadata role.
+    pub fn ensure_metadata_role(&self, caller: Address, privileged: bool) -> Result<()> {
+        if privileged { Ok(()) } else { self.ensure_role(caller, Self::METADATA_ROLE) }
     }
 
     /// Ensures the caller has the default admin role.
@@ -210,7 +219,7 @@ impl<S: SecurityAccounting, P: Policy> B20AssetToken<S, P> {
         value: String,
         privileged: bool,
     ) -> Result<()> {
-        self.ensure_operator_role(caller, privileged)?;
+        self.ensure_metadata_role(caller, privileged)?;
         if identifier_type.is_empty() {
             return Err(BasePrecompileError::revert(IB20Asset::InvalidIdentifierType {}));
         }
@@ -503,6 +512,7 @@ mod tests {
     #[test]
     fn role_and_policy_ids_match_solidity_hashes() {
         assert_eq!(TestSecurityToken::OPERATOR_ROLE, keccak256("OPERATOR_ROLE"));
+        assert_eq!(TestSecurityToken::METADATA_ROLE, keccak256("METADATA_ROLE"));
         assert_eq!(TestSecurityToken::REDEEM_SENDER_POLICY, keccak256("REDEEM_SENDER_POLICY"));
     }
 

--- a/crates/common/precompiles/src/common/test_utils.rs
+++ b/crates/common/precompiles/src/common/test_utils.rs
@@ -47,7 +47,7 @@ pub struct InMemoryTokenAccounting {
     pub decimals: u8,
     /// Stablecoin currency identifier.
     pub currency: String,
-    /// Security ISIN identifier (legacy field; prefer `security_identifiers` map for security tokens).
+    /// Security ISIN identifier (legacy field; prefer `extra_metadata` map for asset tokens).
     pub security_isin: String,
     /// Bitmask of active pause vectors.
     pub paused: U256,


### PR DESCRIPTION
[BOP-237](https://linear.app/coinbase/issue/BOP-237)

## Motivation

`updateExtraMetadata` was previously gated by `OPERATOR_ROLE`, the same role that controls
`announce` and `updateShareRatio`. Bundling metadata updates with those higher-stakes operations
means any operator can edit identifiers, and any metadata editor inherits operator privileges.
BOP-237 calls for a dedicated `METADATA_ROLE` so the two capabilities can be granted
independently.

## What changed

- **`b20_asset/abi.rs`**: Added `function METADATA_ROLE() external view returns (bytes32)` to
  `IB20Asset`. Updated the `OPERATOR_ROLE` doc comment to remove `updateExtraMetadata`, updated
  the `updateExtraMetadata` doc to reference `METADATA_ROLE`, and added a `METADATA_ROLE` arm
  to `as_label`.
- **`b20_asset/token.rs`**: Added `pub const METADATA_ROLE: B256` (keccak256("METADATA_ROLE")),
  `ensure_metadata_role()`, and switched `update_extra_metadata` to call `ensure_metadata_role`
  instead of `ensure_operator_role`. Extended the hash-sanity unit test to cover the new constant.
- **`b20_asset/dispatch.rs`**: Added `SC::METADATA_ROLE` arm in `handle_security_call` so the
  selector returns the correct constant.
- **`beryl/security.rs`**: Grant `METADATA_ROLE` alongside `OPERATOR_ROLE` in the mutation and
  invalid-input test scenarios; add a `METADATA_ROLE` staticcall case to the initializer check.
- **`common/test_utils.rs`**: Fixed a stale doc comment that still referenced `security_identifiers`
  instead of the renamed `extra_metadata` field.

## What was tried / considered

Keeping `updateExtraMetadata` under `OPERATOR_ROLE` was the simplest path, but it couples
metadata editing to share-ratio and announcement privileges with no way to separate them.
An alternative was adding a `METADATA_OPERATOR_ROLE` scoped only inside `B20AssetToken`, but
`METADATA_ROLE` already exists as a named `B20TokenRole` variant (used by `updateName` and
`updateSymbol` on the base token), so reusing the same keccak value keeps the role namespace
consistent and avoids a proliferation of nearly-identical roles.