### PR TITLE
fix(b20-asset): emit effective multiplier (WAD) in MultiplierUpdated when zero is passed

### DIFF
--- a/crates/common/precompiles/src/b20_asset/token.rs
+++ b/crates/common/precompiles/src/b20_asset/token.rs
@@ -215,8 +215,16 @@ impl<S: AssetAccounting, P: Policy> B20AssetToken<S, P> {
     ) -> Result<()> {
         self.ensure_operator_role(caller, privileged)?;
         self.accounting_mut().set_multiplier(new_multiplier)?;
+        // Emit the effective multiplier: zero is the storage sentinel for WAD,
+        // so callers and off-chain indexers always see the value that arithmetic
+        // will actually use. See #3187.
+        let effective = if new_multiplier.is_zero() {
+            B20AssetStorage::WAD
+        } else {
+            new_multiplier
+        };
         self.accounting_mut().emit_event(
-            IB20Asset::MultiplierUpdated { multiplier: new_multiplier }.encode_log_data(),
+            IB20Asset::MultiplierUpdated { multiplier: effective }.encode_log_data(),
         )
     }
 


### PR DESCRIPTION
Fixes #3187.

`update_multiplier(0)` stored zero in the asset slot and emitted `MultiplierUpdated { multiplier: 0 }`, but the `multiplier()` getter treats zero as a sentinel for WAD (1e18):

```rust
Ok(if multiplier.is_zero() { Self::WAD } else { multiplier })
```

So all arithmetic (`to_scaled_balance`, `to_raw_balance`) operated with WAD while the emitted event said `0`. Off-chain indexers and consumers would read a multiplier of `0` but the token would behave as if it were `1e18`.

This PR emits the effective value (`WAD`) when `new_multiplier == 0`, so the event always reflects what arithmetic will actually use. The storage write and the getter behavior are unchanged only the event payload is corrected.

No ABI change. One line behavior fix in `update_multiplier`.