### PR TITLE
test(consensus): Sync Status Regression Coverage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3191,6 +3191,7 @@ dependencies = [
  "base-runtime",
  "base-test-utils",
  "base-tx-manager",
+ "futures",
  "reth-basic-payload-builder",
  "reth-db",
  "reth-db-common",

--- a/actions/harness/Cargo.toml
+++ b/actions/harness/Cargo.toml
@@ -88,6 +88,9 @@ base-blobs.workspace = true
 base-common-precompiles.workspace = true
 base-precompile-storage.workspace = true
 
+# async
+futures.workspace = true
+
 # tokio
 tokio = { workspace = true, features = ["rt", "macros"] }
 

--- a/actions/harness/tests/sync_status.rs
+++ b/actions/harness/tests/sync_status.rs
@@ -72,7 +72,7 @@ async fn sync_status_current_l1_should_track_verifier_depth_origin_not_l1_head()
 
     assert_eq!(l1_head_number.load(Ordering::Relaxed), L1_HEAD);
     assert_eq!(
-        derivation_client.heads.lock().unwrap().last().cloned(),
+        derivation_client.heads.lock().unwrap().last().copied(),
         Some(expected_derivation_origin)
     );
 

--- a/actions/harness/tests/sync_status.rs
+++ b/actions/harness/tests/sync_status.rs
@@ -1,0 +1,95 @@
+//! Action tests for consensus sync-status L1 reporting.
+
+use std::{
+    pin::Pin,
+    sync::{
+        Arc, Mutex,
+        atomic::{AtomicU64, Ordering},
+    },
+};
+
+use async_trait::async_trait;
+use base_action_harness::{ActionL1BlockFetcher, ActionTestHarness, SharedL1Chain};
+use base_consensus_node::{
+    DerivationClientResult, L1WatcherActor, L1WatcherDerivationClient, L1WatcherQueryExecutor,
+    NodeActor,
+};
+use base_consensus_rpc::L1WatcherQueries;
+use base_protocol::BlockInfo;
+use futures::Stream;
+use tokio::sync::{oneshot, watch};
+use tokio_util::sync::CancellationToken;
+
+type BoxedBlockStream = Pin<Box<dyn Stream<Item = BlockInfo> + Unpin + Send>>;
+
+#[derive(Debug, Clone, Default)]
+struct RecordingDerivationClient {
+    heads: Arc<Mutex<Vec<BlockInfo>>>,
+}
+
+#[async_trait]
+impl L1WatcherDerivationClient for RecordingDerivationClient {
+    async fn send_finalized_l1_block(&self, _: BlockInfo) -> DerivationClientResult<()> {
+        Ok(())
+    }
+
+    async fn send_new_l1_head(&self, block: BlockInfo) -> DerivationClientResult<()> {
+        self.heads.lock().unwrap().push(block);
+        Ok(())
+    }
+}
+
+#[tokio::test]
+async fn sync_status_current_l1_should_track_verifier_depth_origin_not_l1_head() {
+    const L1_HEAD: u64 = 100;
+    const VERIFIER_L1_CONFS: u64 = 4;
+
+    let mut harness = ActionTestHarness::default();
+    harness.mine_l1_blocks(L1_HEAD);
+
+    let l1_chain = SharedL1Chain::from_blocks(harness.l1.chain().to_vec());
+    let live_head = harness.l1.tip_info();
+    let expected_derivation_origin = harness.l1.block_info_at(L1_HEAD - VERIFIER_L1_CONFS);
+
+    let derivation_client = RecordingDerivationClient::default();
+    let l1_head_number = Arc::new(AtomicU64::new(0));
+    let (l1_head_tx, l1_head_rx) = watch::channel(None);
+    let head_stream: BoxedBlockStream = Box::pin(futures::stream::iter(vec![live_head]));
+    let finalized_stream: BoxedBlockStream = Box::pin(futures::stream::pending());
+    let actor = L1WatcherActor::new(
+        Arc::new(harness.rollup_config.clone()),
+        ActionL1BlockFetcher::new(l1_chain.clone()),
+        l1_head_tx,
+        derivation_client.clone(),
+        None,
+        CancellationToken::new(),
+        head_stream,
+        finalized_stream,
+        VERIFIER_L1_CONFS,
+        Arc::clone(&l1_head_number),
+    );
+    let _ = actor.start(()).await;
+
+    assert_eq!(l1_head_number.load(Ordering::Relaxed), L1_HEAD);
+    assert_eq!(
+        derivation_client.heads.lock().unwrap().last().cloned(),
+        Some(expected_derivation_origin)
+    );
+
+    let executor = L1WatcherQueryExecutor::new(
+        Arc::new(harness.rollup_config.clone()),
+        Arc::new(ActionL1BlockFetcher::new(l1_chain)),
+        l1_head_rx,
+    );
+    let (sender, receiver) = oneshot::channel();
+
+    executor.execute(L1WatcherQueries::L1State(sender)).await;
+
+    let state = receiver.await.expect("state query should return a response");
+    assert_eq!(state.current_l1, Some(expected_derivation_origin));
+    assert_eq!(state.head_l1, Some(live_head));
+    assert_ne!(
+        state.current_l1, state.head_l1,
+        "verifier_l1_confs should make current_l1 report derivation origin, not live L1 head"
+    );
+}

--- a/crates/consensus/service/tests/actors/verifier_conf_depth.rs
+++ b/crates/consensus/service/tests/actors/verifier_conf_depth.rs
@@ -51,9 +51,9 @@ impl MockL1Fetcher {
 
     fn block_info_for_id(&self, id: BlockId) -> Option<BlockInfo> {
         match id {
-            BlockId::Number(BlockNumberOrTag::Number(number)) => self.blocks.get(&number).cloned(),
+            BlockId::Number(BlockNumberOrTag::Number(number)) => self.blocks.get(&number).copied(),
             BlockId::Number(BlockNumberOrTag::Latest) => {
-                self.blocks.values().max_by_key(|block| block.number).cloned()
+                self.blocks.values().max_by_key(|block| block.number).copied()
             }
             _ => None,
         }
@@ -291,7 +291,7 @@ async fn sync_status_should_report_derivation_origin_not_live_head_with_verifier
 
     assert_eq!(l1_head_number.load(Ordering::Relaxed), 100);
     let heads = derivation_client.heads.lock().unwrap().clone();
-    let derivation_origin = heads.last().cloned().expect("derivation should receive a head");
+    let derivation_origin = heads.last().copied().expect("derivation should receive a head");
     assert_eq!(derivation_origin.number, 96);
 
     let executor = L1WatcherQueryExecutor::new(

--- a/crates/consensus/service/tests/actors/verifier_conf_depth.rs
+++ b/crates/consensus/service/tests/actors/verifier_conf_depth.rs
@@ -15,19 +15,22 @@ use std::{
     },
 };
 
+use alloy_consensus::Header;
 use alloy_eips::{BlockId, BlockNumberOrTag};
-use alloy_primitives::B256;
-use alloy_rpc_types_eth::{Block, Filter, Log};
+use alloy_primitives::{B256, Bloom, U256};
+use alloy_rpc_types_eth::{Block, Filter, Header as RpcHeader, Log};
 use async_trait::async_trait;
 use base_common_genesis::RollupConfig;
 use base_consensus_derive::{ChainProvider, PipelineErrorKind};
 use base_consensus_node::{
-    DerivationClientResult, L1BlockFetcher, L1WatcherActor, L1WatcherDerivationClient, NodeActor,
+    DerivationClientResult, L1BlockFetcher, L1WatcherActor, L1WatcherDerivationClient,
+    L1WatcherQueryExecutor, NodeActor,
 };
 use base_consensus_providers::{AlloyChainProviderError, ConfDepthProvider, L1HeadNumber};
+use base_consensus_rpc::L1WatcherQueries;
 use base_protocol::BlockInfo;
 use futures::Stream;
-use tokio::sync::watch;
+use tokio::sync::{oneshot, watch};
 use tokio_util::sync::CancellationToken;
 
 // ---------------------------------------------------------------------------
@@ -45,6 +48,27 @@ impl MockL1Fetcher {
     fn with_blocks(blocks: impl IntoIterator<Item = BlockInfo>) -> Self {
         Self { blocks: blocks.into_iter().map(|b| (b.number, b)).collect() }
     }
+
+    fn block_info_for_id(&self, id: BlockId) -> Option<BlockInfo> {
+        match id {
+            BlockId::Number(BlockNumberOrTag::Number(number)) => self.blocks.get(&number).cloned(),
+            BlockId::Number(BlockNumberOrTag::Latest) => {
+                self.blocks.values().max_by_key(|block| block.number).cloned()
+            }
+            _ => None,
+        }
+    }
+
+    fn block(block_info: BlockInfo) -> Block {
+        Block::empty(RpcHeader::new(Header {
+            parent_hash: block_info.parent_hash,
+            number: block_info.number,
+            timestamp: block_info.timestamp,
+            logs_bloom: Bloom::ZERO,
+            difficulty: U256::ZERO,
+            ..Default::default()
+        }))
+    }
 }
 
 #[async_trait]
@@ -56,16 +80,7 @@ impl L1BlockFetcher for MockL1Fetcher {
     }
 
     async fn get_block(&self, id: BlockId) -> Result<Option<Block>, Self::Error> {
-        match id {
-            BlockId::Number(BlockNumberOrTag::Number(number)) => {
-                if self.blocks.contains_key(&number) {
-                    Ok(Some(Block::default()))
-                } else {
-                    Ok(None)
-                }
-            }
-            _ => Ok(None),
-        }
+        Ok(self.block_info_for_id(id).map(Self::block))
     }
 }
 
@@ -240,6 +255,60 @@ async fn l1_head_atomic_holds_real_head_not_delayed() {
     // Meanwhile, derivation should have received delayed heads.
     let heads = derivation_client.heads.lock().unwrap().clone();
     assert_eq!(heads.len(), 3, "all three heads should have been forwarded to derivation");
-    // Each head is fetched as Block::default() which maps to block number 0.
-    // The important thing is that derivation received delayed blocks, not the real heads.
+    assert_eq!(
+        heads.iter().map(|head| head.number).collect::<Vec<_>>(),
+        vec![10, 20, 40],
+        "derivation should receive heads delayed by verifier_l1_confs"
+    );
+}
+
+#[tokio::test]
+async fn sync_status_should_report_derivation_origin_not_live_head_with_verifier_confs() {
+    let conf_depth: u64 = 4;
+    let l1_head_number: L1HeadNumber = Arc::new(AtomicU64::new(0));
+    let blocks: Vec<BlockInfo> = (90..=100).map(block_at).collect();
+    let fetcher = MockL1Fetcher::with_blocks(blocks.clone());
+
+    let derivation_client = RecordingDerivationClient::default();
+    let (l1_head_tx, l1_head_rx) = watch::channel(None);
+    let cancel = CancellationToken::new();
+    let head_stream: BoxedBlockStream = Box::pin(futures::stream::iter(vec![block_at(100)]));
+    let finalized_stream: BoxedBlockStream = Box::pin(futures::stream::pending());
+
+    let actor = L1WatcherActor::new(
+        Arc::new(RollupConfig::default()),
+        fetcher,
+        l1_head_tx,
+        derivation_client.clone(),
+        None,
+        cancel,
+        head_stream,
+        finalized_stream,
+        conf_depth,
+        Arc::clone(&l1_head_number),
+    );
+    let _ = actor.start(()).await;
+
+    assert_eq!(l1_head_number.load(Ordering::Relaxed), 100);
+    let heads = derivation_client.heads.lock().unwrap().clone();
+    let derivation_origin = heads.last().cloned().expect("derivation should receive a head");
+    assert_eq!(derivation_origin.number, 96);
+
+    let executor = L1WatcherQueryExecutor::new(
+        Arc::new(RollupConfig::default()),
+        Arc::new(MockL1Fetcher::with_blocks(blocks)),
+        l1_head_rx,
+    );
+    let (sender, receiver) = oneshot::channel();
+
+    executor.execute(L1WatcherQueries::L1State(sender)).await;
+
+    let state = receiver.await.expect("state query should return a response");
+    assert_eq!(state.current_l1.map(|block| block.number), Some(96));
+    assert_eq!(state.head_l1.map(|block| block.number), Some(100));
+    assert_ne!(
+        state.current_l1.map(|block| block.number),
+        state.head_l1.map(|block| block.number),
+        "verifier_l1_confs should make sync status expose derivation origin separately from live head"
+    );
 }


### PR DESCRIPTION
## Summary

This PR intentionally adds regression tests on top of main without the implementation fix. The tests demonstrate that with verifier L1 confirmations configured, optimism_syncStatus still reports current_l1 from the live L1 head instead of the derivation origin. This is expected to fail on main and is meant to document the behavior that the fix PR changes.