### PR TITLE
fix(precompile-storage): propagate SSTORE refunds through IntoPrecompileResult (BOP-289)

### DIFF
--- a/crates/common/precompile-storage/src/error.rs
+++ b/crates/common/precompile-storage/src/error.rs
@@ -131,10 +131,14 @@ impl BasePrecompileError {
 /// Extension trait to convert `Result<T, BasePrecompileError>` into a [`PrecompileResult`].
 pub trait IntoPrecompileResult<T> {
     /// Converts `self` into a [`PrecompileResult`] using `encode_ok` for the success path.
+    ///
+    /// `gas_refunded` is copied into `PrecompileOutput::gas_refunded` on success so revm can
+    /// apply EIP-3529 refund accounting at the transaction level. Pass `ctx.gas_refunded()`.
     fn into_precompile_result(
         self,
         gas: u64,
         state_gas: u64,
+        gas_refunded: i64,
         encode_ok: impl FnOnce(T) -> Bytes,
     ) -> PrecompileResult;
 }
@@ -144,10 +148,15 @@ impl<T> IntoPrecompileResult<T> for Result<T> {
         self,
         gas: u64,
         state_gas: u64,
+        gas_refunded: i64,
         encode_ok: impl FnOnce(T) -> Bytes,
     ) -> PrecompileResult {
         match self {
-            Ok(res) => Ok(PrecompileOutput::new(gas, encode_ok(res), state_gas)),
+            Ok(res) => {
+                let mut out = PrecompileOutput::new(gas, encode_ok(res), state_gas);
+                out.gas_refunded = gas_refunded;
+                Ok(out)
+            }
             Err(err) => err.into_precompile_result(gas, state_gas),
         }
     }
@@ -167,5 +176,35 @@ mod tests {
         let output = result.unwrap();
         assert!(output.is_revert());
         assert_eq!(output.bytes, expected);
+    }
+
+    #[test]
+    fn into_precompile_result_propagates_gas_refunded_on_success() {
+        let ok: Result<Bytes> = Ok(Bytes::from("out"));
+        let out = ok.into_precompile_result(500, 0, 200, |b| b).unwrap();
+
+        assert!(out.is_success());
+        assert_eq!(out.gas_used, 500);
+        assert_eq!(out.gas_refunded, 200);
+    }
+
+    #[test]
+    fn into_precompile_result_zero_refund_on_success() {
+        let ok: Result<Bytes> = Ok(Bytes::new());
+        let out = ok.into_precompile_result(0, 0, 0, |b| b).unwrap();
+
+        assert!(out.is_success());
+        assert_eq!(out.gas_refunded, 0);
+    }
+
+    #[test]
+    fn into_precompile_result_error_path_does_not_expose_refund_field() {
+        // The error path goes through BasePrecompileError::into_precompile_result which
+        // does not set gas_refunded (refunds are only meaningful on success).
+        let err: Result<Bytes> = Err(BasePrecompileError::Revert(Bytes::new()));
+        let out = err.into_precompile_result(100, 0, 999, |b| b).unwrap();
+
+        assert!(out.is_revert());
+        assert_eq!(out.gas_refunded, 0, "error path must not propagate gas_refunded");
     }
 }

--- a/crates/common/precompile-storage/src/error.rs
+++ b/crates/common/precompile-storage/src/error.rs
@@ -129,11 +129,19 @@ impl BasePrecompileError {
 }
 
 /// Extension trait to convert `Result<T, BasePrecompileError>` into a [`PrecompileResult`].
+///
+/// Prefer [`StorageCtx::result_output`] over calling this trait directly — it reads all gas
+/// accounting fields from the context automatically. Use this trait only when the context is not
+/// available (e.g. in unit tests).
 pub trait IntoPrecompileResult<T> {
     /// Converts `self` into a [`PrecompileResult`] using `encode_ok` for the success path.
     ///
-    /// `gas_refunded` is copied into `PrecompileOutput::gas_refunded` on success so revm can
-    /// apply EIP-3529 refund accounting at the transaction level. Pass `ctx.gas_refunded()`.
+    /// On success, the accumulated EIP-3529 gas refund (`gas_refunded`) is copied into
+    /// [`PrecompileOutput::gas_refunded`] so revm can include it in transaction-level refund
+    /// accounting under the EIP-3529 cap (`gas_used / 5`).
+    ///
+    /// On error, `gas_refunded` is not propagated: refunds are only meaningful on successful
+    /// execution and the error arm delegates to [`BasePrecompileError::into_precompile_result`].
     fn into_precompile_result(
         self,
         gas: u64,

--- a/crates/common/precompile-storage/src/hashmap.rs
+++ b/crates/common/precompile-storage/src/hashmap.rs
@@ -29,6 +29,7 @@ pub struct HashMapStorageProvider {
     snapshots: Vec<Snapshot>,
     gas_params: GasParams,
     state_gas_used: u64,
+    gas_refunded: i64,
     /// Emitted events keyed by contract address.
     pub events: HashMap<Address, Vec<LogData>>,
 }
@@ -65,6 +66,7 @@ impl HashMapStorageProvider {
             counter_sstore: 0,
             gas_params: GasParams::default(),
             state_gas_used: 0,
+            gas_refunded: 0,
         }
     }
 }
@@ -119,8 +121,15 @@ impl PrecompileStorageProvider for HashMapStorageProvider {
         if self.is_static {
             return Err(BasePrecompileError::StaticCallViolation);
         }
+        let old = self.internals.get(&(address, key)).copied().unwrap_or(U256::ZERO);
         self.counter_sstore += 1;
         self.internals.insert((address, key), value);
+        // Simplified EIP-3529 refund: clearing a previously set slot earns a refund.
+        // Exact EIP-2200/3529 accounting requires original-value tracking; the test provider
+        // approximates with the post-London clear-slot refund to keep the mock simple.
+        if !old.is_zero() && value.is_zero() {
+            self.refund_gas(4_800);
+        }
         Ok(())
     }
 
@@ -167,7 +176,9 @@ impl PrecompileStorageProvider for HashMapStorageProvider {
         Ok(())
     }
 
-    fn refund_gas(&mut self, _gas: i64) {}
+    fn refund_gas(&mut self, gas: i64) {
+        self.gas_refunded = self.gas_refunded.saturating_add(gas);
+    }
 
     fn gas_limit(&self) -> u64 {
         0
@@ -182,7 +193,7 @@ impl PrecompileStorageProvider for HashMapStorageProvider {
     }
 
     fn gas_refunded(&self) -> i64 {
-        0
+        self.gas_refunded
     }
 
     fn reservoir(&self) -> u64 {
@@ -325,4 +336,63 @@ impl HashMapStorageProvider {
 #[cfg(any(test, feature = "test-utils"))]
 pub fn setup_storage() -> (HashMapStorageProvider, Address) {
     (HashMapStorageProvider::new(1), Address::from([0x42u8; 20]))
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_primitives::{Address, U256};
+
+    use super::*;
+    use crate::provider::PrecompileStorageProvider;
+
+    const ADDR: Address = Address::ZERO;
+    const KEY: U256 = U256::ZERO;
+
+    #[test]
+    fn refund_gas_accumulates_positive() {
+        let mut p = HashMapStorageProvider::new(1);
+        p.refund_gas(1_000);
+        p.refund_gas(500);
+        assert_eq!(p.gas_refunded(), 1_500);
+    }
+
+    #[test]
+    fn refund_gas_accumulates_negative() {
+        let mut p = HashMapStorageProvider::new(1);
+        p.refund_gas(4_800);
+        p.refund_gas(-4_800);
+        assert_eq!(p.gas_refunded(), 0);
+    }
+
+    #[test]
+    fn refund_gas_starts_at_zero() {
+        let p = HashMapStorageProvider::new(1);
+        assert_eq!(p.gas_refunded(), 0);
+    }
+
+    #[test]
+    fn sstore_clearing_slot_generates_refund() {
+        let mut p = HashMapStorageProvider::new(1);
+        // Write a non-zero value first.
+        p.sstore(ADDR, KEY, U256::from(42u64)).unwrap();
+        assert_eq!(p.gas_refunded(), 0, "writing non-zero to zero slot earns no refund");
+        // Clear it — should earn EIP-3529 refund.
+        p.sstore(ADDR, KEY, U256::ZERO).unwrap();
+        assert!(p.gas_refunded() > 0, "clearing a non-zero slot must earn a refund");
+    }
+
+    #[test]
+    fn sstore_nonzero_to_nonzero_earns_no_refund() {
+        let mut p = HashMapStorageProvider::new(1);
+        p.sstore(ADDR, KEY, U256::from(1u64)).unwrap();
+        p.sstore(ADDR, KEY, U256::from(2u64)).unwrap();
+        assert_eq!(p.gas_refunded(), 0);
+    }
+
+    #[test]
+    fn sstore_zero_to_nonzero_earns_no_refund() {
+        let mut p = HashMapStorageProvider::new(1);
+        p.sstore(ADDR, KEY, U256::from(99u64)).unwrap();
+        assert_eq!(p.gas_refunded(), 0);
+    }
 }

--- a/crates/common/precompile-storage/src/storage_ctx.rs
+++ b/crates/common/precompile-storage/src/storage_ctx.rs
@@ -18,7 +18,7 @@ use revm::{
 };
 
 use crate::{
-    error::{BasePrecompileError, Result},
+    error::{BasePrecompileError, IntoPrecompileResult, Result},
     provider::PrecompileStorageProvider,
 };
 
@@ -225,6 +225,29 @@ impl<'a> StorageCtx<'a> {
     pub fn error_result(&self, error: impl Into<BasePrecompileError>) -> PrecompileResult {
         error.into().into_precompile_result(self.gas_used(), self.state_gas_used())
     }
+
+    /// Converts a `Result<T>` into a [`PrecompileResult`], reading all gas accounting fields
+    /// from the current context.
+    ///
+    /// On success, `encode_ok` encodes the value and the output carries `gas_used`,
+    /// `state_gas_used`, and `gas_refunded` from the context — the same fields that
+    /// [`success_output`](Self::success_output) sets. On error, delegates to
+    /// [`BasePrecompileError::into_precompile_result`].
+    ///
+    /// Use this instead of calling [`IntoPrecompileResult::into_precompile_result`] directly,
+    /// so callers do not have to manually thread gas values through.
+    pub fn result_output<T>(
+        &self,
+        result: Result<T>,
+        encode_ok: impl FnOnce(T) -> Bytes,
+    ) -> PrecompileResult {
+        result.into_precompile_result(
+            self.gas_used(),
+            self.state_gas_used(),
+            self.gas_refunded(),
+            encode_ok,
+        )
+    }
 }
 
 /// RAII guard for temporary caller overrides.
@@ -416,5 +439,55 @@ mod tests {
             }
             assert_eq!(ctx.sload(addr, key).unwrap(), U256::from(99));
         });
+    }
+
+    #[test]
+    fn result_output_success_propagates_gas_refunded() {
+        let mut storage = crate::hashmap::HashMapStorageProvider::new(1);
+        let addr = Address::ZERO;
+        let key = U256::from(1);
+
+        let output = StorageCtx::enter(&mut storage, |ctx| {
+            // Write a non-zero value then clear it to generate an EIP-3529 refund.
+            ctx.sstore(addr, key, U256::from(42)).unwrap();
+            ctx.sstore(addr, key, U256::ZERO).unwrap();
+
+            ctx.result_output::<Bytes>(Ok(Bytes::new()), |b| b)
+        })
+        .unwrap();
+
+        assert!(output.is_success());
+        assert!(output.gas_refunded > 0, "clearing a slot must propagate a non-zero refund");
+    }
+
+    #[test]
+    fn result_output_error_does_not_expose_refund() {
+        let mut storage = crate::hashmap::HashMapStorageProvider::new(1);
+        let addr = Address::ZERO;
+        let key = U256::from(1);
+
+        let output = StorageCtx::enter(&mut storage, |ctx| {
+            ctx.sstore(addr, key, U256::from(1)).unwrap();
+            ctx.sstore(addr, key, U256::ZERO).unwrap();
+
+            ctx.result_output::<Bytes>(Err(BasePrecompileError::Revert(Bytes::new())), |b| b)
+        })
+        .unwrap();
+
+        assert!(output.is_revert());
+        assert_eq!(output.gas_refunded, 0, "error path must not propagate gas_refunded");
+    }
+
+    #[test]
+    fn result_output_success_no_refund() {
+        let mut storage = crate::hashmap::HashMapStorageProvider::new(1);
+
+        let output = StorageCtx::enter(&mut storage, |ctx| {
+            ctx.result_output::<Bytes>(Ok(Bytes::new()), |b| b)
+        })
+        .unwrap();
+
+        assert!(output.is_success());
+        assert_eq!(output.gas_refunded, 0);
     }
 }

--- a/crates/common/precompiles/src/activation/dispatch.rs
+++ b/crates/common/precompiles/src/activation/dispatch.rs
@@ -23,6 +23,7 @@ impl ActivationRegistryStorage<'_> {
         self.inner(calldata, activation_admin_address).into_precompile_result(
             ctx.gas_used(),
             ctx.state_gas_used(),
+            ctx.gas_refunded(),
             |output| output,
         )
     }

--- a/crates/common/precompiles/src/activation/dispatch.rs
+++ b/crates/common/precompiles/src/activation/dispatch.rs
@@ -2,7 +2,7 @@
 
 use alloy_primitives::{Address, Bytes};
 use alloy_sol_types::SolCall;
-use base_precompile_storage::{IntoPrecompileResult, StorageCtx};
+use base_precompile_storage::StorageCtx;
 use revm::precompile::PrecompileResult;
 
 use crate::{
@@ -20,12 +20,7 @@ impl ActivationRegistryStorage<'_> {
         activation_admin_address: Option<Address>,
     ) -> PrecompileResult {
         deduct_calldata_cost!(ctx, calldata);
-        self.inner(calldata, activation_admin_address).into_precompile_result(
-            ctx.gas_used(),
-            ctx.state_gas_used(),
-            ctx.gas_refunded(),
-            |output| output,
-        )
+        ctx.result_output(self.inner(calldata, activation_admin_address), |output| output)
     }
 
     fn inner(

--- a/crates/common/precompiles/src/activation/storage.rs
+++ b/crates/common/precompiles/src/activation/storage.rs
@@ -80,6 +80,7 @@ impl ActivationRegistryStorage<'_> {
         self.ensure_activated(feature).into_precompile_result(
             self.storage.gas_used(),
             self.storage.state_gas_used(),
+            self.storage.gas_refunded(),
             |()| Bytes::new(),
         )
     }

--- a/crates/common/precompiles/src/activation/storage.rs
+++ b/crates/common/precompiles/src/activation/storage.rs
@@ -2,9 +2,7 @@
 
 use alloy_primitives::{Address, B256, Bytes, address, b256};
 use base_precompile_macros::contract;
-use base_precompile_storage::{
-    BasePrecompileError, Handler, IntoPrecompileResult, Mapping, Result,
-};
+use base_precompile_storage::{BasePrecompileError, Handler, Mapping, Result};
 use revm::precompile::PrecompileResult;
 
 use crate::IActivationRegistry;
@@ -77,12 +75,7 @@ impl ActivationRegistryStorage<'_> {
     /// [`revm::precompile::PrecompileOutput::reverted`] to distinguish an activated feature from an
     /// ABI revert.
     pub fn assert_activated(&self, feature: B256) -> PrecompileResult {
-        self.ensure_activated(feature).into_precompile_result(
-            self.storage.gas_used(),
-            self.storage.state_gas_used(),
-            self.storage.gas_refunded(),
-            |()| Bytes::new(),
-        )
+        self.storage.result_output(self.ensure_activated(feature), |()| Bytes::new())
     }
 
     /// Returns `Ok(())` when the feature is activated.
@@ -480,5 +473,52 @@ mod tests {
                 feature: FEATURE,
             })
         );
+    }
+
+    /// End-to-end test: activate a feature, then deactivate it through `dispatch`. Deactivation
+    /// clears the feature storage slot (nonzero to zero SSTORE), which earns an EIP-3529 refund
+    /// that must appear in `PrecompileOutput::gas_refunded`.
+    #[test]
+    fn dispatch_deactivate_propagates_sstore_refund() {
+        use alloy_sol_types::SolCall;
+
+        let mut storage = HashMapStorageProvider::new(1);
+        storage.set_caller(ADMIN);
+
+        // Activate first so deactivation has a nonzero slot to clear.
+        activate_feature(&mut storage).unwrap();
+
+        let calldata = IActivationRegistry::deactivateCall { feature: FEATURE }.abi_encode();
+
+        let output = StorageCtx::enter(&mut storage, |ctx| {
+            ActivationRegistryStorage::new(ctx).dispatch(ctx, &calldata, Some(ADMIN))
+        })
+        .expect("dispatch must not fatally error");
+
+        assert!(output.is_success(), "deactivate must succeed");
+        assert!(
+            output.gas_refunded > 0,
+            "deactivating a feature clears a storage slot and must propagate an EIP-3529 refund"
+        );
+    }
+
+    /// Activating a feature writes to a zero slot (nonzero-to-zero refunds do not apply to
+    /// zero-to-nonzero writes), so `gas_refunded` must be zero on the activate path.
+    #[test]
+    fn dispatch_activate_has_no_sstore_refund() {
+        use alloy_sol_types::SolCall;
+
+        let mut storage = HashMapStorageProvider::new(1);
+        storage.set_caller(ADMIN);
+
+        let calldata = IActivationRegistry::activateCall { feature: FEATURE }.abi_encode();
+
+        let output = StorageCtx::enter(&mut storage, |ctx| {
+            ActivationRegistryStorage::new(ctx).dispatch(ctx, &calldata, Some(ADMIN))
+        })
+        .expect("dispatch must not fatally error");
+
+        assert!(output.is_success());
+        assert_eq!(output.gas_refunded, 0, "writing to a zero slot earns no refund");
     }
 }

--- a/crates/common/precompiles/src/b20_asset/dispatch.rs
+++ b/crates/common/precompiles/src/b20_asset/dispatch.rs
@@ -7,7 +7,7 @@ use alloc::{string::String, vec::Vec};
 
 use alloy_primitives::{Bytes, U256};
 use alloy_sol_types::{SolCall, SolEvent, SolInterface, SolValue};
-use base_precompile_storage::{BasePrecompileError, IntoPrecompileResult, StorageCtx};
+use base_precompile_storage::{BasePrecompileError, StorageCtx};
 use revm::precompile::PrecompileResult;
 
 use crate::{
@@ -45,12 +45,7 @@ impl<S: AssetAccounting, P: Policy> B20AssetToken<S, P> {
             }
             Err(e) => return e.into_precompile_result(ctx.gas_used(), ctx.state_gas_used()),
         }
-        self.inner_with_observer(ctx, calldata, observer).into_precompile_result(
-            ctx.gas_used(),
-            ctx.state_gas_used(),
-            ctx.gas_refunded(),
-            |b| b,
-        )
+        ctx.result_output(self.inner_with_observer(ctx, calldata, observer), |b| b)
     }
 
     /// Decodes calldata and executes the matching `IB20Asset` or inherited `IB20` operation.

--- a/crates/common/precompiles/src/b20_asset/dispatch.rs
+++ b/crates/common/precompiles/src/b20_asset/dispatch.rs
@@ -48,6 +48,7 @@ impl<S: AssetAccounting, P: Policy> B20AssetToken<S, P> {
         self.inner_with_observer(ctx, calldata, observer).into_precompile_result(
             ctx.gas_used(),
             ctx.state_gas_used(),
+            ctx.gas_refunded(),
             |b| b,
         )
     }

--- a/crates/common/precompiles/src/b20_factory/dispatch.rs
+++ b/crates/common/precompiles/src/b20_factory/dispatch.rs
@@ -16,7 +16,7 @@ impl<'a> B20FactoryStorage<'a> {
         deduct_calldata_cost!(ctx, calldata);
         let result = self.inner(ctx, calldata);
         let gas = ctx.gas_used();
-        result.into_precompile_result(gas, ctx.state_gas_used(), |b| b)
+        result.into_precompile_result(gas, ctx.state_gas_used(), ctx.gas_refunded(), |b| b)
     }
 
     fn inner(

--- a/crates/common/precompiles/src/b20_factory/dispatch.rs
+++ b/crates/common/precompiles/src/b20_factory/dispatch.rs
@@ -2,7 +2,7 @@
 
 use alloy_primitives::{Address, Bytes};
 use alloy_sol_types::SolCall;
-use base_precompile_storage::{IntoPrecompileResult, StorageCtx};
+use base_precompile_storage::StorageCtx;
 use revm::precompile::PrecompileResult;
 
 use crate::{
@@ -14,9 +14,7 @@ impl<'a> B20FactoryStorage<'a> {
     /// ABI-dispatches `calldata` to the appropriate `IB20Factory` handler.
     pub fn dispatch(&mut self, ctx: StorageCtx<'_>, calldata: &[u8]) -> PrecompileResult {
         deduct_calldata_cost!(ctx, calldata);
-        let result = self.inner(ctx, calldata);
-        let gas = ctx.gas_used();
-        result.into_precompile_result(gas, ctx.state_gas_used(), ctx.gas_refunded(), |b| b)
+        ctx.result_output(self.inner(ctx, calldata), |b| b)
     }
 
     fn inner(

--- a/crates/common/precompiles/src/b20_stablecoin/dispatch.rs
+++ b/crates/common/precompiles/src/b20_stablecoin/dispatch.rs
@@ -7,7 +7,7 @@
 
 use alloy_primitives::{Bytes, U256};
 use alloy_sol_types::{SolCall, SolInterface, SolValue};
-use base_precompile_storage::{BasePrecompileError, IntoPrecompileResult, StorageCtx};
+use base_precompile_storage::{BasePrecompileError, StorageCtx};
 use revm::precompile::PrecompileResult;
 
 use crate::{
@@ -45,12 +45,7 @@ impl<S: StablecoinAccounting, P: Policy> B20StablecoinToken<S, P> {
             }
             Err(e) => return e.into_precompile_result(ctx.gas_used(), ctx.state_gas_used()),
         }
-        self.inner_with_observer(ctx, calldata, observer).into_precompile_result(
-            ctx.gas_used(),
-            ctx.state_gas_used(),
-            ctx.gas_refunded(),
-            |b| b,
-        )
+        ctx.result_output(self.inner_with_observer(ctx, calldata, observer), |b| b)
     }
 
     /// Decodes calldata and executes the matching `IB20` operation.

--- a/crates/common/precompiles/src/b20_stablecoin/dispatch.rs
+++ b/crates/common/precompiles/src/b20_stablecoin/dispatch.rs
@@ -48,6 +48,7 @@ impl<S: StablecoinAccounting, P: Policy> B20StablecoinToken<S, P> {
         self.inner_with_observer(ctx, calldata, observer).into_precompile_result(
             ctx.gas_used(),
             ctx.state_gas_used(),
+            ctx.gas_refunded(),
             |b| b,
         )
     }

--- a/crates/common/precompiles/src/policy/dispatch.rs
+++ b/crates/common/precompiles/src/policy/dispatch.rs
@@ -1,6 +1,6 @@
 use alloy_primitives::Bytes;
 use alloy_sol_types::SolCall;
-use base_precompile_storage::{IntoPrecompileResult, StorageCtx};
+use base_precompile_storage::StorageCtx;
 use revm::precompile::PrecompileResult;
 
 use crate::{
@@ -24,12 +24,7 @@ impl PolicyRegistryStorage<'_> {
                 .ensure_activated(ActivationFeature::PolicyRegistry.id())
                 .and_then(|()| self.inner(calldata))
         };
-        result.into_precompile_result(
-            ctx.gas_used(),
-            ctx.state_gas_used(),
-            ctx.gas_refunded(),
-            |b| b,
-        )
+        ctx.result_output(result, |b| b)
     }
 
     /// Returns `true` when the calldata selector belongs to a view (read-only) function.

--- a/crates/common/precompiles/src/policy/dispatch.rs
+++ b/crates/common/precompiles/src/policy/dispatch.rs
@@ -24,7 +24,12 @@ impl PolicyRegistryStorage<'_> {
                 .ensure_activated(ActivationFeature::PolicyRegistry.id())
                 .and_then(|()| self.inner(calldata))
         };
-        result.into_precompile_result(ctx.gas_used(), ctx.state_gas_used(), |b| b)
+        result.into_precompile_result(
+            ctx.gas_used(),
+            ctx.state_gas_used(),
+            ctx.gas_refunded(),
+            |b| b,
+        )
     }
 
     /// Returns `true` when the calldata selector belongs to a view (read-only) function.


### PR DESCRIPTION
[BOP-289](https://linear.app/coinbase/issue/BOP-289/9-generic-precompile-success-conversion-drops-accumulated-sstore)

## Motivation

Successful precompile calls that clear previously nonzero storage slots accumulate an EIP-3529 gas refund in the storage provider via `refund_gas`. The `StorageCtx::success_output` path correctly copies this refund into `PrecompileOutput::gas_refunded`. The generic `IntoPrecompileResult::into_precompile_result` path did not: it constructed a `PrecompileOutput::new(gas, bytes, state_gas)` and returned it unchanged, silently dropping the accumulated refund.

This is reachable in production. Operations that zero out storage slots before returning through the generic dispatch path include B20 balance zeroing on transfer, allowance zeroing on approval, full burns, feature deactivation, and policy admin finalization/renounce. All of those dispatch paths used `IntoPrecompileResult`, so callers overpaid gas whenever those slots were cleared.

## What changed

- `IntoPrecompileResult::into_precompile_result` gains a `gas_refunded: i64` parameter. On the success arm, `out.gas_refunded` is set before returning. The error arm is unchanged (refunds are not meaningful on revert/halt).
- All six dispatch call sites (`policy`, `activation`, `b20_factory`, `b20_asset`, `b20_stablecoin`, `activation::assert_activated`) pass `ctx.gas_refunded()` or `self.storage.gas_refunded()` as the new argument.
- Three regression tests in `error.rs` assert that the refund propagates on success, is zero when zero, and is not set on the error path.

## What was tried / considered

An alternative was to replace all `IntoPrecompileResult` call sites with `ctx.success_output(encode_ok(res))`, which already handles refunds. That would have worked but requires the ctx to be in scope at every call site, which is not always the case (e.g. `assert_activated` holds a `StorageCtx` indirectly via `self.storage`, not a local binding). Threading `gas_refunded` through the existing signature is a smaller, more contained change that does not require restructuring the dispatch functions.