### PR TITLE
chore(b20-asset): cosmetic security->asset/multiplier/isin cleanup (BOP-241)

### DIFF
--- a/actions/harness/tests/beryl/env.rs
+++ b/actions/harness/tests/beryl/env.rs
@@ -84,14 +84,14 @@ impl BerylTestEnv {
     /// ISO 4217 currency code for the stablecoin B-20 token variant.
     pub(crate) const B20_STABLECOIN_CURRENCY: &str = "USD";
 
-    /// Fixed decimals for the security B-20 token variant.
+    /// Fixed decimals for the asset B-20 token variant.
     pub(crate) const B20_ASSET_DECIMALS: u8 = 6;
 
-    /// Name for the security B-20 token variant.
+    /// Name for the asset B-20 token variant.
     pub(crate) const B20_ASSET_NAME: &str = "Action Asset";
 
-    /// Symbol for the security B-20 token variant.
-    pub(crate) const B20_ASSET_SYMBOL: &str = "ASEC";
+    /// Symbol for the asset B-20 token variant.
+    pub(crate) const B20_ASSET_SYMBOL: &str = "AAST";
 
     /// Initial B-20 supply minted to Alice.
     pub(crate) const B20_INITIAL_SUPPLY: u64 = 1_000_000;

--- a/actions/harness/tests/beryl/env.rs
+++ b/actions/harness/tests/beryl/env.rs
@@ -88,7 +88,7 @@ impl BerylTestEnv {
     pub(crate) const B20_ASSET_DECIMALS: u8 = 6;
 
     /// Name for the security B-20 token variant.
-    pub(crate) const B20_ASSET_NAME: &str = "Action Security";
+    pub(crate) const B20_ASSET_NAME: &str = "Action Asset";
 
     /// Symbol for the security B-20 token variant.
     pub(crate) const B20_ASSET_SYMBOL: &str = "ASEC";

--- a/actions/harness/tests/beryl/security.rs
+++ b/actions/harness/tests/beryl/security.rs
@@ -1,4 +1,4 @@
-//! Security B-20 precompile action tests across the Base Beryl boundary.
+//! Asset B-20 precompile action tests across the Base Beryl boundary.
 
 use alloy_consensus::TxReceipt;
 use alloy_primitives::{Address, B256, Bytes, LogData, TxKind, U256, keccak256};
@@ -12,7 +12,7 @@ use crate::{
 };
 
 const WAD: U256 = U256::from_limbs([1_000_000_000_000_000_000, 0, 0, 0]);
-const UPDATED_RATIO: U256 = U256::from_limbs([2_000_000_000_000_000_000, 0, 0, 0]);
+const UPDATED_MULTIPLIER: U256 = U256::from_limbs([2_000_000_000_000_000_000, 0, 0, 0]);
 const BOB_MINT_AMOUNT: u64 = 100;
 const CAROL_MINT_AMOUNT: u64 = 200;
 const CUSIP: &str = "123456789";
@@ -113,7 +113,7 @@ async fn security_creation_initializes_identifiers_and_factory_views() {
                 StaticcallCase::bytes32(
                     "OPERATOR_ROLE",
                     IB20Asset::OPERATOR_ROLECall {}.abi_encode(),
-                    security_operator_role(),
+                    operator_role(),
                 ),
                 StaticcallCase::bytes32(
                     "METADATA_ROLE",
@@ -135,12 +135,10 @@ async fn security_creation_initializes_identifiers_and_factory_views() {
 #[tokio::test]
 async fn security_mutations_update_state_and_emit_events() {
     let mut scenario = B20AssetScenario::new().await;
-    scenario
-        .grant_roles([security_operator_role(), metadata_role(), B20TokenRole::Mint.id()])
-        .await;
+    scenario.grant_roles([operator_role(), metadata_role(), B20TokenRole::Mint.id()]).await;
 
-    let update_ratio =
-        scenario.call_tx(IB20Asset::updateMultiplierCall { newMultiplier: UPDATED_RATIO });
+    let update_multiplier =
+        scenario.call_tx(IB20Asset::updateMultiplierCall { newMultiplier: UPDATED_MULTIPLIER });
     let update_cusip = scenario.call_tx(IB20Asset::updateExtraMetadataCall {
         key: "CUSIP".to_string(),
         value: CUSIP.to_string(),
@@ -158,7 +156,7 @@ async fn security_mutations_update_state_and_emit_events() {
         uri: ANNOUNCEMENT_URI.to_string(),
     });
     let block = scenario
-        .build_block_with_transactions(vec![update_ratio, update_cusip, batch_mint, announce])
+        .build_block_with_transactions(vec![update_multiplier, update_cusip, batch_mint, announce])
         .await;
 
     for index in 0..4 {
@@ -171,7 +169,7 @@ async fn security_mutations_update_state_and_emit_events() {
     scenario.assert_log(
         &block,
         0,
-        IB20Asset::MultiplierUpdated { multiplier: UPDATED_RATIO }.encode_log_data(),
+        IB20Asset::MultiplierUpdated { multiplier: UPDATED_MULTIPLIER }.encode_log_data(),
     );
     scenario.assert_log(
         &block,
@@ -234,7 +232,7 @@ async fn security_mutations_update_state_and_emit_events() {
                 StaticcallCase::word(
                     "multiplier after update",
                     IB20Asset::multiplierCall {}.abi_encode(),
-                    UPDATED_RATIO,
+                    UPDATED_MULTIPLIER,
                 ),
                 StaticcallCase::word(
                     "toScaledBalance after update",
@@ -277,9 +275,7 @@ async fn security_mutations_update_state_and_emit_events() {
 #[tokio::test]
 async fn security_mutations_revert_on_invalid_inputs() {
     let mut scenario = B20AssetScenario::new().await;
-    scenario
-        .grant_roles([security_operator_role(), metadata_role(), B20TokenRole::Mint.id()])
-        .await;
+    scenario.grant_roles([operator_role(), metadata_role(), B20TokenRole::Mint.id()]).await;
 
     let first_announcement = scenario.call_tx(IB20Asset::announceCall {
         internalCalls: Vec::new(),
@@ -544,7 +540,7 @@ impl B20AssetScenario {
     }
 }
 
-fn security_operator_role() -> B256 {
+fn operator_role() -> B256 {
     keccak256("OPERATOR_ROLE")
 }
 

--- a/crates/common/precompile-storage/src/types/mapping.rs
+++ b/crates/common/precompile-storage/src/types/mapping.rs
@@ -154,7 +154,7 @@ mod tests {
     #[test]
     fn test_string_mapping_slot_matches_solidity_packed_encoding() {
         let slot = U256::from(123u64);
-        let key = "ISIN".to_owned();
+        let key = "description".to_owned();
         let mut buf = key.as_bytes().to_vec();
         buf.extend_from_slice(&slot.to_be_bytes::<32>());
 

--- a/crates/common/precompile-storage/tests/contract.rs
+++ b/crates/common/precompile-storage/tests/contract.rs
@@ -343,18 +343,18 @@ mod type_namespaced_layouts {
         );
 
         let b20_root = erc7201_root("b20");
-        let security_root = erc7201_root("b20.security");
+        let asset_root = erc7201_root("b20.asset");
         let redeem_root = erc7201_root("b20.redeem");
 
         assert_eq!(<B20Storage as StorableType>::STORAGE_NAMESPACE_ID, "b20");
         assert_eq!(<B20Storage as StorableType>::STORAGE_NAMESPACE_ROOT, b20_root);
-        assert_eq!(<B20AssetStorage as StorableType>::STORAGE_NAMESPACE_ROOT, security_root);
+        assert_eq!(<B20AssetStorage as StorableType>::STORAGE_NAMESPACE_ROOT, asset_root);
         assert_eq!(<B20RedeemStorage as StorableType>::STORAGE_NAMESPACE_ROOT, redeem_root);
 
         assert_eq!(slots::LOCAL_HEAD, U256::ZERO);
         assert_eq!(slots::LOCAL_HEAD_OFFSET, 0);
         assert_eq!(slots::B20, b20_root);
-        assert_eq!(slots::SECURITY, security_root);
+        assert_eq!(slots::SECURITY, asset_root);
         assert_eq!(slots::REDEEM, redeem_root);
         assert_eq!(slots::LOCAL_TAIL, U256::ZERO);
         assert_eq!(slots::LOCAL_TAIL_OFFSET, 1);

--- a/crates/common/precompile-storage/tests/contract.rs
+++ b/crates/common/precompile-storage/tests/contract.rs
@@ -295,7 +295,7 @@ mod type_namespaced_layouts {
         balances: Mapping<Address, U256>,
     }
 
-    /// Security-specific B-20 extension storage.
+    /// Asset-specific B-20 extension storage.
     #[derive(Debug, Clone, Storable)]
     #[namespace("b20.asset")]
     struct B20AssetStorage {
@@ -312,12 +312,12 @@ mod type_namespaced_layouts {
         redeem_policy_ids: U256,
     }
 
-    /// Security token layout that composes canonical namespaced storage sections.
+    /// Asset token layout that composes canonical namespaced storage sections.
     #[contract(addr = TYPE_NAMESPACE_ADDR)]
     pub struct B20AssetLayout {
         pub local_head: u8,
         pub b20: B20Storage,
-        pub security: B20AssetStorage,
+        pub asset: B20AssetStorage,
         pub redeem: B20RedeemStorage,
         pub local_tail: u16,
     }
@@ -325,7 +325,7 @@ mod type_namespaced_layouts {
     #[test]
     fn type_level_namespaces_mount_layouts_without_repeating_strings() {
         let b20_value = B20Storage { total_supply: U256::ZERO, balances: Mapping::default() };
-        let security_value = B20AssetStorage {
+        let asset_value = B20AssetStorage {
             multiplier: U256::ZERO,
             used_announcement_ids: Mapping::default(),
             extra_metadata: Mapping::default(),
@@ -335,9 +335,9 @@ mod type_namespaced_layouts {
         let _ = (
             &b20_value.total_supply,
             &b20_value.balances,
-            &security_value.multiplier,
-            &security_value.used_announcement_ids,
-            &security_value.extra_metadata,
+            &asset_value.multiplier,
+            &asset_value.used_announcement_ids,
+            &asset_value.extra_metadata,
             &redeem_value.minimum_redeemable,
             &redeem_value.redeem_policy_ids,
         );
@@ -354,7 +354,7 @@ mod type_namespaced_layouts {
         assert_eq!(slots::LOCAL_HEAD, U256::ZERO);
         assert_eq!(slots::LOCAL_HEAD_OFFSET, 0);
         assert_eq!(slots::B20, b20_root);
-        assert_eq!(slots::SECURITY, asset_root);
+        assert_eq!(slots::ASSET, asset_root);
         assert_eq!(slots::REDEEM, redeem_root);
         assert_eq!(slots::LOCAL_TAIL, U256::ZERO);
         assert_eq!(slots::LOCAL_TAIL_OFFSET, 1);
@@ -371,7 +371,7 @@ mod type_namespaced_layouts {
             layout.local_head.write(0x11).unwrap();
             layout.b20.total_supply.write(U256::from(100)).unwrap();
             layout.b20.balances.at_mut(&holder).write(U256::from(25)).unwrap();
-            layout.security.multiplier.write(U256::from(2)).unwrap();
+            layout.asset.multiplier.write(U256::from(2)).unwrap();
             layout.redeem.minimum_redeemable.write(U256::from(10)).unwrap();
             layout.redeem.redeem_policy_ids.write(U256::from(3)).unwrap();
             layout.local_tail.write(0x2233).unwrap();
@@ -379,7 +379,7 @@ mod type_namespaced_layouts {
             assert_eq!(layout.local_head.read().unwrap(), 0x11);
             assert_eq!(layout.b20.total_supply.read().unwrap(), U256::from(100));
             assert_eq!(layout.b20.balances.at(&holder).read().unwrap(), U256::from(25));
-            assert_eq!(layout.security.multiplier.read().unwrap(), U256::from(2));
+            assert_eq!(layout.asset.multiplier.read().unwrap(), U256::from(2));
             assert_eq!(layout.redeem.minimum_redeemable.read().unwrap(), U256::from(10));
             assert_eq!(layout.redeem.redeem_policy_ids.read().unwrap(), U256::from(3));
             assert_eq!(layout.local_tail.read().unwrap(), 0x2233);
@@ -405,7 +405,7 @@ mod type_namespaced_layouts {
             assert_eq!(
                 ctx.sload(
                     TYPE_NAMESPACE_ADDR,
-                    slots::SECURITY
+                    slots::ASSET
                         + U256::from(__packing_b20_asset_storage::MULTIPLIER_LOC.offset_slots,),
                 )
                 .unwrap(),

--- a/crates/common/precompile-storage/tests/contract.rs
+++ b/crates/common/precompile-storage/tests/contract.rs
@@ -297,11 +297,11 @@ mod type_namespaced_layouts {
 
     /// Security-specific B-20 extension storage.
     #[derive(Debug, Clone, Storable)]
-    #[namespace("b20.security")]
+    #[namespace("b20.asset")]
     struct B20AssetStorage {
         multiplier: U256,
         used_announcement_ids: Mapping<String, bool>,
-        security_identifiers: Mapping<String, bool>,
+        extra_metadata: Mapping<String, bool>,
     }
 
     /// Redeem-specific B-20 extension storage.
@@ -328,7 +328,7 @@ mod type_namespaced_layouts {
         let security_value = B20AssetStorage {
             multiplier: U256::ZERO,
             used_announcement_ids: Mapping::default(),
-            security_identifiers: Mapping::default(),
+            extra_metadata: Mapping::default(),
         };
         let redeem_value =
             B20RedeemStorage { minimum_redeemable: U256::ZERO, redeem_policy_ids: U256::ZERO };
@@ -337,7 +337,7 @@ mod type_namespaced_layouts {
             &b20_value.balances,
             &security_value.multiplier,
             &security_value.used_announcement_ids,
-            &security_value.security_identifiers,
+            &security_value.extra_metadata,
             &redeem_value.minimum_redeemable,
             &redeem_value.redeem_policy_ids,
         );

--- a/crates/common/precompiles/src/b20_asset/abi.rs
+++ b/crates/common/precompiles/src/b20_asset/abi.rs
@@ -91,7 +91,7 @@ sol! {
 
         // ── Extra metadata ────────────────────────────────────────────────
 
-        /// Returns the value of the named metadata entry. Empty string if not set.
+        /// Returns the value of the named metadata entry (e.g. `"category"`, `"region"`). Empty string if not set.
         function extraMetadata(string calldata key) external view returns (string);
 
         /// Sets, updates, or removes an extra-metadata entry. Empty `value` removes the entry. Requires `METADATA_ROLE`.

--- a/crates/common/precompiles/src/b20_asset/dispatch.rs
+++ b/crates/common/precompiles/src/b20_asset/dispatch.rs
@@ -561,12 +561,15 @@ mod tests {
     fn extra_metadata_roundtrip() {
         let mut token = make_token();
 
-        assert_eq!(token.accounting().extra_metadata("ISIN").unwrap(), "");
+        assert_eq!(token.accounting().extra_metadata("category").unwrap(), "");
         token
             .accounting_mut()
-            .set_extra_metadata_value("ISIN", "US0000000000".to_string())
+            .set_extra_metadata_value("category", "real-world-asset".to_string())
             .unwrap();
-        assert_eq!(token.accounting().extra_metadata("ISIN").unwrap(), "US0000000000".to_string());
+        assert_eq!(
+            token.accounting().extra_metadata("category").unwrap(),
+            "real-world-asset".to_string()
+        );
     }
 
     // --- batchMint: EmptyBatch / LengthMismatch ---
@@ -656,20 +659,17 @@ mod tests {
     fn extra_metadata_missing_key_returns_empty() {
         let token = make_token();
         // "Returns the empty string if not set"
-        assert_eq!(token.accounting().extra_metadata("CUSIP").unwrap(), "");
+        assert_eq!(token.accounting().extra_metadata("category").unwrap(), "");
     }
 
     #[test]
     fn extra_metadata_empty_value_clears_entry() {
         let mut token = make_token();
-        token
-            .accounting_mut()
-            .set_extra_metadata_value("FIGI", "BBG000B9XRY4".to_string())
-            .unwrap();
-        assert_eq!(token.accounting().extra_metadata("FIGI").unwrap(), "BBG000B9XRY4");
+        token.accounting_mut().set_extra_metadata_value("region", "us-east".to_string()).unwrap();
+        assert_eq!(token.accounting().extra_metadata("region").unwrap(), "us-east");
         // "passing an empty value removes the entry"
-        token.accounting_mut().set_extra_metadata_value("FIGI", String::new()).unwrap();
-        assert_eq!(token.accounting().extra_metadata("FIGI").unwrap(), "");
+        token.accounting_mut().set_extra_metadata_value("region", String::new()).unwrap();
+        assert_eq!(token.accounting().extra_metadata("region").unwrap(), "");
     }
 
     // --- isAnnouncementIdUsed: fresh state ---


### PR DESCRIPTION
[BOP-241](https://linear.app/coinbase/issue/BOP-241)

## Motivation

Follow-up to #3146 (add custom decimals to B20Asset), which left stale "security" terminology in several places after the B20Security to B20Asset rename.

## What changed

- `env.rs`: corrected `B20_ASSET_NAME` ("Action Security" to "Action Asset"), `B20_ASSET_SYMBOL` ("ASEC" to "AAST"), and doc comments on asset constants
- `security.rs`: module doc, `UPDATED_RATIO` to `UPDATED_MULTIPLIER`, `update_ratio` local, `security_operator_role()` to `operator_role()`
- `contract.rs`: namespace `b20.security` to `b20.asset`, `security_identifiers` to `extra_metadata`, `pub security` to `pub asset` on layout struct, slot and local renames to match
- `abi.rs`: added generic key examples to `extraMetadata` doc comment
- `dispatch.rs`: replaced `"ISIN"`/`"CUSIP"`/`"FIGI"` test values with generic `"category"`/`"region"` keys
- `mapping.rs`: replaced `"ISIN"` key in string mapping slot test with `"description"`