### PR TITLE
feat(basectl): add sync-status subcommand

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6518,7 +6518,6 @@ dependencies = [
  "base-common-network",
  "base-protocol",
  "basectl-cli",
- "chrono",
  "clap",
  "rustls 0.23.40",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6516,6 +6516,7 @@ dependencies = [
  "alloy-rpc-types-eth 2.0.5",
  "anyhow",
  "base-common-network",
+ "base-protocol",
  "basectl-cli",
  "chrono",
  "clap",

--- a/bin/basectl/Cargo.toml
+++ b/bin/basectl/Cargo.toml
@@ -14,7 +14,6 @@ workspace = true
 [dependencies]
 url = { workspace = true }
 anyhow = { workspace = true }
-chrono = { workspace = true }
 alloy-eips = { workspace = true }
 basectl-cli = { workspace = true }
 alloy-provider = { workspace = true }

--- a/bin/basectl/Cargo.toml
+++ b/bin/basectl/Cargo.toml
@@ -24,6 +24,7 @@ clap = { workspace = true, features = ["derive", "env"] }
 serde = { workspace = true, features = ["derive", "std"] }
 alloy-primitives = { workspace = true, features = ["serde"] }
 alloy-rpc-types-eth = { workspace = true, features = ["std"] }
+base-protocol = { workspace = true, features = ["serde", "std"] }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 
 [dev-dependencies]

--- a/bin/basectl/README.md
+++ b/bin/basectl/README.md
@@ -67,7 +67,7 @@ quantities at the top level — byte-equivalent to `cast block --json`.
 Reports the rollup node's `optimism_syncStatus` (CL) joined with the EL's
 `eth_syncing` state, plus a public-RPC tip reference for cross-checking.
 One round-trip each, run in parallel; the CL/EL pair short-circuits on
-failure, the tip reference is best-effort. Visible alias: `ss`.
+failure, the tip reference is best-effort.
 
 The CL response carries every L1/L2 head ref the rollup node knows about,
 each with a block number, hash, and Unix timestamp. Pretty mode prints an
@@ -83,14 +83,15 @@ instead of just seeing "syncing: true."
 A `tip_reference` row compares the local node's unsafe L2 head against the
 preset's public RPC URL (`https://mainnet.base.org/`,
 `https://sepolia.base.org/`, or `http://localhost:7545` for devnet). Status
-is one of `caught_up` (within ±5 blocks of the reference), `behind`,
-`ahead`, or `unavailable` (public RPC unreachable). The threshold is a
-strawman — tunable based on Datadog/on-call feedback.
+is one of `caught_up` (within ±N blocks of the reference, where N is the
+`--tip-tolerance` flag — default 5), `behind`, `ahead`, or `unavailable`
+(public RPC unreachable).
 
 | Flag | Description |
 |------|-------------|
 | `--el-rpc <URL>` | Override the execution-layer RPC URL. Defaults to the chain config's `rpc` field. |
 | `--cl-rpc <URL>` | Override the consensus-node RPC URL. The mainnet and sepolia presets ship `consensus_node_rpc` unset, so non-devnet users must pass this flag (or set the field in their YAML config). |
+| `--tip-tolerance <BLOCKS>` | Block tolerance for the tip-reference `caught_up` classification. Within ±this many blocks of the public reference, the local node is reported as `caught_up`; otherwise `behind` or `ahead`. Default `5` ≈ ~10s at Base's 2s block time. Use `0` for strict alerting, larger values to dampen noise. |
 | `--json` | Emit humanized JSON (decoded numeric values, ISO + local timestamps, precomputed `safeLag*`, `tipReference` object, `elSyncInfo` with `processedBlocks` / `remainingBlocks`) instead of the key-value table. |
 | `--raw` | With `--json`, emit the alloy-typed `optimism_syncStatus` wire format instead of the humanized form. Errors at parse time if used without `--json`. |
 

--- a/bin/basectl/README.md
+++ b/bin/basectl/README.md
@@ -62,6 +62,24 @@ the operator's wall clock is readable without timezone math. Raw JSON
 (`--json --raw`) preserves the alloy/JSON-RPC wire format with hex
 quantities at the top level — byte-equivalent to `cast block --json`.
 
+### `basectl sync-status`
+
+Reports the rollup node's `optimism_syncStatus` (CL) joined with the EL's
+`eth_syncing` state. One round-trip each, run in parallel; either failure
+short-circuits the call. Visible alias: `ss`.
+
+The CL response carries every L1/L2 head ref the rollup node knows about,
+each with a block number, hash, and Unix timestamp. Pretty mode prints an
+aligned key-value table; humanized JSON adds a precomputed `safeLagSeconds`
+/ `safeLagBlocks` pair (`unsafe` minus `safe`) so consumers don't have to
+re-derive lag from raw timestamps.
+
+| Flag | Description |
+|------|-------------|
+| `--cl-rpc <URL>` | Override the consensus-node RPC URL. The mainnet and sepolia presets ship `consensus_node_rpc` unset, so non-devnet users must pass this flag (or set the field in their YAML config). |
+| `--json` | Emit humanized JSON (decoded numeric values, ISO + local timestamps, precomputed `safeLag*`) instead of the key-value table. |
+| `--raw` | With `--json`, emit the alloy-typed `optimism_syncStatus` wire format instead of the humanized form. Errors at parse time if used without `--json`. |
+
 ### `basectl flashblocks`
 
 Streams live flashblocks as newline-delimited JSON to stdout. For the
@@ -103,4 +121,13 @@ basectl -c sepolia block --json latest | jq '{number, gasUsed, baseFeePerGasWei,
 
 # Raw (wire) JSON: same shape as `cast block --json`, useful for round-tripping
 basectl -c mainnet block --json --raw finalized | jq '{number, gasUsed, baseFeePerGas}'
+
+# Sync status against a devnet (consensus_node_rpc is set in the devnet preset)
+basectl -c devnet sync-status
+
+# Sync status against a public chain — requires explicit --cl-rpc since mainnet/sepolia presets ship without one
+basectl -c sepolia sync-status --cl-rpc https://your-rollup-node.example/
+
+# Humanized JSON shows precomputed safe-head lag for downstream tooling
+basectl -c sepolia sync-status --cl-rpc https://your-rollup-node.example/ --json | jq '{safeLagSeconds, safeLagBlocks, elActivelySyncing}'
 ```

--- a/bin/basectl/README.md
+++ b/bin/basectl/README.md
@@ -65,8 +65,9 @@ quantities at the top level — byte-equivalent to `cast block --json`.
 ### `basectl sync-status`
 
 Reports the rollup node's `optimism_syncStatus` (CL) joined with the EL's
-`eth_syncing` state. One round-trip each, run in parallel; either failure
-short-circuits the call. Visible alias: `ss`.
+`eth_syncing` state, plus a public-RPC tip reference for cross-checking.
+One round-trip each, run in parallel; the CL/EL pair short-circuits on
+failure, the tip reference is best-effort. Visible alias: `ss`.
 
 The CL response carries every L1/L2 head ref the rollup node knows about,
 each with a block number, hash, and Unix timestamp. Pretty mode prints an
@@ -74,10 +75,23 @@ aligned key-value table; humanized JSON adds a precomputed `safeLagSeconds`
 / `safeLagBlocks` pair (`unsafe` minus `safe`) so consumers don't have to
 re-derive lag from raw timestamps.
 
+When the EL is mid-sync (`eth_syncing` returns the `Info(...)` variant),
+the output also surfaces `processedBlocks` (`current - starting`) and
+`remainingBlocks` (`highest - current`) so operators can quantify the gap
+instead of just seeing "syncing: true."
+
+A `tip_reference` row compares the local node's unsafe L2 head against the
+preset's public RPC URL (`https://mainnet.base.org/`,
+`https://sepolia.base.org/`, or `http://localhost:7545` for devnet). Status
+is one of `caught_up` (within ±5 blocks of the reference), `behind`,
+`ahead`, or `unavailable` (public RPC unreachable). The threshold is a
+strawman — tunable based on Datadog/on-call feedback.
+
 | Flag | Description |
 |------|-------------|
+| `--el-rpc <URL>` | Override the execution-layer RPC URL. Defaults to the chain config's `rpc` field. |
 | `--cl-rpc <URL>` | Override the consensus-node RPC URL. The mainnet and sepolia presets ship `consensus_node_rpc` unset, so non-devnet users must pass this flag (or set the field in their YAML config). |
-| `--json` | Emit humanized JSON (decoded numeric values, ISO + local timestamps, precomputed `safeLag*`) instead of the key-value table. |
+| `--json` | Emit humanized JSON (decoded numeric values, ISO + local timestamps, precomputed `safeLag*`, `tipReference` object, `elSyncInfo` with `processedBlocks` / `remainingBlocks`) instead of the key-value table. |
 | `--raw` | With `--json`, emit the alloy-typed `optimism_syncStatus` wire format instead of the humanized form. Errors at parse time if used without `--json`. |
 
 ### `basectl flashblocks`

--- a/bin/basectl/src/block.rs
+++ b/bin/basectl/src/block.rs
@@ -7,10 +7,9 @@ use alloy_rpc_types_eth::BlockNumberOrTag;
 use anyhow::{Result, anyhow, bail};
 use base_common_network::Base;
 use basectl_cli::{
-    JsonOutput, KeyValueTable, MonitoringConfig, fetch_block, format_bytes, format_gas,
-    format_gwei, format_unix_timestamp,
+    JsonOutput, KeyValueTable, MonitoringConfig, TimestampJson, fetch_block, format_bytes,
+    format_gas, format_gwei, format_unix_timestamp,
 };
-use chrono::{DateTime, Local, SecondsFormat};
 use serde::Serialize;
 
 /// Parses a CLI block reference into alloy's `BlockId`.
@@ -113,28 +112,6 @@ impl BlockSummaryJson {
             excess_blob_gas: header.excess_blob_gas,
             withdrawals: block.withdrawals.as_ref().map(|w| w.len()),
         }
-    }
-}
-
-/// Three-form timestamp object: raw unix seconds, UTC RFC 3339, and local
-/// RFC 3339 (operator's machine timezone with offset suffix).
-#[derive(Debug, Clone, Serialize)]
-struct TimestampJson {
-    unix: u64,
-    utc: String,
-    local: String,
-}
-
-impl TimestampJson {
-    fn from_unix(secs: u64) -> Self {
-        let dt = i64::try_from(secs).ok().and_then(|s| DateTime::from_timestamp(s, 0));
-        let utc = dt
-            .map(|t| t.to_rfc3339_opts(SecondsFormat::Secs, true))
-            .unwrap_or_else(|| secs.to_string());
-        let local = dt
-            .map(|t| t.with_timezone(&Local).to_rfc3339_opts(SecondsFormat::Secs, false))
-            .unwrap_or_else(|| secs.to_string());
-        Self { unix: secs, utc, local }
     }
 }
 
@@ -249,31 +226,6 @@ mod tests {
     }
 
     #[test]
-    fn timestamp_json_renders_three_forms() {
-        let ts = super::TimestampJson::from_unix(1_780_614_804);
-
-        assert_eq!(ts.unix, 1_780_614_804);
-        assert!(ts.utc.ends_with('Z'), "expected UTC suffix Z, got {}", ts.utc);
-        assert!(ts.utc.starts_with("2026-06-04"), "expected UTC date prefix, got {}", ts.utc);
-        let local_has_offset =
-            ts.local.contains('+') || ts.local.matches('-').count() >= 3 || ts.local.ends_with('Z');
-        assert!(local_has_offset, "expected local RFC 3339 with offset, got {}", ts.local);
-    }
-
-    #[test]
-    fn timestamp_json_falls_back_on_u64_overflow() {
-        // u64 values above i64::MAX would silently wrap to a negative i64 under
-        // an `as i64` cast, producing a misleading pre-epoch RFC 3339 string.
-        // The try_from guard converts that case to None, triggering the raw
-        // seconds fallback for both utc and local.
-        let oversize = super::TimestampJson::from_unix(u64::MAX);
-
-        assert_eq!(oversize.unix, u64::MAX);
-        assert_eq!(oversize.utc, u64::MAX.to_string());
-        assert_eq!(oversize.local, u64::MAX.to_string());
-    }
-
-    #[test]
     fn block_summary_json_serializes_with_camel_case_and_nested_timestamp() {
         let summary = super::BlockSummaryJson {
             network: "sepolia".to_string(),
@@ -281,7 +233,7 @@ mod tests {
             number: 42,
             hash: B256::repeat_byte(0x11),
             parent_hash: B256::repeat_byte(0x22),
-            timestamp: super::TimestampJson::from_unix(1_780_614_804),
+            timestamp: basectl_cli::TimestampJson::from_unix(1_780_614_804),
             transactions: 7,
             gas_used: 21_000,
             gas_limit: 30_000_000,

--- a/bin/basectl/src/cli.rs
+++ b/bin/basectl/src/cli.rs
@@ -53,6 +53,34 @@ pub(crate) enum Commands {
         #[arg(long, requires = "json")]
         raw: bool,
     },
+    /// Report combined CL `optimism_syncStatus` + EL `eth_syncing`.
+    #[command(visible_alias = "ss")]
+    SyncStatus {
+        /// Override the execution-layer RPC URL.
+        ///
+        /// Defaults to the chain config's `rpc` field, which on the
+        /// `mainnet` and `sepolia` presets resolves to the public proxyd
+        /// fleet — `eth_syncing` against that always reports "not syncing"
+        /// because proxyd routes only-healthy backends. Pass this flag to
+        /// point at a single node.
+        #[arg(long = "el-rpc", value_name = "URL")]
+        el_rpc: Option<Url>,
+        /// Override the consensus-node RPC URL.
+        ///
+        /// The mainnet and sepolia presets ship `consensus_node_rpc` unset, so
+        /// non-devnet users must pass this flag (or set the field in their YAML
+        /// config).
+        #[arg(long = "cl-rpc", value_name = "URL")]
+        cl_rpc: Option<Url>,
+        /// Emit JSON (humanized — decoded numbers, ISO + local timestamps,
+        /// precomputed `safeLag*`) instead of the pretty table.
+        #[arg(long)]
+        json: bool,
+        /// With `--json`, emit the JSON-RPC wire format (the alloy-typed
+        /// `optimism_syncStatus` response) instead of the humanized JSON.
+        #[arg(long, requires = "json")]
+        raw: bool,
+    },
     /// Stream flashblocks as JSON lines.
     #[command(after_help = "Use `basectl monitor flashblocks` for the TUI.")]
     Flashblocks,

--- a/bin/basectl/src/cli.rs
+++ b/bin/basectl/src/cli.rs
@@ -54,7 +54,6 @@ pub(crate) enum Commands {
         raw: bool,
     },
     /// Report combined CL `optimism_syncStatus` + EL `eth_syncing`.
-    #[command(visible_alias = "ss")]
     SyncStatus {
         /// Override the execution-layer RPC URL.
         ///
@@ -72,6 +71,15 @@ pub(crate) enum Commands {
         /// config).
         #[arg(long = "cl-rpc", value_name = "URL")]
         cl_rpc: Option<Url>,
+        /// Block tolerance for the tip-reference `caught_up` classification.
+        ///
+        /// The local node is reported as `caught_up` when within ±this many
+        /// blocks of the public reference. Beyond the window, status flips
+        /// to `behind` or `ahead`. Default 5 ≈ ~10s of network jitter at
+        /// Base's 2s block time. Lower the value for stricter alerting,
+        /// raise it to dampen noise on flaky networks.
+        #[arg(long = "tip-tolerance", value_name = "BLOCKS", default_value_t = 5)]
+        tip_tolerance: u64,
         /// Emit JSON (humanized — decoded numbers, ISO + local timestamps,
         /// precomputed `safeLag*`) instead of the pretty table.
         #[arg(long)]

--- a/bin/basectl/src/main.rs
+++ b/bin/basectl/src/main.rs
@@ -25,8 +25,16 @@ async fn main() -> anyhow::Result<()> {
         Some(cli::Commands::Block { reference, json, raw }) => {
             block::run(MonitoringConfig::load(config).await?, &reference, json, raw).await
         }
-        Some(cli::Commands::SyncStatus { el_rpc, cl_rpc, json, raw }) => {
-            sync_status::run(MonitoringConfig::load(config).await?, el_rpc, cl_rpc, json, raw).await
+        Some(cli::Commands::SyncStatus { el_rpc, cl_rpc, tip_tolerance, json, raw }) => {
+            sync_status::run(
+                MonitoringConfig::load(config).await?,
+                el_rpc,
+                cl_rpc,
+                tip_tolerance,
+                json,
+                raw,
+            )
+            .await
         }
         Some(cli::Commands::Flashblocks) => {
             run_flashblocks_json(MonitoringConfig::load(config).await?).await

--- a/bin/basectl/src/main.rs
+++ b/bin/basectl/src/main.rs
@@ -2,6 +2,7 @@
 
 mod block;
 mod cli;
+mod sync_status;
 
 use basectl_cli::{MonitoringConfig, ViewId, run_app, run_flashblocks_json};
 use clap::{CommandFactory, Parser};
@@ -23,6 +24,9 @@ async fn main() -> anyhow::Result<()> {
         }
         Some(cli::Commands::Block { reference, json, raw }) => {
             block::run(MonitoringConfig::load(config).await?, &reference, json, raw).await
+        }
+        Some(cli::Commands::SyncStatus { el_rpc, cl_rpc, json, raw }) => {
+            sync_status::run(MonitoringConfig::load(config).await?, el_rpc, cl_rpc, json, raw).await
         }
         Some(cli::Commands::Flashblocks) => {
             run_flashblocks_json(MonitoringConfig::load(config).await?).await

--- a/bin/basectl/src/sync_status.rs
+++ b/bin/basectl/src/sync_status.rs
@@ -211,6 +211,20 @@ enum TipStatus {
     Unavailable,
 }
 
+impl TipStatus {
+    /// Display label matching the JSON serialization. Compiler-enforced
+    /// exhaustive match keeps this in sync with the `serde(rename_all)`
+    /// when new variants are added.
+    const fn as_str(&self) -> &'static str {
+        match self {
+            Self::CaughtUp => "caught_up",
+            Self::Behind => "behind",
+            Self::Ahead => "ahead",
+            Self::Unavailable => "unavailable",
+        }
+    }
+}
+
 impl TipReferenceJson {
     fn from_local_and_public(url: &str, local: u64, public: Option<u64>) -> Self {
         let Some(public) = public else {
@@ -300,20 +314,16 @@ fn print_pretty(
 }
 
 fn format_tip_reference(url: &str, local: u64, public: Option<u64>) -> String {
-    let Some(public) = public else {
-        return format!("unavailable (url={url} fetch failed)");
-    };
-    let local_i = i64::try_from(local).unwrap_or(i64::MAX);
-    let public_i = i64::try_from(public).unwrap_or(i64::MAX);
-    let delta = public_i.saturating_sub(local_i);
-    let status = if delta.abs() <= TIP_CAUGHT_UP_THRESHOLD {
-        "caught_up"
-    } else if delta > 0 {
-        "behind"
-    } else {
-        "ahead"
-    };
-    format!("#{public} (url={url}) delta={delta} ({status})")
+    // Single source of truth for delta math + classification:
+    // `TipReferenceJson::from_local_and_public`. Build the JSON struct and
+    // read its fields rather than re-deriving the same logic here.
+    let tip = TipReferenceJson::from_local_and_public(url, local, public);
+    match (tip.block_number, tip.delta_blocks) {
+        (Some(block), Some(delta)) => {
+            format!("#{block} (url={url}) delta={delta} ({})", tip.status.as_str())
+        }
+        _ => format!("unavailable (url={url} fetch failed)"),
+    }
 }
 
 fn format_block_info(b: &BlockInfo) -> String {

--- a/bin/basectl/src/sync_status.rs
+++ b/bin/basectl/src/sync_status.rs
@@ -7,10 +7,9 @@ use alloy_rpc_types_eth::SyncStatus as EthSyncStatus;
 use anyhow::{Result, anyhow};
 use base_protocol::{BlockInfo, L2BlockInfo};
 use basectl_cli::{
-    JsonOutput, KeyValueTable, MonitoringConfig, SyncStatusReport, fetch_sync_status,
-    format_duration, format_unix_timestamp,
+    JsonOutput, KeyValueTable, MonitoringConfig, SyncStatusReport, TimestampJson,
+    fetch_sync_status, format_duration, format_unix_timestamp,
 };
-use chrono::{DateTime, Local, SecondsFormat};
 use serde::Serialize;
 use url::Url;
 
@@ -139,28 +138,6 @@ struct ElSyncInfoJson {
     highest_block: u64,
 }
 
-/// Three-form timestamp object: raw unix seconds, UTC RFC 3339, and local
-/// RFC 3339 (operator's machine timezone with offset suffix).
-#[derive(Debug, Clone, Serialize)]
-struct TimestampJson {
-    unix: u64,
-    utc: String,
-    local: String,
-}
-
-impl TimestampJson {
-    fn from_unix(secs: u64) -> Self {
-        let dt = i64::try_from(secs).ok().and_then(|s| DateTime::from_timestamp(s, 0));
-        let utc = dt
-            .map(|t| t.to_rfc3339_opts(SecondsFormat::Secs, true))
-            .unwrap_or_else(|| secs.to_string());
-        let local = dt
-            .map(|t| t.with_timezone(&Local).to_rfc3339_opts(SecondsFormat::Secs, false))
-            .unwrap_or_else(|| secs.to_string());
-        Self { unix: secs, utc, local }
-    }
-}
-
 fn print_pretty(network: &str, report: &SyncStatusReport) -> Result<()> {
     let cl = &report.cl;
     let mut table = KeyValueTable::new();
@@ -219,7 +196,7 @@ mod tests {
     use base_protocol::{BlockInfo, L2BlockInfo, SyncStatus};
     use basectl_cli::SyncStatusReport;
 
-    use super::{SyncStatusJson, TimestampJson};
+    use super::SyncStatusJson;
 
     fn sample_l2(block: u64, ts: u64) -> L2BlockInfo {
         L2BlockInfo::new(
@@ -280,21 +257,5 @@ mod tests {
         let summary = SyncStatusJson::from_report("mainnet", &report);
         assert_eq!(summary.safe_lag_seconds, 0);
         assert_eq!(summary.safe_lag_blocks, 0);
-    }
-
-    #[test]
-    fn timestamp_json_renders_three_forms() {
-        let ts = TimestampJson::from_unix(1_780_614_804);
-        assert_eq!(ts.unix, 1_780_614_804);
-        assert!(ts.utc.ends_with('Z'), "expected UTC suffix Z, got {}", ts.utc);
-        assert!(ts.utc.starts_with("2026-06-04"), "expected UTC date prefix, got {}", ts.utc);
-    }
-
-    #[test]
-    fn timestamp_json_falls_back_on_u64_overflow() {
-        let oversize = TimestampJson::from_unix(u64::MAX);
-        assert_eq!(oversize.unix, u64::MAX);
-        assert_eq!(oversize.utc, u64::MAX.to_string());
-        assert_eq!(oversize.local, u64::MAX.to_string());
     }
 }

--- a/bin/basectl/src/sync_status.rs
+++ b/bin/basectl/src/sync_status.rs
@@ -2,16 +2,22 @@
 
 use std::time::Duration;
 
+use alloy_eips::BlockId;
 use alloy_primitives::B256;
-use alloy_rpc_types_eth::SyncStatus as EthSyncStatus;
+use alloy_rpc_types_eth::{BlockNumberOrTag, SyncStatus as EthSyncStatus};
 use anyhow::{Result, anyhow};
 use base_protocol::{BlockInfo, L2BlockInfo};
 use basectl_cli::{
-    JsonOutput, KeyValueTable, MonitoringConfig, SyncStatusReport, TimestampJson,
+    JsonOutput, KeyValueTable, MonitoringConfig, SyncStatusReport, TimestampJson, fetch_block,
     fetch_sync_status, format_duration, format_unix_timestamp,
 };
 use serde::Serialize;
 use url::Url;
+
+/// Threshold (in blocks) below which the local node is treated as caught up
+/// with the public reference RPC. Strawman — ~10s of network jitter at 2s
+/// block time. Tunable based on Datadog/on-call feedback.
+const TIP_CAUGHT_UP_THRESHOLD: i64 = 5;
 
 /// Runs the `basectl sync-status` subcommand.
 pub(crate) async fn run(
@@ -23,14 +29,25 @@ pub(crate) async fn run(
 ) -> Result<()> {
     let el_rpc = el_rpc_override.unwrap_or_else(|| config.rpc.clone());
     let cl_rpc = resolve_cl_rpc(&config, cl_rpc_override.as_ref())?;
-    let report = fetch_sync_status(&el_rpc, &cl_rpc).await?;
+    // Public tip reference is best-effort — failure marks the row unavailable
+    // rather than failing the whole command. Run in parallel with the local
+    // sync fetch.
+    let (sync_result, tip_result) = tokio::join!(
+        fetch_sync_status(&el_rpc, &cl_rpc),
+        fetch_block(&config.rpc, BlockId::Number(BlockNumberOrTag::Latest)),
+    );
+    let report = sync_result?;
+    let public_tip_block = tip_result.ok().map(|b| b.header.number);
+    let tip_url = config.rpc.as_str();
+
     match (json, raw) {
         (true, true) => JsonOutput::print(&report.cl)?,
         (true, false) => {
-            let summary = SyncStatusJson::from_report(&config.name, &report);
+            let summary =
+                SyncStatusJson::from_report(&config.name, &report, tip_url, public_tip_block);
             JsonOutput::print(&summary)?;
         }
-        (false, _) => print_pretty(&config.name, &report)?,
+        (false, _) => print_pretty(&config.name, &report, tip_url, public_tip_block)?,
     }
     Ok(())
 }
@@ -56,8 +73,9 @@ fn resolve_cl_rpc(config: &MonitoringConfig, override_url: Option<&Url>) -> Resu
 
 /// Humanized JSON shape for `basectl sync-status --json`.
 ///
-/// Decoded numerics, nested timestamp objects, and a precomputed `safeLag*`
-/// pair so consumers don't have to re-derive lag from raw timestamps.
+/// Decoded numerics, nested timestamp objects, a precomputed `safeLag*`
+/// pair, and a `tipReference` block for the public-RPC comparison so
+/// consumers don't have to re-derive any of these from raw fields.
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 struct SyncStatusJson {
@@ -72,26 +90,44 @@ struct SyncStatusJson {
     l1_head: HeadJson,
     l1_safe: HeadJson,
     l1_finalized: HeadJson,
+    tip_reference: TipReferenceJson,
 }
 
 impl SyncStatusJson {
-    fn from_report(network: &str, report: &SyncStatusReport) -> Self {
+    fn from_report(
+        network: &str,
+        report: &SyncStatusReport,
+        tip_url: &str,
+        public_tip_block: Option<u64>,
+    ) -> Self {
         let cl = &report.cl;
         let safe_lag_seconds =
             cl.unsafe_l2.block_info.timestamp.saturating_sub(cl.safe_l2.block_info.timestamp);
         let safe_lag_blocks =
             cl.unsafe_l2.block_info.number.saturating_sub(cl.safe_l2.block_info.number);
         let (el_actively_syncing, el_sync_info) = match &report.el {
-            EthSyncStatus::Info(info) => (
-                true,
-                Some(ElSyncInfoJson {
-                    starting_block: info.starting_block.to::<u64>(),
-                    current_block: info.current_block.to::<u64>(),
-                    highest_block: info.highest_block.to::<u64>(),
-                }),
-            ),
+            EthSyncStatus::Info(info) => {
+                let starting = info.starting_block.to::<u64>();
+                let current = info.current_block.to::<u64>();
+                let highest = info.highest_block.to::<u64>();
+                (
+                    true,
+                    Some(ElSyncInfoJson {
+                        starting_block: starting,
+                        current_block: current,
+                        highest_block: highest,
+                        processed_blocks: current.saturating_sub(starting),
+                        remaining_blocks: highest.saturating_sub(current),
+                    }),
+                )
+            }
             EthSyncStatus::None => (false, None),
         };
+        let tip_reference = TipReferenceJson::from_local_and_public(
+            tip_url,
+            cl.unsafe_l2.block_info.number,
+            public_tip_block,
+        );
         Self {
             network: network.to_string(),
             el_actively_syncing,
@@ -104,6 +140,7 @@ impl SyncStatusJson {
             l1_head: HeadJson::from_l1(&cl.head_l1),
             l1_safe: HeadJson::from_l1(&cl.safe_l1),
             l1_finalized: HeadJson::from_l1(&cl.finalized_l1),
+            tip_reference,
         }
     }
 }
@@ -136,9 +173,77 @@ struct ElSyncInfoJson {
     starting_block: u64,
     current_block: u64,
     highest_block: u64,
+    /// Blocks processed since EL sync began (`current - starting`).
+    processed_blocks: u64,
+    /// Blocks still to process before EL sync completes (`highest - current`).
+    remaining_blocks: u64,
 }
 
-fn print_pretty(network: &str, report: &SyncStatusReport) -> Result<()> {
+/// Comparison of the local node's unsafe L2 head against a public-RPC
+/// reference (`config.rpc` for the active preset). Best-effort — when the
+/// public fetch fails, `block_number` and `delta_blocks` are `None` and
+/// `status` is `unavailable`.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct TipReferenceJson {
+    /// The public-RPC URL queried (the preset's `config.rpc`).
+    url: String,
+    /// Latest block number reported by the public RPC. `None` if the call failed.
+    block_number: Option<u64>,
+    /// Signed delta `public - local`. Positive means local is behind; negative
+    /// means local is ahead. `None` if the public block isn't known.
+    delta_blocks: Option<i64>,
+    /// Coarse classification of `delta_blocks` against the catch-up threshold.
+    status: TipStatus,
+}
+
+/// Coarse status of the local node relative to the public-RPC reference.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum TipStatus {
+    /// Local within `±TIP_CAUGHT_UP_THRESHOLD` blocks of the public reference.
+    CaughtUp,
+    /// Local is more than `TIP_CAUGHT_UP_THRESHOLD` blocks behind the reference.
+    Behind,
+    /// Local is more than `TIP_CAUGHT_UP_THRESHOLD` blocks ahead of the reference.
+    Ahead,
+    /// Public reference fetch failed; comparison not available.
+    Unavailable,
+}
+
+impl TipReferenceJson {
+    fn from_local_and_public(url: &str, local: u64, public: Option<u64>) -> Self {
+        let Some(public) = public else {
+            return Self {
+                url: url.to_string(),
+                block_number: None,
+                delta_blocks: None,
+                status: TipStatus::Unavailable,
+            };
+        };
+        // delta = public - local; positive = local behind, negative = local ahead.
+        // Saturating signed conversion keeps absurd RPC values from panicking;
+        // real chain heights are always well under i64::MAX.
+        let local_i = i64::try_from(local).unwrap_or(i64::MAX);
+        let public_i = i64::try_from(public).unwrap_or(i64::MAX);
+        let delta = public_i.saturating_sub(local_i);
+        let status = if delta.abs() <= TIP_CAUGHT_UP_THRESHOLD {
+            TipStatus::CaughtUp
+        } else if delta > 0 {
+            TipStatus::Behind
+        } else {
+            TipStatus::Ahead
+        };
+        Self { url: url.to_string(), block_number: Some(public), delta_blocks: Some(delta), status }
+    }
+}
+
+fn print_pretty(
+    network: &str,
+    report: &SyncStatusReport,
+    tip_url: &str,
+    public_tip_block: Option<u64>,
+) -> Result<()> {
     let cl = &report.cl;
     let mut table = KeyValueTable::new();
     table.row("network", network);
@@ -148,12 +253,16 @@ fn print_pretty(network: &str, report: &SyncStatusReport) -> Result<()> {
             table.row("el_syncing", "false");
         }
         EthSyncStatus::Info(info) => {
+            let starting = info.starting_block.to::<u64>();
+            let current = info.current_block.to::<u64>();
+            let highest = info.highest_block.to::<u64>();
+            let processed = current.saturating_sub(starting);
+            let remaining = highest.saturating_sub(current);
             table.row(
                 "el_syncing",
                 format!(
-                    "true (current={} highest={})",
-                    info.current_block.to::<u64>(),
-                    info.highest_block.to::<u64>(),
+                    "true (catching up: {remaining} blocks remaining, {processed} done; \
+                     current={current} highest={highest})",
                 ),
             );
         }
@@ -181,8 +290,30 @@ fn print_pretty(network: &str, report: &SyncStatusReport) -> Result<()> {
         .row("l1_safe", format_block_info(&cl.safe_l1))
         .row("l1_finalized", format_block_info(&cl.finalized_l1));
 
+    table.row(
+        "tip_reference",
+        format_tip_reference(tip_url, cl.unsafe_l2.block_info.number, public_tip_block),
+    );
+
     table.print()?;
     Ok(())
+}
+
+fn format_tip_reference(url: &str, local: u64, public: Option<u64>) -> String {
+    let Some(public) = public else {
+        return format!("unavailable (url={url} fetch failed)");
+    };
+    let local_i = i64::try_from(local).unwrap_or(i64::MAX);
+    let public_i = i64::try_from(public).unwrap_or(i64::MAX);
+    let delta = public_i.saturating_sub(local_i);
+    let status = if delta.abs() <= TIP_CAUGHT_UP_THRESHOLD {
+        "caught_up"
+    } else if delta > 0 {
+        "behind"
+    } else {
+        "ahead"
+    };
+    format!("#{public} (url={url}) delta={delta} ({status})")
 }
 
 fn format_block_info(b: &BlockInfo) -> String {
@@ -225,10 +356,17 @@ mod tests {
     }
 
     #[test]
-    fn sync_status_json_serializes_camelcase_with_lag() {
+    fn sync_status_json_serializes_camelcase_with_lag_and_tip_reference() {
         let report =
             SyncStatusReport { cl: sample_status(), el: alloy_rpc_types_eth::SyncStatus::None };
-        let summary = SyncStatusJson::from_report("mainnet", &report);
+        // Public reference 2 blocks ahead of local — within the caught-up
+        // threshold (5).
+        let summary = SyncStatusJson::from_report(
+            "mainnet",
+            &report,
+            "https://mainnet.base.org/",
+            Some(18_432_102),
+        );
         let value: serde_json::Value = serde_json::to_value(&summary).unwrap();
 
         assert_eq!(value["network"], "mainnet");
@@ -244,6 +382,11 @@ mod tests {
         assert_eq!(value["l1Safe"]["number"], 20_123_400);
         assert_eq!(value["l1Finalized"]["number"], 20_123_000);
         assert!(value["unsafeL2"]["timestamp"]["utc"].as_str().unwrap().ends_with('Z'));
+
+        assert_eq!(value["tipReference"]["url"], "https://mainnet.base.org/");
+        assert_eq!(value["tipReference"]["blockNumber"], 18_432_102);
+        assert_eq!(value["tipReference"]["deltaBlocks"], 2);
+        assert_eq!(value["tipReference"]["status"], "caught_up");
     }
 
     #[test]
@@ -254,8 +397,107 @@ mod tests {
         status.unsafe_l2 = sample_l2(100, 1_000);
         status.safe_l2 = sample_l2(200, 2_000);
         let report = SyncStatusReport { cl: status, el: alloy_rpc_types_eth::SyncStatus::None };
-        let summary = SyncStatusJson::from_report("mainnet", &report);
+        let summary = SyncStatusJson::from_report("mainnet", &report, "https://example/", None);
         assert_eq!(summary.safe_lag_seconds, 0);
         assert_eq!(summary.safe_lag_blocks, 0);
+    }
+
+    #[test]
+    fn tip_reference_classifies_behind_when_local_significantly_behind_public() {
+        // Local at 18,432,100; public at 18,432,500 → 400 blocks behind.
+        let report =
+            SyncStatusReport { cl: sample_status(), el: alloy_rpc_types_eth::SyncStatus::None };
+        let summary = SyncStatusJson::from_report(
+            "mainnet",
+            &report,
+            "https://mainnet.base.org/",
+            Some(18_432_500),
+        );
+        let value: serde_json::Value = serde_json::to_value(&summary).unwrap();
+
+        assert_eq!(value["tipReference"]["deltaBlocks"], 400);
+        assert_eq!(value["tipReference"]["status"], "behind");
+    }
+
+    #[test]
+    fn tip_reference_classifies_ahead_when_local_ahead_of_public() {
+        // Local at 18,432,100; public at 18,431,700 → 400 ahead (negative delta).
+        let report =
+            SyncStatusReport { cl: sample_status(), el: alloy_rpc_types_eth::SyncStatus::None };
+        let summary = SyncStatusJson::from_report(
+            "mainnet",
+            &report,
+            "https://mainnet.base.org/",
+            Some(18_431_700),
+        );
+        let value: serde_json::Value = serde_json::to_value(&summary).unwrap();
+
+        assert_eq!(value["tipReference"]["deltaBlocks"], -400);
+        assert_eq!(value["tipReference"]["status"], "ahead");
+    }
+
+    #[test]
+    fn tip_reference_unavailable_when_public_block_is_none() {
+        let report =
+            SyncStatusReport { cl: sample_status(), el: alloy_rpc_types_eth::SyncStatus::None };
+        let summary =
+            SyncStatusJson::from_report("mainnet", &report, "https://mainnet.base.org/", None);
+        let value: serde_json::Value = serde_json::to_value(&summary).unwrap();
+
+        assert!(value["tipReference"]["blockNumber"].is_null());
+        assert!(value["tipReference"]["deltaBlocks"].is_null());
+        assert_eq!(value["tipReference"]["status"], "unavailable");
+        assert_eq!(value["tipReference"]["url"], "https://mainnet.base.org/");
+    }
+
+    #[test]
+    fn el_sync_info_includes_remaining_and_processed_when_syncing() {
+        use alloy_primitives::U256;
+        let info = Box::new(alloy_rpc_types_eth::SyncInfo {
+            starting_block: U256::from(1_000u64),
+            current_block: U256::from(1_500u64),
+            highest_block: U256::from(2_000u64),
+            warp_chunks_amount: None,
+            warp_chunks_processed: None,
+            stages: None,
+        });
+        let report = SyncStatusReport {
+            cl: sample_status(),
+            el: alloy_rpc_types_eth::SyncStatus::Info(info),
+        };
+        let summary =
+            SyncStatusJson::from_report("mainnet", &report, "https://example/", Some(18_432_100));
+        let value: serde_json::Value = serde_json::to_value(&summary).unwrap();
+
+        assert_eq!(value["elActivelySyncing"], true);
+        assert_eq!(value["elSyncInfo"]["startingBlock"], 1_000);
+        assert_eq!(value["elSyncInfo"]["currentBlock"], 1_500);
+        assert_eq!(value["elSyncInfo"]["highestBlock"], 2_000);
+        assert_eq!(value["elSyncInfo"]["processedBlocks"], 500);
+        assert_eq!(value["elSyncInfo"]["remainingBlocks"], 500);
+    }
+
+    #[test]
+    fn el_sync_info_saturates_when_current_exceeds_highest() {
+        // Pathological: current > highest (e.g. RPC reordering during a
+        // probe). remaining_blocks must saturate to 0, not underflow.
+        use alloy_primitives::U256;
+        let info = Box::new(alloy_rpc_types_eth::SyncInfo {
+            starting_block: U256::from(1_000u64),
+            current_block: U256::from(2_500u64),
+            highest_block: U256::from(2_000u64),
+            warp_chunks_amount: None,
+            warp_chunks_processed: None,
+            stages: None,
+        });
+        let report = SyncStatusReport {
+            cl: sample_status(),
+            el: alloy_rpc_types_eth::SyncStatus::Info(info),
+        };
+        let summary = SyncStatusJson::from_report("mainnet", &report, "https://example/", None);
+        let value: serde_json::Value = serde_json::to_value(&summary).unwrap();
+
+        assert_eq!(value["elSyncInfo"]["processedBlocks"], 1_500);
+        assert_eq!(value["elSyncInfo"]["remainingBlocks"], 0);
     }
 }

--- a/bin/basectl/src/sync_status.rs
+++ b/bin/basectl/src/sync_status.rs
@@ -14,16 +14,12 @@ use basectl_cli::{
 use serde::Serialize;
 use url::Url;
 
-/// Threshold (in blocks) below which the local node is treated as caught up
-/// with the public reference RPC. Strawman — ~10s of network jitter at 2s
-/// block time. Tunable based on Datadog/on-call feedback.
-const TIP_CAUGHT_UP_THRESHOLD: i64 = 5;
-
 /// Runs the `basectl sync-status` subcommand.
 pub(crate) async fn run(
     config: MonitoringConfig,
     el_rpc_override: Option<Url>,
     cl_rpc_override: Option<Url>,
+    tip_tolerance: u64,
     json: bool,
     raw: bool,
 ) -> Result<()> {
@@ -43,11 +39,18 @@ pub(crate) async fn run(
     match (json, raw) {
         (true, true) => JsonOutput::print(&report.cl)?,
         (true, false) => {
-            let summary =
-                SyncStatusJson::from_report(&config.name, &report, tip_url, public_tip_block);
+            let summary = SyncStatusJson::from_report(
+                &config.name,
+                &report,
+                tip_url,
+                public_tip_block,
+                tip_tolerance,
+            );
             JsonOutput::print(&summary)?;
         }
-        (false, _) => print_pretty(&config.name, &report, tip_url, public_tip_block)?,
+        (false, _) => {
+            print_pretty(&config.name, &report, tip_url, public_tip_block, tip_tolerance)?;
+        }
     }
     Ok(())
 }
@@ -99,6 +102,7 @@ impl SyncStatusJson {
         report: &SyncStatusReport,
         tip_url: &str,
         public_tip_block: Option<u64>,
+        tip_tolerance: u64,
     ) -> Self {
         let cl = &report.cl;
         let safe_lag_seconds =
@@ -127,6 +131,7 @@ impl SyncStatusJson {
             tip_url,
             cl.unsafe_l2.block_info.number,
             public_tip_block,
+            tip_tolerance,
         );
         Self {
             network: network.to_string(),
@@ -201,11 +206,12 @@ struct TipReferenceJson {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "snake_case")]
 enum TipStatus {
-    /// Local within `±TIP_CAUGHT_UP_THRESHOLD` blocks of the public reference.
+    /// Local within `±tolerance` blocks of the public reference (configurable
+    /// via `--tip-tolerance`).
     CaughtUp,
-    /// Local is more than `TIP_CAUGHT_UP_THRESHOLD` blocks behind the reference.
+    /// Local is more than `tolerance` blocks behind the reference.
     Behind,
-    /// Local is more than `TIP_CAUGHT_UP_THRESHOLD` blocks ahead of the reference.
+    /// Local is more than `tolerance` blocks ahead of the reference.
     Ahead,
     /// Public reference fetch failed; comparison not available.
     Unavailable,
@@ -226,7 +232,7 @@ impl TipStatus {
 }
 
 impl TipReferenceJson {
-    fn from_local_and_public(url: &str, local: u64, public: Option<u64>) -> Self {
+    fn from_local_and_public(url: &str, local: u64, public: Option<u64>, tolerance: u64) -> Self {
         let Some(public) = public else {
             return Self {
                 url: url.to_string(),
@@ -240,8 +246,9 @@ impl TipReferenceJson {
         // real chain heights are always well under i64::MAX.
         let local_i = i64::try_from(local).unwrap_or(i64::MAX);
         let public_i = i64::try_from(public).unwrap_or(i64::MAX);
+        let tolerance_i = i64::try_from(tolerance).unwrap_or(i64::MAX);
         let delta = public_i.saturating_sub(local_i);
-        let status = if delta.abs() <= TIP_CAUGHT_UP_THRESHOLD {
+        let status = if delta.abs() <= tolerance_i {
             TipStatus::CaughtUp
         } else if delta > 0 {
             TipStatus::Behind
@@ -257,6 +264,7 @@ fn print_pretty(
     report: &SyncStatusReport,
     tip_url: &str,
     public_tip_block: Option<u64>,
+    tip_tolerance: u64,
 ) -> Result<()> {
     let cl = &report.cl;
     let mut table = KeyValueTable::new();
@@ -306,18 +314,23 @@ fn print_pretty(
 
     table.row(
         "tip_reference",
-        format_tip_reference(tip_url, cl.unsafe_l2.block_info.number, public_tip_block),
+        format_tip_reference(
+            tip_url,
+            cl.unsafe_l2.block_info.number,
+            public_tip_block,
+            tip_tolerance,
+        ),
     );
 
     table.print()?;
     Ok(())
 }
 
-fn format_tip_reference(url: &str, local: u64, public: Option<u64>) -> String {
+fn format_tip_reference(url: &str, local: u64, public: Option<u64>, tolerance: u64) -> String {
     // Single source of truth for delta math + classification:
     // `TipReferenceJson::from_local_and_public`. Build the JSON struct and
     // read its fields rather than re-deriving the same logic here.
-    let tip = TipReferenceJson::from_local_and_public(url, local, public);
+    let tip = TipReferenceJson::from_local_and_public(url, local, public, tolerance);
     match (tip.block_number, tip.delta_blocks) {
         (Some(block), Some(delta)) => {
             format!("#{block} (url={url}) delta={delta} ({})", tip.status.as_str())
@@ -370,12 +383,13 @@ mod tests {
         let report =
             SyncStatusReport { cl: sample_status(), el: alloy_rpc_types_eth::SyncStatus::None };
         // Public reference 2 blocks ahead of local — within the caught-up
-        // threshold (5).
+        // tolerance (5).
         let summary = SyncStatusJson::from_report(
             "mainnet",
             &report,
             "https://mainnet.base.org/",
             Some(18_432_102),
+            5,
         );
         let value: serde_json::Value = serde_json::to_value(&summary).unwrap();
 
@@ -407,7 +421,7 @@ mod tests {
         status.unsafe_l2 = sample_l2(100, 1_000);
         status.safe_l2 = sample_l2(200, 2_000);
         let report = SyncStatusReport { cl: status, el: alloy_rpc_types_eth::SyncStatus::None };
-        let summary = SyncStatusJson::from_report("mainnet", &report, "https://example/", None);
+        let summary = SyncStatusJson::from_report("mainnet", &report, "https://example/", None, 5);
         assert_eq!(summary.safe_lag_seconds, 0);
         assert_eq!(summary.safe_lag_blocks, 0);
     }
@@ -422,6 +436,7 @@ mod tests {
             &report,
             "https://mainnet.base.org/",
             Some(18_432_500),
+            5,
         );
         let value: serde_json::Value = serde_json::to_value(&summary).unwrap();
 
@@ -439,6 +454,7 @@ mod tests {
             &report,
             "https://mainnet.base.org/",
             Some(18_431_700),
+            5,
         );
         let value: serde_json::Value = serde_json::to_value(&summary).unwrap();
 
@@ -451,7 +467,7 @@ mod tests {
         let report =
             SyncStatusReport { cl: sample_status(), el: alloy_rpc_types_eth::SyncStatus::None };
         let summary =
-            SyncStatusJson::from_report("mainnet", &report, "https://mainnet.base.org/", None);
+            SyncStatusJson::from_report("mainnet", &report, "https://mainnet.base.org/", None, 5);
         let value: serde_json::Value = serde_json::to_value(&summary).unwrap();
 
         assert!(value["tipReference"]["blockNumber"].is_null());
@@ -475,8 +491,13 @@ mod tests {
             cl: sample_status(),
             el: alloy_rpc_types_eth::SyncStatus::Info(info),
         };
-        let summary =
-            SyncStatusJson::from_report("mainnet", &report, "https://example/", Some(18_432_100));
+        let summary = SyncStatusJson::from_report(
+            "mainnet",
+            &report,
+            "https://example/",
+            Some(18_432_100),
+            5,
+        );
         let value: serde_json::Value = serde_json::to_value(&summary).unwrap();
 
         assert_eq!(value["elActivelySyncing"], true);
@@ -504,10 +525,30 @@ mod tests {
             cl: sample_status(),
             el: alloy_rpc_types_eth::SyncStatus::Info(info),
         };
-        let summary = SyncStatusJson::from_report("mainnet", &report, "https://example/", None);
+        let summary = SyncStatusJson::from_report("mainnet", &report, "https://example/", None, 5);
         let value: serde_json::Value = serde_json::to_value(&summary).unwrap();
 
         assert_eq!(value["elSyncInfo"]["processedBlocks"], 1_500);
         assert_eq!(value["elSyncInfo"]["remainingBlocks"], 0);
+    }
+
+    #[test]
+    fn tip_reference_tolerance_widens_caught_up_band() {
+        // Same fixture as the "behind" test (delta = 400) but with tolerance
+        // bumped to 500 — classification flips to caught_up, demonstrating
+        // that the --tip-tolerance flag actually controls the boundary.
+        let report =
+            SyncStatusReport { cl: sample_status(), el: alloy_rpc_types_eth::SyncStatus::None };
+        let summary = SyncStatusJson::from_report(
+            "mainnet",
+            &report,
+            "https://mainnet.base.org/",
+            Some(18_432_500),
+            500,
+        );
+        let value: serde_json::Value = serde_json::to_value(&summary).unwrap();
+
+        assert_eq!(value["tipReference"]["deltaBlocks"], 400);
+        assert_eq!(value["tipReference"]["status"], "caught_up");
     }
 }

--- a/bin/basectl/src/sync_status.rs
+++ b/bin/basectl/src/sync_status.rs
@@ -1,0 +1,300 @@
+//! Implementation of the `basectl sync-status` subcommand.
+
+use std::time::Duration;
+
+use alloy_primitives::B256;
+use alloy_rpc_types_eth::SyncStatus as EthSyncStatus;
+use anyhow::{Result, anyhow};
+use base_protocol::{BlockInfo, L2BlockInfo};
+use basectl_cli::{
+    JsonOutput, KeyValueTable, MonitoringConfig, SyncStatusReport, fetch_sync_status,
+    format_duration, format_unix_timestamp,
+};
+use chrono::{DateTime, Local, SecondsFormat};
+use serde::Serialize;
+use url::Url;
+
+/// Runs the `basectl sync-status` subcommand.
+pub(crate) async fn run(
+    config: MonitoringConfig,
+    el_rpc_override: Option<Url>,
+    cl_rpc_override: Option<Url>,
+    json: bool,
+    raw: bool,
+) -> Result<()> {
+    let el_rpc = el_rpc_override.unwrap_or_else(|| config.rpc.clone());
+    let cl_rpc = resolve_cl_rpc(&config, cl_rpc_override.as_ref())?;
+    let report = fetch_sync_status(&el_rpc, &cl_rpc).await?;
+    match (json, raw) {
+        (true, true) => JsonOutput::print(&report.cl)?,
+        (true, false) => {
+            let summary = SyncStatusJson::from_report(&config.name, &report);
+            JsonOutput::print(&summary)?;
+        }
+        (false, _) => print_pretty(&config.name, &report)?,
+    }
+    Ok(())
+}
+
+/// Resolves the consensus-node RPC URL with precedence:
+/// `--cl-rpc` flag → `MonitoringConfig.consensus_node_rpc` → clear error.
+///
+/// The mainnet and sepolia presets ship `consensus_node_rpc: None`, so
+/// non-devnet users must supply the URL explicitly.
+fn resolve_cl_rpc(config: &MonitoringConfig, override_url: Option<&Url>) -> Result<Url> {
+    if let Some(u) = override_url {
+        return Ok(u.clone());
+    }
+    config.consensus_node_rpc.clone().ok_or_else(|| {
+        anyhow!(
+            "sync-status needs a consensus-node RPC URL.\n\
+             The '{}' config does not set `consensus_node_rpc`.\n\
+             Override with `--cl-rpc <url>` or set `consensus_node_rpc` in your YAML config.",
+            config.name
+        )
+    })
+}
+
+/// Humanized JSON shape for `basectl sync-status --json`.
+///
+/// Decoded numerics, nested timestamp objects, and a precomputed `safeLag*`
+/// pair so consumers don't have to re-derive lag from raw timestamps.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct SyncStatusJson {
+    network: String,
+    el_actively_syncing: bool,
+    el_sync_info: Option<ElSyncInfoJson>,
+    unsafe_l2: HeadJson,
+    safe_l2: HeadJson,
+    finalized_l2: HeadJson,
+    safe_lag_seconds: u64,
+    safe_lag_blocks: u64,
+    l1_head: HeadJson,
+    l1_safe: HeadJson,
+    l1_finalized: HeadJson,
+}
+
+impl SyncStatusJson {
+    fn from_report(network: &str, report: &SyncStatusReport) -> Self {
+        let cl = &report.cl;
+        let safe_lag_seconds =
+            cl.unsafe_l2.block_info.timestamp.saturating_sub(cl.safe_l2.block_info.timestamp);
+        let safe_lag_blocks =
+            cl.unsafe_l2.block_info.number.saturating_sub(cl.safe_l2.block_info.number);
+        let (el_actively_syncing, el_sync_info) = match &report.el {
+            EthSyncStatus::Info(info) => (
+                true,
+                Some(ElSyncInfoJson {
+                    starting_block: info.starting_block.to::<u64>(),
+                    current_block: info.current_block.to::<u64>(),
+                    highest_block: info.highest_block.to::<u64>(),
+                }),
+            ),
+            EthSyncStatus::None => (false, None),
+        };
+        Self {
+            network: network.to_string(),
+            el_actively_syncing,
+            el_sync_info,
+            unsafe_l2: HeadJson::from_l2(&cl.unsafe_l2),
+            safe_l2: HeadJson::from_l2(&cl.safe_l2),
+            finalized_l2: HeadJson::from_l2(&cl.finalized_l2),
+            safe_lag_seconds,
+            safe_lag_blocks,
+            l1_head: HeadJson::from_l1(&cl.head_l1),
+            l1_safe: HeadJson::from_l1(&cl.safe_l1),
+            l1_finalized: HeadJson::from_l1(&cl.finalized_l1),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct HeadJson {
+    number: u64,
+    hash: B256,
+    timestamp: TimestampJson,
+}
+
+impl HeadJson {
+    fn from_l2(b: &L2BlockInfo) -> Self {
+        Self::from_block_info(&b.block_info)
+    }
+
+    fn from_l1(b: &BlockInfo) -> Self {
+        Self::from_block_info(b)
+    }
+
+    fn from_block_info(b: &BlockInfo) -> Self {
+        Self { number: b.number, hash: b.hash, timestamp: TimestampJson::from_unix(b.timestamp) }
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ElSyncInfoJson {
+    starting_block: u64,
+    current_block: u64,
+    highest_block: u64,
+}
+
+/// Three-form timestamp object: raw unix seconds, UTC RFC 3339, and local
+/// RFC 3339 (operator's machine timezone with offset suffix).
+#[derive(Debug, Clone, Serialize)]
+struct TimestampJson {
+    unix: u64,
+    utc: String,
+    local: String,
+}
+
+impl TimestampJson {
+    fn from_unix(secs: u64) -> Self {
+        let dt = i64::try_from(secs).ok().and_then(|s| DateTime::from_timestamp(s, 0));
+        let utc = dt
+            .map(|t| t.to_rfc3339_opts(SecondsFormat::Secs, true))
+            .unwrap_or_else(|| secs.to_string());
+        let local = dt
+            .map(|t| t.with_timezone(&Local).to_rfc3339_opts(SecondsFormat::Secs, false))
+            .unwrap_or_else(|| secs.to_string());
+        Self { unix: secs, utc, local }
+    }
+}
+
+fn print_pretty(network: &str, report: &SyncStatusReport) -> Result<()> {
+    let cl = &report.cl;
+    let mut table = KeyValueTable::new();
+    table.row("network", network);
+
+    match &report.el {
+        EthSyncStatus::None => {
+            table.row("el_syncing", "false");
+        }
+        EthSyncStatus::Info(info) => {
+            table.row(
+                "el_syncing",
+                format!(
+                    "true (current={} highest={})",
+                    info.current_block.to::<u64>(),
+                    info.highest_block.to::<u64>(),
+                ),
+            );
+        }
+    }
+
+    table
+        .row("unsafe_l2", format_block_info(&cl.unsafe_l2.block_info))
+        .row("safe_l2", format_block_info(&cl.safe_l2.block_info))
+        .row("finalized_l2", format_block_info(&cl.finalized_l2.block_info));
+
+    let lag_seconds =
+        cl.unsafe_l2.block_info.timestamp.saturating_sub(cl.safe_l2.block_info.timestamp);
+    let lag_blocks = cl.unsafe_l2.block_info.number.saturating_sub(cl.safe_l2.block_info.number);
+    table.row(
+        "safe_lag",
+        format!(
+            "{} ({} blocks behind unsafe)",
+            format_duration(Duration::from_secs(lag_seconds)),
+            lag_blocks,
+        ),
+    );
+
+    table
+        .row("l1_head", format_block_info(&cl.head_l1))
+        .row("l1_safe", format_block_info(&cl.safe_l1))
+        .row("l1_finalized", format_block_info(&cl.finalized_l1));
+
+    table.print()?;
+    Ok(())
+}
+
+fn format_block_info(b: &BlockInfo) -> String {
+    format!("#{} ts={} ({})", b.number, b.timestamp, format_unix_timestamp(b.timestamp))
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_eips::BlockNumHash;
+    use alloy_primitives::B256;
+    use base_protocol::{BlockInfo, L2BlockInfo, SyncStatus};
+    use basectl_cli::SyncStatusReport;
+
+    use super::{SyncStatusJson, TimestampJson};
+
+    fn sample_l2(block: u64, ts: u64) -> L2BlockInfo {
+        L2BlockInfo::new(
+            BlockInfo::new(B256::repeat_byte((block & 0xff) as u8), block, B256::ZERO, ts),
+            BlockNumHash { number: block / 2, hash: B256::ZERO },
+            0,
+        )
+    }
+
+    fn sample_l1(block: u64, ts: u64) -> BlockInfo {
+        BlockInfo::new(B256::repeat_byte((block & 0xff) as u8), block, B256::ZERO, ts)
+    }
+
+    fn sample_status() -> SyncStatus {
+        SyncStatus {
+            current_l1: sample_l1(20_123_400, 1_780_270_000),
+            current_l1_finalized: sample_l1(20_123_000, 1_780_265_000),
+            head_l1: sample_l1(20_123_456, 1_780_270_500),
+            safe_l1: sample_l1(20_123_400, 1_780_270_000),
+            finalized_l1: sample_l1(20_123_000, 1_780_265_000),
+            unsafe_l2: sample_l2(18_432_100, 1_780_274_000),
+            safe_l2: sample_l2(18_431_900, 1_780_273_580),
+            finalized_l2: sample_l2(18_425_000, 1_780_260_000),
+            local_safe_l2: L2BlockInfo::default(),
+        }
+    }
+
+    #[test]
+    fn sync_status_json_serializes_camelcase_with_lag() {
+        let report =
+            SyncStatusReport { cl: sample_status(), el: alloy_rpc_types_eth::SyncStatus::None };
+        let summary = SyncStatusJson::from_report("mainnet", &report);
+        let value: serde_json::Value = serde_json::to_value(&summary).unwrap();
+
+        assert_eq!(value["network"], "mainnet");
+        assert_eq!(value["elActivelySyncing"], false);
+        assert!(value["elSyncInfo"].is_null());
+        assert_eq!(value["unsafeL2"]["number"], 18_432_100);
+        assert_eq!(value["safeL2"]["number"], 18_431_900);
+        assert_eq!(value["finalizedL2"]["number"], 18_425_000);
+        // unsafe_ts - safe_ts = 1_780_274_000 - 1_780_273_580 = 420
+        assert_eq!(value["safeLagSeconds"], 420);
+        assert_eq!(value["safeLagBlocks"], 200);
+        assert_eq!(value["l1Head"]["number"], 20_123_456);
+        assert_eq!(value["l1Safe"]["number"], 20_123_400);
+        assert_eq!(value["l1Finalized"]["number"], 20_123_000);
+        assert!(value["unsafeL2"]["timestamp"]["utc"].as_str().unwrap().ends_with('Z'));
+    }
+
+    #[test]
+    fn sync_status_json_handles_safe_ahead_of_unsafe_without_underflow() {
+        // Pathological: safe head reported newer than unsafe (shouldn't happen
+        // in practice, but the lag math must saturate, not panic).
+        let mut status = sample_status();
+        status.unsafe_l2 = sample_l2(100, 1_000);
+        status.safe_l2 = sample_l2(200, 2_000);
+        let report = SyncStatusReport { cl: status, el: alloy_rpc_types_eth::SyncStatus::None };
+        let summary = SyncStatusJson::from_report("mainnet", &report);
+        assert_eq!(summary.safe_lag_seconds, 0);
+        assert_eq!(summary.safe_lag_blocks, 0);
+    }
+
+    #[test]
+    fn timestamp_json_renders_three_forms() {
+        let ts = TimestampJson::from_unix(1_780_614_804);
+        assert_eq!(ts.unix, 1_780_614_804);
+        assert!(ts.utc.ends_with('Z'), "expected UTC suffix Z, got {}", ts.utc);
+        assert!(ts.utc.starts_with("2026-06-04"), "expected UTC date prefix, got {}", ts.utc);
+    }
+
+    #[test]
+    fn timestamp_json_falls_back_on_u64_overflow() {
+        let oversize = TimestampJson::from_unix(u64::MAX);
+        assert_eq!(oversize.unix, u64::MAX);
+        assert_eq!(oversize.utc, u64::MAX.to_string());
+        assert_eq!(oversize.local, u64::MAX.to_string());
+    }
+}

--- a/crates/infra/basectl/src/lib.rs
+++ b/crates/infra/basectl/src/lib.rs
@@ -15,10 +15,10 @@ mod output;
 pub use output::{
     COLOR_ACTIVE_BORDER, COLOR_BASE_BLUE, COLOR_BURN, COLOR_GAS_FILL, COLOR_GROWTH,
     COLOR_ROW_HIGHLIGHTED, COLOR_ROW_SELECTED, COLOR_TARGET, JsonOutput, KeyValueTable,
-    L1BlocksTableParams, backlog_size_color, block_color, block_color_bright, build_gas_bar,
-    format_bytes, format_duration, format_gas, format_gwei, format_rate, format_unix_timestamp,
-    render_da_backlog_bar, render_gas_usage_bar, render_l1_blocks_table, target_usage_color,
-    time_diff_color, truncate_block_number,
+    L1BlocksTableParams, TimestampJson, backlog_size_color, block_color, block_color_bright,
+    build_gas_bar, format_bytes, format_duration, format_gas, format_gwei, format_rate,
+    format_unix_timestamp, render_da_backlog_bar, render_gas_usage_bar, render_l1_blocks_table,
+    target_usage_color, time_diff_color, truncate_block_number,
 };
 
 mod config;

--- a/crates/infra/basectl/src/lib.rs
+++ b/crates/infra/basectl/src/lib.rs
@@ -32,14 +32,14 @@ pub use rpc::{
     BacklogBlock, BacklogFetchResult, BacklogProgress, BlockDaInfo, ConductorNodeStatus,
     ConductorPollUpdate, InitialBacklog, L1BlockInfo, L1ConnectionMode, LatestProposal,
     PausedPeers, PodGroupStatus, PodStatus, PodsPoller, PodsSnapshot, ProofsSnapshot,
-    TimestampedFlashblock, TxSummary, ValidatorNodeStatus, conductor_pause_all_nodes,
-    conductor_pause_node, conductor_resume_all_nodes, conductor_resume_node,
-    decode_flashblock_transactions, fetch_block, fetch_block_transactions,
+    SyncStatusReport, TimestampedFlashblock, TxSummary, ValidatorNodeStatus,
+    conductor_pause_all_nodes, conductor_pause_node, conductor_resume_all_nodes,
+    conductor_resume_node, decode_flashblock_transactions, fetch_block, fetch_block_transactions,
     fetch_full_system_config, fetch_initial_backlog_with_progress, fetch_safe_and_latest,
-    pause_sequencer_node, restart_conductor_node, run_block_fetcher, run_conductor_poller,
-    run_flashblock_ws, run_flashblock_ws_timestamped, run_l1_blob_watcher, run_pods_poller,
-    run_proofs_poller, run_safe_head_poller, run_validator_poller, start_sequencer_node,
-    stop_sequencer_node, transfer_conductor_leader, unpause_sequencer_node,
+    fetch_sync_status, pause_sequencer_node, restart_conductor_node, run_block_fetcher,
+    run_conductor_poller, run_flashblock_ws, run_flashblock_ws_timestamped, run_l1_blob_watcher,
+    run_pods_poller, run_proofs_poller, run_safe_head_poller, run_validator_poller,
+    start_sequencer_node, stop_sequencer_node, transfer_conductor_leader, unpause_sequencer_node,
 };
 
 mod tui;

--- a/crates/infra/basectl/src/output/json.rs
+++ b/crates/infra/basectl/src/output/json.rs
@@ -3,6 +3,7 @@
 use std::io::{self, Write};
 
 use anyhow::Result;
+use chrono::{DateTime, Local, SecondsFormat};
 use serde::Serialize;
 
 /// JSON writer for non-TUI command output.
@@ -25,11 +26,48 @@ impl JsonOutput {
     }
 }
 
+/// Three-form timestamp object for `--json` command output: raw unix
+/// seconds, UTC RFC 3339, and local RFC 3339 (operator's machine timezone
+/// with offset suffix).
+///
+/// Shared by every non-TUI subcommand that surfaces a Unix timestamp in
+/// its humanized JSON shape — saves consumers from re-deriving wall-clock
+/// time from raw seconds.
+#[derive(Debug, Clone, Serialize)]
+pub struct TimestampJson {
+    /// Raw Unix seconds since epoch.
+    pub unix: u64,
+    /// RFC 3339 UTC string (e.g. `2026-06-04T18:00:00Z`).
+    pub utc: String,
+    /// RFC 3339 string in the operator's local timezone with offset suffix.
+    pub local: String,
+}
+
+impl TimestampJson {
+    /// Builds a `TimestampJson` from raw Unix seconds.
+    ///
+    /// Values above `i64::MAX` (impossible for real chain timestamps —
+    /// year 9999 is still ~3 orders of magnitude under) fall back to the
+    /// raw decimal in both `utc` and `local`, instead of silently
+    /// wrapping to a fabricated pre-epoch RFC 3339 string under an
+    /// `as i64` cast.
+    pub fn from_unix(secs: u64) -> Self {
+        let dt = i64::try_from(secs).ok().and_then(|s| DateTime::from_timestamp(s, 0));
+        let utc = dt
+            .map(|t| t.to_rfc3339_opts(SecondsFormat::Secs, true))
+            .unwrap_or_else(|| secs.to_string());
+        let local = dt
+            .map(|t| t.with_timezone(&Local).to_rfc3339_opts(SecondsFormat::Secs, false))
+            .unwrap_or_else(|| secs.to_string());
+        Self { unix: secs, utc, local }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use serde_json::json;
 
-    use super::JsonOutput;
+    use super::{JsonOutput, TimestampJson};
 
     #[test]
     fn write_emits_pretty_json_with_trailing_newline() {
@@ -38,5 +76,30 @@ mod tests {
         let rendered = String::from_utf8(buf).unwrap();
 
         assert_eq!(rendered, "{\n  \"k\": 1\n}\n");
+    }
+
+    #[test]
+    fn timestamp_json_renders_three_forms() {
+        let ts = TimestampJson::from_unix(1_780_614_804);
+
+        assert_eq!(ts.unix, 1_780_614_804);
+        assert!(ts.utc.ends_with('Z'), "expected UTC suffix Z, got {}", ts.utc);
+        assert!(ts.utc.starts_with("2026-06-04"), "expected UTC date prefix, got {}", ts.utc);
+        let local_has_offset =
+            ts.local.contains('+') || ts.local.matches('-').count() >= 3 || ts.local.ends_with('Z');
+        assert!(local_has_offset, "expected local RFC 3339 with offset, got {}", ts.local);
+    }
+
+    #[test]
+    fn timestamp_json_falls_back_on_u64_overflow() {
+        // u64 values above i64::MAX would silently wrap to a negative i64 under
+        // an `as i64` cast, producing a misleading pre-epoch RFC 3339 string.
+        // The try_from guard converts that case to None, triggering the raw
+        // seconds fallback for both utc and local.
+        let oversize = TimestampJson::from_unix(u64::MAX);
+
+        assert_eq!(oversize.unix, u64::MAX);
+        assert_eq!(oversize.utc, u64::MAX.to_string());
+        assert_eq!(oversize.local, u64::MAX.to_string());
     }
 }

--- a/crates/infra/basectl/src/output/mod.rs
+++ b/crates/infra/basectl/src/output/mod.rs
@@ -9,7 +9,7 @@ pub use format::{
 };
 
 mod json;
-pub use json::JsonOutput;
+pub use json::{JsonOutput, TimestampJson};
 
 mod render;
 pub use render::{

--- a/crates/infra/basectl/src/rpc/mod.rs
+++ b/crates/infra/basectl/src/rpc/mod.rs
@@ -32,6 +32,6 @@ pub use pods::{PodGroupStatus, PodStatus, PodsPoller, PodsSnapshot, run_pods_pol
 
 mod rollup;
 pub use rollup::{
-    LatestProposal, ProofsSnapshot, ValidatorNodeStatus, fetch_safe_and_latest, run_proofs_poller,
-    run_safe_head_poller, run_validator_poller,
+    LatestProposal, ProofsSnapshot, SyncStatusReport, ValidatorNodeStatus, fetch_safe_and_latest,
+    fetch_sync_status, run_proofs_poller, run_safe_head_poller, run_validator_poller,
 };

--- a/crates/infra/basectl/src/rpc/rollup.rs
+++ b/crates/infra/basectl/src/rpc/rollup.rs
@@ -2,10 +2,11 @@ use std::{sync::Arc, time::Duration};
 
 use alloy_primitives::{Address, B256};
 use alloy_provider::{Provider, ProviderBuilder};
-use alloy_rpc_types_eth::BlockNumberOrTag;
+use alloy_rpc_types_eth::{BlockNumberOrTag, SyncStatus as EthSyncStatus};
 use alloy_sol_types::sol;
-use anyhow::Result;
+use anyhow::{Context, Result};
 use base_consensus_rpc::{BaseP2PApiClient, RollupNodeApiClient};
+use base_protocol::SyncStatus;
 use jsonrpsee::{core::client::ClientT, http_client::HttpClientBuilder, rpc_params};
 use tokio::sync::mpsc;
 use tracing::warn;
@@ -15,6 +16,52 @@ use crate::{
     config::{ProofsConfig, ValidatorNodeConfig},
     tui::Toast,
 };
+
+/// Combined CL `optimism_syncStatus` + EL `eth_syncing` snapshot.
+///
+/// The CL `SyncStatus` carries every L1/L2 head ref the rollup node knows
+/// about, including timestamps on `unsafe_l2`/`safe_l2`/`finalized_l2` via
+/// `L2BlockInfo.block_info.timestamp`. The EL `EthSyncStatus` is alloy's
+/// typed `eth_syncing` response (`Info(SyncInfo)` while syncing, `None`
+/// otherwise).
+///
+/// Doctor (Phase 2.8) reuses this to compute `unsafe.timestamp -
+/// safe.timestamp` for its safe-head-recency check, gated on whether the
+/// EL is actively syncing.
+#[derive(Debug, Clone)]
+pub struct SyncStatusReport {
+    /// Rollup node `optimism_syncStatus` response.
+    pub cl: SyncStatus,
+    /// Execution-layer `eth_syncing` response.
+    pub el: EthSyncStatus,
+}
+
+/// Fetches a combined CL + EL sync-status snapshot.
+///
+/// Calls `optimism_syncStatus` against the consensus-node RPC and
+/// `eth_syncing` against the execution-layer RPC in parallel; either error
+/// short-circuits the call.
+pub async fn fetch_sync_status(rpc: &Url, cl_rpc: &Url) -> Result<SyncStatusReport> {
+    let cl_client = HttpClientBuilder::default()
+        .request_timeout(Duration::from_secs(10))
+        .build(cl_rpc.as_str())
+        .with_context(|| format!("connecting to consensus node RPC at {cl_rpc}"))?;
+    let el_provider = ProviderBuilder::new()
+        .connect(rpc.as_str())
+        .await
+        .with_context(|| format!("connecting to L2 EL RPC at {rpc}"))?;
+    let (cl, el) = tokio::try_join!(
+        async {
+            RollupNodeApiClient::sync_status(&cl_client)
+                .await
+                .with_context(|| format!("fetching optimism_syncStatus from {cl_rpc}"))
+        },
+        async {
+            el_provider.syncing().await.with_context(|| format!("fetching eth_syncing from {rpc}"))
+        },
+    )?;
+    Ok(SyncStatusReport { cl, el })
+}
 
 /// Fetches the safe and latest L2 block numbers.
 pub async fn fetch_safe_and_latest(l2_rpc: &str) -> Result<(u64, u64)> {


### PR DESCRIPTION
  ## Summary

  - Adds `basectl sync-status` — joins CL `optimism_syncStatus` with EL `eth_syncing` in a single command. Pretty table by default;
  `--json` for humanized output (decoded numerics, nested timestamps, precomputed `safeLag*`); `--json --raw` for the alloy wire format.
  - Adds the library helper `fetch_sync_status(rpc, cl_rpc) -> Result<SyncStatusReport>` exposing block timestamps + EL sync state.
  - `--cl-rpc` and `--el-rpc` flags let operators target a specific node. The mainnet/sepolia presets ship `consensus_node_rpc: None`, so `--cl-rpc` is required there with a clear error message naming the preset.

  ## Test Plan

  - [x] **Unit tests pass** — 4 new tests in `bin/basectl/src/sync_status.rs` covering JSON output shape, the "safe head ahead of unsafe" guard, and timestamp overflow handling. Full bin suite: 13 passed. Lib suite: 33 passed.
  - [x] **Cargo gates green** — `cargo build -p basectl-cli`, `cargo clippy -p basectl-cli -p basectl --all-targets -- -D warnings`, `cargo test-p basectl-cli`, `cargo +nightly fmt --all -- --check` all clean.
  
  - [x] **Live-network smoke** against an internal Base sepolia node (both EL `:8545` and CL `:7545` overrides) — pretty mode renders all rows correctly; `--json` produces valid jq-pipeable output with precomputed `safeLagSeconds`/`safeLagBlocks`; `--json --raw` emits the alloy `optimism_syncStatus` wire shape (snake_case top-level per OP spec).
  
  - [x] **Error paths exercised** — sepolia preset without `--cl-rpc` fails before any RPC call with a clear actionable message; `--raw` without `--json` errors at clap parse time (`requires = "json"`).
  
  - [x] **Edge cases considered** — handles "safe head reported ahead of unsafe" without panicking or returning garbage (returns lag = 0 instead); `u64::MAX` timestamps fall back to raw seconds instead of silently wrapping to a fake pre-epoch date; both EL `eth_syncing` response variants (`Info(...)` while syncing, `None` when caught up) handled.
  
  - [x] **Live `SyncStatus::Info(...)` arm** — not exercised against live data (sepolia internal node is caught up). Unit test covers the path; will smoke against a fresh / restarted node next time one's available.