### PR TITLE
ci(releases): cross-compile Linux ARM release binaries on x86

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -96,16 +96,14 @@ jobs:
           ln -sf "$MOLD_BIN" "$MOLD_CROSS_BIN/ld"
           ln -sf "$MOLD_BIN" "$MOLD_CROSS_BIN/ld.mold"
 
-          cat > "$MOLD_CROSS_BIN/aarch64-linux-gnu-gcc-with-mold" <<EOF
-#!/usr/bin/env bash
-exec "$CROSS_GCC" -B"$MOLD_CROSS_BIN" "\$@"
-EOF
+          printf '%s\n' '#!/usr/bin/env bash' \
+            "exec \"$CROSS_GCC\" -B\"$MOLD_CROSS_BIN\" \"\\$@\"" \
+            > "$MOLD_CROSS_BIN/aarch64-linux-gnu-gcc-with-mold"
           chmod +x "$MOLD_CROSS_BIN/aarch64-linux-gnu-gcc-with-mold"
 
-          cat > "$MOLD_CROSS_BIN/aarch64-linux-gnu-g++-with-mold" <<EOF
-#!/usr/bin/env bash
-exec "$CROSS_GXX" -B"$MOLD_CROSS_BIN" "\$@"
-EOF
+          printf '%s\n' '#!/usr/bin/env bash' \
+            "exec \"$CROSS_GXX\" -B\"$MOLD_CROSS_BIN\" \"\\$@\"" \
+            > "$MOLD_CROSS_BIN/aarch64-linux-gnu-g++-with-mold"
           chmod +x "$MOLD_CROSS_BIN/aarch64-linux-gnu-g++-with-mold"
 
           echo "MOLD_CROSS_BIN=$MOLD_CROSS_BIN" >> "$GITHUB_ENV"

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -96,14 +96,16 @@ jobs:
           ln -sf "$MOLD_BIN" "$MOLD_CROSS_BIN/ld"
           ln -sf "$MOLD_BIN" "$MOLD_CROSS_BIN/ld.mold"
 
-          printf '%s\n' '#!/usr/bin/env bash' \
-            "exec \"$CROSS_GCC\" -B\"$MOLD_CROSS_BIN\" \"\\$@\"" \
-            > "$MOLD_CROSS_BIN/aarch64-linux-gnu-gcc-with-mold"
+          {
+            echo '#!/usr/bin/env bash'
+            printf 'exec %q -B%q "$@"\n' "$CROSS_GCC" "$MOLD_CROSS_BIN"
+          } > "$MOLD_CROSS_BIN/aarch64-linux-gnu-gcc-with-mold"
           chmod +x "$MOLD_CROSS_BIN/aarch64-linux-gnu-gcc-with-mold"
 
-          printf '%s\n' '#!/usr/bin/env bash' \
-            "exec \"$CROSS_GXX\" -B\"$MOLD_CROSS_BIN\" \"\\$@\"" \
-            > "$MOLD_CROSS_BIN/aarch64-linux-gnu-g++-with-mold"
+          {
+            echo '#!/usr/bin/env bash'
+            printf 'exec %q -B%q "$@"\n' "$CROSS_GXX" "$MOLD_CROSS_BIN"
+          } > "$MOLD_CROSS_BIN/aarch64-linux-gnu-g++-with-mold"
           chmod +x "$MOLD_CROSS_BIN/aarch64-linux-gnu-g++-with-mold"
 
           echo "MOLD_CROSS_BIN=$MOLD_CROSS_BIN" >> "$GITHUB_ENV"

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -82,6 +82,34 @@ jobs:
         if: matrix.target.os == 'linux'
         uses: rui314/setup-mold@725a8794d15fc7563f59595bd9556495c0564878 # v1
 
+      - name: Configure mold for AArch64 cross-linking
+        if: matrix.target.triple == 'aarch64-unknown-linux-gnu'
+        run: |
+          set -euo pipefail
+
+          MOLD_BIN="$(command -v mold)"
+          CROSS_GCC="$(command -v aarch64-linux-gnu-gcc)"
+          CROSS_GXX="$(command -v aarch64-linux-gnu-g++)"
+          MOLD_CROSS_BIN="${RUNNER_TEMP}/mold-cross/bin"
+
+          mkdir -p "$MOLD_CROSS_BIN"
+          ln -sf "$MOLD_BIN" "$MOLD_CROSS_BIN/ld"
+          ln -sf "$MOLD_BIN" "$MOLD_CROSS_BIN/ld.mold"
+
+          cat > "$MOLD_CROSS_BIN/aarch64-linux-gnu-gcc-with-mold" <<EOF
+#!/usr/bin/env bash
+exec "$CROSS_GCC" -B"$MOLD_CROSS_BIN" "\$@"
+EOF
+          chmod +x "$MOLD_CROSS_BIN/aarch64-linux-gnu-gcc-with-mold"
+
+          cat > "$MOLD_CROSS_BIN/aarch64-linux-gnu-g++-with-mold" <<EOF
+#!/usr/bin/env bash
+exec "$CROSS_GXX" -B"$MOLD_CROSS_BIN" "\$@"
+EOF
+          chmod +x "$MOLD_CROSS_BIN/aarch64-linux-gnu-g++-with-mold"
+
+          echo "MOLD_CROSS_BIN=$MOLD_CROSS_BIN" >> "$GITHUB_ENV"
+
       - name: Install lld linker (macOS)
         if: matrix.target.os == 'macos'
         run: |
@@ -124,9 +152,9 @@ jobs:
 
           if [[ "${{ matrix.target.triple }}" == "aarch64-unknown-linux-gnu" ]]; then
             export AR_aarch64_unknown_linux_gnu=aarch64-linux-gnu-ar
-            export CC_aarch64_unknown_linux_gnu=aarch64-linux-gnu-gcc
-            export CXX_aarch64_unknown_linux_gnu=aarch64-linux-gnu-g++
-            export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc
+            export CC_aarch64_unknown_linux_gnu="${MOLD_CROSS_BIN}/aarch64-linux-gnu-gcc-with-mold"
+            export CXX_aarch64_unknown_linux_gnu="${MOLD_CROSS_BIN}/aarch64-linux-gnu-g++-with-mold"
+            export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER="${MOLD_CROSS_BIN}/aarch64-linux-gnu-gcc-with-mold"
             export PKG_CONFIG_ALLOW_CROSS=1
             export RANLIB_aarch64_unknown_linux_gnu=aarch64-linux-gnu-ranlib
           fi

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -73,7 +73,6 @@ jobs:
               gcc-aarch64-linux-gnu
               g++-aarch64-linux-gnu
               libc6-dev-arm64-cross
-              pkg-config-aarch64-linux-gnu
             )
           fi
           sudo apt-get install -y "${packages[@]}"
@@ -124,7 +123,6 @@ jobs:
             export CC_aarch64_unknown_linux_gnu=aarch64-linux-gnu-gcc
             export CXX_aarch64_unknown_linux_gnu=aarch64-linux-gnu-g++
             export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc
-            export PKG_CONFIG=aarch64-linux-gnu-pkg-config
             export PKG_CONFIG_ALLOW_CROSS=1
             export RANLIB_aarch64_unknown_linux_gnu=aarch64-linux-gnu-ranlib
           fi

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -99,6 +99,9 @@ jobs:
         with:
           targets: ${{ matrix.target.triple }}
 
+      - name: Add Rust target
+        run: rustup target add "${{ matrix.target.triple }}"
+
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
 

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -42,10 +42,10 @@ jobs:
             runner: ubuntu-24.04
             os: linux
           - triple: aarch64-unknown-linux-gnu
-            runner: ubuntu-24.04-arm
+            runner: ubuntu-24.04
             os: linux
           - triple: aarch64-apple-darwin
-            runner: macos-14
+            runner: macos-latest
             os: macos
 
     runs-on: ${{ matrix.target.runner }}
@@ -67,7 +67,16 @@ jobs:
         if: matrix.target.os == 'linux'
         run: |
           sudo apt-get update
-          sudo apt-get install -y libclang-dev pkg-config
+          packages=(libclang-dev pkg-config)
+          if [[ "${{ matrix.target.triple }}" == "aarch64-unknown-linux-gnu" ]]; then
+            packages+=(
+              gcc-aarch64-linux-gnu
+              g++-aarch64-linux-gnu
+              libc6-dev-arm64-cross
+              pkg-config-aarch64-linux-gnu
+            )
+          fi
+          sudo apt-get install -y "${packages[@]}"
 
       - name: Install mold linker (Linux)
         if: matrix.target.os == 'linux'
@@ -88,6 +97,8 @@ jobs:
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@4305c38b25d97ef35a8ad1f985ccf2d2242004f2 # stable
+        with:
+          targets: ${{ matrix.target.triple }}
 
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
@@ -107,7 +118,18 @@ jobs:
             [[ -n "$bin" ]] || continue
             cargo_args+=(--bin "$bin")
           done <<< "${RELEASE_BINS}"
-          cargo build --locked --profile maxperf "${cargo_args[@]}"
+
+          if [[ "${{ matrix.target.triple }}" == "aarch64-unknown-linux-gnu" ]]; then
+            export AR_aarch64_unknown_linux_gnu=aarch64-linux-gnu-ar
+            export CC_aarch64_unknown_linux_gnu=aarch64-linux-gnu-gcc
+            export CXX_aarch64_unknown_linux_gnu=aarch64-linux-gnu-g++
+            export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc
+            export PKG_CONFIG=aarch64-linux-gnu-pkg-config
+            export PKG_CONFIG_ALLOW_CROSS=1
+            export RANLIB_aarch64_unknown_linux_gnu=aarch64-linux-gnu-ranlib
+          fi
+
+          cargo build --locked --profile maxperf --target "${{ matrix.target.triple }}" "${cargo_args[@]}"
 
       - name: Package binaries
         run: |
@@ -116,7 +138,7 @@ jobs:
           while IFS= read -r bin; do
             [[ -n "$bin" ]] || continue
             ARCHIVE="${bin}-${TAG}-${TARGET}.tar.gz"
-            tar -czf "$ARCHIVE" -C target/maxperf "$bin"
+            tar -czf "$ARCHIVE" -C "target/${TARGET}/maxperf" "$bin"
             if command -v sha256sum &>/dev/null; then
               sha256sum "$ARCHIVE" > "${ARCHIVE}.sha256"
             else

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -70,6 +70,7 @@ jobs:
           packages=(libclang-dev pkg-config)
           if [[ "${{ matrix.target.triple }}" == "aarch64-unknown-linux-gnu" ]]; then
             packages+=(
+              binutils-aarch64-linux-gnu
               gcc-aarch64-linux-gnu
               g++-aarch64-linux-gnu
               libc6-dev-arm64-cross


### PR DESCRIPTION
## Summary
- build `aarch64-unknown-linux-gnu` release binaries on `ubuntu-24.04` instead of an ARM runner
- install the AArch64 GNU cross-compilation toolchain and pass Cargo the explicit Rust target
- package release artifacts from the target-specific output directory
- keep the Darwin ARM release build on `macos-latest`

## Testing
- not run locally; workflow-only change
