### PR TITLE
refactor (basectl): Move basectl TUI routes under monitor subcommand

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -197,4 +197,4 @@ bench-proof-mpt:
 
 # Run basectl TUI dashboard
 basectl:
-    cargo run -p basectl --release
+    cargo run -p basectl --release -- monitor

--- a/bin/basectl/README.md
+++ b/bin/basectl/README.md
@@ -34,8 +34,8 @@ Opens the interactive TUI. With no subcommand, opens the Home view.
 ### `basectl flashblocks --json`
 
 Streams live flashblocks as newline-delimited JSON to stdout. This is the only
-non-TUI subcommand. Running `basectl flashblocks` without `--json` will print a
-helpful error.
+non-TUI subcommand. Running `basectl flashblocks` without `--json` is rejected
+by the CLI usage parser; use `basectl monitor flashblocks` for the TUI.
 
 ## Examples
 

--- a/bin/basectl/README.md
+++ b/bin/basectl/README.md
@@ -31,11 +31,10 @@ Opens the interactive TUI. With no subcommand, opens the Home view.
 | `monitor upgrades` | `u` | Network upgrade activation countdown and history |
 | `monitor config` | `c` | Chain configuration view |
 
-### `basectl flashblocks --json`
+### `basectl flashblocks`
 
 Streams live flashblocks as newline-delimited JSON to stdout. This is the only
-non-TUI subcommand. Running `basectl flashblocks` without `--json` is rejected
-by the CLI usage parser; use `basectl monitor flashblocks` for the TUI.
+non-TUI subcommand. For the interactive view, use `basectl monitor flashblocks`.
 
 ## Examples
 
@@ -50,5 +49,5 @@ basectl -c devnet monitor
 basectl monitor conductor
 
 # Stream flashblocks as JSONL on sepolia
-basectl -c sepolia flashblocks --json
+basectl -c sepolia flashblocks
 ```

--- a/bin/basectl/README.md
+++ b/bin/basectl/README.md
@@ -1,3 +1,54 @@
 # `basectl`
 
-The Base control center.
+The Base infrastructure control CLI.
+
+## Usage
+
+```
+basectl [OPTIONS] [COMMAND]
+```
+
+Global options:
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `-c, --config <CONFIG>` | `mainnet` | Chain config: `mainnet`, `sepolia`, `devnet`, or a path to a config file |
+| `--conductor-rpc <URL>` | `http://localhost:5545` | Bootstrap conductor JSON-RPC URL for runtime cluster discovery. Overrides any hardcoded conductor list in the chain config. Set via `BASECTL_CONDUCTOR_RPC`. |
+
+## Commands
+
+### `basectl monitor`
+
+Opens the interactive TUI. With no subcommand, opens the Home view.
+
+| Command | Alias | Description |
+|---------|-------|-------------|
+| `monitor` | | TUI Home view |
+| `monitor conductor` | `co` | HA conductor cluster monitor |
+| `monitor da` | `d` | DA backlog monitor |
+| `monitor flashblocks` | `f` | Flashblocks TUI monitor |
+| `monitor command-center` | `cc` | Combined command center view |
+| `monitor upgrades` | `u` | Network upgrade activation countdown and history |
+| `monitor config` | `c` | Chain configuration view |
+
+### `basectl flashblocks --json`
+
+Streams live flashblocks as newline-delimited JSON to stdout. This is the only
+non-TUI subcommand. Running `basectl flashblocks` without `--json` will print a
+helpful error.
+
+## Examples
+
+```sh
+# Open TUI on mainnet
+basectl monitor
+
+# Open TUI on devnet
+basectl -c devnet monitor
+
+# Open the conductor view directly
+basectl monitor conductor
+
+# Stream flashblocks as JSONL on sepolia
+basectl -c sepolia flashblocks --json
+```

--- a/bin/basectl/src/cli.rs
+++ b/bin/basectl/src/cli.rs
@@ -18,7 +18,7 @@ pub(crate) struct Cli {
     /// polls all discovered peers via templated ports.
     ///
     /// Only applies to the conductor view (and views that embed it, like the
-    /// command center). Ignored by `flashblocks --json` and other non-TUI
+    /// command center). Ignored by `flashblocks` and other non-TUI
     /// subcommands.
     #[arg(
         long = "conductor-rpc",
@@ -39,13 +39,9 @@ pub(crate) enum Commands {
         #[command(subcommand)]
         command: Option<MonitorCommands>,
     },
-    /// Flashblocks operations
+    /// Stream flashblocks as JSON lines.
     #[command(after_help = "Use `basectl monitor flashblocks` for the TUI.")]
-    Flashblocks {
-        /// Output flashblocks as JSON lines
-        #[arg(long, required = true)]
-        json: bool,
-    },
+    Flashblocks,
 }
 
 /// TUI monitor views.

--- a/bin/basectl/src/cli.rs
+++ b/bin/basectl/src/cli.rs
@@ -40,9 +40,10 @@ pub(crate) enum Commands {
         command: Option<MonitorCommands>,
     },
     /// Flashblocks operations
+    #[command(after_help = "Use `basectl monitor flashblocks` for the TUI.")]
     Flashblocks {
         /// Output flashblocks as JSON lines
-        #[arg(long)]
+        #[arg(long, required = true)]
         json: bool,
     },
 }

--- a/bin/basectl/src/cli.rs
+++ b/bin/basectl/src/cli.rs
@@ -1,5 +1,6 @@
 //! Contains the CLI arguments for the basectl binary.
 
+use basectl_cli::ViewId;
 use clap::{Parser, Subcommand};
 use url::Url;
 
@@ -65,4 +66,17 @@ pub(crate) enum MonitorCommands {
     /// Network upgrade activation countdown and history
     #[command(visible_alias = "u")]
     Upgrades,
+}
+
+impl MonitorCommands {
+    pub(crate) const fn view_id(&self) -> ViewId {
+        match self {
+            Self::Config => ViewId::Config,
+            Self::Flashblocks => ViewId::Flashblocks,
+            Self::Da => ViewId::DaMonitor,
+            Self::CommandCenter => ViewId::CommandCenter,
+            Self::Conductor => ViewId::Conductor,
+            Self::Upgrades => ViewId::Upgrades,
+        }
+    }
 }

--- a/bin/basectl/src/cli.rs
+++ b/bin/basectl/src/cli.rs
@@ -34,16 +34,28 @@ pub(crate) struct Cli {
 /// Subcommands for the basectl CLI.
 #[derive(Debug, Subcommand)]
 pub(crate) enum Commands {
-    /// Chain configuration operations
-    #[command(visible_alias = "c")]
-    Config,
+    /// Open the interactive TUI monitor.
+    Monitor {
+        #[command(subcommand)]
+        command: Option<MonitorCommands>,
+    },
     /// Flashblocks operations
-    #[command(visible_alias = "f")]
     Flashblocks {
-        /// Output flashblocks as JSON lines instead of the TUI
+        /// Output flashblocks as JSON lines
         #[arg(long)]
         json: bool,
     },
+}
+
+/// TUI monitor views.
+#[derive(Debug, Subcommand)]
+pub(crate) enum MonitorCommands {
+    /// Chain configuration operations
+    #[command(visible_alias = "c")]
+    Config,
+    /// Flashblocks monitor
+    #[command(visible_alias = "f")]
+    Flashblocks,
     /// DA (Data Availability) backlog monitor
     #[command(visible_alias = "d")]
     Da,

--- a/bin/basectl/src/main.rs
+++ b/bin/basectl/src/main.rs
@@ -37,13 +37,8 @@ async fn main() -> anyhow::Result<()> {
             }
             None => run_app(ViewId::Home, config, conductor_rpc).await,
         },
-        Some(cli::Commands::Flashblocks { json: true }) => {
+        Some(cli::Commands::Flashblocks { .. }) => {
             run_flashblocks_json(MonitoringConfig::load(config).await?).await
-        }
-        Some(cli::Commands::Flashblocks { json: false }) => {
-            anyhow::bail!(
-                "use `basectl monitor flashblocks` for the TUI or `basectl flashblocks --json` for the JSONL stream"
-            )
         }
         None => {
             cli::Cli::command().print_help()?;

--- a/bin/basectl/src/main.rs
+++ b/bin/basectl/src/main.rs
@@ -37,7 +37,7 @@ async fn main() -> anyhow::Result<()> {
             }
             None => run_app(ViewId::Home, config, conductor_rpc).await,
         },
-        Some(cli::Commands::Flashblocks { .. }) => {
+        Some(cli::Commands::Flashblocks) => {
             run_flashblocks_json(MonitoringConfig::load(config).await?).await
         }
         None => {

--- a/bin/basectl/src/main.rs
+++ b/bin/basectl/src/main.rs
@@ -16,27 +16,10 @@ async fn main() -> anyhow::Result<()> {
     let config = &cli.config;
     let conductor_rpc = cli.conductor_rpc.clone();
     match cli.command {
-        Some(cli::Commands::Monitor { command }) => match command {
-            Some(cli::MonitorCommands::Config) => {
-                run_app(ViewId::Config, config, conductor_rpc).await
-            }
-            Some(cli::MonitorCommands::Flashblocks) => {
-                run_app(ViewId::Flashblocks, config, conductor_rpc).await
-            }
-            Some(cli::MonitorCommands::Da) => {
-                run_app(ViewId::DaMonitor, config, conductor_rpc).await
-            }
-            Some(cli::MonitorCommands::CommandCenter) => {
-                run_app(ViewId::CommandCenter, config, conductor_rpc).await
-            }
-            Some(cli::MonitorCommands::Conductor) => {
-                run_app(ViewId::Conductor, config, conductor_rpc).await
-            }
-            Some(cli::MonitorCommands::Upgrades) => {
-                run_app(ViewId::Upgrades, config, conductor_rpc).await
-            }
-            None => run_app(ViewId::Home, config, conductor_rpc).await,
-        },
+        Some(cli::Commands::Monitor { command }) => {
+            let view = command.map(|c| c.view_id()).unwrap_or(ViewId::Home);
+            run_app(view, config, conductor_rpc).await
+        }
         Some(cli::Commands::Flashblocks) => {
             run_flashblocks_json(MonitoringConfig::load(config).await?).await
         }

--- a/bin/basectl/src/main.rs
+++ b/bin/basectl/src/main.rs
@@ -3,7 +3,7 @@
 mod cli;
 
 use basectl_cli::{MonitoringConfig, ViewId, run_app, run_flashblocks_json};
-use clap::Parser;
+use clap::{CommandFactory, Parser};
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
@@ -16,19 +16,38 @@ async fn main() -> anyhow::Result<()> {
     let config = &cli.config;
     let conductor_rpc = cli.conductor_rpc.clone();
     match cli.command {
-        Some(cli::Commands::Config) => run_app(ViewId::Config, config, conductor_rpc).await,
+        Some(cli::Commands::Monitor { command }) => match command {
+            Some(cli::MonitorCommands::Config) => {
+                run_app(ViewId::Config, config, conductor_rpc).await
+            }
+            Some(cli::MonitorCommands::Flashblocks) => {
+                run_app(ViewId::Flashblocks, config, conductor_rpc).await
+            }
+            Some(cli::MonitorCommands::Da) => {
+                run_app(ViewId::DaMonitor, config, conductor_rpc).await
+            }
+            Some(cli::MonitorCommands::CommandCenter) => {
+                run_app(ViewId::CommandCenter, config, conductor_rpc).await
+            }
+            Some(cli::MonitorCommands::Conductor) => {
+                run_app(ViewId::Conductor, config, conductor_rpc).await
+            }
+            Some(cli::MonitorCommands::Upgrades) => {
+                run_app(ViewId::Upgrades, config, conductor_rpc).await
+            }
+            None => run_app(ViewId::Home, config, conductor_rpc).await,
+        },
         Some(cli::Commands::Flashblocks { json: true }) => {
             run_flashblocks_json(MonitoringConfig::load(config).await?).await
         }
         Some(cli::Commands::Flashblocks { json: false }) => {
-            run_app(ViewId::Flashblocks, config, conductor_rpc).await
+            anyhow::bail!(
+                "use `basectl monitor flashblocks` for the TUI or `basectl flashblocks --json` for the JSONL stream"
+            )
         }
-        Some(cli::Commands::Da) => run_app(ViewId::DaMonitor, config, conductor_rpc).await,
-        Some(cli::Commands::CommandCenter) => {
-            run_app(ViewId::CommandCenter, config, conductor_rpc).await
+        None => {
+            cli::Cli::command().print_help()?;
+            Ok(())
         }
-        Some(cli::Commands::Conductor) => run_app(ViewId::Conductor, config, conductor_rpc).await,
-        Some(cli::Commands::Upgrades) => run_app(ViewId::Upgrades, config, conductor_rpc).await,
-        None => run_app(ViewId::Home, config, conductor_rpc).await,
     }
 }

--- a/etc/docker/Justfile
+++ b/etc/docker/Justfile
@@ -82,7 +82,7 @@ transfer-leader to='':
 
 # TUI dashboard: HA conductor cluster monitor (requires devnet running)
 conductor:
-    cargo run --quiet -p basectl -- -c devnet conductor
+    cargo run --quiet -p basectl -- -c devnet monitor conductor
 
 # Stops devnet+ingress, deletes data, and starts fresh with full ingress stack
 ingress: ingress-down _build-setup-image (_build-rust-images "ingress" "dev")


### PR DESCRIPTION
Moved the TUI under a new `basectl monitor` subtree, reserving top-level `basectl` for future non-interactive operational CLI commands.

  ## Specific changes

  - Bare `basectl` now prints help and exits 0 instead of opening the TUI
  - `basectl monitor` opens the TUI Home view
  - All TUI views moved under `monitor`:
    - `basectl monitor conductor`
    - `basectl monitor da`
    - `basectl monitor flashblocks`
    - `basectl monitor command-center`
    - `basectl monitor upgrades`
    - `basectl monitor config`
  - Short aliases (`c`, `f`, `d`, `cc`, `co`, `u`) moved under `monitor` accordingly
  - `basectl flashblocks` remains top-level and streams JSONL directly. The post-restructure `flashblocks` namespace exists only for the JSONL stream, so the originally-required `--json` flag was dropped — a bool that can only ever be `true` was a code smell with nothing to disambiguate
  - `basectl flashblocks --help` shows an `after_help` pointer to `basectl monitor flashblocks` for users looking for the TUI view
  - Updated `etc/docker/Justfile` devnet conductor recipe to use the new path
  - Updated `bin/basectl/README.md`

  No underlying TUI behavior, views, config loading, background services, or keybindings were changed.

  ## Tests

  - `cargo check -p basectl`
  - `cargo build -p basectl`
  - `cargo clippy -p basectl --all-targets -- -D warnings`
  - `just --justfile etc/docker/Justfile --dry-run conductor`

  ### Manual parser checks

  - Bare `basectl` exits 0 and prints help
  - `basectl monitor --help` shows all moved TUI commands and aliases
  - `basectl flashblocks` streams JSONL (same output as the pre-PR `basectl flashblocks --json` behavior)
  - `basectl flashblocks --json` is rejected by clap as an unknown argument
  - `basectl flashblocks --help` reads cleanly with the `after_help` pointer
  - Old top-level TUI paths (e.g. `basectl conductor`) are correctly rejected
  - All short aliases under `monitor` resolve correctly
  - `basectl monitor --json` is correctly rejected