### PR TITLE
feat(consensus): Pending P2P Connection Controls

### DIFF
--- a/actions/harness/src/p2p.rs
+++ b/actions/harness/src/p2p.rs
@@ -203,5 +203,9 @@ impl GossipTransport for TestGossipTransport {
         self.expected_signer = Some(address);
     }
 
+    fn clear_pending_connections(&mut self) -> usize {
+        0
+    }
+
     fn handle_p2p_rpc(&mut self, _request: P2pRpcRequest) {}
 }

--- a/crates/consensus/cli/src/metrics.rs
+++ b/crates/consensus/cli/src/metrics.rs
@@ -45,6 +45,9 @@ impl CliMetrics {
     /// The high-tide peer count.
     pub const P2P_PEERS_HI: &'static str = "base_node_peers_hi";
 
+    /// The maximum number of outbound libp2p connections that may be pending at once.
+    pub const P2P_MAX_PENDING_OUTGOING: &'static str = "base_node_max_pending_outgoing";
+
     /// The identify peerstore size.
     pub const P2P_IDENTIFY_PEERSTORE_SIZE: &'static str = "base_node_identify_peerstore_size";
 
@@ -98,6 +101,7 @@ impl CliMetrics {
                 ),
                 (Self::P2P_PEERS_LO, p2p.peers_lo.to_string()),
                 (Self::P2P_PEERS_HI, p2p.peers_hi.to_string()),
+                (Self::P2P_MAX_PENDING_OUTGOING, p2p.max_pending_outgoing.to_string()),
                 (Self::P2P_IDENTIFY_PEERSTORE_SIZE, p2p.identify_peerstore_size.to_string()),
                 (Self::P2P_GOSSIP_MESH_D, p2p.gossip_mesh_d.to_string()),
                 (Self::P2P_GOSSIP_MESH_D_LO, p2p.gossip_mesh_dlo.to_string()),

--- a/crates/consensus/cli/src/p2p.rs
+++ b/crates/consensus/cli/src/p2p.rs
@@ -16,7 +16,8 @@ use base_common_genesis::RollupConfig;
 use base_consensus_derive::ChainProvider;
 use base_consensus_disc::LocalNode;
 use base_consensus_gossip::{
-    ConnectionLimitsConfig, DEFAULT_MAX_IDENTIFY_PEERSTORE_PEERS, GaterConfig,
+    ConnectionLimitsConfig, DEFAULT_MAX_IDENTIFY_PEERSTORE_PEERS,
+    DEFAULT_MAX_PENDING_OUTGOING_CONNECTIONS, GaterConfig,
 };
 use base_consensus_node::NetworkConfig;
 use base_consensus_peers::{BootNode, BootStoreFile, PeerMonitoring, PeerScoreLevel};
@@ -114,6 +115,13 @@ pub struct P2PNetworkArgs {
     /// number.
     #[arg(long = "p2p.peers.hi", default_value = "30", env = "BASE_NODE_P2P_PEERS_HI")]
     pub peers_hi: u32,
+    /// Maximum number of outbound libp2p connections that may be pending at once.
+    #[arg(
+        long = "p2p.max-pending-outgoing",
+        default_value_t = DEFAULT_MAX_PENDING_OUTGOING_CONNECTIONS,
+        env = "BASE_NODE_P2P_MAX_PENDING_OUTGOING"
+    )]
+    pub max_pending_outgoing: u32,
     /// Maximum number of peers to retain identify metadata for.
     #[arg(
         long = "p2p.identify.peerstore.size",
@@ -602,7 +610,10 @@ impl P2PArgs {
                 peer_redialing: self.peer_redial,
                 dial_period: Duration::from_secs(60 * self.redial_period),
             },
-            connection_limits_config: ConnectionLimitsConfig::new(self.peers_hi),
+            connection_limits_config: ConnectionLimitsConfig {
+                max_pending_outgoing: self.max_pending_outgoing,
+                ..ConnectionLimitsConfig::new(self.peers_hi)
+            },
             max_identify_peerstore_peers: self.identify_peerstore_size,
             bootnodes,
             rollup_config: config.clone(),
@@ -947,6 +958,19 @@ mod tests {
         assert_eq!(config.connection_limits_config.max_established_incoming, 42);
         assert_eq!(config.connection_limits_config.max_established_outgoing, 42);
         assert_eq!(config.connection_limits_config.max_established, 42);
+    }
+
+    #[tokio::test]
+    async fn test_p2p_config_wires_max_pending_outgoing_to_connection_limits() {
+        let args = MockCommand::parse_from(["test", "--p2p.max-pending-outgoing", "64"]);
+
+        let config = args
+            .p2p
+            .config(&RollupConfig::default(), 8453, None, Some(Address::ZERO))
+            .await
+            .unwrap();
+
+        assert_eq!(config.connection_limits_config.max_pending_outgoing, 64);
     }
 
     #[tokio::test]

--- a/crates/consensus/gossip/src/driver.rs
+++ b/crates/consensus/gossip/src/driver.rs
@@ -17,7 +17,10 @@ use futures::{AsyncWriteExt, stream::StreamExt};
 use libp2p::{
     Multiaddr, PeerId, Swarm, TransportError,
     gossipsub::{IdentTopic, MessageId},
-    swarm::SwarmEvent,
+    swarm::{
+        SwarmEvent,
+        dial_opts::{DialOpts, PeerCondition},
+    },
 };
 use libp2p_identity::Keypair;
 use libp2p_stream::IncomingStreams;
@@ -277,8 +280,12 @@ where
         // Note: libp2p-dns will automatically resolve DNS multiaddrs at the transport layer.
         self.connection_gate.dialing(&addr);
 
-        // Dial
-        match self.swarm.dial(addr.clone()) {
+        let dial_opts = DialOpts::peer_id(peer_id)
+            .addresses(vec![addr.clone()])
+            .condition(PeerCondition::DisconnectedAndNotDialing)
+            .build();
+
+        match self.swarm.dial(dial_opts) {
             Ok(_) => {
                 trace!(target: "gossip", peer=?addr, "Dialed peer");
                 self.connection_gate.dialed(&addr);
@@ -290,6 +297,27 @@ where
                 Metrics::dial_peer_error("connection_error").increment(1.0);
             }
         }
+    }
+
+    /// Aborts every outbound connection attempt currently tracked as pending.
+    pub fn clear_pending_connections(&mut self) -> usize {
+        let pending_dials = self.connection_gate.pending_dials();
+        let count = pending_dials.len();
+
+        for peer_id in pending_dials {
+            let _ = self.swarm.disconnect_peer_id(peer_id);
+            self.connection_gate.remove_dial(&peer_id);
+        }
+
+        if count > 0 {
+            info!(
+                target: "gossip",
+                count,
+                "Cleared pending outgoing connections"
+            );
+        }
+
+        count
     }
 
     fn handle_gossip_event(&mut self, event: Event) -> Option<NetworkPayloadEnvelope> {
@@ -509,7 +537,72 @@ fn peerstore_eviction_candidate<T>(
 
 #[cfg(test)]
 mod tests {
+    use alloy_chains::Chain;
+
     use super::*;
+
+    fn test_driver() -> GossipDriver<ConnectionGater> {
+        let rollup_config = RollupConfig {
+            l2_chain_id: Chain::base_mainnet(),
+            block_time: 2,
+            ..Default::default()
+        };
+
+        let (driver, _signer) = GossipDriver::<ConnectionGater>::builder(
+            rollup_config,
+            Address::repeat_byte(0x11),
+            "/ip4/127.0.0.1/tcp/0".parse().unwrap(),
+            Keypair::generate_secp256k1(),
+        )
+        .build()
+        .unwrap();
+
+        driver
+    }
+
+    #[tokio::test]
+    async fn clear_pending_connections_aborts_known_peer_dials() {
+        let listener = tokio::net::TcpListener::bind(("127.0.0.1", 0)).await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let accept_task = tokio::spawn(async move {
+            if let Ok((_socket, _addr)) = listener.accept().await {
+                tokio::time::sleep(Duration::from_secs(5)).await;
+            }
+        });
+
+        let peer_id = PeerId::random();
+        let addr = format!("/ip4/127.0.0.1/tcp/{port}/p2p/{peer_id}").parse().unwrap();
+        let mut driver = test_driver();
+
+        driver.dial_multiaddr(addr);
+        assert!(driver.connection_gate.current_dials.contains(&peer_id));
+
+        assert_eq!(driver.clear_pending_connections(), 1);
+        assert!(!driver.connection_gate.current_dials.contains(&peer_id));
+
+        let event = tokio::time::timeout(Duration::from_secs(1), driver.next())
+            .await
+            .expect("clearing a known-peer dial should emit an event")
+            .expect("swarm should emit the aborted dial event");
+
+        match event {
+            SwarmEvent::OutgoingConnectionError {
+                peer_id: Some(aborted_peer),
+                error: libp2p::swarm::DialError::Aborted,
+                ..
+            } => assert_eq!(aborted_peer, peer_id),
+            event => panic!("expected aborted outgoing connection event, got {event:?}"),
+        }
+
+        accept_task.abort();
+    }
+
+    #[test]
+    fn clear_pending_connections_returns_zero_when_empty() {
+        let mut driver = test_driver();
+
+        assert_eq!(driver.clear_pending_connections(), 0);
+    }
 
     #[test]
     fn test_peerstore_eviction_candidate_prefers_disconnected_peer() {

--- a/crates/consensus/gossip/src/driver.rs
+++ b/crates/consensus/gossip/src/driver.rs
@@ -448,6 +448,8 @@ where
                 return self.handle_gossip_event(behavior_event);
             }
             SwarmEvent::ConnectionEstablished { peer_id, connection_id, endpoint, .. } => {
+                self.connection_gate.remove_dial(&peer_id);
+
                 if endpoint.is_listener() {
                     let addr = endpoint.get_remote_address();
                     if let Err(error) = self.connection_gate.can_connect_inbound(&peer_id, addr) {
@@ -602,6 +604,39 @@ mod tests {
         let mut driver = test_driver();
 
         assert_eq!(driver.clear_pending_connections(), 0);
+    }
+
+    #[tokio::test]
+    async fn established_connections_are_removed_from_pending_dials() {
+        let mut dialer = test_driver();
+        let mut listener = test_driver();
+        let listener_peer_id = *listener.local_peer_id();
+        let mut listener_addr = listener.start().await.unwrap();
+        listener_addr.push(libp2p::multiaddr::Protocol::P2p(listener_peer_id));
+
+        dialer.dial_multiaddr(listener_addr);
+        assert!(dialer.connection_gate.current_dials.contains(&listener_peer_id));
+
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(3);
+        while tokio::time::Instant::now() < deadline
+            && dialer.connection_gate.current_dials.contains(&listener_peer_id)
+        {
+            tokio::select! {
+                event = dialer.next() => {
+                    if let Some(event) = event {
+                        dialer.handle_event(event);
+                    }
+                }
+                event = listener.next() => {
+                    if let Some(event) = event {
+                        listener.handle_event(event);
+                    }
+                }
+                _ = tokio::time::sleep_until(deadline) => break,
+            }
+        }
+
+        assert!(!dialer.connection_gate.current_dials.contains(&listener_peer_id));
     }
 
     #[test]

--- a/crates/consensus/gossip/src/gate.rs
+++ b/crates/consensus/gossip/src/gate.rs
@@ -34,6 +34,9 @@ pub trait ConnectionGate {
     /// Removes a peer id from the current dials set.
     fn remove_dial(&mut self, peer: &PeerId);
 
+    /// Lists peer ids with outbound dials currently in progress.
+    fn pending_dials(&self) -> Vec<PeerId>;
+
     /// Checks if a peer can be removed from the gossip swarm.
     ///
     /// Since peers can be protected from disconnection, this method

--- a/crates/consensus/gossip/src/gater.rs
+++ b/crates/consensus/gossip/src/gater.rs
@@ -383,6 +383,10 @@ impl ConnectionGate for ConnectionGater {
         self.current_dials.remove(peer_id);
     }
 
+    fn pending_dials(&self) -> Vec<PeerId> {
+        self.current_dials.iter().copied().collect()
+    }
+
     fn can_disconnect(&self, addr: &Multiaddr) -> bool {
         let Some(peer_id) = Self::peer_id_from_addr(addr) else {
             warn!(target: "p2p", peer=?addr, "Failed to extract PeerId from Multiaddr when checking disconnect");

--- a/crates/consensus/rpc/src/admin.rs
+++ b/crates/consensus/rpc/src/admin.rs
@@ -10,6 +10,7 @@ use jsonrpsee::{
     core::RpcResult,
     types::{ErrorCode, ErrorObject},
 };
+use tokio::sync::{mpsc, oneshot};
 
 use crate::{AdminApiServer, SequencerAdminAPIClient};
 
@@ -21,9 +22,14 @@ pub enum NetworkAdminQuery {
         /// The payload to post.
         payload: BaseExecutionPayloadEnvelope,
     },
+    /// An admin rpc request to clear pending outbound P2P connections.
+    ClearPendingP2pConnections {
+        /// The response channel for the number of cleared pending connections.
+        out: oneshot::Sender<usize>,
+    },
 }
 
-type NetworkAdminQuerySender = tokio::sync::mpsc::Sender<NetworkAdminQuery>;
+type NetworkAdminQuerySender = mpsc::Sender<NetworkAdminQuery>;
 
 /// The admin rpc server.
 #[derive(Debug)]
@@ -78,6 +84,18 @@ where
             .send(NetworkAdminQuery::PostUnsafePayload { payload })
             .await
             .map_err(|_| ErrorObject::from(ErrorCode::InternalError))
+    }
+
+    async fn admin_clear_pending_p2p_connections(&self) -> RpcResult<usize> {
+        Metrics::rpc_calls("admin_clearPendingP2pConnections").increment(1.0);
+
+        let (tx, rx) = oneshot::channel();
+        self.network_sender
+            .send(NetworkAdminQuery::ClearPendingP2pConnections { out: tx })
+            .await
+            .map_err(|_| ErrorObject::from(ErrorCode::InternalError))?;
+
+        rx.await.map_err(|_| ErrorObject::from(ErrorCode::InternalError))
     }
 
     async fn admin_sequencer_active(&self) -> RpcResult<bool> {

--- a/crates/consensus/rpc/src/admin.rs
+++ b/crates/consensus/rpc/src/admin.rs
@@ -20,7 +20,7 @@ pub enum NetworkAdminQuery {
     /// An admin rpc request to post an unsafe payload.
     PostUnsafePayload {
         /// The payload to post.
-        payload: BaseExecutionPayloadEnvelope,
+        payload: Box<BaseExecutionPayloadEnvelope>,
     },
     /// An admin rpc request to clear pending outbound P2P connections.
     ClearPendingP2pConnections {
@@ -81,7 +81,7 @@ where
         // operation that is valid on both sequencer and validator nodes.
         Metrics::rpc_calls("admin_postUnsafePayload").increment(1.0);
         self.network_sender
-            .send(NetworkAdminQuery::PostUnsafePayload { payload })
+            .send(NetworkAdminQuery::PostUnsafePayload { payload: Box::new(payload) })
             .await
             .map_err(|_| ErrorObject::from(ErrorCode::InternalError))
     }

--- a/crates/consensus/rpc/src/jsonrpsee.rs
+++ b/crates/consensus/rpc/src/jsonrpsee.rs
@@ -242,6 +242,10 @@ pub trait AdminApi {
         payload: BaseExecutionPayloadEnvelope,
     ) -> RpcResult<()>;
 
+    /// Clears pending outbound P2P connection attempts.
+    #[method(name = "clearPendingP2pConnections")]
+    async fn admin_clear_pending_p2p_connections(&self) -> RpcResult<usize>;
+
     /// Checks if the sequencer is active.
     #[method(name = "sequencerActive")]
     async fn admin_sequencer_active(&self) -> RpcResult<bool>;
@@ -584,6 +588,10 @@ mod tests {
             unimplemented!()
         }
 
+        async fn admin_clear_pending_p2p_connections(&self) -> RpcResult<usize> {
+            unimplemented!()
+        }
+
         async fn admin_sequencer_active(&self) -> RpcResult<bool> {
             unimplemented!()
         }
@@ -619,6 +627,7 @@ mod tests {
 
     #[rstest]
     #[case("admin_postUnsafePayload")]
+    #[case("admin_clearPendingP2pConnections")]
     #[case("admin_sequencerActive")]
     #[case("admin_startSequencer")]
     #[case("admin_stopSequencer")]

--- a/crates/consensus/service/src/actors/network/actor.rs
+++ b/crates/consensus/service/src/actors/network/actor.rs
@@ -204,7 +204,7 @@ where
                     match query {
                         NetworkAdminQuery::PostUnsafePayload { payload } => {
                             debug!(target: "node::p2p", "Forwarding unsafe payload from admin api to engine");
-                            if self.engine_client.send_unsafe_block(payload).await.is_err() {
+                            if self.engine_client.send_unsafe_block(*payload).await.is_err() {
                                 warn!(target: "node::p2p", "Failed to forward admin api unsafe block to engine");
                             }
                         }

--- a/crates/consensus/service/src/actors/network/actor.rs
+++ b/crates/consensus/service/src/actors/network/actor.rs
@@ -200,10 +200,24 @@ where
                         return Err(NetworkActorError::ChannelClosed);
                     }
                 }
-                Some(NetworkAdminQuery::PostUnsafePayload { payload }) = self.admin_rpc.recv(), if !self.admin_rpc.is_closed() => {
-                    debug!(target: "node::p2p", "Forwarding unsafe payload from admin api to engine");
-                    if self.engine_client.send_unsafe_block(payload).await.is_err() {
-                        warn!(target: "node::p2p", "Failed to forward admin api unsafe block to engine");
+                Some(query) = self.admin_rpc.recv(), if !self.admin_rpc.is_closed() => {
+                    match query {
+                        NetworkAdminQuery::PostUnsafePayload { payload } => {
+                            debug!(target: "node::p2p", "Forwarding unsafe payload from admin api to engine");
+                            if self.engine_client.send_unsafe_block(payload).await.is_err() {
+                                warn!(target: "node::p2p", "Failed to forward admin api unsafe block to engine");
+                            }
+                        }
+                        NetworkAdminQuery::ClearPendingP2pConnections { out } => {
+                            let cleared = self.transport.clear_pending_connections();
+                            if out.send(cleared).is_err() {
+                                warn!(
+                                    target: "node::p2p",
+                                    cleared,
+                                    "Failed to send clear pending P2P connections response"
+                                );
+                            }
+                        }
                     }
                 }
                 Some(req) = self.p2p_rpc.recv(), if !self.p2p_rpc.is_closed() => {

--- a/crates/consensus/service/src/actors/network/handler.rs
+++ b/crates/consensus/service/src/actors/network/handler.rs
@@ -173,6 +173,10 @@ impl GossipTransport for NetworkHandler {
         }
     }
 
+    fn clear_pending_connections(&mut self) -> usize {
+        self.gossip.clear_pending_connections()
+    }
+
     fn handle_p2p_rpc(&mut self, request: P2pRpcRequest) {
         request.handle(&mut self.gossip, &self.discovery);
     }

--- a/crates/consensus/service/src/actors/network/transport.rs
+++ b/crates/consensus/service/src/actors/network/transport.rs
@@ -29,6 +29,9 @@ pub trait GossipTransport: Send + 'static {
     /// Updates the unsafe block signer address used to validate inbound gossip.
     fn set_block_signer(&mut self, address: Address);
 
+    /// Aborts pending outbound P2P connection attempts and returns how many were cleared.
+    fn clear_pending_connections(&mut self) -> usize;
+
     /// Dispatches a P2P RPC request to the underlying transport.
     ///
     /// Implementations that do not support P2P RPC (e.g. test transports) may ignore this.


### PR DESCRIPTION
## Summary

This adds a configurable limit for pending outbound libp2p connections so operators can tune the gossip swarm when stale peers consume the default capacity. It also makes outbound dials peer-aware and adds an admin RPC to clear pending P2P connection attempts without recreating the gossip swarm. The new path aborts tracked pending dials and reports how many were cleared.