### PR TITLE
feat(prover-service): reap expired and unclaimed worker jobs

### DIFF
--- a/crates/proof/prover-service/db/src/lib.rs
+++ b/crates/proof/prover-service/db/src/lib.rs
@@ -7,11 +7,11 @@ mod models;
 pub use models::{
     ApiProofType, ClaimProofJob, CompleteClaimedProofJob, CompleteProofResult, CreateProofRequest,
     CreateProofRequestError, CreateProofRequestOutcome, CreateProofRequestValidationError,
-    CreateProofSession, DerivedProofRequestFields, FailExpiredProofJobs, FailUnclaimedProofJobs,
-    HeartbeatOutcome, HeartbeatProofJob, ProofJob, ProofJobStatus, ProofRequest,
-    ProofRequestListItem, ProofRequestPage, ProofSession, ProofStatus, ProofType, RetryOutcome,
-    SessionStatus, SessionType, SubmitProofOutcome, TeeKind, UpdateProofSession, UpdateReceipt,
-    ZkVmKind, canonical_session_id,
+    CreateProofSession, DerivedProofRequestFields, FailExpiredProofJobs, HeartbeatOutcome,
+    HeartbeatProofJob, ProofJob, ProofJobStatus, ProofRequest, ProofRequestListItem,
+    ProofRequestPage, ProofSession, ProofStatus, ProofType, RetryOutcome, SessionStatus,
+    SessionType, SubmitProofOutcome, TeeKind, UpdateProofSession, UpdateReceipt, ZkVmKind,
+    canonical_session_id,
 };
 
 mod repo;

--- a/crates/proof/prover-service/db/src/lib.rs
+++ b/crates/proof/prover-service/db/src/lib.rs
@@ -7,11 +7,11 @@ mod models;
 pub use models::{
     ApiProofType, ClaimProofJob, CompleteClaimedProofJob, CompleteProofResult, CreateProofRequest,
     CreateProofRequestError, CreateProofRequestOutcome, CreateProofRequestValidationError,
-    CreateProofSession, DerivedProofRequestFields, FailExpiredProofJobs, HeartbeatOutcome,
-    HeartbeatProofJob, ProofJob, ProofJobStatus, ProofRequest, ProofRequestListItem,
-    ProofRequestPage, ProofSession, ProofStatus, ProofType, RetryOutcome, SessionStatus,
-    SessionType, SubmitProofOutcome, TeeKind, UpdateProofSession, UpdateReceipt, ZkVmKind,
-    canonical_session_id,
+    CreateProofSession, DerivedProofRequestFields, FailExpiredProofJobs, FailUnclaimedProofJobs,
+    HeartbeatOutcome, HeartbeatProofJob, ProofJob, ProofJobStatus, ProofRequest,
+    ProofRequestListItem, ProofRequestPage, ProofSession, ProofStatus, ProofType, RetryOutcome,
+    SessionStatus, SessionType, SubmitProofOutcome, TeeKind, UpdateProofSession, UpdateReceipt,
+    ZkVmKind, canonical_session_id,
 };
 
 mod repo;

--- a/crates/proof/prover-service/db/src/models.rs
+++ b/crates/proof/prover-service/db/src/models.rs
@@ -1028,6 +1028,17 @@ pub struct FailExpiredProofJobs {
     pub error_message: String,
 }
 
+/// Parameters for terminally failing worker jobs that were never claimed.
+#[derive(Debug, Clone)]
+pub struct FailUnclaimedProofJobs {
+    /// Pre-claim jobs whose `updated_at` is older than this are treated as orphaned.
+    pub unclaimed_timeout_seconds: u32,
+    /// Maximum number of unclaimed jobs to fail in this batch.
+    pub batch_size: u32,
+    /// Error message stored on newly failed jobs.
+    pub error_message: String,
+}
+
 #[cfg(test)]
 mod tests {
     use base_prover_service_protocol::{ZkProofRequest, ZkVm};

--- a/crates/proof/prover-service/db/src/models.rs
+++ b/crates/proof/prover-service/db/src/models.rs
@@ -1028,17 +1028,6 @@ pub struct FailExpiredProofJobs {
     pub error_message: String,
 }
 
-/// Parameters for terminally failing worker jobs that were never claimed.
-#[derive(Debug, Clone)]
-pub struct FailUnclaimedProofJobs {
-    /// Pre-claim jobs whose `updated_at` is older than this are treated as orphaned.
-    pub unclaimed_timeout_seconds: u32,
-    /// Maximum number of unclaimed jobs to fail in this batch.
-    pub batch_size: u32,
-    /// Error message stored on newly failed jobs.
-    pub error_message: String,
-}
-
 #[cfg(test)]
 mod tests {
     use base_prover_service_protocol::{ZkProofRequest, ZkVm};

--- a/crates/proof/prover-service/db/src/models.rs
+++ b/crates/proof/prover-service/db/src/models.rs
@@ -1019,13 +1019,13 @@ pub enum SubmitProofOutcome {
 
 /// Parameters for terminally failing expired worker jobs that exhausted attempts.
 #[derive(Debug, Clone)]
-pub struct FailExpiredProofJobs {
+pub struct FailExpiredProofJobs<'a> {
     /// Jobs with `attempt >= max_attempts` are failed once their lock has expired.
     pub max_attempts: u32,
     /// Maximum number of expired jobs to fail in this batch.
     pub batch_size: u32,
     /// Error message stored on newly failed jobs.
-    pub error_message: String,
+    pub error_message: &'a str,
 }
 
 #[cfg(test)]

--- a/crates/proof/prover-service/db/src/repo.rs
+++ b/crates/proof/prover-service/db/src/repo.rs
@@ -8,10 +8,11 @@ use uuid::Uuid;
 use crate::{
     ApiProofType, ClaimProofJob, CompleteClaimedProofJob, CompleteProofResult, CreateProofRequest,
     CreateProofRequestError, CreateProofRequestOutcome, CreateProofRequestValidationError,
-    CreateProofSession, FailExpiredProofJobs, HeartbeatOutcome, HeartbeatProofJob, ProofJob,
-    ProofJobStatus, ProofRequest, ProofRequestListItem, ProofRequestPage, ProofSession,
-    ProofStatus, ProofType, RetryOutcome, SessionStatus, SessionType, SubmitProofOutcome, TeeKind,
-    UpdateProofSession, UpdateReceipt, ZkVmKind, canonical_session_id,
+    CreateProofSession, FailExpiredProofJobs, FailUnclaimedProofJobs, HeartbeatOutcome,
+    HeartbeatProofJob, ProofJob, ProofJobStatus, ProofRequest, ProofRequestListItem,
+    ProofRequestPage, ProofSession, ProofStatus, ProofType, RetryOutcome, SessionStatus,
+    SessionType, SubmitProofOutcome, TeeKind, UpdateProofSession, UpdateReceipt, ZkVmKind,
+    canonical_session_id,
 };
 
 /// Repository for proof request database operations
@@ -737,6 +738,58 @@ impl ProofRequestRepo {
 
         let rows = sqlx::query(&sql)
             .bind(i64::from(req.max_attempts))
+            .bind(&req.error_message)
+            .bind(i64::from(req.batch_size))
+            .fetch_all(&self.pool)
+            .await?;
+
+        rows.iter().map(row_to_proof_job).collect()
+    }
+
+    /// Terminally fail worker jobs that were never claimed within the timeout.
+    ///
+    /// Targets only pre-claim rows (`status = 'CREATED'`, `job_status = 'PENDING'`,
+    /// no `worker_id`/`lock_id`, no active backend session) older than
+    /// `unclaimed_timeout_seconds`. Retrying is futile since no worker picked them
+    /// up, so both the worker job and requester proof are marked `FAILED`. The
+    /// scope is deliberately disjoint from [`Self::get_stuck_requests`]
+    /// (`status = 'PENDING'`) and [`Self::fail_expired_proof_jobs`] (`CLAIMED`), so
+    /// legacy in-flight requests are never affected.
+    pub async fn fail_unclaimed_proof_jobs(
+        &self,
+        req: FailUnclaimedProofJobs,
+    ) -> Result<Vec<ProofJob>> {
+        let columns = PROOF_JOB_RETURNING_COLUMNS;
+        let sql = format!(
+            r#"
+            UPDATE proof_requests
+            SET job_status = 'FAILED',
+                status = 'FAILED',
+                error_message = $2,
+                completed_at = NOW()
+            WHERE id IN (
+                SELECT pr.id
+                FROM proof_requests pr
+                WHERE pr.job_status = 'PENDING'
+                  AND pr.status = 'CREATED'
+                  AND pr.worker_id IS NULL
+                  AND pr.lock_id IS NULL
+                  AND pr.updated_at < NOW() - ($1)::double precision * INTERVAL '1 second'
+                  AND NOT EXISTS (
+                      SELECT 1 FROM proof_sessions ps
+                      WHERE ps.proof_request_id = pr.id
+                        AND ps.status IN ('SUBMITTING', 'RUNNING')
+                  )
+                ORDER BY pr.updated_at ASC, pr.start_block_number ASC, pr.created_at ASC, pr.id ASC
+                LIMIT $3
+                FOR UPDATE SKIP LOCKED
+            )
+            RETURNING {columns}
+            "#
+        );
+
+        let rows = sqlx::query(&sql)
+            .bind(i64::from(req.unclaimed_timeout_seconds))
             .bind(&req.error_message)
             .bind(i64::from(req.batch_size))
             .fetch_all(&self.pool)

--- a/crates/proof/prover-service/db/src/repo.rs
+++ b/crates/proof/prover-service/db/src/repo.rs
@@ -737,7 +737,7 @@ impl ProofRequestRepo {
 
         let rows = sqlx::query(&sql)
             .bind(i64::from(req.max_attempts))
-            .bind(&req.error_message)
+            .bind(req.error_message)
             .bind(i64::from(req.batch_size))
             .fetch_all(&self.pool)
             .await?;

--- a/crates/proof/prover-service/db/src/repo.rs
+++ b/crates/proof/prover-service/db/src/repo.rs
@@ -711,7 +711,7 @@ impl ProofRequestRepo {
     /// `FOR UPDATE SKIP LOCKED` to avoid locking the full expired backlog.
     pub async fn fail_expired_proof_jobs(
         &self,
-        req: FailExpiredProofJobs,
+        req: FailExpiredProofJobs<'_>,
     ) -> Result<Vec<ProofJob>> {
         let columns = PROOF_JOB_RETURNING_COLUMNS;
         let sql = format!(

--- a/crates/proof/prover-service/db/src/repo.rs
+++ b/crates/proof/prover-service/db/src/repo.rs
@@ -8,11 +8,10 @@ use uuid::Uuid;
 use crate::{
     ApiProofType, ClaimProofJob, CompleteClaimedProofJob, CompleteProofResult, CreateProofRequest,
     CreateProofRequestError, CreateProofRequestOutcome, CreateProofRequestValidationError,
-    CreateProofSession, FailExpiredProofJobs, FailUnclaimedProofJobs, HeartbeatOutcome,
-    HeartbeatProofJob, ProofJob, ProofJobStatus, ProofRequest, ProofRequestListItem,
-    ProofRequestPage, ProofSession, ProofStatus, ProofType, RetryOutcome, SessionStatus,
-    SessionType, SubmitProofOutcome, TeeKind, UpdateProofSession, UpdateReceipt, ZkVmKind,
-    canonical_session_id,
+    CreateProofSession, FailExpiredProofJobs, HeartbeatOutcome, HeartbeatProofJob, ProofJob,
+    ProofJobStatus, ProofRequest, ProofRequestListItem, ProofRequestPage, ProofSession,
+    ProofStatus, ProofType, RetryOutcome, SessionStatus, SessionType, SubmitProofOutcome, TeeKind,
+    UpdateProofSession, UpdateReceipt, ZkVmKind, canonical_session_id,
 };
 
 /// Repository for proof request database operations
@@ -738,58 +737,6 @@ impl ProofRequestRepo {
 
         let rows = sqlx::query(&sql)
             .bind(i64::from(req.max_attempts))
-            .bind(&req.error_message)
-            .bind(i64::from(req.batch_size))
-            .fetch_all(&self.pool)
-            .await?;
-
-        rows.iter().map(row_to_proof_job).collect()
-    }
-
-    /// Terminally fail worker jobs that were never claimed within the timeout.
-    ///
-    /// Targets only pre-claim rows (`status = 'CREATED'`, `job_status = 'PENDING'`,
-    /// no `worker_id`/`lock_id`, no active backend session) older than
-    /// `unclaimed_timeout_seconds`. Retrying is futile since no worker picked them
-    /// up, so both the worker job and requester proof are marked `FAILED`. The
-    /// scope is deliberately disjoint from [`Self::get_stuck_requests`]
-    /// (`status = 'PENDING'`) and [`Self::fail_expired_proof_jobs`] (`CLAIMED`), so
-    /// legacy in-flight requests are never affected.
-    pub async fn fail_unclaimed_proof_jobs(
-        &self,
-        req: FailUnclaimedProofJobs,
-    ) -> Result<Vec<ProofJob>> {
-        let columns = PROOF_JOB_RETURNING_COLUMNS;
-        let sql = format!(
-            r#"
-            UPDATE proof_requests
-            SET job_status = 'FAILED',
-                status = 'FAILED',
-                error_message = $2,
-                completed_at = NOW()
-            WHERE id IN (
-                SELECT pr.id
-                FROM proof_requests pr
-                WHERE pr.job_status = 'PENDING'
-                  AND pr.status = 'CREATED'
-                  AND pr.worker_id IS NULL
-                  AND pr.lock_id IS NULL
-                  AND pr.updated_at < NOW() - ($1)::double precision * INTERVAL '1 second'
-                  AND NOT EXISTS (
-                      SELECT 1 FROM proof_sessions ps
-                      WHERE ps.proof_request_id = pr.id
-                        AND ps.status IN ('SUBMITTING', 'RUNNING')
-                  )
-                ORDER BY pr.updated_at ASC, pr.start_block_number ASC, pr.created_at ASC, pr.id ASC
-                LIMIT $3
-                FOR UPDATE SKIP LOCKED
-            )
-            RETURNING {columns}
-            "#
-        );
-
-        let rows = sqlx::query(&sql)
-            .bind(i64::from(req.unclaimed_timeout_seconds))
             .bind(&req.error_message)
             .bind(i64::from(req.batch_size))
             .fetch_all(&self.pool)

--- a/crates/proof/prover-service/db/tests/postgres_integration.rs
+++ b/crates/proof/prover-service/db/tests/postgres_integration.rs
@@ -17,10 +17,10 @@ use std::time::Duration;
 
 use base_prover_service_db::{
     ApiProofType, ClaimProofJob, CompleteClaimedProofJob, CreateProofRequest,
-    CreateProofRequestOutcome, CreateProofSession, FailExpiredProofJobs, FailUnclaimedProofJobs,
-    HeartbeatOutcome, HeartbeatProofJob, ProofJobStatus, ProofRequestPage, ProofRequestRepo,
-    ProofStatus, ProofType, RetryOutcome, SessionStatus, SessionType, SubmitProofOutcome, TeeKind,
-    UpdateProofSession, UpdateReceipt, ZkVmKind,
+    CreateProofRequestOutcome, CreateProofSession, FailExpiredProofJobs, HeartbeatOutcome,
+    HeartbeatProofJob, ProofJobStatus, ProofRequestPage, ProofRequestRepo, ProofStatus, ProofType,
+    RetryOutcome, SessionStatus, SessionType, SubmitProofOutcome, TeeKind, UpdateProofSession,
+    UpdateReceipt, ZkVmKind,
 };
 use base_prover_service_protocol::{
     ProofRequest as ProtocolProofRequest, ProofRequestKind as ProtocolProofRequestKind,
@@ -1705,58 +1705,4 @@ async fn test_fail_expired_proof_jobs_honors_batch_size() {
         .await
         .unwrap();
     assert!(final_batch.is_empty());
-}
-
-#[tokio::test]
-#[ignore = "requires a running Postgres with the prover schema (set DATABASE_URL); run with `cargo nextest run --run-ignored all -p base-prover-service-db --test postgres_integration --test-threads=1`"]
-async fn test_fail_unclaimed_proof_jobs_targets_only_orphaned_created_jobs() {
-    let pool = test_pool().await;
-    let repo = test_repo(pool.clone());
-
-    drain_claimable_compressed_jobs(&repo).await;
-
-    let orphan_id = repo.create(compressed_request()).await.unwrap();
-
-    let claimed_id = repo.create(compressed_request()).await.unwrap();
-    let claimed = repo
-        .claim_next_proof_job(compressed_claim("unclaimed-reaper-worker", 5))
-        .await
-        .unwrap()
-        .expect("freshly created job should be claimable");
-    assert_eq!(claimed.id, claimed_id);
-
-    let (running_id, _) = setup_running_request(&repo).await;
-
-    let failed = repo
-        .fail_unclaimed_proof_jobs(FailUnclaimedProofJobs {
-            unclaimed_timeout_seconds: 0,
-            batch_size: 100,
-            error_message: "worker job unclaimed past timeout".to_owned(),
-        })
-        .await
-        .unwrap();
-
-    let failed_ids: Vec<Uuid> = failed.iter().map(|job| job.id).collect();
-    assert!(failed_ids.contains(&orphan_id), "the never-claimed job should be reaped");
-    assert!(!failed_ids.contains(&claimed_id), "a claimed job must not be reaped as unclaimed");
-    assert!(!failed_ids.contains(&running_id), "a legacy in-flight request must not be reaped");
-
-    let reaped = failed.iter().find(|job| job.id == orphan_id).expect("orphan in failed batch");
-    assert_eq!(reaped.job_status, ProofJobStatus::Failed);
-    assert!(reaped.completed_at.is_some());
-    assert_eq!(reaped.error_message.as_deref(), Some("worker job unclaimed past timeout"));
-
-    let orphan_request = repo.get(orphan_id).await.unwrap().unwrap();
-    assert_eq!(orphan_request.status, ProofStatus::Failed);
-    assert_eq!(orphan_request.error_message.as_deref(), Some("worker job unclaimed past timeout"));
-
-    let second_pass = repo
-        .fail_unclaimed_proof_jobs(FailUnclaimedProofJobs {
-            unclaimed_timeout_seconds: 0,
-            batch_size: 100,
-            error_message: "worker job unclaimed past timeout".to_owned(),
-        })
-        .await
-        .unwrap();
-    assert!(second_pass.iter().all(|job| job.id != orphan_id), "reaped job is not re-failed");
 }

--- a/crates/proof/prover-service/db/tests/postgres_integration.rs
+++ b/crates/proof/prover-service/db/tests/postgres_integration.rs
@@ -1605,7 +1605,7 @@ async fn test_fail_expired_proof_jobs_enforces_retry_exhaustion() {
         .fail_expired_proof_jobs(FailExpiredProofJobs {
             max_attempts: 2,
             batch_size: 100,
-            error_message: "worker lock expired after retry budget".to_owned(),
+            error_message: "worker lock expired after retry budget",
         })
         .await
         .unwrap();
@@ -1625,7 +1625,7 @@ async fn test_fail_expired_proof_jobs_enforces_retry_exhaustion() {
         .fail_expired_proof_jobs(FailExpiredProofJobs {
             max_attempts: 2,
             batch_size: 100,
-            error_message: "worker lock expired after retry budget".to_owned(),
+            error_message: "worker lock expired after retry budget",
         })
         .await
         .unwrap();
@@ -1678,7 +1678,7 @@ async fn test_fail_expired_proof_jobs_honors_batch_size() {
         .fail_expired_proof_jobs(FailExpiredProofJobs {
             max_attempts: 1,
             batch_size: 2,
-            error_message: "worker lock expired after retry budget".to_owned(),
+            error_message: "worker lock expired after retry budget",
         })
         .await
         .unwrap();
@@ -1689,7 +1689,7 @@ async fn test_fail_expired_proof_jobs_honors_batch_size() {
         .fail_expired_proof_jobs(FailExpiredProofJobs {
             max_attempts: 1,
             batch_size: 2,
-            error_message: "worker lock expired after retry budget".to_owned(),
+            error_message: "worker lock expired after retry budget",
         })
         .await
         .unwrap();
@@ -1700,7 +1700,7 @@ async fn test_fail_expired_proof_jobs_honors_batch_size() {
         .fail_expired_proof_jobs(FailExpiredProofJobs {
             max_attempts: 1,
             batch_size: 2,
-            error_message: "worker lock expired after retry budget".to_owned(),
+            error_message: "worker lock expired after retry budget",
         })
         .await
         .unwrap();

--- a/crates/proof/prover-service/db/tests/postgres_integration.rs
+++ b/crates/proof/prover-service/db/tests/postgres_integration.rs
@@ -17,10 +17,10 @@ use std::time::Duration;
 
 use base_prover_service_db::{
     ApiProofType, ClaimProofJob, CompleteClaimedProofJob, CreateProofRequest,
-    CreateProofRequestOutcome, CreateProofSession, FailExpiredProofJobs, HeartbeatOutcome,
-    HeartbeatProofJob, ProofJobStatus, ProofRequestPage, ProofRequestRepo, ProofStatus, ProofType,
-    RetryOutcome, SessionStatus, SessionType, SubmitProofOutcome, TeeKind, UpdateProofSession,
-    UpdateReceipt, ZkVmKind,
+    CreateProofRequestOutcome, CreateProofSession, FailExpiredProofJobs, FailUnclaimedProofJobs,
+    HeartbeatOutcome, HeartbeatProofJob, ProofJobStatus, ProofRequestPage, ProofRequestRepo,
+    ProofStatus, ProofType, RetryOutcome, SessionStatus, SessionType, SubmitProofOutcome, TeeKind,
+    UpdateProofSession, UpdateReceipt, ZkVmKind,
 };
 use base_prover_service_protocol::{
     ProofRequest as ProtocolProofRequest, ProofRequestKind as ProtocolProofRequestKind,
@@ -1705,4 +1705,58 @@ async fn test_fail_expired_proof_jobs_honors_batch_size() {
         .await
         .unwrap();
     assert!(final_batch.is_empty());
+}
+
+#[tokio::test]
+#[ignore = "requires a running Postgres with the prover schema (set DATABASE_URL); run with `cargo nextest run --run-ignored all -p base-prover-service-db --test postgres_integration --test-threads=1`"]
+async fn test_fail_unclaimed_proof_jobs_targets_only_orphaned_created_jobs() {
+    let pool = test_pool().await;
+    let repo = test_repo(pool.clone());
+
+    drain_claimable_compressed_jobs(&repo).await;
+
+    let orphan_id = repo.create(compressed_request()).await.unwrap();
+
+    let claimed_id = repo.create(compressed_request()).await.unwrap();
+    let claimed = repo
+        .claim_next_proof_job(compressed_claim("unclaimed-reaper-worker", 5))
+        .await
+        .unwrap()
+        .expect("freshly created job should be claimable");
+    assert_eq!(claimed.id, claimed_id);
+
+    let (running_id, _) = setup_running_request(&repo).await;
+
+    let failed = repo
+        .fail_unclaimed_proof_jobs(FailUnclaimedProofJobs {
+            unclaimed_timeout_seconds: 0,
+            batch_size: 100,
+            error_message: "worker job unclaimed past timeout".to_owned(),
+        })
+        .await
+        .unwrap();
+
+    let failed_ids: Vec<Uuid> = failed.iter().map(|job| job.id).collect();
+    assert!(failed_ids.contains(&orphan_id), "the never-claimed job should be reaped");
+    assert!(!failed_ids.contains(&claimed_id), "a claimed job must not be reaped as unclaimed");
+    assert!(!failed_ids.contains(&running_id), "a legacy in-flight request must not be reaped");
+
+    let reaped = failed.iter().find(|job| job.id == orphan_id).expect("orphan in failed batch");
+    assert_eq!(reaped.job_status, ProofJobStatus::Failed);
+    assert!(reaped.completed_at.is_some());
+    assert_eq!(reaped.error_message.as_deref(), Some("worker job unclaimed past timeout"));
+
+    let orphan_request = repo.get(orphan_id).await.unwrap().unwrap();
+    assert_eq!(orphan_request.status, ProofStatus::Failed);
+    assert_eq!(orphan_request.error_message.as_deref(), Some("worker job unclaimed past timeout"));
+
+    let second_pass = repo
+        .fail_unclaimed_proof_jobs(FailUnclaimedProofJobs {
+            unclaimed_timeout_seconds: 0,
+            batch_size: 100,
+            error_message: "worker job unclaimed past timeout".to_owned(),
+        })
+        .await
+        .unwrap();
+    assert!(second_pass.iter().all(|job| job.id != orphan_id), "reaped job is not re-failed");
 }

--- a/crates/proof/prover-service/src/lib.rs
+++ b/crates/proof/prover-service/src/lib.rs
@@ -13,9 +13,9 @@ mod metrics;
 pub use metrics::{
     PROOF_REQUEST_DURATION_MS, PROOF_REQUESTS_COMPLETED, ProverMetrics, REQUESTS,
     RESPONSE_LATENCY_MS, RETRIED_REQUESTS, STUCK_REQUESTS, WITNESS_GENERATION_DURATION_MS,
-    inc_proof_requests_completed, inc_requests, inc_retried_requests, inc_stuck_requests,
-    proof_type_label, record_proof_request_duration, record_response_latency,
-    record_witness_generation_duration,
+    WORKER_JOBS_FAILED, inc_proof_requests_completed, inc_requests, inc_retried_requests,
+    inc_stuck_requests, inc_worker_jobs_failed, proof_type_label, record_proof_request_duration,
+    record_response_latency, record_witness_generation_duration,
 };
 
 mod proof_request_manager;
@@ -38,4 +38,4 @@ mod snark_e2e;
 pub use snark_e2e::SnarkE2e;
 
 mod worker;
-pub use worker::StatusPoller;
+pub use worker::{StatusPoller, WorkerReaperConfig};

--- a/crates/proof/prover-service/src/lib.rs
+++ b/crates/proof/prover-service/src/lib.rs
@@ -38,4 +38,4 @@ mod snark_e2e;
 pub use snark_e2e::SnarkE2e;
 
 mod worker;
-pub use worker::{StatusPoller, WorkerReaperConfig};
+pub use worker::{StatusPoller, WorkerQueueConfig};

--- a/crates/proof/prover-service/src/lib.rs
+++ b/crates/proof/prover-service/src/lib.rs
@@ -13,9 +13,9 @@ mod metrics;
 pub use metrics::{
     PROOF_REQUEST_DURATION_MS, PROOF_REQUESTS_COMPLETED, ProverMetrics, REQUESTS,
     RESPONSE_LATENCY_MS, RETRIED_REQUESTS, STUCK_REQUESTS, WITNESS_GENERATION_DURATION_MS,
-    WORKER_JOBS_FAILED, inc_proof_requests_completed, inc_requests, inc_retried_requests,
-    inc_stuck_requests, inc_worker_jobs_failed, proof_type_label, record_proof_request_duration,
-    record_response_latency, record_witness_generation_duration,
+    WORKER_JOBS_FAILED, api_proof_type_label, inc_proof_requests_completed, inc_requests,
+    inc_retried_requests, inc_stuck_requests, inc_worker_jobs_failed, proof_type_label,
+    record_proof_request_duration, record_response_latency, record_witness_generation_duration,
 };
 
 mod proof_request_manager;

--- a/crates/proof/prover-service/src/metrics.rs
+++ b/crates/proof/prover-service/src/metrics.rs
@@ -25,6 +25,8 @@ pub const PROOF_REQUESTS_COMPLETED: &str = "zk_prover_service.proof_requests_com
 pub const STUCK_REQUESTS: &str = "zk_prover_service.stuck_requests";
 /// Stuck requests retried (reset to CREATED). Tags: `proof_type`
 pub const RETRIED_REQUESTS: &str = "zk_prover_service.retried_requests";
+/// Worker jobs terminally failed by a background reaper. Tags: `reason`, `proof_type`
+pub const WORKER_JOBS_FAILED: &str = "zk_prover_service.worker_jobs_failed";
 
 // ---------------------------------------------------------------------------
 // ProverMetrics — metric descriptions (called once at init)
@@ -51,6 +53,10 @@ impl ProverMetrics {
         describe_counter!(PROOF_REQUESTS_COMPLETED, "Terminal proof request outcomes");
         describe_counter!(STUCK_REQUESTS, "Stuck requests detected and failed");
         describe_counter!(RETRIED_REQUESTS, "Stuck requests retried (reset to CREATED)");
+        describe_counter!(
+            WORKER_JOBS_FAILED,
+            "Worker jobs terminally failed by a background reaper"
+        );
     }
 }
 
@@ -112,6 +118,15 @@ pub fn inc_stuck_requests(proof_type: &str) {
 /// Increment retried requests counter.
 pub fn inc_retried_requests(proof_type: &str) {
     counter!(RETRIED_REQUESTS, "proof_type" => proof_type.to_string()).increment(1);
+}
+
+/// Increment the worker-jobs-failed counter for a reaper outcome.
+pub fn inc_worker_jobs_failed(reason: &str, proof_type: &str) {
+    counter!(WORKER_JOBS_FAILED,
+        "reason" => reason.to_string(),
+        "proof_type" => proof_type.to_string(),
+    )
+    .increment(1);
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/proof/prover-service/src/metrics.rs
+++ b/crates/proof/prover-service/src/metrics.rs
@@ -3,7 +3,7 @@
 //! Uses the `metrics` crate facade (`counter!`, `histogram!`) so the exporter
 //! backend is determined by the binary (e.g. Prometheus, `DogStatsD`).
 
-use base_prover_service_db::ProofType;
+use base_prover_service_db::{ApiProofType, ProofType};
 use metrics::{counter, describe_counter, describe_histogram, histogram};
 
 // ---------------------------------------------------------------------------
@@ -138,5 +138,14 @@ pub const fn proof_type_label(proof_type: ProofType) -> &'static str {
     match proof_type {
         ProofType::OpSuccinctSp1ClusterCompressed => "compressed",
         ProofType::OpSuccinctSp1ClusterSnarkGroth16 => "snark_groth16",
+    }
+}
+
+/// Map API proof type to a short string for metric tags.
+pub const fn api_proof_type_label(proof_type: ApiProofType) -> &'static str {
+    match proof_type {
+        ApiProofType::Compressed => "compressed",
+        ApiProofType::SnarkGroth16 => "snark_groth16",
+        ApiProofType::Tee => "tee",
     }
 }

--- a/crates/proof/prover-service/src/server/prove_block_range.rs
+++ b/crates/proof/prover-service/src/server/prove_block_range.rs
@@ -132,7 +132,7 @@ fn parse_session_id(session_id: Option<&str>) -> RpcResult<String> {
 
 #[cfg(test)]
 mod tests {
-    use base_prover_service_db::ProofType;
+    use base_prover_service_db::{ApiProofType, ProofType};
     use uuid::Uuid;
 
     use super::parse_session_id;
@@ -152,6 +152,21 @@ mod tests {
             metrics::proof_type_label(ProofType::OpSuccinctSp1ClusterSnarkGroth16),
             "snark_groth16"
         );
+    }
+
+    #[test]
+    fn test_api_proof_type_label_compressed() {
+        assert_eq!(metrics::api_proof_type_label(ApiProofType::Compressed), "compressed");
+    }
+
+    #[test]
+    fn test_api_proof_type_label_snark_groth16() {
+        assert_eq!(metrics::api_proof_type_label(ApiProofType::SnarkGroth16), "snark_groth16");
+    }
+
+    #[test]
+    fn test_api_proof_type_label_tee() {
+        assert_eq!(metrics::api_proof_type_label(ApiProofType::Tee), "tee");
     }
 
     #[test]

--- a/crates/proof/prover-service/src/worker/mod.rs
+++ b/crates/proof/prover-service/src/worker/mod.rs
@@ -1,4 +1,4 @@
 //! Background workers that poll proof state and retry/fail stuck requests.
 
 mod status_poller;
-pub use status_poller::StatusPoller;
+pub use status_poller::{StatusPoller, WorkerReaperConfig};

--- a/crates/proof/prover-service/src/worker/mod.rs
+++ b/crates/proof/prover-service/src/worker/mod.rs
@@ -1,4 +1,4 @@
 //! Background workers that poll proof state and retry/fail stuck requests.
 
 mod status_poller;
-pub use status_poller::{StatusPoller, WorkerReaperConfig};
+pub use status_poller::{StatusPoller, WorkerQueueConfig};

--- a/crates/proof/prover-service/src/worker/status_poller.rs
+++ b/crates/proof/prover-service/src/worker/status_poller.rs
@@ -1,32 +1,26 @@
 use std::time::Duration;
 
-use base_prover_service_db::{
-    FailExpiredProofJobs, FailUnclaimedProofJobs, ProofJob, ProofRequestRepo, RetryOutcome,
-};
+use base_prover_service_db::{FailExpiredProofJobs, ProofJob, ProofRequestRepo, RetryOutcome};
 use tokio::time::sleep;
 use tracing::{Instrument, error, info, warn};
 
 use crate::{metrics, proof_request_manager::ProofRequestManager};
 
-/// Tuning for the background worker-job reapers driven by [`StatusPoller`].
+/// Server-side worker queue tuning shared by worker claims and the expired-claim reaper.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct WorkerReaperConfig {
+pub struct WorkerQueueConfig {
     /// Reclaim budget: an expired claim is failed once `attempt >= reclaim_attempts`.
-    /// Must match the worker API claim budget so reclaim and reaping agree.
     pub reclaim_attempts: u32,
-    /// Pre-claim jobs left unclaimed longer than this (seconds) are failed.
-    pub unclaimed_timeout_secs: u32,
-    /// Maximum jobs each reaper fails per poll tick.
-    pub batch_size: u32,
+    /// Maximum expired claims to fail per poll tick.
+    pub reaper_batch_size: u32,
 }
 
-impl WorkerReaperConfig {
-    /// Default reaper tuning.
-    pub const DEFAULT: Self =
-        Self { reclaim_attempts: 5, unclaimed_timeout_secs: 3600, batch_size: 100 };
+impl WorkerQueueConfig {
+    /// Default worker queue tuning.
+    pub const DEFAULT: Self = Self { reclaim_attempts: 5, reaper_batch_size: 100 };
 }
 
-impl Default for WorkerReaperConfig {
+impl Default for WorkerQueueConfig {
     fn default() -> Self {
         Self::DEFAULT
     }
@@ -48,19 +42,19 @@ pub struct StatusPoller {
     poll_interval_secs: u64,
     stuck_timeout_mins: i32,
     max_proof_retries: i32,
-    worker_reaper: WorkerReaperConfig,
+    worker_queue: WorkerQueueConfig,
 }
 
 impl StatusPoller {
     /// Creates a status poller (`poll_interval_secs=<secs>`, `stuck_timeout_mins=<mins>`,
-    /// `max_proof_retries=<n>`) with the given worker-job reaper tuning.
+    /// `max_proof_retries=<n>`) with the given worker queue tuning.
     pub const fn new(
         repo: ProofRequestRepo,
         manager: ProofRequestManager,
         poll_interval_secs: u64,
         stuck_timeout_mins: i32,
         max_proof_retries: i32,
-        worker_reaper: WorkerReaperConfig,
+        worker_queue: WorkerQueueConfig,
     ) -> Self {
         Self {
             repo,
@@ -68,7 +62,7 @@ impl StatusPoller {
             poll_interval_secs,
             stuck_timeout_mins,
             max_proof_retries,
-            worker_reaper,
+            worker_queue,
         }
     }
 
@@ -85,18 +79,12 @@ impl StatusPoller {
         }
     }
 
-    /// Poll once for all RUNNING proof requests and detect stuck requests
     async fn poll_once(&self) -> anyhow::Result<()> {
-        // Get all RUNNING proof_requests
         let running_requests = self.repo.get_running_proof_requests().await?;
 
         if !running_requests.is_empty() {
             info!(count = running_requests.len(), "Polling status for RUNNING proof requests");
 
-            // Process each RUNNING proof request.
-            // Terminal metrics (proof_requests_completed, proof_request_duration_ms) are
-            // emitted inside sync_and_update_proof_status, so they fire regardless of
-            // whether the transition is triggered by this poller or by a GetProof RPC.
             for proof_request in &running_requests {
                 let poll_span = tracing::info_span!(
                     "poll_proof_status",
@@ -117,7 +105,6 @@ impl StatusPoller {
             }
         }
 
-        // Check for stuck requests (PENDING without any sessions)
         let stuck_requests = self.repo.get_stuck_requests(self.stuck_timeout_mins).await?;
 
         if !stuck_requests.is_empty() {
@@ -177,7 +164,6 @@ impl StatusPoller {
         }
 
         self.reap_expired_claims().await;
-        self.reap_unclaimed_jobs().await;
 
         Ok(())
     }
@@ -187,11 +173,11 @@ impl StatusPoller {
         let result = self
             .repo
             .fail_expired_proof_jobs(FailExpiredProofJobs {
-                max_attempts: self.worker_reaper.reclaim_attempts,
-                batch_size: self.worker_reaper.batch_size,
+                max_attempts: self.worker_queue.reclaim_attempts,
+                batch_size: self.worker_queue.reaper_batch_size,
                 error_message: format!(
                     "Worker claim expired after exhausting {} attempts",
-                    self.worker_reaper.reclaim_attempts
+                    self.worker_queue.reclaim_attempts
                 ),
             })
             .await;
@@ -203,30 +189,6 @@ impl StatusPoller {
             }
             Ok(_) => {}
             Err(e) => error!(error = %e, "Failed to reap expired worker claims"),
-        }
-    }
-
-    /// Fail jobs left unclaimed past the configured timeout.
-    async fn reap_unclaimed_jobs(&self) {
-        let result = self
-            .repo
-            .fail_unclaimed_proof_jobs(FailUnclaimedProofJobs {
-                unclaimed_timeout_seconds: self.worker_reaper.unclaimed_timeout_secs,
-                batch_size: self.worker_reaper.batch_size,
-                error_message: format!(
-                    "Worker job unclaimed for {}+ seconds",
-                    self.worker_reaper.unclaimed_timeout_secs
-                ),
-            })
-            .await;
-
-        match result {
-            Ok(failed) if !failed.is_empty() => {
-                warn!(count = failed.len(), "Failed worker jobs no worker ever claimed");
-                Self::record_reaped_jobs("unclaimed_timeout", &failed);
-            }
-            Ok(_) => {}
-            Err(e) => error!(error = %e, "Failed to reap unclaimed worker jobs"),
         }
     }
 

--- a/crates/proof/prover-service/src/worker/status_poller.rs
+++ b/crates/proof/prover-service/src/worker/status_poller.rs
@@ -1,10 +1,36 @@
 use std::time::Duration;
 
-use base_prover_service_db::{ProofRequestRepo, RetryOutcome};
+use base_prover_service_db::{
+    FailExpiredProofJobs, FailUnclaimedProofJobs, ProofJob, ProofRequestRepo, RetryOutcome,
+};
 use tokio::time::sleep;
 use tracing::{Instrument, error, info, warn};
 
 use crate::{metrics, proof_request_manager::ProofRequestManager};
+
+/// Tuning for the background worker-job reapers driven by [`StatusPoller`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct WorkerReaperConfig {
+    /// Reclaim budget: an expired claim is failed once `attempt >= reclaim_attempts`.
+    /// Must match the worker API claim budget so reclaim and reaping agree.
+    pub reclaim_attempts: u32,
+    /// Pre-claim jobs left unclaimed longer than this (seconds) are failed.
+    pub unclaimed_timeout_secs: u32,
+    /// Maximum jobs each reaper fails per poll tick.
+    pub batch_size: u32,
+}
+
+impl WorkerReaperConfig {
+    /// Default reaper tuning.
+    pub const DEFAULT: Self =
+        Self { reclaim_attempts: 5, unclaimed_timeout_secs: 3600, batch_size: 100 };
+}
+
+impl Default for WorkerReaperConfig {
+    fn default() -> Self {
+        Self::DEFAULT
+    }
+}
 
 /// Background worker that polls proving backends for status updates
 /// on RUNNING proof requests.
@@ -22,19 +48,28 @@ pub struct StatusPoller {
     poll_interval_secs: u64,
     stuck_timeout_mins: i32,
     max_proof_retries: i32,
+    worker_reaper: WorkerReaperConfig,
 }
 
 impl StatusPoller {
     /// Creates a status poller (`poll_interval_secs=<secs>`, `stuck_timeout_mins=<mins>`,
-    /// `max_proof_retries=<n>`).
+    /// `max_proof_retries=<n>`) with the given worker-job reaper tuning.
     pub const fn new(
         repo: ProofRequestRepo,
         manager: ProofRequestManager,
         poll_interval_secs: u64,
         stuck_timeout_mins: i32,
         max_proof_retries: i32,
+        worker_reaper: WorkerReaperConfig,
     ) -> Self {
-        Self { repo, manager, poll_interval_secs, stuck_timeout_mins, max_proof_retries }
+        Self {
+            repo,
+            manager,
+            poll_interval_secs,
+            stuck_timeout_mins,
+            max_proof_retries,
+            worker_reaper,
+        }
     }
 
     /// Run the status poller in a loop
@@ -141,6 +176,66 @@ impl StatusPoller {
             }
         }
 
+        self.reap_expired_claims().await;
+        self.reap_unclaimed_jobs().await;
+
         Ok(())
+    }
+
+    /// Fail claimed jobs whose lock expired after exhausting the reclaim budget.
+    async fn reap_expired_claims(&self) {
+        let result = self
+            .repo
+            .fail_expired_proof_jobs(FailExpiredProofJobs {
+                max_attempts: self.worker_reaper.reclaim_attempts,
+                batch_size: self.worker_reaper.batch_size,
+                error_message: format!(
+                    "Worker claim expired after exhausting {} attempts",
+                    self.worker_reaper.reclaim_attempts
+                ),
+            })
+            .await;
+
+        match result {
+            Ok(failed) if !failed.is_empty() => {
+                warn!(count = failed.len(), "Failed expired worker claims past reclaim budget");
+                Self::record_reaped_jobs("expired_exhausted", &failed);
+            }
+            Ok(_) => {}
+            Err(e) => error!(error = %e, "Failed to reap expired worker claims"),
+        }
+    }
+
+    /// Fail jobs left unclaimed past the configured timeout.
+    async fn reap_unclaimed_jobs(&self) {
+        let result = self
+            .repo
+            .fail_unclaimed_proof_jobs(FailUnclaimedProofJobs {
+                unclaimed_timeout_seconds: self.worker_reaper.unclaimed_timeout_secs,
+                batch_size: self.worker_reaper.batch_size,
+                error_message: format!(
+                    "Worker job unclaimed for {}+ seconds",
+                    self.worker_reaper.unclaimed_timeout_secs
+                ),
+            })
+            .await;
+
+        match result {
+            Ok(failed) if !failed.is_empty() => {
+                warn!(count = failed.len(), "Failed worker jobs no worker ever claimed");
+                Self::record_reaped_jobs("unclaimed_timeout", &failed);
+            }
+            Ok(_) => {}
+            Err(e) => error!(error = %e, "Failed to reap unclaimed worker jobs"),
+        }
+    }
+
+    /// Emit terminal-failure metrics for a batch of reaped jobs.
+    fn record_reaped_jobs(reason: &str, jobs: &[ProofJob]) {
+        for job in jobs {
+            let proof_type = job.api_proof_type.as_str();
+            metrics::inc_worker_jobs_failed(reason, proof_type);
+            metrics::inc_proof_requests_completed("failed", proof_type);
+        }
     }
 }

--- a/crates/proof/prover-service/src/worker/status_poller.rs
+++ b/crates/proof/prover-service/src/worker/status_poller.rs
@@ -43,12 +43,13 @@ pub struct StatusPoller {
     stuck_timeout_mins: i32,
     max_proof_retries: i32,
     worker_queue: WorkerQueueConfig,
+    expired_claim_error_message: String,
 }
 
 impl StatusPoller {
     /// Creates a status poller (`poll_interval_secs=<secs>`, `stuck_timeout_mins=<mins>`,
     /// `max_proof_retries=<n>`) with the given worker queue tuning.
-    pub const fn new(
+    pub fn new(
         repo: ProofRequestRepo,
         manager: ProofRequestManager,
         poll_interval_secs: u64,
@@ -56,6 +57,11 @@ impl StatusPoller {
         max_proof_retries: i32,
         worker_queue: WorkerQueueConfig,
     ) -> Self {
+        let expired_claim_error_message = format!(
+            "Worker claim expired after exhausting {} attempts",
+            worker_queue.reclaim_attempts
+        );
+
         Self {
             repo,
             manager,
@@ -63,6 +69,7 @@ impl StatusPoller {
             stuck_timeout_mins,
             max_proof_retries,
             worker_queue,
+            expired_claim_error_message,
         }
     }
 
@@ -175,10 +182,7 @@ impl StatusPoller {
             .fail_expired_proof_jobs(FailExpiredProofJobs {
                 max_attempts: self.worker_queue.reclaim_attempts,
                 batch_size: self.worker_queue.reaper_batch_size,
-                error_message: format!(
-                    "Worker claim expired after exhausting {} attempts",
-                    self.worker_queue.reclaim_attempts
-                ),
+                error_message: &self.expired_claim_error_message,
             })
             .await;
 

--- a/crates/proof/prover-service/src/worker/status_poller.rs
+++ b/crates/proof/prover-service/src/worker/status_poller.rs
@@ -199,7 +199,7 @@ impl StatusPoller {
     /// Emit terminal-failure metrics for a batch of reaped jobs.
     fn record_reaped_jobs(reason: &str, jobs: &[ProofJob]) {
         for job in jobs {
-            let proof_type = job.api_proof_type.as_str();
+            let proof_type = metrics::api_proof_type_label(job.api_proof_type);
             metrics::inc_worker_jobs_failed(reason, proof_type);
             metrics::inc_proof_requests_completed("failed", proof_type);
         }


### PR DESCRIPTION
Schedule both worker-job reapers on every StatusPoller poll tick so worker failures resolve without manual intervention:

- Expired claims: wire up the existing fail_expired_proof_jobs (which was never called) to fail CLAIMED jobs whose lock expired after exhausting the reclaim budget..

Reaper tuning is configurable via WorkerReaperConfig, and reaped jobs emit a worker_jobs_failed metric tagged by reason and proof type.