### PR TITLE
refactor(precompiles): remove base.b20_token feature and rename base.b20_security -> base.b20_asset (BOP-246)

### DIFF
--- a/crates/common/precompiles/src/activation/storage.rs
+++ b/crates/common/precompiles/src/activation/storage.rs
@@ -23,13 +23,11 @@ pub struct ActivationRegistryStorage {
 /// the key when querying or mutating activation state.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ActivationFeature {
-    /// `keccak256("base.b20_token")`
-    B20Token,
     /// `keccak256("base.policy_registry")`
     PolicyRegistry,
     /// `keccak256("base.b20_stablecoin")`
     B20Stablecoin,
-    /// `keccak256("base.b20_security")`
+    /// `keccak256("base.b20_asset")`
     B20Asset,
 }
 
@@ -37,9 +35,6 @@ impl ActivationFeature {
     /// Returns the `keccak256` hash that identifies this feature in storage.
     pub const fn id(self) -> B256 {
         match self {
-            Self::B20Token => {
-                b256!("0x47a1afe8d3d691b87e090ee972d223a11f4da971ff5416c04985bb2393aca752")
-            }
             Self::PolicyRegistry => {
                 b256!("0xb582ebae03f16fee49a6763f78df482fb11ae73f103ed0d330bbe556aa90a43f")
             }
@@ -47,7 +42,7 @@ impl ActivationFeature {
                 b256!("0xecfa0def2c10020caaf65e6155aa69c84b24892aaef76eeac52e0e2b3a0b8601")
             }
             Self::B20Asset => {
-                b256!("0x83d32fab502ae0e8bc4352a117767262cb5e47cc8d67a744008ed4ff03fcf5e6")
+                b256!("0xcdcc772fe4cbdb1029f822861176d09e646db96723d4c1e82ddfdeb8163ef54c")
             }
         }
     }
@@ -276,10 +271,9 @@ mod tests {
 
     #[test]
     fn feature_id_constants_match_canonical_names() {
-        assert_eq!(ActivationFeature::B20Token.id(), keccak256("base.b20_token"));
         assert_eq!(ActivationFeature::PolicyRegistry.id(), keccak256("base.policy_registry"));
         assert_eq!(ActivationFeature::B20Stablecoin.id(), keccak256("base.b20_stablecoin"));
-        assert_eq!(ActivationFeature::B20Asset.id(), keccak256("base.b20_security"));
+        assert_eq!(ActivationFeature::B20Asset.id(), keccak256("base.b20_asset"));
     }
 
     #[test]

--- a/crates/common/precompiles/src/b20_factory/storage.rs
+++ b/crates/common/precompiles/src/b20_factory/storage.rs
@@ -346,7 +346,6 @@ mod tests {
     fn activate_precompiles(storage: &mut HashMapStorageProvider) {
         storage.set_caller(ACTIVATION_ADMIN);
         for key in [
-            ActivationFeature::B20Token.id(),
             ActivationFeature::B20Stablecoin.id(),
             ActivationFeature::B20Asset.id(),
         ] {

--- a/crates/common/precompiles/src/b20_factory/storage.rs
+++ b/crates/common/precompiles/src/b20_factory/storage.rs
@@ -345,10 +345,7 @@ mod tests {
 
     fn activate_precompiles(storage: &mut HashMapStorageProvider) {
         storage.set_caller(ACTIVATION_ADMIN);
-        for key in [
-            ActivationFeature::B20Stablecoin.id(),
-            ActivationFeature::B20Asset.id(),
-        ] {
+        for key in [ActivationFeature::B20Stablecoin.id(), ActivationFeature::B20Asset.id()] {
             StorageCtx::enter(storage, |ctx| {
                 ActivationRegistryStorage::new(ctx).activate(key, Some(ACTIVATION_ADMIN)).unwrap()
             });

--- a/crates/infra/basectl/src/app/views/upgrades.rs
+++ b/crates/infra/basectl/src/app/views/upgrades.rs
@@ -188,14 +188,12 @@ const JOVIAN_CHECK_NAMES: &[&str] = &["bn256Pairing limit", "extra data v1", "GP
 const BERYL_CHECK_NAMES: &[&str] = &[
     "registry precompile",
     "registry admin",
-    "B-20 token feature",
     "policy registry feature",
     "B-20 stablecoin feature",
     "B-20 asset feature",
 ];
 
 const BERYL_FEATURE_CHECKS: &[(&str, ActivationFeature)] = &[
-    ("B-20 token feature", ActivationFeature::B20Token),
     ("policy registry feature", ActivationFeature::PolicyRegistry),
     ("B-20 stablecoin feature", ActivationFeature::B20Stablecoin),
     ("B-20 asset feature", ActivationFeature::B20Asset),


### PR DESCRIPTION
## Summary

Implements [BOP-246](https://linear.app/coinbase/issue/BOP-246/basebase-activationregistry-remove-baseb20-token-and-rename-baseb20).

- Remove the `base.b20_token` feature constant (`B20Token` variant) from the `ActivationRegistry`'s `ActivationFeature` enum.
- Rename the `B20Asset` feature's canonical name from `base.b20_security` -> `base.b20_asset`, updating its `keccak256` id from `0x83d3...f5e6` to `0xcdcc...f54c` (verified via `cast keccak "base.b20_asset"`).

## Changes

- `crates/common/precompiles/src/activation/storage.rs`: drop `B20Token` variant + its `id()` arm; update `B20Asset` doc/hash; update `feature_id_constants_match_canonical_names` test.
- `crates/common/precompiles/src/b20_factory/storage.rs`: remove `ActivationFeature::B20Token` from the `activate_precompiles` test helper.
- `crates/infra/basectl/src/app/views/upgrades.rs`: remove the "B-20 token feature" entry from `BERYL_CHECK_NAMES` and `BERYL_FEATURE_CHECKS` (kept in sync).

## Testing

- `cargo check -p base-common-precompiles -p basectl-cli` — passes.
- `cargo test -p base-common-precompiles` — 353 passed, 0 failed.

> Note: `base-test-utils` fails to compile in this environment due to missing generated Solidity contract bindings; verified pre-existing on a clean tree (unrelated to this change).