### PR TITLE
fix(precompile-storage): replace unimplemented! panics with structured errors in SetHandler transient methods

### DIFF
--- a/crates/common/precompile-storage/src/types/set.rs
+++ b/crates/common/precompile-storage/src/types/set.rs
@@ -308,13 +308,13 @@ where
     }
 
     fn t_read(&self) -> Result<Set<T>> {
-        unimplemented!("Set does not support transient storage")
+        Err(BasePrecompileError::Fatal("Set does not support transient storage".into()))
     }
     fn t_write(&mut self, _: Set<T>) -> Result<()> {
-        unimplemented!("Set does not support transient storage")
+        Err(BasePrecompileError::Fatal("Set does not support transient storage".into()))
     }
     fn t_delete(&mut self) -> Result<()> {
-        unimplemented!("Set does not support transient storage")
+        Err(BasePrecompileError::Fatal("Set does not support transient storage".into()))
     }
 }
 
@@ -378,6 +378,19 @@ mod tests {
             for addr in &addrs {
                 assert!(handler.contains(addr).unwrap());
             }
+        });
+    }
+
+    #[test]
+    fn test_set_transient_methods_return_err() {
+        let (mut storage, contract_addr) = setup_storage();
+        StorageCtx::enter(&mut storage, |ctx| {
+            let base = U256::from(800u64);
+            let mut handler = SetHandler::<Address>::new(base, contract_addr, ctx);
+
+            assert!(handler.t_read().is_err());
+            assert!(handler.t_write(Set::default()).is_err());
+            assert!(handler.t_delete().is_err());
         });
     }
 


### PR DESCRIPTION
[BOP-286](https://linear.app/coinbase/issue/BOP-286/12-transient-sett-operations-panic-instead-of-returning-structured)

## Motivation

`SetHandler<T>` implemented the `Handler<T>` transient methods (`t_read`, `t_write`, `t_delete`) with `unimplemented!()`, causing a process panic if any generic caller invoked them. The `Handler<T>` trait returns `Result` precisely so callers can handle unsupported operations without crashing.

The practical risk is a node crash rather than a clean revert: a future developer adding a `Set` field to a transient storage struct, or a generic caller iterating over handler methods, would cause an unrecoverable panic at runtime instead of receiving a structured error. Even though transient `Set` storage is unlikely by design, the fix is a 3-line change that permanently closes this crash vector. The panic vs. `Err(Fatal)` distinction matters for operational stability: `Fatal` surfaces to revm's frame handler, while a panic kills the process.

## What changed

Replaced the three `unimplemented!()` stubs in `SetHandler<T>`'s `Handler` impl with `Err(BasePrecompileError::Fatal("Set does not support transient storage".into()))`. Added a test asserting all three methods return `Err`.