### PR TITLE
fix(b20-asset): bubble revert reasons from announce inner calls

### DIFF
--- a/crates/common/precompiles/src/b20_asset/dispatch.rs
+++ b/crates/common/precompiles/src/b20_asset/dispatch.rs
@@ -420,8 +420,14 @@ impl<S: AssetAccounting, P: Policy> B20AssetToken<S, P> {
             if call_bytes[..4] == IB20Asset::announceCall::SELECTOR {
                 return Err(BasePrecompileError::revert(IB20Asset::AnnouncementInProgress {}));
             }
-            self.inner_with_privilege(ctx, call_bytes, privileged).map_err(|_| {
-                BasePrecompileError::revert(IB20Asset::InternalCallFailed { call: call.clone() })
+            self.inner_with_privilege(ctx, call_bytes, privileged).map_err(|err| match err {
+                BasePrecompileError::Revert(bytes) if !bytes.is_empty() => {
+                    BasePrecompileError::Revert(bytes)
+                }
+                err if err.is_system_error() => err,
+                _ => BasePrecompileError::revert(IB20Asset::InternalCallFailed {
+                    call: call.clone(),
+                }),
             })?;
         }
 


### PR DESCRIPTION
Fixes #3189.

`announce` was discarding the original error from failing `internal_calls` with `|_|`, so callers only ever saw `InternalCallFailed` with no diagnostic information regardless of the actual failure reason.

This PR mirrors the pattern already used by `b20_factory`'s `map_init_call_error`: non empty reverts are bubbled up directly, system errors are preserved, and only empty reverts fall back to `InternalCallFailed`.

Before:
```rust
.map_err(|_| {
    BasePrecompileError::revert(IB20Asset::InternalCallFailed { call: call.clone() })
})?;
```

After:
```rust
.map_err(|err| match err {
    BasePrecompileError::Revert(bytes) if !bytes.is_empty() => {
        BasePrecompileError::Revert(bytes)
    }
    err if err.is_system_error() => err,
    _ => BasePrecompileError::revert(IB20Asset::InternalCallFailed {
        call: call.clone(),
    }),
})?;
```

No behavior change for the happy path. Failing inner calls now surface their actual revert reason instead of being wrapped in a generic `InternalCallFailed`.