### PR TITLE
fix(ci): Refresh Base-Anvil Patch Packages

### DIFF
--- a/.github/workflows/base-std-fork-tests.yml
+++ b/.github/workflows/base-std-fork-tests.yml
@@ -80,6 +80,10 @@ jobs:
           cargo \
             --config "patch.\"https://github.com/base/base.git\".base-common-precompiles.path=\"$GITHUB_WORKSPACE/crates/common/precompiles\"" \
             --config "patch.\"https://github.com/base/base.git\".base-common-chains.path=\"$GITHUB_WORKSPACE/crates/common/chains\"" \
+            update -p base-common-precompiles -p base-common-chains
+          cargo \
+            --config "patch.\"https://github.com/base/base.git\".base-common-precompiles.path=\"$GITHUB_WORKSPACE/crates/common/precompiles\"" \
+            --config "patch.\"https://github.com/base/base.git\".base-common-chains.path=\"$GITHUB_WORKSPACE/crates/common/chains\"" \
             build --release --no-default-features --features anvil/cli -p anvil -p forge
 
           "$BASE_ANVIL_DIR/target/release/anvil" --version


### PR DESCRIPTION
## Summary

The Base Std Interface Tests were still building the old base-anvil git-locked base-common crates on the release branch because the local patched crates are versioned 1.1.0. This refreshes the patched packages before building base-anvil so Cargo selects the release checkout paths instead of the stale 0.0.0 git revision. I validated the update path against an exported base-anvil tree and confirmed foundry-evm-networks resolves the patched v1.1.0 crates.