### PR TITLE
feat(prover-service): implement worker job api server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5984,6 +5984,7 @@ dependencies = [
  "metrics",
  "nonzero_ext",
  "reqwest 0.13.3",
+ "rstest",
  "serde",
  "serde_json",
  "sp1-cluster-artifact",

--- a/crates/proof/prover-service/Cargo.toml
+++ b/crates/proof/prover-service/Cargo.toml
@@ -63,6 +63,7 @@ metrics.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]
+rstest.workspace = true
 base-proof-primitives = { workspace = true, features = ["serde"] }
 tracing-subscriber = { workspace = true, features = ["env-filter", "fmt"] }
 

--- a/crates/proof/prover-service/db/src/conversions.rs
+++ b/crates/proof/prover-service/db/src/conversions.rs
@@ -245,6 +245,7 @@ mod tests {
             claimed_at: Some(now),
             last_heartbeat_at: Some(now),
             error_message: None,
+            result_payload: None,
             created_at: now,
             updated_at: now,
             completed_at: None,

--- a/crates/proof/prover-service/db/src/models.rs
+++ b/crates/proof/prover-service/db/src/models.rs
@@ -1051,6 +1051,12 @@ pub enum SubmitProofOutcome {
         /// Human-readable description of the mismatch.
         reason: String,
     },
+    /// An idempotent retry from the owning worker/lock submitted a result that
+    /// differs from the one already stored. The stored result is kept.
+    ResultConflict {
+        /// The already-completed job whose stored result was retained.
+        job: ProofJob,
+    },
     /// No proof job exists for the supplied `session_id`.
     NotFound,
     /// The job exists but is not currently claimed.

--- a/crates/proof/prover-service/db/src/models.rs
+++ b/crates/proof/prover-service/db/src/models.rs
@@ -59,11 +59,7 @@ impl TryFrom<&str> for ProofStatus {
     }
 }
 
-/// Worker-owned job lifecycle status, distinct from the requester [`ProofStatus`].
-///
-/// The worker API (`getNextProof` / `heartbeat` / `submitProof`) drives this field
-/// on the same `proof_requests` row, while `status` continues to model the
-/// requester-facing proof lifecycle.
+/// Worker-owned job lifecycle status, distinct from requester [`ProofStatus`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, sqlx::Type)]
 #[sqlx(type_name = "VARCHAR", rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum ProofJobStatus {
@@ -940,7 +936,7 @@ pub struct ClaimProofJob {
     pub zk_vms: Vec<ZkVmKind>,
     /// Lock duration in seconds. Callers must resolve the server default first.
     pub lock_duration_seconds: u32,
-    /// Reclaim budget: expired claims are only reclaimable while `attempt < max_attempts`.
+    /// Reclaim budget for expired claims.
     pub max_attempts: u32,
 }
 
@@ -960,15 +956,15 @@ pub struct HeartbeatProofJob {
 /// Outcome of attempting to heartbeat a worker proof job.
 #[derive(Debug, Clone)]
 pub enum HeartbeatOutcome {
-    /// The heartbeat succeeded and the returned job has the updated lock expiry.
+    /// Heartbeat succeeded.
     Updated(ProofJob),
     /// No proof job exists for the supplied `session_id`.
     NotFound,
     /// The job exists but is not currently claimed.
     NotClaimed(ProofJob),
-    /// The supplied `worker_id` or `lock_id` no longer owns the job.
+    /// The supplied worker or lock no longer owns the job.
     StaleLock(ProofJob),
-    /// The supplied lock matched the job, but it had already expired.
+    /// The lock matched the job but had expired.
     Expired(ProofJob),
     /// The job is already terminal.
     Terminal(ProofJob),
@@ -992,15 +988,15 @@ pub struct CompleteClaimedProofJob {
 /// Outcome of attempting to complete a worker proof job.
 #[derive(Debug, Clone)]
 pub enum SubmitProofOutcome {
-    /// The submit succeeded and the returned job is terminal `SUCCEEDED`.
+    /// Submit succeeded.
     Completed(ProofJob),
     /// No proof job exists for the supplied `session_id`.
     NotFound,
     /// The job exists but is not currently claimed.
     NotClaimed(ProofJob),
-    /// The supplied `worker_id` or `lock_id` no longer owns the job.
+    /// The supplied worker or lock no longer owns the job.
     StaleLock(ProofJob),
-    /// The supplied lock matched the job, but it had already expired.
+    /// The lock matched the job but had expired.
     Expired(ProofJob),
     /// The job is already terminal.
     Terminal(ProofJob),

--- a/crates/proof/prover-service/db/src/models.rs
+++ b/crates/proof/prover-service/db/src/models.rs
@@ -608,6 +608,59 @@ pub struct ProofJob {
     pub completed_at: Option<DateTime<Utc>>,
 }
 
+impl ProofJob {
+    /// Reject a submitted result whose variant or capability discriminator
+    /// (`zk_vm`/`tee_kind`) does not match this claimed job, returning the
+    /// mismatch reason. Guards against a worker storing the wrong proof type.
+    pub fn validate_submitted_result(&self, result: &ProtocolProofResult) -> Result<(), String> {
+        match result {
+            ProtocolProofResult::Compressed(zk) => {
+                self.check_api_proof_type(ApiProofType::Compressed)?;
+                self.check_zk_vm(ZkVmKind::from(zk.zk_vm))
+            }
+            ProtocolProofResult::SnarkGroth16(snark) => {
+                self.check_api_proof_type(ApiProofType::SnarkGroth16)?;
+                self.check_zk_vm(ZkVmKind::from(snark.proof.zk_vm))
+            }
+            ProtocolProofResult::Tee(tee) => {
+                self.check_api_proof_type(ApiProofType::Tee)?;
+                self.check_tee_kind(TeeKind::from(tee.tee_kind))
+            }
+        }
+    }
+
+    fn check_api_proof_type(&self, expected: ApiProofType) -> Result<(), String> {
+        if self.api_proof_type == expected {
+            Ok(())
+        } else {
+            Err(format!(
+                "submitted {expected} result but claimed job proof type is {}",
+                self.api_proof_type
+            ))
+        }
+    }
+
+    fn check_zk_vm(&self, submitted: ZkVmKind) -> Result<(), String> {
+        match self.zk_vm {
+            Some(expected) if expected == submitted => Ok(()),
+            Some(expected) => {
+                Err(format!("submitted zk_vm {submitted} but claimed job zk_vm is {expected}"))
+            }
+            None => Err(format!("submitted zk_vm {submitted} but claimed job has no zk_vm")),
+        }
+    }
+
+    fn check_tee_kind(&self, submitted: TeeKind) -> Result<(), String> {
+        match self.tee_kind {
+            Some(expected) if expected == submitted => Ok(()),
+            Some(expected) => Err(format!(
+                "submitted tee_kind {submitted} but claimed job tee_kind is {expected}"
+            )),
+            None => Err(format!("submitted tee_kind {submitted} but claimed job has no tee_kind")),
+        }
+    }
+}
+
 /// Offset pagination parameters.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ProofRequestPage {
@@ -990,6 +1043,14 @@ pub struct CompleteClaimedProofJob {
 pub enum SubmitProofOutcome {
     /// Submit succeeded.
     Completed(ProofJob),
+    /// The submitted result does not match the claimed job's proof type or
+    /// capability discriminator. The stored job is left unchanged.
+    ResultMismatch {
+        /// The claimed job whose proof type was violated.
+        job: ProofJob,
+        /// Human-readable description of the mismatch.
+        reason: String,
+    },
     /// No proof job exists for the supplied `session_id`.
     NotFound,
     /// The job exists but is not currently claimed.
@@ -1017,9 +1078,38 @@ pub struct FailExpiredProofJobs<'a> {
 
 #[cfg(test)]
 mod tests {
-    use base_prover_service_protocol::{ZkProofRequest, ZkVm};
+    use base_prover_service_protocol::{
+        SnarkGroth16ProofResult, ZkProofRequest, ZkProofResult, ZkVm,
+    };
 
     use super::*;
+
+    fn proof_job_with(
+        api_proof_type: ApiProofType,
+        zk_vm: Option<ZkVmKind>,
+        tee_kind: Option<TeeKind>,
+    ) -> ProofJob {
+        let now = Utc::now();
+        ProofJob {
+            id: Uuid::new_v4(),
+            session_id: "session-1".to_owned(),
+            request_payload: serde_json::Value::Null,
+            api_proof_type,
+            zk_vm,
+            tee_kind,
+            job_status: ProofJobStatus::Claimed,
+            attempt: 1,
+            worker_id: Some("worker-1".to_owned()),
+            lock_id: Some(Uuid::new_v4()),
+            lock_expires_at: Some(now),
+            claimed_at: Some(now),
+            last_heartbeat_at: Some(now),
+            error_message: None,
+            created_at: now,
+            updated_at: now,
+            completed_at: None,
+        }
+    }
 
     fn compressed_protocol_request(session_id: impl Into<String>) -> ProtocolProofRequest {
         ProtocolProofRequest {
@@ -1070,5 +1160,48 @@ mod tests {
         req.session_id = "other-session".to_owned();
 
         assert_eq!(req.validate(), Err(CreateProofRequestValidationError::SessionIdMismatch));
+    }
+
+    #[test]
+    fn validate_submitted_result_accepts_matching_compressed() {
+        let job = proof_job_with(ApiProofType::Compressed, Some(ZkVmKind::Sp1), None);
+        let result = ProtocolProofResult::Compressed(ZkProofResult {
+            zk_vm: ZkVm::Sp1,
+            proof: vec![0x01].into(),
+        });
+
+        assert_eq!(job.validate_submitted_result(&result), Ok(()));
+    }
+
+    #[test]
+    fn validate_submitted_result_rejects_wrong_variant() {
+        let job = proof_job_with(ApiProofType::Tee, None, Some(TeeKind::AwsNitro));
+        let result = ProtocolProofResult::Compressed(ZkProofResult {
+            zk_vm: ZkVm::Sp1,
+            proof: vec![0x01].into(),
+        });
+
+        assert!(job.validate_submitted_result(&result).is_err());
+    }
+
+    #[test]
+    fn validate_submitted_result_rejects_snark_for_compressed_job() {
+        let job = proof_job_with(ApiProofType::Compressed, Some(ZkVmKind::Sp1), None);
+        let result = ProtocolProofResult::SnarkGroth16(SnarkGroth16ProofResult {
+            proof: ZkProofResult { zk_vm: ZkVm::Sp1, proof: vec![0x01].into() },
+        });
+
+        assert!(job.validate_submitted_result(&result).is_err());
+    }
+
+    #[test]
+    fn validate_submitted_result_rejects_missing_zk_vm_capability() {
+        let job = proof_job_with(ApiProofType::Compressed, None, None);
+        let result = ProtocolProofResult::Compressed(ZkProofResult {
+            zk_vm: ZkVm::Sp1,
+            proof: vec![0x01].into(),
+        });
+
+        assert!(job.validate_submitted_result(&result).is_err());
     }
 }

--- a/crates/proof/prover-service/db/src/models.rs
+++ b/crates/proof/prover-service/db/src/models.rs
@@ -600,6 +600,8 @@ pub struct ProofJob {
     pub last_heartbeat_at: Option<DateTime<Utc>>,
     /// Error message when the job failed.
     pub error_message: Option<String>,
+    /// Stored protocol result payload once the job has completed.
+    pub result_payload: Option<serde_json::Value>,
     /// Timestamp when the job was created.
     pub created_at: DateTime<Utc>,
     /// Timestamp of the last update.
@@ -1111,6 +1113,7 @@ mod tests {
             claimed_at: Some(now),
             last_heartbeat_at: Some(now),
             error_message: None,
+            result_payload: None,
             created_at: now,
             updated_at: now,
             completed_at: None,

--- a/crates/proof/prover-service/db/src/repo.rs
+++ b/crates/proof/prover-service/db/src/repo.rs
@@ -553,22 +553,6 @@ impl ProofRequestRepo {
         row.as_ref().map(row_to_proof_job).transpose()
     }
 
-    /// Fetch the stored `result_payload` for a canonical `session_id`, if any.
-    async fn stored_result_payload(&self, session_id: &str) -> Result<Option<serde_json::Value>> {
-        let row = sqlx::query(
-            r#"
-            SELECT result_payload
-            FROM proof_requests
-            WHERE COALESCE(session_id, id::text) = $1
-            "#,
-        )
-        .bind(session_id)
-        .fetch_optional(&self.pool)
-        .await?;
-
-        Ok(row.and_then(|row| row.get::<Option<serde_json::Value>, _>("result_payload")))
-    }
-
     /// Extend the lock for the currently owned worker proof job (`heartbeat`).
     pub async fn heartbeat_proof_job(&self, req: HeartbeatProofJob) -> Result<HeartbeatOutcome> {
         let session_id = canonical_session_id(&req.session_id)
@@ -645,8 +629,7 @@ impl ProofRequestRepo {
             && existing.lock_id == Some(req.lock_id)
             && existing.worker_id.as_deref() == Some(req.worker_id.as_str())
         {
-            let stored = self.stored_result_payload(&session_id).await?;
-            return Ok(if stored.as_ref() == Some(&result_payload) {
+            return Ok(if existing.result_payload.as_ref() == Some(&result_payload) {
                 SubmitProofOutcome::Completed(existing)
             } else {
                 SubmitProofOutcome::ResultConflict { job: existing }
@@ -1903,6 +1886,7 @@ fn row_to_proof_job(row: &sqlx::postgres::PgRow) -> Result<ProofJob> {
         claimed_at: row.get("claimed_at"),
         last_heartbeat_at: row.get("last_heartbeat_at"),
         error_message: base.error_message,
+        result_payload: base.result_payload,
         created_at: base.created_at,
         updated_at: base.updated_at,
         completed_at: base.completed_at,

--- a/crates/proof/prover-service/db/src/repo.rs
+++ b/crates/proof/prover-service/db/src/repo.rs
@@ -553,6 +553,22 @@ impl ProofRequestRepo {
         row.as_ref().map(row_to_proof_job).transpose()
     }
 
+    /// Fetch the stored `result_payload` for a canonical `session_id`, if any.
+    async fn stored_result_payload(&self, session_id: &str) -> Result<Option<serde_json::Value>> {
+        let row = sqlx::query(
+            r#"
+            SELECT result_payload
+            FROM proof_requests
+            WHERE COALESCE(session_id, id::text) = $1
+            "#,
+        )
+        .bind(session_id)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        Ok(row.and_then(|row| row.get::<Option<serde_json::Value>, _>("result_payload")))
+    }
+
     /// Extend the lock for the currently owned worker proof job (`heartbeat`).
     pub async fn heartbeat_proof_job(&self, req: HeartbeatProofJob) -> Result<HeartbeatOutcome> {
         let session_id = canonical_session_id(&req.session_id)
@@ -621,16 +637,22 @@ impl ProofRequestRepo {
             return Ok(SubmitProofOutcome::ResultMismatch { job: existing, reason });
         }
 
-        // Idempotent retry: the same worker/lock already completed this job.
+        let result_payload =
+            serde_json::to_value(&req.result).map_err(|e| sqlx::Error::Encode(Box::new(e)))?;
+
+        // Idempotent retry by the owning worker/lock; a differing payload conflicts.
         if existing.job_status == ProofJobStatus::Succeeded
             && existing.lock_id == Some(req.lock_id)
             && existing.worker_id.as_deref() == Some(req.worker_id.as_str())
         {
-            return Ok(SubmitProofOutcome::Completed(existing));
+            let stored = self.stored_result_payload(&session_id).await?;
+            return Ok(if stored.as_ref() == Some(&result_payload) {
+                SubmitProofOutcome::Completed(existing)
+            } else {
+                SubmitProofOutcome::ResultConflict { job: existing }
+            });
         }
 
-        let result_payload =
-            serde_json::to_value(&req.result).map_err(|e| sqlx::Error::Encode(Box::new(e)))?;
         let (stark_receipt, snark_receipt) = compatibility_receipts_for_result(&req.result);
         let submitted_lock_id = req.lock_id.to_string();
         let columns = PROOF_JOB_RETURNING_COLUMNS;

--- a/crates/proof/prover-service/db/src/repo.rs
+++ b/crates/proof/prover-service/db/src/repo.rs
@@ -611,6 +611,24 @@ impl ProofRequestRepo {
     ) -> Result<SubmitProofOutcome> {
         let session_id = canonical_session_id(&req.session_id)
             .map_err(|e| sqlx::Error::InvalidArgument(e.to_string()))?;
+
+        // Read first to validate the result type and detect idempotent retries.
+        let Some(existing) = self.get_proof_job_by_canonical_session_id(&session_id).await? else {
+            return Ok(SubmitProofOutcome::NotFound);
+        };
+
+        if let Err(reason) = existing.validate_submitted_result(&req.result) {
+            return Ok(SubmitProofOutcome::ResultMismatch { job: existing, reason });
+        }
+
+        // Idempotent retry: the same worker/lock already completed this job.
+        if existing.job_status == ProofJobStatus::Succeeded
+            && existing.lock_id == Some(req.lock_id)
+            && existing.worker_id.as_deref() == Some(req.worker_id.as_str())
+        {
+            return Ok(SubmitProofOutcome::Completed(existing));
+        }
+
         let result_payload =
             serde_json::to_value(&req.result).map_err(|e| sqlx::Error::Encode(Box::new(e)))?;
         let (stark_receipt, snark_receipt) = compatibility_receipts_for_result(&req.result);

--- a/crates/proof/prover-service/db/src/repo.rs
+++ b/crates/proof/prover-service/db/src/repo.rs
@@ -612,10 +612,43 @@ impl ProofRequestRepo {
         let session_id = canonical_session_id(&req.session_id)
             .map_err(|e| sqlx::Error::InvalidArgument(e.to_string()))?;
 
-        // Read first to validate the result type and detect idempotent retries.
+        // Read first to classify ownership state and detect idempotent retries.
         let Some(existing) = self.get_proof_job_by_canonical_session_id(&session_id).await? else {
             return Ok(SubmitProofOutcome::NotFound);
         };
+
+        // Idempotent retry by the owning worker/lock; a differing payload conflicts.
+        if existing.job_status == ProofJobStatus::Succeeded
+            && existing.lock_id == Some(req.lock_id)
+            && existing.worker_id.as_deref() == Some(req.worker_id.as_str())
+        {
+            if let Err(reason) = existing.validate_submitted_result(&req.result) {
+                return Ok(SubmitProofOutcome::ResultMismatch { job: existing, reason });
+            }
+
+            let result_payload =
+                serde_json::to_value(&req.result).map_err(|e| sqlx::Error::Encode(Box::new(e)))?;
+
+            return Ok(if existing.result_payload.as_ref() == Some(&result_payload) {
+                SubmitProofOutcome::Completed(existing)
+            } else {
+                SubmitProofOutcome::ResultConflict { job: existing }
+            });
+        }
+        if matches!(existing.job_status, ProofJobStatus::Succeeded | ProofJobStatus::Failed) {
+            return Ok(SubmitProofOutcome::Terminal(existing));
+        }
+        if existing.job_status != ProofJobStatus::Claimed {
+            return Ok(SubmitProofOutcome::NotClaimed(existing));
+        }
+        if existing.lock_id != Some(req.lock_id)
+            || existing.worker_id.as_deref() != Some(req.worker_id.as_str())
+        {
+            return Ok(SubmitProofOutcome::StaleLock(existing));
+        }
+        if existing.lock_expires_at.is_none_or(|expires_at| expires_at <= Utc::now()) {
+            return Ok(SubmitProofOutcome::Expired(existing));
+        }
 
         if let Err(reason) = existing.validate_submitted_result(&req.result) {
             return Ok(SubmitProofOutcome::ResultMismatch { job: existing, reason });
@@ -623,18 +656,6 @@ impl ProofRequestRepo {
 
         let result_payload =
             serde_json::to_value(&req.result).map_err(|e| sqlx::Error::Encode(Box::new(e)))?;
-
-        // Idempotent retry by the owning worker/lock; a differing payload conflicts.
-        if existing.job_status == ProofJobStatus::Succeeded
-            && existing.lock_id == Some(req.lock_id)
-            && existing.worker_id.as_deref() == Some(req.worker_id.as_str())
-        {
-            return Ok(if existing.result_payload.as_ref() == Some(&result_payload) {
-                SubmitProofOutcome::Completed(existing)
-            } else {
-                SubmitProofOutcome::ResultConflict { job: existing }
-            });
-        }
 
         let (stark_receipt, snark_receipt) = compatibility_receipts_for_result(&req.result);
         let submitted_lock_id = req.lock_id.to_string();

--- a/crates/proof/prover-service/db/src/repo.rs
+++ b/crates/proof/prover-service/db/src/repo.rs
@@ -63,18 +63,7 @@ impl ProofRequestRepo {
         Ok(prepared.id)
     }
 
-    /// Atomically create a proof request for the worker API queue.
-    ///
-    /// New requests are inserted into `proof_requests` with `job_status = 'PENDING'`
-    /// by the schema default. External workers claim these rows via
-    /// [`Self::claim_next_proof_job`].
-    ///
-    /// On `session_id` conflict, lock the row `FOR UPDATE` and branch on state:
-    /// parameter mismatch -> [`CreateProofRequestError::IdCollision`];
-    /// `CREATED` / `PENDING` / `RUNNING` / `SUCCEEDED` -> [`CreateProofRequestOutcome::Replayed`];
-    /// `FAILED` with room under `max_retries` -> reset, bump `retry_count`,
-    /// and make the job claimable again ([`CreateProofRequestOutcome::Requeued`]);
-    /// `FAILED` at cap -> [`CreateProofRequestOutcome::RetryExhausted`].
+    /// Atomically create or replay a proof request for the worker API queue.
     pub async fn create_for_worker_queue(
         &self,
         req: CreateProofRequest,
@@ -519,17 +508,8 @@ impl ProofRequestRepo {
 
     /// Atomically claim the next eligible worker proof job (`getNextProof`).
     ///
-    /// Selects the lowest-start-block job whose `api_proof_type` matches the
-    /// worker and whose capability discriminator (`tee_kind` for TEE, `zk_vm` for
-    /// ZK) is in the worker's advertised set. A job is claimable when it is
-    /// `PENDING`, or when it is `CLAIMED` with an expired lock and still under the
-    /// reclaim budget (`attempt < max_attempts`). The row is locked with
-    /// `FOR UPDATE SKIP LOCKED` so concurrent workers never claim the same job.
-    ///
-    /// On success the job transitions to `job_status = 'CLAIMED'` and requester
-    /// `status = 'RUNNING'`, with a freshly rotated `lock_id`, incremented
-    /// `attempt`, and an extended `lock_expires_at`. Returns `None` when no job is
-    /// eligible (including when the worker advertises no matching capabilities).
+    /// Expired claims are reclaimable while `attempt < max_attempts`. Rows are
+    /// locked with `FOR UPDATE SKIP LOCKED` so concurrent workers do not double-claim.
     pub async fn claim_next_proof_job(&self, req: ClaimProofJob) -> Result<Option<ProofJob>> {
         let lock_id = Uuid::new_v4();
         let sql = claim_query(req.api_proof_type);
@@ -574,11 +554,6 @@ impl ProofRequestRepo {
     }
 
     /// Extend the lock for the currently owned worker proof job (`heartbeat`).
-    ///
-    /// The update is guarded by `session_id`, `job_status = 'CLAIMED'`, `lock_id`,
-    /// `worker_id`, and an unexpired `lock_expires_at`. A stale worker cannot
-    /// revive an expired or reclaimed job because the update only succeeds for the
-    /// current fencing token.
     pub async fn heartbeat_proof_job(&self, req: HeartbeatProofJob) -> Result<HeartbeatOutcome> {
         let session_id = canonical_session_id(&req.session_id)
             .map_err(|e| sqlx::Error::InvalidArgument(e.to_string()))?;
@@ -630,11 +605,6 @@ impl ProofRequestRepo {
     }
 
     /// Complete the currently owned worker proof job (`submitProof`).
-    ///
-    /// The ownership guard matches [`Self::heartbeat_proof_job`]. On success the
-    /// worker job and requester proof both transition to `SUCCEEDED`,
-    /// `result_payload` stores the protocol result, and ZK results are mirrored
-    /// into legacy receipt columns for compatibility.
     pub async fn complete_claimed_proof_job(
         &self,
         req: CompleteClaimedProofJob,
@@ -702,13 +672,7 @@ impl ProofRequestRepo {
         Ok(SubmitProofOutcome::Unknown(job))
     }
 
-    /// Terminally fail expired worker jobs that have exhausted their claim attempts.
-    ///
-    /// Worker execution failure is represented by lock expiry. Jobs remain
-    /// reclaimable while `attempt < max_attempts`; once an expired claim reaches
-    /// the budget, this reaper transition marks both the worker job and requester
-    /// proof `FAILED` and stores `error_message`. The update is batched and uses
-    /// `FOR UPDATE SKIP LOCKED` to avoid locking the full expired backlog.
+    /// Terminally fail expired worker jobs with `attempt >= max_attempts`.
     pub async fn fail_expired_proof_jobs(
         &self,
         req: FailExpiredProofJobs<'_>,

--- a/crates/proof/prover-service/db/tests/postgres_integration.rs
+++ b/crates/proof/prover-service/db/tests/postgres_integration.rs
@@ -1643,6 +1643,21 @@ async fn test_complete_claimed_proof_job_rejects_mismatched_result() {
         .expect("compressed job should be claimed");
     let lock_id = claimed.lock_id.expect("claimed job has lock");
 
+    // Non-owners are rejected before result-type validation, so mismatched
+    // submissions do not expose the job's expected proof result shape.
+    let stale_mismatch = repo
+        .complete_claimed_proof_job(CompleteClaimedProofJob {
+            session_id: claimed.session_id.clone(),
+            lock_id: Uuid::new_v4(),
+            worker_id: "non-owner".to_owned(),
+            result: ProtocolProofResult::SnarkGroth16(SnarkGroth16ProofResult {
+                proof: ZkProofResult { zk_vm: ZkVm::Sp1, proof: vec![0x01].into() },
+            }),
+        })
+        .await
+        .unwrap();
+    assert!(matches!(stale_mismatch, SubmitProofOutcome::StaleLock(_)));
+
     // A valid lock for a compressed job must not store a SNARK result.
     let mismatch = repo
         .complete_claimed_proof_job(CompleteClaimedProofJob {

--- a/crates/proof/prover-service/db/tests/postgres_integration.rs
+++ b/crates/proof/prover-service/db/tests/postgres_integration.rs
@@ -1576,20 +1576,79 @@ async fn test_complete_claimed_proof_job_guards_and_stores_result() {
             .expect("stored result should deserialize");
     assert_eq!(stored, result);
 
-    let duplicate = repo
+    // An identical retry from the same worker/lock is idempotent.
+    let replay = repo
         .complete_claimed_proof_job(CompleteClaimedProofJob {
-            session_id: uppercase_session_id,
+            session_id: uppercase_session_id.clone(),
             lock_id,
             worker_id: "submit-worker".to_owned(),
-            result: compressed_result(vec![0xba, 0xad]),
+            result: result.clone(),
         })
         .await
         .unwrap();
-    assert!(matches!(duplicate, SubmitProofOutcome::Terminal(_)));
+    let SubmitProofOutcome::Completed(replayed) = replay else {
+        panic!("identical retry should be idempotent");
+    };
+    assert_eq!(replayed.job_status, ProofJobStatus::Succeeded);
     assert_eq!(
         repo.get(id).await.unwrap().unwrap().stark_receipt.as_deref(),
         Some(&[0xca, 0xfe][..])
     );
+
+    // A retry that no longer owns the lock still sees a terminal job.
+    let foreign = repo
+        .complete_claimed_proof_job(CompleteClaimedProofJob {
+            session_id: uppercase_session_id,
+            lock_id: Uuid::new_v4(),
+            worker_id: "submit-worker".to_owned(),
+            result: result.clone(),
+        })
+        .await
+        .unwrap();
+    assert!(matches!(foreign, SubmitProofOutcome::Terminal(_)));
+    assert_eq!(
+        repo.get(id).await.unwrap().unwrap().stark_receipt.as_deref(),
+        Some(&[0xca, 0xfe][..])
+    );
+}
+
+#[tokio::test]
+#[ignore = "requires a running Postgres with the prover schema (set DATABASE_URL); run with `cargo nextest run --run-ignored all -p base-prover-service-db --test postgres_integration --test-threads=1`"]
+async fn test_complete_claimed_proof_job_rejects_mismatched_result() {
+    let pool = test_pool().await;
+    let repo = test_repo(pool);
+
+    drain_claimable_compressed_jobs(&repo).await;
+    let id = repo.create(compressed_request()).await.unwrap();
+    let claimed = repo
+        .claim_next_proof_job(compressed_claim("mismatch-worker", 3))
+        .await
+        .unwrap()
+        .expect("compressed job should be claimed");
+    let lock_id = claimed.lock_id.expect("claimed job has lock");
+
+    // A valid lock for a compressed job must not store a SNARK result.
+    let mismatch = repo
+        .complete_claimed_proof_job(CompleteClaimedProofJob {
+            session_id: claimed.session_id.clone(),
+            lock_id,
+            worker_id: "mismatch-worker".to_owned(),
+            result: ProtocolProofResult::SnarkGroth16(SnarkGroth16ProofResult {
+                proof: ZkProofResult { zk_vm: ZkVm::Sp1, proof: vec![0x01].into() },
+            }),
+        })
+        .await
+        .unwrap();
+    assert!(matches!(mismatch, SubmitProofOutcome::ResultMismatch { .. }));
+
+    // The job is left untouched.
+    let job = repo
+        .get_proof_job_by_session_id(&claimed.session_id)
+        .await
+        .unwrap()
+        .expect("job still exists");
+    assert_eq!(job.job_status, ProofJobStatus::Claimed);
+    assert!(repo.get(id).await.unwrap().unwrap().result_payload.is_none());
 }
 
 #[tokio::test]

--- a/crates/proof/prover-service/db/tests/postgres_integration.rs
+++ b/crates/proof/prover-service/db/tests/postgres_integration.rs
@@ -1595,6 +1595,22 @@ async fn test_complete_claimed_proof_job_guards_and_stores_result() {
         Some(&[0xca, 0xfe][..])
     );
 
+    // Same worker/lock, different payload: conflict, stored result kept.
+    let conflict = repo
+        .complete_claimed_proof_job(CompleteClaimedProofJob {
+            session_id: uppercase_session_id.clone(),
+            lock_id,
+            worker_id: "submit-worker".to_owned(),
+            result: compressed_result(vec![0xba, 0xad]),
+        })
+        .await
+        .unwrap();
+    assert!(matches!(conflict, SubmitProofOutcome::ResultConflict { .. }));
+    assert_eq!(
+        repo.get(id).await.unwrap().unwrap().stark_receipt.as_deref(),
+        Some(&[0xca, 0xfe][..])
+    );
+
     // A retry that no longer owns the lock still sees a terminal job.
     let foreign = repo
         .complete_claimed_proof_job(CompleteClaimedProofJob {

--- a/crates/proof/prover-service/src/lib.rs
+++ b/crates/proof/prover-service/src/lib.rs
@@ -30,7 +30,7 @@ pub use request::{ExecutionStats, ProveBlockRequest};
 #[cfg(feature = "rpc-server")]
 mod server;
 #[cfg(feature = "rpc-server")]
-pub use server::{ProverServiceServer, WorkerApiConfig};
+pub use server::{ProverServiceServer, ServerConfig, WorkerApiConfig};
 
 #[cfg(feature = "rpc-client")]
 mod snark_e2e;

--- a/crates/proof/prover-service/src/lib.rs
+++ b/crates/proof/prover-service/src/lib.rs
@@ -30,7 +30,7 @@ pub use request::{ExecutionStats, ProveBlockRequest};
 #[cfg(feature = "rpc-server")]
 mod server;
 #[cfg(feature = "rpc-server")]
-pub use server::ProverServiceServer;
+pub use server::{ProverServiceServer, WorkerApiConfig};
 
 #[cfg(feature = "rpc-client")]
 mod snark_e2e;

--- a/crates/proof/prover-service/src/server/mod.rs
+++ b/crates/proof/prover-service/src/server/mod.rs
@@ -34,9 +34,6 @@ pub struct WorkerApiConfig {
 }
 
 impl WorkerApiConfig {
-    /// Default worker API tuning.
-    pub const DEFAULT: Self = Self::new(300, 3600);
-
     /// Create worker API tuning.
     pub const fn new(default_lock_duration_seconds: u32, max_lock_duration_seconds: u32) -> Self {
         let config = Self { default_lock_duration_seconds, max_lock_duration_seconds };
@@ -55,8 +52,19 @@ impl WorkerApiConfig {
 
 impl Default for WorkerApiConfig {
     fn default() -> Self {
-        Self::DEFAULT
+        Self::new(300, 3600)
     }
+}
+
+/// Tuning for the prover service JSON-RPC server.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ServerConfig {
+    /// Shared `retry_count` cap with [`crate::worker::StatusPoller`].
+    pub max_proof_retries: i32,
+    /// Worker job lock-duration tuning.
+    pub worker: WorkerApiConfig,
+    /// Shared worker-claim reclaim budget.
+    pub worker_queue: WorkerQueueConfig,
 }
 
 /// JSON-RPC server implementing the requester and worker API traits.
@@ -64,21 +72,12 @@ impl Default for WorkerApiConfig {
 pub struct ProverServiceServer {
     repo: ProofRequestRepo,
     manager: ProofRequestManager,
-    /// Shared `retry_count` cap with [`crate::worker::StatusPoller`].
-    max_proof_retries: i32,
-    /// Worker job lock-duration tuning.
-    worker: WorkerApiConfig,
-    /// Shared worker-claim reclaim budget.
-    worker_queue: WorkerQueueConfig,
+    config: ServerConfig,
 }
 
 impl fmt::Debug for ProverServiceServer {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("ProverServiceServer")
-            .field("max_proof_retries", &self.max_proof_retries)
-            .field("worker", &self.worker)
-            .field("worker_queue", &self.worker_queue)
-            .finish_non_exhaustive()
+        f.debug_struct("ProverServiceServer").field("config", &self.config).finish_non_exhaustive()
     }
 }
 
@@ -87,18 +86,10 @@ impl ProverServiceServer {
     pub const fn new(
         repo: ProofRequestRepo,
         manager: ProofRequestManager,
-        max_proof_retries: i32,
-        worker_queue: WorkerQueueConfig,
+        config: ServerConfig,
     ) -> Self {
-        Self { repo, manager, max_proof_retries, worker: WorkerApiConfig::DEFAULT, worker_queue }
-    }
-
-    /// Override worker lock-duration tuning.
-    #[must_use]
-    pub const fn with_worker_config(mut self, worker: WorkerApiConfig) -> Self {
-        worker.validate();
-        self.worker = worker;
-        self
+        config.worker.validate();
+        Self { repo, manager, config }
     }
 }
 

--- a/crates/proof/prover-service/src/server/mod.rs
+++ b/crates/proof/prover-service/src/server/mod.rs
@@ -12,30 +12,72 @@ use jsonrpsee::{
     types::{ErrorCode, ErrorObjectOwned},
 };
 
-use crate::ProofRequestManager;
+use crate::{ProofRequestManager, WorkerQueueConfig};
 
 mod get_proof;
 mod list_proofs;
 mod prove_block_range;
+mod worker_api;
 
 const ERROR_NOT_FOUND: i32 = -32004;
 const ERROR_UNAVAILABLE: i32 = -32014;
 const ERROR_RESOURCE_EXHAUSTED: i32 = -32016;
 const ERROR_FAILED_PRECONDITION: i32 = -32017;
 
-/// JSON-RPC server implementing the requester API trait.
+/// Lock duration tuning for the worker job API.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct WorkerApiConfig {
+    /// Lock duration applied when a worker requests `0` seconds.
+    pub default_lock_duration_seconds: u32,
+    /// Upper bound a worker-requested lock duration is clamped to.
+    pub max_lock_duration_seconds: u32,
+}
+
+impl WorkerApiConfig {
+    /// Default worker API tuning.
+    pub const DEFAULT: Self = Self::new(300, 3600);
+
+    /// Create worker API tuning.
+    pub const fn new(default_lock_duration_seconds: u32, max_lock_duration_seconds: u32) -> Self {
+        let config = Self { default_lock_duration_seconds, max_lock_duration_seconds };
+        config.validate();
+        config
+    }
+
+    /// Panics if the default lock duration exceeds the max.
+    pub const fn validate(&self) {
+        assert!(
+            self.default_lock_duration_seconds <= self.max_lock_duration_seconds,
+            "default lock duration must not exceed max lock duration"
+        );
+    }
+}
+
+impl Default for WorkerApiConfig {
+    fn default() -> Self {
+        Self::DEFAULT
+    }
+}
+
+/// JSON-RPC server implementing the requester and worker API traits.
 #[derive(Clone)]
 pub struct ProverServiceServer {
     repo: ProofRequestRepo,
     manager: ProofRequestManager,
-    /// Shared `retry_count` cap with [`crate::worker::StatusPoller`] (same as `retry_or_fail_stuck_request`).
+    /// Shared `retry_count` cap with [`crate::worker::StatusPoller`].
     max_proof_retries: i32,
+    /// Worker job lock-duration tuning.
+    worker: WorkerApiConfig,
+    /// Shared worker-claim reclaim budget.
+    worker_queue: WorkerQueueConfig,
 }
 
 impl fmt::Debug for ProverServiceServer {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("ProverServiceServer")
             .field("max_proof_retries", &self.max_proof_retries)
+            .field("worker", &self.worker)
+            .field("worker_queue", &self.worker_queue)
             .finish_non_exhaustive()
     }
 }
@@ -46,8 +88,17 @@ impl ProverServiceServer {
         repo: ProofRequestRepo,
         manager: ProofRequestManager,
         max_proof_retries: i32,
+        worker_queue: WorkerQueueConfig,
     ) -> Self {
-        Self { repo, manager, max_proof_retries }
+        Self { repo, manager, max_proof_retries, worker: WorkerApiConfig::DEFAULT, worker_queue }
+    }
+
+    /// Override worker lock-duration tuning.
+    #[must_use]
+    pub const fn with_worker_config(mut self, worker: WorkerApiConfig) -> Self {
+        worker.validate();
+        self.worker = worker;
+        self
     }
 }
 
@@ -113,4 +164,25 @@ fn record_rpc_result<T>(method: &str, start: std::time::Instant, result: &RpcRes
     let elapsed_ms = start.elapsed().as_secs_f64() * 1000.0;
     crate::metrics::inc_requests(method, success, status_code);
     crate::metrics::record_response_latency(method, success, elapsed_ms);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::WorkerApiConfig;
+
+    #[test]
+    fn worker_api_config_new_accepts_valid_durations() {
+        let config = WorkerApiConfig::new(300, 3600);
+
+        assert_eq!(
+            config,
+            WorkerApiConfig { default_lock_duration_seconds: 300, max_lock_duration_seconds: 3600 }
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "default lock duration must not exceed max lock duration")]
+    fn worker_api_config_new_rejects_default_greater_than_max() {
+        let _ = WorkerApiConfig::new(3601, 3600);
+    }
 }

--- a/crates/proof/prover-service/src/server/prove_block_range.rs
+++ b/crates/proof/prover-service/src/server/prove_block_range.rs
@@ -59,7 +59,7 @@ impl ProverServiceServer {
 
         let outcome = self
             .repo
-            .create_for_worker_queue(db_request, self.max_proof_retries)
+            .create_for_worker_queue(db_request, self.config.max_proof_retries)
             .await
             .map_err(|e| match e {
                 CreateProofRequestError::IdCollision { id, field } => {
@@ -90,7 +90,7 @@ impl ProverServiceServer {
                 warn!(
                     proof_request_id = %id,
                     session_id = %session_id,
-                    max_proof_retries = self.max_proof_retries,
+                    max_proof_retries = self.config.max_proof_retries,
                     "rejected ProveBlockRange: proof request retry budget exhausted for this session_id",
                 );
                 return Err(resource_exhausted(format!(

--- a/crates/proof/prover-service/src/server/worker_api.rs
+++ b/crates/proof/prover-service/src/server/worker_api.rs
@@ -203,6 +203,17 @@ impl ProverServiceServer {
                     request.session_id
                 )))
             }
+            SubmitProofOutcome::ResultConflict { .. } => {
+                warn!(
+                    worker_id = %request.worker_id,
+                    session_id = %request.session_id,
+                    "rejected worker proof submission: job already completed with a different result"
+                );
+                Err(failed_precondition(format!(
+                    "submit_proof rejected for session_id {}: job already completed with a different result",
+                    request.session_id
+                )))
+            }
             SubmitProofOutcome::NotFound => {
                 Err(not_found(format!("proof job not found for session_id {}", request.session_id)))
             }

--- a/crates/proof/prover-service/src/server/worker_api.rs
+++ b/crates/proof/prover-service/src/server/worker_api.rs
@@ -65,10 +65,10 @@ impl ProverServiceServer {
             tee_kinds: request.tee_kinds.into_iter().map(Into::into).collect(),
             zk_vms: request.zk_vms.into_iter().map(Into::into).collect(),
             lock_duration_seconds: resolve_lock_duration(
-                self.worker,
+                self.config.worker,
                 request.lock_duration_seconds,
             ),
-            max_attempts: self.worker_queue.reclaim_attempts,
+            max_attempts: self.config.worker_queue.reclaim_attempts,
         };
 
         let job = self
@@ -114,7 +114,10 @@ impl ProverServiceServer {
                 session_id: canonical_session_id,
                 lock_id,
                 worker_id,
-                lock_duration_seconds: resolve_lock_duration(self.worker, lock_duration_seconds),
+                lock_duration_seconds: resolve_lock_duration(
+                    self.config.worker,
+                    lock_duration_seconds,
+                ),
             })
             .await
             .map_err(|e| internal(format!("Database error: {e}")))?;
@@ -188,6 +191,18 @@ impl ProverServiceServer {
                 );
                 Ok(WorkerSubmitProofResponse { job: into_protocol_job(job)? })
             }
+            SubmitProofOutcome::ResultMismatch { reason, .. } => {
+                warn!(
+                    worker_id = %request.worker_id,
+                    session_id = %request.session_id,
+                    reason = %reason,
+                    "rejected worker proof submission: result does not match claimed job"
+                );
+                Err(invalid_argument(format!(
+                    "submit_proof rejected for session_id {}: {reason}",
+                    request.session_id
+                )))
+            }
             SubmitProofOutcome::NotFound => {
                 Err(not_found(format!("proof job not found for session_id {}", request.session_id)))
             }
@@ -249,29 +264,17 @@ fn reject_ownership(method: &str, session_id: &str, reason: &str) -> ErrorObject
 
 #[cfg(test)]
 mod tests {
+    use rstest::rstest;
     use uuid::Uuid;
 
     use super::{WorkerApiConfig, parse_lock_id, resolve_lock_duration};
 
-    #[test]
-    fn resolve_lock_duration_uses_default_for_zero() {
-        let config = WorkerApiConfig::DEFAULT;
-        assert_eq!(resolve_lock_duration(config, 0), config.default_lock_duration_seconds);
-    }
-
-    #[test]
-    fn resolve_lock_duration_clamps_to_max() {
-        let config = WorkerApiConfig::DEFAULT;
-        assert_eq!(
-            resolve_lock_duration(config, config.max_lock_duration_seconds + 1),
-            config.max_lock_duration_seconds
-        );
-    }
-
-    #[test]
-    fn resolve_lock_duration_passes_through_in_range() {
-        let config = WorkerApiConfig::DEFAULT;
-        assert_eq!(resolve_lock_duration(config, 120), 120);
+    #[rstest]
+    #[case::zero_uses_default(0, 300)]
+    #[case::above_max_clamps(3601, 3600)]
+    #[case::in_range_passes_through(120, 120)]
+    fn resolve_lock_duration_resolves(#[case] requested: u32, #[case] expected: u32) {
+        assert_eq!(resolve_lock_duration(WorkerApiConfig::default(), requested), expected);
     }
 
     #[test]

--- a/crates/proof/prover-service/src/server/worker_api.rs
+++ b/crates/proof/prover-service/src/server/worker_api.rs
@@ -1,0 +1,288 @@
+//! Implementation of the prover worker JSON-RPC endpoints.
+
+use base_prover_service_db::{
+    ClaimProofJob, CompleteClaimedProofJob, HeartbeatOutcome, HeartbeatProofJob,
+    SubmitProofOutcome, canonical_session_id,
+};
+use base_prover_service_protocol::{
+    GetNextProofRequest, GetNextProofResponse, HeartbeatRequest, HeartbeatResponse,
+    ProofJob as ProtocolProofJob, ProverWorkerApiServer, WorkerSubmitProofRequest,
+    WorkerSubmitProofResponse,
+};
+use jsonrpsee::{
+    core::{RpcResult, async_trait},
+    types::ErrorObjectOwned,
+};
+use tracing::{info, warn};
+use uuid::Uuid;
+
+use crate::server::{
+    ProverServiceServer, WorkerApiConfig, failed_precondition, internal, invalid_argument,
+    not_found, record_rpc_result,
+};
+
+#[async_trait]
+impl ProverWorkerApiServer for ProverServiceServer {
+    async fn get_next_proof(
+        &self,
+        request: GetNextProofRequest,
+    ) -> RpcResult<GetNextProofResponse> {
+        self.get_next_proof_impl(request).await
+    }
+
+    async fn heartbeat(&self, request: HeartbeatRequest) -> RpcResult<HeartbeatResponse> {
+        self.heartbeat_impl(request).await
+    }
+
+    async fn submit_proof(
+        &self,
+        request: WorkerSubmitProofRequest,
+    ) -> RpcResult<WorkerSubmitProofResponse> {
+        self.submit_proof_impl(request).await
+    }
+}
+
+impl ProverServiceServer {
+    /// Atomically claims and returns the next eligible worker proof job.
+    pub async fn get_next_proof_impl(
+        &self,
+        request: GetNextProofRequest,
+    ) -> RpcResult<GetNextProofResponse> {
+        let start = std::time::Instant::now();
+        let result = self.get_next_proof_inner(request).await;
+        record_rpc_result("GetNextProof", start, &result);
+
+        result
+    }
+
+    async fn get_next_proof_inner(
+        &self,
+        request: GetNextProofRequest,
+    ) -> RpcResult<GetNextProofResponse> {
+        let claim = ClaimProofJob {
+            worker_id: request.worker_id,
+            api_proof_type: request.proof_type.into(),
+            tee_kinds: request.tee_kinds.into_iter().map(Into::into).collect(),
+            zk_vms: request.zk_vms.into_iter().map(Into::into).collect(),
+            lock_duration_seconds: resolve_lock_duration(
+                self.worker,
+                request.lock_duration_seconds,
+            ),
+            max_attempts: self.worker_queue.reclaim_attempts,
+        };
+
+        let job = self
+            .repo
+            .claim_next_proof_job(claim)
+            .await
+            .map_err(|e| internal(format!("Database error: {e}")))?;
+
+        match job {
+            Some(job) => {
+                let worker_id = job.worker_id.as_deref().unwrap_or("<unknown>");
+                info!(
+                    worker_id = %worker_id,
+                    session_id = %job.session_id,
+                    api_proof_type = %job.api_proof_type,
+                    attempt = job.attempt,
+                    "claimed proof job for worker"
+                );
+                Ok(GetNextProofResponse { job: Some(into_protocol_job(job)?) })
+            }
+            None => Ok(GetNextProofResponse { job: None }),
+        }
+    }
+
+    /// Extends the lock on a worker-owned proof job.
+    pub async fn heartbeat_impl(&self, request: HeartbeatRequest) -> RpcResult<HeartbeatResponse> {
+        let start = std::time::Instant::now();
+        let result = self.heartbeat_inner(request).await;
+        record_rpc_result("Heartbeat", start, &result);
+
+        result
+    }
+
+    async fn heartbeat_inner(&self, request: HeartbeatRequest) -> RpcResult<HeartbeatResponse> {
+        let HeartbeatRequest { session_id, lock_id, worker_id, lock_duration_seconds } = request;
+        let canonical_session_id =
+            canonical_session_id(&session_id).map_err(|e| invalid_argument(format!("{e}")))?;
+        let lock_id = parse_lock_id(&lock_id)?;
+
+        let outcome = self
+            .repo
+            .heartbeat_proof_job(HeartbeatProofJob {
+                session_id: canonical_session_id,
+                lock_id,
+                worker_id,
+                lock_duration_seconds: resolve_lock_duration(self.worker, lock_duration_seconds),
+            })
+            .await
+            .map_err(|e| internal(format!("Database error: {e}")))?;
+
+        match outcome {
+            HeartbeatOutcome::Updated(job) => {
+                Ok(HeartbeatResponse { job: into_protocol_job(job)? })
+            }
+            HeartbeatOutcome::NotFound => {
+                Err(not_found(format!("proof job not found for session_id {session_id}")))
+            }
+            HeartbeatOutcome::NotClaimed(_) => {
+                Err(reject_ownership("heartbeat", &session_id, "job is not currently claimed"))
+            }
+            HeartbeatOutcome::StaleLock(_) => Err(reject_ownership(
+                "heartbeat",
+                &session_id,
+                "lock is held by another worker or has been rotated",
+            )),
+            HeartbeatOutcome::Expired(_) => {
+                Err(reject_ownership("heartbeat", &session_id, "lock has expired"))
+            }
+            HeartbeatOutcome::Terminal(_) => Err(reject_ownership(
+                "heartbeat",
+                &session_id,
+                "job has already reached a terminal state",
+            )),
+            HeartbeatOutcome::Unknown(_) => {
+                Err(reject_ownership("heartbeat", &session_id, "lock is no longer valid"))
+            }
+        }
+    }
+
+    /// Records a worker proof submission and completes the job.
+    pub async fn submit_proof_impl(
+        &self,
+        request: WorkerSubmitProofRequest,
+    ) -> RpcResult<WorkerSubmitProofResponse> {
+        let start = std::time::Instant::now();
+        let result = self.submit_proof_inner(request).await;
+        record_rpc_result("SubmitProof", start, &result);
+
+        result
+    }
+
+    async fn submit_proof_inner(
+        &self,
+        request: WorkerSubmitProofRequest,
+    ) -> RpcResult<WorkerSubmitProofResponse> {
+        let session_id = canonical_session_id(&request.session_id)
+            .map_err(|e| invalid_argument(format!("{e}")))?;
+        let lock_id = parse_lock_id(&request.lock_id)?;
+
+        let outcome = self
+            .repo
+            .complete_claimed_proof_job(CompleteClaimedProofJob {
+                session_id,
+                lock_id,
+                worker_id: request.worker_id.clone(),
+                result: request.result,
+            })
+            .await
+            .map_err(|e| internal(format!("Database error: {e}")))?;
+
+        match outcome {
+            SubmitProofOutcome::Completed(job) => {
+                info!(
+                    worker_id = %request.worker_id,
+                    session_id = %request.session_id,
+                    "worker submitted proof result"
+                );
+                Ok(WorkerSubmitProofResponse { job: into_protocol_job(job)? })
+            }
+            SubmitProofOutcome::NotFound => {
+                Err(not_found(format!("proof job not found for session_id {}", request.session_id)))
+            }
+            SubmitProofOutcome::NotClaimed(_) => Err(reject_ownership(
+                "submit_proof",
+                &request.session_id,
+                "job is not currently claimed",
+            )),
+            SubmitProofOutcome::StaleLock(_) => Err(reject_ownership(
+                "submit_proof",
+                &request.session_id,
+                "lock is held by another worker or has been rotated",
+            )),
+            SubmitProofOutcome::Expired(_) => {
+                Err(reject_ownership("submit_proof", &request.session_id, "lock has expired"))
+            }
+            SubmitProofOutcome::Terminal(_) => Err(reject_ownership(
+                "submit_proof",
+                &request.session_id,
+                "job has already reached a terminal state",
+            )),
+            SubmitProofOutcome::Unknown(_) => Err(reject_ownership(
+                "submit_proof",
+                &request.session_id,
+                "lock is no longer valid",
+            )),
+        }
+    }
+}
+
+/// `0` uses the configured default; any value is clamped to the maximum.
+const fn resolve_lock_duration(config: WorkerApiConfig, requested: u32) -> u32 {
+    let duration = if requested == 0 { config.default_lock_duration_seconds } else { requested };
+
+    if duration > config.max_lock_duration_seconds {
+        config.max_lock_duration_seconds
+    } else {
+        duration
+    }
+}
+
+/// Parse a worker fencing token. A malformed token can never own a job, so it is
+/// rejected as a non-retryable precondition failure.
+fn parse_lock_id(lock_id: &str) -> RpcResult<Uuid> {
+    Uuid::parse_str(lock_id).map_err(|e| {
+        failed_precondition(format!("lock_id {lock_id} is not a valid fencing token: {e}"))
+    })
+}
+
+fn into_protocol_job(job: base_prover_service_db::ProofJob) -> RpcResult<ProtocolProofJob> {
+    ProtocolProofJob::try_from(job).map_err(|e| internal(e.to_string()))
+}
+
+/// Build a non-retryable ownership rejection and log it for diagnostics.
+fn reject_ownership(method: &str, session_id: &str, reason: &str) -> ErrorObjectOwned {
+    warn!(method = %method, session_id = %session_id, reason = %reason, "rejected worker ownership request");
+    failed_precondition(format!("{method} rejected for session_id {session_id}: {reason}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use uuid::Uuid;
+
+    use super::{WorkerApiConfig, parse_lock_id, resolve_lock_duration};
+
+    #[test]
+    fn resolve_lock_duration_uses_default_for_zero() {
+        let config = WorkerApiConfig::DEFAULT;
+        assert_eq!(resolve_lock_duration(config, 0), config.default_lock_duration_seconds);
+    }
+
+    #[test]
+    fn resolve_lock_duration_clamps_to_max() {
+        let config = WorkerApiConfig::DEFAULT;
+        assert_eq!(
+            resolve_lock_duration(config, config.max_lock_duration_seconds + 1),
+            config.max_lock_duration_seconds
+        );
+    }
+
+    #[test]
+    fn resolve_lock_duration_passes_through_in_range() {
+        let config = WorkerApiConfig::DEFAULT;
+        assert_eq!(resolve_lock_duration(config, 120), 120);
+    }
+
+    #[test]
+    fn parse_lock_id_accepts_uuid() {
+        let id = Uuid::new_v4();
+        assert_eq!(parse_lock_id(&id.to_string()).unwrap(), id);
+    }
+
+    #[test]
+    fn parse_lock_id_rejects_malformed_token() {
+        let err = parse_lock_id("not-a-uuid").unwrap_err();
+        assert_eq!(err.code(), super::super::ERROR_FAILED_PRECONDITION);
+    }
+}


### PR DESCRIPTION
Wire `ProverWorkerApiServer` (getNextProof/heartbeat/submitProof) onto `ProverServiceServer`, mapping database claim/lock outcomes to JSON-RPC error codes and adding a tunable `WorkerApiConfig` for lock durations and reclaim budget. 