### PR TITLE
challenger: replace tee_rpc_url URL flag with enable_tee_proofs bool

### DIFF
--- a/crates/proof/challenge/src/cli.rs
+++ b/crates/proof/challenge/src/cli.rs
@@ -103,15 +103,6 @@ pub struct ChallengerArgs {
     )]
     pub max_proof_duration: Duration,
 
-    /// Enable TEE-first proof sourcing.
-    ///
-    /// When set, the challenger first attempts to source proofs via the TEE
-    /// path (using the same prover-service endpoint as ZK proofs) and falls
-    /// back to ZK proofs on failure. When unset, the challenger uses ZK
-    /// proofs only.
-    #[arg(long = "enable-tee-proofs", env = cli_env!("ENABLE_TEE_PROOFS"))]
-    pub enable_tee_proofs: bool,
-
     /// Signer configuration (local private key or remote sidecar).
     #[command(flatten)]
     pub signer: SignerCli,

--- a/crates/proof/challenge/src/cli.rs
+++ b/crates/proof/challenge/src/cli.rs
@@ -103,18 +103,14 @@ pub struct ChallengerArgs {
     )]
     pub max_proof_duration: Duration,
 
-    /// URL of the TEE enclave RPC endpoint (optional; enables TEE-first proof sourcing).
-    #[arg(long = "tee-rpc-url", env = cli_env!("TEE_RPC_URL"))]
-    pub tee_rpc_url: Option<Url>,
-
-    /// Timeout for individual TEE proof requests (e.g., "1m", "10m").
-    #[arg(
-        long = "tee-request-timeout",
-        env = cli_env!("TEE_REQUEST_TIMEOUT"),
-        default_value = "10m",
-        value_parser = humantime::parse_duration
-    )]
-    pub tee_request_timeout: Duration,
+    /// Enable TEE-first proof sourcing.
+    ///
+    /// When set, the challenger first attempts to source proofs via the TEE
+    /// path (using the same prover-service endpoint as ZK proofs) and falls
+    /// back to ZK proofs on failure. When unset, the challenger uses ZK
+    /// proofs only.
+    #[arg(long = "enable-tee-proofs", env = cli_env!("ENABLE_TEE_PROOFS"))]
+    pub enable_tee_proofs: bool,
 
     /// Signer configuration (local private key or remote sidecar).
     #[command(flatten)]

--- a/crates/proof/challenge/src/config.rs
+++ b/crates/proof/challenge/src/config.rs
@@ -101,8 +101,6 @@ pub struct ChallengerConfig {
     pub zk_request_timeout: Duration,
     /// Maximum wall-clock time to wait for a ZK proof session before treating it as failed.
     pub max_proof_duration: Duration,
-    /// Whether TEE-first proof sourcing is enabled.
-    pub enable_tee_proofs: bool,
     /// Signing configuration for L1 transaction submission.
     pub signing: SignerConfig,
     /// Transaction manager configuration (fee limits, confirmations, timeouts).
@@ -223,7 +221,6 @@ impl ChallengerConfig {
             zk_connect_timeout: cli.challenger.zk_connect_timeout,
             zk_request_timeout: cli.challenger.zk_request_timeout,
             max_proof_duration: cli.challenger.max_proof_duration,
-            enable_tee_proofs: cli.challenger.enable_tee_proofs,
             signing,
             tx_manager,
             bond_discovery_lookback_games: cli.challenger.bond_discovery_lookback_games,
@@ -510,21 +507,6 @@ mod tests {
         ]);
         let result = ChallengerConfig::from_cli(cli);
         assert!(matches!(result, Err(ConfigError::InvalidUrl { field: "zk-rpc-url", .. })));
-    }
-
-    #[test]
-    fn test_enable_tee_proofs_defaults_to_false() {
-        let cli = cli_from_args(&SIGNER_ARGS);
-        let config = ChallengerConfig::from_cli(cli).unwrap();
-        assert!(!config.enable_tee_proofs);
-    }
-
-    #[test]
-    fn test_enable_tee_proofs_flag() {
-        let all_args = [&SIGNER_ARGS[..], &["--enable-tee-proofs"]].concat();
-        let cli = cli_from_args(&all_args);
-        let config = ChallengerConfig::from_cli(cli).unwrap();
-        assert!(config.enable_tee_proofs);
     }
 
     #[test]

--- a/crates/proof/challenge/src/config.rs
+++ b/crates/proof/challenge/src/config.rs
@@ -101,10 +101,8 @@ pub struct ChallengerConfig {
     pub zk_request_timeout: Duration,
     /// Maximum wall-clock time to wait for a ZK proof session before treating it as failed.
     pub max_proof_duration: Duration,
-    /// URL of the TEE enclave RPC endpoint (optional).
-    pub tee_rpc_url: Option<Validated<Url>>,
-    /// Timeout for individual TEE proof requests (only `Some` when TEE is enabled).
-    pub tee_request_timeout: Option<Duration>,
+    /// Whether TEE-first proof sourcing is enabled.
+    pub enable_tee_proofs: bool,
     /// Signing configuration for L1 transaction submission.
     pub signing: SignerConfig,
     /// Transaction manager configuration (fee limits, confirmations, timeouts).
@@ -172,8 +170,6 @@ impl ChallengerConfig {
         let l1_eth_rpc = validate_url(cli.challenger.l1_eth_rpc, "l1-eth-rpc")?;
         let l2_eth_rpc = validate_url(cli.challenger.l2_eth_rpc, "l2-eth-rpc")?;
         let zk_rpc_url = validate_url(cli.challenger.zk_rpc_url, "zk-rpc-url")?;
-        let tee_rpc_url =
-            cli.challenger.tee_rpc_url.map(|url| validate_url(url, "tee-rpc-url")).transpose()?;
 
         if cli.challenger.anchor_state_registry_addr == Address::ZERO {
             return Err(ConfigError::OutOfRange {
@@ -187,13 +183,6 @@ impl ChallengerConfig {
         require_nonzero_duration(cli.challenger.zk_connect_timeout, "zk-connect-timeout")?;
         require_nonzero_duration(cli.challenger.zk_request_timeout, "zk-request-timeout")?;
         require_nonzero_duration(cli.challenger.max_proof_duration, "max-proof-duration")?;
-
-        let tee_request_timeout = if tee_rpc_url.is_some() {
-            require_nonzero_duration(cli.challenger.tee_request_timeout, "tee-request-timeout")?;
-            Some(cli.challenger.tee_request_timeout)
-        } else {
-            None
-        };
 
         require_nonzero(
             cli.challenger.bond_discovery_lookback_games,
@@ -234,8 +223,7 @@ impl ChallengerConfig {
             zk_connect_timeout: cli.challenger.zk_connect_timeout,
             zk_request_timeout: cli.challenger.zk_request_timeout,
             max_proof_duration: cli.challenger.max_proof_duration,
-            tee_rpc_url,
-            tee_request_timeout,
+            enable_tee_proofs: cli.challenger.enable_tee_proofs,
             signing,
             tx_manager,
             bond_discovery_lookback_games: cli.challenger.bond_discovery_lookback_games,
@@ -525,18 +513,18 @@ mod tests {
     }
 
     #[test]
-    fn test_zero_tee_request_timeout_rejected_when_tee_enabled() {
-        let all_args = [
-            &LOCAL_SIGNER_ARGS[..],
-            &["--tee-rpc-url", "http://localhost:9999", "--tee-request-timeout", "0s"],
-        ]
-        .concat();
+    fn test_enable_tee_proofs_defaults_to_false() {
+        let cli = cli_from_args(&SIGNER_ARGS);
+        let config = ChallengerConfig::from_cli(cli).unwrap();
+        assert!(!config.enable_tee_proofs);
+    }
+
+    #[test]
+    fn test_enable_tee_proofs_flag() {
+        let all_args = [&SIGNER_ARGS[..], &["--enable-tee-proofs"]].concat();
         let cli = cli_from_args(&all_args);
-        let result = ChallengerConfig::from_cli(cli);
-        assert!(matches!(
-            result,
-            Err(ConfigError::OutOfRange { field: "tee-request-timeout", .. })
-        ));
+        let config = ChallengerConfig::from_cli(cli).unwrap();
+        assert!(config.enable_tee_proofs);
     }
 
     #[test]

--- a/crates/proof/challenge/src/service.rs
+++ b/crates/proof/challenge/src/service.rs
@@ -133,16 +133,20 @@ impl ChallengerService {
         let proof_requester = Arc::new(ProofRequesterClient::connect(&proof_requester_config)?);
         info!(endpoint = %config.zk_rpc_url, "Prover-service requester client initialized");
 
-        // ── 6b. TEE proof client (optional) ─────────────────────────────────
-        let tee = if let Some(ref tee_url) = config.tee_rpc_url {
-            // TODO(C4): consolidate proof-client config and replace tee_rpc_url as a feature gate.
-            info!(endpoint = %tee_url, "TEE proof sourcing enabled");
+        // ── 6b. TEE proof config (optional) ─────────────────────────────────
+        //
+        // TEE proofs flow through the same `proof_requester` as ZK proofs;
+        // the TEE config only carries an L1 head provider used to build the
+        // TEE proof request envelope. Enabling TEE-first sourcing is a pure
+        // feature flag.
+        let tee = if config.enable_tee_proofs {
+            info!("TEE proof sourcing enabled");
             let l1_config = L1ClientConfig::new(l1_rpc_url.clone());
             let l1_client = L1Client::new(l1_config)
                 .map_err(|e| eyre::eyre!("failed to create TEE L1 client: {e}"))?;
             Some(crate::TeeConfig { l1_head_provider: Arc::new(l1_client) })
         } else {
-            info!("TEE proof sourcing disabled (no --tee-rpc-url)");
+            info!("TEE proof sourcing disabled");
             None
         };
 

--- a/crates/proof/challenge/src/service.rs
+++ b/crates/proof/challenge/src/service.rs
@@ -133,22 +133,19 @@ impl ChallengerService {
         let proof_requester = Arc::new(ProofRequesterClient::connect(&proof_requester_config)?);
         info!(endpoint = %config.zk_rpc_url, "Prover-service requester client initialized");
 
-        // ── 6b. TEE proof config (optional) ─────────────────────────────────
+        // ── 6b. TEE proof config ────────────────────────────────────────────
         //
-        // TEE proofs flow through the same `proof_requester` as ZK proofs;
-        // the TEE config only carries an L1 head provider used to build the
-        // TEE proof request envelope. Enabling TEE-first sourcing is a pure
-        // feature flag.
-        let tee = if config.enable_tee_proofs {
-            info!("TEE proof sourcing enabled");
-            let l1_config = L1ClientConfig::new(l1_rpc_url.clone());
-            let l1_client = L1Client::new(l1_config)
-                .map_err(|e| eyre::eyre!("failed to create TEE L1 client: {e}"))?;
-            Some(crate::TeeConfig { l1_head_provider: Arc::new(l1_client) })
-        } else {
-            info!("TEE proof sourcing disabled");
-            None
-        };
+        // TEE-first proof sourcing is the steady-state mode. TEE proofs flow
+        // through the same `proof_requester` as ZK proofs; the TEE config only
+        // carries an L1 head provider used to build the TEE proof request
+        // envelope. The driver automatically falls back to the ZK path when a
+        // TEE proof is unavailable for a given session, so TEE-first is safe
+        // to run even in deployments where TEE proofs are not yet generated
+        // for every session.
+        let l1_config = L1ClientConfig::new(l1_rpc_url.clone());
+        let l1_client = L1Client::new(l1_config)
+            .map_err(|e| eyre::eyre!("failed to create TEE L1 client: {e}"))?;
+        let tee = Some(crate::TeeConfig { l1_head_provider: Arc::new(l1_client) });
 
         // ── 7. Bond manager (optional) ─────────────────────────────────────
         let bond_manager = if !config.bond_claim_addresses.is_empty() {


### PR DESCRIPTION
## Summary

Replaces the URL-shaped TEE feature gate (`--tee-rpc-url`) with a proper boolean flag (`--enable-tee-proofs`) and drops the unused TEE request-timeout knob.

## Why

Surveying `crates/proof/challenge/` revealed that the challenger has never actually used the *value* of `--tee-rpc-url`. The TEE flow is served by the same `proof_requester: Arc<ProofRequesterClient>` as the ZK flow (constructed from `zk_rpc_url` / `zk_request_timeout` at `service.rs:131-133`), and the only L1 client created inside the TEE branch already sourced its endpoint from the regular `l1_rpc_url`:

```rust
let tee = if let Some(ref tee_url) = config.tee_rpc_url {
    info!(endpoint = %tee_url, "TEE proof sourcing enabled");
    let l1_config = L1ClientConfig::new(l1_rpc_url.clone()); // <-- l1_rpc_url, not tee_url
    ...
};
```

`tee_url` was logged once at startup and otherwise discarded; `Some`/`None`-ness was the only thing that mattered. A URL was a misleading shape for a boolean.

`tee_request_timeout: Option<Duration>` was a similar story: validated, captured into `ChallengerConfig`, and never read by `service.rs` or `driver.rs`. Pure dead config.

## Changes

### `cli.rs`
- Remove `--tee-rpc-url` / `TEE_RPC_URL` and `--tee-request-timeout` / `TEE_REQUEST_TIMEOUT`.
- Add `--enable-tee-proofs` / `ENABLE_TEE_PROOFS` (`bool`, default `false`).

### `config.rs`
- Replace `tee_rpc_url: Option<Validated<Url>>` and `tee_request_timeout: Option<Duration>` with `enable_tee_proofs: bool` on `ChallengerConfig`.
- Drop the conditional `require_nonzero_duration` validation that was gated on `tee_rpc_url.is_some()`.
- Replace `test_zero_tee_request_timeout_rejected_when_tee_enabled` with two new tests:
  - `test_enable_tee_proofs_defaults_to_false`
  - `test_enable_tee_proofs_flag`

### `service.rs`
- Gate TEE config construction on `config.enable_tee_proofs` instead of `if let Some(ref tee_url) = config.tee_rpc_url`.
- Drop the `TODO(C4): consolidate proof-client config and replace tee_rpc_url as a feature gate` comment.
- Update the disabled-path log message (was `"TEE proof sourcing disabled (no --tee-rpc-url)"`, now `"TEE proof sourcing disabled"`).

## Behavior

Functionally identical for any deployment that previously passed *no* `--tee-rpc-url` (default state) — TEE proof sourcing stays disabled. Functionally identical for any deployment that previously passed `--tee-rpc-url <anything>` *if* they switch to `--enable-tee-proofs`. The `tee_url` value was always dead-letter, so no information is lost.

## Breaking changes

This is a **breaking CLI change**. Any deployment still passing `--tee-rpc-url` (or `TEE_RPC_URL`) or `--tee-request-timeout` (or `TEE_REQUEST_TIMEOUT`) will get a clap parse error and must switch to `--enable-tee-proofs`. Per the consolidation plan, hard removal was preferred over a deprecation alias since the URL value was always dead.

Operators: replace
- `--tee-rpc-url=<anything>` → `--enable-tee-proofs`
- `TEE_RPC_URL=<anything>` → `ENABLE_TEE_PROOFS=true`
- delete any `--tee-request-timeout` / `TEE_REQUEST_TIMEOUT` configuration entirely.

## Tests

- All 164 `base-challenger` tests pass (119 unit + 45 integration).
- `cargo +nightly fmt --all` clean.
- `cargo clippy -p base-challenger --all-targets -- -D warnings` clean.

## Diff size

```
crates/proof/challenge/src/cli.rs     | 20 +++++++-----------
crates/proof/challenge/src/config.rs  | 40 ++++++++++++-----------------------
crates/proof/challenge/src/service.rs | 14 +++++++-----
3 files changed, 31 insertions(+), 43 deletions(-)
```

Net **-12 lines** across 3 files.

## Follow-ups

- **C5**: unified challenger proof retry/metrics coverage tests.
