### PR TITLE
docs(consensus): fix grammar "an non-empty" → "a non-empty" in block_validity.rs

### DIFF
--- a/crates/consensus/gossip/src/block_validity.rs
+++ b/crates/consensus/gossip/src/block_validity.rs
@@ -287,7 +287,7 @@ impl BlockHandler {
         }
 
         // Same as v3, except:
-        // 1. The block should have an non-empty withdrawals root (checked by type-safety)
+        // 1. The block should have a non-empty withdrawals root (checked by type-safety)
         fn validate_v4(
             rollup_config: &RollupConfig,
             block: &BaseExecutionPayloadV4,


### PR DESCRIPTION
Fixes the grammar error originally reported in #2827 (closed as stale without the fix being applied).

`block_validity.rs:290` has `"an non-empty"` which is grammatically incorrect "non-empty" begins with the consonant sound /n/, so the correct indefinite article is "a" not "an".

One character change, no behavior impact.