### PR TITLE
chore(consensus): pin EIP-8130 AA tx type bytes to final values

### DIFF
--- a/crates/common/consensus/src/transaction/eip8130/constants.rs
+++ b/crates/common/consensus/src/transaction/eip8130/constants.rs
@@ -20,23 +20,20 @@ use alloy_primitives::{Address, U256, address};
 pub struct Eip8130Constants;
 
 impl Eip8130Constants {
-    /// [EIP-2718] transaction type byte for AA transactions (`EIP8130_TX_TYPE`).
+    /// [EIP-2718] transaction type byte for AA transactions (`AA_TX_TYPE`).
     ///
-    /// Spec value: TBD. We use `0x7D`, picked to live in the high "OP-style"
-    /// type-byte range adjacent to (but distinct from) the deposit type `0x7E`,
-    /// and to be easy to renumber once the EIP finalizes.
+    /// Pinned to `0x7B` by the EIP-8130 constant table.
     ///
     /// [EIP-2718]: https://eips.ethereum.org/EIPS/eip-2718
-    pub const EIP8130_TX_TYPE: u8 = 0x7D;
+    pub const EIP8130_TX_TYPE: u8 = 0x7B;
 
-    /// Magic prefix byte for payer signature domain separation (`EIP8130_PAYER_TYPE`).
+    /// Magic prefix byte for payer signature domain separation (`AA_PAYER_TYPE`).
     ///
     /// Used in the payer signature preimage:
     /// `keccak256(EIP8130_PAYER_TYPE || rlp([...fields through calls...]))`.
     ///
-    /// Spec value: TBD. We use `0xFA`, distinct from any registered EIP-2718
-    /// transaction type byte to prevent cross-domain reuse.
-    pub const EIP8130_PAYER_TYPE: u8 = 0xFA;
+    /// Pinned to `0x7C` by the EIP-8130 constant table.
+    pub const EIP8130_PAYER_TYPE: u8 = 0x7C;
 
     /// Base intrinsic gas cost for any AA transaction (`EIP8130_BASE_COST`).
     pub const EIP8130_BASE_COST: u64 = 15_000;


### PR DESCRIPTION
## Summary
- EIP-8130 ([ethereum/EIPs#11757](https://github.com/ethereum/EIPs/pull/11757)) pins the transaction type bytes in its constant table: `AA_TX_TYPE = 0x7B` and `AA_PAYER_TYPE = 0x7C`.
- Update `Eip8130Constants::EIP8130_TX_TYPE` (was the provisional `0x7D`) and `EIP8130_PAYER_TYPE` (was `0xFA`) to match, and drop the "TBD / project choice" wording for these two.
- All EIP-8130 type-byte references route through these named constants, so this is the single source of truth — no other literals to change.

## Test plan
- [x] `cargo test -p base-common-consensus --lib eip8130` (34 passed)
- [x] `cargo test -p base-common-consensus --lib tx_type` (2 passed)