### PR TITLE
fix(basectl): replace unsafe i64 cast with safe u64 arithmetic in DaTracker::update_block_info

### DIFF
--- a/crates/infra/basectl/src/app/state.rs
+++ b/crates/infra/basectl/src/app/state.rs
@@ -337,16 +337,17 @@ impl DaTracker {
     pub fn update_block_info(&mut self, block_number: u64, accurate_da_bytes: u64, timestamp: u64) {
         for contrib in &mut self.block_contributions {
             if contrib.block_number == block_number {
-                let diff = accurate_da_bytes as i64 - contrib.da_bytes as i64;
+                let old_bytes = contrib.da_bytes;
                 contrib.da_bytes = accurate_da_bytes;
                 contrib.timestamp = timestamp;
 
                 if block_number > self.safe_l2_block {
-                    if diff > 0 {
-                        self.da_backlog_bytes = self.da_backlog_bytes.saturating_add(diff as u64);
+                    if accurate_da_bytes >= old_bytes {
+                        self.da_backlog_bytes =
+                            self.da_backlog_bytes.saturating_add(accurate_da_bytes - old_bytes);
                     } else {
                         self.da_backlog_bytes =
-                            self.da_backlog_bytes.saturating_sub((-diff) as u64);
+                            self.da_backlog_bytes.saturating_sub(old_bytes - accurate_da_bytes);
                     }
                 }
                 return;


### PR DESCRIPTION
Fixes #3277.

`update_block_info` computed the DA byte delta by casting both `u64` values to `i64`. If either value exceeds `i64::MAX`, the cast silently truncates and flips the sign causing the wrong branch to run and corrupting `da_backlog_bytes`.

The fix stores the old byte count before overwriting it, then uses direct `u64` subtraction with `saturating_add`/`saturating_sub` the same pattern already used in `add_block` and `update_safe_head`.

No behavior change for values within normal range.