### PR TITLE
fix(b20): enforce role admin mutation guard for privileged calls (BOP-233)

### DIFF
--- a/crates/common/precompiles/src/common/ops/roles.rs
+++ b/crates/common/precompiles/src/common/ops/roles.rs
@@ -160,6 +160,11 @@ pub trait RoleManaged: Token {
     }
 
     /// Grants `role` to `account`, optionally bypassing authorization during factory init.
+    ///
+    /// The admin-resurrection guard (`ensure_role_admin_mutations_available`) is always enforced
+    /// for `DEFAULT_ADMIN_ROLE` grants, even in the privileged path. `renounceLastAdmin` is a
+    /// permanent terminal state; granting `DEFAULT_ADMIN_ROLE` after it must be impossible
+    /// regardless of how the call is routed.
     fn grant_role(
         &mut self,
         caller: Address,
@@ -167,8 +172,10 @@ pub trait RoleManaged: Token {
         account: Address,
         privileged: bool,
     ) -> Result<()> {
-        if !privileged {
+        if role == Self::default_admin_role() || !privileged {
             self.ensure_role_admin_mutations_available(caller)?;
+        }
+        if !privileged {
             self.ensure_role(caller, self.role_admin(role)?)?;
         }
         self.grant_role_unchecked(role, account, caller)
@@ -350,6 +357,25 @@ mod tests {
         assert_eq!(
             token.accounting().role_member_count(B20TokenRole::DefaultAdmin.id()).unwrap(),
             U256::ONE
+        );
+    }
+
+    #[test]
+    fn grant_role_rejects_default_admin_after_renounce_last_admin_even_privileged() {
+        let mut token = token_with_default_admin();
+        token.renounce_last_admin(ADMIN).unwrap();
+
+        assert_eq!(
+            token.grant_role(ALICE, B20TokenRole::DefaultAdmin.id(), ALICE, true).unwrap_err(),
+            BasePrecompileError::revert(IB20::AccessControlUnauthorizedAccount {
+                account: ALICE,
+                neededRole: B20TokenRole::DefaultAdmin.id(),
+            })
+        );
+        assert!(!token.has_role(B20TokenRole::DefaultAdmin.id(), ALICE).unwrap());
+        assert_eq!(
+            token.accounting().role_member_count(B20TokenRole::DefaultAdmin.id()).unwrap(),
+            U256::ZERO
         );
     }
 

--- a/crates/common/precompiles/src/common/ops/roles.rs
+++ b/crates/common/precompiles/src/common/ops/roles.rs
@@ -380,6 +380,16 @@ mod tests {
     }
 
     #[test]
+    fn grant_role_allows_non_admin_role_after_renounce_last_admin_privileged() {
+        let mut token = token_with_default_admin();
+        token.renounce_last_admin(ADMIN).unwrap();
+
+        token.grant_role(ALICE, B20TokenRole::Mint.id(), ALICE, true).unwrap();
+
+        assert!(token.has_role(B20TokenRole::Mint.id(), ALICE).unwrap());
+    }
+
+    #[test]
     fn revoke_role_allows_non_final_default_admin() {
         let mut token = token_with_default_admin();
         token.grant_role(ADMIN, B20TokenRole::DefaultAdmin.id(), ALICE, false).unwrap();


### PR DESCRIPTION
[BOP-233](https://linear.app/coinbase/issue/BOP-233)

## Motivation

`renounceLastAdmin` is designed as a permanent, one-way transition: once the last `DEFAULT_ADMIN_ROLE` holder renounces, no new admin should ever be grantable. This invariant was enforced on the standard `grantRole` path, but the privileged path (used by factory `initCalls`) skipped `ensure_role_admin_mutations_available` entirely. A malicious or misconfigured factory call sequence could therefore call `renounceLastAdmin` and then immediately grant `DEFAULT_ADMIN_ROLE` to a new address via a subsequent privileged `initCall`, silently resurrecting admin control.

## What changed

- `grant_role` in `RoleManaged` now unconditionally calls `ensure_role_admin_mutations_available` when `role == DEFAULT_ADMIN_ROLE`, regardless of the `privileged` flag. The authorization check (`ensure_role`) is still skipped for privileged callers; only the resurrection guard is made unconditional.
- Added a unit test `grant_role_rejects_default_admin_after_renounce_last_admin_even_privileged` that calls `renounceLastAdmin` and then asserts that a privileged `grantRole(DEFAULT_ADMIN_ROLE, ...)` reverts with `AccessControlUnauthorizedAccount`.

## What was considered

Enforcing the mutation guard for all roles in the privileged path (not just `DEFAULT_ADMIN_ROLE`) was considered but rejected as unnecessarily broad. Factory `initCalls` may legitimately grant non-admin roles after token creation regardless of admin state. The security concern is specific to `DEFAULT_ADMIN_ROLE` resurrection, so the guard is scoped accordingly.

Blocking `DEFAULT_ADMIN_ROLE` grants when `role_member_count == 0` also covers the edge case of `initialAdmin: address(0)` combined with a privileged `grantRole(DEFAULT_ADMIN_ROLE, ...)` initCall. That pattern is redundant (callers should use the `initialAdmin` field) and is now correctly rejected, consistent with the spec's admin-resurrection guard.