### PR TITLE
feat(b20): add decimals field to B20AssetCreateParams and remo isin in create params 

### DIFF
--- a/actions/harness/tests/beryl/env.rs
+++ b/actions/harness/tests/beryl/env.rs
@@ -63,13 +63,13 @@ impl BerylTestEnv {
     /// Gas limit used for B-20 staticcall probe transactions.
     pub(crate) const B20_PROBE_GAS_LIMIT: u64 = 1_000_000;
 
-    /// Fixed decimals for the default B-20 token variant.
+    /// Fixed decimals for the asset B-20 token variant.
     pub(crate) const B20_DECIMALS: u8 = 6;
 
-    /// Name for the default B-20 token variant.
+    /// Name for the asset B-20 token variant.
     pub(crate) const B20_NAME: &str = "Action B20";
 
-    /// Symbol for the default B-20 token variant.
+    /// Symbol for the asset B-20 token variant.
     pub(crate) const B20_SYMBOL: &str = "AB20";
 
     /// Fixed decimals for the stablecoin B-20 token variant.
@@ -84,20 +84,14 @@ impl BerylTestEnv {
     /// ISO 4217 currency code for the stablecoin B-20 token variant.
     pub(crate) const B20_STABLECOIN_CURRENCY: &str = "USD";
 
-    /// Fixed decimals for the security B-20 token variant.
-    pub(crate) const B20_ASSET_DECIMALS: u8 = 6;
+    /// Decimals for the asset B-20 token variant.
+    pub(crate) const B20_ASSET_DECIMALS: u8 = 8;
 
-    /// Name for the security B-20 token variant.
+    /// Name for the asset B-20 token variant.
     pub(crate) const B20_ASSET_NAME: &str = "Action Security";
 
-    /// Symbol for the security B-20 token variant.
+    /// Symbol for the asset B-20 token variant.
     pub(crate) const B20_ASSET_SYMBOL: &str = "ASEC";
-
-    /// ISIN stored on the security B-20 token at creation.
-    pub(crate) const B20_ASSET_ISIN: &str = "US0000000001";
-
-    /// Initial minimum redeemable share amount for the security B-20 token.
-    pub(crate) const B20_ASSET_MINIMUM_REDEEMABLE: u64 = 10;
 
     /// Initial B-20 supply minted to Alice.
     pub(crate) const B20_INITIAL_SUPPLY: u64 = 1_000_000;
@@ -271,16 +265,14 @@ impl BerylTestEnv {
         )
     }
 
-    /// Creates a transaction that calls the B-20 token factory for a security token.
-    pub(crate) fn create_b20_security_tx(&self) -> BaseTxEnvelope {
-        self.create_b20_security_with_salt_tx(Self::b20_security_salt())
+    pub(crate) fn create_b20_asset_tx(&self) -> BaseTxEnvelope {
+        self.create_b20_asset_with_salt_tx(Self::b20_security_salt())
     }
 
-    /// Creates a security-token factory transaction with the given `salt`.
-    pub(crate) fn create_b20_security_with_salt_tx(&self, salt: B256) -> BaseTxEnvelope {
+    pub(crate) fn create_b20_asset_with_salt_tx(&self, salt: B256) -> BaseTxEnvelope {
         self.create_tx(
             TxKind::Call(B20FactoryStorage::ADDRESS),
-            Bytes::from(self.create_b20_security_call_with_salt(salt).abi_encode()),
+            Bytes::from(self.create_b20_asset_call_with_salt(salt).abi_encode()),
             Self::B20_GAS_LIMIT,
         )
     }
@@ -574,7 +566,7 @@ impl BerylTestEnv {
         }
     }
 
-    fn create_b20_security_call_with_salt(&self, salt: B256) -> IB20Factory::createB20Call {
+    fn create_b20_asset_call_with_salt(&self, salt: B256) -> IB20Factory::createB20Call {
         IB20Factory::createB20Call {
             variant: IB20Factory::B20Variant::ASSET,
             salt,
@@ -629,9 +621,7 @@ impl BerylTestEnv {
             name: Self::B20_NAME.to_string(),
             symbol: Self::B20_SYMBOL.to_string(),
             initialAdmin: Self::alice(),
-            isin: String::new(),
-            minimumRedeemable: U256::ZERO,
-            decimals: 6,
+            decimals: Self::B20_DECIMALS,
         }
     }
 
@@ -651,8 +641,6 @@ impl BerylTestEnv {
             name: Self::B20_ASSET_NAME.to_string(),
             symbol: Self::B20_ASSET_SYMBOL.to_string(),
             initialAdmin: Self::alice(),
-            isin: Self::B20_ASSET_ISIN.to_string(),
-            minimumRedeemable: U256::from(Self::B20_ASSET_MINIMUM_REDEEMABLE),
             decimals: Self::B20_ASSET_DECIMALS,
         }
     }

--- a/actions/harness/tests/beryl/factory.rs
+++ b/actions/harness/tests/beryl/factory.rs
@@ -275,7 +275,7 @@ fn assert_token_created_log(env: &BerylTestEnv, block: &BaseBlock, token: Addres
         name: BerylTestEnv::B20_NAME.to_string(),
         symbol: BerylTestEnv::B20_SYMBOL.to_string(),
         decimals: BerylTestEnv::B20_DECIMALS,
-        variantParams: Bytes::new(),
+        variantEventParams: Bytes::new(),
     }
     .encode_log_data();
     assert!(

--- a/actions/harness/tests/beryl/policy_transfer.rs
+++ b/actions/harness/tests/beryl/policy_transfer.rs
@@ -422,9 +422,7 @@ impl PolicyTransferScenario {
             name: "Policy B20".to_string(),
             symbol: "PB20".to_string(),
             initialAdmin: BerylTestEnv::alice(),
-            isin: String::new(),
-            minimumRedeemable: U256::ZERO,
-            decimals: 6,
+            decimals: 18,
         }
     }
 }

--- a/actions/harness/tests/beryl/security.rs
+++ b/actions/harness/tests/beryl/security.rs
@@ -72,12 +72,12 @@ async fn security_creation_initializes_identifiers_and_factory_views() {
                     "extraMetadata(ISIN)",
                     IB20Asset::extraMetadataCall { identifierType: "ISIN".to_string() }
                         .abi_encode(),
-                    BerylTestEnv::B20_ASSET_ISIN,
+                    "",
                 ),
                 StaticcallCase::word(
                     "decimals",
                     IB20::decimalsCall {}.abi_encode(),
-                    U256::from(BerylTestEnv::B20_ASSET_DECIMALS),
+                    U256::from(8u8),
                 ),
                 StaticcallCase::word(
                     "totalSupply",
@@ -445,7 +445,7 @@ impl B20AssetScenario {
             "POLICY_REGISTRY activation must succeed"
         );
 
-        let create = scenario.env.create_b20_security_tx();
+        let create = scenario.env.create_b20_asset_tx();
         let block = scenario.build_block_with_transactions(vec![create]).await;
 
         assert!(
@@ -524,7 +524,7 @@ impl B20AssetScenario {
             name: BerylTestEnv::B20_ASSET_NAME.to_string(),
             symbol: BerylTestEnv::B20_ASSET_SYMBOL.to_string(),
             decimals: BerylTestEnv::B20_ASSET_DECIMALS,
-            variantParams: Bytes::new(),
+            variantEventParams: Bytes::new(),
         }
         .encode_log_data();
         self.assert_receipt_log(block, 0, B20FactoryStorage::ADDRESS, expected);

--- a/actions/harness/tests/beryl/stablecoin.rs
+++ b/actions/harness/tests/beryl/stablecoin.rs
@@ -357,7 +357,7 @@ impl StablecoinScenario {
             name: BerylTestEnv::B20_STABLECOIN_NAME.to_string(),
             symbol: BerylTestEnv::B20_STABLECOIN_SYMBOL.to_string(),
             decimals: BerylTestEnv::B20_STABLECOIN_DECIMALS,
-            variantParams: variant_params,
+            variantEventParams: variant_params,
         }
         .encode_log_data();
         assert!(
@@ -366,7 +366,7 @@ impl StablecoinScenario {
                 .logs()
                 .iter()
                 .any(|log| log.address == B20FactoryStorage::ADDRESS && log.data == expected),
-            "createB20(STABLECOIN) must emit B20Created with ABI-encoded currency in variantParams"
+            "createB20(STABLECOIN) must emit B20Created with ABI-encoded currency in variantEventParams"
         );
     }
 

--- a/crates/common/precompile-macros/src/accounting.rs
+++ b/crates/common/precompile-macros/src/accounting.rs
@@ -19,18 +19,7 @@ pub(crate) fn derive_asset(input: DeriveInput) -> proc_macro::TokenStream {
 fn expand_token(input: DeriveInput) -> syn::Result<TokenStream> {
     require_field(&input, "b20")?;
     let has_redeem = has_field(&input, "redeem");
-    let has_security = has_field(&input, "asset");
     let name = input.ident;
-    let decimals_impl = if has_security {
-        quote! { crate::AssetAccounting::decimals(self) }
-    } else {
-        quote! {
-            Ok(crate::B20Variant::from_address(
-                ::base_precompile_storage::ContractStorage::address(self),
-            )
-            .map_or(0, crate::B20Variant::decimals))
-        }
-    };
     let redeem = has_redeem.then_some(quote! {
         if policy_scope == Self::REDEEM_SENDER_POLICY {
             return self.redeem.redeem_sender_policy_id();
@@ -143,7 +132,9 @@ fn expand_token(input: DeriveInput) -> syn::Result<TokenStream> {
             }
 
             fn decimals(&self) -> ::base_precompile_storage::Result<u8> {
-                #decimals_impl
+                // Stablecoin returns fixed 6 decimals, Asset reads from storage.
+                // This default assumes stablecoin; B20AssetStorage overrides via its own decimals().
+                Ok(crate::B20Variant::STABLECOIN_DECIMALS)
             }
 
             fn paused(&self) -> ::base_precompile_storage::Result<::alloy_primitives::U256> {
@@ -340,7 +331,7 @@ fn expand_asset(input: DeriveInput) -> syn::Result<TokenStream> {
             ) -> ::base_precompile_storage::Result<::alloc::string::String> {
                 ::base_precompile_storage::Handler::read(
                     self.asset
-                        .identifiers
+                        .extra_metadata
                         .at(&::alloc::string::String::from(identifier_type)),
                 )
             }
@@ -352,10 +343,10 @@ fn expand_asset(input: DeriveInput) -> syn::Result<TokenStream> {
             ) -> ::base_precompile_storage::Result<()> {
                 let key = ::alloc::string::String::from(identifier_type);
                 if value.is_empty() {
-                    ::base_precompile_storage::Handler::delete(self.asset.identifiers.at_mut(&key))
+                    ::base_precompile_storage::Handler::delete(self.asset.extra_metadata.at_mut(&key))
                 } else {
                     ::base_precompile_storage::Handler::write(
-                        self.asset.identifiers.at_mut(&key),
+                        self.asset.extra_metadata.at_mut(&key),
                         value,
                     )
                 }
@@ -398,8 +389,7 @@ fn expand_asset(input: DeriveInput) -> syn::Result<TokenStream> {
             }
 
             fn decimals(&self) -> ::base_precompile_storage::Result<u8> {
-                let stored = self.asset.decimals()?;
-                Ok(if stored == 0 { 6 } else { stored })
+                self.asset.decimals()
             }
         }
     })

--- a/crates/common/precompiles/benches/base_precompiles.rs
+++ b/crates/common/precompiles/benches/base_precompiles.rs
@@ -32,9 +32,7 @@ impl BaseTokenBenchSetup {
             name: name.to_string(),
             symbol: symbol.to_string(),
             initialAdmin: Self::admin(),
-            isin: String::new(),
-            minimumRedeemable: U256::ZERO,
-            decimals: 6,
+            decimals: 18,
         }
     }
 

--- a/crates/common/precompiles/src/b20_asset/storage.rs
+++ b/crates/common/precompiles/src/b20_asset/storage.rs
@@ -4,25 +4,25 @@ use alloc::string::String;
 
 use alloy_primitives::{Address, B256, FixedBytes, U256, b256};
 use base_precompile_macros::{AssetAccounting, Storable, TokenAccounting, contract};
-use base_precompile_storage::{BasePrecompileError, Handler, Mapping, Result, StorageCtx};
+use base_precompile_storage::{Handler, Mapping, Result, StorageCtx};
 
-use crate::{B20CoreStorage, IB20Asset, PolicyRegistryStorage};
+use crate::{B20CoreStorage, PolicyRegistryStorage};
 
 /// Asset-specific B-20 storage rooted at the `base.b20.asset` ERC-7201 namespace.
 #[derive(Debug, Clone, Storable)]
 #[namespace("base.b20.asset")]
 pub struct B20AssetExtensionStorage {
-    /// Custom decimal precision for this token; stored once at creation time.
+    /// ERC-20 decimals (immutable after creation).
     #[accessor]
-    pub decimals: u8, // slot 0, offset 0
+    pub decimals: u8, // slot 0
     /// Multiplier scaled to WAD.
     #[accessor]
     #[mutator]
     pub multiplier: U256, // slot 1
     /// Announcement IDs that have already been consumed.
     pub used_announcement_ids: Mapping<String, bool>, // slot 2
-    /// Security identifier values by identifier type.
-    pub identifiers: Mapping<String, String>, // slot 3
+    /// Asset metadata values by key.
+    pub extra_metadata: Mapping<String, String>, // slot 3
 }
 
 /// Redemption-specific B-20 storage rooted at the `base.b20.redeem` ERC-7201 namespace.
@@ -51,23 +51,17 @@ pub struct B20AssetStorage {
 }
 
 /// Creation-time parameters for an asset B-20 token.
-///
-/// Passed to [`B20AssetStorage::initialize`] to write all fields atomically.
 #[derive(Debug)]
 pub struct B20AssetInit {
-    /// ERC-20 token name.
+    /// Token name.
     pub name: String,
-    /// ERC-20 token symbol.
+    /// Token symbol.
     pub symbol: String,
-    /// Maximum total supply.
+    /// Maximum total supply for mint operations.
     pub supply_cap: U256,
-    /// Initial multiplier at WAD precision.
+    /// Initial multiplier at WAD precision (1:1 when zero).
     pub multiplier: U256,
-    /// ISIN identifier stored under the `"ISIN"` key.
-    pub isin: String,
-    /// Minimum redeemable amount; `0` allows any non-zero redemption.
-    pub minimum_redeemable: U256,
-    /// Custom decimal precision for this token; must be in `[6, 18]`.
+    /// Token decimals (must be in range 6..=18).
     pub decimals: u8,
 }
 
@@ -83,40 +77,30 @@ impl<'a> B20AssetStorage<'a> {
     }
 
     /// Writes all creation-time fields atomically.
-    ///
-    /// `isin` may be empty; when non-empty it is stored under the `"ISIN"` key
-    /// in the security identifiers mapping.
-    ///
-    /// `REDEEM_SENDER_POLICY` is initialised to `ALWAYS_BLOCK_ID` so redemption
-    /// is closed by default; issuers must explicitly open it after creation.
     pub fn initialize(&mut self, init: B20AssetInit) -> Result<()> {
-        if init.decimals < Self::MIN_DECIMALS || init.decimals > Self::MAX_DECIMALS {
-            return Err(BasePrecompileError::revert(IB20Asset::InvalidDecimals {}));
-        }
         self.b20.name.write(init.name)?;
         self.b20.symbol.write(init.symbol)?;
         self.b20.supply_cap.write(init.supply_cap)?;
         self.asset.multiplier.write(init.multiplier)?;
         self.asset.decimals.write(init.decimals)?;
-        self.redeem.minimum_redeemable.write(init.minimum_redeemable)?;
-        if !init.isin.is_empty() {
-            self.asset.identifiers.at_mut(&String::from("ISIN")).write(init.isin)?;
-        }
         self.write_redeem_policy_ids_default()?;
         Ok(())
     }
 }
 
 impl B20AssetStorage<'_> {
-    /// Minimum allowed decimals for a B-20 asset token.
+    /// Minimum allowed decimals for asset tokens.
     pub const MIN_DECIMALS: u8 = 6;
-    /// Maximum allowed decimals for a B-20 asset token.
+    /// Maximum allowed decimals for asset tokens.
     pub const MAX_DECIMALS: u8 = 18;
-    /// WAD precision for multiplier arithmetic: 1e18.
+    /// 10^18 fixed-point unit for multiplier arithmetic.
     pub const WAD: U256 = U256::from_limbs([1_000_000_000_000_000_000, 0, 0, 0]);
 
-    /// Writes the default `redeem_sender_policy_id` to `ALWAYS_BLOCK_ID`.
-    /// Called once from [`initialize`].
+    /// Returns the token decimals stored at creation time.
+    pub fn decimals(&self) -> Result<u8> {
+        self.asset.decimals()
+    }
+
     fn write_redeem_policy_ids_default(&mut self) -> Result<()> {
         self.redeem.set_redeem_sender_policy_id(PolicyRegistryStorage::ALWAYS_BLOCK_ID)
     }
@@ -171,7 +155,7 @@ mod tests {
             __packing_b20_asset_extension_storage::USED_ANNOUNCEMENT_IDS_LOC.offset_slots,
             2
         );
-        assert_eq!(__packing_b20_asset_extension_storage::IDENTIFIERS_LOC.offset_slots, 3);
+        assert_eq!(__packing_b20_asset_extension_storage::EXTRA_METADATA_LOC.offset_slots, 3);
         assert_eq!(__packing_b20_redeem_storage::MINIMUM_REDEEMABLE_LOC.offset_slots, 0);
         assert_eq!(__packing_b20_redeem_storage::REDEEM_SENDER_POLICY_ID_LOC.offset_slots, 1);
         assert_eq!(__packing_b20_redeem_storage::REDEEM_SENDER_POLICY_ID_LOC.offset_bytes, 0);
@@ -220,7 +204,7 @@ mod tests {
             token.asset.used_announcement_ids.at_mut(&announcement_id).write(true).unwrap();
             token
                 .asset
-                .identifiers
+                .extra_metadata
                 .at_mut(&identifier_type)
                 .write(identifier_value.clone())
                 .unwrap();
@@ -230,8 +214,10 @@ mod tests {
                 + U256::from(
                     __packing_b20_asset_extension_storage::USED_ANNOUNCEMENT_IDS_LOC.offset_slots,
                 );
-            let identifiers_slot = ASSET_ROOT
-                + U256::from(__packing_b20_asset_extension_storage::IDENTIFIERS_LOC.offset_slots);
+            let extra_metadata_slot = ASSET_ROOT
+                + U256::from(
+                    __packing_b20_asset_extension_storage::EXTRA_METADATA_LOC.offset_slots,
+                );
             let minimum_slot = REDEEM_ROOT
                 + U256::from(__packing_b20_redeem_storage::MINIMUM_REDEEMABLE_LOC.offset_slots);
 
@@ -240,7 +226,7 @@ mod tests {
                 U256::ONE
             );
             assert_eq!(
-                ctx.sload(TOKEN, identifier_type.mapping_slot(identifiers_slot)).unwrap(),
+                ctx.sload(TOKEN, identifier_type.mapping_slot(extra_metadata_slot)).unwrap(),
                 short_string_word(&identifier_value)
             );
             assert_eq!(ctx.sload(TOKEN, minimum_slot).unwrap(), U256::from(10u64));
@@ -282,9 +268,7 @@ mod tests {
                     symbol: String::from("TST"),
                     supply_cap: U256::from(1_000_000u64),
                     multiplier: B20AssetStorage::WAD,
-                    isin: String::new(),
-                    minimum_redeemable: U256::ZERO,
-                    decimals: 6,
+                    decimals: 8,
                 })
                 .unwrap();
 
@@ -309,8 +293,6 @@ mod tests {
             symbol: String::from("TST"),
             supply_cap: U256::from(1_000_000u64),
             multiplier: B20AssetStorage::WAD,
-            isin: String::new(),
-            minimum_redeemable: U256::ZERO,
             decimals,
         }
     }
@@ -334,54 +316,6 @@ mod tests {
             let mut token = B20AssetStorage::from_address(TOKEN, ctx);
             token.initialize(make_init(18)).unwrap();
             assert_eq!(token.asset.decimals.read().unwrap(), 18);
-        });
-    }
-
-    #[test]
-    fn decimals_5_reverts_with_invalid_decimals() {
-        let (mut storage, _) = setup_storage();
-
-        StorageCtx::enter(&mut storage, |ctx| {
-            let mut token = B20AssetStorage::from_address(TOKEN, ctx);
-            let err = token.initialize(make_init(5)).unwrap_err();
-            assert_eq!(
-                err,
-                base_precompile_storage::BasePrecompileError::revert(
-                    crate::IB20Asset::InvalidDecimals {}
-                )
-            );
-        });
-    }
-
-    #[test]
-    fn decimals_19_reverts_with_invalid_decimals() {
-        let (mut storage, _) = setup_storage();
-
-        StorageCtx::enter(&mut storage, |ctx| {
-            let mut token = B20AssetStorage::from_address(TOKEN, ctx);
-            let err = token.initialize(make_init(19)).unwrap_err();
-            assert_eq!(
-                err,
-                base_precompile_storage::BasePrecompileError::revert(
-                    crate::IB20Asset::InvalidDecimals {}
-                )
-            );
-        });
-    }
-
-    #[test]
-    fn decimals_uninitialized_slot_falls_back_to_six() {
-        let (mut storage, _) = setup_storage();
-
-        StorageCtx::enter(&mut storage, |ctx| {
-            // Token address exists but initialize() was never called — storage slot is 0.
-            let token = B20AssetStorage::from_address(TOKEN, ctx);
-            assert_eq!(token.asset.decimals.read().unwrap(), 0, "raw slot should be 0");
-            assert_eq!(
-                crate::AssetAccounting::decimals(&token).unwrap(),
-                6,
-                "fallback must return 6 for uninitialized tokens"
-            );
         });
     }
 }

--- a/crates/common/precompiles/src/b20_factory/abi.rs
+++ b/crates/common/precompiles/src/b20_factory/abi.rs
@@ -27,8 +27,6 @@ sol! {
             string name;
             string symbol;
             address initialAdmin;
-            string isin;
-            uint256 minimumRedeemable;
             uint8 decimals;
         }
 
@@ -53,6 +51,9 @@ sol! {
         /// One of the post-creation init calls failed.
         error InitCallFailed(uint256 index);
 
+        /// The asset `decimals` was outside the allowed range.
+        error InvalidDecimals(uint8 decimals);
+
         // ── Events ───────────────────────────────────────────────────────────
 
         event B20Created(
@@ -61,7 +62,7 @@ sol! {
             string name,
             string symbol,
             uint8 decimals,
-            bytes variantParams
+            bytes variantEventParams
         );
 
         /// ABI-encoded payload for the `variantParams` field of `B20Created`

--- a/crates/common/precompiles/src/b20_factory/storage.rs
+++ b/crates/common/precompiles/src/b20_factory/storage.rs
@@ -12,12 +12,10 @@ use crate::{
     RoleManaged, Token,
 };
 
-/// Version byte for `B20StablecoinEventParams` inside `B20Created.variantParams`.
+/// Version byte for `B20StablecoinEventParams` inside `B20Created.variantEventParams`.
 const B20_STABLECOIN_EVENT_PARAMS_VERSION: u8 = 1;
 
-/// ABI-encodes stablecoin-specific `variantParams` for `B20Created`.
-/// DEFAULT and ASSET call sites use `Bytes::new()` directly.
-fn encode_stablecoin_variant_params(currency: &str) -> Bytes {
+fn encode_stablecoin_variant_event_params(currency: &str) -> Bytes {
     IB20Factory::B20StablecoinEventParams {
         version: B20_STABLECOIN_EVENT_PARAMS_VERSION,
         currency: currency.to_string(),
@@ -121,8 +119,8 @@ impl<'a> B20FactoryStorage<'a> {
             variant: B20Variant::Stablecoin.abi(),
             name,
             symbol,
-            decimals: B20Variant::Stablecoin.decimals(),
-            variantParams: encode_stablecoin_variant_params(&currency),
+            decimals: B20Variant::STABLECOIN_DECIMALS,
+            variantEventParams: encode_stablecoin_variant_event_params(&currency),
         })?;
 
         if !common.initial_admin.is_zero() {
@@ -155,7 +153,7 @@ impl<'a> B20FactoryStorage<'a> {
             B20AssetStorage::from_address(token_address, self.storage),
             PolicyHandle::new(self.storage),
         );
-        let (name, symbol) = (init.name.clone(), init.symbol.clone());
+        let (name, symbol, decimals) = (init.name.clone(), init.symbol.clone(), init.decimals);
         token.accounting_mut().initialize(init)?;
 
         self.emit_event(IB20Factory::B20Created {
@@ -163,8 +161,8 @@ impl<'a> B20FactoryStorage<'a> {
             variant: B20Variant::Asset.abi(),
             name,
             symbol,
-            decimals: B20Variant::Asset.decimals(),
-            variantParams: Bytes::new(),
+            decimals,
+            variantEventParams: Bytes::new(),
         })?;
 
         if !common.initial_admin.is_zero() {
@@ -267,9 +265,7 @@ impl TokenCreateParams {
                         symbol: p.symbol,
                         supply_cap: DEFAULT_SUPPLY_CAP,
                         multiplier: INITIAL_MULTIPLIER,
-                        isin: p.isin,
                         decimals: p.decimals,
-                        minimum_redeemable: p.minimumRedeemable,
                     },
                 })
             }
@@ -283,27 +279,26 @@ impl TokenCreateParams {
         }
     }
 
-    /// Validates variant-specific invariants after the shared version check.
-    ///
-    /// Each arm owns its own rules. Version is checked first by the caller (`check_version`)
-    /// so that version errors always take precedence over field-level errors.
-    pub const fn validate(&self) -> Result<()> {
+    /// Validates the token create parameters for the variant.
+    pub fn validate(&self) -> Result<()> {
         match self {
             Self::Stablecoin { init, .. } => Self::validate_stablecoin(init),
             Self::Asset { init, .. } => Self::validate_asset(init),
         }
     }
 
-    /// Validates stablecoin initialization fields.
+    /// Validates stablecoin-specific create parameters.
     pub const fn validate_stablecoin(_init: &B20StablecoinInit) -> Result<()> {
-        // Currency validation is delegated to `B20StablecoinStorage::initialize`, which rejects
-        // empty values with `MissingRequiredField` and non-A-Z values with `InvalidCurrency`.
         Ok(())
     }
 
-    /// Validates asset-token initialization fields.
-    pub const fn validate_asset(_init: &B20AssetInit) -> Result<()> {
-        // isin is optional — empty string is accepted.
+    /// Validates asset-specific create parameters (decimals range).
+    pub fn validate_asset(init: &B20AssetInit) -> Result<()> {
+        if !B20Variant::is_valid_asset_decimals(init.decimals) {
+            return Err(BasePrecompileError::revert(IB20Factory::InvalidDecimals {
+                decimals: init.decimals,
+            }));
+        }
         Ok(())
     }
 
@@ -355,8 +350,6 @@ mod tests {
             name: name.to_string(),
             symbol: symbol.to_string(),
             initialAdmin: Address::repeat_byte(0xAB),
-            isin: String::new(),
-            minimumRedeemable: U256::ZERO,
             decimals: 6,
         }
     }
@@ -422,19 +415,18 @@ mod tests {
         assert_eq!(addr.as_slice()[11..], tail);
         assert!(B20Variant::is_b20_address(addr));
         assert_eq!(B20Variant::from_address(addr), Some(B20Variant::Asset));
-        assert_eq!(B20Variant::decimals_of(addr), Some(6));
     }
 
     #[test]
-    fn test_address_derivation_ignores_decimals_and_uses_variant() {
+    fn test_address_derivation_uses_variant() {
         let creator = Address::repeat_byte(0x11);
         let salt = B256::repeat_byte(0x33);
         let (asset_token, _) = B20Variant::Asset.compute_address(creator, salt);
         let (stablecoin, _) = B20Variant::Stablecoin.compute_address(creator, salt);
 
         assert_ne!(asset_token, stablecoin);
-        assert_eq!(B20Variant::decimals_of(asset_token), Some(6));
-        assert_eq!(B20Variant::decimals_of(stablecoin), Some(6));
+        assert_eq!(B20Variant::from_address(asset_token), Some(B20Variant::Asset));
+        assert_eq!(B20Variant::from_address(stablecoin), Some(B20Variant::Stablecoin));
     }
 
     #[test]
@@ -479,7 +471,7 @@ mod tests {
     }
 
     #[test]
-    fn test_create_token_stores_metadata_and_uses_variant_decimals() {
+    fn test_create_token_stores_metadata_and_decimals() {
         let mut storage = HashMapStorageProvider::new(1);
         activate_precompiles(&mut storage);
         let caller = Address::repeat_byte(0x55);
@@ -496,7 +488,6 @@ mod tests {
             assert_eq!(token.b20.symbol.read().unwrap(), "MYT");
             assert_eq!(token.decimals().unwrap(), 6);
             assert_eq!(token.supply_cap().unwrap(), B20FactoryStorage::DEFAULT_SUPPLY_CAP);
-            assert_eq!(B20Variant::decimals_of(token_addr), Some(6));
         });
     }
 
@@ -751,12 +742,11 @@ mod tests {
             assert_eq!(stablecoin.stablecoin.currency.read().unwrap(), "USD");
             assert_eq!(stablecoin.b20.name.read().unwrap(), "Stablecoin Token");
             assert_eq!(B20Variant::from_address(stablecoin_addr), Some(B20Variant::Stablecoin));
-            assert_eq!(B20Variant::decimals_of(stablecoin_addr), Some(6));
         });
     }
 
     #[test]
-    fn test_create_asset_token_stores_isin_and_ratio() {
+    fn test_create_asset_token_stores_decimals_and_ratio() {
         let mut storage = HashMapStorageProvider::new(1);
         activate_precompiles(&mut storage);
         let caller = Address::repeat_byte(0x55);
@@ -768,9 +758,7 @@ mod tests {
             name: "Asset Token".to_string(),
             symbol: "AST".to_string(),
             initialAdmin: Address::repeat_byte(0xAB),
-            isin: "US0000000000".to_string(),
-            minimumRedeemable: U256::ONE,
-            decimals: 6,
+            decimals: 12,
         };
         let asset_call = IB20Factory::createB20Call {
             variant: IB20Factory::B20Variant::ASSET,
@@ -790,14 +778,8 @@ mod tests {
             let asset_storage = B20AssetStorage::from_address(expected_addr, ctx);
             assert_eq!(asset_storage.b20.name.read().unwrap(), "Asset Token");
             assert_eq!(asset_storage.b20.symbol.read().unwrap(), "AST");
-            assert_eq!(asset_storage.decimals().unwrap(), 6);
+            assert_eq!(asset_storage.decimals().unwrap(), 12);
             assert_eq!(asset_storage.asset.multiplier.read().unwrap(), U256::ZERO);
-            assert_eq!(asset_storage.redeem.minimum_redeemable.read().unwrap(), U256::ONE);
-            // ISIN is stored in the identifiers mapping under the raw "ISIN" key.
-            assert_eq!(
-                asset_storage.asset.identifiers.at(&String::from("ISIN")).read().unwrap(),
-                "US0000000000"
-            );
         });
     }
 
@@ -1128,9 +1110,7 @@ mod tests {
             name: "Asset Token".to_string(),
             symbol: "AST".to_string(),
             initialAdmin: initial_admin,
-            isin: "US0000000001".to_string(),
-            minimumRedeemable: U256::ZERO,
-            decimals: 6,
+            decimals: 8,
         };
         let call = IB20Factory::createB20Call {
             variant: IB20Factory::B20Variant::ASSET,
@@ -1151,15 +1131,12 @@ mod tests {
             assert!(!token.has_role(B20TokenRole::DefaultAdmin.id(), Address::ZERO).unwrap());
         });
 
-        // Zero initialAdmin grants no role.
         let params_no_admin = IB20Factory::B20AssetCreateParams {
             version: B20Variant::Asset.supported_version(),
             name: "No Admin".to_string(),
             symbol: "NA".to_string(),
             initialAdmin: Address::ZERO,
-            isin: "US0000000002".to_string(),
-            minimumRedeemable: U256::ZERO,
-            decimals: 6,
+            decimals: 8,
         };
         let call_no_admin = IB20Factory::createB20Call {
             variant: IB20Factory::B20Variant::ASSET,
@@ -1182,7 +1159,7 @@ mod tests {
     }
 
     #[test]
-    fn b20created_asset_variant_emits_empty_variant_params() {
+    fn b20created_asset_variant_emits_empty_variant_event_params() {
         let mut storage = HashMapStorageProvider::new(1);
         activate_precompiles(&mut storage);
         let call = IB20Factory::createB20Call {
@@ -1193,9 +1170,7 @@ mod tests {
                 name: "T".to_string(),
                 symbol: "T".to_string(),
                 initialAdmin: Address::repeat_byte(0xAB),
-                isin: String::new(),
-                minimumRedeemable: U256::ZERO,
-                decimals: 6,
+                decimals: 18,
             }
             .abi_encode()
             .into(),
@@ -1210,7 +1185,7 @@ mod tests {
             .iter()
             .find_map(|l| IB20Factory::B20Created::decode_log_data(l).ok())
             .expect("B20Created must be emitted");
-        assert!(event.variantParams.is_empty(), "ASSET variantParams must be empty");
+        assert!(event.variantEventParams.is_empty(), "ASSET variantEventParams must be empty");
     }
 
     #[test]
@@ -1240,9 +1215,12 @@ mod tests {
             .iter()
             .find_map(|l| IB20Factory::B20Created::decode_log_data(l).ok())
             .expect("B20Created must be emitted");
-        assert!(!event.variantParams.is_empty(), "STABLECOIN variantParams must not be empty");
-        let params = IB20Factory::B20StablecoinEventParams::abi_decode(&event.variantParams)
-            .expect("variantParams must decode as B20StablecoinEventParams");
+        assert!(
+            !event.variantEventParams.is_empty(),
+            "STABLECOIN variantEventParams must not be empty"
+        );
+        let params = IB20Factory::B20StablecoinEventParams::abi_decode(&event.variantEventParams)
+            .expect("variantEventParams must decode as B20StablecoinEventParams");
         assert_eq!(params.version, super::B20_STABLECOIN_EVENT_PARAMS_VERSION);
         assert_eq!(params.currency, "USD");
     }
@@ -1254,5 +1232,31 @@ mod tests {
         // constant sharing.
         assert!(B20Variant::Stablecoin.supported_version() > 0);
         assert!(B20Variant::Asset.supported_version() > 0);
+    }
+
+    #[test]
+    fn test_invalid_decimals_reverts() {
+        let mut storage = HashMapStorageProvider::new(1);
+        activate_precompiles(&mut storage);
+        let call = IB20Factory::createB20Call {
+            variant: IB20Factory::B20Variant::ASSET,
+            salt: B256::repeat_byte(0x72),
+            params: IB20Factory::B20AssetCreateParams {
+                version: 1,
+                name: "Bad".to_string(),
+                symbol: "BAD".to_string(),
+                initialAdmin: Address::repeat_byte(0xAB),
+                decimals: 5,
+            }
+            .abi_encode()
+            .into(),
+            initCalls: Vec::new(),
+        };
+        StorageCtx::enter(&mut storage, |ctx| {
+            assert_output(
+                dispatch_factory_revert(ctx, call),
+                IB20Factory::InvalidDecimals { decimals: 5 }.abi_encode(),
+            );
+        });
     }
 }

--- a/crates/common/precompiles/src/b20_factory/variant.rs
+++ b/crates/common/precompiles/src/b20_factory/variant.rs
@@ -29,6 +29,15 @@ impl B20Variant {
     /// Variant discriminant for stablecoin B-20 tokens.
     pub const STABLECOIN_DISCRIMINANT: u8 = Self::Stablecoin as u8;
 
+    /// Minimum allowed decimals for the Asset variant.
+    pub const MIN_ASSET_DECIMALS: u8 = 6;
+
+    /// Maximum allowed decimals for the Asset variant.
+    pub const MAX_ASSET_DECIMALS: u8 = 18;
+
+    /// Fixed decimals value for the Stablecoin variant.
+    pub const STABLECOIN_DECIMALS: u8 = 6;
+
     /// Returns the currently supported creation-parameter version for this variant.
     ///
     /// Each variant owns its version independently so that one variant advancing to v2
@@ -93,11 +102,9 @@ impl B20Variant {
         }
     }
 
-    /// Returns this variant's fixed decimal precision.
-    pub const fn decimals(self) -> u8 {
-        match self {
-            Self::Asset | Self::Stablecoin => 6,
-        }
+    /// Returns whether `decimals` is valid for the Asset variant.
+    pub const fn is_valid_asset_decimals(decimals: u8) -> bool {
+        decimals >= Self::MIN_ASSET_DECIMALS && decimals <= Self::MAX_ASSET_DECIMALS
     }
 
     /// Returns the activation feature that controls creation of this variant.
@@ -157,10 +164,5 @@ impl B20Variant {
     pub fn variant_of(address: Address) -> Option<u8> {
         Self::from_address(address)?;
         Some(address.as_slice()[10])
-    }
-
-    /// Returns the fixed decimals for the variant encoded in `address`.
-    pub fn decimals_of(address: Address) -> Option<u8> {
-        Some(Self::from_address(address)?.decimals())
     }
 }

--- a/etc/systems/src/b20.rs
+++ b/etc/systems/src/b20.rs
@@ -115,9 +115,7 @@ impl<'a> B20PrecompileClient<'a> {
                 name: name.to_string(),
                 symbol: symbol.to_string(),
                 initialAdmin: initial_admin,
-                isin: String::new(),
-                minimumRedeemable: U256::ZERO,
-                decimals: 6,
+                decimals: 8,
             },
             initial_supply,
             initial_supply_recipient,
@@ -224,9 +222,10 @@ impl<'a> B20PrecompileClient<'a> {
         B20Variant::from_address(token).wrap_err("Token address is not a supported B-20 token")
     }
 
-    /// Reads the fixed decimals for the token variant encoded in an address.
+    /// Reads the decimals for a B-20 token.
     pub async fn decimals_of(&self, token: Address) -> Result<u8> {
-        B20Variant::decimals_of(token).wrap_err("Token address is not a supported B-20 token")
+        let result = self.call(token, IB20::decimalsCall {}).await?;
+        Ok(result.0)
     }
 
     /// Mints B-20 tokens to an account.


### PR DESCRIPTION
## Summary

BOP-244: Add configurable decimals field to B20AssetCreateParams, replacing isin/minimumRedeemable.

## Changes

- **B20AssetCreateParams**: Replaced `isin` (string) and `minimumRedeemable` (uint256) with `decimals` (uint8)
- **B20Created event**: Renamed `variantParams` to `variantEventParams` for clarity
- **Error handling**: Added `InvalidDecimals(uint8)` error for validation failures
- **B20Variant constants**: Added `MIN_ASSET_DECIMALS=6`, `MAX_ASSET_DECIMALS=18`, `STABLECOIN_DECIMALS=6`
- **B20AssetExtensionStorage**: Added `decimals` field at storage offset 3
- **TokenAccounting macro**: `decimals()` returns `STABLECOIN_DECIMALS`; Asset tokens override via their own `decimals()` method
- **Tests**: Updated all factory and harness tests

## Validation

- All 353 tests pass in `base-common-precompiles`
- Asset decimals validated to range 6-18
- Stablecoin decimals fixed at 6

## Notes

- `minimumRedeemable` functionality still exists on Asset tokens (getter/setter) - just removed from factory create params
- `isin` (security identifier) can still be set post-creation via `updateSecurityIdentifier`

Depends on: rayyan/bop-242-remove-b20-default-variant