### PR TITLE
refactor(registrar): extract cert revoker

### DIFF
--- a/crates/proof/tee/registrar/src/cert_revoker.rs
+++ b/crates/proof/tee/registrar/src/cert_revoker.rs
@@ -4,7 +4,6 @@ use alloy_primitives::{Address, Bytes, FixedBytes};
 use alloy_sol_types::SolCall;
 use base_proof_contracts::INitroEnclaveVerifier;
 use base_tx_manager::{TxCandidate, TxManager};
-use tokio::task::JoinHandle;
 use tracing::{info, warn};
 
 use crate::RegistrarMetrics;
@@ -18,22 +17,11 @@ pub struct CertRevoker<T> {
 
 impl<T> CertRevoker<T>
 where
-    T: TxManager + 'static,
+    T: TxManager,
 {
     /// Creates a revoker bound to a `NitroEnclaveVerifier` address.
     pub const fn new(verifier_address: Address, tx_manager: T) -> Self {
         Self { verifier_address, tx_manager }
-    }
-
-    /// Spawns a task that submits a `revokeCert` transaction and relies on the
-    /// tx manager to deliver a confirmed receipt.
-    ///
-    /// Dropping the returned handle detaches the task; awaiting it lets callers
-    /// observe task panics or coordinate shutdown.
-    pub fn revoke_cert(self, cert_hash: FixedBytes<32>) -> JoinHandle<()> {
-        tokio::spawn(async move {
-            self.submit_revoke_cert(cert_hash).await;
-        })
     }
 
     /// Builds the transaction candidate for `NitroEnclaveVerifier.revokeCert`.
@@ -44,7 +32,8 @@ where
         TxCandidate { tx_data: calldata, to: Some(self.verifier_address), ..Default::default() }
     }
 
-    async fn submit_revoke_cert(self, cert_hash: FixedBytes<32>) {
+    /// Submits a `revokeCert` transaction and records the transaction outcome.
+    pub async fn revoke_cert(self, cert_hash: FixedBytes<32>) {
         let candidate = self.candidate(cert_hash);
         match self.tx_manager.send(candidate).await {
             Ok(receipt) => {
@@ -108,11 +97,11 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn submit_revoke_cert_sends_candidate() {
+    async fn revoke_cert_submits_candidate() {
         let tx_manager = MockTxManager::default();
         let revoker = CertRevoker::new(VERIFIER_ADDRESS, tx_manager.clone());
 
-        revoker.submit_revoke_cert(CERT_HASH).await;
+        revoker.revoke_cert(CERT_HASH).await;
 
         assert_eq!(
             tx_manager.take_candidate().tx_data,
@@ -121,13 +110,11 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn revoke_cert_returns_join_handle_for_spawned_submission() {
+    async fn revoke_cert_sends_candidate() {
         let tx_manager = MockTxManager::default();
         let revoker = CertRevoker::new(VERIFIER_ADDRESS, tx_manager.clone());
 
-        let handle = revoker.revoke_cert(CERT_HASH);
-
-        handle.await.unwrap();
+        revoker.revoke_cert(CERT_HASH).await;
         assert_eq!(
             tx_manager.take_candidate().tx_data,
             Bytes::from(INitroEnclaveVerifier::revokeCertCall { certHash: CERT_HASH }.abi_encode())
@@ -151,7 +138,7 @@ mod tests {
                     let tx_manager = MockTxManager::with_receipt_status(false);
                     let revoker = CertRevoker::new(VERIFIER_ADDRESS, tx_manager);
 
-                    revoker.submit_revoke_cert(CERT_HASH).await;
+                    revoker.revoke_cert(CERT_HASH).await;
                 });
             });
 

--- a/crates/proof/tee/registrar/src/cert_revoker.rs
+++ b/crates/proof/tee/registrar/src/cert_revoker.rs
@@ -1,0 +1,168 @@
+//! Certificate revocation transaction sender.
+
+use alloy_primitives::{Address, Bytes, FixedBytes};
+use alloy_sol_types::SolCall;
+use base_proof_contracts::INitroEnclaveVerifier;
+use base_tx_manager::{TxCandidate, TxManager};
+use tracing::{info, warn};
+
+use crate::RegistrarMetrics;
+
+/// Sends `NitroEnclaveVerifier.revokeCert` transactions through a tx manager.
+#[derive(Debug)]
+pub struct CertRevoker<T> {
+    verifier_address: Address,
+    tx_manager: T,
+}
+
+impl<T> CertRevoker<T>
+where
+    T: TxManager + 'static,
+{
+    /// Creates a revoker bound to a `NitroEnclaveVerifier` address.
+    pub const fn new(verifier_address: Address, tx_manager: T) -> Self {
+        Self { verifier_address, tx_manager }
+    }
+
+    /// Spawns a detached task that submits a `revokeCert` transaction and
+    /// relies on the tx manager to deliver a confirmed receipt.
+    pub fn revoke_cert(self, cert_hash: FixedBytes<32>) {
+        tokio::spawn(async move {
+            self.submit_revoke_cert(cert_hash).await;
+        });
+    }
+
+    /// Builds the transaction candidate for `NitroEnclaveVerifier.revokeCert`.
+    pub fn candidate(&self, cert_hash: FixedBytes<32>) -> TxCandidate {
+        let calldata =
+            Bytes::from(INitroEnclaveVerifier::revokeCertCall { certHash: cert_hash }.abi_encode());
+
+        TxCandidate { tx_data: calldata, to: Some(self.verifier_address), ..Default::default() }
+    }
+
+    async fn submit_revoke_cert(self, cert_hash: FixedBytes<32>) {
+        let candidate = self.candidate(cert_hash);
+        match self.tx_manager.send(candidate).await {
+            Ok(receipt) => {
+                if !receipt.inner.status() {
+                    warn!(
+                        cert_hash = %cert_hash,
+                        tx_hash = %receipt.transaction_hash,
+                        "revokeCert transaction reverted (cert may already be revoked)"
+                    );
+                } else {
+                    info!(
+                        cert_hash = %cert_hash,
+                        tx_hash = %receipt.transaction_hash,
+                        "certificate revoked successfully"
+                    );
+                    RegistrarMetrics::revoke_cert_success_total().increment(1);
+                }
+            }
+            Err(e) => {
+                warn!(
+                    error = %e,
+                    cert_hash = %cert_hash,
+                    "failed to submit revokeCert transaction"
+                );
+                RegistrarMetrics::revoke_cert_tx_failures().increment(1);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Mutex;
+
+    use alloy_consensus::{Eip658Value, Receipt, ReceiptEnvelope, ReceiptWithBloom};
+    use alloy_primitives::{B256, Bloom, b256};
+    use alloy_rpc_types_eth::TransactionReceipt;
+    use alloy_sol_types::SolCall;
+    use base_proof_contracts::INitroEnclaveVerifier;
+
+    use super::*;
+
+    const VERIFIER_ADDRESS: Address = Address::new([0x11; 20]);
+    const CERT_HASH: B256 =
+        b256!("2222222222222222222222222222222222222222222222222222222222222222");
+
+    #[test]
+    fn candidate_targets_verifier_with_revoke_cert_calldata() {
+        let tx_manager = MockTxManager::default();
+        let revoker = CertRevoker::new(VERIFIER_ADDRESS, tx_manager);
+        let candidate = revoker.candidate(CERT_HASH);
+
+        assert_eq!(candidate.to, Some(VERIFIER_ADDRESS));
+        assert_eq!(
+            candidate.tx_data,
+            Bytes::from(INitroEnclaveVerifier::revokeCertCall { certHash: CERT_HASH }.abi_encode())
+        );
+        assert_eq!(candidate.gas_limit, 0);
+        assert!(candidate.blobs.is_empty());
+    }
+
+    #[tokio::test]
+    async fn submit_revoke_cert_sends_candidate() {
+        let tx_manager = MockTxManager::default();
+        let revoker = CertRevoker::new(VERIFIER_ADDRESS, tx_manager.clone());
+
+        revoker.submit_revoke_cert(CERT_HASH).await;
+
+        assert_eq!(
+            tx_manager.take_candidate().tx_data,
+            Bytes::from(INitroEnclaveVerifier::revokeCertCall { certHash: CERT_HASH }.abi_encode())
+        );
+    }
+
+    #[derive(Debug, Clone, Default)]
+    struct MockTxManager {
+        sent_candidate: std::sync::Arc<Mutex<Option<TxCandidate>>>,
+    }
+
+    impl MockTxManager {
+        fn take_candidate(&self) -> TxCandidate {
+            self.sent_candidate.lock().unwrap().take().expect("candidate was sent")
+        }
+    }
+
+    impl TxManager for MockTxManager {
+        async fn send(&self, candidate: TxCandidate) -> base_tx_manager::SendResponse {
+            *self.sent_candidate.lock().unwrap() = Some(candidate);
+            Ok(stub_receipt())
+        }
+
+        async fn send_async(&self, _candidate: TxCandidate) -> base_tx_manager::SendHandle {
+            unreachable!("candidate construction test does not send transactions")
+        }
+
+        fn sender_address(&self) -> Address {
+            Address::ZERO
+        }
+    }
+
+    fn stub_receipt() -> TransactionReceipt {
+        let inner = ReceiptEnvelope::Legacy(ReceiptWithBloom {
+            receipt: Receipt {
+                status: Eip658Value::Eip658(true),
+                cumulative_gas_used: 21_000,
+                logs: vec![],
+            },
+            logs_bloom: Bloom::ZERO,
+        });
+        TransactionReceipt {
+            inner,
+            transaction_hash: B256::ZERO,
+            transaction_index: Some(0),
+            block_hash: Some(B256::ZERO),
+            block_number: Some(1),
+            gas_used: 21_000,
+            effective_gas_price: 1_000_000_000,
+            blob_gas_used: None,
+            blob_gas_price: None,
+            from: Address::ZERO,
+            to: Some(Address::ZERO),
+            contract_address: None,
+        }
+    }
+}

--- a/crates/proof/tee/registrar/src/cert_revoker.rs
+++ b/crates/proof/tee/registrar/src/cert_revoker.rs
@@ -10,17 +10,17 @@ use crate::RegistrarMetrics;
 
 /// Sends `NitroEnclaveVerifier.revokeCert` transactions through a tx manager.
 #[derive(Debug)]
-pub struct CertRevoker<T> {
+pub struct CertRevoker<'a, T> {
     verifier_address: Address,
-    tx_manager: T,
+    tx_manager: &'a T,
 }
 
-impl<T> CertRevoker<T>
+impl<'a, T> CertRevoker<'a, T>
 where
     T: TxManager,
 {
     /// Creates a revoker bound to a `NitroEnclaveVerifier` address.
-    pub const fn new(verifier_address: Address, tx_manager: T) -> Self {
+    pub const fn new(verifier_address: Address, tx_manager: &'a T) -> Self {
         Self { verifier_address, tx_manager }
     }
 
@@ -33,7 +33,7 @@ where
     }
 
     /// Submits a `revokeCert` transaction and records the transaction outcome.
-    pub async fn revoke_cert(self, cert_hash: FixedBytes<32>) {
+    pub async fn revoke_cert(&self, cert_hash: FixedBytes<32>) {
         let candidate = self.candidate(cert_hash);
         match self.tx_manager.send(candidate).await {
             Ok(receipt) => {
@@ -84,7 +84,7 @@ mod tests {
     #[test]
     fn candidate_targets_verifier_with_revoke_cert_calldata() {
         let tx_manager = MockTxManager::default();
-        let revoker = CertRevoker::new(VERIFIER_ADDRESS, tx_manager);
+        let revoker = CertRevoker::new(VERIFIER_ADDRESS, &tx_manager);
         let candidate = revoker.candidate(CERT_HASH);
 
         assert_eq!(candidate.to, Some(VERIFIER_ADDRESS));
@@ -99,22 +99,10 @@ mod tests {
     #[tokio::test]
     async fn revoke_cert_submits_candidate() {
         let tx_manager = MockTxManager::default();
-        let revoker = CertRevoker::new(VERIFIER_ADDRESS, tx_manager.clone());
+        let revoker = CertRevoker::new(VERIFIER_ADDRESS, &tx_manager);
 
         revoker.revoke_cert(CERT_HASH).await;
 
-        assert_eq!(
-            tx_manager.take_candidate().tx_data,
-            Bytes::from(INitroEnclaveVerifier::revokeCertCall { certHash: CERT_HASH }.abi_encode())
-        );
-    }
-
-    #[tokio::test]
-    async fn revoke_cert_sends_candidate() {
-        let tx_manager = MockTxManager::default();
-        let revoker = CertRevoker::new(VERIFIER_ADDRESS, tx_manager.clone());
-
-        revoker.revoke_cert(CERT_HASH).await;
         assert_eq!(
             tx_manager.take_candidate().tx_data,
             Bytes::from(INitroEnclaveVerifier::revokeCertCall { certHash: CERT_HASH }.abi_encode())
@@ -136,7 +124,7 @@ mod tests {
             metrics::with_local_recorder(&recorder, || {
                 rt.block_on(async {
                     let tx_manager = MockTxManager::with_receipt_status(false);
-                    let revoker = CertRevoker::new(VERIFIER_ADDRESS, tx_manager);
+                    let revoker = CertRevoker::new(VERIFIER_ADDRESS, &tx_manager);
 
                     revoker.revoke_cert(CERT_HASH).await;
                 });

--- a/crates/proof/tee/registrar/src/cert_revoker.rs
+++ b/crates/proof/tee/registrar/src/cert_revoker.rs
@@ -4,6 +4,7 @@ use alloy_primitives::{Address, Bytes, FixedBytes};
 use alloy_sol_types::SolCall;
 use base_proof_contracts::INitroEnclaveVerifier;
 use base_tx_manager::{TxCandidate, TxManager};
+use tokio::task::JoinHandle;
 use tracing::{info, warn};
 
 use crate::RegistrarMetrics;
@@ -24,12 +25,15 @@ where
         Self { verifier_address, tx_manager }
     }
 
-    /// Spawns a detached task that submits a `revokeCert` transaction and
-    /// relies on the tx manager to deliver a confirmed receipt.
-    pub fn revoke_cert(self, cert_hash: FixedBytes<32>) {
+    /// Spawns a task that submits a `revokeCert` transaction and relies on the
+    /// tx manager to deliver a confirmed receipt.
+    ///
+    /// Dropping the returned handle detaches the task; awaiting it lets callers
+    /// observe task panics or coordinate shutdown.
+    pub fn revoke_cert(self, cert_hash: FixedBytes<32>) -> JoinHandle<()> {
         tokio::spawn(async move {
             self.submit_revoke_cert(cert_hash).await;
-        });
+        })
     }
 
     /// Builds the transaction candidate for `NitroEnclaveVerifier.revokeCert`.
@@ -50,6 +54,7 @@ where
                         tx_hash = %receipt.transaction_hash,
                         "revokeCert transaction reverted (cert may already be revoked)"
                     );
+                    RegistrarMetrics::revoke_cert_reverted_total().increment(1);
                 } else {
                     info!(
                         cert_hash = %cert_hash,
@@ -115,12 +120,70 @@ mod tests {
         );
     }
 
-    #[derive(Debug, Clone, Default)]
+    #[tokio::test]
+    async fn revoke_cert_returns_join_handle_for_spawned_submission() {
+        let tx_manager = MockTxManager::default();
+        let revoker = CertRevoker::new(VERIFIER_ADDRESS, tx_manager.clone());
+
+        let handle = revoker.revoke_cert(CERT_HASH);
+
+        handle.await.unwrap();
+        assert_eq!(
+            tx_manager.take_candidate().tx_data,
+            Bytes::from(INitroEnclaveVerifier::revokeCertCall { certHash: CERT_HASH }.abi_encode())
+        );
+    }
+
+    #[cfg(feature = "metrics")]
+    mod metric_tests {
+        use metrics_exporter_prometheus::PrometheusBuilder;
+
+        use super::*;
+
+        #[test]
+        fn submit_revoke_cert_records_reverted_metric() {
+            let rt = tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap();
+            let recorder = PrometheusBuilder::new().build_recorder();
+            let handle = recorder.handle();
+
+            metrics::with_local_recorder(&recorder, || {
+                rt.block_on(async {
+                    let tx_manager = MockTxManager::with_receipt_status(false);
+                    let revoker = CertRevoker::new(VERIFIER_ADDRESS, tx_manager);
+
+                    revoker.submit_revoke_cert(CERT_HASH).await;
+                });
+            });
+
+            let rendered = handle.render();
+            assert!(
+                rendered.contains("base_registrar_revoke_cert_reverted_total 1"),
+                "reverted revokeCert transaction should increment the revert counter. Got:\n{rendered}",
+            );
+            assert!(
+                !rendered.contains("base_registrar_revoke_cert_success_total 1"),
+                "reverted revokeCert transaction must not increment the success counter. Got:\n{rendered}",
+            );
+        }
+    }
+
+    #[derive(Debug, Clone)]
     struct MockTxManager {
         sent_candidate: std::sync::Arc<Mutex<Option<TxCandidate>>>,
+        receipt_status: bool,
+    }
+
+    impl Default for MockTxManager {
+        fn default() -> Self {
+            Self::with_receipt_status(true)
+        }
     }
 
     impl MockTxManager {
+        fn with_receipt_status(receipt_status: bool) -> Self {
+            Self { sent_candidate: std::sync::Arc::default(), receipt_status }
+        }
+
         fn take_candidate(&self) -> TxCandidate {
             self.sent_candidate.lock().unwrap().take().expect("candidate was sent")
         }
@@ -129,7 +192,7 @@ mod tests {
     impl TxManager for MockTxManager {
         async fn send(&self, candidate: TxCandidate) -> base_tx_manager::SendResponse {
             *self.sent_candidate.lock().unwrap() = Some(candidate);
-            Ok(stub_receipt())
+            Ok(stub_receipt(self.receipt_status))
         }
 
         async fn send_async(&self, _candidate: TxCandidate) -> base_tx_manager::SendHandle {
@@ -141,10 +204,10 @@ mod tests {
         }
     }
 
-    fn stub_receipt() -> TransactionReceipt {
+    fn stub_receipt(status: bool) -> TransactionReceipt {
         let inner = ReceiptEnvelope::Legacy(ReceiptWithBloom {
             receipt: Receipt {
-                status: Eip658Value::Eip658(true),
+                status: Eip658Value::Eip658(status),
                 cumulative_gas_used: 21_000,
                 logs: vec![],
             },

--- a/crates/proof/tee/registrar/src/cert_revoker.rs
+++ b/crates/proof/tee/registrar/src/cert_revoker.rs
@@ -35,6 +35,13 @@ where
     /// Submits a `revokeCert` transaction and records the transaction outcome.
     pub async fn revoke_cert(&self, cert_hash: FixedBytes<32>) {
         let candidate = self.candidate(cert_hash);
+        info!(
+            verifier = %self.verifier_address,
+            cert_hash = %cert_hash,
+            calldata_len = candidate.tx_data.len(),
+            "sending revokeCert transaction"
+        );
+
         match self.tx_manager.send(candidate).await {
             Ok(receipt) => {
                 if !receipt.inner.status() {

--- a/crates/proof/tee/registrar/src/driver.rs
+++ b/crates/proof/tee/registrar/src/driver.rs
@@ -12,7 +12,7 @@ use std::{
     time::Duration,
 };
 
-use alloy_primitives::{Address, Bytes, FixedBytes, hex};
+use alloy_primitives::{Address, Bytes, hex};
 use alloy_sol_types::SolCall;
 use base_proof_contracts::ITEEProverRegistry;
 use base_proof_tee_nitro_attestation_prover::AttestationProofProvider;
@@ -2024,7 +2024,7 @@ mod tests {
     };
 
     use alloy_consensus::{Eip658Value, Receipt, ReceiptEnvelope, ReceiptWithBloom};
-    use alloy_primitives::{Address, B256, Bloom, Bytes, address};
+    use alloy_primitives::{Address, B256, Bloom, Bytes, FixedBytes, address};
     use alloy_rpc_types_eth::TransactionReceipt;
     use alloy_sol_types::SolCall;
     use async_trait::async_trait;

--- a/crates/proof/tee/registrar/src/driver.rs
+++ b/crates/proof/tee/registrar/src/driver.rs
@@ -635,7 +635,6 @@ where
             match self.check_and_revoke_crls(&all_attestations[0], instance).await {
                 Ok(true) => {
                     // Confirmed revocation — block registration for this instance.
-                    // The revokeCert task was already spawned above.
                     warn!(
                         instance = %instance.instance_id,
                         "certificate revoked, skipping registration for this instance"
@@ -1084,9 +1083,9 @@ where
     ///
     /// **Cancellation contract.** This future checks
     /// `self.config.cancel.is_cancelled()` before starting new side effects.
-    /// `check_and_revoke_crls` enqueues any `revokeCert` transactions in
-    /// detached tasks, so the resolution future does not await revocation
-    /// delivery.
+    /// `check_and_revoke_crls` awaits any `revokeCert` transaction
+    /// submissions it triggers, so revocation outcomes are logged before
+    /// the resolution future returns.
     async fn resolve_instance(&self, instance: &ProverInstance) -> Result<ResolveOutcome> {
         if self.config.cancel.is_cancelled() {
             return Ok(ResolveOutcome {
@@ -1162,8 +1161,8 @@ where
         }
 
         if self.config.crl.enabled {
-            // Skip the CRL check (and its potential `revokeCert` task spawn)
-            // on shutdown so we do not start new onchain work.
+            // Skip the CRL check and any `revokeCert` submission on shutdown
+            // so we do not start new onchain work.
             //
             // Return `attestations: None` so the safety invariant —
             // `Some(..)` ↔ "passed every eligibility + security gate,
@@ -1819,7 +1818,7 @@ where
                 "submitting revokeCert transaction"
             );
 
-            self.submit_revoke_cert(verifier_address, revoked.path_digest);
+            self.submit_revoke_cert(verifier_address, revoked.path_digest).await;
         }
 
         Ok(true)
@@ -1829,14 +1828,14 @@ where
     ///
     /// Errors are logged but not propagated — a failed revocation should not
     /// block the registration cycle.
-    fn submit_revoke_cert(&self, verifier_address: Address, cert_hash: FixedBytes<32>) {
+    async fn submit_revoke_cert(&self, verifier_address: Address, cert_hash: FixedBytes<32>) {
         info!(
             verifier = %verifier_address,
             cert_hash = %cert_hash,
             "Revoking certificate"
         );
 
-        drop(CertRevoker::new(verifier_address, self.tx_manager.clone()).revoke_cert(cert_hash));
+        CertRevoker::new(verifier_address, self.tx_manager.clone()).revoke_cert(cert_hash).await;
     }
 
     /// Submits a `deregisterSigner` transaction and returns whether it succeeded.

--- a/crates/proof/tee/registrar/src/driver.rs
+++ b/crates/proof/tee/registrar/src/driver.rs
@@ -1819,29 +1819,10 @@ where
                 "submitting revokeCert transaction"
             );
 
-            self.submit_revoke_cert(&cert_revoker, verifier_address, revoked.path_digest).await;
+            cert_revoker.revoke_cert(revoked.path_digest).await;
         }
 
         Ok(true)
-    }
-
-    /// Submits a `revokeCert` transaction to the `NitroEnclaveVerifier`.
-    ///
-    /// Errors are logged but not propagated — a failed revocation should not
-    /// block the registration cycle.
-    async fn submit_revoke_cert(
-        &self,
-        cert_revoker: &CertRevoker<'_, T>,
-        verifier_address: Address,
-        cert_hash: FixedBytes<32>,
-    ) {
-        info!(
-            verifier = %verifier_address,
-            cert_hash = %cert_hash,
-            "Revoking certificate"
-        );
-
-        cert_revoker.revoke_cert(cert_hash).await;
     }
 
     /// Submits a `deregisterSigner` transaction and returns whether it succeeded.

--- a/crates/proof/tee/registrar/src/driver.rs
+++ b/crates/proof/tee/registrar/src/driver.rs
@@ -1836,7 +1836,7 @@ where
             "Revoking certificate"
         );
 
-        CertRevoker::new(verifier_address, self.tx_manager.clone()).revoke_cert(cert_hash);
+        drop(CertRevoker::new(verifier_address, self.tx_manager.clone()).revoke_cert(cert_hash));
     }
 
     /// Submits a `deregisterSigner` transaction and returns whether it succeeded.

--- a/crates/proof/tee/registrar/src/driver.rs
+++ b/crates/proof/tee/registrar/src/driver.rs
@@ -14,7 +14,7 @@ use std::{
 
 use alloy_primitives::{Address, Bytes, FixedBytes, hex};
 use alloy_sol_types::SolCall;
-use base_proof_contracts::{INitroEnclaveVerifier, ITEEProverRegistry};
+use base_proof_contracts::ITEEProverRegistry;
 use base_proof_tee_nitro_attestation_prover::AttestationProofProvider;
 use base_proof_tee_nitro_verifier::AttestationReport;
 use base_tx_manager::{TxCandidate, TxManager, TxManagerError};
@@ -28,8 +28,9 @@ use tokio_util::sync::CancellationToken;
 use tracing::{Instrument, debug, info, info_span, warn};
 
 use crate::{
-    CrlConfig, InstanceDiscovery, InstanceHealthStatus, NitroVerifierClient, ProverClient,
-    ProverInstance, RegistrarError, RegistrarMetrics, RegistryClient, Result, SignerClient, crl,
+    CertRevoker, CrlConfig, InstanceDiscovery, InstanceHealthStatus, NitroVerifierClient,
+    ProverClient, ProverInstance, RegistrarError, RegistrarMetrics, RegistryClient, Result,
+    SignerClient, crl,
 };
 
 /// Default maximum number of instances processed concurrently.
@@ -319,7 +320,7 @@ where
     D: InstanceDiscovery + 'static,
     P: AttestationProofProvider + 'static,
     R: RegistryClient + 'static,
-    T: TxManager + 'static,
+    T: TxManager + Clone + 'static,
     S: SignerClient + 'static,
 {
     /// Creates a new registration driver.
@@ -634,7 +635,7 @@ where
             match self.check_and_revoke_crls(&all_attestations[0], instance).await {
                 Ok(true) => {
                     // Confirmed revocation — block registration for this instance.
-                    // The revokeCert transaction was already submitted above.
+                    // The revokeCert task was already spawned above.
                     warn!(
                         instance = %instance.instance_id,
                         "certificate revoked, skipping registration for this instance"
@@ -1081,16 +1082,11 @@ where
     /// so the [`Self::run`] pipeline can spawn registration tasks
     /// separately from discovery.
     ///
-    /// **Cancellation contract.** This future is allowed to be dropped by
-    /// the caller only at boundaries that contain no in-flight
-    /// `tx_manager.send()` — i.e. before, between, or after the explicit
-    /// `self.config.cancel.is_cancelled()` early-return checks below.
-    /// `check_and_revoke_crls` submits `revokeCert` transactions via
-    /// [`Self::submit_revoke_cert`]; dropping that future after a
-    /// `NonceGuard` has been acquired but before broadcast would leave a
-    /// permanent nonce gap. `discover_and_resolve` therefore drains its
-    /// `buffer_unordered` stream to natural completion instead of wrapping
-    /// `futs.next()` in a cancel-select.
+    /// **Cancellation contract.** This future checks
+    /// `self.config.cancel.is_cancelled()` before starting new side effects.
+    /// `check_and_revoke_crls` enqueues any `revokeCert` transactions in
+    /// detached tasks, so the resolution future does not await revocation
+    /// delivery.
     async fn resolve_instance(&self, instance: &ProverInstance) -> Result<ResolveOutcome> {
         if self.config.cancel.is_cancelled() {
             return Ok(ResolveOutcome {
@@ -1166,10 +1162,8 @@ where
         }
 
         if self.config.crl.enabled {
-            // Skip the CRL check (and its potential `revokeCert` submission)
-            // on shutdown so we don't acquire a nonce we won't broadcast.
-            // Already-running `submit_revoke_cert` calls are NOT cancelled —
-            // see the cancellation contract on this function.
+            // Skip the CRL check (and its potential `revokeCert` task spawn)
+            // on shutdown so we do not start new onchain work.
             //
             // Return `attestations: None` so the safety invariant —
             // `Some(..)` ↔ "passed every eligibility + security gate,
@@ -1227,15 +1221,13 @@ where
     /// dedicated task per registerable signer instead, so that long
     /// Boundless proofs do not block the next discovery cycle.
     ///
-    /// **Why no outer cancel-select.** `resolve_instance` may call
-    /// `check_and_revoke_crls` → `submit_revoke_cert` → `tx_manager.send()`;
-    /// dropping that future after `NonceGuard` acquisition leaves a
-    /// permanent nonce gap. The buffered stream is therefore drained to
-    /// natural completion; each `resolve_instance` short-circuits on
-    /// `self.config.cancel` *between* awaits but never abandons an
-    /// in-flight send. Shutdown latency is bounded by `max_concurrency` ×
-    /// the slowest signer-RPC / CRL-fetch timeout, not by long proof work
-    /// (which lives in the spawned proof tasks).
+    /// **Why no outer cancel-select.** `resolve_instance` performs several
+    /// side effects before deciding whether an instance is registerable. The
+    /// buffered stream is therefore drained to natural completion; each
+    /// `resolve_instance` short-circuits on `self.config.cancel` between
+    /// awaits. Shutdown latency is bounded by `max_concurrency` × the slowest
+    /// signer-RPC / CRL-fetch timeout, not by long proof work (which lives in
+    /// the spawned proof tasks).
     ///
     /// The returned `ok_to_dereg` flag bakes in the cancellation policy
     /// (token not cancelled), the inconclusive-resolution guard (no
@@ -1281,11 +1273,10 @@ where
         }))
         .buffer_unordered(concurrency);
 
-        // No cancel-select around `futs.next()`: `resolve_instance` may
-        // hold an in-flight `tx_manager.send()` (via CRL revokeCert) whose
-        // nonce we MUST broadcast to avoid a permanent gap. Each future
-        // checks `self.config.cancel` cooperatively between awaits; new
-        // work is short-circuited, but in-flight sends complete naturally.
+        // No cancel-select around `futs.next()`: each future checks
+        // `self.config.cancel` cooperatively between awaits, so new work is
+        // short-circuited while already-started resolution work reaches a
+        // natural boundary.
         while let Some((instance, result)) = futs.next().await {
             match result {
                 Ok(outcome) => {
@@ -1828,7 +1819,7 @@ where
                 "submitting revokeCert transaction"
             );
 
-            self.submit_revoke_cert(verifier_address, revoked.path_digest).await;
+            self.submit_revoke_cert(verifier_address, revoked.path_digest);
         }
 
         Ok(true)
@@ -1838,46 +1829,14 @@ where
     ///
     /// Errors are logged but not propagated — a failed revocation should not
     /// block the registration cycle.
-    async fn submit_revoke_cert(&self, verifier_address: Address, cert_hash: FixedBytes<32>) {
-        let calldata =
-            Bytes::from(INitroEnclaveVerifier::revokeCertCall { certHash: cert_hash }.abi_encode());
-
+    fn submit_revoke_cert(&self, verifier_address: Address, cert_hash: FixedBytes<32>) {
         info!(
             verifier = %verifier_address,
             cert_hash = %cert_hash,
-            calldata_len = calldata.len(),
             "Revoking certificate"
         );
 
-        let candidate =
-            TxCandidate { tx_data: calldata, to: Some(verifier_address), ..Default::default() };
-
-        match self.tx_manager.send(candidate).await {
-            Ok(receipt) => {
-                if !receipt.inner.status() {
-                    warn!(
-                        cert_hash = %cert_hash,
-                        tx_hash = %receipt.transaction_hash,
-                        "revokeCert transaction reverted (cert may already be revoked)"
-                    );
-                } else {
-                    info!(
-                        cert_hash = %cert_hash,
-                        tx_hash = %receipt.transaction_hash,
-                        "certificate revoked successfully"
-                    );
-                    RegistrarMetrics::revoke_cert_success_total().increment(1);
-                }
-            }
-            Err(e) => {
-                warn!(
-                    error = %e,
-                    cert_hash = %cert_hash,
-                    "failed to submit revokeCert transaction"
-                );
-                RegistrarMetrics::revoke_cert_tx_failures().increment(1);
-            }
-        }
+        CertRevoker::new(verifier_address, self.tx_manager.clone()).revoke_cert(cert_hash);
     }
 
     /// Submits a `deregisterSigner` transaction and returns whether it succeeded.
@@ -4414,13 +4373,10 @@ mod tests {
     // even when every future was blocked on a `Notify` gate. The
     // production replacement `discover_and_resolve` deliberately does
     // NOT `select!` on `cancel.cancelled()` around its `futs.next()`
-    // loop — see the rationale comment at the call site (cancelling a
-    // `resolve_instance` future that holds an in-flight CRL
-    // `revokeCert` `tx_manager.send()` would leak a nonce). Cooperative
-    // cancellation between awaits is the contract, and end-to-end
-    // shutdown latency (including the per-task cooperative cancel +
-    // drain timeout) is covered by the pipeline tests further down in
-    // this module (e.g. `run_drains_pending_proof_tasks_on_shutdown`).
+    // loop; cooperative cancellation between awaits is the contract, and
+    // end-to-end shutdown latency (including the per-task cooperative
+    // cancel + drain timeout) is covered by the pipeline tests further
+    // down in this module (e.g. `run_drains_pending_proof_tasks_on_shutdown`).
     //
     // The companion `BlockingSignerClient` was deleted with this test.
 

--- a/crates/proof/tee/registrar/src/driver.rs
+++ b/crates/proof/tee/registrar/src/driver.rs
@@ -320,7 +320,7 @@ where
     D: InstanceDiscovery + 'static,
     P: AttestationProofProvider + 'static,
     R: RegistryClient + 'static,
-    T: TxManager + Clone + 'static,
+    T: TxManager + 'static,
     S: SignerClient + 'static,
 {
     /// Creates a new registration driver.
@@ -1810,6 +1810,7 @@ where
 
         RegistrarMetrics::crl_revocations_detected().increment(revoked_certs.len() as u64);
 
+        let cert_revoker = CertRevoker::new(verifier_address, &self.tx_manager);
         for revoked in &revoked_certs {
             warn!(
                 cert = %revoked.label,
@@ -1818,7 +1819,7 @@ where
                 "submitting revokeCert transaction"
             );
 
-            self.submit_revoke_cert(verifier_address, revoked.path_digest).await;
+            self.submit_revoke_cert(&cert_revoker, verifier_address, revoked.path_digest).await;
         }
 
         Ok(true)
@@ -1828,14 +1829,19 @@ where
     ///
     /// Errors are logged but not propagated — a failed revocation should not
     /// block the registration cycle.
-    async fn submit_revoke_cert(&self, verifier_address: Address, cert_hash: FixedBytes<32>) {
+    async fn submit_revoke_cert(
+        &self,
+        cert_revoker: &CertRevoker<'_, T>,
+        verifier_address: Address,
+        cert_hash: FixedBytes<32>,
+    ) {
         info!(
             verifier = %verifier_address,
             cert_hash = %cert_hash,
             "Revoking certificate"
         );
 
-        CertRevoker::new(verifier_address, self.tx_manager.clone()).revoke_cert(cert_hash).await;
+        cert_revoker.revoke_cert(cert_hash).await;
     }
 
     /// Submits a `deregisterSigner` transaction and returns whether it succeeded.

--- a/crates/proof/tee/registrar/src/lib.rs
+++ b/crates/proof/tee/registrar/src/lib.rs
@@ -7,6 +7,9 @@ pub use config::{
     DEFAULT_MAX_RECOVERY_ATTEMPTS, ProvingConfig, RegistrarConfig,
 };
 
+mod cert_revoker;
+pub use cert_revoker::CertRevoker;
+
 mod crl;
 pub use crl::{
     CertCrlInfo, CrlError, DEFAULT_CRL_FETCH_TIMEOUT_SECS, RevokedCertInfo, build_crl_http_client,

--- a/crates/proof/tee/registrar/src/metrics.rs
+++ b/crates/proof/tee/registrar/src/metrics.rs
@@ -37,6 +37,9 @@ base_metrics::define_metrics! {
     #[describe("Total number of revokeCert transaction submission failures")]
     revoke_cert_tx_failures: counter,
 
+    #[describe("Total number of revokeCert transactions that landed onchain but reverted")]
+    revoke_cert_reverted_total: counter,
+
     #[describe("Total number of successful revokeCert transactions")]
     revoke_cert_success_total: counter,
 


### PR DESCRIPTION
### What changed? Why?

- Added a `CertRevoker` helper that builds and submits `NitroEnclaveVerifier.revokeCert` transaction candidates through the registrar tx manager.
- Updated CRL handling to reuse `CertRevoker` from the registrar paths and await each CRL-triggered revocation submission before returning a revoked outcome.
- Added `base_registrar_revoke_cert_reverted_total` so reverted `revokeCert` receipts are tracked separately from submission failures and successful revocations.

### Notes to reviewers

- CRL detection still blocks registration for instances whose intermediate certificate chain is revoked, but `revokeCert` send failures are logged and metered rather than propagated.
- The revocation flow is no longer detached from instance resolution. Cancellation checks run before new side effects, and each triggered `revokeCert` submission is allowed to finish before resolution returns.
- Existing onchain durable revocation pre-check behavior is unchanged: a verifier sentinel hit short-circuits AWS CRL fetching and does not submit a new `revokeCert` transaction.

### How has it been tested?

- `cargo fmt --check` (passes with existing stable rustfmt warnings about nightly-only formatting options)
- `cargo test -p base-proof-tee-registrar cert_revoker --lib`
- `cargo test -p base-proof-tee-registrar cert_revoker --lib --features metrics`