### PR TITLE
fix(consensus): speed up reset anchor selection

### DIFF
--- a/crates/consensus/derive/src/pipeline/core.rs
+++ b/crates/consensus/derive/src/pipeline/core.rs
@@ -65,6 +65,7 @@ where
     async fn initial_reset(
         &mut self,
         l2_safe_head: L2BlockInfo,
+        l2_reset_anchor_hint: Option<BlockNumHash>,
     ) -> PipelineResult<(BlockNumHash, SystemConfig)>
     where
         <P as BatchValidationProvider>::Error: Into<PipelineErrorKind>,
@@ -73,22 +74,9 @@ where
         let l1_origin_ts_lower_bound =
             l2_safe_head_ts.saturating_sub(self.rollup_config.max_sequencer_drift(l2_safe_head_ts));
         let channel_timeout = self.rollup_config.channel_timeout(l1_origin_ts_lower_bound);
-        let l1_origin_number = l2_safe_head.l1_origin.number;
-        let mut current = l2_safe_head;
-
-        loop {
-            if current.block_info.number == self.rollup_config.genesis.l2.number {
-                break;
-            }
-            if current.l1_origin.number + channel_timeout <= l1_origin_number {
-                break;
-            }
-            current = self
-                .l2_chain_provider
-                .l2_block_info_by_number(current.block_info.number - 1)
-                .await
-                .map_err(Into::into)?;
-        }
+        let current = self
+            .find_initial_reset_block(l2_safe_head, l2_reset_anchor_hint, channel_timeout)
+            .await?;
 
         let system_config = self
             .l2_chain_provider
@@ -97,6 +85,147 @@ where
             .map_err(Into::into)?;
 
         Ok((current.l1_origin, system_config))
+    }
+
+    async fn find_initial_reset_block(
+        &mut self,
+        l2_safe_head: L2BlockInfo,
+        l2_reset_anchor_hint: Option<BlockNumHash>,
+        channel_timeout: u64,
+    ) -> PipelineResult<L2BlockInfo>
+    where
+        <P as BatchValidationProvider>::Error: Into<PipelineErrorKind>,
+    {
+        let l1_origin_number = l2_safe_head.l1_origin.number;
+        let genesis_l2_number = self.rollup_config.genesis.l2.number;
+
+        if self.is_initial_reset_block(l2_safe_head, channel_timeout, l1_origin_number) {
+            return Ok(l2_safe_head);
+        }
+
+        if let Some(hint) = l2_reset_anchor_hint
+            && hint.number <= l2_safe_head.block_info.number
+        {
+            match self
+                .l2_chain_provider
+                .l2_block_info_by_number(hint.number)
+                .await
+                .map_err(Into::into)
+            {
+                Ok(block)
+                    if block.block_info.hash == hint.hash
+                        && self.is_initial_reset_block(
+                            block,
+                            channel_timeout,
+                            l1_origin_number,
+                        ) =>
+                {
+                    tracing::debug!(
+                        target: "pipeline",
+                        hint_l2 = hint.number,
+                        safe_l2 = l2_safe_head.block_info.number,
+                        "accepted reset anchor hint"
+                    );
+                    return self
+                        .find_highest_initial_reset_block(
+                            block,
+                            l2_safe_head.block_info.number,
+                            channel_timeout,
+                            l1_origin_number,
+                        )
+                        .await;
+                }
+                Ok(block) => {
+                    tracing::debug!(
+                        target: "pipeline",
+                        hint_l2 = hint.number,
+                        hint_hash = %hint.hash,
+                        actual_hash = %block.block_info.hash,
+                        actual_l1_origin = block.l1_origin.number,
+                        safe_l1_origin = l1_origin_number,
+                        channel_timeout,
+                        "ignored invalid reset anchor hint"
+                    );
+                }
+                Err(err) => {
+                    tracing::debug!(
+                        target: "pipeline",
+                        hint_l2 = hint.number,
+                        error = ?err,
+                        "ignored unavailable reset anchor hint"
+                    );
+                }
+            }
+        }
+
+        let mut step = 1_u64;
+        let lower_bound = loop {
+            let candidate_number =
+                l2_safe_head.block_info.number.saturating_sub(step).max(genesis_l2_number);
+            let candidate = self
+                .l2_chain_provider
+                .l2_block_info_by_number(candidate_number)
+                .await
+                .map_err(Into::into)?;
+
+            if self.is_initial_reset_block(candidate, channel_timeout, l1_origin_number) {
+                break candidate;
+            }
+
+            if candidate_number == genesis_l2_number {
+                break candidate;
+            }
+
+            step = step.saturating_mul(2);
+        };
+
+        self.find_highest_initial_reset_block(
+            lower_bound,
+            l2_safe_head.block_info.number,
+            channel_timeout,
+            l1_origin_number,
+        )
+        .await
+    }
+
+    async fn find_highest_initial_reset_block(
+        &mut self,
+        mut lower_bound: L2BlockInfo,
+        mut upper_number: u64,
+        channel_timeout: u64,
+        l1_origin_number: u64,
+    ) -> PipelineResult<L2BlockInfo>
+    where
+        <P as BatchValidationProvider>::Error: Into<PipelineErrorKind>,
+    {
+        while lower_bound.block_info.number + 1 < upper_number {
+            let mid = lower_bound.block_info.number
+                + ((upper_number - lower_bound.block_info.number) / 2);
+            let block =
+                self.l2_chain_provider.l2_block_info_by_number(mid).await.map_err(Into::into)?;
+
+            if self.is_initial_reset_block(block, channel_timeout, l1_origin_number) {
+                lower_bound = block;
+            } else {
+                upper_number = mid;
+            }
+        }
+
+        Ok(lower_bound)
+    }
+
+    fn is_initial_reset_block(
+        &self,
+        block: L2BlockInfo,
+        channel_timeout: u64,
+        l1_origin_number: u64,
+    ) -> bool {
+        block.block_info.number == self.rollup_config.genesis.l2.number
+            || block
+                .l1_origin
+                .number
+                .checked_add(channel_timeout)
+                .is_some_and(|timeout_l1| timeout_l1 <= l1_origin_number)
     }
 }
 
@@ -143,8 +272,9 @@ where
     /// [`initial_reset`]: Self::initial_reset
     async fn signal(&mut self, signal: Signal) -> PipelineResult<()> {
         match signal {
-            Signal::Reset(ResetSignal { l2_safe_head }) => {
-                let (l1_origin, system_config) = self.initial_reset(l2_safe_head).await?;
+            Signal::Reset(ResetSignal { l2_safe_head, l2_reset_anchor_hint }) => {
+                let (l1_origin, system_config) =
+                    self.initial_reset(l2_safe_head, l2_reset_anchor_hint).await?;
                 match self.attributes.reset(l1_origin, system_config).await {
                     Ok(()) => trace!(target: "pipeline", "Stages reset"),
                     Err(err) => {
@@ -297,6 +427,45 @@ mod tests {
         }
     }
 
+    fn test_l2_block(number: u64) -> L2BlockInfo {
+        L2BlockInfo {
+            block_info: BlockInfo {
+                number,
+                hash: B256::with_last_byte((number & 0xff) as u8),
+                parent_hash: if number == 0 {
+                    B256::ZERO
+                } else {
+                    B256::with_last_byte(((number - 1) & 0xff) as u8)
+                },
+                timestamp: number,
+            },
+            l1_origin: BlockNumHash {
+                number,
+                hash: B256::with_last_byte(((number ^ 0x80) & 0xff) as u8),
+            },
+            seq_num: 0,
+        }
+    }
+
+    fn reset_search_pipeline(
+        safe_l2_number: u64,
+        channel_timeout: u64,
+    ) -> DerivationPipeline<TestNextAttributes, TestL2ChainProvider> {
+        let rollup_config = Arc::new(RollupConfig { channel_timeout, ..Default::default() });
+        let mut l2_chain_provider = TestL2ChainProvider::default();
+        for n in 0..=safe_l2_number {
+            l2_chain_provider.blocks.push(test_l2_block(n));
+            l2_chain_provider.system_configs.insert(
+                n,
+                SystemConfig {
+                    batcher_address: Address::repeat_byte((n & 0xff) as u8),
+                    ..Default::default()
+                },
+            );
+        }
+        DerivationPipeline::new(TestNextAttributes::default(), rollup_config, l2_chain_provider)
+    }
+
     #[test]
     fn test_pipeline_next_attributes_empty() {
         let mut pipeline = new_test_pipeline();
@@ -423,8 +592,67 @@ mod tests {
             l1_origin: BlockNumHash { number: 5, hash: Default::default() },
             ..Default::default()
         };
-        let result = pipeline.initial_reset(l2_safe_head).await;
+        let result = pipeline.initial_reset(l2_safe_head, None).await;
         assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_derivation_pipeline_initial_reset_search_finds_highest_valid_block() {
+        const SAFE_HEAD: u64 = 50;
+        const CHANNEL_TIMEOUT: u64 = 10;
+        const EXPECTED_RESET_BLOCK: u64 = SAFE_HEAD - CHANNEL_TIMEOUT;
+
+        let mut pipeline = reset_search_pipeline(SAFE_HEAD, CHANNEL_TIMEOUT);
+
+        let (l1_origin, system_config) =
+            pipeline.initial_reset(test_l2_block(SAFE_HEAD), None).await.unwrap();
+
+        assert_eq!(l1_origin.number, EXPECTED_RESET_BLOCK);
+        assert_eq!(system_config.batcher_address, Address::repeat_byte(EXPECTED_RESET_BLOCK as u8));
+    }
+
+    #[tokio::test]
+    async fn test_derivation_pipeline_initial_reset_uses_valid_hint_as_search_floor() {
+        const SAFE_HEAD: u64 = 50;
+        const CHANNEL_TIMEOUT: u64 = 10;
+        const EXPECTED_RESET_BLOCK: u64 = SAFE_HEAD - CHANNEL_TIMEOUT;
+
+        let mut pipeline = reset_search_pipeline(SAFE_HEAD, CHANNEL_TIMEOUT);
+        let hint_block = test_l2_block(EXPECTED_RESET_BLOCK);
+
+        let (l1_origin, system_config) = pipeline
+            .initial_reset(
+                test_l2_block(SAFE_HEAD),
+                Some(BlockNumHash {
+                    number: hint_block.block_info.number,
+                    hash: hint_block.block_info.hash,
+                }),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(l1_origin.number, EXPECTED_RESET_BLOCK);
+        assert_eq!(system_config.batcher_address, Address::repeat_byte(EXPECTED_RESET_BLOCK as u8));
+    }
+
+    #[tokio::test]
+    async fn test_derivation_pipeline_initial_reset_ignores_invalid_hint() {
+        const SAFE_HEAD: u64 = 50;
+        const CHANNEL_TIMEOUT: u64 = 10;
+        const EXPECTED_RESET_BLOCK: u64 = SAFE_HEAD - CHANNEL_TIMEOUT;
+
+        let mut pipeline = reset_search_pipeline(SAFE_HEAD, CHANNEL_TIMEOUT);
+
+        let (l1_origin, system_config) = pipeline
+            .initial_reset(
+                test_l2_block(SAFE_HEAD),
+                Some(BlockNumHash { number: EXPECTED_RESET_BLOCK, hash: B256::ZERO }),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(l1_origin.number, EXPECTED_RESET_BLOCK);
+        assert_eq!(system_config.batcher_address, Address::repeat_byte(EXPECTED_RESET_BLOCK as u8));
     }
 
     /// On a Granite-straddle safe head — L2 timestamp post-Granite while its L1 origin
@@ -461,7 +689,7 @@ mod tests {
         });
 
         let mut l2_chain_provider = TestL2ChainProvider::default();
-        for n in SPEC_STOP_L1_ORIGIN..=L1_HEAD {
+        for n in 0..=L1_HEAD {
             let timestamp = if n == L1_HEAD { L2_SAFE_HEAD_TIMESTAMP } else { 0 };
             l2_chain_provider.blocks.push(L2BlockInfo {
                 block_info: BlockInfo {
@@ -503,7 +731,7 @@ mod tests {
             seq_num: 0,
         };
 
-        let (l1_origin, system_config) = pipeline.initial_reset(safe_head).await.unwrap();
+        let (l1_origin, system_config) = pipeline.initial_reset(safe_head, None).await.unwrap();
         assert_eq!(
             l1_origin.number, SPEC_STOP_L1_ORIGIN,
             "spec walk-back must stop at L1 origin {SPEC_STOP_L1_ORIGIN} (pre-Granite=300), not at {CODE_STOP_L1_ORIGIN} (Granite=50)"

--- a/crates/consensus/derive/src/types/signals.rs
+++ b/crates/consensus/derive/src/types/signals.rs
@@ -4,6 +4,7 @@
 //! of the pipeline. They allow the pipeline driver to perform actions such as
 //! resetting all stages in the pipeline through message passing.
 
+use alloy_eips::BlockNumHash;
 use base_protocol::L2BlockInfo;
 
 /// A signal to send to the pipeline.
@@ -32,6 +33,11 @@ impl core::fmt::Display for Signal {
 pub struct ResetSignal {
     /// The L2 safe head to reset to.
     pub l2_safe_head: L2BlockInfo,
+    /// Optional L2 block hint for the pipeline's reset walk-back target.
+    ///
+    /// The pipeline validates this hint against the local L2 chain before using it. Invalid,
+    /// missing, or too-new hints are ignored and the pipeline falls back to searching.
+    pub l2_reset_anchor_hint: Option<BlockNumHash>,
 }
 
 impl ResetSignal {

--- a/crates/consensus/engine/src/sync/mod.rs
+++ b/crates/consensus/engine/src/sync/mod.rs
@@ -64,6 +64,7 @@ pub async fn find_starting_forkchoice_with_checkpoint_reader<
     );
 
     // Search for the highest `unsafe` block, relative to the initial `unsafe` block's L1 origin,
+    let mut unsafe_walk_depth = 0_u64;
     loop {
         let l1_origin =
             engine_client.get_l1_block(current_fc.un_safe.l1_origin.hash.into()).await?;
@@ -80,11 +81,13 @@ pub async fn find_starting_forkchoice_with_checkpoint_reader<
                 info!(
                     target: "sync_start",
                     l2_unsafe = %current_fc.un_safe.block_info.number,
+                    unsafe_walk_depth,
                     "Found L2 unsafe block with canonical L1 origin"
                 );
                 break;
             }
             None => {
+                unsafe_walk_depth = unsafe_walk_depth.saturating_add(1);
                 let l2_parent_hash = current_fc.un_safe.block_info.parent_hash.into();
                 let l2_parent = engine_client
                     .get_l2_block(l2_parent_hash)
@@ -103,6 +106,7 @@ pub async fn find_starting_forkchoice_with_checkpoint_reader<
     // Search for the highest `safe` block that's L1 origin is at least older than the sequencing
     // window, relative to the L1 origin of the `unsafe` block.
     let mut safe_cursor = current_fc.un_safe;
+    let mut safe_walk_depth = 0_u64;
     loop {
         info!(
             target: "sync_start",
@@ -125,16 +129,19 @@ pub async fn find_starting_forkchoice_with_checkpoint_reader<
                 is_labeled_safe,
                 is_finalized,
                 is_genesis,
+                safe_walk_depth,
                 "Found suitable L2 safe block"
             );
             current_fc.safe = safe_cursor;
             break;
         }
         if safe_cursor.block_info.parent_hash == current_fc.safe.block_info.hash {
+            safe_walk_depth = safe_walk_depth.saturating_add(1);
             safe_cursor = current_fc.safe;
             continue;
         }
         if safe_cursor.block_info.parent_hash == current_fc.finalized.block_info.hash {
+            safe_walk_depth = safe_walk_depth.saturating_add(1);
             safe_cursor = current_fc.finalized;
             continue;
         }
@@ -147,6 +154,7 @@ pub async fn find_starting_forkchoice_with_checkpoint_reader<
             &block.into_consensus().map_transactions(|tx| tx.inner.inner.into_inner()),
             &cfg.genesis,
         )?;
+        safe_walk_depth = safe_walk_depth.saturating_add(1);
     }
 
     // Leave the finalized block as-is, and return the current forkchoice.

--- a/crates/consensus/providers/src/pipeline.rs
+++ b/crates/consensus/providers/src/pipeline.rs
@@ -69,7 +69,7 @@ impl OnlinePipeline {
 
         // Reset the pipeline to populate the initial L1/L2 cursor and system configuration in L1
         // Traversal.
-        pipeline.signal(ResetSignal { l2_safe_head }.signal()).await?;
+        pipeline.signal(ResetSignal { l2_safe_head, l2_reset_anchor_hint: None }.signal()).await?;
 
         Ok(pipeline)
     }

--- a/crates/consensus/service/src/actors/derivation/actor.rs
+++ b/crates/consensus/service/src/actors/derivation/actor.rs
@@ -96,7 +96,7 @@ where
 
     /// Handles a [`Signal`] received over the derivation signal receiver channel.
     async fn signal(&mut self, signal: Signal) {
-        if let Signal::Reset(ResetSignal { l2_safe_head: _reset_safe_head }) = signal {
+        if let Signal::Reset(ResetSignal { l2_safe_head: _reset_safe_head, .. }) = signal {
             Metrics::derivation_l1_origin().absolute(_reset_safe_head.l1_origin.number);
             // Clear the finalization queue on reset.
             self.finalizer.clear();

--- a/crates/consensus/service/src/actors/engine/engine_request_processor.rs
+++ b/crates/consensus/service/src/actors/engine/engine_request_processor.rs
@@ -1,6 +1,6 @@
 use std::{fmt, sync::Arc};
 
-use alloy_eips::BlockNumberOrTag;
+use alloy_eips::{BlockNumHash, BlockNumberOrTag};
 use base_common_genesis::RollupConfig;
 use base_common_rpc_types_engine::BaseExecutionPayloadEnvelope;
 use base_consensus_derive::{ResetSignal, Signal};
@@ -10,6 +10,7 @@ use base_consensus_engine::{
     ForkchoiceCheckpointReader, InsertTask, InsertTaskResult, Metrics as EngineMetrics,
     NoopForkchoiceCheckpointReader, SealTaskError,
 };
+use base_consensus_safedb::{DisabledSafeDB, SafeDBError, SafeDBReader};
 use base_protocol::L2BlockInfo;
 use tokio::{
     sync::{mpsc, watch},
@@ -131,6 +132,8 @@ where
     checkpoint_reader: Arc<dyn ForkchoiceCheckpointReader>,
     /// Writes checkpointed forkchoice state after engine state changes.
     checkpoint_writer: Arc<dyn CheckpointWriter>,
+    /// Reads SafeDB reset anchor hints when SafeDB is configured.
+    safe_db_reader: Arc<dyn SafeDBReader>,
 }
 
 impl<EngineClient_, DerivationClient> EngineProcessor<EngineClient_, DerivationClient>
@@ -167,9 +170,33 @@ where
         checkpoint_reader: Arc<dyn ForkchoiceCheckpointReader>,
         checkpoint_writer: Arc<dyn CheckpointWriter>,
     ) -> Self {
+        Self::new_with_checkpoint_and_safedb(
+            client,
+            config,
+            derivation_client,
+            engine,
+            options,
+            checkpoint_reader,
+            checkpoint_writer,
+            Arc::new(DisabledSafeDB),
+        )
+    }
+
+    /// Constructs a new [`EngineProcessor`] with checkpoint persistence and SafeDB reset hints.
+    pub fn new_with_checkpoint_and_safedb(
+        client: Arc<EngineClient_>,
+        config: Arc<RollupConfig>,
+        derivation_client: DerivationClient,
+        engine: Engine<EngineClient_>,
+        options: EngineProcessorOptions,
+        checkpoint_reader: Arc<dyn ForkchoiceCheckpointReader>,
+        checkpoint_writer: Arc<dyn CheckpointWriter>,
+        safe_db_reader: Arc<dyn SafeDBReader>,
+    ) -> Self {
         Self {
             checkpoint_reader,
             checkpoint_writer,
+            safe_db_reader,
             client,
             conductor: options.conductor,
             derivation_client,
@@ -182,6 +209,39 @@ where
             rollup: config,
             sequencer_stopped: options.sequencer_stopped,
             unsafe_head_tx: options.unsafe_head_tx,
+        }
+    }
+
+    async fn reset_anchor_hint(&self, l2_safe_head: L2BlockInfo) -> Option<BlockNumHash> {
+        let safe_head_ts = l2_safe_head.block_info.timestamp;
+        let l1_origin_ts_lower_bound =
+            safe_head_ts.saturating_sub(self.rollup.max_sequencer_drift(safe_head_ts));
+        let channel_timeout = self.rollup.channel_timeout(l1_origin_ts_lower_bound);
+        let query_l1_number = l2_safe_head.l1_origin.number.saturating_sub(channel_timeout);
+
+        match self.safe_db_reader.safe_head_at_l1(query_l1_number).await {
+            Ok(response) => {
+                debug!(
+                    target: "engine",
+                    safe_l2 = l2_safe_head.block_info.number,
+                    safe_l1_origin = l2_safe_head.l1_origin.number,
+                    query_l1_number,
+                    hint_l1 = response.l1_block.number,
+                    hint_l2 = response.safe_head.number,
+                    "found SafeDB reset anchor hint"
+                );
+                Some(response.safe_head)
+            }
+            Err(SafeDBError::Disabled | SafeDBError::NotFound) => None,
+            Err(err) => {
+                warn!(
+                    target: "engine",
+                    error = %err,
+                    query_l1_number,
+                    "failed to query SafeDB reset anchor hint; continuing without hint"
+                );
+                None
+            }
         }
     }
 
@@ -200,8 +260,10 @@ where
 
         self.checkpoint_forkchoice_state_if_updated().await;
 
+        let l2_reset_anchor_hint = self.reset_anchor_hint(l2_safe_head).await;
+
         // Signal the derivation actor to reset.
-        let signal = ResetSignal { l2_safe_head };
+        let signal = ResetSignal { l2_safe_head, l2_reset_anchor_hint };
         match self.derivation_client.send_signal(signal.signal()).await {
             Ok(_) => info!(target: "engine", "Sent reset signal to derivation actor"),
             Err(err) => {
@@ -873,12 +935,13 @@ mod tests {
     use base_consensus_derive::Signal;
     use base_consensus_engine::{
         Engine, EngineState, EngineTaskError, EngineTaskErrorSeverity, ForkchoiceCheckpointError,
-        ForkchoiceCheckpointLabel, ForkchoiceCheckpointReader,
+        ForkchoiceCheckpointLabel, ForkchoiceCheckpointReader, NoopForkchoiceCheckpointReader,
         test_utils::{
             TestAttributesBuilder, TestEngineStateBuilder, test_block_info,
             test_engine_client_builder,
         },
     };
+    use base_consensus_safedb::{SafeDBError, SafeDBReader, SafeHeadResponse};
     use base_protocol::{BlockInfo, L1BlockInfoBedrock, L2BlockInfo};
     use rstest::rstest;
     use tokio::sync::{mpsc, watch};
@@ -910,6 +973,23 @@ mod tests {
                 ForkchoiceCheckpointLabel::Safe => self.safe,
                 ForkchoiceCheckpointLabel::Finalized => self.finalized,
             })
+        }
+    }
+
+    #[derive(Debug)]
+    struct TestSafeDBReader {
+        expected_l1_number: u64,
+        response: SafeHeadResponse,
+    }
+
+    #[async_trait]
+    impl SafeDBReader for TestSafeDBReader {
+        async fn safe_head_at_l1(
+            &self,
+            l1_block_num: u64,
+        ) -> Result<SafeHeadResponse, SafeDBError> {
+            assert_eq!(l1_block_num, self.expected_l1_number);
+            Ok(self.response)
         }
     }
 
@@ -1023,6 +1103,48 @@ mod tests {
             ),
             queue_rx,
         )
+    }
+
+    #[tokio::test]
+    async fn reset_anchor_hint_queries_safedb_at_channel_timeout_cutoff() {
+        let client = Arc::new(test_engine_client_builder().build());
+        let config = Arc::new(RollupConfig { channel_timeout: 10, ..Default::default() });
+        let derivation_client = MockEngineDerivationClient::new();
+        let initial_state = EngineState::default();
+        let (state_tx, _) = watch::channel(initial_state);
+        let (queue_tx, _) = watch::channel(0usize);
+        let engine = Engine::new(initial_state, state_tx, queue_tx);
+        let hint = BlockNumHash { number: 40, hash: B256::with_last_byte(40) };
+
+        let processor = EngineProcessor::new_with_checkpoint_and_safedb(
+            client,
+            Arc::clone(&config),
+            derivation_client,
+            engine,
+            EngineProcessorOptions {
+                node_mode: NodeMode::Validator,
+                unsafe_head_tx: None,
+                conductor: None,
+                sequencer_stopped: false,
+            },
+            Arc::new(NoopForkchoiceCheckpointReader),
+            Arc::new(NoopCheckpointWriter),
+            Arc::new(TestSafeDBReader {
+                expected_l1_number: 90,
+                response: SafeHeadResponse {
+                    l1_block: BlockNumHash { number: 90, hash: B256::with_last_byte(90) },
+                    safe_head: hint,
+                },
+            }),
+        );
+
+        let l2_safe_head = L2BlockInfo {
+            block_info: BlockInfo { number: 100, timestamp: 100, ..Default::default() },
+            l1_origin: BlockNumHash { number: 100, hash: B256::with_last_byte(100) },
+            seq_num: 0,
+        };
+
+        assert_eq!(processor.reset_anchor_hint(l2_safe_head).await, Some(hint));
     }
 
     #[rstest]

--- a/crates/consensus/service/src/service/node.rs
+++ b/crates/consensus/service/src/service/node.rs
@@ -240,6 +240,7 @@ impl RollupNode {
         unsafe_head_tx: watch::Sender<L2BlockInfo>,
         conductor: Option<Arc<dyn Conductor>>,
         checkpoint_client: CheckpointClient,
+        safe_db_reader: Arc<dyn SafeDBReader>,
     ) -> (EngineActor<EngineProcessor<E, QueuedEngineDerivationClient>>, EngineRpcProcessor<E>)
     {
         let engine_state = EngineState::default();
@@ -251,7 +252,7 @@ impl RollupNode {
         let checkpoint_reader: Arc<dyn ForkchoiceCheckpointReader> =
             Arc::new(checkpoint_client.clone());
         let checkpoint_writer: Arc<dyn CheckpointWriter> = Arc::new(checkpoint_client);
-        let engine_processor = EngineProcessor::new_with_checkpoint(
+        let engine_processor = EngineProcessor::new_with_checkpoint_and_safedb(
             Arc::clone(&engine_client),
             Arc::clone(&self.config),
             derivation_client,
@@ -264,6 +265,7 @@ impl RollupNode {
             },
             checkpoint_reader,
             checkpoint_writer,
+            safe_db_reader,
         );
 
         let engine_rpc_processor = EngineRpcProcessor::new(
@@ -434,6 +436,7 @@ impl RollupNode {
             unsafe_head_tx,
             engine_conductor,
             checkpoint_client,
+            Arc::clone(&safe_db_reader),
         );
 
         // Select the concrete derivation actor implementation based on


### PR DESCRIPTION
## Summary

This is a discussion PR for reducing base-consensus reset latency after shallow L1 reorgs.

It changes derivation reset anchor selection from a one-L2-block-at-a-time walk to:

- a validated SafeDB hint when SafeDB is configured
- an exponential backward search plus binary search fallback when no usable hint exists
- the same channel-timeout/system-config correctness condition as the existing reset path

It also threads SafeDB into the engine reset path as a read-only hint source and adds walk-depth fields to sync-start logs.

## Incident context

On 2026-06-02 at 7:28 AM PDT, Base mainnet produced five consecutive empty L2 blocks after a 1-block Ethereum L1 reorg. The reorg detection itself was immediate: base-consensus logged an L1 parent-hash mismatch at `2026-06-02T14:28:04.444581Z`.

The delay appears to have been in the reset path after detection. Logs from the active host show `sync_start` walking the reset safe cursor backward from about L2 `46810567` toward about `46809969`, with sampled messages spanning roughly 10.3 seconds. During that window, the builder logged late forkchoice updates and produced five empty blocks.

The working hypothesis from `docs/blog/2026-06-02-mainnet-l1-reorg-reset-delay.md` is that reset reloaded forkchoice from the EL labels and used an older EL-labeled safe head, even though the engine actor had recently observed a newer in-memory safe head around `46810502`. One plausible code-level explanation is that some safe-head advancement can happen through in-memory consolidation paths without an FCU that updates reth's `safe` label. If reset then trusts the older EL label, it may perform a large serial parent walk before it can resume derivation/sequencing.

This PR does not try to prove or fix every part of that hypothesis. It gives us a concrete starting point for one mitigation: keep reset correctness unchanged, but make the expensive derivation reset anchor lookup sublinear and allow SafeDB to provide a validated jump target.

## Design

`ResetSignal` now carries an optional `l2_reset_anchor_hint`. The engine processor computes the current reset cutoff from the selected safe head's L1 origin and the configured channel timeout. If SafeDB is enabled, it queries `safe_head_at_l1(cutoff_l1)` and passes the returned L2 block ID as a hint.

The derivation pipeline treats the hint as untrusted:

- it fetches the hinted L2 block locally
- it checks the hash matches
- it checks the block satisfies the existing reset condition: `block.l1_origin + channel_timeout <= safe_head.l1_origin`
- if any check fails, it ignores the hint and searches normally

The fallback search preserves existing semantics but avoids the linear scan:

- exponential search backward from the selected safe head until it finds a block satisfying the reset condition or genesis
- binary search forward to find the highest block satisfying that same condition
- system config is still fetched from the selected reset block

This intentionally does not change the channel-timeout invariant. We still rewind far enough to preserve open-channel and system-config correctness.

## Why this is useful

The incident logs suggest the reset path walked hundreds of L2 parents through serial RPC calls. With this change, the no-SafeDB path should perform O(log N) L2 block lookups for the same target. If SafeDB is enabled and contains a useful entry, reset can start near the target and validate the candidate before doing any narrowing.

This also makes reset behavior easier to discuss and observe:

- SafeDB hint success/failure is logged
- sync-start unsafe/safe walk depths are logged
- derivation reset behavior remains covered by the same correctness condition as before

## Non-goals

- This does not enable SafeDB in Helm or production configs.
- This does not change SafeDB schema or RPC behavior.
- This does not yet prefer the engine actor's newer in-memory safe head over the EL safe label.
- This does not yet suspend/cancel sequencer builds while reset is in progress.

Those are likely separate follow-ups if the team agrees with the direction.

## Tests

- `cargo check -p base-consensus-derive -p base-consensus-engine -p base-consensus-node`
- `cargo test -p base-consensus-derive --lib initial_reset`
- `cargo test -p base-consensus-node --lib reset_anchor_hint_queries_safedb_at_channel_timeout_cutoff`
- `cargo test -p base-consensus-derive -p base-consensus-engine -p base-consensus-node`
- `cargo +nightly fmt`
- `git diff --check`

type=routine
risk=low
impact=sev5
