### PR TITLE
feat(chains): add Base networks as L1 configs for L3 support

### DIFF
--- a/crates/common/chains/src/base/config.rs
+++ b/crates/common/chains/src/base/config.rs
@@ -1,0 +1,32 @@
+//! Static Base L1 chain configuration mapping.
+
+use alloy_chains::NamedChain;
+use alloy_genesis::ChainConfig as GenesisChainConfig;
+
+use crate::{BaseMainnet, BaseSepolia};
+
+pub(crate) fn l1_configs() -> impl ExactSizeIterator<Item = (u64, GenesisChainConfig)> {
+    [
+        (NamedChain::Base.into(), BaseMainnet::l1_config()),
+        (NamedChain::BaseSepolia.into(), BaseSepolia::l1_config()),
+    ]
+    .into_iter()
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_primitives::map::HashMap;
+
+    use super::*;
+
+    #[test]
+    fn base_l1_config_all_chains() {
+        let base_chain_id = u64::from(NamedChain::Base);
+        let base_sepolia_chain_id = u64::from(NamedChain::BaseSepolia);
+        let configs = HashMap::<_, _>::from_iter(l1_configs());
+
+        assert!(configs.get(&base_chain_id).is_some());
+        assert!(configs.get(&base_sepolia_chain_id).is_some());
+        assert!(configs.get(&99999).is_none());
+    }
+}

--- a/crates/common/chains/src/base/mainnet.rs
+++ b/crates/common/chains/src/base/mainnet.rs
@@ -1,0 +1,97 @@
+//! Base mainnet L1 chain configuration.
+
+use alloy_chains::NamedChain;
+use alloy_genesis::ChainConfig;
+use alloy_primitives::U256;
+
+/// Base mainnet L1 chain configuration builder.
+#[derive(Debug, Clone, Copy)]
+pub struct BaseMainnet;
+
+impl BaseMainnet {
+    /// Canyon activation timestamp, inherited from the OP mainnet superchain schedule.
+    /// Maps to the Shanghai execution-layer fork.
+    const CANYON_TIME: u64 = 1_704_992_401;
+    /// Ecotone activation timestamp, inherited from the OP mainnet superchain schedule.
+    /// Maps to the Cancun execution-layer fork.
+    const ECOTONE_TIME: u64 = 1_710_374_401;
+    /// Isthmus activation timestamp, inherited from the OP mainnet superchain schedule.
+    /// Maps to the Prague execution-layer fork.
+    const ISTHMUS_TIME: u64 = 1_746_806_401;
+
+    /// Returns the Base mainnet [`ChainConfig`].
+    ///
+    /// Base is an OP Stack chain: it is post-merge from genesis, so every pre-merge fork is
+    /// active at block 0, there is no proof-of-work stage, and there is no beacon deposit
+    /// contract. The time-based forks are pinned to the OP upgrade activations that bring the
+    /// equivalent execution-layer features (Canyon=>Shanghai, Ecotone=>Cancun, Isthmus=>Prague).
+    pub fn l1_config() -> ChainConfig {
+        ChainConfig {
+            chain_id: NamedChain::Base.into(),
+            homestead_block: Some(0),
+            dao_fork_block: Some(0),
+            dao_fork_support: false,
+            eip150_block: Some(0),
+            eip155_block: Some(0),
+            eip158_block: Some(0),
+            byzantium_block: Some(0),
+            constantinople_block: Some(0),
+            petersburg_block: Some(0),
+            istanbul_block: Some(0),
+            muir_glacier_block: Some(0),
+            berlin_block: Some(0),
+            london_block: Some(0),
+            arrow_glacier_block: Some(0),
+            gray_glacier_block: Some(0),
+            shanghai_time: Some(Self::CANYON_TIME),
+            cancun_time: Some(Self::ECOTONE_TIME),
+            prague_time: Some(Self::ISTHMUS_TIME),
+            osaka_time: None,
+            amsterdam_time: None,
+            bpo1_time: None,
+            bpo2_time: None,
+            bpo3_time: None,
+            bpo4_time: None,
+            bpo5_time: None,
+            ethash: None,
+            blob_schedule: super::BlobSchedule::schedule(),
+            merge_netsplit_block: Some(0),
+            terminal_total_difficulty: Some(U256::ZERO),
+            deposit_contract_address: None,
+            clique: None,
+            parlia: None,
+            extra_fields: Default::default(),
+            terminal_total_difficulty_passed: true,
+            _non_exhaustive: (),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn maps_op_upgrades_to_el_forks() {
+        let cfg = BaseMainnet::l1_config();
+
+        assert_eq!(cfg.chain_id, u64::from(NamedChain::Base));
+        assert_eq!(cfg.shanghai_time, Some(BaseMainnet::CANYON_TIME));
+        assert_eq!(cfg.cancun_time, Some(BaseMainnet::ECOTONE_TIME));
+        assert_eq!(cfg.prague_time, Some(BaseMainnet::ISTHMUS_TIME));
+        // Azul (the Osaka-equivalent OP upgrade) is not live, so Osaka is unscheduled.
+        assert_eq!(cfg.osaka_time, None);
+    }
+
+    #[test]
+    fn is_post_merge_from_genesis() {
+        let cfg = BaseMainnet::l1_config();
+
+        assert_eq!(cfg.london_block, Some(0));
+        assert_eq!(cfg.merge_netsplit_block, Some(0));
+        assert_eq!(cfg.terminal_total_difficulty, Some(U256::ZERO));
+        assert!(cfg.terminal_total_difficulty_passed);
+        assert!(cfg.ethash.is_none());
+        assert!(cfg.deposit_contract_address.is_none());
+    }
+}

--- a/crates/common/chains/src/base/mod.rs
+++ b/crates/common/chains/src/base/mod.rs
@@ -1,0 +1,41 @@
+//! Base L1 chain configurations for known networks.
+//!
+//! These mirror the Ethereum L1 configurations but describe the Base networks acting as the
+//! parent ("L1") chain of an L3. Base is an OP Stack chain, so the configs are post-merge from
+//! genesis and pin the time-based execution-layer forks to the equivalent OP upgrade activations.
+
+use alloc::{
+    collections::BTreeMap,
+    string::{String, ToString},
+};
+
+use alloy_eips::eip7840::BlobParams;
+
+mod mainnet;
+pub use mainnet::BaseMainnet;
+
+mod sepolia;
+pub use sepolia::BaseSepolia;
+
+pub(super) mod config;
+
+/// Shared blob schedule builder for all Base networks.
+///
+/// Base inherits Ethereum's blob parameters for the forks it has adopted: Cancun (via Ecotone)
+/// and Prague (via Isthmus).
+pub(super) struct BlobSchedule;
+
+impl BlobSchedule {
+    pub(super) fn schedule() -> BTreeMap<String, BlobParams> {
+        BTreeMap::from([
+            (
+                alloy_hardforks::EthereumHardfork::Cancun.name().to_string().to_lowercase(),
+                BlobParams::cancun(),
+            ),
+            (
+                alloy_hardforks::EthereumHardfork::Prague.name().to_string().to_lowercase(),
+                BlobParams::prague(),
+            ),
+        ])
+    }
+}

--- a/crates/common/chains/src/base/sepolia.rs
+++ b/crates/common/chains/src/base/sepolia.rs
@@ -1,0 +1,97 @@
+//! Base Sepolia testnet L1 chain configuration.
+
+use alloy_chains::NamedChain;
+use alloy_genesis::ChainConfig;
+use alloy_primitives::U256;
+
+/// Base Sepolia testnet L1 chain configuration builder.
+#[derive(Debug, Clone, Copy)]
+pub struct BaseSepolia;
+
+impl BaseSepolia {
+    /// Canyon activation timestamp, inherited from the OP Sepolia superchain schedule.
+    /// Maps to the Shanghai execution-layer fork.
+    const CANYON_TIME: u64 = 1_699_981_200;
+    /// Ecotone activation timestamp, inherited from the OP Sepolia superchain schedule.
+    /// Maps to the Cancun execution-layer fork.
+    const ECOTONE_TIME: u64 = 1_708_534_800;
+    /// Isthmus activation timestamp, inherited from the OP Sepolia superchain schedule.
+    /// Maps to the Prague execution-layer fork.
+    const ISTHMUS_TIME: u64 = 1_744_905_600;
+
+    /// Returns the Base Sepolia testnet [`ChainConfig`].
+    ///
+    /// Base is an OP Stack chain: it is post-merge from genesis, so every pre-merge fork is
+    /// active at block 0, there is no proof-of-work stage, and there is no beacon deposit
+    /// contract. The time-based forks are pinned to the OP upgrade activations that bring the
+    /// equivalent execution-layer features (Canyon=>Shanghai, Ecotone=>Cancun, Isthmus=>Prague).
+    pub fn l1_config() -> ChainConfig {
+        ChainConfig {
+            chain_id: NamedChain::BaseSepolia.into(),
+            homestead_block: Some(0),
+            dao_fork_block: Some(0),
+            dao_fork_support: false,
+            eip150_block: Some(0),
+            eip155_block: Some(0),
+            eip158_block: Some(0),
+            byzantium_block: Some(0),
+            constantinople_block: Some(0),
+            petersburg_block: Some(0),
+            istanbul_block: Some(0),
+            muir_glacier_block: Some(0),
+            berlin_block: Some(0),
+            london_block: Some(0),
+            arrow_glacier_block: Some(0),
+            gray_glacier_block: Some(0),
+            shanghai_time: Some(Self::CANYON_TIME),
+            cancun_time: Some(Self::ECOTONE_TIME),
+            prague_time: Some(Self::ISTHMUS_TIME),
+            osaka_time: None,
+            amsterdam_time: None,
+            bpo1_time: None,
+            bpo2_time: None,
+            bpo3_time: None,
+            bpo4_time: None,
+            bpo5_time: None,
+            ethash: None,
+            blob_schedule: super::BlobSchedule::schedule(),
+            merge_netsplit_block: Some(0),
+            terminal_total_difficulty: Some(U256::ZERO),
+            deposit_contract_address: None,
+            clique: None,
+            parlia: None,
+            extra_fields: Default::default(),
+            terminal_total_difficulty_passed: true,
+            _non_exhaustive: (),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn maps_op_upgrades_to_el_forks() {
+        let cfg = BaseSepolia::l1_config();
+
+        assert_eq!(cfg.chain_id, u64::from(NamedChain::BaseSepolia));
+        assert_eq!(cfg.shanghai_time, Some(BaseSepolia::CANYON_TIME));
+        assert_eq!(cfg.cancun_time, Some(BaseSepolia::ECOTONE_TIME));
+        assert_eq!(cfg.prague_time, Some(BaseSepolia::ISTHMUS_TIME));
+        // Azul (the Osaka-equivalent OP upgrade) is not live, so Osaka is unscheduled.
+        assert_eq!(cfg.osaka_time, None);
+    }
+
+    #[test]
+    fn is_post_merge_from_genesis() {
+        let cfg = BaseSepolia::l1_config();
+
+        assert_eq!(cfg.london_block, Some(0));
+        assert_eq!(cfg.merge_netsplit_block, Some(0));
+        assert_eq!(cfg.terminal_total_difficulty, Some(U256::ZERO));
+        assert!(cfg.terminal_total_difficulty_passed);
+        assert!(cfg.ethash.is_none());
+        assert!(cfg.deposit_contract_address.is_none());
+    }
+}

--- a/crates/common/chains/src/ethereum/config.rs
+++ b/crates/common/chains/src/ethereum/config.rs
@@ -2,20 +2,18 @@
 
 use alloy_chains::NamedChain;
 use alloy_genesis::ChainConfig as GenesisChainConfig;
-use alloy_primitives::map::HashMap;
-use spin::Lazy;
 
 use crate::{Holesky, Hoodi, Mainnet, Sepolia};
 
-/// Ethereum L1 chain configurations keyed by chain ID.
-pub static L1_CONFIGS: Lazy<HashMap<u64, GenesisChainConfig>> = Lazy::new(|| {
-    let mut map = HashMap::default();
-    map.insert(NamedChain::Mainnet.into(), Mainnet::l1_config());
-    map.insert(NamedChain::Sepolia.into(), Sepolia::l1_config());
-    map.insert(NamedChain::Holesky.into(), Holesky::l1_config());
-    map.insert(NamedChain::Hoodi.into(), Hoodi::l1_config());
-    map
-});
+pub(crate) fn l1_configs() -> impl ExactSizeIterator<Item = (u64, GenesisChainConfig)> {
+    [
+        (NamedChain::Mainnet.into(), Mainnet::l1_config()),
+        (NamedChain::Sepolia.into(), Sepolia::l1_config()),
+        (NamedChain::Holesky.into(), Holesky::l1_config()),
+        (NamedChain::Hoodi.into(), Hoodi::l1_config()),
+    ]
+    .into_iter()
+}
 
 #[cfg(test)]
 mod tests {
@@ -23,6 +21,7 @@ mod tests {
         holesky::{HOLESKY_BPO1_TIMESTAMP, HOLESKY_BPO2_TIMESTAMP},
         sepolia::{SEPOLIA_BPO1_TIMESTAMP, SEPOLIA_BPO2_TIMESTAMP},
     };
+    use alloy_primitives::map::HashMap;
 
     use super::*;
 
@@ -33,20 +32,24 @@ mod tests {
         let holesky_chain_id = u64::from(NamedChain::Holesky);
         let hoodi_chain_id = u64::from(NamedChain::Hoodi);
 
-        assert!(L1_CONFIGS.get(&mainnet_chain_id).is_some());
-        assert!(L1_CONFIGS.get(&sepolia_chain_id).is_some());
-        assert!(L1_CONFIGS.get(&holesky_chain_id).is_some());
-        assert!(L1_CONFIGS.get(&hoodi_chain_id).is_some());
-        assert!(L1_CONFIGS.get(&99999).is_none());
+        let configs = HashMap::<_, _>::from_iter(l1_configs());
+
+        assert!(configs.get(&mainnet_chain_id).is_some());
+        assert!(configs.get(&sepolia_chain_id).is_some());
+        assert!(configs.get(&holesky_chain_id).is_some());
+        assert!(configs.get(&hoodi_chain_id).is_some());
+        assert!(configs.get(&99999).is_none());
     }
 
     #[test]
     fn bpo_timestamps() {
-        let sepolia = L1_CONFIGS.get(&11155111).unwrap();
+        let configs = HashMap::<_, _>::from_iter(l1_configs());
+
+        let sepolia = configs.get(&11155111).unwrap();
         assert_eq!(sepolia.bpo1_time, Some(SEPOLIA_BPO1_TIMESTAMP));
         assert_eq!(sepolia.bpo2_time, Some(SEPOLIA_BPO2_TIMESTAMP));
 
-        let holesky = L1_CONFIGS.get(&17000).unwrap();
+        let holesky = configs.get(&17000).unwrap();
         assert_eq!(holesky.bpo1_time, Some(HOLESKY_BPO1_TIMESTAMP));
         assert_eq!(holesky.bpo2_time, Some(HOLESKY_BPO2_TIMESTAMP));
     }

--- a/crates/common/chains/src/ethereum/mod.rs
+++ b/crates/common/chains/src/ethereum/mod.rs
@@ -19,8 +19,7 @@ pub use holesky::Holesky;
 mod hoodi;
 pub use hoodi::Hoodi;
 
-mod config;
-pub use config::L1_CONFIGS;
+pub(super) mod config;
 
 /// Shared blob schedule builder for all Ethereum networks.
 pub(super) struct BlobSchedule;

--- a/crates/common/chains/src/lib.rs
+++ b/crates/common/chains/src/lib.rs
@@ -3,6 +3,10 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![no_std]
 
+use alloy_genesis::ChainConfig as GenesisChainConfig;
+use alloy_primitives::map::HashMap;
+use spin::Lazy;
+
 extern crate alloc;
 
 mod config;
@@ -21,7 +25,17 @@ mod macros;
 pub use macros::RollupConfigSource;
 
 mod ethereum;
-pub use ethereum::{Holesky, Hoodi, L1_CONFIGS, Mainnet, Sepolia};
+pub use ethereum::{Holesky, Hoodi, Mainnet, Sepolia};
+
+mod base;
+pub use base::{BaseMainnet, BaseSepolia};
 
 #[cfg(any(test, feature = "test-utils"))]
 pub mod test_utils;
+
+/// L1 chain configurations keyed by chain ID.
+///
+/// Covers the Ethereum networks that Base settles to, plus the Base networks
+/// themselves, so they are recognized as parent ("L1") chains for an L3.
+pub static L1_CONFIGS: Lazy<HashMap<u64, GenesisChainConfig>> =
+    Lazy::new(|| ethereum::config::l1_configs().chain(base::config::l1_configs()).collect());


### PR DESCRIPTION
Add BaseMainnet and BaseSepolia chain configurations so the Base networks are recognized as parent ("L1") chains when running an L3. These mirror the Ethereum L1 configs but describe Base as an OP Stack chain: post-merge from genesis with time-based forks pinned to the equivalent OP upgrade activations.

With this commit, _both_ the Ethereum _and_ the Base chains will be considered as valid chains. In practice, we will likely want to have an _either_/_or_ behavior here, but this is left as a future improvement.