### PR TITLE
feat(builder): add tracing spans for per-tx execution and state root calculation

### DIFF
--- a/crates/builder/core/src/flashblocks/context.rs
+++ b/crates/builder/core/src/flashblocks/context.rs
@@ -38,7 +38,7 @@ use reth_transaction_pool::{BestTransactionsAttributes, PoolTransaction};
 use revm::{DatabaseCommit, context::result::ResultAndState, interpreter::as_u64_saturated};
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
-use tracing::{debug, error, trace, warn, Level, span};
+use tracing::{Level, debug, error, span, trace, warn};
 
 use crate::{
     BuilderConfig, BuilderMetrics, ExecutionInfo, ExecutionMeteringLimitExceeded, PayloadTxsBounds,

--- a/crates/builder/core/src/flashblocks/context.rs
+++ b/crates/builder/core/src/flashblocks/context.rs
@@ -38,7 +38,7 @@ use reth_transaction_pool::{BestTransactionsAttributes, PoolTransaction};
 use revm::{DatabaseCommit, context::result::ResultAndState, interpreter::as_u64_saturated};
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
-use tracing::{debug, error, trace, warn};
+use tracing::{debug, error, trace, warn, Level, span};
 
 use crate::{
     BuilderConfig, BuilderMetrics, ExecutionInfo, ExecutionMeteringLimitExceeded, PayloadTxsBounds,
@@ -901,6 +901,14 @@ impl BasePayloadBuilderCtx {
                     (info.executed_transactions.len() as u64).saturating_sub(min_tx_index);
                 return Ok(diag);
             }
+
+            let tx_span = span!(
+                Level::TRACE,
+                "execute_transaction",
+                tx_hash = %tx_hash,
+                tx_gas_limit = tx.gas_limit(),
+            );
+            let _tx_span_guard = tx_span.enter();
 
             let execution_start_time = Instant::now();
             let ResultAndState { result, state } = match evm.transact(&tx) {

--- a/crates/builder/core/src/flashblocks/payload.rs
+++ b/crates/builder/core/src/flashblocks/payload.rs
@@ -219,8 +219,9 @@ where
         } = args;
 
         // We log only every Nth block based on sampling ratio to reduce usage
+        let block_number = config.parent_header.number + 1;
         let span = if config.parent_header.number.is_multiple_of(self.config.sampling_ratio) {
-            span!(Level::INFO, "build_payload")
+            span!(Level::INFO, "build_payload", block_number)
         } else {
             tracing::Span::none()
         };
@@ -417,6 +418,7 @@ where
 
         // Process flashblocks in a blocking loop
         loop {
+            let flashblock_index = ctx.flashblock_index();
             let fb_span = if span.is_none() {
                 tracing::Span::none()
             } else {
@@ -424,6 +426,7 @@ where
                     parent: &span,
                     Level::INFO,
                     "build_flashblock",
+                    flashblock_index,
                 )
             };
             let _entered = fb_span.enter();

--- a/crates/builder/core/src/flashblocks/payload.rs
+++ b/crates/builder/core/src/flashblocks/payload.rs
@@ -980,6 +980,14 @@ where
     let mut hashed_state = HashedPostState::default();
 
     if calculate_state_root {
+        let state_root_span = span!(
+            Level::INFO,
+            "calculate_state_root",
+            block_number = ctx.block_number(),
+            parent_hash = %ctx.parent().hash(),
+        );
+        let _state_root_span_guard = state_root_span.enter();
+
         let state_provider = state.database.as_ref();
         hashed_state = state_provider.hashed_post_state(&state.bundle_state);
         (state_root, trie_output) =

--- a/crates/builder/publish/src/publisher.rs
+++ b/crates/builder/publish/src/publisher.rs
@@ -7,7 +7,7 @@ use serde::Serialize;
 use tokio::sync::broadcast;
 use tokio_tungstenite::tungstenite::Utf8Bytes;
 use tokio_util::sync::CancellationToken;
-use tracing::info;
+use tracing::{Level, info, span};
 
 use crate::{Listener, PublisherMetrics, PublishingMetrics};
 
@@ -105,8 +105,18 @@ impl WebSocketPublisher {
         block_number: u64,
         flashblock_index: u64,
     ) -> Result<usize, serde_json::Error> {
+        let publish_span = span!(
+            Level::INFO,
+            "publish_flashblock",
+            block_number,
+            flashblock_index,
+            byte_size = tracing::field::Empty,
+        );
+        let _publish_span_guard = publish_span.enter();
+
         let json = serde_json::to_string(payload)?;
         let size = json.len();
+        publish_span.record("byte_size", size);
         let utf8_bytes = Utf8Bytes::from(json);
         let position = FlashblockPosition { block_number, flashblock_index };
 


### PR DESCRIPTION
## Summary

Adds tracing spans throughout the flashblock builder pipeline for observability:

### `build_payload` span (INFO)
- Fields: `block_number`, `payload_id`
- Top-level span for the entire block build job (sampled per `sampling_ratio`)

### `build_flashblock` span (INFO)
- Fields: `flashblock_index`
- Child of `build_payload`, one per flashblock iteration

### `publish_flashblock` span (INFO) — `base-builder-publish`
- Fields: `block_number`, `flashblock_index`, `byte_size`
- Child of `build_flashblock`, wraps the WebSocket broadcast in `WebSocketPublisher::publish`

### `execute_transaction` span (TRACE) — `base-builder-core`
- Fields: `tx_hash`, `tx_gas_limit`
- Child of `build_flashblock`, fires once per transaction that reaches EVM execution (after all pre-execution rejection checks)
- TRACE level to keep it off by default in production

### `calculate_state_root` span (INFO)
- Fields: `block_number`, `parent_hash`
- Wraps `state_root_with_updates` — only fires when `calculate_state_root=true` (canonical block finalization, not intermediate flashblock builds)