### PR TITLE
docs(precompile-storage): fix stale packing module doc comment

### DIFF
--- a/crates/common/precompile-storage/src/packing.rs
+++ b/crates/common/precompile-storage/src/packing.rs
@@ -3,8 +3,14 @@
 //! This module provides helper functions for bit-level manipulation of storage slots,
 //! enabling efficient packing of multiple small values into single 32-byte slots.
 //!
-//! Packing only applies to primitive types where `LAYOUT::Bytes(count) && count < 32`.
-//! Non-primitives (structs, fixed-size arrays, dynamic types) have `LAYOUT = Layout::Slot`.
+//! Storage layout is described by the [`Layout`](crate::provider::Layout) enum:
+//! - `Layout::Bytes(N)` -- primitive types that fit in N bytes (1-32). Types with N < 32
+//!   are packable: multiple values can share a single 32-byte slot.
+//! - `Layout::Slots(N)` -- types that span N full slots and cannot be packed. This includes
+//!   structs and dynamic types (e.g. `Mapping`, `Vec`), but also fixed-size arrays whose
+//!   element type is small (<=16 bytes). For those arrays `N = calc_packed_slot_count(len,
+//!   elem_bytes)`, and individual elements within each slot are still packed using
+//!   `extract_from_word` / `insert_into_word`.
 //!
 //! ## Solidity Compatibility
 //!


### PR DESCRIPTION
[BOP-284](https://linear.app/coinbase/issue/BOP-284/14-packing-module-rustdoc-uses-stale-layoutslot-and-misstates-fixed)

## Motivation

The packing module rustdoc described storage layout using a non-existent `Layout::Slot` variant and stated that fixed-size arrays are non-packable non-primitives. Both claims are wrong. The real enum has `Layout::Bytes(usize)` and `Layout::Slots(usize)`. Fixed-size arrays with small element types (<=16 bytes) are packed: their `LAYOUT` is `Layout::Slots(calc_packed_slot_count(N, elem_bytes))`, not one slot per element.

This matters beyond internal clarity. The packing module describes the storage layout model that off-chain tools (storage inspectors, indexers, migration scripts) use to decode precompile state. An integrator reading the old docs would reserve one slot per fixed-array element even when the generated implementation packs multiple elements per slot, producing wrong slot addresses and silent data corruption in off-chain tooling. As B20 moves toward mainnet and external teams write indexers, this stale doc becomes a real integration hazard. The fix is a doc-only update with no runtime change.

## What changed

Updated the `packing.rs` module doc comment to use real variant names and correctly describe the three layout categories: `Layout::Bytes` for packable primitives, `Layout::Slots(N)` for full-slot multi-value types, and `Layout::Slots(calc_packed_slot_count(...))` for fixed-size arrays with packable element types.