### PR TITLE
chore(prover-service-client): add retrying proof requester

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6003,6 +6003,7 @@ name = "base-prover-service-client"
 version = "0.0.0"
 dependencies = [
  "async-trait",
+ "backon",
  "base-prover-service-protocol",
  "chrono",
  "jsonrpsee",

--- a/crates/proof/prover-service/client/Cargo.toml
+++ b/crates/proof/prover-service/client/Cargo.toml
@@ -16,6 +16,7 @@ base-prover-service-protocol = { workspace = true, features = ["rpc-client"] }
 jsonrpsee = { workspace = true, features = ["http-client"] }
 
 # Async
+backon.workspace = true
 async-trait.workspace = true
 
 # URL parsing

--- a/crates/proof/prover-service/client/src/config.rs
+++ b/crates/proof/prover-service/client/src/config.rs
@@ -10,6 +10,8 @@ use thiserror::Error;
 use tracing::debug;
 use url::Url;
 
+use crate::ProofRequesterRetryConfig;
+
 /// Errors that can occur during prover-service client configuration validation.
 #[derive(Clone, Debug, Error, Eq, PartialEq)]
 pub enum ProverServiceClientConfigError {
@@ -54,6 +56,7 @@ pub struct ProverServiceClientConfig {
     request_timeout: Duration,
     poll_interval: Duration,
     max_wait: Duration,
+    retry: ProofRequesterRetryConfig,
 }
 
 impl ProverServiceClientConfig {
@@ -73,6 +76,7 @@ impl ProverServiceClientConfig {
             request_timeout: Self::DEFAULT_REQUEST_TIMEOUT,
             poll_interval: Self::DEFAULT_POLL_INTERVAL,
             max_wait: Self::DEFAULT_MAX_WAIT,
+            retry: ProofRequesterRetryConfig::default(),
         }
     }
 
@@ -96,6 +100,14 @@ impl ProverServiceClientConfig {
         self.max_wait
     }
 
+    /// Return the retry configuration applied by [`ProofRequesterClient`] when calling
+    /// requester JSON-RPC methods.
+    ///
+    /// [`ProofRequesterClient`]: crate::ProofRequesterClient
+    pub const fn retry_config(&self) -> ProofRequesterRetryConfig {
+        self.retry
+    }
+
     /// Set the per-request timeout used by the JSON-RPC HTTP client.
     pub const fn with_request_timeout(mut self, request_timeout: Duration) -> Self {
         self.request_timeout = request_timeout;
@@ -111,6 +123,15 @@ impl ProverServiceClientConfig {
     /// Set the maximum time to wait for proof completion.
     pub const fn with_max_wait(mut self, max_wait: Duration) -> Self {
         self.max_wait = max_wait;
+        self
+    }
+
+    /// Set the retry configuration applied by [`ProofRequesterClient`] when calling
+    /// requester JSON-RPC methods.
+    ///
+    /// [`ProofRequesterClient`]: crate::ProofRequesterClient
+    pub const fn with_retry_config(mut self, retry: ProofRequesterRetryConfig) -> Self {
+        self.retry = retry;
         self
     }
 

--- a/crates/proof/prover-service/client/src/config.rs
+++ b/crates/proof/prover-service/client/src/config.rs
@@ -36,6 +36,9 @@ pub enum ProverServiceClientConfigError {
     /// The configured poll interval is greater than the maximum wait duration.
     #[error("poll interval must be less than or equal to max wait")]
     PollIntervalExceedsMaxWait,
+    /// The configured retry initial delay is greater than the retry max delay.
+    #[error("retry initial delay must be less than or equal to retry max delay")]
+    RetryInitialDelayExceedsMaxDelay,
 }
 
 /// Errors that can occur when building a prover-service client.
@@ -164,6 +167,17 @@ impl ProverServiceClientConfig {
             return Err(ProverServiceClientConfigError::PollIntervalExceedsMaxWait);
         }
 
+        // Validate retry sub-config. `max_attempts == 0` is intentionally accepted and
+        // documented as equivalent to one attempt by `ProofRequesterRetryConfig`, matching
+        // the workspace's `base_proof_rpc::config::RetryConfig` convention; the broader
+        // API hardening (private fields + construction-time validation) is tracked as
+        // S2 in the consolidation plan. We do reject `initial_delay > max_delay` here so
+        // misconfiguration surfaces as a config error rather than a silent clamp inside
+        // the backoff builder.
+        if self.retry.initial_delay > self.retry.max_delay {
+            return Err(ProverServiceClientConfigError::RetryInitialDelayExceedsMaxDelay);
+        }
+
         Ok(())
     }
 
@@ -254,5 +268,27 @@ mod tests {
         let err = config.validate().expect_err("invalid config should fail validation");
 
         assert!(err.to_string().contains(expected_message));
+    }
+
+    #[test]
+    fn config_validation_rejects_retry_initial_delay_greater_than_max_delay() {
+        let config = ProverServiceClientConfig::new("http://localhost:8545").with_retry_config(
+            ProofRequesterRetryConfig::new(3, Duration::from_secs(60), Duration::from_millis(50)),
+        );
+
+        let err = config.validate().expect_err("invalid retry config should fail validation");
+
+        assert_eq!(err, ProverServiceClientConfigError::RetryInitialDelayExceedsMaxDelay);
+    }
+
+    #[test]
+    fn config_validation_accepts_zero_retry_max_attempts() {
+        // `max_attempts == 0` is documented as equivalent to one attempt by
+        // `ProofRequesterRetryConfig`; validation must not reject it.
+        let config = ProverServiceClientConfig::new("http://localhost:8545").with_retry_config(
+            ProofRequesterRetryConfig::new(0, Duration::from_millis(10), Duration::from_millis(20)),
+        );
+
+        config.validate().expect("zero max_attempts retry config should pass validation");
     }
 }

--- a/crates/proof/prover-service/client/src/lib.rs
+++ b/crates/proof/prover-service/client/src/lib.rs
@@ -15,7 +15,6 @@ mod retry;
 pub use retry::{
     DEFAULT_PROOF_REQUESTER_INITIAL_DELAY, DEFAULT_PROOF_REQUESTER_MAX_ATTEMPTS,
     DEFAULT_PROOF_REQUESTER_MAX_DELAY, MIN_PROOF_REQUESTER_RETRY_DELAY, ProofRequesterRetryConfig,
-    RetryingProofRequester,
 };
 
 mod worker;

--- a/crates/proof/prover-service/client/src/lib.rs
+++ b/crates/proof/prover-service/client/src/lib.rs
@@ -11,5 +11,12 @@ pub use error::ProverServiceClientError;
 mod requester;
 pub use requester::{ProofRequesterClient, ProofRequesterProvider};
 
+mod retry;
+pub use retry::{
+    DEFAULT_PROOF_REQUESTER_INITIAL_DELAY, DEFAULT_PROOF_REQUESTER_MAX_ATTEMPTS,
+    DEFAULT_PROOF_REQUESTER_MAX_DELAY, MIN_PROOF_REQUESTER_RETRY_DELAY, ProofRequesterRetryConfig,
+    RetryingProofRequester,
+};
+
 mod worker;
 pub use worker::{ProverWorkerClient, ProverWorkerProvider};

--- a/crates/proof/prover-service/client/src/requester.rs
+++ b/crates/proof/prover-service/client/src/requester.rs
@@ -87,6 +87,12 @@ impl ProofRequesterClient {
     }
 
     /// Submit a prove-block-range proof request.
+    ///
+    /// When `request.proof.session_id` is `None`, the prover service generates a fresh
+    /// UUID per call, so retrying a transient failure could enqueue a duplicate proof
+    /// under a different session ID. To stay idempotent, requests without a client-
+    /// supplied `session_id` are issued exactly once and any error is surfaced as-is.
+    /// Once `session_id` becomes a required protocol field, this guard can be removed.
     pub async fn prove_block_range(
         &self,
         request: ProveBlockRangeRequest,
@@ -95,6 +101,11 @@ impl ProofRequesterClient {
             session_id = ?request.proof.session_id,
             "proving block range"
         );
+
+        if request.proof.session_id.is_none() {
+            return Ok(self.inner.prove_block_range(request).await?);
+        }
+
         (|| {
             let request = request.clone();
 
@@ -524,6 +535,30 @@ mod tests {
 
         assert!(err.is_retryable());
         assert_eq!(api_clone.prove_calls(), total_calls);
+
+        server.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn requester_does_not_retry_prove_block_range_without_session_id() {
+        let api = MockRequesterApi::new();
+        // Even with retryable outcomes queued, the client must call the server exactly
+        // once when session_id is None to avoid enqueueing duplicate proofs under a
+        // server-generated UUID.
+        api.queue_prove_outcomes([ScriptedOutcome::Retryable, ScriptedOutcome::Retryable]);
+        let api_clone = api.clone();
+        let server = RunningRequesterServer::spawn_with_retry(api, fast_retry_config()).await;
+
+        let mut request = sample_prove_request("ignored");
+        request.proof.session_id = None;
+        let err = server
+            .client
+            .prove_block_range(request)
+            .await
+            .expect_err("retryable error should propagate without retry");
+
+        assert!(err.is_retryable());
+        assert_eq!(api_clone.prove_calls(), 1);
 
         server.shutdown().await;
     }

--- a/crates/proof/prover-service/client/src/requester.rs
+++ b/crates/proof/prover-service/client/src/requester.rs
@@ -472,9 +472,14 @@ mod tests {
     #[tokio::test]
     async fn requester_rpc_errors_preserve_call_context_and_retryability() {
         let api = MockRequesterApi::rejecting_get_proof();
+        // Use a single explicit retry with 1ms delays so the test exercises the real
+        // retry code path quickly without relying on the `0 -> 1` clamp inside
+        // `ProofRequesterRetryConfig::normalized_max_attempts`. Call count is not
+        // asserted; this test only verifies the final error variant, code, and
+        // retryability classification.
         let server = RunningRequesterServer::spawn_with_retry(
             api,
-            ProofRequesterRetryConfig::new(0, Duration::from_millis(1), Duration::from_millis(1)),
+            ProofRequesterRetryConfig::new(1, Duration::from_millis(1), Duration::from_millis(1)),
         )
         .await;
         let provider: &dyn ProofRequesterProvider = &server.client;

--- a/crates/proof/prover-service/client/src/requester.rs
+++ b/crates/proof/prover-service/client/src/requester.rs
@@ -1,14 +1,18 @@
 //! Client for proof requester JSON-RPC methods.
 
 use async_trait::async_trait;
+use backon::Retryable;
 use base_prover_service_protocol::{
     GetProofRequest, GetProofResponse, ListProofsRequest, ListProofsResponse,
     ProveBlockRangeRequest, ProveBlockRangeResponse, ProverRequesterApiClient,
 };
 use jsonrpsee::http_client::HttpClient;
-use tracing::debug;
+use tracing::{debug, warn};
 
-use crate::{ProverServiceClientBuildError, ProverServiceClientConfig, ProverServiceClientError};
+use crate::{
+    ProofRequesterRetryConfig, ProverServiceClientBuildError, ProverServiceClientConfig,
+    ProverServiceClientError,
+};
 
 /// Abstraction over proof requester JSON-RPC methods.
 ///
@@ -38,27 +42,48 @@ pub trait ProofRequesterProvider: Send + Sync {
 }
 
 /// JSON-RPC client for proof requester methods.
+///
+/// Each requester operation is wrapped in a `backon` exponential backoff that retries
+/// transient JSON-RPC failures (per [`ProverServiceClientError::is_retryable`]). Retry
+/// behavior is controlled by the [`ProofRequesterRetryConfig`] passed at construction
+/// time, defaulting to [`ProofRequesterRetryConfig::default`].
 #[derive(Clone, Debug)]
 pub struct ProofRequesterClient {
     inner: HttpClient,
+    retry: ProofRequesterRetryConfig,
 }
 
 impl ProofRequesterClient {
-    /// Create a requester client from an existing JSON-RPC HTTP client.
-    pub const fn new(inner: HttpClient) -> Self {
-        Self { inner }
+    /// Create a requester client from an existing JSON-RPC HTTP client. Retries use
+    /// [`ProofRequesterRetryConfig::default`]; call [`Self::with_retry_config`] to
+    /// override.
+    pub fn new(inner: HttpClient) -> Self {
+        Self { inner, retry: ProofRequesterRetryConfig::default() }
     }
 
-    /// Connect a requester client using the provided configuration.
+    /// Connect a requester client using the provided configuration. The retry
+    /// configuration is taken from [`ProverServiceClientConfig::retry_config`].
     pub fn connect(
         config: &ProverServiceClientConfig,
     ) -> Result<Self, ProverServiceClientBuildError> {
-        Ok(Self::new(config.build_http_client()?))
+        Ok(Self::new(config.build_http_client()?).with_retry_config(config.retry_config()))
+    }
+
+    /// Override the retry configuration applied to requester operations.
+    #[must_use]
+    pub const fn with_retry_config(mut self, retry: ProofRequesterRetryConfig) -> Self {
+        self.retry = retry;
+        self
     }
 
     /// Return the underlying JSON-RPC HTTP client.
     pub const fn inner(&self) -> &HttpClient {
         &self.inner
+    }
+
+    /// Return the retry configuration applied to requester operations.
+    pub const fn retry_config(&self) -> ProofRequesterRetryConfig {
+        self.retry
     }
 
     /// Submit a prove-block-range proof request.
@@ -70,7 +95,22 @@ impl ProofRequesterClient {
             session_id = ?request.proof.session_id,
             "proving block range"
         );
-        Ok(self.inner.prove_block_range(request).await?)
+        (|| {
+            let request = request.clone();
+
+            async move { Ok(self.inner.prove_block_range(request).await?) }
+        })
+        .retry(self.retry.to_backoff_builder())
+        .when(ProverServiceClientError::is_retryable)
+        .notify(|error, delay| {
+            warn!(
+                session_id = ?request.proof.session_id,
+                backoff_ms = delay.as_millis(),
+                error = %error,
+                "prove block range failed; retrying"
+            );
+        })
+        .await
     }
 
     /// Return proof status and result data for a submitted proof request.
@@ -79,7 +119,22 @@ impl ProofRequesterClient {
         request: GetProofRequest,
     ) -> Result<GetProofResponse, ProverServiceClientError> {
         debug!(session_id = %request.session_id, "fetching proof");
-        Ok(self.inner.get_proof(request).await?)
+        (|| {
+            let request = request.clone();
+
+            async move { Ok(self.inner.get_proof(request).await?) }
+        })
+        .retry(self.retry.to_backoff_builder())
+        .when(ProverServiceClientError::is_retryable)
+        .notify(|error, delay| {
+            warn!(
+                session_id = %request.session_id,
+                backoff_ms = delay.as_millis(),
+                error = %error,
+                "get proof failed; retrying"
+            );
+        })
+        .await
     }
 
     /// List submitted proof requests.
@@ -93,7 +148,20 @@ impl ProofRequesterClient {
             status_filter = ?request.status_filter,
             "listing proofs"
         );
-        Ok(self.inner.list_proofs(request).await?)
+        (|| async move { Ok(self.inner.list_proofs(request).await?) })
+            .retry(self.retry.to_backoff_builder())
+            .when(ProverServiceClientError::is_retryable)
+            .notify(|error, delay| {
+                warn!(
+                    offset = request.offset,
+                    limit = request.limit,
+                    status_filter = ?request.status_filter,
+                    backoff_ms = delay.as_millis(),
+                    error = %error,
+                    "list proofs failed; retrying"
+                );
+            })
+            .await
     }
 }
 
@@ -124,8 +192,13 @@ impl ProofRequesterProvider for ProofRequesterClient {
 #[cfg(test)]
 mod tests {
     use std::{
+        collections::VecDeque,
         net::SocketAddr,
-        sync::{Arc, Mutex},
+        sync::{
+            Arc, Mutex,
+            atomic::{AtomicU32, Ordering},
+        },
+        time::Duration,
     };
 
     use async_trait::async_trait;
@@ -140,16 +213,29 @@ mod tests {
         core::{RpcResult, client::Error as JsonRpcClientError},
         http_client::HttpClientBuilder,
         server::{Server, ServerHandle},
-        types::ErrorObjectOwned,
+        types::{ErrorObjectOwned, error::ErrorCode},
     };
 
     use super::{ProofRequesterClient, ProofRequesterProvider};
-    use crate::ProverServiceClientError;
+    use crate::{ProofRequesterRetryConfig, ProverServiceClientError};
+
+    /// Outcome script for a single requester call when the test wants to drive
+    /// retry behavior. The server returns the head of the queue per call.
+    #[derive(Debug)]
+    enum ScriptedOutcome {
+        Retryable,
+        Fatal,
+        Success,
+    }
 
     #[derive(Clone, Debug)]
     struct MockRequesterApi {
         state: Arc<Mutex<MockRequesterState>>,
         reject_get_proof: bool,
+        prove_script: Arc<Mutex<VecDeque<ScriptedOutcome>>>,
+        get_script: Arc<Mutex<VecDeque<ScriptedOutcome>>>,
+        prove_calls: Arc<AtomicU32>,
+        get_calls: Arc<AtomicU32>,
     }
 
     #[derive(Debug, Default)]
@@ -170,19 +256,42 @@ mod tests {
             Self {
                 state: Arc::new(Mutex::new(MockRequesterState::default())),
                 reject_get_proof: false,
+                prove_script: Arc::new(Mutex::new(VecDeque::new())),
+                get_script: Arc::new(Mutex::new(VecDeque::new())),
+                prove_calls: Arc::new(AtomicU32::new(0)),
+                get_calls: Arc::new(AtomicU32::new(0)),
             }
         }
 
         fn rejecting_get_proof() -> Self {
-            Self {
-                state: Arc::new(Mutex::new(MockRequesterState::default())),
-                reject_get_proof: true,
-            }
+            let mut api = Self::new();
+            api.reject_get_proof = true;
+            api
+        }
+
+        fn queue_prove_outcomes<I: IntoIterator<Item = ScriptedOutcome>>(&self, outcomes: I) {
+            self.prove_script.lock().expect("script lock").extend(outcomes);
+        }
+
+        fn queue_get_outcomes<I: IntoIterator<Item = ScriptedOutcome>>(&self, outcomes: I) {
+            self.get_script.lock().expect("script lock").extend(outcomes);
+        }
+
+        fn prove_calls(&self) -> u32 {
+            self.prove_calls.load(Ordering::SeqCst)
+        }
+
+        fn get_calls(&self) -> u32 {
+            self.get_calls.load(Ordering::SeqCst)
         }
     }
 
     impl RunningRequesterServer {
         async fn spawn(api: MockRequesterApi) -> Self {
+            Self::spawn_with_retry(api, ProofRequesterRetryConfig::default()).await
+        }
+
+        async fn spawn_with_retry(api: MockRequesterApi, retry: ProofRequesterRetryConfig) -> Self {
             let addr: SocketAddr = "127.0.0.1:0".parse().expect("test address should parse");
             let server = Server::builder().build(addr).await.expect("server should bind");
             let local_addr = server.local_addr().expect("server should have local address");
@@ -190,7 +299,7 @@ mod tests {
             let endpoint = format!("http://{local_addr}");
             let inner = HttpClientBuilder::default().build(endpoint).expect("client should build");
 
-            Self { client: ProofRequesterClient::new(inner), handle }
+            Self { client: ProofRequesterClient::new(inner).with_retry_config(retry), handle }
         }
 
         async fn shutdown(self) {
@@ -199,29 +308,66 @@ mod tests {
         }
     }
 
+    fn unavailable_error(message: impl Into<String>) -> ErrorObjectOwned {
+        ErrorObjectOwned::owned(
+            ProverServiceClientError::ERROR_UNAVAILABLE,
+            message.into(),
+            None::<()>,
+        )
+    }
+
+    fn invalid_params_error(message: impl Into<String>) -> ErrorObjectOwned {
+        ErrorObjectOwned::owned(ErrorCode::InvalidParams.code(), message.into(), None::<()>)
+    }
+
+    fn fast_retry_config() -> ProofRequesterRetryConfig {
+        ProofRequesterRetryConfig::new(3, Duration::from_millis(1), Duration::from_millis(1))
+    }
+
     #[async_trait]
     impl ProverRequesterApiServer for MockRequesterApi {
         async fn prove_block_range(
             &self,
             request: ProveBlockRangeRequest,
         ) -> RpcResult<ProveBlockRangeResponse> {
+            self.prove_calls.fetch_add(1, Ordering::SeqCst);
             self.state.lock().expect("state lock should not be poisoned").prove_request =
                 Some(request.clone());
 
-            let session_id = request.proof.session_id.expect("test request should set session_id");
-            Ok(ProveBlockRangeResponse { session_id })
+            let scripted = self.prove_script.lock().expect("script lock").pop_front();
+            match scripted {
+                Some(ScriptedOutcome::Retryable) => {
+                    Err(unavailable_error("scripted prove_block_range retryable failure"))
+                }
+                Some(ScriptedOutcome::Fatal) => {
+                    Err(invalid_params_error("scripted prove_block_range fatal failure"))
+                }
+                None | Some(ScriptedOutcome::Success) => {
+                    let session_id =
+                        request.proof.session_id.expect("test request should set session_id");
+                    Ok(ProveBlockRangeResponse { session_id })
+                }
+            }
         }
 
         async fn get_proof(&self, request: GetProofRequest) -> RpcResult<GetProofResponse> {
+            self.get_calls.fetch_add(1, Ordering::SeqCst);
             self.state.lock().expect("state lock should not be poisoned").get_request =
                 Some(request.clone());
 
-            if self.reject_get_proof {
-                return Err(ErrorObjectOwned::owned(
-                    ProverServiceClientError::ERROR_UNAVAILABLE,
-                    format!("session_id {} is temporarily unavailable", request.session_id),
-                    None::<()>,
-                ));
+            let scripted = self.get_script.lock().expect("script lock").pop_front();
+            if let Some(ScriptedOutcome::Fatal) = scripted {
+                return Err(invalid_params_error(format!(
+                    "session_id {} is invalid",
+                    request.session_id
+                )));
+            }
+
+            if self.reject_get_proof || matches!(scripted, Some(ScriptedOutcome::Retryable)) {
+                return Err(unavailable_error(format!(
+                    "session_id {} is temporarily unavailable",
+                    request.session_id
+                )));
             }
 
             Ok(GetProofResponse {
@@ -315,7 +461,11 @@ mod tests {
     #[tokio::test]
     async fn requester_rpc_errors_preserve_call_context_and_retryability() {
         let api = MockRequesterApi::rejecting_get_proof();
-        let server = RunningRequesterServer::spawn(api).await;
+        let server = RunningRequesterServer::spawn_with_retry(
+            api,
+            ProofRequesterRetryConfig::new(0, Duration::from_millis(1), Duration::from_millis(1)),
+        )
+        .await;
         let provider: &dyn ProofRequesterProvider = &server.client;
 
         let err = provider
@@ -332,6 +482,67 @@ mod tests {
             }
             other => panic!("unexpected error variant: {other:?}"),
         }
+
+        server.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn requester_retries_retryable_prove_block_range_until_success() {
+        let api = MockRequesterApi::new();
+        api.queue_prove_outcomes([ScriptedOutcome::Retryable, ScriptedOutcome::Success]);
+        let api_clone = api.clone();
+        let server = RunningRequesterServer::spawn_with_retry(api, fast_retry_config()).await;
+
+        let response = server
+            .client
+            .prove_block_range(sample_prove_request("session-retry"))
+            .await
+            .expect("prove_block_range should succeed after retry");
+
+        assert_eq!(response.session_id, "session-retry");
+        assert_eq!(api_clone.prove_calls(), 2);
+
+        server.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn requester_propagates_final_error_when_retries_exhausted() {
+        let config = fast_retry_config();
+        let api = MockRequesterApi::new();
+        // backon's `with_max_times(n)` allows `n` retries on top of the initial call,
+        // so an exhausted run performs `max_attempts + 1` total calls.
+        let total_calls = config.normalized_max_attempts() + 1;
+        api.queue_prove_outcomes((0..total_calls).map(|_| ScriptedOutcome::Retryable));
+        let api_clone = api.clone();
+        let server = RunningRequesterServer::spawn_with_retry(api, config).await;
+
+        let err = server
+            .client
+            .prove_block_range(sample_prove_request("session-exhaust"))
+            .await
+            .expect_err("retries should be exhausted");
+
+        assert!(err.is_retryable());
+        assert_eq!(api_clone.prove_calls(), total_calls);
+
+        server.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn requester_does_not_retry_fatal_get_proof() {
+        let api = MockRequesterApi::new();
+        api.queue_get_outcomes([ScriptedOutcome::Fatal]);
+        let api_clone = api.clone();
+        let server = RunningRequesterServer::spawn_with_retry(api, fast_retry_config()).await;
+
+        let err = server
+            .client
+            .get_proof(GetProofRequest { session_id: "session-fatal".to_owned() })
+            .await
+            .expect_err("fatal error should not be retried");
+
+        assert!(!err.is_retryable());
+        assert_eq!(api_clone.get_calls(), 1);
 
         server.shutdown().await;
     }

--- a/crates/proof/prover-service/client/src/retry.rs
+++ b/crates/proof/prover-service/client/src/retry.rs
@@ -1,16 +1,8 @@
-//! Retrying proof requester provider.
+//! Retry configuration for proof requester RPC operations.
 
-use std::{sync::Arc, time::Duration};
+use std::time::Duration;
 
-use async_trait::async_trait;
-use backon::{ExponentialBuilder, Retryable};
-use base_prover_service_protocol::{
-    GetProofRequest, GetProofResponse, ListProofsRequest, ListProofsResponse,
-    ProveBlockRangeRequest, ProveBlockRangeResponse,
-};
-use tracing::warn;
-
-use crate::{ProofRequesterProvider, ProverServiceClientError};
+use backon::ExponentialBuilder;
 
 /// Minimum delay used to avoid tight retry loops.
 pub const MIN_PROOF_REQUESTER_RETRY_DELAY: Duration = Duration::from_millis(1);
@@ -79,277 +71,35 @@ impl Default for ProofRequesterRetryConfig {
     }
 }
 
-/// Proof requester wrapper that retries transient requester RPC failures.
-#[derive(Clone)]
-pub struct RetryingProofRequester {
-    inner: Arc<dyn ProofRequesterProvider>,
-    retry: ProofRequesterRetryConfig,
-}
-
-impl RetryingProofRequester {
-    /// Creates a retrying proof requester with default retry settings.
-    pub fn new(inner: Arc<dyn ProofRequesterProvider>) -> Self {
-        Self { inner, retry: ProofRequesterRetryConfig::default() }
-    }
-
-    /// Creates a retrying proof requester with the provided retry settings.
-    pub const fn with_retry_config(
-        inner: Arc<dyn ProofRequesterProvider>,
-        retry: ProofRequesterRetryConfig,
-    ) -> Self {
-        Self { inner, retry }
-    }
-}
-
-impl std::fmt::Debug for RetryingProofRequester {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("RetryingProofRequester").field("retry", &self.retry).finish_non_exhaustive()
-    }
-}
-
-#[async_trait]
-impl ProofRequesterProvider for RetryingProofRequester {
-    async fn prove_block_range(
-        &self,
-        request: ProveBlockRangeRequest,
-    ) -> Result<ProveBlockRangeResponse, ProverServiceClientError> {
-        (|| {
-            let request = request.clone();
-
-            async move { self.inner.prove_block_range(request).await }
-        })
-        .retry(self.retry.to_backoff_builder())
-        .when(ProverServiceClientError::is_retryable)
-        .notify(|error, delay| {
-            warn!(
-                session_id = ?request.proof.session_id,
-                backoff_ms = delay.as_millis(),
-                error = %error,
-                "prove block range failed; retrying"
-            );
-        })
-        .await
-    }
-
-    async fn get_proof(
-        &self,
-        request: GetProofRequest,
-    ) -> Result<GetProofResponse, ProverServiceClientError> {
-        (|| {
-            let request = request.clone();
-
-            async move { self.inner.get_proof(request).await }
-        })
-        .retry(self.retry.to_backoff_builder())
-        .when(ProverServiceClientError::is_retryable)
-        .notify(|error, delay| {
-            warn!(
-                session_id = %request.session_id,
-                backoff_ms = delay.as_millis(),
-                error = %error,
-                "get proof failed; retrying"
-            );
-        })
-        .await
-    }
-
-    async fn list_proofs(
-        &self,
-        request: ListProofsRequest,
-    ) -> Result<ListProofsResponse, ProverServiceClientError> {
-        (|| async { self.inner.list_proofs(request).await })
-            .retry(self.retry.to_backoff_builder())
-            .when(ProverServiceClientError::is_retryable)
-            .notify(|error, delay| {
-                warn!(
-                    offset = request.offset,
-                    limit = request.limit,
-                    status_filter = ?request.status_filter,
-                    backoff_ms = delay.as_millis(),
-                    error = %error,
-                    "list proofs failed; retrying"
-                );
-            })
-            .await
-    }
-}
-
 #[cfg(test)]
 mod tests {
-    use std::{collections::VecDeque, sync::Mutex, time::Duration};
-
-    use base_prover_service_protocol::{ProofRequest, ProofRequestKind, ZkProofRequest, ZkVm};
-
     use super::*;
 
-    enum MockOutcome<T> {
-        Ok(T),
-        Retryable,
-        Fatal,
+    #[test]
+    fn normalized_max_attempts_clamps_zero_to_one() {
+        let config =
+            ProofRequesterRetryConfig::new(0, Duration::from_millis(10), Duration::from_millis(20));
+        assert_eq!(config.normalized_max_attempts(), 1);
     }
 
-    struct MockRequester {
-        prove_outcomes: Mutex<VecDeque<MockOutcome<ProveBlockRangeResponse>>>,
-        get_outcomes: Mutex<VecDeque<MockOutcome<GetProofResponse>>>,
-        list_outcomes: Mutex<VecDeque<MockOutcome<ListProofsResponse>>>,
-        prove_calls: Mutex<u32>,
-        get_calls: Mutex<u32>,
-        list_calls: Mutex<u32>,
+    #[test]
+    fn normalized_initial_delay_is_clamped_to_max_delay() {
+        let config =
+            ProofRequesterRetryConfig::new(3, Duration::from_secs(60), Duration::from_millis(50));
+        assert_eq!(config.normalized_initial_delay(), Duration::from_millis(50));
     }
 
-    impl MockRequester {
-        fn new() -> Self {
-            Self {
-                prove_outcomes: Mutex::new(VecDeque::new()),
-                get_outcomes: Mutex::new(VecDeque::new()),
-                list_outcomes: Mutex::new(VecDeque::new()),
-                prove_calls: Mutex::new(0),
-                get_calls: Mutex::new(0),
-                list_calls: Mutex::new(0),
-            }
-        }
-
-        fn outcome<T>(outcome: MockOutcome<T>) -> Result<T, ProverServiceClientError> {
-            match outcome {
-                MockOutcome::Ok(value) => Ok(value),
-                MockOutcome::Retryable => {
-                    Err(ProverServiceClientError::Timeout("retryable".to_owned()))
-                }
-                MockOutcome::Fatal => {
-                    Err(ProverServiceClientError::ProofFailure { message: "fatal".to_owned() })
-                }
-            }
-        }
+    #[test]
+    fn normalized_max_delay_is_clamped_to_minimum() {
+        let config = ProofRequesterRetryConfig::new(3, Duration::ZERO, Duration::ZERO);
+        assert_eq!(config.normalized_max_delay(), MIN_PROOF_REQUESTER_RETRY_DELAY);
     }
 
-    #[async_trait]
-    impl ProofRequesterProvider for MockRequester {
-        async fn prove_block_range(
-            &self,
-            _request: ProveBlockRangeRequest,
-        ) -> Result<ProveBlockRangeResponse, ProverServiceClientError> {
-            *self.prove_calls.lock().unwrap() += 1;
-            let outcome = self.prove_outcomes.lock().unwrap().pop_front().expect("missing outcome");
-            Self::outcome(outcome)
-        }
-
-        async fn get_proof(
-            &self,
-            _request: GetProofRequest,
-        ) -> Result<GetProofResponse, ProverServiceClientError> {
-            *self.get_calls.lock().unwrap() += 1;
-            let outcome = self.get_outcomes.lock().unwrap().pop_front().expect("missing outcome");
-            Self::outcome(outcome)
-        }
-
-        async fn list_proofs(
-            &self,
-            _request: ListProofsRequest,
-        ) -> Result<ListProofsResponse, ProverServiceClientError> {
-            *self.list_calls.lock().unwrap() += 1;
-            let outcome = self.list_outcomes.lock().unwrap().pop_front().expect("missing outcome");
-            Self::outcome(outcome)
-        }
-    }
-
-    fn retry_config() -> ProofRequesterRetryConfig {
-        ProofRequesterRetryConfig::new(3, Duration::from_millis(1), Duration::from_millis(1))
-    }
-
-    fn prove_request() -> ProveBlockRangeRequest {
-        ProveBlockRangeRequest {
-            proof: ProofRequest {
-                session_id: Some("session".to_owned()),
-                request: ProofRequestKind::Compressed(ZkProofRequest {
-                    start_block_number: 1,
-                    number_of_blocks_to_prove: 1,
-                    sequence_window: None,
-                    l1_head: None,
-                    intermediate_root_interval: None,
-                    zk_vm: ZkVm::Sp1,
-                }),
-            },
-        }
-    }
-
-    #[tokio::test]
-    async fn retrying_requester_retries_retryable_prove_block_range() {
-        let inner = Arc::new(MockRequester::new());
-        inner.prove_outcomes.lock().unwrap().extend([
-            MockOutcome::Retryable,
-            MockOutcome::Ok(ProveBlockRangeResponse { session_id: "session".to_owned() }),
-        ]);
-        let requester = RetryingProofRequester::with_retry_config(
-            Arc::clone(&inner) as Arc<dyn ProofRequesterProvider>,
-            retry_config(),
-        );
-
-        let response = requester.prove_block_range(prove_request()).await.unwrap();
-
-        assert_eq!(response.session_id, "session");
-        assert_eq!(*inner.prove_calls.lock().unwrap(), 2);
-    }
-
-    #[tokio::test]
-    async fn retrying_requester_propagates_final_error_when_retries_exhausted() {
-        let config = retry_config();
-        let inner = Arc::new(MockRequester::new());
-        // backon's `with_max_times(n)` allows `n` retries on top of the initial call,
-        // so an exhausted run performs `max_attempts + 1` total calls.
-        let total_calls = config.normalized_max_attempts() + 1;
-        inner
-            .prove_outcomes
-            .lock()
-            .unwrap()
-            .extend((0..total_calls).map(|_| MockOutcome::Retryable));
-        let requester = RetryingProofRequester::with_retry_config(
-            Arc::clone(&inner) as Arc<dyn ProofRequesterProvider>,
-            config,
-        );
-
-        let err = requester.prove_block_range(prove_request()).await.unwrap_err();
-
-        assert!(matches!(err, ProverServiceClientError::Timeout(_)));
-        assert!(err.is_retryable());
-        assert_eq!(*inner.prove_calls.lock().unwrap(), total_calls);
-    }
-
-    #[tokio::test]
-    async fn retrying_requester_does_not_retry_fatal_get_proof() {
-        let inner = Arc::new(MockRequester::new());
-        inner.get_outcomes.lock().unwrap().push_back(MockOutcome::Fatal);
-        let requester = RetryingProofRequester::with_retry_config(
-            Arc::clone(&inner) as Arc<dyn ProofRequesterProvider>,
-            retry_config(),
-        );
-
-        let err = requester
-            .get_proof(GetProofRequest { session_id: "session".to_owned() })
-            .await
-            .unwrap_err();
-
-        assert!(!err.is_retryable());
-        assert_eq!(*inner.get_calls.lock().unwrap(), 1);
-    }
-
-    #[tokio::test]
-    async fn retrying_requester_retries_list_proofs() {
-        let inner = Arc::new(MockRequester::new());
-        inner.list_outcomes.lock().unwrap().extend([
-            MockOutcome::Retryable,
-            MockOutcome::Ok(ListProofsResponse { proofs: Vec::new(), total_count: 0 }),
-        ]);
-        let requester = RetryingProofRequester::with_retry_config(
-            Arc::clone(&inner) as Arc<dyn ProofRequesterProvider>,
-            retry_config(),
-        );
-
-        let response = requester
-            .list_proofs(ListProofsRequest { offset: 0, limit: 10, status_filter: None })
-            .await
-            .unwrap();
-
-        assert_eq!(response.total_count, 0);
-        assert_eq!(*inner.list_calls.lock().unwrap(), 2);
+    #[test]
+    fn default_config_uses_documented_constants() {
+        let config = ProofRequesterRetryConfig::default();
+        assert_eq!(config.max_attempts, DEFAULT_PROOF_REQUESTER_MAX_ATTEMPTS);
+        assert_eq!(config.initial_delay, DEFAULT_PROOF_REQUESTER_INITIAL_DELAY);
+        assert_eq!(config.max_delay, DEFAULT_PROOF_REQUESTER_MAX_DELAY);
     }
 }

--- a/crates/proof/prover-service/client/src/retry.rs
+++ b/crates/proof/prover-service/client/src/retry.rs
@@ -27,7 +27,10 @@ pub const DEFAULT_PROOF_REQUESTER_MAX_DELAY: Duration = Duration::from_secs(10);
 /// Exponential backoff configuration for proof requester retries.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ProofRequesterRetryConfig {
-    /// Maximum number of retry attempts.
+    /// Maximum number of retries performed after the initial call. The total number of
+    /// requester calls in a fully exhausted run is therefore `max_attempts + 1`. Zero is
+    /// treated as one (a single retry); this matches the existing
+    /// `base_proof_rpc::config::RetryConfig` convention in the workspace.
     pub max_attempts: u32,
     /// First delay after a retryable requester failure.
     pub initial_delay: Duration,
@@ -110,9 +113,8 @@ impl ProofRequesterProvider for RetryingProofRequester {
         &self,
         request: ProveBlockRangeRequest,
     ) -> Result<ProveBlockRangeResponse, ProverServiceClientError> {
-        let request_for_attempt = request.clone();
         (|| {
-            let request = request_for_attempt.clone();
+            let request = request.clone();
 
             async move { self.inner.prove_block_range(request).await }
         })
@@ -133,9 +135,8 @@ impl ProofRequesterProvider for RetryingProofRequester {
         &self,
         request: GetProofRequest,
     ) -> Result<GetProofResponse, ProverServiceClientError> {
-        let request_for_attempt = request.clone();
         (|| {
-            let request = request_for_attempt.clone();
+            let request = request.clone();
 
             async move { self.inner.get_proof(request).await }
         })

--- a/crates/proof/prover-service/client/src/retry.rs
+++ b/crates/proof/prover-service/client/src/retry.rs
@@ -1,0 +1,330 @@
+//! Retrying proof requester provider.
+
+use std::{sync::Arc, time::Duration};
+
+use async_trait::async_trait;
+use backon::{ExponentialBuilder, Retryable};
+use base_prover_service_protocol::{
+    GetProofRequest, GetProofResponse, ListProofsRequest, ListProofsResponse,
+    ProveBlockRangeRequest, ProveBlockRangeResponse,
+};
+use tracing::warn;
+
+use crate::{ProofRequesterProvider, ProverServiceClientError};
+
+/// Minimum delay used to avoid tight retry loops.
+pub const MIN_PROOF_REQUESTER_RETRY_DELAY: Duration = Duration::from_millis(1);
+
+/// Default maximum retry attempts for requester RPC operations.
+pub const DEFAULT_PROOF_REQUESTER_MAX_ATTEMPTS: u32 = 5;
+
+/// Default initial retry delay for requester RPC operations.
+pub const DEFAULT_PROOF_REQUESTER_INITIAL_DELAY: Duration = Duration::from_millis(100);
+
+/// Default maximum retry delay for requester RPC operations.
+pub const DEFAULT_PROOF_REQUESTER_MAX_DELAY: Duration = Duration::from_secs(10);
+
+/// Exponential backoff configuration for proof requester retries.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ProofRequesterRetryConfig {
+    /// Maximum number of retry attempts.
+    pub max_attempts: u32,
+    /// First delay after a retryable requester failure.
+    pub initial_delay: Duration,
+    /// Maximum delay between retry attempts.
+    pub max_delay: Duration,
+}
+
+impl ProofRequesterRetryConfig {
+    /// Creates a proof requester retry config.
+    pub const fn new(max_attempts: u32, initial_delay: Duration, max_delay: Duration) -> Self {
+        Self { max_attempts, initial_delay, max_delay }
+    }
+
+    /// Returns the configured max attempts, clamped to at least one attempt.
+    pub const fn normalized_max_attempts(&self) -> u32 {
+        if self.max_attempts == 0 { 1 } else { self.max_attempts }
+    }
+
+    /// Returns the configured max delay, clamped to the minimum allowed delay.
+    pub fn normalized_max_delay(&self) -> Duration {
+        self.max_delay.max(MIN_PROOF_REQUESTER_RETRY_DELAY)
+    }
+
+    /// Returns the configured initial delay, clamped to the configured max delay.
+    pub fn normalized_initial_delay(&self) -> Duration {
+        self.initial_delay.max(MIN_PROOF_REQUESTER_RETRY_DELAY).min(self.normalized_max_delay())
+    }
+
+    /// Creates a `backon` [`ExponentialBuilder`] from this configuration.
+    pub fn to_backoff_builder(&self) -> ExponentialBuilder {
+        ExponentialBuilder::default()
+            .with_min_delay(self.normalized_initial_delay())
+            .with_max_delay(self.normalized_max_delay())
+            .with_max_times(self.normalized_max_attempts() as usize)
+            .with_jitter()
+    }
+}
+
+impl Default for ProofRequesterRetryConfig {
+    fn default() -> Self {
+        Self::new(
+            DEFAULT_PROOF_REQUESTER_MAX_ATTEMPTS,
+            DEFAULT_PROOF_REQUESTER_INITIAL_DELAY,
+            DEFAULT_PROOF_REQUESTER_MAX_DELAY,
+        )
+    }
+}
+
+/// Proof requester wrapper that retries transient requester RPC failures.
+#[derive(Clone)]
+pub struct RetryingProofRequester {
+    inner: Arc<dyn ProofRequesterProvider>,
+    retry: ProofRequesterRetryConfig,
+}
+
+impl RetryingProofRequester {
+    /// Creates a retrying proof requester with default retry settings.
+    pub fn new(inner: Arc<dyn ProofRequesterProvider>) -> Self {
+        Self { inner, retry: ProofRequesterRetryConfig::default() }
+    }
+
+    /// Creates a retrying proof requester with the provided retry settings.
+    pub const fn with_retry_config(
+        inner: Arc<dyn ProofRequesterProvider>,
+        retry: ProofRequesterRetryConfig,
+    ) -> Self {
+        Self { inner, retry }
+    }
+}
+
+impl std::fmt::Debug for RetryingProofRequester {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RetryingProofRequester").field("retry", &self.retry).finish_non_exhaustive()
+    }
+}
+
+#[async_trait]
+impl ProofRequesterProvider for RetryingProofRequester {
+    async fn prove_block_range(
+        &self,
+        request: ProveBlockRangeRequest,
+    ) -> Result<ProveBlockRangeResponse, ProverServiceClientError> {
+        let request_for_attempt = request.clone();
+        (|| {
+            let request = request_for_attempt.clone();
+
+            async move { self.inner.prove_block_range(request).await }
+        })
+        .retry(self.retry.to_backoff_builder())
+        .when(ProverServiceClientError::is_retryable)
+        .notify(|error, delay| {
+            warn!(
+                session_id = ?request.proof.session_id,
+                backoff_ms = delay.as_millis(),
+                error = %error,
+                "prove block range failed; retrying"
+            );
+        })
+        .await
+    }
+
+    async fn get_proof(
+        &self,
+        request: GetProofRequest,
+    ) -> Result<GetProofResponse, ProverServiceClientError> {
+        let request_for_attempt = request.clone();
+        (|| {
+            let request = request_for_attempt.clone();
+
+            async move { self.inner.get_proof(request).await }
+        })
+        .retry(self.retry.to_backoff_builder())
+        .when(ProverServiceClientError::is_retryable)
+        .notify(|error, delay| {
+            warn!(
+                session_id = %request.session_id,
+                backoff_ms = delay.as_millis(),
+                error = %error,
+                "get proof failed; retrying"
+            );
+        })
+        .await
+    }
+
+    async fn list_proofs(
+        &self,
+        request: ListProofsRequest,
+    ) -> Result<ListProofsResponse, ProverServiceClientError> {
+        (|| async { self.inner.list_proofs(request).await })
+            .retry(self.retry.to_backoff_builder())
+            .when(ProverServiceClientError::is_retryable)
+            .notify(|error, delay| {
+                warn!(
+                    offset = request.offset,
+                    limit = request.limit,
+                    status_filter = ?request.status_filter,
+                    backoff_ms = delay.as_millis(),
+                    error = %error,
+                    "list proofs failed; retrying"
+                );
+            })
+            .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{collections::VecDeque, sync::Mutex, time::Duration};
+
+    use base_prover_service_protocol::{ProofRequest, ProofRequestKind, ZkProofRequest, ZkVm};
+
+    use super::*;
+
+    enum MockOutcome<T> {
+        Ok(T),
+        Retryable,
+        Fatal,
+    }
+
+    struct MockRequester {
+        prove_outcomes: Mutex<VecDeque<MockOutcome<ProveBlockRangeResponse>>>,
+        get_outcomes: Mutex<VecDeque<MockOutcome<GetProofResponse>>>,
+        list_outcomes: Mutex<VecDeque<MockOutcome<ListProofsResponse>>>,
+        prove_calls: Mutex<u32>,
+        get_calls: Mutex<u32>,
+        list_calls: Mutex<u32>,
+    }
+
+    impl MockRequester {
+        fn new() -> Self {
+            Self {
+                prove_outcomes: Mutex::new(VecDeque::new()),
+                get_outcomes: Mutex::new(VecDeque::new()),
+                list_outcomes: Mutex::new(VecDeque::new()),
+                prove_calls: Mutex::new(0),
+                get_calls: Mutex::new(0),
+                list_calls: Mutex::new(0),
+            }
+        }
+
+        fn outcome<T>(outcome: MockOutcome<T>) -> Result<T, ProverServiceClientError> {
+            match outcome {
+                MockOutcome::Ok(value) => Ok(value),
+                MockOutcome::Retryable => {
+                    Err(ProverServiceClientError::Timeout("retryable".to_owned()))
+                }
+                MockOutcome::Fatal => {
+                    Err(ProverServiceClientError::ProofFailure { message: "fatal".to_owned() })
+                }
+            }
+        }
+    }
+
+    #[async_trait]
+    impl ProofRequesterProvider for MockRequester {
+        async fn prove_block_range(
+            &self,
+            _request: ProveBlockRangeRequest,
+        ) -> Result<ProveBlockRangeResponse, ProverServiceClientError> {
+            *self.prove_calls.lock().unwrap() += 1;
+            let outcome = self.prove_outcomes.lock().unwrap().pop_front().expect("missing outcome");
+            Self::outcome(outcome)
+        }
+
+        async fn get_proof(
+            &self,
+            _request: GetProofRequest,
+        ) -> Result<GetProofResponse, ProverServiceClientError> {
+            *self.get_calls.lock().unwrap() += 1;
+            let outcome = self.get_outcomes.lock().unwrap().pop_front().expect("missing outcome");
+            Self::outcome(outcome)
+        }
+
+        async fn list_proofs(
+            &self,
+            _request: ListProofsRequest,
+        ) -> Result<ListProofsResponse, ProverServiceClientError> {
+            *self.list_calls.lock().unwrap() += 1;
+            let outcome = self.list_outcomes.lock().unwrap().pop_front().expect("missing outcome");
+            Self::outcome(outcome)
+        }
+    }
+
+    fn retry_config() -> ProofRequesterRetryConfig {
+        ProofRequesterRetryConfig::new(3, Duration::from_millis(1), Duration::from_millis(1))
+    }
+
+    fn prove_request() -> ProveBlockRangeRequest {
+        ProveBlockRangeRequest {
+            proof: ProofRequest {
+                session_id: Some("session".to_owned()),
+                request: ProofRequestKind::Compressed(ZkProofRequest {
+                    start_block_number: 1,
+                    number_of_blocks_to_prove: 1,
+                    sequence_window: None,
+                    l1_head: None,
+                    intermediate_root_interval: None,
+                    zk_vm: ZkVm::Sp1,
+                }),
+            },
+        }
+    }
+
+    #[tokio::test]
+    async fn retrying_requester_retries_retryable_prove_block_range() {
+        let inner = Arc::new(MockRequester::new());
+        inner.prove_outcomes.lock().unwrap().extend([
+            MockOutcome::Retryable,
+            MockOutcome::Ok(ProveBlockRangeResponse { session_id: "session".to_owned() }),
+        ]);
+        let requester = RetryingProofRequester::with_retry_config(
+            Arc::clone(&inner) as Arc<dyn ProofRequesterProvider>,
+            retry_config(),
+        );
+
+        let response = requester.prove_block_range(prove_request()).await.unwrap();
+
+        assert_eq!(response.session_id, "session");
+        assert_eq!(*inner.prove_calls.lock().unwrap(), 2);
+    }
+
+    #[tokio::test]
+    async fn retrying_requester_does_not_retry_fatal_get_proof() {
+        let inner = Arc::new(MockRequester::new());
+        inner.get_outcomes.lock().unwrap().push_back(MockOutcome::Fatal);
+        let requester = RetryingProofRequester::with_retry_config(
+            Arc::clone(&inner) as Arc<dyn ProofRequesterProvider>,
+            retry_config(),
+        );
+
+        let err = requester
+            .get_proof(GetProofRequest { session_id: "session".to_owned() })
+            .await
+            .unwrap_err();
+
+        assert!(!err.is_retryable());
+        assert_eq!(*inner.get_calls.lock().unwrap(), 1);
+    }
+
+    #[tokio::test]
+    async fn retrying_requester_retries_list_proofs() {
+        let inner = Arc::new(MockRequester::new());
+        inner.list_outcomes.lock().unwrap().extend([
+            MockOutcome::Retryable,
+            MockOutcome::Ok(ListProofsResponse { proofs: Vec::new(), total_count: 0 }),
+        ]);
+        let requester = RetryingProofRequester::with_retry_config(
+            Arc::clone(&inner) as Arc<dyn ProofRequesterProvider>,
+            retry_config(),
+        );
+
+        let response = requester
+            .list_proofs(ListProofsRequest { offset: 0, limit: 10, status_filter: None })
+            .await
+            .unwrap();
+
+        assert_eq!(response.total_count, 0);
+        assert_eq!(*inner.list_calls.lock().unwrap(), 2);
+    }
+}

--- a/crates/proof/prover-service/client/src/retry.rs
+++ b/crates/proof/prover-service/client/src/retry.rs
@@ -290,6 +290,30 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn retrying_requester_propagates_final_error_when_retries_exhausted() {
+        let config = retry_config();
+        let inner = Arc::new(MockRequester::new());
+        // backon's `with_max_times(n)` allows `n` retries on top of the initial call,
+        // so an exhausted run performs `max_attempts + 1` total calls.
+        let total_calls = config.normalized_max_attempts() + 1;
+        inner
+            .prove_outcomes
+            .lock()
+            .unwrap()
+            .extend((0..total_calls).map(|_| MockOutcome::Retryable));
+        let requester = RetryingProofRequester::with_retry_config(
+            Arc::clone(&inner) as Arc<dyn ProofRequesterProvider>,
+            config,
+        );
+
+        let err = requester.prove_block_range(prove_request()).await.unwrap_err();
+
+        assert!(matches!(err, ProverServiceClientError::Timeout(_)));
+        assert!(err.is_retryable());
+        assert_eq!(*inner.prove_calls.lock().unwrap(), total_calls);
+    }
+
+    #[tokio::test]
     async fn retrying_requester_does_not_retry_fatal_get_proof() {
         let inner = Arc::new(MockRequester::new());
         inner.get_outcomes.lock().unwrap().push_back(MockOutcome::Fatal);


### PR DESCRIPTION
## What

Adds S1 from the proof consolidation plan: a shared retry/backoff wrapper for proof requester operations.

- Adds `ProofRequesterRetryConfig` with exponential backoff defaults.
- Adds `RetryingProofRequester`, an opt-in wrapper around `Arc<dyn ProofRequesterProvider>`.
- Retries requester RPCs when `ProverServiceClientError::is_retryable()` returns true:
  - `prove_block_range`
  - `get_proof`
  - `list_proofs`
- Leaves existing `ProofRequesterClient` behavior unchanged; consumers can opt in by wrapping it.

## Why

This centralizes retry/backoff behavior in `base-prover-service-client` so proposer, challenger, and future callers do not each implement local retry loops.

## Test plan

- `cargo +nightly fmt --all --check`
- `cargo test -p base-prover-service-client`
- `cargo clippy -p base-prover-service-client --all-targets -- -D warnings`