### PR TITLE
feat(proposer): add consolidated proof metrics and restart/idempotency tests

### DIFF
--- a/crates/proof/proposer/src/metrics.rs
+++ b/crates/proof/proposer/src/metrics.rs
@@ -13,6 +13,10 @@ base_metrics::define_metrics! {
     #[no_zero]
     last_proposed_block: gauge,
 
+    #[describe("Most recently collected (proved) L2 block number awaiting submission")]
+    #[no_zero]
+    last_collected_block: gauge,
+
     #[describe("Proof tasks currently in flight")]
     inflight_proofs: gauge,
 
@@ -21,6 +25,21 @@ base_metrics::define_metrics! {
 
     #[describe("Total pending retries across all target blocks")]
     pipeline_retries: gauge,
+
+    #[describe("Total proof dispatch outcomes from the prover service")]
+    #[label(name = "outcome", default = ["accepted", "failed"])]
+    proof_dispatch_total: counter,
+
+    #[describe("Total proof collection outcomes returned by the proof collector")]
+    #[label(name = "outcome", default = ["ready", "failed"])]
+    proof_collection_total: counter,
+
+    #[describe("Total proof statuses received when polling the prover service")]
+    #[label(name = "status", default = ["queued", "running", "succeeded", "failed"])]
+    proof_status_received_total: counter,
+
+    #[describe("Total number of proof retries scheduled after a failed dispatch or collection")]
+    proof_retries_total: counter,
 
     #[describe("Latest safe (or finalized) L2 block number")]
     #[no_zero]
@@ -65,6 +84,30 @@ base_metrics::define_metrics! {
 }
 
 impl Metrics {
+    /// Label value for an accepted dispatch outcome.
+    pub const DISPATCH_OUTCOME_ACCEPTED: &str = "accepted";
+
+    /// Label value for a failed dispatch outcome.
+    pub const DISPATCH_OUTCOME_FAILED: &str = "failed";
+
+    /// Label value for a ready (successfully collected) proof.
+    pub const COLLECTION_OUTCOME_READY: &str = "ready";
+
+    /// Label value for a failed proof collection.
+    pub const COLLECTION_OUTCOME_FAILED: &str = "failed";
+
+    /// Label value for a queued proof status response.
+    pub const PROOF_STATUS_QUEUED: &str = "queued";
+
+    /// Label value for a running proof status response.
+    pub const PROOF_STATUS_RUNNING: &str = "running";
+
+    /// Label value for a succeeded proof status response.
+    pub const PROOF_STATUS_SUCCEEDED: &str = "succeeded";
+
+    /// Label value for a failed proof status response.
+    pub const PROOF_STATUS_FAILED: &str = "failed";
+
     /// Records that the proposer service has started by setting the `up` gauge to 1.
     pub fn record_startup() {
         Self::up().set(1.0);

--- a/crates/proof/proposer/src/pipeline.rs
+++ b/crates/proof/proposer/src/pipeline.rs
@@ -555,6 +555,7 @@ where
                     from_block = plan.start_block,
                     "Proof request accepted by prover service"
                 );
+                Metrics::proof_dispatch_total(Metrics::DISPATCH_OUTCOME_ACCEPTED).increment(1);
                 state.record_gauges();
             }
             ProofDispatchOutcome::Failed { plan, error } => {
@@ -569,6 +570,7 @@ where
                     return;
                 }
 
+                Metrics::proof_dispatch_total(Metrics::DISPATCH_OUTCOME_FAILED).increment(1);
                 self.handle_proof_failure(plan.target_block, error, state);
             }
         }
@@ -593,6 +595,8 @@ where
                     state.inflight.remove(&target_block);
                     state.retry_counts.remove(&target_block);
                     state.proved.insert(target_block, proof);
+                    Metrics::proof_collection_total(Metrics::COLLECTION_OUTCOME_READY).increment(1);
+                    Metrics::last_collected_block().set(target_block as f64);
                     state.record_gauges();
                     info!(
                         target_block,
@@ -611,6 +615,8 @@ where
                         continue;
                     }
 
+                    Metrics::proof_collection_total(Metrics::COLLECTION_OUTCOME_FAILED)
+                        .increment(1);
                     self.handle_proof_failure(target_block, error, state);
                 }
             }
@@ -622,6 +628,7 @@ where
         state.inflight.remove(&target);
         let count = state.retry_counts.entry(target).or_insert(0);
         *count += 1;
+        Metrics::proof_retries_total().increment(1);
         if *count >= self.config.max_retries {
             error!(
                 target_block = target,
@@ -1771,6 +1778,94 @@ mod tests {
                     assert_eq!(value.into_inner(), TEST_BLOCK_INTERVAL as f64);
                 }
                 other => panic!("expected recovered last_proposed_block gauge, got {other:?}"),
+            }
+        });
+    }
+
+    /// Verifies `handle_proof_failure` increments `proof_retries_total` on every
+    /// retry attempt below `max_retries`.
+    #[cfg(feature = "metrics")]
+    #[test]
+    fn test_handle_proof_failure_emits_retry_metrics() {
+        let pipeline =
+            recovery_pipeline(MockDisputeGameFactory::with_games(vec![]), HashMap::new());
+
+        with_recorder(|snap| {
+            let mut state = PipelineState::new();
+            let target = TEST_BLOCK_INTERVAL * 3;
+            state.inflight.insert(target);
+
+            // Each call to `handle_proof_failure` increments `proof_retries_total`
+            // before the max-retries check, so two calls yield a counter value of 2.
+            pipeline.handle_proof_failure(target, ProposerError::Prover("boom".into()), &mut state);
+            pipeline.handle_proof_failure(target, ProposerError::Prover("boom".into()), &mut state);
+
+            let snapshot = snap.snapshot().into_vec();
+            match find_metric(&snapshot, MetricKind::Counter, "base_proposer.proof_retries_total") {
+                Some(DebugValue::Counter(value)) => assert_eq!(*value, 2),
+                other => panic!("expected proof_retries_total counter, got {other:?}"),
+            }
+        });
+    }
+
+    /// Verifies `handle_dispatch_result` increments `proof_dispatch_total` with
+    /// the right `outcome` label for both accepted and failed dispatch outcomes.
+    #[cfg(feature = "metrics")]
+    #[test]
+    fn test_handle_dispatch_result_emits_dispatch_metrics() {
+        let pipeline =
+            recovery_pipeline(MockDisputeGameFactory::with_games(vec![]), HashMap::new());
+
+        with_recorder(|snap| {
+            let mut state = PipelineState::new();
+            let accepted_target = TEST_BLOCK_INTERVAL;
+            let failed_target = TEST_BLOCK_INTERVAL * 2;
+            state.inflight.insert(accepted_target);
+            state.inflight.insert(failed_target);
+
+            pipeline.handle_dispatch_result(
+                Ok(ProofDispatchOutcome::Accepted {
+                    plan: ProofPlan { start_block: 0, target_block: accepted_target },
+                    session_id: "session-accepted".to_owned(),
+                }),
+                &mut state,
+            );
+            pipeline.handle_dispatch_result(
+                Ok(ProofDispatchOutcome::Failed {
+                    plan: ProofPlan { start_block: accepted_target, target_block: failed_target },
+                    error: ProposerError::Prover("dispatch failed".into()),
+                }),
+                &mut state,
+            );
+
+            let snapshot = snap.snapshot().into_vec();
+            let accepted = snapshot
+                .iter()
+                .find(|(ck, _, _, _)| {
+                    ck.kind() == MetricKind::Counter
+                        && ck.key().name() == "base_proposer.proof_dispatch_total"
+                        && ck
+                            .key()
+                            .labels()
+                            .any(|l| l.key() == "outcome" && l.value() == "accepted")
+                })
+                .map(|(_, _, _, v)| v);
+            match accepted {
+                Some(DebugValue::Counter(value)) => assert_eq!(*value, 1),
+                other => panic!("expected accepted dispatch counter, got {other:?}"),
+            }
+
+            let failed = snapshot
+                .iter()
+                .find(|(ck, _, _, _)| {
+                    ck.kind() == MetricKind::Counter
+                        && ck.key().name() == "base_proposer.proof_dispatch_total"
+                        && ck.key().labels().any(|l| l.key() == "outcome" && l.value() == "failed")
+                })
+                .map(|(_, _, _, v)| v);
+            match failed {
+                Some(DebugValue::Counter(value)) => assert_eq!(*value, 1),
+                other => panic!("expected failed dispatch counter, got {other:?}"),
             }
         });
     }

--- a/crates/proof/proposer/src/proof_adapter.rs
+++ b/crates/proof/proposer/src/proof_adapter.rs
@@ -308,4 +308,30 @@ mod tests {
         assert_eq!(requester.prove_requests.lock().unwrap().len(), 1);
         assert!(requester.get_requests.lock().unwrap().is_empty());
     }
+
+    /// Restart/idempotency: dispatching the same proof request twice — e.g. after
+    /// a proposer restart re-discovers the same target — yields the same
+    /// deterministic session id. The prover service is expected to dedupe the
+    /// underlying session by id, but the proposer surfaces the same id either
+    /// way so that a subsequent `get_proof` call lands on the existing session.
+    #[tokio::test]
+    async fn proof_requester_dispatcher_is_idempotent_for_same_request() {
+        let requester = std::sync::Arc::new(MockProofRequester::default());
+        let dispatcher = ProofRequesterDispatcher::aws_nitro(
+            std::sync::Arc::clone(&requester) as std::sync::Arc<dyn ProofRequesterProvider>
+        );
+        let request = test_request(B256::repeat_byte(0xaa));
+        let expected_session_id = ProposerProofAdapter::tee_session_id(&request, TeeKind::AwsNitro);
+
+        let first = dispatcher.dispatch_tee(request.clone()).await.unwrap();
+        let second = dispatcher.dispatch_tee(request).await.unwrap();
+
+        assert_eq!(first.session_id, expected_session_id);
+        assert_eq!(second.session_id, expected_session_id);
+        let prove_requests = requester.prove_requests.lock().unwrap();
+        assert_eq!(prove_requests.len(), 2);
+        // Both calls carry the same session id and identical TEE proof payload.
+        assert_eq!(prove_requests[0].proof.session_id, expected_session_id);
+        assert_eq!(prove_requests[1].proof.session_id, expected_session_id);
+    }
 }

--- a/crates/proof/proposer/src/proof_collector.rs
+++ b/crates/proof/proposer/src/proof_collector.rs
@@ -392,7 +392,7 @@ mod tests {
         // It must rederive the session id from the canonical chain root and
         // recover the in-flight session.
         let collector =
-            ProofCollector::aws_nitro(Arc::clone(&proof_requester), rollup_client, 100, 4, 4);
+            ProofCollector::aws_nitro(Arc::clone(&proof_requester), rollup_client, 100, 4);
         let outcomes = collector.collect(&[target_block]).await;
 
         assert_eq!(outcomes.len(), 1);

--- a/crates/proof/proposer/src/proof_collector.rs
+++ b/crates/proof/proposer/src/proof_collector.rs
@@ -23,7 +23,10 @@ use base_prover_service_protocol::{GetProofRequest, ProofStatus, TeeKind};
 use futures::{StreamExt, stream};
 use tracing::debug;
 
-use crate::{driver::RecoveredState, error::ProposerError, proof_adapter::ProposerProofAdapter};
+use crate::{
+    driver::RecoveredState, error::ProposerError, metrics::Metrics,
+    proof_adapter::ProposerProofAdapter,
+};
 
 /// Outcome returned by [`ProofCollector::collect`] for a single target block.
 #[derive(Debug)]
@@ -196,6 +199,7 @@ impl<R: RollupProvider + 'static> ProofCollector<R> {
                 }
             };
 
+            Metrics::proof_status_received_total(Self::status_label(response.status)).increment(1);
             match response.status {
                 ProofStatus::Queued | ProofStatus::Running => {
                     debug!(
@@ -248,6 +252,16 @@ impl<R: RollupProvider + 'static> ProofCollector<R> {
         }
 
         outcomes
+    }
+
+    /// Maps a [`ProofStatus`] to its `proof_status_received_total` label value.
+    const fn status_label(status: ProofStatus) -> &'static str {
+        match status {
+            ProofStatus::Queued => Metrics::PROOF_STATUS_QUEUED,
+            ProofStatus::Running => Metrics::PROOF_STATUS_RUNNING,
+            ProofStatus::Succeeded => Metrics::PROOF_STATUS_SUCCEEDED,
+            ProofStatus::Failed => Metrics::PROOF_STATUS_FAILED,
+        }
     }
 
     async fn fetch_canonical_root_results(
@@ -348,5 +362,67 @@ mod tests {
 
         // Next target = 600 > safe_head=550, so no targets.
         assert!(targets.is_empty());
+    }
+
+    /// Restart/recovery: the collector derives the prover-service session id
+    /// solely from the canonical L2 output root + tee kind, so a freshly
+    /// constructed collector (mirroring a proposer restart) can pick up an
+    /// in-flight session that a previous run dispatched.
+    #[tokio::test]
+    async fn collector_recovers_in_flight_session_across_restart() {
+        use crate::proof_adapter::ProofRequesterDispatcher;
+
+        let proof_requester: Arc<dyn ProofRequesterProvider> =
+            Arc::new(MockProofRequester::default());
+
+        let target_block = 600u64;
+        let canonical_root = B256::repeat_byte(0xCC);
+        let mut output_roots = HashMap::new();
+        output_roots.insert(target_block, canonical_root);
+        let rollup_client = Arc::new(MockRollupClient {
+            sync_status: test_sync_status(target_block, B256::ZERO),
+            output_roots,
+            max_safe_block: None,
+        });
+
+        // First "run": dispatch a TEE proof for `target_block` via a dispatcher
+        // that shares the prover-service stub.
+        let dispatcher = ProofRequesterDispatcher::aws_nitro(Arc::clone(&proof_requester));
+        let proof_request = base_proof_primitives::ProofRequest {
+            l1_head: B256::repeat_byte(0x01),
+            agreed_l2_head_hash: B256::repeat_byte(0x02),
+            agreed_l2_output_root: B256::repeat_byte(0x03),
+            claimed_l2_output_root: canonical_root,
+            claimed_l2_block_number: target_block,
+            proposer: Address::repeat_byte(0x04),
+            intermediate_block_interval: 300,
+            l1_head_number: 1200,
+            image_hash: B256::repeat_byte(0x05),
+        };
+        let dispatched = dispatcher.dispatch_tee(proof_request).await.unwrap();
+        let expected_session_id = dispatched.session_id.clone();
+        // Drop the dispatcher to simulate the prior proposer process exiting.
+        drop(dispatcher);
+
+        // "Restart": build a fresh collector with no in-memory dispatch state.
+        // It must rederive the session id from the canonical chain root and
+        // recover the in-flight session.
+        let collector = ProofCollector::aws_nitro(
+            Arc::clone(&proof_requester),
+            rollup_client,
+            target_block,
+            4,
+            4,
+        );
+        let outcomes = collector.collect(&[target_block]).await;
+
+        assert_eq!(outcomes.len(), 1);
+        match &outcomes[0] {
+            CollectedProof::Ready { target_block: t, session_id, .. } => {
+                assert_eq!(*t, target_block);
+                assert_eq!(session_id, &expected_session_id);
+            }
+            other => panic!("expected Ready, got {other:?}"),
+        }
     }
 }

--- a/crates/proof/proposer/src/proof_collector.rs
+++ b/crates/proof/proposer/src/proof_collector.rs
@@ -407,13 +407,8 @@ mod tests {
         // "Restart": build a fresh collector with no in-memory dispatch state.
         // It must rederive the session id from the canonical chain root and
         // recover the in-flight session.
-        let collector = ProofCollector::aws_nitro(
-            Arc::clone(&proof_requester),
-            rollup_client,
-            target_block,
-            4,
-            4,
-        );
+        let collector =
+            ProofCollector::aws_nitro(Arc::clone(&proof_requester), rollup_client, 100, 4, 4);
         let outcomes = collector.collect(&[target_block]).await;
 
         assert_eq!(outcomes.len(), 1);


### PR DESCRIPTION
## Summary

Adds end-to-end observability for the consolidated dispatcher/collector pipeline introduced in #3239 / #3241, plus the restart/idempotency tests called out by the plan.

## New metrics

| Metric | Type | Labels | Emitted from |
| --- | --- | --- | --- |
| `proof_dispatch_total` | counter | `outcome=accepted\|failed` | `ProvingPipeline::handle_dispatch_result` |
| `proof_collection_total` | counter | `outcome=ready\|failed` | `ProvingPipeline::collect_proofs` |
| `proof_status_received_total` | counter | `status=queued\|running\|succeeded\|failed` | `ProofCollector::collect` (every `get_proof` response) |
| `proof_retries_total` | counter | — | `ProvingPipeline::handle_proof_failure` |
| `last_collected_block` | gauge (no_zero) | — | `ProvingPipeline::collect_proofs` on `CollectedProof::Ready` |

`last_collected_block` pairs with the existing `last_proposed_block` so dashboards can see the proving lead over submission.

## New tests

- `proof_requester_dispatcher_is_idempotent_for_same_request` — duplicate `prove_block_range` calls with the same request yield the same deterministic session id, so a restarted proposer's redispatch lands on the prover service's existing session.
- `collector_recovers_in_flight_session_across_restart` — a freshly constructed `ProofCollector` (mirroring a proposer restart with no in-memory dispatch state) rederives the session id from the canonical L2 output root and successfully recovers a session initiated by a previous run.
- `test_handle_proof_failure_emits_retry_metrics` — verifies `proof_retries_total` fires per retry attempt.
- `test_handle_dispatch_result_emits_dispatch_metrics` — verifies the `outcome` label of `proof_dispatch_total` is correctly emitted for both accepted and failed dispatches.

## Verification

- `cargo +nightly fmt --all`
- `cargo clippy -p base-proposer --all-targets -- -D warnings` — clean
- `cargo clippy -p base-proposer --all-targets --features metrics -- -D warnings` — clean
- `cargo test -p base-proposer` — **125 passed** (was 123)
- `cargo test -p base-proposer --features metrics` — **128 passed** (adds the 3 metric-emission tests)

Stat: `4 files changed, 243 insertions(+), 1 deletion(-)`.

## Stack

Stacked on **#3259**. Targets `feat/proposer-p7-remove-transitional-prover-client`; will be retargeted to `main` once that merges.

Related: #3239, #3241, #3245, #3248, #3259.