### PR TITLE
chore(release): Set V1.0.1 Release Version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2284,7 +2284,7 @@ dependencies = [
 
 [[package]]
 name = "audit-archiver"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "audit-archiver-lib",
@@ -2303,7 +2303,7 @@ dependencies = [
 
 [[package]]
 name = "audit-archiver-lib"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-primitives",
@@ -3109,7 +3109,7 @@ dependencies = [
 
 [[package]]
 name = "base"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "alloy-chains",
  "base-cli-utils",
@@ -3130,7 +3130,7 @@ dependencies = [
 
 [[package]]
 name = "base-access-lists"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-contract 2.0.5",
@@ -3148,7 +3148,7 @@ dependencies = [
 
 [[package]]
 name = "base-action-harness"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -3212,7 +3212,7 @@ dependencies = [
 
 [[package]]
 name = "base-balance-monitor"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "alloy-network 2.0.5",
  "alloy-node-bindings 2.0.5",
@@ -3225,7 +3225,7 @@ dependencies = [
 
 [[package]]
 name = "base-batcher-admin"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "base-batcher-core",
  "derive_more 2.1.1",
@@ -3236,7 +3236,7 @@ dependencies = [
 
 [[package]]
 name = "base-batcher-bin"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "alloy-primitives",
  "alloy-signer-local 2.0.5",
@@ -3255,7 +3255,7 @@ dependencies = [
 
 [[package]]
 name = "base-batcher-core"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-primitives",
@@ -3280,7 +3280,7 @@ dependencies = [
 
 [[package]]
 name = "base-batcher-encoder"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -3300,7 +3300,7 @@ dependencies = [
 
 [[package]]
 name = "base-batcher-service"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-primitives",
@@ -3334,7 +3334,7 @@ dependencies = [
 
 [[package]]
 name = "base-batcher-source"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-primitives",
@@ -3351,7 +3351,7 @@ dependencies = [
 
 [[package]]
 name = "base-blobs"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-primitives",
@@ -3362,7 +3362,7 @@ dependencies = [
 
 [[package]]
 name = "base-builder-bin"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "alloy-primitives",
  "base-builder-core",
@@ -3382,7 +3382,7 @@ dependencies = [
 
 [[package]]
 name = "base-builder-core"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-contract 2.0.5",
@@ -3511,7 +3511,7 @@ dependencies = [
 
 [[package]]
 name = "base-builder-metering"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "alloy-primitives",
  "base-builder-core",
@@ -3524,7 +3524,7 @@ dependencies = [
 
 [[package]]
 name = "base-builder-publish"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "base-metrics",
  "base-ring-buffer",
@@ -3544,7 +3544,7 @@ dependencies = [
 
 [[package]]
 name = "base-bundle-extension"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "base-execution-txpool",
  "base-node-runner",
@@ -3557,7 +3557,7 @@ dependencies = [
 
 [[package]]
 name = "base-bundles"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-primitives",
@@ -3574,7 +3574,7 @@ dependencies = [
 
 [[package]]
 name = "base-challenger"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-primitives",
@@ -3618,7 +3618,7 @@ dependencies = [
 
 [[package]]
 name = "base-challenger-bin"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "base-challenger",
  "base-cli-utils",
@@ -3628,7 +3628,7 @@ dependencies = [
 
 [[package]]
 name = "base-cli-utils"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "backtrace",
  "base-metrics",
@@ -3651,7 +3651,7 @@ dependencies = [
 
 [[package]]
 name = "base-common-chains"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "alloy-chains",
  "alloy-eips 2.0.5",
@@ -3667,7 +3667,7 @@ dependencies = [
 
 [[package]]
 name = "base-common-consensus"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -3697,7 +3697,7 @@ dependencies = [
 
 [[package]]
 name = "base-common-evm"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -3721,7 +3721,7 @@ dependencies = [
 
 [[package]]
 name = "base-common-flashblocks"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-engine",
@@ -3737,7 +3737,7 @@ dependencies = [
 
 [[package]]
 name = "base-common-flz"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "hex-literal 1.1.0",
  "rstest",
@@ -3745,7 +3745,7 @@ dependencies = [
 
 [[package]]
 name = "base-common-genesis"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "alloy-chains",
  "alloy-consensus 2.0.5",
@@ -3766,7 +3766,7 @@ dependencies = [
 
 [[package]]
 name = "base-common-network"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-network 2.0.5",
@@ -3784,7 +3784,7 @@ dependencies = [
 
 [[package]]
 name = "base-common-precompiles"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -3800,7 +3800,7 @@ dependencies = [
 
 [[package]]
 name = "base-common-rpc-types"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -3825,7 +3825,7 @@ dependencies = [
 
 [[package]]
 name = "base-common-rpc-types-engine"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -3848,7 +3848,7 @@ dependencies = [
 
 [[package]]
 name = "base-common-signer"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -3868,7 +3868,7 @@ dependencies = [
 
 [[package]]
 name = "base-comp"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -3893,7 +3893,7 @@ dependencies = [
 
 [[package]]
 name = "base-consensus"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "base-cli-utils",
  "base-consensus-cli",
@@ -3902,7 +3902,7 @@ dependencies = [
 
 [[package]]
 name = "base-consensus-cli"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "alloy-chains",
  "alloy-genesis 2.0.5",
@@ -3945,7 +3945,7 @@ dependencies = [
 
 [[package]]
 name = "base-consensus-derive"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -3975,7 +3975,7 @@ dependencies = [
 
 [[package]]
 name = "base-consensus-disc"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "alloy-rlp",
  "backon",
@@ -3998,7 +3998,7 @@ dependencies = [
 
 [[package]]
 name = "base-consensus-engine"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -4041,7 +4041,7 @@ dependencies = [
 
 [[package]]
 name = "base-consensus-gossip"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "alloy-chains",
  "alloy-consensus 2.0.5",
@@ -4080,7 +4080,7 @@ dependencies = [
 
 [[package]]
 name = "base-consensus-node"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "alloy-chains",
  "alloy-consensus 2.0.5",
@@ -4150,7 +4150,7 @@ dependencies = [
 
 [[package]]
 name = "base-consensus-peers"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -4176,7 +4176,7 @@ dependencies = [
 
 [[package]]
 name = "base-consensus-providers"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -4213,7 +4213,7 @@ dependencies = [
 
 [[package]]
 name = "base-consensus-rpc"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-primitives",
@@ -4239,7 +4239,7 @@ dependencies = [
 
 [[package]]
 name = "base-consensus-safedb"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-primitives",
@@ -4255,7 +4255,7 @@ dependencies = [
 
 [[package]]
 name = "base-consensus-sources"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-client 2.0.5",
@@ -4277,7 +4277,7 @@ dependencies = [
 
 [[package]]
 name = "base-consensus-upgrades"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-primitives",
@@ -4289,7 +4289,7 @@ dependencies = [
 
 [[package]]
 name = "base-engine-tree"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "alloy-chains",
  "alloy-consensus 2.0.5",
@@ -4337,7 +4337,7 @@ dependencies = [
 
 [[package]]
 name = "base-execution-chainspec"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "alloy-chains",
  "alloy-consensus 2.0.5",
@@ -4359,7 +4359,7 @@ dependencies = [
 
 [[package]]
 name = "base-execution-cli"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "alloy-eips 2.0.5",
  "backon",
@@ -4414,7 +4414,7 @@ dependencies = [
 
 [[package]]
 name = "base-execution-consensus"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "alloy-chains",
  "alloy-consensus 2.0.5",
@@ -4444,7 +4444,7 @@ dependencies = [
 
 [[package]]
 name = "base-execution-evm"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -4471,7 +4471,7 @@ dependencies = [
 
 [[package]]
 name = "base-execution-exex"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -4497,7 +4497,7 @@ dependencies = [
 
 [[package]]
 name = "base-execution-payload-builder"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -4537,7 +4537,7 @@ dependencies = [
 
 [[package]]
 name = "base-execution-rpc"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -4601,7 +4601,7 @@ dependencies = [
 
 [[package]]
 name = "base-execution-trie"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -4647,7 +4647,7 @@ dependencies = [
 
 [[package]]
 name = "base-execution-txpool"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -4689,7 +4689,7 @@ dependencies = [
 
 [[package]]
 name = "base-flashblocks"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -4745,7 +4745,7 @@ dependencies = [
 
 [[package]]
 name = "base-flashblocks-node"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-contract 2.0.5",
@@ -4801,7 +4801,7 @@ dependencies = [
 
 [[package]]
 name = "base-health"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "alloy-transport-http 2.0.5",
  "async-trait",
@@ -4823,7 +4823,7 @@ dependencies = [
 
 [[package]]
 name = "base-jwt"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "alloy-primitives",
  "alloy-provider 2.0.5",
@@ -4839,7 +4839,7 @@ dependencies = [
 
 [[package]]
 name = "base-load-tester-bin"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "alloy-network 2.0.5",
  "alloy-primitives",
@@ -4861,7 +4861,7 @@ dependencies = [
 
 [[package]]
 name = "base-load-tests"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -4899,7 +4899,7 @@ dependencies = [
 
 [[package]]
 name = "base-metering"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -4953,7 +4953,7 @@ dependencies = [
 
 [[package]]
 name = "base-metrics"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "ctor",
  "metrics",
@@ -4963,7 +4963,7 @@ dependencies = [
 
 [[package]]
 name = "base-node-core"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -5032,7 +5032,7 @@ dependencies = [
 
 [[package]]
 name = "base-node-runner"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-genesis 2.0.5",
@@ -5083,7 +5083,7 @@ dependencies = [
 
 [[package]]
 name = "base-precompile-macros"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "alloy-primitives",
  "proc-macro2",
@@ -5093,7 +5093,7 @@ dependencies = [
 
 [[package]]
 name = "base-precompile-storage"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -5107,7 +5107,7 @@ dependencies = [
 
 [[package]]
 name = "base-proof"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -5145,7 +5145,7 @@ dependencies = [
 
 [[package]]
 name = "base-proof-client"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-evm",
@@ -5168,7 +5168,7 @@ dependencies = [
 
 [[package]]
 name = "base-proof-contracts"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "alloy-contract 2.0.5",
  "alloy-primitives",
@@ -5185,7 +5185,7 @@ dependencies = [
 
 [[package]]
 name = "base-proof-driver"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-evm",
@@ -5205,7 +5205,7 @@ dependencies = [
 
 [[package]]
 name = "base-proof-executor"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -5239,7 +5239,7 @@ dependencies = [
 
 [[package]]
 name = "base-proof-host"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -5280,7 +5280,7 @@ dependencies = [
 
 [[package]]
 name = "base-proof-mpt"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-primitives",
@@ -5301,7 +5301,7 @@ dependencies = [
 
 [[package]]
 name = "base-proof-preimage"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "alloy-primitives",
  "async-channel",
@@ -5315,7 +5315,7 @@ dependencies = [
 
 [[package]]
 name = "base-proof-primitives"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "alloy-chains",
  "alloy-eips 2.0.5",
@@ -5333,7 +5333,7 @@ dependencies = [
 
 [[package]]
 name = "base-proof-rpc"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-network 2.0.5",
@@ -5360,7 +5360,7 @@ dependencies = [
 
 [[package]]
 name = "base-proof-succinct-build-utils"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "cargo_metadata 0.18.1",
  "sp1-build",
@@ -5368,7 +5368,7 @@ dependencies = [
 
 [[package]]
 name = "base-proof-succinct-client-utils"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -5405,7 +5405,7 @@ dependencies = [
 
 [[package]]
 name = "base-proof-succinct-elfs"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "serde",
  "sha2 0.10.9",
@@ -5414,7 +5414,7 @@ dependencies = [
 
 [[package]]
 name = "base-proof-succinct-ethereum-client-utils"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "alloy-genesis 2.0.5",
  "anyhow",
@@ -5431,7 +5431,7 @@ dependencies = [
 
 [[package]]
 name = "base-proof-succinct-ethereum-host-utils"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-primitives",
@@ -5450,7 +5450,7 @@ dependencies = [
 
 [[package]]
 name = "base-proof-succinct-host-utils"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-contract 2.0.5",
@@ -5504,7 +5504,7 @@ dependencies = [
 
 [[package]]
 name = "base-proof-succinct-proof-utils"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "base-proof-succinct-elfs",
@@ -5524,7 +5524,7 @@ dependencies = [
 
 [[package]]
 name = "base-proof-succinct-prove"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "alloy-contract 2.0.5",
  "alloy-eips 2.0.5",
@@ -5559,7 +5559,7 @@ dependencies = [
 
 [[package]]
 name = "base-proof-succinct-scripts"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-network 2.0.5",
@@ -5591,7 +5591,7 @@ dependencies = [
 
 [[package]]
 name = "base-proof-succinct-signer-utils"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -5612,7 +5612,7 @@ dependencies = [
 
 [[package]]
 name = "base-proof-succinct-validity"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-primitives",
@@ -5651,7 +5651,7 @@ dependencies = [
 
 [[package]]
 name = "base-proof-tee-nitro-attestation-prover"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "alloy-primitives",
  "anyhow",
@@ -5669,7 +5669,7 @@ dependencies = [
 
 [[package]]
 name = "base-proof-tee-nitro-enclave"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "alloy-chains",
  "alloy-eips 2.0.5",
@@ -5702,7 +5702,7 @@ dependencies = [
 
 [[package]]
 name = "base-proof-tee-nitro-host"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "alloy-primitives",
  "alloy-signer 2.0.5",
@@ -5726,7 +5726,7 @@ dependencies = [
 
 [[package]]
 name = "base-proof-tee-nitro-verifier"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -5743,7 +5743,7 @@ dependencies = [
 
 [[package]]
 name = "base-proof-tee-registrar"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-primitives",
@@ -5780,7 +5780,7 @@ dependencies = [
 
 [[package]]
 name = "base-proof-tee-registrar-bin"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "alloy-primitives",
  "alloy-provider 2.0.5",
@@ -5810,7 +5810,7 @@ dependencies = [
 
 [[package]]
 name = "base-proofs-extension"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "base-common-consensus",
  "base-execution-exex",
@@ -5829,7 +5829,7 @@ dependencies = [
 
 [[package]]
 name = "base-proposer"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-primitives",
@@ -5867,7 +5867,7 @@ dependencies = [
 
 [[package]]
 name = "base-proposer-bin"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "base-cli-utils",
  "base-proposer",
@@ -5878,7 +5878,7 @@ dependencies = [
 
 [[package]]
 name = "base-protocol"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "alloc-no-stdlib",
  "alloy-consensus 2.0.5",
@@ -5914,7 +5914,7 @@ dependencies = [
 
 [[package]]
 name = "base-prover-nitro-enclave"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "base-proof-tee-nitro-enclave",
  "eyre",
@@ -5923,7 +5923,7 @@ dependencies = [
 
 [[package]]
 name = "base-prover-nitro-host"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "alloy-primitives",
  "base-cli-utils",
@@ -5940,7 +5940,7 @@ dependencies = [
 
 [[package]]
 name = "base-prover-zk"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "base-cli-utils",
  "base-proof-succinct-host-utils",
@@ -5968,14 +5968,14 @@ dependencies = [
 
 [[package]]
 name = "base-reth-cli"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "reth-node-core",
 ]
 
 [[package]]
 name = "base-reth-node"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "base-cli-utils",
  "base-execution-cli",
@@ -5986,11 +5986,11 @@ dependencies = [
 
 [[package]]
 name = "base-ring-buffer"
-version = "1.0.0"
+version = "1.0.1"
 
 [[package]]
 name = "base-runtime"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "futures",
  "rand 0.9.4",
@@ -6002,7 +6002,7 @@ dependencies = [
 
 [[package]]
 name = "base-snapshotter"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6027,7 +6027,7 @@ dependencies = [
 
 [[package]]
 name = "base-snapshotter-bin"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "aws-config",
@@ -6043,7 +6043,7 @@ dependencies = [
 
 [[package]]
 name = "base-snark-e2e"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "base-zk-service",
  "tokio",
@@ -6053,7 +6053,7 @@ dependencies = [
 
 [[package]]
 name = "base-test-utils"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-contract 2.0.5",
@@ -6071,7 +6071,7 @@ dependencies = [
 
 [[package]]
 name = "base-tx-forwarding"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "base-execution-txpool",
  "base-node-runner",
@@ -6081,7 +6081,7 @@ dependencies = [
 
 [[package]]
 name = "base-tx-manager"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -6115,7 +6115,7 @@ dependencies = [
 
 [[package]]
 name = "base-txpool-rpc"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "alloy-primitives",
  "base-node-runner",
@@ -6132,7 +6132,7 @@ dependencies = [
 
 [[package]]
 name = "base-txpool-tracing"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -6163,7 +6163,7 @@ dependencies = [
 
 [[package]]
 name = "base-witness-diff"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "alloy-primitives",
  "alloy-provider 2.0.5",
@@ -6189,7 +6189,7 @@ checksum = "4cbbc9d0964165b47557570cce6c952866c2678457aca742aafc9fb771d30270"
 
 [[package]]
 name = "base-zk-client"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "async-trait",
  "prost 0.14.3",
@@ -6205,7 +6205,7 @@ dependencies = [
 
 [[package]]
 name = "base-zk-db"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6221,7 +6221,7 @@ dependencies = [
 
 [[package]]
 name = "base-zk-outbox"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6234,7 +6234,7 @@ dependencies = [
 
 [[package]]
 name = "base-zk-service"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "alloy-primitives",
  "alloy-provider 2.0.5",
@@ -6320,7 +6320,7 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
 name = "basectl"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "basectl-cli",
@@ -6332,7 +6332,7 @@ dependencies = [
 
 [[package]]
 name = "basectl-cli"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-contract 2.0.5",
@@ -6368,7 +6368,7 @@ dependencies = [
 
 [[package]]
 name = "based"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-primitives",
@@ -6384,7 +6384,7 @@ dependencies = [
 
 [[package]]
 name = "based-bin"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "base-cli-utils",
  "based",
@@ -8463,7 +8463,7 @@ dependencies = [
 
 [[package]]
 name = "devnet"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -11113,7 +11113,7 @@ dependencies = [
 
 [[package]]
 name = "ingress-rpc"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "alloy-provider 2.0.5",
  "anyhow",
@@ -11132,7 +11132,7 @@ dependencies = [
 
 [[package]]
 name = "ingress-rpc-lib"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -24442,7 +24442,7 @@ dependencies = [
 
 [[package]]
 name = "websocket-proxy"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "axum 0.8.9",
  "backoff",
@@ -24463,7 +24463,7 @@ dependencies = [
 
 [[package]]
 name = "websocket-proxy-bin"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "axum 0.8.9",
  "base-cli-utils",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "1.0.0"
+version = "1.0.1"
 edition = "2024"
 rust-version = "1.93"
 license = "MIT"


### PR DESCRIPTION
## Summary

This sets the releases/v1.0.1 workspace version to 1.0.1. It also refreshes Cargo.lock so workspace crates resolve to the same patch version as the release branch.