### PR TITLE
[backport] chore(common): Schedule Zeronet Beryl Activation

### DIFF
--- a/crates/common/chains/src/chain.rs
+++ b/crates/common/chains/src/chain.rs
@@ -302,15 +302,11 @@ mod tests {
 
     #[test]
     fn is_beryl_active_at_timestamp() {
-        for forks in [
-            ChainUpgrades::mainnet(),
-            ChainUpgrades::sepolia(),
-            ChainUpgrades::devnet(),
-            ChainUpgrades::zeronet(),
-        ] {
-            assert!(!forks.is_beryl_active_at_timestamp(0));
-            assert!(!forks.is_beryl_active_at_timestamp(u64::MAX));
-        }
+        let zeronet_forks = ChainUpgrades::zeronet();
+        assert!(!zeronet_forks.is_beryl_active_at_timestamp(0));
+        assert!(!zeronet_forks.is_beryl_active_at_timestamp(1_780_678_799));
+        assert!(zeronet_forks.is_beryl_active_at_timestamp(1_780_678_800));
+        assert!(zeronet_forks.is_beryl_active_at_timestamp(u64::MAX));
     }
 
     #[test]

--- a/crates/common/chains/src/config.rs
+++ b/crates/common/chains/src/config.rs
@@ -539,7 +539,7 @@ const ZERONET: ChainConfig = ChainConfig {
     isthmus_timestamp: 0,
     jovian_timestamp: 0,
     azul_timestamp: Some(1_775_152_800),
-    beryl_timestamp: None,
+    beryl_timestamp: Some(1_780_678_800),
     cobalt_timestamp: None,
 
     genesis_l1_hash: b256!("b7d4b69971ff31d5179be5e1b83f5a4f438f4cd1db886a6630623b7047f32cfd"),
@@ -616,9 +616,9 @@ mod tests {
     }
 
     #[test]
-    fn zeronet_beryl_is_unscheduled() {
-        assert_eq!(ChainConfig::zeronet().beryl_timestamp, None);
-        assert_eq!(ChainConfig::zeronet().hardfork_config().base.beryl, None);
+    fn zeronet_beryl_is_scheduled() {
+        assert_eq!(ChainConfig::zeronet().beryl_timestamp, Some(1_780_678_800));
+        assert_eq!(ChainConfig::zeronet().hardfork_config().base.beryl, Some(1_780_678_800));
         assert_eq!(ChainConfig::zeronet().cobalt_timestamp, None);
         assert_eq!(ChainConfig::zeronet().hardfork_config().base.cobalt, None);
     }

--- a/crates/common/chains/src/upgrade.rs
+++ b/crates/common/chains/src/upgrade.rs
@@ -241,6 +241,11 @@ mod tests {
                 ChainConfig::sepolia().azul_timestamp.unwrap(),
                 BaseUpgrade::Azul,
             ),
+            (
+                Chain::from_id(ChainConfig::zeronet().chain_id),
+                ChainConfig::zeronet().beryl_timestamp.unwrap(),
+                BaseUpgrade::Beryl,
+            ),
         ];
 
         for (chain_id, timestamp, expected) in test_cases {


### PR DESCRIPTION
> [!NOTE]
> This is a backport of #3213 into `releases/v1.1.0`.

## Summary

Sets Zeronet Beryl activation to `1_780_678_800`. See [Unix Timestamp](https://www.unixtimestamp.com/).