### PR TITLE
fix(b20-factory): align getB20Address to return zero on invalid variant (BOP-229)

### DIFF
--- a/crates/common/precompiles/src/b20_factory/dispatch.rs
+++ b/crates/common/precompiles/src/b20_factory/dispatch.rs
@@ -1,8 +1,8 @@
 //! ABI dispatch for the `B20Factory` precompile.
 
-use alloy_primitives::Bytes;
+use alloy_primitives::{Address, Bytes};
 use alloy_sol_types::SolCall;
-use base_precompile_storage::{BasePrecompileError, IntoPrecompileResult, StorageCtx};
+use base_precompile_storage::{IntoPrecompileResult, StorageCtx};
 use revm::precompile::PrecompileResult;
 
 use crate::{
@@ -33,9 +33,11 @@ impl<'a> B20FactoryStorage<'a> {
                 Ok(IB20Factory::createB20Call::abi_encode_returns(&token).into())
             }
             IB20Factory::IB20FactoryCalls::getB20Address(call) => {
-                let variant = B20Variant::from_abi(call.variant)
-                    .ok_or_else(|| BasePrecompileError::revert(IB20Factory::InvalidVariant {}))?;
-                let (addr, _) = variant.compute_address(call.sender, call.salt);
+                // Returns zero for an unrecognized variant to match base-std, which documents
+                // this function as "Never reverts."
+                let addr = B20Variant::from_abi(call.variant)
+                    .map(|v| v.compute_address(call.sender, call.salt).0)
+                    .unwrap_or(Address::ZERO);
                 Ok(IB20Factory::getB20AddressCall::abi_encode_returns(&addr).into())
             }
             IB20Factory::IB20FactoryCalls::isB20(call) => {

--- a/crates/common/precompiles/src/b20_factory/storage.rs
+++ b/crates/common/precompiles/src/b20_factory/storage.rs
@@ -962,7 +962,7 @@ mod tests {
                 IB20Factory::getB20AddressCall::abi_encode_returns(&expected_token),
             );
             assert_output(
-                dispatch_factory_revert(
+                dispatch_factory_success(
                     ctx,
                     IB20Factory::getB20AddressCall {
                         variant: IB20Factory::B20Variant::__Invalid,
@@ -970,7 +970,7 @@ mod tests {
                         salt,
                     },
                 ),
-                IB20Factory::InvalidVariant {}.abi_encode(),
+                IB20Factory::getB20AddressCall::abi_encode_returns(&Address::ZERO),
             );
 
             assert_output(
@@ -1271,5 +1271,27 @@ mod tests {
             .find_map(|l| IB20Factory::B20Created::decode_log_data(l).ok())
             .expect("B20Created must be emitted");
         assert!(event.variantParams.is_empty(), "SECURITY variantParams must be empty");
+    }
+
+    #[test]
+    fn get_b20_address_returns_zero_for_invalid_variant() {
+        let mut storage = HashMapStorageProvider::new(1);
+        activate_precompiles(&mut storage);
+        let sender = Address::repeat_byte(0x11);
+        let salt = B256::repeat_byte(0xAB);
+
+        StorageCtx::enter(&mut storage, |ctx| {
+            assert_output(
+                dispatch_factory_success(
+                    ctx,
+                    IB20Factory::getB20AddressCall {
+                        variant: IB20Factory::B20Variant::__Invalid,
+                        sender,
+                        salt,
+                    },
+                ),
+                IB20Factory::getB20AddressCall::abi_encode_returns(&Address::ZERO),
+            );
+        });
     }
 }


### PR DESCRIPTION
[BOP-229](https://linear.app/coinbase/issue/BOP-229)

## Motivation

The Rust `getB20Address` reverted on invalid variant while base-std silently returns zero. base-std documents this function as "Never reverts." This PR aligns the Rust implementation to match the Solidity behavior.

## Changes

Updated `getB20Address` dispatch to return zero address on unrecognized variant, matching base-std. Updated the existing test that expected an `InvalidVariant` revert, and added a dedicated test asserting that an invalid variant returns zero rather than reverting.

type=routine
risk=low
impact=sev4