### PR TITLE
refactor(common): Rename B20 Asset Accounting

### DIFF
--- a/crates/common/precompile-macros/src/accounting.rs
+++ b/crates/common/precompile-macros/src/accounting.rs
@@ -12,8 +12,8 @@ pub(crate) fn derive_stablecoin(input: DeriveInput) -> proc_macro::TokenStream {
     expand_stablecoin(input).unwrap_or_else(syn::Error::into_compile_error).into()
 }
 
-pub(crate) fn derive_security(input: DeriveInput) -> proc_macro::TokenStream {
-    expand_security(input).unwrap_or_else(syn::Error::into_compile_error).into()
+pub(crate) fn derive_asset(input: DeriveInput) -> proc_macro::TokenStream {
+    expand_asset(input).unwrap_or_else(syn::Error::into_compile_error).into()
 }
 
 fn expand_token(input: DeriveInput) -> syn::Result<TokenStream> {
@@ -306,16 +306,16 @@ fn expand_stablecoin(input: DeriveInput) -> syn::Result<TokenStream> {
     })
 }
 
-fn expand_security(input: DeriveInput) -> syn::Result<TokenStream> {
-    require_field(&input, "security")?;
+fn expand_asset(input: DeriveInput) -> syn::Result<TokenStream> {
+    require_field(&input, "asset")?;
     require_field(&input, "redeem")?;
     let name = input.ident;
     Ok(quote! {
-        impl crate::SecurityAccounting for #name<'_> {
+        impl crate::AssetAccounting for #name<'_> {
             fn multiplier(
                 &self,
             ) -> ::base_precompile_storage::Result<::alloy_primitives::U256> {
-                let multiplier = self.security.multiplier()?;
+                let multiplier = self.asset.multiplier()?;
                 Ok(if multiplier.is_zero() { Self::WAD } else { multiplier })
             }
 
@@ -323,7 +323,7 @@ fn expand_security(input: DeriveInput) -> syn::Result<TokenStream> {
                 &mut self,
                 multiplier: ::alloy_primitives::U256,
             ) -> ::base_precompile_storage::Result<()> {
-                self.security.set_multiplier(multiplier)
+                self.asset.set_multiplier(multiplier)
             }
 
             fn extra_metadata(
@@ -331,7 +331,7 @@ fn expand_security(input: DeriveInput) -> syn::Result<TokenStream> {
                 identifier_type: &str,
             ) -> ::base_precompile_storage::Result<::alloc::string::String> {
                 ::base_precompile_storage::Handler::read(
-                    self.security
+                    self.asset
                         .identifiers
                         .at(&::alloc::string::String::from(identifier_type)),
                 )
@@ -344,10 +344,10 @@ fn expand_security(input: DeriveInput) -> syn::Result<TokenStream> {
             ) -> ::base_precompile_storage::Result<()> {
                 let key = ::alloc::string::String::from(identifier_type);
                 if value.is_empty() {
-                    ::base_precompile_storage::Handler::delete(self.security.identifiers.at_mut(&key))
+                    ::base_precompile_storage::Handler::delete(self.asset.identifiers.at_mut(&key))
                 } else {
                     ::base_precompile_storage::Handler::write(
-                        self.security.identifiers.at_mut(&key),
+                        self.asset.identifiers.at_mut(&key),
                         value,
                     )
                 }
@@ -371,7 +371,7 @@ fn expand_security(input: DeriveInput) -> syn::Result<TokenStream> {
                 id: &str,
             ) -> ::base_precompile_storage::Result<bool> {
                 ::base_precompile_storage::Handler::read(
-                    self.security
+                    self.asset
                         .used_announcement_ids
                         .at(&::alloc::string::String::from(id)),
                 )
@@ -382,7 +382,7 @@ fn expand_security(input: DeriveInput) -> syn::Result<TokenStream> {
                 id: &str,
             ) -> ::base_precompile_storage::Result<()> {
                 ::base_precompile_storage::Handler::write(
-                    self.security
+                    self.asset
                         .used_announcement_ids
                         .at_mut(&::alloc::string::String::from(id)),
                     true,

--- a/crates/common/precompile-macros/src/lib.rs
+++ b/crates/common/precompile-macros/src/lib.rs
@@ -64,10 +64,10 @@ pub fn derive_stablecoin_accounting(input: TokenStream) -> TokenStream {
     accounting::derive_stablecoin(parse_macro_input!(input as DeriveInput))
 }
 
-/// Derives the security-token storage port for contract storage structs.
-#[proc_macro_derive(SecurityAccounting)]
-pub fn derive_security_accounting(input: TokenStream) -> TokenStream {
-    accounting::derive_security(parse_macro_input!(input as DeriveInput))
+/// Derives the asset-token storage port for contract storage structs.
+#[proc_macro_derive(AssetAccounting)]
+pub fn derive_asset_accounting(input: TokenStream) -> TokenStream {
+    accounting::derive_asset(parse_macro_input!(input as DeriveInput))
 }
 
 /// Generate `StorableType` and `Storable` implementations for all standard integer types.

--- a/crates/common/precompiles/README.md
+++ b/crates/common/precompiles/README.md
@@ -16,7 +16,7 @@ that lets downstream crates use their own spec wrapper as long as it converts to
 
 The crate also exports the ABI types, storage adapters, entry points, and shared token traits for
 the native B-20 token system. Those exports cover the activation registry, policy registry, B-20
-factory, default B-20 token, stablecoin token, security token, and the reusable role, pause, policy,
+factory, default B-20 token, stablecoin token, asset token, and the reusable role, pause, policy,
 permit, and accounting helpers used by those precompiles.
 
 ## Behavior
@@ -52,12 +52,12 @@ policies, supports staged admin transfer and admin renunciation, and provides bu
 The B-20 factory is the singleton precompile at `0xB20F000000000000000000000000000000000000`. It
 creates deterministic B-20 token addresses from the caller, variant, and salt. B-20 token addresses
 use the `0xb2` prefix with the variant encoded in the address. The default B-20 variant uses 18
-decimals, while stablecoin and security variants use 6 decimals.
+decimals, while stablecoin and asset variants use 6 decimals.
 
 Default B-20 tokens implement the ERC-20 surface plus roles, pausing, supply caps, memo transfers,
 policy hooks, EIP-2612 permits, ERC-5267 domain reporting, and ERC-7572 contract metadata. The
-stablecoin variant adds currency metadata. The security variant adds multiplier-based scaling,
-minimum redeemable checks, batched mint and burn operations, security identifiers, and announcement
+stablecoin variant adds currency metadata. The asset variant adds multiplier-based scaling,
+minimum redeemable checks, batched mint and burn operations, asset metadata, and announcement
 flows that can execute internal token calls.
 
 ## Usage

--- a/crates/common/precompiles/src/b20_asset/abi.rs
+++ b/crates/common/precompiles/src/b20_asset/abi.rs
@@ -114,12 +114,12 @@ sol! {
         /// Returns the minimum-redeemable threshold in scaled units.
         function minimumRedeemable() external view returns (uint256);
 
-        // ── Security identifiers ─────────────────────────────────────────────
+        // ── Asset metadata ──────────────────────────────────────────────────
 
         /// Returns the value of the named identifier (e.g. ISIN, CUSIP). Empty string if not set.
         function extraMetadata(string calldata identifierType) external view returns (string);
 
-        /// Sets, updates, or removes a security identifier. Empty `value` removes the entry. Requires `METADATA_ROLE`.
+        /// Sets, updates, or removes asset metadata. Empty `value` removes the entry. Requires `METADATA_ROLE`.
         function updateExtraMetadata(
             string calldata identifierType,
             string calldata value
@@ -177,7 +177,7 @@ mod tests {
     }
 
     #[test]
-    fn security_call_labels_are_stable() {
+    fn asset_call_labels_are_stable() {
         assert_eq!(
             IB20Asset::IB20AssetCalls::minimumRedeemable(IB20Asset::minimumRedeemableCall {},)
                 .as_label(),

--- a/crates/common/precompiles/src/b20_asset/accounting.rs
+++ b/crates/common/precompiles/src/b20_asset/accounting.rs
@@ -1,4 +1,4 @@
-//! `SecurityAccounting` — storage port extension for security tokens.
+//! `AssetAccounting` — storage port extension for asset tokens.
 
 use alloc::string::String;
 
@@ -7,19 +7,19 @@ use base_precompile_storage::Result;
 
 use crate::TokenAccounting;
 
-/// Extends [`TokenAccounting`] with security-token-specific storage slots.
+/// Extends [`TokenAccounting`] with asset-token-specific storage slots.
 ///
-/// Security identifiers (ISIN, CUSIP, etc.) and redeem parameters are only
-/// exposed through the security-token surface, not the base B-20 surface.
-pub trait SecurityAccounting: TokenAccounting {
+/// Asset metadata (ISIN, CUSIP, etc.) and redeem parameters are only exposed
+/// through the asset-token surface, not the base B-20 surface.
+pub trait AssetAccounting: TokenAccounting {
     /// Returns the current multiplier scaled to WAD (1e18).
     fn multiplier(&self) -> Result<U256>;
     /// Writes a new multiplier.
     fn set_multiplier(&mut self, multiplier: U256) -> Result<()>;
 
-    /// Returns the security identifier value for `identifier_type`, or an empty string if unset.
+    /// Returns the asset metadata value for `identifier_type`, or an empty string if unset.
     fn extra_metadata(&self, identifier_type: &str) -> Result<String>;
-    /// Writes (or removes when `value` is empty) the security identifier for `identifier_type`.
+    /// Writes (or removes when `value` is empty) the asset metadata for `identifier_type`.
     fn set_extra_metadata_value(&mut self, identifier_type: &str, value: String) -> Result<()>;
 
     /// Returns the minimum amount that may be redeemed in a single call.

--- a/crates/common/precompiles/src/b20_asset/dispatch.rs
+++ b/crates/common/precompiles/src/b20_asset/dispatch.rs
@@ -1,10 +1,10 @@
 //! ABI dispatch for the asset B-20 variant.
 //!
-//! Security-specific selectors are tried first via `IB20Asset::IB20AssetCalls`.
+//! Asset-specific selectors are tried first via `IB20Asset::IB20AssetCalls`.
 //! This catches overridden selectors (`redeem`, `redeemWithMemo`) before the
-//! inherited `IB20` fallthrough, ensuring security semantics always apply.
+//! inherited `IB20` fallthrough, ensuring asset semantics always apply.
 //! The `IB20` match block still includes those arms (Rust requires exhaustiveness)
-//! and routes them to the same security implementation as a safety net.
+//! and routes them to the same asset implementation as a safety net.
 
 use alloc::{string::String, vec::Vec};
 
@@ -14,15 +14,15 @@ use base_precompile_storage::{BasePrecompileError, IntoPrecompileResult, Storage
 use revm::precompile::PrecompileResult;
 
 use crate::{
-    B20AssetStorage, B20AssetToken, B20TokenRole, Burnable, Configurable,
+    AssetAccounting, B20AssetStorage, B20AssetToken, B20TokenRole, Burnable, Configurable,
     IB20::{self, IB20Calls as C},
     IB20Asset::{self, IB20AssetCalls as SC},
     Mintable, NoopPrecompileCallObserver, Pausable, PermitArgs, Permittable, Policy,
-    PrecompileCallObserver, RoleManaged, SecurityAccounting, Token, Transferable,
+    PrecompileCallObserver, RoleManaged, Token, Transferable,
     macros::{decode_precompile_call, deduct_calldata_cost},
 };
 
-impl<S: SecurityAccounting, P: Policy> B20AssetToken<S, P> {
+impl<S: AssetAccounting, P: Policy> B20AssetToken<S, P> {
     /// ABI-dispatches `calldata` to the appropriate `IB20Asset` handler.
     pub fn dispatch(&mut self, ctx: StorageCtx<'_>, calldata: &[u8]) -> PrecompileResult {
         self.dispatch_with_observer(ctx, calldata, NoopPrecompileCallObserver)
@@ -104,10 +104,10 @@ impl<S: SecurityAccounting, P: Policy> B20AssetToken<S, P> {
     where
         O: PrecompileCallObserver,
     {
-        // Security-specific and overridden selectors are caught here first.
+        // Asset-specific and overridden selectors are caught here first.
         if let Ok(call) = IB20Asset::IB20AssetCalls::abi_decode(calldata) {
             let label = call.as_label();
-            return observer.observe(label, || self.handle_security_call(ctx, call, privileged));
+            return observer.observe(label, || self.handle_asset_call(ctx, call, privileged));
         }
 
         // Fall through to inherited IB20 selectors.
@@ -327,7 +327,7 @@ impl<S: SecurityAccounting, P: Policy> B20AssetToken<S, P> {
         Ok(encoded)
     }
 
-    fn handle_security_call(
+    fn handle_asset_call(
         &mut self,
         ctx: StorageCtx<'_>,
         call: SC,
@@ -351,7 +351,7 @@ impl<S: SecurityAccounting, P: Policy> B20AssetToken<S, P> {
                 self.accounting().is_announcement_id_used(c.id.as_str())?.abi_encode().into()
             }
 
-            // --- Security identifier reads ---
+            // --- Asset metadata reads ---
             SC::extraMetadata(c) => {
                 self.accounting().extra_metadata(c.identifierType.as_str())?.abi_encode().into()
             }
@@ -374,24 +374,24 @@ impl<S: SecurityAccounting, P: Policy> B20AssetToken<S, P> {
                 Bytes::new()
             }
 
-            // --- Security redeem (overrides IB20 redeem semantics) ---
+            // --- Asset redeem (overrides IB20 redeem semantics) ---
             SC::redeem(c) => {
-                self.security_redeem(caller, c.amount)?;
+                self.asset_redeem(caller, c.amount)?;
                 Bytes::new()
             }
             SC::redeemWithMemo(c) => {
-                self.security_redeem_with_memo(caller, c.amount, c.memo)?;
+                self.asset_redeem_with_memo(caller, c.amount, c.memo)?;
                 Bytes::new()
             }
 
-            // --- Minimum redeemable (security version, in scaled units) ---
+            // --- Minimum redeemable (asset version, in scaled units) ---
             SC::minimumRedeemable(_) => self.accounting().minimum_redeemable()?.abi_encode().into(),
             SC::updateMinimumRedeemable(c) => {
                 self.update_minimum_redeemable(caller, c.newMinimumRedeemable, privileged)?;
                 Bytes::new()
             }
 
-            // --- Security identifier mutations ---
+            // --- Asset metadata mutations ---
             SC::updateExtraMetadata(c) => {
                 self.update_extra_metadata(caller, c.identifierType, c.value, privileged)?;
                 Bytes::new()
@@ -459,25 +459,25 @@ mod tests {
     };
 
     use crate::{
-        ActivationFeature, ActivationRegistryStorage, B20AssetStorage, B20AssetToken,
-        B20PausableFeature, B20TokenRole, IB20, IB20Asset, InMemoryPolicy, InMemoryTokenAccounting,
-        PolicyHandle, PolicyRegistryStorage, SecurityAccounting, Token, TokenAccounting,
+        ActivationFeature, ActivationRegistryStorage, AssetAccounting, B20AssetStorage,
+        B20AssetToken, B20PausableFeature, B20TokenRole, IB20, IB20Asset, InMemoryPolicy,
+        InMemoryTokenAccounting, PolicyHandle, PolicyRegistryStorage, Token, TokenAccounting,
     };
 
-    type TestSecurityToken = B20AssetToken<InMemoryTokenAccounting, InMemoryPolicy>;
+    type TestAssetToken = B20AssetToken<InMemoryTokenAccounting, InMemoryPolicy>;
 
-    const REDEEM_SENDER_POLICY: B256 = TestSecurityToken::REDEEM_SENDER_POLICY;
+    const REDEEM_SENDER_POLICY: B256 = TestAssetToken::REDEEM_SENDER_POLICY;
 
     const ALICE: Address = Address::repeat_byte(0xaa);
     const BOB: Address = Address::repeat_byte(0xbb);
     const TOKEN: Address = Address::repeat_byte(0x01);
     const ACTIVATION_ADMIN: Address = Address::repeat_byte(0xcb);
-    fn make_token() -> TestSecurityToken {
+    fn make_token() -> TestAssetToken {
         let mut accounting = InMemoryTokenAccounting::new(TOKEN);
         accounting.multiplier = B20AssetStorage::WAD; // 1:1 multiplier
         // Explicitly open redemption so non-policy tests are not blocked by the ALWAYS_BLOCK default.
         accounting.policy_ids.insert(REDEEM_SENDER_POLICY, PolicyRegistryStorage::ALWAYS_ALLOW_ID);
-        TestSecurityToken::with_storage_and_policy(accounting, InMemoryPolicy::new())
+        TestAssetToken::with_storage_and_policy(accounting, InMemoryPolicy::new())
     }
 
     fn activate_b20_asset(storage: &mut HashMapStorageProvider) {
@@ -496,11 +496,7 @@ mod tests {
         storage
     }
 
-    fn call_security(
-        token: &mut TestSecurityToken,
-        caller: Address,
-        calldata: Vec<u8>,
-    ) -> Result<Bytes> {
+    fn call_asset(token: &mut TestAssetToken, caller: Address, calldata: Vec<u8>) -> Result<Bytes> {
         let mut storage = storage_with_caller(caller);
         StorageCtx::enter(&mut storage, |ctx| token.inner(ctx, calldata.as_ref()))
     }
@@ -519,7 +515,7 @@ mod tests {
     fn to_scaled_balance_two_to_one_multiplier() {
         let mut accounting = InMemoryTokenAccounting::new(TOKEN);
         accounting.multiplier = B20AssetStorage::WAD * U256::from(2u64);
-        let token = TestSecurityToken::with_storage_and_policy(accounting, InMemoryPolicy::new());
+        let token = TestAssetToken::with_storage_and_policy(accounting, InMemoryPolicy::new());
         assert_eq!(token.to_scaled_balance(U256::from(50u64)).unwrap(), U256::from(100u64));
     }
 
@@ -528,7 +524,7 @@ mod tests {
         let mut token = make_token();
         token.accounting_mut().roles.insert((B20TokenRole::Mint.id(), ALICE), true);
 
-        call_security(
+        call_asset(
             &mut token,
             ALICE,
             batch_mint_calldata(
@@ -556,7 +552,7 @@ mod tests {
     fn batch_mint_requires_mint_role() {
         let mut token = make_token();
 
-        let err = call_security(
+        let err = call_asset(
             &mut token,
             ALICE,
             batch_mint_calldata(alloc::vec![BOB], alloc::vec![U256::from(100u64)]),
@@ -575,13 +571,13 @@ mod tests {
     }
 
     #[test]
-    fn security_redeem_burns_and_emits_security_event() {
+    fn asset_redeem_burns_and_emits_asset_event() {
         let mut token = make_token();
         token.accounting_mut().balances.insert(ALICE, U256::from(100u64));
         token.accounting_mut().total_supply = U256::from(100u64);
         token.accounting_mut().minimum_redeemable = U256::from(1u64);
 
-        token.security_redeem(ALICE, U256::from(50u64)).unwrap();
+        token.asset_redeem(ALICE, U256::from(50u64)).unwrap();
 
         assert_eq!(token.accounting().balance_of(ALICE).unwrap(), U256::from(50u64));
         assert_eq!(token.accounting().total_supply().unwrap(), U256::from(50u64));
@@ -589,13 +585,13 @@ mod tests {
     }
 
     #[test]
-    fn security_redeem_zero_amount_is_no_op() {
+    fn asset_redeem_zero_amount_is_no_op() {
         let mut token = make_token();
         token.accounting_mut().balances.insert(ALICE, U256::from(100u64));
         token.accounting_mut().total_supply = U256::from(100u64);
         token.accounting_mut().minimum_redeemable = U256::from(1u64);
 
-        token.security_redeem(ALICE, U256::ZERO).unwrap();
+        token.asset_redeem(ALICE, U256::ZERO).unwrap();
 
         assert_eq!(token.accounting().balance_of(ALICE).unwrap(), U256::from(100u64));
         assert_eq!(token.accounting().total_supply().unwrap(), U256::from(100u64));
@@ -603,36 +599,36 @@ mod tests {
     }
 
     #[test]
-    fn security_redeem_rejects_below_minimum_scaled_amount() {
+    fn asset_redeem_rejects_below_minimum_scaled_amount() {
         let mut token = make_token();
         token.accounting_mut().balances.insert(ALICE, U256::from(100u64));
         token.accounting_mut().total_supply = U256::from(100u64);
         token.accounting_mut().minimum_redeemable = U256::from(10u64);
 
         // 5 tokens * 1e18 multiplier / 1e18 = 5 scaled < 10 minimum
-        assert!(token.security_redeem(ALICE, U256::from(5u64)).is_err());
+        assert!(token.asset_redeem(ALICE, U256::from(5u64)).is_err());
     }
 
     #[test]
-    fn security_redeem_rejects_zero_scaled_amount() {
+    fn asset_redeem_rejects_zero_scaled_amount() {
         let mut token = make_token();
         token.accounting_mut().multiplier = U256::ONE;
         token.accounting_mut().balances.insert(ALICE, U256::from(100u64));
         token.accounting_mut().total_supply = U256::from(100u64);
 
         // 1 token-wei * 1 / WAD rounds down to 0 scaled units, which is always rejected.
-        assert!(token.security_redeem(ALICE, U256::ONE).is_err());
+        assert!(token.asset_redeem(ALICE, U256::ONE).is_err());
     }
 
     #[test]
-    fn security_redeem_rejects_when_redeem_feature_paused() {
+    fn asset_redeem_rejects_when_redeem_feature_paused() {
         let mut token = make_token();
         token.accounting_mut().paused = B20PausableFeature::mask(IB20::PausableFeature::REDEEM);
         token.accounting_mut().balances.insert(ALICE, U256::from(100u64));
         token.accounting_mut().total_supply = U256::from(100u64);
 
         assert_eq!(
-            token.security_redeem(ALICE, U256::from(1u64)).unwrap_err(),
+            token.asset_redeem(ALICE, U256::from(1u64)).unwrap_err(),
             BasePrecompileError::revert(IB20::ContractPaused {
                 feature: IB20::PausableFeature::REDEEM,
             })
@@ -640,7 +636,7 @@ mod tests {
     }
 
     #[test]
-    fn security_redeem_rejects_when_sender_policy_denies() {
+    fn asset_redeem_rejects_when_sender_policy_denies() {
         let policy_id = 7;
         let mut accounting = InMemoryTokenAccounting::new(TOKEN);
         accounting.multiplier = B20AssetStorage::WAD;
@@ -649,10 +645,10 @@ mod tests {
         accounting.policy_ids.insert(REDEEM_SENDER_POLICY, policy_id);
         let mut policy = InMemoryPolicy::new();
         policy.create_existing_policy(policy_id);
-        let mut token = TestSecurityToken::with_storage_and_policy(accounting, policy);
+        let mut token = TestAssetToken::with_storage_and_policy(accounting, policy);
 
         assert_eq!(
-            token.security_redeem(ALICE, U256::from(1u64)).unwrap_err(),
+            token.asset_redeem(ALICE, U256::from(1u64)).unwrap_err(),
             BasePrecompileError::revert(IB20::PolicyForbids {
                 policyScope: REDEEM_SENDER_POLICY,
                 policyId: policy_id,
@@ -690,7 +686,7 @@ mod tests {
         token.accounting_mut().roles.insert((B20TokenRole::Mint.id(), ALICE), true);
 
         assert_eq!(
-            call_security(&mut token, ALICE, batch_mint_calldata(alloc::vec![], alloc::vec![]))
+            call_asset(&mut token, ALICE, batch_mint_calldata(alloc::vec![], alloc::vec![]))
                 .unwrap_err(),
             BasePrecompileError::revert(IB20Asset::EmptyBatch {})
         );
@@ -702,7 +698,7 @@ mod tests {
         token.accounting_mut().roles.insert((B20TokenRole::Mint.id(), ALICE), true);
 
         assert_eq!(
-            call_security(
+            call_asset(
                 &mut token,
                 ALICE,
                 batch_mint_calldata(alloc::vec![ALICE], alloc::vec![U256::ONE, U256::ONE]),
@@ -715,7 +711,7 @@ mod tests {
         );
 
         assert_eq!(
-            call_security(
+            call_asset(
                 &mut token,
                 ALICE,
                 batch_mint_calldata(alloc::vec![], alloc::vec![U256::ONE]),
@@ -731,19 +727,19 @@ mod tests {
     // --- redeem: InsufficientBalance / boundary / scaled math / event pair ---
 
     #[test]
-    fn security_redeem_rejects_insufficient_balance() {
+    fn asset_redeem_rejects_insufficient_balance() {
         let mut token = make_token();
         token.accounting_mut().balances.insert(ALICE, U256::from(10u64));
         token.accounting_mut().total_supply = U256::from(10u64);
         token.accounting_mut().minimum_redeemable = U256::from(1u64);
         // amount=100 > balance=10 → InsufficientBalance after the scaled-floor check passes
-        assert!(token.security_redeem(ALICE, U256::from(100u64)).is_err());
+        assert!(token.asset_redeem(ALICE, U256::from(100u64)).is_err());
         // no state mutation on failure
         assert_eq!(token.accounting().balance_of(ALICE).unwrap(), U256::from(10u64));
     }
 
     #[test]
-    fn security_redeem_supply_underflow_is_under_overflow_panic() {
+    fn asset_redeem_supply_underflow_is_under_overflow_panic() {
         // Regression: before BOP-160, saturating_sub silently clamped supply to zero.
         // If an accounting bug left total_supply < balance, the correct behavior is to
         // revert with an arithmetic under/overflow panic rather than zeroing the supply.
@@ -754,25 +750,25 @@ mod tests {
 
         // amount=75 passes the balance check (100 >= 75) but underflows total_supply (50 - 75).
         assert_eq!(
-            token.security_redeem(ALICE, U256::from(75u64)).unwrap_err(),
+            token.asset_redeem(ALICE, U256::from(75u64)).unwrap_err(),
             BasePrecompileError::under_overflow()
         );
     }
 
     #[test]
-    fn security_redeem_at_exact_minimum_succeeds() {
+    fn asset_redeem_at_exact_minimum_succeeds() {
         let mut token = make_token(); // 1:1 multiplier
         token.accounting_mut().balances.insert(ALICE, U256::from(50u64));
         token.accounting_mut().total_supply = U256::from(50u64);
         // 5 tokens * WAD / WAD = 5 scaled == minimum → boundary must be accepted
         token.accounting_mut().minimum_redeemable = U256::from(5u64);
-        token.security_redeem(ALICE, U256::from(5u64)).unwrap();
+        token.asset_redeem(ALICE, U256::from(5u64)).unwrap();
         assert_eq!(token.accounting().balance_of(ALICE).unwrap(), U256::from(45u64));
         assert_eq!(token.accounting().total_supply().unwrap(), U256::from(45u64));
     }
 
     #[test]
-    fn security_redeem_with_non_unit_multiplier_applies_correct_scaled_math() {
+    fn asset_redeem_with_non_unit_multiplier_applies_correct_scaled_math() {
         let mut token = make_token();
         // 2x multiplier: 1 token scales to 2 units
         token.accounting_mut().multiplier = B20AssetStorage::WAD * U256::from(2u64);
@@ -781,25 +777,25 @@ mod tests {
         // minimum = 10 scaled → need at least 5 tokens
         token.accounting_mut().minimum_redeemable = U256::from(10u64);
         // 4 tokens → 8 scaled < 10 → BelowMinimumRedeemable
-        assert!(token.security_redeem(ALICE, U256::from(4u64)).is_err());
+        assert!(token.asset_redeem(ALICE, U256::from(4u64)).is_err());
         // 5 tokens → 10 scaled == minimum → accepted
-        token.security_redeem(ALICE, U256::from(5u64)).unwrap();
+        token.asset_redeem(ALICE, U256::from(5u64)).unwrap();
         assert_eq!(token.accounting().balance_of(ALICE).unwrap(), U256::from(95u64));
     }
 
     #[test]
-    fn security_redeem_emits_transfer_then_redeemed() {
+    fn asset_redeem_emits_transfer_then_redeemed() {
         let mut token = make_token();
         token.accounting_mut().balances.insert(ALICE, U256::from(100u64));
         token.accounting_mut().total_supply = U256::from(100u64);
         token.accounting_mut().minimum_redeemable = U256::from(1u64);
-        token.security_redeem(ALICE, U256::from(10u64)).unwrap();
+        token.asset_redeem(ALICE, U256::from(10u64)).unwrap();
         // "Emits Transfer(caller, address(0), amount) followed by Redeemed(caller, amount, multiplier)"
         assert_eq!(token.accounting().events.len(), 2);
     }
 
     #[test]
-    fn security_redeem_with_memo_emits_memo_before_redeemed() {
+    fn asset_redeem_with_memo_emits_memo_before_redeemed() {
         let mut token = make_token();
         let amount = U256::from(10u64);
         let memo = B256::repeat_byte(0x42);
@@ -807,7 +803,7 @@ mod tests {
         token.accounting_mut().total_supply = U256::from(100u64);
         token.accounting_mut().minimum_redeemable = U256::from(1u64);
 
-        token.security_redeem_with_memo(ALICE, amount, memo).unwrap();
+        token.asset_redeem_with_memo(ALICE, amount, memo).unwrap();
 
         assert_eq!(
             token.accounting().events[0],
@@ -837,7 +833,7 @@ mod tests {
         let mut accounting = InMemoryTokenAccounting::new(TOKEN);
         // 0.5 WAD: 1 token → 0.5 scaled → truncates to 0 via integer division
         accounting.multiplier = B20AssetStorage::WAD / U256::from(2u64);
-        let token = TestSecurityToken::with_storage_and_policy(accounting, InMemoryPolicy::new());
+        let token = TestAssetToken::with_storage_and_policy(accounting, InMemoryPolicy::new());
         assert_eq!(token.to_scaled_balance(U256::from(1u64)).unwrap(), U256::ZERO);
     }
 
@@ -864,7 +860,7 @@ mod tests {
             token.accounting_mut().set_minimum_redeemable(U256::from(10u64)).unwrap();
 
             assert_eq!(token.accounting().multiplier().unwrap(), B20AssetStorage::WAD);
-            token.security_redeem(ALICE, U256::from(10u64)).unwrap();
+            token.asset_redeem(ALICE, U256::from(10u64)).unwrap();
 
             assert_eq!(token.accounting().balance_of(ALICE).unwrap(), U256::from(90u64));
             assert_eq!(token.accounting().total_supply().unwrap(), U256::from(90u64));
@@ -930,7 +926,7 @@ mod tests {
         let mut accounting = InMemoryTokenAccounting::new(TOKEN);
         // Any balance > 1 overflows when multiplied by this multiplier.
         accounting.multiplier = U256::MAX / U256::from(2u64) + U256::ONE;
-        let token = TestSecurityToken::with_storage_and_policy(accounting, InMemoryPolicy::new());
+        let token = TestAssetToken::with_storage_and_policy(accounting, InMemoryPolicy::new());
 
         assert_eq!(
             token.to_scaled_balance(U256::from(2u64)).unwrap_err(),
@@ -938,10 +934,10 @@ mod tests {
         );
     }
 
-    /// `security_redeem` must return an arithmetic overflow panic rather than
+    /// `asset_redeem` must return an arithmetic overflow panic rather than
     /// silently saturating when `amount * multiplier` exceeds `U256::MAX`.
     #[test]
-    fn security_redeem_overflows_when_product_exceeds_u256_max() {
+    fn asset_redeem_overflows_when_product_exceeds_u256_max() {
         let mut accounting = InMemoryTokenAccounting::new(TOKEN);
         // Any amount > 1 overflows when multiplied by this multiplier.
         accounting.multiplier = U256::MAX / U256::from(2u64) + U256::ONE;
@@ -949,11 +945,10 @@ mod tests {
         accounting.total_supply = U256::from(2u64);
         // Open redemption so the policy gate does not block the call before the overflow.
         accounting.policy_ids.insert(REDEEM_SENDER_POLICY, PolicyRegistryStorage::ALWAYS_ALLOW_ID);
-        let mut token =
-            TestSecurityToken::with_storage_and_policy(accounting, InMemoryPolicy::new());
+        let mut token = TestAssetToken::with_storage_and_policy(accounting, InMemoryPolicy::new());
 
         assert_eq!(
-            token.security_redeem(ALICE, U256::from(2u64)).unwrap_err(),
+            token.asset_redeem(ALICE, U256::from(2u64)).unwrap_err(),
             BasePrecompileError::under_overflow()
         );
     }

--- a/crates/common/precompiles/src/b20_asset/mod.rs
+++ b/crates/common/precompiles/src/b20_asset/mod.rs
@@ -4,7 +4,7 @@ mod abi;
 pub use abi::IB20Asset;
 
 mod accounting;
-pub use accounting::SecurityAccounting;
+pub use accounting::AssetAccounting;
 
 mod dispatch;
 

--- a/crates/common/precompiles/src/b20_asset/storage.rs
+++ b/crates/common/precompiles/src/b20_asset/storage.rs
@@ -3,7 +3,7 @@
 use alloc::string::String;
 
 use alloy_primitives::{Address, B256, FixedBytes, U256, b256};
-use base_precompile_macros::{SecurityAccounting, Storable, TokenAccounting, contract};
+use base_precompile_macros::{AssetAccounting, Storable, TokenAccounting, contract};
 use base_precompile_storage::{Handler, Mapping, Result, StorageCtx};
 
 use crate::{B20CoreStorage, PolicyRegistryStorage};
@@ -18,7 +18,7 @@ pub struct B20AssetExtensionStorage {
     pub multiplier: U256, // offset 0
     /// Announcement IDs that have already been consumed.
     pub used_announcement_ids: Mapping<String, bool>, // offset 1
-    /// Security identifier values by identifier type.
+    /// Asset metadata values by identifier type.
     pub identifiers: Mapping<String, String>, // offset 2
 }
 
@@ -40,10 +40,10 @@ pub struct B20RedeemStorage {
 
 /// EVM-backed storage for an asset B-20 token.
 #[contract]
-#[derive(TokenAccounting, SecurityAccounting)]
+#[derive(TokenAccounting, AssetAccounting)]
 pub struct B20AssetStorage {
     pub b20: B20CoreStorage,
-    pub security: B20AssetExtensionStorage,
+    pub asset: B20AssetExtensionStorage,
     pub redeem: B20RedeemStorage,
 }
 
@@ -80,7 +80,7 @@ impl<'a> B20AssetStorage<'a> {
     /// Writes all creation-time fields atomically.
     ///
     /// `isin` may be empty; when non-empty it is stored under the `"ISIN"` key
-    /// in the security identifiers mapping.
+    /// in the asset metadata mapping.
     ///
     /// `REDEEM_SENDER_POLICY` is initialised to `ALWAYS_BLOCK_ID` so redemption
     /// is closed by default; issuers must explicitly open it after creation.
@@ -88,10 +88,10 @@ impl<'a> B20AssetStorage<'a> {
         self.b20.name.write(init.name)?;
         self.b20.symbol.write(init.symbol)?;
         self.b20.supply_cap.write(init.supply_cap)?;
-        self.security.multiplier.write(init.multiplier)?;
+        self.asset.multiplier.write(init.multiplier)?;
         self.redeem.minimum_redeemable.write(init.minimum_redeemable)?;
         if !init.isin.is_empty() {
-            self.security.identifiers.at_mut(&String::from("ISIN")).write(init.isin)?;
+            self.asset.identifiers.at_mut(&String::from("ISIN")).write(init.isin)?;
         }
         self.write_redeem_policy_ids_default()?;
         Ok(())
@@ -118,7 +118,7 @@ mod tests {
         __packing_b20_asset_extension_storage, __packing_b20_redeem_storage,
         B20AssetExtensionStorage, B20AssetInit, B20AssetStorage, B20RedeemStorage, slots,
     };
-    use crate::{B20CoreStorage, PolicyRegistryStorage, SecurityAccounting, TokenAccounting};
+    use crate::{AssetAccounting, B20CoreStorage, PolicyRegistryStorage, TokenAccounting};
 
     const TOKEN: Address = address!("000000000000000000000000000000000000b021");
     const B20_ROOT: U256 =
@@ -145,7 +145,7 @@ mod tests {
         assert_eq!(<B20RedeemStorage as StorableType>::STORAGE_NAMESPACE_ROOT, REDEEM_ROOT);
 
         assert_eq!(slots::B20, B20_ROOT);
-        assert_eq!(slots::SECURITY, ASSET_ROOT);
+        assert_eq!(slots::ASSET, ASSET_ROOT);
         assert_eq!(slots::REDEEM, REDEEM_ROOT);
     }
 
@@ -194,7 +194,7 @@ mod tests {
     }
 
     #[test]
-    fn security_string_mapping_slots_use_solidity_string_key_derivation() {
+    fn asset_string_mapping_slots_use_solidity_string_key_derivation() {
         let (mut storage, _) = setup_storage();
         let announcement_id = String::from("2026-Q1-split");
         let identifier_type = String::from("ISIN");
@@ -202,9 +202,9 @@ mod tests {
 
         StorageCtx::enter(&mut storage, |ctx| {
             let mut token = B20AssetStorage::from_address(TOKEN, ctx);
-            token.security.used_announcement_ids.at_mut(&announcement_id).write(true).unwrap();
+            token.asset.used_announcement_ids.at_mut(&announcement_id).write(true).unwrap();
             token
-                .security
+                .asset
                 .identifiers
                 .at_mut(&identifier_type)
                 .write(identifier_value.clone())

--- a/crates/common/precompiles/src/b20_asset/token.rs
+++ b/crates/common/precompiles/src/b20_asset/token.rs
@@ -7,27 +7,27 @@ use alloy_sol_types::SolEvent;
 use base_precompile_storage::{BasePrecompileError, Result};
 
 use crate::{
-    B20AssetStorage, B20Guards, B20PolicyType, B20TokenRole, Burnable, Configurable,
+    AssetAccounting, B20AssetStorage, B20Guards, B20PolicyType, B20TokenRole, Burnable,
+    Configurable,
     IB20::{self},
-    IB20Asset, Mintable, Pausable, Permittable, Policy, RoleManaged, SecurityAccounting, Token,
-    Transferable,
+    IB20Asset, Mintable, Pausable, Permittable, Policy, RoleManaged, Token, Transferable,
 };
 
 /// EVM precompile for the asset B-20 variant.
 ///
-/// Mirrors the structure of [`crate::B20Token`] but requires `S: SecurityAccounting`
-/// so the dispatch layer can read and write security-specific storage (multiplier,
-/// security identifiers, announcement IDs). The `in_announcement` flag guards against
+/// Mirrors the structure of [`crate::B20Token`] but requires `S: AssetAccounting`
+/// so the dispatch layer can read and write asset-specific storage (multiplier,
+/// asset metadata, announcement IDs). The `in_announcement` flag guards against
 /// recursive `announce` calls within a single precompile invocation.
 #[derive(Debug, Clone)]
-pub struct B20AssetToken<S: SecurityAccounting, P: Policy> {
+pub struct B20AssetToken<S: AssetAccounting, P: Policy> {
     accounting: S,
     policy: P,
     in_announcement: bool,
 }
 
-impl<S: SecurityAccounting, P: Policy> B20AssetToken<S, P> {
-    /// Role identifier for security operators: `keccak256("OPERATOR_ROLE")`.
+impl<S: AssetAccounting, P: Policy> B20AssetToken<S, P> {
+    /// Role identifier for asset operators: `keccak256("OPERATOR_ROLE")`.
     pub const OPERATOR_ROLE: B256 =
         b256!("97667070c54ef182b0f5858b034beac1b6f3089aa2d3188bb1e8929f4fa9b929");
 
@@ -54,7 +54,7 @@ impl<S: SecurityAccounting, P: Policy> B20AssetToken<S, P> {
     }
 }
 
-impl<S: SecurityAccounting, P: Policy> Token for B20AssetToken<S, P> {
+impl<S: AssetAccounting, P: Policy> Token for B20AssetToken<S, P> {
     type Accounting = S;
     type Policy = P;
 
@@ -79,21 +79,21 @@ impl<S: SecurityAccounting, P: Policy> Token for B20AssetToken<S, P> {
     }
 }
 
-impl<S: SecurityAccounting, P: Policy> Transferable for B20AssetToken<S, P> {}
-impl<S: SecurityAccounting, P: Policy> Mintable for B20AssetToken<S, P> {}
-impl<S: SecurityAccounting, P: Policy> Burnable for B20AssetToken<S, P> {}
-impl<S: SecurityAccounting, P: Policy> Pausable for B20AssetToken<S, P> {}
-impl<S: SecurityAccounting, P: Policy> Configurable for B20AssetToken<S, P> {}
-impl<S: SecurityAccounting, P: Policy> Permittable for B20AssetToken<S, P> {}
-impl<S: SecurityAccounting, P: Policy> RoleManaged for B20AssetToken<S, P> {}
+impl<S: AssetAccounting, P: Policy> Transferable for B20AssetToken<S, P> {}
+impl<S: AssetAccounting, P: Policy> Mintable for B20AssetToken<S, P> {}
+impl<S: AssetAccounting, P: Policy> Burnable for B20AssetToken<S, P> {}
+impl<S: AssetAccounting, P: Policy> Pausable for B20AssetToken<S, P> {}
+impl<S: AssetAccounting, P: Policy> Configurable for B20AssetToken<S, P> {}
+impl<S: AssetAccounting, P: Policy> Permittable for B20AssetToken<S, P> {}
+impl<S: AssetAccounting, P: Policy> RoleManaged for B20AssetToken<S, P> {}
 
-// --- Security-Specific Operations ---
+// --- Asset-Specific Operations ---
 
-impl<S: SecurityAccounting, P: Policy> B20AssetToken<S, P> {
+impl<S: AssetAccounting, P: Policy> B20AssetToken<S, P> {
     // --- Policy Scope Validation ---
 
     /// Ensures `policy_scope` names either an inherited B-20 policy slot or the
-    /// security redeem slot.
+    /// asset redeem slot.
     pub fn is_supported_policy_scope(policy_scope: B256) -> bool {
         policy_scope == Self::REDEEM_SENDER_POLICY || B20PolicyType::from_id(policy_scope).is_some()
     }
@@ -111,7 +111,7 @@ impl<S: SecurityAccounting, P: Policy> B20AssetToken<S, P> {
 
     // --- Authorization Helpers ---
 
-    /// Ensures the caller has the security operator role.
+    /// Ensures the caller has the asset operator role.
     pub fn ensure_operator_role(&self, caller: Address, privileged: bool) -> Result<()> {
         if privileged { Ok(()) } else { self.ensure_role(caller, Self::OPERATOR_ROLE) }
     }
@@ -231,9 +231,9 @@ impl<S: SecurityAccounting, P: Policy> B20AssetToken<S, P> {
         )
     }
 
-    // --- Security Identifier Operations ---
+    // --- Asset Metadata Operations ---
 
-    /// Updates a security identifier value.
+    /// Updates an asset metadata value.
     pub fn update_extra_metadata(
         &mut self,
         caller: Address,
@@ -252,28 +252,28 @@ impl<S: SecurityAccounting, P: Policy> B20AssetToken<S, P> {
         )
     }
 
-    // --- Security Redeem Operations ---
+    // --- Asset Redeem Operations ---
 
-    /// Performs a security-specific redeem: multiplier floor check, burn, security `Redeemed` event.
-    pub fn security_redeem(&mut self, caller: Address, amount: U256) -> Result<()> {
-        let multiplier = self.security_redeem_burn(caller, amount)?;
+    /// Performs an asset-specific redeem: multiplier floor check, burn, asset `Redeemed` event.
+    pub fn asset_redeem(&mut self, caller: Address, amount: U256) -> Result<()> {
+        let multiplier = self.asset_redeem_burn(caller, amount)?;
         self.emit_redeemed(caller, amount, multiplier)
     }
 
-    /// [`Self::security_redeem`] with a memo emitted between `Transfer` and `Redeemed`.
-    pub fn security_redeem_with_memo(
+    /// [`Self::asset_redeem`] with a memo emitted between `Transfer` and `Redeemed`.
+    pub fn asset_redeem_with_memo(
         &mut self,
         caller: Address,
         amount: U256,
         memo: B256,
     ) -> Result<()> {
-        let multiplier = self.security_redeem_burn(caller, amount)?;
+        let multiplier = self.asset_redeem_burn(caller, amount)?;
         self.accounting_mut().emit_event(IB20::Memo { caller, memo }.encode_log_data())?;
         self.emit_redeemed(caller, amount, multiplier)
     }
 
-    /// Performs the shared security redeem burn and returns the multiplier used for the floor check.
-    fn security_redeem_burn(&mut self, caller: Address, amount: U256) -> Result<U256> {
+    /// Performs the shared asset redeem burn and returns the multiplier used for the floor check.
+    fn asset_redeem_burn(&mut self, caller: Address, amount: U256) -> Result<U256> {
         B20Guards::ensure_not_paused::<Self>(self, IB20::PausableFeature::REDEEM)?;
         B20Guards::ensure_policy::<Self>(self, Self::REDEEM_SENDER_POLICY, caller)?;
         let multiplier = self.accounting().multiplier()?;
@@ -363,21 +363,20 @@ mod tests {
         InMemoryPolicy, InMemoryTokenAccounting, PolicyRegistryStorage, Token,
     };
 
-    type TestSecurityToken = B20AssetToken<InMemoryTokenAccounting, InMemoryPolicy>;
+    type TestAssetToken = B20AssetToken<InMemoryTokenAccounting, InMemoryPolicy>;
 
     const CALLER: Address = Address::repeat_byte(0xcc);
     const ALICE: Address = Address::repeat_byte(0xaa);
     const BOB: Address = Address::repeat_byte(0xbb);
     const TOKEN: Address = Address::repeat_byte(0x01);
 
-    fn make_token() -> TestSecurityToken {
+    fn make_token() -> TestAssetToken {
         let mut accounting = InMemoryTokenAccounting::new(TOKEN);
         accounting.multiplier = B20AssetStorage::WAD;
-        accounting.policy_ids.insert(
-            TestSecurityToken::REDEEM_SENDER_POLICY,
-            PolicyRegistryStorage::ALWAYS_ALLOW_ID,
-        );
-        TestSecurityToken::with_storage_and_policy(accounting, InMemoryPolicy::new())
+        accounting
+            .policy_ids
+            .insert(TestAssetToken::REDEEM_SENDER_POLICY, PolicyRegistryStorage::ALWAYS_ALLOW_ID);
+        TestAssetToken::with_storage_and_policy(accounting, InMemoryPolicy::new())
     }
 
     #[derive(Debug, Clone, Copy)]
@@ -388,7 +387,7 @@ mod tests {
         LengthMismatch,
     }
 
-    fn setup_batch_mint(setup: BatchMintSetup) -> (TestSecurityToken, Vec<Address>, Vec<U256>) {
+    fn setup_batch_mint(setup: BatchMintSetup) -> (TestAssetToken, Vec<Address>, Vec<U256>) {
         let mut accounting = InMemoryTokenAccounting::new(TOKEN);
         accounting.multiplier = B20AssetStorage::WAD;
         let recipients;
@@ -416,7 +415,7 @@ mod tests {
             }
         }
 
-        let token = TestSecurityToken::with_storage_and_policy(accounting, InMemoryPolicy::new());
+        let token = TestAssetToken::with_storage_and_policy(accounting, InMemoryPolicy::new());
         (token, recipients, amounts)
     }
 
@@ -442,33 +441,33 @@ mod tests {
     }
 
     #[derive(Debug, Clone, Copy)]
-    enum SecurityRedeemSetup {
+    enum AssetRedeemSetup {
         Paused,
         PolicyBlocked,
         InsufficientBalance,
     }
 
-    fn setup_security_redeem(setup: SecurityRedeemSetup) -> TestSecurityToken {
+    fn setup_asset_redeem(setup: AssetRedeemSetup) -> TestAssetToken {
         let mut accounting = InMemoryTokenAccounting::new(TOKEN);
         accounting.multiplier = B20AssetStorage::WAD;
 
         match setup {
-            SecurityRedeemSetup::Paused => {
+            AssetRedeemSetup::Paused => {
                 accounting.paused = B20PausableFeature::mask(IB20::PausableFeature::REDEEM);
                 accounting.policy_ids.insert(
-                    TestSecurityToken::REDEEM_SENDER_POLICY,
+                    TestAssetToken::REDEEM_SENDER_POLICY,
                     PolicyRegistryStorage::ALWAYS_BLOCK_ID,
                 );
             }
-            SecurityRedeemSetup::PolicyBlocked => {
+            AssetRedeemSetup::PolicyBlocked => {
                 accounting.policy_ids.insert(
-                    TestSecurityToken::REDEEM_SENDER_POLICY,
+                    TestAssetToken::REDEEM_SENDER_POLICY,
                     PolicyRegistryStorage::ALWAYS_BLOCK_ID,
                 );
             }
-            SecurityRedeemSetup::InsufficientBalance => {
+            AssetRedeemSetup::InsufficientBalance => {
                 accounting.policy_ids.insert(
-                    TestSecurityToken::REDEEM_SENDER_POLICY,
+                    TestAssetToken::REDEEM_SENDER_POLICY,
                     PolicyRegistryStorage::ALWAYS_ALLOW_ID,
                 );
                 accounting.minimum_redeemable = U256::from(1u64);
@@ -476,21 +475,19 @@ mod tests {
             }
         }
 
-        TestSecurityToken::with_storage_and_policy(accounting, InMemoryPolicy::new())
+        TestAssetToken::with_storage_and_policy(accounting, InMemoryPolicy::new())
     }
 
-    fn expected_security_redeem_error(setup: SecurityRedeemSetup) -> BasePrecompileError {
+    fn expected_asset_redeem_error(setup: AssetRedeemSetup) -> BasePrecompileError {
         match setup {
-            SecurityRedeemSetup::Paused => BasePrecompileError::revert(IB20::ContractPaused {
+            AssetRedeemSetup::Paused => BasePrecompileError::revert(IB20::ContractPaused {
                 feature: IB20::PausableFeature::REDEEM,
             }),
-            SecurityRedeemSetup::PolicyBlocked => {
-                BasePrecompileError::revert(IB20::PolicyForbids {
-                    policyScope: TestSecurityToken::REDEEM_SENDER_POLICY,
-                    policyId: PolicyRegistryStorage::ALWAYS_BLOCK_ID,
-                })
-            }
-            SecurityRedeemSetup::InsufficientBalance => {
+            AssetRedeemSetup::PolicyBlocked => BasePrecompileError::revert(IB20::PolicyForbids {
+                policyScope: TestAssetToken::REDEEM_SENDER_POLICY,
+                policyId: PolicyRegistryStorage::ALWAYS_BLOCK_ID,
+            }),
+            AssetRedeemSetup::InsufficientBalance => {
                 BasePrecompileError::revert(IB20::InsufficientBalance {
                     sender: CALLER,
                     balance: U256::from(5u64),
@@ -506,7 +503,7 @@ mod tests {
         InvalidScope,
     }
 
-    fn setup_update_policy(setup: UpdatePolicySetup) -> (TestSecurityToken, B256) {
+    fn setup_update_policy(setup: UpdatePolicySetup) -> (TestAssetToken, B256) {
         let mut token = make_token();
         let invalid_scope = B256::repeat_byte(0xff);
 
@@ -533,9 +530,9 @@ mod tests {
 
     #[test]
     fn role_and_policy_ids_match_solidity_hashes() {
-        assert_eq!(TestSecurityToken::OPERATOR_ROLE, keccak256("OPERATOR_ROLE"));
-        assert_eq!(TestSecurityToken::METADATA_ROLE, keccak256("METADATA_ROLE"));
-        assert_eq!(TestSecurityToken::REDEEM_SENDER_POLICY, keccak256("REDEEM_SENDER_POLICY"));
+        assert_eq!(TestAssetToken::OPERATOR_ROLE, keccak256("OPERATOR_ROLE"));
+        assert_eq!(TestAssetToken::METADATA_ROLE, keccak256("METADATA_ROLE"));
+        assert_eq!(TestAssetToken::REDEEM_SENDER_POLICY, keccak256("REDEEM_SENDER_POLICY"));
     }
 
     #[rstest]
@@ -552,15 +549,15 @@ mod tests {
     }
 
     #[rstest]
-    #[case::paused_gets_pause_error(SecurityRedeemSetup::Paused)]
-    #[case::policy_blocked_gets_policy_error(SecurityRedeemSetup::PolicyBlocked)]
-    #[case::insufficient_balance_gets_business_error(SecurityRedeemSetup::InsufficientBalance)]
-    fn security_redeem_check_order(#[case] setup: SecurityRedeemSetup) {
-        let mut token = setup_security_redeem(setup);
+    #[case::paused_gets_pause_error(AssetRedeemSetup::Paused)]
+    #[case::policy_blocked_gets_policy_error(AssetRedeemSetup::PolicyBlocked)]
+    #[case::insufficient_balance_gets_business_error(AssetRedeemSetup::InsufficientBalance)]
+    fn asset_redeem_check_order(#[case] setup: AssetRedeemSetup) {
+        let mut token = setup_asset_redeem(setup);
 
-        let err = token.security_redeem(CALLER, U256::from(10u64)).unwrap_err();
+        let err = token.asset_redeem(CALLER, U256::from(10u64)).unwrap_err();
 
-        assert_eq!(err, expected_security_redeem_error(setup));
+        assert_eq!(err, expected_asset_redeem_error(setup));
     }
 
     #[rstest]
@@ -581,7 +578,7 @@ mod tests {
     #[test]
     fn update_extra_metadata_requires_metadata_role_not_operator_role() {
         let mut token = make_token();
-        token.accounting_mut().roles.insert((TestSecurityToken::OPERATOR_ROLE, CALLER), true);
+        token.accounting_mut().roles.insert((TestAssetToken::OPERATOR_ROLE, CALLER), true);
 
         let err = token
             .update_extra_metadata(CALLER, "ISIN".to_string(), "US0000000000".to_string(), false)
@@ -591,7 +588,7 @@ mod tests {
             err,
             BasePrecompileError::revert(IB20::AccessControlUnauthorizedAccount {
                 account: CALLER,
-                neededRole: TestSecurityToken::METADATA_ROLE,
+                neededRole: TestAssetToken::METADATA_ROLE,
             })
         );
     }

--- a/crates/common/precompiles/src/b20_factory/storage.rs
+++ b/crates/common/precompiles/src/b20_factory/storage.rs
@@ -16,7 +16,7 @@ use crate::{
 const B20_STABLECOIN_EVENT_PARAMS_VERSION: u8 = 1;
 
 /// ABI-encodes stablecoin-specific `variantParams` for `B20Created`.
-/// DEFAULT and SECURITY call sites use `Bytes::new()` directly.
+/// DEFAULT and ASSET call sites use `Bytes::new()` directly.
 fn encode_stablecoin_variant_params(currency: &str) -> Bytes {
     IB20Factory::B20StablecoinEventParams {
         version: B20_STABLECOIN_EVENT_PARAMS_VERSION,
@@ -427,11 +427,11 @@ mod tests {
     fn test_address_derivation_ignores_decimals_and_uses_variant() {
         let creator = Address::repeat_byte(0x11);
         let salt = B256::repeat_byte(0x33);
-        let (security_token, _) = B20Variant::Asset.compute_address(creator, salt);
+        let (asset_token, _) = B20Variant::Asset.compute_address(creator, salt);
         let (stablecoin, _) = B20Variant::Stablecoin.compute_address(creator, salt);
 
-        assert_ne!(security_token, stablecoin);
-        assert_eq!(B20Variant::decimals_of(security_token), Some(6));
+        assert_ne!(asset_token, stablecoin);
+        assert_eq!(B20Variant::decimals_of(asset_token), Some(6));
         assert_eq!(B20Variant::decimals_of(stablecoin), Some(6));
     }
 
@@ -440,15 +440,15 @@ mod tests {
         let creator = Address::repeat_byte(0x11);
         let salt = B256::repeat_byte(0x44);
         let (stablecoin, _) = B20Variant::compute_address_for_discriminant(creator, 0, salt);
-        let (security, _) = B20Variant::compute_address_for_discriminant(creator, 1, salt);
+        let (asset, _) = B20Variant::compute_address_for_discriminant(creator, 1, salt);
 
         assert!(B20Variant::is_supported_discriminant(0));
         assert!(B20Variant::is_supported_discriminant(1));
         assert!(!B20Variant::is_supported_discriminant(2));
         assert!(B20Variant::is_b20_address(stablecoin));
-        assert!(B20Variant::is_b20_address(security));
+        assert!(B20Variant::is_b20_address(asset));
         assert_eq!(B20Variant::from_address(stablecoin), Some(B20Variant::Stablecoin));
-        assert_eq!(B20Variant::from_address(security), Some(B20Variant::Asset));
+        assert_eq!(B20Variant::from_address(asset), Some(B20Variant::Asset));
     }
 
     #[test]
@@ -746,45 +746,45 @@ mod tests {
     }
 
     #[test]
-    fn test_create_security_token_stores_isin_and_ratio() {
+    fn test_create_asset_token_stores_isin_and_ratio() {
         let mut storage = HashMapStorageProvider::new(1);
         activate_precompiles(&mut storage);
         let caller = Address::repeat_byte(0x55);
         let salt = B256::repeat_byte(0x09);
         let (expected_addr, _) = B20Variant::Asset.compute_address(caller, salt);
 
-        let security_params = IB20Factory::B20AssetCreateParams {
+        let asset_params = IB20Factory::B20AssetCreateParams {
             version: B20Variant::Asset.supported_version(),
-            name: "Security Token".to_string(),
-            symbol: "SEC".to_string(),
+            name: "Asset Token".to_string(),
+            symbol: "AST".to_string(),
             initialAdmin: Address::repeat_byte(0xAB),
             isin: "US0000000000".to_string(),
             minimumRedeemable: U256::ONE,
         };
-        let security_call = IB20Factory::createB20Call {
+        let asset_call = IB20Factory::createB20Call {
             variant: IB20Factory::B20Variant::ASSET,
             salt,
-            params: security_params.abi_encode().into(),
+            params: asset_params.abi_encode().into(),
             initCalls: Vec::new(),
         };
 
         storage.set_caller(caller);
         StorageCtx::enter(&mut storage, |ctx| {
             assert_output(
-                dispatch_factory_success(ctx, security_call),
+                dispatch_factory_success(ctx, asset_call),
                 IB20Factory::createB20Call::abi_encode_returns(&expected_addr),
             );
             assert!(ctx.has_bytecode(expected_addr).unwrap());
 
-            let sec_storage = B20AssetStorage::from_address(expected_addr, ctx);
-            assert_eq!(sec_storage.b20.name.read().unwrap(), "Security Token");
-            assert_eq!(sec_storage.b20.symbol.read().unwrap(), "SEC");
-            assert_eq!(sec_storage.decimals().unwrap(), 6);
-            assert_eq!(sec_storage.security.multiplier.read().unwrap(), U256::ZERO);
-            assert_eq!(sec_storage.redeem.minimum_redeemable.read().unwrap(), U256::ONE);
+            let asset_storage = B20AssetStorage::from_address(expected_addr, ctx);
+            assert_eq!(asset_storage.b20.name.read().unwrap(), "Asset Token");
+            assert_eq!(asset_storage.b20.symbol.read().unwrap(), "AST");
+            assert_eq!(asset_storage.decimals().unwrap(), 6);
+            assert_eq!(asset_storage.asset.multiplier.read().unwrap(), U256::ZERO);
+            assert_eq!(asset_storage.redeem.minimum_redeemable.read().unwrap(), U256::ONE);
             // ISIN is stored in the identifiers mapping under the raw "ISIN" key.
             assert_eq!(
-                sec_storage.security.identifiers.at(&String::from("ISIN")).read().unwrap(),
+                asset_storage.asset.identifiers.at(&String::from("ISIN")).read().unwrap(),
                 "US0000000000"
             );
         });
@@ -1106,7 +1106,7 @@ mod tests {
     }
 
     #[test]
-    fn test_create_security_token_grants_default_admin_role() {
+    fn test_create_asset_token_grants_default_admin_role() {
         let mut storage = HashMapStorageProvider::new(1);
         activate_precompiles(&mut storage);
         let caller = Address::repeat_byte(0x55);
@@ -1114,8 +1114,8 @@ mod tests {
 
         let params = IB20Factory::B20AssetCreateParams {
             version: B20Variant::Asset.supported_version(),
-            name: "Security Token".to_string(),
-            symbol: "SEC".to_string(),
+            name: "Asset Token".to_string(),
+            symbol: "AST".to_string(),
             initialAdmin: initial_admin,
             isin: "US0000000001".to_string(),
             minimumRedeemable: U256::ZERO,

--- a/crates/common/precompiles/src/b20_stablecoin/accounting.rs
+++ b/crates/common/precompiles/src/b20_stablecoin/accounting.rs
@@ -8,7 +8,7 @@ use crate::TokenAccounting;
 
 /// Extends [`TokenAccounting`] with the stablecoin-specific `currency` slot.
 ///
-/// Only [`super::B20StablecoinToken`] requires this bound; default and security
+/// Only [`super::B20StablecoinToken`] requires this bound; default and asset
 /// tokens use the base [`TokenAccounting`] port exclusively.
 pub trait StablecoinAccounting: TokenAccounting {
     /// Returns the stablecoin currency identifier.

--- a/crates/common/precompiles/src/common/test_utils.rs
+++ b/crates/common/precompiles/src/common/test_utils.rs
@@ -10,7 +10,7 @@ use base_precompile_storage::Result;
 
 use crate::{
     B20AssetStorage, IPolicyRegistry, PolicyRegistry, PolicyRegistryStorage,
-    b20_asset::{B20AssetToken, SecurityAccounting},
+    b20_asset::{AssetAccounting, B20AssetToken},
     b20_stablecoin::{B20StablecoinToken, StablecoinAccounting},
     common::{Policy, TokenAccounting},
 };
@@ -47,8 +47,8 @@ pub struct InMemoryTokenAccounting {
     pub decimals: u8,
     /// Stablecoin currency identifier.
     pub currency: String,
-    /// Security ISIN identifier (legacy field; prefer `extra_metadata` map for asset tokens).
-    pub security_isin: String,
+    /// Asset ISIN identifier (legacy field; prefer `extra_metadata` map for asset tokens).
+    pub asset_isin: String,
     /// Bitmask of active pause vectors.
     pub paused: U256,
     /// Per-account EIP-2612 nonces.
@@ -65,11 +65,11 @@ pub struct InMemoryTokenAccounting {
     pub role_admins: HashMap<B256, B256>,
     /// Policy IDs keyed by policy type.
     pub policy_ids: HashMap<B256, u64>,
-    /// Multiplier scaled to WAD (1e18). Security tokens only.
+    /// Multiplier scaled to WAD (1e18). Asset tokens only.
     pub multiplier: U256,
-    /// Security identifier values keyed by raw `identifier_type`. Security tokens only.
+    /// Asset metadata values keyed by raw `identifier_type`. Asset tokens only.
     pub extra_metadata: HashMap<String, String>,
-    /// Consumed announcement ids keyed by raw announcement id. Security tokens only.
+    /// Consumed announcement ids keyed by raw announcement id. Asset tokens only.
     pub announcement_ids_used: HashSet<String>,
     /// Events collected by `emit_event`; does not produce real EVM logs.
     pub events: Vec<LogData>,
@@ -89,7 +89,7 @@ impl InMemoryTokenAccounting {
             symbol: String::new(),
             decimals: 18,
             currency: String::new(),
-            security_isin: String::new(),
+            asset_isin: String::new(),
             paused: U256::ZERO,
             nonces: HashMap::new(),
             minimum_redeemable: U256::ZERO,
@@ -385,7 +385,7 @@ impl PolicyRegistry for InMemoryPolicy {
     }
 }
 
-impl SecurityAccounting for InMemoryTokenAccounting {
+impl AssetAccounting for InMemoryTokenAccounting {
     fn multiplier(&self) -> Result<U256> {
         const WAD: U256 = U256::from_limbs([1_000_000_000_000_000_000, 0, 0, 0]);
         Ok(if self.multiplier.is_zero() { WAD } else { self.multiplier })
@@ -400,7 +400,7 @@ impl SecurityAccounting for InMemoryTokenAccounting {
         if let Some(val) = self.extra_metadata.get(identifier_type) {
             return Ok(val.clone());
         }
-        if identifier_type == "ISIN" { Ok(self.security_isin.clone()) } else { Ok(String::new()) }
+        if identifier_type == "ISIN" { Ok(self.asset_isin.clone()) } else { Ok(String::new()) }
     }
 
     fn set_extra_metadata_value(&mut self, identifier_type: &str, value: String) -> Result<()> {

--- a/crates/common/precompiles/src/lib.rs
+++ b/crates/common/precompiles/src/lib.rs
@@ -50,8 +50,8 @@ pub use observer::{EndGuard, NoopPrecompileCallObserver, PrecompileCallObserver}
 
 mod b20_asset;
 pub use b20_asset::{
-    B20AssetExtensionStorage, B20AssetInit, B20AssetPrecompile, B20AssetStorage, B20AssetToken,
-    B20RedeemStorage, IB20Asset, SecurityAccounting,
+    AssetAccounting, B20AssetExtensionStorage, B20AssetInit, B20AssetPrecompile, B20AssetStorage,
+    B20AssetToken, B20RedeemStorage, IB20Asset,
 };
 
 mod b20_stablecoin;


### PR DESCRIPTION
## Summary

This renames the B20 asset accounting derive and storage surface away from security terminology. The macro now derives AssetAccounting against an asset field, and the B20 asset token, storage, dispatch, tests, and docs use asset naming consistently.