### PR TITLE
refactor(b20_asset): align naming with base-std IB20Asset

### DIFF
--- a/actions/harness/tests/beryl/security.rs
+++ b/actions/harness/tests/beryl/security.rs
@@ -70,8 +70,7 @@ async fn security_creation_initializes_identifiers_and_factory_views() {
                 StaticcallCase::string("contractURI", IB20::contractURICall {}.abi_encode(), ""),
                 StaticcallCase::string(
                     "extraMetadata(unset)",
-                    IB20Asset::extraMetadataCall { identifierType: "ISIN".to_string() }
-                        .abi_encode(),
+                    IB20Asset::extraMetadataCall { key: "ISIN".to_string() }.abi_encode(),
                     "",
                 ),
                 StaticcallCase::word(
@@ -118,7 +117,7 @@ async fn security_creation_initializes_identifiers_and_factory_views() {
                 ),
                 StaticcallCase::bytes32(
                     "METADATA_ROLE",
-                    IB20Asset::METADATA_ROLECall {}.abi_encode(),
+                    IB20::METADATA_ROLECall {}.abi_encode(),
                     metadata_role(),
                 ),
                 StaticcallCase::returndata(
@@ -143,17 +142,15 @@ async fn security_mutations_update_state_and_emit_events() {
     let update_ratio =
         scenario.call_tx(IB20Asset::updateMultiplierCall { newMultiplier: UPDATED_RATIO });
     let update_cusip = scenario.call_tx(IB20Asset::updateExtraMetadataCall {
-        identifierType: "CUSIP".to_string(),
+        key: "CUSIP".to_string(),
         value: CUSIP.to_string(),
     });
     let batch_mint = scenario.call_tx(IB20Asset::batchMintCall {
         recipients: vec![BerylTestEnv::bob(), BerylTestEnv::carol()],
         amounts: vec![U256::from(BOB_MINT_AMOUNT), U256::from(CAROL_MINT_AMOUNT)],
     });
-    let announced_identifier = IB20Asset::updateExtraMetadataCall {
-        identifierType: "FIGI".to_string(),
-        value: FIGI.to_string(),
-    };
+    let announced_identifier =
+        IB20Asset::updateExtraMetadataCall { key: "FIGI".to_string(), value: FIGI.to_string() };
     let announce = scenario.call_tx(IB20Asset::announceCall {
         internalCalls: vec![Bytes::from(announced_identifier.abi_encode())],
         id: ANNOUNCEMENT_ID.to_string(),
@@ -179,11 +176,8 @@ async fn security_mutations_update_state_and_emit_events() {
     scenario.assert_log(
         &block,
         1,
-        IB20Asset::ExtraMetadataUpdated {
-            identifierType: "CUSIP".to_string(),
-            value: CUSIP.to_string(),
-        }
-        .encode_log_data(),
+        IB20Asset::ExtraMetadataUpdated { key: "CUSIP".to_string(), value: CUSIP.to_string() }
+            .encode_log_data(),
     );
     scenario.assert_log(
         &block,
@@ -219,11 +213,8 @@ async fn security_mutations_update_state_and_emit_events() {
     scenario.assert_log(
         &block,
         3,
-        IB20Asset::ExtraMetadataUpdated {
-            identifierType: "FIGI".to_string(),
-            value: FIGI.to_string(),
-        }
-        .encode_log_data(),
+        IB20Asset::ExtraMetadataUpdated { key: "FIGI".to_string(), value: FIGI.to_string() }
+            .encode_log_data(),
     );
     scenario.assert_log(
         &block,
@@ -257,14 +248,12 @@ async fn security_mutations_update_state_and_emit_events() {
                 ),
                 StaticcallCase::string(
                     "extraMetadata(CUSIP)",
-                    IB20Asset::extraMetadataCall { identifierType: "CUSIP".to_string() }
-                        .abi_encode(),
+                    IB20Asset::extraMetadataCall { key: "CUSIP".to_string() }.abi_encode(),
                     CUSIP,
                 ),
                 StaticcallCase::string(
                     "extraMetadata(FIGI)",
-                    IB20Asset::extraMetadataCall { identifierType: "FIGI".to_string() }
-                        .abi_encode(),
+                    IB20Asset::extraMetadataCall { key: "FIGI".to_string() }.abi_encode(),
                     FIGI,
                 ),
                 StaticcallCase::word(
@@ -304,10 +293,8 @@ async fn security_mutations_revert_on_invalid_inputs() {
         recipients: vec![BerylTestEnv::bob()],
         amounts: vec![U256::from(1), U256::from(2)],
     });
-    let empty_identifier_type = scenario.call_tx(IB20Asset::updateExtraMetadataCall {
-        identifierType: String::new(),
-        value: "x".to_string(),
-    });
+    let empty_metadata_key = scenario
+        .call_tx(IB20Asset::updateExtraMetadataCall { key: String::new(), value: "x".to_string() });
     let duplicate_announcement = scenario.call_tx(IB20Asset::announceCall {
         internalCalls: Vec::new(),
         id: "duplicate-id".to_string(),
@@ -337,7 +324,7 @@ async fn security_mutations_revert_on_invalid_inputs() {
             first_announcement,
             empty_batch_mint,
             mismatched_batch_mint,
-            empty_identifier_type,
+            empty_metadata_key,
             duplicate_announcement,
             malformed_internal_call,
             recursive_announcement,

--- a/crates/common/precompile-macros/src/accounting.rs
+++ b/crates/common/precompile-macros/src/accounting.rs
@@ -309,39 +309,39 @@ fn expand_asset(input: DeriveInput) -> syn::Result<TokenStream> {
             fn multiplier(
                 &self,
             ) -> ::base_precompile_storage::Result<::alloy_primitives::U256> {
-                let ratio = self.asset.multiplier()?;
-                Ok(if ratio.is_zero() { Self::WAD } else { ratio })
+                let multiplier = self.asset.multiplier()?;
+                Ok(if multiplier.is_zero() { Self::WAD } else { multiplier })
             }
 
             fn set_multiplier(
                 &mut self,
-                ratio: ::alloy_primitives::U256,
+                multiplier: ::alloy_primitives::U256,
             ) -> ::base_precompile_storage::Result<()> {
-                self.asset.set_multiplier(ratio)
+                self.asset.set_multiplier(multiplier)
             }
 
             fn extra_metadata(
                 &self,
-                identifier_type: &str,
+                key: &str,
             ) -> ::base_precompile_storage::Result<::alloc::string::String> {
                 ::base_precompile_storage::Handler::read(
                     self.asset
-                        .identifiers
-                        .at(&::alloc::string::String::from(identifier_type)),
+                        .extra_metadata
+                        .at(&::alloc::string::String::from(key)),
                 )
             }
 
             fn set_extra_metadata_value(
                 &mut self,
-                identifier_type: &str,
+                key: &str,
                 value: ::alloc::string::String,
             ) -> ::base_precompile_storage::Result<()> {
-                let key = ::alloc::string::String::from(identifier_type);
+                let key = ::alloc::string::String::from(key);
                 if value.is_empty() {
-                    ::base_precompile_storage::Handler::delete(self.asset.identifiers.at_mut(&key))
+                    ::base_precompile_storage::Handler::delete(self.asset.extra_metadata.at_mut(&key))
                 } else {
                     ::base_precompile_storage::Handler::write(
-                        self.asset.identifiers.at_mut(&key),
+                        self.asset.extra_metadata.at_mut(&key),
                         value,
                     )
                 }

--- a/crates/common/precompiles/src/b20_asset/abi.rs
+++ b/crates/common/precompiles/src/b20_asset/abi.rs
@@ -37,7 +37,7 @@ sol! {
         event MultiplierUpdated(uint256 multiplier);
 
         /// Emitted by `updateExtraMetadata`. Empty `value` indicates removal.
-        event ExtraMetadataUpdated(string identifierType, string value);
+        event ExtraMetadataUpdated(string key, string value);
 
         /// Emitted at the start of `announce`. Indexers join with `EndAnnouncement` via `id`.
         event Announcement(address indexed caller, string id, string description, string uri);
@@ -49,9 +49,6 @@ sol! {
 
         /// `keccak256("OPERATOR_ROLE")` — required for `announce` and `updateMultiplier`.
         function OPERATOR_ROLE() external view returns (bytes32);
-
-        /// `keccak256("METADATA_ROLE")` — required for `updateExtraMetadata`.
-        function METADATA_ROLE() external view returns (bytes32);
 
         /// Fixed-point precision for `multiplier`: `1e18` (one WAD).
         function WAD_PRECISION() external view returns (uint256);
@@ -92,14 +89,14 @@ sol! {
         /// Mints `amounts[i]` to `recipients[i]`. Requires `MINT_ROLE`. All-or-nothing.
         function batchMint(address[] calldata recipients, uint256[] calldata amounts) external;
 
-        // ── Asset identifiers ─────────────────────────────────────────────
+        // ── Extra metadata ────────────────────────────────────────────────
 
-        /// Returns the value of the named identifier (e.g. ISIN, CUSIP). Empty string if not set.
-        function extraMetadata(string calldata identifierType) external view returns (string);
+        /// Returns the value of the named metadata entry. Empty string if not set.
+        function extraMetadata(string calldata key) external view returns (string);
 
-        /// Sets, updates, or removes a asset identifier. Empty `value` removes the entry. Requires `METADATA_ROLE`.
+        /// Sets, updates, or removes an extra-metadata entry. Empty `value` removes the entry. Requires `METADATA_ROLE`.
         function updateExtraMetadata(
-            string calldata identifierType,
+            string calldata key,
             string calldata value
         ) external;
     }
@@ -110,7 +107,6 @@ impl IB20Asset::IB20AssetCalls {
     pub const fn as_label(&self) -> &'static str {
         match self {
             Self::OPERATOR_ROLE(_) => "precompile-b20-asset-OPERATOR_ROLE",
-            Self::METADATA_ROLE(_) => "precompile-b20-asset-METADATA_ROLE",
             Self::WAD_PRECISION(_) => "precompile-b20-asset-WAD_PRECISION",
             Self::announce(_) => "precompile-b20-asset-announce",
             Self::isAnnouncementIdUsed(_) => "precompile-b20-asset-isAnnouncementIdUsed",
@@ -134,7 +130,7 @@ mod tests {
     fn asset_call_labels_are_stable() {
         assert_eq!(
             IB20Asset::IB20AssetCalls::updateExtraMetadata(IB20Asset::updateExtraMetadataCall {
-                identifierType: alloc::string::String::new(),
+                key: alloc::string::String::new(),
                 value: alloc::string::String::new(),
             })
             .as_label(),

--- a/crates/common/precompiles/src/b20_asset/accounting.rs
+++ b/crates/common/precompiles/src/b20_asset/accounting.rs
@@ -9,18 +9,18 @@ use crate::TokenAccounting;
 
 /// Extends [`TokenAccounting`] with asset-token-specific storage slots.
 ///
-/// Asset identifiers (ISIN, CUSIP, etc.) are only exposed through the
-/// asset-token surface, not the base B-20 surface.
+/// Extra metadata entries are only exposed through the asset-token surface,
+/// not the base B-20 surface.
 pub trait AssetAccounting: TokenAccounting {
-    /// Returns the current share-to-tokens ratio scaled to WAD (1e18).
+    /// Returns the current multiplier scaled to WAD (1e18).
     fn multiplier(&self) -> Result<U256>;
-    /// Writes a new share-to-tokens ratio.
-    fn set_multiplier(&mut self, ratio: U256) -> Result<()>;
+    /// Writes a new multiplier.
+    fn set_multiplier(&mut self, multiplier: U256) -> Result<()>;
 
-    /// Returns the asset identifier value for `identifier_type`, or an empty string if unset.
-    fn extra_metadata(&self, identifier_type: &str) -> Result<String>;
-    /// Writes (or removes when `value` is empty) the asset identifier for `identifier_type`.
-    fn set_extra_metadata_value(&mut self, identifier_type: &str, value: String) -> Result<()>;
+    /// Returns the extra-metadata value for `key`, or an empty string if unset.
+    fn extra_metadata(&self, key: &str) -> Result<String>;
+    /// Writes (or removes when `value` is empty) the extra-metadata entry for `key`.
+    fn set_extra_metadata_value(&mut self, key: &str, value: String) -> Result<()>;
 
     /// Returns `true` if `id` has been consumed by `announce`.
     fn is_announcement_id_used(&self, id: &str) -> Result<bool>;

--- a/crates/common/precompiles/src/b20_asset/dispatch.rs
+++ b/crates/common/precompiles/src/b20_asset/dispatch.rs
@@ -336,10 +336,9 @@ impl<S: AssetAccounting, P: Policy> B20AssetToken<S, P> {
         let encoded: Bytes = match call {
             // --- Role / precision constants ---
             SC::OPERATOR_ROLE(_) => Self::OPERATOR_ROLE.abi_encode().into(),
-            SC::METADATA_ROLE(_) => Self::METADATA_ROLE.abi_encode().into(),
             SC::WAD_PRECISION(_) => B20AssetStorage::WAD.abi_encode().into(),
 
-            // --- Share ratio reads ---
+            // --- Multiplier reads ---
             SC::multiplier(_) => self.accounting().multiplier()?.abi_encode().into(),
             SC::toScaledBalance(c) => self.to_scaled_balance(c.rawBalance)?.abi_encode().into(),
             SC::toRawBalance(c) => self.to_raw_balance(c.scaledBalance)?.abi_encode().into(),
@@ -350,12 +349,12 @@ impl<S: AssetAccounting, P: Policy> B20AssetToken<S, P> {
                 self.accounting().is_announcement_id_used(c.id.as_str())?.abi_encode().into()
             }
 
-            // --- Asset identifier reads ---
+            // --- Extra metadata reads ---
             SC::extraMetadata(c) => {
-                self.accounting().extra_metadata(c.identifierType.as_str())?.abi_encode().into()
+                self.accounting().extra_metadata(c.key.as_str())?.abi_encode().into()
             }
 
-            // --- Share ratio mutations ---
+            // --- Multiplier mutations ---
             SC::updateMultiplier(c) => {
                 self.update_multiplier(caller, c.newMultiplier, privileged)?;
                 Bytes::new()
@@ -373,9 +372,9 @@ impl<S: AssetAccounting, P: Policy> B20AssetToken<S, P> {
                 Bytes::new()
             }
 
-            // --- Asset identifier mutations ---
+            // --- Extra metadata mutations ---
             SC::updateExtraMetadata(c) => {
-                self.update_extra_metadata(caller, c.identifierType, c.value, privileged)?;
+                self.update_extra_metadata(caller, c.key, c.value, privileged)?;
                 Bytes::new()
             }
         };
@@ -454,7 +453,7 @@ mod tests {
     const ACTIVATION_ADMIN: Address = Address::repeat_byte(0xcb);
     fn make_token() -> TestAssetToken {
         let mut accounting = InMemoryTokenAccounting::new(TOKEN);
-        accounting.multiplier = B20AssetStorage::WAD; // 1:1 ratio
+        accounting.multiplier = B20AssetStorage::WAD; // 1:1 multiplier
         TestAssetToken::with_storage_and_policy(accounting, InMemoryPolicy::new())
     }
 
@@ -484,13 +483,13 @@ mod tests {
     }
 
     #[test]
-    fn to_scaled_balance_one_to_one_ratio() {
+    fn to_scaled_balance_one_to_one_multiplier() {
         let token = make_token();
         assert_eq!(token.to_scaled_balance(U256::from(100u64)).unwrap(), U256::from(100u64));
     }
 
     #[test]
-    fn to_scaled_balance_two_to_one_ratio() {
+    fn to_scaled_balance_two_to_one_multiplier() {
         let mut accounting = InMemoryTokenAccounting::new(TOKEN);
         accounting.multiplier = B20AssetStorage::WAD * U256::from(2u64);
         let token = TestAssetToken::with_storage_and_policy(accounting, InMemoryPolicy::new());
@@ -624,17 +623,17 @@ mod tests {
     }
 
     #[test]
-    fn to_scaled_balance_sub_wad_ratio_truncates_to_zero() {
+    fn to_scaled_balance_sub_wad_multiplier_truncates_to_zero() {
         let mut accounting = InMemoryTokenAccounting::new(TOKEN);
-        // 0.5 WAD: 1 token → 0.5 shares → truncates to 0 via integer division
+        // 0.5 WAD: 1 token → 0.5 scaled → truncates to 0 via integer division
         accounting.multiplier = B20AssetStorage::WAD / U256::from(2u64);
         let token = TestAssetToken::with_storage_and_policy(accounting, InMemoryPolicy::new());
         assert_eq!(token.to_scaled_balance(U256::from(1u64)).unwrap(), U256::ZERO);
     }
 
     #[test]
-    fn shares_of_derives_from_balance() {
-        let mut token = make_token(); // 1:1 ratio
+    fn scaled_balance_of_derives_from_balance() {
+        let mut token = make_token(); // 1:1 multiplier
         token.accounting_mut().balances.insert(ALICE, U256::from(75u64));
         // scaledBalanceOf(account) = toScaledBalance(balanceOf(account))
         let balance = token.accounting().balance_of(ALICE).unwrap();
@@ -646,9 +645,9 @@ mod tests {
     #[test]
     fn multiplier_update_persists() {
         let mut token = make_token();
-        let new_ratio = B20AssetStorage::WAD * U256::from(3u64);
-        token.accounting_mut().set_multiplier(new_ratio).unwrap();
-        assert_eq!(token.accounting().multiplier().unwrap(), new_ratio);
+        let new_multiplier = B20AssetStorage::WAD * U256::from(3u64);
+        token.accounting_mut().set_multiplier(new_multiplier).unwrap();
+        assert_eq!(token.accounting().multiplier().unwrap(), new_multiplier);
     }
 
     // --- extraMetadata / updateExtraMetadata ---
@@ -688,7 +687,7 @@ mod tests {
     #[test]
     fn to_scaled_balance_overflows_when_product_exceeds_u256_max() {
         let mut accounting = InMemoryTokenAccounting::new(TOKEN);
-        // Any balance > 1 overflows when multiplied by this ratio.
+        // Any balance > 1 overflows when multiplied by this multiplier.
         accounting.multiplier = U256::MAX / U256::from(2u64) + U256::ONE;
         let token = TestAssetToken::with_storage_and_policy(accounting, InMemoryPolicy::new());
 

--- a/crates/common/precompiles/src/b20_asset/storage.rs
+++ b/crates/common/precompiles/src/b20_asset/storage.rs
@@ -22,7 +22,7 @@ pub struct B20AssetExtensionStorage {
     /// Announcement IDs that have already been consumed.
     pub used_announcement_ids: Mapping<String, bool>, // slot 2
     /// Extra metadata values by metadata key.
-    pub identifiers: Mapping<String, String>, // slot 3
+    pub extra_metadata: Mapping<String, String>, // slot 3
 }
 
 /// EVM-backed storage for an asset B-20 token.
@@ -44,9 +44,9 @@ pub struct B20AssetInit {
     pub symbol: String,
     /// Maximum total supply.
     pub supply_cap: U256,
-    /// Share-to-token conversion ratio at WAD precision.
+    /// Multiplier at WAD precision.
     pub multiplier: U256,
-    /// Custom decimal precision for this token; must be in `[6, 18]`.
+    /// Custom decimal precision for this token; range is validated by the factory.
     pub decimals: u8,
 }
 
@@ -126,7 +126,7 @@ mod tests {
             __packing_b20_asset_extension_storage::USED_ANNOUNCEMENT_IDS_LOC.offset_slots,
             2
         );
-        assert_eq!(__packing_b20_asset_extension_storage::IDENTIFIERS_LOC.offset_slots, 3);
+        assert_eq!(__packing_b20_asset_extension_storage::EXTRA_METADATA_LOC.offset_slots, 3);
     }
 
     #[test]
@@ -135,10 +135,10 @@ mod tests {
 
         StorageCtx::enter(&mut storage, |ctx| {
             let token = B20AssetStorage::from_address(TOKEN, ctx);
-            let ratio_slot = ASSET_ROOT
+            let multiplier_slot = ASSET_ROOT
                 + U256::from(__packing_b20_asset_extension_storage::MULTIPLIER_LOC.offset_slots);
 
-            assert_eq!(ctx.sload(TOKEN, ratio_slot).unwrap(), U256::ZERO);
+            assert_eq!(ctx.sload(TOKEN, multiplier_slot).unwrap(), U256::ZERO);
             assert_eq!(token.multiplier().unwrap(), B20AssetStorage::WAD);
         });
     }
@@ -146,17 +146,17 @@ mod tests {
     #[test]
     fn multiplier_preserves_configured_value() {
         let (mut storage, _) = setup_storage();
-        let configured_ratio = B20AssetStorage::WAD * U256::from(3u64);
+        let configured_multiplier = B20AssetStorage::WAD * U256::from(3u64);
 
         StorageCtx::enter(&mut storage, |ctx| {
             let mut token = B20AssetStorage::from_address(TOKEN, ctx);
-            token.set_multiplier(configured_ratio).unwrap();
+            token.set_multiplier(configured_multiplier).unwrap();
 
-            let ratio_slot = ASSET_ROOT
+            let multiplier_slot = ASSET_ROOT
                 + U256::from(__packing_b20_asset_extension_storage::MULTIPLIER_LOC.offset_slots);
 
-            assert_eq!(ctx.sload(TOKEN, ratio_slot).unwrap(), configured_ratio);
-            assert_eq!(token.multiplier().unwrap(), configured_ratio);
+            assert_eq!(ctx.sload(TOKEN, multiplier_slot).unwrap(), configured_multiplier);
+            assert_eq!(token.multiplier().unwrap(), configured_multiplier);
         });
     }
 
@@ -170,14 +170,16 @@ mod tests {
         StorageCtx::enter(&mut storage, |ctx| {
             let mut token = B20AssetStorage::from_address(TOKEN, ctx);
             token.asset.used_announcement_ids.at_mut(&announcement_id).write(true).unwrap();
-            token.asset.identifiers.at_mut(&metadata_key).write(metadata_value.clone()).unwrap();
+            token.asset.extra_metadata.at_mut(&metadata_key).write(metadata_value.clone()).unwrap();
 
             let announcement_slot = ASSET_ROOT
                 + U256::from(
                     __packing_b20_asset_extension_storage::USED_ANNOUNCEMENT_IDS_LOC.offset_slots,
                 );
             let metadata_slot = ASSET_ROOT
-                + U256::from(__packing_b20_asset_extension_storage::IDENTIFIERS_LOC.offset_slots);
+                + U256::from(
+                    __packing_b20_asset_extension_storage::EXTRA_METADATA_LOC.offset_slots,
+                );
 
             assert_eq!(
                 ctx.sload(TOKEN, announcement_id.mapping_slot(announcement_slot)).unwrap(),

--- a/crates/common/precompiles/src/b20_asset/token.rs
+++ b/crates/common/precompiles/src/b20_asset/token.rs
@@ -16,8 +16,8 @@ use crate::{
 /// EVM precompile for the asset B-20 variant.
 ///
 /// Mirrors the structure of [`crate::B20Token`] but requires `S: AssetAccounting`
-/// so the dispatch layer can read and write asset-specific storage (share ratio,
-/// asset identifiers, announcement IDs). The `in_announcement` flag guards against
+/// so the dispatch layer can read and write asset-specific storage (multiplier,
+/// extra metadata, announcement IDs). The `in_announcement` flag guards against
 /// recursive `announce` calls within a single precompile invocation.
 #[derive(Debug, Clone)]
 pub struct B20AssetToken<S: AssetAccounting, P: Policy> {
@@ -181,62 +181,62 @@ impl<S: AssetAccounting, P: Policy> B20AssetToken<S, P> {
         )
     }
 
-    // --- Share Ratio Operations ---
+    // --- Multiplier Operations ---
 
-    /// Converts a token balance to shares: `balance * multiplier / WAD`.
+    /// Converts a raw balance to its scaled view: `rawBalance * multiplier / WAD`.
     pub fn to_scaled_balance(&self, balance: U256) -> Result<U256> {
-        let ratio = self.accounting().multiplier()?;
-        let product = balance.checked_mul(ratio).ok_or_else(BasePrecompileError::under_overflow)?;
+        let multiplier = self.accounting().multiplier()?;
+        let product =
+            balance.checked_mul(multiplier).ok_or_else(BasePrecompileError::under_overflow)?;
         Ok(product / B20AssetStorage::WAD)
     }
 
-    /// Converts a scaled balance back to its raw representation: `scaled * WAD / multiplier`.
+    /// Converts a scaled balance back to its raw representation: `scaledBalance * WAD / multiplier`.
     pub fn to_raw_balance(&self, balance: U256) -> Result<U256> {
-        let ratio = self.accounting().multiplier()?;
+        let multiplier = self.accounting().multiplier()?;
         let product = balance
             .checked_mul(B20AssetStorage::WAD)
             .ok_or_else(BasePrecompileError::under_overflow)?;
-        Ok(product / ratio)
+        Ok(product / multiplier)
     }
 
-    /// Returns the shares for an account (balance converted to shares).
+    /// Returns the scaled balance for an account.
     pub fn scaled_balance_of(&self, account: Address) -> Result<U256> {
         let balance = self.accounting().balance_of(account)?;
         self.to_scaled_balance(balance)
     }
 
-    /// Updates the share-to-tokens ratio.
+    /// Sets a new multiplier.
     pub fn update_multiplier(
         &mut self,
         caller: Address,
-        new_ratio: U256,
+        new_multiplier: U256,
         privileged: bool,
     ) -> Result<()> {
         self.ensure_operator_role(caller, privileged)?;
-        self.accounting_mut().set_multiplier(new_ratio)?;
-        self.accounting_mut()
-            .emit_event(IB20Asset::MultiplierUpdated { multiplier: new_ratio }.encode_log_data())
+        self.accounting_mut().set_multiplier(new_multiplier)?;
+        self.accounting_mut().emit_event(
+            IB20Asset::MultiplierUpdated { multiplier: new_multiplier }.encode_log_data(),
+        )
     }
 
-    // --- Asset Identifier Operations ---
+    // --- Extra Metadata Operations ---
 
-    /// Updates a asset identifier value.
+    /// Sets, updates, or removes an extra-metadata entry.
     pub fn update_extra_metadata(
         &mut self,
         caller: Address,
-        identifier_type: String,
+        key: String,
         value: String,
         privileged: bool,
     ) -> Result<()> {
         self.ensure_metadata_role(caller, privileged)?;
-        if identifier_type.is_empty() {
+        if key.is_empty() {
             return Err(BasePrecompileError::revert(IB20Asset::InvalidMetadataKey {}));
         }
-        self.accounting_mut().set_extra_metadata_value(identifier_type.as_str(), value.clone())?;
-        self.accounting_mut().emit_event(
-            IB20Asset::ExtraMetadataUpdated { identifierType: identifier_type, value }
-                .encode_log_data(),
-        )
+        self.accounting_mut().set_extra_metadata_value(key.as_str(), value.clone())?;
+        self.accounting_mut()
+            .emit_event(IB20Asset::ExtraMetadataUpdated { key, value }.encode_log_data())
     }
 
     // --- Batch Operations ---

--- a/crates/common/precompiles/src/common/test_utils.rs
+++ b/crates/common/precompiles/src/common/test_utils.rs
@@ -61,9 +61,9 @@ pub struct InMemoryTokenAccounting {
     pub role_admins: HashMap<B256, B256>,
     /// Policy IDs keyed by policy type.
     pub policy_ids: HashMap<B256, u64>,
-    /// Share-to-tokens ratio scaled to WAD (1e18). Asset tokens only.
+    /// Multiplier scaled to WAD (1e18). Asset tokens only.
     pub multiplier: U256,
-    /// Asset identifier values keyed by raw `identifier_type`. Asset tokens only.
+    /// Extra-metadata values keyed by raw metadata `key`. Asset tokens only.
     pub extra_metadata: HashMap<String, String>,
     /// Consumed announcement ids keyed by raw announcement id. Asset tokens only.
     pub announcement_ids_used: HashSet<String>,
@@ -385,15 +385,15 @@ impl AssetAccounting for InMemoryTokenAccounting {
         Ok(())
     }
 
-    fn extra_metadata(&self, identifier_type: &str) -> Result<String> {
-        Ok(self.extra_metadata.get(identifier_type).cloned().unwrap_or_default())
+    fn extra_metadata(&self, key: &str) -> Result<String> {
+        Ok(self.extra_metadata.get(key).cloned().unwrap_or_default())
     }
 
-    fn set_extra_metadata_value(&mut self, identifier_type: &str, value: String) -> Result<()> {
+    fn set_extra_metadata_value(&mut self, key: &str, value: String) -> Result<()> {
         if value.is_empty() {
-            self.extra_metadata.remove(identifier_type);
+            self.extra_metadata.remove(key);
         } else {
-            self.extra_metadata.insert(identifier_type.to_owned(), value);
+            self.extra_metadata.insert(key.to_owned(), value);
         }
         Ok(())
     }

--- a/crates/infra/load-tests/src/runner/load_runner.rs
+++ b/crates/infra/load-tests/src/runner/load_runner.rs
@@ -988,7 +988,7 @@ impl LoadRunner {
         if token_address.is_none() {
             // Activate B-20 features if not already active. Activation is idempotent on
             // already-active features but reverts if the funder is not the activation admin.
-            let features = [ActivationFeature::B20Factory.id(), ActivationFeature::B20Token.id()];
+            let features = [ActivationFeature::B20Asset.id()];
             for feature in &features {
                 let is_activated_call = IActivationRegistry::isActivatedCall { feature: *feature };
                 let check_result = self
@@ -1047,20 +1047,21 @@ impl LoadRunner {
             info!("creating new B-20 token via factory");
 
             let salt = B256::from(rand::random::<[u8; 32]>());
-            let predicted = B20Variant::B20.compute_address(funder_address, salt).0;
+            let predicted = B20Variant::Asset.compute_address(funder_address, salt).0;
 
-            let params = IB20Factory::B20CreateParams {
-                version: 1,
+            let params = IB20Factory::B20AssetCreateParams {
+                version: B20Variant::Asset.supported_version(),
                 name: "Load Test B20".to_string(),
                 symbol: "LTB20".to_string(),
                 initialAdmin: funder_address,
+                decimals: 6,
             };
 
             let init_calls: Vec<Bytes> =
                 vec![IB20::updateSupplyCapCall { newSupplyCap: U256::MAX }.abi_encode().into()];
 
             let create_call = IB20Factory::createB20Call {
-                variant: IB20Factory::B20Variant::DEFAULT,
+                variant: IB20Factory::B20Variant::ASSET,
                 salt,
                 params: params.abi_encode().into(),
                 initCalls: init_calls,


### PR DESCRIPTION
## Summary

Naming-consistency follow-ups from an audit of the **B20 asset precompile** (`crates/common/precompiles/src/b20_asset/`) against the canonical base-std `IB20Asset` interface. **No functional/ABI behavior changes** — selectors and event topics are unchanged (Solidity parameter names are not part of signatures).

## Changes

1. **Align extra-metadata naming with base-std (`key`)** — renamed the metadata key parameter `identifierType`/`identifier_type` → `key` across the `sol!` ABI, dispatch, token logic, the `AssetAccounting` trait, and the test mock. Renamed the storage field `identifiers` → `extra_metadata` (which required updating the hardcoded references in the shared `#[derive(AssetAccounting)]` macro and the generated packing constant `IDENTIFIERS_LOC` → `EXTRA_METADATA_LOC`).
2. **Remove redundant `METADATA_ROLE()` getter** from the `IB20Asset` interface — it is inherited from `IB20` and already dispatched there; the asset-side re-declaration was an anomaly (the stablecoin variant does not re-declare inherited getters).
3. **Normalize multiplier vocabulary** — internal "share ratio"/"shares" comments and locals → "multiplier"/"scaled"/"raw" to match the ABI and spec (wstETH-style). Fixed the `B20AssetInit.decimals` doc to note the range is factory-validated.

## Why

base-std `IB20Asset.sol` is the source of truth and consistently uses `key`, declares `METADATA_ROLE()` only on `IB20`, and uses multiplier/scaled/raw vocabulary. This brings the Rust precompile into naming parity.

## Verification

- `cargo check -p base-common-precompiles -p base-precompile-macros` ✅
- `cargo test -p base-common-precompiles` ✅ **344 passed, 0 failed**
- No residual `identifierType`/`identifier_type`/`.identifiers`/`IDENTIFIERS_LOC` references remain in `base/crates`.

## Notes

Branched off latest `main` (`64024c4cf`). This is a naming-only refactor; a separate test-coverage gap (P14 — no selector-coverage / static-call / authorization / event-emission tests for the asset-only selectors) was identified in the audit but is intentionally **out of scope** for this PR.