### PR TITLE
fix(prover-service-client): retry idempotent worker RPCs

### DIFF
--- a/crates/proof/prover-service/client/src/config.rs
+++ b/crates/proof/prover-service/client/src/config.rs
@@ -105,10 +105,8 @@ impl ProverServiceClientConfig {
         self.max_wait
     }
 
-    /// Return the retry configuration applied by [`ProofRequesterClient`] when calling
-    /// requester JSON-RPC methods.
-    ///
-    /// [`ProofRequesterClient`]: crate::ProofRequesterClient
+    /// Return the retry configuration applied by [`crate::ProofRequesterClient`] and
+    /// idempotent [`crate::ProverWorkerClient`] JSON-RPC methods.
     pub const fn retry_config(&self) -> RetryConfig {
         self.retry
     }
@@ -131,10 +129,8 @@ impl ProverServiceClientConfig {
         self
     }
 
-    /// Set the retry configuration applied by [`ProofRequesterClient`] when calling
-    /// requester JSON-RPC methods.
-    ///
-    /// [`ProofRequesterClient`]: crate::ProofRequesterClient
+    /// Set the retry configuration applied by [`crate::ProofRequesterClient`] and
+    /// idempotent [`crate::ProverWorkerClient`] JSON-RPC methods.
     pub const fn with_retry_config(mut self, retry: RetryConfig) -> Self {
         self.retry = retry;
         self

--- a/crates/proof/prover-service/client/src/worker.rs
+++ b/crates/proof/prover-service/client/src/worker.rs
@@ -1,14 +1,25 @@
 //! Client for prover worker JSON-RPC methods.
 
 use async_trait::async_trait;
+use backon::Retryable;
 use base_prover_service_protocol::{
     GetNextProofRequest, GetNextProofResponse, HeartbeatRequest, HeartbeatResponse,
     ProverWorkerApiClient, WorkerSubmitProofRequest, WorkerSubmitProofResponse,
 };
+use base_retry::{
+    DEFAULT_BOUNDED_INITIAL_DELAY, DEFAULT_BOUNDED_MAX_ATTEMPTS, DEFAULT_BOUNDED_MAX_DELAY,
+    RetryConfig,
+};
 use jsonrpsee::http_client::HttpClient;
-use tracing::debug;
+use tracing::{debug, warn};
 
 use crate::{ProverServiceClientBuildError, ProverServiceClientConfig, ProverServiceClientError};
+
+const DEFAULT_RETRY_CONFIG: RetryConfig = RetryConfig::new(
+    DEFAULT_BOUNDED_MAX_ATTEMPTS,
+    DEFAULT_BOUNDED_INITIAL_DELAY,
+    DEFAULT_BOUNDED_MAX_DELAY,
+);
 
 /// Abstraction over prover worker JSON-RPC methods.
 ///
@@ -37,22 +48,36 @@ pub trait ProverWorkerProvider: Send + Sync {
 }
 
 /// JSON-RPC client for prover worker methods.
+///
+/// Idempotent worker operations are wrapped in a `backon` exponential backoff that retries
+/// transient JSON-RPC failures (per [`ProverServiceClientError::is_retryable`]). Retry
+/// behavior is controlled by the [`RetryConfig`] passed at construction time, defaulting
+/// to [`RetryConfig::default`].
 #[derive(Clone, Debug)]
 pub struct ProverWorkerClient {
     inner: HttpClient,
+    retry: RetryConfig,
 }
 
 impl ProverWorkerClient {
-    /// Create a worker client from an existing JSON-RPC HTTP client.
+    /// Create a worker client from an existing JSON-RPC HTTP client. Idempotent worker retries
+    /// use [`RetryConfig::default`]; call [`Self::with_retry_config`] to override.
     pub const fn new(inner: HttpClient) -> Self {
-        Self { inner }
+        Self { inner, retry: DEFAULT_RETRY_CONFIG }
     }
 
     /// Connect a worker client using the provided configuration.
     pub fn connect(
         config: &ProverServiceClientConfig,
     ) -> Result<Self, ProverServiceClientBuildError> {
-        Ok(Self::new(config.build_http_client()?))
+        Ok(Self::new(config.build_http_client()?).with_retry_config(config.retry_config()))
+    }
+
+    /// Override the retry configuration applied to idempotent worker operations.
+    #[must_use]
+    pub const fn with_retry_config(mut self, retry: RetryConfig) -> Self {
+        self.retry = retry;
+        self
     }
 
     /// Return the underlying JSON-RPC HTTP client.
@@ -60,7 +85,15 @@ impl ProverWorkerClient {
         &self.inner
     }
 
+    /// Return the retry configuration applied to idempotent worker operations.
+    pub const fn retry_config(&self) -> RetryConfig {
+        self.retry
+    }
+
     /// Atomically claim the next available proof job for this worker.
+    ///
+    /// This call is issued exactly once because it mutates server-side job lock state and has no
+    /// idempotency key. Retrying after a lost response could claim and lock another job.
     pub async fn get_next_proof(
         &self,
         request: GetNextProofRequest,
@@ -88,7 +121,25 @@ impl ProverWorkerClient {
             lock_duration_seconds = request.lock_duration_seconds,
             "heartbeating proof job"
         );
-        Ok(self.inner.heartbeat(request).await?)
+        (|| {
+            let request = request.clone();
+
+            async move { Ok(self.inner.heartbeat(request).await?) }
+        })
+        .retry(self.retry.to_backoff_builder())
+        .when(ProverServiceClientError::is_retryable)
+        .notify(|error, delay| {
+            warn!(
+                session_id = %request.session_id,
+                lock_id = %request.lock_id,
+                worker_id = %request.worker_id,
+                lock_duration_seconds = request.lock_duration_seconds,
+                backoff_ms = delay.as_millis(),
+                error = %error,
+                "heartbeat failed; retrying"
+            );
+        })
+        .await
     }
 
     /// Submit a proof result for a proof job.
@@ -102,7 +153,24 @@ impl ProverWorkerClient {
             worker_id = %request.worker_id,
             "submitting proof job result"
         );
-        Ok(self.inner.submit_proof(request).await?)
+        (|| {
+            let request = request.clone();
+
+            async move { Ok(self.inner.submit_proof(request).await?) }
+        })
+        .retry(self.retry.to_backoff_builder())
+        .when(ProverServiceClientError::is_retryable)
+        .notify(|error, delay| {
+            warn!(
+                session_id = %request.session_id,
+                lock_id = %request.lock_id,
+                worker_id = %request.worker_id,
+                backoff_ms = delay.as_millis(),
+                error = %error,
+                "submit proof failed; retrying"
+            );
+        })
+        .await
     }
 }
 
@@ -133,20 +201,26 @@ impl ProverWorkerProvider for ProverWorkerClient {
 #[cfg(test)]
 mod tests {
     use std::{
+        collections::VecDeque,
         net::SocketAddr,
-        sync::{Arc, Mutex},
+        sync::{
+            Arc, Mutex,
+            atomic::{AtomicU32, Ordering},
+        },
+        time::Duration,
     };
 
     use base_prover_service_protocol::{
         ProofJob, ProofJobStatus, ProofRequest, ProofRequestKind, ProofResult, ProofType,
         ProverWorkerApiServer, ZkProofRequest, ZkProofResult, ZkVm,
     };
+    use base_retry::RetryConfig;
     use chrono::Utc;
     use jsonrpsee::{
         core::{RpcResult, async_trait, client::Error as JsonRpcClientError},
         http_client::HttpClientBuilder,
         server::{Server, ServerHandle},
-        types::ErrorObjectOwned,
+        types::{ErrorObjectOwned, error::ErrorCode},
     };
 
     use super::{
@@ -156,10 +230,23 @@ mod tests {
     };
     use crate::ProverServiceClientError;
 
+    #[derive(Debug)]
+    enum ScriptedOutcome {
+        Retryable,
+        Fatal,
+        Success,
+    }
+
     #[derive(Clone, Debug)]
     struct MockWorkerApi {
         state: Arc<Mutex<MockWorkerState>>,
         reject_heartbeat: bool,
+        get_next_script: Arc<Mutex<VecDeque<ScriptedOutcome>>>,
+        heartbeat_script: Arc<Mutex<VecDeque<ScriptedOutcome>>>,
+        submit_script: Arc<Mutex<VecDeque<ScriptedOutcome>>>,
+        get_next_calls: Arc<AtomicU32>,
+        heartbeat_calls: Arc<AtomicU32>,
+        submit_calls: Arc<AtomicU32>,
     }
 
     #[derive(Debug, Default)]
@@ -180,11 +267,43 @@ mod tests {
             Self {
                 state: Arc::new(Mutex::new(MockWorkerState::default())),
                 reject_heartbeat: false,
+                get_next_script: Arc::new(Mutex::new(VecDeque::new())),
+                heartbeat_script: Arc::new(Mutex::new(VecDeque::new())),
+                submit_script: Arc::new(Mutex::new(VecDeque::new())),
+                get_next_calls: Arc::new(AtomicU32::new(0)),
+                heartbeat_calls: Arc::new(AtomicU32::new(0)),
+                submit_calls: Arc::new(AtomicU32::new(0)),
             }
         }
 
         fn rejecting_heartbeat() -> Self {
-            Self { state: Arc::new(Mutex::new(MockWorkerState::default())), reject_heartbeat: true }
+            let mut api = Self::new();
+            api.reject_heartbeat = true;
+            api
+        }
+
+        fn queue_get_next_outcomes<I: IntoIterator<Item = ScriptedOutcome>>(&self, outcomes: I) {
+            self.get_next_script.lock().expect("script lock").extend(outcomes);
+        }
+
+        fn queue_heartbeat_outcomes<I: IntoIterator<Item = ScriptedOutcome>>(&self, outcomes: I) {
+            self.heartbeat_script.lock().expect("script lock").extend(outcomes);
+        }
+
+        fn queue_submit_outcomes<I: IntoIterator<Item = ScriptedOutcome>>(&self, outcomes: I) {
+            self.submit_script.lock().expect("script lock").extend(outcomes);
+        }
+
+        fn get_next_calls(&self) -> u32 {
+            self.get_next_calls.load(Ordering::SeqCst)
+        }
+
+        fn heartbeat_calls(&self) -> u32 {
+            self.heartbeat_calls.load(Ordering::SeqCst)
+        }
+
+        fn submit_calls(&self) -> u32 {
+            self.submit_calls.load(Ordering::SeqCst)
         }
     }
 
@@ -194,8 +313,20 @@ mod tests {
             &self,
             request: GetNextProofRequest,
         ) -> RpcResult<GetNextProofResponse> {
+            self.get_next_calls.fetch_add(1, Ordering::SeqCst);
             self.state.lock().expect("state lock should not be poisoned").get_next_request =
                 Some(request.clone());
+
+            match self.get_next_script.lock().expect("script lock").pop_front() {
+                Some(ScriptedOutcome::Retryable) => {
+                    return Err(unavailable_error("scripted get_next_proof retryable failure"));
+                }
+                Some(ScriptedOutcome::Fatal) => {
+                    return Err(invalid_params_error("scripted get_next_proof fatal failure"));
+                }
+                None | Some(ScriptedOutcome::Success) => {}
+            }
+
             let session_id = format!("session-for-{}", request.worker_id);
 
             Ok(GetNextProofResponse {
@@ -210,8 +341,19 @@ mod tests {
         }
 
         async fn heartbeat(&self, request: HeartbeatRequest) -> RpcResult<HeartbeatResponse> {
+            self.heartbeat_calls.fetch_add(1, Ordering::SeqCst);
             self.state.lock().expect("state lock should not be poisoned").heartbeat_request =
                 Some(request.clone());
+
+            match self.heartbeat_script.lock().expect("script lock").pop_front() {
+                Some(ScriptedOutcome::Retryable) => {
+                    return Err(unavailable_error("scripted heartbeat retryable failure"));
+                }
+                Some(ScriptedOutcome::Fatal) => {
+                    return Err(invalid_params_error("scripted heartbeat fatal failure"));
+                }
+                None | Some(ScriptedOutcome::Success) => {}
+            }
 
             if self.reject_heartbeat {
                 return Err(ErrorObjectOwned::owned(
@@ -239,8 +381,19 @@ mod tests {
             &self,
             request: WorkerSubmitProofRequest,
         ) -> RpcResult<WorkerSubmitProofResponse> {
+            self.submit_calls.fetch_add(1, Ordering::SeqCst);
             self.state.lock().expect("state lock should not be poisoned").submit_request =
                 Some(request.clone());
+
+            match self.submit_script.lock().expect("script lock").pop_front() {
+                Some(ScriptedOutcome::Retryable) => {
+                    return Err(unavailable_error("scripted submit_proof retryable failure"));
+                }
+                Some(ScriptedOutcome::Fatal) => {
+                    return Err(invalid_params_error("scripted submit_proof fatal failure"));
+                }
+                None | Some(ScriptedOutcome::Success) => {}
+            }
 
             Ok(WorkerSubmitProofResponse {
                 job: proof_job(
@@ -256,6 +409,10 @@ mod tests {
 
     impl RunningWorkerServer {
         async fn spawn(api: MockWorkerApi) -> Self {
+            Self::spawn_with_retry(api, RetryConfig::default()).await
+        }
+
+        async fn spawn_with_retry(api: MockWorkerApi, retry: RetryConfig) -> Self {
             let addr: SocketAddr = "127.0.0.1:0".parse().expect("test address should parse");
             let server = Server::builder().build(addr).await.expect("server should bind");
             let local_addr = server.local_addr().expect("server should have local address");
@@ -263,12 +420,56 @@ mod tests {
             let endpoint = format!("http://{local_addr}");
             let inner = HttpClientBuilder::default().build(endpoint).expect("client should build");
 
-            Self { client: ProverWorkerClient::new(inner), handle }
+            Self { client: ProverWorkerClient::new(inner).with_retry_config(retry), handle }
         }
 
         async fn shutdown(self) {
             self.handle.stop().expect("server should stop");
             self.handle.stopped().await;
+        }
+    }
+
+    fn unavailable_error(message: impl Into<String>) -> ErrorObjectOwned {
+        ErrorObjectOwned::owned(
+            ProverServiceClientError::ERROR_UNAVAILABLE,
+            message.into(),
+            None::<()>,
+        )
+    }
+
+    fn invalid_params_error(message: impl Into<String>) -> ErrorObjectOwned {
+        ErrorObjectOwned::owned(ErrorCode::InvalidParams.code(), message.into(), None::<()>)
+    }
+
+    fn fast_retry_config() -> RetryConfig {
+        RetryConfig::new(3, Duration::from_millis(1), Duration::from_millis(1))
+    }
+
+    fn sample_get_next_request(worker_id: &str) -> GetNextProofRequest {
+        GetNextProofRequest {
+            worker_id: worker_id.to_owned(),
+            proof_type: ProofType::Compressed,
+            tee_kinds: Vec::new(),
+            zk_vms: vec![ZkVm::Sp1],
+            lock_duration_seconds: 60,
+        }
+    }
+
+    fn sample_heartbeat_request(session_id: &str) -> HeartbeatRequest {
+        HeartbeatRequest {
+            session_id: session_id.to_owned(),
+            lock_id: "lock-heartbeat".to_owned(),
+            worker_id: "worker-heartbeat".to_owned(),
+            lock_duration_seconds: 30,
+        }
+    }
+
+    fn sample_submit_request(session_id: &str) -> WorkerSubmitProofRequest {
+        WorkerSubmitProofRequest {
+            session_id: session_id.to_owned(),
+            lock_id: "lock-submit".to_owned(),
+            worker_id: "worker-submit".to_owned(),
+            result: proof_result(),
         }
     }
 
@@ -404,6 +605,103 @@ mod tests {
             }
             other => panic!("unexpected error variant: {other:?}"),
         }
+
+        server.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn worker_does_not_retry_retryable_get_next_proof() {
+        let api = MockWorkerApi::new();
+        api.queue_get_next_outcomes([ScriptedOutcome::Retryable, ScriptedOutcome::Success]);
+        let api_clone = api.clone();
+        let server = RunningWorkerServer::spawn_with_retry(api, fast_retry_config()).await;
+
+        let err = server
+            .client
+            .get_next_proof(sample_get_next_request("worker-retry"))
+            .await
+            .expect_err("get_next_proof retryable error should not be retried");
+
+        assert!(err.is_retryable());
+        assert_eq!(api_clone.get_next_calls(), 1);
+
+        server.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn worker_retries_retryable_heartbeat_until_success() {
+        let api = MockWorkerApi::new();
+        api.queue_heartbeat_outcomes([ScriptedOutcome::Retryable, ScriptedOutcome::Success]);
+        let api_clone = api.clone();
+        let server = RunningWorkerServer::spawn_with_retry(api, fast_retry_config()).await;
+
+        let response = server
+            .client
+            .heartbeat(sample_heartbeat_request("session-heartbeat-retry"))
+            .await
+            .expect("heartbeat should succeed after retry");
+
+        assert_eq!(response.job.session_id, "session-heartbeat-retry");
+        assert_eq!(api_clone.heartbeat_calls(), 2);
+
+        server.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn worker_retries_retryable_submit_proof_until_success() {
+        let api = MockWorkerApi::new();
+        api.queue_submit_outcomes([ScriptedOutcome::Retryable, ScriptedOutcome::Success]);
+        let api_clone = api.clone();
+        let server = RunningWorkerServer::spawn_with_retry(api, fast_retry_config()).await;
+
+        let response = server
+            .client
+            .submit_proof(sample_submit_request("session-submit-retry"))
+            .await
+            .expect("submit_proof should succeed after retry");
+
+        assert_eq!(response.job.session_id, "session-submit-retry");
+        assert_eq!(api_clone.submit_calls(), 2);
+
+        server.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn worker_propagates_final_error_when_retries_exhausted() {
+        let config = fast_retry_config();
+        let api = MockWorkerApi::new();
+        let total_calls = config.max_attempts.expect("fast retry config should be bounded") + 1;
+        api.queue_submit_outcomes((0..total_calls).map(|_| ScriptedOutcome::Retryable));
+        let api_clone = api.clone();
+        let server = RunningWorkerServer::spawn_with_retry(api, config).await;
+
+        let err = server
+            .client
+            .submit_proof(sample_submit_request("session-exhaust"))
+            .await
+            .expect_err("retries should be exhausted");
+
+        assert!(err.is_retryable());
+        assert_eq!(api_clone.submit_calls(), total_calls);
+
+        server.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn worker_does_not_retry_fatal_heartbeat() {
+        let api = MockWorkerApi::new();
+        api.queue_heartbeat_outcomes([ScriptedOutcome::Fatal]);
+        let api_clone = api.clone();
+        let server = RunningWorkerServer::spawn_with_retry(api, fast_retry_config()).await;
+
+        let err = server
+            .client
+            .heartbeat(sample_heartbeat_request("session-fatal"))
+            .await
+            .expect_err("fatal error should not be retried");
+
+        assert!(!err.is_retryable());
+        assert_eq!(api_clone.heartbeat_calls(), 1);
 
         server.shutdown().await;
     }

--- a/crates/proof/prover-service/client/src/worker.rs
+++ b/crates/proof/prover-service/client/src/worker.rs
@@ -6,20 +6,11 @@ use base_prover_service_protocol::{
     GetNextProofRequest, GetNextProofResponse, HeartbeatRequest, HeartbeatResponse,
     ProverWorkerApiClient, WorkerSubmitProofRequest, WorkerSubmitProofResponse,
 };
-use base_retry::{
-    DEFAULT_BOUNDED_INITIAL_DELAY, DEFAULT_BOUNDED_MAX_ATTEMPTS, DEFAULT_BOUNDED_MAX_DELAY,
-    RetryConfig,
-};
+use base_retry::RetryConfig;
 use jsonrpsee::http_client::HttpClient;
 use tracing::{debug, warn};
 
 use crate::{ProverServiceClientBuildError, ProverServiceClientConfig, ProverServiceClientError};
-
-const DEFAULT_RETRY_CONFIG: RetryConfig = RetryConfig::new(
-    DEFAULT_BOUNDED_MAX_ATTEMPTS,
-    DEFAULT_BOUNDED_INITIAL_DELAY,
-    DEFAULT_BOUNDED_MAX_DELAY,
-);
 
 /// Abstraction over prover worker JSON-RPC methods.
 ///
@@ -62,8 +53,8 @@ pub struct ProverWorkerClient {
 impl ProverWorkerClient {
     /// Create a worker client from an existing JSON-RPC HTTP client. Idempotent worker retries
     /// use [`RetryConfig::default`]; call [`Self::with_retry_config`] to override.
-    pub const fn new(inner: HttpClient) -> Self {
-        Self { inner, retry: DEFAULT_RETRY_CONFIG }
+    pub fn new(inner: HttpClient) -> Self {
+        Self { inner, retry: RetryConfig::default() }
     }
 
     /// Connect a worker client using the provided configuration.


### PR DESCRIPTION
### What changed? Why?

This adds retry handling to idempotent prover worker JSON-RPC operations. `heartbeat` and `submit_proof` now use the configured bounded retry policy for retryable transient failures, matching the requester client behavior.

`get_next_proof` remains a single attempt because it mutates server-side job lock state and does not have an idempotency key. Retrying it after a lost response could claim and lock another job.

### Notes to reviewers

The worker client now stores a `RetryConfig`, defaults to the existing bounded retry values, and picks up `ProverServiceClientConfig::retry_config()` when constructed via `connect`.

The tests use scripted worker responses to verify retryable success, retry exhaustion, fatal error handling, and the no-retry behavior for `get_next_proof`.

### How has it been tested?

- `cargo fmt --check`
- `cargo test -p base-prover-service-client worker`