### PR TITLE
fix(precompile-storage): enforce EIP-2200 gas-stipend guard in sstore

### DIFF
--- a/crates/common/precompile-storage/src/evm.rs
+++ b/crates/common/precompile-storage/src/evm.rs
@@ -173,6 +173,14 @@ impl PrecompileStorageProvider for EvmPrecompileStorageProvider<'_> {
         if self.is_static {
             return Err(BasePrecompileError::StaticCallViolation);
         }
+        // EIP-2200: if remaining gas is at or below the call stipend (2300), halt with
+        // out-of-gas. This is the reentrancy sentry that Solidity's `.transfer()` relies on:
+        // forwarding only 2300 gas guarantees the recipient cannot perform state-changing
+        // SSTOREs. Without this guard, a warm-dirty rewrite (~200 gas) would succeed where
+        // the EVM SSTORE opcode would have halted, breaking the 2300-gas invariant.
+        if self.gas.remaining() <= self.gas_params.call_stipend() {
+            return Err(BasePrecompileError::OutOfGas);
+        }
         let s = self
             .internals
             .sstore(address, key, value)
@@ -300,6 +308,24 @@ mod tests {
         let mut provider = HashMapStorageProvider::new(1);
         provider.set_gas_params(GasParams::new_spec(SpecId::AMSTERDAM));
         provider
+    }
+
+    /// The EIP-2200 stipend guard in [`super::EvmPrecompileStorageProvider::sstore`] compares
+    /// `gas.remaining()` against `gas_params.call_stipend()`. This test verifies that the
+    /// call stipend constant returned by `GasParams` is exactly 2300, as required by EIP-2200.
+    ///
+    /// Unit tests cannot directly instantiate [`super::EvmPrecompileStorageProvider`] because
+    /// it requires a live EVM journal via `PrecompileInput`. The stipend guard is therefore not
+    /// exercisable in isolation here. Full coverage of the guard at runtime is provided by the
+    /// B20 fork tests that forward exactly 2300 gas into a stateful precompile call.
+    #[test]
+    fn eip_2200_stipend_guard_constant_is_2300() {
+        let gas_params = GasParams::new_spec(SpecId::AMSTERDAM);
+        assert_eq!(
+            gas_params.call_stipend(),
+            2300,
+            "call_stipend must equal 2300 as required by EIP-2200"
+        );
     }
 
     /// `set_code` on a brand-new account must charge both `create_state_gas` and


### PR DESCRIPTION
[BOP-291](https://linear.app/coinbase/issue/BOP-291/7-native-sstore-path-omits-eip-2200-gas-stipend-guard)

## Motivation

EIP-2200 specifies that an SSTORE must halt with out-of-gas if the frame's remaining gas is at or below the call stipend (2300). This is the reentrancy sentry that Solidity's `.transfer()` relies on: by forwarding only 2300 gas, a contract guarantees the recipient cannot perform state-changing SSTOREs. The native precompile `sstore` path skipped this check, checking only for static-call violations before mutating storage.

The practical exploit requires deliberate setup: a transaction that first warms and dirties a target slot, then makes a direct call into a stateful precompile (e.g., B20 `approve`) with remaining gas at or below 2300. At that point, a warm dirty rewrite costs only ~200 gas, so the write succeeds where the EVM SSTORE opcode would have halted. The attack is not trivial but the preconditions are realistic for allowance-style B20 flows.

The more important reason to fix this is EVM semantic parity. As the B20 ecosystem grows, contracts will be written assuming the 2300-gas invariant holds across all state-changing operations on Base. Breaking that assumption silently is the kind of divergence that produces serious audit findings 6 months post-launch. The fix is a one-line guard.

## What changed

Added an EIP-2200 stipend sentry to `EvmPrecompileStorageProvider::sstore`: returns `OutOfGas` when `gas.remaining() <= gas_params.call_stipend()` before the storage write, mirroring revm's opcode-level guard.

## What was tried / considered

Placing the guard at the dispatch layer (in the `base_precompile!` macro) rather than in `sstore` was considered. That would catch the boundary earlier but would require threading gas state into the macro and would not protect callers that invoke `sstore` through the `PrecompileStorageProvider` trait directly. Placing it in `sstore` is more defensive and matches where revm enforces it at the opcode level.