### PR TITLE
feat(prover-service): add guarded worker heartbeat and submit

### DIFF
--- a/crates/proof/prover-service/db/README.md
+++ b/crates/proof/prover-service/db/README.md
@@ -1,20 +1,3 @@
 # `base-prover-service-db`
 
 `PostgreSQL` persistence layer for prover-service proof requests and sessions.
-
-## Worker Job Model
-
-`proof_requests` is the source of truth for requester-submitted proof jobs. The
-requester lifecycle is stored in `status` (`CREATED`, `PENDING`, `RUNNING`,
-`SUCCEEDED`, `FAILED`), while the external worker lifecycle is stored in
-`job_status` (`PENDING`, `CLAIMED`, `SUCCEEDED`, `FAILED`). Backend-specific
-`proof_sessions` rows remain an implementation detail for providers that need
-asynchronous STARK/SNARK sessions.
-
-Workers claim jobs directly from `proof_requests`. Every active claim has a
-`worker_id`, `lock_id`, `lock_expires_at`, and `attempt`; heartbeat and submit
-updates are guarded by all ownership fields plus an unexpired lock. Worker
-execution failure is represented by lock expiry rather than an explicit
-`failProof` API: expired claims are reclaimable while `attempt < max_attempts`,
-and `fail_expired_proof_jobs` terminally fails expired jobs in bounded batches
-once the retry budget is exhausted.

--- a/crates/proof/prover-service/db/README.md
+++ b/crates/proof/prover-service/db/README.md
@@ -1,3 +1,20 @@
 # `base-prover-service-db`
 
 `PostgreSQL` persistence layer for prover-service proof requests and sessions.
+
+## Worker Job Model
+
+`proof_requests` is the source of truth for requester-submitted proof jobs. The
+requester lifecycle is stored in `status` (`CREATED`, `PENDING`, `RUNNING`,
+`SUCCEEDED`, `FAILED`), while the external worker lifecycle is stored in
+`job_status` (`PENDING`, `CLAIMED`, `SUCCEEDED`, `FAILED`). Backend-specific
+`proof_sessions` rows remain an implementation detail for providers that need
+asynchronous STARK/SNARK sessions.
+
+Workers claim jobs directly from `proof_requests`. Every active claim has a
+`worker_id`, `lock_id`, `lock_expires_at`, and `attempt`; heartbeat and submit
+updates are guarded by all ownership fields plus an unexpired lock. Worker
+execution failure is represented by lock expiry rather than an explicit
+`failProof` API: expired claims are reclaimable while `attempt < max_attempts`,
+and `fail_expired_proof_jobs` terminally fails expired jobs in bounded batches
+once the retry budget is exhausted.

--- a/crates/proof/prover-service/db/src/lib.rs
+++ b/crates/proof/prover-service/db/src/lib.rs
@@ -5,12 +5,14 @@ pub use config::DatabaseConfig;
 
 mod models;
 pub use models::{
-    ApiProofType, ClaimProofJob, CompleteProofResult, CreateOutboxEntry, CreateProofRequest,
-    CreateProofRequestError, CreateProofRequestOutcome, CreateProofRequestValidationError,
-    CreateProofSession, DerivedProofRequestFields, MarkOutboxError, MarkOutboxProcessed,
-    OutboxEntry, ProofJob, ProofJobStatus, ProofRequest, ProofRequestListItem, ProofRequestPage,
-    ProofSession, ProofStatus, ProofType, RetryOutcome, SessionStatus, SessionType, TeeKind,
-    UpdateProofSession, UpdateReceipt, ZkVmKind, canonical_session_id,
+    ApiProofType, ClaimProofJob, CompleteClaimedProofJob, CompleteProofResult, CreateOutboxEntry,
+    CreateProofRequest, CreateProofRequestError, CreateProofRequestOutcome,
+    CreateProofRequestValidationError, CreateProofSession, DerivedProofRequestFields,
+    FailExpiredProofJobs, HeartbeatOutcome, HeartbeatProofJob, MarkOutboxError,
+    MarkOutboxProcessed, OutboxEntry, ProofJob, ProofJobStatus, ProofRequest, ProofRequestListItem,
+    ProofRequestPage, ProofSession, ProofStatus, ProofType, RetryOutcome, SessionStatus,
+    SessionType, SubmitProofOutcome, TeeKind, UpdateProofSession, UpdateReceipt, ZkVmKind,
+    canonical_session_id,
 };
 
 mod repo;

--- a/crates/proof/prover-service/db/src/models.rs
+++ b/crates/proof/prover-service/db/src/models.rs
@@ -582,7 +582,7 @@ pub struct ProofRequestListItem {
 
 /// Worker-visible proof job, combining requester request data with the
 /// worker-owned claim/lock state needed to build a protocol `ProofJob`.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ProofJob {
     /// Internal proof request identifier.
     pub id: Uuid,
@@ -959,6 +959,77 @@ pub struct ClaimProofJob {
     pub lock_duration_seconds: u32,
     /// Reclaim budget: expired claims are only reclaimable while `attempt < max_attempts`.
     pub max_attempts: u32,
+}
+
+/// Parameters for extending the currently owned worker proof job lock.
+#[derive(Debug, Clone)]
+pub struct HeartbeatProofJob {
+    /// Public proof session identifier.
+    pub session_id: String,
+    /// Current worker fencing token.
+    pub lock_id: Uuid,
+    /// Worker identifier that owns the claim.
+    pub worker_id: String,
+    /// Lock duration in seconds. Callers must resolve the server default first.
+    pub lock_duration_seconds: u32,
+}
+
+/// Outcome of attempting to heartbeat a worker proof job.
+#[derive(Debug, Clone)]
+pub enum HeartbeatOutcome {
+    /// The heartbeat succeeded and the returned job has the updated lock expiry.
+    Updated(ProofJob),
+    /// No proof job exists for the supplied `session_id`.
+    NotFound,
+    /// The job exists but is not currently claimed.
+    NotClaimed(ProofJob),
+    /// The supplied `worker_id` or `lock_id` no longer owns the job.
+    StaleLock(ProofJob),
+    /// The supplied lock matched the job, but it had already expired.
+    Expired(ProofJob),
+    /// The job is already terminal.
+    Terminal(ProofJob),
+}
+
+/// Parameters for completing a claimed worker proof job.
+#[derive(Debug, Clone)]
+pub struct CompleteClaimedProofJob {
+    /// Public proof session identifier.
+    pub session_id: String,
+    /// Current worker fencing token.
+    pub lock_id: Uuid,
+    /// Worker identifier that owns the claim.
+    pub worker_id: String,
+    /// Protocol result to store in `result_payload`.
+    pub result: ProtocolProofResult,
+}
+
+/// Outcome of attempting to complete a worker proof job.
+#[derive(Debug, Clone)]
+pub enum SubmitProofOutcome {
+    /// The submit succeeded and the returned job is terminal `SUCCEEDED`.
+    Completed(ProofJob),
+    /// No proof job exists for the supplied `session_id`.
+    NotFound,
+    /// The job exists but is not currently claimed.
+    NotClaimed(ProofJob),
+    /// The supplied `worker_id` or `lock_id` no longer owns the job.
+    StaleLock(ProofJob),
+    /// The supplied lock matched the job, but it had already expired.
+    Expired(ProofJob),
+    /// The job is already terminal.
+    Terminal(ProofJob),
+}
+
+/// Parameters for terminally failing expired worker jobs that exhausted attempts.
+#[derive(Debug, Clone)]
+pub struct FailExpiredProofJobs {
+    /// Jobs with `attempt >= max_attempts` are failed once their lock has expired.
+    pub max_attempts: u32,
+    /// Maximum number of expired jobs to fail in this batch.
+    pub batch_size: u32,
+    /// Error message stored on newly failed jobs.
+    pub error_message: String,
 }
 
 /// Outbox entry for reliable task processing

--- a/crates/proof/prover-service/db/src/models.rs
+++ b/crates/proof/prover-service/db/src/models.rs
@@ -582,7 +582,7 @@ pub struct ProofRequestListItem {
 
 /// Worker-visible proof job, combining requester request data with the
 /// worker-owned claim/lock state needed to build a protocol `ProofJob`.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone)]
 pub struct ProofJob {
     /// Internal proof request identifier.
     pub id: Uuid,
@@ -989,6 +989,8 @@ pub enum HeartbeatOutcome {
     Expired(ProofJob),
     /// The job is already terminal.
     Terminal(ProofJob),
+    /// The update was denied, but the diagnostic read did not identify a stable reason.
+    Unknown(ProofJob),
 }
 
 /// Parameters for completing a claimed worker proof job.
@@ -1019,6 +1021,8 @@ pub enum SubmitProofOutcome {
     Expired(ProofJob),
     /// The job is already terminal.
     Terminal(ProofJob),
+    /// The update was denied, but the diagnostic read did not identify a stable reason.
+    Unknown(ProofJob),
 }
 
 /// Parameters for terminally failing expired worker jobs that exhausted attempts.

--- a/crates/proof/prover-service/db/src/repo.rs
+++ b/crates/proof/prover-service/db/src/repo.rs
@@ -1,15 +1,17 @@
 use base_prover_service_protocol::{
     ProofResult as ProtocolProofResult, SnarkGroth16ProofResult, ZkProofResult, ZkVm,
 };
+use chrono::Utc;
 use sqlx::{PgPool, Result, Row};
 use uuid::Uuid;
 
 use crate::{
-    ApiProofType, ClaimProofJob, CompleteProofResult, CreateOutboxEntry, CreateProofRequest,
-    CreateProofRequestError, CreateProofRequestOutcome, CreateProofRequestValidationError,
-    CreateProofSession, MarkOutboxError, MarkOutboxProcessed, OutboxEntry, ProofJob,
-    ProofJobStatus, ProofRequest, ProofRequestListItem, ProofRequestPage, ProofSession,
-    ProofStatus, ProofType, RetryOutcome, SessionStatus, SessionType, TeeKind, UpdateProofSession,
+    ApiProofType, ClaimProofJob, CompleteClaimedProofJob, CompleteProofResult, CreateOutboxEntry,
+    CreateProofRequest, CreateProofRequestError, CreateProofRequestOutcome,
+    CreateProofRequestValidationError, CreateProofSession, FailExpiredProofJobs, HeartbeatOutcome,
+    HeartbeatProofJob, MarkOutboxError, MarkOutboxProcessed, OutboxEntry, ProofJob, ProofJobStatus,
+    ProofRequest, ProofRequestListItem, ProofRequestPage, ProofSession, ProofStatus, ProofType,
+    RetryOutcome, SessionStatus, SessionType, SubmitProofOutcome, TeeKind, UpdateProofSession,
     UpdateReceipt, ZkVmKind, canonical_session_id,
 };
 
@@ -583,6 +585,192 @@ impl ProofRequestRepo {
             .await?;
 
         row.as_ref().map(row_to_proof_job).transpose()
+    }
+
+    /// Fetch a worker-visible proof job by protocol `session_id`.
+    pub async fn get_proof_job_by_session_id(&self, session_id: &str) -> Result<Option<ProofJob>> {
+        let columns = PROOF_JOB_RETURNING_COLUMNS;
+        let sql = format!(
+            r#"
+            SELECT {columns}
+            FROM proof_requests
+            WHERE COALESCE(session_id, id::text) = $1
+            "#
+        );
+
+        let row = sqlx::query(&sql).bind(session_id).fetch_optional(&self.pool).await?;
+
+        row.as_ref().map(row_to_proof_job).transpose()
+    }
+
+    /// Extend the lock for the currently owned worker proof job (`heartbeat`).
+    ///
+    /// The update is guarded by `session_id`, `job_status = 'CLAIMED'`, `lock_id`,
+    /// `worker_id`, and an unexpired `lock_expires_at`. A stale worker cannot
+    /// revive an expired or reclaimed job because the update only succeeds for the
+    /// current fencing token.
+    pub async fn heartbeat_proof_job(&self, req: HeartbeatProofJob) -> Result<HeartbeatOutcome> {
+        let columns = PROOF_JOB_RETURNING_COLUMNS;
+        let sql = format!(
+            r#"
+            UPDATE proof_requests
+            SET last_heartbeat_at = NOW(),
+                lock_expires_at = NOW() + ($4)::double precision * INTERVAL '1 second'
+            WHERE COALESCE(session_id, id::text) = $1
+              AND job_status = 'CLAIMED'
+              AND lock_id = $2
+              AND worker_id = $3
+              AND lock_expires_at > NOW()
+            RETURNING {columns}
+            "#
+        );
+
+        let row = sqlx::query(&sql)
+            .bind(&req.session_id)
+            .bind(req.lock_id)
+            .bind(&req.worker_id)
+            .bind(i64::from(req.lock_duration_seconds))
+            .fetch_optional(&self.pool)
+            .await?;
+
+        if let Some(row) = row {
+            return row_to_proof_job(&row).map(HeartbeatOutcome::Updated);
+        }
+
+        let Some(job) = self.get_proof_job_by_session_id(&req.session_id).await? else {
+            return Ok(HeartbeatOutcome::NotFound);
+        };
+
+        if matches!(job.job_status, ProofJobStatus::Succeeded | ProofJobStatus::Failed) {
+            return Ok(HeartbeatOutcome::Terminal(job));
+        }
+        if job.job_status != ProofJobStatus::Claimed {
+            return Ok(HeartbeatOutcome::NotClaimed(job));
+        }
+        if job.lock_id != Some(req.lock_id) || job.worker_id.as_deref() != Some(&req.worker_id) {
+            return Ok(HeartbeatOutcome::StaleLock(job));
+        }
+        if job.lock_expires_at.is_none_or(|expires_at| expires_at <= Utc::now()) {
+            return Ok(HeartbeatOutcome::Expired(job));
+        }
+
+        // Timing-window fallback between database time and app diagnostics.
+        Ok(HeartbeatOutcome::StaleLock(job))
+    }
+
+    /// Complete the currently owned worker proof job (`submitProof`).
+    ///
+    /// The ownership guard matches [`Self::heartbeat_proof_job`]. On success the
+    /// worker job and requester proof both transition to `SUCCEEDED`,
+    /// `result_payload` stores the protocol result, and ZK results are mirrored
+    /// into legacy receipt columns for compatibility.
+    pub async fn complete_claimed_proof_job(
+        &self,
+        req: CompleteClaimedProofJob,
+    ) -> Result<SubmitProofOutcome> {
+        let result_payload =
+            serde_json::to_value(&req.result).map_err(|e| sqlx::Error::Encode(Box::new(e)))?;
+        let (stark_receipt, snark_receipt) = compatibility_receipts_for_result(&req.result);
+        let submitted_lock_id = req.lock_id.to_string();
+        let columns = PROOF_JOB_RETURNING_COLUMNS;
+        let sql = format!(
+            r#"
+            UPDATE proof_requests
+            SET job_status = 'SUCCEEDED',
+                status = 'SUCCEEDED',
+                result_payload = $4,
+                submitted_by_worker_id = $3,
+                submitted_lock_id = $5,
+                stark_receipt = COALESCE($6, stark_receipt),
+                snark_receipt = COALESCE($7, snark_receipt),
+                error_message = NULL,
+                completed_at = NOW()
+            WHERE COALESCE(session_id, id::text) = $1
+              AND job_status = 'CLAIMED'
+              AND lock_id = $2
+              AND worker_id = $3
+              AND lock_expires_at > NOW()
+            RETURNING {columns}
+            "#
+        );
+
+        let row = sqlx::query(&sql)
+            .bind(&req.session_id)
+            .bind(req.lock_id)
+            .bind(&req.worker_id)
+            .bind(&result_payload)
+            .bind(&submitted_lock_id)
+            .bind(&stark_receipt)
+            .bind(&snark_receipt)
+            .fetch_optional(&self.pool)
+            .await?;
+
+        if let Some(row) = row {
+            return row_to_proof_job(&row).map(SubmitProofOutcome::Completed);
+        }
+
+        let Some(job) = self.get_proof_job_by_session_id(&req.session_id).await? else {
+            return Ok(SubmitProofOutcome::NotFound);
+        };
+
+        if matches!(job.job_status, ProofJobStatus::Succeeded | ProofJobStatus::Failed) {
+            return Ok(SubmitProofOutcome::Terminal(job));
+        }
+        if job.job_status != ProofJobStatus::Claimed {
+            return Ok(SubmitProofOutcome::NotClaimed(job));
+        }
+        if job.lock_id != Some(req.lock_id) || job.worker_id.as_deref() != Some(&req.worker_id) {
+            return Ok(SubmitProofOutcome::StaleLock(job));
+        }
+        if job.lock_expires_at.is_none_or(|expires_at| expires_at <= Utc::now()) {
+            return Ok(SubmitProofOutcome::Expired(job));
+        }
+
+        // Timing-window fallback between database time and app diagnostics.
+        Ok(SubmitProofOutcome::StaleLock(job))
+    }
+
+    /// Terminally fail expired worker jobs that have exhausted their claim attempts.
+    ///
+    /// Worker execution failure is represented by lock expiry. Jobs remain
+    /// reclaimable while `attempt < max_attempts`; once an expired claim reaches
+    /// the budget, this reaper transition marks both the worker job and requester
+    /// proof `FAILED` and stores `error_message`. The update is batched and uses
+    /// `FOR UPDATE SKIP LOCKED` to avoid locking the full expired backlog.
+    pub async fn fail_expired_proof_jobs(
+        &self,
+        req: FailExpiredProofJobs,
+    ) -> Result<Vec<ProofJob>> {
+        let columns = PROOF_JOB_RETURNING_COLUMNS;
+        let sql = format!(
+            r#"
+            UPDATE proof_requests
+            SET job_status = 'FAILED',
+                status = 'FAILED',
+                error_message = $2,
+                completed_at = NOW()
+            WHERE id IN (
+                SELECT id
+                FROM proof_requests
+                WHERE job_status = 'CLAIMED'
+                  AND lock_expires_at < NOW()
+                  AND attempt >= $1
+                ORDER BY lock_expires_at ASC, start_block_number ASC, created_at ASC, id ASC
+                LIMIT $3
+                FOR UPDATE SKIP LOCKED
+            )
+            RETURNING {columns}
+            "#
+        );
+
+        let rows = sqlx::query(&sql)
+            .bind(i64::from(req.max_attempts))
+            .bind(&req.error_message)
+            .bind(i64::from(req.batch_size))
+            .fetch_all(&self.pool)
+            .await?;
+
+        rows.iter().map(row_to_proof_job).collect()
     }
 
     /// Retry a stuck PENDING request if under the retry limit, otherwise fail it permanently.

--- a/crates/proof/prover-service/db/src/repo.rs
+++ b/crates/proof/prover-service/db/src/repo.rs
@@ -589,6 +589,15 @@ impl ProofRequestRepo {
 
     /// Fetch a worker-visible proof job by protocol `session_id`.
     pub async fn get_proof_job_by_session_id(&self, session_id: &str) -> Result<Option<ProofJob>> {
+        let session_id = canonical_session_id(session_id)
+            .map_err(|e| sqlx::Error::InvalidArgument(e.to_string()))?;
+        self.get_proof_job_by_canonical_session_id(&session_id).await
+    }
+
+    async fn get_proof_job_by_canonical_session_id(
+        &self,
+        session_id: &str,
+    ) -> Result<Option<ProofJob>> {
         let columns = PROOF_JOB_RETURNING_COLUMNS;
         let sql = format!(
             r#"
@@ -610,6 +619,8 @@ impl ProofRequestRepo {
     /// revive an expired or reclaimed job because the update only succeeds for the
     /// current fencing token.
     pub async fn heartbeat_proof_job(&self, req: HeartbeatProofJob) -> Result<HeartbeatOutcome> {
+        let session_id = canonical_session_id(&req.session_id)
+            .map_err(|e| sqlx::Error::InvalidArgument(e.to_string()))?;
         let columns = PROOF_JOB_RETURNING_COLUMNS;
         let sql = format!(
             r#"
@@ -626,7 +637,7 @@ impl ProofRequestRepo {
         );
 
         let row = sqlx::query(&sql)
-            .bind(&req.session_id)
+            .bind(&session_id)
             .bind(req.lock_id)
             .bind(&req.worker_id)
             .bind(i64::from(req.lock_duration_seconds))
@@ -637,7 +648,7 @@ impl ProofRequestRepo {
             return row_to_proof_job(&row).map(HeartbeatOutcome::Updated);
         }
 
-        let Some(job) = self.get_proof_job_by_session_id(&req.session_id).await? else {
+        let Some(job) = self.get_proof_job_by_canonical_session_id(&session_id).await? else {
             return Ok(HeartbeatOutcome::NotFound);
         };
 
@@ -654,8 +665,7 @@ impl ProofRequestRepo {
             return Ok(HeartbeatOutcome::Expired(job));
         }
 
-        // Timing-window fallback between database time and app diagnostics.
-        Ok(HeartbeatOutcome::StaleLock(job))
+        Ok(HeartbeatOutcome::Unknown(job))
     }
 
     /// Complete the currently owned worker proof job (`submitProof`).
@@ -668,6 +678,8 @@ impl ProofRequestRepo {
         &self,
         req: CompleteClaimedProofJob,
     ) -> Result<SubmitProofOutcome> {
+        let session_id = canonical_session_id(&req.session_id)
+            .map_err(|e| sqlx::Error::InvalidArgument(e.to_string()))?;
         let result_payload =
             serde_json::to_value(&req.result).map_err(|e| sqlx::Error::Encode(Box::new(e)))?;
         let (stark_receipt, snark_receipt) = compatibility_receipts_for_result(&req.result);
@@ -695,7 +707,7 @@ impl ProofRequestRepo {
         );
 
         let row = sqlx::query(&sql)
-            .bind(&req.session_id)
+            .bind(&session_id)
             .bind(req.lock_id)
             .bind(&req.worker_id)
             .bind(&result_payload)
@@ -709,7 +721,7 @@ impl ProofRequestRepo {
             return row_to_proof_job(&row).map(SubmitProofOutcome::Completed);
         }
 
-        let Some(job) = self.get_proof_job_by_session_id(&req.session_id).await? else {
+        let Some(job) = self.get_proof_job_by_canonical_session_id(&session_id).await? else {
             return Ok(SubmitProofOutcome::NotFound);
         };
 
@@ -726,8 +738,7 @@ impl ProofRequestRepo {
             return Ok(SubmitProofOutcome::Expired(job));
         }
 
-        // Timing-window fallback between database time and app diagnostics.
-        Ok(SubmitProofOutcome::StaleLock(job))
+        Ok(SubmitProofOutcome::Unknown(job))
     }
 
     /// Terminally fail expired worker jobs that have exhausted their claim attempts.

--- a/crates/proof/prover-service/db/tests/postgres_integration.rs
+++ b/crates/proof/prover-service/db/tests/postgres_integration.rs
@@ -1499,6 +1499,13 @@ fn compressed_result(bytes: Vec<u8>) -> ProtocolProofResult {
     ProtocolProofResult::Compressed(ZkProofResult { zk_vm: ZkVm::Sp1, proof: bytes.into() })
 }
 
+fn uppercase_uuid_session_id() -> (Uuid, String) {
+    let mut bytes = *Uuid::new_v4().as_bytes();
+    bytes[0] = 0xaa;
+    let id = Uuid::from_bytes(bytes);
+    (id, id.to_string().to_uppercase())
+}
+
 #[tokio::test]
 #[ignore = "requires a running Postgres with the prover schema (set DATABASE_URL); run with `cargo nextest run --run-ignored all -p base-prover-service-db --test postgres_integration --test-threads=1`"]
 async fn test_claim_next_proof_job_claim_and_capabilities() {
@@ -1633,7 +1640,11 @@ async fn test_heartbeat_proof_job_guards_current_expired_and_reclaimed_locks() {
     let repo = test_repo(pool.clone());
 
     drain_claimable_tee_jobs(&repo).await;
-    let id = repo.create(tee_request()).await.unwrap();
+    let (explicit_id, uppercase_session_id) = uppercase_uuid_session_id();
+    let mut request = tee_request();
+    request.session_id = Some(uppercase_session_id.clone());
+    let id = repo.create(request).await.unwrap();
+    assert_eq!(id, explicit_id);
     let first = repo
         .claim_next_proof_job(tee_claim("first-worker", 3))
         .await
@@ -1644,7 +1655,7 @@ async fn test_heartbeat_proof_job_guards_current_expired_and_reclaimed_locks() {
 
     let updated = repo
         .heartbeat_proof_job(HeartbeatProofJob {
-            session_id: first.session_id.clone(),
+            session_id: uppercase_session_id.clone(),
             lock_id: first_lock,
             worker_id: "first-worker".to_owned(),
             lock_duration_seconds: 7200,
@@ -1661,7 +1672,7 @@ async fn test_heartbeat_proof_job_guards_current_expired_and_reclaimed_locks() {
 
     let stale = repo
         .heartbeat_proof_job(HeartbeatProofJob {
-            session_id: first.session_id.clone(),
+            session_id: uppercase_session_id.clone(),
             lock_id: Uuid::new_v4(),
             worker_id: "first-worker".to_owned(),
             lock_duration_seconds: 7200,
@@ -1674,7 +1685,7 @@ async fn test_heartbeat_proof_job_guards_current_expired_and_reclaimed_locks() {
 
     let expired = repo
         .heartbeat_proof_job(HeartbeatProofJob {
-            session_id: first.session_id.clone(),
+            session_id: uppercase_session_id.clone(),
             lock_id: first_lock,
             worker_id: "first-worker".to_owned(),
             lock_duration_seconds: 3600,
@@ -1692,7 +1703,7 @@ async fn test_heartbeat_proof_job_guards_current_expired_and_reclaimed_locks() {
 
     let stale = repo
         .heartbeat_proof_job(HeartbeatProofJob {
-            session_id: first.session_id,
+            session_id: uppercase_session_id,
             lock_id: first_lock,
             worker_id: "first-worker".to_owned(),
             lock_duration_seconds: 3600,
@@ -1709,7 +1720,11 @@ async fn test_complete_claimed_proof_job_guards_and_stores_result() {
     let repo = test_repo(pool);
 
     drain_claimable_compressed_jobs(&repo).await;
-    let id = repo.create(compressed_request()).await.unwrap();
+    let (explicit_id, uppercase_session_id) = uppercase_uuid_session_id();
+    let mut request = compressed_request();
+    request.session_id = Some(uppercase_session_id.clone());
+    let id = repo.create(request).await.unwrap();
+    assert_eq!(id, explicit_id);
     let claimed = repo
         .claim_next_proof_job(compressed_claim("submit-worker", 3))
         .await
@@ -1720,7 +1735,7 @@ async fn test_complete_claimed_proof_job_guards_and_stores_result() {
 
     let stale = repo
         .complete_claimed_proof_job(CompleteClaimedProofJob {
-            session_id: claimed.session_id.clone(),
+            session_id: uppercase_session_id.clone(),
             lock_id: Uuid::new_v4(),
             worker_id: "submit-worker".to_owned(),
             result: compressed_result(vec![0xde, 0xad]),
@@ -1733,7 +1748,7 @@ async fn test_complete_claimed_proof_job_guards_and_stores_result() {
     let result = compressed_result(vec![0xca, 0xfe]);
     let submitted = repo
         .complete_claimed_proof_job(CompleteClaimedProofJob {
-            session_id: claimed.session_id.clone(),
+            session_id: uppercase_session_id.clone(),
             lock_id,
             worker_id: "submit-worker".to_owned(),
             result: result.clone(),
@@ -1759,7 +1774,7 @@ async fn test_complete_claimed_proof_job_guards_and_stores_result() {
 
     let duplicate = repo
         .complete_claimed_proof_job(CompleteClaimedProofJob {
-            session_id: claimed.session_id,
+            session_id: uppercase_session_id,
             lock_id,
             worker_id: "submit-worker".to_owned(),
             result: compressed_result(vec![0xba, 0xad]),
@@ -1836,4 +1851,60 @@ async fn test_fail_expired_proof_jobs_enforces_retry_exhaustion() {
         .await
         .unwrap();
     assert!(matches!(terminal, HeartbeatOutcome::Terminal(_)));
+}
+
+#[tokio::test]
+#[ignore = "requires a running Postgres with the prover schema (set DATABASE_URL); run with `cargo nextest run --run-ignored all -p base-prover-service-db --test postgres_integration --test-threads=1`"]
+async fn test_fail_expired_proof_jobs_honors_batch_size() {
+    let pool = test_pool().await;
+    let repo = test_repo(pool.clone());
+
+    drain_claimable_tee_jobs(&repo).await;
+    let ids = [
+        repo.create(tee_request()).await.unwrap(),
+        repo.create(tee_request()).await.unwrap(),
+        repo.create(tee_request()).await.unwrap(),
+    ];
+
+    for _ in ids {
+        let claimed = repo
+            .claim_next_proof_job(tee_claim("batch-reaper-worker", 1))
+            .await
+            .unwrap()
+            .expect("pending job should be claimed");
+        assert!(ids.contains(&claimed.id));
+        expire_lock(&pool, claimed.id).await;
+    }
+
+    let first_batch = repo
+        .fail_expired_proof_jobs(FailExpiredProofJobs {
+            max_attempts: 1,
+            batch_size: 2,
+            error_message: "worker lock expired after retry budget".to_owned(),
+        })
+        .await
+        .unwrap();
+    assert_eq!(first_batch.len(), 2);
+    assert!(first_batch.iter().all(|job| ids.contains(&job.id)));
+
+    let second_batch = repo
+        .fail_expired_proof_jobs(FailExpiredProofJobs {
+            max_attempts: 1,
+            batch_size: 2,
+            error_message: "worker lock expired after retry budget".to_owned(),
+        })
+        .await
+        .unwrap();
+    assert_eq!(second_batch.len(), 1);
+    assert!(ids.contains(&second_batch[0].id));
+
+    let final_batch = repo
+        .fail_expired_proof_jobs(FailExpiredProofJobs {
+            max_attempts: 1,
+            batch_size: 2,
+            error_message: "worker lock expired after retry budget".to_owned(),
+        })
+        .await
+        .unwrap();
+    assert!(final_batch.is_empty());
 }

--- a/crates/proof/prover-service/db/tests/postgres_integration.rs
+++ b/crates/proof/prover-service/db/tests/postgres_integration.rs
@@ -16,10 +16,11 @@
 use std::time::Duration;
 
 use base_prover_service_db::{
-    ApiProofType, ClaimProofJob, CreateProofRequest, CreateProofRequestError,
-    CreateProofRequestOutcome, CreateProofSession, MarkOutboxError, MarkOutboxProcessed,
-    ProofJobStatus, ProofRequestPage, ProofRequestRepo, ProofStatus, ProofType, RetryOutcome,
-    SessionStatus, SessionType, TeeKind, UpdateProofSession, UpdateReceipt, ZkVmKind,
+    ApiProofType, ClaimProofJob, CompleteClaimedProofJob, CreateProofRequest,
+    CreateProofRequestError, CreateProofRequestOutcome, CreateProofSession, FailExpiredProofJobs,
+    HeartbeatOutcome, HeartbeatProofJob, MarkOutboxError, MarkOutboxProcessed, ProofJobStatus,
+    ProofRequestPage, ProofRequestRepo, ProofStatus, ProofType, RetryOutcome, SessionStatus,
+    SessionType, SubmitProofOutcome, TeeKind, UpdateProofSession, UpdateReceipt, ZkVmKind,
 };
 use base_prover_service_protocol::{
     ProofRequest as ProtocolProofRequest, ProofRequestKind as ProtocolProofRequestKind,
@@ -1472,7 +1473,8 @@ async fn drain_claimable_tee_jobs(repo: &ProofRequestRepo) {
     {}
 }
 
-/// Drain every currently claimable compressed job by claiming it under a long lease.
+/// Drain every currently claimable compressed job for tests that need to claim a
+/// freshly inserted ZK request deterministically.
 async fn drain_claimable_compressed_jobs(repo: &ProofRequestRepo) {
     while repo
         .claim_next_proof_job(compressed_claim("drain-zk-worker", u32::MAX))
@@ -1491,6 +1493,10 @@ async fn expire_lock(pool: &PgPool, id: Uuid) {
     .execute(pool)
     .await
     .expect("expire lock should succeed");
+}
+
+fn compressed_result(bytes: Vec<u8>) -> ProtocolProofResult {
+    ProtocolProofResult::Compressed(ZkProofResult { zk_vm: ZkVm::Sp1, proof: bytes.into() })
 }
 
 #[tokio::test]
@@ -1618,4 +1624,216 @@ async fn test_claim_next_proof_job_expired_lock_lifecycle() {
         repo.claim_next_proof_job(tee_claim("worker-c", 2)).await.unwrap().is_none(),
         "exhausted job must not be reclaimed"
     );
+}
+
+#[tokio::test]
+#[ignore = "requires a running Postgres with the prover schema (set DATABASE_URL); run with `cargo nextest run --run-ignored all -p base-prover-service-db --test postgres_integration --test-threads=1`"]
+async fn test_heartbeat_proof_job_guards_current_expired_and_reclaimed_locks() {
+    let pool = test_pool().await;
+    let repo = test_repo(pool.clone());
+
+    drain_claimable_tee_jobs(&repo).await;
+    let id = repo.create(tee_request()).await.unwrap();
+    let first = repo
+        .claim_next_proof_job(tee_claim("first-worker", 3))
+        .await
+        .unwrap()
+        .expect("first claim should succeed");
+    assert_eq!(first.id, id);
+    let first_lock = first.lock_id.expect("first claim has lock");
+
+    let updated = repo
+        .heartbeat_proof_job(HeartbeatProofJob {
+            session_id: first.session_id.clone(),
+            lock_id: first_lock,
+            worker_id: "first-worker".to_owned(),
+            lock_duration_seconds: 7200,
+        })
+        .await
+        .unwrap();
+    let HeartbeatOutcome::Updated(updated) = updated else {
+        panic!("heartbeat should update the current lock");
+    };
+    assert_eq!(updated.id, id);
+    assert_eq!(updated.lock_id, Some(first_lock));
+    assert_eq!(updated.worker_id.as_deref(), Some("first-worker"));
+    assert!(updated.lock_expires_at >= first.lock_expires_at);
+
+    let stale = repo
+        .heartbeat_proof_job(HeartbeatProofJob {
+            session_id: first.session_id.clone(),
+            lock_id: Uuid::new_v4(),
+            worker_id: "first-worker".to_owned(),
+            lock_duration_seconds: 7200,
+        })
+        .await
+        .unwrap();
+    assert!(matches!(stale, HeartbeatOutcome::StaleLock(_)));
+
+    expire_lock(&pool, id).await;
+
+    let expired = repo
+        .heartbeat_proof_job(HeartbeatProofJob {
+            session_id: first.session_id.clone(),
+            lock_id: first_lock,
+            worker_id: "first-worker".to_owned(),
+            lock_duration_seconds: 3600,
+        })
+        .await
+        .unwrap();
+    assert!(matches!(expired, HeartbeatOutcome::Expired(_)));
+
+    let second = repo
+        .claim_next_proof_job(tee_claim("second-worker", 3))
+        .await
+        .unwrap()
+        .expect("expired lock should be reclaimed");
+    assert_ne!(second.lock_id, Some(first_lock));
+
+    let stale = repo
+        .heartbeat_proof_job(HeartbeatProofJob {
+            session_id: first.session_id,
+            lock_id: first_lock,
+            worker_id: "first-worker".to_owned(),
+            lock_duration_seconds: 3600,
+        })
+        .await
+        .unwrap();
+    assert!(matches!(stale, HeartbeatOutcome::StaleLock(_)));
+}
+
+#[tokio::test]
+#[ignore = "requires a running Postgres with the prover schema (set DATABASE_URL); run with `cargo nextest run --run-ignored all -p base-prover-service-db --test postgres_integration --test-threads=1`"]
+async fn test_complete_claimed_proof_job_guards_and_stores_result() {
+    let pool = test_pool().await;
+    let repo = test_repo(pool);
+
+    drain_claimable_compressed_jobs(&repo).await;
+    let id = repo.create(compressed_request()).await.unwrap();
+    let claimed = repo
+        .claim_next_proof_job(compressed_claim("submit-worker", 3))
+        .await
+        .unwrap()
+        .expect("compressed job should be claimed");
+    assert_eq!(claimed.id, id);
+    let lock_id = claimed.lock_id.expect("claimed job has lock");
+
+    let stale = repo
+        .complete_claimed_proof_job(CompleteClaimedProofJob {
+            session_id: claimed.session_id.clone(),
+            lock_id: Uuid::new_v4(),
+            worker_id: "submit-worker".to_owned(),
+            result: compressed_result(vec![0xde, 0xad]),
+        })
+        .await
+        .unwrap();
+    assert!(matches!(stale, SubmitProofOutcome::StaleLock(_)));
+    assert!(repo.get(id).await.unwrap().unwrap().result_payload.is_none());
+
+    let result = compressed_result(vec![0xca, 0xfe]);
+    let submitted = repo
+        .complete_claimed_proof_job(CompleteClaimedProofJob {
+            session_id: claimed.session_id.clone(),
+            lock_id,
+            worker_id: "submit-worker".to_owned(),
+            result: result.clone(),
+        })
+        .await
+        .unwrap();
+    let SubmitProofOutcome::Completed(completed) = submitted else {
+        panic!("submit should complete the current claim");
+    };
+    assert_eq!(completed.job_status, ProofJobStatus::Succeeded);
+    assert!(completed.completed_at.is_some());
+
+    let req = repo.get(id).await.unwrap().unwrap();
+    assert_eq!(req.status, ProofStatus::Succeeded);
+    assert_eq!(req.stark_receipt.as_deref(), Some(&[0xca, 0xfe][..]));
+    assert!(req.snark_receipt.is_none());
+    assert_eq!(req.submitted_by_worker_id.as_deref(), Some("submit-worker"));
+    assert_eq!(req.submitted_lock_id, Some(lock_id.to_string()));
+    let stored: ProtocolProofResult =
+        serde_json::from_value(req.result_payload.expect("result payload should be stored"))
+            .expect("stored result should deserialize");
+    assert_eq!(stored, result);
+
+    let duplicate = repo
+        .complete_claimed_proof_job(CompleteClaimedProofJob {
+            session_id: claimed.session_id,
+            lock_id,
+            worker_id: "submit-worker".to_owned(),
+            result: compressed_result(vec![0xba, 0xad]),
+        })
+        .await
+        .unwrap();
+    assert!(matches!(duplicate, SubmitProofOutcome::Terminal(_)));
+    assert_eq!(
+        repo.get(id).await.unwrap().unwrap().stark_receipt.as_deref(),
+        Some(&[0xca, 0xfe][..])
+    );
+}
+
+#[tokio::test]
+#[ignore = "requires a running Postgres with the prover schema (set DATABASE_URL); run with `cargo nextest run --run-ignored all -p base-prover-service-db --test postgres_integration --test-threads=1`"]
+async fn test_fail_expired_proof_jobs_enforces_retry_exhaustion() {
+    let pool = test_pool().await;
+    let repo = test_repo(pool.clone());
+
+    drain_claimable_tee_jobs(&repo).await;
+    let id = repo.create(tee_request()).await.unwrap();
+    let first = repo
+        .claim_next_proof_job(tee_claim("retry-worker-a", 2))
+        .await
+        .unwrap()
+        .expect("first claim should succeed");
+    expire_lock(&pool, id).await;
+
+    let failed = repo
+        .fail_expired_proof_jobs(FailExpiredProofJobs {
+            max_attempts: 2,
+            batch_size: 100,
+            error_message: "worker lock expired after retry budget".to_owned(),
+        })
+        .await
+        .unwrap();
+    assert!(failed.iter().all(|job| job.id != id), "attempt 1 is still under the retry budget");
+
+    let second = repo
+        .claim_next_proof_job(tee_claim("retry-worker-b", 2))
+        .await
+        .unwrap()
+        .expect("second claim should succeed before exhaustion");
+    assert_eq!(second.id, id);
+    assert_eq!(second.attempt, 2);
+    assert_ne!(second.lock_id, first.lock_id);
+    expire_lock(&pool, id).await;
+
+    let failed = repo
+        .fail_expired_proof_jobs(FailExpiredProofJobs {
+            max_attempts: 2,
+            batch_size: 100,
+            error_message: "worker lock expired after retry budget".to_owned(),
+        })
+        .await
+        .unwrap();
+    let job = failed.iter().find(|job| job.id == id).expect("exhausted job should fail");
+    assert_eq!(job.job_status, ProofJobStatus::Failed);
+    assert!(job.completed_at.is_some());
+    assert_eq!(job.error_message.as_deref(), Some("worker lock expired after retry budget"));
+
+    let req = repo.get(id).await.unwrap().unwrap();
+    assert_eq!(req.status, ProofStatus::Failed);
+    assert_eq!(req.error_message.as_deref(), Some("worker lock expired after retry budget"));
+    assert!(req.completed_at.is_some());
+
+    let terminal = repo
+        .heartbeat_proof_job(HeartbeatProofJob {
+            session_id: second.session_id,
+            lock_id: second.lock_id.expect("second claim has lock"),
+            worker_id: "retry-worker-b".to_owned(),
+            lock_duration_seconds: 3600,
+        })
+        .await
+        .unwrap();
+    assert!(matches!(terminal, HeartbeatOutcome::Terminal(_)));
 }


### PR DESCRIPTION
## Summary
- add guarded DB methods for worker heartbeat and proof submission
- store protocol result payloads plus legacy ZK receipt mirrors on worker submit
- document and implement lock-expiry retry exhaustion via fail_expired_proof_jobs
- add ignored Postgres integration coverage for heartbeat, submit, stale locks, and retry exhaustion