### PR TITLE
feat(basectl): add `block <ref>` subcommand

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6499,6 +6499,8 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 name = "basectl"
 version = "0.0.0"
 dependencies = [
+ "alloy-eips 2.0.5",
+ "alloy-primitives",
  "alloy-provider 2.0.5",
  "alloy-rpc-types-eth 2.0.5",
  "anyhow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6506,8 +6506,11 @@ dependencies = [
  "anyhow",
  "base-common-network",
  "basectl-cli",
+ "chrono",
  "clap",
  "rustls 0.23.40",
+ "serde",
+ "serde_json",
  "tokio",
  "url",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6499,7 +6499,10 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 name = "basectl"
 version = "0.0.0"
 dependencies = [
+ "alloy-provider 2.0.5",
+ "alloy-rpc-types-eth 2.0.5",
  "anyhow",
+ "base-common-network",
  "basectl-cli",
  "clap",
  "rustls 0.23.40",

--- a/bin/basectl/Cargo.toml
+++ b/bin/basectl/Cargo.toml
@@ -15,6 +15,9 @@ workspace = true
 url = { workspace = true }
 anyhow = { workspace = true }
 basectl-cli = { workspace = true }
+alloy-provider = { workspace = true }
+base-common-network = { workspace = true }
 rustls = { workspace = true, features = ["ring"] }
 clap = { workspace = true, features = ["derive", "env"] }
+alloy-rpc-types-eth = { workspace = true, features = ["std"] }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }

--- a/bin/basectl/Cargo.toml
+++ b/bin/basectl/Cargo.toml
@@ -14,12 +14,17 @@ workspace = true
 [dependencies]
 url = { workspace = true }
 anyhow = { workspace = true }
+chrono = { workspace = true }
 alloy-eips = { workspace = true }
 basectl-cli = { workspace = true }
 alloy-provider = { workspace = true }
 base-common-network = { workspace = true }
 rustls = { workspace = true, features = ["ring"] }
 clap = { workspace = true, features = ["derive", "env"] }
+serde = { workspace = true, features = ["derive", "std"] }
 alloy-primitives = { workspace = true, features = ["serde"] }
 alloy-rpc-types-eth = { workspace = true, features = ["std"] }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
+
+[dev-dependencies]
+serde_json = { workspace = true }

--- a/bin/basectl/Cargo.toml
+++ b/bin/basectl/Cargo.toml
@@ -14,10 +14,12 @@ workspace = true
 [dependencies]
 url = { workspace = true }
 anyhow = { workspace = true }
+alloy-eips = { workspace = true }
 basectl-cli = { workspace = true }
 alloy-provider = { workspace = true }
 base-common-network = { workspace = true }
 rustls = { workspace = true, features = ["ring"] }
 clap = { workspace = true, features = ["derive", "env"] }
+alloy-primitives = { workspace = true, features = ["serde"] }
 alloy-rpc-types-eth = { workspace = true, features = ["std"] }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }

--- a/bin/basectl/README.md
+++ b/bin/basectl/README.md
@@ -51,14 +51,16 @@ supported (alloy's typed block can't deserialize null number/hash).
 
 | Flag | Description |
 |------|-------------|
-| `--json` | Emit pretty JSON instead of the key-value table. |
+| `--json` | Emit humanized JSON (decoded numeric values, ISO + local timestamps, `network`/`reference` context fields) instead of the key-value table. |
+| `--raw` | With `--json`, emit the JSON-RPC wire format (camelCase field names, hex-string quantities, no `network`/`reference` wrapper) instead of the humanized form. Useful for round-tripping through `cast` or other JSON-RPC-aware tooling. Errors at parse time if used without `--json`. |
 
 Pretty mode converts hex quantities to decimal and Unix timestamps to
-`YYYY-MM-DD HH:MM:SS UTC`. JSON mode preserves the JSON-RPC wire format —
-camelCase field names, hex-string quantities — so it round-trips cleanly
-through any JSON-RPC-aware tool. All header fields are at the top level of
-the JSON object (no `.header` wrapper), matching the `eth_getBlockByNumber`
-response shape.
+`YYYY-MM-DD HH:MM:SS UTC`. Humanized JSON (`--json`) decodes numeric values
+(`number: 42417649`, `gasUsed: 5345789`, `baseFeePerGasWei: 5000000`) and
+gives you a nested `timestamp` object with `unix`/`utc`/`local` fields so
+the operator's wall clock is readable without timezone math. Raw JSON
+(`--json --raw`) preserves the alloy/JSON-RPC wire format with hex
+quantities at the top level — byte-equivalent to `cast block --json`.
 
 ### `basectl flashblocks`
 
@@ -95,4 +97,10 @@ basectl -c mainnet b latest
 
 # Look up a block by 32-byte hash (canonical, orphan, or reorged-out)
 basectl -c sepolia block 0x9fa0d82dfdf395d552e92caec6a9d5482c53f1800e8f3ff29994b7a431447148
+
+# Humanized JSON: decoded numbers, nested timestamp with utc + local, network context
+basectl -c sepolia block --json latest | jq '{number, gasUsed, baseFeePerGasWei, timestamp}'
+
+# Raw (wire) JSON: same shape as `cast block --json`, useful for round-tripping
+basectl -c mainnet block --json --raw finalized | jq '{number, gasUsed, baseFeePerGas}'
 ```

--- a/bin/basectl/README.md
+++ b/bin/basectl/README.md
@@ -33,8 +33,9 @@ Opens the interactive TUI. With no subcommand, opens the Home view.
 
 ### `basectl block <REF>`
 
-Inspects a single L2 block via `eth_getBlockByNumber` and prints either an
-aligned key-value table (default) or the full block as pretty JSON (`--json`).
+Inspects a single L2 block via `eth_getBlockByHash` or `eth_getBlockByNumber`
+(alloy dispatches based on the reference shape) and prints either an aligned
+key-value table (default) or the full block as pretty JSON (`--json`).
 Visible alias: `b`.
 
 `<REF>` accepts:
@@ -42,9 +43,11 @@ Visible alias: `b`.
 - A decimal block number (e.g. `42417649`)
 - A `0x`-hex block number (e.g. `0x2871c71`)
 - A tag: `latest`, `safe`, `finalized`, `earliest`
+- A 32-byte block hash (`0x` + 64 hex chars)
 
-Block-hash references (a `0x`-prefixed 32-byte hex string) are explicitly
-rejected — pass a number or tag instead.
+Hash lookups can return blocks regardless of canonical-chain status — orphans
+and reorged-out heads are also fetchable by hash. The `pending` tag is not
+supported (alloy's typed block can't deserialize null number/hash).
 
 | Flag | Description |
 |------|-------------|
@@ -89,4 +92,7 @@ basectl -c mainnet block --json finalized | jq '{number, hash, gasUsed, baseFeeP
 
 # Use the visible alias `b`
 basectl -c mainnet b latest
+
+# Look up a block by 32-byte hash (canonical, orphan, or reorged-out)
+basectl -c sepolia block 0x9fa0d82dfdf395d552e92caec6a9d5482c53f1800e8f3ff29994b7a431447148
 ```

--- a/bin/basectl/README.md
+++ b/bin/basectl/README.md
@@ -31,10 +31,36 @@ Opens the interactive TUI. With no subcommand, opens the Home view.
 | `monitor upgrades` | `u` | Network upgrade activation countdown and history |
 | `monitor config` | `c` | Chain configuration view |
 
+### `basectl block <REF>`
+
+Inspects a single L2 block via `eth_getBlockByNumber` and prints either an
+aligned key-value table (default) or the full block as pretty JSON (`--json`).
+Visible alias: `b`.
+
+`<REF>` accepts:
+
+- A decimal block number (e.g. `42417649`)
+- A `0x`-hex block number (e.g. `0x2871c71`)
+- A tag: `latest`, `safe`, `finalized`, `earliest`
+
+Block-hash references (a `0x`-prefixed 32-byte hex string) are explicitly
+rejected — pass a number or tag instead.
+
+| Flag | Description |
+|------|-------------|
+| `--json` | Emit pretty JSON instead of the key-value table. |
+
+Pretty mode converts hex quantities to decimal and Unix timestamps to
+`YYYY-MM-DD HH:MM:SS UTC`. JSON mode preserves the JSON-RPC wire format —
+camelCase field names, hex-string quantities — so it round-trips cleanly
+through any JSON-RPC-aware tool. All header fields are at the top level of
+the JSON object (no `.header` wrapper), matching the `eth_getBlockByNumber`
+response shape.
+
 ### `basectl flashblocks`
 
-Streams live flashblocks as newline-delimited JSON to stdout. This is the only
-non-TUI subcommand. For the interactive view, use `basectl monitor flashblocks`.
+Streams live flashblocks as newline-delimited JSON to stdout. For the
+interactive view, use `basectl monitor flashblocks`.
 
 ## Examples
 
@@ -50,4 +76,17 @@ basectl monitor conductor
 
 # Stream flashblocks as JSONL on sepolia
 basectl -c sepolia flashblocks
+
+# Inspect the latest block on sepolia
+basectl -c sepolia block latest
+
+# Decimal and 0x-hex refs produce identical output apart from the `reference` row
+basectl -c sepolia block 42417649
+basectl -c sepolia block 0x2871c71
+
+# JSON mode pipes cleanly into jq (header fields are top-level, hex quantities preserved)
+basectl -c mainnet block --json finalized | jq '{number, hash, gasUsed, baseFeePerGas}'
+
+# Use the visible alias `b`
+basectl -c mainnet b latest
 ```

--- a/bin/basectl/src/block.rs
+++ b/bin/basectl/src/block.rs
@@ -11,9 +11,12 @@ use basectl_cli::{
 
 /// Parses a CLI block reference into alloy's `BlockNumberOrTag`.
 ///
-/// Adds two behaviors on top of `BlockNumberOrTag::FromStr`: bare decimal
-/// numbers (alloy requires `0x` on numbers) and explicit rejection of
-/// 64-hex-char block-hash references.
+/// Adds three behaviors on top of `BlockNumberOrTag::FromStr`: bare decimal
+/// numbers (alloy requires `0x` on numbers), explicit rejection of
+/// 64-hex-char block-hash references, and rejection of the `pending` tag
+/// (alloy's typed `Block` can't deserialize a pending block's null number
+/// and hash, so accepting it here would only produce a confusing error
+/// after a wasted RPC round-trip).
 pub(crate) fn parse_block_ref(s: &str) -> Result<BlockNumberOrTag> {
     let trimmed = s.trim();
     if trimmed.is_empty() {
@@ -28,7 +31,14 @@ pub(crate) fn parse_block_ref(s: &str) -> Result<BlockNumberOrTag> {
     {
         bail!("block hash references are not supported; use a block number or tag");
     }
-    trimmed.parse::<BlockNumberOrTag>().map_err(|e| anyhow!("invalid block reference: {e}"))
+    let tag =
+        trimmed.parse::<BlockNumberOrTag>().map_err(|e| anyhow!("invalid block reference: {e}"))?;
+    if tag == BlockNumberOrTag::Pending {
+        bail!(
+            "the `pending` tag is not supported; use `latest`, `safe`, `finalized`, or `earliest`"
+        );
+    }
+    Ok(tag)
 }
 
 /// Runs the `basectl block` subcommand.
@@ -108,7 +118,17 @@ mod tests {
         assert_eq!(parse_block_ref("safe").unwrap(), BlockNumberOrTag::Safe);
         assert_eq!(parse_block_ref("finalized").unwrap(), BlockNumberOrTag::Finalized);
         assert_eq!(parse_block_ref("earliest").unwrap(), BlockNumberOrTag::Earliest);
-        assert_eq!(parse_block_ref("pending").unwrap(), BlockNumberOrTag::Pending);
+    }
+
+    #[test]
+    fn rejects_pending() {
+        for input in ["pending", "Pending", "PENDING"] {
+            let err = parse_block_ref(input).unwrap_err().to_string();
+            assert!(
+                err.contains("`pending` tag is not supported"),
+                "expected pending rejection for {input:?}, got: {err}",
+            );
+        }
     }
 
     #[test]

--- a/bin/basectl/src/block.rs
+++ b/bin/basectl/src/block.rs
@@ -127,7 +127,7 @@ struct TimestampJson {
 
 impl TimestampJson {
     fn from_unix(secs: u64) -> Self {
-        let dt = DateTime::from_timestamp(secs as i64, 0);
+        let dt = i64::try_from(secs).ok().and_then(|s| DateTime::from_timestamp(s, 0));
         let utc = dt
             .map(|t| t.to_rfc3339_opts(SecondsFormat::Secs, true))
             .unwrap_or_else(|| secs.to_string());
@@ -258,6 +258,19 @@ mod tests {
         let local_has_offset =
             ts.local.contains('+') || ts.local.matches('-').count() >= 3 || ts.local.ends_with('Z');
         assert!(local_has_offset, "expected local RFC 3339 with offset, got {}", ts.local);
+    }
+
+    #[test]
+    fn timestamp_json_falls_back_on_u64_overflow() {
+        // u64 values above i64::MAX would silently wrap to a negative i64 under
+        // an `as i64` cast, producing a misleading pre-epoch RFC 3339 string.
+        // The try_from guard converts that case to None, triggering the raw
+        // seconds fallback for both utc and local.
+        let oversize = super::TimestampJson::from_unix(u64::MAX);
+
+        assert_eq!(oversize.unix, u64::MAX);
+        assert_eq!(oversize.utc, u64::MAX.to_string());
+        assert_eq!(oversize.local, u64::MAX.to_string());
     }
 
     #[test]

--- a/bin/basectl/src/block.rs
+++ b/bin/basectl/src/block.rs
@@ -1,0 +1,127 @@
+//! Implementation of the `basectl block <ref>` subcommand.
+
+use alloy_provider::Network;
+use alloy_rpc_types_eth::BlockNumberOrTag;
+use anyhow::{Result, anyhow, bail};
+use base_common_network::Base;
+use basectl_cli::{
+    JsonOutput, KeyValueTable, MonitoringConfig, fetch_block, format_bytes, format_gas,
+    format_gwei, format_unix_timestamp,
+};
+
+/// Parses a CLI block reference into alloy's `BlockNumberOrTag`.
+///
+/// Adds two behaviors on top of `BlockNumberOrTag::FromStr`: bare decimal
+/// numbers (alloy requires `0x` on numbers) and explicit rejection of
+/// 64-hex-char block-hash references.
+pub(crate) fn parse_block_ref(s: &str) -> Result<BlockNumberOrTag> {
+    let trimmed = s.trim();
+    if trimmed.is_empty() {
+        bail!("invalid block reference: empty input");
+    }
+    if let Ok(number) = trimmed.parse::<u64>() {
+        return Ok(BlockNumberOrTag::Number(number));
+    }
+    if let Some(hex) = trimmed.strip_prefix("0x").or_else(|| trimmed.strip_prefix("0X"))
+        && hex.len() == 64
+        && hex.chars().all(|c| c.is_ascii_hexdigit())
+    {
+        bail!("block hash references are not supported; use a block number or tag");
+    }
+    trimmed.parse::<BlockNumberOrTag>().map_err(|e| anyhow!("invalid block reference: {e}"))
+}
+
+/// Runs the `basectl block` subcommand.
+pub(crate) async fn run(config: MonitoringConfig, reference: &str, json: bool) -> Result<()> {
+    let block_ref = parse_block_ref(reference)?;
+    let block = fetch_block(&config.rpc, block_ref).await?;
+    if json {
+        JsonOutput::print(&block)?;
+    } else {
+        print_pretty(&config.name, block_ref, &block)?;
+    }
+    Ok(())
+}
+
+fn print_pretty(
+    network: &str,
+    reference: BlockNumberOrTag,
+    block: &<Base as Network>::BlockResponse,
+) -> Result<()> {
+    let header = &block.header;
+    let mut table = KeyValueTable::new();
+    table
+        .row("network", network)
+        .row("reference", reference.to_string())
+        .row("number", header.number.to_string())
+        .row("hash", format!("{:#x}", header.hash))
+        .row("parent_hash", format!("{:#x}", header.parent_hash))
+        .row(
+            "timestamp",
+            format!("{} ({})", header.timestamp, format_unix_timestamp(header.timestamp)),
+        )
+        .row("transactions", block.transactions.len().to_string())
+        .row("gas_used", format_gas(header.gas_used))
+        .row("gas_limit", format_gas(header.gas_limit));
+    if let Some(base_fee) = header.base_fee_per_gas {
+        table.row("base_fee_per_gas", format_gwei(u128::from(base_fee)));
+    }
+    if let Some(size) = header.size
+        && let Ok(size_u64) = u64::try_from(size)
+    {
+        table.row("size", format_bytes(size_u64));
+    }
+    if let Some(blob_gas_used) = header.blob_gas_used {
+        table.row("blob_gas_used", format_gas(blob_gas_used));
+    }
+    if let Some(excess_blob_gas) = header.excess_blob_gas {
+        table.row("excess_blob_gas", format_gas(excess_blob_gas));
+    }
+    if let Some(withdrawals) = block.withdrawals.as_ref() {
+        table.row("withdrawals", withdrawals.len().to_string());
+    }
+    table.print()?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_rpc_types_eth::BlockNumberOrTag;
+
+    use super::parse_block_ref;
+
+    #[test]
+    fn parses_decimal() {
+        assert_eq!(parse_block_ref("123").unwrap(), BlockNumberOrTag::Number(123));
+        assert_eq!(parse_block_ref("  42  ").unwrap(), BlockNumberOrTag::Number(42));
+    }
+
+    #[test]
+    fn parses_hex() {
+        assert_eq!(parse_block_ref("0x1a").unwrap(), BlockNumberOrTag::Number(26));
+        assert_eq!(parse_block_ref("0X1A").unwrap(), BlockNumberOrTag::Number(26));
+    }
+
+    #[test]
+    fn parses_tags() {
+        assert_eq!(parse_block_ref("latest").unwrap(), BlockNumberOrTag::Latest);
+        assert_eq!(parse_block_ref("safe").unwrap(), BlockNumberOrTag::Safe);
+        assert_eq!(parse_block_ref("finalized").unwrap(), BlockNumberOrTag::Finalized);
+        assert_eq!(parse_block_ref("earliest").unwrap(), BlockNumberOrTag::Earliest);
+        assert_eq!(parse_block_ref("pending").unwrap(), BlockNumberOrTag::Pending);
+    }
+
+    #[test]
+    fn rejects_64_hex_char_hash() {
+        let hash = format!("0x{}", "11".repeat(32));
+        let err = parse_block_ref(&hash).unwrap_err().to_string();
+        assert!(err.contains("hash references are not supported"));
+    }
+
+    #[test]
+    fn rejects_invalid_input() {
+        assert!(parse_block_ref("notatag").is_err());
+        assert!(parse_block_ref("").is_err());
+        assert!(parse_block_ref("   ").is_err());
+    }
+}

--- a/bin/basectl/src/block.rs
+++ b/bin/basectl/src/block.rs
@@ -10,6 +10,8 @@ use basectl_cli::{
     JsonOutput, KeyValueTable, MonitoringConfig, fetch_block, format_bytes, format_gas,
     format_gwei, format_unix_timestamp,
 };
+use chrono::{DateTime, Local, SecondsFormat};
+use serde::Serialize;
 
 /// Parses a CLI block reference into alloy's `BlockId`.
 ///
@@ -46,15 +48,94 @@ pub(crate) fn parse_block_ref(s: &str) -> Result<BlockId> {
 }
 
 /// Runs the `basectl block` subcommand.
-pub(crate) async fn run(config: MonitoringConfig, reference: &str, json: bool) -> Result<()> {
+pub(crate) async fn run(
+    config: MonitoringConfig,
+    reference: &str,
+    json: bool,
+    raw: bool,
+) -> Result<()> {
     let block_ref = parse_block_ref(reference)?;
     let block = fetch_block(&config.rpc, block_ref).await?;
-    if json {
-        JsonOutput::print(&block)?;
-    } else {
-        print_pretty(&config.name, block_ref, &block)?;
+    match (json, raw) {
+        (true, true) => JsonOutput::print(&block)?,
+        (true, false) => {
+            let summary = BlockSummaryJson::from_block(&config.name, block_ref, &block);
+            JsonOutput::print(&summary)?;
+        }
+        (false, _) => print_pretty(&config.name, block_ref, &block)?,
     }
     Ok(())
+}
+
+/// Humanized JSON shape for the `basectl block --json` output.
+///
+/// Mirrors the field selection of `print_pretty`, but with decoded numeric
+/// values instead of the JSON-RPC wire format's hex-string quantities.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct BlockSummaryJson {
+    network: String,
+    reference: String,
+    number: u64,
+    hash: B256,
+    parent_hash: B256,
+    timestamp: TimestampJson,
+    transactions: usize,
+    gas_used: u64,
+    gas_limit: u64,
+    base_fee_per_gas_wei: Option<u128>,
+    size_bytes: Option<u64>,
+    blob_gas_used: Option<u64>,
+    excess_blob_gas: Option<u64>,
+    withdrawals: Option<usize>,
+}
+
+impl BlockSummaryJson {
+    fn from_block(
+        network: &str,
+        reference: BlockId,
+        block: &<Base as Network>::BlockResponse,
+    ) -> Self {
+        let header = &block.header;
+        Self {
+            network: network.to_string(),
+            reference: reference.to_string(),
+            number: header.number,
+            hash: header.hash,
+            parent_hash: header.parent_hash,
+            timestamp: TimestampJson::from_unix(header.timestamp),
+            transactions: block.transactions.len(),
+            gas_used: header.gas_used,
+            gas_limit: header.gas_limit,
+            base_fee_per_gas_wei: header.base_fee_per_gas.map(u128::from),
+            size_bytes: header.size.and_then(|size| u64::try_from(size).ok()),
+            blob_gas_used: header.blob_gas_used,
+            excess_blob_gas: header.excess_blob_gas,
+            withdrawals: block.withdrawals.as_ref().map(|w| w.len()),
+        }
+    }
+}
+
+/// Three-form timestamp object: raw unix seconds, UTC RFC 3339, and local
+/// RFC 3339 (operator's machine timezone with offset suffix).
+#[derive(Debug, Clone, Serialize)]
+struct TimestampJson {
+    unix: u64,
+    utc: String,
+    local: String,
+}
+
+impl TimestampJson {
+    fn from_unix(secs: u64) -> Self {
+        let dt = DateTime::from_timestamp(secs as i64, 0);
+        let utc = dt
+            .map(|t| t.to_rfc3339_opts(SecondsFormat::Secs, true))
+            .unwrap_or_else(|| secs.to_string());
+        let local = dt
+            .map(|t| t.with_timezone(&Local).to_rfc3339_opts(SecondsFormat::Secs, false))
+            .unwrap_or_else(|| secs.to_string());
+        Self { unix: secs, utc, local }
+    }
 }
 
 fn print_pretty(
@@ -165,5 +246,56 @@ mod tests {
         assert!(parse_block_ref("notatag").is_err());
         assert!(parse_block_ref("").is_err());
         assert!(parse_block_ref("   ").is_err());
+    }
+
+    #[test]
+    fn timestamp_json_renders_three_forms() {
+        let ts = super::TimestampJson::from_unix(1_780_614_804);
+
+        assert_eq!(ts.unix, 1_780_614_804);
+        assert!(ts.utc.ends_with('Z'), "expected UTC suffix Z, got {}", ts.utc);
+        assert!(ts.utc.starts_with("2026-06-04"), "expected UTC date prefix, got {}", ts.utc);
+        let local_has_offset =
+            ts.local.contains('+') || ts.local.matches('-').count() >= 3 || ts.local.ends_with('Z');
+        assert!(local_has_offset, "expected local RFC 3339 with offset, got {}", ts.local);
+    }
+
+    #[test]
+    fn block_summary_json_serializes_with_camel_case_and_nested_timestamp() {
+        let summary = super::BlockSummaryJson {
+            network: "sepolia".to_string(),
+            reference: "latest".to_string(),
+            number: 42,
+            hash: B256::repeat_byte(0x11),
+            parent_hash: B256::repeat_byte(0x22),
+            timestamp: super::TimestampJson::from_unix(1_780_614_804),
+            transactions: 7,
+            gas_used: 21_000,
+            gas_limit: 30_000_000,
+            base_fee_per_gas_wei: Some(5_000_000),
+            size_bytes: Some(500),
+            blob_gas_used: Some(2),
+            excess_blob_gas: None,
+            withdrawals: Some(3),
+        };
+
+        let value: serde_json::Value = serde_json::to_value(&summary).unwrap();
+
+        assert_eq!(value["network"], "sepolia");
+        assert_eq!(value["reference"], "latest");
+        assert_eq!(value["number"], 42);
+        assert!(value["hash"].as_str().unwrap().starts_with("0x11"));
+        assert!(value["parentHash"].as_str().unwrap().starts_with("0x22"));
+        assert_eq!(value["timestamp"]["unix"], 1_780_614_804u64);
+        assert!(value["timestamp"]["utc"].as_str().unwrap().ends_with('Z'));
+        assert!(value["timestamp"]["local"].is_string());
+        assert_eq!(value["transactions"], 7);
+        assert_eq!(value["gasUsed"], 21_000);
+        assert_eq!(value["gasLimit"], 30_000_000);
+        assert_eq!(value["baseFeePerGasWei"], 5_000_000);
+        assert_eq!(value["sizeBytes"], 500);
+        assert_eq!(value["blobGasUsed"], 2);
+        assert!(value["excessBlobGas"].is_null());
+        assert_eq!(value["withdrawals"], 3);
     }
 }

--- a/bin/basectl/src/block.rs
+++ b/bin/basectl/src/block.rs
@@ -1,5 +1,7 @@
 //! Implementation of the `basectl block <ref>` subcommand.
 
+use alloy_eips::BlockId;
+use alloy_primitives::B256;
 use alloy_provider::Network;
 use alloy_rpc_types_eth::BlockNumberOrTag;
 use anyhow::{Result, anyhow, bail};
@@ -9,27 +11,29 @@ use basectl_cli::{
     format_gwei, format_unix_timestamp,
 };
 
-/// Parses a CLI block reference into alloy's `BlockNumberOrTag`.
+/// Parses a CLI block reference into alloy's `BlockId`.
 ///
-/// Adds three behaviors on top of `BlockNumberOrTag::FromStr`: bare decimal
-/// numbers (alloy requires `0x` on numbers), explicit rejection of
-/// 64-hex-char block-hash references, and rejection of the `pending` tag
-/// (alloy's typed `Block` can't deserialize a pending block's null number
-/// and hash, so accepting it here would only produce a confusing error
-/// after a wasted RPC round-trip).
-pub(crate) fn parse_block_ref(s: &str) -> Result<BlockNumberOrTag> {
+/// Adds three behaviors on top of alloy's parsers: bare decimal numbers
+/// (alloy requires `0x` on numbers), explicit handling of 64-hex-char block
+/// hashes (returned as `BlockId::Hash`), and rejection of the `pending`
+/// tag (alloy's typed `Block` can't deserialize a pending block's null
+/// number and hash, so accepting it here would only produce a confusing
+/// error after a wasted RPC round-trip).
+pub(crate) fn parse_block_ref(s: &str) -> Result<BlockId> {
     let trimmed = s.trim();
     if trimmed.is_empty() {
         bail!("invalid block reference: empty input");
     }
     if let Ok(number) = trimmed.parse::<u64>() {
-        return Ok(BlockNumberOrTag::Number(number));
+        return Ok(BlockId::Number(BlockNumberOrTag::Number(number)));
     }
     if let Some(hex) = trimmed.strip_prefix("0x").or_else(|| trimmed.strip_prefix("0X"))
         && hex.len() == 64
         && hex.chars().all(|c| c.is_ascii_hexdigit())
     {
-        bail!("block hash references are not supported; use a block number or tag");
+        let hash: B256 =
+            trimmed.parse().map_err(|_| anyhow!("invalid block reference: malformed hash"))?;
+        return Ok(BlockId::Hash(hash.into()));
     }
     let tag =
         trimmed.parse::<BlockNumberOrTag>().map_err(|e| anyhow!("invalid block reference: {e}"))?;
@@ -38,7 +42,7 @@ pub(crate) fn parse_block_ref(s: &str) -> Result<BlockNumberOrTag> {
             "the `pending` tag is not supported; use `latest`, `safe`, `finalized`, or `earliest`"
         );
     }
-    Ok(tag)
+    Ok(BlockId::Number(tag))
 }
 
 /// Runs the `basectl block` subcommand.
@@ -55,7 +59,7 @@ pub(crate) async fn run(config: MonitoringConfig, reference: &str, json: bool) -
 
 fn print_pretty(
     network: &str,
-    reference: BlockNumberOrTag,
+    reference: BlockId,
     block: &<Base as Network>::BlockResponse,
 ) -> Result<()> {
     let header = &block.header;
@@ -96,28 +100,53 @@ fn print_pretty(
 
 #[cfg(test)]
 mod tests {
+    use alloy_eips::BlockId;
+    use alloy_primitives::B256;
     use alloy_rpc_types_eth::BlockNumberOrTag;
 
     use super::parse_block_ref;
 
     #[test]
     fn parses_decimal() {
-        assert_eq!(parse_block_ref("123").unwrap(), BlockNumberOrTag::Number(123));
-        assert_eq!(parse_block_ref("  42  ").unwrap(), BlockNumberOrTag::Number(42));
+        assert_eq!(parse_block_ref("123").unwrap(), BlockId::Number(BlockNumberOrTag::Number(123)),);
+        assert_eq!(
+            parse_block_ref("  42  ").unwrap(),
+            BlockId::Number(BlockNumberOrTag::Number(42)),
+        );
     }
 
     #[test]
     fn parses_hex() {
-        assert_eq!(parse_block_ref("0x1a").unwrap(), BlockNumberOrTag::Number(26));
-        assert_eq!(parse_block_ref("0X1A").unwrap(), BlockNumberOrTag::Number(26));
+        assert_eq!(parse_block_ref("0x1a").unwrap(), BlockId::Number(BlockNumberOrTag::Number(26)),);
+        assert_eq!(parse_block_ref("0X1A").unwrap(), BlockId::Number(BlockNumberOrTag::Number(26)),);
     }
 
     #[test]
     fn parses_tags() {
-        assert_eq!(parse_block_ref("latest").unwrap(), BlockNumberOrTag::Latest);
-        assert_eq!(parse_block_ref("safe").unwrap(), BlockNumberOrTag::Safe);
-        assert_eq!(parse_block_ref("finalized").unwrap(), BlockNumberOrTag::Finalized);
-        assert_eq!(parse_block_ref("earliest").unwrap(), BlockNumberOrTag::Earliest);
+        assert_eq!(parse_block_ref("latest").unwrap(), BlockId::Number(BlockNumberOrTag::Latest));
+        assert_eq!(parse_block_ref("safe").unwrap(), BlockId::Number(BlockNumberOrTag::Safe));
+        assert_eq!(
+            parse_block_ref("finalized").unwrap(),
+            BlockId::Number(BlockNumberOrTag::Finalized),
+        );
+        assert_eq!(
+            parse_block_ref("earliest").unwrap(),
+            BlockId::Number(BlockNumberOrTag::Earliest),
+        );
+    }
+
+    #[test]
+    fn parses_block_hash() {
+        let canonical = format!("0x{}", "11".repeat(32));
+        let expected = canonical.parse::<B256>().unwrap();
+
+        for input in [canonical.clone(), canonical.replace("0x", "0X"), canonical.to_uppercase()] {
+            let parsed = parse_block_ref(&input).unwrap();
+            let BlockId::Hash(rpc_hash) = parsed else {
+                panic!("expected BlockId::Hash for {input:?}, got {parsed:?}");
+            };
+            assert_eq!(rpc_hash.block_hash, expected, "hash mismatch for {input:?}");
+        }
     }
 
     #[test]
@@ -129,13 +158,6 @@ mod tests {
                 "expected pending rejection for {input:?}, got: {err}",
             );
         }
-    }
-
-    #[test]
-    fn rejects_64_hex_char_hash() {
-        let hash = format!("0x{}", "11".repeat(32));
-        let err = parse_block_ref(&hash).unwrap_err().to_string();
-        assert!(err.contains("hash references are not supported"));
     }
 
     #[test]

--- a/bin/basectl/src/cli.rs
+++ b/bin/basectl/src/cli.rs
@@ -46,9 +46,12 @@ pub(crate) enum Commands {
         /// Block number (decimal or 0x-hex), tag (latest/safe/finalized/earliest), or 32-byte block hash.
         #[arg(value_name = "REF")]
         reference: String,
-        /// Emit JSON instead of the pretty table.
+        /// Emit JSON (humanized — decoded numbers, ISO + local timestamps) instead of the pretty table.
         #[arg(long)]
         json: bool,
+        /// With `--json`, emit the JSON-RPC wire format (camelCase, hex-string quantities) instead of the humanized JSON.
+        #[arg(long, requires = "json")]
+        raw: bool,
     },
     /// Stream flashblocks as JSON lines.
     #[command(after_help = "Use `basectl monitor flashblocks` for the TUI.")]

--- a/bin/basectl/src/cli.rs
+++ b/bin/basectl/src/cli.rs
@@ -43,7 +43,7 @@ pub(crate) enum Commands {
     /// Inspect a single L2 block.
     #[command(visible_alias = "b")]
     Block {
-        /// Block number (decimal or 0x-hex) or tag: latest, safe, finalized, earliest.
+        /// Block number (decimal or 0x-hex), tag (latest/safe/finalized/earliest), or 32-byte block hash.
         #[arg(value_name = "REF")]
         reference: String,
         /// Emit JSON instead of the pretty table.

--- a/bin/basectl/src/cli.rs
+++ b/bin/basectl/src/cli.rs
@@ -40,6 +40,16 @@ pub(crate) enum Commands {
         #[command(subcommand)]
         command: Option<MonitorCommands>,
     },
+    /// Inspect a single L2 block.
+    #[command(visible_alias = "b")]
+    Block {
+        /// Block number (decimal or 0x-hex) or tag: latest, safe, finalized, earliest.
+        #[arg(value_name = "REF")]
+        reference: String,
+        /// Emit JSON instead of the pretty table.
+        #[arg(long)]
+        json: bool,
+    },
     /// Stream flashblocks as JSON lines.
     #[command(after_help = "Use `basectl monitor flashblocks` for the TUI.")]
     Flashblocks,

--- a/bin/basectl/src/main.rs
+++ b/bin/basectl/src/main.rs
@@ -1,5 +1,6 @@
 //! Base infrastructure control CLI binary.
 
+mod block;
 mod cli;
 
 use basectl_cli::{MonitoringConfig, ViewId, run_app, run_flashblocks_json};
@@ -19,6 +20,9 @@ async fn main() -> anyhow::Result<()> {
         Some(cli::Commands::Monitor { command }) => {
             let view = command.map(|c| c.view_id()).unwrap_or(ViewId::Home);
             run_app(view, config, conductor_rpc).await
+        }
+        Some(cli::Commands::Block { reference, json }) => {
+            block::run(MonitoringConfig::load(config).await?, &reference, json).await
         }
         Some(cli::Commands::Flashblocks) => {
             run_flashblocks_json(MonitoringConfig::load(config).await?).await

--- a/bin/basectl/src/main.rs
+++ b/bin/basectl/src/main.rs
@@ -21,8 +21,8 @@ async fn main() -> anyhow::Result<()> {
             let view = command.map(|c| c.view_id()).unwrap_or(ViewId::Home);
             run_app(view, config, conductor_rpc).await
         }
-        Some(cli::Commands::Block { reference, json }) => {
-            block::run(MonitoringConfig::load(config).await?, &reference, json).await
+        Some(cli::Commands::Block { reference, json, raw }) => {
+            block::run(MonitoringConfig::load(config).await?, &reference, json, raw).await
         }
         Some(cli::Commands::Flashblocks) => {
             run_flashblocks_json(MonitoringConfig::load(config).await?).await

--- a/crates/infra/basectl/src/lib.rs
+++ b/crates/infra/basectl/src/lib.rs
@@ -14,11 +14,11 @@ pub use app::{
 mod output;
 pub use output::{
     COLOR_ACTIVE_BORDER, COLOR_BASE_BLUE, COLOR_BURN, COLOR_GAS_FILL, COLOR_GROWTH,
-    COLOR_ROW_HIGHLIGHTED, COLOR_ROW_SELECTED, COLOR_TARGET, L1BlocksTableParams,
-    backlog_size_color, block_color, block_color_bright, build_gas_bar, format_bytes,
-    format_duration, format_gas, format_gwei, format_rate, render_da_backlog_bar,
-    render_gas_usage_bar, render_l1_blocks_table, target_usage_color, time_diff_color,
-    truncate_block_number,
+    COLOR_ROW_HIGHLIGHTED, COLOR_ROW_SELECTED, COLOR_TARGET, JsonOutput, KeyValueTable,
+    L1BlocksTableParams, backlog_size_color, block_color, block_color_bright, build_gas_bar,
+    format_bytes, format_duration, format_gas, format_gwei, format_rate, format_unix_timestamp,
+    render_da_backlog_bar, render_gas_usage_bar, render_l1_blocks_table, target_usage_color,
+    time_diff_color, truncate_block_number,
 };
 
 mod config;
@@ -34,10 +34,11 @@ pub use rpc::{
     PausedPeers, PodGroupStatus, PodStatus, PodsPoller, PodsSnapshot, ProofsSnapshot,
     TimestampedFlashblock, TxSummary, ValidatorNodeStatus, conductor_pause_all_nodes,
     conductor_pause_node, conductor_resume_all_nodes, conductor_resume_node,
-    decode_flashblock_transactions, fetch_block_transactions, fetch_full_system_config,
-    fetch_initial_backlog_with_progress, fetch_safe_and_latest, pause_sequencer_node,
-    restart_conductor_node, run_block_fetcher, run_conductor_poller, run_flashblock_ws,
-    run_flashblock_ws_timestamped, run_l1_blob_watcher, run_pods_poller, run_proofs_poller,
+    decode_flashblock_transactions, fetch_block, fetch_block_transactions,
+    fetch_full_system_config, fetch_initial_backlog_with_progress, fetch_safe_and_latest,
+    pause_sequencer_node, restart_conductor_node, run_block_fetcher, run_conductor_poller,
+    run_flashblock_ws, run_flashblock_ws_timestamped, run_l1_blob_watcher, run_pods_poller,
+    run_proofs_poller,
     run_safe_head_poller, run_validator_poller, start_sequencer_node, stop_sequencer_node,
     transfer_conductor_leader, unpause_sequencer_node,
 };

--- a/crates/infra/basectl/src/lib.rs
+++ b/crates/infra/basectl/src/lib.rs
@@ -38,9 +38,8 @@ pub use rpc::{
     fetch_full_system_config, fetch_initial_backlog_with_progress, fetch_safe_and_latest,
     pause_sequencer_node, restart_conductor_node, run_block_fetcher, run_conductor_poller,
     run_flashblock_ws, run_flashblock_ws_timestamped, run_l1_blob_watcher, run_pods_poller,
-    run_proofs_poller,
-    run_safe_head_poller, run_validator_poller, start_sequencer_node, stop_sequencer_node,
-    transfer_conductor_leader, unpause_sequencer_node,
+    run_proofs_poller, run_safe_head_poller, run_validator_poller, start_sequencer_node,
+    stop_sequencer_node, transfer_conductor_leader, unpause_sequencer_node,
 };
 
 mod tui;

--- a/crates/infra/basectl/src/output/format.rs
+++ b/crates/infra/basectl/src/output/format.rs
@@ -1,5 +1,6 @@
 use std::time::Duration;
 
+use chrono::DateTime;
 use ratatui::prelude::Color;
 
 const BLOCK_COLORS: [Color; 24] = [
@@ -178,4 +179,12 @@ pub fn time_diff_color(ms: i64) -> Color {
     } else {
         Color::Red
     }
+}
+
+/// Formats a Unix timestamp (seconds since epoch) as `YYYY-MM-DD HH:MM:SS UTC`.
+///
+/// Falls back to the raw seconds string when the timestamp is out of range.
+pub fn format_unix_timestamp(secs: u64) -> String {
+    DateTime::from_timestamp(secs as i64, 0)
+        .map_or_else(|| secs.to_string(), |t| t.format("%Y-%m-%d %H:%M:%S UTC").to_string())
 }

--- a/crates/infra/basectl/src/output/format.rs
+++ b/crates/infra/basectl/src/output/format.rs
@@ -185,6 +185,8 @@ pub fn time_diff_color(ms: i64) -> Color {
 ///
 /// Falls back to the raw seconds string when the timestamp is out of range.
 pub fn format_unix_timestamp(secs: u64) -> String {
-    DateTime::from_timestamp(secs as i64, 0)
+    i64::try_from(secs)
+        .ok()
+        .and_then(|s| DateTime::from_timestamp(s, 0))
         .map_or_else(|| secs.to_string(), |t| t.format("%Y-%m-%d %H:%M:%S UTC").to_string())
 }

--- a/crates/infra/basectl/src/output/json.rs
+++ b/crates/infra/basectl/src/output/json.rs
@@ -1,0 +1,42 @@
+//! JSON output for non-TUI commands.
+
+use std::io::{self, Write};
+
+use anyhow::Result;
+use serde::Serialize;
+
+/// JSON writer for non-TUI command output.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct JsonOutput;
+
+impl JsonOutput {
+    /// Pretty-prints `value` as JSON to stdout, terminating with a newline.
+    pub fn print<T: Serialize>(value: &T) -> Result<()> {
+        let mut stdout = io::stdout().lock();
+        Self::write(&mut stdout, value)?;
+        Ok(())
+    }
+
+    /// Pretty-prints `value` as JSON to `writer`, terminating with a newline.
+    pub fn write<W: Write, T: Serialize>(writer: &mut W, value: &T) -> Result<()> {
+        serde_json::to_writer_pretty(&mut *writer, value)?;
+        writer.write_all(b"\n")?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::JsonOutput;
+
+    #[test]
+    fn write_emits_pretty_json_with_trailing_newline() {
+        let mut buf = Vec::new();
+        JsonOutput::write(&mut buf, &json!({"k": 1})).unwrap();
+        let rendered = String::from_utf8(buf).unwrap();
+
+        assert_eq!(rendered, "{\n  \"k\": 1\n}\n");
+    }
+}

--- a/crates/infra/basectl/src/output/mod.rs
+++ b/crates/infra/basectl/src/output/mod.rs
@@ -5,11 +5,17 @@ pub use format::{
     COLOR_ACTIVE_BORDER, COLOR_BASE_BLUE, COLOR_BURN, COLOR_GAS_FILL, COLOR_GROWTH,
     COLOR_ROW_HIGHLIGHTED, COLOR_ROW_SELECTED, COLOR_TARGET, backlog_size_color, block_color,
     block_color_bright, format_bytes, format_duration, format_gas, format_gwei, format_rate,
-    target_usage_color, time_diff_color, truncate_block_number,
+    format_unix_timestamp, target_usage_color, time_diff_color, truncate_block_number,
 };
+
+mod json;
+pub use json::JsonOutput;
 
 mod render;
 pub use render::{
     L1BlocksTableParams, build_gas_bar, render_da_backlog_bar, render_gas_usage_bar,
     render_l1_blocks_table,
 };
+
+mod table;
+pub use table::KeyValueTable;

--- a/crates/infra/basectl/src/output/table.rs
+++ b/crates/infra/basectl/src/output/table.rs
@@ -1,0 +1,66 @@
+//! Aligned key-value table renderer for non-TUI command output.
+
+use std::io::{self, Write};
+
+/// Aligned key-value rows for pretty CLI output.
+#[derive(Debug, Default, Clone)]
+pub struct KeyValueTable {
+    rows: Vec<(String, String)>,
+}
+
+impl KeyValueTable {
+    /// Creates an empty table.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Appends a key-value row.
+    pub fn row(&mut self, key: impl Into<String>, value: impl Into<String>) -> &mut Self {
+        self.rows.push((key.into(), value.into()));
+        self
+    }
+
+    /// Writes the rows to `writer`, padding keys to the longest key width.
+    pub fn render<W: Write>(&self, writer: &mut W) -> io::Result<()> {
+        let width = self.rows.iter().map(|(k, _)| k.len()).max().unwrap_or(0);
+        for (key, value) in &self.rows {
+            writeln!(writer, "{key:<width$}  {value}")?;
+        }
+        Ok(())
+    }
+
+    /// Writes the rows to stdout, padding keys to the longest key width.
+    pub fn print(&self) -> io::Result<()> {
+        self.render(&mut io::stdout().lock())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::KeyValueTable;
+
+    #[test]
+    fn render_pads_keys_to_longest_width() {
+        let mut table = KeyValueTable::new();
+        table.row("number", "123").row("hash", "0xabc").row("transaction count", "5");
+
+        let mut buf = Vec::new();
+        table.render(&mut buf).unwrap();
+        let rendered = String::from_utf8(buf).unwrap();
+
+        assert_eq!(
+            rendered,
+            "number             123\n\
+             hash               0xabc\n\
+             transaction count  5\n",
+        );
+    }
+
+    #[test]
+    fn render_empty_table_writes_nothing() {
+        let table = KeyValueTable::new();
+        let mut buf = Vec::new();
+        table.render(&mut buf).unwrap();
+        assert!(buf.is_empty());
+    }
+}

--- a/crates/infra/basectl/src/rpc/el.rs
+++ b/crates/infra/basectl/src/rpc/el.rs
@@ -1,7 +1,10 @@
 use std::sync::Arc;
 
 use alloy_consensus::{Transaction, transaction::SignerRecoverable};
-use alloy_eips::eip2718::{Decodable2718, Encodable2718};
+use alloy_eips::{
+    BlockId,
+    eip2718::{Decodable2718, Encodable2718},
+};
 use alloy_primitives::{Address, B256, Bytes};
 use alloy_provider::{Network, Provider, ProviderBuilder, network::TransactionResponse};
 use alloy_rpc_types_eth::BlockNumberOrTag;
@@ -18,14 +21,16 @@ use crate::tui::Toast;
 
 const CONCURRENT_BLOCK_FETCHES: usize = 16;
 
-/// Fetches a single L2 block via `eth_getBlockByNumber`.
+/// Fetches a single L2 block via `eth_getBlockByHash` or `eth_getBlockByNumber`.
 ///
-/// Returns the typed block as deserialized by alloy. The `pending` tag is
-/// not supported here because alloy's typed `Block` does not accept a null
-/// number/hash; pass a number, `latest`, `safe`, `finalized`, or `earliest`.
+/// `reference` selects the block by hash, number, or tag (alloy's `BlockId`
+/// dispatches between the two RPC methods internally). The `pending` tag is
+/// not supported because alloy's typed `Block` does not accept a null
+/// number/hash; pass a number, hash, or `latest` / `safe` / `finalized` /
+/// `earliest`.
 pub async fn fetch_block(
     rpc: &Url,
-    reference: BlockNumberOrTag,
+    reference: BlockId,
 ) -> Result<<Base as Network>::BlockResponse> {
     let provider = ProviderBuilder::new()
         .disable_recommended_fillers()
@@ -34,7 +39,7 @@ pub async fn fetch_block(
         .await
         .with_context(|| format!("connecting to L2 RPC at {rpc}"))?;
     provider
-        .get_block_by_number(reference)
+        .get_block(reference)
         .await
         .with_context(|| format!("fetching block {reference}"))?
         .ok_or_else(|| anyhow!("block {reference} not found"))

--- a/crates/infra/basectl/src/rpc/el.rs
+++ b/crates/infra/basectl/src/rpc/el.rs
@@ -3,19 +3,42 @@ use std::sync::Arc;
 use alloy_consensus::{Transaction, transaction::SignerRecoverable};
 use alloy_eips::eip2718::{Decodable2718, Encodable2718};
 use alloy_primitives::{Address, B256, Bytes};
-use alloy_provider::{Provider, ProviderBuilder, network::TransactionResponse};
+use alloy_provider::{Network, Provider, ProviderBuilder, network::TransactionResponse};
 use alloy_rpc_types_eth::BlockNumberOrTag;
-use anyhow::Result;
+use anyhow::{Context, Result, anyhow};
 use base_common_consensus::BaseTxEnvelope;
 use base_common_network::Base;
 use futures::{StreamExt, stream};
 use tokio::sync::mpsc;
 use tracing::warn;
+use url::Url;
 
 use super::fetch_safe_and_latest;
 use crate::tui::Toast;
 
 const CONCURRENT_BLOCK_FETCHES: usize = 16;
+
+/// Fetches a single L2 block via `eth_getBlockByNumber`.
+///
+/// Returns the typed block as deserialized by alloy. The `pending` tag is
+/// not supported here because alloy's typed `Block` does not accept a null
+/// number/hash; pass a number, `latest`, `safe`, `finalized`, or `earliest`.
+pub async fn fetch_block(
+    rpc: &Url,
+    reference: BlockNumberOrTag,
+) -> Result<<Base as Network>::BlockResponse> {
+    let provider = ProviderBuilder::new()
+        .disable_recommended_fillers()
+        .network::<Base>()
+        .connect(rpc.as_str())
+        .await
+        .with_context(|| format!("connecting to L2 RPC at {rpc}"))?;
+    provider
+        .get_block_by_number(reference)
+        .await
+        .with_context(|| format!("fetching block {reference}"))?
+        .ok_or_else(|| anyhow!("block {reference} not found"))
+}
 
 /// DA and gas information for a single L2 block.
 #[derive(Debug, Clone)]

--- a/crates/infra/basectl/src/rpc/mod.rs
+++ b/crates/infra/basectl/src/rpc/mod.rs
@@ -15,8 +15,8 @@ pub use conductor::{
 mod el;
 pub use el::{
     BacklogBlock, BacklogFetchResult, BacklogProgress, BlockDaInfo, InitialBacklog, TxSummary,
-    decode_flashblock_transactions, fetch_block_transactions, fetch_initial_backlog_with_progress,
-    run_block_fetcher,
+    decode_flashblock_transactions, fetch_block, fetch_block_transactions,
+    fetch_initial_backlog_with_progress, run_block_fetcher,
 };
 
 mod flashblocks;


### PR DESCRIPTION
## Summary

- Adds `basectl block <REF>` (visible alias `b`) — first non-TUI inspection command in the rearchitecture.
- Accepts decimal numbers, `0x`-hex numbers, the canonical tags (`latest` / `safe` / `finalized` / `earliest`), and 32-byte block hashes. Alloy dispatches between `eth_getBlockByHash` and `eth_getBlockByNumber` based on the reference shape.
- Pretty mode prints an aligned key/value table (hex→decimal, unix timestamp→`YYYY-MM-DD HH:MM:SS UTC`, gas/gwei/bytes humanized via existing `output/format.rs` helpers).
- `--json` emits humanized JSON: decoded numeric values (`gasUsed: 5345789`, `baseFeePerGasWei: 5000000`), a nested `timestamp { unix, utc, local }` object so operators can read their wall clock without timezone math, and top-level `network` / `reference` context fields.
- `--json --raw` preserves the JSON-RPC wire format (camelCase, hex-string quantities, flat header) — byte-equivalent to `cast block --json`, useful for round-tripping through `cast` or any other JSON-RPC-aware tool.

## What's added

| Layer | Item |
| --- | --- |
| `crates/infra/basectl/src/rpc/el.rs` | `fetch_block(rpc, BlockId) -> Result<<Base as Network>::BlockResponse>` — thin wrapper that dispatches between alloy's typed `eth_getBlockByHash` and `eth_getBlockByNumber` based on the `BlockId` variant |
| `crates/infra/basectl/src/output/table.rs` | `KeyValueTable` — aligned key/value renderer for pretty CLI output |
| `crates/infra/basectl/src/output/json.rs` | `JsonOutput` — pretty-JSON-to-stdout emitter |
| `crates/infra/basectl/src/output/format.rs` | `format_unix_timestamp` — only formatter not already there |
| `bin/basectl/src/block.rs` | `parse_block_ref` (wraps alloy's `BlockId` / `BlockNumberOrTag` parsers with bare-decimal, hash, and `pending`-rejection); `BlockSummaryJson` + nested `TimestampJson` for humanized `--json` output; the `run` dispatch + pretty/JSON printers |
| `bin/basectl/README.md` | New `### basectl block <REF>` section + examples covering pretty, humanized JSON, raw JSON, hash lookups |

## Example output

### Pretty mode

```text
$ basectl -c sepolia block latest
network           sepolia
reference         latest
number            42423258
hash              0x0d5ff5ed4311228faed8cff27f205f5e21166c4f01409d8a49c267e866845799
parent_hash       0x8241324a28f9e24a10c78d43d81ddbac14acf3cdbfa0dbb1ac1f5e084319d497
timestamp         1780614804 (2026-06-04 23:13:24 UTC)
transactions      18
gas_used          2.8M
gas_limit         1200.0M
base_fee_per_gas  0.0050 gwei
size              9K
blob_gas_used     1.7M
excess_blob_gas   0
withdrawals       0
```

### Humanized JSON (`--json`, default)

```text
$ basectl -c sepolia block --json latest | jq '{number, gasUsed, baseFeePerGasWei, transactions, timestamp}'
{
  "number": 42423399,
  "gasUsed": 10623885,
  "baseFeePerGasWei": 5000000,
  "transactions": 33,
  "timestamp": {
    "unix": 1780615086,
    "utc": "2026-06-04T23:18:06Z",
    "local": "2026-06-04T16:18:06-07:00"
  }
}
```

### Raw JSON (`--json --raw`)

```text
$ basectl -c sepolia block --json --raw latest | jq '{number, gasUsed, baseFeePerGas, timestamp}'
{
  "number": "0x2875469",
  "gasUsed": "0x1cbeeb",
  "baseFeePerGas": "0x4c4b40",
  "timestamp": "0x6a2207b2"
}
```

### Hash lookup

```text
$ basectl -c sepolia block 0xd3041e6950b3ef0f6f7d18f2e7c5f60303f54c08d29b734fd401fa7172e7e724
network           sepolia
reference         hash 0xd3041e6950b3ef0f6f7d18f2e7c5f60303f54c08d29b734fd401fa7172e7e724
number            42423259
hash              0xd3041e6950b3ef0f6f7d18f2e7c5f60303f54c08d29b734fd401fa7172e7e724
parent_hash       0x0d5ff5ed4311228faed8cff27f205f5e21166c4f01409d8a49c267e866845799
timestamp         1780614806 (2026-06-04 23:13:26 UTC)
transactions      14
...
```

## Test plan

- [x] `cargo build -p basectl-cli -p basectl`
- [x] `cargo clippy -p basectl-cli -p basectl --all-targets -- -D warnings`
- [x] `cargo test -p basectl-cli -p basectl` — 32 lib + 9 bin = 41 tests passing (29 C3 baseline + 12 new: 2 `KeyValueTable`, 1 `JsonOutput`, 5 `parse_block_ref` core forms, 1 `parses_block_hash`, 1 `rejects_pending`, 1 `timestamp_json_renders_three_forms`, 1 `block_summary_json_serializes_*`, 1 `timestamp_json_falls_back_on_u64_overflow`)
- [x] `cargo +nightly fmt --all -- --check`
- [x] Sepolia: `block latest`, `block earliest`, `block <number>`, `block 0x<hex-of-number>`, `block 0x<32-byte-hash>` all render
- [x] Decimal vs `0x`-hex of the same number produce identical output apart from the `reference` row
- [x] `--json` produces decoded numeric values + nested timestamp object with `unix` / `utc` / `local`; `--json --raw` produces JSON-RPC wire format; `--raw` without `--json` is rejected by clap at parse time
- [x] Error paths: `block pending`, `block notatag`, malformed hex all produce clean error messages without making an RPC call
- [x] `u64::MAX` timestamp falls back to the raw seconds string instead of fabricating a pre-epoch RFC 3339 (regression test for the lossy `as i64` cast review feedback)
- [x] `basectl block --help` reads cleanly; visible alias `b` works
