### PR TITLE
chore: remove base discovery protocol flag

### DIFF
--- a/crates/execution/cli/src/commands/p2p/bootnode.rs
+++ b/crates/execution/cli/src/commands/p2p/bootnode.rs
@@ -41,10 +41,6 @@ pub struct Command {
     /// Run a discv5 topic discovery bootnode in addition to discv4.
     #[arg(long)]
     pub v5: bool,
-
-    /// Enable the Base discv5 protocol identity.
-    #[arg(long = "v5.base-protocol", default_value_t = true, action = clap::ArgAction::Set)]
-    pub base_protocol: bool,
 }
 
 impl Command {
@@ -144,12 +140,10 @@ impl Command {
     pub fn discv5_config(&self) -> Config {
         let mut inner_builder = Discv5ConfigBuilder::new(DEFAULT_DISCOVERY_V5_LISTEN_CONFIG);
 
-        if self.base_protocol {
-            inner_builder.protocol_identity(ProtocolIdentity {
-                protocol_id: BASE_V0_PROTOCOL_VERSION,
-                ..Default::default()
-            });
-        }
+        inner_builder.protocol_identity(ProtocolIdentity {
+            protocol_id: BASE_V0_PROTOCOL_VERSION,
+            ..Default::default()
+        });
 
         Config::builder(self.v5_addr).discv5_config(inner_builder.build()).build()
     }
@@ -176,7 +170,6 @@ mod tests {
             p2p_secret_key: None,
             nat: NatResolver::None,
             v5: false,
-            base_protocol: true,
         }
     }
 

--- a/crates/execution/node/src/args.rs
+++ b/crates/execution/node/src/args.rs
@@ -134,12 +134,6 @@ pub struct RollupArgs {
     )]
     pub proofs_history_verification_interval: u64,
 
-    /// Enable the Base discv5 protocol identity.
-    ///
-    /// When enabled, the node advertises itself with the `basev0` protocol ID in discv5,
-    /// allowing it to find and connect to other Base nodes more efficiently.
-    #[arg(long = "rollup.discovery.v5.base", default_value_t = true, action = clap::ArgAction::Set)]
-    pub base_protocol: bool,
 }
 
 impl Default for RollupArgs {
@@ -158,7 +152,6 @@ impl Default for RollupArgs {
             proofs_history_window: 1_296_000,
             proofs_history_prune_interval: Duration::from_secs(15),
             proofs_history_verification_interval: 0,
-            base_protocol: true,
         }
     }
 }
@@ -280,20 +273,4 @@ mod tests {
         assert_eq!(args.txpool_ordering, TxpoolOrdering::Timestamp);
     }
 
-    #[test]
-    fn test_parse_base_protocol_default_true() {
-        let args = CommandParser::<RollupArgs>::parse_from(["reth"]).args;
-        assert!(args.base_protocol);
-    }
-
-    #[test]
-    fn test_parse_base_protocol_disabled() {
-        let args = CommandParser::<RollupArgs>::parse_from([
-            "reth",
-            "--rollup.discovery.v5.base",
-            "false",
-        ])
-        .args;
-        assert!(!args.base_protocol);
-    }
 }

--- a/crates/execution/node/src/args.rs
+++ b/crates/execution/node/src/args.rs
@@ -133,7 +133,6 @@ pub struct RollupArgs {
         default_value_t = 0
     )]
     pub proofs_history_verification_interval: u64,
-
 }
 
 impl Default for RollupArgs {
@@ -272,5 +271,4 @@ mod tests {
         .args;
         assert_eq!(args.txpool_ordering, TxpoolOrdering::Timestamp);
     }
-
 }

--- a/crates/execution/node/src/node.rs
+++ b/crates/execution/node/src/node.rs
@@ -1073,18 +1073,12 @@ where
 }
 
 /// A basic Base network builder.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct BaseNetworkBuilder {
     /// Disable transaction pool gossip
     pub disable_txpool_gossip: bool,
     /// Disable discovery v4
     pub disable_discovery_v4: bool,
-}
-
-impl Default for BaseNetworkBuilder {
-    fn default() -> Self {
-        Self { disable_discovery_v4: false, disable_txpool_gossip: false }
-    }
 }
 
 impl BaseNetworkBuilder {

--- a/crates/execution/node/src/node.rs
+++ b/crates/execution/node/src/node.rs
@@ -246,7 +246,6 @@ impl BaseNode {
             compute_pending_block,
             discovery_v4,
             txpool_ordering,
-            base_protocol,
             max_inflight_delegated_slots,
             ..
         } = self.args;
@@ -267,7 +266,7 @@ impl BaseNode {
                     .with_da_config(self.da_config.clone())
                     .with_gas_limit_config(self.gas_limit_config.clone()),
             ))
-            .network(BaseNetworkBuilder::new(disable_txpool_gossip, !discovery_v4, base_protocol))
+            .network(BaseNetworkBuilder::new(disable_txpool_gossip, !discovery_v4))
             .consensus(BaseConsensusBuilder::default())
     }
 
@@ -1080,24 +1079,18 @@ pub struct BaseNetworkBuilder {
     pub disable_txpool_gossip: bool,
     /// Disable discovery v4
     pub disable_discovery_v4: bool,
-    /// Enable the Base discv5 protocol identity
-    pub base_protocol: bool,
 }
 
 impl Default for BaseNetworkBuilder {
     fn default() -> Self {
-        Self { disable_discovery_v4: false, disable_txpool_gossip: false, base_protocol: true }
+        Self { disable_discovery_v4: false, disable_txpool_gossip: false }
     }
 }
 
 impl BaseNetworkBuilder {
     /// Creates a new `BaseNetworkBuilder`.
-    pub const fn new(
-        disable_txpool_gossip: bool,
-        disable_discovery_v4: bool,
-        base_protocol: bool,
-    ) -> Self {
-        Self { disable_txpool_gossip, disable_discovery_v4, base_protocol }
+    pub const fn new(disable_txpool_gossip: bool, disable_discovery_v4: bool) -> Self {
+        Self { disable_txpool_gossip, disable_discovery_v4 }
     }
 
     /// Runs a future on the current runtime, or creates one when needed.
@@ -1115,14 +1108,12 @@ impl BaseNetworkBuilder {
 pub struct BaseDiscoveryConfig {
     /// Disable discovery v4.
     pub disable_discovery_v4: bool,
-    /// Enable the Base discv5 protocol identity.
-    pub base_protocol: bool,
 }
 
 impl BaseDiscoveryConfig {
     /// Creates a new discovery config.
-    pub const fn new(disable_discovery_v4: bool, base_protocol: bool) -> Self {
-        Self { disable_discovery_v4, base_protocol }
+    pub const fn new(disable_discovery_v4: bool) -> Self {
+        Self { disable_discovery_v4 }
     }
 
     /// Returns true if discv4 discovery should be disabled.
@@ -1175,16 +1166,14 @@ impl BaseDiscoveryConfig {
         builder
     }
 
-    /// Creates the inner discv5 config with Base protocol identity when enabled.
+    /// Creates the inner discv5 config with the Base protocol identity.
     pub fn discv5_config(&self, args: &RethNetworkArgs) -> reth_discv5::discv5::Config {
         let mut builder = reth_discv5::discv5::ConfigBuilder::new(Self::discv5_listen_config(args));
 
-        if self.base_protocol {
-            builder.protocol_identity(reth_discv5::discv5::ProtocolIdentity {
-                protocol_id: BASE_V0_PROTOCOL_VERSION,
-                ..Default::default()
-            });
-        }
+        builder.protocol_identity(reth_discv5::discv5::ProtocolIdentity {
+            protocol_id: BASE_V0_PROTOCOL_VERSION,
+            ..Default::default()
+        });
 
         builder.build()
     }
@@ -1251,8 +1240,7 @@ impl BaseNetworkBuilder {
         NetworkP: NetworkPrimitives,
     {
         let disable_txpool_gossip = self.disable_txpool_gossip;
-        let discovery_config =
-            BaseDiscoveryConfig::new(self.disable_discovery_v4, self.base_protocol);
+        let discovery_config = BaseDiscoveryConfig::new(self.disable_discovery_v4);
         let args = &ctx.config().network;
         let network_builder = ctx
             .network_config_builder()?
@@ -1362,10 +1350,7 @@ mod tests {
     };
 
     use reth_chainspec::MAINNET;
-    use reth_discv5::{
-        build_local_enr,
-        discv5::{ListenConfig, ProtocolIdentity},
-    };
+    use reth_discv5::{build_local_enr, discv5::ListenConfig};
     use reth_network::{EthNetworkPrimitives, NetworkConfigBuilder, config::rng_secret_key};
     use rstest::rstest;
 
@@ -1387,7 +1372,7 @@ mod tests {
             disable_discv4_discovery: disable_by_reth,
             ..Default::default()
         };
-        let discovery_config = BaseDiscoveryConfig::new(disable_by_base, true);
+        let discovery_config = BaseDiscoveryConfig::new(disable_by_base);
 
         assert_eq!(discovery_config.should_disable_discv4(&discovery_args), expected);
     }
@@ -1406,7 +1391,7 @@ mod tests {
         let mut args = RethNetworkArgs::default();
         args.discovery.disable_discovery = disable_all_discovery;
         args.discovery.disable_discv4_discovery = disable_by_reth;
-        let discovery_config = BaseDiscoveryConfig::new(disable_by_base, true);
+        let discovery_config = BaseDiscoveryConfig::new(disable_by_base);
 
         let network_config = discovery_config
             .apply_to_network_builder(
@@ -1431,7 +1416,7 @@ mod tests {
     ) {
         let mut args = RethNetworkArgs::default();
         args.discovery.disable_discovery = disable_all_discovery;
-        let discovery_config = BaseDiscoveryConfig::new(false, true);
+        let discovery_config = BaseDiscoveryConfig::new(false);
 
         let network_config = discovery_config
             .apply_to_network_builder(
@@ -1447,19 +1432,14 @@ mod tests {
         assert_eq!(network_config.discovery_v5_config.is_some(), expected_enabled);
     }
 
-    #[rstest]
-    #[case::base_protocol_enabled(true, BASE_V0_PROTOCOL_VERSION)]
-    #[case::default_protocol(false, ProtocolIdentity::default().protocol_id)]
-    fn discv5_config_uses_protocol_identity(
-        #[case] base_protocol: bool,
-        #[case] expected_protocol_id: [u8; 6],
-    ) {
+    #[test]
+    fn discv5_config_uses_base_protocol_identity() {
         let args = RethNetworkArgs::default();
-        let discovery_config = BaseDiscoveryConfig::new(false, base_protocol);
+        let discovery_config = BaseDiscoveryConfig::new(false);
 
         let discv5_config = discovery_config.discv5_config(&args);
 
-        assert_eq!(discv5_config.protocol_identity.protocol_id, expected_protocol_id);
+        assert_eq!(discv5_config.protocol_identity.protocol_id, BASE_V0_PROTOCOL_VERSION);
     }
 
     #[rstest]
@@ -1513,7 +1493,7 @@ mod tests {
         args.discovery.discv5_addr_ipv6 = discv5_addr_ipv6;
         args.discovery.discv5_port = discv5_port;
         args.discovery.discv5_port_ipv6 = discv5_port_ipv6;
-        let discovery_config = BaseDiscoveryConfig::new(false, true);
+        let discovery_config = BaseDiscoveryConfig::new(false);
 
         let reth_discv5_config =
             discovery_config.discovery_v5_builder(&args, Vec::<NodeRecord>::new(), None).build();
@@ -1531,7 +1511,7 @@ mod tests {
     fn discovery_v5_builder_advertises_external_ip(#[case] external_addr: IpAddr) {
         let args =
             RethNetworkArgs { addr: IpAddr::V4(Ipv4Addr::UNSPECIFIED), ..Default::default() };
-        let discovery_config = BaseDiscoveryConfig::new(false, true);
+        let discovery_config = BaseDiscoveryConfig::new(false);
 
         let reth_discv5_config = discovery_config
             .discovery_v5_builder(&args, Vec::<NodeRecord>::new(), Some(external_addr))
@@ -1559,7 +1539,7 @@ mod tests {
         #[case] expected: ListenConfig,
     ) {
         let args = RethNetworkArgs { addr: rlpx_ip, port: 30303, ..Default::default() };
-        let discovery_config = BaseDiscoveryConfig::new(false, true);
+        let discovery_config = BaseDiscoveryConfig::new(false);
 
         let discv5_config = discovery_config.discv5_config(&args);
 

--- a/crates/execution/node/tests/it/priority.rs
+++ b/crates/execution/node/tests/it/priority.rs
@@ -97,7 +97,6 @@ where
         disable_txpool_gossip,
         compute_pending_block,
         discovery_v4,
-        base_protocol,
         ..
     } = RollupArgs::default();
     ComponentsBuilder::default()
@@ -108,7 +107,7 @@ where
             BasePayloadBuilder::new(compute_pending_block)
                 .with_transactions(CustomTxPriority { chain_id }),
         ))
-        .network(BaseNetworkBuilder::new(disable_txpool_gossip, !discovery_v4, base_protocol))
+        .network(BaseNetworkBuilder::new(disable_txpool_gossip, !discovery_v4))
         .consensus(BaseConsensusBuilder::default())
 }
 

--- a/crates/execution/node/tests/it/priority.rs
+++ b/crates/execution/node/tests/it/priority.rs
@@ -93,12 +93,8 @@ fn build_components<Node>(
 where
     Node: FullNodeTypes<Types: BaseNodeTypes>,
 {
-    let RollupArgs {
-        disable_txpool_gossip,
-        compute_pending_block,
-        discovery_v4,
-        ..
-    } = RollupArgs::default();
+    let RollupArgs { disable_txpool_gossip, compute_pending_block, discovery_v4, .. } =
+        RollupArgs::default();
     ComponentsBuilder::default()
         .node_types::<Node>()
         .pool(BasePoolBuilder::default())

--- a/crates/execution/runner/src/node.rs
+++ b/crates/execution/runner/src/node.rs
@@ -72,7 +72,6 @@ impl BaseNode {
             disable_txpool_gossip,
             compute_pending_block,
             discovery_v4,
-            base_protocol,
             max_inflight_delegated_slots,
             ..
         } = self.args;
@@ -88,7 +87,7 @@ impl BaseNode {
                     .with_da_config(self.da_config.clone())
                     .with_gas_limit_config(self.gas_limit_config.clone()),
             ))
-            .network(BaseNetworkBuilder::new(disable_txpool_gossip, !discovery_v4, base_protocol))
+            .network(BaseNetworkBuilder::new(disable_txpool_gossip, !discovery_v4))
             .consensus(BaseConsensusBuilder::default())
     }
 


### PR DESCRIPTION
The `--rollup.discovery.v5.base` / `--v5.base-protocol` flag defaulted to `true` and was always enabled in production. This PR removes it and hardcodes the base protocol identity to always be advertised in discv5.

## Changes

- **`crates/execution/node/src/args.rs`**: removed `base_protocol: bool` field from `RollupArgs`
- **`crates/execution/node/src/node.rs`**: removed `base_protocol` from `BaseNetworkBuilder` and `BaseDiscoveryConfig`; `discv5_config()` now unconditionally sets base protocol identity
- **`crates/execution/runner/src/node.rs`**: removed `base_protocol` from destructuring and `BaseNetworkBuilder::new()` call
- **`crates/execution/node/tests/it/priority.rs`**: updated test helper
- **`crates/execution/cli/src/commands/p2p/bootnode.rs`**: removed `--v5.base-protocol` flag; always sets base protocol identity