### PR TITLE
fix(ci): publish partial release artifacts

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -31,6 +31,7 @@ jobs:
   # Build native binaries for release artifacts
   build-binaries:
     strategy:
+      fail-fast: false
       matrix:
         target:
           - triple: x86_64-unknown-linux-gnu
@@ -147,6 +148,7 @@ jobs:
   # Build multi-arch Docker images
   build-and-push:
     strategy:
+      fail-fast: false
       matrix:
         settings:
           - arch: linux/amd64
@@ -221,6 +223,7 @@ jobs:
   # Merge manifests and publish
   publish:
     needs: [build-and-push, build-binaries]
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
 
     steps:
@@ -268,25 +271,33 @@ jobs:
           fi
 
       - name: Create manifest list and push
-        working-directory: ${{ runner.temp }}/digests
+        id: create-manifest
         run: |
           shopt -s nullglob
-          DIGESTS=(*)
+          DIGEST_DIR="${{ runner.temp }}/digests"
+          DIGESTS=("$DIGEST_DIR"/*)
           if [[ ${#DIGESTS[@]} -eq 0 ]]; then
-            echo "::error::No digests found — build-and-push may have failed"
-            exit 1
+            echo "::warning::No Docker digests found — all Docker builds may have failed, skipping manifest push"
+            echo "pushed=false" >> $GITHUB_OUTPUT
+            exit 0
           fi
 
           IFS=',' read -ra TAGS <<< "${{ steps.tags.outputs.docker_tags }}"
-          TAG_ARGS=""
+          TAG_ARGS=()
           for tag in "${TAGS[@]}"; do
-            TAG_ARGS="$TAG_ARGS -t $tag"
+            TAG_ARGS+=(-t "$tag")
           done
 
-          docker buildx imagetools create $TAG_ARGS \
-            $(printf '${{ env.REGISTRY_IMAGE }}@sha256:%s ' "${DIGESTS[@]}")
+          SOURCES=()
+          for digest in "${DIGESTS[@]}"; do
+            SOURCES+=("${{ env.REGISTRY_IMAGE }}@sha256:${digest##*/}")
+          done
+
+          docker buildx imagetools create "${TAG_ARGS[@]}" "${SOURCES[@]}"
+          echo "pushed=true" >> $GITHUB_OUTPUT
 
       - name: Inspect image
+        if: steps.create-manifest.outputs.pushed == 'true'
         run: |
           docker buildx imagetools inspect ${{ env.REGISTRY_IMAGE }}:${{ steps.tags.outputs.tag }}
 
@@ -316,7 +327,15 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           TAG="${{ inputs.tag }}"
-          gh release upload "$TAG" ${{ runner.temp }}/binaries/*.tar.gz ${{ runner.temp }}/binaries/*.tar.gz.sha256 ${{ runner.temp }}/binaries/*.tar.gz.asc
+          BINARY_DIR="${{ runner.temp }}/binaries"
+          mkdir -p "$BINARY_DIR"
+          shopt -s nullglob
+          files=("$BINARY_DIR"/*.tar.gz "$BINARY_DIR"/*.tar.gz.sha256 "$BINARY_DIR"/*.tar.gz.asc)
+          if [[ ${#files[@]} -eq 0 ]]; then
+            echo "::warning::No binary artifacts found — all binary builds may have failed, skipping upload"
+          else
+            gh release upload "$TAG" "${files[@]}"
+          fi
 
       - name: Summary
         run: |

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -223,7 +223,7 @@ jobs:
   # Merge manifests and publish
   publish:
     needs: [build-and-push, build-binaries]
-    if: ${{ !cancelled() }}
+    if: ${{ !cancelled() && (needs.build-and-push.result == 'success' || needs.build-binaries.result == 'success') }}
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -240,7 +240,13 @@ jobs:
         id: artifacts
         env:
           GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          GH_RUN_ID: ${{ github.run_id }}
         run: |
+          set -euo pipefail
+
+          artifact_names=$(gh api "repos/$GH_REPO/actions/runs/$GH_RUN_ID/artifacts" --paginate --jq '.artifacts[].name')
+
           has_digests=false
           has_binaries=false
 
@@ -249,7 +255,7 @@ jobs:
               digests-*) has_digests=true ;;
               binaries-*) has_binaries=true ;;
             esac
-          done < <(gh api "repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts" --paginate --jq '.artifacts[].name')
+          done <<< "$artifact_names"
 
           echo "has_digests=$has_digests" >> "$GITHUB_OUTPUT"
           echo "has_binaries=$has_binaries" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -221,24 +221,20 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
-  # Merge manifests and publish
-  publish:
+  # Check which release artifacts exist after partial matrix failures
+  find-release-artifacts:
     needs: [build-and-push, build-binaries]
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
+    outputs:
+      has_digests: ${{ steps.artifacts.outputs.has_digests }}
+      has_binaries: ${{ steps.artifacts.outputs.has_binaries }}
 
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
           egress-policy: audit
-
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          ref: ${{ inputs.tag }}
-          fetch-depth: 0
-          fetch-tags: true
 
       - name: Find release artifacts
         id: artifacts
@@ -258,8 +254,27 @@ jobs:
           echo "has_digests=$has_digests" >> "$GITHUB_OUTPUT"
           echo "has_binaries=$has_binaries" >> "$GITHUB_OUTPUT"
 
+  # Merge manifests and publish
+  publish:
+    needs: [find-release-artifacts]
+    if: ${{ !cancelled() && (needs.find-release-artifacts.outputs.has_digests == 'true' || (inputs.is_final && needs.find-release-artifacts.outputs.has_binaries == 'true')) }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ inputs.tag }}
+          fetch-depth: 0
+          fetch-tags: true
+
       - name: Download digests
-        if: steps.artifacts.outputs.has_digests == 'true'
+        if: needs.find-release-artifacts.outputs.has_digests == 'true'
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: ${{ runner.temp }}/digests
@@ -267,7 +282,7 @@ jobs:
           merge-multiple: true
 
       - name: Login to GHCR
-        if: steps.artifacts.outputs.has_digests == 'true'
+        if: needs.find-release-artifacts.outputs.has_digests == 'true'
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ghcr.io
@@ -275,11 +290,11 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
-        if: steps.artifacts.outputs.has_digests == 'true'
+        if: needs.find-release-artifacts.outputs.has_digests == 'true'
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
       - name: Determine Docker tags
-        if: steps.artifacts.outputs.has_digests == 'true'
+        if: needs.find-release-artifacts.outputs.has_digests == 'true'
         id: tags
         run: |
           TAG="${{ inputs.tag }}"
@@ -294,6 +309,7 @@ jobs:
           fi
 
       - name: Create manifest list and push
+        if: needs.find-release-artifacts.outputs.has_digests == 'true'
         id: create-manifest
         run: |
           shopt -s nullglob
@@ -320,12 +336,12 @@ jobs:
           echo "pushed=true" >> $GITHUB_OUTPUT
 
       - name: Inspect image
-        if: steps.artifacts.outputs.has_digests == 'true' && steps.create-manifest.outputs.pushed == 'true'
+        if: needs.find-release-artifacts.outputs.has_digests == 'true' && steps.create-manifest.outputs.pushed == 'true'
         run: |
           docker buildx imagetools inspect ${{ env.REGISTRY_IMAGE }}:${{ steps.tags.outputs.tag }}
 
       - name: Create GitHub Release
-        if: inputs.is_final && (steps.create-manifest.outputs.pushed == 'true' || steps.artifacts.outputs.has_binaries == 'true')
+        if: inputs.is_final && (steps.create-manifest.outputs.pushed == 'true' || needs.find-release-artifacts.outputs.has_binaries == 'true')
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -337,7 +353,7 @@ jobs:
           fi
 
       - name: Download binary artifacts
-        if: inputs.is_final && steps.artifacts.outputs.has_binaries == 'true'
+        if: inputs.is_final && needs.find-release-artifacts.outputs.has_binaries == 'true'
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: ${{ runner.temp }}/binaries
@@ -345,7 +361,7 @@ jobs:
           merge-multiple: true
 
       - name: Upload binaries to GitHub Release
-        if: inputs.is_final
+        if: inputs.is_final && needs.find-release-artifacts.outputs.has_binaries == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -372,9 +388,11 @@ jobs:
           else
             echo "**Type**: Release Candidate" >> $GITHUB_STEP_SUMMARY
           fi
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "### Docker Images" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "\`\`\`bash" >> $GITHUB_STEP_SUMMARY
-          echo "docker pull ${{ env.REGISTRY_IMAGE }}:${TAG}" >> $GITHUB_STEP_SUMMARY
-          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+          if [[ "${{ steps.create-manifest.outputs.pushed }}" == "true" ]]; then
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "### Docker Images" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "\`\`\`bash" >> $GITHUB_STEP_SUMMARY
+            echo "docker pull ${{ env.REGISTRY_IMAGE }}:${TAG}" >> $GITHUB_STEP_SUMMARY
+            echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+          fi

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -22,6 +22,7 @@ env:
     basectl
 
 permissions:
+  actions: read
   contents: write
   packages: write
   id-token: write
@@ -223,7 +224,7 @@ jobs:
   # Merge manifests and publish
   publish:
     needs: [build-and-push, build-binaries]
-    if: ${{ !cancelled() && (needs.build-and-push.result == 'success' || needs.build-binaries.result == 'success') }}
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
 
     steps:
@@ -239,7 +240,26 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
 
+      - name: Find release artifacts
+        id: artifacts
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          has_digests=false
+          has_binaries=false
+
+          while IFS= read -r name; do
+            case "$name" in
+              digests-*) has_digests=true ;;
+              binaries-*) has_binaries=true ;;
+            esac
+          done < <(gh api "repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts" --paginate --jq '.artifacts[].name')
+
+          echo "has_digests=$has_digests" >> "$GITHUB_OUTPUT"
+          echo "has_binaries=$has_binaries" >> "$GITHUB_OUTPUT"
+
       - name: Download digests
+        if: steps.artifacts.outputs.has_digests == 'true'
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: ${{ runner.temp }}/digests
@@ -247,6 +267,7 @@ jobs:
           merge-multiple: true
 
       - name: Login to GHCR
+        if: steps.artifacts.outputs.has_digests == 'true'
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ghcr.io
@@ -254,9 +275,11 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
+        if: steps.artifacts.outputs.has_digests == 'true'
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
       - name: Determine Docker tags
+        if: steps.artifacts.outputs.has_digests == 'true'
         id: tags
         run: |
           TAG="${{ inputs.tag }}"
@@ -297,12 +320,12 @@ jobs:
           echo "pushed=true" >> $GITHUB_OUTPUT
 
       - name: Inspect image
-        if: steps.create-manifest.outputs.pushed == 'true'
+        if: steps.artifacts.outputs.has_digests == 'true' && steps.create-manifest.outputs.pushed == 'true'
         run: |
           docker buildx imagetools inspect ${{ env.REGISTRY_IMAGE }}:${{ steps.tags.outputs.tag }}
 
       - name: Create GitHub Release
-        if: inputs.is_final
+        if: inputs.is_final && (steps.create-manifest.outputs.pushed == 'true' || steps.artifacts.outputs.has_binaries == 'true')
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -314,7 +337,7 @@ jobs:
           fi
 
       - name: Download binary artifacts
-        if: inputs.is_final
+        if: inputs.is_final && steps.artifacts.outputs.has_binaries == 'true'
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: ${{ runner.temp }}/binaries

--- a/.github/workflows/create-rc.yml
+++ b/.github/workflows/create-rc.yml
@@ -6,6 +6,7 @@ on:
       - 'releases/v*'
 
 permissions:
+  actions: read
   contents: write
   packages: write
   id-token: write

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -9,6 +9,7 @@ on:
         type: string
 
 permissions:
+  actions: read
   contents: write
   packages: write
   id-token: write


### PR DESCRIPTION
  ## Summary

  - Allow release builds to publish successfully produced Docker and binary artifacts when one arch fails.
  - Keep existing release names, tags, archive names, checksums, and signatures unchanged when all builds pass.
  - Skip Docker manifest or binary upload with a warning when no matching artifacts exist.

  ## Testing

  - `actionlint .github/workflows/build-release.yml`
  - `git show --check --stat --oneline --summary
  HEAD`