### PR TITLE
Make flashblocks ping interval configurable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4384,6 +4384,7 @@ dependencies = [
  "clap",
  "eyre",
  "futures",
+ "humantime",
  "proptest",
  "reth-chainspec",
  "reth-cli",

--- a/crates/execution/cli/Cargo.toml
+++ b/crates/execution/cli/Cargo.toml
@@ -55,6 +55,7 @@ futures.workspace = true
 clap = { workspace = true, features = ["derive", "env"] }
 
 eyre.workspace = true
+humantime.workspace = true
 url.workspace = true
 tokio.workspace = true
 backon.workspace = true

--- a/crates/execution/cli/src/standard_node.rs
+++ b/crates/execution/cli/src/standard_node.rs
@@ -332,9 +332,8 @@ mod tests {
         .args;
 
         let standard_args = StandardNodeArgs::from(args);
-        let config: FlashblocksConfig =
-            <&StandardNodeArgs as Into<Option<FlashblocksConfig>>>::into(&standard_args)
-                .expect("flashblocks config should exist");
+        let config: FlashblocksConfig = Option::<FlashblocksConfig>::from(&standard_args)
+            .expect("flashblocks config should exist");
 
         assert_eq!(config.subscriber_ping_interval, Duration::from_secs(45));
     }

--- a/crates/execution/cli/src/standard_node.rs
+++ b/crates/execution/cli/src/standard_node.rs
@@ -307,10 +307,7 @@ mod tests {
         ])
         .args;
 
-        assert_eq!(
-            args.flashblocks_ping_interval,
-            FlashblocksConfig::DEFAULT_SUBSCRIBER_PING_INTERVAL
-        );
+        assert_eq!(args.flashblocks_ping_interval, Duration::from_secs(30));
     }
 
     #[test]
@@ -320,10 +317,7 @@ mod tests {
             .args;
 
         assert_eq!(args.flashblocks_url, None);
-        assert_eq!(
-            args.flashblocks_ping_interval,
-            FlashblocksConfig::DEFAULT_SUBSCRIBER_PING_INTERVAL
-        );
+        assert_eq!(args.flashblocks_ping_interval, Duration::from_secs(30));
     }
 
     #[test]

--- a/crates/execution/cli/src/standard_node.rs
+++ b/crates/execution/cli/src/standard_node.rs
@@ -333,7 +333,8 @@ mod tests {
 
         let standard_args = StandardNodeArgs::from(args);
         let config: FlashblocksConfig =
-            (&standard_args).into().expect("flashblocks config should exist");
+            <&StandardNodeArgs as Into<Option<FlashblocksConfig>>>::into(&standard_args)
+                .expect("flashblocks config should exist");
 
         assert_eq!(config.subscriber_ping_interval, Duration::from_secs(45));
     }

--- a/crates/execution/cli/src/standard_node.rs
+++ b/crates/execution/cli/src/standard_node.rs
@@ -293,7 +293,7 @@ mod tests {
 
     use super::*;
 
-    #[derive(Parser)]
+    #[derive(Debug, Parser)]
     struct CommandParser<T: Args> {
         #[command(flatten)]
         args: T,

--- a/crates/execution/cli/src/standard_node.rs
+++ b/crates/execution/cli/src/standard_node.rs
@@ -143,7 +143,8 @@ pub struct RpcStandardNodeArgs {
         long = "flashblocks.ping-interval",
         value_name = "FLASHBLOCKS_PING_INTERVAL",
         default_value = "30s",
-        value_parser = humantime::parse_duration
+        value_parser = humantime::parse_duration,
+        requires = "flashblocks_url"
     )]
     pub flashblocks_ping_interval: Duration,
 
@@ -311,13 +312,25 @@ mod tests {
     }
 
     #[test]
-    fn test_flashblocks_ping_interval_does_not_require_flashblocks_url() {
+    fn test_flashblocks_ping_interval_defaults_without_flashblocks_url() {
         let args = CommandParser::<RpcStandardNodeArgs>::try_parse_from(["reth"])
             .expect("default args should parse without flashblocks enabled")
             .args;
 
         assert_eq!(args.flashblocks_url, None);
         assert_eq!(args.flashblocks_ping_interval, Duration::from_secs(30));
+    }
+
+    #[test]
+    fn test_flashblocks_ping_interval_requires_flashblocks_url() {
+        let error = CommandParser::<RpcStandardNodeArgs>::try_parse_from([
+            "reth",
+            "--flashblocks.ping-interval",
+            "45s",
+        ])
+        .expect_err("ping interval should require flashblocks url");
+
+        assert!(error.to_string().contains("--flashblocks-url"));
     }
 
     #[test]

--- a/crates/execution/cli/src/standard_node.rs
+++ b/crates/execution/cli/src/standard_node.rs
@@ -143,7 +143,7 @@ pub struct RpcStandardNodeArgs {
         long = "flashblocks.ping-interval",
         value_name = "FLASHBLOCKS_PING_INTERVAL",
         default_value = "30s",
-        value_parser = parse_positive_duration
+        value_parser = humantime::parse_duration
     )]
     pub flashblocks_ping_interval: Duration,
 
@@ -201,14 +201,6 @@ impl From<&StandardNodeArgs> for TxForwardingConfig {
             .with_max_batch_size(args.tx_forwarding_batch_size)
             .with_max_rps(args.tx_forwarding_max_rps)
     }
-}
-
-fn parse_positive_duration(input: &str) -> Result<Duration, String> {
-    let duration = humantime::parse_duration(input).map_err(|error| error.to_string())?;
-    if duration.is_zero() {
-        return Err("ping interval must be positive".to_string());
-    }
-    Ok(duration)
 }
 
 /// Standard Base execution-node runner wiring.
@@ -326,20 +318,6 @@ mod tests {
 
         assert_eq!(args.flashblocks_url, None);
         assert_eq!(args.flashblocks_ping_interval, Duration::from_secs(30));
-    }
-
-    #[test]
-    fn test_flashblocks_ping_interval_rejects_zero() {
-        let error = CommandParser::<RpcStandardNodeArgs>::try_parse_from([
-            "reth",
-            "--flashblocks-url",
-            "wss://example.com/ws",
-            "--flashblocks.ping-interval",
-            "0s",
-        ])
-        .expect_err("zero ping interval should be rejected");
-
-        assert!(error.to_string().contains("ping interval must be positive"));
     }
 
     #[test]

--- a/crates/execution/cli/src/standard_node.rs
+++ b/crates/execution/cli/src/standard_node.rs
@@ -1,5 +1,7 @@
 //! Standard Base execution-node arguments and runner wiring.
 
+use std::time::Duration;
+
 use base_bundle_extension::BundleExtension;
 use base_flashblocks::FlashblocksConfig;
 use base_flashblocks_node::FlashblocksExtension;
@@ -136,6 +138,15 @@ pub struct RpcStandardNodeArgs {
     #[arg(long = "flashblocks.cached-execution", requires = "flashblocks_url")]
     pub flashblocks_cached_execution: bool,
 
+    /// Interval between flashblocks upstream websocket ping frames.
+    #[arg(
+        long = "flashblocks.ping-interval",
+        value_name = "FLASHBLOCKS_PING_INTERVAL",
+        default_value = "30s",
+        value_parser = humantime::parse_duration
+    )]
+    pub flashblocks_ping_interval: Duration,
+
     /// Enable transaction tracing for mempool-to-block timing analysis
     #[arg(long = "enable-transaction-tracing", value_name = "ENABLE_TRANSACTION_TRACING")]
     pub enable_transaction_tracing: bool,
@@ -171,7 +182,8 @@ impl From<RpcStandardNodeArgs> for StandardNodeArgs {
 impl From<&StandardNodeArgs> for Option<FlashblocksConfig> {
     fn from(args: &StandardNodeArgs) -> Self {
         args.rpc.flashblocks_url.clone().map(|url| {
-            let mut config = FlashblocksConfig::new(url, args.rpc.max_pending_blocks_depth);
+            let mut config = FlashblocksConfig::new(url, args.rpc.max_pending_blocks_depth)
+                .with_subscriber_ping_interval(args.rpc.flashblocks_ping_interval);
             config.cached_execution = args.rpc.flashblocks_cached_execution;
             config
         })
@@ -269,5 +281,66 @@ impl StandardBaseRethNode {
         args: StandardNodeArgs,
     ) -> eyre::Result<LaunchedBaseNode> {
         Self::runner_with_version_metrics(args)?.launch(builder).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use clap::{Args, Parser};
+
+    use super::*;
+
+    #[derive(Parser)]
+    struct CommandParser<T: Args> {
+        #[command(flatten)]
+        args: T,
+    }
+
+    #[test]
+    fn test_flashblocks_ping_interval_defaults_to_30_seconds() {
+        let args = CommandParser::<RpcStandardNodeArgs>::parse_from([
+            "reth",
+            "--flashblocks-url",
+            "wss://example.com/ws",
+        ])
+        .args;
+
+        assert_eq!(
+            args.flashblocks_ping_interval,
+            FlashblocksConfig::DEFAULT_SUBSCRIBER_PING_INTERVAL
+        );
+    }
+
+    #[test]
+    fn test_flashblocks_ping_interval_does_not_require_flashblocks_url() {
+        let args = CommandParser::<RpcStandardNodeArgs>::try_parse_from(["reth"])
+            .expect("default args should parse without flashblocks enabled")
+            .args;
+
+        assert_eq!(args.flashblocks_url, None);
+        assert_eq!(
+            args.flashblocks_ping_interval,
+            FlashblocksConfig::DEFAULT_SUBSCRIBER_PING_INTERVAL
+        );
+    }
+
+    #[test]
+    fn test_flashblocks_ping_interval_flows_into_config() {
+        let args = CommandParser::<RpcStandardNodeArgs>::parse_from([
+            "reth",
+            "--flashblocks-url",
+            "wss://example.com/ws",
+            "--flashblocks.ping-interval",
+            "45s",
+        ])
+        .args;
+
+        let standard_args = StandardNodeArgs::from(args);
+        let config: FlashblocksConfig =
+            (&standard_args).into().expect("flashblocks config should exist");
+
+        assert_eq!(config.subscriber_ping_interval, Duration::from_secs(45));
     }
 }

--- a/crates/execution/cli/src/standard_node.rs
+++ b/crates/execution/cli/src/standard_node.rs
@@ -143,7 +143,7 @@ pub struct RpcStandardNodeArgs {
         long = "flashblocks.ping-interval",
         value_name = "FLASHBLOCKS_PING_INTERVAL",
         default_value = "30s",
-        value_parser = humantime::parse_duration
+        value_parser = parse_positive_duration
     )]
     pub flashblocks_ping_interval: Duration,
 
@@ -201,6 +201,14 @@ impl From<&StandardNodeArgs> for TxForwardingConfig {
             .with_max_batch_size(args.tx_forwarding_batch_size)
             .with_max_rps(args.tx_forwarding_max_rps)
     }
+}
+
+fn parse_positive_duration(input: &str) -> Result<Duration, String> {
+    let duration = humantime::parse_duration(input).map_err(|error| error.to_string())?;
+    if duration.is_zero() {
+        return Err("ping interval must be positive".to_string());
+    }
+    Ok(duration)
 }
 
 /// Standard Base execution-node runner wiring.
@@ -318,6 +326,20 @@ mod tests {
 
         assert_eq!(args.flashblocks_url, None);
         assert_eq!(args.flashblocks_ping_interval, Duration::from_secs(30));
+    }
+
+    #[test]
+    fn test_flashblocks_ping_interval_rejects_zero() {
+        let error = CommandParser::<RpcStandardNodeArgs>::try_parse_from([
+            "reth",
+            "--flashblocks-url",
+            "wss://example.com/ws",
+            "--flashblocks.ping-interval",
+            "0s",
+        ])
+        .expect_err("zero ping interval should be rejected");
+
+        assert!(error.to_string().contains("ping interval must be positive"));
     }
 
     #[test]

--- a/crates/execution/flashblocks-node/src/extension.rs
+++ b/crates/execution/flashblocks-node/src/extension.rs
@@ -37,7 +37,11 @@ impl BaseNodeExtension for FlashblocksExtension {
         };
 
         let state = cfg.state;
-        let mut subscriber = FlashblocksSubscriber::new(Arc::clone(&state), cfg.websocket_url);
+        let mut subscriber = FlashblocksSubscriber::new(
+            Arc::clone(&state),
+            cfg.websocket_url,
+            cfg.subscriber_ping_interval,
+        );
 
         let state_for_canonical = Arc::clone(&state);
         let state_for_rpc = Arc::clone(&state);

--- a/crates/execution/flashblocks/README.md
+++ b/crates/execution/flashblocks/README.md
@@ -42,7 +42,7 @@ base-flashblocks = { git = "https://github.com/base/base" }
 Subscribe to flashblocks and process state updates:
 
 ```rust,ignore
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 
 use base_flashblocks::{
     FlashblocksAPI, FlashblocksState, FlashblocksSubscriber, PendingBlocksAPI,
@@ -56,7 +56,8 @@ let state = Arc::new(FlashblocksState::new(3));
 state.start(provider.clone());
 
 // Connect to the builder's flashblocks WebSocket and forward decoded payloads into state.
-let mut subscriber = FlashblocksSubscriber::new(Arc::clone(&state), flashblocks_url);
+let mut subscriber =
+    FlashblocksSubscriber::new(Arc::clone(&state), flashblocks_url, Duration::from_secs(30));
 subscriber.start();
 
 // Read the current pending snapshot.

--- a/crates/execution/flashblocks/src/config.rs
+++ b/crates/execution/flashblocks/src/config.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 
 use url::Url;
 
@@ -11,6 +11,8 @@ pub struct FlashblocksConfig {
     pub websocket_url: Url,
     /// Maximum number of pending flashblocks to retain in memory.
     pub max_pending_blocks_depth: u64,
+    /// Interval between upstream websocket ping frames.
+    pub subscriber_ping_interval: Duration,
     /// Whether to enable cached execution via the flashblocks-aware engine validator.
     pub cached_execution: bool,
     /// Shared Flashblocks state.
@@ -18,9 +20,27 @@ pub struct FlashblocksConfig {
 }
 
 impl FlashblocksConfig {
+    /// Default interval between upstream websocket ping frames.
+    pub const DEFAULT_SUBSCRIBER_PING_INTERVAL: Duration = Duration::from_secs(30);
+
     /// Create a new Flashblocks configuration.
     pub fn new(websocket_url: Url, max_pending_blocks_depth: u64) -> Self {
         let state = Arc::new(FlashblocksState::new(max_pending_blocks_depth));
-        Self { websocket_url, max_pending_blocks_depth, cached_execution: false, state }
+        Self {
+            websocket_url,
+            max_pending_blocks_depth,
+            subscriber_ping_interval: Self::DEFAULT_SUBSCRIBER_PING_INTERVAL,
+            cached_execution: false,
+            state,
+        }
+    }
+
+    /// Set the interval between upstream websocket ping frames.
+    pub const fn with_subscriber_ping_interval(
+        mut self,
+        subscriber_ping_interval: Duration,
+    ) -> Self {
+        self.subscriber_ping_interval = subscriber_ping_interval;
+        self
     }
 }

--- a/crates/execution/flashblocks/src/config.rs
+++ b/crates/execution/flashblocks/src/config.rs
@@ -20,16 +20,13 @@ pub struct FlashblocksConfig {
 }
 
 impl FlashblocksConfig {
-    /// Default interval between upstream websocket ping frames.
-    pub const DEFAULT_SUBSCRIBER_PING_INTERVAL: Duration = Duration::from_secs(30);
-
     /// Create a new Flashblocks configuration.
     pub fn new(websocket_url: Url, max_pending_blocks_depth: u64) -> Self {
         let state = Arc::new(FlashblocksState::new(max_pending_blocks_depth));
         Self {
             websocket_url,
             max_pending_blocks_depth,
-            subscriber_ping_interval: Self::DEFAULT_SUBSCRIBER_PING_INTERVAL,
+            subscriber_ping_interval: Duration::from_secs(30),
             cached_execution: false,
             state,
         }

--- a/crates/execution/flashblocks/src/config.rs
+++ b/crates/execution/flashblocks/src/config.rs
@@ -37,6 +37,7 @@ impl FlashblocksConfig {
         mut self,
         subscriber_ping_interval: Duration,
     ) -> Self {
+        assert!(!subscriber_ping_interval.is_zero(), "ping interval must be positive");
         self.subscriber_ping_interval = subscriber_ping_interval;
         self
     }

--- a/crates/execution/flashblocks/src/subscription.rs
+++ b/crates/execution/flashblocks/src/subscription.rs
@@ -4,7 +4,10 @@ use std::{sync::Arc, time::Duration};
 
 use base_common_flashblocks::Flashblock;
 use futures::{SinkExt as _, StreamExt};
-use tokio::{sync::mpsc, time::interval};
+use tokio::{
+    sync::mpsc,
+    time::{Instant, interval_at},
+};
 use tokio_tungstenite::{connect_async, tungstenite::protocol::Message};
 use url::Url;
 
@@ -60,7 +63,8 @@ where
                         backoff = Duration::from_secs(1);
                         info!(message = "WebSocket connection established");
 
-                        let mut ping_interval = interval(ping_period);
+                        let mut ping_interval =
+                            interval_at(Instant::now() + ping_period, ping_period);
                         let mut awaiting_pong_resp = false;
 
                         let (mut write, mut read) = ws_stream.split();

--- a/crates/execution/flashblocks/src/subscription.rs
+++ b/crates/execution/flashblocks/src/subscription.rs
@@ -20,21 +20,23 @@ enum ActorMessage {
 pub struct FlashblocksSubscriber<Receiver> {
     flashblocks_state: Arc<Receiver>,
     ws_url: Url,
+    ping_interval: Duration,
 }
 
 impl<Receiver> FlashblocksSubscriber<Receiver>
 where
     Receiver: FlashblocksReceiver + Send + Sync + 'static,
 {
-    /// Interval of liveness check of upstream, in milliseconds.
-    pub const PING_INTERVAL_MS: u64 = 500;
-
     /// Max duration of backoff before reconnecting to upstream.
     pub const MAX_BACKOFF: Duration = Duration::from_secs(10);
 
     /// Creates a new flashblocks subscriber.
-    pub const fn new(flashblocks_state: Arc<Receiver>, ws_url: Url) -> Self {
-        Self { ws_url, flashblocks_state }
+    pub const fn new(
+        flashblocks_state: Arc<Receiver>,
+        ws_url: Url,
+        ping_interval: Duration,
+    ) -> Self {
+        Self { ws_url, flashblocks_state, ping_interval }
     }
 
     /// Starts the WebSocket subscription to receive flashblocks.
@@ -45,6 +47,7 @@ where
         );
 
         let ws_url = self.ws_url.clone();
+        let ping_period = self.ping_interval;
 
         let (sender, mut mailbox) = mpsc::channel(100);
 
@@ -57,8 +60,7 @@ where
                         backoff = Duration::from_secs(1);
                         info!(message = "WebSocket connection established");
 
-                        let mut ping_interval =
-                            interval(Duration::from_millis(Self::PING_INTERVAL_MS));
+                        let mut ping_interval = interval(ping_period);
                         let mut awaiting_pong_resp = false;
 
                         let (mut write, mut read) = ws_stream.split();
@@ -112,7 +114,7 @@ where
                                           warn!(
                                             target: "flashblocks_rpc::subscription",
                                             ?backoff,
-                                            timeout_ms = Self::PING_INTERVAL_MS,
+                                            timeout = ?ping_period,
                                             "No pong response from upstream, reconnecting",
                                         );
 


### PR DESCRIPTION
Makes the flashblocks subscriber ping interval configurable through the existing CLI and config path instead of relying on a hard-coded value. The default ping interval is now 30s, and the new tests pin both the default and the CLI override wiring.