### PR TITLE
fix(release): allow publishing existing tags

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -20,6 +20,9 @@ env:
     base-reth-node
     base-consensus
     basectl
+  CARGO_TERM_COLOR: always
+  SCCACHE_GHA_ENABLED: "true"
+  RUSTC_WRAPPER: "sccache"
 
 permissions:
   actions: read
@@ -85,6 +88,17 @@ jobs:
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@4305c38b25d97ef35a8ad1f985ccf2d2242004f2 # stable
+
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
+
+      - name: Rust cache
+        uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
+        with:
+          cache-on-failure: true
+          shared-key: release-${{ matrix.target.triple }}
+          save-if: ${{ true }}
+          cache-targets: "false"
 
       - name: Build binaries
         run: |

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -379,7 +379,7 @@ jobs:
           if [[ ${#files[@]} -eq 0 ]]; then
             echo "::warning::No binary artifacts found — all binary builds may have failed, skipping upload"
           else
-            gh release upload "$TAG" "${files[@]}"
+            gh release upload --clobber "$TAG" "${files[@]}"
           fi
 
       - name: Summary

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -82,19 +82,23 @@ jobs:
             exit 1
           fi
 
-          # Ensure no final git tag already exists
-          if git rev-parse "v${VERSION}" > /dev/null 2>&1; then
-            echo "::error::Tag v${VERSION} already exists"
-            exit 1
+          # Existing final tags are allowed so failed/partial publish runs can be retried.
+          if git rev-parse "refs/tags/${TAG}" > /dev/null 2>&1; then
+            TAG_SHA=$(git rev-parse "refs/tags/${TAG}^{}")
+            HEAD_SHA=$(git rev-parse HEAD)
+            if [[ "$TAG_SHA" == "$HEAD_SHA" ]]; then
+              echo "::notice::Tag ${TAG} already exists at release branch HEAD; reusing it"
+            else
+              echo "::notice::Tag ${TAG} already exists at ${TAG_SHA}; reusing it instead of release branch HEAD ${HEAD_SHA}"
+            fi
           fi
 
-          # Ensure no final release already exists
+          # Existing releases are allowed because the publish job can fill in missing artifacts.
           if gh release view "$TAG" > /dev/null 2>&1; then
-            echo "::error::Release $TAG already exists"
-            exit 1
+            echo "::notice::Release $TAG already exists; build will reuse it"
           fi
 
-      - name: Create and push tag
+      - name: Create or reuse tag
         run: ./etc/scripts/release/create-tag.sh "releases/v${{ inputs.version }}" final
 
       - name: Read tag
@@ -113,7 +117,7 @@ jobs:
         run: |
           TAG="${{ steps.read-tag.outputs.tag }}"
 
-          echo "## Tag Created" >> $GITHUB_STEP_SUMMARY
+          echo "## Tag Ready" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "**Tag**: \`$TAG\`" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -89,7 +89,9 @@ jobs:
             if [[ "$TAG_SHA" == "$HEAD_SHA" ]]; then
               echo "::notice::Tag ${TAG} already exists at release branch HEAD; reusing it"
             else
-              echo "::notice::Tag ${TAG} exists at ${TAG_SHA} (not HEAD ${HEAD_SHA}); create-tag will move it to HEAD"
+              echo "::error::Tag ${TAG} already exists at ${TAG_SHA}, not release branch HEAD ${HEAD_SHA}"
+              echo "::error::Refusing to move an existing release tag to a different commit"
+              exit 1
             fi
           fi
 

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -89,7 +89,7 @@ jobs:
             if [[ "$TAG_SHA" == "$HEAD_SHA" ]]; then
               echo "::notice::Tag ${TAG} already exists at release branch HEAD; reusing it"
             else
-              echo "::notice::Tag ${TAG} already exists at ${TAG_SHA}; reusing it instead of release branch HEAD ${HEAD_SHA}"
+              echo "::notice::Tag ${TAG} exists at ${TAG_SHA} (not HEAD ${HEAD_SHA}); create-tag will move it to HEAD"
             fi
           fi
 

--- a/etc/scripts/release/common.sh
+++ b/etc/scripts/release/common.sh
@@ -34,7 +34,7 @@ get_next_rc_number() {
 
 tag_exists() {
     local tag="$1"
-    git rev-parse "$tag" >/dev/null 2>&1
+    git rev-parse --verify "refs/tags/$tag" >/dev/null 2>&1
 }
 
 configure_git() {

--- a/etc/scripts/release/create-tag.sh
+++ b/etc/scripts/release/create-tag.sh
@@ -47,14 +47,6 @@ main() {
         HEAD_SHA=$(git rev-parse HEAD)
         if [[ "$TAG_SHA" == "$HEAD_SHA" ]]; then
             echo "Tag $TAG already exists at HEAD, skipping creation"
-        elif [[ "$RELEASE_TYPE" == "final" ]]; then
-            echo "Tag $TAG exists at $TAG_SHA; moving to HEAD ($HEAD_SHA) for retry"
-            configure_git
-            git push origin ":refs/tags/$TAG"
-            git tag -d "$TAG"
-            create_and_push_tag "$TAG"
-            echo ""
-            echo "=== Tag $TAG moved to HEAD ==="
         else
             echo "Error: Tag $TAG already exists but points at $TAG_SHA, not HEAD ($HEAD_SHA)"
             exit 1

--- a/etc/scripts/release/create-tag.sh
+++ b/etc/scripts/release/create-tag.sh
@@ -48,8 +48,7 @@ main() {
         if [[ "$TAG_SHA" == "$HEAD_SHA" ]]; then
             echo "Tag $TAG already exists at HEAD, skipping creation"
         else
-            echo "Error: Tag $TAG already exists but points at $TAG_SHA, not HEAD ($HEAD_SHA)"
-            exit 1
+            echo "Tag $TAG already exists at $TAG_SHA, reusing it instead of HEAD ($HEAD_SHA)"
         fi
     else
         configure_git

--- a/etc/scripts/release/create-tag.sh
+++ b/etc/scripts/release/create-tag.sh
@@ -47,8 +47,17 @@ main() {
         HEAD_SHA=$(git rev-parse HEAD)
         if [[ "$TAG_SHA" == "$HEAD_SHA" ]]; then
             echo "Tag $TAG already exists at HEAD, skipping creation"
+        elif [[ "$RELEASE_TYPE" == "final" ]]; then
+            echo "Tag $TAG exists at $TAG_SHA; moving to HEAD ($HEAD_SHA) for retry"
+            configure_git
+            git push origin ":refs/tags/$TAG"
+            git tag -d "$TAG"
+            create_and_push_tag "$TAG"
+            echo ""
+            echo "=== Tag $TAG moved to HEAD ==="
         else
-            echo "Tag $TAG already exists at $TAG_SHA, reusing it instead of HEAD ($HEAD_SHA)"
+            echo "Error: Tag $TAG already exists but points at $TAG_SHA, not HEAD ($HEAD_SHA)"
+            exit 1
         fi
     else
         configure_git


### PR DESCRIPTION
## Summary

  Allow the final release publish workflow to be rerun when the release tag or GitHub release already
  exists.

  Previously, `publish-release.yml` failed during validation if `vX.Y.Z` already existed, which blocked
  retrying failed or partial publish runs for historical releases. This change makes the final publish
  path reuse existing tags/releases and continue into the build/publish workflow.

  ## Changes

  - Allow `publish-release.yml` to continue when the final git tag already exists.
  - Allow existing GitHub releases so reruns can fill in missing artifacts.
  - Update `create-tag.sh` to reuse existing final tags instead of failing.
  - Keep RC tag behavior strict so RC creation still advances normally.
  - Tighten `tag_exists` to check `refs/tags/*` explicitly.

  ## Test Plan

  - `bash -n etc/scripts/release/common.sh`
  - `bash -n etc/scripts/release/create-tag.sh`
  - YAML parse for `.github/workflows/publish-release.yml`