### PR TITLE
fix(proof/proposer): use checked_add for index base in extract_intermediate_roots

### DIFF
--- a/crates/proof/proposer/src/proof_submitter.rs
+++ b/crates/proof/proposer/src/proof_submitter.rs
@@ -413,7 +413,12 @@ where
     ) -> Result<Vec<B256>, ProposerError> {
         let mut roots = Vec::with_capacity(blocks.len());
         for &target_block in blocks {
-            let idx = target_block.checked_sub(starting_block_number + 1).ok_or_else(|| {
+            let base = starting_block_number.checked_add(1).ok_or_else(|| {
+                ProposerError::Internal(
+                    "overflow computing proposal index base".into(),
+                )
+            })?;
+            let idx = target_block.checked_sub(base).ok_or_else(|| {
                 ProposerError::Internal(format!(
                     "underflow computing proposal index for block {target_block}"
                 ))


### PR DESCRIPTION
Fixes #3282.

`extract_intermediate_roots` computed the proposal index with an unchecked `starting_block_number + 1`. If `starting_block_number` is `u64::MAX`, this wraps to `0` in release mode and `checked_sub` produces a wrong index silently selecting the wrong output root or returning a misleading error.

The rest of the file (`intermediate_block_numbers`) already uses `checked_add`/`checked_mul` for every arithmetic operation. This PR applies the same pattern to `extract_intermediate_roots` for consistency.