### PR TITLE
fix(docker-l3): bump action versions and add cache-from

### DIFF
--- a/.github/workflows/docker-l3.yml
+++ b/.github/workflows/docker-l3.yml
@@ -26,19 +26,19 @@ jobs:
 
     steps:
       - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@a90bcbc6539c36a85cdfeb73f7e2f433735f215b # v2.15.0
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
           egress-policy: audit
 
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
       - name: Login to GHCR
-        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -50,6 +50,8 @@ jobs:
             --set ${{ matrix.target }}.tags=${{ env.REGISTRY_IMAGE }}:${{ matrix.target }}-sha-${{ github.sha }} \
             --set ${{ matrix.target }}.platform=linux/amd64 \
             --set ${{ matrix.target }}.output=type=image,push=true \
+            --set ${{ matrix.target }}.cache-from=type=registry,ref=${{ env.REGISTRY_IMAGE }}:cache-l3-${{ matrix.target }}-linux-amd64 \
+            --set ${{ matrix.target }}.cache-from=type=registry,ref=${{ env.REGISTRY_IMAGE }}:cache-${PLATFORM_PAIR:-linux-amd64} \
             --set ${{ matrix.target }}.cache-to=type=registry,ref=${{ env.REGISTRY_IMAGE }}:cache-l3-${{ matrix.target }}-linux-amd64,mode=max
 
       - name: Tag as latest l3
@@ -67,19 +69,19 @@ jobs:
 
     steps:
       - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@a90bcbc6539c36a85cdfeb73f7e2f433735f215b # v2.15.0
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
           egress-policy: audit
 
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
       - name: Login to GHCR
-        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -92,6 +94,7 @@ jobs:
             -t ${{ env.REGISTRY_IMAGE }}:devnet-setup-sha-${{ github.sha }} \
             --platform linux/amd64 \
             --push \
+            --cache-from type=registry,ref=${{ env.REGISTRY_IMAGE }}:cache-l3-devnet-setup-linux-amd64 \
             --cache-to type=registry,ref=${{ env.REGISTRY_IMAGE }}:cache-l3-devnet-setup-linux-amd64,mode=max \
             .
 

--- a/.github/workflows/docker-l3.yml
+++ b/.github/workflows/docker-l3.yml
@@ -51,7 +51,7 @@ jobs:
             --set ${{ matrix.target }}.platform=linux/amd64 \
             --set ${{ matrix.target }}.output=type=image,push=true \
             --set ${{ matrix.target }}.cache-from=type=registry,ref=${{ env.REGISTRY_IMAGE }}:cache-l3-${{ matrix.target }}-linux-amd64 \
-            --set ${{ matrix.target }}.cache-from=type=registry,ref=${{ env.REGISTRY_IMAGE }}:cache-${PLATFORM_PAIR:-linux-amd64} \
+            --set ${{ matrix.target }}.cache-from=type=registry,ref=${{ env.REGISTRY_IMAGE }}:cache-linux-amd64 \
             --set ${{ matrix.target }}.cache-to=type=registry,ref=${{ env.REGISTRY_IMAGE }}:cache-l3-${{ matrix.target }}-linux-amd64,mode=max
 
       - name: Tag as latest l3


### PR DESCRIPTION
Addresses review comments from #3262:

1. **Outdated action versions** — Aligned all pinned actions with `main`'s `docker.yml`:
   - `harden-runner` v2.15.0 → v2.19.4
   - `checkout` v5.0.0 → v6.0.2
   - `setup-buildx-action` v3.11.1 → v4.1.0
   - `login-action` v3.6.0 → v4.2.0

2. **Missing `cache-from`** — Both jobs now read from their L3-namespaced caches so subsequent builds reuse prior layers instead of starting cold:
   - Rust services: reads from L3 target cache (primary) + main's common cache (fallback for cold starts)
   - Devnet-setup: reads from L3 devnet-setup cache