### PR TITLE
feat(infra): Add Basectl Pods Monitor

### DIFF
--- a/bin/basectl/src/cli.rs
+++ b/bin/basectl/src/cli.rs
@@ -63,6 +63,9 @@ pub(crate) enum MonitorCommands {
     /// HA conductor cluster monitor
     #[command(visible_alias = "co")]
     Conductor,
+    /// Kubernetes pod monitor
+    #[command(visible_alias = "po")]
+    Pods,
     /// Network upgrade activation countdown and history
     #[command(visible_alias = "u")]
     Upgrades,
@@ -76,6 +79,7 @@ impl MonitorCommands {
             Self::Da => ViewId::DaMonitor,
             Self::CommandCenter => ViewId::CommandCenter,
             Self::Conductor => ViewId::Conductor,
+            Self::Pods => ViewId::Pods,
             Self::Upgrades => ViewId::Upgrades,
         }
     }

--- a/crates/infra/basectl/README.md
+++ b/crates/infra/basectl/README.md
@@ -9,6 +9,22 @@ node sync status, flashblock throughput, and system metrics. `run_app` launches 
 with configurable views. Also supports `run_flashblocks_json` for non-interactive JSON output,
 suitable for piping into other tools.
 
+## Pods View
+
+`basectl monitor pods` displays Kubernetes pod status from groups defined in a
+local network config. Keep environment-specific names, namespaces, contexts, and
+URLs in user-local config; this public crate only stores the generic schema.
+
+```yaml
+pods:
+  refresh_interval_ms: 1000
+  groups:
+    - alias: example
+      label: Example
+      context: example-context
+      namespace: example-namespace
+```
+
 ## Usage
 
 Add the dependency to your `Cargo.toml`:

--- a/crates/infra/basectl/src/app/core.rs
+++ b/crates/infra/basectl/src/app/core.rs
@@ -110,6 +110,7 @@ impl App {
             self.resources.conductor.poll();
             self.resources.validators.poll();
             self.resources.proofs.poll();
+            self.resources.pods.poll();
             // When a conductor cluster is configured, bridge the Raft leader's
             // safe head into the DA tracker each tick.  The conductor poller
             // already queries `sync_status` from every node's CL, so the

--- a/crates/infra/basectl/src/app/mod.rs
+++ b/crates/infra/basectl/src/app/mod.rs
@@ -8,7 +8,8 @@ pub use core::App;
 
 mod resources;
 pub use resources::{
-    ConductorState, DaState, FlashState, ProofsState, Resources, SourceLabel, ValidatorState,
+    ConductorState, DaState, FlashState, PodsState, ProofsState, Resources, SourceLabel,
+    ValidatorState,
 };
 
 mod router;
@@ -31,6 +32,6 @@ pub use view::View;
 mod views;
 pub use views::{
     ActionMenuItem, CommandCenterView, ConductorView, ConfigView, ConfirmButton, DaMonitorView,
-    FlashblocksView, HomeView, Overlay, PendingAction, ProofsView, TransactionPane, UpgradesView,
-    create_view,
+    FlashblocksView, HomeView, Overlay, PendingAction, PodsView, ProofsView, TransactionPane,
+    UpgradesView, create_view,
 };

--- a/crates/infra/basectl/src/app/resources.rs
+++ b/crates/infra/basectl/src/app/resources.rs
@@ -15,7 +15,7 @@ use crate::{
     config::{ConductorNodeConfig, MonitoringConfig},
     rpc::{
         BacklogFetchResult, BlockDaInfo, ConductorNodeStatus, ConductorPollUpdate, L1BlockInfo,
-        L1ConnectionMode, ProofsSnapshot, TimestampedFlashblock, ValidatorNodeStatus,
+        L1ConnectionMode, PodsSnapshot, ProofsSnapshot, TimestampedFlashblock, ValidatorNodeStatus,
     },
     tui::ToastState,
 };
@@ -192,6 +192,29 @@ impl ProofsState {
     }
 }
 
+/// State for Kubernetes pod monitoring.
+#[derive(Debug, Default)]
+pub struct PodsState {
+    /// Most recent Kubernetes pods snapshot.
+    pub snapshot: Option<PodsSnapshot>,
+    rx: Option<mpsc::Receiver<PodsSnapshot>>,
+}
+
+impl PodsState {
+    /// Sets the channel for receiving pods snapshots.
+    pub fn set_channel(&mut self, rx: mpsc::Receiver<PodsSnapshot>) {
+        self.rx = Some(rx);
+    }
+
+    /// Drains the latest pods snapshot from the background poller.
+    pub fn poll(&mut self) {
+        let Some(ref mut rx) = self.rx else { return };
+        while let Ok(snapshot) = rx.try_recv() {
+            self.snapshot = Some(snapshot);
+        }
+    }
+}
+
 /// Shared resources available to all TUI views.
 #[derive(Debug)]
 pub struct Resources {
@@ -209,6 +232,8 @@ pub struct Resources {
     pub validators: ValidatorState,
     /// Proof system monitoring state.
     pub proofs: ProofsState,
+    /// Kubernetes pod monitoring state.
+    pub pods: PodsState,
     /// L1 system config fetched from the contract.
     pub system_config: Option<SystemConfig>,
     sys_config_rx: Option<mpsc::Receiver<SystemConfig>>,
@@ -269,6 +294,7 @@ impl Resources {
             conductor: ConductorState::default(),
             validators: ValidatorState::default(),
             proofs: ProofsState::default(),
+            pods: PodsState::default(),
             system_config: None,
             sys_config_rx: None,
         }

--- a/crates/infra/basectl/src/app/router.rs
+++ b/crates/infra/basectl/src/app/router.rs
@@ -15,6 +15,8 @@ pub enum ViewId {
     Conductor,
     /// Proof system monitor (dispute games, anchor state).
     Proofs,
+    /// Kubernetes pods monitor.
+    Pods,
     /// Network upgrade activation countdown and history.
     Upgrades,
 }

--- a/crates/infra/basectl/src/app/runner.rs
+++ b/crates/infra/basectl/src/app/runner.rs
@@ -11,10 +11,11 @@ use crate::{
     config::{ConductorSource, MonitoringConfig},
     rpc::{
         BacklogFetchResult, BlockDaInfo, ConductorPollUpdate, L1BlockInfo, L1ConnectionMode,
-        ProofsSnapshot, TimestampedFlashblock, ValidatorNodeStatus, fetch_full_system_config,
-        fetch_initial_backlog_with_progress, run_block_fetcher, run_conductor_poller,
-        run_flashblock_ws, run_flashblock_ws_timestamped, run_l1_blob_watcher, run_proofs_poller,
-        run_safe_head_poller, run_validator_poller,
+        PodsSnapshot, ProofsSnapshot, TimestampedFlashblock, ValidatorNodeStatus,
+        fetch_full_system_config, fetch_initial_backlog_with_progress, run_block_fetcher,
+        run_conductor_poller, run_flashblock_ws, run_flashblock_ws_timestamped,
+        run_l1_blob_watcher, run_pods_poller, run_proofs_poller, run_safe_head_poller,
+        run_validator_poller,
     },
     tui::Toast,
 };
@@ -199,6 +200,12 @@ pub fn start_background_services(
             proofs_tx,
             proofs_toast_tx,
         ));
+    }
+
+    if let Some(pods_config) = config.pods.clone() {
+        let (pods_tx, pods_rx) = mpsc::channel::<PodsSnapshot>(4);
+        resources.pods.set_channel(pods_rx);
+        tokio::spawn(run_pods_poller(pods_config, pods_tx));
     }
 }
 

--- a/crates/infra/basectl/src/app/views/factory.rs
+++ b/crates/infra/basectl/src/app/views/factory.rs
@@ -1,6 +1,6 @@
 use super::{
     CommandCenterView, ConductorView, ConfigView, DaMonitorView, FlashblocksView, HomeView,
-    ProofsView, UpgradesView,
+    PodsView, ProofsView, UpgradesView,
 };
 use crate::app::{View, ViewId};
 
@@ -14,6 +14,7 @@ pub fn create_view(view_id: ViewId) -> Box<dyn View> {
         ViewId::Flashblocks => Box::new(FlashblocksView::new()),
         ViewId::Config => Box::new(ConfigView::new()),
         ViewId::Proofs => Box::new(ProofsView::new()),
+        ViewId::Pods => Box::new(PodsView::new()),
         ViewId::Upgrades => Box::new(UpgradesView::new()),
     }
 }

--- a/crates/infra/basectl/src/app/views/home.rs
+++ b/crates/infra/basectl/src/app/views/home.rs
@@ -68,6 +68,13 @@ const MENU_ITEMS: &[MenuItem] = &[
         view_id: Some(ViewId::Conductor),
     },
     MenuItem {
+        key: 'o',
+        label: "Pods",
+        description: "Monitor Kubernetes pod status",
+        badge: Some("config-required"),
+        view_id: Some(ViewId::Pods),
+    },
+    MenuItem {
         key: 'p',
         label: "Proofs",
         description: "Monitor dispute games and anchor state",
@@ -90,6 +97,7 @@ const KEYBINDINGS: &[Keybinding] = &[
     Keybinding { key: "d", description: "DA Monitor" },
     Keybinding { key: "f", description: "Flashblocks" },
     Keybinding { key: "h", description: "HA Conductor" },
+    Keybinding { key: "o", description: "Pods" },
     Keybinding { key: "p", description: "Proofs" },
     Keybinding { key: "u", description: "Upgrades" },
     Keybinding { key: "j/k", description: "Navigate" },
@@ -130,6 +138,7 @@ impl View for HomeView {
             KeyCode::Char('d') => Action::SwitchView(ViewId::DaMonitor),
             KeyCode::Char('f') => Action::SwitchView(ViewId::Flashblocks),
             KeyCode::Char('h') => Action::SwitchView(ViewId::Conductor),
+            KeyCode::Char('o') => Action::SwitchView(ViewId::Pods),
             KeyCode::Char('p') => Action::SwitchView(ViewId::Proofs),
             KeyCode::Char('u') => Action::SwitchView(ViewId::Upgrades),
             KeyCode::Up | KeyCode::Char('k') => {

--- a/crates/infra/basectl/src/app/views/mod.rs
+++ b/crates/infra/basectl/src/app/views/mod.rs
@@ -21,6 +21,9 @@ pub use flashblocks::FlashblocksView;
 mod home;
 pub use home::HomeView;
 
+mod pods;
+pub use pods::PodsView;
+
 mod proofs;
 pub use proofs::ProofsView;
 

--- a/crates/infra/basectl/src/app/views/pods.rs
+++ b/crates/infra/basectl/src/app/views/pods.rs
@@ -1,0 +1,340 @@
+use crossterm::event::{KeyCode, KeyEvent};
+use ratatui::{
+    layout::{Alignment, Constraint, Direction, Layout, Rect},
+    prelude::*,
+    widgets::{Block, Borders, Paragraph},
+};
+
+use crate::{
+    app::{Action, Resources, View},
+    output::COLOR_BASE_BLUE,
+    rpc::{PodGroupStatus, PodStatus, PodsSnapshot},
+    tui::Keybinding,
+};
+
+const KEYBINDINGS: &[Keybinding] = &[
+    Keybinding { key: "Esc", description: "Back to home" },
+    Keybinding { key: "?", description: "Toggle help" },
+    Keybinding { key: "↑/k", description: "Scroll up" },
+    Keybinding { key: "↓/j", description: "Scroll down" },
+    Keybinding { key: "PgUp/PgDn", description: "Page scroll" },
+    Keybinding { key: "g/G", description: "Top/Bottom" },
+];
+
+const READY_WIDTH: usize = 7;
+const STATUS_WIDTH: usize = 18;
+const RESTARTS_WIDTH: usize = 8;
+const AGE_WIDTH: usize = 8;
+const COLUMN_SPACING: usize = 8;
+const MIN_NAME_WIDTH: usize = 22;
+const MAX_NAME_WIDTH: usize = 48;
+const MIN_GROUP_WIDTH: usize = 72;
+const MAX_GROUP_WIDTH: usize = 104;
+
+/// Kubernetes pods view.
+#[derive(Debug, Default)]
+pub struct PodsView {
+    scroll: u16,
+    last_width: u16,
+    last_height: u16,
+}
+
+impl PodsView {
+    /// Creates a new pods view.
+    pub const fn new() -> Self {
+        Self { scroll: 0, last_width: 100, last_height: 24 }
+    }
+
+    /// Returns a display color for Kubernetes pod status.
+    pub fn status_color(status: &str) -> Color {
+        match status {
+            "Running" => Color::Green,
+            "Pending" | "Terminating" => Color::Yellow,
+            "Completed" | "Succeeded" => Color::Cyan,
+            "Error" | "Failed" | "OOMKilled" | "CrashLoopBackOff" | "ImagePullBackOff" => {
+                Color::Red
+            }
+            "Unknown" => Color::DarkGray,
+            _ => Color::White,
+        }
+    }
+
+    /// Returns a display color for Kubernetes restart count.
+    pub fn restart_color(restarts: &str) -> Color {
+        let count = restarts.parse::<u64>().unwrap_or(0);
+        match count {
+            0 => Color::Green,
+            1..=5 => Color::Yellow,
+            _ => Color::Red,
+        }
+    }
+
+    /// Truncates a value to fit in a fixed terminal column.
+    pub fn truncate(value: &str, width: usize) -> String {
+        if value.chars().count() <= width {
+            return value.to_string();
+        }
+        if width <= 3 {
+            return ".".repeat(width);
+        }
+        let keep = width - 3;
+        let mut out: String = value.chars().take(keep).collect();
+        out.push_str("...");
+        out
+    }
+
+    /// Computes the pod group container width for the current viewport.
+    pub fn group_width(width: u16) -> usize {
+        let viewport = usize::from(width).max(1);
+        viewport.min(MAX_GROUP_WIDTH).max(MIN_GROUP_WIDTH.min(viewport))
+    }
+
+    /// Computes the pod-name column width for the current group container.
+    pub fn name_width(group_width: usize) -> usize {
+        let fixed = READY_WIDTH + STATUS_WIDTH + RESTARTS_WIDTH + AGE_WIDTH + COLUMN_SPACING;
+        let available = group_width.saturating_sub(3).saturating_sub(fixed);
+        available.min(MAX_NAME_WIDTH).max(MIN_NAME_WIDTH.min(available))
+    }
+
+    /// Builds all scrollable content lines for a snapshot.
+    pub fn snapshot_lines(snapshot: &PodsSnapshot, width: u16) -> Vec<Line<'static>> {
+        let mut lines = Vec::new();
+        let refreshed = snapshot.refreshed_at.format("%H:%M:%S").to_string();
+        lines.push(Line::from(vec![
+            Span::styled("PODS", Style::default().fg(COLOR_BASE_BLUE).add_modifier(Modifier::BOLD)),
+            Span::styled(format!("  refreshed {refreshed}"), Style::default().fg(Color::DarkGray)),
+        ]));
+
+        if snapshot.groups.is_empty() {
+            lines.push(Line::from(Span::styled(
+                "No pod groups configured.",
+                Style::default().fg(Color::DarkGray),
+            )));
+            return lines;
+        }
+
+        for group in &snapshot.groups {
+            lines.push(Line::raw(""));
+            lines.extend(Self::group_lines(group, width));
+        }
+
+        lines
+    }
+
+    /// Builds rendered lines for one pod group.
+    pub fn group_lines(group: &PodGroupStatus, width: u16) -> Vec<Line<'static>> {
+        let mut lines = Vec::new();
+        let group_width = Self::group_width(width);
+        let name_width = Self::name_width(group_width);
+        let meta = format!("{} · {}", group.group.alias, group.group.namespace);
+
+        lines.push(Self::top_border_line(&group.group.label, group_width));
+        lines.push(Self::boxed_line(
+            vec![(
+                Self::truncate(&meta, group_width.saturating_sub(4)),
+                Style::default().fg(Color::DarkGray),
+            )],
+            group_width,
+        ));
+        lines.push(Self::separator_line(group_width));
+        lines.push(Self::boxed_line(Self::header_parts(name_width), group_width));
+
+        if let Some(error) = group.error.as_ref() {
+            lines.push(Self::boxed_line(
+                vec![(
+                    Self::truncate(error, group_width.saturating_sub(4)),
+                    Style::default().fg(Color::Red),
+                )],
+                group_width,
+            ));
+            lines.push(Self::bottom_border_line(group_width));
+            return lines;
+        }
+
+        if group.pods.is_empty() {
+            lines.push(Self::boxed_line(
+                vec![("no pods".to_string(), Style::default().fg(Color::DarkGray))],
+                group_width,
+            ));
+            lines.push(Self::bottom_border_line(group_width));
+            return lines;
+        }
+
+        for pod in &group.pods {
+            lines.push(Self::pod_line(pod, name_width, group_width));
+        }
+        lines.push(Self::bottom_border_line(group_width));
+        lines
+    }
+
+    fn top_border_line(label: &str, width: usize) -> Line<'static> {
+        let label = Self::truncate(label, width.saturating_sub(8));
+        let label_width = label.chars().count();
+        let fill_width = width.saturating_sub(label_width + 5);
+        Line::from(vec![
+            Span::raw("┌─ "),
+            Span::styled(label, Style::default().fg(Color::White).add_modifier(Modifier::BOLD)),
+            Span::raw(" "),
+            Span::raw("─".repeat(fill_width)),
+            Span::raw("┐"),
+        ])
+    }
+
+    fn separator_line(width: usize) -> Line<'static> {
+        Line::from(format!("├{}┤", "─".repeat(width.saturating_sub(2))))
+    }
+
+    fn bottom_border_line(width: usize) -> Line<'static> {
+        Line::from(format!("└{}┘", "─".repeat(width.saturating_sub(2))))
+    }
+
+    fn boxed_line(parts: Vec<(String, Style)>, width: usize) -> Line<'static> {
+        let content_width: usize = parts.iter().map(|(value, _)| value.chars().count()).sum();
+        let padding = width.saturating_sub(content_width + 3);
+        let mut spans = Vec::with_capacity(parts.len() + 3);
+        spans.push(Span::raw("│ "));
+        spans.extend(parts.into_iter().map(|(value, style)| Span::styled(value, style)));
+        spans.push(Span::raw(" ".repeat(padding)));
+        spans.push(Span::raw("│"));
+        Line::from(spans)
+    }
+
+    fn header_parts(name_width: usize) -> Vec<(String, Style)> {
+        let style = Style::default().fg(Color::DarkGray).add_modifier(Modifier::BOLD);
+        vec![
+            (format!("{:<width$}", "NAME", width = name_width), style),
+            ("  ".to_string(), Style::default()),
+            (format!("{:^READY_WIDTH$}", "READY"), style),
+            ("  ".to_string(), Style::default()),
+            (format!("{:^STATUS_WIDTH$}", "STATUS"), style),
+            ("  ".to_string(), Style::default()),
+            (format!("{:>RESTARTS_WIDTH$}", "RESTARTS"), style),
+            ("  ".to_string(), Style::default()),
+            (format!("{:>AGE_WIDTH$}", "AGE"), style),
+        ]
+    }
+
+    /// Builds a single pod row line.
+    pub fn pod_line(pod: &PodStatus, name_width: usize, group_width: usize) -> Line<'static> {
+        let name = Self::truncate(&pod.name, name_width);
+        let status = Self::truncate(&pod.status, STATUS_WIDTH);
+        Self::boxed_line(
+            vec![
+                (format!("{name:<name_width$}"), Style::default().fg(Color::Cyan)),
+                ("  ".to_string(), Style::default()),
+                (format!("{:^READY_WIDTH$}", pod.ready), Style::default().fg(Color::White)),
+                ("  ".to_string(), Style::default()),
+                (
+                    format!("{status:^STATUS_WIDTH$}"),
+                    Style::default().fg(Self::status_color(&pod.status)),
+                ),
+                ("  ".to_string(), Style::default()),
+                (
+                    format!("{:>RESTARTS_WIDTH$}", pod.restarts),
+                    Style::default().fg(Self::restart_color(&pod.restarts)),
+                ),
+                ("  ".to_string(), Style::default()),
+                (format!("{:>AGE_WIDTH$}", pod.age), Style::default().fg(Color::White)),
+            ],
+            group_width,
+        )
+    }
+
+    /// Returns the maximum scroll offset for the current resources and height.
+    pub fn max_scroll(resources: &Resources, width: u16, height: u16) -> u16 {
+        let line_count = resources
+            .pods
+            .snapshot
+            .as_ref()
+            .map_or(1usize, |snapshot| Self::snapshot_lines(snapshot, width).len());
+        line_count.saturating_sub(usize::from(height)) as u16
+    }
+
+    /// Keeps the scroll offset inside the current content bounds.
+    pub fn clamp_scroll(&mut self, resources: &Resources, width: u16, height: u16) {
+        self.scroll = self.scroll.min(Self::max_scroll(resources, width, height));
+    }
+
+    /// Renders the not-yet-loaded or unconfigured state.
+    pub fn render_empty(frame: &mut Frame<'_>, area: Rect, resources: &Resources) {
+        let message = if resources.config.pods.is_some() {
+            "Loading pods..."
+        } else {
+            "No pod groups configured for this network."
+        };
+        let paragraph = Paragraph::new(message)
+            .alignment(Alignment::Center)
+            .style(Style::default().fg(Color::DarkGray));
+        frame.render_widget(paragraph, area);
+    }
+
+    /// Renders the footer.
+    pub fn render_footer(frame: &mut Frame<'_>, area: Rect) {
+        let key_style = Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD);
+        let desc_style = Style::default().fg(Color::DarkGray);
+        let line = Line::from(vec![
+            Span::styled("[Esc]", key_style),
+            Span::raw(" "),
+            Span::styled("back", desc_style),
+            Span::styled("  |  ", desc_style),
+            Span::styled("[j/k]", key_style),
+            Span::raw(" "),
+            Span::styled("scroll", desc_style),
+            Span::styled("  |  ", desc_style),
+            Span::styled("[n]", key_style),
+            Span::raw(" "),
+            Span::styled("network", desc_style),
+        ]);
+        frame.render_widget(Paragraph::new(line), area);
+    }
+}
+
+impl View for PodsView {
+    fn keybindings(&self) -> &'static [Keybinding] {
+        KEYBINDINGS
+    }
+
+    fn handle_key(&mut self, key: KeyEvent, resources: &mut Resources) -> Action {
+        let max = Self::max_scroll(resources, self.last_width, self.last_height);
+        match key.code {
+            KeyCode::Up | KeyCode::Char('k') => self.scroll = self.scroll.saturating_sub(1),
+            KeyCode::Down | KeyCode::Char('j') => {
+                self.scroll = self.scroll.saturating_add(1).min(max)
+            }
+            KeyCode::PageUp => self.scroll = self.scroll.saturating_sub(10),
+            KeyCode::PageDown => self.scroll = self.scroll.saturating_add(10).min(max),
+            KeyCode::Char('g') => self.scroll = 0,
+            KeyCode::Char('G') => self.scroll = max,
+            _ => {}
+        }
+        Action::None
+    }
+
+    fn render(&mut self, frame: &mut Frame<'_>, area: Rect, resources: &Resources) {
+        let chunks = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([Constraint::Min(0), Constraint::Length(1)])
+            .split(area);
+
+        let block = Block::default()
+            .title(" Pods ")
+            .borders(Borders::ALL)
+            .border_style(Style::default().fg(COLOR_BASE_BLUE));
+        let inner = block.inner(chunks[0]);
+        frame.render_widget(block, chunks[0]);
+
+        self.last_width = inner.width;
+        self.last_height = inner.height;
+        self.clamp_scroll(resources, inner.width, inner.height);
+
+        if let Some(snapshot) = resources.pods.snapshot.as_ref() {
+            let lines = Self::snapshot_lines(snapshot, inner.width);
+            let paragraph = Paragraph::new(lines).scroll((self.scroll, 0));
+            frame.render_widget(paragraph, inner);
+        } else {
+            Self::render_empty(frame, inner, resources);
+        }
+
+        Self::render_footer(frame, chunks[1]);
+    }
+}

--- a/crates/infra/basectl/src/config.rs
+++ b/crates/infra/basectl/src/config.rs
@@ -9,6 +9,53 @@ use serde::{Deserialize, Serialize};
 use tracing::warn;
 use url::Url;
 
+/// Configuration for one Kubernetes pod group rendered by the pods view.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PodGroupConfig {
+    /// Short group alias shown in compact tables.
+    pub alias: String,
+    /// Human-readable group label.
+    pub label: String,
+    /// Kubernetes context passed to `kubectl --context`.
+    pub context: String,
+    /// Kubernetes namespace passed to `kubectl --namespace`.
+    pub namespace: String,
+    /// Optional Kubernetes label selector passed to `kubectl -l`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub selector: Option<String>,
+}
+
+/// Configuration for the Kubernetes pods view.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PodsConfig {
+    /// Optional path to a `kubectl` executable. Defaults to `kubectl` from `PATH`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub kubectl: Option<PathBuf>,
+    /// How often to refresh pod status, in milliseconds.
+    #[serde(default = "default_pods_refresh_interval_ms")]
+    pub refresh_interval_ms: u64,
+    /// Static pod groups from the user's local config file.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub groups: Vec<PodGroupConfig>,
+}
+
+impl PodsConfig {
+    /// Returns the command used to invoke Kubernetes.
+    pub fn kubectl_program(&self) -> PathBuf {
+        self.kubectl.clone().unwrap_or_else(|| PathBuf::from("kubectl"))
+    }
+
+    /// Returns the configured refresh interval, never less than 250 ms.
+    pub const fn refresh_interval(&self) -> std::time::Duration {
+        let millis = if self.refresh_interval_ms < 250 { 250 } else { self.refresh_interval_ms };
+        std::time::Duration::from_millis(millis)
+    }
+}
+
+const fn default_pods_refresh_interval_ms() -> u64 {
+    1_000
+}
+
 /// Configuration for proof system monitoring (proposer + dispute games).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ProofsConfig {
@@ -294,6 +341,9 @@ pub struct MonitoringConfig {
     /// Proof system monitoring configuration (dispute games, anchor state).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub proofs: Option<ProofsConfig>,
+    /// Kubernetes pod groups to display in the pods view.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pods: Option<PodsConfig>,
 }
 
 impl MonitoringConfig {
@@ -377,6 +427,7 @@ struct MonitoringConfigOverride {
     discovery: Option<DiscoveryConfig>,
     validators: Option<Vec<ValidatorNodeConfig>>,
     proofs: Option<ProofsConfig>,
+    pods: Option<PodsConfig>,
 }
 
 impl MonitoringConfig {
@@ -424,6 +475,7 @@ impl MonitoringConfig {
             }),
             validators: None,
             proofs: None,
+            pods: None,
         }
     }
 
@@ -447,6 +499,7 @@ impl MonitoringConfig {
             }),
             validators: None,
             proofs: None,
+            pods: None,
         }
     }
 
@@ -528,6 +581,7 @@ impl MonitoringConfig {
             ]),
             discovery: None,
             proofs: None,
+            pods: None,
         }
     }
 
@@ -646,6 +700,7 @@ impl MonitoringConfig {
             discovery: overrides.discovery.or(base.discovery),
             validators: overrides.validators.or(base.validators),
             proofs: overrides.proofs.or(base.proofs),
+            pods: overrides.pods.or(base.pods),
         })
     }
 

--- a/crates/infra/basectl/src/lib.rs
+++ b/crates/infra/basectl/src/lib.rs
@@ -5,10 +5,10 @@ pub use app::{
     Action, ActionMenuItem, App, BLOB_SIZE, BlockContribution, CommandCenterView, ConductorState,
     ConductorView, ConfigView, ConfirmButton, DaMonitorView, DaState, DaTracker,
     EVENT_POLL_TIMEOUT, FlashState, FlashblockEntry, FlashblocksView, HomeView, L1_BLOCK_WINDOW,
-    L1Block, L1BlockFilter, LoadingState, MAX_HISTORY, Overlay, PendingAction, ProofsState,
-    ProofsView, RATE_WINDOW_2M, RATE_WINDOW_5M, RATE_WINDOW_30S, RateTracker, Resources, Router,
-    SourceLabel, TransactionPane, UpgradesView, ValidatorState, View, ViewId, create_view, run_app,
-    run_flashblocks_json, start_background_services,
+    L1Block, L1BlockFilter, LoadingState, MAX_HISTORY, Overlay, PendingAction, PodsState, PodsView,
+    ProofsState, ProofsView, RATE_WINDOW_2M, RATE_WINDOW_5M, RATE_WINDOW_30S, RateTracker,
+    Resources, Router, SourceLabel, TransactionPane, UpgradesView, ValidatorState, View, ViewId,
+    create_view, run_app, run_flashblocks_json, start_background_services,
 };
 
 mod output;
@@ -24,19 +24,20 @@ pub use output::{
 mod config;
 pub use config::{
     ConductorNodeConfig, ConductorSource, DiscoveryConfig, DiscoveryPorts, MonitoringConfig,
-    ProofsConfig, ValidatorNodeConfig,
+    PodGroupConfig, PodsConfig, ProofsConfig, ValidatorNodeConfig,
 };
 
 mod rpc;
 pub use rpc::{
     BacklogBlock, BacklogFetchResult, BacklogProgress, BlockDaInfo, ConductorNodeStatus,
     ConductorPollUpdate, InitialBacklog, L1BlockInfo, L1ConnectionMode, LatestProposal,
-    PausedPeers, ProofsSnapshot, TimestampedFlashblock, TxSummary, ValidatorNodeStatus,
-    conductor_pause_all_nodes, conductor_pause_node, conductor_resume_all_nodes,
-    conductor_resume_node, decode_flashblock_transactions, fetch_block_transactions,
-    fetch_full_system_config, fetch_initial_backlog_with_progress, fetch_safe_and_latest,
-    pause_sequencer_node, restart_conductor_node, run_block_fetcher, run_conductor_poller,
-    run_flashblock_ws, run_flashblock_ws_timestamped, run_l1_blob_watcher, run_proofs_poller,
+    PausedPeers, PodGroupStatus, PodStatus, PodsPoller, PodsSnapshot, ProofsSnapshot,
+    TimestampedFlashblock, TxSummary, ValidatorNodeStatus, conductor_pause_all_nodes,
+    conductor_pause_node, conductor_resume_all_nodes, conductor_resume_node,
+    decode_flashblock_transactions, fetch_block_transactions, fetch_full_system_config,
+    fetch_initial_backlog_with_progress, fetch_safe_and_latest, pause_sequencer_node,
+    restart_conductor_node, run_block_fetcher, run_conductor_poller, run_flashblock_ws,
+    run_flashblock_ws_timestamped, run_l1_blob_watcher, run_pods_poller, run_proofs_poller,
     run_safe_head_poller, run_validator_poller, start_sequencer_node, stop_sequencer_node,
     transfer_conductor_leader, unpause_sequencer_node,
 };

--- a/crates/infra/basectl/src/rpc/mod.rs
+++ b/crates/infra/basectl/src/rpc/mod.rs
@@ -27,6 +27,9 @@ pub use l1::{L1BlockInfo, L1ConnectionMode, fetch_full_system_config, run_l1_blo
 
 mod p2p;
 
+mod pods;
+pub use pods::{PodGroupStatus, PodStatus, PodsPoller, PodsSnapshot, run_pods_poller};
+
 mod rollup;
 pub use rollup::{
     LatestProposal, ProofsSnapshot, ValidatorNodeStatus, fetch_safe_and_latest, run_proofs_poller,

--- a/crates/infra/basectl/src/rpc/pods.rs
+++ b/crates/infra/basectl/src/rpc/pods.rs
@@ -1,0 +1,177 @@
+//! Kubernetes pod polling helpers for basectl.
+
+use std::{
+    path::{Path, PathBuf},
+    time::Duration,
+};
+
+use tokio::sync::mpsc;
+
+use crate::config::{PodGroupConfig, PodsConfig};
+
+/// Live status row for a single Kubernetes pod.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PodStatus {
+    /// Pod name from `kubectl get pods`.
+    pub name: String,
+    /// Ready container count, e.g. `2/2`.
+    pub ready: String,
+    /// Kubernetes pod status.
+    pub status: String,
+    /// Restart count as rendered by `kubectl`.
+    pub restarts: String,
+    /// Pod age as rendered by `kubectl`.
+    pub age: String,
+}
+
+/// Live status snapshot for one configured Kubernetes pod group.
+#[derive(Debug, Clone)]
+pub struct PodGroupStatus {
+    /// Group definition used for this query.
+    pub group: PodGroupConfig,
+    /// Pods returned by Kubernetes for this group.
+    pub pods: Vec<PodStatus>,
+    /// Query error, if this group could not be fetched.
+    pub error: Option<String>,
+}
+
+/// Latest Kubernetes pods snapshot consumed by the pods view.
+#[derive(Debug, Clone)]
+pub struct PodsSnapshot {
+    /// Per-group pod status.
+    pub groups: Vec<PodGroupStatus>,
+    /// Local time when this snapshot was refreshed.
+    pub refreshed_at: chrono::DateTime<chrono::Local>,
+}
+
+/// Kubernetes pod polling helpers.
+#[derive(Debug)]
+pub struct PodsPoller;
+
+impl PodsPoller {
+    /// Builds one pods snapshot by querying each configured Kubernetes group.
+    pub async fn snapshot(config: &PodsConfig) -> PodsSnapshot {
+        let kubectl = config.kubectl_program();
+        let statuses = futures::future::join_all(config.groups.clone().into_iter().map(|group| {
+            let kubectl = kubectl.clone();
+            async move { Self::fetch_group(&kubectl, group).await }
+        }))
+        .await;
+
+        PodsSnapshot { groups: statuses, refreshed_at: chrono::Local::now() }
+    }
+
+    /// Queries Kubernetes for one pod group.
+    pub async fn fetch_group(kubectl: &Path, group: PodGroupConfig) -> PodGroupStatus {
+        const KUBECTL_TIMEOUT: Duration = Duration::from_secs(15);
+
+        let mut command = tokio::process::Command::new(Self::expand_user_path(kubectl));
+        command.args([
+            "--context",
+            &group.context,
+            "--namespace",
+            &group.namespace,
+            "get",
+            "pods",
+            "--no-headers",
+        ]);
+        if let Some(selector) = group.selector.as_ref() {
+            command.args(["-l", selector]);
+        }
+
+        let output = tokio::time::timeout(KUBECTL_TIMEOUT, command.output()).await;
+        match output {
+            Ok(Ok(out)) if out.status.success() => {
+                let stdout = String::from_utf8_lossy(&out.stdout);
+                PodGroupStatus { group, pods: Self::parse_kubectl_pods(&stdout), error: None }
+            }
+            Ok(Ok(out)) => {
+                let stderr = String::from_utf8_lossy(&out.stderr);
+                let stdout = String::from_utf8_lossy(&out.stdout);
+                let detail = if stderr.trim().is_empty() { stdout.trim() } else { stderr.trim() };
+                PodGroupStatus {
+                    group,
+                    pods: Vec::new(),
+                    error: Some(format!("kubectl get pods failed: {detail}")),
+                }
+            }
+            Ok(Err(error)) => PodGroupStatus {
+                group,
+                pods: Vec::new(),
+                error: Some(format!("kubectl failed to start: {error}")),
+            },
+            Err(_) => {
+                PodGroupStatus { group, pods: Vec::new(), error: Some("kubectl timed out".into()) }
+            }
+        }
+    }
+
+    /// Parses `kubectl get pods --no-headers` output.
+    pub fn parse_kubectl_pods(stdout: &str) -> Vec<PodStatus> {
+        stdout
+            .lines()
+            .filter_map(|line| {
+                let parts: Vec<&str> = line.split_whitespace().collect();
+                let name = parts.first()?;
+                let ready = parts.get(1).copied().unwrap_or("-");
+                let status = parts.get(2).copied().unwrap_or("-");
+                let restarts = parts.get(3).copied().unwrap_or("-");
+                let age = parts.last().copied().unwrap_or("-");
+                Some(PodStatus {
+                    name: (*name).to_string(),
+                    ready: ready.to_string(),
+                    status: status.to_string(),
+                    restarts: restarts.to_string(),
+                    age: age.to_string(),
+                })
+            })
+            .collect()
+    }
+
+    /// Expands a leading `~` in a user-configured executable path.
+    pub fn expand_user_path(path: &Path) -> PathBuf {
+        let Some(raw) = path.to_str() else { return path.to_path_buf() };
+        if raw == "~" {
+            return dirs::home_dir().unwrap_or_else(|| path.to_path_buf());
+        }
+        let Some(rest) = raw.strip_prefix("~/") else { return path.to_path_buf() };
+        dirs::home_dir().map_or_else(|| path.to_path_buf(), |home| home.join(rest))
+    }
+}
+
+/// Polls Kubernetes pods at the configured interval and forwards snapshots.
+pub async fn run_pods_poller(config: PodsConfig, tx: mpsc::Sender<PodsSnapshot>) {
+    let mut interval = tokio::time::interval(config.refresh_interval());
+    interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+
+    loop {
+        interval.tick().await;
+
+        let snapshot = PodsPoller::snapshot(&config).await;
+        if tx.send(snapshot).await.is_err() {
+            break;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::PodsPoller;
+
+    #[test]
+    fn parses_kubectl_pod_rows() {
+        let pods = PodsPoller::parse_kubectl_pods(
+            "example-a 2/2 Running 0 4d\nexample-b 1/2 CrashLoopBackOff 7 (1m ago) 2h\n",
+        );
+
+        assert_eq!(pods.len(), 2);
+        assert_eq!(pods[0].name, "example-a");
+        assert_eq!(pods[0].ready, "2/2");
+        assert_eq!(pods[0].status, "Running");
+        assert_eq!(pods[0].restarts, "0");
+        assert_eq!(pods[0].age, "4d");
+        assert_eq!(pods[1].name, "example-b");
+        assert_eq!(pods[1].restarts, "7");
+        assert_eq!(pods[1].age, "2h");
+    }
+}


### PR DESCRIPTION
## Summary

This adds a `basectl monitor pods` view that displays Kubernetes pod status for configured groups. It introduces pod monitoring config, a background kubectl poller, and TUI rendering with empty and error states. The CLI and README are updated for the new monitor view.