### PR TITLE
refactor(b20-asset): align coding style with B20 and B20Stablecoin (BOP-231)

### DIFF
--- a/crates/common/precompiles/src/b20_asset/dispatch.rs
+++ b/crates/common/precompiles/src/b20_asset/dispatch.rs
@@ -14,7 +14,7 @@ use base_precompile_storage::{BasePrecompileError, IntoPrecompileResult, Storage
 use revm::precompile::PrecompileResult;
 
 use crate::{
-    B20AssetStorage, B20AssetToken, B20PolicyType, B20TokenRole, Burnable, Configurable,
+    B20AssetStorage, B20AssetToken, B20TokenRole, Burnable, Configurable,
     IB20::{self, IB20Calls as C},
     IB20Asset::{self, IB20AssetCalls as SC},
     Mintable, NoopPrecompileCallObserver, Pausable, PermitArgs, Permittable, Policy,
@@ -136,7 +136,7 @@ impl<S: SecurityAccounting, P: Policy> B20AssetToken<S, P> {
             C::contractURI(_) => self.accounting().contract_uri()?.abi_encode().into(),
 
             // --- Role identifiers ---
-            C::DEFAULT_ADMIN_ROLE(_) => Self::default_admin_role().abi_encode().into(),
+            C::DEFAULT_ADMIN_ROLE(_) => B20TokenRole::DefaultAdmin.id().abi_encode().into(),
             C::MINT_ROLE(_) => B20TokenRole::Mint.id().abi_encode().into(),
             C::BURN_ROLE(_) => B20TokenRole::Burn.id().abi_encode().into(),
             C::BURN_BLOCKED_ROLE(_) => B20TokenRole::BurnBlocked.id().abi_encode().into(),
@@ -145,25 +145,21 @@ impl<S: SecurityAccounting, P: Policy> B20AssetToken<S, P> {
             C::METADATA_ROLE(_) => B20TokenRole::Metadata.id().abi_encode().into(),
 
             // --- Policy type identifiers ---
-            C::TRANSFER_SENDER_POLICY(_) => B20PolicyType::TransferSender.id().abi_encode().into(),
-            C::TRANSFER_RECEIVER_POLICY(_) => {
-                B20PolicyType::TransferReceiver.id().abi_encode().into()
-            }
-            C::TRANSFER_EXECUTOR_POLICY(_) => {
-                B20PolicyType::TransferExecutor.id().abi_encode().into()
-            }
-            C::MINT_RECEIVER_POLICY(_) => B20PolicyType::MintReceiver.id().abi_encode().into(),
+            C::TRANSFER_SENDER_POLICY(_) => Self::transfer_sender_policy().abi_encode().into(),
+            C::TRANSFER_RECEIVER_POLICY(_) => Self::transfer_receiver_policy().abi_encode().into(),
+            C::TRANSFER_EXECUTOR_POLICY(_) => Self::transfer_executor_policy().abi_encode().into(),
+            C::MINT_RECEIVER_POLICY(_) => Self::mint_receiver_policy().abi_encode().into(),
 
             // --- Role reads ---
-            C::hasRole(c) => self.accounting().has_role(c.role, c.account)?.abi_encode().into(),
-            C::getRoleAdmin(c) => self.accounting().role_admin(c.role)?.abi_encode().into(),
+            C::hasRole(c) => self.has_role(c.role, c.account)?.abi_encode().into(),
+            C::getRoleAdmin(c) => self.role_admin(c.role)?.abi_encode().into(),
 
             // --- Pause reads ---
             C::pausedFeatures(_) => self.paused_features()?.abi_encode().into(),
             C::isPaused(c) => self.is_paused(c.feature)?.abi_encode().into(),
 
             // --- Policy reads ---
-            C::policyId(c) => self.policy_id_checked(c.policyScope)?.abi_encode().into(),
+            C::policyId(c) => self.policy_id(c.policyScope)?.abi_encode().into(),
 
             // --- Domain reads ---
             C::DOMAIN_SEPARATOR(_) => self.domain_separator(ctx.chain_id())?.abi_encode().into(),

--- a/crates/common/precompiles/src/b20_asset/token.rs
+++ b/crates/common/precompiles/src/b20_asset/token.rs
@@ -117,10 +117,32 @@ impl<S: SecurityAccounting, P: Policy> B20AssetToken<S, P> {
         if privileged { Ok(()) } else { self.ensure_role(caller, Self::default_admin_role()) }
     }
 
+    // --- Policy Scope Helpers ---
+
+    /// Policy slot checked against transfer senders.
+    pub const fn transfer_sender_policy() -> B256 {
+        B20PolicyType::TransferSender.id()
+    }
+
+    /// Policy slot checked against transfer receivers.
+    pub const fn transfer_receiver_policy() -> B256 {
+        B20PolicyType::TransferReceiver.id()
+    }
+
+    /// Policy slot checked against delegated transfer executors.
+    pub const fn transfer_executor_policy() -> B256 {
+        B20PolicyType::TransferExecutor.id()
+    }
+
+    /// Policy slot checked against mint receivers.
+    pub const fn mint_receiver_policy() -> B256 {
+        B20PolicyType::MintReceiver.id()
+    }
+
     // --- Policy Operations ---
 
     /// Returns the configured policy ID for `policy_scope`.
-    pub fn policy_id_checked(&self, policy_scope: B256) -> Result<u64> {
+    pub fn policy_id(&self, policy_scope: B256) -> Result<u64> {
         Self::ensure_supported_policy_type(policy_scope)?;
         self.accounting().policy_id(policy_scope)
     }

--- a/crates/common/precompiles/src/b20_factory/storage.rs
+++ b/crates/common/precompiles/src/b20_factory/storage.rs
@@ -151,9 +151,12 @@ impl<'a> B20FactoryStorage<'a> {
         init: B20AssetInit,
         init_calls: Vec<Bytes>,
     ) -> Result<()> {
-        let mut storage = B20AssetStorage::from_address(token_address, self.storage);
+        let mut token = B20AssetToken::with_storage_and_policy(
+            B20AssetStorage::from_address(token_address, self.storage),
+            PolicyHandle::new(self.storage),
+        );
         let (name, symbol) = (init.name.clone(), init.symbol.clone());
-        storage.initialize(init)?;
+        token.accounting_mut().initialize(init)?;
 
         self.emit_event(IB20Factory::B20Created {
             token: token_address,
@@ -165,10 +168,6 @@ impl<'a> B20FactoryStorage<'a> {
         })?;
 
         if !common.initial_admin.is_zero() {
-            let mut token = B20AssetToken::with_storage_and_policy(
-                B20AssetStorage::from_address(token_address, self.storage),
-                PolicyHandle::new(self.storage),
-            );
             token.grant_role_unchecked(
                 B20TokenRole::DefaultAdmin.id(),
                 common.initial_admin,
@@ -178,12 +177,9 @@ impl<'a> B20FactoryStorage<'a> {
 
         self.storage.with_caller(Self::ADDRESS, || {
             for (index, calldata) in init_calls.into_iter().enumerate() {
-                B20AssetToken::with_storage_and_policy(
-                    B20AssetStorage::from_address(token_address, self.storage),
-                    PolicyHandle::new(self.storage),
-                )
-                .inner_with_privilege(self.storage, &calldata, true)
-                .map_err(|err| Self::map_init_call_error(index, err))?;
+                token
+                    .inner_with_privilege(self.storage, &calldata, true)
+                    .map_err(|err| Self::map_init_call_error(index, err))?;
             }
             Ok::<(), BasePrecompileError>(())
         })?;


### PR DESCRIPTION
[BOP-231](https://linear.app/coinbase/issue/BOP-231)

## Motivation

`b20_asset` accumulated several small style divergences from `b20_stablecoin` during the rename and earlier refactors. The inconsistencies made the code harder to read side-by-side: the factory initialised asset storage directly on the raw struct instead of through the token wrapper, role reads bypassed the `RoleManaged` trait, `DEFAULT_ADMIN_ROLE` was returned via `Self::default_admin_role()` while all other variants use `B20TokenRole::DefaultAdmin.id()`, policy-type constants were expressed inline with `B20PolicyType::X.id()` instead of named helpers, and `policy_id_checked` diverged in name from the equivalent `policy_id` on `B20StablecoinToken`. This PR brings all five patterns into alignment with no behaviour changes.

## What changed

- `b20_asset/token.rs`: added `transfer_sender_policy()`, `transfer_receiver_policy()`, `transfer_executor_policy()`, and `mint_receiver_policy()` associated functions, matching the helpers on `B20StablecoinToken`; renamed `policy_id_checked` to `policy_id` (same semantics, consistent name).
- `b20_asset/dispatch.rs`: replaced `Self::default_admin_role()` with `B20TokenRole::DefaultAdmin.id()`; replaced inline `B20PolicyType::X.id()` calls with the new `Self::X_policy()` helpers; replaced `self.accounting().has_role` / `self.accounting().role_admin` with the `RoleManaged` trait methods `self.has_role` / `self.role_admin`; replaced `self.policy_id_checked` with `self.policy_id`.
- `b20_factory/storage.rs`: refactored `init_asset_token` to construct a single `B20AssetToken` up front and call `token.accounting_mut().initialize(init)`, matching the `init_stablecoin` pattern rather than operating on the raw `B20AssetStorage` directly.

## What was tried / considered

All five changes could have been made in separate PRs. Batching them avoids a noisy diff history for what is collectively one style-alignment pass, and the changes are small enough that reviewers can follow them together.