### PR TITLE
chore: support running devnet without Succinct ELFs

### DIFF
--- a/etc/docker/Dockerfile.rust-services
+++ b/etc/docker/Dockerfile.rust-services
@@ -131,10 +131,11 @@ COPY . .
 
 FROM zk-source AS zk-prover-builder
 ARG PROFILE=release
+ARG BASE_SUCCINCT_ELF_REQUIRE=1
 RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
     --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
     --mount=type=cache,target=/app/target,id=zk-prover-target,sharing=locked \
-    BASE_SUCCINCT_ELF_REQUIRE=1 cargo build --profile $PROFILE --package base-prover-zk --bin base-prover-zk && \
+    cargo build --profile $PROFILE --package base-prover-zk --bin base-prover-zk && \
     cp /app/target/$([ "$PROFILE" = "dev" ] && echo debug || echo "$PROFILE")/base-prover-zk /app/base-prover-zk
 
 FROM public.ecr.aws/docker/library/debian:trixie-slim AS runtime-base

--- a/etc/docker/Justfile
+++ b/etc/docker/Justfile
@@ -10,15 +10,15 @@ default:
     @just --justfile {{source_file()}} --list
 
 # Stops devnet, deletes data, and starts fresh (3-node HA conductor cluster)
-up: down _ensure-sp1-elfs _build-setup-image (_build-rust-images "devnet" "dev")
+up: down _build-setup-image (_build-rust-images "devnet" "dev")
     docker compose {{ _env }} {{ _ha }} up -d --no-build
 
 # Stops devnet, deletes data, and starts fresh with a single sequencer (no conductor)
-up-single: down _ensure-sp1-elfs _build-setup-image (_build-rust-images "devnet" "dev")
+up-single: down _build-setup-image (_build-rust-images "devnet" "dev")
     docker compose {{ _env }} {{ _base }} up -d --no-build
 
 # Stops devnet, deletes data, and starts fresh with profiling (Pyroscope + optimized builds)
-profiling: down _ensure-sp1-elfs _build-setup-image (_build-rust-images "devnet" "profiling")
+profiling: down _build-setup-image (_build-rust-images "devnet" "profiling")
     docker compose {{ _env }} {{ _ha }} --profile profiling up -d --no-build
 
 # Stops devnet and deletes all data
@@ -133,20 +133,6 @@ bench name:
 [private]
 _install-nextest:
     @command -v cargo-nextest >/dev/null 2>&1 || cargo install cargo-nextest
-
-# Ensures SP1 toolchain is installed and ELF artifacts are cached.
-# Installs SP1 automatically if cargo-prove is not found.
-[private]
-_ensure-sp1-elfs:
-    #!/usr/bin/env bash
-    set -euo pipefail
-    if ! command -v ~/.sp1/bin/cargo-prove &>/dev/null; then
-        echo "SP1 toolchain not found. Installing..."
-        curl -L https://sp1.succinct.xyz | bash
-        ~/.sp1/bin/sp1up
-    fi
-    cd "$(git rev-parse --show-toplevel)"
-    just succinct ensure-elfs
 
 # Env var: CONTRACTS_COMMIT overrides the base/contracts commit SHA (default in Dockerfile).
 [private]

--- a/etc/docker/Justfile
+++ b/etc/docker/Justfile
@@ -96,7 +96,15 @@ build-image target='client' profile='dev':
       arm64|aarch64) platform_pair="linux-arm64" ;;
       *) echo "unsupported architecture: $(uname -m)" >&2; exit 1 ;;
     esac
-    PROFILE="{{ profile }}" PLATFORM_PAIR="${platform_pair}" docker buildx bake -f etc/docker/docker-bake.hcl "{{ target }}" --load
+    elf_require=1
+    case "{{ profile }}" in
+      dev|profiling)
+        case "{{ target }}" in
+          zk-prover|devnet) elf_require=0 ;;
+        esac
+        ;;
+    esac
+    PROFILE="{{ profile }}" BASE_SUCCINCT_ELF_REQUIRE="${elf_require}" PLATFORM_PAIR="${platform_pair}" docker buildx bake -f etc/docker/docker-bake.hcl "{{ target }}" --load
 
 # Prepares Docker images needed for devnet tests
 pull-images:
@@ -155,7 +163,15 @@ _build-rust-images group profile='dev':
       arm64|aarch64) platform_pair="linux-arm64" ;;
       *) echo "unsupported architecture: $(uname -m)" >&2; exit 1 ;;
     esac
-    PROFILE="{{ profile }}" PLATFORM_PAIR="${platform_pair}" docker buildx bake -f etc/docker/docker-bake.hcl "{{ group }}" --load
+    elf_require=1
+    case "{{ profile }}" in
+      dev|profiling)
+        case "{{ group }}" in
+          devnet) elf_require=0 ;;
+        esac
+        ;;
+    esac
+    PROFILE="{{ profile }}" BASE_SUCCINCT_ELF_REQUIRE="${elf_require}" PLATFORM_PAIR="${platform_pair}" docker buildx bake -f etc/docker/docker-bake.hcl "{{ group }}" --load
 
 [private]
 _build-contracts:

--- a/etc/docker/docker-bake.hcl
+++ b/etc/docker/docker-bake.hcl
@@ -10,6 +10,10 @@ variable "RUST_VERSION" {
   default = "1.93"
 }
 
+variable "BASE_SUCCINCT_ELF_REQUIRE" {
+  default = "1"
+}
+
 variable "REGISTRY_IMAGE" {
   default = "ghcr.io/base/node-reth-dev"
 }
@@ -133,7 +137,8 @@ target "zk-prover" {
   inherits = ["_rust-service-common"]
   target = "zk-prover"
   args = {
-    PROFILE = "${ZK_PROVER_PROFILE}"
+    PROFILE                   = "${ZK_PROVER_PROFILE}"
+    BASE_SUCCINCT_ELF_REQUIRE = "${BASE_SUCCINCT_ELF_REQUIRE}"
   }
   tags = ["base-prover-zk:local"]
   cache-from = [

--- a/etc/docker/docker-compose.yml
+++ b/etc/docker/docker-compose.yml
@@ -3,6 +3,7 @@ x-rust-service-build: &rust-service-build
   dockerfile: etc/docker/Dockerfile.rust-services
   args:
     PROFILE: "${CARGO_PROFILE:-dev}"
+    BASE_SUCCINCT_ELF_REQUIRE: "${BASE_SUCCINCT_ELF_REQUIRE:-0}"
 
 services:
   setup-l1:


### PR DESCRIPTION
cherry-picks 60c2d1b from `main` to allow local devnets to run with stub Succinct ELFs

removes `_ensure-sp1-elfs` recipe and dependency from devnet commands to use stubs