### PR TITLE
feat(activation): add checkActivated to activation registry ABI and dispatch

### DIFF
--- a/crates/common/precompiles/src/activation/abi.rs
+++ b/crates/common/precompiles/src/activation/abi.rs
@@ -32,6 +32,9 @@ sol! {
         /// Returns true when `feature` is activated.
         function isActivated(bytes32 feature) external view returns (bool);
 
+        /// Reverts with `FeatureNotActivated` if `feature` is not activated.
+        function checkActivated(bytes32 feature) external view;
+
         /// Returns the activation admin.
         function admin() external view returns (address);
 

--- a/crates/common/precompiles/src/activation/dispatch.rs
+++ b/crates/common/precompiles/src/activation/dispatch.rs
@@ -37,6 +37,10 @@ impl ActivationRegistryStorage<'_> {
                 let activated = self.is_activated(call.feature)?;
                 Ok(IActivationRegistry::isActivatedCall::abi_encode_returns(&activated).into())
             }
+            C::checkActivated(call) => {
+                self.ensure_activated(call.feature)?;
+                Ok(Bytes::new())
+            }
             C::activate(call) => {
                 self.activate(call.feature, activation_admin_address)?;
                 Ok(Bytes::new())

--- a/crates/common/precompiles/src/activation/storage.rs
+++ b/crates/common/precompiles/src/activation/storage.rs
@@ -433,4 +433,51 @@ mod tests {
         assert!(!activated_output.is_revert());
         assert!(deactivated_output.is_revert());
     }
+
+    #[test]
+    fn ensure_activated_succeeds_when_feature_is_active() {
+        let mut storage = HashMapStorageProvider::new(1);
+
+        activate_feature(&mut storage).unwrap();
+
+        let result = StorageCtx::enter(&mut storage, |ctx| {
+            ActivationRegistryStorage::new(ctx).ensure_activated(FEATURE)
+        });
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn ensure_activated_reverts_when_feature_never_activated() {
+        let mut storage = HashMapStorageProvider::new(1);
+
+        let result = StorageCtx::enter(&mut storage, |ctx| {
+            ActivationRegistryStorage::new(ctx).ensure_activated(FEATURE)
+        });
+
+        assert_eq!(
+            result.unwrap_err(),
+            BasePrecompileError::revert(IActivationRegistry::FeatureNotActivated {
+                feature: FEATURE,
+            })
+        );
+    }
+
+    #[test]
+    fn ensure_activated_reverts_after_deactivate() {
+        let mut storage = HashMapStorageProvider::new(1);
+
+        activate_feature(&mut storage).unwrap();
+        deactivate_feature(&mut storage).unwrap();
+
+        let result = StorageCtx::enter(&mut storage, |ctx| {
+            ActivationRegistryStorage::new(ctx).ensure_activated(FEATURE)
+        });
+
+        assert_eq!(
+            result.unwrap_err(),
+            BasePrecompileError::revert(IActivationRegistry::FeatureNotActivated {
+                feature: FEATURE,
+            })
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Adds the `checkActivated(bytes32)` view function to the activation registry precompile, aligning the Rust implementation with the `IActivationRegistry` Solidity interface defined in [base-std](../base-std/src/interfaces/IActivationRegistry.sol).

## Motivation

The Solidity interface declares `checkActivated(bytes32 feature) external view` — a pure assertion entry point that reverts with `FeatureNotActivated` if the feature is inactive, so callers don't have to redefine the error. The mock implements it, and `MockB20Factory` already calls it to gate variant creation. However, the Rust precompile ABI and dispatch were missing this function, meaning any on-chain call to `checkActivated` would hit an unrecognized selector.

## Changes

| File | Change |
|------|--------|
| `activation/abi.rs` | Added `checkActivated(bytes32) external view` to the `sol!` interface block |
| `activation/dispatch.rs` | Added dispatch arm: routes to `ensure_activated()`, returns empty bytes on success, reverts `FeatureNotActivated` on failure |
| `activation/storage.rs` | Added 3 unit tests for `ensure_activated` (the code path `checkActivated` dispatch calls) |

## Testing

- `cargo check -p base-common-precompiles` — clean
- `cargo test -p base-common-precompiles -- activation` — 20/20 pass (17 existing + 3 new)

New tests:
- `ensure_activated_succeeds_when_feature_is_active`
- `ensure_activated_reverts_when_feature_never_activated`
- `ensure_activated_reverts_after_deactivate`