### PR TITLE
feat(proposer): rework proving pipeline

### DIFF
--- a/crates/proof/proposer/src/constants.rs
+++ b/crates/proof/proposer/src/constants.rs
@@ -6,6 +6,11 @@ use std::time::Duration;
 /// transaction to be included on-chain.
 pub const PROPOSAL_TIMEOUT: Duration = Duration::from_mins(10);
 
+/// Default maximum time for a single inline submit attempt
+/// (validation + L1 transaction). Allows [`PROPOSAL_TIMEOUT`] for the
+/// transaction itself plus a 2-minute slack for JIT validation RPCs.
+pub const SUBMIT_TIMEOUT: Duration = Duration::from_mins(12);
+
 /// Default maximum number of concurrent RPC calls during the recovery scan.
 pub const RECOVERY_SCAN_CONCURRENCY: usize = 8;
 

--- a/crates/proof/proposer/src/driver.rs
+++ b/crates/proof/proposer/src/driver.rs
@@ -277,6 +277,7 @@ mod tests {
 
         let pipeline = ProvingPipeline::new(
             PipelineConfig {
+                submit_timeout: std::time::Duration::from_secs(60),
                 max_retries: 3,
                 recovery_scan_concurrency: 8,
                 tee_prover_registry_address: None,

--- a/crates/proof/proposer/src/lib.rs
+++ b/crates/proof/proposer/src/lib.rs
@@ -15,7 +15,9 @@ mod config;
 pub use config::{ConfigError, ProposerConfig};
 
 mod constants;
-pub use constants::{MAX_PROOF_RETRIES, PROPOSAL_TIMEOUT, RECOVERY_SCAN_CONCURRENCY};
+pub use constants::{
+    MAX_PROOF_RETRIES, PROPOSAL_TIMEOUT, RECOVERY_SCAN_CONCURRENCY, SUBMIT_TIMEOUT,
+};
 
 mod output_proposer;
 pub use output_proposer::{DryRunProposer, OutputProposer, ProposalSubmitter};
@@ -24,7 +26,7 @@ mod proof_adapter;
 pub use proof_adapter::{DispatchedProof, ProofRequesterDispatcher, ProposerProofAdapter};
 
 mod proof_collector;
-pub use proof_collector::{CollectedProof, ProofCollector};
+pub use proof_collector::{ProofCollector, TargetPoll};
 
 mod proof_submitter;
 pub use proof_submitter::{ProofSubmitter, ProofSubmitterConfig, SubmitAction};

--- a/crates/proof/proposer/src/metrics.rs
+++ b/crates/proof/proposer/src/metrics.rs
@@ -24,9 +24,6 @@ base_metrics::define_metrics! {
     #[label(name = "outcome", default = ["accepted", "failed", "build_failed"])]
     proof_dispatch_total: counter,
 
-    #[describe("Total target blocks discarded by the submitter and skipped by subsequent polls")]
-    discarded_targets_total: counter,
-
     #[describe("Total proof collection outcomes returned by the proof collector")]
     #[label(name = "outcome", default = ["ready", "failed"])]
     proof_collection_total: counter,

--- a/crates/proof/proposer/src/metrics.rs
+++ b/crates/proof/proposer/src/metrics.rs
@@ -13,15 +13,9 @@ base_metrics::define_metrics! {
     #[no_zero]
     last_proposed_block: gauge,
 
-    #[describe("Most recently collected (proved) L2 block number awaiting submission")]
+    #[describe("Highest L2 block number for which a proof has been polled Ready and submitted inline")]
     #[no_zero]
     last_collected_block: gauge,
-
-    #[describe("Proof tasks currently in flight")]
-    inflight_proofs: gauge,
-
-    #[describe("Proved results awaiting sequential submission")]
-    proved_queue_depth: gauge,
 
     #[describe("Total pending retries across all target blocks")]
     pipeline_retries: gauge,

--- a/crates/proof/proposer/src/metrics.rs
+++ b/crates/proof/proposer/src/metrics.rs
@@ -21,8 +21,11 @@ base_metrics::define_metrics! {
     pipeline_retries: gauge,
 
     #[describe("Total proof dispatch outcomes from the prover service")]
-    #[label(name = "outcome", default = ["accepted", "failed"])]
+    #[label(name = "outcome", default = ["accepted", "failed", "build_failed"])]
     proof_dispatch_total: counter,
+
+    #[describe("Total target blocks discarded by the submitter and skipped by subsequent polls")]
+    discarded_targets_total: counter,
 
     #[describe("Total proof collection outcomes returned by the proof collector")]
     #[label(name = "outcome", default = ["ready", "failed"])]
@@ -83,6 +86,12 @@ impl Metrics {
 
     /// Label value for a failed dispatch outcome.
     pub const DISPATCH_OUTCOME_FAILED: &str = "failed";
+
+    /// Label value for a dispatch attempt that failed before reaching the
+    /// prover service (e.g. while building the request from L1/L2 RPC data).
+    /// Build failures are transient infrastructure errors and do not count
+    /// against the per-target retry budget.
+    pub const DISPATCH_OUTCOME_BUILD_FAILED: &str = "build_failed";
 
     /// Label value for a ready (successfully collected) proof.
     pub const COLLECTION_OUTCOME_READY: &str = "ready";

--- a/crates/proof/proposer/src/pipeline.rs
+++ b/crates/proof/proposer/src/pipeline.rs
@@ -488,122 +488,135 @@ where
         if cursor.is_none_or(|c| c.l2_block_number < recovered.l2_block_number) {
             *cursor = Some(recovered);
         }
-        let Some(current) = *cursor else { return };
+        while let Some(current) = *cursor {
+            let target_block = match self.next_target_block(current.l2_block_number) {
+                Some(block) => block,
+                None => break,
+            };
 
-        let target_block = match self.next_target_block(current.l2_block_number) {
-            Some(block) => block,
-            None => return,
-        };
-
-        if target_block > safe_head {
-            debug!(
-                current_block = current.l2_block_number,
-                target_block,
-                safe_head,
-                "Safe head below collection target, waiting for L2 head to advance"
-            );
-            Metrics::pipeline_retries().set(retry_counts.values().sum::<u32>() as f64);
-            return;
-        }
-
-        let poll = if let Some(session_id) = retry_sessions.get(&target_block).cloned() {
-            self.proof_collector.poll_session(target_block, session_id).await
-        } else {
-            self.proof_collector.poll(target_block).await
-        };
-
-        match poll {
-            TargetPoll::Ready { session_id, proof } => {
-                info!(
+            if target_block > safe_head {
+                debug!(
+                    current_block = current.l2_block_number,
                     target_block,
-                    session_id = %session_id,
-                    "Proof ready, submitting inline"
+                    safe_head,
+                    "Safe head below collection target, waiting for L2 head to advance"
                 );
-                Metrics::proof_collection_total(Metrics::COLLECTION_OUTCOME_READY).increment(1);
-                match self.submit_inline(target_block, &current, proof, retry_counts, cache).await {
-                    SubmitEffect::Submitted => {
-                        retry_sessions.remove(&target_block);
-                        discard_retry_counts.remove(&target_block);
-                        if let Some(cached) = cache.as_ref() {
-                            *cursor = Some(cached.state);
+                break;
+            }
+
+            let poll = if let Some(session_id) = retry_sessions.get(&target_block).cloned() {
+                self.proof_collector.poll_session(target_block, session_id).await
+            } else {
+                self.proof_collector.poll(target_block).await
+            };
+
+            match poll {
+                TargetPoll::Ready { session_id, proof } => {
+                    info!(
+                        target_block,
+                        session_id = %session_id,
+                        "Proof ready, submitting inline"
+                    );
+                    Metrics::proof_collection_total(Metrics::COLLECTION_OUTCOME_READY).increment(1);
+                    match self
+                        .submit_inline(target_block, &current, proof, retry_counts, cache)
+                        .await
+                    {
+                        SubmitEffect::Submitted => {
+                            retry_sessions.remove(&target_block);
+                            discard_retry_counts.remove(&target_block);
+                            if let Some(cached) = cache.as_ref() {
+                                *cursor = Some(cached.state);
+                                if cached.state.l2_block_number > current.l2_block_number {
+                                    continue;
+                                }
+                            }
+                            break;
+                        }
+                        SubmitEffect::Restart => {
+                            request_restart(restart_tx, "submit failure").await;
+                            break;
+                        }
+                        SubmitEffect::Redispatch { claimed_l2_output_root } => {
+                            self.dispatch_discard_retry(
+                                target_block,
+                                &current,
+                                claimed_l2_output_root,
+                                retry_counts,
+                                cache,
+                                DiscardRetryState {
+                                    counts: discard_retry_counts,
+                                    sessions: retry_sessions,
+                                },
+                            )
+                            .await;
+                            break;
                         }
                     }
-                    SubmitEffect::Restart => {
-                        request_restart(restart_tx, "submit failure").await;
-                    }
-                    SubmitEffect::Redispatch { claimed_l2_output_root } => {
-                        self.dispatch_discard_retry(
-                            target_block,
-                            &current,
-                            claimed_l2_output_root,
-                            retry_counts,
-                            cache,
-                            DiscardRetryState {
-                                counts: discard_retry_counts,
-                                sessions: retry_sessions,
-                            },
-                        )
-                        .await;
-                    }
                 }
-            }
-            TargetPoll::Pending { session_id, status } => {
-                debug!(
-                    target_block,
-                    session_id = %session_id,
-                    ?status,
-                    "Proof pending, waiting for prover service"
-                );
-            }
-            TargetPoll::NotFound { session_id, claimed_l2_output_root } => {
-                debug!(
-                    target_block,
-                    session_id = %session_id,
-                    claimed_l2_output_root = %claimed_l2_output_root,
-                    "No prover-service session for target, waiting for dispatcher"
-                );
-            }
-            TargetPoll::Failed { session_id, claimed_l2_output_root, error } => {
-                warn!(
-                    target_block,
-                    session_id = %session_id,
-                    error = %error,
-                    "Prover service reported failed session, re-dispatching"
-                );
-                Metrics::proof_collection_total(Metrics::COLLECTION_OUTCOME_FAILED).increment(1);
-                if self.handle_proof_failure(target_block, error, retry_counts, cache) {
-                    if retry_sessions.get(&target_block).is_some_and(|id| id == &session_id) {
-                        self.dispatch_discard_retry(
-                            target_block,
-                            &current,
-                            claimed_l2_output_root,
-                            retry_counts,
-                            cache,
-                            DiscardRetryState {
-                                counts: discard_retry_counts,
-                                sessions: retry_sessions,
-                            },
-                        )
-                        .await;
-                    } else {
-                        self.dispatch_for(
-                            target_block,
-                            &current,
-                            claimed_l2_output_root,
-                            retry_counts,
-                            cache,
-                        )
-                        .await;
-                    }
+                TargetPoll::Pending { session_id, status } => {
+                    debug!(
+                        target_block,
+                        session_id = %session_id,
+                        ?status,
+                        "Proof pending, waiting for prover service"
+                    );
+                    break;
                 }
-            }
-            TargetPoll::Unknown { session_id, error } => {
-                debug!(
-                    target_block,
-                    session_id = ?session_id,
-                    error = %error,
-                    "Transient poll failure, will retry next iteration"
-                );
+                TargetPoll::NotFound { session_id, claimed_l2_output_root } => {
+                    debug!(
+                        target_block,
+                        session_id = %session_id,
+                        claimed_l2_output_root = %claimed_l2_output_root,
+                        "No prover-service session for target, waiting for dispatcher"
+                    );
+                    break;
+                }
+                TargetPoll::Failed { session_id, claimed_l2_output_root, error } => {
+                    warn!(
+                        target_block,
+                        session_id = %session_id,
+                        error = %error,
+                        "Prover service reported failed session, re-dispatching"
+                    );
+                    Metrics::proof_collection_total(Metrics::COLLECTION_OUTCOME_FAILED)
+                        .increment(1);
+                    if self.handle_proof_failure(target_block, error, retry_counts, cache) {
+                        if retry_sessions.get(&target_block).is_some_and(|id| id == &session_id) {
+                            self.dispatch_discard_retry(
+                                target_block,
+                                &current,
+                                claimed_l2_output_root,
+                                retry_counts,
+                                cache,
+                                DiscardRetryState {
+                                    counts: discard_retry_counts,
+                                    sessions: retry_sessions,
+                                },
+                            )
+                            .await;
+                        } else {
+                            self.dispatch_for(
+                                target_block,
+                                &current,
+                                claimed_l2_output_root,
+                                retry_counts,
+                                cache,
+                            )
+                            .await;
+                        }
+                    }
+                    break;
+                }
+                TargetPoll::Unknown { session_id, error } => {
+                    debug!(
+                        target_block,
+                        session_id = ?session_id,
+                        error = %error,
+                        "Transient poll failure, will retry next iteration"
+                    );
+                    break;
+                }
             }
         }
 
@@ -1398,7 +1411,14 @@ async fn request_restart(restart_tx: &mpsc::Sender<String>, reason: &str) {
 
 #[cfg(test)]
 mod tests {
-    use std::{collections::HashMap, sync::Arc, time::Duration};
+    use std::{
+        collections::HashMap,
+        sync::{
+            Arc,
+            atomic::{AtomicU64, Ordering},
+        },
+        time::Duration,
+    };
 
     use alloy_primitives::{Address, B256};
     use async_trait::async_trait;
@@ -2364,6 +2384,74 @@ mod tests {
         }
     }
 
+    #[derive(Debug)]
+    struct AdvancingGameFactory {
+        submitted_games: Arc<AtomicU64>,
+    }
+
+    #[async_trait]
+    impl DisputeGameFactoryClient for AdvancingGameFactory {
+        async fn game_count(&self) -> Result<u64, base_proof_contracts::ContractError> {
+            Ok(self.submitted_games.load(Ordering::SeqCst))
+        }
+
+        async fn game_at_index(
+            &self,
+            index: u64,
+        ) -> Result<base_proof_contracts::GameAtIndex, base_proof_contracts::ContractError>
+        {
+            Ok(base_proof_contracts::GameAtIndex {
+                game_type: TEST_GAME_TYPE,
+                timestamp: 0,
+                proxy: proxy_addr(index),
+            })
+        }
+
+        async fn init_bonds(
+            &self,
+            _: u32,
+        ) -> Result<alloy_primitives::U256, base_proof_contracts::ContractError> {
+            Ok(alloy_primitives::U256::ZERO)
+        }
+
+        async fn game_impls(&self, _: u32) -> Result<Address, base_proof_contracts::ContractError> {
+            Ok(Address::ZERO)
+        }
+
+        async fn games(
+            &self,
+            _: u32,
+            root_claim: B256,
+            _: alloy_primitives::Bytes,
+        ) -> Result<Address, base_proof_contracts::ContractError> {
+            let block = root_claim.as_slice()[0] as u64;
+            let index = block / SUBMIT_BLOCK_INTERVAL;
+            if index > 0 && index <= self.submitted_games.load(Ordering::SeqCst) {
+                Ok(proxy_addr(index - 1))
+            } else {
+                Ok(Address::ZERO)
+            }
+        }
+    }
+
+    #[derive(Debug)]
+    struct AdvancingOutputProposer {
+        submitted_games: Arc<AtomicU64>,
+    }
+
+    #[async_trait]
+    impl OutputProposer for AdvancingOutputProposer {
+        async fn propose_output(
+            &self,
+            _: &Proposal,
+            _: Address,
+            _: &[B256],
+        ) -> Result<(), ProposerError> {
+            self.submitted_games.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        }
+    }
+
     /// `handle_proof_failure` increments per-target counters and drops the
     /// cached recovery once the target reaches `max_retries`.
     #[tokio::test(flavor = "current_thread", start_paused = true)]
@@ -2570,6 +2658,94 @@ mod tests {
             restart_rx.try_recv().expect("collector should request restart"),
             "submit failure"
         );
+    }
+
+    /// When the dispatcher has already produced a backlog of ready proofs, the
+    /// collector should submit each sequentially ready target in one tick
+    /// instead of sleeping `poll_interval` between successful submissions.
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn test_collector_tick_drains_ready_backlog_after_success() {
+        let submitted_games = Arc::new(AtomicU64::new(0));
+        let proof_requester = Arc::new(MockProofRequester::default());
+        let cancel = CancellationToken::new();
+        let l1 = Arc::new(MockL1 { latest_block_number: TEST_L1_BLOCK_NUMBER });
+        let l2 = Arc::new(MockL2 { block_not_found: true, canonical_hash: None });
+        let rollup = Arc::new(MockRollupClient {
+            sync_status: test_sync_status(SUBMIT_BLOCK_INTERVAL * 3, B256::ZERO),
+            output_roots: HashMap::new(),
+            max_safe_block: None,
+        });
+        let anchor_registry = Arc::new(MockAnchorStateRegistry {
+            anchor_root: test_anchor_root(TEST_ANCHOR_BLOCK),
+            anchor_game: Address::ZERO,
+        });
+        let factory =
+            Arc::new(AdvancingGameFactory { submitted_games: Arc::clone(&submitted_games) });
+        let output_proposer =
+            Arc::new(AdvancingOutputProposer { submitted_games: Arc::clone(&submitted_games) });
+
+        let pipeline = ProvingPipeline::new(
+            PipelineConfig {
+                submit_timeout: Duration::from_secs(60),
+                max_retries: 3,
+                recovery_scan_concurrency: 8,
+                tee_prover_registry_address: None,
+                driver: DriverConfig {
+                    game_type: TEST_GAME_TYPE,
+                    block_interval: SUBMIT_BLOCK_INTERVAL,
+                    intermediate_block_interval: SUBMIT_BLOCK_INTERVAL,
+                    poll_interval: Duration::from_millis(10),
+                    ..Default::default()
+                },
+            },
+            Arc::clone(&proof_requester) as Arc<dyn ProofRequesterProvider>,
+            l1,
+            l2,
+            rollup,
+            anchor_registry,
+            factory,
+            Arc::new(MockAggregateVerifier::default()),
+            output_proposer,
+            cancel,
+        );
+
+        let mut dispatch_cache: Option<CachedRecovery> = None;
+        let mut dispatch_retries: HashMap<u64, u32> = HashMap::new();
+        let mut dispatch_cursor: Option<RecoveredState> = None;
+        pipeline
+            .dispatcher_tick(&mut dispatch_cache, &mut dispatch_retries, &mut dispatch_cursor)
+            .await;
+
+        assert_eq!(
+            proof_requester.requests.lock().unwrap().len(),
+            3,
+            "test setup should dispatch three ready proofs"
+        );
+
+        let mut collect_cache: Option<CachedRecovery> = None;
+        let mut collect_retries: HashMap<u64, u32> = HashMap::new();
+        let mut collect_cursor: Option<RecoveredState> = None;
+        let mut discard_retry_counts: HashMap<u64, u32> = HashMap::new();
+        let mut retry_sessions: HashMap<u64, String> = HashMap::new();
+        let (restart_tx, mut restart_rx) = mpsc::channel(1);
+
+        pipeline
+            .collector_tick(
+                &mut collect_cache,
+                &mut collect_retries,
+                &mut collect_cursor,
+                &mut discard_retry_counts,
+                &mut retry_sessions,
+                &restart_tx,
+            )
+            .await;
+
+        assert_eq!(
+            submitted_games.load(Ordering::SeqCst),
+            3,
+            "collector should submit every ready proof without waiting another poll tick"
+        );
+        assert!(restart_rx.try_recv().is_err(), "successful backlog drain should not restart");
     }
 
     /// `submit_inline` with a `RootMismatch` outcome drops the cached

--- a/crates/proof/proposer/src/pipeline.rs
+++ b/crates/proof/proposer/src/pipeline.rs
@@ -96,6 +96,21 @@ enum PipelineSessionExit {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TaskKind {
+    Dispatcher,
+    Collector,
+}
+
+impl TaskKind {
+    const fn label(self) -> &'static str {
+        match self {
+            Self::Dispatcher => "dispatcher",
+            Self::Collector => "collector",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum DispatchOutcome {
     Accepted,
     Skipped,
@@ -296,14 +311,12 @@ where
             }
             result = &mut dispatcher => {
                 dispatcher_done = true;
-                result??;
-                warn!("Dispatcher loop exited unexpectedly, restarting pipeline session");
+                handle_task_result(TaskKind::Dispatcher, result);
                 PipelineSessionExit::Restart
             }
             result = &mut collector => {
                 collector_done = true;
-                result??;
-                warn!("Collector loop exited unexpectedly, restarting pipeline session");
+                handle_task_result(TaskKind::Collector, result);
                 PipelineSessionExit::Restart
             }
         };
@@ -772,6 +785,20 @@ where
         cache: &mut Option<CachedRecovery>,
         discard_retry: DiscardRetryState<'_>,
     ) {
+        let current_attempt = discard_retry.counts.get(&target_block).copied().unwrap_or(0);
+        if current_attempt >= self.config.max_retries {
+            error!(
+                target_block,
+                attempts = current_attempt,
+                max_retries = self.config.max_retries,
+                "Discard retry budget exhausted, dropping recovery cache"
+            );
+            discard_retry.counts.remove(&target_block);
+            discard_retry.sessions.remove(&target_block);
+            *cache = None;
+            return;
+        }
+
         let request = match self
             .build_proof_request_for(target_block, recovered, claimed_l2_output_root)
             .await
@@ -1336,6 +1363,23 @@ where
 async fn await_loop(handle: JoinHandle<Result<()>>) -> Result<()> {
     handle.await??;
     Ok(())
+}
+
+fn handle_task_result(
+    kind: TaskKind,
+    result: std::result::Result<Result<()>, tokio::task::JoinError>,
+) {
+    match result {
+        Ok(Ok(())) => {
+            warn!(task = kind.label(), "Pipeline task exited unexpectedly, restarting session");
+        }
+        Ok(Err(error)) => {
+            warn!(task = kind.label(), error = %error, "Pipeline task failed, restarting session");
+        }
+        Err(error) => {
+            warn!(task = kind.label(), error = %error, "Pipeline task panicked, restarting session");
+        }
+    }
 }
 
 async fn sleep_or_cancel(duration: Duration, cancel: &CancellationToken) {
@@ -2955,5 +2999,57 @@ mod tests {
             ),
             "discard retries must not reuse root-derived session id"
         );
+    }
+
+    /// Discard retries are capped so persistent discard reasons do not create
+    /// unbounded prover-service sessions for one target.
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn test_dispatch_discard_retry_exhaustion_drops_cache() {
+        let (pipeline, proof_requester, _cancel) = step_pipeline_full(
+            HashMap::new(),
+            SUBMIT_BLOCK_INTERVAL,
+            2,
+            Duration::from_secs(60),
+            Arc::new(MockOutputProposer),
+        );
+        let recovered = anchor_recovered_state();
+        let mut cache = Some(CachedRecovery { game_count: 0, state: recovered });
+        let mut retry_counts: HashMap<u64, u32> = HashMap::new();
+        let mut discard_retry_counts: HashMap<u64, u32> =
+            HashMap::from([(SUBMIT_BLOCK_INTERVAL, 2)]);
+        let mut retry_sessions: HashMap<u64, String> =
+            HashMap::from([(SUBMIT_BLOCK_INTERVAL, "stale-session".to_owned())]);
+
+        pipeline
+            .dispatch_discard_retry(
+                SUBMIT_BLOCK_INTERVAL,
+                &recovered,
+                B256::repeat_byte(SUBMIT_BLOCK_INTERVAL as u8),
+                &mut retry_counts,
+                &mut cache,
+                DiscardRetryState {
+                    counts: &mut discard_retry_counts,
+                    sessions: &mut retry_sessions,
+                },
+            )
+            .await;
+
+        assert!(cache.is_none(), "discard exhaustion should drop the recovery cache");
+        assert!(discard_retry_counts.is_empty(), "discard exhaustion should clear retry count");
+        assert!(retry_sessions.is_empty(), "discard exhaustion should clear retry session");
+        assert!(
+            proof_requester.requests.lock().unwrap().is_empty(),
+            "discard exhaustion should not dispatch another session"
+        );
+    }
+
+    /// A task panic is treated as a session restart instead of being
+    /// propagated out of the pipeline runner.
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_handle_task_result_treats_panic_as_restartable() {
+        let handle = tokio::spawn(async { panic!("simulated task panic") });
+        let result = handle.await;
+        assert!(result.is_err(), "test setup should produce a JoinError");
+        handle_task_result(TaskKind::Dispatcher, result.map(|()| Ok(())));
     }
 }

--- a/crates/proof/proposer/src/pipeline.rs
+++ b/crates/proof/proposer/src/pipeline.rs
@@ -1,38 +1,35 @@
-//! Parallel proving pipeline for the proposer.
+//! Self-driving proving pipeline for the proposer.
 //!
-//! The [`ProvingPipeline`] is an event-driven coordinator that runs multiple
-//! proofs concurrently while maintaining strictly sequential on-chain submission.
+//! The [`ProvingPipeline`] runs a single sequential loop: each iteration
+//! recovers the latest on-chain tip, derives the next target block, polls the
+//! prover service for its deterministic session, and either submits inline,
+//! dispatches a fresh request, waits, or treats the result as a transient
+//! failure.
 //!
-//! # Architecture
+//! # Iteration
 //!
 //! ```text
-//! ┌──────────┐     ┌──────────────┐     ┌──────────────┐
-//! │  PLAN    │ ──▶ │  PROVE       │ ──▶ │  SUBMIT      │
-//! │ (scan)   │     │ (parallel)   │     │ (at most 1)  │
-//! └──────────┘     └──────────────┘     └──────────────┘
+//! ┌──────────┐     ┌──────────────────┐     ┌────────────────────────┐
+//! │ RECOVER  │ ──▶ │ POLL(target)     │ ──▶ │ Ready    → submit      │
+//! │ (cached) │     │ (deterministic)  │     │ NotFound → dispatch    │
+//! └──────────┘     └──────────────────┘     │ Pending  → wait        │
+//!                                           │ Failed   → retry/drop  │
+//!                                           │ Unknown  → wait        │
+//!                                           └────────────────────────┘
 //! ```
 //!
-//! The coordinator loop uses `tokio::select!` over three event sources:
+//! There is no in-memory queue of dispatched-but-not-yet-collected sessions:
+//! the prover service is the source of truth and the collector rederives
+//! sessions from canonical output roots. State that survives across
+//! iterations is limited to the recovery cache and a per-target retry
+//! counter, both passed by reference into [`ProvingPipeline::step`].
 //!
-//! - **Submit completion** — when the spawned L1 transaction resolves, the
-//!   coordinator processes the outcome and (on success only) chains the next
-//!   submission immediately.
-//! - **Proof completion** — when any proof task finishes, its result is stored
-//!   in `proved` and the coordinator attempts to start a submission if one is
-//!   ready and no submission is in flight.
-//! - **Poll-interval tick** — periodic recovery scan that discovers new safe
-//!   head advances, refills proof slots, and retries failed submissions.
-//!
-//! Submission runs as a separate spawned task so the coordinator never blocks
-//! on L1 transaction confirmation. Failed submissions defer retry to the next
-//! tick rather than retrying immediately, preventing tight loops when L1 is
-//! persistently failing.
+//! On success the loop advances by exactly one `block_interval` per iteration;
+//! on `Pending` / `Unknown` it sleeps for `poll_interval` and retries. Submit
+//! is wrapped in [`tokio::time::timeout`] so a stuck L1 RPC never blocks
+//! progress beyond `submit_timeout`.
 
-use std::{
-    collections::{BTreeMap, BTreeSet, HashMap},
-    panic::AssertUnwindSafe,
-    sync::Arc,
-};
+use std::{collections::HashMap, sync::Arc, time::Duration};
 
 use alloy_primitives::{Address, B256};
 use base_proof_contracts::{
@@ -41,10 +38,8 @@ use base_proof_contracts::{
 use base_proof_primitives::{ProofRequest, ProofResult};
 use base_proof_rpc::{L1Provider, L2Provider, RollupProvider, RpcError};
 use base_prover_service_client::ProofRequesterProvider;
-use base_prover_service_protocol::TeeKind;
 use eyre::Result;
-use futures::{FutureExt, StreamExt, stream};
-use tokio::task::JoinSet;
+use futures::{StreamExt, stream};
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info, instrument, warn};
 
@@ -53,20 +48,24 @@ use crate::{
     driver::{DriverConfig, RecoveredState},
     error::ProposerError,
     output_proposer::OutputProposer,
-    proof_adapter::{ProofRequesterDispatcher, ProposerProofAdapter},
-    proof_collector::{CollectedProof, ProofCollector},
+    proof_adapter::ProofRequesterDispatcher,
+    proof_collector::{ProofCollector, TargetPoll},
     proof_submitter::{ProofSubmitter, ProofSubmitterConfig, SubmitAction},
 };
 
-/// Configuration for the parallel proving pipeline.
+/// Configuration for the self-driving proving pipeline.
 #[derive(Debug, Clone)]
 pub struct PipelineConfig {
-    /// Maximum retries for a single proof range before dropping that target
-    /// and the cached recovery; other in-flight and proved entries are
-    /// preserved.
+    /// Maximum retries for a single target block before dropping the cached
+    /// recovery. Only proof failures and dispatch RPC errors count against
+    /// this budget; transient submit and poll errors do not.
     pub max_retries: u32,
     /// Maximum number of concurrent RPC calls during the recovery scan.
     pub recovery_scan_concurrency: usize,
+    /// Maximum duration for a single inline submit (validation + L1
+    /// transaction). When exceeded, the loop logs and continues to the next
+    /// iteration without counting against the retry budget.
+    pub submit_timeout: Duration,
     /// Base driver configuration.
     pub driver: DriverConfig,
     /// Optional address of the `TEEProverRegistry` contract on L1.
@@ -97,72 +96,13 @@ struct CachedRecovery {
     state: RecoveredState,
 }
 
-/// Mutable state for the coordinator loop.
-struct PipelineState {
-    /// Running proof dispatch tasks, each accepting a prover-service session.
-    dispatch_tasks: JoinSet<ProofDispatchOutcome>,
-    /// At most one concurrent submission task.
-    submit_tasks: JoinSet<SubmitOutcome>,
-    /// Completed proofs waiting for sequential submission, keyed by target block.
-    proved: BTreeMap<u64, ProofResult>,
-    /// Target blocks currently being proved.
-    inflight: BTreeSet<u64>,
-    /// Target block currently being submitted (at most one).
-    submitting: Option<u64>,
-    /// Per-target-block retry counts; exceeding `max_retries` triggers a full reset.
-    retry_counts: BTreeMap<u64, u32>,
-    /// Cached result from the last successful recovery scan.
-    cached_recovery: Option<CachedRecovery>,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-struct ProofPlan {
-    start_block: u64,
-    target_block: u64,
-}
-
-enum ProofDispatchOutcome {
-    Accepted { plan: ProofPlan, session_id: String },
-    Failed { plan: ProofPlan, error: ProposerError },
-}
-
-impl PipelineState {
-    fn new() -> Self {
-        Self {
-            dispatch_tasks: JoinSet::new(),
-            submit_tasks: JoinSet::new(),
-            proved: BTreeMap::new(),
-            inflight: BTreeSet::new(),
-            submitting: None,
-            retry_counts: BTreeMap::new(),
-            cached_recovery: None,
-        }
-    }
-
-    fn record_gauges(&self) {
-        Metrics::inflight_proofs().set(self.inflight.len() as f64);
-        Metrics::proved_queue_depth().set(self.proved.len() as f64);
-        Metrics::pipeline_retries().set(self.retry_counts.values().sum::<u32>() as f64);
-    }
-
-    fn prune_stale(&mut self, recovered_block: u64) {
-        self.proved.retain(|&target, _| target > recovered_block);
-        self.inflight.retain(|&target| target > recovered_block);
-        self.retry_counts.retain(|&target, _| target > recovered_block);
-        // NOTE: we intentionally do NOT abort in-flight submit tasks here.
-        // When the recovered block advances past the submitting block, it
-        // means the transaction already landed on L1.  Aborting the task
-        // would prevent `handle_submit_result` from recording the
-        // `last_proposed_block` metric and performing proper state cleanup.
-        // The task will finish with `Success` or `GameAlreadyExists`, and
-        // `handle_submit_result` will clear `submitting` and update metrics.
-    }
-}
-
-/// The parallel proving pipeline.
+/// The self-driving proving pipeline.
 ///
-/// Orchestrates multiple concurrent proof tasks with a single-threaded
-/// coordinator loop.
+/// Runs a single sequential loop per [`Self::run`] call. Each iteration is
+/// independent and re-derives all required state from on-chain reads plus
+/// deterministic prover-service session lookups; the only state that
+/// survives across iterations is the recovery cache and per-target retry
+/// counts, both passed by reference into [`Self::step`].
 pub struct ProvingPipeline<L1, L2, R, ASR, F>
 where
     L1: L1Provider,
@@ -293,336 +233,297 @@ where
         self.cancel = cancel;
     }
 
-    /// Runs the parallel proving pipeline until cancelled.
+    /// Runs the self-driving proving pipeline until cancelled.
     ///
-    /// The coordinator never blocks on L1 transaction confirmation. Submission
-    /// runs as a separate spawned task while the coordinator continues to
-    /// collect proof completions and refill proof slots immediately.
+    /// Each iteration recovers the on-chain tip, derives the next target,
+    /// polls the prover service, and acts on the [`TargetPoll`] outcome by
+    /// submitting inline, dispatching a fresh request, waiting, or applying
+    /// the retry policy. Sleeps for `poll_interval` between iterations.
+    /// Cancellation is honored at every `await`.
     pub async fn run(&self) -> Result<()> {
         info!(
             block_interval = self.config.driver.block_interval,
-            "Starting parallel proving pipeline"
+            poll_interval_secs = self.config.driver.poll_interval.as_secs(),
+            submit_timeout_secs = self.config.submit_timeout.as_secs(),
+            "Starting self-driving proving pipeline"
         );
 
-        let mut state = PipelineState::new();
-        let mut poll_interval = tokio::time::interval(self.config.driver.poll_interval);
+        let mut cache: Option<CachedRecovery> = None;
+        let mut retry_counts: HashMap<u64, u32> = HashMap::new();
 
         loop {
             tokio::select! {
                 biased;
+                () = self.cancel.cancelled() => break,
+                () = self.step(&mut cache, &mut retry_counts) => {}
+            }
 
-                () = self.cancel.cancelled() => {
-                    state.dispatch_tasks.abort_all();
-                    state.submit_tasks.abort_all();
-                    break;
-                }
-
-                Some(result) = state.dispatch_tasks.join_next() => {
-                    self.handle_dispatch_result(result, &mut state);
-                }
-
-                Some(result) = state.submit_tasks.join_next() => {
-                    let chain_next = self.handle_submit_result(result, &mut state).await;
-                    if chain_next {
-                        self.try_submit(&mut state);
-                    }
-                }
-
-                _ = poll_interval.tick() => {
-                    if let Err(e) = self.tick(&mut state).await {
-                        error!(error = ?e, "Pipeline tick failed, retrying next interval");
-                    }
-                    self.try_submit(&mut state);
-                }
+            tokio::select! {
+                biased;
+                () = self.cancel.cancelled() => break,
+                () = tokio::time::sleep(self.config.driver.poll_interval) => {}
             }
         }
 
-        info!("Parallel proving pipeline stopped");
+        info!("Self-driving proving pipeline stopped");
         Ok(())
     }
 
+    /// Executes a single iteration of the self-driving loop.
+    ///
+    /// Recovers the on-chain tip, derives the next target block, polls the
+    /// prover service, and acts on the [`TargetPoll`] outcome.
     #[instrument(skip_all)]
-    async fn tick(&self, state: &mut PipelineState) -> Result<()> {
+    async fn step(&self, cache: &mut Option<CachedRecovery>, retry_counts: &mut HashMap<u64, u32>) {
         let _tick_timer = base_metrics::timed!(Metrics::tick_duration_seconds());
 
-        if let Some((recovered, safe_head)) =
-            self.try_recover_and_plan(&mut state.cached_recovery).await
-        {
-            Metrics::safe_head().set(safe_head as f64);
-            Metrics::last_proposed_block().set(recovered.l2_block_number as f64);
-            state.prune_stale(recovered.l2_block_number);
-            self.collect_proofs(&recovered, safe_head, state).await;
-            self.dispatch_proofs(&recovered, safe_head, state).await?;
-        }
-        Ok(())
-    }
-
-    #[instrument(skip_all, fields(
-        recovered_block = recovered.l2_block_number,
-        safe_head = safe_head,
-    ))]
-    async fn dispatch_proofs(
-        &self,
-        recovered: &RecoveredState,
-        safe_head: u64,
-        state: &mut PipelineState,
-    ) -> Result<()> {
-        let (plans, output_blocks) = self.plan_proofs(recovered, safe_head, state)?;
-
-        if plans.is_empty() {
-            state.record_gauges();
-            return Ok(());
-        }
-
-        let requests = match self
-            .build_proof_requests_for(recovered, &plans, output_blocks.into_iter().collect())
-            .await
-        {
-            Ok(requests) => requests,
-            Err(e) => {
-                warn!(error = %e, "Failed to build proof request batch");
-                state.record_gauges();
-                return Ok(());
-            }
-        };
-
-        for (plan, request) in requests {
-            let retry_count = state.retry_counts.get(&plan.target_block).copied().unwrap_or(0);
-            let session_id = ProposerProofAdapter::tee_session_id(&request, TeeKind::AwsNitro);
-            let dispatcher = self.proof_dispatcher.clone();
-            let cancel = self.cancel.child_token();
-
-            info!(
-                session_id = %session_id,
-                from_block = plan.start_block,
-                to_block = plan.target_block,
-                blocks = plan.target_block.saturating_sub(plan.start_block),
-                retry_count,
-                "Dispatching proof task"
-            );
-            state.inflight.insert(plan.target_block);
-            state.dispatch_tasks.spawn(async move {
-                let inner = async move {
-                    tokio::select! {
-                        () = cancel.cancelled() => {
-                            ProofDispatchOutcome::Failed {
-                                plan,
-                                error: ProposerError::Internal("cancelled".into()),
-                            }
-                        }
-                        result = dispatcher.dispatch_tee(request) => {
-                            match result {
-                                Ok(dispatched) if dispatched.session_id == session_id => {
-                                    ProofDispatchOutcome::Accepted { plan, session_id }
-                                }
-                                Ok(dispatched) => ProofDispatchOutcome::Failed {
-                                    plan,
-                                    error: ProposerError::Prover(format!(
-                                        "prover service returned mismatched session_id: expected {}, got {}",
-                                        session_id,
-                                        dispatched.session_id
-                                    )),
-                                },
-                                Err(error) => ProofDispatchOutcome::Failed { plan, error },
-                            }
-                        }
-                    }
-                };
-                // Catch panics inside the dispatch future so a single bad task
-                // never bubbles up as a tokio JoinError that the coordinator
-                // can't attribute to a specific target.
-                match AssertUnwindSafe(inner).catch_unwind().await {
-                    Ok(outcome) => outcome,
-                    Err(panic) => ProofDispatchOutcome::Failed {
-                        plan,
-                        error: ProposerError::Internal(format!(
-                            "proof dispatch task panicked: {}",
-                            panic_message(&panic),
-                        )),
-                    },
-                }
-            });
-        }
-
-        state.record_gauges();
-        Ok(())
-    }
-
-    fn plan_proofs(
-        &self,
-        recovered: &RecoveredState,
-        safe_head: u64,
-        state: &PipelineState,
-    ) -> Result<(Vec<ProofPlan>, BTreeSet<u64>)> {
-        let mut cursor = recovered
-            .l2_block_number
-            .checked_add(self.config.driver.block_interval)
-            .ok_or_else(|| {
-            eyre::eyre!(
-                "overflow: l2_block_number {} + block_interval {}",
-                recovered.l2_block_number,
-                self.config.driver.block_interval
-            )
-        })?;
-
-        let mut start_block = recovered.l2_block_number;
-        let mut plans = Vec::new();
-        let mut output_blocks = BTreeSet::new();
-
-        // Plan every eligible target up to the safe head. There is no per-tick
-        // parallel cap: dispatch is fire-and-forget against the prover service
-        // (which queues sessions itself) and collection is naturally bounded
-        // by the safe head's distance from the recovered tip.
-        while cursor <= safe_head {
-            let mut last_skipped = None;
-            while cursor <= safe_head
-                && (state.inflight.contains(&cursor)
-                    || state.proved.contains_key(&cursor)
-                    || state.submitting == Some(cursor))
-            {
-                last_skipped = Some(cursor);
-                cursor = match cursor.checked_add(self.config.driver.block_interval) {
-                    Some(c) => c,
-                    None => return Ok((plans, output_blocks)),
-                };
-            }
-
-            if cursor > safe_head {
-                break;
-            }
-
-            if let Some(skipped) = last_skipped {
-                start_block = skipped;
-                output_blocks.insert(skipped);
-            }
-
-            plans.push(ProofPlan { start_block, target_block: cursor });
-            output_blocks.insert(cursor);
-            start_block = cursor;
-
-            cursor = match cursor.checked_add(self.config.driver.block_interval) {
-                Some(c) => c,
-                None => break,
-            };
-        }
-        Ok((plans, output_blocks))
-    }
-
-    fn handle_dispatch_result(
-        &self,
-        join_result: Result<ProofDispatchOutcome, tokio::task::JoinError>,
-        state: &mut PipelineState,
-    ) {
-        let outcome = match join_result {
-            Ok(outcome) => outcome,
-            Err(join_err) if join_err.is_cancelled() => {
-                debug!(error = %join_err, "Proof dispatch task cancelled");
-                return;
-            }
-            Err(join_err) => {
-                // Panics inside dispatch futures are caught and returned as
-                // `ProofDispatchOutcome::Failed` with target context. A raw
-                // join error here has no target block, so stale inflight
-                // cleanup falls back to `prune_stale`.
-                warn!(error = %join_err, "Proof dispatch task join error");
-                state.record_gauges();
+        let (recovered, safe_head) = match self.try_recover_and_plan(cache).await {
+            Some(pair) => pair,
+            None => {
+                Metrics::pipeline_retries().set(retry_counts.values().sum::<u32>() as f64);
                 return;
             }
         };
 
-        match outcome {
-            ProofDispatchOutcome::Accepted { plan, session_id } => {
-                if !state.inflight.contains(&plan.target_block)
-                    || state.proved.contains_key(&plan.target_block)
-                {
-                    debug!(
-                        target_block = plan.target_block,
-                        session_id = %session_id,
-                        "Ignoring stale proof dispatch result"
+        Metrics::safe_head().set(safe_head as f64);
+
+        // Drop retry counters for targets the chain has already passed.
+        retry_counts.retain(|&target, _| target > recovered.l2_block_number);
+
+        let target_block =
+            match recovered.l2_block_number.checked_add(self.config.driver.block_interval) {
+                Some(t) => t,
+                None => {
+                    error!(
+                        recovered_block = recovered.l2_block_number,
+                        block_interval = self.config.driver.block_interval,
+                        "Overflow computing next target block, halting iteration"
                     );
                     return;
                 }
+            };
 
+        if target_block > safe_head {
+            debug!(
+                recovered_block = recovered.l2_block_number,
+                target_block,
+                safe_head,
+                "Safe head below next target, waiting for L2 head to advance"
+            );
+            Metrics::pipeline_retries().set(retry_counts.values().sum::<u32>() as f64);
+            return;
+        }
+
+        match self.proof_collector.poll(target_block).await {
+            TargetPoll::Ready { session_id, proof } => {
                 info!(
-                    target_block = plan.target_block,
+                    target_block,
                     session_id = %session_id,
-                    from_block = plan.start_block,
+                    "Proof ready, submitting inline"
+                );
+                Metrics::proof_collection_total(Metrics::COLLECTION_OUTCOME_READY).increment(1);
+                self.submit_inline(target_block, &recovered, proof, retry_counts, cache).await;
+            }
+            TargetPoll::Pending { session_id, status } => {
+                debug!(
+                    target_block,
+                    session_id = %session_id,
+                    ?status,
+                    "Proof pending, waiting for prover service"
+                );
+            }
+            TargetPoll::NotFound { session_id } => {
+                info!(
+                    target_block,
+                    session_id = %session_id,
+                    "No prover-service session for target, dispatching"
+                );
+                self.dispatch_for(target_block, &recovered, retry_counts, cache).await;
+            }
+            TargetPoll::Failed { session_id, error } => {
+                warn!(
+                    target_block,
+                    session_id = %session_id,
+                    error = %error,
+                    "Prover service reported failed session"
+                );
+                Metrics::proof_collection_total(Metrics::COLLECTION_OUTCOME_FAILED).increment(1);
+                self.handle_proof_failure(target_block, error, retry_counts, cache);
+            }
+            TargetPoll::Unknown { session_id, error } => {
+                debug!(
+                    target_block,
+                    session_id = ?session_id,
+                    error = %error,
+                    "Transient poll failure, will retry next iteration"
+                );
+            }
+        }
+
+        Metrics::pipeline_retries().set(retry_counts.values().sum::<u32>() as f64);
+    }
+
+    /// Validates and submits the proof inline against the `submit_timeout`
+    /// budget.
+    ///
+    /// On success, advances `last_proposed_block` and `last_collected_block`,
+    /// drops the per-target retry counter, and refreshes the recovery cache
+    /// incrementally. Submit failures are transient by default — they do not
+    /// count against the per-target retry budget — except `RootMismatch` and
+    /// `Failed { is_invalid_parent_game }`, which drop the cached recovery
+    /// so the next iteration re-walks the chain.
+    async fn submit_inline(
+        &self,
+        target_block: u64,
+        recovered: &RecoveredState,
+        proof: ProofResult,
+        retry_counts: &mut HashMap<u64, u32>,
+        cache: &mut Option<CachedRecovery>,
+    ) {
+        let parent_address = recovered.parent_address;
+        info!(target_block, parent_address = %parent_address, "Submitting proof inline");
+
+        let mut submit_timer = base_metrics::timed!(Metrics::proposal_total_duration_seconds());
+        let result = tokio::time::timeout(
+            self.config.submit_timeout,
+            self.validate_and_submit(&proof, target_block, parent_address),
+        )
+        .await;
+
+        match result {
+            Err(_) => {
+                submit_timer.disarm();
+                warn!(
+                    target_block,
+                    timeout_secs = self.config.submit_timeout.as_secs(),
+                    "Inline submit timed out, will retry next iteration"
+                );
+            }
+            Ok(Ok(())) => {
+                drop(submit_timer);
+                info!(target_block, "Submission successful");
+                Metrics::last_proposed_block().set(target_block as f64);
+                Metrics::last_collected_block().set(target_block as f64);
+                retry_counts.remove(&target_block);
+                if let Err(e) = self.recover_latest_state(cache).await {
+                    warn!(error = %e, "Failed to recover state after submission");
+                }
+            }
+            Ok(Err(SubmitAction::RootMismatch)) => {
+                submit_timer.disarm();
+                warn!(target_block, "Output root mismatch at submit time, dropping recovery cache");
+                Metrics::root_mismatch_total().increment(1);
+                *cache = None;
+            }
+            Ok(Err(SubmitAction::GameAlreadyExists)) => {
+                submit_timer.disarm();
+                info!(target_block, "Game already exists on chain");
+                Metrics::last_proposed_block().set(target_block as f64);
+                Metrics::last_collected_block().set(target_block as f64);
+                retry_counts.remove(&target_block);
+                // The game exists but the forward walk missed it — most
+                // likely because `game_count` was read from a different L1
+                // RPC replica than the one serving `factory.games()`.
+                // Decrement the cached game_count so the next recovery sees
+                // `actual_count > cached_count` and performs an incremental
+                // forward walk.
+                if let Some(cached) = cache.as_mut() {
+                    cached.game_count = cached.game_count.saturating_sub(1);
+                }
+                if let Err(e) = self.recover_latest_state(cache).await {
+                    warn!(error = %e, "Failed to recover state after GameAlreadyExists");
+                }
+            }
+            Ok(Err(SubmitAction::Failed(error))) => {
+                submit_timer.disarm();
+                Metrics::errors_total(error.metric_label()).increment(1);
+                if error.is_invalid_parent_game() {
+                    warn!(
+                        target_block,
+                        error = %error,
+                        "Submission rejected: parent game invalid, dropping recovery cache"
+                    );
+                    *cache = None;
+                } else {
+                    warn!(
+                        target_block,
+                        error = %error,
+                        "Submission failed, will retry next iteration"
+                    );
+                }
+            }
+            Ok(Err(SubmitAction::Discard(error))) => {
+                submit_timer.disarm();
+                Metrics::errors_total(error.metric_label()).increment(1);
+                warn!(
+                    target_block,
+                    error = %error,
+                    "Proof discarded by submitter, will re-derive next iteration"
+                );
+            }
+        }
+    }
+
+    /// Builds and dispatches a fresh `prove_block_range` request for
+    /// `target_block`.
+    ///
+    /// Treats request-build failures and dispatcher errors uniformly via
+    /// [`Self::handle_proof_failure`].
+    async fn dispatch_for(
+        &self,
+        target_block: u64,
+        recovered: &RecoveredState,
+        retry_counts: &mut HashMap<u64, u32>,
+        cache: &mut Option<CachedRecovery>,
+    ) {
+        let request = match self.build_proof_request_for(target_block, recovered).await {
+            Ok(req) => req,
+            Err(e) => {
+                warn!(
+                    target_block,
+                    error = %e,
+                    "Failed to build proof request, treating as proof failure"
+                );
+                Metrics::proof_dispatch_total(Metrics::DISPATCH_OUTCOME_FAILED).increment(1);
+                self.handle_proof_failure(target_block, e, retry_counts, cache);
+                return;
+            }
+        };
+
+        match self.proof_dispatcher.dispatch_tee(request).await {
+            Ok(dispatched) => {
+                info!(
+                    target_block,
+                    session_id = %dispatched.session_id,
+                    from_block = recovered.l2_block_number,
                     "Proof request accepted by prover service"
                 );
                 Metrics::proof_dispatch_total(Metrics::DISPATCH_OUTCOME_ACCEPTED).increment(1);
-                state.record_gauges();
             }
-            ProofDispatchOutcome::Failed { plan, error } => {
-                if !state.inflight.contains(&plan.target_block)
-                    || state.proved.contains_key(&plan.target_block)
-                {
-                    debug!(
-                        target_block = plan.target_block,
-                        error = %error,
-                        "Ignoring stale proof dispatch failure"
-                    );
-                    return;
-                }
-
+            Err(error) => {
                 Metrics::proof_dispatch_total(Metrics::DISPATCH_OUTCOME_FAILED).increment(1);
-                self.handle_proof_failure(plan.target_block, error, state);
+                self.handle_proof_failure(target_block, error, retry_counts, cache);
             }
         }
     }
 
-    async fn collect_proofs(
+    /// Records a proof failure for `target` and applies the retry policy.
+    ///
+    /// Increments `proof_retries_total` and the per-target counter. When the
+    /// counter reaches `max_retries`, drops the cached recovery so the next
+    /// iteration performs a full forward walk.
+    fn handle_proof_failure(
         &self,
-        recovered: &RecoveredState,
-        safe_head: u64,
-        state: &mut PipelineState,
+        target: u64,
+        error: ProposerError,
+        retry_counts: &mut HashMap<u64, u32>,
+        cache: &mut Option<CachedRecovery>,
     ) {
-        // Compute targets synchronously while we still hold an immutable view of
-        // `state` so the collector itself can run without borrowing pipeline state
-        // across await points.
-        let targets = self.proof_collector.collectable_targets(recovered, safe_head, |target| {
-            state.proved.contains_key(&target) || state.submitting == Some(target)
-        });
-
-        for outcome in self.proof_collector.collect(&targets).await {
-            match outcome {
-                CollectedProof::Ready { target_block, session_id, proof } => {
-                    state.inflight.remove(&target_block);
-                    state.retry_counts.remove(&target_block);
-                    state.proved.insert(target_block, proof);
-                    Metrics::proof_collection_total(Metrics::COLLECTION_OUTCOME_READY).increment(1);
-                    Metrics::last_collected_block().set(target_block as f64);
-                    state.record_gauges();
-                    info!(
-                        target_block,
-                        session_id = %session_id,
-                        "Proof completed successfully"
-                    );
-                }
-                CollectedProof::Failed { target_block, session_id, error } => {
-                    if !state.inflight.contains(&target_block) {
-                        debug!(
-                            target_block,
-                            session_id = %session_id,
-                            error = %error,
-                            "Ignoring failed proof result for non-inflight target"
-                        );
-                        continue;
-                    }
-
-                    Metrics::proof_collection_total(Metrics::COLLECTION_OUTCOME_FAILED)
-                        .increment(1);
-                    self.handle_proof_failure(target_block, error, state);
-                }
-            }
-        }
-    }
-
-    fn handle_proof_failure(&self, target: u64, error: ProposerError, state: &mut PipelineState) {
         Metrics::errors_total(error.metric_label()).increment(1);
-        state.inflight.remove(&target);
-        let count = state.retry_counts.entry(target).or_insert(0);
-        *count += 1;
         Metrics::proof_retries_total().increment(1);
+
+        let count = retry_counts.entry(target).or_insert(0);
+        *count += 1;
         if *count >= self.config.max_retries {
             error!(
                 target_block = target,
@@ -630,222 +531,15 @@ where
                 error = %error,
                 "Proof failed after max retries, dropping cached recovery"
             );
-            state.retry_counts.remove(&target);
-            state.cached_recovery = None;
+            retry_counts.remove(&target);
+            *cache = None;
         } else {
             warn!(
                 target_block = target,
                 attempt = *count,
                 error = %error,
-                "Proof failed, will retry next tick"
+                "Proof failed, will retry next iteration"
             );
-        }
-        state.record_gauges();
-    }
-
-    fn try_submit(&self, state: &mut PipelineState) {
-        if state.submitting.is_some() || !state.submit_tasks.is_empty() {
-            return;
-        }
-
-        let recovered = match &state.cached_recovery {
-            Some(cached) => cached.state,
-            _ => return,
-        };
-
-        let next_to_submit =
-            match recovered.l2_block_number.checked_add(self.config.driver.block_interval) {
-                Some(n) => n,
-                None => return,
-            };
-
-        let proof_result = match state.proved.remove(&next_to_submit) {
-            Some(r) => r,
-            None => return,
-        };
-
-        let parent_address = recovered.parent_address;
-        state.submitting = Some(next_to_submit);
-        state.record_gauges();
-
-        info!(target_block = next_to_submit, parent_address = %parent_address, "Spawning submission task");
-
-        let pipeline = self.clone();
-        // Keep a clone outside the spawned future so a panic inside the task
-        // does not destroy the proof; the catch_unwind branch re-attaches it
-        // to a Failed outcome so the coordinator can re-queue it for retry.
-        let proof_for_panic = proof_result.clone();
-        state.submit_tasks.spawn(async move {
-            let inner = async move {
-                let mut submit_timer =
-                    base_metrics::timed!(Metrics::proposal_total_duration_seconds());
-                let result = pipeline
-                    .validate_and_submit(&proof_result, next_to_submit, parent_address)
-                    .await;
-                match result {
-                    Ok(()) => {
-                        drop(submit_timer);
-                        SubmitOutcome::Success { target_block: next_to_submit }
-                    }
-                    Err(SubmitAction::RootMismatch) => {
-                        submit_timer.disarm();
-                        SubmitOutcome::RootMismatch { target_block: next_to_submit }
-                    }
-                    Err(SubmitAction::Failed(e)) => {
-                        submit_timer.disarm();
-                        SubmitOutcome::Failed {
-                            target_block: next_to_submit,
-                            proof: proof_result,
-                            error: e,
-                        }
-                    }
-                    Err(SubmitAction::GameAlreadyExists) => {
-                        submit_timer.disarm();
-                        SubmitOutcome::GameAlreadyExists { target_block: next_to_submit }
-                    }
-                    Err(SubmitAction::Discard(e)) => {
-                        submit_timer.disarm();
-                        SubmitOutcome::Discard { target_block: next_to_submit, error: e }
-                    }
-                }
-            };
-            match AssertUnwindSafe(inner).catch_unwind().await {
-                Ok(outcome) => outcome,
-                Err(panic) => SubmitOutcome::Failed {
-                    target_block: next_to_submit,
-                    proof: proof_for_panic,
-                    error: ProposerError::Internal(format!(
-                        "submit task panicked: {}",
-                        panic_message(&panic)
-                    )),
-                },
-            }
-        });
-    }
-
-    /// Returns `true` when the caller should immediately attempt the next
-    /// submission (i.e. on success). Returns `false` on failure/discard so
-    /// that retry is deferred to the next poll-interval tick.
-    async fn handle_submit_result(
-        &self,
-        join_result: Result<SubmitOutcome, tokio::task::JoinError>,
-        state: &mut PipelineState,
-    ) -> bool {
-        let outcome = match join_result {
-            Ok(outcome) => outcome,
-            Err(join_err) if join_err.is_cancelled() => {
-                debug!(error = %join_err, "Submit task cancelled");
-                state.submitting = None;
-                return false;
-            }
-            Err(join_err) => {
-                // Panics are caught inside the spawned future and reported as
-                // SubmitOutcome::Failed (with the proof re-attached) so this
-                // branch should not normally fire. Treat as a transient
-                // failure: release the slot and leave `proved` intact.
-                warn!(error = %join_err, "Submit task join error");
-                state.submitting = None;
-                state.record_gauges();
-                return false;
-            }
-        };
-
-        match outcome {
-            SubmitOutcome::Success { target_block } => {
-                info!(target_block, "Submission successful");
-                Metrics::last_proposed_block().set(target_block as f64);
-                state.retry_counts.remove(&target_block);
-                state.submitting = None;
-                // Don't clear the cache — recover_latest_state will see the
-                // new game_count and incrementally scan just the new entry.
-                match self.recover_latest_state(&mut state.cached_recovery).await {
-                    Ok(recovered) => {
-                        state.prune_stale(recovered.l2_block_number);
-                    }
-                    Err(e) => {
-                        warn!(error = %e, "Failed to recover state after submission");
-                    }
-                }
-                state.record_gauges();
-                true
-            }
-            SubmitOutcome::GameAlreadyExists { target_block } => {
-                info!(target_block, "Game already exists on chain");
-                Metrics::last_proposed_block().set(target_block as f64);
-                state.retry_counts.remove(&target_block);
-                state.submitting = None;
-                // The game exists but the forward walk missed it — most
-                // likely because `game_count` was read from a different L1
-                // RPC replica than the one serving `factory.games()`.
-                // Decrement the cached game_count so the next recovery sees
-                // `actual_count > cached_count` and performs an incremental
-                // forward walk from the cached tip (O(1): a single
-                // `factory.games()` lookup at the next expected block).
-                if let Some(ref mut cached) = state.cached_recovery {
-                    cached.game_count = cached.game_count.saturating_sub(1);
-                }
-                match self.recover_latest_state(&mut state.cached_recovery).await {
-                    Ok(recovered) => {
-                        state.prune_stale(recovered.l2_block_number);
-                    }
-                    Err(e) => {
-                        warn!(error = %e, "Failed to recover state after GameAlreadyExists");
-                    }
-                }
-                state.record_gauges();
-                true
-            }
-            SubmitOutcome::RootMismatch { target_block } => {
-                warn!(
-                    target_block,
-                    "Output root mismatch at submit time, dropping cached recovery"
-                );
-                Metrics::root_mismatch_total().increment(1);
-                // The mismatched proof was already removed from `proved` by
-                // `try_submit`. Drop the recovery cache so the next tick
-                // re-walks the chain and `prune_stale` evicts any newly
-                // overtaken entries. Other proved entries are left intact:
-                // each faces JIT validation independently at submit time and
-                // any that have gone stale will self-eject via this same
-                // path. Re-proving a still-valid block is much more expensive
-                // than one extra JIT validation RPC.
-                state.cached_recovery = None;
-                state.submitting = None;
-                state.record_gauges();
-                false
-            }
-            SubmitOutcome::Failed { target_block, proof, error } => {
-                Metrics::errors_total(error.metric_label()).increment(1);
-                // Drop the cache only when the contract explicitly reports
-                // the parent is no longer valid; transient failures (RPC,
-                // gas/nonce, signing) leave it intact to avoid an
-                // unnecessary forward walk on the next tick.
-                if error.is_invalid_parent_game() {
-                    warn!(
-                        error = %error,
-                        target_block,
-                        "Submission rejected: parent game invalid, dropping recovery cache"
-                    );
-                    state.cached_recovery = None;
-                } else {
-                    warn!(error = %error, target_block, "Submission failed, will retry");
-                }
-                state.proved.insert(target_block, proof);
-                state.submitting = None;
-                state.record_gauges();
-                false
-            }
-            SubmitOutcome::Discard { target_block, error } => {
-                Metrics::errors_total(error.metric_label()).increment(1);
-                warn!(
-                    error = %error,
-                    target_block,
-                    "Proof discarded, will re-prove"
-                );
-                state.submitting = None;
-                state.record_gauges();
-                false
-            }
         }
     }
 
@@ -1222,139 +916,64 @@ where
             .await
     }
 
-    async fn build_proof_requests_for(
+    /// Builds a proof request for a single `target_block`, parallelising the
+    /// three required RPCs: L1 head header, target-block canonical output
+    /// root, and L2 head at the recovered tip.
+    async fn build_proof_request_for(
         &self,
+        target_block: u64,
         recovered: &RecoveredState,
-        plans: &[ProofPlan],
-        output_blocks: Vec<u64>,
-    ) -> Result<Vec<(ProofPlan, ProofRequest)>, ProposerError> {
-        let start_blocks: Vec<u64> = plans
-            .iter()
-            .map(|plan| plan.start_block)
-            .collect::<BTreeSet<_>>()
-            .into_iter()
-            .collect();
-
-        let (l1_head_result, output_roots, l2_heads) = tokio::join!(
+    ) -> Result<ProofRequest, ProposerError> {
+        let (l1_head_result, target_root_result, agreed_head_result) = tokio::join!(
             async { self.l1_client.header_by_number(None).await.map_err(ProposerError::Rpc) },
-            self.fetch_canonical_root_results(output_blocks),
             async {
-                stream::iter(start_blocks)
-                    .map(|block_number| {
-                        let l2 = &self.l2_client;
-                        async move {
-                            let result = l2
-                                .header_by_number(Some(block_number))
-                                .await
-                                .map_err(ProposerError::Rpc);
-                            (block_number, result)
-                        }
-                    })
-                    .buffered(self.config.recovery_scan_concurrency)
-                    .collect::<HashMap<_, _>>()
+                self.rollup_client
+                    .output_at_block(target_block)
                     .await
+                    .map(|out| out.output_root)
+                    .map_err(ProposerError::Rpc)
+            },
+            async {
+                self.l2_client
+                    .header_by_number(Some(recovered.l2_block_number))
+                    .await
+                    .map_err(ProposerError::Rpc)
             },
         );
+
         let l1_head = l1_head_result?;
+        let claimed_l2_output_root = target_root_result?;
+        let agreed_l2_head = agreed_head_result?;
 
-        let mut requests = Vec::with_capacity(plans.len());
-        for plan in plans {
-            let agreed_l2_head = match l2_heads.get(&plan.start_block) {
-                Some(Ok(header)) => header,
-                Some(Err(e)) => {
-                    warn!(
-                        error = %e,
-                        start_block = plan.start_block,
-                        target_block = plan.target_block,
-                        "Stopping proof request batch after L2 header fetch failed"
-                    );
-                    break;
-                }
-                None => {
-                    warn!(
-                        start_block = plan.start_block,
-                        target_block = plan.target_block,
-                        "Stopping proof request batch because L2 header is missing"
-                    );
-                    break;
-                }
-            };
+        let request = ProofRequest {
+            l1_head: l1_head.hash,
+            agreed_l2_head_hash: agreed_l2_head.hash,
+            agreed_l2_output_root: recovered.output_root,
+            claimed_l2_output_root,
+            claimed_l2_block_number: target_block,
+            proposer: self.config.driver.proposer_address,
+            intermediate_block_interval: self.config.driver.intermediate_block_interval,
+            l1_head_number: l1_head.number,
+            image_hash: self.config.driver.tee_image_hash,
+        };
 
-            let agreed_output_root = if plan.start_block == recovered.l2_block_number {
-                recovered.output_root
-            } else {
-                match output_roots.get(&plan.start_block) {
-                    Some(Ok(root)) => *root,
-                    Some(Err(e)) => {
-                        warn!(
-                            error = %e,
-                            start_block = plan.start_block,
-                            target_block = plan.target_block,
-                            "Stopping proof request batch after start output fetch failed"
-                        );
-                        break;
-                    }
-                    None => {
-                        warn!(
-                            start_block = plan.start_block,
-                            target_block = plan.target_block,
-                            "Stopping proof request batch because start output is missing"
-                        );
-                        break;
-                    }
-                }
-            };
+        info!(
+            from_block = recovered.l2_block_number,
+            to_block = target_block,
+            l1_head_number = l1_head.number,
+            "Built proof request"
+        );
 
-            let claimed_l2_output_root = match output_roots.get(&plan.target_block) {
-                Some(Ok(root)) => *root,
-                Some(Err(e)) => {
-                    warn!(
-                        error = %e,
-                        target_block = plan.target_block,
-                        "Stopping proof request batch after target output fetch failed"
-                    );
-                    break;
-                }
-                None => {
-                    warn!(
-                        target_block = plan.target_block,
-                        "Stopping proof request batch because target output is missing"
-                    );
-                    break;
-                }
-            };
-
-            let request = ProofRequest {
-                l1_head: l1_head.hash,
-                agreed_l2_head_hash: agreed_l2_head.hash,
-                agreed_l2_output_root: agreed_output_root,
-                claimed_l2_output_root,
-                claimed_l2_block_number: plan.target_block,
-                proposer: self.config.driver.proposer_address,
-                intermediate_block_interval: self.config.driver.intermediate_block_interval,
-                l1_head_number: l1_head.number,
-                image_hash: self.config.driver.tee_image_hash,
-            };
-
-            info!(
-                from_block = plan.start_block,
-                to_block = plan.target_block,
-                l1_head_number = l1_head.number,
-                "Built proof request for parallel proving"
-            );
-
-            requests.push((*plan, request));
-        }
-
-        Ok(requests)
+        Ok(request)
     }
 
     /// Validates the proof and submits it to L1 by delegating to the
     /// [`ProofSubmitter`].
     ///
-    /// Kept on the pipeline as a thin wrapper so the spawned submission task
-    /// in [`Self::try_submit`] (and existing tests) can continue to call a
-    /// single entry point.
+    /// Kept on the pipeline as a thin wrapper so the inline submit path in
+    /// [`Self::submit_inline`] (and existing tests) can continue to call a
+    /// single entry point. This method itself does NOT apply
+    /// `submit_timeout`; the timeout is applied by [`Self::submit_inline`].
     async fn validate_and_submit(
         &self,
         proof_result: &ProofResult,
@@ -1365,34 +984,9 @@ where
     }
 }
 
-/// Extracts a printable message from a `catch_unwind` panic payload.
-fn panic_message(panic: &Box<dyn std::any::Any + Send + 'static>) -> String {
-    panic
-        .downcast_ref::<&'static str>()
-        .map(|s| (*s).to_string())
-        .or_else(|| panic.downcast_ref::<String>().cloned())
-        .unwrap_or_else(|| "non-string panic payload".to_string())
-}
-
-/// Result of a concurrent submission task, returned to the coordinator.
-enum SubmitOutcome {
-    Success { target_block: u64 },
-    GameAlreadyExists { target_block: u64 },
-    RootMismatch { target_block: u64 },
-    Failed { target_block: u64, proof: ProofResult, error: ProposerError },
-    Discard { target_block: u64, error: ProposerError },
-}
-
 #[cfg(test)]
 mod tests {
-    use std::{
-        collections::HashMap,
-        sync::{
-            Arc,
-            atomic::{AtomicUsize, Ordering},
-        },
-        time::Duration,
-    };
+    use std::{collections::HashMap, sync::Arc, time::Duration};
 
     use alloy_primitives::{Address, B256};
     use async_trait::async_trait;
@@ -1545,38 +1139,6 @@ mod tests {
         }
     }
 
-    fn test_pipeline(
-        pipeline_config: PipelineConfig,
-        safe_block_number: u64,
-        cancel: CancellationToken,
-    ) -> TestPipeline {
-        let l1 = Arc::new(MockL1 { latest_block_number: TEST_L1_BLOCK_NUMBER });
-        let l2 = Arc::new(MockL2 { block_not_found: true, canonical_hash: None });
-        let rollup = Arc::new(MockRollupClient {
-            sync_status: test_sync_status(safe_block_number, B256::ZERO),
-            output_roots: HashMap::new(),
-            max_safe_block: None,
-        });
-        let anchor_registry = Arc::new(MockAnchorStateRegistry {
-            anchor_root: test_anchor_root(TEST_ANCHOR_BLOCK),
-            anchor_game: Address::ZERO,
-        });
-        let factory = Arc::new(MockDisputeGameFactory::with_games(vec![]));
-
-        ProvingPipeline::new(
-            pipeline_config,
-            Arc::new(MockProofRequester::default()),
-            l1,
-            l2,
-            rollup,
-            anchor_registry,
-            factory,
-            Arc::new(MockAggregateVerifier::default()),
-            Arc::new(MockOutputProposer),
-            cancel,
-        )
-    }
-
     /// Builds a recovery pipeline with a pre-configured factory and canonical
     /// output roots. Uses default anchor block and block interval.
     fn recovery_pipeline(
@@ -1671,6 +1233,7 @@ mod tests {
 
         ProvingPipeline::new(
             PipelineConfig {
+                submit_timeout: std::time::Duration::from_secs(60),
                 max_retries: 1,
                 recovery_scan_concurrency: 8,
                 tee_prover_registry_address: None,
@@ -1694,174 +1257,6 @@ mod tests {
     }
 
     // ---- Pipeline lifecycle tests ----
-
-    #[tokio::test(flavor = "current_thread", start_paused = true)]
-    async fn test_pipeline_cancellation() {
-        let cancel = CancellationToken::new();
-        let pipeline = test_pipeline(
-            PipelineConfig {
-                max_retries: 3,
-                recovery_scan_concurrency: 8,
-                tee_prover_registry_address: None,
-                driver: DriverConfig {
-                    poll_interval: Duration::from_secs(3600),
-                    block_interval: TEST_BLOCK_INTERVAL,
-                    intermediate_block_interval: TEST_BLOCK_INTERVAL,
-                    ..Default::default()
-                },
-            },
-            200, // safe head below first target, so no proofs dispatched
-            cancel.clone(),
-        );
-
-        let handle = tokio::spawn(async move { pipeline.run().await });
-        cancel.cancel();
-
-        let result = handle.await.expect("task should not panic");
-        assert!(result.is_ok(), "run() should return Ok on cancellation");
-    }
-
-    #[tokio::test(flavor = "current_thread", start_paused = true)]
-    async fn test_pipeline_proves_and_submits() {
-        let cancel = CancellationToken::new();
-        let pipeline = test_pipeline(
-            PipelineConfig {
-                max_retries: 3,
-                recovery_scan_concurrency: 8,
-                tee_prover_registry_address: None,
-                driver: DriverConfig {
-                    poll_interval: Duration::from_millis(100),
-                    block_interval: TEST_BLOCK_INTERVAL,
-                    intermediate_block_interval: TEST_BLOCK_INTERVAL,
-                    ..Default::default()
-                },
-            },
-            TEST_BLOCK_INTERVAL, // safe head at first target block
-            cancel.clone(),
-        );
-
-        let handle = tokio::spawn(async move { pipeline.run().await });
-
-        tokio::time::sleep(Duration::from_secs(5)).await;
-        cancel.cancel();
-
-        let result = handle.await.expect("task should not panic");
-        assert!(result.is_ok());
-    }
-
-    #[cfg(feature = "metrics")]
-    #[test]
-    fn test_tick_records_recovered_last_proposed_block() {
-        let (factory, output_roots) = game_chain(1);
-        let pipeline = recovery_pipeline(factory, output_roots);
-
-        with_recorder(|snap| {
-            let rt = tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap();
-            let mut state = PipelineState::new();
-
-            rt.block_on(async {
-                pipeline.tick(&mut state).await.unwrap();
-            });
-
-            let snapshot = snap.snapshot().into_vec();
-            match find_metric(&snapshot, MetricKind::Gauge, "base_proposer.last_proposed_block") {
-                Some(DebugValue::Gauge(value)) => {
-                    assert_eq!(value.into_inner(), TEST_BLOCK_INTERVAL as f64);
-                }
-                other => panic!("expected recovered last_proposed_block gauge, got {other:?}"),
-            }
-        });
-    }
-
-    /// Verifies `handle_proof_failure` increments `proof_retries_total` on every
-    /// retry attempt below `max_retries`.
-    #[cfg(feature = "metrics")]
-    #[test]
-    fn test_handle_proof_failure_emits_retry_metrics() {
-        let pipeline =
-            recovery_pipeline(MockDisputeGameFactory::with_games(vec![]), HashMap::new());
-
-        with_recorder(|snap| {
-            let mut state = PipelineState::new();
-            let target = TEST_BLOCK_INTERVAL * 3;
-            state.inflight.insert(target);
-
-            // Each call to `handle_proof_failure` increments `proof_retries_total`
-            // before the max-retries check, so two calls yield a counter value of 2.
-            pipeline.handle_proof_failure(target, ProposerError::Prover("boom".into()), &mut state);
-            pipeline.handle_proof_failure(target, ProposerError::Prover("boom".into()), &mut state);
-
-            let snapshot = snap.snapshot().into_vec();
-            match find_metric(&snapshot, MetricKind::Counter, "base_proposer.proof_retries_total") {
-                Some(DebugValue::Counter(value)) => assert_eq!(*value, 2),
-                other => panic!("expected proof_retries_total counter, got {other:?}"),
-            }
-        });
-    }
-
-    /// Verifies `handle_dispatch_result` increments `proof_dispatch_total` with
-    /// the right `outcome` label for both accepted and failed dispatch outcomes.
-    #[cfg(feature = "metrics")]
-    #[test]
-    fn test_handle_dispatch_result_emits_dispatch_metrics() {
-        let pipeline =
-            recovery_pipeline(MockDisputeGameFactory::with_games(vec![]), HashMap::new());
-
-        with_recorder(|snap| {
-            let mut state = PipelineState::new();
-            let accepted_target = TEST_BLOCK_INTERVAL;
-            let failed_target = TEST_BLOCK_INTERVAL * 2;
-            state.inflight.insert(accepted_target);
-            state.inflight.insert(failed_target);
-
-            pipeline.handle_dispatch_result(
-                Ok(ProofDispatchOutcome::Accepted {
-                    plan: ProofPlan { start_block: 0, target_block: accepted_target },
-                    session_id: "session-accepted".to_owned(),
-                }),
-                &mut state,
-            );
-            pipeline.handle_dispatch_result(
-                Ok(ProofDispatchOutcome::Failed {
-                    plan: ProofPlan { start_block: accepted_target, target_block: failed_target },
-                    error: ProposerError::Prover("dispatch failed".into()),
-                }),
-                &mut state,
-            );
-
-            let snapshot = snap.snapshot().into_vec();
-            let accepted = snapshot
-                .iter()
-                .find(|(ck, _, _, _)| {
-                    ck.kind() == MetricKind::Counter
-                        && ck.key().name() == "base_proposer.proof_dispatch_total"
-                        && ck
-                            .key()
-                            .labels()
-                            .any(|l| l.key() == "outcome" && l.value() == "accepted")
-                })
-                .map(|(_, _, _, v)| v);
-            match accepted {
-                Some(DebugValue::Counter(value)) => assert_eq!(*value, 1),
-                other => panic!("expected accepted dispatch counter, got {other:?}"),
-            }
-
-            let failed = snapshot
-                .iter()
-                .find(|(ck, _, _, _)| {
-                    ck.kind() == MetricKind::Counter
-                        && ck.key().name() == "base_proposer.proof_dispatch_total"
-                        && ck.key().labels().any(|l| l.key() == "outcome" && l.value() == "failed")
-                })
-                .map(|(_, _, _, v)| v);
-            match failed {
-                Some(DebugValue::Counter(value)) => assert_eq!(*value, 1),
-                other => panic!("expected failed dispatch counter, got {other:?}"),
-            }
-        });
-    }
-
-    // ---- Recovery: empty factory ----
 
     #[tokio::test(flavor = "current_thread", start_paused = true)]
     async fn test_recovery_returns_anchor_when_no_games() {
@@ -1930,6 +1325,7 @@ mod tests {
 
         let pipeline = ProvingPipeline::new(
             PipelineConfig {
+                submit_timeout: std::time::Duration::from_secs(60),
                 max_retries: 3,
                 recovery_scan_concurrency: 8,
                 tee_prover_registry_address: None,
@@ -2050,6 +1446,7 @@ mod tests {
 
         let pipeline = ProvingPipeline::new(
             PipelineConfig {
+                submit_timeout: std::time::Duration::from_secs(60),
                 max_retries: 1,
                 recovery_scan_concurrency: 8,
                 tee_prover_registry_address: None,
@@ -2101,31 +1498,6 @@ mod tests {
         assert_eq!(state2.parent_address, state1.parent_address);
         assert_eq!(state2.l2_block_number, state1.l2_block_number);
         assert_eq!(state2.output_root, state1.output_root);
-    }
-
-    #[tokio::test(flavor = "current_thread", start_paused = true)]
-    async fn test_tick_skips_recovery_when_safe_head_below_cached_next_target() {
-        let game_count_calls = Arc::new(AtomicUsize::new(0));
-        let mut factory = MockDisputeGameFactory::with_games(vec![]);
-        factory.game_count_calls = Some(Arc::clone(&game_count_calls));
-        let pipeline = recovery_pipeline(factory, HashMap::new());
-
-        let cached = CachedRecovery {
-            game_count: 0,
-            state: RecoveredState {
-                parent_address: Address::ZERO,
-                output_root: B256::ZERO,
-                l2_block_number: TEST_ANCHOR_BLOCK,
-            },
-        };
-        let mut state = PipelineState::new();
-        state.cached_recovery = Some(cached);
-
-        pipeline.tick(&mut state).await.unwrap();
-
-        assert_eq!(game_count_calls.load(Ordering::SeqCst), 0);
-        assert_eq!(state.cached_recovery, Some(cached));
-        assert!(state.inflight.is_empty());
     }
 
     #[tokio::test(flavor = "current_thread", start_paused = true)]
@@ -2304,451 +1676,6 @@ mod tests {
         assert_eq!(state.l2_block_number, RECOVERY_BI * 2);
     }
 
-    // ---- Dispatch: slot filling ----
-
-    #[tokio::test(flavor = "current_thread", start_paused = true)]
-    async fn test_dispatch_skips_inflight_and_proved_blocks() {
-        // Scenario: blocks 512–2048 were dispatched on the first tick.
-        // Proof for 512 completed (now in `proved`); proofs for
-        // 1024/1536/2048 are still in-flight.  The next tick calls
-        // dispatch_proofs which must skip past all four handled blocks and
-        // dispatch every remaining eligible block up to the safe head.
-        let cancel = CancellationToken::new();
-        let safe_head = TEST_BLOCK_INTERVAL * 6;
-
-        let l1 = Arc::new(MockL1 { latest_block_number: TEST_L1_BLOCK_NUMBER });
-        let l2 = Arc::new(MockL2 { block_not_found: true, canonical_hash: None });
-        let rollup = Arc::new(MockRollupClient {
-            sync_status: test_sync_status(safe_head, B256::ZERO),
-            output_roots: HashMap::new(),
-            max_safe_block: None,
-        });
-        let anchor_registry = Arc::new(MockAnchorStateRegistry {
-            anchor_root: test_anchor_root(TEST_ANCHOR_BLOCK),
-            anchor_game: Address::ZERO,
-        });
-        let factory = Arc::new(MockDisputeGameFactory::with_games(vec![]));
-
-        let pipeline = ProvingPipeline::new(
-            PipelineConfig {
-                max_retries: 3,
-                recovery_scan_concurrency: 8,
-                tee_prover_registry_address: None,
-                driver: DriverConfig {
-                    block_interval: TEST_BLOCK_INTERVAL,
-                    intermediate_block_interval: TEST_BLOCK_INTERVAL,
-                    ..Default::default()
-                },
-            },
-            Arc::new(MockProofRequester::default()),
-            l1,
-            l2,
-            rollup,
-            anchor_registry,
-            factory,
-            Arc::new(MockAggregateVerifier::default()),
-            Arc::new(MockOutputProposer),
-            cancel,
-        );
-
-        let recovered = RecoveredState {
-            parent_address: Address::ZERO,
-            output_root: B256::ZERO,
-            l2_block_number: TEST_ANCHOR_BLOCK,
-        };
-
-        let mut state = PipelineState::new();
-        state.proved.insert(TEST_BLOCK_INTERVAL, {
-            let p = test_proposal(TEST_BLOCK_INTERVAL);
-            ProofResult::Tee { aggregate_proposal: p.clone(), proposals: vec![p] }
-        });
-        state.inflight.insert(TEST_BLOCK_INTERVAL * 2);
-        state.inflight.insert(TEST_BLOCK_INTERVAL * 3);
-        state.inflight.insert(TEST_BLOCK_INTERVAL * 4);
-
-        pipeline.dispatch_proofs(&recovered, safe_head, &mut state).await.unwrap();
-
-        // safe_head = TEST_BLOCK_INTERVAL * 6 yields candidates 1..=6.
-        // Already handled: 1 (proved), 2/3/4 (inflight). Dispatch should add
-        // 5 and 6 — every remaining eligible target up to the safe head.
-        assert!(
-            state.inflight.contains(&(TEST_BLOCK_INTERVAL * 5)),
-            "block {} should have been dispatched",
-            TEST_BLOCK_INTERVAL * 5
-        );
-        assert!(
-            state.inflight.contains(&(TEST_BLOCK_INTERVAL * 6)),
-            "block {} should have been dispatched",
-            TEST_BLOCK_INTERVAL * 6
-        );
-        assert_eq!(
-            state.inflight.len(),
-            5,
-            "all eligible targets up to safe_head should be inflight"
-        );
-        assert!(
-            state.proved.contains_key(&TEST_BLOCK_INTERVAL),
-            "proved entries must not be removed by dispatch"
-        );
-    }
-
-    #[tokio::test(flavor = "current_thread", start_paused = true)]
-    async fn test_dispatch_keeps_successful_plans_when_later_output_fetch_fails() {
-        let cancel = CancellationToken::new();
-        let safe_head = TEST_BLOCK_INTERVAL * 2;
-
-        let l1 = Arc::new(MockL1 { latest_block_number: TEST_L1_BLOCK_NUMBER });
-        let l2 = Arc::new(MockL2 { block_not_found: true, canonical_hash: None });
-        let rollup = Arc::new(MockRollupClient {
-            sync_status: test_sync_status(safe_head, B256::ZERO),
-            output_roots: HashMap::new(),
-            max_safe_block: Some(TEST_BLOCK_INTERVAL),
-        });
-        let anchor_registry = Arc::new(MockAnchorStateRegistry {
-            anchor_root: test_anchor_root(TEST_ANCHOR_BLOCK),
-            anchor_game: Address::ZERO,
-        });
-        let factory = Arc::new(MockDisputeGameFactory::with_games(vec![]));
-
-        let pipeline = ProvingPipeline::new(
-            PipelineConfig {
-                max_retries: 3,
-                recovery_scan_concurrency: 8,
-                tee_prover_registry_address: None,
-                driver: DriverConfig {
-                    block_interval: TEST_BLOCK_INTERVAL,
-                    intermediate_block_interval: TEST_BLOCK_INTERVAL,
-                    ..Default::default()
-                },
-            },
-            Arc::new(MockProofRequester::default()),
-            l1,
-            l2,
-            rollup,
-            anchor_registry,
-            factory,
-            Arc::new(MockAggregateVerifier::default()),
-            Arc::new(MockOutputProposer),
-            cancel,
-        );
-
-        let recovered = RecoveredState {
-            parent_address: Address::ZERO,
-            output_root: B256::ZERO,
-            l2_block_number: TEST_ANCHOR_BLOCK,
-        };
-        let mut state = PipelineState::new();
-
-        pipeline.dispatch_proofs(&recovered, safe_head, &mut state).await.unwrap();
-
-        assert!(state.inflight.contains(&TEST_BLOCK_INTERVAL));
-        assert!(!state.inflight.contains(&(TEST_BLOCK_INTERVAL * 2)));
-        assert_eq!(state.inflight.len(), 1);
-    }
-
-    #[tokio::test(flavor = "current_thread", start_paused = true)]
-    async fn test_dispatch_skips_submitting_block() {
-        let cancel = CancellationToken::new();
-        let safe_head = TEST_BLOCK_INTERVAL * 4;
-
-        let l1 = Arc::new(MockL1 { latest_block_number: TEST_L1_BLOCK_NUMBER });
-        let l2 = Arc::new(MockL2 { block_not_found: true, canonical_hash: None });
-        let rollup = Arc::new(MockRollupClient {
-            sync_status: test_sync_status(safe_head, B256::ZERO),
-            output_roots: HashMap::new(),
-            max_safe_block: None,
-        });
-        let anchor_registry = Arc::new(MockAnchorStateRegistry {
-            anchor_root: test_anchor_root(TEST_ANCHOR_BLOCK),
-            anchor_game: Address::ZERO,
-        });
-        let factory = Arc::new(MockDisputeGameFactory::with_games(vec![]));
-
-        let pipeline = ProvingPipeline::new(
-            PipelineConfig {
-                max_retries: 3,
-                recovery_scan_concurrency: 8,
-                tee_prover_registry_address: None,
-                driver: DriverConfig {
-                    block_interval: TEST_BLOCK_INTERVAL,
-                    intermediate_block_interval: TEST_BLOCK_INTERVAL,
-                    ..Default::default()
-                },
-            },
-            Arc::new(MockProofRequester::default()),
-            l1,
-            l2,
-            rollup,
-            anchor_registry,
-            factory,
-            Arc::new(MockAggregateVerifier::default()),
-            Arc::new(MockOutputProposer),
-            cancel,
-        );
-
-        let recovered = RecoveredState {
-            parent_address: Address::ZERO,
-            output_root: B256::ZERO,
-            l2_block_number: TEST_ANCHOR_BLOCK,
-        };
-
-        let mut state = PipelineState::new();
-        state.submitting = Some(TEST_BLOCK_INTERVAL);
-
-        pipeline.dispatch_proofs(&recovered, safe_head, &mut state).await.unwrap();
-
-        assert!(
-            !state.inflight.contains(&TEST_BLOCK_INTERVAL),
-            "submitting block must not be re-dispatched"
-        );
-        assert!(
-            state.inflight.contains(&(TEST_BLOCK_INTERVAL * 2)),
-            "block after submitting should be dispatched"
-        );
-    }
-
-    // ---- State management tests ----
-
-    #[tokio::test(flavor = "current_thread", start_paused = true)]
-    async fn test_prune_stale_does_not_abort_inflight_submit() {
-        let mut state = PipelineState::new();
-        state.submitting = Some(512);
-        state.proved.insert(512, {
-            let p = test_proposal(512);
-            ProofResult::Tee { aggregate_proposal: p.clone(), proposals: vec![p] }
-        });
-        state.inflight.insert(512);
-        state.retry_counts.insert(512, 1);
-
-        state.submit_tasks.spawn(async { SubmitOutcome::Success { target_block: 512 } });
-
-        state.prune_stale(512);
-
-        assert!(state.proved.is_empty());
-        assert!(state.inflight.is_empty());
-        assert!(state.retry_counts.is_empty());
-        assert!(!state.submit_tasks.is_empty(), "submit task must not be aborted by prune_stale");
-
-        let result = state.submit_tasks.join_next().await.expect("task should exist");
-        let outcome = result.expect("task should complete without cancellation");
-        assert!(
-            matches!(outcome, SubmitOutcome::Success { target_block: 512 }),
-            "submit task should produce Success, not be cancelled"
-        );
-    }
-
-    /// Builds a `PipelineState` populated with several proved entries plus a
-    /// couple of in-flight bookkeeping targets, used for failure-isolation
-    /// tests that need to assert sibling entries survive.
-    fn state_with_proved_siblings() -> PipelineState {
-        let mut state = PipelineState::new();
-        for target in [TEST_BLOCK_INTERVAL, TEST_BLOCK_INTERVAL * 2, TEST_BLOCK_INTERVAL * 3] {
-            let p = test_proposal(target);
-            state.proved.insert(
-                target,
-                ProofResult::Tee { aggregate_proposal: p.clone(), proposals: vec![p] },
-            );
-        }
-        // Unrelated in-flight + retry-count entries that must not be wiped
-        // when a sibling target hits a failure path.
-        state.inflight.insert(TEST_BLOCK_INTERVAL * 4);
-        state.retry_counts.insert(TEST_BLOCK_INTERVAL * 4, 1);
-        state.cached_recovery = Some(CachedRecovery {
-            game_count: 10,
-            state: RecoveredState {
-                parent_address: proxy_addr(5),
-                output_root: B256::repeat_byte(0x11),
-                l2_block_number: 0,
-            },
-        });
-        state
-    }
-
-    #[tokio::test(flavor = "current_thread", start_paused = true)]
-    async fn test_proof_max_retries_preserves_proved_queue() {
-        let pipeline =
-            recovery_pipeline(MockDisputeGameFactory::with_games(vec![]), HashMap::new());
-        let mut state = state_with_proved_siblings();
-        let failing_target = TEST_BLOCK_INTERVAL * 7;
-        state.inflight.insert(failing_target);
-        state.retry_counts.insert(failing_target, pipeline.config.max_retries.saturating_sub(1));
-
-        // Final attempt fails and pushes the counter to max_retries.
-        pipeline.handle_proof_failure(
-            failing_target,
-            ProposerError::Prover("boom".into()),
-            &mut state,
-        );
-
-        assert!(!state.inflight.contains(&failing_target), "failing target cleared");
-        assert!(!state.retry_counts.contains_key(&failing_target), "retry count cleared");
-        assert!(
-            state.cached_recovery.is_none(),
-            "cached_recovery should be dropped to force a re-walk"
-        );
-        assert_eq!(state.proved.len(), 3, "proved entries for sibling targets must survive");
-        assert!(state.inflight.contains(&(TEST_BLOCK_INTERVAL * 4)), "unrelated inflight survives");
-        assert_eq!(
-            state.retry_counts.get(&(TEST_BLOCK_INTERVAL * 4)),
-            Some(&1),
-            "unrelated retry count survives"
-        );
-    }
-
-    #[tokio::test(flavor = "current_thread", start_paused = true)]
-    async fn test_dispatch_join_error_preserves_proved_queue() {
-        // Construct a synthetic JoinError by joining an aborted task.
-        let cancelled_err = {
-            let mut js: JoinSet<()> = JoinSet::new();
-            let handle = js.spawn(async { std::future::pending::<()>().await });
-            handle.abort();
-            js.join_next().await.unwrap().unwrap_err()
-        };
-        assert!(cancelled_err.is_cancelled(), "fixture must produce a cancellation error");
-
-        let pipeline =
-            recovery_pipeline(MockDisputeGameFactory::with_games(vec![]), HashMap::new());
-        let mut state = state_with_proved_siblings();
-        let proved_before = state.proved.clone();
-        let cached_before = state.cached_recovery;
-
-        // A cancellation join error is the only join error reachable in practice
-        // (panics are caught inside the spawned future). Verify it leaves
-        // state alone.
-        pipeline.handle_dispatch_result(Err(cancelled_err), &mut state);
-        assert_eq!(state.proved, proved_before, "proved queue untouched on cancellation");
-        assert_eq!(state.cached_recovery, cached_before, "cache untouched on cancellation");
-    }
-
-    #[tokio::test(flavor = "current_thread", start_paused = true)]
-    async fn test_root_mismatch_preserves_proved_queue() {
-        let pipeline =
-            recovery_pipeline(MockDisputeGameFactory::with_games(vec![]), HashMap::new());
-        let mut state = state_with_proved_siblings();
-        state.submitting = Some(TEST_BLOCK_INTERVAL * 5);
-
-        let chain_next = pipeline
-            .handle_submit_result(
-                Ok(SubmitOutcome::RootMismatch { target_block: TEST_BLOCK_INTERVAL * 5 }),
-                &mut state,
-            )
-            .await;
-
-        assert!(!chain_next, "root mismatch must not chain another submit");
-        assert!(state.submitting.is_none(), "submitting slot released");
-        assert!(state.cached_recovery.is_none(), "cached_recovery dropped on mismatch");
-        assert_eq!(
-            state.proved.len(),
-            3,
-            "sibling proved entries must survive a root mismatch on a different target"
-        );
-    }
-
-    #[tokio::test(flavor = "current_thread", start_paused = true)]
-    async fn test_submit_join_error_preserves_proved_queue() {
-        // Build a real cancellation JoinError (only join error reachable
-        // post-catch_unwind).
-        let cancelled_err = {
-            let mut js: JoinSet<()> = JoinSet::new();
-            let handle = js.spawn(async { std::future::pending::<()>().await });
-            handle.abort();
-            js.join_next().await.unwrap().unwrap_err()
-        };
-
-        let pipeline =
-            recovery_pipeline(MockDisputeGameFactory::with_games(vec![]), HashMap::new());
-        let mut state = state_with_proved_siblings();
-        state.submitting = Some(TEST_BLOCK_INTERVAL * 9);
-        let proved_before = state.proved.clone();
-
-        let chain_next = pipeline.handle_submit_result(Err(cancelled_err), &mut state).await;
-
-        assert!(!chain_next);
-        assert!(state.submitting.is_none(), "slot released");
-        assert_eq!(state.proved, proved_before, "proved queue survives a submit join error");
-    }
-
-    /// Pipeline, primed state with a cached recovery tip, and a proof ready
-    /// for `handle_submit_result(SubmitOutcome::Failed { .. })` tests.
-    fn submission_failure_fixture() -> (TestPipeline, PipelineState, ProofResult) {
-        let pipeline =
-            recovery_pipeline(MockDisputeGameFactory::with_games(vec![]), HashMap::new());
-        let target_block = TEST_BLOCK_INTERVAL;
-        let proposal = test_proposal(target_block);
-        let proof =
-            ProofResult::Tee { aggregate_proposal: proposal.clone(), proposals: vec![proposal] };
-
-        let mut state = PipelineState::new();
-        state.submitting = Some(target_block);
-        state.cached_recovery = Some(CachedRecovery {
-            game_count: 1,
-            state: RecoveredState {
-                parent_address: proxy_addr(0),
-                output_root: B256::repeat_byte(0x01),
-                l2_block_number: target_block,
-            },
-        });
-
-        (pipeline, state, proof)
-    }
-
-    #[tokio::test(flavor = "current_thread", start_paused = true)]
-    async fn test_invalid_parent_game_submission_clears_cached_recovery() {
-        let (pipeline, mut state, proof) = submission_failure_fixture();
-        let target_block = TEST_BLOCK_INTERVAL;
-        let cached_before = state.cached_recovery;
-
-        let chain_next = pipeline
-            .handle_submit_result(
-                Ok(SubmitOutcome::Failed {
-                    target_block,
-                    proof,
-                    error: ProposerError::InvalidParentGame,
-                }),
-                &mut state,
-            )
-            .await;
-
-        assert!(cached_before.is_some());
-        assert!(!chain_next, "failed submission should not chain another submit");
-        assert!(state.cached_recovery.is_none(), "InvalidParentGame must drop the cache");
-        assert!(state.proved.contains_key(&target_block), "proof should be re-queued for retry");
-        assert!(state.submitting.is_none(), "submitting slot should be released");
-    }
-
-    #[rstest]
-    #[case::contract_revert(ProposerError::Contract("mock submission failure".into()))]
-    #[case::rpc_transport(ProposerError::Rpc(base_proof_rpc::RpcError::Transport("rpc down".into())))]
-    #[case::rpc_timeout(ProposerError::Rpc(base_proof_rpc::RpcError::Timeout("slow rpc".into())))]
-    #[case::tx_manager_nonce(ProposerError::TxManager(
-        base_tx_manager::TxManagerError::NonceTooLow
-    ))]
-    #[case::tx_reverted(ProposerError::TxReverted("0xdeadbeef".into()))]
-    #[case::internal(ProposerError::Internal("bug".into()))]
-    #[tokio::test(flavor = "current_thread", start_paused = true)]
-    async fn test_transient_failed_submission_preserves_cached_recovery(
-        #[case] error: ProposerError,
-    ) {
-        let (pipeline, mut state, proof) = submission_failure_fixture();
-        let target_block = TEST_BLOCK_INTERVAL;
-        let cached_before = state.cached_recovery;
-
-        let chain_next = pipeline
-            .handle_submit_result(
-                Ok(SubmitOutcome::Failed { target_block, proof, error }),
-                &mut state,
-            )
-            .await;
-
-        assert!(!chain_next, "transient failure should not chain another submit");
-        assert_eq!(
-            state.cached_recovery, cached_before,
-            "transient failure must preserve the cached recovery tip"
-        );
-        assert!(state.proved.contains_key(&target_block), "proof should be re-queued for retry");
-        assert!(state.submitting.is_none(), "submitting slot should be released");
-    }
-
     // ---- Intermediate output root validation (submission) tests ----
 
     /// Shared block intervals for submission validation tests.
@@ -2914,5 +1841,449 @@ mod tests {
             matches!(result, Err(SubmitAction::RootMismatch)),
             "{scenario}: expected RootMismatch, got {result:?}"
         );
+    }
+
+    // ---- Self-driving loop: step / submit_inline / handle_proof_failure ----
+
+    /// Builds a pipeline tailored for `step()` / `submit_inline()` tests.
+    ///
+    /// Uses `SUBMIT_BLOCK_INTERVAL` for short cycles and exposes the
+    /// underlying [`MockProofRequester`] so tests can pre-seed the
+    /// prover-service stub or assert on its post-state. Also returns the
+    /// `CancellationToken` so tests covering `run()` can stop the loop.
+    fn step_pipeline_full(
+        output_roots: HashMap<u64, B256>,
+        safe_head_block: u64,
+        max_retries: u32,
+        submit_timeout: Duration,
+        output_proposer: Arc<dyn OutputProposer>,
+    ) -> (TestPipeline, Arc<MockProofRequester>, CancellationToken) {
+        let proof_requester = Arc::new(MockProofRequester::default());
+        let cancel = CancellationToken::new();
+        let l1 = Arc::new(MockL1 { latest_block_number: TEST_L1_BLOCK_NUMBER });
+        let l2 = Arc::new(MockL2 { block_not_found: true, canonical_hash: None });
+        let rollup = Arc::new(MockRollupClient {
+            sync_status: test_sync_status(safe_head_block, B256::ZERO),
+            output_roots,
+            max_safe_block: None,
+        });
+        let anchor_registry = Arc::new(MockAnchorStateRegistry {
+            anchor_root: test_anchor_root(TEST_ANCHOR_BLOCK),
+            anchor_game: Address::ZERO,
+        });
+
+        let pipeline = ProvingPipeline::new(
+            PipelineConfig {
+                submit_timeout,
+                max_retries,
+                recovery_scan_concurrency: 8,
+                tee_prover_registry_address: None,
+                driver: DriverConfig {
+                    game_type: TEST_GAME_TYPE,
+                    block_interval: SUBMIT_BLOCK_INTERVAL,
+                    intermediate_block_interval: SUBMIT_INTERMEDIATE_INTERVAL,
+                    poll_interval: Duration::from_millis(10),
+                    ..Default::default()
+                },
+            },
+            Arc::clone(&proof_requester) as Arc<dyn ProofRequesterProvider>,
+            l1,
+            l2,
+            rollup,
+            anchor_registry,
+            Arc::new(MockDisputeGameFactory::with_games(vec![])),
+            Arc::new(MockAggregateVerifier::default()),
+            output_proposer,
+            cancel.clone(),
+        );
+
+        (pipeline, proof_requester, cancel)
+    }
+
+    fn step_pipeline_default(
+        safe_head_block: u64,
+    ) -> (TestPipeline, Arc<MockProofRequester>, CancellationToken) {
+        step_pipeline_full(
+            HashMap::new(),
+            safe_head_block,
+            3,
+            Duration::from_secs(60),
+            Arc::new(MockOutputProposer),
+        )
+    }
+
+    fn anchor_recovered_state() -> RecoveredState {
+        RecoveredState {
+            parent_address: Address::ZERO,
+            output_root: B256::ZERO,
+            l2_block_number: TEST_ANCHOR_BLOCK,
+        }
+    }
+
+    /// Output proposer that always rejects with `InvalidParentGame`.
+    #[derive(Debug)]
+    struct InvalidParentGameOutputProposer;
+
+    #[async_trait]
+    impl OutputProposer for InvalidParentGameOutputProposer {
+        async fn propose_output(
+            &self,
+            _: &Proposal,
+            _: Address,
+            _: &[B256],
+        ) -> Result<(), ProposerError> {
+            Err(ProposerError::InvalidParentGame)
+        }
+    }
+
+    /// Output proposer that always rejects with a transient internal error.
+    #[derive(Debug)]
+    struct TransientFailOutputProposer;
+
+    #[async_trait]
+    impl OutputProposer for TransientFailOutputProposer {
+        async fn propose_output(
+            &self,
+            _: &Proposal,
+            _: Address,
+            _: &[B256],
+        ) -> Result<(), ProposerError> {
+            Err(ProposerError::Internal("simulated transient failure".into()))
+        }
+    }
+
+    /// `handle_proof_failure` increments per-target counters and drops the
+    /// cached recovery once the target reaches `max_retries`.
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn test_handle_proof_failure_drops_cache_at_max_retries() {
+        let (pipeline, _proof_requester, _cancel) = step_pipeline_full(
+            HashMap::new(),
+            0,
+            3,
+            Duration::from_secs(60),
+            Arc::new(MockOutputProposer),
+        );
+
+        let mut retry_counts: HashMap<u64, u32> = HashMap::new();
+        let mut cache = Some(CachedRecovery { game_count: 0, state: anchor_recovered_state() });
+
+        // First two failures: counter increments, cache is preserved.
+        for attempt in 1..=2u32 {
+            pipeline.handle_proof_failure(
+                SUBMIT_BLOCK_INTERVAL,
+                ProposerError::Internal("simulated".into()),
+                &mut retry_counts,
+                &mut cache,
+            );
+            assert_eq!(
+                retry_counts.get(&SUBMIT_BLOCK_INTERVAL).copied(),
+                Some(attempt),
+                "attempt {attempt}: counter should equal attempt count",
+            );
+            assert!(cache.is_some(), "attempt {attempt}: cache should still be populated");
+        }
+
+        // Third failure trips max_retries=3: counter is removed and cache is cleared.
+        pipeline.handle_proof_failure(
+            SUBMIT_BLOCK_INTERVAL,
+            ProposerError::Internal("simulated".into()),
+            &mut retry_counts,
+            &mut cache,
+        );
+
+        assert!(
+            !retry_counts.contains_key(&SUBMIT_BLOCK_INTERVAL),
+            "retry counter should be removed at max_retries"
+        );
+        assert!(cache.is_none(), "cache should be dropped when max_retries is reached");
+    }
+
+    /// `run()` honors cancellation between iterations.
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_run_returns_when_cancelled() {
+        let (pipeline, _proof_requester, cancel) = step_pipeline_default(0);
+        let pipeline = Arc::new(pipeline);
+
+        let runner = tokio::spawn({
+            let pipeline = Arc::clone(&pipeline);
+            async move { pipeline.run().await }
+        });
+
+        // Yield once so the spawned task can begin its first iteration.
+        tokio::task::yield_now().await;
+        cancel.cancel();
+
+        let result = tokio::time::timeout(Duration::from_secs(5), runner)
+            .await
+            .expect("run should return promptly after cancel")
+            .expect("run task should not panic");
+        assert!(result.is_ok(), "run should return Ok when cancelled");
+    }
+
+    /// When `safe_head < target_block`, `step()` returns without dispatching
+    /// or submitting and leaves retry counters untouched.
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn test_step_skips_when_safe_head_below_next_target() {
+        // safe_head=0, target = 0 + SUBMIT_BLOCK_INTERVAL = 4 > 0 → skip.
+        let (pipeline, proof_requester, _cancel) = step_pipeline_default(0);
+
+        let mut cache: Option<CachedRecovery> = None;
+        let mut retry_counts: HashMap<u64, u32> = HashMap::new();
+        pipeline.step(&mut cache, &mut retry_counts).await;
+
+        assert!(
+            proof_requester.requests.lock().unwrap().is_empty(),
+            "no proof should have been dispatched while safe head is behind target"
+        );
+        assert!(retry_counts.is_empty(), "retry counters should be untouched");
+    }
+
+    /// When the prover service has no session for the next target,
+    /// `step()` dispatches a fresh request via `dispatch_for`.
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn test_step_dispatches_when_no_session_exists() {
+        let (pipeline, proof_requester, _cancel) = step_pipeline_default(SUBMIT_BLOCK_INTERVAL);
+
+        let mut cache: Option<CachedRecovery> = None;
+        let mut retry_counts: HashMap<u64, u32> = HashMap::new();
+        pipeline.step(&mut cache, &mut retry_counts).await;
+
+        let requests = proof_requester.requests.lock().unwrap();
+        assert_eq!(
+            requests.len(),
+            1,
+            "exactly one prove_block_range request should have been dispatched"
+        );
+        assert!(retry_counts.is_empty(), "successful dispatch should not bump the retry counter");
+    }
+
+    /// `submit_inline` with a `RootMismatch` outcome drops the cached
+    /// recovery but leaves retry counters untouched (transient submit
+    /// failures never count against the per-target retry budget).
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn test_submit_inline_root_mismatch_clears_cache_only() {
+        // Force a final-root mismatch by overriding the canonical root for
+        // the target block.
+        let output_roots = HashMap::from([(SUBMIT_BLOCK_INTERVAL, B256::repeat_byte(0xFF))]);
+        let (pipeline, _proof_requester, _cancel) = step_pipeline_full(
+            output_roots,
+            SUBMIT_BLOCK_INTERVAL,
+            3,
+            Duration::from_secs(60),
+            Arc::new(MockOutputProposer),
+        );
+
+        let recovered = anchor_recovered_state();
+        let proof = submit_proof_result(SUBMIT_BLOCK_INTERVAL);
+        let mut cache = Some(CachedRecovery { game_count: 0, state: recovered });
+        let mut retry_counts: HashMap<u64, u32> = HashMap::from([(SUBMIT_BLOCK_INTERVAL, 1)]);
+
+        pipeline
+            .submit_inline(SUBMIT_BLOCK_INTERVAL, &recovered, proof, &mut retry_counts, &mut cache)
+            .await;
+
+        assert!(cache.is_none(), "RootMismatch should drop the recovery cache");
+        assert_eq!(
+            retry_counts.get(&SUBMIT_BLOCK_INTERVAL).copied(),
+            Some(1),
+            "submit failures should not bump per-target retry counters"
+        );
+    }
+
+    /// `submit_inline` with an `InvalidParentGame` rejection drops the
+    /// cached recovery (so the next iteration re-walks) and does not bump
+    /// retry counters.
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn test_submit_inline_invalid_parent_game_clears_cache() {
+        let (pipeline, _proof_requester, _cancel) = step_pipeline_full(
+            HashMap::new(),
+            SUBMIT_BLOCK_INTERVAL,
+            3,
+            Duration::from_secs(60),
+            Arc::new(InvalidParentGameOutputProposer),
+        );
+
+        let recovered = anchor_recovered_state();
+        let proof = submit_proof_result(SUBMIT_BLOCK_INTERVAL);
+        let mut cache = Some(CachedRecovery { game_count: 0, state: recovered });
+        let mut retry_counts: HashMap<u64, u32> = HashMap::new();
+
+        pipeline
+            .submit_inline(SUBMIT_BLOCK_INTERVAL, &recovered, proof, &mut retry_counts, &mut cache)
+            .await;
+
+        assert!(cache.is_none(), "InvalidParentGame should drop the recovery cache");
+        assert!(retry_counts.is_empty(), "submit failures should not bump retry counters");
+    }
+
+    /// Other transient submit failures preserve both the cache and retry
+    /// counters — the next loop iteration re-collects and retries.
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn test_submit_inline_transient_failure_preserves_cache() {
+        let (pipeline, _proof_requester, _cancel) = step_pipeline_full(
+            HashMap::new(),
+            SUBMIT_BLOCK_INTERVAL,
+            3,
+            Duration::from_secs(60),
+            Arc::new(TransientFailOutputProposer),
+        );
+
+        let recovered = anchor_recovered_state();
+        let proof = submit_proof_result(SUBMIT_BLOCK_INTERVAL);
+        let mut cache = Some(CachedRecovery { game_count: 0, state: recovered });
+        let mut retry_counts: HashMap<u64, u32> = HashMap::new();
+
+        pipeline
+            .submit_inline(SUBMIT_BLOCK_INTERVAL, &recovered, proof, &mut retry_counts, &mut cache)
+            .await;
+
+        assert!(cache.is_some(), "transient submit failures should preserve the recovery cache");
+        assert!(
+            retry_counts.is_empty(),
+            "transient submit failures should not bump retry counters"
+        );
+    }
+
+    /// When `submit_inline` exceeds `submit_timeout`, neither the cache
+    /// nor retry counters are mutated.
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn test_submit_inline_timeout_does_not_count_against_retries() {
+        let submit_timeout = Duration::from_millis(50);
+        let (pipeline, _proof_requester, _cancel) = step_pipeline_full(
+            HashMap::new(),
+            SUBMIT_BLOCK_INTERVAL,
+            3,
+            submit_timeout,
+            Arc::new(DelayedOutputProposer { delay: submit_timeout * 10 }),
+        );
+
+        let recovered = anchor_recovered_state();
+        let proof = submit_proof_result(SUBMIT_BLOCK_INTERVAL);
+        let mut cache = Some(CachedRecovery { game_count: 0, state: recovered });
+        let mut retry_counts: HashMap<u64, u32> = HashMap::new();
+
+        pipeline
+            .submit_inline(SUBMIT_BLOCK_INTERVAL, &recovered, proof, &mut retry_counts, &mut cache)
+            .await;
+
+        assert!(cache.is_some(), "submit timeout should preserve the recovery cache");
+        assert!(retry_counts.is_empty(), "submit timeout should not bump retry counters");
+    }
+
+    /// On a successful submission `submit_inline` advances both
+    /// `last_proposed_block` and `last_collected_block` to the target block.
+    #[cfg(feature = "metrics")]
+    #[test]
+    fn test_submit_inline_advances_block_gauges_on_success() {
+        let rt = tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap();
+        with_recorder(|snap| {
+            rt.block_on(async {
+                let (pipeline, _proof_requester, _cancel) = step_pipeline_full(
+                    HashMap::new(),
+                    SUBMIT_BLOCK_INTERVAL,
+                    3,
+                    Duration::from_secs(60),
+                    Arc::new(MockOutputProposer),
+                );
+                let recovered = anchor_recovered_state();
+                let proof = submit_proof_result(SUBMIT_BLOCK_INTERVAL);
+                let mut cache: Option<CachedRecovery> = None;
+                let mut retry_counts: HashMap<u64, u32> = HashMap::new();
+                pipeline
+                    .submit_inline(
+                        SUBMIT_BLOCK_INTERVAL,
+                        &recovered,
+                        proof,
+                        &mut retry_counts,
+                        &mut cache,
+                    )
+                    .await;
+            });
+
+            let snapshot = snap.snapshot().into_vec();
+            for name in ["base_proposer.last_proposed_block", "base_proposer.last_collected_block"]
+            {
+                match find_metric(&snapshot, MetricKind::Gauge, name) {
+                    Some(DebugValue::Gauge(value)) => {
+                        assert_eq!(
+                            value.into_inner(),
+                            SUBMIT_BLOCK_INTERVAL as f64,
+                            "{name} should advance to target block on success",
+                        );
+                    }
+                    other => panic!("expected {name} gauge, got {other:?}"),
+                }
+            }
+        });
+    }
+
+    /// `submit_inline` with a `RootMismatch` outcome increments the
+    /// `root_mismatch_total` counter.
+    #[cfg(feature = "metrics")]
+    #[test]
+    fn test_submit_inline_increments_root_mismatch_total() {
+        let rt = tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap();
+        with_recorder(|snap| {
+            rt.block_on(async {
+                let output_roots =
+                    HashMap::from([(SUBMIT_BLOCK_INTERVAL, B256::repeat_byte(0xFF))]);
+                let (pipeline, _proof_requester, _cancel) = step_pipeline_full(
+                    output_roots,
+                    SUBMIT_BLOCK_INTERVAL,
+                    3,
+                    Duration::from_secs(60),
+                    Arc::new(MockOutputProposer),
+                );
+                let recovered = anchor_recovered_state();
+                let proof = submit_proof_result(SUBMIT_BLOCK_INTERVAL);
+                let mut cache = Some(CachedRecovery { game_count: 0, state: recovered });
+                let mut retry_counts: HashMap<u64, u32> = HashMap::new();
+                pipeline
+                    .submit_inline(
+                        SUBMIT_BLOCK_INTERVAL,
+                        &recovered,
+                        proof,
+                        &mut retry_counts,
+                        &mut cache,
+                    )
+                    .await;
+            });
+
+            let snapshot = snap.snapshot().into_vec();
+            match find_metric(&snapshot, MetricKind::Counter, "base_proposer.root_mismatch_total") {
+                Some(DebugValue::Counter(value)) => {
+                    assert_eq!(*value, 1, "root_mismatch_total should increment once");
+                }
+                other => panic!("expected root_mismatch_total counter, got {other:?}"),
+            }
+        });
+    }
+
+    /// On successful submission, `submit_inline` clears the per-target
+    /// retry counter and refreshes the recovery cache.
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn test_submit_inline_success_clears_retry_counter() {
+        let (pipeline, _proof_requester, _cancel) = step_pipeline_full(
+            HashMap::new(),
+            SUBMIT_BLOCK_INTERVAL,
+            3,
+            Duration::from_secs(60),
+            Arc::new(MockOutputProposer),
+        );
+
+        let recovered = anchor_recovered_state();
+        let proof = submit_proof_result(SUBMIT_BLOCK_INTERVAL);
+        let mut cache: Option<CachedRecovery> = None;
+        let mut retry_counts: HashMap<u64, u32> = HashMap::from([(SUBMIT_BLOCK_INTERVAL, 2)]);
+
+        pipeline
+            .submit_inline(SUBMIT_BLOCK_INTERVAL, &recovered, proof, &mut retry_counts, &mut cache)
+            .await;
+
+        assert!(
+            !retry_counts.contains_key(&SUBMIT_BLOCK_INTERVAL),
+            "successful submit should clear the per-target retry counter"
+        );
+        assert!(cache.is_some(), "successful submit should refresh the cache");
     }
 }

--- a/crates/proof/proposer/src/pipeline.rs
+++ b/crates/proof/proposer/src/pipeline.rs
@@ -29,7 +29,11 @@
 //! is wrapped in [`tokio::time::timeout`] so a stuck L1 RPC never blocks
 //! progress beyond `submit_timeout`.
 
-use std::{collections::HashMap, sync::Arc, time::Duration};
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+    time::Duration,
+};
 
 use alloy_primitives::{Address, B256};
 use base_proof_contracts::{
@@ -246,12 +250,22 @@ where
 
         let mut cache: Option<CachedRecovery> = None;
         let mut retry_counts: HashMap<u64, u32> = HashMap::new();
+        // Targets the submitter has irrecoverably discarded (e.g.
+        // `L1OriginTooOld`, `InvalidSigner`). The prover-service session for
+        // a discarded target is `Succeeded` with a deterministic id, so a
+        // naive next-iteration poll would re-deliver the same `Ready` proof
+        // and re-discard it indefinitely. Tracking discarded targets in
+        // memory lets us short-circuit polling until the chain advances past
+        // them; the set is cleared on restart, matching the implicit
+        // skip-via-dropped-`proved`-map behavior of the previous parallel
+        // pipeline.
+        let mut discarded_targets: HashSet<u64> = HashSet::new();
 
         loop {
             tokio::select! {
                 biased;
                 () = self.cancel.cancelled() => break,
-                () = self.step(&mut cache, &mut retry_counts) => {}
+                () = self.step(&mut cache, &mut retry_counts, &mut discarded_targets) => {}
             }
 
             tokio::select! {
@@ -270,7 +284,12 @@ where
     /// Recovers the on-chain tip, derives the next target block, polls the
     /// prover service, and acts on the [`TargetPoll`] outcome.
     #[instrument(skip_all)]
-    async fn step(&self, cache: &mut Option<CachedRecovery>, retry_counts: &mut HashMap<u64, u32>) {
+    async fn step(
+        &self,
+        cache: &mut Option<CachedRecovery>,
+        retry_counts: &mut HashMap<u64, u32>,
+        discarded_targets: &mut HashSet<u64>,
+    ) {
         let _tick_timer = base_metrics::timed!(Metrics::tick_duration_seconds());
 
         let (recovered, safe_head) = match self.try_recover_and_plan(cache).await {
@@ -289,8 +308,10 @@ where
         // run had advanced the chain.
         Metrics::last_proposed_block().set(recovered.l2_block_number as f64);
 
-        // Drop retry counters for targets the chain has already passed.
+        // Drop retry counters and discarded markers for targets the chain
+        // has already passed.
         retry_counts.retain(|&target, _| target > recovered.l2_block_number);
+        discarded_targets.retain(|&target| target > recovered.l2_block_number);
 
         let target_block =
             match recovered.l2_block_number.checked_add(self.config.driver.block_interval) {
@@ -316,6 +337,19 @@ where
             return;
         }
 
+        // Skip targets the submitter has already discarded. The
+        // prover-service session for a discarded target is deterministic
+        // and sticky in `Succeeded`, so polling again would re-deliver the
+        // same `Ready` proof and re-discard it. The discarded marker is
+        // cleared above once the on-chain tip advances past `target_block`.
+        if discarded_targets.contains(&target_block) {
+            debug!(
+                target_block,
+                "Target previously discarded by submitter, waiting for chain to advance"
+            );
+            return;
+        }
+
         match self.proof_collector.poll(target_block).await {
             TargetPoll::Ready { session_id, proof } => {
                 info!(
@@ -324,7 +358,15 @@ where
                     "Proof ready, submitting inline"
                 );
                 Metrics::proof_collection_total(Metrics::COLLECTION_OUTCOME_READY).increment(1);
-                self.submit_inline(target_block, &recovered, proof, retry_counts, cache).await;
+                self.submit_inline(
+                    target_block,
+                    &recovered,
+                    proof,
+                    retry_counts,
+                    cache,
+                    discarded_targets,
+                )
+                .await;
             }
             TargetPoll::Pending { session_id, status } => {
                 debug!(
@@ -388,6 +430,7 @@ where
         proof: ProofResult,
         retry_counts: &mut HashMap<u64, u32>,
         cache: &mut Option<CachedRecovery>,
+        discarded_targets: &mut HashSet<u64>,
     ) {
         let parent_address = recovered.parent_address;
         info!(target_block, parent_address = %parent_address, "Submitting proof inline");
@@ -464,10 +507,17 @@ where
             Ok(Err(SubmitAction::Discard(error))) => {
                 submit_timer.disarm();
                 Metrics::errors_total(error.metric_label()).increment(1);
+                Metrics::discarded_targets_total().increment(1);
+                // The prover-service session for this target is keyed
+                // deterministically on the canonical output root, so the
+                // next poll would return the same `Ready` proof and
+                // re-discard it. Mark the target as discarded so subsequent
+                // iterations skip polling until the chain advances past it.
+                discarded_targets.insert(target_block);
                 warn!(
                     target_block,
                     error = %error,
-                    "Proof discarded by submitter, will re-derive next iteration"
+                    "Proof discarded by submitter, skipping until chain advances past target"
                 );
             }
         }
@@ -476,8 +526,12 @@ where
     /// Builds and dispatches a fresh `prove_block_range` request for
     /// `target_block`.
     ///
-    /// Treats request-build failures and dispatcher errors uniformly via
-    /// [`Self::handle_proof_failure`].
+    /// Request-build failures (transient L1/L2 RPC errors while assembling
+    /// the request) are logged and skipped without bumping the per-target
+    /// retry budget — they never reached the prover service, so the
+    /// proof-failure retry policy does not apply. Dispatcher errors (the
+    /// prover service rejected an otherwise valid request) flow through
+    /// [`Self::handle_proof_failure`] and do count against the budget.
     async fn dispatch_for(
         &self,
         target_block: u64,
@@ -495,10 +549,9 @@ where
                 warn!(
                     target_block,
                     error = %e,
-                    "Failed to build proof request, treating as proof failure"
+                    "Failed to build proof request, will retry next iteration"
                 );
-                Metrics::proof_dispatch_total(Metrics::DISPATCH_OUTCOME_FAILED).increment(1);
-                self.handle_proof_failure(target_block, e, retry_counts, cache);
+                Metrics::proof_dispatch_total(Metrics::DISPATCH_OUTCOME_BUILD_FAILED).increment(1);
                 return;
             }
         };
@@ -994,7 +1047,11 @@ where
 
 #[cfg(test)]
 mod tests {
-    use std::{collections::HashMap, sync::Arc, time::Duration};
+    use std::{
+        collections::{HashMap, HashSet},
+        sync::Arc,
+        time::Duration,
+    };
 
     use alloy_primitives::{Address, B256};
     use async_trait::async_trait;
@@ -2037,7 +2094,8 @@ mod tests {
 
         let mut cache: Option<CachedRecovery> = None;
         let mut retry_counts: HashMap<u64, u32> = HashMap::new();
-        pipeline.step(&mut cache, &mut retry_counts).await;
+        let mut discarded_targets: HashSet<u64> = HashSet::new();
+        pipeline.step(&mut cache, &mut retry_counts, &mut discarded_targets).await;
 
         assert!(
             proof_requester.requests.lock().unwrap().is_empty(),
@@ -2054,7 +2112,8 @@ mod tests {
 
         let mut cache: Option<CachedRecovery> = None;
         let mut retry_counts: HashMap<u64, u32> = HashMap::new();
-        pipeline.step(&mut cache, &mut retry_counts).await;
+        let mut discarded_targets: HashSet<u64> = HashSet::new();
+        pipeline.step(&mut cache, &mut retry_counts, &mut discarded_targets).await;
 
         let requests = proof_requester.requests.lock().unwrap();
         assert_eq!(
@@ -2085,9 +2144,17 @@ mod tests {
         let proof = submit_proof_result(SUBMIT_BLOCK_INTERVAL);
         let mut cache = Some(CachedRecovery { game_count: 0, state: recovered });
         let mut retry_counts: HashMap<u64, u32> = HashMap::from([(SUBMIT_BLOCK_INTERVAL, 1)]);
+        let mut discarded_targets: HashSet<u64> = HashSet::new();
 
         pipeline
-            .submit_inline(SUBMIT_BLOCK_INTERVAL, &recovered, proof, &mut retry_counts, &mut cache)
+            .submit_inline(
+                SUBMIT_BLOCK_INTERVAL,
+                &recovered,
+                proof,
+                &mut retry_counts,
+                &mut cache,
+                &mut discarded_targets,
+            )
             .await;
 
         assert!(cache.is_none(), "RootMismatch should drop the recovery cache");
@@ -2115,9 +2182,17 @@ mod tests {
         let proof = submit_proof_result(SUBMIT_BLOCK_INTERVAL);
         let mut cache = Some(CachedRecovery { game_count: 0, state: recovered });
         let mut retry_counts: HashMap<u64, u32> = HashMap::new();
+        let mut discarded_targets: HashSet<u64> = HashSet::new();
 
         pipeline
-            .submit_inline(SUBMIT_BLOCK_INTERVAL, &recovered, proof, &mut retry_counts, &mut cache)
+            .submit_inline(
+                SUBMIT_BLOCK_INTERVAL,
+                &recovered,
+                proof,
+                &mut retry_counts,
+                &mut cache,
+                &mut discarded_targets,
+            )
             .await;
 
         assert!(cache.is_none(), "InvalidParentGame should drop the recovery cache");
@@ -2140,9 +2215,17 @@ mod tests {
         let proof = submit_proof_result(SUBMIT_BLOCK_INTERVAL);
         let mut cache = Some(CachedRecovery { game_count: 0, state: recovered });
         let mut retry_counts: HashMap<u64, u32> = HashMap::new();
+        let mut discarded_targets: HashSet<u64> = HashSet::new();
 
         pipeline
-            .submit_inline(SUBMIT_BLOCK_INTERVAL, &recovered, proof, &mut retry_counts, &mut cache)
+            .submit_inline(
+                SUBMIT_BLOCK_INTERVAL,
+                &recovered,
+                proof,
+                &mut retry_counts,
+                &mut cache,
+                &mut discarded_targets,
+            )
             .await;
 
         assert!(cache.is_some(), "transient submit failures should preserve the recovery cache");
@@ -2169,9 +2252,17 @@ mod tests {
         let proof = submit_proof_result(SUBMIT_BLOCK_INTERVAL);
         let mut cache = Some(CachedRecovery { game_count: 0, state: recovered });
         let mut retry_counts: HashMap<u64, u32> = HashMap::new();
+        let mut discarded_targets: HashSet<u64> = HashSet::new();
 
         pipeline
-            .submit_inline(SUBMIT_BLOCK_INTERVAL, &recovered, proof, &mut retry_counts, &mut cache)
+            .submit_inline(
+                SUBMIT_BLOCK_INTERVAL,
+                &recovered,
+                proof,
+                &mut retry_counts,
+                &mut cache,
+                &mut discarded_targets,
+            )
             .await;
 
         assert!(cache.is_some(), "submit timeout should preserve the recovery cache");
@@ -2197,6 +2288,7 @@ mod tests {
                 let proof = submit_proof_result(SUBMIT_BLOCK_INTERVAL);
                 let mut cache: Option<CachedRecovery> = None;
                 let mut retry_counts: HashMap<u64, u32> = HashMap::new();
+                let mut discarded_targets: HashSet<u64> = HashSet::new();
                 pipeline
                     .submit_inline(
                         SUBMIT_BLOCK_INTERVAL,
@@ -2204,6 +2296,7 @@ mod tests {
                         proof,
                         &mut retry_counts,
                         &mut cache,
+                        &mut discarded_targets,
                     )
                     .await;
             });
@@ -2246,6 +2339,7 @@ mod tests {
                 let proof = submit_proof_result(SUBMIT_BLOCK_INTERVAL);
                 let mut cache = Some(CachedRecovery { game_count: 0, state: recovered });
                 let mut retry_counts: HashMap<u64, u32> = HashMap::new();
+                let mut discarded_targets: HashSet<u64> = HashSet::new();
                 pipeline
                     .submit_inline(
                         SUBMIT_BLOCK_INTERVAL,
@@ -2253,6 +2347,7 @@ mod tests {
                         proof,
                         &mut retry_counts,
                         &mut cache,
+                        &mut discarded_targets,
                     )
                     .await;
             });
@@ -2283,9 +2378,17 @@ mod tests {
         let proof = submit_proof_result(SUBMIT_BLOCK_INTERVAL);
         let mut cache: Option<CachedRecovery> = None;
         let mut retry_counts: HashMap<u64, u32> = HashMap::from([(SUBMIT_BLOCK_INTERVAL, 2)]);
+        let mut discarded_targets: HashSet<u64> = HashSet::new();
 
         pipeline
-            .submit_inline(SUBMIT_BLOCK_INTERVAL, &recovered, proof, &mut retry_counts, &mut cache)
+            .submit_inline(
+                SUBMIT_BLOCK_INTERVAL,
+                &recovered,
+                proof,
+                &mut retry_counts,
+                &mut cache,
+                &mut discarded_targets,
+            )
             .await;
 
         assert!(
@@ -2293,5 +2396,189 @@ mod tests {
             "successful submit should clear the per-target retry counter"
         );
         assert!(cache.is_some(), "successful submit should refresh the cache");
+    }
+
+    /// L1 mock whose `header_by_number` always errors. Used to drive
+    /// `dispatch_for` through its build-failure path.
+    #[derive(Debug)]
+    struct FailingL1;
+
+    #[async_trait]
+    impl L1Provider for FailingL1 {
+        async fn block_number(&self) -> base_proof_rpc::RpcResult<u64> {
+            Ok(TEST_L1_BLOCK_NUMBER)
+        }
+        async fn header_by_number(
+            &self,
+            _: Option<u64>,
+        ) -> base_proof_rpc::RpcResult<alloy_rpc_types_eth::Header> {
+            Err(RpcError::Transport("simulated L1 outage".into()))
+        }
+        async fn header_by_hash(
+            &self,
+            _: B256,
+        ) -> base_proof_rpc::RpcResult<alloy_rpc_types_eth::Header> {
+            unimplemented!()
+        }
+        async fn block_receipts(
+            &self,
+            _: B256,
+        ) -> base_proof_rpc::RpcResult<Vec<alloy_rpc_types_eth::TransactionReceipt>> {
+            unimplemented!()
+        }
+        async fn code_at(
+            &self,
+            _: Address,
+            _: Option<u64>,
+        ) -> base_proof_rpc::RpcResult<alloy_primitives::Bytes> {
+            unimplemented!()
+        }
+        async fn call_contract(
+            &self,
+            _: Address,
+            _: alloy_primitives::Bytes,
+            _: Option<u64>,
+        ) -> base_proof_rpc::RpcResult<alloy_primitives::Bytes> {
+            unimplemented!()
+        }
+        async fn get_balance(
+            &self,
+            _: Address,
+        ) -> base_proof_rpc::RpcResult<alloy_primitives::U256> {
+            Ok(alloy_primitives::U256::ZERO)
+        }
+    }
+
+    /// `dispatch_for` build failures are transient infrastructure errors and
+    /// must not bump the per-target retry budget — they never reached the
+    /// prover service, so the proof-failure retry policy does not apply.
+    /// Without this guard a sustained L1 RPC outage would burn the whole
+    /// retry budget and drop the recovery cache, causing a noisy
+    /// re-walk-and-fail-again cycle on every tick.
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn test_dispatch_for_build_failure_does_not_bump_retries() {
+        let proof_requester = Arc::new(MockProofRequester::default());
+        let cancel = CancellationToken::new();
+        let l1 = Arc::new(FailingL1);
+        let l2 = Arc::new(MockL2 { block_not_found: true, canonical_hash: None });
+        let rollup = Arc::new(MockRollupClient {
+            sync_status: test_sync_status(SUBMIT_BLOCK_INTERVAL, B256::ZERO),
+            output_roots: HashMap::new(),
+            max_safe_block: None,
+        });
+        let anchor_registry = Arc::new(MockAnchorStateRegistry {
+            anchor_root: test_anchor_root(TEST_ANCHOR_BLOCK),
+            anchor_game: Address::ZERO,
+        });
+
+        let pipeline = ProvingPipeline::new(
+            PipelineConfig {
+                submit_timeout: Duration::from_secs(60),
+                max_retries: 3,
+                recovery_scan_concurrency: 8,
+                tee_prover_registry_address: None,
+                driver: DriverConfig {
+                    game_type: TEST_GAME_TYPE,
+                    block_interval: SUBMIT_BLOCK_INTERVAL,
+                    intermediate_block_interval: SUBMIT_INTERMEDIATE_INTERVAL,
+                    poll_interval: Duration::from_millis(10),
+                    ..Default::default()
+                },
+            },
+            Arc::clone(&proof_requester) as Arc<dyn ProofRequesterProvider>,
+            l1,
+            l2,
+            rollup,
+            anchor_registry,
+            Arc::new(MockDisputeGameFactory::with_games(vec![])),
+            Arc::new(MockAggregateVerifier::default()),
+            Arc::new(MockOutputProposer),
+            cancel,
+        );
+
+        let recovered = anchor_recovered_state();
+        let mut cache = Some(CachedRecovery { game_count: 0, state: recovered });
+        let mut retry_counts: HashMap<u64, u32> = HashMap::new();
+
+        pipeline
+            .dispatch_for(
+                SUBMIT_BLOCK_INTERVAL,
+                &recovered,
+                B256::repeat_byte(SUBMIT_BLOCK_INTERVAL as u8),
+                &mut retry_counts,
+                &mut cache,
+            )
+            .await;
+
+        assert!(
+            proof_requester.requests.lock().unwrap().is_empty(),
+            "build failure should not reach the prover service"
+        );
+        assert!(retry_counts.is_empty(), "build failures must not bump per-target retry counters");
+        assert!(cache.is_some(), "build failures must not drop the recovery cache");
+    }
+
+    /// `step()` short-circuits polling when the target block has already
+    /// been marked as discarded. The submitter's `Discard` outcomes (e.g.
+    /// `L1OriginTooOld`, `InvalidSigner`) leave the prover-service session
+    /// in `Succeeded` with a deterministic id, so re-polling would loop on
+    /// the same `Ready` proof indefinitely.
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn test_step_skips_polling_for_discarded_targets() {
+        let (pipeline, proof_requester, _cancel) = step_pipeline_default(SUBMIT_BLOCK_INTERVAL);
+
+        let mut cache: Option<CachedRecovery> = None;
+        let mut retry_counts: HashMap<u64, u32> = HashMap::new();
+        let mut discarded_targets: HashSet<u64> = HashSet::from([SUBMIT_BLOCK_INTERVAL]);
+
+        pipeline.step(&mut cache, &mut retry_counts, &mut discarded_targets).await;
+
+        assert!(
+            proof_requester.requests.lock().unwrap().is_empty(),
+            "discarded targets must not trigger a fresh prover-service dispatch"
+        );
+        assert!(
+            discarded_targets.contains(&SUBMIT_BLOCK_INTERVAL),
+            "discard marker should persist while target is ahead of the chain tip"
+        );
+    }
+
+    /// `submit_inline` with a `Discard` outcome (e.g. `L1OriginTooOld`)
+    /// records the target in `discarded_targets` so subsequent iterations
+    /// short-circuit polling instead of re-delivering and re-discarding the
+    /// same proof indefinitely.
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn test_submit_inline_discard_marks_target() {
+        let (pipeline, _proof_requester, _cancel) = step_pipeline_full(
+            HashMap::new(),
+            SUBMIT_BLOCK_INTERVAL,
+            3,
+            Duration::from_secs(60),
+            Arc::new(L1OriginTooOldOutputProposer),
+        );
+
+        let recovered = anchor_recovered_state();
+        let proof = submit_proof_result(SUBMIT_BLOCK_INTERVAL);
+        let mut cache = Some(CachedRecovery { game_count: 0, state: recovered });
+        let mut retry_counts: HashMap<u64, u32> = HashMap::new();
+        let mut discarded_targets: HashSet<u64> = HashSet::new();
+
+        pipeline
+            .submit_inline(
+                SUBMIT_BLOCK_INTERVAL,
+                &recovered,
+                proof,
+                &mut retry_counts,
+                &mut cache,
+                &mut discarded_targets,
+            )
+            .await;
+
+        assert!(
+            discarded_targets.contains(&SUBMIT_BLOCK_INTERVAL),
+            "Discard outcome should mark the target so subsequent polls skip it"
+        );
+        assert!(retry_counts.is_empty(), "Discard must not bump per-target retry counters");
+        assert!(cache.is_some(), "Discard must not drop the recovery cache");
     }
 }

--- a/crates/proof/proposer/src/pipeline.rs
+++ b/crates/proof/proposer/src/pipeline.rs
@@ -174,7 +174,7 @@ where
     ASR: AnchorStateRegistryClient + 'static,
     F: DisputeGameFactoryClient + 'static,
 {
-    /// Creates a new parallel proving pipeline.
+    /// Creates a new self-driving proving pipeline.
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         config: PipelineConfig,
@@ -188,12 +188,8 @@ where
         output_proposer: Arc<dyn OutputProposer>,
         cancel: CancellationToken,
     ) -> Self {
-        let proof_collector = ProofCollector::aws_nitro(
-            Arc::clone(&proof_requester),
-            Arc::clone(&rollup_client),
-            config.driver.block_interval,
-            config.recovery_scan_concurrency,
-        );
+        let proof_collector =
+            ProofCollector::aws_nitro(Arc::clone(&proof_requester), Arc::clone(&rollup_client));
         let proof_submitter = ProofSubmitter::new(
             Arc::clone(&output_proposer),
             Arc::clone(&rollup_client),
@@ -286,6 +282,12 @@ where
         };
 
         Metrics::safe_head().set(safe_head as f64);
+        // Reflect the on-chain proposer tip on every iteration. Without this,
+        // dashboards that alert on proposer lag would see the gauge stuck at
+        // its last submit value (or unset on cold start) until the next
+        // successful inline submit, even if other proposers or a previous
+        // run had advanced the chain.
+        Metrics::last_proposed_block().set(recovered.l2_block_number as f64);
 
         // Drop retry counters for targets the chain has already passed.
         retry_counts.retain(|&target, _| target > recovered.l2_block_number);
@@ -332,13 +334,20 @@ where
                     "Proof pending, waiting for prover service"
                 );
             }
-            TargetPoll::NotFound { session_id } => {
+            TargetPoll::NotFound { session_id, claimed_l2_output_root } => {
                 info!(
                     target_block,
                     session_id = %session_id,
                     "No prover-service session for target, dispatching"
                 );
-                self.dispatch_for(target_block, &recovered, retry_counts, cache).await;
+                self.dispatch_for(
+                    target_block,
+                    &recovered,
+                    claimed_l2_output_root,
+                    retry_counts,
+                    cache,
+                )
+                .await;
             }
             TargetPoll::Failed { session_id, error } => {
                 warn!(
@@ -473,10 +482,14 @@ where
         &self,
         target_block: u64,
         recovered: &RecoveredState,
+        claimed_l2_output_root: B256,
         retry_counts: &mut HashMap<u64, u32>,
         cache: &mut Option<CachedRecovery>,
     ) {
-        let request = match self.build_proof_request_for(target_block, recovered).await {
+        let request = match self
+            .build_proof_request_for(target_block, recovered, claimed_l2_output_root)
+            .await
+        {
             Ok(req) => req,
             Err(e) => {
                 warn!(
@@ -917,22 +930,18 @@ where
     }
 
     /// Builds a proof request for a single `target_block`, parallelising the
-    /// three required RPCs: L1 head header, target-block canonical output
-    /// root, and L2 head at the recovered tip.
+    /// two required RPCs: L1 head header and L2 head at the recovered tip.
+    /// The canonical output root for `target_block` is supplied by the
+    /// caller (already fetched while deriving the prover-service session id
+    /// in [`crate::proof_collector::ProofCollector::poll`]).
     async fn build_proof_request_for(
         &self,
         target_block: u64,
         recovered: &RecoveredState,
+        claimed_l2_output_root: B256,
     ) -> Result<ProofRequest, ProposerError> {
-        let (l1_head_result, target_root_result, agreed_head_result) = tokio::join!(
+        let (l1_head_result, agreed_head_result) = tokio::join!(
             async { self.l1_client.header_by_number(None).await.map_err(ProposerError::Rpc) },
-            async {
-                self.rollup_client
-                    .output_at_block(target_block)
-                    .await
-                    .map(|out| out.output_root)
-                    .map_err(ProposerError::Rpc)
-            },
             async {
                 self.l2_client
                     .header_by_number(Some(recovered.l2_block_number))
@@ -942,7 +951,6 @@ where
         );
 
         let l1_head = l1_head_result?;
-        let claimed_l2_output_root = target_root_result?;
         let agreed_l2_head = agreed_head_result?;
 
         let request = ProofRequest {

--- a/crates/proof/proposer/src/pipeline.rs
+++ b/crates/proof/proposer/src/pipeline.rs
@@ -1,39 +1,27 @@
-//! Self-driving proving pipeline for the proposer.
+//! Proving pipeline for the proposer.
 //!
-//! The [`ProvingPipeline`] runs a single sequential loop: each iteration
-//! recovers the latest on-chain tip, derives the next target block, polls the
-//! prover service for its deterministic session, and either submits inline,
-//! dispatches a fresh request, waits, or treats the result as a transient
-//! failure.
+//! The [`ProvingPipeline`] runs two cooperative tasks per session: a
+//! dispatcher loop that walks forward from the latest on-chain game and sends
+//! proof requests up to the safe head, and a collector loop that polls and
+//! submits completed proofs in order. Submit failures restart both tasks from
+//! chain-derived state.
 //!
 //! # Iteration
 //!
 //! ```text
-//! ┌──────────┐     ┌──────────────────┐     ┌────────────────────────┐
-//! │ RECOVER  │ ──▶ │ POLL(target)     │ ──▶ │ Ready    → submit      │
-//! │ (cached) │     │ (deterministic)  │     │ NotFound → dispatch    │
-//! └──────────┘     └──────────────────┘     │ Pending  → wait        │
-//!                                           │ Failed   → retry/drop  │
-//!                                           │ Unknown  → wait        │
-//!                                           └────────────────────────┘
+//! ┌──────────┐     ┌──────────────────┐
+//! │ RECOVER  │ ──▶ │ DISPATCH LOOP    │ ──▶ prover service
+//! │ (cached) │     └──────────────────┘
+//! │          │     ┌──────────────────┐
+//! │          │ ──▶ │ COLLECT LOOP     │ ──▶ L1 submitter
+//! └──────────┘     └──────────────────┘
 //! ```
 //!
-//! There is no in-memory queue of dispatched-but-not-yet-collected sessions:
-//! the prover service is the source of truth and the collector rederives
-//! sessions from canonical output roots. State that survives across
-//! iterations is limited to the recovery cache and a per-target retry
-//! counter, both passed by reference into [`ProvingPipeline::step`].
-//!
-//! On success the loop advances by exactly one `block_interval` per iteration;
-//! on `Pending` / `Unknown` it sleeps for `poll_interval` and retries. Submit
-//! is wrapped in [`tokio::time::timeout`] so a stuck L1 RPC never blocks
-//! progress beyond `submit_timeout`.
+//! Normal sessions remain root-derived so a restarted proposer can rediscover
+//! work. Discard retries use retry-specific sessions because the prover service
+//! intentionally replays `Succeeded` sessions for the root-derived id.
 
-use std::{
-    collections::{HashMap, HashSet},
-    sync::Arc,
-    time::Duration,
-};
+use std::{collections::HashMap, sync::Arc, time::Duration};
 
 use alloy_primitives::{Address, B256};
 use base_proof_contracts::{
@@ -44,6 +32,7 @@ use base_proof_rpc::{L1Provider, L2Provider, RollupProvider, RpcError};
 use base_prover_service_client::ProofRequesterProvider;
 use eyre::Result;
 use futures::{StreamExt, stream};
+use tokio::{sync::mpsc, task::JoinHandle};
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info, instrument, warn};
 
@@ -52,12 +41,12 @@ use crate::{
     driver::{DriverConfig, RecoveredState},
     error::ProposerError,
     output_proposer::OutputProposer,
-    proof_adapter::ProofRequesterDispatcher,
+    proof_adapter::{ProofRequesterDispatcher, ProposerProofAdapter},
     proof_collector::{ProofCollector, TargetPoll},
     proof_submitter::{ProofSubmitter, ProofSubmitterConfig, SubmitAction},
 };
 
-/// Configuration for the self-driving proving pipeline.
+/// Configuration for the proving pipeline.
 #[derive(Debug, Clone)]
 pub struct PipelineConfig {
     /// Maximum retries for a single target block before dropping the cached
@@ -100,13 +89,35 @@ struct CachedRecovery {
     state: RecoveredState,
 }
 
-/// The self-driving proving pipeline.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PipelineSessionExit {
+    Cancelled,
+    Restart,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DispatchOutcome {
+    Accepted,
+    Skipped,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SubmitEffect {
+    Submitted,
+    Restart,
+    Redispatch { claimed_l2_output_root: B256 },
+}
+
+struct DiscardRetryState<'a> {
+    counts: &'a mut HashMap<u64, u32>,
+    sessions: &'a mut HashMap<u64, String>,
+}
+
+/// The proving pipeline.
 ///
-/// Runs a single sequential loop per [`Self::run`] call. Each iteration is
-/// independent and re-derives all required state from on-chain reads plus
-/// deterministic prover-service session lookups; the only state that
-/// survives across iterations is the recovery cache and per-target retry
-/// counts, both passed by reference into [`Self::step`].
+/// Runs concurrent dispatcher and collector tasks per [`Self::run`] session.
+/// Submit failures restart both tasks from on-chain state; cancellation stops
+/// them cleanly.
 pub struct ProvingPipeline<L1, L2, R, ASR, F>
 where
     L1: L1Provider,
@@ -178,7 +189,7 @@ where
     ASR: AnchorStateRegistryClient + 'static,
     F: DisputeGameFactoryClient + 'static,
 {
-    /// Creates a new self-driving proving pipeline.
+    /// Creates a new proving pipeline.
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         config: PipelineConfig,
@@ -233,62 +244,113 @@ where
         self.cancel = cancel;
     }
 
-    /// Runs the self-driving proving pipeline until cancelled.
+    /// Runs the proving pipeline until cancelled.
     ///
-    /// Each iteration recovers the on-chain tip, derives the next target,
-    /// polls the prover service, and acts on the [`TargetPoll`] outcome by
-    /// submitting inline, dispatching a fresh request, waiting, or applying
-    /// the retry policy. Sleeps for `poll_interval` between iterations.
-    /// Cancellation is honored at every `await`.
+    /// Each session starts a dispatcher task and a collector task. The
+    /// dispatcher can run ahead up to the safe head, while the collector
+    /// submits proofs in order. Submit failures restart both tasks from a
+    /// fresh recovery walk.
     pub async fn run(&self) -> Result<()> {
         info!(
             block_interval = self.config.driver.block_interval,
             poll_interval_secs = self.config.driver.poll_interval.as_secs(),
             submit_timeout_secs = self.config.submit_timeout.as_secs(),
-            "Starting self-driving proving pipeline"
+            "Starting proving pipeline"
         );
 
+        loop {
+            match self.run_session().await? {
+                PipelineSessionExit::Cancelled => break,
+                PipelineSessionExit::Restart => {
+                    info!("Restarting proving pipeline after submit failure");
+                }
+            }
+        }
+
+        info!("Proving pipeline stopped");
+        Ok(())
+    }
+
+    async fn run_session(&self) -> Result<PipelineSessionExit> {
+        let session_cancel = self.cancel.child_token();
+        let (restart_tx, mut restart_rx) = mpsc::channel(1);
+
+        let mut dispatcher =
+            spawn_loop(self.clone(), session_cancel.clone(), |pipeline, cancel| async move {
+                pipeline.dispatcher_loop(cancel).await
+            });
+        let mut collector =
+            spawn_loop(self.clone(), session_cancel.clone(), |pipeline, cancel| async move {
+                pipeline.collector_loop(cancel, restart_tx).await
+            });
+        let mut dispatcher_done = false;
+        let mut collector_done = false;
+
+        let exit = tokio::select! {
+            biased;
+            () = self.cancel.cancelled() => PipelineSessionExit::Cancelled,
+            reason = restart_rx.recv() => {
+                let reason = reason.unwrap_or_else(|| "collector restart channel closed".to_owned());
+                warn!(reason = %reason, "Restarting pipeline session");
+                PipelineSessionExit::Restart
+            }
+            result = &mut dispatcher => {
+                dispatcher_done = true;
+                result??;
+                warn!("Dispatcher loop exited unexpectedly, restarting pipeline session");
+                PipelineSessionExit::Restart
+            }
+            result = &mut collector => {
+                collector_done = true;
+                result??;
+                warn!("Collector loop exited unexpectedly, restarting pipeline session");
+                PipelineSessionExit::Restart
+            }
+        };
+
+        session_cancel.cancel();
+        if !dispatcher_done {
+            await_loop(dispatcher).await?;
+        }
+        if !collector_done {
+            await_loop(collector).await?;
+        }
+        Ok(exit)
+    }
+
+    /// Runs the proof dispatcher loop.
+    ///
+    /// The dispatcher recovers the latest on-chain game, then dispatches every
+    /// missing block interval up to the safe head. Its cursor is intentionally
+    /// independent from the collector cursor: it tracks how far proof requests
+    /// have been sent, not how far proofs have landed on-chain.
+    #[instrument(skip_all)]
+    async fn dispatcher_loop(&self, cancel: CancellationToken) -> Result<()> {
         let mut cache: Option<CachedRecovery> = None;
         let mut retry_counts: HashMap<u64, u32> = HashMap::new();
-        // Targets the submitter has irrecoverably discarded (e.g.
-        // `L1OriginTooOld`, `InvalidSigner`). The prover-service session for
-        // a discarded target is `Succeeded` with a deterministic id, so a
-        // naive next-iteration poll would re-deliver the same `Ready` proof
-        // and re-discard it indefinitely. Tracking discarded targets in
-        // memory lets us short-circuit polling until the chain advances past
-        // them; the set is cleared on restart, matching the implicit
-        // skip-via-dropped-`proved`-map behavior of the previous parallel
-        // pipeline.
-        let mut discarded_targets: HashSet<u64> = HashSet::new();
+        let mut cursor: Option<RecoveredState> = None;
 
         loop {
             tokio::select! {
                 biased;
-                () = self.cancel.cancelled() => break,
-                () = self.step(&mut cache, &mut retry_counts, &mut discarded_targets) => {}
+                () = cancel.cancelled() => break,
+                () = self.dispatcher_tick(&mut cache, &mut retry_counts, &mut cursor) => {}
             }
 
-            tokio::select! {
-                biased;
-                () = self.cancel.cancelled() => break,
-                () = tokio::time::sleep(self.config.driver.poll_interval) => {}
+            sleep_or_cancel(self.config.driver.poll_interval, &cancel).await;
+            if cancel.is_cancelled() {
+                break;
             }
         }
 
-        info!("Self-driving proving pipeline stopped");
         Ok(())
     }
 
-    /// Executes a single iteration of the self-driving loop.
-    ///
-    /// Recovers the on-chain tip, derives the next target block, polls the
-    /// prover service, and acts on the [`TargetPoll`] outcome.
-    #[instrument(skip_all)]
-    async fn step(
+    async fn dispatcher_tick(
         &self,
         cache: &mut Option<CachedRecovery>,
         retry_counts: &mut HashMap<u64, u32>,
-        discarded_targets: &mut HashSet<u64>,
+        cursor: &mut Option<RecoveredState>,
     ) {
         let _tick_timer = base_metrics::timed!(Metrics::tick_duration_seconds());
 
@@ -301,56 +363,143 @@ where
         };
 
         Metrics::safe_head().set(safe_head as f64);
-        // Reflect the on-chain proposer tip on every iteration. Without this,
-        // dashboards that alert on proposer lag would see the gauge stuck at
-        // its last submit value (or unset on cold start) until the next
-        // successful inline submit, even if other proposers or a previous
-        // run had advanced the chain.
         Metrics::last_proposed_block().set(recovered.l2_block_number as f64);
 
-        // Drop retry counters and discarded markers for targets the chain
-        // has already passed.
         retry_counts.retain(|&target, _| target > recovered.l2_block_number);
-        discarded_targets.retain(|&target| target > recovered.l2_block_number);
 
-        let target_block =
-            match recovered.l2_block_number.checked_add(self.config.driver.block_interval) {
-                Some(t) => t,
-                None => {
-                    error!(
-                        recovered_block = recovered.l2_block_number,
-                        block_interval = self.config.driver.block_interval,
-                        "Overflow computing next target block, halting iteration"
-                    );
-                    return;
-                }
+        if cursor.is_none_or(|c| c.l2_block_number < recovered.l2_block_number) {
+            *cursor = Some(recovered);
+        }
+
+        let mut current = cursor.unwrap_or(recovered);
+        loop {
+            let target_block = match self.next_target_block(current.l2_block_number) {
+                Some(block) => block,
+                None => return,
             };
+            if target_block > safe_head {
+                debug!(
+                    current_block = current.l2_block_number,
+                    target_block,
+                    safe_head,
+                    "Safe head below dispatch target, waiting for L2 head to advance"
+                );
+                break;
+            }
+
+            let claimed_l2_output_root = match self.canonical_output_root(target_block).await {
+                Some(root) => root,
+                None => break,
+            };
+
+            if self
+                .dispatch_for(target_block, &current, claimed_l2_output_root, retry_counts, cache)
+                .await
+                == DispatchOutcome::Accepted
+            {
+                current.l2_block_number = target_block;
+                current.output_root = claimed_l2_output_root;
+                *cursor = Some(current);
+            } else {
+                break;
+            }
+        }
+
+        Metrics::pipeline_retries().set(retry_counts.values().sum::<u32>() as f64);
+    }
+
+    /// Runs the proof collector loop.
+    ///
+    /// The collector submits proofs in order. Any non-success submit outcome
+    /// that invalidates the current submit attempt asks the driver to restart
+    /// both loops from a fresh forward walk.
+    #[instrument(skip_all)]
+    async fn collector_loop(
+        &self,
+        cancel: CancellationToken,
+        restart_tx: mpsc::Sender<String>,
+    ) -> Result<()> {
+        let mut cache: Option<CachedRecovery> = None;
+        let mut retry_counts: HashMap<u64, u32> = HashMap::new();
+        let mut cursor: Option<RecoveredState> = None;
+        let mut discard_retry_counts: HashMap<u64, u32> = HashMap::new();
+        let mut retry_sessions: HashMap<u64, String> = HashMap::new();
+
+        loop {
+            tokio::select! {
+                biased;
+                () = cancel.cancelled() => break,
+                () = self.collector_tick(
+                    &mut cache,
+                    &mut retry_counts,
+                    &mut cursor,
+                    &mut discard_retry_counts,
+                    &mut retry_sessions,
+                    &restart_tx,
+                ) => {}
+            }
+
+            sleep_or_cancel(self.config.driver.poll_interval, &cancel).await;
+            if cancel.is_cancelled() {
+                break;
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn collector_tick(
+        &self,
+        cache: &mut Option<CachedRecovery>,
+        retry_counts: &mut HashMap<u64, u32>,
+        cursor: &mut Option<RecoveredState>,
+        discard_retry_counts: &mut HashMap<u64, u32>,
+        retry_sessions: &mut HashMap<u64, String>,
+        restart_tx: &mpsc::Sender<String>,
+    ) {
+        let (recovered, safe_head) = match self.try_recover_and_plan(cache).await {
+            Some(pair) => pair,
+            None => {
+                Metrics::pipeline_retries().set(retry_counts.values().sum::<u32>() as f64);
+                return;
+            }
+        };
+
+        Metrics::safe_head().set(safe_head as f64);
+        Metrics::last_proposed_block().set(recovered.l2_block_number as f64);
+
+        retry_counts.retain(|&target, _| target > recovered.l2_block_number);
+        discard_retry_counts.retain(|&target, _| target > recovered.l2_block_number);
+        retry_sessions.retain(|&target, _| target > recovered.l2_block_number);
+
+        if cursor.is_none_or(|c| c.l2_block_number < recovered.l2_block_number) {
+            *cursor = Some(recovered);
+        }
+        let Some(current) = *cursor else { return };
+
+        let target_block = match self.next_target_block(current.l2_block_number) {
+            Some(block) => block,
+            None => return,
+        };
 
         if target_block > safe_head {
             debug!(
-                recovered_block = recovered.l2_block_number,
+                current_block = current.l2_block_number,
                 target_block,
                 safe_head,
-                "Safe head below next target, waiting for L2 head to advance"
+                "Safe head below collection target, waiting for L2 head to advance"
             );
             Metrics::pipeline_retries().set(retry_counts.values().sum::<u32>() as f64);
             return;
         }
 
-        // Skip targets the submitter has already discarded. The
-        // prover-service session for a discarded target is deterministic
-        // and sticky in `Succeeded`, so polling again would re-deliver the
-        // same `Ready` proof and re-discard it. The discarded marker is
-        // cleared above once the on-chain tip advances past `target_block`.
-        if discarded_targets.contains(&target_block) {
-            debug!(
-                target_block,
-                "Target previously discarded by submitter, waiting for chain to advance"
-            );
-            return;
-        }
+        let poll = if let Some(session_id) = retry_sessions.get(&target_block).cloned() {
+            self.proof_collector.poll_session(target_block, session_id).await
+        } else {
+            self.proof_collector.poll(target_block).await
+        };
 
-        match self.proof_collector.poll(target_block).await {
+        match poll {
             TargetPoll::Ready { session_id, proof } => {
                 info!(
                     target_block,
@@ -358,15 +507,32 @@ where
                     "Proof ready, submitting inline"
                 );
                 Metrics::proof_collection_total(Metrics::COLLECTION_OUTCOME_READY).increment(1);
-                self.submit_inline(
-                    target_block,
-                    &recovered,
-                    proof,
-                    retry_counts,
-                    cache,
-                    discarded_targets,
-                )
-                .await;
+                match self.submit_inline(target_block, &current, proof, retry_counts, cache).await {
+                    SubmitEffect::Submitted => {
+                        retry_sessions.remove(&target_block);
+                        discard_retry_counts.remove(&target_block);
+                        if let Some(cached) = cache.as_ref() {
+                            *cursor = Some(cached.state);
+                        }
+                    }
+                    SubmitEffect::Restart => {
+                        request_restart(restart_tx, "submit failure").await;
+                    }
+                    SubmitEffect::Redispatch { claimed_l2_output_root } => {
+                        self.dispatch_discard_retry(
+                            target_block,
+                            &current,
+                            claimed_l2_output_root,
+                            retry_counts,
+                            cache,
+                            DiscardRetryState {
+                                counts: discard_retry_counts,
+                                sessions: retry_sessions,
+                            },
+                        )
+                        .await;
+                    }
+                }
             }
             TargetPoll::Pending { session_id, status } => {
                 debug!(
@@ -377,29 +543,46 @@ where
                 );
             }
             TargetPoll::NotFound { session_id, claimed_l2_output_root } => {
-                info!(
+                debug!(
                     target_block,
                     session_id = %session_id,
-                    "No prover-service session for target, dispatching"
+                    claimed_l2_output_root = %claimed_l2_output_root,
+                    "No prover-service session for target, waiting for dispatcher"
                 );
-                self.dispatch_for(
-                    target_block,
-                    &recovered,
-                    claimed_l2_output_root,
-                    retry_counts,
-                    cache,
-                )
-                .await;
             }
-            TargetPoll::Failed { session_id, error } => {
+            TargetPoll::Failed { session_id, claimed_l2_output_root, error } => {
                 warn!(
                     target_block,
                     session_id = %session_id,
                     error = %error,
-                    "Prover service reported failed session"
+                    "Prover service reported failed session, re-dispatching"
                 );
                 Metrics::proof_collection_total(Metrics::COLLECTION_OUTCOME_FAILED).increment(1);
-                self.handle_proof_failure(target_block, error, retry_counts, cache);
+                if self.handle_proof_failure(target_block, error, retry_counts, cache) {
+                    if retry_sessions.get(&target_block).is_some_and(|id| id == &session_id) {
+                        self.dispatch_discard_retry(
+                            target_block,
+                            &current,
+                            claimed_l2_output_root,
+                            retry_counts,
+                            cache,
+                            DiscardRetryState {
+                                counts: discard_retry_counts,
+                                sessions: retry_sessions,
+                            },
+                        )
+                        .await;
+                    } else {
+                        self.dispatch_for(
+                            target_block,
+                            &current,
+                            claimed_l2_output_root,
+                            retry_counts,
+                            cache,
+                        )
+                        .await;
+                    }
+                }
             }
             TargetPoll::Unknown { session_id, error } => {
                 debug!(
@@ -430,8 +613,14 @@ where
         proof: ProofResult,
         retry_counts: &mut HashMap<u64, u32>,
         cache: &mut Option<CachedRecovery>,
-        discarded_targets: &mut HashSet<u64>,
-    ) {
+    ) -> SubmitEffect {
+        let claimed_l2_output_root = match &proof {
+            ProofResult::Tee { aggregate_proposal, .. } => aggregate_proposal.output_root,
+            ProofResult::Zk { .. } => {
+                warn!(target_block, "Unexpected ZK proof result in TEE proposer path");
+                return SubmitEffect::Restart;
+            }
+        };
         let parent_address = recovered.parent_address;
         info!(target_block, parent_address = %parent_address, "Submitting proof inline");
 
@@ -448,8 +637,9 @@ where
                 warn!(
                     target_block,
                     timeout_secs = self.config.submit_timeout.as_secs(),
-                    "Inline submit timed out, will retry next iteration"
+                    "Inline submit timed out, restarting pipeline session"
                 );
+                SubmitEffect::Restart
             }
             Ok(Ok(())) => {
                 drop(submit_timer);
@@ -460,12 +650,14 @@ where
                 if let Err(e) = self.recover_latest_state(cache).await {
                     warn!(error = %e, "Failed to recover state after submission");
                 }
+                SubmitEffect::Submitted
             }
             Ok(Err(SubmitAction::RootMismatch)) => {
                 submit_timer.disarm();
-                warn!(target_block, "Output root mismatch at submit time, dropping recovery cache");
+                warn!(target_block, "Output root mismatch at submit time, restarting pipeline");
                 Metrics::root_mismatch_total().increment(1);
                 *cache = None;
+                SubmitEffect::Restart
             }
             Ok(Err(SubmitAction::GameAlreadyExists)) => {
                 submit_timer.disarm();
@@ -485,6 +677,7 @@ where
                 if let Err(e) = self.recover_latest_state(cache).await {
                     warn!(error = %e, "Failed to recover state after GameAlreadyExists");
                 }
+                SubmitEffect::Submitted
             }
             Ok(Err(SubmitAction::Failed(error))) => {
                 submit_timer.disarm();
@@ -493,32 +686,27 @@ where
                     warn!(
                         target_block,
                         error = %error,
-                        "Submission rejected: parent game invalid, dropping recovery cache"
+                        "Submission rejected: parent game invalid, restarting pipeline"
                     );
                     *cache = None;
                 } else {
                     warn!(
                         target_block,
                         error = %error,
-                        "Submission failed, will retry next iteration"
+                        "Submission failed, restarting pipeline"
                     );
                 }
+                SubmitEffect::Restart
             }
             Ok(Err(SubmitAction::Discard(error))) => {
                 submit_timer.disarm();
                 Metrics::errors_total(error.metric_label()).increment(1);
-                Metrics::discarded_targets_total().increment(1);
-                // The prover-service session for this target is keyed
-                // deterministically on the canonical output root, so the
-                // next poll would return the same `Ready` proof and
-                // re-discard it. Mark the target as discarded so subsequent
-                // iterations skip polling until the chain advances past it.
-                discarded_targets.insert(target_block);
                 warn!(
                     target_block,
                     error = %error,
-                    "Proof discarded by submitter, skipping until chain advances past target"
+                    "Proof discarded by submitter, dispatching fresh retry proof"
                 );
+                SubmitEffect::Redispatch { claimed_l2_output_root }
             }
         }
     }
@@ -539,7 +727,7 @@ where
         claimed_l2_output_root: B256,
         retry_counts: &mut HashMap<u64, u32>,
         cache: &mut Option<CachedRecovery>,
-    ) {
+    ) -> DispatchOutcome {
         let request = match self
             .build_proof_request_for(target_block, recovered, claimed_l2_output_root)
             .await
@@ -552,7 +740,7 @@ where
                     "Failed to build proof request, will retry next iteration"
                 );
                 Metrics::proof_dispatch_total(Metrics::DISPATCH_OUTCOME_BUILD_FAILED).increment(1);
-                return;
+                return DispatchOutcome::Skipped;
             }
         };
 
@@ -565,6 +753,60 @@ where
                     "Proof request accepted by prover service"
                 );
                 Metrics::proof_dispatch_total(Metrics::DISPATCH_OUTCOME_ACCEPTED).increment(1);
+                DispatchOutcome::Accepted
+            }
+            Err(error) => {
+                Metrics::proof_dispatch_total(Metrics::DISPATCH_OUTCOME_FAILED).increment(1);
+                self.handle_proof_failure(target_block, error, retry_counts, cache);
+                DispatchOutcome::Skipped
+            }
+        }
+    }
+
+    async fn dispatch_discard_retry(
+        &self,
+        target_block: u64,
+        recovered: &RecoveredState,
+        claimed_l2_output_root: B256,
+        retry_counts: &mut HashMap<u64, u32>,
+        cache: &mut Option<CachedRecovery>,
+        discard_retry: DiscardRetryState<'_>,
+    ) {
+        let request = match self
+            .build_proof_request_for(target_block, recovered, claimed_l2_output_root)
+            .await
+        {
+            Ok(req) => req,
+            Err(e) => {
+                warn!(
+                    target_block,
+                    error = %e,
+                    "Failed to build discard retry proof request"
+                );
+                Metrics::proof_dispatch_total(Metrics::DISPATCH_OUTCOME_BUILD_FAILED).increment(1);
+                return;
+            }
+        };
+
+        let attempt = discard_retry.counts.entry(target_block).or_insert(0);
+        *attempt += 1;
+        let session_id = ProposerProofAdapter::tee_discard_retry_session_id(
+            &request,
+            self.proof_collector.tee_kind(),
+            *attempt,
+        );
+
+        match self.proof_dispatcher.dispatch_tee_with_session_id(request, session_id.clone()).await
+        {
+            Ok(dispatched) => {
+                info!(
+                    target_block,
+                    session_id = %dispatched.session_id,
+                    attempt = *attempt,
+                    "Discard retry proof request accepted by prover service"
+                );
+                Metrics::proof_dispatch_total(Metrics::DISPATCH_OUTCOME_ACCEPTED).increment(1);
+                discard_retry.sessions.insert(target_block, dispatched.session_id);
             }
             Err(error) => {
                 Metrics::proof_dispatch_total(Metrics::DISPATCH_OUTCOME_FAILED).increment(1);
@@ -584,7 +826,7 @@ where
         error: ProposerError,
         retry_counts: &mut HashMap<u64, u32>,
         cache: &mut Option<CachedRecovery>,
-    ) {
+    ) -> bool {
         Metrics::errors_total(error.metric_label()).increment(1);
         Metrics::proof_retries_total().increment(1);
 
@@ -599,13 +841,15 @@ where
             );
             retry_counts.remove(&target);
             *cache = None;
+            false
         } else {
             warn!(
                 target_block = target,
                 attempt = *count,
                 error = %error,
-                "Proof failed, will retry next iteration"
+                "Proof failed, re-dispatching"
             );
+            true
         }
     }
 
@@ -946,6 +1190,34 @@ where
         }
     }
 
+    fn next_target_block(&self, current_block: u64) -> Option<u64> {
+        current_block.checked_add(self.config.driver.block_interval).map_or_else(
+            || {
+                error!(
+                    current_block,
+                    block_interval = self.config.driver.block_interval,
+                    "Overflow computing next target block"
+                );
+                None
+            },
+            Some,
+        )
+    }
+
+    async fn canonical_output_root(&self, target_block: u64) -> Option<B256> {
+        match self.rollup_client.output_at_block(target_block).await {
+            Ok(output) => Some(output.output_root),
+            Err(e) => {
+                warn!(
+                    target_block,
+                    error = %e,
+                    "Failed to fetch canonical output root for dispatch target"
+                );
+                None
+            }
+        }
+    }
+
     /// Concurrently fetches canonical output roots for the given block numbers.
     async fn fetch_canonical_roots(
         &self,
@@ -1045,13 +1317,44 @@ where
     }
 }
 
+fn spawn_loop<L1, L2, R, ASR, F, Fut>(
+    pipeline: ProvingPipeline<L1, L2, R, ASR, F>,
+    cancel: CancellationToken,
+    f: impl FnOnce(ProvingPipeline<L1, L2, R, ASR, F>, CancellationToken) -> Fut,
+) -> JoinHandle<Result<()>>
+where
+    L1: L1Provider + 'static,
+    L2: L2Provider + 'static,
+    R: RollupProvider + 'static,
+    ASR: AnchorStateRegistryClient + 'static,
+    F: DisputeGameFactoryClient + 'static,
+    Fut: std::future::Future<Output = Result<()>> + Send + 'static,
+{
+    tokio::spawn(f(pipeline, cancel))
+}
+
+async fn await_loop(handle: JoinHandle<Result<()>>) -> Result<()> {
+    handle.await??;
+    Ok(())
+}
+
+async fn sleep_or_cancel(duration: Duration, cancel: &CancellationToken) {
+    tokio::select! {
+        biased;
+        () = cancel.cancelled() => {}
+        () = tokio::time::sleep(duration) => {}
+    }
+}
+
+async fn request_restart(restart_tx: &mpsc::Sender<String>, reason: &str) {
+    if restart_tx.send(reason.to_owned()).await.is_err() {
+        warn!(reason, "Failed to send pipeline restart request");
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use std::{
-        collections::{HashMap, HashSet},
-        sync::Arc,
-        time::Duration,
-    };
+    use std::{collections::HashMap, sync::Arc, time::Duration};
 
     use alloy_primitives::{Address, B256};
     use async_trait::async_trait;
@@ -1908,9 +2211,9 @@ mod tests {
         );
     }
 
-    // ---- Self-driving loop: step / submit_inline / handle_proof_failure ----
+    // ---- Pipeline loops: dispatch / collect / submit / retry ----
 
-    /// Builds a pipeline tailored for `step()` / `submit_inline()` tests.
+    /// Builds a pipeline tailored for dispatcher / collector / submit tests.
     ///
     /// Uses `SUBMIT_BLOCK_INTERVAL` for short cycles and exposes the
     /// underlying [`MockProofRequester`] so tests can pre-seed the
@@ -2085,17 +2388,17 @@ mod tests {
         assert!(result.is_ok(), "run should return Ok when cancelled");
     }
 
-    /// When `safe_head < target_block`, `step()` returns without dispatching
-    /// or submitting and leaves retry counters untouched.
+    /// When `safe_head < target_block`, the dispatcher returns without
+    /// dispatching and leaves retry counters untouched.
     #[tokio::test(flavor = "current_thread", start_paused = true)]
-    async fn test_step_skips_when_safe_head_below_next_target() {
+    async fn test_dispatcher_tick_skips_when_safe_head_below_next_target() {
         // safe_head=0, target = 0 + SUBMIT_BLOCK_INTERVAL = 4 > 0 → skip.
         let (pipeline, proof_requester, _cancel) = step_pipeline_default(0);
 
         let mut cache: Option<CachedRecovery> = None;
         let mut retry_counts: HashMap<u64, u32> = HashMap::new();
-        let mut discarded_targets: HashSet<u64> = HashSet::new();
-        pipeline.step(&mut cache, &mut retry_counts, &mut discarded_targets).await;
+        let mut cursor: Option<RecoveredState> = None;
+        pipeline.dispatcher_tick(&mut cache, &mut retry_counts, &mut cursor).await;
 
         assert!(
             proof_requester.requests.lock().unwrap().is_empty(),
@@ -2104,24 +2407,125 @@ mod tests {
         assert!(retry_counts.is_empty(), "retry counters should be untouched");
     }
 
-    /// When the prover service has no session for the next target,
-    /// `step()` dispatches a fresh request via `dispatch_for`.
+    /// The dispatcher sends proof requests up to the safe head instead of
+    /// limiting itself to one in-flight proof.
     #[tokio::test(flavor = "current_thread", start_paused = true)]
-    async fn test_step_dispatches_when_no_session_exists() {
-        let (pipeline, proof_requester, _cancel) = step_pipeline_default(SUBMIT_BLOCK_INTERVAL);
+    async fn test_dispatcher_tick_dispatches_all_targets_up_to_safe_head() {
+        let safe_head = SUBMIT_BLOCK_INTERVAL * 3;
+        let (pipeline, proof_requester, _cancel) = step_pipeline_default(safe_head);
 
         let mut cache: Option<CachedRecovery> = None;
         let mut retry_counts: HashMap<u64, u32> = HashMap::new();
-        let mut discarded_targets: HashSet<u64> = HashSet::new();
-        pipeline.step(&mut cache, &mut retry_counts, &mut discarded_targets).await;
+        let mut cursor: Option<RecoveredState> = None;
+        pipeline.dispatcher_tick(&mut cache, &mut retry_counts, &mut cursor).await;
 
         let requests = proof_requester.requests.lock().unwrap();
-        assert_eq!(
-            requests.len(),
-            1,
-            "exactly one prove_block_range request should have been dispatched"
-        );
+        assert_eq!(requests.len(), 3, "dispatcher should dispatch every interval up to safe head");
         assert!(retry_counts.is_empty(), "successful dispatch should not bump the retry counter");
+    }
+
+    /// A terminal prover-service `Failed` status is sticky until the proposer
+    /// calls `prove_block_range` again for the same session id. The collector
+    /// must therefore re-dispatch immediately instead of only incrementing a
+    /// local retry counter and polling the same failed row again.
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn test_collector_tick_redispatches_failed_session() {
+        let (pipeline, proof_requester, _cancel) = step_pipeline_default(SUBMIT_BLOCK_INTERVAL);
+        let mut dispatch_cache: Option<CachedRecovery> = None;
+        let mut dispatch_retries: HashMap<u64, u32> = HashMap::new();
+        let mut dispatch_cursor: Option<RecoveredState> = None;
+        pipeline
+            .dispatcher_tick(&mut dispatch_cache, &mut dispatch_retries, &mut dispatch_cursor)
+            .await;
+
+        let session_id = ProposerProofAdapter::tee_session_id_for_root(
+            B256::repeat_byte(SUBMIT_BLOCK_INTERVAL as u8),
+            pipeline.proof_collector.tee_kind(),
+        );
+        proof_requester
+            .failed_sessions
+            .lock()
+            .unwrap()
+            .insert(session_id, "simulated prover failure".to_owned());
+        let prove_count_before =
+            proof_requester.prove_count.load(std::sync::atomic::Ordering::SeqCst);
+
+        let mut collect_cache: Option<CachedRecovery> = None;
+        let mut collect_retries: HashMap<u64, u32> = HashMap::new();
+        let mut collect_cursor: Option<RecoveredState> = None;
+        let mut discard_retry_counts: HashMap<u64, u32> = HashMap::new();
+        let mut retry_sessions: HashMap<u64, String> = HashMap::new();
+        let (restart_tx, _restart_rx) = mpsc::channel(1);
+
+        pipeline
+            .collector_tick(
+                &mut collect_cache,
+                &mut collect_retries,
+                &mut collect_cursor,
+                &mut discard_retry_counts,
+                &mut retry_sessions,
+                &restart_tx,
+            )
+            .await;
+
+        assert!(
+            proof_requester.prove_count.load(std::sync::atomic::Ordering::SeqCst)
+                > prove_count_before,
+            "collector should re-dispatch failed prover-service sessions"
+        );
+        assert_eq!(
+            collect_retries.get(&SUBMIT_BLOCK_INTERVAL).copied(),
+            Some(1),
+            "failed session should consume one retry attempt"
+        );
+    }
+
+    /// Submit failures ask the driver to restart both dispatcher and collector
+    /// tasks from chain-derived state.
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn test_collector_tick_requests_restart_on_submit_failure() {
+        let (pipeline, proof_requester, _cancel) = step_pipeline_full(
+            HashMap::new(),
+            SUBMIT_BLOCK_INTERVAL,
+            3,
+            Duration::from_secs(60),
+            Arc::new(TransientFailOutputProposer),
+        );
+        let mut dispatch_cache: Option<CachedRecovery> = None;
+        let mut dispatch_retries: HashMap<u64, u32> = HashMap::new();
+        let mut dispatch_cursor: Option<RecoveredState> = None;
+        pipeline
+            .dispatcher_tick(&mut dispatch_cache, &mut dispatch_retries, &mut dispatch_cursor)
+            .await;
+
+        assert_eq!(
+            proof_requester.requests.lock().unwrap().len(),
+            1,
+            "test setup should dispatch one ready proof"
+        );
+
+        let mut collect_cache: Option<CachedRecovery> = None;
+        let mut collect_retries: HashMap<u64, u32> = HashMap::new();
+        let mut collect_cursor: Option<RecoveredState> = None;
+        let mut discard_retry_counts: HashMap<u64, u32> = HashMap::new();
+        let mut retry_sessions: HashMap<u64, String> = HashMap::new();
+        let (restart_tx, mut restart_rx) = mpsc::channel(1);
+
+        pipeline
+            .collector_tick(
+                &mut collect_cache,
+                &mut collect_retries,
+                &mut collect_cursor,
+                &mut discard_retry_counts,
+                &mut retry_sessions,
+                &restart_tx,
+            )
+            .await;
+
+        assert_eq!(
+            restart_rx.try_recv().expect("collector should request restart"),
+            "submit failure"
+        );
     }
 
     /// `submit_inline` with a `RootMismatch` outcome drops the cached
@@ -2144,20 +2548,13 @@ mod tests {
         let proof = submit_proof_result(SUBMIT_BLOCK_INTERVAL);
         let mut cache = Some(CachedRecovery { game_count: 0, state: recovered });
         let mut retry_counts: HashMap<u64, u32> = HashMap::from([(SUBMIT_BLOCK_INTERVAL, 1)]);
-        let mut discarded_targets: HashSet<u64> = HashSet::new();
 
-        pipeline
-            .submit_inline(
-                SUBMIT_BLOCK_INTERVAL,
-                &recovered,
-                proof,
-                &mut retry_counts,
-                &mut cache,
-                &mut discarded_targets,
-            )
+        let effect = pipeline
+            .submit_inline(SUBMIT_BLOCK_INTERVAL, &recovered, proof, &mut retry_counts, &mut cache)
             .await;
 
         assert!(cache.is_none(), "RootMismatch should drop the recovery cache");
+        assert_eq!(effect, SubmitEffect::Restart, "RootMismatch should restart the session");
         assert_eq!(
             retry_counts.get(&SUBMIT_BLOCK_INTERVAL).copied(),
             Some(1),
@@ -2182,25 +2579,18 @@ mod tests {
         let proof = submit_proof_result(SUBMIT_BLOCK_INTERVAL);
         let mut cache = Some(CachedRecovery { game_count: 0, state: recovered });
         let mut retry_counts: HashMap<u64, u32> = HashMap::new();
-        let mut discarded_targets: HashSet<u64> = HashSet::new();
 
-        pipeline
-            .submit_inline(
-                SUBMIT_BLOCK_INTERVAL,
-                &recovered,
-                proof,
-                &mut retry_counts,
-                &mut cache,
-                &mut discarded_targets,
-            )
+        let effect = pipeline
+            .submit_inline(SUBMIT_BLOCK_INTERVAL, &recovered, proof, &mut retry_counts, &mut cache)
             .await;
 
         assert!(cache.is_none(), "InvalidParentGame should drop the recovery cache");
+        assert_eq!(effect, SubmitEffect::Restart, "InvalidParentGame should restart the session");
         assert!(retry_counts.is_empty(), "submit failures should not bump retry counters");
     }
 
     /// Other transient submit failures preserve both the cache and retry
-    /// counters — the next loop iteration re-collects and retries.
+    /// counters, but restart both loops from a fresh recovery walk.
     #[tokio::test(flavor = "current_thread", start_paused = true)]
     async fn test_submit_inline_transient_failure_preserves_cache() {
         let (pipeline, _proof_requester, _cancel) = step_pipeline_full(
@@ -2215,20 +2605,13 @@ mod tests {
         let proof = submit_proof_result(SUBMIT_BLOCK_INTERVAL);
         let mut cache = Some(CachedRecovery { game_count: 0, state: recovered });
         let mut retry_counts: HashMap<u64, u32> = HashMap::new();
-        let mut discarded_targets: HashSet<u64> = HashSet::new();
 
-        pipeline
-            .submit_inline(
-                SUBMIT_BLOCK_INTERVAL,
-                &recovered,
-                proof,
-                &mut retry_counts,
-                &mut cache,
-                &mut discarded_targets,
-            )
+        let effect = pipeline
+            .submit_inline(SUBMIT_BLOCK_INTERVAL, &recovered, proof, &mut retry_counts, &mut cache)
             .await;
 
         assert!(cache.is_some(), "transient submit failures should preserve the recovery cache");
+        assert_eq!(effect, SubmitEffect::Restart, "transient submit failures should restart");
         assert!(
             retry_counts.is_empty(),
             "transient submit failures should not bump retry counters"
@@ -2236,7 +2619,7 @@ mod tests {
     }
 
     /// When `submit_inline` exceeds `submit_timeout`, neither the cache
-    /// nor retry counters are mutated.
+    /// nor retry counters are mutated, but the pipeline session restarts.
     #[tokio::test(flavor = "current_thread", start_paused = true)]
     async fn test_submit_inline_timeout_does_not_count_against_retries() {
         let submit_timeout = Duration::from_millis(50);
@@ -2252,21 +2635,14 @@ mod tests {
         let proof = submit_proof_result(SUBMIT_BLOCK_INTERVAL);
         let mut cache = Some(CachedRecovery { game_count: 0, state: recovered });
         let mut retry_counts: HashMap<u64, u32> = HashMap::new();
-        let mut discarded_targets: HashSet<u64> = HashSet::new();
 
-        pipeline
-            .submit_inline(
-                SUBMIT_BLOCK_INTERVAL,
-                &recovered,
-                proof,
-                &mut retry_counts,
-                &mut cache,
-                &mut discarded_targets,
-            )
+        let effect = pipeline
+            .submit_inline(SUBMIT_BLOCK_INTERVAL, &recovered, proof, &mut retry_counts, &mut cache)
             .await;
 
         assert!(cache.is_some(), "submit timeout should preserve the recovery cache");
         assert!(retry_counts.is_empty(), "submit timeout should not bump retry counters");
+        assert_eq!(effect, SubmitEffect::Restart, "submit timeout should restart the session");
     }
 
     /// On a successful submission `submit_inline` advances both
@@ -2288,7 +2664,6 @@ mod tests {
                 let proof = submit_proof_result(SUBMIT_BLOCK_INTERVAL);
                 let mut cache: Option<CachedRecovery> = None;
                 let mut retry_counts: HashMap<u64, u32> = HashMap::new();
-                let mut discarded_targets: HashSet<u64> = HashSet::new();
                 pipeline
                     .submit_inline(
                         SUBMIT_BLOCK_INTERVAL,
@@ -2296,7 +2671,6 @@ mod tests {
                         proof,
                         &mut retry_counts,
                         &mut cache,
-                        &mut discarded_targets,
                     )
                     .await;
             });
@@ -2339,7 +2713,6 @@ mod tests {
                 let proof = submit_proof_result(SUBMIT_BLOCK_INTERVAL);
                 let mut cache = Some(CachedRecovery { game_count: 0, state: recovered });
                 let mut retry_counts: HashMap<u64, u32> = HashMap::new();
-                let mut discarded_targets: HashSet<u64> = HashSet::new();
                 pipeline
                     .submit_inline(
                         SUBMIT_BLOCK_INTERVAL,
@@ -2347,7 +2720,6 @@ mod tests {
                         proof,
                         &mut retry_counts,
                         &mut cache,
-                        &mut discarded_targets,
                     )
                     .await;
             });
@@ -2378,17 +2750,9 @@ mod tests {
         let proof = submit_proof_result(SUBMIT_BLOCK_INTERVAL);
         let mut cache: Option<CachedRecovery> = None;
         let mut retry_counts: HashMap<u64, u32> = HashMap::from([(SUBMIT_BLOCK_INTERVAL, 2)]);
-        let mut discarded_targets: HashSet<u64> = HashSet::new();
 
-        pipeline
-            .submit_inline(
-                SUBMIT_BLOCK_INTERVAL,
-                &recovered,
-                proof,
-                &mut retry_counts,
-                &mut cache,
-                &mut discarded_targets,
-            )
+        let effect = pipeline
+            .submit_inline(SUBMIT_BLOCK_INTERVAL, &recovered, proof, &mut retry_counts, &mut cache)
             .await;
 
         assert!(
@@ -2396,6 +2760,7 @@ mod tests {
             "successful submit should clear the per-target retry counter"
         );
         assert!(cache.is_some(), "successful submit should refresh the cache");
+        assert_eq!(effect, SubmitEffect::Submitted, "successful submit should be Submitted");
     }
 
     /// L1 mock whose `header_by_number` always errors. Used to drive
@@ -2500,7 +2865,7 @@ mod tests {
         let mut cache = Some(CachedRecovery { game_count: 0, state: recovered });
         let mut retry_counts: HashMap<u64, u32> = HashMap::new();
 
-        pipeline
+        let outcome = pipeline
             .dispatch_for(
                 SUBMIT_BLOCK_INTERVAL,
                 &recovered,
@@ -2516,39 +2881,13 @@ mod tests {
         );
         assert!(retry_counts.is_empty(), "build failures must not bump per-target retry counters");
         assert!(cache.is_some(), "build failures must not drop the recovery cache");
-    }
-
-    /// `step()` short-circuits polling when the target block has already
-    /// been marked as discarded. The submitter's `Discard` outcomes (e.g.
-    /// `L1OriginTooOld`, `InvalidSigner`) leave the prover-service session
-    /// in `Succeeded` with a deterministic id, so re-polling would loop on
-    /// the same `Ready` proof indefinitely.
-    #[tokio::test(flavor = "current_thread", start_paused = true)]
-    async fn test_step_skips_polling_for_discarded_targets() {
-        let (pipeline, proof_requester, _cancel) = step_pipeline_default(SUBMIT_BLOCK_INTERVAL);
-
-        let mut cache: Option<CachedRecovery> = None;
-        let mut retry_counts: HashMap<u64, u32> = HashMap::new();
-        let mut discarded_targets: HashSet<u64> = HashSet::from([SUBMIT_BLOCK_INTERVAL]);
-
-        pipeline.step(&mut cache, &mut retry_counts, &mut discarded_targets).await;
-
-        assert!(
-            proof_requester.requests.lock().unwrap().is_empty(),
-            "discarded targets must not trigger a fresh prover-service dispatch"
-        );
-        assert!(
-            discarded_targets.contains(&SUBMIT_BLOCK_INTERVAL),
-            "discard marker should persist while target is ahead of the chain tip"
-        );
+        assert_eq!(outcome, DispatchOutcome::Skipped, "build failure should skip dispatch");
     }
 
     /// `submit_inline` with a `Discard` outcome (e.g. `L1OriginTooOld`)
-    /// records the target in `discarded_targets` so subsequent iterations
-    /// short-circuit polling instead of re-delivering and re-discarding the
-    /// same proof indefinitely.
+    /// returns a re-dispatch effect instead of marking the target skipped.
     #[tokio::test(flavor = "current_thread", start_paused = true)]
-    async fn test_submit_inline_discard_marks_target() {
+    async fn test_submit_inline_discard_requests_redispatch() {
         let (pipeline, _proof_requester, _cancel) = step_pipeline_full(
             HashMap::new(),
             SUBMIT_BLOCK_INTERVAL,
@@ -2561,24 +2900,60 @@ mod tests {
         let proof = submit_proof_result(SUBMIT_BLOCK_INTERVAL);
         let mut cache = Some(CachedRecovery { game_count: 0, state: recovered });
         let mut retry_counts: HashMap<u64, u32> = HashMap::new();
-        let mut discarded_targets: HashSet<u64> = HashSet::new();
 
-        pipeline
-            .submit_inline(
-                SUBMIT_BLOCK_INTERVAL,
-                &recovered,
-                proof,
-                &mut retry_counts,
-                &mut cache,
-                &mut discarded_targets,
-            )
+        let effect = pipeline
+            .submit_inline(SUBMIT_BLOCK_INTERVAL, &recovered, proof, &mut retry_counts, &mut cache)
             .await;
 
-        assert!(
-            discarded_targets.contains(&SUBMIT_BLOCK_INTERVAL),
-            "Discard outcome should mark the target so subsequent polls skip it"
+        assert_eq!(
+            effect,
+            SubmitEffect::Redispatch {
+                claimed_l2_output_root: B256::repeat_byte(SUBMIT_BLOCK_INTERVAL as u8),
+            },
+            "Discard outcome should request a fresh proof dispatch"
         );
         assert!(retry_counts.is_empty(), "Discard must not bump per-target retry counters");
         assert!(cache.is_some(), "Discard must not drop the recovery cache");
+    }
+
+    /// Discard retries use retry-specific session ids so a previously
+    /// `Succeeded` root-derived session does not force the collector to reuse
+    /// the same discarded proof forever.
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn test_dispatch_discard_retry_uses_retry_session() {
+        let (pipeline, proof_requester, _cancel) = step_pipeline_default(SUBMIT_BLOCK_INTERVAL);
+        let recovered = anchor_recovered_state();
+        let mut cache = Some(CachedRecovery { game_count: 0, state: recovered });
+        let mut retry_counts: HashMap<u64, u32> = HashMap::new();
+        let mut discard_retry_counts: HashMap<u64, u32> = HashMap::new();
+        let mut retry_sessions: HashMap<u64, String> = HashMap::new();
+
+        pipeline
+            .dispatch_discard_retry(
+                SUBMIT_BLOCK_INTERVAL,
+                &recovered,
+                B256::repeat_byte(SUBMIT_BLOCK_INTERVAL as u8),
+                &mut retry_counts,
+                &mut cache,
+                DiscardRetryState {
+                    counts: &mut discard_retry_counts,
+                    sessions: &mut retry_sessions,
+                },
+            )
+            .await;
+
+        let requests = proof_requester.requests.lock().unwrap();
+        let retry_session = retry_sessions
+            .get(&SUBMIT_BLOCK_INTERVAL)
+            .expect("discard retry should store retry session id");
+        assert!(requests.contains_key(retry_session), "retry session should be dispatched");
+        assert_ne!(
+            retry_session,
+            &ProposerProofAdapter::tee_session_id_for_root(
+                B256::repeat_byte(SUBMIT_BLOCK_INTERVAL as u8),
+                pipeline.proof_collector.tee_kind(),
+            ),
+            "discard retries must not reuse root-derived session id"
+        );
     }
 }

--- a/crates/proof/proposer/src/pipeline.rs
+++ b/crates/proof/proposer/src/pipeline.rs
@@ -564,12 +564,32 @@ where
                     break;
                 }
                 TargetPoll::NotFound { session_id, claimed_l2_output_root } => {
-                    debug!(
-                        target_block,
-                        session_id = %session_id,
-                        claimed_l2_output_root = %claimed_l2_output_root,
-                        "No prover-service session for target, waiting for dispatcher"
-                    );
+                    if retry_sessions.get(&target_block).is_some_and(|id| id == &session_id) {
+                        warn!(
+                            target_block,
+                            session_id = %session_id,
+                            "Discard retry session missing, dispatching a fresh retry"
+                        );
+                        self.dispatch_discard_retry(
+                            target_block,
+                            &current,
+                            claimed_l2_output_root,
+                            retry_counts,
+                            cache,
+                            DiscardRetryState {
+                                counts: discard_retry_counts,
+                                sessions: retry_sessions,
+                            },
+                        )
+                        .await;
+                    } else {
+                        debug!(
+                            target_block,
+                            session_id = %session_id,
+                            claimed_l2_output_root = %claimed_l2_output_root,
+                            "No prover-service session for target, waiting for dispatcher"
+                        );
+                    }
                     break;
                 }
                 TargetPoll::Failed { session_id, claimed_l2_output_root, error } => {
@@ -3216,6 +3236,47 @@ mod tests {
         assert!(
             proof_requester.requests.lock().unwrap().is_empty(),
             "discard exhaustion should not dispatch another session"
+        );
+    }
+
+    /// If a retry-specific session disappears from prover service, the
+    /// collector should dispatch a fresh retry instead of polling the missing
+    /// session forever.
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn test_collector_tick_redispatches_missing_retry_session() {
+        let (pipeline, proof_requester, _cancel) = step_pipeline_default(SUBMIT_BLOCK_INTERVAL);
+
+        let mut cache: Option<CachedRecovery> = None;
+        let mut retry_counts: HashMap<u64, u32> = HashMap::new();
+        let mut cursor: Option<RecoveredState> = None;
+        let mut discard_retry_counts: HashMap<u64, u32> = HashMap::new();
+        let mut retry_sessions: HashMap<u64, String> =
+            HashMap::from([(SUBMIT_BLOCK_INTERVAL, "missing-retry-session".to_owned())]);
+        let (restart_tx, _restart_rx) = mpsc::channel(1);
+
+        pipeline
+            .collector_tick(
+                &mut cache,
+                &mut retry_counts,
+                &mut cursor,
+                &mut discard_retry_counts,
+                &mut retry_sessions,
+                &restart_tx,
+            )
+            .await;
+
+        let retry_session = retry_sessions
+            .get(&SUBMIT_BLOCK_INTERVAL)
+            .expect("missing retry session should be replaced");
+        assert_ne!(retry_session, "missing-retry-session");
+        assert!(
+            proof_requester.requests.lock().unwrap().contains_key(retry_session),
+            "collector should dispatch the replacement retry session"
+        );
+        assert_eq!(
+            discard_retry_counts.get(&SUBMIT_BLOCK_INTERVAL).copied(),
+            Some(1),
+            "replacement retry should consume one discard retry attempt"
         );
     }
 

--- a/crates/proof/proposer/src/proof_adapter.rs
+++ b/crates/proof/proposer/src/proof_adapter.rs
@@ -46,6 +46,33 @@ impl ProofRequesterDispatcher {
         request: PrimitiveProofRequest,
     ) -> Result<DispatchedProof, ProposerError> {
         let request = ProposerProofAdapter::tee_prove_block_range_request(request, self.tee_kind);
+        self.dispatch_prepared(request).await
+    }
+
+    /// Submits a TEE proof request under an explicit session id.
+    ///
+    /// Used for discard retries. The normal proposer session id is keyed only
+    /// by claimed output root so restarts can rediscover in-flight work, but a
+    /// discarded `Succeeded` session cannot be requeued by replaying that same
+    /// id. A retry-specific id lets the proposer obtain a genuinely fresh TEE
+    /// proof for the same output root.
+    pub async fn dispatch_tee_with_session_id(
+        &self,
+        request: PrimitiveProofRequest,
+        session_id: String,
+    ) -> Result<DispatchedProof, ProposerError> {
+        let request = ProposerProofAdapter::tee_prove_block_range_request_with_session_id(
+            request,
+            self.tee_kind,
+            session_id,
+        );
+        self.dispatch_prepared(request).await
+    }
+
+    async fn dispatch_prepared(
+        &self,
+        request: ProveBlockRangeRequest,
+    ) -> Result<DispatchedProof, ProposerError> {
         let response = self
             .requester
             .prove_block_range(request)
@@ -97,12 +124,37 @@ impl ProposerProofAdapter {
         ProofSessionId::derive(Self::SESSION_NAMESPACE, Self::tee_session_label(tee_kind), root)
     }
 
+    /// Derives a TEE proof retry session id for a discarded proof.
+    pub fn tee_discard_retry_session_id(
+        request: &PrimitiveProofRequest,
+        tee_kind: TeeKind,
+        attempt: u32,
+    ) -> String {
+        let label = Self::tee_session_label(tee_kind);
+        let l1_head_number = request.l1_head_number.to_be_bytes();
+        let attempt = attempt.to_be_bytes();
+        ProofSessionId::derive_from_components(
+            Self::SESSION_NAMESPACE,
+            label,
+            &[request.claimed_l2_output_root.as_slice(), &l1_head_number, &attempt],
+        )
+    }
+
     /// Builds a prover-service request for a TEE proposal proof.
     pub fn tee_prove_block_range_request(
         request: PrimitiveProofRequest,
         tee_kind: TeeKind,
     ) -> ProveBlockRangeRequest {
         let session_id = Self::tee_session_id(&request, tee_kind);
+        Self::tee_prove_block_range_request_with_session_id(request, tee_kind, session_id)
+    }
+
+    /// Builds a prover-service request for a TEE proposal proof with a caller-supplied session id.
+    pub const fn tee_prove_block_range_request_with_session_id(
+        request: PrimitiveProofRequest,
+        tee_kind: TeeKind,
+        session_id: String,
+    ) -> ProveBlockRangeRequest {
         ProveBlockRangeRequest {
             proof: ProofRequest {
                 session_id,

--- a/crates/proof/proposer/src/proof_collector.rs
+++ b/crates/proof/proposer/src/proof_collector.rs
@@ -211,6 +211,14 @@ impl<R: RollupProvider + 'static> ProofCollector<R> {
             Ok(response) => {
                 self.response_to_poll(target_block, session_id, output.output_root, response)
             }
+            Err(e) if e.is_not_found() => {
+                debug!(
+                    target_block,
+                    session_id = %session_id,
+                    "Retry session missing from prover service, dispatch needed",
+                );
+                TargetPoll::NotFound { session_id, claimed_l2_output_root: output.output_root }
+            }
             Err(e) => TargetPoll::Unknown {
                 session_id: Some(session_id),
                 error: Self::error_from_client(e),

--- a/crates/proof/proposer/src/proof_collector.rs
+++ b/crates/proof/proposer/src/proof_collector.rs
@@ -20,7 +20,7 @@ use alloy_primitives::B256;
 use base_proof_primitives::ProofResult;
 use base_proof_rpc::RollupProvider;
 use base_prover_service_client::{ProofRequesterProvider, ProverServiceClientError};
-use base_prover_service_protocol::{GetProofRequest, ProofStatus, TeeKind};
+use base_prover_service_protocol::{GetProofRequest, GetProofResponse, ProofStatus, TeeKind};
 use tracing::debug;
 
 use crate::{error::ProposerError, metrics::Metrics, proof_adapter::ProposerProofAdapter};
@@ -28,7 +28,7 @@ use crate::{error::ProposerError, metrics::Metrics, proof_adapter::ProposerProof
 /// Outcome of polling the prover service for a single target block.
 ///
 /// Returned by [`ProofCollector::poll`] and consumed by the proposer's
-/// self-driving loop to choose the next action: submit, dispatch, wait, or
+/// proposer pipeline to choose the next action: submit, dispatch, wait, or
 /// retry.
 #[derive(Debug)]
 pub enum TargetPoll {
@@ -44,6 +44,8 @@ pub enum TargetPoll {
     Failed {
         /// Deterministic prover-service session identifier.
         session_id: String,
+        /// Canonical L2 output root at the target block.
+        claimed_l2_output_root: B256,
         /// Underlying error returned by the prover service or the decoder.
         error: ProposerError,
     },
@@ -153,12 +155,7 @@ impl<R: RollupProvider + 'static> ProofCollector<R> {
         let session_id =
             ProposerProofAdapter::tee_session_id_for_root(output.output_root, self.tee_kind);
 
-        // 2. Ask the prover service for the proof status.
-        let response = match self
-            .proof_requester
-            .get_proof(GetProofRequest { session_id: session_id.clone() })
-            .await
-        {
+        let response = match self.get_proof(session_id.clone()).await {
             Ok(response) => response,
             Err(e) if e.is_not_found() => {
                 debug!(
@@ -185,7 +182,56 @@ impl<R: RollupProvider + 'static> ProofCollector<R> {
             }
         };
 
-        // 3. Translate the prover-service response into a TargetPoll variant.
+        self.response_to_poll(target_block, session_id, output.output_root, response)
+    }
+
+    /// Polls a specific prover-service session for `target_block`.
+    ///
+    /// Used after a discard retry is dispatched under a retry-specific session
+    /// id. The canonical root is still fetched so a terminal failed session can
+    /// be re-dispatched with a complete proof request.
+    pub async fn poll_session(&self, target_block: u64, session_id: String) -> TargetPoll {
+        let output = match self.rollup_client.output_at_block(target_block).await {
+            Ok(out) => out,
+            Err(e) => {
+                debug!(
+                    target_block,
+                    session_id = %session_id,
+                    error = %e,
+                    "Failed to fetch canonical output root for retry session",
+                );
+                return TargetPoll::Unknown {
+                    session_id: Some(session_id),
+                    error: ProposerError::Rpc(e),
+                };
+            }
+        };
+
+        match self.get_proof(session_id.clone()).await {
+            Ok(response) => {
+                self.response_to_poll(target_block, session_id, output.output_root, response)
+            }
+            Err(e) => TargetPoll::Unknown {
+                session_id: Some(session_id),
+                error: Self::error_from_client(e),
+            },
+        }
+    }
+
+    async fn get_proof(
+        &self,
+        session_id: String,
+    ) -> Result<GetProofResponse, ProverServiceClientError> {
+        self.proof_requester.get_proof(GetProofRequest { session_id }).await
+    }
+
+    fn response_to_poll(
+        &self,
+        target_block: u64,
+        session_id: String,
+        claimed_l2_output_root: B256,
+        response: GetProofResponse,
+    ) -> TargetPoll {
         Metrics::proof_status_received_total(Self::status_label(response.status)).increment(1);
         match response.status {
             ProofStatus::Queued | ProofStatus::Running => {
@@ -201,7 +247,11 @@ impl<R: RollupProvider + 'static> ProofCollector<R> {
                 let message = response.error_message.unwrap_or_else(|| {
                     format!("proof session {session_id} failed without an error message")
                 });
-                TargetPoll::Failed { session_id, error: ProposerError::Prover(message) }
+                TargetPoll::Failed {
+                    session_id,
+                    claimed_l2_output_root,
+                    error: ProposerError::Prover(message),
+                }
             }
             ProofStatus::Succeeded => {
                 let result = match response.result {
@@ -210,12 +260,12 @@ impl<R: RollupProvider + 'static> ProofCollector<R> {
                         let error = ProposerError::Prover(format!(
                             "proof session {session_id} succeeded without a result"
                         ));
-                        return TargetPoll::Failed { session_id, error };
+                        return TargetPoll::Failed { session_id, claimed_l2_output_root, error };
                     }
                 };
                 match ProposerProofAdapter::tee_proof_result(result, self.tee_kind) {
                     Ok(proof) => TargetPoll::Ready { session_id, proof },
-                    Err(error) => TargetPoll::Failed { session_id, error },
+                    Err(error) => TargetPoll::Failed { session_id, claimed_l2_output_root, error },
                 }
             }
         }

--- a/crates/proof/proposer/src/proof_collector.rs
+++ b/crates/proof/proposer/src/proof_collector.rs
@@ -1,62 +1,83 @@
-//! Polls the prover service for completed proofs of derived target blocks.
+//! Polls the prover service for the proof of a single derived target block.
 //!
 //! The [`ProofCollector`] does not care about the proof dispatcher. It assumes that
-//! eligible block ranges have already had `prove_block_range` requests initiated
-//! (whether by this proposer instance or a previous one), derives the next-expected
-//! L2 block targets from the recovered on-chain state and the safe head, derives
-//! the deterministic prover-service session ID via
-//! [`ProposerProofAdapter::tee_session_id_for_root`], calls `get_proof`, and returns
-//! ready/failed outcomes to the caller.
+//! the eligible block range either has, or will have, a `prove_block_range` request
+//! initiated against the prover service (whether by this proposer instance or a
+//! previous one). Given a target block, the collector fetches its canonical L2
+//! output root, derives the deterministic prover-service session ID via
+//! [`ProposerProofAdapter::tee_session_id_for_root`], calls `get_proof`, and
+//! returns a [`TargetPoll`] outcome that tells the caller exactly what to do
+//! next: submit the proof, dispatch a new request, wait, or treat as a transient
+//! error.
 //!
-//! Because session derivation is deterministic and independent of in-memory dispatch
-//! state, the collector can rediscover and complete sessions across proposer restarts.
-//! The pipeline owns its [`PipelineState`](crate::pipeline) and is responsible for
-//! applying retry/recovery bookkeeping to the returned outcomes.
+//! Because session derivation is deterministic and independent of in-memory
+//! dispatch state, the collector can rediscover and complete sessions across
+//! proposer restarts.
 
-use std::{collections::HashMap, sync::Arc};
+use std::sync::Arc;
 
-use alloy_primitives::B256;
 use base_proof_primitives::ProofResult;
 use base_proof_rpc::RollupProvider;
-use base_prover_service_client::ProofRequesterProvider;
+use base_prover_service_client::{ProofRequesterProvider, ProverServiceClientError};
 use base_prover_service_protocol::{GetProofRequest, ProofStatus, TeeKind};
-use futures::{StreamExt, stream};
 use tracing::debug;
 
-use crate::{
-    driver::RecoveredState, error::ProposerError, metrics::Metrics,
-    proof_adapter::ProposerProofAdapter,
-};
+use crate::{error::ProposerError, metrics::Metrics, proof_adapter::ProposerProofAdapter};
 
-/// Outcome returned by [`ProofCollector::collect`] for a single target block.
+/// Outcome of polling the prover service for a single target block.
+///
+/// Returned by [`ProofCollector::poll`] and consumed by the proposer's
+/// self-driving loop to choose the next action: submit, dispatch, wait, or
+/// retry.
 #[derive(Debug)]
-pub enum CollectedProof {
-    /// A successfully proved target whose result was decoded into a [`ProofResult`].
+pub enum TargetPoll {
+    /// The prover service produced a successful, decoded proof for the target.
     Ready {
-        /// Target L2 block number for the completed proof.
-        target_block: u64,
         /// Deterministic prover-service session identifier.
         session_id: String,
-        /// Decoded proof result ready for sequential on-chain submission.
+        /// Decoded proof result ready for inline on-chain submission.
         proof: ProofResult,
     },
-    /// The prover service reported a failed session, or its result could not be decoded.
+    /// The prover service reported a terminal failed session, or its result
+    /// could not be decoded.
     Failed {
-        /// Target L2 block number whose proof failed.
-        target_block: u64,
         /// Deterministic prover-service session identifier.
         session_id: String,
-        /// Underlying error returned by the prover service or the result decoder.
+        /// Underlying error returned by the prover service or the decoder.
+        error: ProposerError,
+    },
+    /// The prover service has the session but it has not finished proving.
+    Pending {
+        /// Deterministic prover-service session identifier.
+        session_id: String,
+        /// Either [`ProofStatus::Queued`] or [`ProofStatus::Running`].
+        status: ProofStatus,
+    },
+    /// The prover service has no record of a session for this target's
+    /// canonical output root. The caller should dispatch a new request.
+    NotFound {
+        /// Deterministic prover-service session identifier the caller should
+        /// expect when dispatching the matching `prove_block_range` request.
+        session_id: String,
+    },
+    /// A transient error prevented the poll from completing (RPC failure,
+    /// canonical root fetch error, etc.). The caller should sleep and retry
+    /// on the next iteration without counting against the retry budget.
+    Unknown {
+        /// Optional session identifier when it could be derived before the
+        /// failure. `None` if the canonical output-root fetch itself failed.
+        session_id: Option<String>,
+        /// The underlying transient error.
         error: ProposerError,
     },
 }
 
-/// Polls the prover service for completed proofs of the next-expected target blocks.
+/// Polls the prover service for the proof of a single derived target block.
 ///
-/// Behavior is independent of the proof dispatcher: target blocks are derived
-/// deterministically from `recovered` and `safe_head`, and session IDs are derived
-/// from the canonical claimed output root, so a restarted proposer can still pick
-/// up sessions previously initiated by another instance.
+/// Behavior is independent of the proof dispatcher: the target block is
+/// supplied by the caller, and the session ID is derived from the canonical
+/// claimed output root, so a restarted proposer can still pick up sessions
+/// previously initiated by another instance.
 pub struct ProofCollector<R> {
     proof_requester: Arc<dyn ProofRequesterProvider>,
     rollup_client: Arc<R>,
@@ -120,130 +141,108 @@ impl<R: RollupProvider + 'static> ProofCollector<R> {
         self.tee_kind
     }
 
-    /// Returns the next-expected target blocks to poll, derived from `recovered`,
-    /// the L2 `safe_head`, and the caller-supplied `is_excluded` predicate.
-    ///
-    /// All eligible targets up to `safe_head` are returned. There is no
-    /// per-tick parallel-poll cap: collection is fundamentally bounded by the
-    /// safe head's distance from the recovered tip, and the prover service
-    /// queues sessions itself.
-    ///
-    /// `is_excluded(target)` should return `true` when the caller already has a
-    /// completed proof for `target` or has begun submitting it; such targets
-    /// are skipped.
-    pub fn collectable_targets(
-        &self,
-        recovered: &RecoveredState,
-        safe_head: u64,
-        is_excluded: impl Fn(u64) -> bool,
-    ) -> Vec<u64> {
-        let mut cursor = match recovered.l2_block_number.checked_add(self.block_interval) {
-            Some(cursor) => cursor,
-            None => return Vec::new(),
-        };
-        let mut targets = Vec::new();
-
-        while cursor <= safe_head {
-            if !is_excluded(cursor) {
-                targets.push(cursor);
-            }
-            cursor = match cursor.checked_add(self.block_interval) {
-                Some(cursor) => cursor,
-                None => break,
-            };
-        }
-
-        targets
+    /// Returns the block interval the collector was configured with.
+    pub const fn block_interval(&self) -> u64 {
+        self.block_interval
     }
 
-    /// Polls the prover service for each target and returns ready/failed outcomes.
+    /// Returns the rollup-output fetch concurrency the collector was configured with.
+    pub const fn output_fetch_concurrency(&self) -> usize {
+        self.output_fetch_concurrency
+    }
+
+    /// Polls the prover service for the proof of `target_block`.
     ///
-    /// Pending sessions (`Queued` or `Running`) are not returned and are left for the
-    /// caller to retry on the next tick. Targets whose canonical output root cannot
-    /// be fetched are skipped silently; the underlying RPC failure is logged at debug
-    /// level via the standard rollup-client error path.
-    pub async fn collect(&self, targets: &[u64]) -> Vec<CollectedProof> {
-        if targets.is_empty() {
-            return Vec::new();
-        }
+    /// Returns a [`TargetPoll`] describing the next action the caller should
+    /// take. The session ID is derived deterministically from the canonical
+    /// L2 output root at `target_block` and the configured TEE kind, so a
+    /// freshly constructed collector can rediscover an in-flight session
+    /// dispatched by a previous proposer instance.
+    pub async fn poll(&self, target_block: u64) -> TargetPoll {
+        // 1. Fetch the canonical output root needed to derive the session id.
+        let output = match self.rollup_client.output_at_block(target_block).await {
+            Ok(out) => out,
+            Err(e) => {
+                debug!(
+                    target_block,
+                    error = %e,
+                    "Failed to fetch canonical output root for target",
+                );
+                return TargetPoll::Unknown { session_id: None, error: ProposerError::Rpc(e) };
+            }
+        };
 
-        let roots = self.fetch_canonical_root_results(targets).await;
+        let session_id =
+            ProposerProofAdapter::tee_session_id_for_root(output.output_root, self.tee_kind);
 
-        let mut outcomes = Vec::new();
-        for &target in targets {
-            let Some(Ok(root)) = roots.get(&target) else { continue };
-            let session_id = ProposerProofAdapter::tee_session_id_for_root(*root, self.tee_kind);
+        // 2. Ask the prover service for the proof status.
+        let response = match self
+            .proof_requester
+            .get_proof(GetProofRequest { session_id: session_id.clone() })
+            .await
+        {
+            Ok(response) => response,
+            Err(e) if e.is_not_found() => {
+                debug!(
+                    target_block,
+                    session_id = %session_id,
+                    "No prover-service session for target, dispatch needed",
+                );
+                return TargetPoll::NotFound { session_id };
+            }
+            Err(e) => {
+                debug!(
+                    target_block,
+                    session_id = %session_id,
+                    error = %e,
+                    "Transient failure polling prover service",
+                );
+                return TargetPoll::Unknown {
+                    session_id: Some(session_id),
+                    error: Self::error_from_client(e),
+                };
+            }
+        };
 
-            let response = match self
-                .proof_requester
-                .get_proof(GetProofRequest { session_id: session_id.clone() })
-                .await
-            {
-                Ok(response) => response,
-                Err(e) => {
-                    debug!(
-                        error = %e,
-                        target_block = target,
-                        session_id = %session_id,
-                        "Failed to poll proof status"
-                    );
-                    continue;
-                }
-            };
-
-            Metrics::proof_status_received_total(Self::status_label(response.status)).increment(1);
-            match response.status {
-                ProofStatus::Queued | ProofStatus::Running => {
-                    debug!(
-                        target_block = target,
-                        session_id = %session_id,
-                        status = ?response.status,
-                        "Proof request still pending"
-                    );
-                }
-                ProofStatus::Failed => {
-                    let message = response.error_message.unwrap_or_else(|| {
-                        format!("proof session {session_id} failed without an error message")
-                    });
-                    outcomes.push(CollectedProof::Failed {
-                        target_block: target,
-                        session_id,
-                        error: ProposerError::Prover(message),
-                    });
-                }
-                ProofStatus::Succeeded => {
-                    let result = match response.result {
-                        Some(result) => result,
-                        None => {
-                            let error = ProposerError::Prover(format!(
-                                "proof session {session_id} succeeded without a result"
-                            ));
-                            outcomes.push(CollectedProof::Failed {
-                                target_block: target,
-                                session_id,
-                                error,
-                            });
-                            continue;
-                        }
-                    };
-
-                    match ProposerProofAdapter::tee_proof_result(result, self.tee_kind) {
-                        Ok(proof) => outcomes.push(CollectedProof::Ready {
-                            target_block: target,
-                            session_id,
-                            proof,
-                        }),
-                        Err(error) => outcomes.push(CollectedProof::Failed {
-                            target_block: target,
-                            session_id,
-                            error,
-                        }),
+        // 3. Translate the prover-service response into a TargetPoll variant.
+        Metrics::proof_status_received_total(Self::status_label(response.status)).increment(1);
+        match response.status {
+            ProofStatus::Queued | ProofStatus::Running => {
+                debug!(
+                    target_block,
+                    session_id = %session_id,
+                    status = ?response.status,
+                    "Proof request still pending",
+                );
+                TargetPoll::Pending { session_id, status: response.status }
+            }
+            ProofStatus::Failed => {
+                let message = response.error_message.unwrap_or_else(|| {
+                    format!("proof session {session_id} failed without an error message")
+                });
+                TargetPoll::Failed { session_id, error: ProposerError::Prover(message) }
+            }
+            ProofStatus::Succeeded => {
+                let result = match response.result {
+                    Some(result) => result,
+                    None => {
+                        let error = ProposerError::Prover(format!(
+                            "proof session {session_id} succeeded without a result"
+                        ));
+                        return TargetPoll::Failed { session_id, error };
                     }
+                };
+                match ProposerProofAdapter::tee_proof_result(result, self.tee_kind) {
+                    Ok(proof) => TargetPoll::Ready { session_id, proof },
+                    Err(error) => TargetPoll::Failed { session_id, error },
                 }
             }
         }
+    }
 
-        outcomes
+    /// Maps a [`ProverServiceClientError`] into the proposer's error type.
+    fn error_from_client(error: ProverServiceClientError) -> ProposerError {
+        ProposerError::Prover(error.to_string())
     }
 
     /// Maps a [`ProofStatus`] to its `proof_status_received_total` label value.
@@ -255,107 +254,26 @@ impl<R: RollupProvider + 'static> ProofCollector<R> {
             ProofStatus::Failed => Metrics::PROOF_STATUS_FAILED,
         }
     }
-
-    async fn fetch_canonical_root_results(
-        &self,
-        blocks: &[u64],
-    ) -> HashMap<u64, Result<B256, ProposerError>> {
-        if blocks.is_empty() {
-            return HashMap::new();
-        }
-        let rollup = &self.rollup_client;
-        stream::iter(blocks.iter().copied())
-            .map(|block_number| async move {
-                let result = rollup
-                    .output_at_block(block_number)
-                    .await
-                    .map(|out| out.output_root)
-                    .map_err(ProposerError::Rpc);
-                (block_number, result)
-            })
-            .buffered(self.output_fetch_concurrency)
-            .collect()
-            .await
-    }
 }
 
 #[cfg(test)]
 mod tests {
-    use std::collections::{BTreeSet, HashMap};
+    use std::collections::HashMap;
 
-    use alloy_primitives::Address;
+    use alloy_primitives::{Address, B256};
 
     use super::*;
     use crate::{
-        driver::RecoveredState,
+        proof_adapter::ProofRequesterDispatcher,
         test_utils::{MockProofRequester, MockRollupClient, test_sync_status},
     };
-
-    fn make_collector(block_interval: u64) -> ProofCollector<MockRollupClient> {
-        let proof_requester: Arc<dyn ProofRequesterProvider> =
-            Arc::new(MockProofRequester::default());
-        let rollup_client = Arc::new(MockRollupClient {
-            sync_status: test_sync_status(0, B256::ZERO),
-            output_roots: HashMap::new(),
-            max_safe_block: None,
-        });
-        ProofCollector::aws_nitro(proof_requester, rollup_client, block_interval, 4)
-    }
-
-    fn recovered(block: u64) -> RecoveredState {
-        RecoveredState {
-            parent_address: Address::ZERO,
-            output_root: B256::ZERO,
-            l2_block_number: block,
-        }
-    }
-
-    #[test]
-    fn collectable_targets_returns_next_expected_blocks_excluding_proved_and_submitting() {
-        let collector = make_collector(100);
-
-        let proved: BTreeSet<u64> = [200, 400].into_iter().collect();
-        let submitting: Option<u64> = Some(300);
-
-        let targets = collector.collectable_targets(&recovered(100), 700, |t| {
-            proved.contains(&t) || submitting == Some(t)
-        });
-
-        // From recovered=100, step=100, safe_head=700 → candidates 200..=700.
-        // Excluded: 200 (proved), 300 (submitting), 400 (proved).
-        // Expected: 500, 600, 700.
-        assert_eq!(targets, vec![500, 600, 700]);
-    }
-
-    /// All eligible targets up to `safe_head` are returned: there is no
-    /// per-tick parallel-poll cap. The safe head is the only natural bound.
-    #[test]
-    fn collectable_targets_returns_all_eligible_targets_up_to_safe_head() {
-        let collector = make_collector(100);
-
-        let targets = collector.collectable_targets(&recovered(100), 1000, |_| false);
-
-        assert_eq!(targets, vec![200, 300, 400, 500, 600, 700, 800, 900, 1000]);
-    }
-
-    #[test]
-    fn collectable_targets_returns_empty_when_safe_head_below_first_target() {
-        let collector = make_collector(100);
-
-        let targets = collector.collectable_targets(&recovered(500), 550, |_| false);
-
-        // Next target = 600 > safe_head=550, so no targets.
-        assert!(targets.is_empty());
-    }
 
     /// Restart/recovery: the collector derives the prover-service session id
     /// solely from the canonical L2 output root + tee kind, so a freshly
     /// constructed collector (mirroring a proposer restart) can pick up an
     /// in-flight session that a previous run dispatched.
     #[tokio::test]
-    async fn collector_recovers_in_flight_session_across_restart() {
-        use crate::proof_adapter::ProofRequesterDispatcher;
-
+    async fn poll_recovers_in_flight_session_across_restart() {
         let proof_requester: Arc<dyn ProofRequesterProvider> =
             Arc::new(MockProofRequester::default());
 
@@ -393,15 +311,34 @@ mod tests {
         // recover the in-flight session.
         let collector =
             ProofCollector::aws_nitro(Arc::clone(&proof_requester), rollup_client, 100, 4);
-        let outcomes = collector.collect(&[target_block]).await;
 
-        assert_eq!(outcomes.len(), 1);
-        match &outcomes[0] {
-            CollectedProof::Ready { target_block: t, session_id, .. } => {
-                assert_eq!(*t, target_block);
-                assert_eq!(session_id, &expected_session_id);
+        match collector.poll(target_block).await {
+            TargetPoll::Ready { session_id, .. } => {
+                assert_eq!(session_id, expected_session_id);
             }
             other => panic!("expected Ready, got {other:?}"),
+        }
+    }
+
+    /// When the prover service has no record of a session, `poll()` returns
+    /// [`TargetPoll::NotFound`] so the caller can dispatch a new request.
+    #[tokio::test]
+    async fn poll_returns_not_found_for_unknown_session() {
+        let proof_requester: Arc<dyn ProofRequesterProvider> =
+            Arc::new(MockProofRequester::default());
+        let target_block = 200u64;
+        let mut output_roots = HashMap::new();
+        output_roots.insert(target_block, B256::repeat_byte(0xAA));
+        let rollup_client = Arc::new(MockRollupClient {
+            sync_status: test_sync_status(target_block, B256::ZERO),
+            output_roots,
+            max_safe_block: None,
+        });
+
+        let collector = ProofCollector::aws_nitro(proof_requester, rollup_client, 100, 4);
+        match collector.poll(target_block).await {
+            TargetPoll::NotFound { session_id } => assert!(!session_id.is_empty()),
+            other => panic!("expected NotFound, got {other:?}"),
         }
     }
 }

--- a/crates/proof/proposer/src/proof_collector.rs
+++ b/crates/proof/proposer/src/proof_collector.rs
@@ -16,6 +16,7 @@
 
 use std::sync::Arc;
 
+use alloy_primitives::B256;
 use base_proof_primitives::ProofResult;
 use base_proof_rpc::RollupProvider;
 use base_prover_service_client::{ProofRequesterProvider, ProverServiceClientError};
@@ -59,6 +60,11 @@ pub enum TargetPoll {
         /// Deterministic prover-service session identifier the caller should
         /// expect when dispatching the matching `prove_block_range` request.
         session_id: String,
+        /// Canonical L2 output root at the target block, already fetched
+        /// while deriving the session id. Threaded through so the dispatch
+        /// path does not need to call `output_at_block(target_block)` a
+        /// second time.
+        claimed_l2_output_root: B256,
     },
     /// A transient error prevented the poll from completing (RPC failure,
     /// canonical root fetch error, etc.). The caller should sleep and retry
@@ -81,8 +87,6 @@ pub enum TargetPoll {
 pub struct ProofCollector<R> {
     proof_requester: Arc<dyn ProofRequesterProvider>,
     rollup_client: Arc<R>,
-    block_interval: u64,
-    output_fetch_concurrency: usize,
     tee_kind: TeeKind,
 }
 
@@ -91,8 +95,6 @@ impl<R> Clone for ProofCollector<R> {
         Self {
             proof_requester: Arc::clone(&self.proof_requester),
             rollup_client: Arc::clone(&self.rollup_client),
-            block_interval: self.block_interval,
-            output_fetch_concurrency: self.output_fetch_concurrency,
             tee_kind: self.tee_kind,
         }
     }
@@ -100,11 +102,7 @@ impl<R> Clone for ProofCollector<R> {
 
 impl<R> std::fmt::Debug for ProofCollector<R> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("ProofCollector")
-            .field("block_interval", &self.block_interval)
-            .field("output_fetch_concurrency", &self.output_fetch_concurrency)
-            .field("tee_kind", &self.tee_kind)
-            .finish_non_exhaustive()
+        f.debug_struct("ProofCollector").field("tee_kind", &self.tee_kind).finish_non_exhaustive()
     }
 }
 
@@ -113,42 +111,22 @@ impl<R: RollupProvider + 'static> ProofCollector<R> {
     pub fn aws_nitro(
         proof_requester: Arc<dyn ProofRequesterProvider>,
         rollup_client: Arc<R>,
-        block_interval: u64,
-        output_fetch_concurrency: usize,
     ) -> Self {
-        Self::new(
-            proof_requester,
-            rollup_client,
-            block_interval,
-            output_fetch_concurrency,
-            TeeKind::AwsNitro,
-        )
+        Self::new(proof_requester, rollup_client, TeeKind::AwsNitro)
     }
 
     /// Creates a proof collector for the given TEE implementation.
     pub const fn new(
         proof_requester: Arc<dyn ProofRequesterProvider>,
         rollup_client: Arc<R>,
-        block_interval: u64,
-        output_fetch_concurrency: usize,
         tee_kind: TeeKind,
     ) -> Self {
-        Self { proof_requester, rollup_client, block_interval, output_fetch_concurrency, tee_kind }
+        Self { proof_requester, rollup_client, tee_kind }
     }
 
     /// Returns the TEE implementation this collector polls proofs for.
     pub const fn tee_kind(&self) -> TeeKind {
         self.tee_kind
-    }
-
-    /// Returns the block interval the collector was configured with.
-    pub const fn block_interval(&self) -> u64 {
-        self.block_interval
-    }
-
-    /// Returns the rollup-output fetch concurrency the collector was configured with.
-    pub const fn output_fetch_concurrency(&self) -> usize {
-        self.output_fetch_concurrency
     }
 
     /// Polls the prover service for the proof of `target_block`.
@@ -188,7 +166,10 @@ impl<R: RollupProvider + 'static> ProofCollector<R> {
                     session_id = %session_id,
                     "No prover-service session for target, dispatch needed",
                 );
-                return TargetPoll::NotFound { session_id };
+                return TargetPoll::NotFound {
+                    session_id,
+                    claimed_l2_output_root: output.output_root,
+                };
             }
             Err(e) => {
                 debug!(
@@ -309,8 +290,7 @@ mod tests {
         // "Restart": build a fresh collector with no in-memory dispatch state.
         // It must rederive the session id from the canonical chain root and
         // recover the in-flight session.
-        let collector =
-            ProofCollector::aws_nitro(Arc::clone(&proof_requester), rollup_client, 100, 4);
+        let collector = ProofCollector::aws_nitro(Arc::clone(&proof_requester), rollup_client);
 
         match collector.poll(target_block).await {
             TargetPoll::Ready { session_id, .. } => {
@@ -335,9 +315,16 @@ mod tests {
             max_safe_block: None,
         });
 
-        let collector = ProofCollector::aws_nitro(proof_requester, rollup_client, 100, 4);
+        let collector = ProofCollector::aws_nitro(proof_requester, rollup_client);
         match collector.poll(target_block).await {
-            TargetPoll::NotFound { session_id } => assert!(!session_id.is_empty()),
+            TargetPoll::NotFound { session_id, claimed_l2_output_root } => {
+                assert!(!session_id.is_empty());
+                assert_eq!(
+                    claimed_l2_output_root,
+                    B256::repeat_byte(0xAA),
+                    "should surface the canonical root already fetched",
+                );
+            }
             other => panic!("expected NotFound, got {other:?}"),
         }
     }

--- a/crates/proof/proposer/src/service.rs
+++ b/crates/proof/proposer/src/service.rs
@@ -29,7 +29,7 @@ use tracing::{info, warn};
 use crate::{
     Metrics,
     config::ProposerConfig,
-    constants::MAX_PROOF_RETRIES,
+    constants::{MAX_PROOF_RETRIES, SUBMIT_TIMEOUT},
     driver::{DriverConfig, PipelineHandle, ProposerDriverControl},
     output_proposer::ProposalSubmitter,
     pipeline::{PipelineConfig, ProvingPipeline},
@@ -204,6 +204,7 @@ impl ProposerService {
         let pipeline_config = PipelineConfig {
             max_retries: MAX_PROOF_RETRIES,
             recovery_scan_concurrency: config.recovery_scan_concurrency,
+            submit_timeout: SUBMIT_TIMEOUT,
             tee_prover_registry_address: config.tee_prover_registry_address,
             driver: DriverConfig {
                 poll_interval: config.poll_interval,

--- a/crates/proof/proposer/src/test_utils.rs
+++ b/crates/proof/proposer/src/test_utils.rs
@@ -413,6 +413,10 @@ pub fn test_proposal(block_number: u64) -> Proposal {
 pub struct MockProofRequester {
     /// Requests accepted through `prove_block_range`.
     pub requests: std::sync::Mutex<HashMap<String, ProveBlockRangeRequest>>,
+    /// Sessions that should return a terminal failed status from `get_proof`.
+    pub failed_sessions: std::sync::Mutex<HashMap<String, String>>,
+    /// Number of `prove_block_range` calls accepted.
+    pub prove_count: AtomicUsize,
 }
 
 #[async_trait]
@@ -422,6 +426,7 @@ impl ProofRequesterProvider for MockProofRequester {
         request: ProveBlockRangeRequest,
     ) -> Result<ProveBlockRangeResponse, ProverServiceClientError> {
         let session_id = request.proof.session_id.clone();
+        self.prove_count.fetch_add(1, Ordering::SeqCst);
         self.requests.lock().unwrap().insert(session_id.clone(), request);
         Ok(ProveBlockRangeResponse { session_id })
     }
@@ -430,10 +435,18 @@ impl ProofRequesterProvider for MockProofRequester {
         &self,
         request: GetProofRequest,
     ) -> Result<GetProofResponse, ProverServiceClientError> {
+        if let Some(message) = self.failed_sessions.lock().unwrap().get(&request.session_id) {
+            return Ok(GetProofResponse {
+                status: ProofStatus::Failed,
+                error_message: Some(message.clone()),
+                result: None,
+            });
+        }
+
         let requests = self.requests.lock().unwrap();
         let request = requests.get(&request.session_id).ok_or_else(|| {
             // Mirror the production prover-service: an unknown session_id surfaces
-            // as a JSON-RPC NotFound error. The proposer self-driving loop relies
+            // as a JSON-RPC NotFound error. The proposer pipeline relies
             // on this to distinguish "no session yet, dispatch needed" from other
             // transient or terminal errors.
             ProverServiceClientError::RpcTransport(JsonRpcClientError::Call(

--- a/crates/proof/proposer/src/test_utils.rs
+++ b/crates/proof/proposer/src/test_utils.rs
@@ -28,6 +28,7 @@ use base_prover_service_protocol::{
     ProofRequestKind as ApiProofRequestKind, ProofResult as ApiProofResult, ProofStatus,
     ProveBlockRangeRequest, ProveBlockRangeResponse, TeeKind, TeeProofResult,
 };
+use jsonrpsee::{core::client::Error as JsonRpcClientError, types::ErrorObjectOwned};
 
 use crate::{error::ProposerError, output_proposer::OutputProposer};
 
@@ -430,9 +431,19 @@ impl ProofRequesterProvider for MockProofRequester {
         request: GetProofRequest,
     ) -> Result<GetProofResponse, ProverServiceClientError> {
         let requests = self.requests.lock().unwrap();
-        let request = requests
-            .get(&request.session_id)
-            .ok_or_else(|| ProverServiceClientError::MissingResult("unknown session".to_owned()))?;
+        let request = requests.get(&request.session_id).ok_or_else(|| {
+            // Mirror the production prover-service: an unknown session_id surfaces
+            // as a JSON-RPC NotFound error. The proposer self-driving loop relies
+            // on this to distinguish "no session yet, dispatch needed" from other
+            // transient or terminal errors.
+            ProverServiceClientError::RpcTransport(JsonRpcClientError::Call(
+                ErrorObjectOwned::owned(
+                    ProverServiceClientError::ERROR_NOT_FOUND,
+                    "Proof request not found",
+                    None::<()>,
+                ),
+            ))
+        })?;
         let ApiProofRequestKind::Tee(tee_request) = &request.proof.request else {
             return Err(ProverServiceClientError::UnexpectedResultPayload(
                 "expected TEE request".to_owned(),

--- a/crates/proof/prover-service/client/src/error.rs
+++ b/crates/proof/prover-service/client/src/error.rs
@@ -38,6 +38,9 @@ pub enum ProverServiceClientError {
 }
 
 impl ProverServiceClientError {
+    /// JSON-RPC code used by the prover service when the requested session does not exist.
+    pub const ERROR_NOT_FOUND: i32 = -32004;
+
     /// JSON-RPC code used by the prover service when a dependency is unavailable.
     pub const ERROR_UNAVAILABLE: i32 = -32014;
 
@@ -58,6 +61,16 @@ impl ProverServiceClientError {
             | Self::MissingResult(_)
             | Self::UnexpectedResultPayload(_) => false,
         }
+    }
+
+    /// Returns `true` when the prover service responded that the session does not exist.
+    ///
+    /// The proposer's self-driving loop uses this to distinguish "no session yet,
+    /// dispatch needed" from other transient or terminal errors.
+    #[must_use]
+    pub fn is_not_found(&self) -> bool {
+        let Self::RpcTransport(JsonRpcClientError::Call(call)) = self else { return false };
+        call.code() == Self::ERROR_NOT_FOUND
     }
 
     /// Returns `true` when the JSON-RPC error is classified as transient.
@@ -146,5 +159,21 @@ mod tests {
         #[case] expected_retryable: bool,
     ) {
         assert_eq!(error.is_retryable(), expected_retryable);
+    }
+
+    #[test]
+    fn is_not_found_matches_only_call_with_not_found_code() {
+        let not_found = rpc_call_error(ProverServiceClientError::ERROR_NOT_FOUND, "missing");
+        assert!(not_found.is_not_found());
+
+        let other_call = rpc_call_error(ProverServiceClientError::ERROR_UNAVAILABLE, "down");
+        assert!(!other_call.is_not_found());
+
+        let transport: ProverServiceClientError =
+            JsonRpcClientError::Transport(io::Error::other("connection refused").into()).into();
+        assert!(!transport.is_not_found());
+
+        let timeout = ProverServiceClientError::Timeout("not ready".into());
+        assert!(!timeout.is_not_found());
     }
 }


### PR DESCRIPTION
## Summary

Reworks the proposer proving pipeline into the planned concurrent dispatcher / collector architecture.

The pipeline now runs two cooperative tasks per session:

- **Dispatcher loop:** recovers the latest on-chain game, walks forward by `block_interval`, and dispatches proof requests up to the safe head so the proposer can catch up from a deficit.
- **Collector loop:** independently derives prover-service sessions from canonical L2 output roots, polls completed proofs, and submits proposals sequentially in on-chain order.

Submit failures restart both loops from fresh chain-derived recovery state. This keeps the dispatcher and collector independent while ensuring failure handling returns to the canonical on-chain tip.

```text
┌──────────┐     ┌──────────────────┐
│ RECOVER  │ ──> │ DISPATCH LOOP    │ ──> prover service
│ (cached) │     └──────────────────┘
│          │     ┌──────────────────┐
│          │ ──> │ COLLECT LOOP     │ ──> L1 submitter
└──────────┘     └──────────────────┘
```

## Behavior

- Dispatcher can fan out proof requests for every eligible target up to safe head, instead of limiting the proposer to one in-flight proof.
- Collector preserves sequential submission order, but drains immediately-ready proof backlogs in one tick instead of sleeping `poll_interval` between successful submits.
- Normal prover-service sessions remain deterministic and root-derived so restarts can rediscover in-flight work.
- Terminal prover-service `Failed` sessions are re-dispatched so prover-service actually requeues them.
- `SubmitAction::Discard` no longer skips the target. It dispatches retry-specific sessions so `L1OriginTooOld` / `InvalidSigner` can obtain a fresh TEE proof instead of looping on the old `Succeeded` session.
- Discard retries are capped by `max_retries`; exhaustion clears retry state and drops the recovery cache.
- Missing retry-specific sessions are treated as dispatch-needed and replaced with a fresh retry session.
- Request-build failures from transient L1/L2 RPC reads are logged as `build_failed` dispatch outcomes and do not burn the proof retry budget.
- Submit failures that invalidate progress (`RootMismatch`, invalid parent game, timeout, transient submit failure) request a session restart so both loops re-walk from chain state.
- `GameAlreadyExists` is treated as success-like: gauges advance and recovery is refreshed to discover the existing game.
- Task exits, task errors, and task panics restart the pipeline session instead of terminating `run()`.

## Observability

- Removed obsolete in-memory queue metrics that no longer apply to the final task structure.
- Added `proof_dispatch_total{outcome="build_failed"}` for request-build failures that never reached prover-service.
- `last_proposed_block` reflects the recovered on-chain tip on every iteration.
- `last_collected_block` advances on successful inline submit / success-like `GameAlreadyExists` handling.
- `PipelineConfig.submit_timeout` controls the inline validation + submit budget.

## Tests

Added or updated coverage for:

- dispatcher fan-out up to safe head
- collector backlog draining without `poll_interval` lag
- prover-service `Failed` re-dispatch
- discard retry-specific sessions
- discard retry exhaustion
- missing retry-session replacement
- submit-failure restart signaling
- task panic restart handling
- build-error no-retry-budget behavior
- inline submit success and failure mappings
- recovery cache / forward-walk behavior

Verification run locally:

- `cargo +nightly fmt -p base-proposer`
- `cargo test -p base-proposer --lib` -> 121 passed
- `cargo test -p base-proposer --lib --features metrics` -> 123 passed
- `cargo clippy -p base-proposer --all-targets -- -D warnings`
- `cargo clippy -p base-proposer --all-targets --features metrics -- -D warnings`
