### PR TITLE
feat(eip-8130): gate account-abstraction txs behind the Cobalt upgrade

### DIFF
--- a/crates/consensus/protocol/src/batch/single.rs
+++ b/crates/consensus/protocol/src/batch/single.rs
@@ -179,6 +179,12 @@ impl SingleBatch {
             {
                 return BatchValidity::Drop(BatchDropReason::Eip7702PreIsthmus);
             }
+            // If cobalt is not active yet and the transaction is an 8130, drop the batch.
+            if !cfg.is_cobalt_active(self.timestamp)
+                && tx.as_ref().first() == Some(&(OpTxType::Eip8130 as u8))
+            {
+                return BatchValidity::Drop(BatchDropReason::Eip8130PreCobalt);
+            }
         }
 
         BatchValidity::Accept
@@ -191,10 +197,10 @@ mod tests {
 
     use alloy_consensus::{SignableTransaction, TxEip1559, TxEip7702, TxEnvelope};
     use alloy_eips::eip2718::{Decodable2718, Encodable2718};
-    use alloy_primitives::{Address, Sealed, Signature, TxKind, U256};
+    use alloy_primitives::{Address, Bytes, Sealed, Signature, TxKind, U256};
     use alloy_rlp::{Decodable, Encodable};
     use base_common_consensus::{BaseTxEnvelope, TxDeposit};
-    use base_common_genesis::HardForkConfig;
+    use base_common_genesis::{HardForkConfig, HardforkConfig};
     use tracing::Level;
 
     use super::*;
@@ -508,6 +514,74 @@ mod tests {
         let cfg = RollupConfig {
             max_sequencer_drift: 1,
             hardforks: HardForkConfig { isthmus_time: Some(0), ..Default::default() },
+            ..Default::default()
+        };
+        let l1_blocks = vec![BlockInfo::default(), BlockInfo::default()];
+        let l2_safe_head = L2BlockInfo {
+            block_info: BlockInfo { timestamp: 1, ..Default::default() },
+            ..Default::default()
+        };
+        let inclusion_block = BlockInfo::default();
+        assert_eq!(
+            single_batch.check_batch(&cfg, &l1_blocks, l2_safe_head, &inclusion_block),
+            BatchValidity::Accept
+        );
+    }
+
+    /// Minimal batch tx bytes whose leading 2718 type byte marks an EIP-8130
+    /// transaction. Batch validation keys the Cobalt gate on this type byte, so
+    /// a fully formed envelope is unnecessary here.
+    fn eip_8130_tx_bytes() -> Bytes {
+        Bytes::from(vec![OpTxType::Eip8130 as u8, 0x00])
+    }
+
+    #[test]
+    fn test_check_batch_drop_8130_pre_cobalt() {
+        let mut transactions = example_transactions();
+        transactions.push(eip_8130_tx_bytes());
+
+        let single_batch = SingleBatch {
+            parent_hash: BlockHash::ZERO,
+            epoch_num: 1,
+            epoch_hash: BlockHash::ZERO,
+            timestamp: 1,
+            transactions,
+        };
+
+        // Notice: Cobalt is _not_ active yet.
+        let cfg = RollupConfig { max_sequencer_drift: 1, ..Default::default() };
+        let l1_blocks = vec![BlockInfo::default(), BlockInfo::default()];
+        let l2_safe_head = L2BlockInfo {
+            block_info: BlockInfo { timestamp: 1, ..Default::default() },
+            ..Default::default()
+        };
+        let inclusion_block = BlockInfo::default();
+        assert_eq!(
+            single_batch.check_batch(&cfg, &l1_blocks, l2_safe_head, &inclusion_block),
+            BatchValidity::Drop(BatchDropReason::Eip8130PreCobalt)
+        );
+    }
+
+    #[test]
+    fn test_check_batch_accept_8130_post_cobalt() {
+        let mut transactions = example_transactions();
+        transactions.push(eip_8130_tx_bytes());
+
+        let single_batch = SingleBatch {
+            parent_hash: BlockHash::ZERO,
+            epoch_num: 1,
+            epoch_hash: BlockHash::ZERO,
+            timestamp: 1,
+            transactions,
+        };
+
+        // Notice: Cobalt is active.
+        let cfg = RollupConfig {
+            max_sequencer_drift: 1,
+            hardforks: HardForkConfig {
+                base: HardforkConfig { cobalt: Some(0), ..Default::default() },
+                ..Default::default()
+            },
             ..Default::default()
         };
         let l1_blocks = vec![BlockInfo::default(), BlockInfo::default()];

--- a/crates/consensus/protocol/src/batch/span.rs
+++ b/crates/consensus/protocol/src/batch/span.rs
@@ -514,6 +514,14 @@ impl SpanBatch {
                     warn!(target: "batch_span", tx_index = i, "EIP-7702 transactions are not supported pre-isthmus");
                     return BatchValidity::Drop(BatchDropReason::Eip7702PreIsthmus);
                 }
+
+                // If cobalt is not active yet and the transaction is an 8130, drop the batch.
+                if !cfg.is_cobalt_active(batch.timestamp)
+                    && tx.as_ref().first() == Some(&(OpTxType::Eip8130 as u8))
+                {
+                    warn!(target: "batch_span", tx_index = i, "EIP-8130 transactions are not supported pre-cobalt");
+                    return BatchValidity::Drop(BatchDropReason::Eip8130PreCobalt);
+                }
             }
         }
 
@@ -758,7 +766,7 @@ mod tests {
     use alloy_eips::BlockNumHash;
     use alloy_primitives::{B256, Bytes, b256};
     use base_common_consensus::BaseBlock;
-    use base_common_genesis::{ChainGenesis, HardForkConfig};
+    use base_common_genesis::{ChainGenesis, HardForkConfig, HardforkConfig};
     use tracing::Level;
 
     use super::*;
@@ -1971,6 +1979,130 @@ mod tests {
             logs[0].contains("EIP-7702 transactions are not supported pre-isthmus")
                 && logs[0].contains("tx_index")
                 && logs[0].contains('0')
+        );
+    }
+
+    #[tokio::test]
+    async fn test_check_batch_with_eip8130_tx() {
+        let (trace_store, _guard) = crate::capture_traces!();
+
+        let cfg = RollupConfig {
+            seq_window_size: 100,
+            max_sequencer_drift: 100,
+            hardforks: HardForkConfig { delta_time: Some(0), ..Default::default() },
+            block_time: 10,
+            ..Default::default()
+        };
+        let l1_blocks = gen_l1_blocks(9, 3, 0, 10);
+        let parent_hash = b256!("1111111111111111111111111111111111111111000000000000000000000000");
+        let l2_safe_head = L2BlockInfo {
+            block_info: BlockInfo {
+                number: 41,
+                timestamp: 10,
+                hash: parent_hash,
+                ..Default::default()
+            },
+            l1_origin: BlockNumHash { number: 9, ..Default::default() },
+            ..Default::default()
+        };
+        let inclusion_block = BlockInfo { number: 50, ..Default::default() };
+        let l2_block = L2BlockInfo {
+            block_info: BlockInfo { number: 40, ..Default::default() },
+            ..Default::default()
+        };
+        let mut fetcher: TestBatchValidator =
+            TestBatchValidator { blocks: vec![l2_block], ..Default::default() };
+        let filler_bytes = Bytes::copy_from_slice(&[EIP1559_TX_TYPE_ID]);
+        let first = SpanBatchElement {
+            epoch_num: 10,
+            timestamp: 20,
+            transactions: vec![filler_bytes.clone()],
+        };
+        let second = SpanBatchElement {
+            epoch_num: 10,
+            timestamp: 20,
+            transactions: vec![Bytes::copy_from_slice(&[OpTxType::Eip8130 as u8])],
+        };
+        let third =
+            SpanBatchElement { epoch_num: 11, timestamp: 20, transactions: vec![filler_bytes] };
+        let batch = SpanBatch {
+            batches: vec![first, second, third],
+            parent_check: FixedBytes::<20>::from_slice(&parent_hash[..20]),
+            l1_origin_check: FixedBytes::<20>::from_slice(&l1_blocks[0].hash[..20]),
+            txs: SpanBatchTransactions::default(),
+            ..Default::default()
+        };
+        assert_eq!(
+            batch.check_batch(&cfg, &l1_blocks, l2_safe_head, &inclusion_block, &mut fetcher).await,
+            BatchValidity::Drop(BatchDropReason::Eip8130PreCobalt)
+        );
+        let logs = trace_store.get_by_level(Level::WARN);
+        assert_eq!(logs.len(), 1);
+        assert!(
+            logs[0].contains("EIP-8130 transactions are not supported pre-cobalt")
+                && logs[0].contains("tx_index")
+                && logs[0].contains('0')
+        );
+    }
+
+    #[tokio::test]
+    async fn test_check_batch_accept_eip8130_post_cobalt() {
+        // Mirror of `test_check_batch_with_eip8130_tx` with Cobalt active: the same
+        // span batch carrying an EIP-8130 transaction is accepted once the fork gate
+        // opens, exercising the post-Cobalt side for symmetry with the single-batch tests.
+        let cfg = RollupConfig {
+            seq_window_size: 100,
+            max_sequencer_drift: 100,
+            hardforks: HardForkConfig {
+                delta_time: Some(0),
+                base: HardforkConfig { cobalt: Some(0), ..Default::default() },
+                ..Default::default()
+            },
+            block_time: 10,
+            ..Default::default()
+        };
+        let l1_blocks = gen_l1_blocks(9, 3, 0, 10);
+        let parent_hash = b256!("1111111111111111111111111111111111111111000000000000000000000000");
+        let l2_safe_head = L2BlockInfo {
+            block_info: BlockInfo {
+                number: 41,
+                timestamp: 10,
+                hash: parent_hash,
+                ..Default::default()
+            },
+            l1_origin: BlockNumHash { number: 9, ..Default::default() },
+            ..Default::default()
+        };
+        let inclusion_block = BlockInfo { number: 50, ..Default::default() };
+        let l2_block = L2BlockInfo {
+            block_info: BlockInfo { number: 40, ..Default::default() },
+            ..Default::default()
+        };
+        let mut fetcher: TestBatchValidator =
+            TestBatchValidator { blocks: vec![l2_block], ..Default::default() };
+        let filler_bytes = Bytes::copy_from_slice(&[EIP1559_TX_TYPE_ID]);
+        let first = SpanBatchElement {
+            epoch_num: 10,
+            timestamp: 20,
+            transactions: vec![filler_bytes.clone()],
+        };
+        let second = SpanBatchElement {
+            epoch_num: 10,
+            timestamp: 20,
+            transactions: vec![Bytes::copy_from_slice(&[OpTxType::Eip8130 as u8])],
+        };
+        let third =
+            SpanBatchElement { epoch_num: 11, timestamp: 20, transactions: vec![filler_bytes] };
+        let batch = SpanBatch {
+            batches: vec![first, second, third],
+            parent_check: FixedBytes::<20>::from_slice(&parent_hash[..20]),
+            l1_origin_check: FixedBytes::<20>::from_slice(&l1_blocks[0].hash[..20]),
+            txs: SpanBatchTransactions::default(),
+            ..Default::default()
+        };
+        assert_eq!(
+            batch.check_batch(&cfg, &l1_blocks, l2_safe_head, &inclusion_block, &mut fetcher).await,
+            BatchValidity::Accept
         );
     }
 

--- a/crates/consensus/protocol/src/batch/validity.rs
+++ b/crates/consensus/protocol/src/batch/validity.rs
@@ -42,6 +42,8 @@ pub enum BatchDropReason {
     DepositTransaction,
     /// EIP-7702 transaction included before Isthmus activation.
     Eip7702PreIsthmus,
+    /// EIP-8130 transaction included before Cobalt activation.
+    Eip8130PreCobalt,
     /// Non-empty batch in Jovian transition block.
     NonEmptyTransitionBlock,
 
@@ -93,6 +95,7 @@ impl core::fmt::Display for BatchDropReason {
             Self::EmptyTransaction => write!(f, "batch contains empty transaction"),
             Self::DepositTransaction => write!(f, "batch contains deposit transaction"),
             Self::Eip7702PreIsthmus => write!(f, "EIP-7702 transaction before Isthmus activation"),
+            Self::Eip8130PreCobalt => write!(f, "EIP-8130 transaction before Cobalt activation"),
             Self::NonEmptyTransitionBlock => write!(f, "non-empty batch in transition block"),
             Self::SpanBatchPreDelta => write!(f, "span batch received before Delta hard fork"),
             Self::SpanBatchNoNewBlocksPreHolocene => {

--- a/crates/execution/chainspec/src/builder.rs
+++ b/crates/execution/chainspec/src/builder.rs
@@ -152,6 +152,13 @@ impl BaseChainSpecBuilder {
         self
     }
 
+    /// Enable Cobalt at genesis.
+    pub fn cobalt_activated(mut self) -> Self {
+        self = self.beryl_activated();
+        self.inner = self.inner.with_fork(BaseUpgrade::Cobalt, ForkCondition::Timestamp(0));
+        self
+    }
+
     /// Tries to build the resulting [`BaseChainSpec`].
     ///
     /// # Panics

--- a/crates/execution/txpool/src/validator.rs
+++ b/crates/execution/txpool/src/validator.rs
@@ -189,10 +189,10 @@ where
     /// This behaves the same as [`EthTransactionValidator::validate_one_with_state`], but in
     /// addition applies Base-specific validity checks:
     /// - ensures tx is not eip4844
-    /// - for eip8130 (account abstraction): rejects local-origin submissions and enforces the
-    ///   structural admission gate from [`Self::validate_eip8130_structural`] before the inner
-    ///   Eth checks; authenticator dispatch, account state lookups, and fork gating are not yet
-    ///   performed
+    /// - for eip8130 (account abstraction): rejects submissions before the Cobalt upgrade is
+    ///   active, rejects local-origin submissions, and enforces the structural admission gate
+    ///   from [`Self::validate_eip8130_structural`] before the inner Eth checks; authenticator
+    ///   dispatch and account state lookups are not yet performed
     /// - ensures that the account has enough balance to cover the L1 gas cost
     pub async fn validate_one_with_state(
         &self,
@@ -217,9 +217,9 @@ where
     }
 
     /// Runs the mempool admission checks that apply to EIP-8130 (account
-    /// abstraction) transactions without requiring authenticator dispatch, account
-    /// state lookups, or fork activation. Mirrors the structural invariants
-    /// listed in EIP-8130 § Validation and § Nonce-Free Mode.
+    /// abstraction) transactions without requiring authenticator dispatch or account
+    /// state lookups. Enforces the Cobalt fork gate and the structural
+    /// invariants listed in EIP-8130 § Validation and § Nonce-Free Mode.
     fn validate_eip8130_structural(
         &self,
         origin: TransactionOrigin,
@@ -228,12 +228,17 @@ where
         if !origin.is_external() {
             return Err(InvalidTransactionError::TxTypeNotSupported.into());
         }
+        // Single read of the head-block timestamp so the fork gate and the
+        // expiry check see the same value even when `on_new_head_block` updates
+        // the atomic concurrently.
+        let now = self.block_timestamp();
+        // Fork gate: EIP-8130 (account abstraction) transactions are only
+        // admissible to the pool once the Cobalt upgrade is active.
+        if !self.chain_spec().is_cobalt_active_at_timestamp(now) {
+            return Err(InvalidTransactionError::TxTypeNotSupported.into());
+        }
         let local_chain_id = self.inner.chain_spec().chain().id();
         signed.validate_static(local_chain_id).map_err(InvalidPoolTransactionError::from)?;
-        // Single read of the head-block timestamp so both branches see the
-        // same value even when `on_new_head_block` updates the atomic
-        // concurrently.
-        let now = self.block_timestamp();
         signed.validate_timestamp(now).map_err(InvalidPoolTransactionError::from)?;
         Self::validate_sender_auth(signed)?;
         Self::validate_payer_auth(signed)?;
@@ -504,7 +509,7 @@ mod tests {
         BaseTxEnvelope, ConfigChange, CreateEntry, Delegation, Eip8130Constants, Eip8130Signed,
         InitialActor, Scope, TxDeposit, TxEip8130,
     };
-    use base_execution_chainspec::BaseChainSpec;
+    use base_execution_chainspec::{BaseChainSpec, BaseChainSpecBuilder};
     use base_execution_evm::BaseEvmConfig;
     use base_test_utils::Account;
     use reth_provider::test_utils::{ExtendedAccount, MockEthProvider};
@@ -522,11 +527,9 @@ mod tests {
         BaseEvmConfig,
     >;
 
-    /// Builds a [`BaseTransactionValidator`] configured against the mainnet chain spec with
-    /// no accounts seeded. Suitable for tests that exercise the EIP-8130 structural-acceptance
-    /// gate, which rejects without touching account state.
-    fn build_test_validator() -> TestValidator {
-        let chain_spec = Arc::new(BaseChainSpec::mainnet());
+    /// Builds a [`BaseTransactionValidator`] configured against the given chain spec with
+    /// no accounts seeded.
+    fn build_test_validator_with_spec(chain_spec: Arc<BaseChainSpec>) -> TestValidator {
         let client = MockEthProvider::<BasePrimitives>::new()
             .with_chain_spec(Arc::clone(&chain_spec))
             .with_genesis_block();
@@ -536,6 +539,14 @@ mod tests {
             .no_cancun()
             .build(InMemoryBlobStore::default());
         BaseTransactionValidator::with_block_info(inner, BaseL1BlockInfo::default())
+    }
+
+    /// Builds a [`BaseTransactionValidator`] against a Cobalt-activated mainnet chain spec with
+    /// no accounts seeded. EIP-8130 admission is fork-gated on Cobalt, so the structural-gate
+    /// tests run with Cobalt active (at genesis) to exercise the checks past the fork gate.
+    fn build_test_validator() -> TestValidator {
+        let chain_spec = Arc::new(BaseChainSpecBuilder::base_mainnet().cobalt_activated().build());
+        build_test_validator_with_spec(chain_spec)
     }
 
     /// Returns the chain id the [`build_test_validator`] is configured against.
@@ -609,6 +620,17 @@ mod tests {
         let signed = sign_eoa_eip8130(minimal_valid_eoa_tx());
         assert!(
             validator.validate_eip8130_structural(TransactionOrigin::External, &signed).is_ok()
+        );
+    }
+
+    #[test]
+    fn rejects_eip8130_before_cobalt_activation() {
+        // Mainnet leaves Cobalt unscheduled, so the fork gate rejects an otherwise
+        // structurally valid EIP-8130 transaction regardless of its contents.
+        let validator = build_test_validator_with_spec(Arc::new(BaseChainSpec::mainnet()));
+        let signed = sign_eoa_eip8130(minimal_valid_eoa_tx());
+        assert_unsupported(
+            validator.validate_eip8130_structural(TransactionOrigin::External, &signed),
         );
     }
 


### PR DESCRIPTION
## Summary

Fork-gates EIP-8130 (account abstraction) admission on the **Cobalt** upgrade. Before Cobalt is active, no AA transaction can enter the mempool and no AA transaction can be included in a block; once Cobalt activates, the existing behavior resumes. Cobalt is unscheduled on every network, so this is a no-op today and purely sets up the gate.

Both gates reuse the established fork-gating patterns:

* **Mempool gate** (`crates/execution/txpool/src/validator.rs`): `validate_eip8130_structural` rejects with `TxTypeNotSupported` unless `chain_spec.is_cobalt_active_at_timestamp(head_timestamp)`. Mirrors the existing Jovian DA-footprint check.
* **Block gate** (`crates/consensus/protocol/src/batch/{single,span}.rs`): batch derivation drops any batch containing an EIP-8130 transaction before Cobalt, via `BatchDropReason::Eip8130PreCobalt` (mirrors `Eip7702PreIsthmus`).
* Adds a `cobalt_activated()` chain-spec builder helper.

### Review follow-ups addressed
* Removed the duplicate `accepts_eip8130_once_cobalt_active` test; the Cobalt-active `build_test_validator` acceptance test plus `rejects_eip8130_before_cobalt_activation` cover both sides of the gate.
* Added `test_check_batch_accept_eip8130_post_cobalt` to the span-batch tests for symmetry with the single-batch acceptance test.

### Out of scope / follow-ups
* RPC ingress still rejects the AA type byte unconditionally (correct pre-Cobalt). Making it Cobalt-conditional belongs with the post-Cobalt acceptance + EVM execution work.

## Test plan
* `cargo test -p base-execution-txpool --lib` — 80 passed (incl. `rejects_eip8130_before_cobalt_activation`).
* `cargo test -p base-protocol --lib batch` — 111 passed (incl. new single + span pre/post-Cobalt drop/accept tests).
* `cargo fmt`, `cargo clippy` — clean.