### PR TITLE
feat(zk-benchmarks): scaffold benchmark crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6375,6 +6375,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cbbc9d0964165b47557570cce6c952866c2678457aca742aafc9fb771d30270"
 
 [[package]]
+name = "base-zk-benchmarks"
+version = "0.0.0"
+
+[[package]]
 name = "base-zk-client"
 version = "0.0.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -225,6 +225,7 @@ base-load-tests = { path = "crates/infra/load-tests" }
 ingress-rpc-lib = { path = "crates/infra/ingress-rpc" }
 base-snapshotter = { path = "crates/infra/snapshotter" }
 websocket-proxy = { path = "crates/infra/websocket-proxy" }
+base-zk-benchmarks = { path = "crates/infra/zk-benchmarks" }
 
 # Proof
 base-proof-rpc = { path = "crates/proof/rpc" }

--- a/crates/infra/zk-benchmarks/Cargo.toml
+++ b/crates/infra/zk-benchmarks/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "base-zk-benchmarks"
+description = "ZK proving benchmark scenarios for Base devnets"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true

--- a/crates/infra/zk-benchmarks/README.md
+++ b/crates/infra/zk-benchmarks/README.md
@@ -1,0 +1,6 @@
+# Base ZK Benchmarks
+
+Reusable ZK proving benchmark scenarios for Base devnets.
+
+Scenarios describe the workload to run. Runtime profiles provide endpoint defaults, and proof
+configuration selects how the resulting block range is proven.

--- a/crates/infra/zk-benchmarks/src/lib.rs
+++ b/crates/infra/zk-benchmarks/src/lib.rs
@@ -1,0 +1,2 @@
+#![doc = include_str!("../README.md")]
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]


### PR DESCRIPTION
## Summary
- add the empty base-zk-benchmarks crate scaffold
- include the crate README and minimal lib.rs
- register the scaffold in Cargo.lock without exposing benchmark logic yet

## Testing
- cargo check -p base-zk-benchmarks

Stack bottom for the ZK benchmarks work.