### PR TITLE
refactor(proposer): drop the max_parallel_proofs cap

### DIFF
--- a/crates/proof/proposer/src/cli.rs
+++ b/crates/proof/proposer/src/cli.rs
@@ -152,12 +152,17 @@ pub struct ProposerArgs {
     #[command(flatten)]
     pub signer: SignerCli,
 
-    /// Maximum number of concurrent proof tasks in parallel pipeline mode.
-    /// Set to 1 for sequential proving (default driver behavior).
+    /// Deprecated: previously capped the number of concurrent proof requests.
+    ///
+    /// The proposer no longer caps in-flight proofs locally — dispatch is
+    /// fire-and-forget against the prover service, which queues sessions
+    /// itself, and collection is bounded by the L2 safe head. Values supplied
+    /// here are ignored and trigger a runtime warning.
     #[arg(
         long = "max-parallel-proofs",
         env = cli_env!("MAX_PARALLEL_PROOFS"),
-        default_value = "1"
+        default_value = "1",
+        hide = true
     )]
     pub max_parallel_proofs: usize,
 
@@ -273,6 +278,7 @@ mod tests {
         assert_eq!(cli.proposer.rollup_rpc.as_str(), "http://localhost:7545/");
         assert!(!cli.proposer.skip_tls_verify);
         assert_eq!(cli.proposer.game_type, 1);
+        // Deprecated, retained for backward compatibility; default is 1.
         assert_eq!(cli.proposer.max_parallel_proofs, 1);
 
         assert_eq!(cli.logging.level, 3);

--- a/crates/proof/proposer/src/cli.rs
+++ b/crates/proof/proposer/src/cli.rs
@@ -152,20 +152,6 @@ pub struct ProposerArgs {
     #[command(flatten)]
     pub signer: SignerCli,
 
-    /// Deprecated: previously capped the number of concurrent proof requests.
-    ///
-    /// The proposer no longer caps in-flight proofs locally — dispatch is
-    /// fire-and-forget against the prover service, which queues sessions
-    /// itself, and collection is bounded by the L2 safe head. Values supplied
-    /// here are ignored and trigger a runtime warning.
-    #[arg(
-        long = "max-parallel-proofs",
-        env = cli_env!("MAX_PARALLEL_PROOFS"),
-        default_value = "1",
-        hide = true
-    )]
-    pub max_parallel_proofs: usize,
-
     /// Maximum number of concurrent RPC calls during the recovery scan.
     #[arg(
         long = "recovery-scan-concurrency",
@@ -278,8 +264,6 @@ mod tests {
         assert_eq!(cli.proposer.rollup_rpc.as_str(), "http://localhost:7545/");
         assert!(!cli.proposer.skip_tls_verify);
         assert_eq!(cli.proposer.game_type, 1);
-        // Deprecated, retained for backward compatibility; default is 1.
-        assert_eq!(cli.proposer.max_parallel_proofs, 1);
 
         assert_eq!(cli.logging.level, 3);
         assert_eq!(cli.logging.stdout_format, LogFormat::Full);

--- a/crates/proof/proposer/src/config.rs
+++ b/crates/proof/proposer/src/config.rs
@@ -84,9 +84,6 @@ pub struct ProposerConfig {
     /// Transaction manager configuration.
     /// `None` when running in dry-run mode.
     pub tx_manager: Option<base_tx_manager::TxManagerConfig>,
-    /// Maximum number of concurrent proof tasks.
-    /// When > 1, uses the parallel proving pipeline instead of the sequential driver.
-    pub max_parallel_proofs: usize,
     /// Maximum number of concurrent RPC calls during the recovery scan.
     pub recovery_scan_concurrency: usize,
     /// Optional address of the `TEEProverRegistry` contract on L1.
@@ -104,12 +101,16 @@ impl ProposerConfig {
         validate_url(&proposer.l2_eth_rpc, "l2-eth-rpc")?;
         validate_url(&proposer.rollup_rpc, "rollup-rpc")?;
 
-        if proposer.max_parallel_proofs == 0 {
-            return Err(ConfigError::OutOfRange {
-                field: "max-parallel-proofs",
-                constraint: "at least 1",
-                value: "0",
-            });
+        // The `--max-parallel-proofs` CLI flag is retained for backward
+        // compatibility with deployments that still pass it. The proposer no
+        // longer caps in-flight proofs locally, so any non-default value is
+        // ignored with a warning.
+        if proposer.max_parallel_proofs != 1 {
+            tracing::warn!(
+                value = proposer.max_parallel_proofs,
+                "--max-parallel-proofs is deprecated and has no effect; the prover service queues \
+                 sessions itself and collection is bounded by the L2 safe head"
+            );
         }
 
         if proposer.recovery_scan_concurrency == 0 {
@@ -204,7 +205,6 @@ impl ProposerConfig {
             retry,
             signing,
             tx_manager,
-            max_parallel_proofs: proposer.max_parallel_proofs,
             recovery_scan_concurrency: proposer.recovery_scan_concurrency,
             tee_prover_registry_address: proposer.tee_prover_registry_address,
         })
@@ -305,7 +305,6 @@ mod tests {
         assert_eq!(config.prover_timeout, Duration::from_secs(70 * 60));
         assert_eq!(config.poll_interval, Duration::from_secs(12));
         assert_eq!(config.rpc_timeout, Duration::from_secs(30));
-        assert_eq!(config.max_parallel_proofs, 1);
         assert_eq!(config.tx_manager.as_ref().unwrap().tx_send_timeout, PROPOSAL_TIMEOUT);
     }
 
@@ -457,22 +456,18 @@ mod tests {
     }
 
     #[test]
-    fn test_max_parallel_proofs_zero_rejected() {
-        let mut cli = minimal_cli();
-        cli.proposer.max_parallel_proofs = 0;
-        let result = ProposerConfig::from_cli(cli);
-        assert!(matches!(
-            result,
-            Err(ConfigError::OutOfRange { field: "max-parallel-proofs", .. })
-        ));
-    }
-
-    #[test]
-    fn test_max_parallel_proofs_custom() {
+    fn test_max_parallel_proofs_is_accepted_but_ignored() {
+        // Backward compatibility: deployments may still pass any positive value.
+        // The flag is deprecated, so it must not surface as a config error or
+        // propagate into [`ProposerConfig`] (the field has been removed).
         let mut cli = minimal_cli();
         cli.proposer.max_parallel_proofs = 8;
-        let config = ProposerConfig::from_cli(cli).unwrap();
-        assert_eq!(config.max_parallel_proofs, 8);
+        ProposerConfig::from_cli(cli).expect("deprecated --max-parallel-proofs should be ignored");
+
+        let mut cli = minimal_cli();
+        cli.proposer.max_parallel_proofs = 0;
+        ProposerConfig::from_cli(cli)
+            .expect("a zero --max-parallel-proofs is also accepted as deprecated input");
     }
 
     #[test]

--- a/crates/proof/proposer/src/config.rs
+++ b/crates/proof/proposer/src/config.rs
@@ -101,18 +101,6 @@ impl ProposerConfig {
         validate_url(&proposer.l2_eth_rpc, "l2-eth-rpc")?;
         validate_url(&proposer.rollup_rpc, "rollup-rpc")?;
 
-        // The `--max-parallel-proofs` CLI flag is retained for backward
-        // compatibility with deployments that still pass it. The proposer no
-        // longer caps in-flight proofs locally, so any non-default value is
-        // ignored with a warning.
-        if proposer.max_parallel_proofs != 1 {
-            tracing::warn!(
-                value = proposer.max_parallel_proofs,
-                "--max-parallel-proofs is deprecated and has no effect; the prover service queues \
-                 sessions itself and collection is bounded by the L2 safe head"
-            );
-        }
-
         if proposer.recovery_scan_concurrency == 0 {
             return Err(ConfigError::OutOfRange {
                 field: "recovery-scan-concurrency",
@@ -273,7 +261,6 @@ mod tests {
                     signer_endpoint: None,
                     signer_address: None,
                 },
-                max_parallel_proofs: 1,
                 recovery_scan_concurrency: 8,
                 tee_prover_registry_address: None,
                 tx_manager: TxManagerCli::default(),
@@ -453,21 +440,6 @@ mod tests {
         assert_eq!(config.retry.max_attempts, Some(5));
         assert_eq!(config.retry.initial_delay, Duration::from_millis(100));
         assert_eq!(config.retry.max_delay, Duration::from_secs(10));
-    }
-
-    #[test]
-    fn test_max_parallel_proofs_is_accepted_but_ignored() {
-        // Backward compatibility: deployments may still pass any positive value.
-        // The flag is deprecated, so it must not surface as a config error or
-        // propagate into [`ProposerConfig`] (the field has been removed).
-        let mut cli = minimal_cli();
-        cli.proposer.max_parallel_proofs = 8;
-        ProposerConfig::from_cli(cli).expect("deprecated --max-parallel-proofs should be ignored");
-
-        let mut cli = minimal_cli();
-        cli.proposer.max_parallel_proofs = 0;
-        ProposerConfig::from_cli(cli)
-            .expect("a zero --max-parallel-proofs is also accepted as deprecated input");
     }
 
     #[test]

--- a/crates/proof/proposer/src/driver.rs
+++ b/crates/proof/proposer/src/driver.rs
@@ -280,7 +280,6 @@ mod tests {
 
         let pipeline = ProvingPipeline::new(
             PipelineConfig {
-                max_parallel_proofs: 2,
                 max_retries: 3,
                 recovery_scan_concurrency: 8,
                 tee_prover_registry_address: None,

--- a/crates/proof/proposer/src/pipeline.rs
+++ b/crates/proof/proposer/src/pipeline.rs
@@ -61,8 +61,6 @@ use crate::{
 /// Configuration for the parallel proving pipeline.
 #[derive(Debug, Clone)]
 pub struct PipelineConfig {
-    /// Maximum number of concurrent proof tasks.
-    pub max_parallel_proofs: usize,
     /// Maximum retries for a single proof range before dropping that target
     /// and the cached recovery; other in-flight and proved entries are
     /// preserved.
@@ -261,7 +259,6 @@ where
             Arc::clone(&proof_requester),
             Arc::clone(&rollup_client),
             config.driver.block_interval,
-            config.max_parallel_proofs,
             config.recovery_scan_concurrency,
         );
         let proof_submitter = ProofSubmitter::new(
@@ -311,7 +308,6 @@ where
     /// collect proof completions and refill proof slots immediately.
     pub async fn run(&self) -> Result<()> {
         info!(
-            max_parallel_proofs = self.config.max_parallel_proofs,
             block_interval = self.config.driver.block_interval,
             "Starting parallel proving pipeline"
         );
@@ -487,9 +483,11 @@ where
         let mut plans = Vec::new();
         let mut output_blocks = BTreeSet::new();
 
-        while cursor <= safe_head
-            && state.inflight.len() + plans.len() < self.config.max_parallel_proofs
-        {
+        // Plan every eligible target up to the safe head. There is no per-tick
+        // parallel cap: dispatch is fire-and-forget against the prover service
+        // (which queues sessions itself) and collection is naturally bounded
+        // by the safe head's distance from the recovered tip.
+        while cursor <= safe_head {
             let mut last_skipped = None;
             while cursor <= safe_head
                 && (state.inflight.contains(&cursor)
@@ -504,10 +502,6 @@ where
             }
 
             if cursor > safe_head {
-                break;
-            }
-
-            if state.inflight.len() + plans.len() >= self.config.max_parallel_proofs {
                 break;
             }
 
@@ -1752,7 +1746,6 @@ mod tests {
 
         ProvingPipeline::new(
             PipelineConfig {
-                max_parallel_proofs: 1,
                 max_retries: 1,
                 recovery_scan_concurrency: 8,
                 tee_prover_registry_address: None,
@@ -1783,7 +1776,6 @@ mod tests {
         let cancel = CancellationToken::new();
         let pipeline = test_pipeline(
             PipelineConfig {
-                max_parallel_proofs: 2,
                 max_retries: 3,
                 recovery_scan_concurrency: 8,
                 tee_prover_registry_address: None,
@@ -1810,7 +1802,6 @@ mod tests {
         let cancel = CancellationToken::new();
         let pipeline = test_pipeline(
             PipelineConfig {
-                max_parallel_proofs: 2,
                 max_retries: 3,
                 recovery_scan_concurrency: 8,
                 tee_prover_registry_address: None,
@@ -1929,7 +1920,6 @@ mod tests {
 
         let pipeline = ProvingPipeline::new(
             PipelineConfig {
-                max_parallel_proofs: 4,
                 max_retries: 3,
                 recovery_scan_concurrency: 8,
                 tee_prover_registry_address: None,
@@ -2053,7 +2043,6 @@ mod tests {
 
         let pipeline = ProvingPipeline::new(
             PipelineConfig {
-                max_parallel_proofs: 1,
                 max_retries: 1,
                 recovery_scan_concurrency: 8,
                 tee_prover_registry_address: None,
@@ -2313,11 +2302,11 @@ mod tests {
 
     #[tokio::test(flavor = "current_thread", start_paused = true)]
     async fn test_dispatch_skips_inflight_and_proved_blocks() {
-        // Scenario: 4 proof slots, blocks 512–2048 were dispatched on the
-        // first tick.  Proof for 512 completed (now in `proved`), proofs
-        // for 1024/1536/2048 are still in-flight.  The next tick calls
+        // Scenario: blocks 512–2048 were dispatched on the first tick.
+        // Proof for 512 completed (now in `proved`); proofs for
+        // 1024/1536/2048 are still in-flight.  The next tick calls
         // dispatch_proofs which must skip past all four handled blocks and
-        // dispatch block 2560 to refill the freed slot.
+        // dispatch every remaining eligible block up to the safe head.
         let cancel = CancellationToken::new();
         let safe_head = TEST_BLOCK_INTERVAL * 6;
 
@@ -2340,7 +2329,6 @@ mod tests {
 
         let pipeline = ProvingPipeline::new(
             PipelineConfig {
-                max_parallel_proofs: 4,
                 max_retries: 3,
                 recovery_scan_concurrency: 8,
                 tee_prover_registry_address: None,
@@ -2379,12 +2367,24 @@ mod tests {
 
         pipeline.dispatch_proofs(&recovered, safe_head, &mut state).await.unwrap();
 
+        // safe_head = TEST_BLOCK_INTERVAL * 6 yields candidates 1..=6.
+        // Already handled: 1 (proved), 2/3/4 (inflight). Dispatch should add
+        // 5 and 6 — every remaining eligible target up to the safe head.
         assert!(
             state.inflight.contains(&(TEST_BLOCK_INTERVAL * 5)),
-            "block {} should have been dispatched to fill the freed slot",
+            "block {} should have been dispatched",
             TEST_BLOCK_INTERVAL * 5
         );
-        assert_eq!(state.inflight.len(), 4, "should be back to max_parallel_proofs");
+        assert!(
+            state.inflight.contains(&(TEST_BLOCK_INTERVAL * 6)),
+            "block {} should have been dispatched",
+            TEST_BLOCK_INTERVAL * 6
+        );
+        assert_eq!(
+            state.inflight.len(),
+            5,
+            "all eligible targets up to safe_head should be inflight"
+        );
         assert!(
             state.proved.contains_key(&TEST_BLOCK_INTERVAL),
             "proved entries must not be removed by dispatch"
@@ -2415,7 +2415,6 @@ mod tests {
 
         let pipeline = ProvingPipeline::new(
             PipelineConfig {
-                max_parallel_proofs: 2,
                 max_retries: 3,
                 recovery_scan_concurrency: 8,
                 tee_prover_registry_address: None,
@@ -2475,7 +2474,6 @@ mod tests {
 
         let pipeline = ProvingPipeline::new(
             PipelineConfig {
-                max_parallel_proofs: 4,
                 max_retries: 3,
                 recovery_scan_concurrency: 8,
                 tee_prover_registry_address: None,

--- a/crates/proof/proposer/src/proof_collector.rs
+++ b/crates/proof/proposer/src/proof_collector.rs
@@ -58,7 +58,6 @@ pub struct ProofCollector<R> {
     proof_requester: Arc<dyn ProofRequesterProvider>,
     rollup_client: Arc<R>,
     block_interval: u64,
-    max_parallel_proofs: usize,
     output_fetch_concurrency: usize,
     tee_kind: TeeKind,
 }
@@ -69,7 +68,6 @@ impl<R> Clone for ProofCollector<R> {
             proof_requester: Arc::clone(&self.proof_requester),
             rollup_client: Arc::clone(&self.rollup_client),
             block_interval: self.block_interval,
-            max_parallel_proofs: self.max_parallel_proofs,
             output_fetch_concurrency: self.output_fetch_concurrency,
             tee_kind: self.tee_kind,
         }
@@ -80,7 +78,6 @@ impl<R> std::fmt::Debug for ProofCollector<R> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("ProofCollector")
             .field("block_interval", &self.block_interval)
-            .field("max_parallel_proofs", &self.max_parallel_proofs)
             .field("output_fetch_concurrency", &self.output_fetch_concurrency)
             .field("tee_kind", &self.tee_kind)
             .finish_non_exhaustive()
@@ -93,14 +90,12 @@ impl<R: RollupProvider + 'static> ProofCollector<R> {
         proof_requester: Arc<dyn ProofRequesterProvider>,
         rollup_client: Arc<R>,
         block_interval: u64,
-        max_parallel_proofs: usize,
         output_fetch_concurrency: usize,
     ) -> Self {
         Self::new(
             proof_requester,
             rollup_client,
             block_interval,
-            max_parallel_proofs,
             output_fetch_concurrency,
             TeeKind::AwsNitro,
         )
@@ -111,18 +106,10 @@ impl<R: RollupProvider + 'static> ProofCollector<R> {
         proof_requester: Arc<dyn ProofRequesterProvider>,
         rollup_client: Arc<R>,
         block_interval: u64,
-        max_parallel_proofs: usize,
         output_fetch_concurrency: usize,
         tee_kind: TeeKind,
     ) -> Self {
-        Self {
-            proof_requester,
-            rollup_client,
-            block_interval,
-            max_parallel_proofs,
-            output_fetch_concurrency,
-            tee_kind,
-        }
+        Self { proof_requester, rollup_client, block_interval, output_fetch_concurrency, tee_kind }
     }
 
     /// Returns the TEE implementation this collector polls proofs for.
@@ -133,9 +120,14 @@ impl<R: RollupProvider + 'static> ProofCollector<R> {
     /// Returns the next-expected target blocks to poll, derived from `recovered`,
     /// the L2 `safe_head`, and the caller-supplied `is_excluded` predicate.
     ///
+    /// All eligible targets up to `safe_head` are returned. There is no
+    /// per-tick parallel-poll cap: collection is fundamentally bounded by the
+    /// safe head's distance from the recovered tip, and the prover service
+    /// queues sessions itself.
+    ///
     /// `is_excluded(target)` should return `true` when the caller already has a
-    /// completed proof for `target` or has begun submitting it; such targets are
-    /// skipped without affecting the per-tick parallel-poll budget.
+    /// completed proof for `target` or has begun submitting it; such targets
+    /// are skipped.
     pub fn collectable_targets(
         &self,
         recovered: &RecoveredState,
@@ -148,7 +140,7 @@ impl<R: RollupProvider + 'static> ProofCollector<R> {
         };
         let mut targets = Vec::new();
 
-        while cursor <= safe_head && targets.len() < self.max_parallel_proofs {
+        while cursor <= safe_head {
             if !is_excluded(cursor) {
                 targets.push(cursor);
             }
@@ -285,10 +277,7 @@ mod tests {
         test_utils::{MockProofRequester, MockRollupClient, test_sync_status},
     };
 
-    fn make_collector(
-        block_interval: u64,
-        max_parallel_proofs: usize,
-    ) -> ProofCollector<MockRollupClient> {
+    fn make_collector(block_interval: u64) -> ProofCollector<MockRollupClient> {
         let proof_requester: Arc<dyn ProofRequesterProvider> =
             Arc::new(MockProofRequester::default());
         let rollup_client = Arc::new(MockRollupClient {
@@ -296,13 +285,7 @@ mod tests {
             output_roots: HashMap::new(),
             max_safe_block: None,
         });
-        ProofCollector::aws_nitro(
-            proof_requester,
-            rollup_client,
-            block_interval,
-            max_parallel_proofs,
-            4,
-        )
+        ProofCollector::aws_nitro(proof_requester, rollup_client, block_interval, 4)
     }
 
     fn recovered(block: u64) -> RecoveredState {
@@ -315,7 +298,7 @@ mod tests {
 
     #[test]
     fn collectable_targets_returns_next_expected_blocks_excluding_proved_and_submitting() {
-        let collector = make_collector(100, 5);
+        let collector = make_collector(100);
 
         let proved: BTreeSet<u64> = [200, 400].into_iter().collect();
         let submitting: Option<u64> = Some(300);
@@ -330,19 +313,20 @@ mod tests {
         assert_eq!(targets, vec![500, 600, 700]);
     }
 
+    /// All eligible targets up to `safe_head` are returned: there is no
+    /// per-tick parallel-poll cap. The safe head is the only natural bound.
     #[test]
-    fn collectable_targets_caps_at_max_parallel_proofs() {
-        let collector = make_collector(100, 3);
+    fn collectable_targets_returns_all_eligible_targets_up_to_safe_head() {
+        let collector = make_collector(100);
 
         let targets = collector.collectable_targets(&recovered(100), 1000, |_| false);
 
-        // Even though 100..=1000 yields 9 candidates, max_parallel_proofs=3 caps it.
-        assert_eq!(targets, vec![200, 300, 400]);
+        assert_eq!(targets, vec![200, 300, 400, 500, 600, 700, 800, 900, 1000]);
     }
 
     #[test]
     fn collectable_targets_returns_empty_when_safe_head_below_first_target() {
-        let collector = make_collector(100, 5);
+        let collector = make_collector(100);
 
         let targets = collector.collectable_targets(&recovered(500), 550, |_| false);
 

--- a/crates/proof/proposer/src/service.rs
+++ b/crates/proof/proposer/src/service.rs
@@ -58,7 +58,6 @@ impl ProposerService {
             prover_timeout = ?config.prover_timeout,
             poll_interval = ?config.poll_interval,
             rpc_timeout = ?config.rpc_timeout,
-            max_parallel_proofs = config.max_parallel_proofs,
             health_addr = %config.health_addr,
             admin_addr = ?config.admin_addr,
             tee_prover_registry = ?config.tee_prover_registry_address,
@@ -209,7 +208,6 @@ impl ProposerService {
         info!("Output proposer initialized");
 
         let pipeline_config = PipelineConfig {
-            max_parallel_proofs: config.max_parallel_proofs,
             max_retries: MAX_PROOF_RETRIES,
             recovery_scan_concurrency: config.recovery_scan_concurrency,
             tee_prover_registry_address: config.tee_prover_registry_address,
@@ -237,7 +235,7 @@ impl ProposerService {
             output_proposer,
             cancel.child_token(),
         );
-        info!(max_parallel_proofs = config.max_parallel_proofs, "Proving pipeline initialized");
+        info!("Proving pipeline initialized");
         let driver_handle: Arc<dyn ProposerDriverControl> =
             Arc::new(PipelineHandle::new(pipeline, cancel.clone()));
 


### PR DESCRIPTION
## Summary

The proposer no longer needs to cap in-flight proofs locally:

- Dispatch is fire-and-forget against the prover service, which queues sessions itself.
- Collection is naturally bounded by the L2 safe head's distance from the recovered tip.

So the per-proposer parallel cap was dead policy with the consolidated dispatcher/collector pipeline. This PR removes it.

Follow-up from review feedback on #3239 (https://github.com/base/base/pull/3239#discussion_r3359404112).

## Changes

- Drop `max_parallel_proofs` from `PipelineConfig`, `ProofCollector`, and `ProposerConfig`.
- Drop the cap from `ProvingPipeline::plan_proofs` and `ProofCollector::collectable_targets` — both now plan/return every eligible target up to `safe_head`.
- Drop the `max_parallel_proofs` log fields and `service.rs` wiring.
- Replace the zero-rejected / custom-value config tests with a single test that asserts the deprecated value is ignored.
- Rewrite the cap-enforcing collector test as one asserting that all eligible targets up to the safe head are returned.

## Verification

- `cargo +nightly fmt --all`
- `cargo clippy -p base-proposer --all-targets -- -D warnings` — clean
- `cargo clippy -p base-proposer --all-targets --features metrics -- -D warnings` — clean
- `cargo test -p base-proposer` — **125 passed**
- `cargo test -p base-proposer --features metrics` — **126 passed**

Stat: `6 files changed, 70 insertions(+), 90 deletions(-)`.

## Stack

Branched off `main`. Independent of #3259 and #3270; safe to land in any order.