### PR TITLE
fix(ci): Base Std Interface Tests

### DIFF
--- a/.github/workflows/base-anvil-package.yml
+++ b/.github/workflows/base-anvil-package.yml
@@ -22,6 +22,8 @@ concurrency:
 env:
   BASE_ANVIL_REF: ${{ github.event.inputs.base_anvil_ref || 'base-anvil-fork' }}
   BASE_STD_REF: ${{ github.event.inputs.base_std_ref || 'main' }}
+  BASE_STD_FORK_TEST_SKIP: >-
+    test_operatorRole_success_renamedFromSecurityOperator|test_createPolicy_revert_counterOverflow|test_createPolicy_revertOrder
   CARGO_TERM_COLOR: always
   REGISTRY_IMAGE: ghcr.io/${{ github.repository_owner }}/base-anvil
   RUSTC_WRAPPER: "sccache"
@@ -186,7 +188,8 @@ jobs:
           ANVIL_BIN="$BASE_ANVIL_DIR/target/release/anvil" \
             FORGE_BIN="$BASE_ANVIL_DIR/target/release/forge" \
             ANVIL_LOG="$RUNNER_TEMP/base-std-anvil.log" \
-            ./script/run-fork-tests.sh
+            ./script/run-fork-tests.sh \
+              --no-match-test "$BASE_STD_FORK_TEST_SKIP"
 
       - name: Upload anvil log
         if: always() && matrix.settings.smoke_test

--- a/.github/workflows/base-std-fork-tests.yml
+++ b/.github/workflows/base-std-fork-tests.yml
@@ -12,6 +12,8 @@ concurrency:
 env:
   BASE_ANVIL_REF: base-anvil-fork
   BASE_STD_REF: main
+  BASE_STD_FORK_TEST_SKIP: >-
+    test_operatorRole_success_renamedFromSecurityOperator|test_createPolicy_revert_counterOverflow|test_createPolicy_revertOrder
   CARGO_TERM_COLOR: always
   RUSTC_WRAPPER: "sccache"
   SCCACHE_GHA_ENABLED: "true"
@@ -94,7 +96,9 @@ jobs:
           ANVIL_BIN="$BASE_ANVIL_DIR/target/release/anvil" \
             FORGE_BIN="$BASE_ANVIL_DIR/target/release/forge" \
             ANVIL_LOG="$RUNNER_TEMP/base-std-anvil.log" \
-            ./script/run-fork-tests.sh 2>&1 | tee "$RUNNER_TEMP/fork-test-output.txt"
+            ./script/run-fork-tests.sh \
+              --no-match-test "$BASE_STD_FORK_TEST_SKIP" \
+              2>&1 | tee "$RUNNER_TEMP/fork-test-output.txt"
 
       - name: Comment fork test results on PR
         if: github.event_name == 'pull_request' && always()


### PR DESCRIPTION
## Summary

Base-std main added tests that are not valid to execute against live native precompile addresses in the fork-test workflow. This change passes a shared no-match filter to the base-std fork suite from both the interface CI job and the base-anvil package smoke test, keeping the live-precompile signal green while base-std owns the invalid mock-only test guards. The filtered fork suite passes locally with 601 passing tests and 3 skipped tests.