### PR TITLE
fix(basectl): use saturating_add for byte accumulation in RateTracker::rate_over

### DIFF
--- a/crates/infra/basectl/src/app/state.rs
+++ b/crates/infra/basectl/src/app/state.rs
@@ -231,7 +231,7 @@ impl RateTracker {
         let (count, total, earliest) = self.samples.iter().filter(|(t, _)| *t >= cutoff).fold(
             (0usize, 0u64, None::<Instant>),
             |(count, total, earliest), (t, b)| {
-                (count + 1, total + b, Some(earliest.map_or(*t, |e: Instant| e.min(*t))))
+                (count + 1, total.saturating_add(*b), Some(earliest.map_or(*t, |e: Instant| e.min(*t))))
             },
         );
 


### PR DESCRIPTION
Fixes #3275.

`rate_over` accumulated byte samples with a plain `+` operator on `u64` values. In release mode this wraps silently on overflow, producing a wrong rate result. In debug mode it panics.

The fix replaces `total + b` with `total.saturating_add(*b)`, which caps at `u64::MAX` instead of wrapping. This matches the defensive style already used elsewhere in the codebase and makes the accumulation consistent with `add_sample`'s eviction logic.

One character fix, no behavior change under normal operating conditions.