### PR TITLE
fix(sp1): use Rust 1.94 toolchain for ELF builds

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -19,7 +19,7 @@ inputs:
     default: "false"
   sp1-version:
     description: SP1 release tag used when sp1 is enabled (matches etc/just/succinct.just)
-    default: "v6.1.0"
+    default: "v6.2.3"
   elf-cache:
     description: Restore/save the ELF cache keyed on crates/proof/succinct/elf/manifest.toml
     default: "false"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2284,7 +2284,7 @@ dependencies = [
 
 [[package]]
 name = "audit-archiver"
-version = "0.0.0"
+version = "1.1.0"
 dependencies = [
  "anyhow",
  "audit-archiver-lib",
@@ -2303,7 +2303,7 @@ dependencies = [
 
 [[package]]
 name = "audit-archiver-lib"
-version = "0.0.0"
+version = "1.1.0"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-primitives",
@@ -3109,7 +3109,7 @@ dependencies = [
 
 [[package]]
 name = "base"
-version = "0.0.0"
+version = "1.1.0"
 dependencies = [
  "alloy-chains",
  "base-cli-utils",
@@ -3130,7 +3130,7 @@ dependencies = [
 
 [[package]]
 name = "base-access-lists"
-version = "0.0.0"
+version = "1.1.0"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-contract 2.0.5",
@@ -3148,7 +3148,7 @@ dependencies = [
 
 [[package]]
 name = "base-action-harness"
-version = "0.0.0"
+version = "1.1.0"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -3212,7 +3212,7 @@ dependencies = [
 
 [[package]]
 name = "base-balance-monitor"
-version = "0.0.0"
+version = "1.1.0"
 dependencies = [
  "alloy-network 2.0.5",
  "alloy-node-bindings 2.0.5",
@@ -3225,7 +3225,7 @@ dependencies = [
 
 [[package]]
 name = "base-batcher-admin"
-version = "0.0.0"
+version = "1.1.0"
 dependencies = [
  "base-batcher-core",
  "derive_more 2.1.1",
@@ -3236,7 +3236,7 @@ dependencies = [
 
 [[package]]
 name = "base-batcher-bin"
-version = "0.0.0"
+version = "1.1.0"
 dependencies = [
  "alloy-primitives",
  "alloy-signer-local 2.0.5",
@@ -3255,7 +3255,7 @@ dependencies = [
 
 [[package]]
 name = "base-batcher-core"
-version = "0.0.0"
+version = "1.1.0"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-primitives",
@@ -3280,7 +3280,7 @@ dependencies = [
 
 [[package]]
 name = "base-batcher-encoder"
-version = "0.0.0"
+version = "1.1.0"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -3300,7 +3300,7 @@ dependencies = [
 
 [[package]]
 name = "base-batcher-service"
-version = "0.0.0"
+version = "1.1.0"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-primitives",
@@ -3334,7 +3334,7 @@ dependencies = [
 
 [[package]]
 name = "base-batcher-source"
-version = "0.0.0"
+version = "1.1.0"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-primitives",
@@ -3351,7 +3351,7 @@ dependencies = [
 
 [[package]]
 name = "base-blobs"
-version = "0.0.0"
+version = "1.1.0"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-primitives",
@@ -3362,7 +3362,7 @@ dependencies = [
 
 [[package]]
 name = "base-builder-bin"
-version = "0.0.0"
+version = "1.1.0"
 dependencies = [
  "alloy-primitives",
  "base-builder-core",
@@ -3382,7 +3382,7 @@ dependencies = [
 
 [[package]]
 name = "base-builder-core"
-version = "0.0.0"
+version = "1.1.0"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-contract 2.0.5",
@@ -3511,7 +3511,7 @@ dependencies = [
 
 [[package]]
 name = "base-builder-metering"
-version = "0.0.0"
+version = "1.1.0"
 dependencies = [
  "alloy-primitives",
  "base-builder-core",
@@ -3524,7 +3524,7 @@ dependencies = [
 
 [[package]]
 name = "base-builder-publish"
-version = "0.0.0"
+version = "1.1.0"
 dependencies = [
  "base-metrics",
  "base-ring-buffer",
@@ -3544,7 +3544,7 @@ dependencies = [
 
 [[package]]
 name = "base-bundle-extension"
-version = "0.0.0"
+version = "1.1.0"
 dependencies = [
  "base-execution-txpool",
  "base-node-runner",
@@ -3557,7 +3557,7 @@ dependencies = [
 
 [[package]]
 name = "base-bundles"
-version = "0.0.0"
+version = "1.1.0"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-primitives",
@@ -3574,7 +3574,7 @@ dependencies = [
 
 [[package]]
 name = "base-challenger"
-version = "0.0.0"
+version = "1.1.0"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-primitives",
@@ -3617,7 +3617,7 @@ dependencies = [
 
 [[package]]
 name = "base-challenger-bin"
-version = "0.0.0"
+version = "1.1.0"
 dependencies = [
  "base-challenger",
  "base-cli-utils",
@@ -3627,7 +3627,7 @@ dependencies = [
 
 [[package]]
 name = "base-cli-utils"
-version = "0.0.0"
+version = "1.1.0"
 dependencies = [
  "backtrace",
  "base-metrics",
@@ -3650,7 +3650,7 @@ dependencies = [
 
 [[package]]
 name = "base-common-chains"
-version = "0.0.0"
+version = "1.1.0"
 dependencies = [
  "alloy-chains",
  "alloy-eips 2.0.5",
@@ -3666,7 +3666,7 @@ dependencies = [
 
 [[package]]
 name = "base-common-consensus"
-version = "0.0.0"
+version = "1.1.0"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -3697,7 +3697,7 @@ dependencies = [
 
 [[package]]
 name = "base-common-evm"
-version = "0.0.0"
+version = "1.1.0"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -3721,7 +3721,7 @@ dependencies = [
 
 [[package]]
 name = "base-common-flashblocks"
-version = "0.0.0"
+version = "1.1.0"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-engine",
@@ -3737,7 +3737,7 @@ dependencies = [
 
 [[package]]
 name = "base-common-flz"
-version = "0.0.0"
+version = "1.1.0"
 dependencies = [
  "hex-literal 1.1.0",
  "rstest",
@@ -3745,7 +3745,7 @@ dependencies = [
 
 [[package]]
 name = "base-common-genesis"
-version = "0.0.0"
+version = "1.1.0"
 dependencies = [
  "alloy-chains",
  "alloy-consensus 2.0.5",
@@ -3766,7 +3766,7 @@ dependencies = [
 
 [[package]]
 name = "base-common-network"
-version = "0.0.0"
+version = "1.1.0"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-network 2.0.5",
@@ -3784,7 +3784,7 @@ dependencies = [
 
 [[package]]
 name = "base-common-precompiles"
-version = "0.0.0"
+version = "1.1.0"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -3800,7 +3800,7 @@ dependencies = [
 
 [[package]]
 name = "base-common-rpc-types"
-version = "0.0.0"
+version = "1.1.0"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -3825,7 +3825,7 @@ dependencies = [
 
 [[package]]
 name = "base-common-rpc-types-engine"
-version = "0.0.0"
+version = "1.1.0"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -3848,7 +3848,7 @@ dependencies = [
 
 [[package]]
 name = "base-common-signer"
-version = "0.0.0"
+version = "1.1.0"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -3868,7 +3868,7 @@ dependencies = [
 
 [[package]]
 name = "base-comp"
-version = "0.0.0"
+version = "1.1.0"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -3893,7 +3893,7 @@ dependencies = [
 
 [[package]]
 name = "base-consensus"
-version = "0.0.0"
+version = "1.1.0"
 dependencies = [
  "base-cli-utils",
  "base-consensus-cli",
@@ -3902,7 +3902,7 @@ dependencies = [
 
 [[package]]
 name = "base-consensus-cli"
-version = "0.0.0"
+version = "1.1.0"
 dependencies = [
  "alloy-chains",
  "alloy-genesis 2.0.5",
@@ -3945,7 +3945,7 @@ dependencies = [
 
 [[package]]
 name = "base-consensus-derive"
-version = "0.0.0"
+version = "1.1.0"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -3975,7 +3975,7 @@ dependencies = [
 
 [[package]]
 name = "base-consensus-disc"
-version = "0.0.0"
+version = "1.1.0"
 dependencies = [
  "alloy-rlp",
  "backon",
@@ -3998,7 +3998,7 @@ dependencies = [
 
 [[package]]
 name = "base-consensus-engine"
-version = "0.0.0"
+version = "1.1.0"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -4041,7 +4041,7 @@ dependencies = [
 
 [[package]]
 name = "base-consensus-gossip"
-version = "0.0.0"
+version = "1.1.0"
 dependencies = [
  "alloy-chains",
  "alloy-consensus 2.0.5",
@@ -4080,7 +4080,7 @@ dependencies = [
 
 [[package]]
 name = "base-consensus-node"
-version = "0.0.0"
+version = "1.1.0"
 dependencies = [
  "alloy-chains",
  "alloy-consensus 2.0.5",
@@ -4150,7 +4150,7 @@ dependencies = [
 
 [[package]]
 name = "base-consensus-peers"
-version = "0.0.0"
+version = "1.1.0"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -4176,7 +4176,7 @@ dependencies = [
 
 [[package]]
 name = "base-consensus-providers"
-version = "0.0.0"
+version = "1.1.0"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -4213,7 +4213,7 @@ dependencies = [
 
 [[package]]
 name = "base-consensus-rpc"
-version = "0.0.0"
+version = "1.1.0"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-primitives",
@@ -4239,7 +4239,7 @@ dependencies = [
 
 [[package]]
 name = "base-consensus-safedb"
-version = "0.0.0"
+version = "1.1.0"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-primitives",
@@ -4255,7 +4255,7 @@ dependencies = [
 
 [[package]]
 name = "base-consensus-sources"
-version = "0.0.0"
+version = "1.1.0"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-client 2.0.5",
@@ -4277,7 +4277,7 @@ dependencies = [
 
 [[package]]
 name = "base-consensus-upgrades"
-version = "0.0.0"
+version = "1.1.0"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-primitives",
@@ -4289,7 +4289,7 @@ dependencies = [
 
 [[package]]
 name = "base-engine-tree"
-version = "0.0.0"
+version = "1.1.0"
 dependencies = [
  "alloy-chains",
  "alloy-consensus 2.0.5",
@@ -4337,7 +4337,7 @@ dependencies = [
 
 [[package]]
 name = "base-execution-chainspec"
-version = "0.0.0"
+version = "1.1.0"
 dependencies = [
  "alloy-chains",
  "alloy-consensus 2.0.5",
@@ -4360,7 +4360,7 @@ dependencies = [
 
 [[package]]
 name = "base-execution-cli"
-version = "0.0.0"
+version = "1.1.0"
 dependencies = [
  "alloy-eips 2.0.5",
  "backon",
@@ -4415,7 +4415,7 @@ dependencies = [
 
 [[package]]
 name = "base-execution-consensus"
-version = "0.0.0"
+version = "1.1.0"
 dependencies = [
  "alloy-chains",
  "alloy-consensus 2.0.5",
@@ -4445,7 +4445,7 @@ dependencies = [
 
 [[package]]
 name = "base-execution-evm"
-version = "0.0.0"
+version = "1.1.0"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -4472,7 +4472,7 @@ dependencies = [
 
 [[package]]
 name = "base-execution-exex"
-version = "0.0.0"
+version = "1.1.0"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -4498,7 +4498,7 @@ dependencies = [
 
 [[package]]
 name = "base-execution-payload-builder"
-version = "0.0.0"
+version = "1.1.0"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -4538,7 +4538,7 @@ dependencies = [
 
 [[package]]
 name = "base-execution-rpc"
-version = "0.0.0"
+version = "1.1.0"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -4602,7 +4602,7 @@ dependencies = [
 
 [[package]]
 name = "base-execution-trie"
-version = "0.0.0"
+version = "1.1.0"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -4648,7 +4648,7 @@ dependencies = [
 
 [[package]]
 name = "base-execution-txpool"
-version = "0.0.0"
+version = "1.1.0"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -4690,7 +4690,7 @@ dependencies = [
 
 [[package]]
 name = "base-flashblocks"
-version = "0.0.0"
+version = "1.1.0"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -4746,7 +4746,7 @@ dependencies = [
 
 [[package]]
 name = "base-flashblocks-node"
-version = "0.0.0"
+version = "1.1.0"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-contract 2.0.5",
@@ -4802,7 +4802,7 @@ dependencies = [
 
 [[package]]
 name = "base-health"
-version = "0.0.0"
+version = "1.1.0"
 dependencies = [
  "alloy-transport-http 2.0.5",
  "async-trait",
@@ -4824,7 +4824,7 @@ dependencies = [
 
 [[package]]
 name = "base-jwt"
-version = "0.0.0"
+version = "1.1.0"
 dependencies = [
  "alloy-primitives",
  "alloy-provider 2.0.5",
@@ -4840,7 +4840,7 @@ dependencies = [
 
 [[package]]
 name = "base-load-tester-bin"
-version = "0.0.0"
+version = "1.1.0"
 dependencies = [
  "alloy-network 2.0.5",
  "alloy-primitives",
@@ -4862,7 +4862,7 @@ dependencies = [
 
 [[package]]
 name = "base-load-tests"
-version = "0.0.0"
+version = "1.1.0"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -4901,7 +4901,7 @@ dependencies = [
 
 [[package]]
 name = "base-metering"
-version = "0.0.0"
+version = "1.1.0"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -4955,7 +4955,7 @@ dependencies = [
 
 [[package]]
 name = "base-metrics"
-version = "0.0.0"
+version = "1.1.0"
 dependencies = [
  "ctor",
  "metrics",
@@ -4965,7 +4965,7 @@ dependencies = [
 
 [[package]]
 name = "base-node-core"
-version = "0.0.0"
+version = "1.1.0"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -5034,7 +5034,7 @@ dependencies = [
 
 [[package]]
 name = "base-node-runner"
-version = "0.0.0"
+version = "1.1.0"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-genesis 2.0.5",
@@ -5085,7 +5085,7 @@ dependencies = [
 
 [[package]]
 name = "base-precompile-macros"
-version = "0.0.0"
+version = "1.1.0"
 dependencies = [
  "alloy-primitives",
  "proc-macro2",
@@ -5095,7 +5095,7 @@ dependencies = [
 
 [[package]]
 name = "base-precompile-storage"
-version = "0.0.0"
+version = "1.1.0"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -5109,7 +5109,7 @@ dependencies = [
 
 [[package]]
 name = "base-proof"
-version = "0.0.0"
+version = "1.1.0"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -5147,7 +5147,7 @@ dependencies = [
 
 [[package]]
 name = "base-proof-client"
-version = "0.0.0"
+version = "1.1.0"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-evm",
@@ -5170,7 +5170,7 @@ dependencies = [
 
 [[package]]
 name = "base-proof-contracts"
-version = "0.0.0"
+version = "1.1.0"
 dependencies = [
  "alloy-contract 2.0.5",
  "alloy-primitives",
@@ -5187,7 +5187,7 @@ dependencies = [
 
 [[package]]
 name = "base-proof-driver"
-version = "0.0.0"
+version = "1.1.0"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-evm",
@@ -5207,7 +5207,7 @@ dependencies = [
 
 [[package]]
 name = "base-proof-executor"
-version = "0.0.0"
+version = "1.1.0"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -5241,7 +5241,7 @@ dependencies = [
 
 [[package]]
 name = "base-proof-host"
-version = "0.0.0"
+version = "1.1.0"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -5282,7 +5282,7 @@ dependencies = [
 
 [[package]]
 name = "base-proof-mpt"
-version = "0.0.0"
+version = "1.1.0"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-primitives",
@@ -5303,7 +5303,7 @@ dependencies = [
 
 [[package]]
 name = "base-proof-preimage"
-version = "0.0.0"
+version = "1.1.0"
 dependencies = [
  "alloy-primitives",
  "async-channel",
@@ -5317,7 +5317,7 @@ dependencies = [
 
 [[package]]
 name = "base-proof-primitives"
-version = "0.0.0"
+version = "1.1.0"
 dependencies = [
  "alloy-chains",
  "alloy-eips 2.0.5",
@@ -5335,7 +5335,7 @@ dependencies = [
 
 [[package]]
 name = "base-proof-rpc"
-version = "0.0.0"
+version = "1.1.0"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-network 2.0.5",
@@ -5362,7 +5362,7 @@ dependencies = [
 
 [[package]]
 name = "base-proof-succinct-build-utils"
-version = "0.0.0"
+version = "1.1.0"
 dependencies = [
  "cargo_metadata 0.18.1",
  "sp1-build",
@@ -5370,7 +5370,7 @@ dependencies = [
 
 [[package]]
 name = "base-proof-succinct-client-utils"
-version = "0.0.0"
+version = "1.1.0"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -5407,7 +5407,7 @@ dependencies = [
 
 [[package]]
 name = "base-proof-succinct-elfs"
-version = "0.0.0"
+version = "1.1.0"
 dependencies = [
  "serde",
  "sha2 0.10.9",
@@ -5416,7 +5416,7 @@ dependencies = [
 
 [[package]]
 name = "base-proof-succinct-ethereum-client-utils"
-version = "0.0.0"
+version = "1.1.0"
 dependencies = [
  "alloy-genesis 2.0.5",
  "anyhow",
@@ -5433,7 +5433,7 @@ dependencies = [
 
 [[package]]
 name = "base-proof-succinct-ethereum-host-utils"
-version = "0.0.0"
+version = "1.1.0"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-primitives",
@@ -5452,7 +5452,7 @@ dependencies = [
 
 [[package]]
 name = "base-proof-succinct-host-utils"
-version = "0.0.0"
+version = "1.1.0"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-contract 2.0.5",
@@ -5506,7 +5506,7 @@ dependencies = [
 
 [[package]]
 name = "base-proof-succinct-proof-utils"
-version = "0.0.0"
+version = "1.1.0"
 dependencies = [
  "anyhow",
  "base-proof-succinct-elfs",
@@ -5526,7 +5526,7 @@ dependencies = [
 
 [[package]]
 name = "base-proof-succinct-prove"
-version = "0.0.0"
+version = "1.1.0"
 dependencies = [
  "alloy-contract 2.0.5",
  "alloy-eips 2.0.5",
@@ -5561,7 +5561,7 @@ dependencies = [
 
 [[package]]
 name = "base-proof-succinct-scripts"
-version = "0.0.0"
+version = "1.1.0"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-network 2.0.5",
@@ -5593,7 +5593,7 @@ dependencies = [
 
 [[package]]
 name = "base-proof-succinct-signer-utils"
-version = "0.0.0"
+version = "1.1.0"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -5614,7 +5614,7 @@ dependencies = [
 
 [[package]]
 name = "base-proof-succinct-validity"
-version = "0.0.0"
+version = "1.1.0"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-primitives",
@@ -5653,7 +5653,7 @@ dependencies = [
 
 [[package]]
 name = "base-proof-tee-nitro-attestation-prover"
-version = "0.0.0"
+version = "1.1.0"
 dependencies = [
  "alloy-primitives",
  "anyhow",
@@ -5672,7 +5672,7 @@ dependencies = [
 
 [[package]]
 name = "base-proof-tee-nitro-enclave"
-version = "0.0.0"
+version = "1.1.0"
 dependencies = [
  "alloy-chains",
  "alloy-eips 2.0.5",
@@ -5705,7 +5705,7 @@ dependencies = [
 
 [[package]]
 name = "base-proof-tee-nitro-host"
-version = "0.0.0"
+version = "1.1.0"
 dependencies = [
  "alloy-genesis 2.0.5",
  "alloy-primitives",
@@ -5736,7 +5736,7 @@ dependencies = [
 
 [[package]]
 name = "base-proof-tee-nitro-verifier"
-version = "0.0.0"
+version = "1.1.0"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -5753,7 +5753,7 @@ dependencies = [
 
 [[package]]
 name = "base-proof-tee-registrar"
-version = "0.0.0"
+version = "1.1.0"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-primitives",
@@ -5791,7 +5791,7 @@ dependencies = [
 
 [[package]]
 name = "base-proof-tee-registrar-bin"
-version = "0.0.0"
+version = "1.1.0"
 dependencies = [
  "alloy-primitives",
  "alloy-provider 2.0.5",
@@ -5821,7 +5821,7 @@ dependencies = [
 
 [[package]]
 name = "base-proofs-extension"
-version = "0.0.0"
+version = "1.1.0"
 dependencies = [
  "base-common-consensus",
  "base-execution-exex",
@@ -5840,7 +5840,7 @@ dependencies = [
 
 [[package]]
 name = "base-proposer"
-version = "0.0.0"
+version = "1.1.0"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-primitives",
@@ -5881,7 +5881,7 @@ dependencies = [
 
 [[package]]
 name = "base-proposer-bin"
-version = "0.0.0"
+version = "1.1.0"
 dependencies = [
  "base-cli-utils",
  "base-proposer",
@@ -5892,7 +5892,7 @@ dependencies = [
 
 [[package]]
 name = "base-protocol"
-version = "0.0.0"
+version = "1.1.0"
 dependencies = [
  "alloc-no-stdlib",
  "alloy-consensus 2.0.5",
@@ -5928,7 +5928,7 @@ dependencies = [
 
 [[package]]
 name = "base-prover-nitro-enclave"
-version = "0.0.0"
+version = "1.1.0"
 dependencies = [
  "base-proof-tee-nitro-enclave",
  "eyre",
@@ -5937,7 +5937,7 @@ dependencies = [
 
 [[package]]
 name = "base-prover-nitro-host"
-version = "0.0.0"
+version = "1.1.0"
 dependencies = [
  "alloy-primitives",
  "base-cli-utils",
@@ -5957,7 +5957,7 @@ dependencies = [
 
 [[package]]
 name = "base-prover-service"
-version = "0.0.0"
+version = "1.1.0"
 dependencies = [
  "alloy-primitives",
  "alloy-provider 2.0.5",
@@ -6000,7 +6000,7 @@ dependencies = [
 
 [[package]]
 name = "base-prover-service-client"
-version = "0.0.0"
+version = "1.1.0"
 dependencies = [
  "async-trait",
  "base-prover-service-protocol",
@@ -6015,7 +6015,7 @@ dependencies = [
 
 [[package]]
 name = "base-prover-service-db"
-version = "0.0.0"
+version = "1.1.0"
 dependencies = [
  "anyhow",
  "base-prover-service-protocol",
@@ -6032,7 +6032,7 @@ dependencies = [
 
 [[package]]
 name = "base-prover-service-outbox"
-version = "0.0.0"
+version = "1.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6046,7 +6046,7 @@ dependencies = [
 
 [[package]]
 name = "base-prover-service-protocol"
-version = "0.0.0"
+version = "1.1.0"
 dependencies = [
  "alloy-primitives",
  "base-proof-primitives",
@@ -6059,7 +6059,7 @@ dependencies = [
 
 [[package]]
 name = "base-prover-zk"
-version = "0.0.0"
+version = "1.1.0"
 dependencies = [
  "base-cli-utils",
  "base-proof-succinct-host-utils",
@@ -6087,14 +6087,14 @@ dependencies = [
 
 [[package]]
 name = "base-reth-cli"
-version = "0.0.0"
+version = "1.1.0"
 dependencies = [
  "reth-node-core",
 ]
 
 [[package]]
 name = "base-reth-node"
-version = "0.0.0"
+version = "1.1.0"
 dependencies = [
  "base-cli-utils",
  "base-execution-cli",
@@ -6105,11 +6105,11 @@ dependencies = [
 
 [[package]]
 name = "base-ring-buffer"
-version = "0.0.0"
+version = "1.1.0"
 
 [[package]]
 name = "base-runtime"
-version = "0.0.0"
+version = "1.1.0"
 dependencies = [
  "futures",
  "rand 0.9.4",
@@ -6121,7 +6121,7 @@ dependencies = [
 
 [[package]]
 name = "base-snapshotter"
-version = "0.0.0"
+version = "1.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6146,7 +6146,7 @@ dependencies = [
 
 [[package]]
 name = "base-snapshotter-bin"
-version = "0.0.0"
+version = "1.1.0"
 dependencies = [
  "anyhow",
  "aws-config",
@@ -6162,7 +6162,7 @@ dependencies = [
 
 [[package]]
 name = "base-snark-e2e"
-version = "0.0.0"
+version = "1.1.0"
 dependencies = [
  "base-zk-service",
  "tokio",
@@ -6172,7 +6172,7 @@ dependencies = [
 
 [[package]]
 name = "base-system-tests"
-version = "0.0.0"
+version = "1.1.0"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -6240,7 +6240,7 @@ dependencies = [
 
 [[package]]
 name = "base-test-utils"
-version = "0.0.0"
+version = "1.1.0"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-contract 2.0.5",
@@ -6258,7 +6258,7 @@ dependencies = [
 
 [[package]]
 name = "base-tx-forwarding"
-version = "0.0.0"
+version = "1.1.0"
 dependencies = [
  "base-execution-txpool",
  "base-node-runner",
@@ -6268,7 +6268,7 @@ dependencies = [
 
 [[package]]
 name = "base-tx-manager"
-version = "0.0.0"
+version = "1.1.0"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -6302,7 +6302,7 @@ dependencies = [
 
 [[package]]
 name = "base-txpool-rpc"
-version = "0.0.0"
+version = "1.1.0"
 dependencies = [
  "alloy-primitives",
  "base-node-runner",
@@ -6319,7 +6319,7 @@ dependencies = [
 
 [[package]]
 name = "base-txpool-tracing"
-version = "0.0.0"
+version = "1.1.0"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -6350,7 +6350,7 @@ dependencies = [
 
 [[package]]
 name = "base-witness-diff"
-version = "0.0.0"
+version = "1.1.0"
 dependencies = [
  "alloy-primitives",
  "alloy-provider 2.0.5",
@@ -6376,7 +6376,7 @@ checksum = "4cbbc9d0964165b47557570cce6c952866c2678457aca742aafc9fb771d30270"
 
 [[package]]
 name = "base-zk-client"
-version = "0.0.0"
+version = "1.1.0"
 dependencies = [
  "async-trait",
  "prost 0.14.3",
@@ -6392,7 +6392,7 @@ dependencies = [
 
 [[package]]
 name = "base-zk-db"
-version = "0.0.0"
+version = "1.1.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6408,7 +6408,7 @@ dependencies = [
 
 [[package]]
 name = "base-zk-outbox"
-version = "0.0.0"
+version = "1.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6421,7 +6421,7 @@ dependencies = [
 
 [[package]]
 name = "base-zk-service"
-version = "0.0.0"
+version = "1.1.0"
 dependencies = [
  "alloy-primitives",
  "alloy-provider 2.0.5",
@@ -6507,7 +6507,7 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
 name = "basectl"
-version = "0.0.0"
+version = "1.1.0"
 dependencies = [
  "anyhow",
  "basectl-cli",
@@ -6519,7 +6519,7 @@ dependencies = [
 
 [[package]]
 name = "basectl-cli"
-version = "0.0.0"
+version = "1.1.0"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-contract 2.0.5",
@@ -6556,7 +6556,7 @@ dependencies = [
 
 [[package]]
 name = "based"
-version = "0.0.0"
+version = "1.1.0"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-primitives",
@@ -6572,7 +6572,7 @@ dependencies = [
 
 [[package]]
 name = "based-bin"
-version = "0.0.0"
+version = "1.1.0"
 dependencies = [
  "base-cli-utils",
  "based",
@@ -11233,7 +11233,7 @@ dependencies = [
 
 [[package]]
 name = "ingress-rpc"
-version = "0.0.0"
+version = "1.1.0"
 dependencies = [
  "alloy-provider 2.0.5",
  "anyhow",
@@ -11252,7 +11252,7 @@ dependencies = [
 
 [[package]]
 name = "ingress-rpc-lib"
-version = "0.0.0"
+version = "1.1.0"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -24562,7 +24562,7 @@ dependencies = [
 
 [[package]]
 name = "websocket-proxy"
-version = "0.0.0"
+version = "1.1.0"
 dependencies = [
  "axum 0.8.9",
  "backoff",
@@ -24583,7 +24583,7 @@ dependencies = [
 
 [[package]]
 name = "websocket-proxy-bin"
-version = "0.0.0"
+version = "1.1.0"
 dependencies = [
  "axum 0.8.9",
  "base-cli-utils",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -459,13 +459,13 @@ boundless-market = "1.1"
 risc0-ethereum-contracts = "3.0.1"
 risc0-zkvm = { version = "^3.0", default-features = false }
 
-# SP1 v6.1.0 (Hypercube) — used by crates/proof/succinct
-sp1-sdk = { version = "=6.2.1" }
+# SP1 v6.2.1 (Hypercube) — used by crates/proof/succinct
 sp1-build = "=6.2.1"
 sp1-prover-types = "=6.2.1"
-sp1-cluster-artifact = { git = "https://github.com/succinctlabs/sp1-cluster", tag = "v2.3.2" }
-sp1-cluster-common = { git = "https://github.com/succinctlabs/sp1-cluster", tag = "v2.3.2" }
+sp1-sdk = { version = "=6.2.1" }
 sp1-cluster-utils = { git = "https://github.com/succinctlabs/sp1-cluster", tag = "v2.3.2" }
+sp1-cluster-common = { git = "https://github.com/succinctlabs/sp1-cluster", tag = "v2.3.2" }
+sp1-cluster-artifact = { git = "https://github.com/succinctlabs/sp1-cluster", tag = "v2.3.2" }
 
 # crypto
 sha3 = "0.10"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.0.0"
+version = "1.1.0"
 edition = "2024"
 rust-version = "1.94"
 license = "MIT"

--- a/crates/proof/succinct/elf/manifest.toml
+++ b/crates/proof/succinct/elf/manifest.toml
@@ -17,8 +17,8 @@
 
 [[elfs]]
 name = "range-elf-embedded"
-sha256 = "b678508eb6d75befac282b9af9cb873d112a424f6a5fbdc4213b31628c0c2f8a"
+sha256 = "5ca834ef66f14780376b5907179280b6b102d8dd54ddbabb5dd48a92009233b3"
 
 [[elfs]]
 name = "aggregation-elf"
-sha256 = "baf0a889a5c493d780235b14f21e4f6c94feb8d4d8e138224f0d7d8572c944b9"
+sha256 = "5e4f197bbbdd51a276d3c6b49e0236566bb9555d68b6b1c3b03e3d289a2f9e14"

--- a/crates/proof/succinct/programs/Cargo.lock
+++ b/crates/proof/succinct/programs/Cargo.lock
@@ -657,7 +657,7 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "base-common-chains"
-version = "0.0.0"
+version = "1.1.0"
 dependencies = [
  "alloy-chains",
  "alloy-eips 2.0.5",
@@ -672,7 +672,7 @@ dependencies = [
 
 [[package]]
 name = "base-common-consensus"
-version = "0.0.0"
+version = "1.1.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -691,7 +691,7 @@ dependencies = [
 
 [[package]]
 name = "base-common-evm"
-version = "0.0.0"
+version = "1.1.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -708,11 +708,11 @@ dependencies = [
 
 [[package]]
 name = "base-common-flz"
-version = "0.0.0"
+version = "1.1.0"
 
 [[package]]
 name = "base-common-genesis"
-version = "0.0.0"
+version = "1.1.0"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -728,7 +728,7 @@ dependencies = [
 
 [[package]]
 name = "base-common-precompiles"
-version = "0.0.0"
+version = "1.1.0"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "base-common-rpc-types-engine"
-version = "0.0.0"
+version = "1.1.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -757,7 +757,7 @@ dependencies = [
 
 [[package]]
 name = "base-consensus-derive"
-version = "0.0.0"
+version = "1.1.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -778,7 +778,7 @@ dependencies = [
 
 [[package]]
 name = "base-consensus-upgrades"
-version = "0.0.0"
+version = "1.1.0"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-primitives",
@@ -787,11 +787,11 @@ dependencies = [
 
 [[package]]
 name = "base-metrics"
-version = "0.0.0"
+version = "1.1.0"
 
 [[package]]
 name = "base-precompile-macros"
-version = "0.0.0"
+version = "1.1.0"
 dependencies = [
  "alloy-primitives",
  "proc-macro2",
@@ -801,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "base-precompile-storage"
-version = "0.0.0"
+version = "1.1.0"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -814,7 +814,7 @@ dependencies = [
 
 [[package]]
 name = "base-proof"
-version = "0.0.0"
+version = "1.1.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -847,7 +847,7 @@ dependencies = [
 
 [[package]]
 name = "base-proof-driver"
-version = "0.0.0"
+version = "1.1.0"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -867,7 +867,7 @@ dependencies = [
 
 [[package]]
 name = "base-proof-executor"
-version = "0.0.0"
+version = "1.1.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -889,7 +889,7 @@ dependencies = [
 
 [[package]]
 name = "base-proof-mpt"
-version = "0.0.0"
+version = "1.1.0"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -900,7 +900,7 @@ dependencies = [
 
 [[package]]
 name = "base-proof-preimage"
-version = "0.0.0"
+version = "1.1.0"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -912,7 +912,7 @@ dependencies = [
 
 [[package]]
 name = "base-proof-primitives"
-version = "0.0.0"
+version = "1.1.0"
 dependencies = [
  "alloy-chains",
  "alloy-eips 2.0.5",
@@ -925,7 +925,7 @@ dependencies = [
 
 [[package]]
 name = "base-proof-succinct-client-utils"
-version = "0.0.0"
+version = "1.1.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -961,7 +961,7 @@ dependencies = [
 
 [[package]]
 name = "base-proof-succinct-ethereum-client-utils"
-version = "0.0.0"
+version = "1.1.0"
 dependencies = [
  "alloy-genesis",
  "anyhow",
@@ -991,7 +991,7 @@ dependencies = [
 
 [[package]]
 name = "base-protocol"
-version = "0.0.0"
+version = "1.1.0"
 dependencies = [
  "alloc-no-stdlib",
  "alloy-consensus",
@@ -1959,7 +1959,7 @@ dependencies = [
 [[package]]
 name = "k256"
 version = "0.13.4"
-source = "git+https://github.com/sp1-patches/elliptic-curves?tag=patch-k256-13.4-sp1-6.0.0#476243d31d3ffd9d882d0e5da1f6adaa2a204b62"
+source = "git+https://github.com/sp1-patches/elliptic-curves?tag=patch-k256-13.4-sp1-6.2.0#41374de1febd88e67faa695a5641ae46460a8cb6"
 dependencies = [
  "cfg-if",
  "ecdsa 0.16.9 (git+https://github.com/sp1-patches/signatures?tag=sp1-skip-verify-on-recovery)",
@@ -2261,7 +2261,7 @@ dependencies = [
 [[package]]
 name = "p256"
 version = "0.13.2"
-source = "git+https://github.com/sp1-patches/elliptic-curves?tag=patch-p256-13.2-sp1-6.0.0#923794180d3d7716ba3eed94459d4b434f844090"
+source = "git+https://github.com/sp1-patches/elliptic-curves?tag=patch-p256-13.2-sp1-6.2.0#778543de72a8160a9ce253870da1efae6b18e6d3"
 dependencies = [
  "ecdsa 0.16.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "elliptic-curve",
@@ -2525,7 +2525,7 @@ dependencies = [
 [[package]]
 name = "primeorder"
 version = "0.13.1"
-source = "git+https://github.com/sp1-patches/elliptic-curves?tag=patch-p256-13.2-sp1-6.0.0#923794180d3d7716ba3eed94459d4b434f844090"
+source = "git+https://github.com/sp1-patches/elliptic-curves?tag=patch-p256-13.2-sp1-6.2.0#778543de72a8160a9ce253870da1efae6b18e6d3"
 dependencies = [
  "elliptic-curve",
 ]
@@ -3237,7 +3237,7 @@ dependencies = [
 [[package]]
 name = "sha2"
 version = "0.10.9"
-source = "git+https://github.com/sp1-patches/RustCrypto-hashes?tag=patch-sha2-0.10.9-sp1-6.0.0#e48b656ebc806117554bb33c2f8687e4637e37ff"
+source = "git+https://github.com/sp1-patches/RustCrypto-hashes?tag=patch-sha2-0.10.9-sp1-6.2.0#e48b656ebc806117554bb33c2f8687e4637e37ff"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
@@ -3299,9 +3299,9 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "slop-algebra"
-version = "6.2.2"
+version = "6.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e8abf7cfad18c0580576e8adc01f7fa27b1cb19432e451e82950c9a445a7cfc"
+checksum = "6d7e25239ac2fe1cbc2ed5114844209d70361c8d55ef812cb935c90d6f771b5b"
 dependencies = [
  "itertools 0.14.0",
  "p3-field",
@@ -3310,9 +3310,9 @@ dependencies = [
 
 [[package]]
 name = "slop-bn254"
-version = "6.2.2"
+version = "6.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c327e0927fabf9c0ae9a7b0333027dc04431e5981ab80d7bbe994d6c4ce35fc1"
+checksum = "1243ca619a3f4c07f536a060d1fd2c6f779d5b0e4cfeee3acee4d1f76ae35cb4"
 dependencies = [
  "ff",
  "p3-bn254-fr",
@@ -3325,9 +3325,9 @@ dependencies = [
 
 [[package]]
 name = "slop-challenger"
-version = "6.2.2"
+version = "6.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c263e731bb694d4465eedae7ecd6faf1f277198e751f3c209a1c4186d80d1b6b"
+checksum = "594a3251b7fbbabf7e0ba1e5c2f563c2797fc2d51982c0208ce70b2f52b8fbe4"
 dependencies = [
  "futures",
  "p3-challenger",
@@ -3338,9 +3338,9 @@ dependencies = [
 
 [[package]]
 name = "slop-koala-bear"
-version = "6.2.2"
+version = "6.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a8cdc74f04d13e738b4628312b16dfec6a2e547bde697c8bdcf556884c6e91f"
+checksum = "1ccc675284794435dd053d5e7415089bbd08fccf92cd91e044ea3213821dfb5c"
 dependencies = [
  "lazy_static",
  "p3-koala-bear",
@@ -3353,27 +3353,27 @@ dependencies = [
 
 [[package]]
 name = "slop-poseidon2"
-version = "6.2.2"
+version = "6.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3aedfc3bf87cf2694bd108c039d663c346c7bb807491a7db6701eb9dff5c6e5d"
+checksum = "7f77602b918f667f970d017293189f9e60ba056d1933c9f717634877838297bc"
 dependencies = [
  "p3-poseidon2",
 ]
 
 [[package]]
 name = "slop-primitives"
-version = "6.2.2"
+version = "6.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f30e6e332c3cb103541bed9f5f477b769df1b5fb6076b5e2386569c94b1475dc"
+checksum = "592ded42eb74fd87d2ce13592906cf86f201128dd18e2aa5a35d298bc3534dcb"
 dependencies = [
  "slop-algebra",
 ]
 
 [[package]]
 name = "slop-symmetric"
-version = "6.2.2"
+version = "6.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cb1de854325a8c36a1bdfee5514e1d4c9f39290ae19eeaecb21ca6ee88d96d6"
+checksum = "108bf1769132b782218e3606b8e2f310741fb89d1745234b59ff17d9e7ab8700"
 dependencies = [
  "p3-symmetric",
 ]
@@ -3389,9 +3389,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-lib"
-version = "6.1.0"
+version = "6.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b96392c1b1c197beaa6b0806099a8d73643a09d5ac0874e26c9c5153a7fcb4c"
+checksum = "20e8b776b02a868c482b70b5dca58204f27fc860dbbe5eda70437299367f494c"
 dependencies = [
  "bincode",
  "elliptic-curve",
@@ -3401,9 +3401,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-primitives"
-version = "6.2.2"
+version = "6.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13ad00052921b993af682403b378c8fe23c40382f9790f093c8fac0f30433c5e"
+checksum = "f20c3dd3131b1285420ca25a37f507915ab609887d6dda73973396a0faa719c1"
 dependencies = [
  "bincode",
  "blake3",
@@ -3425,9 +3425,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-zkvm"
-version = "6.1.0"
+version = "6.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d31a7c3f072f248342284031684c9195e2264422964129c3b8652f9196ecc937"
+checksum = "c2dea6f1d7c79d27c9890c39786b68061c5a82b4c21669aafc98ae95337d792f"
 dependencies = [
  "cfg-if",
  "critical-section",
@@ -3916,14 +3916,14 @@ dependencies = [
 [[patch.unused]]
 name = "sha3"
 version = "0.10.8"
-source = "git+https://github.com/sp1-patches/RustCrypto-hashes?tag=patch-sha3-0.10.8-sp1-6.0.0#0a16ae7acd5cd5fbb432d884bd4aae2764a18cf7"
+source = "git+https://github.com/sp1-patches/RustCrypto-hashes?tag=patch-sha3-0.10.8-sp1-6.2.0#0a16ae7acd5cd5fbb432d884bd4aae2764a18cf7"
 
 [[patch.unused]]
 name = "substrate-bn"
 version = "0.6.0"
-source = "git+https://github.com/sp1-patches/bn?tag=patch-0.6.0-sp1-6.0.0-substrate-bn#13747d255e00c158afbb6d4a4a94275edd804bbf"
+source = "git+https://github.com/sp1-patches/bn?tag=patch-0.6.0-sp1-6.2.0-substrate-bn#b9cd95a749de1f20ac786178f9f8754f79a5ad55"
 
 [[patch.unused]]
 name = "tiny-keccak"
 version = "2.0.2"
-source = "git+https://github.com/sp1-patches/tiny-keccak?tag=patch-2.0.2-sp1-6.0.0#957430a459f7a2332ab5bab4a12f9b473bb95c87"
+source = "git+https://github.com/sp1-patches/tiny-keccak?tag=patch-2.0.2-sp1-6.2.0#c3f95bcc35b391101d0cf0abe91ea4c8423868b0"

--- a/crates/proof/succinct/programs/Cargo.toml
+++ b/crates/proof/succinct/programs/Cargo.toml
@@ -41,9 +41,9 @@ base-proof = { path = "../../../proof/proof", default-features = false }
 base-proof-succinct-client-utils = { path = "../utils/client" }
 base-proof-succinct-ethereum-client-utils = { path = "../utils/ethereum/client" }
 
-# SP1 (must match root Cargo.toml versions)
-sp1-zkvm = { version = "=6.1.0", features = ["verify"] }
-sp1-lib = { version = "=6.1.0", features = ["verify"] }
+# SP1 (must match the cargo-prove Docker tag)
+sp1-lib = { version = "=6.2.3", features = ["verify"] }
+sp1-zkvm = { version = "=6.2.3", features = ["verify"] }
 
 # alloy (must match root Cargo.toml versions)
 alloy-consensus = { version = "2.0.4", default-features = false }
@@ -75,9 +75,9 @@ codegen-units = 16
 # the zkVM target (`target_os = "zkvm"`).  On native builds the
 # patches are no-ops.
 [patch.crates-io]
-sha2 = { git = "https://github.com/sp1-patches/RustCrypto-hashes", package = "sha2", tag = "patch-sha2-0.10.9-sp1-6.0.0" }
-sha3 = { git = "https://github.com/sp1-patches/RustCrypto-hashes", package = "sha3", tag = "patch-sha3-0.10.8-sp1-6.0.0" }
-substrate-bn = { git = "https://github.com/sp1-patches/bn", tag = "patch-0.6.0-sp1-6.0.0-substrate-bn" }
-p256 = { git = "https://github.com/sp1-patches/elliptic-curves", tag = "patch-p256-13.2-sp1-6.0.0" }
-k256 = { git = "https://github.com/sp1-patches/elliptic-curves", tag = "patch-k256-13.4-sp1-6.0.0" }
-tiny-keccak = { git = "https://github.com/sp1-patches/tiny-keccak", tag = "patch-2.0.2-sp1-6.0.0" }
+tiny-keccak = { git = "https://github.com/sp1-patches/tiny-keccak", tag = "patch-2.0.2-sp1-6.2.0" }
+p256 = { git = "https://github.com/sp1-patches/elliptic-curves", tag = "patch-p256-13.2-sp1-6.2.0" }
+k256 = { git = "https://github.com/sp1-patches/elliptic-curves", tag = "patch-k256-13.4-sp1-6.2.0" }
+substrate-bn = { git = "https://github.com/sp1-patches/bn", tag = "patch-0.6.0-sp1-6.2.0-substrate-bn" }
+sha2 = { git = "https://github.com/sp1-patches/RustCrypto-hashes", package = "sha2", tag = "patch-sha2-0.10.9-sp1-6.2.0" }
+sha3 = { git = "https://github.com/sp1-patches/RustCrypto-hashes", package = "sha3", tag = "patch-sha3-0.10.8-sp1-6.2.0" }

--- a/crates/proof/succinct/utils/build/src/lib.rs
+++ b/crates/proof/succinct/utils/build/src/lib.rs
@@ -11,7 +11,7 @@ fn build_program(program_name: &str, elf_name: &str, features: Option<Vec<String
         elf_name: Some(elf_name.to_string()),
         output_directory: Some("../../elf".to_string()),
         docker: true,
-        tag: "v6.1.0".to_string(),
+        tag: "v6.2.3".to_string(),
         workspace_directory: Some("../../".to_string()),
         ..Default::default()
     };

--- a/crates/proof/succinct/validity/Dockerfile
+++ b/crates/proof/succinct/validity/Dockerfile
@@ -22,7 +22,7 @@ WORKDIR /build
 
 # Install SP1
 RUN curl -L https://sp1.succinct.xyz | bash && \
-    ~/.sp1/bin/sp1up -v 6.1.0 && \
+    ~/.sp1/bin/sp1up -v 6.2.3 && \
     ~/.sp1/bin/cargo-prove prove --version
 
 # Copy only what's needed for the build.
@@ -64,7 +64,7 @@ RUN apt-get update && apt-get install -y \
 
 # Install SP1
 RUN curl -L https://sp1.succinct.xyz | bash && \
-    ~/.sp1/bin/sp1up -v 6.1.0 && \
+    ~/.sp1/bin/sp1up -v 6.2.3 && \
     ~/.sp1/bin/cargo-prove prove --version
 
 # Copy only the built binaries from builder

--- a/etc/just/succinct.just
+++ b/etc/just/succinct.just
@@ -1,5 +1,5 @@
 _cargo_prove := "~/.sp1/bin/cargo-prove"
-_sp1_tag := "v6.1.0"
+_sp1_tag := "v6.2.3"
 _repo_root := justfile_directory()
 _succinct_dir := justfile_directory() / "crates/proof/succinct"
 


### PR DESCRIPTION
## Summary
- keep host SP1 crates on the cluster-compatible 6.2.1 line
- move SP1 ELF builds and guest runtime crates to 6.2.3 so Docker uses rustc 1.94
- regenerate SP1 guest lockfile entries and ELF manifest hashes

## Verification
- just succinct build-elfs
- cargo check --locked --workspace (in crates/proof/succinct/programs)
- BASE_SUCCINCT_ELF_STUB=1 cargo check --locked -p base-proof-succinct-validity -p base-prover-service
- python3 etc/scripts/local/check-elf-manifest.py crates/proof/succinct/elf/manifest.toml crates/proof/succinct/elf
- git diff --check