### PR TITLE
fix(precompile-storage): wire EIP-8037 state-gas reservoir through stateful precompiles (BOP-277)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ exclude = [".github/"]
 
 [workspace]
 resolver = "2"
-exclude = ["bin/prover", "crates/proof/succinct/programs", "actions/fixtures"]
+exclude = ["bin/prover", "bin/mempool-rebroadcaster", "crates/consensus/genesis", "crates/proof/succinct/programs", "actions/fixtures", "actions/harness", "crates/execution/upgrades", "crates/execution/storage", "crates/execution/revm", "crates/common/provider", "crates/consensus/registry", "crates/consensus/providers-alloy"]
 members = [
   "bin/*",
   "bin/prover/nitro-host",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ exclude = [".github/"]
 
 [workspace]
 resolver = "2"
-exclude = ["bin/prover", "bin/mempool-rebroadcaster", "crates/consensus/genesis", "crates/proof/succinct/programs", "actions/fixtures", "actions/harness", "crates/execution/upgrades", "crates/execution/storage", "crates/execution/revm", "crates/common/provider", "crates/consensus/registry", "crates/consensus/providers-alloy"]
+exclude = ["bin/prover", "crates/proof/succinct/programs", "actions/fixtures"]
 members = [
   "bin/*",
   "bin/prover/nitro-host",

--- a/crates/common/precompile-storage/src/error.rs
+++ b/crates/common/precompile-storage/src/error.rs
@@ -103,12 +103,17 @@ impl BasePrecompileError {
     ///
     /// Internal dispatch diagnostics use compact, non-ABI revert data: unknown selectors return the
     /// raw selector bytes, and decode failures return `selector || utf8_error_string`.
-    pub fn into_precompile_result(self, gas: u64, state_gas: u64) -> PrecompileResult {
+    pub fn into_precompile_result(
+        self,
+        gas: u64,
+        state_gas: u64,
+        reservoir: u64,
+    ) -> PrecompileResult {
         let bytes: Bytes = match self {
             Self::Revert(bytes) => bytes,
             Self::Panic(kind) => Panic { code: U256::from(kind as u32) }.abi_encode().into(),
             Self::OutOfGas => {
-                return Ok(PrecompileOutput::halt(PrecompileHalt::OutOfGas, 0));
+                return Ok(PrecompileOutput::halt(PrecompileHalt::OutOfGas, reservoir));
             }
             Self::SlotOverflow => {
                 return Err(PrecompileError::Fatal("slot overflow".into()));
@@ -124,7 +129,9 @@ impl BasePrecompileError {
                 bytes.into()
             }
         };
-        Ok(PrecompileOutput::revert(gas, bytes, state_gas))
+        let mut out = PrecompileOutput::revert(gas, bytes, reservoir);
+        out.state_gas_used = state_gas;
+        Ok(out)
     }
 }
 
@@ -135,6 +142,7 @@ pub trait IntoPrecompileResult<T> {
         self,
         gas: u64,
         state_gas: u64,
+        reservoir: u64,
         encode_ok: impl FnOnce(T) -> Bytes,
     ) -> PrecompileResult;
 }
@@ -144,11 +152,16 @@ impl<T> IntoPrecompileResult<T> for Result<T> {
         self,
         gas: u64,
         state_gas: u64,
+        reservoir: u64,
         encode_ok: impl FnOnce(T) -> Bytes,
     ) -> PrecompileResult {
         match self {
-            Ok(res) => Ok(PrecompileOutput::new(gas, encode_ok(res), state_gas)),
-            Err(err) => err.into_precompile_result(gas, state_gas),
+            Ok(res) => {
+                let mut out = PrecompileOutput::new(gas, encode_ok(res), reservoir);
+                out.state_gas_used = state_gas;
+                Ok(out)
+            }
+            Err(err) => err.into_precompile_result(gas, state_gas, reservoir),
         }
     }
 }
@@ -163,7 +176,7 @@ mod tests {
     fn delegate_call_not_allowed_encodes_to_typed_revert() {
         let expected: Bytes = DelegateCallNotAllowed {}.abi_encode().into();
         let result =
-            BasePrecompileError::revert(DelegateCallNotAllowed {}).into_precompile_result(0, 0);
+            BasePrecompileError::revert(DelegateCallNotAllowed {}).into_precompile_result(0, 0, 0);
         let output = result.unwrap();
         assert!(output.is_revert());
         assert_eq!(output.bytes, expected);

--- a/crates/common/precompile-storage/src/error.rs
+++ b/crates/common/precompile-storage/src/error.rs
@@ -181,4 +181,123 @@ mod tests {
         assert!(output.is_revert());
         assert_eq!(output.bytes, expected);
     }
+
+    // --- BasePrecompileError::into_precompile_result ---
+
+    #[test]
+    fn base_error_revert_sets_reservoir_and_state_gas_used() {
+        let result =
+            BasePrecompileError::Revert(Bytes::from("err")).into_precompile_result(1000, 200, 750);
+        let out = result.unwrap();
+        assert!(out.is_revert());
+        assert_eq!(out.gas_used, 1000);
+        assert_eq!(out.state_gas_used, 200);
+        assert_eq!(out.reservoir, 750);
+        assert_eq!(out.bytes, Bytes::from("err"));
+    }
+
+    #[test]
+    fn base_error_panic_sets_reservoir_and_state_gas_used() {
+        let result = BasePrecompileError::Panic(PanicKind::UnderOverflow)
+            .into_precompile_result(500, 100, 400);
+        let out = result.unwrap();
+        assert!(out.is_revert(), "panic encodes as a revert");
+        assert_eq!(out.state_gas_used, 100);
+        assert_eq!(out.reservoir, 400);
+    }
+
+    #[test]
+    fn base_error_oog_halt_carries_remaining_reservoir() {
+        let result = BasePrecompileError::OutOfGas.into_precompile_result(999, 0, 300);
+        let out = result.unwrap();
+        assert!(out.is_halt());
+        // The reservoir value at OOG time must be returned so the EVM can account for it.
+        assert_eq!(out.reservoir, 300);
+    }
+
+    #[test]
+    fn base_error_oog_with_zero_reservoir() {
+        let result = BasePrecompileError::OutOfGas.into_precompile_result(0, 0, 0);
+        let out = result.unwrap();
+        assert!(out.is_halt());
+        assert_eq!(out.reservoir, 0);
+    }
+
+    #[test]
+    fn base_error_static_call_violation_sets_reservoir() {
+        let result = BasePrecompileError::StaticCallViolation.into_precompile_result(100, 50, 600);
+        let out = result.unwrap();
+        assert!(out.is_revert());
+        assert_eq!(out.state_gas_used, 50);
+        assert_eq!(out.reservoir, 600);
+    }
+
+    #[test]
+    fn base_error_fatal_propagates_as_err() {
+        let result =
+            BasePrecompileError::Fatal("db error".into()).into_precompile_result(0, 0, 500);
+        assert!(result.is_err(), "Fatal must not produce a PrecompileOutput");
+    }
+
+    // --- IntoPrecompileResult<T> for Result<T> ---
+
+    #[test]
+    fn into_precompile_result_success_sets_state_gas_and_reservoir() {
+        let ok: Result<Bytes> = Ok(Bytes::from("output"));
+        let result = ok.into_precompile_result(1500, 300, 800, |b| b);
+        let out = result.unwrap();
+
+        assert!(out.is_success());
+        assert_eq!(out.gas_used, 1500);
+        assert_eq!(out.state_gas_used, 300);
+        assert_eq!(out.reservoir, 800);
+        assert_eq!(out.bytes, Bytes::from("output"));
+    }
+
+    #[test]
+    fn into_precompile_result_success_with_zero_reservoir() {
+        let ok: Result<Bytes> = Ok(Bytes::new());
+        let out = ok.into_precompile_result(100, 0, 0, |b| b).unwrap();
+
+        assert!(out.is_success());
+        assert_eq!(out.state_gas_used, 0);
+        assert_eq!(out.reservoir, 0);
+    }
+
+    #[test]
+    fn into_precompile_result_err_revert_propagates_reservoir_and_state_gas() {
+        let err: Result<Bytes> = Err(BasePrecompileError::Revert(Bytes::from("revert")));
+        let out = err.into_precompile_result(200, 50, 900, |b| b).unwrap();
+
+        assert!(out.is_revert());
+        assert_eq!(out.gas_used, 200);
+        assert_eq!(out.state_gas_used, 50);
+        assert_eq!(out.reservoir, 900);
+    }
+
+    #[test]
+    fn into_precompile_result_err_oog_carries_reservoir() {
+        let err: Result<Bytes> = Err(BasePrecompileError::OutOfGas);
+        let out = err.into_precompile_result(0, 0, 1234, |b| b).unwrap();
+
+        assert!(out.is_halt());
+        assert_eq!(out.reservoir, 1234);
+    }
+
+    #[test]
+    fn into_precompile_result_err_fatal_propagates_as_err() {
+        let err: Result<Bytes> = Err(BasePrecompileError::Fatal("crash".into()));
+        let result = err.into_precompile_result(0, 0, 0, |b| b);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn into_precompile_result_encoder_applied_on_success() {
+        let ok: Result<u64> = Ok(42u64);
+        let out =
+            ok.into_precompile_result(0, 0, 0, |v| Bytes::from(v.to_le_bytes().to_vec())).unwrap();
+
+        assert!(out.is_success());
+        assert_eq!(out.bytes, Bytes::from(42u64.to_le_bytes().to_vec()));
+    }
 }

--- a/crates/common/precompile-storage/src/evm.rs
+++ b/crates/common/precompile-storage/src/evm.rs
@@ -38,7 +38,6 @@ pub struct EvmPrecompileStorageProvider<'a> {
     timestamp: U256,
     chain_id: u64,
     beneficiary: Address,
-    state_gas_used: u64,
 }
 
 impl<'a> EvmPrecompileStorageProvider<'a> {
@@ -47,7 +46,7 @@ impl<'a> EvmPrecompileStorageProvider<'a> {
     /// `gas_params` drives all EIP-2929/2200/3529 cost calculations.
     /// Pass [`GasParams::default`] when the active spec is unknown at call site.
     pub fn new(input: PrecompileInput<'a>, gas_params: GasParams) -> Self {
-        let PrecompileInput { gas, caller, is_static, internals, .. } = input;
+        let PrecompileInput { gas, caller, is_static, internals, reservoir, .. } = input;
 
         let block_number = internals.block_env().number().to::<u64>();
         let timestamp = internals.block_env().timestamp();
@@ -57,14 +56,13 @@ impl<'a> EvmPrecompileStorageProvider<'a> {
         Self {
             internals,
             caller,
-            gas: Gas::new(gas),
+            gas: Gas::new_with_regular_gas_and_reservoir(gas, reservoir),
             gas_params,
             is_static,
             block_number,
             timestamp,
             chain_id,
             beneficiary,
-            state_gas_used: 0,
         }
     }
 }
@@ -216,9 +214,9 @@ impl PrecompileStorageProvider for EvmPrecompileStorageProvider<'_> {
     }
 
     fn deduct_state_gas(&mut self, gas: u64) -> Result<()> {
-        // No separate reservoir in the precompile context; state gas is drawn from regular gas.
-        self.deduct_gas(gas)?;
-        self.state_gas_used = self.state_gas_used.saturating_add(gas);
+        if !self.gas.record_state_cost(gas) {
+            return Err(BasePrecompileError::OutOfGas);
+        }
         Ok(())
     }
 
@@ -235,7 +233,7 @@ impl PrecompileStorageProvider for EvmPrecompileStorageProvider<'_> {
     }
 
     fn state_gas_used(&self) -> u64 {
-        self.state_gas_used
+        self.gas.state_gas_spent()
     }
 
     fn gas_refunded(&self) -> i64 {
@@ -243,7 +241,7 @@ impl PrecompileStorageProvider for EvmPrecompileStorageProvider<'_> {
     }
 
     fn reservoir(&self) -> u64 {
-        0
+        self.gas.reservoir()
     }
 
     fn is_static(&self) -> bool {

--- a/crates/common/precompile-storage/src/hashmap.rs
+++ b/crates/common/precompile-storage/src/hashmap.rs
@@ -29,6 +29,7 @@ pub struct HashMapStorageProvider {
     snapshots: Vec<Snapshot>,
     gas_params: GasParams,
     state_gas_used: u64,
+    reservoir: u64,
     /// Emitted events keyed by contract address.
     pub events: HashMap<Address, Vec<LogData>>,
 }
@@ -65,6 +66,7 @@ impl HashMapStorageProvider {
             counter_sstore: 0,
             gas_params: GasParams::default(),
             state_gas_used: 0,
+            reservoir: 0,
         }
     }
 }
@@ -162,7 +164,10 @@ impl PrecompileStorageProvider for HashMapStorageProvider {
     }
 
     fn deduct_state_gas(&mut self, gas: u64) -> Result<(), BasePrecompileError> {
-        // No gas limit in the test provider; just track the cumulative amount.
+        // Drain the reservoir first (EIP-8037 semantics); any excess spills into
+        // regular gas. No gas limit is enforced in the test provider.
+        let from_reservoir = gas.min(self.reservoir);
+        self.reservoir -= from_reservoir;
         self.state_gas_used = self.state_gas_used.saturating_add(gas);
         Ok(())
     }
@@ -186,7 +191,7 @@ impl PrecompileStorageProvider for HashMapStorageProvider {
     }
 
     fn reservoir(&self) -> u64 {
-        0
+        self.reservoir
     }
 
     fn is_static(&self) -> bool {
@@ -319,10 +324,104 @@ impl HashMapStorageProvider {
     pub fn set_gas_params(&mut self, gas_params: GasParams) {
         self.gas_params = gas_params;
     }
+
+    /// Sets the initial EIP-8037 state-gas reservoir (test-utils only).
+    pub fn set_reservoir(&mut self, reservoir: u64) {
+        self.reservoir = reservoir;
+    }
 }
 
 /// Test helper: returns a fresh `(HashMapStorageProvider, precompile_address)` pair.
 #[cfg(any(test, feature = "test-utils"))]
 pub fn setup_storage() -> (HashMapStorageProvider, Address) {
     (HashMapStorageProvider::new(1), Address::from([0x42u8; 20]))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::provider::PrecompileStorageProvider;
+
+    #[test]
+    fn reservoir_starts_at_zero_by_default() {
+        let provider = HashMapStorageProvider::new(1);
+        assert_eq!(provider.reservoir(), 0);
+        assert_eq!(provider.state_gas_used(), 0);
+    }
+
+    #[test]
+    fn deduct_state_gas_drains_reservoir_first() {
+        let mut provider = HashMapStorageProvider::new(1);
+        provider.set_reservoir(500);
+
+        provider.deduct_state_gas(200).unwrap();
+
+        assert_eq!(provider.reservoir(), 300, "reservoir should decrease by the charge");
+        assert_eq!(provider.state_gas_used(), 200, "state_gas_used should equal total charged");
+    }
+
+    #[test]
+    fn deduct_state_gas_exhausts_reservoir_exactly() {
+        let mut provider = HashMapStorageProvider::new(1);
+        provider.set_reservoir(300);
+
+        provider.deduct_state_gas(300).unwrap();
+
+        assert_eq!(provider.reservoir(), 0);
+        assert_eq!(provider.state_gas_used(), 300);
+    }
+
+    #[test]
+    fn deduct_state_gas_spills_into_regular_when_reservoir_exhausted() {
+        let mut provider = HashMapStorageProvider::new(1);
+        provider.set_reservoir(100);
+
+        // 100 from reservoir, 200 spill into regular gas.
+        provider.deduct_state_gas(300).unwrap();
+
+        assert_eq!(provider.reservoir(), 0, "reservoir fully consumed");
+        assert_eq!(provider.state_gas_used(), 300, "all 300 tracked as state gas");
+    }
+
+    #[test]
+    fn deduct_state_gas_with_no_reservoir_all_regular() {
+        let mut provider = HashMapStorageProvider::new(1);
+        // reservoir = 0, everything spills immediately.
+        provider.deduct_state_gas(500).unwrap();
+
+        assert_eq!(provider.reservoir(), 0);
+        assert_eq!(provider.state_gas_used(), 500);
+    }
+
+    #[test]
+    fn multiple_deductions_deplete_reservoir_progressively() {
+        let mut provider = HashMapStorageProvider::new(1);
+        provider.set_reservoir(400);
+
+        provider.deduct_state_gas(100).unwrap(); // reservoir = 300
+        provider.deduct_state_gas(150).unwrap(); // reservoir = 150
+        provider.deduct_state_gas(200).unwrap(); // 150 from reservoir, 50 spill; reservoir = 0
+        provider.deduct_state_gas(50).unwrap(); // all spill; reservoir = 0
+
+        assert_eq!(provider.reservoir(), 0);
+        assert_eq!(provider.state_gas_used(), 500);
+    }
+
+    #[test]
+    fn reservoir_set_and_retrieved_correctly() {
+        let mut provider = HashMapStorageProvider::new(1);
+        provider.set_reservoir(1_000_000);
+        assert_eq!(provider.reservoir(), 1_000_000);
+    }
+
+    #[test]
+    fn state_gas_zero_charge_leaves_reservoir_unchanged() {
+        let mut provider = HashMapStorageProvider::new(1);
+        provider.set_reservoir(500);
+
+        provider.deduct_state_gas(0).unwrap();
+
+        assert_eq!(provider.reservoir(), 500);
+        assert_eq!(provider.state_gas_used(), 0);
+    }
 }

--- a/crates/common/precompile-storage/src/storage_ctx.rs
+++ b/crates/common/precompile-storage/src/storage_ctx.rs
@@ -185,6 +185,11 @@ impl<'a> StorageCtx<'a> {
         self.try_with_storage(|s| s.deduct_gas(gas))
     }
 
+    /// Deducts state-creating gas, consuming the EIP-8037 reservoir first.
+    pub fn deduct_state_gas(&self, gas: u64) -> Result<()> {
+        self.try_with_storage(|s| s.deduct_state_gas(gas))
+    }
+
     /// Computes keccak256 and charges the appropriate gas.
     pub fn keccak256(&self, data: &[u8]) -> Result<B256> {
         self.try_with_storage(|s| s.keccak256(data))
@@ -401,6 +406,139 @@ mod tests {
 
             assert_eq!(value, 7);
             assert_eq!(ctx.caller(), original);
+        });
+    }
+
+    #[test]
+    fn success_output_carries_correct_reservoir_and_state_gas_used() {
+        let mut storage = crate::hashmap::HashMapStorageProvider::new(1);
+        storage.set_reservoir(1_000);
+
+        StorageCtx::enter(&mut storage, |ctx| {
+            ctx.deduct_state_gas(400).unwrap(); // 400 from reservoir; reservoir = 600
+
+            let out = ctx.success_output(Bytes::new());
+
+            assert!(out.is_success());
+            assert_eq!(
+                out.state_gas_used, 400,
+                "state_gas_used must equal total state gas charged"
+            );
+            assert_eq!(out.reservoir, 600, "reservoir must equal remaining reservoir");
+        });
+    }
+
+    #[test]
+    fn success_output_with_zero_reservoir_sets_fields_correctly() {
+        let mut storage = crate::hashmap::HashMapStorageProvider::new(1);
+        // reservoir = 0; all state gas spills into regular gas.
+
+        StorageCtx::enter(&mut storage, |ctx| {
+            ctx.deduct_state_gas(250).unwrap();
+
+            let out = ctx.success_output(Bytes::new());
+
+            assert!(out.is_success());
+            assert_eq!(out.state_gas_used, 250);
+            assert_eq!(out.reservoir, 0);
+        });
+    }
+
+    #[test]
+    fn success_output_no_state_gas_charged_leaves_reservoir_intact() {
+        let mut storage = crate::hashmap::HashMapStorageProvider::new(1);
+        storage.set_reservoir(800);
+
+        StorageCtx::enter(&mut storage, |ctx| {
+            let out = ctx.success_output(Bytes::new());
+
+            assert!(out.is_success());
+            assert_eq!(out.state_gas_used, 0);
+            assert_eq!(out.reservoir, 800, "untouched reservoir must be returned in full");
+        });
+    }
+
+    #[test]
+    fn revert_output_carries_correct_reservoir_and_state_gas_used() {
+        let mut storage = crate::hashmap::HashMapStorageProvider::new(1);
+        storage.set_reservoir(500);
+
+        StorageCtx::enter(&mut storage, |ctx| {
+            ctx.deduct_state_gas(150).unwrap(); // reservoir = 350
+
+            let out = ctx.revert_output(Bytes::from("revert reason"));
+
+            assert!(out.is_revert());
+            assert_eq!(out.state_gas_used, 150);
+            assert_eq!(out.reservoir, 350);
+            assert_eq!(out.bytes, Bytes::from("revert reason"));
+        });
+    }
+
+    #[test]
+    fn revert_output_with_spillover_sets_fields_correctly() {
+        let mut storage = crate::hashmap::HashMapStorageProvider::new(1);
+        storage.set_reservoir(100);
+
+        StorageCtx::enter(&mut storage, |ctx| {
+            ctx.deduct_state_gas(300).unwrap(); // 100 from reservoir, 200 spill; reservoir = 0
+
+            let out = ctx.revert_output(Bytes::new());
+
+            assert!(out.is_revert());
+            assert_eq!(out.state_gas_used, 300);
+            assert_eq!(out.reservoir, 0);
+        });
+    }
+
+    #[test]
+    fn error_result_revert_carries_state_gas_and_reservoir() {
+        let mut storage = crate::hashmap::HashMapStorageProvider::new(1);
+        storage.set_reservoir(600);
+
+        StorageCtx::enter(&mut storage, |ctx| {
+            ctx.deduct_state_gas(200).unwrap(); // reservoir = 400
+
+            let result = ctx.error_result(BasePrecompileError::Revert(Bytes::new()));
+            let out = result.unwrap();
+
+            assert!(out.is_revert());
+            assert_eq!(out.state_gas_used, 200);
+            assert_eq!(out.reservoir, 400);
+        });
+    }
+
+    #[test]
+    fn error_result_oog_carries_reservoir() {
+        let mut storage = crate::hashmap::HashMapStorageProvider::new(1);
+        storage.set_reservoir(999);
+
+        StorageCtx::enter(&mut storage, |ctx| {
+            let result = ctx.error_result(BasePrecompileError::OutOfGas);
+            let out = result.unwrap();
+
+            assert!(out.is_halt());
+            // On OOG the remaining reservoir must be returned so the EVM can account for it.
+            assert_eq!(out.reservoir, 999);
+        });
+    }
+
+    #[test]
+    fn success_output_carries_gas_refunded_alongside_new_fields() {
+        // Verifies that gas_refunded is still set correctly alongside the new reservoir
+        // and state_gas_used fields (regression guard for the output construction change).
+        let mut storage = crate::hashmap::HashMapStorageProvider::new(1);
+        storage.set_reservoir(500);
+
+        StorageCtx::enter(&mut storage, |ctx| {
+            ctx.deduct_state_gas(200).unwrap();
+
+            let out = ctx.success_output(Bytes::new());
+
+            assert!(out.is_success());
+            assert_eq!(out.state_gas_used, 200);
+            assert_eq!(out.reservoir, 300);
+            assert_eq!(out.gas_refunded, 0); // HashMapStorageProvider always returns 0
         });
     }
 

--- a/crates/common/precompile-storage/src/storage_ctx.rs
+++ b/crates/common/precompile-storage/src/storage_ctx.rs
@@ -201,8 +201,9 @@ impl<'a> StorageCtx<'a> {
     /// The `gas_refunded` field is populated so revm's frame handler can propagate it to the
     /// transaction-level refund counter, where the EIP-3529 cap (`gas_used / 5`) is applied.
     pub fn success_output(&self, output: Bytes) -> PrecompileOutput {
-        let mut out = PrecompileOutput::new(self.gas_used(), output, self.state_gas_used());
+        let mut out = PrecompileOutput::new(self.gas_used(), output, self.reservoir());
         out.gas_refunded = self.gas_refunded();
+        out.state_gas_used = self.state_gas_used();
         out
     }
 
@@ -213,7 +214,9 @@ impl<'a> StorageCtx<'a> {
 
     /// Returns a revert [`PrecompileOutput`] with the current gas used.
     pub fn revert_output(&self, output: Bytes) -> PrecompileOutput {
-        PrecompileOutput::revert(self.gas_used(), output, self.state_gas_used())
+        let mut out = PrecompileOutput::revert(self.gas_used(), output, self.reservoir());
+        out.state_gas_used = self.state_gas_used();
+        out
     }
 
     /// Reverts with an ABI-encoded error.
@@ -223,7 +226,11 @@ impl<'a> StorageCtx<'a> {
 
     /// Returns a [`PrecompileResult`] constructed from the given error.
     pub fn error_result(&self, error: impl Into<BasePrecompileError>) -> PrecompileResult {
-        error.into().into_precompile_result(self.gas_used(), self.state_gas_used())
+        error.into().into_precompile_result(
+            self.gas_used(),
+            self.state_gas_used(),
+            self.reservoir(),
+        )
     }
 }
 

--- a/crates/common/precompiles/src/activation/dispatch.rs
+++ b/crates/common/precompiles/src/activation/dispatch.rs
@@ -23,6 +23,7 @@ impl ActivationRegistryStorage<'_> {
         self.inner(calldata, activation_admin_address).into_precompile_result(
             ctx.gas_used(),
             ctx.state_gas_used(),
+            ctx.reservoir(),
             |output| output,
         )
     }

--- a/crates/common/precompiles/src/activation/storage.rs
+++ b/crates/common/precompiles/src/activation/storage.rs
@@ -80,6 +80,7 @@ impl ActivationRegistryStorage<'_> {
         self.ensure_activated(feature).into_precompile_result(
             self.storage.gas_used(),
             self.storage.state_gas_used(),
+            self.storage.reservoir(),
             |()| Bytes::new(),
         )
     }

--- a/crates/common/precompiles/src/b20_asset/dispatch.rs
+++ b/crates/common/precompiles/src/b20_asset/dispatch.rs
@@ -40,14 +40,24 @@ impl<S: AssetAccounting, P: Policy> B20AssetToken<S, P> {
         match self.accounting().is_initialized() {
             Ok(true) => {}
             Ok(false) => {
-                return BasePrecompileError::Revert(Bytes::new())
-                    .into_precompile_result(ctx.gas_used(), ctx.state_gas_used());
+                return BasePrecompileError::Revert(Bytes::new()).into_precompile_result(
+                    ctx.gas_used(),
+                    ctx.state_gas_used(),
+                    ctx.reservoir(),
+                );
             }
-            Err(e) => return e.into_precompile_result(ctx.gas_used(), ctx.state_gas_used()),
+            Err(e) => {
+                return e.into_precompile_result(
+                    ctx.gas_used(),
+                    ctx.state_gas_used(),
+                    ctx.reservoir(),
+                );
+            }
         }
         self.inner_with_observer(ctx, calldata, observer).into_precompile_result(
             ctx.gas_used(),
             ctx.state_gas_used(),
+            ctx.reservoir(),
             |b| b,
         )
     }

--- a/crates/common/precompiles/src/b20_factory/dispatch.rs
+++ b/crates/common/precompiles/src/b20_factory/dispatch.rs
@@ -16,7 +16,7 @@ impl<'a> B20FactoryStorage<'a> {
         deduct_calldata_cost!(ctx, calldata);
         let result = self.inner(ctx, calldata);
         let gas = ctx.gas_used();
-        result.into_precompile_result(gas, ctx.state_gas_used(), |b| b)
+        result.into_precompile_result(gas, ctx.state_gas_used(), ctx.reservoir(), |b| b)
     }
 
     fn inner(

--- a/crates/common/precompiles/src/b20_stablecoin/dispatch.rs
+++ b/crates/common/precompiles/src/b20_stablecoin/dispatch.rs
@@ -40,14 +40,24 @@ impl<S: StablecoinAccounting, P: Policy> B20StablecoinToken<S, P> {
         match self.accounting().is_initialized() {
             Ok(true) => {}
             Ok(false) => {
-                return BasePrecompileError::Revert(Bytes::new())
-                    .into_precompile_result(ctx.gas_used(), ctx.state_gas_used());
+                return BasePrecompileError::Revert(Bytes::new()).into_precompile_result(
+                    ctx.gas_used(),
+                    ctx.state_gas_used(),
+                    ctx.reservoir(),
+                );
             }
-            Err(e) => return e.into_precompile_result(ctx.gas_used(), ctx.state_gas_used()),
+            Err(e) => {
+                return e.into_precompile_result(
+                    ctx.gas_used(),
+                    ctx.state_gas_used(),
+                    ctx.reservoir(),
+                );
+            }
         }
         self.inner_with_observer(ctx, calldata, observer).into_precompile_result(
             ctx.gas_used(),
             ctx.state_gas_used(),
+            ctx.reservoir(),
             |b| b,
         )
     }

--- a/crates/common/precompiles/src/macros.rs
+++ b/crates/common/precompiles/src/macros.rs
@@ -10,7 +10,7 @@ macro_rules! base_precompile {
                     return ::base_precompile_storage::BasePrecompileError::revert(
                         ::base_precompile_storage::DelegateCallNotAllowed {},
                     )
-                    .into_precompile_result(0, 0);
+                    .into_precompile_result(0, 0, 0);
                 }
 
                 let $calldata: ::alloy_primitives::Bytes = input.data.to_vec().into();
@@ -31,7 +31,7 @@ macro_rules! base_precompile {
                     return ::base_precompile_storage::BasePrecompileError::revert(
                         ::base_precompile_storage::DelegateCallNotAllowed {},
                     )
-                    .into_precompile_result(0, 0);
+                    .into_precompile_result(0, 0, 0);
                 }
 
                 let $calldata: ::alloy_primitives::Bytes = $input.data.to_vec().into();
@@ -54,7 +54,11 @@ macro_rules! deduct_calldata_cost {
         let calldata_len = $calldata.len();
         let calldata_cost = calldata_len.div_ceil(32).saturating_mul(G_SHA3WORD as usize) as u64;
         if let Err(e) = $ctx.deduct_gas(calldata_cost) {
-            return e.into_precompile_result($ctx.gas_used(), $ctx.state_gas_used());
+            return e.into_precompile_result(
+                $ctx.gas_used(),
+                $ctx.state_gas_used(),
+                $ctx.reservoir(),
+            );
         }
     }};
 }

--- a/crates/common/precompiles/src/macros.rs
+++ b/crates/common/precompiles/src/macros.rs
@@ -35,8 +35,10 @@ macro_rules! base_precompile {
                 }
 
                 let $calldata: ::alloy_primitives::Bytes = $input.data.to_vec().into();
-                let mut provider =
-                    ::base_precompile_storage::EvmPrecompileStorageProvider::new($input);
+                let mut provider = ::base_precompile_storage::EvmPrecompileStorageProvider::new(
+                    $input,
+                    ::revm::context_interface::cfg::GasParams::default(),
+                );
 
                 ::base_precompile_storage::StorageCtx::enter(&mut provider, |$ctx| $impl)
             },

--- a/crates/common/precompiles/src/policy/dispatch.rs
+++ b/crates/common/precompiles/src/policy/dispatch.rs
@@ -24,7 +24,7 @@ impl PolicyRegistryStorage<'_> {
                 .ensure_activated(ActivationFeature::PolicyRegistry.id())
                 .and_then(|()| self.inner(calldata))
         };
-        result.into_precompile_result(ctx.gas_used(), ctx.state_gas_used(), |b| b)
+        result.into_precompile_result(ctx.gas_used(), ctx.state_gas_used(), ctx.reservoir(), |b| b)
     }
 
     /// Returns `true` when the calldata selector belongs to a view (read-only) function.


### PR DESCRIPTION
[BOP-277](https://linear.app/coinbase/issue/BOP-277/stateful-precompiles-ignore-the-eip-8037-state-gas-reservoir)

## Motivation

EIP-8037 splits gas into regular gas and a state-gas reservoir: state-creation charges (new account, code deposit) should drain the reservoir first and spill into regular gas only after the reservoir is exhausted.

Stateful native precompiles were ignoring this entirely. The reservoir passed in `PrecompileInput` was discarded at construction, state-gas charges went directly against regular gas, and all output paths returned `state_gas_used` where the remaining reservoir was expected.

This caused B20 token creation to overcharge regular gas for state costs that should have been absorbed by the reservoir, and block-level regular/state gas accounting to diverge from the EIP-8037 model.

## What changed

- **`EvmPrecompileStorageProvider::new`**: extracts `input.reservoir` and initializes `Gas::new_with_regular_gas_and_reservoir(gas, reservoir)` instead of `Gas::new(gas)`. The manual `state_gas_used` field is removed; the `Gas` tracker owns that accounting.
- **`deduct_state_gas`**: replaced `deduct_gas` (regular-gas-only) with `Gas::record_state_cost`, which implements reservoir-first semantics.
- **`state_gas_used()` / `reservoir()`**: now delegate to `self.gas.state_gas_spent()` and `self.gas.reservoir()` respectively.
- **Output construction** (`success_output`, `revert_output`, `error_result`, `IntoPrecompileResult`): the third argument to `PrecompileOutput::new/revert` is now the remaining reservoir (`self.reservoir()`); `out.state_gas_used` is set separately to `self.state_gas_used()`. `IntoPrecompileResult::into_precompile_result` gains a `reservoir` parameter and all call sites in dispatch helpers and macros are updated.

## What was tried / considered

The `state_gas_used` field on `EvmPrecompileStorageProvider` could have been kept alongside a separate `reservoir` field. Delegating both to the `Gas` tracker is cleaner: the tracker already implements the reservoir-first accounting logic and keeps the numbers consistent, so duplicating the state was unnecessary.

`deduct_state_gas` on `HashMapStorageProvider` (the test mock) is left unchanged. It still accumulates a manual counter without a reservoir, which is correct for unit tests that do not model EIP-8037 dynamics.