### PR TITLE
refactor(b20-asset): rename share ratio to multiplier (BOP-238)

### DIFF
--- a/actions/harness/tests/beryl/security.rs
+++ b/actions/harness/tests/beryl/security.rs
@@ -89,24 +89,20 @@ async fn security_creation_initializes_identifiers_and_factory_views() {
                     IB20::balanceOfCall { account: BerylTestEnv::alice() }.abi_encode(),
                     U256::from(BerylTestEnv::B20_INITIAL_SUPPLY),
                 ),
-                StaticcallCase::word(
-                    "sharesToTokensRatio",
-                    IB20Asset::sharesToTokensRatioCall {}.abi_encode(),
-                    WAD,
-                ),
+                StaticcallCase::word("multiplier", IB20Asset::multiplierCall {}.abi_encode(), WAD),
                 StaticcallCase::word(
                     "WAD_PRECISION",
                     IB20Asset::WAD_PRECISIONCall {}.abi_encode(),
                     WAD,
                 ),
                 StaticcallCase::word(
-                    "toShares",
-                    IB20Asset::toSharesCall { balance: U256::from(100) }.abi_encode(),
+                    "toScaledBalance",
+                    IB20Asset::toScaledBalanceCall { rawBalance: U256::from(100) }.abi_encode(),
                     U256::from(100),
                 ),
                 StaticcallCase::word(
-                    "sharesOf(alice)",
-                    IB20Asset::sharesOfCall { account: BerylTestEnv::alice() }.abi_encode(),
+                    "scaledBalanceOf(alice)",
+                    IB20Asset::scaledBalanceOfCall { account: BerylTestEnv::alice() }.abi_encode(),
                     U256::from(BerylTestEnv::B20_INITIAL_SUPPLY),
                 ),
                 StaticcallCase::word(
@@ -138,7 +134,7 @@ async fn security_mutations_update_state_and_emit_events() {
     scenario.grant_roles([security_operator_role(), B20TokenRole::Mint.id()]).await;
 
     let update_ratio =
-        scenario.call_tx(IB20Asset::updateShareRatioCall { newSharesToTokensRatio: UPDATED_RATIO });
+        scenario.call_tx(IB20Asset::updateMultiplierCall { newMultiplier: UPDATED_RATIO });
     let update_cusip = scenario.call_tx(IB20Asset::updateExtraMetadataCall {
         identifierType: "CUSIP".to_string(),
         value: CUSIP.to_string(),
@@ -171,7 +167,7 @@ async fn security_mutations_update_state_and_emit_events() {
     scenario.assert_log(
         &block,
         0,
-        IB20Asset::ShareRatioUpdated { sharesToTokensRatio: UPDATED_RATIO }.encode_log_data(),
+        IB20Asset::MultiplierUpdated { multiplier: UPDATED_RATIO }.encode_log_data(),
     );
     scenario.assert_log(
         &block,
@@ -238,18 +234,18 @@ async fn security_mutations_update_state_and_emit_events() {
             scenario.token,
             vec![
                 StaticcallCase::word(
-                    "sharesToTokensRatio after update",
-                    IB20Asset::sharesToTokensRatioCall {}.abi_encode(),
+                    "multiplier after update",
+                    IB20Asset::multiplierCall {}.abi_encode(),
                     UPDATED_RATIO,
                 ),
                 StaticcallCase::word(
-                    "toShares after update",
-                    IB20Asset::toSharesCall { balance: U256::from(50) }.abi_encode(),
+                    "toScaledBalance after update",
+                    IB20Asset::toScaledBalanceCall { rawBalance: U256::from(50) }.abi_encode(),
                     U256::from(100),
                 ),
                 StaticcallCase::word(
-                    "sharesOf(alice) after update",
-                    IB20Asset::sharesOfCall { account: BerylTestEnv::alice() }.abi_encode(),
+                    "scaledBalanceOf(alice) after update",
+                    IB20Asset::scaledBalanceOfCall { account: BerylTestEnv::alice() }.abi_encode(),
                     U256::from(BerylTestEnv::B20_INITIAL_SUPPLY) * U256::from(2),
                 ),
                 StaticcallCase::string(
@@ -401,7 +397,7 @@ async fn security_calls_succeed_while_security_feature_is_deactivated() {
 
     let probe_call = scenario.env.call_staticcall_probe_tx(
         probe,
-        Bytes::from(IB20Asset::sharesToTokensRatioCall {}.abi_encode()),
+        Bytes::from(IB20Asset::multiplierCall {}.abi_encode()),
         BerylTestEnv::B20_PROBE_GAS_LIMIT,
     );
     let block = scenario.build_block_with_transactions(vec![probe_call]).await;

--- a/crates/common/precompile-macros/src/accounting.rs
+++ b/crates/common/precompile-macros/src/accounting.rs
@@ -315,15 +315,15 @@ fn expand_security(input: DeriveInput) -> syn::Result<TokenStream> {
             fn multiplier(
                 &self,
             ) -> ::base_precompile_storage::Result<::alloy_primitives::U256> {
-                let ratio = self.security.multiplier()?;
-                Ok(if ratio.is_zero() { Self::WAD } else { ratio })
+                let multiplier = self.security.multiplier()?;
+                Ok(if multiplier.is_zero() { Self::WAD } else { multiplier })
             }
 
             fn set_multiplier(
                 &mut self,
-                ratio: ::alloy_primitives::U256,
+                multiplier: ::alloy_primitives::U256,
             ) -> ::base_precompile_storage::Result<()> {
-                self.security.set_multiplier(ratio)
+                self.security.set_multiplier(multiplier)
             }
 
             fn extra_metadata(

--- a/crates/common/precompile-macros/src/accounting.rs
+++ b/crates/common/precompile-macros/src/accounting.rs
@@ -312,18 +312,18 @@ fn expand_security(input: DeriveInput) -> syn::Result<TokenStream> {
     let name = input.ident;
     Ok(quote! {
         impl crate::SecurityAccounting for #name<'_> {
-            fn shares_to_tokens_ratio(
+            fn multiplier(
                 &self,
             ) -> ::base_precompile_storage::Result<::alloy_primitives::U256> {
-                let ratio = self.security.shares_to_tokens_ratio()?;
+                let ratio = self.security.multiplier()?;
                 Ok(if ratio.is_zero() { Self::WAD } else { ratio })
             }
 
-            fn set_shares_to_tokens_ratio(
+            fn set_multiplier(
                 &mut self,
                 ratio: ::alloy_primitives::U256,
             ) -> ::base_precompile_storage::Result<()> {
-                self.security.set_shares_to_tokens_ratio(ratio)
+                self.security.set_multiplier(ratio)
             }
 
             fn extra_metadata(

--- a/crates/common/precompile-storage/README.md
+++ b/crates/common/precompile-storage/README.md
@@ -41,7 +41,7 @@ field with that type is automatically mounted at the type's namespace root:
 #[derive(Debug, Clone, Storable)]
 #[namespace("b20.asset")]
 pub struct B20AssetStorage {
-    pub shares_to_tokens_ratio: U256,
+    pub multiplier: U256,
 }
 
 #[contract]

--- a/crates/common/precompile-storage/tests/contract.rs
+++ b/crates/common/precompile-storage/tests/contract.rs
@@ -299,7 +299,7 @@ mod type_namespaced_layouts {
     #[derive(Debug, Clone, Storable)]
     #[namespace("b20.security")]
     struct B20AssetStorage {
-        shares_to_tokens_ratio: U256,
+        multiplier: U256,
         used_announcement_ids: Mapping<String, bool>,
         security_identifiers: Mapping<String, bool>,
     }
@@ -326,7 +326,7 @@ mod type_namespaced_layouts {
     fn type_level_namespaces_mount_layouts_without_repeating_strings() {
         let b20_value = B20Storage { total_supply: U256::ZERO, balances: Mapping::default() };
         let security_value = B20AssetStorage {
-            shares_to_tokens_ratio: U256::ZERO,
+            multiplier: U256::ZERO,
             used_announcement_ids: Mapping::default(),
             security_identifiers: Mapping::default(),
         };
@@ -335,7 +335,7 @@ mod type_namespaced_layouts {
         let _ = (
             &b20_value.total_supply,
             &b20_value.balances,
-            &security_value.shares_to_tokens_ratio,
+            &security_value.multiplier,
             &security_value.used_announcement_ids,
             &security_value.security_identifiers,
             &redeem_value.minimum_redeemable,
@@ -371,7 +371,7 @@ mod type_namespaced_layouts {
             layout.local_head.write(0x11).unwrap();
             layout.b20.total_supply.write(U256::from(100)).unwrap();
             layout.b20.balances.at_mut(&holder).write(U256::from(25)).unwrap();
-            layout.security.shares_to_tokens_ratio.write(U256::from(2)).unwrap();
+            layout.security.multiplier.write(U256::from(2)).unwrap();
             layout.redeem.minimum_redeemable.write(U256::from(10)).unwrap();
             layout.redeem.redeem_policy_ids.write(U256::from(3)).unwrap();
             layout.local_tail.write(0x2233).unwrap();
@@ -379,7 +379,7 @@ mod type_namespaced_layouts {
             assert_eq!(layout.local_head.read().unwrap(), 0x11);
             assert_eq!(layout.b20.total_supply.read().unwrap(), U256::from(100));
             assert_eq!(layout.b20.balances.at(&holder).read().unwrap(), U256::from(25));
-            assert_eq!(layout.security.shares_to_tokens_ratio.read().unwrap(), U256::from(2));
+            assert_eq!(layout.security.multiplier.read().unwrap(), U256::from(2));
             assert_eq!(layout.redeem.minimum_redeemable.read().unwrap(), U256::from(10));
             assert_eq!(layout.redeem.redeem_policy_ids.read().unwrap(), U256::from(3));
             assert_eq!(layout.local_tail.read().unwrap(), 0x2233);
@@ -406,9 +406,7 @@ mod type_namespaced_layouts {
                 ctx.sload(
                     TYPE_NAMESPACE_ADDR,
                     slots::SECURITY
-                        + U256::from(
-                            __packing_b20_asset_storage::SHARES_TO_TOKENS_RATIO_LOC.offset_slots,
-                        ),
+                        + U256::from(__packing_b20_asset_storage::MULTIPLIER_LOC.offset_slots,),
                 )
                 .unwrap(),
                 U256::from(2)

--- a/crates/common/precompiles/README.md
+++ b/crates/common/precompiles/README.md
@@ -56,7 +56,7 @@ decimals, while stablecoin and security variants use 6 decimals.
 
 Default B-20 tokens implement the ERC-20 surface plus roles, pausing, supply caps, memo transfers,
 policy hooks, EIP-2612 permits, ERC-5267 domain reporting, and ERC-7572 contract metadata. The
-stablecoin variant adds currency metadata. The security variant adds share-ratio accounting,
+stablecoin variant adds currency metadata. The security variant adds multiplier-based scaling,
 minimum redeemable checks, batched mint and burn operations, security identifiers, and announcement
 flows that can execute internal token calls.
 

--- a/crates/common/precompiles/src/b20_asset/abi.rs
+++ b/crates/common/precompiles/src/b20_asset/abi.rs
@@ -22,8 +22,8 @@ sol! {
         /// A batched function was called with empty arrays.
         error EmptyBatch();
 
-        /// `redeem`/`redeemWithMemo` was called with a share count below the floor, or zero.
-        error BelowMinimumRedeemable(uint256 shares, uint256 minimum);
+        /// `redeem`/`redeemWithMemo` was called with a scaled amount below the floor, or zero.
+        error BelowMinimumRedeemable(uint256 scaledAmount, uint256 minimum);
 
         /// An `internalCalls` entry tried to invoke `announce` itself.
         error AnnouncementInProgress();
@@ -99,16 +99,16 @@ sol! {
 
         // ── Redemption ────────────────────────────────────────────────────────
 
-        /// Burns `amount` from caller with a share-based minimum floor check.
+        /// Burns `amount` from caller with a multiplier-scaled minimum floor check.
         function redeem(uint256 amount) external;
 
         /// Same as `redeem`, followed by a `Memo` event.
         function redeemWithMemo(uint256 amount, bytes32 memo) external;
 
-        /// Sets the minimum-redeemable threshold in shares. Requires `DEFAULT_ADMIN_ROLE`.
+        /// Sets the minimum-redeemable threshold in scaled units. Requires `DEFAULT_ADMIN_ROLE`.
         function updateMinimumRedeemable(uint256 newMinimumRedeemable) external;
 
-        /// Returns the minimum-redeemable threshold in shares.
+        /// Returns the minimum-redeemable threshold in scaled units.
         function minimumRedeemable() external view returns (uint256);
 
         // ── Security identifiers ─────────────────────────────────────────────

--- a/crates/common/precompiles/src/b20_asset/abi.rs
+++ b/crates/common/precompiles/src/b20_asset/abi.rs
@@ -36,14 +36,14 @@ sol! {
 
         // ── Events ───────────────────────────────────────────────────────────
 
-        /// Emitted by `redeem`/`redeemWithMemo`. Includes the active share ratio at redemption time.
-        event Redeemed(address indexed from, uint256 amt, uint256 sharesToTokensRatio);
+        /// Emitted by `redeem`/`redeemWithMemo`. Includes the active multiplier at redemption time.
+        event Redeemed(address indexed from, uint256 amt, uint256 multiplier);
 
         /// Emitted by `updateMinimumRedeemable`.
         event MinimumRedeemableUpdated(address indexed caller, uint256 newMinimumRedeemable);
 
-        /// Emitted by `updateShareRatio`.
-        event ShareRatioUpdated(uint256 sharesToTokensRatio);
+        /// Emitted by `updateMultiplier`.
+        event MultiplierUpdated(uint256 multiplier);
 
         /// Emitted by `updateExtraMetadata`. Empty `value` indicates removal.
         event ExtraMetadataUpdated(string identifierType, string value);
@@ -56,10 +56,10 @@ sol! {
 
         // ── Role / precision identifiers ─────────────────────────────────────
 
-        /// `keccak256("OPERATOR_ROLE")` — required for `announce`, `updateShareRatio`, `updateExtraMetadata`.
+        /// `keccak256("OPERATOR_ROLE")` — required for `announce`, `updateMultiplier`, `updateExtraMetadata`.
         function OPERATOR_ROLE() external view returns (bytes32);
 
-        /// Fixed-point precision for `sharesToTokensRatio`: `1e18` (one WAD).
+        /// Fixed-point precision for `multiplier`: `1e18` (one WAD).
         function WAD_PRECISION() external view returns (uint256);
 
         /// `keccak256("REDEEM_SENDER_POLICY")` — consulted on `redeem`/`redeemWithMemo`.
@@ -78,19 +78,19 @@ sol! {
         /// Returns true if `id` has been consumed by `announce`.
         function isAnnouncementIdUsed(string calldata id) external view returns (bool);
 
-        // ── Share ratio ───────────────────────────────────────────────────────
+        // ── Multiplier ────────────────────────────────────────────────────────
 
-        /// The current share-to-tokens ratio, scaled to `WAD_PRECISION`.
-        function sharesToTokensRatio() external view returns (uint256);
+        /// The current multiplier, scaled to `WAD_PRECISION`.
+        function multiplier() external view returns (uint256);
 
-        /// Converts `balance` tokens to shares: `balance * sharesToTokensRatio / WAD_PRECISION`.
-        function toShares(uint256 balance) external view returns (uint256);
+        /// Converts a raw balance to its scaled view: `rawBalance * multiplier / WAD_PRECISION`.
+        function toScaledBalance(uint256 rawBalance) external view returns (uint256);
 
-        /// Convenience: `toShares(balanceOf(account))`.
-        function sharesOf(address account) external view returns (uint256);
+        /// Convenience: `toScaledBalance(balanceOf(account))`.
+        function scaledBalanceOf(address account) external view returns (uint256);
 
-        /// Sets a new share ratio. Holder balances are not rewritten; share count derives at read time.
-        function updateShareRatio(uint256 newSharesToTokensRatio) external;
+        /// Sets a new multiplier. Holder balances are not rewritten; scaled balances derive at read time.
+        function updateMultiplier(uint256 newMultiplier) external;
 
         // ── Batched issuance and clawback ────────────────────────────────────
 
@@ -133,10 +133,10 @@ impl IB20Asset::IB20AssetCalls {
             Self::REDEEM_SENDER_POLICY(_) => "precompile-b20-asset-REDEEM_SENDER_POLICY",
             Self::announce(_) => "precompile-b20-asset-announce",
             Self::isAnnouncementIdUsed(_) => "precompile-b20-asset-isAnnouncementIdUsed",
-            Self::sharesToTokensRatio(_) => "precompile-b20-asset-sharesToTokensRatio",
-            Self::toShares(_) => "precompile-b20-asset-toShares",
-            Self::sharesOf(_) => "precompile-b20-asset-sharesOf",
-            Self::updateShareRatio(_) => "precompile-b20-asset-updateShareRatio",
+            Self::multiplier(_) => "precompile-b20-asset-multiplier",
+            Self::toScaledBalance(_) => "precompile-b20-asset-toScaledBalance",
+            Self::scaledBalanceOf(_) => "precompile-b20-asset-scaledBalanceOf",
+            Self::updateMultiplier(_) => "precompile-b20-asset-updateMultiplier",
             Self::batchMint(_) => "precompile-b20-asset-batchMint",
             Self::redeem(_) => "precompile-b20-asset-redeem",
             Self::redeemWithMemo(_) => "precompile-b20-asset-redeemWithMemo",

--- a/crates/common/precompiles/src/b20_asset/accounting.rs
+++ b/crates/common/precompiles/src/b20_asset/accounting.rs
@@ -12,10 +12,10 @@ use crate::TokenAccounting;
 /// Security identifiers (ISIN, CUSIP, etc.) and redeem parameters are only
 /// exposed through the security-token surface, not the base B-20 surface.
 pub trait SecurityAccounting: TokenAccounting {
-    /// Returns the current share-to-tokens ratio scaled to WAD (1e18).
-    fn shares_to_tokens_ratio(&self) -> Result<U256>;
-    /// Writes a new share-to-tokens ratio.
-    fn set_shares_to_tokens_ratio(&mut self, ratio: U256) -> Result<()>;
+    /// Returns the current multiplier scaled to WAD (1e18).
+    fn multiplier(&self) -> Result<U256>;
+    /// Writes a new multiplier.
+    fn set_multiplier(&mut self, ratio: U256) -> Result<()>;
 
     /// Returns the security identifier value for `identifier_type`, or an empty string if unset.
     fn extra_metadata(&self, identifier_type: &str) -> Result<String>;

--- a/crates/common/precompiles/src/b20_asset/accounting.rs
+++ b/crates/common/precompiles/src/b20_asset/accounting.rs
@@ -15,7 +15,7 @@ pub trait SecurityAccounting: TokenAccounting {
     /// Returns the current multiplier scaled to WAD (1e18).
     fn multiplier(&self) -> Result<U256>;
     /// Writes a new multiplier.
-    fn set_multiplier(&mut self, ratio: U256) -> Result<()>;
+    fn set_multiplier(&mut self, multiplier: U256) -> Result<()>;
 
     /// Returns the security identifier value for `identifier_type`, or an empty string if unset.
     fn extra_metadata(&self, identifier_type: &str) -> Result<String>;

--- a/crates/common/precompiles/src/b20_asset/dispatch.rs
+++ b/crates/common/precompiles/src/b20_asset/dispatch.rs
@@ -344,12 +344,10 @@ impl<S: SecurityAccounting, P: Policy> B20AssetToken<S, P> {
             SC::WAD_PRECISION(_) => B20AssetStorage::WAD.abi_encode().into(),
             SC::REDEEM_SENDER_POLICY(_) => Self::REDEEM_SENDER_POLICY.abi_encode().into(),
 
-            // --- Share ratio reads ---
-            SC::sharesToTokensRatio(_) => {
-                self.accounting().shares_to_tokens_ratio()?.abi_encode().into()
-            }
-            SC::toShares(c) => self.to_shares(c.balance)?.abi_encode().into(),
-            SC::sharesOf(c) => self.shares_of(c.account)?.abi_encode().into(),
+            // --- Multiplier reads ---
+            SC::multiplier(_) => self.accounting().multiplier()?.abi_encode().into(),
+            SC::toScaledBalance(c) => self.to_scaled_balance(c.rawBalance)?.abi_encode().into(),
+            SC::scaledBalanceOf(c) => self.scaled_balance_of(c.account)?.abi_encode().into(),
 
             // --- Announcement reads ---
             SC::isAnnouncementIdUsed(c) => {
@@ -361,9 +359,9 @@ impl<S: SecurityAccounting, P: Policy> B20AssetToken<S, P> {
                 self.accounting().extra_metadata(c.identifierType.as_str())?.abi_encode().into()
             }
 
-            // --- Share ratio mutations ---
-            SC::updateShareRatio(c) => {
-                self.update_share_ratio(caller, c.newSharesToTokensRatio, privileged)?;
+            // --- Multiplier mutations ---
+            SC::updateMultiplier(c) => {
+                self.update_multiplier(caller, c.newMultiplier, privileged)?;
                 Bytes::new()
             }
 
@@ -479,7 +477,7 @@ mod tests {
     const ACTIVATION_ADMIN: Address = Address::repeat_byte(0xcb);
     fn make_token() -> TestSecurityToken {
         let mut accounting = InMemoryTokenAccounting::new(TOKEN);
-        accounting.shares_to_tokens_ratio = B20AssetStorage::WAD; // 1:1 ratio
+        accounting.multiplier = B20AssetStorage::WAD; // 1:1 multiplier
         // Explicitly open redemption so non-policy tests are not blocked by the ALWAYS_BLOCK default.
         accounting.policy_ids.insert(REDEEM_SENDER_POLICY, PolicyRegistryStorage::ALWAYS_ALLOW_ID);
         TestSecurityToken::with_storage_and_policy(accounting, InMemoryPolicy::new())
@@ -515,17 +513,17 @@ mod tests {
     }
 
     #[test]
-    fn to_shares_one_to_one_ratio() {
+    fn to_scaled_balance_one_to_one_multiplier() {
         let token = make_token();
-        assert_eq!(token.to_shares(U256::from(100u64)).unwrap(), U256::from(100u64));
+        assert_eq!(token.to_scaled_balance(U256::from(100u64)).unwrap(), U256::from(100u64));
     }
 
     #[test]
-    fn to_shares_two_to_one_ratio() {
+    fn to_scaled_balance_two_to_one_multiplier() {
         let mut accounting = InMemoryTokenAccounting::new(TOKEN);
-        accounting.shares_to_tokens_ratio = B20AssetStorage::WAD * U256::from(2u64);
+        accounting.multiplier = B20AssetStorage::WAD * U256::from(2u64);
         let token = TestSecurityToken::with_storage_and_policy(accounting, InMemoryPolicy::new());
-        assert_eq!(token.to_shares(U256::from(50u64)).unwrap(), U256::from(100u64));
+        assert_eq!(token.to_scaled_balance(U256::from(50u64)).unwrap(), U256::from(100u64));
     }
 
     #[test]
@@ -621,7 +619,7 @@ mod tests {
     #[test]
     fn security_redeem_rejects_zero_shares() {
         let mut token = make_token();
-        token.accounting_mut().shares_to_tokens_ratio = U256::ONE;
+        token.accounting_mut().multiplier = U256::ONE;
         token.accounting_mut().balances.insert(ALICE, U256::from(100u64));
         token.accounting_mut().total_supply = U256::from(100u64);
 
@@ -648,7 +646,7 @@ mod tests {
     fn security_redeem_rejects_when_sender_policy_denies() {
         let policy_id = 7;
         let mut accounting = InMemoryTokenAccounting::new(TOKEN);
-        accounting.shares_to_tokens_ratio = B20AssetStorage::WAD;
+        accounting.multiplier = B20AssetStorage::WAD;
         accounting.balances.insert(ALICE, U256::from(100u64));
         accounting.total_supply = U256::from(100u64);
         accounting.policy_ids.insert(REDEEM_SENDER_POLICY, policy_id);
@@ -780,7 +778,7 @@ mod tests {
     fn security_redeem_with_non_unit_ratio_applies_correct_share_math() {
         let mut token = make_token();
         // 2:1 ratio: 1 token = 2 shares
-        token.accounting_mut().shares_to_tokens_ratio = B20AssetStorage::WAD * U256::from(2u64);
+        token.accounting_mut().multiplier = B20AssetStorage::WAD * U256::from(2u64);
         token.accounting_mut().balances.insert(ALICE, U256::from(100u64));
         token.accounting_mut().total_supply = U256::from(100u64);
         // minimum = 10 shares → need at least 5 tokens
@@ -824,43 +822,39 @@ mod tests {
         );
         assert_eq!(
             token.accounting().events[2],
-            IB20Asset::Redeemed {
-                from: ALICE,
-                amt: amount,
-                sharesToTokensRatio: B20AssetStorage::WAD,
-            }
-            .encode_log_data()
+            IB20Asset::Redeemed { from: ALICE, amt: amount, multiplier: B20AssetStorage::WAD }
+                .encode_log_data()
         );
     }
 
-    // --- toShares: zero balance / sub-WAD truncation / sharesOf delegation ---
+    // --- toScaledBalance: zero balance / sub-WAD truncation / scaledBalanceOf delegation ---
 
     #[test]
-    fn to_shares_zero_balance_yields_zero() {
+    fn to_scaled_balance_zero_balance_yields_zero() {
         let token = make_token();
-        assert_eq!(token.to_shares(U256::ZERO).unwrap(), U256::ZERO);
+        assert_eq!(token.to_scaled_balance(U256::ZERO).unwrap(), U256::ZERO);
     }
 
     #[test]
-    fn to_shares_sub_wad_ratio_truncates_to_zero() {
+    fn to_scaled_balance_sub_wad_multiplier_truncates_to_zero() {
         let mut accounting = InMemoryTokenAccounting::new(TOKEN);
-        // 0.5 WAD: 1 token → 0.5 shares → truncates to 0 via integer division
-        accounting.shares_to_tokens_ratio = B20AssetStorage::WAD / U256::from(2u64);
+        // 0.5 WAD: 1 token → 0.5 scaled → truncates to 0 via integer division
+        accounting.multiplier = B20AssetStorage::WAD / U256::from(2u64);
         let token = TestSecurityToken::with_storage_and_policy(accounting, InMemoryPolicy::new());
-        assert_eq!(token.to_shares(U256::from(1u64)).unwrap(), U256::ZERO);
+        assert_eq!(token.to_scaled_balance(U256::from(1u64)).unwrap(), U256::ZERO);
     }
 
     #[test]
-    fn shares_of_derives_from_balance() {
-        let mut token = make_token(); // 1:1 ratio
+    fn scaled_balance_of_derives_from_balance() {
+        let mut token = make_token(); // 1:1 multiplier
         token.accounting_mut().balances.insert(ALICE, U256::from(75u64));
-        // sharesOf(account) = toShares(balanceOf(account))
+        // scaledBalanceOf(account) = toScaledBalance(balanceOf(account))
         let balance = token.accounting().balance_of(ALICE).unwrap();
-        assert_eq!(token.to_shares(balance).unwrap(), U256::from(75u64));
+        assert_eq!(token.to_scaled_balance(balance).unwrap(), U256::from(75u64));
     }
 
     #[test]
-    fn storage_backed_redeem_uses_wad_when_share_ratio_slot_is_unset() {
+    fn storage_backed_redeem_uses_wad_when_multiplier_slot_is_unset() {
         let (mut storage, _) = setup_storage();
 
         StorageCtx::enter(&mut storage, |ctx| {
@@ -872,7 +866,7 @@ mod tests {
             token.accounting_mut().set_total_supply(U256::from(100u64)).unwrap();
             token.accounting_mut().set_minimum_redeemable(U256::from(10u64)).unwrap();
 
-            assert_eq!(token.accounting().shares_to_tokens_ratio().unwrap(), B20AssetStorage::WAD);
+            assert_eq!(token.accounting().multiplier().unwrap(), B20AssetStorage::WAD);
             token.security_redeem(ALICE, U256::from(10u64)).unwrap();
 
             assert_eq!(token.accounting().balance_of(ALICE).unwrap(), U256::from(90u64));
@@ -880,14 +874,14 @@ mod tests {
         });
     }
 
-    // --- updateShareRatio: persistence ---
+    // --- updateMultiplier: persistence ---
 
     #[test]
-    fn shares_to_tokens_ratio_update_persists() {
+    fn multiplier_update_persists() {
         let mut token = make_token();
-        let new_ratio = B20AssetStorage::WAD * U256::from(3u64);
-        token.accounting_mut().set_shares_to_tokens_ratio(new_ratio).unwrap();
-        assert_eq!(token.accounting().shares_to_tokens_ratio().unwrap(), new_ratio);
+        let new_multiplier = B20AssetStorage::WAD * U256::from(3u64);
+        token.accounting_mut().set_multiplier(new_multiplier).unwrap();
+        assert_eq!(token.accounting().multiplier().unwrap(), new_multiplier);
     }
 
     // --- extraMetadata / updateExtraMetadata ---
@@ -932,28 +926,28 @@ mod tests {
         assert!(!token.accounting().is_announcement_id_used(id).unwrap());
     }
 
-    /// `to_shares` must return an arithmetic overflow panic rather than silently
-    /// saturating when `balance * sharesToTokensRatio` exceeds `U256::MAX`.
+    /// `to_scaled_balance` must return an arithmetic overflow panic rather than silently
+    /// saturating when `rawBalance * multiplier` exceeds `U256::MAX`.
     #[test]
-    fn to_shares_overflows_when_product_exceeds_u256_max() {
+    fn to_scaled_balance_overflows_when_product_exceeds_u256_max() {
         let mut accounting = InMemoryTokenAccounting::new(TOKEN);
-        // Any balance > 1 overflows when multiplied by this ratio.
-        accounting.shares_to_tokens_ratio = U256::MAX / U256::from(2u64) + U256::ONE;
+        // Any balance > 1 overflows when multiplied by this multiplier.
+        accounting.multiplier = U256::MAX / U256::from(2u64) + U256::ONE;
         let token = TestSecurityToken::with_storage_and_policy(accounting, InMemoryPolicy::new());
 
         assert_eq!(
-            token.to_shares(U256::from(2u64)).unwrap_err(),
+            token.to_scaled_balance(U256::from(2u64)).unwrap_err(),
             BasePrecompileError::under_overflow()
         );
     }
 
     /// `security_redeem` must return an arithmetic overflow panic rather than
-    /// silently saturating when `amount * sharesToTokensRatio` exceeds `U256::MAX`.
+    /// silently saturating when `amount * multiplier` exceeds `U256::MAX`.
     #[test]
     fn security_redeem_overflows_when_product_exceeds_u256_max() {
         let mut accounting = InMemoryTokenAccounting::new(TOKEN);
-        // Any amount > 1 overflows when multiplied by this ratio.
-        accounting.shares_to_tokens_ratio = U256::MAX / U256::from(2u64) + U256::ONE;
+        // Any amount > 1 overflows when multiplied by this multiplier.
+        accounting.multiplier = U256::MAX / U256::from(2u64) + U256::ONE;
         accounting.balances.insert(ALICE, U256::from(2u64));
         accounting.total_supply = U256::from(2u64);
         // Open redemption so the policy gate does not block the call before the overflow.

--- a/crates/common/precompiles/src/b20_asset/dispatch.rs
+++ b/crates/common/precompiles/src/b20_asset/dispatch.rs
@@ -731,7 +731,7 @@ mod tests {
         );
     }
 
-    // --- redeem: InsufficientBalance / boundary / ratio math / event pair ---
+    // --- redeem: InsufficientBalance / boundary / scaled math / event pair ---
 
     #[test]
     fn security_redeem_rejects_insufficient_balance() {
@@ -797,7 +797,7 @@ mod tests {
         token.accounting_mut().total_supply = U256::from(100u64);
         token.accounting_mut().minimum_redeemable = U256::from(1u64);
         token.security_redeem(ALICE, U256::from(10u64)).unwrap();
-        // "Emits Transfer(caller, address(0), amount) followed by Redeemed(caller, amount, ratio)"
+        // "Emits Transfer(caller, address(0), amount) followed by Redeemed(caller, amount, multiplier)"
         assert_eq!(token.accounting().events.len(), 2);
     }
 

--- a/crates/common/precompiles/src/b20_asset/dispatch.rs
+++ b/crates/common/precompiles/src/b20_asset/dispatch.rs
@@ -387,7 +387,7 @@ impl<S: SecurityAccounting, P: Policy> B20AssetToken<S, P> {
                 Bytes::new()
             }
 
-            // --- Minimum redeemable (security version, in shares) ---
+            // --- Minimum redeemable (security version, in scaled units) ---
             SC::minimumRedeemable(_) => self.accounting().minimum_redeemable()?.abi_encode().into(),
             SC::updateMinimumRedeemable(c) => {
                 self.update_minimum_redeemable(caller, c.newMinimumRedeemable, privileged)?;
@@ -602,28 +602,28 @@ mod tests {
 
         assert_eq!(token.accounting().balance_of(ALICE).unwrap(), U256::from(100u64));
         assert_eq!(token.accounting().total_supply().unwrap(), U256::from(100u64));
-        assert_eq!(token.accounting().events.len(), 2); // Transfer(ALICE, 0x0, 0) + Redeemed(ALICE, 0, ratio)
+        assert_eq!(token.accounting().events.len(), 2); // Transfer(ALICE, 0x0, 0) + Redeemed(ALICE, 0, multiplier)
     }
 
     #[test]
-    fn security_redeem_rejects_below_minimum_shares() {
+    fn security_redeem_rejects_below_minimum_scaled_amount() {
         let mut token = make_token();
         token.accounting_mut().balances.insert(ALICE, U256::from(100u64));
         token.accounting_mut().total_supply = U256::from(100u64);
         token.accounting_mut().minimum_redeemable = U256::from(10u64);
 
-        // 5 tokens * 1e18 ratio / 1e18 = 5 shares < 10 minimum
+        // 5 tokens * 1e18 multiplier / 1e18 = 5 scaled < 10 minimum
         assert!(token.security_redeem(ALICE, U256::from(5u64)).is_err());
     }
 
     #[test]
-    fn security_redeem_rejects_zero_shares() {
+    fn security_redeem_rejects_zero_scaled_amount() {
         let mut token = make_token();
         token.accounting_mut().multiplier = U256::ONE;
         token.accounting_mut().balances.insert(ALICE, U256::from(100u64));
         token.accounting_mut().total_supply = U256::from(100u64);
 
-        // 1 token-wei * 1 / WAD rounds down to 0 shares, which is always rejected.
+        // 1 token-wei * 1 / WAD rounds down to 0 scaled units, which is always rejected.
         assert!(token.security_redeem(ALICE, U256::ONE).is_err());
     }
 
@@ -739,7 +739,7 @@ mod tests {
         token.accounting_mut().balances.insert(ALICE, U256::from(10u64));
         token.accounting_mut().total_supply = U256::from(10u64);
         token.accounting_mut().minimum_redeemable = U256::from(1u64);
-        // amount=100 > balance=10 → InsufficientBalance after the share-floor check passes
+        // amount=100 > balance=10 → InsufficientBalance after the scaled-floor check passes
         assert!(token.security_redeem(ALICE, U256::from(100u64)).is_err());
         // no state mutation on failure
         assert_eq!(token.accounting().balance_of(ALICE).unwrap(), U256::from(10u64));
@@ -764,10 +764,10 @@ mod tests {
 
     #[test]
     fn security_redeem_at_exact_minimum_succeeds() {
-        let mut token = make_token(); // 1:1 ratio
+        let mut token = make_token(); // 1:1 multiplier
         token.accounting_mut().balances.insert(ALICE, U256::from(50u64));
         token.accounting_mut().total_supply = U256::from(50u64);
-        // 5 tokens * WAD / WAD = 5 shares == minimum → boundary must be accepted
+        // 5 tokens * WAD / WAD = 5 scaled == minimum → boundary must be accepted
         token.accounting_mut().minimum_redeemable = U256::from(5u64);
         token.security_redeem(ALICE, U256::from(5u64)).unwrap();
         assert_eq!(token.accounting().balance_of(ALICE).unwrap(), U256::from(45u64));
@@ -775,17 +775,17 @@ mod tests {
     }
 
     #[test]
-    fn security_redeem_with_non_unit_ratio_applies_correct_share_math() {
+    fn security_redeem_with_non_unit_multiplier_applies_correct_scaled_math() {
         let mut token = make_token();
-        // 2:1 ratio: 1 token = 2 shares
+        // 2x multiplier: 1 token scales to 2 units
         token.accounting_mut().multiplier = B20AssetStorage::WAD * U256::from(2u64);
         token.accounting_mut().balances.insert(ALICE, U256::from(100u64));
         token.accounting_mut().total_supply = U256::from(100u64);
-        // minimum = 10 shares → need at least 5 tokens
+        // minimum = 10 scaled → need at least 5 tokens
         token.accounting_mut().minimum_redeemable = U256::from(10u64);
-        // 4 tokens → 8 shares < 10 → BelowMinimumRedeemable
+        // 4 tokens → 8 scaled < 10 → BelowMinimumRedeemable
         assert!(token.security_redeem(ALICE, U256::from(4u64)).is_err());
-        // 5 tokens → 10 shares == minimum → accepted
+        // 5 tokens → 10 scaled == minimum → accepted
         token.security_redeem(ALICE, U256::from(5u64)).unwrap();
         assert_eq!(token.accounting().balance_of(ALICE).unwrap(), U256::from(95u64));
     }

--- a/crates/common/precompiles/src/b20_asset/storage.rs
+++ b/crates/common/precompiles/src/b20_asset/storage.rs
@@ -26,7 +26,7 @@ pub struct B20AssetExtensionStorage {
 #[derive(Debug, Clone, Storable)]
 #[namespace("base.b20.redeem")]
 pub struct B20RedeemStorage {
-    /// Minimum share amount required for a redeem operation.
+    /// Minimum scaled amount required for a redeem operation.
     #[accessor]
     #[mutator]
     pub minimum_redeemable: U256, // offset 0

--- a/crates/common/precompiles/src/b20_asset/storage.rs
+++ b/crates/common/precompiles/src/b20_asset/storage.rs
@@ -12,10 +12,10 @@ use crate::{B20CoreStorage, PolicyRegistryStorage};
 #[derive(Debug, Clone, Storable)]
 #[namespace("base.b20.asset")]
 pub struct B20AssetExtensionStorage {
-    /// Share-to-token conversion ratio scaled to WAD.
+    /// Multiplier scaled to WAD.
     #[accessor]
     #[mutator]
-    pub shares_to_tokens_ratio: U256, // offset 0
+    pub multiplier: U256, // offset 0
     /// Announcement IDs that have already been consumed.
     pub used_announcement_ids: Mapping<String, bool>, // offset 1
     /// Security identifier values by identifier type.
@@ -58,8 +58,8 @@ pub struct B20AssetInit {
     pub symbol: String,
     /// Maximum total supply.
     pub supply_cap: U256,
-    /// Share-to-token conversion ratio at WAD precision.
-    pub shares_to_tokens_ratio: U256,
+    /// Initial multiplier at WAD precision.
+    pub multiplier: U256,
     /// ISIN identifier stored under the `"ISIN"` key.
     pub isin: String,
     /// Minimum redeemable amount; `0` allows any non-zero redemption.
@@ -88,7 +88,7 @@ impl<'a> B20AssetStorage<'a> {
         self.b20.name.write(init.name)?;
         self.b20.symbol.write(init.symbol)?;
         self.b20.supply_cap.write(init.supply_cap)?;
-        self.security.shares_to_tokens_ratio.write(init.shares_to_tokens_ratio)?;
+        self.security.multiplier.write(init.multiplier)?;
         self.redeem.minimum_redeemable.write(init.minimum_redeemable)?;
         if !init.isin.is_empty() {
             self.security.identifiers.at_mut(&String::from("ISIN")).write(init.isin)?;
@@ -99,7 +99,7 @@ impl<'a> B20AssetStorage<'a> {
 }
 
 impl B20AssetStorage<'_> {
-    /// WAD precision for share ratio arithmetic: 1e18.
+    /// WAD precision for multiplier arithmetic: 1e18.
     pub const WAD: U256 = U256::from_limbs([1_000_000_000_000_000_000, 0, 0, 0]);
 
     /// Writes the default `redeem_sender_policy_id` to `ALWAYS_BLOCK_ID`.
@@ -151,10 +151,7 @@ mod tests {
 
     #[test]
     fn asset_extension_offsets_match_mock_storage() {
-        assert_eq!(
-            __packing_b20_asset_extension_storage::SHARES_TO_TOKENS_RATIO_LOC.offset_slots,
-            0
-        );
+        assert_eq!(__packing_b20_asset_extension_storage::MULTIPLIER_LOC.offset_slots, 0);
         assert_eq!(
             __packing_b20_asset_extension_storage::USED_ANNOUNCEMENT_IDS_LOC.offset_slots,
             1
@@ -166,37 +163,33 @@ mod tests {
     }
 
     #[test]
-    fn shares_to_tokens_ratio_defaults_unset_slot_to_wad() {
+    fn multiplier_defaults_unset_slot_to_wad() {
         let (mut storage, _) = setup_storage();
 
         StorageCtx::enter(&mut storage, |ctx| {
             let token = B20AssetStorage::from_address(TOKEN, ctx);
-            let ratio_slot = ASSET_ROOT
-                + U256::from(
-                    __packing_b20_asset_extension_storage::SHARES_TO_TOKENS_RATIO_LOC.offset_slots,
-                );
+            let multiplier_slot = ASSET_ROOT
+                + U256::from(__packing_b20_asset_extension_storage::MULTIPLIER_LOC.offset_slots);
 
-            assert_eq!(ctx.sload(TOKEN, ratio_slot).unwrap(), U256::ZERO);
-            assert_eq!(token.shares_to_tokens_ratio().unwrap(), B20AssetStorage::WAD);
+            assert_eq!(ctx.sload(TOKEN, multiplier_slot).unwrap(), U256::ZERO);
+            assert_eq!(token.multiplier().unwrap(), B20AssetStorage::WAD);
         });
     }
 
     #[test]
-    fn shares_to_tokens_ratio_preserves_configured_value() {
+    fn multiplier_preserves_configured_value() {
         let (mut storage, _) = setup_storage();
-        let configured_ratio = B20AssetStorage::WAD * U256::from(3u64);
+        let configured_multiplier = B20AssetStorage::WAD * U256::from(3u64);
 
         StorageCtx::enter(&mut storage, |ctx| {
             let mut token = B20AssetStorage::from_address(TOKEN, ctx);
-            token.set_shares_to_tokens_ratio(configured_ratio).unwrap();
+            token.set_multiplier(configured_multiplier).unwrap();
 
-            let ratio_slot = ASSET_ROOT
-                + U256::from(
-                    __packing_b20_asset_extension_storage::SHARES_TO_TOKENS_RATIO_LOC.offset_slots,
-                );
+            let multiplier_slot = ASSET_ROOT
+                + U256::from(__packing_b20_asset_extension_storage::MULTIPLIER_LOC.offset_slots);
 
-            assert_eq!(ctx.sload(TOKEN, ratio_slot).unwrap(), configured_ratio);
-            assert_eq!(token.shares_to_tokens_ratio().unwrap(), configured_ratio);
+            assert_eq!(ctx.sload(TOKEN, multiplier_slot).unwrap(), configured_multiplier);
+            assert_eq!(token.multiplier().unwrap(), configured_multiplier);
         });
     }
 
@@ -273,7 +266,7 @@ mod tests {
                     name: String::from("Test"),
                     symbol: String::from("TST"),
                     supply_cap: U256::from(1_000_000u64),
-                    shares_to_tokens_ratio: B20AssetStorage::WAD,
+                    multiplier: B20AssetStorage::WAD,
                     isin: String::new(),
                     minimum_redeemable: U256::ZERO,
                 })

--- a/crates/common/precompiles/src/b20_asset/token.rs
+++ b/crates/common/precompiles/src/b20_asset/token.rs
@@ -223,10 +223,10 @@ impl<S: SecurityAccounting, P: Policy> B20AssetToken<S, P> {
 
     // --- Security Redeem Operations ---
 
-    /// Performs a security-specific redeem: share-based floor check, burn, security `Redeemed` event.
+    /// Performs a security-specific redeem: multiplier floor check, burn, security `Redeemed` event.
     pub fn security_redeem(&mut self, caller: Address, amount: U256) -> Result<()> {
-        let ratio = self.security_redeem_burn(caller, amount)?;
-        self.emit_redeemed(caller, amount, ratio)
+        let multiplier = self.security_redeem_burn(caller, amount)?;
+        self.emit_redeemed(caller, amount, multiplier)
     }
 
     /// [`Self::security_redeem`] with a memo emitted between `Transfer` and `Redeemed`.
@@ -236,24 +236,24 @@ impl<S: SecurityAccounting, P: Policy> B20AssetToken<S, P> {
         amount: U256,
         memo: B256,
     ) -> Result<()> {
-        let ratio = self.security_redeem_burn(caller, amount)?;
+        let multiplier = self.security_redeem_burn(caller, amount)?;
         self.accounting_mut().emit_event(IB20::Memo { caller, memo }.encode_log_data())?;
-        self.emit_redeemed(caller, amount, ratio)
+        self.emit_redeemed(caller, amount, multiplier)
     }
 
     /// Performs the shared security redeem burn and returns the multiplier used for the floor check.
     fn security_redeem_burn(&mut self, caller: Address, amount: U256) -> Result<U256> {
         B20Guards::ensure_not_paused::<Self>(self, IB20::PausableFeature::REDEEM)?;
         B20Guards::ensure_policy::<Self>(self, Self::REDEEM_SENDER_POLICY, caller)?;
-        let ratio = self.accounting().multiplier()?;
+        let multiplier = self.accounting().multiplier()?;
         if !amount.is_zero() {
-            let shares =
-                amount.checked_mul(ratio).ok_or_else(BasePrecompileError::under_overflow)?
+            let scaled =
+                amount.checked_mul(multiplier).ok_or_else(BasePrecompileError::under_overflow)?
                     / B20AssetStorage::WAD;
             let minimum = self.accounting().minimum_redeemable()?;
-            if shares == U256::ZERO || shares < minimum {
+            if scaled == U256::ZERO || scaled < minimum {
                 return Err(BasePrecompileError::revert(IB20Asset::BelowMinimumRedeemable {
-                    shares,
+                    shares: scaled,
                     minimum,
                 }));
             }
@@ -274,12 +274,12 @@ impl<S: SecurityAccounting, P: Policy> B20AssetToken<S, P> {
         self.accounting_mut().emit_event(
             IB20::Transfer { from: caller, to: Address::ZERO, amount }.encode_log_data(),
         )?;
-        Ok(ratio)
+        Ok(multiplier)
     }
 
-    fn emit_redeemed(&mut self, caller: Address, amount: U256, ratio: U256) -> Result<()> {
+    fn emit_redeemed(&mut self, caller: Address, amount: U256, multiplier: U256) -> Result<()> {
         self.accounting_mut().emit_event(
-            IB20Asset::Redeemed { from: caller, amt: amount, multiplier: ratio }.encode_log_data(),
+            IB20Asset::Redeemed { from: caller, amt: amount, multiplier }.encode_log_data(),
         )
     }
 

--- a/crates/common/precompiles/src/b20_asset/token.rs
+++ b/crates/common/precompiles/src/b20_asset/token.rs
@@ -253,7 +253,7 @@ impl<S: SecurityAccounting, P: Policy> B20AssetToken<S, P> {
             let minimum = self.accounting().minimum_redeemable()?;
             if scaled == U256::ZERO || scaled < minimum {
                 return Err(BasePrecompileError::revert(IB20Asset::BelowMinimumRedeemable {
-                    shares: scaled,
+                    scaledAmount: scaled,
                     minimum,
                 }));
             }

--- a/crates/common/precompiles/src/b20_asset/token.rs
+++ b/crates/common/precompiles/src/b20_asset/token.rs
@@ -16,7 +16,7 @@ use crate::{
 /// EVM precompile for the asset B-20 variant.
 ///
 /// Mirrors the structure of [`crate::B20Token`] but requires `S: SecurityAccounting`
-/// so the dispatch layer can read and write security-specific storage (share ratio,
+/// so the dispatch layer can read and write security-specific storage (multiplier,
 /// security identifiers, announcement IDs). The `in_announcement` flag guards against
 /// recursive `announce` calls within a single precompile invocation.
 #[derive(Debug, Clone)]
@@ -154,32 +154,32 @@ impl<S: SecurityAccounting, P: Policy> B20AssetToken<S, P> {
         )
     }
 
-    // --- Share Ratio Operations ---
+    // --- Multiplier Operations ---
 
-    /// Converts a token balance to shares: `balance * sharesToTokensRatio / WAD`.
-    pub fn to_shares(&self, balance: U256) -> Result<U256> {
-        let ratio = self.accounting().shares_to_tokens_ratio()?;
-        let product = balance.checked_mul(ratio).ok_or_else(BasePrecompileError::under_overflow)?;
+    /// Converts a raw balance to its scaled view: `rawBalance * multiplier / WAD`.
+    pub fn to_scaled_balance(&self, raw_balance: U256) -> Result<U256> {
+        let m = self.accounting().multiplier()?;
+        let product = raw_balance.checked_mul(m).ok_or_else(BasePrecompileError::under_overflow)?;
         Ok(product / B20AssetStorage::WAD)
     }
 
-    /// Returns the shares for an account (balance converted to shares).
-    pub fn shares_of(&self, account: Address) -> Result<U256> {
+    /// Returns the scaled balance for an account.
+    pub fn scaled_balance_of(&self, account: Address) -> Result<U256> {
         let balance = self.accounting().balance_of(account)?;
-        self.to_shares(balance)
+        self.to_scaled_balance(balance)
     }
 
-    /// Updates the share-to-tokens ratio.
-    pub fn update_share_ratio(
+    /// Sets a new multiplier.
+    pub fn update_multiplier(
         &mut self,
         caller: Address,
-        new_ratio: U256,
+        new_multiplier: U256,
         privileged: bool,
     ) -> Result<()> {
         self.ensure_operator_role(caller, privileged)?;
-        self.accounting_mut().set_shares_to_tokens_ratio(new_ratio)?;
+        self.accounting_mut().set_multiplier(new_multiplier)?;
         self.accounting_mut().emit_event(
-            IB20Asset::ShareRatioUpdated { sharesToTokensRatio: new_ratio }.encode_log_data(),
+            IB20Asset::MultiplierUpdated { multiplier: new_multiplier }.encode_log_data(),
         )
     }
 
@@ -241,11 +241,11 @@ impl<S: SecurityAccounting, P: Policy> B20AssetToken<S, P> {
         self.emit_redeemed(caller, amount, ratio)
     }
 
-    /// Performs the shared security redeem burn and returns the ratio used for the floor check.
+    /// Performs the shared security redeem burn and returns the multiplier used for the floor check.
     fn security_redeem_burn(&mut self, caller: Address, amount: U256) -> Result<U256> {
         B20Guards::ensure_not_paused::<Self>(self, IB20::PausableFeature::REDEEM)?;
         B20Guards::ensure_policy::<Self>(self, Self::REDEEM_SENDER_POLICY, caller)?;
-        let ratio = self.accounting().shares_to_tokens_ratio()?;
+        let ratio = self.accounting().multiplier()?;
         if !amount.is_zero() {
             let shares =
                 amount.checked_mul(ratio).ok_or_else(BasePrecompileError::under_overflow)?
@@ -279,8 +279,7 @@ impl<S: SecurityAccounting, P: Policy> B20AssetToken<S, P> {
 
     fn emit_redeemed(&mut self, caller: Address, amount: U256, ratio: U256) -> Result<()> {
         self.accounting_mut().emit_event(
-            IB20Asset::Redeemed { from: caller, amt: amount, sharesToTokensRatio: ratio }
-                .encode_log_data(),
+            IB20Asset::Redeemed { from: caller, amt: amount, multiplier: ratio }.encode_log_data(),
         )
     }
 
@@ -342,7 +341,7 @@ mod tests {
 
     fn make_token() -> TestSecurityToken {
         let mut accounting = InMemoryTokenAccounting::new(TOKEN);
-        accounting.shares_to_tokens_ratio = B20AssetStorage::WAD;
+        accounting.multiplier = B20AssetStorage::WAD;
         accounting.policy_ids.insert(
             TestSecurityToken::REDEEM_SENDER_POLICY,
             PolicyRegistryStorage::ALWAYS_ALLOW_ID,
@@ -360,7 +359,7 @@ mod tests {
 
     fn setup_batch_mint(setup: BatchMintSetup) -> (TestSecurityToken, Vec<Address>, Vec<U256>) {
         let mut accounting = InMemoryTokenAccounting::new(TOKEN);
-        accounting.shares_to_tokens_ratio = B20AssetStorage::WAD;
+        accounting.multiplier = B20AssetStorage::WAD;
         let recipients;
         let amounts;
 
@@ -420,7 +419,7 @@ mod tests {
 
     fn setup_security_redeem(setup: SecurityRedeemSetup) -> TestSecurityToken {
         let mut accounting = InMemoryTokenAccounting::new(TOKEN);
-        accounting.shares_to_tokens_ratio = B20AssetStorage::WAD;
+        accounting.multiplier = B20AssetStorage::WAD;
 
         match setup {
             SecurityRedeemSetup::Paused => {

--- a/crates/common/precompiles/src/b20_factory/storage.rs
+++ b/crates/common/precompiles/src/b20_factory/storage.rs
@@ -29,8 +29,8 @@ fn encode_stablecoin_variant_params(currency: &str) -> Bytes {
 /// Maximum total supply for all newly-created B-20 tokens.
 const DEFAULT_SUPPLY_CAP: U256 = U256::MAX;
 
-/// Initial share-to-token ratio storage value. Reads treat zero as WAD precision (1:1).
-const INITIAL_SHARES_TO_TOKENS_RATIO: U256 = U256::ZERO;
+/// Initial multiplier storage value. Reads treat zero as WAD precision (1:1).
+const INITIAL_MULTIPLIER: U256 = U256::ZERO;
 
 /// The B-20 token factory precompile.
 #[contract(addr = Self::ADDRESS)]
@@ -270,7 +270,7 @@ impl TokenCreateParams {
                         name: p.name,
                         symbol: p.symbol,
                         supply_cap: DEFAULT_SUPPLY_CAP,
-                        shares_to_tokens_ratio: INITIAL_SHARES_TO_TOKENS_RATIO,
+                        multiplier: INITIAL_MULTIPLIER,
                         isin: p.isin,
                         minimum_redeemable: p.minimumRedeemable,
                     },
@@ -789,7 +789,7 @@ mod tests {
             assert_eq!(sec_storage.b20.name.read().unwrap(), "Security Token");
             assert_eq!(sec_storage.b20.symbol.read().unwrap(), "SEC");
             assert_eq!(sec_storage.decimals().unwrap(), 6);
-            assert_eq!(sec_storage.security.shares_to_tokens_ratio.read().unwrap(), U256::ZERO);
+            assert_eq!(sec_storage.security.multiplier.read().unwrap(), U256::ZERO);
             assert_eq!(sec_storage.redeem.minimum_redeemable.read().unwrap(), U256::ONE);
             // ISIN is stored in the identifiers mapping under the raw "ISIN" key.
             assert_eq!(

--- a/crates/common/precompiles/src/common/test_utils.rs
+++ b/crates/common/precompiles/src/common/test_utils.rs
@@ -65,8 +65,8 @@ pub struct InMemoryTokenAccounting {
     pub role_admins: HashMap<B256, B256>,
     /// Policy IDs keyed by policy type.
     pub policy_ids: HashMap<B256, u64>,
-    /// Share-to-tokens ratio scaled to WAD (1e18). Security tokens only.
-    pub shares_to_tokens_ratio: U256,
+    /// Multiplier scaled to WAD (1e18). Security tokens only.
+    pub multiplier: U256,
     /// Security identifier values keyed by raw `identifier_type`. Security tokens only.
     pub extra_metadata: HashMap<String, String>,
     /// Consumed announcement ids keyed by raw announcement id. Security tokens only.
@@ -98,7 +98,7 @@ impl InMemoryTokenAccounting {
             role_member_counts: HashMap::new(),
             role_admins: HashMap::new(),
             policy_ids: HashMap::new(),
-            shares_to_tokens_ratio: U256::ZERO,
+            multiplier: U256::ZERO,
             extra_metadata: HashMap::new(),
             announcement_ids_used: HashSet::new(),
             events: Vec::new(),
@@ -386,13 +386,13 @@ impl PolicyRegistry for InMemoryPolicy {
 }
 
 impl SecurityAccounting for InMemoryTokenAccounting {
-    fn shares_to_tokens_ratio(&self) -> Result<U256> {
+    fn multiplier(&self) -> Result<U256> {
         const WAD: U256 = U256::from_limbs([1_000_000_000_000_000_000, 0, 0, 0]);
-        Ok(if self.shares_to_tokens_ratio.is_zero() { WAD } else { self.shares_to_tokens_ratio })
+        Ok(if self.multiplier.is_zero() { WAD } else { self.multiplier })
     }
 
-    fn set_shares_to_tokens_ratio(&mut self, ratio: U256) -> Result<()> {
-        self.shares_to_tokens_ratio = ratio;
+    fn set_multiplier(&mut self, ratio: U256) -> Result<()> {
+        self.multiplier = ratio;
         Ok(())
     }
 

--- a/crates/common/precompiles/src/common/test_utils.rs
+++ b/crates/common/precompiles/src/common/test_utils.rs
@@ -391,8 +391,8 @@ impl SecurityAccounting for InMemoryTokenAccounting {
         Ok(if self.multiplier.is_zero() { WAD } else { self.multiplier })
     }
 
-    fn set_multiplier(&mut self, ratio: U256) -> Result<()> {
-        self.multiplier = ratio;
+    fn set_multiplier(&mut self, multiplier: U256) -> Result<()> {
+        self.multiplier = multiplier;
         Ok(())
     }
 


### PR DESCRIPTION
[BOP-238](https://linear.app/coinbase/issue/BOP-238)

## Motivation

The B20Asset spec has settled on "multiplier" as the term for what was previously called "share ratio." The old naming leaked implementation details about how balances are stored and scaled. Renaming to multiplier aligns the on-chain interface with `IB20Asset.sol` in base-std and makes the semantics clearer: holders have raw balances that are scaled by a multiplier to produce a displayed value.

## What changed

ABI surface (Solidity-facing names, affects selectors):
- `sharesToTokensRatio()` -> `multiplier()`
- `updateShareRatio(uint256 newSharesToTokensRatio)` -> `updateMultiplier(uint256 newMultiplier)`
- `toShares(uint256 balance)` -> `toScaledBalance(uint256 rawBalance)`
- `sharesOf(address account)` -> `scaledBalanceOf(address account)`
- Event `ShareRatioUpdated(uint256 sharesToTokensRatio)` -> `MultiplierUpdated(uint256 multiplier)`
- Event `Redeemed` field `sharesToTokensRatio` -> `multiplier`

Rust internals:
- `SecurityAccounting` trait: `shares_to_tokens_ratio` / `set_shares_to_tokens_ratio` -> `multiplier` / `set_multiplier`
- `B20AssetExtensionStorage` field: `shares_to_tokens_ratio` -> `multiplier`
- `B20AssetInit` field: `shares_to_tokens_ratio` -> `multiplier`
- `B20AssetToken` methods: `to_shares` -> `to_scaled_balance`, `shares_of` -> `scaled_balance_of`, `update_share_ratio` -> `update_multiplier`
- Factory constant `INITIAL_SHARES_TO_TOKENS_RATIO` -> `INITIAL_MULTIPLIER`
- All generated packing constants (`SHARES_TO_TOKENS_RATIO_LOC` -> `MULTIPLIER_LOC`) follow from the field rename
- Tests and label strings updated throughout

## What was tried / considered

The storage slot layout is unchanged: the `multiplier` field occupies offset 0 in the `base.b20.asset` ERC-7201 namespace, same as the old `shares_to_tokens_ratio` field. Only the name changed, so there is no migration needed for deployed tokens.

`WAD_PRECISION` was kept as-is because base-std retains that name.