### PR TITLE
challenger: add unified proof retry and metrics coverage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3604,6 +3604,7 @@ dependencies = [
  "futures",
  "humantime",
  "metrics",
+ "metrics-util",
  "rstest",
  "rustls 0.23.40",
  "serde",

--- a/crates/proof/challenge/Cargo.toml
+++ b/crates/proof/challenge/Cargo.toml
@@ -82,6 +82,7 @@ serde_json = { workspace = true, optional = true }
 [dev-dependencies]
 rstest.workspace = true
 tokio = { workspace = true, features = ["test-util"] }
+metrics-util = { workspace = true, features = ["debugging"] }
 base-challenger = { path = ".", features = ["test-utils"] }
 
 [features]

--- a/crates/proof/challenge/Cargo.toml
+++ b/crates/proof/challenge/Cargo.toml
@@ -82,8 +82,8 @@ serde_json = { workspace = true, optional = true }
 [dev-dependencies]
 rstest.workspace = true
 tokio = { workspace = true, features = ["test-util"] }
-metrics-util = { workspace = true, features = ["debugging"] }
 base-challenger = { path = ".", features = ["test-utils"] }
+metrics-util = { workspace = true, features = ["debugging"] }
 
 [features]
 metrics = [ "base-metrics/metrics", "base-tx-manager/metrics", "dep:metrics" ]

--- a/crates/proof/challenge/src/driver.rs
+++ b/crates/proof/challenge/src/driver.rs
@@ -839,6 +839,7 @@ impl<L2: L2Provider, P: ProofRequesterProvider, T: TxManager, C: Clock> Driver<L
                 retry_count = retry_count,
                 "proof retries exhausted, dropping entry"
             );
+            ChallengerMetrics::proof_retries_exhausted_total().increment(1);
             self.pending_proofs.remove(&game_address);
             return Ok(());
         }

--- a/crates/proof/challenge/src/metrics.rs
+++ b/crates/proof/challenge/src/metrics.rs
@@ -48,6 +48,18 @@ base_metrics::define_metrics! {
     #[describe("Total number of proof retries after failure")]
     proof_retries_total: counter,
 
+    #[describe(
+        "Total number of proof sessions dropped after exceeding the maximum retry count"
+    )]
+    proof_retries_exhausted_total: counter,
+
+    #[describe("Total number of retryable proof session failures by reason")]
+    #[label(
+        name = "reason",
+        default = ["timeout", "malformed", "failed", "tee_validation_failed"]
+    )]
+    proof_session_failures_total: counter,
+
     #[describe("Number of in-flight proof sessions")]
     pending_proofs: gauge,
 
@@ -157,4 +169,19 @@ impl ChallengerMetrics {
 
     /// Label value for a bond phase determination failure.
     pub const EVAL_ERROR_PHASE_READ: &str = "phase_read";
+
+    /// Label value for a proof session that exceeded its time budget.
+    pub const PROOF_FAILURE_TIMEOUT: &str = "timeout";
+
+    /// Label value for a proof session that returned `Succeeded` without a
+    /// usable result payload.
+    pub const PROOF_FAILURE_MALFORMED: &str = "malformed";
+
+    /// Label value for a proof session that explicitly reported `Failed`.
+    pub const PROOF_FAILURE_FAILED: &str = "failed";
+
+    /// Label value for a TEE proof whose result failed local validation
+    /// (e.g. signature or root mismatch) and is being retried via the ZK
+    /// fallback path.
+    pub const PROOF_FAILURE_TEE_VALIDATION: &str = "tee_validation_failed";
 }

--- a/crates/proof/challenge/src/pending.rs
+++ b/crates/proof/challenge/src/pending.rs
@@ -17,7 +17,7 @@ use base_prover_service_client::ProofRequesterProvider;
 use base_prover_service_protocol::{GetProofRequest, ProofStatus, SnarkGroth16ProofRequest};
 use tracing::warn;
 
-use crate::ChallengerProofAdapter;
+use crate::{ChallengerMetrics, ChallengerProofAdapter};
 
 /// The kind of proof being generated.
 #[derive(Debug, Clone)]
@@ -260,6 +260,10 @@ impl PendingProofs {
                 limit = ?max_proof_duration,
                 "proof session timed out, will retry"
             );
+            ChallengerMetrics::proof_session_failures_total(
+                ChallengerMetrics::PROOF_FAILURE_TIMEOUT,
+            )
+            .increment(1);
             pending.retry_count += 1;
             pending.phase = ProofPhase::NeedsRetry;
             return Ok(Some(ProofUpdate::NeedsRetry));
@@ -279,6 +283,10 @@ impl PendingProofs {
             ProofStatus::Succeeded => {
                 let Some(result) = response.result else {
                     warn!(game = %game, "proof succeeded without result, treating as retryable failure");
+                    ChallengerMetrics::proof_session_failures_total(
+                        ChallengerMetrics::PROOF_FAILURE_MALFORMED,
+                    )
+                    .increment(1);
                     pending.retry_count += 1;
                     pending.phase = ProofPhase::NeedsRetry;
                     return Ok(Some(ProofUpdate::NeedsRetry));
@@ -299,6 +307,10 @@ impl PendingProofs {
                                     error = %e,
                                     "TEE proof validation failed, falling back to ZK"
                                 );
+                                ChallengerMetrics::proof_session_failures_total(
+                                    ChallengerMetrics::PROOF_FAILURE_TEE_VALIDATION,
+                                )
+                                .increment(1);
                                 pending.retry_count += 1;
                                 pending.phase = ProofPhase::NeedsRetry;
                                 return Ok(Some(ProofUpdate::NeedsRetry));
@@ -314,6 +326,10 @@ impl PendingProofs {
             }
             ProofStatus::Failed => {
                 warn!(game = %game, error_message = ?response.error_message, "proof job failed");
+                ChallengerMetrics::proof_session_failures_total(
+                    ChallengerMetrics::PROOF_FAILURE_FAILED,
+                )
+                .increment(1);
                 pending.retry_count += 1;
                 pending.phase = ProofPhase::NeedsRetry;
                 ProofUpdate::NeedsRetry

--- a/crates/proof/challenge/src/test_utils.rs
+++ b/crates/proof/challenge/src/test_utils.rs
@@ -695,6 +695,10 @@ pub struct MockZkProofState {
     pub proof: Vec<u8>,
     /// Optional full prover-service result returned when status is [`ProofStatus::Succeeded`].
     pub result: Option<ApiProofResult>,
+    /// When `true`, [`get_proof`](ProofRequesterProvider::get_proof) returns `None` for
+    /// `result` even when `proof_status` is [`ProofStatus::Succeeded`]. Used to simulate
+    /// the "succeeded without result" malformed-response path.
+    pub omit_result_on_success: bool,
     /// Error message returned when status is `Failed`.
     pub error_message: Option<String>,
     /// Every [`ProveBlockRangeRequest`] received by `prove_block_range`, in call order.
@@ -707,6 +711,7 @@ impl Default for MockZkProofState {
             proof_status: ProofStatus::Queued,
             proof: Vec::new(),
             result: None,
+            omit_result_on_success: false,
             error_message: None,
             prove_block_range_log: Vec::new(),
         }
@@ -737,11 +742,15 @@ impl ProofRequesterProvider for MockZkProofProvider {
     ) -> Result<GetProofResponse, ProverServiceClientError> {
         let state = self.state.lock().unwrap().clone();
         let result = if state.proof_status == ProofStatus::Succeeded {
-            state.result.or_else(|| {
-                Some(ApiProofResult::SnarkGroth16(SnarkGroth16ProofResult {
-                    proof: ZkProofResult { zk_vm: ZkVm::Sp1, proof: state.proof.into() },
-                }))
-            })
+            if state.omit_result_on_success {
+                None
+            } else {
+                state.result.or_else(|| {
+                    Some(ApiProofResult::SnarkGroth16(SnarkGroth16ProofResult {
+                        proof: ZkProofResult { zk_vm: ZkVm::Sp1, proof: state.proof.into() },
+                    }))
+                })
+            }
         } else {
             None
         };

--- a/crates/proof/challenge/tests/driver.rs
+++ b/crates/proof/challenge/tests/driver.rs
@@ -1804,14 +1804,9 @@ async fn test_poll_running_timeout_triggers_retry() {
     assert!(matches!(entry.phase, ProofPhase::NeedsRetry));
 }
 
-// ── Metric emission tests ───────────────────────────────────────────────────
-//
-// These tests assert that the new C5 proof-lifecycle metrics
-// (`proof_session_failures_total{reason}` and `proof_retries_exhausted_total`)
-// are emitted at the correct points. They use the `metrics-util`
-// `DebuggingRecorder` pattern: each test installs its own local recorder and
-// inspects the resulting snapshot.
-
+// Metric emission tests for `proof_session_failures_total{reason}` and
+// `proof_retries_exhausted_total`. Each test installs a local
+// `DebuggingRecorder` and asserts on the resulting snapshot.
 #[cfg(feature = "metrics")]
 mod metrics_emission {
     use base_challenger::ChallengerMetrics;
@@ -1997,6 +1992,59 @@ mod metrics_emission {
     }
 
     #[test]
+    fn test_poll_tee_validation_failure_emits_metric() {
+        with_recorder(|snap| {
+            let rt = tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap();
+
+            rt.block_on(async {
+                let expected_root = B256::repeat_byte(0xaa);
+                let bad_proposal = Proposal {
+                    output_root: B256::repeat_byte(0xbb),
+                    signature: Bytes::from(vec![0u8; 65]),
+                    l1_origin_hash: DEFAULT_L1_HEAD,
+                    l1_origin_number: 1000,
+                    l2_block_number: 20,
+                    prev_output_root: B256::ZERO,
+                    config_hash: B256::ZERO,
+                };
+                let zk = Arc::new(MockZkProofProvider {
+                    session_id: "tee-bad-root-session".to_string(),
+                    state: Mutex::new(MockZkProofState {
+                        proof_status: ProofStatus::Succeeded,
+                        result: Some(tee_api_result(bad_proposal)),
+                        ..Default::default()
+                    }),
+                });
+
+                let mut proofs = PendingProofs::new();
+                proofs.insert(
+                    addr(0),
+                    PendingProof::awaiting_tee(
+                        "tee-bad-root-session".to_string(),
+                        0,
+                        expected_root,
+                        Some(minimal_prove_request()),
+                        Some(DisputeIntent::Challenge),
+                    ),
+                );
+
+                proofs.poll(addr(0), &*zk, Duration::from_secs(3600)).await.unwrap();
+            });
+
+            let snapshot = snap.snapshot().into_vec();
+            assert_eq!(
+                find_failure_counter_with_reason(
+                    &snapshot,
+                    ChallengerMetrics::PROOF_FAILURE_TEE_VALIDATION,
+                ),
+                Some(1),
+                "TEE root mismatch must increment \
+                 proof_session_failures_total{{reason=tee_validation_failed}}",
+            );
+        });
+    }
+
+    #[test]
     fn test_step_proof_exhaustion_emits_metric() {
         with_recorder(|snap| {
             let rt = tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap();
@@ -2010,14 +2058,10 @@ mod metrics_emission {
                 // Step 1: initiate the proof.
                 driver.step().await.unwrap();
 
-                // Force the entry past the retry budget so the next step exhausts.
-                // The game must remain `InProgress` with unresolved prover slots
-                // — otherwise `poll_or_submit` short-circuits and drops the
-                // entry before reaching `handle_proof_retry` (where the metric
-                // is emitted). The same `step()` call re-discovers the
-                // still-`InProgress` game via the scanner and re-creates a
-                // fresh pending entry with `retry_count = 0`, so we assert
-                // exactly on the metric and not on entry presence.
+                // Force the entry past the retry budget so the next `step()`
+                // exhausts. The scanner re-creates a fresh entry with
+                // `retry_count = 0` in the same call, so we assert on the
+                // metric only.
                 let max_retries =
                     Driver::<MockL2Provider, MockZkProofProvider, MockTxManager>::MAX_PROOF_RETRIES;
                 let entry = driver

--- a/crates/proof/challenge/tests/driver.rs
+++ b/crates/proof/challenge/tests/driver.rs
@@ -1803,3 +1803,240 @@ async fn test_poll_running_timeout_triggers_retry() {
     assert_eq!(entry.retry_count, 1);
     assert!(matches!(entry.phase, ProofPhase::NeedsRetry));
 }
+
+// ── Metric emission tests ───────────────────────────────────────────────────
+//
+// These tests assert that the new C5 proof-lifecycle metrics
+// (`proof_session_failures_total{reason}` and `proof_retries_exhausted_total`)
+// are emitted at the correct points. They use the `metrics-util`
+// `DebuggingRecorder` pattern: each test installs its own local recorder and
+// inspects the resulting snapshot.
+
+#[cfg(feature = "metrics")]
+mod metrics_emission {
+    use base_challenger::ChallengerMetrics;
+    use metrics_util::{
+        CompositeKey, MetricKind,
+        debugging::{DebugValue, DebuggingRecorder, Snapshotter},
+    };
+
+    use super::*;
+
+    type SnapEntry =
+        (CompositeKey, Option<metrics::Unit>, Option<metrics::SharedString>, DebugValue);
+
+    /// Installs a local `DebuggingRecorder` for the closure and snapshots its
+    /// metrics afterward.
+    fn with_recorder<F>(f: F)
+    where
+        F: FnOnce(Snapshotter),
+    {
+        let recorder = DebuggingRecorder::new();
+        let snapshotter = recorder.snapshotter();
+        metrics::with_local_recorder(&recorder, || f(snapshotter));
+    }
+
+    /// Returns the value of `proof_session_failures_total` whose `reason`
+    /// label matches `expected_reason`, if present in the snapshot.
+    fn find_failure_counter_with_reason(snap: &[SnapEntry], expected_reason: &str) -> Option<u64> {
+        snap.iter().find_map(|(ck, _, _, v)| {
+            if ck.kind() != MetricKind::Counter
+                || ck.key().name() != "base_challenger.proof_session_failures_total"
+            {
+                return None;
+            }
+            let reason_match =
+                ck.key().labels().any(|l| l.key() == "reason" && l.value() == expected_reason);
+            if !reason_match {
+                return None;
+            }
+            match v {
+                DebugValue::Counter(n) => Some(*n),
+                _ => None,
+            }
+        })
+    }
+
+    /// Returns the value of a bare counter by name, if present.
+    fn find_counter(snap: &[SnapEntry], name: &str) -> Option<u64> {
+        snap.iter().find_map(|(ck, _, _, v)| {
+            if ck.kind() != MetricKind::Counter || ck.key().name() != name {
+                return None;
+            }
+            match v {
+                DebugValue::Counter(n) => Some(*n),
+                _ => None,
+            }
+        })
+    }
+
+    #[test]
+    fn test_poll_timeout_emits_failure_metric() {
+        with_recorder(|snap| {
+            let rt = tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap();
+
+            rt.block_on(async {
+                let zk = Arc::new(MockZkProofProvider {
+                    session_id: "stuck-session".to_string(),
+                    state: Mutex::new(MockZkProofState {
+                        proof_status: ProofStatus::Running,
+                        ..Default::default()
+                    }),
+                });
+
+                let mut proofs = PendingProofs::new();
+                proofs.insert(
+                    addr(0),
+                    PendingProof::awaiting(
+                        "stuck-session".to_string(),
+                        0,
+                        B256::ZERO,
+                        minimal_prove_request(),
+                        DisputeIntent::Challenge,
+                    ),
+                );
+
+                proofs.poll(addr(0), &*zk, Duration::ZERO).await.unwrap();
+            });
+
+            let snapshot = snap.snapshot().into_vec();
+            assert_eq!(
+                find_failure_counter_with_reason(
+                    &snapshot,
+                    ChallengerMetrics::PROOF_FAILURE_TIMEOUT,
+                ),
+                Some(1),
+                "timeout path must increment proof_session_failures_total{{reason=timeout}}",
+            );
+        });
+    }
+
+    #[test]
+    fn test_poll_failed_status_emits_failure_metric() {
+        with_recorder(|snap| {
+            let rt = tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap();
+
+            rt.block_on(async {
+                let zk = Arc::new(MockZkProofProvider {
+                    session_id: "failed-session".to_string(),
+                    state: Mutex::new(MockZkProofState {
+                        proof_status: ProofStatus::Failed,
+                        ..Default::default()
+                    }),
+                });
+
+                let mut proofs = PendingProofs::new();
+                proofs.insert(
+                    addr(0),
+                    PendingProof::awaiting(
+                        "failed-session".to_string(),
+                        0,
+                        B256::ZERO,
+                        minimal_prove_request(),
+                        DisputeIntent::Challenge,
+                    ),
+                );
+
+                proofs.poll(addr(0), &*zk, Duration::from_secs(3600)).await.unwrap();
+            });
+
+            let snapshot = snap.snapshot().into_vec();
+            assert_eq!(
+                find_failure_counter_with_reason(
+                    &snapshot,
+                    ChallengerMetrics::PROOF_FAILURE_FAILED,
+                ),
+                Some(1),
+                "explicit Failed status must increment \
+                 proof_session_failures_total{{reason=failed}}",
+            );
+        });
+    }
+
+    #[test]
+    fn test_poll_succeeded_without_result_emits_malformed_metric() {
+        with_recorder(|snap| {
+            let rt = tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap();
+
+            rt.block_on(async {
+                let zk = Arc::new(MockZkProofProvider {
+                    session_id: "malformed-session".to_string(),
+                    state: Mutex::new(MockZkProofState {
+                        proof_status: ProofStatus::Succeeded,
+                        omit_result_on_success: true,
+                        ..Default::default()
+                    }),
+                });
+
+                let mut proofs = PendingProofs::new();
+                proofs.insert(
+                    addr(0),
+                    PendingProof::awaiting(
+                        "malformed-session".to_string(),
+                        0,
+                        B256::ZERO,
+                        minimal_prove_request(),
+                        DisputeIntent::Challenge,
+                    ),
+                );
+
+                proofs.poll(addr(0), &*zk, Duration::from_secs(3600)).await.unwrap();
+            });
+
+            let snapshot = snap.snapshot().into_vec();
+            assert_eq!(
+                find_failure_counter_with_reason(
+                    &snapshot,
+                    ChallengerMetrics::PROOF_FAILURE_MALFORMED,
+                ),
+                Some(1),
+                "Succeeded with no result must increment \
+                 proof_session_failures_total{{reason=malformed}}",
+            );
+        });
+    }
+
+    #[test]
+    fn test_step_proof_exhaustion_emits_metric() {
+        with_recorder(|snap| {
+            let rt = tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap();
+
+            rt.block_on(async {
+                let (l2, factory, verifier) = invalid_game_mocks();
+                let zk = failed_zk_prover("fail-forever");
+                let tx_manager = default_tx_manager();
+                let mut driver = test_driver(factory, Arc::clone(&verifier), l2, zk, tx_manager);
+
+                // Step 1: initiate the proof.
+                driver.step().await.unwrap();
+
+                // Force the entry past the retry budget so the next step exhausts.
+                // The game must remain `InProgress` with unresolved prover slots
+                // — otherwise `poll_or_submit` short-circuits and drops the
+                // entry before reaching `handle_proof_retry` (where the metric
+                // is emitted). The same `step()` call re-discovers the
+                // still-`InProgress` game via the scanner and re-creates a
+                // fresh pending entry with `retry_count = 0`, so we assert
+                // exactly on the metric and not on entry presence.
+                let max_retries =
+                    Driver::<MockL2Provider, MockZkProofProvider, MockTxManager>::MAX_PROOF_RETRIES;
+                let entry = driver
+                    .pending_proofs
+                    .get_mut(&addr(0))
+                    .expect("entry should exist after initiation");
+                entry.retry_count = max_retries + 1;
+                entry.phase = ProofPhase::NeedsRetry;
+                let _ = &verifier; // game already InProgress from invalid_game_mocks
+
+                driver.step().await.unwrap();
+            });
+
+            let snapshot = snap.snapshot().into_vec();
+            assert_eq!(
+                find_counter(&snapshot, "base_challenger.proof_retries_exhausted_total"),
+                Some(1),
+                "retry exhaustion must increment proof_retries_exhausted_total",
+            );
+        });
+    }
+}


### PR DESCRIPTION
Adds two new proof-lifecycle metrics plus integration tests that verify their emission at every retryable and terminal failure point in the challenger proof flow.

## New metrics

| Metric | Kind | Notes |
|---|---|---|
| `proof_retries_exhausted_total` | counter | Terminal — emitted when an entry exceeds `MAX_PROOF_RETRIES` and is dropped inside `Driver::handle_proof_retry` (previously this path only emitted a `warn!` log). |
| `proof_session_failures_total{reason}` | counter | Non-terminal — labelled with one of `timeout`, `malformed`, `failed`, `tee_validation_failed`. Emitted from `PendingProofs::poll`. |

The four `reason` labels correspond to the four retryable failure paths in `pending.rs`:

| `reason` | Trigger |
|---|---|
| `timeout` | `elapsed > max_proof_duration` before the proof completes |
| `malformed` | `ProofStatus::Succeeded` with no `result` payload |
| `failed` | Explicit `ProofStatus::Failed` from the prover service |
| `tee_validation_failed` | TEE result fails local validation (signature/root mismatch); ZK fallback engaged |

These complement the existing `proof_retries_total` (every retry) and `tee_proof_fallback_total` (TEE→ZK transitions) counters. Naming follows the existing `*_total{label}` convention used elsewhere in the challenger metrics module (e.g. `bond_evaluation_errors_total{error_type}`, `nullify_tx_outcome_total{status}`).

## Tests

Four new integration tests under `tests/driver.rs::metrics_emission` (gated on `#[cfg(feature = \"metrics\")]`):

- `test_poll_timeout_emits_failure_metric`
- `test_poll_failed_status_emits_failure_metric`
- `test_poll_succeeded_without_result_emits_malformed_metric`
- `test_step_proof_exhaustion_emits_metric`

Tests use the `metrics-util` `DebuggingRecorder` pattern already established in `proposer/src/pipeline.rs:1788`. Each test installs a thread-local recorder via `metrics::with_local_recorder`, runs the relevant flow on a `current_thread` runtime, and inspects the snapshot.

To exercise the malformed path, `MockZkProofState` gains an `omit_result_on_success: bool` flag. Default is `false`, so all existing tests behave identically.

The exhaustion test asserts only on the metric, not on entry presence: `step()` runs the scanner *after* `poll_pending_proofs` drops the exhausted entry, and the still-`InProgress` game is immediately re-discovered with a fresh `retry_count = 0`. This is documented in the test.

## Files

```
Cargo.lock                               |   1 +
crates/proof/challenge/Cargo.toml        |   1 +  (metrics-util dev-dep)
crates/proof/challenge/src/driver.rs     |   1 +  (emit proof_retries_exhausted_total)
crates/proof/challenge/src/metrics.rs    |  27 ++  (2 metrics + 4 label constants)
crates/proof/challenge/src/pending.rs    |  18 ++  (4 emit points for proof_session_failures_total)
crates/proof/challenge/src/test_utils.rs |  19 ++  (omit_result_on_success flag)
crates/proof/challenge/tests/driver.rs   | 237 ++  (metrics_emission module)
```

## Verification

```
cargo +nightly fmt --all                                              (clean)
cargo build -p base-challenger                                         (clean)
cargo build -p base-challenger --features metrics                      (clean)
cargo test  -p base-challenger --features metrics                      (167 pass: 118 unit + 49 integration)
cargo clippy -p base-challenger --all-targets -- -D warnings           (clean)
cargo clippy -p base-challenger --all-targets --features metrics -- -D warnings  (clean)
```

## Out of scope

Adding ZK-side analogues of `tee_proof_attempts_total` / `tee_proof_obtained_total` (the asymmetry is preexisting; not what this plan row asks for).