### PR TITLE
feat(tools): Add Beryl Activator Helper

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3211,6 +3211,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "base-activator"
+version = "0.0.0"
+dependencies = [
+ "alloy-primitives",
+ "alloy-provider 2.0.5",
+ "alloy-rpc-client 2.0.5",
+ "alloy-rpc-types-eth 2.0.5",
+ "alloy-sol-types",
+ "alloy-transport-http 2.0.5",
+ "base-common-chains",
+ "base-common-network",
+ "base-common-precompiles",
+ "base-common-rpc-types",
+ "clap",
+ "eyre",
+ "hex",
+ "serde_json",
+ "serde_yaml",
+ "tokio",
+ "url",
+]
+
+[[package]]
 name = "base-balance-monitor"
 version = "0.0.0"
 dependencies = [

--- a/Justfile
+++ b/Justfile
@@ -198,3 +198,7 @@ bench-proof-mpt:
 # Run basectl TUI dashboard
 basectl:
     cargo run -p basectl --release -- monitor
+
+# Run the Beryl precompile activator helper
+activator +args='list':
+    @cargo run --quiet -p base-activator -- "$@"

--- a/etc/tools/activator/Cargo.toml
+++ b/etc/tools/activator/Cargo.toml
@@ -1,0 +1,35 @@
+[package]
+name = "base-activator"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+# alloy
+alloy-provider.workspace = true
+alloy-sol-types.workspace = true
+alloy-primitives.workspace = true
+alloy-rpc-client.workspace = true
+alloy-transport-http.workspace = true
+alloy-rpc-types-eth = { workspace = true, features = ["std"] }
+
+# base
+base-common-chains.workspace = true
+base-common-network.workspace = true
+base-common-rpc-types.workspace = true
+base-common-precompiles.workspace = true
+
+# misc
+hex.workspace = true
+url.workspace = true
+eyre.workspace = true
+serde_json.workspace = true
+serde_yaml.workspace = true
+clap = { workspace = true, features = ["derive"] }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "time"] }

--- a/etc/tools/activator/README.md
+++ b/etc/tools/activator/README.md
@@ -1,0 +1,36 @@
+# Base Activator
+
+`base-activator` inspects the Beryl native precompile surface and generates activation-registry calldata.
+
+## Commands
+
+List Beryl precompiles and the upgrade that installs them:
+
+```sh
+cargo run -p base-activator -- list
+```
+
+Generate raw transaction data for the activation registry:
+
+```sh
+cargo run -p base-activator -- calldata activate b20-asset
+cargo run -p base-activator -- calldata deactivate policy-registry
+```
+
+Check activation registry state on Base Mainnet, Base Sepolia, and Base Zeronet:
+
+```sh
+cargo run -p base-activator -- status
+```
+
+Mainnet and Sepolia use the baked-in public Base RPC URLs when no flag or environment variable is
+provided. Zeronet has no baked-in public URL. If a configured or default RPC does not reach the
+expected chain ID, the command falls back to a `rpc:` field in
+`~/.config/base/networks/{mainnet,sepolia,zeronet}.yaml` or `.yml`, when present.
+
+RPC URL priority is:
+
+1. `--mainnet-rpc-url`, `--sepolia-rpc-url`, or `--zeronet-rpc-url`.
+2. `BASE_MAINNET_RPC_URL`, `BASE_SEPOLIA_RPC_URL`, or `BASE_ZERONET_RPC_URL`.
+3. Baked-in public URL for Mainnet and Sepolia.
+4. Basectl user config in `~/.config/base/networks/`.

--- a/etc/tools/activator/src/calldata.rs
+++ b/etc/tools/activator/src/calldata.rs
@@ -1,0 +1,82 @@
+use alloy_primitives::{Address, B256, Bytes};
+use alloy_sol_types::SolCall;
+use base_common_precompiles::{ActivationRegistryStorage, IActivationRegistry};
+
+use crate::{CalldataAction, FeatureName};
+
+/// Encoded transaction target and calldata for an activation registry mutation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CalldataOutput {
+    /// Activation registry method that was encoded.
+    pub action: CalldataAction,
+    /// Feature targeted by the encoded method.
+    pub feature: FeatureName,
+    /// Transaction recipient.
+    pub to: Address,
+    /// Encoded calldata.
+    pub data: Bytes,
+    /// Activation registry feature ID.
+    pub feature_id: B256,
+}
+
+/// Encodes activation registry calldata.
+#[derive(Debug, Clone, Copy)]
+pub struct CalldataEncoder;
+
+impl CalldataEncoder {
+    /// Encodes calldata for `action(feature)`.
+    pub fn encode(action: CalldataAction, feature: FeatureName) -> CalldataOutput {
+        let feature_id = feature.activation_feature().id();
+        let data = match action {
+            CalldataAction::Activate => {
+                IActivationRegistry::activateCall { feature: feature_id }.abi_encode()
+            }
+            CalldataAction::Deactivate => {
+                IActivationRegistry::deactivateCall { feature: feature_id }.abi_encode()
+            }
+        };
+
+        CalldataOutput {
+            action,
+            feature,
+            to: ActivationRegistryStorage::ADDRESS,
+            data: Bytes::from(data),
+            feature_id,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_sol_types::SolCall;
+    use base_common_precompiles::{ActivationFeature, IActivationRegistry};
+
+    use super::*;
+
+    #[test]
+    fn encode_activate_uses_generated_activation_registry_abi() {
+        let output = CalldataEncoder::encode(CalldataAction::Activate, FeatureName::B20Asset);
+        let feature = ActivationFeature::B20Asset.id();
+
+        assert_eq!(output.to, ActivationRegistryStorage::ADDRESS);
+        assert_eq!(output.feature_id, feature);
+        assert_eq!(
+            output.data,
+            Bytes::from(IActivationRegistry::activateCall { feature }.abi_encode())
+        );
+    }
+
+    #[test]
+    fn encode_deactivate_uses_generated_activation_registry_abi() {
+        let output =
+            CalldataEncoder::encode(CalldataAction::Deactivate, FeatureName::PolicyRegistry);
+        let feature = ActivationFeature::PolicyRegistry.id();
+
+        assert_eq!(output.to, ActivationRegistryStorage::ADDRESS);
+        assert_eq!(output.feature_id, feature);
+        assert_eq!(
+            output.data,
+            Bytes::from(IActivationRegistry::deactivateCall { feature }.abi_encode())
+        );
+    }
+}

--- a/etc/tools/activator/src/cli.rs
+++ b/etc/tools/activator/src/cli.rs
@@ -1,0 +1,216 @@
+use std::{env, fmt};
+
+use base_common_precompiles::ActivationFeature;
+use clap::{Args, Parser, Subcommand, ValueEnum};
+
+use crate::NetworkConfig;
+
+/// Command-line entry point for the Base activation registry helper.
+#[derive(Debug, Parser)]
+#[command(name = "base-activator")]
+#[command(about = "Inspect Beryl precompiles and build activation registry calldata.")]
+pub struct Cli {
+    /// Command to execute.
+    #[command(subcommand)]
+    pub command: Commands,
+}
+
+/// Top-level activator commands.
+#[derive(Debug, Subcommand)]
+pub enum Commands {
+    /// List Beryl precompiles and activation gates.
+    List(ListCommand),
+    /// Generate raw activation registry transaction calldata.
+    Calldata(CalldataCommand),
+    /// Check activation registry state across Base networks.
+    Status(StatusCommand),
+}
+
+/// Arguments for listing the Beryl precompile inventory.
+#[derive(Debug, Args)]
+pub struct ListCommand {
+    /// Output format.
+    #[arg(long, value_enum, default_value_t = OutputFormat::Table)]
+    pub format: OutputFormat,
+}
+
+/// Arguments for generating activation-registry calldata.
+#[derive(Debug, Args)]
+pub struct CalldataCommand {
+    /// Activation registry method to encode.
+    #[arg(value_enum)]
+    pub action: CalldataAction,
+    /// Feature controlled by the activation registry.
+    #[arg(value_enum)]
+    pub feature: FeatureName,
+    /// Output format.
+    #[arg(long, value_enum, default_value_t = OutputFormat::Table)]
+    pub format: OutputFormat,
+}
+
+/// Arguments for checking activation-registry state.
+#[derive(Args)]
+pub struct StatusCommand {
+    /// Base Mainnet RPC URL. Falls back to `BASE_MAINNET_RPC_URL`, the default public RPC, then basectl config.
+    #[arg(long)]
+    pub mainnet_rpc_url: Option<String>,
+    /// Base Sepolia RPC URL. Falls back to `BASE_SEPOLIA_RPC_URL`, the default public RPC, then basectl config.
+    #[arg(long)]
+    pub sepolia_rpc_url: Option<String>,
+    /// Base Zeronet RPC URL. Falls back to `BASE_ZERONET_RPC_URL`, then basectl config.
+    #[arg(long)]
+    pub zeronet_rpc_url: Option<String>,
+    /// Output format.
+    #[arg(long, value_enum, default_value_t = OutputFormat::Table)]
+    pub format: OutputFormat,
+}
+
+impl StatusCommand {
+    /// Redacts an optional RPC URL for debug output.
+    pub fn redacted_url(url: &Option<String>) -> Option<&'static str> {
+        url.as_ref().map(|_| "<redacted>")
+    }
+
+    /// Resolves all required RPC URLs from flags or environment variables.
+    pub fn networks(&self) -> Vec<NetworkConfig> {
+        vec![
+            NetworkConfig::mainnet(Self::rpc_url(
+                self.mainnet_rpc_url.as_deref(),
+                "BASE_MAINNET_RPC_URL",
+            )),
+            NetworkConfig::sepolia(Self::rpc_url(
+                self.sepolia_rpc_url.as_deref(),
+                "BASE_SEPOLIA_RPC_URL",
+            )),
+            NetworkConfig::zeronet(Self::rpc_url(
+                self.zeronet_rpc_url.as_deref(),
+                "BASE_ZERONET_RPC_URL",
+            )),
+        ]
+    }
+
+    /// Resolves one RPC URL from a command-line flag or environment variable.
+    pub fn rpc_url(flag: Option<&str>, env_var: &'static str) -> Option<String> {
+        if let Some(url) = flag {
+            return Some(url.to_owned());
+        }
+
+        env::var(env_var).ok()
+    }
+}
+
+impl fmt::Debug for StatusCommand {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("StatusCommand")
+            .field("mainnet_rpc_url", &Self::redacted_url(&self.mainnet_rpc_url))
+            .field("sepolia_rpc_url", &Self::redacted_url(&self.sepolia_rpc_url))
+            .field("zeronet_rpc_url", &Self::redacted_url(&self.zeronet_rpc_url))
+            .field("format", &self.format)
+            .finish()
+    }
+}
+
+/// Activation registry calldata action.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+#[value(rename_all = "kebab-case")]
+pub enum CalldataAction {
+    /// Encode `activate(bytes32)`.
+    Activate,
+    /// Encode `deactivate(bytes32)`.
+    Deactivate,
+}
+
+impl CalldataAction {
+    /// Returns the ABI method name.
+    pub const fn method(self) -> &'static str {
+        match self {
+            Self::Activate => "activate",
+            Self::Deactivate => "deactivate",
+        }
+    }
+}
+
+/// Activation-registry feature selector.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+#[value(rename_all = "kebab-case")]
+pub enum FeatureName {
+    /// Policy registry writes.
+    PolicyRegistry,
+    /// B-20 asset token creation.
+    B20Asset,
+    /// B-20 stablecoin token creation.
+    B20Stablecoin,
+}
+
+impl FeatureName {
+    /// Returns the corresponding activation feature.
+    pub const fn activation_feature(self) -> ActivationFeature {
+        match self {
+            Self::PolicyRegistry => ActivationFeature::PolicyRegistry,
+            Self::B20Asset => ActivationFeature::B20Asset,
+            Self::B20Stablecoin => ActivationFeature::B20Stablecoin,
+        }
+    }
+
+    /// Returns the CLI label.
+    pub const fn label(self) -> &'static str {
+        match self {
+            Self::PolicyRegistry => "policy-registry",
+            Self::B20Asset => "b20-asset",
+            Self::B20Stablecoin => "b20-stablecoin",
+        }
+    }
+}
+
+/// Output serialization format.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, ValueEnum)]
+#[value(rename_all = "kebab-case")]
+pub enum OutputFormat {
+    /// Human-readable table output.
+    #[default]
+    Table,
+    /// JSON output for scripts.
+    Json,
+}
+
+impl fmt::Display for OutputFormat {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            Self::Table => "table",
+            Self::Json => "json",
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn feature_names_map_to_precompile_feature_ids() {
+        assert_eq!(
+            FeatureName::PolicyRegistry.activation_feature(),
+            ActivationFeature::PolicyRegistry
+        );
+        assert_eq!(FeatureName::B20Asset.activation_feature(), ActivationFeature::B20Asset);
+        assert_eq!(
+            FeatureName::B20Stablecoin.activation_feature(),
+            ActivationFeature::B20Stablecoin
+        );
+    }
+
+    #[test]
+    fn status_command_debug_redacts_rpc_urls() {
+        let command = StatusCommand {
+            mainnet_rpc_url: Some("https://example.invalid/?token=secret".to_owned()),
+            sepolia_rpc_url: None,
+            zeronet_rpc_url: Some("https://zeronet.invalid/?token=secret".to_owned()),
+            format: OutputFormat::Json,
+        };
+
+        let debug = format!("{command:?}");
+
+        assert!(debug.contains("<redacted>"));
+        assert!(!debug.contains("token=secret"));
+    }
+}

--- a/etc/tools/activator/src/inventory.rs
+++ b/etc/tools/activator/src/inventory.rs
@@ -1,0 +1,366 @@
+use std::fmt;
+
+use alloy_primitives::{Address, B256};
+use base_common_chains::{BaseUpgrade, ChainConfig};
+use base_common_precompiles::{
+    ActivationRegistryStorage, B20FactoryStorage, B20Variant, PolicyRegistryStorage,
+};
+
+use crate::FeatureName;
+
+/// Location for a Beryl precompile surface.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PrecompileLocation {
+    /// A singleton precompile address.
+    Address(Address),
+    /// A dynamic address family identified by an 11-byte prefix.
+    AddressPrefix([u8; 11]),
+}
+
+/// Describes a precompile surface installed at Beryl.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PrecompileInfo {
+    /// Human-readable precompile name.
+    pub name: &'static str,
+    /// Address or address family for this precompile.
+    pub location: PrecompileLocation,
+    /// Base upgrade that installs this precompile surface.
+    pub installed_at: BaseUpgrade,
+    /// Optional activation feature that gates meaningful writes or creation.
+    pub activation_feature: Option<FeatureName>,
+    /// Short operational note.
+    pub note: &'static str,
+}
+
+/// Known activation-registry feature metadata.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FeatureInfo {
+    /// CLI feature selector.
+    pub feature: FeatureName,
+    /// Activation registry feature ID.
+    pub id: B256,
+}
+
+/// RPC configuration for one Base network.
+#[derive(Clone, PartialEq, Eq)]
+pub struct NetworkConfig {
+    /// Network display name.
+    pub name: &'static str,
+    /// User-configured RPC URL. This is never printed because it may contain credentials.
+    pub rpc_url: Option<String>,
+    /// Flag used to configure this network's RPC URL.
+    pub rpc_url_flag: &'static str,
+    /// Environment variable used to configure this network's RPC URL.
+    pub rpc_url_env_var: &'static str,
+    /// Built-in public RPC URL.
+    pub default_rpc_url: Option<&'static str>,
+    /// Basectl network config name used for fallback lookup.
+    pub basectl_config_name: &'static str,
+    /// Expected L2 chain ID.
+    pub expected_chain_id: u64,
+    /// Configured Beryl timestamp for this network, if scheduled.
+    pub beryl_timestamp: Option<u64>,
+}
+
+impl NetworkConfig {
+    /// Redacts the configured RPC URL for debug output.
+    pub fn redacted_rpc_url(&self) -> Option<&'static str> {
+        self.rpc_url.as_ref().map(|_| "<redacted>")
+    }
+
+    /// Creates a Base Mainnet status target.
+    pub const fn mainnet(rpc_url: Option<String>) -> Self {
+        Self::from_chain_config(
+            "base-mainnet",
+            rpc_url,
+            "--mainnet-rpc-url",
+            "BASE_MAINNET_RPC_URL",
+            Some("https://mainnet.base.org"),
+            "mainnet",
+            ChainConfig::mainnet(),
+        )
+    }
+
+    /// Creates a Base Sepolia status target.
+    pub const fn sepolia(rpc_url: Option<String>) -> Self {
+        Self::from_chain_config(
+            "base-sepolia",
+            rpc_url,
+            "--sepolia-rpc-url",
+            "BASE_SEPOLIA_RPC_URL",
+            Some("https://sepolia.base.org"),
+            "sepolia",
+            ChainConfig::sepolia(),
+        )
+    }
+
+    /// Creates a Base Zeronet status target.
+    pub const fn zeronet(rpc_url: Option<String>) -> Self {
+        Self::from_chain_config(
+            "base-zeronet",
+            rpc_url,
+            "--zeronet-rpc-url",
+            "BASE_ZERONET_RPC_URL",
+            None,
+            "zeronet",
+            ChainConfig::zeronet(),
+        )
+    }
+
+    /// Creates a status target from a chain config.
+    pub const fn from_chain_config(
+        name: &'static str,
+        rpc_url: Option<String>,
+        rpc_url_flag: &'static str,
+        rpc_url_env_var: &'static str,
+        default_rpc_url: Option<&'static str>,
+        basectl_config_name: &'static str,
+        chain_config: &'static ChainConfig,
+    ) -> Self {
+        Self {
+            name,
+            rpc_url,
+            rpc_url_flag,
+            rpc_url_env_var,
+            default_rpc_url,
+            basectl_config_name,
+            expected_chain_id: chain_config.chain_id,
+            beryl_timestamp: chain_config.beryl_timestamp,
+        }
+    }
+}
+
+impl fmt::Debug for NetworkConfig {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("NetworkConfig")
+            .field("name", &self.name)
+            .field("rpc_url", &self.redacted_rpc_url())
+            .field("rpc_url_flag", &self.rpc_url_flag)
+            .field("rpc_url_env_var", &self.rpc_url_env_var)
+            .field("default_rpc_url", &self.default_rpc_url)
+            .field("basectl_config_name", &self.basectl_config_name)
+            .field("expected_chain_id", &self.expected_chain_id)
+            .field("beryl_timestamp", &self.beryl_timestamp)
+            .finish()
+    }
+}
+
+/// Activation state returned by a live registry check.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ActivationState {
+    /// The feature is active.
+    Active,
+    /// The feature is inactive.
+    Inactive,
+    /// The registry is not available at the queried block or endpoint.
+    Unavailable,
+    /// The RPC returned an error or invalid ABI data.
+    Error(String),
+}
+
+/// Activation state for one feature on one network.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FeatureStatus {
+    /// Feature that was checked.
+    pub feature: FeatureName,
+    /// Feature ID sent to the registry.
+    pub feature_id: B256,
+    /// Observed state.
+    pub state: ActivationState,
+}
+
+/// Activation status for one network.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NetworkStatus {
+    /// Network display name.
+    pub network: &'static str,
+    /// Expected chain ID from `base-common-chains`.
+    pub expected_chain_id: u64,
+    /// Chain ID returned by the RPC endpoint, if available.
+    pub chain_id: Option<u64>,
+    /// Configured Beryl timestamp for this network, if scheduled.
+    pub beryl_timestamp: Option<u64>,
+    /// Source of the RPC URL that produced this status.
+    pub rpc_source: Option<RpcSource>,
+    /// Network-level error. When set, feature checks were skipped.
+    pub error: Option<String>,
+    /// Per-feature activation states.
+    pub features: Vec<FeatureStatus>,
+}
+
+/// Activation status report for all requested networks.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StatusReport {
+    /// Per-network activation status.
+    pub networks: Vec<NetworkStatus>,
+}
+
+/// Non-secret label for the origin of an RPC URL candidate.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RpcSource {
+    /// Command-line flag or environment variable.
+    Configured,
+    /// Built-in public RPC URL.
+    Default,
+    /// User basectl config under `~/.config/base/networks`.
+    BasectlConfig,
+}
+
+impl RpcSource {
+    /// Returns a stable display label.
+    pub const fn label(self) -> &'static str {
+        match self {
+            Self::Configured => "configured",
+            Self::Default => "default",
+            Self::BasectlConfig => "basectl-config",
+        }
+    }
+}
+
+/// One RPC URL candidate. The URL itself must not be printed.
+#[derive(Clone, PartialEq, Eq)]
+pub struct RpcCandidate {
+    /// Non-secret source label.
+    pub source: RpcSource,
+    /// RPC URL. This may contain credentials and should not be displayed.
+    pub url: String,
+}
+
+impl fmt::Debug for RpcCandidate {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("RpcCandidate")
+            .field("source", &self.source)
+            .field("url", &"<redacted>")
+            .finish()
+    }
+}
+
+/// Provides the activation feature inventory.
+#[derive(Debug, Clone, Copy)]
+pub struct FeatureCatalog;
+
+impl FeatureCatalog {
+    /// Returns the activation-registry features controlled by this tool.
+    pub const fn features() -> [FeatureInfo; 3] {
+        [
+            Self::feature(FeatureName::PolicyRegistry),
+            Self::feature(FeatureName::B20Asset),
+            Self::feature(FeatureName::B20Stablecoin),
+        ]
+    }
+
+    /// Returns metadata for one activation-registry feature.
+    pub const fn feature(feature: FeatureName) -> FeatureInfo {
+        FeatureInfo { feature, id: feature.activation_feature().id() }
+    }
+}
+
+/// Provides the Beryl precompile inventory.
+#[derive(Debug, Clone, Copy)]
+pub struct PrecompileCatalog;
+
+impl PrecompileCatalog {
+    /// Returns the known Beryl precompile surfaces.
+    pub fn beryl() -> Vec<PrecompileInfo> {
+        vec![
+            PrecompileInfo {
+                name: "activation-registry",
+                location: PrecompileLocation::Address(ActivationRegistryStorage::ADDRESS),
+                installed_at: BaseUpgrade::Beryl,
+                activation_feature: None,
+                note: "controls runtime activation flags",
+            },
+            PrecompileInfo {
+                name: "policy-registry",
+                location: PrecompileLocation::Address(PolicyRegistryStorage::ADDRESS),
+                installed_at: BaseUpgrade::Beryl,
+                activation_feature: Some(FeatureName::PolicyRegistry),
+                note: "view calls are open; writes require activation",
+            },
+            PrecompileInfo {
+                name: "b20-factory",
+                location: PrecompileLocation::Address(B20FactoryStorage::ADDRESS),
+                installed_at: BaseUpgrade::Beryl,
+                activation_feature: None,
+                note: "token creation checks the selected variant feature",
+            },
+            PrecompileInfo {
+                name: "b20-asset",
+                location: PrecompileLocation::AddressPrefix(B20Variant::Asset.address_prefix()),
+                installed_at: BaseUpgrade::Beryl,
+                activation_feature: Some(FeatureName::B20Asset),
+                note: "dynamic token precompile address family",
+            },
+            PrecompileInfo {
+                name: "b20-stablecoin",
+                location: PrecompileLocation::AddressPrefix(
+                    B20Variant::Stablecoin.address_prefix(),
+                ),
+                installed_at: BaseUpgrade::Beryl,
+                activation_feature: Some(FeatureName::B20Stablecoin),
+                note: "dynamic token precompile address family",
+            },
+        ]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use base_common_precompiles::{
+        ActivationFeature, ActivationRegistryStorage, B20FactoryStorage, PolicyRegistryStorage,
+    };
+
+    use super::*;
+
+    #[test]
+    fn inventory_uses_exported_precompile_addresses() {
+        let items = PrecompileCatalog::beryl();
+
+        assert!(items.iter().any(|item| {
+            item.location == PrecompileLocation::Address(ActivationRegistryStorage::ADDRESS)
+        }));
+        assert!(items.iter().any(|item| {
+            item.location == PrecompileLocation::Address(PolicyRegistryStorage::ADDRESS)
+        }));
+        assert!(
+            items.iter().any(
+                |item| item.location == PrecompileLocation::Address(B20FactoryStorage::ADDRESS)
+            )
+        );
+    }
+
+    #[test]
+    fn feature_catalog_uses_exported_feature_ids() {
+        let features = FeatureCatalog::features();
+
+        assert!(features.iter().any(|feature| feature.id == ActivationFeature::B20Asset.id()));
+        assert!(features.iter().any(|feature| feature.id == ActivationFeature::B20Stablecoin.id()));
+        assert!(
+            features.iter().any(|feature| feature.id == ActivationFeature::PolicyRegistry.id())
+        );
+    }
+
+    #[test]
+    fn network_config_debug_redacts_rpc_url() {
+        let config =
+            NetworkConfig::mainnet(Some("https://example.invalid/?token=secret".to_owned()));
+
+        let debug = format!("{config:?}");
+
+        assert!(debug.contains("<redacted>"));
+        assert!(!debug.contains("token=secret"));
+    }
+
+    #[test]
+    fn rpc_candidate_debug_redacts_rpc_url() {
+        let candidate = RpcCandidate {
+            source: RpcSource::Configured,
+            url: "https://example.invalid/?token=secret".to_owned(),
+        };
+
+        let debug = format!("{candidate:?}");
+
+        assert!(debug.contains("<redacted>"));
+        assert!(!debug.contains("token=secret"));
+    }
+}

--- a/etc/tools/activator/src/lib.rs
+++ b/etc/tools/activator/src/lib.rs
@@ -1,0 +1,25 @@
+#![doc = include_str!("../README.md")]
+
+mod calldata;
+pub use calldata::{CalldataEncoder, CalldataOutput};
+
+mod cli;
+pub use cli::{
+    CalldataAction, CalldataCommand, Cli, Commands, FeatureName, ListCommand, OutputFormat,
+    StatusCommand,
+};
+
+mod inventory;
+pub use inventory::{
+    ActivationState, FeatureCatalog, FeatureInfo, FeatureStatus, NetworkConfig, NetworkStatus,
+    PrecompileCatalog, PrecompileInfo, PrecompileLocation, RpcCandidate, RpcSource, StatusReport,
+};
+
+mod output;
+pub use output::OutputWriter;
+
+mod runner;
+pub use runner::Activator;
+
+mod status;
+pub use status::StatusChecker;

--- a/etc/tools/activator/src/main.rs
+++ b/etc/tools/activator/src/main.rs
@@ -1,0 +1,10 @@
+#![doc = include_str!("../README.md")]
+
+use base_activator::{Activator, Cli};
+use clap::Parser;
+use eyre::Result;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    Activator::run(Cli::parse()).await
+}

--- a/etc/tools/activator/src/output.rs
+++ b/etc/tools/activator/src/output.rs
@@ -1,0 +1,253 @@
+use eyre::Result;
+use serde_json::{Value, json};
+
+use crate::{
+    ActivationState, CalldataOutput, FeatureCatalog, FeatureStatus, NetworkStatus, OutputFormat,
+    PrecompileInfo, PrecompileLocation, StatusReport,
+};
+
+/// Writes activator command output.
+#[derive(Debug, Clone, Copy)]
+pub struct OutputWriter;
+
+impl OutputWriter {
+    /// Writes the Beryl precompile inventory.
+    pub fn write_inventory(format: OutputFormat, items: &[PrecompileInfo]) -> Result<()> {
+        match format {
+            OutputFormat::Table => Self::write_inventory_table(items),
+            OutputFormat::Json => Self::write_json(Self::inventory_json(items)),
+        }
+    }
+
+    /// Writes encoded activation registry calldata.
+    pub fn write_calldata(format: OutputFormat, output: &CalldataOutput) -> Result<()> {
+        match format {
+            OutputFormat::Table => Self::write_calldata_table(output),
+            OutputFormat::Json => Self::write_json(Self::calldata_json(output)),
+        }
+    }
+
+    /// Writes activation status for all queried networks.
+    pub fn write_status(format: OutputFormat, report: &StatusReport) -> Result<()> {
+        match format {
+            OutputFormat::Table => Self::write_status_table(report),
+            OutputFormat::Json => Self::write_json(Self::status_json(report)),
+        }
+    }
+
+    /// Writes JSON to stdout.
+    pub fn write_json(value: Value) -> Result<()> {
+        println!("{}", serde_json::to_string_pretty(&value)?);
+        Ok(())
+    }
+
+    /// Writes the inventory in table form.
+    pub fn write_inventory_table(items: &[PrecompileInfo]) -> Result<()> {
+        println!("{:<20} {:<50} {:<10} {:<18} note", "name", "location", "installed", "feature");
+        for item in items {
+            println!(
+                "{:<20} {:<50} {:<10} {:<18} {}",
+                item.name,
+                Self::location_string(item.location),
+                Self::upgrade_string(item.installed_at),
+                item.activation_feature.map_or("-", |feature| feature.label()),
+                item.note
+            );
+        }
+        Ok(())
+    }
+
+    /// Writes encoded calldata in table form.
+    pub fn write_calldata_table(output: &CalldataOutput) -> Result<()> {
+        println!("action:      {}", output.action.method());
+        println!("feature:     {}", output.feature.label());
+        println!("feature_id:  {}", output.feature_id);
+        println!("to:          {}", Self::address_string(output.to));
+        println!("data:        {}", Self::bytes_string(output.data.as_ref()));
+        Ok(())
+    }
+
+    /// Writes activation status in table form.
+    pub fn write_status_table(report: &StatusReport) -> Result<()> {
+        println!(
+            "{:<15} {:<10} {:<15} {:<10} {:<18} state",
+            "network", "chain_id", "rpc", "beryl", "feature"
+        );
+        for network in &report.networks {
+            if let Some(error) = &network.error {
+                println!(
+                    "{:<15} {:<10} {:<15} {:<10} {:<18} {}",
+                    network.network,
+                    Self::chain_id_string(network),
+                    Self::rpc_source_string(network),
+                    Self::beryl_string(network),
+                    "-",
+                    Self::state_string(&ActivationState::Error(error.clone()))
+                );
+                continue;
+            }
+
+            for feature in &network.features {
+                println!(
+                    "{:<15} {:<10} {:<15} {:<10} {:<18} {}",
+                    network.network,
+                    Self::chain_id_string(network),
+                    Self::rpc_source_string(network),
+                    Self::beryl_string(network),
+                    feature.feature.label(),
+                    Self::state_string(&feature.state)
+                );
+            }
+        }
+        Ok(())
+    }
+
+    /// Builds JSON for the inventory output.
+    pub fn inventory_json(items: &[PrecompileInfo]) -> Value {
+        json!({
+            "precompiles": items.iter().map(Self::precompile_json).collect::<Vec<_>>(),
+            "features": FeatureCatalog::features().iter().map(Self::feature_json).collect::<Vec<_>>(),
+        })
+    }
+
+    /// Builds JSON for encoded calldata output.
+    pub fn calldata_json(output: &CalldataOutput) -> Value {
+        json!({
+            "action": output.action.method(),
+            "feature": output.feature.label(),
+            "feature_id": output.feature_id.to_string(),
+            "to": Self::address_string(output.to),
+            "data": Self::bytes_string(output.data.as_ref()),
+        })
+    }
+
+    /// Builds JSON for status output.
+    pub fn status_json(report: &StatusReport) -> Value {
+        json!({
+            "networks": report.networks.iter().map(Self::network_json).collect::<Vec<_>>(),
+        })
+    }
+
+    /// Converts one precompile inventory entry to JSON.
+    pub fn precompile_json(item: &PrecompileInfo) -> Value {
+        json!({
+            "name": item.name,
+            "location": Self::location_string(item.location),
+            "installed_at": Self::upgrade_string(item.installed_at),
+            "activation_feature": item.activation_feature.map(|feature| feature.label()),
+            "note": item.note,
+        })
+    }
+
+    /// Converts one activation feature to JSON.
+    pub fn feature_json(feature: &crate::FeatureInfo) -> Value {
+        json!({
+            "feature": feature.feature.label(),
+            "id": feature.id.to_string(),
+        })
+    }
+
+    /// Converts one network status to JSON.
+    pub fn network_json(network: &NetworkStatus) -> Value {
+        json!({
+            "network": network.network,
+            "expected_chain_id": network.expected_chain_id,
+            "chain_id": network.chain_id,
+            "chain_id_matches": network.chain_id.map(|chain_id| chain_id == network.expected_chain_id),
+            "beryl_timestamp": network.beryl_timestamp,
+            "rpc_source": network.rpc_source.map(crate::RpcSource::label),
+            "error": network.error,
+            "features": network.features.iter().map(Self::feature_status_json).collect::<Vec<_>>(),
+        })
+    }
+
+    /// Converts one feature status to JSON.
+    pub fn feature_status_json(status: &FeatureStatus) -> Value {
+        json!({
+            "feature": status.feature.label(),
+            "feature_id": status.feature_id.to_string(),
+            "state": Self::state_string(&status.state),
+        })
+    }
+
+    /// Converts a precompile location to a display string.
+    pub fn location_string(location: PrecompileLocation) -> String {
+        match location {
+            PrecompileLocation::Address(address) => Self::address_string(address),
+            PrecompileLocation::AddressPrefix(prefix) => {
+                format!("prefix:{}", Self::bytes_string(&prefix))
+            }
+        }
+    }
+
+    /// Converts bytes to a `0x`-prefixed hex string.
+    pub fn bytes_string(bytes: &[u8]) -> String {
+        format!("0x{}", hex::encode(bytes))
+    }
+
+    /// Converts an address to a lowercase `0x`-prefixed hex string.
+    pub fn address_string(address: alloy_primitives::Address) -> String {
+        format!("{address:#x}")
+    }
+
+    /// Converts a Base upgrade to a display string.
+    pub fn upgrade_string(upgrade: base_common_chains::BaseUpgrade) -> String {
+        format!("{upgrade:?}")
+    }
+
+    /// Converts an optional chain ID to a display string.
+    pub fn chain_id_string(network: &NetworkStatus) -> String {
+        match network.chain_id {
+            Some(chain_id) if chain_id == network.expected_chain_id => chain_id.to_string(),
+            Some(chain_id) => format!("{chain_id}!"),
+            None => "-".to_owned(),
+        }
+    }
+
+    /// Converts an optional Beryl timestamp to a display string.
+    pub fn beryl_string(network: &NetworkStatus) -> String {
+        network.beryl_timestamp.map_or_else(|| "none".to_owned(), |ts| ts.to_string())
+    }
+
+    /// Converts an optional RPC source to a display string.
+    pub fn rpc_source_string(network: &NetworkStatus) -> &'static str {
+        network.rpc_source.map_or("-", crate::RpcSource::label)
+    }
+
+    /// Converts an activation state to a display string.
+    pub fn state_string(state: &ActivationState) -> String {
+        match state {
+            ActivationState::Active => "active".to_owned(),
+            ActivationState::Inactive => "inactive".to_owned(),
+            ActivationState::Unavailable => "unavailable".to_owned(),
+            ActivationState::Error(error) => format!("error: {error}"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use base_common_precompiles::ActivationRegistryStorage;
+
+    use super::*;
+    use crate::{CalldataAction, CalldataEncoder, FeatureName, PrecompileCatalog};
+
+    #[test]
+    fn inventory_json_contains_exported_precompile_rows() {
+        let json = OutputWriter::inventory_json(&PrecompileCatalog::beryl());
+
+        let precompiles = json["precompiles"].as_array().expect("precompile array");
+        assert!(precompiles.iter().any(|item| item["name"] == "activation-registry"));
+        assert!(precompiles.iter().any(|item| item["name"] == "b20-factory"));
+    }
+
+    #[test]
+    fn calldata_json_includes_to_and_data() {
+        let output = CalldataEncoder::encode(CalldataAction::Activate, FeatureName::B20Stablecoin);
+        let json = OutputWriter::calldata_json(&output);
+
+        assert_eq!(json["feature"], "b20-stablecoin");
+        assert_eq!(json["to"], OutputWriter::address_string(ActivationRegistryStorage::ADDRESS));
+        assert!(json["data"].as_str().expect("data string").starts_with("0x"));
+    }
+}

--- a/etc/tools/activator/src/runner.rs
+++ b/etc/tools/activator/src/runner.rs
@@ -1,0 +1,27 @@
+use eyre::Result;
+
+use crate::{CalldataEncoder, Cli, Commands, OutputWriter, PrecompileCatalog, StatusChecker};
+
+/// Runs activator commands.
+#[derive(Debug, Clone, Copy)]
+pub struct Activator;
+
+impl Activator {
+    /// Executes one parsed activator command.
+    pub async fn run(cli: Cli) -> Result<()> {
+        match cli.command {
+            Commands::List(command) => {
+                OutputWriter::write_inventory(command.format, &PrecompileCatalog::beryl())
+            }
+            Commands::Calldata(command) => {
+                let output = CalldataEncoder::encode(command.action, command.feature);
+                OutputWriter::write_calldata(command.format, &output)
+            }
+            Commands::Status(command) => {
+                let networks = command.networks();
+                let report = StatusChecker::check_all(&networks).await?;
+                OutputWriter::write_status(command.format, &report)
+            }
+        }
+    }
+}

--- a/etc/tools/activator/src/status.rs
+++ b/etc/tools/activator/src/status.rs
@@ -1,0 +1,314 @@
+use std::{
+    env, fs,
+    path::{Path, PathBuf},
+    time::Duration,
+};
+
+use alloy_primitives::{B256, Bytes};
+use alloy_provider::{Provider, RootProvider};
+use alloy_rpc_client::RpcClient;
+use alloy_rpc_types_eth::TransactionInput;
+use alloy_sol_types::SolCall;
+use alloy_transport_http::{Client, Http};
+use base_common_network::Base;
+use base_common_precompiles::{ActivationRegistryStorage, IActivationRegistry};
+use base_common_rpc_types::BaseTransactionRequest;
+use eyre::{Context, Result};
+use serde_yaml::Value;
+use tokio::time::timeout;
+use url::Url;
+
+use crate::{
+    ActivationState, FeatureCatalog, FeatureStatus, NetworkConfig, NetworkStatus, RpcCandidate,
+    RpcSource, StatusReport,
+};
+
+/// Checks live activation registry state over JSON-RPC.
+#[derive(Debug, Clone, Copy)]
+pub struct StatusChecker;
+
+impl StatusChecker {
+    /// Per-RPC-candidate timeout.
+    pub const CANDIDATE_TIMEOUT: Duration = Duration::from_secs(10);
+
+    /// Checks every activation feature on every configured network.
+    pub async fn check_all(networks: &[NetworkConfig]) -> Result<StatusReport> {
+        let mut statuses = Vec::with_capacity(networks.len());
+        for network in networks {
+            statuses.push(Self::check_network(network).await?);
+        }
+        Ok(StatusReport { networks: statuses })
+    }
+
+    /// Checks every activation feature on one network.
+    pub async fn check_network(network: &NetworkConfig) -> Result<NetworkStatus> {
+        let candidates = Self::rpc_candidates(network);
+        if candidates.is_empty() {
+            return Ok(Self::network_error(
+                network,
+                None,
+                None,
+                format!(
+                    "missing RPC URL; pass {}, set {}, or add rpc to basectl config {}",
+                    network.rpc_url_flag,
+                    network.rpc_url_env_var,
+                    Self::basectl_config_hint(network)
+                ),
+            ));
+        };
+
+        let mut last_error = None;
+        for candidate in candidates {
+            match Self::check_candidate_with_timeout(network, &candidate).await {
+                Ok(status) => return Ok(status),
+                Err(error) => {
+                    last_error = Some(error);
+                }
+            }
+        }
+
+        Ok(Self::network_error(
+            network,
+            None,
+            None,
+            last_error.unwrap_or_else(|| "all RPC candidates failed".to_owned()),
+        ))
+    }
+
+    /// Checks one network with one RPC candidate and applies a bounded timeout.
+    pub async fn check_candidate_with_timeout(
+        network: &NetworkConfig,
+        candidate: &RpcCandidate,
+    ) -> std::result::Result<NetworkStatus, String> {
+        timeout(Self::CANDIDATE_TIMEOUT, Self::check_candidate(network, candidate))
+            .await
+            .unwrap_or_else(|_| Err(Self::candidate_error(candidate, "timed out")))
+    }
+
+    /// Checks one network with one RPC candidate.
+    pub async fn check_candidate(
+        network: &NetworkConfig,
+        candidate: &RpcCandidate,
+    ) -> std::result::Result<NetworkStatus, String> {
+        let provider = Self::provider(&candidate.url)
+            .map_err(|_| Self::candidate_error(candidate, "invalid RPC URL"))?;
+        let chain_id = provider
+            .get_chain_id()
+            .await
+            .map_err(|_| Self::candidate_error(candidate, "chain ID request failed"))?;
+        if chain_id != network.expected_chain_id {
+            return Err(Self::candidate_error(
+                candidate,
+                &format!("chain ID mismatch: expected {}", network.expected_chain_id),
+            ));
+        }
+
+        let mut features = Vec::new();
+        for feature in FeatureCatalog::features() {
+            let state = Self::check_feature_call(&provider, feature.id)
+                .await
+                .map_err(|error| Self::candidate_error(candidate, &error))?;
+            features.push(FeatureStatus {
+                feature: feature.feature,
+                feature_id: feature.id,
+                state,
+            });
+        }
+
+        Ok(NetworkStatus {
+            network: network.name,
+            expected_chain_id: network.expected_chain_id,
+            chain_id: Some(chain_id),
+            beryl_timestamp: network.beryl_timestamp,
+            rpc_source: Some(candidate.source),
+            error: None,
+            features,
+        })
+    }
+
+    /// Builds a network-level error status.
+    pub const fn network_error(
+        network: &NetworkConfig,
+        chain_id: Option<u64>,
+        rpc_source: Option<RpcSource>,
+        error: String,
+    ) -> NetworkStatus {
+        NetworkStatus {
+            network: network.name,
+            expected_chain_id: network.expected_chain_id,
+            chain_id,
+            beryl_timestamp: network.beryl_timestamp,
+            rpc_source,
+            error: Some(error),
+            features: Vec::new(),
+        }
+    }
+
+    /// Returns RPC URL candidates in priority order.
+    pub fn rpc_candidates(network: &NetworkConfig) -> Vec<RpcCandidate> {
+        let mut candidates = Vec::new();
+        if let Some(url) = &network.rpc_url {
+            Self::push_candidate(&mut candidates, RpcSource::Configured, url.clone());
+        }
+        if let Some(url) = network.default_rpc_url {
+            Self::push_candidate(&mut candidates, RpcSource::Default, url.to_owned());
+        }
+        if let Some(url) = Self::basectl_rpc_url(network) {
+            Self::push_candidate(&mut candidates, RpcSource::BasectlConfig, url);
+        }
+        candidates
+    }
+
+    /// Pushes a candidate, skipping duplicate URLs already present from higher-priority sources.
+    pub fn push_candidate(candidates: &mut Vec<RpcCandidate>, source: RpcSource, url: String) {
+        if candidates.iter().any(|candidate| candidate.url == url) {
+            return;
+        }
+        candidates.push(RpcCandidate { source, url });
+    }
+
+    /// Reads the `rpc` field from basectl's user network config, if present.
+    pub fn basectl_rpc_url(network: &NetworkConfig) -> Option<String> {
+        let path = Self::basectl_config_path(network)?;
+        Self::basectl_rpc_url_from_path(&path)
+    }
+
+    /// Reads the `rpc` field from one basectl user network config path.
+    pub fn basectl_rpc_url_from_path(path: &Path) -> Option<String> {
+        let contents = fs::read_to_string(path).ok()?;
+        Self::basectl_rpc_url_from_yaml(&contents)
+    }
+
+    /// Reads the `rpc` field from basectl YAML contents.
+    pub fn basectl_rpc_url_from_yaml(contents: &str) -> Option<String> {
+        let value: Value = serde_yaml::from_str(contents).ok()?;
+        value.get("rpc")?.as_str().filter(|url| !url.trim().is_empty()).map(str::to_owned)
+    }
+
+    /// Returns basectl's user network config path for this network.
+    pub fn basectl_config_path(network: &NetworkConfig) -> Option<PathBuf> {
+        let dir = Self::basectl_config_dir()?;
+        let yaml = dir.join(format!("{}.yaml", network.basectl_config_name));
+        if yaml.exists() {
+            return Some(yaml);
+        }
+        let yml = dir.join(format!("{}.yml", network.basectl_config_name));
+        if yml.exists() {
+            return Some(yml);
+        }
+        None
+    }
+
+    /// Returns basectl's user network config directory.
+    pub fn basectl_config_dir() -> Option<PathBuf> {
+        env::var_os("HOME")
+            .map(|home| PathBuf::from(home).join(".config").join("base").join("networks"))
+    }
+
+    /// Returns a non-secret basectl config hint for error messages.
+    pub fn basectl_config_hint(network: &NetworkConfig) -> String {
+        format!("~/.config/base/networks/{}.yaml", network.basectl_config_name)
+    }
+
+    /// Builds a non-secret candidate failure message.
+    pub fn candidate_error(candidate: &RpcCandidate, reason: &str) -> String {
+        format!("{} RPC {reason}", candidate.source.label())
+    }
+
+    /// Creates a Base JSON-RPC provider.
+    pub fn provider(rpc_url: &str) -> Result<RootProvider<Base>> {
+        let url: Url = rpc_url.parse().wrap_err("invalid RPC URL")?;
+        let http = Http::<Client>::new(url);
+        Ok(RootProvider::<Base>::new(RpcClient::new(http, false)))
+    }
+
+    /// Checks one activation feature.
+    pub async fn check_feature(provider: &RootProvider<Base>, feature_id: B256) -> ActivationState {
+        match Self::check_feature_call(provider, feature_id).await {
+            Ok(state) => state,
+            Err(error) => ActivationState::Error(error),
+        }
+    }
+
+    /// Checks one activation feature, returning transport failures as candidate failures.
+    pub async fn check_feature_call(
+        provider: &RootProvider<Base>,
+        feature_id: B256,
+    ) -> std::result::Result<ActivationState, String> {
+        let call = IActivationRegistry::isActivatedCall { feature: feature_id };
+        let request = BaseTransactionRequest::default()
+            .to(ActivationRegistryStorage::ADDRESS)
+            .input(TransactionInput::new(Bytes::from(call.abi_encode())));
+
+        let output = match provider.call(request).await {
+            Ok(output) => output,
+            Err(_) => return Err("activation registry call failed".to_owned()),
+        };
+        if output.is_empty() {
+            return Ok(ActivationState::Unavailable);
+        }
+
+        Ok(match IActivationRegistry::isActivatedCall::abi_decode_returns(output.as_ref()) {
+            Ok(true) => ActivationState::Active,
+            Ok(false) => ActivationState::Inactive,
+            Err(error) => ActivationState::Error(error.to_string()),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_rpc_urls_are_baked_in_for_public_networks() {
+        assert_eq!(NetworkConfig::mainnet(None).default_rpc_url, Some("https://mainnet.base.org"));
+        assert_eq!(NetworkConfig::sepolia(None).default_rpc_url, Some("https://sepolia.base.org"));
+        assert_eq!(NetworkConfig::zeronet(None).default_rpc_url, None);
+    }
+
+    #[test]
+    fn push_candidate_keeps_first_source_for_duplicate_urls() {
+        let mut candidates = Vec::new();
+
+        StatusChecker::push_candidate(
+            &mut candidates,
+            RpcSource::Configured,
+            "https://mainnet.base.org".to_owned(),
+        );
+        StatusChecker::push_candidate(
+            &mut candidates,
+            RpcSource::Default,
+            "https://mainnet.base.org".to_owned(),
+        );
+
+        assert_eq!(
+            candidates,
+            vec![RpcCandidate {
+                source: RpcSource::Configured,
+                url: "https://mainnet.base.org".to_owned(),
+            }]
+        );
+    }
+
+    #[test]
+    fn basectl_rpc_url_from_yaml_reads_top_level_rpc() {
+        let contents = r#"
+name: custom-mainnet
+rpc: https://example.invalid/base
+pods:
+  namespace: default
+"#;
+
+        assert_eq!(
+            StatusChecker::basectl_rpc_url_from_yaml(contents),
+            Some("https://example.invalid/base".to_owned())
+        );
+    }
+
+    #[test]
+    fn basectl_rpc_url_from_yaml_ignores_missing_or_empty_rpc() {
+        assert_eq!(StatusChecker::basectl_rpc_url_from_yaml("pods: []"), None);
+        assert_eq!(StatusChecker::basectl_rpc_url_from_yaml("rpc: ''"), None);
+    }
+}


### PR DESCRIPTION
## Summary

This adds a new `base-activator` tooling crate for inspecting the Beryl precompile inventory, generating activation-registry calldata, and checking activation status across Base networks. The tool uses exported chain and precompile metadata, redacts RPC URLs in debug surfaces, and includes focused unit coverage for inventory, calldata, output, and status helpers. A `just activator` shortcut runs the helper from the workspace.