### PR TITLE
feat: make beacon API optional

### DIFF
--- a/bin/prover/nitro-host/src/cli.rs
+++ b/bin/prover/nitro-host/src/cli.rs
@@ -156,7 +156,7 @@ impl ServerArgs {
         let config = ProverConfig {
             l1_eth_url: self.server.l1_eth_url,
             l2_eth_url: self.server.l2_eth_url,
-            l1_beacon_url: self.server.l1_beacon_url,
+            l1_beacon_url: Some(self.server.l1_beacon_url),
             l2_chain_id: self.server.l2_chain_id,
             rollup_config,
             l1_config,
@@ -218,7 +218,7 @@ impl LocalArgs {
         let prover_config = ProverConfig {
             l1_eth_url: self.server.l1_eth_url,
             l2_eth_url: self.server.l2_eth_url,
-            l1_beacon_url: self.server.l1_beacon_url,
+            l1_beacon_url: Some(self.server.l1_beacon_url),
             l2_chain_id: self.server.l2_chain_id,
             rollup_config,
             l1_config,

--- a/bin/prover/nitro-host/src/cli.rs
+++ b/bin/prover/nitro-host/src/cli.rs
@@ -75,7 +75,11 @@ struct ProverServerArgs {
 
     /// L1 beacon API URL.
     #[arg(long, env = "L1_BEACON_URL")]
-    l1_beacon_url: String,
+    l1_beacon_url: Option<String>,
+
+    /// Run proving without an L1 beacon API (calldata-only / appchain mode).
+    #[arg(long, env = "L1_CALLDATA_ONLY")]
+    l1_calldata_only: bool,
 
     /// L2 chain ID.
     #[arg(long, env = "L2_CHAIN_ID")]
@@ -101,6 +105,24 @@ struct ProverServerArgs {
 
 #[cfg(any(target_os = "linux", feature = "local"))]
 impl ProverServerArgs {
+    fn l1_beacon_url(&self) -> eyre::Result<Option<String>> {
+        let l1_beacon_url =
+            self.l1_beacon_url.as_deref().map(str::trim).filter(|url| !url.is_empty());
+
+        match (l1_beacon_url, self.l1_calldata_only) {
+            (Some(url), false) => Ok(Some(url.to_string())),
+            (None, true) => Ok(None),
+            (None, false) => Err(eyre!(
+                "no L1 derivation mode selected: provide --l1-beacon-url <url> for blob-backed \
+                 proving, or pass --l1-calldata-only for calldata-only proving"
+            )),
+            (Some(_), true) => Err(eyre!(
+                "conflicting L1 derivation modes: --l1-beacon-url and --l1-calldata-only are \
+                 mutually exclusive"
+            )),
+        }
+    }
+
     fn registration_health_config(&self) -> Option<RegistrationHealthConfig> {
         self.tee_prover_registry_address.map(|address| RegistrationHealthConfig {
             registry_address: address,
@@ -143,6 +165,7 @@ impl Cli {
 #[cfg(target_os = "linux")]
 impl ServerArgs {
     async fn run(self) -> eyre::Result<()> {
+        let l1_beacon_url = self.server.l1_beacon_url()?;
         let rollup_config = rollup_config!(self.server.l2_chain_id)
             .ok_or_else(|| eyre!("unknown L2 chain ID: {}", self.server.l2_chain_id))?;
 
@@ -156,7 +179,7 @@ impl ServerArgs {
         let config = ProverConfig {
             l1_eth_url: self.server.l1_eth_url,
             l2_eth_url: self.server.l2_eth_url,
-            l1_beacon_url: Some(self.server.l1_beacon_url),
+            l1_beacon_url,
             l2_chain_id: self.server.l2_chain_id,
             rollup_config,
             l1_config,
@@ -205,6 +228,7 @@ struct LocalArgs {
 #[cfg(feature = "local")]
 impl LocalArgs {
     async fn run(self) -> eyre::Result<()> {
+        let l1_beacon_url = self.server.l1_beacon_url()?;
         let rollup_config = rollup_config!(self.server.l2_chain_id)
             .ok_or_else(|| eyre!("unknown L2 chain ID: {}", self.server.l2_chain_id))?;
 
@@ -218,7 +242,7 @@ impl LocalArgs {
         let prover_config = ProverConfig {
             l1_eth_url: self.server.l1_eth_url,
             l2_eth_url: self.server.l2_eth_url,
-            l1_beacon_url: Some(self.server.l1_beacon_url),
+            l1_beacon_url,
             l2_chain_id: self.server.l2_chain_id,
             rollup_config,
             l1_config,
@@ -250,5 +274,55 @@ impl LocalArgs {
         let handle = server.run(self.server.listen_addr).await?;
         handle.stopped().await;
         Ok(())
+    }
+}
+
+#[cfg(all(test, feature = "local"))]
+mod tests {
+    use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+
+    use super::ProverServerArgs;
+
+    fn args(l1_beacon_url: Option<&str>, l1_calldata_only: bool) -> ProverServerArgs {
+        ProverServerArgs {
+            l1_eth_url: "http://localhost:8545".to_string(),
+            l2_eth_url: "http://localhost:9545".to_string(),
+            l1_beacon_url: l1_beacon_url.map(str::to_string),
+            l1_calldata_only,
+            l2_chain_id: 8453,
+            listen_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 8080),
+            enable_experimental_witness_endpoint: false,
+            proof_request_timeout_secs: 1740,
+            tee_prover_registry_address: None,
+        }
+    }
+
+    #[test]
+    fn beacon_mode_is_valid() {
+        let l1_beacon_url = args(Some("http://localhost:5052"), false).l1_beacon_url().unwrap();
+
+        assert_eq!(l1_beacon_url, Some("http://localhost:5052".to_string()));
+    }
+
+    #[test]
+    fn calldata_only_mode_is_valid() {
+        let l1_beacon_url = args(None, true).l1_beacon_url().unwrap();
+
+        assert_eq!(l1_beacon_url, None);
+    }
+
+    #[test]
+    fn neither_mode_is_an_error() {
+        assert!(args(None, false).l1_beacon_url().is_err());
+    }
+
+    #[test]
+    fn both_modes_are_an_error() {
+        assert!(args(Some("http://localhost:5052"), true).l1_beacon_url().is_err());
+    }
+
+    #[test]
+    fn empty_beacon_url_is_treated_as_missing() {
+        assert!(args(Some("  "), false).l1_beacon_url().is_err());
     }
 }

--- a/bin/prover/zk/src/cli.rs
+++ b/bin/prover/zk/src/cli.rs
@@ -52,6 +52,9 @@ struct ZkArgs {
     #[arg(long, env = "L1_BEACON_ADDRESS")]
     l1_beacon_address: Option<String>,
 
+    #[arg(long, env = "L1_CALLDATA_ONLY")]
+    l1_calldata_only: bool,
+
     #[arg(long, env = "L2_NODE_ADDRESS")]
     l2_node_address: String,
 
@@ -150,6 +153,7 @@ impl ZkArgs {
     /// Runs the ZK prover service.
     async fn run(self) -> eyre::Result<()> {
         self.validate_config()?;
+        let configured_beacon_url = self.l1_beacon_url()?;
 
         info!("initializing database connection");
         let db_config = DatabaseConfig::from_env().map_err(|e| eyre!(e))?;
@@ -157,14 +161,6 @@ impl ZkArgs {
         let repo = ProofRequestRepo::new(pool);
         info!("database connection initialized");
 
-        // Normalize an absent/blank beacon address to `None` so the prover runs in
-        // calldata-only mode.
-        let configured_beacon_url = self
-            .l1_beacon_address
-            .as_deref()
-            .map(str::trim)
-            .filter(|url| !url.is_empty())
-            .map(ToOwned::to_owned);
         let (l1_url, l2_url, beacon_url, proxy_handles) = if self.proxy_enable {
             info!("proxy enabled, starting rate-limited RPC proxies");
 
@@ -203,7 +199,14 @@ impl ZkArgs {
         };
 
         let beacon_log = beacon_url.as_deref().unwrap_or("<none>");
-        info!(l1_url = %l1_url, l2_url = %l2_url, beacon_url = %beacon_log, "using RPC URLs");
+        let l1_derivation_mode = if beacon_url.is_some() { "beacon" } else { "calldata_only" };
+        info!(
+            l1_url = %l1_url,
+            l2_url = %l2_url,
+            beacon_url = %beacon_log,
+            l1_derivation_mode = %l1_derivation_mode,
+            "using RPC URLs"
+        );
 
         let rpc_config = RPCConfig {
             l1_rpc: Url::parse(&l1_url).map_err(|e| eyre!("invalid L1 RPC URL: {e}"))?,
@@ -518,6 +521,24 @@ impl ZkArgs {
         Ok(())
     }
 
+    fn l1_beacon_url(&self) -> eyre::Result<Option<String>> {
+        let l1_beacon_address =
+            self.l1_beacon_address.as_deref().map(str::trim).filter(|url| !url.is_empty());
+
+        match (l1_beacon_address, self.l1_calldata_only) {
+            (Some(url), false) => Ok(Some(url.to_string())),
+            (None, true) => Ok(None),
+            (None, false) => Err(eyre!(
+                "no L1 derivation mode selected: provide --l1-beacon-address <url> for \
+                 blob-backed proving, or pass --l1-calldata-only for calldata-only proving"
+            )),
+            (Some(_), true) => Err(eyre!(
+                "conflicting L1 derivation modes: --l1-beacon-address and --l1-calldata-only are \
+                 mutually exclusive"
+            )),
+        }
+    }
+
     /// Creates the artifact client and its corresponding storage config descriptor.
     async fn create_artifact_client(
         &self,
@@ -568,5 +589,73 @@ impl ZkArgs {
 
     fn non_empty(opt: &Option<String>) -> bool {
         opt.as_ref().is_some_and(|s| !s.is_empty())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ZkArgs;
+
+    fn args(l1_beacon_address: Option<&str>, l1_calldata_only: bool) -> ZkArgs {
+        ZkArgs {
+            base_consensus_address: "http://localhost:9546".to_string(),
+            l1_node_address: "http://localhost:8545".to_string(),
+            l1_beacon_address: l1_beacon_address.map(str::to_string),
+            l1_calldata_only,
+            l2_node_address: "http://localhost:9545".to_string(),
+            default_sequence_window: 50,
+            proxy_enable: true,
+            proxy_l2_port: 8545,
+            proxy_l1_port: 8546,
+            proxy_beacon_port: 8547,
+            rate_limit_rps: 50,
+            rate_limit_concurrent: 25,
+            rate_limit_queue_timeout_secs: 90,
+            outbox_poll_interval_secs: 5,
+            outbox_batch_size: 10,
+            outbox_max_retries: 5,
+            status_poller_interval_secs: 30,
+            stuck_request_timeout_mins: 10,
+            max_proof_retries: 3,
+            prover_mode: "mock".to_string(),
+            sp1_cluster_api_endpoint: None,
+            sp1_cluster_timeout_hours: 24,
+            cli_redis_nodes: None,
+            cli_s3_bucket: None,
+            cli_s3_region: None,
+            sp1_network_private_key: None,
+            sp1_fulfillment_strategy: "reserved".to_string(),
+            use_kms_requester: false,
+            grpc_listen_addr: "0.0.0.0:9000".to_string(),
+        }
+    }
+
+    #[test]
+    fn beacon_mode_is_valid() {
+        let l1_beacon_url = args(Some("http://localhost:5052"), false).l1_beacon_url().unwrap();
+
+        assert_eq!(l1_beacon_url, Some("http://localhost:5052".to_string()));
+    }
+
+    #[test]
+    fn calldata_only_mode_is_valid() {
+        let l1_beacon_url = args(None, true).l1_beacon_url().unwrap();
+
+        assert_eq!(l1_beacon_url, None);
+    }
+
+    #[test]
+    fn neither_mode_is_an_error() {
+        assert!(args(None, false).l1_beacon_url().is_err());
+    }
+
+    #[test]
+    fn both_modes_are_an_error() {
+        assert!(args(Some("http://localhost:5052"), true).l1_beacon_url().is_err());
+    }
+
+    #[test]
+    fn empty_beacon_url_is_treated_as_missing() {
+        assert!(args(Some("  "), false).l1_beacon_url().is_err());
     }
 }

--- a/bin/prover/zk/src/cli.rs
+++ b/bin/prover/zk/src/cli.rs
@@ -50,7 +50,7 @@ struct ZkArgs {
     l1_node_address: String,
 
     #[arg(long, env = "L1_BEACON_ADDRESS")]
-    l1_beacon_address: String,
+    l1_beacon_address: Option<String>,
 
     #[arg(long, env = "L2_NODE_ADDRESS")]
     l2_node_address: String,
@@ -157,6 +157,7 @@ impl ZkArgs {
         let repo = ProofRequestRepo::new(pool);
         info!("database connection initialized");
 
+        let configured_beacon_url = Self::trimmed_optional(&self.l1_beacon_address);
         let (l1_url, l2_url, beacon_url, proxy_handles) = if self.proxy_enable {
             info!("proxy enabled, starting rate-limited RPC proxies");
 
@@ -172,7 +173,7 @@ impl ZkArgs {
                 self.proxy_l2_port,
                 self.l2_node_address.clone(),
                 self.proxy_beacon_port,
-                self.l1_beacon_address.clone(),
+                configured_beacon_url.clone(),
                 rate_limit,
             );
 
@@ -181,7 +182,7 @@ impl ZkArgs {
             (
                 proxy_configs.l1.local_address(),
                 proxy_configs.l2.local_address(),
-                proxy_configs.beacon.local_address(),
+                proxy_configs.beacon.as_ref().map(|beacon| beacon.local_address()),
                 handles,
             )
         } else {
@@ -189,18 +190,20 @@ impl ZkArgs {
             (
                 self.l1_node_address.clone(),
                 self.l2_node_address.clone(),
-                self.l1_beacon_address.clone(),
+                configured_beacon_url,
                 Vec::new(),
             )
         };
 
-        info!(l1_url = %l1_url, l2_url = %l2_url, beacon_url = %beacon_url, "using RPC URLs");
+        let beacon_log = beacon_url.as_deref().unwrap_or("<none>");
+        info!(l1_url = %l1_url, l2_url = %l2_url, beacon_url = %beacon_log, "using RPC URLs");
 
         let rpc_config = RPCConfig {
             l1_rpc: Url::parse(&l1_url).map_err(|e| eyre!("invalid L1 RPC URL: {e}"))?,
-            l1_beacon_rpc: Some(
-                Url::parse(&beacon_url).map_err(|e| eyre!("invalid beacon RPC URL: {e}"))?,
-            ),
+            l1_beacon_rpc: beacon_url
+                .as_deref()
+                .map(|url| Url::parse(url).map_err(|e| eyre!("invalid beacon RPC URL: {e}")))
+                .transpose()?,
             l2_rpc: Url::parse(&l2_url).map_err(|e| eyre!("invalid L2 RPC URL: {e}"))?,
             l2_node_rpc: Url::parse(&self.base_consensus_address)
                 .map_err(|e| eyre!("invalid L2 node RPC URL: {e}"))?,
@@ -558,5 +561,9 @@ impl ZkArgs {
 
     fn non_empty(opt: &Option<String>) -> bool {
         opt.as_ref().is_some_and(|s| !s.is_empty())
+    }
+
+    fn trimmed_optional(opt: &Option<String>) -> Option<String> {
+        opt.as_deref().map(str::trim).filter(|s| !s.is_empty()).map(ToOwned::to_owned)
     }
 }

--- a/bin/prover/zk/src/cli.rs
+++ b/bin/prover/zk/src/cli.rs
@@ -157,7 +157,14 @@ impl ZkArgs {
         let repo = ProofRequestRepo::new(pool);
         info!("database connection initialized");
 
-        let configured_beacon_url = Self::trimmed_optional(&self.l1_beacon_address);
+        // Normalize an absent/blank beacon address to `None` so the prover runs in
+        // calldata-only mode.
+        let configured_beacon_url = self
+            .l1_beacon_address
+            .as_deref()
+            .map(str::trim)
+            .filter(|url| !url.is_empty())
+            .map(ToOwned::to_owned);
         let (l1_url, l2_url, beacon_url, proxy_handles) = if self.proxy_enable {
             info!("proxy enabled, starting rate-limited RPC proxies");
 
@@ -561,9 +568,5 @@ impl ZkArgs {
 
     fn non_empty(opt: &Option<String>) -> bool {
         opt.as_ref().is_some_and(|s| !s.is_empty())
-    }
-
-    fn trimmed_optional(opt: &Option<String>) -> Option<String> {
-        opt.as_deref().map(str::trim).filter(|s| !s.is_empty()).map(ToOwned::to_owned)
     }
 }

--- a/crates/consensus/cli/src/follow.rs
+++ b/crates/consensus/cli/src/follow.rs
@@ -243,8 +243,7 @@ impl ConsensusFollowNodeArgs {
         let l1_beacon = self
             .config
             .l1_rpc_args
-            .l1_beacon
-            .as_ref()
+            .l1_beacon()?
             .map(|beacon| OnlineBeaconClient::new_http(beacon.to_string()));
 
         Ok(L1Config {

--- a/crates/consensus/cli/src/follow.rs
+++ b/crates/consensus/cli/src/follow.rs
@@ -238,7 +238,12 @@ impl ConsensusFollowNodeArgs {
     pub fn l1_config(&self, cfg: &RollupConfig) -> eyre::Result<L1Config> {
         let l1_chain_config =
             self.config.l1_config.load(cfg.l1_chain_id).map_err(|e| eyre::eyre!(e))?;
-        let l1_beacon = OnlineBeaconClient::new_http(self.config.l1_rpc_args.l1_beacon.to_string());
+        let l1_beacon = self
+            .config
+            .l1_rpc_args
+            .l1_beacon
+            .as_ref()
+            .map(|beacon| OnlineBeaconClient::new_http(beacon.to_string()));
 
         Ok(L1Config {
             chain_config: Arc::new(l1_chain_config),

--- a/crates/consensus/cli/src/follow.rs
+++ b/crates/consensus/cli/src/follow.rs
@@ -236,6 +236,8 @@ impl ConsensusFollowNodeArgs {
 
     /// Builds the L1 configuration for the follow node.
     pub fn l1_config(&self, cfg: &RollupConfig) -> eyre::Result<L1Config> {
+        self.config.l1_rpc_args.validate()?;
+
         let l1_chain_config =
             self.config.l1_config.load(cfg.l1_chain_id).map_err(|e| eyre::eyre!(e))?;
         let l1_beacon = self
@@ -298,5 +300,14 @@ mod tests {
         let config = parse_config(&["--rpc.disabled"]);
 
         assert!(Option::<RpcBuilder>::from(config.rpc_flags).is_none());
+    }
+
+    #[test]
+    fn l1_config_rejects_conflicting_derivation_modes() {
+        let config = parse_config(&["--l1-calldata-only"]);
+        let args = ConsensusFollowNodeArgs::new(ConsensusChainArgs::default(), config);
+        let cfg = args.load_rollup_config().unwrap();
+
+        assert!(args.l1_config(&cfg).is_err());
     }
 }

--- a/crates/consensus/cli/src/l1.rs
+++ b/crates/consensus/cli/src/l1.rs
@@ -20,8 +20,12 @@ pub struct L1ClientArgs {
     )]
     pub l1_trust_rpc: bool,
     /// URL of the L1 beacon API.
+    ///
+    /// Optional: omit it when the L1 parent chain has no beacon (blob) DA endpoint - e.g. an L2
+    /// settlement layer. Blob-based batches cannot be derived without it, so the parent must use
+    /// calldata (or alt-DA) batching.
     #[arg(long, visible_alias = "l1.beacon", env = "BASE_NODE_L1_BEACON")]
-    pub l1_beacon: Url,
+    pub l1_beacon: Option<Url>,
     /// Duration in seconds of an L1 slot.
     ///
     /// This is an optional argument that can be used to use a fixed slot duration for l1 blocks
@@ -45,7 +49,7 @@ impl Default for L1ClientArgs {
         Self {
             l1_eth_rpc: Url::parse("http://localhost:8545").unwrap(),
             l1_trust_rpc: DEFAULT_L1_TRUST_RPC,
-            l1_beacon: Url::parse("http://localhost:5052").unwrap(),
+            l1_beacon: Some(Url::parse("http://localhost:5052").unwrap()),
             l1_slot_duration_override: None,
             l1_verifier_confs: 0,
         }

--- a/crates/consensus/cli/src/l1.rs
+++ b/crates/consensus/cli/src/l1.rs
@@ -1,5 +1,6 @@
 //! L1 Client CLI arguments.
 
+use tracing::{info, warn};
 use url::Url;
 
 const DEFAULT_L1_TRUST_RPC: bool = true;
@@ -21,11 +22,17 @@ pub struct L1ClientArgs {
     pub l1_trust_rpc: bool,
     /// URL of the L1 beacon API.
     ///
-    /// Optional: omit it when the L1 parent chain has no beacon (blob) DA endpoint - e.g. an L2
-    /// settlement layer. Blob-based batches cannot be derived without it, so the parent must use
-    /// calldata (or alt-DA) batching.
+    /// Required for the main Base chain (parent chain = Ethereum), which derives blob-based batches.
+    /// Omit it together with `--l1.calldata-only` when the L1 parent chain has no beacon (blob) DA
+    /// endpoint - e.g. an appchain settling to Base, which must use calldata (or alt-DA) batching.
     #[arg(long, visible_alias = "l1.beacon", env = "BASE_NODE_L1_BEACON")]
     pub l1_beacon: Option<Url>,
+    /// Run derivation without an L1 beacon API (calldata-only / appchain mode).
+    ///
+    /// Mutually exclusive with `--l1.beacon`. When set, blob-based batches cannot be derived, so the
+    /// parent chain must batch via calldata (or alt-DA).
+    #[arg(long, visible_alias = "l1.calldata-only", env = "BASE_NODE_L1_CALLDATA_ONLY")]
+    pub l1_calldata_only: bool,
     /// Duration in seconds of an L1 slot.
     ///
     /// This is an optional argument that can be used to use a fixed slot duration for l1 blocks
@@ -50,8 +57,77 @@ impl Default for L1ClientArgs {
             l1_eth_rpc: Url::parse("http://localhost:8545").unwrap(),
             l1_trust_rpc: DEFAULT_L1_TRUST_RPC,
             l1_beacon: Some(Url::parse("http://localhost:5052").unwrap()),
+            l1_calldata_only: false,
             l1_slot_duration_override: None,
             l1_verifier_confs: 0,
         }
+    }
+}
+
+impl L1ClientArgs {
+    /// Validates that exactly one derivation mode is selected, making the choice explicit so a
+    /// main-chain node cannot silently run without a beacon API.
+    ///
+    /// - `--l1.beacon <url>` (no `--l1.calldata-only`): beacon mode (main Base chain).
+    /// - `--l1.calldata-only` (no `--l1.beacon`): calldata-only mode (appchain).
+    /// - neither: error - the operator must state intent.
+    /// - both: error - conflicting flags.
+    pub fn validate(&self) -> eyre::Result<()> {
+        match (self.l1_beacon.is_some(), self.l1_calldata_only) {
+            (true, false) | (false, true) => Ok(()),
+            (false, false) => Err(eyre::eyre!(
+                "no L1 derivation mode selected: provide --l1.beacon <url> for the main Base chain, \
+                 or pass --l1.calldata-only for an appchain parent with no beacon API"
+            )),
+            (true, true) => Err(eyre::eyre!(
+                "conflicting L1 derivation modes: --l1.beacon and --l1.calldata-only are mutually \
+                 exclusive"
+            )),
+        }
+    }
+
+    /// Logs the active L1 derivation mode at startup. Call after [`Self::validate`].
+    pub fn log_derivation_mode(&self) {
+        match self.l1_beacon.as_ref() {
+            Some(beacon) => {
+                info!(target: "rollup_node", l1_beacon = %beacon, "L1 beacon mode: deriving blob-based batches")
+            }
+            None => {
+                warn!(target: "rollup_node", "L1 calldata-only mode: no beacon API configured; blob-based batches cannot be derived")
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn args(beacon: Option<&str>, calldata_only: bool) -> L1ClientArgs {
+        L1ClientArgs {
+            l1_beacon: beacon.map(|b| Url::parse(b).unwrap()),
+            l1_calldata_only: calldata_only,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn beacon_mode_is_valid() {
+        assert!(args(Some("http://localhost:5052"), false).validate().is_ok());
+    }
+
+    #[test]
+    fn calldata_only_mode_is_valid() {
+        assert!(args(None, true).validate().is_ok());
+    }
+
+    #[test]
+    fn neither_flag_is_an_error() {
+        assert!(args(None, false).validate().is_err());
+    }
+
+    #[test]
+    fn both_flags_are_an_error() {
+        assert!(args(Some("http://localhost:5052"), true).validate().is_err());
     }
 }

--- a/crates/consensus/cli/src/l1.rs
+++ b/crates/consensus/cli/src/l1.rs
@@ -1,5 +1,6 @@
 //! L1 Client CLI arguments.
 
+use eyre::WrapErr;
 use tracing::{info, warn};
 use url::Url;
 
@@ -25,8 +26,12 @@ pub struct L1ClientArgs {
     /// Required for the main Base chain (parent chain = Ethereum), which derives blob-based batches.
     /// Omit it together with `--l1.calldata-only` when the L1 parent chain has no beacon (blob) DA
     /// endpoint - e.g. an appchain settling to Base, which must use calldata (or alt-DA) batching.
+    ///
+    /// A blank or whitespace-only value is treated as absent (equivalent to not passing the flag),
+    /// so an empty env var like `BASE_NODE_L1_BEACON=` works the same as omitting it. Access the
+    /// normalized, parsed URL via [`Self::l1_beacon`].
     #[arg(long, visible_alias = "l1.beacon", env = "BASE_NODE_L1_BEACON")]
-    pub l1_beacon: Option<Url>,
+    pub l1_beacon: Option<String>,
     /// Run derivation without an L1 beacon API (calldata-only / appchain mode).
     ///
     /// Mutually exclusive with `--l1.beacon`. When set, blob-based batches cannot be derived, so the
@@ -56,7 +61,7 @@ impl Default for L1ClientArgs {
         Self {
             l1_eth_rpc: Url::parse("http://localhost:8545").unwrap(),
             l1_trust_rpc: DEFAULT_L1_TRUST_RPC,
-            l1_beacon: Some(Url::parse("http://localhost:5052").unwrap()),
+            l1_beacon: Some("http://localhost:5052".to_string()),
             l1_calldata_only: false,
             l1_slot_duration_override: None,
             l1_verifier_confs: 0,
@@ -65,6 +70,18 @@ impl Default for L1ClientArgs {
 }
 
 impl L1ClientArgs {
+    /// The configured L1 beacon URL, with blank or whitespace-only values treated as absent
+    /// (mirroring the prover's `l1_beacon_rpc_from_env`). Returns an error if a non-blank value is
+    /// not a valid URL.
+    pub fn l1_beacon(&self) -> eyre::Result<Option<Url>> {
+        self.l1_beacon
+            .as_deref()
+            .map(str::trim)
+            .filter(|url| !url.is_empty())
+            .map(|url| Url::parse(url).wrap_err("BASE_NODE_L1_BEACON must be a valid URL"))
+            .transpose()
+    }
+
     /// Validates that exactly one derivation mode is selected, making the choice explicit so a
     /// main-chain node cannot silently run without a beacon API.
     ///
@@ -73,7 +90,7 @@ impl L1ClientArgs {
     /// - neither: error - the operator must state intent.
     /// - both: error - conflicting flags.
     pub fn validate(&self) -> eyre::Result<()> {
-        match (self.l1_beacon.is_some(), self.l1_calldata_only) {
+        match (self.l1_beacon()?.is_some(), self.l1_calldata_only) {
             (true, false) | (false, true) => Ok(()),
             (false, false) => Err(eyre::eyre!(
                 "no L1 derivation mode selected: provide --l1.beacon <url> for the main Base chain, \
@@ -86,9 +103,10 @@ impl L1ClientArgs {
         }
     }
 
-    /// Logs the active L1 derivation mode at startup. Call after [`Self::validate`].
+    /// Logs the active L1 derivation mode at startup. Call after [`Self::validate`], which has
+    /// already vetted the beacon URL.
     pub fn log_derivation_mode(&self) {
-        match self.l1_beacon.as_ref() {
+        match self.l1_beacon().ok().flatten() {
             Some(beacon) => {
                 info!(target: "rollup_node", l1_beacon = %beacon, "L1 beacon mode: deriving blob-based batches")
             }
@@ -105,7 +123,7 @@ mod tests {
 
     fn args(beacon: Option<&str>, calldata_only: bool) -> L1ClientArgs {
         L1ClientArgs {
-            l1_beacon: beacon.map(|b| Url::parse(b).unwrap()),
+            l1_beacon: beacon.map(str::to_string),
             l1_calldata_only: calldata_only,
             ..Default::default()
         }
@@ -129,5 +147,28 @@ mod tests {
     #[test]
     fn both_flags_are_an_error() {
         assert!(args(Some("http://localhost:5052"), true).validate().is_err());
+    }
+
+    #[test]
+    fn blank_beacon_is_treated_as_missing() {
+        // A blank/whitespace beacon is normalized to None, so it routes through the same
+        // "no derivation mode selected" path as omitting the flag entirely.
+        assert_eq!(args(Some("  "), false).l1_beacon().unwrap(), None);
+        assert!(args(Some("  "), false).validate().is_err());
+        assert!(args(Some("  "), true).validate().is_ok());
+    }
+
+    #[test]
+    fn beacon_url_is_trimmed_and_parsed() {
+        assert_eq!(
+            args(Some(" http://localhost:5052 "), false).l1_beacon().unwrap().unwrap().as_str(),
+            "http://localhost:5052/"
+        );
+    }
+
+    #[test]
+    fn malformed_beacon_url_is_an_error() {
+        assert!(args(Some("not a url"), false).l1_beacon().is_err());
+        assert!(args(Some("not a url"), false).validate().is_err());
     }
 }

--- a/crates/consensus/cli/src/node.rs
+++ b/crates/consensus/cli/src/node.rs
@@ -227,6 +227,8 @@ impl ConsensusNodeArgs {
         overrides: ConsensusNodeOverrides,
     ) -> eyre::Result<RollupNode> {
         self.validate_sequencer_key()?;
+        self.config.l1_rpc_args.validate()?;
+        self.config.l1_rpc_args.log_derivation_mode();
 
         info!(
             target: "rollup_node",

--- a/crates/consensus/cli/src/node.rs
+++ b/crates/consensus/cli/src/node.rs
@@ -244,7 +244,7 @@ impl ConsensusNodeArgs {
         let l1_config = L1ConfigBuilder {
             chain_config: l1_chain_config,
             trust_rpc: self.config.l1_rpc_args.l1_trust_rpc,
-            beacon: self.config.l1_rpc_args.l1_beacon.clone(),
+            beacon: self.config.l1_rpc_args.l1_beacon()?,
             rpc_url: self.config.l1_rpc_args.l1_eth_rpc.clone(),
             slot_duration_override: self.config.l1_rpc_args.l1_slot_duration_override,
             verifier_l1_confs: self.config.l1_rpc_args.l1_verifier_confs,

--- a/crates/consensus/providers/src/blobs.rs
+++ b/crates/consensus/providers/src/blobs.rs
@@ -33,10 +33,15 @@ pub struct BlobWithCommitmentAndProof {
 }
 
 /// An online implementation of the [`BlobProvider`] trait.
+///
+/// The beacon client is optional: when the L1 parent chain has no beacon (blob) DA
+/// endpoint - e.g. an L2 settlement layer running in calldata-only mode - the provider is
+/// constructed via [`OnlineBlobProvider::disabled`] and any attempt to actually fetch blobs
+/// returns an error. Calldata-only derivation never requests blobs, so it never hits that path.
 #[derive(Debug, Clone)]
 pub struct OnlineBlobProvider<B: BeaconClient> {
-    /// The Beacon API client.
-    pub beacon_client: B,
+    /// The Beacon API client, or `None` when no beacon endpoint is configured.
+    pub beacon_client: Option<B>,
     /// Beacon Genesis time used for the time to slot conversion.
     pub genesis_time: u64,
     /// Slot interval used for the time to slot conversion.
@@ -65,8 +70,20 @@ impl<B: BeaconClient> OnlineBlobProvider<B> {
             .map(|r| r.data.seconds_per_slot)
             .map_err(|e| BlobProviderError::Backend(e.to_string()))
             .expect("Failed to load slot interval from beacon client");
-        Self { beacon_client, genesis_time, slot_interval }
+        Self { beacon_client: Some(beacon_client), genesis_time, slot_interval }
     }
+
+    /// Creates an [`OnlineBlobProvider`] with no beacon backend.
+    ///
+    /// Used when the L1 parent chain exposes no beacon (blob) DA endpoint. Blob fetches return
+    /// [`BlobProviderError::Backend`]; calldata-only derivation never requests blobs.
+    pub const fn disabled() -> Self {
+        Self { beacon_client: None, genesis_time: 0, slot_interval: 0 }
+    }
+
+    /// Error message returned when blobs are requested but no beacon endpoint is configured.
+    const NO_BEACON_ERR: &'static str =
+        "L1 beacon endpoint not configured; cannot fetch blobs (calldata-only mode)";
 
     /// Computes the slot for the given timestamp.
     pub const fn slot(
@@ -86,24 +103,27 @@ impl<B: BeaconClient> OnlineBlobProvider<B> {
         slot: u64,
         blob_hashes: &[B256],
     ) -> Result<Vec<BoxedBlob>, BlobProviderError> {
+        let Some(beacon_client) = self.beacon_client.as_ref() else {
+            return Err(BlobProviderError::Backend(Self::NO_BEACON_ERR.to_string()));
+        };
+
         Metrics::blob_fetches().increment(1);
 
-        let result =
-            self.beacon_client.filtered_beacon_blobs(slot, blob_hashes).await.map_err(|e| {
-                // The beacon node returned 404 for this slot. The slot was missed or
-                // orphaned; its blobs will never be available. Map to BlobNotFound so
-                // the pipeline issues a reset rather than retrying indefinitely.
-                let Some(missing_slot) = B::slot_not_found(&e) else {
-                    return BlobProviderError::Backend(e.to_string());
-                };
-                warn!(
-                    target: "blob_provider",
-                    slot = missing_slot,
-                    "Beacon slot not found (404); slot may be missed or orphaned, \
-                     triggering pipeline reset"
-                );
-                BlobProviderError::BlobNotFound { slot: missing_slot, reason: e.to_string() }
-            });
+        let result = beacon_client.filtered_beacon_blobs(slot, blob_hashes).await.map_err(|e| {
+            // The beacon node returned 404 for this slot. The slot was missed or
+            // orphaned; its blobs will never be available. Map to BlobNotFound so
+            // the pipeline issues a reset rather than retrying indefinitely.
+            let Some(missing_slot) = B::slot_not_found(&e) else {
+                return BlobProviderError::Backend(e.to_string());
+            };
+            warn!(
+                target: "blob_provider",
+                slot = missing_slot,
+                "Beacon slot not found (404); slot may be missed or orphaned, \
+                 triggering pipeline reset"
+            );
+            BlobProviderError::BlobNotFound { slot: missing_slot, reason: e.to_string() }
+        });
 
         if result.is_err() {
             Metrics::blob_fetch_errors().increment(1);
@@ -164,6 +184,9 @@ impl<B: BeaconClient> OnlineBlobProvider<B> {
         if blob_hashes.is_empty() {
             return Ok(Default::default());
         }
+        if self.beacon_client.is_none() {
+            return Err(BlobProviderError::Backend(Self::NO_BEACON_ERR.to_string()));
+        }
 
         // Calculate the slot for the given timestamp.
         let slot = Self::slot(self.genesis_time, self.slot_interval, block_ref.timestamp)?;
@@ -193,6 +216,9 @@ where
     ) -> Result<Vec<Box<Blob>>, Self::Error> {
         if blob_hashes.is_empty() {
             return Ok(Default::default());
+        }
+        if self.beacon_client.is_none() {
+            return Err(BlobProviderError::Backend(Self::NO_BEACON_ERR.to_string()));
         }
 
         // Calculate the slot for the given timestamp.
@@ -295,13 +321,33 @@ mod tests {
     #[tokio::test]
     async fn test_get_and_validate_blobs_empty() {
         let mut provider = OnlineBlobProvider {
-            beacon_client: MockBeaconClient::default(),
+            beacon_client: Some(MockBeaconClient::default()),
             genesis_time: 0,
             slot_interval: 12,
         };
         let block_ref = BlockInfo::default();
         let result = provider.get_and_validate_blobs(&block_ref, &[]).await.unwrap();
         assert!(result.is_empty(), "empty hashes must return empty blob vec");
+    }
+
+    /// A disabled (no-beacon) provider returns `Ok(vec![])` for empty hashes (the calldata-only
+    /// path) but errors when blobs are actually requested.
+    #[tokio::test]
+    async fn test_disabled_provider() {
+        let mut provider = OnlineBlobProvider::<MockBeaconClient>::disabled();
+        let block_ref = BlockInfo { timestamp: 12, ..Default::default() };
+
+        // Calldata-only derivation never requests blobs: empty hashes must succeed.
+        let empty = provider.get_and_validate_blobs(&block_ref, &[]).await.unwrap();
+        assert!(empty.is_empty(), "empty hashes must return empty blob vec without a beacon");
+
+        // Requesting an actual blob without a beacon must error rather than panic.
+        let hash = versioned_hash_for(&FixedBytes::repeat_byte(1));
+        let result = provider.get_and_validate_blobs(&block_ref, &[hash]).await;
+        assert!(
+            matches!(result, Err(BlobProviderError::Backend(_))),
+            "blob fetch without a beacon must return a Backend error, got {result:?}"
+        );
     }
 
     /// Verifies that `get_and_validate_blobs` preserves the ordering of the input hashes.
@@ -321,7 +367,7 @@ mod tests {
         mock.blobs.insert(hash_b, blob_b);
 
         let mut provider =
-            OnlineBlobProvider { beacon_client: mock, genesis_time: 0, slot_interval: 12 };
+            OnlineBlobProvider { beacon_client: Some(mock), genesis_time: 0, slot_interval: 12 };
         let block_ref = BlockInfo { timestamp: 12, ..Default::default() };
 
         let result = provider.get_and_validate_blobs(&block_ref, &[hash_b, hash_a]).await.unwrap();
@@ -344,7 +390,7 @@ mod tests {
         let mock = MockBeaconClient { fail_with_slot_not_found: true, ..Default::default() };
 
         let mut provider =
-            OnlineBlobProvider { beacon_client: mock, genesis_time: 0, slot_interval: 12 };
+            OnlineBlobProvider { beacon_client: Some(mock), genesis_time: 0, slot_interval: 12 };
         let block_ref = BlockInfo { timestamp: 12, ..Default::default() };
 
         let result = provider.get_and_validate_blobs(&block_ref, &[hash]).await;
@@ -368,7 +414,7 @@ mod tests {
         mock.blobs.insert(hash, blob);
 
         let provider =
-            OnlineBlobProvider { beacon_client: mock, genesis_time: 0, slot_interval: 12 };
+            OnlineBlobProvider { beacon_client: Some(mock), genesis_time: 0, slot_interval: 12 };
         let block_ref = BlockInfo { timestamp: 12, ..Default::default() };
 
         let result: Vec<BlobWithCommitmentAndProof> =

--- a/crates/consensus/providers/src/blobs.rs
+++ b/crates/consensus/providers/src/blobs.rs
@@ -9,7 +9,7 @@ use base_consensus_derive::{BlobProvider, BlobProviderError};
 use base_protocol::BlockInfo;
 use tracing::warn;
 
-use crate::{BeaconClient, Metrics};
+use crate::{BeaconClient, Metrics, OnlineBeaconClient};
 
 /// A boxed blob.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -32,16 +32,15 @@ pub struct BlobWithCommitmentAndProof {
     pub kzg_proof: Bytes48,
 }
 
-/// An online implementation of the [`BlobProvider`] trait.
+/// An online implementation of the [`BlobProvider`] trait, backed by an L1 beacon API client.
 ///
-/// The beacon client is optional: when the L1 parent chain has no beacon (blob) DA
-/// endpoint - e.g. an L2 settlement layer running in calldata-only mode - the provider is
-/// constructed via [`OnlineBlobProvider::disabled`] and any attempt to actually fetch blobs
-/// returns an error. Calldata-only derivation never requests blobs, so it never hits that path.
+/// Used when the L1 parent chain exposes a beacon (blob) DA endpoint - e.g. the main Base chain
+/// running against Ethereum. For a parent chain with no beacon endpoint (e.g. an appchain settling
+/// to Base) use [`NoBlobProvider`] instead. [`L1BlobProvider`] selects between the two at runtime.
 #[derive(Debug, Clone)]
 pub struct OnlineBlobProvider<B: BeaconClient> {
-    /// The Beacon API client, or `None` when no beacon endpoint is configured.
-    pub beacon_client: Option<B>,
+    /// The Beacon API client.
+    pub beacon_client: B,
     /// Beacon Genesis time used for the time to slot conversion.
     pub genesis_time: u64,
     /// Slot interval used for the time to slot conversion.
@@ -70,22 +69,8 @@ impl<B: BeaconClient> OnlineBlobProvider<B> {
             .map(|r| r.data.seconds_per_slot)
             .map_err(|e| BlobProviderError::Backend(e.to_string()))
             .expect("Failed to load slot interval from beacon client");
-        Self { beacon_client: Some(beacon_client), genesis_time, slot_interval }
+        Self { beacon_client, genesis_time, slot_interval }
     }
-
-    /// Creates an [`OnlineBlobProvider`] with no beacon backend.
-    ///
-    /// Used when the L1 parent chain exposes no beacon (blob) DA endpoint. Blob fetches return
-    /// [`BlobProviderError::Backend`]; calldata-only derivation never requests blobs.
-    pub const fn disabled() -> Self {
-        // slot_interval is 0 so that `Self::slot()` returns an error rather than dividing by
-        // zero if ever reached without the `beacon_client.is_none()` guard.
-        Self { beacon_client: None, genesis_time: 0, slot_interval: 0 }
-    }
-
-    /// Error message returned when blobs are requested but no beacon endpoint is configured.
-    const NO_BEACON_ERR: &'static str =
-        "L1 beacon endpoint not configured; cannot fetch blobs (calldata-only mode)";
 
     /// Computes the slot for the given timestamp.
     pub const fn slot(
@@ -108,27 +93,24 @@ impl<B: BeaconClient> OnlineBlobProvider<B> {
         slot: u64,
         blob_hashes: &[B256],
     ) -> Result<Vec<BoxedBlob>, BlobProviderError> {
-        let Some(beacon_client) = self.beacon_client.as_ref() else {
-            return Err(BlobProviderError::Backend(Self::NO_BEACON_ERR.to_string()));
-        };
-
         Metrics::blob_fetches().increment(1);
 
-        let result = beacon_client.filtered_beacon_blobs(slot, blob_hashes).await.map_err(|e| {
-            // The beacon node returned 404 for this slot. The slot was missed or
-            // orphaned; its blobs will never be available. Map to BlobNotFound so
-            // the pipeline issues a reset rather than retrying indefinitely.
-            let Some(missing_slot) = B::slot_not_found(&e) else {
-                return BlobProviderError::Backend(e.to_string());
-            };
-            warn!(
-                target: "blob_provider",
-                slot = missing_slot,
-                "Beacon slot not found (404); slot may be missed or orphaned, \
-                 triggering pipeline reset"
-            );
-            BlobProviderError::BlobNotFound { slot: missing_slot, reason: e.to_string() }
-        });
+        let result =
+            self.beacon_client.filtered_beacon_blobs(slot, blob_hashes).await.map_err(|e| {
+                // The beacon node returned 404 for this slot. The slot was missed or
+                // orphaned; its blobs will never be available. Map to BlobNotFound so
+                // the pipeline issues a reset rather than retrying indefinitely.
+                let Some(missing_slot) = B::slot_not_found(&e) else {
+                    return BlobProviderError::Backend(e.to_string());
+                };
+                warn!(
+                    target: "blob_provider",
+                    slot = missing_slot,
+                    "Beacon slot not found (404); slot may be missed or orphaned, \
+                     triggering pipeline reset"
+                );
+                BlobProviderError::BlobNotFound { slot: missing_slot, reason: e.to_string() }
+            });
 
         if result.is_err() {
             Metrics::blob_fetch_errors().increment(1);
@@ -189,9 +171,6 @@ impl<B: BeaconClient> OnlineBlobProvider<B> {
         if blob_hashes.is_empty() {
             return Ok(Default::default());
         }
-        if self.beacon_client.is_none() {
-            return Err(BlobProviderError::Backend(Self::NO_BEACON_ERR.to_string()));
-        }
 
         // Calculate the slot for the given timestamp.
         let slot = Self::slot(self.genesis_time, self.slot_interval, block_ref.timestamp)?;
@@ -222,9 +201,6 @@ where
         if blob_hashes.is_empty() {
             return Ok(Default::default());
         }
-        if self.beacon_client.is_none() {
-            return Err(BlobProviderError::Backend(Self::NO_BEACON_ERR.to_string()));
-        }
 
         // Calculate the slot for the given timestamp.
         let slot = Self::slot(self.genesis_time, self.slot_interval, block_ref.timestamp)?;
@@ -238,6 +214,110 @@ where
     }
 }
 
+/// A [`BlobProvider`] for parent chains with no beacon (blob) DA endpoint.
+///
+/// Used by calldata-only derivation - e.g. an appchain settling to Base. Calldata-only derivation
+/// never requests blobs, so blob fetches return an empty vector for an empty hash slice; a non-empty
+/// request (which should never occur in calldata-only mode) returns a [`BlobProviderError::Backend`]
+/// error rather than panicking.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct NoBlobProvider;
+
+impl NoBlobProvider {
+    /// Error message returned when blobs are requested but no beacon endpoint is configured.
+    const NO_BEACON_ERR: &'static str =
+        "calldata-only mode: no L1 beacon endpoint configured; cannot fetch blobs";
+
+    /// Mirrors [`OnlineBlobProvider::fetch_blobs_with_proofs`] for the no-beacon case: an empty
+    /// request succeeds, a non-empty request errors.
+    pub fn fetch_blobs_with_proofs(
+        &self,
+        _block_ref: &BlockInfo,
+        blob_hashes: &[B256],
+    ) -> Result<Vec<BlobWithCommitmentAndProof>, BlobProviderError> {
+        if blob_hashes.is_empty() {
+            return Ok(Default::default());
+        }
+        Err(BlobProviderError::Backend(Self::NO_BEACON_ERR.to_string()))
+    }
+}
+
+#[async_trait]
+impl BlobProvider for NoBlobProvider {
+    type Error = BlobProviderError;
+
+    async fn get_and_validate_blobs(
+        &mut self,
+        _block_ref: &BlockInfo,
+        blob_hashes: &[B256],
+    ) -> Result<Vec<Box<Blob>>, Self::Error> {
+        if blob_hashes.is_empty() {
+            return Ok(Default::default());
+        }
+        Err(BlobProviderError::Backend(Self::NO_BEACON_ERR.to_string()))
+    }
+}
+
+/// The L1 blob provider used by the derivation pipeline, selected at runtime by execution mode.
+///
+/// [`L1BlobProvider::Beacon`] backs the main Base chain (parent chain = Ethereum, with a
+/// beacon/blob DA endpoint); [`L1BlobProvider::CalldataOnly`] backs an appchain (parent chain =
+/// Base, no beacon). Selecting between the two is done once, where the providers are built.
+#[derive(Debug, Clone)]
+pub enum L1BlobProvider {
+    /// Beacon-backed blob provider for a parent chain with a beacon (blob) DA endpoint.
+    Beacon(OnlineBlobProvider<OnlineBeaconClient>),
+    /// No-beacon provider for calldata-only derivation.
+    CalldataOnly(NoBlobProvider),
+}
+
+impl L1BlobProvider {
+    /// Creates a beacon-backed provider.
+    pub const fn beacon(provider: OnlineBlobProvider<OnlineBeaconClient>) -> Self {
+        Self::Beacon(provider)
+    }
+
+    /// Creates a calldata-only (no-beacon) provider.
+    pub const fn calldata_only() -> Self {
+        Self::CalldataOnly(NoBlobProvider)
+    }
+
+    /// Fetches and validates blobs, recomputing their KZG commitments and proofs. See
+    /// [`OnlineBlobProvider::fetch_blobs_with_proofs`].
+    pub async fn fetch_blobs_with_proofs(
+        &self,
+        block_ref: &BlockInfo,
+        blob_hashes: &[B256],
+    ) -> Result<Vec<BlobWithCommitmentAndProof>, BlobProviderError> {
+        match self {
+            Self::Beacon(provider) => {
+                provider.fetch_blobs_with_proofs(block_ref, blob_hashes).await
+            }
+            Self::CalldataOnly(provider) => {
+                provider.fetch_blobs_with_proofs(block_ref, blob_hashes)
+            }
+        }
+    }
+}
+
+#[async_trait]
+impl BlobProvider for L1BlobProvider {
+    type Error = BlobProviderError;
+
+    async fn get_and_validate_blobs(
+        &mut self,
+        block_ref: &BlockInfo,
+        blob_hashes: &[B256],
+    ) -> Result<Vec<Box<Blob>>, Self::Error> {
+        match self {
+            Self::Beacon(provider) => provider.get_and_validate_blobs(block_ref, blob_hashes).await,
+            Self::CalldataOnly(provider) => {
+                provider.get_and_validate_blobs(block_ref, blob_hashes).await
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
@@ -248,7 +328,7 @@ mod tests {
     use base_consensus_derive::{BlobProvider, BlobProviderError};
     use base_protocol::BlockInfo;
 
-    use super::{BlobWithCommitmentAndProof, BoxedBlob, OnlineBlobProvider};
+    use super::{BlobWithCommitmentAndProof, BoxedBlob, NoBlobProvider, OnlineBlobProvider};
     use crate::{APIConfigResponse, APIGenesisResponse, BeaconClient};
 
     /// Local error type for [`MockBeaconClient`].
@@ -326,7 +406,7 @@ mod tests {
     #[tokio::test]
     async fn test_get_and_validate_blobs_empty() {
         let mut provider = OnlineBlobProvider {
-            beacon_client: Some(MockBeaconClient::default()),
+            beacon_client: MockBeaconClient::default(),
             genesis_time: 0,
             slot_interval: 12,
         };
@@ -335,11 +415,11 @@ mod tests {
         assert!(result.is_empty(), "empty hashes must return empty blob vec");
     }
 
-    /// A disabled (no-beacon) provider returns `Ok(vec![])` for empty hashes (the calldata-only
-    /// path) but errors when blobs are actually requested.
+    /// A [`NoBlobProvider`] returns `Ok(vec![])` for empty hashes (the calldata-only path) but
+    /// errors when blobs are actually requested.
     #[tokio::test]
-    async fn test_disabled_provider() {
-        let mut provider = OnlineBlobProvider::<MockBeaconClient>::disabled();
+    async fn test_no_blob_provider() {
+        let mut provider = NoBlobProvider;
         let block_ref = BlockInfo { timestamp: 12, ..Default::default() };
 
         // Calldata-only derivation never requests blobs: empty hashes must succeed.
@@ -355,9 +435,8 @@ mod tests {
         );
     }
 
-    /// `slot()` must return an error rather than divide by zero when `slot_time` is 0, the value
-    /// a [`OnlineBlobProvider::disabled`] provider carries. This guards external callers that reach
-    /// `slot()` without the `beacon_client.is_none()` check.
+    /// `slot()` must return an error rather than divide by zero when `slot_time` is 0. This guards
+    /// external callers that reach `slot()` with an unset slot interval.
     #[test]
     fn test_slot_zero_slot_time_errors() {
         let result = OnlineBlobProvider::<MockBeaconClient>::slot(0, 0, 12);
@@ -384,7 +463,7 @@ mod tests {
         mock.blobs.insert(hash_b, blob_b);
 
         let mut provider =
-            OnlineBlobProvider { beacon_client: Some(mock), genesis_time: 0, slot_interval: 12 };
+            OnlineBlobProvider { beacon_client: mock, genesis_time: 0, slot_interval: 12 };
         let block_ref = BlockInfo { timestamp: 12, ..Default::default() };
 
         let result = provider.get_and_validate_blobs(&block_ref, &[hash_b, hash_a]).await.unwrap();
@@ -407,7 +486,7 @@ mod tests {
         let mock = MockBeaconClient { fail_with_slot_not_found: true, ..Default::default() };
 
         let mut provider =
-            OnlineBlobProvider { beacon_client: Some(mock), genesis_time: 0, slot_interval: 12 };
+            OnlineBlobProvider { beacon_client: mock, genesis_time: 0, slot_interval: 12 };
         let block_ref = BlockInfo { timestamp: 12, ..Default::default() };
 
         let result = provider.get_and_validate_blobs(&block_ref, &[hash]).await;
@@ -431,7 +510,7 @@ mod tests {
         mock.blobs.insert(hash, blob);
 
         let provider =
-            OnlineBlobProvider { beacon_client: Some(mock), genesis_time: 0, slot_interval: 12 };
+            OnlineBlobProvider { beacon_client: mock, genesis_time: 0, slot_interval: 12 };
         let block_ref = BlockInfo { timestamp: 12, ..Default::default() };
 
         let result: Vec<BlobWithCommitmentAndProof> =

--- a/crates/consensus/providers/src/blobs.rs
+++ b/crates/consensus/providers/src/blobs.rs
@@ -78,6 +78,8 @@ impl<B: BeaconClient> OnlineBlobProvider<B> {
     /// Used when the L1 parent chain exposes no beacon (blob) DA endpoint. Blob fetches return
     /// [`BlobProviderError::Backend`]; calldata-only derivation never requests blobs.
     pub const fn disabled() -> Self {
+        // slot_interval is 0 so that `Self::slot()` returns an error rather than dividing by
+        // zero if ever reached without the `beacon_client.is_none()` guard.
         Self { beacon_client: None, genesis_time: 0, slot_interval: 0 }
     }
 
@@ -92,6 +94,9 @@ impl<B: BeaconClient> OnlineBlobProvider<B> {
         timestamp: u64,
     ) -> Result<u64, BlobProviderError> {
         if timestamp < genesis {
+            return Err(BlobProviderError::SlotDerivation);
+        }
+        if slot_time == 0 {
             return Err(BlobProviderError::SlotDerivation);
         }
         Ok((timestamp - genesis) / slot_time)
@@ -347,6 +352,18 @@ mod tests {
         assert!(
             matches!(result, Err(BlobProviderError::Backend(_))),
             "blob fetch without a beacon must return a Backend error, got {result:?}"
+        );
+    }
+
+    /// `slot()` must return an error rather than divide by zero when `slot_time` is 0, the value
+    /// a [`OnlineBlobProvider::disabled`] provider carries. This guards external callers that reach
+    /// `slot()` without the `beacon_client.is_none()` check.
+    #[test]
+    fn test_slot_zero_slot_time_errors() {
+        let result = OnlineBlobProvider::<MockBeaconClient>::slot(0, 0, 12);
+        assert!(
+            matches!(result, Err(BlobProviderError::SlotDerivation)),
+            "slot() with slot_time=0 must return SlotDerivation, got {result:?}"
         );
     }
 

--- a/crates/consensus/providers/src/lib.rs
+++ b/crates/consensus/providers/src/lib.rs
@@ -16,7 +16,9 @@ pub use beacon_client::{
 };
 
 mod blobs;
-pub use blobs::{BlobWithCommitmentAndProof, BoxedBlob, OnlineBlobProvider};
+pub use blobs::{
+    BlobWithCommitmentAndProof, BoxedBlob, L1BlobProvider, NoBlobProvider, OnlineBlobProvider,
+};
 
 mod chain_provider;
 pub use chain_provider::{AlloyChainProvider, AlloyChainProviderError};

--- a/crates/consensus/providers/src/pipeline.rs
+++ b/crates/consensus/providers/src/pipeline.rs
@@ -14,8 +14,7 @@ use base_consensus_derive::{
 use base_protocol::{AttributesWithParent, BlockInfo, L2BlockInfo};
 
 use crate::{
-    AlloyChainProvider, AlloyL2ChainProvider, ConfDepthProvider, L1HeadNumber, OnlineBeaconClient,
-    OnlineBlobProvider,
+    AlloyChainProvider, AlloyL2ChainProvider, ConfDepthProvider, L1BlobProvider, L1HeadNumber,
 };
 
 /// An online polled derivation pipeline.
@@ -30,8 +29,7 @@ type OnlinePolledDerivationPipeline = DerivationPipeline<
 >;
 
 /// An RPC-backed Ethereum data source.
-type OnlineDataProvider =
-    EthereumDataSource<ConfDepthProvider, OnlineBlobProvider<OnlineBeaconClient>>;
+type OnlineDataProvider = EthereumDataSource<ConfDepthProvider, L1BlobProvider>;
 
 /// An RPC-backed payload attributes builder for the `AttributesQueue` stage of the derivation
 /// pipeline.
@@ -51,7 +49,7 @@ impl OnlinePipeline {
         cfg: Arc<RollupConfig>,
         l1_cfg: Arc<ChainConfig>,
         l2_safe_head: L2BlockInfo,
-        blob_provider: OnlineBlobProvider<OnlineBeaconClient>,
+        blob_provider: L1BlobProvider,
         chain_provider: AlloyChainProvider,
         l2_chain_provider: AlloyL2ChainProvider,
         l1_head_number: L1HeadNumber,
@@ -85,7 +83,7 @@ impl OnlinePipeline {
     pub fn new_polled(
         cfg: Arc<RollupConfig>,
         l1_cfg: Arc<ChainConfig>,
-        blob_provider: OnlineBlobProvider<OnlineBeaconClient>,
+        blob_provider: L1BlobProvider,
         chain_provider: AlloyChainProvider,
         l2_chain_provider: AlloyL2ChainProvider,
         l1_head_number: L1HeadNumber,

--- a/crates/consensus/service/src/service/builder.rs
+++ b/crates/consensus/service/src/service/builder.rs
@@ -38,8 +38,8 @@ pub struct L1ConfigBuilder {
     pub chain_config: ChainConfig,
     /// Whether to trust the L1 RPC.
     pub trust_rpc: bool,
-    /// The L1 beacon API.
-    pub beacon: Url,
+    /// The L1 beacon API, or `None` when the L1 parent has no beacon (blob) DA endpoint.
+    pub beacon: Option<Url>,
     /// The L1 RPC URL.
     pub rpc_url: Url,
     /// The duration in seconds of an L1 slot. This can be used to hardcode a fixed slot
@@ -164,10 +164,13 @@ impl RollupNodeBuilder {
     /// remains lazy during startup. `file://` URLs still connect eagerly because IPC is an
     /// explicit opt-in transport.
     pub async fn build(self) -> TransportResult<RollupNode> {
-        let mut l1_beacon = OnlineBeaconClient::new_http(self.l1_config_builder.beacon.to_string());
-        if let Some(l1_slot_duration) = self.l1_config_builder.slot_duration_override {
-            l1_beacon = l1_beacon.with_l1_slot_duration_override(l1_slot_duration);
-        }
+        let l1_beacon = self.l1_config_builder.beacon.as_ref().map(|beacon| {
+            let mut client = OnlineBeaconClient::new_http(beacon.to_string());
+            if let Some(l1_slot_duration) = self.l1_config_builder.slot_duration_override {
+                client = client.with_l1_slot_duration_override(l1_slot_duration);
+            }
+            client
+        });
 
         let finalized_poll_interval = self
             .finalized_poll_interval
@@ -236,7 +239,7 @@ mod tests {
         let l1_config_builder = L1ConfigBuilder {
             chain_config: ChainConfig::default(),
             trust_rpc: true,
-            beacon: Url::parse("http://127.0.0.1:5052").unwrap(),
+            beacon: Some(Url::parse("http://127.0.0.1:5052").unwrap()),
             rpc_url: Url::parse("http://127.0.0.1:8545").unwrap(),
             slot_duration_override: None,
             verifier_l1_confs: 0,

--- a/crates/consensus/service/src/service/node.rs
+++ b/crates/consensus/service/src/service/node.rs
@@ -48,8 +48,9 @@ pub struct L1Config {
     pub chain_config: Arc<GenesisChainConfig>,
     /// Whether to trust the L1 RPC.
     pub trust_rpc: bool,
-    /// The L1 beacon client.
-    pub beacon_client: OnlineBeaconClient,
+    /// The L1 beacon client, or `None` when no beacon endpoint is configured (e.g. an L2
+    /// parent chain with no blob DA, running calldata-only).
+    pub beacon_client: Option<OnlineBeaconClient>,
     /// The L1 engine provider.
     pub engine_provider: RootProvider,
     /// How frequently to poll L1 for a new finalized block.
@@ -214,10 +215,15 @@ impl RollupNode {
             self.l2_trust_rpc,
         );
 
+        let blob_provider = match self.l1_config.beacon_client.clone() {
+            Some(beacon_client) => OnlineBlobProvider::init(beacon_client).await,
+            None => OnlineBlobProvider::disabled(),
+        };
+
         OnlinePipeline::new_polled(
             Arc::clone(&self.config),
             Arc::clone(&self.l1_config.chain_config),
-            OnlineBlobProvider::init(self.l1_config.beacon_client.clone()).await,
+            blob_provider,
             l1_derivation_provider,
             l2_derivation_provider,
             l1_head_number,

--- a/crates/consensus/service/src/service/node.rs
+++ b/crates/consensus/service/src/service/node.rs
@@ -15,8 +15,8 @@ use base_common_network::Base;
 use base_consensus_derive::{Pipeline, SignalReceiver, StatefulAttributesBuilder};
 use base_consensus_engine::{Engine, EngineClient, EngineState};
 use base_consensus_providers::{
-    AlloyChainProvider, AlloyL2ChainProvider, OnlineBeaconClient, OnlineBlobProvider,
-    OnlinePipeline,
+    AlloyChainProvider, AlloyL2ChainProvider, L1BlobProvider, OnlineBeaconClient,
+    OnlineBlobProvider, OnlinePipeline,
 };
 use base_consensus_rpc::RpcBuilder;
 use base_consensus_safedb::{DisabledSafeDB, SafeDB, SafeDBReader, SafeHeadListener};
@@ -216,8 +216,10 @@ impl RollupNode {
         );
 
         let blob_provider = match self.l1_config.beacon_client.clone() {
-            Some(beacon_client) => OnlineBlobProvider::init(beacon_client).await,
-            None => OnlineBlobProvider::disabled(),
+            Some(beacon_client) => {
+                L1BlobProvider::beacon(OnlineBlobProvider::init(beacon_client).await)
+            }
+            None => L1BlobProvider::calldata_only(),
         };
 
         OnlinePipeline::new_polled(

--- a/crates/proof/host/src/backend/online.rs
+++ b/crates/proof/host/src/backend/online.rs
@@ -212,7 +212,7 @@ mod tests {
         let l2 = RootProvider::new_http("http://127.0.0.1:1".parse().unwrap());
         let beacon = OnlineBeaconClient::new_http("http://127.0.0.1:1".to_string());
         let blobs =
-            OnlineBlobProvider { beacon_client: beacon, genesis_time: 0, slot_interval: 12 };
+            OnlineBlobProvider { beacon_client: Some(beacon), genesis_time: 0, slot_interval: 12 };
         HostProviders { l1, blobs, l2 }
     }
 
@@ -222,7 +222,7 @@ mod tests {
             prover: ProverConfig {
                 l1_eth_url: "http://127.0.0.1:1".to_string(),
                 l2_eth_url: "http://127.0.0.1:1".to_string(),
-                l1_beacon_url: "http://127.0.0.1:1".to_string(),
+                l1_beacon_url: Some("http://127.0.0.1:1".to_string()),
                 l2_chain_id: 0,
                 rollup_config: RollupConfig::default(),
                 l1_config: ChainConfig::default(),

--- a/crates/proof/host/src/backend/online.rs
+++ b/crates/proof/host/src/backend/online.rs
@@ -188,7 +188,7 @@ mod tests {
     use alloy_genesis::ChainConfig;
     use alloy_provider::RootProvider;
     use base_common_genesis::RollupConfig;
-    use base_consensus_providers::{OnlineBeaconClient, OnlineBlobProvider};
+    use base_consensus_providers::{L1BlobProvider, OnlineBeaconClient, OnlineBlobProvider};
     use base_proof::{Hint, HintType};
     use base_proof_preimage::{
         HintRouter, PreimageFetcher, PreimageKey, errors::PreimageOracleError,
@@ -211,8 +211,11 @@ mod tests {
         let l1 = RootProvider::new_http("http://127.0.0.1:1".parse().unwrap());
         let l2 = RootProvider::new_http("http://127.0.0.1:1".parse().unwrap());
         let beacon = OnlineBeaconClient::new_http("http://127.0.0.1:1".to_string());
-        let blobs =
-            OnlineBlobProvider { beacon_client: Some(beacon), genesis_time: 0, slot_interval: 12 };
+        let blobs = L1BlobProvider::beacon(OnlineBlobProvider {
+            beacon_client: beacon,
+            genesis_time: 0,
+            slot_interval: 12,
+        });
         HostProviders { l1, blobs, l2 }
     }
 

--- a/crates/proof/host/src/config.rs
+++ b/crates/proof/host/src/config.rs
@@ -28,8 +28,8 @@ pub struct ProverConfig {
     pub l1_eth_url: String,
     /// L2 execution layer RPC URL.
     pub l2_eth_url: String,
-    /// L1 beacon API URL.
-    pub l1_beacon_url: String,
+    /// L1 beacon API URL, or `None` when the L1 parent has no beacon/blob DA endpoint.
+    pub l1_beacon_url: Option<String>,
     /// L2 chain ID.
     pub l2_chain_id: u64,
     /// Rollup configuration.

--- a/crates/proof/host/src/config.rs
+++ b/crates/proof/host/src/config.rs
@@ -4,7 +4,7 @@ use alloy_genesis::ChainConfig;
 use alloy_provider::RootProvider;
 use base_common_genesis::RollupConfig;
 use base_common_network::Base;
-use base_consensus_providers::{OnlineBeaconClient, OnlineBlobProvider};
+use base_consensus_providers::L1BlobProvider;
 use base_proof_primitives::ProofRequest;
 use serde::Serialize;
 
@@ -13,8 +13,8 @@ use serde::Serialize;
 pub struct HostProviders {
     /// The L1 EL provider.
     pub l1: RootProvider,
-    /// The L1 beacon node provider.
-    pub blobs: OnlineBlobProvider<OnlineBeaconClient>,
+    /// The L1 blob provider (beacon-backed, or calldata-only when no beacon is configured).
+    pub blobs: L1BlobProvider,
     /// The L2 EL provider.
     pub l2: RootProvider<Base>,
 }

--- a/crates/proof/host/src/handler.rs
+++ b/crates/proof/host/src/handler.rs
@@ -1016,7 +1016,7 @@ mod tests {
             prover: ProverConfig {
                 l1_eth_url: "http://127.0.0.1:1".to_string(),
                 l2_eth_url: "http://127.0.0.1:1".to_string(),
-                l1_beacon_url: "http://127.0.0.1:1".to_string(),
+                l1_beacon_url: Some("http://127.0.0.1:1".to_string()),
                 l2_chain_id: 0,
                 rollup_config: RollupConfig::default(),
                 l1_config: ChainConfig::default(),
@@ -1030,7 +1030,7 @@ mod tests {
         let l1 = RootProvider::new_http("http://127.0.0.1:1".parse().unwrap());
         let beacon = OnlineBeaconClient::new_http("http://127.0.0.1:1".to_string());
         let blobs =
-            OnlineBlobProvider { beacon_client: beacon, genesis_time: 0, slot_interval: 12 };
+            OnlineBlobProvider { beacon_client: Some(beacon), genesis_time: 0, slot_interval: 12 };
         HostProviders { l1, blobs, l2 }
     }
 

--- a/crates/proof/host/src/handler.rs
+++ b/crates/proof/host/src/handler.rs
@@ -987,7 +987,7 @@ mod tests {
     use alloy_provider::{RootProvider, builder as provider_builder, mock::Asserter};
     use base_common_genesis::RollupConfig;
     use base_common_network::Base;
-    use base_consensus_providers::{OnlineBeaconClient, OnlineBlobProvider};
+    use base_consensus_providers::{L1BlobProvider, OnlineBeaconClient, OnlineBlobProvider};
     use base_proof_primitives::ProofRequest;
     use tokio::sync::RwLock;
 
@@ -1029,8 +1029,11 @@ mod tests {
     fn test_providers(l2: RootProvider<Base>) -> HostProviders {
         let l1 = RootProvider::new_http("http://127.0.0.1:1".parse().unwrap());
         let beacon = OnlineBeaconClient::new_http("http://127.0.0.1:1".to_string());
-        let blobs =
-            OnlineBlobProvider { beacon_client: Some(beacon), genesis_time: 0, slot_interval: 12 };
+        let blobs = L1BlobProvider::beacon(OnlineBlobProvider {
+            beacon_client: beacon,
+            genesis_time: 0,
+            slot_interval: 12,
+        });
         HostProviders { l1, blobs, l2 }
     }
 

--- a/crates/proof/host/src/host.rs
+++ b/crates/proof/host/src/host.rs
@@ -191,10 +191,19 @@ impl Host {
     /// Creates the providers required for the host backend.
     pub async fn create_providers(&self) -> Result<HostProviders> {
         let l1_provider = rpc_provider(&self.config.prover.l1_eth_url).await?;
-        let blob_provider = OnlineBlobProvider::init(OnlineBeaconClient::new_http(
-            self.config.prover.l1_beacon_url.clone(),
-        ))
-        .await;
+        let blob_provider = match self
+            .config
+            .prover
+            .l1_beacon_url
+            .as_deref()
+            .map(str::trim)
+            .filter(|url| !url.is_empty())
+        {
+            Some(url) => {
+                OnlineBlobProvider::init(OnlineBeaconClient::new_http(url.to_string())).await
+            }
+            None => OnlineBlobProvider::disabled(),
+        };
         let l2_provider = rpc_provider::<Base>(&self.config.prover.l2_eth_url).await?;
 
         Ok(HostProviders { l1: l1_provider, blobs: blob_provider, l2: l2_provider })

--- a/crates/proof/host/src/host.rs
+++ b/crates/proof/host/src/host.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use alloy_provider::{Network, RootProvider};
 use base_common_evm::BaseEvmFactory;
 use base_common_network::Base;
-use base_consensus_providers::{OnlineBeaconClient, OnlineBlobProvider};
+use base_consensus_providers::{L1BlobProvider, OnlineBeaconClient, OnlineBlobProvider};
 use base_proof::HintType;
 use base_proof_client::{FaultProofProgramError, Prologue};
 use base_proof_preimage::{
@@ -199,10 +199,10 @@ impl Host {
             .map(str::trim)
             .filter(|url| !url.is_empty())
         {
-            Some(url) => {
-                OnlineBlobProvider::init(OnlineBeaconClient::new_http(url.to_string())).await
-            }
-            None => OnlineBlobProvider::disabled(),
+            Some(url) => L1BlobProvider::beacon(
+                OnlineBlobProvider::init(OnlineBeaconClient::new_http(url.to_string())).await,
+            ),
+            None => L1BlobProvider::calldata_only(),
         };
         let l2_provider = rpc_provider::<Base>(&self.config.prover.l2_eth_url).await?;
 

--- a/crates/proof/succinct/utils/host/src/fetcher.rs
+++ b/crates/proof/succinct/utils/host/src/fetcher.rs
@@ -783,8 +783,7 @@ impl OPSuccinctDataFetcher {
             .rpc_config
             .l1_beacon_rpc
             .as_ref()
-            .map(|addr| addr.as_str().trim_end_matches('/').to_string())
-            .unwrap_or_default();
+            .map(|addr| addr.as_str().trim_end_matches('/').to_string());
 
         // Load L1 config from file or registry.
         let l1_config = if let Some(ref l1_config_path) = self.l1_config_path {

--- a/crates/proof/succinct/utils/host/src/fetcher.rs
+++ b/crates/proof/succinct/utils/host/src/fetcher.rs
@@ -94,18 +94,18 @@ pub enum RPCMode {
 ///
 /// `L1_RPC`: The L1 RPC URL.
 /// `L1_BEACON_RPC`: The L1 beacon RPC URL.
+/// `L1_CALLDATA_ONLY`: Whether to run without an L1 beacon RPC URL.
 /// `L2_RPC`: The L2 RPC URL.
 /// `L2_NODE_RPC`: The L2 node RPC URL.
 pub fn get_rpcs_from_env() -> RPCConfig {
     let l1_rpc = env::var("L1_RPC").expect("L1_RPC must be set");
     let maybe_l1_beacon_rpc = env::var("L1_BEACON_RPC").ok();
-
-    // L1_BEACON_RPC is optional. If not set or empty, set to None.
-    let l1_beacon_rpc = maybe_l1_beacon_rpc
+    let l1_calldata_only = env::var("L1_CALLDATA_ONLY")
+        .ok()
         .as_deref()
         .map(str::trim)
-        .filter(|s| !s.is_empty())
-        .map(|s| Url::parse(s).expect("L1_BEACON_RPC must be a valid URL"));
+        .is_some_and(|value| value.eq_ignore_ascii_case("true"));
+    let l1_beacon_rpc = l1_beacon_rpc_from_env(maybe_l1_beacon_rpc.as_deref(), l1_calldata_only);
 
     let l2_rpc = env::var("L2_RPC").expect("L2_RPC must be set");
     let l2_node_rpc = env::var("L2_NODE_RPC").expect("L2_NODE_RPC must be set");
@@ -115,6 +115,24 @@ pub fn get_rpcs_from_env() -> RPCConfig {
         l1_beacon_rpc,
         l2_rpc: Url::parse(&l2_rpc).expect("L2_RPC must be a valid URL"),
         l2_node_rpc: Url::parse(&l2_node_rpc).expect("L2_NODE_RPC must be a valid URL"),
+    }
+}
+
+fn l1_beacon_rpc_from_env(
+    maybe_l1_beacon_rpc: Option<&str>,
+    l1_calldata_only: bool,
+) -> Option<Url> {
+    let l1_beacon_rpc = maybe_l1_beacon_rpc.map(str::trim).filter(|url| !url.is_empty());
+
+    match (l1_beacon_rpc, l1_calldata_only) {
+        (Some(url), false) => Some(Url::parse(url).expect("L1_BEACON_RPC must be a valid URL")),
+        (None, true) => None,
+        (None, false) => {
+            panic!("provide L1_BEACON_RPC for blob-backed proving or set L1_CALLDATA_ONLY=true")
+        }
+        (Some(_), true) => {
+            panic!("L1_BEACON_RPC and L1_CALLDATA_ONLY=true are mutually exclusive")
+        }
     }
 }
 
@@ -824,5 +842,42 @@ impl OPSuccinctDataFetcher {
         };
 
         Ok(HostConfig { request, prover, data_dir: None })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::l1_beacon_rpc_from_env;
+
+    #[test]
+    fn beacon_mode_is_valid() {
+        let l1_beacon_rpc = l1_beacon_rpc_from_env(Some("http://localhost:5052"), false);
+
+        assert_eq!(l1_beacon_rpc.unwrap().as_str(), "http://localhost:5052/");
+    }
+
+    #[test]
+    fn calldata_only_mode_is_valid() {
+        let l1_beacon_rpc = l1_beacon_rpc_from_env(None, true);
+
+        assert_eq!(l1_beacon_rpc, None);
+    }
+
+    #[test]
+    #[should_panic(expected = "provide L1_BEACON_RPC")]
+    fn neither_mode_panics() {
+        let _ = l1_beacon_rpc_from_env(None, false);
+    }
+
+    #[test]
+    #[should_panic(expected = "mutually exclusive")]
+    fn both_modes_panic() {
+        let _ = l1_beacon_rpc_from_env(Some("http://localhost:5052"), true);
+    }
+
+    #[test]
+    #[should_panic(expected = "provide L1_BEACON_RPC")]
+    fn empty_beacon_url_is_treated_as_missing() {
+        let _ = l1_beacon_rpc_from_env(Some("  "), false);
     }
 }

--- a/crates/proof/zk/service/src/backends/traits.rs
+++ b/crates/proof/zk/service/src/backends/traits.rs
@@ -174,8 +174,8 @@ pub enum BackendConfig {
         base_consensus_url: String,
         /// L1 execution node RPC URL.
         l1_node_url: String,
-        /// L1 beacon node URL.
-        l1_beacon_url: String,
+        /// L1 beacon node URL, or `None` when the L1 parent has no beacon/blob DA endpoint.
+        l1_beacon_url: Option<String>,
         /// L2 execution node RPC URL.
         l2_node_url: String,
         /// Default sequence window for L1 head calculations.
@@ -199,8 +199,8 @@ pub enum BackendConfig {
         base_consensus_url: String,
         /// L1 execution node RPC URL.
         l1_node_url: String,
-        /// L1 beacon node URL.
-        l1_beacon_url: String,
+        /// L1 beacon node URL, or `None` when the L1 parent has no beacon/blob DA endpoint.
+        l1_beacon_url: Option<String>,
         /// L2 execution node RPC URL.
         l2_node_url: String,
         /// Default sequence window for L1 head calculations.

--- a/crates/proof/zk/service/src/proxy/config.rs
+++ b/crates/proof/zk/service/src/proxy/config.rs
@@ -83,10 +83,8 @@ impl ProxyConfigs {
         Self {
             l1: ProxyConfig::new(l1_port, l1_backend, &rate_limit),
             l2: ProxyConfig::new(l2_port, l2_backend, &rate_limit),
-            beacon: match beacon_backend {
-                Some(backend) => Some(ProxyConfig::new(beacon_port, backend, &rate_limit)),
-                None => None,
-            },
+            beacon: beacon_backend
+                .map(|backend| ProxyConfig::new(beacon_port, backend, &rate_limit)),
         }
     }
 

--- a/crates/proof/zk/service/src/proxy/config.rs
+++ b/crates/proof/zk/service/src/proxy/config.rs
@@ -66,24 +66,27 @@ pub struct ProxyConfigs {
     /// Proxy config for L2 RPC traffic.
     pub l2: ProxyConfig,
     /// Proxy config for beacon API traffic.
-    pub beacon: ProxyConfig,
+    pub beacon: Option<ProxyConfig>,
 }
 
 impl ProxyConfigs {
-    /// Creates a bundled proxy config for L1, L2, and beacon endpoints.
-    pub const fn new(
+    /// Creates a bundled proxy config for L1, L2, and optional beacon endpoints.
+    pub fn new(
         l1_port: u16,
         l1_backend: String,
         l2_port: u16,
         l2_backend: String,
         beacon_port: u16,
-        beacon_backend: String,
+        beacon_backend: Option<String>,
         rate_limit: RateLimitConfig,
     ) -> Self {
         Self {
             l1: ProxyConfig::new(l1_port, l1_backend, &rate_limit),
             l2: ProxyConfig::new(l2_port, l2_backend, &rate_limit),
-            beacon: ProxyConfig::new(beacon_port, beacon_backend, &rate_limit),
+            beacon: match beacon_backend {
+                Some(backend) => Some(ProxyConfig::new(beacon_port, backend, &rate_limit)),
+                None => None,
+            },
         }
     }
 
@@ -91,7 +94,9 @@ impl ProxyConfigs {
     pub fn validate(&self) -> anyhow::Result<()> {
         self.l1.validate()?;
         self.l2.validate()?;
-        self.beacon.validate()?;
+        if let Some(beacon) = &self.beacon {
+            beacon.validate()?;
+        }
         Ok(())
     }
 }

--- a/crates/proof/zk/service/src/proxy/mod.rs
+++ b/crates/proof/zk/service/src/proxy/mod.rs
@@ -1,4 +1,4 @@
-//! Rate-limited reverse-proxy servers for L1, L2, and Beacon RPC endpoints.
+//! Rate-limited reverse-proxy servers for L1, L2, and optional Beacon RPC endpoints.
 
 mod config;
 pub use config::{ProxyConfig, ProxyConfigs, RateLimitConfig};
@@ -11,7 +11,7 @@ use server::start_proxy;
 use tokio::task::JoinHandle;
 use tracing::{error, info};
 
-/// Start all proxy servers (L1, L2, Beacon) as background tasks.
+/// Start all configured proxy servers as background tasks.
 /// Returns handles to the spawned tasks.
 pub async fn start_all_proxies(configs: ProxyConfigs) -> anyhow::Result<Vec<JoinHandle<()>>> {
     configs.validate()?;
@@ -27,11 +27,15 @@ pub async fn start_all_proxies(configs: ProxyConfigs) -> anyhow::Result<Vec<Join
         l2_backend = %configs.l2.backend_url,
         "L2 proxy"
     );
-    info!(
-        beacon_local = %configs.beacon.local_address(),
-        beacon_backend = %configs.beacon.backend_url,
-        "Beacon proxy"
-    );
+    if let Some(beacon) = &configs.beacon {
+        info!(
+            beacon_local = %beacon.local_address(),
+            beacon_backend = %beacon.backend_url,
+            "Beacon proxy"
+        );
+    } else {
+        info!("Beacon proxy disabled");
+    }
     info!(
         requests_per_second = configs.l1.requests_per_second,
         max_concurrent_requests = configs.l1.max_concurrent_requests,
@@ -59,14 +63,14 @@ pub async fn start_all_proxies(configs: ProxyConfigs) -> anyhow::Result<Vec<Join
     });
     handles.push(l2_handle);
 
-    // Spawn Beacon proxy
-    let beacon_config = configs.beacon;
-    let beacon_handle = tokio::spawn(async move {
-        if let Err(err) = start_proxy(beacon_config).await {
-            error!(error = %err, "Beacon proxy server failed");
-        }
-    });
-    handles.push(beacon_handle);
+    if let Some(beacon_config) = configs.beacon {
+        let beacon_handle = tokio::spawn(async move {
+            if let Err(err) = start_proxy(beacon_config).await {
+                error!(error = %err, "Beacon proxy server failed");
+            }
+        });
+        handles.push(beacon_handle);
+    }
 
     // Give servers a moment to bind
     tokio::time::sleep(std::time::Duration::from_millis(100)).await;
@@ -78,7 +82,7 @@ pub async fn start_all_proxies(configs: ProxyConfigs) -> anyhow::Result<Vec<Join
 
 #[cfg(test)]
 mod tests {
-    use super::config::{ProxyConfig, RateLimitConfig};
+    use super::config::{ProxyConfig, ProxyConfigs, RateLimitConfig};
 
     fn default_rate_limit() -> RateLimitConfig {
         RateLimitConfig {
@@ -130,5 +134,21 @@ mod tests {
         let rl = default_rate_limit();
         let config = ProxyConfig::new(18546, "http://example.com".to_string(), &rl);
         assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn test_proxy_configs_without_beacon() {
+        let rl = default_rate_limit();
+        let configs = ProxyConfigs::new(
+            18545,
+            "http://l1.example.com".to_string(),
+            18546,
+            "http://l2.example.com".to_string(),
+            18547,
+            None,
+            rl,
+        );
+        assert!(configs.validate().is_ok());
+        assert!(configs.beacon.is_none());
     }
 }

--- a/devnet/src/l2/in_process_consensus.rs
+++ b/devnet/src/l2/in_process_consensus.rs
@@ -141,7 +141,7 @@ impl InProcessConsensus {
         let l1_config = L1ConfigBuilder {
             chain_config: l1_chain_config,
             trust_rpc: true,
-            beacon: config.l1_beacon_url,
+            beacon: Some(config.l1_beacon_url),
             rpc_url: config.l1_rpc_url.clone(),
             slot_duration_override: config.l1_slot_duration_override,
             verifier_l1_confs: config.verifier_l1_confs,


### PR DESCRIPTION
Makes beacon API configuration optional so calldata-only / beaconless devnet modes can run without an L1 beacon endpoint. The base-anvil L3 devnet wiring is split into the stacked follow-up PR #3219.

Targeting `privacy` for now, since this may be temporary and replaced with alt-DA