### PR TITLE
fix(proof): correct L2 header error message in fetcher

### DIFF
--- a/crates/proof/succinct/utils/host/src/fetcher.rs
+++ b/crates/proof/succinct/utils/host/src/fetcher.rs
@@ -284,7 +284,7 @@ impl OPSuccinctDataFetcher {
         if let Some(block) = block {
             Ok(block.header.inner)
         } else {
-            bail!("Failed to get L1 header for block {block_number}");
+            bail!("Failed to get L2 header for block {block_number}");
         }
     }
 


### PR DESCRIPTION
`get_l2_header`'s error message mentions "Failed to get L1 header". If I'm understanding it right, I'm guessing this is just a copy/paste typo from `get_l1_header`.