### PR TITLE
fix(common): Align B20 Base Std Interface

### DIFF
--- a/actions/harness/tests/beryl/env.rs
+++ b/actions/harness/tests/beryl/env.rs
@@ -11,8 +11,8 @@ use base_action_harness::{
 use base_batcher_encoder::{DaType, EncoderConfig};
 use base_common_consensus::{BaseBlock, BaseReceipt, BaseTxEnvelope};
 use base_common_precompiles::{
-    ActivationFeature, ActivationRegistryStorage, B20AssetStorage, B20FactoryStorage, B20Variant,
-    IActivationRegistry, IB20, IB20Factory, IPolicyRegistry, PolicyRegistryStorage,
+    ActivationFeature, ActivationRegistryStorage, B20FactoryStorage, B20Variant,
+    IActivationRegistry, IB20, IB20Factory, IPolicyRegistry,
 };
 use base_precompile_storage::StorageKey;
 use base_test_utils::Account;
@@ -92,12 +92,6 @@ impl BerylTestEnv {
 
     /// Symbol for the security B-20 token variant.
     pub(crate) const B20_ASSET_SYMBOL: &str = "ASEC";
-
-    /// ISIN stored on the security B-20 token at creation.
-    pub(crate) const B20_ASSET_ISIN: &str = "US0000000001";
-
-    /// Initial minimum redeemable share amount for the security B-20 token.
-    pub(crate) const B20_ASSET_MINIMUM_REDEEMABLE: u64 = 10;
 
     /// Initial B-20 supply minted to Alice.
     pub(crate) const B20_INITIAL_SUPPLY: u64 = 1_000_000;
@@ -583,12 +577,6 @@ impl BerylTestEnv {
                 IB20::mintCall { to: Self::alice(), amount: U256::from(Self::B20_INITIAL_SUPPLY) }
                     .abi_encode()
                     .into(),
-                IB20::updatePolicyCall {
-                    policyScope: B20AssetStorage::REDEEM_SENDER_POLICY,
-                    newPolicyId: PolicyRegistryStorage::ALWAYS_ALLOW_ID,
-                }
-                .abi_encode()
-                .into(),
             ],
         }
     }
@@ -629,8 +617,6 @@ impl BerylTestEnv {
             name: Self::B20_NAME.to_string(),
             symbol: Self::B20_SYMBOL.to_string(),
             initialAdmin: Self::alice(),
-            isin: String::new(),
-            minimumRedeemable: U256::ZERO,
             decimals: 6,
         }
     }
@@ -651,8 +637,6 @@ impl BerylTestEnv {
             name: Self::B20_ASSET_NAME.to_string(),
             symbol: Self::B20_ASSET_SYMBOL.to_string(),
             initialAdmin: Self::alice(),
-            isin: Self::B20_ASSET_ISIN.to_string(),
-            minimumRedeemable: U256::from(Self::B20_ASSET_MINIMUM_REDEEMABLE),
             decimals: Self::B20_ASSET_DECIMALS,
         }
     }

--- a/actions/harness/tests/beryl/policy_transfer.rs
+++ b/actions/harness/tests/beryl/policy_transfer.rs
@@ -422,8 +422,6 @@ impl PolicyTransferScenario {
             name: "Policy B20".to_string(),
             symbol: "PB20".to_string(),
             initialAdmin: BerylTestEnv::alice(),
-            isin: String::new(),
-            minimumRedeemable: U256::ZERO,
             decimals: 6,
         }
     }

--- a/actions/harness/tests/beryl/security.rs
+++ b/actions/harness/tests/beryl/security.rs
@@ -69,10 +69,10 @@ async fn security_creation_initializes_identifiers_and_factory_views() {
                 ),
                 StaticcallCase::string("contractURI", IB20::contractURICall {}.abi_encode(), ""),
                 StaticcallCase::string(
-                    "extraMetadata(ISIN)",
+                    "extraMetadata(unset)",
                     IB20Asset::extraMetadataCall { identifierType: "ISIN".to_string() }
                         .abi_encode(),
-                    BerylTestEnv::B20_ASSET_ISIN,
+                    "",
                 ),
                 StaticcallCase::word(
                     "decimals",
@@ -101,7 +101,7 @@ async fn security_creation_initializes_identifiers_and_factory_views() {
                     U256::from(100),
                 ),
                 StaticcallCase::word(
-                    "scaledBalanceOf(alice)",
+                    "scaledBalanceOf((alice)",
                     IB20Asset::scaledBalanceOfCall { account: BerylTestEnv::alice() }.abi_encode(),
                     U256::from(BerylTestEnv::B20_INITIAL_SUPPLY),
                 ),
@@ -251,7 +251,7 @@ async fn security_mutations_update_state_and_emit_events() {
                     U256::from(100),
                 ),
                 StaticcallCase::word(
-                    "scaledBalanceOf(alice) after update",
+                    "scaledBalanceOf((alice) after update",
                     IB20Asset::scaledBalanceOfCall { account: BerylTestEnv::alice() }.abi_encode(),
                     U256::from(BerylTestEnv::B20_INITIAL_SUPPLY) * U256::from(2),
                 ),

--- a/crates/common/precompile-macros/src/accounting.rs
+++ b/crates/common/precompile-macros/src/accounting.rs
@@ -18,10 +18,9 @@ pub(crate) fn derive_asset(input: DeriveInput) -> proc_macro::TokenStream {
 
 fn expand_token(input: DeriveInput) -> syn::Result<TokenStream> {
     require_field(&input, "b20")?;
-    let has_redeem = has_field(&input, "redeem");
-    let has_security = has_field(&input, "asset");
+    let has_asset = has_field(&input, "asset");
     let name = input.ident;
-    let decimals_impl = if has_security {
+    let decimals_impl = if has_asset {
         quote! { crate::AssetAccounting::decimals(self) }
     } else {
         quote! {
@@ -31,16 +30,6 @@ fn expand_token(input: DeriveInput) -> syn::Result<TokenStream> {
             .map_or(0, crate::B20Variant::decimals))
         }
     };
-    let redeem = has_redeem.then_some(quote! {
-        if policy_scope == Self::REDEEM_SENDER_POLICY {
-            return self.redeem.redeem_sender_policy_id();
-        }
-    });
-    let set_redeem = has_redeem.then_some(quote! {
-        if policy_scope == Self::REDEEM_SENDER_POLICY {
-            return self.redeem.set_redeem_sender_policy_id(policy_id);
-        }
-    });
 
     Ok(quote! {
         impl #name<'_> {
@@ -250,7 +239,6 @@ fn expand_token(input: DeriveInput) -> syn::Result<TokenStream> {
                 &self,
                 policy_scope: ::alloy_primitives::B256,
             ) -> ::base_precompile_storage::Result<u64> {
-                #redeem
                 match Self::__require_policy_type(policy_scope)? {
                     crate::B20PolicyType::TransferSender => self.b20.transfer_sender_policy_id(),
                     crate::B20PolicyType::TransferReceiver => {
@@ -268,7 +256,6 @@ fn expand_token(input: DeriveInput) -> syn::Result<TokenStream> {
                 policy_scope: ::alloy_primitives::B256,
                 policy_id: u64,
             ) -> ::base_precompile_storage::Result<()> {
-                #set_redeem
                 match Self::__require_policy_type(policy_scope)? {
                     crate::B20PolicyType::TransferSender => {
                         self.b20.set_transfer_sender_policy_id(policy_id)
@@ -316,22 +303,21 @@ fn expand_stablecoin(input: DeriveInput) -> syn::Result<TokenStream> {
 
 fn expand_asset(input: DeriveInput) -> syn::Result<TokenStream> {
     require_field(&input, "asset")?;
-    require_field(&input, "redeem")?;
     let name = input.ident;
     Ok(quote! {
         impl crate::AssetAccounting for #name<'_> {
             fn multiplier(
                 &self,
             ) -> ::base_precompile_storage::Result<::alloy_primitives::U256> {
-                let multiplier = self.asset.multiplier()?;
-                Ok(if multiplier.is_zero() { Self::WAD } else { multiplier })
+                let ratio = self.asset.multiplier()?;
+                Ok(if ratio.is_zero() { Self::WAD } else { ratio })
             }
 
             fn set_multiplier(
                 &mut self,
-                multiplier: ::alloy_primitives::U256,
+                ratio: ::alloy_primitives::U256,
             ) -> ::base_precompile_storage::Result<()> {
-                self.asset.set_multiplier(multiplier)
+                self.asset.set_multiplier(ratio)
             }
 
             fn extra_metadata(
@@ -359,19 +345,6 @@ fn expand_asset(input: DeriveInput) -> syn::Result<TokenStream> {
                         value,
                     )
                 }
-            }
-
-            fn minimum_redeemable(
-                &self,
-            ) -> ::base_precompile_storage::Result<::alloy_primitives::U256> {
-                self.redeem.minimum_redeemable()
-            }
-
-            fn set_minimum_redeemable(
-                &mut self,
-                minimum: ::alloy_primitives::U256,
-            ) -> ::base_precompile_storage::Result<()> {
-                self.redeem.set_minimum_redeemable(minimum)
             }
 
             fn is_announcement_id_used(

--- a/crates/common/precompile-storage/README.md
+++ b/crates/common/precompile-storage/README.md
@@ -41,7 +41,7 @@ field with that type is automatically mounted at the type's namespace root:
 #[derive(Debug, Clone, Storable)]
 #[namespace("b20.asset")]
 pub struct B20AssetStorage {
-    pub multiplier: U256,
+    pub shares_to_tokens_ratio: U256,
 }
 
 #[contract]

--- a/crates/common/precompiles/README.md
+++ b/crates/common/precompiles/README.md
@@ -16,7 +16,7 @@ that lets downstream crates use their own spec wrapper as long as it converts to
 
 The crate also exports the ABI types, storage adapters, entry points, and shared token traits for
 the native B-20 token system. Those exports cover the activation registry, policy registry, B-20
-factory, default B-20 token, stablecoin token, asset token, and the reusable role, pause, policy,
+factory, default B-20 token, stablecoin token, security token, and the reusable role, pause, policy,
 permit, and accounting helpers used by those precompiles.
 
 ## Behavior
@@ -52,12 +52,12 @@ policies, supports staged admin transfer and admin renunciation, and provides bu
 The B-20 factory is the singleton precompile at `0xB20F000000000000000000000000000000000000`. It
 creates deterministic B-20 token addresses from the caller, variant, and salt. B-20 token addresses
 use the `0xb2` prefix with the variant encoded in the address. The default B-20 variant uses 18
-decimals, while stablecoin and asset variants use 6 decimals.
+decimals, while stablecoin and security variants use 6 decimals.
 
 Default B-20 tokens implement the ERC-20 surface plus roles, pausing, supply caps, memo transfers,
 policy hooks, EIP-2612 permits, ERC-5267 domain reporting, and ERC-7572 contract metadata. The
-stablecoin variant adds currency metadata. The asset variant adds multiplier-based scaling,
-minimum redeemable checks, batched mint and burn operations, asset metadata, and announcement
+stablecoin variant adds currency metadata. The security variant adds share-ratio accounting,
+batched mint and burn operations, security identifiers, and announcement
 flows that can execute internal token calls.
 
 ## Usage

--- a/crates/common/precompiles/benches/base_precompiles.rs
+++ b/crates/common/precompiles/benches/base_precompiles.rs
@@ -32,8 +32,6 @@ impl BaseTokenBenchSetup {
             name: name.to_string(),
             symbol: symbol.to_string(),
             initialAdmin: Self::admin(),
-            isin: String::new(),
-            minimumRedeemable: U256::ZERO,
             decimals: 6,
         }
     }

--- a/crates/common/precompiles/src/b20_asset/abi.rs
+++ b/crates/common/precompiles/src/b20_asset/abi.rs
@@ -13,17 +13,14 @@ sol! {
         /// `id` has previously been consumed by `announce`. Each id may be used at most once.
         error AnnouncementIdAlreadyUsed(string id);
 
-        /// `updateExtraMetadata` was called with an empty `identifierType`.
-        error InvalidIdentifierType();
+        /// `updateExtraMetadata` was called with an empty metadata key.
+        error InvalidMetadataKey();
 
         /// A batched function was called with parallel arrays of differing lengths.
         error LengthMismatch(uint256 leftLen, uint256 rightLen);
 
         /// A batched function was called with empty arrays.
         error EmptyBatch();
-
-        /// `redeem`/`redeemWithMemo` was called with a scaled amount below the floor, or zero.
-        error BelowMinimumRedeemable(uint256 scaledAmount, uint256 minimum);
 
         /// An `internalCalls` entry tried to invoke `announce` itself.
         error AnnouncementInProgress();
@@ -34,16 +31,7 @@ sol! {
         /// An `internalCalls` entry reverted during its inner dispatch.
         error InternalCallFailed(bytes call);
 
-        /// `decimals` was not in the allowed range `[6, 18]`.
-        error InvalidDecimals();
-
         // ── Events ───────────────────────────────────────────────────────────
-
-        /// Emitted by `redeem`/`redeemWithMemo`. Includes the active multiplier at redemption time.
-        event Redeemed(address indexed from, uint256 amt, uint256 multiplier);
-
-        /// Emitted by `updateMinimumRedeemable`.
-        event MinimumRedeemableUpdated(address indexed caller, uint256 newMinimumRedeemable);
 
         /// Emitted by `updateMultiplier`.
         event MultiplierUpdated(uint256 multiplier);
@@ -68,8 +56,6 @@ sol! {
         /// Fixed-point precision for `multiplier`: `1e18` (one WAD).
         function WAD_PRECISION() external view returns (uint256);
 
-        /// `keccak256("REDEEM_SENDER_POLICY")` — consulted on `redeem`/`redeemWithMemo`.
-        function REDEEM_SENDER_POLICY() external view returns (bytes32);
 
         // ── Announcements ────────────────────────────────────────────────────
 
@@ -92,6 +78,9 @@ sol! {
         /// Converts a raw balance to its scaled view: `rawBalance * multiplier / WAD_PRECISION`.
         function toScaledBalance(uint256 rawBalance) external view returns (uint256);
 
+        /// Converts a scaled balance back to its raw representation.
+        function toRawBalance(uint256 scaledBalance) external view returns (uint256 rawBalance);
+
         /// Convenience: `toScaledBalance(balanceOf(account))`.
         function scaledBalanceOf(address account) external view returns (uint256);
 
@@ -103,26 +92,12 @@ sol! {
         /// Mints `amounts[i]` to `recipients[i]`. Requires `MINT_ROLE`. All-or-nothing.
         function batchMint(address[] calldata recipients, uint256[] calldata amounts) external;
 
-        // ── Redemption ────────────────────────────────────────────────────────
-
-        /// Burns `amount` from caller with a multiplier-scaled minimum floor check.
-        function redeem(uint256 amount) external;
-
-        /// Same as `redeem`, followed by a `Memo` event.
-        function redeemWithMemo(uint256 amount, bytes32 memo) external;
-
-        /// Sets the minimum-redeemable threshold in scaled units. Requires `DEFAULT_ADMIN_ROLE`.
-        function updateMinimumRedeemable(uint256 newMinimumRedeemable) external;
-
-        /// Returns the minimum-redeemable threshold in scaled units.
-        function minimumRedeemable() external view returns (uint256);
-
-        // ── Asset metadata ──────────────────────────────────────────────────
+        // ── Asset identifiers ─────────────────────────────────────────────
 
         /// Returns the value of the named identifier (e.g. ISIN, CUSIP). Empty string if not set.
         function extraMetadata(string calldata identifierType) external view returns (string);
 
-        /// Sets, updates, or removes asset metadata. Empty `value` removes the entry. Requires `METADATA_ROLE`.
+        /// Sets, updates, or removes a asset identifier. Empty `value` removes the entry. Requires `METADATA_ROLE`.
         function updateExtraMetadata(
             string calldata identifierType,
             string calldata value
@@ -137,18 +112,14 @@ impl IB20Asset::IB20AssetCalls {
             Self::OPERATOR_ROLE(_) => "precompile-b20-asset-OPERATOR_ROLE",
             Self::METADATA_ROLE(_) => "precompile-b20-asset-METADATA_ROLE",
             Self::WAD_PRECISION(_) => "precompile-b20-asset-WAD_PRECISION",
-            Self::REDEEM_SENDER_POLICY(_) => "precompile-b20-asset-REDEEM_SENDER_POLICY",
             Self::announce(_) => "precompile-b20-asset-announce",
             Self::isAnnouncementIdUsed(_) => "precompile-b20-asset-isAnnouncementIdUsed",
             Self::multiplier(_) => "precompile-b20-asset-multiplier",
             Self::toScaledBalance(_) => "precompile-b20-asset-toScaledBalance",
+            Self::toRawBalance(_) => "precompile-b20-asset-toRawBalance",
             Self::scaledBalanceOf(_) => "precompile-b20-asset-scaledBalanceOf",
             Self::updateMultiplier(_) => "precompile-b20-asset-updateMultiplier",
             Self::batchMint(_) => "precompile-b20-asset-batchMint",
-            Self::redeem(_) => "precompile-b20-asset-redeem",
-            Self::redeemWithMemo(_) => "precompile-b20-asset-redeemWithMemo",
-            Self::updateMinimumRedeemable(_) => "precompile-b20-asset-updateMinimumRedeemable",
-            Self::minimumRedeemable(_) => "precompile-b20-asset-minimumRedeemable",
             Self::extraMetadata(_) => "precompile-b20-asset-extraMetadata",
             Self::updateExtraMetadata(_) => "precompile-b20-asset-updateExtraMetadata",
         }
@@ -157,39 +128,17 @@ impl IB20Asset::IB20AssetCalls {
 
 #[cfg(test)]
 mod tests {
-    use alloy_primitives::{U256, b256, keccak256};
-    use alloy_sol_types::{SolCall, SolEvent};
-
     use crate::IB20Asset;
-
-    #[test]
-    fn redeem_sender_policy_selector_matches_solidity_interface() {
-        assert_eq!(IB20Asset::REDEEM_SENDER_POLICYCall::SELECTOR, [0x1c, 0x6f, 0x9d, 0x42]);
-    }
-
-    #[test]
-    fn minimum_redeemable_updated_topic_matches_solidity_interface() {
-        assert_eq!(
-            IB20Asset::MinimumRedeemableUpdated::SIGNATURE_HASH,
-            b256!("7fdd6ea6dad98bfcd2c5ec538e748a5e8ecc40d0fc824f55dfc7397fe78a183b")
-        );
-        assert_eq!(
-            IB20Asset::MinimumRedeemableUpdated::SIGNATURE_HASH,
-            keccak256("MinimumRedeemableUpdated(address,uint256)")
-        );
-    }
 
     #[test]
     fn asset_call_labels_are_stable() {
         assert_eq!(
-            IB20Asset::IB20AssetCalls::minimumRedeemable(IB20Asset::minimumRedeemableCall {},)
-                .as_label(),
-            "precompile-b20-asset-minimumRedeemable"
-        );
-        assert_eq!(
-            IB20Asset::IB20AssetCalls::redeem(IB20Asset::redeemCall { amount: U256::ZERO })
-                .as_label(),
-            "precompile-b20-asset-redeem"
+            IB20Asset::IB20AssetCalls::updateExtraMetadata(IB20Asset::updateExtraMetadataCall {
+                identifierType: alloc::string::String::new(),
+                value: alloc::string::String::new(),
+            })
+            .as_label(),
+            "precompile-b20-asset-updateExtraMetadata"
         );
     }
 }

--- a/crates/common/precompiles/src/b20_asset/accounting.rs
+++ b/crates/common/precompiles/src/b20_asset/accounting.rs
@@ -9,29 +9,24 @@ use crate::TokenAccounting;
 
 /// Extends [`TokenAccounting`] with asset-token-specific storage slots.
 ///
-/// Asset metadata (ISIN, CUSIP, etc.) and redeem parameters are only exposed
-/// through the asset-token surface, not the base B-20 surface.
+/// Asset identifiers (ISIN, CUSIP, etc.) are only exposed through the
+/// asset-token surface, not the base B-20 surface.
 pub trait AssetAccounting: TokenAccounting {
-    /// Returns the current multiplier scaled to WAD (1e18).
+    /// Returns the current share-to-tokens ratio scaled to WAD (1e18).
     fn multiplier(&self) -> Result<U256>;
-    /// Writes a new multiplier.
-    fn set_multiplier(&mut self, multiplier: U256) -> Result<()>;
+    /// Writes a new share-to-tokens ratio.
+    fn set_multiplier(&mut self, ratio: U256) -> Result<()>;
 
-    /// Returns the asset metadata value for `identifier_type`, or an empty string if unset.
+    /// Returns the asset identifier value for `identifier_type`, or an empty string if unset.
     fn extra_metadata(&self, identifier_type: &str) -> Result<String>;
-    /// Writes (or removes when `value` is empty) the asset metadata for `identifier_type`.
+    /// Writes (or removes when `value` is empty) the asset identifier for `identifier_type`.
     fn set_extra_metadata_value(&mut self, identifier_type: &str, value: String) -> Result<()>;
-
-    /// Returns the minimum amount that may be redeemed in a single call.
-    fn minimum_redeemable(&self) -> Result<U256>;
-    /// Overwrites the minimum redeemable amount.
-    fn set_minimum_redeemable(&mut self, minimum: U256) -> Result<()>;
 
     /// Returns `true` if `id` has been consumed by `announce`.
     fn is_announcement_id_used(&self, id: &str) -> Result<bool>;
     /// Marks `id` as consumed. Called exactly once per announcement id.
     fn mark_announcement_id_used(&mut self, id: &str) -> Result<()>;
 
-    /// Returns the custom decimal precision stored for this security token.
+    /// Returns the custom decimal precision stored for this asset token.
     fn decimals(&self) -> Result<u8>;
 }

--- a/crates/common/precompiles/src/b20_asset/dispatch.rs
+++ b/crates/common/precompiles/src/b20_asset/dispatch.rs
@@ -1,10 +1,7 @@
 //! ABI dispatch for the asset B-20 variant.
 //!
 //! Asset-specific selectors are tried first via `IB20Asset::IB20AssetCalls`.
-//! This catches overridden selectors (`redeem`, `redeemWithMemo`) before the
-//! inherited `IB20` fallthrough, ensuring asset semantics always apply.
-//! The `IB20` match block still includes those arms (Rust requires exhaustiveness)
-//! and routes them to the same asset implementation as a safety net.
+//! The `IB20` match block handles inherited selectors.
 
 use alloc::{string::String, vec::Vec};
 
@@ -341,11 +338,11 @@ impl<S: AssetAccounting, P: Policy> B20AssetToken<S, P> {
             SC::OPERATOR_ROLE(_) => Self::OPERATOR_ROLE.abi_encode().into(),
             SC::METADATA_ROLE(_) => Self::METADATA_ROLE.abi_encode().into(),
             SC::WAD_PRECISION(_) => B20AssetStorage::WAD.abi_encode().into(),
-            SC::REDEEM_SENDER_POLICY(_) => Self::REDEEM_SENDER_POLICY.abi_encode().into(),
 
-            // --- Multiplier reads ---
+            // --- Share ratio reads ---
             SC::multiplier(_) => self.accounting().multiplier()?.abi_encode().into(),
             SC::toScaledBalance(c) => self.to_scaled_balance(c.rawBalance)?.abi_encode().into(),
+            SC::toRawBalance(c) => self.to_raw_balance(c.scaledBalance)?.abi_encode().into(),
             SC::scaledBalanceOf(c) => self.scaled_balance_of(c.account)?.abi_encode().into(),
 
             // --- Announcement reads ---
@@ -353,12 +350,12 @@ impl<S: AssetAccounting, P: Policy> B20AssetToken<S, P> {
                 self.accounting().is_announcement_id_used(c.id.as_str())?.abi_encode().into()
             }
 
-            // --- Asset metadata reads ---
+            // --- Asset identifier reads ---
             SC::extraMetadata(c) => {
                 self.accounting().extra_metadata(c.identifierType.as_str())?.abi_encode().into()
             }
 
-            // --- Multiplier mutations ---
+            // --- Share ratio mutations ---
             SC::updateMultiplier(c) => {
                 self.update_multiplier(caller, c.newMultiplier, privileged)?;
                 Bytes::new()
@@ -376,24 +373,7 @@ impl<S: AssetAccounting, P: Policy> B20AssetToken<S, P> {
                 Bytes::new()
             }
 
-            // --- Asset redeem (overrides IB20 redeem semantics) ---
-            SC::redeem(c) => {
-                self.asset_redeem(caller, c.amount)?;
-                Bytes::new()
-            }
-            SC::redeemWithMemo(c) => {
-                self.asset_redeem_with_memo(caller, c.amount, c.memo)?;
-                Bytes::new()
-            }
-
-            // --- Minimum redeemable (asset version, in scaled units) ---
-            SC::minimumRedeemable(_) => self.accounting().minimum_redeemable()?.abi_encode().into(),
-            SC::updateMinimumRedeemable(c) => {
-                self.update_minimum_redeemable(caller, c.newMinimumRedeemable, privileged)?;
-                Bytes::new()
-            }
-
-            // --- Asset metadata mutations ---
+            // --- Asset identifier mutations ---
             SC::updateExtraMetadata(c) => {
                 self.update_extra_metadata(caller, c.identifierType, c.value, privileged)?;
                 Bytes::new()
@@ -454,21 +434,19 @@ impl<S: AssetAccounting, P: Policy> B20AssetToken<S, P> {
 mod tests {
     use alloc::vec::Vec;
 
-    use alloy_primitives::{Address, B256, Bytes, U256};
+    use alloy_primitives::{Address, Bytes, U256};
     use alloy_sol_types::{SolCall, SolEvent};
     use base_precompile_storage::{
-        BasePrecompileError, HashMapStorageProvider, Result, StorageCtx, setup_storage,
+        BasePrecompileError, HashMapStorageProvider, Result, StorageCtx,
     };
 
     use crate::{
         ActivationFeature, ActivationRegistryStorage, AssetAccounting, B20AssetStorage,
-        B20AssetToken, B20PausableFeature, B20TokenRole, IB20, IB20Asset, InMemoryPolicy,
-        InMemoryTokenAccounting, PolicyHandle, PolicyRegistryStorage, Token, TokenAccounting,
+        B20AssetToken, B20TokenRole, IB20, IB20Asset, InMemoryPolicy, InMemoryTokenAccounting,
+        Token, TokenAccounting,
     };
 
     type TestAssetToken = B20AssetToken<InMemoryTokenAccounting, InMemoryPolicy>;
-
-    const REDEEM_SENDER_POLICY: B256 = TestAssetToken::REDEEM_SENDER_POLICY;
 
     const ALICE: Address = Address::repeat_byte(0xaa);
     const BOB: Address = Address::repeat_byte(0xbb);
@@ -476,9 +454,7 @@ mod tests {
     const ACTIVATION_ADMIN: Address = Address::repeat_byte(0xcb);
     fn make_token() -> TestAssetToken {
         let mut accounting = InMemoryTokenAccounting::new(TOKEN);
-        accounting.multiplier = B20AssetStorage::WAD; // 1:1 multiplier
-        // Explicitly open redemption so non-policy tests are not blocked by the ALWAYS_BLOCK default.
-        accounting.policy_ids.insert(REDEEM_SENDER_POLICY, PolicyRegistryStorage::ALWAYS_ALLOW_ID);
+        accounting.multiplier = B20AssetStorage::WAD; // 1:1 ratio
         TestAssetToken::with_storage_and_policy(accounting, InMemoryPolicy::new())
     }
 
@@ -508,13 +484,13 @@ mod tests {
     }
 
     #[test]
-    fn to_scaled_balance_one_to_one_multiplier() {
+    fn to_scaled_balance_one_to_one_ratio() {
         let token = make_token();
         assert_eq!(token.to_scaled_balance(U256::from(100u64)).unwrap(), U256::from(100u64));
     }
 
     #[test]
-    fn to_scaled_balance_two_to_one_multiplier() {
+    fn to_scaled_balance_two_to_one_ratio() {
         let mut accounting = InMemoryTokenAccounting::new(TOKEN);
         accounting.multiplier = B20AssetStorage::WAD * U256::from(2u64);
         let token = TestAssetToken::with_storage_and_policy(accounting, InMemoryPolicy::new());
@@ -570,92 +546,6 @@ mod tests {
         );
         assert_eq!(token.accounting().balance_of(BOB).unwrap(), U256::ZERO);
         assert_eq!(token.accounting().total_supply().unwrap(), U256::ZERO);
-    }
-
-    #[test]
-    fn asset_redeem_burns_and_emits_asset_event() {
-        let mut token = make_token();
-        token.accounting_mut().balances.insert(ALICE, U256::from(100u64));
-        token.accounting_mut().total_supply = U256::from(100u64);
-        token.accounting_mut().minimum_redeemable = U256::from(1u64);
-
-        token.asset_redeem(ALICE, U256::from(50u64)).unwrap();
-
-        assert_eq!(token.accounting().balance_of(ALICE).unwrap(), U256::from(50u64));
-        assert_eq!(token.accounting().total_supply().unwrap(), U256::from(50u64));
-        assert_eq!(token.accounting().events.len(), 2); // Transfer + Redeemed
-    }
-
-    #[test]
-    fn asset_redeem_zero_amount_is_no_op() {
-        let mut token = make_token();
-        token.accounting_mut().balances.insert(ALICE, U256::from(100u64));
-        token.accounting_mut().total_supply = U256::from(100u64);
-        token.accounting_mut().minimum_redeemable = U256::from(1u64);
-
-        token.asset_redeem(ALICE, U256::ZERO).unwrap();
-
-        assert_eq!(token.accounting().balance_of(ALICE).unwrap(), U256::from(100u64));
-        assert_eq!(token.accounting().total_supply().unwrap(), U256::from(100u64));
-        assert_eq!(token.accounting().events.len(), 2); // Transfer(ALICE, 0x0, 0) + Redeemed(ALICE, 0, multiplier)
-    }
-
-    #[test]
-    fn asset_redeem_rejects_below_minimum_scaled_amount() {
-        let mut token = make_token();
-        token.accounting_mut().balances.insert(ALICE, U256::from(100u64));
-        token.accounting_mut().total_supply = U256::from(100u64);
-        token.accounting_mut().minimum_redeemable = U256::from(10u64);
-
-        // 5 tokens * 1e18 multiplier / 1e18 = 5 scaled < 10 minimum
-        assert!(token.asset_redeem(ALICE, U256::from(5u64)).is_err());
-    }
-
-    #[test]
-    fn asset_redeem_rejects_zero_scaled_amount() {
-        let mut token = make_token();
-        token.accounting_mut().multiplier = U256::ONE;
-        token.accounting_mut().balances.insert(ALICE, U256::from(100u64));
-        token.accounting_mut().total_supply = U256::from(100u64);
-
-        // 1 token-wei * 1 / WAD rounds down to 0 scaled units, which is always rejected.
-        assert!(token.asset_redeem(ALICE, U256::ONE).is_err());
-    }
-
-    #[test]
-    fn asset_redeem_rejects_when_redeem_feature_paused() {
-        let mut token = make_token();
-        token.accounting_mut().paused = B20PausableFeature::mask(IB20::PausableFeature::REDEEM);
-        token.accounting_mut().balances.insert(ALICE, U256::from(100u64));
-        token.accounting_mut().total_supply = U256::from(100u64);
-
-        assert_eq!(
-            token.asset_redeem(ALICE, U256::from(1u64)).unwrap_err(),
-            BasePrecompileError::revert(IB20::ContractPaused {
-                feature: IB20::PausableFeature::REDEEM,
-            })
-        );
-    }
-
-    #[test]
-    fn asset_redeem_rejects_when_sender_policy_denies() {
-        let policy_id = 7;
-        let mut accounting = InMemoryTokenAccounting::new(TOKEN);
-        accounting.multiplier = B20AssetStorage::WAD;
-        accounting.balances.insert(ALICE, U256::from(100u64));
-        accounting.total_supply = U256::from(100u64);
-        accounting.policy_ids.insert(REDEEM_SENDER_POLICY, policy_id);
-        let mut policy = InMemoryPolicy::new();
-        policy.create_existing_policy(policy_id);
-        let mut token = TestAssetToken::with_storage_and_policy(accounting, policy);
-
-        assert_eq!(
-            token.asset_redeem(ALICE, U256::from(1u64)).unwrap_err(),
-            BasePrecompileError::revert(IB20::PolicyForbids {
-                policyScope: REDEEM_SENDER_POLICY,
-                policyId: policy_id,
-            })
-        );
     }
 
     #[test]
@@ -726,104 +616,7 @@ mod tests {
         );
     }
 
-    // --- redeem: InsufficientBalance / boundary / scaled math / event pair ---
-
-    #[test]
-    fn asset_redeem_rejects_insufficient_balance() {
-        let mut token = make_token();
-        token.accounting_mut().balances.insert(ALICE, U256::from(10u64));
-        token.accounting_mut().total_supply = U256::from(10u64);
-        token.accounting_mut().minimum_redeemable = U256::from(1u64);
-        // amount=100 > balance=10 → InsufficientBalance after the scaled-floor check passes
-        assert!(token.asset_redeem(ALICE, U256::from(100u64)).is_err());
-        // no state mutation on failure
-        assert_eq!(token.accounting().balance_of(ALICE).unwrap(), U256::from(10u64));
-    }
-
-    #[test]
-    fn asset_redeem_supply_underflow_is_under_overflow_panic() {
-        // Regression: before BOP-160, saturating_sub silently clamped supply to zero.
-        // If an accounting bug left total_supply < balance, the correct behavior is to
-        // revert with an arithmetic under/overflow panic rather than zeroing the supply.
-        let mut token = make_token();
-        // Supply invariant violated: balance exceeds total supply.
-        token.accounting_mut().balances.insert(ALICE, U256::from(100u64));
-        token.accounting_mut().total_supply = U256::from(50u64);
-
-        // amount=75 passes the balance check (100 >= 75) but underflows total_supply (50 - 75).
-        assert_eq!(
-            token.asset_redeem(ALICE, U256::from(75u64)).unwrap_err(),
-            BasePrecompileError::under_overflow()
-        );
-    }
-
-    #[test]
-    fn asset_redeem_at_exact_minimum_succeeds() {
-        let mut token = make_token(); // 1:1 multiplier
-        token.accounting_mut().balances.insert(ALICE, U256::from(50u64));
-        token.accounting_mut().total_supply = U256::from(50u64);
-        // 5 tokens * WAD / WAD = 5 scaled == minimum → boundary must be accepted
-        token.accounting_mut().minimum_redeemable = U256::from(5u64);
-        token.asset_redeem(ALICE, U256::from(5u64)).unwrap();
-        assert_eq!(token.accounting().balance_of(ALICE).unwrap(), U256::from(45u64));
-        assert_eq!(token.accounting().total_supply().unwrap(), U256::from(45u64));
-    }
-
-    #[test]
-    fn asset_redeem_with_non_unit_multiplier_applies_correct_scaled_math() {
-        let mut token = make_token();
-        // 2x multiplier: 1 token scales to 2 units
-        token.accounting_mut().multiplier = B20AssetStorage::WAD * U256::from(2u64);
-        token.accounting_mut().balances.insert(ALICE, U256::from(100u64));
-        token.accounting_mut().total_supply = U256::from(100u64);
-        // minimum = 10 scaled → need at least 5 tokens
-        token.accounting_mut().minimum_redeemable = U256::from(10u64);
-        // 4 tokens → 8 scaled < 10 → BelowMinimumRedeemable
-        assert!(token.asset_redeem(ALICE, U256::from(4u64)).is_err());
-        // 5 tokens → 10 scaled == minimum → accepted
-        token.asset_redeem(ALICE, U256::from(5u64)).unwrap();
-        assert_eq!(token.accounting().balance_of(ALICE).unwrap(), U256::from(95u64));
-    }
-
-    #[test]
-    fn asset_redeem_emits_transfer_then_redeemed() {
-        let mut token = make_token();
-        token.accounting_mut().balances.insert(ALICE, U256::from(100u64));
-        token.accounting_mut().total_supply = U256::from(100u64);
-        token.accounting_mut().minimum_redeemable = U256::from(1u64);
-        token.asset_redeem(ALICE, U256::from(10u64)).unwrap();
-        // "Emits Transfer(caller, address(0), amount) followed by Redeemed(caller, amount, multiplier)"
-        assert_eq!(token.accounting().events.len(), 2);
-    }
-
-    #[test]
-    fn asset_redeem_with_memo_emits_memo_before_redeemed() {
-        let mut token = make_token();
-        let amount = U256::from(10u64);
-        let memo = B256::repeat_byte(0x42);
-        token.accounting_mut().balances.insert(ALICE, U256::from(100u64));
-        token.accounting_mut().total_supply = U256::from(100u64);
-        token.accounting_mut().minimum_redeemable = U256::from(1u64);
-
-        token.asset_redeem_with_memo(ALICE, amount, memo).unwrap();
-
-        assert_eq!(
-            token.accounting().events[0],
-            IB20::Transfer { from: ALICE, to: Address::ZERO, amount }.encode_log_data()
-        );
-        assert_eq!(
-            token.accounting().events[1],
-            IB20::Memo { caller: ALICE, memo }.encode_log_data()
-        );
-        assert_eq!(
-            token.accounting().events[2],
-            IB20Asset::Redeemed { from: ALICE, amt: amount, multiplier: B20AssetStorage::WAD }
-                .encode_log_data()
-        );
-    }
-
     // --- toScaledBalance: zero balance / sub-WAD truncation / scaledBalanceOf delegation ---
-
     #[test]
     fn to_scaled_balance_zero_balance_yields_zero() {
         let token = make_token();
@@ -831,42 +624,21 @@ mod tests {
     }
 
     #[test]
-    fn to_scaled_balance_sub_wad_multiplier_truncates_to_zero() {
+    fn to_scaled_balance_sub_wad_ratio_truncates_to_zero() {
         let mut accounting = InMemoryTokenAccounting::new(TOKEN);
-        // 0.5 WAD: 1 token → 0.5 scaled → truncates to 0 via integer division
+        // 0.5 WAD: 1 token → 0.5 shares → truncates to 0 via integer division
         accounting.multiplier = B20AssetStorage::WAD / U256::from(2u64);
         let token = TestAssetToken::with_storage_and_policy(accounting, InMemoryPolicy::new());
         assert_eq!(token.to_scaled_balance(U256::from(1u64)).unwrap(), U256::ZERO);
     }
 
     #[test]
-    fn scaled_balance_of_derives_from_balance() {
-        let mut token = make_token(); // 1:1 multiplier
+    fn shares_of_derives_from_balance() {
+        let mut token = make_token(); // 1:1 ratio
         token.accounting_mut().balances.insert(ALICE, U256::from(75u64));
         // scaledBalanceOf(account) = toScaledBalance(balanceOf(account))
         let balance = token.accounting().balance_of(ALICE).unwrap();
         assert_eq!(token.to_scaled_balance(balance).unwrap(), U256::from(75u64));
-    }
-
-    #[test]
-    fn storage_backed_redeem_uses_wad_when_multiplier_slot_is_unset() {
-        let (mut storage, _) = setup_storage();
-
-        StorageCtx::enter(&mut storage, |ctx| {
-            let mut token = B20AssetToken::with_storage_and_policy(
-                B20AssetStorage::from_address(TOKEN, ctx),
-                PolicyHandle::new(ctx),
-            );
-            token.accounting_mut().set_balance(ALICE, U256::from(100u64)).unwrap();
-            token.accounting_mut().set_total_supply(U256::from(100u64)).unwrap();
-            token.accounting_mut().set_minimum_redeemable(U256::from(10u64)).unwrap();
-
-            assert_eq!(token.accounting().multiplier().unwrap(), B20AssetStorage::WAD);
-            token.asset_redeem(ALICE, U256::from(10u64)).unwrap();
-
-            assert_eq!(token.accounting().balance_of(ALICE).unwrap(), U256::from(90u64));
-            assert_eq!(token.accounting().total_supply().unwrap(), U256::from(90u64));
-        });
     }
 
     // --- updateMultiplier: persistence ---
@@ -874,9 +646,9 @@ mod tests {
     #[test]
     fn multiplier_update_persists() {
         let mut token = make_token();
-        let new_multiplier = B20AssetStorage::WAD * U256::from(3u64);
-        token.accounting_mut().set_multiplier(new_multiplier).unwrap();
-        assert_eq!(token.accounting().multiplier().unwrap(), new_multiplier);
+        let new_ratio = B20AssetStorage::WAD * U256::from(3u64);
+        token.accounting_mut().set_multiplier(new_ratio).unwrap();
+        assert_eq!(token.accounting().multiplier().unwrap(), new_ratio);
     }
 
     // --- extraMetadata / updateExtraMetadata ---
@@ -901,16 +673,6 @@ mod tests {
         assert_eq!(token.accounting().extra_metadata("FIGI").unwrap(), "");
     }
 
-    // --- minimumRedeemable / updateMinimumRedeemable ---
-
-    #[test]
-    fn minimum_redeemable_persists() {
-        let mut token = make_token();
-        let floor = U256::from(42u64);
-        token.accounting_mut().set_minimum_redeemable(floor).unwrap();
-        assert_eq!(token.accounting().minimum_redeemable().unwrap(), floor);
-    }
-
     // --- isAnnouncementIdUsed: fresh state ---
 
     #[test]
@@ -922,35 +684,16 @@ mod tests {
     }
 
     /// `to_scaled_balance` must return an arithmetic overflow panic rather than silently
-    /// saturating when `rawBalance * multiplier` exceeds `U256::MAX`.
+    /// saturating when `balance * multiplier` exceeds `U256::MAX`.
     #[test]
     fn to_scaled_balance_overflows_when_product_exceeds_u256_max() {
         let mut accounting = InMemoryTokenAccounting::new(TOKEN);
-        // Any balance > 1 overflows when multiplied by this multiplier.
+        // Any balance > 1 overflows when multiplied by this ratio.
         accounting.multiplier = U256::MAX / U256::from(2u64) + U256::ONE;
         let token = TestAssetToken::with_storage_and_policy(accounting, InMemoryPolicy::new());
 
         assert_eq!(
             token.to_scaled_balance(U256::from(2u64)).unwrap_err(),
-            BasePrecompileError::under_overflow()
-        );
-    }
-
-    /// `asset_redeem` must return an arithmetic overflow panic rather than
-    /// silently saturating when `amount * multiplier` exceeds `U256::MAX`.
-    #[test]
-    fn asset_redeem_overflows_when_product_exceeds_u256_max() {
-        let mut accounting = InMemoryTokenAccounting::new(TOKEN);
-        // Any amount > 1 overflows when multiplied by this multiplier.
-        accounting.multiplier = U256::MAX / U256::from(2u64) + U256::ONE;
-        accounting.balances.insert(ALICE, U256::from(2u64));
-        accounting.total_supply = U256::from(2u64);
-        // Open redemption so the policy gate does not block the call before the overflow.
-        accounting.policy_ids.insert(REDEEM_SENDER_POLICY, PolicyRegistryStorage::ALWAYS_ALLOW_ID);
-        let mut token = TestAssetToken::with_storage_and_policy(accounting, InMemoryPolicy::new());
-
-        assert_eq!(
-            token.asset_redeem(ALICE, U256::from(2u64)).unwrap_err(),
             BasePrecompileError::under_overflow()
         );
     }

--- a/crates/common/precompiles/src/b20_asset/mod.rs
+++ b/crates/common/precompiles/src/b20_asset/mod.rs
@@ -12,7 +12,7 @@ mod precompile;
 pub use precompile::B20AssetPrecompile;
 
 mod storage;
-pub use storage::{B20AssetExtensionStorage, B20AssetInit, B20AssetStorage, B20RedeemStorage};
+pub use storage::{B20AssetExtensionStorage, B20AssetInit, B20AssetStorage};
 
 mod token;
 pub use token::B20AssetToken;

--- a/crates/common/precompiles/src/b20_asset/storage.rs
+++ b/crates/common/precompiles/src/b20_asset/storage.rs
@@ -2,11 +2,11 @@
 
 use alloc::string::String;
 
-use alloy_primitives::{Address, B256, FixedBytes, U256, b256};
+use alloy_primitives::{Address, U256};
 use base_precompile_macros::{AssetAccounting, Storable, TokenAccounting, contract};
-use base_precompile_storage::{BasePrecompileError, Handler, Mapping, Result, StorageCtx};
+use base_precompile_storage::{Handler, Mapping, Result, StorageCtx};
 
-use crate::{B20CoreStorage, IB20Asset, PolicyRegistryStorage};
+use crate::B20CoreStorage;
 
 /// Asset-specific B-20 storage rooted at the `base.b20.asset` ERC-7201 namespace.
 #[derive(Debug, Clone, Storable)]
@@ -21,24 +21,8 @@ pub struct B20AssetExtensionStorage {
     pub multiplier: U256, // slot 1
     /// Announcement IDs that have already been consumed.
     pub used_announcement_ids: Mapping<String, bool>, // slot 2
-    /// Security identifier values by identifier type.
+    /// Extra metadata values by metadata key.
     pub identifiers: Mapping<String, String>, // slot 3
-}
-
-/// Redemption-specific B-20 storage rooted at the `base.b20.redeem` ERC-7201 namespace.
-#[derive(Debug, Clone, Storable)]
-#[namespace("base.b20.redeem")]
-pub struct B20RedeemStorage {
-    /// Minimum scaled amount required for a redeem operation.
-    #[accessor]
-    #[mutator]
-    pub minimum_redeemable: U256, // offset 0
-    /// Redeem sender policy ID.
-    #[accessor]
-    #[mutator]
-    pub redeem_sender_policy_id: u64, // slot 1, offset 0
-    /// Reserved padding to fill the remainder of slot 1.
-    pub redeem_reserved: FixedBytes<24>, // slot 1, offset 8 (fills remaining 24 bytes)
 }
 
 /// EVM-backed storage for an asset B-20 token.
@@ -47,7 +31,6 @@ pub struct B20RedeemStorage {
 pub struct B20AssetStorage {
     pub b20: B20CoreStorage,
     pub asset: B20AssetExtensionStorage,
-    pub redeem: B20RedeemStorage,
 }
 
 /// Creation-time parameters for an asset B-20 token.
@@ -61,48 +44,25 @@ pub struct B20AssetInit {
     pub symbol: String,
     /// Maximum total supply.
     pub supply_cap: U256,
-    /// Initial multiplier at WAD precision.
+    /// Share-to-token conversion ratio at WAD precision.
     pub multiplier: U256,
-    /// ISIN identifier stored under the `"ISIN"` key.
-    pub isin: String,
-    /// Minimum redeemable amount; `0` allows any non-zero redemption.
-    pub minimum_redeemable: U256,
     /// Custom decimal precision for this token; must be in `[6, 18]`.
     pub decimals: u8,
 }
 
 impl<'a> B20AssetStorage<'a> {
-    /// Policy scope identifier for the sender of a redeem operation:
-    /// `keccak256("REDEEM_SENDER_POLICY")`.
-    pub const REDEEM_SENDER_POLICY: B256 =
-        b256!("0ff53b08b65363a609bb561211128f4044adc0e351f0b92b6aa23f8d85462f59");
-
     /// Creates a `B20AssetStorage` instance targeting `addr`.
     pub fn from_address(addr: Address, storage: StorageCtx<'a>) -> Self {
         Self::__new(addr, storage)
     }
 
     /// Writes all creation-time fields atomically.
-    ///
-    /// `isin` may be empty; when non-empty it is stored under the `"ISIN"` key
-    /// in the security identifiers mapping.
-    ///
-    /// `REDEEM_SENDER_POLICY` is initialised to `ALWAYS_BLOCK_ID` so redemption
-    /// is closed by default; issuers must explicitly open it after creation.
     pub fn initialize(&mut self, init: B20AssetInit) -> Result<()> {
-        if init.decimals < Self::MIN_DECIMALS || init.decimals > Self::MAX_DECIMALS {
-            return Err(BasePrecompileError::revert(IB20Asset::InvalidDecimals {}));
-        }
         self.b20.name.write(init.name)?;
         self.b20.symbol.write(init.symbol)?;
         self.b20.supply_cap.write(init.supply_cap)?;
-        self.asset.multiplier.write(init.multiplier)?;
         self.asset.decimals.write(init.decimals)?;
-        self.redeem.minimum_redeemable.write(init.minimum_redeemable)?;
-        if !init.isin.is_empty() {
-            self.asset.identifiers.at_mut(&String::from("ISIN")).write(init.isin)?;
-        }
-        self.write_redeem_policy_ids_default()?;
+        self.asset.multiplier.write(init.multiplier)?;
         Ok(())
     }
 }
@@ -115,10 +75,10 @@ impl B20AssetStorage<'_> {
     /// WAD precision for multiplier arithmetic: 1e18.
     pub const WAD: U256 = U256::from_limbs([1_000_000_000_000_000_000, 0, 0, 0]);
 
-    /// Writes the default `redeem_sender_policy_id` to `ALWAYS_BLOCK_ID`.
-    /// Called once from [`initialize`].
-    fn write_redeem_policy_ids_default(&mut self) -> Result<()> {
-        self.redeem.set_redeem_sender_policy_id(PolicyRegistryStorage::ALWAYS_BLOCK_ID)
+    /// Returns the configured asset decimals, defaulting an unset storage slot to `6`.
+    pub fn decimals(&self) -> Result<u8> {
+        let decimals = self.asset.decimals()?;
+        Ok(if decimals == 0 { Self::MIN_DECIMALS } else { decimals })
     }
 }
 
@@ -128,18 +88,16 @@ mod tests {
     use base_precompile_storage::{Handler, StorableType, StorageCtx, StorageKey, setup_storage};
 
     use super::{
-        __packing_b20_asset_extension_storage, __packing_b20_redeem_storage,
-        B20AssetExtensionStorage, B20AssetInit, B20AssetStorage, B20RedeemStorage, slots,
+        __packing_b20_asset_extension_storage, B20AssetExtensionStorage, B20AssetInit,
+        B20AssetStorage, slots,
     };
-    use crate::{AssetAccounting, B20CoreStorage, PolicyRegistryStorage, TokenAccounting};
+    use crate::{AssetAccounting, B20CoreStorage};
 
     const TOKEN: Address = address!("000000000000000000000000000000000000b021");
     const B20_ROOT: U256 =
         uint!(0xc78b71fee795ddd74aff64ea9b2474194c938c3196430e10bb5f01ed48434000_U256);
     const ASSET_ROOT: U256 =
         uint!(0xfdc6d4552d1286ade4d9facdbf0fb50d2ec9b89a90e104f26fd277585e374b00_U256);
-    const REDEEM_ROOT: U256 =
-        uint!(0xc95c24ab0255f9fb9fcdcd524f71c4fe0437265856b7e5e6d0801df0e6cf5100_U256);
 
     #[test]
     fn wad_constant_is_ten_to_the_eighteenth() {
@@ -147,19 +105,16 @@ mod tests {
     }
 
     #[test]
-    fn security_namespaces_match_base_std_roots() {
+    fn asset_namespaces_match_base_std_roots() {
         assert_eq!(<B20CoreStorage as StorableType>::STORAGE_NAMESPACE_ROOT, B20_ROOT);
         assert_eq!(
             <B20AssetExtensionStorage as StorableType>::STORAGE_NAMESPACE_ID,
             "base.b20.asset"
         );
         assert_eq!(<B20AssetExtensionStorage as StorableType>::STORAGE_NAMESPACE_ROOT, ASSET_ROOT);
-        assert_eq!(<B20RedeemStorage as StorableType>::STORAGE_NAMESPACE_ID, "base.b20.redeem");
-        assert_eq!(<B20RedeemStorage as StorableType>::STORAGE_NAMESPACE_ROOT, REDEEM_ROOT);
 
         assert_eq!(slots::B20, B20_ROOT);
         assert_eq!(slots::ASSET, ASSET_ROOT);
-        assert_eq!(slots::REDEEM, REDEEM_ROOT);
     }
 
     #[test]
@@ -172,9 +127,6 @@ mod tests {
             2
         );
         assert_eq!(__packing_b20_asset_extension_storage::IDENTIFIERS_LOC.offset_slots, 3);
-        assert_eq!(__packing_b20_redeem_storage::MINIMUM_REDEEMABLE_LOC.offset_slots, 0);
-        assert_eq!(__packing_b20_redeem_storage::REDEEM_SENDER_POLICY_ID_LOC.offset_slots, 1);
-        assert_eq!(__packing_b20_redeem_storage::REDEEM_SENDER_POLICY_ID_LOC.offset_bytes, 0);
     }
 
     #[test]
@@ -183,10 +135,10 @@ mod tests {
 
         StorageCtx::enter(&mut storage, |ctx| {
             let token = B20AssetStorage::from_address(TOKEN, ctx);
-            let multiplier_slot = ASSET_ROOT
+            let ratio_slot = ASSET_ROOT
                 + U256::from(__packing_b20_asset_extension_storage::MULTIPLIER_LOC.offset_slots);
 
-            assert_eq!(ctx.sload(TOKEN, multiplier_slot).unwrap(), U256::ZERO);
+            assert_eq!(ctx.sload(TOKEN, ratio_slot).unwrap(), U256::ZERO);
             assert_eq!(token.multiplier().unwrap(), B20AssetStorage::WAD);
         });
     }
@@ -194,104 +146,46 @@ mod tests {
     #[test]
     fn multiplier_preserves_configured_value() {
         let (mut storage, _) = setup_storage();
-        let configured_multiplier = B20AssetStorage::WAD * U256::from(3u64);
+        let configured_ratio = B20AssetStorage::WAD * U256::from(3u64);
 
         StorageCtx::enter(&mut storage, |ctx| {
             let mut token = B20AssetStorage::from_address(TOKEN, ctx);
-            token.set_multiplier(configured_multiplier).unwrap();
+            token.set_multiplier(configured_ratio).unwrap();
 
-            let multiplier_slot = ASSET_ROOT
+            let ratio_slot = ASSET_ROOT
                 + U256::from(__packing_b20_asset_extension_storage::MULTIPLIER_LOC.offset_slots);
 
-            assert_eq!(ctx.sload(TOKEN, multiplier_slot).unwrap(), configured_multiplier);
-            assert_eq!(token.multiplier().unwrap(), configured_multiplier);
+            assert_eq!(ctx.sload(TOKEN, ratio_slot).unwrap(), configured_ratio);
+            assert_eq!(token.multiplier().unwrap(), configured_ratio);
         });
     }
 
     #[test]
-    fn security_string_mapping_slots_use_solidity_string_key_derivation() {
+    fn string_mapping_slots_use_solidity_string_key_derivation() {
         let (mut storage, _) = setup_storage();
         let announcement_id = String::from("2026-Q1-split");
-        let identifier_type = String::from("ISIN");
-        let identifier_value = String::from("US0000000000");
+        let metadata_key = String::from("category");
+        let metadata_value = String::from("fund");
 
         StorageCtx::enter(&mut storage, |ctx| {
             let mut token = B20AssetStorage::from_address(TOKEN, ctx);
             token.asset.used_announcement_ids.at_mut(&announcement_id).write(true).unwrap();
-            token
-                .asset
-                .identifiers
-                .at_mut(&identifier_type)
-                .write(identifier_value.clone())
-                .unwrap();
-            token.redeem.minimum_redeemable.write(U256::from(10u64)).unwrap();
+            token.asset.identifiers.at_mut(&metadata_key).write(metadata_value.clone()).unwrap();
 
             let announcement_slot = ASSET_ROOT
                 + U256::from(
                     __packing_b20_asset_extension_storage::USED_ANNOUNCEMENT_IDS_LOC.offset_slots,
                 );
-            let identifiers_slot = ASSET_ROOT
+            let metadata_slot = ASSET_ROOT
                 + U256::from(__packing_b20_asset_extension_storage::IDENTIFIERS_LOC.offset_slots);
-            let minimum_slot = REDEEM_ROOT
-                + U256::from(__packing_b20_redeem_storage::MINIMUM_REDEEMABLE_LOC.offset_slots);
 
             assert_eq!(
                 ctx.sload(TOKEN, announcement_id.mapping_slot(announcement_slot)).unwrap(),
                 U256::ONE
             );
             assert_eq!(
-                ctx.sload(TOKEN, identifier_type.mapping_slot(identifiers_slot)).unwrap(),
-                short_string_word(&identifier_value)
-            );
-            assert_eq!(ctx.sload(TOKEN, minimum_slot).unwrap(), U256::from(10u64));
-        });
-    }
-
-    #[test]
-    fn redeem_sender_policy_uses_redeem_storage_lane() {
-        let (mut storage, _) = setup_storage();
-        let policy_id = 42u64;
-
-        StorageCtx::enter(&mut storage, |ctx| {
-            {
-                let mut token = B20AssetStorage::from_address(TOKEN, ctx);
-                token.set_policy_id(B20AssetStorage::REDEEM_SENDER_POLICY, policy_id).unwrap();
-                assert_eq!(
-                    token.policy_id(B20AssetStorage::REDEEM_SENDER_POLICY).unwrap(),
-                    policy_id
-                );
-            }
-
-            let redeem_policy_slot = REDEEM_ROOT
-                + U256::from(
-                    __packing_b20_redeem_storage::REDEEM_SENDER_POLICY_ID_LOC.offset_slots,
-                );
-            assert_eq!(ctx.sload(TOKEN, redeem_policy_slot).unwrap(), U256::from(policy_id));
-        });
-    }
-
-    #[test]
-    fn initialize_sets_redeem_sender_policy_to_always_block() {
-        let (mut storage, _) = setup_storage();
-
-        StorageCtx::enter(&mut storage, |ctx| {
-            let mut token = B20AssetStorage::from_address(TOKEN, ctx);
-            token
-                .initialize(B20AssetInit {
-                    name: String::from("Test"),
-                    symbol: String::from("TST"),
-                    supply_cap: U256::from(1_000_000u64),
-                    multiplier: B20AssetStorage::WAD,
-                    isin: String::new(),
-                    minimum_redeemable: U256::ZERO,
-                    decimals: 6,
-                })
-                .unwrap();
-
-            assert_eq!(
-                token.policy_id(B20AssetStorage::REDEEM_SENDER_POLICY).unwrap(),
-                PolicyRegistryStorage::ALWAYS_BLOCK_ID,
-                "REDEEM_SENDER_POLICY must default to ALWAYS_BLOCK_ID at creation"
+                ctx.sload(TOKEN, metadata_key.mapping_slot(metadata_slot)).unwrap(),
+                short_string_word(&metadata_value)
             );
         });
     }
@@ -309,63 +203,31 @@ mod tests {
             symbol: String::from("TST"),
             supply_cap: U256::from(1_000_000u64),
             multiplier: B20AssetStorage::WAD,
-            isin: String::new(),
-            minimum_redeemable: U256::ZERO,
             decimals,
         }
     }
 
     #[test]
-    fn decimals_6_stores_and_reads_back() {
+    fn decimals_stores_and_reads_back_lower_bound() {
         let (mut storage, _) = setup_storage();
 
         StorageCtx::enter(&mut storage, |ctx| {
             let mut token = B20AssetStorage::from_address(TOKEN, ctx);
-            token.initialize(make_init(6)).unwrap();
-            assert_eq!(token.asset.decimals.read().unwrap(), 6);
+            token.initialize(make_init(B20AssetStorage::MIN_DECIMALS)).unwrap();
+            assert_eq!(token.asset.decimals.read().unwrap(), B20AssetStorage::MIN_DECIMALS);
+            assert_eq!(AssetAccounting::decimals(&token).unwrap(), B20AssetStorage::MIN_DECIMALS);
         });
     }
 
     #[test]
-    fn decimals_18_stores_and_reads_back() {
+    fn decimals_stores_and_reads_back_upper_bound() {
         let (mut storage, _) = setup_storage();
 
         StorageCtx::enter(&mut storage, |ctx| {
             let mut token = B20AssetStorage::from_address(TOKEN, ctx);
-            token.initialize(make_init(18)).unwrap();
-            assert_eq!(token.asset.decimals.read().unwrap(), 18);
-        });
-    }
-
-    #[test]
-    fn decimals_5_reverts_with_invalid_decimals() {
-        let (mut storage, _) = setup_storage();
-
-        StorageCtx::enter(&mut storage, |ctx| {
-            let mut token = B20AssetStorage::from_address(TOKEN, ctx);
-            let err = token.initialize(make_init(5)).unwrap_err();
-            assert_eq!(
-                err,
-                base_precompile_storage::BasePrecompileError::revert(
-                    crate::IB20Asset::InvalidDecimals {}
-                )
-            );
-        });
-    }
-
-    #[test]
-    fn decimals_19_reverts_with_invalid_decimals() {
-        let (mut storage, _) = setup_storage();
-
-        StorageCtx::enter(&mut storage, |ctx| {
-            let mut token = B20AssetStorage::from_address(TOKEN, ctx);
-            let err = token.initialize(make_init(19)).unwrap_err();
-            assert_eq!(
-                err,
-                base_precompile_storage::BasePrecompileError::revert(
-                    crate::IB20Asset::InvalidDecimals {}
-                )
-            );
+            token.initialize(make_init(B20AssetStorage::MAX_DECIMALS)).unwrap();
+            assert_eq!(token.asset.decimals.read().unwrap(), B20AssetStorage::MAX_DECIMALS);
+            assert_eq!(AssetAccounting::decimals(&token).unwrap(), B20AssetStorage::MAX_DECIMALS);
         });
     }
 
@@ -374,14 +236,9 @@ mod tests {
         let (mut storage, _) = setup_storage();
 
         StorageCtx::enter(&mut storage, |ctx| {
-            // Token address exists but initialize() was never called — storage slot is 0.
             let token = B20AssetStorage::from_address(TOKEN, ctx);
-            assert_eq!(token.asset.decimals.read().unwrap(), 0, "raw slot should be 0");
-            assert_eq!(
-                crate::AssetAccounting::decimals(&token).unwrap(),
-                6,
-                "fallback must return 6 for uninitialized tokens"
-            );
+            assert_eq!(token.asset.decimals.read().unwrap(), 0);
+            assert_eq!(AssetAccounting::decimals(&token).unwrap(), B20AssetStorage::MIN_DECIMALS);
         });
     }
 }

--- a/crates/common/precompiles/src/b20_asset/token.rs
+++ b/crates/common/precompiles/src/b20_asset/token.rs
@@ -16,8 +16,8 @@ use crate::{
 /// EVM precompile for the asset B-20 variant.
 ///
 /// Mirrors the structure of [`crate::B20Token`] but requires `S: AssetAccounting`
-/// so the dispatch layer can read and write asset-specific storage (multiplier,
-/// asset metadata, announcement IDs). The `in_announcement` flag guards against
+/// so the dispatch layer can read and write asset-specific storage (share ratio,
+/// asset identifiers, announcement IDs). The `in_announcement` flag guards against
 /// recursive `announce` calls within a single precompile invocation.
 #[derive(Debug, Clone)]
 pub struct B20AssetToken<S: AssetAccounting, P: Policy> {
@@ -34,9 +34,6 @@ impl<S: AssetAccounting, P: Policy> B20AssetToken<S, P> {
     /// Role identifier for metadata updaters: `keccak256("METADATA_ROLE")`.
     pub const METADATA_ROLE: B256 =
         b256!("6bd6b5318a46e5fff572d5e4258a20774aab40cc35ac7680654b9081fcc82f80");
-
-    /// Policy scope identifier for redeem senders: `keccak256("REDEEM_SENDER_POLICY")`.
-    pub const REDEEM_SENDER_POLICY: B256 = B20AssetStorage::REDEEM_SENDER_POLICY;
 
     /// Creates a `B20AssetToken` backed by the provided storage and policy adapters.
     pub const fn with_storage_and_policy(accounting: S, policy: P) -> Self {
@@ -92,10 +89,9 @@ impl<S: AssetAccounting, P: Policy> RoleManaged for B20AssetToken<S, P> {}
 impl<S: AssetAccounting, P: Policy> B20AssetToken<S, P> {
     // --- Policy Scope Validation ---
 
-    /// Ensures `policy_scope` names either an inherited B-20 policy slot or the
-    /// asset redeem slot.
+    /// Ensures `policy_scope` names an inherited B-20 policy slot.
     pub fn is_supported_policy_scope(policy_scope: B256) -> bool {
-        policy_scope == Self::REDEEM_SENDER_POLICY || B20PolicyType::from_id(policy_scope).is_some()
+        B20PolicyType::from_id(policy_scope).is_some()
     }
 
     /// Validates that the policy scope is supported.
@@ -185,55 +181,46 @@ impl<S: AssetAccounting, P: Policy> B20AssetToken<S, P> {
         )
     }
 
-    // --- Multiplier Operations ---
+    // --- Share Ratio Operations ---
 
-    /// Converts a raw balance to its scaled view: `rawBalance * multiplier / WAD`.
-    pub fn to_scaled_balance(&self, raw_balance: U256) -> Result<U256> {
-        let m = self.accounting().multiplier()?;
-        let product = raw_balance.checked_mul(m).ok_or_else(BasePrecompileError::under_overflow)?;
+    /// Converts a token balance to shares: `balance * multiplier / WAD`.
+    pub fn to_scaled_balance(&self, balance: U256) -> Result<U256> {
+        let ratio = self.accounting().multiplier()?;
+        let product = balance.checked_mul(ratio).ok_or_else(BasePrecompileError::under_overflow)?;
         Ok(product / B20AssetStorage::WAD)
     }
 
-    /// Returns the scaled balance for an account.
+    /// Converts a scaled balance back to its raw representation: `scaled * WAD / multiplier`.
+    pub fn to_raw_balance(&self, balance: U256) -> Result<U256> {
+        let ratio = self.accounting().multiplier()?;
+        let product = balance
+            .checked_mul(B20AssetStorage::WAD)
+            .ok_or_else(BasePrecompileError::under_overflow)?;
+        Ok(product / ratio)
+    }
+
+    /// Returns the shares for an account (balance converted to shares).
     pub fn scaled_balance_of(&self, account: Address) -> Result<U256> {
         let balance = self.accounting().balance_of(account)?;
         self.to_scaled_balance(balance)
     }
 
-    /// Sets a new multiplier.
+    /// Updates the share-to-tokens ratio.
     pub fn update_multiplier(
         &mut self,
         caller: Address,
-        new_multiplier: U256,
+        new_ratio: U256,
         privileged: bool,
     ) -> Result<()> {
         self.ensure_operator_role(caller, privileged)?;
-        self.accounting_mut().set_multiplier(new_multiplier)?;
-        self.accounting_mut().emit_event(
-            IB20Asset::MultiplierUpdated { multiplier: new_multiplier }.encode_log_data(),
-        )
+        self.accounting_mut().set_multiplier(new_ratio)?;
+        self.accounting_mut()
+            .emit_event(IB20Asset::MultiplierUpdated { multiplier: new_ratio }.encode_log_data())
     }
 
-    // --- Minimum Redeemable Operations ---
+    // --- Asset Identifier Operations ---
 
-    /// Updates the minimum redeemable amount.
-    pub fn update_minimum_redeemable(
-        &mut self,
-        caller: Address,
-        new_minimum: U256,
-        privileged: bool,
-    ) -> Result<()> {
-        self.ensure_default_admin(caller, privileged)?;
-        self.accounting_mut().set_minimum_redeemable(new_minimum)?;
-        self.accounting_mut().emit_event(
-            IB20Asset::MinimumRedeemableUpdated { caller, newMinimumRedeemable: new_minimum }
-                .encode_log_data(),
-        )
-    }
-
-    // --- Asset Metadata Operations ---
-
-    /// Updates an asset metadata value.
+    /// Updates a asset identifier value.
     pub fn update_extra_metadata(
         &mut self,
         caller: Address,
@@ -243,74 +230,12 @@ impl<S: AssetAccounting, P: Policy> B20AssetToken<S, P> {
     ) -> Result<()> {
         self.ensure_metadata_role(caller, privileged)?;
         if identifier_type.is_empty() {
-            return Err(BasePrecompileError::revert(IB20Asset::InvalidIdentifierType {}));
+            return Err(BasePrecompileError::revert(IB20Asset::InvalidMetadataKey {}));
         }
         self.accounting_mut().set_extra_metadata_value(identifier_type.as_str(), value.clone())?;
         self.accounting_mut().emit_event(
             IB20Asset::ExtraMetadataUpdated { identifierType: identifier_type, value }
                 .encode_log_data(),
-        )
-    }
-
-    // --- Asset Redeem Operations ---
-
-    /// Performs an asset-specific redeem: multiplier floor check, burn, asset `Redeemed` event.
-    pub fn asset_redeem(&mut self, caller: Address, amount: U256) -> Result<()> {
-        let multiplier = self.asset_redeem_burn(caller, amount)?;
-        self.emit_redeemed(caller, amount, multiplier)
-    }
-
-    /// [`Self::asset_redeem`] with a memo emitted between `Transfer` and `Redeemed`.
-    pub fn asset_redeem_with_memo(
-        &mut self,
-        caller: Address,
-        amount: U256,
-        memo: B256,
-    ) -> Result<()> {
-        let multiplier = self.asset_redeem_burn(caller, amount)?;
-        self.accounting_mut().emit_event(IB20::Memo { caller, memo }.encode_log_data())?;
-        self.emit_redeemed(caller, amount, multiplier)
-    }
-
-    /// Performs the shared asset redeem burn and returns the multiplier used for the floor check.
-    fn asset_redeem_burn(&mut self, caller: Address, amount: U256) -> Result<U256> {
-        B20Guards::ensure_not_paused::<Self>(self, IB20::PausableFeature::REDEEM)?;
-        B20Guards::ensure_policy::<Self>(self, Self::REDEEM_SENDER_POLICY, caller)?;
-        let multiplier = self.accounting().multiplier()?;
-        if !amount.is_zero() {
-            let scaled =
-                amount.checked_mul(multiplier).ok_or_else(BasePrecompileError::under_overflow)?
-                    / B20AssetStorage::WAD;
-            let minimum = self.accounting().minimum_redeemable()?;
-            if scaled == U256::ZERO || scaled < minimum {
-                return Err(BasePrecompileError::revert(IB20Asset::BelowMinimumRedeemable {
-                    scaledAmount: scaled,
-                    minimum,
-                }));
-            }
-        }
-        let balance = self.accounting().balance_of(caller)?;
-        if balance < amount {
-            return Err(BasePrecompileError::revert(IB20::InsufficientBalance {
-                sender: caller,
-                balance,
-                needed: amount,
-            }));
-        }
-        self.accounting_mut().set_balance(caller, balance - amount)?;
-        let supply = self.accounting().total_supply()?;
-        let new_supply =
-            supply.checked_sub(amount).ok_or_else(BasePrecompileError::under_overflow)?;
-        self.accounting_mut().set_total_supply(new_supply)?;
-        self.accounting_mut().emit_event(
-            IB20::Transfer { from: caller, to: Address::ZERO, amount }.encode_log_data(),
-        )?;
-        Ok(multiplier)
-    }
-
-    fn emit_redeemed(&mut self, caller: Address, amount: U256, multiplier: U256) -> Result<()> {
-        self.accounting_mut().emit_event(
-            IB20Asset::Redeemed { from: caller, amt: amount, multiplier }.encode_log_data(),
         )
     }
 
@@ -360,7 +285,7 @@ mod tests {
 
     use crate::{
         B20AssetStorage, B20AssetToken, B20PausableFeature, B20TokenRole, IB20, IB20Asset,
-        InMemoryPolicy, InMemoryTokenAccounting, PolicyRegistryStorage, Token,
+        InMemoryPolicy, InMemoryTokenAccounting, Token,
     };
 
     type TestAssetToken = B20AssetToken<InMemoryTokenAccounting, InMemoryPolicy>;
@@ -373,9 +298,6 @@ mod tests {
     fn make_token() -> TestAssetToken {
         let mut accounting = InMemoryTokenAccounting::new(TOKEN);
         accounting.multiplier = B20AssetStorage::WAD;
-        accounting
-            .policy_ids
-            .insert(TestAssetToken::REDEEM_SENDER_POLICY, PolicyRegistryStorage::ALWAYS_ALLOW_ID);
         TestAssetToken::with_storage_and_policy(accounting, InMemoryPolicy::new())
     }
 
@@ -441,63 +363,6 @@ mod tests {
     }
 
     #[derive(Debug, Clone, Copy)]
-    enum AssetRedeemSetup {
-        Paused,
-        PolicyBlocked,
-        InsufficientBalance,
-    }
-
-    fn setup_asset_redeem(setup: AssetRedeemSetup) -> TestAssetToken {
-        let mut accounting = InMemoryTokenAccounting::new(TOKEN);
-        accounting.multiplier = B20AssetStorage::WAD;
-
-        match setup {
-            AssetRedeemSetup::Paused => {
-                accounting.paused = B20PausableFeature::mask(IB20::PausableFeature::REDEEM);
-                accounting.policy_ids.insert(
-                    TestAssetToken::REDEEM_SENDER_POLICY,
-                    PolicyRegistryStorage::ALWAYS_BLOCK_ID,
-                );
-            }
-            AssetRedeemSetup::PolicyBlocked => {
-                accounting.policy_ids.insert(
-                    TestAssetToken::REDEEM_SENDER_POLICY,
-                    PolicyRegistryStorage::ALWAYS_BLOCK_ID,
-                );
-            }
-            AssetRedeemSetup::InsufficientBalance => {
-                accounting.policy_ids.insert(
-                    TestAssetToken::REDEEM_SENDER_POLICY,
-                    PolicyRegistryStorage::ALWAYS_ALLOW_ID,
-                );
-                accounting.minimum_redeemable = U256::from(1u64);
-                accounting.balances.insert(CALLER, U256::from(5u64));
-            }
-        }
-
-        TestAssetToken::with_storage_and_policy(accounting, InMemoryPolicy::new())
-    }
-
-    fn expected_asset_redeem_error(setup: AssetRedeemSetup) -> BasePrecompileError {
-        match setup {
-            AssetRedeemSetup::Paused => BasePrecompileError::revert(IB20::ContractPaused {
-                feature: IB20::PausableFeature::REDEEM,
-            }),
-            AssetRedeemSetup::PolicyBlocked => BasePrecompileError::revert(IB20::PolicyForbids {
-                policyScope: TestAssetToken::REDEEM_SENDER_POLICY,
-                policyId: PolicyRegistryStorage::ALWAYS_BLOCK_ID,
-            }),
-            AssetRedeemSetup::InsufficientBalance => {
-                BasePrecompileError::revert(IB20::InsufficientBalance {
-                    sender: CALLER,
-                    balance: U256::from(5u64),
-                    needed: U256::from(10u64),
-                })
-            }
-        }
-    }
-
-    #[derive(Debug, Clone, Copy)]
     enum UpdatePolicySetup {
         NoRole,
         InvalidScope,
@@ -529,10 +394,9 @@ mod tests {
     }
 
     #[test]
-    fn role_and_policy_ids_match_solidity_hashes() {
+    fn role_ids_match_solidity_hashes() {
         assert_eq!(TestAssetToken::OPERATOR_ROLE, keccak256("OPERATOR_ROLE"));
         assert_eq!(TestAssetToken::METADATA_ROLE, keccak256("METADATA_ROLE"));
-        assert_eq!(TestAssetToken::REDEEM_SENDER_POLICY, keccak256("REDEEM_SENDER_POLICY"));
     }
 
     #[rstest]
@@ -549,18 +413,6 @@ mod tests {
     }
 
     #[rstest]
-    #[case::paused_gets_pause_error(AssetRedeemSetup::Paused)]
-    #[case::policy_blocked_gets_policy_error(AssetRedeemSetup::PolicyBlocked)]
-    #[case::insufficient_balance_gets_business_error(AssetRedeemSetup::InsufficientBalance)]
-    fn asset_redeem_check_order(#[case] setup: AssetRedeemSetup) {
-        let mut token = setup_asset_redeem(setup);
-
-        let err = token.asset_redeem(CALLER, U256::from(10u64)).unwrap_err();
-
-        assert_eq!(err, expected_asset_redeem_error(setup));
-    }
-
-    #[rstest]
     #[case::no_role_gets_role_error(UpdatePolicySetup::NoRole)]
     #[case::invalid_scope_gets_input_error(UpdatePolicySetup::InvalidScope)]
     fn update_policy_check_order(#[case] setup: UpdatePolicySetup) {
@@ -569,27 +421,5 @@ mod tests {
         let err = token.update_policy(CALLER, invalid_scope, 999, false).unwrap_err();
 
         assert_eq!(err, expected_update_policy_error(setup, invalid_scope));
-    }
-
-    /// Caller holding only `OPERATOR_ROLE` must be denied `updateExtraMetadata`.
-    ///
-    /// This guards against regressions where `ensure_metadata_role` is accidentally
-    /// reverted to `ensure_operator_role`, collapsing the two distinct capabilities.
-    #[test]
-    fn update_extra_metadata_requires_metadata_role_not_operator_role() {
-        let mut token = make_token();
-        token.accounting_mut().roles.insert((TestAssetToken::OPERATOR_ROLE, CALLER), true);
-
-        let err = token
-            .update_extra_metadata(CALLER, "ISIN".to_string(), "US0000000000".to_string(), false)
-            .unwrap_err();
-
-        assert_eq!(
-            err,
-            BasePrecompileError::revert(IB20::AccessControlUnauthorizedAccount {
-                account: CALLER,
-                neededRole: TestAssetToken::METADATA_ROLE,
-            })
-        );
     }
 }

--- a/crates/common/precompiles/src/b20_factory/abi.rs
+++ b/crates/common/precompiles/src/b20_factory/abi.rs
@@ -8,10 +8,10 @@ sol! {
         // ── Structs ─────────────────────────────────────────────────────────
 
         enum B20Variant {
-            /// Stablecoin B-20 token variant.
-            STABLECOIN,
             /// Asset B-20 token variant.
-            ASSET
+            ASSET,
+            /// Stablecoin B-20 token variant.
+            STABLECOIN
         }
 
         struct B20StablecoinCreateParams {
@@ -27,8 +27,6 @@ sol! {
             string name;
             string symbol;
             address initialAdmin;
-            string isin;
-            uint256 minimumRedeemable;
             uint8 decimals;
         }
 
@@ -49,6 +47,9 @@ sol! {
 
         /// The stablecoin `currency` field was not on the ISO 4217 fiat allowlist.
         error InvalidCurrency(string code);
+
+        /// The asset `decimals` field was outside the allowed range.
+        error InvalidDecimals(uint8 decimals);
 
         /// One of the post-creation init calls failed.
         error InitCallFailed(uint256 index);

--- a/crates/common/precompiles/src/b20_factory/storage.rs
+++ b/crates/common/precompiles/src/b20_factory/storage.rs
@@ -155,7 +155,7 @@ impl<'a> B20FactoryStorage<'a> {
             B20AssetStorage::from_address(token_address, self.storage),
             PolicyHandle::new(self.storage),
         );
-        let (name, symbol) = (init.name.clone(), init.symbol.clone());
+        let (name, symbol, decimals) = (init.name.clone(), init.symbol.clone(), init.decimals);
         token.accounting_mut().initialize(init)?;
 
         self.emit_event(IB20Factory::B20Created {
@@ -163,7 +163,7 @@ impl<'a> B20FactoryStorage<'a> {
             variant: B20Variant::Asset.abi(),
             name,
             symbol,
-            decimals: B20Variant::Asset.decimals(),
+            decimals,
             variantParams: Bytes::new(),
         })?;
 
@@ -267,9 +267,7 @@ impl TokenCreateParams {
                         symbol: p.symbol,
                         supply_cap: DEFAULT_SUPPLY_CAP,
                         multiplier: INITIAL_MULTIPLIER,
-                        isin: p.isin,
                         decimals: p.decimals,
-                        minimum_redeemable: p.minimumRedeemable,
                     },
                 })
             }
@@ -287,7 +285,7 @@ impl TokenCreateParams {
     ///
     /// Each arm owns its own rules. Version is checked first by the caller (`check_version`)
     /// so that version errors always take precedence over field-level errors.
-    pub const fn validate(&self) -> Result<()> {
+    pub fn validate(&self) -> Result<()> {
         match self {
             Self::Stablecoin { init, .. } => Self::validate_stablecoin(init),
             Self::Asset { init, .. } => Self::validate_asset(init),
@@ -302,8 +300,14 @@ impl TokenCreateParams {
     }
 
     /// Validates asset-token initialization fields.
-    pub const fn validate_asset(_init: &B20AssetInit) -> Result<()> {
-        // isin is optional — empty string is accepted.
+    pub fn validate_asset(init: &B20AssetInit) -> Result<()> {
+        if init.decimals < B20AssetStorage::MIN_DECIMALS
+            || init.decimals > B20AssetStorage::MAX_DECIMALS
+        {
+            return Err(BasePrecompileError::revert(IB20Factory::InvalidDecimals {
+                decimals: init.decimals,
+            }));
+        }
         Ok(())
     }
 
@@ -325,9 +329,10 @@ mod tests {
     use base_precompile_storage::{Handler, HashMapStorageProvider, StorageCtx};
 
     use crate::{
-        ActivationFeature, ActivationRegistryStorage, B20AssetStorage, B20AssetToken,
-        B20FactoryStorage, B20StablecoinStorage, B20TokenRole, B20Variant, IB20, IB20Factory,
-        Mintable, Permittable, PolicyHandle, RoleManaged, Token, TokenAccounting, Transferable,
+        ActivationFeature, ActivationRegistryStorage, AssetAccounting, B20AssetStorage,
+        B20AssetToken, B20FactoryStorage, B20StablecoinStorage, B20TokenRole, B20Variant, IB20,
+        IB20Factory, Mintable, Permittable, PolicyHandle, RoleManaged, Token, TokenAccounting,
+        Transferable,
     };
 
     const ACTIVATION_ADMIN: Address = address!("0xcb00000000000000000000000000000000000000");
@@ -355,8 +360,6 @@ mod tests {
             name: name.to_string(),
             symbol: symbol.to_string(),
             initialAdmin: Address::repeat_byte(0xAB),
-            isin: String::new(),
-            minimumRedeemable: U256::ZERO,
             decimals: 6,
         }
     }
@@ -422,35 +425,34 @@ mod tests {
         assert_eq!(addr.as_slice()[11..], tail);
         assert!(B20Variant::is_b20_address(addr));
         assert_eq!(B20Variant::from_address(addr), Some(B20Variant::Asset));
-        assert_eq!(B20Variant::decimals_of(addr), Some(6));
     }
 
     #[test]
-    fn test_address_derivation_ignores_decimals_and_uses_variant() {
+    fn test_address_derivation_uses_variant() {
         let creator = Address::repeat_byte(0x11);
         let salt = B256::repeat_byte(0x33);
         let (asset_token, _) = B20Variant::Asset.compute_address(creator, salt);
         let (stablecoin, _) = B20Variant::Stablecoin.compute_address(creator, salt);
 
         assert_ne!(asset_token, stablecoin);
-        assert_eq!(B20Variant::decimals_of(asset_token), Some(6));
-        assert_eq!(B20Variant::decimals_of(stablecoin), Some(6));
+        assert_eq!(B20Variant::from_address(asset_token), Some(B20Variant::Asset));
+        assert_eq!(B20Variant::from_address(stablecoin), Some(B20Variant::Stablecoin));
     }
 
     #[test]
     fn test_supported_variants_are_b20_prefixes() {
         let creator = Address::repeat_byte(0x11);
         let salt = B256::repeat_byte(0x44);
-        let (stablecoin, _) = B20Variant::compute_address_for_discriminant(creator, 0, salt);
-        let (asset, _) = B20Variant::compute_address_for_discriminant(creator, 1, salt);
+        let (asset, _) = B20Variant::compute_address_for_discriminant(creator, 0, salt);
+        let (stablecoin, _) = B20Variant::compute_address_for_discriminant(creator, 1, salt);
 
         assert!(B20Variant::is_supported_discriminant(0));
         assert!(B20Variant::is_supported_discriminant(1));
         assert!(!B20Variant::is_supported_discriminant(2));
-        assert!(B20Variant::is_b20_address(stablecoin));
         assert!(B20Variant::is_b20_address(asset));
-        assert_eq!(B20Variant::from_address(stablecoin), Some(B20Variant::Stablecoin));
+        assert!(B20Variant::is_b20_address(stablecoin));
         assert_eq!(B20Variant::from_address(asset), Some(B20Variant::Asset));
+        assert_eq!(B20Variant::from_address(stablecoin), Some(B20Variant::Stablecoin));
     }
 
     #[test]
@@ -471,7 +473,7 @@ mod tests {
     }
 
     #[test]
-    fn test_create_token_stores_metadata_and_uses_variant_decimals() {
+    fn test_create_token_stores_metadata_and_decimals() {
         let mut storage = HashMapStorageProvider::new(1);
         activate_precompiles(&mut storage);
         let caller = Address::repeat_byte(0x55);
@@ -486,9 +488,8 @@ mod tests {
 
             assert_eq!(token.b20.name.read().unwrap(), "My Token");
             assert_eq!(token.b20.symbol.read().unwrap(), "MYT");
-            assert_eq!(token.decimals().unwrap(), 6);
+            assert_eq!(AssetAccounting::decimals(&token).unwrap(), 6);
             assert_eq!(token.supply_cap().unwrap(), B20FactoryStorage::DEFAULT_SUPPLY_CAP);
-            assert_eq!(B20Variant::decimals_of(token_addr), Some(6));
         });
     }
 
@@ -743,12 +744,11 @@ mod tests {
             assert_eq!(stablecoin.stablecoin.currency.read().unwrap(), "USD");
             assert_eq!(stablecoin.b20.name.read().unwrap(), "Stablecoin Token");
             assert_eq!(B20Variant::from_address(stablecoin_addr), Some(B20Variant::Stablecoin));
-            assert_eq!(B20Variant::decimals_of(stablecoin_addr), Some(6));
         });
     }
 
     #[test]
-    fn test_create_asset_token_stores_isin_and_ratio() {
+    fn test_create_asset_token_stores_decimals_and_multiplier() {
         let mut storage = HashMapStorageProvider::new(1);
         activate_precompiles(&mut storage);
         let caller = Address::repeat_byte(0x55);
@@ -760,9 +760,7 @@ mod tests {
             name: "Asset Token".to_string(),
             symbol: "AST".to_string(),
             initialAdmin: Address::repeat_byte(0xAB),
-            isin: "US0000000000".to_string(),
-            minimumRedeemable: U256::ONE,
-            decimals: 6,
+            decimals: 12,
         };
         let asset_call = IB20Factory::createB20Call {
             variant: IB20Factory::B20Variant::ASSET,
@@ -782,14 +780,8 @@ mod tests {
             let asset_storage = B20AssetStorage::from_address(expected_addr, ctx);
             assert_eq!(asset_storage.b20.name.read().unwrap(), "Asset Token");
             assert_eq!(asset_storage.b20.symbol.read().unwrap(), "AST");
-            assert_eq!(asset_storage.decimals().unwrap(), 6);
+            assert_eq!(AssetAccounting::decimals(&asset_storage).unwrap(), 12);
             assert_eq!(asset_storage.asset.multiplier.read().unwrap(), U256::ZERO);
-            assert_eq!(asset_storage.redeem.minimum_redeemable.read().unwrap(), U256::ONE);
-            // ISIN is stored in the identifiers mapping under the raw "ISIN" key.
-            assert_eq!(
-                asset_storage.asset.identifiers.at(&String::from("ISIN")).read().unwrap(),
-                "US0000000000"
-            );
         });
     }
 
@@ -1120,8 +1112,6 @@ mod tests {
             name: "Asset Token".to_string(),
             symbol: "AST".to_string(),
             initialAdmin: initial_admin,
-            isin: "US0000000001".to_string(),
-            minimumRedeemable: U256::ZERO,
             decimals: 6,
         };
         let call = IB20Factory::createB20Call {
@@ -1149,8 +1139,6 @@ mod tests {
             name: "No Admin".to_string(),
             symbol: "NA".to_string(),
             initialAdmin: Address::ZERO,
-            isin: "US0000000002".to_string(),
-            minimumRedeemable: U256::ZERO,
             decimals: 6,
         };
         let call_no_admin = IB20Factory::createB20Call {
@@ -1185,8 +1173,6 @@ mod tests {
                 name: "T".to_string(),
                 symbol: "T".to_string(),
                 initialAdmin: Address::repeat_byte(0xAB),
-                isin: String::new(),
-                minimumRedeemable: U256::ZERO,
                 decimals: 6,
             }
             .abi_encode()
@@ -1237,6 +1223,28 @@ mod tests {
             .expect("variantParams must decode as B20StablecoinEventParams");
         assert_eq!(params.version, super::B20_STABLECOIN_EVENT_PARAMS_VERSION);
         assert_eq!(params.currency, "USD");
+    }
+
+    #[test]
+    fn get_b20_address_returns_zero_for_invalid_variant() {
+        let mut storage = HashMapStorageProvider::new(1);
+        activate_precompiles(&mut storage);
+        let sender = Address::repeat_byte(0x11);
+        let salt = B256::repeat_byte(0xAB);
+
+        StorageCtx::enter(&mut storage, |ctx| {
+            assert_output(
+                dispatch_factory_success(
+                    ctx,
+                    IB20Factory::getB20AddressCall {
+                        variant: IB20Factory::B20Variant::__Invalid,
+                        sender,
+                        salt,
+                    },
+                ),
+                IB20Factory::getB20AddressCall::abi_encode_returns(&Address::ZERO),
+            );
+        });
     }
 
     #[test]

--- a/crates/common/precompiles/src/b20_factory/variant.rs
+++ b/crates/common/precompiles/src/b20_factory/variant.rs
@@ -8,26 +8,26 @@ use crate::{ActivationFeature, IB20Factory};
 /// B-20 token variant encoded in token address byte `[10]`.
 ///
 /// Discriminant values match the `B20Variant` ABI enum ordinals directly
-/// (STABLECOIN=0, ASSET=1), so `uint8(variant)` in Solidity
+/// (ASSET=0, STABLECOIN=1), so `uint8(variant)` in Solidity
 /// equals the byte written at address position `[10]` with no offset.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
 pub enum B20Variant {
-    /// Stablecoin B-20 token.
-    Stablecoin = 0,
     /// Asset B-20 token.
-    Asset = 1,
+    Asset = 0,
+    /// Stablecoin B-20 token.
+    Stablecoin = 1,
 }
 
 impl B20Variant {
     /// First byte of every B-20 address.
     pub const PREFIX_BYTE: u8 = 0xb2;
 
-    /// Variant discriminant for stablecoin B-20 tokens.
-    pub const STABLECOIN_DISCRIMINANT: u8 = Self::Stablecoin as u8;
-
     /// Variant discriminant for asset B-20 tokens.
     pub const ASSET_DISCRIMINANT: u8 = Self::Asset as u8;
+
+    /// Variant discriminant for stablecoin B-20 tokens.
+    pub const STABLECOIN_DISCRIMINANT: u8 = Self::Stablecoin as u8;
 
     /// Returns the currently supported creation-parameter version for this variant.
     ///
@@ -42,8 +42,8 @@ impl B20Variant {
     /// Returns the supported token variant for `variant`, if any.
     pub const fn from_discriminant(variant: u8) -> Option<Self> {
         match variant {
-            Self::STABLECOIN_DISCRIMINANT => Some(Self::Stablecoin),
             Self::ASSET_DISCRIMINANT => Some(Self::Asset),
+            Self::STABLECOIN_DISCRIMINANT => Some(Self::Stablecoin),
             _ => None,
         }
     }
@@ -51,8 +51,8 @@ impl B20Variant {
     /// Returns the supported token variant for an ABI enum value, or `None` for unknown variants.
     pub const fn from_abi(variant: IB20Factory::B20Variant) -> Option<Self> {
         match variant {
-            IB20Factory::B20Variant::STABLECOIN => Some(Self::Stablecoin),
             IB20Factory::B20Variant::ASSET => Some(Self::Asset),
+            IB20Factory::B20Variant::STABLECOIN => Some(Self::Stablecoin),
             IB20Factory::B20Variant::__Invalid => None,
         }
     }
@@ -88,12 +88,12 @@ impl B20Variant {
     /// Returns this variant as the generated ABI enum.
     pub const fn abi(self) -> IB20Factory::B20Variant {
         match self {
-            Self::Stablecoin => IB20Factory::B20Variant::STABLECOIN,
             Self::Asset => IB20Factory::B20Variant::ASSET,
+            Self::Stablecoin => IB20Factory::B20Variant::STABLECOIN,
         }
     }
 
-    /// Returns this variant's fixed decimal precision.
+    /// Returns the default fixed decimal precision for variants without stored decimals.
     pub const fn decimals(self) -> u8 {
         match self {
             Self::Stablecoin | Self::Asset => 6,
@@ -157,10 +157,5 @@ impl B20Variant {
     pub fn variant_of(address: Address) -> Option<u8> {
         Self::from_address(address)?;
         Some(address.as_slice()[10])
-    }
-
-    /// Returns the fixed decimals for the variant encoded in `address`.
-    pub fn decimals_of(address: Address) -> Option<u8> {
-        Some(Self::from_address(address)?.decimals())
     }
 }

--- a/crates/common/precompiles/src/common/abi.rs
+++ b/crates/common/precompiles/src/common/abi.rs
@@ -11,9 +11,7 @@ sol! {
             /// Mint operations.
             MINT,
             /// Burn operations.
-            BURN,
-            /// Redeem operations.
-            REDEEM
+            BURN
         }
 
         // Errors

--- a/crates/common/precompiles/src/common/ops/pausable.rs
+++ b/crates/common/precompiles/src/common/ops/pausable.rs
@@ -13,6 +13,7 @@ use crate::{B20Guards, B20PausableFeature, B20TokenRole, IB20, Token, TokenAccou
 pub trait Pausable: Token {
     /// Returns whether the given pause `feature` is currently set.
     fn is_paused(&self, feature: IB20::PausableFeature) -> Result<bool> {
+        B20PausableFeature::ensure_valid(feature)?;
         Ok((self.accounting().paused()? & B20PausableFeature::mask(feature)) != U256::ZERO)
     }
 
@@ -24,7 +25,6 @@ pub trait Pausable: Token {
             IB20::PausableFeature::TRANSFER,
             IB20::PausableFeature::MINT,
             IB20::PausableFeature::BURN,
-            IB20::PausableFeature::REDEEM,
         ] {
             if (paused & B20PausableFeature::mask(feature)) != U256::ZERO {
                 features.push(feature);
@@ -40,11 +40,14 @@ pub trait Pausable: Token {
         features: Vec<IB20::PausableFeature>,
         privileged: bool,
     ) -> Result<()> {
-        if features.is_empty() {
-            return Err(BasePrecompileError::revert(IB20::EmptyFeatureSet {}));
+        for feature in &features {
+            B20PausableFeature::ensure_valid(*feature)?;
         }
         if !privileged {
             B20Guards::ensure_token_role::<Self>(self, caller, B20TokenRole::Pause)?;
+        }
+        if features.is_empty() {
+            return Err(BasePrecompileError::revert(IB20::EmptyFeatureSet {}));
         }
         let current = self.accounting().paused()?;
         let mut next = current;
@@ -63,11 +66,14 @@ pub trait Pausable: Token {
         features: Vec<IB20::PausableFeature>,
         privileged: bool,
     ) -> Result<()> {
-        if features.is_empty() {
-            return Err(BasePrecompileError::revert(IB20::EmptyFeatureSet {}));
+        for feature in &features {
+            B20PausableFeature::ensure_valid(*feature)?;
         }
         if !privileged {
             B20Guards::ensure_token_role::<Self>(self, caller, B20TokenRole::Unpause)?;
+        }
+        if features.is_empty() {
+            return Err(BasePrecompileError::revert(IB20::EmptyFeatureSet {}));
         }
         let mut next = self.accounting().paused()?;
         for feature in &features {

--- a/crates/common/precompiles/src/common/ops/transferable.rs
+++ b/crates/common/precompiles/src/common/ops/transferable.rs
@@ -236,16 +236,6 @@ mod tests {
     }
 
     #[test]
-    fn transfer_from_with_zero_from_address_reverts() {
-        let mut token = make_token();
-
-        assert_eq!(
-            token.transfer_from(SPENDER, Address::ZERO, BOB, U256::ONE, false).unwrap_err(),
-            BasePrecompileError::revert(IB20::InvalidSender { sender: Address::ZERO })
-        );
-    }
-
-    #[test]
     fn transfer_to_zero_receiver_reverts() {
         let mut token = token_with_balance(U256::from(100u64));
 

--- a/crates/common/precompiles/src/common/pausable_feature.rs
+++ b/crates/common/precompiles/src/common/pausable_feature.rs
@@ -1,6 +1,7 @@
 //! Pause-bit helpers for B-20 tokens.
 
 use alloy_primitives::U256;
+use base_precompile_storage::{BasePrecompileError, Result};
 
 use crate::IB20;
 
@@ -9,6 +10,16 @@ use crate::IB20;
 pub struct B20PausableFeature;
 
 impl B20PausableFeature {
+    /// Returns an enum-conversion panic when `feature` is outside the B-20 pause enum.
+    pub const fn ensure_valid(feature: IB20::PausableFeature) -> Result<()> {
+        match feature {
+            IB20::PausableFeature::TRANSFER
+            | IB20::PausableFeature::MINT
+            | IB20::PausableFeature::BURN => Ok(()),
+            IB20::PausableFeature::__Invalid => Err(BasePrecompileError::enum_conversion_error()),
+        }
+    }
+
     /// Returns the storage bit for a pausable feature.
     pub fn mask(feature: IB20::PausableFeature) -> U256 {
         U256::ONE.checked_shl(usize::from(feature as u8)).unwrap_or(U256::ZERO)

--- a/crates/common/precompiles/src/common/policy.rs
+++ b/crates/common/precompiles/src/common/policy.rs
@@ -5,7 +5,7 @@ use base_precompile_storage::Result;
 
 use crate::IPolicyRegistry::PolicyType;
 
-/// Minimal read-only policy interface consulted by B-20 tokens on every transfer, mint, and redeem.
+/// Minimal read-only policy interface consulted by B-20 tokens on every transfer and mint.
 ///
 /// # `is_authorized` vs `policy_exists`
 ///

--- a/crates/common/precompiles/src/common/test_utils.rs
+++ b/crates/common/precompiles/src/common/test_utils.rs
@@ -9,7 +9,7 @@ use alloy_primitives::{Address, B256, LogData, U256};
 use base_precompile_storage::Result;
 
 use crate::{
-    B20AssetStorage, IPolicyRegistry, PolicyRegistry, PolicyRegistryStorage,
+    IPolicyRegistry, PolicyRegistry, PolicyRegistryStorage,
     b20_asset::{AssetAccounting, B20AssetToken},
     b20_stablecoin::{B20StablecoinToken, StablecoinAccounting},
     common::{Policy, TokenAccounting},
@@ -47,14 +47,10 @@ pub struct InMemoryTokenAccounting {
     pub decimals: u8,
     /// Stablecoin currency identifier.
     pub currency: String,
-    /// Asset ISIN identifier (legacy field; prefer `extra_metadata` map for asset tokens).
-    pub asset_isin: String,
     /// Bitmask of active pause vectors.
     pub paused: U256,
     /// Per-account EIP-2612 nonces.
     pub nonces: HashMap<Address, U256>,
-    /// Minimum amount required for a redeem operation.
-    pub minimum_redeemable: U256,
     /// URI pointing to the contract-level metadata.
     pub contract_uri: String,
     /// Role membership keyed by `(role, account)`.
@@ -65,9 +61,9 @@ pub struct InMemoryTokenAccounting {
     pub role_admins: HashMap<B256, B256>,
     /// Policy IDs keyed by policy type.
     pub policy_ids: HashMap<B256, u64>,
-    /// Multiplier scaled to WAD (1e18). Asset tokens only.
+    /// Share-to-tokens ratio scaled to WAD (1e18). Asset tokens only.
     pub multiplier: U256,
-    /// Asset metadata values keyed by raw `identifier_type`. Asset tokens only.
+    /// Asset identifier values keyed by raw `identifier_type`. Asset tokens only.
     pub extra_metadata: HashMap<String, String>,
     /// Consumed announcement ids keyed by raw announcement id. Asset tokens only.
     pub announcement_ids_used: HashSet<String>,
@@ -89,10 +85,8 @@ impl InMemoryTokenAccounting {
             symbol: String::new(),
             decimals: 18,
             currency: String::new(),
-            asset_isin: String::new(),
             paused: U256::ZERO,
             nonces: HashMap::new(),
-            minimum_redeemable: U256::ZERO,
             contract_uri: String::new(),
             roles: HashMap::new(),
             role_member_counts: HashMap::new(),
@@ -229,12 +223,7 @@ impl TokenAccounting for InMemoryTokenAccounting {
     }
 
     fn policy_id(&self, policy_scope: B256) -> Result<u64> {
-        let default = if policy_scope == B20AssetStorage::REDEEM_SENDER_POLICY {
-            PolicyRegistryStorage::ALWAYS_BLOCK_ID
-        } else {
-            PolicyRegistryStorage::ALWAYS_ALLOW_ID
-        };
-        Ok(*self.policy_ids.get(&policy_scope).unwrap_or(&default))
+        Ok(*self.policy_ids.get(&policy_scope).unwrap_or(&PolicyRegistryStorage::ALWAYS_ALLOW_ID))
     }
 
     fn set_policy_id(&mut self, policy_scope: B256, policy_id: u64) -> Result<()> {
@@ -391,16 +380,13 @@ impl AssetAccounting for InMemoryTokenAccounting {
         Ok(if self.multiplier.is_zero() { WAD } else { self.multiplier })
     }
 
-    fn set_multiplier(&mut self, multiplier: U256) -> Result<()> {
-        self.multiplier = multiplier;
+    fn set_multiplier(&mut self, ratio: U256) -> Result<()> {
+        self.multiplier = ratio;
         Ok(())
     }
 
     fn extra_metadata(&self, identifier_type: &str) -> Result<String> {
-        if let Some(val) = self.extra_metadata.get(identifier_type) {
-            return Ok(val.clone());
-        }
-        if identifier_type == "ISIN" { Ok(self.asset_isin.clone()) } else { Ok(String::new()) }
+        Ok(self.extra_metadata.get(identifier_type).cloned().unwrap_or_default())
     }
 
     fn set_extra_metadata_value(&mut self, identifier_type: &str, value: String) -> Result<()> {
@@ -409,15 +395,6 @@ impl AssetAccounting for InMemoryTokenAccounting {
         } else {
             self.extra_metadata.insert(identifier_type.to_owned(), value);
         }
-        Ok(())
-    }
-
-    fn minimum_redeemable(&self) -> Result<U256> {
-        Ok(self.minimum_redeemable)
-    }
-
-    fn set_minimum_redeemable(&mut self, minimum: U256) -> Result<()> {
-        self.minimum_redeemable = minimum;
         Ok(())
     }
 

--- a/crates/common/precompiles/src/lib.rs
+++ b/crates/common/precompiles/src/lib.rs
@@ -51,7 +51,7 @@ pub use observer::{EndGuard, NoopPrecompileCallObserver, PrecompileCallObserver}
 mod b20_asset;
 pub use b20_asset::{
     AssetAccounting, B20AssetExtensionStorage, B20AssetInit, B20AssetPrecompile, B20AssetStorage,
-    B20AssetToken, B20RedeemStorage, IB20Asset,
+    B20AssetToken, IB20Asset,
 };
 
 mod b20_stablecoin;

--- a/etc/systems/src/b20.rs
+++ b/etc/systems/src/b20.rs
@@ -115,8 +115,6 @@ impl<'a> B20PrecompileClient<'a> {
                 name: name.to_string(),
                 symbol: symbol.to_string(),
                 initialAdmin: initial_admin,
-                isin: String::new(),
-                minimumRedeemable: U256::ZERO,
                 decimals: 6,
             },
             initial_supply,
@@ -224,9 +222,11 @@ impl<'a> B20PrecompileClient<'a> {
         B20Variant::from_address(token).wrap_err("Token address is not a supported B-20 token")
     }
 
-    /// Reads the fixed decimals for the token variant encoded in an address.
+    /// Reads the token decimals.
     pub async fn decimals_of(&self, token: Address) -> Result<u8> {
-        B20Variant::decimals_of(token).wrap_err("Token address is not a supported B-20 token")
+        let output = self.call(token, IB20::decimalsCall {}).await?;
+        IB20::decimalsCall::abi_decode_returns(output.as_ref())
+            .wrap_err("Failed to decode decimals")
     }
 
     /// Mints B-20 tokens to an account.
@@ -533,13 +533,8 @@ impl<'a> B20PrecompileClient<'a> {
 }
 
 fn pausable_features_from_mask(mask: U256) -> Vec<IB20::PausableFeature> {
-    [
-        IB20::PausableFeature::TRANSFER,
-        IB20::PausableFeature::MINT,
-        IB20::PausableFeature::BURN,
-        IB20::PausableFeature::REDEEM,
-    ]
-    .into_iter()
-    .filter(|feature| (mask & B20PausableFeature::mask(*feature)) != U256::ZERO)
-    .collect()
+    [IB20::PausableFeature::TRANSFER, IB20::PausableFeature::MINT, IB20::PausableFeature::BURN]
+        .into_iter()
+        .filter(|feature| (mask & B20PausableFeature::mask(*feature)) != U256::ZERO)
+        .collect()
 }

--- a/etc/systems/tests/policy_transfer.rs
+++ b/etc/systems/tests/policy_transfer.rs
@@ -27,8 +27,8 @@ const SALT_ALLOWLIST: B256 = B256::repeat_byte(0x50);
 const SALT_BLOCKLIST: B256 = B256::repeat_byte(0x51);
 const SALT_ALWAYS_BLOCK: B256 = B256::repeat_byte(0x52);
 
-/// Activates `B20_TOKEN` and `POLICY_REGISTRY` features, then returns a
-/// [`B20PrecompileClient`] ready for precompile calls.
+/// Activates `B20_FACTORY`, `B20_TOKEN`, and `POLICY_REGISTRY` features, then
+/// returns a [`B20PrecompileClient`] ready for precompile calls.
 async fn activated_client<'a>(
     provider: &'a RootProvider<Base>,
     admin: &'a PrivateKeySigner,


### PR DESCRIPTION
## Summary

This aligns the B20 precompile surface with the current base-std interface so the fork/interface suite passes against the rebuilt local base-anvil binaries. It removes the redemption paths, restores the asset and stablecoin variant and decimal semantics expected by base-std, and updates related policy, pause, storage, action harness, and system test call sites. Local precompile tests, formatting, staged diff checks, and the base-std fork suite are passing.